### PR TITLE
Phase 1 of #2761: introduce general-purpose RenderableRegistry

### DIFF
--- a/GumCommon/GueDeriving/RenderableRegistry.cs
+++ b/GumCommon/GueDeriving/RenderableRegistry.cs
@@ -1,0 +1,129 @@
+using System;
+using System.Collections.Generic;
+
+namespace Gum.GueDeriving;
+
+/// <summary>
+/// Registration point that lets optional packages — or consumers — supply renderable
+/// implementations to core <see cref="Gum.Wireframe.GraphicalUiElement"/>-derived runtimes
+/// without core MonoGameGum referencing those packages.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Mirrors the existing optional-package extension pattern used by
+/// <c>ElementSaveExtensions.RegisterGueInstantiation</c>,
+/// <c>StandardElementsManager.CustomGetDefaultState</c>, and
+/// <c>CustomSetPropertyOnRenderable.AdditionalPropertyOnRenderable</c>: core defines the
+/// hook, an optional package (or test setup) fills it. Capabilities are keyed by type —
+/// typically a small capability interface such as <c>IFilledShapeRenderable</c>.
+/// </para>
+/// <para>
+/// Two registration semantics are supported, layered by priority. The general factory
+/// (<see cref="RegisterFactory{T}"/>) is the active layer; the default factory
+/// (<see cref="RegisterDefaultFactory{T}"/>) is the fallback. <see cref="GetFactory{T}"/>
+/// returns the active factory if one is registered, otherwise the default, otherwise null.
+/// </para>
+/// <para>
+/// Use the active layer alone (no default) for capabilities core cannot construct itself —
+/// the optional package registers a factory, callers handle null as graceful degradation.
+/// Use both layers for capabilities core ships a default implementation of that a consumer
+/// may choose to replace.
+/// </para>
+/// </remarks>
+public static class RenderableRegistry
+{
+    private static readonly Dictionary<Type, Delegate> _factories = new();
+    private static readonly Dictionary<Type, Delegate> _defaultFactories = new();
+    private static readonly object _sync = new();
+
+    /// <summary>
+    /// Register the active factory for capability <typeparamref name="T"/>. Replaces any
+    /// previously registered active factory for the same capability. Used either as the
+    /// sole registration (factory-or-nothing — no default) or to override a registered
+    /// default (default-plus-override).
+    /// </summary>
+    public static void RegisterFactory<T>(Func<T> factory) where T : class
+    {
+        if (factory == null)
+        {
+            throw new ArgumentNullException(nameof(factory));
+        }
+        lock (_sync)
+        {
+            _factories[typeof(T)] = factory;
+        }
+    }
+
+    /// <summary>
+    /// Register the fallback factory for capability <typeparamref name="T"/>. Used when core
+    /// ships a default implementation that a consumer may optionally replace via
+    /// <see cref="RegisterFactory{T}"/>. Replaces any previously registered default.
+    /// </summary>
+    public static void RegisterDefaultFactory<T>(Func<T> factory) where T : class
+    {
+        if (factory == null)
+        {
+            throw new ArgumentNullException(nameof(factory));
+        }
+        lock (_sync)
+        {
+            _defaultFactories[typeof(T)] = factory;
+        }
+    }
+
+    /// <summary>
+    /// Remove the active factory (if any) for capability <typeparamref name="T"/>. The
+    /// resolved factory falls back to the default, or null if none was registered.
+    /// </summary>
+    public static void ClearFactory<T>() where T : class
+    {
+        lock (_sync)
+        {
+            _factories.Remove(typeof(T));
+        }
+    }
+
+    /// <summary>
+    /// Return the resolved factory for capability <typeparamref name="T"/>: the active
+    /// factory if registered, otherwise the default, otherwise null. Callers treat null
+    /// as "capability not available."
+    /// </summary>
+    public static Func<T>? GetFactory<T>() where T : class
+    {
+        lock (_sync)
+        {
+            if (_factories.TryGetValue(typeof(T), out Delegate? active))
+            {
+                return (Func<T>)active;
+            }
+            if (_defaultFactories.TryGetValue(typeof(T), out Delegate? fallback))
+            {
+                return (Func<T>)fallback;
+            }
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Convenience: invoke the resolved factory for capability <typeparamref name="T"/>,
+    /// or return null when no factory is registered.
+    /// </summary>
+    public static T? Create<T>() where T : class
+    {
+        Func<T>? factory = GetFactory<T>();
+        return factory?.Invoke();
+    }
+
+    /// <summary>
+    /// Remove all registered factories (active and default). Intended for test isolation;
+    /// production code should not call this.
+    /// </summary>
+    public static void Reset()
+    {
+        lock (_sync)
+        {
+            _factories.Clear();
+            _defaultFactories.Clear();
+        }
+    }
+}

--- a/GumCoreShared.projitems
+++ b/GumCoreShared.projitems
@@ -25,6 +25,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)GumCommon\Bundle\LooseFileGumFileProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GumCommon\Bundle\WalkResult.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GumCommon\Collections\GraphicalUiElementCollection.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)GumCommon\GueDeriving\RenderableRegistry.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GumDataTypes\Behaviors\BehaviorInstanceSave.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GumDataTypes\Behaviors\BehaviorReference.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GumDataTypes\Behaviors\BehaviorSave.cs" />

--- a/MonoGameGum.Tests/BaseTestClass.cs
+++ b/MonoGameGum.Tests/BaseTestClass.cs
@@ -1,5 +1,6 @@
 ﻿using Gum.Forms;
 using Gum.Forms.Controls;
+using Gum.GueDeriving;
 using Gum.Wireframe;
 using MonoGameGum.Input;
 using Moq;
@@ -91,5 +92,12 @@ public class BaseTestClass : IDisposable
 
         RenderingLibrary.Graphics.Text.Customizations.Clear();
         RenderingLibrary.Graphics.Text.ContextCustomizations.Clear();
+
+        // RenderableRegistry holds static per-capability factories. Anything a test
+        // (or production code path exercised by a test) registers must be cleared so
+        // it doesn't leak into the next test. Module-initializer registrations from
+        // optional packages (e.g. MonoGameGumShapes) re-run at assembly load only —
+        // not after Reset — so this Reset is intended for test-introduced state.
+        RenderableRegistry.Reset();
     }
 }

--- a/MonoGameGum.Tests/Runtimes/RenderableRegistryTests.cs
+++ b/MonoGameGum.Tests/Runtimes/RenderableRegistryTests.cs
@@ -1,0 +1,176 @@
+using Gum.GueDeriving;
+using Shouldly;
+using System;
+using Xunit;
+
+namespace MonoGameGum.Tests.Runtimes;
+
+public class RenderableRegistryTests : BaseTestClass
+{
+    // RenderableRegistry.Reset() runs in BaseTestClass.Dispose so every test starts
+    // with an empty registry without needing a per-class override here.
+
+    [Fact]
+    public void ClearFactory_ShouldBeNoOp_WhenNoActiveFactoryRegistered()
+    {
+        Action act = () => RenderableRegistry.ClearFactory<ICapabilityA>();
+
+        act.ShouldNotThrow();
+    }
+
+    [Fact]
+    public void ClearFactory_ShouldFallBackToDefault_WhenDefaultIsRegistered()
+    {
+        RenderableRegistry.RegisterDefaultFactory<ICapabilityA>(() => new CapabilityAImplementation("default"));
+        RenderableRegistry.RegisterFactory<ICapabilityA>(() => new CapabilityAImplementation("override"));
+
+        RenderableRegistry.ClearFactory<ICapabilityA>();
+
+        ICapabilityA? created = RenderableRegistry.Create<ICapabilityA>();
+        created.ShouldNotBeNull();
+        created.Label.ShouldBe("default");
+    }
+
+    [Fact]
+    public void ClearFactory_ShouldReturnNull_WhenNoDefaultRegistered()
+    {
+        RenderableRegistry.RegisterFactory<ICapabilityA>(() => new CapabilityAImplementation("active"));
+
+        RenderableRegistry.ClearFactory<ICapabilityA>();
+
+        RenderableRegistry.Create<ICapabilityA>().ShouldBeNull();
+    }
+
+    [Fact]
+    public void Create_ShouldInvokeActiveFactoryOverDefault_WhenBothRegistered()
+    {
+        RenderableRegistry.RegisterDefaultFactory<ICapabilityA>(() => new CapabilityAImplementation("default"));
+        RenderableRegistry.RegisterFactory<ICapabilityA>(() => new CapabilityAImplementation("active"));
+
+        ICapabilityA? created = RenderableRegistry.Create<ICapabilityA>();
+
+        created.ShouldNotBeNull();
+        created.Label.ShouldBe("active");
+    }
+
+    [Fact]
+    public void Create_ShouldReturnInstanceFromDefaultFactory_WhenOnlyDefaultRegistered()
+    {
+        RenderableRegistry.RegisterDefaultFactory<ICapabilityA>(() => new CapabilityAImplementation("default"));
+
+        ICapabilityA? created = RenderableRegistry.Create<ICapabilityA>();
+
+        created.ShouldNotBeNull();
+        created.Label.ShouldBe("default");
+    }
+
+    [Fact]
+    public void Create_ShouldReturnInstanceFromFactory_WhenOnlyActiveRegistered()
+    {
+        RenderableRegistry.RegisterFactory<ICapabilityA>(() => new CapabilityAImplementation("active"));
+
+        ICapabilityA? created = RenderableRegistry.Create<ICapabilityA>();
+
+        created.ShouldNotBeNull();
+        created.Label.ShouldBe("active");
+    }
+
+    [Fact]
+    public void Create_ShouldReturnNull_WhenNoFactoryRegistered()
+    {
+        RenderableRegistry.Create<ICapabilityA>().ShouldBeNull();
+    }
+
+    [Fact]
+    public void GetFactory_ShouldKeyByType_NotShareBetweenCapabilities()
+    {
+        RenderableRegistry.RegisterFactory<ICapabilityA>(() => new CapabilityAImplementation("a"));
+
+        RenderableRegistry.GetFactory<ICapabilityA>().ShouldNotBeNull();
+        RenderableRegistry.GetFactory<ICapabilityB>().ShouldBeNull();
+    }
+
+    [Fact]
+    public void GetFactory_ShouldReturnNull_WhenNothingRegistered()
+    {
+        RenderableRegistry.GetFactory<ICapabilityA>().ShouldBeNull();
+    }
+
+    [Fact]
+    public void RegisterDefaultFactory_ShouldReplacePreviousDefault()
+    {
+        RenderableRegistry.RegisterDefaultFactory<ICapabilityA>(() => new CapabilityAImplementation("first"));
+        RenderableRegistry.RegisterDefaultFactory<ICapabilityA>(() => new CapabilityAImplementation("second"));
+
+        ICapabilityA? created = RenderableRegistry.Create<ICapabilityA>();
+
+        created.ShouldNotBeNull();
+        created.Label.ShouldBe("second");
+    }
+
+    [Fact]
+    public void RegisterDefaultFactory_ShouldThrow_WhenFactoryIsNull()
+    {
+        Action act = () => RenderableRegistry.RegisterDefaultFactory<ICapabilityA>(null!);
+
+        act.ShouldThrow<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void RegisterFactory_ShouldReplacePreviousFactory()
+    {
+        RenderableRegistry.RegisterFactory<ICapabilityA>(() => new CapabilityAImplementation("first"));
+        RenderableRegistry.RegisterFactory<ICapabilityA>(() => new CapabilityAImplementation("second"));
+
+        ICapabilityA? created = RenderableRegistry.Create<ICapabilityA>();
+
+        created.ShouldNotBeNull();
+        created.Label.ShouldBe("second");
+    }
+
+    [Fact]
+    public void RegisterFactory_ShouldThrow_WhenFactoryIsNull()
+    {
+        Action act = () => RenderableRegistry.RegisterFactory<ICapabilityA>(null!);
+
+        act.ShouldThrow<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void Reset_ShouldClearActiveAndDefaultFactories()
+    {
+        RenderableRegistry.RegisterDefaultFactory<ICapabilityA>(() => new CapabilityAImplementation("default"));
+        RenderableRegistry.RegisterFactory<ICapabilityA>(() => new CapabilityAImplementation("active"));
+        RenderableRegistry.RegisterFactory<ICapabilityB>(() => new CapabilityBImplementation());
+
+        RenderableRegistry.Reset();
+
+        RenderableRegistry.GetFactory<ICapabilityA>().ShouldBeNull();
+        RenderableRegistry.GetFactory<ICapabilityB>().ShouldBeNull();
+    }
+
+    // Sentinel capability contracts used purely for these tests; they intentionally do not
+    // derive from any real renderable interface — RenderableRegistry keys by generic type only.
+    private interface ICapabilityA
+    {
+        string Label { get; }
+    }
+
+    private interface ICapabilityB
+    {
+    }
+
+    private sealed class CapabilityAImplementation : ICapabilityA
+    {
+        public CapabilityAImplementation(string label)
+        {
+            Label = label;
+        }
+
+        public string Label { get; }
+    }
+
+    private sealed class CapabilityBImplementation : ICapabilityB
+    {
+    }
+}

--- a/MonoGameGum/GumService.cs
+++ b/MonoGameGum/GumService.cs
@@ -761,6 +761,17 @@ public class GumService
         LoaderManager.Self.DisposeAndClear();
 
 #if XNALIKE
+        // RenderableRegistry holds static per-capability factories. Clearing here
+        // mirrors how Uninitialize treats the other extension points
+        // (ElementSaveExtensions.ClearRegistrations, Text.Customizations.Clear,
+        // FrameworkElement.DefaultFormsTemplates.Clear, etc.) so a subsequent
+        // Initialize starts from a known empty state. Optional packages are
+        // expected to expose a static RegisterRuntimeTypes method — Initialize's
+        // reflection scan re-invokes it each cycle, so their registrations come
+        // back. Packages that register only via [ModuleInitializer] won't, by
+        // design — that's a known load-order contract gap tracked in issue #2761.
+        RenderableRegistry.Reset();
+
         Text.Customizations.Clear();
         Text.ContextCustomizations.Clear();
         Text.DefaultBitmapFont = null;

--- a/Tests/MonoGameGum.IntegrationTests/BaseTestClass.cs
+++ b/Tests/MonoGameGum.IntegrationTests/BaseTestClass.cs
@@ -1,4 +1,5 @@
-﻿using Gum.Managers;
+﻿using Gum.GueDeriving;
+using Gum.Managers;
 using Gum.Wireframe;
 using Gum.Forms.Controls;
 using System;
@@ -57,5 +58,9 @@ public class BaseTestClass : IDisposable
         // a .gumx, the project sticks around and pollutes tests that assert on the
         // "no project loaded" state (e.g. LoadAnimations_ThrowsException_WhenNoProjectLoaded).
         ObjectFinder.Self.GumProjectSave = null;
+
+        // Clear any per-capability factories a test registered into the static
+        // RenderableRegistry so they don't leak into the next test.
+        RenderableRegistry.Reset();
     }
 }

--- a/Tests/MonoGameGum.IntegrationTests/MonoGameGum/UninitializeTests.cs
+++ b/Tests/MonoGameGum.IntegrationTests/MonoGameGum/UninitializeTests.cs
@@ -1,11 +1,14 @@
 using Gum.Forms;
+using Gum.GueDeriving;
 using Gum.Wireframe;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary;
 using RenderingLibrary.Content;
 using Shouldly;
+// MonoGameGum.GueDeriving.ContainerRuntime is obsolete — Gum.GueDeriving.ContainerRuntime
+// (above) is the supported type. Drop the legacy using to avoid the CS0104 collision now
+// that this file references both namespaces' contents.
 
 namespace MonoGameGum.IntegrationTests.MonoGameGum;
 
@@ -94,6 +97,20 @@ public class UninitializeTests : BaseTestClass
     }
 
     [Fact]
+    public void Uninitialize_ClearsRenderableRegistry()
+    {
+        using GameForUninitializeTest game = new GameForUninitializeTest();
+        game.RunOneFrame();
+
+        RenderableRegistry.RegisterFactory<IRegistryCapability>(() => new RegistryCapability());
+        RenderableRegistry.GetFactory<IRegistryCapability>().ShouldNotBeNull();
+
+        game.GumService.Uninitialize();
+
+        RenderableRegistry.GetFactory<IRegistryCapability>().ShouldBeNull();
+    }
+
+    [Fact]
     public void Uninitialize_AllowsReinitialize()
     {
         using var reinitGame = new GameForReinitializeTest();
@@ -172,5 +189,15 @@ public class UninitializeTests : BaseTestClass
             LoaderManager.Self?.DisposeAndClear();
             base.Dispose(disposing);
         }
+    }
+
+    // Sentinel capability for Uninitialize_ClearsRenderableRegistry — intentionally
+    // unrelated to any real renderable contract; RenderableRegistry keys by type only.
+    private interface IRegistryCapability
+    {
+    }
+
+    private sealed class RegistryCapability : IRegistryCapability
+    {
     }
 }

--- a/Tests/MonoGameGum.Tests.V2/BaseTestClass.cs
+++ b/Tests/MonoGameGum.Tests.V2/BaseTestClass.cs
@@ -1,5 +1,6 @@
 ﻿using Gum.Forms;
 using Gum.Forms.Controls;
+using Gum.GueDeriving;
 using Gum.Wireframe;
 using MonoGameGum.Input;
 using Moq;
@@ -72,5 +73,9 @@ public class BaseTestClass : IDisposable
         GumService.Default.Root.Children.Clear();
         GumService.Default.ModalRoot.Children.Clear();
         GumService.Default.PopupRoot.Children.Clear();
+
+        // Clear any per-capability factories a test registered into the static
+        // RenderableRegistry so they don't leak into the next test.
+        RenderableRegistry.Reset();
     }
 }


### PR DESCRIPTION
Phase 1 of #2761. Generalizes the spike-branch `ShapeRenderableRegistry` (#2758) into a capability-keyed registration point that lets optional packages — or consumers — supply renderable implementations to core runtimes without core referencing those packages. No callers yet; wiring `CircleRuntime` through it is Phase 2.

## Why `GumCommon` (and not `MonoGameGum`)

The spike gated its registry `#if XNALIKE` because the spike is *one* concrete capability (`IFilledShapeRenderable` for Apos.Shapes) happens to be XNA-only. The registry itself has **zero** XNA dependencies — it is `Dictionary<Type, Delegate>` plus generic `Func<T>` factories. Putting it in `GumCommon` makes it visible to every backend (MonoGame, KNI, FNA, Raylib, Skia, Sokol) and to the Gum tool, so the same swap mechanism is available wherever a runtime might want one. Capability interfaces (e.g. a future `IFilledShapeRenderable`) live wherever their members do — the registry never names them, so its reach is independent of any capability is reach.

## API

Two layers, priority ordered:

- `RegisterFactory<T>` — active layer. Either the sole registration (factory-or-nothing, the Circle / Apos.Shapes case) or an override of a registered default (default-plus-override, the future Text / FontStashSharp case).
- `RegisterDefaultFactory<T>` — fallback layer. For capabilities core ships a default implementation of that a consumer may replace.

`GetFactory<T>` returns active → default → null. `Create<T>` is the invoke-and-return convenience. `ClearFactory<T>` removes only the active layer; `Reset` clears both (test-isolation hook).

## Static, deliberately

Kept static, matching the sibling extension points (`ElementSaveExtensions.RegisterGueInstantiation`, `StandardElementsManager.CustomGetDefaultState`, `CustomSetPropertyOnRenderable.AdditionalPropertyOnRenderable`) per the explicit call-out in issue finding #5. Documented as a conscious deviation from `code-style.md` is general DI-over-singleton preference.

## Test isolation

The registry is static, so cross-test pollution is the natural failure mode. `RenderableRegistry.Reset()` is called from the per-test `Dispose()` of every `BaseTestClass` whose project sees `MonoGameGum` in its dependency graph:

- `MonoGameGum.Tests/BaseTestClass.cs`
- `Tests/MonoGameGum.IntegrationTests/BaseTestClass.cs`
- `Tests/MonoGameGum.Tests.V2/BaseTestClass.cs`

It also runs in `GumService.Uninitialize()`, alongside the other static-state clears (`ElementSaveExtensions.ClearRegistrations`, `Text.Customizations.Clear`, etc.), so XnaFiddle-style hosts that recreate Gum between projects start from a known empty registry. Optional packages that expose a static `RegisterRuntimeTypes` method are re-invoked by Initialize is reflection scan, so their registrations come back on re-init; packages that register *only* via `[ModuleInitializer]` will not, which is a known load-order gap explicitly tracked as Phase 2 work.

## Tests

- `RenderableRegistryTests` (14 focused unit tests) covering both registration semantics, override-clearing, type-keying, null-arg validation, replacement, and reset.
- `UninitializeTests.Uninitialize_ClearsRenderableRegistry` proving the Uninitialize hook.

All 1450 `MonoGameGum.Tests` + 24 `MonoGameGum.IntegrationTests` pass. KniGum and GumCommon build clean with zero new warnings.

## Boyscout

Adding `using Gum.GueDeriving;` to `UninitializeTests.cs` made `ContainerRuntime` ambiguous with the obsolete `MonoGameGum.GueDeriving.ContainerRuntime`, which had been silently warning CS0618. Resolved by dropping the legacy `using` so it binds to the non-obsolete type. Zero warnings in that project now.

## Out of scope (deferred)

- `Circle` collapse via the registry — Phase 2 of #2761.
- Per-instance swap (vs. the all-or-nothing global semantic). Open question from the issue; not addressed here.
- Raylib/Skia `Circle` collapse — sequenced after MonoGame.

## FRB1 sync

`GumCoreShared.projitems` updated for `GumCommon/GueDeriving/RenderableRegistry.cs`.

Closes #2761 partially; Phase 2 continues separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)