### PR TITLE
Set application icon

### DIFF
--- a/Gum/Gum.csproj
+++ b/Gum/Gum.csproj
@@ -61,6 +61,9 @@
   <PropertyGroup>
     <StartupObject>Gum.Program</StartupObject>
   </PropertyGroup>
+  <PropertyGroup>
+    <ApplicationIcon>GumIcon.ico</ApplicationIcon>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.Xna.Framework, Version=4.0.0.0, Culture=neutral, PublicKeyToken=842cf8be1de50553, processorArchitecture=x86">
       <SpecificVersion>False</SpecificVersion>
@@ -612,6 +615,7 @@
     <Content Include="Content\Icons\Units\PixelsFromBaseline.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="GumIcon.ico" />
     <Content Include="Libraries\TargaImage.dll" />
     <Content Include="Libraries\TargaImage.xml" />
     <None Include="Content\InvalidTexture.png">


### PR DESCRIPTION
Probably the most minor, least important thing, but at least now when I go to run Gum directly I'll see its proper icon instead of the Windows default icon for executables.