### PR TITLE
Remove SelectedState.Self

### DIFF
--- a/CodeOutputPlugin/MainCodeOutputPlugin.cs
+++ b/CodeOutputPlugin/MainCodeOutputPlugin.cs
@@ -161,7 +161,7 @@ public class MainCodeOutputPlugin : PluginBase
     {
         if (control != null)
         {
-            LoadCodeSettingsFile(GumState.Self.SelectedState.SelectedElement);
+            LoadCodeSettingsFile(_selectedState.SelectedElement);
 
             RefreshCodeDisplay();
         }
@@ -171,7 +171,7 @@ public class MainCodeOutputPlugin : PluginBase
     {
         if(control != null)
         {
-            LoadCodeSettingsFile(GumState.Self.SelectedState.SelectedElement);
+            LoadCodeSettingsFile(_selectedState.SelectedElement);
 
             RefreshCodeDisplay();
         }
@@ -270,7 +270,7 @@ public class MainCodeOutputPlugin : PluginBase
     {
         //GumCommands.Self.GuiCommands.ShowControl(control);
 
-        LoadCodeSettingsFile(GumState.Self.SelectedState.SelectedElement);
+        LoadCodeSettingsFile(_selectedState.SelectedElement);
 
         RefreshCodeDisplay();
 

--- a/CodeOutputPlugin/MainCodeOutputPlugin.cs
+++ b/CodeOutputPlugin/MainCodeOutputPlugin.cs
@@ -19,6 +19,7 @@ using System.Runtime;
 using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Forms;
+using GumCommon;
 using ToolsUtilities;
 
 namespace CodeOutputPlugin;
@@ -64,9 +65,9 @@ public class MainCodeOutputPlugin : PluginBase
 
 
         _codeGenerator = new CodeGenerator();
-        _selectedState = Builder.Get<ISelectedState>();
-        _localizationManager = Builder.Get<LocalizationManager>();
-        _guiCommands = Builder.Get<GuiCommands>();
+        _selectedState = Locator.GetRequiredService<ISelectedState>();
+        _localizationManager = Locator.GetRequiredService<LocalizationManager>();
+        _guiCommands = Locator.GetRequiredService<GuiCommands>();
         _codeGenerationService = new CodeGenerationService(_guiCommands, _codeGenerator);
         _renameService = new RenameService(_codeGenerationService);
 
@@ -302,8 +303,8 @@ public class MainCodeOutputPlugin : PluginBase
         }
         /////////////////////end early out/////////////////
 
-        var instance = SelectedState.Self.SelectedInstance;
-        var selectedElement = SelectedState.Self.SelectedElement;
+        var instance = _selectedState.SelectedInstance;
+        var selectedElement = _selectedState.SelectedElement;
 
         viewModel.IsViewingStandardElement = selectedElement is StandardElementSave;
 
@@ -328,7 +329,7 @@ public class MainCodeOutputPlugin : PluginBase
                     }
                     break;
                 case ViewModels.WhatToView.SelectedState:
-                    var state = SelectedState.Self.SelectedStateSave;
+                    var state = _selectedState.SelectedStateSave;
 
                     if (state != null && selectedElement != null)
                     {
@@ -389,7 +390,7 @@ public class MainCodeOutputPlugin : PluginBase
 
     private void HandleCodeOutputPropertyChanged()
     {
-        var element = SelectedState.Self.SelectedElement;
+        var element = _selectedState.SelectedElement;
         if(element != null)
         {
             CodeOutputElementSettingsManager.WriteSettingsForElement(element, control.CodeOutputElementSettings);
@@ -415,7 +416,7 @@ public class MainCodeOutputPlugin : PluginBase
 
             _guiCommands.ShowMessage(message);
         }
-        else if (SelectedState.Self.SelectedElement != null)
+        else if (_selectedState.SelectedElement != null)
         {
             if(viewModel.IsAllInProjectGenerating)
             {
@@ -439,7 +440,7 @@ public class MainCodeOutputPlugin : PluginBase
             }
             else
             {
-                GenerateCodeForElement(showPopups:true, SelectedState.Self.SelectedElement);
+                GenerateCodeForElement(showPopups:true, _selectedState.SelectedElement);
             }
         }
     }
@@ -463,7 +464,7 @@ public class MainCodeOutputPlugin : PluginBase
 
     private void GenerateCodeForSelectedElement(bool showPopups)
     {
-        var selectedElement = SelectedState.Self.SelectedElement;
+        var selectedElement = _selectedState.SelectedElement;
         GenerateCodeForElement(showPopups, selectedElement);
     }
 

--- a/CodeOutputPlugin/Manager/ParentSetLogic.cs
+++ b/CodeOutputPlugin/Manager/ParentSetLogic.cs
@@ -8,15 +8,18 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using GumCommon;
 using ToolsUtilities;
 
 namespace CodeOutputPlugin.Manager
 {
     public static class ParentSetLogic
     {
+        private static readonly ISelectedState _selectedState = Locator.GetRequiredService<ISelectedState>();
+        
         public static void HandleVariableSet(ElementSave element, InstanceSave instance, string variableName, object oldValue, CodeOutputProjectSettings codeOutputProjectSettings)
         {
-            var currentState = SelectedState.Self.SelectedStateSave;
+            var currentState = _selectedState.SelectedStateSave;
             ///////////////////////Early Out//////////////////
             if(variableName != "Parent" || instance == null || currentState == null)
             {

--- a/Gum/CommandLine/CommandLineManager.cs
+++ b/Gum/CommandLine/CommandLineManager.cs
@@ -4,6 +4,7 @@ using Gum.Services;
 using System;
 using System.Linq;
 using System.Threading.Tasks;
+using GumCommon;
 using ToolsUtilities;
 
 namespace Gum.CommandLine
@@ -31,7 +32,7 @@ namespace Gum.CommandLine
 
         public CommandLineManager()
         {
-            _fontManager = Builder.Get<FontManager>();
+            _fontManager = Locator.GetRequiredService<FontManager>();
         }
 
         public async Task ReadCommandLine()

--- a/Gum/Commands/EditCommands.cs
+++ b/Gum/Commands/EditCommands.cs
@@ -17,12 +17,19 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Windows.Controls;
 using System.Windows.Forms;
+using GumCommon;
 using ToolsUtilities;
 
 namespace Gum.Commands
 {
     public class EditCommands
     {
+        private ISelectedState _selectedState;
+
+        public EditCommands()
+        {
+            _selectedState = Locator.GetRequiredService<ISelectedState>();
+        }
         #region State
 
         public void AskToDeleteState(StateSave stateSave, IStateContainer stateContainer)
@@ -104,7 +111,7 @@ namespace Gum.Commands
                 TextInputWindow tiw = new TextInputWindow();
                 tiw.Message = "Enter new state name";
                 tiw.Title = "Rename state";
-                tiw.Result = SelectedState.Self.SelectedStateSave.Name;
+                tiw.Result = _selectedState.SelectedStateSave.Name;
                 var result = tiw.ShowDialog();
 
                 if (result == DialogResult.OK)
@@ -150,7 +157,7 @@ namespace Gum.Commands
             newCategory.States.Add(stateToMove);
 
             GumCommands.Self.GuiCommands.RefreshStateTreeView();
-            SelectedState.Self.SelectedStateSave = stateToMove;
+            _selectedState.SelectedStateSave = stateToMove;
 
             // make sure to propagate all variables in this new state and
             // also move all existing variables to the new state (use the first)
@@ -216,7 +223,7 @@ namespace Gum.Commands
             if (element == null)
             {
                 // ... if we can't find it for some reason, assume it's the current element (is this bad?)
-                element = SelectedState.Self.SelectedElement;
+                element = _selectedState.SelectedElement;
             }
 
             var componentSave = element as ComponentSave;
@@ -296,7 +303,7 @@ namespace Gum.Commands
 
                     PluginManager.Self.BehaviorCreated(behavior);
 
-                    SelectedState.Self.SelectedBehavior = behavior;
+                    _selectedState.SelectedBehavior = behavior;
 
                     GumCommands.Self.FileCommands.TryAutoSaveProject();
                     GumCommands.Self.FileCommands.TryAutoSaveBehavior(behavior);
@@ -310,7 +317,7 @@ namespace Gum.Commands
 
         public void DuplicateSelectedElement()
         {
-            var element = SelectedState.Self.SelectedElement;
+            var element = _selectedState.SelectedElement;
 
             if (element == null)
             {
@@ -414,8 +421,8 @@ namespace Gum.Commands
 
         public void ShowCreateComponentFromInstancesDialog()
         {
-            var element = SelectedState.Self.SelectedElement;
-            var instances = SelectedState.Self.SelectedInstances.ToList();
+            var element = _selectedState.SelectedElement;
+            var instances = _selectedState.SelectedInstances.ToList();
             if (instances == null || instances.Count == 0 || element == null)
             {
                 MessageBox.Show("You must first save the project before adding a new component");
@@ -525,11 +532,11 @@ namespace Gum.Commands
 
                     if (selectedItem is InstanceSave instance)
                     {
-                        SelectedState.Self.SelectedInstance = instance;
+                        _selectedState.SelectedInstance = instance;
                     }
                     else if (selectedItem is ElementSave selectedElement)
                     {
-                        SelectedState.Self.SelectedElement = selectedElement;
+                        _selectedState.SelectedElement = selectedElement;
                     }
                     else if (selectedItem is VariableSave variable)
                     {
@@ -547,7 +554,7 @@ namespace Gum.Commands
 
                             if (instanceWithVariable != null)
                             {
-                                SelectedState.Self.SelectedInstance = instanceWithVariable;
+                                _selectedState.SelectedInstance = instanceWithVariable;
                             }
                         }
                     }
@@ -559,7 +566,7 @@ namespace Gum.Commands
                         {
                             if (string.IsNullOrEmpty(variableListSave.SourceObject))
                             {
-                                SelectedState.Self.SelectedElement = foundElement;
+                                _selectedState.SelectedElement = foundElement;
                             }
                             else
                             {
@@ -567,7 +574,7 @@ namespace Gum.Commands
 
                                 if (instanceWithVariable != null)
                                 {
-                                    SelectedState.Self.SelectedInstance = instanceWithVariable;
+                                    _selectedState.SelectedInstance = instanceWithVariable;
                                 }
                             }
                         }

--- a/Gum/Commands/EditCommands.cs
+++ b/Gum/Commands/EditCommands.cs
@@ -166,7 +166,7 @@ namespace Gum.Commands
                 foreach (var variable in stateToMove.Variables)
                 {
                     VariableInCategoryPropagationLogic.Self.PropagateVariablesInCategory(variable.Name,
-                        element, GumState.Self.SelectedState.SelectedStateCategorySave);
+                        element, _selectedState.SelectedStateCategorySave);
                 }
 
 
@@ -176,7 +176,7 @@ namespace Gum.Commands
                     foreach (var variable in firstState.Variables)
                     {
                         VariableInCategoryPropagationLogic.Self.PropagateVariablesInCategory(variable.Name,
-                            element, GumState.Self.SelectedState.SelectedStateCategorySave);
+                            element, _selectedState.SelectedStateCategorySave);
                     }
                 }
             }

--- a/Gum/Commands/FileCommands.cs
+++ b/Gum/Commands/FileCommands.cs
@@ -9,13 +9,22 @@ using Gum.Undo;
 using Gum.Plugins;
 using ToolsUtilities;
 using Gum.Logic.FileWatch;
+using GumCommon;
 
 namespace Gum.Commands
 {
     public class FileCommands
     {
         private LocalizationManager _localizationManager;
+        private readonly ISelectedState _selectedState;
+        
         MainWindow mainWindow;
+
+        public FileCommands()
+        {
+            _selectedState = Locator.GetRequiredService<ISelectedState>();
+        }
+        
         public void Initialize(MainWindow mainWindow, LocalizationManager localizationManager)
         {
             _localizationManager = localizationManager;
@@ -27,9 +36,9 @@ namespace Gum.Commands
         /// </summary>
         public void TryAutoSaveCurrentObject()
         {
-            if(SelectedState.Self.SelectedBehavior != null)
+            if(_selectedState.SelectedBehavior != null)
             {
-                TryAutoSaveBehavior(SelectedState.Self.SelectedBehavior);
+                TryAutoSaveBehavior(_selectedState.SelectedBehavior);
             }
             else
             {
@@ -39,7 +48,7 @@ namespace Gum.Commands
 
         public void TryAutoSaveCurrentElement()
         {
-            TryAutoSaveElement(SelectedState.Self.SelectedElement);
+            TryAutoSaveElement(_selectedState.SelectedElement);
         }
 
 
@@ -76,11 +85,11 @@ namespace Gum.Commands
 
         internal void NewProject()
         {
-            SelectedState.Self.SelectedElement = null;
-            SelectedState.Self.SelectedInstance = null;
-            SelectedState.Self.SelectedBehavior = null;
-            SelectedState.Self.SelectedStateCategorySave = null;
-            SelectedState.Self.SelectedStateSave = null;
+            _selectedState.SelectedElement = null;
+            _selectedState.SelectedInstance = null;
+            _selectedState.SelectedBehavior = null;
+            _selectedState.SelectedStateCategorySave = null;
+            _selectedState.SelectedStateSave = null;
 
             ProjectManager.Self.CreateNewProject();
 

--- a/Gum/Commands/GuiCommands.cs
+++ b/Gum/Commands/GuiCommands.cs
@@ -26,6 +26,7 @@ using Microsoft.Extensions.Hosting;
 using Gum.Services;
 using Microsoft.Extensions.DependencyInjection;
 using System.Windows.Media;
+using GumCommon;
 
 namespace Gum.Commands
 {
@@ -40,11 +41,13 @@ namespace Gum.Commands
 
         MainPanelControl mainPanelControl;
 
+        private readonly ISelectedState _selectedState;
+
         #endregion
 
         public GuiCommands()
         {
-
+            _selectedState = Locator.GetRequiredService<ISelectedState>();
         }
 
         internal void Initialize(MainWindow mainWindow, MainPanelControl mainPanelControl)
@@ -56,13 +59,13 @@ namespace Gum.Commands
         internal void BroadcastRefreshBehaviorView()
         {
             PluginManager.Self.RefreshBehaviorView(
-                SelectedState.Self.SelectedElement);
+                _selectedState.SelectedElement);
         }
 
         internal void BroadcastBehaviorReferencesChanged()
         {
             PluginManager.Self.BehaviorReferencesChanged(
-                SelectedState.Self.SelectedElement);
+                _selectedState.SelectedElement);
         }
 
         #region Refresh Commands
@@ -320,7 +323,7 @@ namespace Gum.Commands
         #region Show Add XXX Widows
         public void ShowAddVariableWindow()
         {
-            var canShow = SelectedState.Self.SelectedBehavior != null || SelectedState.Self.SelectedElement != null;
+            var canShow = _selectedState.SelectedBehavior != null || _selectedState.SelectedElement != null;
 
             /////////////// Early Out///////////////
             if (!canShow)
@@ -328,12 +331,9 @@ namespace Gum.Commands
                 return;
             }
             //////////////End Early Out/////////////
-            var host = Builder.App;
-            var services = host.Services;
-
-            var vm = services.GetRequiredService<AddVariableViewModel>();
+            var vm = Locator.GetRequiredService<AddVariableViewModel>();
             vm.RenameType = RenameType.NormalName;
-            vm.Element = SelectedState.Self.SelectedElement;
+            vm.Element = _selectedState.SelectedElement;
             vm.Variable = null;
 
             var window = new AddVariableWindow(vm);
@@ -349,7 +349,7 @@ namespace Gum.Commands
         public void ShowAddCategoryWindow()
         {
 
-            var target = SelectedState.Self.SelectedStateContainer;
+            var target = _selectedState.SelectedStateContainer;
             if (target == null)
             {
                 MessageBox.Show("You must first select an element or behavior to add a state category");
@@ -395,7 +395,7 @@ namespace Gum.Commands
                     StateSaveCategory category = ElementCommands.Self.AddCategory(
                         target, name);
 
-                    SelectedState.Self.SelectedStateCategorySave = category;
+                    _selectedState.SelectedStateCategorySave = category;
                 }
             }
 
@@ -403,7 +403,7 @@ namespace Gum.Commands
 
         public void ShowAddStateWindow()
         {
-            if (SelectedState.Self.SelectedStateCategorySave == null && SelectedState.Self.SelectedElement == null)
+            if (_selectedState.SelectedStateCategorySave == null && _selectedState.SelectedElement == null)
             {
                 MessageBox.Show("You must first select an element or a behavior category to add a state");
             }
@@ -417,7 +417,7 @@ namespace Gum.Commands
                 {
                     string name = tiw.Result;
 
-                    if (!NameVerifier.Self.IsStateNameValid(name, SelectedState.Self.SelectedStateCategorySave, null, out string whyNotValid))
+                    if (!NameVerifier.Self.IsStateNameValid(name, _selectedState.SelectedStateCategorySave, null, out string whyNotValid))
                     {
                         GumCommands.Self.GuiCommands.ShowMessage(whyNotValid);
                     }
@@ -426,10 +426,10 @@ namespace Gum.Commands
                         using (UndoManager.Self.RequestLock())
                         {
                             StateSave stateSave = ElementCommands.Self.AddState(
-                                SelectedState.Self.SelectedStateContainer, SelectedState.Self.SelectedStateCategorySave, name);
+                                _selectedState.SelectedStateContainer, _selectedState.SelectedStateCategorySave, name);
 
 
-                            SelectedState.Self.SelectedStateSave = stateSave;
+                            _selectedState.SelectedStateSave = stateSave;
 
                         }
                     }

--- a/Gum/Controls/ToggleButtonOptionContainer.cs
+++ b/Gum/Controls/ToggleButtonOptionContainer.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Reflection;
 using System.Windows.Controls;
 using System.Windows.Media.Imaging;
+using GumCommon;
 using WpfDataUi;
 using WpfDataUi.Controls;
 using WpfDataUi.DataTypes;
@@ -108,17 +109,19 @@ namespace Gum.Controls
 
         protected static StandardElementSave GetRootElement()
         {
+            ISelectedState selectedState = Locator.GetRequiredService<ISelectedState>();
+            
             StandardElementSave rootElement = null;
 
-            if (SelectedState.Self.SelectedInstance != null)
+            if (selectedState.SelectedInstance != null)
             {
                 rootElement =
-                    ObjectFinder.Self.GetRootStandardElementSave(SelectedState.Self.SelectedInstance);
+                    ObjectFinder.Self.GetRootStandardElementSave(selectedState.SelectedInstance);
             }
-            else if (SelectedState.Self.SelectedElement != null)
+            else if (selectedState.SelectedElement != null)
             {
                 rootElement =
-                    ObjectFinder.Self.GetRootStandardElementSave(SelectedState.Self.SelectedElement);
+                    ObjectFinder.Self.GetRootStandardElementSave(selectedState.SelectedElement);
             }
 
             return rootElement;

--- a/Gum/Controls/WidthUnitsControl.cs
+++ b/Gum/Controls/WidthUnitsControl.cs
@@ -3,6 +3,7 @@ using Gum.Managers;
 using Gum.ToolStates;
 using System.Collections.Generic;
 using System.Linq;
+using GumCommon;
 using static WpfDataUi.Controls.ToggleButtonOptionDisplay;
 
 namespace Gum.Controls
@@ -52,17 +53,19 @@ namespace Gum.Controls
 
         private static StandardElementSave GetRootElement()
         {
+            ISelectedState selectedState = Locator.GetRequiredService<ISelectedState>();
+            
             StandardElementSave rootElement = null;
 
-            if (SelectedState.Self.SelectedInstance != null)
+            if (selectedState.SelectedInstance != null)
             {
                 rootElement =
-                    ObjectFinder.Self.GetRootStandardElementSave(SelectedState.Self.SelectedInstance);
+                    ObjectFinder.Self.GetRootStandardElementSave(selectedState.SelectedInstance);
             }
-            else if (SelectedState.Self.SelectedElement != null)
+            else if (selectedState.SelectedElement != null)
             {
                 rootElement =
-                    ObjectFinder.Self.GetRootStandardElementSave(SelectedState.Self.SelectedElement);
+                    ObjectFinder.Self.GetRootStandardElementSave(selectedState.SelectedElement);
             }
 
             return rootElement;

--- a/Gum/DataTypes/ElementSaveExtensionMethods.GumTool.cs
+++ b/Gum/DataTypes/ElementSaveExtensionMethods.GumTool.cs
@@ -6,12 +6,14 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using GumCommon;
 using ToolsUtilities;
 
 namespace Gum.DataTypes
 {
     public static class ElementSaveExtensionMethodsGumTool
     {
+        private static readonly ISelectedState _selectedState = Locator.GetRequiredService<ISelectedState>();
         public static FilePath GetFullPathXmlFile(this ElementSave elementSave)
         {
             return elementSave?.GetFullPathXmlFile(elementSave.Name);
@@ -79,11 +81,11 @@ namespace Gum.DataTypes
         {
             StateSave stateToPullFrom = element.DefaultState;
 
-            if (element == SelectedState.Self.SelectedElement &&
-                SelectedState.Self.SelectedStateSave != null &&
+            if (element == _selectedState.SelectedElement &&
+                _selectedState.SelectedStateSave != null &&
                 !forceDefault)
             {
-                stateToPullFrom = SelectedState.Self.SelectedStateSave;
+                stateToPullFrom = _selectedState.SelectedStateSave;
             }
 
             return stateToPullFrom.GetVariableRecursive(variable);
@@ -93,11 +95,11 @@ namespace Gum.DataTypes
         {
             var stateToPullFrom = element.DefaultState;
 
-            if (element == SelectedState.Self.SelectedElement &&
-                SelectedState.Self.SelectedStateSave != null &&
+            if (element == _selectedState.SelectedElement &&
+                _selectedState.SelectedStateSave != null &&
                 !forceDefault)
             {
-                stateToPullFrom = SelectedState.Self.SelectedStateSave;
+                stateToPullFrom = _selectedState.SelectedStateSave;
             }
 
             return stateToPullFrom.GetVariableListRecursive(variable);
@@ -111,11 +113,11 @@ namespace Gum.DataTypes
         {
             StateSave stateToPullFrom = element.DefaultState;
 
-            if (element == SelectedState.Self.SelectedElement &&
-                SelectedState.Self.SelectedStateSave != null &&
+            if (element == _selectedState.SelectedElement &&
+                _selectedState.SelectedStateSave != null &&
                 !forceDefault)
             {
-                stateToPullFrom = SelectedState.Self.SelectedStateSave;
+                stateToPullFrom = _selectedState.SelectedStateSave;
             }
 
             VariableSave variableSave = stateToPullFrom.GetVariableRecursive(variable);

--- a/Gum/Logic/CopyPasteLogic.cs
+++ b/Gum/Logic/CopyPasteLogic.cs
@@ -86,11 +86,11 @@ public class CopyPasteLogic : Singleton<CopyPasteLogic>
 
         if (copyType == CopyType.InstanceOrElement)
         {
-            if (ProjectState.Self.Selected.SelectedInstances.Count() != 0)
+            if (_selectedState.SelectedInstances.Count() != 0)
             {
                 StoreCopiedInstances();
             }
-            else if (ProjectState.Self.Selected.SelectedElement != null)
+            else if (_selectedState.SelectedElement != null)
             {
                 StoreCopiedElementSave();
             }

--- a/Gum/Logic/CopyPasteLogic.cs
+++ b/Gum/Logic/CopyPasteLogic.cs
@@ -8,6 +8,7 @@ using Gum.Wireframe;
 using System.Collections.Generic;
 using System.Linq;
 using System.Windows;
+using GumCommon;
 using ToolsUtilities;
 
 namespace Gum.Logic;
@@ -46,6 +47,8 @@ public class CopyPasteLogic : Singleton<CopyPasteLogic>
 {
     #region Fields/Properties
 
+    private readonly ISelectedState _selectedState;
+    
     public CopiedData CopiedData { get; private set; } = new CopiedData();
 
     CopyType mCopyType;
@@ -61,6 +64,11 @@ public class CopyPasteLogic : Singleton<CopyPasteLogic>
     List<InstanceSave> LastPastedInstances = new List<InstanceSave>();
 
     #endregion
+
+    public CopyPasteLogic()
+    {
+        _selectedState = Locator.GetRequiredService<ISelectedState>();
+    }
 
     #region Copy
     public void OnCopy(CopyType copyType)
@@ -95,20 +103,20 @@ public class CopyPasteLogic : Singleton<CopyPasteLogic>
 
     private void StoreCopiedState()
     {
-        if (SelectedState.Self.SelectedStateSave != null)
+        if (_selectedState.SelectedStateSave != null)
         {
             CopiedData.CopiedStates.Clear();
-            CopiedData.CopiedStates.Add(SelectedState.Self.SelectedStateSave.Clone());
+            CopiedData.CopiedStates.Add(_selectedState.SelectedStateSave.Clone());
         }
     }
 
     private void StoreCopiedInstances()
     {
-        if (SelectedState.Self.SelectedInstance != null)
+        if (_selectedState.SelectedInstance != null)
         {
-            var element = SelectedState.Self.SelectedElement;
+            var element = _selectedState.SelectedElement;
 
-            var state = SelectedState.Self.SelectedStateSave;
+            var state = _selectedState.SelectedStateSave;
 
             // a state may not be selected if the user selected a category.
             if(state == null)
@@ -130,7 +138,7 @@ public class CopyPasteLogic : Singleton<CopyPasteLogic>
                 CopiedData.CopiedStates.Add(state.Clone());
             }
 
-            if(SelectedState.Self.SelectedStateCategorySave != null && SelectedState.Self.SelectedStateSave != null && element != null)
+            if(_selectedState.SelectedStateCategorySave != null && _selectedState.SelectedStateSave != null && element != null)
             {
                 // it's categorized, so add the default:
                 CopiedData.CopiedStates.Add(element.DefaultState.Clone());
@@ -139,10 +147,10 @@ public class CopyPasteLogic : Singleton<CopyPasteLogic>
             List<InstanceSave> selected = new List<InstanceSave>();
             // When copying we want to grab all instances in the order that they are in their container.
             // That way when they're pasted they are pasted in the right order
-            selected.AddRange(SelectedState.Self.SelectedInstances);
+            selected.AddRange(_selectedState.SelectedInstances);
 
             CopiedData.CopiedInstancesSelected.Clear();
-            CopiedData.CopiedInstancesSelected.AddRange(SelectedState.Self.SelectedInstances);
+            CopiedData.CopiedInstancesSelected.AddRange(_selectedState.SelectedInstances);
 
             var parentContainer = selected.FirstOrDefault()?.ParentContainer;
             if(parentContainer != null)
@@ -189,15 +197,15 @@ public class CopyPasteLogic : Singleton<CopyPasteLogic>
 
     private void StoreCopiedElementSave()
     {
-        if (SelectedState.Self.SelectedElement != null)
+        if (_selectedState.SelectedElement != null)
         {
-            if (SelectedState.Self.SelectedElement is ScreenSave)
+            if (_selectedState.SelectedElement is ScreenSave)
             {
-                CopiedData.CopiedElement = ((ScreenSave)SelectedState.Self.SelectedElement).Clone();
+                CopiedData.CopiedElement = ((ScreenSave)_selectedState.SelectedElement).Clone();
             }
-            else if (SelectedState.Self.SelectedElement is ComponentSave)
+            else if (_selectedState.SelectedElement is ComponentSave)
             {
-                CopiedData.CopiedElement = ((ComponentSave)SelectedState.Self.SelectedElement).Clone();
+                CopiedData.CopiedElement = ((ComponentSave)_selectedState.SelectedElement).Clone();
             }
         }
     }
@@ -208,7 +216,7 @@ public class CopyPasteLogic : Singleton<CopyPasteLogic>
     {
         StoreCopiedObject(copyType);
 
-        ElementSave sourceElement = SelectedState.Self.SelectedElement;
+        ElementSave sourceElement = _selectedState.SelectedElement;
 
         if(CopiedData.CopiedInstancesRecursive.Any())
         {
@@ -264,7 +272,7 @@ public class CopyPasteLogic : Singleton<CopyPasteLogic>
 
     private void PasteCopiedInstanceSaves(TopOrRecursive topOrRecursive)
     {
-        var element = SelectedState.Self.SelectedElement;
+        var element = _selectedState.SelectedElement;
 
         if(element == null)
         {
@@ -272,18 +280,18 @@ public class CopyPasteLogic : Singleton<CopyPasteLogic>
         }
         else if(topOrRecursive == TopOrRecursive.Recursive)
         {
-            PasteInstanceSaves(CopiedData.CopiedInstancesRecursive, CopiedData.CopiedStates, SelectedState.Self.SelectedElement, SelectedState.Self.SelectedInstance);
+            PasteInstanceSaves(CopiedData.CopiedInstancesRecursive, CopiedData.CopiedStates, _selectedState.SelectedElement, _selectedState.SelectedInstance);
         }
         else
         {
-            PasteInstanceSaves(CopiedData.CopiedInstancesSelected, CopiedData.CopiedStates, SelectedState.Self.SelectedElement, SelectedState.Self.SelectedInstance);
+            PasteInstanceSaves(CopiedData.CopiedInstancesSelected, CopiedData.CopiedStates, _selectedState.SelectedElement, _selectedState.SelectedInstance);
         }
     }
 
     private void PastedCopiedState()
     {
-        ElementSave container = SelectedState.Self.SelectedElement;
-        var targetCategory = SelectedState.Self.SelectedStateCategorySave;
+        ElementSave container = _selectedState.SelectedElement;
+        var targetCategory = _selectedState.SelectedStateCategorySave;
 
         /////////////////////Early Out//////////////////
         if (container == null)
@@ -320,8 +328,8 @@ public class CopyPasteLogic : Singleton<CopyPasteLogic>
 
 
 
-        //SelectedState.Self.SelectedInstance = targetInstance;
-        SelectedState.Self.SelectedStateSave = newStateSave;
+        //_selectedState.SelectedInstance = targetInstance;
+        _selectedState.SelectedStateSave = newStateSave;
 
         GumCommands.Self.FileCommands.TryAutoSaveElement(container);
     }
@@ -431,7 +439,7 @@ public class CopyPasteLogic : Singleton<CopyPasteLogic>
 
             if(selectedInstance != null)
             {
-                var childName = ObjectFinder.Self.GetDefaultChildName(selectedInstance, SelectedState.Self.SelectedStateSave);
+                var childName = ObjectFinder.Self.GetDefaultChildName(selectedInstance, _selectedState.SelectedStateSave);
 
                 if(!string.IsNullOrEmpty(childName))
                 {
@@ -459,11 +467,11 @@ public class CopyPasteLogic : Singleton<CopyPasteLogic>
                     }
                     else
                     {
-                        var selectedElement = SelectedState.Self.SelectedElement;
+                        var selectedElement = _selectedState.SelectedElement;
 
                         targetState = selectedElement.AllStates.FirstOrDefault(item => item.Name == stateSave.Name) ?? 
-                            SelectedState.Self.SelectedElement.DefaultState;
-                            //SelectedState.Self.SelectedStateSave ?? SelectedState.Self.SelectedElement.DefaultState;
+                            _selectedState.SelectedElement.DefaultState;
+                            //_selectedState.SelectedStateSave ?? _selectedState.SelectedElement.DefaultState;
 
                     }
 
@@ -567,7 +575,7 @@ public class CopyPasteLogic : Singleton<CopyPasteLogic>
         WireframeObjectManager.Self.RefreshAll(true);
         GumCommands.Self.GuiCommands.RefreshElementTreeView(targetElement);
         GumCommands.Self.FileCommands.TryAutoSaveElement(targetElement);
-        SelectedState.Self.SelectedInstances = newInstances;
+        _selectedState.SelectedInstances = newInstances;
 
         LastPastedInstances.Clear();
         LastPastedInstances.AddRange(newInstances);
@@ -593,7 +601,7 @@ public class CopyPasteLogic : Singleton<CopyPasteLogic>
 
         var strippedName = toAdd.StrippedName;
 
-        var selectedNode = SelectedState.Self.SelectedTreeNode;
+        var selectedNode = _selectedState.SelectedTreeNode;
 
         if(toAdd is ScreenSave && selectedNode.IsScreensFolderTreeNode())
         {
@@ -630,7 +638,7 @@ public class CopyPasteLogic : Singleton<CopyPasteLogic>
 
         GumCommands.Self.GuiCommands.RefreshElementTreeView();
 
-        SelectedState.Self.SelectedElement = toAdd;
+        _selectedState.SelectedElement = toAdd;
 
         PluginManager.Self.ElementDuplicate(CopiedData.CopiedElement, toAdd);
 

--- a/Gum/Logic/RenameLogic.cs
+++ b/Gum/Logic/RenameLogic.cs
@@ -12,6 +12,7 @@ using CommonFormsAndControls;
 using Gum.Controls;
 using System.Drawing;
 using System.Windows.Documents.DocumentStructures;
+using GumCommon;
 using ToolsUtilities;
 
 namespace Gum.Logic;
@@ -63,6 +64,13 @@ public class VariableChangeResponse
 public class RenameLogic
 {
     static bool isRenamingXmlFile;
+
+    private readonly ISelectedState _selectedState;
+
+    public RenameLogic()
+    {
+        _selectedState = Locator.GetRequiredService<ISelectedState>();
+    }
 
     #region StateSave
 
@@ -382,6 +390,7 @@ public class RenameLogic
 
     private static void RenameAllReferencesTo(ElementSave elementSave, InstanceSave instance, string oldName)
     {
+        ISelectedState selectedState = Locator.GetRequiredService<ISelectedState>();
         var project = ProjectManager.Self.GumProjectSave;
         // Tell the GumProjectSave to react to the rename.
         // This changes the names of the ElementSave references.
@@ -464,14 +473,14 @@ public class RenameLogic
         {
             string newName = instance.Name;
 
-            if (SelectedState.Self.SelectedElement != null)
+            if (selectedState.SelectedElement != null)
             {
-                foreach (StateSave stateSave in SelectedState.Self.SelectedElement.AllStates)
+                foreach (StateSave stateSave in selectedState.SelectedElement.AllStates)
                 {
                     stateSave.ReactToInstanceNameChange(instance, oldName, newName);
                 }
 
-                foreach (var eventSave in SelectedState.Self.SelectedElement.Events)
+                foreach (var eventSave in selectedState.SelectedElement.Events)
                 {
                     if (eventSave.GetSourceObject() == oldName)
                     {
@@ -480,7 +489,7 @@ public class RenameLogic
                 }
 
                 var renamedDefaultChildContainer = false;
-                foreach (var state in SelectedState.Self.SelectedElement.AllStates)
+                foreach (var state in selectedState.SelectedElement.AllStates)
                 {
                     var variable = state.Variables.FirstOrDefault(item => item.Name == nameof(ComponentSave.DefaultChildContainer));
 

--- a/Gum/Logic/ReorderLogic.cs
+++ b/Gum/Logic/ReorderLogic.cs
@@ -4,15 +4,23 @@ using Gum.Plugins;
 using Gum.ToolStates;
 using Gum.Undo;
 using Gum.Wireframe;
+using GumCommon;
 
 namespace Gum.Logic
 {
     public class ReorderLogic : Singleton<ReorderLogic>
     {
+        private ISelectedState _selectedState;
+
+        public ReorderLogic()
+        {
+            _selectedState = Locator.GetRequiredService<ISelectedState>();
+        }
+        
         public void MoveSelectedInstanceForward()
         {
-            var instance = SelectedState.Self.SelectedInstance;
-            var element = SelectedState.Self.SelectedElement;
+            var instance = _selectedState.SelectedInstance;
+            var element = _selectedState.SelectedElement;
 
             if (instance != null)
             {
@@ -41,8 +49,8 @@ namespace Gum.Logic
 
         public void MoveSelectedInstanceBackward()
         {
-            var instance = SelectedState.Self.SelectedInstance;
-            var element = SelectedState.Self.SelectedElement;
+            var instance = _selectedState.SelectedInstance;
+            var element = _selectedState.SelectedElement;
 
             if (instance != null)
             {
@@ -71,8 +79,8 @@ namespace Gum.Logic
 
         public void MoveSelectedInstanceToFront()
         {
-            InstanceSave instance = SelectedState.Self.SelectedInstance;
-            ElementSave element = SelectedState.Self.SelectedElement;
+            InstanceSave instance = _selectedState.SelectedInstance;
+            ElementSave element = _selectedState.SelectedElement;
 
             if (instance != null)
             {
@@ -90,8 +98,8 @@ namespace Gum.Logic
 
         public void MoveSelectedInstanceToBack()
         {
-            InstanceSave instance = SelectedState.Self.SelectedInstance;
-            ElementSave element = SelectedState.Self.SelectedElement;
+            InstanceSave instance = _selectedState.SelectedInstance;
+            ElementSave element = _selectedState.SelectedElement;
 
             if (instance != null)
             {
@@ -109,8 +117,8 @@ namespace Gum.Logic
 
         public void MoveSelectedInstanceInFrontOf(InstanceSave whatToMoveInFrontOf)
         {
-            var element = SelectedState.Self.SelectedElement;
-            var whatToInsert = SelectedState.Self.SelectedInstance;
+            var element = _selectedState.SelectedElement;
+            var whatToInsert = _selectedState.SelectedInstance;
             if (whatToInsert != null)
             {
                 using (UndoManager.Self.RequestLock())
@@ -128,7 +136,7 @@ namespace Gum.Logic
         }
         private void RefreshInResponseToReorder(InstanceSave instance)
         {
-            var element = SelectedState.Self.SelectedElement;
+            var element = _selectedState.SelectedElement;
 
             GumCommands.Self.GuiCommands.RefreshElementTreeView(element);
 

--- a/Gum/Logic/VariableSaveLogic.cs
+++ b/Gum/Logic/VariableSaveLogic.cs
@@ -76,7 +76,7 @@ namespace Gum.Logic
 
                     var elementWithState = new ElementWithState(container);
                     elementWithState.InstanceName = currentInstance?.Name;
-                    elementWithState.StateName = GumState.Self.SelectedState.SelectedStateSave?.Name;
+                    elementWithState.StateName = _selectedState.SelectedStateSave?.Name;
                     var stack = new List<ElementWithState>() { elementWithState };
 
                     // Pass in the current instance so that everything is relative to that and the checks don't have to prefix anything

--- a/Gum/Logic/VariableSaveLogic.cs
+++ b/Gum/Logic/VariableSaveLogic.cs
@@ -6,11 +6,14 @@ using Gum.ToolStates;
 using Gum.Wireframe;
 using System.Collections.Generic;
 using System.Linq;
+using GumCommon;
 
 namespace Gum.Logic
 {
     public static class VariableSaveLogic
     {
+        private static readonly ISelectedState _selectedState = Locator.GetRequiredService<ISelectedState>();
+        
         public static bool GetIfVariableIsActive(VariableSave defaultVariable, ElementSave container, InstanceSave currentInstance)
         {
             bool shouldInclude = GetIfShouldIncludeAccordingToDefaultState(defaultVariable, container, currentInstance);
@@ -112,7 +115,7 @@ namespace Gum.Logic
             }
             bool shouldInclude = true;
 
-            bool isDefault = SelectedState.Self.SelectedStateSave == SelectedState.Self.SelectedElement.DefaultState;
+            bool isDefault = _selectedState.SelectedStateSave == _selectedState.SelectedElement.DefaultState;
 
             if (currentInstance != null)
             {
@@ -131,7 +134,7 @@ namespace Gum.Logic
             bool toReturn = true;
             if (variableSave.Name == "Guide")
             {
-                if (currentInstance != null && SelectedState.Self.SelectedScreen == null)
+                if (currentInstance != null && _selectedState.SelectedScreen == null)
                 {
                     toReturn = false;
                 }
@@ -185,7 +188,7 @@ namespace Gum.Logic
             else
             {
 
-                shouldInclude = SelectedState.Self.SelectedInstance != null
+                shouldInclude = _selectedState.SelectedInstance != null
                     // VariableLists cannot be exposed (currently)
                     //|| !string.IsNullOrEmpty(variableList.ExposedAsName);
                     ;
@@ -261,7 +264,7 @@ namespace Gum.Logic
             else
             {
 
-                shouldInclude = SelectedState.Self.SelectedInstance != null || !string.IsNullOrEmpty(defaultVariable.ExposedAsName);
+                shouldInclude = _selectedState.SelectedInstance != null || !string.IsNullOrEmpty(defaultVariable.ExposedAsName);
             }
             return shouldInclude;
         }

--- a/Gum/MainWindow.cs
+++ b/Gum/MainWindow.cs
@@ -52,8 +52,7 @@ namespace Gum
             System.Diagnostics.PresentationTraceSources.DataBindingSource.Switch.Level =
                 System.Diagnostics.SourceLevels.Critical;
 #endif
-            var builder = new Builder();
-            builder.Build();
+            _ = GumBuilder.BuildGum();
 
             InitializeComponent();
 

--- a/Gum/MainWindow.cs
+++ b/Gum/MainWindow.cs
@@ -16,6 +16,7 @@ using Gum.Services;
 using Gum.Undo;
 using Gum.Logic;
 using Gum.Plugins.InternalPlugins.MenuStripPlugin;
+using GumCommon;
 using GumRuntime;
 
 namespace Gum
@@ -63,7 +64,7 @@ namespace Gum
 
 
             // Initialize before the StateView is created...
-            GumCommands.Self.Initialize(this, mainPanelControl, Builder.Get<LocalizationManager>());
+            GumCommands.Self.Initialize(this, mainPanelControl, Locator.GetRequiredService<LocalizationManager>());
 
             TypeManager.Self.Initialize();
 
@@ -85,7 +86,7 @@ namespace Gum
 
             // ProperGridManager before MenuStripManager. Why does it need to be initialized before MainMenuStripPlugin?
             // Is htere a way to move this to a plugin?
-            PropertyGridManager.Self.InitializeEarly(Builder.Get<LocalizationManager>());
+            PropertyGridManager.Self.InitializeEarly(Locator.GetRequiredService<LocalizationManager>());
 
             // bah we have to do this before initializing all plugins because we need the menu strip to exist:
             MainMenuStripPlugin.InitializeMenuStrip();
@@ -111,7 +112,7 @@ namespace Gum
             // does, then we need to make sure that the wireframe controls
             // are set up properly before that happens.
 
-            var localizationManager = Builder.Get<LocalizationManager>();
+            var localizationManager = Locator.GetRequiredService<LocalizationManager>();
             Wireframe.WireframeObjectManager.Self.Initialize(localizationManager);
 
             PluginManager.Self.XnaInitialized();

--- a/Gum/Managers/DeleteLogic.cs
+++ b/Gum/Managers/DeleteLogic.cs
@@ -14,6 +14,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Windows.Forms;
+using GumCommon;
 
 namespace Gum.Managers
 {
@@ -25,7 +26,7 @@ namespace Gum.Managers
         public DeleteLogic()
         {
             _projectCommands = ProjectCommands.Self;
-            _selectedState = SelectedState.Self;
+            _selectedState = Locator.GetRequiredService<ISelectedState>();
         }
 
 

--- a/Gum/Managers/DragDropManager.cs
+++ b/Gum/Managers/DragDropManager.cs
@@ -306,12 +306,12 @@ public class DragDropManager
             errorMessage = "The source file for " + target.Name + " is missing, so it cannot be edited";
         }
 
-        if(errorMessage == null && target == GumState.Self.SelectedState.SelectedElement)
+        if(errorMessage == null && target == _selectedState.SelectedElement)
         {
-            if(GumState.Self.SelectedState.SelectedStateSave != GumState.Self.SelectedState.SelectedElement.DefaultState)
+            if(_selectedState.SelectedStateSave != _selectedState.SelectedElement.DefaultState)
             {
                 errorMessage = $"Cannot add instances to " +
-                    $"{GumState.Self.SelectedState.SelectedElement} while the {GumState.Self.SelectedState.SelectedStateSave} " +
+                    $"{_selectedState.SelectedElement} while the {_selectedState.SelectedStateSave} " +
                     $"state is selected. Select the Default state first.";
             }
         }

--- a/Gum/Managers/DragDropManager.cs
+++ b/Gum/Managers/DragDropManager.cs
@@ -21,6 +21,7 @@ using Gum.DataTypes.Behaviors;
 using Gum.Undo;
 using Gum.Plugins;
 using Gum.Services;
+using GumCommon;
 
 namespace Gum.Managers;
 
@@ -50,7 +51,7 @@ public class DragDropManager
     public DragDropManager(CircularReferenceManager circularReferenceManager)
     {
         _circularReferenceManager = circularReferenceManager;
-        _selectedState = SelectedState.Self;
+        _selectedState = Locator.GetRequiredService<ISelectedState>();
         _elementCommands = ElementCommands.Self;
     }
 
@@ -382,7 +383,7 @@ public class DragDropManager
 
         _elementCommands.AddBehaviorTo(behavior, targetComponent);
 
-        if(targetComponent == SelectedState.Self.SelectedComponent)
+        if(targetComponent == _selectedState.SelectedComponent)
         {
             GumCommands.Self.GuiCommands.RefreshStateTreeView();
             GumCommands.Self.GuiCommands.BroadcastRefreshBehaviorView();
@@ -476,7 +477,7 @@ public class DragDropManager
             {
                 // setting the parent:
                 parentName = targetInstance.Name;
-                string defaultChild = ObjectFinder.Self.GetDefaultChildName(targetInstance, SelectedState.Self.SelectedStateSave);
+                string defaultChild = ObjectFinder.Self.GetDefaultChildName(targetInstance, _selectedState.SelectedStateSave);
 
                 if (!string.IsNullOrEmpty(defaultChild))
                 {
@@ -490,7 +491,7 @@ public class DragDropManager
                 parentName = null;
             }
             // Since the Parent property can only be set in the default state, we will
-            // set the Parent variable on that instead of the SelectedState.Self.SelectedStateSave
+            // set the Parent variable on that instead of the _selectedState.SelectedStateSave
             var stateToAssignOn = targetElementSave.DefaultState;
 
             // todo - this needs to request the lock for the particular element
@@ -604,9 +605,9 @@ public class DragDropManager
         // The selected nodes should contain the dragged item, but I don't know for 100% certain.
         // If not, then we'll just use the dragged item. If it does, then we'll also add all other
         // selected items:
-        if (SelectedState.Self.SelectedTreeNodes.Contains(mDraggedItem))
+        if (_selectedState.SelectedTreeNodes.Contains(mDraggedItem))
         {
-            var whatToAdd = SelectedState.Self.SelectedTreeNodes.Where(item => item != mDraggedItem && item != null && item.Tag != null);
+            var whatToAdd = _selectedState.SelectedTreeNodes.Where(item => item != mDraggedItem && item != null && item.Tag != null);
             treeNodesToDrop.AddRange(whatToAdd);
         }
 
@@ -671,9 +672,9 @@ public class DragDropManager
 
     private bool CanDrop()
     {
-        return SelectedState.Self.SelectedStandardElement == null &&    // Don't allow dropping on standard elements
-               SelectedState.Self.SelectedElement != null &&            // An element must be selected
-               SelectedState.Self.SelectedStateSave != null;            // A state must be selected
+        return _selectedState.SelectedStandardElement == null &&    // Don't allow dropping on standard elements
+               _selectedState.SelectedElement != null &&            // An element must be selected
+               _selectedState.SelectedStateSave != null;            // A state must be selected
     }
 
     public void HandleFileDragEnter(object sender, DragEventArgs e)
@@ -720,7 +721,7 @@ public class DragDropManager
 
     public void SetInstanceToPosition(float worldX, float worldY, InstanceSave instance)
     {
-        var component = SelectedState.Self.SelectedComponent;
+        var component = _selectedState.SelectedComponent;
 
         float xToSet = worldX;
         float yToSet = worldY;
@@ -750,18 +751,18 @@ public class DragDropManager
 
 
 
-        var instanceXUnits = (PositionUnitType)SelectedState.Self.SelectedStateSave.GetValueRecursive($"{instance.Name}.XUnits");
+        var instanceXUnits = (PositionUnitType)_selectedState.SelectedStateSave.GetValueRecursive($"{instance.Name}.XUnits");
         var asGeneralXUnitType = UnitConverter.ConvertToGeneralUnit(instanceXUnits);
         xToSet = UnitConverter.Self.ConvertXPosition(differenceX, GeneralUnitType.PixelsFromSmall, asGeneralXUnitType, containerWidth);
 
         var differenceY = worldY - containerTop;
-        var instanceYUnits = (PositionUnitType)SelectedState.Self.SelectedStateSave.GetValueRecursive($"{instance.Name}.YUnits");
+        var instanceYUnits = (PositionUnitType)_selectedState.SelectedStateSave.GetValueRecursive($"{instance.Name}.YUnits");
         var asGeneralYUnitType = UnitConverter.ConvertToGeneralUnit(instanceYUnits);
         yToSet = UnitConverter.Self.ConvertYPosition(differenceY, GeneralUnitType.PixelsFromSmall, asGeneralYUnitType, containerHeight);
 
 
-        SelectedState.Self.SelectedStateSave.SetValue(instance.Name + ".X", xToSet);
-        SelectedState.Self.SelectedStateSave.SetValue(instance.Name + ".Y", yToSet);
+        _selectedState.SelectedStateSave.SetValue(instance.Name + ".X", xToSet);
+        _selectedState.SelectedStateSave.SetValue(instance.Name + ".Y", yToSet);
     }
 
     #endregion

--- a/Gum/Managers/FileChangeReactionLogic.cs
+++ b/Gum/Managers/FileChangeReactionLogic.cs
@@ -3,12 +3,19 @@ using Gum.DataTypes.Behaviors;
 using Gum.Plugins;
 using Gum.ToolStates;
 using System.Linq;
+using GumCommon;
 using ToolsUtilities;
 
 namespace Gum.Managers
 {
     public class FileChangeReactionLogic : Singleton<FileChangeReactionLogic>
     {
+        private readonly ISelectedState _selectedState;
+        public FileChangeReactionLogic()
+        {
+            _selectedState = Locator.GetRequiredService<ISelectedState>();
+        }
+        
         public void ReactToFileChanged(FilePath file)
         {
             var extension = file.Extension;
@@ -91,7 +98,7 @@ namespace Gum.Managers
 
         private void ReactToImageFileChanged(FilePath file)
         {
-            var currentElement = SelectedState.Self.SelectedElement;
+            var currentElement = _selectedState.SelectedElement;
             string relativeDirectory = ProjectState.Self.ProjectDirectory;
 
             if (currentElement != null)
@@ -111,7 +118,7 @@ namespace Gum.Managers
 
         private void ReactToAnimationChainChanged(FilePath file)
         {
-            var currentElement = SelectedState.Self.SelectedElement;
+            var currentElement = _selectedState.SelectedElement;
             string relativeDirectory = ProjectState.Self.ProjectDirectory;
             if (currentElement != null)
             {
@@ -129,7 +136,7 @@ namespace Gum.Managers
 
         private void ReactToFontFileChanged(FilePath file)
         {
-            var currentElement = SelectedState.Self.SelectedElement;
+            var currentElement = _selectedState.SelectedElement;
             string relativeDirectory = ProjectState.Self.ProjectDirectory;
 
             if (currentElement != null)
@@ -152,7 +159,7 @@ namespace Gum.Managers
         {
             var element = ObjectFinder.Self.GetElementSave(file.StandardizedNoPathNoExtension);
 
-            var refreshingSelected = element == SelectedState.Self.SelectedElement;
+            var refreshingSelected = element == _selectedState.SelectedElement;
 
             if(element != null)
             {
@@ -177,7 +184,7 @@ namespace Gum.Managers
 
             bool shouldReloadWireframe = false;
 
-            var currentElement = SelectedState.Self.SelectedElement;
+            var currentElement = _selectedState.SelectedElement;
 
             if(currentElement != null)
             {
@@ -212,7 +219,7 @@ namespace Gum.Managers
             // It's somehow possible for behaviors with no name to make it in the project. let's tolerate it
                 item?.Name.ToLowerInvariant() == file.StandardizedNoPathNoExtension.ToLowerInvariant());
 
-            var refreshingSelected = behavior == SelectedState.Self.SelectedBehavior;
+            var refreshingSelected = behavior == _selectedState.SelectedBehavior;
 
             if (behavior != null)
             {

--- a/Gum/Managers/FileChangeReactionLogic.cs
+++ b/Gum/Managers/FileChangeReactionLogic.cs
@@ -80,7 +80,7 @@ namespace Gum.Managers
 
         private void ReactToProjectChanged(FilePath file)
         {
-            var currentElement = GumState.Self.SelectedState.SelectedElement;
+            var currentElement = _selectedState.SelectedElement;
             var elementName = currentElement?.Name;
 
             GumCommands.Self.FileCommands.LoadProject(file.Standardized);
@@ -91,7 +91,7 @@ namespace Gum.Managers
 
                 if(elementToSelect != null)
                 {
-                    GumState.Self.SelectedState.SelectedElement = elementToSelect;
+                    _selectedState.SelectedElement = elementToSelect;
                 }
             }
         }

--- a/Gum/Managers/HotkeyManager.cs
+++ b/Gum/Managers/HotkeyManager.cs
@@ -8,6 +8,7 @@ using Gum.ToolStates;
 using Gum.Wireframe;
 using System;
 using System.Windows.Forms;
+using GumCommon;
 
 namespace Gum.Managers;
 
@@ -182,12 +183,12 @@ public class HotkeyManager : Singleton<HotkeyManager>
     private readonly ISelectedState _selectedState;
 
     // If adding any new keys here, modify HotkeyViewModel
-
+    
     public HotkeyManager()
     {
         _copyPasteLogic = CopyPasteLogic.Self;
         _guiCommands = GumCommands.Self.GuiCommands;
-        _selectedState = SelectedState.Self;
+        _selectedState = Locator.GetRequiredService<ISelectedState>();
     }
 
     #region App Wide Keys
@@ -353,7 +354,7 @@ public class HotkeyManager : Singleton<HotkeyManager>
             {
                 elementToGoTo = ObjectFinder.Self.GetElementSave(_selectedState.SelectedInstance.BaseType);
             }
-            else if (!string.IsNullOrWhiteSpace(SelectedState.Self.SelectedElement?.BaseType))
+            else if (!string.IsNullOrWhiteSpace(_selectedState.SelectedElement?.BaseType))
             {
                 elementToGoTo = ObjectFinder.Self.GetElementSave(_selectedState.SelectedElement.BaseType);
             }

--- a/Gum/Managers/ProjectManager.cs
+++ b/Gum/Managers/ProjectManager.cs
@@ -20,6 +20,7 @@ using System.ComponentModel;
 using System.Management.Instrumentation;
 using Gum.ToolCommands;
 using System.Threading.Tasks;
+using GumCommon;
 
 namespace Gum
 {
@@ -32,6 +33,8 @@ namespace Gum
         static ProjectManager mSelf;
 
         bool mHaveErrorsOccurredLoadingProject = false;
+        
+        private readonly ISelectedState _selectedState;
 
         #endregion
 
@@ -77,7 +80,7 @@ namespace Gum
 
         private ProjectManager()
         {
-
+            _selectedState = Locator.GetRequiredService<ISelectedState>();
         }
 
         public void LoadSettings()
@@ -100,7 +103,7 @@ namespace Gum
 
                     if (!string.IsNullOrEmpty(CommandLineManager.Self.ElementName))
                     {
-                        SelectedState.Self.SelectedElement = ObjectFinder.Self.GetElementSave(CommandLineManager.Self.ElementName);
+                        _selectedState.SelectedElement = ObjectFinder.Self.GetElementSave(CommandLineManager.Self.ElementName);
                     }
                 }
                 else if (!isShift && !string.IsNullOrEmpty(GeneralSettingsFile.LastProject))
@@ -139,8 +142,8 @@ namespace Gum
             {
                 string fileName = openFileDialog.FileName;
 
-                SelectedState.Self.SelectedInstance = null;
-                SelectedState.Self.SelectedElement = null;
+                _selectedState.SelectedInstance = null;
+                _selectedState.SelectedElement = null;
 
                 GumCommands.Self.FileCommands.LoadProject(fileName);
 
@@ -242,11 +245,11 @@ namespace Gum
             }
 
             // Deselect everything
-            SelectedState.Self.SelectedElement = null;
-            SelectedState.Self.SelectedInstance = null;
-            SelectedState.Self.SelectedBehavior = null;
-            SelectedState.Self.SelectedStateCategorySave = null;
-            SelectedState.Self.SelectedStateSave = null;
+            _selectedState.SelectedElement = null;
+            _selectedState.SelectedInstance = null;
+            _selectedState.SelectedBehavior = null;
+            _selectedState.SelectedStateCategorySave = null;
+            _selectedState.SelectedStateSave = null;
 
 
             if (mGumProjectSave != null)

--- a/Gum/Plugins/Fonts/MainFontPlugin.cs
+++ b/Gum/Plugins/Fonts/MainFontPlugin.cs
@@ -7,6 +7,7 @@ using Gum.ToolStates;
 using System;
 using System.ComponentModel.Composition;
 using System.Threading.Tasks;
+using GumCommon;
 
 namespace Gum.Plugins.Fonts;
 
@@ -19,8 +20,8 @@ public class MainFontPlugin : InternalPlugin
 
     public MainFontPlugin()
     {
-        _guiCommands = Builder.Get<GuiCommands>();
-        _fontManager = Builder.Get<FontManager>();
+        _guiCommands = Locator.GetRequiredService<GuiCommands>();
+        _fontManager = Locator.GetRequiredService<FontManager>();
     }
 
     public override void StartUp()

--- a/Gum/Plugins/ImportPlugin/Manager/ImportLogic.cs
+++ b/Gum/Plugins/ImportPlugin/Manager/ImportLogic.cs
@@ -8,12 +8,14 @@ using System;
 using System.Drawing;
 using System.Linq;
 using System.Windows.Forms;
+using GumCommon;
 using ToolsUtilities;
 
 namespace Gum.Plugins.ImportPlugin.Manager;
 
 public static class ImportLogic
 {
+    private static readonly ISelectedState _selectedState = Locator.GetRequiredService<ISelectedState>();
     #region Screen
 
     internal static void ShowImportScreenUi()
@@ -88,7 +90,7 @@ public static class ImportLogic
             if(saveProject)
             {
                 GumCommands.Self.GuiCommands.RefreshElementTreeView();
-                SelectedState.Self.SelectedScreen = screenSave;
+                _selectedState.SelectedScreen = screenSave;
                 GumCommands.Self.FileCommands.TryAutoSaveProject();
             }
             GumCommands.Self.FileCommands.TryAutoSaveElement(screenSave);
@@ -156,7 +158,7 @@ public static class ImportLogic
         if (lastImportedComponent != null)
         {
             GumCommands.Self.GuiCommands.RefreshElementTreeView();
-            SelectedState.Self.SelectedComponent = lastImportedComponent;
+            _selectedState.SelectedComponent = lastImportedComponent;
             GumCommands.Self.FileCommands.TryAutoSaveProject();
         }
     }
@@ -217,7 +219,7 @@ public static class ImportLogic
             if(saveProject)
             {
                 GumCommands.Self.GuiCommands.RefreshElementTreeView();
-                SelectedState.Self.SelectedComponent = componentSave;
+                _selectedState.SelectedComponent = componentSave;
                 GumCommands.Self.FileCommands.TryAutoSaveProject();
             }
             GumCommands.Self.FileCommands.TryAutoSaveElement(componentSave);
@@ -286,7 +288,7 @@ public static class ImportLogic
         if (lastImportedBehavior != null)
         {
             GumCommands.Self.GuiCommands.RefreshElementTreeView();
-            SelectedState.Self.SelectedBehavior = lastImportedBehavior;
+            _selectedState.SelectedBehavior = lastImportedBehavior;
             GumCommands.Self.FileCommands.TryAutoSaveProject();
         }
     }
@@ -345,7 +347,7 @@ public static class ImportLogic
             if(saveProject)
             {
                 GumCommands.Self.GuiCommands.RefreshElementTreeView();
-                SelectedState.Self.SelectedBehavior = behaviorSave;
+                _selectedState.SelectedBehavior = behaviorSave;
                 GumCommands.Self.FileCommands.TryAutoSaveProject();
             }
 

--- a/Gum/Plugins/InternalPlugins/AlignmentButtons/AlignmentMainPlugin.cs
+++ b/Gum/Plugins/InternalPlugins/AlignmentButtons/AlignmentMainPlugin.cs
@@ -3,15 +3,23 @@ using Gum.Plugins.BaseClasses;
 using Gum.ToolStates;
 using System.ComponentModel.Composition;
 using System.Windows.Forms;
+using GumCommon;
 
 namespace Gum.Plugins.AlignmentButtons
 {
     [Export(typeof(PluginBase))]
     public class AlignmentMainPlugin : InternalPlugin
     {
+        private readonly ISelectedState _selectedState;
+        
         AlignmentPluginControl control;
         bool isAdded = false;
 
+        public AlignmentMainPlugin()
+        {
+            _selectedState = Locator.GetRequiredService<ISelectedState>();
+        }
+        
         public override void StartUp()
         {
             AssignEvents();
@@ -61,15 +69,15 @@ namespace Gum.Plugins.AlignmentButtons
             }
         }
 
-        private static bool DetermineIfShouldShowTab()
+        private bool DetermineIfShouldShowTab()
         {
-            var shouldAdd = SelectedState.Self.SelectedElement != null &&
-                SelectedState.Self.SelectedStateSave != null;
+            var shouldAdd = _selectedState.SelectedElement != null &&
+                _selectedState.SelectedStateSave != null;
 
             if (shouldAdd)
             {
-                if (SelectedState.Self.SelectedScreen != null &&
-                    SelectedState.Self.SelectedInstance == null)
+                if (_selectedState.SelectedScreen != null &&
+                    _selectedState.SelectedInstance == null)
                 {
                     // screens as a whole can't be aligned
                     shouldAdd = false;
@@ -77,9 +85,9 @@ namespace Gum.Plugins.AlignmentButtons
 
             }
 
-            if(shouldAdd && SelectedState.Self.SelectedInstance != null)
+            if(shouldAdd && _selectedState.SelectedInstance != null)
             {
-                var elementSave = ObjectFinder.Self.GetRootStandardElementSave(SelectedState.Self.SelectedInstance);
+                var elementSave = ObjectFinder.Self.GetRootStandardElementSave(_selectedState.SelectedInstance);
 
                 if(elementSave?.Name == "Circle")
                 {

--- a/Gum/Plugins/InternalPlugins/AlignmentButtons/AlignmentPluginControl.xaml.cs
+++ b/Gum/Plugins/InternalPlugins/AlignmentButtons/AlignmentPluginControl.xaml.cs
@@ -2,6 +2,7 @@
 using Gum.Services;
 using Gum.ToolStates;
 using System.Windows.Controls;
+using GumCommon;
 
 namespace Gum.Plugins.AlignmentButtons
 {
@@ -14,7 +15,7 @@ namespace Gum.Plugins.AlignmentButtons
         {
             InitializeComponent();
 
-            var selectedState = Builder.Get<ISelectedState>();
+            var selectedState = Locator.GetRequiredService<ISelectedState>();
 
             this.DataContext = new AlignmentViewModel(new CommonControlLogic(selectedState));
 

--- a/Gum/Plugins/InternalPlugins/AlignmentButtons/AnchorControl.xaml.cs
+++ b/Gum/Plugins/InternalPlugins/AlignmentButtons/AnchorControl.xaml.cs
@@ -4,6 +4,7 @@ using Gum.Plugins.InternalPlugins.AlignmentButtons.ViewModels;
 using Gum.ToolStates;
 using Gum.Undo;
 using System.Windows.Controls;
+using GumCommon;
 
 namespace Gum.Plugins.AlignmentButtons
 {
@@ -12,19 +13,21 @@ namespace Gum.Plugins.AlignmentButtons
     /// </summary>
     public partial class AnchorControl : UserControl
     {
+        private readonly ISelectedState _selectedState;
+        
         AlignmentViewModel ViewModel => (AlignmentViewModel)DataContext;
 
         StateSave CurrentState
         {
             get
             {
-                if(SelectedState.Self.SelectedStateSave != null)
+                if(_selectedState.SelectedStateSave != null)
                 {
-                    return SelectedState.Self.SelectedStateSave;
+                    return _selectedState.SelectedStateSave;
                 }
                 else
                 {
-                    return SelectedState.Self.SelectedElement?.DefaultState;
+                    return _selectedState.SelectedElement?.DefaultState;
                 }
             }
         }
@@ -32,6 +35,7 @@ namespace Gum.Plugins.AlignmentButtons
         public AnchorControl()
         {
             InitializeComponent();
+            _selectedState = Locator.GetRequiredService<ISelectedState>();
         }
 
         private void TopLeftButton_Click(object sender, System.Windows.RoutedEventArgs e)

--- a/Gum/Plugins/InternalPlugins/AlignmentButtons/ViewModels/AlignmentViewModel.cs
+++ b/Gum/Plugins/InternalPlugins/AlignmentButtons/ViewModels/AlignmentViewModel.cs
@@ -9,12 +9,14 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using GumCommon;
 
 namespace Gum.Plugins.InternalPlugins.AlignmentButtons.ViewModels;
 
 public class AlignmentViewModel : ViewModel
 {
     private readonly CommonControlLogic _commonControlLogic;
+    private readonly ISelectedState _selectedState;
 
     public float DockMargin
     {
@@ -25,6 +27,7 @@ public class AlignmentViewModel : ViewModel
     public AlignmentViewModel(CommonControlLogic commonControlLogic)
     {
         _commonControlLogic = commonControlLogic;
+        _selectedState = Locator.GetRequiredService<ISelectedState>();
     }
 
     #region Anchor Actions
@@ -189,7 +192,7 @@ public class AlignmentViewModel : ViewModel
     {
         using (UndoManager.Self.RequestLock())
         {
-            var state = SelectedState.Self.SelectedStateSave;
+            var state = _selectedState.SelectedStateSave;
 
             _commonControlLogic.SetXValues(global::RenderingLibrary.Graphics.HorizontalAlignment.Center, PositionUnitType.PixelsFromCenterX);
             _commonControlLogic.SetYValues(global::RenderingLibrary.Graphics.VerticalAlignment.Top, PositionUnitType.PixelsFromTop, DockMargin);
@@ -206,7 +209,7 @@ public class AlignmentViewModel : ViewModel
     {
         using (UndoManager.Self.RequestLock())
         {
-            var state = SelectedState.Self.SelectedStateSave;
+            var state = _selectedState.SelectedStateSave;
 
             _commonControlLogic.SetAndCallReact("Width", DockMargin * 2, "float");
             _commonControlLogic.SetAndCallReact("WidthUnits", DimensionUnitType.RelativeToChildren, typeof(DimensionUnitType).Name);
@@ -220,7 +223,7 @@ public class AlignmentViewModel : ViewModel
     {
         using (UndoManager.Self.RequestLock())
         {
-            var state = SelectedState.Self.SelectedStateSave;
+            var state = _selectedState.SelectedStateSave;
 
             _commonControlLogic.SetXValues(global::RenderingLibrary.Graphics.HorizontalAlignment.Left, PositionUnitType.PixelsFromLeft, DockMargin);
             _commonControlLogic.SetYValues(global::RenderingLibrary.Graphics.VerticalAlignment.Center, PositionUnitType.PixelsFromCenterY);
@@ -237,7 +240,7 @@ public class AlignmentViewModel : ViewModel
         using (UndoManager.Self.RequestLock())
         {
 
-            var state = SelectedState.Self.SelectedStateSave;
+            var state = _selectedState.SelectedStateSave;
 
             _commonControlLogic.SetXValues(global::RenderingLibrary.Graphics.HorizontalAlignment.Center, PositionUnitType.PixelsFromCenterX);
             _commonControlLogic.SetYValues(global::RenderingLibrary.Graphics.VerticalAlignment.Center, PositionUnitType.PixelsFromCenterY);
@@ -257,7 +260,7 @@ public class AlignmentViewModel : ViewModel
         using (UndoManager.Self.RequestLock())
         {
 
-            var state = SelectedState.Self.SelectedStateSave;
+            var state = _selectedState.SelectedStateSave;
 
             _commonControlLogic.SetXValues(global::RenderingLibrary.Graphics.HorizontalAlignment.Right, PositionUnitType.PixelsFromRight, -DockMargin);
             _commonControlLogic.SetYValues(global::RenderingLibrary.Graphics.VerticalAlignment.Center, PositionUnitType.PixelsFromCenterY);
@@ -273,7 +276,7 @@ public class AlignmentViewModel : ViewModel
     {
         using (UndoManager.Self.RequestLock())
         {
-            var state = SelectedState.Self.SelectedStateSave;
+            var state = _selectedState.SelectedStateSave;
 
             _commonControlLogic.SetXValues(global::RenderingLibrary.Graphics.HorizontalAlignment.Center, PositionUnitType.PixelsFromCenterX);
             _commonControlLogic.SetYValues(global::RenderingLibrary.Graphics.VerticalAlignment.Bottom, PositionUnitType.PixelsFromBottom, -DockMargin);
@@ -290,7 +293,7 @@ public class AlignmentViewModel : ViewModel
         using (UndoManager.Self.RequestLock())
         {
 
-            var state = SelectedState.Self.SelectedStateSave;
+            var state = _selectedState.SelectedStateSave;
 
             _commonControlLogic.SetYValues(global::RenderingLibrary.Graphics.VerticalAlignment.Center, PositionUnitType.PixelsFromCenterY);
 
@@ -306,7 +309,7 @@ public class AlignmentViewModel : ViewModel
         using (UndoManager.Self.RequestLock())
         {
 
-            var state = SelectedState.Self.SelectedStateSave;
+            var state = _selectedState.SelectedStateSave;
 
             _commonControlLogic.SetXValues(global::RenderingLibrary.Graphics.HorizontalAlignment.Center, PositionUnitType.PixelsFromCenterX);
 

--- a/Gum/Plugins/InternalPlugins/Behaviors/BehaviorsControl.xaml.cs
+++ b/Gum/Plugins/InternalPlugins/Behaviors/BehaviorsControl.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using Gum.ToolStates;
 using System.Windows;
 using System.Windows.Controls;
+using GumCommon;
 
 namespace Gum.Plugins.Behaviors
 {
@@ -9,6 +10,7 @@ namespace Gum.Plugins.Behaviors
     /// </summary>
     public partial class BehaviorsControl : UserControl
     {
+        private readonly ISelectedState _selectedState;
         BehaviorsViewModel ViewModel
         {
             get
@@ -19,11 +21,12 @@ namespace Gum.Plugins.Behaviors
         public BehaviorsControl()
         {
             InitializeComponent();
+            _selectedState = Locator.GetRequiredService<ISelectedState>();
         }
 
         private void HandleEditClick(object sender, RoutedEventArgs e)
         {
-            var component = GumState.Self.SelectedState.SelectedComponent;
+            var component = _selectedState.SelectedComponent;
             if(component != null)
             {
                 ViewModel.UpdateTo(component);

--- a/Gum/Plugins/InternalPlugins/Behaviors/MainBehaviorsPlugin.cs
+++ b/Gum/Plugins/InternalPlugins/Behaviors/MainBehaviorsPlugin.cs
@@ -62,7 +62,7 @@ public class MainBehaviorsPlugin : InternalPlugin
 
     private void HandleRefreshBehaviorView()
     {
-        HandleElementSelected(GumState.Self.SelectedState.SelectedElement);
+        HandleElementSelected(_selectedState.SelectedElement);
     }
 
     private void HandleStateMovedToCategory(StateSave stateSave, StateSaveCategory newCategory, StateSaveCategory oldCategory)

--- a/Gum/Plugins/InternalPlugins/Behaviors/MainBehaviorsPlugin.cs
+++ b/Gum/Plugins/InternalPlugins/Behaviors/MainBehaviorsPlugin.cs
@@ -12,6 +12,7 @@ using Gum.DataTypes.Variables;
 using Gum.Managers;
 using System.Collections.Generic;
 using Gum.ToolCommands;
+using GumCommon;
 
 namespace Gum.Plugins.Behaviors;
 
@@ -26,7 +27,7 @@ public class MainBehaviorsPlugin : InternalPlugin
 
     public MainBehaviorsPlugin()
     {
-        _selectedState = SelectedState.Self;
+        _selectedState = Locator.GetRequiredService<ISelectedState>();
     }
 
     public override void StartUp()
@@ -132,7 +133,7 @@ public class MainBehaviorsPlugin : InternalPlugin
     private void HandleApplyBehaviorChanges(object sender, EventArgs e)
     {
 
-        var component = SelectedState.Self.SelectedComponent;
+        var component = _selectedState.SelectedComponent;
         if (component == null) return;
 
         isApplyingChanges = true;

--- a/Gum/Plugins/InternalPlugins/CirclePlugin/MainCirclePlugin.cs
+++ b/Gum/Plugins/InternalPlugins/CirclePlugin/MainCirclePlugin.cs
@@ -2,12 +2,20 @@
 using Gum.Plugins.BaseClasses;
 using Gum.ToolStates;
 using System.ComponentModel.Composition;
+using GumCommon;
 
 namespace Gum.Plugins.CirclePlugin
 {
     [Export(typeof(PluginBase))]
     public class MainCirclePlugin : InternalPlugin
     {
+        private readonly ISelectedState _selectedState;
+
+        public MainCirclePlugin()
+        {
+            _selectedState = Locator.GetRequiredService<ISelectedState>();
+        }
+        
         public override void StartUp()
         {
             this.VariableSet += HandleVariableSet;
@@ -15,7 +23,7 @@ namespace Gum.Plugins.CirclePlugin
 
         private void HandleVariableSet(ElementSave element, InstanceSave instance, string variable, object oldValue)
         {
-            var state = SelectedState.Self.SelectedStateSave;
+            var state = _selectedState.SelectedStateSave;
 
             var shouldRefreshGrid = false;
 

--- a/Gum/Plugins/InternalPlugins/MenuStripPlugin/MenuStripManager.cs
+++ b/Gum/Plugins/InternalPlugins/MenuStripPlugin/MenuStripManager.cs
@@ -9,6 +9,7 @@ using System.Diagnostics;
 using ExCSS;
 using Gum.Commands;
 using Gum.ToolCommands;
+using GumCommon;
 
 namespace Gum.Managers
 {
@@ -17,6 +18,7 @@ namespace Gum.Managers
         #region Fields
 
         private readonly GuiCommands _guiCommands;
+        private readonly ISelectedState _selectedState;
 
         private MenuStrip _menuStrip;
 
@@ -47,6 +49,7 @@ namespace Gum.Managers
         public MenuStripManager(GuiCommands guiCommands)
         {
             _guiCommands = guiCommands;
+            _selectedState = Locator.GetRequiredService<ISelectedState>();
         }
 
         public void Initialize()
@@ -349,20 +352,20 @@ namespace Gum.Managers
         private void HanldeRemoveBehaviorVariableClicked(object sender, EventArgs e)
         {
             GumCommands.Self.Edit.RemoveBehaviorVariable(
-                SelectedState.Self.SelectedBehavior,
-                SelectedState.Self.SelectedBehaviorVariable);
+                _selectedState.SelectedBehavior,
+                _selectedState.SelectedBehaviorVariable);
         }
 
         public void RefreshUI()
         {
-            if (SelectedState.Self.SelectedStateSave != null && SelectedState.Self.SelectedStateSave.Name != "Default")
+            if (_selectedState.SelectedStateSave != null && _selectedState.SelectedStateSave.Name != "Default")
             {
-                RemoveStateMenuItem.Text = "State " + SelectedState.Self.SelectedStateSave.Name;
+                RemoveStateMenuItem.Text = "State " + _selectedState.SelectedStateSave.Name;
                 RemoveStateMenuItem.Enabled = true;
             }
-            else if (SelectedState.Self.SelectedStateCategorySave != null)
+            else if (_selectedState.SelectedStateCategorySave != null)
             {
-                RemoveStateMenuItem.Text = "Category " + SelectedState.Self.SelectedStateCategorySave.Name;
+                RemoveStateMenuItem.Text = "Category " + _selectedState.SelectedStateCategorySave.Name;
                 RemoveStateMenuItem.Enabled = true;
             }
             else
@@ -371,9 +374,9 @@ namespace Gum.Managers
                 RemoveStateMenuItem.Enabled = false;
             }
 
-            if (SelectedState.Self.SelectedElement != null && !(SelectedState.Self.SelectedElement is StandardElementSave))
+            if (_selectedState.SelectedElement != null && !(_selectedState.SelectedElement is StandardElementSave))
             {
-                RemoveElementMenuItem.Text = SelectedState.Self.SelectedElement.Name;
+                RemoveElementMenuItem.Text = _selectedState.SelectedElement.Name;
                 RemoveElementMenuItem.Enabled = true;
             }
             else
@@ -382,9 +385,9 @@ namespace Gum.Managers
                 RemoveElementMenuItem.Enabled = false;
             }
 
-            if(SelectedState.Self.SelectedBehaviorVariable != null)
+            if(_selectedState.SelectedBehaviorVariable != null)
             {
-                RemoveVariableMenuItem.Text = SelectedState.Self.SelectedBehaviorVariable.ToString();
+                RemoveVariableMenuItem.Text = _selectedState.SelectedBehaviorVariable.ToString();
                 RemoveVariableMenuItem.Enabled = true;
             }
             else
@@ -398,21 +401,21 @@ namespace Gum.Managers
 
         private void RemoveElementClicked(object sender, EventArgs e)
         {
-            ProjectCommands.Self.RemoveElement(SelectedState.Self.SelectedElement);
-            SelectedState.Self.SelectedElement = null;
+            ProjectCommands.Self.RemoveElement(_selectedState.SelectedElement);
+            _selectedState.SelectedElement = null;
         }
 
         private void RemoveStateOrCategoryClicked(object sender, EventArgs e)
         {
-            if (SelectedState.Self.SelectedStateSave != null)
+            if (_selectedState.SelectedStateSave != null)
             {
                 GumCommands.Self.Edit.AskToDeleteState(
-                    SelectedState.Self.SelectedStateSave, SelectedState.Self.SelectedStateContainer);
+                    _selectedState.SelectedStateSave, _selectedState.SelectedStateContainer);
             }
-            else if (SelectedState.Self.SelectedStateCategorySave != null)
+            else if (_selectedState.SelectedStateCategorySave != null)
             {
                 GumCommands.Self.Edit.RemoveStateCategory(
-                    SelectedState.Self.SelectedStateCategorySave, SelectedState.Self.SelectedStateContainer);
+                    _selectedState.SelectedStateCategorySave, _selectedState.SelectedStateContainer);
             }
         }
 

--- a/Gum/Plugins/InternalPlugins/ParentPlugin/MainParentPlugin.cs
+++ b/Gum/Plugins/InternalPlugins/ParentPlugin/MainParentPlugin.cs
@@ -4,12 +4,20 @@ using Gum.Plugins.BaseClasses;
 using Gum.ToolStates;
 using System.ComponentModel.Composition;
 using System.Linq;
+using GumCommon;
 
 namespace Gum.Plugins.ParentPlugin
 {
     [Export(typeof(PluginBase))]
     public class MainParentPlugin : InternalPlugin
     {
+        private readonly ISelectedState _selectedState;
+
+        public MainParentPlugin()
+        {
+            _selectedState = Locator.GetRequiredService<ISelectedState>();
+        }
+        
         public override void StartUp()
         {
             this.VariableSet += HandleVariableSet;
@@ -24,7 +32,7 @@ namespace Gum.Plugins.ParentPlugin
             }
             /////////////////////End Early Out////////////////
 
-            var currentState = SelectedState.Self.SelectedStateSave ?? 
+            var currentState = _selectedState.SelectedStateSave ?? 
                 // This can happen if the user drag+drops one item on another without anything selected:
                 container.DefaultState;
             var newParentName = currentState.GetValueOrDefault<string>($"{instance.Name}.Parent");

--- a/Gum/Plugins/InternalPlugins/ProjectPropertiesWindowPlugin/MainPropertiesWindowPlugin.cs
+++ b/Gum/Plugins/InternalPlugins/ProjectPropertiesWindowPlugin/MainPropertiesWindowPlugin.cs
@@ -14,6 +14,7 @@ using Color = System.Drawing.Color;
 using Rectangle = System.Drawing.Rectangle;
 using Matrix = System.Numerics.Matrix4x4;
 using Gum.Services;
+using GumCommon;
 
 namespace Gum.Plugins.PropertiesWindowPlugin;
 
@@ -40,7 +41,7 @@ class MainPropertiesWindowPlugin : InternalPlugin
 
     public MainPropertiesWindowPlugin()
     {
-        _fontManager = Builder.Get<FontManager>();
+        _fontManager = Locator.GetRequiredService<FontManager>();
     }
 
     public override void StartUp()

--- a/Gum/Plugins/InternalPlugins/StatePlugin/MainStatePlugin.cs
+++ b/Gum/Plugins/InternalPlugins/StatePlugin/MainStatePlugin.cs
@@ -14,6 +14,7 @@ using System;
 using System.ComponentModel.Composition;
 using System.Linq;
 using System.Windows.Forms;
+using GumCommon;
 
 namespace Gum.Plugins.StatePlugin;
 
@@ -35,7 +36,7 @@ public class MainStatePlugin : InternalPlugin
     private readonly ObjectFinder _objectFinder;
 
     #endregion
-
+    
     #region Initialize
 
     public MainStatePlugin()
@@ -43,7 +44,7 @@ public class MainStatePlugin : InternalPlugin
         _gumCommands = GumCommands.Self;
         _stateTreeViewRightClickService = new StateTreeViewRightClickService(GumState.Self.SelectedState, _gumCommands);
         _hotkeyManager = HotkeyManager.Self;
-        _selectedState = GumState.Self.SelectedState;
+        _selectedState = Locator.GetRequiredService<ISelectedState>();
         _objectFinder = ObjectFinder.Self;
     }
 
@@ -175,10 +176,9 @@ public class MainStatePlugin : InternalPlugin
     private void HandleTreeNodeSelected(TreeNode node)
     {
         RefreshTabHeaders();
-
-        var selectedState = SelectedState.Self;
-        if (selectedState.SelectedBehavior == null &&
-            selectedState.SelectedElement == null)
+        
+        if (_selectedState.SelectedBehavior == null &&
+            _selectedState.SelectedElement == null)
         {
 
             _stateTreeViewRightClickService.PopulateMenuStrip();
@@ -186,10 +186,9 @@ public class MainStatePlugin : InternalPlugin
         }
     }
 
-    private ISelectedState RefreshTabHeaders()
+    private void RefreshTabHeaders()
     {
-        var selectedState = SelectedState.Self;
-        var element = selectedState.SelectedElement;
+        var element = _selectedState.SelectedElement;
         string desiredTitle = "States";
         if (element != null)
         {
@@ -197,7 +196,6 @@ public class MainStatePlugin : InternalPlugin
         }
 
         newPluginTab.Title = desiredTitle;
-        return selectedState;
     }
 
     private void HandleStateSelected(TreeNode stateTreeNode)

--- a/Gum/Plugins/InternalPlugins/StatePlugin/MainStatePlugin.cs
+++ b/Gum/Plugins/InternalPlugins/StatePlugin/MainStatePlugin.cs
@@ -41,10 +41,10 @@ public class MainStatePlugin : InternalPlugin
 
     public MainStatePlugin()
     {
-        _gumCommands = GumCommands.Self;
-        _stateTreeViewRightClickService = new StateTreeViewRightClickService(GumState.Self.SelectedState, _gumCommands);
-        _hotkeyManager = HotkeyManager.Self;
         _selectedState = Locator.GetRequiredService<ISelectedState>();
+        _gumCommands = GumCommands.Self;
+        _stateTreeViewRightClickService = new StateTreeViewRightClickService(_selectedState, _gumCommands);
+        _hotkeyManager = HotkeyManager.Self;
         _objectFinder = ObjectFinder.Self;
     }
 

--- a/Gum/Plugins/InternalPlugins/StatePlugin/StateTreeViewManager.cs
+++ b/Gum/Plugins/InternalPlugins/StatePlugin/StateTreeViewManager.cs
@@ -7,6 +7,7 @@ using Gum.DataTypes.Variables;
 using System.Windows.Forms;
 using Gum.ToolStates;
 using Gum.Plugins;
+using GumCommon;
 
 namespace Gum.Managers
 {
@@ -18,6 +19,7 @@ namespace Gum.Managers
 
         StateTreeViewRightClickService _stateTreeViewRightClickService;
         HotkeyManager _hotkeyManager;
+        private readonly ISelectedState _selectedState;
 
         #endregion
 
@@ -39,6 +41,11 @@ namespace Gum.Managers
 
         #endregion
 
+        public StateTreeViewManager()
+        {
+            _selectedState = Locator.GetRequiredService<ISelectedState>();
+        }
+
         public void Initialize(
             StateTreeViewRightClickService stateTreeViewRightClickService,
             HotkeyManager hotkeyManager)
@@ -51,30 +58,30 @@ namespace Gum.Managers
         {
             if(_hotkeyManager.Rename.IsPressed(e))
             {
-                if(SelectedState.Self.SelectedStateSave != null )
+                if(_selectedState.SelectedStateSave != null )
                 {
-                    if(SelectedState.Self.SelectedElement?.DefaultState != SelectedState.Self.SelectedStateSave)
+                    if(_selectedState.SelectedElement?.DefaultState != _selectedState.SelectedStateSave)
                     {
                         _stateTreeViewRightClickService.RenameStateClick();
 
                     }
                 }
-                else if(SelectedState.Self.SelectedStateCategorySave != null)
+                else if(_selectedState.SelectedStateCategorySave != null)
                 {
                     _stateTreeViewRightClickService.RenameCategoryClick();
                 }
             }
             else if(_hotkeyManager.Delete.IsPressed(e))
             {
-                if (SelectedState.Self.SelectedStateSave != null)
+                if (_selectedState.SelectedStateSave != null)
                 {
-                    if (SelectedState.Self.SelectedElement?.DefaultState != SelectedState.Self.SelectedStateSave)
+                    if (_selectedState.SelectedElement?.DefaultState != _selectedState.SelectedStateSave)
                     {
                         _stateTreeViewRightClickService.DeleteStateClick();
 
                     }
                 }
-                else if (SelectedState.Self.SelectedStateCategorySave != null)
+                else if (_selectedState.SelectedStateCategorySave != null)
                 {
                     _stateTreeViewRightClickService.DeleteCategoryClick();
                 }

--- a/Gum/Plugins/InternalPlugins/StatePlugin/StateTreeViewRightClickService.cs
+++ b/Gum/Plugins/InternalPlugins/StatePlugin/StateTreeViewRightClickService.cs
@@ -96,7 +96,7 @@ public class StateTreeViewRightClickService
             // We used to show the category editing commands if a state was selected 
             // (if a state is selected, a category is implicitly selected too). Now we
             // check if a category is highlighted (not state)
-            //if(SelectedState.Self.SelectedStateCategorySave != null)
+            //if(_selectedState.SelectedStateCategorySave != null)
             if (_selectedState.SelectedStateCategorySave != null && _selectedState.SelectedStateSave == null)
             {
 
@@ -238,7 +238,7 @@ public class StateTreeViewRightClickService
             .Select(item => item.Name).ToList();
 
         // As of before 2024 we no longer allow uncategorized non-default states
-        //if(SelectedState.Self.SelectedStateCategorySave != null)
+        //if(_selectedState.SelectedStateCategorySave != null)
         //{
         //    categoryNames.Insert(0, mNoCategory);
         //}
@@ -333,21 +333,21 @@ public class StateTreeViewRightClickService
 
     public void RenameStateClick()
     {
-        _gumCommands.Edit.AskToRenameState(SelectedState.Self.SelectedStateSave,
-            SelectedState.Self.SelectedStateContainer);
+        _gumCommands.Edit.AskToRenameState(_selectedState.SelectedStateSave,
+            _selectedState.SelectedStateContainer);
     }
 
     public void RenameCategoryClick()
     {
         _gumCommands.Edit.AskToRenameStateCategory(
-            SelectedState.Self.SelectedStateCategorySave,
-            SelectedState.Self.SelectedElement);
+            _selectedState.SelectedStateCategorySave,
+            _selectedState.SelectedElement);
     }
 
     private void MoveToCategory(string categoryNameToMoveTo)
     {
-        var stateToMove = SelectedState.Self.SelectedStateSave;
-        var stateContainer = SelectedState.Self.SelectedStateContainer;
+        var stateToMove = _selectedState.SelectedStateSave;
+        var stateContainer = _selectedState.SelectedStateContainer;
         _gumCommands.Edit.MoveToCategory(categoryNameToMoveTo, stateToMove, stateContainer);
     }
 

--- a/Gum/Plugins/InternalPlugins/StatePlugin/ViewModels/StateTreeViewModel.cs
+++ b/Gum/Plugins/InternalPlugins/StatePlugin/ViewModels/StateTreeViewModel.cs
@@ -10,6 +10,7 @@ using System.ComponentModel;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using GumCommon;
 
 namespace Gum.Plugins.InternalPlugins.StatePlugin.ViewModels;
 
@@ -17,6 +18,8 @@ public class StateTreeViewModel : ViewModel
 {
     #region Fields/Properties
 
+    private readonly ISelectedState _selectedState;
+    
     [DependsOn(nameof(Categories))]
     [DependsOn(nameof(States))]
     public IEnumerable<StateTreeViewItem> Items => Categories.Concat<StateTreeViewItem>(States);
@@ -36,6 +39,11 @@ public class StateTreeViewModel : ViewModel
 
 
     #endregion
+
+    public StateTreeViewModel()
+    {
+        _selectedState = Locator.GetRequiredService<ISelectedState>();
+    }
 
     #region Initialize
 
@@ -65,19 +73,19 @@ public class StateTreeViewModel : ViewModel
 
             if (sender is StateViewModel stateVm && stateVm.IsSelected == true)
             {
-                GumState.Self.SelectedState.SelectedStateSave = stateVm.Data;
+                _selectedState.SelectedStateSave = stateVm.Data;
                 // No need to do this, we have events that do this for us:
                 //_stateTreeViewRightClickService.PopulateMenuStrip();
             }
             else if(sender is CategoryViewModel categoryVm && categoryVm.IsSelected)
             {
                 // If a state was selected, we need to deselect everything and forcefully select the state:
-                if(GumState.Self.SelectedState.SelectedStateSave != null)
+                if(_selectedState.SelectedStateSave != null)
                 {
-                    GumState.Self.SelectedState.SelectedStateSave = null;
-                    GumState.Self.SelectedState.SelectedStateCategorySave = null;
+                    _selectedState.SelectedStateSave = null;
+                    _selectedState.SelectedStateCategorySave = null;
                 }
-                GumState.Self.SelectedState.SelectedStateCategorySave = categoryVm.Data;
+                _selectedState.SelectedStateCategorySave = categoryVm.Data;
                 // I don't think we need to do this anymore because we can rely on the plugin to respond to events
                 //_stateTreeViewRightClickService.PopulateMenuStrip();
             }

--- a/Gum/Plugins/InternalPlugins/TreeView/ElementTreeViewManager.RightClick.cs
+++ b/Gum/Plugins/InternalPlugins/TreeView/ElementTreeViewManager.RightClick.cs
@@ -13,6 +13,7 @@ using Gum.Logic;
 using Gum.DataTypes.Behaviors;
 using Gum.PropertyGridHelpers;
 using Gum.Controls;
+using GumCommon;
 
 namespace Gum.Managers;
 
@@ -39,9 +40,6 @@ public partial class ElementTreeViewManager
     ToolStripMenuItem mAddFolder;
 
     ToolStripMenuItem duplicateElement;
-
-
-
     #endregion
 
     #region Initialize and event handlers
@@ -106,8 +104,8 @@ public partial class ElementTreeViewManager
 
     void HandleDuplicateElementClick(object sender, EventArgs e)
     {
-        if (SelectedState.Self.SelectedScreen != null ||
-            SelectedState.Self.SelectedComponent != null)
+        if (_selectedState.SelectedScreen != null ||
+            _selectedState.SelectedComponent != null)
         {
             GumCommands.Self.Edit.DuplicateSelectedElement();
         }
@@ -115,18 +113,18 @@ public partial class ElementTreeViewManager
 
     void OnGoToDefinitionClick(object sender, EventArgs e)
     {
-        if (SelectedState.Self.SelectedInstance != null)
+        if (_selectedState.SelectedInstance != null)
         {
-            ElementSave element = ObjectFinder.Self.GetElementSave(SelectedState.Self.SelectedInstance.BaseType);
+            ElementSave element = ObjectFinder.Self.GetElementSave(_selectedState.SelectedInstance.BaseType);
 
-            SelectedState.Self.SelectedElement = element;
+            _selectedState.SelectedElement = element;
         }
     }
 
     void CreateComponentClick(object sender, EventArgs e)
     {
-        if (SelectedState.Self.SelectedScreen != null ||
-            SelectedState.Self.SelectedComponent != null)
+        if (_selectedState.SelectedScreen != null ||
+            _selectedState.SelectedComponent != null)
         {
             GumCommands.Self.Edit.ShowCreateComponentFromInstancesDialog();
         }
@@ -134,7 +132,7 @@ public partial class ElementTreeViewManager
 
     void ForceSaveObjectClick(object sender, EventArgs e)
     {
-        GumCommands.Self.FileCommands.ForceSaveElement(SelectedState.Self.SelectedElement);
+        GumCommands.Self.FileCommands.ForceSaveElement(_selectedState.SelectedElement);
     }
 
     void AddFolderClick(object sender, EventArgs e)
@@ -145,7 +143,7 @@ public partial class ElementTreeViewManager
 
     void HandleViewInExplorer(object sender, EventArgs e)
     {
-        TreeNode treeNode = SelectedState.Self.SelectedTreeNode;
+        TreeNode treeNode = _selectedState.SelectedTreeNode;
 
         if (treeNode != null)
         {
@@ -196,7 +194,7 @@ public partial class ElementTreeViewManager
 
     void HandleDeleteFolder(object sender, EventArgs e)
     {
-        TreeNode treeNode = SelectedState.Self.SelectedTreeNode;
+        TreeNode treeNode = _selectedState.SelectedTreeNode;
 
         if (treeNode != null)
         {
@@ -259,9 +257,9 @@ public partial class ElementTreeViewManager
         {
             #region InstanceSave 
             // InstanceSave selected
-            if (SelectedState.Self.SelectedInstance != null)
+            if (_selectedState.SelectedInstance != null)
             {
-                var containerElement = SelectedState.Self.SelectedElement;
+                var containerElement = _selectedState.SelectedElement;
                 mMenuStrip.Items.Add(mGoToDefinition);
 
                 if (containerElement != null)
@@ -273,9 +271,9 @@ public partial class ElementTreeViewManager
 
                 mMenuStrip.Items.Add("-");
 
-                var deleteText = SelectedState.Self.SelectedInstances.Count() > 1
-                    ? $"Delete {SelectedState.Self.SelectedInstances.Count()} instances"
-                    : $"Delete {SelectedState.Self.SelectedInstance.Name}";
+                var deleteText = _selectedState.SelectedInstances.Count() > 1
+                    ? $"Delete {_selectedState.SelectedInstances.Count()} instances"
+                    : $"Delete {_selectedState.SelectedInstance.Name}";
                 mMenuStrip.Items.Add(deleteText, null, (not, used) => GumCommands.Self.Edit.DeleteSelection());
 
 
@@ -284,9 +282,9 @@ public partial class ElementTreeViewManager
                 {
                     mMenuStrip.Items.Add("-");
 
-                    mAddInstance.Text = $"Add child object to '{SelectedState.Self.SelectedInstance.Name}'";
+                    mAddInstance.Text = $"Add child object to '{_selectedState.SelectedInstance.Name}'";
                     mMenuStrip.Items.Add(mAddInstance);
-                    mAddParentInstance.Text = $"Add parent object to '{SelectedState.Self.SelectedInstance.Name}'";
+                    mAddParentInstance.Text = $"Add parent object to '{_selectedState.SelectedInstance.Name}'";
                     mMenuStrip.Items.Add(mAddParentInstance);
 
                     if (!string.IsNullOrEmpty(containerElement?.BaseType))
@@ -295,9 +293,9 @@ public partial class ElementTreeViewManager
 
                         if (containerBase is ScreenSave || containerBase is ComponentSave)
                         {
-                            mMenuStrip.Items.Add($"Add {SelectedState.Self.SelectedInstance.Name} to base {containerBase}",
+                            mMenuStrip.Items.Add($"Add {_selectedState.SelectedInstance.Name} to base {containerBase}",
                                 null,
-                                (not, used) => HandleMoveToBase(SelectedState.Self.SelectedInstances, SelectedState.Self.SelectedElement, containerBase));
+                                (not, used) => HandleMoveToBase(_selectedState.SelectedInstances, _selectedState.SelectedElement, containerBase));
                         }
                     }
 
@@ -309,7 +307,7 @@ public partial class ElementTreeViewManager
 
             #region Screen or Component
             // ScreenSave or ComponentSave
-            else if (SelectedState.Self.SelectedScreen != null || SelectedState.Self.SelectedComponent != null)
+            else if (_selectedState.SelectedScreen != null || _selectedState.SelectedComponent != null)
             {
                 mMenuStrip.Items.Add("View in explorer", null, HandleViewInExplorer);
 
@@ -317,16 +315,16 @@ public partial class ElementTreeViewManager
 
                 mMenuStrip.Items.Add("-");
 
-                mAddInstance.Text = "Add object to " + SelectedState.Self.SelectedElement.Name;
+                mAddInstance.Text = "Add object to " + _selectedState.SelectedElement.Name;
                 mMenuStrip.Items.Add(mAddInstance);
                 mMenuStrip.Items.Add(mSaveObject);
-                if (SelectedState.Self.SelectedScreen != null)
+                if (_selectedState.SelectedScreen != null)
                 {
-                    duplicateElement.Text = $"Duplicate {SelectedState.Self.SelectedScreen.Name}";
+                    duplicateElement.Text = $"Duplicate {_selectedState.SelectedScreen.Name}";
                 }
                 else
                 {
-                    duplicateElement.Text = $"Duplicate {SelectedState.Self.SelectedComponent.Name}";
+                    duplicateElement.Text = $"Duplicate {_selectedState.SelectedComponent.Name}";
                 }
                 mMenuStrip.Items.Add(duplicateElement);
 
@@ -335,7 +333,7 @@ public partial class ElementTreeViewManager
                 mMenuStrip.Items.Add("-");
 
 
-                mDeleteObject.Text = "Delete " + SelectedState.Self.SelectedElement.ToString();
+                mDeleteObject.Text = "Delete " + _selectedState.SelectedElement.ToString();
                 mMenuStrip.Items.Add(mDeleteObject);
 
             }
@@ -343,11 +341,11 @@ public partial class ElementTreeViewManager
 
             #region Behavior
 
-            else if (SelectedState.Self.SelectedBehavior != null)
+            else if (_selectedState.SelectedBehavior != null)
             {
                 mMenuStrip.Items.Add("View in explorer", null, HandleViewInExplorer);
                 mMenuStrip.Items.Add("-");
-                mDeleteObject.Text = "Delete " + SelectedState.Self.SelectedBehavior.ToString();
+                mDeleteObject.Text = "Delete " + _selectedState.SelectedBehavior.ToString();
                 mMenuStrip.Items.Add(mDeleteObject);
             }
 
@@ -355,7 +353,7 @@ public partial class ElementTreeViewManager
 
             #region Standard Element
 
-            else if (SelectedState.Self.SelectedStandardElement != null)
+            else if (_selectedState.SelectedStandardElement != null)
             {
                 mMenuStrip.Items.Add("View in explorer", null, HandleViewInExplorer);
 
@@ -471,7 +469,7 @@ public partial class ElementTreeViewManager
 
     private void HandleViewReferences(object sender, EventArgs e)
     {
-        GumCommands.Self.Edit.DisplayReferencesTo(SelectedState.Self.SelectedElement);
+        GumCommands.Self.Edit.DisplayReferencesTo(_selectedState.SelectedElement);
     }
 
     private void HandleRenameFolder(object sender, EventArgs e)
@@ -537,7 +535,7 @@ public partial class ElementTreeViewManager
 
                     GumCommands.Self.GuiCommands.RefreshElementTreeView();
 
-                    SelectedState.Self.SelectedScreen = screenSave;
+                    _selectedState.SelectedScreen = screenSave;
 
                     GumCommands.Self.FileCommands.TryAutoSaveElement(screenSave);
                     GumCommands.Self.FileCommands.TryAutoSaveProject();
@@ -617,7 +615,7 @@ public partial class ElementTreeViewManager
         if (lastImportedComponent != null)
         {
             GumCommands.Self.GuiCommands.RefreshElementTreeView();
-            SelectedState.Self.SelectedComponent = lastImportedComponent;
+            _selectedState.SelectedComponent = lastImportedComponent;
             GumCommands.Self.FileCommands.TryAutoSaveProject();
         }
     }
@@ -635,7 +633,7 @@ public partial class ElementTreeViewManager
         {
             string whyNotValid;
 
-            if (!NameVerifier.Self.IsInstanceNameValid(name, null, SelectedState.Self.SelectedElement, out whyNotValid))
+            if (!NameVerifier.Self.IsInstanceNameValid(name, null, _selectedState.SelectedElement, out whyNotValid))
             {
                 MessageBox.Show(whyNotValid);
 
@@ -651,12 +649,12 @@ public partial class ElementTreeViewManager
     {
         if (!ShowNewObjectDialog(out var name)) return;
 
-        var focusedInstance = SelectedState.Self.SelectedInstance;
-        var newInstance = GumCommands.Self.ProjectCommands.ElementCommands.AddInstance(SelectedState.Self.SelectedElement, name, StandardElementsManager.Self.DefaultType);
+        var focusedInstance = _selectedState.SelectedInstance;
+        var newInstance = GumCommands.Self.ProjectCommands.ElementCommands.AddInstance(_selectedState.SelectedElement, name, StandardElementsManager.Self.DefaultType);
 
         if (focusedInstance != null)
         {
-            SetInstanceParent(SelectedState.Self.SelectedElement, newInstance, focusedInstance);
+            SetInstanceParent(_selectedState.SelectedElement, newInstance, focusedInstance);
         }
     }
 
@@ -664,12 +662,12 @@ public partial class ElementTreeViewManager
     {
         if (!ShowNewObjectDialog(out var name)) return;
 
-        var focusedInstance = SelectedState.Self.SelectedInstance;
-        var newInstance = GumCommands.Self.ProjectCommands.ElementCommands.AddInstance(SelectedState.Self.SelectedElement, name, StandardElementsManager.Self.DefaultType);
+        var focusedInstance = _selectedState.SelectedInstance;
+        var newInstance = GumCommands.Self.ProjectCommands.ElementCommands.AddInstance(_selectedState.SelectedElement, name, StandardElementsManager.Self.DefaultType);
 
         System.Diagnostics.Debug.Assert(focusedInstance != null);
 
-        SetInstanceParentWrapper(SelectedState.Self.SelectedElement, newInstance, focusedInstance);
+        SetInstanceParentWrapper(_selectedState.SelectedElement, newInstance, focusedInstance);
     }
 
     private static void SetInstanceParentWrapper(ElementSave targetElement, InstanceSave newInstance, InstanceSave existingInstance)
@@ -686,7 +684,7 @@ public partial class ElementTreeViewManager
 
         // From DragDropManager:
         // "Since the Parent property can only be set in the default state, we will
-        // set the Parent variable on that instead of the SelectedState.Self.SelectedStateSave"
+        // set the Parent variable on that instead of the _selectedState.SelectedStateSave"
         var stateToAssignOn = targetElement.DefaultState;
 
         var variableName = newInstance.Name + ".Parent";
@@ -705,7 +703,7 @@ public partial class ElementTreeViewManager
     {
         // From DragDropManager:
         // "Since the Parent property can only be set in the default state, we will
-        // set the Parent variable on that instead of the SelectedState.Self.SelectedStateSave"
+        // set the Parent variable on that instead of the _selectedState.SelectedStateSave"
         var stateToAssignOn = targetElement.DefaultState;
         var variableName = child.Name + ".Parent";
         var oldValue = stateToAssignOn.GetValue(variableName) as string;        // This will always be empty anyway...

--- a/Gum/Plugins/InternalPlugins/TreeView/ElementTreeViewManager.cs
+++ b/Gum/Plugins/InternalPlugins/TreeView/ElementTreeViewManager.cs
@@ -2086,17 +2086,17 @@ namespace Gum.Managers
             if(backingObject != null)
             {
                 if (backingObject is ScreenSave asScreen)
-                    GumState.Self.SelectedState.SelectedElement = asScreen;
+                    _selectedState.SelectedElement = asScreen;
                 else if (backingObject is ComponentSave asComponent)
-                    GumState.Self.SelectedState.SelectedElement = asComponent;
+                    _selectedState.SelectedElement = asComponent;
                 else if (backingObject is StandardElementSave asStandard)
-                    GumState.Self.SelectedState.SelectedElement = asStandard;
+                    _selectedState.SelectedElement = asStandard;
                 else if (backingObject is InstanceSave asInstance)
-                    GumState.Self.SelectedState.SelectedInstance = asInstance;
+                    _selectedState.SelectedInstance = asInstance;
                 else if (backingObject is VariableSave asVariable)
-                    GumState.Self.SelectedState.SelectedBehaviorVariable = asVariable;
+                    _selectedState.SelectedBehaviorVariable = asVariable;
                 else if(backingObject is BehaviorSave asBehavior)
-                    GumState.Self.SelectedState.SelectedBehavior = asBehavior;
+                    _selectedState.SelectedBehavior = asBehavior;
 
                 searchTextBox.Text = null;
                 FilterText = null;

--- a/Gum/Plugins/InternalPlugins/TreeView/ElementTreeViewManager.cs
+++ b/Gum/Plugins/InternalPlugins/TreeView/ElementTreeViewManager.cs
@@ -20,6 +20,7 @@ using Gum.Logic;
 using System.Drawing;
 using WpfInput = System.Windows.Input;
 using Gum.Services;
+using GumCommon;
 
 namespace Gum.Managers
 {
@@ -76,6 +77,7 @@ namespace Gum.Managers
     {
         #region Fields
 
+        private readonly ISelectedState _selectedState;
 
         public const int TransparentImageIndex = 0;
         public const int FolderImageIndex = 1;
@@ -233,6 +235,11 @@ namespace Gum.Managers
         }
 
         #endregion
+
+        public ElementTreeViewManager()
+        {
+            _selectedState = Locator.GetRequiredService<ISelectedState>();
+        }
 
         #region Methods
 
@@ -436,12 +443,12 @@ namespace Gum.Managers
         }
 
         #endregion
-
+        
 
         public void Initialize(IContainer components, ImageList ElementTreeImages,
             CopyPasteLogic copyPasteLogic)
         {
-            _dragDropManager = Builder.Get<DragDropManager>();
+            _dragDropManager = Locator.GetRequiredService<DragDropManager>();
             _copyPasteLogic = copyPasteLogic;
 
             CreateObjectTreeView(ElementTreeImages);
@@ -914,9 +921,9 @@ namespace Gum.Managers
             ////////////End Early Out////////////
 
             // Save off old selected stuff
-            InstanceSave selectedInstance = SelectedState.Self.SelectedInstance;
-            ElementSave selectedElement = SelectedState.Self.SelectedElement;
-            BehaviorSave selectedBehavior = SelectedState.Self.SelectedBehavior;
+            InstanceSave selectedInstance = _selectedState.SelectedInstance;
+            ElementSave selectedElement = _selectedState.SelectedElement;
+            BehaviorSave selectedBehavior = _selectedState.SelectedBehavior;
 
 
             #region Add nodes that haven't been added yet
@@ -1113,11 +1120,11 @@ namespace Gum.Managers
             {
                 if (selectedInstance != null)
                 {
-                    SelectedState.Self.SelectedInstance = selectedInstance;
+                    _selectedState.SelectedInstance = selectedInstance;
                 }
                 if(selectedBehavior != null)
                 {
-                    SelectedState.Self.SelectedBehavior = selectedBehavior;
+                    _selectedState.SelectedBehavior = selectedBehavior;
                 }
             }
             catch
@@ -1188,16 +1195,16 @@ namespace Gum.Managers
 
         public void RecordSelection()
         {
-            mRecordedSelectedObject = SelectedState.Self.SelectedInstance;
+            mRecordedSelectedObject = _selectedState.SelectedInstance;
 
             if (mRecordedSelectedObject == null)
             {
-                mRecordedSelectedObject = SelectedState.Self.SelectedElement;
+                mRecordedSelectedObject = _selectedState.SelectedElement;
             }
 
             if(mRecordedSelectedObject == null)
             {
-                mRecordedSelectedObject = SelectedState.Self.SelectedBehavior;
+                mRecordedSelectedObject = _selectedState.SelectedBehavior;
             }
         }
 
@@ -1209,15 +1216,15 @@ namespace Gum.Managers
                 {
                     if (mRecordedSelectedObject is InstanceSave)
                     {
-                        SelectedState.Self.SelectedInstance = mRecordedSelectedObject as InstanceSave;
+                        _selectedState.SelectedInstance = mRecordedSelectedObject as InstanceSave;
                     }
                     else if (mRecordedSelectedObject is ElementSave)
                     {
-                        SelectedState.Self.SelectedElement = mRecordedSelectedObject as ElementSave;
+                        _selectedState.SelectedElement = mRecordedSelectedObject as ElementSave;
                     }
                     else if(mRecordedSelectedObject is BehaviorSave)
                     {
-                        SelectedState.Self.SelectedBehavior = mRecordedSelectedObject as BehaviorSave;
+                        _selectedState.SelectedBehavior = mRecordedSelectedObject as BehaviorSave;
                     }
                 }
             }
@@ -1750,20 +1757,20 @@ namespace Gum.Managers
                 IsInUiInitiatedSelection = true;
                 if (selectedObject == null)
                 {
-                    SelectedState.Self.SelectedElement = null;
-                    SelectedState.Self.SelectedBehavior = null;
-                    SelectedState.Self.SelectedInstance = null;
+                    _selectedState.SelectedElement = null;
+                    _selectedState.SelectedBehavior = null;
+                    _selectedState.SelectedInstance = null;
 
                     // do nothing
                 }
                 else if(selectedObject is ElementSave elementSave)
                 {
-                    SelectedState.Self.SelectedInstance = null;
+                    _selectedState.SelectedInstance = null;
                     var elements = this.SelectedNodes
                         .Where(item => item.Tag is ElementSave)
                         .Select(item => item.Tag as ElementSave);
 
-                    SelectedState.Self.SelectedElements = elements;
+                    _selectedState.SelectedElements = elements;
                 }
                 else if (selectedObject is InstanceSave selectedInstance)
                 {
@@ -1771,12 +1778,12 @@ namespace Gum.Managers
                         .Where(item => item is InstanceSave)
                         .Select(item => item as InstanceSave);
 
-                    //SelectedState.Self.SelectedInstance = selectedInstance;
-                    SelectedState.Self.SelectedInstances = instances;
+                    //_selectedState.SelectedInstance = selectedInstance;
+                    _selectedState.SelectedInstances = instances;
                 }
                 else if(selectedObject is BehaviorSave behavior)
                 {
-                    SelectedState.Self.SelectedBehavior = behavior;
+                    _selectedState.SelectedBehavior = behavior;
                 }
 
                 PluginManager.Self.TreeNodeSelected(selectedTreeNode);

--- a/Gum/Plugins/InternalPlugins/TreeView/MainTreeViewPlugin.cs
+++ b/Gum/Plugins/InternalPlugins/TreeView/MainTreeViewPlugin.cs
@@ -11,12 +11,20 @@ using System.ComponentModel.Composition;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using GumCommon;
 
 namespace Gum.Plugins.InternalPlugins.TreeView;
 
 [Export(typeof(PluginBase))]
 internal class MainTreeViewPlugin : InternalPlugin
 {
+    private readonly ISelectedState _selectedState;
+    
+    public MainTreeViewPlugin()
+    {
+        _selectedState = Locator.GetRequiredService<ISelectedState>();
+    }
+    
     public override void StartUp()
     {
         AssignEvents();
@@ -92,7 +100,7 @@ internal class MainTreeViewPlugin : InternalPlugin
             if(instance != null)
             {
 
-                ElementTreeViewManager.Self.Select(SelectedState.Self.SelectedInstances);
+                ElementTreeViewManager.Self.Select(_selectedState.SelectedInstances);
             }
 
             if(instance == null && element != null)

--- a/Gum/Plugins/InternalPlugins/Undos/UndosViewModel.cs
+++ b/Gum/Plugins/InternalPlugins/Undos/UndosViewModel.cs
@@ -9,12 +9,14 @@ using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using GumCommon;
 using ToolsUtilities;
 
 namespace Gum.Plugins.Undos
 {
     public class UndosViewModel : INotifyPropertyChanged
     {
+        private readonly ISelectedState _selectedState;
         //ObservableCollection<string> mUndos = new ObservableCollection<string>();
         //public ObservableCollection<string> Undos
         //{
@@ -130,7 +132,7 @@ namespace Gum.Plugins.Undos
 
             var elementToClone =
                 //elementHistory.InitialState;
-                GumState.Self.SelectedState.SelectedElement;
+                _selectedState.SelectedElement;
 
             if (this.UndoIndex < elementHistory.Actions.Count - 1)
             {
@@ -173,14 +175,14 @@ namespace Gum.Plugins.Undos
             return undoStringList;
         }
 
-        private static ElementSave GetSelectedElementClone()
+        private ElementSave GetSelectedElementClone()
         {
             ElementSave selectedElementClone = null;
 
 
-            if (GumState.Self.SelectedState.SelectedElement != null)
+            if (_selectedState.SelectedElement != null)
             {
-                return UndoManager.CloneWithFixedEnumerations(GumState.Self.SelectedState.SelectedElement);
+                return UndoManager.CloneWithFixedEnumerations(_selectedState.SelectedElement);
             }
 
             return null;
@@ -188,6 +190,7 @@ namespace Gum.Plugins.Undos
 
         public UndosViewModel()
         {
+            _selectedState = Locator.GetRequiredService<ISelectedState>();
             UndoManager.Self.UndosChanged += HandleUndosChanged;
         }
 

--- a/Gum/Plugins/InternalPlugins/VariableGrid/ElementSaveDisplayer.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/ElementSaveDisplayer.cs
@@ -19,6 +19,7 @@ using Newtonsoft.Json.Linq;
 using Gum.Undo;
 using System.Security.Principal;
 using Gum.Plugins.InternalPlugins.VariableGrid;
+using GumCommon;
 
 namespace Gum.PropertyGridHelpers
 {
@@ -38,12 +39,14 @@ namespace Gum.PropertyGridHelpers
 
         static PropertyDescriptorHelper mHelper = new PropertyDescriptorHelper();
         private readonly SubtextLogic _subtextLogic;
+        private readonly ISelectedState _selectedState;
 
         #endregion
 
         public ElementSaveDisplayer(SubtextLogic subtextLogic)
         {
             _subtextLogic = subtextLogic;
+            _selectedState = Locator.GetRequiredService<ISelectedState>();
         }
 
         private List<InstanceSavePropertyDescriptor> GetProperties(ElementSave elementSave, InstanceSave instanceSave, StateSave stateSave)
@@ -71,8 +74,8 @@ namespace Gum.PropertyGridHelpers
         private void FillPropertyList(List<InstanceSavePropertyDescriptor> pdc, ElementSave elementSave,
             InstanceSave instanceSave, StateSave defaultState, AmountToDisplay amountToDisplay = AmountToDisplay.AllVariables)
         {
-            var currentState = SelectedState.Self.SelectedStateSave;
-            bool isDefault = currentState == SelectedState.Self.SelectedElement.DefaultState;
+            var currentState = _selectedState.SelectedStateSave;
+            bool isDefault = currentState == _selectedState.SelectedElement.DefaultState;
             if (instanceSave?.DefinedByBase == true)
             {
                 isDefault = false;

--- a/Gum/Plugins/InternalPlugins/VariableGrid/ExclusionsPlugin.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/ExclusionsPlugin.cs
@@ -7,6 +7,7 @@ using RenderingLibrary.Graphics;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
+using GumCommon;
 
 namespace Gum.Plugins.InternalPlugins.VariableGrid;
 
@@ -42,7 +43,7 @@ public class ExclusionsPlugin : InternalPlugin
 
     public ExclusionsPlugin()
     {
-        _selectedState = SelectedState.Self;
+        _selectedState = Locator.GetRequiredService<ISelectedState>();
         _objectFinder = ObjectFinder.Self;
     }
 

--- a/Gum/Plugins/InternalPlugins/VariableGrid/MainVariableGridPlugin.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/MainVariableGridPlugin.cs
@@ -13,6 +13,7 @@ using HarfBuzzSharp;
 using System;
 using System.ComponentModel.Composition;
 using System.Windows.Forms;
+using GumCommon;
 using Microsoft.CodeAnalysis.CSharp;
 
 namespace Gum.Plugins.InternalPlugins.VariableGrid;
@@ -26,8 +27,7 @@ public class MainVariableGridPlugin : InternalPlugin
     public MainVariableGridPlugin()
     {
         _propertyGridManager = PropertyGridManager.Self;
-        _variableReferenceLogic = new VariableReferenceLogic(
-            Builder.Get<GuiCommands>());
+        _variableReferenceLogic = new VariableReferenceLogic(Locator.GetRequiredService<GuiCommands>());
         ElementSaveExtensions.CustomEvaluateExpression = EvaluateExpression;
     }
 

--- a/Gum/Plugins/InternalPlugins/VariableGrid/MainVariableGridPlugin.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/MainVariableGridPlugin.cs
@@ -23,9 +23,11 @@ public class MainVariableGridPlugin : InternalPlugin
 {
     PropertyGridManager _propertyGridManager;
     private readonly VariableReferenceLogic _variableReferenceLogic;
+    private readonly ISelectedState _selectedState;
 
     public MainVariableGridPlugin()
     {
+        _selectedState = Locator.GetRequiredService<ISelectedState>();
         _propertyGridManager = PropertyGridManager.Self;
         _variableReferenceLogic = new VariableReferenceLogic(Locator.GetRequiredService<GuiCommands>());
         ElementSaveExtensions.CustomEvaluateExpression = EvaluateExpression;
@@ -143,13 +145,13 @@ public class MainVariableGridPlugin : InternalPlugin
 
     private void HandleTreeNodeSelected(TreeNode node)
     {
-        var selectedState = GumState.Self.SelectedState;
+        var selectedState = _selectedState;
         var shouldShowButton = (selectedState.SelectedBehavior != null ||
             selectedState.SelectedComponent != null ||
             selectedState.SelectedScreen != null);
         if(shouldShowButton)
         {
-            shouldShowButton = GumState.Self.SelectedState.SelectedInstance == null;
+            shouldShowButton = _selectedState.SelectedInstance == null;
         }
         PropertyGridManager.Self.VariableViewModel.AddVariableButtonVisibility =
             shouldShowButton.ToVisibility();

--- a/Gum/Plugins/InternalPlugins/VariableGrid/PropertyGridManager.RightClick.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/PropertyGridManager.RightClick.cs
@@ -22,16 +22,16 @@ namespace Gum.Managers
             // doesn't have this variable then the RVF will return the variable from the
             // base.  Instead, we want to set the value right on the instance if an instance
             // is selected.
-            //VariableSave variable = SelectedState.Self.SelectedRecursiveVariableFinder.GetVariable("SourceFile");
-            if (SelectedState.Self.SelectedInstance != null)
+            //VariableSave variable = _selectedState.SelectedRecursiveVariableFinder.GetVariable("SourceFile");
+            if (_selectedState.SelectedInstance != null)
             {
-                SelectedState.Self.SelectedStateSave.SetValue(
-                    SelectedState.Self.SelectedInstance.Name + ".SourceFile", text);
+                _selectedState.SelectedStateSave.SetValue(
+                    _selectedState.SelectedInstance.Name + ".SourceFile", text);
 
             }
             else
             {
-                SelectedState.Self.SelectedStateSave.SetValue(
+                _selectedState.SelectedStateSave.SetValue(
                     "SourceFile", text);
 
             }

--- a/Gum/Plugins/InternalPlugins/VariableGrid/SetVariableLogic.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/SetVariableLogic.cs
@@ -138,7 +138,7 @@ namespace Gum.PropertyGridHelpers
                         // This code used to not specify the category, so it defaulted to the selected category.
                         // I'm maintaining this behavior but I'm not sure if it's what should happen - maybe we should
                         // serach for the owner category of the state?
-                        GumState.Self.SelectedState.SelectedStateCategorySave);
+                        _selectedState.SelectedStateCategorySave);
 
                     // Need to record undo before refreshing and reselecting the UI
                     if (recordUndo)

--- a/Gum/Plugins/InternalPlugins/VariableGrid/SetVariableLogic.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/SetVariableLogic.cs
@@ -20,6 +20,7 @@ using Gum.Plugins.InternalPlugins.VariableGrid;
 using Gum.Services;
 using Gum.Commands;
 using Gum.Graphics;
+using GumCommon;
 
 namespace Gum.PropertyGridHelpers
 {
@@ -29,16 +30,22 @@ namespace Gum.PropertyGridHelpers
         private CircularReferenceManager _circularReferenceManager;
         private FontManager _fontManager;
         private FileCommands _fileCommands;
+        private readonly ISelectedState _selectedState;
+
+        public SetVariableLogic()
+        {
+            _selectedState = Locator.GetRequiredService<ISelectedState>();
+        }
 
         // this is needed as we unroll all the other singletons...
         public void Initialize(CircularReferenceManager circularReferenceManager, FileCommands fileCommands)
         {
 
             _variableReferenceLogic = new VariableReferenceLogic(
-                Builder.Get<GuiCommands>());
+                Locator.GetRequiredService<GuiCommands>());
             _circularReferenceManager = circularReferenceManager;
 
-            _fontManager = Builder.Get<FontManager>();
+            _fontManager = Locator.GetRequiredService<FontManager>();
             _fileCommands = fileCommands;
         }
 
@@ -59,11 +66,11 @@ namespace Gum.PropertyGridHelpers
 
                 if (instance != null)
                 {
-                    SelectedState.Self.SelectedVariableSave = stateContainingVariable.GetVariableSave(instance.Name + "." + unqualifiedMemberName);
+                    _selectedState.SelectedVariableSave = stateContainingVariable.GetVariableSave(instance.Name + "." + unqualifiedMemberName);
                 }
                 else
                 {
-                    SelectedState.Self.SelectedVariableSave = stateContainingVariable.GetVariableSave(unqualifiedMemberName);
+                    _selectedState.SelectedVariableSave = stateContainingVariable.GetVariableSave(unqualifiedMemberName);
                 }
             }
 
@@ -227,7 +234,7 @@ namespace Gum.PropertyGridHelpers
 
             if (rootVariableName == "BaseType")
             {
-                VariableSave variable = SelectedState.Self.SelectedVariableSave;
+                VariableSave variable = _selectedState.SelectedVariableSave;
 
                 if (instance != null)
                 {
@@ -252,7 +259,7 @@ namespace Gum.PropertyGridHelpers
 
         private void ReactIfChangedMemberIsDefaultChildContainer(ElementSave parentElement, InstanceSave instance, string rootVariableName, object oldValue)
         {
-            VariableSave variable = SelectedState.Self.SelectedVariableSave;
+            VariableSave variable = _selectedState.SelectedVariableSave;
 
             if (variable != null && rootVariableName == nameof(ComponentSave.DefaultChildContainer))
             {
@@ -326,12 +333,12 @@ namespace Gum.PropertyGridHelpers
                     TryAddForced("IsItalic");
                     TryAddForced("IsBold");
 
-                    StateSave stateSave = SelectedState.Self.SelectedStateSave;
+                    StateSave stateSave = _selectedState.SelectedStateSave;
 
                     // If the user has a category selected but no state in the category, then use the default:
-                    if (stateSave == null && SelectedState.Self.SelectedStateCategorySave != null)
+                    if (stateSave == null && _selectedState.SelectedStateCategorySave != null)
                     {
-                        stateSave = SelectedState.Self.SelectedElement.DefaultState;
+                        stateSave = _selectedState.SelectedElement.DefaultState;
                     }
 
 
@@ -351,7 +358,7 @@ namespace Gum.PropertyGridHelpers
         {
             bool wasAnythingSet = false;
             string variableToSet = null;
-            StateSave stateSave = SelectedState.Self.SelectedStateSave;
+            StateSave stateSave = _selectedState.SelectedStateSave;
             float valueToSet = 0;
 
             var wereUnitValuesChanged =
@@ -397,7 +404,7 @@ namespace Gum.PropertyGridHelpers
 
                     var editingCommands = GumCommands.Self.ProjectCommands.ElementCommands;
 
-                    object unitTypeAsObject = editingCommands.GetCurrentValueForVariable(changedMember, SelectedState.Self.SelectedInstance);
+                    object unitTypeAsObject = editingCommands.GetCurrentValueForVariable(changedMember, _selectedState.SelectedInstance);
                     GeneralUnitType unitType = UnitConverter.ConvertToGeneralUnit(unitTypeAsObject);
 
 
@@ -457,12 +464,12 @@ namespace Gum.PropertyGridHelpers
 
             if (wasAnythingSet && AttemptToPersistPositionsOnUnitChanges && !float.IsPositiveInfinity(valueToSet))
             {
-                InstanceSave instanceSave = SelectedState.Self.SelectedInstance;
+                InstanceSave instanceSave = _selectedState.SelectedInstance;
 
                 string unqualifiedVariableToSet = variableToSet;
-                if (SelectedState.Self.SelectedInstance != null)
+                if (_selectedState.SelectedInstance != null)
                 {
-                    variableToSet = SelectedState.Self.SelectedInstance.Name + "." + variableToSet;
+                    variableToSet = _selectedState.SelectedInstance.Name + "." + variableToSet;
                 }
 
                 stateSave.SetValue(variableToSet, valueToSet, instanceSave);
@@ -490,7 +497,7 @@ namespace Gum.PropertyGridHelpers
 
             variableFullName = $"{instancePrefix}{changedMember}";
 
-            VariableSave variable = SelectedState.Self.SelectedStateSave?.GetVariableSave(variableFullName);
+            VariableSave variable = _selectedState.SelectedStateSave?.GetVariableSave(variableFullName);
 
             bool isSourcefile = variable?.GetRootName() == "SourceFile";
 
@@ -514,7 +521,7 @@ namespace Gum.PropertyGridHelpers
                 string value;
 
                 value = variable.Value as string;
-                StateSave stateSave = SelectedState.Self.SelectedStateSave;
+                StateSave stateSave = _selectedState.SelectedStateSave;
 
                 if (!string.IsNullOrEmpty(value))
                 {
@@ -705,7 +712,7 @@ namespace Gum.PropertyGridHelpers
         {
             bool isValidAssignment = true;
 
-            VariableSave variable = SelectedState.Self.SelectedVariableSave;
+            VariableSave variable = _selectedState.SelectedVariableSave;
             // Eventually need to handle tunneled variables
             if (variable != null && changedMember == "Parent")
             {
@@ -783,10 +790,10 @@ namespace Gum.PropertyGridHelpers
             {
                 RecursiveVariableFinder rvf;
 
-                var instance = SelectedState.Self.SelectedInstance;
+                var instance = _selectedState.SelectedInstance;
                 if (instance != null)
                 {
-                    rvf = new RecursiveVariableFinder(SelectedState.Self.SelectedInstance, parentElement);
+                    rvf = new RecursiveVariableFinder(_selectedState.SelectedInstance, parentElement);
                 }
                 else
                 {
@@ -839,9 +846,9 @@ namespace Gum.PropertyGridHelpers
 
         string GetQualifiedName(string variableName)
         {
-            if (SelectedState.Self.SelectedInstance != null)
+            if (_selectedState.SelectedInstance != null)
             {
-                return SelectedState.Self.SelectedInstance.Name + "." + variableName;
+                return _selectedState.SelectedInstance.Name + "." + variableName;
             }
             else
             {

--- a/Gum/Plugins/InternalPlugins/VariableGrid/StateReferencingInstanceMember.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/StateReferencingInstanceMember.cs
@@ -21,6 +21,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using System.Windows.Forms;
+using GumCommon;
 using ToolsUtilities;
 using WpfDataUi.Controls;
 using WpfDataUi.DataTypes;
@@ -46,6 +47,7 @@ namespace Gum.PropertyGridHelpers
 
         private readonly IEditVariableService _editVariablesService;
         private readonly IExposeVariableService _exposeVariableService;
+        private readonly ISelectedState _selectedState;
         #endregion
 
         #region Properties
@@ -243,12 +245,13 @@ namespace Gum.PropertyGridHelpers
             UndoManager undoManager) :
             base(variableName, stateSave)
         {
-            _editVariablesService = Gum.Services.Builder.Get<IEditVariableService>();
-            _exposeVariableService = Gum.Services.Builder.Get<IExposeVariableService>();
+            _editVariablesService = Locator.GetRequiredService<IEditVariableService>();
+            _exposeVariableService = Locator.GetRequiredService<IExposeVariableService>();
             _objectFinder = ObjectFinder.Self;
             _hotkeyManager = HotkeyManager.Self;
-            _deleteVariableLogic = Gum.Services.Builder.App.Services.GetRequiredService<IDeleteVariableService>();
+            _deleteVariableLogic = Locator.GetRequiredService<IDeleteVariableService>();
             _undoManager = undoManager;
+            _selectedState = Locator.GetRequiredService<ISelectedState>();
 
             StateSaveCategory = stateSaveCategory;
             InstanceSave = instanceSave;
@@ -421,11 +424,11 @@ namespace Gum.PropertyGridHelpers
                         }
                         if (instance != null)
                         {
-                            SelectedState.Self.SelectedInstance = instance;
+                            _selectedState.SelectedInstance = instance;
                         }
                         else
                         {
-                            SelectedState.Self.SelectedElement = element;
+                            _selectedState.SelectedElement = element;
                         }
                     }
                 }
@@ -536,7 +539,7 @@ namespace Gum.PropertyGridHelpers
         private void HandleExposeVariableClick(object sender, System.Windows.RoutedEventArgs e)
         {
             var variableToExpose = this.VariableSave;
-            _exposeVariableService.HandleExposeVariableClick(SelectedState.Self.SelectedInstance,
+            _exposeVariableService.HandleExposeVariableClick(_selectedState.SelectedInstance,
                 variableToExpose, this.RootVariableName);
         }
 
@@ -589,7 +592,7 @@ namespace Gum.PropertyGridHelpers
             }
             /////////////////End Early Out////////////////////////
 
-            var stateSave = SelectedState.Self.SelectedStateSave;
+            var stateSave = _selectedState.SelectedStateSave;
             var instanceSave = gumElementOrInstanceSaveAsObject as InstanceSave;
             var elementSave = instanceSave?.ParentContainer ?? gumElementOrInstanceSaveAsObject as ElementSave;
 
@@ -687,15 +690,15 @@ namespace Gum.PropertyGridHelpers
                 // need to set the exposed name on the variable, but only if it is defined in this component or in
                 // a base component:
 
-                variableDefinedInThisOrBase = SelectedState.Self.SelectedStateSave.GetVariableSave(Name);
-                if (variableDefinedInThisOrBase == null && SelectedState.Self.SelectedStateSave != SelectedState.Self.SelectedElement.DefaultState)
+                variableDefinedInThisOrBase = _selectedState.SelectedStateSave.GetVariableSave(Name);
+                if (variableDefinedInThisOrBase == null && _selectedState.SelectedStateSave != _selectedState.SelectedElement.DefaultState)
                 {
-                    variableDefinedInThisOrBase = SelectedState.Self.SelectedElement.DefaultState.GetVariableSave(Name);
+                    variableDefinedInThisOrBase = _selectedState.SelectedElement.DefaultState.GetVariableSave(Name);
                 }
 
                 if (variableDefinedInThisOrBase == null)
                 {
-                    var allBase = _objectFinder.GetBaseElements(SelectedState.Self.SelectedElement);
+                    var allBase = _objectFinder.GetBaseElements(_selectedState.SelectedElement);
                     foreach (var baseElement in allBase)
                     {
                         variableDefinedInThisOrBase = baseElement.DefaultState.GetVariableSave(Name);
@@ -732,13 +735,13 @@ namespace Gum.PropertyGridHelpers
             bool shouldReset = false;
             bool affectsTreeView = false;
 
-            var selectedElement = SelectedState.Self.SelectedElement;
-            var selectedInstance = SelectedState.Self.SelectedInstance;
+            var selectedElement = _selectedState.SelectedElement;
+            var selectedInstance = _selectedState.SelectedInstance;
 
             if (selectedInstance != null)
             {
                 affectsTreeView = variableName == "Parent";
-                //variableName = SelectedState.Self.SelectedInstance.Name + "." + variableName;
+                //variableName = _selectedState.SelectedInstance.Name + "." + variableName;
 
                 shouldReset = true;
             }
@@ -748,7 +751,7 @@ namespace Gum.PropertyGridHelpers
                     // Don't let the user reset standard element variables, they have to have some actual value
                     (selectedElement is StandardElementSave) == false ||
                     // ... unless it's not the default
-                    SelectedState.Self.SelectedStateSave != SelectedState.Self.SelectedElement.DefaultState;
+                    _selectedState.SelectedStateSave != _selectedState.SelectedElement.DefaultState;
             }
 
             // now we reset, but we don't remove the variable:
@@ -765,7 +768,7 @@ namespace Gum.PropertyGridHelpers
             //    }
             //}
 
-            StateSave state = SelectedState.Self.SelectedStateSave;
+            StateSave state = _selectedState.SelectedStateSave;
             VariableSave variable = state?.GetVariableSave(variableName);
             var oldValue = variable?.Value;
             LastOldFullCommitValue = oldValue;
@@ -787,8 +790,8 @@ namespace Gum.PropertyGridHelpers
                     // necessarily need to have all
                     // of their variables, we can remove
                     // the variable now. In fact, we should
-                    //bool shouldRemove = SelectedState.Self.SelectedInstance != null ||
-                    //    SelectedState.Self.SelectedStateSave != SelectedState.Self.SelectedElement.DefaultState;
+                    //bool shouldRemove = _selectedState.SelectedInstance != null ||
+                    //    _selectedState.SelectedStateSave != _selectedState.SelectedElement.DefaultState;
                     // Also, don't remove it if it's an exposed variable, this un-exposes things
                     bool shouldRemove = string.IsNullOrEmpty(variable.ExposedAsName) && !isPartOfCategory && !variable.IsCustomVariable;
 
@@ -815,7 +818,7 @@ namespace Gum.PropertyGridHelpers
                     }
                     else if (isPartOfCategory)
                     {
-                        var variableInDefault = SelectedState.Self.SelectedElement.DefaultState.GetVariableSave(variable.Name);
+                        var variableInDefault = _selectedState.SelectedElement.DefaultState.GetVariableSave(variable.Name);
                         if (variableInDefault != null)
                         {
                             GumCommands.Self.GuiCommands.PrintOutput(
@@ -880,10 +883,10 @@ namespace Gum.PropertyGridHelpers
 
                     if (affectsTreeView)
                     {
-                        GumCommands.Self.GuiCommands.RefreshElementTreeView(SelectedState.Self.SelectedElement);
+                        GumCommands.Self.GuiCommands.RefreshElementTreeView(_selectedState.SelectedElement);
                     }
 
-                    GumCommands.Self.FileCommands.TryAutoSaveElement(SelectedState.Self.SelectedElement);
+                    GumCommands.Self.FileCommands.TryAutoSaveElement(_selectedState.SelectedElement);
                 }
             }
             else

--- a/Gum/Plugins/InternalPlugins/VariableGrid/ViewModels/AddVariableViewModel.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/ViewModels/AddVariableViewModel.cs
@@ -12,6 +12,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using GumCommon;
 using ToolsUtilities;
 
 namespace Gum.Plugins.InternalPlugins.VariableGrid.ViewModels;
@@ -98,18 +99,17 @@ public class AddVariableViewModel : ViewModel
     #endregion
 
     public AddVariableViewModel(Commands.GuiCommands guiCommands,
-        ISelectedState selectedState,
         UndoManager undoManager,
         ElementCommands elementCommands,
         FileCommands fileCommands,
         NameVerifier nameVerifier)
     {
         _guiCommands = guiCommands;
-        _selectedState = selectedState;
         _undoManager = undoManager;
         _elementCommands = elementCommands;
         _fileCommands = fileCommands;
         _nameVerifier = nameVerifier;
+        _selectedState = Locator.GetRequiredService<ISelectedState>();
 
         AvailableTypes = new List<string>();
         AvailableTypes.Add("float");

--- a/Gum/Plugins/InternalPlugins/VariableGrid/ViewModels/AddVariableViewModel.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/ViewModels/AddVariableViewModel.cs
@@ -227,7 +227,7 @@ public class AddVariableViewModel : ViewModel
         }
         else if (_selectedState.SelectedElement != null)
         {
-            DoEditsToVariableOnElement(variable, SelectedState.Self.SelectedElement, changes, type, newName);
+            DoEditsToVariableOnElement(variable, _selectedState.SelectedElement, changes, type, newName);
         }
         _guiCommands.RefreshVariables(force: true);
     }

--- a/Gum/Plugins/PluginManager.cs
+++ b/Gum/Plugins/PluginManager.cs
@@ -22,6 +22,7 @@ using Gum.Managers;
 using Gum.Services;
 using RenderingLibrary;
 using System.Numerics;
+using GumCommon;
 
 namespace Gum.Plugins
 {
@@ -100,7 +101,7 @@ namespace Gum.Plugins
         }
 
         [Export("LocalizationManager")]
-        public LocalizationManager LocalizationManager => Builder.Get<LocalizationManager>();
+        public LocalizationManager LocalizationManager => Locator.GetRequiredService<LocalizationManager>();
 
 
         internal static List<PluginContainer> AllPluginContainers

--- a/Gum/PropertyGridHelpers/Converters/AvailableAnimationNamesConverter.cs
+++ b/Gum/PropertyGridHelpers/Converters/AvailableAnimationNamesConverter.cs
@@ -4,17 +4,23 @@ using Gum.DataTypes.Variables;
 using Gum.ToolStates;
 using System.Collections.Generic;
 using System.ComponentModel;
+using GumCommon;
 using ToolsUtilities;
 
 namespace Gum.PropertyGridHelpers.Converters
 {
     internal class AvailableAnimationNamesConverter : TypeConverter
     {
+        private readonly ISelectedState _selectedState;
+        
         ElementSave container;
+        
         public AvailableAnimationNamesConverter(ElementSave container)
         {
             this.container = container;
+            _selectedState = Locator.GetRequiredService<ISelectedState>();
         }
+        
         public override bool GetStandardValuesSupported(ITypeDescriptorContext context)
         {
             return true;
@@ -27,8 +33,8 @@ namespace Gum.PropertyGridHelpers.Converters
 
         public override TypeConverter.StandardValuesCollection GetStandardValues(ITypeDescriptorContext context)
         {
-            var stateSave = SelectedState.Self.SelectedStateSave;
-            var instance = SelectedState.Self.SelectedInstance;
+            var stateSave = _selectedState.SelectedStateSave;
+            var instance = _selectedState.SelectedInstance;
             List<string> values = GetAvailableValues(container, instance, stateSave);
 
             return new StandardValuesCollection(values);

--- a/Gum/PropertyGridHelpers/Converters/AvailableContainedTypeConverter.cs
+++ b/Gum/PropertyGridHelpers/Converters/AvailableContainedTypeConverter.cs
@@ -4,11 +4,19 @@ using Gum.ToolStates;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using GumCommon;
 
 namespace Gum.PropertyGridHelpers.Converters
 {
     public class AvailableContainedTypeConverter : TypeConverter
     {
+        private readonly ISelectedState _selectedState;
+        
+        public AvailableContainedTypeConverter()
+        {
+            _selectedState = Locator.GetRequiredService<ISelectedState>();
+        }
+        
         public override bool GetStandardValuesSupported(ITypeDescriptorContext context)
         {
             return true;
@@ -36,11 +44,11 @@ namespace Gum.PropertyGridHelpers.Converters
                 }
             }
 
-            var instance = GumState.Self.SelectedState.SelectedInstance;
+            var instance = _selectedState.SelectedInstance;
             if(instance != null)
             {
                 var instanceName = instance.Name;
-                var currentElement = GumState.Self.SelectedState.SelectedElement;
+                var currentElement = _selectedState.SelectedElement;
 
                 foreach(var otherInstance in currentElement.Instances)
                 {

--- a/Gum/PropertyGridHelpers/Converters/AvailableInstancesConverter.cs
+++ b/Gum/PropertyGridHelpers/Converters/AvailableInstancesConverter.cs
@@ -4,11 +4,14 @@ using Gum.ToolStates;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
+using GumCommon;
 
 namespace Gum.PropertyGridHelpers.Converters
 {
     public class AvailableInstancesConverter : TypeConverter
     {
+        private readonly ISelectedState _selectedState;
+        
         public bool ExcludeCurrentInstance
         {
             get;
@@ -34,6 +37,7 @@ namespace Gum.PropertyGridHelpers.Converters
         public AvailableInstancesConverter()
         {
             ExcludeCurrentInstance = true;
+            _selectedState = Locator.GetRequiredService<ISelectedState>();
         }
 
 
@@ -42,7 +46,7 @@ namespace Gum.PropertyGridHelpers.Converters
         {
             List<string> values;
 
-            var element = SelectedState.Self.SelectedElement;
+            var element = _selectedState.SelectedElement;
 
             if (element == null)
             {
@@ -50,8 +54,8 @@ namespace Gum.PropertyGridHelpers.Converters
             }
             else
             {
-                values = SelectedState.Self.SelectedElement.Instances
-                    .Where(item=>item != SelectedState.Self.SelectedInstance)
+                values = _selectedState.SelectedElement.Instances
+                    .Where(item=>item != _selectedState.SelectedInstance)
                     .Select(item => item.Name)
                     .ToList<string>();
             }
@@ -59,7 +63,7 @@ namespace Gum.PropertyGridHelpers.Converters
             values.Insert(0, "<NONE>");
 
             // If the selected object is an instance which is part of a component, don't let the user attach that to screen bounds:
-            var isInstanceInComponent = element is ComponentSave && SelectedState.Self.SelectedInstance != null;
+            var isInstanceInComponent = element is ComponentSave && _selectedState.SelectedInstance != null;
             if (IncludeScreenBounds && !isInstanceInComponent)
             {
                 values.Insert(1, StandardElementsManager.ScreenBoundsName);

--- a/Gum/PropertyGridHelpers/Converters/AvailableStatesConverter.cs
+++ b/Gum/PropertyGridHelpers/Converters/AvailableStatesConverter.cs
@@ -4,11 +4,14 @@ using System.Linq;
 using Gum.DataTypes;
 using Gum.Managers;
 using Gum.ToolStates;
+using GumCommon;
 
 namespace Gum.PropertyGridHelpers.Converters
 {
     public class AvailableStatesConverter : TypeConverter
     {
+        private readonly ISelectedState _selectedState;
+        
         InstanceSave mOverridingInstanceSave;
         ElementSave mOverridingElementSave;
 
@@ -27,7 +30,7 @@ namespace Gum.PropertyGridHelpers.Converters
                 }
                 else
                 {
-                    return SelectedState.Self.SelectedInstance;
+                    return _selectedState.SelectedInstance;
                 }
             }
             set
@@ -46,7 +49,7 @@ namespace Gum.PropertyGridHelpers.Converters
                 }
                 else
                 {
-                    return SelectedState.Self.SelectedElement;
+                    return _selectedState.SelectedElement;
 
                 }
             }
@@ -60,7 +63,7 @@ namespace Gum.PropertyGridHelpers.Converters
         public AvailableStatesConverter(string category)
         {
             CategoryName = category;
-
+            _selectedState = Locator.GetRequiredService<ISelectedState>();
         }
 
 

--- a/Gum/Services/EditVariableService.cs
+++ b/Gum/Services/EditVariableService.cs
@@ -16,6 +16,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using GumCommon;
 using WpfDataUi.DataTypes;
 
 namespace Gum.Services;
@@ -230,7 +231,7 @@ public class EditVariableService : IEditVariableService
         }
 
         // We can re-use the logic in the AddVariableViewModel:
-        var vm = Builder.Get<AddVariableViewModel>();
+        var vm = Locator.GetRequiredService<AddVariableViewModel>();
         vm.RenameType = RenameType.ExposedName;
         vm.ApplyVariableReferenceChanges(changeResponse, newName, oldName, changedElements);
 
@@ -244,7 +245,7 @@ public class EditVariableService : IEditVariableService
 
     private void ShowFullEditUi(VariableSave variable, IStateContainer container)
     {
-        var vm = Builder.Get<AddVariableViewModel>();
+        var vm = Locator.GetRequiredService<AddVariableViewModel>();
         vm.RenameType = RenameType.NormalName;
 
         vm.Variable = variable;

--- a/Gum/Services/ExposeVariableService.cs
+++ b/Gum/Services/ExposeVariableService.cs
@@ -33,14 +33,16 @@ internal class ExposeVariableService : IExposeVariableService
     private readonly GuiCommands _guiCommands;
     private readonly FileCommands _fileCommands;
     private readonly RenameLogic _renameLogic;
+    private readonly ISelectedState _selectedState;
 
     public ExposeVariableService(UndoManager undoManager, GuiCommands guiCommands, FileCommands fileCommands,
-        RenameLogic renameLogic)
+        RenameLogic renameLogic, ISelectedState selectedState)
     {
         _undoManager = undoManager;
         _guiCommands = guiCommands;
         _fileCommands = fileCommands;
         _renameLogic = renameLogic;
+        _selectedState = selectedState;
     }
 
     public void HandleExposeVariableClick(InstanceSave instanceSave, VariableSave variableSave, string rootVariableName)
@@ -73,16 +75,16 @@ internal class ExposeVariableService : IExposeVariableService
         if (result == DialogResult.OK)
         {
             string whyNot;
-            if (!NameVerifier.Self.IsVariableNameValid(tiw.Result, SelectedState.Self.SelectedElement, variableSave, out whyNot))
+            if (!NameVerifier.Self.IsVariableNameValid(tiw.Result, _selectedState.SelectedElement, variableSave, out whyNot))
             {
                 MessageBox.Show(whyNot);
             }
             else
             {
-                var elementSave = SelectedState.Self.SelectedElement;
+                var elementSave = _selectedState.SelectedElement;
                 // if there is an inactive variable,
                 // we should get rid of it:
-                var existingVariable = SelectedState.Self.SelectedElement.GetVariableFromThisOrBase(tiw.Result);
+                var existingVariable = _selectedState.SelectedElement.GetVariableFromThisOrBase(tiw.Result);
 
                 // there's a variable but we shouldn't consider it
                 // unless it's "Active" - inactive variables may be
@@ -106,7 +108,7 @@ internal class ExposeVariableService : IExposeVariableService
 
                 if(variableSave == null)
                 {
-                    StateSave stateToExposeOn = SelectedState.Self.SelectedElement.DefaultState;
+                    StateSave stateToExposeOn = _selectedState.SelectedElement.DefaultState;
 
                     var variableInDefault = ObjectFinder.Self.GetRootVariable(fullVariableName, instanceSave.ParentContainer);
 
@@ -148,8 +150,8 @@ internal class ExposeVariableService : IExposeVariableService
         // was selected; however, exposed
         // variables should be exposed on the
         // default state or else Gum breaks
-        //StateSave currentStateSave = SelectedState.Self.SelectedStateSave;
-        StateSave stateToExposeOn = SelectedState.Self.SelectedElement.DefaultState;
+        //StateSave currentStateSave = _selectedState.SelectedStateSave;
+        StateSave stateToExposeOn = _selectedState.SelectedElement.DefaultState;
 
         if (variableSave == null)
         {
@@ -178,7 +180,7 @@ internal class ExposeVariableService : IExposeVariableService
         // Actually yes, expose it
         // but make it read-only.
         // https://github.com/vchelaru/Gum/issues/521
-        //var selectedElement = SelectedState.Self.SelectedElement;
+        //var selectedElement = _selectedState.SelectedElement;
 
         //var fullVariableName = instanceSave.Name + "." + rootVariableName;
 

--- a/Gum/Services/ExposeVariableService.cs
+++ b/Gum/Services/ExposeVariableService.cs
@@ -13,6 +13,7 @@ using System.Threading.Tasks;
 using System.Windows.Forms;
 using Gum.Commands;
 using Gum.Undo;
+using GumCommon;
 using ToolsUtilities;
 
 namespace Gum.Services;
@@ -36,13 +37,13 @@ internal class ExposeVariableService : IExposeVariableService
     private readonly ISelectedState _selectedState;
 
     public ExposeVariableService(UndoManager undoManager, GuiCommands guiCommands, FileCommands fileCommands,
-        RenameLogic renameLogic, ISelectedState selectedState)
+        RenameLogic renameLogic)
     {
         _undoManager = undoManager;
         _guiCommands = guiCommands;
         _fileCommands = fileCommands;
         _renameLogic = renameLogic;
-        _selectedState = selectedState;
+        _selectedState = Locator.GetRequiredService<ISelectedState>();
     }
 
     public void HandleExposeVariableClick(InstanceSave instanceSave, VariableSave variableSave, string rootVariableName)

--- a/Gum/ToolCommands/ElementCommands.cs
+++ b/Gum/ToolCommands/ElementCommands.cs
@@ -13,6 +13,7 @@ using Gum.Wireframe;
 using GumRuntime;
 using Gum.Converters;
 using Gum.RenderingLibrary;
+using GumCommon;
 using RenderingLibrary;
 
 namespace Gum.ToolCommands
@@ -21,6 +22,8 @@ namespace Gum.ToolCommands
     {
         #region Fields
 
+        private readonly ISelectedState _selectedState;
+        
         static ElementCommands mSelf;
 
         #endregion
@@ -40,6 +43,11 @@ namespace Gum.ToolCommands
         }
 
         #endregion
+
+        public ElementCommands()
+        {
+            _selectedState = Locator.GetRequiredService<ISelectedState>();
+        }
 
         #region Instance
 
@@ -65,7 +73,7 @@ namespace Gum.ToolCommands
             GumCommands.Self.GuiCommands.RefreshElementTreeView(elementToAddTo);
 
             Wireframe.WireframeObjectManager.Self.RefreshAll(true);
-            //SelectedState.Self.SelectedInstance = instanceSave;
+            //_selectedState.SelectedInstance = instanceSave;
 
             // Set the parent before adding the instance in case plugins want to reject the creation of the object...
             if (!string.IsNullOrEmpty(parentName))
@@ -90,7 +98,7 @@ namespace Gum.ToolCommands
             }
             else
             {
-                SelectedState.Self.SelectedInstance = instanceSave;
+                _selectedState.SelectedInstance = instanceSave;
             }
 
             GumCommands.Self.FileCommands.TryAutoSaveElement(elementToAddTo);
@@ -120,9 +128,9 @@ namespace Gum.ToolCommands
 
             PluginManager.Self.InstanceDelete(elementToRemoveFrom, instanceToRemove);
 
-            if (SelectedState.Self.SelectedInstance == instanceToRemove)
+            if (_selectedState.SelectedInstance == instanceToRemove)
             {
-                SelectedState.Self.SelectedInstance = null;
+                _selectedState.SelectedInstance = null;
             }
         }
 
@@ -138,9 +146,9 @@ namespace Gum.ToolCommands
 
             PluginManager.Self.InstancesDelete(elementToRemoveFrom, instances.ToArray());
 
-            var newSelection = SelectedState.Self.SelectedInstances.ToList()
+            var newSelection = _selectedState.SelectedInstances.ToList()
                 .Except(instances);
-            SelectedState.Self.SelectedInstances = newSelection;
+            _selectedState.SelectedInstances = newSelection;
         }
 
         #endregion
@@ -273,18 +281,18 @@ namespace Gum.ToolCommands
             // knows, maybe other parts of the code
             // in the future), so we should make sure
             // that something is really selected.
-            var hasSelection = SelectedState.Self.SelectedComponent != null ||
-                SelectedState.Self.SelectedStandardElement != null ||
-                SelectedState.Self.SelectedInstance != null;
+            var hasSelection = _selectedState.SelectedComponent != null ||
+                _selectedState.SelectedStandardElement != null ||
+                _selectedState.SelectedInstance != null;
 
             if (hasSelection)
             {
-                var isMovingElement = SelectedState.Self.SelectedInstances.Count() == 0 &&
-                    (SelectedState.Self.SelectedComponent != null || SelectedState.Self.SelectedStandardElement != null);
+                var isMovingElement = _selectedState.SelectedInstances.Count() == 0 &&
+                    (_selectedState.SelectedComponent != null || _selectedState.SelectedStandardElement != null);
 
                 if (isMovingElement)
                 {
-                    var element = SelectedState.Self.SelectedElement;
+                    var element = _selectedState.SelectedElement;
                     if (xToMoveBy != 0)
                     {
                         hasChangeOccurred = true;
@@ -298,7 +306,7 @@ namespace Gum.ToolCommands
                 }
                 else
                 {
-                    var selectedInstances = SelectedState.Self.SelectedInstances;
+                    var selectedInstances = _selectedState.SelectedInstances;
 
                     foreach (InstanceSave instance in selectedInstances)
                     {
@@ -332,11 +340,11 @@ namespace Gum.ToolCommands
 
         public bool ShouldSkipDraggingMovementOn(InstanceSave instanceSave)
         {
-            ElementWithState element = new ElementWithState(SelectedState.Self.SelectedElement);
+            ElementWithState element = new ElementWithState(_selectedState.SelectedElement);
 
             List<ElementWithState> stack = new List<ElementWithState>() { element };
 
-            var selectedInstances = SelectedState.Self.SelectedInstances;
+            var selectedInstances = _selectedState.SelectedInstances;
 
             bool shouldSkip = false;
             // Make sure this isn't attached to another instance
@@ -370,7 +378,7 @@ namespace Gum.ToolCommands
 
             bool shouldContinue = true;
 
-            if (SelectedState.Self.CustomCurrentStateSave != null || currentValueAsObject == null)
+            if (_selectedState.CustomCurrentStateSave != null || currentValueAsObject == null)
             {
                 // This is okay, we will do nothing here:
                 shouldContinue = false;
@@ -405,12 +413,12 @@ namespace Gum.ToolCommands
                 }
 
                 float newValue = currentValue + modificationAmount;
-                SelectedState.Self.SelectedStateSave.SetValue(nameWithInstance, newValue, instanceSave, "float");
-                ElementSaveExtensions.ApplyVariableReferences(SelectedState.Self.SelectedElement, SelectedState.Self.SelectedStateSave);
+                _selectedState.SelectedStateSave.SetValue(nameWithInstance, newValue, instanceSave, "float");
+                ElementSaveExtensions.ApplyVariableReferences(_selectedState.SelectedElement, _selectedState.SelectedStateSave);
 
                 graphicalUiElement.SetProperty(baseVariableName, newValue);
 
-                WireframeObjectManager.Self.RootGue?.ApplyVariableReferences(SelectedState.Self.SelectedStateSave);
+                WireframeObjectManager.Self.RootGue?.ApplyVariableReferences(_selectedState.SelectedStateSave);
 
                 VariableInCategoryPropagationLogic.Self.PropagateVariablesInCategory(nameWithInstance,
                     GumState.Self.SelectedState.SelectedElement, GumState.Self.SelectedState.SelectedStateCategorySave);
@@ -438,7 +446,7 @@ namespace Gum.ToolCommands
             modificationAmount = ConvertAmountToPixelAccordingToUnitType(baseVariableName, modificationAmount, unitsVariableAsObject);
 
             float newValue = currentValue + modificationAmount;
-            SelectedState.Self.SelectedStateSave.SetValue(baseVariableName, newValue, null, "float");
+            _selectedState.SelectedStateSave.SetValue(baseVariableName, newValue, null, "float");
 
 
             var ipso = WireframeObjectManager.Self.GetRepresentation(elementSave);
@@ -469,22 +477,22 @@ namespace Gum.ToolCommands
         /// <param name="nameWithInstance"></param>
         /// <param name="currentValue"></param>
         /// <returns></returns>
-        private static object GetCurrentValueForVariable(string baseVariableName, InstanceSave instanceSave, out string nameWithInstance, out object currentValue)
+        private object GetCurrentValueForVariable(string baseVariableName, InstanceSave instanceSave, out string nameWithInstance, out object currentValue)
         {
             nameWithInstance = baseVariableName;
 
             currentValue = null;
 
-            if (SelectedState.Self.SelectedStateSave != null)
+            if (_selectedState.SelectedStateSave != null)
             {
                 if (instanceSave != null)
                 {
                     nameWithInstance = instanceSave.Name + "." + baseVariableName;
-                    currentValue = SelectedState.Self.SelectedStateSave.GetValueRecursive(nameWithInstance);
+                    currentValue = _selectedState.SelectedStateSave.GetValueRecursive(nameWithInstance);
                 }
                 else
                 {
-                    currentValue = SelectedState.Self.SelectedStateSave.GetValueRecursive(nameWithInstance);
+                    currentValue = _selectedState.SelectedStateSave.GetValueRecursive(nameWithInstance);
                 }
             }
 
@@ -652,7 +660,7 @@ namespace Gum.ToolCommands
                 }
             }
 
-            ElementTreeViewManager.Self.RefreshUi(SelectedState.Self.SelectedStateContainer);
+            ElementTreeViewManager.Self.RefreshUi(_selectedState.SelectedStateContainer);
 
             GumCommands.Self.GuiCommands.RefreshStateTreeView();
 
@@ -684,7 +692,7 @@ namespace Gum.ToolCommands
             GumCommands.Self.GuiCommands.RefreshElementTreeView(behaviorToAddTo);
 
             Wireframe.WireframeObjectManager.Self.RefreshAll(true);
-            //SelectedState.Self.SelectedInstance = instanceSave;
+            //_selectedState.SelectedInstance = instanceSave;
 
             // Set the parent before adding the instance in case plugins want to reject the creation of the object...
             //if (!string.IsNullOrEmpty(parentName))
@@ -709,7 +717,7 @@ namespace Gum.ToolCommands
             //}
             //else
             {
-                SelectedState.Self.SelectedInstance = instanceSave;
+                _selectedState.SelectedInstance = instanceSave;
             }
 
             GumCommands.Self.FileCommands.TryAutoSaveBehavior(behaviorToAddTo);

--- a/Gum/ToolCommands/ElementCommands.cs
+++ b/Gum/ToolCommands/ElementCommands.cs
@@ -421,7 +421,7 @@ namespace Gum.ToolCommands
                 WireframeObjectManager.Self.RootGue?.ApplyVariableReferences(_selectedState.SelectedStateSave);
 
                 VariableInCategoryPropagationLogic.Self.PropagateVariablesInCategory(nameWithInstance,
-                    GumState.Self.SelectedState.SelectedElement, GumState.Self.SelectedState.SelectedStateCategorySave);
+                    _selectedState.SelectedElement, _selectedState.SelectedStateCategorySave);
 
 
                 return newValue;
@@ -454,7 +454,7 @@ namespace Gum.ToolCommands
 
             VariableInCategoryPropagationLogic.Self.PropagateVariablesInCategory(baseVariableName,
                 elementSave,
-                GumState.Self.SelectedState.SelectedStateCategorySave);
+                _selectedState.SelectedStateCategorySave);
 
             return newValue;
         }

--- a/Gum/ToolCommands/ProjectCommands.cs
+++ b/Gum/ToolCommands/ProjectCommands.cs
@@ -10,6 +10,7 @@ using System.Windows.Controls;
 using Gum.DataTypes.Variables;
 using Gum.Plugins;
 using System.Linq;
+using GumCommon;
 
 namespace Gum.ToolCommands;
 
@@ -18,6 +19,7 @@ public class ProjectCommands
     #region Fields
 
     static ProjectCommands mSelf;
+    private readonly ISelectedState _selectedState;
 
     #endregion
 
@@ -39,6 +41,11 @@ public class ProjectCommands
 
     #endregion
 
+    public ProjectCommands()
+    {
+        _selectedState = Locator.GetRequiredService<ISelectedState>();
+    }
+    
     #region Screens
     /// <summary>
     /// Creates a new Screen using the argument as the name. This saves the newly created screen to disk and saves the project.
@@ -144,7 +151,7 @@ public class ProjectCommands
             }
         }
 
-        SelectedState.Self.SelectedBehavior = null;
+        _selectedState.SelectedBehavior = null;
 
         PluginManager.Self.BehaviorDeleted(behavior);
 
@@ -237,7 +244,7 @@ public class ProjectCommands
         GumCommands.Self.FileCommands.TryAutoSaveElement(componentSave);
         Plugins.PluginManager.Self.ElementAdd(componentSave);
 
-        SelectedState.Self.SelectedComponent = componentSave;
+        _selectedState.SelectedComponent = componentSave;
     }
 
     private void PrepareNewComponentSave(ComponentSave componentSave, string componentName)

--- a/Gum/ToolStates/GumState.cs
+++ b/Gum/ToolStates/GumState.cs
@@ -5,6 +5,5 @@ namespace Gum.ToolStates
     public class GumState : Singleton<GumState>
     {
         public ProjectState ProjectState => ProjectState.Self;
-        public ISelectedState SelectedState => Gum.ToolStates.SelectedState.Self;
     }
 }

--- a/Gum/ToolStates/ProjectState.cs
+++ b/Gum/ToolStates/ProjectState.cs
@@ -17,14 +17,6 @@ public class ProjectState
         }
     }
 
-    public ISelectedState Selected
-    {
-        get
-        {
-            return SelectedState.Self;
-        }
-    }
-
     public GumProjectSave GumProjectSave => ProjectManager.Self.GumProjectSave;
     public GeneralSettingsFile GeneralSettings => ProjectManager.Self.GeneralSettingsFile;
 

--- a/Gum/ToolStates/SelectedState.cs
+++ b/Gum/ToolStates/SelectedState.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Gum.DataTypes;
@@ -717,11 +717,6 @@ public class SelectedState : ISelectedState
     }
 
     #endregion
-
-    private SelectedState()
-    {
-
-    }
 
     public List<ElementWithState> GetTopLevelElementStack()
     {

--- a/Gum/ToolStates/SelectedState.cs
+++ b/Gum/ToolStates/SelectedState.cs
@@ -241,24 +241,7 @@ public class SelectedState : ISelectedState
     #endregion
 
     #region Properties
-
-    public static ISelectedState Self
-    {
-        // We usually won't use this in the actual product, but useful for testing
-        set
-        {
-            mSelf = value;
-        }
-        get
-        {
-            if (mSelf == null)
-            {
-                mSelf = new SelectedState();
-            }
-            return mSelf;
-        }
-    }
-
+    
     public IStateContainer SelectedStateContainer
     {
         get

--- a/Gum/ToolStates/SelectedState.cs
+++ b/Gum/ToolStates/SelectedState.cs
@@ -20,7 +20,6 @@ public class SelectedState : ISelectedState
 {
     #region Fields
 
-    static ISelectedState mSelf;
     SelectedStateSnapshot snapshot = new SelectedStateSnapshot();
 
     #endregion

--- a/Gum/Undo/UndoPlugin.cs
+++ b/Gum/Undo/UndoPlugin.cs
@@ -5,6 +5,7 @@ using Gum.DataTypes.Variables;
 using System;
 using Gum.ToolStates;
 using Gum.Services;
+using GumCommon;
 
 namespace Gum.Undo;
 
@@ -15,7 +16,7 @@ public class UndoPlugin : InternalPlugin
     UndoManager _undoManager;
     public UndoPlugin() 
     {
-        _selectedState = Builder.Get<ISelectedState>();
+        _selectedState = Locator.GetRequiredService<ISelectedState>();
         _undoManager = UndoManager.Self;
     }
 

--- a/Gum/Wireframe/GrabbedState.cs
+++ b/Gum/Wireframe/GrabbedState.cs
@@ -6,6 +6,7 @@ using InputLibrary;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using GumCommon;
 using Vector2 = System.Numerics.Vector2;
 using Matrix = System.Numerics.Matrix4x4;
 
@@ -22,6 +23,7 @@ public struct StateAndAbsoluteVector2
 public class GrabbedState
 {
 
+    private readonly ISelectedState _selectedState;
     public StateSave StateSave { get; private set; }
 
     public XOrY? AxisMovedFurthestAlong
@@ -113,6 +115,11 @@ public class GrabbedState
         }
     }
 
+    public GrabbedState()
+    {
+        _selectedState = Locator.GetRequiredService<ISelectedState>();
+    }
+
     public void HandlePush()
     {
         Cursor cursor = InputLibrary.Cursor.Self;
@@ -123,7 +130,7 @@ public class GrabbedState
         AccumulatedXOffset = 0;
         AccumulatedYOffset = 0;
 
-        if(SelectedState.Self.SelectedStateSave != null)
+        if(_selectedState.SelectedStateSave != null)
         {
             RecordInitialPositions();
         }
@@ -134,19 +141,19 @@ public class GrabbedState
         InstancePositions.Clear();
         InstanceSizes.Clear();
 
-        StateSave = SelectedState.Self.SelectedStateSave.Clone();
+        StateSave = _selectedState.SelectedStateSave.Clone();
 
-        if (SelectedState.Self.SelectedInstances.Count() == 0 && SelectedState.Self.SelectedElement != null)
+        if (_selectedState.SelectedInstances.Count() == 0 && _selectedState.SelectedElement != null)
         {
-            var graphicalUiElement = WireframeObjectManager.Self.GetRepresentation(SelectedState.Self.SelectedElement);
+            var graphicalUiElement = WireframeObjectManager.Self.GetRepresentation(_selectedState.SelectedElement);
 
             ComponentPosition = new Vector2(graphicalUiElement.X, graphicalUiElement.Y);
             ComponentSize = new Vector2(graphicalUiElement.Width, graphicalUiElement.Height);
         }
-        else if(SelectedState.Self.SelectedInstances.Count() != 0)
+        else if(_selectedState.SelectedInstances.Count() != 0)
         {
-            var stateSave = SelectedState.Self.SelectedStateSave;
-            foreach(var instance in SelectedState.Self.SelectedInstances)
+            var stateSave = _selectedState.SelectedStateSave;
+            foreach(var instance in _selectedState.SelectedInstances)
             {
                 var instanceGue = WireframeObjectManager.Self.GetRepresentation(instance);
 

--- a/Gum/Wireframe/WireframeObjectManager.RepresentationCreation.cs
+++ b/Gum/Wireframe/WireframeObjectManager.RepresentationCreation.cs
@@ -11,6 +11,7 @@ using Gum.PropertyGridHelpers.Converters;
 using GumRuntime;
 using Gum.Plugins;
 using Gum.Services;
+using GumCommon;
 
 namespace Gum.Wireframe;
 
@@ -51,18 +52,20 @@ public partial class WireframeObjectManager
     #endregion
 
     FontManager _fontManager;
+    private readonly ISelectedState _selectedState;
 
     public WireframeObjectManager()
     {
-        _fontManager = Builder.Get<FontManager>();
+        _fontManager = Locator.GetRequiredService<FontManager>();
+        _selectedState = Locator.GetRequiredService<ISelectedState>();
     }
 
-    private static bool GetIfSelectedStateIsSetRecursively()
+    private bool GetIfSelectedStateIsSetRecursively()
     {
-        var category = SelectedState.Self.SelectedStateCategorySave;
+        var category = _selectedState.SelectedStateCategorySave;
         if(category != null)
         {
-            var selectedElement = SelectedState.Self.SelectedElement;
+            var selectedElement = _selectedState.SelectedElement;
             foreach(var behaviorReference in selectedElement.Behaviors)
             {
                 var behavior = ObjectFinder.Self.GetBehavior(behaviorReference);

--- a/Gum/Wireframe/WireframeObjectManager.cs
+++ b/Gum/Wireframe/WireframeObjectManager.cs
@@ -184,7 +184,7 @@ public partial class WireframeObjectManager
 
                     // Always set default first, then if the selected state is not the default, then apply that after:
                     RootGue.SetVariablesRecursively(elementSave, elementSave.DefaultState);
-                    var selectedState = GumState.Self.SelectedState.SelectedStateSave;
+                    var selectedState = _selectedState.SelectedStateSave;
                     if(selectedState != null && selectedState != elementSave.DefaultState)
                     {
                         RootGue.ApplyState(selectedState);
@@ -297,7 +297,7 @@ public partial class WireframeObjectManager
         var shouldLocalize = GumState.Self.ProjectState.GumProjectSave.ShowLocalizationInGum;
         //if(gue.Tag is InstanceSave instance)
         //{
-        //    var rfv = new RecursiveVariableFinder(GumState.Self.SelectedState.SelectedStateSave);
+        //    var rfv = new RecursiveVariableFinder(_selectedState.SelectedStateSave);
 
         //    var value = rfv.GetValue<bool>(instance.Name + ".Apply Localization");
         //    isLocalized = value;

--- a/Gum/Wireframe/WireframeObjectManager.cs
+++ b/Gum/Wireframe/WireframeObjectManager.cs
@@ -9,6 +9,7 @@ using RenderingLibrary.Content;
 using RenderingLibrary;
 using Gum.RenderingLibrary;
 using Gum.Plugins;
+using GumCommon;
 using Color = System.Drawing.Color;
 using Rectangle = System.Drawing.Rectangle;
 using Matrix = System.Numerics.Matrix4x4;
@@ -36,7 +37,6 @@ public partial class WireframeObjectManager
 
     GraphicalUiElementManager gueManager;
     private LocalizationManager _localizationManager;
-
 
     #endregion
 
@@ -71,7 +71,7 @@ public partial class WireframeObjectManager
     public System.Windows.Forms.Cursor AddCursor { get; private set; }
 
     #endregion
-
+    
     #region Initialize
 
     public void Initialize(
@@ -131,9 +131,9 @@ public partial class WireframeObjectManager
         ElementSave elementSave = null;
 
         // If mulitple elements are selected then we can't show them all, so act as if nothing is selected.
-        if(SelectedState.Self.SelectedElements.Count() == 1)
+        if(_selectedState.SelectedElements.Count() == 1)
         {
-            elementSave = SelectedState.Self.SelectedElement;
+            elementSave = _selectedState.SelectedElement;
         }
 
 
@@ -356,17 +356,17 @@ public partial class WireframeObjectManager
 
     public GraphicalUiElement GetSelectedRepresentation()
     {
-        if (SelectedState.Self.SelectedIpso == null)
+        if (_selectedState.SelectedIpso == null)
         {
             return null;
         }
-        else if (SelectedState.Self.SelectedInstance != null)
+        else if (_selectedState.SelectedInstance != null)
         {
-            return GetRepresentation(SelectedState.Self.SelectedInstance, SelectedState.Self.GetTopLevelElementStack());
+            return GetRepresentation(_selectedState.SelectedInstance, _selectedState.GetTopLevelElementStack());
         }
-        else if (SelectedState.Self.SelectedElement != null)
+        else if (_selectedState.SelectedElement != null)
         {
-            return GetRepresentation(SelectedState.Self.SelectedElement);
+            return GetRepresentation(_selectedState.SelectedElement);
         }
         else
         {
@@ -376,21 +376,21 @@ public partial class WireframeObjectManager
 
     public GraphicalUiElement[] GetSelectedRepresentations()
     {
-        if (SelectedState.Self.SelectedIpso == null)
+        if (_selectedState.SelectedIpso == null)
         {
             return null;
         }
-        else if(SelectedState.Self.SelectedInstances.Count() > 0)
+        else if(_selectedState.SelectedInstances.Count() > 0)
         {
-            return SelectedState.Self.SelectedInstances
-                .Select(item => GetRepresentation(item, SelectedState.Self.GetTopLevelElementStack()))
+            return _selectedState.SelectedInstances
+                .Select(item => GetRepresentation(item, _selectedState.GetTopLevelElementStack()))
                 .ToArray();
         }
-        else if (SelectedState.Self.SelectedElement != null)
+        else if (_selectedState.SelectedElement != null)
         {
             return new GraphicalUiElement[]
             {
-                GetRepresentation(SelectedState.Self.SelectedElement)
+                GetRepresentation(_selectedState.SelectedElement)
             };
         }
         else
@@ -452,7 +452,7 @@ public partial class WireframeObjectManager
     /// <returns>The InstanceSave or null if one isn't found.</returns>
     public InstanceSave GetInstance(IRenderableIpso representation, InstanceFetchType fetchType, List<ElementWithState> elementStack)
     {
-        ElementSave selectedElement = SelectedState.Self.SelectedElement;
+        ElementSave selectedElement = _selectedState.SelectedElement;
 
         string prefix = selectedElement.Name + ".";
         if (selectedElement is ScreenSave)
@@ -558,10 +558,10 @@ public partial class WireframeObjectManager
 
     public ElementSave GetElement(IPositionedSizedObject representation)
     {
-        if (SelectedState.Self.SelectedElement != null &&
-            SelectedState.Self.SelectedElement.Name == representation.Name)
+        if (_selectedState.SelectedElement != null &&
+            _selectedState.SelectedElement.Name == representation.Name)
         {
-            return SelectedState.Self.SelectedElement;
+            return _selectedState.SelectedElement;
         }
 
         return null;

--- a/GumCommon/GumCommon.csproj
+++ b/GumCommon/GumCommon.csproj
@@ -157,4 +157,7 @@
 			<Link>Graphics\HorizontalAlignment.cs</Link>
 		</Compile>
 	</ItemGroup>
+	<ItemGroup>
+	  <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.6" />
+	</ItemGroup>
 </Project>

--- a/GumCommon/Locator.cs
+++ b/GumCommon/Locator.cs
@@ -1,0 +1,20 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+
+namespace GumCommon;
+
+public static class Locator
+{
+    private static List<IServiceProvider> ServiceProviders { get; } = [];
+    public static void Register(IServiceProvider serviceProvider)
+    {
+        if (ServiceProviders.Contains(serviceProvider))
+        {
+            throw new InvalidOperationException("Trying to register a provider that is already registered.");
+        }
+        ServiceProviders.Insert(0, serviceProvider);
+    }
+
+    public static T GetRequiredService<T>() => ServiceProviders
+        .Select(isp => isp.GetService<T>())
+        .FirstOrDefault(x => x is not null) ?? throw new InvalidOperationException($"No service for {typeof(T)} has been registered.");
+}

--- a/StateAnimationPlugin/MainStateAnimationPlugin.cs
+++ b/StateAnimationPlugin/MainStateAnimationPlugin.cs
@@ -23,6 +23,7 @@ using Gum.StateAnimation.SaveClasses;
 
 using Gum.Plugins;
 using System.Windows.Forms;
+using GumCommon;
 
 
 namespace StateAnimationPlugin;
@@ -64,7 +65,7 @@ public class MainStateAnimationPlugin : PluginBase
 
     public MainStateAnimationPlugin()
     {
-        _selectedState = SelectedState.Self;
+        _selectedState = Locator.GetRequiredService<ISelectedState>();
         _duplicateService = new DuplicateService();
         _animationFilePathService = new AnimationFilePathService();
         _elementDeleteService = new ElementDeleteService(_animationFilePathService);
@@ -179,7 +180,7 @@ public class MainStateAnimationPlugin : PluginBase
             CreateViewModel();
         }
 
-        if (SelectedState.Self.SelectedElement != null)
+        if (_selectedState.SelectedElement != null)
         {
             RenameManager.Self.HandleRename(instanceSave, oldName, _viewModel);
         }
@@ -189,7 +190,7 @@ public class MainStateAnimationPlugin : PluginBase
     {
         RefreshViewModel();
 
-        if (SelectedState.Self.SelectedElement != null)
+        if (_selectedState.SelectedElement != null)
         {
             RenameManager.Self.HandleRename(stateSave, oldName, _viewModel);
         }
@@ -213,7 +214,7 @@ public class MainStateAnimationPlugin : PluginBase
         }
 
         // We only care about this if we have an element. Otherwise, it could be a behavior:
-        if(SelectedState.Self.SelectedElement != null)
+        if(_selectedState.SelectedElement != null)
         {
             RenameManager.Self.HandleRename(category, oldName, _viewModel);
         }
@@ -297,7 +298,7 @@ public class MainStateAnimationPlugin : PluginBase
             lbmb.Message = "Select a state";
             lbmb.Title = "Add a state";
 
-            var element = SelectedState.Self.SelectedElement;
+            var element = _selectedState.SelectedElement;
 
             foreach (var state in element.States)
             {
@@ -369,7 +370,7 @@ public class MainStateAnimationPlugin : PluginBase
             whyIsntValid = "You must first select an Animation";
         }
 
-        if (SelectedState.Self.SelectedScreen == null && SelectedState.Self.SelectedComponent == null)
+        if (_selectedState.SelectedScreen == null && _selectedState.SelectedComponent == null)
         {
             whyIsntValid = "You must first select a Screen or Component";
         }
@@ -406,7 +407,7 @@ public class MainStateAnimationPlugin : PluginBase
 
         var states = new List<string>();
 
-        var element = SelectedState.Self.SelectedElement;
+        var element = _selectedState.SelectedElement;
 
         if (element != null)
         {
@@ -430,7 +431,7 @@ public class MainStateAnimationPlugin : PluginBase
             currentlyReferencedElement = _viewModel.Element;
         }
 
-        var element = SelectedState.Self.SelectedElement;
+        var element = _selectedState.SelectedElement;
 
         if (currentlyReferencedElement != element)
         {
@@ -502,7 +503,7 @@ public class MainStateAnimationPlugin : PluginBase
         var animationTime = _viewModel.DisplayedAnimationTime;
 
         var animation = _viewModel.SelectedAnimation;
-        var element = SelectedState.Self.SelectedElement;
+        var element = _selectedState.SelectedElement;
 
         animation.SetStateAtTime(animationTime, element, defaultIfNull:true);
     }

--- a/StateAnimationPlugin/Managers/AnimationCollectionViewModelManager.cs
+++ b/StateAnimationPlugin/Managers/AnimationCollectionViewModelManager.cs
@@ -10,6 +10,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using GumCommon;
 using ToolsUtilities;
 
 namespace StateAnimationPlugin.Managers;
@@ -17,10 +18,12 @@ namespace StateAnimationPlugin.Managers;
 public class AnimationCollectionViewModelManager : Singleton<AnimationCollectionViewModelManager>
 {
     AnimationFilePathService _animationFilePathService;
+    private readonly ISelectedState _selectedState;
 
     public AnimationCollectionViewModelManager()
     {
         _animationFilePathService = new AnimationFilePathService();
+        _selectedState = Locator.GetRequiredService<ISelectedState>();
     }
 
     public ElementAnimationsViewModel GetAnimationCollectionViewModel(ElementSave element)
@@ -75,7 +78,7 @@ public class AnimationCollectionViewModelManager : Singleton<AnimationCollection
 
     public void Save(ElementAnimationsViewModel viewModel)
     {
-        var currentElement = SelectedState.Self.SelectedElement;
+        var currentElement = _selectedState.SelectedElement;
 
         var fileName = _animationFilePathService.GetAbsoluteAnimationFileNameFor(currentElement);
 

--- a/StateAnimationPlugin/Managers/AnimationFilePathService.cs
+++ b/StateAnimationPlugin/Managers/AnimationFilePathService.cs
@@ -5,15 +5,22 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using GumCommon;
 using ToolsUtilities;
 
 namespace StateAnimationPlugin.Managers;
 
 internal class AnimationFilePathService
 {
+    private readonly ISelectedState _selectedState;
+    public AnimationFilePathService()
+    {
+        _selectedState = _selectedState = Locator.GetRequiredService<ISelectedState>();
+    }
+    
     public FilePath GetAbsoluteAnimationFileNameFor(string elementName)
     {
-        var fullPathXmlForElement = ElementSaveExtensionMethodsGumTool.GetFullPathXmlFile(SelectedState.Self.SelectedElement, elementName);
+        var fullPathXmlForElement = ElementSaveExtensionMethodsGumTool.GetFullPathXmlFile(_selectedState.SelectedElement, elementName);
 
         if (fullPathXmlForElement == null)
         {

--- a/StateAnimationPlugin/Managers/RenameManager.cs
+++ b/StateAnimationPlugin/Managers/RenameManager.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using GumCommon;
 using ToolsUtilities;
 
 namespace StateAnimationPlugin.Managers
@@ -17,10 +18,12 @@ namespace StateAnimationPlugin.Managers
     class RenameManager : Singleton<RenameManager>
     {
         private readonly AnimationFilePathService _animationFilePathService;
+        private readonly ISelectedState _selectedState;
 
         public RenameManager()
         {
             _animationFilePathService = new AnimationFilePathService();
+            _selectedState = Locator.GetRequiredService<ISelectedState>();
         }
 
         public void HandleRename(ElementSave elementSave, string oldName, ElementAnimationsViewModel viewModel)
@@ -97,7 +100,7 @@ namespace StateAnimationPlugin.Managers
 
         public void HandleRename(StateSave stateSave, string oldName, ElementAnimationsViewModel viewModel)
         {
-            var parentCategory = SelectedState.Self.SelectedElement?.Categories.FirstOrDefault(item => item.States.Contains(stateSave));
+            var parentCategory = _selectedState.SelectedElement?.Categories.FirstOrDefault(item => item.States.Contains(stateSave));
 
             string prefix = "";
             if(parentCategory != null)

--- a/StateAnimationPlugin/ViewModels/ElementAnimationsViewModel.cs
+++ b/StateAnimationPlugin/ViewModels/ElementAnimationsViewModel.cs
@@ -21,6 +21,7 @@ using ToolsUtilities;
 using System.Globalization;
 using Gum.Mvvm;
 using Gum.Wireframe;
+using GumCommon;
 
 namespace StateAnimationPlugin.ViewModels;
 
@@ -39,7 +40,7 @@ public class ElementAnimationsViewModel : ViewModel
     BitmapFrame mPlayBitmap;
     BitmapFrame mStopBitmap;
 
-
+    private readonly ISelectedState _selectedState;
 
     #endregion
 
@@ -88,7 +89,7 @@ public class ElementAnimationsViewModel : ViewModel
             {
                 if (SelectedAnimation != null)
                 {
-                    var selectedElement = SelectedState.Self.SelectedElement;
+                    var selectedElement = _selectedState.SelectedElement;
                     if(selectedElement == null)
                     {
                         return;
@@ -225,6 +226,8 @@ public class ElementAnimationsViewModel : ViewModel
         mPlayBitmap = BitmapLoader.Self.LoadImage("PlayIcon.png");
 
         mStopBitmap = BitmapLoader.Self.LoadImage("StopIcon.png");
+
+        _selectedState = Locator.GetRequiredService<ISelectedState>();
     }
 
     public static ElementAnimationsViewModel FromSave(ElementAnimationsSave save, Gum.DataTypes.ElementSave element)
@@ -517,7 +520,7 @@ public class ElementAnimationsViewModel : ViewModel
     public string GetWhyAddingAnimationIsInvalid()
     {
         string whyIsntValid = null;
-        if (SelectedState.Self.SelectedScreen == null && SelectedState.Self.SelectedComponent == null)
+        if (_selectedState.SelectedScreen == null && _selectedState.SelectedComponent == null)
         {
             whyIsntValid = "You must first select a Screen or Component";
         }

--- a/StateAnimationPlugin/Views/MainWindow.xaml.cs
+++ b/StateAnimationPlugin/Views/MainWindow.xaml.cs
@@ -26,6 +26,7 @@ using SkiaSharp;
 using System.ComponentModel;
 using SkiaSharp.Views.WPF;
 using Gum.Logic;
+using GumCommon;
 using ToolsUtilities;
 
 namespace StateAnimationPlugin.Views
@@ -54,6 +55,8 @@ namespace StateAnimationPlugin.Views
 
         #endregion
 
+        private readonly ISelectedState _selectedState;
+
         public event EventHandler AddStateKeyframeClicked;
         public event Action<AnimatedKeyframeViewModel> AnimationKeyframeAdded;
 
@@ -65,7 +68,8 @@ namespace StateAnimationPlugin.Views
 
             InitializeTimer();
 
-            DataContextChanged += HandleDataContext;            
+            DataContextChanged += HandleDataContext;
+            _selectedState = Locator.GetRequiredService<ISelectedState>();
         }
 
         private void HandleDataContext(object sender, DependencyPropertyChangedEventArgs e)
@@ -289,11 +293,11 @@ namespace StateAnimationPlugin.Views
             var AnimationContainers = new List<AnimationContainerViewModel>();
 
             var acvm = new AnimationContainerViewModel(
-                SelectedState.Self.SelectedElement, null
+                _selectedState.SelectedElement, null
                 );
             AnimationContainers.Add(acvm);
 
-            foreach (var instance in SelectedState.Self.SelectedElement.Instances)
+            foreach (var instance in _selectedState.SelectedElement.Instances)
             {
                 var instanceElement = ObjectFinder.Self.GetElementSave(instance);
                 if (instanceElement != null)
@@ -301,7 +305,7 @@ namespace StateAnimationPlugin.Views
                     var animationSave = AnimationCollectionViewModelManager.Self.GetElementAnimationsSave(instanceElement);
                     if (animationSave != null && animationSave.Animations.Count != 0)
                     {
-                        acvm = new AnimationContainerViewModel(SelectedState.Self.SelectedElement, instance);
+                        acvm = new AnimationContainerViewModel(_selectedState.SelectedElement, instance);
                         AnimationContainers.Add(acvm);
                     }
                 }
@@ -446,9 +450,9 @@ namespace StateAnimationPlugin.Views
 
         private void HandlePlayStopClicked(object sender, RoutedEventArgs e)
         {
-            if (this.ViewModel != null && SelectedState.Self.SelectedElement != null && this.ViewModel.SelectedAnimation != null)
+            if (this.ViewModel != null && _selectedState.SelectedElement != null && this.ViewModel.SelectedAnimation != null)
             {
-                this.ViewModel.SelectedAnimation.RefreshCumulativeStates(SelectedState.Self.SelectedElement);
+                this.ViewModel.SelectedAnimation.RefreshCumulativeStates(_selectedState.SelectedElement);
             }
 
             ViewModel.TogglePlayStop();

--- a/SvgPlugin/MainSvgPlugin.cs
+++ b/SvgPlugin/MainSvgPlugin.cs
@@ -15,6 +15,7 @@ using System.ComponentModel.Composition;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using GumCommon;
 using ToolsUtilities;
 
 namespace SkiaPlugin
@@ -27,9 +28,15 @@ namespace SkiaPlugin
         public override string FriendlyName => "Skia Plugin";
 
         public override Version Version => new Version(1, 1);
+        
+        private readonly ISelectedState _selectedState;
 
         #endregion
 
+        public MainSvgPlugin()
+        {
+            _selectedState = Locator.GetRequiredService<ISelectedState>();
+        }
         public override bool ShutDown(PluginShutDownReason shutDownReason)
         {
             return true;
@@ -79,7 +86,7 @@ namespace SkiaPlugin
         private void HandleFileChanged(FilePath filePath)
         {
             var isSvg = filePath.Extension == "svg";
-            var currentElement = SelectedState.Self.SelectedElement;
+            var currentElement = _selectedState.SelectedElement;
 
             ///////////////////Early Out///////////////////////
             if(!isSvg || currentElement == null)

--- a/TextureCoordinateSelectionPlugin/Logic/ControlLogic.cs
+++ b/TextureCoordinateSelectionPlugin/Logic/ControlLogic.cs
@@ -13,6 +13,7 @@ using RenderingLibrary.Math;
 using RenderingLibrary.Math.Geometry;
 using System;
 using System.ComponentModel;
+using GumCommon;
 using TextureCoordinateSelectionPlugin.ViewModels;
 using TextureCoordinateSelectionPlugin.Views;
 using Color = System.Drawing.Color;
@@ -31,6 +32,7 @@ public enum RefreshType
 
 public class ControlLogic : Singleton<ControlLogic>
 {
+    private readonly ISelectedState _selectedState;
     LineRectangle textureOutlineRectangle = null;
 
     MainControlViewModel ViewModel;
@@ -60,6 +62,11 @@ public class ControlLogic : Singleton<ControlLogic>
     {
         get => mainControl.InnerControl.CurrentTexture;
         set => mainControl.InnerControl.CurrentTexture = value;
+    }
+
+    public ControlLogic()
+    {
+        _selectedState = Locator.GetRequiredService<ISelectedState>();
     }
 
     public PluginTab CreateControl()
@@ -306,9 +313,9 @@ public class ControlLogic : Singleton<ControlLogic>
     {
         using var undoLock = UndoManager.Self.RequestLock();
 
-        var state = SelectedState.Self.SelectedStateSave;
-        var instancePrefix = SelectedState.Self.SelectedInstance?.Name;
-        var graphicalUiElement = SelectedState.Self.SelectedIpso as GraphicalUiElement;
+        var state = _selectedState.SelectedStateSave;
+        var instancePrefix = _selectedState.SelectedInstance?.Name;
+        var graphicalUiElement = _selectedState.SelectedIpso as GraphicalUiElement;
 
         if (!string.IsNullOrEmpty(instancePrefix))
         {
@@ -363,9 +370,9 @@ public class ControlLogic : Singleton<ControlLogic>
     {
         UndoManager.Self.RecordUndo();
 
-        var state = SelectedState.Self.SelectedStateSave;
+        var state = _selectedState.SelectedStateSave;
 
-        var instancePrefix = SelectedState.Self.SelectedInstance?.Name;
+        var instancePrefix = _selectedState.SelectedInstance?.Name;
 
         if (!string.IsNullOrEmpty(instancePrefix))
         {
@@ -382,7 +389,7 @@ public class ControlLogic : Singleton<ControlLogic>
     {
         var control = sender as ImageRegionSelectionControl;
 
-        var graphicalUiElement = SelectedState.Self.SelectedIpso as GraphicalUiElement;
+        var graphicalUiElement = _selectedState.SelectedIpso as GraphicalUiElement;
 
         if (graphicalUiElement != null)
         {
@@ -394,8 +401,8 @@ public class ControlLogic : Singleton<ControlLogic>
             graphicalUiElement.TextureWidth = MathFunctions.RoundToInt(selector.Width);
             graphicalUiElement.TextureHeight = MathFunctions.RoundToInt(selector.Height);
 
-            var state = SelectedState.Self.SelectedStateSave;
-            var instancePrefix = SelectedState.Self.SelectedInstance?.Name;
+            var state = _selectedState.SelectedStateSave;
+            var instancePrefix = _selectedState.SelectedInstance?.Name;
 
             if (!string.IsNullOrEmpty(instancePrefix))
             {
@@ -418,9 +425,9 @@ public class ControlLogic : Singleton<ControlLogic>
 
     private void HandleEndRegionChanged(object sender, EventArgs e)
     {
-        var element = SelectedState.Self.SelectedElement;
-        var instance = SelectedState.Self.SelectedInstance;
-        var state = SelectedState.Self.SelectedStateSave;
+        var element = _selectedState.SelectedElement;
+        var instance = _selectedState.SelectedInstance;
+        var state = _selectedState.SelectedStateSave;
 
         shouldRefreshAccordingToVariableSets = false;
         {
@@ -488,7 +495,7 @@ public class ControlLogic : Singleton<ControlLogic>
             return;
         }
 
-        if (SelectedState.Self.SelectedElement == null)
+        if (_selectedState.SelectedElement == null)
         {
             // in case a behavior is selected:
             return;
@@ -497,12 +504,12 @@ public class ControlLogic : Singleton<ControlLogic>
         //////////////end early out///////////////////////////////
 
         var shouldClearOut = true;
-        if (SelectedState.Self.SelectedStateSave != null)
+        if (_selectedState.SelectedStateSave != null)
         {
 
-            var graphicalUiElement = SelectedState.Self.SelectedIpso as GraphicalUiElement;
-            var rfv = new RecursiveVariableFinder(SelectedState.Self.SelectedStateSave);
-            var instancePrefix = SelectedState.Self.SelectedInstance?.Name;
+            var graphicalUiElement = _selectedState.SelectedIpso as GraphicalUiElement;
+            var rfv = new RecursiveVariableFinder(_selectedState.SelectedStateSave);
+            var instancePrefix = _selectedState.SelectedInstance?.Name;
 
             if (!string.IsNullOrEmpty(instancePrefix))
             {

--- a/TextureCoordinateSelectionPlugin/MainTextureCoordinatePlugin.cs
+++ b/TextureCoordinateSelectionPlugin/MainTextureCoordinatePlugin.cs
@@ -18,6 +18,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Forms;
+using GumCommon;
 
 namespace TextureCoordinateSelectionPlugin;
 
@@ -46,7 +47,7 @@ public class MainTextureCoordinatePlugin : PluginBase
 
     public MainTextureCoordinatePlugin()
     {
-        _selectedState = SelectedState.Self;
+        _selectedState = Locator.GetRequiredService<ISelectedState>();
     }
 
     public override bool ShutDown(PluginShutDownReason shutDownReason)
@@ -137,9 +138,9 @@ public class MainTextureCoordinatePlugin : PluginBase
 
 
 
-    private static Texture2D GetTextureToAssign(out bool isNineslice, out float? customFrameTextureCoordinateWidth)
+    private Texture2D GetTextureToAssign(out bool isNineslice, out float? customFrameTextureCoordinateWidth)
     {
-        var graphicalUiElement = SelectedState.Self.SelectedIpso as GraphicalUiElement;
+        var graphicalUiElement = _selectedState.SelectedIpso as GraphicalUiElement;
         isNineslice = false;
         customFrameTextureCoordinateWidth = null;
         Texture2D textureToAssign = null;

--- a/Tool/EditorTabPlugin_XNA/EditingManager.RightClick.cs
+++ b/Tool/EditorTabPlugin_XNA/EditingManager.RightClick.cs
@@ -98,7 +98,7 @@ public partial class EditingManager
         }
         ///////////End Early Out//////////////////
 
-        if (SelectedState.Self.SelectedInstance != null)
+        if (_selectedState.SelectedInstance != null)
         {
             mContextMenuStrip.Items.Add(mBringToFront);
             mContextMenuStrip.Items.Add(mMoveForward);
@@ -119,8 +119,8 @@ public partial class EditingManager
     {
         mMoveInFrontOf.DropDownItems.Clear();
 
-        var selectedInstance = SelectedState.Self.SelectedInstance;
-        var selectedElement = SelectedState.Self.SelectedElement;
+        var selectedInstance = _selectedState.SelectedInstance;
+        var selectedElement = _selectedState.SelectedElement;
 
         string selectedParent = null;
 

--- a/Tool/EditorTabPlugin_XNA/EditingManager.cs
+++ b/Tool/EditorTabPlugin_XNA/EditingManager.cs
@@ -11,12 +11,18 @@ using Gum.Converters;
 using Gum.Events;
 using Gum.RenderingLibrary;
 using Gum.PropertyGridHelpers;
+using GumCommon;
 using GumRuntime;
 
 namespace Gum.Wireframe;
 
 public partial class EditingManager
 {
+    private readonly ISelectedState _selectedState;
+    public EditingManager()
+    {
+        _selectedState = Locator.GetRequiredService<ISelectedState>();
+    }
     #region Methods
 
     public void Initialize(System.Windows.Forms.ContextMenuStrip contextMenuStrip)

--- a/Tool/EditorTabPlugin_XNA/Editors/PolygonWireframeEditor.cs
+++ b/Tool/EditorTabPlugin_XNA/Editors/PolygonWireframeEditor.cs
@@ -377,13 +377,13 @@ namespace Gum.Wireframe.Editors
                 }
 
                 var variableName = "Points";
-                if(SelectedState.Self.SelectedInstance != null)
+                if(_selectedState.SelectedInstance != null)
                 {
-                    variableName = SelectedState.Self.SelectedInstance.Name + "." + variableName;
+                    variableName = _selectedState.SelectedInstance.Name + "." + variableName;
                 }
 
                 var pointsVariableList = 
-                    SelectedState.Self.SelectedStateSave.VariableLists.FirstOrDefault(item => item.Name == variableName);
+                    _selectedState.SelectedStateSave.VariableLists.FirstOrDefault(item => item.Name == variableName);
 
                 // This might be null if the points aren't set in this state, but are inherited from a base 
                 // state or object
@@ -392,7 +392,7 @@ namespace Gum.Wireframe.Editors
                     pointsVariableList = new VariableListSave<Vector2>();
                     pointsVariableList.Name = variableName;
                     pointsVariableList.Type = "Vector2";
-                    SelectedState.Self.SelectedStateSave.VariableLists.Add(pointsVariableList);
+                    _selectedState.SelectedStateSave.VariableLists.Add(pointsVariableList);
                 }
                 pointsVariableList.ValueAsIList = vectors;
             }

--- a/Tool/EditorTabPlugin_XNA/Editors/StandardWireframeEditor.cs
+++ b/Tool/EditorTabPlugin_XNA/Editors/StandardWireframeEditor.cs
@@ -287,7 +287,7 @@ public class StandardWireframeEditor : WireframeEditor
                 _selectedState.SelectedInstance, "float");
 
             VariableInCategoryPropagationLogic.Self.PropagateVariablesInCategory(nameWithInstance,
-                GumState.Self.SelectedState.SelectedElement, GumState.Self.SelectedState.SelectedStateCategorySave);
+                _selectedState.SelectedElement, _selectedState.SelectedStateCategorySave);
 
             GumCommands.Self.GuiCommands.RefreshVariableValues();
 

--- a/Tool/EditorTabPlugin_XNA/Editors/StandardWireframeEditor.cs
+++ b/Tool/EditorTabPlugin_XNA/Editors/StandardWireframeEditor.cs
@@ -120,7 +120,7 @@ public class StandardWireframeEditor : WireframeEditor
 
     public override void Activity(ICollection<GraphicalUiElement> selectedObjects)
     {
-        if (selectedObjects.Count != 0 && SelectedState.Self.SelectedStateSave != null && SelectedState.Self.CustomCurrentStateSave == null)
+        if (selectedObjects.Count != 0 && _selectedState.SelectedStateSave != null && _selectedState.CustomCurrentStateSave == null)
         {
             RefreshSideOver();
 
@@ -175,7 +175,7 @@ public class StandardWireframeEditor : WireframeEditor
         }
         if(tag is ElementSave element)
         {
-            rfv = new RecursiveVariableFinder(SelectedState.Self.SelectedStateSave);
+            rfv = new RecursiveVariableFinder(_selectedState.SelectedStateSave);
         }
             
         var variableReferences = rfv?.GetVariableList("VariableReferences");
@@ -277,14 +277,14 @@ public class StandardWireframeEditor : WireframeEditor
 
             string nameWithInstance = "Rotation";
 
-            if(SelectedState.Self.SelectedInstance != null)
+            if(_selectedState.SelectedInstance != null)
             {
-                nameWithInstance = SelectedState.Self.SelectedInstance.Name + 
+                nameWithInstance = _selectedState.SelectedInstance.Name + 
                     "." + nameWithInstance;
             }
 
-            SelectedState.Self.SelectedStateSave.SetValue(nameWithInstance, rotationValueDegrees - parentRotation, 
-                SelectedState.Self.SelectedInstance, "float");
+            _selectedState.SelectedStateSave.SetValue(nameWithInstance, rotationValueDegrees - parentRotation, 
+                _selectedState.SelectedInstance, "float");
 
             VariableInCategoryPropagationLogic.Self.PropagateVariablesInCategory(nameWithInstance,
                 GumState.Self.SelectedState.SelectedElement, GumState.Self.SelectedState.SelectedStateCategorySave);
@@ -457,14 +457,14 @@ public class StandardWireframeEditor : WireframeEditor
         }
 
         bool hasChangeOccurred = false;
-        var elementStack = SelectedState.Self.GetTopLevelElementStack();
-        if (_selectionManager.HasSelection && SelectedState.Self.SelectedInstances.Count() == 0)
+        var elementStack = _selectedState.GetTopLevelElementStack();
+        if (_selectionManager.HasSelection && _selectedState.SelectedInstances.Count() == 0)
         {
             // That means we have the entire component selected
             hasChangeOccurred |= SideGrabbingActivityForInstanceSave(effectiveXToMoveBy, effectiveYToMoveBy, instanceSave: null, elementStack: elementStack);
         }
 
-        foreach (InstanceSave save in SelectedState.Self.SelectedInstances)
+        foreach (InstanceSave save in _selectedState.SelectedInstances)
         {
             hasChangeOccurred |= SideGrabbingActivityForInstanceSave(effectiveXToMoveBy, effectiveYToMoveBy, instanceSave: save, elementStack: elementStack);
         }
@@ -657,8 +657,8 @@ public class StandardWireframeEditor : WireframeEditor
         bool wasAnythingModified = false;
 
 
-        if (SelectedState.Self.SelectedInstances.Count() == 0 &&
-            (SelectedState.Self.SelectedComponent != null || SelectedState.Self.SelectedStandardElement != null))
+        if (_selectedState.SelectedInstances.Count() == 0 &&
+            (_selectedState.SelectedComponent != null || _selectedState.SelectedStandardElement != null))
         {
             GraphicalUiElement gue = _selectionManager.SelectedGue;
 
@@ -671,26 +671,26 @@ public class StandardWireframeEditor : WireframeEditor
 
             if (differenceToUnitX != 0)
             {
-                gue.X = _elementCommands.ModifyVariable("X", differenceToUnitX, SelectedState.Self.SelectedElement);
+                gue.X = _elementCommands.ModifyVariable("X", differenceToUnitX, _selectedState.SelectedElement);
                 wasAnythingModified = true;
             }
             if (differenceToUnitY != 0)
             {
-                gue.Y = _elementCommands.ModifyVariable("Y", differenceToUnitY, SelectedState.Self.SelectedElement);
+                gue.Y = _elementCommands.ModifyVariable("Y", differenceToUnitY, _selectedState.SelectedElement);
                 wasAnythingModified = true;
             }
             if (differenceToUnitWidth != 0)
             {
-                gue.Width = _elementCommands.ModifyVariable("Width", differenceToUnitWidth, SelectedState.Self.SelectedElement);
+                gue.Width = _elementCommands.ModifyVariable("Width", differenceToUnitWidth, _selectedState.SelectedElement);
                 wasAnythingModified = true;
             }
             if (differenceToUnitHeight != 0)
             {
-                gue.Height = _elementCommands.ModifyVariable("Height", differenceToUnitHeight, SelectedState.Self.SelectedElement);
+                gue.Height = _elementCommands.ModifyVariable("Height", differenceToUnitHeight, _selectedState.SelectedElement);
                 wasAnythingModified = true;
             }
         }
-        else if (SelectedState.Self.SelectedInstances.Count() != 0)
+        else if (_selectedState.SelectedInstances.Count() != 0)
         {
             var gues = _selectionManager.SelectedGues.ToArray();
             foreach (var gue in gues)
@@ -799,7 +799,7 @@ public class StandardWireframeEditor : WireframeEditor
         var ipso = WireframeObjectManager.Self.GetRepresentation(instanceSave, elementStack);
         if (ipso == null)
         {
-            ipso = WireframeObjectManager.Self.GetRepresentation(SelectedState.Self.SelectedElement);
+            ipso = WireframeObjectManager.Self.GetRepresentation(_selectedState.SelectedElement);
         }
 
         switch (this.SideGrabbed)

--- a/Tool/EditorTabPlugin_XNA/Editors/WireframeEditor.cs
+++ b/Tool/EditorTabPlugin_XNA/Editors/WireframeEditor.cs
@@ -18,6 +18,7 @@ using Gum.PropertyGridHelpers;
 using System.Security.Policy;
 using EditorTabPlugin_XNA.ExtensionMethods;
 using Gum.Services;
+using GumCommon;
 
 namespace Gum.Wireframe;
 
@@ -27,7 +28,7 @@ public abstract class WireframeEditor
 
     private readonly SelectionManager _selectionManager;
     private readonly SetVariableLogic _setVariableLogic;
-    private readonly ISelectedState _selectedState;
+    protected readonly ISelectedState _selectedState;
     protected GrabbedState grabbedState = new GrabbedState();
 
     protected bool mHasChangedAnythingSinceLastPush = false;
@@ -49,8 +50,8 @@ public abstract class WireframeEditor
     {
         _hotkeyManager = hotkeyManager;
         _selectionManager = selectionManager;
-        _setVariableLogic = Builder.Get<SetVariableLogic>();
-        _selectedState = selectedState;
+        _setVariableLogic = Locator.GetRequiredService<SetVariableLogic>();
+        _selectedState = Locator.GetRequiredService<ISelectedState>();
     }
 
     public abstract void UpdateToSelection(ICollection<GraphicalUiElement> selectedObjects);

--- a/Tool/EditorTabPlugin_XNA/MainEditorTabPlugin.cs
+++ b/Tool/EditorTabPlugin_XNA/MainEditorTabPlugin.cs
@@ -113,17 +113,18 @@ internal class MainEditorTabPlugin : InternalPlugin
 
     public MainEditorTabPlugin()
     {
+        _selectedState = Locator.GetRequiredService<ISelectedState>();
+        
         _scrollbarService = new ScrollbarService();
         _guiCommands = Locator.GetRequiredService<GuiCommands>();
         _localizationManager = Locator.GetRequiredService<LocalizationManager>();
         _editingManager = new EditingManager();
-        _selectionManager = new SelectionManager(SelectedState.Self, _editingManager);
+        _selectionManager = new SelectionManager(_selectedState, _editingManager);
         _screenshotService = new ScreenshotService(_selectionManager);
         _elementCommands = ElementCommands.Self;
         _singlePixelTextureService = new SinglePixelTextureService();
         _backgroundSpriteService = new BackgroundSpriteService();
         _dragDropManager = Locator.GetRequiredService<DragDropManager>();
-        _selectedState = Locator.GetRequiredService<ISelectedState>();
     }
 
     public override void StartUp()
@@ -766,7 +767,7 @@ internal class MainEditorTabPlugin : InternalPlugin
                     .GetValueOrDefault<string>("SourceFile");
 
                 _selectedState.SelectedStateSave.SetValue("SourceFile", fileName);
-                ProjectState.Self.Selected.SelectedInstance = null;
+                _selectedState.SelectedInstance = null;
                 SetVariableLogic.Self.PropertyValueChanged(
                     "SourceFile", 
                     oldValue, 
@@ -822,7 +823,7 @@ internal class MainEditorTabPlugin : InternalPlugin
                     .GetValueOrDefault<string>(instance.Name + ".SourceFile");
 
                 _selectedState.SelectedStateSave.SetValue(instance.Name + ".SourceFile", fileName, instance);
-                ProjectState.Self.Selected.SelectedInstance = instance;
+                _selectedState.SelectedInstance = instance;
 
                 SetVariableLogic.Self.PropertyValueChanged(
                     "SourceFile", 

--- a/Tool/EditorTabPlugin_XNA/ScrollbarService.cs
+++ b/Tool/EditorTabPlugin_XNA/ScrollbarService.cs
@@ -8,13 +8,20 @@ using RenderingLibrary.Graphics;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
+using GumCommon;
 
 namespace Gum.Plugins.ScrollBarPlugin;
 
 public class ScrollbarService
 {
     ScrollBarControlLogic scrollBarControlLogic;
+    private readonly ISelectedState _selectedState;
 
+    public ScrollbarService()
+    {
+        _selectedState = Locator.GetRequiredService<ISelectedState>();
+    }
+    
     public void HandleElementSelected(ElementSave obj)
     {
 
@@ -38,7 +45,7 @@ public class ScrollbarService
 
             List<IRenderableIpso> toLoop = new List<IRenderableIpso>();
 
-            if(GumState.Self.SelectedState.SelectedScreen != null)
+            if(_selectedState.SelectedScreen != null)
             {
                 toLoop.AddRange(asGue.ContainedElements);
             }


### PR DESCRIPTION
- Removes SelectedState.Self
- Existing usages are accessed through a property assigned by the service locator.
- Sets up two service containers. One for clean services which have no static singleton instance dependencies, and one for services that are in transition. 