### PR TITLE
Add RuntimeObjectCreator tests for the Raylib runtime

### DIFF
--- a/Tests/RaylibGum.Tests/Wireframe/RuntimeObjectCreatorTests.cs
+++ b/Tests/RaylibGum.Tests/Wireframe/RuntimeObjectCreatorTests.cs
@@ -1,0 +1,112 @@
+using Gum.Renderables;
+using Gum.Wireframe;
+using RenderingLibrary.Graphics;
+using Shouldly;
+
+namespace RaylibGum.Tests.Wireframe;
+
+/// <summary>
+/// Unit tests for <see cref="RuntimeObjectCreator.TryHandleAsBaseType"/> as compiled for the
+/// Raylib runtime. The same source file backs every runtime via <c>#if</c> fences, but the
+/// Raylib path diverges from the XNA-like runtimes: Container/Component always resolve to an
+/// <see cref="InvisibleRenderable"/> and never honor <see cref="GraphicalUiElement.ShowLineRectangles"/>.
+/// </summary>
+public class RuntimeObjectCreatorTests : BaseTestClass
+{
+    public override void Dispose()
+    {
+        // The XNA-like RuntimeObjectCreator path reads this static; reset it so the
+        // ShowLineRectangles toggle test cannot leak into other tests.
+        GraphicalUiElement.ShowLineRectangles = false;
+        base.Dispose();
+    }
+
+    [Fact]
+    public void TryHandleAsBaseType_Circle_ReturnsLineCircle()
+    {
+        IRenderable result = RuntimeObjectCreator.TryHandleAsBaseType("Circle", null);
+        result.ShouldBeOfType<LineCircle>();
+    }
+
+    [Fact]
+    public void TryHandleAsBaseType_ColoredRectangle_ReturnsSolidRectangle()
+    {
+        IRenderable result = RuntimeObjectCreator.TryHandleAsBaseType("ColoredRectangle", null);
+        result.ShouldBeOfType<SolidRectangle>();
+    }
+
+    [Fact]
+    public void TryHandleAsBaseType_Component_ReturnsInvisibleRenderable()
+    {
+        IRenderable result = RuntimeObjectCreator.TryHandleAsBaseType("Component", null);
+
+        result.ShouldNotBeNull();
+        result.ShouldBeOfType<InvisibleRenderable>();
+    }
+
+    [Fact]
+    public void TryHandleAsBaseType_Container_ReturnsInvisibleRenderable()
+    {
+        IRenderable result = RuntimeObjectCreator.TryHandleAsBaseType("Container", null);
+
+        result.ShouldNotBeNull();
+        result.ShouldBeOfType<InvisibleRenderable>();
+    }
+
+    [Fact]
+    public void TryHandleAsBaseType_Container_ReturnsInvisibleRenderable_EvenWhenShowLineRectanglesIsTrue()
+    {
+        // Unlike the XNA-like runtimes, the Raylib path has no ShowLineRectangles branch:
+        // Container must resolve to an InvisibleRenderable regardless of the toggle. This
+        // locks in the platform divergence so it is not "fixed" to match MonoGame by accident.
+        GraphicalUiElement.ShowLineRectangles = true;
+
+        IRenderable result = RuntimeObjectCreator.TryHandleAsBaseType("Container", null);
+
+        result.ShouldBeOfType<InvisibleRenderable>();
+    }
+
+    [Fact]
+    public void TryHandleAsBaseType_NineSlice_ReturnsNineSlice()
+    {
+        IRenderable result = RuntimeObjectCreator.TryHandleAsBaseType("NineSlice", null);
+        result.ShouldBeOfType<NineSlice>();
+    }
+
+    [Fact]
+    public void TryHandleAsBaseType_Polygon_ReturnsLinePolygon()
+    {
+        IRenderable result = RuntimeObjectCreator.TryHandleAsBaseType("Polygon", null);
+        result.ShouldBeOfType<LinePolygon>();
+    }
+
+    [Fact]
+    public void TryHandleAsBaseType_Rectangle_ReturnsLineRectangle()
+    {
+        IRenderable result = RuntimeObjectCreator.TryHandleAsBaseType("Rectangle", null);
+        result.ShouldBeOfType<LineRectangle>();
+    }
+
+    [Fact]
+    public void TryHandleAsBaseType_Sprite_ReturnsSprite()
+    {
+        IRenderable result = RuntimeObjectCreator.TryHandleAsBaseType("Sprite", null);
+        result.ShouldBeOfType<Sprite>();
+    }
+
+    [Fact]
+    public void TryHandleAsBaseType_Text_ReturnsText()
+    {
+        IRenderable result = RuntimeObjectCreator.TryHandleAsBaseType("Text", null);
+        result.ShouldBeOfType<Text>();
+    }
+
+    [Fact]
+    public void TryHandleAsBaseType_UnrecognizedType_ReturnsNull()
+    {
+        // A non-standard name (e.g. a custom component's own name) is expected to fall through;
+        // ElementSaveExtensions.CreateGraphicalComponent relies on this null to recurse into base types.
+        IRenderable result = RuntimeObjectCreator.TryHandleAsBaseType("SomeCustomComponent", null);
+        result.ShouldBeNull();
+    }
+}


### PR DESCRIPTION
## What

Adds `Tests/RaylibGum.Tests/Wireframe/RuntimeObjectCreatorTests.cs` — factory-contract coverage for `RuntimeObjectCreator.TryHandleAsBaseType` as compiled for the **Raylib** runtime.

`RuntimeObjectCreator.cs` is a single source file `#if`-fenced into every runtime, but until now only the **MonoGame** compilation had tests (`MonoGameGum.Tests/Wireframe/RuntimeObjectCreatorTests.cs`). This is the first step toward issue #2747 ("tests for all platforms").

## Why the Raylib path needs its own tests

The Raylib compilation **diverges** from the XNA-like runtimes:
- `Container` / `Component` always resolve to an `InvisibleRenderable`.
- The Raylib path has **no `ShowLineRectangles` branch** — it never returns a `LineRectangle` for `Container`, unlike MonoGame/KNI/FNA which do when `GraphicalUiElement.ShowLineRectangles` is `true`.

The new file includes an explicit test that the toggle is ignored, so the divergence is locked in rather than silently "fixed" to match MonoGame.

## Result

All 11 new tests pass; the full `RaylibGum.Tests` suite stays green (154 passed). The Raylib factory contract is sound at the isolation level.

## Not in this PR

- KNI/FNA share the MonoGame source path exactly — `MonoGameGum.Tests` already covers the logic; dedicated test projects would only catch assembly-linking regressions (low value).
- Skia/Sokol do **not** compile `RuntimeObjectCreator.cs` at all (neither their csprojs nor `GumCommon` include it) — the `#if SKIA`/`SOKOL` branches appear to be dead code. Needs investigation before those platforms can be meaningfully tested; tracked separately under #2747.
- These are isolation-level tests (direct `TryHandleAsBaseType` calls with `null` managers, matching the MonoGame file). End-to-end `.gumx`-load coverage for Raylib is a larger build-out (`RaylibGum.Tests` has no file-loading harness today) and is left as follow-up.

Contributes to #2747.

🤖 Generated with [Claude Code](https://claude.com/claude-code)