### PR TITLE
Spike #2758: renderable-swap mechanism for a fill-capable CircleRuntime

### DIFF
--- a/MonoGameGum.Tests/Runtimes/CircleRuntimeTests.cs
+++ b/MonoGameGum.Tests/Runtimes/CircleRuntimeTests.cs
@@ -1,0 +1,24 @@
+using Gum.GueDeriving;
+using Microsoft.Xna.Framework;
+using RenderingLibrary.Math.Geometry;
+using Shouldly;
+using Xunit;
+
+namespace MonoGameGum.Tests.Runtimes;
+
+public class CircleRuntimeTests : BaseTestClass
+{
+    // Spike (#2758): when the optional MonoGameGumShapes package is NOT referenced (as is the
+    // case for this test project), the ShapeRenderableRegistry factory is never populated.
+    // Setting FillColor must degrade gracefully — no crash, and the runtime stays on its
+    // outline LineCircle renderable.
+    [Fact]
+    public void FillColor_WhenSetWithoutShapesPackage_DoesNotThrowAndStaysOutline()
+    {
+        CircleRuntime sut = new();
+
+        Should.NotThrow(() => sut.FillColor = Color.Red);
+
+        sut.RenderableComponent.ShouldBeOfType<LineCircle>();
+    }
+}

--- a/MonoGameGum/GueDeriving/CircleRuntime.cs
+++ b/MonoGameGum/GueDeriving/CircleRuntime.cs
@@ -114,6 +114,78 @@ public class CircleRuntime : GraphicalUiElement
 #endif
     }
 
+#if XNALIKE
+    Color? _fillColor;
+
+    /// <summary>
+    /// When non-null, the circle renders as a solid fill of this color. When null (the default),
+    /// the circle renders as an outline via its <see cref="LineCircle"/> renderable.
+    /// </summary>
+    /// <remarks>
+    /// Filled rendering requires the optional MonoGameGumShapes (Apos.Shapes) package, which
+    /// registers a renderable factory with <see cref="ShapeRenderableRegistry"/>. When that
+    /// package is not referenced, setting <see cref="FillColor"/> is a graceful no-op for the
+    /// visual: the runtime stays on its outline renderable rather than crashing.
+    ///
+    /// Spike (#2758): proof-of-concept for the renderable-swap mechanism only. It does not yet
+    /// route the existing Color/Radius/Alpha properties through a swapped-in fill renderable —
+    /// that wiring is part of the actual ColoredCircle/Circle collapse, which is out of scope
+    /// for the spike.
+    /// </remarks>
+    public Color? FillColor
+    {
+        get => _fillColor;
+        set
+        {
+            _fillColor = value;
+            UpdateRenderableFromFillColor();
+            NotifyPropertyChanged();
+        }
+    }
+
+    /// <summary>
+    /// Swaps the contained renderable to match the current <see cref="FillColor"/>: a
+    /// fill-capable renderable (from <see cref="ShapeRenderableRegistry"/>) when FillColor is
+    /// set, or the outline <see cref="LineCircle"/> when it is null. This is the core of the
+    /// renderable-swap mechanism the spike exists to prove.
+    /// </summary>
+    void UpdateRenderableFromFillColor()
+    {
+        if (_fillColor.HasValue)
+        {
+            if (RenderableComponent is IFilledShapeRenderable existingFill)
+            {
+                // Already on a fill-capable renderable — just update it.
+                existingFill.IsFilled = true;
+                existingFill.Color = _fillColor.Value;
+            }
+            else
+            {
+                var factory = ShapeRenderableRegistry.CreateFilledCircleRenderable;
+                if (factory != null)
+                {
+                    var fillRenderable = factory();
+                    fillRenderable.IsFilled = true;
+                    fillRenderable.Color = _fillColor.Value;
+                    containedLineCircle = null;
+                    SetContainedObject(fillRenderable);
+                }
+                // else: MonoGameGumShapes is not referenced, so no fill-capable renderable can
+                // be created. Degrade gracefully — stay on the outline LineCircle, no crash.
+            }
+        }
+        else if (RenderableComponent is not ContainedCircleType)
+        {
+            // FillColor cleared while on a fill renderable — swap back to the outline LineCircle.
+            var lineCircle = new ContainedCircleType();
+            lineCircle.CircleOrigin = CircleOrigin.TopLeft;
+            lineCircle.Color = ColorExtensions.White;
+            containedLineCircle = lineCircle;
+            SetContainedObject(lineCircle);
+        }
+    }
+#endif
+
     /// <inheritdoc cref="GraphicalUiElement.AddToManagers()"/>
     [Obsolete("Use the AddToRoot extension method instead (e.g. myCircle.AddToRoot()).")]
     public void AddToManagers() => base.AddToManagers(SystemManagers.Default, layer: null);

--- a/MonoGameGum/GueDeriving/IFilledShapeRenderable.cs
+++ b/MonoGameGum/GueDeriving/IFilledShapeRenderable.cs
@@ -1,0 +1,31 @@
+#if XNALIKE
+using Microsoft.Xna.Framework;
+using RenderingLibrary.Graphics;
+
+namespace Gum.GueDeriving;
+
+/// <summary>
+/// Capability contract for a renderable that can draw a filled shape. Defined in core
+/// MonoGameGum so that runtimes like <see cref="CircleRuntime"/> can drive a fill-capable
+/// renderable without core referencing the optional Apos.Shapes package.
+/// </summary>
+/// <remarks>
+/// The optional MonoGameGumShapes package implements this interface on its Apos.Shapes-backed
+/// renderables and registers a factory via <see cref="ShapeRenderableRegistry"/>. When that
+/// package is not referenced, no factory is registered and runtimes degrade to outline-only.
+///
+/// Spike (#2758): throwaway scope — only the members CircleRuntime's FillColor path needs.
+/// </remarks>
+public interface IFilledShapeRenderable : IRenderable
+{
+    /// <summary>
+    /// Whether the shape renders as a solid fill (<c>true</c>) or an outline (<c>false</c>).
+    /// </summary>
+    bool IsFilled { get; set; }
+
+    /// <summary>
+    /// The color used to render the shape.
+    /// </summary>
+    Color Color { get; set; }
+}
+#endif

--- a/MonoGameGum/GueDeriving/ShapeRenderableRegistry.cs
+++ b/MonoGameGum/GueDeriving/ShapeRenderableRegistry.cs
@@ -1,0 +1,31 @@
+#if XNALIKE
+using System;
+
+namespace Gum.GueDeriving;
+
+/// <summary>
+/// Registration point that lets the optional MonoGameGumShapes package supply fill-capable
+/// shape renderables to core runtimes (currently <see cref="CircleRuntime"/>) without core
+/// MonoGameGum referencing Apos.Shapes.
+/// </summary>
+/// <remarks>
+/// Mirrors the existing optional-package extension pattern used by
+/// <c>ElementSaveExtensions.RegisterGueInstantiation</c> and
+/// <c>CustomSetPropertyOnRenderable.AdditionalPropertyOnRenderable</c>: core defines the hook,
+/// and MonoGameGumShapes fills it from its <c>[ModuleInitializer]</c>
+/// (<c>AposShapeRuntime.RegisterRuntimeTypes</c>). When the package is absent the factory
+/// stays null and runtimes degrade to outline-only.
+///
+/// Spike (#2758): throwaway scope — a single circle factory. The real implementation would
+/// generalize this to a capability-keyed registry (filled? rounded? gradient?).
+/// </remarks>
+public static class ShapeRenderableRegistry
+{
+    /// <summary>
+    /// Factory that creates a fill-capable circle renderable, or <c>null</c> when no shapes
+    /// package is loaded. Set by MonoGameGumShapes at module-init time; consumed by
+    /// <see cref="CircleRuntime"/> when its <c>FillColor</c> is assigned a non-null value.
+    /// </summary>
+    public static Func<IFilledShapeRenderable>? CreateFilledCircleRenderable { get; set; }
+}
+#endif

--- a/Runtimes/GumShapes/GueDeriving/AposShapeRuntime.cs
+++ b/Runtimes/GumShapes/GueDeriving/AposShapeRuntime.cs
@@ -64,9 +64,13 @@ public abstract class AposShapeRuntime : GraphicalUiElement
 
         StandardElementsManager.Self.CustomGetDefaultState += HandleCustomGetDefaultState;
 
-        CustomSetPropertyOnRenderable.AdditionalPropertyOnRenderable += 
+        CustomSetPropertyOnRenderable.AdditionalPropertyOnRenderable +=
             MonoGameGumShapes.CustomSetPropertyOnRenderable.SetPropertyOnRenderableFunc;
 
+        // Spike (#2758): supply core CircleRuntime with a fill-capable renderable factory.
+        // Core MonoGameGum cannot reference Apos.Shapes, so it exposes ShapeRenderableRegistry
+        // as the extension point and we fill it here, from this same module initializer.
+        ShapeRenderableRegistry.CreateFilledCircleRenderable = () => new Circle();
     }
 
     private static StateSave HandleCustomGetDefaultState(string arg)

--- a/Runtimes/GumShapes/Renderables/RenderableShapeBase.cs
+++ b/Runtimes/GumShapes/Renderables/RenderableShapeBase.cs
@@ -2,6 +2,7 @@
 using Gum;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using RenderingLibrary;
@@ -17,7 +18,10 @@ using Color = Microsoft.Xna.Framework.Color;
 
 namespace MonoGameAndGum.Renderables;
 
-public abstract class RenderableShapeBase : RenderableBase
+// IFilledShapeRenderable is the core-side (MonoGameGum/KniGum) capability contract that lets
+// CircleRuntime drive a fill-capable renderable across the optional-dependency boundary. The
+// IsFilled and Color members it requires already exist below — see issue #2758.
+public abstract class RenderableShapeBase : RenderableBase, IFilledShapeRenderable
 {
     protected ShapeRenderer ShapeRenderer => ShapeRenderer.Self;
 

--- a/Tests/MonoGameGum.Shapes.Tests/CircleRuntimeFillColorTests.cs
+++ b/Tests/MonoGameGum.Shapes.Tests/CircleRuntimeFillColorTests.cs
@@ -1,0 +1,54 @@
+using Gum.GueDeriving;
+using Microsoft.Xna.Framework;
+using MonoGameAndGum.Renderables;
+using RenderingLibrary.Math.Geometry;
+using Shouldly;
+
+namespace MonoGameGum.Shapes.Tests;
+
+// Spike (#2758): proves the renderable-swap mechanism. A core CircleRuntime (in MonoGameGum,
+// which does NOT reference Apos.Shapes) acquires a fill-capable Apos.Shapes renderable across
+// the optional-dependency boundary via ShapeRenderableRegistry, which the optional
+// MonoGameGumShapes package populates from its [ModuleInitializer].
+public class CircleRuntimeFillColorTests
+{
+    public CircleRuntimeFillColorTests()
+    {
+        // CircleRuntime lives in core MonoGameGum, so newing one does not load the
+        // MonoGameGumShapes assembly or fire its [ModuleInitializer]. Touch the registration
+        // explicitly so the registry is populated. The call is idempotent.
+        AposShapeRuntime.RegisterRuntimeTypes();
+    }
+
+    [Fact]
+    public void FillColor_WhenClearedToNull_SwapsRenderableBackToLineCircle()
+    {
+        CircleRuntime sut = new();
+        sut.FillColor = Color.Red;
+        sut.FillColor = null;
+
+        sut.RenderableComponent.ShouldBeOfType<LineCircle>();
+    }
+
+    [Fact]
+    public void FillColor_WhenSet_ForwardsColorToFilledRenderable()
+    {
+        CircleRuntime sut = new();
+        sut.FillColor = Color.Red;
+
+        Circle renderable = sut.RenderableComponent.ShouldBeOfType<Circle>();
+        renderable.IsFilled.ShouldBeTrue();
+        renderable.Color.ShouldBe(Color.Red);
+    }
+
+    [Fact]
+    public void FillColor_WhenSet_SwapsRenderableToFilledShape()
+    {
+        CircleRuntime sut = new();
+        sut.RenderableComponent.ShouldBeOfType<LineCircle>();
+
+        sut.FillColor = Color.Red;
+
+        sut.RenderableComponent.ShouldBeOfType<Circle>();
+    }
+}


### PR DESCRIPTION
## Spike #2758 — outcome

**Decision: capability-factory / registration, not composite, for the `Circle` collapse.**

The spike's load-bearing question was: *how does a single `CircleRuntime` (in core `MonoGameGum`) acquire a fill-capable renderable from the optional Apos.Shapes package, without core referencing that package?*

**Composite is dead on arrival for `Circle`.** Composite means core `CircleRuntime` owns both renderables and toggles between them — but the fill renderable (`MonoGameAndGum.Renderables.Circle`) lives in `MonoGameGumShapes`, and the dependency arrow is `MonoGameGumShapes → MonoGameGum` only. Core can't `new Circle()` — can't even name the type. This contradicts `TypeCollapse.md`'s "composite first" recommendation *for `Circle` specifically*; `Rectangle` is unaffected (both its renderables ship in core).

**The good news:** the capability-factory is *one more* of an extension pattern the codebase already uses for this exact optional-package boundary — `ElementSaveExtensions.RegisterGueInstantiation`, `StandardElementsManager.CustomGetDefaultState`, `CustomSetPropertyOnRenderable.AdditionalPropertyOnRenderable`. All core-defined hooks, all filled by `MonoGameGumShapes` from the same `[ModuleInitializer]`. And `GraphicalUiElement.SetContainedObject` already does the renderable rewire. Low risk.

## Proof-of-concept (throwaway-quality, FillColor-only per spike scope)

- **Core `MonoGameGum`** (`#if XNALIKE`): `IFilledShapeRenderable` capability contract + `ShapeRenderableRegistry` static extension point.
- **`CircleRuntime.FillColor`** (`Color?`) drives the swap via `SetContainedObject`: builds a fill-capable renderable from the registry when present; stays on the outline `LineCircle` when absent — graceful degradation, no crash.
- **`MonoGameGumShapes`**: `RenderableShapeBase` implements `IFilledShapeRenderable`; `AposShapeRuntime.RegisterRuntimeTypes()` registers `() => new Circle()`.

## Tests — both sides of the boundary

- `MonoGameGum.Shapes.Tests/CircleRuntimeFillColorTests` — the swap works (renderable becomes the Apos `Circle`, color forwarded, swaps back to `LineCircle` on null).
- `MonoGameGum.Tests/Runtimes/CircleRuntimeTests` — graceful degradation when `MonoGameGumShapes` is *not* referenced (no crash, stays outline).

Full `MonoGameGum.Shapes.Tests` (21) and `MonoGameGum.Tests` Runtimes (649) green. `KniGum` / `KniGumShapes` / `RaylibGum` build clean. `FnaGum` not verified — the FNA submodule isn't checked out in this worktree — but it follows the same glob + `XNALIKE` path with no shapes package, landing on graceful degradation.

## Findings for the *actual* collapse (out of scope here; recorded in `TypeCollapse.md`)

1. Registration is assembly-load-triggered, and `CircleRuntime` lives in a different assembly than the registrant — using `CircleRuntime` alone doesn't load `MonoGameGumShapes`. The collapse should make the load-order contract explicit.
2. The `internal OnPreRender` hook can't be wired from core — `StrokeWidth` with `ScreenPixel` units will need the factory signature to become `Func<GraphicalUiElement, IFilledShapeRenderable>`.
3. `CircleRuntime`'s existing `Color`/`Radius`/`Alpha` read through a `LineCircle` cast that returns null post-swap — routing those is the bulk of the real collapse work.

`TypeCollapse.md` lives under the gitignored `.claude/designs/` tree, so its update isn't in this diff — it's been updated in the local checkout with the full outcome writeup.

Closes #2758

🤖 Generated with [Claude Code](https://claude.com/claude-code)
