### PR TITLE
1168/add texture to nineslice styling

### DIFF
--- a/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
+++ b/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
@@ -23,6 +23,7 @@ using System.IO;
 using MonoGameGum.Localization;
 using System.Security.Policy;
 using Gum.Managers;
+using Microsoft.Xna.Framework.Graphics;
 
 #if GUM
 using Gum.Services;
@@ -248,11 +249,16 @@ public class CustomSetPropertyOnRenderable
             nineSlice.Blue = (int)value;
             handled = true;
         }
+        else if (propertyName == "Texture")
+        {
+            nineSlice.SetSingleTexture((Texture2D)value);
+            handled = true;
+        }
 
-        // Texture coordiantes like TextureLeft, TextureRight, TextureWidth, and TextureHeight
-        // are handled by GraphicalUiElement so we don't have to handle it here
+            // Texture coordiantes like TextureLeft, TextureRight, TextureWidth, and TextureHeight
+            // are handled by GraphicalUiElement so we don't have to handle it here
 
-        return handled;
+            return handled;
     }
 
     private static void AssignSourceFileOnNineSlice(string value, GraphicalUiElement graphicalUiElement, NineSlice nineSlice)

--- a/MonoGameGum/Forms/DefaultVisuals/Styling.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/Styling.cs
@@ -17,16 +17,31 @@ public class Styling
     /// This allows someone to get the active style from any instance they create, or from the class self like Styling.ActiveStyle.
     /// </summary>
     public static Styling ActiveStyle { get; set; }
-    public Texture2D SpriteSheet { get; set; }
+
+    private Texture2D _spriteSheet;
+    public Texture2D SpriteSheet { 
+        get => _spriteSheet;
+        set
+        {
+            _spriteSheet = value;
+            if (UseDefaults)
+            {
+                NineSlice.UseDefaults(_spriteSheet);
+                Icons.UseDefaults(_spriteSheet);
+            }
+        }
+    }
 
     public Colors Colors { get; set; } = new ();
-    public NineSlice NineSlice { get; set; } = new ();
+    public NineSlice NineSlice { get; set; }
 
-    public Icons Icons { get; set; } = new();
+    public Icons Icons { get; set; }
 
     public Text Text { get; set; } = new ();
 
-    public Styling(Texture2D? spriteSheet)
+    public bool UseDefaults { get; set; }
+
+    public Styling(Texture2D? spriteSheet, bool useDefaults = true)
     {
 #if RAYLIB
         this.SpriteSheet = spriteSheet.Value;
@@ -45,27 +60,51 @@ public class Styling
         {
             ActiveStyle = this;
         }
+
+        UseDefaults = useDefaults;
+        NineSlice = new();
+        Icons = new();
+        if (useDefaults)
+        {
+            NineSlice.UseDefaults(spriteSheet);
+            Icons.UseDefaults(spriteSheet);
+        }
     }
 
+    /// <summary>
+    /// Creates a StateSave object that represents the rectangle position on a specific Texture2D
+    /// </summary>
+    /// <param name="left"></param>
+    /// <param name="top"></param>
+    /// <param name="width"></param>
+    /// <param name="height"></param>
+    /// <param name="texture"></param>
+    /// <returns></returns>
+    public static StateSave CreateTextureCoordinateState(int left, int top, int width, int height, Texture2D texture)
+    {
+        var variables = new List<VariableSave>
+        {
+            new() { Name = "TextureLeft", Type = "int", Value = left },
+            new() { Name = "TextureTop", Type = "int", Value = top },
+            new() { Name = "TextureWidth", Type = "int", Value = width },
+            new() { Name = "TextureHeight", Type = "int", Value = height },
+            new() { Name = "TextureAddress", Type = "int", Value = Gum.Managers.TextureAddress.Custom }
+        };
+
+        if (texture != null)
+        {
+            variables.Add(new VariableSave { Name = "Texture", Type = "Texture2D", Value = texture });
+        }
+
+        return new StateSave
+        {
+            Variables = variables
+        };
+    }
 }
 
 public class Colors
 {
-    private static StateSave CreateTextureCoordinateState(int left, int top, int width, int height)
-    {
-        return new()
-        {
-            Variables = new()
-            {
-                new() { Name = "TextureLeft", Type = "int", Value = left },
-                new() { Name = "TextureTop", Type = "int", Value = top },
-                new() { Name = "TextureWidth", Type = "int", Value = width },
-                new() { Name = "TextureHeight", Type = "int", Value = height },
-                new() { Name = "TextureAddress", Type = "int", Value = Gum.Managers.TextureAddress.Custom }
-            }
-        };
-    }
-
     public Color Black { get; set; } = new Color(0, 0, 0);
     public Color DarkGray { get; set; } = new Color(70, 70, 80);
     public Color Gray { get; set; } = new Color(130, 130, 130);
@@ -77,132 +116,190 @@ public class Colors
     public Color Success { get; set; } = new Color(62, 167, 48);
     public Color Warning { get; set; } = new Color(232, 171, 25);
     public Color Danger { get; set; } = new Color(212, 18, 41);
-
     public Color Accent { get; set; } = new Color(140, 48, 138);
-
 }
 
 
 public class NineSlice
 {
-    private static StateSave CreateTextureCoordinateState(int left, int top, int width, int height)
+    public StateSave Solid;
+    public StateSave Bordered;
+    public StateSave BracketVertical;
+    public StateSave BracketHorizontal;
+    public StateSave Tab;
+    public StateSave TabBordered;
+    public StateSave Outlined;
+    public StateSave OutlinedHeavy;
+    public StateSave Panel;
+    public StateSave CircleSolid;
+    public StateSave CircleBordered;
+    public StateSave CircleOutlined;
+    public StateSave CircleOutlinedHeavy;
+
+    public void UseDefaults(Texture2D texture)
     {
-        return new()
-        {
-            Variables = new()
-            {
-                new() { Name = "TextureLeft", Type = "int", Value = left },
-                new() { Name = "TextureTop", Type = "int", Value = top },
-                new() { Name = "TextureWidth", Type = "int", Value = width },
-                new() { Name = "TextureHeight", Type = "int", Value = height },
-                new() { Name = "TextureAddress", Type = "int", Value = Gum.Managers.TextureAddress.Custom }
-            }
-        };
+        Solid = Styling.CreateTextureCoordinateState(0, 48, 24, 24, texture);
+        Bordered = Styling.CreateTextureCoordinateState(24, 48, 24, 24, texture);
+        BracketVertical = Styling.CreateTextureCoordinateState(48, 72, 24, 24, texture);
+        BracketHorizontal = Styling.CreateTextureCoordinateState(72, 72, 24, 24, texture);
+        Tab = Styling.CreateTextureCoordinateState(48, 48, 24, 24, texture);
+        TabBordered = Styling.CreateTextureCoordinateState(72, 48, 24, 24, texture);
+        Outlined = Styling.CreateTextureCoordinateState(0, 72, 24, 24, texture);
+        OutlinedHeavy = Styling.CreateTextureCoordinateState(24, 72, 24, 24, texture);
+        Panel = Styling.CreateTextureCoordinateState(96, 48, 24, 24, texture);
+        CircleSolid = Styling.CreateTextureCoordinateState(0, 96, 24, 24, texture);
+        CircleBordered = Styling.CreateTextureCoordinateState(24, 96, 24, 24, texture);
+        CircleOutlined = Styling.CreateTextureCoordinateState(0, 120, 24, 24, texture);
+        CircleOutlinedHeavy = Styling.CreateTextureCoordinateState(24, 120, 24, 24, texture);
     }
-
-    public StateSave Solid = CreateTextureCoordinateState(0, 48, 24, 24);
-    public StateSave Bordered = CreateTextureCoordinateState(24, 48, 24, 24);
-    public StateSave BracketVertical = CreateTextureCoordinateState(48, 72, 24, 24);
-    public StateSave BracketHorizontal = CreateTextureCoordinateState(72, 72, 24, 24);
-    public StateSave Tab = CreateTextureCoordinateState(48, 48, 24, 24);
-    public StateSave TabBordered = CreateTextureCoordinateState(72, 48, 24, 24);
-    public StateSave Outlined = CreateTextureCoordinateState(0, 72, 24, 24);
-    public StateSave OutlinedHeavy = CreateTextureCoordinateState(24, 72, 24, 24);
-    public StateSave Panel = CreateTextureCoordinateState(96, 48, 24, 24);
-    public StateSave CircleSolid = CreateTextureCoordinateState(0, 96, 24, 24);
-    public StateSave CircleBordered = CreateTextureCoordinateState(24, 96, 24, 24);
-    public StateSave CircleOutlined = CreateTextureCoordinateState(0, 120, 24, 24);
-    public StateSave CircleOutlinedHeavy = CreateTextureCoordinateState(24, 120, 24, 24);
-
 }
 
 public class Icons
 {
-    private static StateSave CreateTextureCoordinateState(int left, int top, int width, int height)
-    {
-        return new()
-        {
-            Variables = new()
-            {
-                new() { Name = "TextureLeft", Type = "int", Value = left },
-                new() { Name = "TextureTop", Type = "int", Value = top },
-                new() { Name = "TextureWidth", Type = "int", Value = width },
-                new() { Name = "TextureHeight", Type = "int", Value = height },
-                new() { Name = "TextureAddress", Type = "int", Value = Gum.Managers.TextureAddress.Custom }
-            }
-        };
-    }
+    public StateSave Arrow1;
+    public StateSave Arrow2;
+    public StateSave Arrow3;
+    public StateSave Basket;
+    public StateSave Battery;
+    public StateSave Check;
+    public StateSave CheckeredFlag;
+    public StateSave Circle1;
+    public StateSave Circle2;
+    public StateSave Close;
+    public StateSave Crosshairs;
+    public StateSave Currency;
+    public StateSave Cursor;
+    public StateSave CursorText;
+    public StateSave Dash;
+    public StateSave Delete;
+    public StateSave Enter;
+    public StateSave Expand;
+    public StateSave Gamepad;
+    public StateSave GamepadNES;
+    public StateSave GamepadSNES;
+    public StateSave GamepadNintendo64;
+    public StateSave GamepadGamecube;
+    public StateSave GamepadSwitchPro;
+    public StateSave GamepadXbox;
+    public StateSave GamepadPlaystationDualShock;
+    public StateSave GamepadSegaGenesis;
+    public StateSave Gear;
+    public StateSave FastForward;
+    public StateSave FastForwardBar;
+    public StateSave FitToScreen;
+    public StateSave Flame1;
+    public StateSave Flame2;
+    public StateSave Heart;
+    public StateSave Info;
+    public StateSave Keyboard;
+    public StateSave Leaf;
+    public StateSave Lightning;
+    public StateSave Minimize;
+    public StateSave Monitor;
+    public StateSave Mouse;
+    public StateSave Music;
+    public StateSave Pause;
+    public StateSave Pencil;
+    public StateSave Play;
+    public StateSave PlayBar;
+    public StateSave Power;
+    public StateSave Radiation;
+    public StateSave Reduce;
+    public StateSave Shield;
+    public StateSave Shot;
+    public StateSave Skull;
+    public StateSave Sliders;
+    public StateSave SoundMaximum;
+    public StateSave SoundMinimum;
+    public StateSave Speech;
+    public StateSave Star;
+    public StateSave Stop;
+    public StateSave Temperature;
+    public StateSave Touch;
+    public StateSave Trash;
+    public StateSave Trophy;
+    public StateSave User;
+    public StateSave UserAdd;
+    public StateSave UserDelete;
+    public StateSave UserGear;
+    public StateSave UserMulti;
+    public StateSave UserRemove;
+    public StateSave Warning;
+    public StateSave Wrench;
 
-    public StateSave Arrow1 => CreateTextureCoordinateState(288, 256, 32, 32);
-    public StateSave Arrow2 => CreateTextureCoordinateState(320, 256, 32, 32);
-    public StateSave Arrow3 => CreateTextureCoordinateState(352, 256, 32, 32);
-    public StateSave Basket => CreateTextureCoordinateState(288, 224, 32, 32);
-    public StateSave Battery => CreateTextureCoordinateState(320, 224, 32, 32);
-    public StateSave Check => CreateTextureCoordinateState(384, 128, 32, 32);
-    public StateSave CheckeredFlag => CreateTextureCoordinateState(384, 288, 32, 32);
-    public StateSave Circle1 => CreateTextureCoordinateState(448, 128, 32, 32);
-    public StateSave Circle2 => CreateTextureCoordinateState(416, 128, 32, 32);
-    public StateSave Close => CreateTextureCoordinateState(416, 192, 32, 32);
-    public StateSave Crosshairs => CreateTextureCoordinateState(352, 288, 32, 32);
-    public StateSave Currency => CreateTextureCoordinateState(352, 224, 32, 32);
-    public StateSave Cursor => CreateTextureCoordinateState(384, 32, 32, 32);
-    public StateSave CursorText => CreateTextureCoordinateState(416, 32, 32, 32);
-    public StateSave Dash => CreateTextureCoordinateState(352, 204, 32, 20);
-    public StateSave Delete => CreateTextureCoordinateState(288, 320, 32, 32);
-    public StateSave Enter => CreateTextureCoordinateState(320, 320, 32, 32);
-    public StateSave Expand => CreateTextureCoordinateState(384, 192, 32, 32);
-    public StateSave Gamepad => CreateTextureCoordinateState(352, 320, 32, 32);
-    public StateSave GamepadNES => CreateTextureCoordinateState(416, 320, 32, 32);
-    public StateSave GamepadSNES => CreateTextureCoordinateState(448, 320, 32, 32);
-    public StateSave GamepadNintendo64 => CreateTextureCoordinateState(384, 352, 32, 32);
-    public StateSave GamepadGamecube => CreateTextureCoordinateState(416, 352, 32, 32);
-    public StateSave GamepadSwitchPro => CreateTextureCoordinateState(352, 320, 32, 32);
-    public StateSave GamepadXbox => CreateTextureCoordinateState(384, 320, 32, 32);
-    public StateSave GamepadPlaystationDualShock => CreateTextureCoordinateState(352, 352, 32, 32);
-    public StateSave GamepadSegaGenesis => CreateTextureCoordinateState(448, 352, 32, 32);
-    public StateSave Gear => CreateTextureCoordinateState(320, 96, 32, 32);
-    public StateSave FastForward => CreateTextureCoordinateState(384, 160, 32, 32);
-    public StateSave FastForwardBar => CreateTextureCoordinateState(416, 160, 32, 32);
-    public StateSave FitToScreen => CreateTextureCoordinateState(288, 192, 32, 32);
-    public StateSave Flame1 => CreateTextureCoordinateState(320, 64, 32, 32);
-    public StateSave Flame2 => CreateTextureCoordinateState(352, 64, 32, 32);
-    public StateSave Heart => CreateTextureCoordinateState(320, 128, 32, 32);
-    public StateSave Info => CreateTextureCoordinateState(416, 256, 32, 32);
-    public StateSave Keyboard => CreateTextureCoordinateState(320, 32, 32, 32);
-    public StateSave Leaf => CreateTextureCoordinateState(288, 64, 32, 32);
-    public StateSave Lightning => CreateTextureCoordinateState(416, 64, 32, 32);
-    public StateSave Minimize => CreateTextureCoordinateState(352, 192, 32, 32);
-    public StateSave Monitor => CreateTextureCoordinateState(448, 192, 32, 32);
-    public StateSave Mouse => CreateTextureCoordinateState(448, 32, 32, 32);
-    public StateSave Music => CreateTextureCoordinateState(384, 224, 32, 32);
-    public StateSave Pause => CreateTextureCoordinateState(320, 160, 32, 32);
-    public StateSave Pencil => CreateTextureCoordinateState(288, 96, 32, 32);
-    public StateSave Play => CreateTextureCoordinateState(288, 160, 32, 32);
-    public StateSave PlayBar => CreateTextureCoordinateState(448, 160, 32, 32);
-    public StateSave Power => CreateTextureCoordinateState(288, 288, 32, 32);
-    public StateSave Radiation => CreateTextureCoordinateState(384, 64, 32, 32);
-    public StateSave Reduce => CreateTextureCoordinateState(320, 192, 32, 32);
-    public StateSave Shield => CreateTextureCoordinateState(416, 288, 32, 32);
-    public StateSave Shot => CreateTextureCoordinateState(320, 288, 32, 32);
-    public StateSave Skull => CreateTextureCoordinateState(448, 288, 32, 32);
-    public StateSave Sliders => CreateTextureCoordinateState(352, 96, 32, 32);
-    public StateSave SoundMaximum => CreateTextureCoordinateState(448, 224, 32, 32);
-    public StateSave SoundMinimum => CreateTextureCoordinateState(416, 224, 32, 32);
-    public StateSave Speech => CreateTextureCoordinateState(448, 96, 32, 32);
-    public StateSave Star => CreateTextureCoordinateState(352, 128, 32, 32);
-    public StateSave Stop => CreateTextureCoordinateState(352, 160, 32, 32);
-    public StateSave Temperature => CreateTextureCoordinateState(448, 64, 32, 32);
-    public StateSave Touch => CreateTextureCoordinateState(352, 32, 32, 32);
-    public StateSave Trash => CreateTextureCoordinateState(416, 96, 32, 32);
-    public StateSave Trophy => CreateTextureCoordinateState(288, 128, 32, 32);
-    public StateSave User => CreateTextureCoordinateState(288, 0, 32, 32);
-    public StateSave UserAdd => CreateTextureCoordinateState(384, 0, 32, 32);
-    public StateSave UserDelete => CreateTextureCoordinateState(416, 0, 32, 32);
-    public StateSave UserGear => CreateTextureCoordinateState(352, 0, 32, 32);
-    public StateSave UserMulti => CreateTextureCoordinateState(320, 0, 32, 32);
-    public StateSave UserRemove => CreateTextureCoordinateState(448, 0, 32, 32);
-    public StateSave Warning => CreateTextureCoordinateState(448, 256, 32, 32);
-    public StateSave Wrench => CreateTextureCoordinateState(384, 96, 32, 32);
+    public void UseDefaults(Texture2D texture)
+    {
+        Arrow1 = Styling.CreateTextureCoordinateState(288, 256, 32, 32, texture);
+        Arrow2 = Styling.CreateTextureCoordinateState(320, 256, 32, 32, texture);
+        Arrow3 = Styling.CreateTextureCoordinateState(352, 256, 32, 32, texture);
+        Basket = Styling.CreateTextureCoordinateState(288, 224, 32, 32, texture);
+        Battery = Styling.CreateTextureCoordinateState(320, 224, 32, 32, texture);
+        Check = Styling.CreateTextureCoordinateState(384, 128, 32, 32, texture);
+        CheckeredFlag = Styling.CreateTextureCoordinateState(384, 288, 32, 32, texture);
+        Circle1 = Styling.CreateTextureCoordinateState(448, 128, 32, 32, texture);
+        Circle2 = Styling.CreateTextureCoordinateState(416, 128, 32, 32, texture);
+        Close = Styling.CreateTextureCoordinateState(416, 192, 32, 32, texture);
+        Crosshairs = Styling.CreateTextureCoordinateState(352, 288, 32, 32, texture);
+        Currency = Styling.CreateTextureCoordinateState(352, 224, 32, 32, texture);
+        Cursor = Styling.CreateTextureCoordinateState(384, 32, 32, 32, texture);
+        CursorText = Styling.CreateTextureCoordinateState(416, 32, 32, 32, texture);
+        Dash = Styling.CreateTextureCoordinateState(352, 204, 32, 20, texture);
+        Delete = Styling.CreateTextureCoordinateState(288, 320, 32, 32, texture);
+        Enter = Styling.CreateTextureCoordinateState(320, 320, 32, 32, texture);
+        Expand = Styling.CreateTextureCoordinateState(384, 192, 32, 32, texture);
+        Gamepad = Styling.CreateTextureCoordinateState(352, 320, 32, 32, texture);
+        GamepadNES = Styling.CreateTextureCoordinateState(416, 320, 32, 32, texture);
+        GamepadSNES = Styling.CreateTextureCoordinateState(448, 320, 32, 32, texture);
+        GamepadNintendo64 = Styling.CreateTextureCoordinateState(384, 352, 32, 32, texture);
+        GamepadGamecube = Styling.CreateTextureCoordinateState(416, 352, 32, 32, texture);
+        GamepadSwitchPro = Styling.CreateTextureCoordinateState(352, 320, 32, 32, texture);
+        GamepadXbox = Styling.CreateTextureCoordinateState(384, 320, 32, 32, texture);
+        GamepadPlaystationDualShock = Styling.CreateTextureCoordinateState(352, 352, 32, 32, texture);
+        GamepadSegaGenesis = Styling.CreateTextureCoordinateState(448, 352, 32, 32, texture);
+        Gear = Styling.CreateTextureCoordinateState(320, 96, 32, 32, texture);
+        FastForward = Styling.CreateTextureCoordinateState(384, 160, 32, 32, texture);
+        FastForwardBar = Styling.CreateTextureCoordinateState(416, 160, 32, 32, texture);
+        FitToScreen = Styling.CreateTextureCoordinateState(288, 192, 32, 32, texture);
+        Flame1 = Styling.CreateTextureCoordinateState(320, 64, 32, 32, texture);
+        Flame2 = Styling.CreateTextureCoordinateState(352, 64, 32, 32, texture);
+        Heart = Styling.CreateTextureCoordinateState(320, 128, 32, 32, texture);
+        Info = Styling.CreateTextureCoordinateState(416, 256, 32, 32, texture);
+        Keyboard = Styling.CreateTextureCoordinateState(320, 32, 32, 32, texture);
+        Leaf = Styling.CreateTextureCoordinateState(288, 64, 32, 32, texture);
+        Lightning = Styling.CreateTextureCoordinateState(416, 64, 32, 32, texture);
+        Minimize = Styling.CreateTextureCoordinateState(352, 192, 32, 32, texture);
+        Monitor = Styling.CreateTextureCoordinateState(448, 192, 32, 32, texture);
+        Mouse = Styling.CreateTextureCoordinateState(448, 32, 32, 32, texture);
+        Music = Styling.CreateTextureCoordinateState(384, 224, 32, 32, texture);
+        Pause = Styling.CreateTextureCoordinateState(320, 160, 32, 32, texture);
+        Pencil = Styling.CreateTextureCoordinateState(288, 96, 32, 32, texture);
+        Play = Styling.CreateTextureCoordinateState(288, 160, 32, 32, texture);
+        PlayBar = Styling.CreateTextureCoordinateState(448, 160, 32, 32, texture);
+        Power = Styling.CreateTextureCoordinateState(288, 288, 32, 32, texture);
+        Radiation = Styling.CreateTextureCoordinateState(384, 64, 32, 32, texture);
+        Reduce = Styling.CreateTextureCoordinateState(320, 192, 32, 32, texture);
+        Shield = Styling.CreateTextureCoordinateState(416, 288, 32, 32, texture);
+        Shot = Styling.CreateTextureCoordinateState(320, 288, 32, 32, texture);
+        Skull = Styling.CreateTextureCoordinateState(448, 288, 32, 32, texture);
+        Sliders = Styling.CreateTextureCoordinateState(352, 96, 32, 32, texture);
+        SoundMaximum = Styling.CreateTextureCoordinateState(448, 224, 32, 32, texture);
+        SoundMinimum = Styling.CreateTextureCoordinateState(416, 224, 32, 32, texture);
+        Speech = Styling.CreateTextureCoordinateState(448, 96, 32, 32, texture);
+        Star = Styling.CreateTextureCoordinateState(352, 128, 32, 32, texture);
+        Stop = Styling.CreateTextureCoordinateState(352, 160, 32, 32, texture);
+        Temperature = Styling.CreateTextureCoordinateState(448, 64, 32, 32, texture);
+        Touch = Styling.CreateTextureCoordinateState(352, 32, 32, 32, texture);
+        Trash = Styling.CreateTextureCoordinateState(416, 96, 32, 32, texture);
+        Trophy = Styling.CreateTextureCoordinateState(288, 128, 32, 32, texture);
+        User = Styling.CreateTextureCoordinateState(288, 0, 32, 32, texture);
+        UserAdd = Styling.CreateTextureCoordinateState(384, 0, 32, 32, texture);
+        UserDelete = Styling.CreateTextureCoordinateState(416, 0, 32, 32, texture);
+        UserGear = Styling.CreateTextureCoordinateState(352, 0, 32, 32, texture);
+        UserMulti = Styling.CreateTextureCoordinateState(320, 0, 32, 32, texture);
+        UserRemove = Styling.CreateTextureCoordinateState(448, 0, 32, 32, texture);
+        Warning = Styling.CreateTextureCoordinateState(448, 256, 32, 32, texture);
+        Wrench = Styling.CreateTextureCoordinateState(384, 96, 32, 32, texture);
+    }
 }
 
 public class Text


### PR DESCRIPTION
Resolves #1168 

Accept, decline, or add comments.

I'm just proposing this small adjustment that doesn't affect existing functionality (I hope) but adds to it.

Features:
1. Texture used to create a style is automatically included in any "Defaults" for things like NineSlice.Bordered or Icons
2. Users can create a style and specify NOT to use the defaults
3. Users can create texture regions that include the texture or not

If you see value, cool, if not, decline, delete the branch, and close the ticket.  No worries.