### PR TITLE
Pin TextBox numeric-binding behavior (#609)

### DIFF
--- a/MonoGameGum.Tests/Forms/FrameworkElementBindingTests.cs
+++ b/MonoGameGum.Tests/Forms/FrameworkElementBindingTests.cs
@@ -461,6 +461,190 @@ public class FrameworkElementBindingTests : BaseTestClass
         element.TicksFrequency.ShouldBe(0);
     }
 
+    // ---- Issue #609: TextBox bound to numeric source — round-trip conversions
+    //
+    // These tests pin down the conversion behavior of NpcBindingExpression for
+    // every numeric type called out in #609 (byte, int, float, double, decimal),
+    // in both directions. The conversion goes through System.Convert.ChangeType
+    // wrapped in a try/catch (NpcBindingExpression.TryConvert).
+
+    [Theory]
+    [InlineData("0", (byte)0)]
+    [InlineData("8", (byte)8)]
+    [InlineData("255", (byte)255)]
+    public void Binding_TextBox_TargetToSource_StringToByte_Converts(string input, byte expected)
+    {
+        TestViewModel vm = new();
+        TextBox element = new() { BindingContext = vm };
+        element.SetBinding(nameof(TextBox.Text), nameof(TestViewModel.ByteValue));
+
+        element.Text = input;
+
+        vm.ByteValue.ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData("-1", -1)]
+    [InlineData("0", 0)]
+    [InlineData("8", 8)]
+    [InlineData("2147483647", int.MaxValue)]
+    public void Binding_TextBox_TargetToSource_StringToInt_Converts(string input, int expected)
+    {
+        TestViewModel vm = new();
+        TextBox element = new() { BindingContext = vm };
+        element.SetBinding(nameof(TextBox.Text), nameof(TestViewModel.IntValue));
+
+        element.Text = input;
+
+        vm.IntValue.ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData("0", 0f)]
+    [InlineData("12.5", 12.5f)]
+    [InlineData("-3.14", -3.14f)]
+    public void Binding_TextBox_TargetToSource_StringToFloat_Converts(string input, float expected)
+    {
+        TestViewModel vm = new();
+        TextBox element = new() { BindingContext = vm };
+        element.SetBinding(nameof(TextBox.Text), nameof(TestViewModel.FloatValue));
+
+        element.Text = input;
+
+        vm.FloatValue.ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData("0", 0.0)]
+    [InlineData("12.5", 12.5)]
+    [InlineData("-3.14159", -3.14159)]
+    public void Binding_TextBox_TargetToSource_StringToDouble_Converts(string input, double expected)
+    {
+        TestViewModel vm = new();
+        TextBox element = new() { BindingContext = vm };
+        element.SetBinding(nameof(TextBox.Text), nameof(TestViewModel.DoubleValue));
+
+        element.Text = input;
+
+        vm.DoubleValue.ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData("0", "0")]
+    [InlineData("12.5", "12.5")]
+    [InlineData("-3.14", "-3.14")]
+    public void Binding_TextBox_TargetToSource_StringToDecimal_Converts(string input, string expectedAsString)
+    {
+        // [InlineData] cannot carry decimal literals, so the expected value
+        // is written as a string and parsed inside the test.
+        TestViewModel vm = new();
+        TextBox element = new() { BindingContext = vm };
+        element.SetBinding(nameof(TextBox.Text), nameof(TestViewModel.DecimalValue));
+
+        element.Text = input;
+
+        vm.DecimalValue.ShouldBe(decimal.Parse(expectedAsString, System.Globalization.CultureInfo.InvariantCulture));
+    }
+
+    [Theory]
+    [InlineData((byte)0, "0")]
+    [InlineData((byte)8, "8")]
+    [InlineData((byte)255, "255")]
+    public void Binding_TextBox_SourceToTarget_ByteToString_Converts(byte sourceValue, string expectedText)
+    {
+        TestViewModel vm = new() { ByteValue = sourceValue };
+        TextBox element = new() { BindingContext = vm };
+
+        element.SetBinding(nameof(TextBox.Text), nameof(TestViewModel.ByteValue));
+
+        element.Text.ShouldBe(expectedText);
+    }
+
+    [Theory]
+    [InlineData(-1, "-1")]
+    [InlineData(0, "0")]
+    [InlineData(8, "8")]
+    public void Binding_TextBox_SourceToTarget_IntToString_Converts(int sourceValue, string expectedText)
+    {
+        TestViewModel vm = new() { IntValue = sourceValue };
+        TextBox element = new() { BindingContext = vm };
+
+        element.SetBinding(nameof(TextBox.Text), nameof(TestViewModel.IntValue));
+
+        element.Text.ShouldBe(expectedText);
+    }
+
+    [Theory]
+    [InlineData(0f, "0")]
+    [InlineData(12.5f, "12.5")]
+    [InlineData(-3.14f, "-3.14")]
+    public void Binding_TextBox_SourceToTarget_FloatToString_Converts(float sourceValue, string expectedText)
+    {
+        TestViewModel vm = new() { FloatValue = sourceValue };
+        TextBox element = new() { BindingContext = vm };
+
+        element.SetBinding(nameof(TextBox.Text), nameof(TestViewModel.FloatValue));
+
+        element.Text.ShouldBe(expectedText);
+    }
+
+    [Theory]
+    [InlineData(0.0, "0")]
+    [InlineData(12.5, "12.5")]
+    public void Binding_TextBox_SourceToTarget_DoubleToString_Converts(double sourceValue, string expectedText)
+    {
+        TestViewModel vm = new() { DoubleValue = sourceValue };
+        TextBox element = new() { BindingContext = vm };
+
+        element.SetBinding(nameof(TextBox.Text), nameof(TestViewModel.DoubleValue));
+
+        element.Text.ShouldBe(expectedText);
+    }
+
+    [Theory]
+    [InlineData("0", "0")]
+    [InlineData("12.5", "12.5")]
+    [InlineData("-3.14", "-3.14")]
+    public void Binding_TextBox_SourceToTarget_DecimalToString_Converts(string sourceValueAsString, string expectedText)
+    {
+        decimal sourceValue = decimal.Parse(sourceValueAsString, System.Globalization.CultureInfo.InvariantCulture);
+        TestViewModel vm = new() { DecimalValue = sourceValue };
+        TextBox element = new() { BindingContext = vm };
+
+        element.SetBinding(nameof(TextBox.Text), nameof(TestViewModel.DecimalValue));
+
+        element.Text.ShouldBe(expectedText);
+    }
+
+    [Fact]
+    public void Binding_TextBox_TargetToSource_EmptyString_LeavesIntSourceUnchanged()
+    {
+        // System.Convert.ChangeType("", typeof(int)) throws FormatException,
+        // which TryConvert swallows; the source must therefore be left alone.
+        TestViewModel vm = new() { IntValue = 42 };
+        TextBox element = new() { BindingContext = vm };
+        element.SetBinding(nameof(TextBox.Text), nameof(TestViewModel.IntValue));
+
+        element.Text = string.Empty;
+
+        vm.IntValue.ShouldBe(42);
+    }
+
+    [Fact]
+    public void Binding_TextBox_TargetToSource_EmptyString_LeavesNullableIntSourceUnchanged()
+    {
+        // System.Convert.ChangeType("", typeof(int?)) throws like the non-
+        // nullable case — Nullable<T> targets do not get a free null pass for
+        // empty strings. Pin this so callers don't assume "" -> null.
+        TestViewModel vm = new() { NullableIntValue = 42 };
+        TextBox element = new() { BindingContext = vm };
+        element.SetBinding(nameof(TextBox.Text), nameof(TestViewModel.NullableIntValue));
+
+        element.Text = string.Empty;
+
+        vm.NullableIntValue.ShouldBe(42);
+    }
+
     [Fact]
     public void ComplexPath_Mode_OneWay_OnlyUpdatesTarget()
     {

--- a/MonoGameGum.Tests/Forms/TestClasses.cs
+++ b/MonoGameGum.Tests/Forms/TestClasses.cs
@@ -49,6 +49,36 @@ public class TestViewModel : ViewModel
         set => Set(value);
     }
 
+    public int IntValue
+    {
+        get => Get<int>();
+        set => Set(value);
+    }
+
+    public int? NullableIntValue
+    {
+        get => Get<int?>();
+        set => Set(value);
+    }
+
+    public double DoubleValue
+    {
+        get => Get<double>();
+        set => Set(value);
+    }
+
+    public decimal DecimalValue
+    {
+        get => Get<decimal>();
+        set => Set(value);
+    }
+
+    public byte ByteValue
+    {
+        get => Get<byte>();
+        set => Set(value);
+    }
+
     public override string ToString() => Text ?? string.Empty;
 }
 


### PR DESCRIPTION
## Summary
Fixes / closes #609.

The reported crash ("blows up when typing into a TextBox bound to an int") is no longer reproducible — `NpcBindingExpression` already runs target/source values through `System.Convert.ChangeType` (wrapped in `TryConvert`'s try/catch) in both directions. The binding now silently leaves the source unchanged on conversion failure rather than throwing.

What was missing was **test coverage** to lock that in. Before this change, the only conversion-related test was a single negative case (`Binding_TargetToSource_InvalidCast_LeavesSourceUnchanged`). This PR adds positive round-trip tests for every numeric type called out in the issue.

These are **characterization tests** — they pin existing behavior so a future refactor can't silently regress it. No production code changes.

## Changes
- Add `IntValue` / `NullableIntValue` / `DoubleValue` / `DecimalValue` / `ByteValue` to the shared `TestViewModel` in `MonoGameGum.Tests/Forms/TestClasses.cs`, mirroring the existing `FloatValue` / `NullableFloatValue` INPC pattern.
- Add `[Theory]` tests in `MonoGameGum.Tests/Forms/FrameworkElementBindingTests.cs` for each of the 5 types in both directions (10 theories, ~30 case rows total).
- Pin the empty-string edge case: `""` does **not** convert to `null` for `int?` — `Convert.ChangeType` throws regardless of nullability, so the binding leaves the source untouched in both `int` and `int?` cases.

## Test plan
- [x] `dotnet test MonoGameGum.Tests/MonoGameGum.Tests.csproj --filter "FullyQualifiedName~Binding_TextBox"` — 32/32 new pass.
- [x] Existing invalid-cast tests still pass (34/34 with both old and new under the filter).

## Out of scope (worth flagging)
`TryConvert` calls `Convert.ChangeType(value, targetType)` without an `IFormatProvider`, so conversions are **culture-sensitive** (e.g. on a locale where the decimal separator is `,`, `"3.14"` would fail). Not a regression introduced here, but a future ticket might want to make this culture-invariant or expose it via `Binding.ConverterCulture`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)