### PR TITLE
Update sonarscanner.yml

### DIFF
--- a/.github/workflows/sonarscanner.yml
+++ b/.github/workflows/sonarscanner.yml
@@ -34,7 +34,8 @@ jobs:
           key: ${{ runner.os }}-sonar-scanner
           restore-keys: ${{ runner.os }}-sonar-scanner
       - name: Install SonarQube scanner
-        if: steps.cache-sonar-scanner.outputs.cache-hit != 'true'
+        # Remove caching for now, this is to make sure we are on the newest version of the scanner
+        #if: steps.cache-sonar-scanner.outputs.cache-hit != 'true'
         shell: powershell
         run: |
           New-Item -Path .\.sonar\scanner -ItemType Directory


### PR DESCRIPTION
Removing the cache, which should force the install of the dotnet-scanner to be the latest always.  Since this runs AFTER The merge into the primary branch, it shouldn't impact other PR's.

We can always add it back after the version gets "bumped"

Also, this fixes #1353 but technically we were not using the github specific action, so we were not impacted by this.  However, just in case we were somehow impacted by the changes I've removed the cache so we get the newest scanner.