### PR TITLE
960 - Wraps text in message dialog

### DIFF
--- a/Gum/Services/Dialogs/MessageDialogView.xaml
+++ b/Gum/Services/Dialogs/MessageDialogView.xaml
@@ -9,5 +9,5 @@
              d:DataContext="{d:DesignInstance Type={x:Type local:MessageDialogViewModel}, IsDesignTimeCreatable=False}"
              local:Dialog.DialogTitle="{Binding Title}"
              MaxWidth="400">
-    <TextBlock Text="{Binding Message}" />
+    <TextBlock Text="{Binding Message}" TextWrapping="Wrap" />
 </UserControl>


### PR DESCRIPTION
fixes #960

Ensures that long messages in the message dialog are properly displayed by wrapping the text. This prevents the text from overflowing the dialog's boundaries.
