### PR TITLE
Fix enum handling and UI refresh for TextureAddress

### DIFF
--- a/Gum/Plugins/InternalPlugins/VariableGrid/StateReferencingInstanceMember.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/StateReferencingInstanceMember.cs
@@ -752,6 +752,26 @@ public class StateReferencingInstanceMember : InstanceMember
                     var rootVariable = ObjectFinder.Self.GetRootVariable(this.Name, elementSave);
                     variableType = rootVariable?.Type;
                 }
+
+                // Convert enum values coming from dropdown UI
+                if (newValue is string s && !string.IsNullOrEmpty(variableType))
+                {
+                    var enumType = Type.GetType($"Gum.Managers.{variableType}")
+                                   ?? Type.GetType(variableType);
+
+                    if (enumType != null && enumType.IsEnum)
+                    {
+                        try
+                        {
+                            newValue = Enum.Parse(enumType, s);
+                        }
+                        catch
+                        {
+                            // ignore if not valid enum value
+                        }
+                    }
+                }
+
                 // ...set variable after getting it from base, or else we'd get the variable we just set...
                 stateSave.SetValue(Name, newValue, instanceSave, variableType);
                 if (!string.IsNullOrEmpty(existingVariable?.ExposedAsName) && variableDefinedInThisOrBase != null)

--- a/GumRuntime/GraphicalUiElement.cs
+++ b/GumRuntime/GraphicalUiElement.cs
@@ -5738,6 +5738,16 @@ public partial class GraphicalUiElement : IRenderableIpso, IVisible, INotifyProp
     /// <param name="value">The value, casted to the correct type.</param>
     public void SetProperty(string propertyName, object? value)
     {
+        if (value is string stringValue)
+        {
+            if (propertyName == "TextureAddress")
+            {
+                if (Enum.TryParse(typeof(Gum.Managers.TextureAddress), stringValue, out var parsed))
+                {
+                    value = parsed;
+                }
+            }
+        }
 
         if (mExposedVariables.ContainsKey(propertyName))
         {

--- a/Tool/EditorTabPlugin_XNA/MainEditorTabPlugin.cs
+++ b/Tool/EditorTabPlugin_XNA/MainEditorTabPlugin.cs
@@ -643,6 +643,16 @@ internal class MainEditorTabPlugin : InternalPlugin, IRecipient<UiBaseFontSizeCh
                         }
                     }
 
+                    // Fix enum assignment coming from dropdown UI
+                    if (unqualifiedMember == "TextureAddress" && value is string stringValue)
+                    {
+                        if (Enum.TryParse(typeof(Gum.Managers.TextureAddress), stringValue, out var parsed))
+                        {
+                            value = parsed;
+                            state.SetValue(qualifiedName, parsed);
+                        }
+                    }
+
                     gue.SetProperty(unqualifiedMember, value);
 
                     _wireframeObjectManager.RootGue?.ApplyVariableReferences(state);


### PR DESCRIPTION
Changing the TextureAddress property in the editor could result in the value being stored as a string ("Custom") instead of the enum TextureAddress.Custom. This caused two issues.

Runtime crash

```
InvalidCastException: Unable to cast object of type 'System.String'
to type 'Gum.Managers.TextureAddress'
```

and Property grid inconsistency

The coordinate fields (TextureLeft, TextureTop, TextureWidth, TextureHeight) were conditionally visible when:

`TextureAddress == Custom`

Because the state sometimes stored "Custom" as a string, the visibility rule failed and the fields would not appear until the element was reselected. This also effected the generated code but it was pretty hard to get that far.

I tired a couple older versions, all the way back to Nov. Not sure why I was running into this issue when it didn't seem widespread, but I'm pretty sure I was using the tool correctly.

Tried to get to the root of the issue, but I likely didn't find it. I settled for converting dropdown string values to the correct enum type before storing them in the state
in `HandleCustomSet` and a defensive conversion in `MainEditorTabPlugin.HandleVariableSetLate`
to convert any remaining string values to the correct enum before applying them to the runtime object.
 
 There probably could be a better way to handle this issue, but so far this fix is working for me.

