### PR TITLE
Improvements to Linux manual and automated Gum Tool Installation

### DIFF
--- a/docs/gum-tool/setup/README.md
+++ b/docs/gum-tool/setup/README.md
@@ -76,29 +76,23 @@ These following commands will go through the steps of downloading and running th
 
 1. Download the setup\_gum.linux.sh script\
    [https://raw.githubusercontent.com/vchelaru/Gum/master/setup\_gum\_linux.sh](https://raw.githubusercontent.com/vchelaru/Gum/master/setup_gum_linux.sh)
-2. Open a terminal and `cd` to the directory that the script was downloaded to
-3. Make the script executable
+2. Open a terminal and `cd` to the directory that the script was downloaded to.
+3. Make the script executable and run the setup.
 
 ```sh
-chmod +x ./setup_gum_linux.sh
-```
-
-4. Execute the script
-
-```sh
-./setup_gum_linux.sh
+chmod +x ./setup_gum_linux.sh && ./setup_gum_linux.sh
 ```
 
 **Install WINE and Winetricks Manually**
 
 If the auto script fails to install the prerequisites try this.
 
-You can install WINE and Winetricks using your package manager. Open a terminal and run the following commands:
-
 If your distro is not listed bellow please use your prefered search engine to find out how to install\
 wine and winetricks properly on your system.
 
-Ubuntu 22.04
+You can install WINE and Winetricks using your package manager. Open a terminal and run the following commands:
+
+##### Ubuntu 22.04
 
 ```sh
 sudo dpkg --add-architecture i386 
@@ -109,7 +103,7 @@ sudo apt update && sudo apt install --install-recommends winehq-stable
 sudo apt-get -y install winetricks
 ```
 
-Ubuntu 24.04
+##### Ubuntu 24.04
 
 ```sh
 sudo dpkg --add-architecture i386 
@@ -120,14 +114,14 @@ sudo apt update && sudo apt install --install-recommends winehq-stable
 sudo apt-get -y install winetricks
 ```
 
-Fedora & Nobara (All Versions)
+##### Fedora & Nobara (All Versions)
 
 ```sh
 sudo dnf install wine
 sudo dnf install winetricks
 ```
 
-Linux Mint 20
+##### Linux Mint 20
 
 ```sh
 sudo apt install dirmngr ca-certificates software-properties-common apt-transport-https curl -y
@@ -137,7 +131,7 @@ echo deb [signed-by=/usr/share/keyrings/winehq.gpg] http://dl.winehq.org/wine-bu
 sudo apt-get install winetricks
 ```
 
-Linux Mint 21
+##### Linux Mint 21
 
 ```sh
 sudo apt install dirmngr ca-certificates software-properties-common apt-transport-https curl -y
@@ -147,7 +141,7 @@ echo deb [signed-by=/usr/share/keyrings/winehq.gpg] http://dl.winehq.org/wine-bu
 sudo apt-get install winetricks
 ```
 
-Linux Mint 22
+##### Linux Mint 22
 
 ```sh
 sudo apt install dirmngr ca-certificates software-properties-common apt-transport-https curl -y
@@ -161,52 +155,59 @@ sudo apt-get install winetricks
 
 These following commands will go through the steps setting up your macOS or Linux environment to run the GUM tool using WINE.
 
-1. Open a new terminal
-2. Install .NET Framework 4.8 using `winetricks` with the following command:
+1. Open a new terminal and set our wine prefix for Gum with the following command:
 
 ```sh
-winetricks dotnet48
+GUM_WINE_PREFIX_PATH=$HOME/.wine_gum_prefix/
+```
+
+2. Install Windows All Fonts using `winetricks` with the following command:
+
+```sh
+WINEPREFIX=$GUM_WINE_PREFIX_PATH winetricks allfonts
+```
+
+3. Install .NET Framework 4.8 using `winetricks` with the following command:
+
+```sh
+WINEPREFIX=$GUM_WINE_PREFIX_PATH winetricks dotnet48
 ```
 
 This command initiates the installation of .NET Framework 4.8. A total of two installer dialogs appear one after another. Follow the steps for both to complete the installation. **This process may take a several minutes, so please be patient**.
 
-1. Download the XNA 4.0 Redistributable MSI file from Microsoft. You can download it using the following command:
+4. Download the XNA 4.0 Redistributable MSI file from Microsoft. You can download it using the following command:
 
 ```sh
 curl -O https://download.microsoft.com/download/A/C/2/AC2C903B-E6E8-42C2-9FD7-BEBAC362A930/xnafx40_redist.msi
 ```
 
-4. After downloading the MSI file, install it using the following command:
+5. After downloading the MSI file, install it using the following command:
 
 ```sh
-wine msiexec /i xnafx40_redist.msi
+WINEPREFIX=$GUM_WINE_PREFIX_PATH wine msiexec /i xnafx40_redist.msi
 ```
 
 Follow the installation prompts. At the end of the installation, it may display an error related to launching DirectX. **This is normal; just click "Close" on the error dialog.**
 
-5. Download the Gum Tool ZIP file from the FlatRedBall website and save it to your preferred location. You can download it using the following command:
+6. Download the Gum Tool ZIP file from the FlatRedBall website and save it to your preferred location. You can download it using the following command:
 
 ```sh
 curl -o Gum.zip https://files.flatredball.com/content/Tools/Gum/Gum.zip
 ```
 
-6. Unzip the downloaded Gum Tool ZIP file into the Program Files directory of the WINE folder. Run the following command in the terminal:
+7. Unzip the downloaded Gum Tool ZIP file into the Program Files directory of the WINE folder, this will also remove any existing Gum Tool installed and the zip to clean up. Run the following command in the terminal:
 
 ```sh
-unzip Gum.zip -d ~/.wine/drive_c/Program\ Files/Gum
-```
-
-7. After unzipping the Gum Tool, remove the downloaded ZIP file using the following command:
-
-```sh
+rm -rf $GUM_WINE_PREFIX_PATH/drive_c/Program\ Files/Gum && \
+unzip Gum.zip -d $GUM_WINE_PREFIX_PATH/drive_c/Program\ Files/Gum && \
 rm -f Gum.zip
 ```
 
 8. Create a script to run the Gum Tool. Run the following command in the terminal:
 
 ```sh
-echo '#!/bin/bash
-wine ~/.wine/drive_c/Program\\ Files/Gum/Data/Gum.exe' > ~/bin/Gum
+GUM_EXE_PATH=$(find "$GUM_WINE_PREFIX_PATH" -name "Gum.exe" -type f) && \
+printf '#!%s\nWINEPREFIX=%s wine "%s"\n' "/bin/bash" "$GUM_WINE_PREFIX_PATH" "$GUM_EXE_PATH" > ~/bin/gum
 ```
 
 9. Make the script executable by running:
@@ -249,9 +250,9 @@ source ~/.zshrc
 
 #### Running the Gum Tool
 
-Congratulations! You have now successfully set up the Gum Tool on macOS using WINE. You can open the Gum Tool by simply typing the following command in the terminal:
+Congratulations! You have now successfully set up the Gum Tool on Linux using WINE. You can open the Gum Tool by simply typing the following command in the terminal:
 
-```
+```sh
 gum
 ```
 

--- a/docs/gum-tool/setup/README.md
+++ b/docs/gum-tool/setup/README.md
@@ -175,27 +175,13 @@ WINEPREFIX=$GUM_WINE_PREFIX_PATH winetricks dotnet48
 
 This command initiates the installation of .NET Framework 4.8. A total of two installer dialogs appear one after another. Follow the steps for both to complete the installation. **This process may take a several minutes, so please be patient**.
 
-4. Download the XNA 4.0 Redistributable MSI file from Microsoft. You can download it using the following command:
-
-```sh
-curl -O https://download.microsoft.com/download/A/C/2/AC2C903B-E6E8-42C2-9FD7-BEBAC362A930/xnafx40_redist.msi
-```
-
-5. After downloading the MSI file, install it using the following command:
-
-```sh
-WINEPREFIX=$GUM_WINE_PREFIX_PATH wine msiexec /i xnafx40_redist.msi
-```
-
-Follow the installation prompts. At the end of the installation, it may display an error related to launching DirectX. **This is normal; just click "Close" on the error dialog.**
-
-6. Download the Gum Tool ZIP file from the FlatRedBall website and save it to your preferred location. You can download it using the following command:
+4. Download the Gum Tool ZIP file from the FlatRedBall website and save it to your preferred location. You can download it using the following command:
 
 ```sh
 curl -o Gum.zip https://files.flatredball.com/content/Tools/Gum/Gum.zip
 ```
 
-7. Unzip the downloaded Gum Tool ZIP file into the Program Files directory of the WINE folder, this will also remove any existing Gum Tool installed and the zip to clean up. Run the following command in the terminal:
+5. Unzip the downloaded Gum Tool ZIP file into the Program Files directory of the WINE folder, this will also remove any existing Gum Tool installed and the zip to clean up. Run the following command in the terminal:
 
 ```sh
 rm -rf $GUM_WINE_PREFIX_PATH/drive_c/Program\ Files/Gum && \
@@ -203,7 +189,7 @@ unzip Gum.zip -d $GUM_WINE_PREFIX_PATH/drive_c/Program\ Files/Gum && \
 rm -f Gum.zip
 ```
 
-8. Create a script to run the Gum Tool. Run the following command in the terminal:
+6. Create a script to run the Gum Tool. Run the following command in the terminal:
 
 ```sh
 GUM_EXE_PATH=$(find "$GUM_WINE_PREFIX_PATH" -name "Gum.exe" -type f) && \
@@ -212,7 +198,7 @@ printf '#!%s\nWINEPREFIX=%s wine "%s"\n' "/bin/bash" "$GUM_WINE_PREFIX_PATH" "$G
 chmod +x ~/bin/gum
 ```
 
-9. To ensure you can run the Gum Tool from any directory, add the script directory to your PATH. Most Linux and macOS users using macOS 10.14 or lower, will be using the BASH shell.
+7. To ensure you can run the Gum Tool from any directory, add the script directory to your PATH. Most Linux and macOS users using macOS 10.14 or lower, will be using the BASH shell.
 
 **For Bash SHELL**
 
@@ -230,7 +216,7 @@ if ! grep -q 'export PATH="\$HOME/bin:\$PATH"' ~/.zshrc 2>/dev/null; then
 fi
 ```
 
-10. Reload the shell configuration to apply the changes. Run the following command:
+8. Reload the shell configuration to apply the changes. Run the following command:
 
 **For BASH Shell**
 

--- a/docs/gum-tool/setup/README.md
+++ b/docs/gum-tool/setup/README.md
@@ -207,22 +207,18 @@ rm -f Gum.zip
 
 ```sh
 GUM_EXE_PATH=$(find "$GUM_WINE_PREFIX_PATH" -name "Gum.exe" -type f) && \
-printf '#!%s\nWINEPREFIX=%s wine "%s"\n' "/bin/bash" "$GUM_WINE_PREFIX_PATH" "$GUM_EXE_PATH" > ~/bin/gum
-```
-
-9. Make the script executable by running:
-
-```sh
+mkdir -p $HOME/bin && \
+printf '#!%s\nWINEPREFIX=%s wine "%s"\n' "/bin/bash" "$GUM_WINE_PREFIX_PATH" "$GUM_EXE_PATH" > $HOME/bin/gum && \
 chmod +x ~/bin/gum
 ```
 
-10. To ensure you can run the Gum Tool from any directory, add the script directory to your PATH. Most Linux and macOS users using macOS 10.14 or lower, will be using the BASH shell. While for most macOS user using macOS 10.15 or higher, you'll be using the ZSH shell.
+9. To ensure you can run the Gum Tool from any directory, add the script directory to your PATH. Most Linux and macOS users using macOS 10.14 or lower, will be using the BASH shell.
 
 **For Bash SHELL**
 
 ```sh
-if ! grep -q 'export PATH="\$HOME/bin:\$PATH"' ~/.bash_profile 2>/dev/null; then
-    echo 'export PATH="$HOME/bin:$PATH"' >> ~/.bash_profile
+if ! grep -q 'export PATH="\$HOME/bin:\$PATH"' ~/.bashrc 2>/dev/null; then
+    echo 'export PATH="$HOME/bin:$PATH"' >> ~/.bashrc
 fi
 ```
 
@@ -234,12 +230,12 @@ if ! grep -q 'export PATH="\$HOME/bin:\$PATH"' ~/.zshrc 2>/dev/null; then
 fi
 ```
 
-11. Reload the shell configuration to apply the changes. Run the following command:
+10. Reload the shell configuration to apply the changes. Run the following command:
 
 **For BASH Shell**
 
 ```sh
-source ~/.bash_profile
+source ~/.bashrc
 ```
 
 **For ZSH Shell**

--- a/setup_gum_linux.sh
+++ b/setup_gum_linux.sh
@@ -133,24 +133,6 @@ echo "They may take a few minutes to install, please be patient"
 WINEPREFIX=$GUM_WINE_PREFIX_PATH winetricks dotnet48 &> /dev/null
 
 ################################################################################
-### Download the xna redistributable msi file from Microsoft
-################################################################################
-echo "Installing XNA 4.0 Redistributable, please follow the installation prompts"
-echo "At the end of the installation it may say it has an error launching DirectX, this is normal, just click close on the error dialog"
-curl -O https://download.microsoft.com/download/A/C/2/AC2C903B-E6E8-42C2-9FD7-BEBAC362A930/xnafx40_redist.msi &> /dev/null
-
-################################################################################
-### Execute the XNA MSI file using WINE 
-################################################################################
-WINEPREFIX=$GUM_WINE_PREFIX_PATH wine msiexec /i xnafx40_redist.msi &> /dev/null || true 
-## We must return true, so when you click cancel (if for example you must rerun the script it wont't close the script!
-
-################################################################################
-### Clean up the file we downloaded.
-################################################################################
-rm -f ./xnafx40_redist.msi &> /dev/null
-
-################################################################################
 ### Download the gum.zip file from the FRB site into the Program Files directory
 ### of the wine folder
 ################################################################################

--- a/setup_gum_linux.sh
+++ b/setup_gum_linux.sh
@@ -9,7 +9,7 @@ set -e
 GUM_WINE_PREFIX_PATH=$HOME/.wine_gum_prefix/
 
 echo "This is an experimental script."
-echo "Script last updated on the 8th of May 2025!"
+echo "Script last updated on the 29th of July 2025!"
 
 read -p "Do you wish to continue? (y/n): " choice
 case "$choice" in
@@ -23,11 +23,11 @@ echo "Verifying that WINE is installed..."
 if ! command -v wine &> /dev/null; then
     echo "Wine is not installed. Attempting to install..."
 
-    DISTRO=$(lsb_release -si 2>/dev/null || grep '^ID=' /etc/os-release | cut -d= -f2 | tr -d '"')
+    DISTRO=$(( lsb_release -si 2>/dev/null || grep '^ID=' /etc/os-release ) | cut -d= -f2 | tr -d '"' | tr '[:upper:]'  '[:lower:]')
     VERSION=$(lsb_release -sr 2>/dev/null || grep '^VERSION_ID=' /etc/os-release | cut -d= -f2 | tr -d '"')
 
     case "$DISTRO" in
-        Ubuntu)
+        ubuntu)
             if [[ "$VERSION" == "22.04" ]]; then
                 echo "Installing Wine for Ubuntu 22.04"
                 sudo dpkg --add-architecture i386 
@@ -47,7 +47,7 @@ if ! command -v wine &> /dev/null; then
             fi
             ;;
 
-        LinuxMint)
+        linuxmint)
             if [[ "$VERSION" == "20" ]]; then
                 BASE="focal"
             elif [[ "$VERSION" == "21" ]]; then
@@ -67,12 +67,12 @@ if ! command -v wine &> /dev/null; then
             sudo apt install --install-recommends winehq-stable -y
             ;;
 
-        Fedora|Nobara)
+        fedora|nobara)
             echo "Installing Wine for Fedora/Nobara"
             sudo dnf install -y wine
             ;;
 
-        Darwin)
+        darwin)
             echo "Detected macOS"
             echo "Please install Wine-stable manually:"
             echo "brew install --cask --no-quarantine wine-stable"
@@ -95,13 +95,13 @@ if ! command -v winetricks &> /dev/null; then
     echo "Winetricks is not installed. Attempting to install..."
 
     case "$DISTRO" in
-        Ubuntu|LinuxMint)
+        ubuntu|linuxmint)
             sudo apt install -y winetricks
             ;;
-        Fedora|Nobara)
+        fedora|nobara)
             sudo dnf install -y winetricks
             ;;
-        Darwin)
+        darwin)
             echo "Please install Winetricks manually:"
             echo "brew install winetricks"
             exit 1

--- a/setup_gum_linux.sh
+++ b/setup_gum_linux.sh
@@ -228,4 +228,4 @@ fi
 ################################################################################
 echo "Gum setup on Linux using WINE is now complete. You can open the GUM Tool by using the command 'gum'."
 echo "Pro Tip: Install dxvk with the command winetricks dxvk, if you can use Vulkan on your system! (It handles better than OpenGL)."
-echo "You may need to close and reopen the terminal if it doesn't work at first."
+echo "You may need to close and reopen the terminal if it doesn't work at first, due to the update to your PATH."

--- a/setup_gum_linux.sh
+++ b/setup_gum_linux.sh
@@ -6,6 +6,8 @@
 
 set -e
 
+GUM_WINE_PREFIX_PATH=$HOME/.wine_gum_prefix/
+
 echo "This is an experimental script."
 echo "Script last updated on the 8th of May 2025!"
 
@@ -114,13 +116,21 @@ fi
 echo "Winetricks is installed"
 
 ################################################################################
+### Install windows allfonts with winetricks.  They can take a few minutes to finish, please be patient
+################################################################################
+echo "Installing all fonts using winetricks"
+echo "An installer dialog may appear, follow the steps to install"
+echo "They may take a few minutes to install, please be patient"
+WINEPREFIX=$GUM_WINE_PREFIX_PATH winetricks allfonts &> /dev/null
+
+################################################################################
 ### Install dotnet48 with winetricks. This will cause two installation prompts
 ### to appear.  They can take a few minutes to finish, please be patient
 ################################################################################
 echo "Installing .NET Framework 4.8 using winetricks"
 echo "Two installer dialogs will appear, follow the steps for both to install"
 echo "They may take a few minutes to install, please be patient"
-WINEPREFIX=~/.wine_gum_prefix/ winetricks dotnet48 &> /dev/null
+WINEPREFIX=$GUM_WINE_PREFIX_PATH winetricks dotnet48 &> /dev/null
 
 ################################################################################
 ### Download the xna redistributable msi file from Microsoft
@@ -132,9 +142,8 @@ curl -O https://download.microsoft.com/download/A/C/2/AC2C903B-E6E8-42C2-9FD7-BE
 ################################################################################
 ### Execute the XNA MSI file using WINE 
 ################################################################################
-WINEPREFIX=~/.wine_gum_prefix/ wine msiexec /i xnafx40_redist.msi &> /dev/null || true 
+WINEPREFIX=$GUM_WINE_PREFIX_PATH wine msiexec /i xnafx40_redist.msi &> /dev/null || true 
 ## We must return true, so when you click cancel (if for example you must rerun the script it wont't close the script!
-
 
 ################################################################################
 ### Clean up the file we downloaded.
@@ -146,31 +155,30 @@ rm -f ./xnafx40_redist.msi &> /dev/null
 ### of the wine folder
 ################################################################################
 echo "Installing GUM Tool..."
-curl -L -o ~/.wine_gum_prefix/drive_c/"Program Files"/Gum.zip "https://files.flatredball.com/content/Tools/Gum/Gum.zip" \
+GUM_ZIP_FILE="$WINE_PREFIX_PATH/drive_c/Program Files/Gum.zip"
+curl -L -o "$GUM_ZIP_FILE" "https://files.flatredball.com/content/Tools/Gum/Gum.zip" \
     && echo "Download completed." || { echo "Download failed."; exit 1; }
 
 ################################################################################
 ### Unzip the gum.zip file into Program Files/Gum
 ################################################################################
 echo "Extracting GUM Tool..."
-unzip -q ~/.wine_gum_prefix/drive_c/"Program Files"/Gum.zip -d ~/.wine_gum_prefix/drive_c/"Program Files"/Gum \
+GUM_WINE_EXTRACT_DIR="$WINE_PREFIX_PATH/drive_c/Program Files/Gum"
+rm -rf "$GUM_WINE_EXTRACT_DIR"
+unzip -q "$GUM_ZIP_FILE" -d "$GUM_WINE_EXTRACT_DIR" \
     && echo "Extraction completed." || { echo "Extraction failed."; exit 1; }
-
-################################################################################
-### Clean up the zip file we downloaded
-################################################################################
 echo "Cleaning up..."
-rm -f ~/.wine_gum_prefix/drive_c/"Program Files"/Gum.zip \
+rm -f "$GUM_ZIP_FILE" \
     && echo "Cleanup completed." || { echo "Cleanup failed."; exit 1; }
-
 
 echo "Adding Gum to path"
 
 ################################################################################
 ### Define the script content
 ################################################################################
-SCRIPT_CONTENT='#!/bin/bash
-WINEPREFIX=~/.wine_gum_prefix/ wine ~/.wine_gum_prefix/drive_c/Program\ Files/Gum/Data/Debug/Gum.exe'
+GUM_EXE_PATH=$(find "$GUM_WINE_EXTRACT_DIR" -name "Gum.exe" -type f)
+SCRIPT_CONTENT="#!/bin/bash
+WINEPREFIX=\"$GUM_WINE_PREFIX_PATH\" wine \"$GUM_EXE_PATH\""
 
 ################################################################################
 ### Create the ~/bin directory if it doesn't exist
@@ -218,7 +226,6 @@ fi
 ################################################################################
 ### Finished
 ################################################################################
-echo "Gum setup on Linux using WINE is now complete. You can open the GUM Tool by using the command 'Gum'."
-echo "Pro Tip 1: Install dxvk with the command winetricks dxvk, if you can use Vulkan on your system! (It handles better than OpenGL)."
-echo "Pro Tip 2: Install allfonts with the command winetricks allfonts, it'll make text look better (you maybe able to get by with just arial, but just to be safe."
+echo "Gum setup on Linux using WINE is now complete. You can open the GUM Tool by using the command 'gum'."
+echo "Pro Tip: Install dxvk with the command winetricks dxvk, if you can use Vulkan on your system! (It handles better than OpenGL)."
 echo "You may need to close and reopen the terminal if it doesn't work at first."

--- a/setup_gum_linux.sh
+++ b/setup_gum_linux.sh
@@ -155,7 +155,7 @@ rm -f ./xnafx40_redist.msi &> /dev/null
 ### of the wine folder
 ################################################################################
 echo "Installing GUM Tool..."
-GUM_ZIP_FILE="$WINE_PREFIX_PATH/drive_c/Program Files/Gum.zip"
+GUM_ZIP_FILE="$GUM_WINE_PREFIX_PATH/drive_c/Program Files/Gum.zip"
 curl -L -o "$GUM_ZIP_FILE" "https://files.flatredball.com/content/Tools/Gum/Gum.zip" \
     && echo "Download completed." || { echo "Download failed."; exit 1; }
 
@@ -163,7 +163,7 @@ curl -L -o "$GUM_ZIP_FILE" "https://files.flatredball.com/content/Tools/Gum/Gum.
 ### Unzip the gum.zip file into Program Files/Gum
 ################################################################################
 echo "Extracting GUM Tool..."
-GUM_WINE_EXTRACT_DIR="$WINE_PREFIX_PATH/drive_c/Program Files/Gum"
+GUM_WINE_EXTRACT_DIR="$GUM_WINE_PREFIX_PATH/drive_c/Program Files/Gum"
 rm -rf "$GUM_WINE_EXTRACT_DIR"
 unzip -q "$GUM_ZIP_FILE" -d "$GUM_WINE_EXTRACT_DIR" \
     && echo "Extraction completed." || { echo "Extraction failed."; exit 1; }

--- a/setup_gum_linux.sh
+++ b/setup_gum_linux.sh
@@ -24,20 +24,20 @@ if ! command -v wine &> /dev/null; then
     echo "Wine is not installed. Attempting to install..."
 
     DISTRO=$(( lsb_release -si 2>/dev/null || grep '^ID=' /etc/os-release ) | cut -d= -f2 | tr -d '"' | tr '[:upper:]'  '[:lower:]')
-    VERSION=$(lsb_release -sr 2>/dev/null || grep '^VERSION_ID=' /etc/os-release | cut -d= -f2 | tr -d '"')
+    VERSION=$(( lsb_release -sr 2>/dev/null || grep '^VERSION_ID=' /etc/os-release ) | cut -d= -f2 | tr -d '"' | cut -c1-2 )
 
     case "$DISTRO" in
         ubuntu)
-            if [[ "$VERSION" == "22.04" ]]; then
-                echo "Installing Wine for Ubuntu 22.04"
+            if [[ "$VERSION" == "22" ]]; then
+                echo "Installing Wine for Ubuntu 22.xx"
                 sudo dpkg --add-architecture i386 
                 sudo mkdir -pm755 /etc/apt/keyrings
                 wget -O - https://dl.winehq.org/wine-builds/winehq.key | sudo gpg --dearmor -o /etc/apt/keyrings/winehq-archive.key -
                 sudo wget -NP /etc/apt/sources.list.d/ https://dl.winehq.org/wine-builds/ubuntu/dists/jammy/winehq-jammy.sources
                 sudo apt update
                 sudo apt install --install-recommends winehq-stable -y
-            elif [[ "$VERSION" == "24.04" ]]; then
-                echo "Installing Wine for Ubuntu 24.04"
+            elif [[ "$VERSION" == "24" ]]; then
+                echo "Installing Wine for Ubuntu 24.xx"
                 sudo dpkg --add-architecture i386 
                 sudo mkdir -pm755 /etc/apt/keyrings
                 wget -O - https://dl.winehq.org/wine-builds/winehq.key | sudo gpg --dearmor -o /etc/apt/keyrings/winehq-archive.key -


### PR DESCRIPTION
Added improvements to both the Linux manual and automated installation for Gum Tool.

Key items;
- Improved distro & distro version check functionality to be more flexable
- Added required installation packages for fresh WINE installs required by Gum Tool
- Improved automated installation for Gum Tool especially around the gum shell file
- Improved manual installation by aligning it to the automated install script (same wine prefix for example) and reduced steps required by doing multiline commands for smaller items (e.g. chmod +x)

Tested on a fresh Linux Mint 22.1 install for both automated and manual.