### PR TITLE
Implements base dialog service

### DIFF
--- a/Gum/MainWindow.cs
+++ b/Gum/MainWindow.cs
@@ -54,6 +54,7 @@ namespace Gum
                 System.Diagnostics.SourceLevels.Critical;
 #endif
             _ = GumBuilder.BuildGum();
+            ((MainFormWindowHandleProvider)Locator.GetRequiredService<IMainWindowHandleProvider>()).Initialize(() => Handle);
             
             InitializeComponent();
 

--- a/Gum/Services/Builder.cs
+++ b/Gum/Services/Builder.cs
@@ -14,6 +14,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Gum.Services.Dialogs;
 using GumCommon;
 using Gum.Services.Dialogs;
 
@@ -57,7 +58,6 @@ file static class ServiceCollectionExtensions
         services.AddSingleton<LocalizationManager>();
         services.AddSingleton<NameVerifier>();
         services.AddSingleton<UndoManager>();
-        services.AddSingleton<IDialogService, DialogService>();
         
         //logic
         services.AddSingleton<VariableReferenceLogic>();
@@ -68,6 +68,10 @@ file static class ServiceCollectionExtensions
         services.AddSingleton<GuiCommands>();
         services.AddSingleton<EditCommands>();
         services.AddSingleton<ElementCommands>();
+        
+        services.AddSingleton<IMainWindowHandleProvider, MainFormWindowHandleProvider>();
+        services.AddSingleton<IDialogViewResolver, DialogViewResolver>();
+        services.AddSingleton<IDialogService, DialogService>();
     }
     
     // Register legacy services that may use Locator or have unresolved dependencies.

--- a/Gum/Services/Dialogs/Dialog.cs
+++ b/Gum/Services/Dialogs/Dialog.cs
@@ -1,0 +1,151 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Media;
+using System.Windows.Media.Media3D;
+using System.Windows.Threading;
+using GumCommon;
+using Xceed.Wpf.AvalonDock.Controls;
+
+namespace Gum.Services.Dialogs;
+
+public class Dialog : ContentControl
+{
+    public static readonly DependencyProperty DialogTitleProperty = DependencyProperty.RegisterAttached(
+        "DialogTitle", typeof(string), typeof(Dialog), new PropertyMetadata(default(string?)));
+
+    public static void SetDialogTitle(DependencyObject element, string? value)
+    {
+        element.SetValue(DialogTitleProperty, value);
+    }
+
+    public static string? GetDialogTitle(DependencyObject element)
+    {
+        return (string?) element.GetValue(DialogTitleProperty);
+    }
+
+
+    public static readonly DependencyProperty ActionsProperty =
+        DependencyProperty.RegisterAttached("Actions", typeof(object), typeof(Dialog), new PropertyMetadata(null));
+
+    public static object? GetActions(DependencyObject obj)
+    {
+        return obj.GetValue(ActionsProperty);
+    }
+
+    public static void SetActions(DependencyObject obj, object value)
+    {
+        obj.SetValue(ActionsProperty, value);
+    }
+    
+    public Dialog()
+    {
+        ContentTemplateSelector = new DialogTemplateSelector();
+    }
+
+    protected override void OnContentChanged(object oldContent, object newContent)
+    {
+        base.OnContentChanged(oldContent, newContent);
+        Dispatcher.CurrentDispatcher.BeginInvoke(() =>
+        {
+            UserControl? userControl = this.VisitDescendentsBfs().OfType<UserControl>().FirstOrDefault();
+            if (userControl != null)
+            {
+                Bind(DialogTitleProperty);
+                Bind(ActionsProperty);
+            }
+
+            void Bind(DependencyProperty source)
+            {
+                SetBinding(source, new Binding()
+                {
+                    Path = new PropertyPath("(0)", source),
+                    Source = userControl,
+                });
+            }
+        }, DispatcherPriority.Loaded);
+    }
+    
+    private class DialogTemplateSelector : DataTemplateSelector
+    {
+        private static IDialogViewResolver DialogViewResolver { get; } = Locator.GetRequiredService<IDialogViewResolver>();
+        private static Dictionary<Type, DataTemplate> ResolvedTemplates { get; } = [];
+
+        public override DataTemplate? SelectTemplate(object? item, DependencyObject container)
+        {
+            if (item?.GetType() is not { } itemType)
+            {
+                return base.SelectTemplate(item, container);
+            }
+            
+            if (ResolvedTemplates.TryGetValue(itemType, out var template))
+            {
+                return template;
+            }
+            
+            if (DialogViewResolver.GetDialogViewType(itemType) is { } viewType)
+            {
+                DataTemplate newTemplate = new(itemType)
+                {
+                    VisualTree = new(viewType)
+                };
+                ResolvedTemplates.Add(itemType, newTemplate);
+                return newTemplate;
+            }
+
+            return base.SelectTemplate(item, container);
+        }
+    }
+}
+
+file static class VisualTreeHelpers
+{
+    public static IEnumerable<DependencyObject> VisitDescendentsBfs(this DependencyObject root, bool includeRoot = false)
+    {
+        if (includeRoot)
+            yield return root;
+
+        Queue<DependencyObject> queue = new();
+        queue.Enqueue(root);
+        do
+        {
+            DependencyObject current = queue.Dequeue();
+            foreach (DependencyObject child in current.GetChildObjects(true))
+            {
+                yield return current;
+                queue.Enqueue(child);
+            }
+        } while (queue.Count > 0);
+    }
+    
+    private static IEnumerable<DependencyObject> GetChildObjects(this DependencyObject? parent, bool forceUsingTheVisualTreeHelper = false)
+    {
+        if (parent is not null)
+        {
+            if (!forceUsingTheVisualTreeHelper && parent is ContentElement or FrameworkElement)
+            {
+                // use the logical tree for content / framework elements
+                foreach (var obj in LogicalTreeHelper.GetChildren(parent))
+                {
+                    if (obj is DependencyObject dependencyObject)
+                    {
+                        yield return dependencyObject;
+                    }
+                }
+            }
+            else if (parent is Visual or Visual3D)
+            {
+                // use the visual tree per default
+                int count = VisualTreeHelper.GetChildrenCount(parent);
+                for (int i = 0; i < count; i++)
+                {
+                    yield return VisualTreeHelper.GetChild(parent, i);
+                }
+            }
+        }
+    }
+}

--- a/Gum/Services/Dialogs/DialogViewModel.cs
+++ b/Gum/Services/Dialogs/DialogViewModel.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Windows.Input;
+using Gum.Mvvm;
+using Microsoft.Xaml.Behaviors.Core;
+
+namespace Gum.Services.Dialogs;
+
+public abstract class DialogViewModel : ViewModel
+{
+    public event EventHandler<bool>? RequestClose;
+    public string? AffirmativeText { get => Get<string>(); set => Set(value); }
+    public string? NegativeText { get => Get<string>(); set => Set(value); }
+
+    public ICommand AffirmativeCommand { get; }
+    public ICommand NegativeCommand { get; }
+
+    protected DialogViewModel()
+    {
+        AffirmativeCommand = new ActionCommand(Affirmative);
+        NegativeCommand = new ActionCommand(Negative);
+    }
+
+    private void Affirmative()
+    {
+        OnAffirmative();
+        RequestClose?.Invoke(this, true);
+    }
+
+    private void Negative()
+    {
+        OnNegative();
+        RequestClose?.Invoke(this, false);
+    }
+    
+    protected virtual void OnAffirmative(){}
+    protected virtual void OnNegative(){}
+}

--- a/Gum/Services/Dialogs/DialogViewResolver.cs
+++ b/Gum/Services/Dialogs/DialogViewResolver.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Windows;
+using Microsoft.Extensions.Logging;
+
+namespace Gum.Services.Dialogs;
+
+internal interface IDialogViewResolver
+{
+    Type? GetDialogViewType(Type viewModelType);
+}
+
+internal class DialogViewResolver : IDialogViewResolver
+{
+    private readonly ILogger _logger;
+    
+    private readonly HashSet<Assembly> _checkedAssemblies = [];
+    private readonly Dictionary<Type, Type> _vmViewPaires = [];
+
+    public DialogViewResolver(ILogger<DialogViewResolver> logger)
+    {
+        _logger = logger;
+    }
+    
+    public Type? GetDialogViewType(Type viewModelType)
+    {
+        if (_vmViewPaires.TryGetValue(viewModelType, out Type viewType))
+        {
+            return viewType;
+        }
+
+        if (!_checkedAssemblies.Contains(viewModelType.Assembly))
+        {
+            Scan(viewModelType.Assembly);
+            if (_vmViewPaires.TryGetValue(viewModelType, out Type addedViewType))
+            {
+                return addedViewType;
+            }
+        }
+        
+        _logger.LogError($"Unable to resolve view associated with viewmodel type {viewModelType.FullName}");
+        return null;
+    }
+
+    private void Scan(Assembly assembly)
+    {
+        if (!_checkedAssemblies.Add(assembly))
+        {
+            return;
+        }
+
+        try
+        {
+            List<Type> viewTypes = assembly.GetTypes()
+                .Where(t => typeof(FrameworkElement).IsAssignableFrom(t) && t.Name.Contains("DialogView")).ToList();
+
+            Dictionary<Type, Type> vmViewPairs = assembly.GetTypes()
+                .Where(t => typeof(DialogViewModel).IsAssignableFrom(t))
+                .Aggregate(new Dictionary<Type, Type>(),
+                    (types, vmType) =>
+                    {
+                        if (viewTypes.FirstOrDefault(type => vmType.Name == $"{type.Name}Model") is { } viewType)
+                        {
+                            types[vmType] = viewType;
+                        }
+
+                        return types;
+                    });
+            foreach (var pair in vmViewPairs)
+            {
+                _vmViewPaires[pair.Key] = pair.Value;
+            }
+        }
+        catch
+        {
+            _checkedAssemblies.Remove(assembly);
+        }
+    }
+}

--- a/Gum/Services/Dialogs/DialogWindow.xaml
+++ b/Gum/Services/Dialogs/DialogWindow.xaml
@@ -1,0 +1,61 @@
+﻿<Window x:Class="Gum.Services.Dialogs.DialogWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:local="clr-namespace:Gum.Services.Dialogs"
+        mc:Ignorable="d"
+        WindowStartupLocation="CenterOwner"
+        SizeToContent="WidthAndHeight"
+        ResizeMode="NoResize"
+        Title="{Binding (local:Dialog.DialogTitle), ElementName=DialogImpl}">
+    <Window.Resources>
+        <Style TargetType="{x:Type local:Dialog}">
+            <Setter Property="Content" Value="{Binding}" />
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="{x:Type local:Dialog}">
+                        <Grid Margin="8">
+                            <Grid.RowDefinitions>
+                                <RowDefinition/>
+                                <RowDefinition/>
+                            </Grid.RowDefinitions>
+                            <ContentPresenter x:Name="DialogPresenter" Grid.Row="0" />
+                            <ContentPresenter x:Name="ActionsPresenter" Grid.Row="1"
+                                            Margin="0,16,0,0"
+                                            Content="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(local:Dialog.Actions)}"/>
+                        </Grid>
+    
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="local:Dialog.Actions" Value="{x:Null}">
+                                <Setter TargetName="ActionsPresenter" Property="Content" Value="{Binding}"/>
+                                <Setter TargetName="ActionsPresenter" Property="ContentTemplate">
+                                    <Setter.Value>
+                                        <DataTemplate DataType="{x:Type local:DialogViewModel}">
+                                            <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                                                <Button Content="{Binding AffirmativeText}" Padding="16,4" MinWidth="64" Margin="5,0,0,0" Command="{Binding AffirmativeCommand}" />
+                                                <Button Content="{Binding NegativeText}" Padding="16,4" MinWidth="64" Margin="5,0,0,0" Command="{Binding NegativeCommand}">
+                                                    <Button.Style>
+                                                        <Style TargetType="{x:Type Button}" BasedOn="{StaticResource {x:Type Button}}">
+                                                            <Style.Triggers>
+                                                                <DataTrigger Binding="{Binding NegativeText}" Value="{x:Null}">
+                                                                    <Setter Property="Visibility" Value="Collapsed" />
+                                                                </DataTrigger>
+                                                            </Style.Triggers>
+                                                        </Style>
+                                                    </Button.Style>
+                                                </Button>
+                                            </StackPanel>
+                                        </DataTemplate>
+                                    </Setter.Value>
+                                </Setter>
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+    </Window.Resources>
+    
+    <local:Dialog x:Name="DialogImpl"/>
+</Window>

--- a/Gum/Services/Dialogs/DialogWindow.xaml.cs
+++ b/Gum/Services/Dialogs/DialogWindow.xaml.cs
@@ -1,0 +1,11 @@
+﻿using System.Windows;
+
+namespace Gum.Services.Dialogs;
+
+public partial class DialogWindow : Window
+{
+    public DialogWindow()
+    {
+        InitializeComponent();
+    }
+}

--- a/Gum/Services/Dialogs/MainWindowHandleProvider.cs
+++ b/Gum/Services/Dialogs/MainWindowHandleProvider.cs
@@ -1,0 +1,20 @@
+﻿using System;
+
+namespace Gum.Services.Dialogs;
+
+internal interface IMainWindowHandleProvider
+{
+    IntPtr GetMainWindowHandle();
+}
+
+internal class MainFormWindowHandleProvider : IMainWindowHandleProvider
+{
+    public IntPtr GetMainWindowHandle() => Getter?.Invoke() ?? IntPtr.Zero;
+    
+    private Func<IntPtr>? Getter { get; set; }
+    
+    public void Initialize(Func<IntPtr> getMainWindowHandle)
+    {
+        Getter = getMainWindowHandle;
+    }
+}

--- a/Gum/Services/Dialogs/MessageDialog.cs
+++ b/Gum/Services/Dialogs/MessageDialog.cs
@@ -1,16 +1,31 @@
-﻿namespace Gum.Services.Dialogs;
+namespace Gum.Services.Dialogs;
 
 public enum MessageDialogResult
 {
     Canceled = -1,
     Negative = 0,
-    Affirmative = 1
+    Affirmative = 1,
 }
 
 public class MessageDialogStyle
 {
-    private MessageDialogStyle(){}
-    public static MessageDialogStyle OK { get; } = new();
-    public static MessageDialogStyle OKCancel { get; } = new();
-    public static MessageDialogStyle YesNo { get; } = new();
+    public string? AffirmativeText { get; set; }
+    public string? NegativeText { get; set; }
+
+    public static MessageDialogStyle Ok => new()
+    {
+        AffirmativeText = "Ok",
+    };
+
+    public static MessageDialogStyle OkCancel => new()
+    {
+        AffirmativeText = "Ok",
+        NegativeText = "Cancel",
+    };
+
+    public static MessageDialogStyle YesNo => new()
+    {
+        AffirmativeText = "Yes",
+        NegativeText = "No",
+    };
 }

--- a/Gum/Services/Dialogs/MessageDialogView.xaml
+++ b/Gum/Services/Dialogs/MessageDialogView.xaml
@@ -1,0 +1,13 @@
+﻿<UserControl x:Class="Gum.Services.Dialogs.MessageDialogView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:local="clr-namespace:Gum.Services.Dialogs"
+             mc:Ignorable="d"
+             d:DesignHeight="300" d:DesignWidth="300"
+             d:DataContext="{d:DesignInstance Type={x:Type local:MessageDialogViewModel}, IsDesignTimeCreatable=False}"
+             local:Dialog.DialogTitle="{Binding Title}"
+             MaxWidth="400">
+    <TextBlock Text="{Binding Message}" />
+</UserControl>

--- a/Gum/Services/Dialogs/MessageDialogView.xaml.cs
+++ b/Gum/Services/Dialogs/MessageDialogView.xaml.cs
@@ -1,0 +1,11 @@
+﻿using System.Windows.Controls;
+
+namespace Gum.Services.Dialogs;
+
+public partial class MessageDialogView : UserControl
+{
+    public MessageDialogView()
+    {
+        InitializeComponent();
+    }
+}

--- a/Gum/Services/Dialogs/MessageDialogViewModel.cs
+++ b/Gum/Services/Dialogs/MessageDialogViewModel.cs
@@ -1,0 +1,7 @@
+﻿namespace Gum.Services.Dialogs;
+
+public class MessageDialogViewModel : DialogViewModel
+{
+    public string? Title { get => Get<string>(); set => Set(value); }
+    public string Message { get => Get<string>(); set => Set(value); }
+}

--- a/Gum/Wireframe/WireframeObjectManager.cs
+++ b/Gum/Wireframe/WireframeObjectManager.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Gum.DataTypes;
@@ -9,11 +9,11 @@ using RenderingLibrary.Content;
 using RenderingLibrary;
 using Gum.RenderingLibrary;
 using Gum.Plugins;
-using Gum.Services;
-using GumCommon;
-using Color = System.Drawing.Color;
-using Rectangle = System.Drawing.Rectangle;
-using Matrix = System.Numerics.Matrix4x4;
+using Gum.Services.Dialogs; 
+using GumCommon; 
+using Color = System.Drawing.Color; 
+using Rectangle = System.Drawing.Rectangle; 
+using Matrix = System.Numerics.Matrix4x4; 
 using GumRuntime;
 
 namespace Gum.Wireframe;


### PR DESCRIPTION
Implements the base dialog service using WPF windows and MVVM.

This commit introduces a new dialog service that leverages WPF for displaying dialog windows,
offering a more modern and flexible approach compared to the previous WinForms-based implementation.
It includes view model support and dialog resolution through naming conventions.

Additionally, this commit includes a provider for obtaining the main window handle,
enabling proper parent-child relationships for dialog windows and ensuring correct window centering.
