### PR TITLE
Remove HotkeyManager.Self

### DIFF
--- a/Gum/Controls/MainPanelControl.xaml.cs
+++ b/Gum/Controls/MainPanelControl.xaml.cs
@@ -17,6 +17,8 @@ public partial class MainPanelControl : UserControl
     GridLength bottomRowLength;
 
     GridLength splitterLength;
+    
+    private readonly HotkeyManager _hotkeyManager;
 
     IEnumerable<TabControl> AllControls
     {
@@ -31,16 +33,17 @@ public partial class MainPanelControl : UserControl
     }
 
     bool isHidden;
-    public MainPanelControl()
+    public MainPanelControl(HotkeyManager hotkeyManager)
     {
         InitializeComponent();
 
+        _hotkeyManager = hotkeyManager;
         this.KeyDown += HandleKeyDown;
     }
 
     private void HandleKeyDown(object sender, System.Windows.Input.KeyEventArgs e)
     {
-        HotkeyManager.Self.HandleKeyDownAppWide(e);
+        _hotkeyManager.HandleKeyDownAppWide(e);
     }
 
     private void CenterBottomTabControl_SelectionChanged(object sender, SelectionChangedEventArgs e)

--- a/Gum/MainWindow.cs
+++ b/Gum/MainWindow.cs
@@ -65,7 +65,7 @@ namespace Gum
             
             InitializeComponent();
 
-            CreateMainWpfPanel();
+            CreateMainWpfPanel(services.GetRequiredService<HotkeyManager>());
 
             this.KeyPreview = true;
             this.KeyDown += HandleKeyDown;
@@ -145,11 +145,11 @@ namespace Gum
             }
         }
 
-        private void CreateMainWpfPanel()
+        private void CreateMainWpfPanel(HotkeyManager hotkeyManager)
         {
             var wpfHost = new ElementHost();
             wpfHost.Dock = DockStyle.Fill;
-            mainPanelControl = new MainPanelControl();
+            mainPanelControl = new MainPanelControl(hotkeyManager);
             wpfHost.Child = mainPanelControl;
             this.Controls.Add(wpfHost);
             this.PerformLayout();

--- a/Gum/Managers/HotkeyManager.cs
+++ b/Gum/Managers/HotkeyManager.cs
@@ -142,7 +142,7 @@ public class KeyCombination
 }
 #endregion
 
-public class HotkeyManager : Singleton<HotkeyManager>
+public class HotkeyManager
 {
     public KeyCombination Delete { get; private set; } = KeyCombination.Pressed(Keys.Delete);
     public KeyCombination Copy { get; private set; } = KeyCombination.Ctrl(Keys.C);
@@ -190,14 +190,18 @@ public class HotkeyManager : Singleton<HotkeyManager>
 
     // If adding any new keys here, modify HotkeyViewModel
     
-    public HotkeyManager()
+    public HotkeyManager(GuiCommands guiCommands, 
+        ISelectedState selectedState, 
+        ElementCommands elementCommands,
+        IDialogService dialogService,
+        FileCommands fileCommands)
     {
         _copyPasteLogic = CopyPasteLogic.Self;
-        _guiCommands = Locator.GetRequiredService<GuiCommands>();
-        _selectedState = Locator.GetRequiredService<ISelectedState>();
-        _elementCommands = Locator.GetRequiredService<ElementCommands>();
-        _dialogService =  Locator.GetRequiredService<IDialogService>();
-        _fileCommands = Locator.GetRequiredService<FileCommands>();
+        _guiCommands = guiCommands;
+        _selectedState = selectedState;
+        _elementCommands = elementCommands;
+        _dialogService = dialogService;
+        _fileCommands = fileCommands;
     }
 
     #region App Wide Keys

--- a/Gum/Plugins/InternalPlugins/Hotkey/MainHotkeyPlugin.cs
+++ b/Gum/Plugins/InternalPlugins/Hotkey/MainHotkeyPlugin.cs
@@ -3,6 +3,8 @@ using Gum.Plugins.InternalPlugins.Hotkey.Views;
 using System;
 using System.ComponentModel.Composition;
 using System.Windows.Forms;
+using Gum.Plugins.InternalPlugins.Hotkey.ViewModels;
+using Gum.Services;
 
 namespace Gum.Plugins.InternalPlugins.Hotkey
 {
@@ -16,7 +18,10 @@ namespace Gum.Plugins.InternalPlugins.Hotkey
         public override void StartUp()
         {
             menuItem = this.AddMenuItemTo("View Hotkeys", HandleToggleTabVisibility, "View");
-            hotkeyView = new Views.HotkeyView();
+            hotkeyView = new Views.HotkeyView()
+            {
+                DataContext = Locator.GetRequiredService<HotkeyViewModel>()
+            };
             pluginTab = base.CreateTab(hotkeyView, "Hotkeys", TabLocation.CenterBottom);
             pluginTab.TabShown += HandleTabShown;
             pluginTab.TabHidden += HandleTabHidden;

--- a/Gum/Plugins/InternalPlugins/Hotkey/Views/HotkeyView.xaml.cs
+++ b/Gum/Plugins/InternalPlugins/Hotkey/Views/HotkeyView.xaml.cs
@@ -14,6 +14,7 @@ using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Navigation;
 using System.Windows.Shapes;
+using Gum.Services;
 
 namespace Gum.Plugins.InternalPlugins.Hotkey.Views
 {
@@ -25,9 +26,6 @@ namespace Gum.Plugins.InternalPlugins.Hotkey.Views
         public HotkeyView()
         {
             InitializeComponent();
-
-            var viewModel = new HotkeyViewModel(HotkeyManager.Self);
-            this.DataContext = viewModel;
         }
     }
 }

--- a/Gum/Plugins/InternalPlugins/StatePlugin/MainStatePlugin.cs
+++ b/Gum/Plugins/InternalPlugins/StatePlugin/MainStatePlugin.cs
@@ -48,7 +48,7 @@ public class MainStatePlugin : InternalPlugin
         var editCommands = Locator.GetRequiredService<EditCommands>();
         var dialogService = Locator.GetRequiredService<IDialogService>();
         _stateTreeViewRightClickService = new StateTreeViewRightClickService(_selectedState, elementCommands, editCommands, dialogService, _guiCommands, _fileCommands);
-        _hotkeyManager = HotkeyManager.Self;
+        _hotkeyManager = Locator.GetRequiredService<HotkeyManager>();
         _objectFinder = ObjectFinder.Self;
     }
 

--- a/Gum/Plugins/InternalPlugins/TreeView/ElementTreeViewManager.cs
+++ b/Gum/Plugins/InternalPlugins/TreeView/ElementTreeViewManager.cs
@@ -113,7 +113,7 @@ public partial class ElementTreeViewManager
     private readonly GuiCommands _guiCommands;
     private readonly IDialogService _dialogService;
     private readonly FileCommands _fileCommands;
-
+    private readonly HotkeyManager _hotkeyManager;
 
     public const int TransparentImageIndex = 0;
     public const int FolderImageIndex = 1;
@@ -279,6 +279,7 @@ public partial class ElementTreeViewManager
         _guiCommands = Locator.GetRequiredService<GuiCommands>();
         _dialogService = Locator.GetRequiredService<IDialogService>();
         _fileCommands = Locator.GetRequiredService<FileCommands>();
+        _hotkeyManager = Locator.GetRequiredService<HotkeyManager>();
         
         TreeNodeExtensionMethods.ElementTreeViewManager = this;
     }
@@ -1874,7 +1875,7 @@ public partial class ElementTreeViewManager
             OnSelect((SelectedNode as TreeNodeWrapper)?.Node);
         }
 
-        HotkeyManager.Self.HandleKeyDownElementTreeView(e);
+        _hotkeyManager.HandleKeyDownElementTreeView(e);
 
         if (didTreeViewHaveFocus)
         {
@@ -2116,7 +2117,7 @@ public partial class ElementTreeViewManager
                 }
             }
 
-            HotkeyManager.Self.HandleKeyDownAppWide(args);
+            _hotkeyManager.HandleKeyDownAppWide(args);
         };
 
         grid.Children.Add(searchTextBox);

--- a/Gum/Plugins/InternalPlugins/VariableGrid/StateReferencingInstanceMember.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/StateReferencingInstanceMember.cs
@@ -253,7 +253,7 @@ namespace Gum.PropertyGridHelpers
             _editVariablesService = Locator.GetRequiredService<IEditVariableService>();
             _exposeVariableService = Locator.GetRequiredService<IExposeVariableService>();
             _objectFinder = ObjectFinder.Self;
-            _hotkeyManager = HotkeyManager.Self;
+            _hotkeyManager = Locator.GetRequiredService<HotkeyManager>();
             _deleteVariableLogic = Locator.GetRequiredService<IDeleteVariableService>();
             _undoManager = undoManager;
             _selectedState = Locator.GetRequiredService<ISelectedState>();

--- a/Gum/Services/Builder.cs
+++ b/Gum/Services/Builder.cs
@@ -63,6 +63,7 @@ file static class ServiceCollectionExtensions
         services.AddSingleton<NameVerifier>();
         services.AddSingleton<UndoManager>();
         services.AddSingleton<FontManager>();
+        services.AddSingleton<HotkeyManager>();
         services.AddSingleton<IEditVariableService, EditVariableService>();
         services.AddSingleton<IDeleteVariableService, DeleteVariableService>();
         services.AddSingleton<IExposeVariableService, ExposeVariableService>();
@@ -89,7 +90,6 @@ file static class ServiceCollectionExtensions
     public static void AddLegacyServices(this IServiceCollection services)
     {
         services.AddSingleton(SetVariableLogic.Self);
-        services.AddSingleton(HotkeyManager.Self);
         services.AddSingleton<IObjectFinder>(ObjectFinder.Self);
         
         services.AddSingleton<CircularReferenceManager>();

--- a/Tool/EditorTabPlugin_XNA/MainEditorTabPlugin.cs
+++ b/Tool/EditorTabPlugin_XNA/MainEditorTabPlugin.cs
@@ -102,6 +102,7 @@ internal class MainEditorTabPlugin : InternalPlugin
     private readonly ISelectedState _selectedState;
     private readonly WireframeCommands _wireframeCommands;
     private readonly FileCommands _fileCommands;
+    private readonly HotkeyManager _hotkeyManager;
     private DragDropManager _dragDropManager;
     WireframeControl _wireframeControl;
 
@@ -125,7 +126,8 @@ internal class MainEditorTabPlugin : InternalPlugin
         _editingManager = new EditingManager();
         UndoManager undoManager = Locator.GetRequiredService<UndoManager>();
         IDialogService dialogService = Locator.GetRequiredService<IDialogService>();
-        _selectionManager = new SelectionManager(_selectedState, undoManager, _editingManager, dialogService);
+        HotkeyManager hotkeyManager = Locator.GetRequiredService<HotkeyManager>();
+        _selectionManager = new SelectionManager(_selectedState, undoManager, _editingManager, dialogService, hotkeyManager);
         _screenshotService = new ScreenshotService(_selectionManager);
         _elementCommands = Locator.GetRequiredService<ElementCommands>();
         _singlePixelTextureService = new SinglePixelTextureService();
@@ -133,6 +135,7 @@ internal class MainEditorTabPlugin : InternalPlugin
         _dragDropManager = Locator.GetRequiredService<DragDropManager>();
         _wireframeCommands = Locator.GetRequiredService<WireframeCommands>();
         _fileCommands = Locator.GetRequiredService<FileCommands>();
+        _hotkeyManager = hotkeyManager;
     }
 
     public override void StartUp()
@@ -590,7 +593,7 @@ internal class MainEditorTabPlugin : InternalPlugin
         _wireframeControl.Initialize(
             _wireframeEditControl, 
             gumEditorPanel, 
-            HotkeyManager.Self, 
+            _hotkeyManager, 
             _selectionManager, 
             _dragDropManager);
 

--- a/Tool/EditorTabPlugin_XNA/SelectionManager.cs
+++ b/Tool/EditorTabPlugin_XNA/SelectionManager.cs
@@ -76,6 +76,7 @@ public class SelectionManager
     private readonly EditingManager _editingManager;
     private readonly UndoManager _undoManager;
     private readonly IDialogService _dialogService;
+    private readonly HotkeyManager _hotkeyManager;
 
     public bool IsOverBody
     {
@@ -186,12 +187,17 @@ public class SelectionManager
 
     #region Methods
 
-    internal SelectionManager(ISelectedState selectedState, UndoManager undoManager, EditingManager editingManager, IDialogService dialogService)
+    internal SelectionManager(ISelectedState selectedState, 
+        UndoManager undoManager, 
+        EditingManager editingManager, 
+        IDialogService dialogService,
+        HotkeyManager hotkeyManager)
     {
         _selectedState = selectedState;
         _editingManager = editingManager;
         _undoManager = undoManager;
         _dialogService = dialogService;
+        _hotkeyManager = hotkeyManager;
     }
 
     public void Initialize(LayerService layerService)
@@ -609,7 +615,7 @@ public class SelectionManager
                 }
                 WireframeEditor = new PolygonWireframeEditor(
                     _layerService.OverlayLayer,
-                    global::Gum.Managers.HotkeyManager.Self,
+                    _hotkeyManager,
                     this,
                     _selectedState);
             }
@@ -632,7 +638,7 @@ public class SelectionManager
                 }
                 WireframeEditor = new PolygonWireframeEditor(
                     _layerService.OverlayLayer,
-                    global::Gum.Managers.HotkeyManager.Self,
+                    _hotkeyManager,
                     this,
                     _selectedState);
             }
@@ -656,7 +662,7 @@ public class SelectionManager
                     WireframeEditor = new StandardWireframeEditor(
                         _layerService.OverlayLayer,
                         lineColor, textColor, 
-                        global::Gum.Managers.HotkeyManager.Self,
+                        _hotkeyManager,
                         this,
                         _selectedState);
                 }

--- a/Tool/EditorTabPlugin_XNA/Views/WireframeControl.cs
+++ b/Tool/EditorTabPlugin_XNA/Views/WireframeControl.cs
@@ -29,6 +29,8 @@ namespace Gum.Plugins.InternalPlugins.EditorTab.Views;
 public class WireframeControl : GraphicsDeviceControl
 {
     #region Fields
+    
+    private HotkeyManager _hotkeyManager;
 
     WireframeEditControl mWireframeEditControl;
     private SelectionManager _selectionManager;
@@ -97,14 +99,14 @@ public class WireframeControl : GraphicsDeviceControl
 
     void OnKeyDown(object sender, KeyEventArgs e)
     {
-        HotkeyManager.Self.HandleKeyDownWireframe(e);
+        _hotkeyManager.HandleKeyDownWireframe(e);
         CameraController.Self.HandleKeyPress(e);
 
     }
 
     protected override bool ProcessCmdKey(ref Message msg, Keys keyData)
     {
-        bool handled = HotkeyManager.Self.ProcessCmdKeyWireframe(ref msg, keyData);
+        bool handled = _hotkeyManager.ProcessCmdKeyWireframe(ref msg, keyData);
 
         if (handled)
         {
@@ -130,6 +132,7 @@ public class WireframeControl : GraphicsDeviceControl
     {
         _selectionManager = selectionManager;
         _dragDropManager = dragDropManager;
+        _hotkeyManager = hotkeyManager;
         try
         {
             LoaderManager.Self.ContentLoader = new ContentLoader();
@@ -236,13 +239,13 @@ public class WireframeControl : GraphicsDeviceControl
             ToolFontService.Self,
             ToolLayerService.Self,
             layerService,
-            HotkeyManager.Self);
+            _hotkeyManager);
         mLeftRuler = new Ruler(this, SystemManagers.Default,
             InputLibrary.Cursor.Self,
             ToolFontService.Self,
             ToolLayerService.Self,
             layerService,
-            HotkeyManager.Self);
+            _hotkeyManager);
         mLeftRuler.RulerSide = RulerSide.Left;
 
     }


### PR DESCRIPTION
Changes the HotkeyManager from a singleton to a dependency-injected service.

This improves testability and reduces the reliance on global state.

Updates references to HotkeyManager to resolve through the service locator.
