### PR TITLE
Upgraded to Apos.Shapes 0.6.3, fixing a .xnb error

### DIFF
--- a/GumCommon/GumCommon.csproj
+++ b/GumCommon/GumCommon.csproj
@@ -11,7 +11,7 @@
 		<PackageId>FlatRedBall.GumCommon</PackageId>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 
-		<Version>2026.1.12.1</Version>
+		<Version>2026.1.24.1</Version>
 
 
 

--- a/MonoGameGum/FnaGum/FnaGum.csproj
+++ b/MonoGameGum/FnaGum/FnaGum.csproj
@@ -7,7 +7,7 @@
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 		<PackageId>Gum.FNA</PackageId>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
-		<Version>2026.1.12.1</Version>
+		<Version>2026.1.24.1</Version>
 		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<IncludeSymbols>true</IncludeSymbols>

--- a/MonoGameGum/KniGum/KniGum.csproj
+++ b/MonoGameGum/KniGum/KniGum.csproj
@@ -7,7 +7,7 @@
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 		<PackageId>Gum.KNI</PackageId>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
-		<Version>2026.1.12.1</Version>
+		<Version>2026.1.24.1</Version>
 		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
 		<NoWarn>1591</NoWarn>
 		<DefineConstants>KNI</DefineConstants>

--- a/MonoGameGum/MonoGameGum.csproj
+++ b/MonoGameGum/MonoGameGum.csproj
@@ -7,7 +7,7 @@
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 		<PackageId>Gum.MonoGame</PackageId>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
-		<Version>2026.1.12.1</Version>
+		<Version>2026.1.24.1</Version>
 
 		<NoWarn>1591</NoWarn>
 		<DefineConstants>MONOGAME</DefineConstants>

--- a/Runtimes/GumShapes/KniGumShapes.csproj
+++ b/Runtimes/GumShapes/KniGumShapes.csproj
@@ -8,7 +8,7 @@
 		<PackageId>Gum.Shapes.KNI</PackageId>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 
-		<Version>2026.1.12.1</Version>
+		<Version>2026.1.24.1</Version>
 		<NoWarn>1591</NoWarn>
 
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -31,7 +31,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Apos.Shapes.KNI" Version="0.5.2" />
+		<PackageReference Include="Apos.Shapes.KNI" Version="0.6.3-alpha" />
 		<PackageReference Include="nkast.Xna.Framework" Version="4.2.9001" PrivateAssets="All" />
 		<PackageReference Include="nkast.Xna.Framework.Content" Version="4.2.9001" PrivateAssets="All" />
 		<PackageReference Include="nkast.Xna.Framework.Graphics" Version="4.2.9001" PrivateAssets="All" />

--- a/Runtimes/GumShapes/MonoGameGumShapes.csproj
+++ b/Runtimes/GumShapes/MonoGameGumShapes.csproj
@@ -8,7 +8,7 @@
 		<PackageId>Gum.Shapes.MonoGame</PackageId>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		
-		<Version>2026.1.12.1</Version>
+		<Version>2026.1.24.1</Version>
 		<NoWarn>1591</NoWarn>
 
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -31,7 +31,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Apos.Shapes" Version="0.5.2" />
+		<PackageReference Include="Apos.Shapes" Version="0.6.3-alpha" />
 		<PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.4.1" PrivateAssets="All" />
 	</ItemGroup>
 

--- a/Runtimes/RaylibGum/RaylibGum.csproj
+++ b/Runtimes/RaylibGum/RaylibGum.csproj
@@ -6,7 +6,7 @@
 		<Nullable>enable</Nullable>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 		<PackageId>Gum.raylib</PackageId>
-		<Version>2026.1.12.1</Version>
+		<Version>2026.1.24.1</Version>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 
 		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>

--- a/Runtimes/SkiaGum.Maui/SkiaGum.Maui.csproj
+++ b/Runtimes/SkiaGum.Maui/SkiaGum.Maui.csproj
@@ -7,7 +7,7 @@
 	  <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 	  <PackageId>Gum.SkiaSharp.Maui</PackageId>
 	  <PackageLicenseExpression>MIT</PackageLicenseExpression>
-	  <Version>2026.1.12.1</Version>
+	  <Version>2026.1.24.1</Version>
 
 	  <NoWarn>1591</NoWarn>
 

--- a/Runtimes/SkiaGum/SkiaGum.csproj
+++ b/Runtimes/SkiaGum/SkiaGum.csproj
@@ -6,7 +6,7 @@
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 		<PackageId>Gum.SkiaSharp</PackageId>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
-		<Version>2026.1.12.1</Version>
+		<Version>2026.1.24.1</Version>
 
 		<NoWarn>1591</NoWarn>
 


### PR DESCRIPTION
Increased all Gum library versions to 2026.1.24.1