### PR TITLE
Close variable-reference engine gaps (#2638)

### DIFF
--- a/AllLibraries.sln
+++ b/AllLibraries.sln
@@ -67,6 +67,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SokolGum", "Runtimes\SokolG
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SokolGum.Tests", "Tests\SokolGum.Tests\SokolGum.Tests.csproj", "{2AA3A085-8367-414A-8D73-8A3C2322D62D}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GumExpressions.Tests", "Tests\GumExpressions.Tests\GumExpressions.Tests.csproj", "{DA1C8D4D-D1BA-4A7F-A5ED-413E967F1B2E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -566,6 +568,24 @@ Global
 		{2AA3A085-8367-414A-8D73-8A3C2322D62D}.Release|x64.Build.0 = Release|Any CPU
 		{2AA3A085-8367-414A-8D73-8A3C2322D62D}.Release|x86.ActiveCfg = Release|Any CPU
 		{2AA3A085-8367-414A-8D73-8A3C2322D62D}.Release|x86.Build.0 = Release|Any CPU
+		{DA1C8D4D-D1BA-4A7F-A5ED-413E967F1B2E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DA1C8D4D-D1BA-4A7F-A5ED-413E967F1B2E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DA1C8D4D-D1BA-4A7F-A5ED-413E967F1B2E}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{DA1C8D4D-D1BA-4A7F-A5ED-413E967F1B2E}.Debug|x64.Build.0 = Debug|Any CPU
+		{DA1C8D4D-D1BA-4A7F-A5ED-413E967F1B2E}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{DA1C8D4D-D1BA-4A7F-A5ED-413E967F1B2E}.Debug|x86.Build.0 = Debug|Any CPU
+		{DA1C8D4D-D1BA-4A7F-A5ED-413E967F1B2E}.Release_No_Diagnostics|Any CPU.ActiveCfg = Release|Any CPU
+		{DA1C8D4D-D1BA-4A7F-A5ED-413E967F1B2E}.Release_No_Diagnostics|Any CPU.Build.0 = Release|Any CPU
+		{DA1C8D4D-D1BA-4A7F-A5ED-413E967F1B2E}.Release_No_Diagnostics|x64.ActiveCfg = Release|Any CPU
+		{DA1C8D4D-D1BA-4A7F-A5ED-413E967F1B2E}.Release_No_Diagnostics|x64.Build.0 = Release|Any CPU
+		{DA1C8D4D-D1BA-4A7F-A5ED-413E967F1B2E}.Release_No_Diagnostics|x86.ActiveCfg = Release|Any CPU
+		{DA1C8D4D-D1BA-4A7F-A5ED-413E967F1B2E}.Release_No_Diagnostics|x86.Build.0 = Release|Any CPU
+		{DA1C8D4D-D1BA-4A7F-A5ED-413E967F1B2E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DA1C8D4D-D1BA-4A7F-A5ED-413E967F1B2E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DA1C8D4D-D1BA-4A7F-A5ED-413E967F1B2E}.Release|x64.ActiveCfg = Release|Any CPU
+		{DA1C8D4D-D1BA-4A7F-A5ED-413E967F1B2E}.Release|x64.Build.0 = Release|Any CPU
+		{DA1C8D4D-D1BA-4A7F-A5ED-413E967F1B2E}.Release|x86.ActiveCfg = Release|Any CPU
+		{DA1C8D4D-D1BA-4A7F-A5ED-413E967F1B2E}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -597,6 +617,7 @@ Global
 		{C93E1E71-F28F-4A22-9162-140430874275} = {BB4FD3E1-BF37-801A-7591-DC4DC6E3BB2D}
 		{B685C35E-8233-41B9-AB52-36C56DFEADB1} = {BB4FD3E1-BF37-801A-7591-DC4DC6E3BB2D}
 		{2AA3A085-8367-414A-8D73-8A3C2322D62D} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{DA1C8D4D-D1BA-4A7F-A5ED-413E967F1B2E} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {01002AE6-0158-417E-9B83-D4234361EC1B}

--- a/Gum/Plugins/InternalPlugins/VariableGrid/VariableReferenceLogic.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/VariableReferenceLogic.cs
@@ -156,7 +156,18 @@ public class VariableReferenceLogic : IVariableReferenceLogic
                 $"The right side cannot be evaluated, are you referencing a variable that doesn't exist or mixing variable types?");
         }
 
-        if (response.Succeeded && !evaluatedSyntax.CastTo(leftSideVariable.Type))
+        if (response.Succeeded && IsCategoryStateLeftSide(leftSideVariable, parentElement, leftSideInstance, out _))
+        {
+            // Category-state LHS: cast to string so any string-producing RHS (literal,
+            // ternary, expression) is accepted; CheckIfVariableTypesMatch enforces the
+            // string-only rule and (for literals) the state-name existence check.
+            if (!evaluatedSyntax.CastTo("string"))
+            {
+                response = GeneralResponse.UnsuccessfulWith(
+                    $"Could not cast {evaluatedSyntax.EvaluatedType} to string for category-state assignment");
+            }
+        }
+        else if (response.Succeeded && !evaluatedSyntax.CastTo(leftSideVariable.Type))
         {
             response = GeneralResponse.UnsuccessfulWith(
                 $"Could not cast {evaluatedSyntax.EvaluatedType} to {leftSideVariable.Type}");
@@ -229,6 +240,35 @@ public class VariableReferenceLogic : IVariableReferenceLogic
         var ownerOfRightSideVariable = parentElement.DefaultState;
 
         rightSideType = assignment.EvaluatedType;
+
+        // Category-state synthetic LHS: leftSideType is the category name (e.g. "ButtonCategory")
+        // and we expect a string RHS naming a state in that category. If the RHS is a string
+        // literal we additionally verify it names an existing state; if it is a non-literal
+        // (ternary, expression) we accept and rely on runtime tolerance (ApplyState no-ops on
+        // unknown state names).
+        if (IsCategoryStateLeftSide(leftSideVariable, parentElement, leftSideInstance, out var category))
+        {
+            if (rightSideType != "string")
+            {
+                return GeneralResponse.UnsuccessfulWith(
+                    $"Left side is a state of category [{category!.Name}] but right side is of type [{rightSideType}]");
+            }
+
+            var isStringLiteral = assignment.SyntaxNode is LiteralExpressionSyntax literal
+                && literal.IsKind(SyntaxKind.StringLiteralExpression);
+
+            if (isStringLiteral && assignment.Value is string stateName)
+            {
+                bool stateExists = category.States.Any(s => s.Name == stateName);
+                if (!stateExists)
+                {
+                    return GeneralResponse.UnsuccessfulWith(
+                        $"Category [{category.Name}] has no state named [{stateName}]");
+                }
+            }
+
+            return GeneralResponse.SuccessfulResponse;
+        }
 
         var areEqual = rightSideType == leftSideType;
 
@@ -303,6 +343,26 @@ public class VariableReferenceLogic : IVariableReferenceLogic
 
         var rootVar = ObjectFinder.Self.GetRootVariable(leftSide, element);
 
+        if (rootVar == null && element != null)
+        {
+            // Synthetic category-state LHS: "<CategoryName>State" assigns a state from the
+            // matching StateSaveCategory. The variable does not exist on DefaultState but the
+            // runtime routes the assignment through GraphicalUiElement.SetProperty.
+            var category = FindCategoryForStateLeftSide(element, leftSide);
+            if (category != null)
+            {
+                var syntheticVariable = new VariableSave
+                {
+                    Name = leftSide,
+                    Type = category.Name,
+                    SetsValue = true
+                };
+                var success = GeneralResponse<VariableSave>.SuccessfulResponse;
+                success.Data = syntheticVariable;
+                return success;
+            }
+        }
+
         if(rootVar == null)
         {
             return GeneralResponse<VariableSave>.UnsuccessfulWith($"Could not find variable [{leftSide}]");
@@ -311,6 +371,67 @@ public class VariableReferenceLogic : IVariableReferenceLogic
         var toReturn = GeneralResponse<VariableSave>.SuccessfulResponse;
         toReturn.Data = rootVar;
         return toReturn;
+    }
+
+    /// <summary>
+    /// Looks for a StateSaveCategory on <paramref name="element"/> (or its base-element
+    /// chain) whose name + "State" matches the <paramref name="leftSide"/> token. Returns
+    /// null when no match is found.
+    /// </summary>
+    private static StateSaveCategory? FindCategoryForStateLeftSide(ElementSave element, string leftSide)
+    {
+        if (string.IsNullOrEmpty(leftSide) || !leftSide.EndsWith("State"))
+        {
+            return null;
+        }
+
+        var categoryName = leftSide.Substring(0, leftSide.Length - "State".Length);
+        if (categoryName.Length == 0)
+        {
+            return null;
+        }
+
+        // Walk this element + its inheritance chain looking for a matching category.
+        var match = element.Categories?.FirstOrDefault(c => c.Name == categoryName);
+        if (match != null)
+        {
+            return match;
+        }
+
+        var baseElements = ObjectFinder.Self.GetBaseElements(element);
+        foreach (var baseElement in baseElements)
+        {
+            match = baseElement.Categories?.FirstOrDefault(c => c.Name == categoryName);
+            if (match != null)
+            {
+                return match;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Returns true if <paramref name="leftSideVariable"/> is the synthetic placeholder
+    /// produced by <see cref="CheckLeftSideVariableExistence"/> for a "&lt;CategoryName&gt;State"
+    /// assignment, and outputs the resolved category.
+    /// </summary>
+    private static bool IsCategoryStateLeftSide(VariableSave leftSideVariable, ElementSave parentElement, InstanceSave? leftSideInstance, out StateSaveCategory? category)
+    {
+        category = null;
+        if (leftSideVariable?.Name == null || !leftSideVariable.Name.EndsWith("State"))
+        {
+            return false;
+        }
+
+        var element = leftSideInstance != null ? ObjectFinder.Self.GetElementSave(leftSideInstance) : parentElement;
+        if (element == null)
+        {
+            return false;
+        }
+
+        category = FindCategoryForStateLeftSide(element, leftSideVariable.Name);
+        return category != null;
     }
 
     #endregion

--- a/Runtimes/GumExpressions/EvaluatedSyntax.cs
+++ b/Runtimes/GumExpressions/EvaluatedSyntax.cs
@@ -122,6 +122,20 @@ public class EvaluatedSyntax
             }
 
         }
+        else if (syntaxNode is ConditionalExpressionSyntax conditional)
+        {
+            var conditionEvaluated = Evaluate(conditional.Condition, stateForUnqualifiedRightSide);
+            if (conditionEvaluated?.Value is bool conditionValue)
+            {
+                var branch = conditionValue ? conditional.WhenTrue : conditional.WhenFalse;
+                var branchEvaluated = Evaluate(branch, stateForUnqualifiedRightSide);
+                if (branchEvaluated != null)
+                {
+                    return FromSyntaxAndValue(syntaxNode, branchEvaluated.Value);
+                }
+            }
+            return null;
+        }
         else if (syntaxNode is PrefixUnaryExpressionSyntax prefixUnary)
         {
             if (prefixUnary.OperatorToken.IsKind(Microsoft.CodeAnalysis.CSharp.SyntaxKind.ExclamationToken))
@@ -188,6 +202,37 @@ public class EvaluatedSyntax
             return null;
         }
 
+        // Equality / inequality work on any pair of comparable types (numbers,
+        // strings, bools), so handle them before falling through to the numeric/string
+        // dynamic-coercion path below.
+        if (operatorToken.IsKind(Microsoft.CodeAnalysis.CSharp.SyntaxKind.EqualsEqualsToken))
+        {
+            return object.Equals(leftEvaluated.Value, rightEvaluated.Value);
+        }
+        else if (operatorToken.IsKind(Microsoft.CodeAnalysis.CSharp.SyntaxKind.ExclamationEqualsToken))
+        {
+            return !object.Equals(leftEvaluated.Value, rightEvaluated.Value);
+        }
+
+        // Logical operators require both operands to be bool. We evaluate eagerly
+        // (no short-circuit) because variable lookups have no side effects.
+        if (operatorToken.IsKind(Microsoft.CodeAnalysis.CSharp.SyntaxKind.AmpersandAmpersandToken))
+        {
+            if (leftEvaluated.Value is bool leftBoolAnd && rightEvaluated.Value is bool rightBoolAnd)
+            {
+                return leftBoolAnd && rightBoolAnd;
+            }
+            return null;
+        }
+        else if (operatorToken.IsKind(Microsoft.CodeAnalysis.CSharp.SyntaxKind.BarBarToken))
+        {
+            if (leftEvaluated.Value is bool leftBoolOr && rightEvaluated.Value is bool rightBoolOr)
+            {
+                return leftBoolOr || rightBoolOr;
+            }
+            return null;
+        }
+
         dynamic dynamicValue1, dynamicValue2;
         GetDynamicValues(leftEvaluated.Value, rightEvaluated.Value, out dynamicValue1, out dynamicValue2);
 
@@ -219,9 +264,21 @@ public class EvaluatedSyntax
                 }
                 return result;
             }
-            else
+            else if (operatorToken.IsKind(Microsoft.CodeAnalysis.CSharp.SyntaxKind.LessThanToken))
             {
-                System.Diagnostics.Debugger.Break();
+                return dynamicValue1 < dynamicValue2;
+            }
+            else if (operatorToken.IsKind(Microsoft.CodeAnalysis.CSharp.SyntaxKind.GreaterThanToken))
+            {
+                return dynamicValue1 > dynamicValue2;
+            }
+            else if (operatorToken.IsKind(Microsoft.CodeAnalysis.CSharp.SyntaxKind.LessThanEqualsToken))
+            {
+                return dynamicValue1 <= dynamicValue2;
+            }
+            else if (operatorToken.IsKind(Microsoft.CodeAnalysis.CSharp.SyntaxKind.GreaterThanEqualsToken))
+            {
+                return dynamicValue1 >= dynamicValue2;
             }
         }
         catch(RuntimeBinderException)

--- a/Runtimes/GumExpressions/GumExpressionService.cs
+++ b/Runtimes/GumExpressions/GumExpressionService.cs
@@ -24,7 +24,10 @@ public static class GumExpressionService
     {
         expression = EvaluatedSyntax.ConvertToCSharpSyntax(expression);
 
-        var syntax = CSharpSyntaxTree.ParseText(expression).GetCompilationUnitRoot();
+        // Parse as an expression rather than a compilation unit so top-level constructs
+        // like ternaries (`a ? b : c`) are not mis-parsed as nullable variable declarations
+        // (Roslyn treats `Foo? bar` at statement scope as a NullableTypeSyntax + declarator).
+        var syntax = SyntaxFactory.ParseExpression(expression);
 
         if (syntax != null)
         {

--- a/Tests/GumExpressions.Tests/BaseTestClass.cs
+++ b/Tests/GumExpressions.Tests/BaseTestClass.cs
@@ -1,0 +1,23 @@
+using Gum.Managers;
+using System;
+
+namespace GumExpressions.Tests;
+
+/// <summary>
+/// Minimal base class for expression-engine tests. Initializes the standard-element registry
+/// (some expression evaluations resolve types through it) and clears the global
+/// <see cref="ObjectFinder"/> project after each test so cross-element reference tests
+/// do not bleed into one another.
+/// </summary>
+public class BaseTestClass : IDisposable
+{
+    public BaseTestClass()
+    {
+        StandardElementsManager.Self.Initialize();
+    }
+
+    public virtual void Dispose()
+    {
+        ObjectFinder.Self.GumProjectSave = null;
+    }
+}

--- a/Tests/GumExpressions.Tests/EvaluatedSyntaxTests.cs
+++ b/Tests/GumExpressions.Tests/EvaluatedSyntaxTests.cs
@@ -5,7 +5,7 @@ using Gum.Managers;
 using Microsoft.CodeAnalysis.CSharp;
 using Shouldly;
 
-namespace GumToolUnitTests.VariableGrid;
+namespace GumExpressions.Tests;
 
 public class EvaluatedSyntaxTests : BaseTestClass
 {
@@ -14,7 +14,9 @@ public class EvaluatedSyntaxTests : BaseTestClass
     private static EvaluatedSyntax Evaluate(string expression, StateSave state)
     {
         string csharp = EvaluatedSyntax.ConvertToCSharpSyntax(expression);
-        Microsoft.CodeAnalysis.SyntaxNode syntax = CSharpSyntaxTree.ParseText(csharp).GetCompilationUnitRoot();
+        // Parse as an expression (matches GumExpressionService) so top-level ternaries are not
+        // mis-parsed as nullable variable declarations.
+        Microsoft.CodeAnalysis.SyntaxNode syntax = Microsoft.CodeAnalysis.CSharp.SyntaxFactory.ParseExpression(csharp);
         return EvaluatedSyntax.FromSyntaxNode(syntax, state);
     }
 
@@ -224,6 +226,101 @@ public class EvaluatedSyntaxTests : BaseTestClass
 
     #endregion
 
+    #region ComparisonOperators
+
+    [Fact]
+    public void FromSyntaxNode_EqualityOfNumericValues_ReturnsBool()
+    {
+        StateSave state = BuildState(
+            ("Instance.A", 10f, "float"),
+            ("Instance.B", 10f, "float"));
+
+        EvaluatedSyntax result = Evaluate("Instance.A == Instance.B", state);
+
+        result.ShouldNotBeNull();
+        result.Value.ShouldBe(true);
+        result.EvaluatedType.ShouldBe("bool");
+    }
+
+    [Fact]
+    public void FromSyntaxNode_EqualityOfStrings_ReturnsBool()
+    {
+        StateSave state = BuildState(
+            ("Instance.Name", "Hello", "string"));
+
+        EvaluatedSyntax result = Evaluate("Instance.Name == \"Hello\"", state);
+
+        result.ShouldNotBeNull();
+        result.Value.ShouldBe(true);
+        result.EvaluatedType.ShouldBe("bool");
+    }
+
+    [Fact]
+    public void FromSyntaxNode_GreaterThanOrEqual_ReturnsBool()
+    {
+        StateSave state = BuildState(("Instance.Width", 50f, "float"));
+
+        EvaluatedSyntax result = Evaluate("Instance.Width >= 50", state);
+
+        result.ShouldNotBeNull();
+        result.Value.ShouldBe(true);
+        result.EvaluatedType.ShouldBe("bool");
+    }
+
+    [Fact]
+    public void FromSyntaxNode_GreaterThan_ReturnsBool()
+    {
+        StateSave state = BuildState(("Instance.Width", 100f, "float"));
+
+        EvaluatedSyntax result = Evaluate("Instance.Width > 50", state);
+
+        result.ShouldNotBeNull();
+        result.Value.ShouldBe(true);
+        result.EvaluatedType.ShouldBe("bool");
+    }
+
+    [Fact]
+    public void FromSyntaxNode_InequalityOfNumericValues_ReturnsBool()
+    {
+        StateSave state = BuildState(
+            ("Instance.A", 10f, "float"),
+            ("Instance.B", 20f, "float"));
+
+        EvaluatedSyntax result = Evaluate("Instance.A != Instance.B", state);
+
+        result.ShouldNotBeNull();
+        result.Value.ShouldBe(true);
+        result.EvaluatedType.ShouldBe("bool");
+    }
+
+    [Fact]
+    public void FromSyntaxNode_LessThanOrEqual_ReturnsBool()
+    {
+        StateSave state = BuildState(("Instance.Width", 50f, "float"));
+
+        EvaluatedSyntax result = Evaluate("Instance.Width <= 50", state);
+
+        result.ShouldNotBeNull();
+        result.Value.ShouldBe(true);
+        result.EvaluatedType.ShouldBe("bool");
+    }
+
+    [Fact]
+    public void FromSyntaxNode_LessThan_ReturnsBool()
+    {
+        StateSave state = BuildState(
+            ("Instance.IntVal", 5, "int"),
+            ("Instance.FloatVal", 10f, "float"));
+
+        EvaluatedSyntax result = Evaluate("Instance.IntVal < Instance.FloatVal", state);
+
+        result.ShouldNotBeNull();
+        result.Value.ShouldBe(true);
+        result.EvaluatedType.ShouldBe("bool");
+    }
+
+    #endregion
+
     #region ConvertSyntax
 
     [Fact]
@@ -386,6 +483,52 @@ public class EvaluatedSyntaxTests : BaseTestClass
 
     #endregion
 
+    #region LogicalOperators
+
+    [Fact]
+    public void FromSyntaxNode_LogicalAnd_ReturnsBool()
+    {
+        StateSave state = BuildState(
+            ("Instance.IsVisible", true, "bool"),
+            ("Instance.IsEnabled", false, "bool"));
+
+        EvaluatedSyntax result = Evaluate("Instance.IsVisible && Instance.IsEnabled", state);
+
+        result.ShouldNotBeNull();
+        result.Value.ShouldBe(false);
+        result.EvaluatedType.ShouldBe("bool");
+    }
+
+    [Fact]
+    public void FromSyntaxNode_LogicalOr_ReturnsBool()
+    {
+        StateSave state = BuildState(
+            ("Instance.IsVisible", true, "bool"),
+            ("Instance.IsEnabled", false, "bool"));
+
+        EvaluatedSyntax result = Evaluate("Instance.IsVisible || Instance.IsEnabled", state);
+
+        result.ShouldNotBeNull();
+        result.Value.ShouldBe(true);
+        result.EvaluatedType.ShouldBe("bool");
+    }
+
+    [Fact]
+    public void FromSyntaxNode_LogicalAndWithComparison_ReturnsBool()
+    {
+        StateSave state = BuildState(
+            ("Instance.Count", 5, "int"),
+            ("Instance.IsVisible", true, "bool"));
+
+        EvaluatedSyntax result = Evaluate("Instance.Count > 0 && Instance.IsVisible", state);
+
+        result.ShouldNotBeNull();
+        result.Value.ShouldBe(true);
+        result.EvaluatedType.ShouldBe("bool");
+    }
+
+    #endregion
+
     #region Negation
 
     [Fact]
@@ -455,6 +598,90 @@ public class EvaluatedSyntaxTests : BaseTestClass
 
         result.ShouldNotBeNull();
         result.Value.ShouldBe(42f);
+    }
+
+    #endregion
+
+    #region Ternary
+
+    [Fact]
+    public void FromSyntaxNode_TernaryArithmeticInBranches_EvaluatesSelectedBranch()
+    {
+        StateSave state = BuildState(
+            ("Instance.IsTall", true, "bool"),
+            ("Instance.Width", 50f, "float"));
+
+        EvaluatedSyntax result = Evaluate("Instance.IsTall ? Instance.Width * 2 : Instance.Width", state);
+
+        result.ShouldNotBeNull();
+        result.Value.ShouldBe(100f);
+    }
+
+    [Fact]
+    public void FromSyntaxNode_TernaryBoolIdentifierCondition_TreatsAsBool()
+    {
+        // Reading a bool variable should yield the bool Value, not the string "true"/"false".
+        // Covers Gap 4 (the existing ! operator already exercises this, but ternary
+        // verifies the bool is propagated end-to-end through the condition slot).
+        StateSave state = BuildState(
+            ("Instance.IsEnabled", true, "bool"));
+
+        EvaluatedSyntax result = Evaluate("Instance.IsEnabled ? \"On\" : \"Off\"", state);
+
+        result.ShouldNotBeNull();
+        result.Value.ShouldBe("On");
+    }
+
+    [Fact]
+    public void FromSyntaxNode_TernaryFalseCondition_PicksWhenFalse()
+    {
+        StateSave state = BuildState(
+            ("Instance.IsVisible", false, "bool"));
+
+        EvaluatedSyntax result = Evaluate("Instance.IsVisible ? 100 : 200", state);
+
+        result.ShouldNotBeNull();
+        result.Value.ShouldBe(200);
+    }
+
+    [Fact]
+    public void FromSyntaxNode_TernaryNonBoolCondition_ReturnsNullValue()
+    {
+        // Defensive: a non-bool condition (e.g., int) should not crash; it should yield null.
+        StateSave state = BuildState(
+            ("Instance.Count", 5, "int"));
+
+        EvaluatedSyntax result = Evaluate("Instance.Count ? 1 : 0", state);
+
+        // Whether result itself is null or just its Value, the line should be rejected gracefully.
+        if (result != null)
+        {
+            result.Value.ShouldBeNull();
+        }
+    }
+
+    [Fact]
+    public void FromSyntaxNode_TernaryStringBranches_ResolvesToString()
+    {
+        StateSave state = BuildState(
+            ("Instance.IsActive", true, "bool"));
+
+        EvaluatedSyntax result = Evaluate("Instance.IsActive ? \"Enabled\" : \"Disabled\"", state);
+
+        result.ShouldNotBeNull();
+        result.Value.ShouldBe("Enabled");
+    }
+
+    [Fact]
+    public void FromSyntaxNode_TernaryTrueCondition_PicksWhenTrue()
+    {
+        StateSave state = BuildState(
+            ("Instance.IsVisible", true, "bool"));
+
+        EvaluatedSyntax result = Evaluate("Instance.IsVisible ? 100 : 200", state);
+
+        result.ShouldNotBeNull();
+        result.Value.ShouldBe(100);
     }
 
     #endregion

--- a/Tests/GumExpressions.Tests/GumExpressions.Tests.csproj
+++ b/Tests/GumExpressions.Tests/GumExpressions.Tests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Shouldly" Version="4.3.0" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Runtimes\GumExpressions\GumExpressions.csproj" />
+    <ProjectReference Include="..\..\GumCommon\GumCommon.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/Tool/Tests/GumToolUnitTests/VariableGrid/VariableReferenceLogicTests.cs
+++ b/Tool/Tests/GumToolUnitTests/VariableGrid/VariableReferenceLogicTests.cs
@@ -278,7 +278,208 @@ public class VariableReferenceLogicTests : BaseTestClass
 
     #endregion
 
+    #region CategoryStateLeftSide
+
+    [Fact]
+    public void DoVariableReferenceReaction_CategoryStateLiteralAssignment_AcceptsLine()
+    {
+        // "ButtonCategoryState = \"Disabled\"" is a synthetic category-state LHS that the
+        // runtime routes through GraphicalUiElement.SetProperty. Validation should accept
+        // it when "Disabled" exists in ButtonCategory.
+        ComponentSave button = BuildButtonComponentWithCategory("ButtonCategory", "Enabled", "Disabled");
+        ScreenSave screen = BuildScreenWithVariableReference(
+            line: "ButtonCategoryState = \"Disabled\"",
+            out StateSave defaultState,
+            out VariableListSave<string> varList);
+
+        GumProjectSave project = new GumProjectSave();
+        project.Components.Add(button);
+        project.Screens.Add(screen);
+        ObjectFinder.Self.GumProjectSave = project;
+
+        ScreenInheritsFromButton(screen, button);
+
+        _sut.DoVariableReferenceReaction(
+            parentElement: screen,
+            leftSideInstance: null,
+            unqualifiedMember: "VariableReferences",
+            stateSave: defaultState,
+            qualifiedName: "VariableReferences",
+            trySave: false);
+
+        varList.Value[0].ShouldBe("ButtonCategoryState = \"Disabled\"");
+    }
+
+    [Fact]
+    public void DoVariableReferenceReaction_CategoryStateNonexistentLiteral_CommentsLine()
+    {
+        // Literal RHS that does not name a real state in the category should be rejected.
+        ComponentSave button = BuildButtonComponentWithCategory("ButtonCategory", "Enabled", "Disabled");
+        ScreenSave screen = BuildScreenWithVariableReference(
+            line: "ButtonCategoryState = \"NonexistentState\"",
+            out StateSave defaultState,
+            out VariableListSave<string> varList);
+
+        GumProjectSave project = new GumProjectSave();
+        project.Components.Add(button);
+        project.Screens.Add(screen);
+        ObjectFinder.Self.GumProjectSave = project;
+
+        ScreenInheritsFromButton(screen, button);
+
+        _sut.DoVariableReferenceReaction(
+            parentElement: screen,
+            leftSideInstance: null,
+            unqualifiedMember: "VariableReferences",
+            stateSave: defaultState,
+            qualifiedName: "VariableReferences",
+            trySave: false);
+
+        varList.Value[0].ShouldStartWith("//");
+    }
+
+    [Fact]
+    public void DoVariableReferenceReaction_CategoryStateNonexistentCategory_CommentsLine()
+    {
+        // No <CategoryName> matching "MissingCategory" exists anywhere in the chain.
+        ComponentSave button = BuildButtonComponentWithCategory("ButtonCategory", "Enabled");
+        ScreenSave screen = BuildScreenWithVariableReference(
+            line: "MissingCategoryState = \"Foo\"",
+            out StateSave defaultState,
+            out VariableListSave<string> varList);
+
+        GumProjectSave project = new GumProjectSave();
+        project.Components.Add(button);
+        project.Screens.Add(screen);
+        ObjectFinder.Self.GumProjectSave = project;
+
+        ScreenInheritsFromButton(screen, button);
+
+        _sut.DoVariableReferenceReaction(
+            parentElement: screen,
+            leftSideInstance: null,
+            unqualifiedMember: "VariableReferences",
+            stateSave: defaultState,
+            qualifiedName: "VariableReferences",
+            trySave: false);
+
+        varList.Value[0].ShouldStartWith("//");
+    }
+
+    [Fact]
+    public void DoVariableReferenceReaction_CategoryStateTernaryRhs_AcceptsLineLeniently()
+    {
+        // Non-literal RHS: a ternary that resolves to a string should be accepted even
+        // though we cannot statically verify the resulting state name.
+        ComponentSave button = BuildButtonComponentWithCategory("ButtonCategory", "Enabled", "Disabled");
+        ScreenSave screen = BuildScreenWithVariableReference(
+            line: "ButtonCategoryState = IsEnabled ? \"Enabled\" : \"Disabled\"",
+            out StateSave defaultState,
+            out VariableListSave<string> varList);
+
+        defaultState.Variables.Add(new VariableSave
+        {
+            Name = "IsEnabled",
+            Value = true,
+            Type = "bool",
+            SetsValue = true
+        });
+
+        GumProjectSave project = new GumProjectSave();
+        project.Components.Add(button);
+        project.Screens.Add(screen);
+        ObjectFinder.Self.GumProjectSave = project;
+
+        ScreenInheritsFromButton(screen, button);
+
+        _sut.DoVariableReferenceReaction(
+            parentElement: screen,
+            leftSideInstance: null,
+            unqualifiedMember: "VariableReferences",
+            stateSave: defaultState,
+            qualifiedName: "VariableReferences",
+            trySave: false);
+
+        varList.Value[0].ShouldBe("ButtonCategoryState = IsEnabled ? \"Enabled\" : \"Disabled\"");
+    }
+
+    [Fact]
+    public void DoVariableReferenceReaction_InheritedCategoryState_AcceptsLine()
+    {
+        // The matching category lives on the base component, not directly on the
+        // current element; FindCategoryForStateLeftSide must walk the inheritance chain.
+        ComponentSave baseButton = BuildButtonComponentWithCategory("ButtonCategory", "Enabled", "Disabled");
+        baseButton.Name = "BaseButton";
+
+        ComponentSave derivedButton = new ComponentSave { Name = "DerivedButton", BaseType = "BaseButton" };
+        StateSave derivedDefault = new StateSave { Name = "Default", ParentContainer = derivedButton };
+        derivedButton.States.Add(derivedDefault);
+
+        VariableListSave<string> varList = new VariableListSave<string> { Type = "string", Name = "VariableReferences" };
+        varList.Value.Add("ButtonCategoryState = \"Disabled\"");
+        derivedDefault.VariableLists.Add(varList);
+
+        GumProjectSave project = new GumProjectSave();
+        project.Components.Add(baseButton);
+        project.Components.Add(derivedButton);
+        ObjectFinder.Self.GumProjectSave = project;
+
+        _sut.DoVariableReferenceReaction(
+            parentElement: derivedButton,
+            leftSideInstance: null,
+            unqualifiedMember: "VariableReferences",
+            stateSave: derivedDefault,
+            qualifiedName: "VariableReferences",
+            trySave: false);
+
+        varList.Value[0].ShouldBe("ButtonCategoryState = \"Disabled\"");
+    }
+
+    #endregion
+
     #region Helpers
+
+    private static ComponentSave BuildButtonComponentWithCategory(string categoryName, params string[] stateNames)
+    {
+        ComponentSave button = new ComponentSave { Name = "Button" };
+        StateSave defaultState = new StateSave { Name = "Default", ParentContainer = button };
+        button.States.Add(defaultState);
+
+        StateSaveCategory category = new StateSaveCategory { Name = categoryName };
+        foreach (string stateName in stateNames)
+        {
+            category.States.Add(new StateSave { Name = stateName, ParentContainer = button });
+        }
+        button.Categories.Add(category);
+
+        return button;
+    }
+
+    private static ScreenSave BuildScreenWithVariableReference(string line, out StateSave defaultState, out VariableListSave<string> varList)
+    {
+        ScreenSave screen = new ScreenSave { Name = "TestScreen" };
+        defaultState = new StateSave { Name = "Default", ParentContainer = screen };
+        screen.States.Add(defaultState);
+
+        varList = new VariableListSave<string> { Type = "string", Name = "VariableReferences" };
+        varList.Value.Add(line);
+        defaultState.VariableLists.Add(varList);
+
+        return screen;
+    }
+
+    private static void ScreenInheritsFromButton(ScreenSave screen, ComponentSave button)
+    {
+        // Make the screen carry the category by base inheritance via instances:
+        // simplest setup is to set BaseType so FindCategoryForStateLeftSide walks
+        // GetBaseElements. Screens cannot set BaseType to a Component normally, so we
+        // attach the category directly on the screen element when no inheritance applies.
+        screen.Categories.Add(new StateSaveCategory
+        {
+            Name = button.Categories[0].Name,
+            States = new List<StateSave>(button.Categories[0].States)
+        });
+    }
 
     private static StateSave BuildStateWithVariableReferences(string listName, string item)
     {


### PR DESCRIPTION
## Summary
Closes three gaps in the variable-reference engine that block useful expressions and v2 of #2637 (Forms property promotion).

- **Gap 1 — Ternary expressions**: `EvaluatedSyntax.Evaluate` now handles `ConditionalExpressionSyntax`. Also switched `GumExpressionService.EvaluateExpression` (and the test helper) from `ParseText(...).GetCompilationUnitRoot()` to `SyntaxFactory.ParseExpression` — the former was disambiguating top-level `Foo ? bar` as `NullableType + variable declaration` rather than a ternary, so Gap 1 wouldn't have worked in the runtime path otherwise. Strictly more permissive parsing.
- **Gap 2 — Comparison/logical operators**: `Combine` now handles `==`, `!=`, `<`, `>`, `<=`, `>=`, `&&`, `||`. Equality uses `object.Equals`, relational reuses the existing dynamic numeric-coercion path, logical requires both operands `bool`. Replaced unreachable `Debugger.Break()` on unknown operators with `return null`.
- **Gap 3 — Category-state LHS**: `VariableReferenceLogic` now recognizes `<CategoryName>State = "..."` synthetic LHS by walking the element's categories and inheritance chain via `ObjectFinder.GetBaseElements`. String-literal RHS is checked against existing state names; non-literal RHS (ternary, expression) is accepted leniently because runtime `ApplyState` no-ops on unknown state names.

Gap 4 (boolean variable as ternary condition) was verified to already work — no fix needed.

Authoritative design: `.claude/designs/VariableReferenceGaps.md`.

## Test project move
`EvaluatedSyntaxTests.cs` had been living in `GumToolUnitTests` despite testing a pure runtime class with no WPF dependency. Moved it to a new `Tests/GumExpressions.Tests` project on `AllLibraries.sln` (matches the `MonoGameGum.Tests`, `Gum.Analyzers.Tests`, etc. convention). Gap 3 tests stay in `GumToolUnitTests` because they exercise the WPF plugin's validation logic.

## Test plan
- [x] `dotnet test AllLibraries.sln --filter "FullyQualifiedName~EvaluatedSyntaxTests"` — 52 tests (37 migrated + 15 new for ternary/comparison/logical), all green.
- [x] `dotnet test GumFull.sln --filter "FullyQualifiedName~VariableReferenceLogicTests"` — 19 tests (14 existing + 5 new for category-state LHS), all green.
- [x] `dotnet test MonoGameGum.Tests` — 1297 passing, no regression in runtime consumers of `GumExpressions`.
- [x] `dotnet build GumFull.sln` clean.
- [ ] Manual smoke: in the Gum tool, on a Button-derived component, author `ButtonCategoryState = IsEnabled ? "Enabled" : "Disabled"` and toggle `IsEnabled` to verify visual state switching.

## Out of scope
- Skill-file updates (`gum-tool-variable-references`, `gum-runtime-variable-references`) to document the new operator/ternary surface — deferred to a small follow-up.
- Pre-existing nullable warnings (`CS86xx`) in `GumExpressions` — not addressed to keep diff focused on behavior changes.
- Runtime application of behavior-level variable references (covered by #2637).

🤖 Generated with [Claude Code](https://claude.com/claude-code)