### PR TITLE
Tighten gradient gallery layout: wider spacing, absolute cell width

### DIFF
--- a/Samples/MonoGameGumShapesGallery/Screens/GradientScreen.cs
+++ b/Samples/MonoGameGumShapesGallery/Screens/GradientScreen.cs
@@ -32,7 +32,7 @@ internal class GradientScreen : FrameworkElement
 
         ContainerRuntime container = new ContainerRuntime();
         container.ChildrenLayout = Gum.Managers.ChildrenLayout.TopToBottomStack;
-        container.StackSpacing = 8;
+        container.StackSpacing = 32;
         container.X = 8;
         container.Y = 8;
         this.AddChild(container);
@@ -66,9 +66,10 @@ internal class GradientScreen : FrameworkElement
     {
         ContainerRuntime row = new ContainerRuntime();
         row.ChildrenLayout = Gum.Managers.ChildrenLayout.LeftToRightStack;
-        row.StackSpacing = 12;
+        row.StackSpacing = 38;
         row.WidthUnits = Gum.DataTypes.DimensionUnitType.RelativeToChildren;
         row.HeightUnits = Gum.DataTypes.DimensionUnitType.RelativeToChildren;
+        row.Height = 0;
         parent.AddChild(row);
         return row;
     }
@@ -79,8 +80,10 @@ internal class GradientScreen : FrameworkElement
         ContainerRuntime cell = new ContainerRuntime();
         cell.ChildrenLayout = Gum.Managers.ChildrenLayout.TopToBottomStack;
         cell.StackSpacing = 4;
-        cell.WidthUnits = Gum.DataTypes.DimensionUnitType.RelativeToChildren;
+        cell.WidthUnits = Gum.DataTypes.DimensionUnitType.Absolute;
+        cell.Width = RectWidth;
         cell.HeightUnits = Gum.DataTypes.DimensionUnitType.RelativeToChildren;
+        cell.Height = 0;
         row.AddChild(cell);
 
         RoundedRectangleRuntime rect = new RoundedRectangleRuntime();


### PR DESCRIPTION
## Summary
Follow-up tuning to the gradient page added in #2741. The 8/12 stack-spacing values left cells visually crowded once two-line labels wrapped, and the `RelativeToChildren` cell width meant each cell hugged whichever side (rectangle vs label) happened to be wider — so the three cells in a row didn't line up.

- Bumps the outer container's `StackSpacing` 8 → 32 and each row's 12 → 38.
- Switches the cell from `RelativeToChildren` to `Absolute` width = `RectWidth` so rectangle and label edges line up across the row.
- Pins cell `Height = 0` with `HeightUnits = RelativeToChildren` so the row collapses to the tallest cell instead of inheriting a stale absolute height from the runtime defaults.

## Test plan
- [x] `dotnet build Samples/MonoGameGumShapesGallery/MonoGameGumShapesGallery.csproj` — clean.
- [x] Run the sample, switch to the Gradients page, eyeball that the 3×3 grid now has visible breathing room between cells and that the three cells in each row align horizontally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)