### PR TITLE
Replace color picker with Pixi.ColorPicker

### DIFF
--- a/Gum/Controls/ColorDisplay.xaml
+++ b/Gum/Controls/ColorDisplay.xaml
@@ -3,24 +3,24 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
-             xmlns:xctk="http://schemas.xceed.com/wpf/xaml/toolkit"
+             xmlns:colorpicker="clr-namespace:ColorPicker;assembly=ColorPicker"
              mc:Ignorable="d" 
              Height="26">
     <Grid>
         
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="Auto"></ColumnDefinition>
-            <ColumnDefinition Width="Auto"></ColumnDefinition>
+            <ColumnDefinition Width="1*"></ColumnDefinition>
         </Grid.ColumnDefinitions>
 
 
         <Label x:Name="Label" MinWidth="100">Property Label:</Label>
 
         <!--If this isn't avaiable, try "unblocking" your dlls: https://wpftoolkit.codeplex.com/discussions/572836-->
-        <xctk:ColorPicker Grid.Column="1" Width="60"
-                          Name="ColorPicker" 
-                          SelectedColorChanged="HandleColorChange" VerticalAlignment="Center">
+        <colorpicker:PortableColorPicker Grid.Column="1" Height="12"
+                          Name="ColorPicker"
+                          ColorChanged="HandleColorChange" VerticalAlignment="Center">
             
-        </xctk:ColorPicker>
+        </colorpicker:PortableColorPicker>
     </Grid>
 </UserControl>

--- a/Gum/Controls/ColorDisplay.xaml.cs
+++ b/Gum/Controls/ColorDisplay.xaml.cs
@@ -12,6 +12,7 @@ using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Navigation;
 using System.Windows.Shapes;
+using ColorPicker.Models;
 using WpfDataUi;
 using WpfDataUi.DataTypes;
 
@@ -126,10 +127,10 @@ namespace Gum.Controls.DataUi
                 if (mInstancePropertyType == typeof(Microsoft.Xna.Framework.Color))
                 {
                     Microsoft.Xna.Framework.Color colorToReturn = new Microsoft.Xna.Framework.Color(
-                        ColorPicker.SelectedColor.Value.R,
-                        ColorPicker.SelectedColor.Value.G,
-                        ColorPicker.SelectedColor.Value.B,
-                        ColorPicker.SelectedColor.Value.A);
+                        ColorPicker.SelectedColor.R,
+                        ColorPicker.SelectedColor.G,
+                        ColorPicker.SelectedColor.B,
+                        ColorPicker.SelectedColor.A);
 
                     result = ApplyValueResult.Success;
 
@@ -154,12 +155,17 @@ namespace Gum.Controls.DataUi
             }
         }
 
-        private void HandleColorChange(object sender, RoutedPropertyChangedEventArgs<Color?> e)
-        {
+        private void HandleColorChange(object sender, RoutedEventArgs e) {
+            if (!(e is ColorRoutedEventArgs colorArgs)) return;
+
+            var prevColor = (Microsoft.Xna.Framework.Color)InstanceMember.Value;
+
+            var colorPack = (uint)(colorArgs.Color.R | (colorArgs.Color.G << 8) | (colorArgs.Color.B << 16) | (colorArgs.Color.A << 24));
+            if (colorPack == prevColor.PackedValue) return;
+
             var settingResult = this.TrySetValueOnInstance();
 
-            if (settingResult == ApplyValueResult.NotSupported)
-            {
+            if (settingResult == ApplyValueResult.NotSupported) {
                 this.IsEnabled = false;
             }
         }

--- a/Gum/Gum.csproj
+++ b/Gum/Gum.csproj
@@ -808,6 +808,9 @@
     <PackageReference Include="Newtonsoft.Json">
       <Version>13.0.1</Version>
     </PackageReference>
+    <PackageReference Include="PixiEditor.ColorPicker">
+      <Version>3.4.1</Version>
+    </PackageReference>
     <PackageReference Include="SkiaSharp">
       <Version>2.88.2</Version>
     </PackageReference>


### PR DESCRIPTION
This is probably a "personal preference" issue, so feel free to close if you don't think it's useful.

Personally, I think the current color picker is very hard to use, both because of the unordered list of colors as well as the lackluster "advanced" mode, which doesn't even have a way of picking colors using the HSV/HSL spaces. Also you need 2 clicks to access it, which is not good design (again, IMHO).

I've replaced it with a color picker I found that seems to be an improvement over it, albeit probably still not perfect: https://github.com/PixiEditor/ColorPicker/

<img width="291" alt="Gum_NRTsvem42Z" src="https://github.com/vchelaru/Gum/assets/28616/b8a2310d-74c0-49c7-af78-4a50643ac08e">