### PR TITLE
fix: BindingContext update issue

### DIFF
--- a/MonoGameGum/Forms/Data/NpcBindingExpression.cs
+++ b/MonoGameGum/Forms/Data/NpcBindingExpression.cs
@@ -48,7 +48,7 @@ internal class NpcBindingExpression : UntypedBindingExpression
     {
         if (CurrentRoot != null)
         {
-            AttachToSource(e.NewBindingContext);
+            AttachToSource(_targetElement.BindingContext);
         }
     }
 
@@ -144,7 +144,7 @@ internal class NpcBindingExpression : UntypedBindingExpression
 
     public override void UpdateSource()
     {
-        if (_binding.Mode is BindingMode.OneWay || LeafType is not {} sourceType)
+        if (_binding.Mode is BindingMode.OneWay || LeafType is not {} sourceType || _targetProperty.Name == nameof(FrameworkElement.BindingContext))
         {
             return;
         }

--- a/MonoGameGum/Forms/Data/UntypedBindingExpressionBase.cs
+++ b/MonoGameGum/Forms/Data/UntypedBindingExpressionBase.cs
@@ -105,12 +105,12 @@ internal abstract class UntypedBindingExpression : BindingExpressionBase
 
     protected void SetSourceValue(object? value)
     {
-        if (_sourceSetter is null || !_pathObserver.HasResolution)
+        if (_sourceSetter is null || !_pathObserver.HasResolution || CurrentRoot is null)
         {
             // binding error: broken path
             return;
         }
-        _sourceSetter(_targetElement.BindingContext, value);
+        _sourceSetter(CurrentRoot, value);
     }
 
     protected object? Convert(IValueConverter converter, object? value, Type targetType)


### PR DESCRIPTION
Addresses a bug where binding to the BindingContext incorrectly triggered source updates, leading to potential invalid cast exceptions.

The BindingContext binding is now treated as a one-way binding, preventing unintended updates to the source. This ensures that the BindingContext is only used to update the target element, resolving the invalid cast issue.
