### PR TITLE
Remove the transforms that are not needed

### DIFF
--- a/Gum/Themes/Frb.Styles.Defaults.xaml
+++ b/Gum/Themes/Frb.Styles.Defaults.xaml
@@ -166,11 +166,6 @@
     <Setter Property="BorderBrush" Value="{DynamicResource Frb.Brushes.Contrast02}" />
     <Setter Property="Foreground" Value="{DynamicResource Frb.Brushes.Foreground}" />
     <Setter Property="FontSize" Value="{Binding Source={StaticResource Scale}, Path=Body}" />
-    <Setter Property="LayoutTransform">
-      <Setter.Value>
-        <ScaleTransform ScaleX="{Binding Source={StaticResource Scale}, Path=Ui}" ScaleY="{Binding Source={StaticResource Scale}, Path=Ui}" />
-      </Setter.Value>
-    </Setter>
   </Style>
 
   <!--  Popup  -->
@@ -1136,10 +1131,6 @@
             BorderBrush="{DynamicResource Frb.Brushes.Contrast03}"
             BorderThickness="1"
             CornerRadius="2">
-            <Border.LayoutTransform>
-              <ScaleTransform ScaleX="{Binding Source={StaticResource Scale}, Path=Ui}" ScaleY="{Binding Source={StaticResource Scale}, Path=Ui}" />
-
-            </Border.LayoutTransform>
             <StackPanel
               ClipToBounds="True"
               IsItemsHost="True"


### PR DESCRIPTION
Remove transforms as @vicdotexe  suggested, scaling still works for tooltips and the menu in animations.

Fixes #1697 