### PR TITLE
Collapse shape-runtime color #if blocks behind a per-backend ColorExtensions

### DIFF
--- a/MonoGameGum/GueDeriving/CircleRuntime.cs
+++ b/MonoGameGum/GueDeriving/CircleRuntime.cs
@@ -9,6 +9,7 @@ using System;
 #if RAYLIB
 using Gum.Renderables;
 using Color = Raylib_cs.Color;
+using ColorExtensions = RaylibGum.Helpers.ColorExtensions;
 using ContainedCircleType = Gum.Renderables.LineCircle;
 #elif SOKOL
 using Gum.Renderables;
@@ -20,6 +21,7 @@ using Color = SkiaSharp.SKColor;
 using ContainedCircleType = SkiaGum.Renderables.LineCircle;
 #else
 using Color = Microsoft.Xna.Framework.Color;
+using ColorExtensions = ToolsUtilitiesStandard.Helpers.ColorExtensions;
 using ContainedCircleType = global::RenderingLibrary.Math.Geometry.LineCircle;
 using global::RenderingLibrary.Math.Geometry;
 #endif
@@ -51,17 +53,7 @@ public class CircleRuntime : GraphicalUiElement
         get => ContainedLineCircle.Color.A;
         set
         {
-#if RAYLIB
-            var color = ContainedLineCircle.Color;
-            color.A = (byte)value;
-            ContainedLineCircle.Color = color;
-#else
-            // ColorExtensions.WithAlpha is defined for System.Drawing.Color (the XNA-side LineCircle's Color type).
-            // The new version of Glue is moving away from XNA color values. This code converts color values. If this doesn't run, you need to upgrade your GLUX version.
-            // More info here: https://flatredball.com/documentation/tools/glue-reference/glujglux/
-            var color = ToolsUtilitiesStandard.Helpers.ColorExtensions.WithAlpha(ContainedLineCircle.Color, (byte)value);
-            ContainedLineCircle.Color = color;
-#endif
+            ContainedLineCircle.Color = ColorExtensions.WithAlpha(ContainedLineCircle.Color, (byte)value);
             NotifyPropertyChanged();
         }
     }
@@ -71,14 +63,7 @@ public class CircleRuntime : GraphicalUiElement
         get => ContainedLineCircle.Color.R;
         set
         {
-#if RAYLIB
-            var color = ContainedLineCircle.Color;
-            color.R = (byte)value;
-            ContainedLineCircle.Color = color;
-#else
-            var color = ToolsUtilitiesStandard.Helpers.ColorExtensions.WithRed(ContainedLineCircle.Color, (byte)value);
-            ContainedLineCircle.Color = color;
-#endif
+            ContainedLineCircle.Color = ColorExtensions.WithRed(ContainedLineCircle.Color, (byte)value);
             NotifyPropertyChanged();
         }
     }
@@ -88,14 +73,7 @@ public class CircleRuntime : GraphicalUiElement
         get => ContainedLineCircle.Color.G;
         set
         {
-#if RAYLIB
-            var color = ContainedLineCircle.Color;
-            color.G = (byte)value;
-            ContainedLineCircle.Color = color;
-#else
-            var color = ToolsUtilitiesStandard.Helpers.ColorExtensions.WithGreen(ContainedLineCircle.Color, (byte)value);
-            ContainedLineCircle.Color = color;
-#endif
+            ContainedLineCircle.Color = ColorExtensions.WithGreen(ContainedLineCircle.Color, (byte)value);
             NotifyPropertyChanged();
         }
     }
@@ -105,14 +83,7 @@ public class CircleRuntime : GraphicalUiElement
         get => ContainedLineCircle.Color.B;
         set
         {
-#if RAYLIB
-            var color = ContainedLineCircle.Color;
-            color.B = (byte)value;
-            ContainedLineCircle.Color = color;
-#else
-            var color = ToolsUtilitiesStandard.Helpers.ColorExtensions.WithBlue(ContainedLineCircle.Color, (byte)value);
-            ContainedLineCircle.Color = color;
-#endif
+            ContainedLineCircle.Color = ColorExtensions.WithBlue(ContainedLineCircle.Color, (byte)value);
             NotifyPropertyChanged();
         }
     }
@@ -163,12 +134,8 @@ public class CircleRuntime : GraphicalUiElement
 #if SKIA
             circle.CornerRadius = 0;
             circle.Color = SkiaSharp.SKColors.White;
-#elif RAYLIB
-            circle.Color = Raylib_cs.Color.White;
-#elif SOKOL
-            circle.Color = SokolGum.Color.White;
 #else
-            circle.Color = System.Drawing.Color.White;
+            circle.Color = ColorExtensions.White;
 #endif
             Width = 32;
             Height = 32;

--- a/MonoGameGum/GueDeriving/PolygonRuntime.cs
+++ b/MonoGameGum/GueDeriving/PolygonRuntime.cs
@@ -11,6 +11,7 @@ using System.Numerics;
 #if RAYLIB
 using Gum.Renderables;
 using Color = Raylib_cs.Color;
+using ColorExtensions = RaylibGum.Helpers.ColorExtensions;
 using ContainedPolygonType = Gum.Renderables.LinePolygon;
 #elif SOKOL
 using Gum.Renderables;
@@ -18,6 +19,7 @@ using Color = SokolGum.Color;
 using ContainedPolygonType = Gum.Renderables.LinePolygon;
 #else
 using Color = Microsoft.Xna.Framework.Color;
+using ColorExtensions = ToolsUtilitiesStandard.Helpers.ColorExtensions;
 using ContainedPolygonType = global::RenderingLibrary.Math.Geometry.LinePolygon;
 using global::RenderingLibrary.Math.Geometry;
 #endif
@@ -54,14 +56,7 @@ public class PolygonRuntime : InteractiveGue
         get => ContainedPolygon.Color.R;
         set
         {
-#if RAYLIB
-            var color = ContainedPolygon.Color;
-            color.R = (byte)value;
-            ContainedPolygon.Color = color;
-#else
-            var color = ToolsUtilitiesStandard.Helpers.ColorExtensions.WithRed(ContainedPolygon.Color, (byte)value);
-            ContainedPolygon.Color = color;
-#endif
+            ContainedPolygon.Color = ColorExtensions.WithRed(ContainedPolygon.Color, (byte)value);
             NotifyPropertyChanged();
         }
     }
@@ -74,14 +69,7 @@ public class PolygonRuntime : InteractiveGue
         get => ContainedPolygon.Color.G;
         set
         {
-#if RAYLIB
-            var color = ContainedPolygon.Color;
-            color.G = (byte)value;
-            ContainedPolygon.Color = color;
-#else
-            var color = ToolsUtilitiesStandard.Helpers.ColorExtensions.WithGreen(ContainedPolygon.Color, (byte)value);
-            ContainedPolygon.Color = color;
-#endif
+            ContainedPolygon.Color = ColorExtensions.WithGreen(ContainedPolygon.Color, (byte)value);
             NotifyPropertyChanged();
         }
     }
@@ -94,14 +82,7 @@ public class PolygonRuntime : InteractiveGue
         get => ContainedPolygon.Color.B;
         set
         {
-#if RAYLIB
-            var color = ContainedPolygon.Color;
-            color.B = (byte)value;
-            ContainedPolygon.Color = color;
-#else
-            var color = ToolsUtilitiesStandard.Helpers.ColorExtensions.WithBlue(ContainedPolygon.Color, (byte)value);
-            ContainedPolygon.Color = color;
-#endif
+            ContainedPolygon.Color = ColorExtensions.WithBlue(ContainedPolygon.Color, (byte)value);
             NotifyPropertyChanged();
         }
     }
@@ -114,14 +95,7 @@ public class PolygonRuntime : InteractiveGue
         get => ContainedPolygon.Color.A;
         set
         {
-#if RAYLIB
-            var color = ContainedPolygon.Color;
-            color.A = (byte)value;
-            ContainedPolygon.Color = color;
-#else
-            var color = ToolsUtilitiesStandard.Helpers.ColorExtensions.WithAlpha(ContainedPolygon.Color, (byte)value);
-            ContainedPolygon.Color = color;
-#endif
+            ContainedPolygon.Color = ColorExtensions.WithAlpha(ContainedPolygon.Color, (byte)value);
             NotifyPropertyChanged();
         }
     }
@@ -176,13 +150,7 @@ public class PolygonRuntime : InteractiveGue
             SetContainedObject(polygon);
             containedPolygon = polygon;
 
-#if RAYLIB
-            polygon.Color = Raylib_cs.Color.White;
-#elif SOKOL
-            polygon.Color = SokolGum.Color.White;
-#else
-            polygon.Color = System.Drawing.Color.White;
-#endif
+            polygon.Color = ColorExtensions.White;
 
             polygon.SetPoints(new Vector2[]
             {

--- a/MonoGameGum/GueDeriving/RectangleRuntime.cs
+++ b/MonoGameGum/GueDeriving/RectangleRuntime.cs
@@ -10,6 +10,7 @@ using System;
 #if RAYLIB
 using Gum.Renderables;
 using Color = Raylib_cs.Color;
+using ColorExtensions = RaylibGum.Helpers.ColorExtensions;
 using ContainedLineRectangle = Gum.Renderables.LineRectangle;
 #elif SOKOL
 using Gum.Renderables;
@@ -21,6 +22,7 @@ using Color = SkiaSharp.SKColor;
 using ContainedLineRectangle = SkiaGum.Renderables.LineRectangle;
 #else
 using Color = Microsoft.Xna.Framework.Color;
+using ColorExtensions = ToolsUtilitiesStandard.Helpers.ColorExtensions;
 using ContainedLineRectangle = global::RenderingLibrary.Math.Geometry.LineRectangle;
 using global::RenderingLibrary.Math.Geometry;
 #endif
@@ -72,17 +74,7 @@ public class RectangleRuntime : GraphicalUiElement
         get => ContainedLineRectangle.Color.A;
         set
         {
-#if RAYLIB
-            var color = ContainedLineRectangle.Color;
-            color.A = (byte)value;
-            ContainedLineRectangle.Color = color;
-#else
-            // ColorExtensions.WithAlpha is defined for System.Drawing.Color (the XNA-side LineCircle's Color type).
-            // The new version of Glue is moving away from XNA color values. This code converts color values. If this doesn't run, you need to upgrade your GLUX version.
-            // More info here: https://flatredball.com/documentation/tools/glue-reference/glujglux/
-            var color = ToolsUtilitiesStandard.Helpers.ColorExtensions.WithAlpha(ContainedLineRectangle.Color, (byte)value);
-            ContainedLineRectangle.Color = color;
-#endif
+            ContainedLineRectangle.Color = ColorExtensions.WithAlpha(ContainedLineRectangle.Color, (byte)value);
             NotifyPropertyChanged();
         }
     }
@@ -92,14 +84,7 @@ public class RectangleRuntime : GraphicalUiElement
         get => ContainedLineRectangle.Color.R;
         set
         {
-#if RAYLIB
-            var color = ContainedLineRectangle.Color;
-            color.R = (byte)value;
-            ContainedLineRectangle.Color = color;
-#else
-            var color = ToolsUtilitiesStandard.Helpers.ColorExtensions.WithRed(ContainedLineRectangle.Color, (byte)value);
-            ContainedLineRectangle.Color = color;
-#endif
+            ContainedLineRectangle.Color = ColorExtensions.WithRed(ContainedLineRectangle.Color, (byte)value);
             NotifyPropertyChanged();
         }
     }
@@ -109,14 +94,7 @@ public class RectangleRuntime : GraphicalUiElement
         get => ContainedLineRectangle.Color.G;
         set
         {
-#if RAYLIB
-            var color = ContainedLineRectangle.Color;
-            color.G = (byte)value;
-            ContainedLineRectangle.Color = color;
-#else
-            var color = ToolsUtilitiesStandard.Helpers.ColorExtensions.WithGreen(ContainedLineRectangle.Color, (byte)value);
-            ContainedLineRectangle.Color = color;
-#endif
+            ContainedLineRectangle.Color = ColorExtensions.WithGreen(ContainedLineRectangle.Color, (byte)value);
             NotifyPropertyChanged();
         }
     }
@@ -126,14 +104,7 @@ public class RectangleRuntime : GraphicalUiElement
         get => ContainedLineRectangle.Color.B;
         set
         {
-#if RAYLIB
-            var color = ContainedLineRectangle.Color;
-            color.B = (byte)value;
-            ContainedLineRectangle.Color = color;
-#else
-            var color = ToolsUtilitiesStandard.Helpers.ColorExtensions.WithBlue(ContainedLineRectangle.Color, (byte)value);
-            ContainedLineRectangle.Color = color;
-#endif
+            ContainedLineRectangle.Color = ColorExtensions.WithBlue(ContainedLineRectangle.Color, (byte)value);
             NotifyPropertyChanged();
         }
     }
@@ -170,12 +141,8 @@ public class RectangleRuntime : GraphicalUiElement
 
 #if SKIA
             rectangle.Color = SkiaSharp.SKColors.White;
-#elif RAYLIB
-            rectangle.Color = Raylib_cs.Color.White;
-#elif SOKOL
-            rectangle.Color = SokolGum.Color.White;
 #else
-            rectangle.Color = System.Drawing.Color.White;
+            rectangle.Color = ColorExtensions.White;
 #endif
 
             Width = 50;

--- a/Runtimes/RaylibGum/Helpers/ColorExtensions.cs
+++ b/Runtimes/RaylibGum/Helpers/ColorExtensions.cs
@@ -1,0 +1,48 @@
+using Raylib_cs;
+
+namespace RaylibGum.Helpers;
+
+/// <summary>
+/// Extension and helper methods for working with <see cref="Color"/> values on the Raylib backend.
+/// Mirrors the surface of the XNA-side ToolsUtilitiesStandard.Helpers.ColorExtensions so shared
+/// runtime code can call the same members on either backend.
+/// </summary>
+public static class ColorExtensions
+{
+    /// <summary>
+    /// Gets an opaque white color.
+    /// </summary>
+    public static Color White => Color.White;
+
+    /// <summary>
+    /// Returns a copy of the color with its alpha channel replaced by the specified value.
+    /// </summary>
+    public static Color WithAlpha(this Color color, byte value)
+    {
+        return new Color(color.R, color.G, color.B, value);
+    }
+
+    /// <summary>
+    /// Returns a copy of the color with its red channel replaced by the specified value.
+    /// </summary>
+    public static Color WithRed(this Color color, byte value)
+    {
+        return new Color(value, color.G, color.B, color.A);
+    }
+
+    /// <summary>
+    /// Returns a copy of the color with its green channel replaced by the specified value.
+    /// </summary>
+    public static Color WithGreen(this Color color, byte value)
+    {
+        return new Color(color.R, value, color.B, color.A);
+    }
+
+    /// <summary>
+    /// Returns a copy of the color with its blue channel replaced by the specified value.
+    /// </summary>
+    public static Color WithBlue(this Color color, byte value)
+    {
+        return new Color(color.R, color.G, value, color.A);
+    }
+}

--- a/Tests/RaylibGum.Tests/Helpers/ColorExtensionsTests.cs
+++ b/Tests/RaylibGum.Tests/Helpers/ColorExtensionsTests.cs
@@ -1,0 +1,58 @@
+using Raylib_cs;
+using RaylibGum.Helpers;
+using Shouldly;
+
+namespace RaylibGum.Tests.Helpers;
+
+public class ColorExtensionsTests : BaseTestClass
+{
+    [Fact]
+    public void White_ShouldBeRaylibWhite()
+    {
+        ColorExtensions.White.ShouldBe(Color.White);
+    }
+
+    [Fact]
+    public void WithAlpha_ShouldSetAlpha_AndLeaveOtherChannelsIntact()
+    {
+        Color color = new Color((byte)10, (byte)20, (byte)30, (byte)40);
+        Color result = ColorExtensions.WithAlpha(color, 200);
+        result.R.ShouldBe((byte)10);
+        result.G.ShouldBe((byte)20);
+        result.B.ShouldBe((byte)30);
+        result.A.ShouldBe((byte)200);
+    }
+
+    [Fact]
+    public void WithBlue_ShouldSetBlue_AndLeaveOtherChannelsIntact()
+    {
+        Color color = new Color((byte)10, (byte)20, (byte)30, (byte)40);
+        Color result = ColorExtensions.WithBlue(color, 200);
+        result.R.ShouldBe((byte)10);
+        result.G.ShouldBe((byte)20);
+        result.B.ShouldBe((byte)200);
+        result.A.ShouldBe((byte)40);
+    }
+
+    [Fact]
+    public void WithGreen_ShouldSetGreen_AndLeaveOtherChannelsIntact()
+    {
+        Color color = new Color((byte)10, (byte)20, (byte)30, (byte)40);
+        Color result = ColorExtensions.WithGreen(color, 200);
+        result.R.ShouldBe((byte)10);
+        result.G.ShouldBe((byte)200);
+        result.B.ShouldBe((byte)30);
+        result.A.ShouldBe((byte)40);
+    }
+
+    [Fact]
+    public void WithRed_ShouldSetRed_AndLeaveOtherChannelsIntact()
+    {
+        Color color = new Color((byte)10, (byte)20, (byte)30, (byte)40);
+        Color result = ColorExtensions.WithRed(color, 200);
+        result.R.ShouldBe((byte)200);
+        result.G.ShouldBe((byte)20);
+        result.B.ShouldBe((byte)30);
+        result.A.ShouldBe((byte)40);
+    }
+}

--- a/ToolsUtilities/Helpers/ColorExtensions.cs
+++ b/ToolsUtilities/Helpers/ColorExtensions.cs
@@ -2,6 +2,11 @@
 
 namespace ToolsUtilitiesStandard.Helpers {
 	public static class ColorExtensions {
+		/// <summary>
+		/// Gets an opaque white color.
+		/// </summary>
+		public static Color White => Color.White;
+
 		public static Color WithAlpha(this Color color, byte value) {
 			return Color.FromArgb(value, color.R, color.G, color.B);
 		}


### PR DESCRIPTION
Closes #2751.

## What

Collapses the per-channel color `#if RAYLIB / #else` blocks and the White-init `#elif` ladders in `CircleRuntime`, `PolygonRuntime`, and `RectangleRuntime` behind a per-backend `ColorExtensions` helper, so the runtime call sites become branchless.

## How

- **New** `Runtimes/RaylibGum/Helpers/ColorExtensions.cs` — a Raylib-side `ColorExtensions` static class mirroring the XNA `ToolsUtilitiesStandard.Helpers.ColorExtensions` surface (`WithRed/WithGreen/WithBlue/WithAlpha` + `White`).
- **Edited** `ToolsUtilities/Helpers/ColorExtensions.cs` — added a `White` member so `ColorExtensions.White` resolves on both backends.
- **Edited** the three runtime files — added a `using ColorExtensions = ...` type alias to the `#if RAYLIB` and `#else` using-blocks, then replaced each per-channel setter `#if` block with a single branchless `ColorExtensions.WithX(...)` call and folded the White-init ladders. The `#if SKIA` rungs are kept untouched (they are live for the Skia file-link target and `CircleRuntime`'s also sets `CornerRadius`).

Pure refactor — no behavior change. Net: ~119 lines of `#if`-guarded duplication removed.

## Scope note

`ColoredRectangleRuntime` is **deliberately not included**, even though #2751's acceptance lists it. It is compiled on four backends (Raylib, Skia, Sokol, MonoGame), so unifying it correctly needs a Sokol `ColorExtensions` and a decision on its Skia branch — a second platform pair. Per the cross-platform unification discipline (one pair per turn), that's a clean follow-up. This PR is the MonoGame ↔ Raylib pair on the three Raylib-only shape runtimes.

## Verification

- `RaylibGum`, `MonoGameGum`, `KniGum`, `RaylibGum.Tests` build with 0 warnings / 0 errors.
- New `ColorExtensionsTests` (5 tests) + existing RaylibGum tests: 42 passed.
- MonoGameGum runtime tests: 660 passed.
- Pre-existing `SokolGum` / `FNA.Core` build failures in `AllLibraries.sln` (missing native bindings / submodule) are unrelated and present on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
