### PR TITLE
fix state tree bug

### DIFF
--- a/Gum/Plugins/InternalPlugins/StatePlugin/ViewModels/StateTreeViewModel.cs
+++ b/Gum/Plugins/InternalPlugins/StatePlugin/ViewModels/StateTreeViewModel.cs
@@ -39,16 +39,12 @@ public class StateTreeViewModel : ViewModel
 
 
     #endregion
-
-    public StateTreeViewModel()
-    {
-        _selectedState = Locator.GetRequiredService<ISelectedState>();
-    }
-
+    
     #region Initialize
 
     public StateTreeViewModel(StateTreeViewRightClickService stateTreeViewRightClickService)
     {
+        _selectedState = Locator.GetRequiredService<ISelectedState>();
         _stateTreeViewRightClickService = stateTreeViewRightClickService;
         Categories = new ObservableCollection<CategoryViewModel>();
         States = new ObservableCollection<StateViewModel>();


### PR DESCRIPTION
remove unused empty constructor doing a service assignment and move the assignment to the constructor that is actually used.