### PR TITLE
Moving an object now takes RestrictToUnitValues into account

### DIFF
--- a/Gum/Wireframe/EditingManager.cs
+++ b/Gum/Wireframe/EditingManager.cs
@@ -136,40 +136,70 @@ namespace Gum.Wireframe
                 if (SelectedState.Self.SelectedInstances.Count() == 0 && 
                     (SelectedState.Self.SelectedComponent != null || SelectedState.Self.SelectedStandardElement != null))
                 {
+                    var selfSelectedElement = SelectedState.Self.SelectedElement;
+                    var gue = SelectionManager.Self.SelectedGue;
+                    var restrictToUnitValues = SelectionManager.Self.RestrictToUnitValues;
+
                     if (xToMoveBy != 0)
                     {
                         hasChangeOccurred = true;
-                        ModifyVariable("X", xToMoveBy, SelectedState.Self.SelectedElement);
+                        ModifyVariable("X", xToMoveBy, selfSelectedElement);
+
+                        if (restrictToUnitValues && gue.XUnits.GetIsPixelBased()) {
+                            float x = gue.X;
+                            float desiredX = MathFunctions.RoundToInt(x);
+                            ModifyVariable("X", desiredX - x, selfSelectedElement);
+                        }
                     }
                     if (yToMoveBy != 0)
                     {
                         hasChangeOccurred = true;
-                        ModifyVariable("Y", yToMoveBy, SelectedState.Self.SelectedElement);
-                    }
+                        ModifyVariable("Y", yToMoveBy, selfSelectedElement);
 
+                        if (restrictToUnitValues && gue.YUnits.GetIsPixelBased()) {
+                            float y = gue.Y;
+                            float desiredY = MathFunctions.RoundToInt(y);
+                            ModifyVariable("Y", desiredY - y, selfSelectedElement);
+                        }
+                    }
                 }
                 else
                 {
                     var selectedInstances = SelectedState.Self.SelectedInstances;
+                    var gues = SelectionManager.Self.SelectedGues;
+                    var gueIdx = 0;
+                    var restrictToUnitValues = SelectionManager.Self.RestrictToUnitValues;
 
                     foreach (InstanceSave instance in selectedInstances)
                     {
                         bool shouldSkip = ShouldSkipDraggingMovementOn(instance);
 
-                        if (!shouldSkip)
-                        {
+                        if (!shouldSkip) {
+                            var gue = gues[gueIdx];
                             // This could prevent a double-layout by locking layout until all values have been set
                             if (xToMoveBy != 0)
                             {
                                 hasChangeOccurred = true;
                                 float value = ModifyVariable("X", xToMoveBy, instance);
+                                if (restrictToUnitValues && gue.XUnits.GetIsPixelBased()) {
+                                    float x = gue.X;
+                                    float desiredX = MathFunctions.RoundToInt(x);
+                                    ModifyVariable("X", desiredX - x, instance);
+                                }
                             }
                             if (yToMoveBy != 0)
                             {
                                 hasChangeOccurred = true;
                                 float value = ModifyVariable("Y", yToMoveBy, instance);
+                                if (restrictToUnitValues && gue.YUnits.GetIsPixelBased()) {
+                                    float y = gue.Y;
+                                    float desiredY = MathFunctions.RoundToInt(y);
+                                    ModifyVariable("Y", desiredY - y, instance);
+                                }
                             }
                         }
+
+                        gueIdx++;
                     }
                 }
 


### PR DESCRIPTION
When moving (and resizing) an object, the "RestrictToUnitValues" is only honored after the fact, which is a bit jarring in my opinion (you move it to some place, but after you let go of your mouse it slightly moves back to some invisible grid).

I've added code to fix this issue for movement, although I need some advice on how to proceed:
1. Code is very verbose, not sure if there is a leaner way of doing this. Moving once (instead of moving + adjusting) is obviously possible, but I used the same code from `StandardWireframeEditor::SnapSelectedToUnitValues()` for simplicity, as I'm not even sure of how to fetch the actual "X/Y" value given the levels of indirection present :).
2. Given the resizing code might also move the object to compensate, that one is even more difficult. It might be easier to be able to:
    a. Get existing coordinate value
    b. Adjust to integer value
    c. Set the new value instead of incrementing relatively.
...but this might not be possible at all, hence I'm asking for advice or hep on how to fix that part as well.

Thanks!