### PR TITLE
Replaces Forms.Timer with PeriodicUiTimer

### DIFF
--- a/Gum/MainWindow.cs
+++ b/Gum/MainWindow.cs
@@ -44,7 +44,6 @@ namespace Gum
 
         private readonly IGuiCommands _guiCommands;
         
-        private System.Windows.Forms.Timer FileWatchTimer;
 
         MainPanelControl mainPanelControl;
 
@@ -52,7 +51,8 @@ namespace Gum
 
         public MainWindow(MainPanelControl mainPanelControl,
             MenuStripManager menuStripManager,
-            IMessenger messenger
+            IMessenger messenger,
+            PeriodicUiTimer periodicUiTimer
             )
         {
 #if DEBUG
@@ -109,7 +109,8 @@ namespace Gum
 
             PluginManager.Self.XnaInitialized();
 
-            InitializeFileWatchTimer();
+            periodicUiTimer.Tick += HandleFileWatchTimer;
+            periodicUiTimer.Start(TimeSpan.FromSeconds(2));
         }
         
         private void AddMainPanelControl(MainPanelControl mainPanelControl)
@@ -133,15 +134,7 @@ namespace Gum
             }
         }
 
-        private void InitializeFileWatchTimer()
-        {
-            this.FileWatchTimer = new Timer(this.components);
-            this.FileWatchTimer.Enabled = true;
-            this.FileWatchTimer.Interval = 1000;
-            this.FileWatchTimer.Tick += new System.EventHandler(HandleFileWatchTimer);
-        }
-
-        private void HandleFileWatchTimer(object sender, EventArgs e)
+        private void HandleFileWatchTimer()
         {
             var gumProject = ProjectState.Self.GumProjectSave;
             if (gumProject != null && !string.IsNullOrEmpty(gumProject.FullFileName))

--- a/Gum/Services/AppDispatcher.cs
+++ b/Gum/Services/AppDispatcher.cs
@@ -13,4 +13,5 @@ public class AppDispatcher : IDispatcher
     }
 
     public void Invoke(Action action) => Dispatcher.Value.Invoke(action);
+    public void Post(Action action) => Dispatcher.Value.BeginInvoke(action, DispatcherPriority.Background);
 }

--- a/Gum/Services/Builder.cs
+++ b/Gum/Services/Builder.cs
@@ -43,6 +43,7 @@ file static class ServiceCollectionExtensions
             static (isp, type) => isp.AddTransient(type)
         );
         services.AddTransient(typeof(Lazy<>), typeof(Lazier<>));
+        services.AddTransient<PeriodicUiTimer>();
         
         // static singletons
         services.AddSingleton<IObjectFinder>(ObjectFinder.Self);

--- a/Gum/Services/IDispatcher.cs
+++ b/Gum/Services/IDispatcher.cs
@@ -5,4 +5,5 @@ namespace Gum.Services;
 public interface IDispatcher
 {
     void Invoke(Action action);
+    void Post(Action action);
 }

--- a/Gum/Services/PeriodicUiTimer.cs
+++ b/Gum/Services/PeriodicUiTimer.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using System.Threading;
+using System.Windows.Threading;
+using Microsoft.Extensions.Logging;
+
+namespace Gum.Services;
+
+public class PeriodicUiTimer : IDisposable
+{
+    private IDispatcher Dispatcher { get; }
+    private ILogger Logger { get; }
+    
+    private readonly Timer _timer;
+    private volatile bool _enabled;
+    private int _inTick; // 0 = idle, 1 = running
+
+    public event Action? Tick;
+
+    public PeriodicUiTimer(IDispatcher dispatcher, ILogger<PeriodicUiTimer> logger)
+    {
+        Dispatcher = dispatcher;
+        Logger = logger;
+        _timer = new Timer(OnTimerCallback, null, Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+    }
+
+    private TimeSpan Interval { get; set; } = Timeout.InfiniteTimeSpan;
+
+    public bool Enabled
+    {
+        get => _enabled;
+        set
+        {
+            _enabled = value;
+            _timer.Change(value ? Interval : Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+        }
+    }
+
+    public void Start(TimeSpan interval)
+    { 
+        Interval = interval;
+        Enabled = true;
+    }
+    
+    public void Stop() => Enabled = false;
+
+    private void OnTimerCallback(object? _)
+    {
+        if (Interlocked.Exchange(ref _inTick, 1) == 1)
+        {
+            if (_enabled) _timer.Change(Interval, Timeout.InfiniteTimeSpan);
+            return;
+        }
+
+        Dispatcher.Post(TryTick);
+    }
+    
+    private void TryTick()
+    {
+        try
+        {
+            Tick?.Invoke();
+        }
+        catch (Exception e)
+        {
+            Logger.LogError(e, "Error in UiTimer tick");
+        }
+        finally
+        {
+            Interlocked.Exchange(ref _inTick, 0);
+
+            if (_enabled)
+            {
+                try { _timer.Change(Interval, Timeout.InfiniteTimeSpan); }
+                catch (ObjectDisposedException) { /* ignore */ }
+            }
+        }
+    }
+
+    public void Dispose() => _timer.Dispose();
+}


### PR DESCRIPTION
Uses a custom PeriodicUiTimer instead of the Forms.Timer for file watching.

The PeriodicUiTimer uses the dispatcher to post the tick events, ensuring they are executed on the UI thread.
