### PR TITLE
Multi-file RESX runtime support + GumService RESX auto-load (#2512, p…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,10 +23,18 @@ Select the agent that best matches the task at hand. For tasks that span multipl
 
 ## Building and Testing
 
-* **Always build and test via the solution file** (`Gum.sln`), not individual `.csproj` files. Plugin projects use `$(SolutionDir)` in post-build scripts, which is undefined when building a `.csproj` directly.
-  * Build: `dotnet build Gum.sln`
-  * Test: `dotnet test Gum.sln --filter "TestClassName"`
-* The test project is `Tool/Tests/GumToolUnitTests/GumToolUnitTests.csproj` (included in `Gum.sln`).
+**Always build and test via a solution file**, not individual `.csproj` files. Plugin projects use `$(SolutionDir)` in post-build scripts, which is undefined when building a `.csproj` directly.
+
+Pick the solution based on what you're working on:
+
+* **`GumFull.sln`** — the Gum tool and all tool-related projects (WPF editor, plugins, `GumToolUnitTests`, `Gum.Cli.Tests`, etc.). Use this when working on anything under `Tool/`, `Gum/`, plugins, or tool-side code.
+* **`AllLibraries.sln`** — all runtime-related projects (`GumCommon`, `MonoGameGum`, `KniGum`, `FnaGum`, `SkiaGum`, `RaylibGum`, and their test projects including `MonoGameGum.Tests`). Use this when working on runtime libraries, `GumCommon`, or anything a shipped game would reference.
+
+Examples:
+* Build: `dotnet build GumFull.sln` or `dotnet build AllLibraries.sln`
+* Test: `dotnet test AllLibraries.sln --filter "TestClassName"`
+
+If a change spans both (e.g. editing `GumCommon` which is linked into both), build both solutions.
 
 ## Code Style
 

--- a/GumCommon/Localization/LocalizationServiceExtensions.cs
+++ b/GumCommon/Localization/LocalizationServiceExtensions.cs
@@ -1,4 +1,4 @@
-﻿using CsvHelper;
+using CsvHelper;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -52,45 +52,62 @@ public static class LocalizationServiceExtensions
     /// <param name="baseResxFilePath">Path to the base (default language) .resx file.</param>
     public static void AddResxDatabase(this ILocalizationService service, string baseResxFilePath)
     {
-        var directory = Path.GetDirectoryName(baseResxFilePath)!;
-        var fileNameWithoutExtension = Path.GetFileNameWithoutExtension(baseResxFilePath);
+        AddResxDatabase(service, new[] { baseResxFilePath }, onWarning: null);
+    }
 
-        // Collect all .resx files: base file first, then satellite files sorted alphabetically
-        var resxFiles = new List<(string languageName, string filePath)>();
+    /// <summary>
+    /// Loads localization data from multiple base .resx files, each with their own satellite
+    /// files discovered by convention (e.g., Strings.resx + Strings.es.resx, Buttons.resx +
+    /// Buttons.es.resx). Languages are unioned across all files; missing translations fall
+    /// back to the string ID. String IDs are merged across files with last-write-wins on
+    /// collision.
+    /// </summary>
+    /// <param name="service">The localization service to populate.</param>
+    /// <param name="baseResxFilePaths">Paths to the base (default language) .resx files.</param>
+    /// <param name="onWarning">Optional callback invoked with a descriptive message when
+    /// a string ID collision occurs across files. Not invoked for other events. Does not
+    /// write to Debug or Console by default because this runtime ships in games.</param>
+    public static void AddResxDatabase(this ILocalizationService service,
+        IEnumerable<string> baseResxFilePaths,
+        Action<string>? onWarning = null)
+    {
+        var fileGroups = new List<FileGroup>();
 
-        // The base file represents the default/neutral language
-        resxFiles.Add(("Default", baseResxFilePath));
-
-        // Discover satellite files matching the pattern: BaseName.{culture}.resx
-        var searchPattern = fileNameWithoutExtension + ".*.resx";
-        foreach (var satelliteFile in Directory.GetFiles(directory, searchPattern).OrderBy(f => f))
+        foreach (var baseResxFilePath in baseResxFilePaths)
         {
-            // Extract the culture portion from e.g. "Strings.es.resx" -> "es"
-            var satelliteFileName = Path.GetFileNameWithoutExtension(satelliteFile);
-            var cultureName = satelliteFileName.Substring(fileNameWithoutExtension.Length + 1);
+            var directory = Path.GetDirectoryName(baseResxFilePath)!;
+            var fileNameWithoutExtension = Path.GetFileNameWithoutExtension(baseResxFilePath);
 
-            resxFiles.Add((cultureName, satelliteFile));
-        }
+            var filesForGroup = new List<(string languageName, string filePath)>();
+            filesForGroup.Add(("Default", baseResxFilePath));
 
-        // Read all files into streams and delegate to the stream-based overload
-        var resxStreams = new List<(string languageName, Stream stream)>();
-        try
-        {
-            foreach (var (languageName, filePath) in resxFiles)
+            // Note: this pattern will match any file of the shape {BaseName}.*.resx, including
+            // unintended ones like Strings.backup.resx. Callers are responsible for keeping the
+            // directory clean of non-localization files matching this shape.
+            var searchPattern = fileNameWithoutExtension + ".*.resx";
+            foreach (var satelliteFile in Directory.GetFiles(directory, searchPattern).OrderBy(f => f))
             {
-                var stream = File.OpenRead(filePath);
-                resxStreams.Add((languageName, stream));
+                var satelliteFileName = Path.GetFileNameWithoutExtension(satelliteFile);
+                var cultureName = satelliteFileName.Substring(fileNameWithoutExtension.Length + 1);
+                filesForGroup.Add((cultureName, satelliteFile));
             }
 
-            service.AddResxDatabase(resxStreams);
-        }
-        finally
-        {
-            foreach (var (_, stream) in resxStreams)
+            var group = new FileGroup
             {
-                stream.Dispose();
+                DisplayName = Path.GetFileName(baseResxFilePath),
+                LanguageEntries = new List<(string languageName, Dictionary<string, string> entries)>()
+            };
+
+            foreach (var (languageName, filePath) in filesForGroup)
+            {
+                using var stream = File.OpenRead(filePath);
+                group.LanguageEntries.Add((languageName, ReadResxStream(stream)));
             }
+
+            fileGroups.Add(group);
         }
+
+        BuildAndAddDatabase(service, fileGroups, onWarning);
     }
 
     /// <summary>
@@ -102,49 +119,151 @@ public static class LocalizationServiceExtensions
     public static void AddResxDatabase(this ILocalizationService service,
         IEnumerable<(string languageName, Stream stream)> resxStreams)
     {
-        var streamList = resxStreams.ToList();
-        var headerList = streamList.Select(s => s.languageName).ToList();
+        AddResxDatabase(service,
+            new[] { (groupName: (string?)null, streams: resxStreams) },
+            onWarning: null);
+    }
 
-        // Parse each .resx stream into a dictionary of name -> value
-        var languageDictionaries = new List<Dictionary<string, string>>();
-        foreach (var (_, stream) in streamList)
+    /// <summary>
+    /// Loads localization data from multiple groups of .resx streams. Each group represents
+    /// one base-file worth of per-language streams (e.g., one group for Strings.resx + its
+    /// satellites, another for Buttons.resx + its satellites). Languages are unioned across
+    /// all groups; missing translations fall back to the string ID. String IDs are merged
+    /// across groups with last-write-wins on collision. Use this on mobile/web where
+    /// Directory.GetFiles is unavailable.
+    /// </summary>
+    /// <param name="service">The localization service to populate.</param>
+    /// <param name="fileGroups">Groups of (languageName, stream) pairs, one group per file.</param>
+    /// <param name="onWarning">Optional callback invoked with a descriptive message when
+    /// a string ID collision occurs across groups.</param>
+    public static void AddResxDatabase(this ILocalizationService service,
+        IEnumerable<IEnumerable<(string languageName, Stream stream)>> fileGroups,
+        Action<string>? onWarning = null)
+    {
+        AddResxDatabase(service,
+            fileGroups.Select(g => (groupName: (string?)null, streams: g)),
+            onWarning);
+    }
+
+    /// <summary>
+    /// Loads localization data from multiple named groups of .resx streams. The group name
+    /// is used in collision warning messages; pass null to fall back to "Group {index}".
+    /// Behaves identically to the unnamed multi-group overload otherwise.
+    /// </summary>
+    /// <param name="service">The localization service to populate.</param>
+    /// <param name="fileGroups">Groups of (groupName, streams) pairs. groupName may be null.</param>
+    /// <param name="onWarning">Optional callback invoked with a descriptive message when
+    /// a string ID collision occurs across groups.</param>
+    public static void AddResxDatabase(this ILocalizationService service,
+        IEnumerable<(string? groupName, IEnumerable<(string languageName, Stream stream)> streams)> fileGroups,
+        Action<string>? onWarning = null)
+    {
+        var parsedGroups = new List<FileGroup>();
+
+        var groupIndex = 0;
+        foreach (var (groupName, group) in fileGroups)
         {
-            languageDictionaries.Add(ReadResxStream(stream));
+            var parsed = new FileGroup
+            {
+                DisplayName = groupName ?? ("Group " + groupIndex),
+                LanguageEntries = new List<(string languageName, Dictionary<string, string> entries)>()
+            };
+
+            foreach (var (languageName, stream) in group)
+            {
+                parsed.LanguageEntries.Add((languageName, ReadResxStream(stream)));
+            }
+
+            parsedGroups.Add(parsed);
+            groupIndex++;
         }
 
-        // Collect all string IDs across all languages
-        var allStringIds = new HashSet<string>();
-        foreach (var dict in languageDictionaries)
+        BuildAndAddDatabase(service, parsedGroups, onWarning);
+    }
+
+    private class FileGroup
+    {
+        public string DisplayName { get; set; } = "";
+        public List<(string languageName, Dictionary<string, string> entries)> LanguageEntries { get; set; }
+            = new List<(string, Dictionary<string, string>)>();
+    }
+
+    private static void BuildAndAddDatabase(ILocalizationService service,
+        List<FileGroup> fileGroups,
+        Action<string>? onWarning)
+    {
+        // Union language names across groups, preserving first-seen order.
+        var headerList = new List<string>();
+        var seenLanguages = new HashSet<string>();
+        foreach (var group in fileGroups)
         {
-            foreach (var key in dict.Keys)
+            foreach (var (languageName, _) in group.LanguageEntries)
             {
-                allStringIds.Add(key);
+                if (seenLanguages.Add(languageName))
+                {
+                    headerList.Add(languageName);
+                }
             }
         }
 
-        // Build the entry dictionary in the same format as the CSV loader:
-        // translatedStrings[0] = stringId, translatedStrings[1..N] = translations
-        var totalColumns = streamList.Count + 1;
+        var totalColumns = headerList.Count + 1;
         var entryDictionary = new Dictionary<string, string[]>();
 
-        foreach (var stringId in allStringIds)
-        {
-            var translatedStrings = new string[totalColumns];
-            translatedStrings[0] = stringId;
+        // Track all prior file-groups that provided each stringId for collision reporting.
+        var stringIdToSourceGroups = new Dictionary<string, List<string>>();
 
-            for (int i = 0; i < streamList.Count; i++)
+        foreach (var group in fileGroups)
+        {
+            // Build per-language lookup for this group keyed by language name.
+            var languageMap = new Dictionary<string, Dictionary<string, string>>();
+            foreach (var (languageName, entries) in group.LanguageEntries)
             {
-                if (languageDictionaries[i].TryGetValue(stringId, out var value))
+                languageMap[languageName] = entries;
+            }
+
+            // Collect all string IDs present anywhere in this group.
+            var stringIdsInGroup = new HashSet<string>();
+            foreach (var (_, entries) in group.LanguageEntries)
+            {
+                foreach (var key in entries.Keys)
                 {
-                    translatedStrings[i + 1] = value;
+                    stringIdsInGroup.Add(key);
+                }
+            }
+
+            foreach (var stringId in stringIdsInGroup)
+            {
+                if (stringIdToSourceGroups.TryGetValue(stringId, out var previousSources))
+                {
+                    var priorList = "[" + string.Join(", ", previousSources.Select(s => $"'{s}'")) + "]";
+                    onWarning?.Invoke(
+                        $"Key '{stringId}' collision: overwriting value from {priorList} with value from '{group.DisplayName}' (last-write-wins).");
+                    previousSources.Add(group.DisplayName);
                 }
                 else
                 {
-                    translatedStrings[i + 1] = stringId;
+                    stringIdToSourceGroups[stringId] = new List<string> { group.DisplayName };
                 }
-            }
 
-            entryDictionary[stringId] = translatedStrings;
+                var translatedStrings = new string[totalColumns];
+                translatedStrings[0] = stringId;
+
+                for (var i = 0; i < headerList.Count; i++)
+                {
+                    var languageName = headerList[i];
+                    if (languageMap.TryGetValue(languageName, out var entries)
+                        && entries.TryGetValue(stringId, out var value))
+                    {
+                        translatedStrings[i + 1] = value;
+                    }
+                    else
+                    {
+                        translatedStrings[i + 1] = stringId;
+                    }
+                }
+
+                entryDictionary[stringId] = translatedStrings;
+            }
         }
 
         service.AddDatabase(entryDictionary, headerList);
@@ -152,6 +271,8 @@ public static class LocalizationServiceExtensions
 
     private static Dictionary<string, string> ReadResxStream(Stream stream)
     {
+        // Entries with a null name attribute or null value element are silently skipped
+        // (pre-existing behavior). Malformed entries do not raise exceptions.
         var result = new Dictionary<string, string>();
         var doc = XDocument.Load(stream);
 

--- a/MonoGameGum.Tests/Localization/LocalizationServiceExtensionsTests.cs
+++ b/MonoGameGum.Tests/Localization/LocalizationServiceExtensionsTests.cs
@@ -1,4 +1,4 @@
-﻿using Gum.Localization;
+using Gum.Localization;
 using Shouldly;
 using System;
 using System.Collections.Generic;
@@ -26,48 +26,6 @@ public class LocalizationServiceExtensionsTests : IDisposable
         }
     }
 
-    #region AddCsvDatabase
-
-    [Fact]
-    public void AddCsvDatabase_ShouldLoadStrings_FromStream()
-    {
-        var csv = "StringId,English,Spanish\nT_OK,OK,OK\nT_Cancel,Cancel,Cancelar\n";
-        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(csv));
-
-        _service.AddCsvDatabase(stream);
-
-        _service.HasDatabase.ShouldBeTrue();
-        _service.CurrentLanguage = 1;
-        _service.Translate("T_OK").ShouldBe("OK");
-        _service.Translate("T_Cancel").ShouldBe("Cancel");
-    }
-
-    [Fact]
-    public void AddCsvDatabase_ShouldTranslateToSecondLanguage()
-    {
-        var csv = "StringId,English,Spanish\nT_OK,OK,OK\nT_Cancel,Cancel,Cancelar\n";
-        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(csv));
-
-        _service.AddCsvDatabase(stream);
-        _service.CurrentLanguage = 2;
-
-        _service.Translate("T_OK").ShouldBe("OK");
-        _service.Translate("T_Cancel").ShouldBe("Cancelar");
-    }
-
-    [Fact]
-    public void AddCsvDatabase_ShouldSetLanguageHeaders()
-    {
-        var csv = "StringId,English,Spanish\nT_OK,OK,OK\n";
-        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(csv));
-
-        _service.AddCsvDatabase(stream);
-
-        _service.Languages.Count.ShouldBe(2);
-        _service.Languages[0].ShouldBe("English");
-        _service.Languages[1].ShouldBe("Spanish");
-    }
-
     [Fact]
     public void AddCsvDatabase_ShouldHandleMultipleLanguages()
     {
@@ -86,158 +44,45 @@ public class LocalizationServiceExtensionsTests : IDisposable
         _service.Translate("T_Hello").ShouldBe("Bonjour");
     }
 
-    #endregion
-
-    #region AddResxDatabase (Streams)
-
     [Fact]
-    public void AddResxDatabase_Streams_ShouldLoadStrings()
+    public void AddCsvDatabase_ShouldLoadStrings_FromStream()
     {
-        var englishResx = CreateResxContent(new Dictionary<string, string>
-        {
-            { "T_OK", "OK" },
-            { "T_Cancel", "Cancel" }
-        });
+        var csv = "StringId,English,Spanish\nT_OK,OK,OK\nT_Cancel,Cancel,Cancelar\n";
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(csv));
 
-        var spanishResx = CreateResxContent(new Dictionary<string, string>
-        {
-            { "T_OK", "OK" },
-            { "T_Cancel", "Cancelar" }
-        });
+        _service.AddCsvDatabase(stream);
 
-        var streams = new List<(string languageName, Stream stream)>
-        {
-            ("English", new MemoryStream(Encoding.UTF8.GetBytes(englishResx))),
-            ("Spanish", new MemoryStream(Encoding.UTF8.GetBytes(spanishResx)))
-        };
-
-        try
-        {
-            _service.AddResxDatabase(streams);
-
-            _service.HasDatabase.ShouldBeTrue();
-            _service.CurrentLanguage = 1;
-            _service.Translate("T_OK").ShouldBe("OK");
-            _service.Translate("T_Cancel").ShouldBe("Cancel");
-
-            _service.CurrentLanguage = 2;
-            _service.Translate("T_Cancel").ShouldBe("Cancelar");
-        }
-        finally
-        {
-            foreach (var (_, stream) in streams)
-            {
-                stream.Dispose();
-            }
-        }
+        _service.HasDatabase.ShouldBeTrue();
+        _service.CurrentLanguage = 1;
+        _service.Translate("T_OK").ShouldBe("OK");
+        _service.Translate("T_Cancel").ShouldBe("Cancel");
     }
 
     [Fact]
-    public void AddResxDatabase_Streams_ShouldSetLanguageHeaders()
+    public void AddCsvDatabase_ShouldSetLanguageHeaders()
     {
-        var englishResx = CreateResxContent(new Dictionary<string, string> { { "T_OK", "OK" } });
-        var spanishResx = CreateResxContent(new Dictionary<string, string> { { "T_OK", "OK" } });
+        var csv = "StringId,English,Spanish\nT_OK,OK,OK\n";
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(csv));
 
-        var streams = new List<(string languageName, Stream stream)>
-        {
-            ("English", new MemoryStream(Encoding.UTF8.GetBytes(englishResx))),
-            ("Spanish", new MemoryStream(Encoding.UTF8.GetBytes(spanishResx)))
-        };
+        _service.AddCsvDatabase(stream);
 
-        try
-        {
-            _service.AddResxDatabase(streams);
-
-            _service.Languages.Count.ShouldBe(2);
-            _service.Languages[0].ShouldBe("English");
-            _service.Languages[1].ShouldBe("Spanish");
-        }
-        finally
-        {
-            foreach (var (_, stream) in streams)
-            {
-                stream.Dispose();
-            }
-        }
+        _service.Languages.Count.ShouldBe(2);
+        _service.Languages[0].ShouldBe("English");
+        _service.Languages[1].ShouldBe("Spanish");
     }
 
     [Fact]
-    public void AddResxDatabase_Streams_ShouldFallBackToStringId_WhenKeyMissingInLanguage()
+    public void AddCsvDatabase_ShouldTranslateToSecondLanguage()
     {
-        var englishResx = CreateResxContent(new Dictionary<string, string>
-        {
-            { "T_OK", "OK" },
-            { "T_Cancel", "Cancel" }
-        });
+        var csv = "StringId,English,Spanish\nT_OK,OK,OK\nT_Cancel,Cancel,Cancelar\n";
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(csv));
 
-        // Spanish is missing T_Cancel
-        var spanishResx = CreateResxContent(new Dictionary<string, string>
-        {
-            { "T_OK", "OK" }
-        });
+        _service.AddCsvDatabase(stream);
+        _service.CurrentLanguage = 2;
 
-        var streams = new List<(string languageName, Stream stream)>
-        {
-            ("English", new MemoryStream(Encoding.UTF8.GetBytes(englishResx))),
-            ("Spanish", new MemoryStream(Encoding.UTF8.GetBytes(spanishResx)))
-        };
-
-        try
-        {
-            _service.AddResxDatabase(streams);
-
-            _service.CurrentLanguage = 2;
-            _service.Translate("T_Cancel").ShouldBe("T_Cancel",
-                "Missing keys should fall back to the string ID");
-        }
-        finally
-        {
-            foreach (var (_, stream) in streams)
-            {
-                stream.Dispose();
-            }
-        }
+        _service.Translate("T_OK").ShouldBe("OK");
+        _service.Translate("T_Cancel").ShouldBe("Cancelar");
     }
-
-    [Fact]
-    public void AddResxDatabase_Streams_ShouldHandleThreeLanguages()
-    {
-        var englishResx = CreateResxContent(new Dictionary<string, string> { { "T_Hello", "Hello" } });
-        var spanishResx = CreateResxContent(new Dictionary<string, string> { { "T_Hello", "Hola" } });
-        var frenchResx = CreateResxContent(new Dictionary<string, string> { { "T_Hello", "Bonjour" } });
-
-        var streams = new List<(string languageName, Stream stream)>
-        {
-            ("English", new MemoryStream(Encoding.UTF8.GetBytes(englishResx))),
-            ("Spanish", new MemoryStream(Encoding.UTF8.GetBytes(spanishResx))),
-            ("French", new MemoryStream(Encoding.UTF8.GetBytes(frenchResx)))
-        };
-
-        try
-        {
-            _service.AddResxDatabase(streams);
-
-            _service.CurrentLanguage = 1;
-            _service.Translate("T_Hello").ShouldBe("Hello");
-
-            _service.CurrentLanguage = 2;
-            _service.Translate("T_Hello").ShouldBe("Hola");
-
-            _service.CurrentLanguage = 3;
-            _service.Translate("T_Hello").ShouldBe("Bonjour");
-        }
-        finally
-        {
-            foreach (var (_, stream) in streams)
-            {
-                stream.Dispose();
-            }
-        }
-    }
-
-    #endregion
-
-    #region AddResxDatabase (File Path)
 
     [Fact]
     public void AddResxDatabase_FilePath_ShouldDiscoverSatelliteFiles()
@@ -336,7 +181,570 @@ public class LocalizationServiceExtensionsTests : IDisposable
         _service.Translate("T_OK").ShouldBe("OK");
     }
 
-    #endregion
+    [Fact]
+    public void AddResxDatabase_MultiPath_ShouldIncludeAllPriorSourcesInWarning_WhenThreeFilesCollide()
+    {
+        _tempDirectory = CreateTempDirectory();
+
+        WriteResxFile(Path.Combine(_tempDirectory, "A.resx"), new Dictionary<string, string>
+        {
+            { "T_Shared", "FromA" }
+        });
+        WriteResxFile(Path.Combine(_tempDirectory, "B.resx"), new Dictionary<string, string>
+        {
+            { "T_Shared", "FromB" }
+        });
+        WriteResxFile(Path.Combine(_tempDirectory, "C.resx"), new Dictionary<string, string>
+        {
+            { "T_Shared", "FromC" }
+        });
+
+        List<string> basePaths = new List<string>
+        {
+            Path.Combine(_tempDirectory, "A.resx"),
+            Path.Combine(_tempDirectory, "B.resx"),
+            Path.Combine(_tempDirectory, "C.resx")
+        };
+
+        List<string> warnings = new List<string>();
+        _service.AddResxDatabase(basePaths, onWarning: w => warnings.Add(w));
+
+        // Two collisions: B over A, then C over {A, B}
+        warnings.Count.ShouldBe(2);
+        warnings[1].ShouldContain("A.resx");
+        warnings[1].ShouldContain("B.resx");
+        warnings[1].ShouldContain("C.resx");
+
+        _service.CurrentLanguage = 1;
+        _service.Translate("T_Shared").ShouldBe("FromC");
+    }
+
+    [Fact]
+    public void AddResxDatabase_MultiPath_ShouldInvokeOnWarning_OnKeyCollision()
+    {
+        _tempDirectory = CreateTempDirectory();
+
+        WriteResxFile(Path.Combine(_tempDirectory, "Strings.resx"), new Dictionary<string, string>
+        {
+            { "T_Shared", "FromStrings" }
+        });
+
+        WriteResxFile(Path.Combine(_tempDirectory, "Buttons.resx"), new Dictionary<string, string>
+        {
+            { "T_Shared", "FromButtons" }
+        });
+
+        List<string> basePaths = new List<string>
+        {
+            Path.Combine(_tempDirectory, "Strings.resx"),
+            Path.Combine(_tempDirectory, "Buttons.resx")
+        };
+
+        List<string> warnings = new List<string>();
+        _service.AddResxDatabase(basePaths, onWarning: w => warnings.Add(w));
+
+        warnings.Count.ShouldBe(1);
+        warnings[0].ShouldContain("T_Shared");
+        warnings[0].ShouldContain("Strings.resx");
+        warnings[0].ShouldContain("Buttons.resx");
+
+        // Last-write-wins: Buttons came after Strings
+        _service.CurrentLanguage = 1;
+        _service.Translate("T_Shared").ShouldBe("FromButtons");
+    }
+
+    [Fact]
+    public void AddResxDatabase_MultiPath_ShouldMergeKeysAcrossFiles()
+    {
+        _tempDirectory = CreateTempDirectory();
+
+        WriteResxFile(Path.Combine(_tempDirectory, "Strings.resx"), new Dictionary<string, string>
+        {
+            { "T_OK", "OK" }
+        });
+        WriteResxFile(Path.Combine(_tempDirectory, "Strings.es.resx"), new Dictionary<string, string>
+        {
+            { "T_OK", "Aceptar" }
+        });
+
+        WriteResxFile(Path.Combine(_tempDirectory, "Buttons.resx"), new Dictionary<string, string>
+        {
+            { "B_Save", "Save" }
+        });
+        WriteResxFile(Path.Combine(_tempDirectory, "Buttons.es.resx"), new Dictionary<string, string>
+        {
+            { "B_Save", "Guardar" }
+        });
+
+        List<string> basePaths = new List<string>
+        {
+            Path.Combine(_tempDirectory, "Strings.resx"),
+            Path.Combine(_tempDirectory, "Buttons.resx")
+        };
+
+        _service.AddResxDatabase(basePaths);
+
+        _service.HasDatabase.ShouldBeTrue();
+        _service.Languages.Count.ShouldBe(2);
+        _service.Languages[0].ShouldBe("Default");
+        _service.Languages[1].ShouldBe("es");
+
+        _service.CurrentLanguage = 1;
+        _service.Translate("T_OK").ShouldBe("OK");
+        _service.Translate("B_Save").ShouldBe("Save");
+
+        _service.CurrentLanguage = 2;
+        _service.Translate("T_OK").ShouldBe("Aceptar");
+        _service.Translate("B_Save").ShouldBe("Guardar");
+    }
+
+    [Fact]
+    public void AddResxDatabase_MultiPath_ShouldNotInvokeWarning_OnDuplicateKeyWithinSingleFileGroup()
+    {
+        _tempDirectory = CreateTempDirectory();
+
+        // Same key in base and satellite -- NOT a cross-group collision, so onWarning
+        // should not fire. Last-write-wins silently on the per-language map.
+        WriteResxFile(Path.Combine(_tempDirectory, "Strings.resx"), new Dictionary<string, string>
+        {
+            { "T_OK", "OK_Base" }
+        });
+        WriteResxFile(Path.Combine(_tempDirectory, "Strings.es.resx"), new Dictionary<string, string>
+        {
+            { "T_OK", "OK_Spanish" }
+        });
+
+        List<string> basePaths = new List<string>
+        {
+            Path.Combine(_tempDirectory, "Strings.resx")
+        };
+
+        List<string> warnings = new List<string>();
+        _service.AddResxDatabase(basePaths, onWarning: w => warnings.Add(w));
+
+        warnings.Count.ShouldBe(0);
+
+        _service.CurrentLanguage = 1;
+        _service.Translate("T_OK").ShouldBe("OK_Base");
+        _service.CurrentLanguage = 2;
+        _service.Translate("T_OK").ShouldBe("OK_Spanish");
+    }
+
+    [Fact]
+    public void AddResxDatabase_MultiPath_ShouldNotThrow_WhenOnWarningIsNullAndCollisionOccurs()
+    {
+        _tempDirectory = CreateTempDirectory();
+
+        WriteResxFile(Path.Combine(_tempDirectory, "Strings.resx"), new Dictionary<string, string>
+        {
+            { "T_Shared", "FromStrings" }
+        });
+        WriteResxFile(Path.Combine(_tempDirectory, "Buttons.resx"), new Dictionary<string, string>
+        {
+            { "T_Shared", "FromButtons" }
+        });
+
+        List<string> basePaths = new List<string>
+        {
+            Path.Combine(_tempDirectory, "Strings.resx"),
+            Path.Combine(_tempDirectory, "Buttons.resx")
+        };
+
+        Should.NotThrow(() => _service.AddResxDatabase(basePaths));
+
+        _service.CurrentLanguage = 1;
+        _service.Translate("T_Shared").ShouldBe("FromButtons");
+    }
+
+    [Fact]
+    public void AddResxDatabase_MultiPath_ShouldNotThrow_WhenPathListIsEmpty()
+    {
+        List<string> basePaths = new List<string>();
+
+        Should.NotThrow(() => _service.AddResxDatabase(basePaths));
+    }
+
+    [Fact]
+    public void AddResxDatabase_MultiPath_ShouldRetrieveSatelliteOnlyKey_WithBaseFallback()
+    {
+        _tempDirectory = CreateTempDirectory();
+
+        // Base has no T_SatelliteOnly; satellite does.
+        WriteResxFile(Path.Combine(_tempDirectory, "Strings.resx"), new Dictionary<string, string>
+        {
+            { "T_OK", "OK" }
+        });
+        WriteResxFile(Path.Combine(_tempDirectory, "Strings.es.resx"), new Dictionary<string, string>
+        {
+            { "T_SatelliteOnly", "SoloEs" }
+        });
+
+        List<string> basePaths = new List<string>
+        {
+            Path.Combine(_tempDirectory, "Strings.resx")
+        };
+
+        _service.AddResxDatabase(basePaths);
+
+        // Satellite language: key is present
+        _service.CurrentLanguage = 2;
+        _service.Translate("T_SatelliteOnly").ShouldBe("SoloEs");
+
+        // Default language: missing -> fall back to string ID
+        _service.CurrentLanguage = 1;
+        _service.Translate("T_SatelliteOnly").ShouldBe("T_SatelliteOnly");
+    }
+
+    [Fact]
+    public void AddResxDatabase_MultiPath_ShouldThrow_WhenBaseFileIsMissing()
+    {
+        _tempDirectory = CreateTempDirectory();
+        var missingPath = Path.Combine(_tempDirectory, "DoesNotExist.resx");
+
+        List<string> basePaths = new List<string> { missingPath };
+
+        var ex = Should.Throw<FileNotFoundException>(() => _service.AddResxDatabase(basePaths));
+        ex.Message.ShouldContain("DoesNotExist.resx");
+    }
+
+    [Fact]
+    public void AddResxDatabase_MultiPath_ShouldUnionLanguages_WhenSatellitesDiffer()
+    {
+        _tempDirectory = CreateTempDirectory();
+
+        // Strings has es satellite only
+        WriteResxFile(Path.Combine(_tempDirectory, "Strings.resx"), new Dictionary<string, string>
+        {
+            { "T_OK", "OK" }
+        });
+        WriteResxFile(Path.Combine(_tempDirectory, "Strings.es.resx"), new Dictionary<string, string>
+        {
+            { "T_OK", "Aceptar" }
+        });
+
+        // Buttons has fr satellite only
+        WriteResxFile(Path.Combine(_tempDirectory, "Buttons.resx"), new Dictionary<string, string>
+        {
+            { "B_Save", "Save" }
+        });
+        WriteResxFile(Path.Combine(_tempDirectory, "Buttons.fr.resx"), new Dictionary<string, string>
+        {
+            { "B_Save", "Enregistrer" }
+        });
+
+        List<string> basePaths = new List<string>
+        {
+            Path.Combine(_tempDirectory, "Strings.resx"),
+            Path.Combine(_tempDirectory, "Buttons.resx")
+        };
+
+        _service.AddResxDatabase(basePaths);
+
+        _service.Languages.Count.ShouldBe(3);
+        _service.Languages[0].ShouldBe("Default");
+        _service.Languages[1].ShouldBe("es");
+        _service.Languages[2].ShouldBe("fr");
+
+        // In "es" column, B_Save has no Spanish satellite -> fall back to string ID
+        _service.CurrentLanguage = 2;
+        _service.Translate("T_OK").ShouldBe("Aceptar");
+        _service.Translate("B_Save").ShouldBe("B_Save");
+
+        // In "fr" column, T_OK has no French satellite -> fall back to string ID
+        _service.CurrentLanguage = 3;
+        _service.Translate("T_OK").ShouldBe("T_OK");
+        _service.Translate("B_Save").ShouldBe("Enregistrer");
+    }
+
+    [Fact]
+    public void AddResxDatabase_MultiStreamGroups_ShouldInvokeOnWarning_OnKeyCollision()
+    {
+        string stringsEn = CreateResxContent(new Dictionary<string, string> { { "T_Shared", "FromStrings" } });
+        string buttonsEn = CreateResxContent(new Dictionary<string, string> { { "T_Shared", "FromButtons" } });
+
+        List<(string languageName, Stream stream)> stringsGroup = new List<(string, Stream)>
+        {
+            ("Default", new MemoryStream(Encoding.UTF8.GetBytes(stringsEn)))
+        };
+        List<(string languageName, Stream stream)> buttonsGroup = new List<(string, Stream)>
+        {
+            ("Default", new MemoryStream(Encoding.UTF8.GetBytes(buttonsEn)))
+        };
+
+        List<IEnumerable<(string languageName, Stream stream)>> groups = new List<IEnumerable<(string, Stream)>>
+        {
+            stringsGroup,
+            buttonsGroup
+        };
+
+        List<string> warnings = new List<string>();
+
+        try
+        {
+            _service.AddResxDatabase(groups, onWarning: w => warnings.Add(w));
+
+            warnings.Count.ShouldBe(1);
+            warnings[0].ShouldContain("T_Shared");
+
+            _service.CurrentLanguage = 1;
+            _service.Translate("T_Shared").ShouldBe("FromButtons");
+        }
+        finally
+        {
+            foreach ((string _, Stream stream) in stringsGroup)
+            {
+                stream.Dispose();
+            }
+            foreach ((string _, Stream stream) in buttonsGroup)
+            {
+                stream.Dispose();
+            }
+        }
+    }
+
+    [Fact]
+    public void AddResxDatabase_MultiStreamGroups_ShouldMergeKeysAcrossGroups()
+    {
+        string stringsEn = CreateResxContent(new Dictionary<string, string> { { "T_OK", "OK" } });
+        string stringsEs = CreateResxContent(new Dictionary<string, string> { { "T_OK", "Aceptar" } });
+        string buttonsEn = CreateResxContent(new Dictionary<string, string> { { "B_Save", "Save" } });
+        string buttonsEs = CreateResxContent(new Dictionary<string, string> { { "B_Save", "Guardar" } });
+
+        List<(string languageName, Stream stream)> stringsGroup = new List<(string, Stream)>
+        {
+            ("Default", new MemoryStream(Encoding.UTF8.GetBytes(stringsEn))),
+            ("es", new MemoryStream(Encoding.UTF8.GetBytes(stringsEs)))
+        };
+        List<(string languageName, Stream stream)> buttonsGroup = new List<(string, Stream)>
+        {
+            ("Default", new MemoryStream(Encoding.UTF8.GetBytes(buttonsEn))),
+            ("es", new MemoryStream(Encoding.UTF8.GetBytes(buttonsEs)))
+        };
+
+        List<IEnumerable<(string languageName, Stream stream)>> groups = new List<IEnumerable<(string, Stream)>>
+        {
+            stringsGroup,
+            buttonsGroup
+        };
+
+        try
+        {
+            _service.AddResxDatabase(groups);
+
+            _service.Languages.Count.ShouldBe(2);
+            _service.Languages[0].ShouldBe("Default");
+            _service.Languages[1].ShouldBe("es");
+
+            _service.CurrentLanguage = 1;
+            _service.Translate("T_OK").ShouldBe("OK");
+            _service.Translate("B_Save").ShouldBe("Save");
+
+            _service.CurrentLanguage = 2;
+            _service.Translate("T_OK").ShouldBe("Aceptar");
+            _service.Translate("B_Save").ShouldBe("Guardar");
+        }
+        finally
+        {
+            foreach ((string _, Stream stream) in stringsGroup)
+            {
+                stream.Dispose();
+            }
+            foreach ((string _, Stream stream) in buttonsGroup)
+            {
+                stream.Dispose();
+            }
+        }
+    }
+
+    [Fact]
+    public void AddResxDatabase_NamedStreamGroups_ShouldUseGroupName_InCollisionWarning()
+    {
+        string aEn = CreateResxContent(new Dictionary<string, string> { { "T_Shared", "FromA" } });
+        string bEn = CreateResxContent(new Dictionary<string, string> { { "T_Shared", "FromB" } });
+
+        List<(string languageName, Stream stream)> groupA = new List<(string, Stream)>
+        {
+            ("Default", new MemoryStream(Encoding.UTF8.GetBytes(aEn)))
+        };
+        List<(string languageName, Stream stream)> groupB = new List<(string, Stream)>
+        {
+            ("Default", new MemoryStream(Encoding.UTF8.GetBytes(bEn)))
+        };
+
+        List<(string? groupName, IEnumerable<(string languageName, Stream stream)> streams)> named
+            = new List<(string?, IEnumerable<(string, Stream)>)>
+        {
+            ("CustomGroupA", groupA),
+            ("CustomGroupB", groupB)
+        };
+
+        List<string> warnings = new List<string>();
+
+        try
+        {
+            _service.AddResxDatabase(named, onWarning: w => warnings.Add(w));
+
+            warnings.Count.ShouldBe(1);
+            warnings[0].ShouldContain("CustomGroupA");
+            warnings[0].ShouldContain("CustomGroupB");
+        }
+        finally
+        {
+            foreach ((string _, Stream stream) in groupA)
+            {
+                stream.Dispose();
+            }
+            foreach ((string _, Stream stream) in groupB)
+            {
+                stream.Dispose();
+            }
+        }
+    }
+
+    [Fact]
+    public void AddResxDatabase_Streams_ShouldFallBackToStringId_WhenKeyMissingInLanguage()
+    {
+        var englishResx = CreateResxContent(new Dictionary<string, string>
+        {
+            { "T_OK", "OK" },
+            { "T_Cancel", "Cancel" }
+        });
+
+        // Spanish is missing T_Cancel
+        var spanishResx = CreateResxContent(new Dictionary<string, string>
+        {
+            { "T_OK", "OK" }
+        });
+
+        var streams = new List<(string languageName, Stream stream)>
+        {
+            ("English", new MemoryStream(Encoding.UTF8.GetBytes(englishResx))),
+            ("Spanish", new MemoryStream(Encoding.UTF8.GetBytes(spanishResx)))
+        };
+
+        try
+        {
+            _service.AddResxDatabase(streams);
+
+            _service.CurrentLanguage = 2;
+            _service.Translate("T_Cancel").ShouldBe("T_Cancel",
+                "Missing keys should fall back to the string ID");
+        }
+        finally
+        {
+            foreach (var (_, stream) in streams)
+            {
+                stream.Dispose();
+            }
+        }
+    }
+
+    [Fact]
+    public void AddResxDatabase_Streams_ShouldHandleThreeLanguages()
+    {
+        var englishResx = CreateResxContent(new Dictionary<string, string> { { "T_Hello", "Hello" } });
+        var spanishResx = CreateResxContent(new Dictionary<string, string> { { "T_Hello", "Hola" } });
+        var frenchResx = CreateResxContent(new Dictionary<string, string> { { "T_Hello", "Bonjour" } });
+
+        var streams = new List<(string languageName, Stream stream)>
+        {
+            ("English", new MemoryStream(Encoding.UTF8.GetBytes(englishResx))),
+            ("Spanish", new MemoryStream(Encoding.UTF8.GetBytes(spanishResx))),
+            ("French", new MemoryStream(Encoding.UTF8.GetBytes(frenchResx)))
+        };
+
+        try
+        {
+            _service.AddResxDatabase(streams);
+
+            _service.CurrentLanguage = 1;
+            _service.Translate("T_Hello").ShouldBe("Hello");
+
+            _service.CurrentLanguage = 2;
+            _service.Translate("T_Hello").ShouldBe("Hola");
+
+            _service.CurrentLanguage = 3;
+            _service.Translate("T_Hello").ShouldBe("Bonjour");
+        }
+        finally
+        {
+            foreach (var (_, stream) in streams)
+            {
+                stream.Dispose();
+            }
+        }
+    }
+
+    [Fact]
+    public void AddResxDatabase_Streams_ShouldLoadStrings()
+    {
+        var englishResx = CreateResxContent(new Dictionary<string, string>
+        {
+            { "T_OK", "OK" },
+            { "T_Cancel", "Cancel" }
+        });
+
+        var spanishResx = CreateResxContent(new Dictionary<string, string>
+        {
+            { "T_OK", "OK" },
+            { "T_Cancel", "Cancelar" }
+        });
+
+        var streams = new List<(string languageName, Stream stream)>
+        {
+            ("English", new MemoryStream(Encoding.UTF8.GetBytes(englishResx))),
+            ("Spanish", new MemoryStream(Encoding.UTF8.GetBytes(spanishResx)))
+        };
+
+        try
+        {
+            _service.AddResxDatabase(streams);
+
+            _service.HasDatabase.ShouldBeTrue();
+            _service.CurrentLanguage = 1;
+            _service.Translate("T_OK").ShouldBe("OK");
+            _service.Translate("T_Cancel").ShouldBe("Cancel");
+
+            _service.CurrentLanguage = 2;
+            _service.Translate("T_Cancel").ShouldBe("Cancelar");
+        }
+        finally
+        {
+            foreach (var (_, stream) in streams)
+            {
+                stream.Dispose();
+            }
+        }
+    }
+
+    [Fact]
+    public void AddResxDatabase_Streams_ShouldSetLanguageHeaders()
+    {
+        var englishResx = CreateResxContent(new Dictionary<string, string> { { "T_OK", "OK" } });
+        var spanishResx = CreateResxContent(new Dictionary<string, string> { { "T_OK", "OK" } });
+
+        var streams = new List<(string languageName, Stream stream)>
+        {
+            ("English", new MemoryStream(Encoding.UTF8.GetBytes(englishResx))),
+            ("Spanish", new MemoryStream(Encoding.UTF8.GetBytes(spanishResx)))
+        };
+
+        try
+        {
+            _service.AddResxDatabase(streams);
+
+            _service.Languages.Count.ShouldBe(2);
+            _service.Languages[0].ShouldBe("English");
+            _service.Languages[1].ShouldBe("Spanish");
+        }
+        finally
+        {
+            foreach (var (_, stream) in streams)
+            {
+                stream.Dispose();
+            }
+        }
+    }
 
     #region Helpers
 

--- a/MonoGameGum/GumService.cs
+++ b/MonoGameGum/GumService.cs
@@ -427,10 +427,24 @@ public class GumService
                 var fileName = FileManager.GetDirectory(gumProject.FullFileName) +
                     gumProject.LocalizationFile;
 
-                using var stream = FileManager.GetStreamForFile(fileName);
+                var extension = FileManager.GetExtension(fileName);
+                var localizationService = CustomSetPropertyOnRenderable.LocalizationService;
 
-                CustomSetPropertyOnRenderable.LocalizationService?.AddCsvDatabase(stream);
-
+                if (string.Equals(extension, "resx", StringComparison.OrdinalIgnoreCase))
+                {
+                    // RESX satellite discovery requires enumerating the directory
+                    // (e.g. Strings.es.resx alongside Strings.resx). On desktop platforms
+                    // the path-based overload handles this via Directory.GetFiles.
+                    // Bundled-content platforms (Android/iOS/TitleContainer) cannot
+                    // enumerate sibling files from a stream, so this auto-load path
+                    // assumes real filesystem access - matching the existing CSV behavior.
+                    localizationService?.AddResxDatabase(fileName);
+                }
+                else
+                {
+                    using var stream = FileManager.GetStreamForFile(fileName);
+                    localizationService?.AddCsvDatabase(stream);
+                }
             }
 
             ObjectFinder.Self.GumProjectSave = gumProject;

--- a/Tests/MonoGameGum.IntegrationTests/MonoGameGum/Localization/GumServiceLocalizationAutoLoadTests.cs
+++ b/Tests/MonoGameGum.IntegrationTests/MonoGameGum/Localization/GumServiceLocalizationAutoLoadTests.cs
@@ -1,0 +1,199 @@
+using Gum.Localization;
+using Gum.Wireframe;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using RenderingLibrary.Content;
+using Shouldly;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Xunit;
+
+namespace MonoGameGum.IntegrationTests.MonoGameGum.Localization;
+
+/// <summary>
+/// Integration tests verifying that GumService.Initialize auto-loads the
+/// project's LocalizationFile for both CSV and RESX formats.
+/// </summary>
+public class GumServiceLocalizationAutoLoadTests : BaseTestClass, IDisposable
+{
+    private string? _tempDirectory;
+
+    public override void Dispose()
+    {
+        // Reset the shared static localization service so each test starts clean.
+        CustomSetPropertyOnRenderable.LocalizationService = null;
+
+        base.Dispose();
+
+        if (_tempDirectory != null && Directory.Exists(_tempDirectory))
+        {
+            try
+            {
+                Directory.Delete(_tempDirectory, recursive: true);
+            }
+            catch
+            {
+                // Best effort - file handles may still be held during test teardown.
+            }
+        }
+    }
+
+    [Fact]
+    public void Initialize_ShouldAutoLoadCsvLocalizationFile()
+    {
+        _tempDirectory = CreateTempDirectory();
+
+        string csv = "String ID,English,Spanish\nT_OK,OK,Aceptar\n";
+        File.WriteAllText(Path.Combine(_tempDirectory, "Strings.csv"), csv);
+
+        string gumxPath = Path.Combine(_tempDirectory, "Project.gumx");
+        File.WriteAllText(gumxPath, BuildMinimalGumx(localizationFile: "Strings.csv"));
+
+        using GameForLocalizationTest game = new GameForLocalizationTest(gumxPath);
+        game.RunOneFrame();
+
+        ILocalizationService? service = CustomSetPropertyOnRenderable.LocalizationService;
+        service.ShouldNotBeNull();
+        service.Languages.Count.ShouldBe(2);
+
+        service.CurrentLanguage = 1;
+        service.Translate("T_OK").ShouldBe("OK");
+        service.CurrentLanguage = 2;
+        service.Translate("T_OK").ShouldBe("Aceptar");
+    }
+
+    [Fact]
+    public void Initialize_ShouldAutoLoadResxLocalizationFile()
+    {
+        _tempDirectory = CreateTempDirectory();
+
+        WriteResxFile(Path.Combine(_tempDirectory, "Strings.resx"), new Dictionary<string, string>
+        {
+            { "T_OK", "OK" }
+        });
+
+        string gumxPath = Path.Combine(_tempDirectory, "Project.gumx");
+        File.WriteAllText(gumxPath, BuildMinimalGumx(localizationFile: "Strings.resx"));
+
+        using GameForLocalizationTest game = new GameForLocalizationTest(gumxPath);
+        game.RunOneFrame();
+
+        ILocalizationService? service = CustomSetPropertyOnRenderable.LocalizationService;
+        service.ShouldNotBeNull();
+        service.Languages.Count.ShouldBeGreaterThanOrEqualTo(1);
+        service.CurrentLanguage = 1;
+        service.Translate("T_OK").ShouldBe("OK");
+    }
+
+    [Fact]
+    public void Initialize_ShouldAutoLoadResxWithSatellites()
+    {
+        _tempDirectory = CreateTempDirectory();
+
+        WriteResxFile(Path.Combine(_tempDirectory, "Strings.resx"), new Dictionary<string, string>
+        {
+            { "T_OK", "OK" }
+        });
+        WriteResxFile(Path.Combine(_tempDirectory, "Strings.es.resx"), new Dictionary<string, string>
+        {
+            { "T_OK", "Aceptar" }
+        });
+
+        string gumxPath = Path.Combine(_tempDirectory, "Project.gumx");
+        File.WriteAllText(gumxPath, BuildMinimalGumx(localizationFile: "Strings.resx"));
+
+        using GameForLocalizationTest game = new GameForLocalizationTest(gumxPath);
+        game.RunOneFrame();
+
+        ILocalizationService? service = CustomSetPropertyOnRenderable.LocalizationService;
+        service.ShouldNotBeNull();
+        service.Languages.Count.ShouldBe(2);
+
+        service.CurrentLanguage = 1;
+        service.Translate("T_OK").ShouldBe("OK");
+        service.CurrentLanguage = 2;
+        service.Translate("T_OK").ShouldBe("Aceptar");
+    }
+
+    #region Helpers
+
+    private static string BuildMinimalGumx(string localizationFile)
+    {
+        StringBuilder sb = new StringBuilder();
+        sb.AppendLine("<?xml version=\"1.0\" encoding=\"utf-8\"?>");
+        sb.AppendLine("<GumProjectSave xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">");
+        sb.AppendLine("  <DefaultCanvasWidth>800</DefaultCanvasWidth>");
+        sb.AppendLine("  <DefaultCanvasHeight>600</DefaultCanvasHeight>");
+        sb.AppendLine($"  <LocalizationFile>{localizationFile}</LocalizationFile>");
+        sb.AppendLine("</GumProjectSave>");
+        return sb.ToString();
+    }
+
+    private static string CreateTempDirectory()
+    {
+        string tempDir = Path.Combine(Path.GetTempPath(), "GumAutoLoadTests_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        return tempDir;
+    }
+
+    private static void WriteResxFile(string filePath, Dictionary<string, string> entries)
+    {
+        StringBuilder sb = new StringBuilder();
+        sb.AppendLine("<?xml version=\"1.0\" encoding=\"utf-8\"?>");
+        sb.AppendLine("<root>");
+        sb.AppendLine("  <resheader name=\"resmimetype\"><value>text/microsoft-resx</value></resheader>");
+        sb.AppendLine("  <resheader name=\"version\"><value>2.0</value></resheader>");
+        foreach (KeyValuePair<string, string> entry in entries)
+        {
+            sb.AppendLine($"  <data name=\"{entry.Key}\" xml:space=\"preserve\">");
+            sb.AppendLine($"    <value>{entry.Value}</value>");
+            sb.AppendLine("  </data>");
+        }
+        sb.AppendLine("</root>");
+        File.WriteAllText(filePath, sb.ToString());
+    }
+
+    #endregion
+
+    #region Test Game
+
+    private class GameForLocalizationTest : Game
+    {
+        private readonly GraphicsDeviceManager _graphics;
+        private readonly string _gumProjectFile;
+        public GumService GumService { get; private set; }
+
+        public GameForLocalizationTest(string gumProjectFile)
+        {
+            LoaderManager.Self?.DisposeAndClear();
+            _graphics = new GraphicsDeviceManager(this);
+            Content.RootDirectory = "Content";
+            IsMouseVisible = true;
+            _gumProjectFile = gumProjectFile;
+            GumService = new GumService();
+        }
+
+        protected override void Initialize()
+        {
+            base.Initialize();
+            GumService.Initialize(this, _gumProjectFile);
+        }
+
+        protected override void Update(GameTime gameTime) { }
+
+        protected override void Draw(GameTime gameTime)
+        {
+            GraphicsDevice.Clear(Color.CornflowerBlue);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            LoaderManager.Self?.DisposeAndClear();
+            base.Dispose(disposing);
+        }
+    }
+
+    #endregion
+}

--- a/docs/code/localization.md
+++ b/docs/code/localization.md
@@ -72,6 +72,10 @@ Code-only projects can use the `LocalizationManager` to enable localization. The
 4. Set the language index
 5. Assign Text to a string ID
 
+{% hint style="info" %}
+How you open the stream depends on your platform. XNA-like platforms (MonoGame, KNI, FNA) bundle content files into the app package and require `TitleContainer.OpenStream` to read them — this is the only approach that works on iOS, Android, consoles, and web. Non-XNA platforms (raylib, SkiaSharp, and plain desktop apps) can read content directly from the filesystem with `File.OpenRead`. The examples below show both.
+{% endhint %}
+
 ### Code Example: Loading from CSV
 
 This example uses a CSV file with the following contents:
@@ -85,6 +89,49 @@ T_Greeting,"Welcome, this is a localized project example","Bienvenido, este es u
 
 ```
 
+{% tabs %}
+{% tab title="XNA-like (MonoGame/KNI/FNA)" %}
+```csharp
+// Initialize
+using Gum.Localization; // for extension methods
+using Microsoft.Xna.Framework; // for TitleContainer
+// ...
+protected override void Initialize()
+{
+    //var project = GumUI.Initialize(this, "GumProject/GumProject.gumx");
+    GumUI.Initialize(this);
+
+    var localizationService = GumUI.LocalizationService;
+
+    // TitleContainer opens content bundled into the app package.
+    // This is required on iOS, Android, consoles, and web.
+    using var stream = TitleContainer.OpenStream("Content/LocalizationDB.csv");
+    localizationService.AddCsvDatabase(stream);
+
+    // set the language index before creating your UI:
+    localizationService.CurrentLanguage = 2;
+
+    // create UI using the string IDs:
+    StackPanel panel = new();
+    panel.AddToRoot();
+    panel.Anchor(Anchor.Center);
+
+    Label label = new();
+    panel.AddChild(label);
+    label.Text = "T_Greeting";
+
+    Button okButton = new();
+    panel.AddChild(okButton);
+    okButton.Text = "T_OK";
+
+    Button cancelButton = new();
+    panel.AddChild(cancelButton);
+    cancelButton.Text = "T_Cancel";
+}
+```
+{% endtab %}
+
+{% tab title="Non-XNA (raylib, SkiaSharp, etc.)" %}
 ```csharp
 // Initialize
 using Gum.Localization; // for extension methods
@@ -121,8 +168,170 @@ protected override void Initialize()
     cancelButton.Text = "T_Cancel";
 }
 ```
+{% endtab %}
+{% endtabs %}
 
 <figure><img src="../.gitbook/assets/06_06 21 28.png" alt=""><figcaption><p>Label and Buttons displaying localized UI</p></figcaption></figure>
+
+### Code Example: Loading from RESX
+
+RESX files are the standard .NET resource format and integrate well with tools like Visual Studio's resource editor. Gum loads a base RESX file and automatically discovers satellite files (named by culture code) alongside it.
+
+This example uses a base file `Strings.resx` with English entries:
+
+```xml
+<root>
+  <data name="T_OK"><value>OK</value></data>
+  <data name="T_Cancel"><value>Cancel</value></data>
+  <data name="T_Greeting"><value>Welcome, this is a localized project example</value></data>
+</root>
+```
+
+A satellite `Strings.es.resx` sits next to it with the Spanish translations (same keys, translated values).
+
+{% tabs %}
+{% tab title="XNA-like (MonoGame/KNI/FNA)" %}
+The path-based overload uses `Directory.GetFiles` to auto-discover satellites, which does not work with bundled content. Open the base file and each satellite as streams via `TitleContainer` and pass them as `(languageName, stream)` pairs:
+
+```csharp
+// Initialize
+using Gum.Localization; // for extension methods
+using Microsoft.Xna.Framework; // for TitleContainer
+// ...
+protected override void Initialize()
+{
+    GumUI.Initialize(this);
+
+    var localizationService = GumUI.LocalizationService;
+
+    var streams = new (string languageName, System.IO.Stream stream)[]
+    {
+        ("Default", TitleContainer.OpenStream("Content/Strings.resx")),
+        ("es", TitleContainer.OpenStream("Content/Strings.es.resx")),
+    };
+
+    localizationService.AddResxDatabase(streams);
+
+    // index 0 is the string ID, index 1 is "Default" (base file),
+    // index 2+ are satellites in the order they are passed
+    localizationService.CurrentLanguage = 2; // Spanish
+
+    Label label = new();
+    label.AddToRoot();
+    label.Text = "T_Greeting";
+}
+```
+{% endtab %}
+
+{% tab title="Non-XNA (raylib, SkiaSharp, etc.)" %}
+```csharp
+// Initialize
+using Gum.Localization; // for extension methods
+// ...
+protected override void Initialize()
+{
+    GumUI.Initialize(this);
+
+    var localizationService = GumUI.LocalizationService;
+
+    // pass the path to the base .resx file; satellites are auto-discovered
+    localizationService.AddResxDatabase("Content/Strings.resx");
+
+    // index 0 is the string ID, index 1 is "Default" (base file),
+    // index 2+ are satellites in the order they are discovered
+    localizationService.CurrentLanguage = 2; // Spanish
+
+    Label label = new();
+    label.AddToRoot();
+    label.Text = "T_Greeting";
+}
+```
+{% endtab %}
+{% endtabs %}
+
+{% hint style="info" %}
+Satellite discovery uses the file naming convention `BaseName.<culture>.resx` (for example `Strings.es.resx`, `Strings.fr.resx`). The base file is labeled `"Default"`; each satellite is labeled with its culture code.
+{% endhint %}
+
+### Multiple RESX Files
+
+Larger projects often split localized strings across several base files — for example, one per feature area. This is the layout used by tools like [ResXResourceManager](https://github.com/dotnet/ResXResourceManager), where strings are organized into files such as `Strings.resx`, `Buttons.resx`, and `Errors.resx`, each with its own satellites:
+
+```
+Content/
+  Strings.resx
+  Strings.es.resx
+  Buttons.resx
+  Buttons.es.resx
+  Errors.resx
+  Errors.es.resx
+```
+
+Pass the collection of base files (or groups of streams) to `AddResxDatabase`. Gum merges keys across all files into a single database:
+
+{% tabs %}
+{% tab title="XNA-like (MonoGame/KNI/FNA)" %}
+Build one group per base file. Each group is a collection of `(languageName, stream)` pairs and may optionally be named — the group name appears in collision-warning messages:
+
+```csharp
+// Initialize
+using Microsoft.Xna.Framework; // for TitleContainer
+// ...
+var localizationService = GumUI.LocalizationService;
+
+var groups = new (string? groupName, IEnumerable<(string, System.IO.Stream)>)[]
+{
+    ("Strings", new[]
+    {
+        ("Default", TitleContainer.OpenStream("Content/Strings.resx")),
+        ("es",      TitleContainer.OpenStream("Content/Strings.es.resx")),
+    }),
+    ("Buttons", new[]
+    {
+        ("Default", TitleContainer.OpenStream("Content/Buttons.resx")),
+        ("es",      TitleContainer.OpenStream("Content/Buttons.es.resx")),
+    }),
+    ("Errors", new[]
+    {
+        ("Default", TitleContainer.OpenStream("Content/Errors.resx")),
+        ("es",      TitleContainer.OpenStream("Content/Errors.es.resx")),
+    }),
+};
+
+localizationService.AddResxDatabase(
+    groups,
+    onWarning: message => System.Diagnostics.Trace.WriteLine(message));
+
+localizationService.CurrentLanguage = 2;
+```
+{% endtab %}
+
+{% tab title="Non-XNA (raylib, SkiaSharp, etc.)" %}
+```csharp
+// Initialize
+var localizationService = GumUI.LocalizationService;
+
+var baseFiles = new[]
+{
+    "Content/Strings.resx",
+    "Content/Buttons.resx",
+    "Content/Errors.resx",
+};
+
+localizationService.AddResxDatabase(
+    baseFiles,
+    onWarning: message => System.Diagnostics.Trace.WriteLine(message));
+
+localizationService.CurrentLanguage = 2;
+```
+{% endtab %}
+{% endtabs %}
+
+{% hint style="warning" %}
+If the same key appears in more than one base file, the **last write wins**. When an `onWarning` callback is provided, Gum invokes it once per colliding key with a message listing every source file that defined the key.
+{% endhint %}
+
+The set of languages is the union of cultures across all base files. If `Strings.resx` has an `es` satellite but `Buttons.resx` does not, keys from `Buttons.resx` fall back to their string ID when `es` is selected.
 
 ## Forms Control Localization
 


### PR DESCRIPTION
…art 1/2)

  - Add multi-file AddResxDatabase overloads (path + stream) with last-write-wins collision callback
  - Fix GumService hardcoding AddCsvDatabase — now dispatches on .csv vs .resx
  - Unit + integration tests for loading CSV and single/multi RESX via GumService
  - Docs: add RESX sections, retrofit XNA/non-XNA tabs onto code-only examples