### PR TITLE
Fix issue with down option on right-click when at bottom.  Fix issue …

### DIFF
--- a/Gum/Plugins/InternalPlugins/StatePlugin/StateTreeViewRightClickService.cs
+++ b/Gum/Plugins/InternalPlugins/StatePlugin/StateTreeViewRightClickService.cs
@@ -56,7 +56,7 @@ public class StateTreeViewRightClickService
             {
                 AddSplitter();
                 AddMenuItem("Rename State", RenameStateClick);
-                AddMenuItem("Delete " + _selectedState.SelectedStateSave.Name, DeleteStateClick);
+                AddMenuItem("Delete [" + _selectedState.SelectedStateSave.Name + "]", DeleteStateClick);
                 AddMenuItem("Duplicate State", DuplicateStateClick);
 
                 AddMoveToCategoryItems();
@@ -67,7 +67,10 @@ public class StateTreeViewRightClickService
                 {
                     AddMenuItem("^ Move Up", MoveUpClick, "Alt+Up");
                 }
-                AddMenuItem("v Move Down", MoveDownClick, "Alt+Down");
+                if (GetIfCanMoveDown(_selectedState.SelectedStateSave, _selectedState.SelectedStateCategorySave))
+                {
+                    AddMenuItem("v Move Down", MoveDownClick, "Alt+Down");
+                }
             }
         }
         // We used to show the category editing commands if a state was selected 
@@ -82,7 +85,7 @@ public class StateTreeViewRightClickService
             AddMenuItem("Rename Category", RenameCategoryClick);
 
 
-            AddMenuItem("Delete " + _selectedState.SelectedStateCategorySave.Name, DeleteCategoryClick);
+            AddMenuItem("Delete [" + _selectedState.SelectedStateCategorySave.Name + "]", DeleteCategoryClick);
         }
     }
 
@@ -129,7 +132,7 @@ public class StateTreeViewRightClickService
                 list.Insert(oldIndex - 1, state);
                 shouldSave = true;
             }
-            else if(direction == 1 &&  oldIndex != list.Count-1)
+            else if(direction == 1 && GetIfCanMoveDown(state, _selectedState.SelectedStateCategorySave))
             {
                 list.RemoveAt(oldIndex);
                 list.Insert(oldIndex + 1, state);
@@ -141,6 +144,8 @@ public class StateTreeViewRightClickService
                 GumCommands.Self.GuiCommands.RefreshStateTreeView();
 
                 GumCommands.Self.FileCommands.TryAutoSaveCurrentObject();
+
+                PopulateMenuStrip();
             }
         }
     }
@@ -163,6 +168,19 @@ public class StateTreeViewRightClickService
         }
 
         return stateIndex > indexToBeGreaterThan;
+    }
+
+    bool GetIfCanMoveDown(StateSave state, StateSaveCategory category)
+    {
+        //var list = _selectedState.SelectedStateContainer.UncategorizedStates;
+        var list = _selectedState.SelectedStateCategorySave.States;
+        if (category != null)
+        {
+            list = category.States;
+        }
+
+        int oldIndex = list.IndexOf(state);
+        return oldIndex != list.Count - 1;
     }
 
 

--- a/Gum/Plugins/InternalPlugins/StatePlugin/ViewModels/StateTreeViewModel.cs
+++ b/Gum/Plugins/InternalPlugins/StatePlugin/ViewModels/StateTreeViewModel.cs
@@ -392,12 +392,14 @@ public class StateTreeViewModel : ViewModel
         var stateVm = Categories.SelectMany(item => item.States).FirstOrDefault(item => item.Data == state);
 
         stateVm?.ForceRefreshTitle();
+        _stateTreeViewRightClickService.PopulateMenuStrip();
     }
 
     internal void HandleRename(StateSaveCategory category)
     {
         var categoryVm = Categories.FirstOrDefault(item => item.Data == category);
         categoryVm?.ForceRefreshTitle();
+        _stateTreeViewRightClickService.PopulateMenuStrip();
     }
 
     #endregion


### PR DESCRIPTION
…with right-click menu not refreshing after rename.  Add brackets around category/state name in right-click menu.


fixes #352
fixes #351 