### PR TITLE
1221 treat spaces as underscores in category name verification

### DIFF
--- a/Gum/DataTypes/ElementSaveExtensionMethods.cs
+++ b/Gum/DataTypes/ElementSaveExtensionMethods.cs
@@ -281,22 +281,22 @@ namespace Gum.DataTypes
             return null;
         }
 
+        public static StateSaveCategory GetStateSaveCategoryRecursively(this ElementSave element, Func<StateSaveCategory, bool> condition) =>
+            GetStateSaveCategoryRecursively(element, condition, out ElementSave? _);
+        
         public static StateSaveCategory GetStateSaveCategoryRecursively(this ElementSave element, string categoryName) =>
             GetStateSaveCategoryRecursively(element, categoryName, out ElementSave? _);
 
-        public static StateSaveCategory GetStateSaveCategoryRecursively(this ElementSave element, string categoryName, 
+        public static StateSaveCategory GetStateSaveCategoryRecursively(this ElementSave element, string categoryName, out ElementSave? categoryContainer) => 
+            GetStateSaveCategoryRecursively(element, item => item.Name == categoryName, out categoryContainer);
+        
+        /// <returns>
+        /// The first category of this element that meets the given <paramref name="condition"/>.
+        /// </returns>
+        public static StateSaveCategory GetStateSaveCategoryRecursively(this ElementSave element, Func<StateSaveCategory, bool> condition, 
             out ElementSave? categoryContainer)
         {
-
-            StateSaveCategory? foundCategory = null;
-            foreach(var item in element.Categories)
-            {
-                if( item.Name == categoryName)
-                {
-                    foundCategory = item;
-                    break;
-                }
-            }
+            StateSaveCategory? foundCategory = element.Categories.FirstOrDefault(condition);
 
             if (foundCategory != null)
             {
@@ -315,13 +315,12 @@ namespace Gum.DataTypes
                 }
                 else
                 {
-                    return baseElement.GetStateSaveCategoryRecursively(categoryName, out categoryContainer);
+                    return baseElement.GetStateSaveCategoryRecursively(condition, out categoryContainer);
                 }
             }
 
             categoryContainer = null;
             return null;
-        }
-
+        }        
     }
 }

--- a/Gum/DataTypes/ElementSaveExtensionMethods.cs
+++ b/Gum/DataTypes/ElementSaveExtensionMethods.cs
@@ -281,45 +281,45 @@ namespace Gum.DataTypes
             return null;
         }
 
-        public static StateSaveCategory GetStateSaveCategoryRecursively(this ElementSave element, Func<StateSaveCategory, bool> condition) =>
-            GetStateSaveCategoryRecursively(element, condition, out ElementSave? _);
+        public static StateSaveCategory? GetStateSaveCategoryRecursively(this IStateContainer element, Func<StateSaveCategory, bool> condition) =>
+            GetStateSaveCategoryRecursively(element, condition, out IStateContainer? _);
         
-        public static StateSaveCategory GetStateSaveCategoryRecursively(this ElementSave element, string categoryName) =>
-            GetStateSaveCategoryRecursively(element, categoryName, out ElementSave? _);
+        public static StateSaveCategory? GetStateSaveCategoryRecursively(this IStateContainer element, string categoryName) =>
+            GetStateSaveCategoryRecursively(element, categoryName, out IStateContainer? _);
 
-        public static StateSaveCategory GetStateSaveCategoryRecursively(this ElementSave element, string categoryName, out ElementSave? categoryContainer) => 
+        public static StateSaveCategory? GetStateSaveCategoryRecursively(this IStateContainer element, string categoryName, out IStateContainer? categoryContainer) => 
             GetStateSaveCategoryRecursively(element, item => item.Name == categoryName, out categoryContainer);
         
         /// <returns>
         /// The first category of this element that meets the given <paramref name="condition"/>.
         /// </returns>
-        public static StateSaveCategory GetStateSaveCategoryRecursively(this ElementSave element, Func<StateSaveCategory, bool> condition, 
-            out ElementSave? categoryContainer)
+        public static StateSaveCategory? GetStateSaveCategoryRecursively(this IStateContainer stateContainer, Func<StateSaveCategory, bool> condition, 
+            out IStateContainer? foundStateContainer)
         {
-            StateSaveCategory? foundCategory = element.Categories.FirstOrDefault(condition);
+            StateSaveCategory? foundCategory = stateContainer.Categories.FirstOrDefault(condition);
 
             if (foundCategory != null)
             {
-                categoryContainer = element;
+                foundStateContainer = stateContainer;
                 return foundCategory;
             }
 
-            if (!string.IsNullOrEmpty(element.BaseType))
+            if (stateContainer is ElementSave elementSave && !string.IsNullOrEmpty(elementSave.BaseType))
             {
-                var baseElement = ObjectFinder.Self.GetElementSave(element.BaseType);
+                var baseElement = ObjectFinder.Self.GetElementSave(elementSave.BaseType);
 
                 if(baseElement == null)
                 {
-                    categoryContainer = null;
+                    foundStateContainer = null;
                     return null;
                 }
                 else
                 {
-                    return baseElement.GetStateSaveCategoryRecursively(condition, out categoryContainer);
+                    return baseElement.GetStateSaveCategoryRecursively(condition, out foundStateContainer);
                 }
             }
 
-            categoryContainer = null;
+            foundStateContainer = null;
             return null;
         }        
     }

--- a/Gum/DataTypes/VariableSaveExtensionMethods.cs
+++ b/Gum/DataTypes/VariableSaveExtensionMethods.cs
@@ -139,8 +139,9 @@ namespace Gum.DataTypes
                             }
                             else
                             {
-
-                                category = element.GetStateSaveCategoryRecursively(categoryName, out categoryContainer);
+                                
+                                category = element.GetStateSaveCategoryRecursively(categoryName, out IStateContainer foundCategoryContainer);
+                                categoryContainer = foundCategoryContainer as ElementSave;
                                 return category != null;
                             }
                         }
@@ -156,7 +157,8 @@ namespace Gum.DataTypes
                 else
                 {
 
-                    category = container.GetStateSaveCategoryRecursively(categoryName, out categoryContainer);
+                    category = container.GetStateSaveCategoryRecursively(categoryName, out IStateContainer foundCategoryContainer);
+                    categoryContainer = foundCategoryContainer as ElementSave;
 
                     return category != null;
                 }

--- a/Gum/Dialogs/AddCategoryDialogViewModel.cs
+++ b/Gum/Dialogs/AddCategoryDialogViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using Gum.DataTypes;
 using Gum.DataTypes.Variables;
+using Gum.Managers;
 using Gum.Services.Dialogs;
 using Gum.ToolCommands;
 using Gum.ToolStates;
@@ -14,17 +15,20 @@ public class AddCategoryDialogViewModel : GetUserStringDialogBaseViewModel
     
     private readonly ElementCommands _elementCommands;
     private readonly UndoManager _undoManager;
+    private readonly NameVerifier _nameVerifier;
     private readonly ISelectedState _selectedState;
     private IStateContainer StateContainer => _selectedState.SelectedStateContainer;
 
     public AddCategoryDialogViewModel(
         ISelectedState selectedState,
         ElementCommands elementCommands,
-        UndoManager undoManager)
+        UndoManager undoManager,
+        NameVerifier nameVerifier)
     {
         _selectedState = selectedState;
         _elementCommands = elementCommands;
         _undoManager = undoManager;
+        _nameVerifier = nameVerifier;
     }
 
     protected override void OnAffirmative()
@@ -40,13 +44,8 @@ public class AddCategoryDialogViewModel : GetUserStringDialogBaseViewModel
 
     protected override string? Validate(string? value)
     {
-        
-        if (StateContainer is ElementSave element &&
-            element.GetStateSaveCategoryRecursively(value, out ElementSave categoryContainer) is not null)
-        {
-            return
-                $"Cannot add category - a category with the name {value} is already defined in {categoryContainer}";
-        }
+        if (StateContainer is ElementSave element && _nameVerifier.IsCategoryNameValid(value, element, out string whyNotValid))
+            return whyNotValid;
 
         return base.Validate(value);
     }

--- a/Gum/Dialogs/AddCategoryDialogViewModel.cs
+++ b/Gum/Dialogs/AddCategoryDialogViewModel.cs
@@ -13,17 +13,17 @@ public class AddCategoryDialogViewModel : GetUserStringDialogBaseViewModel
     public override string Title => "New Category";
     public override string Message => "Enter new Category name";
     
-    private readonly ElementCommands _elementCommands;
-    private readonly UndoManager _undoManager;
-    private readonly NameVerifier _nameVerifier;
+    private readonly IElementCommands _elementCommands;
+    private readonly IUndoManager _undoManager;
+    private readonly INameVerifier _nameVerifier;
     private readonly ISelectedState _selectedState;
     private IStateContainer StateContainer => _selectedState.SelectedStateContainer;
 
     public AddCategoryDialogViewModel(
         ISelectedState selectedState,
-        ElementCommands elementCommands,
-        UndoManager undoManager,
-        NameVerifier nameVerifier)
+        IElementCommands elementCommands,
+        IUndoManager undoManager,
+        INameVerifier nameVerifier)
     {
         _selectedState = selectedState;
         _elementCommands = elementCommands;
@@ -44,8 +44,10 @@ public class AddCategoryDialogViewModel : GetUserStringDialogBaseViewModel
 
     protected override string? Validate(string? value)
     {
-        if (StateContainer is ElementSave element && !_nameVerifier.IsCategoryNameValid(value, element, out string whyNotValid))
+        if (!_nameVerifier.IsCategoryNameValid(value, StateContainer, out string whyNotValid))
+        {
             return whyNotValid;
+        }
 
         return base.Validate(value);
     }

--- a/Gum/Dialogs/AddCategoryDialogViewModel.cs
+++ b/Gum/Dialogs/AddCategoryDialogViewModel.cs
@@ -44,7 +44,7 @@ public class AddCategoryDialogViewModel : GetUserStringDialogBaseViewModel
 
     protected override string? Validate(string? value)
     {
-        if (StateContainer is ElementSave element && _nameVerifier.IsCategoryNameValid(value, element, out string whyNotValid))
+        if (StateContainer is ElementSave element && !_nameVerifier.IsCategoryNameValid(value, element, out string whyNotValid))
             return whyNotValid;
 
         return base.Validate(value);

--- a/Gum/Managers/INameVerifier.cs
+++ b/Gum/Managers/INameVerifier.cs
@@ -1,0 +1,12 @@
+﻿using Gum.DataTypes;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Gum.Managers;
+public interface INameVerifier
+{
+    bool IsCategoryNameValid(string name, IStateContainer categoryContainer, out string whyNotValid);
+}

--- a/Gum/Managers/NameVerifier.cs
+++ b/Gum/Managers/NameVerifier.cs
@@ -82,12 +82,21 @@ namespace Gum.Managers
         internal bool IsCategoryNameValid(string name, ElementSave categoryContainer, out string whyNotValid)
         {
             string standardizedName = Standardize(name);
-            StateSaveCategory existingCategory = categoryContainer.GetStateSaveCategoryRecursively(
-                condition: item => Standardize(item.Name) == standardizedName
-            );
 
-            whyNotValid = $"Cannot add category — a category with the name {name} is already defined in {categoryContainer}";
-            return existingCategory != null;
+            string existingName = null;
+            StateSaveCategory existing = categoryContainer.GetStateSaveCategoryRecursively(item =>
+            {
+                if (Standardize(item.Name) == standardizedName)
+                {
+                    existingName = item.Name;
+                    return true;
+                }
+
+                return false;
+            });
+
+            whyNotValid = $"Cannot add category — a category with the name {existingName} is already defined in {categoryContainer}";
+            return existing != null;
         }
         internal bool IsStateNameValid(string name, StateSaveCategory category, StateSave stateSave, out string whyNotValid)
         {

--- a/Gum/Managers/NameVerifier.cs
+++ b/Gum/Managers/NameVerifier.cs
@@ -79,6 +79,16 @@ namespace Gum.Managers
             }
             return string.IsNullOrEmpty(whyNotValid);
         }
+        internal bool IsCategoryNameValid(string name, ElementSave categoryContainer, out string whyNotValid)
+        {
+            string standardizedName = Standardize(name);
+            StateSaveCategory existingCategory = categoryContainer.GetStateSaveCategoryRecursively(
+                condition: item => Standardize(item.Name) == standardizedName
+            );
+
+            whyNotValid = $"Cannot add category — a category with the name {name} is already defined in {categoryContainer}";
+            return existingCategory != null;
+        }
         internal bool IsStateNameValid(string name, StateSaveCategory category, StateSave stateSave, out string whyNotValid)
         {
             IsNameValidCommon(name, out whyNotValid);
@@ -258,14 +268,6 @@ namespace Gum.Managers
                 whyNotValid = "There is a screen named " + screen.Name + " so this name can't be used.";
             }
         }
-        private string Standardize(string name)
-        {
-            if (name == null) return null;
-
-            string formatted = name.Replace(" ", "_");
-            return formatted.ToLowerInvariant();
-        }
-
         public bool IsNameValidAndroidFile(string name, out string whyNotValid)
         {
             whyNotValid = null;
@@ -285,6 +287,13 @@ namespace Gum.Managers
                 //(c >= 'A' && c <= 'Z' && allowUpperCase) ||
                 (c == '_') ||
                 (c >= '0' && c <= '9');
+        }
+        private string Standardize(string name)
+        {
+            if (name == null) return null;
+
+            string formatted = name.Replace(" ", "_");
+            return formatted.ToLowerInvariant();
         }
     }
 }

--- a/Gum/Managers/NameVerifier.cs
+++ b/Gum/Managers/NameVerifier.cs
@@ -6,304 +6,309 @@ using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 using System.Linq;
-namespace Gum.Managers
+namespace Gum.Managers;
+
+public class NameVerifier : INameVerifier
 {
-    public class NameVerifier
-    {
-        #region Fields/Properties
-        public static char[] InvalidCharacters =
-                new char[] 
-            { 
-                '~', '`', '!', '@', '#', '$', '%', '^', '&', '*', 
-                '(', ')', '-', '=', '+', ';', '\'', ':', '"', '<', 
-                ',', '>', '.', '/', '\\', '?', '[', '{', ']', '}', 
-                '|', 
-                // Spaces are handled separately
-            //    ' ' 
-            };
-        public static HashSet<string> InvalidWindowsFileNames = new HashSet<string>
-        {
-            "con",
-            "prn",
-            "aux",
-            "nul",
-            "com0",
-            "com1",
-            "com2",
-            "com3",
-            "com4",
-            "com5",
-            "com6",
-            "com7",
-            "com8",
-            "com9",
-            "lpt0",
-            "lpt1",
-            "lpt2",
-            "lpt3",
-            "lpt4",
-            "lpt5",
-            "lpt6",
-            "lpt7",
-            "lpt8",
-            "lpt9",
+    #region Fields/Properties
+    public static char[] InvalidCharacters =
+            new char[] 
+        { 
+            '~', '`', '!', '@', '#', '$', '%', '^', '&', '*', 
+            '(', ')', '-', '=', '+', ';', '\'', ':', '"', '<', 
+            ',', '>', '.', '/', '\\', '?', '[', '{', ']', '}', 
+            '|', 
+            // Spaces are handled separately
+        //    ' ' 
         };
+    public static HashSet<string> InvalidWindowsFileNames = new HashSet<string>
+    {
+        "con",
+        "prn",
+        "aux",
+        "nul",
+        "com0",
+        "com1",
+        "com2",
+        "com3",
+        "com4",
+        "com5",
+        "com6",
+        "com7",
+        "com8",
+        "com9",
+        "lpt0",
+        "lpt1",
+        "lpt2",
+        "lpt3",
+        "lpt4",
+        "lpt5",
+        "lpt6",
+        "lpt7",
+        "lpt8",
+        "lpt9",
+    };
+    
+    private readonly StandardElementsManager _standardElementsManager;
+    #endregion
+    #region Folder
+    public bool IsFolderNameValid(string folderName, out string whyNotValid)
+    {
+        IsNameValidCommon(folderName, out whyNotValid);
+        return string.IsNullOrEmpty(whyNotValid);
+    }
+    #endregion
+    public NameVerifier()
+    {
+        _standardElementsManager = StandardElementsManager.Self;
+    }
+    public bool IsElementNameValid(string componentNameWithoutFolder, string folderName, ElementSave elementSave, out string whyNotValid)
+    {
+        IsNameValidCommon(componentNameWithoutFolder, out whyNotValid);
+        if (string.IsNullOrEmpty(whyNotValid))
+        {
+            IsFileNameWindowsReserved(componentNameWithoutFolder, out whyNotValid);
+        }
+        //if (string.IsNullOrEmpty(whyNotValid))
+        //{
+        //    IsNameValidVariable(componentName, out whyNotValid);
+        //}
+        if (string.IsNullOrEmpty(whyNotValid))
+        {
+            IsNameAnExistingElement(componentNameWithoutFolder, folderName, elementSave, out whyNotValid);
+        }
+        return string.IsNullOrEmpty(whyNotValid);
+    }
+    public bool IsCategoryNameValid(string name, IStateContainer categoryContainer, out string whyNotValid)
+    {
+        IsNameValidCommon(name, out whyNotValid);
+
+
+        string standardizedName = Standardize(name);
+        string? existingName = null;
+        StateSaveCategory? existing = categoryContainer.GetStateSaveCategoryRecursively(item =>
+        {
+            if (Standardize(item.Name) == standardizedName)
+            {
+                existingName = item.Name;
+                return true;
+            }
+
+            return false;
+        });
+
+        if (existingName != null)
+        {
+            whyNotValid = $"A category with the name {existingName} is already defined in {categoryContainer.Name}";
+        }
         
-        private readonly StandardElementsManager _standardElementsManager;
-        #endregion
-        #region Folder
-        public bool IsFolderNameValid(string folderName, out string whyNotValid)
-        {
-            IsNameValidCommon(folderName, out whyNotValid);
-            return string.IsNullOrEmpty(whyNotValid);
-        }
-        #endregion
-        public NameVerifier()
-        {
-            _standardElementsManager = StandardElementsManager.Self;
-        }
-        public bool IsElementNameValid(string componentNameWithoutFolder, string folderName, ElementSave elementSave, out string whyNotValid)
-        {
-            IsNameValidCommon(componentNameWithoutFolder, out whyNotValid);
-            if (string.IsNullOrEmpty(whyNotValid))
-            {
-                IsFileNameWindowsReserved(componentNameWithoutFolder, out whyNotValid);
-            }
-            //if (string.IsNullOrEmpty(whyNotValid))
-            //{
-            //    IsNameValidVariable(componentName, out whyNotValid);
-            //}
-            if (string.IsNullOrEmpty(whyNotValid))
-            {
-                IsNameAnExistingElement(componentNameWithoutFolder, folderName, elementSave, out whyNotValid);
-            }
-            return string.IsNullOrEmpty(whyNotValid);
-        }
-        internal bool IsCategoryNameValid(string name, ElementSave categoryContainer, out string whyNotValid)
-        {
-            whyNotValid = null;
-            
-            string standardizedName = Standardize(name);
-            string existingName = null;
-            StateSaveCategory existing = categoryContainer.GetStateSaveCategoryRecursively(item =>
-            {
-                if (Standardize(item.Name) == standardizedName)
-                {
-                    existingName = item.Name;
-                    return true;
-                }
 
-                return false;
-            });
+        return string.IsNullOrEmpty(whyNotValid);
+    }
+    internal bool IsStateNameValid(string name, StateSaveCategory category, StateSave stateSave, out string whyNotValid)
+    {
+        IsNameValidCommon(name, out whyNotValid);
+        if(string.IsNullOrEmpty(whyNotValid))
+        {
+            var existing = category?.States.Find(item => Standardize(item.Name) == Standardize(name) && item != stateSave);
+            if (existing != null)
+            {
+                whyNotValid = $"The category {category.Name} already has a state named {name}";
+            }
+        }
+        return string.IsNullOrEmpty(whyNotValid);
+    }
+    public bool IsInstanceNameValid(string instanceName, InstanceSave instanceSave, IInstanceContainer instanceContainer, out string whyNotValid)
+    {
+        IsNameValidCommon(instanceName, out whyNotValid);
+        //if (string.IsNullOrEmpty(whyNotValid))
+        //{
+        //    IsNameValidVariable(instanceName, out whyNotValid);
+        //}
+        // See if this is a variable used by any state in the StandardElementsManager:
+        if(string.IsNullOrEmpty(whyNotValid))
+        {
+            IsNameUsedByStandardVariables(instanceName, out whyNotValid);
+        }
+        if (string.IsNullOrEmpty(whyNotValid))
+        {
+            IsNameAlreadyUsed(instanceName, instanceSave, instanceContainer, out whyNotValid);
+        }
+        return string.IsNullOrEmpty(whyNotValid);
+    }
+    private void IsNameUsedByStandardVariables(string nameToCheck, out string whyNotValid)
+    {
+        var variables = _standardElementsManager.DefaultStates.SelectMany(item => item.Value.Variables);
+        var names = variables.Select(item => item.Name).ToHashSet();
+        whyNotValid = null;
+        if(names.Contains(nameToCheck))
+        {
+            whyNotValid = $"The name {nameToCheck} cannot be used because it is a reserved variable name";
+        }
+        else if(nameToCheck == "Name")
+        {
+            whyNotValid = $"\"Name\" is a reserved keyword so it cannot be used as a name";
+        }
+    }
+    public bool IsVariableNameValid(string variableName, ElementSave elementSave, VariableSave variableSave, out string whyNotValid)
+    {
+        whyNotValid = null;
+        IsNameValidCommon(variableName, out whyNotValid);
+        if (string.IsNullOrEmpty(whyNotValid) && elementSave != null)
+        {
+            IsNameAlreadyUsed(variableName, variableSave, elementSave, out whyNotValid);
+        }
+        if (string.IsNullOrEmpty(whyNotValid))
+        {
+            var existingVariable = elementSave?.GetVariableFromThisOrBase(variableName);
+            // there's a variable but we shouldn't consider it
+            // unless it's "Active" - inactive variables may be
+            // leftovers from a type change
+            if(existingVariable != null && elementSave != null)
+            {
+                var isActive = VariableSaveLogic.GetIfVariableIsActive(existingVariable,
+                    elementSave, null);
+                if(isActive)
+                {
+                    whyNotValid = $"The variable name {variableName} is already used";
+                }
+            }
+        }
+        return string.IsNullOrEmpty(whyNotValid);
+    }
+    public bool IsBehaviorNameValid(string behaviorName, BehaviorSave behaviorSave, out string whyNotValid)
+    {
+        IsNameValidCommon(behaviorName, out whyNotValid);
+        if (string.IsNullOrEmpty(whyNotValid))
+        {
+            IsFileNameWindowsReserved(behaviorName, out whyNotValid);
+        }
+        if (string.IsNullOrEmpty(whyNotValid))
+        {
+            // need to check for duplicate names eventually
+        }
+        return string.IsNullOrEmpty(whyNotValid);
+    }
+    private void IsNameValidCommon(string name, out string whyNotValid)
+    {
+        whyNotValid = null;
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            whyNotValid = "Empty names are not valid";
+        }
+        else if (name.IndexOfAny(InvalidCharacters) != -1)
+        {
+            whyNotValid = "The name can't contain invalid character " + name[name.IndexOfAny(InvalidCharacters)];
+        }
+        if(string.IsNullOrEmpty(whyNotValid) && name.StartsWith(" "))
+        {
+            whyNotValid = "The name can't begin with a space";
+        }
+        if (string.IsNullOrEmpty(whyNotValid) && name.EndsWith(" "))
+        {
+            whyNotValid = "The name can't end with a space";
+        }
+    }
+    private void IsNameValidVariable(string name, out string whyNotValid)
+    {
+        whyNotValid = null;
+        CodeDomProvider provider = CodeDomProvider.CreateProvider("C#");
+        if (provider.IsValidIdentifier(name) == false)
+        {
+            whyNotValid = "The name uses an invalid character";
+        }
+    }
+    private void IsFileNameWindowsReserved(string name, out string whyNotValid)
+    {
+        whyNotValid = null;
+        if (InvalidWindowsFileNames.Contains(name?.ToLower()))
+        {
+            whyNotValid = $"The name {name} is a reserved file name in Windows";
+        }
+    }
+    public bool IsComponentNameAlreadyUsed(string name)
+    {
+        return ObjectFinder.Self.GetComponent(name) != null;
+    }
+    private void IsNameAlreadyUsed(string name, object objectToIgnore, IInstanceContainer instanceContainer, out string whyNotValid)
+    {
+        whyNotValid = null;
+        if (objectToIgnore != instanceContainer && Standardize(name) == Standardize(instanceContainer.Name))
+        {
+            whyNotValid = $"The element is named '{instanceContainer.Name}'";
+        }
+        var instance = instanceContainer.Instances.FirstOrDefault(item => item != objectToIgnore && Standardize(item.Name) == Standardize(name));
+        if (instance != null)
+        {
+            whyNotValid = $"There is already an instance named '{instance.Name}'";
+        }
+        var stateContainer = instanceContainer as IStateContainer;
+        var state = stateContainer?.AllStates.FirstOrDefault(item => item != objectToIgnore && Standardize(item.Name) == Standardize(name));
+        if (state != null)
+        {
+            whyNotValid = $"There is already a state named '{state.Name}'";
+        }
+        
+        var variable = stateContainer?.AllStates
+                                      .SelectMany(item => item.Variables)
+                                      .FirstOrDefault(item => item != objectToIgnore && Standardize(item.ExposedAsName) == Standardize(name));
+        if (variable != null)
+        {
+            whyNotValid = $"There is already a variable named '{variable.Name}'";
+        }
+        //element = ObjectFinder.Self.GumProjectSave.StandardElements.FirstOrDefault(item=>item != objectToIgnore && item.Name == name)
+        //{
+        //    whyNotValid = "There is a standard element named " + element.Name + " so this name can't be used.";
+        //}
+    }
+    private void IsNameAnExistingElement(string name, string folderName, object objectToIgnore, out string whyNotValid)
+    {
+        whyNotValid = null;
+        string newStandardizedNameWithFolder = Standardize(folderName + name);
+        var standardElement = ObjectFinder.Self.GumProjectSave.StandardElements.FirstOrDefault(item =>
+            item != objectToIgnore && Standardize(item.Name) == newStandardizedNameWithFolder);
+        if (standardElement != null)
+        {
+            whyNotValid = "There is a standard element named " + standardElement.Name + " so this name can't be used.";
+        }
+        var component = ObjectFinder.Self.GumProjectSave.Components.FirstOrDefault(item =>
+            item != objectToIgnore && Standardize(item.Name) == newStandardizedNameWithFolder);
+        if (component != null)
+        {
+            whyNotValid = "There is a component named " + component.Name + " so this name can't be used.";
+        }
+        var screen = ObjectFinder.Self.GumProjectSave.Screens.FirstOrDefault(item =>
+            item != objectToIgnore && Standardize(item.Name) == newStandardizedNameWithFolder);
+        if (screen != null)
+        {
+            whyNotValid = "There is a screen named " + screen.Name + " so this name can't be used.";
+        }
+    }
+    public bool IsNameValidAndroidFile(string name, out string whyNotValid)
+    {
+        whyNotValid = null;
+        for(int i = 0; i < name.Length; i++)
+        {
+            if(!IsValidAndroidFileCharacter(name[i]))
+            {
+                whyNotValid = $"The character {name[i]} is not supported on Android.";
+                break;
+            }
+        }
+        return string.IsNullOrEmpty(whyNotValid);
+    }
+    private bool IsValidAndroidFileCharacter(char c)
+    {
+        return (c >= 'a' && c <= 'z') ||
+            //(c >= 'A' && c <= 'Z' && allowUpperCase) ||
+            (c == '_') ||
+            (c >= '0' && c <= '9');
+    }
+    private string Standardize(string name)
+    {
+        if (name == null) return null;
 
-            if (existingName != null) whyNotValid = $"Cannot add category — a category with the name {existingName} is already defined in {categoryContainer}";
-            return existing != null;
-        }
-        internal bool IsStateNameValid(string name, StateSaveCategory category, StateSave stateSave, out string whyNotValid)
-        {
-            IsNameValidCommon(name, out whyNotValid);
-            if(string.IsNullOrEmpty(whyNotValid))
-            {
-                var existing = category?.States.Find(item => Standardize(item.Name) == Standardize(name) && item != stateSave);
-                if (existing != null)
-                {
-                    whyNotValid = $"The category {category.Name} already has a state named {name}";
-                }
-            }
-            return string.IsNullOrEmpty(whyNotValid);
-        }
-        public bool IsInstanceNameValid(string instanceName, InstanceSave instanceSave, IInstanceContainer instanceContainer, out string whyNotValid)
-        {
-            IsNameValidCommon(instanceName, out whyNotValid);
-            //if (string.IsNullOrEmpty(whyNotValid))
-            //{
-            //    IsNameValidVariable(instanceName, out whyNotValid);
-            //}
-            // See if this is a variable used by any state in the StandardElementsManager:
-            if(string.IsNullOrEmpty(whyNotValid))
-            {
-                IsNameUsedByStandardVariables(instanceName, out whyNotValid);
-            }
-            if (string.IsNullOrEmpty(whyNotValid))
-            {
-                IsNameAlreadyUsed(instanceName, instanceSave, instanceContainer, out whyNotValid);
-            }
-            return string.IsNullOrEmpty(whyNotValid);
-        }
-        private void IsNameUsedByStandardVariables(string nameToCheck, out string whyNotValid)
-        {
-            var variables = _standardElementsManager.DefaultStates.SelectMany(item => item.Value.Variables);
-            var names = variables.Select(item => item.Name).ToHashSet();
-            whyNotValid = null;
-            if(names.Contains(nameToCheck))
-            {
-                whyNotValid = $"The name {nameToCheck} cannot be used because it is a reserved variable name";
-            }
-            else if(nameToCheck == "Name")
-            {
-                whyNotValid = $"\"Name\" is a reserved keyword so it cannot be used as a name";
-            }
-        }
-        public bool IsVariableNameValid(string variableName, ElementSave elementSave, VariableSave variableSave, out string whyNotValid)
-        {
-            whyNotValid = null;
-            IsNameValidCommon(variableName, out whyNotValid);
-            if (string.IsNullOrEmpty(whyNotValid) && elementSave != null)
-            {
-                IsNameAlreadyUsed(variableName, variableSave, elementSave, out whyNotValid);
-            }
-            if (string.IsNullOrEmpty(whyNotValid))
-            {
-                var existingVariable = elementSave?.GetVariableFromThisOrBase(variableName);
-                // there's a variable but we shouldn't consider it
-                // unless it's "Active" - inactive variables may be
-                // leftovers from a type change
-                if(existingVariable != null && elementSave != null)
-                {
-                    var isActive = VariableSaveLogic.GetIfVariableIsActive(existingVariable,
-                        elementSave, null);
-                    if(isActive)
-                    {
-                        whyNotValid = $"The variable name {variableName} is already used";
-                    }
-                }
-            }
-            return string.IsNullOrEmpty(whyNotValid);
-        }
-        public bool IsBehaviorNameValid(string behaviorName, BehaviorSave behaviorSave, out string whyNotValid)
-        {
-            IsNameValidCommon(behaviorName, out whyNotValid);
-            if (string.IsNullOrEmpty(whyNotValid))
-            {
-                IsFileNameWindowsReserved(behaviorName, out whyNotValid);
-            }
-            if (string.IsNullOrEmpty(whyNotValid))
-            {
-                // need to check for duplicate names eventually
-            }
-            return string.IsNullOrEmpty(whyNotValid);
-        }
-        private void IsNameValidCommon(string name, out string whyNotValid)
-        {
-            whyNotValid = null;
-            if (string.IsNullOrEmpty(name))
-            {
-                whyNotValid = "Empty names are not valid";
-            }
-            else if (name.IndexOfAny(InvalidCharacters) != -1)
-            {
-                whyNotValid = "The name can't contain invalid character " + name[name.IndexOfAny(InvalidCharacters)];
-            }
-            if(string.IsNullOrEmpty(whyNotValid) && name.StartsWith(" "))
-            {
-                whyNotValid = "The name can't begin with a space";
-            }
-            if (string.IsNullOrEmpty(whyNotValid) && name.EndsWith(" "))
-            {
-                whyNotValid = "The name can't end with a space";
-            }
-        }
-        private void IsNameValidVariable(string name, out string whyNotValid)
-        {
-            whyNotValid = null;
-            CodeDomProvider provider = CodeDomProvider.CreateProvider("C#");
-            if (provider.IsValidIdentifier(name) == false)
-            {
-                whyNotValid = "The name uses an invalid character";
-            }
-        }
-        private void IsFileNameWindowsReserved(string name, out string whyNotValid)
-        {
-            whyNotValid = null;
-            if (InvalidWindowsFileNames.Contains(name?.ToLower()))
-            {
-                whyNotValid = $"The name {name} is a reserved file name in Windows";
-            }
-        }
-        public bool IsComponentNameAlreadyUsed(string name)
-        {
-            return ObjectFinder.Self.GetComponent(name) != null;
-        }
-        private void IsNameAlreadyUsed(string name, object objectToIgnore, IInstanceContainer instanceContainer, out string whyNotValid)
-        {
-            whyNotValid = null;
-            if (objectToIgnore != instanceContainer && Standardize(name) == Standardize(instanceContainer.Name))
-            {
-                whyNotValid = $"The element is named '{instanceContainer.Name}'";
-            }
-            var instance = instanceContainer.Instances.FirstOrDefault(item => item != objectToIgnore && Standardize(item.Name) == Standardize(name));
-            if (instance != null)
-            {
-                whyNotValid = $"There is already an instance named '{instance.Name}'";
-            }
-            var stateContainer = instanceContainer as IStateContainer;
-            var state = stateContainer?.AllStates.FirstOrDefault(item => item != objectToIgnore && Standardize(item.Name) == Standardize(name));
-            if (state != null)
-            {
-                whyNotValid = $"There is already a state named '{state.Name}'";
-            }
-            
-            var variable = stateContainer?.AllStates
-                                          .SelectMany(item => item.Variables)
-                                          .FirstOrDefault(item => item != objectToIgnore && Standardize(item.ExposedAsName) == Standardize(name));
-            if (variable != null)
-            {
-                whyNotValid = $"There is already a variable named '{variable.Name}'";
-            }
-            //element = ObjectFinder.Self.GumProjectSave.StandardElements.FirstOrDefault(item=>item != objectToIgnore && item.Name == name)
-            //{
-            //    whyNotValid = "There is a standard element named " + element.Name + " so this name can't be used.";
-            //}
-        }
-        private void IsNameAnExistingElement(string name, string folderName, object objectToIgnore, out string whyNotValid)
-        {
-            whyNotValid = null;
-            string newStandardizedNameWithFolder = Standardize(folderName + name);
-            var standardElement = ObjectFinder.Self.GumProjectSave.StandardElements.FirstOrDefault(item =>
-                item != objectToIgnore && Standardize(item.Name) == newStandardizedNameWithFolder);
-            if (standardElement != null)
-            {
-                whyNotValid = "There is a standard element named " + standardElement.Name + " so this name can't be used.";
-            }
-            var component = ObjectFinder.Self.GumProjectSave.Components.FirstOrDefault(item =>
-                item != objectToIgnore && Standardize(item.Name) == newStandardizedNameWithFolder);
-            if (component != null)
-            {
-                whyNotValid = "There is a component named " + component.Name + " so this name can't be used.";
-            }
-            var screen = ObjectFinder.Self.GumProjectSave.Screens.FirstOrDefault(item =>
-                item != objectToIgnore && Standardize(item.Name) == newStandardizedNameWithFolder);
-            if (screen != null)
-            {
-                whyNotValid = "There is a screen named " + screen.Name + " so this name can't be used.";
-            }
-        }
-        public bool IsNameValidAndroidFile(string name, out string whyNotValid)
-        {
-            whyNotValid = null;
-            for(int i = 0; i < name.Length; i++)
-            {
-                if(!IsValidAndroidFileCharacter(name[i]))
-                {
-                    whyNotValid = $"The character {name[i]} is not supported on Android.";
-                    break;
-                }
-            }
-            return string.IsNullOrEmpty(whyNotValid);
-        }
-        private bool IsValidAndroidFileCharacter(char c)
-        {
-            return (c >= 'a' && c <= 'z') ||
-                //(c >= 'A' && c <= 'Z' && allowUpperCase) ||
-                (c == '_') ||
-                (c >= '0' && c <= '9');
-        }
-        private string Standardize(string name)
-        {
-            if (name == null) return null;
-
-            string formatted = name.Replace(" ", "_");
-            return formatted.ToLowerInvariant();
-        }
+        string formatted = name.Replace(" ", "_");
+        return formatted.ToLowerInvariant();
     }
 }

--- a/Gum/Managers/NameVerifier.cs
+++ b/Gum/Managers/NameVerifier.cs
@@ -81,8 +81,9 @@ namespace Gum.Managers
         }
         internal bool IsCategoryNameValid(string name, ElementSave categoryContainer, out string whyNotValid)
         {
+            whyNotValid = null;
+            
             string standardizedName = Standardize(name);
-
             string existingName = null;
             StateSaveCategory existing = categoryContainer.GetStateSaveCategoryRecursively(item =>
             {
@@ -95,7 +96,7 @@ namespace Gum.Managers
                 return false;
             });
 
-            whyNotValid = $"Cannot add category — a category with the name {existingName} is already defined in {categoryContainer}";
+            if (existingName != null) whyNotValid = $"Cannot add category — a category with the name {existingName} is already defined in {categoryContainer}";
             return existing != null;
         }
         internal bool IsStateNameValid(string name, StateSaveCategory category, StateSave stateSave, out string whyNotValid)

--- a/Gum/Plugins/InternalPlugins/VariableGrid/ColorPickerLogic.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/ColorPickerLogic.cs
@@ -138,7 +138,6 @@ public class ColorPickerLogic
 
             var indexToInsertAfter = Math.Max(category.Members.IndexOf(redVariable), Math.Max(category.Members.IndexOf(greenVariable), category.Members.IndexOf(blueVariable)));
             category.Members.Insert(indexToInsertAfter + 1, instanceMember);
-
         }
     }
 

--- a/Gum/Plugins/InternalPlugins/VariableGrid/ViewModels/AddVariableViewModel.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/ViewModels/AddVariableViewModel.cs
@@ -194,11 +194,12 @@ public class AddVariableViewModel : DialogViewModel
         {
             var behavior = _selectedState.SelectedBehavior;
 
-            var newVariable = new VariableSave();
-
-            newVariable.Name = name;
-            newVariable.Type = type;
-            newVariable.Value = DefaultValue;
+            var newVariable = new VariableSave
+            {
+                Name = name,
+                Type = type,
+                Value = DefaultValue
+            };
 
             using var undoLock = _undoManager.RequestLock();
 

--- a/Gum/ToolCommands/ElementCommands.cs
+++ b/Gum/ToolCommands/ElementCommands.cs
@@ -19,7 +19,7 @@ using Gum.Services;
 
 namespace Gum.ToolCommands
 {
-    public class ElementCommands
+    public class ElementCommands : IElementCommands
     {
         #region Fields
 

--- a/Gum/ToolCommands/IElementCommands.cs
+++ b/Gum/ToolCommands/IElementCommands.cs
@@ -1,0 +1,13 @@
+﻿using Gum.DataTypes;
+using Gum.DataTypes.Variables;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Gum.ToolCommands;
+public interface IElementCommands
+{
+    StateSaveCategory AddCategory(IStateContainer objectToAddTo, string name);
+}

--- a/Gum/Undo/IUndoManager.cs
+++ b/Gum/Undo/IUndoManager.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Gum.Undo;
+public interface IUndoManager
+{
+    UndoLock RequestLock();
+}

--- a/Gum/Undo/UndoManager.cs
+++ b/Gum/Undo/UndoManager.cs
@@ -82,7 +82,7 @@ public class UndoOperationEventArgs : EventArgs
 
 #endregion
 
-public class UndoManager
+public class UndoManager : IUndoManager
 {
     #region Fields
 

--- a/GumDataTypes/IStateContainer.cs
+++ b/GumDataTypes/IStateContainer.cs
@@ -1,24 +1,23 @@
 ﻿using Gum.DataTypes.Variables;
 using System.Collections.Generic;
 
-namespace Gum.DataTypes
+namespace Gum.DataTypes;
+
+public interface IStateContainer
 {
-    public interface IStateContainer
+    public string Name { get; }
+    IList<StateSave> UncategorizedStates
     {
-        public string Name { get; }
-        IList<StateSave> UncategorizedStates
-        {
-            get;
-        }
+        get;
+    }
 
-        IEnumerable<StateSave> AllStates
-        {
-            get;
-        }
+    IEnumerable<StateSave> AllStates
+    {
+        get;
+    }
 
-        IList<StateSaveCategory> Categories
-        {
-            get;
-        }
+    IList<StateSaveCategory> Categories
+    {
+        get;
     }
 }

--- a/GumDataTypes/Variables/VariableSave.cs
+++ b/GumDataTypes/Variables/VariableSave.cs
@@ -81,6 +81,8 @@ namespace Gum.DataTypes.Variables
                 }
             }
         }
+        
+        public string StandardizedName { get; set; }
 
         public object Value
         {

--- a/Tool/Tests/GumToolUnitTests/Managers/NameVerifierTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Managers/NameVerifierTests.cs
@@ -1,4 +1,5 @@
 ﻿using Gum.DataTypes;
+using Gum.DataTypes.Behaviors;
 using Gum.DataTypes.Variables;
 using Gum.Managers;
 using Shouldly;
@@ -22,26 +23,41 @@ public class NameVerifierTests
     #region StateSaveCategory
 
     [Fact]
-    public void IsCategoryNameValid_ShouldReturnTrue_ForValidNamej()
+    public void IsCategoryNameValid_ShouldReturnTrue_ForValidComponentName()
     {
-        ComponentSave component = new ComponentSave();
-
+        IStateContainer component = new ComponentSave();
         var isValid = _nameVerifier.IsCategoryNameValid("ValidCategory", component, out string whyNotValid);
-
         isValid.ShouldBeTrue();
     }
 
     [Fact]
-    public void IsCategoryNameValid_ShouldReturnFalse_ForEmptyName()
+    public void IsCategoryNameValid_ShouldReturnTrue_ForValidBehaviorName()
     {
-        ComponentSave component = new ComponentSave();
+        IStateContainer behavior = new BehaviorSave();
+        var isValid = _nameVerifier.IsCategoryNameValid("ValidCategory", behavior, out string whyNotValid);
+        isValid.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsCategoryNameValid_ShouldReturnFalse_ForEmptyName_Component()
+    {
+        IStateContainer component = new ComponentSave();
         var isValid = _nameVerifier.IsCategoryNameValid("", component, out string whyNotValid);
         isValid.ShouldBeFalse();
         whyNotValid.ShouldBe("Empty names are not valid");
     }
 
     [Fact]
-    public void IsCategoryNameValid_ShouldReturnFalse_ForWhitespaceName()
+    public void IsCategoryNameValid_ShouldReturnFalse_ForEmptyName_Behavior()
+    {
+        IStateContainer behavior = new BehaviorSave();
+        var isValid = _nameVerifier.IsCategoryNameValid("", behavior, out string whyNotValid);
+        isValid.ShouldBeFalse();
+        whyNotValid.ShouldBe("Empty names are not valid");
+    }
+
+    [Fact]
+    public void IsCategoryNameValid_ShouldReturnFalse_ForWhitespaceName_Component()
     {
         ComponentSave component = new ComponentSave();
         var isValid = _nameVerifier.IsCategoryNameValid("   ", component, out string whyNotValid);
@@ -50,16 +66,34 @@ public class NameVerifierTests
     }
 
     [Fact]
-    public void IsCategoryNameValid_ShouldReturnFalse_ForInvalidCharacters()
+    public void IsCategoryNameValid_ShouldReturnFalse_ForWhitespaceName_Behavior()
     {
-        ComponentSave component = new ComponentSave();
+        IStateContainer behavior = new BehaviorSave();
+        var isValid = _nameVerifier.IsCategoryNameValid("   ", behavior, out string whyNotValid);
+        isValid.ShouldBeFalse();
+        whyNotValid.ShouldBe("Empty names are not valid");
+    }
+
+    [Fact]
+    public void IsCategoryNameValid_ShouldReturnFalse_ForInvalidCharacters_Components()
+    {
+        IStateContainer component = new ComponentSave();
         var isValid = _nameVerifier.IsCategoryNameValid("Invalid@Category", component, out string whyNotValid);
         isValid.ShouldBeFalse();
         whyNotValid.ShouldBe("The name can't contain invalid character @");
     }
 
     [Fact]
-    public void IsCategoryNameValid_ShouldReturnFalse_ForDuplicateName()
+    public void IsCategoryNameValid_ShouldReturnFalse_ForInvalidCharacters_Behaviors()
+    {
+        IStateContainer behavior = new BehaviorSave();
+        var isValid = _nameVerifier.IsCategoryNameValid("Invalid@Category", behavior, out string whyNotValid);
+        isValid.ShouldBeFalse();
+        whyNotValid.ShouldBe("The name can't contain invalid character @");
+    }
+
+    [Fact]
+    public void IsCategoryNameValid_ShouldReturnFalse_ForDuplicateName_Component()
     {
         ComponentSave component = new ComponentSave();
         component.Name = "TestComponent";
@@ -70,12 +104,34 @@ public class NameVerifierTests
     }
 
     [Fact]
-    public void IsCategoryNameValid_ShouldReturnFalse_ForNamesWithMatchingWhitespace()
+    public void IsCategoryNameValid_ShouldReturnFalse_ForDuplicateName_Behavior()
+    {
+        BehaviorSave behavior = new BehaviorSave();
+        behavior.Name = "TestComponent";
+        behavior.Categories.Add(new StateSaveCategory { Name = "ExistingCategory" });
+        var isValid = _nameVerifier.IsCategoryNameValid("ExistingCategory", behavior, out string whyNotValid);
+        isValid.ShouldBeFalse();
+        whyNotValid.ShouldBe("A category with the name ExistingCategory is already defined in TestComponent");
+    }
+
+    [Fact]
+    public void IsCategoryNameValid_ShouldReturnFalse_ForNamesWithMatchingWhitespace_Component()
     {
         ComponentSave component = new ComponentSave();
         component.Name = "TestComponent";
         component.Categories.Add(new StateSaveCategory { Name = "Existing_Category" });
         var isValid = _nameVerifier.IsCategoryNameValid("Existing Category", component, out string whyNotValid);
+        isValid.ShouldBeFalse();
+        whyNotValid.ShouldBe("A category with the name Existing_Category is already defined in TestComponent");
+    }
+
+    [Fact]
+    public void IsCategoryNameValid_ShouldReturnFalse_ForNamesWithMatchingWhitespace_Behavior()
+    {
+        BehaviorSave behavior = new BehaviorSave();
+        behavior.Name = "TestComponent";
+        behavior.Categories.Add(new StateSaveCategory { Name = "Existing_Category" });
+        var isValid = _nameVerifier.IsCategoryNameValid("Existing Category", behavior, out string whyNotValid);
         isValid.ShouldBeFalse();
         whyNotValid.ShouldBe("A category with the name Existing_Category is already defined in TestComponent");
     }

--- a/Tool/Tests/GumToolUnitTests/Managers/NameVerifierTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Managers/NameVerifierTests.cs
@@ -1,0 +1,84 @@
+﻿using Gum.DataTypes;
+using Gum.DataTypes.Variables;
+using Gum.Managers;
+using Shouldly;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace GumToolUnitTests.Managers;
+public class NameVerifierTests
+{
+    NameVerifier _nameVerifier;
+
+    public NameVerifierTests()
+    {
+        _nameVerifier = new NameVerifier();
+    }
+
+
+    #region StateSaveCategory
+
+    [Fact]
+    public void IsCategoryNameValid_ShouldReturnTrue_ForValidNamej()
+    {
+        ComponentSave component = new ComponentSave();
+
+        var isValid = _nameVerifier.IsCategoryNameValid("ValidCategory", component, out string whyNotValid);
+
+        isValid.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsCategoryNameValid_ShouldReturnFalse_ForEmptyName()
+    {
+        ComponentSave component = new ComponentSave();
+        var isValid = _nameVerifier.IsCategoryNameValid("", component, out string whyNotValid);
+        isValid.ShouldBeFalse();
+        whyNotValid.ShouldBe("Empty names are not valid");
+    }
+
+    [Fact]
+    public void IsCategoryNameValid_ShouldReturnFalse_ForWhitespaceName()
+    {
+        ComponentSave component = new ComponentSave();
+        var isValid = _nameVerifier.IsCategoryNameValid("   ", component, out string whyNotValid);
+        isValid.ShouldBeFalse();
+        whyNotValid.ShouldBe("Empty names are not valid");
+    }
+
+    [Fact]
+    public void IsCategoryNameValid_ShouldReturnFalse_ForInvalidCharacters()
+    {
+        ComponentSave component = new ComponentSave();
+        var isValid = _nameVerifier.IsCategoryNameValid("Invalid@Category", component, out string whyNotValid);
+        isValid.ShouldBeFalse();
+        whyNotValid.ShouldBe("The name can't contain invalid character @");
+    }
+
+    [Fact]
+    public void IsCategoryNameValid_ShouldReturnFalse_ForDuplicateName()
+    {
+        ComponentSave component = new ComponentSave();
+        component.Name = "TestComponent";
+        component.Categories.Add(new StateSaveCategory { Name = "ExistingCategory" });
+        var isValid = _nameVerifier.IsCategoryNameValid("ExistingCategory", component, out string whyNotValid);
+        isValid.ShouldBeFalse();
+        whyNotValid.ShouldBe("A category with the name ExistingCategory is already defined in TestComponent");
+    }
+
+    [Fact]
+    public void IsCategoryNameValid_ShouldReturnFalse_ForNamesWithMatchingWhitespace()
+    {
+        ComponentSave component = new ComponentSave();
+        component.Name = "TestComponent";
+        component.Categories.Add(new StateSaveCategory { Name = "Existing_Category" });
+        var isValid = _nameVerifier.IsCategoryNameValid("Existing Category", component, out string whyNotValid);
+        isValid.ShouldBeFalse();
+        whyNotValid.ShouldBe("A category with the name Existing_Category is already defined in TestComponent");
+    }
+
+    #endregion
+}

--- a/Tool/Tests/GumToolUnitTests/ViewModels/Dialogs/AddCategoryDialogViewModelTests.cs
+++ b/Tool/Tests/GumToolUnitTests/ViewModels/Dialogs/AddCategoryDialogViewModelTests.cs
@@ -1,0 +1,80 @@
+﻿using Gum.DataTypes;
+using Gum.DataTypes.Behaviors;
+using Gum.Dialogs;
+using Gum.Managers;
+using Gum.ToolCommands;
+using Gum.ToolStates;
+using Gum.Undo;
+using Moq;
+using Shouldly;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace GumToolUnitTests.ViewModels.Dialogs;
+public class AddCategoryDialogViewModelTests
+{
+    private readonly Mock<ISelectedState> _selectedState;
+    private readonly Mock<IElementCommands> _elementCommands;
+    private readonly Mock<IUndoManager> _undoManager;
+    private readonly Mock<INameVerifier> _nameVerifier;
+    AddCategoryDialogViewModel _viewModel;
+
+    public AddCategoryDialogViewModelTests()
+    {
+        _selectedState = new Mock<ISelectedState>();
+        _elementCommands = new Mock<IElementCommands>();
+        _undoManager = new Mock<IUndoManager>();
+        _nameVerifier = new Mock<INameVerifier>();
+
+        _viewModel = new AddCategoryDialogViewModel(
+            _selectedState.Object,
+            _elementCommands.Object,
+            _undoManager.Object,
+            _nameVerifier.Object);
+    }
+
+    [Fact]
+    public void Validate_ShouldValidateComponentCategories_UsingNameVerifier()
+    {
+        string errorMessage = "Invalid category name";
+        _nameVerifier.Setup(
+            x => x.IsCategoryNameValid(
+                It.IsAny<string>(), 
+                It.IsAny<ElementSave>(), 
+                out errorMessage)) ;
+
+        _selectedState
+            .Setup(x => x.SelectedStateContainer)
+            .Returns(new ComponentSave());
+
+        _viewModel.Value = "NewCategory";
+
+        _viewModel.Validate();
+
+        var error = _viewModel.Error;
+        error.ShouldBe("Invalid category name");
+    }
+
+    [Fact]
+    public void Validate_ShouldValidateBehaviorCategories_UsingNameVerifier()
+    {
+        string errorMessage = "Invalid behavior category name";
+        _nameVerifier.Setup(
+            x => x.IsCategoryNameValid(
+                It.IsAny<string>(), 
+                It.IsAny<BehaviorSave>(), 
+                out errorMessage));
+        
+        _selectedState
+            .Setup(x => x.SelectedStateContainer)
+            .Returns(new BehaviorSave());
+
+        _viewModel.Value = "NewCategory";
+        _viewModel.Validate();
+        var error = _viewModel.Error;
+        error.ShouldBe("Invalid behavior category name");
+    }
+}

--- a/Tool/Tests/GumToolUnitTests/ViewModels/Dialogs/AddCategoryDialogViewModelTests.cs
+++ b/Tool/Tests/GumToolUnitTests/ViewModels/Dialogs/AddCategoryDialogViewModelTests.cs
@@ -54,7 +54,7 @@ public class AddCategoryDialogViewModelTests
 
         _viewModel.Validate();
 
-        var error = _viewModel.Error;
+        string? error = _viewModel.Error;
         error.ShouldBe("Invalid category name");
     }
 
@@ -74,7 +74,7 @@ public class AddCategoryDialogViewModelTests
 
         _viewModel.Value = "NewCategory";
         _viewModel.Validate();
-        var error = _viewModel.Error;
+        string? error = _viewModel.Error;
         error.ShouldBe("Invalid behavior category name");
     }
 }


### PR DESCRIPTION
Closes the first part of #1221 as finished (this time for real) — in PR #1232 I had forgot to handle also category names in name verification.

Before my changes, you could create a state category called `MyCategory` and another state category called `My Category` in the same element.

However, taking into account that we will replace spaces with underscores in Code Generation, that would cause name conflicts.

So now category name verification also treats spaces as underscores so we can safely implement that in CodeGen,

