### PR TITLE
Fix sticky TextBox caret offset on transient bad parent geometry (#2680)

### DIFF
--- a/MonoGameGum.Tests/Forms/TextBoxTests.cs
+++ b/MonoGameGum.Tests/Forms/TextBoxTests.cs
@@ -213,6 +213,28 @@ public class TextBoxTests : BaseTestClass
     }
 
     [Fact]
+    public void Width_ShouldNotShiftTextX_AfterTransientNegativeWidth()
+    {
+        // Repro for issue #2680: when a TextBox's absolute width transitions
+        // from a transient bad value (e.g. -346, which arises during init when
+        // Width and WidthUnits are applied in sequence and the relative-to-parent
+        // math hasn't settled) to a valid positive value, the text instance's
+        // X-offset should reset to 0. Previously KeepCaretEdgeInsideParent was
+        // asymmetric: it shifted the text right when the caret fell to the left
+        // of the (then-tiny) parent, and never snapped back once the parent's
+        // width became reasonable, leaving a permanent ~5px gap on the left.
+        TextBox textBox = new();
+        DefaultTextBoxBaseRuntime visual = (DefaultTextBoxBaseRuntime)textBox.Visual;
+        float restingTextX = visual.TextInstance.X;
+
+        textBox.Visual.Width = -346;
+        textBox.Visual.Width = 294;
+
+        visual.TextInstance.X.ShouldBe(restingTextX,
+            "because once the parent has a valid width and the caret is comfortably inside it, the text X should match its at-rest value; transient bad widths must not leave a sticky horizontal offset");
+    }
+
+    [Fact]
     public void Children_Containers_ShouldNotHaveEvents()
     {
         TextBox textBox = new();

--- a/MonoGameGum/Forms/Controls/TextBoxBase.cs
+++ b/MonoGameGum/Forms/Controls/TextBoxBase.cs
@@ -1852,10 +1852,24 @@ public abstract class TextBoxBase :
             this.textComponent.XUnits = global::Gum.Converters.GeneralUnitType.PixelsFromSmall;
             this.caretComponent.XUnits = global::Gum.Converters.GeneralUnitType.PixelsFromSmall;
 
+            // Skip the shift entirely when the parent's geometry is invalid
+            // (zero or negative absolute width). This happens transiently
+            // during init when Width and WidthUnits are applied in sequence
+            // and the relative-to-parent math hasn't settled. Shifting based
+            // on a backwards parent (farOfParent < nearOfParent) would push
+            // the text by hundreds of pixels and the asymmetric branches
+            // below would never undo it once the parent reached a sane size.
+            // See issue #2680.
+            float parentWidth = caretComponent.EffectiveParentGue.GetAbsoluteWidth();
+            if (parentWidth <= 0)
+            {
+                return;
+            }
+
             float nearOfCaret = caretComponent.GetAbsoluteLeft();
             float farOfCaret = nearOfCaret + caretComponent.GetAbsoluteWidth();
             float nearOfParent = caretComponent.EffectiveParentGue.GetAbsoluteLeft();
-            float farOfParent = nearOfParent + caretComponent.EffectiveParentGue.GetAbsoluteWidth();
+            float farOfParent = nearOfParent + parentWidth;
 
             float shiftAmount = 0;
             if (farOfCaret > farOfParent)
@@ -1882,10 +1896,18 @@ public abstract class TextBoxBase :
             // by a delta works correctly in any unit (it's a pixel offset
             // regardless of origin), and reassigning units would change the
             // meaning of the existing Y value.
+
+            // Same invalid-geometry guard as the horizontal branch (see #2680).
+            float parentHeight = caretComponent.EffectiveParentGue.GetAbsoluteHeight();
+            if (parentHeight <= 0)
+            {
+                return;
+            }
+
             float nearOfCaret = caretComponent.GetAbsoluteTop();
             float farOfCaret = nearOfCaret + caretComponent.GetAbsoluteHeight();
             float nearOfParent = caretComponent.EffectiveParentGue.GetAbsoluteTop();
-            float farOfParent = nearOfParent + caretComponent.EffectiveParentGue.GetAbsoluteHeight();
+            float farOfParent = nearOfParent + parentHeight;
 
             float shiftAmount = 0;
             if (farOfCaret > farOfParent)


### PR DESCRIPTION
## Summary

Fixes #2680. TextBox caret/text positions could drift differently across instances when their parent's absolute width briefly went negative during init (e.g. `Width=-346` applied before `WidthUnits` flipped to `RelativeToParent`).

`KeepCaretEdgeInsideParent` was asymmetric: it shifted text/caret to bring the caret back inside the parent's bounds, but never snapped back when the parent later grew. With a backwards parent (`farOfParent < nearOfParent`) the shift could be hundreds of pixels; once the parent settled to a sane width, the no-shift-needed branch ran and left the drift in place — a permanent ~5px gap on the left edge and inconsistent caret positions across TextBoxes.

## Fix

Skip the shift entirely when the caret's parent has zero/negative absolute extent on the relevant axis. Real "caret outside the viewport" only meaningfully exists when the parent has a positive viewport; shifts derived from inverted geometry only introduce sticky drift.

Applied to both horizontal and vertical branches.

## Test plan

- [x] New repro test `Width_ShouldNotShiftTextX_AfterTransientNegativeWidth` in `MonoGameGum.Tests/Forms/TextBoxTests.cs` — verified red before fix (X=9 instead of resting 4), green after.
- [x] Full `MonoGameGum.Tests` suite passes (1403/1403).
- [x] Manual verification in the Raylib runtime that the caret column from issue #2680 now lines up.

Closes #2680

🤖 Generated with [Claude Code](https://claude.com/claude-code)