### PR TITLE
Improves the dialog service with a pattern for getting user input

### DIFF
--- a/Gum/Commands/GuiCommands.cs
+++ b/Gum/Commands/GuiCommands.cs
@@ -382,42 +382,6 @@ public class GuiCommands
 
     }
 
-    public void ShowAddStateWindow()
-    {
-        if (_selectedState.SelectedStateCategorySave == null && _selectedState.SelectedElement == null)
-        {
-            MessageBox.Show("You must first select an element or a behavior category to add a state");
-        }
-        else
-        {
-            var tiw = new CustomizableTextInputWindow();
-            tiw.Message = "Enter new state name:";
-            tiw.Title = "Add state";
-
-            if (tiw.ShowDialog() == true)
-            {
-                string name = tiw.Result;
-
-                if (!_nameVerifier.IsStateNameValid(name, _selectedState.SelectedStateCategorySave, null, out string whyNotValid))
-                {
-                    _dialogService.ShowMessage(whyNotValid);
-                }
-                else
-                {
-                    using (_undoManager.RequestLock())
-                    {
-                        StateSave stateSave = _elementCommands.AddState(
-                            _selectedState.SelectedStateContainer, _selectedState.SelectedStateCategorySave, name);
-
-
-                        _selectedState.SelectedStateSave = stateSave;
-
-                    }
-                }
-            }
-        }
-    }
-
     public void ShowAddFolderWindow(TreeNode node)
     {
         var tiw = new CustomizableTextInputWindow();

--- a/Gum/Converters/NullToVisibilityConverter.cs
+++ b/Gum/Converters/NullToVisibilityConverter.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+
+namespace Gum.Converters;
+
+public class NullToVisibilityConverter : IValueConverter
+{
+    public bool Invert { get; set; } = false;
+
+    public bool Collapse { get; set; } = true;
+
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        bool isNull = value is null;
+
+        if (Invert)
+            isNull = !isNull;
+
+        return isNull
+            ? (Collapse ? Visibility.Collapsed : Visibility.Hidden)
+            : Visibility.Visible;
+    }
+
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+        throw new NotSupportedException();
+}

--- a/Gum/Dialogs/AddStateDialogViewModel.cs
+++ b/Gum/Dialogs/AddStateDialogViewModel.cs
@@ -1,0 +1,62 @@
+﻿using Gum.DataTypes;
+using Gum.DataTypes.Variables;
+using Gum.Managers;
+using Gum.Services.Dialogs;
+using Gum.ToolCommands;
+using Gum.ToolStates;
+using Gum.Undo;
+
+namespace Gum.Dialogs;
+
+public class AddStateDialogViewModel : GetUserStringDialogBaseViewModel
+{
+    public override string Title => "Add State";
+    public override string Message => "Enter new state name";
+    
+    private readonly ISelectedState _selectedState;
+    private readonly NameVerifier _nameVerifier;
+    private readonly UndoManager _undoManager;
+    private readonly ElementCommands _elementCommands;
+    
+    public AddStateDialogViewModel(
+        ISelectedState selectedState,
+        NameVerifier nameVerifier, 
+        UndoManager undoManager, 
+        ElementCommands elementCommands)
+    {
+        _selectedState = selectedState;
+        _nameVerifier = nameVerifier;
+        _undoManager = undoManager;
+        _elementCommands = elementCommands;
+    }
+
+    protected override void OnAffirmative()
+    {
+        if (Error is not null) return;
+        
+        using (_undoManager.RequestLock())
+        {
+            StateSave stateSave = _elementCommands.AddState(
+                _selectedState.SelectedStateContainer,
+                _selectedState.SelectedStateCategorySave, 
+                Value);
+            
+            _selectedState.SelectedStateSave = stateSave;
+        }
+        
+        base.OnAffirmative();
+    }
+
+    protected override string? Validate(string? value)
+    {
+        if (_selectedState is not { SelectedStateCategorySave: { } category })
+        {
+            return "You must first select an element or a behavior category to add a state";
+        }
+        
+        return _nameVerifier.IsStateNameValid(value, category, null,
+            out string whyNotValid)
+            ? base.Validate(value)
+            : whyNotValid;
+    }
+}

--- a/Gum/Gum.csproj
+++ b/Gum/Gum.csproj
@@ -303,11 +303,13 @@
 		</None>
 	</ItemGroup>
 	<ItemGroup>
-		<Folder Include="Converters\" />
 		<Folder Include="Graphics\Animation\Content\" />
 		<Folder Include="Plugins\InternalPlugins\ScreenshotPlugin\" />
 	</ItemGroup>
 	<ItemGroup>
+		<PackageReference Include="CommunityToolkit.Mvvm">
+		  <Version>8.4.0</Version>
+		</PackageReference>
 		<PackageReference Include="DynamicExpresso.Core">
 			<Version>2.16.1</Version>
 		</PackageReference>

--- a/Gum/Plugins/InternalPlugins/MenuStripPlugin/MenuStripManager.cs
+++ b/Gum/Plugins/InternalPlugins/MenuStripPlugin/MenuStripManager.cs
@@ -8,8 +8,10 @@ using Gum.Gui.Forms;
 using System.Diagnostics;
 using ExCSS;
 using Gum.Commands;
+using Gum.Dialogs;
 using Gum.ToolCommands;
 using Gum.Services;
+using Gum.Services.Dialogs;
 
 namespace Gum.Managers
 {
@@ -21,6 +23,7 @@ namespace Gum.Managers
         private readonly ISelectedState _selectedState;
         private readonly UndoManager _undoManager;
         private readonly EditCommands _editCommands;
+        private readonly IDialogService _dialogService;
 
         private MenuStrip _menuStrip;
 
@@ -54,6 +57,7 @@ namespace Gum.Managers
             _selectedState = Locator.GetRequiredService<ISelectedState>();
             _undoManager = Locator.GetRequiredService<UndoManager>();
             _editCommands = Locator.GetRequiredService<EditCommands>();
+            _dialogService = Locator.GetRequiredService<IDialogService>();
         }
 
         public void Initialize()
@@ -128,8 +132,7 @@ namespace Gum.Managers
                 GumCommands.Self.GuiCommands.ShowAddComponentWindow());
             Add(addToolStripMenuItem, "Instance", () =>
                 GumCommands.Self.GuiCommands.ShowAddInstanceWindow());
-            Add(addToolStripMenuItem, "State", () => 
-                GumCommands.Self.GuiCommands.ShowAddStateWindow());
+            Add(addToolStripMenuItem, "State", () => _dialogService.Show<AddStateDialogViewModel>());
 
             // 
             // RemoveElementMenuItem

--- a/Gum/Plugins/InternalPlugins/StatePlugin/StateTreeViewRightClickService.cs
+++ b/Gum/Plugins/InternalPlugins/StatePlugin/StateTreeViewRightClickService.cs
@@ -12,6 +12,7 @@ using Gum.Plugins;
 using Gum.Commands;
 using Gum.Mvvm;
 using System.Windows;
+using Gum.Dialogs;
 using Gum.Plugins.InternalPlugins.StatePlugin.Views;
 using Gum.Services;
 using Gum.Services.Dialogs;
@@ -75,7 +76,7 @@ public class StateTreeViewRightClickService
             if (_selectedState.SelectedStateCategorySave != null)
             {
                 // As of 5/24/2023, we no longer support uncategorized states
-                AddMenuItem("Add State", _gumCommands.GuiCommands.ShowAddStateWindow);
+                AddMenuItem("Add State", () => _dialogService.Show<AddStateDialogViewModel>());
             }
 
             AddMenuItem("Add Category", _gumCommands.GuiCommands.ShowAddCategoryWindow);
@@ -301,11 +302,6 @@ public class StateTreeViewRightClickService
 
 
     #endregion
-
-    internal void AddStateClick()
-    {
-        _gumCommands.GuiCommands.ShowAddStateWindow();
-    }
 
     private void DuplicateStateClick()
     {

--- a/Gum/Services/Dialogs/DialogService.cs
+++ b/Gum/Services/Dialogs/DialogService.cs
@@ -8,7 +8,8 @@ public interface IDialogService
 {
     MessageDialogResult ShowMessage(string message, string? title = null, MessageDialogStyle? style = null);
     public bool Show<T>(T dialogViewModel) where T : DialogViewModel;
-    bool Show<T>(out T viewModel) where T : DialogViewModel;
+    bool Show<T>(Action<T>? initializer, out T viewModel) where T : DialogViewModel;
+    string? GetUserString(string message, string? title = null, GetUserStringOptions? options = null);
 }
 
 internal class DialogService : IDialogService
@@ -82,10 +83,35 @@ internal class DialogService : IDialogService
         return affirmative is true;
     }
 
-    public bool Show<T>(out T viewModel) where T : DialogViewModel
+    public bool Show<T>(Action<T>? initializer, out T viewModel) where T : DialogViewModel
     {
         viewModel = _serviceProvider.GetService<T>() ?? Locator.GetRequiredService<T>();
+        initializer?.Invoke(viewModel);
         return Show(viewModel);
+    }
+
+    public string? GetUserString(string message, string? title = null, GetUserStringOptions? options = null)
+    {
+        GetUserStringDialogViewModel vm = new(options)
+        {
+            AffirmativeText = "Ok",
+            NegativeText = "Cancel",
+            Title = title,
+            Message = message,
+        };
+        
+        DialogWindow window = CreateDialogWindow(vm);
+
+        bool affirmative = false;
+        vm.RequestClose += (_, e) =>
+        {
+            affirmative = e;
+            window.Close();
+        };
+        
+        window.ShowDialog();
+        
+        return affirmative ? vm.Value : null;
     }
 }
 
@@ -98,6 +124,11 @@ public static class IDialogServiceExt
 
     public static bool Show<T>(this IDialogService dialogService) where T : DialogViewModel
     {
-        return dialogService.Show<T>(out _);
+        return dialogService.Show<T>(null, out _);
+    }
+
+    public static bool Show<T>(this IDialogService dialogService, Action<T> initializer) where T : DialogViewModel
+    {
+        return dialogService.Show<T>(initializer, out _);
     }
 }

--- a/Gum/Services/Dialogs/DialogViewModel.cs
+++ b/Gum/Services/Dialogs/DialogViewModel.cs
@@ -1,5 +1,8 @@
 ﻿using System;
+using System.Collections;
+using System.ComponentModel;
 using System.Windows.Input;
+using CommunityToolkit.Mvvm.Input;
 using Gum.Mvvm;
 using Microsoft.Xaml.Behaviors.Core;
 
@@ -11,27 +14,25 @@ public abstract class DialogViewModel : ViewModel
     public string? AffirmativeText { get => Get<string>(); set => Set(value); }
     public string? NegativeText { get => Get<string>(); set => Set(value); }
 
-    public ICommand AffirmativeCommand { get; }
-    public ICommand NegativeCommand { get; }
+    public RelayCommand AffirmativeCommand { get; }
+    public RelayCommand NegativeCommand { get; }
 
     protected DialogViewModel()
     {
-        AffirmativeCommand = new ActionCommand(Affirmative);
-        NegativeCommand = new ActionCommand(Negative);
+        AffirmativeCommand = new RelayCommand(OnAffirmative, CanExecuteAffirmative);
+        NegativeCommand = new RelayCommand(OnNegative, CanExecuteNegative);
     }
 
-    private void Affirmative()
+    protected virtual void OnAffirmative()
     {
-        OnAffirmative();
         RequestClose?.Invoke(this, true);
     }
 
-    private void Negative()
+    protected virtual void OnNegative()
     {
-        OnNegative();
         RequestClose?.Invoke(this, false);
     }
-    
-    protected virtual void OnAffirmative(){}
-    protected virtual void OnNegative(){}
+
+    public virtual bool CanExecuteAffirmative() => true;
+    public virtual bool CanExecuteNegative() => true;
 }

--- a/Gum/Services/Dialogs/DialogViewResolver.cs
+++ b/Gum/Services/Dialogs/DialogViewResolver.cs
@@ -64,6 +64,10 @@ internal class DialogViewResolver : IDialogViewResolver
                         if (viewTypes.FirstOrDefault(type => vmType.Name == $"{type.Name}Model") is { } viewType)
                         {
                             types[vmType] = viewType;
+                        } 
+                        else if (typeof(GetUserStringDialogBaseViewModel).IsAssignableFrom(vmType) && !vmType.IsAbstract)
+                        {
+                            types[vmType] = typeof(GetUserStringDialogView);
                         }
 
                         return types;

--- a/Gum/Services/Dialogs/DialogWindow.xaml
+++ b/Gum/Services/Dialogs/DialogWindow.xaml
@@ -33,7 +33,7 @@
                                     <Setter.Value>
                                         <DataTemplate DataType="{x:Type local:DialogViewModel}">
                                             <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
-                                                <Button Content="{Binding AffirmativeText}" Padding="16,4" MinWidth="64" Margin="5,0,0,0" Command="{Binding AffirmativeCommand}" />
+                                                <Button Content="{Binding AffirmativeText}" Padding="16,4" MinWidth="64" Margin="5,0,0,0" Command="{Binding AffirmativeCommand}" IsDefault="True"/>
                                                 <Button Content="{Binding NegativeText}" Padding="16,4" MinWidth="64" Margin="5,0,0,0" Command="{Binding NegativeCommand}">
                                                     <Button.Style>
                                                         <Style TargetType="{x:Type Button}" BasedOn="{StaticResource {x:Type Button}}">

--- a/Gum/Services/Dialogs/GetUserStringDialogView.xaml
+++ b/Gum/Services/Dialogs/GetUserStringDialogView.xaml
@@ -1,0 +1,28 @@
+﻿<UserControl x:Class="Gum.Services.Dialogs.GetUserStringDialogView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:local="clr-namespace:Gum.Services.Dialogs"
+             xmlns:mvvm="clr-namespace:Gum.Mvvm"
+             xmlns:converters="clr-namespace:Gum.Converters"
+             mc:Ignorable="d"
+             d:DesignHeight="300" d:DesignWidth="300"
+             d:DataContext="{d:DesignInstance Type={x:Type local:GetUserStringDialogBaseViewModel}, IsDesignTimeCreatable=False}"
+             local:Dialog.DialogTitle="{Binding Title}"
+             MinWidth="400"
+             MaxWidth="400">
+    <UserControl.Resources>
+        <converters:NullToVisibilityConverter x:Key="NullToVisibilityConverter"/>
+    </UserControl.Resources>
+    <StackPanel>
+        <TextBlock Text="{Binding Message}" 
+                   TextWrapping="Wrap"/>
+        <TextBox x:Name="ValueTextBox" 
+                 Text="{Binding Value, UpdateSourceTrigger=PropertyChanged}"/>
+        <TextBlock Text="{Binding Error}" 
+                   Margin="0,4,0,0" 
+                   Visibility="{Binding Error, Converter={StaticResource NullToVisibilityConverter}}" 
+                   TextWrapping="Wrap"/>
+    </StackPanel>
+</UserControl>

--- a/Gum/Services/Dialogs/GetUserStringDialogView.xaml.cs
+++ b/Gum/Services/Dialogs/GetUserStringDialogView.xaml.cs
@@ -1,0 +1,30 @@
+﻿using System.Windows.Controls;
+using System.Windows.Input;
+
+namespace Gum.Services.Dialogs;
+
+public partial class GetUserStringDialogView : UserControl
+{
+    public GetUserStringDialogView()
+    {
+        InitializeComponent();
+        Loaded += (_, _) =>
+        {
+            ValueTextBox.Focus();
+            if (DataContext is GetUserStringDialogBaseViewModel vm)
+            {               
+                if (!string.IsNullOrEmpty(vm.Value))
+                {
+                    ValueTextBox.CaretIndex = vm.Value!.Length;
+                }
+                
+                if (vm.PreSelect)
+                {
+                    ValueTextBox.SelectAll();
+                }
+                
+                vm.Validate();
+            }
+        };
+    }
+}

--- a/Gum/Services/Dialogs/GetUserStringDialogViewModel.cs
+++ b/Gum/Services/Dialogs/GetUserStringDialogViewModel.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.ComponentModel;
+using Gum.Mvvm;
+
+namespace Gum.Services.Dialogs;
+
+
+public abstract class GetUserStringDialogBaseViewModel : DialogViewModel
+{
+    public virtual string? Title { get => Get<string>(); set => Set(value); }
+    public virtual string Message { get => Get<string>(); set => Set(value); }
+    public string? Value { get => Get<string>(); set => Set(value); }
+    public string? Error { get => Get<string>(); private set => Set(value); }
+    public bool PreSelect { get; protected set; }
+    
+    protected GetUserStringDialogBaseViewModel()
+    {
+        AffirmativeText = "OK";
+        NegativeText = "Cancel";
+        
+        PropertyChanged += (_, e) =>
+        {
+            switch (e.PropertyName)
+            {
+                case nameof(Value):
+                    Validate();
+                    break;
+                case nameof(Error):
+                    AffirmativeCommand.NotifyCanExecuteChanged();
+                    break;
+            }
+        };
+    }
+    
+    public void Validate() => Error = Validate(Value);
+    
+    protected virtual string? Validate(string? value) => EnsureNotEmpty(value);
+
+    public override bool CanExecuteAffirmative() => Error is null;
+    
+    private static string? EnsureNotEmpty(string? value)
+    {
+        return string.IsNullOrEmpty(value) ? "Cannot be empty." : null;
+    }
+}
+
+public sealed class GetUserStringDialogViewModel : GetUserStringDialogBaseViewModel
+{
+    private Func<string?,string?>? Validator { get; }
+    public GetUserStringDialogViewModel(GetUserStringOptions? options = null)
+    {
+        Value = options?.InitialValue;
+        Validator = options?.Validator;
+        PreSelect = options?.PreSelect ?? false;
+    }
+    
+    protected override string? Validate(string? value) => Validator?.Invoke(value) ?? base.Validate(value);
+}
+
+public class GetUserStringOptions
+{
+    public Func<string?,string?>? Validator { get; set; }
+    public string? InitialValue { get; set; }
+    public bool PreSelect { get; set; }
+}


### PR DESCRIPTION
Adds both a generic method to get user input on the fly, as well as a base class to derive from for implementing more re-usable and testable setup/logic.

As a first example, migrates the existing "Add State" functionality from GuiCommands to use the new pattern.