### PR TITLE
fix: 1251 - Error tab header UI scaling

### DIFF
--- a/Gum/Controls/MainPanelControl.xaml
+++ b/Gum/Controls/MainPanelControl.xaml
@@ -14,13 +14,12 @@
             
             <!-- When CustomHeaderContent exists, just present it -->
             <DataTemplate x:Key="TabCustomHeaderTemplate">
-                <ContentPresenter Content="{Binding}" />
+                <ContentPresenter Content="{Binding CustomHeaderContent}" />
             </DataTemplate>
 
             <!-- Fallback to Title on the TabItem's DataContext -->
             <DataTemplate x:Key="TabTitleHeaderTemplate">
-                <TextBlock Text="{Binding DataContext.Title,
-                                  RelativeSource={RelativeSource AncestorType=TabItem}}"/>
+                <TextBlock Text="{Binding Title}"/>
             </DataTemplate>
 
             <local:PluginTabHeaderTemplateSelector
@@ -29,7 +28,6 @@
                 TitleHeaderTemplate="{StaticResource TabTitleHeaderTemplate}" />
             
             <Style x:Key="PluginTabStyle" TargetType="{x:Type TabItem}" BasedOn="{StaticResource {x:Type TabItem}}">
-                <Setter Property="Header" Value="{Binding CustomHeaderContent}"/>
                 <Setter Property="HeaderTemplateSelector" Value="{StaticResource PluginTabHeaderSelector}"/>
                 
                 <Setter Property="ContentTemplate">

--- a/Gum/Controls/MainPanelControl.xaml.cs
+++ b/Gum/Controls/MainPanelControl.xaml.cs
@@ -112,8 +112,8 @@ public class PluginTabHeaderTemplateSelector : DataTemplateSelector
     public DataTemplate? CustomHeaderTemplate { get; set; }
     public DataTemplate? TitleHeaderTemplate { get; set; }
 
-    public override DataTemplate SelectTemplate(object item, DependencyObject container)
+    public override DataTemplate SelectTemplate(object? item, DependencyObject container)
     {
-        return item != null ? CustomHeaderTemplate! : TitleHeaderTemplate!;
+        return item is PluginTab { CustomHeaderContent: not null } ? CustomHeaderTemplate! : TitleHeaderTemplate!;
     }
 }


### PR DESCRIPTION
fixes #1251
Updates the tab header template selector to correctly display
custom header content when available, falling back to the title
otherwise. This ensures that tabs with custom headers are
rendered as intended.
