### PR TITLE
Now when a passwordChar is set, it will instantly update the visual

### DIFF
--- a/MonoGameGum/Forms/Controls/PasswordBox.cs
+++ b/MonoGameGum/Forms/Controls/PasswordBox.cs
@@ -56,7 +56,21 @@ public class PasswordBox : TextBoxBase
 
     // Update Gum's default to include this first:
     //public char PasswordChar { get; set; } = '●';
-    public char PasswordChar { get; set; } = '*';
+    private char _passwordChar = '*';
+    public char PasswordChar {
+
+        get => _passwordChar;
+
+        set
+        {
+            if (_passwordChar == value)
+            { 
+                return;
+            }
+            _passwordChar = value;
+            UpdateDisplayedCharacters();
+        }
+    }
 
     public event EventHandler PasswordChanged;
 


### PR DESCRIPTION
Fixes #726

I validated it works in the video below. 
I made sure that the visual change didn't mess up the CaretIndex or visual position.

https://github.com/user-attachments/assets/3ecb7fa8-22ed-4b34-9b85-a65655a2c012

