### PR TITLE
Fix the error by preventing the user from typing characters, when the…

### DIFF
--- a/MonoGameGum/Forms/Controls/PasswordBox.cs
+++ b/MonoGameGum/Forms/Controls/PasswordBox.cs
@@ -123,6 +123,11 @@ public class PasswordBox : TextBoxBase
             {
                 // no enter supported on passwords, do we send an event?
             }
+            else if (caretIndex >= MaxLength)
+            {
+                // If they enter more than the allowed characters, SecrueString.InsertAt will thow an error, so prevent that
+                // throw new ArgumentOutOfRangeException(nameof(index), SR.ArgumentOutOfRange_IndexString);
+            }
             else
             {
                 InsertCharacterAtIndex(character, caretIndex);
@@ -130,8 +135,8 @@ public class PasswordBox : TextBoxBase
 
                 CallMethodsInResponseToPasswordChanged();
             }
-
         }
+
     }
 
     private void CallMethodsInResponseToPasswordChanged()


### PR DESCRIPTION
… caretIndex is at the end of the MaxLength of the passwordbox


https://github.com/user-attachments/assets/c969568e-8150-41eb-aa1e-50695e297759



This fixes #727 