### PR TITLE
Unify runtime namespaces under Gum.GueDeriving (syntax version 1)

### DIFF
--- a/Gum/CodeOutputPlugin/MainCodeOutputPlugin.cs
+++ b/Gum/CodeOutputPlugin/MainCodeOutputPlugin.cs
@@ -84,7 +84,10 @@ public class MainCodeOutputPlugin : PluginBase
         _elementSettingsManager = new CodeOutputElementSettingsManager(_projectDirectoryProvider);
         var typeStringResolver = new ToolTypeStringResolver();
 
-        _codeGenerator = new CodeGenerator(_codeGenerationNameVerifier, _localizationService, _elementSettingsManager, _projectDirectoryProvider, typeStringResolver);
+        var codeGenLoggerForDetection = new ToolCodeGenLogger(Locator.GetRequiredService<IOutputManager>());
+        var syntaxVersionDetectionService = new SyntaxVersionDetectionService(codeGenLoggerForDetection);
+
+        _codeGenerator = new CodeGenerator(_codeGenerationNameVerifier, _localizationService, _elementSettingsManager, _projectDirectoryProvider, typeStringResolver, syntaxVersionDetectionService);
 
         _codeGenerationFileLocationsService = new CodeGenerationFileLocationsService(_codeGenerator, _codeGenerationNameVerifier, _projectDirectoryProvider);
 

--- a/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
+++ b/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
@@ -28,7 +28,7 @@ using Gum.Converters;
 using Gum.Wireframe;
 
 #if !FRB && !RAYLIB
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 #endif
 
 
@@ -492,7 +492,7 @@ public class CustomSetPropertyOnRenderable
         // FRB doesn't yet have a TextRuntime, so we have to do this:
         var textRuntime = graphicalUiElement;
 #else
-        var textRuntime = graphicalUiElement as MonoGameGum.GueDeriving.TextRuntime;
+        var textRuntime = graphicalUiElement as Gum.GueDeriving.TextRuntime;
 #endif
 
         void ReactToFontValueChange()
@@ -593,7 +593,7 @@ public class CustomSetPropertyOnRenderable
 
         }
 #if USE_GUMCOMMON
-        else if(propertyName == nameof(MonoGameGum.GueDeriving.TextRuntime.BitmapFont))
+        else if(propertyName == nameof(Gum.GueDeriving.TextRuntime.BitmapFont))
         {
             if(textRuntime != null)
             {
@@ -810,7 +810,7 @@ public class CustomSetPropertyOnRenderable
 #if FRB
         var textRuntime = graphicalUiElement;
 #else
-        var textRuntime = graphicalUiElement as MonoGameGum.GueDeriving.TextRuntime;
+        var textRuntime = graphicalUiElement as Gum.GueDeriving.TextRuntime;
 #endif
 
         if(textRuntime != null)
@@ -1287,7 +1287,7 @@ public class CustomSetPropertyOnRenderable
         // FRB doesn't yet have a TextRuntime, so we have to do this:
         var textRuntime = graphicalUiElement;
 #else
-        var textRuntime = graphicalUiElement as MonoGameGum.GueDeriving.TextRuntime;
+        var textRuntime = graphicalUiElement as Gum.GueDeriving.TextRuntime;
 
 #endif
         if (text == null || textRuntime == null)
@@ -2039,7 +2039,7 @@ public class CustomSetPropertyOnRenderable
         // FRB doesn't yet have a TextRuntime, so we have to do this:
         var textRuntime = graphicalUiElement;
 #else
-            var textRuntime = graphicalUiElement as MonoGameGum.GueDeriving.TextRuntime;
+            var textRuntime = graphicalUiElement as Gum.GueDeriving.TextRuntime;
 
 #endif
 

--- a/MonoGameGum.Tests/Binding/GraphicalUiElementDottedBindingTests.cs
+++ b/MonoGameGum.Tests/Binding/GraphicalUiElementDottedBindingTests.cs
@@ -1,6 +1,6 @@
 using Gum.Mvvm;
 using Gum.Wireframe;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using RenderingLibrary.Graphics;
 using Shouldly;
 using System;

--- a/MonoGameGum.Tests/Forms/ButtonTests.cs
+++ b/MonoGameGum.Tests/Forms/ButtonTests.cs
@@ -2,7 +2,7 @@
 using Gum.Wireframe;
 using Gum.Forms.Controls;
 using Gum.Forms.DefaultVisuals;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using MonoGameGum.Input;
 using Moq;
 using Shouldly;

--- a/MonoGameGum.Tests/Forms/ComboBoxTests.cs
+++ b/MonoGameGum.Tests/Forms/ComboBoxTests.cs
@@ -5,7 +5,7 @@ using Gum.Forms.DefaultVisuals;
 using Gum.Mvvm;
 using Gum.Wireframe;
 using Microsoft.Xna.Framework;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using Moq;
 using RenderingLibrary.Graphics;
 using Shouldly;

--- a/MonoGameGum.Tests/Forms/DialogBoxTests.cs
+++ b/MonoGameGum.Tests/Forms/DialogBoxTests.cs
@@ -1,7 +1,7 @@
 using Gum.DataTypes;
 using Gum.Forms.Controls.Games;
 using Gum.Wireframe;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using RenderingLibrary.Graphics;
 using Shouldly;
 using Xunit;

--- a/MonoGameGum.Tests/Forms/FrameworkElementTests.cs
+++ b/MonoGameGum.Tests/Forms/FrameworkElementTests.cs
@@ -1,7 +1,7 @@
 ﻿using Gum.Forms.Controls;
 using Gum.Wireframe;
 using Microsoft.Xna.Framework;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using MonoGameGum.Input;
 using Moq;
 using NVorbis.Ogg;

--- a/MonoGameGum.Tests/Forms/GridTests.cs
+++ b/MonoGameGum.Tests/Forms/GridTests.cs
@@ -2,7 +2,7 @@ using Gum.DataTypes;
 using Gum.Forms.Controls;
 using Gum.Managers;
 using Gum.Wireframe;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using RenderingLibrary.Graphics;
 using Shouldly;
 using System;

--- a/MonoGameGum.Tests/Forms/ItemsControlTests.cs
+++ b/MonoGameGum.Tests/Forms/ItemsControlTests.cs
@@ -1,7 +1,7 @@
 ﻿using Gum.Forms.Controls;
 using Gum.Managers;
 using Gum.Wireframe;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using RenderingLibrary.Graphics;
 using Shouldly;
 using System;

--- a/MonoGameGum.Tests/Forms/LabelTests.cs
+++ b/MonoGameGum.Tests/Forms/LabelTests.cs
@@ -1,5 +1,5 @@
 ﻿using Gum.Forms.Controls;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using RenderingLibrary.Graphics;
 using Shouldly;
 using System;

--- a/MonoGameGum.Tests/Forms/ListBoxItemTests.cs
+++ b/MonoGameGum.Tests/Forms/ListBoxItemTests.cs
@@ -1,6 +1,6 @@
 ﻿using Gum.Forms.Controls;
 using Gum.Wireframe;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using Shouldly;
 using System;
 using System.Collections.Generic;

--- a/MonoGameGum.Tests/Forms/ListBoxTests.cs
+++ b/MonoGameGum.Tests/Forms/ListBoxTests.cs
@@ -2,7 +2,7 @@
 using Gum.Forms.DefaultVisuals;
 using Gum.Wireframe;
 using MonoGameGum.Forms.DefaultVisuals;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using MonoGameGum.Input;
 using Moq;
 using RenderingLibrary;

--- a/MonoGameGum.Tests/Forms/ScrollBarTests.cs
+++ b/MonoGameGum.Tests/Forms/ScrollBarTests.cs
@@ -1,6 +1,6 @@
 ﻿using Gum.Forms.Controls;
 using Gum.Wireframe;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using Shouldly;
 using System;
 using System.Collections.Generic;

--- a/MonoGameGum.Tests/Forms/ScrollViewerTests.cs
+++ b/MonoGameGum.Tests/Forms/ScrollViewerTests.cs
@@ -1,7 +1,7 @@
 ﻿using Gum.Forms.Controls;
 using Gum.Wireframe;
 using Microsoft.Xna.Framework.Input;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using MonoGameGum.Input;
 using Moq;
 using Shouldly;

--- a/MonoGameGum.Tests/Forms/SliderTests.cs
+++ b/MonoGameGum.Tests/Forms/SliderTests.cs
@@ -1,6 +1,6 @@
 ﻿using Gum.Forms.Controls;
 using Gum.Wireframe;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using MonoGameGum.Input;
 using Moq;
 using Shouldly;

--- a/MonoGameGum.Tests/Forms/TextBoxTests.cs
+++ b/MonoGameGum.Tests/Forms/TextBoxTests.cs
@@ -4,7 +4,7 @@ using Gum.Localization;
 using Gum.Mvvm;
 using Gum.Wireframe;
 using MonoGameGum.Forms.DefaultVisuals;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using Moq;
 using Shouldly;
 using System;

--- a/MonoGameGum.Tests/Input/CursorExtensionsTests.cs
+++ b/MonoGameGum.Tests/Input/CursorExtensionsTests.cs
@@ -2,7 +2,7 @@ using Gum.DataTypes;
 using Gum.Forms;
 using Gum.Forms.Controls;
 using Gum.Wireframe;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using MonoGameGum.Input;
 using Moq;
 using RenderingLibrary.Graphics;

--- a/MonoGameGum.Tests/Runtimes/AnimationControllerTests.cs
+++ b/MonoGameGum.Tests/Runtimes/AnimationControllerTests.cs
@@ -3,7 +3,7 @@ using Gum.DataTypes;
 using Gum.DataTypes.Variables;
 using Gum.StateAnimation.Runtime;
 using Gum.Wireframe;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using RenderingLibrary.Graphics;
 using Shouldly;
 using System;

--- a/MonoGameGum.Tests/Runtimes/AnimationRuntimeTests.cs
+++ b/MonoGameGum.Tests/Runtimes/AnimationRuntimeTests.cs
@@ -3,7 +3,7 @@ using Gum.DataTypes.Variables;
 using Gum.Managers;
 using Gum.StateAnimation.Runtime;
 using Gum.Wireframe;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using Shouldly;
 using System;
 using System.Collections.Generic;

--- a/MonoGameGum.Tests/Runtimes/ApplyVariableReferencesRuntimeTests.cs
+++ b/MonoGameGum.Tests/Runtimes/ApplyVariableReferencesRuntimeTests.cs
@@ -3,7 +3,7 @@ using Gum.DataTypes.Variables;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using Shouldly;
 using Xunit;
 

--- a/MonoGameGum.Tests/Runtimes/BindableGueTests.cs
+++ b/MonoGameGum.Tests/Runtimes/BindableGueTests.cs
@@ -1,7 +1,7 @@
 ﻿using Gum.Mvvm;
 using Gum.Wireframe;
 using MonoGameGum.Forms;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using RenderingLibrary;
 using RenderingLibrary.Graphics;
 using Shouldly;

--- a/MonoGameGum.Tests/Runtimes/ColoredRectangleRuntimeTests.cs
+++ b/MonoGameGum.Tests/Runtimes/ColoredRectangleRuntimeTests.cs
@@ -1,4 +1,4 @@
-﻿using MonoGameGum.GueDeriving;
+﻿using Gum.GueDeriving;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/MonoGameGum.Tests/Runtimes/ContainerRuntimeTests.cs
+++ b/MonoGameGum.Tests/Runtimes/ContainerRuntimeTests.cs
@@ -1,4 +1,4 @@
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using RenderingLibrary.Graphics;
 using Shouldly;
 using System;

--- a/MonoGameGum.Tests/Runtimes/ElementSaveExtensions.cs
+++ b/MonoGameGum.Tests/Runtimes/ElementSaveExtensions.cs
@@ -2,7 +2,7 @@
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using RenderingLibrary.Graphics;
 using Shouldly;
 using System;

--- a/MonoGameGum.Tests/Runtimes/FontServiceTests.cs
+++ b/MonoGameGum.Tests/Runtimes/FontServiceTests.cs
@@ -1,5 +1,5 @@
 using Gum.Wireframe;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using Moq;
 using RenderingLibrary.Graphics.Fonts;
 using Shouldly;

--- a/MonoGameGum.Tests/Runtimes/GraphicalUiElementTests.cs
+++ b/MonoGameGum.Tests/Runtimes/GraphicalUiElementTests.cs
@@ -1,4 +1,4 @@
-﻿using MonoGameGum.GueDeriving;
+﻿using Gum.GueDeriving;
 using RenderingLibrary.Graphics;
 using Shouldly;
 using System;

--- a/MonoGameGum.Tests/Runtimes/InteractiveGueTests.cs
+++ b/MonoGameGum.Tests/Runtimes/InteractiveGueTests.cs
@@ -1,7 +1,7 @@
 ﻿using Gum.Forms;
 using Gum.Forms.Controls;
 using Gum.Wireframe;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using MonoGameGum.Input;
 using Moq;
 using RenderingLibrary.Graphics;

--- a/MonoGameGum.Tests/Runtimes/LayoutExporterTests.cs
+++ b/MonoGameGum.Tests/Runtimes/LayoutExporterTests.cs
@@ -1,7 +1,7 @@
 using Gum.DataTypes;
 using Gum.Wireframe;
 using GumRuntime;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using Shouldly;
 using System.Text.Json;
 using Xunit;

--- a/MonoGameGum.Tests/Runtimes/LayoutUnitTests.cs
+++ b/MonoGameGum.Tests/Runtimes/LayoutUnitTests.cs
@@ -1,4 +1,4 @@
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using Moq;
 using RenderingLibrary;
 using RenderingLibrary.Graphics;

--- a/MonoGameGum.Tests/Runtimes/NineSliceRuntimeTests.cs
+++ b/MonoGameGum.Tests/Runtimes/NineSliceRuntimeTests.cs
@@ -1,4 +1,4 @@
-﻿using MonoGameGum.GueDeriving;
+﻿using Gum.GueDeriving;
 using Shouldly;
 using System;
 using System.Collections.Generic;

--- a/MonoGameGum.Tests/Runtimes/RefreshStylesTests.cs
+++ b/MonoGameGum.Tests/Runtimes/RefreshStylesTests.cs
@@ -4,7 +4,7 @@ using Gum.Forms.Controls;
 using Gum.Forms.DefaultVisuals;
 using Gum.Wireframe;
 using Microsoft.Xna.Framework;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using Shouldly;
 using System.Linq;
 using Xunit;

--- a/MonoGameGum.Tests/Runtimes/SpriteRuntimeTests.cs
+++ b/MonoGameGum.Tests/Runtimes/SpriteRuntimeTests.cs
@@ -1,6 +1,6 @@
 ﻿using Gum.Graphics.Animation;
 using Microsoft.Xna.Framework.Graphics;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using RenderingLibrary.Graphics;
 using Shouldly;
 using System;

--- a/MonoGameGum.Tests/Runtimes/TextRuntimeTests.cs
+++ b/MonoGameGum.Tests/Runtimes/TextRuntimeTests.cs
@@ -1,7 +1,7 @@
 ﻿using Gum.DataTypes;
 using Gum.Wireframe;
 using Microsoft.Xna.Framework.Graphics;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using Gum.Localization;
 using Moq;
 using RenderingLibrary.Graphics;

--- a/MonoGameGum/AssemblyAttributes.cs
+++ b/MonoGameGum/AssemblyAttributes.cs
@@ -1,3 +1,3 @@
 using Gum.DataTypes;
 
-[assembly: GumSyntaxVersion(Version = 0)]
+[assembly: GumSyntaxVersion(Version = 1)]

--- a/MonoGameGum/FnaGum/FnaGum.csproj
+++ b/MonoGameGum/FnaGum/FnaGum.csproj
@@ -117,6 +117,10 @@
 	<ItemGroup>
 		<ProjectReference Include="..\..\fna\FNA.Core.csproj" PrivateAssets="All" />
 		<ProjectReference Include="..\..\GumCommon\GumCommon.csproj" />
+		<ProjectReference Include="..\..\Tools\Gum.Analyzers\Gum.Analyzers.csproj"
+						  Condition="'$(IncludeAnalyzers)' != 'false'"
+						  OutputItemType="Analyzer"
+						  ReferenceOutputAssembly="false" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/MonoGameGum/Forms/Controls/Image.cs
+++ b/MonoGameGum/Forms/Controls/Image.cs
@@ -1,4 +1,4 @@
-﻿using MonoGameGum.GueDeriving;
+﻿using Gum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System;
 using System.Collections.Generic;

--- a/MonoGameGum/Forms/DefaultFromFileVisuals/DefaultFromFileLabelTextRuntime.cs
+++ b/MonoGameGum/Forms/DefaultFromFileVisuals/DefaultFromFileLabelTextRuntime.cs
@@ -7,7 +7,7 @@ using System.Text;
 using System.Threading.Tasks;
 
 #if XNALIKE
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 #else
 using Gum.GueDeriving;
 #endif

--- a/MonoGameGum/Forms/DefaultFromFileVisuals/DefaultFromFilePanelRuntime.cs
+++ b/MonoGameGum/Forms/DefaultFromFileVisuals/DefaultFromFilePanelRuntime.cs
@@ -6,7 +6,7 @@ using System.Text;
 using System.Threading.Tasks;
 
 #if XNALIKE
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 #else
 using Gum.GueDeriving;
 #endif

--- a/MonoGameGum/Forms/DefaultFromFileVisuals/DefaultFromFileStackPanelRuntime.cs
+++ b/MonoGameGum/Forms/DefaultFromFileVisuals/DefaultFromFileStackPanelRuntime.cs
@@ -6,7 +6,7 @@ using System.Text;
 using System.Threading.Tasks;
 
 #if XNALIKE
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 #else
 using Gum.GueDeriving;
 #endif

--- a/MonoGameGum/Forms/DefaultVisuals/ButtonVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/ButtonVisual.cs
@@ -7,7 +7,7 @@ using RenderingLibrary.Graphics;
 
 #if XNALIKE
 using Microsoft.Xna.Framework;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using Microsoft.Xna.Framework.Graphics;
 #else
 using Gum.GueDeriving;

--- a/MonoGameGum/Forms/DefaultVisuals/CheckBoxVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/CheckBoxVisual.cs
@@ -12,7 +12,7 @@ using System.Threading.Tasks;
 #if XNALIKE
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using RenderingLibrary.Math.Geometry;
 #else
 using Gum.GueDeriving;

--- a/MonoGameGum/Forms/DefaultVisuals/ComboBoxVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/ComboBoxVisual.cs
@@ -12,7 +12,7 @@ using System.Threading.Tasks;
 #if XNALIKE
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 #else
 using Gum.GueDeriving;
 #endif

--- a/MonoGameGum/Forms/DefaultVisuals/DefaultButtonRuntime.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/DefaultButtonRuntime.cs
@@ -2,7 +2,7 @@
 using Gum.Wireframe;
 using Microsoft.Xna.Framework;
 using Gum.Forms.Controls;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System;
 using System.Collections.Generic;

--- a/MonoGameGum/Forms/DefaultVisuals/DefaultCheckboxRuntime.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/DefaultCheckboxRuntime.cs
@@ -2,7 +2,7 @@
 using Gum.Wireframe;
 using Microsoft.Xna.Framework;
 using Gum.Forms.Controls;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using RenderingLibrary.Graphics;
 using RenderingLibrary.Math.Geometry;
 using System;

--- a/MonoGameGum/Forms/DefaultVisuals/DefaultComboBoxRuntime.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/DefaultComboBoxRuntime.cs
@@ -3,7 +3,7 @@ using Gum.DataTypes.Variables;
 using Gum.Wireframe;
 using Microsoft.Xna.Framework;
 using Gum.Forms.Controls;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System;
 using System.Collections.Generic;

--- a/MonoGameGum/Forms/DefaultVisuals/DefaultLabelRuntime.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/DefaultLabelRuntime.cs
@@ -1,6 +1,6 @@
 ﻿using Gum.Wireframe;
 using Gum.Forms.Controls;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System;
 using System.Collections.Generic;

--- a/MonoGameGum/Forms/DefaultVisuals/DefaultListBoxItemRuntime.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/DefaultListBoxItemRuntime.cs
@@ -2,7 +2,7 @@
 using Gum.DataTypes.Variables;
 using Gum.Wireframe;
 using Gum.Forms.Controls;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System;
 using System.Collections.Generic;

--- a/MonoGameGum/Forms/DefaultVisuals/DefaultListBoxRuntime.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/DefaultListBoxRuntime.cs
@@ -3,7 +3,7 @@ using Gum.DataTypes.Variables;
 using Gum.Wireframe;
 using Microsoft.Xna.Framework;
 using Gum.Forms.Controls;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System;
 using System.Collections.Generic;

--- a/MonoGameGum/Forms/DefaultVisuals/DefaultMenuItemRuntime.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/DefaultMenuItemRuntime.cs
@@ -2,7 +2,7 @@
 using Gum.Wireframe;
 using Microsoft.Xna.Framework;
 using Gum.Forms.Controls;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System;
 using System.Collections.Generic;

--- a/MonoGameGum/Forms/DefaultVisuals/DefaultMenuRuntime.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/DefaultMenuRuntime.cs
@@ -1,7 +1,7 @@
 ﻿using Gum.Converters;
 using Gum.Wireframe;
 using Gum.Forms.Controls;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System;
 using System.Collections.Generic;

--- a/MonoGameGum/Forms/DefaultVisuals/DefaultRadioButtonRuntime.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/DefaultRadioButtonRuntime.cs
@@ -2,7 +2,7 @@
 using Gum.Wireframe;
 using Microsoft.Xna.Framework;
 using Gum.Forms.Controls;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using RenderingLibrary;
 using RenderingLibrary.Graphics;
 using System;

--- a/MonoGameGum/Forms/DefaultVisuals/DefaultScrollBarRuntime.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/DefaultScrollBarRuntime.cs
@@ -2,7 +2,7 @@
 using Gum.Wireframe;
 using Microsoft.Xna.Framework;
 using Gum.Forms.Controls;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System;
 using System.Collections.Generic;

--- a/MonoGameGum/Forms/DefaultVisuals/DefaultScrollViewerRuntime.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/DefaultScrollViewerRuntime.cs
@@ -1,7 +1,7 @@
 ﻿using Gum.Converters;
 using Gum.Wireframe;
 using Gum.Forms.Controls;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System;
 using System.Collections.Generic;

--- a/MonoGameGum/Forms/DefaultVisuals/DefaultSliderRuntime.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/DefaultSliderRuntime.cs
@@ -3,7 +3,7 @@ using Gum.DataTypes.Variables;
 using Gum.Wireframe;
 using Microsoft.Xna.Framework;
 using Gum.Forms.Controls;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System;
 using System.Collections.Generic;

--- a/MonoGameGum/Forms/DefaultVisuals/DefaultSplitterRuntime.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/DefaultSplitterRuntime.cs
@@ -1,6 +1,6 @@
 ﻿using Gum.Wireframe;
 using Gum.Forms.Controls;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System;
 using System.Collections.Generic;

--- a/MonoGameGum/Forms/DefaultVisuals/DefaultTextBoxBaseRuntime.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/DefaultTextBoxBaseRuntime.cs
@@ -2,7 +2,7 @@
 using Gum.DataTypes.Variables;
 using Gum.Wireframe;
 using Gum.Forms.Controls;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System;
 using System.Collections.Generic;

--- a/MonoGameGum/Forms/DefaultVisuals/DefaultTextBoxRuntime.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/DefaultTextBoxRuntime.cs
@@ -1,7 +1,7 @@
 ﻿using Gum.Converters;
 using Gum.Wireframe;
 using Gum.Forms.Controls;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System;
 using System.Collections.Generic;

--- a/MonoGameGum/Forms/DefaultVisuals/DefaultWindowRuntime.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/DefaultWindowRuntime.cs
@@ -1,7 +1,7 @@
 ﻿using Gum.Wireframe;
 using MonoGameGum;
 using Gum.Forms.Controls;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System;
 using System.Collections.Generic;

--- a/MonoGameGum/Forms/DefaultVisuals/LabelVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/LabelVisual.cs
@@ -3,7 +3,7 @@ using RenderingLibrary.Graphics;
 
 
 #if XNALIKE
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using Microsoft.Xna.Framework;
 #else
 using Gum.GueDeriving;

--- a/MonoGameGum/Forms/DefaultVisuals/ListBoxItemVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/ListBoxItemVisual.cs
@@ -12,7 +12,7 @@ using System.Threading.Tasks;
 #if XNALIKE
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 #else
 using Gum.GueDeriving;
 #endif

--- a/MonoGameGum/Forms/DefaultVisuals/ListBoxVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/ListBoxVisual.cs
@@ -11,7 +11,7 @@ using System.Threading.Tasks;
 #if XNALIKE
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 #else
 using Gum.GueDeriving;
 #endif

--- a/MonoGameGum/Forms/DefaultVisuals/MenuItemVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/MenuItemVisual.cs
@@ -3,7 +3,7 @@ using Gum.DataTypes.Variables;
 using Gum.Wireframe;
 using Gum.Forms.Controls;
 using Microsoft.Xna.Framework;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System;
 using System.Collections.Generic;

--- a/MonoGameGum/Forms/DefaultVisuals/MenuVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/MenuVisual.cs
@@ -2,7 +2,7 @@
 using Gum.DataTypes.Variables;
 using Gum.Wireframe;
 using Gum.Forms.Controls;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System;
 using System.Collections.Generic;

--- a/MonoGameGum/Forms/DefaultVisuals/RadioButtonVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/RadioButtonVisual.cs
@@ -13,7 +13,7 @@ using System.Threading.Tasks;
 
 #if XNALIKE
 using Microsoft.Xna.Framework;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 #else
 using Gum.GueDeriving;
 #endif

--- a/MonoGameGum/Forms/DefaultVisuals/ScrollBarVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/ScrollBarVisual.cs
@@ -15,7 +15,7 @@ using Gum.DataTypes;
 #if XNALIKE
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 #else
 using Gum.GueDeriving;
 #endif

--- a/MonoGameGum/Forms/DefaultVisuals/ScrollViewerVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/ScrollViewerVisual.cs
@@ -11,7 +11,7 @@ using System.Threading.Tasks;
 
 #if XNALIKE
 using Microsoft.Xna.Framework.Graphics;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 #else
 using Gum.GueDeriving;
 #endif

--- a/MonoGameGum/Forms/DefaultVisuals/SliderVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/SliderVisual.cs
@@ -10,7 +10,7 @@ using System.Threading.Tasks;
 
 #if XNALIKE
 using Microsoft.Xna.Framework;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 #else
 using Gum.GueDeriving;
 #endif

--- a/MonoGameGum/Forms/DefaultVisuals/SplitterVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/SplitterVisual.cs
@@ -8,7 +8,7 @@ using System.Text;
 using System.Threading.Tasks;
 
 #if XNALIKE
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 #else
 using Gum.GueDeriving;
 #endif

--- a/MonoGameGum/Forms/DefaultVisuals/TextBoxBaseVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/TextBoxBaseVisual.cs
@@ -4,7 +4,7 @@ using Gum.Wireframe;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Gum.Forms.Controls;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using RenderingLibrary.Graphics;
 
 

--- a/MonoGameGum/Forms/DefaultVisuals/V3/ButtonVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/V3/ButtonVisual.cs
@@ -7,7 +7,7 @@ using RenderingLibrary.Graphics;
 
 #if XNALIKE
 using Microsoft.Xna.Framework;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using Microsoft.Xna.Framework.Graphics;
 #else
 using Gum.GueDeriving;

--- a/MonoGameGum/Forms/DefaultVisuals/V3/CheckBoxVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/V3/CheckBoxVisual.cs
@@ -12,7 +12,7 @@ using System.Threading.Tasks;
 #if XNALIKE
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using RenderingLibrary.Math.Geometry;
 #else
 using Gum.GueDeriving;

--- a/MonoGameGum/Forms/DefaultVisuals/V3/ComboBoxVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/V3/ComboBoxVisual.cs
@@ -12,7 +12,7 @@ using System.Threading.Tasks;
 #if XNALIKE
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 #else
 using Gum.GueDeriving;
 #endif

--- a/MonoGameGum/Forms/DefaultVisuals/V3/DialogBoxVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/V3/DialogBoxVisual.cs
@@ -6,7 +6,7 @@ using RenderingLibrary.Graphics;
 
 #if XNALIKE
 using Microsoft.Xna.Framework;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 #else
 using Gum.GueDeriving;
 #endif

--- a/MonoGameGum/Forms/DefaultVisuals/V3/LabelVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/V3/LabelVisual.cs
@@ -3,7 +3,7 @@ using RenderingLibrary.Graphics;
 
 
 #if XNALIKE
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using Microsoft.Xna.Framework;
 #else
 using Gum.GueDeriving;

--- a/MonoGameGum/Forms/DefaultVisuals/V3/ListBoxItemVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/V3/ListBoxItemVisual.cs
@@ -12,7 +12,7 @@ using System.Threading.Tasks;
 #if XNALIKE
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 #else
 using Gum.GueDeriving;
 #endif

--- a/MonoGameGum/Forms/DefaultVisuals/V3/ListBoxVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/V3/ListBoxVisual.cs
@@ -11,7 +11,7 @@ using System.Threading.Tasks;
 #if XNALIKE
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 #else
 using Gum.GueDeriving;
 #endif

--- a/MonoGameGum/Forms/DefaultVisuals/V3/MenuItemVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/V3/MenuItemVisual.cs
@@ -2,7 +2,7 @@
 using Gum.DataTypes.Variables;
 using Gum.Wireframe;
 using Gum.Forms.Controls;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System;
 using System.Collections.Generic;

--- a/MonoGameGum/Forms/DefaultVisuals/V3/MenuVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/V3/MenuVisual.cs
@@ -2,7 +2,7 @@
 using Gum.DataTypes.Variables;
 using Gum.Wireframe;
 using Gum.Forms.Controls;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System;
 using System.Collections.Generic;

--- a/MonoGameGum/Forms/DefaultVisuals/V3/RadioButtonVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/V3/RadioButtonVisual.cs
@@ -13,7 +13,7 @@ using System.Threading.Tasks;
 
 #if XNALIKE
 using Microsoft.Xna.Framework;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 #else
 using Gum.GueDeriving;
 #endif

--- a/MonoGameGum/Forms/DefaultVisuals/V3/ScrollBarVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/V3/ScrollBarVisual.cs
@@ -15,7 +15,7 @@ using Gum.DataTypes;
 #if XNALIKE
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 #else
 using Gum.GueDeriving;
 #endif

--- a/MonoGameGum/Forms/DefaultVisuals/V3/ScrollViewerVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/V3/ScrollViewerVisual.cs
@@ -13,7 +13,7 @@ using System.Threading.Tasks;
 #if XNALIKE
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 #else
 using Gum.GueDeriving;
 #endif

--- a/MonoGameGum/Forms/DefaultVisuals/V3/SliderVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/V3/SliderVisual.cs
@@ -10,7 +10,7 @@ using System.Threading.Tasks;
 
 #if XNALIKE
 using Microsoft.Xna.Framework;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 #else
 using Gum.GueDeriving;
 #endif

--- a/MonoGameGum/Forms/DefaultVisuals/V3/SplitterVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/V3/SplitterVisual.cs
@@ -10,7 +10,7 @@ using System.Threading.Tasks;
 
 #if XNALIKE
 using Microsoft.Xna.Framework;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 #else
 using Gum.GueDeriving;
 #endif

--- a/MonoGameGum/Forms/DefaultVisuals/V3/TextBoxBaseVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/V3/TextBoxBaseVisual.cs
@@ -8,7 +8,7 @@ using System;
 
 
 #if XNALIKE
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using Microsoft.Xna.Framework;
 #else
 using Gum.GueDeriving;

--- a/MonoGameGum/Forms/DefaultVisuals/V3/ToggleButtonVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/V3/ToggleButtonVisual.cs
@@ -8,7 +8,7 @@ using RenderingLibrary.Graphics;
 
 #if XNALIKE
 using Microsoft.Xna.Framework;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using Microsoft.Xna.Framework.Graphics;
 #else
 using Gum.GueDeriving;

--- a/MonoGameGum/Forms/DefaultVisuals/V3/TooltipVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/V3/TooltipVisual.cs
@@ -6,7 +6,7 @@ using RenderingLibrary.Graphics;
 
 #if XNALIKE
 using Microsoft.Xna.Framework;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using Microsoft.Xna.Framework.Graphics;
 #else
 using Gum.GueDeriving;

--- a/MonoGameGum/Forms/DefaultVisuals/V3/WindowVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/V3/WindowVisual.cs
@@ -10,7 +10,7 @@ using System.Threading.Tasks;
 
 #if XNALIKE
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using Microsoft.Xna.Framework;
 #else
 using Gum.GueDeriving;

--- a/MonoGameGum/Forms/DefaultVisuals/WindowVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/WindowVisual.cs
@@ -9,7 +9,7 @@ using System.Threading.Tasks;
 
 #if XNALIKE
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 #else
 using Gum.GueDeriving;
 #endif

--- a/MonoGameGum/Forms/FormsUtilities.cs
+++ b/MonoGameGum/Forms/FormsUtilities.cs
@@ -18,7 +18,7 @@ using System.Linq;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using MonoGameGum.Forms.DefaultVisuals;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using MonoGameGum.Input;
 #else
 using Gum.GueDeriving;

--- a/MonoGameGum/Forms/ScreenBase.cs
+++ b/MonoGameGum/Forms/ScreenBase.cs
@@ -7,7 +7,7 @@ using System.Text;
 using System.Threading.Tasks;
 
 #if XNALIKE
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 #else
 using Gum.GueDeriving;
 #endif

--- a/MonoGameGum/GueDeriving/CircleRuntime.cs
+++ b/MonoGameGum/GueDeriving/CircleRuntime.cs
@@ -1,13 +1,17 @@
 ﻿using Gum.Wireframe;
 using RenderingLibrary;
-using RenderingLibrary.Math.Geometry;
+using global::RenderingLibrary.Math.Geometry;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
+#if FRB
 namespace MonoGameGum.GueDeriving;
+#else
+namespace Gum.GueDeriving;
+#endif
 
 public class CircleRuntime : GraphicalUiElement
 {
@@ -102,11 +106,11 @@ public class CircleRuntime : GraphicalUiElement
     {
         get
         {
-            return RenderingLibrary.Graphics.XNAExtensions.ToXNA(ContainedLineCircle.Color);
+            return global::RenderingLibrary.Graphics.XNAExtensions.ToXNA(ContainedLineCircle.Color);
         }
         set
         {
-            ContainedLineCircle.Color = RenderingLibrary.Graphics.XNAExtensions.ToSystemDrawing(value);
+            ContainedLineCircle.Color = global::RenderingLibrary.Graphics.XNAExtensions.ToSystemDrawing(value);
             NotifyPropertyChanged();
         }
     }
@@ -119,7 +123,7 @@ public class CircleRuntime : GraphicalUiElement
     {
         if (fullInstantiation)
         {
-            var circle = new RenderingLibrary.Math.Geometry.LineCircle();
+            var circle = new global::RenderingLibrary.Math.Geometry.LineCircle();
             circle.CircleOrigin = CircleOrigin.TopLeft;
             SetContainedObject(circle);
             containedLineCircle = circle;

--- a/MonoGameGum/GueDeriving/ColoredRectangleRuntime.cs
+++ b/MonoGameGum/GueDeriving/ColoredRectangleRuntime.cs
@@ -11,22 +11,24 @@ using System;
 using Gum.Renderables;
 using Color = Raylib_cs.Color;
 using ContainedRectangleType = Gum.Renderables.SolidRectangle;
-namespace Gum.GueDeriving;
 #elif SOKOL
 using Gum.Renderables;
 using Color = SokolGum.Color;
 using ContainedRectangleType = Gum.Renderables.SolidRectangle;
-namespace Gum.GueDeriving;
 #elif SKIA
 using SkiaGum.Renderables;
 using Color = SkiaSharp.SKColor;
 using ContainedRectangleType = SkiaGum.Renderables.RoundedRectangle;
-namespace SkiaGum.GueDeriving;
 #else
 using Gum.RenderingLibrary;
 using Color = Microsoft.Xna.Framework.Color;
-using ContainedRectangleType = RenderingLibrary.Graphics.SolidRectangle;
+using ContainedRectangleType = global::RenderingLibrary.Graphics.SolidRectangle;
+#endif
+
+#if FRB
 namespace MonoGameGum.GueDeriving;
+#else
+namespace Gum.GueDeriving;
 #endif
 
 
@@ -131,10 +133,10 @@ public class ColoredRectangleRuntime : GraphicalUiElement
     public Color Color
     {
 #if XNALIKE
-        get => RenderingLibrary.Graphics.XNAExtensions.ToXNA(ContainedColoredRectangle.Color);
+        get => global::RenderingLibrary.Graphics.XNAExtensions.ToXNA(ContainedColoredRectangle.Color);
         set
         {
-            ContainedColoredRectangle.Color = RenderingLibrary.Graphics.XNAExtensions.ToSystemDrawing(value);
+            ContainedColoredRectangle.Color = global::RenderingLibrary.Graphics.XNAExtensions.ToSystemDrawing(value);
             NotifyPropertyChanged();
         }
 #else

--- a/MonoGameGum/GueDeriving/ContainerRuntime.cs
+++ b/MonoGameGum/GueDeriving/ContainerRuntime.cs
@@ -13,16 +13,19 @@ using System.Text;
 using System.Threading.Tasks;
 
 #if XNALIKE
-using BlendState = Microsoft.Xna.Framework.Graphics.BlendState;
+using BlendStateAlias = global::Microsoft.Xna.Framework.Graphics.BlendState;
+#elif RAYLIB || SOKOL
+using BlendStateAlias = global::Gum.BlendState;
+#elif SKIA
+// SkiaGum has no BlendState property on ContainerRuntime
+#else
+using BlendStateAlias = global::Gum.BlendState;
 #endif
 
-#if RAYLIB || SOKOL
-using BlendState = Gum.BlendState;
-namespace Gum.GueDeriving;
-#elif SKIA
-namespace SkiaGum.GueDeriving;
-#else
+#if FRB
 namespace MonoGameGum.GueDeriving;
+#else
+namespace Gum.GueDeriving;
 #endif
 
 
@@ -54,7 +57,7 @@ public class ContainerRuntime : InteractiveGue
 
 
 #if !SKIA && !SOKOL
-    public BlendState BlendState
+    public BlendStateAlias BlendState
     {
 #if XNALIKE
         get => RenderableComponent.BlendState.ToXNA();

--- a/MonoGameGum/GueDeriving/NineSliceRuntime.cs
+++ b/MonoGameGum/GueDeriving/NineSliceRuntime.cs
@@ -13,7 +13,11 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
+#if FRB
 namespace MonoGameGum.GueDeriving
+#else
+namespace Gum.GueDeriving
+#endif
 {
     public class NineSliceRuntime : InteractiveGue
     {
@@ -127,11 +131,11 @@ namespace MonoGameGum.GueDeriving
         {
             get
             {
-                return RenderingLibrary.Graphics.XNAExtensions.ToXNA(ContainedNineSlice.Color);
+                return global::RenderingLibrary.Graphics.XNAExtensions.ToXNA(ContainedNineSlice.Color);
             }
             set
             {
-                ContainedNineSlice.Color = RenderingLibrary.Graphics.XNAExtensions.ToSystemDrawing(value);
+                ContainedNineSlice.Color = global::RenderingLibrary.Graphics.XNAExtensions.ToSystemDrawing(value);
                 NotifyPropertyChanged();
             }
         }

--- a/MonoGameGum/GueDeriving/PolygonRuntime.cs
+++ b/MonoGameGum/GueDeriving/PolygonRuntime.cs
@@ -8,21 +8,25 @@ using System.Numerics;
 using System.Text;
 using System.Threading.Tasks;
 
+#if FRB
 namespace MonoGameGum.GueDeriving;
+#else
+namespace Gum.GueDeriving;
+#endif
 
 /// <summary>
 /// A visual polygon element which can display any arbitrary convex or concave shape.
 /// </summary>
 public class PolygonRuntime : InteractiveGue
 {
-    RenderingLibrary.Math.Geometry.LinePolygon containedPolygon;
-    RenderingLibrary.Math.Geometry.LinePolygon ContainedPolygon
+    global::RenderingLibrary.Math.Geometry.LinePolygon containedPolygon;
+    global::RenderingLibrary.Math.Geometry.LinePolygon ContainedPolygon
     {
         get
         {
             if (containedPolygon == null)
             {
-                containedPolygon = this.RenderableComponent as RenderingLibrary.Math.Geometry.LinePolygon;
+                containedPolygon = this.RenderableComponent as global::RenderingLibrary.Math.Geometry.LinePolygon;
             }
             return containedPolygon;
         }
@@ -107,11 +111,11 @@ public class PolygonRuntime : InteractiveGue
     {
         get
         {
-            return RenderingLibrary.Graphics.XNAExtensions.ToXNA(ContainedPolygon.Color);
+            return global::RenderingLibrary.Graphics.XNAExtensions.ToXNA(ContainedPolygon.Color);
         }
         set
         {
-            ContainedPolygon.Color = RenderingLibrary.Graphics.XNAExtensions.ToSystemDrawing(value);
+            ContainedPolygon.Color = global::RenderingLibrary.Graphics.XNAExtensions.ToSystemDrawing(value);
             NotifyPropertyChanged();
         }
     }
@@ -120,7 +124,7 @@ public class PolygonRuntime : InteractiveGue
     {
         if (fullInstantiation)
         {
-            var polygon = new RenderingLibrary.Math.Geometry.LinePolygon(systemManagers ?? SystemManagers.Default);
+            var polygon = new global::RenderingLibrary.Math.Geometry.LinePolygon(systemManagers ?? SystemManagers.Default);
             SetContainedObject(polygon);
             containedPolygon = polygon;
 

--- a/MonoGameGum/GueDeriving/RectangleRuntime.cs
+++ b/MonoGameGum/GueDeriving/RectangleRuntime.cs
@@ -7,18 +7,22 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
+#if FRB
 namespace MonoGameGum.GueDeriving
+#else
+namespace Gum.GueDeriving
+#endif
 {
     public class RectangleRuntime : GraphicalUiElement
     {
-        RenderingLibrary.Math.Geometry.LineRectangle containedLineRectangle;
-        RenderingLibrary.Math.Geometry.LineRectangle ContainedLineRectangle
+        global::RenderingLibrary.Math.Geometry.LineRectangle containedLineRectangle;
+        global::RenderingLibrary.Math.Geometry.LineRectangle ContainedLineRectangle
         {
             get
             {
                 if (containedLineRectangle == null)
                 {
-                    containedLineRectangle = this.RenderableComponent as RenderingLibrary.Math.Geometry.LineRectangle;
+                    containedLineRectangle = this.RenderableComponent as global::RenderingLibrary.Math.Geometry.LineRectangle;
                 }
                 return containedLineRectangle;
             }
@@ -105,11 +109,11 @@ namespace MonoGameGum.GueDeriving
         {
             get
             {
-                return RenderingLibrary.Graphics.XNAExtensions.ToXNA(ContainedLineRectangle.Color);
+                return global::RenderingLibrary.Graphics.XNAExtensions.ToXNA(ContainedLineRectangle.Color);
             }
             set
             {
-                ContainedLineRectangle.Color = RenderingLibrary.Graphics.XNAExtensions.ToSystemDrawing(value);
+                ContainedLineRectangle.Color = global::RenderingLibrary.Graphics.XNAExtensions.ToSystemDrawing(value);
                 NotifyPropertyChanged();
             }
         }
@@ -122,7 +126,7 @@ namespace MonoGameGum.GueDeriving
         {
             if (fullInstantiation)
             {
-                var rectangle = new RenderingLibrary.Math.Geometry.LineRectangle(systemManagers);
+                var rectangle = new global::RenderingLibrary.Math.Geometry.LineRectangle(systemManagers);
                 SetContainedObject(rectangle);
                 containedLineRectangle = rectangle;
 

--- a/MonoGameGum/GueDeriving/Shims/CircleRuntimeShim.cs
+++ b/MonoGameGum/GueDeriving/Shims/CircleRuntimeShim.cs
@@ -1,0 +1,19 @@
+#if !FRB
+using System;
+
+namespace MonoGameGum.GueDeriving;
+
+/// <summary>
+/// Compatibility shim. The real type lives in <see cref="Gum.GueDeriving.CircleRuntime"/>.
+/// This derived class exists so existing user code with <c>using MonoGameGum.GueDeriving;</c>
+/// continues to compile during the deprecation window.
+/// </summary>
+[Obsolete("Use Gum.GueDeriving.CircleRuntime instead. The MonoGameGum.GueDeriving namespace will be removed in a future release.")]
+public class CircleRuntime : Gum.GueDeriving.CircleRuntime
+{
+    /// <inheritdoc/>
+    public CircleRuntime(bool fullInstantiation = true) : base(fullInstantiation)
+    {
+    }
+}
+#endif

--- a/MonoGameGum/GueDeriving/Shims/ColoredRectangleRuntimeShim.cs
+++ b/MonoGameGum/GueDeriving/Shims/ColoredRectangleRuntimeShim.cs
@@ -1,0 +1,19 @@
+#if !FRB
+using System;
+
+namespace MonoGameGum.GueDeriving;
+
+/// <summary>
+/// Compatibility shim. The real type lives in <see cref="Gum.GueDeriving.ColoredRectangleRuntime"/>.
+/// This derived class exists so existing user code with <c>using MonoGameGum.GueDeriving;</c>
+/// continues to compile during the deprecation window.
+/// </summary>
+[Obsolete("Use Gum.GueDeriving.ColoredRectangleRuntime instead. The MonoGameGum.GueDeriving namespace will be removed in a future release.")]
+public class ColoredRectangleRuntime : Gum.GueDeriving.ColoredRectangleRuntime
+{
+    /// <inheritdoc/>
+    public ColoredRectangleRuntime(bool fullInstantiation = true) : base(fullInstantiation)
+    {
+    }
+}
+#endif

--- a/MonoGameGum/GueDeriving/Shims/ContainerRuntimeShim.cs
+++ b/MonoGameGum/GueDeriving/Shims/ContainerRuntimeShim.cs
@@ -1,0 +1,24 @@
+#if !FRB
+using System;
+
+namespace MonoGameGum.GueDeriving;
+
+/// <summary>
+/// Compatibility shim. The real type lives in <see cref="Gum.GueDeriving.ContainerRuntime"/>.
+/// This derived class exists so existing user code with <c>using MonoGameGum.GueDeriving;</c>
+/// continues to compile during the deprecation window.
+/// </summary>
+[Obsolete("Use Gum.GueDeriving.ContainerRuntime instead. The MonoGameGum.GueDeriving namespace will be removed in a future release.")]
+public class ContainerRuntime : Gum.GueDeriving.ContainerRuntime
+{
+    /// <inheritdoc/>
+    public ContainerRuntime() : base()
+    {
+    }
+
+    /// <inheritdoc/>
+    public ContainerRuntime(bool fullInstantiation = true) : base(fullInstantiation)
+    {
+    }
+}
+#endif

--- a/MonoGameGum/GueDeriving/Shims/NineSliceRuntimeShim.cs
+++ b/MonoGameGum/GueDeriving/Shims/NineSliceRuntimeShim.cs
@@ -1,0 +1,19 @@
+#if !FRB
+using System;
+
+namespace MonoGameGum.GueDeriving;
+
+/// <summary>
+/// Compatibility shim. The real type lives in <see cref="Gum.GueDeriving.NineSliceRuntime"/>.
+/// This derived class exists so existing user code with <c>using MonoGameGum.GueDeriving;</c>
+/// continues to compile during the deprecation window.
+/// </summary>
+[Obsolete("Use Gum.GueDeriving.NineSliceRuntime instead. The MonoGameGum.GueDeriving namespace will be removed in a future release.")]
+public class NineSliceRuntime : Gum.GueDeriving.NineSliceRuntime
+{
+    /// <inheritdoc/>
+    public NineSliceRuntime(bool fullInstantiation = true) : base(fullInstantiation)
+    {
+    }
+}
+#endif

--- a/MonoGameGum/GueDeriving/Shims/PolygonRuntimeShim.cs
+++ b/MonoGameGum/GueDeriving/Shims/PolygonRuntimeShim.cs
@@ -1,0 +1,21 @@
+#if !FRB
+using System;
+using RenderingLibrary;
+
+namespace MonoGameGum.GueDeriving;
+
+/// <summary>
+/// Compatibility shim. The real type lives in <see cref="Gum.GueDeriving.PolygonRuntime"/>.
+/// This derived class exists so existing user code with <c>using MonoGameGum.GueDeriving;</c>
+/// continues to compile during the deprecation window.
+/// </summary>
+[Obsolete("Use Gum.GueDeriving.PolygonRuntime instead. The MonoGameGum.GueDeriving namespace will be removed in a future release.")]
+public class PolygonRuntime : Gum.GueDeriving.PolygonRuntime
+{
+    /// <inheritdoc/>
+    public PolygonRuntime(bool fullInstantiation = true, SystemManagers? systemManagers = null)
+        : base(fullInstantiation, systemManagers)
+    {
+    }
+}
+#endif

--- a/MonoGameGum/GueDeriving/Shims/RectangleRuntimeShim.cs
+++ b/MonoGameGum/GueDeriving/Shims/RectangleRuntimeShim.cs
@@ -1,0 +1,21 @@
+#if !FRB
+using System;
+using RenderingLibrary;
+
+namespace MonoGameGum.GueDeriving;
+
+/// <summary>
+/// Compatibility shim. The real type lives in <see cref="Gum.GueDeriving.RectangleRuntime"/>.
+/// This derived class exists so existing user code with <c>using MonoGameGum.GueDeriving;</c>
+/// continues to compile during the deprecation window.
+/// </summary>
+[Obsolete("Use Gum.GueDeriving.RectangleRuntime instead. The MonoGameGum.GueDeriving namespace will be removed in a future release.")]
+public class RectangleRuntime : Gum.GueDeriving.RectangleRuntime
+{
+    /// <inheritdoc/>
+    public RectangleRuntime(bool fullInstantiation = true, SystemManagers systemManagers = null)
+        : base(fullInstantiation, systemManagers)
+    {
+    }
+}
+#endif

--- a/MonoGameGum/GueDeriving/Shims/SpriteRuntimeShim.cs
+++ b/MonoGameGum/GueDeriving/Shims/SpriteRuntimeShim.cs
@@ -1,0 +1,20 @@
+#if !FRB
+using System;
+
+namespace MonoGameGum.GueDeriving;
+
+/// <summary>
+/// Compatibility shim. The real type lives in <see cref="Gum.GueDeriving.SpriteRuntime"/>.
+/// This derived class exists so existing user code with <c>using MonoGameGum.GueDeriving;</c>
+/// continues to compile during the deprecation window.
+/// </summary>
+[Obsolete("Use Gum.GueDeriving.SpriteRuntime instead. The MonoGameGum.GueDeriving namespace will be removed in a future release.")]
+public class SpriteRuntime : Gum.GueDeriving.SpriteRuntime
+{
+    /// <inheritdoc/>
+    public SpriteRuntime(bool fullInstantiation = true, bool tryCreateFormsObject = true)
+        : base(fullInstantiation, tryCreateFormsObject)
+    {
+    }
+}
+#endif

--- a/MonoGameGum/GueDeriving/Shims/TextRuntimeShim.cs
+++ b/MonoGameGum/GueDeriving/Shims/TextRuntimeShim.cs
@@ -1,0 +1,21 @@
+#if !FRB
+using System;
+using RenderingLibrary;
+
+namespace MonoGameGum.GueDeriving;
+
+/// <summary>
+/// Compatibility shim. The real type lives in <see cref="Gum.GueDeriving.TextRuntime"/>.
+/// This derived class exists so existing user code with <c>using MonoGameGum.GueDeriving;</c>
+/// continues to compile during the deprecation window.
+/// </summary>
+[Obsolete("Use Gum.GueDeriving.TextRuntime instead. The MonoGameGum.GueDeriving namespace will be removed in a future release.")]
+public class TextRuntime : Gum.GueDeriving.TextRuntime
+{
+    /// <inheritdoc/>
+    public TextRuntime(bool fullInstantiation = true, SystemManagers? systemManagers = null)
+        : base(fullInstantiation, systemManagers)
+    {
+    }
+}
+#endif

--- a/MonoGameGum/GueDeriving/SpriteRuntime.cs
+++ b/MonoGameGum/GueDeriving/SpriteRuntime.cs
@@ -19,21 +19,24 @@ using Color = Raylib_cs.Color;
 using Rectangle = Raylib_cs.Rectangle;
 using Texture2D = Raylib_cs.Texture2D;
 using ContainedSpriteType = Gum.Renderables.Sprite;
-namespace Gum.GueDeriving;
 #elif SKIA
 using SkiaGum.Renderables;
 using Color = SkiaSharp.SKColor;
 using Rectangle = SkiaSharp.SKRect;
 using Texture2D = SkiaSharp.SKBitmap;
 using ContainedSpriteType = SkiaGum.Renderables.Sprite;
-namespace SkiaGum.GueDeriving;
 #else
 using RenderingLibrary.Graphics;
 using Color = Microsoft.Xna.Framework.Color;
 using Rectangle = Microsoft.Xna.Framework.Rectangle;
 using Texture2D = Microsoft.Xna.Framework.Graphics.Texture2D;
-using ContainedSpriteType = RenderingLibrary.Graphics.Sprite;
+using ContainedSpriteType = global::RenderingLibrary.Graphics.Sprite;
+#endif
+
+#if FRB
 namespace MonoGameGum.GueDeriving;
+#else
+namespace Gum.GueDeriving;
 #endif
 
 /// <summary>
@@ -125,7 +128,7 @@ public class SpriteRuntime : GraphicalUiElement
 #if RAYLIB || SKIA
             return ContainedSprite.Color;
 #else
-            return RenderingLibrary.Graphics.XNAExtensions.ToXNA(ContainedSprite.Color);
+            return global::RenderingLibrary.Graphics.XNAExtensions.ToXNA(ContainedSprite.Color);
 #endif
         }
         set
@@ -133,7 +136,7 @@ public class SpriteRuntime : GraphicalUiElement
 #if RAYLIB || SKIA
             ContainedSprite.Color = value;
 #else
-            ContainedSprite.Color = RenderingLibrary.Graphics.XNAExtensions.ToSystemDrawing(value);
+            ContainedSprite.Color = global::RenderingLibrary.Graphics.XNAExtensions.ToSystemDrawing(value);
 #endif
             NotifyPropertyChanged();
         }
@@ -509,7 +512,7 @@ public class SpriteRuntime : GraphicalUiElement
 #if RAYLIB || SKIA
             mContainedSprite = new ContainedSpriteType();
 #else
-            mContainedSprite = new RenderingLibrary.Graphics.Sprite(null);
+            mContainedSprite = new global::RenderingLibrary.Graphics.Sprite(null);
 #endif
             SetContainedObject(mContainedSprite);
             Width = 100;

--- a/MonoGameGum/GueDeriving/TextRuntime.cs
+++ b/MonoGameGum/GueDeriving/TextRuntime.cs
@@ -5,6 +5,7 @@ using Gum.DataTypes;
 #if RAYLIB
 using Gum.Renderables;
 #elif SKIA
+using SkiaGum;
 using SkiaSharp;
 #else
 using Gum.Graphics;
@@ -21,13 +22,16 @@ using System.Threading.Tasks;
 
 #if RAYLIB
 using Raylib_cs;
-namespace Gum.GueDeriving;
 #elif SKIA
 using Color = SkiaSharp.SKColor;
-namespace SkiaGum.GueDeriving;
 #else
 using Color = Microsoft.Xna.Framework.Color;
+#endif
+
+#if FRB
 namespace MonoGameGum.GueDeriving;
+#else
+namespace Gum.GueDeriving;
 #endif
 
 /// <summary>
@@ -123,10 +127,10 @@ public class TextRuntime : InteractiveGue
     public Color Color
     {
 #if XNALIKE
-        get => RenderingLibrary.Graphics.XNAExtensions.ToXNA(ContainedText.Color);
+        get => global::RenderingLibrary.Graphics.XNAExtensions.ToXNA(ContainedText.Color);
         set
         {
-            ContainedText.Color = RenderingLibrary.Graphics.XNAExtensions.ToSystemDrawing(value);
+            ContainedText.Color = global::RenderingLibrary.Graphics.XNAExtensions.ToSystemDrawing(value);
             NotifyPropertyChanged();
         }
 #else

--- a/MonoGameGum/GumService.cs
+++ b/MonoGameGum/GumService.cs
@@ -22,7 +22,7 @@ using Gum.Threading;
 using Gum.Localization;
 
 #if XNALIKE
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using MonoGameGum.Input;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;

--- a/MonoGameGum/KniGum/KniGum.csproj
+++ b/MonoGameGum/KniGum/KniGum.csproj
@@ -149,6 +149,10 @@
 
 	<ItemGroup>
 		<ProjectReference Include="..\..\GumCommon\GumCommon.csproj" />
+		<ProjectReference Include="..\..\Tools\Gum.Analyzers\Gum.Analyzers.csproj"
+						  Condition="'$(IncludeAnalyzers)' != 'false'"
+						  OutputItemType="Analyzer"
+						  ReferenceOutputAssembly="false" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/MonoGameGum/MonoGameGum.csproj
+++ b/MonoGameGum/MonoGameGum.csproj
@@ -182,7 +182,7 @@
 
 	<ItemGroup>
 		<ProjectReference Include="..\GumCommon\GumCommon.csproj" />
-		<ProjectReference Include="..\Tools\Gum.Analyzers\Gum.Analyzers.csproj" Condition="'$(IncludeAnalyzers)' == 'true'" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+		<ProjectReference Include="..\Tools\Gum.Analyzers\Gum.Analyzers.csproj" Condition="'$(IncludeAnalyzers)' != 'false'" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/RenderingLibrary/Graphics/IRenderableIpso.cs
+++ b/RenderingLibrary/Graphics/IRenderableIpso.cs
@@ -1,5 +1,5 @@
 ﻿#if SKIA
-using SkiaGum.GueDeriving;
+using Gum.GueDeriving;
 using SkiaGum.Renderables;
 using SkiaSharp;
 #endif

--- a/RenderingLibrary/SystemManagers.cs
+++ b/RenderingLibrary/SystemManagers.cs
@@ -18,7 +18,11 @@ using static System.Runtime.InteropServices.JavaScript.JSType;
 
 
 #if USE_GUMCOMMON
+#if FRB
 using MonoGameGum.GueDeriving;
+#else
+using Gum.GueDeriving;
+#endif
 using Gum.Managers;
 using GumRuntime;
 

--- a/Runtimes/GumShapes/GueDeriving/AposShapeRuntime.cs
+++ b/Runtimes/GumShapes/GueDeriving/AposShapeRuntime.cs
@@ -14,7 +14,11 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
+#if FRB
 namespace MonoGameGum.GueDeriving;
+#else
+namespace Gum.GueDeriving;
+#endif
 
 /// <summary>
 /// Base class for all shapes, providng common properties like color, gradient, and dropshadow.

--- a/Runtimes/GumShapes/GueDeriving/ArcRuntime.cs
+++ b/Runtimes/GumShapes/GueDeriving/ArcRuntime.cs
@@ -6,7 +6,11 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
+#if FRB
 namespace MonoGameGum.GueDeriving;
+#else
+namespace Gum.GueDeriving;
+#endif
 
 /// <summary>
 /// Runtime that draws a circular arc inscribed in its Width x Height bounds.

--- a/Runtimes/GumShapes/GueDeriving/ColoredCircleRuntime.cs
+++ b/Runtimes/GumShapes/GueDeriving/ColoredCircleRuntime.cs
@@ -8,7 +8,11 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
+#if FRB
 namespace MonoGameGum.GueDeriving;
+#else
+namespace Gum.GueDeriving;
+#endif
 
 /// <summary>
 /// Runtime that draws a circle (or ellipse) sized by its Width and Height. Adds no properties beyond

--- a/Runtimes/GumShapes/GueDeriving/LineRuntime.cs
+++ b/Runtimes/GumShapes/GueDeriving/LineRuntime.cs
@@ -1,6 +1,10 @@
 using MonoGameAndGum.Renderables;
 
+#if FRB
 namespace MonoGameGum.GueDeriving;
+#else
+namespace Gum.GueDeriving;
+#endif
 
 /// <summary>
 /// Runtime for a line shape that draws from the top-left to the bottom-right of its bounding rectangle.

--- a/Runtimes/GumShapes/GueDeriving/Shims/AposShapeRuntimeShim.cs
+++ b/Runtimes/GumShapes/GueDeriving/Shims/AposShapeRuntimeShim.cs
@@ -1,0 +1,15 @@
+#if !FRB
+using System;
+
+namespace MonoGameGum.GueDeriving;
+
+/// <summary>
+/// Compatibility shim. The real type lives in <see cref="Gum.GueDeriving.AposShapeRuntime"/>.
+/// This derived class exists so existing user code with <c>using Gum.GueDeriving;</c>
+/// continues to compile during the deprecation window.
+/// </summary>
+[Obsolete("Use Gum.GueDeriving.AposShapeRuntime instead. The MonoGameGum.GueDeriving namespace will be removed in a future release.")]
+public abstract class AposShapeRuntime : Gum.GueDeriving.AposShapeRuntime
+{
+}
+#endif

--- a/Runtimes/GumShapes/GueDeriving/Shims/ArcRuntimeShim.cs
+++ b/Runtimes/GumShapes/GueDeriving/Shims/ArcRuntimeShim.cs
@@ -1,0 +1,19 @@
+#if !FRB
+using System;
+
+namespace MonoGameGum.GueDeriving;
+
+/// <summary>
+/// Compatibility shim. The real type lives in <see cref="Gum.GueDeriving.ArcRuntime"/>.
+/// This derived class exists so existing user code with <c>using Gum.GueDeriving;</c>
+/// continues to compile during the deprecation window.
+/// </summary>
+[Obsolete("Use Gum.GueDeriving.ArcRuntime instead. The MonoGameGum.GueDeriving namespace will be removed in a future release.")]
+public class ArcRuntime : Gum.GueDeriving.ArcRuntime
+{
+    /// <inheritdoc/>
+    public ArcRuntime(bool fullInstantiation = true) : base(fullInstantiation)
+    {
+    }
+}
+#endif

--- a/Runtimes/GumShapes/GueDeriving/Shims/ColoredCircleRuntimeShim.cs
+++ b/Runtimes/GumShapes/GueDeriving/Shims/ColoredCircleRuntimeShim.cs
@@ -1,0 +1,19 @@
+#if !FRB
+using System;
+
+namespace MonoGameGum.GueDeriving;
+
+/// <summary>
+/// Compatibility shim. The real type lives in <see cref="Gum.GueDeriving.ColoredCircleRuntime"/>.
+/// This derived class exists so existing user code with <c>using Gum.GueDeriving;</c>
+/// continues to compile during the deprecation window.
+/// </summary>
+[Obsolete("Use Gum.GueDeriving.ColoredCircleRuntime instead. The MonoGameGum.GueDeriving namespace will be removed in a future release.")]
+public class ColoredCircleRuntime : Gum.GueDeriving.ColoredCircleRuntime
+{
+    /// <inheritdoc/>
+    public ColoredCircleRuntime(bool fullInstantiation = true) : base(fullInstantiation)
+    {
+    }
+}
+#endif

--- a/Runtimes/GumShapes/GueDeriving/Shims/LineRuntimeShim.cs
+++ b/Runtimes/GumShapes/GueDeriving/Shims/LineRuntimeShim.cs
@@ -1,0 +1,19 @@
+#if !FRB
+using System;
+
+namespace MonoGameGum.GueDeriving;
+
+/// <summary>
+/// Compatibility shim. The real type lives in <see cref="Gum.GueDeriving.LineRuntime"/>.
+/// This derived class exists so existing user code with <c>using Gum.GueDeriving;</c>
+/// continues to compile during the deprecation window.
+/// </summary>
+[Obsolete("Use Gum.GueDeriving.LineRuntime instead. The MonoGameGum.GueDeriving namespace will be removed in a future release.")]
+public class LineRuntime : Gum.GueDeriving.LineRuntime
+{
+    /// <inheritdoc/>
+    public LineRuntime(bool fullInstantiation = true) : base(fullInstantiation)
+    {
+    }
+}
+#endif

--- a/Runtimes/GumShapes/GueDeriving/Shims/RoundedRectangleRuntimeShim.cs
+++ b/Runtimes/GumShapes/GueDeriving/Shims/RoundedRectangleRuntimeShim.cs
@@ -1,0 +1,26 @@
+#if !FRB
+using System;
+
+namespace MonoGameGum.GueDeriving;
+
+/// <summary>
+/// Compatibility shim. The real type lives in <see cref="Gum.GueDeriving.RoundedRectangleRuntime"/>.
+/// This derived class exists so existing user code with <c>using MonoGameGum.GueDeriving;</c>
+/// continues to compile during the deprecation window.
+/// </summary>
+/// <remarks>
+/// The shim file lives under <c>Runtimes/GumShapes/GueDeriving/Shims/</c> rather than alongside
+/// the other MonoGameGum.GueDeriving shims because <c>RoundedRectangleRuntime</c>'s real source
+/// is file-linked from SkiaGum into the Apos.Shapes-backed projects (MonoGameGumShapes,
+/// KniGumShapes). Placing the shim here scopes it to those projects only, matching the type's
+/// actual compilation surface.
+/// </remarks>
+[Obsolete("Use Gum.GueDeriving.RoundedRectangleRuntime instead. The MonoGameGum.GueDeriving namespace will be removed in a future release.")]
+public class RoundedRectangleRuntime : Gum.GueDeriving.RoundedRectangleRuntime
+{
+    /// <inheritdoc/>
+    public RoundedRectangleRuntime(bool fullInstantiation = true) : base(fullInstantiation)
+    {
+    }
+}
+#endif

--- a/Runtimes/GumShapes/KniGumShapes.csproj
+++ b/Runtimes/GumShapes/KniGumShapes.csproj
@@ -52,6 +52,10 @@
 
 	<ItemGroup>
 	  <ProjectReference Include="..\..\MonoGameGum\KniGum\KniGum.csproj" />
+	  <ProjectReference Include="..\..\Tools\Gum.Analyzers\Gum.Analyzers.csproj"
+					    Condition="'$(IncludeAnalyzers)' != 'false'"
+					    OutputItemType="Analyzer"
+					    ReferenceOutputAssembly="false" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Runtimes/GumShapes/MonoGameGumShapes.csproj
+++ b/Runtimes/GumShapes/MonoGameGumShapes.csproj
@@ -42,6 +42,10 @@
 
 	<ItemGroup>
 		<ProjectReference Include="..\..\MonoGameGum\MonoGameGum.csproj" />
+		<ProjectReference Include="..\..\Tools\Gum.Analyzers\Gum.Analyzers.csproj"
+						  Condition="'$(IncludeAnalyzers)' != 'false'"
+						  OutputItemType="Analyzer"
+						  ReferenceOutputAssembly="false" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Runtimes/GumShapes/Renderables/ShapeRenderer.cs
+++ b/Runtimes/GumShapes/Renderables/ShapeRenderer.cs
@@ -70,7 +70,7 @@ public class ShapeRenderer
         // Belt-and-suspenders for consumers using GumBatch directly (without GumService).
         // GumService.Initialize already triggers this via reflection scan; calling it here
         // covers the path that bypasses GumService. Idempotent via the guard inside.
-        MonoGameGum.GueDeriving.AposShapeRuntime.RegisterRuntimeTypes();
+        Gum.GueDeriving.AposShapeRuntime.RegisterRuntimeTypes();
     }
 
     [Conditional("DEBUG")]

--- a/Runtimes/RaylibGum/AssemblyAttributes.cs
+++ b/Runtimes/RaylibGum/AssemblyAttributes.cs
@@ -1,3 +1,3 @@
 using Gum.DataTypes;
 
-[assembly: GumSyntaxVersion(Version = 0)]
+[assembly: GumSyntaxVersion(Version = 1)]

--- a/Runtimes/RaylibGum/RaylibGum.csproj
+++ b/Runtimes/RaylibGum/RaylibGum.csproj
@@ -168,7 +168,7 @@
 	<ItemGroup>
 		<ProjectReference Include="..\..\GumCommon\GumCommon.csproj" />
 		<ProjectReference Include="..\..\Tools\Gum.Analyzers\Gum.Analyzers.csproj"
-						  Condition="'$(IncludeAnalyzers)' == 'true'"
+						  Condition="'$(IncludeAnalyzers)' != 'false'"
 						  OutputItemType="Analyzer"
 						  ReferenceOutputAssembly="false" />
 	</ItemGroup>

--- a/Runtimes/SkiaGum.Maui/SkiaGumCanvasView.cs
+++ b/Runtimes/SkiaGum.Maui/SkiaGumCanvasView.cs
@@ -2,7 +2,7 @@
 using Microsoft.Maui;
 using RenderingLibrary;
 using RenderingLibrary.Graphics;
-using SkiaGum.GueDeriving;
+using Gum.GueDeriving;
 using SkiaSharp;
 using SkiaSharp.Views.Maui;
 using System;

--- a/Runtimes/SkiaGum.Wpf/GumSKElement.cs
+++ b/Runtimes/SkiaGum.Wpf/GumSKElement.cs
@@ -1,7 +1,7 @@
 ﻿using Gum.Wireframe;
 using RenderingLibrary;
 using RenderingLibrary.Graphics;
-using SkiaGum.GueDeriving;
+using Gum.GueDeriving;
 using SkiaSharp;
 using SkiaSharp.Views.Desktop;
 using SkiaSharp.Views.WPF;

--- a/Runtimes/SkiaGum/AssemblyAttributes.cs
+++ b/Runtimes/SkiaGum/AssemblyAttributes.cs
@@ -1,3 +1,3 @@
 using Gum.DataTypes;
 
-[assembly: GumSyntaxVersion(Version = 0)]
+[assembly: GumSyntaxVersion(Version = 1)]

--- a/Runtimes/SkiaGum/CustomSetPropertyOnRenderable.cs
+++ b/Runtimes/SkiaGum/CustomSetPropertyOnRenderable.cs
@@ -15,14 +15,14 @@ using System.Threading.Tasks;
 #if SKIA
 using HarfBuzzSharp;
 using SkiaGum.Content;
-using SkiaGum.GueDeriving;
+using Gum.GueDeriving;
 using SkiaGum.Renderables;
 using SkiaSharp;
 using RenderableShapeBase = SkiaGum.Renderables.RenderableShapeBase;
 namespace SkiaGum;
 #else
 using MonoGameAndGum.Renderables;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 namespace MonoGameGumShapes;
 
 #endif

--- a/Runtimes/SkiaGum/GueDeriving/ArcRuntime.cs
+++ b/Runtimes/SkiaGum/GueDeriving/ArcRuntime.cs
@@ -5,11 +5,15 @@ using RenderingLibrary.Graphics;
 using SkiaGum.Renderables;
 using SkiaSharp;
 
+#if FRB
 namespace SkiaGum.GueDeriving;
+#else
+namespace Gum.GueDeriving;
+#endif
 
 public class ArcRuntime : SkiaShapeRuntime
 {
-    protected override Renderables.RenderableShapeBase ContainedRenderable => ContainedArc;
+    protected override RenderableShapeBase ContainedRenderable => ContainedArc;
 
     Arc mContainedArc;
     Arc ContainedArc

--- a/Runtimes/SkiaGum/GueDeriving/CircleRuntime.cs
+++ b/Runtimes/SkiaGum/GueDeriving/CircleRuntime.cs
@@ -7,7 +7,11 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
+#if FRB
 namespace SkiaGum.GueDeriving;
+#else
+namespace Gum.GueDeriving;
+#endif
 public class CircleRuntime : SkiaShapeRuntime
 {
     protected override RenderableShapeBase ContainedRenderable => ContainedCircle;

--- a/Runtimes/SkiaGum/GueDeriving/ColoredCircleRuntime.cs
+++ b/Runtimes/SkiaGum/GueDeriving/ColoredCircleRuntime.cs
@@ -5,11 +5,15 @@ using RenderingLibrary.Graphics;
 using SkiaGum.Renderables;
 using SkiaSharp;
 
+#if FRB
 namespace SkiaGum.GueDeriving;
+#else
+namespace Gum.GueDeriving;
+#endif
 
 public class ColoredCircleRuntime : SkiaShapeRuntime
 {
-    protected override Renderables.RenderableShapeBase ContainedRenderable => ContainedCircle;
+    protected override RenderableShapeBase ContainedRenderable => ContainedCircle;
 
     SkiaGum.Renderables.Circle mContainedCircle;
     SkiaGum.Renderables.Circle ContainedCircle

--- a/Runtimes/SkiaGum/GueDeriving/LineGridRuntime.cs
+++ b/Runtimes/SkiaGum/GueDeriving/LineGridRuntime.cs
@@ -2,7 +2,11 @@
 using SkiaGum.Renderables;
 using SkiaSharp;
 
+#if FRB
 namespace SkiaGum.GueDeriving;
+#else
+namespace Gum.GueDeriving;
+#endif
 
 
 public class LineGridRuntime: SkiaShapeRuntime

--- a/Runtimes/SkiaGum/GueDeriving/LineRuntime.cs
+++ b/Runtimes/SkiaGum/GueDeriving/LineRuntime.cs
@@ -2,7 +2,11 @@ using Gum.Wireframe;
 using SkiaGum.Renderables;
 using SkiaSharp;
 
+#if FRB
 namespace SkiaGum.GueDeriving;
+#else
+namespace Gum.GueDeriving;
+#endif
 
 /// <summary>
 /// Runtime for a line shape that draws from the top-left to the bottom-right of its bounding rectangle.

--- a/Runtimes/SkiaGum/GueDeriving/LottieAnimationRuntime.cs
+++ b/Runtimes/SkiaGum/GueDeriving/LottieAnimationRuntime.cs
@@ -3,7 +3,11 @@ using SkiaGum.Renderables;
 using SkiaSharp.Skottie;
 using System;
 
+#if FRB
 namespace SkiaGum.GueDeriving;
+#else
+namespace Gum.GueDeriving;
+#endif
 
 public class LottieAnimationRuntime : InteractiveGue
 {

--- a/Runtimes/SkiaGum/GueDeriving/PolygonRuntime.cs
+++ b/Runtimes/SkiaGum/GueDeriving/PolygonRuntime.cs
@@ -4,7 +4,11 @@ using SkiaGum.Renderables;
 using SkiaSharp;
 using System.Collections.Generic;
 
+#if FRB
 namespace SkiaGum.GueDeriving;
+#else
+namespace Gum.GueDeriving;
+#endif
 
 public class PolygonRuntime : SkiaShapeRuntime
 {

--- a/Runtimes/SkiaGum/GueDeriving/RoundedRectangleRuntime.cs
+++ b/Runtimes/SkiaGum/GueDeriving/RoundedRectangleRuntime.cs
@@ -6,10 +6,18 @@ using RenderingLibrary.Graphics;
 #if SKIA
 using SkiaGum.Renderables;
 using SkiaSharp;
-namespace SkiaGum.GueDeriving;
 #else
 using MonoGameAndGum.Renderables;
+#endif
+
+#if FRB
+#if SKIA
+namespace SkiaGum.GueDeriving;
+#else
 namespace MonoGameGum.GueDeriving;
+#endif
+#else
+namespace Gum.GueDeriving;
 #endif
 
 /// <summary>

--- a/Runtimes/SkiaGum/GueDeriving/Shims/ArcRuntimeShim.cs
+++ b/Runtimes/SkiaGum/GueDeriving/Shims/ArcRuntimeShim.cs
@@ -1,0 +1,15 @@
+#if !FRB
+using System;
+
+namespace SkiaGum.GueDeriving;
+
+/// <summary>
+/// Compatibility shim. The real type lives in <see cref="Gum.GueDeriving.ArcRuntime"/>.
+/// This derived class exists so existing user code with <c>using SkiaGum.GueDeriving;</c>
+/// continues to compile during the deprecation window.
+/// </summary>
+[Obsolete("Use Gum.GueDeriving.ArcRuntime instead. The SkiaGum.GueDeriving namespace will be removed in a future release.")]
+public class ArcRuntime : Gum.GueDeriving.ArcRuntime
+{
+}
+#endif

--- a/Runtimes/SkiaGum/GueDeriving/Shims/CircleRuntimeShim.cs
+++ b/Runtimes/SkiaGum/GueDeriving/Shims/CircleRuntimeShim.cs
@@ -1,0 +1,19 @@
+#if !FRB
+using System;
+
+namespace SkiaGum.GueDeriving;
+
+/// <summary>
+/// Compatibility shim. The real type lives in <see cref="Gum.GueDeriving.CircleRuntime"/>.
+/// This derived class exists so existing user code with <c>using SkiaGum.GueDeriving;</c>
+/// continues to compile during the deprecation window.
+/// </summary>
+[Obsolete("Use Gum.GueDeriving.CircleRuntime instead. The SkiaGum.GueDeriving namespace will be removed in a future release.")]
+public class CircleRuntime : Gum.GueDeriving.CircleRuntime
+{
+    /// <inheritdoc/>
+    public CircleRuntime(bool fullInstantiation = true) : base(fullInstantiation)
+    {
+    }
+}
+#endif

--- a/Runtimes/SkiaGum/GueDeriving/Shims/ColoredCircleRuntimeShim.cs
+++ b/Runtimes/SkiaGum/GueDeriving/Shims/ColoredCircleRuntimeShim.cs
@@ -1,0 +1,19 @@
+#if !FRB
+using System;
+
+namespace SkiaGum.GueDeriving;
+
+/// <summary>
+/// Compatibility shim. The real type lives in <see cref="Gum.GueDeriving.ColoredCircleRuntime"/>.
+/// This derived class exists so existing user code with <c>using SkiaGum.GueDeriving;</c>
+/// continues to compile during the deprecation window.
+/// </summary>
+[Obsolete("Use Gum.GueDeriving.ColoredCircleRuntime instead. The SkiaGum.GueDeriving namespace will be removed in a future release.")]
+public class ColoredCircleRuntime : Gum.GueDeriving.ColoredCircleRuntime
+{
+    /// <inheritdoc/>
+    public ColoredCircleRuntime(bool fullInstantiation = true) : base(fullInstantiation)
+    {
+    }
+}
+#endif

--- a/Runtimes/SkiaGum/GueDeriving/Shims/ColoredRectangleRuntimeShim.cs
+++ b/Runtimes/SkiaGum/GueDeriving/Shims/ColoredRectangleRuntimeShim.cs
@@ -1,0 +1,19 @@
+#if !FRB
+using System;
+
+namespace SkiaGum.GueDeriving;
+
+/// <summary>
+/// Compatibility shim. The real type lives in <see cref="Gum.GueDeriving.ColoredRectangleRuntime"/>.
+/// This derived class exists so existing user code with <c>using SkiaGum.GueDeriving;</c>
+/// continues to compile during the deprecation window.
+/// </summary>
+[Obsolete("Use Gum.GueDeriving.ColoredRectangleRuntime instead. The SkiaGum.GueDeriving namespace will be removed in a future release.")]
+public class ColoredRectangleRuntime : Gum.GueDeriving.ColoredRectangleRuntime
+{
+    /// <inheritdoc/>
+    public ColoredRectangleRuntime(bool fullInstantiation = true) : base(fullInstantiation)
+    {
+    }
+}
+#endif

--- a/Runtimes/SkiaGum/GueDeriving/Shims/ContainerRuntimeShim.cs
+++ b/Runtimes/SkiaGum/GueDeriving/Shims/ContainerRuntimeShim.cs
@@ -1,0 +1,24 @@
+#if !FRB
+using System;
+
+namespace SkiaGum.GueDeriving;
+
+/// <summary>
+/// Compatibility shim. The real type lives in <see cref="Gum.GueDeriving.ContainerRuntime"/>.
+/// This derived class exists so existing user code with <c>using SkiaGum.GueDeriving;</c>
+/// continues to compile during the deprecation window.
+/// </summary>
+[Obsolete("Use Gum.GueDeriving.ContainerRuntime instead. The SkiaGum.GueDeriving namespace will be removed in a future release.")]
+public class ContainerRuntime : Gum.GueDeriving.ContainerRuntime
+{
+    /// <inheritdoc/>
+    public ContainerRuntime() : base()
+    {
+    }
+
+    /// <inheritdoc/>
+    public ContainerRuntime(bool fullInstantiation = true) : base(fullInstantiation)
+    {
+    }
+}
+#endif

--- a/Runtimes/SkiaGum/GueDeriving/Shims/LineGridRuntimeShim.cs
+++ b/Runtimes/SkiaGum/GueDeriving/Shims/LineGridRuntimeShim.cs
@@ -1,0 +1,19 @@
+#if !FRB
+using System;
+
+namespace SkiaGum.GueDeriving;
+
+/// <summary>
+/// Compatibility shim. The real type lives in <see cref="Gum.GueDeriving.LineGridRuntime"/>.
+/// This derived class exists so existing user code with <c>using SkiaGum.GueDeriving;</c>
+/// continues to compile during the deprecation window.
+/// </summary>
+[Obsolete("Use Gum.GueDeriving.LineGridRuntime instead. The SkiaGum.GueDeriving namespace will be removed in a future release.")]
+public class LineGridRuntime : Gum.GueDeriving.LineGridRuntime
+{
+    /// <inheritdoc/>
+    public LineGridRuntime() : base()
+    {
+    }
+}
+#endif

--- a/Runtimes/SkiaGum/GueDeriving/Shims/LineRuntimeShim.cs
+++ b/Runtimes/SkiaGum/GueDeriving/Shims/LineRuntimeShim.cs
@@ -1,0 +1,19 @@
+#if !FRB
+using System;
+
+namespace SkiaGum.GueDeriving;
+
+/// <summary>
+/// Compatibility shim. The real type lives in <see cref="Gum.GueDeriving.LineRuntime"/>.
+/// This derived class exists so existing user code with <c>using SkiaGum.GueDeriving;</c>
+/// continues to compile during the deprecation window.
+/// </summary>
+[Obsolete("Use Gum.GueDeriving.LineRuntime instead. The SkiaGum.GueDeriving namespace will be removed in a future release.")]
+public class LineRuntime : Gum.GueDeriving.LineRuntime
+{
+    /// <inheritdoc/>
+    public LineRuntime(bool fullInstantiation = true) : base(fullInstantiation)
+    {
+    }
+}
+#endif

--- a/Runtimes/SkiaGum/GueDeriving/Shims/LottieAnimationRuntimeShim.cs
+++ b/Runtimes/SkiaGum/GueDeriving/Shims/LottieAnimationRuntimeShim.cs
@@ -1,0 +1,19 @@
+#if !FRB
+using System;
+
+namespace SkiaGum.GueDeriving;
+
+/// <summary>
+/// Compatibility shim. The real type lives in <see cref="Gum.GueDeriving.LottieAnimationRuntime"/>.
+/// This derived class exists so existing user code with <c>using SkiaGum.GueDeriving;</c>
+/// continues to compile during the deprecation window.
+/// </summary>
+[Obsolete("Use Gum.GueDeriving.LottieAnimationRuntime instead. The SkiaGum.GueDeriving namespace will be removed in a future release.")]
+public class LottieAnimationRuntime : Gum.GueDeriving.LottieAnimationRuntime
+{
+    /// <inheritdoc/>
+    public LottieAnimationRuntime(bool fullInstantiation = true) : base(fullInstantiation)
+    {
+    }
+}
+#endif

--- a/Runtimes/SkiaGum/GueDeriving/Shims/PolygonRuntimeShim.cs
+++ b/Runtimes/SkiaGum/GueDeriving/Shims/PolygonRuntimeShim.cs
@@ -1,0 +1,19 @@
+#if !FRB
+using System;
+
+namespace SkiaGum.GueDeriving;
+
+/// <summary>
+/// Compatibility shim. The real type lives in <see cref="Gum.GueDeriving.PolygonRuntime"/>.
+/// This derived class exists so existing user code with <c>using SkiaGum.GueDeriving;</c>
+/// continues to compile during the deprecation window.
+/// </summary>
+[Obsolete("Use Gum.GueDeriving.PolygonRuntime instead. The SkiaGum.GueDeriving namespace will be removed in a future release.")]
+public class PolygonRuntime : Gum.GueDeriving.PolygonRuntime
+{
+    /// <inheritdoc/>
+    public PolygonRuntime(bool fullInstantiation = true) : base(fullInstantiation)
+    {
+    }
+}
+#endif

--- a/Runtimes/SkiaGum/GueDeriving/Shims/RoundedRectangleRuntimeShim.cs
+++ b/Runtimes/SkiaGum/GueDeriving/Shims/RoundedRectangleRuntimeShim.cs
@@ -1,0 +1,19 @@
+#if !FRB
+using System;
+
+namespace SkiaGum.GueDeriving;
+
+/// <summary>
+/// Compatibility shim. The real type lives in <see cref="Gum.GueDeriving.RoundedRectangleRuntime"/>.
+/// This derived class exists so existing user code with <c>using SkiaGum.GueDeriving;</c>
+/// continues to compile during the deprecation window.
+/// </summary>
+[Obsolete("Use Gum.GueDeriving.RoundedRectangleRuntime instead. The SkiaGum.GueDeriving namespace will be removed in a future release.")]
+public class RoundedRectangleRuntime : Gum.GueDeriving.RoundedRectangleRuntime
+{
+    /// <inheritdoc/>
+    public RoundedRectangleRuntime(bool fullInstantiation = true) : base(fullInstantiation)
+    {
+    }
+}
+#endif

--- a/Runtimes/SkiaGum/GueDeriving/Shims/SkiaShapeRuntimeShim.cs
+++ b/Runtimes/SkiaGum/GueDeriving/Shims/SkiaShapeRuntimeShim.cs
@@ -1,0 +1,15 @@
+#if !FRB
+using System;
+
+namespace SkiaGum.GueDeriving;
+
+/// <summary>
+/// Compatibility shim. The real type lives in <see cref="Gum.GueDeriving.SkiaShapeRuntime"/>.
+/// This derived class exists so existing user code with <c>using SkiaGum.GueDeriving;</c>
+/// continues to compile during the deprecation window.
+/// </summary>
+[Obsolete("Use Gum.GueDeriving.SkiaShapeRuntime instead. The SkiaGum.GueDeriving namespace will be removed in a future release.")]
+public abstract class SkiaShapeRuntime : Gum.GueDeriving.SkiaShapeRuntime
+{
+}
+#endif

--- a/Runtimes/SkiaGum/GueDeriving/Shims/SolidRectangleRuntimeShim.cs
+++ b/Runtimes/SkiaGum/GueDeriving/Shims/SolidRectangleRuntimeShim.cs
@@ -1,0 +1,19 @@
+#if !FRB
+using System;
+
+namespace SkiaGum.GueDeriving;
+
+/// <summary>
+/// Compatibility shim. The real type lives in <see cref="Gum.GueDeriving.SolidRectangleRuntime"/>.
+/// This derived class exists so existing user code with <c>using SkiaGum.GueDeriving;</c>
+/// continues to compile during the deprecation window.
+/// </summary>
+[Obsolete("Use Gum.GueDeriving.SolidRectangleRuntime instead. The SkiaGum.GueDeriving namespace will be removed in a future release.")]
+public class SolidRectangleRuntime : Gum.GueDeriving.SolidRectangleRuntime
+{
+    /// <inheritdoc/>
+    public SolidRectangleRuntime(bool fullInstantiation = true) : base(fullInstantiation)
+    {
+    }
+}
+#endif

--- a/Runtimes/SkiaGum/GueDeriving/Shims/SpriteRuntimeShim.cs
+++ b/Runtimes/SkiaGum/GueDeriving/Shims/SpriteRuntimeShim.cs
@@ -1,0 +1,20 @@
+#if !FRB
+using System;
+
+namespace SkiaGum.GueDeriving;
+
+/// <summary>
+/// Compatibility shim. The real type lives in <see cref="Gum.GueDeriving.SpriteRuntime"/>.
+/// This derived class exists so existing user code with <c>using SkiaGum.GueDeriving;</c>
+/// continues to compile during the deprecation window.
+/// </summary>
+[Obsolete("Use Gum.GueDeriving.SpriteRuntime instead. The SkiaGum.GueDeriving namespace will be removed in a future release.")]
+public class SpriteRuntime : Gum.GueDeriving.SpriteRuntime
+{
+    /// <inheritdoc/>
+    public SpriteRuntime(bool fullInstantiation = true, bool tryCreateFormsObject = true)
+        : base(fullInstantiation, tryCreateFormsObject)
+    {
+    }
+}
+#endif

--- a/Runtimes/SkiaGum/GueDeriving/Shims/SvgRuntimeShim.cs
+++ b/Runtimes/SkiaGum/GueDeriving/Shims/SvgRuntimeShim.cs
@@ -1,0 +1,19 @@
+#if !FRB
+using System;
+
+namespace SkiaGum.GueDeriving;
+
+/// <summary>
+/// Compatibility shim. The real type lives in <see cref="Gum.GueDeriving.SvgRuntime"/>.
+/// This derived class exists so existing user code with <c>using SkiaGum.GueDeriving;</c>
+/// continues to compile during the deprecation window.
+/// </summary>
+[Obsolete("Use Gum.GueDeriving.SvgRuntime instead. The SkiaGum.GueDeriving namespace will be removed in a future release.")]
+public class SvgRuntime : Gum.GueDeriving.SvgRuntime
+{
+    /// <inheritdoc/>
+    public SvgRuntime(bool fullInstantiation = true) : base(fullInstantiation)
+    {
+    }
+}
+#endif

--- a/Runtimes/SkiaGum/GueDeriving/Shims/TextRuntimeShim.cs
+++ b/Runtimes/SkiaGum/GueDeriving/Shims/TextRuntimeShim.cs
@@ -1,0 +1,21 @@
+#if !FRB
+using System;
+using RenderingLibrary;
+
+namespace SkiaGum.GueDeriving;
+
+/// <summary>
+/// Compatibility shim. The real type lives in <see cref="Gum.GueDeriving.TextRuntime"/>.
+/// This derived class exists so existing user code with <c>using SkiaGum.GueDeriving;</c>
+/// continues to compile during the deprecation window.
+/// </summary>
+[Obsolete("Use Gum.GueDeriving.TextRuntime instead. The SkiaGum.GueDeriving namespace will be removed in a future release.")]
+public class TextRuntime : Gum.GueDeriving.TextRuntime
+{
+    /// <inheritdoc/>
+    public TextRuntime(bool fullInstantiation = true, SystemManagers? systemManagers = null)
+        : base(fullInstantiation, systemManagers)
+    {
+    }
+}
+#endif

--- a/Runtimes/SkiaGum/GueDeriving/SkiaShapeRuntime.cs
+++ b/Runtimes/SkiaGum/GueDeriving/SkiaShapeRuntime.cs
@@ -5,11 +5,15 @@ using RenderingLibrary.Graphics;
 using SkiaGum.Renderables;
 using SkiaSharp;
 
+#if FRB
 namespace SkiaGum.GueDeriving;
+#else
+namespace Gum.GueDeriving;
+#endif
 
 public abstract class SkiaShapeRuntime : InteractiveGue
 {
-    protected abstract Renderables.RenderableShapeBase ContainedRenderable { get; }
+    protected abstract RenderableShapeBase ContainedRenderable { get; }
 
     #region Solid colors
 

--- a/Runtimes/SkiaGum/GueDeriving/SolidRectangleRuntime.cs
+++ b/Runtimes/SkiaGum/GueDeriving/SolidRectangleRuntime.cs
@@ -2,7 +2,11 @@
 using SkiaGum.Renderables;
 using SkiaSharp;
 
+#if FRB
 namespace SkiaGum.GueDeriving;
+#else
+namespace Gum.GueDeriving;
+#endif
 
 public class SolidRectangleRuntime : InteractiveGue
 {

--- a/Runtimes/SkiaGum/GueDeriving/SvgRuntime.cs
+++ b/Runtimes/SkiaGum/GueDeriving/SvgRuntime.cs
@@ -1,9 +1,14 @@
 ﻿using Gum.DataTypes;
 using Gum.Wireframe;
+using SkiaGum;
 using SkiaSharp;
 using Svg.Skia;
 
+#if FRB
 namespace SkiaGum.GueDeriving;
+#else
+namespace Gum.GueDeriving;
+#endif
 
 public class SvgRuntime : InteractiveGue
 {

--- a/Runtimes/SkiaGum/GumService.cs
+++ b/Runtimes/SkiaGum/GumService.cs
@@ -2,7 +2,7 @@ using Gum.DataTypes;
 using Gum.Managers;
 using Gum.Wireframe;
 using RenderingLibrary;
-using SkiaGum.GueDeriving;
+using Gum.GueDeriving;
 using SkiaSharp;
 using System;
 using System.Collections.Generic;

--- a/Runtimes/SkiaGum/Renderables/CanvasRenderable.cs
+++ b/Runtimes/SkiaGum/Renderables/CanvasRenderable.cs
@@ -1,6 +1,6 @@
 ﻿using RenderingLibrary;
 using RenderingLibrary.Graphics;
-using SkiaGum.GueDeriving;
+using Gum.GueDeriving;
 using System;
 using System.Collections.ObjectModel;
 using Vector2 = System.Numerics.Vector2;

--- a/Runtimes/SkiaGum/Renderables/LottieAnimation.cs
+++ b/Runtimes/SkiaGum/Renderables/LottieAnimation.cs
@@ -1,6 +1,6 @@
 ﻿using RenderingLibrary;
 using RenderingLibrary.Graphics;
-using SkiaGum.GueDeriving;
+using Gum.GueDeriving;
 using SkiaSharp;
 using System;
 using System.Collections.ObjectModel;

--- a/Runtimes/SkiaGum/Renderables/Text.cs
+++ b/Runtimes/SkiaGum/Renderables/Text.cs
@@ -1,6 +1,6 @@
 ﻿using RenderingLibrary;
 using RenderingLibrary.Graphics;
-using SkiaGum.GueDeriving;
+using Gum.GueDeriving;
 using SkiaSharp;
 using System;
 using System.Collections.ObjectModel;

--- a/Runtimes/SkiaGum/Renderables/VectorSprite.cs
+++ b/Runtimes/SkiaGum/Renderables/VectorSprite.cs
@@ -1,6 +1,6 @@
 ﻿using RenderingLibrary;
 using RenderingLibrary.Graphics;
-using SkiaGum.GueDeriving;
+using Gum.GueDeriving;
 using SkiaSharp;
 using Svg.Skia;
 using System.Collections.ObjectModel;

--- a/Runtimes/SkiaGum/RenderingLibrary/IRenderableIpsoExtensions.cs
+++ b/Runtimes/SkiaGum/RenderingLibrary/IRenderableIpsoExtensions.cs
@@ -1,6 +1,6 @@
 ﻿using Gum.Wireframe;
 using RenderingLibrary.Graphics;
-using SkiaGum.GueDeriving;
+using Gum.GueDeriving;
 using SkiaGum.Renderables;
 using SkiaSharp;
 using System;

--- a/Runtimes/SkiaGum/RenderingLibrary/Renderer.cs
+++ b/Runtimes/SkiaGum/RenderingLibrary/Renderer.cs
@@ -1,4 +1,4 @@
-﻿using SkiaGum.GueDeriving;
+﻿using Gum.GueDeriving;
 using SkiaSharp;
 using System;
 using System.Collections.Generic;

--- a/Runtimes/SkiaGum/RenderingLibrary/SystemManagers.cs
+++ b/Runtimes/SkiaGum/RenderingLibrary/SystemManagers.cs
@@ -6,7 +6,7 @@ using RenderingLibrary.Content;
 using RenderingLibrary.Graphics;
 using SkiaGum;
 using SkiaGum.Content;
-using SkiaGum.GueDeriving;
+using Gum.GueDeriving;
 using SkiaGum.Renderables;
 using SkiaPlugin.Managers;
 using System;

--- a/Runtimes/SkiaGum/SkiaGum.csproj
+++ b/Runtimes/SkiaGum/SkiaGum.csproj
@@ -64,7 +64,7 @@
 	<ItemGroup>
 		<ProjectReference Include="..\..\GumCommon\GumCommon.csproj" />
 		<ProjectReference Include="..\..\Tools\Gum.Analyzers\Gum.Analyzers.csproj"
-						  Condition="'$(IncludeAnalyzers)' == 'true'"
+						  Condition="'$(IncludeAnalyzers)' != 'false'"
 						  OutputItemType="Analyzer"
 						  ReferenceOutputAssembly="false" />
 	</ItemGroup>

--- a/Runtimes/SokolGum/README.md
+++ b/Runtimes/SokolGum/README.md
@@ -53,7 +53,7 @@ Runtimes/SokolGum/
 │                       # are file-linked from MonoGameGum/GueDeriving/
 │                       # via #if SOKOL branches; NineSliceRuntime
 │                       # is file-linked from RaylibGum/GueDeriving/.
-│                       # See .claude/designs/runtime-refactoring.md.
+│                       # See .claude/designs/runtime-unification/runtime-refactoring.md.
 ├── Renderables/        # Sprite, NineSlice, SolidRectangle, Text,
 │                       # Line, LineRectangle, LineCircle, LinePolygon,
 │                       # LineGrid

--- a/Samples/FnaGum/FnaSample/Game1.cs
+++ b/Samples/FnaGum/FnaSample/Game1.cs
@@ -8,7 +8,7 @@ using System.Linq;
 using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Input;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using MonoGameGum.Forms.Controls;
 using Gum.Wireframe;
 using FnaSample.Screens;

--- a/Samples/GameUiSamples/Components/FrbClickerComponents/BallButtonRuntime.cs
+++ b/Samples/GameUiSamples/Components/FrbClickerComponents/BallButtonRuntime.cs
@@ -1,6 +1,6 @@
 ﻿using Gum.Wireframe;
 using Gum.Forms.Controls;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System;
 using System.Collections.Generic;

--- a/Samples/GameUiSamples/Components/FrbClickerComponents/BuildingButtonRuntime.cs
+++ b/Samples/GameUiSamples/Components/FrbClickerComponents/BuildingButtonRuntime.cs
@@ -1,7 +1,7 @@
 ﻿using Gum.Wireframe;
 using Gum.Forms.Controls;
 using Gum.Forms.DefaultVisuals;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System;
 using System.Collections.Generic;

--- a/Samples/GameUiSamples/Components/FrbClickerComponents/ToolTip.cs
+++ b/Samples/GameUiSamples/Components/FrbClickerComponents/ToolTip.cs
@@ -1,5 +1,5 @@
 ﻿using Gum.Wireframe;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System;
 using System.Collections.Generic;

--- a/Samples/GumFormsSample/GumFormsSampleCommon/CustomForms/ColorComponentSlider.cs
+++ b/Samples/GumFormsSample/GumFormsSampleCommon/CustomForms/ColorComponentSlider.cs
@@ -2,7 +2,7 @@
 using Microsoft.Xna.Framework.Graphics;
 using MonoGameGum;
 using Gum.Forms.Controls;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/Samples/GumFormsSample/GumFormsSampleCommon/CustomRuntimes/CustomListBoxItemRuntime.cs
+++ b/Samples/GumFormsSample/GumFormsSampleCommon/CustomRuntimes/CustomListBoxItemRuntime.cs
@@ -1,7 +1,7 @@
 ﻿using Gum.Converters;
 using Gum.Wireframe;
 using Gum.Forms.Controls;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System;
 using System.Collections.Generic;

--- a/Samples/GumFormsSample/GumFormsSampleCommon/CustomRuntimes/FullyCustomizedButton.cs
+++ b/Samples/GumFormsSample/GumFormsSampleCommon/CustomRuntimes/FullyCustomizedButton.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 using Gum.Wireframe;
 using Microsoft.Xna.Framework;
 using Gum.Forms.Controls;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using RenderingLibrary.Graphics;
 
 namespace GumFormsSample

--- a/Samples/GumFormsSample/GumFormsSampleCommon/CustomRuntimes/SimpleListBoxItemRuntime.cs
+++ b/Samples/GumFormsSample/GumFormsSampleCommon/CustomRuntimes/SimpleListBoxItemRuntime.cs
@@ -1,5 +1,5 @@
 ﻿using MonoGameGum.Forms.DefaultVisuals;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/Samples/GumFormsSample/GumFormsSampleCommon/Screens/ComplexListBoxItemScreen.cs
+++ b/Samples/GumFormsSample/GumFormsSampleCommon/Screens/ComplexListBoxItemScreen.cs
@@ -5,7 +5,7 @@ using GumFormsSample.CustomRuntimes;
 using GumRuntime;
 using Gum.Forms;
 using Gum.Forms.Controls;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using RenderingLibrary;
 using System;
 using System.Collections.Generic;

--- a/Samples/GumFormsSample/GumFormsSampleCommon/Screens/FormsCustomizationScreen.cs
+++ b/Samples/GumFormsSample/GumFormsSampleCommon/Screens/FormsCustomizationScreen.cs
@@ -4,7 +4,7 @@ using GumFormsSample.CustomForms;
 using GumFormsSample.CustomRuntimes;
 using MonoGameGum;
 using Gum.Forms.Controls;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/Samples/GumFormsSample/GumFormsSampleCommon/Screens/FrameworkElementExampleScreen.cs
+++ b/Samples/GumFormsSample/GumFormsSampleCommon/Screens/FrameworkElementExampleScreen.cs
@@ -5,7 +5,7 @@ using MonoGameGum;
 using Gum.Forms;
 using Gum.Forms.Controls;
 using Gum.Forms.DefaultVisuals;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using RenderingLibrary;
 using RenderingLibrary.Graphics;
 using System;

--- a/Samples/GumFormsSample/GumFormsSampleCommon/Screens/ListBoxBindingScreen.cs
+++ b/Samples/GumFormsSample/GumFormsSampleCommon/Screens/ListBoxBindingScreen.cs
@@ -1,7 +1,7 @@
 ﻿using Gum.Mvvm;
 using Gum.Wireframe;
 using Gum.Forms.Controls;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System;
 using System.Collections.Generic;

--- a/Samples/KniGumFromFile/KniGumFromFileCommon/KniGumFromFileGame.cs
+++ b/Samples/KniGumFromFile/KniGumFromFileCommon/KniGumFromFileGame.cs
@@ -13,7 +13,7 @@ using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Input;
 using Microsoft.Xna.Framework.Input.Touch;
 using Microsoft.Xna.Framework.Media;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using MonoGameGum.Input;
 using MonoGameGum.Renderables;
 using KniGumFromFile.ComponentRuntimes;

--- a/Samples/KniGumInCode/KniGumInCodeCommon/KniGumInCodeGame.cs
+++ b/Samples/KniGumInCode/KniGumInCodeCommon/KniGumInCodeGame.cs
@@ -6,7 +6,7 @@ using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Input;
 using Microsoft.Xna.Framework.Input.Touch;
 using Microsoft.Xna.Framework.Media;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using RenderingLibrary;
 using RenderingLibrary.Graphics;
 using Gum.Wireframe;

--- a/Samples/MVVM/Game1.cs
+++ b/Samples/MVVM/Game1.cs
@@ -4,7 +4,7 @@ using GumRuntime;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Input;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using RenderingLibrary;
 using System.Linq;
 

--- a/Samples/MauiSkiaGum/MainPage.xaml.cs
+++ b/Samples/MauiSkiaGum/MainPage.xaml.cs
@@ -1,6 +1,6 @@
 ﻿using MauiSkiaGum.Components;
 using SkiaGum.Content;
-using SkiaGum.GueDeriving;
+using Gum.GueDeriving;
 using SkiaGum.Maui;
 using SkiaSharp;
 

--- a/Samples/MonoGameGumFontLoading/MonoGameGumFontLoading/Game1.cs
+++ b/Samples/MonoGameGumFontLoading/MonoGameGumFontLoading/Game1.cs
@@ -1,7 +1,7 @@
 ﻿using Gum.Wireframe;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using RenderingLibrary;
 using System;
 using System.Collections.Generic;

--- a/Samples/MonoGameGumFromFile/MonoGameGumFromFile/Game1.cs
+++ b/Samples/MonoGameGumFromFile/MonoGameGumFromFile/Game1.cs
@@ -8,7 +8,7 @@ using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Input;
 using MonoGameGum;
 using MonoGameGum.Forms;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using MonoGameGum.Input;
 using MonoGameGum.Renderables;
 using MonoGameGumFromFile.ComponentRuntimes;

--- a/Samples/MonoGameGumImmediateMode/MonoGameGumImmediateMode/Game1.cs
+++ b/Samples/MonoGameGumImmediateMode/MonoGameGumImmediateMode/Game1.cs
@@ -3,7 +3,7 @@ using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Input;
 using Gum.Forms;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using RenderingLibrary;
 using RenderingLibrary.Graphics;
 

--- a/Samples/MonoGameGumInCode/MonoGameGumInCode/Game1.cs
+++ b/Samples/MonoGameGumInCode/MonoGameGumInCode/Game1.cs
@@ -4,7 +4,7 @@ using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Input;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using MonoGameGumInCode.Screens;
 using RenderingLibrary;
 using RenderingLibrary.Graphics;

--- a/Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/FormsScreen.cs
+++ b/Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/FormsScreen.cs
@@ -1,5 +1,5 @@
 ﻿using Gum.Forms.Controls;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/StandardsScreen.cs
+++ b/Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/StandardsScreen.cs
@@ -1,5 +1,5 @@
 ﻿using Gum.Forms.Controls;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/Samples/SilkNetGum/SilkNetGum/Program.cs
+++ b/Samples/SilkNetGum/SilkNetGum/Program.cs
@@ -6,7 +6,7 @@ using System.Diagnostics;
 using System.Runtime.InteropServices;
 using RenderingLibrary;
 using Gum.Wireframe;
-using SkiaGum.GueDeriving;
+using Gum.GueDeriving;
 using RenderingLibrary.Graphics;
 using SkiaGum;
 using SilkNetGum.Screens;

--- a/Samples/SilkNetGum/SilkNetGum/Screens/CodeOnlyScreen.cs
+++ b/Samples/SilkNetGum/SilkNetGum/Screens/CodeOnlyScreen.cs
@@ -1,6 +1,6 @@
 ﻿using Gum.Wireframe;
 using RenderingLibrary.Graphics;
-using SkiaGum.GueDeriving;
+using Gum.GueDeriving;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/Samples/SkiaGumWpfSample/SkiaGumWpfSample/MainWindow.xaml.cs
+++ b/Samples/SkiaGumWpfSample/SkiaGumWpfSample/MainWindow.xaml.cs
@@ -1,4 +1,4 @@
-﻿using SkiaGum.GueDeriving;
+﻿using Gum.GueDeriving;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/Tests/Gum.Analyzers.Tests/NamespaceMigrationAnalyzerTests.cs
+++ b/Tests/Gum.Analyzers.Tests/NamespaceMigrationAnalyzerTests.cs
@@ -10,28 +10,9 @@ namespace Gum.Analyzers.Tests;
 public class NamespaceMigrationAnalyzerTests
 {
     [Fact]
-    public async Task EmptyMappingTable_NoDiagnostics()
-    {
-        // With an empty mapping table (Phase 1 state), the analyzer should never fire,
-        // even on code that uses namespaces which will eventually be migrated.
-        // We use only System namespaces here to avoid compiler errors in the test harness.
-        string testCode = @"
-using System;
-using System.Collections.Generic;
-
-namespace TestProject
-{
-    class MyClass { }
-}
-";
-
-        // This should produce no diagnostics since the mapping table is empty
-        await AnalyzerVerifier.VerifyAnalyzerAsync(testCode);
-    }
-
-    [Fact]
     public async Task UnrelatedUsing_NoDiagnostics()
     {
+        // Using directives that aren't in the migration table should never raise GUM001.
         string testCode = @"
 using System;
 using System.Collections.Generic;
@@ -43,21 +24,5 @@ namespace TestProject
 ";
 
         await AnalyzerVerifier.VerifyAnalyzerAsync(testCode);
-    }
-
-    [Fact]
-    public void MappingTable_IsEmpty_InPhase1()
-    {
-        // Verify our Phase 1 assumption: no migrations are registered yet
-        Assert.True(NamespaceMigrationMapping.Migrations.IsEmpty,
-            "Migration table should be empty during Phase 1. " +
-            "Entries should only be added when types are actually moved.");
-    }
-
-    [Fact]
-    public void MappingTable_ByOldNamespace_IsEmpty_InPhase1()
-    {
-        Assert.True(NamespaceMigrationMapping.ByOldNamespace.IsEmpty,
-            "ByOldNamespace lookup should be empty during Phase 1.");
     }
 }

--- a/Tests/Gum.Analyzers.Tests/NamespaceMigrationCodeFixTests.cs
+++ b/Tests/Gum.Analyzers.Tests/NamespaceMigrationCodeFixTests.cs
@@ -1,0 +1,159 @@
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Testing;
+using Xunit;
+using CodeFixVerifier = Microsoft.CodeAnalysis.CSharp.Testing.CSharpCodeFixVerifier<
+    Gum.Analyzers.NamespaceMigrationAnalyzer,
+    Gum.Analyzers.NamespaceMigrationCodeFixProvider,
+    Microsoft.CodeAnalysis.Testing.DefaultVerifier>;
+
+namespace Gum.Analyzers.Tests;
+
+/// <summary>
+/// Verifies that <c>GUM001</c> fires on <c>using</c> directives that import old runtime namespaces
+/// (<c>MonoGameGum.GueDeriving</c>, <c>SkiaGum.GueDeriving</c>) and that the code fix rewrites them
+/// to the unified <c>Gum.GueDeriving</c> namespace.
+/// </summary>
+public class NamespaceMigrationCodeFixTests
+{
+    [Fact]
+    public async Task MappingTable_ContainsRuntimeMigrations()
+    {
+        // Smoke test: at least one migration from each old namespace should be present
+        // after Phase 2 lands.
+        Assert.False(NamespaceMigrationMapping.Migrations.IsEmpty,
+            "Migration table should contain runtime namespace migrations after Phase 2.");
+
+        Assert.True(NamespaceMigrationMapping.ByOldNamespace.ContainsKey("MonoGameGum.GueDeriving"),
+            "MonoGameGum.GueDeriving should be a registered old namespace.");
+        Assert.True(NamespaceMigrationMapping.ByOldNamespace.ContainsKey("SkiaGum.GueDeriving"),
+            "SkiaGum.GueDeriving should be a registered old namespace.");
+    }
+
+    [Fact]
+    public async Task UsingMonoGameGumGueDeriving_RaisesGum001()
+    {
+        string testCode = @"
+{|GUM001:using MonoGameGum.GueDeriving;|}
+
+namespace TestProject
+{
+    class MyClass { }
+}
+
+namespace MonoGameGum.GueDeriving
+{
+    public class SpriteRuntime { }
+}
+";
+
+        await CodeFixVerifier.VerifyAnalyzerAsync(testCode);
+    }
+
+    [Fact]
+    public async Task UsingSkiaGumGueDeriving_RaisesGum001()
+    {
+        string testCode = @"
+{|GUM001:using SkiaGum.GueDeriving;|}
+
+namespace TestProject
+{
+    class MyClass { }
+}
+
+namespace SkiaGum.GueDeriving
+{
+    public class ArcRuntime { }
+}
+";
+
+        await CodeFixVerifier.VerifyAnalyzerAsync(testCode);
+    }
+
+    [Fact]
+    public async Task CodeFix_RewritesMonoGameGumGueDerivingUsing()
+    {
+        string testCode = @"
+{|GUM001:using MonoGameGum.GueDeriving;|}
+
+namespace TestProject
+{
+    class MyClass { }
+}
+
+namespace MonoGameGum.GueDeriving
+{
+    public class SpriteRuntime { }
+}
+
+namespace Gum.GueDeriving
+{
+    public class SpriteRuntime { }
+}
+";
+
+        string fixedCode = @"
+using Gum.GueDeriving;
+
+namespace TestProject
+{
+    class MyClass { }
+}
+
+namespace MonoGameGum.GueDeriving
+{
+    public class SpriteRuntime { }
+}
+
+namespace Gum.GueDeriving
+{
+    public class SpriteRuntime { }
+}
+";
+
+        await CodeFixVerifier.VerifyCodeFixAsync(testCode, fixedCode);
+    }
+
+    [Fact]
+    public async Task CodeFix_RewritesSkiaGumGueDerivingUsing()
+    {
+        string testCode = @"
+{|GUM001:using SkiaGum.GueDeriving;|}
+
+namespace TestProject
+{
+    class MyClass { }
+}
+
+namespace SkiaGum.GueDeriving
+{
+    public class ArcRuntime { }
+}
+
+namespace Gum.GueDeriving
+{
+    public class ArcRuntime { }
+}
+";
+
+        string fixedCode = @"
+using Gum.GueDeriving;
+
+namespace TestProject
+{
+    class MyClass { }
+}
+
+namespace SkiaGum.GueDeriving
+{
+    public class ArcRuntime { }
+}
+
+namespace Gum.GueDeriving
+{
+    public class ArcRuntime { }
+}
+";
+
+        await CodeFixVerifier.VerifyCodeFixAsync(testCode, fixedCode);
+    }
+}

--- a/Tests/Gum.ProjectServices.Tests/CodeGeneratorSyntaxVersionNamespaceTests.cs
+++ b/Tests/Gum.ProjectServices.Tests/CodeGeneratorSyntaxVersionNamespaceTests.cs
@@ -1,0 +1,175 @@
+using Gum.DataTypes;
+using Gum.Managers;
+using Gum.ProjectServices.CodeGeneration;
+using Shouldly;
+
+namespace Gum.ProjectServices.Tests;
+
+/// <summary>
+/// Tests that the code generator emits the unified <c>Gum.GueDeriving</c> namespace when the
+/// resolved syntax version is &gt;= 1, and falls back to the legacy <c>MonoGameGum.GueDeriving</c>
+/// / <c>SkiaGum.GueDeriving</c> namespaces for version 0.
+/// </summary>
+public class CodeGeneratorSyntaxVersionNamespaceTests
+{
+    [Fact]
+    public void GetGueDerivingNamespace_Version0_MonoGame_ReturnsMonoGameGumNamespace()
+    {
+        string result = CodeGenerator.GetGueDerivingNamespace(syntaxVersion: 0, isSkia: false);
+
+        result.ShouldBe("MonoGameGum.GueDeriving");
+    }
+
+    [Fact]
+    public void GetGueDerivingNamespace_Version0_Skia_ReturnsSkiaGumNamespace()
+    {
+        string result = CodeGenerator.GetGueDerivingNamespace(syntaxVersion: 0, isSkia: true);
+
+        result.ShouldBe("SkiaGum.GueDeriving");
+    }
+
+    [Fact]
+    public void GetGueDerivingNamespace_Version1_MonoGame_ReturnsUnifiedNamespace()
+    {
+        string result = CodeGenerator.GetGueDerivingNamespace(syntaxVersion: 1, isSkia: false);
+
+        result.ShouldBe("Gum.GueDeriving");
+    }
+
+    [Fact]
+    public void GetGueDerivingNamespace_Version1_Skia_ReturnsUnifiedNamespace()
+    {
+        string result = CodeGenerator.GetGueDerivingNamespace(syntaxVersion: 1, isSkia: true);
+
+        result.ShouldBe("Gum.GueDeriving");
+    }
+
+    [Fact]
+    public void GetGueDerivingNamespace_Version2_MonoGame_ReturnsUnifiedNamespace()
+    {
+        // Any version >= 1 should use the unified namespace (forward compatible)
+        string result = CodeGenerator.GetGueDerivingNamespace(syntaxVersion: 2, isSkia: false);
+
+        result.ShouldBe("Gum.GueDeriving");
+    }
+
+    [Fact]
+    public void GetInheritance_Version0_MonoGame_StandardElement_UsesLegacyNamespace()
+    {
+        // Set up a Container standard element that GetInheritance will resolve against.
+        // Use "Sprite" — for "Container" + MonoGame the codegen takes a special branch that
+        // emits an unqualified ContainerRuntime (relying on the using directive). Sprite goes
+        // through the namespace-prefixed branch we want to verify.
+        StandardElementSave sprite = new StandardElementSave { Name = "Sprite" };
+        GumProjectSave project = new GumProjectSave();
+        project.StandardElements.Add(sprite);
+        ObjectFinder.Self.GumProjectSave = project;
+
+        try
+        {
+            ComponentSave component = new ComponentSave();
+            component.BaseType = "Sprite";
+
+            CodeOutputProjectSettings settings = new CodeOutputProjectSettings
+            {
+                OutputLibrary = OutputLibrary.MonoGame
+            };
+
+            string? result = CodeGenerator.GetInheritance(component, settings, resolvedSyntaxVersion: 0);
+
+            result.ShouldBe("global::MonoGameGum.GueDeriving.SpriteRuntime");
+        }
+        finally
+        {
+            ObjectFinder.Self.GumProjectSave = null;
+        }
+    }
+
+    [Fact]
+    public void GetInheritance_Version1_MonoGame_StandardElement_UsesUnifiedNamespace()
+    {
+        // Use "Sprite" — for "Container" + MonoGame the codegen takes a special branch that
+        // emits an unqualified ContainerRuntime (relying on the using directive). Sprite goes
+        // through the namespace-prefixed branch we want to verify.
+        StandardElementSave sprite = new StandardElementSave { Name = "Sprite" };
+        GumProjectSave project = new GumProjectSave();
+        project.StandardElements.Add(sprite);
+        ObjectFinder.Self.GumProjectSave = project;
+
+        try
+        {
+            ComponentSave component = new ComponentSave();
+            component.BaseType = "Sprite";
+
+            CodeOutputProjectSettings settings = new CodeOutputProjectSettings
+            {
+                OutputLibrary = OutputLibrary.MonoGame
+            };
+
+            string? result = CodeGenerator.GetInheritance(component, settings, resolvedSyntaxVersion: 1);
+
+            result.ShouldBe("global::Gum.GueDeriving.SpriteRuntime");
+        }
+        finally
+        {
+            ObjectFinder.Self.GumProjectSave = null;
+        }
+    }
+
+    [Fact]
+    public void GetInheritance_Version1_Skia_StandardElement_UsesUnifiedNamespace()
+    {
+        StandardElementSave container = new StandardElementSave { Name = "Container" };
+        GumProjectSave project = new GumProjectSave();
+        project.StandardElements.Add(container);
+        ObjectFinder.Self.GumProjectSave = project;
+
+        try
+        {
+            ComponentSave component = new ComponentSave();
+            component.BaseType = "Container";
+
+            CodeOutputProjectSettings settings = new CodeOutputProjectSettings
+            {
+                OutputLibrary = OutputLibrary.Skia
+            };
+
+            string? result = CodeGenerator.GetInheritance(component, settings, resolvedSyntaxVersion: 1);
+
+            // Skia always emits ContainerRuntime; check the namespace flips.
+            result.ShouldBe("Gum.GueDeriving.ContainerRuntime");
+        }
+        finally
+        {
+            ObjectFinder.Self.GumProjectSave = null;
+        }
+    }
+
+    [Fact]
+    public void GetInheritance_Version0_Skia_StandardElement_UsesLegacyNamespace()
+    {
+        StandardElementSave container = new StandardElementSave { Name = "Container" };
+        GumProjectSave project = new GumProjectSave();
+        project.StandardElements.Add(container);
+        ObjectFinder.Self.GumProjectSave = project;
+
+        try
+        {
+            ComponentSave component = new ComponentSave();
+            component.BaseType = "Container";
+
+            CodeOutputProjectSettings settings = new CodeOutputProjectSettings
+            {
+                OutputLibrary = OutputLibrary.Skia
+            };
+
+            string? result = CodeGenerator.GetInheritance(component, settings, resolvedSyntaxVersion: 0);
+
+            result.ShouldBe("SkiaGum.GueDeriving.ContainerRuntime");
+        }
+        finally
+        {
+            ObjectFinder.Self.GumProjectSave = null;
+        }
+    }
+}

--- a/Tests/MonoGameGum.Tests.V2/Forms/ListBoxTests.cs
+++ b/Tests/MonoGameGum.Tests.V2/Forms/ListBoxTests.cs
@@ -1,6 +1,6 @@
 ﻿using Gum.Forms.Controls;
 using Gum.Wireframe;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using Shouldly;
 using System;
 using System.Collections.Generic;

--- a/Tests/MonoGameGum.Tests.V2/Forms/ScrollBarTests.cs
+++ b/Tests/MonoGameGum.Tests.V2/Forms/ScrollBarTests.cs
@@ -1,7 +1,7 @@
 ﻿using Gum.Forms.Controls;
 using Gum.Forms.DefaultVisuals;
 using Gum.Wireframe;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using Shouldly;
 using System;
 using System.Collections.Generic;

--- a/Tests/MonoGameGum.Tests.V2/Forms/ScrollViewerTests.cs
+++ b/Tests/MonoGameGum.Tests.V2/Forms/ScrollViewerTests.cs
@@ -1,6 +1,6 @@
 ﻿using Gum.Forms.Controls;
 using Gum.Wireframe;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using MonoGameGum.Input;
 using Moq;
 using Shouldly;

--- a/Tests/MonoGameGum.Tests.V2/Forms/SliderTests.cs
+++ b/Tests/MonoGameGum.Tests.V2/Forms/SliderTests.cs
@@ -1,6 +1,6 @@
 ﻿using Gum.Forms.Controls;
 using Gum.Wireframe;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using Shouldly;
 using System;
 using System.Collections.Generic;

--- a/Tests/MonoGameGum.Tests.V2/Forms/TextBoxTests.cs
+++ b/Tests/MonoGameGum.Tests.V2/Forms/TextBoxTests.cs
@@ -1,7 +1,7 @@
 ﻿using Gum.Forms;
 using Gum.Forms.Controls;
 using Gum.Wireframe;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using Shouldly;
 using System;
 using System.Collections.Generic;

--- a/Tests/MonoGameGum.Tests.V2/GumServiceUninitializeTests.cs
+++ b/Tests/MonoGameGum.Tests.V2/GumServiceUninitializeTests.cs
@@ -2,7 +2,7 @@ using Gum.Forms;
 using Gum.Forms.Controls;
 using Gum.Wireframe;
 using MonoGameGum.Input;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using RenderingLibrary;
 using Shouldly;
 using System;

--- a/Tests/MonoGameGum.Tests.V2/Runtimes/NineSliceRuntimeTests.cs
+++ b/Tests/MonoGameGum.Tests.V2/Runtimes/NineSliceRuntimeTests.cs
@@ -1,6 +1,6 @@
 using Gum.DataTypes.Variables;
 using Gum.Managers;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using RenderingLibrary.Graphics;
 using Shouldly;
 

--- a/Tests/MonoGameGum.Tests.V2/Runtimes/TextRuntimeTests.cs
+++ b/Tests/MonoGameGum.Tests.V2/Runtimes/TextRuntimeTests.cs
@@ -1,4 +1,4 @@
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using RenderingLibrary.Graphics;
 using Shouldly;
 

--- a/Tests/MonoGameGum.Tests.V3/ListBoxVisualTests.cs
+++ b/Tests/MonoGameGum.Tests.V3/ListBoxVisualTests.cs
@@ -1,6 +1,6 @@
 ﻿using Gum.Forms.Controls;
 using Gum.Wireframe;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using Shouldly;
 using System;
 using System.Collections.Generic;

--- a/Tests/MonoGameGum.Tests.V3/ScrollBarVisualTests.cs
+++ b/Tests/MonoGameGum.Tests.V3/ScrollBarVisualTests.cs
@@ -1,6 +1,6 @@
 ﻿using Gum.Forms.Controls;
 using Gum.Wireframe;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using Shouldly;
     using System;
 using System.Collections.Generic;

--- a/Tests/MonoGameGum.Tests.V3/ScrollViewerVisualTests.cs
+++ b/Tests/MonoGameGum.Tests.V3/ScrollViewerVisualTests.cs
@@ -1,6 +1,6 @@
 ﻿using Gum.Forms.Controls;
 using Gum.Wireframe;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using Shouldly;
 using Xunit;
 

--- a/Tests/MonoGameGum.Tests.V3/SliderVisualTests.cs
+++ b/Tests/MonoGameGum.Tests.V3/SliderVisualTests.cs
@@ -2,7 +2,7 @@ using Gum.Forms.Controls;
 using Gum.Forms.DefaultVisuals.V3;
 using Gum.Wireframe;
 using Microsoft.Xna.Framework;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using Shouldly;
 using System;
 using System.Collections.Generic;

--- a/Tests/MonoGameGum.Tests.V3/TextBoxVisualTests.cs
+++ b/Tests/MonoGameGum.Tests.V3/TextBoxVisualTests.cs
@@ -1,7 +1,7 @@
 ﻿using Gum.Forms.Controls;
 using Gum.Forms.DefaultVisuals.V3;
 using Gum.Wireframe;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using Shouldly;
 using System;
 using System.Collections.Generic;

--- a/Tests/MonoGameGum.Tests.V3/WindowVisualTests.cs
+++ b/Tests/MonoGameGum.Tests.V3/WindowVisualTests.cs
@@ -1,7 +1,7 @@
 ﻿using Gum.Forms;
 using Gum.Forms.Controls;
 using Gum.Forms.DefaultVisuals.V3;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using Shouldly;
 using System;
 using System.Collections.Generic;

--- a/Themes/Gum.Themes.Editor.MonoGame/ButtonVisual.cs
+++ b/Themes/Gum.Themes.Editor.MonoGame/ButtonVisual.cs
@@ -1,5 +1,5 @@
 using BaseButtonVisual = Gum.Forms.DefaultVisuals.V3.ButtonVisual;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 
 namespace Gum.Themes.Editor;
 

--- a/Themes/Gum.Themes.Editor.MonoGame/CheckBoxVisual.cs
+++ b/Themes/Gum.Themes.Editor.MonoGame/CheckBoxVisual.cs
@@ -1,5 +1,5 @@
 using BaseCheckBoxVisual = Gum.Forms.DefaultVisuals.V3.CheckBoxVisual;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 
 namespace Gum.Themes.Editor;
 

--- a/Themes/Gum.Themes.Editor.MonoGame/ComboBoxVisual.cs
+++ b/Themes/Gum.Themes.Editor.MonoGame/ComboBoxVisual.cs
@@ -1,6 +1,6 @@
 using BaseComboBoxVisual = Gum.Forms.DefaultVisuals.V3.ComboBoxVisual;
 using Gum.Forms.DefaultVisuals.V3;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 
 namespace Gum.Themes.Editor;
 

--- a/Themes/Gum.Themes.Editor.MonoGame/ExpanderVisual.cs
+++ b/Themes/Gum.Themes.Editor.MonoGame/ExpanderVisual.cs
@@ -2,7 +2,7 @@ using Gum.DataTypes;
 using Gum.Forms.Controls;
 using Gum.Wireframe;
 using Microsoft.Xna.Framework;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using RenderingLibrary.Graphics;
 
 namespace Gum.Themes.Editor;

--- a/Themes/Gum.Themes.Editor.MonoGame/ListBoxItemVisual.cs
+++ b/Themes/Gum.Themes.Editor.MonoGame/ListBoxItemVisual.cs
@@ -1,6 +1,6 @@
 using Gum.Forms.Controls;
 using BaseListBoxItemVisual = Gum.Forms.DefaultVisuals.V3.ListBoxItemVisual;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 
 namespace Gum.Themes.Editor;
 

--- a/Themes/Gum.Themes.Editor.MonoGame/ListBoxVisual.cs
+++ b/Themes/Gum.Themes.Editor.MonoGame/ListBoxVisual.cs
@@ -1,5 +1,5 @@
 using BaseListBoxVisual = Gum.Forms.DefaultVisuals.V3.ListBoxVisual;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 
 namespace Gum.Themes.Editor;
 

--- a/Themes/Gum.Themes.Editor.MonoGame/PropertyGridVisual.cs
+++ b/Themes/Gum.Themes.Editor.MonoGame/PropertyGridVisual.cs
@@ -1,7 +1,7 @@
 using Gum.DataTypes;
 using Gum.Forms.Controls;
 using Microsoft.Xna.Framework;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using RenderingLibrary.Graphics;
 
 namespace Gum.Themes.Editor;

--- a/Themes/Gum.Themes.Editor.MonoGame/TextBoxVisual.cs
+++ b/Themes/Gum.Themes.Editor.MonoGame/TextBoxVisual.cs
@@ -1,7 +1,7 @@
 using BaseTextBoxVisual = Gum.Forms.DefaultVisuals.V3.TextBoxVisual;
 using Gum.Forms.DefaultVisuals.V3;
 using Microsoft.Xna.Framework;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 
 namespace Gum.Themes.Editor;
 

--- a/Tool/EditorTabPlugin_XNA/Views/WireframeControl.cs
+++ b/Tool/EditorTabPlugin_XNA/Views/WireframeControl.cs
@@ -10,7 +10,7 @@ using Gum.ToolCommands;
 using Gum.Wireframe;
 using GumRuntime;
 using Microsoft.Xna.Framework.Graphics;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using RenderingLibrary;
 using RenderingLibrary.Content;
 using RenderingLibrary.Graphics;

--- a/Tools/Gum.Analyzers/NamespaceMigrationAnalyzer.cs
+++ b/Tools/Gum.Analyzers/NamespaceMigrationAnalyzer.cs
@@ -18,12 +18,12 @@ public sealed class NamespaceMigrationAnalyzer : DiagnosticAnalyzer
     /// </summary>
     public static readonly DiagnosticDescriptor MovedTypeRule = new DiagnosticDescriptor(
         id: "GUM001",
-        title: "Type moved to new namespace",
-        messageFormat: "'{0}' has moved from '{1}' to '{2}'. Update your using directive.",
+        title: "Namespace has migrated to a new location",
+        messageFormat: "Types from '{0}' have moved to '{1}'. Update your using directive.",
         category: "Migration",
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
-        description: "This type has been moved to a new namespace as part of the Gum namespace unification. Use the code fix to update automatically.");
+        description: "Types from this namespace have been moved to a new namespace as part of the Gum namespace unification. Use the code fix to update automatically.");
 
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
         ImmutableArray.Create(MovedTypeRule);
@@ -63,21 +63,16 @@ public sealed class NamespaceMigrationAnalyzer : DiagnosticAnalyzer
             return;
         }
 
-        // Check if any of the migrated types from this namespace are actually used in the file
-        var root = context.Node.SyntaxTree.GetRoot(context.CancellationToken);
-        var semanticModel = context.SemanticModel;
+        // Report a single diagnostic per using directive that points at a migrated namespace.
+        // All migrations from the same old namespace currently share one new namespace, so the
+        // user-facing message only needs the namespace pair (not every type name).
+        var firstMigration = migrations[0];
+        var diagnostic = Diagnostic.Create(
+            MovedTypeRule,
+            usingDirective.GetLocation(),
+            firstMigration.OldNamespace,
+            firstMigration.NewNamespace);
 
-        foreach (var migration in migrations)
-        {
-            // Report one diagnostic per migrated type found in this using's namespace
-            var diagnostic = Diagnostic.Create(
-                MovedTypeRule,
-                usingDirective.GetLocation(),
-                migration.TypeName,
-                migration.OldNamespace,
-                migration.NewNamespace);
-
-            context.ReportDiagnostic(diagnostic);
-        }
+        context.ReportDiagnostic(diagnostic);
     }
 }

--- a/Tools/Gum.Analyzers/NamespaceMigrationCodeFixProvider.cs
+++ b/Tools/Gum.Analyzers/NamespaceMigrationCodeFixProvider.cs
@@ -35,7 +35,8 @@ public sealed class NamespaceMigrationCodeFixProvider : CodeFixProvider
         foreach (var diagnostic in context.Diagnostics)
         {
             var node = root.FindNode(diagnostic.Location.SourceSpan);
-            if (node is not UsingDirectiveSyntax usingDirective)
+            UsingDirectiveSyntax? usingDirective = node as UsingDirectiveSyntax;
+            if (usingDirective == null)
             {
                 // Walk up if needed — the diagnostic location might be on the name, not the using
                 usingDirective = node.FirstAncestorOrSelf<UsingDirectiveSyntax>();

--- a/Tools/Gum.Analyzers/NamespaceMigrationMapping.cs
+++ b/Tools/Gum.Analyzers/NamespaceMigrationMapping.cs
@@ -27,13 +27,43 @@ internal static class NamespaceMigrationMapping
 {
     /// <summary>
     /// All known type migrations. Each entry maps an old (namespace, type) pair to a new namespace.
-    /// This table is empty during Phase 1 — entries will be added in Phase 2 when enums are moved.
+    /// Entries are added when types move; the analyzer reads from this table to raise <c>GUM001</c>
+    /// and the code fix uses it to rewrite <c>using</c> directives.
     /// </summary>
     public static readonly ImmutableArray<TypeMigration> Migrations = ImmutableArray.Create<TypeMigration>(
-        // Phase 2 entries will look like:
-        // new TypeMigration("Gum.DataTypes", "Gum.Layout", "DimensionUnitType"),
-        // new TypeMigration("Gum.Managers", "Gum.Layout", "ChildrenLayout"),
-        // new TypeMigration("RenderingLibrary.Graphics", "Gum.Layout", "HorizontalAlignment"),
+        // Runtime namespace unification (syntax version 1):
+        // MonoGameGum.GueDeriving → Gum.GueDeriving
+        new TypeMigration("MonoGameGum.GueDeriving", "Gum.GueDeriving", "TextRuntime"),
+        new TypeMigration("MonoGameGum.GueDeriving", "Gum.GueDeriving", "ContainerRuntime"),
+        new TypeMigration("MonoGameGum.GueDeriving", "Gum.GueDeriving", "SpriteRuntime"),
+        new TypeMigration("MonoGameGum.GueDeriving", "Gum.GueDeriving", "ColoredRectangleRuntime"),
+        new TypeMigration("MonoGameGum.GueDeriving", "Gum.GueDeriving", "NineSliceRuntime"),
+        new TypeMigration("MonoGameGum.GueDeriving", "Gum.GueDeriving", "CircleRuntime"),
+        new TypeMigration("MonoGameGum.GueDeriving", "Gum.GueDeriving", "PolygonRuntime"),
+        new TypeMigration("MonoGameGum.GueDeriving", "Gum.GueDeriving", "RectangleRuntime"),
+        // Apos shapes (also previously MonoGameGum.GueDeriving)
+        new TypeMigration("MonoGameGum.GueDeriving", "Gum.GueDeriving", "AposShapeRuntime"),
+        new TypeMigration("MonoGameGum.GueDeriving", "Gum.GueDeriving", "ArcRuntime"),
+        new TypeMigration("MonoGameGum.GueDeriving", "Gum.GueDeriving", "ColoredCircleRuntime"),
+        new TypeMigration("MonoGameGum.GueDeriving", "Gum.GueDeriving", "LineRuntime"),
+        new TypeMigration("MonoGameGum.GueDeriving", "Gum.GueDeriving", "RoundedRectangleRuntime"),
+        // SkiaGum.GueDeriving → Gum.GueDeriving (Skia-only types)
+        new TypeMigration("SkiaGum.GueDeriving", "Gum.GueDeriving", "ArcRuntime"),
+        new TypeMigration("SkiaGum.GueDeriving", "Gum.GueDeriving", "CircleRuntime"),
+        new TypeMigration("SkiaGum.GueDeriving", "Gum.GueDeriving", "ColoredCircleRuntime"),
+        new TypeMigration("SkiaGum.GueDeriving", "Gum.GueDeriving", "LineGridRuntime"),
+        new TypeMigration("SkiaGum.GueDeriving", "Gum.GueDeriving", "LineRuntime"),
+        new TypeMigration("SkiaGum.GueDeriving", "Gum.GueDeriving", "LottieAnimationRuntime"),
+        new TypeMigration("SkiaGum.GueDeriving", "Gum.GueDeriving", "PolygonRuntime"),
+        new TypeMigration("SkiaGum.GueDeriving", "Gum.GueDeriving", "RoundedRectangleRuntime"),
+        new TypeMigration("SkiaGum.GueDeriving", "Gum.GueDeriving", "SkiaShapeRuntime"),
+        new TypeMigration("SkiaGum.GueDeriving", "Gum.GueDeriving", "SolidRectangleRuntime"),
+        new TypeMigration("SkiaGum.GueDeriving", "Gum.GueDeriving", "SvgRuntime"),
+        // SkiaGum-side shims for shared types (Text, Container, Sprite, ColoredRectangle)
+        new TypeMigration("SkiaGum.GueDeriving", "Gum.GueDeriving", "TextRuntime"),
+        new TypeMigration("SkiaGum.GueDeriving", "Gum.GueDeriving", "ContainerRuntime"),
+        new TypeMigration("SkiaGum.GueDeriving", "Gum.GueDeriving", "SpriteRuntime"),
+        new TypeMigration("SkiaGum.GueDeriving", "Gum.GueDeriving", "ColoredRectangleRuntime")
     );
 
     /// <summary>

--- a/Tools/Gum.Cli/Commands/CodegenCommand.cs
+++ b/Tools/Gum.Cli/Commands/CodegenCommand.cs
@@ -105,8 +105,11 @@ public static class CodegenCommand
         var codeGenNameVerifier = new CodeGenerationNameVerifier(nameVerifier);
         var elementSettingsManager = new CodeOutputElementSettingsManager(projectDirectoryProvider);
         var localizationService = new Gum.Localization.LocalizationService();
+        var syntaxVersionDetectionService = new SyntaxVersionDetectionService(logger);
         var codeGenerator = new CodeGenerator(
-            codeGenNameVerifier, localizationService, elementSettingsManager, projectDirectoryProvider);
+            codeGenNameVerifier, localizationService, elementSettingsManager, projectDirectoryProvider,
+            typeStringResolver: null,
+            syntaxVersionDetectionService: syntaxVersionDetectionService);
 
         var customCodeGenerator = new CustomCodeGenerator(codeGenerator, codeGenNameVerifier);
         var fileLocationsService = new CodeGenerationFileLocationsService(

--- a/Tools/Gum.ProjectServices/CodeGeneration/CodeGenerator.cs
+++ b/Tools/Gum.ProjectServices/CodeGeneration/CodeGenerator.cs
@@ -64,6 +64,15 @@ public class CodeGenerationContext
     public ElementSave Element { get; set; }
     public StringBuilder StringBuilder { get; set; } = new StringBuilder();
 
+    /// <summary>
+    /// The resolved syntax version of the runtime referenced by this project. Determines which
+    /// namespace generated code should target for runtime types (e.g. <c>SpriteRuntime</c>):
+    /// version 0 emits the legacy <c>MonoGameGum.GueDeriving</c> / <c>SkiaGum.GueDeriving</c>
+    /// namespaces; version &gt;= 1 emits the unified <c>Gum.GueDeriving</c> namespace.
+    /// Defaults to 0 so existing call sites that don't supply a version preserve legacy behavior.
+    /// </summary>
+    public int ResolvedSyntaxVersion { get; set; }
+
     CodeOutputProjectSettings _codeOutputProjectSettings = new ();
     public CodeOutputProjectSettings CodeOutputProjectSettings
     {
@@ -252,6 +261,7 @@ public class CodeGenerator
     private readonly ITypeStringResolver? _typeStringResolver;
     private readonly CodeOutputElementSettingsManager _elementSettingsManager;
     private readonly IProjectDirectoryProvider _projectDirectoryProvider;
+    private readonly ISyntaxVersionDetectionService? _syntaxVersionDetectionService;
 
     /// <summary>
     /// The current project directory (folder containing the .gumx file). Read lazily from the
@@ -274,13 +284,54 @@ public class CodeGenerator
 
     public CodeGenerator(CodeGenerationNameVerifier codeGenerationNameVerifier, LocalizationService localizationService,
         CodeOutputElementSettingsManager elementSettingsManager, IProjectDirectoryProvider projectDirectoryProvider,
-        ITypeStringResolver? typeStringResolver = null)
+        ITypeStringResolver? typeStringResolver = null,
+        ISyntaxVersionDetectionService? syntaxVersionDetectionService = null)
     {
         _codeGenerationNameVerifier = codeGenerationNameVerifier;
         _localizationService = localizationService;
         _elementSettingsManager = elementSettingsManager;
         _projectDirectoryProvider = projectDirectoryProvider;
         _typeStringResolver = typeStringResolver;
+        _syntaxVersionDetectionService = syntaxVersionDetectionService;
+    }
+
+    /// <summary>
+    /// Returns the namespace generated code should reference for runtime types
+    /// (<c>SpriteRuntime</c>, <c>ContainerRuntime</c>, etc.) based on the resolved
+    /// runtime syntax version. Version 0 keeps the legacy split namespaces; version &gt;= 1
+    /// emits the unified <c>Gum.GueDeriving</c> namespace.
+    /// </summary>
+    public static string GetGueDerivingNamespace(int syntaxVersion, bool isSkia)
+    {
+        if (syntaxVersion >= 1)
+        {
+            return "Gum.GueDeriving";
+        }
+        return isSkia ? "SkiaGum.GueDeriving" : "MonoGameGum.GueDeriving";
+    }
+
+    /// <summary>
+    /// Resolves the effective syntax version for the supplied project settings using the
+    /// injected <see cref="ISyntaxVersionDetectionService"/> when available. Falls back to
+    /// parsing <see cref="CodeOutputProjectSettings.SyntaxVersion"/> directly (treating
+    /// auto-detect <c>"*"</c> as version 0) when no detection service is wired in.
+    /// </summary>
+    internal int ResolveSyntaxVersion(CodeOutputProjectSettings projectSettings)
+    {
+        if (_syntaxVersionDetectionService != null)
+        {
+            SyntaxVersionResult result = _syntaxVersionDetectionService.Detect(projectSettings, _projectDirectoryProvider.ProjectDirectory);
+            return result.Version;
+        }
+
+        if (projectSettings.SyntaxVersion != null
+            && projectSettings.SyntaxVersion != "*"
+            && int.TryParse(projectSettings.SyntaxVersion, out int explicitVersion))
+        {
+            return explicitVersion;
+        }
+
+        return 0;
     }
 
     #region Using Statements
@@ -298,13 +349,13 @@ public class CodeGenerator
             context.CodeOutputProjectSettings.OutputLibrary == OutputLibrary.MonoGameForms)
         {
             neededUsings.Add("MonoGameGum");
-            neededUsings.Add("MonoGameGum.GueDeriving");
+            neededUsings.Add(GetGueDerivingNamespace(context.ResolvedSyntaxVersion, isSkia: false));
         }
 
         if (context.CodeOutputProjectSettings.OutputLibrary == OutputLibrary.Skia)
         {
             // https://github.com/vchelaru/Gum/issues/895
-            neededUsings.Add("SkiaGum.GueDeriving");
+            neededUsings.Add(GetGueDerivingNamespace(context.ResolvedSyntaxVersion, isSkia: true));
         }
 
         foreach (var instance in context.Element.Instances)
@@ -441,7 +492,7 @@ public class CodeGenerator
 
         if (context.CodeOutputProjectSettings.InheritanceLocation == InheritanceLocation.InGeneratedCode)
         {
-            var inheritance = GetInheritance(context.Element, context.CodeOutputProjectSettings);
+            var inheritance = GetInheritance(context.Element, context.CodeOutputProjectSettings, context.ResolvedSyntaxVersion);
             header += " : " + inheritance;
         }
 
@@ -535,7 +586,7 @@ public class CodeGenerator
         return className;
     }
 
-    public static string? GetInheritance(ElementSave element, CodeOutputProjectSettings projectSettings)
+    public static string? GetInheritance(ElementSave element, CodeOutputProjectSettings projectSettings, int resolvedSyntaxVersion = 0)
     {
         string? inheritance = null;
         if (element is ScreenSave)
@@ -603,7 +654,7 @@ public class CodeGenerator
                 var standardElement = ObjectFinder.Self.GetStandardElement(element.BaseType);
                 if(standardElement != null)
                 {
-                    inheritance = "global::MonoGameGum.GueDeriving." + element.BaseType + "Runtime";
+                    inheritance = "global::" + GetGueDerivingNamespace(resolvedSyntaxVersion, isSkia: false) + "." + element.BaseType + "Runtime";
                 }
                 else
                 {
@@ -612,7 +663,7 @@ public class CodeGenerator
             }
             else
             {
-                inheritance = "SkiaGum.GueDeriving.ContainerRuntime";
+                inheritance = GetGueDerivingNamespace(resolvedSyntaxVersion, isSkia: true) + ".ContainerRuntime";
             }
         }
         else
@@ -1285,7 +1336,7 @@ public class CodeGenerator
                 
                 context.StringBuilder.AppendLine(
                     $"{context.Tabs}{_codeGenerationNameVerifier.ToCSharpName(instance.Name)} = this.Visual?.GetGraphicalUiElementByName(\"{instance.Name}\") as " +
-                    $"global::MonoGameGum.GueDeriving.{className};");
+                    $"global::{GetGueDerivingNamespace(context.ResolvedSyntaxVersion, isSkia: false)}.{className};");
             }
         }
         else
@@ -1295,7 +1346,7 @@ public class CodeGenerator
             {
                 context.StringBuilder.AppendLine(
                     $"{context.Tabs}{_codeGenerationNameVerifier.ToCSharpName(instance.Name)} = this.GetGraphicalUiElementByName(\"{instance.Name}\") as " +
-                    $"global::MonoGameGum.GueDeriving.{GetClassNameForType(instance, context.VisualApi, context)};");
+                    $"global::{GetGueDerivingNamespace(context.ResolvedSyntaxVersion, isSkia: false)}.{GetClassNameForType(instance, context.VisualApi, context)};");
 
             }
             else
@@ -1340,7 +1391,7 @@ public class CodeGenerator
         {
             if(isInstanceStandard)
             {
-                context.StringBuilder.AppendLine($"{tabs}{instanceName} = new global::SkiaGum.GueDeriving.{GetClassNameForType(instance, visualApi, context)}();");
+                context.StringBuilder.AppendLine($"{tabs}{instanceName} = new global::{GetGueDerivingNamespace(context.ResolvedSyntaxVersion, isSkia: true)}.{GetClassNameForType(instance, visualApi, context)}();");
             }
             else
             {
@@ -1351,7 +1402,7 @@ public class CodeGenerator
         {
             if(isInstanceStandard)
             {
-                context.StringBuilder.AppendLine($"{tabs}{instanceName} = new global::MonoGameGum.GueDeriving.{GetClassNameForType(instance, visualApi, context)}();");
+                context.StringBuilder.AppendLine($"{tabs}{instanceName} = new global::{GetGueDerivingNamespace(context.ResolvedSyntaxVersion, isSkia: false)}.{GetClassNameForType(instance, visualApi, context)}();");
             }
             else
             {
@@ -1445,11 +1496,11 @@ public class CodeGenerator
             if(inheritsFromText)
             {
                 // special case for label:
-                builder.AppendLine(context.Tabs + "var visual = new global::MonoGameGum.GueDeriving.TextRuntime();");
+                builder.AppendLine(context.Tabs + $"var visual = new global::{GetGueDerivingNamespace(context.ResolvedSyntaxVersion, isSkia: false)}.TextRuntime();");
             }
             else
             {
-                builder.AppendLine(context.Tabs + "var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();");
+                builder.AppendLine(context.Tabs + $"var visual = new global::{GetGueDerivingNamespace(context.ResolvedSyntaxVersion, isSkia: false)}.ContainerRuntime();");
             }
 
 
@@ -3218,6 +3269,7 @@ public class CodeGenerator
         context.TabCount = 0;
         context.CodeOutputProjectSettings = projectSettings;
         context.ElementSettings = elementSettings;
+        context.ResolvedSyntaxVersion = ResolveSyntaxVersion(projectSettings);
 
         var stringBuilder = context.StringBuilder;
 
@@ -3333,6 +3385,7 @@ public class CodeGenerator
         var context = new CodeGenerationContext(_codeGenerationNameVerifier, element);
         context.Instance = instance;
         context.CodeOutputProjectSettings = codeOutputProjectSettings;
+        context.ResolvedSyntaxVersion = ResolveSyntaxVersion(codeOutputProjectSettings);
         var stringBuilder = context.StringBuilder;
 
         FillWithInstanceDeclaration(context);
@@ -3502,6 +3555,7 @@ public class CodeGenerator
 
         var context = new CodeGenerationContext(_codeGenerationNameVerifier, container);
         context.CodeOutputProjectSettings = codeOutputProjectSettings;
+        context.ResolvedSyntaxVersion = ResolveSyntaxVersion(codeOutputProjectSettings);
 
 
         FillWithVariablesInState(stateSave, stringBuilder, 0, context);

--- a/Tools/Gum.ProjectServices/CodeGeneration/CustomCodeGenerator.cs
+++ b/Tools/Gum.ProjectServices/CodeGeneration/CustomCodeGenerator.cs
@@ -87,13 +87,15 @@ namespace Gum.ProjectServices.CodeGeneration
             string inheritance = string.Empty;
             
             
+            int resolvedSyntaxVersion = _codeGenerator.ResolveSyntaxVersion(projectSettings);
             if(projectSettings.InheritanceLocation == InheritanceLocation.InCustomCode)
             {
-                inheritance = CodeGenerator.GetInheritance(element, projectSettings) ?? string.Empty;
+                inheritance = CodeGenerator.GetInheritance(element, projectSettings, resolvedSyntaxVersion) ?? string.Empty;
             }
 
             var context = new CodeGenerationContext(_nameVerifier, element);
             context.CodeOutputProjectSettings = projectSettings;
+            context.ResolvedSyntaxVersion = resolvedSyntaxVersion;
 
             // intentionally do not include "public" or "internal" so the user can customize this as desired
             // https://github.com/vchelaru/Gum/issues/581

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -148,6 +148,8 @@
 * [Bitmap font generator (.fnt)](gum-tool/bitmap-font-generator-.fnt.md)
 * [Upgrading](gum-tool/upgrading/README.md)
   * [Upgrading File (GUMX) Version](gum-tool/upgrading/upgrading-file-gumx-version.md)
+  * [Syntax Versions](gum-tool/upgrading/syntax-versions.md)
+    * [Syntax Version 1](gum-tool/upgrading/syntax-version-1.md)
   * [Migrating to 2026 April](gum-tool/upgrading/migrating-to-2026-april.md)
   * [Migrating to 2026 March](gum-tool/upgrading/migrating-to-2026-march.md)
   * [Migrating to 2026 February](gum-tool/upgrading/migrating-to-2026-february.md)

--- a/docs/code/binding-viewmodels/binding-custom-view-properties.md
+++ b/docs/code/binding-viewmodels/binding-custom-view-properties.md
@@ -12,7 +12,7 @@ Custom properties are typically added to views to control additional visuals. Fo
 using Gum.Forms.Controls;
 using Gum.Forms.DefaultVisuals.V3;
 using Microsoft.Xna.Framework;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using System;
 
 namespace MonoGameAndGum;

--- a/docs/code/binding-viewmodels/items-binding-listbox-combobox-itemscontrol.md
+++ b/docs/code/binding-viewmodels/items-binding-listbox-combobox-itemscontrol.md
@@ -228,7 +228,7 @@ using Gum.Wireframe;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using System.Collections.ObjectModel;
 
 namespace MonoGameAndGum;

--- a/docs/code/controls/label.md
+++ b/docs/code/controls/label.md
@@ -48,7 +48,7 @@ label.Visual.Width = 300;
 label.Visual.WidthUnits = Gum.DataTypes.DimensionUnitType.Absolute;
 label.Visual.Height = 100;
 label.Visual.HeightUnits = Gum.DataTypes.DimensionUnitType.Absolute;
-var textRuntime = (MonoGameGum.GueDeriving.TextRuntime)label.TextComponent;
+var textRuntime = (Gum.GueDeriving.TextRuntime)label.TextComponent;
 textRuntime.HorizontalAlignment = RenderingLibrary.Graphics.HorizontalAlignment.Center;
 textRuntime.VerticalAlignment = RenderingLibrary.Graphics.VerticalAlignment.Center;
 ```

--- a/docs/code/getting-started/setup/adding-initializing-gum/silk.net.md
+++ b/docs/code/getting-started/setup/adding-initializing-gum/silk.net.md
@@ -49,7 +49,7 @@ Gum requires SkiaSharp to render in Silk.NET. A full Silk.NET project requires a
 using SkiaSharp;
 using RenderingLibrary;
 using Gum.Wireframe;
-using SkiaGum.GueDeriving;
+using Gum.GueDeriving;
 using RenderingLibrary.Graphics;
 using SkiaGum;
 using SilkNetGum.Screens;

--- a/docs/code/getting-started/tutorials/code-only-gum-forms-tutorial/creating-new-controls.md
+++ b/docs/code/getting-started/tutorials/code-only-gum-forms-tutorial/creating-new-controls.md
@@ -17,7 +17,7 @@ To create this class:
 ```csharp
 using Gum.Forms;
 using Gum.Forms.Controls;
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 using Gum.Forms.DefaultVisuals;
 
 namespace MonoGameAndGum.Components;

--- a/docs/gum-tool/code-tab/README.md
+++ b/docs/gum-tool/code-tab/README.md
@@ -107,7 +107,7 @@ For more details see the [Runtime Generation Details](runtime-generation-details
 Add the following using statement at the end of the Project-wide Using Statement box so that references to standard runtime types are found.
 
 ```csharp
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 ```
 
 If you plan on creating Screens, you should also add using statements for your component runtimes

--- a/docs/gum-tool/upgrading/syntax-version-1.md
+++ b/docs/gum-tool/upgrading/syntax-version-1.md
@@ -1,0 +1,78 @@
+# Syntax Version 1: Runtime Namespace Unification
+
+This page describes the changes introduced in **Gum syntax version 1**: a non-breaking move of runtime classes (`SpriteRuntime`, `TextRuntime`, `ContainerRuntime`, etc.) into a single unified namespace, `Gum.GueDeriving`.
+
+## What Changed
+
+Prior to version 1, runtime classes were split across backend-specific namespaces:
+
+- `MonoGameGum.GueDeriving.*` (MonoGame, KNI, FNA, Apos.Shapes runtimes)
+- `SkiaGum.GueDeriving.*` (Skia runtimes plus shared types like `TextRuntime`)
+- `Gum.GueDeriving.*` (Raylib and Sokol)
+
+In version 1, every runtime class moves to `Gum.GueDeriving`. The same `SpriteRuntime` is now available regardless of backend.
+
+## Non-Breaking by Design
+
+Existing user code is unaffected. The old `MonoGameGum.GueDeriving` and `SkiaGum.GueDeriving` namespaces still exist and still expose every runtime class — they just now contain thin `[Obsolete]` derived shims that forward to the real class in `Gum.GueDeriving`.
+
+This means:
+
+- `using MonoGameGum.GueDeriving;` still compiles.
+- `new SpriteRuntime()` still works.
+- You will see compiler warnings (`CS0618`) on each obsolete reference, plus an analyzer warning (`GUM001`) from the bundled Gum.Analyzers package.
+
+## Auto-Migration via Roslyn Analyzer
+
+The Gum NuGet packages ship with a Roslyn analyzer (`Gum.Analyzers`) that detects old-namespace `using` directives and offers a one-click code fix:
+
+1. Place the cursor on the warning squiggle under `using MonoGameGum.GueDeriving;` or `using SkiaGum.GueDeriving;`.
+2. Trigger the lightbulb (Ctrl+. in Visual Studio / Rider).
+3. Choose **Change to 'using Gum.GueDeriving'**.
+4. To migrate the entire solution at once, use **Fix all in solution**.
+
+The analyzer rewrites `using` directives only. Fully-qualified references like `new MonoGameGum.GueDeriving.SpriteRuntime()` still raise `GUM001` but are not auto-fixed — update those by hand.
+
+## Generated Code
+
+When the Gum tool detects that your project references a runtime with `GumSyntaxVersion(Version = 1)` or higher, generated code emits `using Gum.GueDeriving;` and fully-qualified references like `global::Gum.GueDeriving.SpriteRuntime`. Older runtimes (version 0) continue to receive the legacy namespaces.
+
+If auto-detection fails, you can pin a version manually by setting the `SyntaxVersion` field in `ProjectCodeSettings.codsj`. See [Syntax Versions](syntax-versions.md) for details.
+
+## Deprecation Timeline
+
+The compatibility shims will remain in place for **at least six months** to give users time to migrate. After that window, the shim namespaces will be marked `[Obsolete(error: true)]` in a subsequent release, breaking compilation for any code still using them. The exact removal date will be announced in the corresponding monthly migration page.
+
+## Before / After
+
+Before:
+
+```csharp
+using MonoGameGum.GueDeriving;
+
+public class MyScreen
+{
+    public void Setup()
+    {
+        SpriteRuntime sprite = new SpriteRuntime();
+        sprite.Width = 100;
+    }
+}
+```
+
+After:
+
+```csharp
+using Gum.GueDeriving;
+
+public class MyScreen
+{
+    public void Setup()
+    {
+        SpriteRuntime sprite = new SpriteRuntime();
+        sprite.Width = 100;
+    }
+}
+```
+
+The only change is the `using` directive — the class API is unchanged.

--- a/docs/gum-tool/upgrading/syntax-version-1.md
+++ b/docs/gum-tool/upgrading/syntax-version-1.md
@@ -76,3 +76,33 @@ public class MyScreen
 ```
 
 The only change is the `using` directive — the class API is unchanged.
+
+## Troubleshooting
+
+### `RenderingLibrary` references stop compiling after migration
+
+If your code is declared **inside the `Gum.*` namespace tree** (for example, `namespace Gum.GueDeriving;` to add a custom runtime, or `namespace Gum.MyExtensions;` for helpers), unqualified references to the top-level `RenderingLibrary` namespace may stop resolving:
+
+```csharp
+namespace Gum.GueDeriving;
+
+public class MyCustomRuntime : ContainerRuntime
+{
+    void Setup()
+    {
+        RenderingLibrary.Camera camera; // CS0234: 'Camera' does not exist
+    }
+}
+```
+
+This happens because there is also a `Gum.RenderingLibrary` namespace (a small set of blend-related helpers), and C# searches the containing namespace chain first — so when your file is inside `Gum.*`, `Gum.RenderingLibrary` shadows the top-level `RenderingLibrary`.
+
+**Fix:** prefix the global namespace alias:
+
+```csharp
+global::RenderingLibrary.Camera camera;
+```
+
+Or move your code out of the `Gum.*` namespace tree (for example, into `MyGame.Extensions`) and import what you need with a `using` directive. That's the recommended structure for user code anyway.
+
+Most users will not encounter this — code declared in your own namespace (`MyGame`, `Acme.Game`, etc.) and importing Gum types via `using Gum.GueDeriving;` is unaffected.

--- a/docs/gum-tool/upgrading/syntax-version-1.md
+++ b/docs/gum-tool/upgrading/syntax-version-1.md
@@ -41,7 +41,7 @@ If auto-detection fails, you can pin a version manually by setting the `SyntaxVe
 
 ## Deprecation Timeline
 
-The compatibility shims will remain in place for **at least six months** to give users time to migrate. After that window, the shim namespaces will be marked `[Obsolete(error: true)]` in a subsequent release, breaking compilation for any code still using them. The exact removal date will be announced in the corresponding monthly migration page.
+The compatibility shims will remain in place **until at least the November 2026 release** (six months after this change shipped in May 2026). After that window, the shim namespaces will be marked `[Obsolete(error: true)]` in a subsequent release, breaking compilation for any code still using them. The exact removal date will be announced in the corresponding monthly migration page.
 
 ## Before / After
 

--- a/docs/gum-tool/upgrading/syntax-versions.md
+++ b/docs/gum-tool/upgrading/syntax-versions.md
@@ -21,7 +21,7 @@ The detected version is displayed in the Code tab under "Project-Wide Code Gener
 | Version | Introduced | Changes |
 |---|---|---|
 | 0 | 2026.4.x | Baseline. Attribute system introduced. No breaking changes from prior releases. All existing namespace conventions are preserved. |
-| 1 | TBD | Runtime class namespace unification (non-breaking). Runtime classes like `TextRuntime`, `SpriteRuntime`, etc. become available in a unified namespace. Old namespaces continue to work via compatibility shims marked `[Obsolete]`. |
+| 1 | 2026.5.x | Runtime class namespace unification (non-breaking). Runtime classes like `TextRuntime`, `SpriteRuntime`, etc. move to the unified `Gum.GueDeriving` namespace. Old namespaces (`MonoGameGum.GueDeriving`, `SkiaGum.GueDeriving`) continue to work via compatibility shims marked `[Obsolete]`. See [Syntax Version 1](syntax-version-1.md) for details. |
 | 2 | TBD | Layout enum namespace unification (breaking). Enums like `DimensionUnitType`, `ChildrenLayout`, `HorizontalAlignment`, etc. move to a unified namespace. The bundled Roslyn analyzer provides one-click migration. |
 
 When a new syntax version is introduced, the corresponding monthly migration page will document the specific changes. See the [runtime refactoring plan](../../contributing/runtime-refactoring.md) for full details.


### PR DESCRIPTION
## Summary

Workstream **#1** of the four-part runtime refactor effort. Moves all runtime classes from `MonoGameGum.GueDeriving` / `SkiaGum.GueDeriving` to the unified **`Gum.GueDeriving`** namespace so users no longer need backend-specific `using` statements. **Non-breaking** — old namespaces remain as `[Obsolete]` derived shims for the deprecation window.

Bumps Gum syntax version from 0 to 1. The Roslyn analyzer ships a `GUM001` diagnostic with a one-click code-fix for `using` directives.

## What changed (sections of [the plan](.claude/designs/runtime-unification/Plan-NamespaceUnification.md))

- **A. Real-namespace moves** — 23 runtime files (MonoGame, Apos shapes, SkiaGum) now declare `namespace Gum.GueDeriving;` with `#if FRB` keeping the old namespace for FlatRedBall 1.
- **B. Shims** — 27 `[Obsolete]` derived shims under `*/GueDeriving/Shims/`, wrapped in `#if !FRB`. Forward all constructor overloads. Excluded from \`GumCoreShared.projitems\` (FRB1 keeps the old namespace as real, not shimmed).
- **C. Internal `using` updates** — Forms code, GumService, plugins, themes, and tests updated so internal code does not emit obsolete warnings.
- **D. Code generator** — emits the new namespace at syntax version >= 1 via a `GetGueDerivingNamespace` helper threaded through \`CodeGenerationContext\`.
- **E. Roslyn analyzer** — \`NamespaceMigrationMapping.Migrations\` populated with all 27 type entries. Diagnostic emits one per `using` directive (cleaner UX). Code-fix scope: `using` directives only.
- **F. Syntax version** — bumped to \`Version = 1\` in MonoGameGum, RaylibGum, SkiaGum \`AssemblyAttributes.cs\`.
- **G. Docs** — six existing pages updated; new migration page at [\`docs/gum-tool/upgrading/syntax-version-1.md\`](docs/gum-tool/upgrading/syntax-version-1.md).
- **H. Hand-written samples** — 29 standalone \`Samples/*.cs\` files updated. 175 partial-class siblings of \`*.Generated.cs\` were left on the old namespace; they regenerate clean on next codegen run.

## FRB1 untouched

No \`#if FRB\` block was modified. No shims sit inside \`#if FRB\`. FRB1 builds keep \`MonoGameGum.GueDeriving\` as the real namespace permanently.

## Test plan

- [x] \`dotnet build AllLibraries.sln\` — 0 errors, 0 warnings.
- [x] \`dotnet build GumFull.sln\` — 0 errors (3104 pre-existing warnings, no new ones).
- [x] \`dotnet test AllLibraries.sln\` — **1719 pass**, 0 fail (includes 9 new codegen tests + 5 new analyzer tests).
- [x] \`dotnet test GumFull.sln\` — **866 pass**, 0 fail (5 pre-existing skipped).
- [x] Codegen smoke verified by new \`CodeGeneratorSyntaxVersionNamespaceTests\` covering both v0 and v1 emission paths for MonoGame and Skia.
- [x] Analyzer smoke verified by new \`NamespaceMigrationCodeFixTests\` demonstrating GUM001 fires and rewrites \`using\` correctly.
- [x] Spot-checked one runtime file per backend confirming new namespace is real with FRB guard preserved.
- [ ] Manual smoke: open the Gum tool against a project referencing the new runtime NuGet, confirm "Syntax Version: 1 (auto-detected)" displays and generated code uses \`using Gum.GueDeriving;\`. *(Not run — needs reviewer's tool environment.)*

## Follow-ups (not in this PR)

- Once samples are regenerated against the new runtime, the 175 partial-class hand-written samples can have their \`using\` updated in a quick follow-up.
- \`Samples/GumFormsSample/MonoGameGumFormsSample.sln\` has 2 pre-existing \`MonoGameGum.Forms.Controls not found\` errors unrelated to this change — worth tracking separately.

## Design docs

This PR implements the plan at \`.claude/designs/runtime-unification/Plan-NamespaceUnification.md\` (gitignored, local). The companion design docs are also in that folder:

- \`RuntimeNorthStar.md\` — end state and the four workstreams
- \`RuntimeNamespaceUnification.md\` — the design for this workstream
- \`runtime-refactoring.md\` — file-link convergence (workstream #2)
- \`TypeCollapse.md\` — workstream #3 stub
- \`FillStrokeUnification.md\` — workstream #4 stub

🤖 Generated with [Claude Code](https://claude.com/claude-code)