### PR TITLE
Fix tooltip bleeding past canvas edge; share clamp logic with popups

### DIFF
--- a/MonoGameGum.Tests/Forms/TooltipTests.cs
+++ b/MonoGameGum.Tests/Forms/TooltipTests.cs
@@ -143,6 +143,29 @@ public class TooltipTests : BaseTestClass
     }
 
     [Fact]
+    public void Positioning_WhenCanvasSmallerThanCameraClient_ClampsToCanvas()
+    {
+        // Repro for issue #2661: in raylib (and any setup where the camera client
+        // area is larger than the logical canvas), tooltips were clamping against
+        // camera client size instead of the canvas/PopupRoot they live in, so they
+        // could render past the canvas edge.
+        // BaseTestClass leaves Camera.ClientWidth/Height at 800x600. Shrinking the
+        // canvas to 400x300 gives us divergence without mutating shared camera state.
+        GraphicalUiElement.CanvasWidth = 400;
+        GraphicalUiElement.CanvasHeight = 300;
+
+        Tooltip tooltip = new Tooltip();
+        tooltip.Content = "The quick brown fox jumps over the lazy dog";
+
+        tooltip.Show(cursorX: 390, cursorY: 290);
+
+        var width = tooltip.Visual.GetAbsoluteWidth();
+        var height = tooltip.Visual.GetAbsoluteHeight();
+        tooltip.Visual.X.ShouldBeLessThanOrEqualTo(400 - width);
+        tooltip.Visual.Y.ShouldBeLessThanOrEqualTo(300 - height);
+    }
+
+    [Fact]
     public void Show_Hide_Programmatic_RaisesOpenedClosedEvents()
     {
         Tooltip tooltip = new Tooltip();

--- a/MonoGameGum/Forms/Controls/FrameworkElement.cs
+++ b/MonoGameGum/Forms/Controls/FrameworkElement.cs
@@ -930,28 +930,47 @@ public class FrameworkElement : INotifyPropertyChanged
     }
 #endif
 
+    /// <summary>
+    /// Repositions this element so it stays inside the logical Gum canvas
+    /// (<see cref="GraphicalUiElement.CanvasWidth"/> / <see cref="GraphicalUiElement.CanvasHeight"/>),
+    /// which is the space PopupRoot/ModalRoot are sized to. Clamps all four edges.
+    /// Used by popups (ListBox dropdown, Tooltip, MenuItem submenu) so they don't
+    /// render past the canvas edge regardless of how the camera/screen is sized.
+    /// </summary>
     public void RepositionToKeepInScreen()
     {
-#if FULL_DIAGNOSTICS
         if (Visual == null)
         {
-            throw new InvalidOperationException("Visual hasn't yet been set");
+            return;
         }
-        if (Visual.Parent != null)
-        {
-            throw new InvalidOperationException("This cannot be moved to keep in screen because it depends on its parent's position");
-        }
-#endif
-        //var cameraTop = 0;
-        var cameraBottom = Renderer.Self.Camera.ClientHeight / Renderer.Self.Camera.Zoom;
-        //var cameraLeft = 0;
-        var cameraRight = Renderer.Self.Camera.ClientWidth / Renderer.Self.Camera.Zoom;
 
-        var thisBottom = this.Visual.AbsoluteY + this.Visual.GetAbsoluteHeight();
-        if (thisBottom > cameraBottom)
+        var canvasWidth = GraphicalUiElement.CanvasWidth;
+        var canvasHeight = GraphicalUiElement.CanvasHeight;
+
+        var width = Visual.GetAbsoluteWidth();
+        var height = Visual.GetAbsoluteHeight();
+
+        // Use Absolute coords for the bounds check so this works even when Visual has
+        // a non-zero-positioned parent. Mutate local X/Y by the same delta — the parent
+        // doesn't move, so a delta in absolute space equals a delta in local space.
+        var right = Visual.AbsoluteX + width;
+        if (right > canvasWidth)
         {
-            // assume absolute positioning (for now?)
-            this.Y -= (thisBottom - cameraBottom);
+            this.X -= (right - canvasWidth);
+        }
+        if (Visual.AbsoluteX < 0)
+        {
+            this.X -= Visual.AbsoluteX;
+        }
+
+        var bottom = Visual.AbsoluteY + height;
+        if (bottom > canvasHeight)
+        {
+            this.Y -= (bottom - canvasHeight);
+        }
+        if (Visual.AbsoluteY < 0)
+        {
+            this.Y -= Visual.AbsoluteY;
         }
     }
 

--- a/MonoGameGum/Forms/Controls/Tooltip.cs
+++ b/MonoGameGum/Forms/Controls/Tooltip.cs
@@ -1,5 +1,4 @@
 using Gum.Wireframe;
-using RenderingLibrary;
 using RenderingLibrary.Graphics;
 using System;
 
@@ -130,7 +129,7 @@ public class Tooltip : FrameworkElement
             FrameworkElement.PopupRoot.Children.Add(Visual);
         }
 
-        ClampToScreen();
+        RepositionToKeepInScreen();
 #endif
 
         IsOpen = true;
@@ -168,38 +167,4 @@ public class Tooltip : FrameworkElement
         Closed?.Invoke(this, EventArgs.Empty);
     }
 
-    private void ClampToScreen()
-    {
-        if (Visual == null)
-        {
-            return;
-        }
-
-        var camera = Renderer.Self.Camera;
-        var cameraRight = camera.ClientWidth / camera.Zoom;
-        var cameraBottom = camera.ClientHeight / camera.Zoom;
-
-        var width = Visual.GetAbsoluteWidth();
-        var height = Visual.GetAbsoluteHeight();
-
-        var right = Visual.X + width;
-        if (right > cameraRight)
-        {
-            Visual.X -= (right - cameraRight);
-        }
-        if (Visual.X < 0)
-        {
-            Visual.X = 0;
-        }
-
-        var bottom = Visual.Y + height;
-        if (bottom > cameraBottom)
-        {
-            Visual.Y -= (bottom - cameraBottom);
-        }
-        if (Visual.Y < 0)
-        {
-            Visual.Y = 0;
-        }
-    }
 }


### PR DESCRIPTION
## Summary
- Tooltips were clamping against `Renderer.Self.Camera.ClientWidth/Height` (screen pixels) but live under `PopupRoot`, which is sized to `GraphicalUiElement.CanvasWidth/Height` (logical canvas). When the two diverged — common in raylib, where the camera client is the raw window size and the logical canvas can be smaller — tooltips clamped against the wrong bound and rendered past the visible canvas.
- Consolidate the clamp into `FrameworkElement.RepositionToKeepInScreen`, switch it to canvas dimensions, and have it clamp all four edges (it previously only handled the bottom). `Tooltip.Show` now calls the shared method instead of a private duplicate.

Closes #2661

## Test plan
- [x] New `Positioning_WhenCanvasSmallerThanCameraClient_ClampsToCanvas` test reproduces the raylib-style mismatch (canvas 400×300, camera client 800×600) and fails before the fix, passes after.
- [x] Existing `Positioning_NearRightEdge_ReposToStayOnScreen` still passes.
- [x] All 504 `MonoGameGum.Tests.Forms` tests pass — covers ListBox/ComboBox/MenuItem callers of `RepositionToKeepInScreen`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)