### PR TITLE
Removed the SaveProject call in LoadProject

### DIFF
--- a/Gum/DataTypes/GumProjectSaveExtensionMethods.cs
+++ b/Gum/DataTypes/GumProjectSaveExtensionMethods.cs
@@ -15,10 +15,8 @@ namespace Gum.DataTypes
         /// checking for other errors.
         /// </summary>
         /// <param name="gumProjectSave">The GumProjectSave</param>
-        public static bool Initialize(this GumProjectSave gumProjectSave)
+        public static void Initialize(this GumProjectSave gumProjectSave)
         {
-            bool wasModified = false;
-
             gumProjectSave.ScreenReferences.Sort((first, second) => first.Name.CompareTo(second.Name));
             gumProjectSave.ComponentReferences.Sort((first, second) => first.Name.CompareTo(second.Name));
             gumProjectSave.StandardElementReferences.Sort((first, second) => first.Name.CompareTo(second.Name));
@@ -37,7 +35,7 @@ namespace Gum.DataTypes
                 StateSave stateSave = StandardElementsManager.Self.GetDefaultStateFor(standardElementSave.Name);
                 // this will result in extra variables being
                 // added
-                wasModified = standardElementSave.Initialize(stateSave) || wasModified;
+                standardElementSave.Initialize(stateSave);
 
                 stateSave.ParentContainer = standardElementSave;
             }
@@ -47,7 +45,6 @@ namespace Gum.DataTypes
                 screenSave.Initialize(null);
             }
 
-            
 
             foreach (ComponentSave componentSave in gumProjectSave.Components)
             {
@@ -71,15 +68,8 @@ namespace Gum.DataTypes
                     defaultStateSave = ses.DefaultState;
                 }
 
-                if(componentSave.Initialize(defaultStateSave))
-                {
-                    wasModified = true;
-                }
-
-                if(componentSave.Initialize(StandardElementsManager.Self.DefaultStates["Component"]))
-                {
-                    wasModified = true;
-                }
+                componentSave.Initialize(defaultStateSave);
+                componentSave.Initialize(StandardElementsManager.Self.DefaultStates["Component"]);
             }
 
             if(gumProjectSave.Version < 1)
@@ -119,11 +109,7 @@ namespace Gum.DataTypes
                         }
                     }
                 }
-
-                wasModified = true;
             }
-
-            return wasModified;
         }
 
         /// <summary>

--- a/Gum/Managers/ProjectManager.cs
+++ b/Gum/Managers/ProjectManager.cs
@@ -175,8 +175,7 @@ namespace Gum
 
             if (mGumProjectSave != null)
             {
-                bool wasModified = mGumProjectSave.Initialize();
-
+                mGumProjectSave.Initialize();
 
                 RecreateMissingStandardElements();
 
@@ -191,11 +190,6 @@ namespace Gum
                 EditingManager.Self.RestrictToUnitValues = mGumProjectSave.RestrictToUnitValues;
 
                 PluginManager.Self.ProjectLoad(mGumProjectSave);
-
-                if (wasModified)
-                {
-                    ProjectManager.Self.SaveProject(forceSaveContainedElements:true);
-                }
 
                 GraphicalUiElement.CanvasWidth = mGumProjectSave.DefaultCanvasWidth;
                 GraphicalUiElement.CanvasHeight = mGumProjectSave.DefaultCanvasHeight;
@@ -233,11 +227,8 @@ namespace Gum
                 if (element.IsSourceFileMissing)
                 {
                     missingElements.Add(element);
-
                 }
             }
-
-
 
             foreach (var element in missingElements)
             {

--- a/Gum/Wireframe/EditingManager.RightClick.cs
+++ b/Gum/Wireframe/EditingManager.RightClick.cs
@@ -161,8 +161,6 @@ namespace Gum.Wireframe
                 PropertyGridManager.Self.RefreshUI();
                 GumCommands.Self.GuiCommands.RefreshElementTreeView();
             }
-
-
         }
         
         public void OnPaste(CopyType copyType)


### PR DESCRIPTION
It's in my opinion quite a bad idea to automatically save the whole project when it gets loaded. Two examples where this goes wrong:

* Version control systems like Perforce require files to be checked out before being written to. In effect, this behavior causes all files in the project to be checked out just by opening Gum.

* Sometimes I've managed to start Gum without our plugin loaded. This would then inadvertedly cause the Standard elements to get written to disk, including the set of properties that I'm suppressing in the   plugin.

In general, I think it's just unexpected behavior. It's also unnecessary because whatever changes are being made to the project during load, you can expect Gum to make those same changes again next time it loads the project.

Finally, if you really want a project to be saved in its entirety, then there is already a menu item available for this.

Closes #18.