### PR TITLE
Update to use ITabManager instead of GuiCommands for tab operations

### DIFF
--- a/CodeOutputPlugin/MainCodeOutputPlugin.cs
+++ b/CodeOutputPlugin/MainCodeOutputPlugin.cs
@@ -373,7 +373,7 @@ public class MainCodeOutputPlugin : PluginBase
 
         control.DataContext = viewModel;
 
-        pluginTab = _guiCommands.AddControl(control, "Code", TabLocation.RightBottom);
+        pluginTab = _tabManager.AddControl(control, "Code", TabLocation.RightBottom);
         pluginTab.GotFocus += () => RefreshCodeDisplay();
     }
 

--- a/Gum/Commands/GuiCommands.cs
+++ b/Gum/Commands/GuiCommands.cs
@@ -39,7 +39,6 @@ public class GuiCommands
 
 
     MainPanelControl mainPanelControl;
-    private ITabManager _tabManager => mainPanelControl;
 
     private readonly Lazy<ISelectedState> _lazySelectedState;
     private ISelectedState _selectedState => _lazySelectedState.Value;
@@ -133,68 +132,6 @@ public class GuiCommands
     {
         PluginManager.Self.RefreshElementTreeView(instanceContainer);
     }
-
-    #endregion
-
-    #region Tab Controls
-
-    public PluginTab AddControl(System.Windows.FrameworkElement control, string tabTitle, TabLocation tabLocation = TabLocation.CenterBottom)
-    {
-        CheckForInitialization();
-        return _tabManager.AddControl(control, tabTitle, tabLocation);
-    }
-
-    public void ShowTab(PluginTab tab, bool focus = true) =>
-        _tabManager.ShowTab(tab, focus);
-
-    public void HideTab(PluginTab tab)
-    { 
-        _tabManager.HideTab(tab);
-    }
-
-    public PluginTab AddControl(System.Windows.Forms.Control control, string tabTitle, TabLocation tabLocation)
-    {
-        CheckForInitialization();
-        return _tabManager.AddControl(control, tabTitle, tabLocation);
-    }
-
-    private void CheckForInitialization()
-    {
-        if (_tabManager == null)
-        {
-            throw new InvalidOperationException("Need to call Initialize first");
-        }
-    }
-
-    public PluginTab AddWinformsControl(Control control, string tabTitle, TabLocation tabLocation)
-    {
-        return _tabManager.AddControl(control, tabTitle, tabLocation);
-    }
-
-    public bool IsTabVisible(PluginTab pluginTab)
-    {
-        return _tabManager.IsTabVisible(pluginTab);
-    }
-
-
-    public void RemoveControl(System.Windows.Controls.UserControl control)
-    {
-        _tabManager.RemoveControl(control);
-    }
-
-    /// <summary>
-    /// Selects the tab which contains the argument control
-    /// </summary>
-    /// <param name="control">The control to show.</param>
-    /// <returns>Whether the control was shown. If the control is not found, false is returned.</returns>
-    public bool ShowTabForControl(System.Windows.Controls.UserControl control)
-    {
-        return _tabManager.ShowTabForControl(control);
-    }
-
-
-    internal bool IsTabFocused(PluginTab pluginTab) =>
-                    _tabManager.IsTabFocused(pluginTab);
 
     #endregion
 

--- a/Gum/Plugins/BaseClasses/PluginBase.cs
+++ b/Gum/Plugins/BaseClasses/PluginBase.cs
@@ -24,6 +24,7 @@ namespace Gum.Plugins.BaseClasses
     {
         protected readonly GuiCommands _guiCommands;
         protected readonly FileCommands _fileCommands;
+        protected readonly ITabManager _tabManager;
         
         #region Events
 
@@ -223,6 +224,7 @@ namespace Gum.Plugins.BaseClasses
         {
             _guiCommands = Locator.GetRequiredService<GuiCommands>();
             _fileCommands = Locator.GetRequiredService<FileCommands>();
+            _tabManager = Locator.GetRequiredService<ITabManager>();
         }
 
         public abstract void StartUp();
@@ -341,29 +343,20 @@ namespace Gum.Plugins.BaseClasses
 
             //return CreateTab(wpfHost, tabName);
 
-            var page = new PluginTabItem();
-            page.Header = tabName;
-            page.Content = control;
-
-
-            PluginTab pluginTab = new PluginTab();
-            pluginTab.TabItem = page;
-            pluginTab.Title = tabName;
-
-            pluginTab.SuggestedLocation = defaultLocation;
-
-            return pluginTab;
-
+            PluginTab newTab = _tabManager.AddControl(control, tabName, defaultLocation);
+            newTab.SuggestedLocation = defaultLocation;
+            newTab.Hide();
+            return newTab;
         }
 
         public PluginTab AddControl(System.Windows.FrameworkElement control, string tabName, TabLocation tabLocation)
         {
-            return _guiCommands.AddControl(control, tabName, tabLocation);
+            return _tabManager.AddControl(control, tabName, tabLocation);
         }
 
         public void RemoveControl(System.Windows.Controls.UserControl control)
         {
-            _guiCommands.RemoveControl(control);
+            _tabManager.RemoveControl(control);
         }
 
         #endregion

--- a/Gum/Plugins/InternalPlugins/AlignmentButtons/AlignmentMainPlugin.cs
+++ b/Gum/Plugins/InternalPlugins/AlignmentButtons/AlignmentMainPlugin.cs
@@ -55,7 +55,7 @@ namespace Gum.Plugins.AlignmentButtons
 
                 if (!isAdded)
                 {
-                    _guiCommands.AddControl(control, "Alignment");
+                    _tabManager.AddControl(control, "Alignment");
                     isAdded = true;
                 }
             }
@@ -63,7 +63,7 @@ namespace Gum.Plugins.AlignmentButtons
             {
                 if (control != null && isAdded)
                 {
-                    _guiCommands.RemoveControl(control);
+                    _tabManager.RemoveControl(control);
                     isAdded = false;
                 }
             }

--- a/Gum/Plugins/InternalPlugins/Behaviors/MainBehaviorsPlugin.cs
+++ b/Gum/Plugins/InternalPlugins/Behaviors/MainBehaviorsPlugin.cs
@@ -45,7 +45,6 @@ public class MainBehaviorsPlugin : InternalPlugin
         control = new BehaviorsControl();
         control.DataContext = viewModel;
         behaviorsTab = this.CreateTab(control, "Behaviors", TabLocation.CenterBottom);
-        behaviorsTab.Hide();
 
         stateDataUiGrid = new DataUiGrid();
         AssignEvents();

--- a/Gum/Plugins/InternalPlugins/Errors/MainErrorsPlugin.cs
+++ b/Gum/Plugins/InternalPlugins/Errors/MainErrorsPlugin.cs
@@ -36,7 +36,7 @@ public class MainErrorsPlugin : InternalPlugin
     {
         control = new ErrorDisplay();
         control.DataContext = viewModel;
-        tabPage = _guiCommands.AddControl(control, "Errors", TabLocation.RightBottom);
+        tabPage = _tabManager.AddControl(control, "Errors", TabLocation.RightBottom);
 
         _tabPageHeader = new ErrorTabHeader();
         tabPage.TabItem.Header = _tabPageHeader;

--- a/Gum/Plugins/InternalPlugins/FileWatchPlugin/MainFileWatchPlugin.cs
+++ b/Gum/Plugins/InternalPlugins/FileWatchPlugin/MainFileWatchPlugin.cs
@@ -41,7 +41,7 @@ public class MainFileWatchPlugin : InternalPlugin
         _fileWatchLogic = FileWatchLogic.Self;
         _guiCommands = Locator.GetRequiredService<GuiCommands>();
 
-        pluginTab = _guiCommands.AddControl(control, "File Watch", TabLocation.RightBottom);
+        pluginTab = _tabManager.AddControl(control, "File Watch", TabLocation.RightBottom);
         pluginTab.Hide();
 
         pluginTab.TabHidden += HandleTabHidden;
@@ -117,7 +117,7 @@ public class MainFileWatchPlugin : InternalPlugin
 
     private void HandleShowFileWatch(object sender, EventArgs e)
     {
-        var isShown = _guiCommands.IsTabVisible(pluginTab);
+        var isShown = _tabManager.IsTabVisible(pluginTab);
         if(isShown)
         {
             pluginTab.Hide();

--- a/Gum/Plugins/InternalPlugins/Hotkey/MainHotkeyPlugin.cs
+++ b/Gum/Plugins/InternalPlugins/Hotkey/MainHotkeyPlugin.cs
@@ -41,7 +41,7 @@ namespace Gum.Plugins.InternalPlugins.Hotkey
 
         private void HandleToggleTabVisibility(object sender, EventArgs e)
         {
-            if(!_guiCommands.IsTabVisible(pluginTab))
+            if(!_tabManager.IsTabVisible(pluginTab))
             {
                 pluginTab.Show();
             } 

--- a/Gum/Plugins/InternalPlugins/Output/MainOutputPlugin.cs
+++ b/Gum/Plugins/InternalPlugins/Output/MainOutputPlugin.cs
@@ -27,7 +27,7 @@ namespace Gum.Plugins.Output
             outputTextBox.TabIndex = 0;
             outputTextBox.Text = "";
 
-            _guiCommands.AddWinformsControl(outputTextBox, "Output", TabLocation.RightBottom);
+            _tabManager.AddControl(outputTextBox, "Output", TabLocation.RightBottom);
             OutputManager.Self.Initialize(outputTextBox);
         }
     }

--- a/Gum/Plugins/InternalPlugins/ProjectPropertiesWindowPlugin/MainPropertiesWindowPlugin.cs
+++ b/Gum/Plugins/InternalPlugins/ProjectPropertiesWindowPlugin/MainPropertiesWindowPlugin.cs
@@ -41,12 +41,14 @@ class MainPropertiesWindowPlugin : InternalPlugin
     private readonly FontManager _fontManager;
     private readonly WireframeCommands _wireframeCommands;
     private readonly IDialogService _dialogService;
+    private readonly ITabManager _tabManager;
 
     public MainPropertiesWindowPlugin()
     {
         _fontManager = Locator.GetRequiredService<FontManager>();
         _wireframeCommands = Locator.GetRequiredService<WireframeCommands>();
         _dialogService = Locator.GetRequiredService<IDialogService>();
+        _tabManager = Locator.GetRequiredService<ITabManager>();
     }
 
     public override void StartUp()
@@ -82,14 +84,14 @@ class MainPropertiesWindowPlugin : InternalPlugin
 
             viewModel.SetFrom(ProjectManager.Self.GeneralSettingsFile, ProjectState.Self.GumProjectSave);
             var wasShown = 
-                _guiCommands.ShowTabForControl(control);
+                _tabManager.ShowTabForControl(control);
 
             if(!wasShown)
             {
-                var tab = _guiCommands.AddControl(control, "Project Properties");
+                var tab = _tabManager.AddControl(control, "Project Properties");
                 tab.CanClose = true;
                 control.ViewModel = viewModel;
-                _guiCommands.ShowTabForControl(control);
+                _tabManager.ShowTabForControl(control);
             }
         }
         catch (Exception ex)
@@ -222,6 +224,6 @@ class MainPropertiesWindowPlugin : InternalPlugin
 
     private void HandleCloseClicked(object sender, EventArgs e)
     {
-        _guiCommands.RemoveControl(control);
+        _tabManager.RemoveControl(control);
     }
 }

--- a/Gum/Plugins/InternalPlugins/StatePlugin/MainStatePlugin.cs
+++ b/Gum/Plugins/InternalPlugins/StatePlugin/MainStatePlugin.cs
@@ -101,7 +101,7 @@ public class MainStatePlugin : InternalPlugin
         stateTreeView = new StateTreeView(stateTreeViewModel, _stateTreeViewRightClickService, _hotkeyManager, _selectedState);
         _stateTreeViewRightClickService.SetMenuStrip(stateTreeView.TreeViewContextMenu, stateTreeView);
         
-        newPluginTab = _guiCommands.AddControl(stateTreeView, "States", TabLocation.CenterTop);
+        newPluginTab = _tabManager.AddControl(stateTreeView, "States", TabLocation.CenterTop);
     }
 
     #endregion

--- a/Gum/Plugins/InternalPlugins/TreeView/ElementTreeViewManager.cs
+++ b/Gum/Plugins/InternalPlugins/TreeView/ElementTreeViewManager.cs
@@ -114,6 +114,7 @@ public partial class ElementTreeViewManager
     private readonly IDialogService _dialogService;
     private readonly FileCommands _fileCommands;
     private readonly HotkeyManager _hotkeyManager;
+    private readonly ITabManager _tabManager;
 
     public const int TransparentImageIndex = 0;
     public const int FolderImageIndex = 1;
@@ -280,6 +281,7 @@ public partial class ElementTreeViewManager
         _dialogService = Locator.GetRequiredService<IDialogService>();
         _fileCommands = Locator.GetRequiredService<FileCommands>();
         _hotkeyManager = Locator.GetRequiredService<HotkeyManager>();
+        _tabManager = Locator.GetRequiredService<ITabManager>();
         
         TreeNodeExtensionMethods.ElementTreeViewManager = this;
     }
@@ -524,7 +526,7 @@ public partial class ElementTreeViewManager
             new System.Windows.Controls.RowDefinition() 
             { Height = new System.Windows.GridLength(1, System.Windows.GridUnitType.Star) });
 
-        _guiCommands.AddControl(grid, "Project", TabLocation.Left);
+        _tabManager.AddControl(grid, "Project", TabLocation.Left);
 
         ObjectTreeView.Dock = DockStyle.Fill;
         //panel.Controls.Add(ObjectTreeView);

--- a/Gum/Plugins/InternalPlugins/Undos/MainPlugin.cs
+++ b/Gum/Plugins/InternalPlugins/Undos/MainPlugin.cs
@@ -15,7 +15,7 @@ namespace Gum.Plugins.Undos
 
             control.DataContext = new UndosViewModel();
 
-            _guiCommands.AddControl(control, "History", TabLocation.RightBottom);
+            _tabManager.AddControl(control, "History", TabLocation.RightBottom);
 
         }
     }

--- a/Gum/Plugins/InternalPlugins/VariableGrid/PropertyGridManager.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/PropertyGridManager.cs
@@ -34,6 +34,7 @@ public partial class PropertyGridManager
     private readonly SetVariableLogic _setVariableLogic;
     private readonly IDialogService _dialogService;
     private readonly LocalizationManager _localizationManager;
+    private readonly ITabManager _tabManager;
     
     WpfDataUi.DataUiGrid mVariablesDataGrid;
     MainPropertyGrid mainControl;
@@ -113,6 +114,7 @@ public partial class PropertyGridManager
         _dialogService = Locator.GetRequiredService<IDialogService>();
         _fileCommands = Locator.GetRequiredService<FileCommands>();
         _localizationManager = Locator.GetRequiredService<LocalizationManager>();
+        _tabManager = Locator.GetRequiredService<ITabManager>();
     }
 
     // Normally plugins will initialize through the PluginManager. This needs to happen earlier (see where it's called for info)
@@ -129,7 +131,7 @@ public partial class PropertyGridManager
 
         mainControl = new Gum.MainPropertyGrid();
 
-        _guiCommands.AddControl(mainControl, "Variables", TabLocation.CenterBottom);
+        _tabManager.AddControl(mainControl, "Variables", TabLocation.CenterBottom);
 
         mVariablesDataGrid = mainControl.DataGrid;
 

--- a/Gum/Plugins/PluginTab.cs
+++ b/Gum/Plugins/PluginTab.cs
@@ -1,12 +1,13 @@
 ﻿using System;
 using Gum.Commands;
+using Gum.Managers;
 using Gum.Services;
 
 namespace Gum.Plugins
 {
     public class PluginTab
     {
-        private readonly GuiCommands _guiCommands;
+        private readonly ITabManager _tabManager;
         
         public string Title
         {
@@ -41,7 +42,7 @@ namespace Gum.Plugins
 
         public PluginTab()
         {
-            _guiCommands = Locator.GetRequiredService<GuiCommands>();
+            _tabManager = Locator.GetRequiredService<ITabManager>();
         }
 
         private void HandleMiddleMouseClicked()
@@ -52,8 +53,8 @@ namespace Gum.Plugins
             }
         }
 
-        public void Show(bool focus = true) => _guiCommands.ShowTab(this, focus);
-        public void Hide() => _guiCommands.HideTab(this);
+        public void Show(bool focus = true) => _tabManager.ShowTab(this, focus);
+        public void Hide() => _tabManager.HideTab(this);
 
         public void RaiseTabShown() => TabShown?.Invoke();
         public event Action TabShown;
@@ -65,7 +66,7 @@ namespace Gum.Plugins
         public void Focus() => TabItem.Focus();
 
         public bool IsFocused =>
-            _guiCommands.IsTabFocused(this);
+            _tabManager.IsTabFocused(this);
 
         public bool CanClose { get; set; }
     }

--- a/PerformanceMeasurementPlugin/MainPlugin.cs
+++ b/PerformanceMeasurementPlugin/MainPlugin.cs
@@ -46,7 +46,7 @@ namespace PerformanceMeasurementPlugin
 
         public override bool ShutDown(Gum.Plugins.PluginShutDownReason shutDownReason)
         {
-            _guiCommands.RemoveControl(view);
+            _tabManager.RemoveControl(view);
             return true;
         }
     }

--- a/StateAnimationPlugin/MainStateAnimationPlugin.cs
+++ b/StateAnimationPlugin/MainStateAnimationPlugin.cs
@@ -126,7 +126,7 @@ public class MainStateAnimationPlugin : PluginBase
     {
         RefreshViewModel();
 
-        if (element != null && !_guiCommands.IsTabVisible(pluginTab))
+        if (element != null && !_tabManager.IsTabVisible(pluginTab))
         {
             var fileName = _animationFilePathService.GetAbsoluteAnimationFileNameFor(element);
 
@@ -249,7 +249,7 @@ public class MainStateAnimationPlugin : PluginBase
 
     private void HandleToggleTabVisibility(object sender, EventArgs e)
     {
-        if (!_guiCommands.IsTabVisible(pluginTab))
+        if (!_tabManager.IsTabVisible(pluginTab))
         {
             pluginTab.Show();
         }
@@ -277,11 +277,11 @@ public class MainStateAnimationPlugin : PluginBase
             mMainWindow.AnimationColumnsResized += HandleAnimationColumnsResized;
         }
 
-        var wasShown = _guiCommands.ShowTabForControl(mMainWindow);
+        var wasShown = _tabManager.ShowTabForControl(mMainWindow);
 
         if (!wasShown)
         {
-            pluginTab = _guiCommands.AddControl(mMainWindow, "Animations",
+            pluginTab = _tabManager.AddControl(mMainWindow, "Animations",
                 TabLocation.RightBottom);
 
             pluginTab.TabShown += HandleTabShown;

--- a/TextureCoordinateSelectionPlugin/Logic/ControlLogic.cs
+++ b/TextureCoordinateSelectionPlugin/Logic/ControlLogic.cs
@@ -38,6 +38,7 @@ public class ControlLogic : Singleton<ControlLogic>
     private readonly GuiCommands _guiCommands;
     private readonly FileCommands _fileCommands;
     private readonly SetVariableLogic _setVariableLogic;
+    private readonly ITabManager _tabManager;
     
     LineRectangle textureOutlineRectangle = null;
 
@@ -77,6 +78,7 @@ public class ControlLogic : Singleton<ControlLogic>
         _guiCommands = Locator.GetRequiredService<GuiCommands>();
         _fileCommands = Locator.GetRequiredService<FileCommands>();
         _setVariableLogic = Locator.GetRequiredService<SetVariableLogic>();
+        _tabManager = Locator.GetRequiredService<ITabManager>();
     }
 
     public PluginTab CreateControl()
@@ -108,7 +110,7 @@ public class ControlLogic : Singleton<ControlLogic>
 
         //_guiCommands.AddWinformsControl(control, "Texture Coordinates", TabLocation.Right);
 
-        var pluginTab = _guiCommands.AddControl(mainControl, "Texture Coordinates", TabLocation.RightBottom);
+        var pluginTab = _tabManager.AddControl(mainControl, "Texture Coordinates", TabLocation.RightBottom);
         innerControl.DoubleClick += (not, used) =>
             HandleRegionDoubleClicked(innerControl, ref textureOutlineRectangle);
 

--- a/Tool/EditorTabPlugin_XNA/MainEditorTabPlugin.cs
+++ b/Tool/EditorTabPlugin_XNA/MainEditorTabPlugin.cs
@@ -899,7 +899,7 @@ internal class MainEditorTabPlugin : InternalPlugin
         // be added to the gumEditorPanel 2nd, no idea why
         CreateWireframeEditControl(gumEditorPanel);
 
-        _guiCommands.AddControl(gumEditorPanel, "Editor", TabLocation.RightTop);
+        _tabManager.AddControl(gumEditorPanel, "Editor", TabLocation.RightTop);
 
         _wireframeControl.XnaUpdate += () =>
         {


### PR DESCRIPTION
- Add ITabManager dependency to PluginBase and inject it
- Update all plugins to use _tabManager instead of _guiCommands
- This separates tab management from other GUI operations
- Prepares for MVVM-based tab management implementation
- Remove all tab-related methods from GuiCommands class
- Tab management is now exclusively handled by ITabManager
- Clean separation of concerns between GUI commands and tab management