### PR TITLE
fix: revert a commit that used collection expression

### DIFF
--- a/MonoGameGum/Forms/Data/PropertyPathObserver.cs
+++ b/MonoGameGum/Forms/Data/PropertyPathObserver.cs
@@ -29,7 +29,7 @@ internal class PropertyPathObserver : IDisposable
 
     public PropertyPathObserver(string path)
     {
-        _segments = path.Split(["."], StringSplitOptions.RemoveEmptyEntries);
+        _segments = path.Split('.', StringSplitOptions.RemoveEmptyEntries);
     }
 
     public void Detach()


### PR DESCRIPTION
It looks like [this commit](https://github.com/vchelaru/Gum/commit/7fbc5f78314c15fd8f034ba908c38120b75d3d55) was removing the ^ operator (index from end) to be compatible with netstandad2.0 but also introduced the c#12 collection-expression feature. (maybe on accident as I would think this would cause similar problems?)

Reverting that part of the change since it's currently breaking KniGum and failing the pipelines.