### PR TITLE
Control style updates

### DIFF
--- a/WpfDataUi/Controls/SliderDisplay.xaml
+++ b/WpfDataUi/Controls/SliderDisplay.xaml
@@ -17,7 +17,7 @@
                 <Setter.Value>
                     <ControlTemplate TargetType="{x:Type RepeatButton}">
                         <Border BorderThickness="1" Margin="0,3,-2,3"
-                            CornerRadius="3,0,0,3" BorderBrush="#dddddd" Background="#dddddd">
+                            CornerRadius="3,0,0,3" BorderBrush="#888888" Background="#dddddd">
                         </Border>
                     </ControlTemplate>
                 </Setter.Value>
@@ -32,7 +32,7 @@
                 <Setter.Value>
                     <ControlTemplate TargetType="{x:Type RepeatButton}">
                         <Border BorderThickness="1" Margin="-2,3,0,3"
-                            CornerRadius="0,3,3,0" BorderBrush="#dddddd" Background="#ffffff">
+                            CornerRadius="0,3,3,0" BorderBrush="#888888" Background="#ffffff">
                         </Border>
                     </ControlTemplate>
                 </Setter.Value>
@@ -125,7 +125,7 @@
                 Style="{StaticResource MyCustomStyleForSlider}"
                 ></Slider>
 
-            <TextBox Grid.Column="2" x:Name="TextBox" Margin="1" Height="22"
+            <TextBox Grid.Column="2" x:Name="TextBox" Margin="3,1,1,1" Height="22"
                      LostFocus="TextBox_LostFocus_1">
                 <TextBox.ContextMenu>
                     <ContextMenu>

--- a/WpfDataUi/DataUiGrid.xaml
+++ b/WpfDataUi/DataUiGrid.xaml
@@ -36,7 +36,7 @@
                     <ItemsControl x:Name="ItemsControlInstance" ItemsSource="{Binding Members}" Focusable="False">
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>
-                                <DataUi:SingleDataUiContainer FontSize="12" Margin="3,0,3,0" Background="{Binding BackgroundColor}"/>
+                                <DataUi:SingleDataUiContainer FontSize="12" Margin="3,0,3,3" Background="{Binding BackgroundColor}"/>
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>


### PR DESCRIPTION
These are the updates I thought were in the FRB PR. I didn't realize the controls were in a different repo

- Updated the XAML for the main editor to add a bit of spacing around the inside so objects aren't lined up against the window edge
- Property grid items have a little bit of padding at the bottom. This prevents the items from running too close together and adds visual spacing