### PR TITLE
Update KNI version to 4.2

### DIFF
--- a/MonoGameGum/KniGum/KniGum.csproj
+++ b/MonoGameGum/KniGum/KniGum.csproj
@@ -6,7 +6,7 @@
 		<Nullable>enable</Nullable>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 		<PackageId>Gum.KNI</PackageId>
-		<Version>2025.10.31.1</Version>
+		<Version>2025.11.10.1</Version>
 
 
 
@@ -134,16 +134,16 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="nkast.Xna.Framework" Version="4.1.9001" />
-		<PackageReference Include="nkast.Xna.Framework.Content" Version="4.1.9001" />
-		<PackageReference Include="nkast.Xna.Framework.Graphics" Version="4.1.9001" />
-		<PackageReference Include="nkast.Xna.Framework.Audio" Version="4.1.9001" />
-		<PackageReference Include="nkast.Xna.Framework.Media" Version="4.1.9001" />
-		<PackageReference Include="nkast.Xna.Framework.Input" Version="4.1.9001" />
-		<PackageReference Include="nkast.Xna.Framework.Game" Version="4.1.9001" />
-		<PackageReference Include="nkast.Xna.Framework.Devices" Version="4.1.9001" />
-		<PackageReference Include="nkast.Xna.Framework.Storage" Version="4.1.9001" />
-		<PackageReference Include="nkast.Xna.Framework.XR" Version="4.1.9001" />
+		<PackageReference Include="nkast.Xna.Framework" Version="4.2.9001" />
+		<PackageReference Include="nkast.Xna.Framework.Content" Version="4.2.9001" />
+		<PackageReference Include="nkast.Xna.Framework.Graphics" Version="4.2.9001" />
+		<PackageReference Include="nkast.Xna.Framework.Audio" Version="4.2.9001" />
+		<PackageReference Include="nkast.Xna.Framework.Media" Version="4.2.9001" />
+		<PackageReference Include="nkast.Xna.Framework.Input" Version="4.2.9001" />
+		<PackageReference Include="nkast.Xna.Framework.Game" Version="4.2.9001" />
+		<PackageReference Include="nkast.Xna.Framework.Devices" Version="4.2.9001" />
+		<PackageReference Include="nkast.Xna.Framework.Storage" Version="4.2.9001" />
+		<PackageReference Include="nkast.Xna.Framework.XR" Version="4.2.9001" />
 
 		<PackageReference Include="TextCopy" Version="6.2.1" />
 	</ItemGroup>

--- a/Samples/GumFormsSample/GumFormsSampleCommon/KniGumFormsSampleCommon.csproj
+++ b/Samples/GumFormsSample/GumFormsSampleCommon/KniGumFormsSampleCommon.csproj
@@ -20,16 +20,16 @@
 	
 	
   <ItemGroup>
-    <PackageReference Include="nkast.Xna.Framework" Version="4.1.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Content" Version="4.1.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Graphics" Version="4.1.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Audio" Version="4.1.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Media" Version="4.1.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Input" Version="4.1.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Game" Version="4.1.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Devices" Version="4.1.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Storage" Version="4.1.9001" />
-    <PackageReference Include="nkast.Xna.Framework.XR" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework" Version="4.2.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Content" Version="4.2.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Graphics" Version="4.2.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Audio" Version="4.2.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Media" Version="4.2.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Input" Version="4.2.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Game" Version="4.2.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Devices" Version="4.2.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Storage" Version="4.2.9001" />
+    <PackageReference Include="nkast.Xna.Framework.XR" Version="4.2.9001" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Samples/GumFormsSample/KniGumFormsSample.Android/KniGumFormsSample.Android.csproj
+++ b/Samples/GumFormsSample/KniGumFormsSample.Android/KniGumFormsSample.Android.csproj
@@ -26,18 +26,18 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="nkast.Xna.Framework" Version="4.1.9001" />
-		<PackageReference Include="nkast.Xna.Framework.Content" Version="4.1.9001" />
-		<PackageReference Include="nkast.Xna.Framework.Graphics" Version="4.1.9001" />
-		<PackageReference Include="nkast.Xna.Framework.Audio" Version="4.1.9001" />
-		<PackageReference Include="nkast.Xna.Framework.Media" Version="4.1.9001" />
-		<PackageReference Include="nkast.Xna.Framework.Input" Version="4.1.9001" />
-		<PackageReference Include="nkast.Xna.Framework.Game" Version="4.1.9001" />
-		<PackageReference Include="nkast.Xna.Framework.Devices" Version="4.1.9001" />
-		<PackageReference Include="nkast.Xna.Framework.Storage" Version="4.1.9001" />
-		<PackageReference Include="nkast.Xna.Framework.XR" Version="4.1.9001" />
-		<PackageReference Include="nkast.Kni.Platform.Android.GL" Version="4.1.9001" />
-		<PackageReference Include="nkast.Xna.Framework.Content.Pipeline.Builder" Version="4.1.9001" />
+		<PackageReference Include="nkast.Xna.Framework" Version="4.2.9001" />
+		<PackageReference Include="nkast.Xna.Framework.Content" Version="4.2.9001" />
+		<PackageReference Include="nkast.Xna.Framework.Graphics" Version="4.2.9001" />
+		<PackageReference Include="nkast.Xna.Framework.Audio" Version="4.2.9001" />
+		<PackageReference Include="nkast.Xna.Framework.Media" Version="4.2.9001" />
+		<PackageReference Include="nkast.Xna.Framework.Input" Version="4.2.9001" />
+		<PackageReference Include="nkast.Xna.Framework.Game" Version="4.2.9001" />
+		<PackageReference Include="nkast.Xna.Framework.Devices" Version="4.2.9001" />
+		<PackageReference Include="nkast.Xna.Framework.Storage" Version="4.2.9001" />
+		<PackageReference Include="nkast.Xna.Framework.XR" Version="4.2.9001" />
+		<PackageReference Include="nkast.Kni.Platform.Android.GL" Version="4.2.9001.1" />
+		<PackageReference Include="nkast.Xna.Framework.Content.Pipeline.Builder" Version="4.2.9001" />
 	</ItemGroup>
 	<ItemGroup>
 		<Compile Include="GumFormsSampleActivity.cs" />

--- a/Samples/GumFormsSample/KniGumFormsSample.BlazorGL/KniGumFormsSample.BlazorGL.csproj
+++ b/Samples/GumFormsSample/KniGumFormsSample.BlazorGL/KniGumFormsSample.BlazorGL.csproj
@@ -28,23 +28,23 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="nkast.Xna.Framework" Version="4.1.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Content" Version="4.1.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Graphics" Version="4.1.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Audio" Version="4.1.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Media" Version="4.1.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Input" Version="4.1.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Game" Version="4.1.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Devices" Version="4.1.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Storage" Version="4.1.9001" />
-    <PackageReference Include="nkast.Xna.Framework.XR" Version="4.1.9001" />
-    <PackageReference Include="nkast.Kni.Platform.Blazor.GL" Version="4.1.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Content.Pipeline.Builder" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework" Version="4.2.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Content" Version="4.2.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Graphics" Version="4.2.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Audio" Version="4.2.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Media" Version="4.2.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Input" Version="4.2.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Game" Version="4.2.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Devices" Version="4.2.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Storage" Version="4.2.9001" />
+    <PackageReference Include="nkast.Xna.Framework.XR" Version="4.2.9001" />
+    <PackageReference Include="nkast.Kni.Platform.Blazor.GL" Version="4.2.9001.1" />
+    <PackageReference Include="nkast.Xna.Framework.Content.Pipeline.Builder" Version="4.2.9001" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.11" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.11" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.17" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.17" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Samples/GumFormsSample/KniGumFormsSample.BlazorGL/wwwroot/index.html
+++ b/Samples/GumFormsSample/KniGumFormsSample.BlazorGL/wwwroot/index.html
@@ -59,17 +59,17 @@
         });
     </script>
 
-    <script src="_content/nkast.Wasm.Dom/js/JSObject.8.0.5.js"></script>
-    <script src="_content/nkast.Wasm.Dom/js/Window.8.0.5.js"></script>
-    <script src="_content/nkast.Wasm.Dom/js/Document.8.0.5.js"></script>
-    <script src="_content/nkast.Wasm.Dom/js/Navigator.8.0.5.js"></script>
-    <script src="_content/nkast.Wasm.Dom/js/Gamepad.8.0.5.js"></script>
-    <script src="_content/nkast.Wasm.Dom/js/Media.8.0.5.js"></script>
-    <script src="_content/nkast.Wasm.XHR/js/XHR.8.0.5.js"></script>
-    <script src="_content/nkast.Wasm.Canvas/js/Canvas.8.0.5.js"></script>
-    <script src="_content/nkast.Wasm.Canvas/js/CanvasGLContext.8.0.5.js"></script>
-    <script src="_content/nkast.Wasm.Audio/js/Audio.8.0.5.js"></script>
-    <script src="_content/nkast.Wasm.XR/js/XR.8.0.5.js"></script>
+    <script src="_content/nkast.Wasm.JSInterop/js/JSObject.8.0.11.js"></script>
+    <script src="_content/nkast.Wasm.Dom/js/Window.8.0.11.js"></script>
+    <script src="_content/nkast.Wasm.Dom/js/Document.8.0.11.js"></script>
+    <script src="_content/nkast.Wasm.Dom/js/Navigator.8.0.11.js"></script>
+    <script src="_content/nkast.Wasm.Dom/js/Gamepad.8.0.11.js"></script>
+    <script src="_content/nkast.Wasm.Dom/js/Media.8.0.11.js"></script>
+    <script src="_content/nkast.Wasm.XHR/js/XHR.8.0.11.js"></script>
+    <script src="_content/nkast.Wasm.Canvas/js/Canvas.8.0.11.js"></script>
+    <script src="_content/nkast.Wasm.Canvas/js/CanvasGLContext.8.0.11.js"></script>
+    <script src="_content/nkast.Wasm.Audio/js/Audio.8.0.11.js"></script>
+    <script src="_content/nkast.Wasm.XR/js/XR.8.0.11.js"></script>
 
     <script>
         function tickJS()
@@ -94,20 +94,19 @@
             window.requestAnimationFrame(tickJS);
         };
 
-        window.onkeydown = function(event)
+        window.addEventListener("keydown", function(event)
         {
             // Prevent Arrows Keys and Spacebar scrolling the outer page
             // when running inside an iframe. e.g: itch.io embedding.
             if ([32, 37, 38, 39, 40].indexOf(event.keyCode) > -1)
                 event.preventDefault();
-        };
-		function preventScroll(event) {
-			// Prevent Mousewheel scrolling the outer page
-			// when running inside an iframe. e.g: itch.io embedding.
-			event.preventDefault();
-		}
-		window.onmousewheel = preventScroll;      // optional fallback for old browsers
-		window.addEventListener('wheel', preventScroll, { passive: false });
+        });
+        window.addEventListener("wheel", function(event)
+        {
+            // Prevent Mousewheel scrolling the outer page
+            // when running inside an iframe. e.g: itch.io embedding.
+            event.preventDefault();
+        }, { passive: false });
     </script>
 </body>
 

--- a/Samples/GumFormsSample/KniGumFormsSample.DesktopGL/KniGumFormsSample.DesktopGL.csproj
+++ b/Samples/GumFormsSample/KniGumFormsSample.DesktopGL/KniGumFormsSample.DesktopGL.csproj
@@ -29,18 +29,18 @@
 		<ApplicationManifest>app.manifest</ApplicationManifest>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="nkast.Xna.Framework" Version="4.1.9001" />
-		<PackageReference Include="nkast.Xna.Framework.Content" Version="4.1.9001" />
-		<PackageReference Include="nkast.Xna.Framework.Graphics" Version="4.1.9001" />
-		<PackageReference Include="nkast.Xna.Framework.Audio" Version="4.1.9001" />
-		<PackageReference Include="nkast.Xna.Framework.Media" Version="4.1.9001" />
-		<PackageReference Include="nkast.Xna.Framework.Input" Version="4.1.9001" />
-		<PackageReference Include="nkast.Xna.Framework.Game" Version="4.1.9001" />
-		<PackageReference Include="nkast.Xna.Framework.Devices" Version="4.1.9001" />
-		<PackageReference Include="nkast.Xna.Framework.Storage" Version="4.1.9001" />
-		<PackageReference Include="nkast.Xna.Framework.XR" Version="4.1.9001" />
-		<PackageReference Include="nkast.Kni.Platform.SDL2.GL" Version="4.1.9001" />
-		<PackageReference Include="nkast.Xna.Framework.Content.Pipeline.Builder" Version="4.1.9001" />
+		<PackageReference Include="nkast.Xna.Framework" Version="4.2.9001" />
+		<PackageReference Include="nkast.Xna.Framework.Content" Version="4.2.9001" />
+		<PackageReference Include="nkast.Xna.Framework.Graphics" Version="4.2.9001" />
+		<PackageReference Include="nkast.Xna.Framework.Audio" Version="4.2.9001" />
+		<PackageReference Include="nkast.Xna.Framework.Media" Version="4.2.9001" />
+		<PackageReference Include="nkast.Xna.Framework.Input" Version="4.2.9001" />
+		<PackageReference Include="nkast.Xna.Framework.Game" Version="4.2.9001" />
+		<PackageReference Include="nkast.Xna.Framework.Devices" Version="4.2.9001" />
+		<PackageReference Include="nkast.Xna.Framework.Storage" Version="4.2.9001" />
+		<PackageReference Include="nkast.Xna.Framework.XR" Version="4.2.9001" />
+		<PackageReference Include="nkast.Kni.Platform.SDL2.GL" Version="4.2.9001.1" />
+		<PackageReference Include="nkast.Xna.Framework.Content.Pipeline.Builder" Version="4.2.9001" />
 	</ItemGroup>
 	<ItemGroup>
 		<Compile Include="Program.cs" />

--- a/Samples/GumFormsSample/KniGumFormsSample.WindowsDX/KniGumFormsSample.WindowsDX.csproj
+++ b/Samples/GumFormsSample/KniGumFormsSample.WindowsDX/KniGumFormsSample.WindowsDX.csproj
@@ -28,18 +28,18 @@
 		<ApplicationManifest>app.manifest</ApplicationManifest>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="nkast.Xna.Framework" Version="4.1.9001" />
-		<PackageReference Include="nkast.Xna.Framework.Content" Version="4.1.9001" />
-		<PackageReference Include="nkast.Xna.Framework.Graphics" Version="4.1.9001" />
-		<PackageReference Include="nkast.Xna.Framework.Audio" Version="4.1.9001" />
-		<PackageReference Include="nkast.Xna.Framework.Media" Version="4.1.9001" />
-		<PackageReference Include="nkast.Xna.Framework.Input" Version="4.1.9001" />
-		<PackageReference Include="nkast.Xna.Framework.Game" Version="4.1.9001" />
-		<PackageReference Include="nkast.Xna.Framework.Devices" Version="4.1.9001" />
-		<PackageReference Include="nkast.Xna.Framework.Storage" Version="4.1.9001" />
-		<PackageReference Include="nkast.Xna.Framework.XR" Version="4.1.9001" />
-		<PackageReference Include="nkast.Kni.Platform.WinForms.DX11" Version="4.1.9001" />
-		<PackageReference Include="nkast.Xna.Framework.Content.Pipeline.Builder" Version="4.1.9001" />
+		<PackageReference Include="nkast.Xna.Framework" Version="4.2.9001" />
+		<PackageReference Include="nkast.Xna.Framework.Content" Version="4.2.9001" />
+		<PackageReference Include="nkast.Xna.Framework.Graphics" Version="4.2.9001" />
+		<PackageReference Include="nkast.Xna.Framework.Audio" Version="4.2.9001" />
+		<PackageReference Include="nkast.Xna.Framework.Media" Version="4.2.9001" />
+		<PackageReference Include="nkast.Xna.Framework.Input" Version="4.2.9001" />
+		<PackageReference Include="nkast.Xna.Framework.Game" Version="4.2.9001" />
+		<PackageReference Include="nkast.Xna.Framework.Devices" Version="4.2.9001" />
+		<PackageReference Include="nkast.Xna.Framework.Storage" Version="4.2.9001" />
+		<PackageReference Include="nkast.Xna.Framework.XR" Version="4.2.9001" />
+		<PackageReference Include="nkast.Kni.Platform.WinForms.DX11" Version="4.2.9001" />
+		<PackageReference Include="nkast.Xna.Framework.Content.Pipeline.Builder" Version="4.2.9001" />
 	</ItemGroup>
 	<ItemGroup>
 		<Compile Include="Program.cs" />

--- a/Samples/KniGumFromFile/KniGumFromFile.Android/KniGumFromFile.Android.csproj
+++ b/Samples/KniGumFromFile/KniGumFromFile.Android/KniGumFromFile.Android.csproj
@@ -26,18 +26,18 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="nkast.Xna.Framework" Version="4.1.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Content" Version="4.1.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Graphics" Version="4.1.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Audio" Version="4.1.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Media" Version="4.1.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Input" Version="4.1.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Game" Version="4.1.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Devices" Version="4.1.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Storage" Version="4.1.9001" />
-    <PackageReference Include="nkast.Xna.Framework.XR" Version="4.1.9001" />
-    <PackageReference Include="nkast.Kni.Platform.Android.GL" Version="4.1.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Content.Pipeline.Builder" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework" Version="4.2.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Content" Version="4.2.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Graphics" Version="4.2.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Audio" Version="4.2.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Media" Version="4.2.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Input" Version="4.2.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Game" Version="4.2.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Devices" Version="4.2.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Storage" Version="4.2.9001" />
+    <PackageReference Include="nkast.Xna.Framework.XR" Version="4.2.9001" />
+    <PackageReference Include="nkast.Kni.Platform.Android.GL" Version="4.2.9001.1" />
+    <PackageReference Include="nkast.Xna.Framework.Content.Pipeline.Builder" Version="4.2.9001" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="KniGumFromFileActivity.cs" />

--- a/Samples/KniGumFromFile/KniGumFromFile.BlazorGL/KniGumFromFile.BlazorGL.csproj
+++ b/Samples/KniGumFromFile/KniGumFromFile.BlazorGL/KniGumFromFile.BlazorGL.csproj
@@ -28,23 +28,23 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="nkast.Xna.Framework" Version="4.1.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Content" Version="4.1.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Graphics" Version="4.1.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Audio" Version="4.1.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Media" Version="4.1.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Input" Version="4.1.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Game" Version="4.1.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Devices" Version="4.1.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Storage" Version="4.1.9001" />
-    <PackageReference Include="nkast.Xna.Framework.XR" Version="4.1.9001" />
-    <PackageReference Include="nkast.Kni.Platform.Blazor.GL" Version="4.1.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Content.Pipeline.Builder" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework" Version="4.2.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Content" Version="4.2.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Graphics" Version="4.2.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Audio" Version="4.2.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Media" Version="4.2.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Input" Version="4.2.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Game" Version="4.2.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Devices" Version="4.2.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Storage" Version="4.2.9001" />
+    <PackageReference Include="nkast.Xna.Framework.XR" Version="4.2.9001" />
+    <PackageReference Include="nkast.Kni.Platform.Blazor.GL" Version="4.2.9001.1" />
+    <PackageReference Include="nkast.Xna.Framework.Content.Pipeline.Builder" Version="4.2.9001" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.11" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.11" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.17" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.17" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Samples/KniGumFromFile/KniGumFromFile.BlazorGL/wwwroot/index.html
+++ b/Samples/KniGumFromFile/KniGumFromFile.BlazorGL/wwwroot/index.html
@@ -57,17 +57,17 @@
             });
         </script>
 
-        <script src="_content/nkast.Wasm.Dom/js/JSObject.8.0.5.js"></script>
-        <script src="_content/nkast.Wasm.Dom/js/Window.8.0.5.js"></script>
-        <script src="_content/nkast.Wasm.Dom/js/Document.8.0.5.js"></script>
-        <script src="_content/nkast.Wasm.Dom/js/Navigator.8.0.5.js"></script>
-        <script src="_content/nkast.Wasm.Dom/js/Gamepad.8.0.5.js"></script>
-        <script src="_content/nkast.Wasm.Dom/js/Media.8.0.5.js"></script>
-        <script src="_content/nkast.Wasm.XHR/js/XHR.8.0.5.js"></script>
-        <script src="_content/nkast.Wasm.Canvas/js/Canvas.8.0.5.js"></script>
-        <script src="_content/nkast.Wasm.Canvas/js/CanvasGLContext.8.0.5.js"></script>
-        <script src="_content/nkast.Wasm.Audio/js/Audio.8.0.5.js"></script>
-        <script src="_content/nkast.Wasm.XR/js/XR.8.0.5.js"></script>
+        <script src="_content/nkast.Wasm.JSInterop/js/JSObject.8.0.11.js"></script>
+        <script src="_content/nkast.Wasm.Dom/js/Window.8.0.11.js"></script>
+        <script src="_content/nkast.Wasm.Dom/js/Document.8.0.11.js"></script>
+        <script src="_content/nkast.Wasm.Dom/js/Navigator.8.0.11.js"></script>
+        <script src="_content/nkast.Wasm.Dom/js/Gamepad.8.0.11.js"></script>
+        <script src="_content/nkast.Wasm.Dom/js/Media.8.0.11.js"></script>
+        <script src="_content/nkast.Wasm.XHR/js/XHR.8.0.11.js"></script>
+        <script src="_content/nkast.Wasm.Canvas/js/Canvas.8.0.11.js"></script>
+        <script src="_content/nkast.Wasm.Canvas/js/CanvasGLContext.8.0.11.js"></script>
+        <script src="_content/nkast.Wasm.Audio/js/Audio.8.0.11.js"></script>
+        <script src="_content/nkast.Wasm.XR/js/XR.8.0.11.js"></script>
 
         <script>
             function tickJS() {
@@ -90,19 +90,19 @@
                 window.requestAnimationFrame(tickJS);
             };
 
-            window.onkeydown = function (event) {
+            window.addEventListener("keydown", function(event)
+            {
                 // Prevent Arrows Keys and Spacebar scrolling the outer page
                 // when running inside an iframe. e.g: itch.io embedding.
                 if ([32, 37, 38, 39, 40].indexOf(event.keyCode) > -1)
                     event.preventDefault();
-            };
-			function preventScroll(event) {
-				// Prevent Mousewheel scrolling the outer page
-				// when running inside an iframe. e.g: itch.io embedding.
-				event.preventDefault();
-			}
-			window.onmousewheel = preventScroll;      // optional fallback for old browsers
-			window.addEventListener('wheel', preventScroll, { passive: false });
+            });
+            window.addEventListener("wheel", function(event)
+            {
+                // Prevent Mousewheel scrolling the outer page
+                // when running inside an iframe. e.g: itch.io embedding.
+                event.preventDefault();
+            }, { passive: false });
         </script>
 </body>
 

--- a/Samples/KniGumFromFile/KniGumFromFile.DesktopGL/KniGumFromFile.DesktopGL.csproj
+++ b/Samples/KniGumFromFile/KniGumFromFile.DesktopGL/KniGumFromFile.DesktopGL.csproj
@@ -29,18 +29,18 @@
     <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="nkast.Xna.Framework" Version="4.1.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Content" Version="4.1.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Graphics" Version="4.1.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Audio" Version="4.1.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Media" Version="4.1.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Input" Version="4.1.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Game" Version="4.1.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Devices" Version="4.1.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Storage" Version="4.1.9001" />
-    <PackageReference Include="nkast.Xna.Framework.XR" Version="4.1.9001" />
-    <PackageReference Include="nkast.Kni.Platform.SDL2.GL" Version="4.1.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Content.Pipeline.Builder" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework" Version="4.2.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Content" Version="4.2.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Graphics" Version="4.2.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Audio" Version="4.2.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Media" Version="4.2.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Input" Version="4.2.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Game" Version="4.2.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Devices" Version="4.2.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Storage" Version="4.2.9001" />
+    <PackageReference Include="nkast.Xna.Framework.XR" Version="4.2.9001" />
+    <PackageReference Include="nkast.Kni.Platform.SDL2.GL" Version="4.2.9001.1" />
+    <PackageReference Include="nkast.Xna.Framework.Content.Pipeline.Builder" Version="4.2.9001" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Program.cs" />

--- a/Samples/KniGumFromFile/KniGumFromFile.WindowsDX/KniGumFromFile.WindowsDX.csproj
+++ b/Samples/KniGumFromFile/KniGumFromFile.WindowsDX/KniGumFromFile.WindowsDX.csproj
@@ -28,18 +28,18 @@
     <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="nkast.Xna.Framework" Version="4.1.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Content" Version="4.1.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Graphics" Version="4.1.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Audio" Version="4.1.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Media" Version="4.1.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Input" Version="4.1.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Game" Version="4.1.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Devices" Version="4.1.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Storage" Version="4.1.9001" />
-    <PackageReference Include="nkast.Xna.Framework.XR" Version="4.1.9001" />
-    <PackageReference Include="nkast.Kni.Platform.WinForms.DX11" Version="4.1.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Content.Pipeline.Builder" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework" Version="4.2.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Content" Version="4.2.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Graphics" Version="4.2.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Audio" Version="4.2.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Media" Version="4.2.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Input" Version="4.2.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Game" Version="4.2.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Devices" Version="4.2.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Storage" Version="4.2.9001" />
+    <PackageReference Include="nkast.Xna.Framework.XR" Version="4.2.9001" />
+    <PackageReference Include="nkast.Kni.Platform.WinForms.DX11" Version="4.2.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Content.Pipeline.Builder" Version="4.2.9001" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Program.cs" />

--- a/Samples/KniGumFromFile/KniGumFromFileCommon/KniGumFromFileCommon.csproj
+++ b/Samples/KniGumFromFile/KniGumFromFileCommon/KniGumFromFileCommon.csproj
@@ -18,16 +18,16 @@
   </PropertyGroup>
 	
   <ItemGroup>
-	<PackageReference Include="nkast.Xna.Framework" Version="4.1.9001" />
-	<PackageReference Include="nkast.Xna.Framework.Content" Version="4.1.9001" />
-	<PackageReference Include="nkast.Xna.Framework.Graphics" Version="4.1.9001" />
-	<PackageReference Include="nkast.Xna.Framework.Audio" Version="4.1.9001" />
-	<PackageReference Include="nkast.Xna.Framework.Media" Version="4.1.9001" />
-	<PackageReference Include="nkast.Xna.Framework.Input" Version="4.1.9001" />
-	<PackageReference Include="nkast.Xna.Framework.Game" Version="4.1.9001" />
-	<PackageReference Include="nkast.Xna.Framework.Devices" Version="4.1.9001" />
-	<PackageReference Include="nkast.Xna.Framework.Storage" Version="4.1.9001" />
-	<PackageReference Include="nkast.Xna.Framework.XR" Version="4.1.9001" />
+	<PackageReference Include="nkast.Xna.Framework" Version="4.2.9001" />
+	<PackageReference Include="nkast.Xna.Framework.Content" Version="4.2.9001" />
+	<PackageReference Include="nkast.Xna.Framework.Graphics" Version="4.2.9001" />
+	<PackageReference Include="nkast.Xna.Framework.Audio" Version="4.2.9001" />
+	<PackageReference Include="nkast.Xna.Framework.Media" Version="4.2.9001" />
+	<PackageReference Include="nkast.Xna.Framework.Input" Version="4.2.9001" />
+	<PackageReference Include="nkast.Xna.Framework.Game" Version="4.2.9001" />
+	<PackageReference Include="nkast.Xna.Framework.Devices" Version="4.2.9001" />
+	<PackageReference Include="nkast.Xna.Framework.Storage" Version="4.2.9001" />
+	<PackageReference Include="nkast.Xna.Framework.XR" Version="4.2.9001" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Samples/KniGumInCode/KniGumInCode.Android/KniGumInCode.Android.csproj
+++ b/Samples/KniGumInCode/KniGumInCode.Android/KniGumInCode.Android.csproj
@@ -26,18 +26,18 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="nkast.Xna.Framework" Version="4.1.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Content" Version="4.1.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Graphics" Version="4.1.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Audio" Version="4.1.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Media" Version="4.1.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Input" Version="4.1.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Game" Version="4.1.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Devices" Version="4.1.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Storage" Version="4.1.9001" />
-    <PackageReference Include="nkast.Xna.Framework.XR" Version="4.1.9001" />
-    <PackageReference Include="nkast.Kni.Platform.Android.GL" Version="4.1.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Content.Pipeline.Builder" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework" Version="4.2.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Content" Version="4.2.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Graphics" Version="4.2.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Audio" Version="4.2.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Media" Version="4.2.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Input" Version="4.2.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Game" Version="4.2.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Devices" Version="4.2.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Storage" Version="4.2.9001" />
+    <PackageReference Include="nkast.Xna.Framework.XR" Version="4.2.9001" />
+    <PackageReference Include="nkast.Kni.Platform.Android.GL" Version="4.2.9001.1" />
+    <PackageReference Include="nkast.Xna.Framework.Content.Pipeline.Builder" Version="4.2.9001" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="KniGumInCodeActivity.cs" />

--- a/Samples/KniGumInCode/KniGumInCode.BlazorGL/KniGumInCode.BlazorGL.csproj
+++ b/Samples/KniGumInCode/KniGumInCode.BlazorGL/KniGumInCode.BlazorGL.csproj
@@ -28,23 +28,23 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="nkast.Xna.Framework" Version="4.1.9001" />
-		<PackageReference Include="nkast.Xna.Framework.Content" Version="4.1.9001" />
-		<PackageReference Include="nkast.Xna.Framework.Graphics" Version="4.1.9001" />
-		<PackageReference Include="nkast.Xna.Framework.Audio" Version="4.1.9001" />
-		<PackageReference Include="nkast.Xna.Framework.Media" Version="4.1.9001" />
-		<PackageReference Include="nkast.Xna.Framework.Input" Version="4.1.9001" />
-		<PackageReference Include="nkast.Xna.Framework.Game" Version="4.1.9001" />
-		<PackageReference Include="nkast.Xna.Framework.Devices" Version="4.1.9001" />
-		<PackageReference Include="nkast.Xna.Framework.Storage" Version="4.1.9001" />
-		<PackageReference Include="nkast.Xna.Framework.XR" Version="4.1.9001" />
-		<PackageReference Include="nkast.Kni.Platform.Blazor.GL" Version="4.1.9001" />
-		<PackageReference Include="nkast.Xna.Framework.Content.Pipeline.Builder" Version="4.1.9001" />
+		<PackageReference Include="nkast.Xna.Framework" Version="4.2.9001" />
+		<PackageReference Include="nkast.Xna.Framework.Content" Version="4.2.9001" />
+		<PackageReference Include="nkast.Xna.Framework.Graphics" Version="4.2.9001" />
+		<PackageReference Include="nkast.Xna.Framework.Audio" Version="4.2.9001" />
+		<PackageReference Include="nkast.Xna.Framework.Media" Version="4.2.9001" />
+		<PackageReference Include="nkast.Xna.Framework.Input" Version="4.2.9001" />
+		<PackageReference Include="nkast.Xna.Framework.Game" Version="4.2.9001" />
+		<PackageReference Include="nkast.Xna.Framework.Devices" Version="4.2.9001" />
+		<PackageReference Include="nkast.Xna.Framework.Storage" Version="4.2.9001" />
+		<PackageReference Include="nkast.Xna.Framework.XR" Version="4.2.9001" />
+		<PackageReference Include="nkast.Kni.Platform.Blazor.GL" Version="4.2.9001.1" />
+		<PackageReference Include="nkast.Xna.Framework.Content.Pipeline.Builder" Version="4.2.9001" />
 	</ItemGroup>
 
 	<ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
-		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.11" />
-		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.11" PrivateAssets="all" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.17" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.17" PrivateAssets="all" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Samples/KniGumInCode/KniGumInCode.BlazorGL/wwwroot/index.html
+++ b/Samples/KniGumInCode/KniGumInCode.BlazorGL/wwwroot/index.html
@@ -56,17 +56,17 @@
             });
         </script>
 
-        <script src="_content/nkast.Wasm.Dom/js/JSObject.8.0.5.js"></script>
-        <script src="_content/nkast.Wasm.Dom/js/Window.8.0.5.js"></script>
-        <script src="_content/nkast.Wasm.Dom/js/Document.8.0.5.js"></script>
-        <script src="_content/nkast.Wasm.Dom/js/Navigator.8.0.5.js"></script>
-        <script src="_content/nkast.Wasm.Dom/js/Gamepad.8.0.5.js"></script>
-        <script src="_content/nkast.Wasm.Dom/js/Media.8.0.5.js"></script>
-        <script src="_content/nkast.Wasm.XHR/js/XHR.8.0.5.js"></script>
-        <script src="_content/nkast.Wasm.Canvas/js/Canvas.8.0.5.js"></script>
-        <script src="_content/nkast.Wasm.Canvas/js/CanvasGLContext.8.0.5.js"></script>
-        <script src="_content/nkast.Wasm.Audio/js/Audio.8.0.5.js"></script>
-        <script src="_content/nkast.Wasm.XR/js/XR.8.0.5.js"></script>
+        <script src="_content/nkast.Wasm.JSInterop/js/JSObject.8.0.11.js"></script>
+        <script src="_content/nkast.Wasm.Dom/js/Window.8.0.11.js"></script>
+        <script src="_content/nkast.Wasm.Dom/js/Document.8.0.11.js"></script>
+        <script src="_content/nkast.Wasm.Dom/js/Navigator.8.0.11.js"></script>
+        <script src="_content/nkast.Wasm.Dom/js/Gamepad.8.0.11.js"></script>
+        <script src="_content/nkast.Wasm.Dom/js/Media.8.0.11.js"></script>
+        <script src="_content/nkast.Wasm.XHR/js/XHR.8.0.11.js"></script>
+        <script src="_content/nkast.Wasm.Canvas/js/Canvas.8.0.11.js"></script>
+        <script src="_content/nkast.Wasm.Canvas/js/CanvasGLContext.8.0.11.js"></script>
+        <script src="_content/nkast.Wasm.Audio/js/Audio.8.0.11.js"></script>
+        <script src="_content/nkast.Wasm.XR/js/XR.8.0.11.js"></script>
 
         <script>
             function tickJS(){
@@ -89,20 +89,19 @@
                 window.requestAnimationFrame(tickJS);
             };
 
-            window.onkeydown = function(event){
+            window.addEventListener("keydown", function(event)
+            {
                 // Prevent Arrows Keys and Spacebar scrolling the outer page
                 // when running inside an iframe. e.g: itch.io embedding.
                 if ([32, 37, 38, 39, 40].indexOf(event.keyCode) > -1)
                     event.preventDefault();
-            };
-			
-			function preventScroll(event) {
-				// Prevent Mousewheel scrolling the outer page
-				// when running inside an iframe. e.g: itch.io embedding.
-				event.preventDefault();
-			}
-			window.onmousewheel = preventScroll;      // optional fallback for old browsers
-			window.addEventListener('wheel', preventScroll, { passive: false });
+            });
+            window.addEventListener("wheel", function(event)
+            {
+                // Prevent Mousewheel scrolling the outer page
+                // when running inside an iframe. e.g: itch.io embedding.
+                event.preventDefault();
+            }, { passive: false });
         </script>
 </body>
 

--- a/Samples/KniGumInCode/KniGumInCode.DesktopGL/KniGumInCode.DesktopGL.csproj
+++ b/Samples/KniGumInCode/KniGumInCode.DesktopGL/KniGumInCode.DesktopGL.csproj
@@ -29,18 +29,18 @@
     <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="nkast.Xna.Framework" Version="4.1.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Content" Version="4.1.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Graphics" Version="4.1.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Audio" Version="4.1.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Media" Version="4.1.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Input" Version="4.1.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Game" Version="4.1.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Devices" Version="4.1.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Storage" Version="4.1.9001" />
-    <PackageReference Include="nkast.Xna.Framework.XR" Version="4.1.9001" />
-    <PackageReference Include="nkast.Kni.Platform.SDL2.GL" Version="4.1.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Content.Pipeline.Builder" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework" Version="4.2.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Content" Version="4.2.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Graphics" Version="4.2.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Audio" Version="4.2.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Media" Version="4.2.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Input" Version="4.2.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Game" Version="4.2.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Devices" Version="4.2.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Storage" Version="4.2.9001" />
+    <PackageReference Include="nkast.Xna.Framework.XR" Version="4.2.9001" />
+    <PackageReference Include="nkast.Kni.Platform.SDL2.GL" Version="4.2.9001.1" />
+    <PackageReference Include="nkast.Xna.Framework.Content.Pipeline.Builder" Version="4.2.9001" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Program.cs" />

--- a/Samples/KniGumInCode/KniGumInCode.WindowsDX/KniGumInCode.WindowsDX.csproj
+++ b/Samples/KniGumInCode/KniGumInCode.WindowsDX/KniGumInCode.WindowsDX.csproj
@@ -29,18 +29,18 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="nkast.Xna.Framework" Version="4.1.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Content" Version="4.1.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Graphics" Version="4.1.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Audio" Version="4.1.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Media" Version="4.1.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Input" Version="4.1.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Game" Version="4.1.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Devices" Version="4.1.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Storage" Version="4.1.9001" />
-    <PackageReference Include="nkast.Xna.Framework.XR" Version="4.1.9001" />
-    <PackageReference Include="nkast.Kni.Platform.WinForms.DX11" Version="4.1.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Content.Pipeline.Builder" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework" Version="4.2.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Content" Version="4.2.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Graphics" Version="4.2.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Audio" Version="4.2.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Media" Version="4.2.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Input" Version="4.2.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Game" Version="4.2.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Devices" Version="4.2.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Storage" Version="4.2.9001" />
+    <PackageReference Include="nkast.Xna.Framework.XR" Version="4.2.9001" />
+    <PackageReference Include="nkast.Kni.Platform.WinForms.DX11" Version="4.2.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Content.Pipeline.Builder" Version="4.2.9001" />
   </ItemGroup>
 	
   <ItemGroup>

--- a/Samples/KniGumInCode/KniGumInCodeCommon/KniGumInCodeCommon.csproj
+++ b/Samples/KniGumInCode/KniGumInCodeCommon/KniGumInCodeCommon.csproj
@@ -23,16 +23,16 @@
   </ItemGroup>
 	
   <ItemGroup>
-    <PackageReference Include="nkast.Xna.Framework" Version="4.1.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Content" Version="4.1.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Graphics" Version="4.1.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Audio" Version="4.1.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Media" Version="4.1.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Input" Version="4.1.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Game" Version="4.1.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Devices" Version="4.1.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Storage" Version="4.1.9001" />
-    <PackageReference Include="nkast.Xna.Framework.XR" Version="4.1.9001" />
+    <PackageReference Include="nkast.Xna.Framework" Version="4.2.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Content" Version="4.2.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Graphics" Version="4.2.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Audio" Version="4.2.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Media" Version="4.2.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Input" Version="4.2.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Game" Version="4.2.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Devices" Version="4.2.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Storage" Version="4.2.9001" />
+    <PackageReference Include="nkast.Xna.Framework.XR" Version="4.2.9001" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Updates library and samples using KNI to version 4.2.

This version should now resolve the KNI issue [#2344 Implement Microsoft.Xna.Framework.Input.Mouse.SetCursor in Kni.Blazor](https://github.com/kniEngine/kni/issues/2344).

Also as this includes the KNI PR [#2351 Implements BlazorGameWindow.OnTextInput](https://github.com/kniEngine/kni/pull/2351), it should now be possible to fix Gum Issue [#928 TextCopy crash issues when using KNI.Gum with BlazorGL](https://github.com/vchelaru/Gum/issues/928). I'll need to submit a separate Gum PR for that though soon.

