### PR TITLE
Auto-refresh live UI on CurrentLanguage change, fix #2632

### DIFF
--- a/.claude/skills/gum-localization/SKILL.md
+++ b/.claude/skills/gum-localization/SKILL.md
@@ -15,12 +15,15 @@ Localization is opt-in via a nullable static property. When set, text assigned t
 
 **Access at runtime:** `GumService.Default.LocalizationService` forwards to the static property above.
 
+**Runtime language switching:** `ILocalizationService.CurrentLanguageChanged` fires when `CurrentLanguage` is reassigned to a different value. `GumService` subscribes and walks `Root`/`PopupRoot`/`ModalRoot` re-translating every text-bearing element that was assigned via the localized path. Manual entry point: `GumService.Default.RefreshLocalization()`. Per-element entry: `GraphicalUiElement.RefreshLocalization()` recurses into `Children`. The per-element re-translate is delegated through `GraphicalUiElement.RefreshLocalizationOnElementAction` (wired by `GumService` since `GumRuntime` cannot reference `CustomSetPropertyOnRenderable`). Originating string IDs live in a static `ConditionalWeakTable<GraphicalUiElement, string>` on `CustomSetPropertyOnRenderable`, populated whenever `TrySetPropertyOnText` runs the localization path and cleared by `SetTextNoTranslate`.
+
 ## ILocalizationService
 
-`GumCommon/Localization/ILocalizationService.cs` — five members:
+`GumCommon/Localization/ILocalizationService.cs` — six members:
 
 - `CurrentLanguage` (int) — index into the translation arrays (0 = default/source language)
 - `Languages` (`IReadOnlyList<string>`) — language names populated after loading; empty until a database is loaded
+- `CurrentLanguageChanged` (`event Action?`) — fires when `CurrentLanguage` is reassigned to a different value; subscribed by `GumService` to drive automatic re-translation of live visuals
 - `AddDatabase(Dictionary<string, string[]>, List<string>)` — loads translations; key = string ID, value = array where `[0]` is the ID and `[1..N]` are translations per language
 - `Clear()` — resets the database and Languages list
 - `Translate(string stringId)` — returns the translated string for `CurrentLanguage`
@@ -126,7 +129,7 @@ PasswordBox uses `TextNoTranslate` for mask characters (e.g., "●●●●") si
 
 1. **"(loc)" suffix is intentional** — When a database is loaded but a string ID isn't found, `Translate()` appends "(loc)". This is a debugging feature, not a bug. Empty databases return strings unchanged (no suffix).
 
-2. **Translation happens at assignment time, not read time** — The renderable stores only the final translated string. Changing `CurrentLanguage` after setting text does NOT retroactively update existing UI. You must re-assign `Text` to all controls.
+2. **Translation happens at assignment time, not read time** — The renderable stores only the final translated string. Live UI is kept in sync by a separate path: `CustomSetPropertyOnRenderable` records the original raw value in a `ConditionalWeakTable<GraphicalUiElement, string>` whenever the localized `Text` path runs, and `GumService` subscribes to `ILocalizationService.CurrentLanguageChanged` to walk the live tree and re-call `SetProperty("Text", storedKey)` on every tracked element. `SetTextNoTranslate` clears the entry, so user input and explicit literals survive language switches. Programmatic dynamic strings assigned via the localized `Text` property still get re-translated on language change and will pick up the `(loc)` suffix — use `SetTextNoTranslate` for those. Bound `Text` is overwritten by refresh; the design assumes bindings and runtime language switching aren't combined.
 
 3. **Null service = no localization** — If `LocalizationService` is null, all text passes through unchanged. This is the expected state when localization isn't needed.
 
@@ -143,14 +146,16 @@ PasswordBox uses `TextNoTranslate` for mask characters (e.g., "●●●●") si
 - `GumCommon/Localization/ILocalizationService.cs` — interface (`CurrentLanguage`, `Languages`, `AddDatabase`, `Clear`, `Translate`)
 - `GumCommon/Localization/LocalizationService.cs` — default implementation
 - `GumCommon/Localization/LocalizationServiceExtensions.cs` — CSV/RESX loaders
-- `Gum/Wireframe/CustomSetPropertyOnRenderable.cs` — static `LocalizationService` property and translation logic in `TrySetPropertyOnText`
+- `Gum/Wireframe/CustomSetPropertyOnRenderable.cs` — static `LocalizationService` property (with `LocalizationServiceChanged` event), `_localizationKeys` `ConditionalWeakTable`, `TryGetLocalizationKey`, and translation logic in `TrySetPropertyOnText`
 - `Gum/Commands/FileCommands.cs` — `LoadLocalizationFile()` (CSV/RESX branch, `LocalizationLoaded` event)
 - `Gum/Commands/IFileCommands.cs` — `LocalizationLoaded` event declaration
 - `Gum/Managers/FileChangeReactionLogic.cs` — `IsLocalizationFileThatShouldTriggerReload()` (list + satellite matching)
 - `Gum/Plugins/InternalPlugins/ProjectPropertiesWindowPlugin/` — Language dropdown + `LocalizationFiles` list editor UI
 - `WpfDataUi/Controls/MultiFileDisplay.xaml(.cs)` — `IDataUi` control for `List<string>` file-path lists; composes `FilePickingLogic`
 - `WpfDataUi/Controls/FilePickingLogic.cs` — shared file-dialog/relative-path plumbing (pattern like `TextBoxDisplayLogic`)
-- `MonoGameGum/GumService.cs` — runtime auto-load of `.gumx` `LocalizationFiles`; collision warnings surface on `GumLoadResult.Warnings`
+- `MonoGameGum/GumService.cs` — runtime auto-load of `.gumx` `LocalizationFiles`; collision warnings surface on `GumLoadResult.Warnings`; `RefreshLocalization()` walks the three roots; constructor wires the `RefreshLocalizationOnElementAction` delegate and subscribes to `LocalizationServiceChanged`
+- `GumRuntime/GraphicalUiElement.cs` — `RefreshLocalization()` recursion + `RefreshLocalizationOnElementAction` static delegate hook
+- `MonoGameGum.Tests/Localization/RefreshLocalizationTests.cs` — runtime language-switch tests (Forms controls, BBCode-from-translation, TextNoTranslate survival, popup/modal roots)
 - `MonoGameGum/GueDeriving/TextRuntime.cs` — `Text` property and `SetTextNoTranslate` method
 - `MonoGameGum/Forms/Controls/` — Forms control localization pattern
 - `MonoGameGum.Tests/Localization/LocalizationServiceExtensionsTests.cs` — CSV/RESX loader tests

--- a/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
+++ b/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
@@ -49,7 +49,46 @@ namespace Gum.Wireframe;
 
 public class CustomSetPropertyOnRenderable
 {
-    public static ILocalizationService? LocalizationService { get; set; }
+    private static ILocalizationService? _localizationService;
+
+    /// <summary>
+    /// The active localization service used by the runtime. Assigning a new
+    /// instance fires <see cref="LocalizationServiceChanged"/> so consumers
+    /// (e.g. <c>GumService</c>) can re-wire <see cref="ILocalizationService.CurrentLanguageChanged"/>
+    /// subscriptions for runtime language switching.
+    /// </summary>
+    public static ILocalizationService? LocalizationService
+    {
+        get => _localizationService;
+        set
+        {
+            if (ReferenceEquals(_localizationService, value))
+            {
+                return;
+            }
+            ILocalizationService? previous = _localizationService;
+            _localizationService = value;
+            LocalizationServiceChanged?.Invoke(previous, value);
+        }
+    }
+
+    /// <summary>
+    /// Raised when <see cref="LocalizationService"/> is replaced. Arguments are
+    /// (previousService, newService) — either may be null.
+    /// </summary>
+    public static event Action<ILocalizationService?, ILocalizationService?>? LocalizationServiceChanged;
+
+    private static readonly ConditionalWeakTable<GraphicalUiElement, string> _localizationKeys = new();
+
+    /// <summary>
+    /// Returns the original (pre-translation) string assigned via the localization
+    /// path on the given element, or null if no localizable text has been assigned
+    /// (or it was overwritten via <c>SetTextNoTranslate</c>).
+    /// </summary>
+    public static string? TryGetLocalizationKey(GraphicalUiElement element)
+    {
+        return _localizationKeys.TryGetValue(element, out string? key) ? key : null;
+    }
 
 #if !FRB
     /// <summary>
@@ -514,6 +553,23 @@ public class CustomSetPropertyOnRenderable
 
             var valueAsString = value as string;
 
+            // Track the original (untranslated) value so RefreshLocalization can
+            // re-translate this element if CurrentLanguage changes later.
+            // - "Text" with an active LocalizationService stores the raw input.
+            // - "TextNoTranslate" always clears any previously-stored key so user
+            //   input or explicitly-untranslated values aren't re-translated later.
+            if (propertyName == "TextNoTranslate")
+            {
+                _localizationKeys.Remove(graphicalUiElement);
+            }
+            else if (LocalizationService != null && valueAsString != null)
+            {
+                _localizationKeys.AddOrUpdate(graphicalUiElement, valueAsString);
+            }
+            else
+            {
+                _localizationKeys.Remove(graphicalUiElement);
+            }
 
             textRenderable.InlineVariables.Clear();
             if (valueAsString?.Contains("[") == true)

--- a/GumCommon/Localization/ILocalizationService.cs
+++ b/GumCommon/Localization/ILocalizationService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -9,6 +9,13 @@ public interface ILocalizationService
 {
     int CurrentLanguage { get; set; }
     IReadOnlyList<string> Languages { get; }
+
+    /// <summary>
+    /// Raised when <see cref="CurrentLanguage"/> changes. Subscribers (such as
+    /// <c>GumService</c>) use this to walk the live visual tree and re-translate
+    /// already-instantiated text without the caller having to rebuild it.
+    /// </summary>
+    event Action? CurrentLanguageChanged;
 
     void AddDatabase(Dictionary<string, string[]> entryDictionary, List<string> headerList);
     void Clear();

--- a/GumCommon/Localization/LocalizationService.cs
+++ b/GumCommon/Localization/LocalizationService.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using Gum.Localization;
@@ -29,11 +30,24 @@ public class LocalizationService : ILocalizationService
         private set;
     }
 
+    private int _currentLanguage;
+
     public int CurrentLanguage
     {
-        get;
-        set;
+        get => _currentLanguage;
+        set
+        {
+            if (_currentLanguage == value)
+            {
+                return;
+            }
+            _currentLanguage = value;
+            CurrentLanguageChanged?.Invoke();
+        }
     }
+
+    /// <inheritdoc/>
+    public event Action? CurrentLanguageChanged;
 
     public LocalizationService()
     {

--- a/GumRuntime/GraphicalUiElement.cs
+++ b/GumRuntime/GraphicalUiElement.cs
@@ -5452,6 +5452,36 @@ public partial class GraphicalUiElement : IRenderableIpso, IVisible, INotifyProp
         }
     }
 
+    /// <summary>
+    /// Optional delegate that re-translates the <c>Text</c> property on a single
+    /// element using the most recently assigned localization key, if any. Wired
+    /// by MonoGameGum since GumRuntime cannot reference
+    /// <c>CustomSetPropertyOnRenderable</c> directly. Used by
+    /// <c>GumService.RefreshLocalization</c>.
+    /// </summary>
+    public static Action<GraphicalUiElement>? RefreshLocalizationOnElementAction;
+
+    /// <summary>
+    /// Re-applies the most recently assigned localization key on this element
+    /// and all descendants via <see cref="RefreshLocalizationOnElementAction"/>.
+    /// Each element that had its <c>Text</c> set via the localization path
+    /// re-runs <c>SetProperty("Text", key)</c>, which routes through translation
+    /// again with the current language.
+    /// </summary>
+    /// <remarks>
+    /// Elements whose text was assigned via <c>SetTextNoTranslate</c> (e.g. user
+    /// input in a <c>TextBox</c>) are skipped. Bound Text values may be overwritten
+    /// — refresh while bindings are active is not supported.
+    /// </remarks>
+    public void RefreshLocalization()
+    {
+        RefreshLocalizationOnElementAction?.Invoke(this);
+        for (int i = 0; i < Children.Count; i++)
+        {
+            Children[i].RefreshLocalization();
+        }
+    }
+
     string NameOrType => !string.IsNullOrEmpty(Name) ? Name : $"<{GetType().Name}>";
 
     string ParentQualifiedName => Parent as GraphicalUiElement == null ? NameOrType : (Parent as GraphicalUiElement).ParentQualifiedName + "." + NameOrType;

--- a/MonoGameGum.Tests/Localization/RefreshLocalizationTests.cs
+++ b/MonoGameGum.Tests/Localization/RefreshLocalizationTests.cs
@@ -1,0 +1,150 @@
+using Gum.Forms.Controls;
+using Gum.Localization;
+using Gum.Wireframe;
+using Gum.GueDeriving;
+using Shouldly;
+using System.Collections.Generic;
+using Xunit;
+
+namespace MonoGameGum.Tests.Localization;
+
+/// <summary>
+/// Tests runtime language switching: when CurrentLanguage changes, already-instantiated
+/// text-bearing visuals should re-translate without the caller having to recreate them.
+/// </summary>
+public class RefreshLocalizationTests : BaseTestClass
+{
+    private LocalizationService _localizationService = null!;
+
+    public RefreshLocalizationTests() : base()
+    {
+        _localizationService = new LocalizationService();
+        Dictionary<string, string[]> entries = new()
+        {
+            { "Greeting", new[] { "Hello", "Hola", "Bonjour" } },
+            { "Farewell", new[] { "Goodbye", "Adios", "Au revoir" } },
+            { "BBStr",    new[] { "plain English", "[Color=Red]Spanish red[/Color]", "French" } },
+        };
+        List<string> headers = new() { "English", "Spanish", "French" };
+        _localizationService.AddDatabase(entries, headers);
+        _localizationService.CurrentLanguage = 0;
+        CustomSetPropertyOnRenderable.LocalizationService = _localizationService;
+    }
+
+    [Fact]
+    public void RefreshLocalization_ShouldRetranslateLiveText_WhenLanguageChanges()
+    {
+        TextRuntime text = new();
+        text.AddToRoot();
+        text.Text = "Greeting";
+        text.Text.ShouldBe("Hello");
+
+        _localizationService.CurrentLanguage = 1;
+        GumService.Default.RefreshLocalization();
+
+        text.Text.ShouldBe("Hola");
+    }
+
+    [Fact]
+    public void RefreshLocalization_ShouldRetranslateButton()
+    {
+        Button button = new();
+        button.Visual.AddToRoot();
+        button.Text = "Greeting";
+        button.Text.ShouldBe("Hello");
+
+        _localizationService.CurrentLanguage = 2;
+        GumService.Default.RefreshLocalization();
+
+        button.Text.ShouldBe("Bonjour");
+    }
+
+    [Fact]
+    public void RefreshLocalization_ShouldNotTouchTextNoTranslate_WhenLanguageChanges()
+    {
+        TextRuntime text = new();
+        text.AddToRoot();
+        text.SetTextNoTranslate("Greeting");
+        text.Text.ShouldBe("Greeting");
+
+        _localizationService.CurrentLanguage = 1;
+        GumService.Default.RefreshLocalization();
+
+        text.Text.ShouldBe("Greeting");
+    }
+
+    [Fact]
+    public void RefreshLocalization_ShouldNotRetranslateUserTypedTextBoxInput()
+    {
+        TextBox textBox = new();
+        textBox.Visual.AddToRoot();
+        textBox.HandleCharEntered('H');
+        textBox.HandleCharEntered('i');
+        textBox.Text.ShouldBe("Hi");
+
+        _localizationService.CurrentLanguage = 1;
+        GumService.Default.RefreshLocalization();
+
+        textBox.Text.ShouldBe("Hi");
+    }
+
+    [Fact]
+    public void RefreshLocalization_ShouldHandleBBCodeProducedByTranslation()
+    {
+        TextRuntime text = new();
+        text.AddToRoot();
+        text.Text = "BBStr";
+        text.Text.ShouldBe("plain English");
+
+        _localizationService.CurrentLanguage = 1;
+        GumService.Default.RefreshLocalization();
+
+        // Spanish entry contains BBCode markup, which should be parsed on refresh.
+        // We verify by checking that StoredMarkupText was populated.
+        var renderable = (RenderingLibrary.Graphics.Text)text.RenderableComponent;
+        renderable.StoredMarkupText.ShouldBe("[Color=Red]Spanish red[/Color]");
+    }
+
+    [Fact]
+    public void CurrentLanguageChanged_ShouldFireRefresh_Automatically()
+    {
+        TextRuntime text = new();
+        text.AddToRoot();
+        text.Text = "Greeting";
+        text.Text.ShouldBe("Hello");
+
+        // No explicit RefreshLocalization() call — assignment alone should refresh.
+        _localizationService.CurrentLanguage = 2;
+
+        text.Text.ShouldBe("Bonjour");
+    }
+
+    [Fact]
+    public void RefreshLocalization_ShouldBeNoOp_WhenLocalizationServiceIsNull()
+    {
+        TextRuntime text = new();
+        text.AddToRoot();
+        text.Text = "Greeting";
+
+        CustomSetPropertyOnRenderable.LocalizationService = null;
+
+        Should.NotThrow(() => GumService.Default.RefreshLocalization());
+    }
+
+    [Fact]
+    public void RefreshLocalization_ShouldRefresh_PopupRootAndModalRoot()
+    {
+        TextRuntime popupText = new();
+        TextRuntime modalText = new();
+        GumService.Default.PopupRoot.Children.Add(popupText);
+        GumService.Default.ModalRoot.Children.Add(modalText);
+        popupText.Text = "Greeting";
+        modalText.Text = "Farewell";
+
+        _localizationService.CurrentLanguage = 1;
+        GumService.Default.RefreshLocalization();
+
+        popupText.Text.ShouldBe("Hola");
+        modalText.Text.ShouldBe("Adios");
+    }
+}

--- a/MonoGameGum/GumService.cs
+++ b/MonoGameGum/GumService.cs
@@ -131,6 +131,42 @@ public class GumService
     }
 
     /// <summary>
+    /// Re-translates all live text on Root, PopupRoot, and ModalRoot using the
+    /// current language on <see cref="LocalizationService"/>. Call this after
+    /// changing <see cref="ILocalizationService.CurrentLanguage"/> if you have
+    /// disabled the automatic refresh by replacing the service. Otherwise this
+    /// is invoked automatically on language change.
+    /// </summary>
+    /// <remarks>
+    /// Text assigned via <c>SetTextNoTranslate</c> (such as user input in a
+    /// <c>TextBox</c>) is skipped. Programmatic strings assigned via the
+    /// localized <c>Text</c> property are re-translated, so dynamic values
+    /// (e.g. <c>"Score: " + score</c>) will receive the "(loc)" missing-key
+    /// suffix on language change unless they are assigned via the no-translate API.
+    /// </remarks>
+    public void RefreshLocalization()
+    {
+        Root?.RefreshLocalization();
+        PopupRoot?.RefreshLocalization();
+        ModalRoot?.RefreshLocalization();
+    }
+
+    private ILocalizationService? _subscribedLocalizationService;
+
+    private void HandleLocalizationServiceChanged(ILocalizationService? previous, ILocalizationService? current)
+    {
+        if (_subscribedLocalizationService != null)
+        {
+            _subscribedLocalizationService.CurrentLanguageChanged -= RefreshLocalization;
+        }
+        _subscribedLocalizationService = current;
+        if (current != null)
+        {
+            current.CurrentLanguageChanged += RefreshLocalization;
+        }
+    }
+
+    /// <summary>
     /// Re-applies all styles on the specified element and its children. Call after
     /// <see cref="GumRuntime.ElementSaveExtensions.ApplyAllVariableReferences"/>
     /// to push variable reference changes to live visuals in a specific subtree.
@@ -244,6 +280,19 @@ public class GumService
         Root.HasEvents = false;
 
         Root.Children.CollectionChanged += (o, e) => Gum.Forms.FormsUtilities.HandleRootCollectionChanged(Root, e);
+
+        CustomSetPropertyOnRenderable.LocalizationServiceChanged += HandleLocalizationServiceChanged;
+        // Pick up any LocalizationService that was assigned before this GumService was constructed.
+        HandleLocalizationServiceChanged(null, CustomSetPropertyOnRenderable.LocalizationService);
+
+        GraphicalUiElement.RefreshLocalizationOnElementAction = element =>
+        {
+            string? key = CustomSetPropertyOnRenderable.TryGetLocalizationKey(element);
+            if (key != null)
+            {
+                element.SetProperty("Text", key);
+            }
+        };
 
         DeferredQueue = new DeferredActionQueue();
 

--- a/Runtimes/RaylibGum/Renderables/CustomSetPropertyOnRenderable.cs
+++ b/Runtimes/RaylibGum/Renderables/CustomSetPropertyOnRenderable.cs
@@ -51,7 +51,45 @@ namespace Gum.Wireframe;
 
 public class CustomSetPropertyOnRenderable
 {
-    public static ILocalizationService LocalizationService { get; set; }
+    private static ILocalizationService _localizationService;
+
+    /// <summary>
+    /// The active localization service used by the runtime. Assigning a new
+    /// instance fires <see cref="LocalizationServiceChanged"/> so consumers
+    /// (e.g. <c>GumService</c>) can re-wire <see cref="ILocalizationService.CurrentLanguageChanged"/>
+    /// subscriptions for runtime language switching.
+    /// </summary>
+    public static ILocalizationService LocalizationService
+    {
+        get => _localizationService;
+        set
+        {
+            if (ReferenceEquals(_localizationService, value))
+            {
+                return;
+            }
+            ILocalizationService previous = _localizationService;
+            _localizationService = value;
+            LocalizationServiceChanged?.Invoke(previous, value);
+        }
+    }
+
+    /// <summary>
+    /// Raised when <see cref="LocalizationService"/> is replaced. Arguments are
+    /// (previousService, newService) — either may be null.
+    /// </summary>
+    public static event Action<ILocalizationService, ILocalizationService> LocalizationServiceChanged;
+
+    private static readonly ConditionalWeakTable<GraphicalUiElement, string> _localizationKeys = new();
+
+    /// <summary>
+    /// Returns the original (pre-translation) string assigned via the localization
+    /// path on the given element, or null if no localizable text has been assigned.
+    /// </summary>
+    public static string TryGetLocalizationKey(GraphicalUiElement element)
+    {
+        return _localizationKeys.TryGetValue(element, out string key) ? key : null;
+    }
 
 #if !FRB
     /// <summary>
@@ -367,6 +405,21 @@ public class CustomSetPropertyOnRenderable
             }
 
             var valueAsString = value as string;
+
+            // Track the original (untranslated) value so RefreshLocalization can
+            // re-translate this element if CurrentLanguage changes later.
+            if (propertyName == "TextNoTranslate")
+            {
+                _localizationKeys.Remove(graphicalUiElement);
+            }
+            else if (LocalizationService != null && valueAsString != null)
+            {
+                _localizationKeys.AddOrUpdate(graphicalUiElement, valueAsString);
+            }
+            else
+            {
+                _localizationKeys.Remove(graphicalUiElement);
+            }
 
             var rawText = valueAsString;
 

--- a/docs/code/localization.md
+++ b/docs/code/localization.md
@@ -343,6 +343,47 @@ It does **not** work on bundled-content platforms — iOS, Android, consoles, an
 A stream-based auto-load path for bundled content is on the roadmap. If this is blocking you, let us know on Discord or file an issue on [GitHub](https://github.com/vchelaru/Gum/issues) — real usage reports help us prioritize.
 {% endhint %}
 
+## Switching Language at Runtime
+
+Gum re-translates already-instantiated visuals when you change `CurrentLanguage`. You do not need to recreate screens or rebuild controls — assigning a new value triggers the refresh automatically.
+
+```csharp
+// switch to Spanish — all visible text re-translates in place
+GumUI.LocalizationService.CurrentLanguage = 2;
+```
+
+{% hint style="info" %}
+Automatic runtime language switching requires the May 2026 Gum release or newer. On earlier versions, changing `CurrentLanguage` only affected text assigned _after_ the change — already-displayed text kept its old translation, and the only way to refresh was to recreate the screen.
+{% endhint %}
+
+The refresh walks `Root`, `PopupRoot`, and `ModalRoot` and re-applies the original string ID assigned to each control's `Text`, `Header`, or `Placeholder`. State-driven text (e.g. a `Highlighted` state that sets `Text` to a different string ID) refreshes correctly because the most recently assigned string ID is what gets re-translated.
+
+If you need to refresh manually — for example, after building visuals that aren't attached to one of the standard roots — call `RefreshLocalization` directly:
+
+```csharp
+GumUI.RefreshLocalization();
+```
+
+### Behavior of Untranslated Text on Refresh
+
+Text assigned via `SetTextNoTranslate` (or `SetHeaderNoTranslate` / `SetPlaceholderNoTranslate`) is _not_ touched by refresh. This is what makes user input in a `TextBox` survive language switches — TextBox routes typing, pasting, and deleting through the no-translate path internally.
+
+Programmatic dynamic strings should also use the no-translate API. For example:
+
+```csharp
+// dynamic value — bypasses translation, survives language switches as-is
+scoreLabel.SetTextNoTranslate($"Score: {score}");
+
+// localizable value — picks up the new language on switch
+greetingLabel.Text = "T_Greeting";
+```
+
+If you assign a dynamic string through the localized `Text` property while a `LocalizationService` is active, Gum will treat it as a string ID. On the first assignment it gets the `(loc)` missing-key suffix; on every subsequent language switch it will be re-translated and pick up the suffix again.
+
+### Data Bindings
+
+If a control's `Text` is data-bound, refreshing the language will overwrite the bound value with a re-translated string ID. Refresh while bindings are active is not supported — prefer `SetTextNoTranslate` for bound text, or unbind before switching.
+
 ## Forms Control Localization
 
 Forms controls localize text automatically when a `LocalizationService` is active. When you assign a string ID to a control's `Text` property (or `Header` for MenuItem, `Placeholder` for TextBox), Gum translates it at assignment time. Each control that supports localization also provides a no-translate method for setting literal text that should not be translated.


### PR DESCRIPTION
## Summary

- Changing `LocalizationService.CurrentLanguage` now re-translates already-instantiated UI in place — no screen rebuild required (closes #2632).
- New `ILocalizationService.CurrentLanguageChanged` event drives the refresh; `GumService` subscribes automatically and walks `Root`/`PopupRoot`/`ModalRoot`. Manual entry: `GumService.Default.RefreshLocalization()`.
- Original string IDs are captured in a `ConditionalWeakTable` on `CustomSetPropertyOnRenderable` when the localized `Text` path runs; `SetTextNoTranslate` clears them, so user input in `TextBox` and explicit literals survive language switches.

## Test plan

- [x] Added 8 unit tests in `MonoGameGum.Tests/Localization/RefreshLocalizationTests.cs` covering live re-translate, Forms control coverage (Button), `SetTextNoTranslate` survival, user-typed `TextBox` input survival, BBCode produced by translation, automatic refresh via `CurrentLanguageChanged`, null-service no-op, popup/modal root coverage.
- [x] `dotnet build AllLibraries.sln` and `dotnet build GumFull.sln` succeed with 0 errors.
- [x] `dotnet test AllLibraries.sln` — all test projects pass (1305 in MonoGameGum.Tests).
- [x] Manually exercised the sample project at `MonoGameAma/Localization/MonoGameAndGum`: toggling language at runtime updates the greeting label, OK button, and Cancel button in place; user-typed `TextBox` input and `SetTextNoTranslate` labels survive the toggle; placeholder text re-translates correctly.

## Documentation

- Added a **Switching Language at Runtime** section to `docs/code/localization.md` with an `info` hint block calling out the May 2026 release requirement, plus subsections on `SetTextNoTranslate` behavior across refresh and the data-binding caveat.
- Updated the `gum-localization` skill (Architecture Overview, `ILocalizationService` member list, Gotcha #2, and Key Files).

## Notes for reviewers

- The recursion lives on `GraphicalUiElement.RefreshLocalization()` but the per-element re-translate is delegated through a new `RefreshLocalizationOnElementAction` static (mirrors the existing `SaveFormsRuntimePropertiesAction` pattern), since `GumRuntime` cannot reference `CustomSetPropertyOnRenderable` directly.
- Programmatic dynamic strings assigned via the localized `Text` property will still get re-translated on language change and pick up the `(loc)` suffix — documented in the new section. The fix for that footgun is for callers to use `SetTextNoTranslate` for dynamic content.
- The Raylib variant of `CustomSetPropertyOnRenderable` got the same key-tracking changes for compile-symmetry with `GumService`. SkiaGum/SokolGum still don't support localization at all in their `TrySetPropertyOnText` copies — addressing those is a separate effort tied to the cross-platform unification work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)