### PR TITLE
Hide ExposeChildrenEvents on Forms controls (except generic containers)

### DIFF
--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ButtonClose.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ButtonClose.gucx
@@ -205,5 +205,6 @@
     <string>ChildrenLayout</string>
     <string>ClipsChildren</string>
     <string>IsRenderTarget</string>
+    <string>ExposeChildrenEvents</string>
   </VariablesHiddenFromInstances>
 </ComponentSave>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ButtonConfirm.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ButtonConfirm.gucx
@@ -214,5 +214,6 @@
     <string>ChildrenLayout</string>
     <string>ClipsChildren</string>
     <string>IsRenderTarget</string>
+    <string>ExposeChildrenEvents</string>
   </VariablesHiddenFromInstances>
 </ComponentSave>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ButtonDeny.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ButtonDeny.gucx
@@ -214,5 +214,6 @@
     <string>ChildrenLayout</string>
     <string>ClipsChildren</string>
     <string>IsRenderTarget</string>
+    <string>ExposeChildrenEvents</string>
   </VariablesHiddenFromInstances>
 </ComponentSave>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ButtonIcon.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ButtonIcon.gucx
@@ -210,5 +210,6 @@
     <string>ChildrenLayout</string>
     <string>ClipsChildren</string>
     <string>IsRenderTarget</string>
+    <string>ExposeChildrenEvents</string>
   </VariablesHiddenFromInstances>
 </ComponentSave>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ButtonStandard.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ButtonStandard.gucx
@@ -217,5 +217,6 @@
     <string>ChildrenLayout</string>
     <string>ClipsChildren</string>
     <string>IsRenderTarget</string>
+    <string>ExposeChildrenEvents</string>
   </VariablesHiddenFromInstances>
 </ComponentSave>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ButtonStandardIcon.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ButtonStandardIcon.gucx
@@ -232,5 +232,6 @@
     <string>ChildrenLayout</string>
     <string>ClipsChildren</string>
     <string>IsRenderTarget</string>
+    <string>ExposeChildrenEvents</string>
   </VariablesHiddenFromInstances>
 </ComponentSave>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ButtonTab.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ButtonTab.gucx
@@ -201,5 +201,6 @@
     <string>ChildrenLayout</string>
     <string>ClipsChildren</string>
     <string>IsRenderTarget</string>
+    <string>ExposeChildrenEvents</string>
   </VariablesHiddenFromInstances>
 </ComponentSave>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/CheckBox.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/CheckBox.gucx
@@ -590,5 +590,6 @@
     <string>ChildrenLayout</string>
     <string>ClipsChildren</string>
     <string>IsRenderTarget</string>
+    <string>ExposeChildrenEvents</string>
   </VariablesHiddenFromInstances>
 </ComponentSave>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ComboBox.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ComboBox.gucx
@@ -261,5 +261,6 @@
     <string>ChildrenLayout</string>
     <string>ClipsChildren</string>
     <string>IsRenderTarget</string>
+    <string>ExposeChildrenEvents</string>
   </VariablesHiddenFromInstances>
 </ComponentSave>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/DialogBox.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/DialogBox.gucx
@@ -95,5 +95,6 @@
   <VariablesHiddenFromInstances>
     <string>ContainedType</string>
     <string>ChildrenLayout</string>
+    <string>ExposeChildrenEvents</string>
   </VariablesHiddenFromInstances>
 </ComponentSave>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ItemsControl.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ItemsControl.gucx
@@ -276,5 +276,6 @@
     <string>ItemsControlCategoryState</string>
     <string>ContainedType</string>
     <string>ChildrenLayout</string>
+    <string>ExposeChildrenEvents</string>
   </VariablesHiddenFromInstances>
 </ComponentSave>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/Keyboard.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/Keyboard.gucx
@@ -1856,5 +1856,6 @@
     <string>ChildrenLayout</string>
     <string>ClipsChildren</string>
     <string>IsRenderTarget</string>
+    <string>ExposeChildrenEvents</string>
   </VariablesHiddenFromInstances>
 </ComponentSave>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/KeyboardKey.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/KeyboardKey.gucx
@@ -202,5 +202,6 @@
     <string>ChildrenLayout</string>
     <string>ClipsChildren</string>
     <string>IsRenderTarget</string>
+    <string>ExposeChildrenEvents</string>
   </VariablesHiddenFromInstances>
 </ComponentSave>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/Label.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/Label.gucx
@@ -34,5 +34,6 @@
     <string>ChildrenLayout</string>
     <string>ClipsChildren</string>
     <string>IsRenderTarget</string>
+    <string>ExposeChildrenEvents</string>
   </VariablesHiddenFromInstances>
 </ComponentSave>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ListBox.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ListBox.gucx
@@ -269,5 +269,6 @@
     <string>ChildrenLayout</string>
     <string>ClipsChildren</string>
     <string>IsRenderTarget</string>
+    <string>ExposeChildrenEvents</string>
   </VariablesHiddenFromInstances>
 </ComponentSave>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ListBoxItem.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ListBoxItem.gucx
@@ -184,5 +184,6 @@
     <string>ChildrenLayout</string>
     <string>ClipsChildren</string>
     <string>IsRenderTarget</string>
+    <string>ExposeChildrenEvents</string>
   </VariablesHiddenFromInstances>
 </ComponentSave>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/Menu.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/Menu.gucx
@@ -125,5 +125,6 @@
     <string>ChildrenLayout</string>
     <string>ClipsChildren</string>
     <string>IsRenderTarget</string>
+    <string>ExposeChildrenEvents</string>
   </VariablesHiddenFromInstances>
 </ComponentSave>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/MenuItem.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/MenuItem.gucx
@@ -274,5 +274,6 @@
     <string>ChildrenLayout</string>
     <string>ClipsChildren</string>
     <string>IsRenderTarget</string>
+    <string>ExposeChildrenEvents</string>
   </VariablesHiddenFromInstances>
 </ComponentSave>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/PasswordBox.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/PasswordBox.gucx
@@ -343,5 +343,6 @@
     <string>ChildrenLayout</string>
     <string>ClipsChildren</string>
     <string>IsRenderTarget</string>
+    <string>ExposeChildrenEvents</string>
   </VariablesHiddenFromInstances>
 </ComponentSave>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/RadioButton.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/RadioButton.gucx
@@ -398,5 +398,6 @@
     <string>ChildrenLayout</string>
     <string>ClipsChildren</string>
     <string>IsRenderTarget</string>
+    <string>ExposeChildrenEvents</string>
   </VariablesHiddenFromInstances>
 </ComponentSave>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ScrollBar.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ScrollBar.gucx
@@ -327,5 +327,6 @@
     <string>ChildrenLayout</string>
     <string>ClipsChildren</string>
     <string>IsRenderTarget</string>
+    <string>ExposeChildrenEvents</string>
   </VariablesHiddenFromInstances>
 </ComponentSave>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ScrollViewer.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ScrollViewer.gucx
@@ -288,5 +288,6 @@
   <VariablesHiddenFromInstances>
     <string>ContainedType</string>
     <string>ChildrenLayout</string>
+    <string>ExposeChildrenEvents</string>
   </VariablesHiddenFromInstances>
 </ComponentSave>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/SettingsView.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/SettingsView.gucx
@@ -70,4 +70,7 @@
       <BehaviorName>SettingsViewBehavior</BehaviorName>
     </ElementBehaviorReference>
   </Behaviors>
+  <VariablesHiddenFromInstances>
+    <string>ExposeChildrenEvents</string>
+  </VariablesHiddenFromInstances>
 </ComponentSave>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/Slider.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/Slider.gucx
@@ -186,5 +186,6 @@
     <string>ChildrenLayout</string>
     <string>ClipsChildren</string>
     <string>IsRenderTarget</string>
+    <string>ExposeChildrenEvents</string>
   </VariablesHiddenFromInstances>
 </ComponentSave>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/SplitterStandard.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/SplitterStandard.gucx
@@ -73,5 +73,6 @@
     <string>ChildrenLayout</string>
     <string>ClipsChildren</string>
     <string>IsRenderTarget</string>
+    <string>ExposeChildrenEvents</string>
   </VariablesHiddenFromInstances>
 </ComponentSave>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/TextBox.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/TextBox.gucx
@@ -403,5 +403,6 @@
     <string>ChildrenLayout</string>
     <string>ClipsChildren</string>
     <string>IsRenderTarget</string>
+    <string>ExposeChildrenEvents</string>
   </VariablesHiddenFromInstances>
 </ComponentSave>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/Toast.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/Toast.gucx
@@ -127,5 +127,6 @@
     <string>ChildrenLayout</string>
     <string>ClipsChildren</string>
     <string>IsRenderTarget</string>
+    <string>ExposeChildrenEvents</string>
   </VariablesHiddenFromInstances>
 </ComponentSave>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/TreeView.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/TreeView.gucx
@@ -154,5 +154,6 @@
     <string>ChildrenLayout</string>
     <string>ClipsChildren</string>
     <string>IsRenderTarget</string>
+    <string>ExposeChildrenEvents</string>
   </VariablesHiddenFromInstances>
 </ComponentSave>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/TreeViewItem.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/TreeViewItem.gucx
@@ -70,5 +70,6 @@
     <string>ChildrenLayout</string>
     <string>ClipsChildren</string>
     <string>IsRenderTarget</string>
+    <string>ExposeChildrenEvents</string>
   </VariablesHiddenFromInstances>
 </ComponentSave>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/TreeViewToggle.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/TreeViewToggle.gucx
@@ -203,5 +203,6 @@
     <string>ChildrenLayout</string>
     <string>ClipsChildren</string>
     <string>IsRenderTarget</string>
+    <string>ExposeChildrenEvents</string>
   </VariablesHiddenFromInstances>
 </ComponentSave>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/Window.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/Window.gucx
@@ -333,5 +333,6 @@
   <VariablesHiddenFromInstances>
     <string>ContainedType</string>
     <string>ChildrenLayout</string>
+    <string>ExposeChildrenEvents</string>
   </VariablesHiddenFromInstances>
 </ComponentSave>


### PR DESCRIPTION
## Summary
- Marks `ExposeChildrenEvents` as `IsHiddenFromInstance` on every shipped Forms control template except the three generic-container extension points (Panel, StackPanel, UserControl).
- Same template-data mechanism as #2673, but the rationale is stronger here: this isn't visual clutter, it's a footgun. Each control's author already picked the value its interaction model requires (Slider thumb vs. track, ScrollBar thumb/track/arrows, TreeViewToggle hit target, etc.). An instance toggling it silently breaks the control rather than restyling it.

## Test plan
- [ ] Open the Gum tool with a Forms-using project, drop a `Button` / `Slider` / `ScrollBar` / `TreeViewItem` / etc. instance, confirm `ExposeChildrenEvents` no longer appears in the variable grid.
- [ ] Drop a `Panel`, `StackPanel`, or `UserControl` instance, confirm `ExposeChildrenEvents` is still visible.
- [ ] Open the original component definitions, confirm `ExposeChildrenEvents` is still editable on the component itself (only hidden on instances).

Closes #2675