### PR TITLE
Document IsAllLayoutSuspended as font-batching mechanism

### DIFF
--- a/docs/code/files-and-fonts/font-performance.md
+++ b/docs/code/files-and-fonts/font-performance.md
@@ -25,6 +25,31 @@ KernSmith rasterizes every glyph in the requested character set into an atlas. T
 
 The rule of thumb: if your charset is "everything in this language", treat each new `(font, size, style)` combination as expensive. See [Font Preloading](font-preloading.md) for moving that cost off the gameplay path.
 
+## Batching Font Property Changes
+
+Every font-related setter on a `TextRuntime` — `Font`, `FontSize`, `IsBold`, `IsItalic`, `OutlineThickness`, `UseFontSmoothing` — regenerates the font atlas immediately when it runs. Setting four of these in a row produces four full atlas generations, and three of them are immediately thrown away. With a small Latin charset this is hard to notice. With a CJK charset on KernSmith it can be a multi-second hit per setter.
+
+Attachment state does not change this. A freshly-constructed `TextRuntime` that has not been added to any parent still regenerates its atlas on every font-property setter. There is no "construct first, attach later" pattern that avoids the cost.
+
+The way to avoid this waste is to set `GraphicalUiElement.IsAllLayoutSuspended` to `true` before changing font properties, then clear it and trigger a single layout pass:
+
+```csharp
+GraphicalUiElement.IsAllLayoutSuspended = true;
+
+textRuntime.Font = "MyFont";
+textRuntime.FontSize = 32;
+textRuntime.IsBold = true;
+
+GraphicalUiElement.IsAllLayoutSuspended = false;
+textRuntime.UpdateLayout();
+```
+
+While the flag is set, the font-property setters mark the element as needing a font refresh but skip the actual atlas generation. When layout resumes, the regeneration happens once instead of once per setter.
+
+Note that this is the only mechanism that defers font atlas generation. Per-instance `SuspendLayout()` / `ResumeLayout()` defers layout calls but does **not** currently defer font atlas generation on the set-by-string path — the path used by `ApplyState`. To batch font property changes, use the global `IsAllLayoutSuspended` flag.
+
+This same flag also reduces general layout call counts; see [Measuring Layout Calls](../performance-and-optimization/measuring-layout-calls.md) for that side of the story.
+
 ## Atlas Memory Cost
 
 Each unique `(font, family, size, style, outline, smoothing)` combination produces its own atlas texture. Memory cost scales with two things:

--- a/docs/code/gum-code-reference/graphicaluielement/isalllayoutsuspended.md
+++ b/docs/code/gum-code-reference/graphicaluielement/isalllayoutsuspended.md
@@ -114,3 +114,5 @@ This results in far fewer layout calls:
 ```
 Number of layout calls: 174
 ```
+
+This flag also defers font atlas generation when font properties are set on a `TextRuntime`; see [Font Performance](../../files-and-fonts/font-performance.md) for that application.

--- a/docs/code/performance-and-optimization/measuring-layout-calls.md
+++ b/docs/code/performance-and-optimization/measuring-layout-calls.md
@@ -152,6 +152,8 @@ for(int i = 0; i &#x3C; 20; i++)
 
 <figure><img src="../../.gitbook/assets/02_08 34 32.png" alt=""><figcaption><p>Significantly reduced layout calls</p></figcaption></figure>
 
+This same flag also defers font atlas generation, which is the recommended way to batch font property changes on a `TextRuntime` — see [Font Performance](../files-and-fonts/font-performance.md) for the font-specific story.
+
 ## States and Layout Calls
 
 States can be used to set multiple variables at once. Internally Gum automatically suppresses and resumes layouts when states are applied. The following code shows how to apply states to a button. Notice that fewer layout calls are performed compared to explicitly setting each value:


### PR DESCRIPTION
## Summary

- Adds a "Batching Font Property Changes" section to `docs/code/files-and-fonts/font-performance.md` explaining that every font-property setter on a `TextRuntime` regenerates the atlas immediately (multi-second with CJK + KernSmith), that element attachment state does not change this, and that `GraphicalUiElement.IsAllLayoutSuspended` is the only mechanism that coalesces those regenerations. Includes a short C# sample and an honest note about the per-instance `SuspendLayout` gap on the set-by-string (`ApplyState`) path.
- One-line cross-links from `measuring-layout-calls.md` and `isalllayoutsuspended.md` into the new section.
- Companion to merged PR #2714 (which tightened the internals and added proving tests). This is the public-docs side of #2694.

## Test plan

- [x] Read through the new section as a first-time reader; confirm a user hitting CJK + KernSmith hitches can find and apply `IsAllLayoutSuspended` from this page alone.
- [x] Confirm wording never implies `AddToRoot` or element attachment affects font generation.
- [x] Confirm relative cross-links resolve in GitBook preview.
- [x] Verify the per-instance `SuspendLayout` gap description matches `Gum/Wireframe/CustomSetPropertyOnRenderable.cs:1309-1344`.

Closes #2694

🤖 Generated with [Claude Code](https://claude.com/claude-code)