### PR TITLE
Bump PixiEditor.ColorPicker to 3.4.2.3 (fixes hex-paste undo spam)

### DIFF
--- a/Gum/Gum.csproj
+++ b/Gum/Gum.csproj
@@ -378,7 +378,7 @@
 			<Version>13.0.1</Version>
 		</PackageReference>
 		<PackageReference Include="PixiEditor.ColorPicker">
-			<Version>3.4.1</Version>
+			<Version>3.4.2.3</Version>
 		</PackageReference>
 		<PackageReference Include="SharpVectors" Version="1.8.5" />
 		<PackageReference Include="SkiaSharp">


### PR DESCRIPTION
## Summary
- Bumps `PixiEditor.ColorPicker` from 3.4.1 to 3.4.2.3
- Upstream 3.4.2.3 ships PixiEditor/ColorPicker#65, which raises a single color-changed event for hex paste instead of one per RGB channel — pasting a value like `001193` now creates a single undo entry
- This was previously blocked: 3.4.2 fixed the original bug but introduced a regression where the R channel wasn't applied. 3.4.2.3 fixes that regression

## Test plan
- [x] `dotnet build GumFull.sln` succeeds
- [x] Manually verified pasting `001193` into the color picker produces one undo entry

Closes #1654

🤖 Generated with [Claude Code](https://claude.com/claude-code)