### PR TITLE
Forms property promotion: ResizeMode/ResizeBehavior + nullable-enum picker (v5)

### DIFF
--- a/Gum/Reflection/TypeManager.cs
+++ b/Gum/Reflection/TypeManager.cs
@@ -104,6 +104,23 @@ public class TypeManager : ITypeManager
                     return type;
                 }
             }
+
+            // Custom enum nullables: "Foo?" -> typeof(Nullable<Foo>). Primitive nullables
+            // are matched explicitly above; this is the catch-all so FormsProperty entries
+            // like Type="Orientation?" or Type="ResizeBehavior?" resolve to a typed
+            // PropertyType in the variable grid (giving an enum picker with a None entry)
+            // instead of falling back to a string textbox.
+            if (typeAsString.Length > 1 && typeAsString[typeAsString.Length - 1] == '?')
+            {
+                string underlyingName = typeAsString.Substring(0, typeAsString.Length - 1);
+                foreach (Type type in mTypes)
+                {
+                    if (type.IsEnum && type.Name == underlyingName)
+                    {
+                        return typeof(Nullable<>).MakeGenericType(type);
+                    }
+                }
+            }
         }
 
         return null;

--- a/GumCommon/GumCommon.csproj
+++ b/GumCommon/GumCommon.csproj
@@ -224,9 +224,11 @@
 			compile-Remove these entries so they pick the types up via the GumCommon
 			reference instead of duplicating them.
 		-->
+		<Compile Include="..\MonoGameGum\Forms\ResizeMode.cs" Link="Forms\ResizeMode.cs" />
 		<Compile Include="..\MonoGameGum\Forms\TextWrapping.cs" Link="Forms\TextWrapping.cs" />
-		<Compile Include="..\MonoGameGum\Forms\Controls\ScrollBarVisibility.cs" Link="Forms\Controls\ScrollBarVisibility.cs" />
 		<Compile Include="..\MonoGameGum\Forms\Controls\Orientation.cs" Link="Forms\Controls\Orientation.cs" />
+		<Compile Include="..\MonoGameGum\Forms\Controls\ResizeBehavior.cs" Link="Forms\Controls\ResizeBehavior.cs" />
+		<Compile Include="..\MonoGameGum\Forms\Controls\ScrollBarVisibility.cs" Link="Forms\Controls\ScrollBarVisibility.cs" />
 	</ItemGroup>
 	<ItemGroup>
 	  <PackageReference Include="BrotliSharpLib" Version="0.3.3" />

--- a/MonoGameGum.Tests/Forms/BehaviorFormsPropertyApplyTests.cs
+++ b/MonoGameGum.Tests/Forms/BehaviorFormsPropertyApplyTests.cs
@@ -435,6 +435,62 @@ public class BehaviorFormsPropertyApplyTests : BaseTestClass
     }
 
     [Fact]
+    public void Apply_SplitterResizeBehaviorFromBehaviorDefaultString_CoercesToNullableEnum()
+    {
+        // Splitter.ResizeBehavior is ResizeBehavior?, so this exercises the
+        // Nullable.GetUnderlyingType -> IsEnum path on a different enum than Orientation.
+        BehaviorSave behavior = new BehaviorSave { Name = "SplitterBehavior" };
+        behavior.FormsProperties.Add(new VariableSave
+        {
+            Type = "ResizeBehavior?",
+            Name = "ResizeBehavior",
+            Value = "Columns"
+        });
+
+        ComponentSave component = new ComponentSave { Name = "Controls/Splitter", BaseType = "Container" };
+        component.States.Add(new StateSave { Name = "Default", ParentContainer = component });
+        component.Behaviors.Add(new ElementBehaviorReference { BehaviorName = "SplitterBehavior" });
+
+        GumProjectSave project = new GumProjectSave();
+        project.Components.Add(component);
+        project.Behaviors.Add(behavior);
+        ObjectFinder.Self.GumProjectSave = project;
+
+        Splitter splitter = new Splitter();
+        splitter.Visual.ElementSave = component;
+        BehaviorFormsPropertyApplier.Apply(splitter, splitter.Visual);
+
+        splitter.ResizeBehavior.ShouldBe(Gum.Forms.Controls.ResizeBehavior.Columns);
+    }
+
+    [Fact]
+    public void Apply_WindowResizeModeFromBehaviorDefaultString_CoercesToEnum()
+    {
+        BehaviorSave behavior = new BehaviorSave { Name = "WindowBehavior" };
+        behavior.FormsProperties.Add(new VariableSave
+        {
+            Type = "ResizeMode",
+            Name = "ResizeMode",
+            Value = "NoResize"
+        });
+
+        ComponentSave component = new ComponentSave { Name = "Controls/Window", BaseType = "Container" };
+        component.States.Add(new StateSave { Name = "Default", ParentContainer = component });
+        component.Behaviors.Add(new ElementBehaviorReference { BehaviorName = "WindowBehavior" });
+
+        GumProjectSave project = new GumProjectSave();
+        project.Components.Add(component);
+        project.Behaviors.Add(behavior);
+        ObjectFinder.Self.GumProjectSave = project;
+
+        Window window = new Window();
+        window.Visual.ElementSave = component;
+        BehaviorFormsPropertyApplier.Apply(window, window.Visual);
+
+        window.ResizeMode.ShouldBe(ResizeMode.NoResize);
+    }
+
+    [Fact]
     public void Apply_ScrollViewerVisibilityFromStateBoxedEnum_PreservesIsAssignableFromBranch()
     {
         // When the variable grid authors a state value, it stores the boxed enum (not a

--- a/MonoGameGum/FnaGum/FnaGum.csproj
+++ b/MonoGameGum/FnaGum/FnaGum.csproj
@@ -101,9 +101,11 @@
 			Forms enums are owned by GumCommon (referenced via ProjectReference). Exclude
 			them from the ..\**\*.cs sweep so the types aren't compiled twice.
 		-->
+		<Compile Remove="..\Forms\ResizeMode.cs" />
 		<Compile Remove="..\Forms\TextWrapping.cs" />
-		<Compile Remove="..\Forms\Controls\ScrollBarVisibility.cs" />
 		<Compile Remove="..\Forms\Controls\Orientation.cs" />
+		<Compile Remove="..\Forms\Controls\ResizeBehavior.cs" />
+		<Compile Remove="..\Forms\Controls\ScrollBarVisibility.cs" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/MonoGameGum/Forms/Controls/ResizeBehavior.cs
+++ b/MonoGameGum/Forms/Controls/ResizeBehavior.cs
@@ -1,0 +1,11 @@
+#if FRB
+namespace MonoGameGum.Forms.Controls;
+#else
+namespace Gum.Forms.Controls;
+#endif
+
+public enum ResizeBehavior
+{
+    Rows,
+    Columns
+}

--- a/MonoGameGum/Forms/Controls/Splitter.cs
+++ b/MonoGameGum/Forms/Controls/Splitter.cs
@@ -17,12 +17,6 @@ namespace Gum.Forms.Controls;
 
 #endif
 
-public enum ResizeBehavior
-{
-    Rows,
-    Columns
-}
-
 /// <summary>
 /// Control which allows the user to resize two adjacent siblings.
 /// </summary>

--- a/MonoGameGum/Forms/ResizeMode.cs
+++ b/MonoGameGum/Forms/ResizeMode.cs
@@ -1,0 +1,20 @@
+#if FRB
+namespace FlatRedBall.Forms;
+#else
+namespace Gum.Forms;
+#endif
+
+/// <summary>
+/// Values for an element's resize behavior.
+/// </summary>
+public enum ResizeMode
+{
+    /// <summary>
+    /// Resizing using the cursor is not enabled
+    /// </summary>
+    NoResize,
+    /// <summary>
+    /// Resizing is enabled according to the enabled border instances.
+    /// </summary>
+    CanResize
+}

--- a/MonoGameGum/Forms/Window.cs
+++ b/MonoGameGum/Forms/Window.cs
@@ -23,25 +23,6 @@ namespace Gum.Forms;
 
 #endif
 
-#region ResizeMode Enum
-
-/// <summary>
-/// Values for an element's resize behavior.
-/// </summary>
-public enum ResizeMode
-{
-    /// <summary>
-    /// Resizing using the cursor is not enabled
-    /// </summary>
-    NoResize,
-    /// <summary>
-    /// Resizing is enabled according to the enabled border instances.
-    /// </summary>
-    CanResize
-}
-
-#endregion
-
 /// <summary>
 /// A resizable, movable FrameworkElement
 /// </summary>

--- a/MonoGameGum/KniGum/KniGum.csproj
+++ b/MonoGameGum/KniGum/KniGum.csproj
@@ -134,9 +134,11 @@
 			Forms enums are owned by GumCommon (referenced via ProjectReference). Exclude
 			them from the ..\**\*.cs sweep so the types aren't compiled twice.
 		-->
+		<Compile Remove="..\Forms\ResizeMode.cs" />
 		<Compile Remove="..\Forms\TextWrapping.cs" />
-		<Compile Remove="..\Forms\Controls\ScrollBarVisibility.cs" />
 		<Compile Remove="..\Forms\Controls\Orientation.cs" />
+		<Compile Remove="..\Forms\Controls\ResizeBehavior.cs" />
+		<Compile Remove="..\Forms\Controls\ScrollBarVisibility.cs" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/MonoGameGum/MonoGameGum.csproj
+++ b/MonoGameGum/MonoGameGum.csproj
@@ -112,9 +112,11 @@
 			Forms enums are owned by GumCommon (linked via <Compile Include> in
 			GumCommon.csproj). Exclude them here so the types aren't compiled twice.
 		-->
+		<Compile Remove="Forms\ResizeMode.cs" />
 		<Compile Remove="Forms\TextWrapping.cs" />
-		<Compile Remove="Forms\Controls\ScrollBarVisibility.cs" />
 		<Compile Remove="Forms\Controls\Orientation.cs" />
+		<Compile Remove="Forms\Controls\ResizeBehavior.cs" />
+		<Compile Remove="Forms\Controls\ScrollBarVisibility.cs" />
 		<EmbeddedResource Remove="FnaGum\**" />
 		<EmbeddedResource Remove="KniGum\**" />
 		<None Remove="FnaGum\**" />

--- a/Runtimes/RaylibGum/RaylibGum.csproj
+++ b/Runtimes/RaylibGum/RaylibGum.csproj
@@ -147,8 +147,9 @@
 	    Forms enums are owned by GumCommon (referenced via ProjectReference). Exclude them
 	    from the Forms\Controls\**\*.cs glob so the types aren't compiled twice.
 	  -->
-	  <Compile Remove="..\..\MonoGameGum\Forms\Controls\ScrollBarVisibility.cs" />
 	  <Compile Remove="..\..\MonoGameGum\Forms\Controls\Orientation.cs" />
+	  <Compile Remove="..\..\MonoGameGum\Forms\Controls\ResizeBehavior.cs" />
+	  <Compile Remove="..\..\MonoGameGum\Forms\Controls\ScrollBarVisibility.cs" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Runtimes/SokolGum/SokolGum.csproj
+++ b/Runtimes/SokolGum/SokolGum.csproj
@@ -154,8 +154,9 @@
 			Forms enums are owned by GumCommon (referenced via ProjectReference). Exclude them
 			from the Forms\Controls\**\*.cs glob so the types aren't compiled twice.
 		-->
-		<Compile Remove="..\..\MonoGameGum\Forms\Controls\ScrollBarVisibility.cs" />
 		<Compile Remove="..\..\MonoGameGum\Forms\Controls\Orientation.cs" />
+		<Compile Remove="..\..\MonoGameGum\Forms\Controls\ResizeBehavior.cs" />
+		<Compile Remove="..\..\MonoGameGum\Forms\Controls\ScrollBarVisibility.cs" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Tool/Tests/GumToolUnitTests/PropertyGridHelpers/ElementSaveDisplayerFormsPropertiesTests.cs
+++ b/Tool/Tests/GumToolUnitTests/PropertyGridHelpers/ElementSaveDisplayerFormsPropertiesTests.cs
@@ -289,4 +289,46 @@ public class ElementSaveDisplayerFormsPropertiesTests : BaseTestClass
         member.ShouldNotBeNull();
         member.PropertyType.ShouldBe(typeof(Gum.Forms.Controls.ScrollBarVisibility));
     }
+
+    [Fact]
+    public void AddBehaviorFormsPropertyMembers_NullableEnumTypedFormsProperty_ResolvesNullableEnumComponentType()
+    {
+        // FormsProperty Type="Foo?" must resolve to typeof(Foo?) so the variable grid
+        // renders an enum picker (with a "None" option) instead of falling back to a
+        // string textbox. Without nullable-enum support in TypeManager.GetTypeFromString,
+        // the SRIM's PropertyType is null and the grid uses a generic editor — that's
+        // the bug for Splitter.ResizeBehavior? and ItemsControl/ListBox.Orientation?.
+        BehaviorSave splitterBehavior = new BehaviorSave { Name = "SplitterBehavior" };
+        splitterBehavior.FormsProperties.Add(new VariableSave
+        {
+            Type = "ResizeBehavior?",
+            Name = "ResizeBehavior"
+        });
+
+        ComponentSave splitterComponent = new ComponentSave
+        {
+            Name = "Controls/Splitter",
+            BaseType = "Container"
+        };
+        splitterComponent.States.Add(new StateSave { Name = "Default", ParentContainer = splitterComponent });
+        splitterComponent.Behaviors.Add(new ElementBehaviorReference { BehaviorName = "SplitterBehavior" });
+        _project.Behaviors.Add(splitterBehavior);
+        _project.Components.Add(splitterComponent);
+
+        List<MemberCategory> categories = new List<MemberCategory>();
+
+        _displayer.AddBehaviorFormsPropertyMembers(
+            elementWithBehaviors: splitterComponent,
+            instanceOwner: splitterComponent,
+            instance: null,
+            stateSave: splitterComponent.DefaultState,
+            stateSaveCategory: null,
+            categories: categories);
+
+        MemberCategory? behaviorCategory = categories.FirstOrDefault(c => c.Name == "Behavior");
+        behaviorCategory.ShouldNotBeNull();
+        InstanceMember? member = behaviorCategory.Members.FirstOrDefault(m => m.Name == "ResizeBehavior");
+        member.ShouldNotBeNull();
+        member.PropertyType.ShouldBe(typeof(Gum.Forms.Controls.ResizeBehavior?));
+    }
 }

--- a/Tool/Tests/GumToolUnitTests/PropertyGridHelpers/NullableEnumComboBoxDisplayTests.cs
+++ b/Tool/Tests/GumToolUnitTests/PropertyGridHelpers/NullableEnumComboBoxDisplayTests.cs
@@ -1,0 +1,228 @@
+using System.Threading;
+using Shouldly;
+using WpfDataUi;
+using WpfDataUi.Controls;
+using WpfDataUi.DataTypes;
+
+namespace GumToolUnitTests.PropertyGridHelpers;
+
+/// <summary>
+/// Verifies that <see cref="WpfDataUi.Controls.ComboBoxDisplay"/> handles a nullable
+/// enum (e.g., <c>ResizeBehavior?</c>) the same way it handles a non-nullable enum,
+/// with an additional null entry, and that <see cref="SingleDataUiContainer"/> routes
+/// nullable-enum types to the combo box displayer rather than the textbox fallback.
+/// </summary>
+public class NullableEnumComboBoxDisplayTests : BaseTestClass
+{
+    public enum SampleEnum
+    {
+        Alpha,
+        Beta,
+        Gamma
+    }
+
+    [Fact]
+    public void SingleDataUiContainer_RoutingPredicate_NullableEnum_RoutesToComboBoxDisplay()
+    {
+        // The TypeDisplayerAssociation is evaluated in order in
+        // SingleDataUiContainer.CreateInternalControl. Find the first predicate that
+        // matches typeof(SampleEnum?). It must be the ComboBoxDisplay association,
+        // not the textbox fallback (which is only reached when no predicate matches).
+        Type? matchedDisplayer = null;
+        foreach (KeyValuePair<Func<Type, bool>, Type> kvp in SingleDataUiContainer.TypeDisplayerAssociation)
+        {
+            if (kvp.Key(typeof(SampleEnum?)))
+            {
+                matchedDisplayer = kvp.Value;
+                break;
+            }
+        }
+
+        matchedDisplayer.ShouldBe(typeof(ComboBoxDisplay));
+    }
+
+    [Fact]
+    public void SingleDataUiContainer_RoutingPredicate_NonNullableEnum_StillRoutesToComboBoxDisplay()
+    {
+        // Regression guard: do not break the existing non-nullable enum routing
+        // when adding the nullable-enum branch.
+        Type? matchedDisplayer = null;
+        foreach (KeyValuePair<Func<Type, bool>, Type> kvp in SingleDataUiContainer.TypeDisplayerAssociation)
+        {
+            if (kvp.Key(typeof(SampleEnum)))
+            {
+                matchedDisplayer = kvp.Value;
+                break;
+            }
+        }
+
+        matchedDisplayer.ShouldBe(typeof(ComboBoxDisplay));
+    }
+
+    [Fact]
+    public void SingleDataUiContainer_RoutingPredicate_NullablePrimitive_NotRoutedToComboBoxDisplay()
+    {
+        // Make sure the new "nullable enum" predicate doesn't accidentally match
+        // typeof(int?) etc. — only Nullable<TEnum> should reach ComboBoxDisplay.
+        Type? matchedDisplayer = null;
+        foreach (KeyValuePair<Func<Type, bool>, Type> kvp in SingleDataUiContainer.TypeDisplayerAssociation)
+        {
+            if (kvp.Key(typeof(int?)))
+            {
+                matchedDisplayer = kvp.Value;
+                break;
+            }
+        }
+
+        matchedDisplayer.ShouldBeNull();
+    }
+
+    [Fact]
+    public void ComboBoxDisplay_NullableEnumPropertyType_CustomOptionsIncludesNullEntryAndAllEnumValues()
+    {
+        RunOnSta(() =>
+        {
+            TestComboBoxDisplay display = new TestComboBoxDisplay();
+            InstanceMember member = MakeMemberOfType(typeof(SampleEnum?));
+            display.InstanceMember = member;
+
+            List<object?> options = display.GetCustomOptions().ToList();
+
+            // Convention: the no-value sentinel is the "<None>" string, matching
+            // StateReferencingInstanceMember.HandleCustomSet which translates that
+            // string back to null on commit. Using a string sentinel rather than
+            // literal null is required because WPF ComboBox does not handle a null
+            // SelectedItem cleanly — selecting the null item deselects instead.
+            options.Count(o => Equals(o, ComboBoxDisplay.NullSentinel)).ShouldBe(1, "exactly one <None> entry should be present for the no-value option");
+            options.ShouldContain(SampleEnum.Alpha);
+            options.ShouldContain(SampleEnum.Beta);
+            options.ShouldContain(SampleEnum.Gamma);
+            options.Count.ShouldBe(4);
+        });
+    }
+
+    [Fact]
+    public void ComboBoxDisplay_NonNullableEnumPropertyType_CustomOptionsHasNoNullEntry()
+    {
+        RunOnSta(() =>
+        {
+            TestComboBoxDisplay display = new TestComboBoxDisplay();
+            InstanceMember member = MakeMemberOfType(typeof(SampleEnum));
+            display.InstanceMember = member;
+
+            List<object?> options = display.GetCustomOptions().ToList();
+
+            options.ShouldNotContain(ComboBoxDisplay.NullSentinel);
+            options.Count.ShouldBe(3);
+        });
+    }
+
+    [Fact]
+    public void ComboBoxDisplay_NullableEnum_SelectingNoneSentinelWritesSentinelToInstanceMember()
+    {
+        RunOnSta(() =>
+        {
+            // The WpfDataUi layer hands the "<None>" sentinel string straight to
+            // InstanceMember.SetValue. The null translation happens one level up,
+            // in StateReferencingInstanceMember.HandleCustomSet, which is exercised
+            // by the variable-grid integration tests rather than here. This test
+            // pins the contract this layer owns: the sentinel reaches SetValue
+            // intact when the user selects the no-value entry.
+            object? backingValue = SampleEnum.Beta;
+
+            TestComboBoxDisplay display = new TestComboBoxDisplay();
+            InstanceMember member = MakeMemberOfType(typeof(SampleEnum?));
+            member.CustomGetEvent += _ => backingValue;
+            member.CustomSetPropertyEvent += (_, args) => backingValue = args.Value;
+            display.InstanceMember = member;
+
+            display.SimulateUserSelects(ComboBoxDisplay.NullSentinel);
+
+            backingValue.ShouldBe(ComboBoxDisplay.NullSentinel);
+        });
+    }
+
+    [Fact]
+    public void ComboBoxDisplay_NullableEnum_RoundTripsRealEnumValue()
+    {
+        RunOnSta(() =>
+        {
+            SampleEnum? backingValue = null;
+
+            TestComboBoxDisplay display = new TestComboBoxDisplay();
+            InstanceMember member = MakeMemberOfType(typeof(SampleEnum?));
+            member.CustomGetEvent += _ => backingValue;
+            member.CustomSetPropertyEvent += (_, args) => backingValue = (SampleEnum?)args.Value;
+            display.InstanceMember = member;
+
+            display.SimulateUserSelects(SampleEnum.Gamma);
+
+            backingValue.ShouldBe(SampleEnum.Gamma);
+        });
+    }
+
+    /// <summary>
+    /// WPF controls require an STA thread; xUnit's default runner is MTA.
+    /// </summary>
+    private static void RunOnSta(Action action)
+    {
+        Exception? caught = null;
+        Thread thread = new Thread(() =>
+        {
+            try { action(); }
+            catch (Exception ex) { caught = ex; }
+        });
+        thread.SetApartmentState(ApartmentState.STA);
+        thread.Start();
+        thread.Join();
+        if (caught != null)
+        {
+            throw new System.Reflection.TargetInvocationException(caught);
+        }
+    }
+
+    private static InstanceMember MakeMemberOfType(Type type)
+    {
+        InstanceMember member = new InstanceMember { Name = "TestMember" };
+        member.CustomGetTypeEvent += _ => type;
+        // CustomGetEvent must be set for IsDefined to be true — give a default no-op
+        // that callers can override with += to add side-effects.
+        member.CustomGetEvent += _ => null;
+        return member;
+    }
+
+    /// <summary>
+    /// Test harness that exposes the protected <c>CustomOptions</c> for assertion
+    /// and provides a way to simulate user selection without a WPF dispatcher.
+    /// </summary>
+    private sealed class TestComboBoxDisplay : ComboBoxDisplay
+    {
+        public IEnumerable<object?> GetCustomOptions()
+        {
+            // Reflection over the protected property — keeps the test independent of
+            // whether the displayer exposes it directly.
+            System.Reflection.PropertyInfo? prop = typeof(ComboBoxDisplay).GetProperty(
+                "CustomOptions",
+                System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+            prop.ShouldNotBeNull();
+            System.Collections.IEnumerable? raw = (System.Collections.IEnumerable?)prop!.GetValue(this);
+            raw.ShouldNotBeNull();
+            List<object?> result = new List<object?>();
+            foreach (object? item in raw!)
+            {
+                result.Add(item);
+            }
+            return result;
+        }
+
+        public void SimulateUserSelects(object? value)
+        {
+            // Bypass WPF SelectionChanged plumbing — drive the same code path the
+            // selection change uses to commit a value.
+            // The extension method declares object (not object?), but passing null is
+            // exactly what we want to verify here — null-forgive to silence the warning.
+            this.TrySetValueOnInstance(value!);
+        }
+
+    }
+}

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/SplitterBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/SplitterBehavior.behx
@@ -6,6 +6,9 @@
   <FormsProperty Type="bool" Name="IsEnabled">
     <Value xsi:type="xsd:boolean">true</Value>
   </FormsProperty>
+  <FormsProperty Type="ResizeBehavior?" Name="ResizeBehavior">
+    <Description>Rows resizes the row above/below the splitter; Columns resizes the columns to either side. Empty leaves the choice to layout (StackPanel orientation determines the axis).</Description>
+  </FormsProperty>
   <RequiredInstances />
   <RequiredAnimations />
   <DefaultImplementation>Controls/SplitterStandard</DefaultImplementation>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/WindowBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Behaviors/WindowBehavior.behx
@@ -6,6 +6,10 @@
   <FormsProperty Type="bool" Name="IsEnabled">
     <Value xsi:type="xsd:boolean">true</Value>
   </FormsProperty>
+  <FormsProperty Type="ResizeMode" Name="ResizeMode">
+    <Value xsi:type="xsd:string">CanResize</Value>
+    <Description>CanResize lets the user drag the window's borders to resize it; NoResize disables border-driven resizing.</Description>
+  </FormsProperty>
   <RequiredInstances />
   <RequiredAnimations />
   <DefaultImplementation>Controls/WindowStandard</DefaultImplementation>

--- a/WpfDataUi/Controls/ComboBoxDisplay.xaml.cs
+++ b/WpfDataUi/Controls/ComboBoxDisplay.xaml.cs
@@ -14,6 +14,14 @@ namespace WpfDataUi.Controls;
 
 public class ComboBoxDisplay : UserControl, IDataUi, INotifyPropertyChanged
 {
+    /// <summary>
+    /// Sentinel string used as the "no value" entry for nullable-enum combo boxes.
+    /// Matches the pre-existing convention recognised by
+    /// StateReferencingInstanceMember.HandleCustomSet, which translates this string
+    /// back to null when committing to the underlying variable.
+    /// </summary>
+    public const string NullSentinel = "<None>";
+
     #region Fields
 
 
@@ -335,8 +343,23 @@ public class ComboBoxDisplay : UserControl, IDataUi, INotifyPropertyChanged
     public ApplyValueResult TrySetValueOnUi(object valueOnInstance)
     {
         this.SuppressSettingProperty = true;
-        this.ComboBox.SelectedItem = valueOnInstance;
-        this.ComboBox.Text = valueOnInstance?.ToString();
+        // For nullable-enum pickers a stored null maps to the "<None>" sentinel
+        // entry — selecting it visually round-trips through HandleCustomSet which
+        // turns "<None>" back into null on write. Without this mapping a null
+        // value would deselect the combo entirely (WPF's default for SelectedItem
+        // = null), losing the cue that the variable currently has no value.
+        bool isNullableEnum = mInstancePropertyType != null
+            && Nullable.GetUnderlyingType(mInstancePropertyType)?.IsEnum == true;
+        if (valueOnInstance == null && isNullableEnum)
+        {
+            this.ComboBox.SelectedItem = NullSentinel;
+            this.ComboBox.Text = NullSentinel;
+        }
+        else
+        {
+            this.ComboBox.SelectedItem = valueOnInstance;
+            this.ComboBox.Text = valueOnInstance?.ToString();
+        }
         this.SuppressSettingProperty = false;
 
         SyncForegroundWithState();
@@ -350,7 +373,7 @@ public class ComboBoxDisplay : UserControl, IDataUi, INotifyPropertyChanged
         {
             // We want to check the CustomOptions first
             // because we may have an enum that has been
-            // reduced by the converter.  In that case we 
+            // reduced by the converter.  In that case we
             // want to show the reduced set instead of the
             // entire enum
             if (InstanceMember?.CustomOptions != null)
@@ -365,6 +388,25 @@ public class ComboBoxDisplay : UserControl, IDataUi, INotifyPropertyChanged
             {
                 var values = Enum.GetValues(mInstancePropertyType);
                 foreach(var item in values)
+                {
+                    yield return item;
+                }
+            }
+            else if (mInstancePropertyType != null
+                && Nullable.GetUnderlyingType(mInstancePropertyType) is Type underlyingEnumType
+                && underlyingEnumType.IsEnum)
+            {
+                // Nullable enum (e.g., ResizeBehavior?): yield the "<None>" string
+                // sentinel first to represent the no-value option, then the underlying
+                // enum's values. The sentinel matches a pre-existing convention that
+                // StateReferencingInstanceMember.HandleCustomSet already recognises —
+                // it converts "<None>" back to null on write, so the variable round-
+                // trips cleanly. WPF ComboBox does not handle a literal null
+                // SelectedItem cleanly (selecting it deselects rather than picking the
+                // null item), which is why a string sentinel is used.
+                yield return NullSentinel;
+                var values = Enum.GetValues(underlyingEnumType);
+                foreach (var item in values)
                 {
                     yield return item;
                 }

--- a/WpfDataUi/Controls/SingleDataUiContainer.xaml.cs
+++ b/WpfDataUi/Controls/SingleDataUiContainer.xaml.cs
@@ -76,6 +76,15 @@ namespace WpfDataUi
                 typeof(ComboBoxDisplay))
                 );
 
+            // Nullable enums (e.g., FormsProperty Type="ResizeBehavior?") render as a
+            // dropdown picker, same as their non-nullable counterpart. The combo box
+            // populates a null entry alongside the underlying enum's values so the
+            // user can clear the value back to null.
+            mTypeDisplayerAssociation.Add(new KeyValuePair<Func<Type, bool>, Type>(
+                (item) => item != null && Nullable.GetUnderlyingType(item)?.IsEnum == true,
+                typeof(ComboBoxDisplay))
+                );
+
             mTypeDisplayerAssociation.Add(new KeyValuePair<Func<Type, bool>, Type>(
                 (item) => item != null && typeof(IEnumerable).IsAssignableFrom(item) && item != typeof(string),
                 typeof(ListBoxDisplay))


### PR DESCRIPTION
## Summary

Closes the property-promotion machinery work for #2637 by adding the last two enum-typed `FormsProperty` entries called out in the v4 handoff, fixing a latent gap in `TypeManager` that nullable-enum FormsProperties never actually rendered as pickers, and adding the `WpfDataUi` plumbing required for nullable-enum dropdowns to work end-to-end.

### Behaviour-bearing changes

- **`Window.ResizeMode`** (default `CanResize`) and **`Splitter.ResizeBehavior?`** (no default — leaves the choice to layout) added as FormsProperty entries on their behaviors. Pattern mirrors v4 exactly: extract enum to its own file, link into GumCommon, Compile-Remove from per-runtime csprojs.

- **`TypeManager.GetTypeFromString`** now resolves \`Foo?\` to \`typeof(Nullable<Foo>)\` for any custom enum, not just the hard-coded primitive nullables. Without this fix the variable grid renders nullable-enum FormsProperties as a string textbox instead of a typed picker. Latent bug for v4: `ItemsControl.Orientation?` and `ListBox.Orientation?` were affected too (both verified working after this fix).

- **`WpfDataUi.ComboBoxDisplay`** routes `Nullable<TEnum>` to itself (was falling through to the textbox fallback because `typeof(Foo?).IsEnum` is `false`) and yields a \`<None>\` string sentinel as the no-value entry. The sentinel matches the existing convention `StateReferencingInstanceMember.HandleCustomSet` already speaks — it translates `<None>` back to null on commit, so the variable round-trips cleanly. A literal-null sentinel was attempted first; WPF ComboBox does not handle a null `SelectedItem` cleanly (selecting it deselects rather than picking the null item), so the string sentinel is required.

- **`TrySetValueOnUi`** maps a stored null back to `<None>` when the property is `Nullable<TEnum>`, so the dropdown header shows the no-value entry when the variable is unset rather than rendering blank.

### Limitation worth flagging

Selecting `<None>` is equivalent to clearing the variable to its default — Gum's state model has no notion of "explicit null distinct from absent". For Splitter `ResizeBehavior?` this is correct (null means "use layout default" either way). A future FormsProperty with a non-null default that wanted explicit-null override would require state serialization to distinguish the two cases. Out of scope here; flagged for a follow-up issue if it comes up.

### Tests

- `BehaviorFormsPropertyApplyTests` — coercion of string→enum on `Window.ResizeMode` and string→nullable enum on `Splitter.ResizeBehavior?`.
- `ElementSaveDisplayerFormsPropertiesTests` — nullable-enum FormsProperty surfaces with `Nullable<TEnum>` PropertyType (regression for the TypeManager fix).
- `NullableEnumComboBoxDisplayTests` — routing predicate, `<None>` entry presence, sentinel round-trip through `InstanceMember.SetValue`.

## Test plan

- [x] `dotnet build AllLibraries.sln` clean
- [x] `dotnet build GumFull.sln` clean
- [x] `dotnet test GumFull.sln --filter "FullyQualifiedName~NullableEnumComboBoxDisplayTests|FullyQualifiedName~ElementSaveDisplayerFormsPropertiesTests|FullyQualifiedName~BehaviorFormsPropertyApplyTests"` — 15/15 pass
- [x] Manual: Splitter `ResizeBehavior` shows `<None>`/`Rows`/`Columns`; selecting `<None>` clears the variable
- [x] Manual: Window `ResizeMode` shows `NoResize`/`CanResize`
- [x] Manual sanity: ItemsControl/ListBox `Orientation` also pick up the `<None>` entry (latent v4 bug, fixed by the same TypeManager change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)