### PR TITLE
Updated Gum Tool Linux Auto Install Script

### DIFF
--- a/setup_gum_linux.sh
+++ b/setup_gum_linux.sh
@@ -219,4 +219,6 @@ fi
 ### Finished
 ################################################################################
 echo "Gum setup on Linux using WINE is now complete. You can open the GUM Tool by using the command 'Gum'."
+echo "Pro Tip 1: Install dxvk with the command winetricks dxvk, if you can use Vulkan on your system! (It handles better than OpenGL)."
+echo "Pro Tip 2: Install allfonts with the command winetricks allfonts, it'll make text look better (you maybe able to get by with just arial, but just to be safe."
 echo "You may need to close and reopen the terminal if it doesn't work at first."


### PR DESCRIPTION
Fixed the script not properly setting the path for some users using a bash shell.

Fixed bash using `Gum` rather than `gum` which is the command that fish and zshrc uses.

Made it, so the script uses its own `.wine_gum_prefix` prefix, rather than the default .wine folder (which is just a left over of the macOS script which this is based on). You can run into issues when the .wine prefix has already been used and is messy because of failed installations of software and such.  

Made some tweaks to downloading and extracting the Gum Tool zip.

Added two tips when the script is done (just two things the user can install to improve the Gum Tool experience on Wine, but either take too long or will cause issues on very old hardware that don't support Vulkan).