### PR TITLE
Removed mac build since it's EXPENSIVE

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -19,7 +19,14 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 9.0.x
-          cache: true
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/*.fsproj', '**/*.vbproj', '**/packages.lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-nuget-
 
       - name: Build Gum (Windows Only)
         if: runner.os == 'Windows'

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -14,29 +14,12 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - name: Cache .NET SDK
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.dotnet
-            ~/.nuget/packages
-          key: ${{ runner.os }}-dotnet-9.0.x-${{ hashFiles('**/*.csproj', '**/*.fsproj', '**/*.vbproj', '**/packages.lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-dotnet-9.0.x-
-            ${{ runner.os }}-dotnet-
 
       - name: Setup .NET SDKs
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 9.0.x
-
-      - name: Cache NuGet packages
-        uses: actions/cache@v4
-        with:
-          path: ~/.nuget/packages
-          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/*.fsproj', '**/*.vbproj', '**/packages.lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-nuget-
+          cache: true
 
       - name: Build Gum (Windows Only)
         if: runner.os == 'Windows'

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -22,6 +22,9 @@ jobs:
 
       # I tried caching both NuGet packages and also cache on the actions/setup-dotnet@v4
       # In both cases the caching slowed down the total execution time.
+      # Actually on further testing, it does seem like the NuGet cache can speed up the Windows
+      # build by around 20-30 seconds. However, the script for it is a little confusing and it's
+      # not a huge savings. Let's keep it simple and not use caching. 
 
       - name: Build Gum (Windows Only)
         if: runner.os == 'Windows'

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -20,13 +20,8 @@ jobs:
         with:
           dotnet-version: 9.0.x
 
-      - name: Cache NuGet packages
-        uses: actions/cache@v4
-        with:
-          path: ~/.nuget/packages
-          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/*.fsproj', '**/*.vbproj', '**/packages.lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-nuget-
+      # I tried caching both NuGet packages and also cache on the actions/setup-dotnet@v4
+      # In both cases the caching slowed down the total execution time.
 
       - name: Build Gum (Windows Only)
         if: runner.os == 'Windows'

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -1,8 +1,6 @@
 name: Build and Test
 
 on:
-  push:
-    branches: [master]
   pull_request:
     branches: [master]
 
@@ -10,19 +8,35 @@ jobs:
   Build-and-Test:
     strategy:
       matrix:
-        os: [windows-latest, ubuntu-latest, macos-latest]
+        os: [windows-latest, ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
-
-      - name: Initialize Submodules
-        run: git submodule update --init --recursive
-        continue-on-error: false
+        with:
+          submodules: recursive
+      - name: Cache .NET SDK
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.dotnet
+            ~/.nuget/packages
+          key: ${{ runner.os }}-dotnet-9.0.x-${{ hashFiles('**/*.csproj', '**/*.fsproj', '**/*.vbproj', '**/packages.lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-dotnet-9.0.x-
+            ${{ runner.os }}-dotnet-
 
       - name: Setup .NET SDKs
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 9.0.x
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/*.fsproj', '**/*.vbproj', '**/packages.lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-nuget-
 
       - name: Build Gum (Windows Only)
         if: runner.os == 'Windows'


### PR DESCRIPTION
Removed automatic build on push to master, only on PRs Added cache for SDK and NuGet to improve speeds.