### PR TITLE
776 - Add string format to bindings

### DIFF
--- a/MonoGameGum.Tests/Forms/FrameworkElementBindingTests.cs
+++ b/MonoGameGum.Tests/Forms/FrameworkElementBindingTests.cs
@@ -482,6 +482,26 @@ public class FrameworkElementBindingTests
         await Assert.That(propertyChangedCount).IsEqualTo(1);
     }
 
+    [Test]
+    public async Task StringFormat_FormatsNewTargetValue()
+    {
+        TestViewModel vm = new() { FloatValue = 0.1234f };
+        Label label = new() { BindingContext = vm };
+        Binding binding = new(nameof(TestViewModel.FloatValue))
+        {
+            StringFormat = "Value: {0:P}"
+        };
+
+        label.SetBinding(nameof(Label.Text), binding);
+        await Assert.That(label.Text).IsEqualTo("Value: 12.34%");
+
+        label.Text = "Value: 55.55%";
+
+        //string format technically only works on a one-way binding, but we
+        //want to make sure we don't fall over or muck with the source value
+        await Assert.That(vm.FloatValue).IsEqualTo(0.1234f);
+    }
+
 
     private class TestViewModel : ViewModel
     {

--- a/MonoGameGum/Forms/Data/Binding.cs
+++ b/MonoGameGum/Forms/Data/Binding.cs
@@ -44,4 +44,5 @@ public record Binding(string Path)
     public object? TargetNullValue { get; init; }
     public IValueConverter? Converter { get; init; }
     public object? ConverterParameter { get; init; }
+    public string? StringFormat { get; set; }
 }

--- a/MonoGameGum/Forms/Data/NpcBindingExpression.cs
+++ b/MonoGameGum/Forms/Data/NpcBindingExpression.cs
@@ -118,7 +118,9 @@ internal class NpcBindingExpression : UntypedBindingExpression
 
         if (value != GumProperty.UnsetValue)
         {
-            if (_binding.StringFormat is not null && value is not null)
+            if (_targetProperty.PropertyType == typeof(string) && 
+                _binding.StringFormat is not null && 
+                value is not null)
             {
                 value = string.Format(_binding.StringFormat, value);
             }

--- a/MonoGameGum/Forms/Data/NpcBindingExpression.cs
+++ b/MonoGameGum/Forms/Data/NpcBindingExpression.cs
@@ -116,9 +116,16 @@ internal class NpcBindingExpression : UntypedBindingExpression
             return;
         }
 
-        if (value != GumProperty.UnsetValue && !IsValidForType(value, _targetType))
+        if (value != GumProperty.UnsetValue)
         {
-            value = TryConvert(value, _targetType);
+            if (_binding.StringFormat is not null && value is not null)
+            {
+                value = string.Format(_binding.StringFormat, value);
+            }
+            else if (!IsValidForType(value, _targetType))
+            {
+                value = TryConvert(value, _targetType);
+            }
         }
 
         if (value == GumProperty.UnsetValue)


### PR DESCRIPTION
fixes #776 
Implements StringFormat property on Binding to format the target value of a binding expression. This allows for formatting values displayed in UI elements without modifying the source data.