### PR TITLE
Changed the plugin API to make a Perforce plugin possible

### DIFF
--- a/Gum/Managers/ProjectManager.cs
+++ b/Gum/Managers/ProjectManager.cs
@@ -190,6 +190,8 @@ namespace Gum
                 GraphicalUiElement.ShowLineRectangles = mGumProjectSave.ShowOutlines;
                 EditingManager.Self.RestrictToUnitValues = mGumProjectSave.RestrictToUnitValues;
 
+                PluginManager.Self.ProjectLoad(mGumProjectSave);
+
                 if (wasModified)
                 {
                     ProjectManager.Self.SaveProject(forceSaveContainedElements:true);
@@ -198,13 +200,15 @@ namespace Gum
                 GraphicalUiElement.CanvasWidth = mGumProjectSave.DefaultCanvasWidth;
                 GraphicalUiElement.CanvasHeight = mGumProjectSave.DefaultCanvasHeight;
             }
+            else
+            {
+                PluginManager.Self.ProjectLoad(mGumProjectSave);
+            }
 
             // Now that a new project is loaded, refresh the UI!
             GumCommands.Self.GuiCommands.RefreshElementTreeView();
             // And the guides
             WireframeObjectManager.Self.UpdateGuides();
-
-            PluginManager.Self.ProjectLoad(mGumProjectSave);
 
             GeneralSettingsFile.AddToRecentFilesIfNew(fileName);
 
@@ -269,9 +273,27 @@ namespace Gum
 
                 if (shouldSave)
                 {
+                    PluginManager.Self.BeforeProjectSave(GumProjectSave);
+
                     try
                     {
                         bool saveContainedElements = isNewProject || forceSaveContainedElements;
+
+                        if (saveContainedElements)
+                        {
+                            foreach (var screenSave in GumProjectSave.Screens)
+                            {
+                                PluginManager.Self.BeforeElementSave(screenSave);
+                            }
+                            foreach (var componentSave in GumProjectSave.Components)
+                            {
+                                PluginManager.Self.BeforeElementSave(componentSave);
+                            }
+                            foreach (var standardElementSave in GumProjectSave.StandardElements)
+                            {
+                                PluginManager.Self.BeforeElementSave(standardElementSave);
+                            }
+                        }
 
                         GumProjectSave.Save(GumProjectSave.FullFileName, saveContainedElements);
                         succeeded = true;

--- a/Gum/Plugins/BaseClasses/PluginBase.cs
+++ b/Gum/Plugins/BaseClasses/PluginBase.cs
@@ -15,7 +15,8 @@ namespace Gum.Plugins.BaseClasses
 
         public event Action<GumProjectSave> ProjectLoad;
         public event Action<GumProjectSave> ProjectSave;
-
+        public event Action<GumProjectSave> BeforeProjectSave;
+        public event Action<ElementSave> BeforeElementSave;
         public event Action GuidesChanged;
         public event Action<ElementSave> Export;
         public event Action<DeleteOptionsWindow, object> DeleteOptionsWindowShow;
@@ -200,8 +201,21 @@ namespace Gum.Plugins.BaseClasses
             }
         }
 
+        public void CallBeforeElementSave(ElementSave elementSave)
+        {
+            if (BeforeElementSave != null)
+            {
+                BeforeElementSave(elementSave);
+            }
+        }
 
-
+        public void CallBeforeProjectSave(GumProjectSave savedProject)
+        {
+            if (BeforeProjectSave != null)
+            {
+                BeforeProjectSave(savedProject);
+            }
+        }
 
         internal bool GetIfVariableIsExcluded(VariableSave defaultVariable, RecursiveVariableFinder rvf)
         {

--- a/Gum/Plugins/PluginManager.cs
+++ b/Gum/Plugins/PluginManager.cs
@@ -28,7 +28,7 @@ namespace Gum.Plugins
 
     #endregion
 
-    class PluginManager
+    public class PluginManager
     {
         #region Fields
 
@@ -656,6 +656,52 @@ namespace Gum.Plugins
             }      
 
 #endif
+        }
+
+        internal void BeforeElementSave(ElementSave savedElement)
+        {
+            foreach (PluginBase plugin in this.Plugins)
+            {
+                PluginContainer container = this.mPluginContainers[plugin];
+
+                if (container.IsEnabled)
+                {
+                    try
+                    {
+                        plugin.CallBeforeElementSave(savedElement);
+                    }
+                    catch (Exception e)
+                    {
+#if DEBUG
+                        MessageBox.Show("Error in plugin " + plugin.FriendlyName + ":\r\n" + e.ToString());
+#endif
+                        container.Fail(e, "Failed in BeforeElementSave");
+                    }
+                }
+            }
+        }
+
+        internal void BeforeProjectSave(GumProjectSave savedProject)
+        {
+            foreach (var plugin in this.Plugins)
+            {
+                PluginContainer container = this.PluginContainers[plugin];
+
+                if (container.IsEnabled)
+                {
+                    try
+                    {
+                        plugin.CallBeforeProjectSave(savedProject);
+                    }
+                    catch (Exception e)
+                    {
+#if DEBUG
+                        MessageBox.Show("Error in plugin " + plugin.FriendlyName + ":\n\n" + e.ToString());
+#endif
+                        container.Fail(e, "Failed in BeforeProjectSave");
+                    }
+                }
+            }
         }
 
         internal void Export(ElementSave elementToExport)


### PR DESCRIPTION
1. A Perforce plugin needs to know when you're about to write to a file so it can check it out and remove the read-only flag. The existing plugin API did not have the necessary events so I added them.

2. I moved the
`PluginManager.Self.ProjectLoad(mGumProjectSave);`
to before
`ProjectManager.Self.SaveProject(forceSaveContainedElements:true);`
so plugins receive `ProjectLoad` before `ProjectSave` event, so that they can put their project specific initialization code in e.g. `HandleProjectLoad`.

3. I made the PluginManager class public so plugin can be aware of other plugins so that our Lua export plugin can ask the Perforce plugin to unlock destination files before export.

The Perforce plugin itself will come in a separate pull request if/when you accept this one.