### PR TITLE
Move Build Samples to dispatch workflow

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -51,23 +51,3 @@ jobs:
           path: "TestResults/*.trx"
           reporter: dotnet-trx
           fail-on-error: true
-
-  Build-Samples:
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Initialize Submodules
-        run: git submodule update --init --recursive
-        continue-on-error: false
-
-      - name: Setup .NET SDKs
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: 9.0.x
-
-      - name: Install .NET MAUI Workload
-        run: dotnet workload install maui
-
-      - name: Build Samples
-        run: pwsh ./.github/scripts/build-all.ps1 -Path Samples

--- a/.github/workflows/build-samples.yaml
+++ b/.github/workflows/build-samples.yaml
@@ -1,0 +1,23 @@
+name: "Build Samples"
+
+on: workflow_dispatch
+
+jobs:
+    Build-Samples:
+        runs-on: windows-latest
+        steps:
+            - name: Clone Repository
+              uses: actions/checkout@v4
+              with:
+                submodules: recursive
+
+            - name: Setup .NET SDKs
+              uses: actions/setup-dotnet@v4
+              with:
+                dotnet-version: 9.0.x
+
+            - name: Install .NET MAUI Workload
+              run: dotnet workload install maui
+
+            - name: Build Samples
+              run: pwsh ./.github/scripts/build-all.ps1 -Path Samples


### PR DESCRIPTION
## Summary

Removes the `Build Samples`  job from the `build-and-test` workflow and moves it to a its own workflow that is a manual dispatch.
