### PR TITLE
#2789: default new Gum projects to KernSmith font generator

### DIFF
--- a/Gum/Managers/ProjectManager.cs
+++ b/Gum/Managers/ProjectManager.cs
@@ -154,7 +154,10 @@ public class ProjectManager : IProjectManager
 
     public void CreateNewProject()
     {
-        _gumProjectSave = new GumProjectSave();
+        _gumProjectSave = new GumProjectSave
+        {
+            FontGenerator = FontGeneratorType.KernSmith
+        };
         ObjectFinder.Self.GumProjectSave = _gumProjectSave;
 
         StandardElementsManager.Self.PopulateProjectWithDefaultStandards(_gumProjectSave);

--- a/Tests/Gum.ProjectServices.Tests/ProjectCreatorTests.cs
+++ b/Tests/Gum.ProjectServices.Tests/ProjectCreatorTests.cs
@@ -96,6 +96,27 @@ public class ProjectCreatorTests : IDisposable
     }
 
     [Fact]
+    public void Create_ShouldDefaultFontGeneratorToKernSmith()
+    {
+        string filePath = Path.Combine(_tempDirectory, "TestProject.gumx");
+
+        GumProjectSave project = _sut.Create(filePath);
+
+        project.FontGenerator.ShouldBe(FontGeneratorType.KernSmith);
+    }
+
+    [Fact]
+    public void Create_ShouldPersistKernSmithFontGeneratorToDisk()
+    {
+        string filePath = Path.Combine(_tempDirectory, "TestProject.gumx");
+
+        _sut.Create(filePath);
+
+        string gumxContent = File.ReadAllText(filePath);
+        gumxContent.ShouldContain("<FontGenerator>KernSmith</FontGenerator>");
+    }
+
+    [Fact]
     public void Create_ShouldProduceProjectThatLoadsStandardElements()
     {
         string filePath = Path.Combine(_tempDirectory, "TestProject.gumx");

--- a/Tests/Gum.ProjectServices.Tests/ProjectLoaderTests.cs
+++ b/Tests/Gum.ProjectServices.Tests/ProjectLoaderTests.cs
@@ -1,3 +1,4 @@
+using Gum.DataTypes;
 using Gum.ProjectServices;
 using Shouldly;
 
@@ -10,6 +11,65 @@ public class ProjectLoaderTests
     public ProjectLoaderTests()
     {
         _sut = new ProjectLoader();
+    }
+
+    [Fact]
+    public void Load_ShouldDefaultFontGeneratorToBmFont_WhenFontGeneratorElementMissing()
+    {
+        string tempDir = Path.Combine(Path.GetTempPath(), "GumLoaderTest_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        string gumxPath = Path.Combine(tempDir, "Test.gumx");
+        try
+        {
+            ProjectCreator creator = new ProjectCreator();
+            creator.Create(gumxPath);
+
+            // Strip the <FontGenerator> element to simulate a legacy project that predates the setting.
+            string gumxContent = File.ReadAllText(gumxPath);
+            gumxContent = System.Text.RegularExpressions.Regex.Replace(
+                gumxContent,
+                @"\s*<FontGenerator>[^<]*</FontGenerator>",
+                string.Empty);
+            File.WriteAllText(gumxPath, gumxContent);
+
+            ProjectLoadResult result = _sut.Load(gumxPath);
+
+            result.Success.ShouldBeTrue();
+            result.Project!.FontGenerator.ShouldBe(FontGeneratorType.BmFont);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Load_ShouldHonorExplicitBmFontGenerator()
+    {
+        string tempDir = Path.Combine(Path.GetTempPath(), "GumLoaderTest_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        string gumxPath = Path.Combine(tempDir, "Test.gumx");
+        try
+        {
+            ProjectCreator creator = new ProjectCreator();
+            creator.Create(gumxPath);
+
+            string gumxContent = File.ReadAllText(gumxPath);
+            gumxContent = System.Text.RegularExpressions.Regex.Replace(
+                gumxContent,
+                @"<FontGenerator>[^<]*</FontGenerator>",
+                "<FontGenerator>BmFont</FontGenerator>");
+            File.WriteAllText(gumxPath, gumxContent);
+
+            ProjectLoadResult result = _sut.Load(gumxPath);
+
+            result.Success.ShouldBeTrue();
+            result.Project!.FontGenerator.ShouldBe(FontGeneratorType.BmFont);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
     }
 
     [Fact]

--- a/Tools/Gum.ProjectServices/ProjectCreator.cs
+++ b/Tools/Gum.ProjectServices/ProjectCreator.cs
@@ -43,8 +43,11 @@ public class ProjectCreator : IProjectCreator
         ExtractStandardElements(directory);
         ExtractExampleSpriteFrame(directory);
 
-        var project = new GumProjectSave();
-        project.FullFileName = filePath;
+        var project = new GumProjectSave
+        {
+            FontGenerator = FontGeneratorType.KernSmith,
+            FullFileName = filePath
+        };
 
         foreach (var name in StandardElementNames)
         {


### PR DESCRIPTION
Closes #2789

## What

Explicitly set `FontGenerator = FontGeneratorType.KernSmith` at the two new-project construction sites:

- `Gum/Managers/ProjectManager.cs` — tool's *File → New Project* (and the no-last-project fallback).
- `Tools/Gum.ProjectServices/ProjectCreator.cs` — `ProjectCreator.Create(filePath)` (CLI / headless).

The field initializer on `GumProjectSave.FontGenerator` is intentionally left as `BmFont` so legacy `.gumx` files that omit `<FontGenerator>` still deserialize as BmFont — preserving the back-compat contract documented on the property and `ShouldSerializeFontGenerator`.

`ShouldSerializeFontGenerator` already returns `true` for any non-BmFont value, so new projects record `<FontGenerator>KernSmith</FontGenerator>` on first save. From then on the preference is explicit on disk.

## Tests

Added under `Tests/Gum.ProjectServices.Tests/`:

- `ProjectCreatorTests.Create_ShouldDefaultFontGeneratorToKernSmith`
- `ProjectCreatorTests.Create_ShouldPersistKernSmithFontGeneratorToDisk`
- `ProjectLoaderTests.Load_ShouldDefaultFontGeneratorToBmFont_WhenFontGeneratorElementMissing` (back-compat guard)
- `ProjectLoaderTests.Load_ShouldHonorExplicitBmFontGenerator` (back-compat guard)

The two new-behavior tests failed against `main` and pass with the change; the two guards pass on both sides — they exist to prevent a future field-initializer flip from silently breaking legacy projects.

## What this does NOT touch

- `GumProjectSave` itself (field initializer + `ShouldSerializeFontGenerator` unchanged).
- Existing projects on disk.
- Any migration UX for switching old projects to KernSmith — out of scope per the issue.

The issue's suggested integration test against `ProjectManager.CreateNewProject` was skipped: `ProjectManager` has a private constructor and depends on `Locator`, `PluginManager.Self`, `StandardElementsManagerGumTool`, and `_fileCommands.LoadLocalizationFile()`, making it not unit-testable without significant scaffolding. The tool change is a trivial one-liner mirroring the headless path that *is* covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)