### PR TITLE
#2764: add FindFormsControl<T> extensions on GraphicalUiElement

### DIFF
--- a/MonoGameGum.Tests/Forms/GraphicalUiElementFormsExtensionsTests.cs
+++ b/MonoGameGum.Tests/Forms/GraphicalUiElementFormsExtensionsTests.cs
@@ -1,0 +1,149 @@
+using Gum.Forms;
+using Gum.Forms.Controls;
+using Gum.GueDeriving;
+using Gum.Wireframe;
+using Shouldly;
+using Xunit;
+
+namespace MonoGameGum.Tests.Forms;
+
+public class GraphicalUiElementFormsExtensionsTests : BaseTestClass
+{
+    private class SpecialButton : Button { }
+
+    #region FindFormsControl<T>
+
+    [Fact]
+    public void FindFormsControlOfT_FindsDescendantFrameworkElement()
+    {
+        // Window's Visual is a GraphicalUiElement; AddChild places the Button's visual
+        // under it with FormsControlAsObject pointing back at the Button. Starting from
+        // a raw visual (the typical screen/component root case), FindFormsControl<T> must
+        // project descendants through FormsControlAsObject.
+        Window window = new();
+        Button button = new();
+        window.AddChild(button);
+
+        Button? found = window.Visual.FindFormsControl<Button>();
+
+        found.ShouldBe(button);
+    }
+
+    [Fact]
+    public void FindFormsControlOfT_MatchesSubclasses()
+    {
+        Window window = new();
+        SpecialButton special = new();
+        window.AddChild(special);
+
+        Button? found = window.Visual.FindFormsControl<Button>();
+
+        found.ShouldBe(special);
+    }
+
+    [Fact]
+    public void FindFormsControlOfT_ReturnsShallowestMatch()
+    {
+        Window outer = new();
+        Window inner = new();
+        Button shallow = new();
+        Button deep = new();
+        outer.AddChild(shallow);
+        outer.AddChild(inner);
+        inner.AddChild(deep);
+
+        Button? found = outer.Visual.FindFormsControl<Button>();
+
+        found.ShouldBe(shallow);
+    }
+
+    [Fact]
+    public void FindFormsControlOfT_ReturnsNull_WhenNoMatch()
+    {
+        Window window = new();
+
+        Button? found = window.Visual.FindFormsControl<Button>();
+
+        found.ShouldBeNull();
+    }
+
+    #endregion
+
+    #region FindFormsControlByName
+
+    [Fact]
+    public void FindFormsControlByName_MatchesOnVisualName()
+    {
+        Window window = new();
+        Button button = new();
+        button.Visual.Name = "OkButton";
+        window.AddChild(button);
+
+        FrameworkElement? found = window.Visual.FindFormsControlByName("OkButton");
+
+        found.ShouldBe(button);
+    }
+
+    [Fact]
+    public void FindFormsControlByName_SkipsVisualOnlyDescendantsWithSameName()
+    {
+        // A bare visual whose Name matches must NOT be returned — only descendants that
+        // project to a FrameworkElement count. This is what makes FindFormsControlByName
+        // different from GraphicalUiElement.FindByName.
+        Window window = new();
+        ContainerRuntime decoy = new() { Name = "Target" };
+        window.Visual.Children.Add(decoy);
+        Button target = new();
+        target.Visual.Name = "Target";
+        window.AddChild(target);
+
+        FrameworkElement? found = window.Visual.FindFormsControlByName("Target");
+
+        found.ShouldBe(target);
+    }
+
+    [Fact]
+    public void FindFormsControlByName_ReturnsNull_WhenNoMatch()
+    {
+        Window window = new();
+
+        FrameworkElement? found = window.Visual.FindFormsControlByName("Missing");
+
+        found.ShouldBeNull();
+    }
+
+    #endregion
+
+    #region FindFormsControl<T>(name)
+
+    [Fact]
+    public void FindFormsControlOfTByName_RequiresBothTypeAndName()
+    {
+        Window window = new();
+        Button decoy = new();
+        decoy.Visual.Name = "Other";
+        Button match = new();
+        match.Visual.Name = "Target";
+        window.AddChild(decoy);
+        window.AddChild(match);
+
+        Button? found = window.Visual.FindFormsControl<Button>("Target");
+
+        found.ShouldBe(match);
+    }
+
+    [Fact]
+    public void FindFormsControlOfTByName_ReturnsNull_WhenNameMatchesButTypeDoesNot()
+    {
+        Window window = new();
+        Button button = new();
+        button.Visual.Name = "Target";
+        window.AddChild(button);
+
+        CheckBox? found = window.Visual.FindFormsControl<CheckBox>("Target");
+
+        found.ShouldBeNull();
+    }
+
+    #endregion
+}

--- a/MonoGameGum/Forms/FrameworkElementTreeExtensions.cs
+++ b/MonoGameGum/Forms/FrameworkElementTreeExtensions.cs
@@ -118,7 +118,7 @@ public static class FrameworkElementTreeExtensions
         return null;
     }
 
-    private static IEnumerable<FrameworkElement> ProjectToFrameworkElements(IEnumerable<GraphicalUiElement> visuals)
+    internal static IEnumerable<FrameworkElement> ProjectToFrameworkElements(IEnumerable<GraphicalUiElement> visuals)
     {
         foreach (GraphicalUiElement visual in visuals)
         {

--- a/MonoGameGum/Forms/GraphicalUiElementFormsExtensions.cs
+++ b/MonoGameGum/Forms/GraphicalUiElementFormsExtensions.cs
@@ -24,6 +24,65 @@ namespace Gum.Forms;
 
 public static class GraphicalUiElementFormsExtensions
 {
+    #region FindFormsControl — visual-rooted lookup of FrameworkElement descendants
+
+    /// <summary>
+    /// Returns the first descendant of <paramref name="element"/> whose
+    /// <see cref="InteractiveGue.FormsControlAsObject"/> is assignable to
+    /// <typeparamref name="T"/>, or null if none. Search is shallowest-first; subclasses match.
+    /// Mirrors <c>FrameworkElement.FindVisual&lt;T&gt;</c> in the opposite direction:
+    /// start from a visual (typically a screen or component root) and walk down to a
+    /// Forms control.
+    /// </summary>
+    public static T? FindFormsControl<T>(this GraphicalUiElement element) where T : FrameworkElement
+    {
+        foreach (FrameworkElement descendant in FrameworkElementTreeExtensions.ProjectToFrameworkElements(element.Descendants()))
+        {
+            if (descendant is T match)
+            {
+                return match;
+            }
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Returns the first descendant <see cref="FrameworkElement"/> whose underlying
+    /// <c>Visual.Name</c> equals <paramref name="name"/>, or null if none. Visual-only
+    /// descendants with no Forms control are skipped — only nodes that project to a
+    /// <see cref="FrameworkElement"/> are considered.
+    /// </summary>
+    public static FrameworkElement? FindFormsControlByName(this GraphicalUiElement element, string name)
+    {
+        foreach (FrameworkElement descendant in FrameworkElementTreeExtensions.ProjectToFrameworkElements(element.Descendants()))
+        {
+            if (descendant.Visual?.Name == name)
+            {
+                return descendant;
+            }
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Returns the first descendant <see cref="FrameworkElement"/> assignable to
+    /// <typeparamref name="T"/> whose underlying <c>Visual.Name</c> equals
+    /// <paramref name="name"/>, or null if none. Search is shallowest-first.
+    /// </summary>
+    public static T? FindFormsControl<T>(this GraphicalUiElement element, string name) where T : FrameworkElement
+    {
+        foreach (FrameworkElement descendant in FrameworkElementTreeExtensions.ProjectToFrameworkElements(element.Descendants()))
+        {
+            if (descendant is T match && match.Visual?.Name == name)
+            {
+                return match;
+            }
+        }
+        return null;
+    }
+
+    #endregion
+
     /// <summary>
     /// Recursively returns the first matching element with the given name, or throws an exception if not found.
     /// </summary>
@@ -32,6 +91,7 @@ public static class GraphicalUiElementFormsExtensions
     /// <param name="name">The name to match</param>
     /// <returns>Teh found FrameworkElement</returns>
     /// <exception cref="ArgumentException">Throw if a visual is not found by the name, or if a child is found but its type doesn't match.</exception>
+    [Obsolete("Use FindFormsControl<T>(name) instead. This overload's diagnostics are FULL_DIAGNOSTICS-gated and silently returns null on failure in release builds.")]
     public static FrameworkElementType GetFrameworkElementByName<FrameworkElementType>(this GraphicalUiElement graphicalUiElement, string name) where FrameworkElementType : FrameworkElement
     {
         var frameworkVisual = graphicalUiElement.GetGraphicalUiElementByName(name);
@@ -75,6 +135,7 @@ public static class GraphicalUiElementFormsExtensions
         return frameworkElement;
     }
 
+    [Obsolete("Use FindFormsControl<T>(name) instead.")]
     public static FrameworkElementType TryGetFrameworkElementByName<FrameworkElementType>(this GraphicalUiElement graphicalUiElement, string name) where FrameworkElementType : FrameworkElement
     {
         var frameworkVisual = graphicalUiElement.GetGraphicalUiElementByName(name);

--- a/Runtimes/RaylibGum/RaylibGum.csproj
+++ b/Runtimes/RaylibGum/RaylibGum.csproj
@@ -112,6 +112,7 @@
 		<Compile Include="..\..\MonoGameGum\Forms\BehaviorFormsPropertyApplier.cs" Link="Forms\BehaviorFormsPropertyApplier.cs" />
 		<Compile Include="..\..\MonoGameGum\Forms\FormsUtilities.cs" Link="Forms\FormsUtilities.cs" />
 		<Compile Include="..\..\MonoGameGum\Forms\FrameworkElementTemplate.cs" Link="Forms\FrameworkElementTemplate.cs" />
+		<Compile Include="..\..\MonoGameGum\Forms\FrameworkElementTreeExtensions.cs" Link="Forms\FrameworkElementTreeExtensions.cs" />
 		<Compile Include="..\..\MonoGameGum\Forms\GraphicalUiElementFormsExtensions.cs" Link="Forms\Controls\GraphicalUiElementFormsExtensions.cs" />
 		<Compile Include="..\..\MonoGameGum\Forms\ScreenBase.cs" Link="Forms\ScreenBase.cs" />
 		<Compile Include="..\..\MonoGameGum\Forms\VisualTemplate.cs" Link="Forms\VisualTemplate.cs" />

--- a/Runtimes/SokolGum/SokolGum.csproj
+++ b/Runtimes/SokolGum/SokolGum.csproj
@@ -138,6 +138,7 @@
 		<Compile Include="..\..\MonoGameGum\Forms\BehaviorFormsPropertyApplier.cs" Link="Forms\BehaviorFormsPropertyApplier.cs" />
 		<Compile Include="..\..\MonoGameGum\Forms\FormsUtilities.cs" Link="Forms\FormsUtilities.cs" />
 		<Compile Include="..\..\MonoGameGum\Forms\FrameworkElementTemplate.cs" Link="Forms\FrameworkElementTemplate.cs" />
+		<Compile Include="..\..\MonoGameGum\Forms\FrameworkElementTreeExtensions.cs" Link="Forms\FrameworkElementTreeExtensions.cs" />
 		<Compile Include="..\..\MonoGameGum\Forms\GraphicalUiElementFormsExtensions.cs" Link="Forms\Controls\GraphicalUiElementFormsExtensions.cs" />
 		<Compile Include="..\..\MonoGameGum\Forms\ScreenBase.cs" Link="Forms\ScreenBase.cs" />
 		<Compile Include="..\..\MonoGameGum\Forms\VisualTemplate.cs" Link="Forms\VisualTemplate.cs" />


### PR DESCRIPTION
## Summary

Adds the fourth direction of cross-tree lookup that was missing from the new `Find*` traversal API: starting from a `GraphicalUiElement` (typically a screen or component root) and walking down to a `FrameworkElement`. Mirrors the existing `FindVisual*` sugar on `FrameworkElement` in the opposite direction.

New extensions on `GraphicalUiElement` (in `MonoGameGum/Forms/GraphicalUiElementFormsExtensions.cs`):

- `FindFormsControl<T>()`
- `FindFormsControlByName(name)`
- `FindFormsControl<T>(name)`

All three project descendants through `InteractiveGue.FormsControlAsObject` — visual-only nodes are skipped. The projection helper `FrameworkElementTreeExtensions.ProjectToFrameworkElements` was promoted from `private` to `internal` so both extension classes can share it without duplication.

## Naming

Settled on `FindFormsControl*` after discussion. `FindForm*` would collide with the WinForms/WPF/MAUI meaning of "Form" (top-level window). `FindControl*` is ambiguous in this codebase. `FindFrameworkElement*` is more literal but verbose. `FindFormsControl*` matches the team's colloquial term for `FrameworkElement` and parallels `FindVisual*` (both name the *return* type).

## Obsoletions

`GetFrameworkElementByName<T>` and `TryGetFrameworkElementByName<T>` on `GraphicalUiElementFormsExtensions` are now marked `[Obsolete]`. Codegen still emits `TryGetFrameworkElementByName<T>` — replacing those callers is the scope of #2763, which is unblocked by this PR.

## Test plan

- [x] New unit tests in `MonoGameGum.Tests/Forms/GraphicalUiElementFormsExtensionsTests.cs` covering all three overloads, including subclass matching, shallowest-first ordering, visual-only-descendant skipping for `ByName`, and null returns on no-match.
- [x] Full `MonoGameGum.Tests` suite passes (1494/1494).

Closes #2764

🤖 Generated with [Claude Code](https://claude.com/claude-code)