### PR TITLE
Fix linux refreshing issues

### DIFF
--- a/Gum/Commands/FileCommands.cs
+++ b/Gum/Commands/FileCommands.cs
@@ -162,7 +162,7 @@ namespace Gum.Commands
                     }
                     else
                     {
-                        FileWatchManager.Self.IgnoreNextChangeUntil(fileName.FullPath, DateTime.Now.AddSeconds(5));
+                        FileWatchManager.Self.IgnoreNextChangeUntil(fileName.FullPath, DateTime.Now.AddSeconds(1));
 
                         const int maxNumberOfTries = 5;
                         const int msBetweenSaves = 100;
@@ -265,7 +265,7 @@ namespace Gum.Commands
                     //PluginManager.Self.BeforeBehaviorSave(behavior);
 
                     string fileName = GetFullPathXmlFile( behavior).FullPath;
-                    FileWatchLogic.Self.IgnoreNextChangeOn(fileName);
+                    FileWatchManager.Self.IgnoreNextChangeUntil(fileName, DateTime.Now.AddSeconds(1));
                     // if it's readonly, let's warn the user
                     bool isReadOnly = ProjectManager.IsFileReadOnly(fileName);
 

--- a/Gum/Managers/ProjectManager.cs
+++ b/Gum/Managers/ProjectManager.cs
@@ -678,7 +678,7 @@ namespace Gum
                         }
 
                         // todo - this should go through the plugin...
-                        FileWatchLogic.Self.IgnoreNextChangeOn(GumProjectSave.FullFileName);
+                        FileWatchManager.Self.IgnoreNextChangeUntil(GumProjectSave.FullFileName, DateTime.Now.AddSeconds(1));
 
                         GumCommands.Self.TryMultipleTimes(() => GumProjectSave.Save(GumProjectSave.FullFileName, saveContainedElements));
                         succeeded = true;

--- a/Gum/Managers/ProjectManager.cs
+++ b/Gum/Managers/ProjectManager.cs
@@ -678,7 +678,7 @@ namespace Gum
                         }
 
                         // todo - this should go through the plugin...
-                        FileWatchManager.Self.IgnoreNextChangeUntil(GumProjectSave.FullFileName, DateTime.Now.AddSeconds(1));
+                        FileWatchManager.Self.IgnoreNextChangeUntil(GumProjectSave.FullFileName, DateTime.Now.AddSeconds(5));
 
                         GumCommands.Self.TryMultipleTimes(() => GumProjectSave.Save(GumProjectSave.FullFileName, saveContainedElements));
                         succeeded = true;

--- a/Gum/Plugins/InternalPlugins/FileWatchPlugin/FileWatchLogic.cs
+++ b/Gum/Plugins/InternalPlugins/FileWatchPlugin/FileWatchLogic.cs
@@ -133,10 +133,5 @@ namespace Gum.Logic.FileWatch
             fileWatchManager.Disable();
         }
 
-        public void IgnoreNextChangeOn(string fileName)
-        {
-            fileWatchManager.IgnoreNextChangeOn(fileName);
-        }
-
     }
 }

--- a/Gum/Plugins/InternalPlugins/FileWatchPlugin/FileWatchManager.cs
+++ b/Gum/Plugins/InternalPlugins/FileWatchPlugin/FileWatchManager.cs
@@ -171,25 +171,6 @@ namespace Gum.Logic.FileWatch
             return false;
         }
 
-        public void IgnoreNextChangeOn(string fileName)
-        {
-            lock (LockObject)
-            {
-                if (FileManager.IsRelative(fileName))
-                {
-                    throw new Exception("File name should be absolute");
-                }
-                string standardized = FileManager.Standardize(fileName, preserveCase:false, makeAbsolute:true).ToLower();
-                if (changesToIgnore.ContainsKey(standardized))
-                {
-                    changesToIgnore[standardized] = 1 + changesToIgnore[standardized];
-                }
-                else
-                {
-                    changesToIgnore[standardized] = 1;
-                }
-            }
-        }
 
         public void IgnoreNextChangeUntil(FilePath filePath, DateTime time)
         {

--- a/StateAnimationPlugin/Managers/AnimationCollectionViewModelManager.cs
+++ b/StateAnimationPlugin/Managers/AnimationCollectionViewModelManager.cs
@@ -83,7 +83,7 @@ public class AnimationCollectionViewModelManager : Singleton<AnimationCollection
         {
             var save = viewModel.ToSave();
 
-            FileWatchManager.Self.IgnoreNextChangeUntil(fileName.FullPath, DateTime.Now.AddSeconds(1));
+            FileWatchManager.Self.IgnoreNextChangeUntil(fileName.FullPath, DateTime.Now.AddSeconds(5));
             FileManager.XmlSerialize(save, fileName.FullPath);
         }
     }

--- a/StateAnimationPlugin/Managers/AnimationCollectionViewModelManager.cs
+++ b/StateAnimationPlugin/Managers/AnimationCollectionViewModelManager.cs
@@ -83,7 +83,7 @@ public class AnimationCollectionViewModelManager : Singleton<AnimationCollection
         {
             var save = viewModel.ToSave();
 
-            FileWatchLogic.Self.IgnoreNextChangeOn(fileName.FullPath);
+            FileWatchManager.Self.IgnoreNextChangeUntil(fileName.FullPath, DateTime.Now.AddSeconds(1));
             FileManager.XmlSerialize(save, fileName.FullPath);
         }
     }

--- a/Tool/EditorTabPlugin_XNA/Views/Ruler.cs
+++ b/Tool/EditorTabPlugin_XNA/Views/Ruler.cs
@@ -35,6 +35,7 @@ namespace Gum.Plugins.InternalPlugins.EditorTab.Views
         #region Fields / Properties
         private ToolFontService _toolFontService;
         private ToolLayerService _toolLayerService;
+        private readonly HotkeyManager _hotkeyManager;
         GraphicsDeviceControl mControl;
         SystemManagers mManagers;
         Cursor mCursor;
@@ -253,11 +254,17 @@ namespace Gum.Plugins.InternalPlugins.EditorTab.Views
 
 
 
-        public Ruler(GraphicsDeviceControl control, SystemManagers managers, Cursor cursor, 
-            ToolFontService toolFontService, ToolLayerService toolLayerService, LayerService layerService)
+        public Ruler(GraphicsDeviceControl control, 
+            SystemManagers managers, 
+            Cursor cursor, 
+            ToolFontService toolFontService, 
+            ToolLayerService toolLayerService, 
+            LayerService layerService,
+            HotkeyManager hotkeyManager)
         {
             _toolFontService = toolFontService;
             _toolLayerService = toolLayerService;
+            _hotkeyManager = hotkeyManager;
 
             mControl = control;
             mManagers = managers;
@@ -468,11 +475,11 @@ namespace Gum.Plugins.InternalPlugins.EditorTab.Views
 
                 if (RulerSide == RulerSide.Left)
                 {
-                    if (mKeyboard.KeyPushed(Microsoft.Xna.Framework.Input.Keys.Up))
+                    if (_hotkeyManager.NudgeUp.IsPressedInControl())
                     {
                         nudgeYOffset--;
                     }
-                    else if (mKeyboard.KeyPushed(Microsoft.Xna.Framework.Input.Keys.Down))
+                    else if (_hotkeyManager.NudgeDown.IsPressedInControl())
                     {
                         nudgeYOffset++;
                     }
@@ -480,11 +487,11 @@ namespace Gum.Plugins.InternalPlugins.EditorTab.Views
                 }
                 else
                 {
-                    if (mKeyboard.KeyPushed(Microsoft.Xna.Framework.Input.Keys.Left))
+                    if (_hotkeyManager.NudgeLeft.IsPressedInControl())
                     {
                         nudgeXOffset--;
                     }
-                    else if (mKeyboard.KeyPushed(Microsoft.Xna.Framework.Input.Keys.Right))
+                    else if (_hotkeyManager.NudgeRight.IsPressedInControl())
                     {
                         nudgeXOffset++;
                     }

--- a/Tool/EditorTabPlugin_XNA/Views/WireframeControl.cs
+++ b/Tool/EditorTabPlugin_XNA/Views/WireframeControl.cs
@@ -230,16 +230,19 @@ public class WireframeControl : GraphicsDeviceControl
         ShapeManager.Self.Add(mCanvasBounds, layerService.OverlayLayer);
 
 
-        mTopRuler = new Ruler(this, SystemManagers.Default,
+        mTopRuler = new Ruler(this, 
+            SystemManagers.Default,
             InputLibrary.Cursor.Self,
             ToolFontService.Self,
             ToolLayerService.Self,
-            layerService);
+            layerService,
+            HotkeyManager.Self);
         mLeftRuler = new Ruler(this, SystemManagers.Default,
             InputLibrary.Cursor.Self,
             ToolFontService.Self,
             ToolLayerService.Self,
-            layerService);
+            layerService,
+            HotkeyManager.Self);
         mLeftRuler.RulerSide = RulerSide.Left;
 
     }


### PR DESCRIPTION
Applies the fix discussed here https://github.com/vchelaru/Gum/issues/873 to the rest of the usages of `FileWatchLogic.Self.IgnoreNextChangeOn`

Changes
FileWatchLogic.Self.IgnoreNextChangeOn TO FileWatchManager.Self.IgnoreNextChangeUntil with a one second timeframe 

The one second time frame was enough in my testing. 