### PR TITLE
Fix empty-string Text picking up blank-ID CSV rows

### DIFF
--- a/GumCommon/Localization/LocalizationService.cs
+++ b/GumCommon/Localization/LocalizationService.cs
@@ -97,6 +97,15 @@ public class LocalizationService : ILocalizationService
         {
             return "NULL STRING";
         }
+        // Empty input must short-circuit before the dictionary lookup so a
+        // blank-ID entry (e.g. from a CSV continuation row that slipped past
+        // the loader) cannot leak its translation into legitimately-empty Text.
+        // See issue #2685. Null input is handled above and still returns the
+        // "NULL STRING" sentinel.
+        else if (stringID.Length == 0)
+        {
+            return stringID;
+        }
         else if (mStringDatabase.ContainsKey(stringID))
         {
             return mStringDatabase[stringID][language];

--- a/GumCommon/Localization/LocalizationServiceExtensions.cs
+++ b/GumCommon/Localization/LocalizationServiceExtensions.cs
@@ -28,6 +28,16 @@ public static class LocalizationServiceExtensions
         {
             var stringId = csv.GetField(0);
 
+            // Skip rows with a blank/whitespace ID. Translators commonly leave
+            // the ID column empty on dialog continuation rows; storing those
+            // would alias every blank-ID row to the same key (last-write-wins)
+            // and cause empty Text values to translate to leaked content.
+            // See issue #2685.
+            if (string.IsNullOrWhiteSpace(stringId))
+            {
+                continue;
+            }
+
             string[] translatedStrings = new string[columnCount];
 
             translatedStrings[0] = stringId;

--- a/MonoGameGum.Tests/Localization/LocalizationEmptyStringTests.cs
+++ b/MonoGameGum.Tests/Localization/LocalizationEmptyStringTests.cs
@@ -1,0 +1,112 @@
+using Gum.Localization;
+using Shouldly;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Xunit;
+
+namespace MonoGameGum.Tests.Localization;
+
+/// <summary>
+/// Tests for empty/null string ID handling in <see cref="LocalizationService"/>.
+/// Regression coverage for issue #2685: an empty Text value picked up content
+/// from blank-ID CSV continuation rows because (a) blank-ID rows were not
+/// filtered when loading and (b) <c>TranslateForLanguage</c> performed the
+/// dictionary lookup before short-circuiting on empty input.
+/// </summary>
+public class LocalizationEmptyStringTests
+{
+    private readonly LocalizationService _service;
+
+    public LocalizationEmptyStringTests()
+    {
+        _service = new LocalizationService();
+    }
+
+    [Fact]
+    public void Translate_ShouldReturnEmpty_WhenStringIdIsEmpty_EvenIfDatabaseHasEmptyKey()
+    {
+        // Layer 1 contract: TranslateForLanguage must short-circuit on empty input
+        // so that no dictionary lookup can leak content from a blank-ID entry.
+        // We seed the database directly with an empty key whose translations have
+        // real content, simulating the post-load state if the loader's filter
+        // ever regressed again.
+        Dictionary<string, string[]> entryDictionary = new Dictionary<string, string[]>
+        {
+            { "T_Hello", new[] { "T_Hello", "Hello", "Hola" } },
+            { "", new[] { "", "Leaked English", "Leaked Spanish" } }
+        };
+        List<string> headers = new List<string> { "English", "Spanish" };
+
+        _service.AddDatabase(entryDictionary, headers);
+
+        _service.CurrentLanguage = 1;
+        _service.Translate("").ShouldBe("");
+
+        _service.CurrentLanguage = 2;
+        _service.Translate("").ShouldBe("");
+    }
+
+    [Fact]
+    public void AddCsvDatabase_ShouldSkipBlankIdRows()
+    {
+        // Layer 2 contract: the CSV loader must not store rows whose first
+        // column is empty/whitespace. Mirrors the real-world dialog-continuation
+        // pattern from issue #2685 where translators leave the ID blank on
+        // continuation rows but populate the translation columns.
+        string csv =
+            "StringId,English,Spanish\n" +
+            "T_Hello,Hello,Hola\n" +
+            ",Continuation English,Continuation Spanish\n" +
+            "   ,Whitespace English,Whitespace Spanish\n";
+        using MemoryStream stream = new MemoryStream(Encoding.UTF8.GetBytes(csv));
+
+        _service.AddCsvDatabase(stream);
+
+        // Blank-ID rows must not be stored.
+        List<string> keys = _service.Keys.ToList();
+        keys.ShouldNotContain("");
+        keys.ShouldNotContain("   ");
+
+        // Translating empty input still returns empty (belt-and-suspenders with layer 1).
+        _service.CurrentLanguage = 1;
+        _service.Translate("").ShouldBe("");
+
+        // Real keys still translate normally.
+        _service.Translate("T_Hello").ShouldBe("Hello");
+        _service.CurrentLanguage = 2;
+        _service.Translate("T_Hello").ShouldBe("Hola");
+    }
+
+    [Fact]
+    public void Translate_ShouldReturnTranslation_ForPopulatedKey()
+    {
+        // Regression guard: the layer 1 short-circuit must not affect the
+        // happy path for non-empty keys.
+        string csv = "StringId,English,Spanish\nT_Hello,Hello,Hola\n";
+        using MemoryStream stream = new MemoryStream(Encoding.UTF8.GetBytes(csv));
+
+        _service.AddCsvDatabase(stream);
+
+        _service.CurrentLanguage = 1;
+        _service.Translate("T_Hello").ShouldBe("Hello");
+
+        _service.CurrentLanguage = 2;
+        _service.Translate("T_Hello").ShouldBe("Hola");
+    }
+
+    [Fact]
+    public void Translate_ShouldReturnNullStringSentinel_WhenStringIdIsNull()
+    {
+        // Pin existing behavior: null input is distinct from empty input and
+        // continues to return the "NULL STRING" sentinel.
+        string csv = "StringId,English\nT_Hello,Hello\n";
+        using MemoryStream stream = new MemoryStream(Encoding.UTF8.GetBytes(csv));
+
+        _service.AddCsvDatabase(stream);
+
+        _service.CurrentLanguage = 1;
+        _service.Translate(null!).ShouldBe("NULL STRING");
+    }
+}


### PR DESCRIPTION
Fixes #2685

## Summary
- `LocalizationService.TranslateForLanguage` now short-circuits when the string ID is empty, returning it as-is before any dictionary lookup. This restores the deliberate empty-string exclusion that has lived in `ShouldExcludeFromTranslation` since 2021 but was being bypassed because the dictionary lookup ran first.
- `LocalizationServiceExtensions.AddCsvDatabase` now skips rows whose ID column is null, empty, or whitespace. This restores blank-row filtering that was lost when the loader was extracted from the older static `LocalizationManager` in #2105.
- Added `MonoGameGum.Tests/Localization/LocalizationEmptyStringTests.cs` with regression coverage: leak via direct `AddDatabase`, leak via CSV continuation rows, populated-key happy path, and null-input sentinel pin.

## Why two layers
The CSV-loader filter is the root-cause fix. The `TranslateForLanguage` short-circuit is defense-in-depth so any other code path that might inject an empty key into the database (custom `AddDatabase` calls, future loaders) cannot reproduce the same leak.

The original lookup-before-exclusion ordering for non-empty IDs is preserved so populated CSV entries can still override the "no letters" rule for things like numeric or punctuation strings, which is the documented intent from the original 2021 implementation.

## Test plan
- [x] `dotnet build AllLibraries.sln` — succeeds, no new warnings
- [x] `dotnet build GumFull.sln` — succeeds, no new warnings
- [x] New tests fail before the production fix (red), pass after (green)
- [x] Full localization regression sweep: 79 passed in `MonoGameGum.Tests`, 6 passed in `MonoGameGum.IntegrationTests`
- [x] Manual verification in Gum tool: setting Text to empty on a Text element no longer leaks blank-ID CSV row content