### PR TITLE
Made some parts of DeleteObjectPlugin public

### DIFF
--- a/Gum/Gui/Plugins/DeleteObjectPlugin.cs
+++ b/Gum/Gui/Plugins/DeleteObjectPlugin.cs
@@ -13,7 +13,12 @@ namespace Gum.Gui.Plugins
     [Export(typeof(Gum.Plugins.BaseClasses.PluginBase))]
     public class DeleteObjectPlugin : InternalPlugin
     {
-        public CheckBox DeleteXmlCheckBox { get; private set; }
+        private CheckBox mDeleteXmlCheckBox;
+
+        public bool DeleteXmlIsChecked
+        {
+            get { return mDeleteXmlCheckBox.Checked; }
+        }
 
         public override void StartUp()
         {
@@ -25,7 +30,7 @@ namespace Gum.Gui.Plugins
 
         void HandleDeleteConfirm(Forms.DeleteOptionsWindow deleteOptionsWindow, object deletedObject)
         {
-            if (DeleteXmlCheckBox.Checked)
+            if (mDeleteXmlCheckBox.Checked)
             {
                 string fileName = GetFileNameForObject(deletedObject);
 
@@ -63,15 +68,15 @@ namespace Gum.Gui.Plugins
 
         void HandleDeleteOptionsShow(Forms.DeleteOptionsWindow obj, object objectToDelete)
         {
-            obj.AddUi(DeleteXmlCheckBox);
-            DeleteXmlCheckBox.Text = "Delete XML file";
-            DeleteXmlCheckBox.Width = 220;
+            obj.AddUi(mDeleteXmlCheckBox);
+            mDeleteXmlCheckBox.Text = "Delete XML file";
+            mDeleteXmlCheckBox.Width = 220;
         }
 
         private void CreateDeleteXmlFileComboBox()
         {
-            DeleteXmlCheckBox = new CheckBox();
-            DeleteXmlCheckBox.Checked = true;
+            mDeleteXmlCheckBox = new CheckBox();
+            mDeleteXmlCheckBox.Checked = true;
         }
 
     }

--- a/Gum/Gui/Plugins/DeleteObjectPlugin.cs
+++ b/Gum/Gui/Plugins/DeleteObjectPlugin.cs
@@ -13,7 +13,7 @@ namespace Gum.Gui.Plugins
     [Export(typeof(Gum.Plugins.BaseClasses.PluginBase))]
     public class DeleteObjectPlugin : InternalPlugin
     {
-        public CheckBox DeleteXmlComboBox { get; private set; }
+        public CheckBox DeleteXmlCheckBox { get; private set; }
 
         public override void StartUp()
         {
@@ -25,7 +25,7 @@ namespace Gum.Gui.Plugins
 
         void HandleDeleteConfirm(Forms.DeleteOptionsWindow deleteOptionsWindow, object deletedObject)
         {
-            if (DeleteXmlComboBox.Checked)
+            if (DeleteXmlCheckBox.Checked)
             {
                 string fileName = GetFileNameForObject(deletedObject);
 
@@ -63,15 +63,15 @@ namespace Gum.Gui.Plugins
 
         void HandleDeleteOptionsShow(Forms.DeleteOptionsWindow obj, object objectToDelete)
         {
-            obj.AddUi(DeleteXmlComboBox);
-            DeleteXmlComboBox.Text = "Delete XML file";
-            DeleteXmlComboBox.Width = 220;
+            obj.AddUi(DeleteXmlCheckBox);
+            DeleteXmlCheckBox.Text = "Delete XML file";
+            DeleteXmlCheckBox.Width = 220;
         }
 
         private void CreateDeleteXmlFileComboBox()
         {
-            DeleteXmlComboBox = new CheckBox();
-            DeleteXmlComboBox.Checked = true;
+            DeleteXmlCheckBox = new CheckBox();
+            DeleteXmlCheckBox.Checked = true;
         }
 
     }

--- a/Gum/Gui/Plugins/DeleteObjectPlugin.cs
+++ b/Gum/Gui/Plugins/DeleteObjectPlugin.cs
@@ -13,8 +13,7 @@ namespace Gum.Gui.Plugins
     [Export(typeof(Gum.Plugins.BaseClasses.PluginBase))]
     public class DeleteObjectPlugin : InternalPlugin
     {
-        CheckBox mDeleteXmlComboBox;
-
+        public CheckBox DeleteXmlComboBox { get; private set; }
 
         public override void StartUp()
         {
@@ -26,7 +25,7 @@ namespace Gum.Gui.Plugins
 
         void HandleDeleteConfirm(Forms.DeleteOptionsWindow deleteOptionsWindow, object deletedObject)
         {
-            if (mDeleteXmlComboBox.Checked)
+            if (DeleteXmlComboBox.Checked)
             {
                 string fileName = GetFileNameForObject(deletedObject);
 
@@ -44,7 +43,7 @@ namespace Gum.Gui.Plugins
             }
         }
 
-        private string GetFileNameForObject(object deletedObject)
+        public string GetFileNameForObject(object deletedObject)
         {
             if (deletedObject is ElementSave)
             {
@@ -64,15 +63,15 @@ namespace Gum.Gui.Plugins
 
         void HandleDeleteOptionsShow(Forms.DeleteOptionsWindow obj, object objectToDelete)
         {
-            obj.AddUi(mDeleteXmlComboBox);
-            mDeleteXmlComboBox.Text = "Delete XML file";
-            mDeleteXmlComboBox.Width = 220;
+            obj.AddUi(DeleteXmlComboBox);
+            DeleteXmlComboBox.Text = "Delete XML file";
+            DeleteXmlComboBox.Width = 220;
         }
 
         private void CreateDeleteXmlFileComboBox()
         {
-            mDeleteXmlComboBox = new CheckBox();
-            mDeleteXmlComboBox.Checked = true;
+            DeleteXmlComboBox = new CheckBox();
+            DeleteXmlComboBox.Checked = true;
         }
 
     }


### PR DESCRIPTION
I've made DeleteXmlComboBox and GetFileNameForObject public so other plugins can access this information. It is necessary for my Perforce plugin so it can remove the XML file from Perforce correctly.