### PR TITLE
1209/invalid cast when setting Sprite values if `TextureAdress` is set to `Custom`

### DIFF
--- a/GumRuntime/GraphicalUiElement.cs
+++ b/GumRuntime/GraphicalUiElement.cs
@@ -5330,16 +5330,22 @@ public partial class GraphicalUiElement : IRenderableIpso, IVisible, INotifyProp
 
     private bool TrySetValueOnThis(string propertyName, object value)
     {
+        // See issue 1209
+        int ValueToInt() =>
+            value is int intValue ? intValue :
+            value is string stringValue ? int.Parse(stringValue) :
+            throw new InvalidCastException($"value is of unexpected type {value.GetType()}");
+        
         bool toReturn = false;
         try
         {
             switch (propertyName)
             {
                 case "AutoGridHorizontalCells":
-                    this.AutoGridHorizontalCells = (int)value;
+                    this.AutoGridHorizontalCells = ValueToInt();
                     break;
                 case "AutoGridVerticalCells":
-                    this.AutoGridVerticalCells = (int)value;
+                    this.AutoGridVerticalCells = ValueToInt();
                     break;
                 case "ChildrenLayout":
                 case "Children Layout":
@@ -5431,22 +5437,22 @@ public partial class GraphicalUiElement : IRenderableIpso, IVisible, INotifyProp
                     break;
                 case "TextureLeft":
                 case "Texture Left":
-                    this.TextureLeft = (int)value;
+                    this.TextureLeft = ValueToInt();
                     toReturn = true;
                     break;
                 case "TextureTop":
                 case "Texture Top":
-                    this.TextureTop = (int)value;
+                    this.TextureTop = ValueToInt();
                     toReturn = true;
                     break;
                 case "TextureWidth":
                 case "Texture Width":
-                    this.TextureWidth = (int)value;
+                    this.TextureWidth = ValueToInt();
                     toReturn = true;
                     break;
                 case "TextureHeight":
                 case "Texture Height":
-                    this.TextureHeight = (int)value;
+                    this.TextureHeight = ValueToInt();
                     toReturn = true;
 
                     break;

--- a/GumRuntime/GraphicalUiElement.cs
+++ b/GumRuntime/GraphicalUiElement.cs
@@ -16,6 +16,7 @@ using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.Linq;
 using System.ComponentModel;
+using System.Text.RegularExpressions;
 using ToolsUtilitiesStandard.Helpers;
 using MathHelper = ToolsUtilitiesStandard.Helpers.MathHelper;
 using Vector2 = System.Numerics.Vector2;
@@ -5330,11 +5331,22 @@ public partial class GraphicalUiElement : IRenderableIpso, IVisible, INotifyProp
 
     private bool TrySetValueOnThis(string propertyName, object value)
     {
-        // See issue 1209
-        int ValueToInt() =>
-            value is int intValue ? intValue :
-            value is string stringValue ? int.Parse(stringValue) :
-            throw new InvalidCastException($"value is of unexpected type {value.GetType()}");
+        // See issue 1209 & PR 1210
+        int ValueToInt()
+        {
+            switch (value)
+            {
+                case int intVal:
+                    return intVal;
+                
+                case string strVal:
+                    string filteredVal = Regex.Replace(strVal, @"\D", string.Empty);
+                    return int.Parse(filteredVal);
+                
+                default:
+                    throw new InvalidCastException($"value is of unexpected type {value.GetType()}");
+            }
+        }
         
         bool toReturn = false;
         try


### PR DESCRIPTION
After my changes it works just fine for me

https://github.com/user-attachments/assets/45d483cf-3e68-4e7e-86df-72307d586dac

Resolves #1209 

