### PR TITLE
Skia bolding fix

### DIFF
--- a/SkiaGum/RenderingLibrary/SystemManagers.cs
+++ b/SkiaGum/RenderingLibrary/SystemManagers.cs
@@ -89,7 +89,8 @@ namespace RenderingLibrary
             {
                 asText.FontName = textRuntime.Font ?? "Arial";
                 asText.IsItalic = textRuntime.IsItalic;
-                asText.BoldWeight = textRuntime.IsBold ? 1.5f : 1.0f;
+                // BoldWeight is an embolden multiplier (1.0 = normal). Do NOT set CSS weights (400/700) here.
+                asText.BoldWeight = textRuntime.IsBold ? 1.5f : 1.0f; 
                 asText.FontSize = textRuntime.FontSize;
             }
         }


### PR DESCRIPTION
Sorry, pushed the wrong branch on my repo. 

**Issue:** Text rendered via SkiaGum could appear overly bold / wrong weight (notably “Segoe UI” looked incorrect; “Segoe UI Light” appeared closer to expected).

**Cause:** `SystemManagers.UpdateFonts` assigned `BoldWeight` as `700` or `400` (CSS font-weight values). In SkiaGum, BoldWeight is used as an embolden multiplier (≈1.0 for normal, >1.0 for bold), so values like 700 caused extreme emboldening and incorrect glyph appearance.

**Fix:** Use a reasonable multiplier: `BoldWeight = IsBold ? 1.5f : 1.0f.`

**Tested:** Verified with Segoe UI in a Stride + SkiaGum integration (before/after screenshots attached).

Also, some minor refactoring for readability. 

**Before:** 
<img width="878" height="311" alt="image" src="https://github.com/user-attachments/assets/0d0c555a-7995-4345-85d1-25801a8d1695" />

**After:**
<img width="859" height="427" alt="image" src="https://github.com/user-attachments/assets/71f44e39-b45f-412a-a02f-051338e4bda2" />