### PR TITLE
Fix text wrap in SokolGumSample

### DIFF
--- a/Samples/SokolGum/Program.cs
+++ b/Samples/SokolGum/Program.cs
@@ -299,6 +299,8 @@ public static unsafe class Program
             root.Add(new TextRuntime
             {
                 X = 720, Y = 440, Width = 520, Height = 100,
+                WidthUnits = Gum.DataTypes.DimensionUnitType.Absolute,
+                HeightUnits = Gum.DataTypes.DimensionUnitType.Absolute,
                 CustomFont = _font, FontSize = 18,
                 Text = "Multi-line wrapped text, centred horizontally and vertically, with a 2-pixel outline.",
                 Color = new Color(255, 230, 160),


### PR DESCRIPTION
Before
<img width="1392" height="860" alt="image" src="https://github.com/user-attachments/assets/e81f30c4-c704-40da-a059-0ce72277d43a" />

---
After
<img width="1392" height="860" alt="image" src="https://github.com/user-attachments/assets/4d0a7770-d6fd-434e-8951-3c7c428313ca" />

