### PR TITLE
Fixed a NullReferenceException in PerformanceMeasurementPlugin

### DIFF
--- a/PerformanceMeasurementPlugin/ViewModels/PerformanceViewModel.cs
+++ b/PerformanceMeasurementPlugin/ViewModels/PerformanceViewModel.cs
@@ -17,7 +17,14 @@ namespace PerformanceMeasurementPlugin.ViewModels
         {
             get
             {
-                return SystemManagers.Default.Renderer.DrawCalls;
+                if (SystemManagers.Default != null)
+                {
+                    return SystemManagers.Default.Renderer.DrawCalls;
+                }
+                else
+                {
+                    return 0;
+                }
             }
         }
 


### PR DESCRIPTION
It's not critical, and WPF handles the exception, but it's annoying when debugging with Debug -> Exceptions... -> Thrown for NullReferenceException which normally means a bug in code. Returning zero seems like a reasonable choice.