### PR TITLE
Fix DefaultChildContainer leaking onto component instances (#2672)

### DIFF
--- a/Gum/Plugins/InternalPlugins/VariableGrid/ElementSaveDisplayer.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/ElementSaveDisplayer.cs
@@ -232,12 +232,14 @@ public class ElementSaveDisplayer
         }
 
 
-        // now that variables have been added we can remove the default child container:
+        // DefaultChildContainer (a.k.a. "Default Slot") should only appear on the component
+        // itself, never on instances or screens. Add it to addedNames so the per-variable
+        // loop below dedups it instead of re-adding it from the component's default state.
         if(!shouldShowChildContainer)
         {
             string variableName = "DefaultChildContainer";
             propertyList.RemoveAll(item => item.OriginalName == variableName);
-            addedNames.Remove(variableName);
+            addedNames.Add(variableName);
         }
 
         #region Loop through all variables

--- a/Tool/Tests/GumToolUnitTests/PropertyGridHelpers/ElementSaveDisplayerFormsPropertiesTests.cs
+++ b/Tool/Tests/GumToolUnitTests/PropertyGridHelpers/ElementSaveDisplayerFormsPropertiesTests.cs
@@ -1,12 +1,17 @@
 using Gum.DataTypes;
 using Gum.DataTypes.Behaviors;
 using Gum.DataTypes.Variables;
+using Gum.Logic;
 using Gum.Managers;
+using Gum.Plugins;
 using Gum.PropertyGridHelpers;
+using Gum.Services;
 using Gum.ToolStates;
+using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using Moq.AutoMock;
 using Shouldly;
+using System.Reflection;
 using WpfDataUi.DataTypes;
 
 namespace GumToolUnitTests.PropertyGridHelpers;
@@ -21,6 +26,8 @@ public class ElementSaveDisplayerFormsPropertiesTests : BaseTestClass
     private readonly ScreenSave _screen;
     private readonly InstanceSave _buttonInstance;
     private readonly StateSave _screenDefaultState;
+    private readonly IServiceProvider _testServiceProvider;
+    private readonly Mock<IProjectManager> _projectManagerMock;
 
     public ElementSaveDisplayerFormsPropertiesTests()
     {
@@ -56,6 +63,13 @@ public class ElementSaveDisplayerFormsPropertiesTests : BaseTestClass
         _project.Behaviors.Add(_buttonBehavior);
         ObjectFinder.Self.GumProjectSave = _project;
 
+        _projectManagerMock = new Mock<IProjectManager>();
+        _projectManagerMock.SetupGet(x => x.GumProjectSave).Returns(_project);
+        var services = new ServiceCollection();
+        services.AddSingleton(_projectManagerMock.Object);
+        _testServiceProvider = services.BuildServiceProvider();
+        Locator.Register(_testServiceProvider);
+
         _mocker.GetMock<ISelectedState>()
             .Setup(x => x.SelectedStateSave)
             .Returns(_screenDefaultState);
@@ -65,7 +79,25 @@ public class ElementSaveDisplayerFormsPropertiesTests : BaseTestClass
 
         _mocker.Use(Gum.Reflection.TypeManager.Self);
 
+        _mocker.GetMock<IVariableSaveLogic>()
+            .Setup(x => x.GetIfVariableIsActive(It.IsAny<VariableSave>(), It.IsAny<ElementSave>(), It.IsAny<InstanceSave>()))
+            .Returns(true);
+
+        _mocker.GetMock<IPluginManager>()
+            .Setup(x => x.GetAttributesFor(It.IsAny<VariableSave>()))
+            .Returns(new List<Attribute>());
+
         _displayer = _mocker.CreateInstance<ElementSaveDisplayer>();
+    }
+
+    public override void Dispose()
+    {
+        var prop = typeof(Locator).GetProperty(
+            "ServiceProviders", BindingFlags.NonPublic | BindingFlags.Static)!;
+        var providers = (List<IServiceProvider>)prop.GetValue(null)!;
+        providers.Remove(_testServiceProvider);
+
+        base.Dispose();
     }
 
     [Fact]
@@ -288,6 +320,33 @@ public class ElementSaveDisplayerFormsPropertiesTests : BaseTestClass
         InstanceMember? member = behaviorCategory.Members.FirstOrDefault(m => m.Name == "VerticalScrollBarVisibility");
         member.ShouldNotBeNull();
         member.PropertyType.ShouldBe(typeof(Gum.Forms.Controls.ScrollBarVisibility));
+    }
+
+    [Fact]
+    public void GetCategories_InstanceOfComponentWithDefaultChildContainer_DoesNotLeakDefaultChildContainerVariable()
+    {
+        // Repros issue #2672: DefaultChildContainer ("Default Slot") on a component
+        // bled through to instances of that component because the variable grid
+        // displayer removed it from addedNames instead of guarding against re-add.
+        _buttonComponent.DefaultState.Variables.Add(new VariableSave
+        {
+            Type = "string",
+            Name = "DefaultChildContainer",
+            Value = "InnerContainer"
+        });
+
+        List<MemberCategory> categories = new List<MemberCategory>();
+
+        _displayer.GetCategories(
+            instanceOwner: _screen,
+            instance: _buttonInstance,
+            categories: categories,
+            stateSave: _screenDefaultState,
+            stateSaveCategory: null);
+
+        categories.SelectMany(c => c.Members)
+            .ShouldNotContain(m => m.Name.EndsWith("DefaultChildContainer"),
+                "DefaultChildContainer should only appear on the component itself, not on instances of it");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- DefaultChildContainer ("Default Slot") was appearing in the variable grid for instances of any component that set it (ComboBox, ListBox, ScrollViewer, Menu, ...). It should only appear on the component itself.
- Root cause in `ElementSaveDisplayer.FillPropertyList`: when not showing the slot, the code removed `DefaultChildContainer` from `addedNames`, so the later per-variable loop re-added it from the component's default state. Switched to adding it to `addedNames` so the existing dedup guard in `CreatePropertyData` blocks the re-add.

## Test plan
- [x] New unit test `GetCategories_InstanceOfComponentWithDefaultChildContainer_DoesNotLeakDefaultChildContainerVariable` repros the bug (red without the fix, green with it).
- [x] Existing tests in `ElementSaveDisplayerFormsPropertiesTests` still pass.
- [x] Full `GumFull.sln` test suite passes.

Closes #2672