### PR TITLE
Forms property promotion v1: ToolTip authoring at design time

### DIFF
--- a/.claude/skills/gum-forms-behaviors/SKILL.md
+++ b/.claude/skills/gum-forms-behaviors/SKILL.md
@@ -51,20 +51,30 @@ The `DefaultFromFileXxxRuntime` classes exist solely to bridge the file-loading 
 | `StackPanelBehaviorName` | `DefaultFromFileStackPanelRuntime` |
 | `WindowBehaviorName` | `DefaultFromFileWindowRuntime` |
 
-## The Property Promotion Gap
+## The Property Promotion Gap (partially closed)
 
-The Gum tool operates at the visual layer — layout, colors, fonts, dimensions saved as `VariableSave` entries. The Forms behavioral layer (state, data, interaction) is added entirely at runtime. No bridge exists between them.
+The Gum tool operates at the visual layer — layout, colors, fonts, dimensions saved as `VariableSave` entries. The Forms behavioral layer (state, data, interaction) is added entirely at runtime. The save model historically had no bridge to Forms semantics.
 
-**Concrete examples of Forms properties with no Gum variable equivalent:**
-- `Button.Text` / `Label.Text` — visual has a `TextInstance` child, but no top-level "Text" variable on the component
-- `CheckBox.IsChecked` / `ToggleButton.IsChecked` — runtime-only boolean, not representable in the save file
-- `TextBox.Text` — initial text cannot be authored in the tool
-- `Slider.Minimum`, `Slider.Maximum`, `Slider.Value` — numeric range exists only on the Forms control
-- `ListBox.SelectionMode`, `ListBox.DisplayMemberPath`, `ItemsControl.Items` — entirely runtime constructs
+### Behavior FormsProperties — the v1 bridge
 
-**Why this gap exists:** The visual save model (`VariableSave`) has no notion of Forms semantics. The Gum tool has no awareness of which Forms properties correspond to which visual structure. The wrapping is a pure runtime event.
+`BehaviorSave.FormsProperties` (a `List<VariableSave>`) lets a behavior declare design-time properties that flow through to its wrapped `FrameworkElement` at runtime via reflection. Each entry's `Name` must match a property on the corresponding control (e.g. `ToolTip` on `FrameworkElement`); `Value` is the design-time default.
 
-**Impact:** Game code must set all behavioral defaults in code after loading, even properties that logically belong to component design.
+The variable grid in the tool synthesizes a "Behavior" category for these declarations on both the component definition and any instance. When a component sets a default on a promoted property, the standard properties pass picks it up under General first; `ElementSaveDisplayer.AddBehaviorFormsPropertyMembers` relocates it into "Behavior" so categorization stays consistent.
+
+At runtime, `BehaviorFormsPropertyApplier.Apply` is invoked from `FormsUtilities`'s `InitialStateAppliedNotifier` (after the parent's `SetInitialState` completes). It walks the GUE's `ElementSave.Behaviors` (and inherited base-type behaviors), reads each `FormsProperty`'s effective value — preferring parent-state instance overrides like screen `"ButtonInstance.ToolTip"` over the element's own default — and reflects onto the wrapped `FrameworkElement`. The hook lives at the notifier (not the `Visual` setter) because instance-qualified overrides on the parent state aren't visible until after the parent's state has been applied.
+
+### What's covered today
+
+`ToolTip` on every standard Forms behavior. The reflection apply is generic, so any new logical-only `FormsProperty` declaration (e.g. `MaxCharacters`, `Slider.Minimum/Maximum/Value`) would flow through automatically without runtime changes.
+
+### What's still pending (state-mapped properties)
+
+`IsEnabled`, `IsChecked`, and similar properties that have a *visual* state consequence (the Disabled visual category) need a second mechanism: behavior-level tool-only variable references that drive `<Category>State` from the FormsProperty value. That depends on engine work in `#2638` (ternary expressions and category-state LHS in `EvaluatedSyntax` / `VariableReferenceLogic`) and is tracked under v2 of `#2637`.
+
+Examples still requiring code-side initialization:
+- `CheckBox.IsChecked` / `ToggleButton.IsChecked` — needs visual state binding
+- `Button.IsEnabled` / `TextBox.IsEnabled` — needs visual state binding
+- `Button.Text` / `Label.Text` — visual-only pass-through, authored on the child `TextInstance` directly
 
 ## Key Files
 
@@ -74,6 +84,8 @@ The Gum tool operates at the visual layer — layout, colors, fonts, dimensions 
 | `GumDataTypes/Behaviors/ElementBehaviorReference.cs` | Per-element reference holding only `BehaviorName` |
 | `GumDataTypes/Behaviors/StandardFormsBehaviorNames.cs` | String constants for all standard behavior names |
 | `GumDataTypes/ElementSave.cs` | `Behaviors` list on components/screens |
-| `MonoGameGum/Forms/FormsUtilities.cs` | `RegisterFromFileFormRuntimeDefaults()` — drives the mapping |
+| `MonoGameGum/Forms/FormsUtilities.cs` | `RegisterFromFileFormRuntimeDefaults()` — drives the mapping; sets `InitialStateAppliedNotifier` to invoke `BehaviorFormsPropertyApplier` |
 | `MonoGameGum/Forms/DefaultFromFileVisuals/` | `DefaultFromFileXxxRuntime` classes — `AfterFullCreation()` creates Forms objects |
+| `MonoGameGum/Forms/BehaviorFormsPropertyApplier.cs` | Reflects `BehaviorSave.FormsProperties` values onto the wrapped `FrameworkElement` |
+| `Gum/Plugins/InternalPlugins/VariableGrid/ElementSaveDisplayer.cs` | `AddBehaviorFormsPropertyMembers` — surfaces FormsProperties in the variable grid |
 | `GumRuntime/InteractiveGue.cs` | `FormsControlAsObject` back-link property |

--- a/Gum/Plugins/InternalPlugins/VariableGrid/ElementSaveDisplayer.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/ElementSaveDisplayer.cs
@@ -467,6 +467,10 @@ public class ElementSaveDisplayer
 
         }
 
+        AddBehaviorFormsPropertyMembers(
+            instanceElementSave ?? instanceOwner,
+            instanceOwner, instance, stateSave, stateSaveCategory, categories);
+
         // do variable lists last:
         for (int i = 0; i < defaultState.VariableLists.Count; i++)
         {
@@ -563,6 +567,88 @@ public class ElementSaveDisplayer
     }
 
 
+
+    private void AddBehaviorFormsPropertyMembers(
+        ElementSave? elementWithBehaviors,
+        ElementSave instanceOwner,
+        InstanceSave? instance,
+        StateSave stateSave,
+        StateSaveCategory? stateSaveCategory,
+        List<MemberCategory> categories)
+    {
+        if (elementWithBehaviors?.Behaviors == null || elementWithBehaviors.Behaviors.Count == 0)
+        {
+            return;
+        }
+
+        var allBehaviors = ObjectFinder.Self.GumProjectSave?.Behaviors;
+        if (allBehaviors == null)
+        {
+            return;
+        }
+
+        const string categoryName = "Behavior";
+        MemberCategory? behaviorCategory = null;
+
+        foreach (var behaviorRef in elementWithBehaviors.Behaviors)
+        {
+            var behavior = allBehaviors.FirstOrDefault(b => b.Name == behaviorRef.BehaviorName);
+            if (behavior == null)
+            {
+                continue;
+            }
+
+            foreach (var formsProperty in behavior.FormsProperties)
+            {
+                string variableName = instance != null
+                    ? instance.Name + "." + formsProperty.Name
+                    : formsProperty.Name;
+
+                bool alreadyAdded = categories.Any(c => c.Members.Any(m => m.Name == variableName));
+                if (alreadyAdded)
+                {
+                    continue;
+                }
+
+                Type? type = _typeManager.GetTypeFromString(formsProperty.Type);
+
+                var srim = new StateReferencingInstanceMember(
+                    attributes: null,
+                    converter: null,
+                    componentType: type,
+                    isReadOnly: false,
+                    isAssignedByReference: false,
+                    isVariable: true,
+                    stateSave,
+                    stateSaveCategory,
+                    variableName,
+                    instance,
+                    instanceOwner,
+                    _undoManager,
+                    _editVariableService,
+                    _exposeVariableService,
+                    _hotkeyManager,
+                    _deleteVariableService,
+                    _selectedState,
+                    _guiCommands,
+                    _fileCommands,
+                    _setVariableLogic,
+                    _wireframeObjectManager);
+
+                if (behaviorCategory == null)
+                {
+                    behaviorCategory = categories.FirstOrDefault(c => c.Name == categoryName);
+                    if (behaviorCategory == null)
+                    {
+                        behaviorCategory = new MemberCategory(categoryName);
+                        categories.Add(behaviorCategory);
+                    }
+                }
+
+                behaviorCategory.Members.Add(srim);
+            }
+        }
+    }
 
     private StateReferencingInstanceMember CreateSrimFromPropertyData(ElementSave instanceOwner, InstanceSave instance,
         StateSave stateSave, StateSaveCategory stateSaveCategory, PropertyData propertyData)

--- a/Gum/Plugins/InternalPlugins/VariableGrid/ElementSaveDisplayer.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/ElementSaveDisplayer.cs
@@ -604,9 +604,42 @@ public class ElementSaveDisplayer
                     ? instance.Name + "." + formsProperty.Name
                     : formsProperty.Name;
 
-                bool alreadyAdded = categories.Any(c => c.Members.Any(m => m.Name == variableName));
-                if (alreadyAdded)
+                // If a member with this name already exists in another category — typically
+                // because the standard properties pass picked up a value the user authored
+                // on the component's default state — relocate it. The behavior owns the
+                // categorization for FormsProperties; preserving the existing member also
+                // keeps any DetailText, displayer hints, and converter wiring it accumulated.
+                InstanceMember? existing = null;
+                MemberCategory? sourceCategory = null;
+                foreach (var candidate in categories)
                 {
+                    var match = candidate.Members.FirstOrDefault(m => m.Name == variableName);
+                    if (match != null)
+                    {
+                        existing = match;
+                        sourceCategory = candidate;
+                        break;
+                    }
+                }
+
+                if (behaviorCategory == null)
+                {
+                    behaviorCategory = categories.FirstOrDefault(c => c.Name == categoryName);
+                    if (behaviorCategory == null)
+                    {
+                        behaviorCategory = new MemberCategory(categoryName);
+                        categories.Add(behaviorCategory);
+                    }
+                }
+
+                if (existing != null)
+                {
+                    if (sourceCategory == behaviorCategory)
+                    {
+                        continue;
+                    }
+                    sourceCategory!.Members.Remove(existing);
+                    behaviorCategory.Members.Add(existing);
                     continue;
                 }
 
@@ -634,16 +667,6 @@ public class ElementSaveDisplayer
                     _fileCommands,
                     _setVariableLogic,
                     _wireframeObjectManager);
-
-                if (behaviorCategory == null)
-                {
-                    behaviorCategory = categories.FirstOrDefault(c => c.Name == categoryName);
-                    if (behaviorCategory == null)
-                    {
-                        behaviorCategory = new MemberCategory(categoryName);
-                        categories.Add(behaviorCategory);
-                    }
-                }
 
                 behaviorCategory.Members.Add(srim);
             }

--- a/Gum/Plugins/InternalPlugins/VariableGrid/ElementSaveDisplayer.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/ElementSaveDisplayer.cs
@@ -600,6 +600,16 @@ public class ElementSaveDisplayer
 
             foreach (var formsProperty in behavior.FormsProperties)
             {
+                if (string.IsNullOrEmpty(formsProperty.Name))
+                {
+                    // Can occur when a project is at the legacy (v1) gumx format and the
+                    // .behx uses the v2 compact attribute form for FormsProperty entries —
+                    // VariableSave properties stay null because the legacy serializer
+                    // expects element-form children, not attributes. Skip rather than
+                    // crash; the project needs to be saved at v2 for FormsProperty to work.
+                    continue;
+                }
+
                 string variableName = instance != null
                     ? instance.Name + "." + formsProperty.Name
                     : formsProperty.Name;

--- a/Gum/Plugins/InternalPlugins/VariableGrid/ElementSaveDisplayer.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/ElementSaveDisplayer.cs
@@ -568,7 +568,7 @@ public class ElementSaveDisplayer
 
 
 
-    private void AddBehaviorFormsPropertyMembers(
+    internal void AddBehaviorFormsPropertyMembers(
         ElementSave? elementWithBehaviors,
         ElementSave instanceOwner,
         InstanceSave? instance,

--- a/GumDataTypes/Behaviors/BehaviorReference.cs
+++ b/GumDataTypes/Behaviors/BehaviorReference.cs
@@ -39,18 +39,8 @@ namespace Gum.DataTypes.Behaviors
         {
             if (projectVersion >= (int)GumProjectSave.GumxVersions.AttributeVersion)
             {
-                var (content, isCompact) = GumFileSerializer.ReadAndDetectFormat(filePath);
-                if (isCompact)
-                {
-                    var compactSerializer = GumFileSerializer.GetCompactSerializer(typeof(BehaviorSave));
-                    using var reader = new StringReader(content);
-                    return (BehaviorSave)compactSerializer.Deserialize(reader);
-                }
-                else
-                {
-                    return FileManager.XmlDeserializeFromStream<BehaviorSave>(
-                        new System.IO.MemoryStream(System.Text.Encoding.UTF8.GetBytes(content)));
-                }
+                string content = FileManager.FromFileText(filePath);
+                return GumFileSerializer.DeserializeBehaviorSave(content, projectVersion);
             }
             return FileManager.XmlDeserialize<BehaviorSave>(filePath);
         }

--- a/GumDataTypes/Behaviors/BehaviorSave.cs
+++ b/GumDataTypes/Behaviors/BehaviorSave.cs
@@ -22,6 +22,16 @@ namespace Gum.DataTypes.Behaviors
 
         public StateSave RequiredVariables { get; set; } = new StateSave();
 
+        /// <summary>
+        /// Forms properties this behavior promotes to its implementing components. Each entry's
+        /// <see cref="VariableSave.Name"/> must match a property on the corresponding
+        /// <c>FrameworkElement</c> subclass (e.g. <c>ToolTip</c>, <c>IsEnabled</c>); the value
+        /// is the design-time default. Surfaced in the Gum tool's variable grid and reflected
+        /// onto the wrapped Forms control at runtime.
+        /// </summary>
+        [XmlElement("FormsProperty")]
+        public List<VariableSave> FormsProperties { get; set; } = new List<VariableSave>();
+
         IList<StateSaveCategory> IStateContainer.Categories => Categories;
         [XmlElement("Category")]
         public List<StateSaveCategory> Categories { get; set; } = new List<StateSaveCategory>();

--- a/GumDataTypes/Serialization/GumFileSerializer.cs
+++ b/GumDataTypes/Serialization/GumFileSerializer.cs
@@ -130,7 +130,8 @@ public static class GumFileSerializer
     private static bool IsElementContentCompact(string content) =>
         content.Contains("<Variable ")
         || content.Contains("<Instance ")
-        || content.Contains("<InstanceSave ");
+        || content.Contains("<InstanceSave ")
+        || content.Contains("<FormsProperty ");
 
     /// <summary>
     /// Reads a file and detects whether it is in compact (v2) format or legacy (v1) format.

--- a/GumDataTypes/Serialization/GumFileSerializer.cs
+++ b/GumDataTypes/Serialization/GumFileSerializer.cs
@@ -180,9 +180,12 @@ public static class GumFileSerializer
         {
             if (IsElementContentCompact(content))
             {
-                var compactSerializer = GetCompactSerializer(typeof(BehaviorSave));
+                bool hasLegacyInstances = content.Contains("<InstanceSave>");
+                var serializer = hasLegacyInstances
+                    ? GetLegacyInstancesCompactSerializer(typeof(BehaviorSave))
+                    : GetCompactSerializer(typeof(BehaviorSave));
                 using var reader = new StringReader(content);
-                return (BehaviorSave)compactSerializer.Deserialize(reader);
+                return (BehaviorSave)serializer.Deserialize(reader);
             }
         }
 

--- a/MonoGameGum.Tests/DataTypes/GumFileSerializerTests.cs
+++ b/MonoGameGum.Tests/DataTypes/GumFileSerializerTests.cs
@@ -47,6 +47,51 @@ public class GumFileSerializerTests
     }
 
     [Fact]
+    public void DeserializeBehaviorSave_LegacyFormat_LoadsFormsProperties()
+    {
+        BehaviorSave original = new BehaviorSave();
+        original.FormsProperties.Add(new VariableSave { Type = "string", Name = "ToolTip", Value = "Click me" });
+
+        FileManager.XmlSerialize(original, out string xml);
+
+        BehaviorSave? result = GumFileSerializer.DeserializeBehaviorSave(xml, projectVersion: 2);
+
+        result.ShouldNotBeNull();
+        result.FormsProperties.Count.ShouldBe(1);
+        result.FormsProperties[0].Type.ShouldBe("string");
+        result.FormsProperties[0].Name.ShouldBe("ToolTip");
+        result.FormsProperties[0].Value.ShouldBe("Click me");
+    }
+
+    [Fact]
+    public void SerializeBehaviorSave_EmptyFormsProperties_OmittedFromXml()
+    {
+        BehaviorSave original = new BehaviorSave();
+
+        FileManager.XmlSerialize(original, out string xml);
+
+        xml.ShouldNotContain("<FormsProperty");
+    }
+
+    [Fact]
+    public void DeserializeBehaviorSave_CompactFormat_LoadsFormsProperties()
+    {
+        BehaviorSave original = new BehaviorSave();
+        original.FormsProperties.Add(new VariableSave { Type = "string", Name = "ToolTip", Value = "Click me" });
+
+        XmlSerializer compactSerializer = GumFileSerializer.GetCompactSerializer(typeof(BehaviorSave));
+        string xml = SerializeToString(compactSerializer, original);
+
+        BehaviorSave? result = GumFileSerializer.DeserializeBehaviorSave(xml, projectVersion: 2);
+
+        result.ShouldNotBeNull();
+        result.FormsProperties.Count.ShouldBe(1);
+        result.FormsProperties[0].Type.ShouldBe("string");
+        result.FormsProperties[0].Name.ShouldBe("ToolTip");
+        result.FormsProperties[0].Value.ShouldBe("Click me");
+    }
+
+    [Fact]
     public void DeserializeElementSave_CompactFormat_LoadsVariables()
     {
         ScreenSave original = new ScreenSave();

--- a/MonoGameGum.Tests/Forms/BehaviorFormsPropertyApplyTests.cs
+++ b/MonoGameGum.Tests/Forms/BehaviorFormsPropertyApplyTests.cs
@@ -1,6 +1,7 @@
 using Gum.DataTypes;
 using Gum.DataTypes.Behaviors;
 using Gum.DataTypes.Variables;
+using Gum.Forms;
 using Gum.Forms.Controls;
 using Gum.Managers;
 using Gum.Wireframe;
@@ -23,7 +24,7 @@ public class BehaviorFormsPropertyApplyTests : BaseTestClass
     }
 
     [Fact]
-    public void AttachingFormsControl_ToVisualWithBehaviorFormsPropertyDefault_AppliesValueToFormsControl()
+    public void Apply_VisualWithBehaviorFormsPropertyDefault_AppliesValueToFormsControl()
     {
         BehaviorSave behavior = new BehaviorSave { Name = "ButtonBehavior" };
         behavior.FormsProperties.Add(new VariableSave { Type = "string", Name = "ToolTip" });
@@ -49,7 +50,61 @@ public class BehaviorFormsPropertyApplyTests : BaseTestClass
         visual.ElementSave = component;
 
         Button button = new Button(visual);
+        BehaviorFormsPropertyApplier.Apply(button, visual);
 
         button.ToolTip.ShouldBe("Click me");
+    }
+
+    [Fact]
+    public void Apply_ParentScreenInstanceOverride_OverridesComponentDefault()
+    {
+        BehaviorSave behavior = new BehaviorSave { Name = "ButtonBehavior" };
+        behavior.FormsProperties.Add(new VariableSave { Type = "string", Name = "ToolTip" });
+
+        // Component default ToolTip = "Default"
+        ComponentSave component = new ComponentSave { Name = "Controls/ButtonStandard", BaseType = "Container" };
+        StateSave componentDefault = new StateSave { Name = "Default", ParentContainer = component };
+        componentDefault.Variables.Add(new VariableSave
+        {
+            Type = "string",
+            Name = "ToolTip",
+            Value = "Default",
+            SetsValue = true
+        });
+        component.States.Add(componentDefault);
+        component.Behaviors.Add(new ElementBehaviorReference { BehaviorName = "ButtonBehavior" });
+
+        // Screen with instance override "ButtonInstance.ToolTip" = "Overridden"
+        ScreenSave screen = new ScreenSave { Name = "TestScreen" };
+        StateSave screenDefault = new StateSave { Name = "Default", ParentContainer = screen };
+        screenDefault.Variables.Add(new VariableSave
+        {
+            Type = "string",
+            Name = "ButtonInstance.ToolTip",
+            Value = "Overridden",
+            SetsValue = true
+        });
+        screen.States.Add(screenDefault);
+
+        GumProjectSave project = new GumProjectSave();
+        project.Components.Add(component);
+        project.Screens.Add(screen);
+        project.Behaviors.Add(behavior);
+        ObjectFinder.Self.GumProjectSave = project;
+
+        // Live visual tree: screen GUE (ElementSave = screen), button GUE child whose
+        // ElementSave = component, Name = "ButtonInstance", and ElementGueContainingThis
+        // points to the screen GUE — same shape produced by ToGraphicalUiElement.
+        InteractiveGue screenVisual = new InteractiveGue();
+        screenVisual.ElementSave = screen;
+
+        InteractiveGue buttonVisual = new InteractiveGue { Name = "ButtonInstance" };
+        buttonVisual.ElementSave = component;
+        buttonVisual.ElementGueContainingThis = screenVisual;
+
+        Button button = new Button(buttonVisual);
+        BehaviorFormsPropertyApplier.Apply(button, buttonVisual);
+
+        button.ToolTip.ShouldBe("Overridden");
     }
 }

--- a/MonoGameGum.Tests/Forms/BehaviorFormsPropertyApplyTests.cs
+++ b/MonoGameGum.Tests/Forms/BehaviorFormsPropertyApplyTests.cs
@@ -1,0 +1,55 @@
+using Gum.DataTypes;
+using Gum.DataTypes.Behaviors;
+using Gum.DataTypes.Variables;
+using Gum.Forms.Controls;
+using Gum.Managers;
+using Gum.Wireframe;
+using Shouldly;
+using Xunit;
+
+namespace MonoGameGum.Tests.Forms;
+
+public class BehaviorFormsPropertyApplyTests : BaseTestClass
+{
+    public BehaviorFormsPropertyApplyTests()
+    {
+        ObjectFinder.Self.GumProjectSave = null;
+    }
+
+    public override void Dispose()
+    {
+        ObjectFinder.Self.GumProjectSave = null;
+        base.Dispose();
+    }
+
+    [Fact]
+    public void AttachingFormsControl_ToVisualWithBehaviorFormsPropertyDefault_AppliesValueToFormsControl()
+    {
+        BehaviorSave behavior = new BehaviorSave { Name = "ButtonBehavior" };
+        behavior.FormsProperties.Add(new VariableSave { Type = "string", Name = "ToolTip" });
+
+        ComponentSave component = new ComponentSave { Name = "Controls/ButtonStandard", BaseType = "Container" };
+        StateSave defaultState = new StateSave { Name = "Default", ParentContainer = component };
+        defaultState.Variables.Add(new VariableSave
+        {
+            Type = "string",
+            Name = "ToolTip",
+            Value = "Click me",
+            SetsValue = true
+        });
+        component.States.Add(defaultState);
+        component.Behaviors.Add(new ElementBehaviorReference { BehaviorName = "ButtonBehavior" });
+
+        GumProjectSave project = new GumProjectSave();
+        project.Components.Add(component);
+        project.Behaviors.Add(behavior);
+        ObjectFinder.Self.GumProjectSave = project;
+
+        InteractiveGue visual = new InteractiveGue();
+        visual.ElementSave = component;
+
+        Button button = new Button(visual);
+
+        button.ToolTip.ShouldBe("Click me");
+    }
+}

--- a/MonoGameGum/Forms/BehaviorFormsPropertyApplier.cs
+++ b/MonoGameGum/Forms/BehaviorFormsPropertyApplier.cs
@@ -41,7 +41,7 @@ internal static class BehaviorFormsPropertyApplier
                 continue;
             }
 
-            object? value = new RecursiveVariableFinder(elementSave.DefaultState).GetValue(declaration.Name);
+            object? value = ReadEffectiveValue(visual!, declaration.Name);
             if (value == null)
             {
                 continue;
@@ -66,6 +66,27 @@ internal static class BehaviorFormsPropertyApplier
                 // FrameworkElement's property. Silently skip rather than crash construction.
             }
         }
+    }
+
+    private static object? ReadEffectiveValue(GraphicalUiElement visual, string propertyName)
+    {
+        // Prefer a parent-level instance-qualified override (e.g. screen state's
+        // "ButtonInstance.ToolTip") over the element's own default. This matches how Gum
+        // resolves instance variables at design time.
+        GraphicalUiElement? container = visual.ElementGueContainingThis as GraphicalUiElement
+            ?? visual.Parent as GraphicalUiElement;
+
+        if (container?.ElementSave != null && !string.IsNullOrEmpty(visual.Name))
+        {
+            string qualified = visual.Name + "." + propertyName;
+            object? overrideValue = new RecursiveVariableFinder(container.ElementSave.DefaultState).GetValue(qualified);
+            if (overrideValue != null)
+            {
+                return overrideValue;
+            }
+        }
+
+        return new RecursiveVariableFinder(visual.ElementSave.DefaultState).GetValue(propertyName);
     }
 
     private static IEnumerable<VariableSave> EnumerateFormsPropertyDeclarations(

--- a/MonoGameGum/Forms/BehaviorFormsPropertyApplier.cs
+++ b/MonoGameGum/Forms/BehaviorFormsPropertyApplier.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Gum.DataTypes;
+using Gum.DataTypes.Variables;
+using Gum.Forms.Controls;
+using Gum.Managers;
+using Gum.Wireframe;
+
+namespace Gum.Forms;
+
+/// <summary>
+/// Applies design-time values for <see cref="DataTypes.Behaviors.BehaviorSave.FormsProperties"/>
+/// declarations onto a <see cref="FrameworkElement"/> when its Visual is attached. This is the
+/// runtime half of the Forms property promotion feature: design values authored in the Gum tool
+/// flow through the wrapped Forms control's properties via reflection.
+/// </summary>
+internal static class BehaviorFormsPropertyApplier
+{
+    public static void Apply(FrameworkElement formsControl, GraphicalUiElement visual)
+    {
+        ElementSave? elementSave = visual?.ElementSave;
+        if (elementSave == null)
+        {
+            return;
+        }
+
+        GumProjectSave? project = ObjectFinder.Self.GumProjectSave;
+        if (project == null)
+        {
+            return;
+        }
+
+        Type formsType = formsControl.GetType();
+
+        foreach (VariableSave declaration in EnumerateFormsPropertyDeclarations(elementSave, project))
+        {
+            if (string.IsNullOrEmpty(declaration.Name))
+            {
+                continue;
+            }
+
+            object? value = new RecursiveVariableFinder(elementSave.DefaultState).GetValue(declaration.Name);
+            if (value == null)
+            {
+                continue;
+            }
+
+            PropertyInfo? prop = formsType.GetProperty(declaration.Name);
+            if (prop == null || !prop.CanWrite)
+            {
+                continue;
+            }
+
+            try
+            {
+                object coerced = prop.PropertyType.IsAssignableFrom(value.GetType())
+                    ? value
+                    : Convert.ChangeType(value, Nullable.GetUnderlyingType(prop.PropertyType) ?? prop.PropertyType);
+                prop.SetValue(formsControl, coerced);
+            }
+            catch (Exception)
+            {
+                // Coercion or set failed; the FormsProperty type doesn't line up with the
+                // FrameworkElement's property. Silently skip rather than crash construction.
+            }
+        }
+    }
+
+    private static IEnumerable<VariableSave> EnumerateFormsPropertyDeclarations(
+        ElementSave element, GumProjectSave project)
+    {
+        HashSet<string> seen = new HashSet<string>(StringComparer.Ordinal);
+        ElementSave? current = element;
+        while (current != null)
+        {
+            foreach (var behaviorRef in current.Behaviors)
+            {
+                var behavior = project.Behaviors.FirstOrDefault(b => b.Name == behaviorRef.BehaviorName);
+                if (behavior == null)
+                {
+                    continue;
+                }
+
+                foreach (var formsProperty in behavior.FormsProperties)
+                {
+                    if (formsProperty.Name != null && seen.Add(formsProperty.Name))
+                    {
+                        yield return formsProperty;
+                    }
+                }
+            }
+
+            if (string.IsNullOrEmpty(current.BaseType))
+            {
+                yield break;
+            }
+            current = ObjectFinder.Self.GetElementSave(current.BaseType);
+        }
+    }
+}

--- a/MonoGameGum/Forms/Controls/FrameworkElement.cs
+++ b/MonoGameGum/Forms/Controls/FrameworkElement.cs
@@ -560,11 +560,6 @@ public class FrameworkElement : INotifyPropertyChanged
                 }
 
                 ReactToVisualChanged();
-
-                if (visual != null)
-                {
-                    BehaviorFormsPropertyApplier.Apply(this, visual);
-                }
             }
 
         }

--- a/MonoGameGum/Forms/Controls/FrameworkElement.cs
+++ b/MonoGameGum/Forms/Controls/FrameworkElement.cs
@@ -560,6 +560,11 @@ public class FrameworkElement : INotifyPropertyChanged
                 }
 
                 ReactToVisualChanged();
+
+                if (visual != null)
+                {
+                    BehaviorFormsPropertyApplier.Apply(this, visual);
+                }
             }
 
         }

--- a/MonoGameGum/Forms/FormsUtilities.cs
+++ b/MonoGameGum/Forms/FormsUtilities.cs
@@ -560,6 +560,7 @@ public class FormsUtilities
         {
             if (gue is InteractiveGue igue && igue.FormsControlAsObject is FrameworkElement fe)
             {
+                BehaviorFormsPropertyApplier.Apply(fe, igue);
                 fe.UpdateState();
             }
         };

--- a/Runtimes/RaylibGum/RaylibGum.csproj
+++ b/Runtimes/RaylibGum/RaylibGum.csproj
@@ -109,6 +109,7 @@
 		<Compile Include="..\..\MonoGameGum\Forms\DefaultVisuals\V3\TooltipVisual.cs" Link="Forms\DefaultVisuals\V3\TooltipVisual.cs" />
 		<Compile Include="..\..\MonoGameGum\Forms\DefaultVisuals\V3\WindowVisual.cs" Link="Forms\DefaultVisuals\V3\WindowVisual.cs" />
 		<Compile Include="..\..\MonoGameGum\Forms\DefaultVisuals\WindowVisual.cs" Link="Forms\DefaultVisuals\WindowVisual.cs" />
+		<Compile Include="..\..\MonoGameGum\Forms\BehaviorFormsPropertyApplier.cs" Link="Forms\BehaviorFormsPropertyApplier.cs" />
 		<Compile Include="..\..\MonoGameGum\Forms\FormsUtilities.cs" Link="Forms\FormsUtilities.cs" />
 		<Compile Include="..\..\MonoGameGum\Forms\FrameworkElementTemplate.cs" Link="Forms\FrameworkElementTemplate.cs" />
 		<Compile Include="..\..\MonoGameGum\Forms\GraphicalUiElementFormsExtensions.cs" Link="Forms\Controls\GraphicalUiElementFormsExtensions.cs" />

--- a/Runtimes/SokolGum/SokolGum.csproj
+++ b/Runtimes/SokolGum/SokolGum.csproj
@@ -135,6 +135,7 @@
 		<Compile Include="..\..\MonoGameGum\Forms\DefaultVisuals\V3\TooltipVisual.cs" Link="Forms\DefaultVisuals\V3\TooltipVisual.cs" />
 		<Compile Include="..\..\MonoGameGum\Forms\DefaultVisuals\V3\WindowVisual.cs" Link="Forms\DefaultVisuals\V3\WindowVisual.cs" />
 		<Compile Include="..\..\MonoGameGum\Forms\DefaultVisuals\WindowVisual.cs" Link="Forms\DefaultVisuals\WindowVisual.cs" />
+		<Compile Include="..\..\MonoGameGum\Forms\BehaviorFormsPropertyApplier.cs" Link="Forms\BehaviorFormsPropertyApplier.cs" />
 		<Compile Include="..\..\MonoGameGum\Forms\FormsUtilities.cs" Link="Forms\FormsUtilities.cs" />
 		<Compile Include="..\..\MonoGameGum\Forms\FrameworkElementTemplate.cs" Link="Forms\FrameworkElementTemplate.cs" />
 		<Compile Include="..\..\MonoGameGum\Forms\GraphicalUiElementFormsExtensions.cs" Link="Forms\Controls\GraphicalUiElementFormsExtensions.cs" />

--- a/Tool/Tests/GumToolUnitTests/PropertyGridHelpers/ElementSaveDisplayerFormsPropertiesTests.cs
+++ b/Tool/Tests/GumToolUnitTests/PropertyGridHelpers/ElementSaveDisplayerFormsPropertiesTests.cs
@@ -1,0 +1,107 @@
+using Gum.DataTypes;
+using Gum.DataTypes.Behaviors;
+using Gum.DataTypes.Variables;
+using Gum.Managers;
+using Gum.PropertyGridHelpers;
+using Gum.ToolStates;
+using Moq;
+using Moq.AutoMock;
+using Shouldly;
+using WpfDataUi.DataTypes;
+
+namespace GumToolUnitTests.PropertyGridHelpers;
+
+public class ElementSaveDisplayerFormsPropertiesTests : BaseTestClass
+{
+    private readonly AutoMocker _mocker = new();
+    private readonly ElementSaveDisplayer _displayer;
+    private readonly GumProjectSave _project;
+    private readonly BehaviorSave _buttonBehavior;
+    private readonly ComponentSave _buttonComponent;
+    private readonly ScreenSave _screen;
+    private readonly InstanceSave _buttonInstance;
+    private readonly StateSave _screenDefaultState;
+
+    public ElementSaveDisplayerFormsPropertiesTests()
+    {
+        StandardElementsManager.Self.Initialize();
+        Gum.Reflection.TypeManager.Self.Initialize();
+
+        _buttonBehavior = new BehaviorSave { Name = "ButtonBehavior" };
+        _buttonBehavior.FormsProperties.Add(new VariableSave
+        {
+            Type = "string",
+            Name = "ToolTip"
+        });
+
+        _buttonComponent = new ComponentSave { Name = "Controls/ButtonStandard", BaseType = "Container" };
+        _buttonComponent.States.Add(new StateSave { Name = "Default", ParentContainer = _buttonComponent });
+        _buttonComponent.Behaviors.Add(new ElementBehaviorReference { BehaviorName = "ButtonBehavior" });
+
+        _screen = new ScreenSave { Name = "TestScreen" };
+        _screenDefaultState = new StateSave { Name = "Default", ParentContainer = _screen };
+        _screen.States.Add(_screenDefaultState);
+
+        _buttonInstance = new InstanceSave
+        {
+            Name = "ButtonInstance",
+            BaseType = "Controls/ButtonStandard",
+            ParentContainer = _screen
+        };
+        _screen.Instances.Add(_buttonInstance);
+
+        _project = new GumProjectSave();
+        _project.Components.Add(_buttonComponent);
+        _project.Screens.Add(_screen);
+        _project.Behaviors.Add(_buttonBehavior);
+        ObjectFinder.Self.GumProjectSave = _project;
+
+        _mocker.GetMock<ISelectedState>()
+            .Setup(x => x.SelectedStateSave)
+            .Returns(_screenDefaultState);
+        _mocker.GetMock<ISelectedState>()
+            .Setup(x => x.SelectedElement)
+            .Returns(_screen);
+
+        _mocker.Use(Gum.Reflection.TypeManager.Self);
+
+        _displayer = _mocker.CreateInstance<ElementSaveDisplayer>();
+    }
+
+    [Fact]
+    public void AddBehaviorFormsPropertyMembers_InstanceContext_AddsQualifiedToolTipMember()
+    {
+        List<MemberCategory> categories = new List<MemberCategory>();
+
+        _displayer.AddBehaviorFormsPropertyMembers(
+            elementWithBehaviors: _buttonComponent,
+            instanceOwner: _screen,
+            instance: _buttonInstance,
+            stateSave: _screenDefaultState,
+            stateSaveCategory: null,
+            categories: categories);
+
+        var behaviorCategory = categories.FirstOrDefault(c => c.Name == "Behavior");
+        behaviorCategory.ShouldNotBeNull("a Behavior category should be added when the instance's BaseType has a behavior with FormsProperties");
+        behaviorCategory.Members.Any(m => m.Name == "ButtonInstance.ToolTip")
+            .ShouldBeTrue("ToolTip should appear qualified with the instance name");
+    }
+
+    [Fact]
+    public void AddBehaviorFormsPropertyMembers_ComponentContext_AddsUnqualifiedToolTipMember()
+    {
+        List<MemberCategory> categories = new List<MemberCategory>();
+
+        _displayer.AddBehaviorFormsPropertyMembers(
+            elementWithBehaviors: _buttonComponent,
+            instanceOwner: _buttonComponent,
+            instance: null,
+            stateSave: _buttonComponent.DefaultState,
+            stateSaveCategory: null,
+            categories: categories);
+
+        var behaviorCategory = categories.FirstOrDefault(c => c.Name == "Behavior");
+        behaviorCategory.ShouldNotBeNull();
+        behaviorCategory.Members.Any(m => m.Name == "ToolTip").ShouldBeTrue();
+    }
+}

--- a/Tool/Tests/GumToolUnitTests/PropertyGridHelpers/ElementSaveDisplayerFormsPropertiesTests.cs
+++ b/Tool/Tests/GumToolUnitTests/PropertyGridHelpers/ElementSaveDisplayerFormsPropertiesTests.cs
@@ -104,4 +104,35 @@ public class ElementSaveDisplayerFormsPropertiesTests : BaseTestClass
         behaviorCategory.ShouldNotBeNull();
         behaviorCategory.Members.Any(m => m.Name == "ToolTip").ShouldBeTrue();
     }
+
+    [Fact]
+    public void AddBehaviorFormsPropertyMembers_VariableAlreadyInGeneralCategory_MovesToBehaviorCategory()
+    {
+        // Simulates the case where the component has set a default value for the
+        // FormsProperty: the standard properties path adds the variable under
+        // "General" first; the helper must reclaim it into "Behavior".
+        var generalCategory = new MemberCategory("General");
+        var existingMember = new WpfDataUi.DataTypes.InstanceMember
+        {
+            Name = "ButtonInstance.ToolTip"
+        };
+        generalCategory.Members.Add(existingMember);
+        List<MemberCategory> categories = new List<MemberCategory> { generalCategory };
+
+        _displayer.AddBehaviorFormsPropertyMembers(
+            elementWithBehaviors: _buttonComponent,
+            instanceOwner: _screen,
+            instance: _buttonInstance,
+            stateSave: _screenDefaultState,
+            stateSaveCategory: null,
+            categories: categories);
+
+        generalCategory.Members.ShouldNotContain(existingMember,
+            "the existing entry should be moved out of General");
+
+        var behaviorCategory = categories.FirstOrDefault(c => c.Name == "Behavior");
+        behaviorCategory.ShouldNotBeNull();
+        behaviorCategory.Members.ShouldContain(existingMember,
+            "the existing entry should be reused (preserves its DetailText, displayer hints, etc.) rather than rebuilt");
+    }
 }

--- a/Tool/Tests/GumToolUnitTests/PropertyGridHelpers/ElementSaveDisplayerFormsPropertiesTests.cs
+++ b/Tool/Tests/GumToolUnitTests/PropertyGridHelpers/ElementSaveDisplayerFormsPropertiesTests.cs
@@ -106,6 +106,45 @@ public class ElementSaveDisplayerFormsPropertiesTests : BaseTestClass
     }
 
     [Fact]
+    public void AddBehaviorFormsPropertyMembers_FormsPropertyWithNullName_SilentlySkippedNoCrash()
+    {
+        // Reproduces the v1 (legacy) gumx scenario where the standard XmlSerializer
+        // deserializes a compact-form <FormsProperty Type=".." Name=".." /> into a
+        // VariableSave whose Type and Name are both null.
+        BehaviorSave bogusBehavior = new BehaviorSave { Name = "BogusBehavior" };
+        bogusBehavior.FormsProperties.Add(new VariableSave
+        {
+            Type = null,
+            Name = null
+        });
+
+        ComponentSave bogusComponent = new ComponentSave { Name = "Controls/BogusComponent", BaseType = "Container" };
+        bogusComponent.States.Add(new StateSave { Name = "Default", ParentContainer = bogusComponent });
+        bogusComponent.Behaviors.Add(new ElementBehaviorReference { BehaviorName = "BogusBehavior" });
+        _project.Components.Add(bogusComponent);
+        _project.Behaviors.Add(bogusBehavior);
+
+        List<MemberCategory> categories = new List<MemberCategory>();
+
+        Should.NotThrow(() =>
+            _displayer.AddBehaviorFormsPropertyMembers(
+                elementWithBehaviors: bogusComponent,
+                instanceOwner: bogusComponent,
+                instance: null,
+                stateSave: bogusComponent.DefaultState,
+                stateSaveCategory: null,
+                categories: categories));
+
+        // No member added for the malformed entry; the well-formed ToolTip from
+        // ButtonBehavior on the other component is still on a separate path.
+        var behaviorCategory = categories.FirstOrDefault(c => c.Name == "Behavior");
+        if (behaviorCategory != null)
+        {
+            behaviorCategory.Members.Count.ShouldBe(0);
+        }
+    }
+
+    [Fact]
     public void AddBehaviorFormsPropertyMembers_VariableAlreadyInGeneralCategory_MovesToBehaviorCategory()
     {
         // Simulates the case where the component has set a default value for the

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/ButtonBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/ButtonBehavior.behx
@@ -2,6 +2,7 @@
 <BehaviorSave xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <Name>ButtonBehavior</Name>
   <RequiredVariables />
+  <FormsProperty Type="string" Name="ToolTip" />
   <Category>
     <Name>ButtonCategory</Name>
     <State>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/CheckBoxBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/CheckBoxBehavior.behx
@@ -2,6 +2,7 @@
 <BehaviorSave xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <Name>CheckBoxBehavior</Name>
   <RequiredVariables />
+  <FormsProperty Type="string" Name="ToolTip" />
   <Category>
     <Name>CheckBoxCategory</Name>
     <State>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/ComboBoxBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/ComboBoxBehavior.behx
@@ -2,6 +2,7 @@
 <BehaviorSave xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <Name>ComboBoxBehavior</Name>
   <RequiredVariables />
+  <FormsProperty Type="string" Name="ToolTip" />
   <Category>
     <Name>ComboBoxCategory</Name>
     <State>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/DialogBoxBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/DialogBoxBehavior.behx
@@ -2,6 +2,7 @@
 <BehaviorSave xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <Name>DialogBoxBehavior</Name>
   <RequiredVariables />
+  <FormsProperty Type="string" Name="ToolTip" />
   <RequiredInstances />
   <RequiredAnimations />
   <DefaultImplementation>Controls/DialogBox</DefaultImplementation>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/InputDeviceSelectionItemBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/InputDeviceSelectionItemBehavior.behx
@@ -2,6 +2,7 @@
 <BehaviorSave xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <Name>InputDeviceSelectionItemBehavior</Name>
   <RequiredVariables />
+  <FormsProperty Type="string" Name="ToolTip" />
   <Category>
     <Name>JoinedCategory</Name>
     <IsSetRecursively>false</IsSetRecursively>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/InputDeviceSelectorBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/InputDeviceSelectorBehavior.behx
@@ -2,6 +2,7 @@
 <BehaviorSave xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <Name>InputDeviceSelectorBehavior</Name>
   <RequiredVariables />
+  <FormsProperty Type="string" Name="ToolTip" />
   <RequiredInstances>
     <InstanceSave>
       <Name>InputDeviceContainerInstance</Name>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/ItemsControlBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/ItemsControlBehavior.behx
@@ -2,6 +2,7 @@
 <BehaviorSave xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Name>ItemsControlBehavior</Name>
   <RequiredVariables />
+  <FormsProperty Type="string" Name="ToolTip" />
   <RequiredInstances />
   <RequiredAnimations />
 </BehaviorSave>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/LabelBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/LabelBehavior.behx
@@ -2,6 +2,7 @@
 <BehaviorSave xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Name>LabelBehavior</Name>
   <RequiredVariables />
+  <FormsProperty Type="string" Name="ToolTip" />
   <RequiredInstances />
   <RequiredAnimations />
   <DefaultImplementation>Elements/Label</DefaultImplementation>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/ListBoxBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/ListBoxBehavior.behx
@@ -2,6 +2,7 @@
 <BehaviorSave xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <Name>ListBoxBehavior</Name>
   <RequiredVariables />
+  <FormsProperty Type="string" Name="ToolTip" />
   <Category>
     <Name>ListBoxCategory</Name>
     <State>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/ListBoxItemBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/ListBoxItemBehavior.behx
@@ -2,6 +2,7 @@
 <BehaviorSave xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <Name>ListBoxItemBehavior</Name>
   <RequiredVariables />
+  <FormsProperty Type="string" Name="ToolTip" />
   <Category>
     <Name>ListBoxItemCategory</Name>
     <State>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/MenuBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/MenuBehavior.behx
@@ -2,6 +2,7 @@
 <BehaviorSave xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <Name>MenuBehavior</Name>
   <RequiredVariables />
+  <FormsProperty Type="string" Name="ToolTip" />
   <RequiredInstances />
   <RequiredAnimations />
   <DefaultImplementation>Controls/Menu</DefaultImplementation>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/MenuItemBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/MenuItemBehavior.behx
@@ -2,6 +2,7 @@
 <BehaviorSave xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Name>MenuItemBehavior</Name>
   <RequiredVariables />
+  <FormsProperty Type="string" Name="ToolTip" />
   <Category>
     <Name>MenuItemCategory</Name>
     <State>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/OnScreenKeyboardBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/OnScreenKeyboardBehavior.behx
@@ -2,6 +2,7 @@
 <BehaviorSave xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <Name>OnScreenKeyboardBehavior</Name>
   <RequiredVariables />
+  <FormsProperty Type="string" Name="ToolTip" />
   <RequiredInstances />
   <RequiredAnimations />
 </BehaviorSave>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/PanelBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/PanelBehavior.behx
@@ -2,6 +2,7 @@
 <BehaviorSave xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <Name>PanelBehavior</Name>
   <RequiredVariables />
+  <FormsProperty Type="string" Name="ToolTip" />
   <RequiredInstances />
   <RequiredAnimations />
 </BehaviorSave>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/PasswordBoxBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/PasswordBoxBehavior.behx
@@ -2,6 +2,7 @@
 <BehaviorSave xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <Name>PasswordBoxBehavior</Name>
   <RequiredVariables />
+  <FormsProperty Type="string" Name="ToolTip" />
   <Category>
     <Name>PasswordBoxCategory</Name>
     <State>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/PlayerJoinViewBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/PlayerJoinViewBehavior.behx
@@ -2,6 +2,7 @@
 <BehaviorSave xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <Name>PlayerJoinViewBehavior</Name>
   <RequiredVariables />
+  <FormsProperty Type="string" Name="ToolTip" />
   <RequiredInstances>
     <InstanceSave>
       <Name>InnerPanelInstance</Name>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/PlayerJoinViewItemBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/PlayerJoinViewItemBehavior.behx
@@ -2,6 +2,7 @@
 <BehaviorSave xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <Name>PlayerJoinViewItemBehavior</Name>
   <RequiredVariables />
+  <FormsProperty Type="string" Name="ToolTip" />
   <Category>
     <Name>PlayerJoinCategory</Name>
     <State>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/RadioButtonBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/RadioButtonBehavior.behx
@@ -2,6 +2,7 @@
 <BehaviorSave xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <Name>RadioButtonBehavior</Name>
   <RequiredVariables />
+  <FormsProperty Type="string" Name="ToolTip" />
   <Category>
     <Name>RadioButtonCategory</Name>
     <State>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/ScrollBarBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/ScrollBarBehavior.behx
@@ -2,6 +2,7 @@
 <BehaviorSave xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <Name>ScrollBarBehavior</Name>
   <RequiredVariables />
+  <FormsProperty Type="string" Name="ToolTip" />
   <Category>
     <Name>ScrollBarCategory</Name>
   </Category>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/ScrollViewerBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/ScrollViewerBehavior.behx
@@ -2,6 +2,7 @@
 <BehaviorSave xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Name>ScrollViewerBehavior</Name>
   <RequiredVariables />
+  <FormsProperty Type="string" Name="ToolTip" />
   <Category>
     <Name>ScrollBarVisibility</Name>
     <State>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/SettingsViewBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/SettingsViewBehavior.behx
@@ -2,6 +2,7 @@
 <BehaviorSave xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <Name>SettingsViewBehavior</Name>
   <RequiredVariables />
+  <FormsProperty Type="string" Name="ToolTip" />
   <RequiredInstances />
   <RequiredAnimations />
   <DefaultImplementation>Controls/SettingsView</DefaultImplementation>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/SliderBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/SliderBehavior.behx
@@ -2,6 +2,7 @@
 <BehaviorSave xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <Name>SliderBehavior</Name>
   <RequiredVariables />
+  <FormsProperty Type="string" Name="ToolTip" />
   <Category>
     <Name>SliderCategory</Name>
     <State>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/SplitterBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/SplitterBehavior.behx
@@ -2,6 +2,7 @@
 <BehaviorSave xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Name>SplitterBehavior</Name>
   <RequiredVariables />
+  <FormsProperty Type="string" Name="ToolTip" />
   <RequiredInstances />
   <RequiredAnimations />
   <DefaultImplementation>Controls/SplitterStandard</DefaultImplementation>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/StackPanelBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/StackPanelBehavior.behx
@@ -2,6 +2,7 @@
 <BehaviorSave xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <Name>StackPanelBehavior</Name>
   <RequiredVariables />
+  <FormsProperty Type="string" Name="ToolTip" />
   <RequiredInstances />
   <RequiredAnimations />
 </BehaviorSave>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/TextBoxBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/TextBoxBehavior.behx
@@ -2,6 +2,7 @@
 <BehaviorSave xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Name>TextBoxBehavior</Name>
   <RequiredVariables />
+  <FormsProperty Type="string" Name="ToolTip" />
   <Category>
     <Name>TextBoxCategory</Name>
     <State>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/ToastBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/ToastBehavior.behx
@@ -2,6 +2,7 @@
 <BehaviorSave xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <Name>ToastBehavior</Name>
   <RequiredVariables />
+  <FormsProperty Type="string" Name="ToolTip" />
   <RequiredInstances>
     <InstanceSave>
       <Name>TextInstance</Name>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/ToggleBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/ToggleBehavior.behx
@@ -2,6 +2,7 @@
 <BehaviorSave xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <Name>ToggleBehavior</Name>
   <RequiredVariables />
+  <FormsProperty Type="string" Name="ToolTip" />
   <Category>
     <Name>ToggleCategory</Name>
     <State>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/TreeViewBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/TreeViewBehavior.behx
@@ -2,6 +2,7 @@
 <BehaviorSave xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <Name>TreeViewBehavior</Name>
   <RequiredVariables />
+  <FormsProperty Type="string" Name="ToolTip" />
   <Category>
     <Name>TreeViewCategory</Name>
     <State>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/TreeViewItemBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/TreeViewItemBehavior.behx
@@ -2,6 +2,7 @@
 <BehaviorSave xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <Name>TreeViewItemBehavior</Name>
   <RequiredVariables />
+  <FormsProperty Type="string" Name="ToolTip" />
   <RequiredInstances>
     <InstanceSave>
       <Name>InnerPanelInstance</Name>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/UserControlBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/UserControlBehavior.behx
@@ -2,6 +2,7 @@
 <BehaviorSave xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <Name>UserControlBehavior</Name>
   <RequiredVariables />
+  <FormsProperty Type="string" Name="ToolTip" />
   <RequiredInstances />
   <RequiredAnimations />
   <DefaultImplementation>Controls/UserControl</DefaultImplementation>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/WindowBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/WindowBehavior.behx
@@ -2,6 +2,7 @@
 <BehaviorSave xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Name>WindowBehavior</Name>
   <RequiredVariables />
+  <FormsProperty Type="string" Name="ToolTip" />
   <RequiredInstances />
   <RequiredAnimations />
   <DefaultImplementation>Controls/WindowStandard</DefaultImplementation>


### PR DESCRIPTION
## Summary

Closes the design-time half of the **Property Promotion Gap** for one logical-only Forms property (`ToolTip`), end-to-end. Authoring on the component default OR on a per-instance override in a screen now flows through to `FrameworkElement.ToolTip` at runtime with no `CustomInitialize` code required.

Resolves part of #2637. State-mapped properties (`IsEnabled`, `IsChecked`, etc.) are deferred to v2 and depend on the engine work tracked in #2638.

## What's in here

**Save model**
- `BehaviorSave.FormsProperties` — `List<VariableSave>` of declarations a behavior promotes to its implementing components. Round-trip tested against legacy and compact XML formats.
- Mixed-format deserialization fix: `DeserializeBehaviorSave` falls back to `GetLegacyInstancesCompactSerializer` when the file has compact-form `<FormsProperty>` entries alongside legacy-form `<InstanceSave>` blocks. `BehaviorReference.DeserializeBehavior` now delegates to the centralized `DeserializeBehaviorSave` so the fix applies to all callers.

**Tool**
- `ElementSaveDisplayer` synthesizes a `Behavior` category in the variable grid populated from each linked behavior's `FormsProperties`. When a component authors a default value for a promoted property, the standard properties pass picks it up under "General" first; the helper now relocates the existing `InstanceMember` into "Behavior" rather than skipping the duplicate.
- All 31 standard Forms behavior templates under `Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors` gain `<FormsProperty Type="string" Name="ToolTip" />`.

**Runtime**
- `BehaviorFormsPropertyApplier` walks the visual's `ElementSave` plus inherited base-type behaviors, resolves each `FormsProperty` value through `RecursiveVariableFinder`, and reflects onto a matching property on the wrapped `FrameworkElement`.
- Hooked into `FormsUtilities`'s `InitialStateAppliedNotifier` (not the `FrameworkElement.Visual` setter) so parent-level instance overrides — e.g. screen state's `ButtonInstance.ToolTip` — take precedence over the component default. Tested both paths.

**Defensive guards**
- `FormsProperty` entries with null `Name` are silently skipped (avoids a NRE crash when a v1/legacy gumx tries to deserialize compact attribute form, which yields a `VariableSave` with everything null).

## Out of scope (deferred)

- v2 phases: state-mapped properties (`IsEnabled` driving the Disabled visual state) — needs `#2638` engine work for ternary + category-state LHS in variable references.
- v2 schema: `BehaviorSave.ToolOnlyVariableReferences` — not needed in v1 since `ToolTip` has no visual half.
- Auto-migration: existing Forms components in user projects don't get `FormsProperties` populated automatically. New projects do via the FormsTemplate; existing ones can either re-save (auto-upgrades to v2 + propagates) or hand-edit the `.behx` until we add explicit migration tooling.

## Test plan

Unit tests:
- [x] `GumFileSerializerTests` round-trip `FormsProperties` (legacy format, compact format, omitted-when-empty)
- [x] `ElementSaveDisplayerFormsPropertiesTests` — instance and component contexts, re-categorization when component sets a default, null-name guard
- [x] `BehaviorFormsPropertyApplyTests` — component-default and parent-override cases

Manual:
- [x] Variable grid: select a Forms component instance in a screen → `Behavior` category shows `ToolTip`
- [x] Set component default → variable shows up under `Behavior` in instance view (not `General`)
- [x] End-to-end runtime: place a `ButtonStandard` in a screen, set `ToolTip` on the instance, run a sample game, hover → tooltip appears

## Related

- Closes part of #2637 (full feature spans v1-v3)
- Depends on #2638 for v2 (not blocking this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)