### PR TITLE
fix: binding context replacement behavior.

### DIFF
--- a/MonoGameGum.Tests/Forms/FrameworkElementBindingTests.cs
+++ b/MonoGameGum.Tests/Forms/FrameworkElementBindingTests.cs
@@ -594,6 +594,27 @@ public class FrameworkElementBindingTests
         label.Text.ShouldBe(targetNullValue);
     }
 
+    [Fact]
+    public void ReplaceBindingContext_UnrelatedTypes()
+    {
+        // Arrange
+        const string expectedText = nameof(AuxTestViewModel);
+
+        TextBox textBox = new();
+        TestViewModel vm1 = new() {Text = nameof(TestViewModel)};
+        textBox.BindingContext = vm1;
+        textBox.SetBinding(nameof(textBox.Text), nameof(TestViewModel.Text));
+
+        AuxTestViewModel vm2 = new() { Text = expectedText };
+
+        // Act
+        Exception? exception = Record.Exception(() => textBox.BindingContext = vm2);
+
+        // Assert
+        Assert.Null(exception);
+        Assert.Equal(expectedText, textBox.Text);
+    }
+
     private class TestViewModel : ViewModel
     {
         public TestViewModel? Child
@@ -632,6 +653,15 @@ public class FrameworkElementBindingTests
         }
 
         public override string ToString() => Text;
+    }
+
+    public class AuxTestViewModel : ViewModel
+    {
+        public string? Text
+        {
+            get=> Get<string?>();
+            set => Set(value);
+        }
     }
 
     private class TestStringBoolConverter : IValueConverter

--- a/MonoGameGum/Forms/Data/PropertyPathObserver.cs
+++ b/MonoGameGum/Forms/Data/PropertyPathObserver.cs
@@ -71,9 +71,6 @@ internal class PropertyPathObserver : IDisposable
             }
             cursor = pi?.GetValue(cursor);
         }
-
-        // initial fire
-        OnValueChanged();
     }
 
     private void OnSegmentChanged(int level, string propName)


### PR DESCRIPTION
Addresses an issue where replacing the BindingContext with a different type would not update the bound properties correctly.

Adds a test case to verify the correct behavior when replacing the BindingContext with an object of an unrelated type, ensuring that bindings are updated as expected.

Removes the initial OnValueChanged call in PropertyPathObserver to avoid potential issues with initial binding values.
