### PR TITLE
Remove redundant #define XNALIKE headers from GueDeriving runtimes

### DIFF
--- a/MonoGameGum/GueDeriving/CircleRuntime.cs
+++ b/MonoGameGum/GueDeriving/CircleRuntime.cs
@@ -1,7 +1,3 @@
-#if MONOGAME || FNA || KNI
-#define XNALIKE
-#endif
-
 using Gum.Wireframe;
 using RenderingLibrary;
 using System;

--- a/MonoGameGum/GueDeriving/ColoredRectangleRuntime.cs
+++ b/MonoGameGum/GueDeriving/ColoredRectangleRuntime.cs
@@ -1,7 +1,3 @@
-#if MONOGAME || FNA || KNI
-#define XNALIKE
-#endif
-
 using Gum.Wireframe;
 using RenderingLibrary;
 using RenderingLibrary.Graphics;

--- a/MonoGameGum/GueDeriving/ContainerRuntime.cs
+++ b/MonoGameGum/GueDeriving/ContainerRuntime.cs
@@ -1,8 +1,4 @@
-﻿#if MONOGAME || FNA || KNI
-#define XNALIKE
-#endif
-
-using Gum.RenderingLibrary;
+﻿using Gum.RenderingLibrary;
 using Gum.Wireframe;
 using RenderingLibrary;
 using RenderingLibrary.Graphics;

--- a/MonoGameGum/GueDeriving/NineSliceRuntime.cs
+++ b/MonoGameGum/GueDeriving/NineSliceRuntime.cs
@@ -1,7 +1,3 @@
-#if MONOGAME || FNA || KNI
-#define XNALIKE
-#endif
-
 using Gum.Wireframe;
 using RenderingLibrary;
 using System;

--- a/MonoGameGum/GueDeriving/PolygonRuntime.cs
+++ b/MonoGameGum/GueDeriving/PolygonRuntime.cs
@@ -1,7 +1,3 @@
-#if MONOGAME || FNA || KNI
-#define XNALIKE
-#endif
-
 using Gum.Wireframe;
 using RenderingLibrary;
 using System;

--- a/MonoGameGum/GueDeriving/RectangleRuntime.cs
+++ b/MonoGameGum/GueDeriving/RectangleRuntime.cs
@@ -1,8 +1,4 @@
-﻿#if MONOGAME || FNA || KNI
-#define XNALIKE
-#endif
-
-using Gum.Wireframe;
+﻿using Gum.Wireframe;
 using RenderingLibrary;
 using System;
 

--- a/MonoGameGum/GueDeriving/SpriteRuntime.cs
+++ b/MonoGameGum/GueDeriving/SpriteRuntime.cs
@@ -1,7 +1,3 @@
-#if MONOGAME || FNA || KNI
-#define XNALIKE
-#endif
-
 using Gum.Graphics.Animation;
 using Gum.RenderingLibrary;
 using Gum.Wireframe;

--- a/MonoGameGum/GueDeriving/TextRuntime.cs
+++ b/MonoGameGum/GueDeriving/TextRuntime.cs
@@ -1,7 +1,4 @@
-﻿#if MONOGAME || KNI || XNA4 || FNA
-#define XNALIKE
-#endif
-using Gum.DataTypes;
+﻿using Gum.DataTypes;
 #if RAYLIB
 using Gum.Renderables;
 #elif SKIA


### PR DESCRIPTION
Closes #2754 (GueDeriving slice; remaining non-runtime files intentionally not pursued — see issue).

## What

Removes the leading `#if MONOGAME || FNA || KNI` / `#define XNALIKE` / `#endif` header block from the 8 `MonoGameGum/GueDeriving/*Runtime.cs` files.

## Why it's safe

Pure build plumbing, no behavior change. The header was redundant:

- `MonoGameGum`, `KniGum`, and `FnaGum` already define `XNALIKE` in their csproj base `<DefineConstants>`.
- `RaylibGum` / `SkiaGum` / `SokolGum` file-link these files and correctly do **not** define `XNALIKE`; the `#if MONOGAME || FNA || KNI` guard meant the `#define` never fired there anyway.

So `<DefineConstants>` is now the single source of truth for `XNALIKE` in these files. As a bonus this kills the drift the issue mentions — `TextRuntime.cs`'s header had picked up `XNA4`; the other seven hadn't.

## Verification

Built individually (`AllLibraries.sln` can't build as a whole here — it references a missing `FNA.Core` git submodule, pre-existing and unrelated):

- `MonoGameGum` (XNALIKE defined) — 0 errors
- `KniGum` (XNALIKE defined) — 0 errors
- `RaylibGum` (no XNALIKE) — 0 errors
- `SkiaGum` (no XNALIKE) — 0 errors
- `FnaGum` — not built (missing FNA submodule); its csproj defines `XNALIKE` identically to KniGum, so no file-specific risk.

Tests: `MonoGameGum.Tests` 1436 passed, `RaylibGum.Tests` 159 passed.

## Scope note

This is **only the GueDeriving-8 slice**. The other 12 files using the same `#define XNALIKE` header (under `Input/`, `Forms/`, `RenderingLibrary/`, `Wireframe/`, plus `GumService`/`GumHotReloadManager`) are deliberately left out — 6 of them are file-linked into the FRB1-facing `GumCore*` projects, which don't currently define `XNALIKE`, so removing those headers requires coordinated `<DefineConstants>` additions across those csprojs. Tracked on #2754.

🤖 Generated with [Claude Code](https://claude.com/claude-code)