### PR TITLE
Decouples GuiCommands from GumCommands

### DIFF
--- a/CodeOutputPlugin/ViewModels/CodeWindowViewModel.cs
+++ b/CodeOutputPlugin/ViewModels/CodeWindowViewModel.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using System.Windows;
+using Gum.Commands;
 using Gum.Services;
 using Gum.Services.Dialogs;
 using ToolsUtilities;
@@ -37,6 +38,7 @@ public enum WhichElementsToGenerate
 public class CodeWindowViewModel : ViewModel
 {
     private readonly IDialogService _dialogService;
+    private readonly GuiCommands _guiCommands;
     
     public WhatToView WhatToView
     {
@@ -156,6 +158,7 @@ public class CodeWindowViewModel : ViewModel
     public CodeWindowViewModel()
     {
         _dialogService = Locator.GetRequiredService<IDialogService>();
+        _guiCommands = Locator.GetRequiredService<GuiCommands>();
     }
 
     public FilePath? GetCsprojDirectoryAboveGumx()
@@ -265,7 +268,7 @@ public class CodeWindowViewModel : ViewModel
             }
             catch (Exception ex)
             {
-                GumCommands.Self.GuiCommands.PrintOutput($"Error: {ex}");
+                _guiCommands.PrintOutput($"Error: {ex}");
             }
         }
 

--- a/Gum/CommandLine/CommandLineManager.cs
+++ b/Gum/CommandLine/CommandLineManager.cs
@@ -4,6 +4,7 @@ using Gum.Services;
 using System;
 using System.Linq;
 using System.Threading.Tasks;
+using Gum.Commands;
 using ToolsUtilities;
 
 namespace Gum.CommandLine
@@ -11,6 +12,8 @@ namespace Gum.CommandLine
     public class CommandLineManager : Singleton<CommandLineManager>
     {
         private readonly FontManager _fontManager;
+        private readonly GuiCommands _guiCommands;
+        
         #region Fields/Properties
 
         public string GlueProjectToLoad
@@ -32,18 +35,19 @@ namespace Gum.CommandLine
         public CommandLineManager()
         {
             _fontManager = Locator.GetRequiredService<FontManager>();
+            _guiCommands = Locator.GetRequiredService<GuiCommands>();
         }
 
         public async Task ReadCommandLine()
         {
             string[] commandLineArgs = Environment.GetCommandLineArgs();
-            GumCommands.Self.GuiCommands.PrintOutput(commandLineArgs.Length + " command line argument(s)...");
+            _guiCommands.PrintOutput(commandLineArgs.Length + " command line argument(s)...");
 
             for(int i = 0; i < commandLineArgs.Length; i++)
             {
                 var arg = commandLineArgs[i];
 
-                GumCommands.Self.GuiCommands.PrintOutput(arg);
+                _guiCommands.PrintOutput(arg);
 
                 if (!string.IsNullOrEmpty(arg))
                 {

--- a/Gum/Commands/EditCommands.cs
+++ b/Gum/Commands/EditCommands.cs
@@ -1,4 +1,4 @@
-﻿using CommonFormsAndControls;
+using CommonFormsAndControls;
 using Gum.DataTypes;
 using Gum.DataTypes.Behaviors;
 using Gum.DataTypes.Variables;
@@ -170,7 +170,7 @@ public class EditCommands
         oldCategory.States.Remove(stateToMove);
         newCategory.States.Add(stateToMove);
 
-        GumCommands.Self.GuiCommands.RefreshStateTreeView();
+        _guiCommands.RefreshStateTreeView();
         _selectedState.SelectedStateSave = stateToMove;
 
         // make sure to propagate all variables in this new state and
@@ -279,7 +279,7 @@ public class EditCommands
     {
         container.RequiredVariables.Variables.Remove(variable);
         GumCommands.Self.FileCommands.TryAutoSaveBehavior(container);
-        GumCommands.Self.GuiCommands.RefreshVariables();
+        _guiCommands.RefreshVariables();
     }
 
     public void AddBehavior()

--- a/Gum/Commands/FileCommands.cs
+++ b/Gum/Commands/FileCommands.cs
@@ -20,6 +20,7 @@ namespace Gum.Commands
         private readonly ISelectedState _selectedState;
         private readonly UndoManager _undoManager;
         private readonly IDialogService _dialogService;
+        private readonly GuiCommands _guiCommands;
         
         MainWindow mainWindow;
 
@@ -28,6 +29,7 @@ namespace Gum.Commands
             _selectedState = Locator.GetRequiredService<ISelectedState>();
             _undoManager = Locator.GetRequiredService<UndoManager>();
             _dialogService = Locator.GetRequiredService<IDialogService>();
+            _guiCommands = Locator.GetRequiredService<GuiCommands>();
         }
         
         public void Initialize(MainWindow mainWindow, LocalizationManager localizationManager)
@@ -98,8 +100,8 @@ namespace Gum.Commands
 
             ProjectManager.Self.CreateNewProject();
 
-            GumCommands.Self.GuiCommands.RefreshStateTreeView();
-            GumCommands.Self.GuiCommands.RefreshVariables();
+            _guiCommands.RefreshStateTreeView();
+            _guiCommands.RefreshVariables();
             WireframeObjectManager.Self.RefreshAll(true);
         }
 

--- a/Gum/Commands/GuiCommands.cs
+++ b/Gum/Commands/GuiCommands.cs
@@ -42,13 +42,14 @@ public class GuiCommands
 
     MainPanelControl mainPanelControl;
 
-    private readonly ISelectedState _selectedState;
+    private readonly Lazy<ISelectedState> _lazySelectedState;
+    private ISelectedState _selectedState => _lazySelectedState.Value;
 
     #endregion
 
-    public GuiCommands()
+    public GuiCommands(Lazy<ISelectedState> lazySelectedState)
     {
-        _selectedState = Locator.GetRequiredService<ISelectedState>();
+        _lazySelectedState = lazySelectedState;
     }
 
     internal void Initialize(MainWindow mainWindow, MainPanelControl mainPanelControl)
@@ -203,7 +204,7 @@ public class GuiCommands
 
     public void PositionWindowByCursor(System.Windows.Forms.Form window)
     {
-        var mousePosition = GumCommands.Self.GuiCommands.GetMousePosition();
+        var mousePosition = GetMousePosition();
 
         window.Location = new System.Drawing.Point(mousePosition.X - window.Width / 2, mousePosition.Y - window.Height / 2);
     }

--- a/Gum/Commands/GumCommands.cs
+++ b/Gum/Commands/GumCommands.cs
@@ -7,12 +7,6 @@ namespace Gum;
 
 public class GumCommands : Singleton<GumCommands>
 {
-    public GuiCommands GuiCommands
-    {
-        get;
-        private set;
-    }
-
     public FileCommands FileCommands
     {
         get;
@@ -23,7 +17,6 @@ public class GumCommands : Singleton<GumCommands>
 
     public GumCommands()
     {
-        GuiCommands = new GuiCommands();
         FileCommands = new FileCommands();
         ProjectCommands = Gum.ToolCommands.ProjectCommands.Self;
     }
@@ -60,9 +53,8 @@ public class GumCommands : Singleton<GumCommands>
         }
     }
 
-    public void Initialize(MainWindow mainWindow, MainPanelControl mainPanelControl, LocalizationManager localizationManager)
+    public void Initialize(MainWindow mainWindow, LocalizationManager localizationManager)
     {
-        GuiCommands.Initialize(mainWindow, mainPanelControl);
         FileCommands.Initialize(mainWindow, localizationManager);
     }
 

--- a/Gum/Controls/CustomizableTextInputWindow.xaml.cs
+++ b/Gum/Controls/CustomizableTextInputWindow.xaml.cs
@@ -12,6 +12,8 @@ using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Navigation;
 using System.Windows.Shapes;
+using Gum.Commands;
+using Gum.Services;
 
 namespace Gum.Controls;
 
@@ -61,7 +63,8 @@ public partial class CustomizableTextInputWindow : Window
 
         this.WindowStartupLocation = WindowStartupLocation.Manual;
 
-        GumCommands.Self.GuiCommands.MoveToCursor(this);
+        GuiCommands guiCommands = Locator.GetRequiredService<GuiCommands>();
+        guiCommands.MoveToCursor(this);
 
         ValidationLabel.Visibility = Visibility.Hidden;
         this.Loaded += HandleLoaded;

--- a/Gum/Controls/ListBoxMessageBox.xaml.cs
+++ b/Gum/Controls/ListBoxMessageBox.xaml.cs
@@ -4,6 +4,8 @@ using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Windows;
 using System.Windows.Input;
+using Gum.Commands;
+using Gum.Services;
 
 namespace StateAnimationPlugin.Views
 {
@@ -97,7 +99,8 @@ namespace StateAnimationPlugin.Views
 
         private void HandleLoaded(object sender, RoutedEventArgs e)
         {
-            GumCommands.Self.GuiCommands.MoveToCursor(this);
+            GuiCommands guiCommands = Locator.GetRequiredService<GuiCommands>();
+            guiCommands.MoveToCursor(this);
 
             ListBox.Focus();
         }

--- a/Gum/Dialogs/AddScreenDialogViewModel.cs
+++ b/Gum/Dialogs/AddScreenDialogViewModel.cs
@@ -1,4 +1,5 @@
-﻿using Gum.DataTypes;
+﻿using Gum.Commands;
+using Gum.DataTypes;
 using Gum.Managers;
 using Gum.Services.Dialogs;
 using Gum.ToolStates;
@@ -13,11 +14,15 @@ public class AddScreenDialogViewModel : GetUserStringDialogBaseViewModel
     
     private readonly NameVerifier _nameVerifier;
     private readonly ISelectedState _selectedState;
+    private readonly GuiCommands _guiCommands;
 
-    public AddScreenDialogViewModel(NameVerifier nameVerifier, ISelectedState selectedState)
+    public AddScreenDialogViewModel(NameVerifier nameVerifier, 
+        ISelectedState selectedState, 
+        GuiCommands guiCommands)
     {
         _nameVerifier = nameVerifier;
         _selectedState = selectedState;
+        _guiCommands = guiCommands;
     }
 
     protected override void OnAffirmative()
@@ -42,7 +47,7 @@ public class AddScreenDialogViewModel : GetUserStringDialogBaseViewModel
 
         ScreenSave screenSave = GumCommands.Self.ProjectCommands.AddScreen(relativeToScreens + Value);
         
-        GumCommands.Self.GuiCommands.RefreshElementTreeView();
+        _guiCommands.RefreshElementTreeView();
 
         _selectedState.SelectedScreen = screenSave;
 

--- a/Gum/Dialogs/RenameFolderDialogViewModel.cs
+++ b/Gum/Dialogs/RenameFolderDialogViewModel.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Windows.Forms;
+using Gum.Commands;
 using Gum.DataTypes;
 using Gum.Logic;
 using Gum.Managers;
@@ -17,12 +18,17 @@ public class RenameFolderDialogViewModel : GetUserStringDialogBaseViewModel
     
     private readonly NameVerifier _nameVerifier;
     private readonly RenameLogic _renameLogic;
+    private readonly GuiCommands _guiCommands;
     public TreeNode? FolderNode { get; set; }
     
-    public RenameFolderDialogViewModel(NameVerifier nameVerifier, RenameLogic renameLogic)
+    public RenameFolderDialogViewModel(
+        NameVerifier nameVerifier, 
+        RenameLogic renameLogic,
+        GuiCommands guiCommands)
     {
         _nameVerifier = nameVerifier;
         _renameLogic = renameLogic;
+        _guiCommands = guiCommands;
     }
 
     protected override void OnAffirmative()
@@ -95,7 +101,7 @@ public class RenameFolderDialogViewModel : GetUserStringDialogBaseViewModel
         try
         {
             Directory.Move(oldFullPath.FullPath, newFullPath.FullPath);
-            GumCommands.Self.GuiCommands.RefreshElementTreeView();
+            _guiCommands.RefreshElementTreeView();
         }
         catch (Exception e)
         {

--- a/Gum/Gui/Windows/DeleteOptionsWindow.xaml.cs
+++ b/Gum/Gui/Windows/DeleteOptionsWindow.xaml.cs
@@ -2,6 +2,8 @@
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
+using Gum.Commands;
+using Gum.Services;
 
 namespace Gum.Gui.Windows
 {
@@ -33,7 +35,7 @@ namespace Gum.Gui.Windows
 
         private void HandleLoaded(object sender, RoutedEventArgs e)
         {
-            GumCommands.Self.GuiCommands.MoveToCursor(this);
+            Locator.GetRequiredService<GuiCommands>().MoveToCursor(this);
         }
 
         private void YesButtonClick(object sender, RoutedEventArgs e)

--- a/Gum/Logic/CopyPasteLogic.cs
+++ b/Gum/Logic/CopyPasteLogic.cs
@@ -8,6 +8,7 @@ using Gum.Wireframe;
 using System.Collections.Generic;
 using System.Linq;
 using System.Windows;
+using Gum.Commands;
 using Gum.Services;
 using Gum.Services.Dialogs;
 using ToolsUtilities;
@@ -51,6 +52,7 @@ public class CopyPasteLogic : Singleton<CopyPasteLogic>
     private readonly ISelectedState _selectedState;
     private readonly ElementCommands _elementCommands;
     private readonly IDialogService _dialogService;
+    private readonly GuiCommands _guiCommands;
     
     public CopiedData CopiedData { get; private set; } = new CopiedData();
 
@@ -73,6 +75,8 @@ public class CopyPasteLogic : Singleton<CopyPasteLogic>
         _selectedState = Locator.GetRequiredService<ISelectedState>();
         _elementCommands = Locator.GetRequiredService<ElementCommands>();
         _dialogService = Locator.GetRequiredService<IDialogService>();
+        _guiCommands = Locator.GetRequiredService<GuiCommands>();
+        
     }
 
     #region Copy
@@ -237,8 +241,8 @@ public class CopyPasteLogic : Singleton<CopyPasteLogic>
 
             GumCommands.Self.FileCommands.TryAutoSaveElement(sourceElement);
             WireframeObjectManager.Self.RefreshAll(true);
-            GumCommands.Self.GuiCommands.RefreshVariables();
-            GumCommands.Self.GuiCommands.RefreshElementTreeView();
+            _guiCommands.RefreshVariables();
+            _guiCommands.RefreshElementTreeView();
         }
 
         // todo: need to handle cut Element saves, but I don't want to do it yet due to the danger of losing valid data...
@@ -329,7 +333,7 @@ public class CopyPasteLogic : Singleton<CopyPasteLogic>
             container.States.Add(newStateSave);
         }
 
-        GumCommands.Self.GuiCommands.RefreshStateTreeView();
+        _guiCommands.RefreshStateTreeView();
 
 
 
@@ -578,7 +582,7 @@ public class CopyPasteLogic : Singleton<CopyPasteLogic>
 
 
         WireframeObjectManager.Self.RefreshAll(true);
-        GumCommands.Self.GuiCommands.RefreshElementTreeView(targetElement);
+        _guiCommands.RefreshElementTreeView(targetElement);
         GumCommands.Self.FileCommands.TryAutoSaveElement(targetElement);
         _selectedState.SelectedInstances = newInstances;
 

--- a/Gum/Logic/RenameLogic.cs
+++ b/Gum/Logic/RenameLogic.cs
@@ -12,6 +12,7 @@ using CommonFormsAndControls;
 using Gum.Controls;
 using System.Drawing;
 using System.Windows.Documents.DocumentStructures;
+using Gum.Commands;
 using Gum.Services;
 using Gum.Services.Dialogs;
 using ToolsUtilities;
@@ -70,12 +71,14 @@ public class RenameLogic
     private readonly ISelectedState _selectedState;
     private readonly NameVerifier _nameVerifier;
     private readonly IDialogService _dialogService;
+    private readonly GuiCommands _guiCommands;
 
-    public RenameLogic(ISelectedState selectedState, NameVerifier nameVerifier, IDialogService dialogService)
+    public RenameLogic(ISelectedState selectedState, NameVerifier nameVerifier, IDialogService dialogService, GuiCommands guiCommands)
     {
         _selectedState = selectedState;
         _nameVerifier = nameVerifier;
         _dialogService = dialogService;
+        _guiCommands = guiCommands;
     }
 
     #region StateSave
@@ -91,13 +94,13 @@ public class RenameLogic
             string oldName = stateSave.Name;
 
             stateSave.Name = newName;
-            GumCommands.Self.GuiCommands.RefreshStateTreeView();
+            _guiCommands.RefreshStateTreeView();
             // I don't think we need to save the project when renaming a state:
             //GumCommands.Self.FileCommands.TryAutoSaveProject();
 
             // Renaming the state should refresh the property grid
             // because it displays the state name at the top
-            GumCommands.Self.GuiCommands.RefreshVariables(force: true);
+            _guiCommands.RefreshVariables(force: true);
 
             PluginManager.Self.StateRename(stateSave, oldName);
 
@@ -187,7 +190,7 @@ public class RenameLogic
             }
         }
 
-        GumCommands.Self.GuiCommands.RefreshStateTreeView();
+        _guiCommands.RefreshStateTreeView();
         // I don't think we need to save the project when renaming a state:
         //GumCommands.Self.FileCommands.TryAutoSaveProject();
 
@@ -327,7 +330,7 @@ public class RenameLogic
                     RenameXml(elementSave, oldName);
                 }
 
-                GumCommands.Self.GuiCommands.RefreshElementTreeView(instanceContainer);
+                _guiCommands.RefreshElementTreeView(instanceContainer);
             }
 
             if (!shouldContinue && isRenamingXmlFile)
@@ -380,11 +383,11 @@ public class RenameLogic
         if (didMoveToNewDirectory)
         {
             // refresh the entire tree view because the node is moving:
-            GumCommands.Self.GuiCommands.RefreshElementTreeView();
+            _guiCommands.RefreshElementTreeView();
         }
         else
         {
-            GumCommands.Self.GuiCommands.RefreshElementTreeView(elementSave);
+            _guiCommands.RefreshElementTreeView(elementSave);
         }
     }
 

--- a/Gum/Logic/ReorderLogic.cs
+++ b/Gum/Logic/ReorderLogic.cs
@@ -1,4 +1,5 @@
-﻿using Gum.DataTypes;
+﻿using Gum.Commands;
+using Gum.DataTypes;
 using Gum.Managers;
 using Gum.Plugins;
 using Gum.Services;
@@ -12,11 +13,13 @@ namespace Gum.Logic
     {
         private readonly ISelectedState _selectedState;
         private readonly UndoManager _undoManager;
+        private readonly GuiCommands _guiCommands;
 
         public ReorderLogic()
         {
             _selectedState = Locator.GetRequiredService<ISelectedState>();
             _undoManager = Locator.GetRequiredService<UndoManager>();
+            _guiCommands = Locator.GetRequiredService<GuiCommands>();
         }
         
         public void MoveSelectedInstanceForward()
@@ -140,7 +143,7 @@ namespace Gum.Logic
         {
             var element = _selectedState.SelectedElement;
 
-            GumCommands.Self.GuiCommands.RefreshElementTreeView(element);
+            _guiCommands.RefreshElementTreeView(element);
 
 
             WireframeObjectManager.Self.RefreshAll(true);

--- a/Gum/MainWindow.cs
+++ b/Gum/MainWindow.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.ComponentModel;
 using System.Drawing;
 using System.Windows.Forms;
@@ -9,6 +9,7 @@ using Gum.Reflection;
 using Gum.Wireframe;
 using Gum.PropertyGridHelpers;
 using System.Windows.Forms.Integration;
+using Gum.Commands;
 using Gum.Controls;
 using Gum.Logic.FileWatch;
 using Gum.DataTypes;
@@ -38,6 +39,8 @@ namespace Gum
     {
         #region Fields/Properties
 
+        private readonly GuiCommands _guiCommands;
+        
         private System.Windows.Forms.Timer FileWatchTimer;
 
         MainPanelControl mainPanelControl;
@@ -63,7 +66,9 @@ namespace Gum
             this.KeyDown += HandleKeyDown;
 
             // Initialize before the StateView is created...
-            GumCommands.Self.Initialize(this, mainPanelControl, Locator.GetRequiredService<LocalizationManager>());
+            _guiCommands = Locator.GetRequiredService<GuiCommands>();
+            _guiCommands.Initialize(this, mainPanelControl);
+            GumCommands.Self.Initialize(this, Locator.GetRequiredService<LocalizationManager>());
 
             TypeManager.Self.Initialize();
 
@@ -71,7 +76,7 @@ namespace Gum
             ProjectManager.Self.LoadSettings();
 
             Cursor addCursor = LoadAddCursor();
-            GumCommands.Self.GuiCommands.AddCursor = addCursor;
+            _guiCommands.AddCursor = addCursor;
             // Vic says - I tried
             // to instantiate the ElementTreeImages
             // in the ElementTreeViewManager. I move 
@@ -151,7 +156,7 @@ namespace Gum
                  && (args.Modifiers & Keys.Control) == Keys.Control
                 )
             {
-                GumCommands.Self.GuiCommands.FocusSearch();
+                _guiCommands.FocusSearch();
                 args.Handled = true;
                 args.SuppressKeyPress = true;
             }

--- a/Gum/Managers/DeleteLogic.cs
+++ b/Gum/Managers/DeleteLogic.cs
@@ -14,6 +14,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Windows.Forms;
+using Gum.Commands;
 using Gum.Services;
 using Gum.Services.Dialogs;
 using DialogResult = System.Windows.Forms.DialogResult;
@@ -27,6 +28,7 @@ namespace Gum.Managers
         private readonly ElementCommands _elementCommands;
         private readonly UndoManager _undoManager;
         private readonly IDialogService _dialogService;
+        private readonly GuiCommands _guiCommands;
 
         public DeleteLogic()
         {
@@ -36,6 +38,7 @@ namespace Gum.Managers
             _undoManager = Locator.GetRequiredService<UndoManager>();
             _elementCommands = Locator.GetRequiredService<ElementCommands>();
             _dialogService = Locator.GetRequiredService<IDialogService>();
+            _guiCommands = Locator.GetRequiredService<GuiCommands>();
         }
 
 
@@ -242,7 +245,7 @@ namespace Gum.Managers
             optionsWindow.ObjectsToDelete = objectsToDelete;
 
             // do this in Loaded so it has height
-            //GumCommands.Self.GuiCommands.MoveToCursor(optionsWindow);
+            //_guiCommands.MoveToCursor(optionsWindow);
 
             PluginManager.Self.ShowDeleteDialog(optionsWindow, objectsToDelete);
 
@@ -338,12 +341,12 @@ namespace Gum.Managers
             if(selectedElement != null)
             {
                 _selectedState.SelectedElement = elementToReselect;
-                GumCommands.Self.GuiCommands.RefreshElementTreeView(selectedElement);
+                _guiCommands.RefreshElementTreeView(selectedElement);
             }
             else if(behavior != null)
             {
                 _selectedState.SelectedBehavior = behaviorToReselect;
-                GumCommands.Self.GuiCommands.RefreshElementTreeView(behavior);
+                _guiCommands.RefreshElementTreeView(behavior);
             }
 
             WireframeObjectManager.Self.RefreshAll(true);
@@ -471,8 +474,8 @@ namespace Gum.Managers
 
                 GumCommands.Self.FileCommands.TryAutoSaveCurrentElement();
 
-                GumCommands.Self.GuiCommands.RefreshStateTreeView();
-                GumCommands.Self.GuiCommands.RefreshVariables();
+                _guiCommands.RefreshStateTreeView();
+                _guiCommands.RefreshVariables();
                 WireframeObjectManager.Self.RefreshAll(true);
 
                 PluginManager.Self.CategoryDelete(category);
@@ -515,7 +518,7 @@ namespace Gum.Managers
                     _elementCommands.RemoveState(stateSave, _selectedState.SelectedStateContainer);
                     PluginManager.Self.StateDelete(stateSave);
 
-                    GumCommands.Self.GuiCommands.RefreshVariables();
+                    _guiCommands.RefreshVariables();
                     WireframeObjectManager.Self.RefreshAll(true);
 
                     if (shouldSelectAfterRemoval)

--- a/Gum/Managers/DragDropManager.cs
+++ b/Gum/Managers/DragDropManager.cs
@@ -14,6 +14,7 @@ using Gum.ToolCommands;
 using RenderingLibrary.Graphics;
 using Gum.PropertyGridHelpers;
 using System.Drawing;
+using Gum.Commands;
 using Gum.Converters;
 using Gum.Logic;
 using Gum.Plugins.ImportPlugin.Manager;
@@ -50,6 +51,7 @@ public class DragDropManager
     private readonly RenameLogic _renameLogic;
     private readonly UndoManager _undoManager;
     private readonly IDialogService _dialogService;
+    private readonly GuiCommands _guiCommands;
 
     #endregion
 
@@ -71,6 +73,7 @@ public class DragDropManager
         _renameLogic = Locator.GetRequiredService<RenameLogic>();
         _undoManager = Locator.GetRequiredService<UndoManager>();
         _dialogService = Locator.GetRequiredService<IDialogService>();
+        _guiCommands = Locator.GetRequiredService<GuiCommands>();
     }
 
     #region Drag+drop File (from windows explorer)
@@ -403,8 +406,8 @@ public class DragDropManager
 
         if(targetComponent == _selectedState.SelectedComponent)
         {
-            GumCommands.Self.GuiCommands.RefreshStateTreeView();
-            GumCommands.Self.GuiCommands.BroadcastRefreshBehaviorView();
+            _guiCommands.RefreshStateTreeView();
+            _guiCommands.BroadcastRefreshBehaviorView();
         }
     }
 
@@ -474,7 +477,7 @@ public class DragDropManager
         behaviorInstanceSave.Name = draggedAsInstanceSave.Name;
         behaviorInstanceSave.BaseType = draggedAsInstanceSave.BaseType;
         asBehaviorSave.RequiredInstances.Add(behaviorInstanceSave);
-        GumCommands.Self.GuiCommands.RefreshElementTreeView();
+        _guiCommands.RefreshElementTreeView();
         GumCommands.Self.FileCommands.TryAutoSaveBehavior(asBehaviorSave);
 
     }
@@ -723,8 +726,8 @@ public class DragDropManager
     private void SaveAndRefresh()
     {
         GumCommands.Self.FileCommands.TryAutoSaveCurrentElement();
-        GumCommands.Self.GuiCommands.RefreshVariables();
-        GumCommands.Self.GuiCommands.RefreshElementTreeView();
+        _guiCommands.RefreshVariables();
+        _guiCommands.RefreshElementTreeView();
 
         WireframeObjectManager.Self.RefreshAll(true);
     }

--- a/Gum/Managers/FileChangeReactionLogic.cs
+++ b/Gum/Managers/FileChangeReactionLogic.cs
@@ -13,10 +13,13 @@ namespace Gum.Managers
     {
         private readonly ISelectedState _selectedState;
         private readonly WireframeCommands _wireframeCommands;
+        private readonly GuiCommands _guiCommands;
+        
         public FileChangeReactionLogic()
         {
             _selectedState = Locator.GetRequiredService<ISelectedState>();
             _wireframeCommands = Locator.GetRequiredService<WireframeCommands>();
+            _guiCommands = Locator.GetRequiredService<GuiCommands>();
         }
         
         public void ReactToFileChanged(FilePath file)
@@ -175,7 +178,7 @@ namespace Gum.Managers
                 {
                     _selectedState.SelectedElement = null;
                 }
-                GumCommands.Self.GuiCommands.RefreshElementTreeView();
+                _guiCommands.RefreshElementTreeView();
 
                 if(refreshingSelected)
                 {
@@ -212,7 +215,7 @@ namespace Gum.Managers
                 Wireframe.WireframeObjectManager.Self.RefreshAll(true, true);
 
                 // todo - this isn't working if I rename a variable...
-                GumCommands.Self.GuiCommands.RefreshVariables(force: true);
+                _guiCommands.RefreshVariables(force: true);
             }
         }
 
@@ -234,7 +237,7 @@ namespace Gum.Managers
                 {
                     _selectedState.SelectedBehavior = null;
                 }
-                GumCommands.Self.GuiCommands.RefreshElementTreeView();
+                _guiCommands.RefreshElementTreeView();
 
                 if (refreshingSelected)
                 {
@@ -242,7 +245,7 @@ namespace Gum.Managers
                         item.Name.ToLowerInvariant() == file.StandardizedNoPathNoExtension.ToLowerInvariant());
                     _selectedState.SelectedBehavior = behavior;
 
-                    GumCommands.Self.GuiCommands.RefreshVariables(force: true);
+                    _guiCommands.RefreshVariables(force: true);
                 }
 
                 // no need to reload wirefreame like we do for elements because they don't show up visually...

--- a/Gum/Managers/HotkeyManager.cs
+++ b/Gum/Managers/HotkeyManager.cs
@@ -192,7 +192,7 @@ public class HotkeyManager : Singleton<HotkeyManager>
     public HotkeyManager()
     {
         _copyPasteLogic = CopyPasteLogic.Self;
-        _guiCommands = GumCommands.Self.GuiCommands;
+        _guiCommands = Locator.GetRequiredService<GuiCommands>();
         _selectedState = Locator.GetRequiredService<ISelectedState>();
         _elementCommands = Locator.GetRequiredService<ElementCommands>();
         _dialogService =  Locator.GetRequiredService<IDialogService>();
@@ -336,7 +336,7 @@ public class HotkeyManager : Singleton<HotkeyManager>
 
         if(Search.IsPressed(e))
         {
-            GumCommands.Self.GuiCommands.FocusSearch();
+            _guiCommands.FocusSearch();
             e.Handled = true;
         }
     }

--- a/Gum/Managers/ProjectManager.cs
+++ b/Gum/Managers/ProjectManager.cs
@@ -20,6 +20,7 @@ using System.ComponentModel;
 using System.Management.Instrumentation;
 using Gum.ToolCommands;
 using System.Threading.Tasks;
+using Gum.Commands;
 using Gum.Services;
 using Gum.Services.Dialogs;
 using DialogResult = System.Windows.Forms.DialogResult;
@@ -39,6 +40,7 @@ namespace Gum
         private readonly ISelectedState _selectedState;
         private readonly ElementCommands _elementCommands;
         private readonly IDialogService _dialogService;
+        private readonly GuiCommands _guiCommands;
 
         #endregion
 
@@ -87,6 +89,7 @@ namespace Gum
             _selectedState = Locator.GetRequiredService<ISelectedState>();
             _elementCommands = Locator.GetRequiredService<ElementCommands>();
             _dialogService = Locator.GetRequiredService<IDialogService>();
+            _guiCommands = Locator.GetRequiredService<GuiCommands>();
         }
 
         public void LoadSettings()
@@ -394,7 +397,7 @@ namespace Gum
                     }
                     catch (Exception e)
                     {
-                        GumCommands.Self.GuiCommands.PrintOutput($"Error {e}");
+                        _guiCommands.PrintOutput($"Error {e}");
                     }
                 }
             }

--- a/Gum/Plugins/BaseClasses/PluginBase.cs
+++ b/Gum/Plugins/BaseClasses/PluginBase.cs
@@ -14,12 +14,16 @@ using Gum.ToolStates;
 using ExCSS;
 using RenderingLibrary;
 using System.Numerics;
+using Gum.Commands;
 using Gum.Managers;
+using Gum.Services;
 
 namespace Gum.Plugins.BaseClasses
 {
     public abstract class PluginBase : IPlugin
     {
+        protected readonly GuiCommands _guiCommands;
+        
         #region Events
 
         public event Action<GumProjectSave>? ProjectLoad;
@@ -214,6 +218,11 @@ namespace Gum.Plugins.BaseClasses
 
         public virtual Version Version => new Version(1, 0);
 
+        protected PluginBase()
+        {
+            _guiCommands = Locator.GetRequiredService<GuiCommands>();
+        }
+
         public abstract void StartUp();
         public abstract bool ShutDown(PluginShutDownReason shutDownReason);
 
@@ -347,12 +356,12 @@ namespace Gum.Plugins.BaseClasses
 
         public PluginTab AddControl(System.Windows.FrameworkElement control, string tabName, TabLocation tabLocation)
         {
-            return GumCommands.Self.GuiCommands.AddControl(control, tabName, tabLocation);
+            return _guiCommands.AddControl(control, tabName, tabLocation);
         }
 
         public void RemoveControl(System.Windows.Controls.UserControl control)
         {
-            GumCommands.Self.GuiCommands.RemoveControl(control);
+            _guiCommands.RemoveControl(control);
         }
 
         #endregion

--- a/Gum/Plugins/ImportPlugin/Manager/ImportLogic.cs
+++ b/Gum/Plugins/ImportPlugin/Manager/ImportLogic.cs
@@ -9,6 +9,7 @@ using System;
 using System.Drawing;
 using System.Linq;
 using System.Windows.Forms;
+using Gum.Commands;
 using ToolsUtilities;
 
 namespace Gum.Plugins.ImportPlugin.Manager;
@@ -16,6 +17,8 @@ namespace Gum.Plugins.ImportPlugin.Manager;
 public static class ImportLogic
 {
     private static readonly ISelectedState _selectedState = Locator.GetRequiredService<ISelectedState>();
+    private static readonly GuiCommands _guiCommands = Locator.GetRequiredService<GuiCommands>();
+    
     #region Screen
 
     internal static void ShowImportScreenUi()
@@ -89,7 +92,7 @@ public static class ImportLogic
             StandardElementsManagerGumTool.Self.FixCustomTypeConverters(screenSave);
             if(saveProject)
             {
-                GumCommands.Self.GuiCommands.RefreshElementTreeView();
+                _guiCommands.RefreshElementTreeView();
                 _selectedState.SelectedScreen = screenSave;
                 GumCommands.Self.FileCommands.TryAutoSaveProject();
             }
@@ -157,7 +160,7 @@ public static class ImportLogic
 
         if (lastImportedComponent != null)
         {
-            GumCommands.Self.GuiCommands.RefreshElementTreeView();
+            _guiCommands.RefreshElementTreeView();
             _selectedState.SelectedComponent = lastImportedComponent;
             GumCommands.Self.FileCommands.TryAutoSaveProject();
         }
@@ -190,7 +193,7 @@ public static class ImportLogic
                 }
                 catch (Exception ex)
                 {
-                    GumCommands.Self.GuiCommands.PrintOutput("Error copying file: " + ex);
+                    _guiCommands.PrintOutput("Error copying file: " + ex);
                     shouldAdd = false;
                 }
             }
@@ -218,7 +221,7 @@ public static class ImportLogic
 
             if(saveProject)
             {
-                GumCommands.Self.GuiCommands.RefreshElementTreeView();
+                _guiCommands.RefreshElementTreeView();
                 _selectedState.SelectedComponent = componentSave;
                 GumCommands.Self.FileCommands.TryAutoSaveProject();
             }
@@ -287,7 +290,7 @@ public static class ImportLogic
 
         if (lastImportedBehavior != null)
         {
-            GumCommands.Self.GuiCommands.RefreshElementTreeView();
+            _guiCommands.RefreshElementTreeView();
             _selectedState.SelectedBehavior = lastImportedBehavior;
             GumCommands.Self.FileCommands.TryAutoSaveProject();
         }
@@ -320,7 +323,7 @@ public static class ImportLogic
                 }
                 catch (Exception ex)
                 {
-                    GumCommands.Self.GuiCommands.PrintOutput("Error copying file: " + ex);
+                    _guiCommands.PrintOutput("Error copying file: " + ex);
                     shouldAdd = false;
                 }
             }
@@ -346,7 +349,7 @@ public static class ImportLogic
 
             if(saveProject)
             {
-                GumCommands.Self.GuiCommands.RefreshElementTreeView();
+                _guiCommands.RefreshElementTreeView();
                 _selectedState.SelectedBehavior = behaviorSave;
                 GumCommands.Self.FileCommands.TryAutoSaveProject();
             }

--- a/Gum/Plugins/InternalPlugins/AlignmentButtons/AlignmentMainPlugin.cs
+++ b/Gum/Plugins/InternalPlugins/AlignmentButtons/AlignmentMainPlugin.cs
@@ -55,7 +55,7 @@ namespace Gum.Plugins.AlignmentButtons
 
                 if (!isAdded)
                 {
-                    GumCommands.Self.GuiCommands.AddControl(control, "Alignment");
+                    _guiCommands.AddControl(control, "Alignment");
                     isAdded = true;
                 }
             }
@@ -63,7 +63,7 @@ namespace Gum.Plugins.AlignmentButtons
             {
                 if (control != null && isAdded)
                 {
-                    GumCommands.Self.GuiCommands.RemoveControl(control);
+                    _guiCommands.RemoveControl(control);
                     isAdded = false;
                 }
             }

--- a/Gum/Plugins/InternalPlugins/AlignmentButtons/CommonControlLogic.cs
+++ b/Gum/Plugins/InternalPlugins/AlignmentButtons/CommonControlLogic.cs
@@ -11,11 +11,13 @@ public class CommonControlLogic
 {
     private readonly ISelectedState _selectedState;
     private readonly WireframeCommands _wireframeCommands;
+    private readonly GuiCommands _guiCommands;
     
     public CommonControlLogic()
     {
         _selectedState = Locator.GetRequiredService<ISelectedState>();
         _wireframeCommands = Locator.GetRequiredService<WireframeCommands>();
+        _guiCommands = Locator.GetRequiredService<GuiCommands>();
     }
 
     bool SelectionInheritsFromText()
@@ -100,7 +102,7 @@ public class CommonControlLogic
 
     public void RefreshAndSave()
     {
-        GumCommands.Self.GuiCommands.RefreshVariables(force: true);
+        _guiCommands.RefreshVariables(force: true);
         _wireframeCommands.Refresh();
         GumCommands.Self.FileCommands.TryAutoSaveCurrentElement();
     }

--- a/Gum/Plugins/InternalPlugins/Behaviors/MainBehaviorsPlugin.cs
+++ b/Gum/Plugins/InternalPlugins/Behaviors/MainBehaviorsPlugin.cs
@@ -172,7 +172,7 @@ public class MainBehaviorsPlugin : InternalPlugin
                     _elementCommands.AddBehaviorTo(behavior.Name, component, performSave: false);
                 }
 
-                GumCommands.Self.GuiCommands.RefreshStateTreeView();
+                _guiCommands.RefreshStateTreeView();
                 GumCommands.Self.FileCommands.TryAutoSaveElement(component);
             }
             viewModel.UpdateTo(component);

--- a/Gum/Plugins/InternalPlugins/Delete/DeleteObjectPlugin.cs
+++ b/Gum/Plugins/InternalPlugins/Delete/DeleteObjectPlugin.cs
@@ -115,7 +115,7 @@ public class DeleteObjectPlugin : InternalPlugin
             RecursivelyDeleteChildrenOf(instance);
 
             // refresh the property grid, refresh the wireframe, save
-            GumCommands.Self.GuiCommands.RefreshElementTreeView(element);
+            _guiCommands.RefreshElementTreeView(element);
             _wireframeCommands.Refresh();
             GumCommands.Self.FileCommands.TryAutoSaveElement(element);
         }

--- a/Gum/Plugins/InternalPlugins/Errors/MainErrorsPlugin.cs
+++ b/Gum/Plugins/InternalPlugins/Errors/MainErrorsPlugin.cs
@@ -18,14 +18,8 @@ public class MainErrorsPlugin : InternalPlugin
     ErrorDisplay control;
     PluginTab tabPage;
     private ErrorTabHeader _tabPageHeader;
-    private readonly GuiCommands _guiCommands;
 
     #endregion
-
-    public MainErrorsPlugin()
-    {
-        _guiCommands = GumCommands.Self.GuiCommands;
-    }
 
     public override void StartUp()
     {

--- a/Gum/Plugins/InternalPlugins/FileWatchPlugin/MainFileWatchPlugin.cs
+++ b/Gum/Plugins/InternalPlugins/FileWatchPlugin/MainFileWatchPlugin.cs
@@ -8,6 +8,7 @@ using System;
 using System.ComponentModel.Composition;
 using System.Linq;
 using System.Timers;
+using Gum.Services;
 using ToolsUtilities;
 
 namespace Gum.Plugins.FileWatchPlugin;
@@ -38,7 +39,7 @@ public class MainFileWatchPlugin : InternalPlugin
 
         _fileWatchManager = FileWatchManager.Self;
         _fileWatchLogic = FileWatchLogic.Self;
-        _guiCommands = GumCommands.Self.GuiCommands;
+        _guiCommands = Locator.GetRequiredService<GuiCommands>();
 
         pluginTab = _guiCommands.AddControl(control, "File Watch", TabLocation.RightBottom);
         pluginTab.Hide();

--- a/Gum/Plugins/InternalPlugins/HideShowTools/MainHideShowToolsPlugin.cs
+++ b/Gum/Plugins/InternalPlugins/HideShowTools/MainHideShowToolsPlugin.cs
@@ -26,14 +26,14 @@ internal class MainHideShowToolsPlugin : InternalPlugin
         if (areToolsVisible)
         {
             menuItem.Text = "Show Tools";
-            GumCommands.Self.GuiCommands.HideTools();
+            _guiCommands.HideTools();
             areToolsVisible = false;
 
         }
         else
         {
             menuItem.Text = "Hide Tools";
-            GumCommands.Self.GuiCommands.ShowTools();
+            _guiCommands.ShowTools();
             areToolsVisible = true;
         }
     }

--- a/Gum/Plugins/InternalPlugins/Hotkey/MainHotkeyPlugin.cs
+++ b/Gum/Plugins/InternalPlugins/Hotkey/MainHotkeyPlugin.cs
@@ -36,7 +36,7 @@ namespace Gum.Plugins.InternalPlugins.Hotkey
 
         private void HandleToggleTabVisibility(object sender, EventArgs e)
         {
-            if(!GumCommands.Self.GuiCommands.IsTabVisible(pluginTab))
+            if(!_guiCommands.IsTabVisible(pluginTab))
             {
                 pluginTab.Show();
             } 

--- a/Gum/Plugins/InternalPlugins/Inheritance/MainInheritancePlugin.cs
+++ b/Gum/Plugins/InternalPlugins/Inheritance/MainInheritancePlugin.cs
@@ -43,7 +43,7 @@ namespace Gum.Plugins.Inheritance
                     AdjustInstance(directBase, inheritingElement, clone.Name);
 
                     GumCommands.Self.FileCommands.TryAutoSaveElement(inheritingElement);
-                    GumCommands.Self.GuiCommands.RefreshElementTreeView(inheritingElement);
+                    _guiCommands.RefreshElementTreeView(inheritingElement);
                 }
             }
         }
@@ -60,7 +60,7 @@ namespace Gum.Plugins.Inheritance
                     inheritingElement.Instances.RemoveAll(item => item.Name == instance.Name);
 
                     GumCommands.Self.FileCommands.TryAutoSaveElement(inheritingElement);
-                    GumCommands.Self.GuiCommands.RefreshElementTreeView(inheritingElement);
+                    _guiCommands.RefreshElementTreeView(inheritingElement);
                 }
             }
         }
@@ -77,7 +77,7 @@ namespace Gum.Plugins.Inheritance
                 {
                     toRename.Name = instance.Name;
                     GumCommands.Self.FileCommands.TryAutoSaveElement(inheritingElement);
-                    GumCommands.Self.GuiCommands.RefreshElementTreeView(inheritingElement);
+                    _guiCommands.RefreshElementTreeView(inheritingElement);
                 }
             }
         }
@@ -170,9 +170,9 @@ namespace Gum.Plugins.Inheritance
 
             const bool fullRefresh = true;
             // since the type might change:
-            GumCommands.Self.GuiCommands.RefreshElementTreeView(asElementSave);
-            GumCommands.Self.GuiCommands.RefreshVariables(fullRefresh);
-            GumCommands.Self.GuiCommands.RefreshStateTreeView();
+            _guiCommands.RefreshElementTreeView(asElementSave);
+            _guiCommands.RefreshVariables(fullRefresh);
+            _guiCommands.RefreshStateTreeView();
         }
 
         private void HandleInstanceReordered(InstanceSave instance)
@@ -190,7 +190,7 @@ namespace Gum.Plugins.Inheritance
                 if(didShiftIndex)
                 {
                     GumCommands.Self.FileCommands.TryAutoSaveElement(inheritingElement);
-                    GumCommands.Self.GuiCommands.RefreshElementTreeView(inheritingElement);
+                    _guiCommands.RefreshElementTreeView(inheritingElement);
                 }
             }
         }

--- a/Gum/Plugins/InternalPlugins/MenuStripPlugin/MainMenuStripPlugin.cs
+++ b/Gum/Plugins/InternalPlugins/MenuStripPlugin/MainMenuStripPlugin.cs
@@ -12,6 +12,7 @@ using System.ComponentModel.Composition;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Gum.Commands;
 
 namespace Gum.Plugins.InternalPlugins.MenuStripPlugin;
 
@@ -22,7 +23,7 @@ public class MainMenuStripPlugin : InternalPlugin
 
     public static void InitializeMenuStrip()
     {
-        _menuStripManager = new MenuStripManager(GumCommands.Self.GuiCommands);
+        _menuStripManager = new MenuStripManager();
         _menuStripManager.Initialize();
 
     }

--- a/Gum/Plugins/InternalPlugins/MenuStripPlugin/MenuStripManager.cs
+++ b/Gum/Plugins/InternalPlugins/MenuStripPlugin/MenuStripManager.cs
@@ -51,9 +51,9 @@ namespace Gum.Managers
 
         #endregion
 
-        public MenuStripManager(GuiCommands guiCommands)
+        public MenuStripManager()
         {
-            _guiCommands = guiCommands;
+            _guiCommands = Locator.GetRequiredService<GuiCommands>();
             _selectedState = Locator.GetRequiredService<ISelectedState>();
             _undoManager = Locator.GetRequiredService<UndoManager>();
             _editCommands = Locator.GetRequiredService<EditCommands>();
@@ -62,7 +62,7 @@ namespace Gum.Managers
 
         public void Initialize()
         {
-            var mainWindow = GumCommands.Self.GuiCommands.MainWindow;
+            var mainWindow = _guiCommands.MainWindow;
             // Load Recent handled in MainRecentFilesPlugin
 
             #region Local Functions
@@ -279,12 +279,12 @@ namespace Gum.Managers
 
             //Add(viewToolStripMenuItem, "Hide Tools", () =>
             //{
-            //    GumCommands.Self.GuiCommands.HideTools();
+            //    _guiCommands.HideTools();
             //});
 
             //Add(viewToolStripMenuItem, "Show Tools", () =>
             //{
-            //    GumCommands.Self.GuiCommands.ShowTools();
+            //    _guiCommands.ShowTools();
             //});
 
 

--- a/Gum/Plugins/InternalPlugins/NineSlicePlugin/MainNineSlicePlugin.cs
+++ b/Gum/Plugins/InternalPlugins/NineSlicePlugin/MainNineSlicePlugin.cs
@@ -43,7 +43,7 @@ internal class MainNineSlicePlugin : InternalPlugin
         }
         catch (Exception e)
         {
-            GumCommands.Self.GuiCommands.PrintOutput($"Error copying ExampleSpriteFrame.png: {e}");
+            _guiCommands.PrintOutput($"Error copying ExampleSpriteFrame.png: {e}");
         }
     }
 

--- a/Gum/Plugins/InternalPlugins/Output/MainOutputPlugin.cs
+++ b/Gum/Plugins/InternalPlugins/Output/MainOutputPlugin.cs
@@ -27,7 +27,7 @@ namespace Gum.Plugins.Output
             outputTextBox.TabIndex = 0;
             outputTextBox.Text = "";
 
-            GumCommands.Self.GuiCommands.AddWinformsControl(outputTextBox, "Output", TabLocation.RightBottom);
+            _guiCommands.AddWinformsControl(outputTextBox, "Output", TabLocation.RightBottom);
             OutputManager.Self.Initialize(outputTextBox);
         }
     }

--- a/Gum/Plugins/InternalPlugins/ParentPlugin/MainParentPlugin.cs
+++ b/Gum/Plugins/InternalPlugins/ParentPlugin/MainParentPlugin.cs
@@ -69,7 +69,7 @@ namespace Gum.Plugins.ParentPlugin
                         // This container can't support this value
                         currentState.SetValue($"{instance.Name}.Parent", oldValue, "string");
 
-                        GumCommands.Self.GuiCommands.PrintOutput(
+                        _guiCommands.PrintOutput(
                             $"The instance {newParent.Name} has a type restriction of {typeRestriction} so {instance.Name} cannot be added as a child.");
                     }
                 }

--- a/Gum/Plugins/InternalPlugins/ProjectPropertiesWindowPlugin/MainPropertiesWindowPlugin.cs
+++ b/Gum/Plugins/InternalPlugins/ProjectPropertiesWindowPlugin/MainPropertiesWindowPlugin.cs
@@ -1,4 +1,4 @@
-﻿using Gum.DataTypes;
+using Gum.DataTypes;
 using Gum.Gui.Controls;
 using Gum.Managers;
 using Gum.Plugins.BaseClasses;
@@ -82,19 +82,19 @@ class MainPropertiesWindowPlugin : InternalPlugin
 
             viewModel.SetFrom(ProjectManager.Self.GeneralSettingsFile, ProjectState.Self.GumProjectSave);
             var wasShown = 
-                GumCommands.Self.GuiCommands.ShowTabForControl(control);
+                _guiCommands.ShowTabForControl(control);
 
             if(!wasShown)
             {
-                var tab = GumCommands.Self.GuiCommands.AddControl(control, "Project Properties");
+                var tab = _guiCommands.AddControl(control, "Project Properties");
                 tab.CanClose = true;
                 control.ViewModel = viewModel;
-                GumCommands.Self.GuiCommands.ShowTabForControl(control);
+                _guiCommands.ShowTabForControl(control);
             }
         }
         catch (Exception ex)
         {
-            GumCommands.Self.GuiCommands.PrintOutput($"Error showing project properties:\n{ex.ToString()}");
+            _guiCommands.PrintOutput($"Error showing project properties:\n{ex.ToString()}");
         }
     }
 
@@ -222,6 +222,6 @@ class MainPropertiesWindowPlugin : InternalPlugin
 
     private void HandleCloseClicked(object sender, EventArgs e)
     {
-        GumCommands.Self.GuiCommands.RemoveControl(control);
+        _guiCommands.RemoveControl(control);
     }
 }

--- a/Gum/Plugins/InternalPlugins/StatePlugin/MainStatePlugin.cs
+++ b/Gum/Plugins/InternalPlugins/StatePlugin/MainStatePlugin.cs
@@ -1,4 +1,4 @@
-﻿using Gum.Controls;
+using Gum.Controls;
 using Gum.DataTypes;
 using Gum.DataTypes.Behaviors;
 using Gum.DataTypes.Variables;
@@ -45,11 +45,11 @@ public class MainStatePlugin : InternalPlugin
     public MainStatePlugin()
     {
         _selectedState = Locator.GetRequiredService<ISelectedState>();
-        _gumCommands = GumCommands.Self;
         var elementCommands = Locator.GetRequiredService<ElementCommands>();
         var editCommands = Locator.GetRequiredService<EditCommands>();
         var dialogService = Locator.GetRequiredService<IDialogService>();
-        _stateTreeViewRightClickService = new StateTreeViewRightClickService(_selectedState, _gumCommands, elementCommands, editCommands, dialogService);
+        var guiCommands = Locator.GetRequiredService<GuiCommands>();
+        _stateTreeViewRightClickService = new StateTreeViewRightClickService(_selectedState, _gumCommands, elementCommands, editCommands, dialogService, guiCommands);
         _hotkeyManager = HotkeyManager.Self;
         _objectFinder = ObjectFinder.Self;
     }
@@ -103,7 +103,7 @@ public class MainStatePlugin : InternalPlugin
         stateTreeView = new StateTreeView(stateTreeViewModel, _stateTreeViewRightClickService, _hotkeyManager, _selectedState);
         _stateTreeViewRightClickService.SetMenuStrip(stateTreeView.TreeViewContextMenu, stateTreeView);
         
-        newPluginTab = GumCommands.Self.GuiCommands.AddControl(stateTreeView, "States", TabLocation.CenterTop);
+        newPluginTab = _guiCommands.AddControl(stateTreeView, "States", TabLocation.CenterTop);
     }
 
     #endregion

--- a/Gum/Plugins/InternalPlugins/StatePlugin/StateTreeViewRightClickService.cs
+++ b/Gum/Plugins/InternalPlugins/StatePlugin/StateTreeViewRightClickService.cs
@@ -27,6 +27,7 @@ public class StateTreeViewRightClickService
     private readonly ElementCommands _elementCommands;
     private readonly EditCommands _editCommands;
     private readonly IDialogService _dialogService;
+    private readonly GuiCommands _guiCommands;
 
     System.Windows.Controls.ContextMenu _menuStrip;
     GumCommands _gumCommands;
@@ -35,13 +36,15 @@ public class StateTreeViewRightClickService
         GumCommands gumCommands, 
         ElementCommands elementCommands, 
         EditCommands editCommands,
-        IDialogService dialogService)
+        IDialogService dialogService,
+        GuiCommands guiCommands)
     {
         _selectedState = selectedState;
         _gumCommands = gumCommands;
         _elementCommands = elementCommands;
         _editCommands = editCommands;
         _dialogService = dialogService;
+        _guiCommands = guiCommands;
     }
 
     public void SetMenuStrip(System.Windows.Controls.ContextMenu menuStrip, FrameworkElement contextMenuOwner)
@@ -176,7 +179,7 @@ public class StateTreeViewRightClickService
 
             if (shouldSave)
             {
-                _gumCommands.GuiCommands.RefreshStateTreeView();
+                _guiCommands.RefreshStateTreeView();
 
                 _gumCommands.FileCommands.TryAutoSaveCurrentObject();
 
@@ -332,7 +335,7 @@ public class StateTreeViewRightClickService
 
         _elementCommands.AddState(_selectedState.SelectedStateContainer, _selectedState.SelectedStateCategorySave, newState, index + 1);
 
-        _gumCommands.GuiCommands.RefreshStateTreeView();
+        _guiCommands.RefreshStateTreeView();
 
         _selectedState.SelectedStateSave = newState;
 

--- a/Gum/Plugins/InternalPlugins/TreeView/ElementTreeViewManager.cs
+++ b/Gum/Plugins/InternalPlugins/TreeView/ElementTreeViewManager.cs
@@ -275,7 +275,7 @@ public partial class ElementTreeViewManager
     {
         _selectedState = Locator.GetRequiredService<ISelectedState>();
         _editCommands = Locator.GetRequiredService<EditCommands>();
-        _guiCommands = GumCommands.Self.GuiCommands;
+        _guiCommands = Locator.GetRequiredService<GuiCommands>();
 
         _dialogService = Locator.GetRequiredService<IDialogService>();
         
@@ -522,7 +522,7 @@ public partial class ElementTreeViewManager
             new System.Windows.Controls.RowDefinition() 
             { Height = new System.Windows.GridLength(1, System.Windows.GridUnitType.Star) });
 
-        GumCommands.Self.GuiCommands.AddControl(grid, "Project", TabLocation.Left);
+        _guiCommands.AddControl(grid, "Project", TabLocation.Left);
 
         ObjectTreeView.Dock = DockStyle.Fill;
         //panel.Controls.Add(ObjectTreeView);
@@ -547,7 +547,7 @@ public partial class ElementTreeViewManager
         Grid.SetRow(FlatList, 2);
         grid.Children.Add(FlatList);
 
-        //GumCommands.Self.GuiCommands.AddControl(panel, "Project", TabLocation.Left);
+        //_guiCommands.AddControl(panel, "Project", TabLocation.Left);
     }
 
 
@@ -627,7 +627,7 @@ public partial class ElementTreeViewManager
             if(InputLibrary.Cursor.Self.IsInWindow)
             {
                 e.UseDefaultCursors = false;
-                System.Windows.Forms.Cursor.Current = GumCommands.Self.GuiCommands.AddCursor;
+                System.Windows.Forms.Cursor.Current = _guiCommands.AddCursor;
             }
         };
     }

--- a/Gum/Plugins/InternalPlugins/Undos/MainPlugin.cs
+++ b/Gum/Plugins/InternalPlugins/Undos/MainPlugin.cs
@@ -15,7 +15,7 @@ namespace Gum.Plugins.Undos
 
             control.DataContext = new UndosViewModel();
 
-            GumCommands.Self.GuiCommands.AddControl(control, "History", TabLocation.RightBottom);
+            _guiCommands.AddControl(control, "History", TabLocation.RightBottom);
 
         }
     }

--- a/Gum/Plugins/InternalPlugins/VariableGrid/AddVariableWindow.xaml.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/AddVariableWindow.xaml.cs
@@ -1,4 +1,4 @@
-﻿using Gum.Plugins.InternalPlugins.VariableGrid.ViewModels;
+using Gum.Plugins.InternalPlugins.VariableGrid.ViewModels;
 using System.Linq;
 using System.Windows;
 using System.Windows.Controls;

--- a/Gum/Plugins/InternalPlugins/VariableGrid/DeleteVariableService.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/DeleteVariableService.cs
@@ -28,11 +28,11 @@ public class DeleteVariableService : IDeleteVariableService
     private readonly RenameLogic _renameLogic;
     private readonly IDialogService _dialogService;
 
-    public DeleteVariableService(FileCommands fileCommands, GuiCommands guiCommands)
+    public DeleteVariableService(FileCommands fileCommands)
     {
         _undoManager = Locator.GetRequiredService<UndoManager>();
         _fileCommands = fileCommands;
-        _guiCommands = guiCommands;
+        _guiCommands = Locator.GetRequiredService<GuiCommands>();
         _renameLogic = Locator.GetRequiredService<RenameLogic>();
         _dialogService = Locator.GetRequiredService<IDialogService>();
     }

--- a/Gum/Plugins/InternalPlugins/VariableGrid/ExclusionsPlugin.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/ExclusionsPlugin.cs
@@ -58,7 +58,7 @@ public class ExclusionsPlugin : InternalPlugin
         if(variableName == "ChildrenLayout")
         {
             // Changing children layout can result in different values being shown in the property grid
-            GumCommands.Self.GuiCommands.RefreshVariables(force:true);
+            _guiCommands.RefreshVariables(force:true);
         }
     }
 

--- a/Gum/Plugins/InternalPlugins/VariableGrid/PropertyGridManager.RightClick.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/PropertyGridManager.RightClick.cs
@@ -37,7 +37,7 @@ namespace Gum.Managers
             }
 
             Wireframe.WireframeObjectManager.Self.RefreshAll(true);
-            GumCommands.Self.GuiCommands.RefreshVariables();
+            _guiCommands.RefreshVariables();
 
             GumCommands.Self.FileCommands.TryAutoSaveProject();
         }

--- a/Gum/Plugins/InternalPlugins/VariableGrid/PropertyGridManager.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/PropertyGridManager.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Gum.ToolStates;
@@ -130,7 +130,7 @@ public partial class PropertyGridManager
         _localizationManager = localizationManager;
         mainControl = new Gum.MainPropertyGrid();
 
-        GumCommands.Self.GuiCommands.AddControl(mainControl, "Variables", TabLocation.CenterBottom);
+        _guiCommands.AddControl(mainControl, "Variables", TabLocation.CenterBottom);
 
         mVariablesDataGrid = mainControl.DataGrid;
 

--- a/Gum/Plugins/InternalPlugins/VariableGrid/SetVariableLogic.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/SetVariableLogic.cs
@@ -37,6 +37,7 @@ namespace Gum.PropertyGridHelpers
         private readonly ElementCommands _elementCommands;
         private readonly UndoManager _undoManager;
         private readonly WireframeCommands _wireframeCommands;
+        private readonly GuiCommands _guiCommands;
 
         public SetVariableLogic()
         {
@@ -47,15 +48,14 @@ namespace Gum.PropertyGridHelpers
             _undoManager = Locator.GetRequiredService<UndoManager>();
             _wireframeCommands = Locator.GetRequiredService<WireframeCommands>();
             _variableReferenceLogic = Locator.GetRequiredService<VariableReferenceLogic>();
+            _guiCommands = Locator.GetRequiredService<GuiCommands>();
+            _fontManager = Locator.GetRequiredService<FontManager>();
         }
 
         // this is needed as we unroll all the other singletons...
         public void Initialize(CircularReferenceManager circularReferenceManager, FileCommands fileCommands)
         {
-            
             _circularReferenceManager = circularReferenceManager;
-            
-            _fontManager = Locator.GetRequiredService<FontManager>();
             _fileCommands = fileCommands;
         }
 
@@ -192,8 +192,8 @@ namespace Gum.PropertyGridHelpers
 
             if (needsToRefreshEntireElement)
             {
-                GumCommands.Self.GuiCommands.RefreshElementTreeView(parentElement);
-                GumCommands.Self.GuiCommands.RefreshVariables(force: true);
+                _guiCommands.RefreshElementTreeView(parentElement);
+                _guiCommands.RefreshVariables(force: true);
             }
         }
 
@@ -255,8 +255,8 @@ namespace Gum.PropertyGridHelpers
                         MessageBox.Show("This assignment would create a circular reference, which is not allowed.");
                         //stateSave.SetValue("BaseType", oldValue, instance);
                         instance.BaseType = (string)oldValue;
-                        GumCommands.Self.GuiCommands.PrintOutput($"BaseType assignment on {instance.Name} is not allowed - reverting to previous value");
-                        GumCommands.Self.GuiCommands.RefreshVariables(force: true);
+                        _guiCommands.PrintOutput($"BaseType assignment on {instance.Name} is not allowed - reverting to previous value");
+                        _guiCommands.RefreshVariables(force: true);
                     }
 
                     if(instanceContainer != null)
@@ -489,7 +489,7 @@ namespace Gum.PropertyGridHelpers
                 {
                     gue.SetProperty(unqualifiedVariableToSet, valueToSet);
                 }
-                GumCommands.Self.GuiCommands.RefreshVariables(force: true);
+                _guiCommands.RefreshVariables(force: true);
 
 
             }
@@ -565,13 +565,13 @@ namespace Gum.PropertyGridHelpers
                     if (cancel)
                     {
                         variable.Value = oldValue;
-                        GumCommands.Self.GuiCommands.RefreshVariableValues();
+                        _guiCommands.RefreshVariableValues();
                     }
 
                     if (!cancel && filePath.Extension == "achx")
                     {
                         stateSave.SetValue($"{instancePrefix}TextureAddress", Gum.Managers.TextureAddress.Custom);
-                        GumCommands.Self.GuiCommands.RefreshVariables(force: true);
+                        _guiCommands.RefreshVariables(force: true);
                     }
                 }
 
@@ -753,11 +753,11 @@ namespace Gum.PropertyGridHelpers
 
                 if (isValidAssignment)
                 {
-                    GumCommands.Self.GuiCommands.RefreshElementTreeView(parentElement);
+                    _guiCommands.RefreshElementTreeView(parentElement);
                 }
                 else
                 {
-                    GumCommands.Self.GuiCommands.RefreshVariables(force: true);
+                    _guiCommands.RefreshVariables(force: true);
                 }
             }
         }

--- a/Gum/Plugins/InternalPlugins/VariableGrid/StateReferencingInstanceMember.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/StateReferencingInstanceMember.cs
@@ -21,6 +21,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using System.Windows.Forms;
+using Gum.Commands;
 using ToolsUtilities;
 using WpfDataUi.Controls;
 using WpfDataUi.DataTypes;
@@ -36,6 +37,7 @@ namespace Gum.PropertyGridHelpers
         private readonly HotkeyManager _hotkeyManager;
         private readonly UndoManager _undoManager;
         private readonly IDeleteVariableService _deleteVariableLogic;
+        private readonly GuiCommands _guiCommands;
         StateSave mStateSave;
         string mVariableName;
         public InstanceSave InstanceSave { get; private set; }
@@ -252,6 +254,7 @@ namespace Gum.PropertyGridHelpers
             _deleteVariableLogic = Locator.GetRequiredService<IDeleteVariableService>();
             _undoManager = undoManager;
             _selectedState = Locator.GetRequiredService<ISelectedState>();
+            _guiCommands = Locator.GetRequiredService<GuiCommands>();
 
             StateSaveCategory = stateSaveCategory;
             InstanceSave = instanceSave;
@@ -336,7 +339,7 @@ namespace Gum.PropertyGridHelpers
                     catch(Exception e)
                     {
                         // this could be a missing standard element save, print output but tolerate it:
-                        GumCommands.Self.GuiCommands.PrintOutput("Error getting standard element variable:\n" + e);
+                        _guiCommands.PrintOutput("Error getting standard element variable:\n" + e);
                     }
                 }
             }
@@ -806,7 +809,7 @@ namespace Gum.PropertyGridHelpers
                         var variableInDefault = _selectedState.SelectedElement.DefaultState.GetVariableSave(variable.Name);
                         if (variableInDefault != null)
                         {
-                            GumCommands.Self.GuiCommands.PrintOutput(
+                            _guiCommands.PrintOutput(
                                 $"The variable {variable.Name} is part of the category {StateSaveCategory.Name} so it cannot be removed. Instead, the value has been set to the value in the default state");
 
                             variable.Value = variableInDefault.Value;
@@ -821,7 +824,7 @@ namespace Gum.PropertyGridHelpers
                             }
                             else
                             {
-                                GumCommands.Self.GuiCommands.PrintOutput("Could not set value to default because the default state doesn't set this value");
+                                _guiCommands.PrintOutput("Could not set value to default because the default state doesn't set this value");
 
                             }
 
@@ -861,14 +864,14 @@ namespace Gum.PropertyGridHelpers
                 if (wasChangeMade)
                 {
                     _undoManager.RecordUndo();
-                    GumCommands.Self.GuiCommands.RefreshVariables(force: true);
+                    _guiCommands.RefreshVariables(force: true);
                     WireframeObjectManager.Self.RefreshAll(true);
 
                     PluginManager.Self.VariableSet(selectedElement, selectedInstance, variableName, oldValue);
 
                     if (affectsTreeView)
                     {
-                        GumCommands.Self.GuiCommands.RefreshElementTreeView(_selectedState.SelectedElement);
+                        _guiCommands.RefreshElementTreeView(_selectedState.SelectedElement);
                     }
 
                     GumCommands.Self.FileCommands.TryAutoSaveElement(_selectedState.SelectedElement);

--- a/Gum/Plugins/InternalPlugins/VariableGrid/VariableReferenceLogic.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/VariableReferenceLogic.cs
@@ -1,4 +1,4 @@
-﻿using Gum.Commands;
+using Gum.Commands;
 using Gum.DataTypes;
 using Gum.DataTypes.Behaviors;
 using Gum.DataTypes.Variables;
@@ -33,9 +33,9 @@ public class VariableReferenceLogic
 
     #endregion
 
-    public VariableReferenceLogic(GuiCommands guiCommands)
+    public VariableReferenceLogic()
     {
-        _guiCommands = guiCommands;
+        _guiCommands = Locator.GetRequiredService<GuiCommands>();
         _wireframeCommands = Locator.GetRequiredService<WireframeCommands>();
         _dialogService =  Locator.GetRequiredService<IDialogService>();
     }
@@ -502,7 +502,7 @@ public class VariableReferenceLogic
 
         if (didChange)
         {
-            GumCommands.Self.GuiCommands.RefreshVariables(force: true);
+            _guiCommands.RefreshVariables(force: true);
         }
     }
 

--- a/Gum/Plugins/InternalPlugins/VariableGrid/ViewModels/AddVariableViewModel.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/ViewModels/AddVariableViewModel.cs
@@ -101,13 +101,14 @@ public class AddVariableViewModel : DialogViewModel
 
     #endregion
 
-    public AddVariableViewModel(UndoManager undoManager, 
+    public AddVariableViewModel(GuiCommands guiCommands,
+        UndoManager undoManager, 
         ElementCommands elementCommands, 
         NameVerifier nameVerifier, 
         ISelectedState selectedState, 
         IDialogService dialogService)
     {
-        _guiCommands = Locator.GetRequiredService<GuiCommands>();
+        _guiCommands = guiCommands;
         _undoManager = undoManager;
         _elementCommands = elementCommands;
         _fileCommands = Locator.GetRequiredService<FileCommands>();

--- a/Gum/Plugins/PluginManager.cs
+++ b/Gum/Plugins/PluginManager.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.ComponentModel.Composition;
@@ -22,6 +22,7 @@ using Gum.Managers;
 using Gum.Services;
 using RenderingLibrary;
 using System.Numerics;
+using Gum.Commands;
 
 namespace Gum.Plugins
 {
@@ -56,6 +57,8 @@ namespace Gum.Plugins
         static PluginManager mProjectInstance;
         static List<PluginManager> mInstances = new List<PluginManager>();
         private bool mGlobal;
+
+        private readonly GuiCommands _guiCommands;
 
         public static string PluginFolder
         {
@@ -647,6 +650,11 @@ namespace Gum.Plugins
 
         #region Additional Methods
 
+        public PluginManager()
+        {
+            _guiCommands = Locator.GetRequiredService<GuiCommands>();
+        }
+
 
         public void Initialize(MainWindow mainWindow)
         {
@@ -827,7 +835,7 @@ namespace Gum.Plugins
             //MessageBox.Show("Couldn't find assembly: " + args.Name + " for " + args.RequestingAssembly);
             if(args.RequestingAssembly != null)
             {
-                GumCommands.Self.GuiCommands.PrintOutput("Couldn't find assembly: " + args.Name + " for " + args.RequestingAssembly);
+                _guiCommands.PrintOutput("Couldn't find assembly: " + args.Name + " for " + args.RequestingAssembly);
             }
 
             return null;

--- a/Gum/Plugins/PluginTab.cs
+++ b/Gum/Plugins/PluginTab.cs
@@ -1,9 +1,13 @@
 ﻿using System;
+using Gum.Commands;
+using Gum.Services;
 
 namespace Gum.Plugins
 {
     public class PluginTab
     {
+        private readonly GuiCommands _guiCommands;
+        
         public string Title
         {
             get => (string)TabItem.Header;
@@ -35,6 +39,11 @@ namespace Gum.Plugins
         }
         public event Action GotFocus;
 
+        public PluginTab()
+        {
+            _guiCommands = Locator.GetRequiredService<GuiCommands>();
+        }
+
         private void HandleMiddleMouseClicked()
         {
             if(CanClose)
@@ -43,8 +52,8 @@ namespace Gum.Plugins
             }
         }
 
-        public void Show(bool focus = true) => GumCommands.Self.GuiCommands.ShowTab(this, focus);
-        public void Hide() => GumCommands.Self.GuiCommands.HideTab(this);
+        public void Show(bool focus = true) => _guiCommands.ShowTab(this, focus);
+        public void Hide() => _guiCommands.HideTab(this);
 
         public void RaiseTabShown() => TabShown?.Invoke();
         public event Action TabShown;
@@ -56,7 +65,7 @@ namespace Gum.Plugins
         public void Focus() => TabItem.Focus();
 
         public bool IsFocused =>
-            GumCommands.Self.GuiCommands.IsTabFocused(this);
+            _guiCommands.IsTabFocused(this);
 
         public bool CanClose { get; set; }
     }

--- a/Gum/PropertyGridHelpers/VariableInCategoryPropagationLogic.cs
+++ b/Gum/PropertyGridHelpers/VariableInCategoryPropagationLogic.cs
@@ -7,15 +7,19 @@ using Gum.ToolStates;
 using Gum.Undo;
 using System.Linq;
 using System.Windows.Forms;
+using Gum.Commands;
 
 namespace Gum.PropertyGridHelpers
 {
     public class VariableInCategoryPropagationLogic : Singleton<VariableInCategoryPropagationLogic>
     {
         private readonly UndoManager _undoManager;
+        private readonly GuiCommands _guiCommands;
+        
         public VariableInCategoryPropagationLogic()
         {
             _undoManager = Locator.GetRequiredService<UndoManager>();
+            _guiCommands = Locator.GetRequiredService<GuiCommands>();
         }
         public void PropagateVariablesInCategory(string memberName, ElementSave element, StateSaveCategory categoryToPropagate)
         {
@@ -103,7 +107,7 @@ namespace Gum.PropertyGridHelpers
 
                             state.Variables.Add(newVariable);
 
-                            GumCommands.Self.GuiCommands.PrintOutput(
+                            _guiCommands.PrintOutput(
                                 $"Adding {memberName} to {categoryToPropagate.Name}/{state.Name}");
                         }
                     }
@@ -124,7 +128,7 @@ namespace Gum.PropertyGridHelpers
                             //newVariableList.ValueAsIList = defaultVariableList.ValueAsIList;
                             newVariableList.Name = memberName;
                             state.VariableLists.Add(newVariableList);
-                            GumCommands.Self.GuiCommands.PrintOutput(
+                            _guiCommands.PrintOutput(
                                 $"Adding {memberName} to {categoryToPropagate.Name}/{state.Name}");
                         }
                     }
@@ -170,10 +174,10 @@ namespace Gum.PropertyGridHelpers
 
                     // save everything
                     GumCommands.Self.FileCommands.TryAutoSaveCurrentElement();
-                    GumCommands.Self.GuiCommands.RefreshStateTreeView();
+                    _guiCommands.RefreshStateTreeView();
                     // no selection has changed, but we want to force refresh here because we know
                     // we really need a refresh - something was removed.
-                    GumCommands.Self.GuiCommands.RefreshVariables(force:true);
+                    _guiCommands.RefreshVariables(force:true);
 
                     PluginManager.Self.VariableRemovedFromCategory(variableName, stateCategory);
                 }

--- a/Gum/Services/Builder.cs
+++ b/Gum/Services/Builder.cs
@@ -55,6 +55,8 @@ file static class ServiceCollectionExtensions
         services.AddSingleton<LocalizationManager>();
         services.AddSingleton<NameVerifier>();
         services.AddSingleton<UndoManager>();
+        services.AddSingleton<FontManager>();
+        services.AddSingleton<IEditVariableService, EditVariableService>();
         
         //logic
         services.AddSingleton<VariableReferenceLogic>();
@@ -65,8 +67,11 @@ file static class ServiceCollectionExtensions
         services.AddSingleton<GuiCommands>();
         services.AddSingleton<EditCommands>();
         services.AddSingleton<ElementCommands>();
+        services.AddSingleton<GuiCommands>();
 
         services.AddDialogs();
+        
+        services.AddTransient(typeof(Lazy<>), typeof(Lazier<>));
     }
     
     // Register legacy services that may use Locator or have unresolved dependencies.
@@ -75,16 +80,13 @@ file static class ServiceCollectionExtensions
     // they can be moved to AddCleanServices.
     public static void AddLegacyServices(this IServiceCollection services)
     {
-        services.AddSingleton(GumCommands.Self.GuiCommands);
         services.AddSingleton(GumCommands.Self.FileCommands);
         services.AddSingleton(SetVariableLogic.Self);
         services.AddSingleton(HotkeyManager.Self);
         services.AddSingleton<IObjectFinder>(ObjectFinder.Self);
         
         services.AddSingleton<CircularReferenceManager>();
-        services.AddSingleton<FontManager>();
         services.AddSingleton<DragDropManager>();
-        services.AddSingleton<IEditVariableService, EditVariableService>();
         services.AddSingleton<IExposeVariableService, ExposeVariableService>();
         services.AddSingleton<IDeleteVariableService, DeleteVariableService>();
     }
@@ -101,6 +103,11 @@ file static class ServiceCollectionExtensions
         );
 
         return services;
+    }
+    
+    private class Lazier<T> : Lazy<T> where T : notnull
+    {
+        public Lazier(IServiceProvider serviceProvider) : base(serviceProvider.GetRequiredService<T>){}
     }
 }
 

--- a/Gum/Services/EditVariableService.cs
+++ b/Gum/Services/EditVariableService.cs
@@ -1,4 +1,4 @@
-﻿using CommonFormsAndControls;
+using CommonFormsAndControls;
 using ExCSS;
 using Gum.Controls;
 using Gum.DataTypes;
@@ -16,6 +16,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Gum.Commands;
 using Gum.Services.Dialogs;
 using WpfDataUi.DataTypes;
 
@@ -48,11 +49,13 @@ public class EditVariableService : IEditVariableService
 {
     private readonly RenameLogic _renameLogic;
     private readonly IDialogService _dialogService;
+    private readonly GuiCommands _guiCommands;
 
-    public EditVariableService()
+    public EditVariableService(RenameLogic renameLogic, IDialogService dialogService, GuiCommands guiCommands)
     {
-        _renameLogic = Locator.GetRequiredService<RenameLogic>();
-        _dialogService = Locator.GetRequiredService<IDialogService>();
+        _renameLogic = renameLogic;
+        _dialogService = dialogService;
+        _guiCommands = guiCommands;
     }
 
     public void TryAddEditVariableOptions(InstanceMember instanceMember, VariableSave variableSave, IStateContainer stateListCategoryContainer)
@@ -234,7 +237,7 @@ public class EditVariableService : IEditVariableService
         vm.RenameType = RenameType.ExposedName;
         vm.ApplyVariableReferenceChanges(changeResponse, newName, oldName, changedElements);
 
-        GumCommands.Self.GuiCommands.RefreshVariables(force:true);
+        _guiCommands.RefreshVariables(force:true);
         foreach(var element in changedElements)
         {
             GumCommands.Self.FileCommands.TryAutoSaveElement(element);

--- a/Gum/Services/ExposeVariableService.cs
+++ b/Gum/Services/ExposeVariableService.cs
@@ -1,4 +1,4 @@
-﻿using CommonFormsAndControls;
+using CommonFormsAndControls;
 using Gum.DataTypes.Variables;
 using Gum.DataTypes;
 using Gum.Logic;
@@ -39,10 +39,10 @@ internal class ExposeVariableService : IExposeVariableService
     private readonly NameVerifier _nameVerifier;
     private readonly IDialogService _dialogService;
 
-    public ExposeVariableService(GuiCommands guiCommands, FileCommands fileCommands)
+    public ExposeVariableService(FileCommands fileCommands)
     {
         _undoManager = Locator.GetRequiredService<UndoManager>();
-        _guiCommands = guiCommands;
+        _guiCommands = Locator.GetRequiredService<GuiCommands>();
         _fileCommands = fileCommands;
         _renameLogic = Locator.GetRequiredService<RenameLogic>();
         _selectedState = Locator.GetRequiredService<ISelectedState>();
@@ -143,7 +143,7 @@ internal class ExposeVariableService : IExposeVariableService
                 PluginManager.Self.VariableAdd(elementSave, tiw.Result);
 
                 GumCommands.Self.FileCommands.TryAutoSaveCurrentElement();
-                GumCommands.Self.GuiCommands.RefreshVariables(force: true);
+                _guiCommands.RefreshVariables(force: true);
                 toReturn.Data = variableSave;
                 toReturn.Succeeded = true;
             }

--- a/Gum/ToolCommands/ElementCommands.cs
+++ b/Gum/ToolCommands/ElementCommands.cs
@@ -9,6 +9,7 @@ using Gum.ToolStates;
 using Gum.PropertyGridHelpers;
 using Gum.DataTypes.Behaviors;
 using System.ComponentModel;
+using Gum.Commands;
 using Gum.Wireframe;
 using GumRuntime;
 using Gum.Converters;
@@ -23,12 +24,14 @@ namespace Gum.ToolCommands
         #region Fields
 
         private readonly ISelectedState _selectedState;
+        private readonly GuiCommands _guiCommands;
 
         #endregion
 
         public ElementCommands()
         {
             _selectedState = Locator.GetRequiredService<ISelectedState>();
+            _guiCommands = Locator.GetRequiredService<GuiCommands>();
         }
 
         #region Instance
@@ -52,7 +55,7 @@ namespace Gum.ToolCommands
 
             elementToAddTo.Instances.Add(instanceSave);
 
-            GumCommands.Self.GuiCommands.RefreshElementTreeView(elementToAddTo);
+            _guiCommands.RefreshElementTreeView(elementToAddTo);
 
             Wireframe.WireframeObjectManager.Self.RefreshAll(true);
             //_selectedState.SelectedInstance = instanceSave;
@@ -69,7 +72,7 @@ namespace Gum.ToolCommands
             // a plugin may have removed this instance. If so, we need to refresh the tree node again:
             if (elementToAddTo.Instances.Contains(instanceSave) == false)
             {
-                GumCommands.Self.GuiCommands.RefreshElementTreeView(elementToAddTo);
+                _guiCommands.RefreshElementTreeView(elementToAddTo);
                 Wireframe.WireframeObjectManager.Self.RefreshAll(true);
 
                 // August 2, 2022 - this is currently returned even if a plugin
@@ -170,7 +173,7 @@ namespace Gum.ToolCommands
 
             PluginManager.Self.StateAdd(stateSave);
 
-            GumCommands.Self.GuiCommands.RefreshStateTreeView();
+            _guiCommands.RefreshStateTreeView();
 
             if(stateContainer is BehaviorSave behavior)
             {
@@ -313,7 +316,7 @@ namespace Gum.ToolCommands
 
                 if (hasChangeOccurred)
                 {
-                    GumCommands.Self.GuiCommands.RefreshVariableValues();
+                    _guiCommands.RefreshVariableValues();
                 }
             }
 
@@ -642,7 +645,7 @@ namespace Gum.ToolCommands
                 }
             }
 
-            GumCommands.Self.GuiCommands.RefreshStateTreeView();
+            _guiCommands.RefreshStateTreeView();
 
             PluginManager.Self.CategoryAdd(category);
 
@@ -669,7 +672,7 @@ namespace Gum.ToolCommands
             instanceSave.BaseType = type ?? StandardElementsManager.Self.DefaultType;
             behaviorToAddTo.RequiredInstances.Add(instanceSave);
 
-            GumCommands.Self.GuiCommands.RefreshElementTreeView(behaviorToAddTo);
+            _guiCommands.RefreshElementTreeView(behaviorToAddTo);
 
             Wireframe.WireframeObjectManager.Self.RefreshAll(true);
             //_selectedState.SelectedInstance = instanceSave;
@@ -686,7 +689,7 @@ namespace Gum.ToolCommands
             // a plugin may have removed this instance. If so, we need to refresh the tree node again:
             //if (elementToAddTo.Instances.Contains(instanceSave) == false)
             //{
-            //    GumCommands.Self.GuiCommands.RefreshElementTreeView(elementToAddTo);
+            //    _guiCommands.RefreshElementTreeView(elementToAddTo);
             //    Wireframe.WireframeObjectManager.Self.RefreshAll(true);
 
             //    // August 2, 2022 - this is currently returned even if a plugin
@@ -725,7 +728,7 @@ namespace Gum.ToolCommands
 
                 PluginManager.Self.BehaviorReferencesChanged(componentSave);
 
-                GumCommands.Self.GuiCommands.PrintOutput($"Added behavior {behaviorName} to {componentSave}");
+                _guiCommands.PrintOutput($"Added behavior {behaviorName} to {componentSave}");
 
                 if (performSave)
                 {

--- a/Gum/ToolCommands/ProjectCommands.cs
+++ b/Gum/ToolCommands/ProjectCommands.cs
@@ -10,6 +10,7 @@ using System.Windows.Controls;
 using Gum.DataTypes.Variables;
 using Gum.Plugins;
 using System.Linq;
+using Gum.Commands;
 using Gum.Services;
 
 namespace Gum.ToolCommands;
@@ -21,6 +22,7 @@ public class ProjectCommands
     static ProjectCommands mSelf;
     private readonly ISelectedState _selectedState;
     private readonly NameVerifier _nameVerifier;
+    private readonly GuiCommands _guiCommands;
 
     #endregion
 
@@ -44,6 +46,7 @@ public class ProjectCommands
     {
         _selectedState = Locator.GetRequiredService<ISelectedState>();
         _nameVerifier = Locator.GetRequiredService<NameVerifier>();
+        _guiCommands = Locator.GetRequiredService<GuiCommands>();
     }
     
     #region Screens
@@ -155,8 +158,8 @@ public class ProjectCommands
 
         PluginManager.Self.BehaviorDeleted(behavior);
 
-        GumCommands.Self.GuiCommands.RefreshStateTreeView();
-        GumCommands.Self.GuiCommands.RefreshVariables();
+        _guiCommands.RefreshStateTreeView();
+        _guiCommands.RefreshVariables();
         // I don't think we have to refresh the wireframe since nothing is being shown
         //Wireframe.WireframeObjectManager.Self.RefreshAll(true);
 

--- a/Gum/ToolStates/SelectedState.cs
+++ b/Gum/ToolStates/SelectedState.cs
@@ -5,6 +5,7 @@ using Gum.DataTypes;
 using Gum.Managers;
 using Gum.DataTypes.Variables;
 using System.Windows.Forms;
+using Gum.Commands;
 using Gum.Wireframe;
 using Gum.Plugins;
 using Gum.Debug;
@@ -13,12 +14,15 @@ using Gum.DataTypes.Behaviors;
 using Gum.Controls;
 using Newtonsoft.Json.Linq;
 using Gum.Events;
+using Gum.Services;
 
 namespace Gum.ToolStates;
 
 public class SelectedState : ISelectedState
 {
     #region Fields
+    
+    private readonly GuiCommands _guiCommands;
 
     SelectedStateSnapshot snapshot = new SelectedStateSnapshot();
 
@@ -166,7 +170,7 @@ public class SelectedState : ISelectedState
         if (stateBefore == SelectedStateSave)
         {
             // If the state changed (element changed) then no need to force the UI again
-            GumCommands.Self.GuiCommands.RefreshVariables();
+            _guiCommands.RefreshVariables();
         }
     }
 
@@ -223,7 +227,7 @@ public class SelectedState : ISelectedState
         if (behavior != snapshot.SelectedBehavior)
         {
             snapshot.SelectedBehavior = behavior;
-            GumCommands.Self.GuiCommands.RefreshStateTreeView();
+            _guiCommands.RefreshStateTreeView();
 
             WireframeObjectManager.Self.RefreshAll(false);
 
@@ -293,6 +297,11 @@ public class SelectedState : ISelectedState
     }
 
     #endregion
+
+    public SelectedState()
+    {
+        _guiCommands = Locator.GetRequiredService<GuiCommands>();
+    }
 
     #region Instance
 
@@ -436,7 +445,7 @@ public class SelectedState : ISelectedState
             {
                 if (stateContainerBefore != elementAfter && stateContainerBefore != behaviorAfter)
                 {
-                    GumCommands.Self.GuiCommands.RefreshStateTreeView();
+                    _guiCommands.RefreshStateTreeView();
                 }
             }
         }

--- a/Gum/Undo/UndoManager.cs
+++ b/Gum/Undo/UndoManager.cs
@@ -10,6 +10,7 @@ using Gum.Logic;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.Windows.Controls;
+using Gum.Commands;
 using Gum.DataTypes.Behaviors;
 using Gum.Managers;
 
@@ -87,6 +88,7 @@ public class UndoManager
 
     private readonly ISelectedState _selectedState;
     private readonly RenameLogic _renameLogic;
+    private readonly GuiCommands _guiCommands;
     
     internal ObservableCollection<UndoLock> UndoLocks { get; private set; }
 
@@ -130,10 +132,11 @@ public class UndoManager
 
     #endregion
 
-    public UndoManager(ISelectedState selectedState, RenameLogic renameLogic)
+    public UndoManager(ISelectedState selectedState, RenameLogic renameLogic, GuiCommands guiCommands)
     {
         _selectedState = selectedState;
         _renameLogic = renameLogic;
+        _guiCommands = guiCommands;
         UndoLocks = new ObservableCollection<UndoLock>();
         UndoLocks.CollectionChanged += HandleUndoLockChanged;
     }
@@ -467,19 +470,19 @@ public class UndoManager
 
         Plugins.PluginManager.Self.AfterUndo();
 
-        GumCommands.Self.GuiCommands.RefreshElementTreeView(toApplyTo);
+        _guiCommands.RefreshElementTreeView(toApplyTo);
 
         // reset everything. This is slow, but is easy
         WireframeObjectManager.Self.RefreshAll(true);
 
         if (shouldRefreshStateTreeView)
         {
-            GumCommands.Self.GuiCommands.RefreshStateTreeView();
+            _guiCommands.RefreshStateTreeView();
         }
 
         if(shouldRefreshBehaviorView)
         {
-            GumCommands.Self.GuiCommands.BroadcastRefreshBehaviorView();
+            _guiCommands.BroadcastRefreshBehaviorView();
         }
 
         //PrintStatus("PerformUndo");

--- a/Gum/Wireframe/WireframeObjectManager.RepresentationCreation.cs
+++ b/Gum/Wireframe/WireframeObjectManager.RepresentationCreation.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Gum.Commands;
 using RenderingLibrary;
 using Gum.DataTypes;
 using Gum.Managers;
@@ -54,12 +55,14 @@ public partial class WireframeObjectManager
     FontManager _fontManager;
     private readonly ISelectedState _selectedState;
     private readonly IDialogService _dialogService;
+    private readonly GuiCommands _guiCommands;
 
     public WireframeObjectManager()
     {
         _fontManager = Locator.GetRequiredService<FontManager>();
         _selectedState = Locator.GetRequiredService<ISelectedState>();
         _dialogService = Locator.GetRequiredService<IDialogService>();
+        _guiCommands = Locator.GetRequiredService<GuiCommands>();
     }
 
     private bool GetIfSelectedStateIsSetRecursively()

--- a/Gum/Wireframe/WireframeObjectManager.cs
+++ b/Gum/Wireframe/WireframeObjectManager.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Gum.Commands;
 using Gum.DataTypes;
 using Gum.ToolStates;
 using Gum.Managers;
@@ -79,7 +80,6 @@ public partial class WireframeObjectManager
         )
     {
         _localizationManager = localizationManager;
-
         gueManager = new GraphicalUiElementManager();
         GraphicalUiElement.AreUpdatesAppliedWhenInvisible= true;
         GraphicalUiElement.MissingFileBehavior = MissingFileBehavior.ConsumeSilently;
@@ -159,7 +159,7 @@ public partial class WireframeObjectManager
         {
             ClearAll();
             RootGue = null;
-            GumCommands.Self.GuiCommands.PrintOutput($"Error - cannot create representation for Component {elementSave.Name} because its BaseType is not set.");
+            _guiCommands.PrintOutput($"Error - cannot create representation for Component {elementSave.Name} because its BaseType is not set.");
         }
         else if (forceLayout || forceReloadTextures)
         {
@@ -196,7 +196,7 @@ public partial class WireframeObjectManager
                 catch(Exception e)
                 {
                     RootGue = null;
-                    GumCommands.Self.GuiCommands.PrintOutput(e.ToString());
+                    _guiCommands.PrintOutput(e.ToString());
                     _dialogService.ShowMessage($"Error loading {elementSave}. See output window for more details");
                 }
                 GraphicalUiElement.IsAllLayoutSuspended = false;

--- a/PerformanceMeasurementPlugin/MainPlugin.cs
+++ b/PerformanceMeasurementPlugin/MainPlugin.cs
@@ -8,6 +8,8 @@ using System.ComponentModel.Composition;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Gum.Commands;
+using Gum.Services;
 
 namespace PerformanceMeasurementPlugin
 {
@@ -15,6 +17,7 @@ namespace PerformanceMeasurementPlugin
     public class MainPlugin : PluginBase
     {
         PerformanceView view;
+        private readonly GuiCommands _guiCommands;
 
         public override string FriendlyName
         {
@@ -26,19 +29,24 @@ namespace PerformanceMeasurementPlugin
             get { return new Version(1, 1); }
         }
 
+        public MainPlugin()
+        {
+            _guiCommands = Locator.GetRequiredService<GuiCommands>();
+        }
+
         public override void StartUp()
         {
             view = new PerformanceView();
             view.DataContext = new PerformanceViewModel();
 
             // This doesn't work currently so we're not going to show it, it just gets in the way.
-            //GumCommands.Self.GuiCommands.AddControl(view, "Performance");
+            //_guiCommands.AddControl(view, "Performance");
 
         }
 
         public override bool ShutDown(Gum.Plugins.PluginShutDownReason shutDownReason)
         {
-            GumCommands.Self.GuiCommands.RemoveControl(view);
+            _guiCommands.RemoveControl(view);
             return true;
         }
     }

--- a/StateAnimationPlugin/MainStateAnimationPlugin.cs
+++ b/StateAnimationPlugin/MainStateAnimationPlugin.cs
@@ -38,7 +38,6 @@ public class MainStateAnimationPlugin : PluginBase
     private readonly DuplicateService _duplicateService;
     private readonly AnimationFilePathService _animationFilePathService;
     private readonly ElementDeleteService _elementDeleteService;
-    private readonly GuiCommands _gumCommands;
     private readonly RenameManager _renameManager;
     private readonly SettingsManager _settingsManager;
     private readonly ProjectState _projectState;
@@ -76,7 +75,6 @@ public class MainStateAnimationPlugin : PluginBase
         _duplicateService = new DuplicateService();
         _animationFilePathService = new AnimationFilePathService();
         _elementDeleteService = new ElementDeleteService(_animationFilePathService);
-        _gumCommands = GumCommands.Self.GuiCommands;
         _renameManager = RenameManager.Self;
         _settingsManager = SettingsManager.Self;
         _projectState = GumState.Self.ProjectState;
@@ -128,7 +126,7 @@ public class MainStateAnimationPlugin : PluginBase
     {
         RefreshViewModel();
 
-        if (element != null && !_gumCommands.IsTabVisible(pluginTab))
+        if (element != null && !_guiCommands.IsTabVisible(pluginTab))
         {
             var fileName = _animationFilePathService.GetAbsoluteAnimationFileNameFor(element);
 
@@ -251,7 +249,7 @@ public class MainStateAnimationPlugin : PluginBase
 
     private void HandleToggleTabVisibility(object sender, EventArgs e)
     {
-        if (!_gumCommands.IsTabVisible(pluginTab))
+        if (!_guiCommands.IsTabVisible(pluginTab))
         {
             pluginTab.Show();
         }
@@ -279,11 +277,11 @@ public class MainStateAnimationPlugin : PluginBase
             mMainWindow.AnimationColumnsResized += HandleAnimationColumnsResized;
         }
 
-        var wasShown = _gumCommands.ShowTabForControl(mMainWindow);
+        var wasShown = _guiCommands.ShowTabForControl(mMainWindow);
 
         if (!wasShown)
         {
-            pluginTab = _gumCommands.AddControl(mMainWindow, "Animations",
+            pluginTab = _guiCommands.AddControl(mMainWindow, "Animations",
                 TabLocation.RightBottom);
 
             pluginTab.TabShown += HandleTabShown;
@@ -584,7 +582,7 @@ public class MainStateAnimationPlugin : PluginBase
             }
             catch (Exception exc)
             {
-                _gumCommands.PrintOutput($"Could not save animations for {_viewModel?.Element}:\n{exc}");
+                _guiCommands.PrintOutput($"Could not save animations for {_viewModel?.Element}:\n{exc}");
             }
         }
     }

--- a/SvgPlugin/MainSvgPlugin.cs
+++ b/SvgPlugin/MainSvgPlugin.cs
@@ -1,4 +1,4 @@
-﻿using Gum;
+using Gum;
 using Gum.DataTypes;
 using Gum.DataTypes.Variables;
 using Gum.Managers;
@@ -75,7 +75,7 @@ namespace SkiaPlugin
                 else
                 {
                     StandardAdder.AddAllStandards();
-                    GumCommands.Self.GuiCommands.RefreshElementTreeView();
+                    _guiCommands.RefreshElementTreeView();
                 }
             };
         }

--- a/SvgPlugin/Managers/DefaultStateManager.cs
+++ b/SvgPlugin/Managers/DefaultStateManager.cs
@@ -10,6 +10,8 @@ using System.ComponentModel;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Gum.Commands;
+using Gum.Services;
 #if GUM
 using WpfDataUi.Controls;
 #endif
@@ -362,7 +364,7 @@ namespace SkiaPlugin.Managers
             {
 #if GUM
 // This should probably be handled in a plugin somewhere:
-                GumCommands.Self.GuiCommands.RefreshVariables(force: true);
+                Locator.GetRequiredService<GuiCommands>().RefreshVariables(force: true);
 #endif
             }
         }

--- a/TextureCoordinateSelectionPlugin/Logic/ControlLogic.cs
+++ b/TextureCoordinateSelectionPlugin/Logic/ControlLogic.cs
@@ -14,6 +14,7 @@ using RenderingLibrary.Math;
 using RenderingLibrary.Math.Geometry;
 using System;
 using System.ComponentModel;
+using Gum.Commands;
 using TextureCoordinateSelectionPlugin.ViewModels;
 using TextureCoordinateSelectionPlugin.Views;
 using Color = System.Drawing.Color;
@@ -34,6 +35,7 @@ public class ControlLogic : Singleton<ControlLogic>
 {
     private readonly ISelectedState _selectedState;
     private readonly UndoManager _undoManager;
+    private readonly GuiCommands _guiCommands;
     
     LineRectangle textureOutlineRectangle = null;
 
@@ -70,6 +72,7 @@ public class ControlLogic : Singleton<ControlLogic>
     {
         _selectedState = Locator.GetRequiredService<ISelectedState>();
         _undoManager = Locator.GetRequiredService<UndoManager>();
+        _guiCommands = Locator.GetRequiredService<GuiCommands>();
     }
 
     public PluginTab CreateControl()
@@ -99,9 +102,9 @@ public class ControlLogic : Singleton<ControlLogic>
         innerControl.RegionChanged += HandleRegionChanged;
         innerControl.EndRegionChanged += HandleEndRegionChanged;
 
-        //GumCommands.Self.GuiCommands.AddWinformsControl(control, "Texture Coordinates", TabLocation.Right);
+        //_guiCommands.AddWinformsControl(control, "Texture Coordinates", TabLocation.Right);
 
-        var pluginTab = GumCommands.Self.GuiCommands.AddControl(mainControl, "Texture Coordinates", TabLocation.RightBottom);
+        var pluginTab = _guiCommands.AddControl(mainControl, "Texture Coordinates", TabLocation.RightBottom);
         innerControl.DoubleClick += (not, used) =>
             HandleRegionDoubleClicked(innerControl, ref textureOutlineRectangle);
 
@@ -361,8 +364,8 @@ public class ControlLogic : Singleton<ControlLogic>
             // We should refresh the entire grid because we could be
             // changing this from Entire Texture to Custom, resulting in
             // new variables being shown
-            //GumCommands.Self.GuiCommands.RefreshVariableValues();
-            GumCommands.Self.GuiCommands.RefreshVariables();
+            //_guiCommands.RefreshVariableValues();
+            _guiCommands.RefreshVariables();
 
         }
 
@@ -420,7 +423,7 @@ public class ControlLogic : Singleton<ControlLogic>
             state.SetValue($"{instancePrefix}TextureHeight", graphicalUiElement.TextureHeight, "int");
 
 
-            GumCommands.Self.GuiCommands.RefreshVariableValues();
+            _guiCommands.RefreshVariableValues();
         }
 
         RefreshNineSliceGuides();

--- a/Tool/EditorTabPlugin_XNA/Editors/DimensionDisplay.cs
+++ b/Tool/EditorTabPlugin_XNA/Editors/DimensionDisplay.cs
@@ -7,6 +7,7 @@ using Color = System.Drawing.Color;
 using Matrix = System.Numerics.Matrix4x4;
 using Gum.Managers;
 using Gum.Commands;
+using Gum.Services;
 
 namespace Gum.Wireframe.Editors
 {
@@ -43,7 +44,7 @@ namespace Gum.Wireframe.Editors
         public DimensionDisplay()
         {
             _toolFontService = ToolFontService.Self;
-            _guiCommands = GumCommands.Self.GuiCommands;
+            _guiCommands = Locator.GetRequiredService<GuiCommands>();
         }
 
         public void AddToManagers(SystemManagers systemManagers, Layer layer)

--- a/Tool/EditorTabPlugin_XNA/Editors/PolygonWireframeEditor.cs
+++ b/Tool/EditorTabPlugin_XNA/Editors/PolygonWireframeEditor.cs
@@ -340,7 +340,7 @@ namespace Gum.Wireframe.Editors
             hasGrabbedBodyOrPoint = true;
             mHasChangedAnythingSinceLastPush = true;
 
-            GumCommands.Self.GuiCommands.RefreshVariableValues();
+            _guiCommands.RefreshVariableValues();
 
             return newIndex;
         }
@@ -468,7 +468,7 @@ namespace Gum.Wireframe.Editors
             // The values haven't yet been pushed up to the 
             // element/Instance, so this won't do anything yet.
             // Instead we rely on DoEndOfSettingValuesLogic 
-            GumCommands.Self.GuiCommands.RefreshVariableValues();
+            _guiCommands.RefreshVariableValues();
         }
 
         private void BodyGrabbingActivity()
@@ -494,7 +494,7 @@ namespace Gum.Wireframe.Editors
 
                 if(canDelete == false)
                 {
-                    GumCommands.Self.GuiCommands.PrintOutput("Cannot delete point, polygon requires at least 3 points");
+                    _guiCommands.PrintOutput("Cannot delete point, polygon requires at least 3 points");
                 }
                 else
                 {

--- a/Tool/EditorTabPlugin_XNA/Editors/StandardWireframeEditor.cs
+++ b/Tool/EditorTabPlugin_XNA/Editors/StandardWireframeEditor.cs
@@ -82,7 +82,7 @@ public class StandardWireframeEditor : WireframeEditor
         ISelectedState selectedState)
         : base(
               hotkeyManager, 
-              selectionManager, 
+              selectionManager,
               selectedState)
     {
         _elementCommands = Locator.GetRequiredService<ElementCommands>();
@@ -290,7 +290,7 @@ public class StandardWireframeEditor : WireframeEditor
             VariableInCategoryPropagationLogic.Self.PropagateVariablesInCategory(nameWithInstance,
                 _selectedState.SelectedElement, _selectedState.SelectedStateCategorySave);
 
-            GumCommands.Self.GuiCommands.RefreshVariableValues();
+            _guiCommands.RefreshVariableValues();
 
         }
     }
@@ -378,7 +378,7 @@ public class StandardWireframeEditor : WireframeEditor
             {
                 ApplyAxisLockToSelectedState();
 
-                GumCommands.Self.GuiCommands.RefreshVariables();
+                _guiCommands.RefreshVariables();
             }
 
             // let's snap everything
@@ -473,7 +473,7 @@ public class StandardWireframeEditor : WireframeEditor
         if (hasChangeOccurred)
         {
             //UpdateSelectedObjectsPositionAndDimensions();
-            GumCommands.Self.GuiCommands.RefreshVariables();
+            _guiCommands.RefreshVariables();
 
             // I don't think we need this anymore because they're updated automatically in SelectionManager
             //SelectionManager.Self.ShowSizeHandlesFor(WireframeObjectManager.Self.GetSelectedRepresentation());
@@ -735,7 +735,7 @@ public class StandardWireframeEditor : WireframeEditor
 
         if (wasAnythingModified)
         {
-            GumCommands.Self.GuiCommands.RefreshVariables(true);
+            _guiCommands.RefreshVariables(true);
         }
     }
 

--- a/Tool/EditorTabPlugin_XNA/Editors/WireframeEditor.cs
+++ b/Tool/EditorTabPlugin_XNA/Editors/WireframeEditor.cs
@@ -17,6 +17,7 @@ using System;
 using Gum.PropertyGridHelpers;
 using System.Security.Policy;
 using EditorTabPlugin_XNA.ExtensionMethods;
+using Gum.Commands;
 using Gum.Services;
 using Gum.ToolCommands;
 
@@ -31,6 +32,8 @@ public abstract class WireframeEditor
     protected readonly ISelectedState _selectedState;
     private readonly ElementCommands _elementCommands;
     private readonly UndoManager _undoManager;
+    protected readonly GuiCommands _guiCommands;
+    
     protected GrabbedState grabbedState = new GrabbedState();
 
     protected bool mHasChangedAnythingSinceLastPush = false;
@@ -53,9 +56,10 @@ public abstract class WireframeEditor
         _hotkeyManager = hotkeyManager;
         _selectionManager = selectionManager;
         _setVariableLogic = Locator.GetRequiredService<SetVariableLogic>();
-        _selectedState = Locator.GetRequiredService<ISelectedState>();
+        _selectedState = selectedState;
         _elementCommands = Locator.GetRequiredService<ElementCommands>();
         _undoManager = Locator.GetRequiredService<UndoManager>();
+        _guiCommands = Locator.GetRequiredService<GuiCommands>();
     }
 
     public abstract void UpdateToSelection(ICollection<GraphicalUiElement> selectedObjects);
@@ -221,7 +225,7 @@ public abstract class WireframeEditor
                 // go so we'll just deal with that problem for now.
                 //ApplyAxisLockToSelectedState();
 
-                //GumCommands.Self.GuiCommands.RefreshPropertyGrid();
+                //_guiCommands.RefreshPropertyGrid();
             }
             mHasChangedAnythingSinceLastPush = true;
         }
@@ -283,7 +287,7 @@ public abstract class WireframeEditor
 
         using var undoLock = _undoManager.RequestLock();
 
-        GumCommands.Self.GuiCommands.RefreshVariableValues();
+        _guiCommands.RefreshVariableValues();
 
         var element = _selectedState.SelectedElement;
 

--- a/Tool/EditorTabPlugin_XNA/MainEditorTabPlugin.cs
+++ b/Tool/EditorTabPlugin_XNA/MainEditorTabPlugin.cs
@@ -1,4 +1,4 @@
-﻿using CommonFormsAndControls.Forms;
+using CommonFormsAndControls.Forms;
 using EditorTabPlugin_XNA.Services;
 using FlatRedBall.AnimationEditorForms.Controls;
 using Gum.Commands;
@@ -641,7 +641,7 @@ internal class MainEditorTabPlugin : InternalPlugin
         {
             if (args.KeyCode == Keys.Tab)
             {
-                GumCommands.Self.GuiCommands.ToggleToolVisibility();
+                _guiCommands.ToggleToolVisibility();
             }
         };
 
@@ -710,7 +710,7 @@ internal class MainEditorTabPlugin : InternalPlugin
         if (shouldUpdate)
         {
             GumCommands.Self.FileCommands.TryAutoSaveCurrentElement();
-            GumCommands.Self.GuiCommands.RefreshVariables();
+            _guiCommands.RefreshVariables();
 
             WireframeObjectManager.Self.RefreshAll(true);
         }
@@ -892,7 +892,7 @@ internal class MainEditorTabPlugin : InternalPlugin
         // be added to the gumEditorPanel 2nd, no idea why
         CreateWireframeEditControl(gumEditorPanel);
 
-        GumCommands.Self.GuiCommands.AddControl(gumEditorPanel, "Editor", TabLocation.RightTop);
+        _guiCommands.AddControl(gumEditorPanel, "Editor", TabLocation.RightTop);
 
         _wireframeControl.XnaUpdate += () =>
         {

--- a/Tool/EditorTabPlugin_XNA/Services/ScreenshotService.cs
+++ b/Tool/EditorTabPlugin_XNA/Services/ScreenshotService.cs
@@ -17,11 +17,13 @@ internal class ScreenshotService
     Microsoft.Xna.Framework.Graphics.RenderTarget2D renderTarget;
     private readonly SelectionManager _selectionManager;
     private readonly WireframeCommands _wireframeCommands;
+    private readonly GuiCommands _guiCommands;
 
     public ScreenshotService(SelectionManager selectionManager)
     {
         _selectionManager = selectionManager;
         _wireframeCommands = Locator.GetRequiredService<WireframeCommands>();
+        _guiCommands = Locator.GetRequiredService<GuiCommands>();
     }
 
     public void InitializeMenuItem(ToolStripMenuItem item)
@@ -109,7 +111,7 @@ internal class ScreenshotService
             }
             catch (Exception e)
             {
-                GumCommands.Self.GuiCommands.PrintOutput(e.ToString());
+                _guiCommands.PrintOutput(e.ToString());
             }
             renderTarget.Dispose();
             renderTarget = null;


### PR DESCRIPTION
Refactors the code to inject GuiCommands where needed instead of relying on the static GumCommands.Self.GuiCommands, improving testability and reducing dependencies.
This change prepares the codebase for future dependency injection improvements.
