### PR TITLE
AutoSelect when viewing Properties tab

### DIFF
--- a/Gum/Controls/MainPanelControl.xaml.cs
+++ b/Gum/Controls/MainPanelControl.xaml.cs
@@ -100,9 +100,9 @@ public partial class MainPanelControl : UserControl
     private void TabHeader_OnMiddleMouseDown(object sender, MouseButtonEventArgs e)
     {
         if (sender is FrameworkElement { DataContext: PluginTab pluginTab } &&
-            pluginTab.HideCommand.CanExecute(null))
+            pluginTab.CloseCommand.CanExecute(null))
         {
-            pluginTab.HideCommand.Execute(null);
+            pluginTab.CloseCommand.Execute(null);
         }
     }
 }

--- a/Gum/Plugins/InternalPlugins/ProjectPropertiesWindowPlugin/MainPropertiesWindowPlugin.cs
+++ b/Gum/Plugins/InternalPlugins/ProjectPropertiesWindowPlugin/MainPropertiesWindowPlugin.cs
@@ -110,6 +110,8 @@ class MainPropertiesWindowPlugin : InternalPlugin
             viewModel.SetFrom(ProjectManager.Self.GeneralSettingsFile, ProjectState.Self.GumProjectSave);
             control.ViewModel = viewModel;
             _pluginTab?.Show();
+            _pluginTab.CanClose = true;
+            _pluginTab.IsSelected = true;
             RefreshFontRangeEditability();
         }
         catch (Exception ex)

--- a/Gum/Plugins/PluginTab.cs
+++ b/Gum/Plugins/PluginTab.cs
@@ -76,7 +76,7 @@ namespace Gum.Plugins
             {
                 if (Set(value))
                 {
-                    HideCommand.NotifyCanExecuteChanged();
+                    CloseCommand.NotifyCanExecuteChanged();
                 }
             }
         }
@@ -86,21 +86,22 @@ namespace Gum.Plugins
             _messenger = messenger;
             _messenger.RegisterAll(this);
             
-            CanClose = true;
             Location = TabLocation.RightBottom;
             Content = content;
             IsVisible = true;
         }
 
         [RelayCommand(CanExecute = nameof(CanClose))]
-        public void Hide()
+        public void Close()
         {
             if (CanClose)
             {
                 IsVisible = false;
             }
         }
-
+        
+        public void Hide() => IsVisible = false;
+        
         public void Show() => IsVisible = true;
 
         public void Receive(TabSelectedMessage message)


### PR DESCRIPTION
- fixes #1267
- also fixes a bug where tabs became user-closable that weren't prior to refactor. replacing the HideCommand with a plain Hide method for internal scenarios, and introduces a CloseCommand for scenarios where the user attempts to close the tab.
