### PR TITLE
Show "Applies Npx margin" hint under anchor/dock buttons

### DIFF
--- a/Gum/Plugins/InternalPlugins/AlignmentButtons/AlignmentPluginControl.xaml
+++ b/Gum/Plugins/InternalPlugins/AlignmentButtons/AlignmentPluginControl.xaml
@@ -4,7 +4,6 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:local="clr-namespace:Gum.Plugins.AlignmentButtons"
-    xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     d:DesignHeight="300"
     d:DesignWidth="300"
@@ -25,8 +24,7 @@
         <TextBox
             Grid.Column="1"
             Margin="4"
-            materialDesign:ValidationAssist.UsePopup="True"
-            Text="{Binding DockMargin, UpdateSourceTrigger=PropertyChanged}" />
+            Text="{Binding DockMarginText, UpdateSourceTrigger=PropertyChanged}" />
         <Label
             Grid.Row="1"
             VerticalAlignment="Center"

--- a/Gum/Plugins/InternalPlugins/AlignmentButtons/AlignmentPluginControl.xaml
+++ b/Gum/Plugins/InternalPlugins/AlignmentButtons/AlignmentPluginControl.xaml
@@ -17,6 +17,8 @@
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
         <Label VerticalAlignment="Center" Content="Margin" />
         <TextBox
@@ -33,16 +35,32 @@
             Margin="4"
             HorizontalAlignment="Left"
             HorizontalContentAlignment="Left" />
-        <Label
+        <TextBlock
             Grid.Row="2"
+            Grid.Column="1"
+            Margin="4,0,4,4"
+            Foreground="Gray"
+            FontStyle="Italic"
+            Text="{Binding MarginText}"
+            Visibility="{Binding MarginTextVisibility}" />
+        <Label
+            Grid.Row="3"
             VerticalAlignment="Center"
             Content="Dock" />
         <local:DockControl
-            Grid.Row="2"
+            Grid.Row="3"
             Grid.Column="1"
             Margin="4"
             HorizontalAlignment="Stretch"
             HorizontalContentAlignment="Stretch" />
+        <TextBlock
+            Grid.Row="4"
+            Grid.Column="1"
+            Margin="4,0,4,4"
+            Foreground="Gray"
+            FontStyle="Italic"
+            Text="{Binding MarginText}"
+            Visibility="{Binding MarginTextVisibility}" />
 
     </Grid>
 </UserControl>

--- a/Gum/Plugins/InternalPlugins/AlignmentButtons/AlignmentPluginControl.xaml
+++ b/Gum/Plugins/InternalPlugins/AlignmentButtons/AlignmentPluginControl.xaml
@@ -4,6 +4,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:local="clr-namespace:Gum.Plugins.AlignmentButtons"
+    xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     d:DesignHeight="300"
     d:DesignWidth="300"
@@ -24,7 +25,8 @@
         <TextBox
             Grid.Column="1"
             Margin="4"
-            Text="{Binding DockMargin}" />
+            materialDesign:ValidationAssist.UsePopup="True"
+            Text="{Binding DockMargin, UpdateSourceTrigger=PropertyChanged}" />
         <Label
             Grid.Row="1"
             VerticalAlignment="Center"

--- a/Gum/Plugins/InternalPlugins/AlignmentButtons/ViewModels/AlignmentViewModel.cs
+++ b/Gum/Plugins/InternalPlugins/AlignmentButtons/ViewModels/AlignmentViewModel.cs
@@ -7,6 +7,7 @@ using Gum.ToolStates;
 using Gum.Undo;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -26,6 +27,20 @@ public class AlignmentViewModel : ViewModel
         set => Set(value);
     }
 
+    public string DockMarginText
+    {
+        get => Get<string>();
+        set
+        {
+            if (Set(value))
+            {
+                DockMargin = float.TryParse(value, NumberStyles.Float, CultureInfo.CurrentCulture, out var parsed)
+                    ? parsed
+                    : 0f;
+            }
+        }
+    }
+
     [DependsOn(nameof(DockMargin))]
     public string MarginText => $"Applies {DockMargin}px margin";
 
@@ -37,6 +52,7 @@ public class AlignmentViewModel : ViewModel
         _commonControlLogic = commonControlLogic;
         _selectedState = Locator.GetRequiredService<ISelectedState>();
         _undoManager = Locator.GetRequiredService<IUndoManager>();
+        DockMarginText = "0";
     }
 
     #region Anchor Actions

--- a/Gum/Plugins/InternalPlugins/AlignmentButtons/ViewModels/AlignmentViewModel.cs
+++ b/Gum/Plugins/InternalPlugins/AlignmentButtons/ViewModels/AlignmentViewModel.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.Windows;
 
 namespace Gum.Plugins.InternalPlugins.AlignmentButtons.ViewModels;
 
@@ -24,6 +25,12 @@ public class AlignmentViewModel : ViewModel
         get => Get<float>();
         set => Set(value);
     }
+
+    [DependsOn(nameof(DockMargin))]
+    public string MarginText => $"Applies {DockMargin}px margin";
+
+    [DependsOn(nameof(DockMargin))]
+    public Visibility MarginTextVisibility => DockMargin != 0 ? Visibility.Visible : Visibility.Collapsed;
 
     public AlignmentViewModel(CommonControlLogic commonControlLogic)
     {


### PR DESCRIPTION
## Summary
- Adds a muted italic hint label below the Anchor group and the Dock group in the Alignment plugin panel.
- The hint reads `Applies {N}px margin` (where N is the current Margin textbox value) and only shows when Margin is non-zero.
- Helps new users discover that the Margin value feeds into both anchor and dock button actions, addressing the discoverability concern raised in the issue.

Implementation matches the mock posted in the issue: two labels, one under each button group, only visible when margin != 0.

Closes #703

## Test plan
- [x] Open the Gum tool, select an element, and confirm the Alignment panel shows no margin hint when Margin is 0.
- [x] Type a non-zero margin (e.g. 8) and confirm a muted label "Applies 8px margin" appears below both the Anchor buttons and the Dock buttons.
- [x] Clear the margin back to 0 and confirm both labels disappear.