### PR TITLE
Setting Screen base type to empty screen no longer generates bad code

### DIFF
--- a/CodeOutputPlugin/Manager/CodeGenerator.cs
+++ b/CodeOutputPlugin/Manager/CodeGenerator.cs
@@ -442,12 +442,19 @@ public class CodeGenerator
 
     public static string GetInheritance(ElementSave element, CodeOutputProjectSettings projectSettings)
     {
-        string inheritance = null;
+        string? inheritance = null;
         if (element is ScreenSave)
         {
             if (projectSettings.OutputLibrary == OutputLibrary.MonoGameForms)
             {
-                inheritance = element.BaseType ?? "MonoGameGum.Forms.Controls.FrameworkElement";
+                if(string.IsNullOrEmpty( element.BaseType))
+                {
+                    inheritance = "MonoGameGum.Forms.Controls.FrameworkElement";
+                }
+                else
+                {
+                    inheritance = element.BaseType;
+                }
             }
             else
             {

--- a/Gum/DataTypes/StateSaveExtensionMethods.cs
+++ b/Gum/DataTypes/StateSaveExtensionMethods.cs
@@ -614,7 +614,14 @@ public static class StateSaveExtensionMethods
         }
         else if (variableName == "BaseType")
         {
-            stateSave.ParentContainer.BaseType = value?.ToString();
+            if(value?.ToString() == string.Empty)
+            {
+                stateSave.ParentContainer.BaseType = null;
+            }
+            else
+            {
+                stateSave.ParentContainer.BaseType = value?.ToString();
+            }
             isReservedName = true; // don't do anything
         }
 

--- a/Gum/Plugins/InternalPlugins/VariableGrid/StateReferencingInstanceMember.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/StateReferencingInstanceMember.cs
@@ -758,11 +758,11 @@ namespace Gum.PropertyGridHelpers
             var oldValue = variable?.Value;
             LastOldFullCommitValue = oldValue;
 
+            bool wasChangeMade = false;
             if (shouldReset)
             {
                 bool isPartOfCategory = StateSaveCategory != null;
 
-                bool wasChangeMade = false;
                 if (variable != null)
                 {
                     // Don't remove the variable if it's part of an element - we still want it there
@@ -838,6 +838,11 @@ namespace Gum.PropertyGridHelpers
                     // We need to refresh the property grid and the wireframe display
 
                 }
+                else if ((obj == "BaseType") || (obj == "Base Type") && ElementSave != null)
+                {
+                    ElementSave.BaseType = null;
+                    wasChangeMade = true;
+                }
                 else
                 {
                     // Maybe this is a variable list?
@@ -858,25 +863,26 @@ namespace Gum.PropertyGridHelpers
                 }
 
 
-                if (wasChangeMade)
-                {
-                    _undoManager.RecordUndo();
-                    GumCommands.Self.GuiCommands.RefreshVariables(force: true);
-                    WireframeObjectManager.Self.RefreshAll(true);
-
-                    PluginManager.Self.VariableSet(selectedElement, selectedInstance, variableName, oldValue);
-
-                    if (affectsTreeView)
-                    {
-                        GumCommands.Self.GuiCommands.RefreshElementTreeView(_selectedState.SelectedElement);
-                    }
-
-                    GumCommands.Self.FileCommands.TryAutoSaveElement(_selectedState.SelectedElement);
-                }
             }
             else
             {
                 IsDefault = false;
+            }
+
+            if (wasChangeMade)
+            {
+                _undoManager.RecordUndo();
+                GumCommands.Self.GuiCommands.RefreshVariables(force: true);
+                WireframeObjectManager.Self.RefreshAll(true);
+
+                PluginManager.Self.VariableSet(selectedElement, selectedInstance, variableName, oldValue);
+
+                if (affectsTreeView)
+                {
+                    GumCommands.Self.GuiCommands.RefreshElementTreeView(_selectedState.SelectedElement);
+                }
+
+                GumCommands.Self.FileCommands.TryAutoSaveElement(_selectedState.SelectedElement);
             }
 
             var gumElementOrInstanceSaveAsObject = this.Instance;


### PR DESCRIPTION
Fixed right-click, make default on base type not resetting type properly