### PR TITLE
1727 - initialize theming earlier

### DIFF
--- a/Gum/Controls/ThemedScrollbar.cs
+++ b/Gum/Controls/ThemedScrollbar.cs
@@ -93,41 +93,23 @@ public sealed class ThemedScrollBar : Control
         TabStop = false;
         Width = Thickness; Height = 100;
         MouseWheel += OnMouseWheel;
+
+        bool isDarkMode = Locator.GetRequiredService<IThemingService>().EffectiveSettings.IsSystemInDarkMode;
+        ApplyTheme(isDarkMode);
         Locator.GetRequiredService<IMessenger>().Register<ThemeChangedMessage>(this, (recipient, message) =>
         {
             bool dark = message.settings.Mode is ThemeMode.Dark;
             ApplyTheme(dark);
+            Invalidate();
         });
     }
 
     public void ApplyTheme(bool isDarkMode)
     {
-
-
         BackColor = (System.Windows.Application.Current.TryFindResource("Frb.Surface01") as
                         System.Windows.Media.SolidColorBrush) is { Color: { } c }
                         ? Color.FromArgb(c.A, c.R, c.G, c.B)
                         : Color.Transparent;
-
-        Invalidate();
-        //if (isDarkMode)
-        //{
-        //    TrackColor = Color.FromArgb(64, 255, 255, 255);
-        //    TrackHoverColor = Color.FromArgb(96, 255, 255, 255);
-        //    ThumbColor = Color.FromArgb(160, 200, 200, 200);
-        //    ThumbHoverColor = Color.FromArgb(200, 220, 220, 220);
-        //    ThumbActiveColor = Color.FromArgb(220, 240, 240, 240);
-        //}
-        //else
-        //{
-        //    // Light mode
-        //    TrackColor = Color.FromArgb(32, 0, 0, 0);
-        //    TrackHoverColor = Color.FromArgb(48, 0, 0, 0);
-        //    ThumbColor = Color.FromArgb(160, 120, 120, 120);
-        //    ThumbHoverColor = Color.FromArgb(200, 120, 120, 120);
-        //    ThumbActiveColor = Color.FromArgb(220, 120, 120, 120);
-        //}
-        //Invalidate();
     }
 
     protected override void OnMouseEnter(EventArgs e) { base.OnMouseEnter(e); _hover = true; Invalidate(); }

--- a/Gum/Plugins/InternalPlugins/TreeView/ElementTreeViewManager.cs
+++ b/Gum/Plugins/InternalPlugins/TreeView/ElementTreeViewManager.cs
@@ -621,6 +621,7 @@ public partial class ElementTreeViewManager : IRecipient<ThemeChangedMessage>, I
                 ? Visibility.Visible
                 : Visibility.Collapsed;
         }
+        ApplyThemeColors();
     }
 
 
@@ -807,7 +808,7 @@ public partial class ElementTreeViewManager : IRecipient<ThemeChangedMessage>, I
         } 
     }
 
-    void IRecipient<ThemeChangedMessage>.Receive(ThemeChangedMessage message)
+    private void ApplyThemeColors()
     {
         if (System.Windows.Application.Current is { } current &&
             current.TryFindResource("Frb.Brushes.Foreground") is SolidColorBrush { Color: var fg } &&
@@ -846,6 +847,11 @@ public partial class ElementTreeViewManager : IRecipient<ThemeChangedMessage>, I
 
             return (int)Math.Round(value * 255);
         }
+    }
+
+    void IRecipient<ThemeChangedMessage>.Receive(ThemeChangedMessage message)
+    {
+        ApplyThemeColors();
     }
 
     private ImageList CloneImageList(ImageList original)

--- a/Gum/Program.cs
+++ b/Gum/Program.cs
@@ -104,6 +104,8 @@ namespace Gum
             // This has to happen before plugins are loaded since they may depend on settings...
             ProjectManager.Self.LoadSettings();
 
+            MigrateAppSettings(services, ProjectManager.Self.GeneralSettingsFile);
+            services.GetRequiredService<IThemingService>().ApplyInitialTheme();
 
             ElementTreeViewManager.Self.Initialize();
 
@@ -135,11 +137,6 @@ namespace Gum
             // XnaInitialize is where wireframe controls are initialized.
             PluginManager.Self.XnaInitialized();
 
-            MigrateAppSettings(services);
-            services.GetRequiredService<IThemingService>().ApplyInitialTheme();
-
-            // ProjectManager.Initialize loads a project. We want to do that *after* styling
-            // has applied, otherwise we will have the app display as unstyled when we show messages
             await ProjectManager.Self.Initialize();
 
             PeriodicUiTimer fileWatchTimer = services.GetRequiredService<PeriodicUiTimer>();
@@ -155,9 +152,8 @@ namespace Gum
             fileWatchTimer.Start(TimeSpan.FromSeconds(2));
         }
 
-        private static void MigrateAppSettings(IServiceProvider services)
+        private static void MigrateAppSettings(IServiceProvider services, GeneralSettingsFile legacySettings)
         {
-            GeneralSettingsFile legacySettings = ProjectManager.Self.GeneralSettingsFile;
             IConfiguration config = services.GetRequiredService<IConfiguration>();
 
             ApplyIfNotExists<ThemeSettings>(x => ThemeSettings.MigrateExplicitLegacyColors(legacySettings, x));

--- a/Tool/EditorTabPlugin_XNA/MainEditorTabPlugin.cs
+++ b/Tool/EditorTabPlugin_XNA/MainEditorTabPlugin.cs
@@ -6,6 +6,7 @@ using FlatRedBall.Glue.Themes;
 using Gum.Commands;
 using Gum.DataTypes;
 using Gum.DataTypes.Variables;
+using Gum.Dialogs;
 using Gum.Extensions;
 using Gum.Managers;
 using Gum.Plugins.BaseClasses;
@@ -677,6 +678,9 @@ internal class MainEditorTabPlugin : InternalPlugin, IRecipient<UiBaseFontSizeCh
         _wireframeControl.DesiredFramesPerSecond = frameRate;
 
         UpdateWireframeControlSizes();
+
+        IEffectiveThemeSettings themeSettings = Locator.GetRequiredService<IThemingService>().EffectiveSettings;
+        ApplyThemeSettings(themeSettings);
     }
 
     private void HandleControlZoomChange(object sender, EventArgs e)
@@ -1003,15 +1007,18 @@ internal class MainEditorTabPlugin : InternalPlugin, IRecipient<UiBaseFontSizeCh
         _wireframeEditControl.PercentageValue = 100;
         _wireframeEditControl.TabIndex = 1;
         _defaultWireframeEditControlHeight = _wireframeEditControl.Height;
+    }
 
+    private void ApplyThemeSettings(IEffectiveThemeSettings settings)
+    {
+        this._wireframeControl.BackgroundColor = ToXna(settings.CheckerA);
+        this._wireframeControl.SetGuideColors(settings.GuideLine, settings.GuideText);
+        _wireframeContextMenuStrip.Renderer = FrbMenuStripRenderer.GetCurrentThemeRenderer(out _);
+        static Microsoft.Xna.Framework.Color ToXna(Color color) => new Microsoft.Xna.Framework.Color(color.R, color.G, color.B, color.A);
     }
 
     void IRecipient<ThemeChangedMessage>.Receive(ThemeChangedMessage message)
     {
-        this._wireframeControl.BackgroundColor = ToXna(message.settings.CheckerA);
-        this._wireframeControl.SetGuideColors(message.settings.GuideLine, message.settings.GuideText);
-        _wireframeContextMenuStrip.Renderer = FrbMenuStripRenderer.GetCurrentThemeRenderer(out _);
-
-        static Microsoft.Xna.Framework.Color ToXna(Color color) => new Microsoft.Xna.Framework.Color(color.R, color.G, color.B, color.A);
+        ApplyThemeSettings(message.settings);
     }
 }

--- a/Tool/EditorTabPlugin_XNA/Services/BackgroundSpriteService.cs
+++ b/Tool/EditorTabPlugin_XNA/Services/BackgroundSpriteService.cs
@@ -80,6 +80,9 @@ internal class BackgroundSpriteService : IRecipient<ThemeChangedMessage>
             new System.Drawing.Rectangle(0, 0, timesToRepeat * texture.Width, timesToRepeat * texture.Height);
 
         systemManagers.SpriteManager.Add(BackgroundSprite);
+
+        var themeSettings = Locator.GetRequiredService<IThemingService>().EffectiveSettings;
+        ApplyThemingSettings(themeSettings);
     }
 
     public void Activity()
@@ -87,10 +90,15 @@ internal class BackgroundSpriteService : IRecipient<ThemeChangedMessage>
         BackgroundSprite.Visible =
                 _wireframeCommands.IsBackgroundGridVisible;
     }
+
+    private void ApplyThemingSettings(IEffectiveThemeSettings settings)
+    {
+        BackgroundSolidColor.Color = settings.CheckerA;
+        BackgroundSprite.Color = settings.CheckerB;
+    }
     
     void IRecipient<ThemeChangedMessage>.Receive(ThemeChangedMessage message)
     {
-        BackgroundSolidColor.Color = message.settings.CheckerA;
-        BackgroundSprite.Color = message.settings.CheckerB;
+        ApplyThemingSettings(message.settings);
     }
 }


### PR DESCRIPTION
- have winforms controls initialize to proper theme values instead of depending on a message... allows us to move initial theming application as early as possible in the app's initialization flow.

fixes #1727
