### PR TITLE
Close gumpkg docs + test gaps, fix StandardElementsManager init race

### DIFF
--- a/Gum/Managers/StandardElementsManager.cs
+++ b/Gum/Managers/StandardElementsManager.cs
@@ -96,13 +96,16 @@ public class StandardElementsManager
     #endregion
 
     bool hasInitialized = false;
+    readonly object initLock = new object();
 
     public void Initialize()
     {
-        if(!hasInitialized)
+        if (hasInitialized) return;
+        lock (initLock)
         {
-            hasInitialized = true;
+            if (hasInitialized) return;
             RefreshDefaults();
+            hasInitialized = true;
         }
     }
 

--- a/Tests/Gum.Bundle.Tests/AssemblyInfo.cs
+++ b/Tests/Gum.Bundle.Tests/AssemblyInfo.cs
@@ -1,0 +1,10 @@
+using Xunit;
+
+// Bundle tests share global mutable state with the production tool code via ObjectFinder.Self
+// (specifically ObjectFinder.Self.GumProjectSave, which walker tests assign before each Walk
+// call). CLAUDE.md documents ObjectFinder.Self as an intentional process-wide singleton with
+// no plans to migrate. If two test classes set GumProjectSave in parallel, whichever runs
+// second wins and the first sees the wrong project — a silent failure mode worse than a crash.
+// Serialize this assembly until/unless ObjectFinder gains scoped-instance support.
+// The full suite still runs in well under a second.
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/Tests/Gum.Cli.Tests/PackCommandTests.cs
+++ b/Tests/Gum.Cli.Tests/PackCommandTests.cs
@@ -40,6 +40,42 @@ public class PackCommandTests : IDisposable
     }
 
     [Fact]
+    public void Pack_exits_with_2_when_include_is_empty()
+    {
+        string projectPath = CreateCleanProject("EmptyInclude");
+        string outputPath = Path.Combine(Path.GetDirectoryName(projectPath)!, "out.gumpkg");
+
+        CliTestHelper result = CliTestHelper.Run("pack", projectPath, "-o", outputPath, "--include", "");
+
+        result.ExitCode.ShouldBe(2);
+        result.StandardError.ShouldContain("--include");
+        File.Exists(outputPath).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Pack_exits_with_2_when_include_value_is_unknown()
+    {
+        string projectPath = CreateCleanProject("BogusInclude");
+        string outputPath = Path.Combine(Path.GetDirectoryName(projectPath)!, "out.gumpkg");
+
+        CliTestHelper result = CliTestHelper.Run("pack", projectPath, "-o", outputPath, "--include", "bogus");
+
+        result.ExitCode.ShouldBe(2);
+        result.StandardError.ShouldContain("Unknown");
+        File.Exists(outputPath).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Pack_exits_with_2_when_project_file_does_not_exist()
+    {
+        string projectPath = Path.Combine(_tempDirectory, "DoesNotExist", "Missing.gumx");
+
+        CliTestHelper result = CliTestHelper.Run("pack", projectPath);
+
+        result.ExitCode.ShouldBe(2);
+    }
+
+    [Fact]
     public void Pack_is_deterministic_across_invocations()
     {
         string projectPath = CreateProjectWithSpriteAndFont("Deterministic");
@@ -87,6 +123,39 @@ public class PackCommandTests : IDisposable
     }
 
     [Fact]
+    public void Pack_summary_output_includes_counts_and_byte_sizes()
+    {
+        string projectPath = CreateProjectWithSpriteAndFont("Summary");
+        string outputPath = Path.Combine(Path.GetDirectoryName(projectPath)!, "out.gumpkg");
+
+        CliTestHelper result = CliTestHelper.Run("pack", projectPath, "-o", outputPath);
+
+        result.ExitCode.ShouldBe(0);
+        result.StandardOutput.ShouldContain("Packed");
+        result.StandardOutput.ShouldContain("Core:");
+        result.StandardOutput.ShouldContain("FontCache:");
+        result.StandardOutput.ShouldContain("External:");
+        result.StandardOutput.ShouldContain("Uncompressed:");
+        result.StandardOutput.ShouldContain("Compressed:");
+        result.StandardOutput.ShouldContain("Ratio:");
+    }
+
+    [Fact]
+    public void Pack_with_core_and_external_excludes_fontcache()
+    {
+        string projectPath = CreateProjectWithSpriteAndFont("CoreExternal");
+        string outputPath = Path.Combine(Path.GetDirectoryName(projectPath)!, "out.gumpkg");
+
+        CliTestHelper result = CliTestHelper.Run("pack", projectPath, "-o", outputPath, "--include", "core,external");
+
+        result.ExitCode.ShouldBe(0);
+        Dictionary<string, byte[]> entries = ReadBundleEntries(outputPath);
+        entries.Keys.ShouldContain("Components/SpriteHolder.gucx");
+        entries.Keys.ShouldContain("Textures/bg.png");
+        entries.Keys.Any(k => k.StartsWith("FontCache/")).ShouldBeFalse();
+    }
+
+    [Fact]
     public void Pack_with_core_only_excludes_fontcache_and_external()
     {
         string projectPath = CreateProjectWithSpriteAndFont("CoreOnly");
@@ -98,6 +167,35 @@ public class PackCommandTests : IDisposable
         Dictionary<string, byte[]> entries = ReadBundleEntries(outputPath);
         entries.Keys.ShouldNotContain("Textures/bg.png");
         entries.Keys.ShouldContain("Components/SpriteHolder.gucx");
+    }
+
+    [Fact]
+    public void Pack_with_external_only_excludes_core_and_fontcache()
+    {
+        string projectPath = CreateProjectWithSpriteAndFont("ExternalOnly");
+        string outputPath = Path.Combine(Path.GetDirectoryName(projectPath)!, "out.gumpkg");
+
+        CliTestHelper result = CliTestHelper.Run("pack", projectPath, "-o", outputPath, "--include", "external");
+
+        result.ExitCode.ShouldBe(0);
+        Dictionary<string, byte[]> entries = ReadBundleEntries(outputPath);
+        entries.Keys.ShouldContain("Textures/bg.png");
+        entries.Keys.ShouldNotContain("Components/SpriteHolder.gucx");
+        entries.Keys.Any(k => k.EndsWith(".gumx")).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Pack_with_fontcache_only_produces_empty_bundle_when_project_has_no_fonts()
+    {
+        string projectPath = CreateProjectWithSpriteAndFont("FontCacheOnly");
+        string outputPath = Path.Combine(Path.GetDirectoryName(projectPath)!, "out.gumpkg");
+
+        CliTestHelper result = CliTestHelper.Run("pack", projectPath, "-o", outputPath, "--include", "fontcache");
+
+        result.ExitCode.ShouldBe(0);
+        Dictionary<string, byte[]> entries = ReadBundleEntries(outputPath);
+        entries.Keys.ShouldNotContain("Components/SpriteHolder.gucx");
+        entries.Keys.ShouldNotContain("Textures/bg.png");
     }
 
     [Fact]

--- a/docs/cli/pack.md
+++ b/docs/cli/pack.md
@@ -75,4 +75,4 @@ The bundle loader requires .NET 7 or greater (it uses `System.Formats.Tar`). On 
 |------|---------|
 | 0 | Bundle written successfully |
 | 1 | One or more dependency files were missing on disk |
-| 2 | Project failed to load, or an invalid `--include` value was supplied |
+| 2 | Project failed to load, project file not found or unreadable, or an invalid `--include` value was supplied |

--- a/docs/code/files-and-fonts/file-loading.md
+++ b/docs/code/files-and-fonts/file-loading.md
@@ -56,6 +56,15 @@ RelativeDirectory is used whenever files are loaded. These operations include:
 
 It's recommended practice to set the RelativeDirectory to your Gum project's location and to leave it there so you never have to consider subfolders in any code that accesses files directly or indirectly.
 
+### Loading from a `.gumpkg` Bundle
+
+In addition to loose files, Gum can load a project from a single-file `.gumpkg` bundle produced by [`gumcli pack`](../../cli/pack.md). When `GumService.Initialize` is called with a `.gumx` path:
+
+* If the loose `.gumx` exists, Gum loads from loose files (the dev-time path; hot reload also works in this mode).
+* If only a sibling `.gumpkg` exists, Gum reads element XML, textures, and fonts from inside the bundle via `FileManager.CustomGetStreamFromFile`. No loose copy is needed in the output directory.
+
+This means a published build can ship a single `.gumpkg` next to the executable instead of a folder tree of `.gusx`/`.gucx`/`.png`/`.fnt` files. See the [pack](../../cli/pack.md) page for the producer side and the runtime contract.
+
 ### File Caching
 
 By default Gum caches loaded textures. In other words, the following code only results in a single file IO operation:

--- a/docs/code/hot-reload.md
+++ b/docs/code/hot-reload.md
@@ -52,6 +52,12 @@ Hot reload is focused on Gum element definitions. The following are **not** auto
 
 ## Platform Support
 
+{% hint style="info" %}
+Hot reload requires loose project files on disk; it does not watch inside `.gumpkg` bundles. If a sibling `.gumpkg` exists alongside the loose `.gumx`, the loose path wins (see [pack](../cli/pack.md)) and watchers fire normally. A bundle-only deployment (no loose `.gumx`) loads at startup but cannot hot-reload.
+
+If hot reload from a `.gumpkg` (e.g. for a hot-swap-on-deploy workflow) would be useful to you, let us know on [Discord](https://discord.gg/EvqwmSQuBz) or file an issue on [GitHub](https://github.com/vchelaru/Gum/issues) — real usage reports help us prioritize.
+{% endhint %}
+
 Hot reload is available on desktop platforms:
 
 * MonoGame


### PR DESCRIPTION
## Summary

Follow-up review of the `.gumpkg` / `gumcli pack` work (#2595, #2599, #2627). Closes three doc gaps, seven CLI test gaps, and a latent thread-safety bug in `StandardElementsManager.Initialize` that the new tests exposed when multiple test assemblies ran concurrently.

### Docs
- `docs/cli/pack.md` — exit-code-2 row now covers project-file-not-found / unreadable cases.
- `docs/code/files-and-fonts/file-loading.md` — new "Loading from a `.gumpkg` Bundle" subsection cross-linking to `cli/pack.md`.
- `docs/code/hot-reload.md` — clarifies hot reload requires loose files; bundle-only deployments cannot hot-reload, with a Discord/GitHub callout to capture demand.

### Tests (`PackCommandTests.cs`, +7)
- Exit code 2 for empty `--include`, unknown `--include`, and missing project file.
- Summary stdout asserts the documented `Packed / Core / FontCache / External / Uncompressed / Compressed / Ratio` lines.
- `--include core,external`, `--include external` standalone, and `--include fontcache` standalone each verify the right inclusion set.

### `StandardElementsManager.Initialize` race
Old code set `hasInitialized = true` *before* `RefreshDefaults()` populated `mDefaults`, so a second thread observing the flag could call `GetDefaultStateFor` and read `mDefaults == null`. Switched to standard double-checked locking with the flag set after population. Lock-free fast path preserved.

### Bundle test parallelism
Added `Tests/Gum.Bundle.Tests/AssemblyInfo.cs` with `[assembly: CollectionBehavior(DisableTestParallelization = true)]`. Even with the `Initialize` race fixed, walker tests assign `ObjectFinder.Self.GumProjectSave` — `CLAUDE.md` documents this as an intentional process-wide singleton with no migration plan, and parallel writes to it fail silently rather than loudly. Serializing the assembly is the right stance until `ObjectFinder` gains scoped-instance support.

## Test plan
- [x] `Gum.Bundle.Tests` — 60/60
- [x] `Gum.Cli.Tests` — 41/41 (8 existing + 7 new = 15 in `PackCommandTests`)
- [x] `Gum.ProjectServices.Tests` — 201/201
- [x] `Gum.Analyzers.Tests` — 4/4
- [x] `GumToolUnitTests` — 549/549 (5 skipped, pre-existing)
- [x] 4× concurrent `Gum.Bundle.Tests` + `Gum.Cli.Tests` stress runs — all green (previously surfaced the `mDefaults == null` race)

🤖 Generated with [Claude Code](https://claude.com/claude-code)