### PR TITLE
Add child/parent Instance to instances (as opposed to only Elements)

### DIFF
--- a/Gum/Managers/NameVerifier.cs
+++ b/Gum/Managers/NameVerifier.cs
@@ -244,25 +244,25 @@ namespace Gum.Managers
 
             if (objectToIgnore != elementSave && name == elementSave.Name)
             {
-                whyNotValid = "The element is named " + elementSave.Name;
+                whyNotValid = $"The element is named '{elementSave.Name}'";
             }
 
             var instance = elementSave.Instances.FirstOrDefault(item => item != objectToIgnore && item.Name == name);
             if (instance != null)
             {
-                whyNotValid = "There is already an instance named " + instance.ToString();
+                whyNotValid = $"There is already an instance named '{instance.Name}'";
             }
 
             var state = elementSave.States.FirstOrDefault(item => item != objectToIgnore && item.Name == name);
             if (state != null)
             {
-                whyNotValid = "There is already a state named " + state.ToString();
+                whyNotValid = $"There is already a state named '{state.Name}'";
             }
             
             var variable = elementSave.AllStates.SelectMany(item => item.Variables).FirstOrDefault(item => item != objectToIgnore && item.ExposedAsName == name);
             if (variable != null)
             {
-                whyNotValid = "There is already a variable named " + variable.ToString();
+                whyNotValid = $"There is already a variable named '{variable.Name}'";
             }
 
             //element = ObjectFinder.Self.GumProjectSave.StandardElements.FirstOrDefault(item=>item != objectToIgnore && item.Name == name)


### PR DESCRIPTION
Context menu entries for adding child and parent to `Instances`.
<img width="206" alt="Gum_1MPnHORnkE" src="https://github.com/vchelaru/Gum/assets/28616/cae2c655-6292-4cd2-898f-ec843d0d8285">

Something missing is expanding the added node after the fact, I'm not sure how to retrieve the `TreeNode` from the `InstanceSave`, so the new node defaults to be closed.