### PR TITLE
Mac setup: fix Gum zip missing path part

### DIFF
--- a/setup_gum_mac.sh
+++ b/setup_gum_mac.sh
@@ -72,7 +72,7 @@ rm -f ~/.wine/drive_c/Program\ Files/Gum.zip &> /dev/null
 ################################################################################
 echo "Adding Gum to path"
 SCRIPT_CONTENT="#!/bin/bash
-wine ~/.wine/drive_c/Program\\ Files/Gum/Data/Gum.exe"
+wine ~/.wine/drive_c/Program\\ Files/Gum/Data/Debug/Gum.exe"
 
 ################################################################################
 ### Create the ~/bin directory if it doesn't exist


### PR DESCRIPTION
The downloaded Gum zip file puts the Gum.exe in a /Debug folder.

This fixes failing to find the executable with the following error at the end when you ran the `Gum` command after running setup_gum_mac.sh.

```
wine: failed to open "/Users/patridge/.wine/drive_c/Program Files/Gum/Data/Gum.exe": c0000135
```