### PR TITLE
Remove MainWindow's dependency on GuiCommands

### DIFF
--- a/Gum/Commands/GuiCommands.cs
+++ b/Gum/Commands/GuiCommands.cs
@@ -34,12 +34,7 @@ namespace Gum.Commands;
 public class GuiCommands : IGuiCommands
 {
     #region Fields/Properties
-
-    public System.Windows.Forms.Cursor AddCursor { get; set; }
-
-
-    MainPanelControl mainPanelControl;
-
+    
     private readonly Lazy<ISelectedState> _lazySelectedState;
     private readonly IDispatcher _dispatcher;
     private ISelectedState _selectedState => _lazySelectedState.Value;
@@ -51,12 +46,7 @@ public class GuiCommands : IGuiCommands
         _lazySelectedState = lazySelectedState;
         _dispatcher = dispatcher;
     }
-
-    public void Initialize(MainPanelControl mainPanelControl)
-    {
-        this.mainPanelControl = mainPanelControl;
-    }
-
+    
     public void BroadcastRefreshBehaviorView()
     {
         PluginManager.Self.RefreshBehaviorView(
@@ -95,56 +85,13 @@ public class GuiCommands : IGuiCommands
 
     #endregion
 
-    #region Move to Cursor
-
-    public void MoveToCursor(System.Windows.Window window)
-    {
-        window.WindowStartupLocation = System.Windows.WindowStartupLocation.Manual;
-
-        double width = window.Width;
-        if (double.IsNaN(width))
-        {
-            width = 0;
-        }
-        double height = window.Height;
-        if (double.IsNaN(height))
-        {
-            // Let's just assume some small height so it doesn't appear down below the cursor:
-            //height = 0;
-            height = 64;
-        }
-
-        var source = System.Windows.PresentationSource.FromVisual(mainPanelControl);
-
-
-        double mousePositionX = Control.MousePosition.X;
-        double mousePositionY = Control.MousePosition.Y;
-
-        if (source != null)
-        {
-            mousePositionX /= source.CompositionTarget.TransformToDevice.M11;
-            mousePositionY /= source.CompositionTarget.TransformToDevice.M22;
-        }
-
-        window.Left = mousePositionX - width / 2;
-        window.Top = mousePositionY - height / 2;
-
-        window.ShiftWindowOntoScreen();
-    }
-    #endregion
-
     public void PrintOutput(string output)
     {
         _dispatcher.Invoke(() => OutputManager.Self.AddOutput(output));
     }
 
     #region Show/Hide Tools
-
-    public System.Drawing.Point GetMousePosition()
-    {
-        return MainWindow.MousePosition;
-    }
-
+    
     public void ToggleToolVisibility()
     {
         //var areToolsVisible = mMainWindow.LeftAndEverythingContainer.Panel1Collapsed == false;

--- a/Gum/Commands/IGuiCommands.cs
+++ b/Gum/Commands/IGuiCommands.cs
@@ -1,23 +1,15 @@
 ﻿using Gum.Controls;
 using Gum.DataTypes;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Gum.Commands;
 public interface IGuiCommands
 {
-    System.Windows.Forms.Cursor AddCursor { get; set; }
-    void Initialize(MainPanelControl mainPanelControl);
     void BroadcastRefreshBehaviorView();
     void RefreshStateTreeView();
     void RefreshVariables(bool force = false);
     void RefreshVariableValues();
     void RefreshElementTreeView();
     void RefreshElementTreeView(IInstanceContainer instanceContainer);
-    void MoveToCursor(System.Windows.Window window);
     void PrintOutput(string output);
     void ToggleToolVisibility();
     void FocusSearch();

--- a/Gum/Controls/CustomizableTextInputWindow.xaml.cs
+++ b/Gum/Controls/CustomizableTextInputWindow.xaml.cs
@@ -62,10 +62,7 @@ public partial class CustomizableTextInputWindow : Window
         TextBox.Focus();
 
         this.WindowStartupLocation = WindowStartupLocation.Manual;
-
-        IGuiCommands guiCommands = Locator.GetRequiredService<IGuiCommands>();
-        guiCommands.MoveToCursor(this);
-
+        
         ValidationLabel.Visibility = Visibility.Hidden;
         this.Loaded += HandleLoaded;
     }

--- a/Gum/Controls/ListBoxMessageBox.xaml.cs
+++ b/Gum/Controls/ListBoxMessageBox.xaml.cs
@@ -99,9 +99,6 @@ namespace StateAnimationPlugin.Views
 
         private void HandleLoaded(object sender, RoutedEventArgs e)
         {
-            IGuiCommands guiCommands = Locator.GetRequiredService<IGuiCommands>();
-            guiCommands.MoveToCursor(this);
-
             ListBox.Focus();
         }
 

--- a/Gum/Gui/Windows/DeleteOptionsWindow.xaml.cs
+++ b/Gum/Gui/Windows/DeleteOptionsWindow.xaml.cs
@@ -29,13 +29,6 @@ namespace Gum.Gui.Windows
         public DeleteOptionsWindow()
         {
             InitializeComponent();
-
-            this.Loaded += HandleLoaded;
-        }
-
-        private void HandleLoaded(object sender, RoutedEventArgs e)
-        {
-            Locator.GetRequiredService<IGuiCommands>().MoveToCursor(this);
         }
 
         private void YesButtonClick(object sender, RoutedEventArgs e)

--- a/Gum/MainWindow.cs
+++ b/Gum/MainWindow.cs
@@ -51,7 +51,6 @@ namespace Gum
         #endregion
 
         public MainWindow(MainPanelControl mainPanelControl,
-            IGuiCommands guiCommands,
             MenuStripManager menuStripManager,
             IMessenger messenger
             )
@@ -70,18 +69,12 @@ namespace Gum
 
             this.KeyPreview = true;
             this.KeyDown += HandleKeyDown;
-
-            // Initialize before the StateView is created...
-            _guiCommands = guiCommands;
-            _guiCommands.Initialize(mainPanelControl);
-
+            
             TypeManager.Self.Initialize();
 
             // This has to happen before plugins are loaded since they may depend on settings...
             ProjectManager.Self.LoadSettings();
-
-            Cursor addCursor = LoadAddCursor();
-            _guiCommands.AddCursor = addCursor;
+            
             // Vic says - I tried
             // to instantiate the ElementTreeImages
             // in the ElementTreeViewManager. I move 
@@ -129,21 +122,7 @@ namespace Gum
 
             InitializeFileWatchTimer();
         }
-
-        private Cursor LoadAddCursor()
-        {
-            try
-            {
-                var cursor = new System.Windows.Forms.Cursor(this.GetType(), "Content.Cursors.AddCursor.cur");
-                return cursor;
-            }
-            catch
-            {
-                // Vic got this to crash on Sean's machine. Not sure why, but let's tolerate it since it's not breaking
-                return Cursor.Current;
-            }
-        }
-
+        
         private void AddMainPanelControl(MainPanelControl mainPanelControl)
         {
             var wpfHost = new ElementHost();

--- a/Gum/Plugins/InternalPlugins/TreeView/ElementTreeViewManager.cs
+++ b/Gum/Plugins/InternalPlugins/TreeView/ElementTreeViewManager.cs
@@ -154,7 +154,7 @@ public partial class ElementTreeViewManager
     TreeNode mBehaviorsTreeNode;
     TreeNode? mLastHoveredNode;
     private DateTime? hoverStartTime;
-
+    private Cursor AddCursor { get; }
 
 
     FlatSearchListBox FlatList;
@@ -284,6 +284,20 @@ public partial class ElementTreeViewManager
         _tabManager = Locator.GetRequiredService<ITabManager>();
         
         TreeNodeExtensionMethods.ElementTreeViewManager = this;
+        AddCursor = GetAddCursor();
+
+        Cursor GetAddCursor()
+        {
+            try
+            {
+                return new Cursor(typeof(MainWindow), "Content.Cursors.AddCursor.cur");
+            }
+            catch
+            {
+                // Vic got this to crash on Sean's machine. Not sure why, but let's tolerate it since it's not breaking
+                return Cursor.Current;
+            }
+        }
     }
 
     #region Methods
@@ -631,7 +645,7 @@ public partial class ElementTreeViewManager
             if(InputLibrary.Cursor.Self.IsInWindow)
             {
                 e.UseDefaultCursors = false;
-                System.Windows.Forms.Cursor.Current = _guiCommands.AddCursor;
+                System.Windows.Forms.Cursor.Current = AddCursor;
             }
         };
     }


### PR DESCRIPTION
- Remove last of MainPanelControl out of GuiCommands
- GuiCommands no longer needs to be initialized at all -- but specifically from MainWindow control
- Removes it as a MainWindow dependency
