### PR TITLE
Unify Apos Arc on StrokeWidth, fix #2629

### DIFF
--- a/Runtimes/GumShapes/GueDeriving/ArcRuntime.cs
+++ b/Runtimes/GumShapes/GueDeriving/ArcRuntime.cs
@@ -33,12 +33,16 @@ public class ArcRuntime : AposShapeRuntime
     }
 
     /// <summary>
-    /// Gets or sets the thickness of the arc, in pixels.
+    /// Gets or sets the thickness of the arc, in pixels. Façade for
+    /// <see cref="AposShapeRuntime.StrokeWidth"/> - the value is held on the runtime so PreRender
+    /// can apply <see cref="AposShapeRuntime.StrokeWidthUnits"/> (e.g. ScreenPixel zoom scaling)
+    /// before pushing it to the renderable each frame. Matches Skia's ArcRuntime, which routes
+    /// Thickness through base.StrokeWidth the same way.
     /// </summary>
     public float Thickness
     {
-        get => ContainedArc.Thickness;
-        set => ContainedArc.Thickness = value;
+        get => StrokeWidth;
+        set => StrokeWidth = value;
     }
 
     /// <summary>
@@ -84,6 +88,10 @@ public class ArcRuntime : AposShapeRuntime
             this.Color = Microsoft.Xna.Framework.Color.White;
             Width = 100;
             Height = 100;
+
+            // Seed the runtime auto-property StrokeWidth so PreRender pushes the legacy
+            // Arc default (10) to the renderable instead of overwriting it with 0.
+            StrokeWidth = 10;
 
             IsEndRounded = true;
 

--- a/Runtimes/GumShapes/Renderables/Arc.cs
+++ b/Runtimes/GumShapes/Renderables/Arc.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework;
 using RenderingLibrary;
 using RenderingLibrary.Math;
 using System;
@@ -11,6 +11,16 @@ namespace MonoGameAndGum.Renderables;
 
 internal class Arc : RenderableShapeBase
 {
+    public Arc()
+    {
+        // Arc historically defaulted to a thicker stroke than the rest of the shapes (10 vs the
+        // base's 2). Thickness used to be its own backing field; now that it routes through
+        // base.StrokeWidth (matching Skia and unifying with the rest of the shape pipeline) the
+        // ctor seeds the same default. ArcRuntime also seeds its runtime-level StrokeWidth to 10
+        // so PreRender doesn't overwrite this.
+        StrokeWidth = 10;
+        IsFilled = false;
+    }
 
     public float StartAngle
     {
@@ -24,11 +34,17 @@ internal class Arc : RenderableShapeBase
         set;
     } = 90;
 
+    /// <summary>
+    /// Façade for <see cref="RenderableShapeBase.StrokeWidth"/>. Kept for back-compat with the
+    /// older Apos-only Arc API and with .gumx default state which stores this variable as
+    /// "Thickness". Matches Skia's Arc, so the two backends now agree on a single underlying
+    /// field.
+    /// </summary>
     public float Thickness
     {
-        get;
-        set;
-    } = 10;
+        get => StrokeWidth;
+        set => StrokeWidth = value;
+    }
 
     bool _isEndRounded;
     public bool IsEndRounded
@@ -56,7 +72,7 @@ internal class Arc : RenderableShapeBase
             absoluteLeft + Width / 2.0f,
             absoluteTop + Width / 2.0f);
 
-        var radius = Width / 2 - Thickness / 2;
+        var radius = Width / 2 - StrokeWidth / 2;
 
         if(HasDropshadow)
         {
@@ -67,25 +83,25 @@ internal class Arc : RenderableShapeBase
             dropshadowCenter.X += DropshadowOffsetX;
             dropshadowCenter.Y += DropshadowOffsetY;
 
-            RenderInternal(sb, 
-                absoluteLeft: shadowLeft, 
-                absoluteTop: shadowTop, 
-                center: dropshadowCenter, 
+            RenderInternal(sb,
+                absoluteLeft: shadowLeft,
+                absoluteTop: shadowTop,
+                center: dropshadowCenter,
                 radius: radius,
                 antiAliasSize: MathFunctions.RoundToInt(DropshadowBlurX),
-                lineThickness: Thickness - DropshadowBlurX,
+                lineThickness: StrokeWidth - DropshadowBlurX,
                 forcedColor: DropshadowColor);
         }
 
-        RenderInternal(sb, absoluteLeft, absoluteTop, center, radius, 1, Thickness);
+        RenderInternal(sb, absoluteLeft, absoluteTop, center, radius, 1, StrokeWidth);
     }
 
-    private void RenderInternal(Apos.Shapes.ShapeBatch sb, 
-        float absoluteLeft, 
-        float absoluteTop, 
-        Vector2 center, 
+    private void RenderInternal(Apos.Shapes.ShapeBatch sb,
+        float absoluteLeft,
+        float absoluteTop,
+        Vector2 center,
         float radius,
-        int antiAliasSize, 
+        int antiAliasSize,
         float lineThickness,
         Color? forcedColor = null)
     {

--- a/Runtimes/SkiaGum/CustomSetPropertyOnRenderable.cs
+++ b/Runtimes/SkiaGum/CustomSetPropertyOnRenderable.cs
@@ -247,7 +247,50 @@ public class CustomSetPropertyOnRenderable
         bool handled = false;
         if(containedObjectAsIpso is Arc asArc)
         {
-            handled = TrySetPropertiesOnRenderableBase(asArc, graphicalUiElement, propertyName, value);
+            // Mirror RoundedRectangle/Line/ColoredCircle: stroke values must land on the runtime so
+            // AposShapeRuntime.PreRender (which pushes the runtime values to the renderable each
+            // frame, applying ScreenPixel zoom) does not clobber a value written straight to the
+            // renderable. See issue #2629.
+            switch (propertyName)
+            {
+                case nameof(ArcRuntime.StrokeWidth):
+                    if (graphicalUiElement is ArcRuntime arcStrokeRuntime)
+                    {
+                        arcStrokeRuntime.StrokeWidth = (float)value;
+                    }
+                    else
+                    {
+                        asArc.StrokeWidth = (float)value;
+                    }
+                    handled = true;
+                    break;
+                case nameof(ArcRuntime.StrokeDashLength):
+                    if (graphicalUiElement is ArcRuntime arcDashRuntime)
+                    {
+                        arcDashRuntime.StrokeDashLength = (float)value;
+                    }
+                    else
+                    {
+                        asArc.StrokeDashLength = (float)value;
+                    }
+                    handled = true;
+                    break;
+                case nameof(ArcRuntime.StrokeGapLength):
+                    if (graphicalUiElement is ArcRuntime arcGapRuntime)
+                    {
+                        arcGapRuntime.StrokeGapLength = (float)value;
+                    }
+                    else
+                    {
+                        asArc.StrokeGapLength = (float)value;
+                    }
+                    handled = true;
+                    break;
+            }
+            if (!handled)
+            {
+                handled = TrySetPropertiesOnRenderableBase(asArc, graphicalUiElement, propertyName, value);
+            }
             if(!handled)
             {
                 handled = TrySetPropertyOnArc(asArc, graphicalUiElement, propertyName, value);

--- a/Samples/MauiSkiaGum/MainPage.xaml.cs
+++ b/Samples/MauiSkiaGum/MainPage.xaml.cs
@@ -55,7 +55,72 @@ namespace MauiSkiaGum
             var component = new TestComponentRuntime();
             MainStack.AddChild(component);
 
+            // Arc examples - three different APIs for setting stroke width, all of which
+            // should produce identical results.
+            AddArc("Thickness =",   ArcStrokeApi.ThicknessProperty);
+            AddArc("StrokeWidth =", ArcStrokeApi.StrokeWidthProperty);
+            AddArc("SetProperty",   ArcStrokeApi.SetPropertyOfStrokeWidth);
+
             SkiaGumCanvasView.InvalidateSurface();
+        }
+
+        private enum ArcStrokeApi
+        {
+            ThicknessProperty,
+            StrokeWidthProperty,
+            SetPropertyOfStrokeWidth,
+        }
+
+        private void AddArc(string label, ArcStrokeApi api)
+        {
+            const float diameter = 120;
+            const float stroke = diameter * 0.4f;
+
+            // Container so the disc + arc overlap at the same position while the caption sits
+            // below, and the whole probe takes one slot in the LeftToRightStack.
+            var container = new ContainerRuntime();
+            MainStack.AddChild(container);
+            container.Width = diameter;
+            container.Height = diameter + 24;
+
+            // Solid red disc behind a thick black almost-full-sweep arc filling the same
+            // bounding box. The black ring should obscure most of the red disc; if the stroke
+            // value didn't make it through, the red disc shows through where the ring should be.
+            var disc = new ColoredCircleRuntime();
+            container.AddChild(disc);
+            disc.Width = diameter;
+            disc.Height = diameter;
+            disc.Color = SKColors.Red;
+            disc.IsFilled = true;
+
+            var arc = new ArcRuntime();
+            container.AddChild(arc);
+            arc.Width = diameter;
+            arc.Height = diameter;
+            arc.Color = SKColors.Black;
+            arc.StartAngle = 0;
+            arc.SweepAngle = 359;
+            arc.IsEndRounded = false;
+
+            switch (api)
+            {
+                case ArcStrokeApi.ThicknessProperty:
+                    arc.Thickness = stroke;
+                    break;
+                case ArcStrokeApi.StrokeWidthProperty:
+                    arc.StrokeWidth = stroke;
+                    break;
+                case ArcStrokeApi.SetPropertyOfStrokeWidth:
+                    arc.SetProperty("StrokeWidth", stroke);
+                    break;
+            }
+
+            var caption = new TextRuntime();
+            container.AddChild(caption);
+            caption.Y = diameter + 4;
+            caption.Width = diameter;
+            caption.Text = label;
+            caption.Color = SKColors.Black;
         }
 
         private void OnCounterClicked(object sender, EventArgs e)

--- a/Samples/MauiSkiaGum/MauiSkiaGum.csproj
+++ b/Samples/MauiSkiaGum/MauiSkiaGum.csproj
@@ -1,9 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<!-- Github Actions failed if including windows or mac catalyst. For now we're only going to target ios/android to get things working. 
-		If anyone wants to add these platforms back in in the future, a PR is welcome-->
+		<!-- Github Actions failed if including windows or mac catalyst on non-Windows runners. For now we're only going to target ios/android in CI.
+		Windows is added below ONLY when building on a Windows host (so local devs can run with "Windows Machine" in VS without breaking CI).
+		If anyone wants to add macOS back in in the future, a PR is welcome-->
 		<TargetFrameworks>net9.0-android;net9.0-ios</TargetFrameworks>
+		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net9.0-windows10.0.19041.0</TargetFrameworks>
 		<!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
 		<!-- <TargetFrameworks>$(TargetFrameworks);net9.0-tizen</TargetFrameworks> -->
 

--- a/Tests/MonoGameGum.Shapes.Tests/ArcRuntimeTests.cs
+++ b/Tests/MonoGameGum.Shapes.Tests/ArcRuntimeTests.cs
@@ -20,6 +20,85 @@ public class ArcRuntimeTests
         sut.Alpha.ShouldBe(128);
     }
 
+    // Regression for #2629 unification: Thickness must be a true façade for StrokeWidth on the
+    // runtime auto-property. If somebody (a) breaks the façade so Thickness gets its own backing
+    // field again, or (b) does a careless rename like replace-all "Thickness" -> "StrokeWidth"
+    // and produces a self-recursive property, this catches it: the build either fails outright
+    // or the round-trip stops agreeing.
+    [Fact]
+    public void Thickness_AndStrokeWidth_ShouldBeAliased_OnArcRuntime()
+    {
+        ArcRuntime sut = new ArcRuntime();
+
+        sut.Thickness = 7;
+        sut.StrokeWidth.ShouldBe(7);
+
+        sut.StrokeWidth = 12;
+        sut.Thickness.ShouldBe(12);
+    }
+
+    // Regression for #2629 unification: the legacy default thickness of an Arc is 10. ArcRuntime
+    // ctor must seed StrokeWidth=10 so PreRender doesn't push 0 to the renderable. This guards
+    // anyone who refactors the ctor (or deletes the seed line) from silently making every default
+    // Arc render invisible.
+    [Fact]
+    public void Default_ArcRuntime_ShouldRenderWithStrokeWidth10_AfterPreRender()
+    {
+        ArcRuntime sut = new ArcRuntime();
+        sut.StrokeWidthUnits = Gum.DataTypes.DimensionUnitType.Absolute;
+
+        sut.Thickness.ShouldBe(10);
+        sut.StrokeWidth.ShouldBe(10);
+
+        var renderable = (IRenderable)sut.RenderableComponent;
+        var shape = (RenderableShapeBase)sut.RenderableComponent;
+
+        renderable.PreRender();
+
+        shape.StrokeWidth.ShouldBe(10);
+    }
+
+    // Regression for #2629 unification: setting Thickness via SetProperty (the path .gumx default
+    // state uses to push the "Thickness" variable onto a loaded ArcRuntime) must survive PreRender.
+    // Pre-unification, Thickness lived on its own field and PreRender ignored it - so this test
+    // would have passed for the wrong reason. Post-unification, Thickness routes through the
+    // runtime's StrokeWidth auto-property and PreRender is the thing that pushes it through.
+    [Fact]
+    public void Thickness_OnArc_ShouldSurvivePreRender_WhenSetThroughSetProperty()
+    {
+        ArcRuntime sut = new ArcRuntime();
+        sut.SetProperty("Thickness", 6.0f);
+        sut.StrokeWidthUnits = Gum.DataTypes.DimensionUnitType.Absolute;
+
+        var renderable = (IRenderable)sut.RenderableComponent;
+        var shape = (RenderableShapeBase)sut.RenderableComponent;
+
+        renderable.PreRender();
+
+        shape.StrokeWidth.ShouldBe(6);
+    }
+
+    // Regression for #2629: SetProperty("StrokeWidth", x) on ArcRuntime must survive PreRender.
+    // The other shapes (RoundedRectangle, Line, ColoredCircle) special-case StrokeWidth in
+    // CustomSetPropertyOnRenderable so the value lands on the runtime's auto-property; PreRender
+    // then pushes the same value back to the renderable. Arc was missing that case, so SetProperty
+    // wrote 8 directly to the renderable, the runtime's StrokeWidth stayed at 0, and PreRender
+    // clobbered the renderable back to 0.
+    [Fact]
+    public void StrokeWidth_OnArc_ShouldSurvivePreRender_WhenSetThroughSetProperty()
+    {
+        ArcRuntime sut = new ArcRuntime();
+        sut.SetProperty("StrokeWidth", 8.0f);
+        sut.StrokeWidthUnits = Gum.DataTypes.DimensionUnitType.Absolute;
+
+        var renderable = (IRenderable)sut.RenderableComponent;
+        var shape = (RenderableShapeBase)sut.RenderableComponent;
+
+        renderable.PreRender();
+
+        shape.StrokeWidth.ShouldBe(8);
+    }
+
     // Renderer adds the inner Apos.Shapes renderable to the layer (not the runtime/GUE wrapper),
     // so the renderer's PreRender walk only invokes PreRender on the renderable. The runtime's
     // override is reached only because RenderableShapeBase.PreRender now calls back into it via


### PR DESCRIPTION
## Summary

- Apos Arc previously rendered using its own `Thickness` field while every other shape (both Apos and Skia) used `base.StrokeWidth`. This made `SetProperty("StrokeWidth", x)` on `ArcRuntime` silently fail — `PreRender` clobbered the value with the runtime auto-prop default of 0.
- Unified Apos Arc on the same StrokeWidth pipeline Skia already uses: `Thickness` is now a façade for `base.StrokeWidth` on both the renderable and the runtime; `ArcRuntime` ctor seeds `StrokeWidth = 10` to preserve the legacy default; `CustomSetPropertyOnRenderable` routes `StrokeWidth` / `StrokeDashLength` / `StrokeGapLength` through the runtime auto-property the same way the other shapes do. Side benefit: Arc stroke now honors `StrokeWidthUnits.ScreenPixel` zoom scaling, which it never did before.
- Adds a three-arc parity demo to the `MauiSkiaGum` sample so a quick visual check on Skia matches the equivalent harness on Apos. Adds Windows as a Windows-host-only target on the Maui csproj so VS can run "Windows Machine" without disturbing Linux CI runners.

## Test plan

- [x] New unit tests in `Tests/MonoGameGum.Shapes.Tests/ArcRuntimeTests.cs` cover: Thickness↔StrokeWidth aliasing, ctor default of 10 surviving PreRender, both `Thickness` and `StrokeWidth` SetProperty paths surviving PreRender. 11/11 tests pass.
- [x] `AllLibraries.sln` builds with 0 errors / 0 warnings.
- [x] Visual confirmation on Apos (MonoGame): three arcs set via `Thickness =`, `StrokeWidth =`, and `SetProperty("StrokeWidth", …)` all render identically.
- [x] Visual confirmation on Skia (MauiSkiaGum sample on Windows host): same three-API parity confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)