### PR TITLE
Keep V1/V2/V3 default visuals on MonoGameGum.GueDeriving shim types

### DIFF
--- a/MonoGameGum/Forms/DefaultVisuals/ButtonVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/ButtonVisual.cs
@@ -1,4 +1,5 @@
-﻿using Gum.DataTypes.Variables;
+#pragma warning disable CS0618, GUM001 // Default visuals intentionally use deprecated MonoGameGum.GueDeriving shim types for backward compatibility until V1/V2/V3 visuals are retired. See issue #2715.
+using Gum.DataTypes.Variables;
 using Gum.Wireframe;
 using RenderingLibrary;
 using RenderingLibrary.Graphics;
@@ -7,10 +8,10 @@ using RenderingLibrary.Graphics;
 
 #if XNALIKE
 using Microsoft.Xna.Framework;
-using Gum.GueDeriving;
+using MonoGameGum.GueDeriving;
 using Microsoft.Xna.Framework.Graphics;
 #else
-using Gum.GueDeriving;
+using MonoGameGum.GueDeriving;
 #endif
 using Gum.Forms.Controls;
 namespace Gum.Forms.DefaultVisuals;

--- a/MonoGameGum/Forms/DefaultVisuals/ButtonVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/ButtonVisual.cs
@@ -11,7 +11,7 @@ using Microsoft.Xna.Framework;
 using MonoGameGum.GueDeriving;
 using Microsoft.Xna.Framework.Graphics;
 #else
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 #endif
 using Gum.Forms.Controls;
 namespace Gum.Forms.DefaultVisuals;

--- a/MonoGameGum/Forms/DefaultVisuals/CheckBoxVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/CheckBoxVisual.cs
@@ -1,4 +1,5 @@
-﻿using Gum.DataTypes.Variables;
+#pragma warning disable CS0618, GUM001 // Default visuals intentionally use deprecated MonoGameGum.GueDeriving shim types for backward compatibility until V1/V2/V3 visuals are retired. See issue #2715.
+using Gum.DataTypes.Variables;
 using Gum.Wireframe;
 using RenderingLibrary.Graphics;
 using System;
@@ -12,10 +13,10 @@ using System.Threading.Tasks;
 #if XNALIKE
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
-using Gum.GueDeriving;
+using MonoGameGum.GueDeriving;
 using RenderingLibrary.Math.Geometry;
 #else
-using Gum.GueDeriving;
+using MonoGameGum.GueDeriving;
 #endif
 using Gum.Forms.Controls;
 namespace Gum.Forms.DefaultVisuals;

--- a/MonoGameGum/Forms/DefaultVisuals/CheckBoxVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/CheckBoxVisual.cs
@@ -13,10 +13,18 @@ using System.Threading.Tasks;
 #if XNALIKE
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
+#if XNALIKE
 using MonoGameGum.GueDeriving;
+#else
+using Gum.GueDeriving;
+#endif
 using RenderingLibrary.Math.Geometry;
 #else
+#if XNALIKE
 using MonoGameGum.GueDeriving;
+#else
+using Gum.GueDeriving;
+#endif
 #endif
 using Gum.Forms.Controls;
 namespace Gum.Forms.DefaultVisuals;

--- a/MonoGameGum/Forms/DefaultVisuals/ComboBoxVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/ComboBoxVisual.cs
@@ -13,9 +13,17 @@ using System.Threading.Tasks;
 #if XNALIKE
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
+#if XNALIKE
 using MonoGameGum.GueDeriving;
 #else
+using Gum.GueDeriving;
+#endif
+#else
+#if XNALIKE
 using MonoGameGum.GueDeriving;
+#else
+using Gum.GueDeriving;
+#endif
 #endif
 using Gum.Forms.Controls;
 namespace Gum.Forms.DefaultVisuals;

--- a/MonoGameGum/Forms/DefaultVisuals/ComboBoxVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/ComboBoxVisual.cs
@@ -1,4 +1,5 @@
-﻿using Gum.Converters;
+#pragma warning disable CS0618, GUM001 // Default visuals intentionally use deprecated MonoGameGum.GueDeriving shim types for backward compatibility until V1/V2/V3 visuals are retired. See issue #2715.
+using Gum.Converters;
 using Gum.DataTypes.Variables;
 using Gum.Wireframe;
 
@@ -12,9 +13,9 @@ using System.Threading.Tasks;
 #if XNALIKE
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
-using Gum.GueDeriving;
+using MonoGameGum.GueDeriving;
 #else
-using Gum.GueDeriving;
+using MonoGameGum.GueDeriving;
 #endif
 using Gum.Forms.Controls;
 namespace Gum.Forms.DefaultVisuals;

--- a/MonoGameGum/Forms/DefaultVisuals/DefaultButtonRuntime.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/DefaultButtonRuntime.cs
@@ -1,8 +1,9 @@
-﻿using Gum.DataTypes.Variables;
+#pragma warning disable CS0618, GUM001 // Default visuals intentionally use deprecated MonoGameGum.GueDeriving shim types for backward compatibility until V1/V2/V3 visuals are retired. See issue #2715.
+using Gum.DataTypes.Variables;
 using Gum.Wireframe;
 using Microsoft.Xna.Framework;
 using Gum.Forms.Controls;
-using Gum.GueDeriving;
+using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System;
 using System.Collections.Generic;

--- a/MonoGameGum/Forms/DefaultVisuals/DefaultButtonRuntime.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/DefaultButtonRuntime.cs
@@ -3,7 +3,11 @@ using Gum.DataTypes.Variables;
 using Gum.Wireframe;
 using Microsoft.Xna.Framework;
 using Gum.Forms.Controls;
+#if XNALIKE
 using MonoGameGum.GueDeriving;
+#else
+using Gum.GueDeriving;
+#endif
 using RenderingLibrary.Graphics;
 using System;
 using System.Collections.Generic;

--- a/MonoGameGum/Forms/DefaultVisuals/DefaultCheckboxRuntime.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/DefaultCheckboxRuntime.cs
@@ -1,8 +1,9 @@
-﻿using Gum.DataTypes.Variables;
+#pragma warning disable CS0618, GUM001 // Default visuals intentionally use deprecated MonoGameGum.GueDeriving shim types for backward compatibility until V1/V2/V3 visuals are retired. See issue #2715.
+using Gum.DataTypes.Variables;
 using Gum.Wireframe;
 using Microsoft.Xna.Framework;
 using Gum.Forms.Controls;
-using Gum.GueDeriving;
+using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using RenderingLibrary.Math.Geometry;
 using System;

--- a/MonoGameGum/Forms/DefaultVisuals/DefaultCheckboxRuntime.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/DefaultCheckboxRuntime.cs
@@ -3,7 +3,11 @@ using Gum.DataTypes.Variables;
 using Gum.Wireframe;
 using Microsoft.Xna.Framework;
 using Gum.Forms.Controls;
+#if XNALIKE
 using MonoGameGum.GueDeriving;
+#else
+using Gum.GueDeriving;
+#endif
 using RenderingLibrary.Graphics;
 using RenderingLibrary.Math.Geometry;
 using System;

--- a/MonoGameGum/Forms/DefaultVisuals/DefaultComboBoxRuntime.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/DefaultComboBoxRuntime.cs
@@ -4,7 +4,11 @@ using Gum.DataTypes.Variables;
 using Gum.Wireframe;
 using Microsoft.Xna.Framework;
 using Gum.Forms.Controls;
+#if XNALIKE
 using MonoGameGum.GueDeriving;
+#else
+using Gum.GueDeriving;
+#endif
 using RenderingLibrary.Graphics;
 using System;
 using System.Collections.Generic;

--- a/MonoGameGum/Forms/DefaultVisuals/DefaultComboBoxRuntime.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/DefaultComboBoxRuntime.cs
@@ -1,9 +1,10 @@
-﻿using Gum.Converters;
+#pragma warning disable CS0618, GUM001 // Default visuals intentionally use deprecated MonoGameGum.GueDeriving shim types for backward compatibility until V1/V2/V3 visuals are retired. See issue #2715.
+using Gum.Converters;
 using Gum.DataTypes.Variables;
 using Gum.Wireframe;
 using Microsoft.Xna.Framework;
 using Gum.Forms.Controls;
-using Gum.GueDeriving;
+using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System;
 using System.Collections.Generic;

--- a/MonoGameGum/Forms/DefaultVisuals/DefaultLabelRuntime.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/DefaultLabelRuntime.cs
@@ -1,7 +1,11 @@
 #pragma warning disable CS0618, GUM001 // Default visuals intentionally use deprecated MonoGameGum.GueDeriving shim types for backward compatibility until V1/V2/V3 visuals are retired. See issue #2715.
 using Gum.Wireframe;
 using Gum.Forms.Controls;
+#if XNALIKE
 using MonoGameGum.GueDeriving;
+#else
+using Gum.GueDeriving;
+#endif
 using RenderingLibrary.Graphics;
 using System;
 using System.Collections.Generic;

--- a/MonoGameGum/Forms/DefaultVisuals/DefaultLabelRuntime.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/DefaultLabelRuntime.cs
@@ -1,6 +1,7 @@
-﻿using Gum.Wireframe;
+#pragma warning disable CS0618, GUM001 // Default visuals intentionally use deprecated MonoGameGum.GueDeriving shim types for backward compatibility until V1/V2/V3 visuals are retired. See issue #2715.
+using Gum.Wireframe;
 using Gum.Forms.Controls;
-using Gum.GueDeriving;
+using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System;
 using System.Collections.Generic;

--- a/MonoGameGum/Forms/DefaultVisuals/DefaultListBoxItemRuntime.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/DefaultListBoxItemRuntime.cs
@@ -1,8 +1,9 @@
-﻿using Gum.Converters;
+#pragma warning disable CS0618, GUM001 // Default visuals intentionally use deprecated MonoGameGum.GueDeriving shim types for backward compatibility until V1/V2/V3 visuals are retired. See issue #2715.
+using Gum.Converters;
 using Gum.DataTypes.Variables;
 using Gum.Wireframe;
 using Gum.Forms.Controls;
-using Gum.GueDeriving;
+using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System;
 using System.Collections.Generic;

--- a/MonoGameGum/Forms/DefaultVisuals/DefaultListBoxItemRuntime.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/DefaultListBoxItemRuntime.cs
@@ -3,7 +3,11 @@ using Gum.Converters;
 using Gum.DataTypes.Variables;
 using Gum.Wireframe;
 using Gum.Forms.Controls;
+#if XNALIKE
 using MonoGameGum.GueDeriving;
+#else
+using Gum.GueDeriving;
+#endif
 using RenderingLibrary.Graphics;
 using System;
 using System.Collections.Generic;

--- a/MonoGameGum/Forms/DefaultVisuals/DefaultListBoxRuntime.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/DefaultListBoxRuntime.cs
@@ -4,7 +4,11 @@ using Gum.DataTypes.Variables;
 using Gum.Wireframe;
 using Microsoft.Xna.Framework;
 using Gum.Forms.Controls;
+#if XNALIKE
 using MonoGameGum.GueDeriving;
+#else
+using Gum.GueDeriving;
+#endif
 using RenderingLibrary.Graphics;
 using System;
 using System.Collections.Generic;

--- a/MonoGameGum/Forms/DefaultVisuals/DefaultListBoxRuntime.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/DefaultListBoxRuntime.cs
@@ -1,9 +1,10 @@
-﻿using Gum.Converters;
+#pragma warning disable CS0618, GUM001 // Default visuals intentionally use deprecated MonoGameGum.GueDeriving shim types for backward compatibility until V1/V2/V3 visuals are retired. See issue #2715.
+using Gum.Converters;
 using Gum.DataTypes.Variables;
 using Gum.Wireframe;
 using Microsoft.Xna.Framework;
 using Gum.Forms.Controls;
-using Gum.GueDeriving;
+using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System;
 using System.Collections.Generic;

--- a/MonoGameGum/Forms/DefaultVisuals/DefaultMenuItemRuntime.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/DefaultMenuItemRuntime.cs
@@ -3,7 +3,11 @@ using Gum.Converters;
 using Gum.Wireframe;
 using Microsoft.Xna.Framework;
 using Gum.Forms.Controls;
+#if XNALIKE
 using MonoGameGum.GueDeriving;
+#else
+using Gum.GueDeriving;
+#endif
 using RenderingLibrary.Graphics;
 using System;
 using System.Collections.Generic;

--- a/MonoGameGum/Forms/DefaultVisuals/DefaultMenuItemRuntime.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/DefaultMenuItemRuntime.cs
@@ -1,8 +1,9 @@
-﻿using Gum.Converters;
+#pragma warning disable CS0618, GUM001 // Default visuals intentionally use deprecated MonoGameGum.GueDeriving shim types for backward compatibility until V1/V2/V3 visuals are retired. See issue #2715.
+using Gum.Converters;
 using Gum.Wireframe;
 using Microsoft.Xna.Framework;
 using Gum.Forms.Controls;
-using Gum.GueDeriving;
+using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System;
 using System.Collections.Generic;

--- a/MonoGameGum/Forms/DefaultVisuals/DefaultMenuRuntime.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/DefaultMenuRuntime.cs
@@ -2,7 +2,11 @@
 using Gum.Converters;
 using Gum.Wireframe;
 using Gum.Forms.Controls;
+#if XNALIKE
 using MonoGameGum.GueDeriving;
+#else
+using Gum.GueDeriving;
+#endif
 using RenderingLibrary.Graphics;
 using System;
 using System.Collections.Generic;

--- a/MonoGameGum/Forms/DefaultVisuals/DefaultMenuRuntime.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/DefaultMenuRuntime.cs
@@ -1,7 +1,8 @@
-﻿using Gum.Converters;
+#pragma warning disable CS0618, GUM001 // Default visuals intentionally use deprecated MonoGameGum.GueDeriving shim types for backward compatibility until V1/V2/V3 visuals are retired. See issue #2715.
+using Gum.Converters;
 using Gum.Wireframe;
 using Gum.Forms.Controls;
-using Gum.GueDeriving;
+using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System;
 using System.Collections.Generic;

--- a/MonoGameGum/Forms/DefaultVisuals/DefaultRadioButtonRuntime.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/DefaultRadioButtonRuntime.cs
@@ -3,7 +3,11 @@ using Gum.DataTypes.Variables;
 using Gum.Wireframe;
 using Microsoft.Xna.Framework;
 using Gum.Forms.Controls;
+#if XNALIKE
 using MonoGameGum.GueDeriving;
+#else
+using Gum.GueDeriving;
+#endif
 using RenderingLibrary;
 using RenderingLibrary.Graphics;
 using System;

--- a/MonoGameGum/Forms/DefaultVisuals/DefaultRadioButtonRuntime.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/DefaultRadioButtonRuntime.cs
@@ -1,8 +1,9 @@
-﻿using Gum.DataTypes.Variables;
+#pragma warning disable CS0618, GUM001 // Default visuals intentionally use deprecated MonoGameGum.GueDeriving shim types for backward compatibility until V1/V2/V3 visuals are retired. See issue #2715.
+using Gum.DataTypes.Variables;
 using Gum.Wireframe;
 using Microsoft.Xna.Framework;
 using Gum.Forms.Controls;
-using Gum.GueDeriving;
+using MonoGameGum.GueDeriving;
 using RenderingLibrary;
 using RenderingLibrary.Graphics;
 using System;

--- a/MonoGameGum/Forms/DefaultVisuals/DefaultScrollBarRuntime.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/DefaultScrollBarRuntime.cs
@@ -3,7 +3,11 @@ using Gum.Converters;
 using Gum.Wireframe;
 using Microsoft.Xna.Framework;
 using Gum.Forms.Controls;
+#if XNALIKE
 using MonoGameGum.GueDeriving;
+#else
+using Gum.GueDeriving;
+#endif
 using RenderingLibrary.Graphics;
 using System;
 using System.Collections.Generic;

--- a/MonoGameGum/Forms/DefaultVisuals/DefaultScrollBarRuntime.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/DefaultScrollBarRuntime.cs
@@ -1,8 +1,9 @@
-﻿using Gum.Converters;
+#pragma warning disable CS0618, GUM001 // Default visuals intentionally use deprecated MonoGameGum.GueDeriving shim types for backward compatibility until V1/V2/V3 visuals are retired. See issue #2715.
+using Gum.Converters;
 using Gum.Wireframe;
 using Microsoft.Xna.Framework;
 using Gum.Forms.Controls;
-using Gum.GueDeriving;
+using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System;
 using System.Collections.Generic;

--- a/MonoGameGum/Forms/DefaultVisuals/DefaultScrollViewerRuntime.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/DefaultScrollViewerRuntime.cs
@@ -2,7 +2,11 @@
 using Gum.Converters;
 using Gum.Wireframe;
 using Gum.Forms.Controls;
+#if XNALIKE
 using MonoGameGum.GueDeriving;
+#else
+using Gum.GueDeriving;
+#endif
 using RenderingLibrary.Graphics;
 using System;
 using System.Collections.Generic;

--- a/MonoGameGum/Forms/DefaultVisuals/DefaultScrollViewerRuntime.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/DefaultScrollViewerRuntime.cs
@@ -1,7 +1,8 @@
-﻿using Gum.Converters;
+#pragma warning disable CS0618, GUM001 // Default visuals intentionally use deprecated MonoGameGum.GueDeriving shim types for backward compatibility until V1/V2/V3 visuals are retired. See issue #2715.
+using Gum.Converters;
 using Gum.Wireframe;
 using Gum.Forms.Controls;
-using Gum.GueDeriving;
+using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System;
 using System.Collections.Generic;

--- a/MonoGameGum/Forms/DefaultVisuals/DefaultSliderRuntime.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/DefaultSliderRuntime.cs
@@ -4,7 +4,11 @@ using Gum.DataTypes.Variables;
 using Gum.Wireframe;
 using Microsoft.Xna.Framework;
 using Gum.Forms.Controls;
+#if XNALIKE
 using MonoGameGum.GueDeriving;
+#else
+using Gum.GueDeriving;
+#endif
 using RenderingLibrary.Graphics;
 using System;
 using System.Collections.Generic;

--- a/MonoGameGum/Forms/DefaultVisuals/DefaultSliderRuntime.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/DefaultSliderRuntime.cs
@@ -1,9 +1,10 @@
-﻿using Gum.Converters;
+#pragma warning disable CS0618, GUM001 // Default visuals intentionally use deprecated MonoGameGum.GueDeriving shim types for backward compatibility until V1/V2/V3 visuals are retired. See issue #2715.
+using Gum.Converters;
 using Gum.DataTypes.Variables;
 using Gum.Wireframe;
 using Microsoft.Xna.Framework;
 using Gum.Forms.Controls;
-using Gum.GueDeriving;
+using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System;
 using System.Collections.Generic;

--- a/MonoGameGum/Forms/DefaultVisuals/DefaultSplitterRuntime.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/DefaultSplitterRuntime.cs
@@ -1,7 +1,11 @@
 #pragma warning disable CS0618, GUM001 // Default visuals intentionally use deprecated MonoGameGum.GueDeriving shim types for backward compatibility until V1/V2/V3 visuals are retired. See issue #2715.
 using Gum.Wireframe;
 using Gum.Forms.Controls;
+#if XNALIKE
 using MonoGameGum.GueDeriving;
+#else
+using Gum.GueDeriving;
+#endif
 using RenderingLibrary.Graphics;
 using System;
 using System.Collections.Generic;

--- a/MonoGameGum/Forms/DefaultVisuals/DefaultSplitterRuntime.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/DefaultSplitterRuntime.cs
@@ -1,6 +1,7 @@
-﻿using Gum.Wireframe;
+#pragma warning disable CS0618, GUM001 // Default visuals intentionally use deprecated MonoGameGum.GueDeriving shim types for backward compatibility until V1/V2/V3 visuals are retired. See issue #2715.
+using Gum.Wireframe;
 using Gum.Forms.Controls;
-using Gum.GueDeriving;
+using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System;
 using System.Collections.Generic;

--- a/MonoGameGum/Forms/DefaultVisuals/DefaultTextBoxBaseRuntime.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/DefaultTextBoxBaseRuntime.cs
@@ -1,8 +1,9 @@
-﻿using Gum.Converters;
+#pragma warning disable CS0618, GUM001 // Default visuals intentionally use deprecated MonoGameGum.GueDeriving shim types for backward compatibility until V1/V2/V3 visuals are retired. See issue #2715.
+using Gum.Converters;
 using Gum.DataTypes.Variables;
 using Gum.Wireframe;
 using Gum.Forms.Controls;
-using Gum.GueDeriving;
+using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System;
 using System.Collections.Generic;

--- a/MonoGameGum/Forms/DefaultVisuals/DefaultTextBoxBaseRuntime.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/DefaultTextBoxBaseRuntime.cs
@@ -3,7 +3,11 @@ using Gum.Converters;
 using Gum.DataTypes.Variables;
 using Gum.Wireframe;
 using Gum.Forms.Controls;
+#if XNALIKE
 using MonoGameGum.GueDeriving;
+#else
+using Gum.GueDeriving;
+#endif
 using RenderingLibrary.Graphics;
 using System;
 using System.Collections.Generic;

--- a/MonoGameGum/Forms/DefaultVisuals/DefaultTextBoxRuntime.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/DefaultTextBoxRuntime.cs
@@ -2,7 +2,11 @@
 using Gum.Converters;
 using Gum.Wireframe;
 using Gum.Forms.Controls;
+#if XNALIKE
 using MonoGameGum.GueDeriving;
+#else
+using Gum.GueDeriving;
+#endif
 using RenderingLibrary.Graphics;
 using System;
 using System.Collections.Generic;

--- a/MonoGameGum/Forms/DefaultVisuals/DefaultTextBoxRuntime.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/DefaultTextBoxRuntime.cs
@@ -1,7 +1,8 @@
-﻿using Gum.Converters;
+#pragma warning disable CS0618, GUM001 // Default visuals intentionally use deprecated MonoGameGum.GueDeriving shim types for backward compatibility until V1/V2/V3 visuals are retired. See issue #2715.
+using Gum.Converters;
 using Gum.Wireframe;
 using Gum.Forms.Controls;
-using Gum.GueDeriving;
+using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System;
 using System.Collections.Generic;

--- a/MonoGameGum/Forms/DefaultVisuals/DefaultWindowRuntime.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/DefaultWindowRuntime.cs
@@ -1,7 +1,8 @@
-﻿using Gum.Wireframe;
+#pragma warning disable CS0618, GUM001 // Default visuals intentionally use deprecated MonoGameGum.GueDeriving shim types for backward compatibility until V1/V2/V3 visuals are retired. See issue #2715.
+using Gum.Wireframe;
 using MonoGameGum;
 using Gum.Forms.Controls;
-using Gum.GueDeriving;
+using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System;
 using System.Collections.Generic;

--- a/MonoGameGum/Forms/DefaultVisuals/DefaultWindowRuntime.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/DefaultWindowRuntime.cs
@@ -2,7 +2,11 @@
 using Gum.Wireframe;
 using MonoGameGum;
 using Gum.Forms.Controls;
+#if XNALIKE
 using MonoGameGum.GueDeriving;
+#else
+using Gum.GueDeriving;
+#endif
 using RenderingLibrary.Graphics;
 using System;
 using System.Collections.Generic;

--- a/MonoGameGum/Forms/DefaultVisuals/LabelVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/LabelVisual.cs
@@ -1,12 +1,13 @@
-﻿using Gum.Wireframe;
+#pragma warning disable CS0618, GUM001 // Default visuals intentionally use deprecated MonoGameGum.GueDeriving shim types for backward compatibility until V1/V2/V3 visuals are retired. See issue #2715.
+using Gum.Wireframe;
 using RenderingLibrary.Graphics;
 
 
 #if XNALIKE
-using Gum.GueDeriving;
+using MonoGameGum.GueDeriving;
 using Microsoft.Xna.Framework;
 #else
-using Gum.GueDeriving;
+using MonoGameGum.GueDeriving;
 #endif
 using Gum.Forms.Controls;
 namespace Gum.Forms.DefaultVisuals;

--- a/MonoGameGum/Forms/DefaultVisuals/LabelVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/LabelVisual.cs
@@ -4,10 +4,18 @@ using RenderingLibrary.Graphics;
 
 
 #if XNALIKE
+#if XNALIKE
 using MonoGameGum.GueDeriving;
+#else
+using Gum.GueDeriving;
+#endif
 using Microsoft.Xna.Framework;
 #else
+#if XNALIKE
 using MonoGameGum.GueDeriving;
+#else
+using Gum.GueDeriving;
+#endif
 #endif
 using Gum.Forms.Controls;
 namespace Gum.Forms.DefaultVisuals;

--- a/MonoGameGum/Forms/DefaultVisuals/ListBoxItemVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/ListBoxItemVisual.cs
@@ -1,4 +1,5 @@
-﻿using Gum.Converters;
+#pragma warning disable CS0618, GUM001 // Default visuals intentionally use deprecated MonoGameGum.GueDeriving shim types for backward compatibility until V1/V2/V3 visuals are retired. See issue #2715.
+using Gum.Converters;
 using Gum.DataTypes.Variables;
 using Gum.Wireframe;
 using RenderingLibrary.Graphics;
@@ -12,9 +13,9 @@ using System.Threading.Tasks;
 #if XNALIKE
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
-using Gum.GueDeriving;
+using MonoGameGum.GueDeriving;
 #else
-using Gum.GueDeriving;
+using MonoGameGum.GueDeriving;
 #endif
 using Gum.Forms.Controls;
 namespace Gum.Forms.DefaultVisuals;

--- a/MonoGameGum/Forms/DefaultVisuals/ListBoxItemVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/ListBoxItemVisual.cs
@@ -13,9 +13,17 @@ using System.Threading.Tasks;
 #if XNALIKE
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
+#if XNALIKE
 using MonoGameGum.GueDeriving;
 #else
+using Gum.GueDeriving;
+#endif
+#else
+#if XNALIKE
 using MonoGameGum.GueDeriving;
+#else
+using Gum.GueDeriving;
+#endif
 #endif
 using Gum.Forms.Controls;
 namespace Gum.Forms.DefaultVisuals;

--- a/MonoGameGum/Forms/DefaultVisuals/ListBoxVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/ListBoxVisual.cs
@@ -12,9 +12,17 @@ using System.Threading.Tasks;
 #if XNALIKE
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
+#if XNALIKE
 using MonoGameGum.GueDeriving;
 #else
+using Gum.GueDeriving;
+#endif
+#else
+#if XNALIKE
 using MonoGameGum.GueDeriving;
+#else
+using Gum.GueDeriving;
+#endif
 #endif
 using Gum.Forms.Controls;
 namespace Gum.Forms.DefaultVisuals;

--- a/MonoGameGum/Forms/DefaultVisuals/ListBoxVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/ListBoxVisual.cs
@@ -1,4 +1,5 @@
-﻿using Gum.Converters;
+#pragma warning disable CS0618, GUM001 // Default visuals intentionally use deprecated MonoGameGum.GueDeriving shim types for backward compatibility until V1/V2/V3 visuals are retired. See issue #2715.
+using Gum.Converters;
 using Gum.DataTypes.Variables;
 using Gum.Wireframe;
 using RenderingLibrary.Graphics;
@@ -11,9 +12,9 @@ using System.Threading.Tasks;
 #if XNALIKE
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
-using Gum.GueDeriving;
+using MonoGameGum.GueDeriving;
 #else
-using Gum.GueDeriving;
+using MonoGameGum.GueDeriving;
 #endif
 using Gum.Forms.Controls;
 namespace Gum.Forms.DefaultVisuals;

--- a/MonoGameGum/Forms/DefaultVisuals/MenuItemVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/MenuItemVisual.cs
@@ -1,9 +1,10 @@
-﻿using Gum.Converters;
+#pragma warning disable CS0618, GUM001 // Default visuals intentionally use deprecated MonoGameGum.GueDeriving shim types for backward compatibility until V1/V2/V3 visuals are retired. See issue #2715.
+using Gum.Converters;
 using Gum.DataTypes.Variables;
 using Gum.Wireframe;
 using Gum.Forms.Controls;
 using Microsoft.Xna.Framework;
-using Gum.GueDeriving;
+using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System;
 using System.Collections.Generic;

--- a/MonoGameGum/Forms/DefaultVisuals/MenuItemVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/MenuItemVisual.cs
@@ -4,7 +4,11 @@ using Gum.DataTypes.Variables;
 using Gum.Wireframe;
 using Gum.Forms.Controls;
 using Microsoft.Xna.Framework;
+#if XNALIKE
 using MonoGameGum.GueDeriving;
+#else
+using Gum.GueDeriving;
+#endif
 using RenderingLibrary.Graphics;
 using System;
 using System.Collections.Generic;

--- a/MonoGameGum/Forms/DefaultVisuals/MenuVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/MenuVisual.cs
@@ -1,8 +1,9 @@
-﻿using Gum.Converters;
+#pragma warning disable CS0618, GUM001 // Default visuals intentionally use deprecated MonoGameGum.GueDeriving shim types for backward compatibility until V1/V2/V3 visuals are retired. See issue #2715.
+using Gum.Converters;
 using Gum.DataTypes.Variables;
 using Gum.Wireframe;
 using Gum.Forms.Controls;
-using Gum.GueDeriving;
+using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System;
 using System.Collections.Generic;

--- a/MonoGameGum/Forms/DefaultVisuals/MenuVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/MenuVisual.cs
@@ -3,7 +3,11 @@ using Gum.Converters;
 using Gum.DataTypes.Variables;
 using Gum.Wireframe;
 using Gum.Forms.Controls;
+#if XNALIKE
 using MonoGameGum.GueDeriving;
+#else
+using Gum.GueDeriving;
+#endif
 using RenderingLibrary.Graphics;
 using System;
 using System.Collections.Generic;

--- a/MonoGameGum/Forms/DefaultVisuals/RadioButtonVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/RadioButtonVisual.cs
@@ -1,4 +1,5 @@
-﻿using Gum.Converters;
+#pragma warning disable CS0618, GUM001 // Default visuals intentionally use deprecated MonoGameGum.GueDeriving shim types for backward compatibility until V1/V2/V3 visuals are retired. See issue #2715.
+using Gum.Converters;
 using Gum.DataTypes.Variables;
 using Gum.Wireframe;
 using RenderingLibrary;
@@ -13,9 +14,9 @@ using System.Threading.Tasks;
 
 #if XNALIKE
 using Microsoft.Xna.Framework;
-using Gum.GueDeriving;
+using MonoGameGum.GueDeriving;
 #else
-using Gum.GueDeriving;
+using MonoGameGum.GueDeriving;
 #endif
 
 using Gum.Forms.Controls;

--- a/MonoGameGum/Forms/DefaultVisuals/RadioButtonVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/RadioButtonVisual.cs
@@ -14,9 +14,17 @@ using System.Threading.Tasks;
 
 #if XNALIKE
 using Microsoft.Xna.Framework;
+#if XNALIKE
 using MonoGameGum.GueDeriving;
 #else
+using Gum.GueDeriving;
+#endif
+#else
+#if XNALIKE
 using MonoGameGum.GueDeriving;
+#else
+using Gum.GueDeriving;
+#endif
 #endif
 
 using Gum.Forms.Controls;

--- a/MonoGameGum/Forms/DefaultVisuals/ScrollBarVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/ScrollBarVisual.cs
@@ -1,4 +1,5 @@
-﻿using Gum.Converters;
+#pragma warning disable CS0618, GUM001 // Default visuals intentionally use deprecated MonoGameGum.GueDeriving shim types for backward compatibility until V1/V2/V3 visuals are retired. See issue #2715.
+using Gum.Converters;
 using Gum.Wireframe;
 using RenderingLibrary.Graphics;
 using System;
@@ -15,9 +16,9 @@ using Gum.DataTypes;
 #if XNALIKE
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
-using Gum.GueDeriving;
+using MonoGameGum.GueDeriving;
 #else
-using Gum.GueDeriving;
+using MonoGameGum.GueDeriving;
 #endif
 
 using Gum.Forms.Controls;

--- a/MonoGameGum/Forms/DefaultVisuals/ScrollBarVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/ScrollBarVisual.cs
@@ -16,9 +16,17 @@ using Gum.DataTypes;
 #if XNALIKE
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
+#if XNALIKE
 using MonoGameGum.GueDeriving;
 #else
+using Gum.GueDeriving;
+#endif
+#else
+#if XNALIKE
 using MonoGameGum.GueDeriving;
+#else
+using Gum.GueDeriving;
+#endif
 #endif
 
 using Gum.Forms.Controls;

--- a/MonoGameGum/Forms/DefaultVisuals/ScrollViewerVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/ScrollViewerVisual.cs
@@ -1,4 +1,5 @@
-﻿using Gum.Converters;
+#pragma warning disable CS0618, GUM001 // Default visuals intentionally use deprecated MonoGameGum.GueDeriving shim types for backward compatibility until V1/V2/V3 visuals are retired. See issue #2715.
+using Gum.Converters;
 using Gum.DataTypes.Variables;
 using Gum.Wireframe;
 using RenderingLibrary.Graphics;
@@ -11,9 +12,9 @@ using System.Threading.Tasks;
 
 #if XNALIKE
 using Microsoft.Xna.Framework.Graphics;
-using Gum.GueDeriving;
+using MonoGameGum.GueDeriving;
 #else
-using Gum.GueDeriving;
+using MonoGameGum.GueDeriving;
 #endif
 using Gum.Forms.Controls;
 namespace Gum.Forms.DefaultVisuals;

--- a/MonoGameGum/Forms/DefaultVisuals/ScrollViewerVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/ScrollViewerVisual.cs
@@ -12,9 +12,17 @@ using System.Threading.Tasks;
 
 #if XNALIKE
 using Microsoft.Xna.Framework.Graphics;
+#if XNALIKE
 using MonoGameGum.GueDeriving;
 #else
+using Gum.GueDeriving;
+#endif
+#else
+#if XNALIKE
 using MonoGameGum.GueDeriving;
+#else
+using Gum.GueDeriving;
+#endif
 #endif
 using Gum.Forms.Controls;
 namespace Gum.Forms.DefaultVisuals;

--- a/MonoGameGum/Forms/DefaultVisuals/SliderVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/SliderVisual.cs
@@ -1,4 +1,5 @@
-﻿using Gum.Converters;
+#pragma warning disable CS0618, GUM001 // Default visuals intentionally use deprecated MonoGameGum.GueDeriving shim types for backward compatibility until V1/V2/V3 visuals are retired. See issue #2715.
+using Gum.Converters;
 using Gum.DataTypes.Variables;
 using Gum.Wireframe;
 using RenderingLibrary.Graphics;
@@ -10,9 +11,9 @@ using System.Threading.Tasks;
 
 #if XNALIKE
 using Microsoft.Xna.Framework;
-using Gum.GueDeriving;
+using MonoGameGum.GueDeriving;
 #else
-using Gum.GueDeriving;
+using MonoGameGum.GueDeriving;
 #endif
 using Gum.Forms.Controls;
 namespace Gum.Forms.DefaultVisuals;

--- a/MonoGameGum/Forms/DefaultVisuals/SliderVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/SliderVisual.cs
@@ -11,9 +11,17 @@ using System.Threading.Tasks;
 
 #if XNALIKE
 using Microsoft.Xna.Framework;
+#if XNALIKE
 using MonoGameGum.GueDeriving;
 #else
+using Gum.GueDeriving;
+#endif
+#else
+#if XNALIKE
 using MonoGameGum.GueDeriving;
+#else
+using Gum.GueDeriving;
+#endif
 #endif
 using Gum.Forms.Controls;
 namespace Gum.Forms.DefaultVisuals;

--- a/MonoGameGum/Forms/DefaultVisuals/SplitterVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/SplitterVisual.cs
@@ -9,9 +9,17 @@ using System.Text;
 using System.Threading.Tasks;
 
 #if XNALIKE
+#if XNALIKE
 using MonoGameGum.GueDeriving;
 #else
+using Gum.GueDeriving;
+#endif
+#else
+#if XNALIKE
 using MonoGameGum.GueDeriving;
+#else
+using Gum.GueDeriving;
+#endif
 #endif
 using Gum.Forms.Controls;
 namespace Gum.Forms.DefaultVisuals;

--- a/MonoGameGum/Forms/DefaultVisuals/SplitterVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/SplitterVisual.cs
@@ -1,4 +1,5 @@
-﻿using Gum.Wireframe;
+#pragma warning disable CS0618, GUM001 // Default visuals intentionally use deprecated MonoGameGum.GueDeriving shim types for backward compatibility until V1/V2/V3 visuals are retired. See issue #2715.
+using Gum.Wireframe;
 
 using RenderingLibrary.Graphics;
 using System;
@@ -8,9 +9,9 @@ using System.Text;
 using System.Threading.Tasks;
 
 #if XNALIKE
-using Gum.GueDeriving;
+using MonoGameGum.GueDeriving;
 #else
-using Gum.GueDeriving;
+using MonoGameGum.GueDeriving;
 #endif
 using Gum.Forms.Controls;
 namespace Gum.Forms.DefaultVisuals;

--- a/MonoGameGum/Forms/DefaultVisuals/TextBoxBaseVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/TextBoxBaseVisual.cs
@@ -1,10 +1,11 @@
-﻿using Gum.Converters;
+#pragma warning disable CS0618, GUM001 // Default visuals intentionally use deprecated MonoGameGum.GueDeriving shim types for backward compatibility until V1/V2/V3 visuals are retired. See issue #2715.
+using Gum.Converters;
 using Gum.DataTypes.Variables;
 using Gum.Wireframe;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Gum.Forms.Controls;
-using Gum.GueDeriving;
+using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 
 

--- a/MonoGameGum/Forms/DefaultVisuals/TextBoxBaseVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/TextBoxBaseVisual.cs
@@ -5,7 +5,11 @@ using Gum.Wireframe;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Gum.Forms.Controls;
+#if XNALIKE
 using MonoGameGum.GueDeriving;
+#else
+using Gum.GueDeriving;
+#endif
 using RenderingLibrary.Graphics;
 
 

--- a/MonoGameGum/Forms/DefaultVisuals/V3/ButtonVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/V3/ButtonVisual.cs
@@ -1,4 +1,5 @@
-﻿using Gum.DataTypes.Variables;
+#pragma warning disable CS0618, GUM001 // Default visuals intentionally use deprecated MonoGameGum.GueDeriving shim types for backward compatibility until V1/V2/V3 visuals are retired. See issue #2715.
+using Gum.DataTypes.Variables;
 using Gum.Wireframe;
 using RenderingLibrary;
 using RenderingLibrary.Graphics;
@@ -7,10 +8,10 @@ using RenderingLibrary.Graphics;
 
 #if XNALIKE
 using Microsoft.Xna.Framework;
-using Gum.GueDeriving;
+using MonoGameGum.GueDeriving;
 using Microsoft.Xna.Framework.Graphics;
 #else
-using Gum.GueDeriving;
+using MonoGameGum.GueDeriving;
 #endif
 using Gum.Forms.Controls;
 namespace Gum.Forms.DefaultVisuals.V3;

--- a/MonoGameGum/Forms/DefaultVisuals/V3/ButtonVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/V3/ButtonVisual.cs
@@ -11,7 +11,7 @@ using Microsoft.Xna.Framework;
 using MonoGameGum.GueDeriving;
 using Microsoft.Xna.Framework.Graphics;
 #else
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 #endif
 using Gum.Forms.Controls;
 namespace Gum.Forms.DefaultVisuals.V3;

--- a/MonoGameGum/Forms/DefaultVisuals/V3/CheckBoxVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/V3/CheckBoxVisual.cs
@@ -13,10 +13,18 @@ using System.Threading.Tasks;
 #if XNALIKE
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
+#if XNALIKE
 using MonoGameGum.GueDeriving;
+#else
+using Gum.GueDeriving;
+#endif
 using RenderingLibrary.Math.Geometry;
 #else
+#if XNALIKE
 using MonoGameGum.GueDeriving;
+#else
+using Gum.GueDeriving;
+#endif
 #endif
 using Gum.Forms.Controls;
 namespace Gum.Forms.DefaultVisuals.V3;

--- a/MonoGameGum/Forms/DefaultVisuals/V3/CheckBoxVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/V3/CheckBoxVisual.cs
@@ -1,4 +1,5 @@
-﻿using Gum.DataTypes.Variables;
+#pragma warning disable CS0618, GUM001 // Default visuals intentionally use deprecated MonoGameGum.GueDeriving shim types for backward compatibility until V1/V2/V3 visuals are retired. See issue #2715.
+using Gum.DataTypes.Variables;
 using Gum.Wireframe;
 using RenderingLibrary.Graphics;
 using System;
@@ -12,10 +13,10 @@ using System.Threading.Tasks;
 #if XNALIKE
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
-using Gum.GueDeriving;
+using MonoGameGum.GueDeriving;
 using RenderingLibrary.Math.Geometry;
 #else
-using Gum.GueDeriving;
+using MonoGameGum.GueDeriving;
 #endif
 using Gum.Forms.Controls;
 namespace Gum.Forms.DefaultVisuals.V3;

--- a/MonoGameGum/Forms/DefaultVisuals/V3/ComboBoxVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/V3/ComboBoxVisual.cs
@@ -1,4 +1,5 @@
-﻿using Gum.Converters;
+#pragma warning disable CS0618, GUM001 // Default visuals intentionally use deprecated MonoGameGum.GueDeriving shim types for backward compatibility until V1/V2/V3 visuals are retired. See issue #2715.
+using Gum.Converters;
 using Gum.DataTypes.Variables;
 using Gum.Wireframe;
 
@@ -12,9 +13,9 @@ using System.Threading.Tasks;
 #if XNALIKE
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
-using Gum.GueDeriving;
+using MonoGameGum.GueDeriving;
 #else
-using Gum.GueDeriving;
+using MonoGameGum.GueDeriving;
 #endif
 using Gum.Forms.Controls;
 namespace Gum.Forms.DefaultVisuals.V3;

--- a/MonoGameGum/Forms/DefaultVisuals/V3/ComboBoxVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/V3/ComboBoxVisual.cs
@@ -13,9 +13,17 @@ using System.Threading.Tasks;
 #if XNALIKE
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
+#if XNALIKE
 using MonoGameGum.GueDeriving;
 #else
+using Gum.GueDeriving;
+#endif
+#else
+#if XNALIKE
 using MonoGameGum.GueDeriving;
+#else
+using Gum.GueDeriving;
+#endif
 #endif
 using Gum.Forms.Controls;
 namespace Gum.Forms.DefaultVisuals.V3;

--- a/MonoGameGum/Forms/DefaultVisuals/V3/DialogBoxVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/V3/DialogBoxVisual.cs
@@ -7,9 +7,17 @@ using RenderingLibrary.Graphics;
 
 #if XNALIKE
 using Microsoft.Xna.Framework;
+#if XNALIKE
 using MonoGameGum.GueDeriving;
 #else
+using Gum.GueDeriving;
+#endif
+#else
+#if XNALIKE
 using MonoGameGum.GueDeriving;
+#else
+using Gum.GueDeriving;
+#endif
 #endif
 
 namespace Gum.Forms.DefaultVisuals.V3;

--- a/MonoGameGum/Forms/DefaultVisuals/V3/DialogBoxVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/V3/DialogBoxVisual.cs
@@ -1,3 +1,4 @@
+#pragma warning disable CS0618, GUM001 // Default visuals intentionally use deprecated MonoGameGum.GueDeriving shim types for backward compatibility until V1/V2/V3 visuals are retired. See issue #2715.
 using Gum.DataTypes.Variables;
 using Gum.Forms.Controls.Games;
 using Gum.Wireframe;
@@ -6,9 +7,9 @@ using RenderingLibrary.Graphics;
 
 #if XNALIKE
 using Microsoft.Xna.Framework;
-using Gum.GueDeriving;
+using MonoGameGum.GueDeriving;
 #else
-using Gum.GueDeriving;
+using MonoGameGum.GueDeriving;
 #endif
 
 namespace Gum.Forms.DefaultVisuals.V3;

--- a/MonoGameGum/Forms/DefaultVisuals/V3/LabelVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/V3/LabelVisual.cs
@@ -4,10 +4,18 @@ using RenderingLibrary.Graphics;
 
 
 #if XNALIKE
+#if XNALIKE
 using MonoGameGum.GueDeriving;
+#else
+using Gum.GueDeriving;
+#endif
 using Microsoft.Xna.Framework;
 #else
+#if XNALIKE
 using MonoGameGum.GueDeriving;
+#else
+using Gum.GueDeriving;
+#endif
 #endif
 using Gum.Forms.Controls;
 namespace Gum.Forms.DefaultVisuals.V3;

--- a/MonoGameGum/Forms/DefaultVisuals/V3/LabelVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/V3/LabelVisual.cs
@@ -1,12 +1,13 @@
-﻿using Gum.Wireframe;
+#pragma warning disable CS0618, GUM001 // Default visuals intentionally use deprecated MonoGameGum.GueDeriving shim types for backward compatibility until V1/V2/V3 visuals are retired. See issue #2715.
+using Gum.Wireframe;
 using RenderingLibrary.Graphics;
 
 
 #if XNALIKE
-using Gum.GueDeriving;
+using MonoGameGum.GueDeriving;
 using Microsoft.Xna.Framework;
 #else
-using Gum.GueDeriving;
+using MonoGameGum.GueDeriving;
 #endif
 using Gum.Forms.Controls;
 namespace Gum.Forms.DefaultVisuals.V3;

--- a/MonoGameGum/Forms/DefaultVisuals/V3/ListBoxItemVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/V3/ListBoxItemVisual.cs
@@ -13,9 +13,17 @@ using System.Threading.Tasks;
 #if XNALIKE
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
+#if XNALIKE
 using MonoGameGum.GueDeriving;
 #else
+using Gum.GueDeriving;
+#endif
+#else
+#if XNALIKE
 using MonoGameGum.GueDeriving;
+#else
+using Gum.GueDeriving;
+#endif
 #endif
 using Gum.Forms.Controls;
 namespace Gum.Forms.DefaultVisuals.V3;

--- a/MonoGameGum/Forms/DefaultVisuals/V3/ListBoxItemVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/V3/ListBoxItemVisual.cs
@@ -1,4 +1,5 @@
-﻿using Gum.Converters;
+#pragma warning disable CS0618, GUM001 // Default visuals intentionally use deprecated MonoGameGum.GueDeriving shim types for backward compatibility until V1/V2/V3 visuals are retired. See issue #2715.
+using Gum.Converters;
 using Gum.DataTypes.Variables;
 using Gum.Wireframe;
 using RenderingLibrary.Graphics;
@@ -12,9 +13,9 @@ using System.Threading.Tasks;
 #if XNALIKE
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
-using Gum.GueDeriving;
+using MonoGameGum.GueDeriving;
 #else
-using Gum.GueDeriving;
+using MonoGameGum.GueDeriving;
 #endif
 using Gum.Forms.Controls;
 namespace Gum.Forms.DefaultVisuals.V3;

--- a/MonoGameGum/Forms/DefaultVisuals/V3/ListBoxVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/V3/ListBoxVisual.cs
@@ -12,9 +12,17 @@ using System.Threading.Tasks;
 #if XNALIKE
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
+#if XNALIKE
 using MonoGameGum.GueDeriving;
 #else
+using Gum.GueDeriving;
+#endif
+#else
+#if XNALIKE
 using MonoGameGum.GueDeriving;
+#else
+using Gum.GueDeriving;
+#endif
 #endif
 using Gum.Forms.Controls;
 namespace Gum.Forms.DefaultVisuals.V3;

--- a/MonoGameGum/Forms/DefaultVisuals/V3/ListBoxVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/V3/ListBoxVisual.cs
@@ -1,4 +1,5 @@
-﻿using Gum.Converters;
+#pragma warning disable CS0618, GUM001 // Default visuals intentionally use deprecated MonoGameGum.GueDeriving shim types for backward compatibility until V1/V2/V3 visuals are retired. See issue #2715.
+using Gum.Converters;
 using Gum.DataTypes.Variables;
 using Gum.Wireframe;
 using RenderingLibrary.Graphics;
@@ -11,9 +12,9 @@ using System.Threading.Tasks;
 #if XNALIKE
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
-using Gum.GueDeriving;
+using MonoGameGum.GueDeriving;
 #else
-using Gum.GueDeriving;
+using MonoGameGum.GueDeriving;
 #endif
 using Gum.Forms.Controls;
 namespace Gum.Forms.DefaultVisuals.V3;

--- a/MonoGameGum/Forms/DefaultVisuals/V3/MenuItemVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/V3/MenuItemVisual.cs
@@ -1,8 +1,9 @@
-﻿using Gum.Converters;
+#pragma warning disable CS0618, GUM001 // Default visuals intentionally use deprecated MonoGameGum.GueDeriving shim types for backward compatibility until V1/V2/V3 visuals are retired. See issue #2715.
+using Gum.Converters;
 using Gum.DataTypes.Variables;
 using Gum.Wireframe;
 using Gum.Forms.Controls;
-using Gum.GueDeriving;
+using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System;
 using System.Collections.Generic;

--- a/MonoGameGum/Forms/DefaultVisuals/V3/MenuItemVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/V3/MenuItemVisual.cs
@@ -3,7 +3,11 @@ using Gum.Converters;
 using Gum.DataTypes.Variables;
 using Gum.Wireframe;
 using Gum.Forms.Controls;
+#if XNALIKE
 using MonoGameGum.GueDeriving;
+#else
+using Gum.GueDeriving;
+#endif
 using RenderingLibrary.Graphics;
 using System;
 using System.Collections.Generic;

--- a/MonoGameGum/Forms/DefaultVisuals/V3/MenuVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/V3/MenuVisual.cs
@@ -1,8 +1,9 @@
-﻿using Gum.Converters;
+#pragma warning disable CS0618, GUM001 // Default visuals intentionally use deprecated MonoGameGum.GueDeriving shim types for backward compatibility until V1/V2/V3 visuals are retired. See issue #2715.
+using Gum.Converters;
 using Gum.DataTypes.Variables;
 using Gum.Wireframe;
 using Gum.Forms.Controls;
-using Gum.GueDeriving;
+using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System;
 using System.Collections.Generic;

--- a/MonoGameGum/Forms/DefaultVisuals/V3/MenuVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/V3/MenuVisual.cs
@@ -3,7 +3,11 @@ using Gum.Converters;
 using Gum.DataTypes.Variables;
 using Gum.Wireframe;
 using Gum.Forms.Controls;
+#if XNALIKE
 using MonoGameGum.GueDeriving;
+#else
+using Gum.GueDeriving;
+#endif
 using RenderingLibrary.Graphics;
 using System;
 using System.Collections.Generic;

--- a/MonoGameGum/Forms/DefaultVisuals/V3/RadioButtonVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/V3/RadioButtonVisual.cs
@@ -1,4 +1,5 @@
-﻿using Gum.Converters;
+#pragma warning disable CS0618, GUM001 // Default visuals intentionally use deprecated MonoGameGum.GueDeriving shim types for backward compatibility until V1/V2/V3 visuals are retired. See issue #2715.
+using Gum.Converters;
 using Gum.DataTypes.Variables;
 using Gum.Wireframe;
 using RenderingLibrary;
@@ -13,9 +14,9 @@ using System.Threading.Tasks;
 
 #if XNALIKE
 using Microsoft.Xna.Framework;
-using Gum.GueDeriving;
+using MonoGameGum.GueDeriving;
 #else
-using Gum.GueDeriving;
+using MonoGameGum.GueDeriving;
 #endif
 
 using Gum.Forms.Controls;

--- a/MonoGameGum/Forms/DefaultVisuals/V3/RadioButtonVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/V3/RadioButtonVisual.cs
@@ -14,9 +14,17 @@ using System.Threading.Tasks;
 
 #if XNALIKE
 using Microsoft.Xna.Framework;
+#if XNALIKE
 using MonoGameGum.GueDeriving;
 #else
+using Gum.GueDeriving;
+#endif
+#else
+#if XNALIKE
 using MonoGameGum.GueDeriving;
+#else
+using Gum.GueDeriving;
+#endif
 #endif
 
 using Gum.Forms.Controls;

--- a/MonoGameGum/Forms/DefaultVisuals/V3/ScrollBarVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/V3/ScrollBarVisual.cs
@@ -1,4 +1,5 @@
-﻿using Gum.Converters;
+#pragma warning disable CS0618, GUM001 // Default visuals intentionally use deprecated MonoGameGum.GueDeriving shim types for backward compatibility until V1/V2/V3 visuals are retired. See issue #2715.
+using Gum.Converters;
 using Gum.Wireframe;
 using RenderingLibrary.Graphics;
 using System;
@@ -15,9 +16,9 @@ using Gum.DataTypes;
 #if XNALIKE
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
-using Gum.GueDeriving;
+using MonoGameGum.GueDeriving;
 #else
-using Gum.GueDeriving;
+using MonoGameGum.GueDeriving;
 #endif
 
 using Gum.Forms.Controls;

--- a/MonoGameGum/Forms/DefaultVisuals/V3/ScrollBarVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/V3/ScrollBarVisual.cs
@@ -16,9 +16,17 @@ using Gum.DataTypes;
 #if XNALIKE
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
+#if XNALIKE
 using MonoGameGum.GueDeriving;
 #else
+using Gum.GueDeriving;
+#endif
+#else
+#if XNALIKE
 using MonoGameGum.GueDeriving;
+#else
+using Gum.GueDeriving;
+#endif
 #endif
 
 using Gum.Forms.Controls;

--- a/MonoGameGum/Forms/DefaultVisuals/V3/ScrollViewerVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/V3/ScrollViewerVisual.cs
@@ -14,9 +14,17 @@ using System.Threading.Tasks;
 #if XNALIKE
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
+#if XNALIKE
 using MonoGameGum.GueDeriving;
 #else
+using Gum.GueDeriving;
+#endif
+#else
+#if XNALIKE
 using MonoGameGum.GueDeriving;
+#else
+using Gum.GueDeriving;
+#endif
 #endif
 using Gum.Forms.Controls;
 namespace Gum.Forms.DefaultVisuals.V3;

--- a/MonoGameGum/Forms/DefaultVisuals/V3/ScrollViewerVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/V3/ScrollViewerVisual.cs
@@ -1,4 +1,5 @@
-﻿using Gum.Converters;
+#pragma warning disable CS0618, GUM001 // Default visuals intentionally use deprecated MonoGameGum.GueDeriving shim types for backward compatibility until V1/V2/V3 visuals are retired. See issue #2715.
+using Gum.Converters;
 using Gum.DataTypes.Variables;
 using Gum.Wireframe;
 using RenderingLibrary.Graphics;
@@ -13,9 +14,9 @@ using System.Threading.Tasks;
 #if XNALIKE
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
-using Gum.GueDeriving;
+using MonoGameGum.GueDeriving;
 #else
-using Gum.GueDeriving;
+using MonoGameGum.GueDeriving;
 #endif
 using Gum.Forms.Controls;
 namespace Gum.Forms.DefaultVisuals.V3;

--- a/MonoGameGum/Forms/DefaultVisuals/V3/SliderVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/V3/SliderVisual.cs
@@ -1,4 +1,5 @@
-﻿using Gum.Converters;
+#pragma warning disable CS0618, GUM001 // Default visuals intentionally use deprecated MonoGameGum.GueDeriving shim types for backward compatibility until V1/V2/V3 visuals are retired. See issue #2715.
+using Gum.Converters;
 using Gum.DataTypes.Variables;
 using Gum.Wireframe;
 using RenderingLibrary.Graphics;
@@ -10,9 +11,9 @@ using System.Threading.Tasks;
 
 #if XNALIKE
 using Microsoft.Xna.Framework;
-using Gum.GueDeriving;
+using MonoGameGum.GueDeriving;
 #else
-using Gum.GueDeriving;
+using MonoGameGum.GueDeriving;
 #endif
 using Gum.Forms.Controls;
 namespace Gum.Forms.DefaultVisuals.V3;

--- a/MonoGameGum/Forms/DefaultVisuals/V3/SliderVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/V3/SliderVisual.cs
@@ -11,9 +11,17 @@ using System.Threading.Tasks;
 
 #if XNALIKE
 using Microsoft.Xna.Framework;
+#if XNALIKE
 using MonoGameGum.GueDeriving;
 #else
+using Gum.GueDeriving;
+#endif
+#else
+#if XNALIKE
 using MonoGameGum.GueDeriving;
+#else
+using Gum.GueDeriving;
+#endif
 #endif
 using Gum.Forms.Controls;
 namespace Gum.Forms.DefaultVisuals.V3;

--- a/MonoGameGum/Forms/DefaultVisuals/V3/SplitterVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/V3/SplitterVisual.cs
@@ -1,4 +1,5 @@
-﻿using Gum.Wireframe;
+#pragma warning disable CS0618, GUM001 // Default visuals intentionally use deprecated MonoGameGum.GueDeriving shim types for backward compatibility until V1/V2/V3 visuals are retired. See issue #2715.
+using Gum.Wireframe;
 
 using RenderingLibrary.Graphics;
 using System;
@@ -10,9 +11,9 @@ using System.Threading.Tasks;
 
 #if XNALIKE
 using Microsoft.Xna.Framework;
-using Gum.GueDeriving;
+using MonoGameGum.GueDeriving;
 #else
-using Gum.GueDeriving;
+using MonoGameGum.GueDeriving;
 #endif
 using Gum.Forms.Controls;
 namespace Gum.Forms.DefaultVisuals.V3;

--- a/MonoGameGum/Forms/DefaultVisuals/V3/SplitterVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/V3/SplitterVisual.cs
@@ -11,9 +11,17 @@ using System.Threading.Tasks;
 
 #if XNALIKE
 using Microsoft.Xna.Framework;
+#if XNALIKE
 using MonoGameGum.GueDeriving;
 #else
+using Gum.GueDeriving;
+#endif
+#else
+#if XNALIKE
 using MonoGameGum.GueDeriving;
+#else
+using Gum.GueDeriving;
+#endif
 #endif
 using Gum.Forms.Controls;
 namespace Gum.Forms.DefaultVisuals.V3;

--- a/MonoGameGum/Forms/DefaultVisuals/V3/TextBoxBaseVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/V3/TextBoxBaseVisual.cs
@@ -1,4 +1,5 @@
-﻿using Gum.Converters;
+#pragma warning disable CS0618, GUM001 // Default visuals intentionally use deprecated MonoGameGum.GueDeriving shim types for backward compatibility until V1/V2/V3 visuals are retired. See issue #2715.
+using Gum.Converters;
 using Gum.DataTypes;
 using Gum.DataTypes.Variables;
 using Gum.Wireframe;
@@ -8,10 +9,10 @@ using System;
 
 
 #if XNALIKE
-using Gum.GueDeriving;
+using MonoGameGum.GueDeriving;
 using Microsoft.Xna.Framework;
 #else
-using Gum.GueDeriving;
+using MonoGameGum.GueDeriving;
 #endif
 
 

--- a/MonoGameGum/Forms/DefaultVisuals/V3/TextBoxBaseVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/V3/TextBoxBaseVisual.cs
@@ -9,10 +9,18 @@ using System;
 
 
 #if XNALIKE
+#if XNALIKE
 using MonoGameGum.GueDeriving;
+#else
+using Gum.GueDeriving;
+#endif
 using Microsoft.Xna.Framework;
 #else
+#if XNALIKE
 using MonoGameGum.GueDeriving;
+#else
+using Gum.GueDeriving;
+#endif
 #endif
 
 

--- a/MonoGameGum/Forms/DefaultVisuals/V3/ToggleButtonVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/V3/ToggleButtonVisual.cs
@@ -12,7 +12,7 @@ using Microsoft.Xna.Framework;
 using MonoGameGum.GueDeriving;
 using Microsoft.Xna.Framework.Graphics;
 #else
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 #endif
 using Gum.Forms.Controls;
 namespace Gum.Forms.DefaultVisuals.V3;

--- a/MonoGameGum/Forms/DefaultVisuals/V3/ToggleButtonVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/V3/ToggleButtonVisual.cs
@@ -1,3 +1,4 @@
+#pragma warning disable CS0618, GUM001 // Default visuals intentionally use deprecated MonoGameGum.GueDeriving shim types for backward compatibility until V1/V2/V3 visuals are retired. See issue #2715.
 using System;
 using Gum.DataTypes.Variables;
 using Gum.Wireframe;
@@ -8,10 +9,10 @@ using RenderingLibrary.Graphics;
 
 #if XNALIKE
 using Microsoft.Xna.Framework;
-using Gum.GueDeriving;
+using MonoGameGum.GueDeriving;
 using Microsoft.Xna.Framework.Graphics;
 #else
-using Gum.GueDeriving;
+using MonoGameGum.GueDeriving;
 #endif
 using Gum.Forms.Controls;
 namespace Gum.Forms.DefaultVisuals.V3;

--- a/MonoGameGum/Forms/DefaultVisuals/V3/TooltipVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/V3/TooltipVisual.cs
@@ -1,3 +1,4 @@
+#pragma warning disable CS0618, GUM001 // Default visuals intentionally use deprecated MonoGameGum.GueDeriving shim types for backward compatibility until V1/V2/V3 visuals are retired. See issue #2715.
 using Gum.DataTypes.Variables;
 using Gum.Wireframe;
 using RenderingLibrary;
@@ -6,10 +7,10 @@ using RenderingLibrary.Graphics;
 
 #if XNALIKE
 using Microsoft.Xna.Framework;
-using Gum.GueDeriving;
+using MonoGameGum.GueDeriving;
 using Microsoft.Xna.Framework.Graphics;
 #else
-using Gum.GueDeriving;
+using MonoGameGum.GueDeriving;
 #endif
 using Gum.Forms.Controls;
 namespace Gum.Forms.DefaultVisuals.V3;

--- a/MonoGameGum/Forms/DefaultVisuals/V3/TooltipVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/V3/TooltipVisual.cs
@@ -10,7 +10,7 @@ using Microsoft.Xna.Framework;
 using MonoGameGum.GueDeriving;
 using Microsoft.Xna.Framework.Graphics;
 #else
-using MonoGameGum.GueDeriving;
+using Gum.GueDeriving;
 #endif
 using Gum.Forms.Controls;
 namespace Gum.Forms.DefaultVisuals.V3;

--- a/MonoGameGum/Forms/DefaultVisuals/V3/WindowVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/V3/WindowVisual.cs
@@ -1,4 +1,5 @@
-﻿using Gum.Wireframe;
+#pragma warning disable CS0618, GUM001 // Default visuals intentionally use deprecated MonoGameGum.GueDeriving shim types for backward compatibility until V1/V2/V3 visuals are retired. See issue #2715.
+using Gum.Wireframe;
 
 using RenderingLibrary.Graphics;
 using System;
@@ -10,10 +11,10 @@ using System.Threading.Tasks;
 
 #if XNALIKE
 using MonoGameGum;
-using Gum.GueDeriving;
+using MonoGameGum.GueDeriving;
 using Microsoft.Xna.Framework;
 #else
-using Gum.GueDeriving;
+using MonoGameGum.GueDeriving;
 #endif
 using Gum.Forms.Controls;
 

--- a/MonoGameGum/Forms/DefaultVisuals/V3/WindowVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/V3/WindowVisual.cs
@@ -11,10 +11,18 @@ using System.Threading.Tasks;
 
 #if XNALIKE
 using MonoGameGum;
+#if XNALIKE
 using MonoGameGum.GueDeriving;
+#else
+using Gum.GueDeriving;
+#endif
 using Microsoft.Xna.Framework;
 #else
+#if XNALIKE
 using MonoGameGum.GueDeriving;
+#else
+using Gum.GueDeriving;
+#endif
 #endif
 using Gum.Forms.Controls;
 

--- a/MonoGameGum/Forms/DefaultVisuals/WindowVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/WindowVisual.cs
@@ -10,9 +10,17 @@ using System.Threading.Tasks;
 
 #if XNALIKE
 using MonoGameGum;
+#if XNALIKE
 using MonoGameGum.GueDeriving;
 #else
+using Gum.GueDeriving;
+#endif
+#else
+#if XNALIKE
 using MonoGameGum.GueDeriving;
+#else
+using Gum.GueDeriving;
+#endif
 #endif
 using Gum.Forms.Controls;
 using Styling = Gum.Forms.DefaultVisuals.Styling;

--- a/MonoGameGum/Forms/DefaultVisuals/WindowVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/WindowVisual.cs
@@ -1,4 +1,5 @@
-﻿using Gum.Wireframe;
+#pragma warning disable CS0618, GUM001 // Default visuals intentionally use deprecated MonoGameGum.GueDeriving shim types for backward compatibility until V1/V2/V3 visuals are retired. See issue #2715.
+using Gum.Wireframe;
 
 using RenderingLibrary.Graphics;
 using System;
@@ -9,9 +10,9 @@ using System.Threading.Tasks;
 
 #if XNALIKE
 using MonoGameGum;
-using Gum.GueDeriving;
+using MonoGameGum.GueDeriving;
 #else
-using Gum.GueDeriving;
+using MonoGameGum.GueDeriving;
 #endif
 using Gum.Forms.Controls;
 using Styling = Gum.Forms.DefaultVisuals.Styling;

--- a/Tests/MonoGameGum.Tests.V2/Forms/DefaultVisualShimTypeTests.cs
+++ b/Tests/MonoGameGum.Tests.V2/Forms/DefaultVisualShimTypeTests.cs
@@ -1,0 +1,31 @@
+using Gum.Forms.DefaultVisuals;
+using Shouldly;
+
+namespace MonoGameGum.Tests.V2.Forms;
+
+/// <summary>
+/// V1/V2 default visuals must continue to expose their child runtimes as the
+/// deprecated <c>MonoGameGum.GueDeriving</c> shim types so user code that captures
+/// those properties into shim-typed variables keeps compiling. See issue #2715.
+/// </summary>
+public class DefaultVisualShimTypeTests : BaseTestClass
+{
+    [Fact]
+    public void V1_DefaultButtonRuntime_TextInstance_ShouldBeShimType()
+    {
+        var sut = new MonoGameGum.Forms.DefaultVisuals.DefaultButtonRuntime();
+#pragma warning disable CS0618
+        sut.TextInstance.ShouldBeOfType<MonoGameGum.GueDeriving.TextRuntime>();
+#pragma warning restore CS0618
+    }
+
+    [Fact]
+    public void V2_ButtonVisual_TextInstance_ShouldBeShimType()
+    {
+        var sut = new ButtonVisual();
+#pragma warning disable CS0618
+        sut.TextInstance.ShouldBeOfType<MonoGameGum.GueDeriving.TextRuntime>();
+        sut.Background.ShouldBeOfType<MonoGameGum.GueDeriving.NineSliceRuntime>();
+#pragma warning restore CS0618
+    }
+}

--- a/Tests/MonoGameGum.Tests.V3/DefaultVisualShimTypeTests.cs
+++ b/Tests/MonoGameGum.Tests.V3/DefaultVisualShimTypeTests.cs
@@ -1,0 +1,22 @@
+using Shouldly;
+using Xunit;
+
+namespace MonoGameGum.Tests.V3;
+
+/// <summary>
+/// V3 default visuals must continue to expose their child runtimes as the
+/// deprecated <c>MonoGameGum.GueDeriving</c> shim types so user code that captures
+/// those properties into shim-typed variables keeps compiling. See issue #2715.
+/// </summary>
+public class DefaultVisualShimTypeTests
+{
+    [Fact]
+    public void V3_ButtonVisual_TextInstance_ShouldBeShimType()
+    {
+        var sut = new Gum.Forms.DefaultVisuals.V3.ButtonVisual();
+#pragma warning disable CS0618
+        sut.TextInstance.ShouldBeOfType<MonoGameGum.GueDeriving.TextRuntime>();
+        sut.Background.ShouldBeOfType<MonoGameGum.GueDeriving.NineSliceRuntime>();
+#pragma warning restore CS0618
+    }
+}


### PR DESCRIPTION
## Summary
- Restores `using MonoGameGum.GueDeriving;` in all 49 V1/V2/V3 default visual files so their child runtimes (TextRuntime, NineSliceRuntime, etc.) are constructed and exposed as the deprecated shim types. Preserves source compatibility for user code that types those properties as the shim until V1/V2/V3 visuals are retired.
- Adds file-level `#pragma warning disable CS0618, GUM001` (with a comment pointing at #2715) to keep the obsolete-type and analyzer warnings out of our own builds.
- Adds shim-type assertions in `MonoGameGum.Tests.V2` (covering V1 `Default*Runtime` and V2 `*Visual`) and `MonoGameGum.Tests.V3` (covering V3 `*Visual`) on `ButtonVisual.TextInstance` / `Background` as representative checks.

Closes #2715

## Test plan
- [x] `dotnet build MonoGameGum/MonoGameGum.csproj` — clean, no new warnings in `DefaultVisuals/`
- [x] `dotnet test MonoGameGum.Tests/MonoGameGum.Tests.csproj` — 1425/1425 passing
- [x] `dotnet test Tests/MonoGameGum.Tests.V2/MonoGameGum.Tests.V2.csproj` — 88/88 passing
- [x] `dotnet test Tests/MonoGameGum.Tests.V3/MonoGameGum.Tests.V3.csproj` — 55/55 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)