### PR TITLE
Harden #2638: runtime ternary test + docs + skill updates

### DIFF
--- a/.claude/skills/gum-runtime-variable-references/SKILL.md
+++ b/.claude/skills/gum-runtime-variable-references/SKILL.md
@@ -21,7 +21,7 @@ No Roslyn dependency — lives in GumRuntime/GumCommon, available to all platfor
 
 Located in `Runtimes/GumExpressions/`. Provides Roslyn-based expression evaluation for arithmetic in variable references (`Width + 10`, `Width * 2`). Optional — without it, only simple dot-path lookups work (`OtherInstance.Width`).
 
-`GumExpressionService.Initialize()` sets `ElementSaveExtensions.CustomEvaluateExpression` to a Roslyn-based evaluator. The evaluator is `EvaluatedSyntax`, which was extracted from the Gum tool into this project.
+`GumExpressionService.Initialize()` sets `ElementSaveExtensions.CustomEvaluateExpression` to a Roslyn-based evaluator. The evaluator is `EvaluatedSyntax`, which was extracted from the Gum tool into this project. Conditional (ternary), comparison (`==`, `!=`, `<`, `>`, `<=`, `>=`), and logical (`&&`, `||`, `!`) operators all flow through this same path — they work at runtime when `Gum.Expressions` is wired.
 
 ### Two Apply Overloads (ElementSaveExtensions)
 

--- a/.claude/skills/gum-tool-variable-references/SKILL.md
+++ b/.claude/skills/gum-tool-variable-references/SKILL.md
@@ -22,6 +22,8 @@ LeftProperty = RightSide
   - Local: `OtherInstance.X` (same element)
   - Cross-element: `Components/MyComp.InstanceName.Width` (slash-separated element path)
   - Expressions: `OtherInstance.Width + 10`, `OtherInstance.Width * 2`, `!OtherInstance.Visible`
+  - Conditional/comparison/logical operators: ternary `cond ? a : b`, `==`, `!=`, `<`, `>`, `<=`, `>=`, `&&`, `||`, `!`
+  - Category-state LHS: `<CategoryName>State = "StateName"` assigns the categorical state by name
   - Literals: `X = 42`
 - **Comments:** Lines starting with `//` are skipped. Invalid lines are auto-commented on validation failure.
 - **Shorthand:** Writing just `OtherInstance.X` (no left side) auto-expands to `X = OtherInstance.X`.

--- a/MonoGameGum.Tests/MonoGameGum.Tests.csproj
+++ b/MonoGameGum.Tests/MonoGameGum.Tests.csproj
@@ -24,6 +24,7 @@
 	<ItemGroup>
 		<ProjectReference Include="..\GumCommon\GumCommon.csproj" />
 		<ProjectReference Include="..\MonoGameGum\MonoGameGum.csproj" />
+		<ProjectReference Include="..\Runtimes\GumExpressions\GumExpressions.csproj" />
 		<ProjectReference Include="..\Tests\MonoGameGum.TestsCommon\MonoGameGum.TestsCommon.csproj" />
 	</ItemGroup>
 

--- a/MonoGameGum.Tests/Runtimes/ApplyVariableReferencesRuntimeTests.cs
+++ b/MonoGameGum.Tests/Runtimes/ApplyVariableReferencesRuntimeTests.cs
@@ -1,5 +1,6 @@
 using Gum.DataTypes;
 using Gum.DataTypes.Variables;
+using Gum.Expressions;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
@@ -204,6 +205,33 @@ public class ApplyVariableReferencesRuntimeTests : BaseTestClass
 
         parent.X.ShouldBe(10f);
         parent.Y.ShouldBe(20f);
+    }
+
+    #endregion
+
+    #region Ternary
+
+    [Fact]
+    public void ApplyVariableReferences_TernaryConditional_AppliesSelectedBranchValue()
+    {
+        // Locks in that top-level ternary RHS expressions survive the runtime path end-to-end.
+        // Regression guard for the SyntaxFactory.ParseExpression switch in
+        // GumExpressionService.EvaluateExpression — without it, "Foo ? a : b" parsed as a
+        // NullableType + variable declaration and produced no value.
+        GumExpressionService.Initialize();
+
+        ContainerRuntime parent = new ContainerRuntime();
+        parent.Width = 0;
+
+        StateSave state = BuildStateWithVariableReference(
+            "Width = SourceInstance.IsTall ? 200 : 50",
+            null,
+            ("Width", 0f, "float"),
+            ("SourceInstance.IsTall", true, "bool"));
+
+        parent.ApplyVariableReferences(state);
+
+        parent.Width.ShouldBe(200f);
     }
 
     #endregion

--- a/Tests/GumExpressions.Tests/EvaluatedSyntaxTests.cs
+++ b/Tests/GumExpressions.Tests/EvaluatedSyntaxTests.cs
@@ -645,6 +645,37 @@ public class EvaluatedSyntaxTests : BaseTestClass
     }
 
     [Fact]
+    public void FromSyntaxNode_TernaryMixedTypeBranches_FalseCondition_ReturnsNumericBranch()
+    {
+        // Defensive pin: when ternary branches have mismatched types, the result reflects
+        // whichever branch the condition picks. EvaluatedType is derived from the runtime
+        // value type (FromSyntaxAndValue -> GetSimpleTypeNameForValue), so a numeric branch
+        // taken on a false condition yields the int value with EvaluatedType "int".
+        StateSave state = BuildState(("Instance.IsActive", false, "bool"));
+
+        EvaluatedSyntax result = Evaluate("Instance.IsActive ? \"hello\" : 42", state);
+
+        result.ShouldNotBeNull();
+        result.Value.ShouldBe(42);
+        result.EvaluatedType.ShouldBe("int");
+    }
+
+    [Fact]
+    public void FromSyntaxNode_TernaryMixedTypeBranches_TrueCondition_ReturnsStringBranch()
+    {
+        // Defensive pin: see FromSyntaxNode_TernaryMixedTypeBranches_FalseCondition_*. With a
+        // true condition, the string branch is taken and EvaluatedType reflects the string
+        // value, not the unselected numeric branch.
+        StateSave state = BuildState(("Instance.IsActive", true, "bool"));
+
+        EvaluatedSyntax result = Evaluate("Instance.IsActive ? \"hello\" : 42", state);
+
+        result.ShouldNotBeNull();
+        result.Value.ShouldBe("hello");
+        result.EvaluatedType.ShouldBe("string");
+    }
+
+    [Fact]
     public void FromSyntaxNode_TernaryNonBoolCondition_ReturnsNullValue()
     {
         // Defensive: a non-bool condition (e.g., int) should not crash; it should yield null.

--- a/docs/code/styling/runtime-variable-references.md
+++ b/docs/code/styling/runtime-variable-references.md
@@ -169,6 +169,8 @@ GumExpressionService.Initialize();
 The `Gum.Expressions` package uses Microsoft Roslyn for expression parsing, which adds approximately 10 MB to your build output. If your variable references only use simple assignments (no arithmetic), you do not need this package.
 {% endhint %}
 
+The same `Gum.Expressions` package also enables runtime evaluation of conditional (ternary), comparison (`==`, `!=`, `<`, `>`, `<=`, `>=`), and logical (`&&`, `||`, `!`) operators in variable references. See the [Variable References](../../gum-tool/gum-elements/general-properties/variable-references.md) page for the full list of supported syntax.
+
 If you are linking to Gum source instead of NuGet, see the setup page for your platform for instructions on adding GumExpressions as a project reference:
 
 * [MonoGame/KNI/FNA Setup](../getting-started/setup/adding-initializing-gum/monogame-kni-fna/README.md)

--- a/docs/gum-tool/gum-elements/general-properties/variable-references.md
+++ b/docs/gum-tool/gum-elements/general-properties/variable-references.md
@@ -140,6 +140,61 @@ Math operations can reference both constant values (1, 2, 3) or other variables:
 Width = (OtherInstance.Height * 3) + 10
 ```
 
+## Conditional and Logical Expressions
+
+Variable references support conditional (ternary) expressions, comparison operators, and logical operators. These can be combined to drive variable values from boolean conditions or to switch between values based on other variables.
+
+### Conditional (Ternary) Expressions
+
+A conditional expression uses the C# `cond ? a : b` syntax. If `cond` evaluates to `true`, the result is `a`; otherwise the result is `b`. The condition can be a boolean variable or a comparison:
+
+```csharp
+Width = IsTall ? 200 : 50
+X = Count > 0 ? StartX : 0
+```
+
+Ternary expressions can be nested. Use parenthesis to make the order of evaluation clear:
+
+```csharp
+Width = X > 200 ? 300 : (X > 100 ? 200 : 100)
+```
+
+### Comparison Operators
+
+The operators `==`, `!=`, `<`, `>`, `<=`, and `>=` can be used to compare values. The result is a `bool`, so comparisons are most often used as the condition of a ternary or as the right side of a `bool` assignment:
+
+```csharp
+Visible = Count > 0
+Color = Score >= HighScore ? Gold : Silver
+```
+
+### Logical Operators
+
+The logical operators `&&` (and) and `||` (or) combine two `bool` values into a single `bool`. Both operands must be `bool`:
+
+```csharp
+Visible = IsEnabled && IsHovered
+Visible = IsError || IsWarning
+```
+
+### Boolean Negation
+
+The `!` operator inverts a `bool` value:
+
+```csharp
+Visible = !IsDisabled
+```
+
+### Category-State Assignment
+
+Variable references can drive a component's categorical state by assigning to `<CategoryName>State`. The right side must resolve to a `string` matching one of the state names defined in that category. This is useful for switching visual states from a `bool` or other variable. For example, on a button-derived component with a `ButtonCategory` containing `Enabled` and `Disabled` states:
+
+```csharp
+ButtonCategoryState = IsEnabled ? "Enabled" : "Disabled"
+```
+
+If the right side is a literal string, Gum validates it against the category's state names and comments out the line if there is no match.
+
 {% hint style="warning" %}
 Gum treats the prefixes `Components/`, `Screens/`, and `Standards/` as special prefixes and does not consider this to be a division operator. Therefore, you should not name variables Components, Screens, or Standards as these are reserved words. Other variable references can freely use the forward slash character to create division.
 

--- a/docs/gum-tool/gum-elements/general-properties/variable-references.md
+++ b/docs/gum-tool/gum-elements/general-properties/variable-references.md
@@ -130,8 +130,7 @@ Visible = true
 Math operations can be used in variable assignments. This includes add, subtract, multiply, divide, and parenthesis to control order of operations:
 
 ```csharp
-// This evaluates to 17
-Y = (1 + 2) * 7 - 4
+Y = (TitleText.Y + 2) * 7 - 4
 ```
 
 Math operations can reference both constant values (1, 2, 3) or other variables:
@@ -149,14 +148,20 @@ Variable references support conditional (ternary) expressions, comparison operat
 A conditional expression uses the C# `cond ? a : b` syntax. If `cond` evaluates to `true`, the result is `a`; otherwise the result is `b`. The condition can be a boolean variable or a comparison:
 
 ```csharp
-Width = IsTall ? 200 : 50
-X = Count > 0 ? StartX : 0
+Width = TitleText.Visible ? 200 : 100
+X = Background.Width > 500 ? Background.X : 0
+```
+
+Just like simple variable references, the right side can be fully qualified to point at another element:
+
+```csharp
+Width = Components/AppState.IsExpanded ? 400 : 200
 ```
 
 Ternary expressions can be nested. Use parenthesis to make the order of evaluation clear:
 
 ```csharp
-Width = X > 200 ? 300 : (X > 100 ? 200 : 100)
+Width = Container.Width > 500 ? 300 : (Container.Width > 250 ? 200 : 100)
 ```
 
 ### Comparison Operators
@@ -164,8 +169,8 @@ Width = X > 200 ? 300 : (X > 100 ? 200 : 100)
 The operators `==`, `!=`, `<`, `>`, `<=`, and `>=` can be used to compare values. The result is a `bool`, so comparisons are most often used as the condition of a ternary or as the right side of a `bool` assignment:
 
 ```csharp
-Visible = Count > 0
-Color = Score >= HighScore ? Gold : Silver
+Visible = Background.Width > 100
+Width = ScoreText.Y >= TitleText.Y ? 300 : 100
 ```
 
 ### Logical Operators
@@ -173,8 +178,8 @@ Color = Score >= HighScore ? Gold : Silver
 The logical operators `&&` (and) and `||` (or) combine two `bool` values into a single `bool`. Both operands must be `bool`:
 
 ```csharp
-Visible = IsEnabled && IsHovered
-Visible = IsError || IsWarning
+Visible = ToggleButton.Visible && ContentArea.Visible
+Visible = ErrorIcon.Visible || WarningIcon.Visible
 ```
 
 ### Boolean Negation
@@ -182,15 +187,15 @@ Visible = IsError || IsWarning
 The `!` operator inverts a `bool` value:
 
 ```csharp
-Visible = !IsDisabled
+Visible = !LoadingSpinner.Visible
 ```
 
 ### Category-State Assignment
 
-Variable references can drive a component's categorical state by assigning to `<CategoryName>State`. The right side must resolve to a `string` matching one of the state names defined in that category. This is useful for switching visual states from a `bool` or other variable. For example, on a button-derived component with a `ButtonCategory` containing `Enabled` and `Disabled` states:
+Variable references can drive a component's categorical state by assigning to `<CategoryName>State`. The right side must resolve to a `string` matching one of the state names defined in that category. This is useful for switching visual states from another instance's variable. For example, on a button-derived component with a `ButtonCategory` containing `Enabled` and `Disabled` states:
 
 ```csharp
-ButtonCategoryState = IsEnabled ? "Enabled" : "Disabled"
+ButtonCategoryState = Background.Visible ? "Enabled" : "Disabled"
 ```
 
 If the right side is a literal string, Gum validates it against the category's state names and comments out the line if there is no match.


### PR DESCRIPTION
Follow-up to #2640 (merged). Closes the gaps I flagged when reporting that PR ready.

## Summary
1. **Runtime ternary integration test** in `MonoGameGum.Tests/Runtimes/ApplyVariableReferencesRuntimeTests.cs` — exercises the full apply path end-to-end with a ternary RHS, locking in the parser switch from `ParseText` to `SyntaxFactory.ParseExpression` that #2640 introduced. Plus two defensive tests pinning ternary mixed-type branch behavior.
2. **Docs update** — adds a 'Conditional and Logical Expressions' section to `docs/gum-tool/gum-elements/general-properties/variable-references.md` covering ternary, comparison, logical, `!`, and category-state LHS. One-line note on the runtime page. Skill file updates so agents know the new surface is supported.

## Test plan
- [x] `dotnet test AllLibraries.sln --filter "FullyQualifiedName~EvaluatedSyntaxTests"` — 52 → 54, all green.
- [x] `dotnet test AllLibraries.sln --filter "FullyQualifiedName~ApplyVariableReferencesRuntimeTests"` — 8 → 9, all green.
- [x] TDD verification: temporarily disabling `GumExpressionService.Initialize()` in the new test causes the expected failure, confirming it exercises the Roslyn evaluator path rather than the simple-dot fallback.

## Note worth a follow-up
`MonoGameGum.Tests.csproj` gains a `<ProjectReference>` to `Runtimes/GumExpressions/GumExpressions.csproj` so the runtime test can call `GumExpressionService.Initialize()`. This pulls Roslyn into the test project's build (not the runtime library's). End-user MonoGameGum dependency surface is unchanged. If the test-project bloat is a concern, alternative is splitting this into a dedicated runtime-with-expressions test project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)