### PR TITLE
TextBox now suppresses focus if it has keyboard focus

### DIFF
--- a/WpfDataUi/Controls/TextBoxDisplay.xaml.cs
+++ b/WpfDataUi/Controls/TextBoxDisplay.xaml.cs
@@ -150,7 +150,7 @@ namespace WpfDataUi.Controls
             // the value under the cursor
             // If we're default, then go ahead and change the value
             bool canRefresh =
-                this.TextBox.IsFocused == false || forceRefreshEvenIfFocused || mTextBoxLogic.InstanceMember.IsDefault;
+                this.TextBox.IsKeyboardFocused == false || forceRefreshEvenIfFocused || mTextBoxLogic.InstanceMember.IsDefault;
 
             canRefresh = canRefresh && !IsInSet;
 


### PR DESCRIPTION
This fixes a bug where text boxes wouldn't get updated if the app has lost focus while a TextBox has focus.