### PR TITLE
Snap TextBox text X back to resting after horizontal scroll (#2683)

### DIFF
--- a/MonoGameGum.Tests/Forms/TextBoxTests.cs
+++ b/MonoGameGum.Tests/Forms/TextBoxTests.cs
@@ -235,6 +235,87 @@ public class TextBoxTests : BaseTestClass
     }
 
     [Fact]
+    public void IdenticallyConfiguredTextBoxes_ShouldHaveMatchingTextAndCaretX()
+    {
+        // Smoke test for the symptom reported in issue #2680 (Raylib runtime
+        // screenshot showed caret columns drifting between visually-identical
+        // TextBoxes). The root cause was layout-order-dependent shifts in
+        // KeepCaretEdgeInsideParent; this test guards against any future cause
+        // by asserting that two TextBoxes set up the same way end up at the
+        // same horizontal text/caret position.
+        TextBox first = new();
+        first.Visual.Width = -346;
+        first.Visual.WidthUnits = global::Gum.DataTypes.DimensionUnitType.RelativeToParent;
+
+        TextBox second = new();
+        second.Visual.Width = -346;
+        second.Visual.WidthUnits = global::Gum.DataTypes.DimensionUnitType.RelativeToParent;
+
+        DefaultTextBoxBaseRuntime firstVisual = (DefaultTextBoxBaseRuntime)first.Visual;
+        DefaultTextBoxBaseRuntime secondVisual = (DefaultTextBoxBaseRuntime)second.Visual;
+
+        secondVisual.TextInstance.X.ShouldBe(firstVisual.TextInstance.X,
+            "because identically-configured TextBoxes must not drift apart in their text X — that's the visible symptom reported in #2680");
+        secondVisual.CaretInstance.X.ShouldBe(firstVisual.CaretInstance.X,
+            "because identically-configured TextBoxes must not drift apart in their caret X");
+    }
+
+    [Fact]
+    public void DeletingScrolledText_ShouldSnapTextXBackToResting()
+    {
+        // Issue #2683: KeepCaretEdgeInsideParent only shifts to bring the caret
+        // into view; it never undoes a prior shift once the caret is comfortably
+        // inside the band. So after typing past the right edge (which scrolls
+        // textComponent.X negative) and then deleting the text, textComponent.X
+        // is left holding a stale offset and the leading characters sit off to
+        // the left of the visible area. Assert that the text X snaps back to its
+        // resting value when the content shrinks back to fit.
+        TextBox textBox = new();
+        textBox.IsFocused = true;
+
+        DefaultTextBoxBaseRuntime visual = (DefaultTextBoxBaseRuntime)textBox.Visual;
+        float restingTextX = visual.TextInstance.X;
+
+        // Type enough characters to overflow the default width and force a scroll.
+        for (int i = 0; i < 60; i++)
+        {
+            textBox.HandleCharEntered('a');
+        }
+        visual.TextInstance.X.ShouldBeLessThan(restingTextX,
+            "sanity: typing past the right edge should have scrolled the text left");
+
+        // Delete everything.
+        for (int i = 0; i < 60; i++)
+        {
+            textBox.HandleBackspace();
+        }
+
+        visual.TextInstance.X.ShouldBe(restingTextX,
+            "because once the content fits again with the caret at index 0, the text X should return to its at-rest value rather than hold the scroll-left offset from earlier");
+    }
+
+    [Fact]
+    public void Height_ShouldNotShiftTextY_AfterTransientNegativeHeight_Multiline()
+    {
+        // Y-axis analog of Width_ShouldNotShiftTextX_AfterTransientNegativeWidth (#2680).
+        // The vertical branch of KeepCaretEdgeInsideParent received the same
+        // invalid-geometry guard but is otherwise untested. Pin the behavior so
+        // a future refactor of either branch can't silently regress only one axis.
+        TextBox textBox = new();
+        textBox.AcceptsReturn = true;
+        textBox.TextWrapping = Gum.Forms.TextWrapping.Wrap;
+
+        DefaultTextBoxBaseRuntime visual = (DefaultTextBoxBaseRuntime)textBox.Visual;
+        float restingTextY = visual.TextInstance.Y;
+
+        textBox.Visual.Height = -200;
+        textBox.Visual.Height = 200;
+
+        visual.TextInstance.Y.ShouldBe(restingTextY,
+            "because once the parent has a valid height and the caret is comfortably inside it, the text Y should match its at-rest value; transient bad heights must not leave a sticky vertical offset");
+    }
+
+    [Fact]
     public void Children_Containers_ShouldNotHaveEvents()
     {
         TextBox textBox = new();

--- a/MonoGameGum/Forms/Controls/TextBoxBase.cs
+++ b/MonoGameGum/Forms/Controls/TextBoxBase.cs
@@ -84,6 +84,12 @@ public abstract class TextBoxBase :
     protected GraphicalUiElement selectionInstance;
     float _selectionInstanceYOffset;
 
+    // Resting X of the text instance as set by the visual template. KeepCaretEdgeInsideParent
+    // clamps textComponent.X to never exceed this value, so a horizontal scroll-left
+    // (negative offset) applied during typing/overflow snaps back here when the content
+    // shrinks again. See issue #2683.
+    float _textRestingX;
+
     List<GraphicalUiElement> _selectionInstances = new List<GraphicalUiElement>();
 
     GraphicalUiElement selectionTemplate;
@@ -511,6 +517,7 @@ public abstract class TextBoxBase :
         if (coreTextObject == null) throw new Exception("The Text instance must be of type Text");
 #endif
         this.textComponent.XUnits = global::Gum.Converters.GeneralUnitType.PixelsFromSmall;
+        _textRestingX = this.textComponent.X;
         caretComponent.X = 0;
     }
 
@@ -1885,6 +1892,19 @@ public abstract class TextBoxBase :
             {
                 this.textComponent.X += shiftAmount;
                 this.caretComponent.X += shiftAmount;
+            }
+
+            // Snap-back: never let the text drift right past its resting position
+            // (set by the visual template). Without this the asymmetric overflow
+            // shifts above accumulate — e.g. typing past the right edge scrolls
+            // text left, then deleting back to a short string leaves a sticky
+            // negative-then-overcorrected X. The clamp pulls caret/text together
+            // so the caret stays the same number of pixels into the text. See #2683.
+            if (this.textComponent.X > _textRestingX)
+            {
+                float clampShift = _textRestingX - this.textComponent.X;
+                this.textComponent.X += clampShift;
+                this.caretComponent.X += clampShift;
             }
         }
         else


### PR DESCRIPTION
## Summary

Fixes #2683 (follow-up to #2680).

`KeepCaretEdgeInsideParent` was a one-way ratchet: it shifted text/caret to bring the caret into view, but never undid the shift once the caret was comfortably inside the band. Typing past the right edge → text scrolls left (`textComponent.X` negative). Deleting the text → caret returns to a small index but `textComponent.X` keeps the stale negative offset; the next snap-into-view shift over-corrects with `+padding` and the text settles at `restingX + 1` instead of `restingX`.

## Fix

- Capture the visual template's resting text X (`_textRestingX`) in `RefreshInternalVisualReferences`.
- In the horizontal branch of `KeepCaretEdgeInsideParent`, after applying any shift, clamp `textComponent.X` to never exceed `_textRestingX`. The clamp shifts caret in lockstep so the caret stays at the same offset within the text.

## Tests

Three new tests in `MonoGameGum.Tests/Forms/TextBoxTests.cs`:

- **`DeletingScrolledText_ShouldSnapTextXBackToResting`** — red before fix (X=5 vs resting 4), green after. Pins the core bug.
- **`Height_ShouldNotShiftTextY_AfterTransientNegativeHeight_Multiline`** — pins the Y-axis half of the #2680 fix that previously had no test.
- **`IdenticallyConfiguredTextBoxes_ShouldHaveMatchingTextAndCaretX`** — pins the visible symptom from #2680 (caret column drift across visually-identical TextBoxes), independent of which root cause produces it.

Full `MonoGameGum.Tests` suite: 1406/1406.

Closes #2683

🤖 Generated with [Claude Code](https://claude.com/claude-code)