### PR TITLE
Add LINQ-friendly tree-traversal extensions for GraphicalUiElement

### DIFF
--- a/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
+++ b/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
@@ -511,8 +511,8 @@ public class CustomSetPropertyOnRenderable
                 }
                 else if(value is string asString)
                 {
-                    runtime.RenderTargetTextureSource = 
-                        (graphicalUiElement.GetTopParent() as GraphicalUiElement)?.GetChildByNameRecursively(asString);
+                    runtime.RenderTargetTextureSource =
+                        (graphicalUiElement.GetTopParent() as GraphicalUiElement)?.FindByName(asString);
                 }
                 handled = true;
             }

--- a/GumCommon/GumCommon.csproj
+++ b/GumCommon/GumCommon.csproj
@@ -135,6 +135,7 @@
 		</Compile>
 		<Compile Include="..\GumRuntime\GraphicalUiElement.cs" Link="GraphicalUiElement.cs" />
 		<Compile Include="..\GumRuntime\GraphicalUiElement.Binding.cs" Link="GraphicalUiElement.Binding.cs" />
+		<Compile Include="..\GumRuntime\GraphicalUiElementTreeExtensions.cs" Link="GraphicalUiElementTreeExtensions.cs" />
 		<Compile Include="..\GumRuntime\IUpdateEveryFrame.cs" Link="IUpdateEveryFrame.cs" />
 		<Compile Include="..\GumRuntime\LayoutExporter.cs" Link="Runtime\LayoutExporter.cs" />
 

--- a/GumCommon/Runtime/AnimationRuntime.cs
+++ b/GumCommon/Runtime/AnimationRuntime.cs
@@ -84,7 +84,7 @@ public class AnimationRuntime
 
                 string instanceName = name.Substring(0, indexOfDot);
 
-                instance = element.GetChildByNameRecursively(instanceName) as GraphicalUiElement;
+                instance = element.FindByName(instanceName);
             }
             if (instance == null)
             {
@@ -362,7 +362,7 @@ public class AnimationRuntime
                 {
                     instanceName = keyframe.AnimationName.Substring(0, keyframe.AnimationName.IndexOf('.'));
 
-                    var instance = graphicalUiElement.GetChildByNameRecursively(instanceName) as GraphicalUiElement;
+                    var instance = graphicalUiElement.FindByName(instanceName);
 
                     if (instance != null)
                     {

--- a/GumCoreShared.projitems
+++ b/GumCoreShared.projitems
@@ -54,6 +54,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)GumRuntime\BbCodeParser.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GumRuntime\ElementSaveExtensions.GumRuntime.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GumRuntime\GraphicalUiElement.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)GumRuntime\GraphicalUiElementTreeExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GumRuntime\InstanceSaveExtensionMethods.GumRuntime.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Gum\DataTypes\BehaviorSaveExtensionMethods.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Gum\DataTypes\ElementSaveExtensionMethods.cs" />

--- a/GumRuntime/GraphicalUiElement.cs
+++ b/GumRuntime/GraphicalUiElement.cs
@@ -6619,7 +6619,7 @@ public partial class GraphicalUiElement : IRenderableIpso, IVisible, INotifyProp
             if (this.Children?.Count > 0 && mWhatThisContains.Count == 0)
             {
                 // This is a regular item that hasn't had its mWhatThisContains populated
-                return this.GetChildByNameRecursively(name);
+                return this.FindByName(name);
             }
             else
             {
@@ -6705,6 +6705,7 @@ public partial class GraphicalUiElement : IRenderableIpso, IVisible, INotifyProp
         return null;
     }
 
+    [Obsolete("Use FindByName(name) instead. The new extension method is shallowest-first like this method, returns the same type, and composes with LINQ via Descendants().")]
     public GraphicalUiElement? GetChildByNameRecursively(string name)
     {
         return GetChildByName(Children, name);
@@ -6735,6 +6736,7 @@ public partial class GraphicalUiElement : IRenderableIpso, IVisible, INotifyProp
         return null;
     }
 
+    [Obsolete("Use Find<T>() instead, or Descendants().OfType<T>().FirstOrDefault() for non-generic cases. Note: Find<T>() matches subclasses (is-T semantics); this method matches exact type only.")]
     public GraphicalUiElement? GetChildByTypeRecursively(Type type)
     {
         return GetChildByType(Children, type);
@@ -6765,6 +6767,7 @@ public partial class GraphicalUiElement : IRenderableIpso, IVisible, INotifyProp
         return null;
     }
 
+    [Obsolete("Use Ancestors().FirstOrDefault(a => a.Name == name) instead.")]
     public GraphicalUiElement? GetParentByNameRecursively(string name)
     {
         return GetParentByName(this, name);
@@ -6789,6 +6792,7 @@ public partial class GraphicalUiElement : IRenderableIpso, IVisible, INotifyProp
         }
     }
 
+    [Obsolete("Use Ancestors().OfType<T>().FirstOrDefault() instead. Note: OfType<T>() matches subclasses (is-T semantics); this method matches exact type only.")]
     public GraphicalUiElement? GetParentByTypeRecursively(Type type)
     {
         return GetParentByType(this, type);
@@ -6818,6 +6822,7 @@ public partial class GraphicalUiElement : IRenderableIpso, IVisible, INotifyProp
     /// </summary>
     /// <param name="listToFill">List to populate. The type to search for is inferred from the element type and must be an <see cref="IRenderableIpso"/>.
     /// The user has the responsability of instantiating and clearing this list.</param>
+    [Obsolete("Use listToFill.AddRange(this.Descendants().OfType<T>()) instead. Note: Descendants().OfType<T>() matches subclasses (is-T semantics); this method matches exact type only.")]
     public void FillListWithChildrenByTypeRecursively<T>(List<T> listToFill) where T : GraphicalUiElement
     {
         FillListWithChildrenByType(Children, listToFill);
@@ -6828,10 +6833,13 @@ public partial class GraphicalUiElement : IRenderableIpso, IVisible, INotifyProp
     /// </summary>
     /// <typeparam name="T">Type to search for. Must be an <see cref="GraphicalUiElement"/>.</typeparam>
     /// <returns></returns>
+    [Obsolete("Use this.Descendants().OfType<T>().ToList() instead. Note: OfType<T>() matches subclasses (is-T semantics); this method matches exact type only.")]
     public List<T> FillListWithChildrenByTypeRecursively<T>() where T : GraphicalUiElement
     {
         var list = new List<T>();
+#pragma warning disable CS0618
         FillListWithChildrenByTypeRecursively(list);
+#pragma warning restore CS0618
         return list;
     }
 

--- a/GumRuntime/GraphicalUiElementTreeExtensions.cs
+++ b/GumRuntime/GraphicalUiElementTreeExtensions.cs
@@ -1,0 +1,124 @@
+using System.Collections.Generic;
+
+namespace Gum.Wireframe;
+
+/// <summary>
+/// Extension methods for traversing a <see cref="GraphicalUiElement"/> tree.
+/// Compose with LINQ (<c>.OfType&lt;T&gt;()</c>, <c>.Where(...)</c>, <c>.FirstOrDefault(...)</c>)
+/// for any case the <see cref="Find{T}(GraphicalUiElement)"/> / <see cref="FindByName(GraphicalUiElement, string)"/>
+/// sugar doesn't cover.
+/// </summary>
+public static class GraphicalUiElementTreeExtensions
+{
+    /// <summary>
+    /// Enumerates every descendant of <paramref name="element"/>, shallowest-first
+    /// (breadth-first). Common lookups (<see cref="Find{T}(GraphicalUiElement)"/>,
+    /// <see cref="FindByName(GraphicalUiElement, string)"/>) short-circuit on this
+    /// ordering before descending into deep subtrees, so the closest match wins.
+    /// </summary>
+    public static IEnumerable<GraphicalUiElement> Descendants(this GraphicalUiElement element)
+    {
+        Queue<GraphicalUiElement> queue = new Queue<GraphicalUiElement>();
+        foreach (GraphicalUiElement child in element.Children)
+        {
+            queue.Enqueue(child);
+        }
+        while (queue.Count > 0)
+        {
+            GraphicalUiElement current = queue.Dequeue();
+            yield return current;
+            foreach (GraphicalUiElement child in current.Children)
+            {
+                queue.Enqueue(child);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Enumerates <paramref name="element"/> followed by every descendant
+    /// (shallowest-first). Equivalent to <c>[element].Concat(element.Descendants())</c>.
+    /// </summary>
+    public static IEnumerable<GraphicalUiElement> DescendantsAndSelf(this GraphicalUiElement element)
+    {
+        yield return element;
+        foreach (GraphicalUiElement descendant in element.Descendants())
+        {
+            yield return descendant;
+        }
+    }
+
+    /// <summary>
+    /// Enumerates every ancestor of <paramref name="element"/>, nearest-first,
+    /// by walking <see cref="GraphicalUiElement.Parent"/>.
+    /// </summary>
+    public static IEnumerable<GraphicalUiElement> Ancestors(this GraphicalUiElement element)
+    {
+        GraphicalUiElement? current = element.Parent;
+        while (current != null)
+        {
+            yield return current;
+            current = current.Parent;
+        }
+    }
+
+    /// <summary>
+    /// Enumerates <paramref name="element"/> followed by every ancestor (nearest-first).
+    /// </summary>
+    public static IEnumerable<GraphicalUiElement> AncestorsAndSelf(this GraphicalUiElement element)
+    {
+        yield return element;
+        foreach (GraphicalUiElement ancestor in element.Ancestors())
+        {
+            yield return ancestor;
+        }
+    }
+
+    /// <summary>
+    /// Returns the first descendant assignable to <typeparamref name="T"/>, or null if none.
+    /// Search is shallowest-first; subclasses match (<c>is T</c> semantics).
+    /// </summary>
+    public static T? Find<T>(this GraphicalUiElement element) where T : GraphicalUiElement
+    {
+        foreach (GraphicalUiElement descendant in element.Descendants())
+        {
+            if (descendant is T match)
+            {
+                return match;
+            }
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Returns the first descendant whose <see cref="GraphicalUiElement.Name"/>
+    /// equals <paramref name="name"/>, or null if none. Search is shallowest-first.
+    /// </summary>
+    public static GraphicalUiElement? FindByName(this GraphicalUiElement element, string name)
+    {
+        foreach (GraphicalUiElement descendant in element.Descendants())
+        {
+            if (descendant.Name == name)
+            {
+                return descendant;
+            }
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Returns the first descendant assignable to <typeparamref name="T"/>
+    /// whose <see cref="GraphicalUiElement.Name"/> equals <paramref name="name"/>,
+    /// or null if none. Search is shallowest-first.
+    /// </summary>
+    public static T? Find<T>(this GraphicalUiElement element, string name) where T : GraphicalUiElement
+    {
+        foreach (GraphicalUiElement descendant in element.Descendants())
+        {
+            if (descendant is T match && match.Name == name)
+            {
+                return match;
+            }
+        }
+        return null;
+    }
+}

--- a/GumRuntime/GraphicalUiElementTreeExtensions.cs
+++ b/GumRuntime/GraphicalUiElementTreeExtensions.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Linq;
 
 namespace Gum.Wireframe;
 
@@ -9,6 +8,13 @@ namespace Gum.Wireframe;
 /// for any case the <see cref="Find{T}(GraphicalUiElement)"/> / <see cref="FindByName(GraphicalUiElement, string)"/>
 /// sugar doesn't cover.
 /// </summary>
+// The Find* methods below are intentionally hand-rolled rather than expressed as
+// Descendants().OfType<T>().FirstOrDefault(predicate). Algorithmically the two are
+// equivalent (BFS, lazy, short-circuit on first match), but the LINQ form allocates
+// a closure and a delegate per call when the predicate captures `name`. These
+// methods are general-purpose and may end up on hot paths (e.g. inside per-frame
+// update or input handling), so the hand-rolled form avoids that overhead. Do not
+// "simplify" them back to LINQ without a perf review of the call sites.
 public static class GraphicalUiElementTreeExtensions
 {
     /// <summary>
@@ -79,14 +85,32 @@ public static class GraphicalUiElementTreeExtensions
     /// Search is shallowest-first; subclasses match (<c>is T</c> semantics).
     /// </summary>
     public static T? Find<T>(this GraphicalUiElement element) where T : GraphicalUiElement
-        => element.Descendants().OfType<T>().FirstOrDefault();
+    {
+        foreach (GraphicalUiElement descendant in element.Descendants())
+        {
+            if (descendant is T match)
+            {
+                return match;
+            }
+        }
+        return null;
+    }
 
     /// <summary>
     /// Returns the first descendant whose <see cref="GraphicalUiElement.Name"/>
     /// equals <paramref name="name"/>, or null if none. Search is shallowest-first.
     /// </summary>
     public static GraphicalUiElement? FindByName(this GraphicalUiElement element, string name)
-        => element.Descendants().FirstOrDefault(d => d.Name == name);
+    {
+        foreach (GraphicalUiElement descendant in element.Descendants())
+        {
+            if (descendant.Name == name)
+            {
+                return descendant;
+            }
+        }
+        return null;
+    }
 
     /// <summary>
     /// Returns the first descendant assignable to <typeparamref name="T"/>
@@ -94,5 +118,14 @@ public static class GraphicalUiElementTreeExtensions
     /// or null if none. Search is shallowest-first.
     /// </summary>
     public static T? Find<T>(this GraphicalUiElement element, string name) where T : GraphicalUiElement
-        => element.Descendants().OfType<T>().FirstOrDefault(t => t.Name == name);
+    {
+        foreach (GraphicalUiElement descendant in element.Descendants())
+        {
+            if (descendant is T match && match.Name == name)
+            {
+                return match;
+            }
+        }
+        return null;
+    }
 }

--- a/GumRuntime/GraphicalUiElementTreeExtensions.cs
+++ b/GumRuntime/GraphicalUiElementTreeExtensions.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Gum.Wireframe;
 
@@ -78,32 +79,14 @@ public static class GraphicalUiElementTreeExtensions
     /// Search is shallowest-first; subclasses match (<c>is T</c> semantics).
     /// </summary>
     public static T? Find<T>(this GraphicalUiElement element) where T : GraphicalUiElement
-    {
-        foreach (GraphicalUiElement descendant in element.Descendants())
-        {
-            if (descendant is T match)
-            {
-                return match;
-            }
-        }
-        return null;
-    }
+        => element.Descendants().OfType<T>().FirstOrDefault();
 
     /// <summary>
     /// Returns the first descendant whose <see cref="GraphicalUiElement.Name"/>
     /// equals <paramref name="name"/>, or null if none. Search is shallowest-first.
     /// </summary>
     public static GraphicalUiElement? FindByName(this GraphicalUiElement element, string name)
-    {
-        foreach (GraphicalUiElement descendant in element.Descendants())
-        {
-            if (descendant.Name == name)
-            {
-                return descendant;
-            }
-        }
-        return null;
-    }
+        => element.Descendants().FirstOrDefault(d => d.Name == name);
 
     /// <summary>
     /// Returns the first descendant assignable to <typeparamref name="T"/>
@@ -111,14 +94,5 @@ public static class GraphicalUiElementTreeExtensions
     /// or null if none. Search is shallowest-first.
     /// </summary>
     public static T? Find<T>(this GraphicalUiElement element, string name) where T : GraphicalUiElement
-    {
-        foreach (GraphicalUiElement descendant in element.Descendants())
-        {
-            if (descendant is T match && match.Name == name)
-            {
-                return match;
-            }
-        }
-        return null;
-    }
+        => element.Descendants().OfType<T>().FirstOrDefault(t => t.Name == name);
 }

--- a/MonoGameGum.Tests/Forms/FrameworkElementTreeExtensionsTests.cs
+++ b/MonoGameGum.Tests/Forms/FrameworkElementTreeExtensionsTests.cs
@@ -1,0 +1,259 @@
+using Gum.Forms;
+using Gum.Forms.Controls;
+using Gum.GueDeriving;
+using Gum.Wireframe;
+using Shouldly;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace MonoGameGum.Tests.Forms;
+
+public class FrameworkElementTreeExtensionsTests : BaseTestClass
+{
+    private class SpecialButton : Button { }
+
+    #region FindVisual<T>
+
+    [Fact]
+    public void FindVisualOfT_ReturnsVisualUnderControl()
+    {
+        Button button = new();
+
+        TextRuntime? textInstance = button.FindVisual<TextRuntime>();
+
+        textInstance.ShouldNotBeNull();
+        textInstance.ShouldBe(button.Visual.Find<TextRuntime>());
+    }
+
+    [Fact]
+    public void FindVisualOfT_ReturnsNull_WhenNoMatch()
+    {
+        Button button = new();
+
+        SpriteRuntime? result = button.FindVisual<SpriteRuntime>();
+
+        result.ShouldBeNull();
+    }
+
+    #endregion
+
+    #region FindVisualByName
+
+    [Fact]
+    public void FindVisualByName_ReturnsNamedDescendantVisual()
+    {
+        Button button = new();
+
+        GraphicalUiElement? result = button.FindVisualByName("TextInstance");
+
+        result.ShouldNotBeNull();
+        result.Name.ShouldBe("TextInstance");
+    }
+
+    #endregion
+
+    #region FindVisual<T>(name)
+
+    [Fact]
+    public void FindVisualOfTByName_RequiresBothTypeAndName()
+    {
+        Button button = new();
+
+        TextRuntime? result = button.FindVisual<TextRuntime>("TextInstance");
+
+        result.ShouldNotBeNull();
+        result.Name.ShouldBe("TextInstance");
+    }
+
+    #endregion
+
+    #region Find<T>
+
+    [Fact]
+    public void FindOfT_FindsNestedFrameworkElement()
+    {
+        // Window contains Buttons via AddChild — the Button's visual ends up under the
+        // window's InnerPanel visual, with FormsControlAsObject pointing back at the Button.
+        Window window = new();
+        Button button = new();
+        window.AddChild(button);
+
+        Button? found = window.Find<Button>();
+
+        found.ShouldBe(button);
+    }
+
+    [Fact]
+    public void FindOfT_MatchesSubclasses()
+    {
+        Window window = new();
+        SpecialButton special = new();
+        window.AddChild(special);
+
+        Button? found = window.Find<Button>();
+
+        found.ShouldBe(special);
+    }
+
+    [Fact]
+    public void FindOfT_ReturnsShallowestMatch()
+    {
+        Window outer = new();
+        Window inner = new();
+        Button shallow = new();
+        Button deep = new();
+        outer.AddChild(shallow);
+        outer.AddChild(inner);
+        inner.AddChild(deep);
+
+        Button? found = outer.Find<Button>();
+
+        found.ShouldBe(shallow);
+    }
+
+    [Fact]
+    public void FindOfT_ReturnsNull_WhenNoMatchingFrameworkElement()
+    {
+        Window window = new();
+
+        Button? found = window.Find<Button>();
+
+        found.ShouldBeNull();
+    }
+
+    #endregion
+
+    #region FindByName
+
+    [Fact]
+    public void FindByName_MatchesOnVisualName()
+    {
+        Window window = new();
+        Button button = new();
+        button.Visual.Name = "OkButton";
+        window.AddChild(button);
+
+        FrameworkElement? found = window.FindByName("OkButton");
+
+        found.ShouldBe(button);
+    }
+
+    #endregion
+
+    #region Find<T>(name)
+
+    [Fact]
+    public void FindOfTByName_RequiresBothTypeAndName()
+    {
+        Window window = new();
+        Button decoy = new();
+        decoy.Visual.Name = "Target";
+        Button match = new();
+        match.Visual.Name = "Target";
+        window.AddChild(decoy);
+        window.AddChild(match);
+
+        Button? found = window.Find<Button>("Target");
+
+        // Decoy is added first, so shallowest-first returns it.
+        found.ShouldBe(decoy);
+    }
+
+    #endregion
+
+    #region Descendants
+
+    [Fact]
+    public void Descendants_YieldsOnlyFrameworkElements()
+    {
+        // The visual tree contains many non-FE nodes (ContainerRuntime panels, TextRuntime,
+        // NineSliceRuntime borders). Descendants() must skip those and yield only the FEs.
+        Window window = new();
+        Button a = new();
+        Button b = new();
+        window.AddChild(a);
+        window.AddChild(b);
+
+        List<FrameworkElement> result = window.Descendants().ToList();
+
+        result.ShouldContain(a);
+        result.ShouldContain(b);
+        result.ShouldAllBe(x => x is FrameworkElement);
+    }
+
+    [Fact]
+    public void Descendants_DoesNotIncludeSelf()
+    {
+        Window window = new();
+        Button button = new();
+        window.AddChild(button);
+
+        List<FrameworkElement> result = window.Descendants().ToList();
+
+        result.ShouldNotContain(window);
+    }
+
+    #endregion
+
+    #region DescendantsAndSelf
+
+    [Fact]
+    public void DescendantsAndSelf_StartsWithSelf()
+    {
+        Window window = new();
+        Button button = new();
+        window.AddChild(button);
+
+        List<FrameworkElement> result = window.DescendantsAndSelf().ToList();
+
+        result[0].ShouldBe(window);
+        result.ShouldContain(button);
+    }
+
+    #endregion
+
+    #region Ancestors
+
+    [Fact]
+    public void Ancestors_WalksUpToContainingFrameworkElements()
+    {
+        Window window = new();
+        Button button = new();
+        window.AddChild(button);
+
+        List<FrameworkElement> result = button.Ancestors().ToList();
+
+        result.ShouldContain(window);
+        result.ShouldNotContain(button);
+    }
+
+    [Fact]
+    public void Ancestors_ReturnsEmpty_WhenNoFrameworkElementAncestors()
+    {
+        Button button = new();
+
+        IEnumerable<FrameworkElement> result = button.Ancestors();
+
+        result.ShouldBeEmpty();
+    }
+
+    #endregion
+
+    #region AncestorsAndSelf
+
+    [Fact]
+    public void AncestorsAndSelf_StartsWithSelf()
+    {
+        Window window = new();
+        Button button = new();
+        window.AddChild(button);
+
+        List<FrameworkElement> result = button.AncestorsAndSelf().ToList();
+
+        result[0].ShouldBe(button);
+        result.ShouldContain(window);
+    }
+
+    #endregion
+}

--- a/MonoGameGum.Tests/Forms/ListBoxTests.cs
+++ b/MonoGameGum.Tests/Forms/ListBoxTests.cs
@@ -26,8 +26,7 @@ public class ListBoxTests : BaseTestClass
         ListBox listBox = new();
         InteractiveGue visual = listBox.Visual;
 
-        List<ContainerRuntime> children = new ();
-        visual.FillListWithChildrenByTypeRecursively<ContainerRuntime>(children);
+        List<ContainerRuntime> children = visual.Descendants().OfType<ContainerRuntime>().ToList();
 
         foreach(var child in children)
         {
@@ -295,7 +294,7 @@ public class ListBoxTests : BaseTestClass
         listBox.ListBoxItems[0]!.BindingContext.ShouldBe("Item 1");
         listBox.ListBoxItems[1]!.BindingContext.ShouldBe("Item 0");
 
-        var innerPanel = listBox.Visual.GetChildByNameRecursively("InnerPanelInstance")!;
+        var innerPanel = listBox.Visual.FindByName("InnerPanelInstance")!;
         innerPanel.Children.Count.ShouldBe(10);
         for(int i = 0; i < 10; i++)
         {

--- a/MonoGameGum.Tests/Forms/ScrollBarTests.cs
+++ b/MonoGameGum.Tests/Forms/ScrollBarTests.cs
@@ -20,8 +20,7 @@ public class ScrollBarTests
         ScrollBar scrollBar = new();
         InteractiveGue visual = scrollBar.Visual;
 
-        List<ContainerRuntime> children = new();
-        visual.FillListWithChildrenByTypeRecursively<ContainerRuntime>(children);
+        List<ContainerRuntime> children = visual.Descendants().OfType<ContainerRuntime>().ToList();
 
         foreach (var child in children)
         {

--- a/MonoGameGum.Tests/Forms/ScrollViewerTests.cs
+++ b/MonoGameGum.Tests/Forms/ScrollViewerTests.cs
@@ -22,8 +22,7 @@ public class ScrollViewerTests : BaseTestClass
         ScrollViewer scrollViewer = new();
         InteractiveGue visual = scrollViewer.Visual;
 
-        List<ContainerRuntime> children = new();
-        visual.FillListWithChildrenByTypeRecursively<ContainerRuntime>(children);
+        List<ContainerRuntime> children = visual.Descendants().OfType<ContainerRuntime>().ToList();
 
         foreach (var child in children)
         {

--- a/MonoGameGum.Tests/Forms/SliderTests.cs
+++ b/MonoGameGum.Tests/Forms/SliderTests.cs
@@ -20,8 +20,7 @@ public class SliderTests : BaseTestClass
         Slider slider = new();
         InteractiveGue visual = slider.Visual;
 
-        List<ContainerRuntime> children = new();
-        visual.FillListWithChildrenByTypeRecursively<ContainerRuntime>(children);
+        List<ContainerRuntime> children = visual.Descendants().OfType<ContainerRuntime>().ToList();
 
         foreach (var child in children)
         {

--- a/MonoGameGum.Tests/Forms/TextBoxTests.cs
+++ b/MonoGameGum.Tests/Forms/TextBoxTests.cs
@@ -35,7 +35,7 @@ public class TextBoxTests : BaseTestClass
 
 
         var textInstance =
-            (TextRuntime)textBox.Visual.GetChildByNameRecursively("TextInstance")!;
+            textBox.Visual.Find<TextRuntime>("TextInstance")!;
 
         var innerTextObject = (RenderingLibrary.Graphics.Text)textInstance.RenderableComponent;
 
@@ -133,7 +133,7 @@ public class TextBoxTests : BaseTestClass
         textBox.Text = "Hello";
 
         GraphicalUiElement caret = 
-            (GraphicalUiElement)textBox.Visual.GetChildByNameRecursively("CaretInstance")!;
+            textBox.Visual.FindByName("CaretInstance")!;
 
         textBox.CaretIndex = 0;
         float absolutePosition = caret.AbsoluteLeft;
@@ -169,7 +169,7 @@ public class TextBoxTests : BaseTestClass
         textBox.IsFocused = true;
 
         GraphicalUiElement caret =
-            (GraphicalUiElement)textBox.Visual.GetChildByNameRecursively("CaretInstance")!;
+            textBox.Visual.FindByName("CaretInstance")!;
 
         textBox.CaretIndex = 0;
         float absolutePosition = caret.AbsoluteTop;
@@ -218,8 +218,7 @@ public class TextBoxTests : BaseTestClass
         TextBox textBox = new();
         InteractiveGue visual = textBox.Visual;
 
-        List<ContainerRuntime> children = new();
-        visual.FillListWithChildrenByTypeRecursively<ContainerRuntime>(children);
+        List<ContainerRuntime> children = visual.Descendants().OfType<ContainerRuntime>().ToList();
 
         foreach (var child in children)
         {
@@ -328,7 +327,7 @@ public class TextBoxTests : BaseTestClass
             textBox.HandleCharEntered(' ');
         }
 
-        var textInstance = (TextRuntime)textBox.Visual.GetChildByNameRecursively("TextInstance")!;
+        var textInstance = textBox.Visual.Find<TextRuntime>("TextInstance")!;
         var innerTextObject = (RenderingLibrary.Graphics.Text)textInstance.RenderableComponent;
         innerTextObject.WrappedText.Count.ShouldBeGreaterThan(1);
     }
@@ -408,8 +407,7 @@ public class TextBoxTests : BaseTestClass
     public void TextBox_ShouldHaveSelectionInstance()
     {
         var textBox = new TextBox();
-        var selection = (ColoredRectangleRuntime)textBox
-            .Visual.GetChildByNameRecursively("SelectionInstance")!;
+        var selection = textBox.Visual.Find<ColoredRectangleRuntime>("SelectionInstance")!;
 
         selection.Color = Microsoft.Xna.Framework.Color.Blue;
 
@@ -423,8 +421,7 @@ public class TextBoxTests : BaseTestClass
         textBox.MaxNumberOfLines = 3;
         textBox.Text = "line1\nline2\nline3\nline4\nline5";
         
-        var textInstance = (TextRuntime)textBox
-            .Visual.GetChildByNameRecursively("TextInstance")!;
+        var textInstance = textBox.Visual.Find<TextRuntime>("TextInstance")!;
 
         var innerTextObject = (RenderingLibrary.Graphics.Text)textInstance.RenderableComponent;
 
@@ -441,8 +438,7 @@ public class TextBoxTests : BaseTestClass
         textBox.Text = "line1\nline2\nline3\nline4\nline5";
         textBox.MaxNumberOfLines = 3;
 
-        var textInstance = (TextRuntime)textBox
-            .Visual.GetChildByNameRecursively("TextInstance")!;
+        var textInstance = textBox.Visual.Find<TextRuntime>("TextInstance")!;
 
         var innerTextObject = (RenderingLibrary.Graphics.Text)textInstance.RenderableComponent;
 
@@ -459,8 +455,7 @@ public class TextBoxTests : BaseTestClass
         textBox.Text = "line1\nline2\nline3\nline4\nline5";
         textBox.MaxNumberOfLines = null;
 
-        var textInstance = (TextRuntime)textBox
-            .Visual.GetChildByNameRecursively("TextInstance")!;
+        var textInstance = textBox.Visual.Find<TextRuntime>("TextInstance")!;
 
         var innerTextObject = (RenderingLibrary.Graphics.Text)textInstance.RenderableComponent;
 
@@ -483,8 +478,7 @@ public class TextBoxTests : BaseTestClass
         //textBox.Text = "abcdefghijklmnopqrstuvwxyz";
         textBox.MaxLettersToShow = 3;
 
-        var textInstance = (TextRuntime)textBox
-            .Visual.GetChildByNameRecursively("TextInstance")!;
+        var textInstance = textBox.Visual.Find<TextRuntime>("TextInstance")!;
 
         textInstance.MaxLettersToShow.ShouldBe(3);
 

--- a/MonoGameGum.Tests/Forms/WindowTests.cs
+++ b/MonoGameGum.Tests/Forms/WindowTests.cs
@@ -180,7 +180,7 @@ public class WindowTests : BaseTestClass
         sut.AddToRoot();
 
         InteractiveGue left =
-            (InteractiveGue)sut.Visual.GetChildByNameRecursively("BorderLeftInstance")!;
+            sut.Visual.Find<InteractiveGue>("BorderLeftInstance")!;
 
         sut.Visual.Width = 20;
         sut.Visual.MinWidth = 20;
@@ -213,7 +213,7 @@ public class WindowTests : BaseTestClass
         sut.AddToRoot();
 
         InteractiveGue right =
-            (InteractiveGue)sut.Visual.GetChildByNameRecursively("BorderRightInstance")!;
+            sut.Visual.Find<InteractiveGue>("BorderRightInstance")!;
 
         sut.Visual.Width = 20;
         sut.Visual.MinWidth = 20;
@@ -249,7 +249,7 @@ public class WindowTests : BaseTestClass
         sut.AddToRoot();
 
         InteractiveGue top =
-            (InteractiveGue)sut.Visual.GetChildByNameRecursively("BorderTopInstance")!;
+            sut.Visual.Find<InteractiveGue>("BorderTopInstance")!;
 
         sut.Visual.Height = 20;
         sut.Visual.MinHeight = 20;
@@ -282,7 +282,7 @@ public class WindowTests : BaseTestClass
         sut.AddToRoot();
 
         InteractiveGue bottom =
-            (InteractiveGue)sut.Visual.GetChildByNameRecursively("BorderBottomInstance")!;
+            sut.Visual.Find<InteractiveGue>("BorderBottomInstance")!;
 
         sut.Visual.Height = 20;
         sut.Visual.MinHeight = 20;

--- a/MonoGameGum.Tests/Runtimes/GraphicalUiElementTests.cs
+++ b/MonoGameGum.Tests/Runtimes/GraphicalUiElementTests.cs
@@ -722,6 +722,7 @@ public class GraphicalUiElementTests : BaseTestClass
     #endregion
 
     #region FillListWithChildrenByType
+#pragma warning disable CS0618 // Test exists to cover the obsolete API; remove when the API is removed.
     [Fact]
     public void FillListWithChildrenByType_ShouldFillRecursively()
     {
@@ -739,6 +740,7 @@ public class GraphicalUiElementTests : BaseTestClass
         list[0].ShouldBeOfType<SpriteRuntime>();
         list[1].ShouldBeOfType<SpriteRuntime>();
     }
+#pragma warning restore CS0618
 
     #endregion
 
@@ -1766,6 +1768,7 @@ public class GraphicalUiElementTests : BaseTestClass
     }
 
     #region GetParentByTypeRecursively Tests
+#pragma warning disable CS0618 // Tests exist to cover the obsolete API; remove when the API is removed.
 
     // Subclass used to distinguish type from ContainerRuntime in parent-search tests
     private class SpecialContainer : ContainerRuntime { }
@@ -1858,6 +1861,7 @@ public class GraphicalUiElementTests : BaseTestClass
         result.ShouldBe(root);
     }
 
+#pragma warning restore CS0618
     #endregion
 
     #region IRenderableIpso.Children frozen empty collection

--- a/MonoGameGum.Tests/Runtimes/GraphicalUiElementTreeExtensionsTests.cs
+++ b/MonoGameGum.Tests/Runtimes/GraphicalUiElementTreeExtensionsTests.cs
@@ -1,0 +1,262 @@
+using Gum.GueDeriving;
+using Gum.Wireframe;
+using Shouldly;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace MonoGameGum.Tests.Runtimes;
+
+public class GraphicalUiElementTreeExtensionsTests : BaseTestClass
+{
+    private class SpecialContainer : ContainerRuntime { }
+
+    #region Descendants
+
+    [Fact]
+    public void Descendants_ReturnsEmpty_WhenNoChildren()
+    {
+        GraphicalUiElement sut = new();
+
+        IEnumerable<GraphicalUiElement> result = sut.Descendants();
+
+        result.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Descendants_ReturnsDirectChildrenAndDeeper()
+    {
+        ContainerRuntime root = new() { Name = "root" };
+        ContainerRuntime child = new() { Name = "child" };
+        ContainerRuntime grandchild = new() { Name = "grandchild" };
+        root.AddChild(child);
+        child.AddChild(grandchild);
+
+        List<GraphicalUiElement> result = root.Descendants().ToList();
+
+        result.ShouldBe(new GraphicalUiElement[] { child, grandchild });
+    }
+
+    [Fact]
+    public void Descendants_EnumeratesShallowestFirst()
+    {
+        // Tree:
+        //     root
+        //    /    \
+        //   a      b
+        //   |
+        //   a1
+        // Shallowest-first: a, b, a1 (NOT a, a1, b which would be depth-first).
+        ContainerRuntime root = new() { Name = "root" };
+        ContainerRuntime a = new() { Name = "a" };
+        ContainerRuntime b = new() { Name = "b" };
+        ContainerRuntime a1 = new() { Name = "a1" };
+        root.AddChild(a);
+        root.AddChild(b);
+        a.AddChild(a1);
+
+        List<GraphicalUiElement> result = root.Descendants().ToList();
+
+        result.ShouldBe(new GraphicalUiElement[] { a, b, a1 });
+    }
+
+    [Fact]
+    public void Descendants_IsLazy_DoesNotEnumerateUntilIterated()
+    {
+        // Cycle would StackOverflow if eagerly walked, so building a deep tree
+        // and asserting that Take(1) doesn't traverse the whole thing proves laziness.
+        ContainerRuntime root = new();
+        ContainerRuntime current = root;
+        for (int i = 0; i < 1000; i++)
+        {
+            ContainerRuntime next = new() { Name = $"n{i}" };
+            current.AddChild(next);
+            current = next;
+        }
+
+        GraphicalUiElement first = root.Descendants().First();
+
+        first.Name.ShouldBe("n0");
+    }
+
+    #endregion
+
+    #region DescendantsAndSelf
+
+    [Fact]
+    public void DescendantsAndSelf_StartsWithSelf()
+    {
+        ContainerRuntime root = new() { Name = "root" };
+        ContainerRuntime child = new() { Name = "child" };
+        root.AddChild(child);
+
+        List<GraphicalUiElement> result = root.DescendantsAndSelf().ToList();
+
+        result.ShouldBe(new GraphicalUiElement[] { root, child });
+    }
+
+    #endregion
+
+    #region Ancestors
+
+    [Fact]
+    public void Ancestors_ReturnsEmpty_WhenNoParent()
+    {
+        GraphicalUiElement sut = new();
+
+        IEnumerable<GraphicalUiElement> result = sut.Ancestors();
+
+        result.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Ancestors_WalksParentChain_NearestFirst()
+    {
+        ContainerRuntime grandparent = new() { Name = "grandparent" };
+        ContainerRuntime parent = new() { Name = "parent" };
+        GraphicalUiElement child = new() { Name = "child" };
+        grandparent.AddChild(parent);
+        parent.AddChild(child);
+
+        List<GraphicalUiElement> result = child.Ancestors().ToList();
+
+        result.ShouldBe(new GraphicalUiElement[] { parent, grandparent });
+    }
+
+    #endregion
+
+    #region AncestorsAndSelf
+
+    [Fact]
+    public void AncestorsAndSelf_StartsWithSelf()
+    {
+        ContainerRuntime parent = new() { Name = "parent" };
+        GraphicalUiElement child = new() { Name = "child" };
+        parent.AddChild(child);
+
+        List<GraphicalUiElement> result = child.AncestorsAndSelf().ToList();
+
+        result.ShouldBe(new GraphicalUiElement[] { child, parent });
+    }
+
+    #endregion
+
+    #region Find<T>
+
+    [Fact]
+    public void FindOfT_ReturnsFirstShallowestMatch()
+    {
+        // Two SpriteRuntimes — one shallow, one deep. BFS must return the shallow one.
+        ContainerRuntime root = new();
+        ContainerRuntime middle = new();
+        SpriteRuntime deep = new() { Name = "deep" };
+        SpriteRuntime shallow = new() { Name = "shallow" };
+        root.AddChild(middle);
+        root.AddChild(shallow);
+        middle.AddChild(deep);
+
+        SpriteRuntime? result = root.Find<SpriteRuntime>();
+
+        result.ShouldBe(shallow);
+    }
+
+    [Fact]
+    public void FindOfT_MatchesSubclasses()
+    {
+        // is-T semantics: searching for ContainerRuntime should find a SpecialContainer.
+        ContainerRuntime root = new();
+        SpecialContainer special = new() { Name = "special" };
+        root.AddChild(special);
+
+        ContainerRuntime? result = root.Find<ContainerRuntime>();
+
+        result.ShouldBe(special);
+    }
+
+    [Fact]
+    public void FindOfT_ReturnsNull_WhenNoMatch()
+    {
+        ContainerRuntime root = new();
+        root.AddChild(new ContainerRuntime());
+
+        SpriteRuntime? result = root.Find<SpriteRuntime>();
+
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public void FindOfT_DoesNotMatchSelf()
+    {
+        // Sugar walks descendants only, not self — matches legacy GetChild*Recursively behavior.
+        SpriteRuntime sut = new();
+
+        SpriteRuntime? result = sut.Find<SpriteRuntime>();
+
+        result.ShouldBeNull();
+    }
+
+    #endregion
+
+    #region FindByName
+
+    [Fact]
+    public void FindByName_ReturnsFirstShallowestMatch()
+    {
+        // Two children share the name "Target" — the shallower one wins.
+        // This mirrors the legacy GetChildByNameRecursively behavior that ListBox/FocusedIndicator depends on.
+        ContainerRuntime root = new();
+        ContainerRuntime shallow = new() { Name = "Target" };
+        ContainerRuntime middle = new();
+        ContainerRuntime deep = new() { Name = "Target" };
+        root.AddChild(shallow);
+        root.AddChild(middle);
+        middle.AddChild(deep);
+
+        GraphicalUiElement? result = root.FindByName("Target");
+
+        result.ShouldBe(shallow);
+    }
+
+    [Fact]
+    public void FindByName_ReturnsNull_WhenNoMatch()
+    {
+        ContainerRuntime root = new();
+        root.AddChild(new ContainerRuntime { Name = "Other" });
+
+        GraphicalUiElement? result = root.FindByName("Missing");
+
+        result.ShouldBeNull();
+    }
+
+    #endregion
+
+    #region Find<T>(name)
+
+    [Fact]
+    public void FindOfTByName_RequiresBothTypeAndName()
+    {
+        // A ContainerRuntime named "Target" should be skipped when searching for a SpriteRuntime named "Target".
+        ContainerRuntime root = new();
+        ContainerRuntime decoy = new() { Name = "Target" };
+        SpriteRuntime match = new() { Name = "Target" };
+        root.AddChild(decoy);
+        root.AddChild(match);
+
+        SpriteRuntime? result = root.Find<SpriteRuntime>("Target");
+
+        result.ShouldBe(match);
+    }
+
+    [Fact]
+    public void FindOfTByName_ReturnsNull_WhenNoMatch()
+    {
+        ContainerRuntime root = new();
+        root.AddChild(new SpriteRuntime { Name = "Other" });
+
+        SpriteRuntime? result = root.Find<SpriteRuntime>("Target");
+
+        result.ShouldBeNull();
+    }
+
+    #endregion
+}

--- a/MonoGameGum/Forms/FrameworkElementTreeExtensions.cs
+++ b/MonoGameGum/Forms/FrameworkElementTreeExtensions.cs
@@ -1,6 +1,5 @@
 using Gum.Wireframe;
 using System.Collections.Generic;
-using System.Linq;
 
 #if FRB
 using FlatRedBall.Forms.Controls;
@@ -18,6 +17,13 @@ namespace Gum.Forms;
 /// the visual tree that contains <see cref="FrameworkElement"/> back-references) and
 /// for reaching into a control's underlying visuals via the <c>FindVisual*</c> sugar.
 /// </summary>
+// The Find* methods below are intentionally hand-rolled rather than expressed as
+// Descendants().OfType<T>().FirstOrDefault(predicate). Algorithmically the two are
+// equivalent (BFS, lazy, short-circuit on first match), but the LINQ form allocates
+// a closure and a delegate per call when the predicate captures `name`. These
+// methods are general-purpose and may end up on hot paths (e.g. inside per-frame
+// update or input handling), so the hand-rolled form avoids that overhead. Do not
+// "simplify" them back to LINQ without a perf review of the call sites.
 public static class FrameworkElementTreeExtensions
 {
     #region FE-returning traversal (Forms-first)
@@ -68,14 +74,32 @@ public static class FrameworkElementTreeExtensions
     /// <typeparamref name="T"/>, or null if none. Search is shallowest-first; subclasses match.
     /// </summary>
     public static T? Find<T>(this FrameworkElement element) where T : FrameworkElement
-        => element.Descendants().OfType<T>().FirstOrDefault();
+    {
+        foreach (FrameworkElement descendant in element.Descendants())
+        {
+            if (descendant is T match)
+            {
+                return match;
+            }
+        }
+        return null;
+    }
 
     /// <summary>
     /// Returns the first descendant <see cref="FrameworkElement"/> whose underlying
     /// <c>Visual.Name</c> equals <paramref name="name"/>, or null if none.
     /// </summary>
     public static FrameworkElement? FindByName(this FrameworkElement element, string name)
-        => element.Descendants().FirstOrDefault(d => d.Visual?.Name == name);
+    {
+        foreach (FrameworkElement descendant in element.Descendants())
+        {
+            if (descendant.Visual?.Name == name)
+            {
+                return descendant;
+            }
+        }
+        return null;
+    }
 
     /// <summary>
     /// Returns the first descendant <see cref="FrameworkElement"/> assignable to
@@ -83,7 +107,16 @@ public static class FrameworkElementTreeExtensions
     /// <paramref name="name"/>, or null if none.
     /// </summary>
     public static T? Find<T>(this FrameworkElement element, string name) where T : FrameworkElement
-        => element.Descendants().OfType<T>().FirstOrDefault(t => t.Visual?.Name == name);
+    {
+        foreach (FrameworkElement descendant in element.Descendants())
+        {
+            if (descendant is T match && match.Visual?.Name == name)
+            {
+                return match;
+            }
+        }
+        return null;
+    }
 
     private static IEnumerable<FrameworkElement> ProjectToFrameworkElements(IEnumerable<GraphicalUiElement> visuals)
     {

--- a/MonoGameGum/Forms/FrameworkElementTreeExtensions.cs
+++ b/MonoGameGum/Forms/FrameworkElementTreeExtensions.cs
@@ -1,5 +1,6 @@
 using Gum.Wireframe;
 using System.Collections.Generic;
+using System.Linq;
 
 #if FRB
 using FlatRedBall.Forms.Controls;
@@ -26,15 +27,7 @@ public static class FrameworkElementTreeExtensions
     /// shallowest-first. Skips visual-only nodes that have no Forms control attached.
     /// </summary>
     public static IEnumerable<FrameworkElement> Descendants(this FrameworkElement element)
-    {
-        foreach (GraphicalUiElement descendant in element.Visual.Descendants())
-        {
-            if (descendant is InteractiveGue interactive && interactive.FormsControlAsObject is FrameworkElement fe)
-            {
-                yield return fe;
-            }
-        }
-    }
+        => ProjectToFrameworkElements(element.Visual.Descendants());
 
     /// <summary>
     /// Enumerates <paramref name="element"/> followed by every descendant
@@ -55,15 +48,7 @@ public static class FrameworkElementTreeExtensions
     /// where one exists. Nearest-first.
     /// </summary>
     public static IEnumerable<FrameworkElement> Ancestors(this FrameworkElement element)
-    {
-        foreach (GraphicalUiElement ancestor in element.Visual.Ancestors())
-        {
-            if (ancestor is InteractiveGue interactive && interactive.FormsControlAsObject is FrameworkElement fe)
-            {
-                yield return fe;
-            }
-        }
-    }
+        => ProjectToFrameworkElements(element.Visual.Ancestors());
 
     /// <summary>
     /// Enumerates <paramref name="element"/> followed by every ancestor
@@ -83,32 +68,14 @@ public static class FrameworkElementTreeExtensions
     /// <typeparamref name="T"/>, or null if none. Search is shallowest-first; subclasses match.
     /// </summary>
     public static T? Find<T>(this FrameworkElement element) where T : FrameworkElement
-    {
-        foreach (FrameworkElement descendant in element.Descendants())
-        {
-            if (descendant is T match)
-            {
-                return match;
-            }
-        }
-        return null;
-    }
+        => element.Descendants().OfType<T>().FirstOrDefault();
 
     /// <summary>
     /// Returns the first descendant <see cref="FrameworkElement"/> whose underlying
     /// <c>Visual.Name</c> equals <paramref name="name"/>, or null if none.
     /// </summary>
     public static FrameworkElement? FindByName(this FrameworkElement element, string name)
-    {
-        foreach (FrameworkElement descendant in element.Descendants())
-        {
-            if (descendant.Visual?.Name == name)
-            {
-                return descendant;
-            }
-        }
-        return null;
-    }
+        => element.Descendants().FirstOrDefault(d => d.Visual?.Name == name);
 
     /// <summary>
     /// Returns the first descendant <see cref="FrameworkElement"/> assignable to
@@ -116,15 +83,17 @@ public static class FrameworkElementTreeExtensions
     /// <paramref name="name"/>, or null if none.
     /// </summary>
     public static T? Find<T>(this FrameworkElement element, string name) where T : FrameworkElement
+        => element.Descendants().OfType<T>().FirstOrDefault(t => t.Visual?.Name == name);
+
+    private static IEnumerable<FrameworkElement> ProjectToFrameworkElements(IEnumerable<GraphicalUiElement> visuals)
     {
-        foreach (FrameworkElement descendant in element.Descendants())
+        foreach (GraphicalUiElement visual in visuals)
         {
-            if (descendant is T match && match.Visual?.Name == name)
+            if (visual is InteractiveGue interactive && interactive.FormsControlAsObject is FrameworkElement fe)
             {
-                return match;
+                yield return fe;
             }
         }
-        return null;
     }
 
     #endregion
@@ -137,9 +106,7 @@ public static class FrameworkElementTreeExtensions
     /// <c>element.Visual.Find&lt;T&gt;()</c>.
     /// </summary>
     public static T? FindVisual<T>(this FrameworkElement element) where T : GraphicalUiElement
-    {
-        return element.Visual.Find<T>();
-    }
+        => element.Visual.Find<T>();
 
     /// <summary>
     /// Returns the first visual descendant whose <c>Name</c> equals
@@ -147,9 +114,7 @@ public static class FrameworkElementTreeExtensions
     /// <c>element.Visual.FindByName(name)</c>.
     /// </summary>
     public static GraphicalUiElement? FindVisualByName(this FrameworkElement element, string name)
-    {
-        return element.Visual.FindByName(name);
-    }
+        => element.Visual.FindByName(name);
 
     /// <summary>
     /// Returns the first visual descendant assignable to <typeparamref name="T"/>
@@ -157,9 +122,7 @@ public static class FrameworkElementTreeExtensions
     /// Sugar over <c>element.Visual.Find&lt;T&gt;(name)</c>.
     /// </summary>
     public static T? FindVisual<T>(this FrameworkElement element, string name) where T : GraphicalUiElement
-    {
-        return element.Visual.Find<T>(name);
-    }
+        => element.Visual.Find<T>(name);
 
     #endregion
 }

--- a/MonoGameGum/Forms/FrameworkElementTreeExtensions.cs
+++ b/MonoGameGum/Forms/FrameworkElementTreeExtensions.cs
@@ -1,0 +1,165 @@
+using Gum.Wireframe;
+using System.Collections.Generic;
+
+#if FRB
+using FlatRedBall.Forms.Controls;
+using InteractiveGue = global::Gum.Wireframe.GraphicalUiElement;
+namespace MonoGameGum.Forms;
+#endif
+
+#if !FRB
+using Gum.Forms.Controls;
+namespace Gum.Forms;
+#endif
+
+/// <summary>
+/// Extension methods for traversing the Forms control tree (the sparse projection of
+/// the visual tree that contains <see cref="FrameworkElement"/> back-references) and
+/// for reaching into a control's underlying visuals via the <c>FindVisual*</c> sugar.
+/// </summary>
+public static class FrameworkElementTreeExtensions
+{
+    #region FE-returning traversal (Forms-first)
+
+    /// <summary>
+    /// Enumerates every descendant <see cref="FrameworkElement"/> under <paramref name="element"/>,
+    /// shallowest-first. Skips visual-only nodes that have no Forms control attached.
+    /// </summary>
+    public static IEnumerable<FrameworkElement> Descendants(this FrameworkElement element)
+    {
+        foreach (GraphicalUiElement descendant in element.Visual.Descendants())
+        {
+            if (descendant is InteractiveGue interactive && interactive.FormsControlAsObject is FrameworkElement fe)
+            {
+                yield return fe;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Enumerates <paramref name="element"/> followed by every descendant
+    /// <see cref="FrameworkElement"/> (shallowest-first).
+    /// </summary>
+    public static IEnumerable<FrameworkElement> DescendantsAndSelf(this FrameworkElement element)
+    {
+        yield return element;
+        foreach (FrameworkElement descendant in element.Descendants())
+        {
+            yield return descendant;
+        }
+    }
+
+    /// <summary>
+    /// Enumerates every ancestor <see cref="FrameworkElement"/> by walking the visual
+    /// parent chain and projecting each visual to its <c>FormsControlAsObject</c>
+    /// where one exists. Nearest-first.
+    /// </summary>
+    public static IEnumerable<FrameworkElement> Ancestors(this FrameworkElement element)
+    {
+        foreach (GraphicalUiElement ancestor in element.Visual.Ancestors())
+        {
+            if (ancestor is InteractiveGue interactive && interactive.FormsControlAsObject is FrameworkElement fe)
+            {
+                yield return fe;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Enumerates <paramref name="element"/> followed by every ancestor
+    /// <see cref="FrameworkElement"/> (nearest-first).
+    /// </summary>
+    public static IEnumerable<FrameworkElement> AncestorsAndSelf(this FrameworkElement element)
+    {
+        yield return element;
+        foreach (FrameworkElement ancestor in element.Ancestors())
+        {
+            yield return ancestor;
+        }
+    }
+
+    /// <summary>
+    /// Returns the first descendant <see cref="FrameworkElement"/> assignable to
+    /// <typeparamref name="T"/>, or null if none. Search is shallowest-first; subclasses match.
+    /// </summary>
+    public static T? Find<T>(this FrameworkElement element) where T : FrameworkElement
+    {
+        foreach (FrameworkElement descendant in element.Descendants())
+        {
+            if (descendant is T match)
+            {
+                return match;
+            }
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Returns the first descendant <see cref="FrameworkElement"/> whose underlying
+    /// <c>Visual.Name</c> equals <paramref name="name"/>, or null if none.
+    /// </summary>
+    public static FrameworkElement? FindByName(this FrameworkElement element, string name)
+    {
+        foreach (FrameworkElement descendant in element.Descendants())
+        {
+            if (descendant.Visual?.Name == name)
+            {
+                return descendant;
+            }
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Returns the first descendant <see cref="FrameworkElement"/> assignable to
+    /// <typeparamref name="T"/> whose underlying <c>Visual.Name</c> equals
+    /// <paramref name="name"/>, or null if none.
+    /// </summary>
+    public static T? Find<T>(this FrameworkElement element, string name) where T : FrameworkElement
+    {
+        foreach (FrameworkElement descendant in element.Descendants())
+        {
+            if (descendant is T match && match.Visual?.Name == name)
+            {
+                return match;
+            }
+        }
+        return null;
+    }
+
+    #endregion
+
+    #region Visual-returning sugar (drill into the visual tree)
+
+    /// <summary>
+    /// Returns the first visual descendant of <paramref name="element"/>.Visual that
+    /// is assignable to <typeparamref name="T"/>, or null if none. Sugar over
+    /// <c>element.Visual.Find&lt;T&gt;()</c>.
+    /// </summary>
+    public static T? FindVisual<T>(this FrameworkElement element) where T : GraphicalUiElement
+    {
+        return element.Visual.Find<T>();
+    }
+
+    /// <summary>
+    /// Returns the first visual descendant whose <c>Name</c> equals
+    /// <paramref name="name"/>, or null if none. Sugar over
+    /// <c>element.Visual.FindByName(name)</c>.
+    /// </summary>
+    public static GraphicalUiElement? FindVisualByName(this FrameworkElement element, string name)
+    {
+        return element.Visual.FindByName(name);
+    }
+
+    /// <summary>
+    /// Returns the first visual descendant assignable to <typeparamref name="T"/>
+    /// whose <c>Name</c> equals <paramref name="name"/>, or null if none.
+    /// Sugar over <c>element.Visual.Find&lt;T&gt;(name)</c>.
+    /// </summary>
+    public static T? FindVisual<T>(this FrameworkElement element, string name) where T : GraphicalUiElement
+    {
+        return element.Visual.Find<T>(name);
+    }
+
+    #endregion
+}

--- a/Tests/MonoGameGum.Tests.V2/Forms/ListBoxTests.cs
+++ b/Tests/MonoGameGum.Tests.V2/Forms/ListBoxTests.cs
@@ -17,8 +17,7 @@ public class ListBoxTests
         ListBox listBox = new();
         InteractiveGue visual = listBox.Visual;
 
-        List<ContainerRuntime> children = new();
-        visual.FillListWithChildrenByTypeRecursively<ContainerRuntime>(children);
+        List<ContainerRuntime> children = visual.Descendants().OfType<ContainerRuntime>().ToList();
 
         foreach (var child in children)
         {

--- a/Tests/MonoGameGum.Tests.V2/Forms/ScrollBarTests.cs
+++ b/Tests/MonoGameGum.Tests.V2/Forms/ScrollBarTests.cs
@@ -18,8 +18,7 @@ public class ScrollBarTests
         ScrollBar scrollBar = new();
         InteractiveGue visual = scrollBar.Visual;
 
-        List<ContainerRuntime> children = new();
-        visual.FillListWithChildrenByTypeRecursively<ContainerRuntime>(children);
+        List<ContainerRuntime> children = visual.Descendants().OfType<ContainerRuntime>().ToList();
 
         foreach (var child in children)
         {

--- a/Tests/MonoGameGum.Tests.V2/Forms/ScrollViewerTests.cs
+++ b/Tests/MonoGameGum.Tests.V2/Forms/ScrollViewerTests.cs
@@ -21,8 +21,7 @@ public class ScrollViewerTests
         ScrollViewer scrollViewer = new();
         InteractiveGue visual = scrollViewer.Visual;
 
-        List<ContainerRuntime> children = new();
-        visual.FillListWithChildrenByTypeRecursively<ContainerRuntime>(children);
+        List<ContainerRuntime> children = visual.Descendants().OfType<ContainerRuntime>().ToList();
 
         foreach (var child in children)
         {

--- a/Tests/MonoGameGum.Tests.V2/Forms/SliderTests.cs
+++ b/Tests/MonoGameGum.Tests.V2/Forms/SliderTests.cs
@@ -17,8 +17,7 @@ public class SliderTests
         Slider slider = new();
         InteractiveGue visual = slider.Visual;
 
-        List<ContainerRuntime> children = new();
-        visual.FillListWithChildrenByTypeRecursively<ContainerRuntime>(children);
+        List<ContainerRuntime> children = visual.Descendants().OfType<ContainerRuntime>().ToList();
 
         foreach (var child in children)
         {

--- a/Tests/MonoGameGum.Tests.V2/Forms/TextBoxTests.cs
+++ b/Tests/MonoGameGum.Tests.V2/Forms/TextBoxTests.cs
@@ -18,8 +18,7 @@ public class TextBoxTests
         TextBox textBox = new();
         InteractiveGue visual = textBox.Visual;
 
-        List<ContainerRuntime> children = new();
-        visual.FillListWithChildrenByTypeRecursively<ContainerRuntime>(children);
+        List<ContainerRuntime> children = visual.Descendants().OfType<ContainerRuntime>().ToList();
 
         foreach (var child in children)
         {

--- a/Tests/MonoGameGum.Tests.V3/ListBoxVisualTests.cs
+++ b/Tests/MonoGameGum.Tests.V3/ListBoxVisualTests.cs
@@ -19,8 +19,7 @@ public class ListBoxVisualTests
         ListBox listBox = new();
         InteractiveGue visual = listBox.Visual;
 
-        List<ContainerRuntime> children = new();
-        visual.FillListWithChildrenByTypeRecursively<ContainerRuntime>(children);
+        List<ContainerRuntime> children = visual.Descendants().OfType<ContainerRuntime>().ToList();
 
         foreach (var child in children)
         {

--- a/Tests/MonoGameGum.Tests.V3/ScrollBarVisualTests.cs
+++ b/Tests/MonoGameGum.Tests.V3/ScrollBarVisualTests.cs
@@ -19,8 +19,7 @@ public class ScrollBarVisualTests
         ScrollBar scrollBar = new();
         InteractiveGue visual = scrollBar.Visual;
 
-        List<ContainerRuntime> children = new();
-        visual.FillListWithChildrenByTypeRecursively<ContainerRuntime>(children);
+        List<ContainerRuntime> children = visual.Descendants().OfType<ContainerRuntime>().ToList();
 
         foreach (var child in children)
         {

--- a/Tests/MonoGameGum.Tests.V3/ScrollViewerVisualTests.cs
+++ b/Tests/MonoGameGum.Tests.V3/ScrollViewerVisualTests.cs
@@ -2,6 +2,8 @@
 using Gum.Wireframe;
 using Gum.GueDeriving;
 using Shouldly;
+using System.Collections.Generic;
+using System.Linq;
 using Xunit;
 
 namespace MonoGameGum.Tests.V3;
@@ -14,8 +16,7 @@ public class ScrollViewerVisualTests
         ScrollViewer scrollViewer = new();
         InteractiveGue visual = scrollViewer.Visual;
 
-        List<ContainerRuntime> children = new();
-        visual.FillListWithChildrenByTypeRecursively<ContainerRuntime>(children);
+        List<ContainerRuntime> children = visual.Descendants().OfType<ContainerRuntime>().ToList();
 
         // ThumbContainer is used by ScrollBar for clicking to change value
         foreach (var child in children)

--- a/Tests/MonoGameGum.Tests.V3/SliderVisualTests.cs
+++ b/Tests/MonoGameGum.Tests.V3/SliderVisualTests.cs
@@ -29,8 +29,7 @@ public class SliderVisualTests
         Slider slider = new();
         InteractiveGue visual = slider.Visual;
 
-        List<ContainerRuntime> children = new();
-        visual.FillListWithChildrenByTypeRecursively<ContainerRuntime>(children);
+        List<ContainerRuntime> children = visual.Descendants().OfType<ContainerRuntime>().ToList();
 
         foreach (ContainerRuntime child in children)
         {

--- a/Tests/MonoGameGum.Tests.V3/TextBoxVisualTests.cs
+++ b/Tests/MonoGameGum.Tests.V3/TextBoxVisualTests.cs
@@ -20,8 +20,7 @@ public class TextBoxVisualTests
         TextBox textBox = new();
         InteractiveGue visual = textBox.Visual;
 
-        List<ContainerRuntime> children = new();
-        visual.FillListWithChildrenByTypeRecursively<ContainerRuntime>(children);
+        List<ContainerRuntime> children = visual.Descendants().OfType<ContainerRuntime>().ToList();
 
         foreach (var child in children)
         {

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -304,6 +304,9 @@
     * [Text Wrapping](code/standard-visuals/textruntime/text-wrapping.md)
     * [VerticalAlignment](code/standard-visuals/textruntime/verticalalignment.md)
 
+* [Visual Tree](code/visual-tree/README.md)
+  * [Finding Elements](code/visual-tree/finding-elements.md)
+
 * [Rendering](code/rendering/README.md)
   * [GumBatch](code/rendering/gumbatch.md)
   * [Rendering Custom Graphics](code/rendering/rendering-custom-graphics.md)

--- a/docs/code/visual-tree/README.md
+++ b/docs/code/visual-tree/README.md
@@ -1,0 +1,7 @@
+# Visual Tree
+
+## Introduction
+
+At runtime, every `GraphicalUiElement` (and the runtime classes that derive from it — `ContainerRuntime`, `TextRuntime`, `SpriteRuntime`, control visuals, and so on) lives in a parent-child hierarchy known as the **visual tree**. A screen, a Forms control, or any composite component you build is always a sub-tree of `GraphicalUiElement` instances rooted at a parent.
+
+This section covers tasks that involve navigating or manipulating that tree from code: finding a specific child by name or type, walking ancestors, enumerating descendants, and similar runtime operations.

--- a/docs/code/visual-tree/finding-elements.md
+++ b/docs/code/visual-tree/finding-elements.md
@@ -2,11 +2,17 @@
 
 ## Introduction
 
-Once you have a reference to a Forms control — or, less commonly, to a visual — you often need to find something else in the same UI: a child control, a containing window, or one of the runtime visuals that make up a control's appearance. Gum provides extension methods on both `FrameworkElement` (the Forms layer) and `GraphicalUiElement` (the visual layer) for this.
+Once you have a reference to a Forms control or a visual, three patterns of "find something else" come up constantly:
+
+* **Reach into a control's visuals** — `myButton.FindVisual<TextRuntime>()` to grab the runtime visuals that make up a Forms control's appearance.
+* **Find another control** — `dialog.Find<Button>("CancelButton")` to locate a descendant Forms control by type and/or name.
+* **Walk up to a container** — `nested.Ancestors().OfType<Window>().FirstOrDefault()` to find the containing window from somewhere deep inside it.
+
+These extension methods live in `Gum.Forms` (for `FrameworkElement`) and `Gum.Wireframe` (for `GraphicalUiElement`). All `Find*` methods return `null` if nothing matches — they don't throw. The examples below use `!` only because the result is known to exist for that example.
 
 ## Working With Forms Controls
 
-Most game UIs are built from Forms controls (`Button`, `TextBox`, `ListBox`, `Window`, etc.), so most of these queries start from a `FrameworkElement`. The extensions group into three patterns: finding other controls, walking up to a container, and dropping down into a control's underlying visual.
+Most game UIs are built from Forms controls (`Button`, `TextBox`, `ListBox`, `Window`, etc.), so most queries start from a `FrameworkElement`. The extensions group into three patterns: finding other controls, walking up to a container, and dropping down into a control's underlying visual.
 
 ### Finding Another Control
 
@@ -14,7 +20,12 @@ When a control contains other controls — for example a `Window` containing sev
 
 ```csharp
 // Initialize
-Button cancelButton = dialog.Find<Button>("CancelButton")!;
+Window dialog = new();
+Button cancel = new();
+cancel.Visual.Name = "CancelButton";
+dialog.AddChild(cancel);
+
+Button found = dialog.Find<Button>("CancelButton")!;
 ```
 
 `FindByName(name)` matches on the underlying `Visual.Name` without a type filter. `Find<T>()` (no name) returns the first descendant of type `T`.
@@ -26,7 +37,7 @@ When you need every match instead of the first, use `Descendants()` and compose 
 List<Button> buttons = dialog.Descendants().OfType<Button>().ToList();
 ```
 
-`Descendants()` returns `IEnumerable<FrameworkElement>` lazily, so the LINQ pipeline can short-circuit (e.g. `.FirstOrDefault(...)`, `.Take(3)`) without walking the whole tree.
+`Descendants()` returns `IEnumerable<FrameworkElement>` lazily, so the LINQ pipeline can short-circuit without walking the whole tree — `Find*` and `.FirstOrDefault(...)` stop as soon as they hit a match, which keeps lookups cheap even on populated trees like a `ListBox`'s item panel.
 
 ### Walking Up to a Containing Control
 
@@ -65,12 +76,9 @@ Window? containingWindow = someInnerVisual.Ancestors().OfType<Window>().FirstOrD
 
 The full set on `GraphicalUiElement`: `Find<T>`, `Find<T>(name)`, `FindByName(name)`, `Descendants`, `DescendantsAndSelf`, `Ancestors`, `AncestorsAndSelf`. The Forms-layer methods are thin projections built on top of these.
 
-## Ordering and Performance
+## Ordering
 
-`Descendants()` and the `Find*` methods enumerate **shallowest-first**. Two consequences:
-
-* When several descendants match, the one closest to the search root wins. A `ListBox` has a `FocusedIndicator` near its root and another inside each `ListBoxItem`; shallowest-first returns the outer one, which is what you want.
-* `Find*` short-circuits as soon as it finds a match, so common lookups don't descend into deep subtrees like a populated `ListBox`'s item panel.
+`Descendants()` and the `Find*` methods enumerate **shallowest-first**, so the closest match wins. A `ListBox` has a `FocusedIndicator` near its root and another inside each `ListBoxItem`; shallowest-first returns the outer one, which is what you want.
 
 `Ancestors()` enumerates nearest-first.
 

--- a/docs/code/visual-tree/finding-elements.md
+++ b/docs/code/visual-tree/finding-elements.md
@@ -2,68 +2,76 @@
 
 ## Introduction
 
-When you have a reference to a parent — a screen, a Forms control's `Visual`, or any `GraphicalUiElement` — you often need to grab a specific child somewhere underneath it. For example, a Forms `TextBox` exposes its `Visual` property, but to set a property on the inner `TextRuntime` you first have to find it inside the visual.
+Once you have a reference to a Forms control or a visual, you often need to grab something underneath it: a child control, a specific runtime visual, or an ancestor window. Gum provides extension methods on both `FrameworkElement` (the Forms layer) and `GraphicalUiElement` (the visual layer) for this. They live in the `Gum.Forms` and `Gum.Wireframe` namespaces respectively.
 
-Gum provides extension methods on `GraphicalUiElement` that traverse the visual tree and return the elements you ask for. They live in the `Gum.Wireframe` namespace, the same namespace as `GraphicalUiElement` itself, so they show up automatically in IntelliSense as long as you have a `using Gum.Wireframe;` directive.
+## Working With Forms Controls
 
-## Quick Example
+Most game UIs are built from Forms controls (`Button`, `TextBox`, `ListBox`, `Window`, etc.). The Forms-side extensions on `FrameworkElement` come in two flavors: **`Find*`** to find other controls, and **`FindVisual*`** to drop down into the underlying visual.
 
-The most common case: find a named child of a known type underneath a Forms control's `Visual`.
+### Finding a Visual Inside a Control
 
-```csharp
-// Initialize
-TextBox textBox = new();
-TextRuntime textInstance = textBox.Visual.Find<TextRuntime>("TextInstance")!;
-textInstance.Color = Microsoft.Xna.Framework.Color.Red;
-```
-
-`Find<T>(name)` walks the descendants of `textBox.Visual` and returns the first one that is both a `TextRuntime` and named `"TextInstance"`. If no match is found, it returns null.
-
-## Available Methods
-
-The full set of traversal extensions:
-
-| Method | Returns | Description |
-|---|---|---|
-| `Find<T>()` | `T?` | First descendant assignable to `T`. |
-| `FindByName(string name)` | `GraphicalUiElement?` | First descendant whose `Name` equals `name`. |
-| `Find<T>(string name)` | `T?` | First descendant that is both `T` and named `name`. |
-| `Descendants()` | `IEnumerable<GraphicalUiElement>` | Every descendant (excluding self). |
-| `DescendantsAndSelf()` | `IEnumerable<GraphicalUiElement>` | The element followed by every descendant. |
-| `Ancestors()` | `IEnumerable<GraphicalUiElement>` | Every ancestor walking up `Parent` (excluding self). |
-| `AncestorsAndSelf()` | `IEnumerable<GraphicalUiElement>` | The element followed by every ancestor. |
-
-Type matching uses `is T` semantics, so `Find<ContainerRuntime>()` will match any class that derives from `ContainerRuntime`, not just `ContainerRuntime` itself.
-
-## How Matches Are Ordered
-
-`Descendants()` and the `Find*` methods enumerate **shallowest-first** — direct children before grandchildren, grandchildren before great-grandchildren, and so on. There are two reasons:
-
-* **Closest match wins.** When you call `Find<T>()` and there are multiple matching descendants at different depths, you almost always want the one nearest the root you searched from. A `ListBox`, for example, has a `FocusedIndicator` near its root and another `FocusedIndicator` inside each `ListBoxItem`; shallowest-first returns the outer one, which is what callers expect.
-* **Performance.** Lookups short-circuit as soon as they find a match. With shallowest-first ordering, common queries (where the target is near the top of the tree) finish quickly without descending into deep, populated subtrees like a `ListBox`'s item panel.
-
-`Ancestors()` enumerates nearest-first, walking `Parent` once per step.
-
-## Composing With LINQ
-
-`Find<T>()` and `FindByName` cover the common cases. For anything more specific, the `Descendants()` and `Ancestors()` primitives compose with LINQ:
+A Forms `Button` is composed of visuals — a `TextRuntime` for its label, a background, and so on. To set a property that the Forms control itself doesn't expose, use `FindVisual<T>`:
 
 ```csharp
 // Initialize
-using System.Linq;
-using Gum.Wireframe;
-
-// Every TextRuntime under root, materialized as a list:
-List<TextRuntime> texts = root.Descendants().OfType<TextRuntime>().ToList();
-
-// First TextRuntime whose Text starts with "Hello":
-TextRuntime? greeting = root.Descendants()
-    .OfType<TextRuntime>()
-    .FirstOrDefault(t => t.Text?.StartsWith("Hello") == true);
-
-// Walk up from a child to find the containing ListBoxItem visual:
-GraphicalUiElement? listBoxItemVisual = child.Ancestors()
-    .FirstOrDefault(a => a.Name == "ListBoxItemRoot");
+Button okButton = new();
+TextRuntime label = okButton.FindVisual<TextRuntime>()!;
+label.Color = Microsoft.Xna.Framework.Color.LightGreen;
 ```
 
-Because `Descendants()` and `Ancestors()` return `IEnumerable<GraphicalUiElement>` and use deferred execution, they don't allocate a list up-front and they stop walking the tree as soon as the LINQ pipeline has what it needs.
+`FindVisual<T>(name)` adds a name filter, and `FindVisualByName(name)` looks up by name only. All three are sugar over the equivalent calls on `okButton.Visual`.
+
+### Finding Another Control
+
+When a control contains other controls — for example a `Window` containing several `Button`s — `Find<T>` walks the descendant Forms controls and returns the first match:
+
+```csharp
+// Initialize
+Window dialog = new();
+Button cancelButton = new();
+cancelButton.Visual.Name = "CancelButton";
+dialog.AddChild(cancelButton);
+
+Button found = dialog.Find<Button>("CancelButton")!;
+```
+
+`Find<T>` matches subclasses (any `T` or anything derived from `T`). `FindByName(name)` matches on the underlying `Visual.Name`.
+
+### Walking Up
+
+`Ancestors()` returns the containing controls, nearest-first. Useful for asking "which window am I in?" from a deeply-nested control:
+
+```csharp
+// Initialize
+Window? owningWindow = nestedButton.Ancestors().OfType<Window>().FirstOrDefault();
+```
+
+`Descendants()`, `DescendantsAndSelf()`, and `AncestorsAndSelf()` are also available for LINQ-composable traversal — for example `dialog.Descendants().OfType<Button>().ToList()` to gather every button.
+
+## Working With Visuals Directly
+
+If you're operating on `GraphicalUiElement` instances directly — building a screen in code, or working below the Forms layer — the same primitives exist on GUE. Use them via a `using Gum.Wireframe;` directive:
+
+```csharp
+// Initialize
+ContainerRuntime root = new();
+// ... populate root ...
+
+TextRuntime? title = root.Find<TextRuntime>("TitleInstance");
+List<SpriteRuntime> icons = root.Descendants().OfType<SpriteRuntime>().ToList();
+```
+
+The full set: `Find<T>`, `Find<T>(name)`, `FindByName(name)`, `Descendants`, `DescendantsAndSelf`, `Ancestors`, `AncestorsAndSelf`. Same shape, same semantics.
+
+## Ordering and Performance
+
+`Descendants()` and the `Find*` methods enumerate **shallowest-first**. Two consequences:
+
+* When several descendants match, the one closest to the search root wins. A `ListBox` has a `FocusedIndicator` near its root and one inside each `ListBoxItem`; shallowest-first returns the outer one, which is what you want.
+* `Find*` short-circuits as soon as it finds a match, so common lookups don't descend into deep subtrees like a populated `ListBox`'s item panel.
+
+`Ancestors()` enumerates nearest-first.
+
+## Type Matching
+
+All generic methods (`Find<T>`, `OfType<T>`) use `is T` semantics — they match `T` and any subclass. If you specifically need an exact-type match, add an explicit filter: `Descendants().Where(x => x.GetType() == typeof(Button)).FirstOrDefault()`.

--- a/docs/code/visual-tree/finding-elements.md
+++ b/docs/code/visual-tree/finding-elements.md
@@ -6,20 +6,7 @@ Once you have a reference to a Forms control or a visual, you often need to grab
 
 ## Working With Forms Controls
 
-Most game UIs are built from Forms controls (`Button`, `TextBox`, `ListBox`, `Window`, etc.). The Forms-side extensions on `FrameworkElement` come in two flavors: **`Find*`** to find other controls, and **`FindVisual*`** to drop down into the underlying visual.
-
-### Finding a Visual Inside a Control
-
-A Forms `Button` is composed of visuals — a `TextRuntime` for its label, a background, and so on. To set a property that the Forms control itself doesn't expose, use `FindVisual<T>`:
-
-```csharp
-// Initialize
-Button okButton = new();
-TextRuntime label = okButton.FindVisual<TextRuntime>()!;
-label.Color = Microsoft.Xna.Framework.Color.LightGreen;
-```
-
-`FindVisual<T>(name)` adds a name filter, and `FindVisualByName(name)` looks up by name only. All three are sugar over the equivalent calls on `okButton.Visual`.
+Most game UIs are built from Forms controls (`Button`, `TextBox`, `ListBox`, `Window`, etc.). The Forms-side extensions on `FrameworkElement` give you two things: **`Find*`** to navigate the control tree, and **`FindVisual*`** for the cases where you need to drop down into the underlying visual.
 
 ### Finding Another Control
 
@@ -37,7 +24,7 @@ Button found = dialog.Find<Button>("CancelButton")!;
 
 `Find<T>` matches subclasses (any `T` or anything derived from `T`). `FindByName(name)` matches on the underlying `Visual.Name`.
 
-### Walking Up
+### Walking Up to a Containing Control
 
 `Ancestors()` returns the containing controls, nearest-first. Useful for asking "which window am I in?" from a deeply-nested control:
 
@@ -47,6 +34,19 @@ Window? owningWindow = nestedButton.Ancestors().OfType<Window>().FirstOrDefault(
 ```
 
 `Descendants()`, `DescendantsAndSelf()`, and `AncestorsAndSelf()` are also available for LINQ-composable traversal — for example `dialog.Descendants().OfType<Button>().ToList()` to gather every button.
+
+### Reaching Into a Control's Visual
+
+A Forms `Button` is composed of visuals — a `TextRuntime` for its label, a background, and so on. To set a property that the Forms control itself doesn't expose, drop down to the visual with `FindVisual<T>`:
+
+```csharp
+// Initialize
+Button okButton = new();
+TextRuntime label = okButton.FindVisual<TextRuntime>()!;
+label.Color = Microsoft.Xna.Framework.Color.LightGreen;
+```
+
+`FindVisual<T>(name)` adds a name filter, and `FindVisualByName(name)` looks up by name only. All three are sugar over the equivalent calls on `okButton.Visual`.
 
 ## Working With Visuals Directly
 

--- a/docs/code/visual-tree/finding-elements.md
+++ b/docs/code/visual-tree/finding-elements.md
@@ -1,0 +1,69 @@
+# Finding Elements
+
+## Introduction
+
+When you have a reference to a parent — a screen, a Forms control's `Visual`, or any `GraphicalUiElement` — you often need to grab a specific child somewhere underneath it. For example, a Forms `TextBox` exposes its `Visual` property, but to set a property on the inner `TextRuntime` you first have to find it inside the visual.
+
+Gum provides extension methods on `GraphicalUiElement` that traverse the visual tree and return the elements you ask for. They live in the `Gum.Wireframe` namespace, the same namespace as `GraphicalUiElement` itself, so they show up automatically in IntelliSense as long as you have a `using Gum.Wireframe;` directive.
+
+## Quick Example
+
+The most common case: find a named child of a known type underneath a Forms control's `Visual`.
+
+```csharp
+// Initialize
+TextBox textBox = new();
+TextRuntime textInstance = textBox.Visual.Find<TextRuntime>("TextInstance")!;
+textInstance.Color = Microsoft.Xna.Framework.Color.Red;
+```
+
+`Find<T>(name)` walks the descendants of `textBox.Visual` and returns the first one that is both a `TextRuntime` and named `"TextInstance"`. If no match is found, it returns null.
+
+## Available Methods
+
+The full set of traversal extensions:
+
+| Method | Returns | Description |
+|---|---|---|
+| `Find<T>()` | `T?` | First descendant assignable to `T`. |
+| `FindByName(string name)` | `GraphicalUiElement?` | First descendant whose `Name` equals `name`. |
+| `Find<T>(string name)` | `T?` | First descendant that is both `T` and named `name`. |
+| `Descendants()` | `IEnumerable<GraphicalUiElement>` | Every descendant (excluding self). |
+| `DescendantsAndSelf()` | `IEnumerable<GraphicalUiElement>` | The element followed by every descendant. |
+| `Ancestors()` | `IEnumerable<GraphicalUiElement>` | Every ancestor walking up `Parent` (excluding self). |
+| `AncestorsAndSelf()` | `IEnumerable<GraphicalUiElement>` | The element followed by every ancestor. |
+
+Type matching uses `is T` semantics, so `Find<ContainerRuntime>()` will match any class that derives from `ContainerRuntime`, not just `ContainerRuntime` itself.
+
+## How Matches Are Ordered
+
+`Descendants()` and the `Find*` methods enumerate **shallowest-first** — direct children before grandchildren, grandchildren before great-grandchildren, and so on. There are two reasons:
+
+* **Closest match wins.** When you call `Find<T>()` and there are multiple matching descendants at different depths, you almost always want the one nearest the root you searched from. A `ListBox`, for example, has a `FocusedIndicator` near its root and another `FocusedIndicator` inside each `ListBoxItem`; shallowest-first returns the outer one, which is what callers expect.
+* **Performance.** Lookups short-circuit as soon as they find a match. With shallowest-first ordering, common queries (where the target is near the top of the tree) finish quickly without descending into deep, populated subtrees like a `ListBox`'s item panel.
+
+`Ancestors()` enumerates nearest-first, walking `Parent` once per step.
+
+## Composing With LINQ
+
+`Find<T>()` and `FindByName` cover the common cases. For anything more specific, the `Descendants()` and `Ancestors()` primitives compose with LINQ:
+
+```csharp
+// Initialize
+using System.Linq;
+using Gum.Wireframe;
+
+// Every TextRuntime under root, materialized as a list:
+List<TextRuntime> texts = root.Descendants().OfType<TextRuntime>().ToList();
+
+// First TextRuntime whose Text starts with "Hello":
+TextRuntime? greeting = root.Descendants()
+    .OfType<TextRuntime>()
+    .FirstOrDefault(t => t.Text?.StartsWith("Hello") == true);
+
+// Walk up from a child to find the containing ListBoxItem visual:
+GraphicalUiElement? listBoxItemVisual = child.Ancestors()
+    .FirstOrDefault(a => a.Name == "ListBoxItemRoot");
+```
+
+Because `Descendants()` and `Ancestors()` return `IEnumerable<GraphicalUiElement>` and use deferred execution, they don't allocate a list up-front and they stop walking the tree as soon as the LINQ pipeline has what it needs.

--- a/docs/code/visual-tree/finding-elements.md
+++ b/docs/code/visual-tree/finding-elements.md
@@ -2,27 +2,31 @@
 
 ## Introduction
 
-Once you have a reference to a Forms control or a visual, you often need to grab something underneath it: a child control, a specific runtime visual, or an ancestor window. Gum provides extension methods on both `FrameworkElement` (the Forms layer) and `GraphicalUiElement` (the visual layer) for this. They live in the `Gum.Forms` and `Gum.Wireframe` namespaces respectively.
+Once you have a reference to a Forms control — or, less commonly, to a visual — you often need to find something else in the same UI: a child control, a containing window, or one of the runtime visuals that make up a control's appearance. Gum provides extension methods on both `FrameworkElement` (the Forms layer) and `GraphicalUiElement` (the visual layer) for this.
 
 ## Working With Forms Controls
 
-Most game UIs are built from Forms controls (`Button`, `TextBox`, `ListBox`, `Window`, etc.). The Forms-side extensions on `FrameworkElement` give you two things: **`Find*`** to navigate the control tree, and **`FindVisual*`** for the cases where you need to drop down into the underlying visual.
+Most game UIs are built from Forms controls (`Button`, `TextBox`, `ListBox`, `Window`, etc.), so most of these queries start from a `FrameworkElement`. The extensions group into three patterns: finding other controls, walking up to a container, and dropping down into a control's underlying visual.
 
 ### Finding Another Control
 
-When a control contains other controls — for example a `Window` containing several `Button`s — `Find<T>` walks the descendant Forms controls and returns the first match:
+When a control contains other controls — for example a `Window` containing several `Button`s — `Find<T>` walks the descendants and returns the first match:
 
 ```csharp
 // Initialize
-Window dialog = new();
-Button cancelButton = new();
-cancelButton.Visual.Name = "CancelButton";
-dialog.AddChild(cancelButton);
-
-Button found = dialog.Find<Button>("CancelButton")!;
+Button cancelButton = dialog.Find<Button>("CancelButton")!;
 ```
 
-`Find<T>` matches subclasses (any `T` or anything derived from `T`). `FindByName(name)` matches on the underlying `Visual.Name`.
+`FindByName(name)` matches on the underlying `Visual.Name` without a type filter. `Find<T>()` (no name) returns the first descendant of type `T`.
+
+When you need every match instead of the first, use `Descendants()` and compose with LINQ:
+
+```csharp
+// Initialize
+List<Button> buttons = dialog.Descendants().OfType<Button>().ToList();
+```
+
+`Descendants()` returns `IEnumerable<FrameworkElement>` lazily, so the LINQ pipeline can short-circuit (e.g. `.FirstOrDefault(...)`, `.Take(3)`) without walking the whole tree.
 
 ### Walking Up to a Containing Control
 
@@ -33,7 +37,7 @@ Button found = dialog.Find<Button>("CancelButton")!;
 Window? owningWindow = nestedButton.Ancestors().OfType<Window>().FirstOrDefault();
 ```
 
-`Descendants()`, `DescendantsAndSelf()`, and `AncestorsAndSelf()` are also available for LINQ-composable traversal — for example `dialog.Descendants().OfType<Button>().ToList()` to gather every button.
+`AncestorsAndSelf()` and `DescendantsAndSelf()` are available too, for cases where the search should include the starting element.
 
 ### Reaching Into a Control's Visual
 
@@ -46,28 +50,26 @@ TextRuntime label = okButton.FindVisual<TextRuntime>()!;
 label.Color = Microsoft.Xna.Framework.Color.LightGreen;
 ```
 
-`FindVisual<T>(name)` adds a name filter, and `FindVisualByName(name)` looks up by name only. All three are sugar over the equivalent calls on `okButton.Visual`.
+`FindVisual<T>(name)` adds a name filter, and `FindVisualByName(name)` looks up by name only. Each is shorthand for the equivalent call on `okButton.Visual` — the next section covers what's available there.
 
 ## Working With Visuals Directly
 
-If you're operating on `GraphicalUiElement` instances directly — building a screen in code, or working below the Forms layer — the same primitives exist on GUE. Use them via a `using Gum.Wireframe;` directive:
+If you're operating on `GraphicalUiElement` instances directly — building a screen in code, or working below the Forms layer — the same method names exist on `GraphicalUiElement` itself. Add `using Gum.Wireframe;` (and `using System.Linq;` if you compose with LINQ) to bring them into scope:
 
 ```csharp
 // Initialize
-ContainerRuntime root = new();
-// ... populate root ...
-
 TextRuntime? title = root.Find<TextRuntime>("TitleInstance");
 List<SpriteRuntime> icons = root.Descendants().OfType<SpriteRuntime>().ToList();
+Window? containingWindow = someInnerVisual.Ancestors().OfType<Window>().FirstOrDefault();
 ```
 
-The full set: `Find<T>`, `Find<T>(name)`, `FindByName(name)`, `Descendants`, `DescendantsAndSelf`, `Ancestors`, `AncestorsAndSelf`. Same shape, same semantics.
+The full set on `GraphicalUiElement`: `Find<T>`, `Find<T>(name)`, `FindByName(name)`, `Descendants`, `DescendantsAndSelf`, `Ancestors`, `AncestorsAndSelf`. The Forms-layer methods are thin projections built on top of these.
 
 ## Ordering and Performance
 
 `Descendants()` and the `Find*` methods enumerate **shallowest-first**. Two consequences:
 
-* When several descendants match, the one closest to the search root wins. A `ListBox` has a `FocusedIndicator` near its root and one inside each `ListBoxItem`; shallowest-first returns the outer one, which is what you want.
+* When several descendants match, the one closest to the search root wins. A `ListBox` has a `FocusedIndicator` near its root and another inside each `ListBoxItem`; shallowest-first returns the outer one, which is what you want.
 * `Find*` short-circuits as soon as it finds a match, so common lookups don't descend into deep subtrees like a populated `ListBox`'s item panel.
 
 `Ancestors()` enumerates nearest-first.

--- a/docs/gum-tool/upgrading/migrating-to-2026-may.md
+++ b/docs/gum-tool/upgrading/migrating-to-2026-may.md
@@ -72,6 +72,23 @@ The compatibility shims will remain in place until at least the November 2026 re
 
 For full details, including handling of fully-qualified references and a `RenderingLibrary` namespace-shadowing gotcha, see [Syntax Version 1](syntax-version-1.md).
 
+### FrameworkElement tree-traversal extensions
+
+Forms controls (`Button`, `TextBox`, `Window`, etc.) gained extension methods for finding other controls and reaching into their underlying visuals without going through `.Visual` first:
+
+```csharp
+// Drop into the visual layer:
+TextRuntime label = okButton.FindVisual<TextRuntime>()!;
+
+// Find another Forms control:
+Button cancel = dialog.Find<Button>("CancelButton")!;
+
+// Walk ancestors:
+Window? containing = nestedControl.Ancestors().OfType<Window>().FirstOrDefault();
+```
+
+This is purely additive — no existing code changes. See [Finding Elements](../../code/visual-tree/finding-elements.md) for the full set.
+
 ### GraphicalUiElement tree-traversal methods replaced
 
 Five recursive lookup methods on `GraphicalUiElement` are now `[Obsolete]` in favor of LINQ-friendly extension methods that compose more cleanly. Existing calls keep working, but they now produce `CS0618` compiler warnings.

--- a/docs/gum-tool/upgrading/migrating-to-2026-may.md
+++ b/docs/gum-tool/upgrading/migrating-to-2026-may.md
@@ -71,3 +71,31 @@ The `Gum.Analyzers` package ships a one-click code fix for `using` directives �
 The compatibility shims will remain in place until at least the November 2026 release. After that window, they will be marked `[Obsolete(error: true)]` in a subsequent release, breaking compilation for any code still using them.
 
 For full details, including handling of fully-qualified references and a `RenderingLibrary` namespace-shadowing gotcha, see [Syntax Version 1](syntax-version-1.md).
+
+### GraphicalUiElement tree-traversal methods replaced
+
+Five recursive lookup methods on `GraphicalUiElement` are now `[Obsolete]` in favor of LINQ-friendly extension methods that compose more cleanly. Existing calls keep working, but they now produce `CS0618` compiler warnings.
+
+The replaced methods:
+
+* `GetChildByNameRecursively(string)` → `FindByName(string)`
+* `GetChildByTypeRecursively(Type)` → `Find<T>()`
+* `GetParentByNameRecursively(string)` → `Ancestors().FirstOrDefault(a => a.Name == name)`
+* `GetParentByTypeRecursively(Type)` → `Ancestors().OfType<T>().FirstOrDefault()`
+* `FillListWithChildrenByTypeRecursively<T>(...)` → `Descendants().OfType<T>().ToList()`
+
+The new generic methods (`Find<T>`, `OfType<T>`) match subclasses (`is T` semantics). The old methods only matched the exact type. If your code relied on the exact-type behavior, add an explicit `GetType() == typeof(T)` filter to the LINQ pipeline.
+
+❌Old:
+
+```csharp
+var textInstance = (TextRuntime)textBox.Visual.GetChildByNameRecursively("TextInstance")!;
+```
+
+✅New:
+
+```csharp
+TextRuntime textInstance = textBox.Visual.Find<TextRuntime>("TextInstance")!;
+```
+
+For the full set of new methods and how they compose with LINQ, see [Finding Elements](../../code/visual-tree/finding-elements.md).


### PR DESCRIPTION
## Summary
- Adds `Find<T>` / `FindByName` / `Descendants` / `Ancestors` extensions on `GraphicalUiElement` (and the `*AndSelf` variants), so callers can compose with LINQ instead of a growing list of `GetChild*` / `GetParent*` overloads. (Resolves whuop's request in #1500.)
- Adds the same shape on `FrameworkElement`, plus a `FindVisual<T>` / `FindVisualByName` family that lets Forms callers reach into the underlying visual without going through `.Visual` first.
- Marks the five legacy recursive lookup methods on `GraphicalUiElement` `[Obsolete]` with migration pointers, and migrates all internal callers (production + tests, including V2/V3 test projects) to the new API.
- Adds a new "Visual Tree" docs section with a Forms-first "Finding Elements" page, and a release-notes entry in `migrating-to-2026-may.md`.

## Design notes
- **Single traversal order — BFS / shallowest-first.** Picking just one removes the need to remember which method is which. BFS is what the existing legacy code does (the source comment near `GetChildByNameRecursively` calls out the ListBox `FocusedIndicator` case that depends on it), and it short-circuits before descending into deep populated subtrees like a `ListBox`'s item panel — so it wins on both correctness and cost for "find a thing" queries.
- **Type semantics — `is T`, matching `OfType<T>()`.** The legacy `GetChildByTypeRecursively(typeof(Foo))` used exact-type match; `Find<Foo>()` matches subclasses. The behavior delta is called out in the `[Obsolete]` messages and in the migration page so anyone migrating sees it.
- **Extension methods on `GraphicalUiElement`, separate file.** Avoids growing the already 6700+ line GUE class. Same namespace as GUE so they show up in IntelliSense without an extra `using`.
- **FrameworkElement layer is a sparse projection of the visual tree.** FE primitives walk the visual tree and yield only the visuals whose `FormsControlAsObject` is itself a `FrameworkElement`. No separate FE tree to maintain. `FindByName` matches on `Visual.Name` (FrameworkElement has no name of its own).
- **`FindVisual<T>` is one-line sugar over `this.Visual.Find<T>()`.** No parallel `VisualDescendants` / `VisualAncestors` primitives — the existing `myControl.Visual.Descendants()` already covers that case, and adding wrappers would force a naming inconsistency (suffix `FindVisual` vs prefix `VisualDescendants`).
- **Minimal sugar surface.** Just `Find<T>`, `FindByName`, `Find<T>(name)` plus the `FindVisual*` mirror on FE. Anything else is one LINQ call away. Easy to add more sugar later when usage patterns prove it out; hard to un-add.
- `Find*` skips self, matching legacy `GetChild*Recursively` behavior.

## Test plan
- [x] `GraphicalUiElementTreeExtensionsTests` covers shallowest-first ordering, lazy enumeration, `is T` semantics, name + type-and-name lookups, empty cases, and the `*AndSelf` variants. 16 tests.
- [x] `FrameworkElementTreeExtensionsTests` covers `FindVisual` bridging to `Visual.Find`, `Descendants` yielding only FEs (skipping pure-visual nodes), `Ancestors` walking through nested controls, is-T matches, empty cases. 16 tests.
- [x] All existing test suites green: 1386 in `MonoGameGum.Tests`, 86 in V2, 54 in V3, plus Skia/Raylib/Sokol/Expressions/Analyzer suites. 1865 total before this PR's tests; +32 from this PR.
- [x] Full `AllLibraries.sln` build clean; zero new warnings (the legacy-method tests that intentionally exercise the obsolete API are wrapped in `#pragma warning disable CS0618`).

## Notes for reviewer

### FRB1-side follow-up required at merge
This PR adds a new file under `MonoGameGum/Forms/` (`FrameworkElementTreeExtensions.cs`). FRB1 picks files in that folder up via its own `FlatRedBall.Forms.Shared.projitems` in the FRB1 repo, **not** via `GumCoreShared.projitems`. After this PR merges, a sibling FRB1 commit needs to add:

```xml
<Compile Include="$(MSBuildThisFileDirectory)..\..\..\..\..\Gum\MonoGameGum\Forms\FrameworkElementTreeExtensions.cs">
  <Link>%(RecursiveDir)%(Filename)%(Extension)</Link>
</Compile>
```

next to the existing `GraphicalUiElementFormsExtensions.cs` entry (line 105 of that file). Without this, FRB1 builds will not see the new extensions but the build will still succeed.

`GumCoreShared.projitems` and `GumCommon.csproj` were updated for the GUE extensions in this PR, so FRB1's GumCore build picks those up automatically.

### Other notes
- `Runtimes/Python/gumui/typings/Gum/Wireframe/__init__.pyi` still references the obsoleted method names. These are auto-generated and should refresh on the next typings regen — left alone here.
- The legacy reference page at `docs/code/gum-code-reference/graphicaluielement/getchildbynamerecursively.md` is intentionally unchanged. It documents an API people on April-release NuGets are still using; we update it when the May release ships.
- Possible follow-up: hand-rolled ancestor walks in `MonoGameGum/Input/CursorExtensions.cs` (lines 124, 223, 285) could now use `AncestorsAndSelf().Reverse()`. Out of scope for this PR; would be its own "migrate manual traversals" sweep.

Closes #1500

🤖 Generated with [Claude Code](https://claude.com/claude-code)