### PR TITLE
Added F2 rename for behavior instances

### DIFF
--- a/Gum/Logic/InheritanceLogic.cs
+++ b/Gum/Logic/InheritanceLogic.cs
@@ -1,0 +1,227 @@
+using Gum.Commands;
+using Gum.DataTypes;
+using Gum.DataTypes.Variables;
+using Gum.Managers;
+using Gum.Plugins.InternalPlugins.VariableGrid;
+using Gum.Services;
+using System.Linq;
+
+namespace Gum.Logic;
+
+public class InheritanceLogic
+{
+    private readonly IFileCommands _fileCommands;
+    private readonly IGuiCommands _guiCommands;
+    private readonly StandardElementsManagerGumTool _standardElementsManagerGumTool;
+
+    public InheritanceLogic(IFileCommands fileCommands, IGuiCommands guiCommands,
+        StandardElementsManagerGumTool standardElementsManagerGumTool)
+    {
+        _fileCommands = fileCommands;
+        _guiCommands = guiCommands;
+        _standardElementsManagerGumTool = standardElementsManagerGumTool;
+    }
+
+    public void HandleInstanceAdded(ElementSave container, InstanceSave instance)
+    {
+        var elementsInheritingFromContainer =
+            ObjectFinder.Self.GetElementsInheritingFrom(container);
+
+        foreach (var inheritingElement in elementsInheritingFromContainer)
+        {
+            var existingInInheriting = inheritingElement.GetInstance(instance.Name);
+            if (existingInInheriting == null)
+            {
+                var clone = instance.Clone();
+                clone.DefinedByBase = true;
+                clone.ParentContainer = inheritingElement;
+                inheritingElement.Instances.Add(clone);
+
+                var directBase = ObjectFinder.Self.GetElementSave(inheritingElement.BaseType);
+
+                AdjustInstance(directBase, inheritingElement, clone.Name);
+
+                _fileCommands.TryAutoSaveElement(inheritingElement);
+                _guiCommands.RefreshElementTreeView(inheritingElement);
+            }
+        }
+    }
+
+    public void HandleInstanceDeleted(ElementSave? container, InstanceSave instance)
+    {
+        if (container == null) return;
+
+        var elementsInheritingFromContainer =
+            ObjectFinder.Self.GetElementsInheritingFrom(container);
+
+        foreach (var inheritingElement in elementsInheritingFromContainer)
+        {
+            inheritingElement.Instances.RemoveAll(item => item.Name == instance.Name);
+
+            _fileCommands.TryAutoSaveElement(inheritingElement);
+            _guiCommands.RefreshElementTreeView(inheritingElement);
+        }
+    }
+
+    public void HandleInstanceRenamed(ElementSave? container, InstanceSave instance, string oldName)
+    {
+        if (container == null) return;
+
+        var elementsInheritingFromContainer =
+            ObjectFinder.Self.GetElementsInheritingFrom(container);
+
+        foreach (var inheritingElement in elementsInheritingFromContainer)
+        {
+            var toRename = inheritingElement.GetInstance(oldName);
+
+            if (toRename != null)
+            {
+                toRename.Name = instance.Name;
+                _fileCommands.TryAutoSaveElement(inheritingElement);
+                _guiCommands.RefreshElementTreeView(inheritingElement);
+            }
+        }
+    }
+
+    public void HandleInstanceReordered(InstanceSave instance)
+    {
+        var baseElement = instance.ParentContainer;
+
+        if (baseElement != null)
+        {
+            var elementsInheritingFromContainer =
+                ObjectFinder.Self.GetElementsInheritingFrom(baseElement);
+
+            foreach (var inheritingElement in elementsInheritingFromContainer)
+            {
+                var didShiftIndex =
+                    AdjustInstance(baseElement, inheritingElement, instance.Name);
+
+                if (didShiftIndex)
+                {
+                    _fileCommands.TryAutoSaveElement(inheritingElement);
+                    _guiCommands.RefreshElementTreeView(inheritingElement);
+                }
+            }
+        }
+    }
+
+    public void HandleInstanceVariableBaseTypeSet(ElementSave container, InstanceSave instance)
+    {
+        var elementsInheritingFromContainer =
+            ObjectFinder.Self.GetElementsInheritingFrom(container);
+
+        foreach (var inheritingElement in elementsInheritingFromContainer)
+        {
+            var toChange = inheritingElement.GetInstance(instance.Name);
+
+            if (toChange != null)
+            {
+                toChange.BaseType = instance.BaseType;
+                _fileCommands.TryAutoSaveElement(inheritingElement);
+            }
+        }
+    }
+
+    public void HandleElementBaseType(ElementSave asElementSave)
+    {
+        string newValue = asElementSave.BaseType;
+
+        asElementSave.Instances.RemoveAll(item => item.DefinedByBase);
+
+        if (!string.IsNullOrEmpty(newValue))
+        {
+            if (StandardElementsManager.Self.IsDefaultType(newValue))
+            {
+                // Intentionally empty - see comment in original plugin code.
+            }
+            else
+            {
+                var baseElement = ObjectFinder.Self.GetElementSave(asElementSave.BaseType);
+
+                StateSave stateSave = new StateSave();
+                if (baseElement != null)
+                {
+                    foreach (var instance in baseElement.Instances)
+                    {
+                        var instanceName = instance.Name;
+                        var alreadyExists = asElementSave.Instances.FirstOrDefault(item => item.Name == instanceName);
+                        if (alreadyExists != null)
+                        {
+                            alreadyExists.DefinedByBase = true;
+                        }
+                        else
+                        {
+                            var derivedInstance = instance.Clone();
+                            derivedInstance.DefinedByBase = true;
+                            asElementSave.Instances.Add(derivedInstance);
+                        }
+                    }
+                    asElementSave.Initialize(stateSave);
+                    _standardElementsManagerGumTool.FixCustomTypeConverters(asElementSave);
+                }
+            }
+        }
+
+        const bool fullRefresh = true;
+        _guiCommands.RefreshElementTreeView(asElementSave);
+        _guiCommands.RefreshVariables(fullRefresh);
+        _guiCommands.RefreshStateTreeView();
+    }
+
+    private bool AdjustInstance(ElementSave baseElement, ElementSave derivedElement, string instanceName)
+    {
+        var instanceInBase = baseElement.GetInstance(instanceName);
+        var instanceInDerived = derivedElement.GetInstance(instanceName);
+
+        var indexInBase = baseElement.Instances.IndexOf(instanceInBase);
+        string? nameOfObjectBefore = null;
+        if (indexInBase > 0)
+        {
+            nameOfObjectBefore = baseElement.Instances[indexInBase - 1].Name;
+        }
+
+        string? nameOfObjectAfter = null;
+        if (indexInBase < baseElement.Instances.Count - 1)
+        {
+            nameOfObjectAfter = baseElement.Instances[indexInBase + 1].Name;
+        }
+
+        int exclusiveLowerIndexInDerived = -1;
+        if (nameOfObjectBefore != null)
+        {
+            var instanceBefore = derivedElement.GetInstance(nameOfObjectBefore);
+            exclusiveLowerIndexInDerived = derivedElement.Instances.IndexOf(instanceBefore);
+        }
+
+        int exclusiveUpperIndexInDerived = derivedElement.Instances.Count;
+
+        if (nameOfObjectAfter != null)
+        {
+            var instanceAfter = derivedElement.GetInstance(nameOfObjectAfter);
+            exclusiveUpperIndexInDerived = derivedElement.Instances.IndexOf(instanceAfter);
+        }
+
+        int currentDerivedIndex = derivedElement.Instances.IndexOf(instanceInDerived);
+
+        var desiredIndex = System.Math.Min(currentDerivedIndex, exclusiveUpperIndexInDerived - 1);
+        desiredIndex = System.Math.Max(desiredIndex, exclusiveLowerIndexInDerived + 1);
+
+        bool didAdjust = false;
+        if (desiredIndex != currentDerivedIndex)
+        {
+            didAdjust = true;
+            derivedElement.Instances.Remove(instanceInDerived);
+            if (currentDerivedIndex < desiredIndex)
+            {
+                derivedElement.Instances.Insert(desiredIndex - 1, instanceInDerived);
+            }
+            else
+            {
+                derivedElement.Instances.Insert(desiredIndex, instanceInDerived);
+            }
+        }
+
+        return didAdjust;
+    }
+}

--- a/Gum/Managers/DeleteLogic.cs
+++ b/Gum/Managers/DeleteLogic.cs
@@ -139,9 +139,10 @@ public class DeleteLogic : IDeleteLogic
                     {
                         RemoveInstanceFromElement(selectedInstance, selectedElement);
                     }
-                    else if (selectedBehavior != null)
+                    else if (selectedBehavior != null && selectedInstance is BehaviorInstanceSave behaviorInstanceToDelete)
                     {
-                        selectedBehavior.RequiredInstances.Remove(selectedInstance as BehaviorInstanceSave);
+                        selectedBehavior.RequiredInstances.Remove(behaviorInstanceToDelete);
+                        _pluginManager.BehaviorInstanceDelete(selectedBehavior, behaviorInstanceToDelete);
                     }
 
 

--- a/Gum/Managers/DragDropManager.cs
+++ b/Gum/Managers/DragDropManager.cs
@@ -270,7 +270,7 @@ public class DragDropManager : IDragDropManager
             }
 #endif
 
-            string name = GetUniqueNameForNewInstance(draggedElement, behavior);
+            string name = _elementCommands.GetUniqueNameForNewInstance(draggedElement, behavior);
 
             // Capture the pre-change state for undo. We bypass the undo lock here because
             // OnNodeSortingDropped already holds a lock, which would normally block
@@ -366,21 +366,6 @@ public class DragDropManager : IDragDropManager
         return errorMessage;
     }
 
-
-    private string GetUniqueNameForNewInstance(ElementSave elementSaveForNewInstance, BehaviorSave container)
-    {
-#if DEBUG
-        if (elementSaveForNewInstance == null)
-        {
-            throw new ArgumentNullException(nameof(elementSaveForNewInstance));
-        }
-#endif
-        // remove the path - we dont want folders to be part of the name
-        string name = FileManager.RemovePath(elementSaveForNewInstance.Name) + "Instance";
-        IEnumerable<string> existingNames = container.RequiredInstances.Select(i => i.Name);
-
-        return StringFunctions.MakeStringUnique(name, existingNames);
-    }
 
     #endregion
 

--- a/Gum/Managers/HotkeyManager.cs
+++ b/Gum/Managers/HotkeyManager.cs
@@ -320,6 +320,11 @@ public class HotkeyManager : IHotkeyManager
                 });
                 e.Handled = true;
             }
+            else if(_selectedState.SelectedBehavior is { } selectedBehavior)
+            {
+                _editCommands.AskToRenameBehavior(selectedBehavior);
+                e.Handled = true;
+            }
         }
     }
 

--- a/Gum/Plugins/BaseClasses/PluginBase.cs
+++ b/Gum/Plugins/BaseClasses/PluginBase.cs
@@ -178,6 +178,16 @@ public abstract class PluginBase : IPlugin
     /// </summary>
     public event Action<BehaviorSave, BehaviorInstanceSave>? BehaviorInstanceAdd;
 
+    /// <summary>
+    /// Event raised whenever an instance is removed from a behavior's RequiredInstances list.
+    /// </summary>
+    public event Action<BehaviorSave, BehaviorInstanceSave>? BehaviorInstanceDelete;
+
+    /// <summary>
+    /// Event raised whenever an instance in a behavior's RequiredInstances list is renamed.
+    /// </summary>
+    public event Action<BehaviorSave, BehaviorInstanceSave>? BehaviorInstanceRename;
+
     public event Action? RefreshBehaviorView;
     public event Action<bool>? RefreshVariableView;
 
@@ -451,6 +461,8 @@ public abstract class PluginBase : IPlugin
     public void CallInstanceAdd(ElementSave elementSave, InstanceSave instance) => InstanceAdd?.Invoke(elementSave, instance);
 
     public void CallBehaviorInstanceAdd(BehaviorSave behavior, BehaviorInstanceSave instance) => BehaviorInstanceAdd?.Invoke(behavior, instance);
+    public void CallBehaviorInstanceDelete(BehaviorSave behavior, BehaviorInstanceSave instance) => BehaviorInstanceDelete?.Invoke(behavior, instance);
+    public void CallBehaviorInstanceRename(BehaviorSave behavior, BehaviorInstanceSave instance) => BehaviorInstanceRename?.Invoke(behavior, instance);
 
     public void CallBehaviorReferencesChanged(ElementSave element) => BehaviorReferencesChanged?.Invoke(element);
 

--- a/Gum/Plugins/IPluginManager.cs
+++ b/Gum/Plugins/IPluginManager.cs
@@ -116,6 +116,8 @@ public interface IPluginManager
     void InstanceAdd(ElementSave elementSave, InstanceSave instance);
     void InstanceDelete(ElementSave elementSave, InstanceSave instance);
     void BehaviorInstanceAdd(BehaviorSave behavior, BehaviorInstanceSave instance);
+    void BehaviorInstanceDelete(BehaviorSave behavior, BehaviorInstanceSave instance);
+    void BehaviorInstanceRename(BehaviorSave behavior, BehaviorInstanceSave instance);
 
     void InstancesDelete(ElementSave elementSave, InstanceSave[] instances);
     StateSave? GetDefaultStateFor(string type);

--- a/Gum/Plugins/InternalPlugins/Inheritance/MainInheritancePlugin.cs
+++ b/Gum/Plugins/InternalPlugins/Inheritance/MainInheritancePlugin.cs
@@ -1,22 +1,20 @@
 ﻿using Gum.DataTypes;
-using Gum.DataTypes.Variables;
+using Gum.Logic;
 using Gum.Managers;
 using Gum.Plugins.BaseClasses;
-using Gum.Plugins.InternalPlugins.VariableGrid;
 using Gum.Services;
 using System.ComponentModel.Composition;
-using System.Linq;
 
 namespace Gum.Plugins.Inheritance;
 
 [Export(typeof(PluginBase))]
 public class MainInheritancePlugin : InternalPlugin
 {
-    private readonly StandardElementsManagerGumTool _standardElementsManagerGumTool;
+    private readonly InheritanceLogic _inheritanceLogic;
 
     public MainInheritancePlugin()
     {
-        _standardElementsManagerGumTool = Locator.GetRequiredService<StandardElementsManagerGumTool>();
+        _inheritanceLogic = Locator.GetRequiredService<InheritanceLogic>();
     }
 
     public override void StartUp()
@@ -28,249 +26,31 @@ public class MainInheritancePlugin : InternalPlugin
         this.VariableSet += HandleVariableSet;
     }
 
-    private void HandleInstanceAdded(ElementSave container, InstanceSave instance)
-    {
-        var elementsInheritingFromContainer = 
-            ObjectFinder.Self.GetElementsInheritingFrom(container);
+    private void HandleInstanceAdded(ElementSave container, InstanceSave instance) =>
+        _inheritanceLogic.HandleInstanceAdded(container, instance);
 
-        foreach(var inheritingElement in elementsInheritingFromContainer)
-        {
-            // This could be done to satisfy a missing dependency? Or perhaps a refactor by moving
-            // a derived instance to base? Therefore, only see if there is not already an instance here
-            var existingInInheriting = inheritingElement.GetInstance(instance.Name);
-            if(existingInInheriting == null)
-            {
-                var clone = instance.Clone();
-                clone.DefinedByBase = true;
-                clone.ParentContainer = inheritingElement;
-                inheritingElement.Instances.Add(clone);
+    private void HandleInstanceDeleted(ElementSave container, InstanceSave instance) =>
+        _inheritanceLogic.HandleInstanceDeleted(container, instance);
 
-                // inheritingElement could be a derived of derived, in which case we
-                // need to go just one up the inheritance tree:
-                var directBase = ObjectFinder.Self.GetElementSave(inheritingElement.BaseType);
+    private void HandleInstanceRenamed(ElementSave container, InstanceSave instance, string oldName) =>
+        _inheritanceLogic.HandleInstanceRenamed(container, instance, oldName);
 
-                AdjustInstance(directBase, inheritingElement, clone.Name);
-
-                _fileCommands.TryAutoSaveElement(inheritingElement);
-                _guiCommands.RefreshElementTreeView(inheritingElement);
-            }
-        }
-    }
-
-    private void HandleInstanceDeleted(ElementSave container, InstanceSave instance)
-    {
-        if(container != null)
-        {
-            var elementsInheritingFromContainer =
-                ObjectFinder.Self.GetElementsInheritingFrom(container);
-
-            foreach(var inheritingElement in elementsInheritingFromContainer)
-            {
-                inheritingElement.Instances.RemoveAll(item => item.Name == instance.Name);
-
-                _fileCommands.TryAutoSaveElement(inheritingElement);
-                _guiCommands.RefreshElementTreeView(inheritingElement);
-            }
-        }
-    }
-
-    private void HandleInstanceRenamed(ElementSave container, InstanceSave instance, string oldName)
-    {
-        var elementsInheritingFromContainer =
-            ObjectFinder.Self.GetElementsInheritingFrom(container);
-        foreach (var inheritingElement in elementsInheritingFromContainer)
-        {
-            var toRename = inheritingElement.GetInstance(oldName);
-
-            if(toRename != null)
-            {
-                toRename.Name = instance.Name;
-                _fileCommands.TryAutoSaveElement(inheritingElement);
-                _guiCommands.RefreshElementTreeView(inheritingElement);
-            }
-        }
-    }
+    private void HandleInstanceReordered(InstanceSave instance) =>
+        _inheritanceLogic.HandleInstanceReordered(instance);
 
     private void HandleVariableSet(ElementSave container, InstanceSave? instance,
         string variableName, object? oldValue)
     {
-
         if (variableName == "BaseType" && container != null)
         {
-            if(instance != null)
+            if (instance != null)
             {
-                HandleInstanceVariableBaseTypeSet(container, instance);
+                _inheritanceLogic.HandleInstanceVariableBaseTypeSet(container, instance);
             }
             else
             {
-                HandleElementBaseType(container);
+                _inheritanceLogic.HandleElementBaseType(container);
             }
         }
     }
-
-
-    private void HandleInstanceVariableBaseTypeSet(ElementSave container, InstanceSave instance)
-    {
-        var elementsInheritingFromContainer =
-                                ObjectFinder.Self.GetElementsInheritingFrom(container);
-
-        foreach (var inheritingElement in elementsInheritingFromContainer)
-        {
-            // Changed the base type on an instance, so find all instances in derived elements and change their base too
-            var toChange = inheritingElement.GetInstance(instance.Name);
-
-            if (toChange != null)
-            {
-                toChange.BaseType = instance.BaseType;
-
-                _fileCommands.TryAutoSaveElement(inheritingElement);
-            }
-
-        }
-    }
-
-    private void HandleElementBaseType(ElementSave asElementSave)
-    {
-        string newValue = asElementSave.BaseType;
-
-        // kill the old instances:
-        asElementSave.Instances.RemoveAll(item => item.DefinedByBase);
-
-        if(!string.IsNullOrEmpty(newValue))
-        {
-            if (StandardElementsManager.Self.IsDefaultType(newValue))
-            {
-
-                StateSave defaultStateSave = StandardElementsManager.Self.GetDefaultStateFor(newValue);
-
-                // July 17, 2025
-                // Calling this method
-                // results in all of the
-                // default values being assigned
-                // on this instance. Doing so overwrites
-                // the default values inherited from the base
-                // StandardElementSave. Instead, we should inherit
-                // from the base:
-                //asElementSave.Initialize(defaultStateSave);
-                //_standardElementsManagerGumTool.FixCustomTypeConverters(asElementSave);
-            }
-            else
-            {
-                var baseElement = ObjectFinder.Self.GetElementSave(asElementSave.BaseType);
-
-                StateSave stateSave = new StateSave();
-                if (baseElement != null)
-                {
-                    // This copies the values to this explicitly, which we don't want
-                    //FillWithDefaultRecursively(baseElement, stateSave);
-
-                    foreach (var instance in baseElement.Instances)
-                    {
-                        var instanceName = instance.Name;
-                        var alreadyExists = asElementSave.Instances.FirstOrDefault(item => item.Name == instanceName);
-                        if (alreadyExists != null)
-                        {
-                            alreadyExists.DefinedByBase = true;
-                        }
-                        else
-                        {
-                            var derivedInstance = instance.Clone();
-                            derivedInstance.DefinedByBase = true;
-                            asElementSave.Instances.Add(derivedInstance);
-                        }
-                    }
-                    asElementSave.Initialize(stateSave);
-                    _standardElementsManagerGumTool.FixCustomTypeConverters(asElementSave);
-                }
-            }
-        }
-
-        const bool fullRefresh = true;
-        // since the type might change:
-        _guiCommands.RefreshElementTreeView(asElementSave);
-        _guiCommands.RefreshVariables(fullRefresh);
-        _guiCommands.RefreshStateTreeView();
-    }
-
-    private void HandleInstanceReordered(InstanceSave instance)
-    {
-        var baseElement = instance.ParentContainer;
-
-        // instance could be in a behavior, so we could have a null container:
-        if(baseElement != null)
-        {
-            var elementsInheritingFromContainer =
-                    ObjectFinder.Self.GetElementsInheritingFrom(baseElement);
-
-            foreach (var inheritingElement in elementsInheritingFromContainer)
-            {
-                var didShiftIndex = 
-                    AdjustInstance(baseElement, inheritingElement, instance.Name);
-
-                if(didShiftIndex)
-                {
-                    _fileCommands.TryAutoSaveElement(inheritingElement);
-                    _guiCommands.RefreshElementTreeView(inheritingElement);
-                }
-            }
-        }
-    }
-
-    private bool AdjustInstance(ElementSave baseElement, ElementSave derivedElement, string instanceName)
-    {
-        var instanceInBase = baseElement.GetInstance(instanceName);
-        var instanceInDerived = derivedElement.GetInstance(instanceName);
-
-        var indexInBase = baseElement.Instances.IndexOf(instanceInBase);
-        string? nameOfObjectBefore = null;
-        if(indexInBase > 0)
-        {
-            nameOfObjectBefore = baseElement.Instances[indexInBase - 1].Name;
-        }
-
-        string? nameOfObjectAfter = null;
-        if(indexInBase < baseElement.Instances.Count-1)
-        {
-            nameOfObjectAfter = baseElement.Instances[indexInBase + 1].Name;
-        }
-
-        int exclusiveLowerIndexInDerived = -1;
-        if(nameOfObjectBefore != null)
-        {
-            var instanceBefore = derivedElement.GetInstance(nameOfObjectBefore);
-            exclusiveLowerIndexInDerived = derivedElement.Instances.IndexOf(instanceBefore);
-        }
-
-        int exclusiveUpperIndexInDerived = derivedElement.Instances.Count;
-
-        if(nameOfObjectAfter != null)
-        {
-            var instanceAfter = derivedElement.GetInstance(nameOfObjectAfter);
-            exclusiveUpperIndexInDerived = derivedElement.Instances.IndexOf(instanceAfter);
-        }
-
-        int currentDerivedIndex = derivedElement.Instances.IndexOf(instanceInDerived);
-
-        var desiredIndex = System.Math.Min(currentDerivedIndex, exclusiveUpperIndexInDerived - 1);
-        desiredIndex = System.Math.Max(desiredIndex, exclusiveLowerIndexInDerived + 1);
-
-        bool didAdjust = false;
-        if(desiredIndex != currentDerivedIndex)
-        {
-            didAdjust = true;
-            derivedElement.Instances.Remove(instanceInDerived);
-            if(currentDerivedIndex < desiredIndex)
-            {
-                // we'll remove it from instances, which shifts everything above it up by one, so we have to -1 it
-                derivedElement.Instances.Insert(desiredIndex - 1, instanceInDerived);
-            }
-            else
-            {
-                derivedElement.Instances.Insert(desiredIndex, instanceInDerived);
-            }
-        }
-
-        return didAdjust;
-    }
-
 }

--- a/Gum/Plugins/InternalPlugins/TreeView/ElementTreeViewManager.RightClick.cs
+++ b/Gum/Plugins/InternalPlugins/TreeView/ElementTreeViewManager.RightClick.cs
@@ -321,6 +321,8 @@ public partial class ElementTreeViewManager
                 if (selectedBehaviors.Count == 1)
                 {
                     AddMenuItem("Rename", () => _editCommands.AskToRenameBehavior(_selectedState.SelectedBehavior));
+                    AddSeparator();
+                    AddCreateBehaviorInstanceMenuItems("Add object to " + _selectedState.SelectedBehavior.Name);
                 }
                 AddSeparator();
                 var behaviorDeleteText = selectedBehaviors.Count > 1
@@ -475,6 +477,41 @@ public partial class ElementTreeViewManager
                     viewModel.TypeToCreate = type;
                     viewModel.Value = name;
                     viewModel.OnAffirmative();
+                }
+            };
+        }
+    }
+
+    private void AddCreateBehaviorInstanceMenuItems(string itemText)
+    {
+        var parentMenuItem = new MenuItem { Header = itemText };
+        _contextMenu.Items.Add(parentMenuItem);
+
+        var types = new[] {
+            "Circle",
+            "ColoredRectangle",
+            "Container",
+            "NineSlice",
+            "Polygon",
+            "Rectangle",
+            "Sprite",
+            "Text"
+        };
+
+        foreach (var type in types)
+        {
+            var menuItem = new MenuItem { Header = type };
+            parentMenuItem.Items.Add(menuItem);
+
+            menuItem.Click += (_, _) =>
+            {
+                var selectedBehavior = _selectedState.SelectedBehavior;
+                if (selectedBehavior != null)
+                {
+                    var typeElement = ObjectFinder.Self.GetElementSave(type)!;
+                    var name = _elementCommands.GetUniqueNameForNewInstance(typeElement, selectedBehavior);
+                    _undoManager.RecordBehaviorState(selectedBehavior);
+                    _elementCommands.AddInstance(selectedBehavior, name, type);
                 }
             };
         }

--- a/Gum/Plugins/InternalPlugins/TreeView/MainTreeViewPlugin.cs
+++ b/Gum/Plugins/InternalPlugins/TreeView/MainTreeViewPlugin.cs
@@ -89,6 +89,10 @@ internal class MainTreeViewPlugin : InternalPlugin, IRecipient<ApplicationTeardo
         this.StateAdd += HandleStateAdd;
         this.StateDelete += HandleStateDelete;
         this.CategoryDelete += HandleCategoryDelete;
+        this.BehaviorReferencesChanged += HandleBehaviorReferencesChanged;
+        this.BehaviorInstanceAdd += HandleBehaviorInstanceAdd;
+        this.BehaviorInstanceDelete += HandleBehaviorInstanceDelete;
+        this.BehaviorInstanceRename += HandleBehaviorInstanceRename;
     }
 
     private void HandleElementReloaded(ElementSave save)
@@ -311,6 +315,38 @@ internal class MainTreeViewPlugin : InternalPlugin, IRecipient<ApplicationTeardo
     {
         _elementTreeViewManager.RefreshUi();
         RefreshErrorIndicatorsForElement(_selectedState.SelectedElement);
+    }
+
+    private void HandleBehaviorReferencesChanged(ElementSave elementSave)
+    {
+        RefreshErrorIndicatorsForElement(elementSave);
+    }
+
+    private void HandleBehaviorInstanceAdd(BehaviorSave behavior, BehaviorInstanceSave instance)
+    {
+        RefreshErrorIndicatorsForElementsReferencingBehavior(behavior);
+    }
+
+    private void HandleBehaviorInstanceDelete(BehaviorSave behavior, BehaviorInstanceSave instance)
+    {
+        RefreshErrorIndicatorsForElementsReferencingBehavior(behavior);
+    }
+
+    private void HandleBehaviorInstanceRename(BehaviorSave behavior, BehaviorInstanceSave instance)
+    {
+        RefreshErrorIndicatorsForElementsReferencingBehavior(behavior);
+    }
+
+    private void RefreshErrorIndicatorsForElementsReferencingBehavior(BehaviorSave behavior)
+    {
+        var project = _projectState.GumProjectSave;
+        if (project == null) return;
+        var referencingElements = project.Components
+            .Where(c => c.Behaviors.Any(b => b.BehaviorName == behavior.Name));
+        foreach (var element in referencingElements)
+        {
+            RefreshErrorIndicatorsForElement(element);
+        }
     }
 
     private void SaveTreeViewState()

--- a/Gum/Plugins/InternalPlugins/VariableGrid/SetVariableLogic.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/SetVariableLogic.cs
@@ -311,7 +311,7 @@ public class SetVariableLogic : ISetVariableLogic
 
             ReactIfChangedMemberIsDefaultChildContainer(parentElement, instance, rootVariableName, oldValue);
 
-            _variableReferenceLogic.ReactIfChangedMemberIsVariableReference(parentElement, instance, stateSave, rootVariableName, oldValue);
+            _variableReferenceLogic.ReactIfChangedMemberIsVariableReference(instance, stateSave, rootVariableName, oldValue);
         }
         ReactIfChangedBaseType(instanceContainer, instance, stateSave, rootVariableName, oldValue);
 
@@ -974,6 +974,7 @@ public class SetVariableLogic : ISetVariableLogic
                 return renameResponse;
             }
             _pluginManager.InstanceRename(null, instance, (string)oldValue);
+            _pluginManager.BehaviorInstanceRename(behavior, instance);
         }
         return GeneralResponse.SuccessfulResponse;
     }

--- a/Gum/Plugins/InternalPlugins/VariableGrid/VariableReferenceLogic.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/VariableReferenceLogic.cs
@@ -44,7 +44,7 @@ public class VariableReferenceLogic
         _fileCommands = fileCommands;
     }
 
-    public AssignmentExpressionSyntax GetAssignmentSyntax(string item)
+    public AssignmentExpressionSyntax? GetAssignmentSyntax(string item)
     {
         item = EvaluatedSyntax.ConvertToCSharpSyntax(item);
 
@@ -54,7 +54,7 @@ public class VariableReferenceLogic
         return assignment;
     }
 
-    private static AssignmentExpressionSyntax GetAssignmentRoot(SyntaxNode sourceNode)
+    private static AssignmentExpressionSyntax? GetAssignmentRoot(SyntaxNode sourceNode)
     {
 
         if(sourceNode is AssignmentExpressionSyntax assignment)
@@ -80,7 +80,7 @@ public class VariableReferenceLogic
 
     #region Validation (failures)
 
-    private List<(string, GeneralResponse)> GetIndividualFailures(ElementSave parentElement, InstanceSave leftSideInstance, VariableListSave newDirectValue)
+    private List<(string, GeneralResponse)> GetIndividualFailures(ElementSave parentElement, InstanceSave? leftSideInstance, VariableListSave newDirectValue)
     {
         var values = newDirectValue.ValueAsIList;
 
@@ -94,7 +94,7 @@ public class VariableReferenceLogic
         return failures;
     }
 
-    private void AddFailureForLine(ElementSave parentElement, InstanceSave leftSideInstance, List<(string, GeneralResponse)> failures, string line)
+    private void AddFailureForLine(ElementSave parentElement, InstanceSave? leftSideInstance, List<(string, GeneralResponse)> failures, string line)
     {
         if (line.StartsWith("//") || string.IsNullOrEmpty(line))
         {
@@ -220,7 +220,7 @@ public class VariableReferenceLogic
         }
     }
 
-    private GeneralResponse CheckIfVariableTypesMatch(VariableSave leftSideVariable, ElementSave parentElement, InstanceSave leftSideInstance, EvaluatedSyntax assignment)
+    private GeneralResponse CheckIfVariableTypesMatch(VariableSave leftSideVariable, ElementSave parentElement, InstanceSave? leftSideInstance, EvaluatedSyntax assignment)
     {
         var leftSideType = leftSideVariable.Type;
         string rightSideType = null;
@@ -294,7 +294,7 @@ public class VariableReferenceLogic
         return GeneralResponse.SuccessfulResponse;
     }
 
-    private GeneralResponse<VariableSave> CheckLeftSideVariableExistence(ElementSave parentElement, InstanceSave instance, AssignmentExpressionSyntax syntax)
+    private GeneralResponse<VariableSave> CheckLeftSideVariableExistence(ElementSave parentElement, InstanceSave? instance, AssignmentExpressionSyntax syntax)
     {
         var element = instance != null ? ObjectFinder.Self.GetElementSave(instance) : parentElement;
 
@@ -317,7 +317,7 @@ public class VariableReferenceLogic
     #region Assignment Reactions
 
 
-    public void DoVariableReferenceReaction(ElementSave parentElement, InstanceSave leftSideInstance, string unqualifiedMember,
+    public void DoVariableReferenceReaction(ElementSave parentElement, InstanceSave? leftSideInstance, string unqualifiedMember,
         StateSave stateSave, string qualifiedName, bool trySave)
     {
         if (unqualifiedMember == "VariableReferences")
@@ -393,7 +393,7 @@ public class VariableReferenceLogic
         }
     }
 
-    private static bool DoVariableReferenceReactionOnInstanceVariableSet(ElementSave container, InstanceSave instance, StateSave stateSave, string unqualifiedVariableName, object newValue)
+    private static bool DoVariableReferenceReactionOnInstanceVariableSet(ElementSave container, InstanceSave? instance, StateSave stateSave, string unqualifiedVariableName, object newValue)
     {
         var didAssignDeepReference = false;
         ElementSave instanceElement = null;
@@ -486,7 +486,7 @@ public class VariableReferenceLogic
     }
 
 
-    public void ReactIfChangedMemberIsVariableReference(ElementSave parentElement, InstanceSave instance, StateSave stateSave, string changedMember, object oldValue)
+    public void ReactIfChangedMemberIsVariableReference(InstanceSave? instance, StateSave stateSave, string changedMember, object? oldValue)
     {
         ///////////////////// Early Out/////////////////////////////////////
         if (changedMember != "VariableReferences") return;
@@ -515,7 +515,7 @@ public class VariableReferenceLogic
     #region Line Assignment Expansion / Modifications
 
     static char[] equalsArray = new char[] { '=' };
-    bool ModifyLines(object oldValue, List<string> newValueAsList, InstanceSave selectedInstance)
+    bool ModifyLines(object? oldValue, List<string> newValueAsList, InstanceSave? selectedInstance)
     {
         var oldValueAsList = oldValue as List<string>;
 

--- a/Gum/Plugins/PluginManager.cs
+++ b/Gum/Plugins/PluginManager.cs
@@ -425,6 +425,12 @@ public class PluginManager : IPluginManager
     public void BehaviorInstanceAdd(BehaviorSave behavior, BehaviorInstanceSave instance) =>
         CallMethodOnPlugin(plugin => plugin.CallBehaviorInstanceAdd(behavior, instance));
 
+    public void BehaviorInstanceDelete(BehaviorSave behavior, BehaviorInstanceSave instance) =>
+        CallMethodOnPlugin(plugin => plugin.CallBehaviorInstanceDelete(behavior, instance));
+
+    public void BehaviorInstanceRename(BehaviorSave behavior, BehaviorInstanceSave instance) =>
+        CallMethodOnPlugin(plugin => plugin.CallBehaviorInstanceRename(behavior, instance));
+
     public StateSave? GetDefaultStateFor(string type)
     {
         StateSave? toReturn = null;

--- a/Gum/Services/Builder.cs
+++ b/Gum/Services/Builder.cs
@@ -124,6 +124,7 @@ file static class ServiceCollectionExtensions
         services.AddSingleton<IFileWatchManager>(provider => provider.GetRequiredService<FileWatchManager>());
         services.AddSingleton<ReorderLogic>();
         services.AddSingleton<IReorderLogic>(provider => provider.GetRequiredService<ReorderLogic>());
+        services.AddSingleton<InheritanceLogic>();
 
         services.AddSingleton<IUserProjectSettingsManager, UserProjectSettingsManager>();
         services.AddSingleton<ProjectServices.ITypeResolver>(provider =>

--- a/Gum/ToolCommands/ElementCommands.cs
+++ b/Gum/ToolCommands/ElementCommands.cs
@@ -133,6 +133,21 @@ public class ElementCommands : IElementCommands
         return StringFunctions.MakeStringUnique(name, existingNames);
     }
 
+    public string GetUniqueNameForNewInstance(ElementSave elementSaveForNewInstance, BehaviorSave containerForNewInstance)
+    {
+#if DEBUG
+        if (elementSaveForNewInstance == null)
+        {
+            throw new ArgumentNullException(nameof(elementSaveForNewInstance));
+        }
+#endif
+        // remove the path - we dont want folders to be part of the name
+        string name = FileManager.RemovePath(elementSaveForNewInstance.Name) + "Instance";
+        IEnumerable<string> existingNames = containerForNewInstance.RequiredInstances.Select(i => i.Name);
+
+        return StringFunctions.MakeStringUnique(name, existingNames);
+    }
+
     #endregion
 
     #region State

--- a/Gum/ToolCommands/IElementCommands.cs
+++ b/Gum/ToolCommands/IElementCommands.cs
@@ -16,6 +16,8 @@ public interface IElementCommands
     InstanceSave AddInstance(ElementSave elementToAddTo, InstanceSave instanceSave, string? parentName = null, int? desiredIndex = null);
     
     string GetUniqueNameForNewInstance(ElementSave elementSaveForNewInstance, ElementSave containerForNewInstance);
+
+    string GetUniqueNameForNewInstance(ElementSave elementSaveForNewInstance, BehaviorSave containerForNewInstance);
     
     #endregion
 

--- a/Tool/Tests/GumToolUnitTests/Logic/InheritanceLogicTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Logic/InheritanceLogicTests.cs
@@ -1,0 +1,82 @@
+using Gum.Commands;
+using Gum.DataTypes;
+using Gum.DataTypes.Behaviors;
+using Gum.Logic;
+using Gum.Managers;
+using Gum.Plugins.InternalPlugins.VariableGrid;
+using Moq;
+using Shouldly;
+
+namespace GumToolUnitTests.Logic;
+
+public class InheritanceLogicTests : BaseTestClass
+{
+    private readonly Mock<IFileCommands> _fileCommands;
+    private readonly Mock<IGuiCommands> _guiCommands;
+    private readonly InheritanceLogic _sut;
+
+    public InheritanceLogicTests()
+    {
+        _fileCommands = new Mock<IFileCommands>();
+        _guiCommands = new Mock<IGuiCommands>();
+
+        _sut = new InheritanceLogic(
+            _fileCommands.Object,
+            _guiCommands.Object,
+            StandardElementsManagerGumTool.Self);
+    }
+
+    [Fact]
+    public void HandleInstanceRenamed_WithNullContainer_DoesNotThrow()
+    {
+        // Behavior instances fire InstanceRename with a null container (BehaviorSave is
+        // not an ElementSave). Before the fix, this caused an ArgumentNullException
+        // inside ObjectFinder.GetElementsInheritingFrom.
+        var project = new GumProjectSave();
+        ObjectFinder.Self.GumProjectSave = project;
+
+        var behaviorInstance = new BehaviorInstanceSave { Name = "NewName" };
+
+        Should.NotThrow(() => _sut.HandleInstanceRenamed(
+            container: null,
+            instance: behaviorInstance,
+            oldName: "OldName"));
+    }
+
+    [Fact]
+    public void HandleInstanceRenamed_WithNullContainer_DoesNotSaveOrRefresh()
+    {
+        var project = new GumProjectSave();
+        ObjectFinder.Self.GumProjectSave = project;
+
+        var behaviorInstance = new BehaviorInstanceSave { Name = "NewName" };
+
+        _sut.HandleInstanceRenamed(container: null, instance: behaviorInstance, oldName: "OldName");
+
+        _fileCommands.Verify(f => f.TryAutoSaveElement(It.IsAny<ElementSave>()), Times.Never);
+        _guiCommands.Verify(g => g.RefreshElementTreeView(It.IsAny<IInstanceContainer>()), Times.Never);
+    }
+
+    [Fact]
+    public void HandleInstanceRenamed_WithValidContainer_RenamesInstanceInDerivedElements()
+    {
+        var project = new GumProjectSave();
+        ObjectFinder.Self.GumProjectSave = project;
+
+        var baseComponent = new ComponentSave { Name = "Base" };
+        baseComponent.InitializeDefaultAndComponentVariables();
+        var baseInstance = new InstanceSave { Name = "NewName", BaseType = "Sprite" };
+        baseComponent.Instances.Add(baseInstance);
+        project.Components.Add(baseComponent);
+
+        var derivedComponent = new ComponentSave { Name = "Derived", BaseType = "Base" };
+        derivedComponent.InitializeDefaultAndComponentVariables();
+        var derivedInstance = new InstanceSave { Name = "OldName", BaseType = "Sprite" };
+        derivedComponent.Instances.Add(derivedInstance);
+        project.Components.Add(derivedComponent);
+
+        _sut.HandleInstanceRenamed(container: baseComponent, instance: baseInstance, oldName: "OldName");
+
+        derivedInstance.Name.ShouldBe("NewName");
+    }
+}

--- a/Tool/Tests/GumToolUnitTests/ToolCommands/ElementCommandsTests.cs
+++ b/Tool/Tests/GumToolUnitTests/ToolCommands/ElementCommandsTests.cs
@@ -1,5 +1,6 @@
 ﻿using Gum.Commands;
 using Gum.DataTypes;
+using Gum.DataTypes.Behaviors;
 using Gum.Managers;
 using Gum.Plugins;
 using Gum.PropertyGridHelpers;
@@ -119,6 +120,52 @@ public class ElementCommandsTests
 
         // act
         string name = _sut.GetUniqueNameForNewInstance(text, component);
+
+        // assert
+        name.ShouldBe("TextInstance1");
+    }
+
+    [Fact]
+    public void GetUniqueNameForNewInstance_WithBehaviorSave_ShouldReturnDefaultName()
+    {
+        GumProjectSave project = new GumProjectSave();
+        _objectFinder.GumProjectSave = project;
+
+        StandardElementSave text = new()
+        {
+            Name = "Text"
+        };
+        _objectFinder.GumProjectSave.StandardElements.Add(text);
+
+        BehaviorSave behavior = new();
+
+        // act
+        string name = _sut.GetUniqueNameForNewInstance(text, behavior);
+
+        // assert
+        name.ShouldBe("TextInstance");
+    }
+
+    [Fact]
+    public void GetUniqueNameForNewInstance_WithBehaviorSave_ShouldIncrement_OnMatchingName()
+    {
+        GumProjectSave project = new GumProjectSave();
+        _objectFinder.GumProjectSave = project;
+
+        StandardElementSave text = new()
+        {
+            Name = "Text"
+        };
+        _objectFinder.GumProjectSave.StandardElements.Add(text);
+
+        BehaviorSave behavior = new();
+        behavior.RequiredInstances.Add(new BehaviorInstanceSave
+        {
+            Name = "TextInstance"
+        });
+
+        // act
+        string name = _sut.GetUniqueNameForNewInstance(text, behavior);
 
         // assert
         name.ShouldBe("TextInstance1");

--- a/Tool/Tests/GumToolUnitTests/VariableGrid/VariableReferenceLogicTests.cs
+++ b/Tool/Tests/GumToolUnitTests/VariableGrid/VariableReferenceLogicTests.cs
@@ -84,7 +84,7 @@ public class VariableReferenceLogicTests : BaseTestClass
         StateSave stateSave = BuildStateWithVariableReferences("VariableReferences", "Background.Color");
 
         _sut.ReactIfChangedMemberIsVariableReference(
-            parentElement: null, instance: null, stateSave, changedMember: "VariableReferences", oldValue: null);
+            instance: null, stateSave, changedMember: "VariableReferences", oldValue: null);
 
         var varList = (List<string>)stateSave.GetVariableListSave("VariableReferences").ValueAsIList;
         varList.Count.ShouldBe(3);
@@ -100,7 +100,7 @@ public class VariableReferenceLogicTests : BaseTestClass
         StateSave stateSave = BuildStateWithVariableReferences("VariableReferences", "Background.Width");
 
         _sut.ReactIfChangedMemberIsVariableReference(
-            parentElement: null, instance: null, stateSave, changedMember: "VariableReferences", oldValue: null);
+            instance: null, stateSave, changedMember: "VariableReferences", oldValue: null);
 
         var varList = (List<string>)stateSave.GetVariableListSave("VariableReferences").ValueAsIList;
         varList[0].ShouldBe("Width = Background.Width");
@@ -112,7 +112,7 @@ public class VariableReferenceLogicTests : BaseTestClass
         StateSave stateSave = BuildStateWithVariableReferences("VariableReferences", "X=Y");
 
         _sut.ReactIfChangedMemberIsVariableReference(
-            parentElement: null, instance: null, stateSave, changedMember: "VariableReferences", oldValue: null);
+            instance: null, stateSave, changedMember: "VariableReferences", oldValue: null);
 
         _guiCommandsMock.Verify(x => x.RefreshVariables(It.IsAny<bool>()), Times.Once);
     }
@@ -124,7 +124,7 @@ public class VariableReferenceLogicTests : BaseTestClass
         StateSave stateSave = BuildStateWithVariableReferences("VariableReferences", "X=Y");
 
         _sut.ReactIfChangedMemberIsVariableReference(
-            parentElement: null, instance: null, stateSave, changedMember: "VariableReferences", oldValue: oldValue);
+            instance: null, stateSave, changedMember: "VariableReferences", oldValue: oldValue);
 
         _guiCommandsMock.Verify(x => x.RefreshVariables(It.IsAny<bool>()), Times.Never);
     }
@@ -135,7 +135,7 @@ public class VariableReferenceLogicTests : BaseTestClass
         StateSave stateSave = new StateSave();
 
         _sut.ReactIfChangedMemberIsVariableReference(
-            parentElement: null, instance: null, stateSave, changedMember: "Width", oldValue: null);
+            instance: null, stateSave, changedMember: "Width", oldValue: null);
 
         _guiCommandsMock.Verify(x => x.RefreshVariables(It.IsAny<bool>()), Times.Never);
     }
@@ -147,7 +147,7 @@ public class VariableReferenceLogicTests : BaseTestClass
         StateSave stateSave = BuildStateWithVariableReferences("VariableReferences", "Instance.Width=OtherInstance.Width");
 
         _sut.ReactIfChangedMemberIsVariableReference(
-            parentElement: null, instance: null, stateSave, changedMember: "VariableReferences", oldValue: null);
+            instance: null, stateSave, changedMember: "VariableReferences", oldValue: null);
 
         var varList = (List<string>)stateSave.GetVariableListSave("VariableReferences").ValueAsIList;
         varList[0].ShouldBe("Width=OtherInstance.Width");
@@ -161,7 +161,7 @@ public class VariableReferenceLogicTests : BaseTestClass
         StateSave stateSave = BuildStateWithVariableReferences("myInstance.VariableReferences", "Width=SomeVar");
 
         _sut.ReactIfChangedMemberIsVariableReference(
-            parentElement: null, instance, stateSave, changedMember: "VariableReferences", oldValue: null);
+            instance, stateSave, changedMember: "VariableReferences", oldValue: null);
 
         var varList = (List<string>)stateSave.GetVariableListSave("myInstance.VariableReferences").ValueAsIList;
         varList[0].ShouldContain("myInstance.SomeVar");


### PR DESCRIPTION
Changing behaviors (adding or removing instance, renaming instance) now refreshes tree view errors. Fixed crash renaming behavior instances.