### PR TITLE
Open WpfDataUI up to glue theming

### DIFF
--- a/WpfDataUi/Controls/CheckBoxDisplay.xaml.cs
+++ b/WpfDataUi/Controls/CheckBoxDisplay.xaml.cs
@@ -109,7 +109,7 @@ namespace WpfDataUi.Controls
             HintTextBlock.Visibility = !string.IsNullOrEmpty(InstanceMember?.DetailText) ? Visibility.Visible : Visibility.Collapsed;
             HintTextBlock.Text = InstanceMember?.DetailText;
 
-            CheckBox.Foreground = DesiredForegroundBrush;
+            SetForeground(DesiredForegroundBrush);
 
             RefreshIsEnabled();
 
@@ -166,11 +166,19 @@ namespace WpfDataUi.Controls
             {
                 this.TrySetValueOnInstance();
 
+                SetForeground(DesiredForegroundBrush);
+            }
+        }
 
-                CheckBox.Foreground = DesiredForegroundBrush;
-
-
-
+        private void SetForeground(Brush brush)
+        {
+            if (brush == Brushes.Black)
+            {
+                CheckBox.ClearValue(Control.ForegroundProperty);
+            }
+            else
+            {
+                CheckBox.Foreground = brush;
             }
         }
 

--- a/WpfDataUi/Controls/TextBoxDisplayLogic.cs
+++ b/WpfDataUi/Controls/TextBoxDisplayLogic.cs
@@ -403,7 +403,7 @@ namespace WpfDataUi.Controls
             }
         }
 
-        public static SolidColorBrush DefaultValueBackground = new SolidColorBrush(System.Windows.Media.Color.FromRgb(180, 255, 180));
+        public static SolidColorBrush DefaultValueBackground = new SolidColorBrush(System.Windows.Media.Color.FromRgb(180, 255, 180)) { Opacity = 0.5 };
         public static SolidColorBrush IndeterminateValueBackground = new SolidColorBrush(System.Windows.Media.Colors.LightGray);
         public static SolidColorBrush CustomValueBackground = System.Windows.Media.Brushes.White;
 
@@ -491,7 +491,14 @@ namespace WpfDataUi.Controls
             }
             else
             {
-                mAssociatedTextBox.Background = CustomValueBackground;
+                if (mAssociatedTextBox.TryFindResource("Frb.Brushes.TextBox.Background") != null)
+                {
+                    mAssociatedTextBox.SetResourceReference(TextBox.BackgroundProperty, "Frb.Brushes.TextBox.Background");
+                }
+                else
+                {
+                    mAssociatedTextBox.ClearValue(TextBox.BackgroundProperty);
+                }
             }
         }
     }

--- a/WpfDataUi/DataUiGrid.xaml
+++ b/WpfDataUi/DataUiGrid.xaml
@@ -33,12 +33,25 @@
                         Margin="1"
                         local:DataGridAttachedProperties.HideExpanderArrow="{Binding HideHeader}"
                               >
-                    <ItemsControl x:Name="ItemsControlInstance" ItemsSource="{Binding Members}" Focusable="False">
+                    <ItemsControl x:Name="ItemsControlInstance" ItemsSource="{Binding Members}" Focusable="False" AlternationCount="2">
+                        <ItemsControl.Resources>
+                            <SolidColorBrush x:Key="LightBg" Color="White" Opacity="0.1"/>
+                            <SolidColorBrush x:Key="DarkBg" Color="Black" Opacity="0.05"/>
+                        </ItemsControl.Resources>
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>
-                                <DataUi:SingleDataUiContainer FontSize="12" Margin="3,0,3,3" Background="{Binding BackgroundColor}"/>
+                                <DataUi:SingleDataUiContainer x:Name="Container" FontSize="12"  Margin="3,0,3,0" Padding="0,2"/>
+                                <DataTemplate.Triggers>
+                                    <Trigger Property="ItemsControl.AlternationIndex" Value="0">
+                                        <Setter TargetName="Container" Property="Background" Value="{StaticResource LightBg}"/>
+                                    </Trigger>
+                                    <Trigger Property="ItemsControl.AlternationIndex" Value="1">
+                                        <Setter TargetName="Container" Property="Background" Value="{StaticResource DarkBg}"/>
+                                    </Trigger>
+                                </DataTemplate.Triggers>
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>
+
                     </ItemsControl>
                 </Expander>
             </DataTemplate>


### PR DESCRIPTION
Replaces _some_ hard coded dataUI styling, to be more adaptive, additionally looks for resources set by glue to see if they can be used.