### PR TITLE
Check for null before attempting to do a recursive find

### DIFF
--- a/Tool/EditorTabPlugin_XNA/Editors/StandardWireframeEditor.cs
+++ b/Tool/EditorTabPlugin_XNA/Editors/StandardWireframeEditor.cs
@@ -180,7 +180,12 @@ public class StandardWireframeEditor : WireframeEditor
         }
         if(tag is ElementSave element)
         {
-            rfv = new RecursiveVariableFinder(_context.SelectedState.SelectedStateSave);
+            // SelectedStateSave is null when a category node is selected (no state to check)
+            var selectedStateSave = _context.SelectedState.SelectedStateSave;
+            if(selectedStateSave != null)
+            {
+                rfv = new RecursiveVariableFinder(selectedStateSave);
+            }
         }
 
         var variableReferences = rfv?.GetVariableList("VariableReferences");


### PR DESCRIPTION
Fixes #2226

I found this when trying to adjust my state order in gum.