### PR TITLE
Preserve user-picked Behaviors/Standards across recompute (#2642)

### DIFF
--- a/Gum/ImportFromGumxPlugin/Properties/AssemblyInfo.cs
+++ b/Gum/ImportFromGumxPlugin/Properties/AssemblyInfo.cs
@@ -1,6 +1,8 @@
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
+[assembly: InternalsVisibleTo("GumToolUnitTests")]
 [assembly: AssemblyTitle("ImportFromGumxPlugin")]
 [assembly: AssemblyDescription("Gum plugin for importing components and screens from any .gumx file")]
 [assembly: AssemblyCompany("")]

--- a/Gum/ImportFromGumxPlugin/ViewModels/ImportFromGumxViewModel.cs
+++ b/Gum/ImportFromGumxPlugin/ViewModels/ImportFromGumxViewModel.cs
@@ -34,6 +34,11 @@ public class ImportFromGumxViewModel : DialogViewModel
 
     private readonly List<ImportTreeNodeViewModel> _allLeafItems = new List<ImportTreeNodeViewModel>();
     private readonly HashSet<string> _autoAddedComponentNames = new HashSet<string>();
+    // Behaviors and Standards aren't pulled in by the dependency resolver from a user's perspective —
+    // the user picks them directly. Track explicit user picks so RecomputeTransitiveDependencies
+    // doesn't clobber them when it rebuilds those groups from resolver output. (#2642)
+    private readonly HashSet<string> _userExplicitBehaviorNames = new HashSet<string>();
+    private readonly HashSet<string> _userExplicitStandardNames = new HashSet<string>();
     private ImportTreeNodeViewModel? _behaviorsGroupNode;
     private ImportTreeNodeViewModel? _standardsGroupNode;
     private bool _recomputeQueued = false;
@@ -326,6 +331,8 @@ public class ImportFromGumxViewModel : DialogViewModel
             leaf.PropertyChanged -= OnItemPropertyChanged;
         _allLeafItems.Clear();
         _autoAddedComponentNames.Clear();
+        _userExplicitBehaviorNames.Clear();
+        _userExplicitStandardNames.Clear();
         RootNodes.Clear();
         _behaviorsGroupNode = null;
         _standardsGroupNode = null;
@@ -388,21 +395,55 @@ public class ImportFromGumxViewModel : DialogViewModel
     {
         if (e.PropertyName == nameof(ImportTreeNodeViewModel.InclusionState) && !_recomputeQueued)
         {
-            // User directly changed a component — remove it from auto-added tracking so it isn't reset
-            if (sender is ImportTreeNodeViewModel vm && vm.ElementType == ElementItemType.Component)
+            if (sender is ImportTreeNodeViewModel vm)
             {
-                _autoAddedComponentNames.Remove(vm.FullName);
+                // User directly changed a component — remove it from auto-added tracking so it isn't reset
+                if (vm.ElementType == ElementItemType.Component)
+                {
+                    _autoAddedComponentNames.Remove(vm.FullName);
+                }
+                // Behaviors / Standards: track explicit user picks so the recompute pass
+                // doesn't wipe them out (#2642).
+                else if (vm.ElementType == ElementItemType.Behavior)
+                {
+                    if (vm.InclusionState == InclusionState.Explicit) { _userExplicitBehaviorNames.Add(vm.FullName); }
+                    else { _userExplicitBehaviorNames.Remove(vm.FullName); }
+                }
+                else if (vm.ElementType == ElementItemType.Standard)
+                {
+                    if (vm.InclusionState == InclusionState.Explicit) { _userExplicitStandardNames.Add(vm.FullName); }
+                    else { _userExplicitStandardNames.Remove(vm.FullName); }
+                }
             }
             _recomputeQueued = true;
-            System.Windows.Application.Current.Dispatcher.BeginInvoke(() =>
+            // Application.Current is null in unit tests; the test drives recompute directly.
+            var dispatcher = System.Windows.Application.Current?.Dispatcher;
+            if (dispatcher != null)
+            {
+                dispatcher.BeginInvoke(() =>
+                {
+                    _recomputeQueued = false;
+                    RecomputeTransitiveDependencies();
+                });
+            }
+            else
             {
                 _recomputeQueued = false;
-                RecomputeTransitiveDependencies();
-            });
+            }
         }
     }
 
-    private void RecomputeTransitiveDependencies()
+    /// <summary>
+    /// Test seam: directly load a source project without the file/URL fetch step.
+    /// Production callers go through <see cref="LoadPreviewCommand"/>.
+    /// </summary>
+    internal void InitializeFromProjectForTesting(GumProjectSave project)
+    {
+        _sourceProject = project;
+        PopulateItems(project);
+    }
+
+    internal void RecomputeTransitiveDependencies()
     {
         if (_sourceProject == null) { return; }
 
@@ -451,25 +492,25 @@ public class ImportFromGumxViewModel : DialogViewModel
             }
         }
 
-        // Auto-check required behaviors, uncheck others
+        // Auto-check required behaviors, plus any the user explicitly picked; uncheck others
         var requiredBehaviorNames = new HashSet<string>(deps.Behaviors.Select(b => b.Name));
         foreach (ImportTreeNodeViewModel item in _allLeafItems.Where(i => i.ElementType == ElementItemType.Behavior))
         {
+            bool shouldBeExplicit = requiredBehaviorNames.Contains(item.FullName)
+                || _userExplicitBehaviorNames.Contains(item.FullName);
             item.PropertyChanged -= OnItemPropertyChanged;
-            item.InclusionState = requiredBehaviorNames.Contains(item.FullName)
-                ? InclusionState.Explicit
-                : InclusionState.NotIncluded;
+            item.InclusionState = shouldBeExplicit ? InclusionState.Explicit : InclusionState.NotIncluded;
             item.PropertyChanged += OnItemPropertyChanged;
         }
 
-        // Auto-check differing standards, uncheck others
+        // Auto-check differing standards, plus any the user explicitly picked; uncheck others
         var differingStandardNames = new HashSet<string>(deps.DifferingStandards.Select(s => s.Name));
         foreach (ImportTreeNodeViewModel item in _allLeafItems.Where(i => i.ElementType == ElementItemType.Standard))
         {
+            bool shouldBeExplicit = differingStandardNames.Contains(item.FullName)
+                || _userExplicitStandardNames.Contains(item.FullName);
             item.PropertyChanged -= OnItemPropertyChanged;
-            item.InclusionState = differingStandardNames.Contains(item.FullName)
-                ? InclusionState.Explicit
-                : InclusionState.NotIncluded;
+            item.InclusionState = shouldBeExplicit ? InclusionState.Explicit : InclusionState.NotIncluded;
             item.PropertyChanged += OnItemPropertyChanged;
         }
     }

--- a/Tool/Tests/GumToolUnitTests/Plugins/ImportFromGumxPlugin/ImportFromGumxViewModelTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/ImportFromGumxPlugin/ImportFromGumxViewModelTests.cs
@@ -1,0 +1,297 @@
+using Gum.Commands;
+using Gum.DataTypes;
+using Gum.DataTypes.Behaviors;
+using Gum.DataTypes.Variables;
+using Gum.Plugins.ImportPlugin.Manager;
+using Gum.Plugins.ImportPlugin.Services;
+using Gum.Settings;
+using Gum.ToolStates;
+using ImportFromGumxPlugin.Services;
+using ImportFromGumxPlugin.ViewModels;
+using Shouldly;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using ToolsUtilities;
+
+namespace GumToolUnitTests.Plugins.ImportFromGumxPlugin;
+
+/// <summary>
+/// Tests for ImportFromGumxViewModel's leaf-inclusion bookkeeping. Specifically,
+/// regression coverage for issue #2642 — user clicks on Behavior/Standard checkboxes
+/// were being wiped on the next dispatcher tick because RecomputeTransitiveDependencies
+/// rebuilt those groups purely from the dependency resolver.
+/// </summary>
+public class ImportFromGumxViewModelTests
+{
+    private readonly ImportFromGumxViewModel _sut;
+
+    public ImportFromGumxViewModelTests()
+    {
+        GumxSourceService sourceService = new GumxSourceService();
+        GumxDependencyResolver resolver = new GumxDependencyResolver();
+        FakeProjectState projectState = new FakeProjectState();
+        GumxImportService importService = new GumxImportService(
+            new FakeImportLogic(), projectState, new FakeFileCommands(), sourceService);
+
+        _sut = new ImportFromGumxViewModel(sourceService, resolver, importService, projectState);
+    }
+
+    [Fact]
+    public void RecomputeTransitiveDependencies_BehaviorCheckedByUser_RemainsExplicit()
+    {
+        GumProjectSave source = new GumProjectSave();
+        source.Behaviors.Add(new BehaviorSave { Name = "MyBehavior" });
+
+        _sut.InitializeFromProjectForTesting(source);
+        ImportTreeNodeViewModel behaviorLeaf = FindLeaf("MyBehavior", ElementItemType.Behavior);
+
+        behaviorLeaf.InclusionState = InclusionState.Explicit;
+        _sut.RecomputeTransitiveDependencies();
+
+        behaviorLeaf.InclusionState.ShouldBe(InclusionState.Explicit);
+    }
+
+    [Fact]
+    public void RecomputeTransitiveDependencies_StandardCheckedByUser_RemainsExplicit()
+    {
+        GumProjectSave source = new GumProjectSave();
+        source.StandardElements.Add(new StandardElementSave
+        {
+            Name = "Text",
+            States = new List<StateSave> { new StateSave { Name = "Default", Variables = new List<VariableSave>() } }
+        });
+
+        _sut.InitializeFromProjectForTesting(source);
+        ImportTreeNodeViewModel standardLeaf = FindLeaf("Text", ElementItemType.Standard);
+
+        standardLeaf.InclusionState = InclusionState.Explicit;
+        _sut.RecomputeTransitiveDependencies();
+
+        standardLeaf.InclusionState.ShouldBe(InclusionState.Explicit);
+    }
+
+    [Fact]
+    public void RecomputeTransitiveDependencies_BehaviorUncheckedByUser_RemainsNotIncluded()
+    {
+        GumProjectSave source = new GumProjectSave();
+        source.Behaviors.Add(new BehaviorSave { Name = "MyBehavior" });
+
+        _sut.InitializeFromProjectForTesting(source);
+        ImportTreeNodeViewModel behaviorLeaf = FindLeaf("MyBehavior", ElementItemType.Behavior);
+
+        behaviorLeaf.InclusionState = InclusionState.Explicit;
+        _sut.RecomputeTransitiveDependencies();
+        behaviorLeaf.InclusionState = InclusionState.NotIncluded;
+        _sut.RecomputeTransitiveDependencies();
+
+        behaviorLeaf.InclusionState.ShouldBe(InclusionState.NotIncluded);
+    }
+
+    [Fact]
+    public void RecomputeTransitiveDependencies_ComponentRequiresBehavior_BehaviorIsAutoChecked()
+    {
+        // Component depends on behavior via ElementBehaviorReference.BehaviorName
+        BehaviorSave behavior = new BehaviorSave { Name = "Clickable" };
+        ComponentSave component = new ComponentSave
+        {
+            Name = "Button",
+            Behaviors = new List<ElementBehaviorReference>
+            {
+                new ElementBehaviorReference { BehaviorName = "Clickable" }
+            }
+        };
+
+        GumProjectSave source = new GumProjectSave();
+        source.Behaviors.Add(behavior);
+        source.Components.Add(component);
+
+        _sut.InitializeFromProjectForTesting(source);
+        ImportTreeNodeViewModel componentLeaf = FindLeaf("Button", ElementItemType.Component);
+        ImportTreeNodeViewModel behaviorLeaf = FindLeaf("Clickable", ElementItemType.Behavior);
+
+        componentLeaf.InclusionState = InclusionState.Explicit;
+        _sut.RecomputeTransitiveDependencies();
+
+        behaviorLeaf.InclusionState.ShouldBe(InclusionState.Explicit);
+    }
+
+    [Fact]
+    public void RecomputeTransitiveDependencies_AutoCheckedBehaviorThenComponentUnchecked_BehaviorUnchecks()
+    {
+        // Verifies auto-add does NOT pollute the user-explicit set:
+        // when the selecting component goes away, the behavior should follow.
+        BehaviorSave behavior = new BehaviorSave { Name = "Clickable" };
+        ComponentSave component = new ComponentSave
+        {
+            Name = "Button",
+            Behaviors = new List<ElementBehaviorReference>
+            {
+                new ElementBehaviorReference { BehaviorName = "Clickable" }
+            }
+        };
+
+        GumProjectSave source = new GumProjectSave();
+        source.Behaviors.Add(behavior);
+        source.Components.Add(component);
+
+        _sut.InitializeFromProjectForTesting(source);
+        ImportTreeNodeViewModel componentLeaf = FindLeaf("Button", ElementItemType.Component);
+        ImportTreeNodeViewModel behaviorLeaf = FindLeaf("Clickable", ElementItemType.Behavior);
+
+        componentLeaf.InclusionState = InclusionState.Explicit;
+        _sut.RecomputeTransitiveDependencies();
+        behaviorLeaf.InclusionState.ShouldBe(InclusionState.Explicit); // sanity
+
+        componentLeaf.InclusionState = InclusionState.NotIncluded;
+        _sut.RecomputeTransitiveDependencies();
+
+        behaviorLeaf.InclusionState.ShouldBe(InclusionState.NotIncluded);
+    }
+
+    [Fact]
+    public void RecomputeTransitiveDependencies_UserPickedBehaviorPlusAutoRequired_BothPersist()
+    {
+        // User explicitly picks BehaviorA; component requires BehaviorB.
+        // After the component is unchecked, BehaviorA stays (user-explicit)
+        // and BehaviorB drops (was only auto-added).
+        BehaviorSave behaviorA = new BehaviorSave { Name = "BehaviorA" };
+        BehaviorSave behaviorB = new BehaviorSave { Name = "BehaviorB" };
+        ComponentSave component = new ComponentSave
+        {
+            Name = "Button",
+            Behaviors = new List<ElementBehaviorReference>
+            {
+                new ElementBehaviorReference { BehaviorName = "BehaviorB" }
+            }
+        };
+
+        GumProjectSave source = new GumProjectSave();
+        source.Behaviors.Add(behaviorA);
+        source.Behaviors.Add(behaviorB);
+        source.Components.Add(component);
+
+        _sut.InitializeFromProjectForTesting(source);
+        ImportTreeNodeViewModel componentLeaf = FindLeaf("Button", ElementItemType.Component);
+        ImportTreeNodeViewModel behaviorALeaf = FindLeaf("BehaviorA", ElementItemType.Behavior);
+        ImportTreeNodeViewModel behaviorBLeaf = FindLeaf("BehaviorB", ElementItemType.Behavior);
+
+        behaviorALeaf.InclusionState = InclusionState.Explicit;
+        componentLeaf.InclusionState = InclusionState.Explicit;
+        _sut.RecomputeTransitiveDependencies();
+        behaviorALeaf.InclusionState.ShouldBe(InclusionState.Explicit);
+        behaviorBLeaf.InclusionState.ShouldBe(InclusionState.Explicit);
+
+        componentLeaf.InclusionState = InclusionState.NotIncluded;
+        _sut.RecomputeTransitiveDependencies();
+
+        behaviorALeaf.InclusionState.ShouldBe(InclusionState.Explicit);
+        behaviorBLeaf.InclusionState.ShouldBe(InclusionState.NotIncluded);
+    }
+
+    [Fact]
+    public void RecomputeTransitiveDependencies_PopulateItems_ClearsUserExplicitTracking()
+    {
+        GumProjectSave first = new GumProjectSave();
+        first.Behaviors.Add(new BehaviorSave { Name = "First" });
+
+        _sut.InitializeFromProjectForTesting(first);
+        ImportTreeNodeViewModel firstLeaf = FindLeaf("First", ElementItemType.Behavior);
+        firstLeaf.InclusionState = InclusionState.Explicit;
+
+        // Reload with a different project — user-explicit set should reset
+        GumProjectSave second = new GumProjectSave();
+        second.Behaviors.Add(new BehaviorSave { Name = "Second" });
+        _sut.InitializeFromProjectForTesting(second);
+
+        ImportTreeNodeViewModel secondLeaf = FindLeaf("Second", ElementItemType.Behavior);
+        _sut.RecomputeTransitiveDependencies();
+
+        secondLeaf.InclusionState.ShouldBe(InclusionState.NotIncluded);
+    }
+
+    private ImportTreeNodeViewModel FindLeaf(string fullName, ElementItemType elementType)
+    {
+        foreach (ImportTreeNodeViewModel root in _sut.RootNodes)
+        {
+            ImportTreeNodeViewModel? found = FindLeafRecursive(root, fullName, elementType);
+            if (found != null) { return found; }
+        }
+        throw new InvalidOperationException($"Leaf not found: {fullName} ({elementType})");
+    }
+
+    private static ImportTreeNodeViewModel? FindLeafRecursive(
+        ImportTreeNodeViewModel node, string fullName, ElementItemType elementType)
+    {
+        if (node.IsLeaf && node.ElementType == elementType && node.FullName == fullName)
+        {
+            return node;
+        }
+        foreach (ImportTreeNodeViewModel child in node.Children)
+        {
+            ImportTreeNodeViewModel? hit = FindLeafRecursive(child, fullName, elementType);
+            if (hit != null) { return hit; }
+        }
+        return null;
+    }
+
+    // ── fakes ─────────────────────────────────────────────────────────────
+
+    private class FakeImportLogic : IImportLogic
+    {
+        public ComponentSave? ImportComponent(FilePath filePath, string? desiredDirectory = null, bool saveProject = true)
+            => new ComponentSave();
+        public ScreenSave? ImportScreen(FilePath filePath, string? desiredDirectory = null, bool saveProject = true)
+            => new ScreenSave();
+        public BehaviorSave ImportBehavior(FilePath filePath, string? desiredDirectory = null, bool saveProject = false)
+            => new BehaviorSave();
+    }
+
+    private class FakeProjectState : IProjectState
+    {
+        public FakeProjectState()
+        {
+            GumProjectSave = new GumProjectSave();
+        }
+
+        public GumProjectSave GumProjectSave { get; }
+        public GeneralSettingsFile GeneralSettings => new GeneralSettingsFile();
+        public string? ProjectDirectory => null;
+        public FilePath ComponentFilePath => new FilePath(string.Empty);
+        public FilePath ScreenFilePath => new FilePath(string.Empty);
+        public FilePath BehaviorFilePath => new FilePath(string.Empty);
+        public bool NeedsToSaveProject => false;
+    }
+
+    private class FakeFileCommands : IFileCommands
+    {
+#pragma warning disable CS0067 // event unused — only here to satisfy the interface contract for these tests
+        public event Action? LocalizationLoaded;
+#pragma warning restore CS0067
+        public FilePath? ProjectDirectory => null;
+        public bool TryAutoSaveProject(bool forceSaveContainedElements = false) => false;
+        public void LoadProject(string fileName) { }
+        public void DeleteDirectory(FilePath filePath) { }
+        public void MoveToRecycleBin(FilePath filePath) { }
+        public string[] GetFiles(string path) => Array.Empty<string>();
+        public string[] GetFiles(string path, string searchPattern, SearchOption searchOption) => Array.Empty<string>();
+        public string ReadAllText(string path) => string.Empty;
+        public void MoveDirectory(string source, string destination) { }
+        public void SaveEmbeddedResource(Assembly assembly, string resourceName, string targetFileName) { }
+        public void TryAutoSaveCurrentObject() { }
+        public void TryAutoSaveCurrentElement() { }
+        public void TryAutoSaveElement(ElementSave elementSave) { }
+        public void TryAutoSaveBehavior(BehaviorSave behavior) { }
+        public void TryAutoSaveObject(object objectToSave) { }
+        public void NewProject() { }
+        public void ForceSaveProject(bool forceSaveContainedElements = false) { }
+        public void ForceSaveElement(ElementSave element) { }
+        public FilePath GetFullFileName(ElementSave element) => new FilePath(string.Empty);
+        public void LoadLocalizationFile() { }
+        public FilePath GetFullPathXmlFile(BehaviorSave behaviorSave) => new FilePath(string.Empty);
+        public void SaveGeneralSettings() { }
+        public void SaveIfDiffers(FilePath filePath, string contents) { }
+    }
+}


### PR DESCRIPTION
## Summary
- Fixes #2642: in the **Import from Gumx** dialog, clicking a Behavior or Standard checkbox (or the group's check-all) appeared to do nothing — the next dispatcher tick wiped the click.
- Root cause: `RecomputeTransitiveDependencies` unconditionally rebuilt those two groups from the dependency resolver output, so any user-direct selection was reset before the user even saw it.
- Fix: track explicitly-picked behaviors/standards in two new HashSets (mirror of `_autoAddedComponentNames`, inverted) and OR them into the desired-Explicit set in the recompute. Cleared in `PopulateItems` alongside the existing component clear.

Implicit / dependency-driven auto-check still works: `requiredBehaviorNames` (from `deps.Behaviors`) is OR'd with the user-explicit set, and the recompute attaches/detaches the `PropertyChanged` handler around its own writes so auto-adds don't pollute the user-picked set.

## Test plan
- [x] New `ImportFromGumxViewModelTests` covering:
  - User-picked behavior survives recompute (regression for #2642)
  - User-picked standard survives recompute (regression for #2642)
  - Uncheck-after-check leaves the leaf NotIncluded (set is correctly cleared)
  - Reload via `PopulateItems` resets user-explicit tracking
  - Component dependency still auto-checks its required behavior
  - Auto-checked behavior unchecks when its requiring component is unchecked (auto-add doesn't pollute user-explicit)
  - User-picked + component-required behaviors coexist; only the auto-required one drops when the component is unchecked
- [x] `dotnet build GumFull.sln` clean
- [x] Full `GumToolUnitTests` suite: 522 passed / 5 skipped / 0 failed

## Notes
- Added `[InternalsVisibleTo("GumToolUnitTests")]` and exposed `RecomputeTransitiveDependencies` + a new `InitializeFromProjectForTesting` as `internal` for the tests. The new test seam doesn't touch production call sites.
- Made the dispatcher hop in `OnItemPropertyChanged` null-safe (`Application.Current?.Dispatcher`) so the VM is unit-testable without WPF; production behavior is unchanged because `Application.Current` is always present in the running tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)