### PR TITLE
Vertical aligned text fix for Raylib

### DIFF
--- a/Runtimes/RaylibGum/Renderables/Text.cs
+++ b/Runtimes/RaylibGum/Renderables/Text.cs
@@ -643,22 +643,40 @@ public class Text : IVisible, IRenderableIpso,
 
             if (TextRenderingPositionMode == TextRenderingPositionMode.SnapToPixel)
             {
+                // 2025-12 JUSTIN: Changes to vertical alignment resulted fractional
+                // origin values which cause baseline misalignment and broken text.
+                // Applied the same rounding used for position to origin, which fixes
+                // the problem but may cause weird artifacts or "sizzle" for really
+                // small pixel fonts
+                
                 switch (TextPositionRoundingMode)
                 {
                     case TextPositionRoundingMode.Floor:
                         linePosition = new Vector2(
                             (int)Math.Floor(linePosition.X),
                             (int)Math.Floor(linePosition.Y));
+                        origin = new Vector2(
+                            (int)Math.Floor(origin.X),
+                            (int)Math.Floor(origin.Y)
+                        );
                         break;
                     case TextPositionRoundingMode.Ceiling:
                         linePosition = new Vector2(
                             (int)Math.Ceiling(linePosition.X),
                             (int)Math.Ceiling(linePosition.Y));
+                        origin = new Vector2(
+                            (int)Math.Ceiling(origin.X),
+                            (int)Math.Ceiling(origin.Y)
+                        );
                         break;
                     default:
                         linePosition = new Vector2(
                             MathFunctions.RoundToInt(linePosition.X),
                             MathFunctions.RoundToInt(linePosition.Y));
+                        origin = new Vector2(
+                            MathFunctions.RoundToInt(origin.X),
+                            MathFunctions.RoundToInt(origin.Y)
+                        );
                         break;
                 }
             }


### PR DESCRIPTION
Changes to vertical alignment cause text origin to have fractional values, which causes chaotic character alignment with jagged baselines and missing horizontal lines in some text.

Rounding the origin the same way that we round position fixes this.

@vchelaru suggested that we could do away with origin entirely but that requires significantly more testing - left a comment as to why we round.