### PR TITLE
Add macOS and Linux support to Build and Test workflow

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -8,7 +8,10 @@ on:
 
 jobs:
   Build-and-Test:
-    runs-on: windows-latest
+    strategy:
+      matrix:
+        os: [windows-latest, ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
 
@@ -42,7 +45,7 @@ jobs:
       - name: Publish Test Results
         uses: dorny/test-reporter@v2
         with:
-          name: Tests
+          name: Tests ${{ matrix.os }}
           path: "TestResults/*.trx"
           reporter: dotnet-trx
           fail-on-error: true


### PR DESCRIPTION
## Summary

This PR extends the CI/CD pipeline to run build and test jobs on macOS and Linux in addition to Windows, improving cross-platform compatibility validation.

## Changes

- **Updated `Build-and-Test` job**: Converted from single Windows runner to matrix strategy supporting:

    - `windows-latest`
    - `ubuntu-latest`
    - `macos-latest`

- **Updated test reporting**: Updated test results naming to include OS identifier for better distinction between platform results
