### PR TITLE
Update wine and winetricks installation checks

### DIFF
--- a/setup_gum_linux.sh
+++ b/setup_gum_linux.sh
@@ -91,7 +91,7 @@ fi
 ################################################################################
 ### Check if winetricks is installed
 ################################################################################
-if ! command -v winetricks &> /dev/null; then
+if ! winetricks --version &> /dev/null; then
     echo "Winetricks is not installed. Attempting to install..."
 
     case "$DISTRO" in

--- a/setup_gum_linux.sh
+++ b/setup_gum_linux.sh
@@ -20,7 +20,7 @@ esac
 
 echo "Verifying that WINE is installed..."
 
-if ! command -v wine &> /dev/null; then
+if ! wine --version &> /dev/null; then
     echo "Wine is not installed. Attempting to install..."
 
     DISTRO=$(( lsb_release -si 2>/dev/null || grep '^ID=' /etc/os-release ) | cut -d= -f2 | tr -d '"' | tr '[:upper:]'  '[:lower:]')

--- a/setup_gum_mac.sh
+++ b/setup_gum_mac.sh
@@ -4,7 +4,7 @@
 ### Check if wine-stable is installed
 ################################################################################
 echo "Verifying that WINE is installed..."
-if ! command -v wine &> /dev/null
+if ! wine --version &> /dev/null
 then
     echo "Wine-stable is not installed."
     echo "Please install Wine-stable using the following command:"
@@ -16,7 +16,7 @@ fi
 ### Check if winetricks is installed
 ################################################################################
 echo "Verifying that winetricks is installed..."
-if ! command -v winetricks &> /dev/null
+if ! winetricks --version &> /dev/null
 then
     echo "Winetricks is not installed."
     echo "Please install Winetricks using the following command:"


### PR DESCRIPTION
## Description

This updates both the linux and the mac install scripts to use the `wine --version` and `winetricks --version` command directly to test for installation instead of using `command -v`

`command -v` only checks if the command exists in `$PATH`. By calling the executables directly, you are verifying that they are executable and functional.  Wine needs to work, not just exist