### PR TITLE
change directory to normal attributes before attempting a delete

### DIFF
--- a/Gum/Plugins/InternalPlugins/TreeView/ElementTreeViewManager.RightClick.cs
+++ b/Gum/Plugins/InternalPlugins/TreeView/ElementTreeViewManager.RightClick.cs
@@ -264,6 +264,11 @@ public partial class ElementTreeViewManager
                     {
                         try
                         {
+                            // Set the folder to NORMAL so it doesn't retain READONLY or ARCHIVE attributes
+                            // This happens because of OneDrive
+                            DirectoryInfo dir = new DirectoryInfo(fullFile);
+                            dir.Attributes = FileAttributes.Normal;
+
                             Directory.Delete(fullFile);
                             GumCommands.Self.GuiCommands.RefreshElementTreeView();
                         }


### PR DESCRIPTION
Fixes #381 

You can decide if you like the work-around or not :)


https://stackoverflow.com/questions/1701457/directory-delete-doesnt-work-access-denied-error-but-under-windows-explorer-it