### PR TITLE
Update KNI version to 4.1.9001

### DIFF
--- a/MonoGameGum/KniGum/KniGum.csproj
+++ b/MonoGameGum/KniGum/KniGum.csproj
@@ -1,12 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 		<PackageId>Gum.KNI</PackageId>
-		<Version>2025.5.29.1</Version>
+		<Version>2025.6.4.1</Version>
 
 
 
@@ -30,12 +30,12 @@
 	<ItemGroup>
 		<None Remove="..\Content\Font18Arial.fnt" />
 		<None Remove="..\Content\Font18Arial_0.png" />
-    <None Remove="..\Content\Font18Arial_Bold.fnt" />
-    <None Remove="..\Content\Font18Arial_Bold_0.png" />
-    <None Remove="..\Content\Font18Arial_Italic.fnt" />
-    <None Remove="..\Content\Font18Arial_Italic_0.png" />
-    <None Remove="..\Content\Font18Arial_Italic_Bold.fnt" />
-    <None Remove="..\Content\Font18Arial_Italic_Bold_0.png" />
+		<None Remove="..\Content\Font18Arial_Bold.fnt" />
+		<None Remove="..\Content\Font18Arial_Bold_0.png" />
+		<None Remove="..\Content\Font18Arial_Italic.fnt" />
+		<None Remove="..\Content\Font18Arial_Italic_0.png" />
+		<None Remove="..\Content\Font18Arial_Italic_Bold.fnt" />
+		<None Remove="..\Content\Font18Arial_Italic_Bold_0.png" />
 	</ItemGroup>
 
 	<ItemGroup>
@@ -126,13 +126,16 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="nkast.Xna.Framework" Version="3.12.9001" />
-		<PackageReference Include="nkast.Xna.Framework.Content" Version="3.12.9001" />
-		<PackageReference Include="nkast.Xna.Framework.Graphics" Version="3.12.9001" />
-		<PackageReference Include="nkast.Xna.Framework.Input" Version="3.12.9001" />
-		<PackageReference Include="nkast.Xna.Framework.Game" Version="3.12.9001" />
-		<!--<PackageReference Include="nkast.Xna.Framework.Audio" Version="3.12.9001" />-->
-		<!--<PackageReference Include="nkast.Xna.Framework.Media" Version="3.12.9001" />-->
+		<PackageReference Include="nkast.Xna.Framework" Version="4.1.9001" />
+		<PackageReference Include="nkast.Xna.Framework.Content" Version="4.1.9001" />
+		<PackageReference Include="nkast.Xna.Framework.Graphics" Version="4.1.9001" />
+		<PackageReference Include="nkast.Xna.Framework.Audio" Version="4.1.9001" />
+		<PackageReference Include="nkast.Xna.Framework.Media" Version="4.1.9001" />
+		<PackageReference Include="nkast.Xna.Framework.Input" Version="4.1.9001" />
+		<PackageReference Include="nkast.Xna.Framework.Game" Version="4.1.9001" />
+		<PackageReference Include="nkast.Xna.Framework.Devices" Version="4.1.9001" />
+		<PackageReference Include="nkast.Xna.Framework.Storage" Version="4.1.9001" />
+		<PackageReference Include="nkast.Xna.Framework.XR" Version="4.1.9001" />
 
 		<PackageReference Include="TextCopy" Version="6.2.1" />
 	</ItemGroup>

--- a/Samples/GumFormsSample/GumFormsSampleCommon/KniGumFormsSampleCommon.csproj
+++ b/Samples/GumFormsSample/GumFormsSampleCommon/KniGumFormsSampleCommon.csproj
@@ -20,13 +20,16 @@
 	
 	
   <ItemGroup>
-	  <PackageReference Include="nkast.Xna.Framework" Version="3.12.9001" />
-	  <PackageReference Include="nkast.Xna.Framework.Content" Version="3.12.9001" />
-	  <PackageReference Include="nkast.Xna.Framework.Graphics" Version="3.12.9001" />
-	  <PackageReference Include="nkast.Xna.Framework.Input" Version="3.12.9001" />
-	  <PackageReference Include="nkast.Xna.Framework.Game" Version="3.12.9001" />
-	  <PackageReference Include="nkast.Xna.Framework.Audio" Version="3.12.9001" />
-	  <PackageReference Include="nkast.Xna.Framework.Media" Version="3.12.9001" />
+    <PackageReference Include="nkast.Xna.Framework" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Content" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Graphics" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Audio" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Media" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Input" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Game" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Devices" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Storage" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework.XR" Version="4.1.9001" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Samples/GumFormsSample/KniGumFormsSample.Android/KniGumFormsSample.Android.csproj
+++ b/Samples/GumFormsSample/KniGumFormsSample.Android/KniGumFormsSample.Android.csproj
@@ -26,15 +26,18 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="nkast.Xna.Framework" Version="3.12.9001.*" />
-		<PackageReference Include="nkast.Xna.Framework.Content" Version="3.12.9001.*" />
-		<PackageReference Include="nkast.Xna.Framework.Graphics" Version="3.12.9001.*" />
-		<PackageReference Include="nkast.Xna.Framework.Audio" Version="3.12.9001.*" />
-		<PackageReference Include="nkast.Xna.Framework.Media" Version="3.12.9001.*" />
-		<PackageReference Include="nkast.Xna.Framework.Input" Version="3.12.9001.*" />
-		<PackageReference Include="nkast.Xna.Framework.Game" Version="3.12.9001.*" />
-		<PackageReference Include="MonoGame.Framework.Android.9000" Version="3.12.9001.*" />
-		<PackageReference Include="nkast.Xna.Framework.Content.Pipeline.Builder" Version="3.12.9001.*" />
+		<PackageReference Include="nkast.Xna.Framework" Version="4.1.9001" />
+		<PackageReference Include="nkast.Xna.Framework.Content" Version="4.1.9001" />
+		<PackageReference Include="nkast.Xna.Framework.Graphics" Version="4.1.9001" />
+		<PackageReference Include="nkast.Xna.Framework.Audio" Version="4.1.9001" />
+		<PackageReference Include="nkast.Xna.Framework.Media" Version="4.1.9001" />
+		<PackageReference Include="nkast.Xna.Framework.Input" Version="4.1.9001" />
+		<PackageReference Include="nkast.Xna.Framework.Game" Version="4.1.9001" />
+		<PackageReference Include="nkast.Xna.Framework.Devices" Version="4.1.9001" />
+		<PackageReference Include="nkast.Xna.Framework.Storage" Version="4.1.9001" />
+		<PackageReference Include="nkast.Xna.Framework.XR" Version="4.1.9001" />
+		<PackageReference Include="nkast.Kni.Platform.Android.GL" Version="4.1.9001" />
+		<PackageReference Include="nkast.Xna.Framework.Content.Pipeline.Builder" Version="4.1.9001" />
 	</ItemGroup>
 	<ItemGroup>
 		<Compile Include="GumFormsSampleActivity.cs" />

--- a/Samples/GumFormsSample/KniGumFormsSample.BlazorGL/KniGumFormsSample.BlazorGL.csproj
+++ b/Samples/GumFormsSample/KniGumFormsSample.BlazorGL/KniGumFormsSample.BlazorGL.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
+﻿<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
 
   <PropertyGroup>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
@@ -9,7 +9,7 @@
     <RootNamespace>GumFormsSample</RootNamespace>
     <AssemblyName>GumFormsSample</AssemblyName>
     <DefineConstants>$(DefineConstants);BLAZORGL</DefineConstants>
-	<KniPlatform>BlazorGL</KniPlatform>
+    <KniPlatform>BlazorGL</KniPlatform>
   </PropertyGroup>
   
   <PropertyGroup>
@@ -28,29 +28,28 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="nkast.Xna.Framework" Version="3.12.9001.*" />
-    <PackageReference Include="nkast.Xna.Framework.Content" Version="3.12.9001.*" />
-    <PackageReference Include="nkast.Xna.Framework.Graphics" Version="3.12.9001.*" />
-    <PackageReference Include="nkast.Xna.Framework.Audio" Version="3.12.9001.*" />
-    <PackageReference Include="nkast.Xna.Framework.Media" Version="3.12.9001.*" />
-    <PackageReference Include="nkast.Xna.Framework.Input" Version="3.12.9001.*" />
-    <PackageReference Include="nkast.Xna.Framework.Game" Version="3.12.9001.*" />
-    <PackageReference Include="nkast.Xna.Framework.Blazor" Version="3.12.9001.*" />
-    <PackageReference Include="nkast.Xna.Framework.Content.Pipeline.Builder" Version="3.12.9001.*" />
+    <PackageReference Include="nkast.Xna.Framework" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Content" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Graphics" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Audio" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Media" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Input" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Game" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Devices" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Storage" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework.XR" Version="4.1.9001" />
+    <PackageReference Include="nkast.Kni.Platform.Blazor.GL" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Content.Pipeline.Builder" Version="4.1.9001" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="6.0.27" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="6.0.27" PrivateAssets="all" />
-  </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.2" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.11" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.11" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>
-    <KniContentReference Include="..\GumFormsSampleContent\GumFormsSampleContent.mgcb">   
-      <Link>Content\GumFormsSampleContent.mgcb</Link>
+    <KniContentReference Include="..\MonoGameGumFormsSample\Content\KNIContent.mgcb">
+      <Link>Content\KNIGumFormsSampleContent.mgcb</Link>
     </KniContentReference>
   </ItemGroup>
 

--- a/Samples/GumFormsSample/KniGumFormsSample.BlazorGL/wwwroot/Content/.gitignore
+++ b/Samples/GumFormsSample/KniGumFormsSample.BlazorGL/wwwroot/Content/.gitignore
@@ -1,4 +1,12 @@
 *.xnb
 
+*.gumx
+*.gusx
+*.gucx
+*.gutx
+*.behx
+*.bmfc
+*.codsj
+*.ganx
 *.png
 *.fnt

--- a/Samples/GumFormsSample/KniGumFormsSample.BlazorGL/wwwroot/index.html
+++ b/Samples/GumFormsSample/KniGumFormsSample.BlazorGL/wwwroot/index.html
@@ -30,6 +30,7 @@
     <script src="_framework/blazor.webassembly.js" autostart="false"></script>
     <script type="module">
         import { BrotliDecode } from './js/decode.min.js';
+        window.BrotliDecode = BrotliDecode;
         // Set this to enable Brotli (.br) decompression on static webServers
         // that don't support content compression and http://.
         var enableBrotliDecompression = false;
@@ -58,14 +59,17 @@
         });
     </script>
 
-    <script src="_content/nkast.Wasm.Dom/js/JSObject.8.0.0.js"></script>
-    <script src="_content/nkast.Wasm.Dom/js/Window.8.0.0.js"></script>
-    <script src="_content/nkast.Wasm.Dom/js/Document.8.0.0.js"></script>
-    <script src="_content/nkast.Wasm.Dom/js/Media.8.0.0.js"></script>
-    <script src="_content/nkast.Wasm.XHR/js/XHR.8.0.0.js"></script>
-    <script src="_content/nkast.Wasm.Canvas/js/Canvas.8.0.0.js"></script>
-    <script src="_content/nkast.Wasm.Canvas/js/CanvasGLContext.8.0.0.js"></script>
-    <script src="_content/nkast.Wasm.Audio/js/Audio.8.0.0.js"></script>
+    <script src="_content/nkast.Wasm.Dom/js/JSObject.8.0.5.js"></script>
+    <script src="_content/nkast.Wasm.Dom/js/Window.8.0.5.js"></script>
+    <script src="_content/nkast.Wasm.Dom/js/Document.8.0.5.js"></script>
+    <script src="_content/nkast.Wasm.Dom/js/Navigator.8.0.5.js"></script>
+    <script src="_content/nkast.Wasm.Dom/js/Gamepad.8.0.5.js"></script>
+    <script src="_content/nkast.Wasm.Dom/js/Media.8.0.5.js"></script>
+    <script src="_content/nkast.Wasm.XHR/js/XHR.8.0.5.js"></script>
+    <script src="_content/nkast.Wasm.Canvas/js/Canvas.8.0.5.js"></script>
+    <script src="_content/nkast.Wasm.Canvas/js/CanvasGLContext.8.0.5.js"></script>
+    <script src="_content/nkast.Wasm.Audio/js/Audio.8.0.5.js"></script>
+    <script src="_content/nkast.Wasm.XR/js/XR.8.0.5.js"></script>
 
     <script>
         function tickJS()
@@ -102,7 +106,7 @@
             // Prevent Mousewheel scrolling the outer page
             // when running inside an iframe. e.g: itch.io embedding.
             event.preventDefault();
-        };
+        }, { passive: false };
     </script>
 </body>
 

--- a/Samples/GumFormsSample/KniGumFormsSample.DesktopGL/KniGumFormsSample.DesktopGL.csproj
+++ b/Samples/GumFormsSample/KniGumFormsSample.DesktopGL/KniGumFormsSample.DesktopGL.csproj
@@ -29,15 +29,18 @@
 		<ApplicationManifest>app.manifest</ApplicationManifest>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="nkast.Xna.Framework" Version="3.12.9001.*" />
-		<PackageReference Include="nkast.Xna.Framework.Content" Version="3.12.9001.*" />
-		<PackageReference Include="nkast.Xna.Framework.Graphics" Version="3.12.9001.*" />
-		<PackageReference Include="nkast.Xna.Framework.Audio" Version="3.12.9001.*" />
-		<PackageReference Include="nkast.Xna.Framework.Media" Version="3.12.9001.*" />
-		<PackageReference Include="nkast.Xna.Framework.Input" Version="3.12.9001.*" />
-		<PackageReference Include="nkast.Xna.Framework.Game" Version="3.12.9001.*" />
-		<PackageReference Include="MonoGame.Framework.DesktopGL.9000" Version="3.12.9001.*" />
-		<PackageReference Include="nkast.Xna.Framework.Content.Pipeline.Builder" Version="3.12.9001.*" />
+		<PackageReference Include="nkast.Xna.Framework" Version="4.1.9001" />
+		<PackageReference Include="nkast.Xna.Framework.Content" Version="4.1.9001" />
+		<PackageReference Include="nkast.Xna.Framework.Graphics" Version="4.1.9001" />
+		<PackageReference Include="nkast.Xna.Framework.Audio" Version="4.1.9001" />
+		<PackageReference Include="nkast.Xna.Framework.Media" Version="4.1.9001" />
+		<PackageReference Include="nkast.Xna.Framework.Input" Version="4.1.9001" />
+		<PackageReference Include="nkast.Xna.Framework.Game" Version="4.1.9001" />
+		<PackageReference Include="nkast.Xna.Framework.Devices" Version="4.1.9001" />
+		<PackageReference Include="nkast.Xna.Framework.Storage" Version="4.1.9001" />
+		<PackageReference Include="nkast.Xna.Framework.XR" Version="4.1.9001" />
+		<PackageReference Include="nkast.Kni.Platform.SDL2.GL" Version="4.1.9001" />
+		<PackageReference Include="nkast.Xna.Framework.Content.Pipeline.Builder" Version="4.1.9001" />
 	</ItemGroup>
 	<ItemGroup>
 		<Compile Include="Program.cs" />

--- a/Samples/GumFormsSample/KniGumFormsSample.WindowsDX/KniGumFormsSample.WindowsDX.csproj
+++ b/Samples/GumFormsSample/KniGumFormsSample.WindowsDX/KniGumFormsSample.WindowsDX.csproj
@@ -28,15 +28,18 @@
 		<ApplicationManifest>app.manifest</ApplicationManifest>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="nkast.Xna.Framework" Version="3.12.9001.*" />
-		<PackageReference Include="nkast.Xna.Framework.Content" Version="3.12.9001.*" />
-		<PackageReference Include="nkast.Xna.Framework.Graphics" Version="3.12.9001.*" />
-		<PackageReference Include="nkast.Xna.Framework.Audio" Version="3.12.9001.*" />
-		<PackageReference Include="nkast.Xna.Framework.Media" Version="3.12.9001.*" />
-		<PackageReference Include="nkast.Xna.Framework.Input" Version="3.12.9001.*" />
-		<PackageReference Include="nkast.Xna.Framework.Game" Version="3.12.9001.*" />
-		<PackageReference Include="MonoGame.Framework.WindowsDX.9000" Version="3.12.9001.*" />
-		<PackageReference Include="nkast.Xna.Framework.Content.Pipeline.Builder" Version="3.12.9001.*" />
+		<PackageReference Include="nkast.Xna.Framework" Version="4.1.9001" />
+		<PackageReference Include="nkast.Xna.Framework.Content" Version="4.1.9001" />
+		<PackageReference Include="nkast.Xna.Framework.Graphics" Version="4.1.9001" />
+		<PackageReference Include="nkast.Xna.Framework.Audio" Version="4.1.9001" />
+		<PackageReference Include="nkast.Xna.Framework.Media" Version="4.1.9001" />
+		<PackageReference Include="nkast.Xna.Framework.Input" Version="4.1.9001" />
+		<PackageReference Include="nkast.Xna.Framework.Game" Version="4.1.9001" />
+		<PackageReference Include="nkast.Xna.Framework.Devices" Version="4.1.9001" />
+		<PackageReference Include="nkast.Xna.Framework.Storage" Version="4.1.9001" />
+		<PackageReference Include="nkast.Xna.Framework.XR" Version="4.1.9001" />
+		<PackageReference Include="nkast.Kni.Platform.WinForms.DX11" Version="4.1.9001" />
+		<PackageReference Include="nkast.Xna.Framework.Content.Pipeline.Builder" Version="4.1.9001" />
 	</ItemGroup>
 	<ItemGroup>
 		<Compile Include="Program.cs" />
@@ -52,7 +55,7 @@
 			<Link>Content\FormsGumProject\%(RecursiveDir)%(Filename)%(Extension)</Link>
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 		</Content>
-	</ItemGroup>	
+	</ItemGroup>
 	
 	<ItemGroup>
 		<KniContentReference Include="..\GumFormsSampleContent\GumFormsSampleContent.mgcb">

--- a/Samples/GumFormsSample/MonoGameGumFormsSample/Content/KNIContent.mgcb
+++ b/Samples/GumFormsSample/MonoGameGumFormsSample/Content/KNIContent.mgcb
@@ -1,0 +1,681 @@
+
+#----------------------------- Global Properties ----------------------------#
+
+/outputDir:bin/$(Platform)
+/intermediateDir:obj/$(Platform)
+/platform:DesktopGL
+/config:
+/profile:Reach
+/compress:False
+
+#-------------------------------- References --------------------------------#
+
+
+#---------------------------------- Content ---------------------------------#
+
+#begin button_square_gradient.png
+/copy:button_square_gradient.png
+
+#begin FormsGumProject/Behaviors/ButtonBehavior.behx
+/copy:FormsGumProject/Behaviors/ButtonBehavior.behx
+
+#begin FormsGumProject/Behaviors/CheckBoxBehavior.behx
+/copy:FormsGumProject/Behaviors/CheckBoxBehavior.behx
+
+#begin FormsGumProject/Behaviors/ComboBoxBehavior.behx
+/copy:FormsGumProject/Behaviors/ComboBoxBehavior.behx
+
+#begin FormsGumProject/Behaviors/DialogBoxBehavior.behx
+/copy:FormsGumProject/Behaviors/DialogBoxBehavior.behx
+
+#begin FormsGumProject/Behaviors/InputDeviceSelectionItemBehavior.behx
+/copy:FormsGumProject/Behaviors/InputDeviceSelectionItemBehavior.behx
+
+#begin FormsGumProject/Behaviors/InputDeviceSelectorBehavior.behx
+/copy:FormsGumProject/Behaviors/InputDeviceSelectorBehavior.behx
+
+#begin FormsGumProject/Behaviors/LabelBehavior.behx
+/copy:FormsGumProject/Behaviors/LabelBehavior.behx
+
+#begin FormsGumProject/Behaviors/ListBoxBehavior.behx
+/copy:FormsGumProject/Behaviors/ListBoxBehavior.behx
+
+#begin FormsGumProject/Behaviors/ListBoxItemBehavior.behx
+/copy:FormsGumProject/Behaviors/ListBoxItemBehavior.behx
+
+#begin FormsGumProject/Behaviors/MenuBehavior.behx
+/copy:FormsGumProject/Behaviors/MenuBehavior.behx
+
+#begin FormsGumProject/Behaviors/MenuItemBehavior.behx
+/copy:FormsGumProject/Behaviors/MenuItemBehavior.behx
+
+#begin FormsGumProject/Behaviors/OnScreenKeyboardBehavior.behx
+/copy:FormsGumProject/Behaviors/OnScreenKeyboardBehavior.behx
+
+#begin FormsGumProject/Behaviors/PasswordBoxBehavior.behx
+/copy:FormsGumProject/Behaviors/PasswordBoxBehavior.behx
+
+#begin FormsGumProject/Behaviors/PlayerJoinViewBehavior.behx
+/copy:FormsGumProject/Behaviors/PlayerJoinViewBehavior.behx
+
+#begin FormsGumProject/Behaviors/PlayerJoinViewItemBehavior.behx
+/copy:FormsGumProject/Behaviors/PlayerJoinViewItemBehavior.behx
+
+#begin FormsGumProject/Behaviors/RadioButtonBehavior.behx
+/copy:FormsGumProject/Behaviors/RadioButtonBehavior.behx
+
+#begin FormsGumProject/Behaviors/ScrollBarBehavior.behx
+/copy:FormsGumProject/Behaviors/ScrollBarBehavior.behx
+
+#begin FormsGumProject/Behaviors/ScrollViewerBehavior.behx
+/copy:FormsGumProject/Behaviors/ScrollViewerBehavior.behx
+
+#begin FormsGumProject/Behaviors/SettingsViewBehavior.behx
+/copy:FormsGumProject/Behaviors/SettingsViewBehavior.behx
+
+#begin FormsGumProject/Behaviors/SliderBehavior.behx
+/copy:FormsGumProject/Behaviors/SliderBehavior.behx
+
+#begin FormsGumProject/Behaviors/TextBoxBehavior.behx
+/copy:FormsGumProject/Behaviors/TextBoxBehavior.behx
+
+#begin FormsGumProject/Behaviors/ToastBehavior.behx
+/copy:FormsGumProject/Behaviors/ToastBehavior.behx
+
+#begin FormsGumProject/Behaviors/ToggleBehavior.behx
+/copy:FormsGumProject/Behaviors/ToggleBehavior.behx
+
+#begin FormsGumProject/Behaviors/TreeViewBehavior.behx
+/copy:FormsGumProject/Behaviors/TreeViewBehavior.behx
+
+#begin FormsGumProject/Behaviors/TreeViewItemBehavior.behx
+/copy:FormsGumProject/Behaviors/TreeViewItemBehavior.behx
+
+#begin FormsGumProject/Behaviors/UserControlBehavior.behx
+/copy:FormsGumProject/Behaviors/UserControlBehavior.behx
+
+#begin FormsGumProject/Components/Controls/ButtonClose.gucx
+/copy:FormsGumProject/Components/Controls/ButtonClose.gucx
+
+#begin FormsGumProject/Components/Controls/ButtonConfirm.gucx
+/copy:FormsGumProject/Components/Controls/ButtonConfirm.gucx
+
+#begin FormsGumProject/Components/Controls/ButtonDeny.gucx
+/copy:FormsGumProject/Components/Controls/ButtonDeny.gucx
+
+#begin FormsGumProject/Components/Controls/ButtonIcon.gucx
+/copy:FormsGumProject/Components/Controls/ButtonIcon.gucx
+
+#begin FormsGumProject/Components/Controls/ButtonStandard.codsj
+/copy:FormsGumProject/Components/Controls/ButtonStandard.codsj
+
+#begin FormsGumProject/Components/Controls/ButtonStandard.gucx
+/copy:FormsGumProject/Components/Controls/ButtonStandard.gucx
+
+#begin FormsGumProject/Components/Controls/ButtonStandardIcon.gucx
+/copy:FormsGumProject/Components/Controls/ButtonStandardIcon.gucx
+
+#begin FormsGumProject/Components/Controls/ButtonTab.gucx
+/copy:FormsGumProject/Components/Controls/ButtonTab.gucx
+
+#begin FormsGumProject/Components/Controls/CheckBox.codsj
+/copy:FormsGumProject/Components/Controls/CheckBox.codsj
+
+#begin FormsGumProject/Components/Controls/CheckBox.gucx
+/copy:FormsGumProject/Components/Controls/CheckBox.gucx
+
+#begin FormsGumProject/Components/Controls/ComboBox.gucx
+/copy:FormsGumProject/Components/Controls/ComboBox.gucx
+
+#begin FormsGumProject/Components/Controls/DialogBox.gucx
+/copy:FormsGumProject/Components/Controls/DialogBox.gucx
+
+#begin FormsGumProject/Components/Controls/FancyListBoxItem.gucx
+/copy:FormsGumProject/Components/Controls/FancyListBoxItem.gucx
+
+#begin FormsGumProject/Components/Controls/FancyListBoxItemAnimations.ganx
+/copy:FormsGumProject/Components/Controls/FancyListBoxItemAnimations.ganx
+
+#begin FormsGumProject/Components/Controls/InputDeviceSelectionItem.gucx
+/copy:FormsGumProject/Components/Controls/InputDeviceSelectionItem.gucx
+
+#begin FormsGumProject/Components/Controls/InputDeviceSelector.gucx
+/copy:FormsGumProject/Components/Controls/InputDeviceSelector.gucx
+
+#begin FormsGumProject/Components/Controls/Keyboard.gucx
+/copy:FormsGumProject/Components/Controls/Keyboard.gucx
+
+#begin FormsGumProject/Components/Controls/KeyboardAnimations.ganx
+/copy:FormsGumProject/Components/Controls/KeyboardAnimations.ganx
+
+#begin FormsGumProject/Components/Controls/KeyboardKey.gucx
+/copy:FormsGumProject/Components/Controls/KeyboardKey.gucx
+
+#begin FormsGumProject/Components/Controls/KeyboardKeyAnimations.ganx
+/copy:FormsGumProject/Components/Controls/KeyboardKeyAnimations.ganx
+
+#begin FormsGumProject/Components/Controls/ListBox.gucx
+/copy:FormsGumProject/Components/Controls/ListBox.gucx
+
+#begin FormsGumProject/Components/Controls/ListBoxItem.codsj
+/copy:FormsGumProject/Components/Controls/ListBoxItem.codsj
+
+#begin FormsGumProject/Components/Controls/ListBoxItem.gucx
+/copy:FormsGumProject/Components/Controls/ListBoxItem.gucx
+
+#begin FormsGumProject/Components/Controls/Menu.gucx
+/copy:FormsGumProject/Components/Controls/Menu.gucx
+
+#begin FormsGumProject/Components/Controls/MenuItem.gucx
+/copy:FormsGumProject/Components/Controls/MenuItem.gucx
+
+#begin FormsGumProject/Components/Controls/MessageBox.gucx
+/copy:FormsGumProject/Components/Controls/MessageBox.gucx
+
+#begin FormsGumProject/Components/Controls/PasswordBox.gucx
+/copy:FormsGumProject/Components/Controls/PasswordBox.gucx
+
+#begin FormsGumProject/Components/Controls/PlayerJoinView.gucx
+/copy:FormsGumProject/Components/Controls/PlayerJoinView.gucx
+
+#begin FormsGumProject/Components/Controls/PlayerJoinViewItem.gucx
+/copy:FormsGumProject/Components/Controls/PlayerJoinViewItem.gucx
+
+#begin FormsGumProject/Components/Controls/RadioButton.gucx
+/copy:FormsGumProject/Components/Controls/RadioButton.gucx
+
+#begin FormsGumProject/Components/Controls/ScrollBar.gucx
+/copy:FormsGumProject/Components/Controls/ScrollBar.gucx
+
+#begin FormsGumProject/Components/Controls/ScrollViewer.gucx
+/copy:FormsGumProject/Components/Controls/ScrollViewer.gucx
+
+#begin FormsGumProject/Components/Controls/SettingsView.gucx
+/copy:FormsGumProject/Components/Controls/SettingsView.gucx
+
+#begin FormsGumProject/Components/Controls/Slider.gucx
+/copy:FormsGumProject/Components/Controls/Slider.gucx
+
+#begin FormsGumProject/Components/Controls/TextBox.gucx
+/copy:FormsGumProject/Components/Controls/TextBox.gucx
+
+#begin FormsGumProject/Components/Controls/TextBoxAnimations.ganx
+/copy:FormsGumProject/Components/Controls/TextBoxAnimations.ganx
+
+#begin FormsGumProject/Components/Controls/Toast.gucx
+/copy:FormsGumProject/Components/Controls/Toast.gucx
+
+#begin FormsGumProject/Components/Controls/TreeView.gucx
+/copy:FormsGumProject/Components/Controls/TreeView.gucx
+
+#begin FormsGumProject/Components/Controls/TreeViewItem.gucx
+/copy:FormsGumProject/Components/Controls/TreeViewItem.gucx
+
+#begin FormsGumProject/Components/Controls/TreeViewToggle.gucx
+/copy:FormsGumProject/Components/Controls/TreeViewToggle.gucx
+
+#begin FormsGumProject/Components/Controls/TreeViewToggleAnimations.ganx
+/copy:FormsGumProject/Components/Controls/TreeViewToggleAnimations.ganx
+
+#begin FormsGumProject/Components/Controls/UserControl.gucx
+/copy:FormsGumProject/Components/Controls/UserControl.gucx
+
+#begin FormsGumProject/Components/Controls/WeaponListBoxItem.codsj
+/copy:FormsGumProject/Components/Controls/WeaponListBoxItem.codsj
+
+#begin FormsGumProject/Components/Controls/WeaponListBoxItem.gucx
+/copy:FormsGumProject/Components/Controls/WeaponListBoxItem.gucx
+
+#begin FormsGumProject/Components/Controls/WeaponListBoxItemAnimations.ganx
+/copy:FormsGumProject/Components/Controls/WeaponListBoxItemAnimations.ganx
+
+#begin FormsGumProject/Components/Elements/CautionLines.gucx
+/copy:FormsGumProject/Components/Elements/CautionLines.gucx
+
+#begin FormsGumProject/Components/Elements/Divider.gucx
+/copy:FormsGumProject/Components/Elements/Divider.gucx
+
+#begin FormsGumProject/Components/Elements/DividerHorizontal.gucx
+/copy:FormsGumProject/Components/Elements/DividerHorizontal.gucx
+
+#begin FormsGumProject/Components/Elements/DividerHorizontalAnimations.ganx
+/copy:FormsGumProject/Components/Elements/DividerHorizontalAnimations.ganx
+
+#begin FormsGumProject/Components/Elements/DividerVertical.gucx
+/copy:FormsGumProject/Components/Elements/DividerVertical.gucx
+
+#begin FormsGumProject/Components/Elements/DividerVerticalAnimations.ganx
+/copy:FormsGumProject/Components/Elements/DividerVerticalAnimations.ganx
+
+#begin FormsGumProject/Components/Elements/Icon.gucx
+/copy:FormsGumProject/Components/Elements/Icon.gucx
+
+#begin FormsGumProject/Components/Elements/IconAnimations.ganx
+/copy:FormsGumProject/Components/Elements/IconAnimations.ganx
+
+#begin FormsGumProject/Components/Elements/Label.gucx
+/copy:FormsGumProject/Components/Elements/Label.gucx
+
+#begin FormsGumProject/Components/Elements/PercentBar.gucx
+/copy:FormsGumProject/Components/Elements/PercentBar.gucx
+
+#begin FormsGumProject/Components/Elements/PercentBarIcon.gucx
+/copy:FormsGumProject/Components/Elements/PercentBarIcon.gucx
+
+#begin FormsGumProject/Components/Elements/VerticalLines.gucx
+/copy:FormsGumProject/Components/Elements/VerticalLines.gucx
+
+#begin FormsGumProject/FontCache/Font10Arial.bmfc
+/copy:FormsGumProject/FontCache/Font10Arial.bmfc
+
+#begin FormsGumProject/FontCache/Font10Arial.fnt
+/copy:FormsGumProject/FontCache/Font10Arial.fnt
+
+#begin FormsGumProject/FontCache/Font10Arial_0.png
+/copy:FormsGumProject/FontCache/Font10Arial_0.png
+
+#begin FormsGumProject/FontCache/Font10Titillium_Web.bmfc
+/copy:FormsGumProject/FontCache/Font10Titillium_Web.bmfc
+
+#begin FormsGumProject/FontCache/Font10Titillium_Web.fnt
+/copy:FormsGumProject/FontCache/Font10Titillium_Web.fnt
+
+#begin FormsGumProject/FontCache/Font10Titillium_Web_0.png
+/copy:FormsGumProject/FontCache/Font10Titillium_Web_0.png
+
+#begin FormsGumProject/FontCache/Font12Arial.bmfc
+/copy:FormsGumProject/FontCache/Font12Arial.bmfc
+
+#begin FormsGumProject/FontCache/Font12Arial.fnt
+/copy:FormsGumProject/FontCache/Font12Arial.fnt
+
+#begin FormsGumProject/FontCache/Font12Arial_0.png
+/copy:FormsGumProject/FontCache/Font12Arial_0.png
+
+#begin FormsGumProject/FontCache/Font12Titillium_Web.bmfc
+/copy:FormsGumProject/FontCache/Font12Titillium_Web.bmfc
+
+#begin FormsGumProject/FontCache/Font12Titillium_Web.fnt
+/copy:FormsGumProject/FontCache/Font12Titillium_Web.fnt
+
+#begin FormsGumProject/FontCache/Font12Titillium_Web_0.png
+/copy:FormsGumProject/FontCache/Font12Titillium_Web_0.png
+
+#begin FormsGumProject/FontCache/Font12Titillium_Web_Bold.bmfc
+/copy:FormsGumProject/FontCache/Font12Titillium_Web_Bold.bmfc
+
+#begin FormsGumProject/FontCache/Font12Titillium_Web_Bold.fnt
+/copy:FormsGumProject/FontCache/Font12Titillium_Web_Bold.fnt
+
+#begin FormsGumProject/FontCache/Font12Titillium_Web_Bold_0.png
+/copy:FormsGumProject/FontCache/Font12Titillium_Web_Bold_0.png
+
+#begin FormsGumProject/FontCache/Font12Titillium_Web_Italic.bmfc
+/copy:FormsGumProject/FontCache/Font12Titillium_Web_Italic.bmfc
+
+#begin FormsGumProject/FontCache/Font12Titillium_Web_Italic.fnt
+/copy:FormsGumProject/FontCache/Font12Titillium_Web_Italic.fnt
+
+#begin FormsGumProject/FontCache/Font12Titillium_Web_Italic_0.png
+/copy:FormsGumProject/FontCache/Font12Titillium_Web_Italic_0.png
+
+#begin FormsGumProject/FontCache/Font12Titillium_Web_noSmooth.bmfc
+/copy:FormsGumProject/FontCache/Font12Titillium_Web_noSmooth.bmfc
+
+#begin FormsGumProject/FontCache/Font12Titillium_Web_noSmooth.fnt
+/copy:FormsGumProject/FontCache/Font12Titillium_Web_noSmooth.fnt
+
+#begin FormsGumProject/FontCache/Font12Titillium_Web_noSmooth_0.png
+/copy:FormsGumProject/FontCache/Font12Titillium_Web_noSmooth_0.png
+
+#begin FormsGumProject/FontCache/Font12Wasco_Sans.bmfc
+/copy:FormsGumProject/FontCache/Font12Wasco_Sans.bmfc
+
+#begin FormsGumProject/FontCache/Font12Wasco_Sans.fnt
+/copy:FormsGumProject/FontCache/Font12Wasco_Sans.fnt
+
+#begin FormsGumProject/FontCache/Font12Wasco_Sans_0.png
+/copy:FormsGumProject/FontCache/Font12Wasco_Sans_0.png
+
+#begin FormsGumProject/FontCache/Font14Arial.bmfc
+/copy:FormsGumProject/FontCache/Font14Arial.bmfc
+
+#begin FormsGumProject/FontCache/Font14Arial.fnt
+/copy:FormsGumProject/FontCache/Font14Arial.fnt
+
+#begin FormsGumProject/FontCache/Font14Arial_0.png
+/copy:FormsGumProject/FontCache/Font14Arial_0.png
+
+#begin FormsGumProject/FontCache/Font14Arial_Bold.bmfc
+/copy:FormsGumProject/FontCache/Font14Arial_Bold.bmfc
+
+#begin FormsGumProject/FontCache/Font14Arial_Bold.fnt
+/copy:FormsGumProject/FontCache/Font14Arial_Bold.fnt
+
+#begin FormsGumProject/FontCache/Font14Arial_Bold_0.png
+/copy:FormsGumProject/FontCache/Font14Arial_Bold_0.png
+
+#begin FormsGumProject/FontCache/Font14Arial_Italic.bmfc
+/copy:FormsGumProject/FontCache/Font14Arial_Italic.bmfc
+
+#begin FormsGumProject/FontCache/Font14Arial_Italic.fnt
+/copy:FormsGumProject/FontCache/Font14Arial_Italic.fnt
+
+#begin FormsGumProject/FontCache/Font14Arial_Italic_0.png
+/copy:FormsGumProject/FontCache/Font14Arial_Italic_0.png
+
+#begin FormsGumProject/FontCache/Font14Bahnschrift.bmfc
+/copy:FormsGumProject/FontCache/Font14Bahnschrift.bmfc
+
+#begin FormsGumProject/FontCache/Font14Bahnschrift.fnt
+/copy:FormsGumProject/FontCache/Font14Bahnschrift.fnt
+
+#begin FormsGumProject/FontCache/Font14Bahnschrift_0.png
+/copy:FormsGumProject/FontCache/Font14Bahnschrift_0.png
+
+#begin FormsGumProject/FontCache/Font14Elephant.bmfc
+/copy:FormsGumProject/FontCache/Font14Elephant.bmfc
+
+#begin FormsGumProject/FontCache/Font14Elephant.fnt
+/copy:FormsGumProject/FontCache/Font14Elephant.fnt
+
+#begin FormsGumProject/FontCache/Font14Elephant_0.png
+/copy:FormsGumProject/FontCache/Font14Elephant_0.png
+
+#begin FormsGumProject/FontCache/Font14Titillium_Web.bmfc
+/copy:FormsGumProject/FontCache/Font14Titillium_Web.bmfc
+
+#begin FormsGumProject/FontCache/Font14Titillium_Web.fnt
+/copy:FormsGumProject/FontCache/Font14Titillium_Web.fnt
+
+#begin FormsGumProject/FontCache/Font14Titillium_Web_0.png
+/copy:FormsGumProject/FontCache/Font14Titillium_Web_0.png
+
+#begin FormsGumProject/FontCache/Font14Titillium_Web_Bold.bmfc
+/copy:FormsGumProject/FontCache/Font14Titillium_Web_Bold.bmfc
+
+#begin FormsGumProject/FontCache/Font14Titillium_Web_Bold.fnt
+/copy:FormsGumProject/FontCache/Font14Titillium_Web_Bold.fnt
+
+#begin FormsGumProject/FontCache/Font14Titillium_Web_Bold_0.png
+/copy:FormsGumProject/FontCache/Font14Titillium_Web_Bold_0.png
+
+#begin FormsGumProject/FontCache/Font14Titillium_Web_Italic.bmfc
+/copy:FormsGumProject/FontCache/Font14Titillium_Web_Italic.bmfc
+
+#begin FormsGumProject/FontCache/Font14Titillium_Web_Italic.fnt
+/copy:FormsGumProject/FontCache/Font14Titillium_Web_Italic.fnt
+
+#begin FormsGumProject/FontCache/Font14Titillium_Web_Italic_0.png
+/copy:FormsGumProject/FontCache/Font14Titillium_Web_Italic_0.png
+
+#begin FormsGumProject/FontCache/Font14Titillium_Web_noSmooth.bmfc
+/copy:FormsGumProject/FontCache/Font14Titillium_Web_noSmooth.bmfc
+
+#begin FormsGumProject/FontCache/Font14Titillium_Web_noSmooth.fnt
+/copy:FormsGumProject/FontCache/Font14Titillium_Web_noSmooth.fnt
+
+#begin FormsGumProject/FontCache/Font14Titillium_Web_noSmooth_0.png
+/copy:FormsGumProject/FontCache/Font14Titillium_Web_noSmooth_0.png
+
+#begin FormsGumProject/FontCache/Font14Wasco_Sans.bmfc
+/copy:FormsGumProject/FontCache/Font14Wasco_Sans.bmfc
+
+#begin FormsGumProject/FontCache/Font14Wasco_Sans.fnt
+/copy:FormsGumProject/FontCache/Font14Wasco_Sans.fnt
+
+#begin FormsGumProject/FontCache/Font14Wasco_Sans_0.png
+/copy:FormsGumProject/FontCache/Font14Wasco_Sans_0.png
+
+#begin FormsGumProject/FontCache/Font14Wasco_Sans_noSmooth.bmfc
+/copy:FormsGumProject/FontCache/Font14Wasco_Sans_noSmooth.bmfc
+
+#begin FormsGumProject/FontCache/Font14Wasco_Sans_noSmooth.fnt
+/copy:FormsGumProject/FontCache/Font14Wasco_Sans_noSmooth.fnt
+
+#begin FormsGumProject/FontCache/Font14Wasco_Sans_noSmooth_0.png
+/copy:FormsGumProject/FontCache/Font14Wasco_Sans_noSmooth_0.png
+
+#begin FormsGumProject/FontCache/Font16Arial_Bold.bmfc
+/copy:FormsGumProject/FontCache/Font16Arial_Bold.bmfc
+
+#begin FormsGumProject/FontCache/Font16Arial_Bold.fnt
+/copy:FormsGumProject/FontCache/Font16Arial_Bold.fnt
+
+#begin FormsGumProject/FontCache/Font16Arial_Bold_0.png
+/copy:FormsGumProject/FontCache/Font16Arial_Bold_0.png
+
+#begin FormsGumProject/FontCache/Font16Titillium_Web.bmfc
+/copy:FormsGumProject/FontCache/Font16Titillium_Web.bmfc
+
+#begin FormsGumProject/FontCache/Font16Titillium_Web.fnt
+/copy:FormsGumProject/FontCache/Font16Titillium_Web.fnt
+
+#begin FormsGumProject/FontCache/Font16Titillium_Web_0.png
+/copy:FormsGumProject/FontCache/Font16Titillium_Web_0.png
+
+#begin FormsGumProject/FontCache/Font16Titillium_Web_Bold.bmfc
+/copy:FormsGumProject/FontCache/Font16Titillium_Web_Bold.bmfc
+
+#begin FormsGumProject/FontCache/Font16Titillium_Web_Bold.fnt
+/copy:FormsGumProject/FontCache/Font16Titillium_Web_Bold.fnt
+
+#begin FormsGumProject/FontCache/Font16Titillium_Web_Bold_0.png
+/copy:FormsGumProject/FontCache/Font16Titillium_Web_Bold_0.png
+
+#begin FormsGumProject/FontCache/Font18Arial.fnt
+/copy:FormsGumProject/FontCache/Font18Arial.fnt
+
+#begin FormsGumProject/FontCache/Font18Arial_0.png
+/copy:FormsGumProject/FontCache/Font18Arial_0.png
+
+#begin FormsGumProject/FontCache/Font18Arial_Bold.bmfc
+/copy:FormsGumProject/FontCache/Font18Arial_Bold.bmfc
+
+#begin FormsGumProject/FontCache/Font18Arial_Bold.fnt
+/copy:FormsGumProject/FontCache/Font18Arial_Bold.fnt
+
+#begin FormsGumProject/FontCache/Font18Arial_Bold_0.png
+/copy:FormsGumProject/FontCache/Font18Arial_Bold_0.png
+
+#begin FormsGumProject/FontCache/Font18Elephant.bmfc
+/copy:FormsGumProject/FontCache/Font18Elephant.bmfc
+
+#begin FormsGumProject/FontCache/Font18Elephant.fnt
+/copy:FormsGumProject/FontCache/Font18Elephant.fnt
+
+#begin FormsGumProject/FontCache/Font18Elephant_0.png
+/copy:FormsGumProject/FontCache/Font18Elephant_0.png
+
+#begin FormsGumProject/FontCache/Font18Titillium_Web.bmfc
+/copy:FormsGumProject/FontCache/Font18Titillium_Web.bmfc
+
+#begin FormsGumProject/FontCache/Font18Titillium_Web.fnt
+/copy:FormsGumProject/FontCache/Font18Titillium_Web.fnt
+
+#begin FormsGumProject/FontCache/Font18Titillium_Web_0.png
+/copy:FormsGumProject/FontCache/Font18Titillium_Web_0.png
+
+#begin FormsGumProject/FontCache/Font18Titillium_Web_Bold.bmfc
+/copy:FormsGumProject/FontCache/Font18Titillium_Web_Bold.bmfc
+
+#begin FormsGumProject/FontCache/Font18Titillium_Web_Bold.fnt
+/copy:FormsGumProject/FontCache/Font18Titillium_Web_Bold.fnt
+
+#begin FormsGumProject/FontCache/Font18Titillium_Web_Bold_0.png
+/copy:FormsGumProject/FontCache/Font18Titillium_Web_Bold_0.png
+
+#begin FormsGumProject/FontCache/Font18Wasco_Sans.bmfc
+/copy:FormsGumProject/FontCache/Font18Wasco_Sans.bmfc
+
+#begin FormsGumProject/FontCache/Font18Wasco_Sans.fnt
+/copy:FormsGumProject/FontCache/Font18Wasco_Sans.fnt
+
+#begin FormsGumProject/FontCache/Font18Wasco_Sans_0.png
+/copy:FormsGumProject/FontCache/Font18Wasco_Sans_0.png
+
+#begin FormsGumProject/FontCache/Font22Arial_Bold.bmfc
+/copy:FormsGumProject/FontCache/Font22Arial_Bold.bmfc
+
+#begin FormsGumProject/FontCache/Font22Arial_Bold.fnt
+/copy:FormsGumProject/FontCache/Font22Arial_Bold.fnt
+
+#begin FormsGumProject/FontCache/Font22Arial_Bold_0.png
+/copy:FormsGumProject/FontCache/Font22Arial_Bold_0.png
+
+#begin FormsGumProject/FontCache/Font22Titillium_Web_Bold.bmfc
+/copy:FormsGumProject/FontCache/Font22Titillium_Web_Bold.bmfc
+
+#begin FormsGumProject/FontCache/Font22Titillium_Web_Bold.fnt
+/copy:FormsGumProject/FontCache/Font22Titillium_Web_Bold.fnt
+
+#begin FormsGumProject/FontCache/Font22Titillium_Web_Bold_0.png
+/copy:FormsGumProject/FontCache/Font22Titillium_Web_Bold_0.png
+
+#begin FormsGumProject/FontCache/Font24Arial.bmfc
+/copy:FormsGumProject/FontCache/Font24Arial.bmfc
+
+#begin FormsGumProject/FontCache/Font24Arial.fnt
+/copy:FormsGumProject/FontCache/Font24Arial.fnt
+
+#begin FormsGumProject/FontCache/Font24Arial_0.png
+/copy:FormsGumProject/FontCache/Font24Arial_0.png
+
+#begin FormsGumProject/FontCache/Font24Titillium_Web.bmfc
+/copy:FormsGumProject/FontCache/Font24Titillium_Web.bmfc
+
+#begin FormsGumProject/FontCache/Font24Titillium_Web.fnt
+/copy:FormsGumProject/FontCache/Font24Titillium_Web.fnt
+
+#begin FormsGumProject/FontCache/Font24Titillium_Web_0.png
+/copy:FormsGumProject/FontCache/Font24Titillium_Web_0.png
+
+#begin FormsGumProject/FontCache/Font24Titillium_Web_Bold.bmfc
+/copy:FormsGumProject/FontCache/Font24Titillium_Web_Bold.bmfc
+
+#begin FormsGumProject/FontCache/Font24Titillium_Web_Bold.fnt
+/copy:FormsGumProject/FontCache/Font24Titillium_Web_Bold.fnt
+
+#begin FormsGumProject/FontCache/Font24Titillium_Web_Bold_0.png
+/copy:FormsGumProject/FontCache/Font24Titillium_Web_Bold_0.png
+
+#begin FormsGumProject/FontCache/Font28Arial_Bold.bmfc
+/copy:FormsGumProject/FontCache/Font28Arial_Bold.bmfc
+
+#begin FormsGumProject/FontCache/Font28Arial_Bold.fnt
+/copy:FormsGumProject/FontCache/Font28Arial_Bold.fnt
+
+#begin FormsGumProject/FontCache/Font28Arial_Bold_0.png
+/copy:FormsGumProject/FontCache/Font28Arial_Bold_0.png
+
+#begin FormsGumProject/FontCache/Font28Titillium_Web_Bold.bmfc
+/copy:FormsGumProject/FontCache/Font28Titillium_Web_Bold.bmfc
+
+#begin FormsGumProject/FontCache/Font28Titillium_Web_Bold.fnt
+/copy:FormsGumProject/FontCache/Font28Titillium_Web_Bold.fnt
+
+#begin FormsGumProject/FontCache/Font28Titillium_Web_Bold_0.png
+/copy:FormsGumProject/FontCache/Font28Titillium_Web_Bold_0.png
+
+#begin FormsGumProject/FontCache/Font8Titillium_Web.bmfc
+/copy:FormsGumProject/FontCache/Font8Titillium_Web.bmfc
+
+#begin FormsGumProject/FontCache/Font8Titillium_Web.fnt
+/copy:FormsGumProject/FontCache/Font8Titillium_Web.fnt
+
+#begin FormsGumProject/FontCache/Font8Titillium_Web_0.png
+/copy:FormsGumProject/FontCache/Font8Titillium_Web_0.png
+
+#begin FormsGumProject/Screens/DemoScreen.gusx
+/copy:FormsGumProject/Screens/DemoScreen.gusx
+
+#begin FormsGumProject/Screens/DemoScreenGum.codsj
+/copy:FormsGumProject/Screens/DemoScreenGum.codsj
+
+#begin FormsGumProject/Screens/DemoScreenGum.gusx
+/copy:FormsGumProject/Screens/DemoScreenGum.gusx
+
+#begin FormsGumProject/Screens/DemoScreenGumAnimations.ganx
+/copy:FormsGumProject/Screens/DemoScreenGumAnimations.ganx
+
+#begin FormsGumProject/Screens/KeyboardScreenGum.gusx
+/copy:FormsGumProject/Screens/KeyboardScreenGum.gusx
+
+#begin FormsGumProject/Screens/NewScreen1Gum.gusx
+/copy:FormsGumProject/Screens/NewScreen1Gum.gusx
+
+#begin FormsGumProject/Screens/PolygonScreenGum.gusx
+/copy:FormsGumProject/Screens/PolygonScreenGum.gusx
+
+#begin FormsGumProject/Screens/StylesScreen.gusx
+/copy:FormsGumProject/Screens/StylesScreen.gusx
+
+#begin FormsGumProject/Screens/TestScreen.gusx
+/copy:FormsGumProject/Screens/TestScreen.gusx
+
+#begin FormsGumProject/Screens/UserControlPageGum.gusx
+/copy:FormsGumProject/Screens/UserControlPageGum.gusx
+
+#begin FormsGumProject/Standards/StandardGraphics/Red_BottomCenter.png
+/copy:FormsGumProject/Standards/StandardGraphics/Red_BottomCenter.png
+
+#begin FormsGumProject/Standards/StandardGraphics/Red_BottomLeft.png
+/copy:FormsGumProject/Standards/StandardGraphics/Red_BottomLeft.png
+
+#begin FormsGumProject/Standards/StandardGraphics/Red_BottomRight.png
+/copy:FormsGumProject/Standards/StandardGraphics/Red_BottomRight.png
+
+#begin FormsGumProject/Standards/StandardGraphics/Red_Center.png
+/copy:FormsGumProject/Standards/StandardGraphics/Red_Center.png
+
+#begin FormsGumProject/Standards/StandardGraphics/Red_Left.png
+/copy:FormsGumProject/Standards/StandardGraphics/Red_Left.png
+
+#begin FormsGumProject/Standards/StandardGraphics/Red_Right.png
+/copy:FormsGumProject/Standards/StandardGraphics/Red_Right.png
+
+#begin FormsGumProject/Standards/StandardGraphics/Red_TopCenter.png
+/copy:FormsGumProject/Standards/StandardGraphics/Red_TopCenter.png
+
+#begin FormsGumProject/Standards/StandardGraphics/Red_TopLeft.png
+/copy:FormsGumProject/Standards/StandardGraphics/Red_TopLeft.png
+
+#begin FormsGumProject/Standards/StandardGraphics/Red_TopRight.png
+/copy:FormsGumProject/Standards/StandardGraphics/Red_TopRight.png
+
+#begin FormsGumProject/Standards/Circle.gutx
+/copy:FormsGumProject/Standards/Circle.gutx
+
+#begin FormsGumProject/Standards/ColoredRectangle.gutx
+/copy:FormsGumProject/Standards/ColoredRectangle.gutx
+
+#begin FormsGumProject/Standards/Component.gutx
+/copy:FormsGumProject/Standards/Component.gutx
+
+#begin FormsGumProject/Standards/Container.gutx
+/copy:FormsGumProject/Standards/Container.gutx
+
+#begin FormsGumProject/Standards/NineSlice.gutx
+/copy:FormsGumProject/Standards/NineSlice.gutx
+
+#begin FormsGumProject/Standards/Polygon.gutx
+/copy:FormsGumProject/Standards/Polygon.gutx
+
+#begin FormsGumProject/Standards/Rectangle.gutx
+/copy:FormsGumProject/Standards/Rectangle.gutx
+
+#begin FormsGumProject/Standards/Sprite.gutx
+/copy:FormsGumProject/Standards/Sprite.gutx
+
+#begin FormsGumProject/Standards/Text.gutx
+/copy:FormsGumProject/Standards/Text.gutx
+
+#begin FormsGumProject/GumProject.gumx
+/copy:FormsGumProject/GumProject.gumx
+
+#begin FormsGumProject/ProjectCodeSettings.codsj
+/copy:FormsGumProject/ProjectCodeSettings.codsj
+
+#begin FormsGumProject/UISpriteSheet.png
+/copy:FormsGumProject/UISpriteSheet.png
+

--- a/Samples/KniGumFromFile/KniGumFromFile.Android/KniGumFromFile.Android.csproj
+++ b/Samples/KniGumFromFile/KniGumFromFile.Android/KniGumFromFile.Android.csproj
@@ -6,7 +6,7 @@
     <ProjectGuid>5254c63d-ba02-4358-822e-0145db4f33aa</ProjectGuid>
     <OutputType>Exe</OutputType>
     <IsTrimmable>True</IsTrimmable>
-	<TrimMode>partial</TrimMode>
+    <TrimMode>partial</TrimMode>
     <RootNamespace>KniGumFromFile</RootNamespace>
     <AssemblyName>KniGumFromFile</AssemblyName>
     <OutputPath>bin\$(Platform)\$(Configuration)\</OutputPath>
@@ -26,15 +26,18 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="nkast.Xna.Framework" Version="3.12.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Content" Version="3.12.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Graphics" Version="3.12.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Audio" Version="3.12.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Media" Version="3.12.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Input" Version="3.12.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Game" Version="3.12.9001" />
-    <PackageReference Include="MonoGame.Framework.Android.9000" Version="3.12.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Content.Pipeline.Builder" Version="3.12.9001" />
+    <PackageReference Include="nkast.Xna.Framework" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Content" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Graphics" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Audio" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Media" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Input" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Game" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Devices" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Storage" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework.XR" Version="4.1.9001" />
+    <PackageReference Include="nkast.Kni.Platform.Android.GL" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Content.Pipeline.Builder" Version="4.1.9001" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="KniGumFromFileActivity.cs" />

--- a/Samples/KniGumFromFile/KniGumFromFile.BlazorGL/KniGumFromFile.BlazorGL.csproj
+++ b/Samples/KniGumFromFile/KniGumFromFile.BlazorGL/KniGumFromFile.BlazorGL.csproj
@@ -9,7 +9,7 @@
     <RootNamespace>KniGumFromFile</RootNamespace>
     <AssemblyName>KniGumFromFile</AssemblyName>
     <DefineConstants>$(DefineConstants);BLAZORGL</DefineConstants>
-	<KniPlatform>BlazorGL</KniPlatform>
+    <KniPlatform>BlazorGL</KniPlatform>
   </PropertyGroup>
   
   <PropertyGroup>
@@ -28,33 +28,27 @@
   </ItemGroup>
 
   <ItemGroup>
-
-	  <PackageReference Include="nkast.Xna.Framework" Version="4.0.9001" />
-	  <PackageReference Include="nkast.Xna.Framework.Content" Version="4.0.9001" />
-	  <PackageReference Include="nkast.Xna.Framework.Devices" Version="4.0.9001" />
-	  <PackageReference Include="nkast.Xna.Framework.Graphics" Version="4.0.9001" />
-	  <PackageReference Include="nkast.Xna.Framework.Audio" Version="4.0.9001" />
-	  <PackageReference Include="nkast.Xna.Framework.Media" Version="4.0.9001" />
-	  <PackageReference Include="nkast.Xna.Framework.Input" Version="4.0.9001" />
-	  <PackageReference Include="nkast.Xna.Framework.Game" Version="4.0.9001" />
-	  <PackageReference Include="nkast.Xna.Framework.Storage" Version="4.0.9001" />
-	  <PackageReference Include="nkast.Xna.Framework.XR" Version="4.0.9001" />
-	  <PackageReference Include="nkast.Kni.Platform.Blazor.GL" Version="4.0.9001.1" />
-	  
-    <PackageReference Include="nkast.Xna.Framework.Content.Pipeline.Builder" Version="4.0.9001" />
+    <PackageReference Include="nkast.Xna.Framework" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Content" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Graphics" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Audio" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Media" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Input" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Game" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Devices" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Storage" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework.XR" Version="4.1.9001" />
+    <PackageReference Include="nkast.Kni.Platform.Blazor.GL" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Content.Pipeline.Builder" Version="4.1.9001" />
   </ItemGroup>
 
-	<ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="6.0.32" />
-		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="6.0.32" PrivateAssets="all" />
-	</ItemGroup>
-	<ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
-		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.7" />
-		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.7" PrivateAssets="all" />
-	</ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.11" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.11" PrivateAssets="all" />
+  </ItemGroup>
 
   <ItemGroup>
-    <KniContentReference Include="..\KniGumFromFileContent\KniGumFromFileContent.mgcb">   
+    <KniContentReference Include="..\KniGumFromFileContent\KniGumFromFileContent.mgcb">
       <Link>Content\KniGumFromFileContent.mgcb</Link>
     </KniContentReference>
   </ItemGroup>

--- a/Samples/KniGumFromFile/KniGumFromFile.BlazorGL/wwwroot/index.html
+++ b/Samples/KniGumFromFile/KniGumFromFile.BlazorGL/wwwroot/index.html
@@ -30,6 +30,7 @@
         <script src="_framework/blazor.webassembly.js" autostart="false"></script>
         <script type="module">
             import { BrotliDecode } from './js/decode.min.js';
+            window.BrotliDecode = BrotliDecode;
             // Set this to enable Brotli (.br) decompression on static webServers
             // that don't support content compression and http://.
             var enableBrotliDecompression = false;
@@ -99,7 +100,7 @@
                 // Prevent Mousewheel scrolling the outer page
                 // when running inside an iframe. e.g: itch.io embedding.
                 event.preventDefault();
-            };
+            }, { passive: false };
         </script>
 </body>
 

--- a/Samples/KniGumFromFile/KniGumFromFile.DesktopGL/KniGumFromFile.DesktopGL.csproj
+++ b/Samples/KniGumFromFile/KniGumFromFile.DesktopGL/KniGumFromFile.DesktopGL.csproj
@@ -29,15 +29,18 @@
     <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="nkast.Xna.Framework" Version="3.12.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Content" Version="3.12.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Graphics" Version="3.12.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Audio" Version="3.12.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Media" Version="3.12.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Input" Version="3.12.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Game" Version="3.12.9001" />
-    <PackageReference Include="MonoGame.Framework.DesktopGL.9000" Version="3.12.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Content.Pipeline.Builder" Version="3.12.9001" />
+    <PackageReference Include="nkast.Xna.Framework" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Content" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Graphics" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Audio" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Media" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Input" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Game" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Devices" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Storage" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework.XR" Version="4.1.9001" />
+    <PackageReference Include="nkast.Kni.Platform.SDL2.GL" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Content.Pipeline.Builder" Version="4.1.9001" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Program.cs" />

--- a/Samples/KniGumFromFile/KniGumFromFile.WindowsDX/KniGumFromFile.WindowsDX.csproj
+++ b/Samples/KniGumFromFile/KniGumFromFile.WindowsDX/KniGumFromFile.WindowsDX.csproj
@@ -28,15 +28,18 @@
     <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="nkast.Xna.Framework" Version="3.12.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Content" Version="3.12.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Graphics" Version="3.12.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Audio" Version="3.12.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Media" Version="3.12.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Input" Version="3.12.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Game" Version="3.12.9001" />
-    <PackageReference Include="MonoGame.Framework.WindowsDX.9000" Version="3.12.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Content.Pipeline.Builder" Version="3.12.9001" />
+    <PackageReference Include="nkast.Xna.Framework" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Content" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Graphics" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Audio" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Media" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Input" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Game" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Devices" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Storage" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework.XR" Version="4.1.9001" />
+    <PackageReference Include="nkast.Kni.Platform.WinForms.DX11" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Content.Pipeline.Builder" Version="4.1.9001" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Program.cs" />

--- a/Samples/KniGumFromFile/KniGumFromFileCommon/KniGumFromFileCommon.csproj
+++ b/Samples/KniGumFromFile/KniGumFromFileCommon/KniGumFromFileCommon.csproj
@@ -18,13 +18,16 @@
   </PropertyGroup>
 	
   <ItemGroup>
-	  <PackageReference Include="nkast.Xna.Framework" Version="3.12.9001" />
-	  <PackageReference Include="nkast.Xna.Framework.Content" Version="3.12.9001" />
-	  <PackageReference Include="nkast.Xna.Framework.Graphics" Version="3.12.9001" />
-	  <PackageReference Include="nkast.Xna.Framework.Input" Version="3.12.9001" />
-	  <PackageReference Include="nkast.Xna.Framework.Game" Version="3.12.9001" />
-	  <PackageReference Include="nkast.Xna.Framework.Audio" Version="3.12.9001" />
-	  <PackageReference Include="nkast.Xna.Framework.Media" Version="3.12.9001" />
+	<PackageReference Include="nkast.Xna.Framework" Version="4.1.9001" />
+	<PackageReference Include="nkast.Xna.Framework.Content" Version="4.1.9001" />
+	<PackageReference Include="nkast.Xna.Framework.Graphics" Version="4.1.9001" />
+	<PackageReference Include="nkast.Xna.Framework.Audio" Version="4.1.9001" />
+	<PackageReference Include="nkast.Xna.Framework.Media" Version="4.1.9001" />
+	<PackageReference Include="nkast.Xna.Framework.Input" Version="4.1.9001" />
+	<PackageReference Include="nkast.Xna.Framework.Game" Version="4.1.9001" />
+	<PackageReference Include="nkast.Xna.Framework.Devices" Version="4.1.9001" />
+	<PackageReference Include="nkast.Xna.Framework.Storage" Version="4.1.9001" />
+	<PackageReference Include="nkast.Xna.Framework.XR" Version="4.1.9001" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Samples/KniGumInCode/KniGumInCode.Android/KniGumInCode.Android.csproj
+++ b/Samples/KniGumInCode/KniGumInCode.Android/KniGumInCode.Android.csproj
@@ -6,7 +6,7 @@
     <ProjectGuid>16e767a3-be53-4718-a6b5-1d08cf95dfc5</ProjectGuid>
     <OutputType>Exe</OutputType>
     <IsTrimmable>True</IsTrimmable>
-	<TrimMode>partial</TrimMode>
+    <TrimMode>partial</TrimMode>
     <RootNamespace>KniGumInCode</RootNamespace>
     <AssemblyName>KniGumInCode</AssemblyName>
     <OutputPath>bin\$(Platform)\$(Configuration)\</OutputPath>
@@ -26,15 +26,18 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="nkast.Xna.Framework" Version="3.12.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Content" Version="3.12.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Graphics" Version="3.12.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Audio" Version="3.12.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Media" Version="3.12.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Input" Version="3.12.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Game" Version="3.12.9001" />
-    <PackageReference Include="MonoGame.Framework.Android.9000" Version="3.12.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Content.Pipeline.Builder" Version="3.12.9001" />
+    <PackageReference Include="nkast.Xna.Framework" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Content" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Graphics" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Audio" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Media" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Input" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Game" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Devices" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Storage" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework.XR" Version="4.1.9001" />
+    <PackageReference Include="nkast.Kni.Platform.Android.GL" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Content.Pipeline.Builder" Version="4.1.9001" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="KniGumInCodeActivity.cs" />

--- a/Samples/KniGumInCode/KniGumInCode.BlazorGL/KniGumInCode.BlazorGL.csproj
+++ b/Samples/KniGumInCode/KniGumInCode.BlazorGL/KniGumInCode.BlazorGL.csproj
@@ -28,24 +28,23 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="nkast.Xna.Framework" Version="3.12.9001" />
-		<PackageReference Include="nkast.Xna.Framework.Content" Version="3.12.9001" />
-		<PackageReference Include="nkast.Xna.Framework.Graphics" Version="3.12.9001" />
-		<PackageReference Include="nkast.Xna.Framework.Audio" Version="3.12.9001" />
-		<PackageReference Include="nkast.Xna.Framework.Media" Version="3.12.9001" />
-		<PackageReference Include="nkast.Xna.Framework.Input" Version="3.12.9001" />
-		<PackageReference Include="nkast.Xna.Framework.Game" Version="3.12.9001" />
-		<PackageReference Include="nkast.Xna.Framework.Blazor" Version="3.12.9001" />
-		<PackageReference Include="nkast.Xna.Framework.Content.Pipeline.Builder" Version="3.12.9001" />
+		<PackageReference Include="nkast.Xna.Framework" Version="4.1.9001" />
+		<PackageReference Include="nkast.Xna.Framework.Content" Version="4.1.9001" />
+		<PackageReference Include="nkast.Xna.Framework.Graphics" Version="4.1.9001" />
+		<PackageReference Include="nkast.Xna.Framework.Audio" Version="4.1.9001" />
+		<PackageReference Include="nkast.Xna.Framework.Media" Version="4.1.9001" />
+		<PackageReference Include="nkast.Xna.Framework.Input" Version="4.1.9001" />
+		<PackageReference Include="nkast.Xna.Framework.Game" Version="4.1.9001" />
+		<PackageReference Include="nkast.Xna.Framework.Devices" Version="4.1.9001" />
+		<PackageReference Include="nkast.Xna.Framework.Storage" Version="4.1.9001" />
+		<PackageReference Include="nkast.Xna.Framework.XR" Version="4.1.9001" />
+		<PackageReference Include="nkast.Kni.Platform.Blazor.GL" Version="4.1.9001" />
+		<PackageReference Include="nkast.Xna.Framework.Content.Pipeline.Builder" Version="4.1.9001" />
 	</ItemGroup>
 
-	<ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="6.0.27" />
-		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="6.0.27" PrivateAssets="all" />
-	</ItemGroup>
 	<ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
-		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.2" />
-		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.2" PrivateAssets="all" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.11" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.11" PrivateAssets="all" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Samples/KniGumInCode/KniGumInCode.BlazorGL/wwwroot/index.html
+++ b/Samples/KniGumInCode/KniGumInCode.BlazorGL/wwwroot/index.html
@@ -16,94 +16,91 @@
     <div id="app">
         <div id="loading" style="display: table-cell; margin: auto; width:100vw; height:100vh; vertical-align: middle; background: #ffcc10;">
             <div style="display: block; margin: auto; width: 9em; color: white;font-family: 'Segoe UI', sans-serif;">
-            <div style="text-align: center; font-size: 0.85em;">Made with<br/><a href="https://github.com/kniEngine/kni"><img src="kni.png" border="0" alt="Kni"></a></div>
-            <div style="text-align: center; font-size: 1.8em;">loading&nbsp;<marquee style="width:0.9em; vertical-align: bottom;">.&nbsp;.&nbsp;.&nbsp;&nbsp;&nbsp;</marquee></div>
+                <div style="text-align: center; font-size: 0.85em;">Made with<br/><a href="https://github.com/kniEngine/kni"><img src="kni.png" border="0" alt="Kni"></a></div>
+                <div style="text-align: center; font-size: 1.8em;">loading&nbsp;<marquee style="width:0.9em; vertical-align: bottom;">.&nbsp;.&nbsp;.&nbsp;&nbsp;&nbsp;</marquee></div>
+            </div>
         </div>
-    </div>
 
-    <div id="blazor-error-ui">
-        An unhandled error has occurred.
-        <a href="" class="reload">Reload</a>
-        <a class="dismiss">?</a>
-    </div>
+        <div id="blazor-error-ui">
+            An unhandled error has occurred.
+            <a href="" class="reload">Reload</a>
+            <a class="dismiss">?</a>
+        </div>
 
-    <script src="_framework/blazor.webassembly.js" autostart="false"></script>
-    <script type="module">
-        import { BrotliDecode } from './js/decode.min.js';
-        // Set this to enable Brotli (.br) decompression on static webServers
-        // that don't support content compression and http://.
-        var enableBrotliDecompression = false;
-        Blazor.start({
-            loadBootResource: function (type, name, defaultUri, integrity)
-            {
-                if (enableBrotliDecompression === true && type !== 'dotnetjs' && location.hostname !== 'localhost')
-                {
-                    return (async function()
-                    {
-                        const response = await fetch(defaultUri + '.br', { cache: 'no-cache' });
-                        if (!response.ok)
-                            throw new Error(response.statusText);
-                        const originalResponseBuffer = await response.arrayBuffer();
-                        const originalResponseArray = new Int8Array(originalResponseBuffer);
-                        const contentType = (type === 'dotnetwasm')
-                                          ? 'application/wasm'
-                                          : 'application/octet-stream';
-                        const decompressedResponseArray = BrotliDecode(originalResponseArray);
-                        return new Response(decompressedResponseArray,
-                                            { headers: { 'content-type': contentType }
-                                   });
-                    })();
+        <script src="_framework/blazor.webassembly.js" autostart="false"></script>
+        <script type="module">
+            import { BrotliDecode } from './js/decode.min.js';
+            window.BrotliDecode = BrotliDecode;
+            // Set this to enable Brotli (.br) decompression on static webServers
+            // that don't support content compression and http://.
+            var enableBrotliDecompression = false;
+            Blazor.start({
+                loadBootResource: function (type, name, defaultUri, integrity){
+                    if (enableBrotliDecompression === true && type !== 'dotnetjs' && location.hostname !== 'localhost'){
+                        return (async function(){
+                            const response = await fetch(defaultUri + '.br', { cache: 'no-cache' });
+                            if (!response.ok)
+                                throw new Error(response.statusText);
+                            const originalResponseBuffer = await response.arrayBuffer();
+                            const originalResponseArray = new Int8Array(originalResponseBuffer);
+                            const contentType = (type === 'dotnetwasm')
+                                ? 'application/wasm'
+                                : 'application/octet-stream';
+                            const decompressedResponseArray = BrotliDecode(originalResponseArray);
+                            return new Response(decompressedResponseArray,
+                                {headers: { 'content-type': contentType }
+                                });
+                        })();
+                    }
                 }
+            });
+        </script>
+
+        <script src="_content/nkast.Wasm.Dom/js/JSObject.8.0.5.js"></script>
+        <script src="_content/nkast.Wasm.Dom/js/Window.8.0.5.js"></script>
+        <script src="_content/nkast.Wasm.Dom/js/Document.8.0.5.js"></script>
+        <script src="_content/nkast.Wasm.Dom/js/Navigator.8.0.5.js"></script>
+        <script src="_content/nkast.Wasm.Dom/js/Gamepad.8.0.5.js"></script>
+        <script src="_content/nkast.Wasm.Dom/js/Media.8.0.5.js"></script>
+        <script src="_content/nkast.Wasm.XHR/js/XHR.8.0.5.js"></script>
+        <script src="_content/nkast.Wasm.Canvas/js/Canvas.8.0.5.js"></script>
+        <script src="_content/nkast.Wasm.Canvas/js/CanvasGLContext.8.0.5.js"></script>
+        <script src="_content/nkast.Wasm.Audio/js/Audio.8.0.5.js"></script>
+        <script src="_content/nkast.Wasm.XR/js/XR.8.0.5.js"></script>
+
+        <script>
+            function tickJS(){
+                window.theInstance.invokeMethod('TickDotNet');
+                window.requestAnimationFrame(tickJS);
             }
-        });
-    </script>
 
-    <script src="_content/nkast.Wasm.Dom/js/JSObject.8.0.0.js"></script>
-    <script src="_content/nkast.Wasm.Dom/js/Window.8.0.0.js"></script>
-    <script src="_content/nkast.Wasm.Dom/js/Document.8.0.0.js"></script>
-    <script src="_content/nkast.Wasm.Dom/js/Media.8.0.0.js"></script>
-    <script src="_content/nkast.Wasm.XHR/js/XHR.8.0.0.js"></script>
-    <script src="_content/nkast.Wasm.Canvas/js/Canvas.8.0.0.js"></script>
-    <script src="_content/nkast.Wasm.Canvas/js/CanvasGLContext.8.0.0.js"></script>
-    <script src="_content/nkast.Wasm.Audio/js/Audio.8.0.0.js"></script>
+            window.initRenderJS = (instance) =>{
+                window.theInstance = instance;
 
-    <script>
-        function tickJS()
-        {
-            window.theInstance.invokeMethod('TickDotNet');
-            window.requestAnimationFrame(tickJS);
-        }
+                // set initial canvas size
+                var canvas = document.getElementById('theCanvas');
+                var holder = document.getElementById('canvasHolder');
+                canvas.width = holder.clientWidth;
+                canvas.height = holder.clientHeight;
+                // disable context menu on right click
+                canvas.addEventListener("contextmenu", e => e.preventDefault());
 
-        window.initRenderJS = (instance) =>
-        {
-            window.theInstance = instance;
+                // begin game loop
+                window.requestAnimationFrame(tickJS);
+            };
 
-            // set initial canvas size
-            var canvas = document.getElementById('theCanvas');
-            var holder = document.getElementById('canvasHolder');
-            canvas.width = holder.clientWidth;
-            canvas.height = holder.clientHeight;
-            // disable context menu on right click
-            canvas.addEventListener("contextmenu", e => e.preventDefault());
-            
-            // begin game loop
-            window.requestAnimationFrame(tickJS);
-        };
-
-        window.onkeydown = function(event)
-        {
-            // Prevent Arrows Keys and Spacebar scrolling the outer page
-            // when running inside an iframe. e.g: itch.io embedding.
-            if ([32, 37, 38, 39, 40].indexOf(event.keyCode) > -1)
+            window.onkeydown = function(event){
+                // Prevent Arrows Keys and Spacebar scrolling the outer page
+                // when running inside an iframe. e.g: itch.io embedding.
+                if ([32, 37, 38, 39, 40].indexOf(event.keyCode) > -1)
+                    event.preventDefault();
+            };
+            window.onmousewheel = function(event){
+                // Prevent Mousewheel scrolling the outer page
+                // when running inside an iframe. e.g: itch.io embedding.
                 event.preventDefault();
-        };
-        window.onmousewheel = function(event)
-        {
-            // Prevent Mousewheel scrolling the outer page
-            // when running inside an iframe. e.g: itch.io embedding.
-            event.preventDefault();
-        };
-    </script>
+            }, { passive: false };
+        </script>
 </body>
 
 </html>

--- a/Samples/KniGumInCode/KniGumInCode.DesktopGL/KniGumInCode.DesktopGL.csproj
+++ b/Samples/KniGumInCode/KniGumInCode.DesktopGL/KniGumInCode.DesktopGL.csproj
@@ -29,15 +29,18 @@
     <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="nkast.Xna.Framework" Version="3.12.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Content" Version="3.12.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Graphics" Version="3.12.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Audio" Version="3.12.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Media" Version="3.12.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Input" Version="3.12.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Game" Version="3.12.9001" />
-    <PackageReference Include="MonoGame.Framework.DesktopGL.9000" Version="3.12.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Content.Pipeline.Builder" Version="3.12.9001" />
+    <PackageReference Include="nkast.Xna.Framework" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Content" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Graphics" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Audio" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Media" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Input" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Game" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Devices" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Storage" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework.XR" Version="4.1.9001" />
+    <PackageReference Include="nkast.Kni.Platform.SDL2.GL" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Content.Pipeline.Builder" Version="4.1.9001" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Program.cs" />

--- a/Samples/KniGumInCode/KniGumInCode.WindowsDX/KniGumInCode.WindowsDX.csproj
+++ b/Samples/KniGumInCode/KniGumInCode.WindowsDX/KniGumInCode.WindowsDX.csproj
@@ -29,15 +29,18 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="nkast.Xna.Framework" Version="3.12.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Content" Version="3.12.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Graphics" Version="3.12.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Audio" Version="3.12.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Media" Version="3.12.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Input" Version="3.12.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Game" Version="3.12.9001" />
-    <PackageReference Include="MonoGame.Framework.WindowsDX.9000" Version="3.12.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Content.Pipeline.Builder" Version="3.12.9001" />
+    <PackageReference Include="nkast.Xna.Framework" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Content" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Graphics" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Audio" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Media" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Input" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Game" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Devices" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Storage" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework.XR" Version="4.1.9001" />
+    <PackageReference Include="nkast.Kni.Platform.WinForms.DX11" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Content.Pipeline.Builder" Version="4.1.9001" />
   </ItemGroup>
 	
   <ItemGroup>

--- a/Samples/KniGumInCode/KniGumInCodeCommon/KniGumInCodeCommon.csproj
+++ b/Samples/KniGumInCode/KniGumInCodeCommon/KniGumInCodeCommon.csproj
@@ -23,13 +23,16 @@
   </ItemGroup>
 	
   <ItemGroup>
-	  <PackageReference Include="nkast.Xna.Framework" Version="3.12.9001" />
-	  <PackageReference Include="nkast.Xna.Framework.Content" Version="3.12.9001" />
-	  <PackageReference Include="nkast.Xna.Framework.Graphics" Version="3.12.9001" />
-	  <PackageReference Include="nkast.Xna.Framework.Input" Version="3.12.9001" />
-	  <PackageReference Include="nkast.Xna.Framework.Game" Version="3.12.9001" />
-	  <PackageReference Include="nkast.Xna.Framework.Audio" Version="3.12.9001" />
-	  <PackageReference Include="nkast.Xna.Framework.Media" Version="3.12.9001" />
+    <PackageReference Include="nkast.Xna.Framework" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Content" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Graphics" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Audio" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Media" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Input" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Game" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Devices" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Storage" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework.XR" Version="4.1.9001" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Updates library and samples using KNI to version 4.1.9001, which includes:

- MonoGameGum\KniGum
- KniGumFormsSample
- KniGumFromFile
- KniGumInCode

Also added `MonoGameGumFormsSample/Content/KNIContent.mgcb` for the KniGumFormsSample.BlazorGL project. Previously it appeared to need the gum project files to be manually copied and included.