### PR TITLE
Recent project not showing just saved

### DIFF
--- a/Gum/Managers/ProjectManager.cs
+++ b/Gum/Managers/ProjectManager.cs
@@ -582,6 +582,8 @@ namespace Gum
                     {
                         PluginManager.Self.ProjectSave(GumProjectSave);
                         GeneralSettingsFile.AddToRecentFilesIfNew(GumProjectSave.FullFileName);
+                        GeneralSettingsFile.LastProject = GumProjectSave.FullFileName;
+                        GeneralSettingsFile.Save();
                     }
                 }
             }

--- a/Gum/Managers/ProjectManager.cs
+++ b/Gum/Managers/ProjectManager.cs
@@ -581,6 +581,7 @@ namespace Gum
                     if (succeeded)
                     {
                         PluginManager.Self.ProjectSave(GumProjectSave);
+                        GeneralSettingsFile.AddToRecentFilesIfNew(GumProjectSave.FullFileName);
                     }
                 }
             }


### PR DESCRIPTION
This fixes the first part of #203, but I couldn't figure out how to get the menu to refresh for the list of Load Recent items.

I think Somehow the code needs to call MainRecentFilesPlugin.RefreshMenuItems();  also?