### PR TITLE
Adds HorizontalAlignment support to TextBox Caret & Selection

### DIFF
--- a/MonoGameGum/Forms/Controls/TextBoxBase.cs
+++ b/MonoGameGum/Forms/Controls/TextBoxBase.cs
@@ -91,10 +91,13 @@ public abstract class TextBoxBase :
         get => caretIndex; 
         set
         {
-            if(value != caretIndex)
+            bool valueChanged = value != caretIndex;
+
+            caretIndex = value;
+            UpdateCaretPositionFromCaretIndex();
+
+            if (valueChanged)
             {
-                caretIndex = value;
-                UpdateCaretPositionFromCaretIndex();
                 OffsetTextToKeepCaretInView();
                 PushValueToViewModel();
                 CaretIndexChanged?.Invoke(this, EventArgs.Empty);
@@ -359,6 +362,10 @@ public abstract class TextBoxBase :
             case "Text":
                 OnTextChanged(this.coreTextObject.RawText);
                 break;
+            case "HorizontalAlignment":
+                UpdateCaretPositionFromCaretIndex();
+                UpdateToSelection();
+                break;
         }
     }
 
@@ -546,13 +553,15 @@ public abstract class TextBoxBase :
 
             if (lineOn < coreTextObject.WrappedText.Count)
             {
-                int indexInThisLine = GetIndex(cursorOffset, coreTextObject.WrappedText[lineOn]);
+                string lineText = coreTextObject.WrappedText[lineOn];
+                cursorOffset -= GetLineXOffsetForHorizontalAlignment(lineText);
+                int indexInThisLine = GetIndex(cursorOffset, lineText);
 
                 var isOnLastLine = lineOn == coreTextObject.WrappedText.Count - 1;
                 if(!isOnLastLine && 
-                    indexInThisLine == coreTextObject.WrappedText[lineOn].Length &&
+                    indexInThisLine == lineText.Length &&
                     indexInThisLine > 0 &&
-                    char.IsWhiteSpace( coreTextObject.WrappedText[lineOn][indexInThisLine-1]))
+                    char.IsWhiteSpace(lineText[indexInThisLine-1]))
                 {
                     index = indexInThisLine - 1;
                 }
@@ -1524,12 +1533,25 @@ public abstract class TextBoxBase :
         if (this.coreTextObject.BitmapFont != null)
         {
             var measure = this.coreTextObject.BitmapFont.MeasureString(substring, global::RenderingLibrary.Graphics.HorizontalMeasurementStyle.Full);
-            return measure + this.textComponent.X;
+            return measure + this.textComponent.X + GetLineXOffsetForHorizontalAlignment(stringToMeasure);
         }
         else
         {
-            return caretComponent.X = 0;
+            return caretComponent.X = GetLineXOffsetForHorizontalAlignment(stringToMeasure);
         }
+    }
+
+    public float GetLineXOffsetForHorizontalAlignment(string stringToMeasure)
+    {
+        if (coreTextObject.HorizontalAlignment == global::RenderingLibrary.Graphics.HorizontalAlignment.Left)
+            return 0;
+
+        float measuredLineWidth = coreTextObject.MeasureString(stringToMeasure);
+        float textComponentWidth = textComponent.GetAbsoluteWidth();
+        float gapBetweenTextAndEdge = textComponentWidth - measuredLineWidth;
+        if (coreTextObject.HorizontalAlignment == global::RenderingLibrary.Graphics.HorizontalAlignment.Center)
+            gapBetweenTextAndEdge /= 2.0f;
+        return gapBetweenTextAndEdge;
     }
 
     float CoreTextObjectHeight =>

--- a/MonoGameGum/GueDeriving/TextRuntime.cs
+++ b/MonoGameGum/GueDeriving/TextRuntime.cs
@@ -92,7 +92,11 @@ public class TextRuntime : InteractiveGue
     public HorizontalAlignment HorizontalAlignment
     {
         get => ContainedText.HorizontalAlignment;
-        set => ContainedText.HorizontalAlignment = value;
+        set
+        {
+            ContainedText.HorizontalAlignment = value;
+            NotifyPropertyChanged();
+        }
     }
 
     public VerticalAlignment VerticalAlignment

--- a/RenderingLibrary/Graphics/Text.cs
+++ b/RenderingLibrary/Graphics/Text.cs
@@ -971,7 +971,7 @@ namespace RenderingLibrary.Graphics
             mNeedsBitmapFontRefresh = true;
         }
 
-        private float MeasureString(string whatToMeasure)
+        internal float MeasureString(string whatToMeasure)
         {
             if (this.BitmapFont != null)
             {


### PR DESCRIPTION
Previously the TextBox Caret & Selection visuals were only correct for left aligned text.

In summary:
- A method has been added called `GetLineXOffsetForHorizontalAlignment` which provides a per line offset where needed.
- Changing `HorizontalAlignment` at runtime also automatically adjusts visuals via `NotifyPropertyChanged`.
- Even if the `CaretIndex` doesn't change `UpdateCaretPositionFromCaretIndex` is now still called. This means forward deleting via the Delete key (where the index doesn't change but the total width does) updates visuals correctly for center/right alignment.

Suggestions:
- Rather than repeatedly measure strings for lines which haven't changed, a list of line widths could be added.
- For large text data, separating the line code into a separate class/struct may be useful. If a text modification only propagates over a few lines then the previous unchanged line objects could then be appended to the current list of lines.