### PR TITLE
Fixed InvisibleRenderable clone not properly setting parent to null o…

### DIFF
--- a/RenderingLibrary/Graphics/InvisibleRenderable.cs
+++ b/RenderingLibrary/Graphics/InvisibleRenderable.cs
@@ -28,7 +28,7 @@ public class InvisibleRenderable : RenderableBase, ICloneable, IRenderableIpso
     public InvisibleRenderable Clone()
     {
         var newInstance = (InvisibleRenderable)this.MemberwiseClone();
-        ((IRenderableIpso)this).SetParentDirect(null);
+        ((IRenderableIpso)newInstance).SetParentDirect(null);
 
         newInstance._children = new ();
 

--- a/Runtimes/RaylibGum/Input/Keyboard.cs
+++ b/Runtimes/RaylibGum/Input/Keyboard.cs
@@ -241,6 +241,16 @@ public class Keyboard : IInputReceiverKeyboard
                 _lastStringTyped += char.ConvertFromUtf32(codepoint);
                 codepoint = GetCharPressed();
             }
+
+            // Raylib's GetCharPressed only emits printable codepoints, so Enter never arrives
+            // as a character. MonoGame's Keyboard.GetStringTyped injects '\n' on Enter (see
+            // HandleNumPadEnter), and TextBox.HandleCharEntered relies on that for AcceptsReturn
+            // / multi-line input. Mirror the behavior here so multi-line TextBoxes work in raylib.
+            if (IsKeyPressed(KeyboardKey.Enter) || IsKeyPressedRepeat(KeyboardKey.Enter)
+                || IsKeyPressed(KeyboardKey.KpEnter) || IsKeyPressedRepeat(KeyboardKey.KpEnter))
+            {
+                _lastStringTyped += '\n';
+            }
         }
 
 

--- a/Runtimes/RaylibGum/Renderables/NineSlice.cs
+++ b/Runtimes/RaylibGum/Renderables/NineSlice.cs
@@ -11,8 +11,18 @@ using ToolsUtilitiesStandard.Helpers;
 using static Raylib_cs.Raylib;
 
 namespace Gum.Renderables;
-public class NineSlice : RenderableBase, ITextureCoordinate
+public class NineSlice : RenderableBase, ITextureCoordinate, ICloneable
 {
+    public NineSlice Clone()
+    {
+        var newInstance = (NineSlice)this.MemberwiseClone();
+        ((IRenderableIpso)newInstance).SetParentDirect(null);
+        newInstance._children = new();
+        return newInstance;
+    }
+
+    object ICloneable.Clone() => Clone();
+
     public Texture2D? Texture { get; set; }
 
     public Raylib_cs.Rectangle? SourceRectangle

--- a/Runtimes/RaylibGum/Renderables/Text.cs
+++ b/Runtimes/RaylibGum/Renderables/Text.cs
@@ -68,8 +68,18 @@ public enum TextPositionRoundingMode
 
 
 public class Text : IVisible, IRenderableIpso,
-    IWrappedText
+    IWrappedText, ICloneable
 {
+    public Text Clone()
+    {
+        var newInstance = (Text)this.MemberwiseClone();
+        newInstance.mParent = null;
+        newInstance.mChildren = new();
+        return newInstance;
+    }
+
+    object ICloneable.Clone() => Clone();
+
     /// <summary>
     /// The line height as defined by the font, ignoring FontScale.
     /// </summary>

--- a/Runtimes/SkiaGum/Renderables/NineSlice.cs
+++ b/Runtimes/SkiaGum/Renderables/NineSlice.cs
@@ -1,11 +1,16 @@
 ﻿using Gum;
 using RenderingLibrary;
 using RenderingLibrary.Graphics;
+using System;
 
 namespace SkiaGum.Renderables;
 
-public class NineSlice : IRenderable
+public class NineSlice : IRenderable, ICloneable
 {
+    public NineSlice Clone() => (NineSlice)this.MemberwiseClone();
+
+    object ICloneable.Clone() => Clone();
+
     public BlendState BlendState => BlendState.NonPremultiplied;
 
     public bool Wrap => false;

--- a/Runtimes/SokolGum/Renderables/NineSlice.cs
+++ b/Runtimes/SokolGum/Renderables/NineSlice.cs
@@ -22,8 +22,18 @@ namespace Gum.Renderables;
 /// expose <c>AnimationChains</c> on their SpriteRuntime but not their
 /// NineSliceRuntime yet.
 /// </summary>
-public sealed class NineSlice : RenderableBase, ITextureCoordinate, IAnimatable
+public sealed class NineSlice : RenderableBase, ITextureCoordinate, IAnimatable, ICloneable
 {
+    public NineSlice Clone()
+    {
+        var newInstance = (NineSlice)this.MemberwiseClone();
+        ((IRenderableIpso)newInstance).SetParentDirect(null);
+        newInstance._children = new();
+        return newInstance;
+    }
+
+    object ICloneable.Clone() => Clone();
+
     public Texture2D? Texture { get; set; }
     public Rectangle? SourceRectangle { get; set; }
     public Color Color = Color.White;

--- a/Runtimes/SokolGum/Renderables/Text.cs
+++ b/Runtimes/SokolGum/Renderables/Text.cs
@@ -43,8 +43,18 @@ public enum TextPositionRoundingMode
 /// render callbacks emit into sokol_gp, so text batches alongside other
 /// renderables in scene-graph order.
 /// </summary>
-public sealed class Text : RenderableBase, IText, IWrappedText
+public sealed class Text : RenderableBase, IText, IWrappedText, ICloneable
 {
+    public Text Clone()
+    {
+        var newInstance = (Text)this.MemberwiseClone();
+        ((IRenderableIpso)newInstance).SetParentDirect(null);
+        newInstance._children = new();
+        return newInstance;
+    }
+
+    object ICloneable.Clone() => Clone();
+
     /// <summary>
     /// Process-wide default measurer wired by <see cref="SokolGum.SystemManagers.Initialize"/>.
     /// Tests can swap in a <c>FakeTextMeasurer</c> without touching fontstash.

--- a/Tests/RaylibGum.Tests/Forms/TextBoxTests.cs
+++ b/Tests/RaylibGum.Tests/Forms/TextBoxTests.cs
@@ -1,0 +1,57 @@
+using Gum.Forms;
+using Gum.Forms.Controls;
+using RenderingLibrary;
+using Shouldly;
+
+namespace RaylibGum.Tests.Forms;
+
+/// <summary>
+/// Regression coverage for Raylib-side TextBox bugs. Specifically guards against the NRE
+/// in <c>TextBoxBase.UpdateSelectionStartEnds</c> that fires when a multi-line / wrapped
+/// TextBox tries to render its selection but <c>selectionTemplate</c> was never assigned
+/// because the underlying renderable did not implement <see cref="System.ICloneable"/>.
+///
+/// Uses V3 default visuals because (a) V3's <c>SelectionInstance</c> is a NineSlice — the
+/// renderable that exposed the missing <c>ICloneable</c> contract — and (b) raylib's V2
+/// default templates don't register TextBox at all (gated <c>#if XNALIKE || FRB</c>),
+/// so <c>new TextBox()</c> would otherwise produce a null Visual.
+/// </summary>
+public class TextBoxTests : BaseTestClass
+{
+    public TextBoxTests()
+    {
+        // Layered on top of TestAssemblyInitialize's V2 setup. TryAdd-style behavior in
+        // InitializeDefaults means V2 registrations stick; only TextBox (unregistered in
+        // V2 for raylib) and V3-specific Styling.ActiveStyle get added.
+        FormsUtilities.InitializeDefaults(SystemManagers.Default, DefaultVisualsVersion.V3);
+    }
+
+    public override void Dispose()
+    {
+        FrameworkElement.DefaultFormsTemplates.Remove(typeof(TextBox));
+        base.Dispose();
+        TestAssemblyInitialize.ApplyDefaultTestState();
+    }
+
+    [Fact]
+    public void SelectAll_DoesNotThrow_WhenAcceptsReturnIsTrue()
+    {
+        var textBox = new TextBox();
+        textBox.Visual.ShouldNotBeNull();
+        textBox.AcceptsReturn = true;
+        textBox.Text = "line one\nline two";
+
+        Should.NotThrow(() => textBox.SelectAll());
+    }
+
+    [Fact]
+    public void SelectAll_DoesNotThrow_WhenTextWrappingIsWrap()
+    {
+        var textBox = new TextBox();
+        textBox.Visual.ShouldNotBeNull();
+        textBox.TextWrapping = TextWrapping.Wrap;
+        textBox.Text = "some text that may wrap depending on width";
+
+        Should.NotThrow(() => textBox.SelectAll());
+    }
+}

--- a/Tests/RaylibGum.Tests/Inputs/KeyboardTests.cs
+++ b/Tests/RaylibGum.Tests/Inputs/KeyboardTests.cs
@@ -16,6 +16,121 @@ namespace RaylibGum.Tests.Inputs;
 public class KeyboardTests : BaseTestClass
 {
     [Fact]
+    public void GetStringTyped_AppendsNewline_WhenEnterIsPressed()
+    {
+        var sut = new Mock<Keyboard>();
+        sut.Protected()
+            .Setup<int>("GetCharPressed")
+            .Returns(0);
+        sut.Protected()
+            .Setup<bool>("IsKeyPressed", ItExpr.IsAny<KeyboardKey>())
+            .Returns((KeyboardKey k) => k == KeyboardKey.Enter);
+        sut.Protected()
+            .Setup<bool>("IsKeyPressedRepeat", ItExpr.IsAny<KeyboardKey>())
+            .Returns(false);
+
+        sut.Object.Activity(1);
+
+        sut.Object.GetStringTyped().ShouldBe("\n");
+    }
+
+    [Fact]
+    public void GetStringTyped_AppendsNewline_WhenEnterRepeats()
+    {
+        var sut = new Mock<Keyboard>();
+        sut.Protected()
+            .Setup<int>("GetCharPressed")
+            .Returns(0);
+        sut.Protected()
+            .Setup<bool>("IsKeyPressed", ItExpr.IsAny<KeyboardKey>())
+            .Returns(false);
+        sut.Protected()
+            .Setup<bool>("IsKeyPressedRepeat", ItExpr.IsAny<KeyboardKey>())
+            .Returns((KeyboardKey k) => k == KeyboardKey.Enter);
+
+        sut.Object.Activity(1);
+
+        sut.Object.GetStringTyped().ShouldBe("\n");
+    }
+
+    [Fact]
+    public void GetStringTyped_AppendsNewline_WhenKpEnterIsPressed()
+    {
+        var sut = new Mock<Keyboard>();
+        sut.Protected()
+            .Setup<int>("GetCharPressed")
+            .Returns(0);
+        sut.Protected()
+            .Setup<bool>("IsKeyPressed", ItExpr.IsAny<KeyboardKey>())
+            .Returns((KeyboardKey k) => k == KeyboardKey.KpEnter);
+        sut.Protected()
+            .Setup<bool>("IsKeyPressedRepeat", ItExpr.IsAny<KeyboardKey>())
+            .Returns(false);
+
+        sut.Object.Activity(1);
+
+        sut.Object.GetStringTyped().ShouldBe("\n");
+    }
+
+    [Fact]
+    public void GetStringTyped_AppendsNewlineAfterCharacters_WhenEnterIsPressed()
+    {
+        var sut = new Mock<Keyboard>();
+        var codepoints = new Queue<int>(new[] { 72, 105, 0 });
+        sut.Protected()
+            .Setup<int>("GetCharPressed")
+            .Returns(() => codepoints.Count > 0 ? codepoints.Dequeue() : 0);
+        sut.Protected()
+            .Setup<bool>("IsKeyPressed", ItExpr.IsAny<KeyboardKey>())
+            .Returns((KeyboardKey k) => k == KeyboardKey.Enter);
+        sut.Protected()
+            .Setup<bool>("IsKeyPressedRepeat", ItExpr.IsAny<KeyboardKey>())
+            .Returns(false);
+
+        sut.Object.Activity(1);
+
+        sut.Object.GetStringTyped().ShouldBe("Hi\n");
+    }
+
+    [Fact]
+    public void GetStringTyped_AppendsSingleNewline_WhenEnterAndKpEnterBothPressed()
+    {
+        var sut = new Mock<Keyboard>();
+        sut.Protected()
+            .Setup<int>("GetCharPressed")
+            .Returns(0);
+        sut.Protected()
+            .Setup<bool>("IsKeyPressed", ItExpr.IsAny<KeyboardKey>())
+            .Returns((KeyboardKey k) => k == KeyboardKey.Enter || k == KeyboardKey.KpEnter);
+        sut.Protected()
+            .Setup<bool>("IsKeyPressedRepeat", ItExpr.IsAny<KeyboardKey>())
+            .Returns(false);
+
+        sut.Object.Activity(1);
+
+        sut.Object.GetStringTyped().ShouldBe("\n");
+    }
+
+    [Fact]
+    public void GetStringTyped_DoesNotAppendNewline_WhenEnterIsNotPressed()
+    {
+        var sut = new Mock<Keyboard>();
+        sut.Protected()
+            .Setup<int>("GetCharPressed")
+            .Returns(0);
+        sut.Protected()
+            .Setup<bool>("IsKeyPressed", ItExpr.IsAny<KeyboardKey>())
+            .Returns(false);
+        sut.Protected()
+            .Setup<bool>("IsKeyPressedRepeat", ItExpr.IsAny<KeyboardKey>())
+            .Returns(false);
+
+        sut.Object.Activity(1);
+
+        sut.Object.GetStringTyped().ShouldBe(string.Empty);
+    }
+
+    [Fact]
     public void GetStringTyped_ShouldReturnSameValue_WhenCalledMultipleTimes()
     {
         var sut = new Mock<Keyboard>();

--- a/Tests/RaylibGum.Tests/Renderables/RenderableCloneTests.cs
+++ b/Tests/RaylibGum.Tests/Renderables/RenderableCloneTests.cs
@@ -1,0 +1,159 @@
+using Gum.Renderables;
+using Shouldly;
+using System;
+using NineSlice = Gum.Renderables.NineSlice;
+using Sprite = Gum.Renderables.Sprite;
+using Text = Gum.Renderables.Text;
+
+namespace RaylibGum.Tests.Renderables;
+
+/// <summary>
+/// Brings the Raylib renderables in line with the MonoGame contract: NineSlice, Sprite,
+/// and Text must implement <see cref="ICloneable"/> so that
+/// <c>TextBoxBase.RefreshTemplateFromSelectionInstance</c> can clone a SelectionInstance
+/// template without going down the null-template path that NREs.
+/// </summary>
+public class RenderableCloneTests
+{
+    [Fact]
+    public void NineSlice_Clone_CopiesFieldValues()
+    {
+        var original = new NineSlice
+        {
+            Width = 42,
+            Height = 17,
+            Color = new Raylib_cs.Color(10, 20, 30, 40)
+        };
+
+        var clone = (NineSlice)((ICloneable)original).Clone();
+
+        clone.Width.ShouldBe(42);
+        clone.Height.ShouldBe(17);
+        clone.Color.R.ShouldBe((byte)10);
+        clone.Color.A.ShouldBe((byte)40);
+    }
+
+    [Fact]
+    public void NineSlice_Clone_DoesNotShareChildrenWithOriginal()
+    {
+        var original = new NineSlice();
+        var child = new NineSlice();
+        original.Children.Add(child);
+
+        var clone = (NineSlice)((ICloneable)original).Clone();
+
+        clone.Children.ShouldBeEmpty();
+        original.Children.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public void NineSlice_Clone_ResetsParent()
+    {
+        var parent = new NineSlice();
+        var original = new NineSlice { Parent = parent };
+
+        var clone = (NineSlice)((ICloneable)original).Clone();
+
+        clone.Parent.ShouldBeNull();
+    }
+
+    [Fact]
+    public void NineSlice_Clone_ReturnsNewInstance()
+    {
+        var original = new NineSlice();
+
+        var clone = ((ICloneable)original).Clone();
+
+        clone.ShouldNotBeSameAs(original);
+        clone.ShouldBeOfType<NineSlice>();
+    }
+
+    [Fact]
+    public void NineSlice_ImplementsICloneable()
+    {
+        new NineSlice().ShouldBeAssignableTo<ICloneable>();
+    }
+
+    [Fact]
+    public void Sprite_Clone_DoesNotShareChildrenWithOriginal()
+    {
+        var original = new Sprite();
+        var child = new Sprite();
+        original.Children.Add(child);
+
+        var clone = (Sprite)((ICloneable)original).Clone();
+
+        clone.Children.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Sprite_Clone_ResetsParent()
+    {
+        var parent = new Sprite();
+        var original = new Sprite { Parent = parent };
+
+        var clone = (Sprite)((ICloneable)original).Clone();
+
+        clone.Parent.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Sprite_Clone_ReturnsNewInstance()
+    {
+        var original = new Sprite { Width = 25, Height = 50 };
+
+        var clone = ((ICloneable)original).Clone();
+
+        clone.ShouldNotBeSameAs(original);
+        clone.ShouldBeOfType<Sprite>();
+        ((Sprite)clone).Width.ShouldBe(25);
+        ((Sprite)clone).Height.ShouldBe(50);
+    }
+
+    [Fact]
+    public void Sprite_ImplementsICloneable()
+    {
+        new Sprite().ShouldBeAssignableTo<ICloneable>();
+    }
+
+    [Fact]
+    public void Text_Clone_DoesNotShareChildrenWithOriginal()
+    {
+        var original = new Text();
+        var child = new Text();
+        original.Children.Add(child);
+
+        var clone = (Text)((ICloneable)original).Clone();
+
+        clone.Children.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Text_Clone_ResetsParent()
+    {
+        var parent = new Text();
+        var original = new Text { Parent = parent };
+
+        var clone = (Text)((ICloneable)original).Clone();
+
+        clone.Parent.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Text_Clone_ReturnsNewInstance()
+    {
+        var original = new Text { Width = 100 };
+
+        var clone = ((ICloneable)original).Clone();
+
+        clone.ShouldNotBeSameAs(original);
+        clone.ShouldBeOfType<Text>();
+        ((Text)clone).Width.ShouldBe(100);
+    }
+
+    [Fact]
+    public void Text_ImplementsICloneable()
+    {
+        new Text().ShouldBeAssignableTo<ICloneable>();
+    }
+}

--- a/Tests/SkiaGum.Tests/Renderables/RenderableCloneTests.cs
+++ b/Tests/SkiaGum.Tests/Renderables/RenderableCloneTests.cs
@@ -1,0 +1,45 @@
+using Shouldly;
+using SkiaGum.Renderables;
+using System;
+
+namespace SkiaGum.Tests.Renderables;
+
+/// <summary>
+/// Skia-side parity for the SelectionInstance clone contract. Sprite and Text already
+/// implement <see cref="ICloneable"/>; NineSlice did not, even though it's a stub
+/// renderable today — adding it preempts the same NRE class
+/// (<c>TextBoxBase.RefreshTemplateFromSelectionInstance</c> silently failing to assign
+/// <c>selectionTemplate</c>) the moment a Skia consumer wires NineSlice into anything
+/// that gets templated.
+/// </summary>
+public class RenderableCloneTests
+{
+    [Fact]
+    public void NineSlice_Clone_ReturnsNewInstance()
+    {
+        var original = new NineSlice();
+
+        var clone = ((ICloneable)original).Clone();
+
+        clone.ShouldNotBeSameAs(original);
+        clone.ShouldBeOfType<NineSlice>();
+    }
+
+    [Fact]
+    public void NineSlice_ImplementsICloneable()
+    {
+        new NineSlice().ShouldBeAssignableTo<ICloneable>();
+    }
+
+    [Fact]
+    public void Sprite_ImplementsICloneable()
+    {
+        new Sprite().ShouldBeAssignableTo<ICloneable>();
+    }
+
+    [Fact]
+    public void Text_ImplementsICloneable()
+    {
+        new SkiaGum.Text().ShouldBeAssignableTo<ICloneable>();
+    }
+}

--- a/Tests/SokolGum.Tests/Renderables/RenderableCloneTests.cs
+++ b/Tests/SokolGum.Tests/Renderables/RenderableCloneTests.cs
@@ -1,0 +1,129 @@
+using Gum.Renderables;
+using RenderingLibrary.Graphics;
+using Shouldly;
+using System;
+
+namespace SokolGum.Tests.Renderables;
+
+/// <summary>
+/// Brings the Sokol renderables in line with the MonoGame contract: NineSlice, Sprite,
+/// and Text must implement <see cref="ICloneable"/> so that
+/// <c>TextBoxBase.RefreshTemplateFromSelectionInstance</c> can clone a SelectionInstance
+/// template without falling through to the null-template path that NREs. Sprite gets
+/// <see cref="ICloneable"/> for free via <see cref="InvisibleRenderable"/>; NineSlice
+/// and Text need their own implementations.
+/// </summary>
+public class RenderableCloneTests : BaseTestClass
+{
+    [Fact]
+    public void NineSlice_Clone_DoesNotShareChildrenWithOriginal()
+    {
+        var original = new NineSlice();
+        original.Children.Add(new NineSlice());
+
+        var clone = (NineSlice)((ICloneable)original).Clone();
+
+        clone.Children.ShouldBeEmpty();
+        original.Children.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public void NineSlice_Clone_ResetsParent()
+    {
+        var parent = new NineSlice();
+        var original = new NineSlice { Parent = parent };
+
+        var clone = (NineSlice)((ICloneable)original).Clone();
+
+        clone.Parent.ShouldBeNull();
+    }
+
+    [Fact]
+    public void NineSlice_Clone_ReturnsNewInstance()
+    {
+        var original = new NineSlice { Width = 42, Height = 17 };
+
+        var clone = ((ICloneable)original).Clone();
+
+        clone.ShouldNotBeSameAs(original);
+        clone.ShouldBeOfType<NineSlice>();
+        ((NineSlice)clone).Width.ShouldBe(42);
+        ((NineSlice)clone).Height.ShouldBe(17);
+    }
+
+    [Fact]
+    public void NineSlice_ImplementsICloneable()
+    {
+        new NineSlice().ShouldBeAssignableTo<ICloneable>();
+    }
+
+    [Fact]
+    public void Sprite_Clone_DoesNotShareChildrenWithOriginal()
+    {
+        var original = new Sprite();
+        original.Children.Add(new Sprite());
+
+        var clone = (InvisibleRenderable)((ICloneable)original).Clone();
+
+        clone.Children.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Sprite_Clone_ResetsParent()
+    {
+        var parent = new Sprite();
+        var original = new Sprite { Parent = parent };
+
+        var clone = (InvisibleRenderable)((ICloneable)original).Clone();
+
+        clone.Parent.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Sprite_ImplementsICloneable()
+    {
+        new Sprite().ShouldBeAssignableTo<ICloneable>();
+    }
+
+    [Fact]
+    public void Text_Clone_DoesNotShareChildrenWithOriginal()
+    {
+        var original = new Text();
+        original.Children.Add(new Text());
+
+        var clone = (Text)((ICloneable)original).Clone();
+
+        clone.Children.ShouldBeEmpty();
+        original.Children.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public void Text_Clone_ResetsParent()
+    {
+        var parent = new Text();
+        var original = new Text { Parent = parent };
+
+        var clone = (Text)((ICloneable)original).Clone();
+
+        clone.Parent.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Text_Clone_ReturnsNewInstance()
+    {
+        var original = new Text { Width = 100, Height = 50 };
+
+        var clone = ((ICloneable)original).Clone();
+
+        clone.ShouldNotBeSameAs(original);
+        clone.ShouldBeOfType<Text>();
+        ((Text)clone).Width.ShouldBe(100);
+        ((Text)clone).Height.ShouldBe(50);
+    }
+
+    [Fact]
+    public void Text_ImplementsICloneable()
+    {
+        new Text().ShouldBeAssignableTo<ICloneable>();
+    }
+}


### PR DESCRIPTION
…n clone

Implemented ENTER support for multi-line text boxes on raylib Underlying visuals are now cloneable: raylib NineSlice, raylib Text, Skia NineSlice, Sokol NineSlice, Sokol Text.