### PR TITLE
Forms property promotion v3: remaining FrameworkElement properties (#2637)

### DIFF
--- a/.claude/skills/gum-forms-behaviors/SKILL.md
+++ b/.claude/skills/gum-forms-behaviors/SKILL.md
@@ -89,11 +89,31 @@ Tier 3 is **virtual** — never written to state, never appears in `.gusx`. Stat
 - `BehaviorFormsPropertyApplier.Apply` adds the third tier inline: `ReadEffectiveValue(...) ?? declaration.Value`.
 - `StateReferencingInstanceMember.DefaultValueFallback` lets the variable grid show the declared default in the checkbox/text without writing into state. `IsDefault` still returns true (state empty), preserving the grid's italic/grey styling.
 
+### `VariableSave.Description` (v3)
+
+Authored documentation persisted alongside the FormsProperty declaration in the `.behx`. `ElementSaveDisplayer.AddBehaviorFormsPropertyMembers` seeds each row's `srim.DetailText` from the declaration's `Description` when surfacing behavior-promoted variables, so the variable grid shows authored docs by default. Distinct from the `[XmlIgnore]` `DetailText` field, which holds transient state-dependent hints set by tool/plugin code at runtime; see the cross-referencing XML docs on both fields. Use `Description` only when a property's name is ambiguous, has overlapping siblings (e.g. `MaxLength` vs `MaxLettersToShow`), or assumes prior framework knowledge.
+
 ### Covered today
 
-`ToolTip` (logical-only) and `IsEnabled` (state-mapped, with `<X>CategoryState` reference) on every standard Forms behavior. Behaviors with no Disabled visual still get the `IsEnabled` `FormsProperty` (runtime reflection works), but no `ToolOnlyVariableReference` since there's no visual state to drive.
+State-mapped (FormsProperty + ToolOnlyVariableReference, three-tier default resolution):
+- `IsEnabled` — every standard Forms behavior. Behaviors with no Disabled visual still get the `FormsProperty` (runtime reflection works) but no reference (no visual state to drive).
+- `IsChecked` — CheckBox, RadioButton, Toggle, with nested-ternary references combining IsEnabled and IsChecked into the appropriate `<X>CategoryState` slot.
 
-Reflection apply is generic, so any new logical-only `FormsProperty` declaration (e.g. `MaxCharacters`, `Slider.Minimum/Maximum/Value`) flows through without runtime changes. State-mapped properties beyond `IsEnabled` (e.g. `IsChecked`) follow the same v2 shape: declare the `FormsProperty` plus a `ToolOnlyVariableReference` driving the appropriate `<X>CategoryState`.
+Logical-only (FormsProperty only — runtime reflects directly):
+- `ToolTip` — every standard Forms behavior.
+- TextBox/PasswordBox: `AcceptsReturn`, `AcceptsTab`, `IsReadOnly`, `Placeholder`, `MaxLength` (`int?`).
+- TextBox-only: `MaxLettersToShow` (`int?`), `MaxNumberOfLines` (`int?`).
+- Slider/ScrollBar (RangeBase): `Minimum`, `Maximum`, `Value`, `SmallChange`, `LargeChange`.
+- Slider-only: `TicksFrequency`, `IsSnapToTickEnabled`.
+- ScrollViewer: `SmallChange`, `LargeChange` (fanned to inner scroll bars by ScrollViewer's setters).
+
+**Nullable type declarations.** When a Forms control's property is `int?` and `null` is meaningful (e.g. `MaxLength = null` means no limit), declare `Type="int?"` not `Type="int"` so the variable grid renders the nullable editor and authors can clear back to null. The runtime applier reflects on `prop.PropertyType` regardless, so coercion works either way.
+
+Reflection apply is generic, so any new logical-only `FormsProperty` declaration flows through without runtime changes. State-mapped properties beyond what's listed follow the same shape: declare the `FormsProperty`(/ies) plus a `ToolOnlyVariableReference` driving the appropriate `<X>CategoryState`.
+
+### Not yet covered — enum-typed properties
+
+`TextWrapping`, `ScrollBarVisibility`, `Orientation` need string→enum coercion in `BehaviorFormsPropertyApplier.Apply` (currently uses `Convert.ChangeType`, which doesn't handle enums) and `EvaluatedSyntax.CastTo` for engine-side support if any reference puts an enum on a ternary RHS. Tracked as a separate PR.
 
 ## Key Files
 
@@ -107,7 +127,8 @@ Reflection apply is generic, so any new logical-only `FormsProperty` declaration
 | `MonoGameGum/Forms/DefaultFromFileVisuals/` | `DefaultFromFileXxxRuntime` classes — `AfterFullCreation()` creates Forms objects |
 | `MonoGameGum/Forms/BehaviorFormsPropertyApplier.cs` | Reflects `BehaviorSave.FormsProperties` values onto the wrapped `FrameworkElement` (with three-tier default resolution) |
 | `Gum/Plugins/InternalPlugins/VariableGrid/BehaviorToolOnlyReferencesApplier.cs` | Tool-only design-time apply pass for `ToolOnlyVariableReferences`. Strictly tool-only — never invoked from runtime / generated code. |
-| `Gum/Plugins/InternalPlugins/VariableGrid/ElementSaveDisplayer.cs` | `AddBehaviorFormsPropertyMembers` — surfaces FormsProperties in the variable grid; sets `DefaultValueFallback` on each SRIM so the grid shows the declared default. |
+| `Gum/Plugins/InternalPlugins/VariableGrid/ElementSaveDisplayer.cs` | `AddBehaviorFormsPropertyMembers` — surfaces FormsProperties in the variable grid; sets `DefaultValueFallback` on each SRIM so the grid shows the declared default; seeds `srim.DetailText` from the FormsProperty's `Description`. |
+| `GumDataTypes/Variables/VariableSave.cs` | `Description` (persisted, XML-serialized) and `DetailText` (`[XmlIgnore]`, transient) fields with cross-referencing XML docs. |
 | `Gum/Plugins/InternalPlugins/VariableGrid/StateReferencingInstanceMember.cs` | `DefaultValueFallback` final tier in the value getter for grid display. |
 | `Runtimes/GumExpressions/EvaluatedSyntax.cs` | Optional `fallback` parameter on `FromSyntaxNode` threaded through evaluation. |
 | `Gum/DataTypes/RecursiveVariableFinder.cs` | `Fallback` property consulted when state lookup returns null. |

--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ Runtimes/GumShapes/XnbTest/
 # Temp folder for draft/scratch files (e.g. release notes drafts)
 /temp/*
 !/temp/.gitkeep
+/.claude/worktrees

--- a/Gum/Plugins/InternalPlugins/VariableGrid/ElementSaveDisplayer.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/ElementSaveDisplayer.cs
@@ -686,6 +686,14 @@ public class ElementSaveDisplayer
                 VariableSave declaration = formsProperty;
                 srim.DefaultValueFallback = () => declaration.Value;
 
+                // Seed the row's display text from the FormsProperty's authored Description
+                // (persisted in the .behx). Later state-dependent hints set elsewhere via
+                // srim.DetailText can still overwrite or append to this seed.
+                if (!string.IsNullOrEmpty(formsProperty.Description))
+                {
+                    srim.DetailText = formsProperty.Description;
+                }
+
                 behaviorCategory.Members.Add(srim);
             }
         }

--- a/Gum/Plugins/InternalPlugins/VariableGrid/StateReferencingInstanceMember.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/StateReferencingInstanceMember.cs
@@ -129,7 +129,7 @@ public class StateReferencingInstanceMember : InstanceMember
         }
     }
 
-    private object GetValueStrictlyOnSelectedState(object component)
+    private object? GetValueStrictlyOnSelectedState(object component)
     {
         if (mStateSave != null)
         {

--- a/GumDataTypes/Variables/VariableSave.cs
+++ b/GumDataTypes/Variables/VariableSave.cs
@@ -193,6 +193,36 @@ public class VariableSave
     public Type PreferredDisplayer { get; set; }
     // If adding stuff here, make sure to add to the Clone method!
 
+    /// <summary>
+    /// Authored documentation for this variable, persisted alongside the declaration in the
+    /// containing save file (typically a <c>FormsProperty</c> entry inside a <c>.behx</c>, or
+    /// a standard variable declaration). This describes <i>what the variable is</i> and does
+    /// not change at runtime.
+    /// </summary>
+    /// <remarks>
+    /// Distinct from <see cref="DetailText"/>: <see cref="Description"/> is invariant authoring
+    /// data that ships with the project file, whereas <see cref="DetailText"/> is a transient,
+    /// state-dependent hint set by tool/plugin code at runtime. The variable grid surfaces
+    /// <see cref="Description"/> by seeding the row's display text from it; later runtime
+    /// hints can still overwrite or append to that display text via <see cref="DetailText"/>.
+    /// </remarks>
+    public string? Description { get; set; }
+
+    public bool ShouldSerializeDescription() => !string.IsNullOrEmpty(Description);
+
+    /// <summary>
+    /// Transient, runtime-only display hint shown in the variable grid for this variable's
+    /// row. Populated by tool/plugin code based on the current project state — e.g.
+    /// <c>"bmfont cannot generate from .ttf files. Switch to KernSmith in Project Properties."</c>
+    /// shown when the active font configuration is incompatible. Not serialized.
+    /// </summary>
+    /// <remarks>
+    /// Distinct from <see cref="Description"/>: <see cref="DetailText"/> describes
+    /// <i>what's currently true given the project state</i>, while <see cref="Description"/>
+    /// describes <i>what the variable is</i> and is persisted. The variable grid seeds this
+    /// field from <see cref="Description"/> when surfacing FormsProperty declarations, so a
+    /// row with no transient hints still shows the authored documentation.
+    /// </remarks>
     [XmlIgnore]
     public string DetailText { get; set; } = string.Empty;
 

--- a/MonoGameGum.Tests/DataTypes/GumFileSerializerTests.cs
+++ b/MonoGameGum.Tests/DataTypes/GumFileSerializerTests.cs
@@ -139,6 +139,40 @@ public class GumFileSerializerTests
     }
 
     [Fact]
+    public void RoundTripBehaviorSave_FormsPropertyWithDescription_PreservesDescription()
+    {
+        BehaviorSave original = new BehaviorSave();
+        original.FormsProperties.Add(new VariableSave
+        {
+            Type = "bool",
+            Name = "AcceptsReturn",
+            Value = false,
+            Description = "If true, pressing Enter inserts a newline."
+        });
+
+        FileManager.XmlSerialize(original, out string xml);
+
+        xml.ShouldContain("<Description>If true, pressing Enter inserts a newline.</Description>");
+
+        BehaviorSave? result = GumFileSerializer.DeserializeBehaviorSave(xml, projectVersion: 2);
+
+        result.ShouldNotBeNull();
+        result.FormsProperties.Count.ShouldBe(1);
+        result.FormsProperties[0].Description.ShouldBe("If true, pressing Enter inserts a newline.");
+    }
+
+    [Fact]
+    public void SerializeBehaviorSave_FormsPropertyWithoutDescription_OmitsDescriptionElement()
+    {
+        BehaviorSave original = new BehaviorSave();
+        original.FormsProperties.Add(new VariableSave { Type = "string", Name = "ToolTip" });
+
+        FileManager.XmlSerialize(original, out string xml);
+
+        xml.ShouldNotContain("<Description");
+    }
+
+    [Fact]
     public void SerializeBehaviorSave_EmptyToolOnlyVariableReferences_OmittedFromXml()
     {
         BehaviorSave original = new BehaviorSave();

--- a/MonoGameGum.Tests/Forms/BehaviorFormsPropertyApplyTests.cs
+++ b/MonoGameGum.Tests/Forms/BehaviorFormsPropertyApplyTests.cs
@@ -85,6 +85,74 @@ public class BehaviorFormsPropertyApplyTests : BaseTestClass
     }
 
     [Fact]
+    public void Apply_CheckBoxIsCheckedTrueFromState_CoercesBoolToNullableBoolOnCheckBox()
+    {
+        BehaviorSave behavior = new BehaviorSave { Name = "CheckBoxBehavior" };
+        behavior.FormsProperties.Add(new VariableSave
+        {
+            Type = "bool",
+            Name = "IsChecked",
+            Value = false
+        });
+
+        ComponentSave component = new ComponentSave { Name = "Controls/CheckBox", BaseType = "Container" };
+        StateSave defaultState = new StateSave { Name = "Default", ParentContainer = component };
+        defaultState.Variables.Add(new VariableSave
+        {
+            Type = "bool",
+            Name = "IsChecked",
+            Value = true,
+            SetsValue = true
+        });
+        component.States.Add(defaultState);
+        component.Behaviors.Add(new ElementBehaviorReference { BehaviorName = "CheckBoxBehavior" });
+
+        GumProjectSave project = new GumProjectSave();
+        project.Components.Add(component);
+        project.Behaviors.Add(behavior);
+        ObjectFinder.Self.GumProjectSave = project;
+
+        InteractiveGue visual = new InteractiveGue();
+        visual.ElementSave = component;
+
+        CheckBox checkBox = new CheckBox(visual);
+        BehaviorFormsPropertyApplier.Apply(checkBox, visual);
+
+        checkBox.IsChecked.ShouldBe(true);
+    }
+
+    [Fact]
+    public void Apply_CheckBoxIsCheckedUnauthored_FallsBackToBehaviorDefaultFalse()
+    {
+        BehaviorSave behavior = new BehaviorSave { Name = "CheckBoxBehavior" };
+        behavior.FormsProperties.Add(new VariableSave
+        {
+            Type = "bool",
+            Name = "IsChecked",
+            Value = false
+        });
+
+        ComponentSave component = new ComponentSave { Name = "Controls/CheckBox", BaseType = "Container" };
+        component.States.Add(new StateSave { Name = "Default", ParentContainer = component });
+        component.Behaviors.Add(new ElementBehaviorReference { BehaviorName = "CheckBoxBehavior" });
+
+        GumProjectSave project = new GumProjectSave();
+        project.Components.Add(component);
+        project.Behaviors.Add(behavior);
+        ObjectFinder.Self.GumProjectSave = project;
+
+        InteractiveGue visual = new InteractiveGue();
+        visual.ElementSave = component;
+
+        CheckBox checkBox = new CheckBox(visual);
+        // Force a non-default starting value to verify Apply writes the declared default.
+        checkBox.IsChecked = true;
+        BehaviorFormsPropertyApplier.Apply(checkBox, visual);
+
+        checkBox.IsChecked.ShouldBe(false);
+    }
+
+    [Fact]
     public void Apply_ParentScreenInstanceOverride_OverridesComponentDefault()
     {
         BehaviorSave behavior = new BehaviorSave { Name = "ButtonBehavior" };

--- a/MonoGameGum.Tests/Forms/BehaviorFormsPropertyApplyTests.cs
+++ b/MonoGameGum.Tests/Forms/BehaviorFormsPropertyApplyTests.cs
@@ -153,6 +153,44 @@ public class BehaviorFormsPropertyApplyTests : BaseTestClass
     }
 
     [Fact]
+    public void Apply_TextBoxAcceptsReturnTrue_AppliesToFormsControl()
+    {
+        BehaviorSave behavior = new BehaviorSave { Name = "TextBoxBehavior" };
+        behavior.FormsProperties.Add(new VariableSave
+        {
+            Type = "bool",
+            Name = "AcceptsReturn",
+            Value = false
+        });
+
+        ComponentSave component = new ComponentSave { Name = "Controls/TextBox", BaseType = "Container" };
+        StateSave defaultState = new StateSave { Name = "Default", ParentContainer = component };
+        defaultState.Variables.Add(new VariableSave
+        {
+            Type = "bool",
+            Name = "AcceptsReturn",
+            Value = true,
+            SetsValue = true
+        });
+        component.States.Add(defaultState);
+        component.Behaviors.Add(new ElementBehaviorReference { BehaviorName = "TextBoxBehavior" });
+
+        GumProjectSave project = new GumProjectSave();
+        project.Components.Add(component);
+        project.Behaviors.Add(behavior);
+        ObjectFinder.Self.GumProjectSave = project;
+
+        // TextBox's parameterless ctor builds a default visual tree (TextInstance/CaretInstance
+        // children) which TextBoxBase.ReactToVisualChanged requires. Attach the project component
+        // to that visual so the applier can resolve the FormsProperty against state.
+        TextBox textBox = new TextBox();
+        textBox.Visual.ElementSave = component;
+        BehaviorFormsPropertyApplier.Apply(textBox, textBox.Visual);
+
+        textBox.AcceptsReturn.ShouldBe(true);
+    }
+
+    [Fact]
     public void Apply_ParentScreenInstanceOverride_OverridesComponentDefault()
     {
         BehaviorSave behavior = new BehaviorSave { Name = "ButtonBehavior" };

--- a/MonoGameGum.Tests/Forms/BehaviorFormsPropertyApplyTests.cs
+++ b/MonoGameGum.Tests/Forms/BehaviorFormsPropertyApplyTests.cs
@@ -260,6 +260,41 @@ public class BehaviorFormsPropertyApplyTests : BaseTestClass
     }
 
     [Fact]
+    public void Apply_SliderMaximumFromState_AppliesToFormsControl()
+    {
+        BehaviorSave behavior = new BehaviorSave { Name = "SliderBehavior" };
+        behavior.FormsProperties.Add(new VariableSave
+        {
+            Type = "double",
+            Name = "Maximum",
+            Value = 100.0
+        });
+
+        ComponentSave component = new ComponentSave { Name = "Controls/Slider", BaseType = "Container" };
+        StateSave defaultState = new StateSave { Name = "Default", ParentContainer = component };
+        defaultState.Variables.Add(new VariableSave
+        {
+            Type = "double",
+            Name = "Maximum",
+            Value = 250.0,
+            SetsValue = true
+        });
+        component.States.Add(defaultState);
+        component.Behaviors.Add(new ElementBehaviorReference { BehaviorName = "SliderBehavior" });
+
+        GumProjectSave project = new GumProjectSave();
+        project.Components.Add(component);
+        project.Behaviors.Add(behavior);
+        ObjectFinder.Self.GumProjectSave = project;
+
+        Slider slider = new Slider();
+        slider.Visual.ElementSave = component;
+        BehaviorFormsPropertyApplier.Apply(slider, slider.Visual);
+
+        slider.Maximum.ShouldBe(250.0);
+    }
+
+    [Fact]
     public void Apply_ParentScreenInstanceOverride_OverridesComponentDefault()
     {
         BehaviorSave behavior = new BehaviorSave { Name = "ButtonBehavior" };

--- a/MonoGameGum.Tests/Forms/BehaviorFormsPropertyApplyTests.cs
+++ b/MonoGameGum.Tests/Forms/BehaviorFormsPropertyApplyTests.cs
@@ -226,6 +226,40 @@ public class BehaviorFormsPropertyApplyTests : BaseTestClass
     }
 
     [Fact]
+    public void Apply_TextBoxMaxLengthFromState_CoercesIntToNullableIntOnTextBox()
+    {
+        BehaviorSave behavior = new BehaviorSave { Name = "TextBoxBehavior" };
+        behavior.FormsProperties.Add(new VariableSave
+        {
+            Type = "int",
+            Name = "MaxLength"
+        });
+
+        ComponentSave component = new ComponentSave { Name = "Controls/TextBox", BaseType = "Container" };
+        StateSave defaultState = new StateSave { Name = "Default", ParentContainer = component };
+        defaultState.Variables.Add(new VariableSave
+        {
+            Type = "int",
+            Name = "MaxLength",
+            Value = 50,
+            SetsValue = true
+        });
+        component.States.Add(defaultState);
+        component.Behaviors.Add(new ElementBehaviorReference { BehaviorName = "TextBoxBehavior" });
+
+        GumProjectSave project = new GumProjectSave();
+        project.Components.Add(component);
+        project.Behaviors.Add(behavior);
+        ObjectFinder.Self.GumProjectSave = project;
+
+        TextBox textBox = new TextBox();
+        textBox.Visual.ElementSave = component;
+        BehaviorFormsPropertyApplier.Apply(textBox, textBox.Visual);
+
+        textBox.MaxLength.ShouldBe(50);
+    }
+
+    [Fact]
     public void Apply_ParentScreenInstanceOverride_OverridesComponentDefault()
     {
         BehaviorSave behavior = new BehaviorSave { Name = "ButtonBehavior" };

--- a/MonoGameGum.Tests/Forms/BehaviorFormsPropertyApplyTests.cs
+++ b/MonoGameGum.Tests/Forms/BehaviorFormsPropertyApplyTests.cs
@@ -191,6 +191,41 @@ public class BehaviorFormsPropertyApplyTests : BaseTestClass
     }
 
     [Fact]
+    public void Apply_TextBoxIsReadOnlyTrue_AppliesToFormsControl()
+    {
+        BehaviorSave behavior = new BehaviorSave { Name = "TextBoxBehavior" };
+        behavior.FormsProperties.Add(new VariableSave
+        {
+            Type = "bool",
+            Name = "IsReadOnly",
+            Value = false
+        });
+
+        ComponentSave component = new ComponentSave { Name = "Controls/TextBox", BaseType = "Container" };
+        StateSave defaultState = new StateSave { Name = "Default", ParentContainer = component };
+        defaultState.Variables.Add(new VariableSave
+        {
+            Type = "bool",
+            Name = "IsReadOnly",
+            Value = true,
+            SetsValue = true
+        });
+        component.States.Add(defaultState);
+        component.Behaviors.Add(new ElementBehaviorReference { BehaviorName = "TextBoxBehavior" });
+
+        GumProjectSave project = new GumProjectSave();
+        project.Components.Add(component);
+        project.Behaviors.Add(behavior);
+        ObjectFinder.Self.GumProjectSave = project;
+
+        TextBox textBox = new TextBox();
+        textBox.Visual.ElementSave = component;
+        BehaviorFormsPropertyApplier.Apply(textBox, textBox.Visual);
+
+        textBox.IsReadOnly.ShouldBe(true);
+    }
+
+    [Fact]
     public void Apply_ParentScreenInstanceOverride_OverridesComponentDefault()
     {
         BehaviorSave behavior = new BehaviorSave { Name = "ButtonBehavior" };

--- a/Tool/Tests/GumToolUnitTests/PropertyGridHelpers/ElementSaveDisplayerFormsPropertiesTests.cs
+++ b/Tool/Tests/GumToolUnitTests/PropertyGridHelpers/ElementSaveDisplayerFormsPropertiesTests.cs
@@ -182,6 +182,41 @@ public class ElementSaveDisplayerFormsPropertiesTests : BaseTestClass
     }
 
     [Fact]
+    public void AddBehaviorFormsPropertyMembers_FormsPropertyWithDescription_SeedsSrimDetailText()
+    {
+        BehaviorSave describedBehavior = new BehaviorSave { Name = "DescribedBehavior" };
+        describedBehavior.FormsProperties.Add(new VariableSave
+        {
+            Type = "bool",
+            Name = "AcceptsReturn",
+            Value = false,
+            Description = "If true, pressing Enter inserts a newline."
+        });
+
+        ComponentSave component = new ComponentSave { Name = "Controls/Described", BaseType = "Container" };
+        component.States.Add(new StateSave { Name = "Default", ParentContainer = component });
+        component.Behaviors.Add(new ElementBehaviorReference { BehaviorName = "DescribedBehavior" });
+        _project.Behaviors.Add(describedBehavior);
+        _project.Components.Add(component);
+
+        List<MemberCategory> categories = new List<MemberCategory>();
+
+        _displayer.AddBehaviorFormsPropertyMembers(
+            elementWithBehaviors: component,
+            instanceOwner: component,
+            instance: null,
+            stateSave: component.DefaultState,
+            stateSaveCategory: null,
+            categories: categories);
+
+        MemberCategory? behaviorCategory = categories.FirstOrDefault(c => c.Name == "Behavior");
+        behaviorCategory.ShouldNotBeNull();
+        InstanceMember? acceptsReturnMember = behaviorCategory.Members.FirstOrDefault(m => m.Name == "AcceptsReturn");
+        acceptsReturnMember.ShouldNotBeNull();
+        acceptsReturnMember.DetailText.ShouldBe("If true, pressing Enter inserts a newline.");
+    }
+
+    [Fact]
     public void AddBehaviorFormsPropertyMembers_VariableAlreadyInGeneralCategory_MovesToBehaviorCategory()
     {
         // Simulates the case where the component has set a default value for the

--- a/Tool/Tests/GumToolUnitTests/VariableGrid/BehaviorToolOnlyReferencesApplierTests.cs
+++ b/Tool/Tests/GumToolUnitTests/VariableGrid/BehaviorToolOnlyReferencesApplierTests.cs
@@ -194,6 +194,128 @@ public class BehaviorToolOnlyReferencesApplierTests : BaseTestClass
     }
 
     [Fact]
+    public void Apply_CheckBoxIsCheckedTrueAndIsEnabledTrue_WritesEnabledOnCategoryState()
+    {
+        BehaviorSave behavior = BuildCheckBoxBehavior();
+
+        ComponentSave component = new ComponentSave { Name = "Controls/CheckBox", BaseType = "Container" };
+        StateSave defaultState = new StateSave { Name = "Default", ParentContainer = component };
+        defaultState.Variables.Add(new VariableSave
+        {
+            Type = "bool",
+            Name = "IsEnabled",
+            Value = true,
+            SetsValue = true
+        });
+        defaultState.Variables.Add(new VariableSave
+        {
+            Type = "bool",
+            Name = "IsChecked",
+            Value = true,
+            SetsValue = true
+        });
+        component.States.Add(defaultState);
+        component.Behaviors.Add(new ElementBehaviorReference { BehaviorName = "CheckBoxBehavior" });
+
+        GumProjectSave project = new GumProjectSave();
+        project.Components.Add(component);
+        project.Behaviors.Add(behavior);
+        ObjectFinder.Self.GumProjectSave = project;
+
+        BehaviorToolOnlyReferencesApplier.Apply(component, defaultState);
+
+        defaultState.GetValue("CheckBoxCategoryState").ShouldBe("EnabledOn");
+    }
+
+    [Fact]
+    public void Apply_CheckBoxIsCheckedFalseAndIsEnabledFalse_WritesDisabledOffCategoryState()
+    {
+        BehaviorSave behavior = BuildCheckBoxBehavior();
+
+        ComponentSave component = new ComponentSave { Name = "Controls/CheckBox", BaseType = "Container" };
+        StateSave defaultState = new StateSave { Name = "Default", ParentContainer = component };
+        defaultState.Variables.Add(new VariableSave
+        {
+            Type = "bool",
+            Name = "IsEnabled",
+            Value = false,
+            SetsValue = true
+        });
+        defaultState.Variables.Add(new VariableSave
+        {
+            Type = "bool",
+            Name = "IsChecked",
+            Value = false,
+            SetsValue = true
+        });
+        component.States.Add(defaultState);
+        component.Behaviors.Add(new ElementBehaviorReference { BehaviorName = "CheckBoxBehavior" });
+
+        GumProjectSave project = new GumProjectSave();
+        project.Components.Add(component);
+        project.Behaviors.Add(behavior);
+        ObjectFinder.Self.GumProjectSave = project;
+
+        BehaviorToolOnlyReferencesApplier.Apply(component, defaultState);
+
+        defaultState.GetValue("CheckBoxCategoryState").ShouldBe("DisabledOff");
+    }
+
+    [Fact]
+    public void Apply_CheckBoxIsCheckedTrueAndIsEnabledFalse_WritesDisabledOnCategoryState()
+    {
+        BehaviorSave behavior = BuildCheckBoxBehavior();
+
+        ComponentSave component = new ComponentSave { Name = "Controls/CheckBox", BaseType = "Container" };
+        StateSave defaultState = new StateSave { Name = "Default", ParentContainer = component };
+        defaultState.Variables.Add(new VariableSave
+        {
+            Type = "bool",
+            Name = "IsEnabled",
+            Value = false,
+            SetsValue = true
+        });
+        defaultState.Variables.Add(new VariableSave
+        {
+            Type = "bool",
+            Name = "IsChecked",
+            Value = true,
+            SetsValue = true
+        });
+        component.States.Add(defaultState);
+        component.Behaviors.Add(new ElementBehaviorReference { BehaviorName = "CheckBoxBehavior" });
+
+        GumProjectSave project = new GumProjectSave();
+        project.Components.Add(component);
+        project.Behaviors.Add(behavior);
+        ObjectFinder.Self.GumProjectSave = project;
+
+        BehaviorToolOnlyReferencesApplier.Apply(component, defaultState);
+
+        defaultState.GetValue("CheckBoxCategoryState").ShouldBe("DisabledOn");
+    }
+
+    [Fact]
+    public void Apply_CheckBoxStateEmpty_FallsBackToBehaviorIsCheckedFalseAndIsEnabledTrue()
+    {
+        BehaviorSave behavior = BuildCheckBoxBehavior();
+
+        ComponentSave component = new ComponentSave { Name = "Controls/CheckBox", BaseType = "Container" };
+        StateSave defaultState = new StateSave { Name = "Default", ParentContainer = component };
+        component.States.Add(defaultState);
+        component.Behaviors.Add(new ElementBehaviorReference { BehaviorName = "CheckBoxBehavior" });
+
+        GumProjectSave project = new GumProjectSave();
+        project.Components.Add(component);
+        project.Behaviors.Add(behavior);
+        ObjectFinder.Self.GumProjectSave = project;
+
+        BehaviorToolOnlyReferencesApplier.Apply(component, defaultState);
+
+        defaultState.GetValue("CheckBoxCategoryState").ShouldBe("EnabledOff");
+    }
+
+    [Fact]
     public void Apply_BehaviorWithoutToolOnlyReferences_DoesNothing()
     {
         BehaviorSave behavior = new BehaviorSave { Name = "ButtonBehavior" };
@@ -211,5 +333,25 @@ public class BehaviorToolOnlyReferencesApplierTests : BaseTestClass
 
         Should.NotThrow(() => BehaviorToolOnlyReferencesApplier.Apply(component, defaultState));
         defaultState.Variables.ShouldBeEmpty();
+    }
+
+    private static BehaviorSave BuildCheckBoxBehavior()
+    {
+        BehaviorSave behavior = new BehaviorSave { Name = "CheckBoxBehavior" };
+        behavior.FormsProperties.Add(new VariableSave
+        {
+            Type = "bool",
+            Name = "IsEnabled",
+            Value = true
+        });
+        behavior.FormsProperties.Add(new VariableSave
+        {
+            Type = "bool",
+            Name = "IsChecked",
+            Value = false
+        });
+        behavior.ToolOnlyVariableReferences.Add(
+            "CheckBoxCategoryState = IsEnabled ? (IsChecked ? \"EnabledOn\" : \"EnabledOff\") : (IsChecked ? \"DisabledOn\" : \"DisabledOff\")");
+        return behavior;
     }
 }

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/CheckBoxBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/CheckBoxBehavior.behx
@@ -6,7 +6,10 @@
   <FormsProperty Type="bool" Name="IsEnabled">
     <Value xsi:type="xsd:boolean">true</Value>
   </FormsProperty>
-  <ToolOnlyVariableReference>CheckBoxCategoryState = IsEnabled ? "EnabledOff" : "DisabledOff"</ToolOnlyVariableReference>
+  <FormsProperty Type="bool" Name="IsChecked">
+    <Value xsi:type="xsd:boolean">false</Value>
+  </FormsProperty>
+  <ToolOnlyVariableReference>CheckBoxCategoryState = IsEnabled ? (IsChecked ? "EnabledOn" : "EnabledOff") : (IsChecked ? "DisabledOn" : "DisabledOff")</ToolOnlyVariableReference>
   <Category>
     <Name>CheckBoxCategory</Name>
     <State>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/PasswordBoxBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/PasswordBoxBehavior.behx
@@ -8,6 +8,7 @@
   </FormsProperty>
   <FormsProperty Type="bool" Name="AcceptsReturn">
     <Value xsi:type="xsd:boolean">false</Value>
+    <Description>If true, Enter inserts a newline; otherwise it fires the default action.</Description>
   </FormsProperty>
   <ToolOnlyVariableReference>PasswordBoxCategoryState = IsEnabled ? "Enabled" : "Disabled"</ToolOnlyVariableReference>
   <Category>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/PasswordBoxBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/PasswordBoxBehavior.behx
@@ -6,6 +6,9 @@
   <FormsProperty Type="bool" Name="IsEnabled">
     <Value xsi:type="xsd:boolean">true</Value>
   </FormsProperty>
+  <FormsProperty Type="bool" Name="AcceptsReturn">
+    <Value xsi:type="xsd:boolean">false</Value>
+  </FormsProperty>
   <ToolOnlyVariableReference>PasswordBoxCategoryState = IsEnabled ? "Enabled" : "Disabled"</ToolOnlyVariableReference>
   <Category>
     <Name>PasswordBoxCategory</Name>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/PasswordBoxBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/PasswordBoxBehavior.behx
@@ -18,7 +18,7 @@
     <Description>If true, Tab inserts a tab; otherwise it moves focus.</Description>
   </FormsProperty>
   <FormsProperty Type="string" Name="Placeholder" />
-  <FormsProperty Type="int" Name="MaxLength">
+  <FormsProperty Type="int?" Name="MaxLength">
     <Description>Caps how many characters can be entered. Empty = no limit.</Description>
   </FormsProperty>
   <ToolOnlyVariableReference>PasswordBoxCategoryState = IsEnabled ? "Enabled" : "Disabled"</ToolOnlyVariableReference>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/PasswordBoxBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/PasswordBoxBehavior.behx
@@ -10,6 +10,9 @@
     <Value xsi:type="xsd:boolean">false</Value>
     <Description>If true, Enter inserts a newline; otherwise it fires the default action.</Description>
   </FormsProperty>
+  <FormsProperty Type="bool" Name="IsReadOnly">
+    <Value xsi:type="xsd:boolean">false</Value>
+  </FormsProperty>
   <ToolOnlyVariableReference>PasswordBoxCategoryState = IsEnabled ? "Enabled" : "Disabled"</ToolOnlyVariableReference>
   <Category>
     <Name>PasswordBoxCategory</Name>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/PasswordBoxBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/PasswordBoxBehavior.behx
@@ -13,6 +13,14 @@
   <FormsProperty Type="bool" Name="IsReadOnly">
     <Value xsi:type="xsd:boolean">false</Value>
   </FormsProperty>
+  <FormsProperty Type="bool" Name="AcceptsTab">
+    <Value xsi:type="xsd:boolean">false</Value>
+    <Description>If true, Tab inserts a tab; otherwise it moves focus.</Description>
+  </FormsProperty>
+  <FormsProperty Type="string" Name="Placeholder" />
+  <FormsProperty Type="int" Name="MaxLength">
+    <Description>Caps how many characters can be entered. Empty = no limit.</Description>
+  </FormsProperty>
   <ToolOnlyVariableReference>PasswordBoxCategoryState = IsEnabled ? "Enabled" : "Disabled"</ToolOnlyVariableReference>
   <Category>
     <Name>PasswordBoxCategory</Name>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/RadioButtonBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/RadioButtonBehavior.behx
@@ -6,7 +6,10 @@
   <FormsProperty Type="bool" Name="IsEnabled">
     <Value xsi:type="xsd:boolean">true</Value>
   </FormsProperty>
-  <ToolOnlyVariableReference>RadioButtonCategoryState = IsEnabled ? "EnabledOff" : "DisabledOff"</ToolOnlyVariableReference>
+  <FormsProperty Type="bool" Name="IsChecked">
+    <Value xsi:type="xsd:boolean">false</Value>
+  </FormsProperty>
+  <ToolOnlyVariableReference>RadioButtonCategoryState = IsEnabled ? (IsChecked ? "EnabledOn" : "EnabledOff") : (IsChecked ? "DisabledOn" : "DisabledOff")</ToolOnlyVariableReference>
   <Category>
     <Name>RadioButtonCategory</Name>
     <State>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/ScrollBarBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/ScrollBarBehavior.behx
@@ -6,6 +6,23 @@
   <FormsProperty Type="bool" Name="IsEnabled">
     <Value xsi:type="xsd:boolean">true</Value>
   </FormsProperty>
+  <FormsProperty Type="double" Name="Minimum">
+    <Value xsi:type="xsd:double">0</Value>
+  </FormsProperty>
+  <FormsProperty Type="double" Name="Maximum">
+    <Value xsi:type="xsd:double">100</Value>
+  </FormsProperty>
+  <FormsProperty Type="double" Name="Value">
+    <Value xsi:type="xsd:double">0</Value>
+  </FormsProperty>
+  <FormsProperty Type="double" Name="SmallChange">
+    <Value xsi:type="xsd:double">1</Value>
+    <Description>Step size for arrow buttons / mouse wheel.</Description>
+  </FormsProperty>
+  <FormsProperty Type="double" Name="LargeChange">
+    <Value xsi:type="xsd:double">10</Value>
+    <Description>Step size for clicks on the track.</Description>
+  </FormsProperty>
   <Category>
     <Name>ScrollBarCategory</Name>
   </Category>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/ScrollViewerBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/ScrollViewerBehavior.behx
@@ -6,6 +6,14 @@
   <FormsProperty Type="bool" Name="IsEnabled">
     <Value xsi:type="xsd:boolean">true</Value>
   </FormsProperty>
+  <FormsProperty Type="double" Name="SmallChange">
+    <Value xsi:type="xsd:double">1</Value>
+    <Description>Step size for arrow buttons / mouse wheel.</Description>
+  </FormsProperty>
+  <FormsProperty Type="double" Name="LargeChange">
+    <Value xsi:type="xsd:double">10</Value>
+    <Description>Step size for clicks on the scroll bar track.</Description>
+  </FormsProperty>
   <Category>
     <Name>ScrollBarVisibility</Name>
     <State>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/SliderBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/SliderBehavior.behx
@@ -6,6 +6,29 @@
   <FormsProperty Type="bool" Name="IsEnabled">
     <Value xsi:type="xsd:boolean">true</Value>
   </FormsProperty>
+  <FormsProperty Type="double" Name="Minimum">
+    <Value xsi:type="xsd:double">0</Value>
+  </FormsProperty>
+  <FormsProperty Type="double" Name="Maximum">
+    <Value xsi:type="xsd:double">100</Value>
+  </FormsProperty>
+  <FormsProperty Type="double" Name="Value">
+    <Value xsi:type="xsd:double">0</Value>
+  </FormsProperty>
+  <FormsProperty Type="double" Name="SmallChange">
+    <Value xsi:type="xsd:double">1</Value>
+    <Description>Step size for arrow keys / mouse wheel.</Description>
+  </FormsProperty>
+  <FormsProperty Type="double" Name="LargeChange">
+    <Value xsi:type="xsd:double">10</Value>
+    <Description>Step size for clicks on the track.</Description>
+  </FormsProperty>
+  <FormsProperty Type="double" Name="TicksFrequency">
+    <Value xsi:type="xsd:double">1</Value>
+  </FormsProperty>
+  <FormsProperty Type="bool" Name="IsSnapToTickEnabled">
+    <Value xsi:type="xsd:boolean">false</Value>
+  </FormsProperty>
   <Category>
     <Name>SliderCategory</Name>
     <State>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/TextBoxBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/TextBoxBehavior.behx
@@ -18,13 +18,13 @@
     <Description>If true, Tab inserts a tab; otherwise it moves focus.</Description>
   </FormsProperty>
   <FormsProperty Type="string" Name="Placeholder" />
-  <FormsProperty Type="int" Name="MaxLength">
+  <FormsProperty Type="int?" Name="MaxLength">
     <Description>Caps how many characters can be entered. Empty = no limit.</Description>
   </FormsProperty>
-  <FormsProperty Type="int" Name="MaxLettersToShow">
+  <FormsProperty Type="int?" Name="MaxLettersToShow">
     <Description>Caps how many letters are rendered. Use MaxLength to cap input itself.</Description>
   </FormsProperty>
-  <FormsProperty Type="int" Name="MaxNumberOfLines">
+  <FormsProperty Type="int?" Name="MaxNumberOfLines">
     <Description>Caps how many lines are rendered.</Description>
   </FormsProperty>
   <ToolOnlyVariableReference>TextBoxCategoryState = IsEnabled ? "Enabled" : "Disabled"</ToolOnlyVariableReference>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/TextBoxBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/TextBoxBehavior.behx
@@ -13,6 +13,20 @@
   <FormsProperty Type="bool" Name="IsReadOnly">
     <Value xsi:type="xsd:boolean">false</Value>
   </FormsProperty>
+  <FormsProperty Type="bool" Name="AcceptsTab">
+    <Value xsi:type="xsd:boolean">false</Value>
+    <Description>If true, Tab inserts a tab; otherwise it moves focus.</Description>
+  </FormsProperty>
+  <FormsProperty Type="string" Name="Placeholder" />
+  <FormsProperty Type="int" Name="MaxLength">
+    <Description>Caps how many characters can be entered. Empty = no limit.</Description>
+  </FormsProperty>
+  <FormsProperty Type="int" Name="MaxLettersToShow">
+    <Description>Caps how many letters are rendered. Use MaxLength to cap input itself.</Description>
+  </FormsProperty>
+  <FormsProperty Type="int" Name="MaxNumberOfLines">
+    <Description>Caps how many lines are rendered.</Description>
+  </FormsProperty>
   <ToolOnlyVariableReference>TextBoxCategoryState = IsEnabled ? "Enabled" : "Disabled"</ToolOnlyVariableReference>
   <Category>
     <Name>TextBoxCategory</Name>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/TextBoxBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/TextBoxBehavior.behx
@@ -6,6 +6,9 @@
   <FormsProperty Type="bool" Name="IsEnabled">
     <Value xsi:type="xsd:boolean">true</Value>
   </FormsProperty>
+  <FormsProperty Type="bool" Name="AcceptsReturn">
+    <Value xsi:type="xsd:boolean">false</Value>
+  </FormsProperty>
   <ToolOnlyVariableReference>TextBoxCategoryState = IsEnabled ? "Enabled" : "Disabled"</ToolOnlyVariableReference>
   <Category>
     <Name>TextBoxCategory</Name>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/TextBoxBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/TextBoxBehavior.behx
@@ -10,6 +10,9 @@
     <Value xsi:type="xsd:boolean">false</Value>
     <Description>If true, Enter inserts a newline; otherwise it fires the default action.</Description>
   </FormsProperty>
+  <FormsProperty Type="bool" Name="IsReadOnly">
+    <Value xsi:type="xsd:boolean">false</Value>
+  </FormsProperty>
   <ToolOnlyVariableReference>TextBoxCategoryState = IsEnabled ? "Enabled" : "Disabled"</ToolOnlyVariableReference>
   <Category>
     <Name>TextBoxCategory</Name>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/TextBoxBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/TextBoxBehavior.behx
@@ -8,6 +8,7 @@
   </FormsProperty>
   <FormsProperty Type="bool" Name="AcceptsReturn">
     <Value xsi:type="xsd:boolean">false</Value>
+    <Description>If true, Enter inserts a newline; otherwise it fires the default action.</Description>
   </FormsProperty>
   <ToolOnlyVariableReference>TextBoxCategoryState = IsEnabled ? "Enabled" : "Disabled"</ToolOnlyVariableReference>
   <Category>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/ToggleBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/ToggleBehavior.behx
@@ -6,7 +6,10 @@
   <FormsProperty Type="bool" Name="IsEnabled">
     <Value xsi:type="xsd:boolean">true</Value>
   </FormsProperty>
-  <ToolOnlyVariableReference>ToggleCategoryState = IsEnabled ? "EnabledOff" : "DisabledOff"</ToolOnlyVariableReference>
+  <FormsProperty Type="bool" Name="IsChecked">
+    <Value xsi:type="xsd:boolean">false</Value>
+  </FormsProperty>
+  <ToolOnlyVariableReference>ToggleCategoryState = IsEnabled ? (IsChecked ? "EnabledOn" : "EnabledOff") : (IsChecked ? "DisabledOn" : "DisabledOff")</ToolOnlyVariableReference>
   <Category>
     <Name>ToggleCategory</Name>
     <State>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/CheckBox.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/CheckBox.gucx
@@ -84,6 +84,9 @@
     <Variable Type="DimensionUnitType" Name="InnerCheck.WidthUnits" SetsValue="true">
       <Value xsi:type="xsd:int">2</Value>
     </Variable>
+    <Variable Type="bool" Name="IsChecked" SetsValue="true">
+      <Value xsi:type="xsd:boolean">false</Value>
+    </Variable>
     <Variable Type="State" Name="State" Category="States and Visibility" SetsValue="true" />
     <Variable Type="ColorCategory" Name="TextInstance.ColorCategoryState" SetsValue="true">
       <Value xsi:type="xsd:string">White</Value>


### PR DESCRIPTION
## Summary

Closes out #2637 by adding the remaining `FrameworkElement` properties to the design-time Forms-property promotion machinery built up in v1 (#2645) and v2 (#2650). No new infrastructure on the apply paths — the v2 reflection + state-mapped + three-tier-default machinery handles every property in this PR.

The one new piece of infrastructure is `VariableSave.Description`: a persisted XML-serialized doc field, distinct from the existing `[XmlIgnore]` `DetailText` (transient runtime hints set by tool/plugin code). The variable grid seeds each behavior-promoted row's display text from the FormsProperty's authored `Description`.

## What lands

**State-mapped** (FormsProperty + ToolOnlyVariableReference):
- `IsChecked` on CheckBox / RadioButton / Toggle, with nested-ternary references combining IsEnabled and IsChecked into the appropriate `<X>CategoryState`.
- CheckBox component default state authors `IsChecked=false` so the check sprite is hidden by design-time default.

**Logical-only** (FormsProperty only — runtime reflects):
- TextBox/PasswordBox: `AcceptsReturn`, `AcceptsTab`, `IsReadOnly`, `Placeholder`, `MaxLength` (`int?`).
- TextBox-only: `MaxLettersToShow` (`int?`), `MaxNumberOfLines` (`int?`).
- Slider/ScrollBar (RangeBase): `Minimum`, `Maximum`, `Value`, `SmallChange`, `LargeChange`.
- Slider-only: `TicksFrequency`, `IsSnapToTickEnabled`.
- ScrollViewer: `SmallChange`, `LargeChange` (fanned to inner scroll bars by ScrollViewer's setters).

**Documentation infrastructure:**
- `VariableSave.Description` (new, persisted) with cross-referencing XML docs distinguishing it from the existing transient `DetailText`. `ShouldSerializeDescription` suppresses empty values from save files.
- `ElementSaveDisplayer.AddBehaviorFormsPropertyMembers` seeds `srim.DetailText` from the FormsProperty's `Description`.
- Descriptions added on `AcceptsReturn`, `AcceptsTab`, the `MaxLength` / `MaxLettersToShow` / `MaxNumberOfLines` trio (which are easy to confuse), and `SmallChange` / `LargeChange`.

**Nullable type-string fix:** `MaxLength` etc. are declared `Type="int?"` (already registered in `TypeManager.GetTypeFromString`) so the variable grid renders the nullable-int editor and authors can clear back to null (= "no limit").

## What's deferred

Enum-typed properties (`TextWrapping`, `ScrollBarVisibility`, `Orientation`) need a small change to `BehaviorFormsPropertyApplier.Apply` (string→enum coercion via `Enum.Parse`). Tracked as a follow-up; the runtime infrastructure handles everything else generically.

## Tests

New tests in `BehaviorFormsPropertyApplyTests` (runtime), `BehaviorToolOnlyReferencesApplierTests` (tool), `ElementSaveDisplayerFormsPropertiesTests` (grid display), and `GumFileSerializerTests` (Description round-trip + omission). Both solutions green.

## Test plan

- [ ] Author `IsChecked` true/false on a CheckBox, RadioButton, and Toggle component; confirm the wireframe `<X>CategoryState` switches between EnabledOn/EnabledOff/DisabledOn/DisabledOff as IsEnabled and IsChecked vary.
- [ ] Toggle `AcceptsReturn` on a TextBox; confirm Description appears in the grid detail area; confirm runtime behavior changes.
- [ ] Try `MaxLength`, `MaxLettersToShow`, `MaxNumberOfLines`; confirm grid offers a clearable nullable-int editor and that clearing the value reverts to the unlimited behavior.
- [ ] Set `Maximum`, `SmallChange`, `LargeChange` on a Slider/ScrollBar and confirm runtime range/step behavior matches.
- [ ] Confirm `ScrollViewer.SmallChange`/`LargeChange` propagates to both inner scroll bars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)