### PR TITLE
Add new SelectionChanged event

### DIFF
--- a/MonoGameGum/Forms/Controls/TextBoxBase.cs
+++ b/MonoGameGum/Forms/Controls/TextBoxBase.cs
@@ -170,6 +170,7 @@ public abstract class TextBoxBase : FrameworkElement, IInputReceiver
                 selectionLength = System.Math.Min(maxSelectionLengthAllowed, value);
                 UpdateToSelection();
                 UpdateCaretVisibility();
+                RaiseSelectionChanged();
             }
         }
     }
@@ -235,6 +236,8 @@ public abstract class TextBoxBase : FrameworkElement, IInputReceiver
     public event Action<object, TextCompositionEventArgs> PreviewTextInput;
     public event EventHandler CaretIndexChanged;
     protected void RaiseCaretIndexChanged() => CaretIndexChanged?.Invoke(this, EventArgs.Empty);
+    public event EventHandler SelectionChanged;
+    protected void RaiseSelectionChanged() => SelectionChanged?.Invoke(this, EventArgs.Empty);
     protected TextCompositionEventArgs RaisePreviewTextInput(string newText)
     {
         var args = new TextCompositionEventArgs(newText);


### PR DESCRIPTION
This fixes #720



Method to test:

```csharp
        private void MultilinTextBoxTutorial(StackPanel panelToAddTo)
        {
            var multiLinePanel = new StackPanel();
            panelToAddTo.AddChild(multiLinePanel);

            var label = new Label();
            multiLinePanel.AddChild(label);

            var leftToRight = new StackPanel();
            leftToRight.Visual.ChildrenLayout = ChildrenLayout.LeftToRightStack;
            leftToRight.Spacing = 3;
            multiLinePanel.AddChild(leftToRight);

            var startSelection = new Button();
            startSelection.Text = "Start=5";
            leftToRight.AddChild(startSelection);

            var lengthSelection = new Button();
            lengthSelection.Text = "Length=5";
            leftToRight.AddChild(lengthSelection);

            var multiLineTextBox = new TextBox();
            multiLineTextBox.TextWrapping = TextWrapping.Wrap;
            multiLineTextBox.Height = 140;
            multiLinePanel.AddChild(multiLineTextBox);

            multiLineTextBox.SelectionChanged += (sender, args) =>
            {
                var start = (sender as TextBox).SelectionStart;
                var length = (sender as TextBox).SelectionLength;

                var selection = (sender as TextBox).Text.Substring(start, length);
                label.Text = $"Start [{start}] length [{length}] selection [{selection}]";
            };

            startSelection.Click += (sender, args) =>
            {
                multiLineTextBox.SelectionStart = 5;
            };

            lengthSelection.Click += (sender, args) =>
            {
                multiLineTextBox.SelectionLength = 5; // (5-=10)
            };
        }
```