### PR TITLE
Fix Apos.Shapes gradient with Percentage units losing world offset

### DIFF
--- a/Runtimes/GumShapes/Renderables/RenderableShapeBase.cs
+++ b/Runtimes/GumShapes/Renderables/RenderableShapeBase.cs
@@ -470,7 +470,7 @@ public abstract class RenderableShapeBase : RenderableBase
                 effectiveGradientX1 += Width;
                 break;
             case GeneralUnitType.Percentage:
-                effectiveGradientX1 = Width * GradientX1 / 100;
+                effectiveGradientX1 = absoluteLeft + Width * GradientX1 / 100;
                 break;
         }
 
@@ -485,7 +485,7 @@ public abstract class RenderableShapeBase : RenderableBase
                 effectiveGradientY1 += Height;
                 break;
             case GeneralUnitType.Percentage:
-                effectiveGradientY1 = Height * GradientY1 / 100;
+                effectiveGradientY1 = absoluteTop + Height * GradientY1 / 100;
                 break;
         }
 
@@ -502,7 +502,7 @@ public abstract class RenderableShapeBase : RenderableBase
                     effectiveGradientX2 += Width;
                     break;
                 case GeneralUnitType.Percentage:
-                    effectiveGradientX2 = Width * GradientX2 / 100;
+                    effectiveGradientX2 = absoluteLeft + Width * GradientX2 / 100;
                     break;
             }
             var effectiveGradientY2 = absoluteTop + GradientY2;
@@ -515,7 +515,7 @@ public abstract class RenderableShapeBase : RenderableBase
                     effectiveGradientY2 += Height;
                     break;
                 case GeneralUnitType.Percentage:
-                    effectiveGradientY2 = Height * GradientY2 / 100;
+                    effectiveGradientY2 = absoluteTop + Height * GradientY2 / 100;
                     break;
             }
 


### PR DESCRIPTION
## Summary
- `RenderableShapeBase.GetGradient`'s four `Percentage` branches used `=` instead of `+=`, dropping the `absoluteLeft`/`absoluteTop` passed in by the caller. Percentage-based gradients resolved near world (0, 0) — far from the shape — so every pixel sampled the clamped end color and the shape rendered flat.
- Each Percentage branch now adds the absolute offset, matching the pattern already used by the `PixelsFromMiddle` / `PixelsFromLarge` branches.
- Skia parity confirmed: `SkiaGum/Renderables/RenderableShapeBase.ApplyGradientToPaint` computes the percentage offset relative to the bounding rect and adds `rectToUse.Left/Top` afterward, so it was already correct. No Skia change needed.

## Test plan
- [ ] Run the repro from the issue (vertical 2-stop gradient on a `RoundedRectangleRuntime` with `Percentage` units, X1/Y1 = 50/0, X2/Y2 = 50/100). Expected: visible vertical gradient. Before this fix it rendered flat dark green.
- [ ] Verify Forest Glade `ButtonVisual` (which uses the `PixelsFromSmall`/`PixelsFromLarge` workaround) still looks the same — those branches were untouched.

No unit test added: the renderable lives in `Gum.Shapes.MonoGame`, which has no test project and is not referenced by `MonoGameGum.Tests`. Standing up a new test project for a four-line fix is more churn than it's worth, and the issue author flagged this as likely untestable.

Closes #2723

🤖 Generated with [Claude Code](https://claude.com/claude-code)