### PR TITLE
Remove MainPanel references in GuiCommands related to tools visibility

### DIFF
--- a/Gum/Commands/GuiCommands.cs
+++ b/Gum/Commands/GuiCommands.cs
@@ -61,12 +61,6 @@ public class GuiCommands
             _selectedState.SelectedElement);
     }
 
-    internal void BroadcastBehaviorReferencesChanged()
-    {
-        PluginManager.Self.BehaviorReferencesChanged(
-            _selectedState.SelectedElement);
-    }
-
     #region Refresh Commands
 
     internal void RefreshStateTreeView()
@@ -137,13 +131,6 @@ public class GuiCommands
 
     #region Move to Cursor
 
-    public void PositionWindowByCursor(System.Windows.Forms.Form window)
-    {
-        var mousePosition = GetMousePosition();
-
-        window.Location = new System.Drawing.Point(mousePosition.X - window.Width / 2, mousePosition.Y - window.Height / 2);
-    }
-
     public void MoveToCursor(System.Windows.Window window)
     {
         window.WindowStartupLocation = System.Windows.WindowStartupLocation.Manual;
@@ -191,17 +178,6 @@ public class GuiCommands
     {
         return MainWindow.MousePosition;
     }
-
-    public void HideTools()
-    {
-        mainPanelControl.HideTools();
-    }
-
-    public void ShowTools()
-    {
-        mainPanelControl.ShowTools();
-    }
-
 
     public void ToggleToolVisibility()
     {

--- a/Gum/Controls/MainPanelControl.xaml.cs
+++ b/Gum/Controls/MainPanelControl.xaml.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Data;
 using System.Windows.Input;
 
 namespace Gum.Controls;
@@ -13,6 +14,26 @@ namespace Gum.Controls;
 /// </summary>
 public partial class MainPanelControl : UserControl
 {
+    public static readonly DependencyProperty IsToolsVisibleProperty = DependencyProperty.Register(
+        nameof(IsToolsVisible), typeof(bool), typeof(MainPanelControl), new PropertyMetadata(true, static (o, args) =>
+        {
+            MainPanelControl mainPanelControl = (MainPanelControl)o;
+            if (args.NewValue is true)
+            {
+                mainPanelControl.ShowTools();
+            }
+            else
+            {
+                mainPanelControl.HideTools();
+            }
+        }));
+
+    public bool IsToolsVisible
+    {
+        get { return (bool)GetValue(IsToolsVisibleProperty); }
+        set { SetValue(IsToolsVisibleProperty, value); }
+    }
+    
     GridLength expandedLeftColumnLength;
     GridLength expandedMiddleColumnLength;
     GridLength bottomRowLength;
@@ -26,6 +47,7 @@ public partial class MainPanelControl : UserControl
     {
         InitializeComponent();
         DataContext = viewModel;
+        SetBinding(IsToolsVisibleProperty, new Binding(nameof(viewModel.IsToolsVisible)));
         _hotkeyManager = hotkeyManager;
         this.KeyDown += HandleKeyDown;
     }
@@ -35,7 +57,7 @@ public partial class MainPanelControl : UserControl
         _hotkeyManager.HandleKeyDownAppWide(e);
     }
     
-    public void HideTools()
+    private void HideTools()
     {
         if(!isHidden)
         {
@@ -58,7 +80,7 @@ public partial class MainPanelControl : UserControl
         }
     }
 
-    public void ShowTools()
+    private void ShowTools()
     {
         if(isHidden)
         {

--- a/Gum/Plugins/InternalPlugins/HideShowTools/MainHideShowToolsPlugin.cs
+++ b/Gum/Plugins/InternalPlugins/HideShowTools/MainHideShowToolsPlugin.cs
@@ -6,6 +6,8 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Forms;
+using Gum.Controls;
+using Gum.Services;
 
 namespace Gum.Plugins.InternalPlugins.HideShowTools;
 
@@ -13,8 +15,13 @@ namespace Gum.Plugins.InternalPlugins.HideShowTools;
 internal class MainHideShowToolsPlugin : InternalPlugin
 {
     private ToolStripMenuItem menuItem;
-    bool areToolsVisible = true;
+    private readonly MainPanelViewModel _mainPanelViewModel;
 
+    public MainHideShowToolsPlugin()
+    {
+        _mainPanelViewModel = Locator.GetRequiredService<MainPanelViewModel>();
+    }
+    
     public override void StartUp()
     {
         menuItem = AddMenuItem("View", "Hide Tools");
@@ -23,18 +30,7 @@ internal class MainHideShowToolsPlugin : InternalPlugin
 
     private void HandleMenuItemClick(object sender, EventArgs e)
     {
-        if (areToolsVisible)
-        {
-            menuItem.Text = "Show Tools";
-            _guiCommands.HideTools();
-            areToolsVisible = false;
-
-        }
-        else
-        {
-            menuItem.Text = "Hide Tools";
-            _guiCommands.ShowTools();
-            areToolsVisible = true;
-        }
+        _mainPanelViewModel.IsToolsVisible = !_mainPanelViewModel.IsToolsVisible;
+        menuItem.Text = _mainPanelViewModel.IsToolsVisible ? "Hide Tools" : "Show Tools";
     }
 }

--- a/Gum/ViewModels/MainPanelViewModel.cs
+++ b/Gum/ViewModels/MainPanelViewModel.cs
@@ -23,8 +23,16 @@ public class MainPanelViewModel : ViewModel, ITabManager
     public PluginTabContainerViewModel LeftContainer { get; }
     public PluginTabContainerViewModel CenterContainer { get; }
 
+    public bool IsToolsVisible
+    {
+        get => Get<bool>();
+        set => Set(value);
+    }
+
     public MainPanelViewModel(Func<TabLocation, PluginTabContainerViewModel> tabContainerFactory)
     {
+        IsToolsVisible = true;
+        
         TabContainers =
         [
             CenterBottomContainer = tabContainerFactory(TabLocation.CenterBottom),


### PR DESCRIPTION
Uses data binding for tool visibility
Removes direct calls to show/hide the tools panel.

Instead, introduces a dependency property bound to the view model. This allows plugins to toggle the tools panel's visibility through the view model, improving maintainability and decoupling.
