### PR TITLE
Adjust padding and margins in DataUiGrid

### DIFF
--- a/WpfDataUi/DataUiGrid.xaml
+++ b/WpfDataUi/DataUiGrid.xaml
@@ -7,6 +7,7 @@
              xmlns:local="clr-namespace:WpfDataUi"
              mc:Ignorable="d" 
              d:DesignHeight="300" d:DesignWidth="300"
+             Padding="0,1,0,0"
              >
     <!--Vic sasks - why is this wrapped in a stack panel? Shouldn't an ItemsControl expand the same as the stack panel? Having it in a stack panel screws with horizontal layouts...-->
     <!--<StackPanel Background="Purple">-->
@@ -30,7 +31,8 @@
                         BorderThickness="{Binding CategoryBorderThickness}"
                         VerticalAlignment="Stretch"  
                         IsExpanded="True" 
-                        Margin="1"
+                        Margin="0,0,0,4"
+                        Padding="0,0,0,2"
                         local:DataGridAttachedProperties.HideExpanderArrow="{Binding HideHeader}"
                               >
                     <ItemsControl x:Name="ItemsControlInstance" ItemsSource="{Binding Members}" Focusable="False" AlternationCount="2">
@@ -40,7 +42,7 @@
                         </ItemsControl.Resources>
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>
-                                <DataUi:SingleDataUiContainer x:Name="Container" FontSize="12"  Margin="3,0,3,0" Padding="0,2"/>
+                                <DataUi:SingleDataUiContainer x:Name="Container" FontSize="12" Padding="2,1"/>
                                 <DataTemplate.Triggers>
                                     <Trigger Property="ItemsControl.AlternationIndex" Value="0">
                                         <Setter TargetName="Container" Property="Background" Value="{StaticResource LightBg}"/>


### PR DESCRIPTION
These minor adjustments go by nearly un-noticed in the variables tab but provides a cleaner layout for the theming/styling branch. It _may_ be worth looking at other areas outside of the variables tab in Glue, but these adjustments aren't more than 1-2 pixels so it really shouldn't negatively impact other areas.