### PR TITLE
Changed FileManager.XmlDeserialize to throw a more correct exception

### DIFF
--- a/ToolsUtilities/FileManager.cs
+++ b/ToolsUtilities/FileManager.cs
@@ -632,7 +632,8 @@ namespace ToolsUtilities
                 }
                 catch (Exception e)
                 {
-                    throw new Exception("Could not deserialize the XML file " + fileName + " because of the following error:\n\n" + e);
+                    throw new IOException("Could not deserialize the XML file " + fileName
+                        + Environment.NewLine, e);
                 }
 #if !WINDOWS_8
                 stream.Close();


### PR DESCRIPTION
Throw IOException instead of Exception so that plugins can catch the more specific exception. Also, changed the expression to include the caught exception in the InnerException of the newly thrown exception.