### PR TITLE
Bump SharpCompress 0.47.4 -> 0.48.0 to address GHSA-6c8g-7p36-r338

### DIFF
--- a/GumCommon/GumCommon.csproj
+++ b/GumCommon/GumCommon.csproj
@@ -233,7 +233,7 @@
 	</ItemGroup>
 	<ItemGroup>
 	  <PackageReference Include="BrotliSharpLib" Version="0.3.3" />
-	  <PackageReference Include="SharpCompress" Version="0.47.4" />
+	  <PackageReference Include="SharpCompress" Version="0.48.0" />
 	  <PackageReference Include="CsvHelper" Version="33.1.0" />
 	  <PackageReference Include="FlatRedBall.InterpolationCore" Version="2025.4.22.1" />
 	  <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />

--- a/GumCore/GumCoreXnaPc/GumCore.DesktopGlNet6/GumCore.DesktopGlNet6.csproj
+++ b/GumCore/GumCoreXnaPc/GumCore.DesktopGlNet6/GumCore.DesktopGlNet6.csproj
@@ -27,7 +27,7 @@
 			<PrivateAssets>All</PrivateAssets>
 		</PackageReference>
 		<PackageReference Include="BrotliSharpLib" Version="0.3.3" />
-		<PackageReference Include="SharpCompress" Version="0.47.4" />
+		<PackageReference Include="SharpCompress" Version="0.48.0" />
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\..\..\..\FlatRedBall\Engines\FlatRedBallXNA\FlatRedBallDesktopGLNet6\FlatRedBallDesktopGLNet6.csproj" />

--- a/GumCore/GumCoreXnaPc/GumCore.FNA/GumCore.FNA.csproj
+++ b/GumCore/GumCoreXnaPc/GumCore.FNA/GumCore.FNA.csproj
@@ -18,7 +18,7 @@
     </ItemGroup>
     <ItemGroup>
         <PackageReference Include="BrotliSharpLib" Version="0.3.3" />
-        <PackageReference Include="SharpCompress" Version="0.47.4" />
+        <PackageReference Include="SharpCompress" Version="0.48.0" />
     </ItemGroup>
 
     <Import Project="..\..\..\GumCoreShared.projitems" Label="Shared" />

--- a/GumCore/GumCoreXnaPc/GumCore.Kni.DesktopGL/GumCore.Kni.DesktopGL.csproj
+++ b/GumCore/GumCoreXnaPc/GumCore.Kni.DesktopGL/GumCore.Kni.DesktopGL.csproj
@@ -16,6 +16,6 @@
     </ItemGroup>
     <ItemGroup>
         <PackageReference Include="BrotliSharpLib" Version="0.3.3" />
-        <PackageReference Include="SharpCompress" Version="0.47.4" />
+        <PackageReference Include="SharpCompress" Version="0.48.0" />
     </ItemGroup>
 </Project>

--- a/GumCore/GumCoreXnaPc/GumCore.Kni.Web/GumCore.Kni.Web.csproj
+++ b/GumCore/GumCoreXnaPc/GumCore.Kni.Web/GumCore.Kni.Web.csproj
@@ -17,6 +17,6 @@
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="BrotliSharpLib" Version="0.3.3" />
-		<PackageReference Include="SharpCompress" Version="0.47.4" />
+		<PackageReference Include="SharpCompress" Version="0.48.0" />
 	</ItemGroup>
 </Project>

--- a/GumCore/GumCoreXnaPc/GumCoreAndroid/GumCoreAndroid.csproj
+++ b/GumCore/GumCoreXnaPc/GumCoreAndroid/GumCoreAndroid.csproj
@@ -28,7 +28,7 @@
 
 	<ItemGroup>
 	  <PackageReference Include="BrotliSharpLib" Version="0.3.3" />
-	  <PackageReference Include="SharpCompress" Version="0.47.4" />
+	  <PackageReference Include="SharpCompress" Version="0.48.0" />
 	</ItemGroup>
 
 </Project>

--- a/GumCore/GumCoreXnaPc/GumCoreiOS/GumCoreiOS.csproj
+++ b/GumCore/GumCoreXnaPc/GumCoreiOS/GumCoreiOS.csproj
@@ -24,7 +24,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="BrotliSharpLib" Version="0.3.3" />
-		<PackageReference Include="SharpCompress" Version="0.47.4" />
+		<PackageReference Include="SharpCompress" Version="0.48.0" />
 	</ItemGroup>
 
 	<Import Project="..\..\..\GumCoreShared.projitems" Label="Shared" />


### PR DESCRIPTION
## Summary
- Bumps `SharpCompress` from `0.47.4` to `0.48.0` across the 7 csprojs that reference it (GumCommon + 6 GumCore FRB1-side projects), addressing the `NU1902` warning for [GHSA-6c8g-7p36-r338](https://github.com/advisories/GHSA-6c8g-7p36-r338).
- `0.48.0` is the latest stable release on NuGet (`1.0.0` was unlisted by the author as an accidental publication).
- Single Gum call site is in `GumCommon/Bundle/GumBundleReader.cs` (`TarReader.OpenReader` + `ReaderOptions` + `EntryStream`); API is unchanged in 0.48.0.

## Test plan
- [x] `dotnet build GumCommon/GumCommon.csproj` — clean (no more NU1902 from SharpCompress)
- [x] `dotnet test MonoGameGum.Tests/MonoGameGum.Tests.csproj` — 1425/1425 passing
- [ ] FRB1-side `GumCore.*` csprojs require the sibling FlatRedBall repo and were not built locally; the change is a mechanical version-string bump matching the other six.

## Notes
- The advisory currently lists "Patched versions: None," but bumping to the latest maintained release is the standard move and silences the warning while keeping all 7 csprojs in lockstep (per the diamond-dependency caveat in the issue).

Closes #2731