### PR TITLE
Fix ambiguous string.Split call in BmfcSave.cs

### DIFF
--- a/GumCommon/AssemblyInfo.cs
+++ b/GumCommon/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("MonoGameGum.Tests")]

--- a/MonoGameGum.Tests/RenderingLibraries/BmfcSaveTests.cs
+++ b/MonoGameGum.Tests/RenderingLibraries/BmfcSaveTests.cs
@@ -1,0 +1,36 @@
+using RenderingLibrary.Graphics.Fonts;
+using Shouldly;
+using Xunit;
+
+namespace MonoGameGum.Tests.RenderingLibraries;
+
+public class BmfcSaveTests
+{
+    [Fact]
+    public void ParseCharRanges_ShouldExpandRange()
+    {
+        var result = BmfcSave.ParseCharRanges("66-70");
+        result.ShouldBe([66, 67, 68, 69, 70]);
+    }
+
+    [Fact]
+    public void ParseCharRanges_ShouldHandleSingleValue()
+    {
+        var result = BmfcSave.ParseCharRanges("65");
+        result.ShouldBe([65]);
+    }
+
+    [Fact]
+    public void ParseCharRanges_ShouldHandleMultipleRanges()
+    {
+        var result = BmfcSave.ParseCharRanges("32-34,40-42");
+        result.ShouldBe([32, 33, 34, 40, 41, 42]);
+    }
+
+    [Fact]
+    public void ParseCharRanges_ShouldHandleMixedRangesAndSingleValues()
+    {
+        var result = BmfcSave.ParseCharRanges("65,67-69");
+        result.ShouldBe([65, 67, 68, 69]);
+    }
+}

--- a/RenderingLibrary/Graphics/Fonts/BmfcSave.cs
+++ b/RenderingLibrary/Graphics/Fonts/BmfcSave.cs
@@ -134,7 +134,7 @@ public class BmfcSave
         return builder.ToString();
     }
 
-    private static List<int> ParseCharRanges(string charsStr)
+    internal static List<int> ParseCharRanges(string charsStr)
     {
         var allChars = new List<int>();
         var ranges = charsStr.Split(',', StringSplitOptions.RemoveEmptyEntries);


### PR DESCRIPTION
Replace collection expression [','] with a char literal to resolve CS0121 ambiguity between Split(char[]?, StringSplitOptions) and Split(string?, StringSplitOptions) introduced in C# 12.