### PR TITLE
Allow Skip/Overwrite resolution on import conflicts (#2644)

### DIFF
--- a/Gum/ImportFromGumxPlugin/MainImportFromGumxPlugin.cs
+++ b/Gum/ImportFromGumxPlugin/MainImportFromGumxPlugin.cs
@@ -46,7 +46,8 @@ internal class MainImportFromGumxPlugin : PluginBase
             sourceService,
             dependencyResolver,
             importService,
-            projectState);
+            projectState,
+            _dialogService);
 
         var window = new Gum.Services.Dialogs.DialogWindow
         {

--- a/Gum/ImportFromGumxPlugin/Services/GumxImportService.cs
+++ b/Gum/ImportFromGumxPlugin/Services/GumxImportService.cs
@@ -26,6 +26,19 @@ public class ImportResult
 }
 
 /// <summary>
+/// How the import service should treat selected elements whose destination file already exists.
+/// </summary>
+public enum ConflictResolution
+{
+    /// <summary>Default: abort the entire import and surface the conflict list.</summary>
+    Cancel,
+    /// <summary>Leave each conflicting destination file untouched; import only non-conflicting elements.</summary>
+    Skip,
+    /// <summary>Replace conflicting destination files with the source content.</summary>
+    Overwrite,
+}
+
+/// <summary>
 /// The user's explicit selections from the import preview dialog.
 /// </summary>
 public class ImportSelections
@@ -71,7 +84,8 @@ public class GumxImportService
         ImportSelections selections,
         GumProjectSave source,
         string sourceBase,
-        string destinationSubfolder)
+        string destinationSubfolder,
+        ConflictResolution conflictResolution = ConflictResolution.Cancel)
     {
         string projectDir = _projectState.ProjectDirectory
             ?? throw new InvalidOperationException("No project is loaded");
@@ -79,13 +93,17 @@ public class GumxImportService
         var result = new ImportResult();
         var nameMap = BuildNameMap(selections, destinationSubfolder);
 
-        // Cancel early if any destination files already exist
+        // Conflicts are file-level: a destination element file already exists at the same path.
+        // The set of names is needed downstream regardless of resolution so writers can decide
+        // whether to skip the file write (Skip) or skip the IImportLogic registration (Overwrite,
+        // since the element is already known in-memory and will refresh on the post-import reload).
         var conflicts = FindConflictingElements(selections, nameMap, projectDir);
-        if (conflicts.Count > 0)
+        if (conflicts.Count > 0 && conflictResolution == ConflictResolution.Cancel)
         {
             result.ConflictingElements.AddRange(conflicts);
             return result;
         }
+        var conflictNameSet = new HashSet<string>(conflicts, StringComparer.Ordinal);
 
         // Pre-fetch all assets for all candidate elements in parallel, so we can gate each
         // element's import on whether its required assets are actually available.
@@ -117,25 +135,25 @@ public class GumxImportService
         foreach (var element in skippedElements)
             result.SkippedElements.Add(element.Name);
 
-        // 1. Standards
+        // 1. Standards (always overwritten by design — see GumxImportServiceTests on standards)
         foreach (var standard in selections.Standards.Where(s => !skippedElements.Contains(s)))
             await WriteAndImportStandardAsync(standard, source, sourceBase, projectDir);
 
         // 2. Transitive components — topological order (already sorted by GumxDependencyResolver)
         foreach (var component in selections.TransitiveComponents.Where(c => !skippedElements.Contains(c)))
-            await WriteAndImportComponentAsync(component, source, sourceBase, projectDir, nameMap);
+            await WriteAndImportComponentAsync(component, source, sourceBase, projectDir, nameMap, conflictNameSet, conflictResolution);
 
         // 3. Behaviors (no asset dependencies)
         foreach (var behavior in selections.Behaviors)
-            await WriteAndImportBehaviorAsync(behavior, source, sourceBase, projectDir);
+            await WriteAndImportBehaviorAsync(behavior, source, sourceBase, projectDir, conflictNameSet, conflictResolution);
 
         // 4. Direct components
         foreach (var component in selections.DirectComponents.Where(c => !skippedElements.Contains(c)))
-            await WriteAndImportComponentAsync(component, source, sourceBase, projectDir, nameMap);
+            await WriteAndImportComponentAsync(component, source, sourceBase, projectDir, nameMap, conflictNameSet, conflictResolution);
 
         // 5. Screens
         foreach (var screen in selections.DirectScreens.Where(s => !skippedElements.Contains(s)))
-            await WriteAndImportScreenAsync(screen, source, sourceBase, projectDir, nameMap);
+            await WriteAndImportScreenAsync(screen, source, sourceBase, projectDir, nameMap, conflictNameSet, conflictResolution);
 
         // 6. Write pre-fetched asset files to disk for imported elements
         var importedElements = allCandidateElements.Where(e => !skippedElements.Contains(e));
@@ -339,10 +357,16 @@ public class GumxImportService
         GumProjectSave source,
         string sourceBase,
         string projectDir,
-        Dictionary<string, string> nameMap)
+        Dictionary<string, string> nameMap,
+        HashSet<string> conflictNameSet,
+        ConflictResolution conflictResolution)
     {
         string sourceName = component.Name;
         string destName = nameMap.TryGetValue(sourceName, out var mapped) ? mapped : sourceName;
+
+        // Skip resolution: leave the existing destination file alone and don't register anything.
+        bool isConflict = conflictNameSet.Contains(destName);
+        if (isConflict && conflictResolution == ConflictResolution.Skip) { return; }
 
         string relativeSrc = $"Components/{sourceName}.{GumProjectSave.ComponentExtension}";
         string destPath = Path.Combine(projectDir, "Components", $"{destName}.{GumProjectSave.ComponentExtension}");
@@ -350,7 +374,9 @@ public class GumxImportService
         bool wrote = await CopyElementFileWithRemapAsync(
             relativeSrc, sourceBase, destPath, sourceName, destName, nameMap);
 
-        if (wrote)
+        // Overwrite resolution: the element is already in the in-memory project, so skip
+        // ImportLogic registration. The end-of-import save+reload picks up the new file content.
+        if (wrote && !isConflict)
         {
             _importLogic.ImportComponent(new FilePath(destPath), saveProject: false);
         }
@@ -360,12 +386,17 @@ public class GumxImportService
         BehaviorSave behavior,
         GumProjectSave source,
         string sourceBase,
-        string projectDir)
+        string projectDir,
+        HashSet<string> conflictNameSet,
+        ConflictResolution conflictResolution)
     {
+        bool isConflict = conflictNameSet.Contains(behavior.Name);
+        if (isConflict && conflictResolution == ConflictResolution.Skip) { return; }
+
         string relativeSrc = $"Behaviors/{behavior.Name}.{BehaviorReference.Extension}";
         string destPath = Path.Combine(projectDir, "Behaviors", $"{behavior.Name}.{BehaviorReference.Extension}");
 
-        if (await CopyElementFileAsync(relativeSrc, sourceBase, destPath))
+        if (await CopyElementFileAsync(relativeSrc, sourceBase, destPath) && !isConflict)
         {
             _importLogic.ImportBehavior(new FilePath(destPath), saveProject: false);
         }
@@ -376,10 +407,15 @@ public class GumxImportService
         GumProjectSave source,
         string sourceBase,
         string projectDir,
-        Dictionary<string, string> nameMap)
+        Dictionary<string, string> nameMap,
+        HashSet<string> conflictNameSet,
+        ConflictResolution conflictResolution)
     {
         string sourceName = screen.Name;
         string destName = nameMap.TryGetValue(sourceName, out var mapped) ? mapped : sourceName;
+
+        bool isConflict = conflictNameSet.Contains(destName);
+        if (isConflict && conflictResolution == ConflictResolution.Skip) { return; }
 
         string relativeSrc = $"Screens/{sourceName}.{GumProjectSave.ScreenExtension}";
         string destPath = Path.Combine(projectDir, "Screens", $"{destName}.{GumProjectSave.ScreenExtension}");
@@ -387,7 +423,7 @@ public class GumxImportService
         bool wrote = await CopyElementFileWithRemapAsync(
             relativeSrc, sourceBase, destPath, sourceName, destName, nameMap);
 
-        if (wrote)
+        if (wrote && !isConflict)
         {
             _importLogic.ImportScreen(new FilePath(destPath), saveProject: false);
         }

--- a/Gum/ImportFromGumxPlugin/ViewModels/ImportFromGumxViewModel.cs
+++ b/Gum/ImportFromGumxPlugin/ViewModels/ImportFromGumxViewModel.cs
@@ -27,6 +27,7 @@ public class ImportFromGumxViewModel : DialogViewModel
     private readonly GumxDependencyResolver _dependencyResolver;
     private readonly GumxImportService _importService;
     private readonly IProjectState _projectState;
+    private readonly IDialogService _dialogService;
 
     private GumProjectSave? _sourceProject;
     private string _sourceBase = string.Empty;
@@ -152,12 +153,14 @@ public class ImportFromGumxViewModel : DialogViewModel
         GumxSourceService sourceService,
         GumxDependencyResolver dependencyResolver,
         GumxImportService importService,
-        IProjectState projectState)
+        IProjectState projectState,
+        IDialogService dialogService)
     {
         _sourceService = sourceService;
         _dependencyResolver = dependencyResolver;
         _importService = importService;
         _projectState = projectState;
+        _dialogService = dialogService;
 
         AffirmativeText = "Import";
         SourceType = SourceType.LocalFile;
@@ -192,18 +195,32 @@ public class ImportFromGumxViewModel : DialogViewModel
             var result = await _importService.ImportAsync(
                 selections, _sourceProject, _sourceBase, DestinationSubfolder);
 
+            // If conflicts came back, ask the user once how to handle the whole batch and retry.
+            if (result.ConflictingElements.Count > 0)
+            {
+                ConflictResolution? resolution = PromptConflictResolution(result.ConflictingElements);
+                if (resolution == null || resolution == ConflictResolution.Cancel)
+                {
+                    string elementList = FormatConflictList(result.ConflictingElements);
+                    _isImportComplete = true;
+                    ErrorMessage =
+                        $"Import cancelled: {result.ConflictingElements.Count} element(s) already exist " +
+                        $"in this project: {elementList}";
+                    return;
+                }
+
+                result = await _importService.ImportAsync(
+                    selections, _sourceProject, _sourceBase, DestinationSubfolder, resolution.Value);
+            }
+
             _isImportComplete = true;
 
             if (result.ConflictingElements.Count > 0)
             {
-                string elementList = string.Join(", ", result.ConflictingElements.Take(5));
-                if (result.ConflictingElements.Count > 5)
-                {
-                    elementList += $" (and {result.ConflictingElements.Count - 5} more)";
-                }
+                // Defensive: a retry pass should not produce new conflicts, but report them if it does.
                 ErrorMessage =
                     $"Import cancelled: {result.ConflictingElements.Count} element(s) already exist " +
-                    $"in this project: {elementList}";
+                    $"in this project: {FormatConflictList(result.ConflictingElements)}";
             }
             else if (result.SkippedElements.Count > 0)
             {
@@ -230,6 +247,46 @@ public class ImportFromGumxViewModel : DialogViewModel
         {
             IsLoading = false;
         }
+    }
+
+    /// <summary>
+    /// Asks the user how to handle existing destination files. Returns the chosen resolution,
+    /// or <see cref="ConflictResolution.Cancel"/> if the user dismisses the dialog.
+    /// </summary>
+    /// <remarks>Virtual so tests can override without spinning up a WPF dialog.</remarks>
+    protected internal virtual ConflictResolution? PromptConflictResolution(IReadOnlyList<string> conflictingElements)
+    {
+        string elementList = FormatConflictList(conflictingElements, max: 10);
+        string message =
+            $"The following {conflictingElements.Count} element(s) already exist in this project:\n\n" +
+            $"{elementList}\n\n" +
+            "How would you like to proceed?";
+
+        // ShowChoices<T> can't return Nullable<T> when T is a value type, so use string keys
+        // (which can come back as null on cancel) and map to the enum locally.
+        var options = new Dictionary<string, string>
+        {
+            ["skip"] = "Skip Existing",
+            ["overwrite"] = "Overwrite All",
+        };
+
+        string? key = _dialogService.ShowChoices(message, options, title: "Import Conflicts", canCancel: true);
+        return key switch
+        {
+            "skip" => ConflictResolution.Skip,
+            "overwrite" => ConflictResolution.Overwrite,
+            _ => null,
+        };
+    }
+
+    private static string FormatConflictList(IReadOnlyList<string> names, int max = 5)
+    {
+        string list = string.Join(", ", names.Take(max));
+        if (names.Count > max)
+        {
+            list += $" (and {names.Count - max} more)";
+        }
+        return list;
     }
 
     private bool CanExecuteLoadPreview() => !IsLoading && !string.IsNullOrWhiteSpace(SourcePath);

--- a/Tool/Tests/GumToolUnitTests/Plugins/ImportFromGumxPlugin/GumxImportServiceTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/ImportFromGumxPlugin/GumxImportServiceTests.cs
@@ -89,6 +89,15 @@ public class GumxImportServiceTests : IDisposable
 
     private static GumProjectSave SourceProject() => new GumProjectSave();
 
+    // ── helpers for writing source behaviors ──────────────────────────────
+
+    private void WriteSourceBehavior(string name)
+    {
+        string file = Path.Combine(_sourceDir, "Behaviors", $"{name}.{BehaviorReference.Extension}");
+        Directory.CreateDirectory(Path.GetDirectoryName(file)!);
+        File.WriteAllText(file, $"<BehaviorSave><Name>{name}</Name></BehaviorSave>");
+    }
+
     // ── conflict detection ────────────────────────────────────────────────
 
     [Fact]
@@ -303,6 +312,244 @@ public class GumxImportServiceTests : IDisposable
         result.SkippedElements.ShouldBeEmpty();
         result.ConflictingElements.ShouldBeEmpty();
         _importLogic.ImportedComponentPaths.ShouldNotBeEmpty();
+    }
+
+    // ── conflict resolution: Skip ─────────────────────────────────────────
+
+    [Fact]
+    public async Task ImportAsync_SkipResolution_ConflictingComponentLeftUntouched_NonConflictingImported()
+    {
+        // Arrange — one conflicting component (already on disk), one new
+        string conflictingName = "ExistingButton";
+        string newName = "NewButton";
+
+        string destComponentDir = Path.Combine(_projectDir, "Components");
+        Directory.CreateDirectory(destComponentDir);
+        string conflictingDestPath = Path.Combine(destComponentDir, $"{conflictingName}.{GumProjectSave.ComponentExtension}");
+        const string originalContent = "<ComponentSave><Name>ExistingButton</Name><Marker>original</Marker></ComponentSave>";
+        File.WriteAllText(conflictingDestPath, originalContent);
+
+        WriteSourceComponent(conflictingName);
+        WriteSourceComponent(newName);
+
+        ComponentSave conflictingComponent = ComponentNoAssets(conflictingName);
+        ComponentSave newComponent = ComponentNoAssets(newName);
+        GumProjectSave source = SourceProject();
+        source.Components.Add(conflictingComponent);
+        source.Components.Add(newComponent);
+
+        ImportSelections selections = new ImportSelections
+        {
+            DirectComponents = new() { conflictingComponent, newComponent },
+            TransitiveComponents = new(),
+            DirectScreens = new(),
+            Behaviors = new(),
+            Standards = new(),
+        };
+
+        // Act
+        ImportResult result = await _sut.ImportAsync(
+            selections, source, _sourceDir, destinationSubfolder: "",
+            conflictResolution: ConflictResolution.Skip);
+
+        // Assert — conflicting file unchanged on disk, new file written, no cancellation
+        result.ConflictingElements.ShouldBeEmpty();
+        File.ReadAllText(conflictingDestPath).ShouldBe(originalContent);
+
+        string newDestPath = Path.Combine(destComponentDir, $"{newName}.{GumProjectSave.ComponentExtension}");
+        File.Exists(newDestPath).ShouldBeTrue();
+
+        // ImportLogic was called only for the new component
+        _importLogic.ImportedComponentPaths.Count.ShouldBe(1);
+        _importLogic.ImportedComponentPaths[0].ShouldEndWith($"{newName}.{GumProjectSave.ComponentExtension}");
+    }
+
+    [Fact]
+    public async Task ImportAsync_SkipResolution_ConflictingBehavior_NotWritten()
+    {
+        // Arrange
+        string conflictingName = "ExistingBehavior";
+
+        string destBehaviorDir = Path.Combine(_projectDir, "Behaviors");
+        Directory.CreateDirectory(destBehaviorDir);
+        string destPath = Path.Combine(destBehaviorDir, $"{conflictingName}.{BehaviorReference.Extension}");
+        const string originalContent = "<BehaviorSave><Name>ExistingBehavior</Name><Marker>original</Marker></BehaviorSave>";
+        File.WriteAllText(destPath, originalContent);
+
+        WriteSourceBehavior(conflictingName);
+
+        BehaviorSave behavior = new BehaviorSave { Name = conflictingName };
+        GumProjectSave source = SourceProject();
+        source.Behaviors.Add(behavior);
+
+        ImportSelections selections = new ImportSelections
+        {
+            DirectComponents = new(),
+            TransitiveComponents = new(),
+            DirectScreens = new(),
+            Behaviors = new() { behavior },
+            Standards = new(),
+        };
+
+        // Act
+        ImportResult result = await _sut.ImportAsync(
+            selections, source, _sourceDir, destinationSubfolder: "",
+            conflictResolution: ConflictResolution.Skip);
+
+        // Assert
+        result.ConflictingElements.ShouldBeEmpty();
+        File.ReadAllText(destPath).ShouldBe(originalContent);
+        _importLogic.ImportedBehaviorPaths.ShouldBeEmpty();
+    }
+
+    // ── conflict resolution: Overwrite ────────────────────────────────────
+
+    [Fact]
+    public async Task ImportAsync_OverwriteResolution_ConflictingComponent_FileReplaced()
+    {
+        // Arrange
+        string componentName = "Button";
+
+        string destComponentDir = Path.Combine(_projectDir, "Components");
+        Directory.CreateDirectory(destComponentDir);
+        string destPath = Path.Combine(destComponentDir, $"{componentName}.{GumProjectSave.ComponentExtension}");
+        File.WriteAllText(destPath, "<ComponentSave><Name>Button</Name><Marker>original</Marker></ComponentSave>");
+
+        // Source content has a different marker so we can verify the overwrite landed
+        string srcDir = Path.Combine(_sourceDir, "Components");
+        Directory.CreateDirectory(srcDir);
+        const string newContent = "<ComponentSave><Name>Button</Name><Marker>updated</Marker></ComponentSave>";
+        File.WriteAllText(Path.Combine(srcDir, $"{componentName}.{GumProjectSave.ComponentExtension}"), newContent);
+
+        ComponentSave component = ComponentNoAssets(componentName);
+        GumProjectSave source = SourceProject();
+        source.Components.Add(component);
+
+        ImportSelections selections = new ImportSelections
+        {
+            DirectComponents = new() { component },
+            TransitiveComponents = new(),
+            DirectScreens = new(),
+            Behaviors = new(),
+            Standards = new(),
+        };
+
+        // Act
+        ImportResult result = await _sut.ImportAsync(
+            selections, source, _sourceDir, destinationSubfolder: "",
+            conflictResolution: ConflictResolution.Overwrite);
+
+        // Assert — file on disk replaced; ImportLogic NOT called for an already-registered element
+        // (the project save+reload at end of import picks up the new content).
+        result.ConflictingElements.ShouldBeEmpty();
+        File.ReadAllText(destPath).ShouldBe(newContent);
+        _importLogic.ImportedComponentPaths.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task ImportAsync_OverwriteResolution_ConflictingBehavior_FileReplaced()
+    {
+        // Arrange
+        string behaviorName = "Clickable";
+
+        string destBehaviorDir = Path.Combine(_projectDir, "Behaviors");
+        Directory.CreateDirectory(destBehaviorDir);
+        string destPath = Path.Combine(destBehaviorDir, $"{behaviorName}.{BehaviorReference.Extension}");
+        File.WriteAllText(destPath, "<BehaviorSave><Name>Clickable</Name><Marker>original</Marker></BehaviorSave>");
+
+        string srcDir = Path.Combine(_sourceDir, "Behaviors");
+        Directory.CreateDirectory(srcDir);
+        const string newContent = "<BehaviorSave><Name>Clickable</Name><Marker>updated</Marker></BehaviorSave>";
+        File.WriteAllText(Path.Combine(srcDir, $"{behaviorName}.{BehaviorReference.Extension}"), newContent);
+
+        BehaviorSave behavior = new BehaviorSave { Name = behaviorName };
+        GumProjectSave source = SourceProject();
+        source.Behaviors.Add(behavior);
+
+        ImportSelections selections = new ImportSelections
+        {
+            DirectComponents = new(),
+            TransitiveComponents = new(),
+            DirectScreens = new(),
+            Behaviors = new() { behavior },
+            Standards = new(),
+        };
+
+        // Act
+        ImportResult result = await _sut.ImportAsync(
+            selections, source, _sourceDir, destinationSubfolder: "",
+            conflictResolution: ConflictResolution.Overwrite);
+
+        // Assert
+        result.ConflictingElements.ShouldBeEmpty();
+        File.ReadAllText(destPath).ShouldBe(newContent);
+        _importLogic.ImportedBehaviorPaths.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task ImportAsync_OverwriteResolution_NonConflictingComponent_StillRegisteredViaImportLogic()
+    {
+        // A NEW (non-conflicting) component must still be registered via IImportLogic, even when
+        // the resolution is Overwrite — Overwrite only changes the path for already-existing files.
+        string newName = "NewButton";
+        WriteSourceComponent(newName);
+
+        ComponentSave newComponent = ComponentNoAssets(newName);
+        GumProjectSave source = SourceProject();
+        source.Components.Add(newComponent);
+
+        ImportSelections selections = new ImportSelections
+        {
+            DirectComponents = new() { newComponent },
+            TransitiveComponents = new(),
+            DirectScreens = new(),
+            Behaviors = new(),
+            Standards = new(),
+        };
+
+        // Act
+        ImportResult result = await _sut.ImportAsync(
+            selections, source, _sourceDir, destinationSubfolder: "",
+            conflictResolution: ConflictResolution.Overwrite);
+
+        // Assert
+        result.ConflictingElements.ShouldBeEmpty();
+        _importLogic.ImportedComponentPaths.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task ImportAsync_DefaultResolutionStillCancelsOnConflict()
+    {
+        // Regression: omitting the conflictResolution parameter must preserve the legacy
+        // "cancel and report" behavior expected by existing callers.
+        string componentName = "MyButton";
+
+        string destComponentDir = Path.Combine(_projectDir, "Components");
+        Directory.CreateDirectory(destComponentDir);
+        File.WriteAllText(
+            Path.Combine(destComponentDir, $"{componentName}.{GumProjectSave.ComponentExtension}"),
+            "existing");
+
+        WriteSourceComponent(componentName);
+        ComponentSave component = ComponentNoAssets(componentName);
+        GumProjectSave source = SourceProject();
+        source.Components.Add(component);
+
+        ImportSelections selections = new ImportSelections
+        {
+            DirectComponents = new() { component },
+            TransitiveComponents = new(),
+            DirectScreens = new(),
+            Behaviors = new(),
+            Standards = new(),
+        };
+
+        // Act — no conflictResolution argument
+        ImportResult result = await _sut.ImportAsync(selections, source, _sourceDir, destinationSubfolder: "");
+
+        // Assert
+        result.ConflictingElements.ShouldContain(componentName);
+        _importLogic.ImportedComponentPaths.ShouldBeEmpty();
     }
 
     // ── test doubles ──────────────────────────────────────────────────────

--- a/Tool/Tests/GumToolUnitTests/Plugins/ImportFromGumxPlugin/ImportFromGumxViewModelTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/ImportFromGumxPlugin/ImportFromGumxViewModelTests.cs
@@ -4,6 +4,7 @@ using Gum.DataTypes.Behaviors;
 using Gum.DataTypes.Variables;
 using Gum.Plugins.ImportPlugin.Manager;
 using Gum.Plugins.ImportPlugin.Services;
+using Gum.Services.Dialogs;
 using Gum.Settings;
 using Gum.ToolStates;
 using ImportFromGumxPlugin.Services;
@@ -28,6 +29,8 @@ public class ImportFromGumxViewModelTests
 {
     private readonly ImportFromGumxViewModel _sut;
 
+    private readonly FakeDialogService _dialogService;
+
     public ImportFromGumxViewModelTests()
     {
         GumxSourceService sourceService = new GumxSourceService();
@@ -36,7 +39,8 @@ public class ImportFromGumxViewModelTests
         GumxImportService importService = new GumxImportService(
             new FakeImportLogic(), projectState, new FakeFileCommands(), sourceService);
 
-        _sut = new ImportFromGumxViewModel(sourceService, resolver, importService, projectState);
+        _dialogService = new FakeDialogService();
+        _sut = new ImportFromGumxViewModel(sourceService, resolver, importService, projectState, _dialogService);
     }
 
     [Fact]
@@ -212,6 +216,50 @@ public class ImportFromGumxViewModelTests
         secondLeaf.InclusionState.ShouldBe(InclusionState.NotIncluded);
     }
 
+    // ── conflict-resolution dialog (#2644) ────────────────────────────────
+
+    [Fact]
+    public void PromptConflictResolution_OffersSkipAndOverwriteAndAllowsCancel()
+    {
+        ConflictResolution? captured = null;
+        _dialogService.ChoiceDialogStub = vm =>
+        {
+            // Validate the options surfaced to the user — Skip and Overwrite, plus a Cancel path.
+            vm.OptionValues.Count.ShouldBe(2);
+            vm.OptionValues.ShouldContain("Skip Existing");
+            vm.OptionValues.ShouldContain("Overwrite All");
+            vm.CanCancel.ShouldBeTrue();
+            // Don't pick anything → SelectedValue is left as the default first option ("Skip Existing").
+            // To simulate "Cancel", clear the selection.
+            vm.SelectedValue = null;
+        };
+
+        captured = _sut.PromptConflictResolution(new[] { "Behaviors/Clickable", "Components/Button" });
+
+        _dialogService.ShowChoiceCallCount.ShouldBe(1);
+        captured.ShouldBeNull();
+    }
+
+    [Fact]
+    public void PromptConflictResolution_UserPicksSkip_ReturnsSkip()
+    {
+        _dialogService.ChoiceDialogStub = vm => vm.SelectedValue = "Skip Existing";
+
+        ConflictResolution? result = _sut.PromptConflictResolution(new[] { "Behaviors/Clickable" });
+
+        result.ShouldBe(ConflictResolution.Skip);
+    }
+
+    [Fact]
+    public void PromptConflictResolution_UserPicksOverwrite_ReturnsOverwrite()
+    {
+        _dialogService.ChoiceDialogStub = vm => vm.SelectedValue = "Overwrite All";
+
+        ConflictResolution? result = _sut.PromptConflictResolution(new[] { "Components/Button" });
+
+        result.ShouldBe(ConflictResolution.Overwrite);
+    }
+
     private ImportTreeNodeViewModel FindLeaf(string fullName, ElementItemType elementType)
     {
         foreach (ImportTreeNodeViewModel root in _sut.RootNodes)
@@ -238,6 +286,40 @@ public class ImportFromGumxViewModelTests
     }
 
     // ── fakes ─────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Records the last <see cref="Show{T}(Action{T}?, out T)"/> invocation. The IDialogService
+    /// extension <c>ShowChoices&lt;T&gt;</c> resolves a <see cref="ChoiceDialogViewModel"/> via this
+    /// method, so capturing here is enough to verify the conflict-resolution flow.
+    /// </summary>
+    private class FakeDialogService : IDialogService
+    {
+        public Action<ChoiceDialogViewModel>? ChoiceDialogStub { get; set; }
+        public ChoiceDialogViewModel? LastChoiceDialog { get; private set; }
+        public int ShowChoiceCallCount { get; private set; }
+
+        public MessageDialogResult ShowMessage(string message, string? title = null, MessageDialogStyle? style = null)
+            => MessageDialogResult.Canceled;
+        public bool Show<T>(T dialogViewModel) where T : DialogViewModel => false;
+        public bool Show<T>(Action<T>? initializer, out T viewModel) where T : DialogViewModel
+        {
+            // Hand-roll a ChoiceDialogViewModel since the test bypasses DI.
+            if (typeof(T) == typeof(ChoiceDialogViewModel))
+            {
+                ChoiceDialogViewModel choice = new ChoiceDialogViewModel();
+                initializer?.Invoke((T)(object)choice);
+                ChoiceDialogStub?.Invoke(choice);
+                LastChoiceDialog = choice;
+                ShowChoiceCallCount++;
+                viewModel = (T)(object)choice;
+                return false;
+            }
+            viewModel = null!;
+            return false;
+        }
+        public string? GetUserString(string message, string? title = null, GetUserStringOptions? options = null) => null;
+        public List<string>? OpenFile(OpenFileDialogOptions? options = null) => null;
+    }
 
     private class FakeImportLogic : IImportLogic
     {


### PR DESCRIPTION
## Summary
Closes #2644. When the **Import from Gumx** dialog detects that selected Components/Screens/Behaviors already exist in the destination project, the user now gets a bulk-decision dialog instead of an immediate cancellation:

> **Skip Existing** — leave conflicting files alone, import the rest.
> **Overwrite All** — replace conflicting destination files with the source content.
> **Cancel** — preserve current behavior (no-op).

One click, no per-element prompting. Standards continue to always overwrite (their existing policy).

## Implementation notes
- `ConflictResolution` enum (Cancel / Skip / Overwrite) on `GumxImportService` with optional parameter on `ImportAsync` defaulting to Cancel — preserves all legacy callers.
- Per-element gating in the writers: Skip aborts both the file write and the `IImportLogic` registration; Overwrite still writes the file but skips the `IImportLogic` registration for already-registered elements (the existing end-of-import save+reload picks up the new file content — same flow Standards have always relied on).
- `ImportFromGumxViewModel` gained `IDialogService` and a `PromptConflictResolution` helper that raises `IDialogService.ShowChoices`. On first-attempt conflicts the VM prompts, then retries `ImportAsync` with the chosen resolution.
- Used string keys for the choice dialog because `ShowChoices<T>` can't return `Nullable<T>` for value-type T (a generic-constraint quirk in the existing API). The mapping back to the enum is local to the VM.

## Test plan
- [x] New `GumxImportServiceTests`:
  - Skip: conflicting component file unchanged, new component imported, ImportLogic called only for the new one.
  - Skip: conflicting behavior file not written.
  - Overwrite: conflicting component file replaced, ImportLogic NOT called for it (already registered).
  - Overwrite: conflicting behavior file replaced.
  - Overwrite: non-conflicting component still goes through ImportLogic registration.
  - Default (no resolution arg): legacy cancel-on-conflict behavior preserved.
- [x] New `ImportFromGumxViewModelTests`:
  - PromptConflictResolution surfaces both options and a Cancel path.
  - User picks Skip → returns `ConflictResolution.Skip`.
  - User picks Overwrite → returns `ConflictResolution.Overwrite`.
- [x] Full `GumToolUnitTests` suite: 534 passed / 5 skipped / 0 failed.

## Notes / out of scope
- Per-element resolution (skip this one, overwrite that one) — bulk decision only for v1, as agreed in the issue.
- Asset-file conflict resolution is unchanged; existing assets on disk are still kept silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)