### PR TITLE
Added a shortcut function to get all Visual Children by type

### DIFF
--- a/GumDataTypes/GumProjectSave.cs
+++ b/GumDataTypes/GumProjectSave.cs
@@ -401,6 +401,21 @@ public class GumProjectSave
 		}
 #endif
 
+    /// <summary>
+    ///  shortcut function to fetch a specific screen from your gum project.
+    /// <code ang="csharp">
+    /// //same as :
+    /// screen.Find(item => item.Name == "name");
+    /// </code>
+    ///  
+    /// </summary>
+    /// <param name="screenName"></param>
+    /// <returns></returns>
+    public ScreenSave? GetScreenSave(string screenName)
+    {
+        return Screens.FirstOrDefault(item => item.Name == screenName);
+    }
+
     private void PopulateElementSavesFromReferences(string projectRootDirectory, LinkLoadingPreference linkLoadingPreference, GumLoadResult result)
     {
         string errors = "";

--- a/GumDataTypes/GumProjectSave.cs
+++ b/GumDataTypes/GumProjectSave.cs
@@ -416,6 +416,36 @@ public class GumProjectSave
         return Screens.FirstOrDefault(item => item.Name == screenName);
     }
 
+
+    /// <summary>
+    /// shortcu function to fetch a specific component from your gum project
+    ///
+    /// <code ang="csharp">
+    /// //same as :
+    /// components.Find(item => item.Name == "name");
+    /// </code>
+    /// </summary>
+    /// <param name="componentName"></param>
+    /// <returns></returns>
+    public ComponentSave? GetComponentSave(string componentName)
+    {
+        return Components.FirstOrDefault(item => item.Name == componentName);
+    }
+
+    /// <summary>
+    /// shortcut function to fetch a specific standard elements from your gum project.
+    ///
+    /// <code ang="csharp">
+    /// //same as :
+    /// standards.Find(item => item.Name == "name");
+    /// </code>
+    /// </summary>
+    /// <param name="standardElementName"></param>
+    /// <returns></returns>
+    public StandardElementSave? GetStandardElementSave(string standardElementName)
+    {
+        return StandardElements.FirstOrDefault(item => item.Name == standardElementName);
+    }
     private void PopulateElementSavesFromReferences(string projectRootDirectory, LinkLoadingPreference linkLoadingPreference, GumLoadResult result)
     {
         string errors = "";

--- a/MonoGameGum/Forms/Controls/FrameworkElement.cs
+++ b/MonoGameGum/Forms/Controls/FrameworkElement.cs
@@ -720,6 +720,37 @@ public class FrameworkElement
 
     }
 
+
+    /// <summary>
+    /// return all the children of an element who match the required type
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <returns></returns>
+    public List<T> GetAllVisualsByType<T>() where T : GraphicalUiElement
+    {
+        List<T> list = [];
+        var children = Visual.Children;
+        foreach (var child in  children)
+        {
+            if (child is T mathchingChild)
+            {
+                list.Add(mathchingChild);
+            }
+        }
+        return list;
+    }
+
+    /// <summary>
+    /// Return all the children of an element and turn it into a list.
+    /// </summary>
+    /// <remarks>
+    /// do take in consideration you still need to cast the  elements if you seeking to have specific type just use GetAllVisualsByType
+    /// </remarks>
+    /// <returns></returns>
+    public List<IRenderableIpso> GetAllVisuals()
+    {
+        return Visual.Children.ToList();
+    }
     public T? GetVisual<T>(string? name = null) where T : GraphicalUiElement
     {
         var currentItem = Visual;


### PR DESCRIPTION
This function allow for fetching all the children of an Visual specific to a type.

Where would that have usage?  : 
When you need to fetch multiple list of buttons or multiple elements that you want to change at runtime.