### PR TITLE
#2791: Expose gradient properties on MG/Raylib CircleRuntime via IGradientedRenderable

### DIFF
--- a/MonoGameGum.Tests/Runtimes/CircleRuntimeTests.cs
+++ b/MonoGameGum.Tests/Runtimes/CircleRuntimeTests.cs
@@ -1,3 +1,5 @@
+using Gum.Converters;
+using Gum.DataTypes;
 using Gum.GueDeriving;
 using Microsoft.Xna.Framework;
 using MonoGameGum.Renderables;
@@ -53,6 +55,44 @@ public class CircleRuntimeTests : BaseTestClass
         // re-create the runtime) honors the user's color. Without the package, no visual
         // effect — see DefaultStrokedCircleRenderable remarks.
         sut.FillColor.ShouldBe(Color.Red);
+    }
+
+    // Issue #2791 graceful-degradation contract: with no MonoGameGumShapes package the stroke
+    // slot is DefaultStrokedCircleRenderable (does not implement IGradientedRenderable). The
+    // gradient setters must round-trip on the runtime so user code is forward-compatible with
+    // a later install of the package, but produce no visual effect today.
+    [Fact]
+    public void Gradient_RoundTripsBackingFields_WhenNoGradientCapableSlot()
+    {
+        CircleRuntime sut = new();
+
+        sut.UseGradient = true;
+        sut.GradientType = GradientType.Radial;
+        sut.Color1 = Color.Red;
+        sut.Color2 = Color.Blue;
+        sut.GradientX1 = 1;
+        sut.GradientY1 = 2;
+        sut.GradientX2 = 3;
+        sut.GradientY2 = 4;
+        sut.GradientX1Units = GeneralUnitType.PixelsFromMiddle;
+        sut.GradientInnerRadius = 5;
+        sut.GradientOuterRadius = 6;
+        sut.GradientInnerRadiusUnits = DimensionUnitType.PercentageOfParent;
+        sut.GradientOuterRadiusUnits = DimensionUnitType.RelativeToParent;
+
+        sut.UseGradient.ShouldBeTrue();
+        sut.GradientType.ShouldBe(GradientType.Radial);
+        sut.Color1.ShouldBe(Color.Red);
+        sut.Color2.ShouldBe(Color.Blue);
+        sut.GradientX1.ShouldBe(1);
+        sut.GradientY1.ShouldBe(2);
+        sut.GradientX2.ShouldBe(3);
+        sut.GradientY2.ShouldBe(4);
+        sut.GradientX1Units.ShouldBe(GeneralUnitType.PixelsFromMiddle);
+        sut.GradientInnerRadius.ShouldBe(5);
+        sut.GradientOuterRadius.ShouldBe(6);
+        sut.GradientInnerRadiusUnits.ShouldBe(DimensionUnitType.PercentageOfParent);
+        sut.GradientOuterRadiusUnits.ShouldBe(DimensionUnitType.RelativeToParent);
     }
 
     [Fact]

--- a/MonoGameGum/GueDeriving/CircleRuntime.cs
+++ b/MonoGameGum/GueDeriving/CircleRuntime.cs
@@ -3,6 +3,10 @@ using RenderingLibrary;
 using RenderingLibrary.Graphics;
 using System;
 
+#if XNALIKE
+using Gum.Converters;
+#endif
+
 #if RAYLIB
 using Gum.Renderables;
 using Color = Raylib_cs.Color;
@@ -323,6 +327,334 @@ public class CircleRuntime : GraphicalUiElement
             NotifyPropertyChanged();
         }
     }
+
+    #region Gradient
+
+    // Issue #2791: gradient pass-through. Backing fields live on the runtime so values
+    // round-trip even when neither slot implements IGradientedRenderable (e.g. core-only stroke
+    // = DefaultStrokedCircleRenderable, no fill). Setters push to whichever slot(s) implement
+    // it. Pushing to both slots matches Skia's single-renderable behavior, where fill mode and
+    // dashed-stroke mode both consult the same gradient parameters; an Apos-backed
+    // CircleRuntime with both FillColor and StrokeColor + UseGradient = true renders a
+    // gradient-filled disk with a gradient stroke sharing the same gradient.
+
+    bool _useGradient;
+    /// <summary>
+    /// When <c>true</c>, the gradient color/coordinate properties drive rendering instead of
+    /// <see cref="FillColor"/> / <see cref="StrokeColor"/>. Visual effect requires the optional
+    /// MonoGameGumShapes (Apos.Shapes) package; without it the value round-trips but does not
+    /// render.
+    /// </summary>
+    public bool UseGradient
+    {
+        get => _useGradient;
+        set
+        {
+            _useGradient = value;
+            if (_fill is IGradientedRenderable fillGrad) fillGrad.UseGradient = value;
+            if (_stroke is IGradientedRenderable strokeGrad) strokeGrad.UseGradient = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    GradientType _gradientType;
+    public GradientType GradientType
+    {
+        get => _gradientType;
+        set
+        {
+            _gradientType = value;
+            if (_fill is IGradientedRenderable fillGrad) fillGrad.GradientType = value;
+            if (_stroke is IGradientedRenderable strokeGrad) strokeGrad.GradientType = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    int _alpha1 = 255;
+    public int Alpha1
+    {
+        get => _alpha1;
+        set
+        {
+            _alpha1 = value;
+            if (_fill is IGradientedRenderable fillGrad) fillGrad.Alpha1 = value;
+            if (_stroke is IGradientedRenderable strokeGrad) strokeGrad.Alpha1 = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    int _red1;
+    public int Red1
+    {
+        get => _red1;
+        set
+        {
+            _red1 = value;
+            if (_fill is IGradientedRenderable fillGrad) fillGrad.Red1 = value;
+            if (_stroke is IGradientedRenderable strokeGrad) strokeGrad.Red1 = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    int _green1;
+    public int Green1
+    {
+        get => _green1;
+        set
+        {
+            _green1 = value;
+            if (_fill is IGradientedRenderable fillGrad) fillGrad.Green1 = value;
+            if (_stroke is IGradientedRenderable strokeGrad) strokeGrad.Green1 = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    int _blue1;
+    public int Blue1
+    {
+        get => _blue1;
+        set
+        {
+            _blue1 = value;
+            if (_fill is IGradientedRenderable fillGrad) fillGrad.Blue1 = value;
+            if (_stroke is IGradientedRenderable strokeGrad) strokeGrad.Blue1 = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    public Color Color1
+    {
+        get => new Color(_red1, _green1, _blue1, _alpha1);
+        set
+        {
+            Red1 = value.R;
+            Green1 = value.G;
+            Blue1 = value.B;
+            Alpha1 = value.A;
+        }
+    }
+
+    int _alpha2 = 255;
+    public int Alpha2
+    {
+        get => _alpha2;
+        set
+        {
+            _alpha2 = value;
+            if (_fill is IGradientedRenderable fillGrad) fillGrad.Alpha2 = value;
+            if (_stroke is IGradientedRenderable strokeGrad) strokeGrad.Alpha2 = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    int _red2;
+    public int Red2
+    {
+        get => _red2;
+        set
+        {
+            _red2 = value;
+            if (_fill is IGradientedRenderable fillGrad) fillGrad.Red2 = value;
+            if (_stroke is IGradientedRenderable strokeGrad) strokeGrad.Red2 = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    int _green2;
+    public int Green2
+    {
+        get => _green2;
+        set
+        {
+            _green2 = value;
+            if (_fill is IGradientedRenderable fillGrad) fillGrad.Green2 = value;
+            if (_stroke is IGradientedRenderable strokeGrad) strokeGrad.Green2 = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    int _blue2;
+    public int Blue2
+    {
+        get => _blue2;
+        set
+        {
+            _blue2 = value;
+            if (_fill is IGradientedRenderable fillGrad) fillGrad.Blue2 = value;
+            if (_stroke is IGradientedRenderable strokeGrad) strokeGrad.Blue2 = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    public Color Color2
+    {
+        get => new Color(_red2, _green2, _blue2, _alpha2);
+        set
+        {
+            Red2 = value.R;
+            Green2 = value.G;
+            Blue2 = value.B;
+            Alpha2 = value.A;
+        }
+    }
+
+    float _gradientX1;
+    public float GradientX1
+    {
+        get => _gradientX1;
+        set
+        {
+            _gradientX1 = value;
+            if (_fill is IGradientedRenderable fillGrad) fillGrad.GradientX1 = value;
+            if (_stroke is IGradientedRenderable strokeGrad) strokeGrad.GradientX1 = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    GeneralUnitType _gradientX1Units;
+    public GeneralUnitType GradientX1Units
+    {
+        get => _gradientX1Units;
+        set
+        {
+            _gradientX1Units = value;
+            if (_fill is IGradientedRenderable fillGrad) fillGrad.GradientX1Units = value;
+            if (_stroke is IGradientedRenderable strokeGrad) strokeGrad.GradientX1Units = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    float _gradientY1;
+    public float GradientY1
+    {
+        get => _gradientY1;
+        set
+        {
+            _gradientY1 = value;
+            if (_fill is IGradientedRenderable fillGrad) fillGrad.GradientY1 = value;
+            if (_stroke is IGradientedRenderable strokeGrad) strokeGrad.GradientY1 = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    GeneralUnitType _gradientY1Units;
+    public GeneralUnitType GradientY1Units
+    {
+        get => _gradientY1Units;
+        set
+        {
+            _gradientY1Units = value;
+            if (_fill is IGradientedRenderable fillGrad) fillGrad.GradientY1Units = value;
+            if (_stroke is IGradientedRenderable strokeGrad) strokeGrad.GradientY1Units = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    float _gradientX2;
+    public float GradientX2
+    {
+        get => _gradientX2;
+        set
+        {
+            _gradientX2 = value;
+            if (_fill is IGradientedRenderable fillGrad) fillGrad.GradientX2 = value;
+            if (_stroke is IGradientedRenderable strokeGrad) strokeGrad.GradientX2 = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    GeneralUnitType _gradientX2Units;
+    public GeneralUnitType GradientX2Units
+    {
+        get => _gradientX2Units;
+        set
+        {
+            _gradientX2Units = value;
+            if (_fill is IGradientedRenderable fillGrad) fillGrad.GradientX2Units = value;
+            if (_stroke is IGradientedRenderable strokeGrad) strokeGrad.GradientX2Units = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    float _gradientY2;
+    public float GradientY2
+    {
+        get => _gradientY2;
+        set
+        {
+            _gradientY2 = value;
+            if (_fill is IGradientedRenderable fillGrad) fillGrad.GradientY2 = value;
+            if (_stroke is IGradientedRenderable strokeGrad) strokeGrad.GradientY2 = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    GeneralUnitType _gradientY2Units;
+    public GeneralUnitType GradientY2Units
+    {
+        get => _gradientY2Units;
+        set
+        {
+            _gradientY2Units = value;
+            if (_fill is IGradientedRenderable fillGrad) fillGrad.GradientY2Units = value;
+            if (_stroke is IGradientedRenderable strokeGrad) strokeGrad.GradientY2Units = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    float _gradientInnerRadius;
+    public float GradientInnerRadius
+    {
+        get => _gradientInnerRadius;
+        set
+        {
+            _gradientInnerRadius = value;
+            if (_fill is IGradientedRenderable fillGrad) fillGrad.GradientInnerRadius = value;
+            if (_stroke is IGradientedRenderable strokeGrad) strokeGrad.GradientInnerRadius = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    DimensionUnitType _gradientInnerRadiusUnits;
+    public DimensionUnitType GradientInnerRadiusUnits
+    {
+        get => _gradientInnerRadiusUnits;
+        set
+        {
+            _gradientInnerRadiusUnits = value;
+            if (_fill is IGradientedRenderable fillGrad) fillGrad.GradientInnerRadiusUnits = value;
+            if (_stroke is IGradientedRenderable strokeGrad) strokeGrad.GradientInnerRadiusUnits = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    float _gradientOuterRadius;
+    public float GradientOuterRadius
+    {
+        get => _gradientOuterRadius;
+        set
+        {
+            _gradientOuterRadius = value;
+            if (_fill is IGradientedRenderable fillGrad) fillGrad.GradientOuterRadius = value;
+            if (_stroke is IGradientedRenderable strokeGrad) strokeGrad.GradientOuterRadius = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    DimensionUnitType _gradientOuterRadiusUnits;
+    public DimensionUnitType GradientOuterRadiusUnits
+    {
+        get => _gradientOuterRadiusUnits;
+        set
+        {
+            _gradientOuterRadiusUnits = value;
+            if (_fill is IGradientedRenderable fillGrad) fillGrad.GradientOuterRadiusUnits = value;
+            if (_stroke is IGradientedRenderable strokeGrad) strokeGrad.GradientOuterRadiusUnits = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    #endregion
 
     /// <summary>
     /// Pushes runtime-held stroke values to the stroke renderable each frame, resolving

--- a/MonoGameGum/GueDeriving/IGradientedRenderable.cs
+++ b/MonoGameGum/GueDeriving/IGradientedRenderable.cs
@@ -1,0 +1,56 @@
+#if XNALIKE
+using Gum.Converters;
+using Gum.DataTypes;
+using RenderingLibrary.Graphics;
+
+namespace Gum.GueDeriving;
+
+/// <summary>
+/// Opt-in gradient surface for fill/stroke renderables in the two-slot shape runtime model
+/// (issue #2791). Implemented by the optional MonoGameGumShapes <c>Circle</c> /
+/// <c>RoundedRectangle</c> (which inherit the full property bag from
+/// <c>RenderableShapeBase</c>) so <see cref="CircleRuntime"/> and friends can push gradient
+/// state through to whichever slots support it. Core defaults like
+/// <see cref="MonoGameGum.Renderables.DefaultStrokedCircleRenderable"/> deliberately do NOT
+/// implement this interface — gradient setters round-trip on the runtime but render as a
+/// no-op without the optional package (graceful degradation, matching the
+/// <see cref="CircleRuntime.FillColor"/> pattern).
+/// </summary>
+/// <remarks>
+/// Property names mirror <c>SkiaShapeRuntime</c> so the runtime APIs match across backends.
+/// All gradient coordinates are interpreted relative to the renderable's local origin by
+/// the implementation (Apos.Shapes' <c>GetGradient</c> does the unit resolution); the
+/// interface itself is a pure pass-through.
+/// </remarks>
+public interface IGradientedRenderable
+{
+    bool UseGradient { get; set; }
+    GradientType GradientType { get; set; }
+
+    int Alpha1 { get; set; }
+    int Red1 { get; set; }
+    int Green1 { get; set; }
+    int Blue1 { get; set; }
+
+    int Alpha2 { get; set; }
+    int Red2 { get; set; }
+    int Green2 { get; set; }
+    int Blue2 { get; set; }
+
+    float GradientX1 { get; set; }
+    GeneralUnitType GradientX1Units { get; set; }
+    float GradientY1 { get; set; }
+    GeneralUnitType GradientY1Units { get; set; }
+
+    float GradientX2 { get; set; }
+    GeneralUnitType GradientX2Units { get; set; }
+    float GradientY2 { get; set; }
+    GeneralUnitType GradientY2Units { get; set; }
+
+    float GradientInnerRadius { get; set; }
+    DimensionUnitType GradientInnerRadiusUnits { get; set; }
+
+    float GradientOuterRadius { get; set; }
+    DimensionUnitType GradientOuterRadiusUnits { get; set; }
+}
+#endif

--- a/Runtimes/GumShapes/Renderables/Circle.cs
+++ b/Runtimes/GumShapes/Renderables/Circle.cs
@@ -12,8 +12,13 @@ namespace MonoGameAndGum.Renderables;
 
 public class Circle : RenderableShapeBase,
     Gum.GueDeriving.IFilledCircleRenderable,
-    Gum.GueDeriving.IStrokedCircleRenderable
+    Gum.GueDeriving.IStrokedCircleRenderable,
+    Gum.GueDeriving.IGradientedRenderable
 {
+    // IGradientedRenderable surface is satisfied entirely by the property bag inherited from
+    // RenderableShapeBase — every member name and type lines up. This interface declaration
+    // exists only so CircleRuntime can `(_fill as IGradientedRenderable)?...` without coupling
+    // to the concrete Apos.Shapes Circle type.
     /// <inheritdoc/>
     /// <remarks>
     /// Apos.Shapes draws the circle as <c>Width / 2</c> centered on the renderable's

--- a/Samples/MonoGameGumShapesGallery/Screens/CirclesScreen.cs
+++ b/Samples/MonoGameGumShapesGallery/Screens/CirclesScreen.cs
@@ -39,14 +39,7 @@ internal class CirclesScreen : FrameworkElement
         root.AddChild(BuildSection("Modes: FillColor, StrokeColor, default", BuildModeRow()));
         root.AddChild(BuildSection("StrokeWidth (1, 2, 4, 8 px)", BuildStrokeWidthRow()));
         root.AddChild(BuildSection("Alignment inside a 220x100 frame (Top / Center / Bottom)", BuildAlignmentRow()));
-
-        // A "Gradients" row exists on the Skia mirror of this screen
-        // (Samples/SilkNetGum/SilkNetGum/Screens/CirclesScreen.cs). It is not duplicated
-        // here yet because the XNA-like CircleRuntime does not expose UseGradient /
-        // GradientType / Color1 / Color2 / etc. through its renderable interfaces
-        // (IFilledCircleRenderable / IStrokedCircleRenderable). The Apos.Shapes Circle
-        // renderable supports gradients natively, so the work is interface widening +
-        // runtime pass-through. Tracked in #2791.
+        root.AddChild(BuildSection("Gradients (linear / radial / diagonal / centered)", BuildGradientRow()));
     }
 
     static ContainerRuntime BuildSection(string label, GraphicalUiElement body)
@@ -138,6 +131,66 @@ internal class CirclesScreen : FrameworkElement
         {
             row.AddChild(BuildAlignmentCell(alignment));
         }
+        return row;
+    }
+
+    // Mirror of the gradient row on Samples/SilkNetGum/SilkNetGum/Screens/CirclesScreen.cs
+    // (issue #2791). Each cell exercises a different gradient configuration; with
+    // MonoGameGumShapes loaded, CircleRuntime pushes gradient state through to both Apos
+    // Circles (fill and stroke), so a single gradient covers the filled disk.
+    static ContainerRuntime BuildGradientRow()
+    {
+        ContainerRuntime row = BuildHorizontalRow();
+
+        // Linear horizontal: white → blue
+        CircleRuntime linearH = new();
+        linearH.Radius = 28;
+        linearH.FillColor = Color.White; // fill mode; gradient overrides solid color
+        linearH.UseGradient = true;
+        linearH.GradientType = GradientType.Linear;
+        linearH.Color1 = Color.White;
+        linearH.Color2 = Color.SteelBlue;
+        linearH.GradientX1 = 0; linearH.GradientY1 = 0;
+        linearH.GradientX2 = 56; linearH.GradientY2 = 0;
+        row.AddChild(linearH);
+
+        // Linear vertical: gold → crimson
+        CircleRuntime linearV = new();
+        linearV.Radius = 28;
+        linearV.FillColor = Color.White;
+        linearV.UseGradient = true;
+        linearV.GradientType = GradientType.Linear;
+        linearV.Color1 = Color.Gold;
+        linearV.Color2 = Color.Crimson;
+        linearV.GradientX1 = 0; linearV.GradientY1 = 0;
+        linearV.GradientX2 = 0; linearV.GradientY2 = 56;
+        row.AddChild(linearV);
+
+        // Linear diagonal: cyan → magenta
+        CircleRuntime linearD = new();
+        linearD.Radius = 28;
+        linearD.FillColor = Color.White;
+        linearD.UseGradient = true;
+        linearD.GradientType = GradientType.Linear;
+        linearD.Color1 = Color.Cyan;
+        linearD.Color2 = Color.Magenta;
+        linearD.GradientX1 = 0; linearD.GradientY1 = 0;
+        linearD.GradientX2 = 56; linearD.GradientY2 = 56;
+        row.AddChild(linearD);
+
+        // Radial centered: white → dark green
+        CircleRuntime radial = new();
+        radial.Radius = 28;
+        radial.FillColor = Color.White;
+        radial.UseGradient = true;
+        radial.GradientType = GradientType.Radial;
+        radial.Color1 = Color.White;
+        radial.Color2 = Color.DarkGreen;
+        radial.GradientX1 = 28; radial.GradientY1 = 28;
+        radial.GradientInnerRadius = 0;
+        radial.GradientOuterRadius = 28;
+        row.AddChild(radial);
+
         return row;
     }
 

--- a/Tests/MonoGameGum.Shapes.Tests/CircleRuntimeTests.cs
+++ b/Tests/MonoGameGum.Shapes.Tests/CircleRuntimeTests.cs
@@ -1,3 +1,4 @@
+using Gum.Converters;
 using Gum.DataTypes;
 using Gum.GueDeriving;
 using Microsoft.Xna.Framework;
@@ -67,6 +68,38 @@ public class CircleRuntimeTests
     // Load-order contract guard for #2761 / #2768: if any of the four factory registrations
     // moves back inside the _registered guard in AposShapeRuntime, this catches the
     // regression. After Reset + re-call, a new CircleRuntime must still bind Apos Circles.
+    // Issue #2791: gradient props on CircleRuntime push through to both Apos Circles so a single
+    // gradient can paint fill and stroke at once (matches Skia's single-renderable behavior).
+    [Fact]
+    public void Gradient_PropertiesPushedToBothFillAndStrokeSlots()
+    {
+        CircleRuntime sut = new();
+
+        sut.UseGradient = true;
+        sut.GradientType = GradientType.Linear;
+        sut.Color1 = Color.Red;
+        sut.Color2 = Color.Blue;
+        sut.GradientX2 = 56;
+        sut.GradientInnerRadius = 4;
+        sut.GradientInnerRadiusUnits = DimensionUnitType.Absolute;
+
+        Circle fill = (Circle)sut.RenderableComponent;
+        Circle stroke = (Circle)fill.Children[0];
+
+        fill.UseGradient.ShouldBeTrue();
+        stroke.UseGradient.ShouldBeTrue();
+        fill.GradientType.ShouldBe(GradientType.Linear);
+        stroke.GradientType.ShouldBe(GradientType.Linear);
+        fill.Red1.ShouldBe(Color.Red.R);
+        stroke.Red1.ShouldBe(Color.Red.R);
+        fill.Blue2.ShouldBe(Color.Blue.B);
+        stroke.Blue2.ShouldBe(Color.Blue.B);
+        fill.GradientX2.ShouldBe(56);
+        stroke.GradientX2.ShouldBe(56);
+        fill.GradientInnerRadius.ShouldBe(4);
+        stroke.GradientInnerRadius.ShouldBe(4);
+    }
+
     [Fact]
     public void LoadOrderRecovery_AfterRegistryResetAndRecall_StillBindsAposCircles()
     {


### PR DESCRIPTION
Closes #2791.

## What

Adds gradient pass-through on the XNA-like `CircleRuntime` for parity with the Skia `CircleRuntime` (which already inherits gradient surface from `SkiaShapeRuntime`).

## How

- **New `IGradientedRenderable` interface** (`MonoGameGum/GueDeriving/IGradientedRenderable.cs`, `#if XNALIKE`). Holds the full gradient property bag (`UseGradient`, `GradientType`, `Color1/Red1/Green1/Blue1/Alpha1`, `Color2/...`, `GradientX1Y1X2Y2` + units, `GradientInnerRadius/OuterRadius` + units). Chosen over widening `IFilledCircleRenderable` / `IStrokedCircleRenderable` because:
  - Gradient is a separate concern from the fill/stroke role contract.
  - The same interface drops in cleanly when `RectangleRuntime` follows the same path (Apos `RoundedRectangle` already inherits the gradient surface from `RenderableShapeBase`).
  - `DefaultStrokedCircleRenderable` doesn't need no-op stubs — it simply doesn't implement the interface.
- **Apos.Shapes `Circle`** now declares `IGradientedRenderable`. The interface surface is satisfied entirely by the property bag inherited from `RenderableShapeBase`; only the interface declaration is added.
- **`CircleRuntime`** gains the gradient API under `#if XNALIKE` with backing fields on the runtime. Setters push to whichever of `_fill` and `_stroke` implements `IGradientedRenderable`. Pushing to both matches the single-renderable Skia behavior, where filled mode and dashed-stroke mode share one set of gradient parameters.
- **`DefaultStrokedCircleRenderable`** unchanged. Without the optional MonoGameGumShapes package, `_stroke` is the default (no `IGradientedRenderable`) and `_fill` is null — gradient setters round-trip on the runtime's backing fields but do not render. Documented graceful-degradation pattern matching `FillColor`.

## Sample

`Samples/MonoGameGumShapesGallery/Screens/CirclesScreen.cs` adds a "Gradients" row mirroring the same row on the Skia side (`Samples/SilkNetGum/SilkNetGum/Screens/CirclesScreen.cs`, added in #2785). Same four cells: linear horizontal, linear vertical, linear diagonal, radial centered.

## Tests

- `MonoGameGum.Tests/Runtimes/CircleRuntimeTests.cs` — `Gradient_RoundTripsBackingFields_WhenNoGradientCapableSlot` exercises round-trip with no Apos package.
- `Tests/MonoGameGum.Shapes.Tests/CircleRuntimeTests.cs` — `Gradient_PropertiesPushedToBothFillAndStrokeSlots` verifies gradient state lands on both Apos `Circle` instances.

Full `MonoGameGum.Tests` (1497) and `MonoGameGum.Shapes.Tests` (33) suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)