### PR TITLE
Forms property promotion v2: state-mapped IsEnabled with design-time preview (#2637)

### DIFF
--- a/.claude/skills/gum-forms-behaviors/SKILL.md
+++ b/.claude/skills/gum-forms-behaviors/SKILL.md
@@ -51,30 +51,49 @@ The `DefaultFromFileXxxRuntime` classes exist solely to bridge the file-loading 
 | `StackPanelBehaviorName` | `DefaultFromFileStackPanelRuntime` |
 | `WindowBehaviorName` | `DefaultFromFileWindowRuntime` |
 
-## The Property Promotion Gap (partially closed)
+## The Property Promotion Gap (closed for logical + state-mapped)
 
-The Gum tool operates at the visual layer — layout, colors, fonts, dimensions saved as `VariableSave` entries. The Forms behavioral layer (state, data, interaction) is added entirely at runtime. The save model historically had no bridge to Forms semantics.
+The Gum tool operates at the visual layer — layout, colors, fonts, dimensions saved as `VariableSave` entries. The Forms behavioral layer (state, data, interaction) is added at runtime. Two mechanisms now bridge the save model into Forms semantics: **`FormsProperties`** for the value-on-the-control half, and **`ToolOnlyVariableReferences`** for the design-time visual-state preview half.
 
-### Behavior FormsProperties — the v1 bridge
+### `BehaviorSave.FormsProperties` (v1)
 
-`BehaviorSave.FormsProperties` (a `List<VariableSave>`) lets a behavior declare design-time properties that flow through to its wrapped `FrameworkElement` at runtime via reflection. Each entry's `Name` must match a property on the corresponding control (e.g. `ToolTip` on `FrameworkElement`); `Value` is the design-time default.
+A `List<VariableSave>` declaring design-time properties that flow through to the wrapped `FrameworkElement` at runtime via reflection. Each entry's `Name` must match a property on the control (e.g. `ToolTip`, `IsEnabled`); `Value` is the **declared default** (used as a fallback tier — see below).
 
-The variable grid in the tool synthesizes a "Behavior" category for these declarations on both the component definition and any instance. When a component sets a default on a promoted property, the standard properties pass picks it up under General first; `ElementSaveDisplayer.AddBehaviorFormsPropertyMembers` relocates it into "Behavior" so categorization stays consistent.
+The variable grid synthesizes a "Behavior" category for these declarations on both the component definition and any instance (`ElementSaveDisplayer.AddBehaviorFormsPropertyMembers`). When a component sets a default on a promoted property under General, the displayer relocates it into "Behavior" to keep categorization consistent.
 
-At runtime, `BehaviorFormsPropertyApplier.Apply` is invoked from `FormsUtilities`'s `InitialStateAppliedNotifier` (after the parent's `SetInitialState` completes). It walks the GUE's `ElementSave.Behaviors` (and inherited base-type behaviors), reads each `FormsProperty`'s effective value — preferring parent-state instance overrides like screen `"ButtonInstance.ToolTip"` over the element's own default — and reflects onto the wrapped `FrameworkElement`. The hook lives at the notifier (not the `Visual` setter) because instance-qualified overrides on the parent state aren't visible until after the parent's state has been applied.
+### `BehaviorSave.ToolOnlyVariableReferences` (v2)
 
-### What's covered today
+A `List<string>` of variable-reference assignments evaluated **only at design time** to drive wireframe preview. Example on `ButtonBehavior`:
 
-`ToolTip` on every standard Forms behavior. The reflection apply is generic, so any new logical-only `FormsProperty` declaration (e.g. `MaxCharacters`, `Slider.Minimum/Maximum/Value`) would flow through automatically without runtime changes.
+```
+ButtonCategoryState = IsEnabled ? "Enabled" : "Disabled"
+```
 
-### What's still pending (state-mapped properties)
+Tool-time apply (`BehaviorToolOnlyReferencesApplier`, in the variable-grid plugin) walks every linked behavior's `ToolOnlyVariableReferences`, evaluates the RHS via `EvaluatedSyntax` against the component's effective state, and writes the resolved value back into the state via `SetValue`. For instances, bare RHS identifiers are auto-qualified with the instance name. Hooked into `VariableReferenceLogic.DoVariableReferenceReaction` immediately after the existing state-level apply.
 
-`IsEnabled`, `IsChecked`, and similar properties that have a *visual* state consequence (the Disabled visual category) need a second mechanism: behavior-level tool-only variable references that drive `<Category>State` from the FormsProperty value. That depends on engine work in `#2638` (ternary expressions and category-state LHS in `EvaluatedSyntax` / `VariableReferenceLogic`) and is tracked under v2 of `#2637`.
+**The runtime apply path never traverses this list** — that's what the `ToolOnly` name encodes structurally. At runtime, the Forms control's own setter (e.g. `FrameworkElement.IsEnabled` → `UpdateState()`) owns the visual; applying the reference again would double-write.
 
-Examples still requiring code-side initialization:
-- `CheckBox.IsChecked` / `ToggleButton.IsChecked` — needs visual state binding
-- `Button.IsEnabled` / `TextBox.IsEnabled` — needs visual state binding
-- `Button.Text` / `Label.Text` — visual-only pass-through, authored on the child `TextInstance` directly
+### Three-tier default resolution
+
+Both apply paths plus the variable-grid *display* getter consult the same priority order:
+
+1. Parent-state instance override (e.g. screen state `"ButtonInstance.IsEnabled"`)
+2. Component's own default state value
+3. Behavior-declared `FormsProperty.Value` (the implicit default)
+
+Tier 3 is **virtual** — never written to state, never appears in `.gusx`. State-empty stays state-empty. The fallback machinery:
+
+- `RecursiveVariableFinder.Fallback` (`Func<string, object?>?`) — consulted when state lookup returns null.
+- `EvaluatedSyntax.FromSyntaxNode` takes an optional `fallback` parameter threaded through every recursive evaluation.
+- `BehaviorToolOnlyReferencesApplier` builds a per-element fallback that walks every linked behavior's `FormsProperties` and resolves bare or instance-qualified identifiers to declared `Value`.
+- `BehaviorFormsPropertyApplier.Apply` adds the third tier inline: `ReadEffectiveValue(...) ?? declaration.Value`.
+- `StateReferencingInstanceMember.DefaultValueFallback` lets the variable grid show the declared default in the checkbox/text without writing into state. `IsDefault` still returns true (state empty), preserving the grid's italic/grey styling.
+
+### Covered today
+
+`ToolTip` (logical-only) and `IsEnabled` (state-mapped, with `<X>CategoryState` reference) on every standard Forms behavior. Behaviors with no Disabled visual still get the `IsEnabled` `FormsProperty` (runtime reflection works), but no `ToolOnlyVariableReference` since there's no visual state to drive.
+
+Reflection apply is generic, so any new logical-only `FormsProperty` declaration (e.g. `MaxCharacters`, `Slider.Minimum/Maximum/Value`) flows through without runtime changes. State-mapped properties beyond `IsEnabled` (e.g. `IsChecked`) follow the same v2 shape: declare the `FormsProperty` plus a `ToolOnlyVariableReference` driving the appropriate `<X>CategoryState`.
 
 ## Key Files
 
@@ -86,6 +105,10 @@ Examples still requiring code-side initialization:
 | `GumDataTypes/ElementSave.cs` | `Behaviors` list on components/screens |
 | `MonoGameGum/Forms/FormsUtilities.cs` | `RegisterFromFileFormRuntimeDefaults()` — drives the mapping; sets `InitialStateAppliedNotifier` to invoke `BehaviorFormsPropertyApplier` |
 | `MonoGameGum/Forms/DefaultFromFileVisuals/` | `DefaultFromFileXxxRuntime` classes — `AfterFullCreation()` creates Forms objects |
-| `MonoGameGum/Forms/BehaviorFormsPropertyApplier.cs` | Reflects `BehaviorSave.FormsProperties` values onto the wrapped `FrameworkElement` |
-| `Gum/Plugins/InternalPlugins/VariableGrid/ElementSaveDisplayer.cs` | `AddBehaviorFormsPropertyMembers` — surfaces FormsProperties in the variable grid |
+| `MonoGameGum/Forms/BehaviorFormsPropertyApplier.cs` | Reflects `BehaviorSave.FormsProperties` values onto the wrapped `FrameworkElement` (with three-tier default resolution) |
+| `Gum/Plugins/InternalPlugins/VariableGrid/BehaviorToolOnlyReferencesApplier.cs` | Tool-only design-time apply pass for `ToolOnlyVariableReferences`. Strictly tool-only — never invoked from runtime / generated code. |
+| `Gum/Plugins/InternalPlugins/VariableGrid/ElementSaveDisplayer.cs` | `AddBehaviorFormsPropertyMembers` — surfaces FormsProperties in the variable grid; sets `DefaultValueFallback` on each SRIM so the grid shows the declared default. |
+| `Gum/Plugins/InternalPlugins/VariableGrid/StateReferencingInstanceMember.cs` | `DefaultValueFallback` final tier in the value getter for grid display. |
+| `Runtimes/GumExpressions/EvaluatedSyntax.cs` | Optional `fallback` parameter on `FromSyntaxNode` threaded through evaluation. |
+| `Gum/DataTypes/RecursiveVariableFinder.cs` | `Fallback` property consulted when state lookup returns null. |
 | `GumRuntime/InteractiveGue.cs` | `FormsControlAsObject` back-link property |

--- a/.claude/skills/gum-tool-variable-references/SKILL.md
+++ b/.claude/skills/gum-tool-variable-references/SKILL.md
@@ -94,6 +94,12 @@ When a variable changes, `DoVariableReferenceReaction` finds all elements that r
 
 Invalid lines are auto-commented with `//` prefix and a message is shown to the user.
 
+## Behavior-Sourced Tool-Only References
+
+A separate variable-reference flavor lives on `BehaviorSave.ToolOnlyVariableReferences` (a `List<string>`, not a `VariableListSave`). Used by Forms property promotion (#2637 v2): a behavior declares e.g. `ButtonCategoryState = IsEnabled ? "Enabled" : "Disabled"` so the design-time wireframe reflects authored `FormsProperty` values. **Strictly tool-only** — applied by `BehaviorToolOnlyReferencesApplier` invoked from `VariableReferenceLogic.DoVariableReferenceReaction` immediately after the state-level apply. The runtime never traverses this list; the wrapped Forms control's setter (e.g. `FrameworkElement.IsEnabled` → `UpdateState()`) owns the visual at runtime, so applying the reference there would double-write. See `gum-forms-behaviors` for the property-promotion pipeline.
+
+The applier passes a `fallback` resolver into `EvaluatedSyntax.FromSyntaxNode` so identifiers not authored on state fall back to the behavior's `FormsProperty.Value` declarations (mirrors WPF DependencyProperty default values). Plumbed through `RecursiveVariableFinder.Fallback` — any caller that needs the same "default-when-state-empty" shape can use it.
+
 ## Known Gaps
 
 - **Font generation:** `CollectRequiredFonts` (in `HeadlessFontGenerationService`) and `RecursiveVariableFinder` do not resolve variable references. If a font property (Font, FontSize, etc.) is set via a variable reference, the font file may not be generated for that value. The tool-time path works because `VariableChangedThroughReference` fires `PluginManager.VariableSet`, but headless/CLI font generation could miss these. (See issue #2414)

--- a/Gum/DataTypes/RecursiveVariableFinder.cs
+++ b/Gum/DataTypes/RecursiveVariableFinder.cs
@@ -137,8 +137,17 @@ public class RecursiveVariableFinder : IVariableFinder
         ElementStack.Add(new ElementWithState(stateSave.ParentContainer) { StateName = stateSave.Name });
     }
 
+    /// <summary>
+    /// Optional resolver consulted when the primary state lookup returns null.
+    /// Used by the Forms-property-promotion apply pipeline to fall back to a
+    /// linked behavior's <c>FormsProperty.Value</c> declarations when an
+    /// identifier is referenced but no value is authored on any state.
+    /// </summary>
+    public Func<string, object?>? Fallback { get; set; }
+
     public object GetValue(string variableName)
     {
+        object? toReturn;
         switch (ContainerType)
         {
             case VariableContainerType.InstanceSave:
@@ -154,23 +163,21 @@ public class RecursiveVariableFinder : IVariableFinder
 #endif
 
                 VariableSave variable = GetVariable(variableName);
-                if (variable != null)
-                {
-                    return variable.Value;
-                }
-                else
-                {
-                    return null;
-                }
-
-            //return mInstanceSave.GetValueFromThisOrBase(mElementStack, variableName);
-            //break;
+                toReturn = variable?.Value;
+                break;
             case VariableContainerType.StateSave:
-                return mStateSave.GetValueRecursive(variableName);
-            //break;
+                toReturn = mStateSave.GetValueRecursive(variableName);
+                break;
+            default:
+                throw new NotImplementedException();
         }
 
-        throw new NotImplementedException();
+        if (toReturn == null && Fallback != null)
+        {
+            toReturn = Fallback(variableName);
+        }
+
+        return toReturn;
     }
 
     public T GetValue<T>(string variableName)

--- a/Gum/Plugins/InternalPlugins/VariableGrid/BehaviorToolOnlyReferencesApplier.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/BehaviorToolOnlyReferencesApplier.cs
@@ -1,0 +1,119 @@
+using Gum.DataTypes;
+using Gum.DataTypes.Behaviors;
+using Gum.DataTypes.Variables;
+using Gum.Expressions;
+using Gum.Managers;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System.Linq;
+
+namespace Gum.Plugins.InternalPlugins.VariableGrid;
+
+/// <summary>
+/// Tool-only apply pass for <see cref="BehaviorSave.ToolOnlyVariableReferences"/>.
+/// For the supplied state, walks the element's own behaviors plus the behaviors of
+/// each instance's base component and writes the resolved value of every reference
+/// line back into the state — qualifying the left-hand side with the instance name
+/// when the reference comes from an instance's component.
+///
+/// Strictly tool-only by design: never invoked from runtime apply paths or generated
+/// code. The runtime equivalent for these properties is the Forms control's own
+/// setter (e.g. <c>FrameworkElement.IsEnabled</c>'s <c>UpdateState()</c> call), so
+/// applying these references at runtime would double-write the visual state.
+/// </summary>
+public static class BehaviorToolOnlyReferencesApplier
+{
+    public static void Apply(ElementSave element, StateSave stateSave)
+    {
+        ApplyBehaviorsOf(element, instance: null, stateSave);
+
+        foreach (InstanceSave instance in element.Instances)
+        {
+            ElementSave? instanceElement = ObjectFinder.Self.GetElementSave(instance.BaseType);
+            if (instanceElement == null)
+            {
+                continue;
+            }
+
+            ApplyBehaviorsOf(instanceElement, instance, stateSave);
+        }
+    }
+
+    private static void ApplyBehaviorsOf(ElementSave element, InstanceSave? instance, StateSave stateSave)
+    {
+        if (element is not ComponentSave component)
+        {
+            return;
+        }
+
+        foreach (ElementBehaviorReference reference in component.Behaviors)
+        {
+            BehaviorSave? behavior = ObjectFinder.Self.GetBehavior(reference);
+            if (behavior == null || behavior.ToolOnlyVariableReferences.Count == 0)
+            {
+                continue;
+            }
+
+            foreach (string referenceLine in behavior.ToolOnlyVariableReferences)
+            {
+                ApplyLine(referenceLine, instance, stateSave);
+            }
+        }
+    }
+
+    private static void ApplyLine(string referenceLine, InstanceSave? instance, StateSave stateSave)
+    {
+        if (string.IsNullOrWhiteSpace(referenceLine) || referenceLine.TrimStart().StartsWith("//"))
+        {
+            return;
+        }
+
+        int equalsIndex = referenceLine.IndexOf('=');
+        if (equalsIndex < 0)
+        {
+            return;
+        }
+
+        string left = referenceLine.Substring(0, equalsIndex).Trim();
+        string right = referenceLine.Substring(equalsIndex + 1).Trim();
+
+        if (instance != null)
+        {
+            right = QualifyBareIdentifiersWithInstance(right, instance.Name);
+        }
+
+        string rightAsCSharp = EvaluatedSyntax.ConvertToCSharpSyntax(right);
+        ExpressionSyntax rightSyntax = SyntaxFactory.ParseExpression(rightAsCSharp);
+        EvaluatedSyntax? evaluated = EvaluatedSyntax.FromSyntaxNode(rightSyntax, stateSave);
+        if (evaluated?.Value == null)
+        {
+            return;
+        }
+
+        string effectiveLeft = instance == null ? left : $"{instance.Name}.{left}";
+        stateSave.SetValue(effectiveLeft, evaluated.Value, instance);
+    }
+
+    /// <summary>
+    /// Re-writes the right-hand side of an assignment so every bare identifier becomes
+    /// <c>{instanceName}.{identifier}</c>, leaving qualified names and member-access
+    /// expressions alone. Mirrors <c>VariableReferenceLogic.QualifyInstanceVariables</c>.
+    /// </summary>
+    private static string QualifyBareIdentifiersWithInstance(string right, string instanceName)
+    {
+        SyntaxNode tree = CSharpSyntaxTree.ParseText(right).GetCompilationUnitRoot();
+
+        var bareIdentifiers = tree.DescendantNodes()
+            .OfType<IdentifierNameSyntax>()
+            .Where(id => id.Parent is not MemberAccessExpressionSyntax
+                         && id.Parent is not AliasQualifiedNameSyntax)
+            .ToList();
+
+        SyntaxNode rewritten = tree.ReplaceNodes(
+            bareIdentifiers,
+            (node, _) => SyntaxFactory.IdentifierName($"{instanceName}.{node}"));
+
+        return rewritten.ToString();
+    }
+}

--- a/Gum/Plugins/InternalPlugins/VariableGrid/BehaviorToolOnlyReferencesApplier.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/BehaviorToolOnlyReferencesApplier.cs
@@ -6,6 +6,7 @@ using Gum.Managers;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System;
 using System.Linq;
 
 namespace Gum.Plugins.InternalPlugins.VariableGrid;
@@ -26,26 +27,23 @@ public static class BehaviorToolOnlyReferencesApplier
 {
     public static void Apply(ElementSave element, StateSave stateSave)
     {
-        ApplyBehaviorsOf(element, instance: null, stateSave);
+        if (element is ComponentSave component)
+        {
+            ApplyBehaviorsOf(component, instance: null, stateSave);
+        }
 
         foreach (InstanceSave instance in element.Instances)
         {
-            ElementSave? instanceElement = ObjectFinder.Self.GetElementSave(instance.BaseType);
-            if (instanceElement == null)
+            if (ObjectFinder.Self.GetElementSave(instance.BaseType) is ComponentSave instanceComponent)
             {
-                continue;
+                ApplyBehaviorsOf(instanceComponent, instance, stateSave);
             }
-
-            ApplyBehaviorsOf(instanceElement, instance, stateSave);
         }
     }
 
-    private static void ApplyBehaviorsOf(ElementSave element, InstanceSave? instance, StateSave stateSave)
+    private static void ApplyBehaviorsOf(ComponentSave component, InstanceSave? instance, StateSave stateSave)
     {
-        if (element is not ComponentSave component)
-        {
-            return;
-        }
+        Func<string, object?> fallback = BuildFormsPropertyDefaultsFallback(component, instance);
 
         foreach (ElementBehaviorReference reference in component.Behaviors)
         {
@@ -57,12 +55,12 @@ public static class BehaviorToolOnlyReferencesApplier
 
             foreach (string referenceLine in behavior.ToolOnlyVariableReferences)
             {
-                ApplyLine(referenceLine, instance, stateSave);
+                ApplyLine(referenceLine, instance, stateSave, fallback);
             }
         }
     }
 
-    private static void ApplyLine(string referenceLine, InstanceSave? instance, StateSave stateSave)
+    private static void ApplyLine(string referenceLine, InstanceSave? instance, StateSave stateSave, Func<string, object?> fallback)
     {
         if (string.IsNullOrWhiteSpace(referenceLine) || referenceLine.TrimStart().StartsWith("//"))
         {
@@ -85,7 +83,7 @@ public static class BehaviorToolOnlyReferencesApplier
 
         string rightAsCSharp = EvaluatedSyntax.ConvertToCSharpSyntax(right);
         ExpressionSyntax rightSyntax = SyntaxFactory.ParseExpression(rightAsCSharp);
-        EvaluatedSyntax? evaluated = EvaluatedSyntax.FromSyntaxNode(rightSyntax, stateSave);
+        EvaluatedSyntax? evaluated = EvaluatedSyntax.FromSyntaxNode(rightSyntax, stateSave, fallback);
         if (evaluated?.Value == null)
         {
             return;
@@ -93,6 +91,44 @@ public static class BehaviorToolOnlyReferencesApplier
 
         string effectiveLeft = instance == null ? left : $"{instance.Name}.{left}";
         stateSave.SetValue(effectiveLeft, evaluated.Value, instance);
+    }
+
+    /// <summary>
+    /// Builds a name-resolver that looks up bare or instance-qualified identifiers
+    /// against every linked behavior's <c>FormsProperty</c> declarations on
+    /// <paramref name="component"/>, returning the declared <c>Value</c>. Used by
+    /// <see cref="EvaluatedSyntax.FromSyntaxNode"/> as a fallback when the state
+    /// has no authored value — so a behavior-declared default (e.g. IsEnabled = true)
+    /// flows through to the wireframe preview without polluting the saved state.
+    /// </summary>
+    private static Func<string, object?> BuildFormsPropertyDefaultsFallback(ComponentSave component, InstanceSave? instance)
+    {
+        string? instancePrefix = instance != null ? instance.Name + "." : null;
+        return name =>
+        {
+            string lookupName = instancePrefix != null && name.StartsWith(instancePrefix)
+                ? name.Substring(instancePrefix.Length)
+                : name;
+
+            foreach (ElementBehaviorReference reference in component.Behaviors)
+            {
+                BehaviorSave? behavior = ObjectFinder.Self.GetBehavior(reference);
+                if (behavior == null)
+                {
+                    continue;
+                }
+
+                foreach (VariableSave declaration in behavior.FormsProperties)
+                {
+                    if (declaration.Name == lookupName)
+                    {
+                        return declaration.Value;
+                    }
+                }
+            }
+
+            return null;
+        };
     }
 
     /// <summary>

--- a/Gum/Plugins/InternalPlugins/VariableGrid/ElementSaveDisplayer.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/ElementSaveDisplayer.cs
@@ -678,6 +678,14 @@ public class ElementSaveDisplayer
                     _setVariableLogic,
                     _wireframeObjectManager);
 
+                // Surface the behavior's declared default (FormsProperty.Value) so the grid
+                // reflects e.g. IsEnabled = true even before the user authors anything. The
+                // closure captures the FormsProperty so a future .behx edit (after reload)
+                // is picked up; the captured reference doesn't go stale because the SRIM
+                // is rebuilt whenever the variable grid recomputes.
+                VariableSave declaration = formsProperty;
+                srim.DefaultValueFallback = () => declaration.Value;
+
                 behaviorCategory.Members.Add(srim);
             }
         }

--- a/Gum/Plugins/InternalPlugins/VariableGrid/StateReferencingInstanceMember.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/StateReferencingInstanceMember.cs
@@ -51,6 +51,14 @@ public class StateReferencingInstanceMember : InstanceMember
 
     public object LastOldFullCommitValue { get; private set; }
 
+    /// <summary>
+    /// Optional fallback consulted by the value getter when neither the selected
+    /// state nor any inherited state has a value for this variable. Used by the
+    /// behavior-FormsProperty surfacing path so a declared default (e.g.
+    /// <c>IsEnabled = true</c>) appears in the grid without writing into state.
+    /// </summary>
+    public Func<object?>? DefaultValueFallback { get; set; }
+
     Attribute[] _attributes;
     TypeConverter? _converter;
     Type? _componentType;
@@ -715,7 +723,15 @@ public class StateReferencingInstanceMember : InstanceMember
                 }
             }
 
-            // we want to do this by value:
+            // Final tier: behavior-promoted FormsProperty defaults. When neither the
+            // selected state nor any inherited state authors a value, fall back to the
+            // declared FormsProperty.Value so the grid reflects the implicit default
+            // (e.g. IsEnabled = true) without polluting state. IsDefault remains true
+            // because nothing is explicitly authored.
+            if (toReturn == null)
+            {
+                toReturn = DefaultValueFallback?.Invoke();
+            }
 
             return toReturn;
         }

--- a/Gum/Plugins/InternalPlugins/VariableGrid/VariableReferenceLogic.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/VariableReferenceLogic.cs
@@ -462,6 +462,12 @@ public class VariableReferenceLogic : IVariableReferenceLogic
         // apply references on this element first, then apply the values to the other references:
         ElementSaveExtensions.ApplyVariableReferences(parentElement, stateSave);
 
+        // Then evaluate any behavior-level ToolOnlyVariableReferences so design-time
+        // wireframe preview reflects FormsProperty values (e.g. IsEnabled = false →
+        // ButtonCategoryState = "Disabled"). Tool-only by design — never invoked at
+        // runtime, since the Forms control's own setter owns the visual at runtime.
+        BehaviorToolOnlyReferencesApplier.Apply(parentElement, stateSave);
+
         if (unqualifiedMember == "VariableReferences")
         {
             _guiCommands.RefreshVariableValues();

--- a/GumDataTypes/Behaviors/BehaviorSave.cs
+++ b/GumDataTypes/Behaviors/BehaviorSave.cs
@@ -32,6 +32,16 @@ namespace Gum.DataTypes.Behaviors
         [XmlElement("FormsProperty")]
         public List<VariableSave> FormsProperties { get; set; } = new List<VariableSave>();
 
+        /// <summary>
+        /// Variable reference assignments (e.g. <c>ButtonCategoryState = IsEnabled ? "Enabled" : "Disabled"</c>)
+        /// that the Gum tool evaluates at design time to drive wireframe preview from <see cref="FormsProperties"/>.
+        /// Unlike state-level <c>VariableReferences</c>, these are NEVER traversed by the runtime apply pass —
+        /// at runtime the Forms control's own setter (e.g. <c>FrameworkElement.IsEnabled</c>) owns the visual
+        /// state, so applying them again would double-write. Structural separation by name is the contract.
+        /// </summary>
+        [XmlElement("ToolOnlyVariableReference")]
+        public List<string> ToolOnlyVariableReferences { get; set; } = new List<string>();
+
         IList<StateSaveCategory> IStateContainer.Categories => Categories;
         [XmlElement("Category")]
         public List<StateSaveCategory> Categories { get; set; } = new List<StateSaveCategory>();

--- a/GumRuntime/ElementSaveExtensions.GumRuntime.cs
+++ b/GumRuntime/ElementSaveExtensions.GumRuntime.cs
@@ -665,14 +665,23 @@ namespace GumRuntime
             }
         }
 
-        struct VariableReferenceAssignmentResult
+        public struct VariableReferenceAssignmentResult
         {
             public string VariableName;
             public object OldValue;
             public object NewValue;
         }
 
-        private static VariableReferenceAssignmentResult ApplyVariableReferencesOnSpecificOwner(InstanceSave instanceLeft, string referenceString, StateSave stateSave)
+        /// <summary>
+        /// Evaluates a single reference line (e.g. <c>X = SomeOther.X</c>) against
+        /// <paramref name="stateSave"/>, qualifying the left side with
+        /// <paramref name="instanceLeft"/>'s name when present, and writes the result
+        /// back into the state. Used by both state-level <c>VariableReferences</c>
+        /// application and (tool-only) behavior <c>ToolOnlyVariableReferences</c>
+        /// application. Returns the resulting variable name + old/new values so callers
+        /// can fire change notifications.
+        /// </summary>
+        public static VariableReferenceAssignmentResult ApplyVariableReferencesOnSpecificOwner(InstanceSave instanceLeft, string referenceString, StateSave stateSave)
         {
 
             //////////////////////////////Early Out/////////////////////////////////

--- a/MonoGameGum.Tests/DataTypes/GumFileSerializerTests.cs
+++ b/MonoGameGum.Tests/DataTypes/GumFileSerializerTests.cs
@@ -74,6 +74,39 @@ public class GumFileSerializerTests
     }
 
     [Fact]
+    public void DeserializeBehaviorSave_LegacyFormat_LoadsFormsPropertyDefaultBoolValue()
+    {
+        BehaviorSave original = new BehaviorSave();
+        original.FormsProperties.Add(new VariableSave { Type = "bool", Name = "IsEnabled", Value = true });
+
+        FileManager.XmlSerialize(original, out string xml);
+
+        BehaviorSave? result = GumFileSerializer.DeserializeBehaviorSave(xml, projectVersion: 2);
+
+        result.ShouldNotBeNull();
+        result.FormsProperties.Count.ShouldBe(1);
+        result.FormsProperties[0].Type.ShouldBe("bool");
+        result.FormsProperties[0].Name.ShouldBe("IsEnabled");
+        result.FormsProperties[0].Value.ShouldBe(true);
+    }
+
+    [Fact]
+    public void DeserializeBehaviorSave_CompactFormat_LoadsFormsPropertyDefaultBoolValue()
+    {
+        BehaviorSave original = new BehaviorSave();
+        original.FormsProperties.Add(new VariableSave { Type = "bool", Name = "IsEnabled", Value = true });
+
+        XmlSerializer compactSerializer = GumFileSerializer.GetCompactSerializer(typeof(BehaviorSave));
+        string xml = SerializeToString(compactSerializer, original);
+
+        BehaviorSave? result = GumFileSerializer.DeserializeBehaviorSave(xml, projectVersion: 2);
+
+        result.ShouldNotBeNull();
+        result.FormsProperties.Count.ShouldBe(1);
+        result.FormsProperties[0].Value.ShouldBe(true);
+    }
+
+    [Fact]
     public void DeserializeBehaviorSave_LegacyFormat_LoadsToolOnlyVariableReferences()
     {
         BehaviorSave original = new BehaviorSave();

--- a/MonoGameGum.Tests/DataTypes/GumFileSerializerTests.cs
+++ b/MonoGameGum.Tests/DataTypes/GumFileSerializerTests.cs
@@ -74,6 +74,48 @@ public class GumFileSerializerTests
     }
 
     [Fact]
+    public void DeserializeBehaviorSave_LegacyFormat_LoadsToolOnlyVariableReferences()
+    {
+        BehaviorSave original = new BehaviorSave();
+        original.ToolOnlyVariableReferences.Add("ButtonCategoryState = IsEnabled ? \"Enabled\" : \"Disabled\"");
+
+        FileManager.XmlSerialize(original, out string xml);
+
+        BehaviorSave? result = GumFileSerializer.DeserializeBehaviorSave(xml, projectVersion: 2);
+
+        result.ShouldNotBeNull();
+        result.ToolOnlyVariableReferences.Count.ShouldBe(1);
+        result.ToolOnlyVariableReferences[0].ShouldBe("ButtonCategoryState = IsEnabled ? \"Enabled\" : \"Disabled\"");
+    }
+
+    [Fact]
+    public void DeserializeBehaviorSave_CompactFormat_LoadsToolOnlyVariableReferences()
+    {
+        BehaviorSave original = new BehaviorSave();
+        original.FormsProperties.Add(new VariableSave { Type = "bool", Name = "IsEnabled", Value = true });
+        original.ToolOnlyVariableReferences.Add("ButtonCategoryState = IsEnabled ? \"Enabled\" : \"Disabled\"");
+
+        XmlSerializer compactSerializer = GumFileSerializer.GetCompactSerializer(typeof(BehaviorSave));
+        string xml = SerializeToString(compactSerializer, original);
+
+        BehaviorSave? result = GumFileSerializer.DeserializeBehaviorSave(xml, projectVersion: 2);
+
+        result.ShouldNotBeNull();
+        result.ToolOnlyVariableReferences.Count.ShouldBe(1);
+        result.ToolOnlyVariableReferences[0].ShouldBe("ButtonCategoryState = IsEnabled ? \"Enabled\" : \"Disabled\"");
+    }
+
+    [Fact]
+    public void SerializeBehaviorSave_EmptyToolOnlyVariableReferences_OmittedFromXml()
+    {
+        BehaviorSave original = new BehaviorSave();
+
+        FileManager.XmlSerialize(original, out string xml);
+
+        xml.ShouldNotContain("<ToolOnlyVariableReference");
+    }
+
+    [Fact]
     public void DeserializeBehaviorSave_CompactFormat_LoadsFormsProperties()
     {
         BehaviorSave original = new BehaviorSave();

--- a/MonoGameGum.Tests/Forms/BehaviorFormsPropertyApplyTests.cs
+++ b/MonoGameGum.Tests/Forms/BehaviorFormsPropertyApplyTests.cs
@@ -56,6 +56,35 @@ public class BehaviorFormsPropertyApplyTests : BaseTestClass
     }
 
     [Fact]
+    public void Apply_NeitherComponentNorParentDefinesValue_FallsBackToBehaviorFormsPropertyValue()
+    {
+        BehaviorSave behavior = new BehaviorSave { Name = "ButtonBehavior" };
+        behavior.FormsProperties.Add(new VariableSave
+        {
+            Type = "string",
+            Name = "ToolTip",
+            Value = "behavior default tooltip"
+        });
+
+        ComponentSave component = new ComponentSave { Name = "Controls/ButtonStandard", BaseType = "Container" };
+        component.States.Add(new StateSave { Name = "Default", ParentContainer = component });
+        component.Behaviors.Add(new ElementBehaviorReference { BehaviorName = "ButtonBehavior" });
+
+        GumProjectSave project = new GumProjectSave();
+        project.Components.Add(component);
+        project.Behaviors.Add(behavior);
+        ObjectFinder.Self.GumProjectSave = project;
+
+        InteractiveGue visual = new InteractiveGue();
+        visual.ElementSave = component;
+
+        Button button = new Button(visual);
+        BehaviorFormsPropertyApplier.Apply(button, visual);
+
+        button.ToolTip.ShouldBe("behavior default tooltip");
+    }
+
+    [Fact]
     public void Apply_ParentScreenInstanceOverride_OverridesComponentDefault()
     {
         BehaviorSave behavior = new BehaviorSave { Name = "ButtonBehavior" };

--- a/MonoGameGum/Forms/BehaviorFormsPropertyApplier.cs
+++ b/MonoGameGum/Forms/BehaviorFormsPropertyApplier.cs
@@ -41,7 +41,11 @@ internal static class BehaviorFormsPropertyApplier
                 continue;
             }
 
-            object? value = ReadEffectiveValue(visual!, declaration.Name);
+            // Tier order: parent-instance override → own default → behavior FormsProperty
+            // default. The third tier lets a behavior's declared default carry through when
+            // neither component nor parent state authors a value (mirrors WPF
+            // DependencyProperty.PropertyMetadata.DefaultValue).
+            object? value = ReadEffectiveValue(visual!, declaration.Name) ?? declaration.Value;
             if (value == null)
             {
                 continue;

--- a/Runtimes/GumExpressions/EvaluatedSyntax.cs
+++ b/Runtimes/GumExpressions/EvaluatedSyntax.cs
@@ -39,20 +39,25 @@ public class EvaluatedSyntax
 
     #region Parse
 
-    public static EvaluatedSyntax FromSyntaxNode(SyntaxNode syntaxNode, StateSave stateForUnqualifiedRightSide)
+    /// <param name="fallback">Optional resolver consulted when a bare identifier
+    /// or member-access lookup against <paramref name="stateForUnqualifiedRightSide"/>
+    /// returns null. The Forms-property-promotion apply pipeline uses this to fall
+    /// back to a linked behavior's <c>FormsProperty.Value</c> declarations when no
+    /// state authors a value (mirrors WPF DependencyProperty default values).</param>
+    public static EvaluatedSyntax FromSyntaxNode(SyntaxNode syntaxNode, StateSave stateForUnqualifiedRightSide, Func<string, object?>? fallback = null)
     {
-        return Evaluate(syntaxNode, stateForUnqualifiedRightSide);
+        return Evaluate(syntaxNode, stateForUnqualifiedRightSide, fallback);
     }
 
-    private static EvaluatedSyntax Evaluate(SyntaxNode syntaxNode, StateSave stateForUnqualifiedRightSide)
+    private static EvaluatedSyntax Evaluate(SyntaxNode syntaxNode, StateSave stateForUnqualifiedRightSide, Func<string, object?>? fallback = null)
     {
         if (syntaxNode is BinaryExpressionSyntax binaryExpressionSytax)
         {
             var leftSyntax = binaryExpressionSytax.Left;
             var rightSyntax = binaryExpressionSytax.Right;
 
-            var leftEvaluated = Evaluate(leftSyntax, stateForUnqualifiedRightSide);
-            var rightEvaluated = Evaluate(rightSyntax, stateForUnqualifiedRightSide);
+            var leftEvaluated = Evaluate(leftSyntax, stateForUnqualifiedRightSide, fallback);
+            var rightEvaluated = Evaluate(rightSyntax, stateForUnqualifiedRightSide, fallback);
 
             var value = Combine(leftEvaluated, rightEvaluated, binaryExpressionSytax.OperatorToken);
 
@@ -69,7 +74,7 @@ public class EvaluatedSyntax
 
             foreach (var item in childNodes)
             {
-                var evaluatedSyntax = Evaluate(item, stateForUnqualifiedRightSide);
+                var evaluatedSyntax = Evaluate(item, stateForUnqualifiedRightSide, fallback);
                 if (evaluatedSyntax != null)
                 {
                     return evaluatedSyntax;
@@ -79,7 +84,7 @@ public class EvaluatedSyntax
         }
         else if (syntaxNode is IdentifierNameSyntax or VariableDeclarationSyntax)
         {
-            var rfv = new RecursiveVariableFinder(stateForUnqualifiedRightSide);
+            var rfv = new RecursiveVariableFinder(stateForUnqualifiedRightSide) { Fallback = fallback };
 
             var value = rfv.GetValue(syntaxNode.ToString());
 
@@ -114,7 +119,7 @@ public class EvaluatedSyntax
             }
             else
             {
-                rfv = new RecursiveVariableFinder(stateForRfv);
+                rfv = new RecursiveVariableFinder(stateForRfv) { Fallback = fallback };
 
                 var value = rfv.GetValue(rightSideToEvaluate);
 
@@ -124,11 +129,11 @@ public class EvaluatedSyntax
         }
         else if (syntaxNode is ConditionalExpressionSyntax conditional)
         {
-            var conditionEvaluated = Evaluate(conditional.Condition, stateForUnqualifiedRightSide);
+            var conditionEvaluated = Evaluate(conditional.Condition, stateForUnqualifiedRightSide, fallback);
             if (conditionEvaluated?.Value is bool conditionValue)
             {
                 var branch = conditionValue ? conditional.WhenTrue : conditional.WhenFalse;
-                var branchEvaluated = Evaluate(branch, stateForUnqualifiedRightSide);
+                var branchEvaluated = Evaluate(branch, stateForUnqualifiedRightSide, fallback);
                 if (branchEvaluated != null)
                 {
                     return FromSyntaxAndValue(syntaxNode, branchEvaluated.Value);
@@ -140,7 +145,7 @@ public class EvaluatedSyntax
         {
             if (prefixUnary.OperatorToken.IsKind(Microsoft.CodeAnalysis.CSharp.SyntaxKind.ExclamationToken))
             {
-                var operand = Evaluate(prefixUnary.Operand, stateForUnqualifiedRightSide);
+                var operand = Evaluate(prefixUnary.Operand, stateForUnqualifiedRightSide, fallback);
                 if (operand?.Value is bool b)
                 {
                     return FromSyntaxAndValue(syntaxNode, !b);
@@ -167,7 +172,7 @@ public class EvaluatedSyntax
 
             foreach (var item in childNodes)
             {
-                var evaluatedSyntax = Evaluate(item, stateForUnqualifiedRightSide);
+                var evaluatedSyntax = Evaluate(item, stateForUnqualifiedRightSide, fallback);
                 if (evaluatedSyntax != null)
                 {
                     return evaluatedSyntax;
@@ -185,7 +190,7 @@ public class EvaluatedSyntax
 
             foreach (var item in childNodes)
             {
-                var evaluatedSyntax = Evaluate(item, stateForUnqualifiedRightSide);
+                var evaluatedSyntax = Evaluate(item, stateForUnqualifiedRightSide, fallback);
                 if (evaluatedSyntax != null)
                 {
                     return evaluatedSyntax;

--- a/Tool/Tests/GumToolUnitTests/PropertyGridHelpers/ElementSaveDisplayerFormsPropertiesTests.cs
+++ b/Tool/Tests/GumToolUnitTests/PropertyGridHelpers/ElementSaveDisplayerFormsPropertiesTests.cs
@@ -106,6 +106,43 @@ public class ElementSaveDisplayerFormsPropertiesTests : BaseTestClass
     }
 
     [Fact]
+    public void AddBehaviorFormsPropertyMembers_StateMissingValue_MemberValueFallsBackToBehaviorFormsPropertyDefault()
+    {
+        // Behavior declares IsEnabled with default true; component's default state authors nothing.
+        BehaviorSave behaviorWithDefault = new BehaviorSave { Name = "WithDefault" };
+        behaviorWithDefault.FormsProperties.Add(new VariableSave
+        {
+            Type = "bool",
+            Name = "IsEnabled",
+            Value = true
+        });
+
+        ComponentSave component = new ComponentSave { Name = "Controls/PlainButton", BaseType = "Container" };
+        component.States.Add(new StateSave { Name = "Default", ParentContainer = component });
+        component.Behaviors.Add(new ElementBehaviorReference { BehaviorName = "WithDefault" });
+
+        _project.Behaviors.Add(behaviorWithDefault);
+        _project.Components.Add(component);
+
+        List<MemberCategory> categories = new List<MemberCategory>();
+
+        _displayer.AddBehaviorFormsPropertyMembers(
+            elementWithBehaviors: component,
+            instanceOwner: component,
+            instance: null,
+            stateSave: component.DefaultState,
+            stateSaveCategory: null,
+            categories: categories);
+
+        MemberCategory? behaviorCategory = categories.FirstOrDefault(c => c.Name == "Behavior");
+        behaviorCategory.ShouldNotBeNull();
+        InstanceMember? isEnabledMember = behaviorCategory.Members.FirstOrDefault(m => m.Name == "IsEnabled");
+        isEnabledMember.ShouldNotBeNull();
+        isEnabledMember.Value.ShouldBe(true,
+            "with no value authored on state, the variable grid should display the behavior's declared FormsProperty default");
+    }
+
+    [Fact]
     public void AddBehaviorFormsPropertyMembers_FormsPropertyWithNullName_SilentlySkippedNoCrash()
     {
         // Reproduces the v1 (legacy) gumx scenario where the standard XmlSerializer

--- a/Tool/Tests/GumToolUnitTests/VariableGrid/BehaviorToolOnlyReferencesApplierTests.cs
+++ b/Tool/Tests/GumToolUnitTests/VariableGrid/BehaviorToolOnlyReferencesApplierTests.cs
@@ -131,6 +131,69 @@ public class BehaviorToolOnlyReferencesApplierTests : BaseTestClass
     }
 
     [Fact]
+    public void Apply_StateMissingIdentifier_FallsBackToBehaviorFormsPropertyDefault()
+    {
+        BehaviorSave behavior = new BehaviorSave { Name = "ButtonBehavior" };
+        behavior.FormsProperties.Add(new VariableSave
+        {
+            Type = "bool",
+            Name = "IsEnabled",
+            Value = false  // declared default, drives the wireframe to "Disabled" with no instance authoring
+        });
+        behavior.ToolOnlyVariableReferences.Add(
+            "ButtonCategoryState = IsEnabled ? \"Enabled\" : \"Disabled\"");
+
+        ComponentSave component = new ComponentSave { Name = "Controls/ButtonStandard", BaseType = "Container" };
+        StateSave defaultState = new StateSave { Name = "Default", ParentContainer = component };
+        component.States.Add(defaultState);
+        component.Behaviors.Add(new ElementBehaviorReference { BehaviorName = "ButtonBehavior" });
+
+        GumProjectSave project = new GumProjectSave();
+        project.Components.Add(component);
+        project.Behaviors.Add(behavior);
+        ObjectFinder.Self.GumProjectSave = project;
+
+        BehaviorToolOnlyReferencesApplier.Apply(component, defaultState);
+
+        defaultState.GetValue("ButtonCategoryState").ShouldBe("Disabled");
+    }
+
+    [Fact]
+    public void Apply_StateAuthoredValue_OverridesBehaviorFormsPropertyDefault()
+    {
+        BehaviorSave behavior = new BehaviorSave { Name = "ButtonBehavior" };
+        behavior.FormsProperties.Add(new VariableSave
+        {
+            Type = "bool",
+            Name = "IsEnabled",
+            Value = true
+        });
+        behavior.ToolOnlyVariableReferences.Add(
+            "ButtonCategoryState = IsEnabled ? \"Enabled\" : \"Disabled\"");
+
+        ComponentSave component = new ComponentSave { Name = "Controls/ButtonStandard", BaseType = "Container" };
+        StateSave defaultState = new StateSave { Name = "Default", ParentContainer = component };
+        defaultState.Variables.Add(new VariableSave
+        {
+            Type = "bool",
+            Name = "IsEnabled",
+            Value = false,
+            SetsValue = true
+        });
+        component.States.Add(defaultState);
+        component.Behaviors.Add(new ElementBehaviorReference { BehaviorName = "ButtonBehavior" });
+
+        GumProjectSave project = new GumProjectSave();
+        project.Components.Add(component);
+        project.Behaviors.Add(behavior);
+        ObjectFinder.Self.GumProjectSave = project;
+
+        BehaviorToolOnlyReferencesApplier.Apply(component, defaultState);
+
+        defaultState.GetValue("ButtonCategoryState").ShouldBe("Disabled");
+    }
+
+    [Fact]
     public void Apply_BehaviorWithoutToolOnlyReferences_DoesNothing()
     {
         BehaviorSave behavior = new BehaviorSave { Name = "ButtonBehavior" };

--- a/Tool/Tests/GumToolUnitTests/VariableGrid/BehaviorToolOnlyReferencesApplierTests.cs
+++ b/Tool/Tests/GumToolUnitTests/VariableGrid/BehaviorToolOnlyReferencesApplierTests.cs
@@ -1,0 +1,152 @@
+using Gum.DataTypes;
+using Gum.DataTypes.Behaviors;
+using Gum.DataTypes.Variables;
+using Gum.Expressions;
+using Gum.Managers;
+using Gum.Plugins.InternalPlugins.VariableGrid;
+using GumRuntime;
+using Shouldly;
+
+namespace GumToolUnitTests.VariableGrid;
+
+public class BehaviorToolOnlyReferencesApplierTests : BaseTestClass
+{
+    public BehaviorToolOnlyReferencesApplierTests()
+    {
+        GumExpressionService.Initialize();
+    }
+
+    public override void Dispose()
+    {
+        ElementSaveExtensions.CustomEvaluateExpression = null;
+        ElementSaveExtensions.VariableChangedThroughReference = null;
+        base.Dispose();
+    }
+
+    [Fact]
+    public void Apply_ComponentDefaultStateWithIsEnabledFalse_WritesDisabledCategoryState()
+    {
+        BehaviorSave behavior = new BehaviorSave { Name = "ButtonBehavior" };
+        behavior.FormsProperties.Add(new VariableSave { Type = "bool", Name = "IsEnabled" });
+        behavior.ToolOnlyVariableReferences.Add(
+            "ButtonCategoryState = IsEnabled ? \"Enabled\" : \"Disabled\"");
+
+        ComponentSave component = new ComponentSave { Name = "Controls/ButtonStandard", BaseType = "Container" };
+        StateSave defaultState = new StateSave { Name = "Default", ParentContainer = component };
+        defaultState.Variables.Add(new VariableSave
+        {
+            Type = "bool",
+            Name = "IsEnabled",
+            Value = false,
+            SetsValue = true
+        });
+        component.States.Add(defaultState);
+        component.Behaviors.Add(new ElementBehaviorReference { BehaviorName = "ButtonBehavior" });
+
+        GumProjectSave project = new GumProjectSave();
+        project.Components.Add(component);
+        project.Behaviors.Add(behavior);
+        ObjectFinder.Self.GumProjectSave = project;
+
+        BehaviorToolOnlyReferencesApplier.Apply(component, defaultState);
+
+        defaultState.GetValue("ButtonCategoryState").ShouldBe("Disabled");
+    }
+
+    [Fact]
+    public void Apply_ComponentDefaultStateWithIsEnabledTrue_WritesEnabledCategoryState()
+    {
+        BehaviorSave behavior = new BehaviorSave { Name = "ButtonBehavior" };
+        behavior.FormsProperties.Add(new VariableSave { Type = "bool", Name = "IsEnabled" });
+        behavior.ToolOnlyVariableReferences.Add(
+            "ButtonCategoryState = IsEnabled ? \"Enabled\" : \"Disabled\"");
+
+        ComponentSave component = new ComponentSave { Name = "Controls/ButtonStandard", BaseType = "Container" };
+        StateSave defaultState = new StateSave { Name = "Default", ParentContainer = component };
+        defaultState.Variables.Add(new VariableSave
+        {
+            Type = "bool",
+            Name = "IsEnabled",
+            Value = true,
+            SetsValue = true
+        });
+        component.States.Add(defaultState);
+        component.Behaviors.Add(new ElementBehaviorReference { BehaviorName = "ButtonBehavior" });
+
+        GumProjectSave project = new GumProjectSave();
+        project.Components.Add(component);
+        project.Behaviors.Add(behavior);
+        ObjectFinder.Self.GumProjectSave = project;
+
+        BehaviorToolOnlyReferencesApplier.Apply(component, defaultState);
+
+        defaultState.GetValue("ButtonCategoryState").ShouldBe("Enabled");
+    }
+
+    [Fact]
+    public void Apply_ScreenWithButtonInstanceIsEnabledFalse_WritesQualifiedDisabledCategoryState()
+    {
+        BehaviorSave behavior = new BehaviorSave { Name = "ButtonBehavior" };
+        behavior.FormsProperties.Add(new VariableSave { Type = "bool", Name = "IsEnabled" });
+        behavior.ToolOnlyVariableReferences.Add(
+            "ButtonCategoryState = IsEnabled ? \"Enabled\" : \"Disabled\"");
+
+        ComponentSave component = new ComponentSave { Name = "Controls/ButtonStandard", BaseType = "Container" };
+        component.States.Add(new StateSave { Name = "Default", ParentContainer = component });
+        component.Behaviors.Add(new ElementBehaviorReference { BehaviorName = "ButtonBehavior" });
+
+        ScreenSave screen = new ScreenSave { Name = "TestScreen" };
+        StateSave screenDefault = new StateSave { Name = "Default", ParentContainer = screen };
+        screen.States.Add(screenDefault);
+
+        InstanceSave buttonInstance = new InstanceSave
+        {
+            Name = "ButtonInstance",
+            BaseType = "Controls/ButtonStandard",
+            ParentContainer = screen
+        };
+        screen.Instances.Add(buttonInstance);
+
+        screenDefault.Variables.Add(new VariableSave
+        {
+            Type = "bool",
+            Name = "ButtonInstance.IsEnabled",
+            Value = false,
+            SetsValue = true
+        });
+
+        StandardElementSave containerStandard = new StandardElementSave { Name = "Container" };
+        containerStandard.States.Add(new StateSave { Name = "Default", ParentContainer = containerStandard });
+
+        GumProjectSave project = new GumProjectSave();
+        project.StandardElements.Add(containerStandard);
+        project.Components.Add(component);
+        project.Screens.Add(screen);
+        project.Behaviors.Add(behavior);
+        ObjectFinder.Self.GumProjectSave = project;
+
+        BehaviorToolOnlyReferencesApplier.Apply(screen, screenDefault);
+
+        screenDefault.GetValue("ButtonInstance.ButtonCategoryState").ShouldBe("Disabled");
+    }
+
+    [Fact]
+    public void Apply_BehaviorWithoutToolOnlyReferences_DoesNothing()
+    {
+        BehaviorSave behavior = new BehaviorSave { Name = "ButtonBehavior" };
+        behavior.FormsProperties.Add(new VariableSave { Type = "string", Name = "ToolTip" });
+
+        ComponentSave component = new ComponentSave { Name = "Controls/ButtonStandard", BaseType = "Container" };
+        StateSave defaultState = new StateSave { Name = "Default", ParentContainer = component };
+        component.States.Add(defaultState);
+        component.Behaviors.Add(new ElementBehaviorReference { BehaviorName = "ButtonBehavior" });
+
+        GumProjectSave project = new GumProjectSave();
+        project.Components.Add(component);
+        project.Behaviors.Add(behavior);
+        ObjectFinder.Self.GumProjectSave = project;
+
+        Should.NotThrow(() => BehaviorToolOnlyReferencesApplier.Apply(component, defaultState));
+        defaultState.Variables.ShouldBeEmpty();
+    }
+}

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/ButtonBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/ButtonBehavior.behx
@@ -3,6 +3,8 @@
   <Name>ButtonBehavior</Name>
   <RequiredVariables />
   <FormsProperty Type="string" Name="ToolTip" />
+  <FormsProperty Type="bool" Name="IsEnabled" />
+  <ToolOnlyVariableReference>ButtonCategoryState = IsEnabled ? "Enabled" : "Disabled"</ToolOnlyVariableReference>
   <Category>
     <Name>ButtonCategory</Name>
     <State>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/ButtonBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/ButtonBehavior.behx
@@ -3,7 +3,9 @@
   <Name>ButtonBehavior</Name>
   <RequiredVariables />
   <FormsProperty Type="string" Name="ToolTip" />
-  <FormsProperty Type="bool" Name="IsEnabled" />
+  <FormsProperty Type="bool" Name="IsEnabled">
+    <Value xsi:type="xsd:boolean">true</Value>
+  </FormsProperty>
   <ToolOnlyVariableReference>ButtonCategoryState = IsEnabled ? "Enabled" : "Disabled"</ToolOnlyVariableReference>
   <Category>
     <Name>ButtonCategory</Name>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/CheckBoxBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/CheckBoxBehavior.behx
@@ -3,6 +3,8 @@
   <Name>CheckBoxBehavior</Name>
   <RequiredVariables />
   <FormsProperty Type="string" Name="ToolTip" />
+  <FormsProperty Type="bool" Name="IsEnabled" />
+  <ToolOnlyVariableReference>CheckBoxCategoryState = IsEnabled ? "EnabledOff" : "DisabledOff"</ToolOnlyVariableReference>
   <Category>
     <Name>CheckBoxCategory</Name>
     <State>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/CheckBoxBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/CheckBoxBehavior.behx
@@ -3,7 +3,9 @@
   <Name>CheckBoxBehavior</Name>
   <RequiredVariables />
   <FormsProperty Type="string" Name="ToolTip" />
-  <FormsProperty Type="bool" Name="IsEnabled" />
+  <FormsProperty Type="bool" Name="IsEnabled">
+    <Value xsi:type="xsd:boolean">true</Value>
+  </FormsProperty>
   <ToolOnlyVariableReference>CheckBoxCategoryState = IsEnabled ? "EnabledOff" : "DisabledOff"</ToolOnlyVariableReference>
   <Category>
     <Name>CheckBoxCategory</Name>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/ComboBoxBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/ComboBoxBehavior.behx
@@ -3,7 +3,9 @@
   <Name>ComboBoxBehavior</Name>
   <RequiredVariables />
   <FormsProperty Type="string" Name="ToolTip" />
-  <FormsProperty Type="bool" Name="IsEnabled" />
+  <FormsProperty Type="bool" Name="IsEnabled">
+    <Value xsi:type="xsd:boolean">true</Value>
+  </FormsProperty>
   <ToolOnlyVariableReference>ComboBoxCategoryState = IsEnabled ? "Enabled" : "Disabled"</ToolOnlyVariableReference>
   <Category>
     <Name>ComboBoxCategory</Name>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/ComboBoxBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/ComboBoxBehavior.behx
@@ -3,6 +3,8 @@
   <Name>ComboBoxBehavior</Name>
   <RequiredVariables />
   <FormsProperty Type="string" Name="ToolTip" />
+  <FormsProperty Type="bool" Name="IsEnabled" />
+  <ToolOnlyVariableReference>ComboBoxCategoryState = IsEnabled ? "Enabled" : "Disabled"</ToolOnlyVariableReference>
   <Category>
     <Name>ComboBoxCategory</Name>
     <State>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/DialogBoxBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/DialogBoxBehavior.behx
@@ -3,7 +3,9 @@
   <Name>DialogBoxBehavior</Name>
   <RequiredVariables />
   <FormsProperty Type="string" Name="ToolTip" />
-  <FormsProperty Type="bool" Name="IsEnabled" />
+  <FormsProperty Type="bool" Name="IsEnabled">
+    <Value xsi:type="xsd:boolean">true</Value>
+  </FormsProperty>
   <RequiredInstances />
   <RequiredAnimations />
   <DefaultImplementation>Controls/DialogBox</DefaultImplementation>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/DialogBoxBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/DialogBoxBehavior.behx
@@ -3,6 +3,7 @@
   <Name>DialogBoxBehavior</Name>
   <RequiredVariables />
   <FormsProperty Type="string" Name="ToolTip" />
+  <FormsProperty Type="bool" Name="IsEnabled" />
   <RequiredInstances />
   <RequiredAnimations />
   <DefaultImplementation>Controls/DialogBox</DefaultImplementation>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/InputDeviceSelectionItemBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/InputDeviceSelectionItemBehavior.behx
@@ -3,6 +3,7 @@
   <Name>InputDeviceSelectionItemBehavior</Name>
   <RequiredVariables />
   <FormsProperty Type="string" Name="ToolTip" />
+  <FormsProperty Type="bool" Name="IsEnabled" />
   <Category>
     <Name>JoinedCategory</Name>
     <IsSetRecursively>false</IsSetRecursively>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/InputDeviceSelectionItemBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/InputDeviceSelectionItemBehavior.behx
@@ -3,7 +3,9 @@
   <Name>InputDeviceSelectionItemBehavior</Name>
   <RequiredVariables />
   <FormsProperty Type="string" Name="ToolTip" />
-  <FormsProperty Type="bool" Name="IsEnabled" />
+  <FormsProperty Type="bool" Name="IsEnabled">
+    <Value xsi:type="xsd:boolean">true</Value>
+  </FormsProperty>
   <Category>
     <Name>JoinedCategory</Name>
     <IsSetRecursively>false</IsSetRecursively>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/InputDeviceSelectorBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/InputDeviceSelectorBehavior.behx
@@ -3,6 +3,7 @@
   <Name>InputDeviceSelectorBehavior</Name>
   <RequiredVariables />
   <FormsProperty Type="string" Name="ToolTip" />
+  <FormsProperty Type="bool" Name="IsEnabled" />
   <RequiredInstances>
     <InstanceSave>
       <Name>InputDeviceContainerInstance</Name>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/InputDeviceSelectorBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/InputDeviceSelectorBehavior.behx
@@ -3,7 +3,9 @@
   <Name>InputDeviceSelectorBehavior</Name>
   <RequiredVariables />
   <FormsProperty Type="string" Name="ToolTip" />
-  <FormsProperty Type="bool" Name="IsEnabled" />
+  <FormsProperty Type="bool" Name="IsEnabled">
+    <Value xsi:type="xsd:boolean">true</Value>
+  </FormsProperty>
   <RequiredInstances>
     <InstanceSave>
       <Name>InputDeviceContainerInstance</Name>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/ItemsControlBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/ItemsControlBehavior.behx
@@ -3,6 +3,7 @@
   <Name>ItemsControlBehavior</Name>
   <RequiredVariables />
   <FormsProperty Type="string" Name="ToolTip" />
+  <FormsProperty Type="bool" Name="IsEnabled" />
   <RequiredInstances />
   <RequiredAnimations />
 </BehaviorSave>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/ItemsControlBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/ItemsControlBehavior.behx
@@ -3,7 +3,9 @@
   <Name>ItemsControlBehavior</Name>
   <RequiredVariables />
   <FormsProperty Type="string" Name="ToolTip" />
-  <FormsProperty Type="bool" Name="IsEnabled" />
+  <FormsProperty Type="bool" Name="IsEnabled">
+    <Value xsi:type="xsd:boolean">true</Value>
+  </FormsProperty>
   <RequiredInstances />
   <RequiredAnimations />
 </BehaviorSave>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/LabelBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/LabelBehavior.behx
@@ -3,6 +3,7 @@
   <Name>LabelBehavior</Name>
   <RequiredVariables />
   <FormsProperty Type="string" Name="ToolTip" />
+  <FormsProperty Type="bool" Name="IsEnabled" />
   <RequiredInstances />
   <RequiredAnimations />
   <DefaultImplementation>Elements/Label</DefaultImplementation>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/LabelBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/LabelBehavior.behx
@@ -3,7 +3,9 @@
   <Name>LabelBehavior</Name>
   <RequiredVariables />
   <FormsProperty Type="string" Name="ToolTip" />
-  <FormsProperty Type="bool" Name="IsEnabled" />
+  <FormsProperty Type="bool" Name="IsEnabled">
+    <Value xsi:type="xsd:boolean">true</Value>
+  </FormsProperty>
   <RequiredInstances />
   <RequiredAnimations />
   <DefaultImplementation>Elements/Label</DefaultImplementation>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/ListBoxBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/ListBoxBehavior.behx
@@ -3,6 +3,8 @@
   <Name>ListBoxBehavior</Name>
   <RequiredVariables />
   <FormsProperty Type="string" Name="ToolTip" />
+  <FormsProperty Type="bool" Name="IsEnabled" />
+  <ToolOnlyVariableReference>ListBoxCategoryState = IsEnabled ? "Enabled" : "Disabled"</ToolOnlyVariableReference>
   <Category>
     <Name>ListBoxCategory</Name>
     <State>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/ListBoxBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/ListBoxBehavior.behx
@@ -3,7 +3,9 @@
   <Name>ListBoxBehavior</Name>
   <RequiredVariables />
   <FormsProperty Type="string" Name="ToolTip" />
-  <FormsProperty Type="bool" Name="IsEnabled" />
+  <FormsProperty Type="bool" Name="IsEnabled">
+    <Value xsi:type="xsd:boolean">true</Value>
+  </FormsProperty>
   <ToolOnlyVariableReference>ListBoxCategoryState = IsEnabled ? "Enabled" : "Disabled"</ToolOnlyVariableReference>
   <Category>
     <Name>ListBoxCategory</Name>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/ListBoxItemBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/ListBoxItemBehavior.behx
@@ -3,6 +3,7 @@
   <Name>ListBoxItemBehavior</Name>
   <RequiredVariables />
   <FormsProperty Type="string" Name="ToolTip" />
+  <FormsProperty Type="bool" Name="IsEnabled" />
   <Category>
     <Name>ListBoxItemCategory</Name>
     <State>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/ListBoxItemBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/ListBoxItemBehavior.behx
@@ -3,7 +3,9 @@
   <Name>ListBoxItemBehavior</Name>
   <RequiredVariables />
   <FormsProperty Type="string" Name="ToolTip" />
-  <FormsProperty Type="bool" Name="IsEnabled" />
+  <FormsProperty Type="bool" Name="IsEnabled">
+    <Value xsi:type="xsd:boolean">true</Value>
+  </FormsProperty>
   <Category>
     <Name>ListBoxItemCategory</Name>
     <State>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/MenuBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/MenuBehavior.behx
@@ -3,6 +3,7 @@
   <Name>MenuBehavior</Name>
   <RequiredVariables />
   <FormsProperty Type="string" Name="ToolTip" />
+  <FormsProperty Type="bool" Name="IsEnabled" />
   <RequiredInstances />
   <RequiredAnimations />
   <DefaultImplementation>Controls/Menu</DefaultImplementation>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/MenuBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/MenuBehavior.behx
@@ -3,7 +3,9 @@
   <Name>MenuBehavior</Name>
   <RequiredVariables />
   <FormsProperty Type="string" Name="ToolTip" />
-  <FormsProperty Type="bool" Name="IsEnabled" />
+  <FormsProperty Type="bool" Name="IsEnabled">
+    <Value xsi:type="xsd:boolean">true</Value>
+  </FormsProperty>
   <RequiredInstances />
   <RequiredAnimations />
   <DefaultImplementation>Controls/Menu</DefaultImplementation>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/MenuItemBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/MenuItemBehavior.behx
@@ -3,7 +3,9 @@
   <Name>MenuItemBehavior</Name>
   <RequiredVariables />
   <FormsProperty Type="string" Name="ToolTip" />
-  <FormsProperty Type="bool" Name="IsEnabled" />
+  <FormsProperty Type="bool" Name="IsEnabled">
+    <Value xsi:type="xsd:boolean">true</Value>
+  </FormsProperty>
   <ToolOnlyVariableReference>MenuItemCategoryState = IsEnabled ? "Enabled" : "Disabled"</ToolOnlyVariableReference>
   <Category>
     <Name>MenuItemCategory</Name>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/MenuItemBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/MenuItemBehavior.behx
@@ -3,6 +3,8 @@
   <Name>MenuItemBehavior</Name>
   <RequiredVariables />
   <FormsProperty Type="string" Name="ToolTip" />
+  <FormsProperty Type="bool" Name="IsEnabled" />
+  <ToolOnlyVariableReference>MenuItemCategoryState = IsEnabled ? "Enabled" : "Disabled"</ToolOnlyVariableReference>
   <Category>
     <Name>MenuItemCategory</Name>
     <State>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/OnScreenKeyboardBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/OnScreenKeyboardBehavior.behx
@@ -3,6 +3,7 @@
   <Name>OnScreenKeyboardBehavior</Name>
   <RequiredVariables />
   <FormsProperty Type="string" Name="ToolTip" />
+  <FormsProperty Type="bool" Name="IsEnabled" />
   <RequiredInstances />
   <RequiredAnimations />
 </BehaviorSave>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/OnScreenKeyboardBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/OnScreenKeyboardBehavior.behx
@@ -3,7 +3,9 @@
   <Name>OnScreenKeyboardBehavior</Name>
   <RequiredVariables />
   <FormsProperty Type="string" Name="ToolTip" />
-  <FormsProperty Type="bool" Name="IsEnabled" />
+  <FormsProperty Type="bool" Name="IsEnabled">
+    <Value xsi:type="xsd:boolean">true</Value>
+  </FormsProperty>
   <RequiredInstances />
   <RequiredAnimations />
 </BehaviorSave>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/PanelBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/PanelBehavior.behx
@@ -3,6 +3,7 @@
   <Name>PanelBehavior</Name>
   <RequiredVariables />
   <FormsProperty Type="string" Name="ToolTip" />
+  <FormsProperty Type="bool" Name="IsEnabled" />
   <RequiredInstances />
   <RequiredAnimations />
 </BehaviorSave>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/PanelBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/PanelBehavior.behx
@@ -3,7 +3,9 @@
   <Name>PanelBehavior</Name>
   <RequiredVariables />
   <FormsProperty Type="string" Name="ToolTip" />
-  <FormsProperty Type="bool" Name="IsEnabled" />
+  <FormsProperty Type="bool" Name="IsEnabled">
+    <Value xsi:type="xsd:boolean">true</Value>
+  </FormsProperty>
   <RequiredInstances />
   <RequiredAnimations />
 </BehaviorSave>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/PasswordBoxBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/PasswordBoxBehavior.behx
@@ -3,6 +3,8 @@
   <Name>PasswordBoxBehavior</Name>
   <RequiredVariables />
   <FormsProperty Type="string" Name="ToolTip" />
+  <FormsProperty Type="bool" Name="IsEnabled" />
+  <ToolOnlyVariableReference>PasswordBoxCategoryState = IsEnabled ? "Enabled" : "Disabled"</ToolOnlyVariableReference>
   <Category>
     <Name>PasswordBoxCategory</Name>
     <State>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/PasswordBoxBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/PasswordBoxBehavior.behx
@@ -3,7 +3,9 @@
   <Name>PasswordBoxBehavior</Name>
   <RequiredVariables />
   <FormsProperty Type="string" Name="ToolTip" />
-  <FormsProperty Type="bool" Name="IsEnabled" />
+  <FormsProperty Type="bool" Name="IsEnabled">
+    <Value xsi:type="xsd:boolean">true</Value>
+  </FormsProperty>
   <ToolOnlyVariableReference>PasswordBoxCategoryState = IsEnabled ? "Enabled" : "Disabled"</ToolOnlyVariableReference>
   <Category>
     <Name>PasswordBoxCategory</Name>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/PlayerJoinViewBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/PlayerJoinViewBehavior.behx
@@ -3,6 +3,7 @@
   <Name>PlayerJoinViewBehavior</Name>
   <RequiredVariables />
   <FormsProperty Type="string" Name="ToolTip" />
+  <FormsProperty Type="bool" Name="IsEnabled" />
   <RequiredInstances>
     <InstanceSave>
       <Name>InnerPanelInstance</Name>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/PlayerJoinViewBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/PlayerJoinViewBehavior.behx
@@ -3,7 +3,9 @@
   <Name>PlayerJoinViewBehavior</Name>
   <RequiredVariables />
   <FormsProperty Type="string" Name="ToolTip" />
-  <FormsProperty Type="bool" Name="IsEnabled" />
+  <FormsProperty Type="bool" Name="IsEnabled">
+    <Value xsi:type="xsd:boolean">true</Value>
+  </FormsProperty>
   <RequiredInstances>
     <InstanceSave>
       <Name>InnerPanelInstance</Name>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/PlayerJoinViewItemBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/PlayerJoinViewItemBehavior.behx
@@ -3,7 +3,9 @@
   <Name>PlayerJoinViewItemBehavior</Name>
   <RequiredVariables />
   <FormsProperty Type="string" Name="ToolTip" />
-  <FormsProperty Type="bool" Name="IsEnabled" />
+  <FormsProperty Type="bool" Name="IsEnabled">
+    <Value xsi:type="xsd:boolean">true</Value>
+  </FormsProperty>
   <Category>
     <Name>PlayerJoinCategory</Name>
     <State>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/PlayerJoinViewItemBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/PlayerJoinViewItemBehavior.behx
@@ -3,6 +3,7 @@
   <Name>PlayerJoinViewItemBehavior</Name>
   <RequiredVariables />
   <FormsProperty Type="string" Name="ToolTip" />
+  <FormsProperty Type="bool" Name="IsEnabled" />
   <Category>
     <Name>PlayerJoinCategory</Name>
     <State>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/RadioButtonBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/RadioButtonBehavior.behx
@@ -3,7 +3,9 @@
   <Name>RadioButtonBehavior</Name>
   <RequiredVariables />
   <FormsProperty Type="string" Name="ToolTip" />
-  <FormsProperty Type="bool" Name="IsEnabled" />
+  <FormsProperty Type="bool" Name="IsEnabled">
+    <Value xsi:type="xsd:boolean">true</Value>
+  </FormsProperty>
   <ToolOnlyVariableReference>RadioButtonCategoryState = IsEnabled ? "EnabledOff" : "DisabledOff"</ToolOnlyVariableReference>
   <Category>
     <Name>RadioButtonCategory</Name>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/RadioButtonBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/RadioButtonBehavior.behx
@@ -3,6 +3,8 @@
   <Name>RadioButtonBehavior</Name>
   <RequiredVariables />
   <FormsProperty Type="string" Name="ToolTip" />
+  <FormsProperty Type="bool" Name="IsEnabled" />
+  <ToolOnlyVariableReference>RadioButtonCategoryState = IsEnabled ? "EnabledOff" : "DisabledOff"</ToolOnlyVariableReference>
   <Category>
     <Name>RadioButtonCategory</Name>
     <State>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/ScrollBarBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/ScrollBarBehavior.behx
@@ -3,7 +3,9 @@
   <Name>ScrollBarBehavior</Name>
   <RequiredVariables />
   <FormsProperty Type="string" Name="ToolTip" />
-  <FormsProperty Type="bool" Name="IsEnabled" />
+  <FormsProperty Type="bool" Name="IsEnabled">
+    <Value xsi:type="xsd:boolean">true</Value>
+  </FormsProperty>
   <Category>
     <Name>ScrollBarCategory</Name>
   </Category>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/ScrollBarBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/ScrollBarBehavior.behx
@@ -3,6 +3,7 @@
   <Name>ScrollBarBehavior</Name>
   <RequiredVariables />
   <FormsProperty Type="string" Name="ToolTip" />
+  <FormsProperty Type="bool" Name="IsEnabled" />
   <Category>
     <Name>ScrollBarCategory</Name>
   </Category>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/ScrollViewerBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/ScrollViewerBehavior.behx
@@ -3,7 +3,9 @@
   <Name>ScrollViewerBehavior</Name>
   <RequiredVariables />
   <FormsProperty Type="string" Name="ToolTip" />
-  <FormsProperty Type="bool" Name="IsEnabled" />
+  <FormsProperty Type="bool" Name="IsEnabled">
+    <Value xsi:type="xsd:boolean">true</Value>
+  </FormsProperty>
   <Category>
     <Name>ScrollBarVisibility</Name>
     <State>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/ScrollViewerBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/ScrollViewerBehavior.behx
@@ -3,6 +3,7 @@
   <Name>ScrollViewerBehavior</Name>
   <RequiredVariables />
   <FormsProperty Type="string" Name="ToolTip" />
+  <FormsProperty Type="bool" Name="IsEnabled" />
   <Category>
     <Name>ScrollBarVisibility</Name>
     <State>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/SettingsViewBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/SettingsViewBehavior.behx
@@ -3,6 +3,7 @@
   <Name>SettingsViewBehavior</Name>
   <RequiredVariables />
   <FormsProperty Type="string" Name="ToolTip" />
+  <FormsProperty Type="bool" Name="IsEnabled" />
   <RequiredInstances />
   <RequiredAnimations />
   <DefaultImplementation>Controls/SettingsView</DefaultImplementation>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/SettingsViewBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/SettingsViewBehavior.behx
@@ -3,7 +3,9 @@
   <Name>SettingsViewBehavior</Name>
   <RequiredVariables />
   <FormsProperty Type="string" Name="ToolTip" />
-  <FormsProperty Type="bool" Name="IsEnabled" />
+  <FormsProperty Type="bool" Name="IsEnabled">
+    <Value xsi:type="xsd:boolean">true</Value>
+  </FormsProperty>
   <RequiredInstances />
   <RequiredAnimations />
   <DefaultImplementation>Controls/SettingsView</DefaultImplementation>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/SliderBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/SliderBehavior.behx
@@ -3,6 +3,7 @@
   <Name>SliderBehavior</Name>
   <RequiredVariables />
   <FormsProperty Type="string" Name="ToolTip" />
+  <FormsProperty Type="bool" Name="IsEnabled" />
   <Category>
     <Name>SliderCategory</Name>
     <State>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/SliderBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/SliderBehavior.behx
@@ -3,7 +3,9 @@
   <Name>SliderBehavior</Name>
   <RequiredVariables />
   <FormsProperty Type="string" Name="ToolTip" />
-  <FormsProperty Type="bool" Name="IsEnabled" />
+  <FormsProperty Type="bool" Name="IsEnabled">
+    <Value xsi:type="xsd:boolean">true</Value>
+  </FormsProperty>
   <Category>
     <Name>SliderCategory</Name>
     <State>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/SplitterBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/SplitterBehavior.behx
@@ -3,7 +3,9 @@
   <Name>SplitterBehavior</Name>
   <RequiredVariables />
   <FormsProperty Type="string" Name="ToolTip" />
-  <FormsProperty Type="bool" Name="IsEnabled" />
+  <FormsProperty Type="bool" Name="IsEnabled">
+    <Value xsi:type="xsd:boolean">true</Value>
+  </FormsProperty>
   <RequiredInstances />
   <RequiredAnimations />
   <DefaultImplementation>Controls/SplitterStandard</DefaultImplementation>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/SplitterBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/SplitterBehavior.behx
@@ -3,6 +3,7 @@
   <Name>SplitterBehavior</Name>
   <RequiredVariables />
   <FormsProperty Type="string" Name="ToolTip" />
+  <FormsProperty Type="bool" Name="IsEnabled" />
   <RequiredInstances />
   <RequiredAnimations />
   <DefaultImplementation>Controls/SplitterStandard</DefaultImplementation>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/StackPanelBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/StackPanelBehavior.behx
@@ -3,6 +3,7 @@
   <Name>StackPanelBehavior</Name>
   <RequiredVariables />
   <FormsProperty Type="string" Name="ToolTip" />
+  <FormsProperty Type="bool" Name="IsEnabled" />
   <RequiredInstances />
   <RequiredAnimations />
 </BehaviorSave>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/StackPanelBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/StackPanelBehavior.behx
@@ -3,7 +3,9 @@
   <Name>StackPanelBehavior</Name>
   <RequiredVariables />
   <FormsProperty Type="string" Name="ToolTip" />
-  <FormsProperty Type="bool" Name="IsEnabled" />
+  <FormsProperty Type="bool" Name="IsEnabled">
+    <Value xsi:type="xsd:boolean">true</Value>
+  </FormsProperty>
   <RequiredInstances />
   <RequiredAnimations />
 </BehaviorSave>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/TextBoxBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/TextBoxBehavior.behx
@@ -3,7 +3,9 @@
   <Name>TextBoxBehavior</Name>
   <RequiredVariables />
   <FormsProperty Type="string" Name="ToolTip" />
-  <FormsProperty Type="bool" Name="IsEnabled" />
+  <FormsProperty Type="bool" Name="IsEnabled">
+    <Value xsi:type="xsd:boolean">true</Value>
+  </FormsProperty>
   <ToolOnlyVariableReference>TextBoxCategoryState = IsEnabled ? "Enabled" : "Disabled"</ToolOnlyVariableReference>
   <Category>
     <Name>TextBoxCategory</Name>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/TextBoxBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/TextBoxBehavior.behx
@@ -3,6 +3,8 @@
   <Name>TextBoxBehavior</Name>
   <RequiredVariables />
   <FormsProperty Type="string" Name="ToolTip" />
+  <FormsProperty Type="bool" Name="IsEnabled" />
+  <ToolOnlyVariableReference>TextBoxCategoryState = IsEnabled ? "Enabled" : "Disabled"</ToolOnlyVariableReference>
   <Category>
     <Name>TextBoxCategory</Name>
     <State>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/ToastBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/ToastBehavior.behx
@@ -3,7 +3,9 @@
   <Name>ToastBehavior</Name>
   <RequiredVariables />
   <FormsProperty Type="string" Name="ToolTip" />
-  <FormsProperty Type="bool" Name="IsEnabled" />
+  <FormsProperty Type="bool" Name="IsEnabled">
+    <Value xsi:type="xsd:boolean">true</Value>
+  </FormsProperty>
   <RequiredInstances>
     <InstanceSave>
       <Name>TextInstance</Name>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/ToastBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/ToastBehavior.behx
@@ -3,6 +3,7 @@
   <Name>ToastBehavior</Name>
   <RequiredVariables />
   <FormsProperty Type="string" Name="ToolTip" />
+  <FormsProperty Type="bool" Name="IsEnabled" />
   <RequiredInstances>
     <InstanceSave>
       <Name>TextInstance</Name>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/ToggleBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/ToggleBehavior.behx
@@ -3,7 +3,9 @@
   <Name>ToggleBehavior</Name>
   <RequiredVariables />
   <FormsProperty Type="string" Name="ToolTip" />
-  <FormsProperty Type="bool" Name="IsEnabled" />
+  <FormsProperty Type="bool" Name="IsEnabled">
+    <Value xsi:type="xsd:boolean">true</Value>
+  </FormsProperty>
   <ToolOnlyVariableReference>ToggleCategoryState = IsEnabled ? "EnabledOff" : "DisabledOff"</ToolOnlyVariableReference>
   <Category>
     <Name>ToggleCategory</Name>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/ToggleBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/ToggleBehavior.behx
@@ -3,6 +3,8 @@
   <Name>ToggleBehavior</Name>
   <RequiredVariables />
   <FormsProperty Type="string" Name="ToolTip" />
+  <FormsProperty Type="bool" Name="IsEnabled" />
+  <ToolOnlyVariableReference>ToggleCategoryState = IsEnabled ? "EnabledOff" : "DisabledOff"</ToolOnlyVariableReference>
   <Category>
     <Name>ToggleCategory</Name>
     <State>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/TreeViewBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/TreeViewBehavior.behx
@@ -3,6 +3,8 @@
   <Name>TreeViewBehavior</Name>
   <RequiredVariables />
   <FormsProperty Type="string" Name="ToolTip" />
+  <FormsProperty Type="bool" Name="IsEnabled" />
+  <ToolOnlyVariableReference>TreeViewCategoryState = IsEnabled ? "Enabled" : "Disabled"</ToolOnlyVariableReference>
   <Category>
     <Name>TreeViewCategory</Name>
     <State>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/TreeViewBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/TreeViewBehavior.behx
@@ -3,7 +3,9 @@
   <Name>TreeViewBehavior</Name>
   <RequiredVariables />
   <FormsProperty Type="string" Name="ToolTip" />
-  <FormsProperty Type="bool" Name="IsEnabled" />
+  <FormsProperty Type="bool" Name="IsEnabled">
+    <Value xsi:type="xsd:boolean">true</Value>
+  </FormsProperty>
   <ToolOnlyVariableReference>TreeViewCategoryState = IsEnabled ? "Enabled" : "Disabled"</ToolOnlyVariableReference>
   <Category>
     <Name>TreeViewCategory</Name>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/TreeViewItemBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/TreeViewItemBehavior.behx
@@ -3,7 +3,9 @@
   <Name>TreeViewItemBehavior</Name>
   <RequiredVariables />
   <FormsProperty Type="string" Name="ToolTip" />
-  <FormsProperty Type="bool" Name="IsEnabled" />
+  <FormsProperty Type="bool" Name="IsEnabled">
+    <Value xsi:type="xsd:boolean">true</Value>
+  </FormsProperty>
   <RequiredInstances>
     <InstanceSave>
       <Name>InnerPanelInstance</Name>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/TreeViewItemBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/TreeViewItemBehavior.behx
@@ -3,6 +3,7 @@
   <Name>TreeViewItemBehavior</Name>
   <RequiredVariables />
   <FormsProperty Type="string" Name="ToolTip" />
+  <FormsProperty Type="bool" Name="IsEnabled" />
   <RequiredInstances>
     <InstanceSave>
       <Name>InnerPanelInstance</Name>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/UserControlBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/UserControlBehavior.behx
@@ -3,6 +3,7 @@
   <Name>UserControlBehavior</Name>
   <RequiredVariables />
   <FormsProperty Type="string" Name="ToolTip" />
+  <FormsProperty Type="bool" Name="IsEnabled" />
   <RequiredInstances />
   <RequiredAnimations />
   <DefaultImplementation>Controls/UserControl</DefaultImplementation>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/UserControlBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/UserControlBehavior.behx
@@ -3,7 +3,9 @@
   <Name>UserControlBehavior</Name>
   <RequiredVariables />
   <FormsProperty Type="string" Name="ToolTip" />
-  <FormsProperty Type="bool" Name="IsEnabled" />
+  <FormsProperty Type="bool" Name="IsEnabled">
+    <Value xsi:type="xsd:boolean">true</Value>
+  </FormsProperty>
   <RequiredInstances />
   <RequiredAnimations />
   <DefaultImplementation>Controls/UserControl</DefaultImplementation>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/WindowBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/WindowBehavior.behx
@@ -3,7 +3,9 @@
   <Name>WindowBehavior</Name>
   <RequiredVariables />
   <FormsProperty Type="string" Name="ToolTip" />
-  <FormsProperty Type="bool" Name="IsEnabled" />
+  <FormsProperty Type="bool" Name="IsEnabled">
+    <Value xsi:type="xsd:boolean">true</Value>
+  </FormsProperty>
   <RequiredInstances />
   <RequiredAnimations />
   <DefaultImplementation>Controls/WindowStandard</DefaultImplementation>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/WindowBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/WindowBehavior.behx
@@ -3,6 +3,7 @@
   <Name>WindowBehavior</Name>
   <RequiredVariables />
   <FormsProperty Type="string" Name="ToolTip" />
+  <FormsProperty Type="bool" Name="IsEnabled" />
   <RequiredInstances />
   <RequiredAnimations />
   <DefaultImplementation>Controls/WindowStandard</DefaultImplementation>


### PR DESCRIPTION
## Summary

Closes the state-mapped half of the Forms Property Promotion Gap (#2637 v2). Stacks on top of v1 (#2645, already merged). With v1, `ToolTip` and other logical-only properties could be authored at design time and reflected onto the wrapped `FrameworkElement` at runtime. v2 adds:

- A second save-model field on `BehaviorSave` for **design-time-only** variable-reference assignments that drive wireframe preview from `FormsProperty` values.
- A tool-side apply pass that evaluates those references against the component's effective state and writes resolved values back so the wireframe reflects authoring (e.g. `IsEnabled = false` → `ButtonCategoryState = "Disabled"`).
- A **three-tier default resolution** (parent-state override → component default → behavior `FormsProperty.Value`) consulted by both apply paths *and* the variable-grid display getter, mirroring the WPF `DependencyProperty.PropertyMetadata.DefaultValue` pattern.
- `IsEnabled` declared on every standard Forms behavior (default `true`), with category-state references on the 10 behaviors that have an Enabled/Disabled visual pair.

State stays untouched until the user explicitly authors a value — defaults are virtual, so `.gusx` files don't get polluted with implicit values.

## What's new

**Save model** — `BehaviorSave.ToolOnlyVariableReferences : List<string>` (`<ToolOnlyVariableReference>` element). Structurally separate from a future runtime-applied `VariableReferences` field; the name encodes the "tool only" contract and runtime apply paths never traverse it.

**Tool-time apply** — `BehaviorToolOnlyReferencesApplier` walks every linked behavior's `ToolOnlyVariableReferences`, evaluates RHS via `EvaluatedSyntax`, and writes the resolved value into the state. Auto-qualifies bare RHS identifiers with the instance name when applying to an instance. Hooked into `VariableReferenceLogic.DoVariableReferenceReaction` immediately after the existing state-level apply.

**Default fallback machinery** (used by all three consumers):
- `RecursiveVariableFinder.Fallback` (`Func<string, object?>?`) — consulted when state lookup returns null.
- `EvaluatedSyntax.FromSyntaxNode` accepts an optional `fallback` parameter threaded through every recursive evaluation.
- Apply paths build a per-element fallback that resolves bare/qualified identifiers against linked-behavior `FormsProperties`.
- `StateReferencingInstanceMember.DefaultValueFallback` lets the variable grid surface the declared default in the checkbox/text without writing into state. `IsDefault` is intentionally untouched — italic/grey "default" styling still works.

**Behavior content** — `IsEnabled` (`bool`, default `true`) on all 31 standard `FormsTemplate` behaviors. The 10 with an Enabled/Disabled visual category also gain a `ToolOnlyVariableReference` driving `<X>CategoryState = IsEnabled ? "Enabled" : "Disabled"` (or the `*Off` pair for the IsChecked-bearing trio).

**Drive-by fix on v1** — `BehaviorFormsPropertyApplier.cs` was added to `MonoGameGum/Forms/` but `SokolGum.csproj` and `RaylibGum.csproj` link `FormsUtilities.cs` directly without picking up sibling files; CI macOS build was failing for those runtimes. Both csprojs now link the applier explicitly. (Already pushed onto v1 before the squash-merge that produced commit `05e63cdd4` on main.)

## Architectural decisions (locked)

- `ToolOnlyVariableReferences` is structurally tool-only by name. A future `BehaviorSave.VariableReferences` (runtime-applied) is intentionally not added here so runtime double-application is impossible.
- The runtime apply for state-mapped properties is owned by the Forms control's existing setter (e.g. `FrameworkElement.IsEnabled` → `UpdateState()`). v2 adds no per-control wiring for the visual; the runtime side is reflection-only via `BehaviorFormsPropertyApplier`.
- Defaults are **virtual** (consulted at read time), never written into state. Mirrors WPF's local-value vs. metadata-default distinction.

## Test plan

- [x] `BehaviorSave.ToolOnlyVariableReferences` round-trip (legacy + compact, omit-when-empty)
- [x] `BehaviorSave.FormsProperties[*].Value` round-trip with non-null bool default (legacy + compact)
- [x] Tool-side apply: component default state with `IsEnabled` true/false → correct `<X>CategoryState`
- [x] Tool-side apply: screen+instance with `ButtonInstance.IsEnabled = false` → `ButtonInstance.ButtonCategoryState = "Disabled"`
- [x] Tool-side apply: state-empty `IsEnabled` falls back to behavior default
- [x] Tool-side apply: state-authored value overrides behavior default
- [x] Runtime apply: state-empty → fall back to behavior `FormsProperty.Value`
- [x] Runtime apply: parent-state override beats component default beats behavior default (priority order)
- [x] Variable grid display: SRIM value getter falls back to declared default when state empty
- [x] Full `GumFull.sln` test pass (862 passed)
- [x] Full `AllLibraries.sln` test pass (1793 passed)
- [x] Manual: select `ButtonStandard` component, confirm `IsEnabled` checkbox is checked by default and toggling flips wireframe
- [x] Manual: drop button instance into screen, override `IsEnabled = false` on the instance → wireframe shows that one instance Disabled

## Out of scope (future)

- `IsChecked` and other state-mapped properties beyond `IsEnabled` follow the same v2 shape; not added here.
- Per-categorical-state evaluation (`IsEnabled` set inside a `Hovered` state) — design doc tier marked v2 but defers to v3.
- UI for editing `ToolOnlyVariableReferences` on behaviors — they're authored by editing `.behx` directly (or by templates that ship with standard behaviors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)