### PR TITLE
Add .gumpkg bundle format for single-file Gum project loading

### DIFF
--- a/Gum/Managers/ObjectFinder.cs
+++ b/Gum/Managers/ObjectFinder.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using Gum.DataTypes;
 using Gum.DataTypes.Behaviors;
@@ -748,24 +749,55 @@ public class ObjectFinder : IObjectFinder
 
     public IEnumerable<string> GetAllFilesInProject()
     {
-        List<string> toReturn = new List<string>();
-
-        FillListWithReferencedFiles(toReturn, GumProjectSave.Screens);
-        FillListWithReferencedFiles(toReturn, GumProjectSave.Components);
-        FillListWithReferencedFiles(toReturn, GumProjectSave.StandardElements);
-
-        return toReturn.Distinct();
+        return CollectReferencedFilesViaWalker(scopeElement: null).Distinct();
     }
 
     public List<string> GetFilesReferencedBy(ElementSave element)
     {
-        List<string> toReturn = new List<string>();
-
-        FillListWithReferencedFiles(toReturn, element);
-
-        return toReturn.Distinct().ToList();
+        return CollectReferencedFilesViaWalker(scopeElement: element).Distinct().ToList();
     }
 
+    private List<string> CollectReferencedFilesViaWalker(ElementSave? scopeElement)
+    {
+        List<string> result = new List<string>();
+        if (GumProjectSave == null)
+        {
+            return result;
+        }
+
+        string gumProjectDirectory = FileManager.GetDirectory(GumProjectSave.FullFileName);
+
+        Gum.Bundle.GumProjectDependencyWalker walker = new Gum.Bundle.GumProjectDependencyWalker();
+        Gum.Bundle.WalkResult walkResult = walker.Walk(
+            GumProjectSave,
+            gumProjectDirectory,
+            Gum.Bundle.GumBundleInclusion.Core | Gum.Bundle.GumBundleInclusion.FontCache | Gum.Bundle.GumBundleInclusion.ExternalFiles,
+            scopeElement);
+
+        // Walker emits relative-to-project paths (forward-slashed). Existing callers expect
+        // absolute paths normalized through FilePath. Skip the .gumx itself to match the
+        // historical contract — it was never returned by these methods.
+        string gumxFileName = string.IsNullOrEmpty(GumProjectSave.FullFileName)
+            ? string.Empty
+            : Path.GetFileName(GumProjectSave.FullFileName);
+
+        foreach (string relative in walkResult.AllIncludedFiles)
+        {
+            if (!string.IsNullOrEmpty(gumxFileName)
+                && string.Equals(relative, gumxFileName, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+            // Paths stored in SourceFile/CustomFontFile may be absolute (rooted) — preserve those
+            // verbatim. Pure-relative walker output (e.g. "Components/X.gucx", "FontCache/foo.fnt")
+            // gets the project directory prepended so callers see absolute paths as before.
+            string absolute = Path.IsPathRooted(relative) ? relative : gumProjectDirectory + relative;
+            result.Add(new FilePath(absolute).StandardizedCaseSensitive);
+        }
+        return result;
+    }
+
+    [Obsolete("Use GumProjectDependencyWalker via GetAllFilesInProject/GetFilesReferencedBy.")]
     private void FillListWithReferencedFiles<T>(List<string> files, IList<T> elements) where T : ElementSave
     {
         // These files are all relative to the project, so we don't have to worry
@@ -776,7 +808,7 @@ public class ObjectFinder : IObjectFinder
         }
     }
 
-    [Obsolete("Use FillListWithReferencedFilePaths")]
+    [Obsolete("Use GumProjectDependencyWalker via GetAllFilesInProject/GetFilesReferencedBy.")]
     private void FillListWithReferencedFiles(List<string> absoluteFiles, ElementSave element)
     {
         List<FilePath> files = new List<FilePath>();
@@ -786,6 +818,7 @@ public class ObjectFinder : IObjectFinder
         absoluteFiles.AddRange(files.Select(item => item.StandardizedCaseSensitive));
     }
 
+    [Obsolete("Use GumProjectDependencyWalker via GetAllFilesInProject/GetFilesReferencedBy.")]
     private void FillWithReferencedFilePaths(List<FilePath> absoluteFiles, ElementSave element)
     { 
         RecursiveVariableFinder rvf;

--- a/GumCommon/Bundle/BundleGumFileProvider.cs
+++ b/GumCommon/Bundle/BundleGumFileProvider.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.RegularExpressions;
+
+namespace Gum.Bundle;
+
+/// <summary>
+/// <see cref="IGumFileProvider"/> backed by an in-memory <see cref="GumBundle"/>.
+/// Lookups are case-sensitive, matching the bundle's production runtime semantics.
+/// </summary>
+public class BundleGumFileProvider : IGumFileProvider
+{
+    private readonly GumBundle _bundle;
+
+    /// <summary>Initializes a new <see cref="BundleGumFileProvider"/> wrapping <paramref name="bundle"/>.</summary>
+    public BundleGumFileProvider(GumBundle bundle)
+    {
+        if (bundle == null)
+        {
+            throw new ArgumentNullException(nameof(bundle));
+        }
+        _bundle = bundle;
+    }
+
+    /// <inheritdoc/>
+    public bool Exists(string relativePath)
+    {
+        return _bundle.Entries.ContainsKey(Normalize(relativePath));
+    }
+
+    /// <inheritdoc/>
+    public Stream OpenRead(string relativePath)
+    {
+        string key = Normalize(relativePath);
+        if (!_bundle.Entries.TryGetValue(key, out byte[]? bytes))
+        {
+            throw new FileNotFoundException($"Bundle does not contain entry '{relativePath}'.", relativePath);
+        }
+        return new MemoryStream(bytes, writable: false);
+    }
+
+    /// <inheritdoc/>
+    public IEnumerable<string> EnumerateFiles(string searchPattern)
+    {
+        if (searchPattern == null)
+        {
+            throw new ArgumentNullException(nameof(searchPattern));
+        }
+
+        string normalizedPattern = searchPattern.Replace('\\', '/');
+        bool patternHasSlash = GlobMatcher.PatternHasPathSeparator(normalizedPattern);
+        Regex regex = GlobMatcher.Compile(normalizedPattern);
+
+        foreach (string path in _bundle.EntryPathsInOrder)
+        {
+            string candidate = patternHasSlash ? path : GetFileName(path);
+            if (regex.IsMatch(candidate))
+            {
+                yield return path;
+            }
+        }
+    }
+
+    private static string Normalize(string relativePath)
+    {
+        if (relativePath == null)
+        {
+            throw new ArgumentNullException(nameof(relativePath));
+        }
+        return relativePath.Replace('\\', '/');
+    }
+
+    private static string GetFileName(string path)
+    {
+        int slash = path.LastIndexOf('/');
+        return slash < 0 ? path : path.Substring(slash + 1);
+    }
+}

--- a/GumCommon/Bundle/DependencyWarning.cs
+++ b/GumCommon/Bundle/DependencyWarning.cs
@@ -1,0 +1,29 @@
+namespace Gum.Bundle;
+
+/// <summary>
+/// Non-fatal warning emitted by <see cref="GumProjectDependencyWalker"/> when the project
+/// references a file that is not present on disk. The walker does not throw — callers
+/// (e.g. `gumcli pack`) decide whether to treat missing files as fatal.
+/// </summary>
+public class DependencyWarning
+{
+    /// <summary>The bundle-relative path the project asked for (forward slashes).</summary>
+    public string ReferencedPath { get; }
+
+    /// <summary>
+    /// Best-effort name of the element (or `Element.Instance`) that referenced the missing file.
+    /// May be empty when the source could not be attributed to a specific element.
+    /// </summary>
+    public string ReferencedFromElementName { get; }
+
+    /// <summary>Human-readable message describing the warning.</summary>
+    public string Message { get; }
+
+    /// <summary>Initializes a new <see cref="DependencyWarning"/>.</summary>
+    public DependencyWarning(string referencedPath, string referencedFromElementName, string message)
+    {
+        ReferencedPath = referencedPath;
+        ReferencedFromElementName = referencedFromElementName;
+        Message = message;
+    }
+}

--- a/GumCommon/Bundle/GlobMatcher.cs
+++ b/GumCommon/Bundle/GlobMatcher.cs
@@ -1,0 +1,35 @@
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace Gum.Bundle;
+
+internal static class GlobMatcher
+{
+    public static Regex Compile(string searchPattern)
+    {
+        StringBuilder builder = new StringBuilder();
+        builder.Append('^');
+        foreach (char c in searchPattern)
+        {
+            switch (c)
+            {
+                case '*':
+                    builder.Append("[^/]*");
+                    break;
+                case '?':
+                    builder.Append("[^/]");
+                    break;
+                default:
+                    builder.Append(Regex.Escape(c.ToString()));
+                    break;
+            }
+        }
+        builder.Append('$');
+        return new Regex(builder.ToString(), RegexOptions.CultureInvariant);
+    }
+
+    public static bool PatternHasPathSeparator(string searchPattern)
+    {
+        return searchPattern.IndexOf('/') >= 0 || searchPattern.IndexOf('\\') >= 0;
+    }
+}

--- a/GumCommon/Bundle/GumBundle.cs
+++ b/GumCommon/Bundle/GumBundle.cs
@@ -1,0 +1,30 @@
+using System.Collections.Generic;
+
+namespace Gum.Bundle;
+
+/// <summary>
+/// In-memory representation of a decoded `.gumpkg` bundle: the format version
+/// plus all entries keyed by their bundle-relative path.
+/// </summary>
+public class GumBundle
+{
+    /// <summary>Format version byte read from the bundle header.</summary>
+    public byte Version { get; }
+
+    /// <summary>All entries in the bundle, keyed by bundle-relative path (forward slashes).</summary>
+    public IReadOnlyDictionary<string, byte[]> Entries { get; }
+
+    /// <summary>
+    /// Entry paths in the order they appeared in the underlying tar stream.
+    /// Writers sort lexicographically before emitting, so this is the canonical sorted order.
+    /// </summary>
+    public IReadOnlyList<string> EntryPathsInOrder { get; }
+
+    /// <summary>Initializes a new <see cref="GumBundle"/> with the given version and entries.</summary>
+    public GumBundle(byte version, IReadOnlyDictionary<string, byte[]> entries, IReadOnlyList<string> entryPathsInOrder)
+    {
+        Version = version;
+        Entries = entries;
+        EntryPathsInOrder = entryPathsInOrder;
+    }
+}

--- a/GumCommon/Bundle/GumBundleFormat.cs
+++ b/GumCommon/Bundle/GumBundleFormat.cs
@@ -1,0 +1,17 @@
+namespace Gum.Bundle;
+
+/// <summary>
+/// Constants describing the on-disk layout of a `.gumpkg` bundle file:
+/// 4-byte magic ("GUMP") + 1-byte version + brotli-compressed ustar tar payload.
+/// </summary>
+public static class GumBundleFormat
+{
+    /// <summary>The four magic bytes that prefix every bundle file: ASCII "GUMP".</summary>
+    public static readonly byte[] MagicBytes = new byte[] { 0x47, 0x55, 0x4D, 0x50 };
+
+    /// <summary>The current bundle format version this implementation writes and reads.</summary>
+    public const byte CurrentVersion = 0x01;
+
+    /// <summary>Total length of the fixed header (magic bytes + version byte).</summary>
+    public const int HeaderLength = 5;
+}

--- a/GumCommon/Bundle/GumBundleFormatException.cs
+++ b/GumCommon/Bundle/GumBundleFormatException.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace Gum.Bundle;
+
+/// <summary>
+/// Thrown when a `.gumpkg` bundle stream is malformed: bad magic, unsupported version,
+/// or truncated/corrupt compressed payload.
+/// </summary>
+public class GumBundleFormatException : Exception
+{
+    /// <summary>Initializes a new <see cref="GumBundleFormatException"/> with no message.</summary>
+    public GumBundleFormatException() { }
+
+    /// <summary>Initializes a new <see cref="GumBundleFormatException"/> with the supplied message.</summary>
+    public GumBundleFormatException(string message) : base(message) { }
+
+    /// <summary>Initializes a new <see cref="GumBundleFormatException"/> wrapping an inner exception.</summary>
+    public GumBundleFormatException(string message, Exception innerException) : base(message, innerException) { }
+}

--- a/GumCommon/Bundle/GumBundleInclusion.cs
+++ b/GumCommon/Bundle/GumBundleInclusion.cs
@@ -1,0 +1,29 @@
+using System;
+
+namespace Gum.Bundle;
+
+/// <summary>
+/// Categories of files that can be included in a `.gumpkg` bundle. Used by
+/// <see cref="GumProjectDependencyWalker"/> to determine which dependencies to enumerate
+/// and by `gumcli pack` to scope the bundle output.
+/// </summary>
+[Flags]
+public enum GumBundleInclusion
+{
+    /// <summary>
+    /// The Gum project itself: `.gumx` plus all `.gusx`, `.gucx`, `.gutx`, and `.behx` files
+    /// referenced by the project.
+    /// </summary>
+    Core = 1 << 0,
+
+    /// <summary>
+    /// Generated font cache files under `FontCache/` (typically `.fnt` plus their `.png` pages).
+    /// </summary>
+    FontCache = 1 << 1,
+
+    /// <summary>
+    /// Files referenced by the project but living outside the Core/FontCache categories:
+    /// sprite source `.png` textures, custom font files outside `FontCache/`, and similar.
+    /// </summary>
+    ExternalFiles = 1 << 2,
+}

--- a/GumCommon/Bundle/GumBundleLoader.cs
+++ b/GumCommon/Bundle/GumBundleLoader.cs
@@ -1,0 +1,141 @@
+using System;
+using System.IO;
+using ToolsUtilities;
+
+namespace Gum.Bundle;
+
+/// <summary>
+/// Resolves whether a Gum project should load from loose `.gumx` + sibling files on disk
+/// or from a sibling `.gumpkg` bundle, and installs the <see cref="FileManager.CustomGetStreamFromFile"/>
+/// hook to serve bundle entries when needed. Per the bundle plan §4: loose wins when both exist
+/// (dev convenience / hot reload). Production publishes only the bundle.
+/// </summary>
+public static class GumBundleLoader
+{
+    /// <summary>
+    /// Inspects the directory containing <paramref name="gumxPath"/> for a sibling `.gumpkg`
+    /// and returns a <see cref="BundleResolution"/> describing which source the loader should use.
+    /// When bundle mode is selected, installs <see cref="FileManager.CustomGetStreamFromFile"/>
+    /// to serve bundle entries (composing with any pre-existing user hook as a fallback).
+    /// </summary>
+    public static BundleResolution Resolve(string gumxPath)
+    {
+        if (string.IsNullOrEmpty(gumxPath))
+        {
+            throw new ArgumentException("Gumx path must be non-empty.", nameof(gumxPath));
+        }
+
+        // Loose wins when both exist (plan §4.1 / §4.2).
+        if (File.Exists(gumxPath))
+        {
+            return new BundleResolution(usedBundle: false, resolvedGumxPath: gumxPath, previousHook: null);
+        }
+
+        string? directory = Path.GetDirectoryName(gumxPath);
+        string nameWithoutExtension = Path.GetFileNameWithoutExtension(gumxPath);
+        string bundlePath = string.IsNullOrEmpty(directory)
+            ? nameWithoutExtension + ".gumpkg"
+            : Path.Combine(directory!, nameWithoutExtension + ".gumpkg");
+
+        if (!File.Exists(bundlePath))
+        {
+            // Neither exists. Return as-is; downstream Load will surface a "not found" error
+            // with its own message (matches existing GumProjectSave.Load behavior).
+            return new BundleResolution(usedBundle: false, resolvedGumxPath: gumxPath, previousHook: null);
+        }
+
+        GumBundle bundle;
+        using (FileStream fs = File.OpenRead(bundlePath))
+        {
+            bundle = GumBundleReader.Read(fs);
+        }
+
+        BundleGumFileProvider provider = new BundleGumFileProvider(bundle);
+        string projectRoot = string.IsNullOrEmpty(directory) ? "." : directory!;
+        Func<string, Stream>? previousHook = FileManager.CustomGetStreamFromFile;
+
+        // Compose: bundle entries first, fall back to any pre-existing user hook on miss.
+        // Don't clobber state set by the host (e.g. their own asset zip — see SystemManagers.cs:141).
+        FileManager.CustomGetStreamFromFile = incomingPath =>
+        {
+            string? relative = TryMakeRelative(incomingPath, projectRoot);
+            if (relative != null && provider.Exists(relative))
+            {
+                return provider.OpenRead(relative);
+            }
+
+            if (previousHook != null)
+            {
+                return previousHook(incomingPath);
+            }
+
+            // No user fallback — surface a meaningful FileNotFoundException so callers
+            // can distinguish "asked for a path the bundle doesn't have" from generic IO errors.
+            throw new FileNotFoundException(
+                $"File '{incomingPath}' was not found in the Gum bundle and no fallback file provider is installed.",
+                incomingPath);
+        };
+
+        return new BundleResolution(usedBundle: true, resolvedGumxPath: gumxPath, previousHook: previousHook);
+    }
+
+    private static string? TryMakeRelative(string incomingPath, string projectRoot)
+    {
+        if (string.IsNullOrEmpty(incomingPath))
+        {
+            return null;
+        }
+
+        string normalizedIncoming = incomingPath.Replace('\\', '/');
+        string normalizedRoot = projectRoot.Replace('\\', '/').TrimEnd('/');
+
+        if (normalizedRoot.Length == 0 || normalizedRoot == ".")
+        {
+            return normalizedIncoming;
+        }
+
+        // Case-insensitive prefix match on the directory portion: Windows file systems are
+        // case-insensitive and FileManager.MakeAbsolute may differ in case from the original
+        // root we captured. The bundle key lookup itself stays case-sensitive (see
+        // BundleGumFileProvider) — this only relaxes the directory-prefix strip.
+        if (normalizedIncoming.Length > normalizedRoot.Length
+            && normalizedIncoming.StartsWith(normalizedRoot, StringComparison.OrdinalIgnoreCase)
+            && normalizedIncoming[normalizedRoot.Length] == '/')
+        {
+            return normalizedIncoming.Substring(normalizedRoot.Length + 1);
+        }
+
+        return null;
+    }
+}
+
+/// <summary>
+/// Result of <see cref="GumBundleLoader.Resolve"/>: whether the loader should treat the
+/// project as bundle-backed, the path to pass to <c>GumProjectSave.Load</c>, and the previous
+/// <see cref="FileManager.CustomGetStreamFromFile"/> hook (so callers can restore it on dispose
+/// if they need to fully unwind the install).
+/// </summary>
+public class BundleResolution
+{
+    /// <summary>True if a `.gumpkg` was found and the bundle hook was installed.</summary>
+    public bool UsedBundle { get; }
+
+    /// <summary>The path to pass to <c>GumProjectSave.Load</c>. Always the original `.gumx` path.</summary>
+    public string ResolvedGumxPath { get; }
+
+    /// <summary>
+    /// The <see cref="FileManager.CustomGetStreamFromFile"/> hook value at the time
+    /// <see cref="GumBundleLoader.Resolve"/> ran, or <c>null</c> if none was set or bundle mode
+    /// was not selected. Callers that wish to fully uninstall the bundle hook should restore
+    /// this value rather than null'ing the field.
+    /// </summary>
+    public Func<string, Stream>? PreviousHook { get; }
+
+    /// <summary>Initializes a new <see cref="BundleResolution"/>.</summary>
+    public BundleResolution(bool usedBundle, string resolvedGumxPath, Func<string, Stream>? previousHook)
+    {
+        UsedBundle = usedBundle;
+        ResolvedGumxPath = resolvedGumxPath;
+        PreviousHook = previousHook;
+    }
+}

--- a/GumCommon/Bundle/GumBundleReader.cs
+++ b/GumCommon/Bundle/GumBundleReader.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Collections.Generic;
+using System.Formats.Tar;
+using System.IO;
+using System.IO.Compression;
+
+namespace Gum.Bundle;
+
+/// <summary>
+/// Reads a `.gumpkg` bundle stream into a <see cref="GumBundle"/>: validates header,
+/// decompresses brotli payload, and materializes every tar entry into memory.
+/// </summary>
+public static class GumBundleReader
+{
+    /// <summary>
+    /// Reads a bundle from <paramref name="input"/>. Throws <see cref="GumBundleFormatException"/>
+    /// for bad magic, unsupported version, or truncated/corrupt payload.
+    /// </summary>
+    public static GumBundle Read(Stream input)
+    {
+        if (input == null)
+        {
+            throw new ArgumentNullException(nameof(input));
+        }
+
+        byte[] header = new byte[GumBundleFormat.HeaderLength];
+        int read = ReadFully(input, header, 0, header.Length);
+        if (read < GumBundleFormat.HeaderLength)
+        {
+            throw new GumBundleFormatException(
+                $"Bundle stream is too short to contain a header (expected {GumBundleFormat.HeaderLength} bytes, got {read}).");
+        }
+
+        for (int i = 0; i < GumBundleFormat.MagicBytes.Length; i++)
+        {
+            if (header[i] != GumBundleFormat.MagicBytes[i])
+            {
+                throw new GumBundleFormatException(
+                    "Bundle stream does not begin with the expected 'GUMP' magic bytes.");
+            }
+        }
+
+        byte version = header[4];
+        if (version > GumBundleFormat.CurrentVersion)
+        {
+            throw new GumBundleFormatException(
+                $"Bundle version {version} is newer than the highest supported version {GumBundleFormat.CurrentVersion}.");
+        }
+
+        Dictionary<string, byte[]> entries = new Dictionary<string, byte[]>(StringComparer.Ordinal);
+        List<string> orderedPaths = new List<string>();
+
+        try
+        {
+            using BrotliStream brotli = new BrotliStream(input, CompressionMode.Decompress, leaveOpen: true);
+            using TarReader tar = new TarReader(brotli, leaveOpen: true);
+
+            TarEntry? entry;
+            while ((entry = tar.GetNextEntry(copyData: false)) != null)
+            {
+                if (entry.EntryType != TarEntryType.RegularFile && entry.EntryType != TarEntryType.V7RegularFile)
+                {
+                    continue;
+                }
+
+                byte[] content;
+                if (entry.DataStream == null)
+                {
+                    content = Array.Empty<byte>();
+                }
+                else
+                {
+                    using MemoryStream buffer = new MemoryStream();
+                    entry.DataStream.CopyTo(buffer);
+                    content = buffer.ToArray();
+                }
+
+                entries[entry.Name] = content;
+                orderedPaths.Add(entry.Name);
+            }
+        }
+        catch (GumBundleFormatException)
+        {
+            throw;
+        }
+        catch (Exception ex) when (ex is InvalidDataException or EndOfStreamException or IOException or FormatException)
+        {
+            throw new GumBundleFormatException(
+                "Bundle payload is truncated or corrupt; failed to decode the brotli/tar stream.", ex);
+        }
+
+        return new GumBundle(version, entries, orderedPaths);
+    }
+
+    private static int ReadFully(Stream stream, byte[] buffer, int offset, int count)
+    {
+        int total = 0;
+        while (total < count)
+        {
+            int n = stream.Read(buffer, offset + total, count - total);
+            if (n <= 0)
+            {
+                break;
+            }
+            total += n;
+        }
+        return total;
+    }
+}

--- a/GumCommon/Bundle/GumBundleWriter.cs
+++ b/GumCommon/Bundle/GumBundleWriter.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Collections.Generic;
+using System.Formats.Tar;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+
+namespace Gum.Bundle;
+
+/// <summary>
+/// Writes a set of (path, content) entries as a `.gumpkg` bundle: header + brotli(tar(entries)).
+/// Output is deterministic given identical inputs (sorted entries, fixed timestamps/uid/gid/mode).
+/// </summary>
+public static class GumBundleWriter
+{
+    /// <summary>
+    /// Writes the supplied entries to <paramref name="output"/> as a complete bundle stream.
+    /// Entries are sorted lexicographically (ordinal) before writing.
+    /// </summary>
+    public static void Write(Stream output, IEnumerable<(string path, byte[] content)> entries)
+    {
+        if (output == null)
+        {
+            throw new ArgumentNullException(nameof(output));
+        }
+        if (entries == null)
+        {
+            throw new ArgumentNullException(nameof(entries));
+        }
+
+        output.Write(GumBundleFormat.MagicBytes, 0, GumBundleFormat.MagicBytes.Length);
+        output.WriteByte(GumBundleFormat.CurrentVersion);
+
+        List<(string path, byte[] content)> sorted = entries
+            .OrderBy(e => e.path, StringComparer.Ordinal)
+            .ToList();
+
+        // leaveOpen so the caller still owns `output` after we dispose the brotli/tar wrappers.
+        using (BrotliStream brotli = new BrotliStream(output, CompressionLevel.Optimal, leaveOpen: true))
+        {
+            using (TarWriter tar = new TarWriter(brotli, TarEntryFormat.Ustar, leaveOpen: true))
+            {
+                foreach ((string path, byte[] content) in sorted)
+                {
+                    UstarTarEntry entry = new UstarTarEntry(TarEntryType.RegularFile, path)
+                    {
+                        // Fixed metadata so two writes of identical input produce byte-identical output.
+                        ModificationTime = DateTimeOffset.UnixEpoch,
+                        Mode = UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.GroupRead | UnixFileMode.OtherRead,
+                        Uid = 0,
+                        Gid = 0,
+                    };
+                    entry.DataStream = new MemoryStream(content, writable: false);
+                    tar.WriteEntry(entry);
+                }
+            }
+
+            if (sorted.Count == 0)
+            {
+                // TarWriter does not emit the end-of-archive marker (two 512-byte zero blocks)
+                // when no entries were written. Emit it ourselves so the reader can distinguish
+                // an intentionally empty archive from a truncated one.
+                byte[] endOfArchive = new byte[1024];
+                brotli.Write(endOfArchive, 0, endOfArchive.Length);
+            }
+        }
+    }
+}

--- a/GumCommon/Bundle/GumProjectDependencyWalker.cs
+++ b/GumCommon/Bundle/GumProjectDependencyWalker.cs
@@ -1,0 +1,458 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Gum.DataTypes;
+using Gum.DataTypes.Behaviors;
+using Gum.DataTypes.Variables;
+using RenderingLibrary.Graphics.Fonts;
+
+namespace Gum.Bundle;
+
+/// <summary>
+/// Walks a <see cref="GumProjectSave"/> and produces the set of files that need to be packaged
+/// to make the project loadable from a `.gumpkg` bundle. The single source of truth for
+/// "what does this project depend on" — `gumcli pack` consumes the walker's output.
+/// </summary>
+/// <remarks>
+/// The walker is intentionally standalone — it does not depend on the <see cref="Gum.Managers.ObjectFinder"/>
+/// singleton, so callers (CLI, build tasks) can pack a project without first wiring it into the tool.
+/// </remarks>
+public class GumProjectDependencyWalker
+{
+    /// <summary>
+    /// Enumerates the files the given project depends on, partitioned by category.
+    /// Missing files are reported via <see cref="WalkResult.MissingFiles"/> rather than thrown.
+    /// </summary>
+    /// <param name="project">The loaded project to walk. Element/screen/component lists must be populated.</param>
+    /// <param name="projectRootDirectory">Directory that contains the `.gumx` and the `Screens/`, `Components/`, etc. subfolders.</param>
+    /// <param name="inclusion">Which categories of files to enumerate.</param>
+    public WalkResult Walk(GumProjectSave project, string projectRootDirectory, GumBundleInclusion inclusion)
+    {
+        return Walk(project, projectRootDirectory, inclusion, scopeElement: null);
+    }
+
+    /// <summary>
+    /// Same as <see cref="Walk(GumProjectSave, string, GumBundleInclusion)"/> but, when
+    /// <paramref name="scopeElement"/> is non-null, restricts the walk to that single element.
+    /// In scoped mode the project-wide core files (every screen/component/standard/behavior)
+    /// are NOT added — only the .gucx/.gutx files corresponding to the scope element's child
+    /// instances and its own file/font references are emitted.
+    /// </summary>
+    public WalkResult Walk(GumProjectSave project, string projectRootDirectory, GumBundleInclusion inclusion, ElementSave? scopeElement)
+    {
+        if (project == null)
+        {
+            throw new ArgumentNullException(nameof(project));
+        }
+        if (projectRootDirectory == null)
+        {
+            throw new ArgumentNullException(nameof(projectRootDirectory));
+        }
+
+        HashSet<string> core = new HashSet<string>(StringComparer.Ordinal);
+        HashSet<string> fontCache = new HashSet<string>(StringComparer.Ordinal);
+        HashSet<string> external = new HashSet<string>(StringComparer.Ordinal);
+        List<DependencyWarning> missing = new List<DependencyWarning>();
+
+        if (scopeElement == null)
+        {
+            if (inclusion.HasFlag(GumBundleInclusion.Core))
+            {
+                CollectCoreFiles(project, projectRootDirectory, core, missing);
+                CollectInstanceTypeCoreFiles(project, core);
+            }
+
+            if (inclusion.HasFlag(GumBundleInclusion.FontCache) || inclusion.HasFlag(GumBundleInclusion.ExternalFiles))
+            {
+                CollectFileAndFontReferences(project, projectRootDirectory, inclusion, fontCache, external, missing);
+            }
+        }
+        else
+        {
+            CollectForSingleElement(project, scopeElement, projectRootDirectory, inclusion, core, fontCache, external, missing);
+        }
+
+        // Enforce precedence: Core wins over FontCache wins over External.
+        fontCache.ExceptWith(core);
+        external.ExceptWith(core);
+        external.ExceptWith(fontCache);
+
+        return new WalkResult(
+            coreFiles: core.OrderBy(p => p, StringComparer.Ordinal).ToList(),
+            fontCacheFiles: fontCache.OrderBy(p => p, StringComparer.Ordinal).ToList(),
+            externalFiles: external.OrderBy(p => p, StringComparer.Ordinal).ToList(),
+            missingFiles: missing);
+    }
+
+    private static void CollectCoreFiles(
+        GumProjectSave project,
+        string projectRootDirectory,
+        HashSet<string> core,
+        List<DependencyWarning> missing)
+    {
+        // .gumx itself — derive from FullFileName when present, else from any single .gumx in the root.
+        string? gumxRelative = TryGetGumxRelativePath(project, projectRootDirectory);
+        if (gumxRelative != null)
+        {
+            core.Add(gumxRelative);
+        }
+
+        foreach (ElementReference reference in project.ScreenReferences ?? new List<ElementReference>())
+        {
+            reference.ElementType = ElementType.Screen;
+            AddElementReference(reference, projectRootDirectory, core, missing);
+        }
+        foreach (ElementReference reference in project.ComponentReferences ?? new List<ElementReference>())
+        {
+            reference.ElementType = ElementType.Component;
+            AddElementReference(reference, projectRootDirectory, core, missing);
+        }
+        foreach (ElementReference reference in project.StandardElementReferences ?? new List<ElementReference>())
+        {
+            reference.ElementType = ElementType.Standard;
+            AddElementReference(reference, projectRootDirectory, core, missing);
+        }
+        foreach (BehaviorReference reference in project.BehaviorReferences ?? new List<BehaviorReference>())
+        {
+            string relative = NormalizeRelative(BehaviorReference.Subfolder + "/" + reference.Name + "." + BehaviorReference.Extension);
+            core.Add(relative);
+            string fullPath = Path.Combine(projectRootDirectory, relative.Replace('/', Path.DirectorySeparatorChar));
+            if (!File.Exists(fullPath))
+            {
+                missing.Add(new DependencyWarning(relative, reference.Name ?? string.Empty,
+                    $"Behavior file '{relative}' was not found on disk."));
+            }
+        }
+    }
+
+    private static void AddElementReference(
+        ElementReference reference,
+        string projectRootDirectory,
+        HashSet<string> core,
+        List<DependencyWarning> missing)
+    {
+        string relative = NormalizeRelative(reference.Subfolder + "/" + reference.Name + "." + reference.Extension);
+        core.Add(relative);
+        string fullPath = Path.Combine(projectRootDirectory, relative.Replace('/', Path.DirectorySeparatorChar));
+        if (!File.Exists(fullPath))
+        {
+            missing.Add(new DependencyWarning(relative, reference.Name ?? string.Empty,
+                $"Element file '{relative}' was not found on disk."));
+        }
+    }
+
+    private static string? TryGetGumxRelativePath(GumProjectSave project, string projectRootDirectory)
+    {
+        if (!string.IsNullOrEmpty(project.FullFileName))
+        {
+            string fileName = Path.GetFileName(project.FullFileName);
+            if (!string.IsNullOrEmpty(fileName))
+            {
+                return NormalizeRelative(fileName);
+            }
+        }
+        if (Directory.Exists(projectRootDirectory))
+        {
+            string[] gumxFiles = Directory.GetFiles(projectRootDirectory, "*." + GumProjectSave.ProjectExtension, SearchOption.TopDirectoryOnly);
+            if (gumxFiles.Length == 1)
+            {
+                return NormalizeRelative(Path.GetFileName(gumxFiles[0]));
+            }
+        }
+        return null;
+    }
+
+    private static void CollectFileAndFontReferences(
+        GumProjectSave project,
+        string projectRootDirectory,
+        GumBundleInclusion inclusion,
+        HashSet<string> fontCache,
+        HashSet<string> external,
+        List<DependencyWarning> missing)
+    {
+        bool includeFontCache = inclusion.HasFlag(GumBundleInclusion.FontCache);
+        bool includeExternal = inclusion.HasFlag(GumBundleInclusion.ExternalFiles);
+
+        foreach (ElementSave element in project.AllElements)
+        {
+            // Element-level (no instance): default state can carry SourceFile / CustomFontFile.
+            CollectFromState(element, instance: null, element.DefaultState, projectRootDirectory,
+                includeFontCache, includeExternal, fontCache, external, missing);
+
+            foreach (StateSave state in element.AllStates)
+            {
+                if (element.Instances == null)
+                {
+                    continue;
+                }
+                foreach (InstanceSave instance in element.Instances)
+                {
+                    CollectFromState(element, instance, state, projectRootDirectory,
+                        includeFontCache, includeExternal, fontCache, external, missing);
+                }
+            }
+        }
+
+        // SinglePixelTextureFile is a project-level external reference.
+        if (includeExternal && !string.IsNullOrEmpty(project.SinglePixelTextureFile))
+        {
+            AddExternalOrFontCache(project.SinglePixelTextureFile, ownerName: "(project)",
+                projectRootDirectory, includeFontCache, includeExternal, fontCache, external, missing);
+        }
+    }
+
+    private static void CollectInstanceTypeCoreFiles(GumProjectSave project, HashSet<string> core)
+    {
+        // Mirror the historical ObjectFinder behavior: for every instance, add the .gucx/.gutx
+        // file for its BaseType. Projects loaded normally have ComponentReferences/StandardElementReferences
+        // populated (and CollectCoreFiles already adds those), but projects built programmatically
+        // — common in tests and headless tools — may only have Components/StandardElements lists.
+        Dictionary<string, ElementSave> elementsByName = new Dictionary<string, ElementSave>(StringComparer.OrdinalIgnoreCase);
+        foreach (ElementSave e in project.AllElements)
+        {
+            if (!string.IsNullOrEmpty(e.Name) && !elementsByName.ContainsKey(e.Name))
+            {
+                elementsByName[e.Name] = e;
+            }
+        }
+
+        foreach (ElementSave element in project.AllElements)
+        {
+            if (element.Instances == null)
+            {
+                continue;
+            }
+            foreach (InstanceSave instance in element.Instances)
+            {
+                if (string.IsNullOrEmpty(instance.BaseType)
+                    || !elementsByName.TryGetValue(instance.BaseType, out ElementSave? instanceElement))
+                {
+                    continue;
+                }
+                string? subfolder = instanceElement is ComponentSave ? "Components"
+                    : instanceElement is StandardElementSave ? "Standards"
+                    : null;
+                if (subfolder != null)
+                {
+                    core.Add(NormalizeRelative(subfolder + "/" + instanceElement.Name + "." + instanceElement.FileExtension));
+                }
+            }
+        }
+    }
+
+    private static void CollectForSingleElement(
+        GumProjectSave project,
+        ElementSave scopeElement,
+        string projectRootDirectory,
+        GumBundleInclusion inclusion,
+        HashSet<string> core,
+        HashSet<string> fontCache,
+        HashSet<string> external,
+        List<DependencyWarning> missing)
+    {
+        bool includeCore = inclusion.HasFlag(GumBundleInclusion.Core);
+        bool includeFontCache = inclusion.HasFlag(GumBundleInclusion.FontCache);
+        bool includeExternal = inclusion.HasFlag(GumBundleInclusion.ExternalFiles);
+        bool includeFileOrFont = includeFontCache || includeExternal;
+
+        // Build a name -> element lookup once for resolving instance BaseTypes; matches the
+        // private dictionary the project-wide walk uses, scoped here to the single-element path.
+        Dictionary<string, ElementSave> elementsByName = new Dictionary<string, ElementSave>(StringComparer.OrdinalIgnoreCase);
+        foreach (ElementSave e in project.AllElements)
+        {
+            if (!string.IsNullOrEmpty(e.Name) && !elementsByName.ContainsKey(e.Name))
+            {
+                elementsByName[e.Name] = e;
+            }
+        }
+
+        if (includeFileOrFont)
+        {
+            CollectFromState(scopeElement, instance: null, scopeElement.DefaultState, projectRootDirectory,
+                includeFontCache, includeExternal, fontCache, external, missing);
+        }
+
+        if (scopeElement.Instances != null)
+        {
+            foreach (StateSave state in scopeElement.AllStates)
+            {
+                foreach (InstanceSave instance in scopeElement.Instances)
+                {
+                    if (includeCore && !string.IsNullOrEmpty(instance.BaseType)
+                        && elementsByName.TryGetValue(instance.BaseType, out ElementSave? instanceElement))
+                    {
+                        string? subfolder = instanceElement is ComponentSave ? "Components"
+                            : instanceElement is StandardElementSave ? "Standards"
+                            : null;
+                        if (subfolder != null)
+                        {
+                            string relative = NormalizeRelative(subfolder + "/" + instanceElement.Name + "." + instanceElement.FileExtension);
+                            core.Add(relative);
+                        }
+                    }
+
+                    if (includeFileOrFont)
+                    {
+                        CollectFromState(scopeElement, instance, state, projectRootDirectory,
+                            includeFontCache, includeExternal, fontCache, external, missing);
+                    }
+                }
+            }
+        }
+    }
+
+    private static void CollectFromState(
+        ElementSave element,
+        InstanceSave? instance,
+        StateSave? state,
+        string projectRootDirectory,
+        bool includeFontCache,
+        bool includeExternal,
+        HashSet<string> fontCache,
+        HashSet<string> external,
+        List<DependencyWarning> missing)
+    {
+        if (state == null)
+        {
+            return;
+        }
+
+        string ownerName = instance == null ? element.Name : element.Name + "." + instance.Name;
+        string instancePrefix = instance == null ? string.Empty : instance.Name + ".";
+
+        VariableSave? sourceFileVariable = state.GetVariableSave(instancePrefix + "SourceFile");
+        if (sourceFileVariable?.Value is string sourceFile && !string.IsNullOrEmpty(sourceFile))
+        {
+            AddExternalOrFontCache(sourceFile, ownerName, projectRootDirectory,
+                includeFontCache, includeExternal, fontCache, external, missing);
+        }
+
+        VariableSave? useCustomFontVariable = state.GetVariableSave(instancePrefix + "UseCustomFont");
+        bool useCustomFont = useCustomFontVariable?.Value is bool b && b;
+
+        if (useCustomFont)
+        {
+            VariableSave? customFontVariable = state.GetVariableSave(instancePrefix + "CustomFontFile");
+            if (customFontVariable?.Value is string customFont && !string.IsNullOrEmpty(customFont))
+            {
+                AddExternalOrFontCache(customFont, ownerName, projectRootDirectory,
+                    includeFontCache, includeExternal, fontCache, external, missing);
+            }
+        }
+        else
+        {
+            // Derive font cache .fnt name from the standard font variables; this mirrors the runtime's
+            // own derivation in BmfcSave.GetFontCacheFileNameFor.
+            string? fontName = state.GetVariableSave(instancePrefix + "Font")?.Value as string;
+            int? fontSize = state.GetVariableSave(instancePrefix + "FontSize")?.Value as int?;
+            int? outlineThickness = state.GetVariableSave(instancePrefix + "OutlineThickness")?.Value as int?;
+            bool? useFontSmoothing = state.GetVariableSave(instancePrefix + "UseFontSmoothing")?.Value as bool?;
+            bool? isItalic = state.GetVariableSave(instancePrefix + "IsItalic")?.Value as bool?;
+            bool? isBold = state.GetVariableSave(instancePrefix + "IsBold")?.Value as bool?;
+
+            if (fontName != null && fontSize.HasValue && outlineThickness.HasValue
+                && useFontSmoothing.HasValue && isItalic.HasValue && isBold.HasValue)
+            {
+                string fntRelative = BmfcSave.GetFontCacheFileNameFor(
+                    fontSize.Value, fontName, outlineThickness.Value, useFontSmoothing.Value,
+                    isItalic.Value, isBold.Value);
+                AddFontCacheFntAndPages(fntRelative, ownerName, projectRootDirectory,
+                    includeFontCache, includeExternal, fontCache, external, missing);
+            }
+        }
+    }
+
+    private static void AddExternalOrFontCache(
+        string referencedPath,
+        string ownerName,
+        string projectRootDirectory,
+        bool includeFontCache,
+        bool includeExternal,
+        HashSet<string> fontCache,
+        HashSet<string> external,
+        List<DependencyWarning> missing)
+    {
+        string relative = NormalizeRelative(referencedPath);
+        bool isFontCache = relative.StartsWith("FontCache/", StringComparison.OrdinalIgnoreCase);
+
+        if (isFontCache && includeFontCache)
+        {
+            fontCache.Add(relative);
+        }
+        else if (!isFontCache && includeExternal)
+        {
+            external.Add(relative);
+        }
+        else
+        {
+            return;
+        }
+
+        string fullPath = Path.Combine(projectRootDirectory, relative.Replace('/', Path.DirectorySeparatorChar));
+        if (!File.Exists(fullPath))
+        {
+            missing.Add(new DependencyWarning(relative, ownerName,
+                $"Referenced file '{relative}' was not found on disk."));
+        }
+    }
+
+    private static void AddFontCacheFntAndPages(
+        string fntRelative,
+        string ownerName,
+        string projectRootDirectory,
+        bool includeFontCache,
+        bool includeExternal,
+        HashSet<string> fontCache,
+        HashSet<string> external,
+        List<DependencyWarning> missing)
+    {
+        string normalizedFnt = NormalizeRelative(fntRelative);
+        AddExternalOrFontCache(normalizedFnt, ownerName, projectRootDirectory,
+            includeFontCache, includeExternal, fontCache, external, missing);
+
+        if (!includeFontCache)
+        {
+            return;
+        }
+
+        // Multi-page bitmap fonts emit MyFont.png OR MyFont_0.png, MyFont_1.png, etc.
+        // Enumerate the FontCache directory for any .png whose name matches the .fnt base.
+        string fntDirectoryRelative = Path.GetDirectoryName(normalizedFnt)?.Replace('\\', '/') ?? "FontCache";
+        string fntBaseName = Path.GetFileNameWithoutExtension(normalizedFnt);
+        string fntFullDir = Path.Combine(projectRootDirectory, fntDirectoryRelative.Replace('/', Path.DirectorySeparatorChar));
+
+        if (!Directory.Exists(fntFullDir))
+        {
+            return;
+        }
+
+        // Match "BaseName.png" and "BaseName_<digits>.png".
+        foreach (string pngPath in Directory.EnumerateFiles(fntFullDir, fntBaseName + "*.png"))
+        {
+            string pngFileName = Path.GetFileName(pngPath);
+            string withoutExt = Path.GetFileNameWithoutExtension(pngFileName);
+            if (withoutExt == fntBaseName || IsPagedSuffix(withoutExt, fntBaseName))
+            {
+                string pngRelative = NormalizeRelative(fntDirectoryRelative + "/" + pngFileName);
+                fontCache.Add(pngRelative);
+            }
+        }
+    }
+
+    private static bool IsPagedSuffix(string candidate, string baseName)
+    {
+        if (!candidate.StartsWith(baseName + "_", StringComparison.Ordinal))
+        {
+            return false;
+        }
+        string suffix = candidate.Substring(baseName.Length + 1);
+        return suffix.Length > 0 && suffix.All(char.IsDigit);
+    }
+
+    private static string NormalizeRelative(string path)
+    {
+        string normalized = path.Replace('\\', '/').TrimStart('/');
+        return normalized;
+    }
+}

--- a/GumCommon/Bundle/IGumFileProvider.cs
+++ b/GumCommon/Bundle/IGumFileProvider.cs
@@ -1,0 +1,30 @@
+using System.Collections.Generic;
+using System.IO;
+
+namespace Gum.Bundle;
+
+/// <summary>
+/// Abstraction over the file source backing a loaded Gum project: either loose files on disk
+/// (<see cref="LooseFileGumFileProvider"/>) or entries inside a `.gumpkg` bundle
+/// (<see cref="BundleGumFileProvider"/>). All paths are relative to the provider's root and
+/// use forward slashes.
+/// </summary>
+public interface IGumFileProvider
+{
+    /// <summary>Returns true if a file at <paramref name="relativePath"/> exists in the provider.</summary>
+    bool Exists(string relativePath);
+
+    /// <summary>
+    /// Opens a readable stream for <paramref name="relativePath"/>.
+    /// Throws <see cref="FileNotFoundException"/> if the file is not present.
+    /// </summary>
+    Stream OpenRead(string relativePath);
+
+    /// <summary>
+    /// Enumerates files matching <paramref name="searchPattern"/> recursively across the provider's root.
+    /// Supports `*` (any chars except `/`) and `?` (single char except `/`). When the pattern contains a
+    /// `/`, it is matched against the full forward-slash-normalized relative path; otherwise it matches
+    /// against the filename only. Returned paths are forward-slash-normalized and relative to the root.
+    /// </summary>
+    IEnumerable<string> EnumerateFiles(string searchPattern);
+}

--- a/GumCommon/Bundle/LooseFileGumFileProvider.cs
+++ b/GumCommon/Bundle/LooseFileGumFileProvider.cs
@@ -1,0 +1,144 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.RegularExpressions;
+
+namespace Gum.Bundle;
+
+/// <summary>
+/// <see cref="IGumFileProvider"/> backed by loose files in a directory on disk.
+/// Lookups are case-sensitive at the API layer even on case-insensitive filesystems (Windows/macOS),
+/// so that dev-time casing bugs surface here instead of exploding in case-sensitive production environments.
+/// </summary>
+public class LooseFileGumFileProvider : IGumFileProvider
+{
+    private readonly string _rootDirectory;
+    private readonly string _normalizedRoot;
+
+    /// <summary>Initializes a new <see cref="LooseFileGumFileProvider"/> rooted at <paramref name="rootDirectory"/>.</summary>
+    public LooseFileGumFileProvider(string rootDirectory)
+    {
+        if (rootDirectory == null)
+        {
+            throw new ArgumentNullException(nameof(rootDirectory));
+        }
+        _rootDirectory = rootDirectory;
+        _normalizedRoot = Path.GetFullPath(rootDirectory).Replace('\\', '/').TrimEnd('/');
+    }
+
+    /// <inheritdoc/>
+    public bool Exists(string relativePath)
+    {
+        if (relativePath == null)
+        {
+            throw new ArgumentNullException(nameof(relativePath));
+        }
+        string fullPath = Path.Combine(_rootDirectory, relativePath);
+        return File.Exists(fullPath) && CasingMatchesOnDisk(fullPath, relativePath);
+    }
+
+    /// <inheritdoc/>
+    public Stream OpenRead(string relativePath)
+    {
+        if (relativePath == null)
+        {
+            throw new ArgumentNullException(nameof(relativePath));
+        }
+        string fullPath = Path.Combine(_rootDirectory, relativePath);
+        if (!File.Exists(fullPath) || !CasingMatchesOnDisk(fullPath, relativePath))
+        {
+            throw new FileNotFoundException($"File '{relativePath}' was not found under '{_rootDirectory}'.", relativePath);
+        }
+        return File.OpenRead(fullPath);
+    }
+
+    /// <inheritdoc/>
+    public IEnumerable<string> EnumerateFiles(string searchPattern)
+    {
+        if (searchPattern == null)
+        {
+            throw new ArgumentNullException(nameof(searchPattern));
+        }
+
+        if (!Directory.Exists(_rootDirectory))
+        {
+            yield break;
+        }
+
+        string normalizedPattern = searchPattern.Replace('\\', '/');
+        bool patternHasSlash = GlobMatcher.PatternHasPathSeparator(normalizedPattern);
+        Regex regex = GlobMatcher.Compile(normalizedPattern);
+
+        foreach (string fullPath in Directory.EnumerateFiles(_rootDirectory, "*", SearchOption.AllDirectories))
+        {
+            string relative = ToRelativeForwardSlash(fullPath);
+            string candidate = patternHasSlash ? relative : GetFileName(relative);
+            if (regex.IsMatch(candidate))
+            {
+                yield return relative;
+            }
+        }
+    }
+
+    private string ToRelativeForwardSlash(string fullPath)
+    {
+        string normalizedFull = Path.GetFullPath(fullPath).Replace('\\', '/');
+        if (normalizedFull.StartsWith(_normalizedRoot + "/", StringComparison.Ordinal))
+        {
+            return normalizedFull.Substring(_normalizedRoot.Length + 1);
+        }
+        return normalizedFull;
+    }
+
+    private static string GetFileName(string path)
+    {
+        int slash = path.LastIndexOf('/');
+        return slash < 0 ? path : path.Substring(slash + 1);
+    }
+
+    private bool CasingMatchesOnDisk(string fullPath, string requestedRelativePath)
+    {
+        string[] requestedSegments = requestedRelativePath
+            .Replace('\\', '/')
+            .TrimStart('/')
+            .Split('/');
+
+        try
+        {
+            string current = _rootDirectory;
+            for (int i = 0; i < requestedSegments.Length; i++)
+            {
+                string segment = requestedSegments[i];
+                if (segment.Length == 0)
+                {
+                    return false;
+                }
+
+                bool isLast = i == requestedSegments.Length - 1;
+                string[] matches = isLast
+                    ? Directory.GetFiles(current, segment)
+                    : Directory.GetDirectories(current, segment);
+
+                if (matches.Length == 0)
+                {
+                    return false;
+                }
+                string actualName = Path.GetFileName(matches[0]);
+                if (!string.Equals(actualName, segment, StringComparison.Ordinal))
+                {
+                    return false;
+                }
+                current = matches[0];
+            }
+            return true;
+        }
+        catch (IOException)
+        {
+            return false;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return false;
+        }
+    }
+}

--- a/GumCommon/Bundle/WalkResult.cs
+++ b/GumCommon/Bundle/WalkResult.cs
@@ -1,0 +1,46 @@
+using System.Collections.Generic;
+using System.Linq;
+using Gum.DataTypes;
+
+namespace Gum.Bundle;
+
+/// <summary>
+/// Output of <see cref="GumProjectDependencyWalker.Walk(GumProjectSave, string, GumBundleInclusion)"/>: the set of files the project depends on,
+/// split by category, plus warnings for any references whose files were not on disk.
+/// </summary>
+/// <remarks>
+/// All paths in the lists are bundle-relative (relative to the project root directory),
+/// forward-slash-separated, with no leading slash. Each file appears in at most one of the
+/// three category lists; the precedence is Core &gt; FontCache &gt; External.
+/// Lists are sorted lexicographically for determinism.
+/// </remarks>
+public class WalkResult
+{
+    /// <summary>Project files: `.gumx`, `.gusx`, `.gucx`, `.gutx`, `.behx`.</summary>
+    public IReadOnlyList<string> CoreFiles { get; }
+
+    /// <summary>Files under `FontCache/` (typically `.fnt` and their `.png` pages).</summary>
+    public IReadOnlyList<string> FontCacheFiles { get; }
+
+    /// <summary>Other referenced files: sprite textures, custom fonts outside `FontCache/`, etc.</summary>
+    public IReadOnlyList<string> ExternalFiles { get; }
+
+    /// <summary>References to files that were not present on disk during the walk.</summary>
+    public IReadOnlyList<DependencyWarning> MissingFiles { get; }
+
+    /// <summary>Convenience: all included files across all three categories, in the same per-category order.</summary>
+    public IEnumerable<string> AllIncludedFiles => CoreFiles.Concat(FontCacheFiles).Concat(ExternalFiles);
+
+    /// <summary>Initializes a new <see cref="WalkResult"/> with the given file lists and warnings.</summary>
+    public WalkResult(
+        IReadOnlyList<string> coreFiles,
+        IReadOnlyList<string> fontCacheFiles,
+        IReadOnlyList<string> externalFiles,
+        IReadOnlyList<DependencyWarning> missingFiles)
+    {
+        CoreFiles = coreFiles;
+        FontCacheFiles = fontCacheFiles;
+        ExternalFiles = externalFiles;
+        MissingFiles = missingFiles;
+    }
+}

--- a/GumCoreShared.projitems
+++ b/GumCoreShared.projitems
@@ -68,6 +68,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)RenderingLibrary\Graphics\Animation\SpriteAnimationLogic.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RenderingLibrary\Graphics\Atlas.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RenderingLibrary\Graphics\AtlasedTexture.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)RenderingLibrary\Graphics\BatchOrchestrator.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RenderingLibrary\Graphics\BitmapCharacterInfo.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RenderingLibrary\Graphics\Fonts\BitmapFont.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RenderingLibrary\Graphics\Fonts\BmfcSave.cs" />

--- a/MonoGameGum.Tests/DataTypes/GumServiceBundleLoadTests.cs
+++ b/MonoGameGum.Tests/DataTypes/GumServiceBundleLoadTests.cs
@@ -1,0 +1,213 @@
+using Gum.Bundle;
+using Gum.DataTypes;
+using Shouldly;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using ToolsUtilities;
+using Xunit;
+
+namespace MonoGameGum.Tests.DataTypes;
+
+/// <summary>
+/// End-to-end tests for the loose-vs-bundle resolution rule (plan §4) layered on top of
+/// <see cref="GumProjectSave.Load"/>. These exercise the full child-element walk, not just
+/// the .gumx, by reusing the GumProject.zip fixture that
+/// <see cref="GumProjectSaveTests.Load_ShouldLoadEntireProjectThroughCustomGetStreamFromFile_WhenAllFilesComeFromZip"/>
+/// already proves loads correctly through the CustomGetStreamFromFile seam.
+/// </summary>
+public class GumServiceBundleLoadTests : BaseTestClass, IDisposable
+{
+    private readonly string _tempRoot;
+    private readonly string _projectDir;
+    private readonly string _gumxPath;
+    private readonly string _gumpkgPath;
+    private readonly Dictionary<string, byte[]> _entriesByRelativePath;
+
+    public GumServiceBundleLoadTests()
+    {
+        _tempRoot = Path.Combine(Path.GetTempPath(), "GumServiceBundleLoadTests_" + Path.GetRandomFileName());
+        Directory.CreateDirectory(_tempRoot);
+        _projectDir = Path.Combine(_tempRoot, "GumProject");
+        _gumxPath = Path.Combine(_projectDir, "FromZipFileGumProject.gumx");
+        _gumpkgPath = Path.Combine(_projectDir, "FromZipFileGumProject.gumpkg");
+
+        _entriesByRelativePath = ExtractZipToBundleEntries();
+    }
+
+    public override void Dispose()
+    {
+        base.Dispose();
+        if (Directory.Exists(_tempRoot))
+        {
+            try { Directory.Delete(_tempRoot, recursive: true); } catch { /* best-effort */ }
+        }
+    }
+
+    [Fact]
+    public void LoadProject_prefers_loose_provider_when_both_exist()
+    {
+        WriteEntriesAsLooseFiles(_projectDir);
+        WriteBundle(_gumpkgPath, _entriesByRelativePath);
+
+        BundleResolution resolution = GumBundleLoader.Resolve(_gumxPath);
+
+        resolution.UsedBundle.ShouldBeFalse();
+        FileManager.CustomGetStreamFromFile.ShouldBeNull();
+
+        GumProjectSave? project = GumProjectSave.Load(resolution.ResolvedGumxPath, out GumLoadResult result);
+
+        result.ErrorMessage.ShouldBeNullOrEmpty();
+        project.ShouldNotBeNull();
+        project!.Screens.ShouldNotBeEmpty();
+    }
+
+    [Fact]
+    public void LoadProject_uses_bundle_provider_when_only_gumpkg_exists()
+    {
+        WriteBundle(_gumpkgPath, _entriesByRelativePath);
+
+        BundleResolution resolution = GumBundleLoader.Resolve(_gumxPath);
+
+        resolution.UsedBundle.ShouldBeTrue();
+        FileManager.CustomGetStreamFromFile.ShouldNotBeNull();
+
+        GumProjectSave? project = GumProjectSave.Load(resolution.ResolvedGumxPath, out GumLoadResult result);
+
+        result.ErrorMessage.ShouldBeNullOrEmpty();
+        result.MissingFiles.ShouldBeEmpty();
+        project.ShouldNotBeNull();
+        project!.Screens.ShouldNotBeEmpty();
+        project.StandardElements.ShouldNotBeEmpty();
+    }
+
+    [Fact]
+    public void LoadProject_uses_loose_provider_when_only_gumx_exists()
+    {
+        WriteEntriesAsLooseFiles(_projectDir);
+
+        BundleResolution resolution = GumBundleLoader.Resolve(_gumxPath);
+
+        resolution.UsedBundle.ShouldBeFalse();
+        FileManager.CustomGetStreamFromFile.ShouldBeNull();
+
+        GumProjectSave? project = GumProjectSave.Load(resolution.ResolvedGumxPath, out GumLoadResult result);
+
+        result.ErrorMessage.ShouldBeNullOrEmpty();
+        project.ShouldNotBeNull();
+        project!.Screens.ShouldNotBeEmpty();
+    }
+
+    [Fact]
+    public void LoadProject_via_bundle_produces_GumProjectSave_equivalent_to_loose_load()
+    {
+        // Loose load first.
+        WriteEntriesAsLooseFiles(_projectDir);
+        GumProjectSave? loose = GumProjectSave.Load(_gumxPath, out GumLoadResult looseResult);
+        looseResult.ErrorMessage.ShouldBeNullOrEmpty();
+        loose.ShouldNotBeNull();
+
+        // Tear down the loose project and reset the hook between loads so the second load
+        // genuinely goes through the bundle path.
+        FileManager.CustomGetStreamFromFile = null;
+        DeleteLooseProjectFiles(_projectDir);
+        File.Exists(_gumxPath).ShouldBeFalse();
+
+        WriteBundle(_gumpkgPath, _entriesByRelativePath);
+        BundleResolution resolution = GumBundleLoader.Resolve(_gumxPath);
+        resolution.UsedBundle.ShouldBeTrue();
+
+        GumProjectSave? bundled = GumProjectSave.Load(resolution.ResolvedGumxPath, out GumLoadResult bundledResult);
+        bundledResult.ErrorMessage.ShouldBeNullOrEmpty();
+        bundledResult.MissingFiles.ShouldBeEmpty();
+        bundled.ShouldNotBeNull();
+
+        // Structural equivalence: same number of screens/components/standards, and a sampled
+        // variable on the first screen comes through identically. Catches regressions where
+        // bundle loading silently truncates the element walk.
+        bundled!.Screens.Count.ShouldBe(loose!.Screens.Count);
+        bundled.Components.Count.ShouldBe(loose.Components.Count);
+        bundled.StandardElements.Count.ShouldBe(loose.StandardElements.Count);
+        bundled.Behaviors.Count.ShouldBe(loose.Behaviors.Count);
+
+        ScreenSave looseFirstScreen = loose.Screens.First();
+        ScreenSave bundledFirstScreen = bundled.Screens.First(s => s.Name == looseFirstScreen.Name);
+        bundledFirstScreen.Instances.Count.ShouldBe(looseFirstScreen.Instances.Count);
+        bundledFirstScreen.DefaultState.Variables.Count.ShouldBe(looseFirstScreen.DefaultState.Variables.Count);
+    }
+
+    private static Dictionary<string, byte[]> ExtractZipToBundleEntries()
+    {
+        // Bundle entries are keyed by paths relative to the .gumx directory. The zip stores
+        // everything under "GumProject/" — strip that prefix so keys are like "Screens/FirstScreen.gusx".
+        const string zipPrefix = "GumProject/";
+        string zipPath = Path.Combine(AppContext.BaseDirectory, "TestContent", "GumProject.zip");
+        File.Exists(zipPath).ShouldBeTrue($"Test zip missing at {zipPath}");
+
+        Dictionary<string, byte[]> entries = new Dictionary<string, byte[]>(StringComparer.Ordinal);
+        using FileStream fs = File.OpenRead(zipPath);
+        using ZipArchive archive = new ZipArchive(fs, ZipArchiveMode.Read);
+        foreach (ZipArchiveEntry entry in archive.Entries)
+        {
+            if (entry.FullName.EndsWith("/"))
+            {
+                continue;
+            }
+
+            string key = entry.FullName.StartsWith(zipPrefix, StringComparison.Ordinal)
+                ? entry.FullName.Substring(zipPrefix.Length)
+                : entry.FullName;
+
+            using Stream s = entry.Open();
+            using MemoryStream ms = new MemoryStream();
+            s.CopyTo(ms);
+            entries[key] = ms.ToArray();
+        }
+        return entries;
+    }
+
+    private void WriteEntriesAsLooseFiles(string projectDir)
+    {
+        Directory.CreateDirectory(projectDir);
+        foreach (KeyValuePair<string, byte[]> kvp in _entriesByRelativePath)
+        {
+            string fullPath = Path.Combine(projectDir, kvp.Key.Replace('/', Path.DirectorySeparatorChar));
+            string? parent = Path.GetDirectoryName(fullPath);
+            if (!string.IsNullOrEmpty(parent))
+            {
+                Directory.CreateDirectory(parent);
+            }
+            File.WriteAllBytes(fullPath, kvp.Value);
+        }
+    }
+
+    private static void DeleteLooseProjectFiles(string projectDir)
+    {
+        if (Directory.Exists(projectDir))
+        {
+            foreach (string path in Directory.EnumerateFiles(projectDir, "*", SearchOption.AllDirectories))
+            {
+                File.Delete(path);
+            }
+        }
+    }
+
+    private static void WriteBundle(string path, IReadOnlyDictionary<string, byte[]> entries)
+    {
+        string? parent = Path.GetDirectoryName(path);
+        if (!string.IsNullOrEmpty(parent))
+        {
+            Directory.CreateDirectory(parent);
+        }
+
+        List<(string, byte[])> tuples = new List<(string, byte[])>();
+        foreach (KeyValuePair<string, byte[]> kvp in entries)
+        {
+            tuples.Add((kvp.Key, kvp.Value));
+        }
+        using FileStream fs = File.Create(path);
+        GumBundleWriter.Write(fs, tuples);
+    }
+}

--- a/MonoGameGum.Tests/ToolsUtilities/FileManagerTests.cs
+++ b/MonoGameGum.Tests/ToolsUtilities/FileManagerTests.cs
@@ -1,6 +1,7 @@
 ﻿using Shouldly;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -8,8 +9,26 @@ using ToolsUtilities;
 using Xunit;
 
 namespace MonoGameGum.Tests.ToolsUtilities;
-public class FileManagerTests
+public class FileManagerTests : IDisposable
 {
+    private readonly Func<string, Stream>? _previousHook = FileManager.CustomGetStreamFromFile;
+
+    public void Dispose()
+    {
+        FileManager.CustomGetStreamFromFile = _previousHook;
+    }
+
+    [Fact]
+    public void GetStreamForFile_ShouldThrowFileNotFoundException_WhenCustomHookReturnsNull()
+    {
+        FileManager.CustomGetStreamFromFile = _ => null!;
+
+        var ex = Should.Throw<IOException>(() => FileManager.GetStreamForFile("anything.gumx"));
+
+        ex.InnerException.ShouldBeOfType<FileNotFoundException>();
+        ((FileNotFoundException)ex.InnerException!).FileName.ShouldBe("anything.gumx");
+    }
+
     [Fact]
     public void FromFileText_ShouldLoad_WhenPathHasDotDotSlash()
     {

--- a/MonoGameGum/GumService.cs
+++ b/MonoGameGum/GumService.cs
@@ -1,6 +1,7 @@
 ﻿#if MONOGAME || KNI || FNA
 #define XNALIKE
 #endif
+using Gum.Bundle;
 using Gum.DataTypes;
 using Gum.Managers;
 using Gum.StateAnimation.SaveClasses;
@@ -472,7 +473,12 @@ public class GumService
 
         if (!string.IsNullOrEmpty(gumProjectFile))
         {
-            gumProject = GumProjectSave.Load(gumProjectFile, out GumLoadResult loadResult);
+            // Resolve loose-vs-bundle: if a sibling .gumpkg exists (and no loose .gumx),
+            // installs a CustomGetStreamFromFile hook that serves entries from the bundle.
+            // The hook stays installed so runtime asset loads (textures/fonts) also resolve
+            // from the bundle. Plan §4: loose wins when both exist.
+            BundleResolution bundleResolution = GumBundleLoader.Resolve(gumProjectFile);
+            gumProject = GumProjectSave.Load(bundleResolution.ResolvedGumxPath, out GumLoadResult loadResult);
             LastLoadResult = loadResult;
 
             if (gumProject == null || !string.IsNullOrEmpty(loadResult.ErrorMessage) || loadResult.MissingFiles.Count > 0)

--- a/Tests/Gum.Bundle.Tests/BundleGumFileProviderTests.cs
+++ b/Tests/Gum.Bundle.Tests/BundleGumFileProviderTests.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+using System.IO;
+using Gum.Bundle;
+
+namespace Gum.Bundle.Tests;
+
+public class BundleGumFileProviderTests : IGumFileProviderContractTests
+{
+    protected override IGumFileProvider CreateProvider(IReadOnlyDictionary<string, byte[]> files)
+    {
+        List<(string, byte[])> entries = new List<(string, byte[])>();
+        foreach (KeyValuePair<string, byte[]> kvp in files)
+        {
+            entries.Add((kvp.Key, kvp.Value));
+        }
+
+        MemoryStream buffer = new MemoryStream();
+        GumBundleWriter.Write(buffer, entries);
+        buffer.Position = 0;
+        GumBundle bundle = GumBundleReader.Read(buffer);
+        return new BundleGumFileProvider(bundle);
+    }
+}

--- a/Tests/Gum.Bundle.Tests/GoldenManifests/GumProjectZip_BundleEntries.txt
+++ b/Tests/Gum.Bundle.Tests/GoldenManifests/GumProjectZip_BundleEntries.txt
@@ -1,0 +1,14 @@
+ExampleSpriteFrame.png
+FontCache/Font18Arial.fnt
+FontCache/Font18Arial_0.png
+FromZipFileGumProject.gumx
+Screens/FirstScreen.gusx
+Standards/Circle.gutx
+Standards/ColoredRectangle.gutx
+Standards/Component.gutx
+Standards/Container.gutx
+Standards/NineSlice.gutx
+Standards/Polygon.gutx
+Standards/Rectangle.gutx
+Standards/Sprite.gutx
+Standards/Text.gutx

--- a/Tests/Gum.Bundle.Tests/GoldenManifests/GumProjectZip_WalkerDependencies.txt
+++ b/Tests/Gum.Bundle.Tests/GoldenManifests/GumProjectZip_WalkerDependencies.txt
@@ -1,0 +1,14 @@
+ExampleSpriteFrame.png
+FontCache/Font18Arial.fnt
+FontCache/Font18Arial_0.png
+FromZipFileGumProject.gumx
+Screens/FirstScreen.gusx
+Standards/Circle.gutx
+Standards/ColoredRectangle.gutx
+Standards/Component.gutx
+Standards/Container.gutx
+Standards/NineSlice.gutx
+Standards/Polygon.gutx
+Standards/Rectangle.gutx
+Standards/Sprite.gutx
+Standards/Text.gutx

--- a/Tests/Gum.Bundle.Tests/Gum.Bundle.Tests.csproj
+++ b/Tests/Gum.Bundle.Tests/Gum.Bundle.Tests.csproj
@@ -1,0 +1,38 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>12.0</LangVersion>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Shouldly" Version="4.3.0" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\GumCommon\GumCommon.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- Link (do not copy) the GumProject.zip fixture from MonoGameGum.Tests so both test
+         projects share a single source of truth. -->
+    <Content Include="..\..\MonoGameGum.Tests\TestContent\GumProject.zip" Link="TestContent\GumProject.zip">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <None Include="GoldenManifests\*.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/Tests/Gum.Bundle.Tests/GumBundleFormatTests.cs
+++ b/Tests/Gum.Bundle.Tests/GumBundleFormatTests.cs
@@ -1,0 +1,172 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Gum.Bundle;
+using Shouldly;
+
+namespace Gum.Bundle.Tests;
+
+public class GumBundleFormatTests
+{
+    [Fact]
+    public void Header_bytes_are_GUMP_then_0x01()
+    {
+        MemoryStream stream = new MemoryStream();
+        GumBundleWriter.Write(stream, Array.Empty<(string, byte[])>());
+
+        byte[] bytes = stream.ToArray();
+        bytes.Length.ShouldBeGreaterThanOrEqualTo(5);
+        bytes[0].ShouldBe((byte)0x47);
+        bytes[1].ShouldBe((byte)0x55);
+        bytes[2].ShouldBe((byte)0x4D);
+        bytes[3].ShouldBe((byte)0x50);
+        bytes[4].ShouldBe((byte)0x01);
+    }
+
+    [Fact]
+    public void Read_returns_empty_bundle_for_writer_called_with_no_entries()
+    {
+        MemoryStream stream = new MemoryStream();
+        GumBundleWriter.Write(stream, Array.Empty<(string, byte[])>());
+        stream.Position = 0;
+
+        GumBundle bundle = GumBundleReader.Read(stream);
+
+        bundle.Version.ShouldBe((byte)0x01);
+        bundle.Entries.Count.ShouldBe(0);
+    }
+
+    [Fact]
+    public void Read_throws_when_magic_bytes_are_wrong()
+    {
+        byte[] bad = new byte[] { 0x00, 0x00, 0x00, 0x00, 0x01 };
+        MemoryStream stream = new MemoryStream(bad);
+
+        Should.Throw<GumBundleFormatException>(() => GumBundleReader.Read(stream));
+    }
+
+    [Fact]
+    public void Read_throws_when_payload_is_truncated()
+    {
+        MemoryStream stream = new MemoryStream();
+        GumBundleWriter.Write(stream, new (string, byte[])[]
+        {
+            ("a.txt", new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 })
+        });
+
+        byte[] full = stream.ToArray();
+        // Truncate the payload (keep header + a few bytes)
+        byte[] truncated = full.Take(full.Length / 2).ToArray();
+        MemoryStream truncatedStream = new MemoryStream(truncated);
+
+        Should.Throw<GumBundleFormatException>(() => GumBundleReader.Read(truncatedStream));
+    }
+
+    [Fact]
+    public void Read_throws_when_version_is_newer_than_supported()
+    {
+        byte[] futureHeader = new byte[] { 0x47, 0x55, 0x4D, 0x50, 0xFF };
+        MemoryStream stream = new MemoryStream(futureHeader);
+
+        Should.Throw<GumBundleFormatException>(() => GumBundleReader.Read(stream));
+    }
+
+    [Fact]
+    public void Roundtrip_handles_binary_content_unchanged()
+    {
+        byte[] binary = new byte[] { 0x00, 0xFF, 0x89, 0x50, 0x4E, 0x47, 0x00, 0x00 };
+        MemoryStream stream = new MemoryStream();
+        GumBundleWriter.Write(stream, new (string, byte[])[] { ("image.png", binary) });
+        stream.Position = 0;
+
+        GumBundle bundle = GumBundleReader.Read(stream);
+
+        bundle.Entries["image.png"].ShouldBe(binary);
+    }
+
+    [Fact]
+    public void Roundtrip_handles_unicode_path()
+    {
+        string path = "Screens/メニュー.gusx";
+        byte[] content = new byte[] { 1, 2, 3 };
+        MemoryStream stream = new MemoryStream();
+        GumBundleWriter.Write(stream, new (string, byte[])[] { (path, content) });
+        stream.Position = 0;
+
+        GumBundle bundle = GumBundleReader.Read(stream);
+
+        bundle.Entries.ContainsKey(path).ShouldBeTrue();
+        bundle.Entries[path].ShouldBe(content);
+    }
+
+    [Fact]
+    public void Roundtrip_multiple_entries_preserves_all_paths_and_bytes()
+    {
+        (string, byte[])[] entries = new (string, byte[])[]
+        {
+            ("a.gumx", new byte[] { 1 }),
+            ("Screens/Main.gusx", new byte[] { 2, 3 }),
+            ("Components/Button.gucx", new byte[] { 4, 5, 6 }),
+        };
+        MemoryStream stream = new MemoryStream();
+        GumBundleWriter.Write(stream, entries);
+        stream.Position = 0;
+
+        GumBundle bundle = GumBundleReader.Read(stream);
+
+        bundle.Entries.Count.ShouldBe(3);
+        bundle.Entries["a.gumx"].ShouldBe(new byte[] { 1 });
+        bundle.Entries["Screens/Main.gusx"].ShouldBe(new byte[] { 2, 3 });
+        bundle.Entries["Components/Button.gucx"].ShouldBe(new byte[] { 4, 5, 6 });
+    }
+
+    [Fact]
+    public void Roundtrip_single_entry_preserves_path_and_bytes()
+    {
+        byte[] content = new byte[] { 10, 20, 30, 40 };
+        MemoryStream stream = new MemoryStream();
+        GumBundleWriter.Write(stream, new (string, byte[])[] { ("only.txt", content) });
+        stream.Position = 0;
+
+        GumBundle bundle = GumBundleReader.Read(stream);
+
+        bundle.Entries.Count.ShouldBe(1);
+        bundle.Entries["only.txt"].ShouldBe(content);
+    }
+
+    [Fact]
+    public void Write_emits_entries_in_lexicographic_order()
+    {
+        (string, byte[])[] entries = new (string, byte[])[]
+        {
+            ("c.txt", new byte[] { 3 }),
+            ("a.txt", new byte[] { 1 }),
+            ("b.txt", new byte[] { 2 }),
+        };
+        MemoryStream stream = new MemoryStream();
+        GumBundleWriter.Write(stream, entries);
+        stream.Position = 0;
+
+        GumBundle bundle = GumBundleReader.Read(stream);
+
+        bundle.EntryPathsInOrder.ShouldBe(new[] { "a.txt", "b.txt", "c.txt" });
+    }
+
+    [Fact]
+    public void Write_is_deterministic_for_identical_input()
+    {
+        (string, byte[])[] entries = new (string, byte[])[]
+        {
+            ("a.txt", new byte[] { 1, 2, 3 }),
+            ("Screens/Main.gusx", new byte[] { 4, 5, 6 }),
+        };
+        MemoryStream first = new MemoryStream();
+        MemoryStream second = new MemoryStream();
+
+        GumBundleWriter.Write(first, entries);
+        GumBundleWriter.Write(second, entries);
+
+        first.ToArray().ShouldBe(second.ToArray());
+    }
+}

--- a/Tests/Gum.Bundle.Tests/GumBundleLoaderTests.cs
+++ b/Tests/Gum.Bundle.Tests/GumBundleLoaderTests.cs
@@ -1,0 +1,188 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Gum.Bundle;
+using Shouldly;
+using ToolsUtilities;
+
+namespace Gum.Bundle.Tests;
+
+/// <summary>
+/// Tests for <see cref="GumBundleLoader"/>. The hook seam (FileManager.CustomGetStreamFromFile)
+/// is global mutable state, so each test stashes the previous value in the constructor and
+/// restores it in Dispose to guarantee isolation regardless of pass/fail order.
+/// </summary>
+public class GumBundleLoaderTests : IDisposable
+{
+    private readonly Func<string, Stream>? _previousHook;
+    private readonly string _tempDir;
+
+    public GumBundleLoaderTests()
+    {
+        _previousHook = FileManager.CustomGetStreamFromFile;
+        FileManager.CustomGetStreamFromFile = null;
+        _tempDir = Path.Combine(Path.GetTempPath(), "GumBundleLoaderTests_" + Path.GetRandomFileName());
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        FileManager.CustomGetStreamFromFile = _previousHook;
+        if (Directory.Exists(_tempDir))
+        {
+            try { Directory.Delete(_tempDir, recursive: true); } catch { /* best-effort */ }
+        }
+    }
+
+    [Fact]
+    public void Resolve_installs_hook_that_serves_child_element_files_from_bundle()
+    {
+        const string gumxXml = "<GumProjectSave />";
+        byte[] childBytes = Encoding.UTF8.GetBytes("<ScreenSave Name=\"MainScreen\" />");
+
+        string gumxPath = Path.Combine(_tempDir, "Project.gumx");
+        string gumpkgPath = Path.Combine(_tempDir, "Project.gumpkg");
+        WriteBundle(gumpkgPath, new (string, byte[])[]
+        {
+            ("Project.gumx", Encoding.UTF8.GetBytes(gumxXml)),
+            ("Screens/MainScreen.gusx", childBytes),
+        });
+
+        BundleResolution resolution = GumBundleLoader.Resolve(gumxPath);
+
+        resolution.UsedBundle.ShouldBeTrue();
+        FileManager.CustomGetStreamFromFile.ShouldNotBeNull();
+
+        // The runtime loader passes absolute paths (with platform-native separators) to the
+        // hook for child .gusx/.gucx files; this mirrors the behavior exercised in
+        // GumProjectSaveTests.Load_ShouldLoadEntireProjectThroughCustomGetStreamFromFile_*.
+        string childAbsolutePath = Path.Combine(_tempDir, "Screens", "MainScreen.gusx");
+        using Stream stream = FileManager.CustomGetStreamFromFile!(childAbsolutePath);
+        stream.ShouldNotBeNull();
+
+        using MemoryStream copy = new MemoryStream();
+        stream.CopyTo(copy);
+        copy.ToArray().ShouldBe(childBytes);
+    }
+
+    [Fact]
+    public void Resolve_installs_hook_that_serves_gumx_from_bundle_when_only_gumpkg_exists()
+    {
+        byte[] gumxBytes = Encoding.UTF8.GetBytes("<GumProjectSave />");
+        string gumxPath = Path.Combine(_tempDir, "Project.gumx");
+        string gumpkgPath = Path.Combine(_tempDir, "Project.gumpkg");
+        WriteBundle(gumpkgPath, new (string, byte[])[]
+        {
+            ("Project.gumx", gumxBytes),
+        });
+
+        BundleResolution resolution = GumBundleLoader.Resolve(gumxPath);
+
+        resolution.UsedBundle.ShouldBeTrue();
+        resolution.ResolvedGumxPath.ShouldBe(gumxPath);
+        FileManager.CustomGetStreamFromFile.ShouldNotBeNull();
+
+        using Stream stream = FileManager.CustomGetStreamFromFile!(gumxPath);
+        using MemoryStream copy = new MemoryStream();
+        stream.CopyTo(copy);
+        copy.ToArray().ShouldBe(gumxBytes);
+    }
+
+    [Fact]
+    public void Resolve_leaves_hook_untouched_when_only_gumx_exists()
+    {
+        string gumxPath = Path.Combine(_tempDir, "Project.gumx");
+        File.WriteAllText(gumxPath, "<GumProjectSave />");
+
+        BundleResolution resolution = GumBundleLoader.Resolve(gumxPath);
+
+        resolution.UsedBundle.ShouldBeFalse();
+        resolution.ResolvedGumxPath.ShouldBe(gumxPath);
+        FileManager.CustomGetStreamFromFile.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Resolve_prefers_loose_over_bundle_when_both_exist()
+    {
+        string gumxPath = Path.Combine(_tempDir, "Project.gumx");
+        string gumpkgPath = Path.Combine(_tempDir, "Project.gumpkg");
+        File.WriteAllText(gumxPath, "<GumProjectSave />");
+        WriteBundle(gumpkgPath, new (string, byte[])[]
+        {
+            ("Project.gumx", Encoding.UTF8.GetBytes("<GumProjectSave />")),
+        });
+
+        BundleResolution resolution = GumBundleLoader.Resolve(gumxPath);
+
+        resolution.UsedBundle.ShouldBeFalse();
+        FileManager.CustomGetStreamFromFile.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Resolve_preserves_existing_user_hook_as_fallback_when_installing_bundle_hook()
+    {
+        // User has their own hook installed (e.g. they're loading other content from a zip).
+        // Bundle resolution must compose, not clobber: bundle entries come first, falls back
+        // to user hook on miss.
+        byte[] gumxBytes = Encoding.UTF8.GetBytes("<GumProjectSave />");
+        byte[] userBytes = Encoding.UTF8.GetBytes("from-user");
+
+        string gumxPath = Path.Combine(_tempDir, "Project.gumx");
+        string gumpkgPath = Path.Combine(_tempDir, "Project.gumpkg");
+        WriteBundle(gumpkgPath, new (string, byte[])[]
+        {
+            ("Project.gumx", gumxBytes),
+        });
+
+        bool userHookCalled = false;
+        Func<string, Stream> userHook = path =>
+        {
+            userHookCalled = true;
+            return new MemoryStream(userBytes);
+        };
+        FileManager.CustomGetStreamFromFile = userHook;
+
+        BundleResolution resolution = GumBundleLoader.Resolve(gumxPath);
+
+        resolution.UsedBundle.ShouldBeTrue();
+        FileManager.CustomGetStreamFromFile.ShouldNotBeSameAs(userHook);
+
+        // Bundle hit: served from bundle, user hook NOT called.
+        using (Stream s = FileManager.CustomGetStreamFromFile!(gumxPath))
+        {
+            using MemoryStream copy = new MemoryStream();
+            s.CopyTo(copy);
+            copy.ToArray().ShouldBe(gumxBytes);
+        }
+        userHookCalled.ShouldBeFalse();
+
+        // Bundle miss: falls back to user hook.
+        string somethingElse = Path.Combine(_tempDir, "Other", "thing.png");
+        using (Stream s = FileManager.CustomGetStreamFromFile!(somethingElse))
+        {
+            using MemoryStream copy = new MemoryStream();
+            s.CopyTo(copy);
+            copy.ToArray().ShouldBe(userBytes);
+        }
+        userHookCalled.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Resolve_returns_not_found_when_neither_gumx_nor_gumpkg_exists()
+    {
+        string gumxPath = Path.Combine(_tempDir, "Missing.gumx");
+
+        BundleResolution resolution = GumBundleLoader.Resolve(gumxPath);
+
+        resolution.UsedBundle.ShouldBeFalse();
+        resolution.ResolvedGumxPath.ShouldBe(gumxPath);
+        FileManager.CustomGetStreamFromFile.ShouldBeNull();
+    }
+
+    private static void WriteBundle(string path, IEnumerable<(string, byte[])> entries)
+    {
+        using FileStream fs = File.Create(path);
+        GumBundleWriter.Write(fs, entries);
+    }
+}

--- a/Tests/Gum.Bundle.Tests/GumProjectDependencyWalkerTests.cs
+++ b/Tests/Gum.Bundle.Tests/GumProjectDependencyWalkerTests.cs
@@ -1,0 +1,318 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Gum.Bundle;
+using Gum.DataTypes;
+using Gum.DataTypes.Behaviors;
+using RenderingLibrary.Graphics.Fonts;
+using Shouldly;
+
+namespace Gum.Bundle.Tests;
+
+public class GumProjectDependencyWalkerTests : IDisposable
+{
+    private readonly List<string> _tempDirectories;
+    private static readonly byte[] EmptyContent = TestProjectBuilder.EmptyXmlBytes;
+
+    public GumProjectDependencyWalkerTests()
+    {
+        _tempDirectories = new List<string>();
+    }
+
+    [Fact]
+    public void Walk_does_not_duplicate_files_referenced_by_multiple_components()
+    {
+        const string sharedTexture = "Textures/shared.png";
+
+        ComponentSave componentA = TestProjectBuilder.BuildComponent("CompA");
+        TestProjectBuilder.AddSpriteInstance(componentA, "Sprite", sharedTexture);
+
+        ComponentSave componentB = TestProjectBuilder.BuildComponent("CompB");
+        TestProjectBuilder.AddSpriteInstance(componentB, "Sprite", sharedTexture);
+
+        GumProjectSave project = TestProjectBuilder.BuildProject(components: new[] { componentA, componentB });
+        string root = CreateProjectRoot(new[]
+        {
+            ("Components/CompA.gucx", EmptyContent),
+            ("Components/CompB.gucx", EmptyContent),
+            (sharedTexture, EmptyContent),
+        });
+
+        WalkResult result = new GumProjectDependencyWalker().Walk(project, root, GumBundleInclusion.Core | GumBundleInclusion.ExternalFiles);
+
+        result.ExternalFiles.Count(p => p == sharedTexture).ShouldBe(1);
+    }
+
+    [Fact]
+    public void Walk_finds_all_behavior_files_in_project()
+    {
+        BehaviorSave b1 = TestProjectBuilder.BuildBehavior("Toggle");
+        BehaviorSave b2 = TestProjectBuilder.BuildBehavior("Focusable");
+        GumProjectSave project = TestProjectBuilder.BuildProject(behaviors: new[] { b1, b2 });
+        string root = CreateProjectRoot(new[]
+        {
+            ("Behaviors/Toggle.behx", EmptyContent),
+            ("Behaviors/Focusable.behx", EmptyContent),
+        });
+
+        WalkResult result = new GumProjectDependencyWalker().Walk(project, root, GumBundleInclusion.Core);
+
+        result.CoreFiles.ShouldContain("Behaviors/Toggle.behx");
+        result.CoreFiles.ShouldContain("Behaviors/Focusable.behx");
+    }
+
+    [Fact]
+    public void Walk_finds_all_component_files_in_project()
+    {
+        ComponentSave c1 = TestProjectBuilder.BuildComponent("Button");
+        ComponentSave c2 = TestProjectBuilder.BuildComponent("Panel");
+        GumProjectSave project = TestProjectBuilder.BuildProject(components: new[] { c1, c2 });
+        string root = CreateProjectRoot(new[]
+        {
+            ("Components/Button.gucx", EmptyContent),
+            ("Components/Panel.gucx", EmptyContent),
+        });
+
+        WalkResult result = new GumProjectDependencyWalker().Walk(project, root, GumBundleInclusion.Core);
+
+        result.CoreFiles.ShouldContain("Components/Button.gucx");
+        result.CoreFiles.ShouldContain("Components/Panel.gucx");
+    }
+
+    [Fact]
+    public void Walk_finds_all_screen_files_in_project()
+    {
+        ScreenSave s1 = TestProjectBuilder.BuildScreen("MainMenu");
+        ScreenSave s2 = TestProjectBuilder.BuildScreen("Game");
+        GumProjectSave project = TestProjectBuilder.BuildProject(screens: new[] { s1, s2 });
+        string root = CreateProjectRoot(new[]
+        {
+            ("Screens/MainMenu.gusx", EmptyContent),
+            ("Screens/Game.gusx", EmptyContent),
+        });
+
+        WalkResult result = new GumProjectDependencyWalker().Walk(project, root, GumBundleInclusion.Core);
+
+        result.CoreFiles.ShouldContain("Screens/MainMenu.gusx");
+        result.CoreFiles.ShouldContain("Screens/Game.gusx");
+    }
+
+    [Fact]
+    public void Walk_finds_all_standard_element_files_in_project()
+    {
+        StandardElementSave sprite = TestProjectBuilder.BuildStandard("Sprite");
+        StandardElementSave text = TestProjectBuilder.BuildStandard("Text");
+        GumProjectSave project = TestProjectBuilder.BuildProject(standards: new[] { sprite, text });
+        string root = CreateProjectRoot(new[]
+        {
+            ("Standards/Sprite.gutx", EmptyContent),
+            ("Standards/Text.gutx", EmptyContent),
+        });
+
+        WalkResult result = new GumProjectDependencyWalker().Walk(project, root, GumBundleInclusion.Core);
+
+        result.CoreFiles.ShouldContain("Standards/Sprite.gutx");
+        result.CoreFiles.ShouldContain("Standards/Text.gutx");
+    }
+
+    [Fact]
+    public void Walk_normalizes_paths_to_forward_slashes()
+    {
+        ScreenSave screen = TestProjectBuilder.BuildScreen("MainMenu");
+        // Use a backslash in the source-file value to confirm normalization.
+        TestProjectBuilder.AddSpriteInstance(screen, "Sprite", "Textures\\bg.png");
+        GumProjectSave project = TestProjectBuilder.BuildProject(screens: new[] { screen });
+        string root = CreateProjectRoot(new[]
+        {
+            ("Screens/MainMenu.gusx", EmptyContent),
+            ("Textures/bg.png", EmptyContent),
+        });
+
+        WalkResult result = new GumProjectDependencyWalker().Walk(project, root, GumBundleInclusion.Core | GumBundleInclusion.ExternalFiles);
+
+        foreach (string path in result.AllIncludedFiles)
+        {
+            path.ShouldNotContain("\\");
+            path.ShouldNotStartWith("/");
+        }
+        result.ExternalFiles.ShouldContain("Textures/bg.png");
+    }
+
+    [Fact]
+    public void Walk_reports_missing_referenced_file_in_MissingFiles_without_throwing()
+    {
+        ScreenSave screen = TestProjectBuilder.BuildScreen("MainMenu");
+        TestProjectBuilder.AddSpriteInstance(screen, "Sprite", "Textures/missing.png");
+        GumProjectSave project = TestProjectBuilder.BuildProject(screens: new[] { screen });
+        string root = CreateProjectRoot(new[]
+        {
+            ("Screens/MainMenu.gusx", EmptyContent),
+            // Note: Textures/missing.png intentionally not written
+        });
+
+        WalkResult result = new GumProjectDependencyWalker().Walk(project, root, GumBundleInclusion.Core | GumBundleInclusion.ExternalFiles);
+
+        result.MissingFiles.ShouldContain(w => w.ReferencedPath == "Textures/missing.png");
+    }
+
+    [Fact]
+    public void Walk_returns_relative_paths_not_absolute()
+    {
+        ScreenSave screen = TestProjectBuilder.BuildScreen("MainMenu");
+        TestProjectBuilder.AddSpriteInstance(screen, "Sprite", "Textures/bg.png");
+        GumProjectSave project = TestProjectBuilder.BuildProject(screens: new[] { screen });
+        string root = CreateProjectRoot(new[]
+        {
+            ("Screens/MainMenu.gusx", EmptyContent),
+            ("Textures/bg.png", EmptyContent),
+        });
+
+        WalkResult result = new GumProjectDependencyWalker().Walk(project, root, GumBundleInclusion.Core | GumBundleInclusion.ExternalFiles);
+
+        foreach (string path in result.AllIncludedFiles)
+        {
+            Path.IsPathRooted(path).ShouldBeFalse($"Expected relative path, got '{path}'");
+            path.ShouldNotContain(":");
+        }
+    }
+
+    [Fact]
+    public void Walk_with_Core_only_excludes_fonts_and_textures()
+    {
+        ScreenSave screen = TestProjectBuilder.BuildScreen("MainMenu");
+        TestProjectBuilder.AddSpriteInstance(screen, "Sprite", "Textures/bg.png");
+        TestProjectBuilder.AddTextInstanceWithFontCache(screen, "Text", "Arial", 18);
+        GumProjectSave project = TestProjectBuilder.BuildProject(screens: new[] { screen });
+
+        string fntRelative = BmfcSave.GetFontCacheFileNameFor(18, "Arial", 0, useFontSmoothing: true).Replace('\\', '/');
+        string fntBase = Path.GetFileNameWithoutExtension(fntRelative);
+
+        string root = CreateProjectRoot(new[]
+        {
+            ("Screens/MainMenu.gusx", EmptyContent),
+            ("Textures/bg.png", EmptyContent),
+            (fntRelative, EmptyContent),
+            ("FontCache/" + fntBase + ".png", EmptyContent),
+        });
+
+        WalkResult result = new GumProjectDependencyWalker().Walk(project, root, GumBundleInclusion.Core);
+
+        result.FontCacheFiles.ShouldBeEmpty();
+        result.ExternalFiles.ShouldBeEmpty();
+        result.CoreFiles.ShouldContain("Screens/MainMenu.gusx");
+    }
+
+    [Fact]
+    public void Walk_with_ExternalFiles_flag_includes_custom_fonts_outside_FontCache()
+    {
+        const string customFontPath = "Fonts/MyCustom.ttf";
+        ScreenSave screen = TestProjectBuilder.BuildScreen("MainMenu");
+        TestProjectBuilder.AddTextInstanceWithCustomFont(screen, "Text", customFontPath);
+        GumProjectSave project = TestProjectBuilder.BuildProject(screens: new[] { screen });
+        string root = CreateProjectRoot(new[]
+        {
+            ("Screens/MainMenu.gusx", EmptyContent),
+            (customFontPath, EmptyContent),
+        });
+
+        WalkResult result = new GumProjectDependencyWalker().Walk(project, root, GumBundleInclusion.ExternalFiles);
+
+        result.ExternalFiles.ShouldContain(customFontPath);
+    }
+
+    [Fact]
+    public void Walk_with_ExternalFiles_flag_includes_referenced_png_textures()
+    {
+        ScreenSave screen = TestProjectBuilder.BuildScreen("MainMenu");
+        TestProjectBuilder.AddSpriteInstance(screen, "Sprite", "Textures/bg.png");
+        GumProjectSave project = TestProjectBuilder.BuildProject(screens: new[] { screen });
+        string root = CreateProjectRoot(new[]
+        {
+            ("Screens/MainMenu.gusx", EmptyContent),
+            ("Textures/bg.png", EmptyContent),
+        });
+
+        WalkResult result = new GumProjectDependencyWalker().Walk(project, root, GumBundleInclusion.ExternalFiles);
+
+        result.ExternalFiles.ShouldContain("Textures/bg.png");
+    }
+
+    [Fact]
+    public void Walk_with_FontCache_flag_includes_all_png_pages_for_multipage_font()
+    {
+        ScreenSave screen = TestProjectBuilder.BuildScreen("MainMenu");
+        TestProjectBuilder.AddTextInstanceWithFontCache(screen, "Text", "Arial", 18);
+        GumProjectSave project = TestProjectBuilder.BuildProject(screens: new[] { screen });
+
+        string fntRelative = BmfcSave.GetFontCacheFileNameFor(18, "Arial", 0, useFontSmoothing: true).Replace('\\', '/');
+        string fntBase = Path.GetFileNameWithoutExtension(fntRelative);
+
+        string root = CreateProjectRoot(new[]
+        {
+            ("Screens/MainMenu.gusx", EmptyContent),
+            (fntRelative, EmptyContent),
+            ("FontCache/" + fntBase + "_0.png", EmptyContent),
+            ("FontCache/" + fntBase + "_1.png", EmptyContent),
+            ("FontCache/" + fntBase + "_2.png", EmptyContent),
+        });
+
+        WalkResult result = new GumProjectDependencyWalker().Walk(project, root, GumBundleInclusion.FontCache);
+
+        result.FontCacheFiles.ShouldContain("FontCache/" + fntBase + "_0.png");
+        result.FontCacheFiles.ShouldContain("FontCache/" + fntBase + "_1.png");
+        result.FontCacheFiles.ShouldContain("FontCache/" + fntBase + "_2.png");
+    }
+
+    [Fact]
+    public void Walk_with_FontCache_flag_includes_referenced_fnt_and_png_pages()
+    {
+        ScreenSave screen = TestProjectBuilder.BuildScreen("MainMenu");
+        TestProjectBuilder.AddTextInstanceWithFontCache(screen, "Text", "Arial", 18);
+        GumProjectSave project = TestProjectBuilder.BuildProject(screens: new[] { screen });
+
+        string fntRelative = BmfcSave.GetFontCacheFileNameFor(18, "Arial", 0, useFontSmoothing: true).Replace('\\', '/');
+        string fntBase = Path.GetFileNameWithoutExtension(fntRelative);
+
+        string root = CreateProjectRoot(new[]
+        {
+            ("Screens/MainMenu.gusx", EmptyContent),
+            (fntRelative, EmptyContent),
+            ("FontCache/" + fntBase + ".png", EmptyContent),
+        });
+
+        WalkResult result = new GumProjectDependencyWalker().Walk(project, root, GumBundleInclusion.FontCache);
+
+        result.FontCacheFiles.ShouldContain(fntRelative);
+        result.FontCacheFiles.ShouldContain("FontCache/" + fntBase + ".png");
+    }
+
+    private string CreateProjectRoot(IEnumerable<(string, byte[])> files)
+    {
+        // Always include the .gumx so the walker can find the project file.
+        List<(string, byte[])> withProjectFile = new List<(string, byte[])>(files);
+        if (!withProjectFile.Any(t => t.Item1.EndsWith("." + GumProjectSave.ProjectExtension, StringComparison.Ordinal)))
+        {
+            withProjectFile.Add((TestProjectBuilder.DefaultProjectName + "." + GumProjectSave.ProjectExtension, EmptyContent));
+        }
+        string dir = TestProjectBuilder.CreateTempProjectDirectory(withProjectFile);
+        _tempDirectories.Add(dir);
+        return dir;
+    }
+
+    public void Dispose()
+    {
+        foreach (string dir in _tempDirectories)
+        {
+            try
+            {
+                if (Directory.Exists(dir))
+                {
+                    Directory.Delete(dir, recursive: true);
+                }
+            }
+            catch (IOException) { }
+            catch (UnauthorizedAccessException) { }
+        }
+    }
+}

--- a/Tests/Gum.Bundle.Tests/GumProjectGoldenFileTests.cs
+++ b/Tests/Gum.Bundle.Tests/GumProjectGoldenFileTests.cs
@@ -1,0 +1,234 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using Gum.Bundle;
+using Gum.DataTypes;
+using Shouldly;
+
+namespace Gum.Bundle.Tests;
+
+/// <summary>
+/// Regression nets for the bundle pipeline against the real <c>GumProject.zip</c> fixture
+/// shipped with <c>MonoGameGum.Tests</c>. These complement the structural-equivalence test
+/// in <c>GumServiceBundleLoadTests</c>: that one proves a bundled load matches a loose load
+/// today, these ones catch silent walker drift and packer corruption over time.
+///
+/// Path manifests are used as the gold files (not bundle bytes) because brotli output is
+/// not byte-stable across .NET versions, so byte-level gold files would be flaky. Path
+/// manifests are stable, human-reviewable in PRs, and catch the same regressions.
+/// </summary>
+public class GumProjectGoldenFileTests : IDisposable
+{
+    private readonly string _tempRoot;
+    private readonly string _projectDir;
+    private readonly string _gumxPath;
+    private readonly Dictionary<string, byte[]> _entriesByRelativePath;
+
+    public GumProjectGoldenFileTests()
+    {
+        _tempRoot = Path.Combine(Path.GetTempPath(), "GumProjectGoldenFileTests_" + Path.GetRandomFileName());
+        Directory.CreateDirectory(_tempRoot);
+        _projectDir = Path.Combine(_tempRoot, "GumProject");
+        Directory.CreateDirectory(_projectDir);
+
+        _entriesByRelativePath = ExtractZipToBundleEntries();
+        WriteEntriesAsLooseFiles(_projectDir, _entriesByRelativePath);
+        _gumxPath = Path.Combine(_projectDir, "FromZipFileGumProject.gumx");
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempRoot))
+        {
+            try { Directory.Delete(_tempRoot, recursive: true); } catch { /* best-effort */ }
+        }
+    }
+
+    [Fact]
+    public void Pack_compressed_size_is_smaller_than_uncompressed_size()
+    {
+        WalkResult walkResult = WalkFixture();
+        List<(string path, byte[] content)> entries = BuildEntriesFromWalk(walkResult);
+
+        long uncompressed = entries.Sum(e => (long)e.content.Length);
+
+        using MemoryStream output = new MemoryStream();
+        GumBundleWriter.Write(output, entries);
+        long compressed = output.Length;
+
+        compressed.ShouldBeLessThan(uncompressed);
+    }
+
+    [Fact]
+    public void Pack_then_extract_yields_expected_file_set()
+    {
+        WalkResult walkResult = WalkFixture();
+        List<(string path, byte[] content)> entries = BuildEntriesFromWalk(walkResult);
+
+        using MemoryStream output = new MemoryStream();
+        GumBundleWriter.Write(output, entries);
+        output.Position = 0;
+        GumBundle bundle = GumBundleReader.Read(output);
+
+        List<string> actualPaths = bundle.EntryPathsInOrder
+            .OrderBy(p => p, StringComparer.Ordinal)
+            .ToList();
+
+        List<string> expectedPaths = ReadGoldenManifest("GumProjectZip_BundleEntries.txt");
+
+        if (expectedPaths.Count == 0)
+        {
+            // Snapshot bootstrap: write the actual output to the gold file location so the
+            // maintainer can inspect, copy into the source tree, and re-run for green.
+            WriteSnapshotForBootstrap("GumProjectZip_BundleEntries.txt", actualPaths);
+            throw new Xunit.Sdk.XunitException(
+                "Gold file 'GumProjectZip_BundleEntries.txt' was empty. A snapshot has been written next to the test binary; copy it into Tests/Gum.Bundle.Tests/GoldenManifests/ and re-run.");
+        }
+
+        actualPaths.ShouldBe(expectedPaths);
+    }
+
+    [Fact]
+    public void Pack_then_extract_yields_expected_per_entry_bytes()
+    {
+        WalkResult walkResult = WalkFixture();
+        List<(string path, byte[] content)> entries = BuildEntriesFromWalk(walkResult);
+
+        using MemoryStream output = new MemoryStream();
+        GumBundleWriter.Write(output, entries);
+        output.Position = 0;
+        GumBundle bundle = GumBundleReader.Read(output);
+
+        bundle.Entries.Count.ShouldBe(entries.Count);
+
+        foreach ((string path, byte[] content) entry in entries)
+        {
+            bundle.Entries.ContainsKey(entry.path).ShouldBeTrue($"Bundle missing entry '{entry.path}'.");
+            byte[] roundTripped = bundle.Entries[entry.path];
+            byte[] original = _entriesByRelativePath[entry.path];
+
+            roundTripped.ShouldBe(original, $"Entry '{entry.path}' bytes did not round-trip identically.");
+            roundTripped.ShouldBe(entry.content, $"Entry '{entry.path}' bytes differ from packer input.");
+        }
+    }
+
+    [Fact]
+    public void Walker_dependency_list_matches_golden_manifest()
+    {
+        WalkResult walkResult = WalkFixture();
+
+        List<string> actualPaths = walkResult.AllIncludedFiles
+            .OrderBy(p => p, StringComparer.Ordinal)
+            .ToList();
+
+        List<string> expectedPaths = ReadGoldenManifest("GumProjectZip_WalkerDependencies.txt");
+
+        if (expectedPaths.Count == 0)
+        {
+            WriteSnapshotForBootstrap("GumProjectZip_WalkerDependencies.txt", actualPaths);
+            throw new Xunit.Sdk.XunitException(
+                "Gold file 'GumProjectZip_WalkerDependencies.txt' was empty. A snapshot has been written next to the test binary; copy it into Tests/Gum.Bundle.Tests/GoldenManifests/ and re-run.");
+        }
+
+        actualPaths.ShouldBe(expectedPaths);
+    }
+
+    private WalkResult WalkFixture()
+    {
+        GumProjectSave? project = GumProjectSave.Load(_gumxPath, out GumLoadResult result);
+        result.ErrorMessage.ShouldBeNullOrEmpty();
+        project.ShouldNotBeNull();
+
+        GumProjectDependencyWalker walker = new GumProjectDependencyWalker();
+        WalkResult walkResult = walker.Walk(
+            project!,
+            _projectDir,
+            GumBundleInclusion.Core | GumBundleInclusion.FontCache | GumBundleInclusion.ExternalFiles);
+
+        walkResult.MissingFiles.ShouldBeEmpty();
+        return walkResult;
+    }
+
+    private List<(string path, byte[] content)> BuildEntriesFromWalk(WalkResult walkResult)
+    {
+        LooseFileGumFileProvider provider = new LooseFileGumFileProvider(_projectDir);
+        List<(string path, byte[] content)> entries = new List<(string path, byte[] content)>();
+        foreach (string relativePath in walkResult.AllIncludedFiles)
+        {
+            using Stream stream = provider.OpenRead(relativePath);
+            using MemoryStream memory = new MemoryStream();
+            stream.CopyTo(memory);
+            entries.Add((relativePath, memory.ToArray()));
+        }
+        return entries;
+    }
+
+    private static Dictionary<string, byte[]> ExtractZipToBundleEntries()
+    {
+        const string zipPrefix = "GumProject/";
+        string zipPath = Path.Combine(AppContext.BaseDirectory, "TestContent", "GumProject.zip");
+        File.Exists(zipPath).ShouldBeTrue($"Test zip missing at {zipPath}");
+
+        Dictionary<string, byte[]> entries = new Dictionary<string, byte[]>(StringComparer.Ordinal);
+        using FileStream fs = File.OpenRead(zipPath);
+        using ZipArchive archive = new ZipArchive(fs, ZipArchiveMode.Read);
+        foreach (ZipArchiveEntry entry in archive.Entries)
+        {
+            if (entry.FullName.EndsWith("/"))
+            {
+                continue;
+            }
+
+            string key = entry.FullName.StartsWith(zipPrefix, StringComparison.Ordinal)
+                ? entry.FullName.Substring(zipPrefix.Length)
+                : entry.FullName;
+
+            using Stream s = entry.Open();
+            using MemoryStream ms = new MemoryStream();
+            s.CopyTo(ms);
+            entries[key] = ms.ToArray();
+        }
+        return entries;
+    }
+
+    private static void WriteEntriesAsLooseFiles(string projectDir, IReadOnlyDictionary<string, byte[]> entries)
+    {
+        foreach (KeyValuePair<string, byte[]> kvp in entries)
+        {
+            string fullPath = Path.Combine(projectDir, kvp.Key.Replace('/', Path.DirectorySeparatorChar));
+            string? parent = Path.GetDirectoryName(fullPath);
+            if (!string.IsNullOrEmpty(parent))
+            {
+                Directory.CreateDirectory(parent);
+            }
+            File.WriteAllBytes(fullPath, kvp.Value);
+        }
+    }
+
+    private static List<string> ReadGoldenManifest(string fileName)
+    {
+        string path = Path.Combine(AppContext.BaseDirectory, "GoldenManifests", fileName);
+        if (!File.Exists(path))
+        {
+            return new List<string>();
+        }
+
+        return File.ReadAllLines(path)
+            .Select(line => line.Trim())
+            .Where(line => line.Length > 0)
+            .ToList();
+    }
+
+    private static void WriteSnapshotForBootstrap(string fileName, IEnumerable<string> lines)
+    {
+        string path = Path.Combine(AppContext.BaseDirectory, "GoldenManifests", fileName);
+        string? parent = Path.GetDirectoryName(path);
+        if (!string.IsNullOrEmpty(parent))
+        {
+            Directory.CreateDirectory(parent);
+        }
+        File.WriteAllText(path, string.Join("\n", lines) + "\n");
+    }
+}

--- a/Tests/Gum.Bundle.Tests/IGumFileProviderContractTests.cs
+++ b/Tests/Gum.Bundle.Tests/IGumFileProviderContractTests.cs
@@ -1,0 +1,174 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Gum.Bundle;
+using Shouldly;
+
+namespace Gum.Bundle.Tests;
+
+public abstract class IGumFileProviderContractTests
+{
+    protected abstract IGumFileProvider CreateProvider(IReadOnlyDictionary<string, byte[]> files);
+
+    [Fact]
+    public void EnumerateFiles_matches_pattern_with_question_mark_wildcard()
+    {
+        Dictionary<string, byte[]> files = new Dictionary<string, byte[]>
+        {
+            ["a1.txt"] = new byte[] { 1 },
+            ["a2.txt"] = new byte[] { 2 },
+            ["bb.txt"] = new byte[] { 3 },
+        };
+        IGumFileProvider provider = CreateProvider(files);
+
+        List<string> result = provider.EnumerateFiles("a?.txt").ToList();
+
+        result.Count.ShouldBe(2);
+        result.ShouldContain("a1.txt");
+        result.ShouldContain("a2.txt");
+    }
+
+    [Fact]
+    public void EnumerateFiles_matches_pattern_with_star_wildcard()
+    {
+        Dictionary<string, byte[]> files = new Dictionary<string, byte[]>
+        {
+            ["a.txt"] = new byte[] { 1 },
+            ["b.txt"] = new byte[] { 2 },
+            ["a.png"] = new byte[] { 3 },
+        };
+        IGumFileProvider provider = CreateProvider(files);
+
+        List<string> result = provider.EnumerateFiles("*.txt").ToList();
+
+        result.Count.ShouldBe(2);
+        result.ShouldContain("a.txt");
+        result.ShouldContain("b.txt");
+    }
+
+    [Fact]
+    public void EnumerateFiles_matches_pattern_with_subdirectory()
+    {
+        Dictionary<string, byte[]> files = new Dictionary<string, byte[]>
+        {
+            ["Screens/Main.gusx"] = new byte[] { 1 },
+            ["Screens/Other.gusx"] = new byte[] { 2 },
+            ["Components/Foo.gucx"] = new byte[] { 3 },
+        };
+        IGumFileProvider provider = CreateProvider(files);
+
+        List<string> result = provider.EnumerateFiles("Screens/*.gusx").ToList();
+
+        result.Count.ShouldBe(2);
+        result.ShouldContain("Screens/Main.gusx");
+        result.ShouldContain("Screens/Other.gusx");
+    }
+
+    [Fact]
+    public void EnumerateFiles_returns_empty_when_no_match()
+    {
+        Dictionary<string, byte[]> files = new Dictionary<string, byte[]>
+        {
+            ["a.txt"] = new byte[] { 1 },
+        };
+        IGumFileProvider provider = CreateProvider(files);
+
+        List<string> result = provider.EnumerateFiles("*.png").ToList();
+
+        result.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Exists_is_case_sensitive()
+    {
+        Dictionary<string, byte[]> files = new Dictionary<string, byte[]>
+        {
+            ["MyFile.txt"] = new byte[] { 1 },
+        };
+        IGumFileProvider provider = CreateProvider(files);
+
+        provider.Exists("myfile.txt").ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Exists_returns_false_for_absent_file()
+    {
+        Dictionary<string, byte[]> files = new Dictionary<string, byte[]>
+        {
+            ["present.txt"] = new byte[] { 1 },
+        };
+        IGumFileProvider provider = CreateProvider(files);
+
+        provider.Exists("absent.txt").ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Exists_returns_true_for_present_file()
+    {
+        Dictionary<string, byte[]> files = new Dictionary<string, byte[]>
+        {
+            ["present.txt"] = new byte[] { 1 },
+        };
+        IGumFileProvider provider = CreateProvider(files);
+
+        provider.Exists("present.txt").ShouldBeTrue();
+    }
+
+    [Fact]
+    public void OpenRead_is_case_sensitive()
+    {
+        Dictionary<string, byte[]> files = new Dictionary<string, byte[]>
+        {
+            ["MyFile.txt"] = new byte[] { 1, 2, 3 },
+        };
+        IGumFileProvider provider = CreateProvider(files);
+
+        Should.Throw<FileNotFoundException>(() => provider.OpenRead("myfile.txt"));
+    }
+
+    [Fact]
+    public void OpenRead_returns_correct_bytes()
+    {
+        byte[] payload = new byte[] { 10, 20, 30, 40, 50 };
+        Dictionary<string, byte[]> files = new Dictionary<string, byte[]>
+        {
+            ["data.bin"] = payload,
+        };
+        IGumFileProvider provider = CreateProvider(files);
+
+        using Stream stream = provider.OpenRead("data.bin");
+        using MemoryStream copy = new MemoryStream();
+        stream.CopyTo(copy);
+        copy.ToArray().ShouldBe(payload);
+    }
+
+    [Fact]
+    public void OpenRead_throws_FileNotFoundException_for_absent_file()
+    {
+        Dictionary<string, byte[]> files = new Dictionary<string, byte[]>
+        {
+            ["present.txt"] = new byte[] { 1 },
+        };
+        IGumFileProvider provider = CreateProvider(files);
+
+        Should.Throw<FileNotFoundException>(() => provider.OpenRead("absent.txt"));
+    }
+
+    [Fact]
+    public void Paths_use_forward_slashes_in_EnumerateFiles_results()
+    {
+        Dictionary<string, byte[]> files = new Dictionary<string, byte[]>
+        {
+            ["Screens/Main.gusx"] = new byte[] { 1 },
+            ["Components/Sub/Foo.gucx"] = new byte[] { 2 },
+        };
+        IGumFileProvider provider = CreateProvider(files);
+
+        List<string> result = provider.EnumerateFiles("*.gusx").ToList();
+
+        foreach (string path in result)
+        {
+            path.ShouldNotContain("\\");
+        }
+    }
+}

--- a/Tests/Gum.Bundle.Tests/LooseFileGumFileProviderTests.cs
+++ b/Tests/Gum.Bundle.Tests/LooseFileGumFileProviderTests.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Gum.Bundle;
+
+namespace Gum.Bundle.Tests;
+
+public class LooseFileGumFileProviderTests : IGumFileProviderContractTests, IDisposable
+{
+    private readonly List<string> _tempDirectories;
+
+    public LooseFileGumFileProviderTests()
+    {
+        _tempDirectories = new List<string>();
+    }
+
+    protected override IGumFileProvider CreateProvider(IReadOnlyDictionary<string, byte[]> files)
+    {
+        string tempDir = Path.Combine(Path.GetTempPath(), "GumBundleTests_" + Path.GetRandomFileName());
+        Directory.CreateDirectory(tempDir);
+        _tempDirectories.Add(tempDir);
+
+        foreach (KeyValuePair<string, byte[]> kvp in files)
+        {
+            string fullPath = Path.Combine(tempDir, kvp.Key.Replace('/', Path.DirectorySeparatorChar));
+            string? directory = Path.GetDirectoryName(fullPath);
+            if (!string.IsNullOrEmpty(directory))
+            {
+                Directory.CreateDirectory(directory);
+            }
+            File.WriteAllBytes(fullPath, kvp.Value);
+        }
+
+        return new LooseFileGumFileProvider(tempDir);
+    }
+
+    public void Dispose()
+    {
+        foreach (string dir in _tempDirectories)
+        {
+            try
+            {
+                if (Directory.Exists(dir))
+                {
+                    Directory.Delete(dir, recursive: true);
+                }
+            }
+            catch (IOException)
+            {
+            }
+            catch (UnauthorizedAccessException)
+            {
+            }
+        }
+    }
+}

--- a/Tests/Gum.Bundle.Tests/TestProjectBuilder.cs
+++ b/Tests/Gum.Bundle.Tests/TestProjectBuilder.cs
@@ -1,0 +1,179 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Gum.DataTypes;
+using Gum.DataTypes.Behaviors;
+using Gum.DataTypes.Variables;
+
+namespace Gum.Bundle.Tests;
+
+/// <summary>
+/// Helpers for constructing in-memory <see cref="GumProjectSave"/> instances and matching
+/// on-disk fixtures for walker / packer tests.
+/// </summary>
+internal static class TestProjectBuilder
+{
+    public const string DefaultProjectName = "TestProject";
+
+    /// <summary>
+    /// Creates a temp directory with the given files written into it. Returns the directory path.
+    /// </summary>
+    public static string CreateTempProjectDirectory(IEnumerable<(string relativePath, byte[] content)> files)
+    {
+        string dir = Path.Combine(Path.GetTempPath(), "GumBundleWalkerTests_" + Path.GetRandomFileName());
+        Directory.CreateDirectory(dir);
+        foreach ((string relativePath, byte[] content) in files)
+        {
+            string fullPath = Path.Combine(dir, relativePath.Replace('/', Path.DirectorySeparatorChar));
+            string? parent = Path.GetDirectoryName(fullPath);
+            if (!string.IsNullOrEmpty(parent))
+            {
+                Directory.CreateDirectory(parent);
+            }
+            File.WriteAllBytes(fullPath, content);
+        }
+        return dir;
+    }
+
+    public static GumProjectSave BuildProject(
+        string projectName = DefaultProjectName,
+        IEnumerable<ScreenSave>? screens = null,
+        IEnumerable<ComponentSave>? components = null,
+        IEnumerable<StandardElementSave>? standards = null,
+        IEnumerable<BehaviorSave>? behaviors = null)
+    {
+        GumProjectSave project = new GumProjectSave();
+        project.FullFileName = projectName + "." + GumProjectSave.ProjectExtension;
+
+        if (screens != null)
+        {
+            foreach (ScreenSave screen in screens)
+            {
+                project.Screens.Add(screen);
+                project.ScreenReferences.Add(new ElementReference { Name = screen.Name, ElementType = ElementType.Screen });
+            }
+        }
+        if (components != null)
+        {
+            foreach (ComponentSave component in components)
+            {
+                project.Components.Add(component);
+                project.ComponentReferences.Add(new ElementReference { Name = component.Name, ElementType = ElementType.Component });
+            }
+        }
+        if (standards != null)
+        {
+            foreach (StandardElementSave standard in standards)
+            {
+                project.StandardElements.Add(standard);
+                project.StandardElementReferences.Add(new ElementReference { Name = standard.Name, ElementType = ElementType.Standard });
+            }
+        }
+        if (behaviors != null)
+        {
+            foreach (BehaviorSave behavior in behaviors)
+            {
+                project.Behaviors.Add(behavior);
+                project.BehaviorReferences.Add(new BehaviorReference { Name = behavior.Name });
+            }
+        }
+
+        return project;
+    }
+
+    public static ScreenSave BuildScreen(string name)
+    {
+        ScreenSave screen = new ScreenSave { Name = name };
+        EnsureDefaultState(screen);
+        return screen;
+    }
+
+    public static ComponentSave BuildComponent(string name)
+    {
+        ComponentSave component = new ComponentSave { Name = name };
+        EnsureDefaultState(component);
+        return component;
+    }
+
+    public static StandardElementSave BuildStandard(string name)
+    {
+        StandardElementSave standard = new StandardElementSave { Name = name };
+        EnsureDefaultState(standard);
+        return standard;
+    }
+
+    public static BehaviorSave BuildBehavior(string name)
+    {
+        return new BehaviorSave { Name = name };
+    }
+
+    public static InstanceSave AddSpriteInstance(ElementSave element, string instanceName, string sourceFileRelativePath)
+    {
+        InstanceSave instance = new InstanceSave { Name = instanceName, BaseType = "Sprite", ParentContainer = element };
+        element.Instances.Add(instance);
+
+        StateSave state = element.DefaultState;
+        state.Variables.Add(new VariableSave
+        {
+            Name = instanceName + ".SourceFile",
+            Type = "string",
+            Value = sourceFileRelativePath,
+            IsFile = true,
+            SetsValue = true,
+        });
+        return instance;
+    }
+
+    public static InstanceSave AddTextInstanceWithFontCache(
+        ElementSave element,
+        string instanceName,
+        string fontName,
+        int fontSize,
+        int outlineThickness = 0,
+        bool useFontSmoothing = true,
+        bool isItalic = false,
+        bool isBold = false)
+    {
+        InstanceSave instance = new InstanceSave { Name = instanceName, BaseType = "Text", ParentContainer = element };
+        element.Instances.Add(instance);
+
+        StateSave state = element.DefaultState;
+        state.Variables.Add(new VariableSave { Name = instanceName + ".UseCustomFont", Type = "bool", Value = false, SetsValue = true });
+        state.Variables.Add(new VariableSave { Name = instanceName + ".Font", Type = "string", Value = fontName, IsFont = true, SetsValue = true });
+        state.Variables.Add(new VariableSave { Name = instanceName + ".FontSize", Type = "int", Value = fontSize, SetsValue = true });
+        state.Variables.Add(new VariableSave { Name = instanceName + ".OutlineThickness", Type = "int", Value = outlineThickness, SetsValue = true });
+        state.Variables.Add(new VariableSave { Name = instanceName + ".UseFontSmoothing", Type = "bool", Value = useFontSmoothing, SetsValue = true });
+        state.Variables.Add(new VariableSave { Name = instanceName + ".IsItalic", Type = "bool", Value = isItalic, SetsValue = true });
+        state.Variables.Add(new VariableSave { Name = instanceName + ".IsBold", Type = "bool", Value = isBold, SetsValue = true });
+        return instance;
+    }
+
+    public static InstanceSave AddTextInstanceWithCustomFont(
+        ElementSave element,
+        string instanceName,
+        string customFontFilePath)
+    {
+        InstanceSave instance = new InstanceSave { Name = instanceName, BaseType = "Text", ParentContainer = element };
+        element.Instances.Add(instance);
+
+        StateSave state = element.DefaultState;
+        state.Variables.Add(new VariableSave { Name = instanceName + ".UseCustomFont", Type = "bool", Value = true, SetsValue = true });
+        state.Variables.Add(new VariableSave { Name = instanceName + ".CustomFontFile", Type = "string", Value = customFontFilePath, IsFile = true, SetsValue = true });
+        return instance;
+    }
+
+    private static void EnsureDefaultState(ElementSave element)
+    {
+        if (element.States.Count == 0)
+        {
+            StateSave state = new StateSave { Name = "Default", ParentContainer = element };
+            element.States.Add(state);
+        }
+        else
+        {
+            element.States[0].ParentContainer = element;
+        }
+    }
+
+    public static byte[] EmptyXmlBytes => System.Text.Encoding.UTF8.GetBytes("<root />");
+}

--- a/Tests/Gum.Cli.Tests/PackCommandTests.cs
+++ b/Tests/Gum.Cli.Tests/PackCommandTests.cs
@@ -1,0 +1,231 @@
+using Gum.Bundle;
+using Shouldly;
+
+namespace Gum.Cli.Tests;
+
+public class PackCommandTests : IDisposable
+{
+    private readonly string _tempDirectory;
+
+    public PackCommandTests()
+    {
+        _tempDirectory = Path.Combine(Path.GetTempPath(), "GumCliPackTests_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDirectory);
+    }
+
+    [Fact]
+    public void Pack_default_inclusion_includes_core_fontcache_and_external_files()
+    {
+        string projectPath = CreateProjectWithSpriteAndFont("DefaultIncl");
+        string outputPath = Path.Combine(Path.GetDirectoryName(projectPath)!, "out.gumpkg");
+
+        CliTestHelper result = CliTestHelper.Run("pack", projectPath, "-o", outputPath);
+
+        result.ExitCode.ShouldBe(0);
+        Dictionary<string, byte[]> entries = ReadBundleEntries(outputPath);
+        entries.Keys.ShouldContain("Components/SpriteHolder.gucx");
+        entries.Keys.ShouldContain("Textures/bg.png");
+    }
+
+    [Fact]
+    public void Pack_exits_nonzero_when_referenced_file_missing()
+    {
+        string projectPath = CreateProjectWithMissingTexture("MissingFile");
+        string outputPath = Path.Combine(Path.GetDirectoryName(projectPath)!, "out.gumpkg");
+
+        CliTestHelper result = CliTestHelper.Run("pack", projectPath, "-o", outputPath);
+
+        result.ExitCode.ShouldBe(1);
+        File.Exists(outputPath).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Pack_is_deterministic_across_invocations()
+    {
+        string projectPath = CreateProjectWithSpriteAndFont("Deterministic");
+        string outputA = Path.Combine(Path.GetDirectoryName(projectPath)!, "a.gumpkg");
+        string outputB = Path.Combine(Path.GetDirectoryName(projectPath)!, "b.gumpkg");
+
+        CliTestHelper resultA = CliTestHelper.Run("pack", projectPath, "-o", outputA);
+        CliTestHelper resultB = CliTestHelper.Run("pack", projectPath, "-o", outputB);
+
+        resultA.ExitCode.ShouldBe(0);
+        resultB.ExitCode.ShouldBe(0);
+        byte[] bytesA = File.ReadAllBytes(outputA);
+        byte[] bytesB = File.ReadAllBytes(outputB);
+        bytesA.ShouldBe(bytesB);
+    }
+
+    [Fact]
+    public void Pack_lists_missing_files_to_stderr()
+    {
+        string projectPath = CreateProjectWithMissingTexture("MissingStderr");
+        string outputPath = Path.Combine(Path.GetDirectoryName(projectPath)!, "out.gumpkg");
+
+        CliTestHelper result = CliTestHelper.Run("pack", projectPath, "-o", outputPath);
+
+        result.ExitCode.ShouldBe(1);
+        result.StandardError.ShouldContain("Textures/missing.png");
+    }
+
+    [Fact]
+    public void Pack_output_starts_with_GUMP_magic_and_version_byte()
+    {
+        string projectPath = CreateCleanProject("MagicByte");
+        string outputPath = Path.Combine(Path.GetDirectoryName(projectPath)!, "out.gumpkg");
+
+        CliTestHelper result = CliTestHelper.Run("pack", projectPath, "-o", outputPath);
+
+        result.ExitCode.ShouldBe(0);
+        byte[] bytes = File.ReadAllBytes(outputPath);
+        bytes.Length.ShouldBeGreaterThanOrEqualTo(5);
+        bytes[0].ShouldBe((byte)0x47);
+        bytes[1].ShouldBe((byte)0x55);
+        bytes[2].ShouldBe((byte)0x4D);
+        bytes[3].ShouldBe((byte)0x50);
+        bytes[4].ShouldBe((byte)0x01);
+    }
+
+    [Fact]
+    public void Pack_with_core_only_excludes_fontcache_and_external()
+    {
+        string projectPath = CreateProjectWithSpriteAndFont("CoreOnly");
+        string outputPath = Path.Combine(Path.GetDirectoryName(projectPath)!, "out.gumpkg");
+
+        CliTestHelper result = CliTestHelper.Run("pack", projectPath, "-o", outputPath, "--include", "core");
+
+        result.ExitCode.ShouldBe(0);
+        Dictionary<string, byte[]> entries = ReadBundleEntries(outputPath);
+        entries.Keys.ShouldNotContain("Textures/bg.png");
+        entries.Keys.ShouldContain("Components/SpriteHolder.gucx");
+    }
+
+    [Fact]
+    public void Pack_writes_output_to_default_path_when_no_dash_o()
+    {
+        string projectPath = CreateCleanProject("DefaultOut");
+
+        CliTestHelper result = CliTestHelper.Run("pack", projectPath);
+
+        result.ExitCode.ShouldBe(0);
+        string expectedPath = Path.Combine(
+            Path.GetDirectoryName(projectPath)!,
+            Path.GetFileNameWithoutExtension(projectPath) + ".gumpkg");
+        File.Exists(expectedPath).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Pack_writes_output_to_specified_path_when_dash_o()
+    {
+        string projectPath = CreateCleanProject("SpecifiedOut");
+        string outputPath = Path.Combine(_tempDirectory, "custom-name.gumpkg");
+
+        CliTestHelper result = CliTestHelper.Run("pack", projectPath, "-o", outputPath);
+
+        result.ExitCode.ShouldBe(0);
+        File.Exists(outputPath).ShouldBeTrue();
+    }
+
+    /// <summary>
+    /// Creates a minimal project on disk (just the .gumx file with no element references)
+    /// and returns the .gumx path. Avoids the gumcli "new" template which pulls in standard
+    /// elements with default font references that show up as missing FontCache files.
+    /// </summary>
+    private string CreateCleanProject(string name)
+    {
+        string projectDir = Path.Combine(_tempDirectory, name);
+        Directory.CreateDirectory(projectDir);
+        string filePath = Path.Combine(projectDir, name + ".gumx");
+
+        const string gumxContent =
+            """
+            <?xml version="1.0" encoding="utf-8"?>
+            <GumProjectSave xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+            </GumProjectSave>
+            """;
+        File.WriteAllText(filePath, gumxContent);
+        return filePath;
+    }
+
+    /// <summary>
+    /// Creates a project containing a component with a sprite instance pointing at an existing texture file.
+    /// </summary>
+    private string CreateProjectWithSpriteAndFont(string name)
+    {
+        string filePath = CreateCleanProject(name);
+        string projectDir = Path.GetDirectoryName(filePath)!;
+
+        WriteSpriteHolderComponent(projectDir, sourceFileRelative: "Textures/bg.png");
+
+        string textureDir = Path.Combine(projectDir, "Textures");
+        Directory.CreateDirectory(textureDir);
+        File.WriteAllBytes(Path.Combine(textureDir, "bg.png"), new byte[] { 0x89, 0x50, 0x4E, 0x47 });
+
+        AppendComponentReference(filePath, "SpriteHolder");
+        return filePath;
+    }
+
+    /// <summary>
+    /// Creates a project that references a texture file that does not exist on disk.
+    /// </summary>
+    private string CreateProjectWithMissingTexture(string name)
+    {
+        string filePath = CreateCleanProject(name);
+        string projectDir = Path.GetDirectoryName(filePath)!;
+
+        WriteSpriteHolderComponent(projectDir, sourceFileRelative: "Textures/missing.png");
+
+        AppendComponentReference(filePath, "SpriteHolder");
+        return filePath;
+    }
+
+    private static void WriteSpriteHolderComponent(string projectDir, string sourceFileRelative)
+    {
+        string componentDir = Path.Combine(projectDir, "Components");
+        Directory.CreateDirectory(componentDir);
+
+        string componentXml = $$"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <ComponentSave xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+              <Name>SpriteHolder</Name>
+              <BaseType>Container</BaseType>
+              <State>
+                <Name>Default</Name>
+                <Variable IsFile="true" Type="string" Name="Sprite.SourceFile" SetsValue="true">
+                  <Value xsi:type="xsd:string">{{sourceFileRelative}}</Value>
+                </Variable>
+              </State>
+              <Instance Name="Sprite" BaseType="Sprite" />
+            </ComponentSave>
+            """;
+        File.WriteAllText(Path.Combine(componentDir, "SpriteHolder.gucx"), componentXml);
+    }
+
+    private static void AppendComponentReference(string gumxPath, string componentName)
+    {
+        string gumxContent = File.ReadAllText(gumxPath);
+        string componentRef = $"  <ComponentReference Name=\"{componentName}\" />";
+        gumxContent = gumxContent.Replace("</GumProjectSave>", componentRef + "\n</GumProjectSave>");
+        File.WriteAllText(gumxPath, gumxContent);
+    }
+
+    private static Dictionary<string, byte[]> ReadBundleEntries(string bundlePath)
+    {
+        using FileStream stream = File.OpenRead(bundlePath);
+        GumBundle bundle = GumBundleReader.Read(stream);
+        return new Dictionary<string, byte[]>(bundle.Entries);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDirectory))
+        {
+            try
+            {
+                Directory.Delete(_tempDirectory, recursive: true);
+            }
+            catch (IOException) { }
+            catch (UnauthorizedAccessException) { }
+        }
+    }
+}

--- a/Tests/Gum.ProjectServices.Tests/ObjectFinderFileReferencesTests.cs
+++ b/Tests/Gum.ProjectServices.Tests/ObjectFinderFileReferencesTests.cs
@@ -1,0 +1,265 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Gum.DataTypes;
+using Gum.DataTypes.Variables;
+using Gum.Managers;
+using RenderingLibrary.Graphics.Fonts;
+using Shouldly;
+using ToolsUtilities;
+
+namespace Gum.ProjectServices.Tests;
+
+/// <summary>
+/// Characterization tests for <see cref="ObjectFinder.GetAllFilesInProject"/> and
+/// <see cref="ObjectFinder.GetFilesReferencedBy"/>. Pin down current behavior so the
+/// upcoming consolidation onto <c>GumProjectDependencyWalker</c> can be verified safe.
+/// </summary>
+public class ObjectFinderFileReferencesTests : BaseTestClass
+{
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    /// <summary>
+    /// Project directory used in characterization tests. The existing implementation
+    /// derives the project directory from <c>FullFileName</c> via <c>FileManager.GetDirectory</c>,
+    /// which appends a trailing slash. Using a forward-slash absolute-style path keeps the
+    /// test platform-independent and matches the format strings the existing impl emits.
+    /// </summary>
+    private const string FakeProjectDirectory = "C:/FakeGumProject/";
+    private const string FakeProjectFile = FakeProjectDirectory + "MyProject.gumx";
+
+    private void SetProjectFullFileName()
+    {
+        Project.FullFileName = FakeProjectFile;
+        ObjectFinder.Self.GumProjectSave = Project;
+    }
+
+    private static ScreenSave BuildScreen(string name)
+    {
+        ScreenSave screen = new ScreenSave { Name = name };
+        StateSave defaultState = new StateSave { Name = "Default", ParentContainer = screen };
+        screen.States.Add(defaultState);
+        return screen;
+    }
+
+    private static ComponentSave BuildComponent(string name)
+    {
+        ComponentSave component = new ComponentSave { Name = name };
+        StateSave defaultState = new StateSave { Name = "Default", ParentContainer = component };
+        component.States.Add(defaultState);
+        return component;
+    }
+
+    private static InstanceSave AddSpriteInstance(ElementSave element, string instanceName, string sourceFileRelativePath)
+    {
+        InstanceSave instance = new InstanceSave { Name = instanceName, BaseType = "Sprite", ParentContainer = element };
+        element.Instances.Add(instance);
+
+        StateSave state = element.DefaultState;
+        state.Variables.Add(new VariableSave
+        {
+            Name = instanceName + ".SourceFile",
+            Type = "string",
+            Value = sourceFileRelativePath,
+            IsFile = true,
+            SetsValue = true,
+        });
+        return instance;
+    }
+
+    private static InstanceSave AddTextInstanceWithDefaultFont(ElementSave element, string instanceName, string fontName, int fontSize)
+    {
+        InstanceSave instance = new InstanceSave { Name = instanceName, BaseType = "Text", ParentContainer = element };
+        element.Instances.Add(instance);
+
+        StateSave state = element.DefaultState;
+        state.Variables.Add(new VariableSave { Name = instanceName + ".UseCustomFont", Type = "bool", Value = false, SetsValue = true });
+        state.Variables.Add(new VariableSave { Name = instanceName + ".Font", Type = "string", Value = fontName, IsFont = true, SetsValue = true });
+        state.Variables.Add(new VariableSave { Name = instanceName + ".FontSize", Type = "int", Value = fontSize, SetsValue = true });
+        state.Variables.Add(new VariableSave { Name = instanceName + ".OutlineThickness", Type = "int", Value = 0, SetsValue = true });
+        state.Variables.Add(new VariableSave { Name = instanceName + ".UseFontSmoothing", Type = "bool", Value = true, SetsValue = true });
+        state.Variables.Add(new VariableSave { Name = instanceName + ".IsItalic", Type = "bool", Value = false, SetsValue = true });
+        state.Variables.Add(new VariableSave { Name = instanceName + ".IsBold", Type = "bool", Value = false, SetsValue = true });
+        return instance;
+    }
+
+    private static InstanceSave AddTextInstanceWithCustomFont(ElementSave element, string instanceName, string customFontFilePath)
+    {
+        InstanceSave instance = new InstanceSave { Name = instanceName, BaseType = "Text", ParentContainer = element };
+        element.Instances.Add(instance);
+
+        StateSave state = element.DefaultState;
+        state.Variables.Add(new VariableSave { Name = instanceName + ".UseCustomFont", Type = "bool", Value = true, SetsValue = true });
+        state.Variables.Add(new VariableSave { Name = instanceName + ".CustomFontFile", Type = "string", Value = customFontFilePath, IsFile = true, SetsValue = true });
+        return instance;
+    }
+
+    private static InstanceSave AddComponentInstance(ElementSave element, string instanceName, string baseComponentName)
+    {
+        InstanceSave instance = new InstanceSave { Name = instanceName, BaseType = baseComponentName, ParentContainer = element };
+        element.Instances.Add(instance);
+        return instance;
+    }
+
+    /// <summary>
+    /// Standardizes a path the same way <c>FilePath.StandardizedCaseSensitive</c> does for
+    /// already-absolute paths: forward slashes, no leading "./". Used to build expectations
+    /// that match the historical (existing impl) output format.
+    /// </summary>
+    private static string Standardize(string absolutePath)
+    {
+        return new FilePath(absolutePath).StandardizedCaseSensitive;
+    }
+
+    // -----------------------------------------------------------------------
+    // Tests (alphabetical)
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void GetAllFilesInProject_includes_custom_font_file_when_UseCustomFont_is_true()
+    {
+        const string customFontPath = FakeProjectDirectory + "Fonts/MyCustom.ttf";
+
+        ScreenSave screen = BuildScreen("MainMenu");
+        AddTextInstanceWithCustomFont(screen, "Text1", customFontPath);
+        Project.Screens.Add(screen);
+        SetProjectFullFileName();
+
+        IEnumerable<string> files = ObjectFinder.Self.GetAllFilesInProject();
+
+        files.ShouldContain(Standardize(customFontPath));
+    }
+
+    [Fact]
+    public void GetAllFilesInProject_includes_font_cache_fnt_path_for_text_with_default_font_settings()
+    {
+        ScreenSave screen = BuildScreen("MainMenu");
+        AddTextInstanceWithDefaultFont(screen, "Text1", "Arial", 18);
+        Project.Screens.Add(screen);
+        SetProjectFullFileName();
+
+        string fntRelative = BmfcSave.GetFontCacheFileNameFor(
+            fontSize: 18, fontName: "Arial", outline: 0, useFontSmoothing: true, isItalic: false, isBold: false);
+        string expectedFntAbsolute = Standardize(FakeProjectDirectory + fntRelative);
+
+        IEnumerable<string> files = ObjectFinder.Self.GetAllFilesInProject();
+
+        files.ShouldContain(expectedFntAbsolute);
+    }
+
+    [Fact]
+    public void GetAllFilesInProject_includes_gucx_paths_for_component_instances()
+    {
+        ComponentSave button = BuildComponent("Button");
+        Project.Components.Add(button);
+
+        ScreenSave screen = BuildScreen("MainMenu");
+        AddComponentInstance(screen, "MyButton", "Button");
+        Project.Screens.Add(screen);
+        SetProjectFullFileName();
+
+        IEnumerable<string> files = ObjectFinder.Self.GetAllFilesInProject();
+
+        string expected = Standardize(FakeProjectDirectory + "Components/Button." + button.FileExtension);
+        files.ShouldContain(expected);
+    }
+
+    [Fact]
+    public void GetAllFilesInProject_includes_referenced_textures_via_SourceFile()
+    {
+        const string spritePath = FakeProjectDirectory + "Textures/bg.png";
+
+        ScreenSave screen = BuildScreen("MainMenu");
+        AddSpriteInstance(screen, "Sprite1", spritePath);
+        Project.Screens.Add(screen);
+        SetProjectFullFileName();
+
+        IEnumerable<string> files = ObjectFinder.Self.GetAllFilesInProject();
+
+        files.ShouldContain(Standardize(spritePath));
+    }
+
+    [Fact]
+    public void GetAllFilesInProject_returns_absolute_paths_not_relative()
+    {
+        const string spritePath = FakeProjectDirectory + "Textures/bg.png";
+
+        ScreenSave screen = BuildScreen("MainMenu");
+        AddSpriteInstance(screen, "Sprite1", spritePath);
+        Project.Screens.Add(screen);
+        SetProjectFullFileName();
+
+        IEnumerable<string> files = ObjectFinder.Self.GetAllFilesInProject();
+
+        foreach (string file in files)
+        {
+            // Absolute on Windows means rooted (drive letter) or starts with /.
+            // The existing impl always returns paths that FilePath considers rooted.
+            Path.IsPathRooted(file).ShouldBeTrue($"Expected absolute path, got '{file}'");
+        }
+    }
+
+    [Fact]
+    public void GetAllFilesInProject_returns_distinct_paths_when_same_file_referenced_multiply()
+    {
+        const string sharedTexture = FakeProjectDirectory + "Textures/shared.png";
+
+        ScreenSave screenA = BuildScreen("ScreenA");
+        AddSpriteInstance(screenA, "Sprite1", sharedTexture);
+        AddSpriteInstance(screenA, "Sprite2", sharedTexture);
+
+        ScreenSave screenB = BuildScreen("ScreenB");
+        AddSpriteInstance(screenB, "Sprite1", sharedTexture);
+
+        Project.Screens.Add(screenA);
+        Project.Screens.Add(screenB);
+        SetProjectFullFileName();
+
+        List<string> files = ObjectFinder.Self.GetAllFilesInProject().ToList();
+
+        string expected = Standardize(sharedTexture);
+        files.Count(f => f == expected).ShouldBe(1);
+    }
+
+    [Fact]
+    public void GetFilesReferencedBy_excludes_files_referenced_only_by_other_elements()
+    {
+        const string ownTexture = FakeProjectDirectory + "Textures/own.png";
+        const string otherTexture = FakeProjectDirectory + "Textures/other.png";
+
+        ScreenSave screenA = BuildScreen("ScreenA");
+        AddSpriteInstance(screenA, "Sprite1", ownTexture);
+
+        ScreenSave screenB = BuildScreen("ScreenB");
+        AddSpriteInstance(screenB, "Sprite1", otherTexture);
+
+        Project.Screens.Add(screenA);
+        Project.Screens.Add(screenB);
+        SetProjectFullFileName();
+
+        List<string> files = ObjectFinder.Self.GetFilesReferencedBy(screenA);
+
+        files.ShouldContain(Standardize(ownTexture));
+        files.ShouldNotContain(Standardize(otherTexture));
+    }
+
+    [Fact]
+    public void GetFilesReferencedBy_returns_absolute_paths()
+    {
+        const string spritePath = FakeProjectDirectory + "Textures/bg.png";
+
+        ScreenSave screen = BuildScreen("MainMenu");
+        AddSpriteInstance(screen, "Sprite1", spritePath);
+        Project.Screens.Add(screen);
+        SetProjectFullFileName();
+
+        List<string> files = ObjectFinder.Self.GetFilesReferencedBy(screen);
+
+        foreach (string file in files)
+        {
+            Path.IsPathRooted(file).ShouldBeTrue($"Expected absolute path, got '{file}'");
+        }
+    }
+}

--- a/Tools/Gum.Cli/Commands/PackCommand.cs
+++ b/Tools/Gum.Cli/Commands/PackCommand.cs
@@ -1,0 +1,184 @@
+using System;
+using System.Collections.Generic;
+using System.CommandLine;
+using System.CommandLine.Invocation;
+using System.IO;
+using Gum.Bundle;
+using Gum.ProjectServices;
+
+namespace Gum.Cli.Commands;
+
+/// <summary>
+/// Defines the <c>gumcli pack</c> command which loads a project, walks its dependencies,
+/// and writes a `.gumpkg` bundle containing the requested file categories.
+/// </summary>
+public static class PackCommand
+{
+    /// <summary>
+    /// Creates the <c>pack</c> command definition.
+    /// </summary>
+    public static Command Create()
+    {
+        var projectArgument = new Argument<string>(
+            "project",
+            "Path to the .gumx project file.");
+
+        var outputOption = new Option<string?>(
+            aliases: new[] { "--output", "-o" },
+            getDefaultValue: () => null,
+            description: "Output path for the .gumpkg bundle. Defaults to <ProjectName>.gumpkg next to the .gumx.");
+
+        var includeOption = new Option<string>(
+            aliases: new[] { "--include" },
+            getDefaultValue: () => "core,fontcache,external",
+            description: "Comma-separated categories to include. Valid values: core, fontcache, external.");
+
+        var command = new Command("pack", "Pack a Gum project into a .gumpkg bundle.")
+        {
+            projectArgument,
+            outputOption,
+            includeOption
+        };
+
+        command.SetHandler((InvocationContext context) =>
+        {
+            string projectPath = context.ParseResult.GetValueForArgument(projectArgument);
+            string? outputPath = context.ParseResult.GetValueForOption(outputOption);
+            string includeFlags = context.ParseResult.GetValueForOption(includeOption) ?? "core,fontcache,external";
+            context.ExitCode = Execute(projectPath, outputPath, includeFlags);
+        });
+
+        return command;
+    }
+
+    private static int Execute(string projectPath, string? outputPath, string includeFlags)
+    {
+        string fullPath = Path.GetFullPath(projectPath);
+
+        IProjectLoader loader = new ProjectLoader();
+        ProjectLoadResult loadResult = loader.Load(fullPath);
+
+        if (!loadResult.Success)
+        {
+            Console.Error.WriteLine(loadResult.ErrorMessage);
+            return 2;
+        }
+
+        if (!TryParseInclusion(includeFlags, out GumBundleInclusion inclusion, out string? parseError))
+        {
+            Console.Error.WriteLine(parseError);
+            return 2;
+        }
+
+        string projectDirectory = Path.GetDirectoryName(fullPath) ?? "";
+
+        string resolvedOutputPath = outputPath != null
+            ? Path.GetFullPath(outputPath)
+            : Path.Combine(projectDirectory, Path.GetFileNameWithoutExtension(fullPath) + ".gumpkg");
+
+        GumProjectDependencyWalker walker = new GumProjectDependencyWalker();
+        WalkResult walkResult = walker.Walk(loadResult.Project!, projectDirectory, inclusion);
+
+        if (walkResult.MissingFiles.Count > 0)
+        {
+            foreach (DependencyWarning warning in walkResult.MissingFiles)
+            {
+                if (string.IsNullOrEmpty(warning.ReferencedFromElementName))
+                {
+                    Console.Error.WriteLine($"missing: {warning.ReferencedPath}");
+                }
+                else
+                {
+                    Console.Error.WriteLine($"missing: {warning.ReferencedPath} (referenced from: {warning.ReferencedFromElementName})");
+                }
+            }
+            return 1;
+        }
+
+        LooseFileGumFileProvider provider = new LooseFileGumFileProvider(projectDirectory);
+        List<(string path, byte[] content)> entries = new List<(string, byte[])>();
+        long uncompressedBytes = 0;
+
+        foreach (string relativePath in walkResult.AllIncludedFiles)
+        {
+            byte[] bytes;
+            try
+            {
+                using Stream stream = provider.OpenRead(relativePath);
+                using MemoryStream memory = new MemoryStream();
+                stream.CopyTo(memory);
+                bytes = memory.ToArray();
+            }
+            catch (FileNotFoundException)
+            {
+                Console.Error.WriteLine($"missing: {relativePath}");
+                return 1;
+            }
+            entries.Add((relativePath, bytes));
+            uncompressedBytes += bytes.Length;
+        }
+
+        using (FileStream output = File.Create(resolvedOutputPath))
+        {
+            GumBundleWriter.Write(output, entries);
+        }
+
+        long compressedBytes = new FileInfo(resolvedOutputPath).Length;
+        double ratio = uncompressedBytes == 0 ? 0.0 : (double)compressedBytes / uncompressedBytes * 100.0;
+
+        Console.WriteLine($"Packed {entries.Count} files into {resolvedOutputPath}");
+        Console.WriteLine($"  Core:          {walkResult.CoreFiles.Count}");
+        Console.WriteLine($"  FontCache:     {walkResult.FontCacheFiles.Count}");
+        Console.WriteLine($"  External:      {walkResult.ExternalFiles.Count}");
+        Console.WriteLine($"Uncompressed:    {uncompressedBytes} bytes");
+        Console.WriteLine($"Compressed:      {compressedBytes} bytes");
+        Console.WriteLine($"Ratio:           {ratio:F1}%");
+
+        return 0;
+    }
+
+    private static bool TryParseInclusion(string includeFlags, out GumBundleInclusion inclusion, out string? error)
+    {
+        inclusion = 0;
+        error = null;
+
+        if (string.IsNullOrWhiteSpace(includeFlags))
+        {
+            error = "--include must specify at least one category. Valid values: core, fontcache, external.";
+            return false;
+        }
+
+        string[] tokens = includeFlags.Split(',');
+        foreach (string raw in tokens)
+        {
+            string token = raw.Trim().ToLowerInvariant();
+            if (token.Length == 0)
+            {
+                continue;
+            }
+            switch (token)
+            {
+                case "core":
+                    inclusion |= GumBundleInclusion.Core;
+                    break;
+                case "fontcache":
+                    inclusion |= GumBundleInclusion.FontCache;
+                    break;
+                case "external":
+                    inclusion |= GumBundleInclusion.ExternalFiles;
+                    break;
+                default:
+                    error = $"Unknown --include value '{token}'. Valid values: core, fontcache, external.";
+                    return false;
+            }
+        }
+
+        if (inclusion == 0)
+        {
+            error = "--include must specify at least one category. Valid values: core, fontcache, external.";
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/Tools/Gum.Cli/Program.cs
+++ b/Tools/Gum.Cli/Program.cs
@@ -22,6 +22,7 @@ public class Program
 
         rootCommand.AddCommand(NewCommand.Create());
         rootCommand.AddCommand(CheckCommand.Create());
+        rootCommand.AddCommand(PackCommand.Create());
         rootCommand.AddCommand(CodegenCommand.Create());
         rootCommand.AddCommand(CodegenInitCommand.Create());
         rootCommand.AddCommand(FontsCommand.Create());

--- a/ToolsUtilities/FileManager.cs
+++ b/ToolsUtilities/FileManager.cs
@@ -756,7 +756,12 @@ namespace ToolsUtilities
 #else
                 if (CustomGetStreamFromFile != null)
                 {
-                    return CustomGetStreamFromFile(fileName);
+                    var customStream = CustomGetStreamFromFile(fileName);
+                    if (customStream == null)
+                    {
+                        throw new FileNotFoundException($"CustomGetStreamFromFile returned null for {fileName}", fileName);
+                    }
+                    return customStream;
                 }
                 else
                 {


### PR DESCRIPTION
Collapses N-file project loads (one HTTP request per .gucx/.gusx/.fnt/.png)
  into a single brotli-compressed tar. Primary win: web/Blazor first-load,
  where ~70 requests in real projects become 1.

  - Format: 5-byte header (GUMP magic + version) + brotli(tar). Reader/writer in GumCommon/Bundle/.
  - IGumFileProvider abstraction with loose-file and bundle implementations, case-sensitive at API layer to catch dev-time bugs that would explode on web.
  - GumProjectDependencyWalker with [Flags] inclusion (Core | FontCache | ExternalFiles). ObjectFinder.GetAllFilesInProject / GetFilesReferencedBy now delegate to it (single source of truth; characterization tests pin the contract).
  - gumcli pack <Project.gumx> [-o ...] [--include ...].
  - MonoGameGum.GumService auto-detects .gumpkg next to .gumx via FileManager.CustomGetStreamFromFile. Loose wins when both present so hot reload stays unaffected. No change to GumProjectSave.Load signature.
  - Fixes pre-existing NRE in FileManager.GetStreamForFile when a custom hook returned null.

  Test totals: 56 in Gum.Bundle.Tests, 4 integration tests in MonoGameGum.Tests,
  8 ObjectFinder characterization tests, 8 pack command tests. Both solutions
  build clean.