### PR TITLE
Event failure reason now works properly when using GumBatch

### DIFF
--- a/MonoGameGum.Tests/Input/CursorExtensionsTests.cs
+++ b/MonoGameGum.Tests/Input/CursorExtensionsTests.cs
@@ -1,0 +1,152 @@
+using Gum.DataTypes;
+using Gum.Forms;
+using Gum.Forms.Controls;
+using Gum.Wireframe;
+using MonoGameGum.GueDeriving;
+using MonoGameGum.Input;
+using Moq;
+using RenderingLibrary.Graphics;
+using Shouldly;
+using Xunit;
+
+namespace MonoGameGum.Tests.Input;
+
+public class CursorExtensionsTests : BaseTestClass
+{
+    private static InteractiveGue CreateVisibleElement(string name)
+    {
+        InteractiveGue element = new InteractiveGue(new InvisibleRenderable());
+        element.Name = name;
+        element.Width = 200;
+        element.Height = 100;
+        element.WidthUnits = DimensionUnitType.Absolute;
+        element.HeightUnits = DimensionUnitType.Absolute;
+        element.HasEvents = true;
+        return element;
+    }
+
+    [Fact]
+    public void GetEventFailureReason_ShouldContinuePastManagers_WhenInLastEventRoots()
+    {
+        // Simulate a GumBatch scenario: element has no managers but was
+        // passed as a root to Update.
+        InteractiveGue element = CreateVisibleElement("BatchElement");
+
+        Mock<ICursor> cursor = new();
+        cursor.Setup(x => x.XRespectingGumZoomAndBounds()).Returns(50);
+        cursor.Setup(x => x.YRespectingGumZoomAndBounds()).Returns(50);
+        cursor.Setup(x => x.X).Returns(50);
+        cursor.Setup(x => x.Y).Returns(50);
+
+        // Call Update with element as a root to populate LastEventRoots
+        GumService.Default.Update(
+            new Microsoft.Xna.Framework.GameTime(),
+            new GraphicalUiElement[] { element });
+
+        string? reason = cursor.Object.GetEventFailureReason(element);
+
+        // Should not contain "EffectiveManagers" — that check should be skipped
+        if (reason != null)
+        {
+            reason.ShouldNotContain("EffectiveManagers");
+        }
+    }
+
+    [Fact]
+    public void GetEventFailureReason_ShouldMentionUpdate_WhenNotInLastEventRootsAndNoManagers()
+    {
+        InteractiveGue element = CreateVisibleElement("OrphanElement");
+
+        Mock<ICursor> cursor = new();
+        cursor.Setup(x => x.XRespectingGumZoomAndBounds()).Returns(50);
+        cursor.Setup(x => x.YRespectingGumZoomAndBounds()).Returns(50);
+        cursor.Setup(x => x.X).Returns(50);
+        cursor.Setup(x => x.Y).Returns(50);
+
+        // Call Update with a different element so this one is NOT in LastEventRoots
+        InteractiveGue otherElement = new InteractiveGue(new InvisibleRenderable());
+        GumService.Default.Update(
+            new Microsoft.Xna.Framework.GameTime(),
+            new GraphicalUiElement[] { otherElement });
+
+        string? reason = cursor.Object.GetEventFailureReason(element);
+
+        reason.ShouldNotBeNull();
+        reason.ShouldContain("GumService.Update()");
+    }
+
+    [Fact]
+    public void GetEventFailureReason_ShouldReportCursorPosition_WhenInLastEventRootsButCursorOutside()
+    {
+        InteractiveGue element = CreateVisibleElement("BatchElement");
+
+        Mock<ICursor> cursor = new();
+        // Position cursor outside the element
+        cursor.Setup(x => x.XRespectingGumZoomAndBounds()).Returns(500);
+        cursor.Setup(x => x.YRespectingGumZoomAndBounds()).Returns(500);
+        cursor.Setup(x => x.X).Returns(500);
+        cursor.Setup(x => x.Y).Returns(500);
+
+        GumService.Default.Update(
+            new Microsoft.Xna.Framework.GameTime(),
+            new GraphicalUiElement[] { element });
+
+        string? reason = cursor.Object.GetEventFailureReason(element);
+
+        reason.ShouldNotBeNull();
+        // Should give cursor-position info, not "EffectiveManagers"
+        reason.ShouldNotContain("EffectiveManagers");
+        reason.ShouldContain("cursor");
+    }
+
+    [Fact]
+    public void GetEventFailureReason_ShouldSkipRootParentCheck_WhenInLastEventRoots()
+    {
+        // In GumBatch mode, the element won't be under Root/PopupRoot/ModalRoot.
+        // The diagnostic should not report "orphan object" if it was in the event roots.
+        InteractiveGue element = CreateVisibleElement("BatchElement");
+
+        Mock<ICursor> cursor = new();
+        cursor.Setup(x => x.XRespectingGumZoomAndBounds()).Returns(50);
+        cursor.Setup(x => x.YRespectingGumZoomAndBounds()).Returns(50);
+        cursor.Setup(x => x.X).Returns(50);
+        cursor.Setup(x => x.Y).Returns(50);
+
+        GumService.Default.Update(
+            new Microsoft.Xna.Framework.GameTime(),
+            new GraphicalUiElement[] { element });
+
+        string? reason = cursor.Object.GetEventFailureReason(element);
+
+        if (reason != null)
+        {
+            reason.ShouldNotContain("orphan");
+        }
+    }
+
+    [Fact]
+    public void GetEventFailureReason_ShouldIdentifyChildOverlap_WhenCursorOverChildOfTarget()
+    {
+        InteractiveGue parent = CreateVisibleElement("WindowVisual");
+
+        InteractiveGue child = CreateVisibleElement("TitleBarInstance");
+        parent.AddChild(child);
+
+        Mock<ICursor> cursor = new();
+        cursor.Setup(x => x.XRespectingGumZoomAndBounds()).Returns(50);
+        cursor.Setup(x => x.YRespectingGumZoomAndBounds()).Returns(50);
+        cursor.Setup(x => x.X).Returns(50);
+        cursor.Setup(x => x.Y).Returns(50);
+        // Simulate the cursor being over the child, not the parent
+        cursor.SetupGet(x => x.VisualOver).Returns(child);
+
+        parent.AddToRoot();
+
+        string? reason = cursor.Object.GetEventFailureReason(parent);
+
+        reason.ShouldNotBeNull();
+        reason.ShouldContain("child");
+        reason.ShouldContain("TitleBarInstance");
+        reason.ShouldContain("not directly over");
+    }
+}

--- a/MonoGameGum/Forms/FormsUtilities.cs
+++ b/MonoGameGum/Forms/FormsUtilities.cs
@@ -315,6 +315,14 @@ public class FormsUtilities
     static List<GraphicalUiElement> innerList = new List<GraphicalUiElement>();
     static List<GraphicalUiElement> innerRootList = new List<GraphicalUiElement>();
 
+    /// <summary>
+    /// The list of root elements that were tested for events in the most recent Update call.
+    /// Used by GetEventFailureReason to provide useful diagnostics in GumBatch scenarios
+    /// where elements are not added to managers.
+    /// </summary>
+    internal static IReadOnlyList<GraphicalUiElement> LastEventRoots => _lastEventRoots;
+    static List<GraphicalUiElement> _lastEventRoots = new List<GraphicalUiElement>();
+
 #if XNALIKE
     [Obsolete("Use the overload which takes a Game as the first argument, and pass the game instance.")]
     public static void Update(GameTime gameTime, GraphicalUiElement rootGue)
@@ -458,6 +466,9 @@ public class FormsUtilities
             keyboard,
             gameTime);
 #endif
+
+        _lastEventRoots.Clear();
+        _lastEventRoots.AddRange(innerList);
 
         var frameworkElementOver =
             cursor.WindowPushed?.FormsControlAsObject as FrameworkElement ??

--- a/MonoGameGum/Input/CursorExtensions.cs
+++ b/MonoGameGum/Input/CursorExtensions.cs
@@ -98,8 +98,14 @@ public static class CursorExtensions
 
         if(interactiveGue.EffectiveManagers == null)
         {
-            return $"The {NameOrType(interactiveGue)} does not have EffectiveManagers, " +
-                $"which means it was not added to a root object, and it was not added as a descendent of a root object.";
+            if(!IsInLastEventRoots(interactiveGue))
+            {
+                return $"The {NameOrType(interactiveGue)} does not have EffectiveManagers and was not included " +
+                    $"in the roots passed to GumService.Update(). Either add it to managers or include it (or a parent) " +
+                    $"in the roots passed to Update.";
+            }
+            // If it is in the last event roots, it's a GumBatch scenario — skip the managers
+            // check and continue with the remaining diagnostics.
         }
 
 
@@ -161,21 +167,33 @@ public static class CursorExtensions
 
         if(cursor.VisualOver != null && cursor.VisualOver != interactiveGue)
         {
-            return $"The cursor is over {NameOrType(cursor.VisualOver)} instead of {interactiveGue}";
+            if(IsDescendantOf(cursor.VisualOver, interactiveGue))
+            {
+                return $"The cursor is not directly over {NameOrType(interactiveGue)}, " +
+                    $"but is over its child {NameOrType(cursor.VisualOver)}. " +
+                    $"A child is receiving events instead of the parent.\n" +
+                    GetStack(interactiveGue);
+            }
+            return $"The cursor is over {NameOrType(cursor.VisualOver)} instead of {NameOrType(interactiveGue)}";
         }
 
         var rootParent = interactiveGue.GetTopParent();
-        var gumUI = GumService.Default;
-        if(rootParent != gumUI.Root && rootParent != gumUI.PopupRoot && rootParent != gumUI.ModalRoot)
-        {
-            return $"The object must ultimately be added to one of the root objects, but it is not. The top parent {rootParent} is an orphan object";
-        }
+        var isInEventRoots = IsInLastEventRoots(interactiveGue);
 
-        if(rootParent != gumUI.ModalRoot && gumUI.ModalRoot.Children.Count(item => item.Visible) > 0)
+        if(!isInEventRoots)
         {
-            var firstVisible = gumUI.ModalRoot.Children.First(item => item.Visible);
+            var gumUI = GumService.Default;
+            if(rootParent != gumUI.Root && rootParent != gumUI.PopupRoot && rootParent != gumUI.ModalRoot)
+            {
+                return $"The object must ultimately be added to one of the root objects, but it is not. The top parent {rootParent} is an orphan object";
+            }
 
-            return $"There is a modal that is blocking clicks to {interactiveGue}: {firstVisible}";
+            if(rootParent != gumUI.ModalRoot && gumUI.ModalRoot.Children.Count(item => item.Visible) > 0)
+            {
+                var firstVisible = gumUI.ModalRoot.Children.First(item => item.Visible);
+
+                return $"There is a modal that is blocking clicks to {interactiveGue}: {firstVisible}";
+            }
         }
 
         return null;
@@ -295,5 +313,38 @@ public static class CursorExtensions
         {
             return GetNotExposedChildrenEventsParent(visual.Parent as GraphicalUiElement);
         }
+    }
+
+    private static bool IsDescendantOf(GraphicalUiElement possibleDescendant, GraphicalUiElement possibleAncestor)
+    {
+        GraphicalUiElement? current = possibleDescendant.Parent as GraphicalUiElement;
+        while(current != null)
+        {
+            if(current == possibleAncestor)
+            {
+                return true;
+            }
+            current = current.Parent as GraphicalUiElement;
+        }
+        return false;
+    }
+
+    private static bool IsInLastEventRoots(GraphicalUiElement element)
+    {
+        var lastRoots = FormsUtilities.LastEventRoots;
+        if(lastRoots.Count == 0)
+        {
+            return false;
+        }
+
+        var topParent = element.GetTopParent();
+        foreach(var root in lastRoots)
+        {
+            if(root == element || root == topParent)
+            {
+                return true;
+            }
+        }
+        return false;
     }
 }


### PR DESCRIPTION
EventFailureReason now returns more info when a child of the argument object is stealing events