### PR TITLE
Make Build-and-Test workflow cross-platform with conditional Windows-only steps

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -8,7 +8,10 @@ on:
 
 jobs:
   Build-and-Test:
-    runs-on: windows-latest
+    strategy:
+      matrix:
+        os: [windows-latest, ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
 
@@ -42,7 +45,7 @@ jobs:
       - name: Publish Test Results
         uses: dorny/test-reporter@v2
         with:
-          name: Tests
+          name: Tests ${{ matrix.os }}
           path: "TestResults/*.trx"
           reporter: dotnet-trx
           fail-on-error: true

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -24,7 +24,8 @@ jobs:
         with:
           dotnet-version: 9.0.x
 
-      - name: Build Gum
+      - name: Build Gum (Windows Only)
+        if: runner.os == 'Windows'
         run: |
           dotnet restore "Gum.sln"
           dotnet build "Gum.sln" --configuration Release --no-restore --verbosity minimal -p:WarningLevel=0
@@ -38,7 +39,8 @@ jobs:
         run: dotnet test "MonoGameGum.Tests" --configuration Release --no-build --logger "trx" --results-directory "TestResults"
         continue-on-error: true
 
-      - name: GumToolUnitTests
+      - name: GumToolUnitTests (Windows Only)
+        if: runner.os == 'Windows'
         run: dotnet test "Tool/Tests/GumToolUnitTests" --configuration Release --no-build --logger "trx" --results-directory "TestResults"
         continue-on-error: true
 


### PR DESCRIPTION
## Summary

This PR updates the GitHub workflow to properly handle cross-platform testing while isolating Windows-specific components.

## Changes

- Add conditional steps for `Gum.sln` build and `GumToolUnitTests` that only run on Windows using `runner.os == 'Windows'`
- Keep `AllLibraries.sln` build and `MonoGameGum.Tests` running on all platforms in the existing matrix
- Use `runner.os` conditions to skip incompatible steps rather than creating separate jobs