### PR TITLE
Duplicate CSV entries for localization now preserves first

### DIFF
--- a/CsvLibrary/CsvFileManager.cs
+++ b/CsvLibrary/CsvFileManager.cs
@@ -274,14 +274,21 @@ namespace CsvLibrary
         }
 
 
-        public static void CsvDeserializeDictionary<KeyType, ValueType>(string fileName, Dictionary<KeyType, ValueType> dictionaryToPopulate, out RuntimeCsvRepresentation rcr)
+        public static void CsvDeserializeDictionary<KeyType, ValueType>(string fileName, Dictionary<KeyType, ValueType> dictionaryToPopulate, 
+            out RuntimeCsvRepresentation rcr)
         {
             rcr = CsvDeserializeToRuntime(fileName);
 
             rcr.FillObjectDictionary<KeyType, ValueType>(dictionaryToPopulate, "Global");
         }
 
+        public static void CsvDeserializeDictionary<KeyType, ValueType>(string fileName, Dictionary<KeyType, ValueType> dictionaryToPopulate, 
+            DuplicateDictionaryEntryBehavior duplicateDictionaryEntryBehavior, out RuntimeCsvRepresentation rcr)
+        {
+            rcr = CsvDeserializeToRuntime(fileName);
 
+            rcr.FillObjectDictionary<KeyType, ValueType>(dictionaryToPopulate, "Global", duplicateDictionaryEntryBehavior);
+        }
 
     }
 }

--- a/Gum/Managers/LocalizationManager.cs
+++ b/Gum/Managers/LocalizationManager.cs
@@ -53,7 +53,11 @@ namespace Gum.Managers
             //CsvFileManager.Delimiter = delimiter;
             Dictionary<string, string[]> entryDictionary = new Dictionary<string, string[]>();
 
-            CsvFileManager.CsvDeserializeDictionary<string, string[]>(fileName, entryDictionary, out rcr);
+            CsvFileManager.CsvDeserializeDictionary<string, string[]>(fileName, 
+                entryDictionary, 
+                // FRB supports multiple lines of text per single string ID. We don't support this in Gum (yet?), so just use the first:
+                DuplicateDictionaryEntryBehavior.PreserveFirst,
+                out rcr);
             //CsvFileManager.Delimiter = oldDelimiter;
             var keys = entryDictionary.Keys.ToArray();
             foreach(var key in keys)


### PR DESCRIPTION
This allows FRB CSVs to be used.