### PR TITLE
Make it so the Plus symbol isn't cutoff, or the add point textbox and…

### DIFF
--- a/WpfDataUi/Controls/ListBoxDisplay.xaml
+++ b/WpfDataUi/Controls/ListBoxDisplay.xaml
@@ -5,7 +5,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:local="clr-namespace:WpfDataUi.Controls"
              mc:Ignorable="d" 
-             MinHeight="80" MaxHeight="120"
+             MinHeight="80" MaxHeight="260"
              d:DesignWidth="200">
     <Grid>
         <Grid.RowDefinitions>
@@ -28,7 +28,12 @@
             </ListBox>
             <Grid Grid.Row="1">
                 <StackPanel x:Name="NotEditingEntryStackPanel" HorizontalAlignment="Stretch" Orientation="Horizontal">
-                    <Button Height="24" Width="24" Click="AddButtonClicked">+</Button>
+                    <Button 
+                        Height="{Binding ActualHeight, ElementName=Label}"
+                        Width="{Binding ActualHeight, ElementName=Label}"
+                        MinHeight="24"
+                        MinWidth="24"
+                        Click="AddButtonClicked">+</Button>
                 </StackPanel>
             </Grid>
             <Grid Grid.Row="1" x:Name="NewEntryGrid" Visibility="Collapsed">


### PR DESCRIPTION
… buttons.

Relates to #468    this is item 17 on the list

Now the + is no longer cutoff at ridiculous zoom level.  Images were take with 240 max height, but I adjusted it to 260 so 2 lines of points text could fit instead.  Just didn't re-take an image

![image](https://github.com/user-attachments/assets/a8a786f8-445b-4f0f-ab63-4f5f4e628702)

![image](https://github.com/user-attachments/assets/df407344-f1a5-480f-8923-ab6209135210)
