### PR TITLE
Document implicit type conversion in bindings

### DIFF
--- a/.claude/skills/gum-docs-writing/SKILL.md
+++ b/.claude/skills/gum-docs-writing/SKILL.md
@@ -78,6 +78,17 @@ The docs have two top-level sections — **Gum Tool** (`docs/gum-tool/`) and **C
 
 When writing a tool doc page (e.g., a property page under `gum-elements/`), focus entirely on the tool experience: what the property does visually, where it appears in the UI, and screenshots showing the effect. Do not add code examples showing how to set the property in C#. Conversely, code doc pages should not walk through the tool's UI.
 
+## Cross-Cutting Topics (Binding, Localization, Theming)
+
+Some features cut across many controls — binding, localization, theming, code generation — and individual controls have control-specific behaviors that intersect with them. For example, `TextBox.Text` can be bound to a numeric ViewModel property and the binding implicitly converts string ↔ number; `ListBox` interacts with `BindingContext` differently than other controls; localized labels behave differently in `PasswordBox`.
+
+The convention for these:
+
+- **Document the system-level behavior in the feature's own section.** Someone hitting the feature for the first time will look there. Binding rules go in `docs/code/binding-viewmodels/`, localization rules in the localization section, etc. This is the single source of truth.
+- **Add a brief note on the control's page** with a short example and any control-specific gotchas, then **link back to the feature page** for the general rule (e.g. `[Implicit Type Conversion](../binding-viewmodels/advanced-binding-options.md#implicit-type-conversion)`). Do not duplicate the system-level explanation — trust the reader to follow the link.
+
+The control-page note exists so that a reader troubleshooting "why doesn't my int binding take" while reading the TextBox page finds what they need without bouncing around. The feature-page section exists so that a reader learning the binding system isn't surprised later. Both audiences are real; the split avoids both blind spots without duplicating content.
+
 ## Tone and Style
 
 - Second person ("you"), present tense, instructional tone.

--- a/docs/code/binding-viewmodels/advanced-binding-options.md
+++ b/docs/code/binding-viewmodels/advanced-binding-options.md
@@ -204,3 +204,46 @@ Binding binding = new("CurrentPlayer.Name")
 };
 label.SetBinding(nameof(Label.Text), binding);
 ```
+
+## Implicit Type Conversion
+
+When the source and target of a binding have different types, Gum automatically attempts to convert values using `System.Convert.ChangeType` in both directions. This means a string-typed control property like `TextBox.Text` can be bound to a numeric ViewModel property without writing a converter.
+
+The following ViewModel exposes an `int` property:
+
+```csharp
+// Class scope
+class MyViewModel : ViewModel
+{
+    public int Score
+    {
+        get => Get<int>();
+        set => Set(value);
+    }
+}
+```
+
+The TextBox can be bound directly to `Score`:
+
+```csharp
+// Initialize
+MyViewModel vm = new() { Score = 8 };
+TextBox textBox = new() { BindingContext = vm };
+textBox.SetBinding(nameof(TextBox.Text), nameof(MyViewModel.Score));
+```
+
+In the example above, setting `vm.Score = 12` updates `textBox.Text` to `"12"`, and typing `"42"` into the textbox updates `vm.Score` to `42`. The standard numeric types are supported: `byte`, `int`, `float`, `double`, and `decimal`.
+
+### Conversion Failures
+
+If `Convert.ChangeType` cannot convert a value — for example, the user types `"hello"` into a TextBox bound to `int` — the binding silently leaves the destination unchanged. No exception is thrown.
+
+This applies in both directions and to edge cases such as empty strings. Clearing the text in a TextBox bound to `int` does **not** reset the source to `0` — it leaves the source at its previous value.
+
+{% hint style="info" %}
+The same rule applies to `Nullable<T>` source properties. An empty string does not convert to `null`, so the source is left unchanged. To support clearing a numeric field to `null`, supply a `Converter` with explicit `ConvertBack` logic.
+{% endhint %}
+
+### Culture Sensitivity
+
+Implicit conversion uses the current culture. On a system where the decimal separator is `,`, the string `"3.14"` will not parse as a decimal number; `"3,14"` will. If your application needs culture-invariant parsing regardless of system settings, supply a `Converter` rather than relying on implicit conversion.

--- a/docs/code/controls/textbox.md
+++ b/docs/code/controls/textbox.md
@@ -316,6 +316,41 @@ mainPanel.AddChild(textBox);
 
 <figure><img src="../../.gitbook/assets/24_07 50 58.gif" alt=""><figcaption><p>Pressing enter applies binding</p></figcaption></figure>
 
+## Binding to Numeric Properties
+
+`TextBox.Text` can be bound to any standard numeric ViewModel property — `byte`, `int`, `float`, `double`, or `decimal`. The binding automatically converts between strings and numbers, so no `Converter` is required for these types.
+
+The following ViewModel exposes an `int`:
+
+```csharp
+// Class scope
+class PlayerViewModel : ViewModel
+{
+    public int Score
+    {
+        get => Get<int>();
+        set => Set(value);
+    }
+}
+```
+
+The TextBox can be bound directly to `Score`:
+
+```csharp
+// Initialize
+PlayerViewModel vm = new() { Score = 8 };
+TextBox textBox = new() { BindingContext = vm };
+textBox.SetBinding(nameof(TextBox.Text), nameof(PlayerViewModel.Score));
+```
+
+When the user types valid numeric input, the bound property is updated. When the input cannot be parsed — for example, letters in a field bound to `int` — the binding silently leaves the source unchanged. No exception is thrown.
+
+{% hint style="warning" %}
+Clearing the textbox to an empty string does **not** reset a numeric source to `0` or `null`. The source keeps its previous value, because `Convert.ChangeType("", numericType)` fails and failures are silently skipped. If your application needs clearing-to-null behavior, supply a `Converter` to the binding.
+{% endhint %}
+
+For the system-level rule that drives this behavior, including how it works for any binding (not just TextBox), see [Implicit Type Conversion](../binding-viewmodels/advanced-binding-options.md#implicit-type-conversion).
+
 ## Tab Key Behavior
 
 The tab key behavior is controlled by the `AcceptsTab` property. This value is false by default.


### PR DESCRIPTION
## Summary
Companion to #2652. The binding system already converts source/target via `System.Convert.ChangeType` in both directions, but none of that behavior was documented. This PR writes it down following the convention: system-level rule on the feature page, control-specific note on the control page, single source of truth on the feature page.

## Changes
- **`docs/code/binding-viewmodels/advanced-binding-options.md`** — new \"Implicit Type Conversion\" top-level section covering: the general rule, supported numeric types, conversion-failure behavior (silent no-op, including empty strings on `Nullable<T>`), and culture sensitivity.
- **`docs/code/controls/textbox.md`** — new \"Binding to Numeric Properties\" subsection with a small `TextBox` ↔ `int` example, the empty-string gotcha, and a link back to the binding page for the general rule.
- **`.claude/skills/gum-docs-writing/SKILL.md`** — record the cross-cutting-topic convention so future features (localization, theming, etc.) follow the same split.

## Test plan
- [ ] Build the docs locally (or preview on GitBook) and confirm the new sections render with intact hint blocks, code blocks, and the cross-page link.
- [ ] Click through the link from `textbox.md` to the new anchor in `advanced-binding-options.md` to confirm GitBook resolves the cross-file anchor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)