### PR TITLE
Add minimum width enforcement for tool panels

### DIFF
--- a/Gum/Plugins/InternalPlugins/HideShowTools/MainHideShowToolsPlugin.cs
+++ b/Gum/Plugins/InternalPlugins/HideShowTools/MainHideShowToolsPlugin.cs
@@ -14,7 +14,7 @@ namespace Gum.Plugins.InternalPlugins.HideShowTools;
 [Export(typeof(PluginBase))]
 internal class MainHideShowToolsPlugin : InternalPlugin
 {
-    private ToolStripMenuItem menuItem;
+    private ToolStripMenuItem _hideShowMenuItem;
     private readonly MainPanelViewModel _mainPanelViewModel;
 
     public MainHideShowToolsPlugin()
@@ -24,13 +24,19 @@ internal class MainHideShowToolsPlugin : InternalPlugin
     
     public override void StartUp()
     {
-        menuItem = AddMenuItem("View", "Hide Tools");
-        menuItem.Click += HandleMenuItemClick;
+        _hideShowMenuItem = AddMenuItem("View", "Hide Tools");
+        _hideShowMenuItem.Click += HandleMenuItemClick;
     }
 
     private void HandleMenuItemClick(object sender, EventArgs e)
     {
         _mainPanelViewModel.IsToolsVisible = !_mainPanelViewModel.IsToolsVisible;
-        menuItem.Text = _mainPanelViewModel.IsToolsVisible ? "Hide Tools" : "Show Tools";
+
+        if(_mainPanelViewModel.IsToolsVisible)
+        {
+            _mainPanelViewModel.EnsureMinimumWidth();
+        }
+
+        _hideShowMenuItem.Text = _mainPanelViewModel.IsToolsVisible ? "Hide Tools" : "Show Tools";
     }
 }

--- a/Gum/ViewModels/MainPanelViewModel.cs
+++ b/Gum/ViewModels/MainPanelViewModel.cs
@@ -143,4 +143,12 @@ public class MainPanelViewModel : ViewModel, ITabManager, IRecipient<Application
     {
         message.OnTearDown(SaveLayoutSettings);
     }
+
+    internal void EnsureMinimumWidth()
+    {
+        const int minWidth = 20;
+        LeftColumnWidth = Math.Max(LeftColumnWidth, minWidth);
+        CenterColumnWidth = Math.Max(CenterColumnWidth, minWidth);
+        BottomRightHeight = Math.Max(BottomRightHeight, minWidth);
+    }
 }


### PR DESCRIPTION
Introduces EnsureMinimumWidth in MainPanelViewModel to guarantee a minimum size for panel columns and height when tools are shown. Updates MainHideShowToolsPlugin to call this method when toggling tool visibility.