### PR TITLE
725 fix radiobutton istrue in initalize

### DIFF
--- a/MonoGameGum/Forms/Controls/RadioButton.cs
+++ b/MonoGameGum/Forms/Controls/RadioButton.cs
@@ -177,38 +177,6 @@ public class RadioButton : ToggleButton
     #endregion
 
     #region UpdateTo Methods
-
-    public override bool? IsChecked
-    {
-        get
-        {
-            return base.IsChecked;
-        }
-        set
-        {
-            // Don't do anything if it's already the correct value.
-            if (base.IsChecked == value)
-            {
-                return;
-            }
-
-            if (value != null && (bool)value)
-            {
-                SetThisAsOnlyCheckedInGroup();
-            }
-            else
-            {
-                base.IsChecked = value;
-            }
-        }
-    }
-
-    // This is to allow us to set the base of ANOTHER RadioButton from this RadioButton.
-    private void SetIsCheckedBase(bool? value)
-    {
-        base.IsChecked = value;
-    }
-
     private void SetThisAsOnlyCheckedInGroup()
     {
         var parent = GetParent();
@@ -220,12 +188,12 @@ public class RadioButton : ToggleButton
             {
                 if (radio != this)
                 {
-                    radio.SetIsCheckedBase(false);
+                    radio.IsChecked = false;
                 }
             }
         }
 
-        base.IsChecked = true;
+        IsChecked = true;
     }
 
     public override void UpdateState()

--- a/MonoGameGum/Forms/Controls/RadioButton.cs
+++ b/MonoGameGum/Forms/Controls/RadioButton.cs
@@ -178,18 +178,54 @@ public class RadioButton : ToggleButton
 
     #region UpdateTo Methods
 
+    public override bool? IsChecked
+    {
+        get
+        {
+            return base.IsChecked;
+        }
+        set
+        {
+            // Don't do anything if it's already the correct value.
+            if (base.IsChecked == value)
+            {
+                return;
+            }
+
+            if (value != null && (bool)value)
+            {
+                SetThisAsOnlyCheckedInGroup();
+            }
+            else
+            {
+                base.IsChecked = value;
+            }
+        }
+    }
+
+    // This is to allow us to set the base of ANOTHER RadioButton from this RadioButton.
+    private void SetIsCheckedBase(bool? value)
+    {
+        base.IsChecked = value;
+    }
+
     private void SetThisAsOnlyCheckedInGroup()
     {
         var parent = GetParent();
-        foreach (var radio in RadioButtonDictionary[parent][GroupName])
+
+        // Don't set all RadioButtons to FALSE just because they don't have a parent yet!
+        if (parent != FakeRoot)
         {
-            if (radio != this)
+            foreach (var radio in RadioButtonDictionary[parent][GroupName])
             {
-                radio.IsChecked = false;
+                if (radio != this)
+                {
+                    radio.SetIsCheckedBase(false);
+                }
             }
         }
 
-        IsChecked = true;
+        base.IsChecked = true;
     }
 
     public override void UpdateState()

--- a/MonoGameGum/Forms/Controls/ToggleButton.cs
+++ b/MonoGameGum/Forms/Controls/ToggleButton.cs
@@ -19,7 +19,7 @@ public class ToggleButton : ButtonBase
 
     private bool? isChecked = false;
 
-    public bool? IsChecked
+    public virtual bool? IsChecked
     {
         get
         {

--- a/MonoGameGum/Forms/Controls/ToggleButton.cs
+++ b/MonoGameGum/Forms/Controls/ToggleButton.cs
@@ -19,7 +19,7 @@ public class ToggleButton : ButtonBase
 
     private bool? isChecked = false;
 
-    public virtual bool? IsChecked
+    public bool? IsChecked
     {
         get
         {


### PR DESCRIPTION
Fixes #725

In the video I show that on startup, all the checkboxes I manually set are checked.
I show that manually changing them as a user they function correctly.
I show that when another element has code to set IsTrue it also correctly functions.

**NOTE:** The only "gotcha" with my fix is this..... If a user intentionally sets multiple IsChecked values on 2 or more Radio Buttons, and then AFTERWARDS adds them to the same parent, they will all show checked.  I feel this is acceptable, since someone would have to be intentionally trying to break things to set multiple to true themselves in code without a parent.  I could potentially work-around this by doing some logic in HandleParentChanged if you really are concerned with that scenario.

https://github.com/user-attachments/assets/f8036f16-e99d-4be1-bb20-b579ec5beb11

