### PR TITLE
Split shapes gallery into pages: shape survey + gradient deep-dive

### DIFF
--- a/Samples/MonoGameGumShapesGallery/Game1.cs
+++ b/Samples/MonoGameGumShapesGallery/Game1.cs
@@ -1,8 +1,9 @@
-using Gum.GueDeriving;
+using Gum.Forms.Controls;
 using Gum.Wireframe;
 using Microsoft.Xna.Framework;
 using MonoGameAndGum.Renderables;
 using MonoGameGum;
+using MonoGameGumShapesGallery.Screens;
 
 namespace MonoGameGumShapesGallery;
 
@@ -12,27 +13,25 @@ namespace MonoGameGumShapesGallery;
 // PreRender calls. GumService.Default.Draw() drives the whole pipeline; each shape is a
 // runtime instance configured via property setters and added to the visual tree once.
 //
-// Four rows of five cells each, all using runtime types (no raw Apos.Shapes API):
-//   1. ColoredCircleRuntime - solid / gradient / stroked variants.
-//   2. RoundedRectangleRuntime - uniform CornerRadius, gradient, per-corner radii
-//      (Apos.Shapes 0.6.9's CornerRadii overload, including the Forest Glade leaf shape).
-//   3. LineRuntime - varied thickness, end caps, gradient, dropshadow.
-//   4. ArcRuntime - the unified Apos<->Skia runtime from issue #2728. First cell is a bare
-//      `new ArcRuntime()` to visually verify the locked-in defaults (flat caps,
-//      SweepAngle = 90, Thickness = 10). The other cells exercise IsEndRounded, full-ring
-//      sweep, thick stroke, and gradient.
+// The sample is split into pages, each a FrameworkElement-derived screen under Screens/.
+// A horizontal nav strip of Forms Buttons across the top swaps the active page at
+// runtime. Add a page by creating a new Screen and registering it in BuildNavStrip.
 public class Game1 : Game
 {
+    private const int BackBufferWidth = 1280;
+    private const int BackBufferHeight = 900;
+    private const float NavStripHeight = 40;
+
     private readonly GraphicsDeviceManager _graphics;
 
-    private const int RowCount = 4;
-    private const int ColCount = 5;
+    private StackPanel? _navStrip;
+    private FrameworkElement? _currentScreen;
 
     public Game1()
     {
         _graphics = new GraphicsDeviceManager(this);
-        _graphics.PreferredBackBufferWidth = 1280;
-        _graphics.PreferredBackBufferHeight = 900;
+        _graphics.PreferredBackBufferWidth = BackBufferWidth;
+        _graphics.PreferredBackBufferHeight = BackBufferHeight;
         IsMouseVisible = true;
         Content.RootDirectory = "Content";
         Window.Title = "Gum Shapes Gallery";
@@ -46,15 +45,52 @@ public class Game1 : Game
         GumService.Default.Initialize(this);
         ShapeRenderer.Self.Initialize();
 
-        float cellW = _graphics.PreferredBackBufferWidth / (float)ColCount;
-        float rowH = _graphics.PreferredBackBufferHeight / (float)RowCount;
-
-        BuildCircleRow(0, cellW, rowH);
-        BuildRoundedRectangleRow(1, cellW, rowH);
-        BuildLineRow(2, cellW, rowH);
-        BuildArcRow(3, cellW, rowH);
+        BuildNavStrip();
+        ShowScreen(NewSurveyScreen);
 
         base.Initialize();
+    }
+
+    private void BuildNavStrip()
+    {
+        _navStrip = new StackPanel();
+        _navStrip.Orientation = Orientation.Horizontal;
+        _navStrip.Spacing = 4;
+        _navStrip.Visual.X = 4;
+        _navStrip.Visual.Y = 4;
+        _navStrip.AddToRoot();
+
+        AddNavButton("Shape survey", NewSurveyScreen);
+        AddNavButton("Gradients", () => new GradientScreen());
+    }
+
+    private ShapeSurveyScreen NewSurveyScreen() =>
+        new ShapeSurveyScreen(BackBufferWidth, BackBufferHeight - NavStripHeight);
+
+    private void AddNavButton(string text, System.Func<FrameworkElement> factory)
+    {
+        Button button = new Button();
+        button.Text = text;
+        button.Click += (_, _) => ShowScreen(factory);
+        _navStrip!.AddChild(button);
+    }
+
+    private void ShowScreen(System.Func<FrameworkElement> factory)
+    {
+        if (_currentScreen != null)
+        {
+            _currentScreen.RemoveFromRoot();
+        }
+
+        _currentScreen = factory();
+        // Offset the screen so it doesn't sit underneath the nav strip. The screen's ctor
+        // calls Dock(Fill); reset the vertical anchoring to top + shrink height by the nav
+        // strip's footprint so the two never overlap.
+        _currentScreen.Visual.YOrigin = RenderingLibrary.Graphics.VerticalAlignment.Top;
+        _currentScreen.Visual.YUnits = Gum.Converters.GeneralUnitType.PixelsFromSmall;
+        _currentScreen.Visual.Y = NavStripHeight;
+        _currentScreen.Visual.Height = -NavStripHeight;
+        _currentScreen.AddToRoot();
     }
 
     protected override void Update(GameTime gameTime)
@@ -68,204 +104,5 @@ public class Game1 : Game
         GraphicsDevice.Clear(new Color(30, 30, 30));
         GumService.Default.Draw();
         base.Draw(gameTime);
-    }
-
-    private static void Place(GraphicalUiElement shape, int row, int col,
-        float cellW, float rowH, float shapeW, float shapeH)
-    {
-        float cellCenterX = col * cellW + cellW / 2f;
-        float cellCenterY = row * rowH + rowH / 2f;
-        shape.X = cellCenterX - shapeW / 2f;
-        shape.Y = cellCenterY - shapeH / 2f;
-        shape.Width = shapeW;
-        shape.Height = shapeH;
-    }
-
-    private static void BuildCircleRow(int row, float cellW, float rowH)
-    {
-        const float size = 130f;
-        Color teal = new Color(80, 180, 220);
-        Color green = new Color(60, 180, 130);
-        Color orange = new Color(220, 160, 60);
-        Color purple = new Color(180, 80, 220);
-
-        ColoredCircleRuntime filled = new ColoredCircleRuntime();
-        filled.Color = teal;
-        Place(filled, row, 0, cellW, rowH, size, size);
-        filled.AddToRoot();
-
-        ColoredCircleRuntime filledAlt = new ColoredCircleRuntime();
-        filledAlt.Color = green;
-        Place(filledAlt, row, 1, cellW, rowH, size, size);
-        filledAlt.AddToRoot();
-
-        // Gradient: the ctor seeds Red1/Green1/Blue1 = 255 (white) and Red2 = 255, Green2 =
-        // 255, Blue2 = 0 (yellow) along the gradient axis. UseGradient = true picks it up.
-        ColoredCircleRuntime gradient = new ColoredCircleRuntime();
-        gradient.UseGradient = true;
-        Place(gradient, row, 2, cellW, rowH, size, size);
-        gradient.AddToRoot();
-
-        ColoredCircleRuntime strokedThin = new ColoredCircleRuntime();
-        strokedThin.IsFilled = false;
-        strokedThin.Color = orange;
-        strokedThin.StrokeWidth = 4;
-        Place(strokedThin, row, 3, cellW, rowH, size, size);
-        strokedThin.AddToRoot();
-
-        ColoredCircleRuntime strokedThick = new ColoredCircleRuntime();
-        strokedThick.IsFilled = false;
-        strokedThick.Color = purple;
-        strokedThick.StrokeWidth = 12;
-        Place(strokedThick, row, 4, cellW, rowH, size, size);
-        strokedThick.AddToRoot();
-    }
-
-    private static void BuildRoundedRectangleRow(int row, float cellW, float rowH)
-    {
-        const float width = 200f;
-        const float height = 70f;
-        Color teal = new Color(80, 180, 220);
-        Color green = new Color(112, 220, 80);
-        Color orange = new Color(220, 160, 60);
-        Color magenta = new Color(200, 120, 220);
-
-        RoundedRectangleRuntime uniformSmall = new RoundedRectangleRuntime();
-        uniformSmall.Color = teal;
-        uniformSmall.CornerRadius = 8;
-        Place(uniformSmall, row, 0, cellW, rowH, width, height);
-        uniformSmall.AddToRoot();
-
-        RoundedRectangleRuntime uniformLarge = new RoundedRectangleRuntime();
-        uniformLarge.Color = orange;
-        uniformLarge.CornerRadius = 22;
-        Place(uniformLarge, row, 1, cellW, rowH, width, height);
-        uniformLarge.AddToRoot();
-
-        RoundedRectangleRuntime gradient = new RoundedRectangleRuntime();
-        gradient.UseGradient = true;
-        gradient.CornerRadius = 14;
-        Place(gradient, row, 2, cellW, rowH, width, height);
-        gradient.AddToRoot();
-
-        // Forest Glade signature leaf shape - opposite-corner asymmetric per-corner radii.
-        // Uses the Apos.Shapes 0.6.9 CornerRadii overload exposed via CustomRadiusTopLeft etc.
-        // CornerRadius = 0 because the per-corner values take over when any Custom* is set.
-        RoundedRectangleRuntime leaf = new RoundedRectangleRuntime();
-        leaf.Color = green;
-        leaf.CornerRadius = 0;
-        leaf.CustomRadiusTopLeft = 2;
-        leaf.CustomRadiusTopRight = 18;
-        leaf.CustomRadiusBottomRight = 2;
-        leaf.CustomRadiusBottomLeft = 18;
-        Place(leaf, row, 3, cellW, rowH, width, height);
-        leaf.AddToRoot();
-
-        // Fully-asymmetric per-corner radii - sanity check that the four corners are wired
-        // to the right Custom* property (a swap would be visible immediately here).
-        RoundedRectangleRuntime asym = new RoundedRectangleRuntime();
-        asym.Color = magenta;
-        asym.CornerRadius = 0;
-        asym.CustomRadiusTopLeft = 0;
-        asym.CustomRadiusTopRight = 30;
-        asym.CustomRadiusBottomRight = 12;
-        asym.CustomRadiusBottomLeft = 4;
-        Place(asym, row, 4, cellW, rowH, width, height);
-        asym.AddToRoot();
-    }
-
-    private static void BuildLineRow(int row, float cellW, float rowH)
-    {
-        const float width = 200f;
-        const float height = 80f;
-        Color teal = new Color(80, 180, 220);
-        Color orange = new Color(220, 160, 60);
-        Color purple = new Color(180, 80, 220);
-
-        LineRuntime thin = new LineRuntime();
-        thin.Color = teal;
-        thin.StrokeWidth = 2;
-        Place(thin, row, 0, cellW, rowH, width, height);
-        thin.AddToRoot();
-
-        LineRuntime thick = new LineRuntime();
-        thick.Color = orange;
-        thick.StrokeWidth = 10;
-        Place(thick, row, 1, cellW, rowH, width, height);
-        thick.AddToRoot();
-
-        LineRuntime roundedEnds = new LineRuntime();
-        roundedEnds.Color = purple;
-        roundedEnds.StrokeWidth = 14;
-        roundedEnds.IsRounded = true;
-        Place(roundedEnds, row, 2, cellW, rowH, width, height);
-        roundedEnds.AddToRoot();
-
-        LineRuntime gradient = new LineRuntime();
-        gradient.StrokeWidth = 12;
-        gradient.IsRounded = true;
-        gradient.UseGradient = true;
-        Place(gradient, row, 3, cellW, rowH, width, height);
-        gradient.AddToRoot();
-
-        LineRuntime dropshadow = new LineRuntime();
-        dropshadow.Color = teal;
-        dropshadow.StrokeWidth = 10;
-        dropshadow.IsRounded = true;
-        dropshadow.HasDropshadow = true;
-        Place(dropshadow, row, 4, cellW, rowH, width, height);
-        dropshadow.AddToRoot();
-    }
-
-    private static void BuildArcRow(int row, float cellW, float rowH)
-    {
-        const float size = 130f;
-
-        // Bare default - verifies the locked-in defaults from issue #2728. A regression in
-        // any of the unified ctor defaults shows up as a visibly-different first cell:
-        //   IsEndRounded = false (the breaking-change default on Apos; was true pre-#2728)
-        //   SweepAngle = 90
-        //   Thickness = 10
-        //   Color = white
-        ArcRuntime defaultArc = new ArcRuntime();
-        Place(defaultArc, row, 0, cellW, rowH, size, size);
-        defaultArc.AddToRoot();
-
-        // Same as the default but with IsEndRounded explicitly set - this is the toggle
-        // existing Apos consumers must apply if they relied on the previous rounded default.
-        // Documented in docs/gum-tool/upgrading/migrating-to-2026-may.md.
-        ArcRuntime rounded = new ArcRuntime();
-        rounded.IsEndRounded = true;
-        Place(rounded, row, 1, cellW, rowH, size, size);
-        rounded.AddToRoot();
-
-        // Full ring - exercises the SweepAngle = 360 path (DrawRing under the hood when
-        // ends are flat).
-        ArcRuntime fullRing = new ArcRuntime();
-        fullRing.SweepAngle = 360;
-        fullRing.Thickness = 8;
-        Place(fullRing, row, 2, cellW, rowH, size, size);
-        fullRing.AddToRoot();
-
-        // Thick rounded half-circle - bigger stroke + rounded caps stress the radius math
-        // (the renderable computes inner/outer radii from Width/Height minus Thickness).
-        ArcRuntime thickHalf = new ArcRuntime();
-        thickHalf.SweepAngle = 180;
-        thickHalf.Thickness = 18;
-        thickHalf.IsEndRounded = true;
-        thickHalf.Color = new Color(220, 160, 60);
-        Place(thickHalf, row, 3, cellW, rowH, size, size);
-        thickHalf.AddToRoot();
-
-        // Gradient three-quarter arc - exercises the UseGradient branch in Arc.Render. The
-        // gradient stops are pre-seeded in the ctor (white to yellow); UseGradient = true
-        // picks them up.
-        ArcRuntime gradient = new ArcRuntime();
-        gradient.SweepAngle = 270;
-        gradient.Thickness = 14;
-        gradient.IsEndRounded = true;
-        gradient.UseGradient = true;
-        Place(gradient, row, 4, cellW, rowH, size, size);
-        gradient.AddToRoot();
     }
 }

--- a/Samples/MonoGameGumShapesGallery/Screens/GradientScreen.cs
+++ b/Samples/MonoGameGumShapesGallery/Screens/GradientScreen.cs
@@ -1,0 +1,197 @@
+using Gum.Converters;
+using Gum.Forms.Controls;
+using Gum.GueDeriving;
+using Gum.Wireframe;
+using Microsoft.Xna.Framework;
+using MonoGameAndGum.Renderables;
+using RenderingLibrary.Graphics;
+
+namespace MonoGameGumShapesGallery.Screens;
+
+// Deep-dive on RoundedRectangleRuntime's gradient surface. Three rows of three cells -
+// every cell uses the same rectangle size so the configuration is what changes, not the
+// canvas. Each cell shows a rectangle on top and a small label beneath naming the
+// configuration. Together the nine variants cover:
+//   - GradientType: Linear vs Radial
+//   - GeneralUnitType: PixelsFromSmall / PixelsFromMiddle / PixelsFromLarge / Percentage
+//     on all four gradient endpoint axes
+//   - Radial-specific: GradientInnerRadius and GradientOuterRadius in absolute pixels and
+//     in PercentageOfParent (DimensionUnitType, not GeneralUnitType)
+// The Percentage-units cells double as a visual regression check for issue #2723.
+internal class GradientScreen : FrameworkElement
+{
+    private const float RectWidth = 280;
+    private const float RectHeight = 120;
+
+    private static readonly Color StartColor = new Color(15, 196, 72);
+    private static readonly Color EndColor = new Color(0, 70, 22);
+
+    public GradientScreen() : base(new ContainerRuntime())
+    {
+        Dock(Gum.Wireframe.Dock.Fill);
+
+        ContainerRuntime container = new ContainerRuntime();
+        container.ChildrenLayout = Gum.Managers.ChildrenLayout.TopToBottomStack;
+        container.StackSpacing = 8;
+        container.X = 8;
+        container.Y = 8;
+        this.AddChild(container);
+
+        ContainerRuntime row1 = AddRow(container);
+        AddCell(row1, "Linear horizontal\nPixelsFromSmall → PixelsFromLarge X",
+            ConfigureLinearHorizontal);
+        AddCell(row1, "Linear vertical\nPixelsFromSmall → PixelsFromLarge Y",
+            ConfigureLinearVertical);
+        AddCell(row1, "Linear diagonal\nSmall/Small → Large/Large",
+            ConfigureLinearDiagonal);
+
+        ContainerRuntime row2 = AddRow(container);
+        AddCell(row2, "Linear from middle\nPixelsFromMiddle X (0 → 0)",
+            ConfigureLinearFromMiddle);
+        AddCell(row2, "Linear Percentage\n0% → 100% on Y",
+            ConfigureLinearPercentageFull);
+        AddCell(row2, "Linear Percentage band\n25% → 75% on X",
+            ConfigureLinearPercentagePartial);
+
+        ContainerRuntime row3 = AddRow(container);
+        AddCell(row3, "Radial centered\nPixelsFromMiddle (0,0), outer = 100px",
+            ConfigureRadialCentered);
+        AddCell(row3, "Radial with inner radius\nInner 30px, outer 100px",
+            ConfigureRadialDonut);
+        AddCell(row3, "Radial Percentage outer\nPercentageOfParent radius = 50%",
+            ConfigureRadialPercentageOuter);
+    }
+
+    private static ContainerRuntime AddRow(ContainerRuntime parent)
+    {
+        ContainerRuntime row = new ContainerRuntime();
+        row.ChildrenLayout = Gum.Managers.ChildrenLayout.LeftToRightStack;
+        row.StackSpacing = 12;
+        row.WidthUnits = Gum.DataTypes.DimensionUnitType.RelativeToChildren;
+        row.HeightUnits = Gum.DataTypes.DimensionUnitType.RelativeToChildren;
+        parent.AddChild(row);
+        return row;
+    }
+
+    private static void AddCell(ContainerRuntime row, string labelText,
+        System.Action<RoundedRectangleRuntime> configure)
+    {
+        ContainerRuntime cell = new ContainerRuntime();
+        cell.ChildrenLayout = Gum.Managers.ChildrenLayout.TopToBottomStack;
+        cell.StackSpacing = 4;
+        cell.WidthUnits = Gum.DataTypes.DimensionUnitType.RelativeToChildren;
+        cell.HeightUnits = Gum.DataTypes.DimensionUnitType.RelativeToChildren;
+        row.AddChild(cell);
+
+        RoundedRectangleRuntime rect = new RoundedRectangleRuntime();
+        rect.Width = RectWidth;
+        rect.Height = RectHeight;
+        rect.CornerRadius = 6;
+        rect.UseGradient = true;
+        rect.Red1 = StartColor.R; rect.Green1 = StartColor.G; rect.Blue1 = StartColor.B; rect.Alpha1 = 255;
+        rect.Red2 = EndColor.R;   rect.Green2 = EndColor.G;   rect.Blue2 = EndColor.B;   rect.Alpha2 = 255;
+        configure(rect);
+        cell.AddChild(rect);
+
+        TextRuntime label = new TextRuntime();
+        label.Text = labelText;
+        label.WidthUnits = Gum.DataTypes.DimensionUnitType.RelativeToChildren;
+        label.HeightUnits = Gum.DataTypes.DimensionUnitType.RelativeToChildren;
+        cell.AddChild(label);
+    }
+
+    private static void ConfigureLinearHorizontal(RoundedRectangleRuntime rect)
+    {
+        rect.GradientType = GradientType.Linear;
+        rect.GradientX1Units = GeneralUnitType.PixelsFromSmall; rect.GradientX1 = 0;
+        rect.GradientY1Units = GeneralUnitType.PixelsFromMiddle; rect.GradientY1 = 0;
+        rect.GradientX2Units = GeneralUnitType.PixelsFromLarge; rect.GradientX2 = 0;
+        rect.GradientY2Units = GeneralUnitType.PixelsFromMiddle; rect.GradientY2 = 0;
+    }
+
+    private static void ConfigureLinearVertical(RoundedRectangleRuntime rect)
+    {
+        rect.GradientType = GradientType.Linear;
+        rect.GradientX1Units = GeneralUnitType.PixelsFromMiddle; rect.GradientX1 = 0;
+        rect.GradientY1Units = GeneralUnitType.PixelsFromSmall; rect.GradientY1 = 0;
+        rect.GradientX2Units = GeneralUnitType.PixelsFromMiddle; rect.GradientX2 = 0;
+        rect.GradientY2Units = GeneralUnitType.PixelsFromLarge; rect.GradientY2 = 0;
+    }
+
+    private static void ConfigureLinearDiagonal(RoundedRectangleRuntime rect)
+    {
+        rect.GradientType = GradientType.Linear;
+        rect.GradientX1Units = GeneralUnitType.PixelsFromSmall; rect.GradientX1 = 0;
+        rect.GradientY1Units = GeneralUnitType.PixelsFromSmall; rect.GradientY1 = 0;
+        rect.GradientX2Units = GeneralUnitType.PixelsFromLarge; rect.GradientX2 = 0;
+        rect.GradientY2Units = GeneralUnitType.PixelsFromLarge; rect.GradientY2 = 0;
+    }
+
+    // Both endpoints at PixelsFromMiddle with 0 offset collapse into a single point, but
+    // the renderer treats coincident endpoints by sweeping the second color across most of
+    // the area - useful for showing what NOT to do, and that the units math handles the
+    // degenerate case without crashing. Offset slightly so it's not literally zero-length.
+    private static void ConfigureLinearFromMiddle(RoundedRectangleRuntime rect)
+    {
+        rect.GradientType = GradientType.Linear;
+        rect.GradientX1Units = GeneralUnitType.PixelsFromMiddle; rect.GradientX1 = -60;
+        rect.GradientY1Units = GeneralUnitType.PixelsFromMiddle; rect.GradientY1 = 0;
+        rect.GradientX2Units = GeneralUnitType.PixelsFromMiddle; rect.GradientX2 = 60;
+        rect.GradientY2Units = GeneralUnitType.PixelsFromMiddle; rect.GradientY2 = 0;
+    }
+
+    // 0% → 100% on Y is the canonical Percentage case that issue #2723 broke: before
+    // the fix, the Percentage branches in RenderableShapeBase.GetGradient overwrote the
+    // world offset and the rectangle rendered flat (end color everywhere). A visible
+    // top-to-bottom gradient here means the fix is intact.
+    private static void ConfigureLinearPercentageFull(RoundedRectangleRuntime rect)
+    {
+        rect.GradientType = GradientType.Linear;
+        rect.GradientX1Units = GeneralUnitType.Percentage; rect.GradientX1 = 50;
+        rect.GradientY1Units = GeneralUnitType.Percentage; rect.GradientY1 = 0;
+        rect.GradientX2Units = GeneralUnitType.Percentage; rect.GradientX2 = 50;
+        rect.GradientY2Units = GeneralUnitType.Percentage; rect.GradientY2 = 100;
+    }
+
+    // Percentage band: 25%->75% horizontally. Outside the band, the colors should clamp,
+    // so the leftmost 25% is solid start color and the rightmost 25% is solid end color -
+    // a quick visual check that Percentage endpoints really map into the rectangle's
+    // local space, not somewhere far outside it.
+    private static void ConfigureLinearPercentagePartial(RoundedRectangleRuntime rect)
+    {
+        rect.GradientType = GradientType.Linear;
+        rect.GradientX1Units = GeneralUnitType.Percentage; rect.GradientX1 = 25;
+        rect.GradientY1Units = GeneralUnitType.Percentage; rect.GradientY1 = 50;
+        rect.GradientX2Units = GeneralUnitType.Percentage; rect.GradientX2 = 75;
+        rect.GradientY2Units = GeneralUnitType.Percentage; rect.GradientY2 = 50;
+    }
+
+    private static void ConfigureRadialCentered(RoundedRectangleRuntime rect)
+    {
+        rect.GradientType = GradientType.Radial;
+        rect.GradientX1Units = GeneralUnitType.PixelsFromMiddle; rect.GradientX1 = 0;
+        rect.GradientY1Units = GeneralUnitType.PixelsFromMiddle; rect.GradientY1 = 0;
+        rect.GradientOuterRadiusUnits = Gum.DataTypes.DimensionUnitType.Absolute;
+        rect.GradientOuterRadius = 100;
+    }
+
+    private static void ConfigureRadialDonut(RoundedRectangleRuntime rect)
+    {
+        rect.GradientType = GradientType.Radial;
+        rect.GradientX1Units = GeneralUnitType.PixelsFromMiddle; rect.GradientX1 = 0;
+        rect.GradientY1Units = GeneralUnitType.PixelsFromMiddle; rect.GradientY1 = 0;
+        rect.GradientInnerRadiusUnits = Gum.DataTypes.DimensionUnitType.Absolute;
+        rect.GradientInnerRadius = 30;
+        rect.GradientOuterRadiusUnits = Gum.DataTypes.DimensionUnitType.Absolute;
+        rect.GradientOuterRadius = 100;
+    }
+
+    private static void ConfigureRadialPercentageOuter(RoundedRectangleRuntime rect)
+    {
+        rect.GradientType = GradientType.Radial;
+        rect.GradientX1Units = GeneralUnitType.PixelsFromMiddle; rect.GradientX1 = 0;
+        rect.GradientY1Units = GeneralUnitType.PixelsFromMiddle; rect.GradientY1 = 0;
+        rect.GradientOuterRadiusUnits = Gum.DataTypes.DimensionUnitType.PercentageOfParent;
+        rect.GradientOuterRadius = 50;
+    }
+}

--- a/Samples/MonoGameGumShapesGallery/Screens/ShapeSurveyScreen.cs
+++ b/Samples/MonoGameGumShapesGallery/Screens/ShapeSurveyScreen.cs
@@ -1,0 +1,221 @@
+using Gum.Forms.Controls;
+using Gum.GueDeriving;
+using Gum.Wireframe;
+using Microsoft.Xna.Framework;
+
+namespace MonoGameGumShapesGallery.Screens;
+
+// Four rows of five cells each, all using runtime types (no raw Apos.Shapes API):
+//   1. ColoredCircleRuntime - solid / gradient / stroked variants.
+//   2. RoundedRectangleRuntime - uniform CornerRadius, gradient, per-corner radii
+//      (Apos.Shapes 0.6.9's CornerRadii overload, including the Forest Glade leaf shape).
+//   3. LineRuntime - varied thickness, end caps, gradient, dropshadow.
+//   4. ArcRuntime - the unified Apos<->Skia runtime from issue #2728. First cell is a bare
+//      `new ArcRuntime()` to visually verify the locked-in defaults (flat caps,
+//      SweepAngle = 90, Thickness = 10). The other cells exercise IsEndRounded, full-ring
+//      sweep, thick stroke, and gradient.
+internal class ShapeSurveyScreen : FrameworkElement
+{
+    private const int RowCount = 4;
+    private const int ColCount = 5;
+
+    private readonly float _canvasWidth;
+    private readonly float _canvasHeight;
+
+    public ShapeSurveyScreen(float canvasWidth, float canvasHeight)
+        : base(new ContainerRuntime())
+    {
+        _canvasWidth = canvasWidth;
+        _canvasHeight = canvasHeight;
+
+        Dock(Gum.Wireframe.Dock.Fill);
+
+        float cellW = _canvasWidth / ColCount;
+        float rowH = _canvasHeight / RowCount;
+
+        BuildCircleRow(0, cellW, rowH);
+        BuildRoundedRectangleRow(1, cellW, rowH);
+        BuildLineRow(2, cellW, rowH);
+        BuildArcRow(3, cellW, rowH);
+    }
+
+    private void Place(GraphicalUiElement shape, int row, int col,
+        float cellW, float rowH, float shapeW, float shapeH)
+    {
+        float cellCenterX = col * cellW + cellW / 2f;
+        float cellCenterY = row * rowH + rowH / 2f;
+        shape.X = cellCenterX - shapeW / 2f;
+        shape.Y = cellCenterY - shapeH / 2f;
+        shape.Width = shapeW;
+        shape.Height = shapeH;
+        this.AddChild(shape);
+    }
+
+    private void BuildCircleRow(int row, float cellW, float rowH)
+    {
+        const float size = 130f;
+        Color teal = new Color(80, 180, 220);
+        Color green = new Color(60, 180, 130);
+        Color orange = new Color(220, 160, 60);
+        Color purple = new Color(180, 80, 220);
+
+        ColoredCircleRuntime filled = new ColoredCircleRuntime();
+        filled.Color = teal;
+        Place(filled, row, 0, cellW, rowH, size, size);
+
+        ColoredCircleRuntime filledAlt = new ColoredCircleRuntime();
+        filledAlt.Color = green;
+        Place(filledAlt, row, 1, cellW, rowH, size, size);
+
+        // Gradient: the ctor seeds Red1/Green1/Blue1 = 255 (white) and Red2 = 255, Green2 =
+        // 255, Blue2 = 0 (yellow) along the gradient axis. UseGradient = true picks it up.
+        ColoredCircleRuntime gradient = new ColoredCircleRuntime();
+        gradient.UseGradient = true;
+        Place(gradient, row, 2, cellW, rowH, size, size);
+
+        ColoredCircleRuntime strokedThin = new ColoredCircleRuntime();
+        strokedThin.IsFilled = false;
+        strokedThin.Color = orange;
+        strokedThin.StrokeWidth = 4;
+        Place(strokedThin, row, 3, cellW, rowH, size, size);
+
+        ColoredCircleRuntime strokedThick = new ColoredCircleRuntime();
+        strokedThick.IsFilled = false;
+        strokedThick.Color = purple;
+        strokedThick.StrokeWidth = 12;
+        Place(strokedThick, row, 4, cellW, rowH, size, size);
+    }
+
+    private void BuildRoundedRectangleRow(int row, float cellW, float rowH)
+    {
+        const float width = 200f;
+        const float height = 70f;
+        Color teal = new Color(80, 180, 220);
+        Color green = new Color(112, 220, 80);
+        Color orange = new Color(220, 160, 60);
+        Color magenta = new Color(200, 120, 220);
+
+        RoundedRectangleRuntime uniformSmall = new RoundedRectangleRuntime();
+        uniformSmall.Color = teal;
+        uniformSmall.CornerRadius = 8;
+        Place(uniformSmall, row, 0, cellW, rowH, width, height);
+
+        RoundedRectangleRuntime uniformLarge = new RoundedRectangleRuntime();
+        uniformLarge.Color = orange;
+        uniformLarge.CornerRadius = 22;
+        Place(uniformLarge, row, 1, cellW, rowH, width, height);
+
+        RoundedRectangleRuntime gradient = new RoundedRectangleRuntime();
+        gradient.UseGradient = true;
+        gradient.CornerRadius = 14;
+        Place(gradient, row, 2, cellW, rowH, width, height);
+
+        // Forest Glade signature leaf shape - opposite-corner asymmetric per-corner radii.
+        // Uses the Apos.Shapes 0.6.9 CornerRadii overload exposed via CustomRadiusTopLeft etc.
+        // CornerRadius = 0 because the per-corner values take over when any Custom* is set.
+        RoundedRectangleRuntime leaf = new RoundedRectangleRuntime();
+        leaf.Color = green;
+        leaf.CornerRadius = 0;
+        leaf.CustomRadiusTopLeft = 2;
+        leaf.CustomRadiusTopRight = 18;
+        leaf.CustomRadiusBottomRight = 2;
+        leaf.CustomRadiusBottomLeft = 18;
+        Place(leaf, row, 3, cellW, rowH, width, height);
+
+        // Fully-asymmetric per-corner radii - sanity check that the four corners are wired
+        // to the right Custom* property (a swap would be visible immediately here).
+        RoundedRectangleRuntime asym = new RoundedRectangleRuntime();
+        asym.Color = magenta;
+        asym.CornerRadius = 0;
+        asym.CustomRadiusTopLeft = 0;
+        asym.CustomRadiusTopRight = 30;
+        asym.CustomRadiusBottomRight = 12;
+        asym.CustomRadiusBottomLeft = 4;
+        Place(asym, row, 4, cellW, rowH, width, height);
+    }
+
+    private void BuildLineRow(int row, float cellW, float rowH)
+    {
+        const float width = 200f;
+        const float height = 80f;
+        Color teal = new Color(80, 180, 220);
+        Color orange = new Color(220, 160, 60);
+        Color purple = new Color(180, 80, 220);
+
+        LineRuntime thin = new LineRuntime();
+        thin.Color = teal;
+        thin.StrokeWidth = 2;
+        Place(thin, row, 0, cellW, rowH, width, height);
+
+        LineRuntime thick = new LineRuntime();
+        thick.Color = orange;
+        thick.StrokeWidth = 10;
+        Place(thick, row, 1, cellW, rowH, width, height);
+
+        LineRuntime roundedEnds = new LineRuntime();
+        roundedEnds.Color = purple;
+        roundedEnds.StrokeWidth = 14;
+        roundedEnds.IsRounded = true;
+        Place(roundedEnds, row, 2, cellW, rowH, width, height);
+
+        LineRuntime gradient = new LineRuntime();
+        gradient.StrokeWidth = 12;
+        gradient.IsRounded = true;
+        gradient.UseGradient = true;
+        Place(gradient, row, 3, cellW, rowH, width, height);
+
+        LineRuntime dropshadow = new LineRuntime();
+        dropshadow.Color = teal;
+        dropshadow.StrokeWidth = 10;
+        dropshadow.IsRounded = true;
+        dropshadow.HasDropshadow = true;
+        Place(dropshadow, row, 4, cellW, rowH, width, height);
+    }
+
+    private void BuildArcRow(int row, float cellW, float rowH)
+    {
+        const float size = 130f;
+
+        // Bare default - verifies the locked-in defaults from issue #2728. A regression in
+        // any of the unified ctor defaults shows up as a visibly-different first cell:
+        //   IsEndRounded = false (the breaking-change default on Apos; was true pre-#2728)
+        //   SweepAngle = 90
+        //   Thickness = 10
+        //   Color = white
+        ArcRuntime defaultArc = new ArcRuntime();
+        Place(defaultArc, row, 0, cellW, rowH, size, size);
+
+        // Same as the default but with IsEndRounded explicitly set - this is the toggle
+        // existing Apos consumers must apply if they relied on the previous rounded default.
+        // Documented in docs/gum-tool/upgrading/migrating-to-2026-may.md.
+        ArcRuntime rounded = new ArcRuntime();
+        rounded.IsEndRounded = true;
+        Place(rounded, row, 1, cellW, rowH, size, size);
+
+        // Full ring - exercises the SweepAngle = 360 path (DrawRing under the hood when
+        // ends are flat).
+        ArcRuntime fullRing = new ArcRuntime();
+        fullRing.SweepAngle = 360;
+        fullRing.Thickness = 8;
+        Place(fullRing, row, 2, cellW, rowH, size, size);
+
+        // Thick rounded half-circle - bigger stroke + rounded caps stress the radius math
+        // (the renderable computes inner/outer radii from Width/Height minus Thickness).
+        ArcRuntime thickHalf = new ArcRuntime();
+        thickHalf.SweepAngle = 180;
+        thickHalf.Thickness = 18;
+        thickHalf.IsEndRounded = true;
+        thickHalf.Color = new Color(220, 160, 60);
+        Place(thickHalf, row, 3, cellW, rowH, size, size);
+
+        // Gradient three-quarter arc - exercises the UseGradient branch in Arc.Render. The
+        // gradient stops are pre-seeded in the ctor (white to yellow); UseGradient = true
+        // picks them up.
+        ArcRuntime gradient = new ArcRuntime();
+        gradient.SweepAngle = 270;
+        gradient.Thickness = 14;
+        gradient.IsEndRounded = true;
+        gradient.UseGradient = true;
+        Place(gradient, row, 4, cellW, rowH, size, size);
+    }
+}


### PR DESCRIPTION
## Summary
- Refactors `Samples/MonoGameGumShapesGallery/Game1.cs` from one inline gallery into per-screen pages with a Forms nav strip, matching the pattern landed in #2737 for MonoGameGumInCode.
- `ShapeSurveyScreen` lifts the existing 4-row gallery (circles / rounded rects / lines / arcs) into a `FrameworkElement` screen without changing the layout.
- `GradientScreen` is new: a 3×3 grid of `RoundedRectangleRuntime` cells, each demoing one gradient configuration. Covers `GradientType` (Linear / Radial), all four `GeneralUnitType` options on the endpoints (`PixelsFromSmall` / `PixelsFromMiddle` / `PixelsFromLarge` / `Percentage`), and the radial-specific `GradientInnerRadius` / `GradientOuterRadius` in both `Absolute` and `PercentageOfParent` units.

## Dependency on #2723 / PR #2740
The two `Percentage`-units cells on the gradients page exercise the bug fixed in [#2740](https://github.com/vchelaru/Gum/pull/2740) (issue #2723). Until that PR lands, those two cells will render flat (end color only) because the renderable drops the world offset for `Percentage` units. Once #2740 merges to main, those cells render correctly and serve as ongoing visual regression coverage.

## Test plan
- [ ] `dotnet build Samples/MonoGameGumShapesGallery/MonoGameGumShapesGallery.csproj` — clean.
- [ ] Run the sample. Shape-survey page should look identical to before this PR.
- [ ] Click the \"Gradients\" nav button. Seven of nine cells should render gradients on first inspection; the two \"Linear Percentage\" cells will render flat until #2740 merges.
- [ ] After #2740 merges and this branch is rebased on main, all nine cells render gradients with the configurations their labels describe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)