### PR TITLE
Migrate AddFormsWindow

### DIFF
--- a/GumFormsPlugin/MainGumFormsPlugin.cs
+++ b/GumFormsPlugin/MainGumFormsPlugin.cs
@@ -90,10 +90,7 @@ internal class MainGumFormsPlugin : PluginBase
         #endregion
 
         var viewModel = new AddFormsViewModel(_formsFileService, _dialogService, _fileCommands);
-
-        var view = new AddFormsWindow(viewModel);
-        view.ShowDialog();
-
+        _dialogService.Show(viewModel);
     }
 
 }

--- a/GumFormsPlugin/ViewModels/AddFormsViewModel.cs
+++ b/GumFormsPlugin/ViewModels/AddFormsViewModel.cs
@@ -1,24 +1,16 @@
 ﻿using Gum.ToolStates;
-using Gum;
-using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Gum.Plugins.ImportPlugin.Manager;
 using ToolsUtilities;
-using Gum.Mvvm;
 using GumFormsPlugin.Services;
 using Gum.Managers;
-using System.Reflection.Metadata.Ecma335;
 using Gum.Commands;
-using Gum.Services;
 using Gum.Services.Dialogs;
-using Newtonsoft.Json;
 
 namespace GumFormsPlugin.ViewModels;
 
-public class AddFormsViewModel : ViewModel
+public class AddFormsViewModel : DialogViewModel
 {
     #region Fields/Properties
 
@@ -41,7 +33,7 @@ public class AddFormsViewModel : ViewModel
         _fileCommands = fileCommands;
     }
 
-    public void DoIt()
+    protected override void OnAffirmative()
     {
         var sourceDestinations = _formsFileService.GetSourceDestinations(IsIncludeDemoScreenGum);
         bool canSaveFiles = GetIfShouldSave(sourceDestinations);
@@ -65,6 +57,7 @@ public class AddFormsViewModel : ViewModel
                 _dialogService.ShowMessage("You must Save, then close/reopen the project.");
             }
         }
+        base.OnAffirmative();
     }
 
 

--- a/GumFormsPlugin/Views/AddFormsWindow.xaml
+++ b/GumFormsPlugin/Views/AddFormsWindow.xaml
@@ -1,22 +1,12 @@
-﻿<Window x:Class="GumFormsPlugin.Views.AddFormsWindow"
-        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-        xmlns:local="clr-namespace:GumFormsPlugin.Views"
-        mc:Ignorable="d"
-        Title="Add Forms" Height="150" Width="300">
-    <Grid>
-        <Grid.RowDefinitions>
-            <RowDefinition></RowDefinition>
-            <RowDefinition Height="Auto"></RowDefinition>
-        </Grid.RowDefinitions>
-        <StackPanel Margin="5">
-            <CheckBox IsChecked="{Binding IsIncludeDemoScreenGum}">Include DemoScreenGum</CheckBox>
-        </StackPanel>
-        <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Grid.Row="1" Margin="5">
-            <Button Click="OkButtonClicked" Width="60">OK</Button>
-            <Button Click="CancelButtonClicked" Width="60" Margin="5,0,0,0">Cancel</Button>
-        </StackPanel>
-    </Grid>
-</Window>
+﻿<UserControl
+  x:Class="GumFormsPlugin.Views.AddFormsWindow"
+  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+  xmlns:dialogs="clr-namespace:Gum.Services.Dialogs;assembly=Gum"
+  xmlns:local="clr-namespace:GumFormsPlugin.Views"
+  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+  dialogs:Dialog.DialogTitle="Add Forms"
+  mc:Ignorable="d">
+      <CheckBox IsChecked="{Binding IsIncludeDemoScreenGum}">Include DemoScreenGum</CheckBox>
+</UserControl>

--- a/GumFormsPlugin/Views/AddFormsWindow.xaml.cs
+++ b/GumFormsPlugin/Views/AddFormsWindow.xaml.cs
@@ -13,32 +13,20 @@ using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Shapes;
+using Gum.Services.Dialogs;
 
 namespace GumFormsPlugin.Views
 {
     /// <summary>
     /// Interaction logic for AddFormsWindow.xaml
     /// </summary>
-    public partial class AddFormsWindow : Window
+    [Dialog(typeof(AddFormsViewModel))]
+    public partial class AddFormsWindow : UserControl
     {
-        AddFormsViewModel ViewModel => DataContext as AddFormsViewModel;
-        public AddFormsWindow(AddFormsViewModel addFormsViewModel)
+        public AddFormsWindow()
         {
             InitializeComponent();
-
-            DataContext = addFormsViewModel;
         }
 
-        private void OkButtonClicked(object sender, RoutedEventArgs e)
-        {
-            ViewModel.DoIt();
-            this.DialogResult = true;
-
-        }
-
-        private void CancelButtonClicked(object sender, RoutedEventArgs e)
-        {
-            this.DialogResult = false;
-        }
     }
 }


### PR DESCRIPTION
Uses the IDialogService to show the AddFormsWindow instead of directly instantiating and showing a Window.
This aligns with the standard approach for showing dialogs in Gum and enables more flexibility in how dialogs are presented.
The AddFormsWindow is now a UserControl rather than a Window to allow usage with the IDialogService.
