### PR TITLE
RepositionDirection is now internal - it's not used outside of Gum an…

### DIFF
--- a/MonoGameGum/Forms/Controls/ListBox.cs
+++ b/MonoGameGum/Forms/Controls/ListBox.cs
@@ -110,7 +110,7 @@ public enum DragDropReorderMode
 
 #region RepositionDirections Enum
 
-public enum RepositionDirections
+internal enum RepositionDirections
 {
     None = 0,
     Up = 1,


### PR DESCRIPTION
…d can cause naming conflicts with FRB