### PR TITLE
#2781: ScrollBar — react to Track resize, not Visual resize

### DIFF
--- a/MonoGameGum.Tests/Forms/ScrollBarThumbResizeTests.cs
+++ b/MonoGameGum.Tests/Forms/ScrollBarThumbResizeTests.cs
@@ -1,0 +1,213 @@
+using Gum.DataTypes;
+using Gum.Forms.Controls;
+using Gum.Wireframe;
+using MonoGameGum.Forms.DefaultVisuals;
+using Shouldly;
+using Xunit;
+
+namespace MonoGameGum.Tests.Forms;
+
+/// <summary>
+/// Regression coverage for issue #2781 — ScrollBar's thumb is sized in absolute pixels
+/// from a snapshot of <see cref="GraphicalUiElement.GetAbsoluteHeight"/>/<see cref="GraphicalUiElement.GetAbsoluteWidth"/>
+/// on Track. If Track resizes after construction (parent resize, sibling resize, layout reflow,
+/// or direct Track manipulation) and nothing re-runs UpdateThumbSize, the thumb keeps the old
+/// absolute size. The fix is to subscribe to Track.SizeChanged so any Track resize — from any
+/// upstream cause — flows back into thumb size + position.
+/// </summary>
+public class ScrollBarThumbResizeTests : BaseTestClass
+{
+    private static GraphicalUiElement GetThumbVisual(ScrollBar scrollBar) =>
+        (GraphicalUiElement)scrollBar.Visual.GetGraphicalUiElementByName("ThumbInstance")!;
+
+    // Math reference for ViewportSize=40, Minimum=0, Maximum=100:
+    //   thumbRatio = ViewportSize / ((Maximum - Minimum) + ViewportSize) = 40 / 140 ≈ 0.2857
+    // Default vertical visual has Visual.Height=128 → Track height (parent - 48) = 80
+    //   → initial thumb height ≈ 22.86
+    // Picked so MinimumThumbSize (16) does not clamp at either size we test.
+
+    [Fact]
+    public void ThumbPosition_ShouldRecompute_AfterTrackResize_Vertical()
+    {
+        // Track-position math (MaxThumbPosition = trackSize - thumbSize) reads Track size every
+        // call. If only UpdateThumbSize re-runs on Track resize but UpdateThumbPositionAccordingToValue
+        // does not, Value=50 still maps to the OLD track range and the thumb sits in the wrong place.
+        DefaultScrollBarRuntime visual = new DefaultScrollBarRuntime();
+        visual.Width = 24;
+        visual.Height = 128;
+        ScrollBar scrollBar = visual.FormsControl;
+        scrollBar.Orientation = Orientation.Vertical;
+        scrollBar.Minimum = 0;
+        scrollBar.Maximum = 100;
+        scrollBar.ViewportSize = 40;
+        scrollBar.Value = 50;
+        visual.UpdateLayout();
+
+        float trackHeightBefore = scrollBar.Track!.GetAbsoluteHeight();
+        float thumbHeightBefore = GetThumbVisual(scrollBar).GetAbsoluteHeight();
+        float rangeBefore = trackHeightBefore - thumbHeightBefore;
+        GetThumbVisual(scrollBar).Y.ShouldBe(rangeBefore * 0.5f, 0.5f,
+            "Sanity: thumb Y at Value=50 should sit at midpoint of (trackHeight - thumbHeight).");
+
+        visual.Height = 256;
+        visual.UpdateLayout();
+
+        float trackHeightAfter = scrollBar.Track.GetAbsoluteHeight();
+        float thumbHeightAfter = GetThumbVisual(scrollBar).GetAbsoluteHeight();
+        float rangeAfter = trackHeightAfter - thumbHeightAfter;
+        GetThumbVisual(scrollBar).Y.ShouldBe(rangeAfter * 0.5f, 0.5f,
+            "After Track resize, thumb Y must reflect the new (trackHeight - thumbHeight), not the cached old range.");
+    }
+
+    [Fact]
+    public void ThumbSize_ShouldRespectMinimumThumbSize_AfterTrackResize()
+    {
+        // Configured so the BEFORE thumb is well above the floor (40px) and the AFTER thumb
+        // would compute below the floor and must be clamped (-> 16px). A stale (un-recomputed)
+        // thumb would still read 40px and fail this assertion — making this a genuine regression
+        // check for the Track.SizeChanged subscription, not just a positive sanity assertion.
+        DefaultScrollBarRuntime visual = new DefaultScrollBarRuntime();
+        visual.Width = 24;
+        visual.Height = 128;
+        ScrollBar scrollBar = visual.FormsControl;
+        scrollBar.Orientation = Orientation.Vertical;
+        scrollBar.MinimumThumbSize = 16;
+        scrollBar.Minimum = 0;
+        scrollBar.Maximum = 10;
+        scrollBar.ViewportSize = 10;          // ratio 0.5, initial thumb = 80 * 0.5 = 40
+        visual.UpdateLayout();
+        GetThumbVisual(scrollBar).GetAbsoluteHeight().ShouldBe(40f, 0.5f,
+            "Sanity precondition: initial thumb should be 40, well above the 16 floor.");
+
+        // Shrink Track to a size where (trackSize * ratio) = 10, which is below MinimumThumbSize.
+        scrollBar.Track!.HeightUnits = DimensionUnitType.Absolute;
+        scrollBar.Track.Height = 20;
+        visual.UpdateLayout();
+
+        GetThumbVisual(scrollBar).GetAbsoluteHeight().ShouldBe(16f, 0.01f,
+            "After Track shrink, thumb must be re-clamped to MinimumThumbSize (16), not left at the stale 40.");
+    }
+
+    [Fact]
+    public void ThumbSize_ShouldUpdate_WhenScrollBarVisualResizes_Horizontal()
+    {
+        // Visual-level resize path, horizontal orientation. Track is RelativeToParent so resizing
+        // Visual propagates into Track and Track.SizeChanged fires. Guards against the fix
+        // accidentally regressing the path that the previous Visual.SizeChanged hook covered.
+        DefaultScrollBarRuntime visual = new DefaultScrollBarRuntime();
+        visual.Width = 128;
+        visual.Height = 24;
+        ScrollBar scrollBar = visual.FormsControl;
+        scrollBar.Orientation = Orientation.Horizontal;
+        scrollBar.Minimum = 0;
+        scrollBar.Maximum = 100;
+        scrollBar.ViewportSize = 40;
+        visual.UpdateLayout();
+
+        float thumbWidthBefore = GetThumbVisual(scrollBar).GetAbsoluteWidth();
+
+        visual.Width = 256;
+        visual.UpdateLayout();
+
+        float thumbWidthAfter = GetThumbVisual(scrollBar).GetAbsoluteWidth();
+        thumbWidthAfter.ShouldBeGreaterThan(thumbWidthBefore,
+            "Thumb width must grow when the ScrollBar Visual (and therefore Track) widens.");
+
+        float trackWidthAfter = scrollBar.Track!.GetAbsoluteWidth();
+        double expectedRatio = 40.0 / (100.0 + 40.0);
+        thumbWidthAfter.ShouldBe((float)(trackWidthAfter * expectedRatio), 0.5f,
+            "Thumb width should equal trackWidth * (ViewportSize / valueRange) after Visual resize.");
+    }
+
+    [Fact]
+    public void ThumbSize_ShouldUpdate_WhenScrollBarVisualResizes_Vertical()
+    {
+        // Visual-level resize path, vertical orientation. See horizontal sibling for rationale.
+        DefaultScrollBarRuntime visual = new DefaultScrollBarRuntime();
+        visual.Width = 24;
+        visual.Height = 128;
+        ScrollBar scrollBar = visual.FormsControl;
+        scrollBar.Orientation = Orientation.Vertical;
+        scrollBar.Minimum = 0;
+        scrollBar.Maximum = 100;
+        scrollBar.ViewportSize = 40;
+        visual.UpdateLayout();
+
+        float thumbHeightBefore = GetThumbVisual(scrollBar).GetAbsoluteHeight();
+
+        visual.Height = 256;
+        visual.UpdateLayout();
+
+        float thumbHeightAfter = GetThumbVisual(scrollBar).GetAbsoluteHeight();
+        thumbHeightAfter.ShouldBeGreaterThan(thumbHeightBefore,
+            "Thumb height must grow when the ScrollBar Visual (and therefore Track) grows.");
+
+        float trackHeightAfter = scrollBar.Track!.GetAbsoluteHeight();
+        double expectedRatio = 40.0 / (100.0 + 40.0);
+        thumbHeightAfter.ShouldBe((float)(trackHeightAfter * expectedRatio), 0.5f,
+            "Thumb height should equal trackHeight * (ViewportSize / valueRange) after Visual resize.");
+    }
+
+    [Fact]
+    public void ThumbSize_ShouldUpdate_WhenTrackResizesDirectly_Horizontal()
+    {
+        // Canonical bug, horizontal. Same shape as vertical sibling.
+        DefaultScrollBarRuntime visual = new DefaultScrollBarRuntime();
+        visual.Width = 128;
+        visual.Height = 24;
+        ScrollBar scrollBar = visual.FormsControl;
+        scrollBar.Orientation = Orientation.Horizontal;
+        scrollBar.Minimum = 0;
+        scrollBar.Maximum = 100;
+        scrollBar.ViewportSize = 40;
+        visual.UpdateLayout();
+
+        float thumbWidthBefore = GetThumbVisual(scrollBar).GetAbsoluteWidth();
+
+        scrollBar.Track!.WidthUnits = DimensionUnitType.Absolute;
+        scrollBar.Track.Width = 200;
+        visual.UpdateLayout();
+
+        float thumbWidthAfter = GetThumbVisual(scrollBar).GetAbsoluteWidth();
+        thumbWidthAfter.ShouldNotBe(thumbWidthBefore,
+            "Thumb width must change when Track is resized directly.");
+
+        double expectedRatio = 40.0 / (100.0 + 40.0);
+        thumbWidthAfter.ShouldBe((float)(200 * expectedRatio), 0.5f,
+            "Thumb width should equal new trackWidth * (ViewportSize / valueRange).");
+    }
+
+    [Fact]
+    public void ThumbSize_ShouldUpdate_WhenTrackResizesDirectly_Vertical()
+    {
+        // CANONICAL FAILING TEST FOR THE BUG.
+        // Resizes Track without touching Visual. The pre-fix Visual.SizeChanged hook does not
+        // fire here, so nothing re-runs UpdateThumbSize and the thumb keeps its old absolute
+        // height. Post-fix this is covered by the Track.SizeChanged subscription.
+        DefaultScrollBarRuntime visual = new DefaultScrollBarRuntime();
+        visual.Width = 24;
+        visual.Height = 128;
+        ScrollBar scrollBar = visual.FormsControl;
+        scrollBar.Orientation = Orientation.Vertical;
+        scrollBar.Minimum = 0;
+        scrollBar.Maximum = 100;
+        scrollBar.ViewportSize = 40;
+        visual.UpdateLayout();
+
+        float thumbHeightBefore = GetThumbVisual(scrollBar).GetAbsoluteHeight();
+
+        // Override Track sizing to be absolute so Visual size doesn't dictate it. Then resize
+        // Track. This is the path the original Visual.SizeChanged hook fails to cover.
+        scrollBar.Track!.HeightUnits = DimensionUnitType.Absolute;
+        scrollBar.Track.Height = 200;
+        visual.UpdateLayout();
+
+        float thumbHeightAfter = GetThumbVisual(scrollBar).GetAbsoluteHeight();
+        thumbHeightAfter.ShouldNotBe(thumbHeightBefore,
+            "Thumb height must change when Track is resized directly (independent of Visual size).");
+
+        double expectedRatio = 40.0 / (100.0 + 40.0);
+        thumbHeightAfter.ShouldBe((float)(200 * expectedRatio), 0.5f,
+            "Thumb height should equal new trackHeight * (ViewportSize / valueRange).");
+    }
+}

--- a/MonoGameGum.Tests/Forms/SliderThumbResizeTests.cs
+++ b/MonoGameGum.Tests/Forms/SliderThumbResizeTests.cs
@@ -1,0 +1,75 @@
+using Gum.DataTypes;
+using Gum.Forms.Controls;
+using Gum.Wireframe;
+using MonoGameGum.Forms.DefaultVisuals;
+using Shouldly;
+using Xunit;
+
+namespace MonoGameGum.Tests.Forms;
+
+/// <summary>
+/// Probe coverage for issue #2781 — the issue notes Slider is structurally similar to ScrollBar
+/// and may also fail to recompute on Track resize. In practice Slider stores thumb X in
+/// <c>Percentage</c> units and its <c>UpdateThumbPositionAccordingToValue</c> is pure Value/Min/Max
+/// math (it never reads Track size), so Slider should already survive Track resize naturally.
+/// These tests pin that behavior down so a future refactor that switches Slider to absolute
+/// pixel math without re-running on resize gets caught.
+/// </summary>
+public class SliderThumbResizeTests : BaseTestClass
+{
+    private static GraphicalUiElement GetThumbVisual(Slider slider) =>
+        (GraphicalUiElement)slider.Visual.GetGraphicalUiElementByName("ThumbInstance")!;
+
+    // Default thumb has Center XOrigin so AbsoluteLeft is offset by half its width.
+    // Compare centers, not left edges.
+    private static float CenterX(GraphicalUiElement element) =>
+        element.AbsoluteLeft + element.GetAbsoluteWidth() * 0.5f;
+
+    private static float CenterX(InteractiveGue element) =>
+        element.AbsoluteLeft + element.GetAbsoluteWidth() * 0.5f;
+
+    [Fact]
+    public void ThumbCenter_ShouldFollow_WhenSliderVisualResizes()
+    {
+        // At Value=midpoint the thumb center should equal the Track center regardless of width.
+        DefaultSliderRuntime visual = new DefaultSliderRuntime();
+        visual.Width = 128;
+        visual.Height = 24;
+        Slider slider = visual.FormsControl;
+        slider.Minimum = 0;
+        slider.Maximum = 100;
+        slider.Value = 50;
+        visual.UpdateLayout();
+
+        CenterX(GetThumbVisual(slider)).ShouldBe(CenterX(slider.Track!), 0.5f,
+            "Sanity: at Value=50 the thumb center should equal the Track center.");
+
+        visual.Width = 256;
+        visual.UpdateLayout();
+
+        CenterX(GetThumbVisual(slider)).ShouldBe(CenterX(slider.Track!), 0.5f,
+            "After Slider resize, thumb center must still equal the (now wider) Track center.");
+    }
+
+    [Fact]
+    public void ThumbCenter_ShouldFollow_WhenTrackResizesDirectly()
+    {
+        // Direct Track resize — the case ScrollBar misses pre-fix. Slider uses Percentage X for
+        // the thumb so this works without any explicit Track.SizeChanged subscription.
+        DefaultSliderRuntime visual = new DefaultSliderRuntime();
+        visual.Width = 128;
+        visual.Height = 24;
+        Slider slider = visual.FormsControl;
+        slider.Minimum = 0;
+        slider.Maximum = 100;
+        slider.Value = 50;
+        visual.UpdateLayout();
+
+        slider.Track!.WidthUnits = DimensionUnitType.Absolute;
+        slider.Track.Width = 200;
+        visual.UpdateLayout();
+
+        CenterX(GetThumbVisual(slider)).ShouldBe(CenterX(slider.Track), 0.5f,
+            "After direct Track resize, thumb center must still equal the Track center.");
+    }
+}

--- a/MonoGameGum/Forms/Controls/ScrollBar.cs
+++ b/MonoGameGum/Forms/Controls/ScrollBar.cs
@@ -31,6 +31,16 @@ public class ScrollBar : RangeBase
     public Button? DownButton => downButton;
     public float MinimumThumbSize { get; set; } = 16;
 
+    // The Track whose SizeChanged we are currently subscribed to. Stored as a field rather than
+    // re-resolved through the Track property at unsubscribe time so that if Visual (and therefore
+    // Track) is swapped out, we unhook from the original Track instance rather than leaking the
+    // subscription. See issue #2781 — thumb size + position both read Track absolute dimensions,
+    // so any Track resize (parent resize, sibling resize, layout reflow, direct manipulation)
+    // must re-run UpdateThumbSize + UpdateThumbPositionAccordingToValue. The previous hook on
+    // Visual.SizeChanged missed any case where Track changed without the ScrollBar's own Visual
+    // also changing.
+    InteractiveGue? _subscribedTrack;
+
     double viewportSize = .1;
     public double ViewportSize
     {
@@ -90,6 +100,14 @@ public class ScrollBar : RangeBase
     bool hasAssignedOrientation = false;
     protected override void ReactToVisualChanged()
     {
+        // Visual may be reassigned at runtime, which swaps Track. Unhook from the previously
+        // tracked instance before resolving the new one so we don't leak a subscription.
+        if (_subscribedTrack != null)
+        {
+            _subscribedTrack.SizeChanged -= HandleTrackSizeChanged;
+            _subscribedTrack = null;
+        }
+
         if(!hasAssignedOrientation)
         {
             // default it!
@@ -147,7 +165,18 @@ public class ScrollBar : RangeBase
             Track.Push += HandleTrackPush;
 #endif
         }
-        Visual.SizeChanged += HandleVisualSizeChange;
+
+        // Subscribe to Track.SizeChanged rather than Visual.SizeChanged because Track size is what
+        // UpdateThumbSize / UpdateThumbPositionAccordingToValue actually read. If Track fills Visual
+        // (the common case) a Visual resize propagates to Track and fires this anyway. If Track is
+        // sized independently of Visual (e.g. by sibling changes or absolute sizing) we still react.
+        // Hooking only Track is strictly more correct than hooking Visual. Field-tracked for clean
+        // unsubscribe on visual change/removal.
+        if (Track != null)
+        {
+            _subscribedTrack = Track;
+            _subscribedTrack.SizeChanged += HandleTrackSizeChanged;
+        }
 
 
 
@@ -277,10 +306,22 @@ public class ScrollBar : RangeBase
         }
     }
 
-    private void HandleVisualSizeChange(object sender, EventArgs e)
+    private void HandleTrackSizeChanged(object sender, EventArgs e)
     {
-        UpdateThumbPositionAccordingToValue();
         UpdateThumbSize();
+        UpdateThumbPositionAccordingToValue();
+    }
+
+    /// <inheritdoc/>
+    protected override void ReactToVisualRemoved()
+    {
+        base.ReactToVisualRemoved();
+
+        if (_subscribedTrack != null)
+        {
+            _subscribedTrack.SizeChanged -= HandleTrackSizeChanged;
+            _subscribedTrack = null;
+        }
     }
 
     protected override void OnMinimumChanged(double oldMinimum, double newMinimum)


### PR DESCRIPTION
## Summary

`ScrollBar.UpdateThumbSize` / `UpdateThumbPositionAccordingToValue` both read absolute Track dimensions, but the only resize signal we were subscribed to was `Visual.SizeChanged` on the ScrollBar's own root visual. That misses any case where Track resizes *without* the root Visual also resizing — sibling button skin/font reflow, direct Track manipulation, or parent-driven layout that only touches Track. Result: a stale absolute-pixel thumb size and a thumb position computed against the old track range.

Switch the subscription to `Track.SizeChanged` directly. That is strictly more correct:

- If Track fills Visual (the common case), the event still fires on Visual resize via normal layout propagation — nothing lost.
- If Track is sized independently of Visual, we now react where before we didn't — bug fixed.
- If Visual changes but Track doesn't (e.g. Visual grows but Track is absolute), the thumb correctly stays put rather than being thrashed.

Field-tracked so the subscription is cleanly unhooked when Visual (and therefore Track) is swapped at runtime, and a new `ReactToVisualRemoved` override unhooks on teardown.

## Tests

- **`ScrollBarThumbResizeTests`** (6 tests): both orientations × both resize paths (Visual-level, direct Track), the `MinimumThumbSize` floor surviving a Track shrink, and thumb-position math recomputing against the new range.
- **`SliderThumbResizeTests`** (2 probe tests): the linked issue called Slider out as structurally similar. In practice Slider uses `Percentage` units for thumb X and pure Value/Min/Max math for position, so it already survives Track resize without any subscription. These tests pin that down so a future refactor that switches Slider to absolute-pixel math without re-running on resize gets caught.

Full `MonoGameGum.Tests` suite: 1485 passed, 0 failed.

## Notes

- Boyscout: swapped `UpdateThumbSize` / `UpdateThumbPositionAccordingToValue` order in the handler. Position math reads `thumb.ActualHeight` via `MaxThumbPosition`, so sizing must run first.
- TDD: canonical failing test (`ThumbSize_ShouldUpdate_WhenTrackResizesDirectly_Vertical`) was committed and run red against `main` before any production code changed.

Closes #2781

🤖 Generated with [Claude Code](https://claude.com/claude-code)