### PR TITLE
Added null check in UpdateSource

### DIFF
--- a/MonoGameGum/Forms/Data/NpcBindingExpression.cs
+++ b/MonoGameGum/Forms/Data/NpcBindingExpression.cs
@@ -168,7 +168,7 @@ internal class NpcBindingExpression : UntypedBindingExpression
             value = TryConvert(value, sourceType);
         }
 
-        if (value == GumProperty.UnsetValue)
+        if (value == GumProperty.UnsetValue || value == null)
         {
             // conversion failed: don't update source if we don't know what to set
             return;


### PR DESCRIPTION
I'm updating an older game, Masteroid, and screens were crashing because it was trying to set null values.

The `UpdateSource` method is doing a lot of sanity checking on the `value` object but it _wasn't_ actually doing a null check. It felt like a null check belonged semantically with the check for `GumProperty.UnsetValue`.

Adding this fixed my crash but I have no context on how this works so I would like a second set of eyes on this!