### PR TITLE
1242: fix ui scaling

### DIFF
--- a/Gum/Controls/MainPanelControl.xaml
+++ b/Gum/Controls/MainPanelControl.xaml
@@ -9,18 +9,41 @@
              d:DataContext="{d:DesignInstance Type=local:MainPanelViewModel}">
     <UserControl.Resources>
         <ResourceDictionary>
-            <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter"></BooleanToVisibilityConverter>
+            <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
+            <local:PluginTabHeaderTemplateSelector x:Key="TabHeaderTemplateSelector" />
+            
+            <!-- When CustomHeaderContent exists, just present it -->
+            <DataTemplate x:Key="TabCustomHeaderTemplate">
+                <ContentPresenter Content="{Binding}" />
+            </DataTemplate>
+
+            <!-- Fallback to Title on the TabItem's DataContext -->
+            <DataTemplate x:Key="TabTitleHeaderTemplate">
+                <TextBlock Text="{Binding DataContext.Title,
+                                  RelativeSource={RelativeSource AncestorType=TabItem}}"/>
+            </DataTemplate>
+
+            <local:PluginTabHeaderTemplateSelector
+                x:Key="PluginTabHeaderSelector"
+                CustomHeaderTemplate="{StaticResource TabCustomHeaderTemplate}"
+                TitleHeaderTemplate="{StaticResource TabTitleHeaderTemplate}" />
+            
             <Style x:Key="PluginTabStyle" TargetType="{x:Type TabItem}" BasedOn="{StaticResource {x:Type TabItem}}">
-                <Setter Property="Content" Value="{Binding Content}"/>
                 <Setter Property="Header" Value="{Binding CustomHeaderContent}"/>
+                <Setter Property="HeaderTemplateSelector" Value="{StaticResource PluginTabHeaderSelector}"/>
+                
+                <Setter Property="ContentTemplate">
+                    <Setter.Value>
+                        <DataTemplate>
+                            <ContentPresenter Content="{Binding Content}" />
+                        </DataTemplate>
+                    </Setter.Value>
+                </Setter>
+                
                 <Setter Property="Visibility" Value="{Binding IsVisible, Converter={StaticResource BooleanToVisibilityConverter}}"/>
                 <EventSetter Event="MouseDown" Handler="TabHeader_OnMiddleMouseDown"></EventSetter>
-                <Style.Triggers>
-                    <DataTrigger Binding="{Binding CustomHeaderContent}" Value="{x:Null}">
-                        <Setter Property="Header" Value="{Binding Title, FallbackValue='Untitled'}"></Setter>
-                    </DataTrigger>
-                </Style.Triggers>
             </Style>
+            
             <Style x:Key="PluginTabControlStyle" TargetType="{x:Type TabControl}" BasedOn="{StaticResource {x:Type TabControl}}">
                 <Setter Property="ItemContainerStyle" Value="{StaticResource PluginTabStyle}" />
                 <Setter Property="SelectedIndex" Value="{Binding SelectedTabIndex}"/>

--- a/Gum/Controls/MainPanelControl.xaml.cs
+++ b/Gum/Controls/MainPanelControl.xaml.cs
@@ -84,3 +84,14 @@ public partial class MainPanelControl : UserControl
         }
     }
 }
+
+public class PluginTabHeaderTemplateSelector : DataTemplateSelector
+{
+    public DataTemplate? CustomHeaderTemplate { get; set; }
+    public DataTemplate? TitleHeaderTemplate { get; set; }
+
+    public override DataTemplate SelectTemplate(object item, DependencyObject container)
+    {
+        return item != null ? CustomHeaderTemplate! : TitleHeaderTemplate!;
+    }
+}


### PR DESCRIPTION
fixes #1242

- Use templates to present tab related content
Straight assigning the Content/Header breaks normal property value inheritance because they were created outside the logical tree.
