### PR TITLE
Apply LineHeightMultiplier to TextBox caret/selection math (#2712)

### DIFF
--- a/MonoGameGum.Tests/Forms/TextBoxTests.cs
+++ b/MonoGameGum.Tests/Forms/TextBoxTests.cs
@@ -213,6 +213,46 @@ public class TextBoxTests : BaseTestClass
     }
 
     [Fact]
+    public void LineHeightMultiplier_ShouldScaleCaretLineSpacing_Multiline()
+    {
+        // Issue #2712: LineHeightMultiplier was being ignored by the caret/selection
+        // line-position math in TextBoxBase, so the caret sat at the wrong Y for any
+        // line beyond line 0 whenever the multiplier was not 1. Multiplier is set
+        // BEFORE the caret is positioned to isolate the math from any reactivity.
+
+        static float CaretTopForLine(float multiplier, int caretIndex)
+        {
+            TextBox tb = new();
+            tb.TextWrapping = Gum.Forms.TextWrapping.Wrap;
+            tb.AcceptsReturn = true;
+            tb.Height = 400;
+            tb.IsFocused = true;
+
+            DefaultTextBoxBaseRuntime visual = (DefaultTextBoxBaseRuntime)tb.Visual;
+            visual.TextInstance.LineHeightMultiplier = multiplier;
+
+            tb.HandleCharEntered('\n');
+            tb.HandleCharEntered('\n');
+            tb.HandleCharEntered('\n');
+            tb.CaretIndex = caretIndex;
+
+            return visual.CaretInstance.AbsoluteTop;
+        }
+
+        // Gap between line 0 and line 2 at 1x and at 2x. With a 2x multiplier the
+        // gap should be roughly 2x as large; we assert at least 1.5x to allow for
+        // half-line center/edge adjustments without being brittle to font metrics.
+        float gap1x = CaretTopForLine(1.0f, 2) - CaretTopForLine(1.0f, 0);
+        float gap2x = CaretTopForLine(2.0f, 2) - CaretTopForLine(2.0f, 0);
+
+        gap1x.ShouldBeGreaterThan(0f, "sanity: line 2's caret should be below line 0's");
+        gap2x.ShouldBeGreaterThan(gap1x * 1.5f,
+            "because doubling the line height multiplier should roughly double the " +
+            "line-to-line gap; if the gap is unchanged the multiplier is being ignored " +
+            "by the caret-position math (regression of #2712)");
+    }
+
+    [Fact]
     public void Width_ShouldNotShiftTextX_AfterTransientNegativeWidth()
     {
         // Repro for issue #2680: when a TextBox's absolute width transitions

--- a/MonoGameGum/Forms/Controls/TextBoxBase.cs
+++ b/MonoGameGum/Forms/Controls/TextBoxBase.cs
@@ -712,7 +712,7 @@ public abstract class TextBoxBase :
         }
         else
         {
-            var lineHeight = coreTextObject.LineHeightInPixels;
+            var lineHeight = EffectiveLineHeightInPixels;
             var topOfText = this.textComponent.GetAbsoluteTop();
             if (this.coreTextObject?.VerticalAlignment == global::RenderingLibrary.Graphics.VerticalAlignment.Center)
             {
@@ -720,7 +720,7 @@ public abstract class TextBoxBase :
             }
             var cursorYOffset = screenY - topOfText;
 
-            var lineOn = System.Math.Max(0, System.Math.Min((int)cursorYOffset / lineHeight, coreTextObject.WrappedText.Count - 1));
+            var lineOn = System.Math.Max(0, System.Math.Min((int)(cursorYOffset / lineHeight), coreTextObject.WrappedText.Count - 1));
 
             if (lineOn < coreTextObject.WrappedText.Count)
             {
@@ -1012,7 +1012,7 @@ public abstract class TextBoxBase :
         }
         else
         {
-            var lineHeight = coreTextObject.LineHeightInPixels;
+            var lineHeight = EffectiveLineHeightInPixels;
             var newY = absoluteY - lineHeight;
             var index = GetCaretIndexAtPosition(absoluteX, newY);
             CaretIndex = index;
@@ -1029,7 +1029,7 @@ public abstract class TextBoxBase :
         }
         else
         {
-            var lineHeight = coreTextObject.LineHeightInPixels;
+            var lineHeight = EffectiveLineHeightInPixels;
             var newY = absoluteY + lineHeight;
             var index = GetCaretIndexAtPosition(absoluteX, newY);
             CaretIndex = index;
@@ -1832,7 +1832,7 @@ public abstract class TextBoxBase :
         // For the clamp we want the actual content height — line count × line
         // height — so we don't over-clamp and undo a legitimate scroll.
         var lineCount = coreTextObject.WrappedText?.Count ?? 0;
-        float contentHeight = lineCount * coreTextObject.LineHeightInPixels;
+        float contentHeight = lineCount * EffectiveLineHeightInPixels;
         float containerHeight = caretComponent.EffectiveParentGue.GetAbsoluteHeight();
         float maxScrollUp = System.Math.Max(0f, contentHeight - containerHeight);
         float clamped = System.Math.Max(this.textComponent.Y, -maxScrollUp);
@@ -2054,9 +2054,17 @@ public abstract class TextBoxBase :
         return adjusted;
     }
 
+    // The font's raw line height in pixels multiplied by the inner Text's
+    // LineHeightMultiplier. This is the per-line vertical step used for caret
+    // placement, selection-rectangle placement, hit-testing, and vertical
+    // scroll-content sizing — all of which must honor the multiplier so the
+    // caret/selection line up with the text the user actually sees.
+    private float EffectiveLineHeightInPixels =>
+        coreTextObject.LineHeightInPixels * coreTextObject.LineHeightMultiplier;
+
     private float GetCenterOfYForLinePixelsFromSmall(int lineNumber)
     {
-        var lineHeight = coreTextObject.LineHeightInPixels;
+        var lineHeight = EffectiveLineHeightInPixels;
 
         float offset;
 


### PR DESCRIPTION
## Summary

- `TextBoxBase` was using raw `LineHeightInPixels` (font line height) for inter-line spacing in caret position, selection rectangle position, click hit-testing, arrow-key vertical movement, and vertical-scroll content-height clamp — so `LineHeightMultiplier` had **zero effect** on the caret/selection math. The caret sat at the same Y regardless of multiplier, drifting out of sync with the rendered text on any line past line 0.
- Introduce an `EffectiveLineHeightInPixels` helper (`LineHeightInPixels * LineHeightMultiplier`) and use it at the 5 affected sites. `ResolveLineYForComponent` already applied the multiplier for the `YOrigin=Top` half-line adjustment and is unchanged.
- The fix lives in shared Forms source (`MonoGameGum/Forms/Controls/TextBoxBase.cs`), which Raylib links in via `RaylibGum.csproj`, so both runtimes are covered.

## Out of scope

Reactivity — i.e. responding to a runtime change of `LineHeightMultiplier` without a subsequent caret/selection edit — is a separate concern. The math fix means the values are now read fresh on the next `UpdateCaretPositionFromCaretIndex` / `UpdateToSelection` (typing, arrow keys, click). Wiring an automatic refresh on multiplier change is intentionally deferred.

## Test plan

- [x] New diagnostic test `LineHeightMultiplier_ShouldScaleCaretLineSpacing_Multiline` was red before the fix (line-2 caret Y identical at 1x and 2x multiplier) and green after.
- [x] Full `MonoGameGum.Tests` suite: 1413 / 1413 passing.
- [x] Full `RaylibGum.Tests` suite: 115 / 115 passing.
- [ ] Manual verification in a real app (.gumx-loaded scenario from the original report) — recommended before merge.

Closes #2712

🤖 Generated with [Claude Code](https://claude.com/claude-code)