### PR TITLE
Preventing the highlighted nodes from changing color. 

### DIFF
--- a/Gum/Plugins/InternalPlugins/TreeView/ElementTreeViewManager.cs
+++ b/Gum/Plugins/InternalPlugins/TreeView/ElementTreeViewManager.cs
@@ -112,8 +112,8 @@ namespace Gum.Managers
         TreeNode mComponentsTreeNode;
         TreeNode mStandardElementsTreeNode;
         TreeNode mBehaviorsTreeNode;
-        TreeNode mLastHoveredNode;
-        private DateTime hoverStartTime;
+        TreeNode? mLastHoveredNode;
+        private DateTime? hoverStartTime;
 
 
 
@@ -678,6 +678,16 @@ namespace Gum.Managers
                     // Can't do this, it seems to interfere with the Undo History
                     //treeview.SelectedNode = hoveredNode;
 
+                    // Don't do highlighting or folder expanding if we are on the selected nodes!
+                    // Alternative, we COULD "invert" the colors when hovering over a selected node.
+                    foreach (var node in treeview.SelectedNodes)
+                    {
+                        if (node == hoveredNode)
+                        {
+                            return;
+                        }
+                    }
+
                     // So...lets fake it with backcolor/forecolor instead?
                     if (mLastHoveredNode != hoveredNode)
                     {
@@ -707,7 +717,12 @@ namespace Gum.Managers
                         // Make it so that we can EXPAND folders or nodes/items if we hover for half a second
                         if (hoveredNode.Nodes.Count > 0 && !hoveredNode.IsExpanded)
                         {
-                            TimeSpan duration = DateTime.Now - hoverStartTime;
+                            if (hoverStartTime == null)
+                            {
+                                hoverStartTime = DateTime.Now;
+                            }
+
+                            TimeSpan duration = (TimeSpan)(DateTime.Now - hoverStartTime);
                             int hoverDelayMiliseconds = 500;
                             if (duration.TotalMilliseconds > hoverDelayMiliseconds)
                             {
@@ -728,6 +743,8 @@ namespace Gum.Managers
             {
                 mLastHoveredNode.BackColor = ObjectTreeView.BackColor;
                 mLastHoveredNode.ForeColor = ObjectTreeView.ForeColor;
+                mLastHoveredNode = null;
+                hoverStartTime = null;
             }
 
             if (e.Data != null)


### PR DESCRIPTION
 This is similar behavior now to how windows works in the explorer view.

Work towards issues with drag/drop, this fixes the issue where highlighted nodes loose their highlighting if you drag over them.

relates to #767