### PR TITLE
Add fix for graphics device

### DIFF
--- a/XnaAndWinforms/GraphicsDeviceControl.cs
+++ b/XnaAndWinforms/GraphicsDeviceControl.cs
@@ -211,7 +211,11 @@ namespace XnaAndWinforms
                             mRenderError.Message = exception.ToString();
                         }
                     }
-                    else
+                    else if (!mRenderError.GraphicsDeviceResetFailed)
+                    {
+                        TryHandleDeviceReset(mRenderError);
+
+                    } else
                     {
                         // If BeginDraw failed, show an error message using System.Drawing.
                         PaintUsingSystemDrawing(e.Graphics, mRenderError.ProcessedMessage);
@@ -299,6 +303,9 @@ namespace XnaAndWinforms
         /// </summary>
         void TryHandleDeviceReset(RenderingError error)
         {
+            // Don't attempt to reset if we failed resetting before
+            if (error.GraphicsDeviceResetFailed)
+                return;
 
             switch (GraphicsDevice.GraphicsDeviceStatus)
             {
@@ -341,6 +348,7 @@ namespace XnaAndWinforms
                 }
                 catch (Exception e)
                 {
+                    error.GraphicsDeviceResetFailed = true;
                     error.GraphicsDeviceNeedsReset = false;
                     error.Message = "Graphics device reset failed\n\n" + e;
                 }

--- a/XnaAndWinforms/RenderingError.cs
+++ b/XnaAndWinforms/RenderingError.cs
@@ -32,6 +32,15 @@ namespace XnaAndWinforms
             set;
         }
 
+        /// <summary>
+        ///  Indicates that we previously tried to reset the graphics device and it failed to reset
+        /// </summary>
+        public bool GraphicsDeviceResetFailed
+        {
+            get;
+            set;
+        }
+
         public bool HasErrors
         {
             get


### PR DESCRIPTION
This should resolve #412

Unless there is a specific reason this isn't already being done, it works to fix the issue for me.

Steps to reproduce:

Open GUM
1. Lock your computer with WINDOWS+L
2. Unlock your computer
3. Graphics device is lost
4. Steps to fix:

Add this line of code at 216, and comment out the rest.
1. TryHandleDeviceReset(mRenderError);
2. If you still want a fallback, record if we've tried to reset or not, and then display the PaintUsingSystemDrawing instead.

I tested with above code change and it works fine for me.