### PR TITLE
Hide ClipsChildren and IsRenderTarget on leaf Forms controls

### DIFF
--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ButtonClose.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ButtonClose.gucx
@@ -203,6 +203,7 @@
     <string>ButtonCategoryState</string>
     <string>ContainedType</string>
     <string>ChildrenLayout</string>
+    <string>ClipsChildren</string>
     <string>IsRenderTarget</string>
   </VariablesHiddenFromInstances>
 </ComponentSave>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ButtonConfirm.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ButtonConfirm.gucx
@@ -212,5 +212,7 @@
     <string>ButtonCategoryState</string>
     <string>ContainedType</string>
     <string>ChildrenLayout</string>
+    <string>ClipsChildren</string>
+    <string>IsRenderTarget</string>
   </VariablesHiddenFromInstances>
 </ComponentSave>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ButtonDeny.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ButtonDeny.gucx
@@ -212,5 +212,7 @@
     <string>ButtonCategoryState</string>
     <string>ContainedType</string>
     <string>ChildrenLayout</string>
+    <string>ClipsChildren</string>
+    <string>IsRenderTarget</string>
   </VariablesHiddenFromInstances>
 </ComponentSave>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ButtonIcon.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ButtonIcon.gucx
@@ -208,5 +208,7 @@
     <string>ButtonCategoryState</string>
     <string>ContainedType</string>
     <string>ChildrenLayout</string>
+    <string>ClipsChildren</string>
+    <string>IsRenderTarget</string>
   </VariablesHiddenFromInstances>
 </ComponentSave>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ButtonStandard.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ButtonStandard.gucx
@@ -215,5 +215,7 @@
     <string>ButtonCategoryState</string>
     <string>ContainedType</string>
     <string>ChildrenLayout</string>
+    <string>ClipsChildren</string>
+    <string>IsRenderTarget</string>
   </VariablesHiddenFromInstances>
 </ComponentSave>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ButtonStandardIcon.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ButtonStandardIcon.gucx
@@ -230,5 +230,7 @@
     <string>ButtonCategoryState</string>
     <string>ContainedType</string>
     <string>ChildrenLayout</string>
+    <string>ClipsChildren</string>
+    <string>IsRenderTarget</string>
   </VariablesHiddenFromInstances>
 </ComponentSave>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ButtonTab.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ButtonTab.gucx
@@ -199,5 +199,7 @@
     <string>ButtonCategoryState</string>
     <string>ContainedType</string>
     <string>ChildrenLayout</string>
+    <string>ClipsChildren</string>
+    <string>IsRenderTarget</string>
   </VariablesHiddenFromInstances>
 </ComponentSave>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/CheckBox.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/CheckBox.gucx
@@ -588,5 +588,7 @@
     <string>CheckBoxCategoryState</string>
     <string>ContainedType</string>
     <string>ChildrenLayout</string>
+    <string>ClipsChildren</string>
+    <string>IsRenderTarget</string>
   </VariablesHiddenFromInstances>
 </ComponentSave>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ComboBox.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ComboBox.gucx
@@ -259,5 +259,7 @@
     <string>ComboBoxCategoryState</string>
     <string>ContainedType</string>
     <string>ChildrenLayout</string>
+    <string>ClipsChildren</string>
+    <string>IsRenderTarget</string>
   </VariablesHiddenFromInstances>
 </ComponentSave>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/Keyboard.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/Keyboard.gucx
@@ -1854,5 +1854,7 @@
     <string>CursorMoveCategoryState</string>
     <string>ContainedType</string>
     <string>ChildrenLayout</string>
+    <string>ClipsChildren</string>
+    <string>IsRenderTarget</string>
   </VariablesHiddenFromInstances>
 </ComponentSave>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/KeyboardKey.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/KeyboardKey.gucx
@@ -200,5 +200,7 @@
     <string>ButtonCategoryState</string>
     <string>ContainedType</string>
     <string>ChildrenLayout</string>
+    <string>ClipsChildren</string>
+    <string>IsRenderTarget</string>
   </VariablesHiddenFromInstances>
 </ComponentSave>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/Label.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/Label.gucx
@@ -32,5 +32,7 @@
   <VariablesHiddenFromInstances>
     <string>ContainedType</string>
     <string>ChildrenLayout</string>
+    <string>ClipsChildren</string>
+    <string>IsRenderTarget</string>
   </VariablesHiddenFromInstances>
 </ComponentSave>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ListBox.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ListBox.gucx
@@ -267,5 +267,7 @@
     <string>ListBoxCategoryState</string>
     <string>ContainedType</string>
     <string>ChildrenLayout</string>
+    <string>ClipsChildren</string>
+    <string>IsRenderTarget</string>
   </VariablesHiddenFromInstances>
 </ComponentSave>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ListBoxItem.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ListBoxItem.gucx
@@ -182,5 +182,7 @@
     <string>ListBoxItemCategoryState</string>
     <string>ContainedType</string>
     <string>ChildrenLayout</string>
+    <string>ClipsChildren</string>
+    <string>IsRenderTarget</string>
   </VariablesHiddenFromInstances>
 </ComponentSave>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/Menu.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/Menu.gucx
@@ -123,5 +123,7 @@
   <VariablesHiddenFromInstances>
     <string>ContainedType</string>
     <string>ChildrenLayout</string>
+    <string>ClipsChildren</string>
+    <string>IsRenderTarget</string>
   </VariablesHiddenFromInstances>
 </ComponentSave>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/MenuItem.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/MenuItem.gucx
@@ -272,5 +272,7 @@
   <VariablesHiddenFromInstances>
     <string>ContainedType</string>
     <string>ChildrenLayout</string>
+    <string>ClipsChildren</string>
+    <string>IsRenderTarget</string>
   </VariablesHiddenFromInstances>
 </ComponentSave>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/PasswordBox.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/PasswordBox.gucx
@@ -341,5 +341,7 @@
     <string>PasswordBoxCategoryState</string>
     <string>ContainedType</string>
     <string>ChildrenLayout</string>
+    <string>ClipsChildren</string>
+    <string>IsRenderTarget</string>
   </VariablesHiddenFromInstances>
 </ComponentSave>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/RadioButton.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/RadioButton.gucx
@@ -396,5 +396,7 @@
     <string>RadioButtonCategoryState</string>
     <string>ContainedType</string>
     <string>ChildrenLayout</string>
+    <string>ClipsChildren</string>
+    <string>IsRenderTarget</string>
   </VariablesHiddenFromInstances>
 </ComponentSave>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ScrollBar.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ScrollBar.gucx
@@ -325,5 +325,7 @@
     <string>ScrollBarCategoryState</string>
     <string>ContainedType</string>
     <string>ChildrenLayout</string>
+    <string>ClipsChildren</string>
+    <string>IsRenderTarget</string>
   </VariablesHiddenFromInstances>
 </ComponentSave>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/Slider.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/Slider.gucx
@@ -184,5 +184,7 @@
     <string>SliderCategoryState</string>
     <string>ContainedType</string>
     <string>ChildrenLayout</string>
+    <string>ClipsChildren</string>
+    <string>IsRenderTarget</string>
   </VariablesHiddenFromInstances>
 </ComponentSave>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/SplitterStandard.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/SplitterStandard.gucx
@@ -71,5 +71,7 @@
   <VariablesHiddenFromInstances>
     <string>ContainedType</string>
     <string>ChildrenLayout</string>
+    <string>ClipsChildren</string>
+    <string>IsRenderTarget</string>
   </VariablesHiddenFromInstances>
 </ComponentSave>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/TextBox.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/TextBox.gucx
@@ -401,5 +401,7 @@
     <string>TextBoxCategoryState</string>
     <string>ContainedType</string>
     <string>ChildrenLayout</string>
+    <string>ClipsChildren</string>
+    <string>IsRenderTarget</string>
   </VariablesHiddenFromInstances>
 </ComponentSave>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/Toast.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/Toast.gucx
@@ -125,5 +125,7 @@
   <VariablesHiddenFromInstances>
     <string>ContainedType</string>
     <string>ChildrenLayout</string>
+    <string>ClipsChildren</string>
+    <string>IsRenderTarget</string>
   </VariablesHiddenFromInstances>
 </ComponentSave>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/TreeView.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/TreeView.gucx
@@ -152,5 +152,7 @@
   <VariablesHiddenFromInstances>
     <string>ContainedType</string>
     <string>ChildrenLayout</string>
+    <string>ClipsChildren</string>
+    <string>IsRenderTarget</string>
   </VariablesHiddenFromInstances>
 </ComponentSave>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/TreeViewItem.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/TreeViewItem.gucx
@@ -68,5 +68,7 @@
   <VariablesHiddenFromInstances>
     <string>ContainedType</string>
     <string>ChildrenLayout</string>
+    <string>ClipsChildren</string>
+    <string>IsRenderTarget</string>
   </VariablesHiddenFromInstances>
 </ComponentSave>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/TreeViewToggle.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/TreeViewToggle.gucx
@@ -201,5 +201,7 @@
     <string>ToggleCategoryState</string>
     <string>ContainedType</string>
     <string>ChildrenLayout</string>
+    <string>ClipsChildren</string>
+    <string>IsRenderTarget</string>
   </VariablesHiddenFromInstances>
 </ComponentSave>


### PR DESCRIPTION
## Summary
- Adds `ClipsChildren` and `IsRenderTarget` to `<VariablesHiddenFromInstances>` on leaf Forms control templates (Buttons, CheckBox, RadioButton, Slider, TextBox, PasswordBox, ComboBox, ListBox/ListBoxItem, Label, Menu/MenuItem, ScrollBar, SplitterStandard, TreeView/TreeViewItem/TreeViewToggle, Keyboard/KeyboardKey, Toast).
- Containers that legitimately host arbitrary children are unchanged: Panel, StackPanel, UserControl, ScrollViewer, DialogBox, ItemsControl, Window, SettingsView.
- Template-data only — no code changes.

## Test plan
- [ ] Open a project that uses the Forms templates and confirm `ClipsChildren` / `IsRenderTarget` no longer appear on instances of the affected leaf controls in the variable grid.
- [ ] Confirm those variables remain visible on instances of Panel, StackPanel, UserControl, ScrollViewer.
- [ ] Verify the controls still render correctly (no behavior change expected).

Closes #2673