### PR TITLE
Fix incorrect AddToRoot-as-resolution claims in font docs

### DIFF
--- a/docs/code/files-and-fonts/README.md
+++ b/docs/code/files-and-fonts/README.md
@@ -6,8 +6,8 @@ This section covers file loading and font setup for Gum projects. The font pages
 
 * [Fonts](fonts.md) — start here. Decision tree: which font strategy fits your game.
 * [Font Strategies](font-strategies.md) — detailed walkthroughs of each strategy with code samples.
-* [Font Performance](font-performance.md) — where the costs live (generation, memory, draw calls, the property-change footgun).
-* [Font Preloading](font-preloading.md) — force-generate every font/size/style your game uses before gameplay starts.
+* [Font Performance](font-performance.md) — where the costs live (generation, memory, draw calls).
+* [Font Preloading](font-preloading.md) — making sure every font/size/style your game uses is ready before gameplay starts.
 * [Fonts on Web](fonts-web.md) — bandwidth vs CPU tradeoffs for web targets.
 * [Font Localization](font-localization.md) — current behavior and the planned per-locale system.
 * [Font Cache](font-cache.md) — the build-time `.fnt` atlas system.

--- a/docs/code/files-and-fonts/font-performance.md
+++ b/docs/code/files-and-fonts/font-performance.md
@@ -2,18 +2,17 @@
 
 ## Introduction
 
-Fonts are unusual in a Gum UI: they can be the cheapest thing on screen (a few labels with a pre-loaded atlas) or the most expensive (a CJK atlas regenerating mid-frame because someone touched `FontSize` in code). This page describes where the costs live so you can decide which to spend.
+Fonts are unusual in a Gum UI: they can be the cheapest thing on screen (a few labels with a small Latin atlas) or the most expensive (a CJK atlas getting generated for the first time on a mobile device). This page describes where the costs live so you can decide which to spend.
 
 This page is qualitative on purpose. Actual numbers depend on character set, platform, GPU, and how your game uses text — measure on your target hardware rather than trusting a number from a doc.
 
 ## Where the Costs Live
 
-There are four costs to think about:
+There are three costs to think about:
 
-1. **Atlas generation cost (CPU)** — the one-time work of rasterizing glyphs into a texture. Applies to KernSmith every time a new `(font, size, style)` combination is requested at runtime.
+1. **Atlas generation cost (CPU)** — the one-time work of rasterizing glyphs into a texture. Applies to KernSmith whenever a new `(font, size, style)` combination is first needed at runtime.
 2. **Atlas memory cost (VRAM and RAM)** — each atlas is a texture. More atlases means more texture memory.
 3. **Draw call cost (GPU)** — text and non-text alternation on the same screen costs one draw call per alternation. Gum does not currently sort by texture or batch across textures.
-4. **Property-change cost** — setting font properties one at a time on an existing `TextRuntime` triggers a full font resolution on each property assignment.
 
 The next sections cover each in turn.
 
@@ -21,10 +20,10 @@ The next sections cover each in turn.
 
 KernSmith rasterizes every glyph in the requested character set into an atlas. The cost scales with the number of glyphs.
 
-* **Small charsets (Latin, Cyrillic, Greek, and similar).** Generation is fast enough that most projects can do it on-demand during gameplay without a perceptible hitch.
+* **Small charsets (Latin, Cyrillic, Greek, and similar).** Generation is fast enough that most projects can absorb it during normal play without a perceptible hitch.
 * **Large charsets (CJK — Chinese, Japanese Kanji, Korean Hangul).** Generation can be slow enough that the player sees a frame hitch, sometimes a full pause. Plan to do this work behind a loading screen.
 
-The rule of thumb: if your charset is "everything in this language", treat the first use of a font/size combination as expensive. See [Font Preloading](font-preloading.md) for how to move that cost off the gameplay path.
+The rule of thumb: if your charset is "everything in this language", treat each new `(font, size, style)` combination as expensive. See [Font Preloading](font-preloading.md) for moving that cost off the gameplay path.
 
 ## Atlas Memory Cost
 
@@ -51,52 +50,15 @@ Workarounds you can apply today:
 
 A future Gum release (Phase 5 — [#2697](https://github.com/vchelaru/Gum/issues/2697)) targets KernSmith using one shared atlas plus a sort-by-texture pass, which removes most of this cost. bmfont users (pre-baked `.fnt`) do not benefit from that change; the migration path is to switch to KernSmith.
 
-## Property-Change Cost (The Footgun)
-
-This one is worth calling out because it surprises people.
-
-When you set a font-related property on a `TextRuntime` (`Font`, `FontSize`, `IsBold`, `IsItalic`, `OutlineThickness`, `UseFontSmoothing`), the runtime immediately resolves the font for the new combination. If KernSmith is in use, "resolves" can mean "generate a new atlas".
-
-Setting four properties in a row therefore triggers up to four font resolutions, three of which are wasted:
-
-```csharp
-// Initialize — BAD: each line may trigger an atlas generation.
-text.Font = "Noto Sans CJK";   // generates atlas for current size/style
-text.FontSize = 24;            // re-resolves
-text.IsBold = true;            // re-resolves
-text.OutlineThickness = 2;     // re-resolves
-text.AddToRoot();
-```
-
-The fix is to configure the `TextRuntime` fully **before** it's added to the layout root. While an element is detached, layout (including font resolution) is suspended:
-
-```csharp
-// Initialize — GOOD: font resolves once, after AddToRoot.
-var text = new TextRuntime();
-text.Font = "Noto Sans CJK";
-text.FontSize = 24;
-text.IsBold = true;
-text.OutlineThickness = 2;
-text.Text = "Hello";
-text.AddToRoot();              // single resolution here
-```
-
-This is the recommended pattern for any `TextRuntime` you create from code. For the deeper mechanism behind it, see Phase 2 of the font roadmap ([#2694](https://github.com/vchelaru/Gum/issues/2694)) — `GraphicalUiElement.IsAllLayoutSuspended` is the underlying knob.
-
-{% hint style="warning" %}
-There is no per-instance equivalent of "suspend layout on this one `TextRuntime`" that defers font resolution across property sets after the element has been added to the root. If you need to retune fonts on an existing on-screen `TextRuntime`, the resolution cost happens — there is no way to coalesce it today.
-{% endhint %}
-
 ## Cost by Strategy
 
 A quick reference of which costs apply to which [font strategy](font-strategies.md):
 
 | Cost | Dynamic KernSmith | Custom Font File | Direct BitmapFont | Build-Time FontCache |
 |---|---|---|---|---|
-| Atlas generation (CPU) | Yes, on first use | No | No | No |
+| Atlas generation (CPU) | Yes | No | No | No |
 | Atlas memory (VRAM) | Yes | Yes | Yes | Yes |
 | Draw call alternation | Yes | Yes | Yes | Yes |
-| Property-change footgun | Yes | N/A (one file = one atlas) | N/A | Yes |
 
 ## Related Pages
 

--- a/docs/code/files-and-fonts/font-preloading.md
+++ b/docs/code/files-and-fonts/font-preloading.md
@@ -2,68 +2,41 @@
 
 ## Introduction
 
-When you use KernSmith with a large character set (CJK, large Cyrillic blocks, or any font with thousands of glyphs), the first use of each `(font, size, style)` combination triggers atlas generation. If this happens during gameplay, the player sees a hitch — sometimes a noticeable pause.
+When you use KernSmith with a large character set (CJK, large Cyrillic blocks, or any font with thousands of glyphs), generating an atlas for a new `(font, size, style)` combination is expensive. If that work happens during gameplay, the player can see a hitch — sometimes a noticeable pause.
 
-The fix is to force-generate every combination your game uses **before** gameplay starts, behind a loading screen or splash. This page describes the pattern.
+The fix in shape is to make sure every combination your game uses has its atlas ready **before** gameplay starts — behind a loading screen or splash.
 
 For when this matters and what it costs, see [Font Performance](font-performance.md).
 
-## The Pattern
-
-A preload step does three things:
-
-1. Enumerate every `(font, size, style, outline, smoothing)` combination your game uses.
-2. Construct a temporary `TextRuntime` for each combination, with a representative string, and add it to the root (which forces font resolution).
-3. Discard the temporary `TextRuntime`s. The generated atlases stay in memory.
-
-The simplest version:
-
-```csharp
-// Initialize
-void PreloadFonts()
-{
-    PreloadFont("Noto Sans CJK", fontSize: 16, isBold: false);
-    PreloadFont("Noto Sans CJK", fontSize: 16, isBold: true);
-    PreloadFont("Noto Sans CJK", fontSize: 24, isBold: false);
-    PreloadFont("Noto Sans CJK", fontSize: 24, isBold: true);
-    PreloadFont("Noto Sans CJK", fontSize: 32, isBold: false);
-}
-
-void PreloadFont(string font, int fontSize, bool isBold)
-{
-    var text = new TextRuntime();
-    text.Font = font;
-    text.FontSize = fontSize;
-    text.IsBold = isBold;
-    text.Text = "preload";
-    text.AddToRoot();
-    text.RemoveFromRoot();
-}
-```
-
-Call `PreloadFonts()` from a loading screen so the cost is absorbed before gameplay starts.
-
-## Driving Preloads from Real Usage
-
-Hand-maintaining a list of every combination drifts out of sync the first time a designer changes a size in the tool. A more robust approach is to derive the list from your Gum project itself — walk the project's elements, collect every distinct font configuration they reference, and preload that set.
-
-This isn't built into Gum yet. The pattern most projects end up with is something like:
-
-* Load the `.gumx` project at startup.
-* Walk every element, looking at `Text` instances and their state variations.
-* Build a `HashSet<(string font, int size, bool bold, bool italic, int outline, bool smoothing)>`.
-* Call the preload loop on every entry in the set.
-
-The benefit is that adding a new size in the Gum tool automatically adds it to the preload list. The cost is a bit of bookkeeping code that knows your project layout.
+{% hint style="warning" %}
+The recommended preloading recipe (the specific API calls and lifecycle) is being finalized as part of a follow-up task. This page covers the goal and the inventory you need to preload; the canonical code pattern will land in a later docs update. If you need to ship a preloader today and you're not sure how, ask on Discord or [open an issue](https://github.com/vchelaru/Gum/issues).
+{% endhint %}
 
 ## What to Preload
 
-* **Every font family** you reference, including UI labels, dialogue, headings.
+Whatever pattern you use, the **set** you preload is the same. Enumerate every `(font, family, size, style, outline thickness, smoothing)` combination your UI uses, and make sure each one is generated before the player starts playing.
+
+That set includes:
+
+* **Every font family** you reference — UI labels, dialogue, headings.
 * **Every size** that actually appears on screen. Don't preload sizes that are defined but never used.
 * **Every style** (bold/italic) — these produce distinct atlases.
 * **Outline thickness and font-smoothing variants** if your game uses them.
 
 If you're shipping a single locale, this set is finite and usually small enough to preload behind a loading screen even for a large charset. If you ship multiple locales in one build, preload only the active locale at startup and reload on locale change — see [Font Localization](font-localization.md) for the planned support and current limitations.
+
+## Driving the List from Your Gum Project
+
+Hand-maintaining a list of every combination drifts out of sync the first time a designer changes a size in the tool. A more robust approach is to derive the list from your Gum project itself: walk the project's elements, collect every distinct font configuration they reference, and preload that set.
+
+This isn't built into Gum yet. The pattern most projects end up with is something like:
+
+* Load the `.gumx` project at startup.
+* Walk every element, looking at `Text` instances and their state variations.
+* Build a set of unique `(font, size, style, outline, smoothing)` tuples.
+* Drive a preload pass over each entry in the set.
+
+The benefit is that adding a new size in the Gum tool automatically adds it to the preload list. The cost is a bit of bookkeeping code that knows your project layout.
 
 ## Verifying Preloads Worked
 

--- a/docs/code/files-and-fonts/fonts.md
+++ b/docs/code/files-and-fonts/fonts.md
@@ -47,8 +47,8 @@ The Gum tool generates these atlases automatically while you edit your project. 
 ## Hub Contents
 
 * [Font Strategies](font-strategies.md) — concrete details and code samples for each strategy above.
-* [Font Performance](font-performance.md) — what costs each strategy, where the hitches and footguns are.
-* [Font Preloading](font-preloading.md) — how to force-generate every font/size/style your game uses before gameplay starts.
+* [Font Performance](font-performance.md) — what costs each strategy, where the hitches live.
+* [Font Preloading](font-preloading.md) — making sure every font/size/style your game uses is ready before gameplay starts.
 * [Fonts on Web](fonts-web.md) — bandwidth vs CPU tradeoffs for web targets.
 * [Font Localization](font-localization.md) — current behavior, known limitations, and the per-locale design that's coming.
 * [Font Cache](font-cache.md) — the build-time `.fnt` atlas system, naming convention, and when to use it.

--- a/docs/code/standard-visuals/textruntime/fonts.md
+++ b/docs/code/standard-visuals/textruntime/fonts.md
@@ -22,7 +22,7 @@ By default all `TextRuntime` instances use an Arial 18-point font embedded in th
 
 ## How These Properties Resolve to a Font
 
-When any of the font-component properties change, `TextRuntime` resolves them to an actual font in one of these ways:
+A `TextRuntime`'s font is chosen by one of these paths, in priority order:
 
 1. **`BitmapFont` is set directly** → that font is used; the component properties are ignored.
 2. **`UseCustomFont` is `true`** → `CustomFontFile` is loaded from disk.
@@ -32,28 +32,11 @@ When any of the font-component properties change, `TextRuntime` resolves them to
 For the full details on each path — when to use it, code samples, and the costs involved — see:
 
 * [Font Strategies](../../files-and-fonts/font-strategies.md) — full walkthroughs.
-* [Font Performance](../../files-and-fonts/font-performance.md) — costs and the property-change footgun.
+* [Font Performance](../../files-and-fonts/font-performance.md) — generation, memory, and draw-call costs.
 
 {% hint style="info" %}
 **Choosing a font strategy?** Start at the [Fonts hub](../../files-and-fonts/fonts.md). It has a four-path decision tree that points you at the right approach in about a minute.
 {% endhint %}
-
-## Setting Font Properties Efficiently
-
-Each font-component property assignment can trigger a font resolution. On large character sets this is expensive enough to matter. The recommended pattern is to set every property **before** adding the `TextRuntime` to the root:
-
-```csharp
-// Initialize
-var text = new TextRuntime();
-text.Font = "Noto Sans CJK";
-text.FontSize = 24;
-text.IsBold = true;
-text.OutlineThickness = 2;
-text.Text = "Hello";
-text.AddToRoot();              // single resolution here
-```
-
-See [Font Performance — Property-Change Cost](../../files-and-fonts/font-performance.md#property-change-cost-the-footgun) for the full explanation.
 
 ## Missing Font Exceptions
 


### PR DESCRIPTION
## Summary

Follow-up to #2708 (Phase 1 font docs hub, merged) — that PR repeatedly suggested font resolution happens at \`AddToRoot\` or on each font-property assignment. That's wrong: font resolution runs every frame regardless of root attachment. This PR scrubs those claims so we don't mislead readers. The correct mechanics will be documented in a follow-up task.

- **font-performance.md** — drop the *Property-Change Cost (The Footgun)* section, drop the related row from the Cost-by-Strategy table, drop the "on first use" qualifier from the atlas-generation row.
- **font-preloading.md** — drop the AddToRoot/RemoveFromRoot recipe. Keep the *what* (which set of font/size/style combos to preload, why) and replace the *how* with a warning hint that the canonical pattern is pending.
- **standard-visuals/textruntime/fonts.md** — drop the *Setting Font Properties Efficiently* section and the link to the deleted footgun anchor. Rephrase the resolution decision tree so it describes which path is chosen, not when it runs.
- **fonts.md / README.md** — drop "footgun" and "force-generate" phrasings from the hub blurb and section index.

Relates to #2693.

## Test plan

- [ ] Verify no remaining text claims font resolution is tied to \`AddToRoot\` or to property-set timing.
- [ ] Verify the link to \`#property-change-cost-the-footgun\` is gone (anchor no longer exists).
- [ ] Render docs locally / on GitBook and walk **Files and Fonts → Fonts**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)