### PR TITLE
Add TooltipBehavior to FormsTemplate

### DIFF
--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/TooltipBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/TooltipBehavior.behx
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<BehaviorSave xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <Name>TooltipBehavior</Name>
+  <RequiredVariables />
+  <RequiredInstances />
+  <RequiredAnimations />
+</BehaviorSave>


### PR DESCRIPTION
## Summary
- Adds `TooltipBehavior.behx` to `Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/`.
- Minimal marker behavior — no `FormsProperties`, `RequiredVariables`, `RequiredInstances`, or `DefaultImplementation`. Used to associate a component with the `Tooltip` Forms control.
- The matching `TooltipBehaviorName = "TooltipBehavior"` constant already exists in `StandardFormsBehaviorNames`.

## Test plan
- [x] `dotnet build Tools/Gum.ProjectServices/Gum.ProjectServices.csproj` succeeds (file is auto-included via the existing `Templates\FormsTemplate\**\*` embedded-resource glob).
- [ ] In the Gum tool, create a component, attach `TooltipBehavior`, and confirm the runtime wraps it with a `Tooltip` Forms control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)