### PR TITLE
Set dimensions based on texture dimensions for any ipso

### DIFF
--- a/GumRuntime/GraphicalUiElement.cs
+++ b/GumRuntime/GraphicalUiElement.cs
@@ -3325,6 +3325,12 @@ namespace Gum.Wireframe
             {
                 bool wasSet = false;
 
+                if (mTextureHeight > 0)
+                {
+                    heightToSet = mTextureHeight * mHeight / 100.0f;
+                    wasSet = true;
+                }
+
                 if (mContainedObjectAsIpso is ITextureCoordinate iTextureCoordinate)
                 {
                     if (iTextureCoordinate.TextureHeight != null)
@@ -3638,6 +3644,12 @@ namespace Gum.Wireframe
             else if (mWidthUnit == DimensionUnitType.PercentageOfSourceFile)
             {
                 bool wasSet = false;
+
+                if (mTextureWidth > 0)
+                {
+                    widthToSet = mTextureWidth * mWidth / 100.0f;
+                    wasSet = true;
+                }
 
                 if (mContainedObjectAsIpso is ITextureCoordinate iTextureCoordinate)
                 {


### PR DESCRIPTION
If dimension units are `PercentageOfSourceFile` and a non-zero texture width/height was specified, then adjust the height to be based on the texture's width/height. This allows non-`ITextureCoordinate` ipsos to be used while correctly adjusting the dimensions as requested.