### PR TITLE
#2798: expose IsAntialiased on MG CircleRuntime via IAntialiasedRenderable

### DIFF
--- a/MonoGameGum.Tests/Runtimes/CircleRuntimeTests.cs
+++ b/MonoGameGum.Tests/Runtimes/CircleRuntimeTests.cs
@@ -95,6 +95,22 @@ public class CircleRuntimeTests : BaseTestClass
         sut.GradientOuterRadiusUnits.ShouldBe(DimensionUnitType.RelativeToParent);
     }
 
+    // Issue #2798: IsAntialiased graceful-degradation contract. With no MonoGameGumShapes
+    // package, neither slot implements IAntialiasedRenderable. The setter must round-trip on
+    // the runtime so user code is forward-compatible with a later install of the package, but
+    // produce no visual effect today (LineCircle has no AA concept).
+    [Fact]
+    public void IsAntialiased_RoundTripsBackingField_WhenNoAntialiasedCapableSlot()
+    {
+        CircleRuntime sut = new();
+
+        sut.IsAntialiased.ShouldBeTrue("default matches Apos.Shapes' own default");
+
+        sut.IsAntialiased = false;
+
+        sut.IsAntialiased.ShouldBeFalse();
+    }
+
     [Fact]
     public void LegacyColor_RoutesToStrokeRenderable()
     {

--- a/MonoGameGum/GueDeriving/CircleRuntime.cs
+++ b/MonoGameGum/GueDeriving/CircleRuntime.cs
@@ -311,6 +311,32 @@ public class CircleRuntime : GraphicalUiElement
         }
     }
 
+    bool _isAntialiased = true;
+
+    /// <summary>
+    /// When <c>true</c> (the default, matching Apos.Shapes) the circle's edge is rendered
+    /// with 1 px of anti-aliasing. When <c>false</c> the AA radius drops to 0 for crisp
+    /// rasterization — useful for pixel-art / retro themes (Win95 dotted focus rect, hairline
+    /// borders, 1 px dash/gap patterns where AA bloom widens a nominal 1 px stroke).
+    /// </summary>
+    /// <remarks>
+    /// Pushed to both fill and stroke slots each frame in <see cref="PreRender"/> via
+    /// <see cref="IAntialiasedRenderable"/>. Visual effect requires the optional
+    /// MonoGameGumShapes (Apos.Shapes) package; without it neither slot implements the
+    /// interface and the value round-trips on the runtime but renders as a no-op —
+    /// <see cref="MonoGameGum.Renderables.DefaultStrokedCircleRenderable"/> wraps
+    /// <c>LineCircle</c>, which has no AA concept.
+    /// </remarks>
+    public bool IsAntialiased
+    {
+        get => _isAntialiased;
+        set
+        {
+            _isAntialiased = value;
+            NotifyPropertyChanged();
+        }
+    }
+
     DimensionUnitType _strokeWidthUnits;
 
     /// <summary>
@@ -675,6 +701,12 @@ public class CircleRuntime : GraphicalUiElement
             }
         }
         _stroke.StrokeWidth = strokeWidth;
+
+        // Issue #2798: push AA to both slots so a single setter flips fill + stroke together.
+        // Mirrors AposShapeRuntime.PreRender. Skipped for slots that don't implement the
+        // interface (core DefaultStrokedCircleRenderable has no AA concept).
+        if (_fill is IAntialiasedRenderable fillAa) fillAa.IsAntialiased = _isAntialiased;
+        if (_stroke is IAntialiasedRenderable strokeAa) strokeAa.IsAntialiased = _isAntialiased;
 
         // When fill is the contained object and stroke is its child, the layout system pushes
         // size onto fill but not stroke (stroke is a plain renderable, not a layout-aware

--- a/MonoGameGum/GueDeriving/IAntialiasedRenderable.cs
+++ b/MonoGameGum/GueDeriving/IAntialiasedRenderable.cs
@@ -1,0 +1,26 @@
+#if XNALIKE
+namespace Gum.GueDeriving;
+
+/// <summary>
+/// Opt-in anti-aliasing surface for fill/stroke renderables in the two-slot shape runtime
+/// model (issue #2798). Implemented by the optional MonoGameGumShapes <c>Circle</c> /
+/// <c>RoundedRectangle</c> (the property bag is inherited from <c>RenderableShapeBase</c>),
+/// so <see cref="CircleRuntime"/> can push <c>IsAntialiased</c> through to whichever slots
+/// support it. Core defaults like
+/// <see cref="MonoGameGum.Renderables.DefaultStrokedCircleRenderable"/> deliberately do NOT
+/// implement this interface — <c>LineCircle</c> has no AA concept, so the value is purely
+/// advisory there. Setters round-trip on the runtime but render as a no-op without the
+/// optional package (graceful degradation, matching the <see cref="CircleRuntime.FillColor"/>
+/// and <see cref="IGradientedRenderable"/> patterns).
+/// </summary>
+public interface IAntialiasedRenderable
+{
+    /// <summary>
+    /// When <c>true</c> (the default on Apos.Shapes) edges are rendered with 1 px of
+    /// anti-aliasing. When <c>false</c> the AA radius is dropped to 0 for crisp rasterization —
+    /// useful for retro / pixel-art / hairline patterns where AA bloom would widen a nominal
+    /// 1 px stroke.
+    /// </summary>
+    bool IsAntialiased { get; set; }
+}
+#endif

--- a/Runtimes/GumShapes/Renderables/Circle.cs
+++ b/Runtimes/GumShapes/Renderables/Circle.cs
@@ -13,12 +13,13 @@ namespace MonoGameAndGum.Renderables;
 public class Circle : RenderableShapeBase,
     Gum.GueDeriving.IFilledCircleRenderable,
     Gum.GueDeriving.IStrokedCircleRenderable,
-    Gum.GueDeriving.IGradientedRenderable
+    Gum.GueDeriving.IGradientedRenderable,
+    Gum.GueDeriving.IAntialiasedRenderable
 {
-    // IGradientedRenderable surface is satisfied entirely by the property bag inherited from
-    // RenderableShapeBase — every member name and type lines up. This interface declaration
-    // exists only so CircleRuntime can `(_fill as IGradientedRenderable)?...` without coupling
-    // to the concrete Apos.Shapes Circle type.
+    // IGradientedRenderable and IAntialiasedRenderable are both satisfied entirely by the
+    // property bag inherited from RenderableShapeBase — every member name and type lines up.
+    // The interface declarations exist only so CircleRuntime can pattern-match on each slot
+    // without coupling to the concrete Apos.Shapes Circle type.
     /// <inheritdoc/>
     /// <remarks>
     /// Apos.Shapes draws the circle as <c>Width / 2</c> centered on the renderable's

--- a/Runtimes/SkiaGum/GueDeriving/SkiaShapeRuntime.cs
+++ b/Runtimes/SkiaGum/GueDeriving/SkiaShapeRuntime.cs
@@ -319,6 +319,18 @@ public abstract class SkiaShapeRuntime : InteractiveGue
         set;
     }
 
+    /// <summary>
+    /// Pass-through to the contained renderable's anti-aliasing flag (issue #2798). Mirrors
+    /// the property of the same name on the MonoGame <c>CircleRuntime</c>, which routes
+    /// through <c>IAntialiasedRenderable</c>; on Skia the contained renderable is always
+    /// AA-capable so the value pushes straight through.
+    /// </summary>
+    public bool IsAntialiased
+    {
+        get => ContainedRenderable.IsAntialiased;
+        set => ContainedRenderable.IsAntialiased = value;
+    }
+
     public float StrokeDashLength
     {
         get => ContainedRenderable.StrokeDashLength;

--- a/Runtimes/SkiaGum/Renderables/RenderableShapeBase.cs
+++ b/Runtimes/SkiaGum/Renderables/RenderableShapeBase.cs
@@ -438,6 +438,27 @@ public class RenderableShapeBase : IRenderableIpso, IVisible, IDisposable
         }
     }
 
+    bool _isAntialiased = true;
+    /// <summary>
+    /// When <c>true</c> (the default) edges are rendered with Skia's <c>SKPaint.IsAntialias</c>
+    /// on, producing smooth edges. When <c>false</c> the paint is created without anti-aliasing
+    /// for crisp / pixel-art rasterization (issue #2798). Surfaced on
+    /// <see cref="Gum.GueDeriving.SkiaShapeRuntime"/> so that <c>CircleRuntime</c> etc. expose
+    /// the same <c>IsAntialiased</c> property as their Apos.Shapes counterparts on MonoGame.
+    /// </summary>
+    public bool IsAntialiased
+    {
+        get => _isAntialiased;
+        set
+        {
+            if (_isAntialiased != value)
+            {
+                _isAntialiased = value;
+                ClearCachedPaint();
+            }
+        }
+    }
+
     float _strokeWidth = 2;
     public float StrokeWidth
     {
@@ -745,7 +766,7 @@ public class RenderableShapeBase : IRenderableIpso, IVisible, IDisposable
             Color = effectiveColor,
             Style = IsFilled ? SKPaintStyle.Fill : SKPaintStyle.Stroke,
             StrokeWidth = StrokeWidth,
-            IsAntialias = true
+            IsAntialias = _isAntialiased
         };
 
         if (HasDropshadow)

--- a/Samples/MonoGameGumShapesGallery/MonoGameGumShapesGallery.slnx
+++ b/Samples/MonoGameGumShapesGallery/MonoGameGumShapesGallery.slnx
@@ -1,6 +1,8 @@
 <Solution>
-  <Project Path="../../GumCommon/GumCommon.csproj" />
-  <Project Path="../../MonoGameGum/MonoGameGum.csproj" />
-  <Project Path="../../Runtimes/GumShapes/MonoGameGumShapes.csproj" />
+  <Folder Name="/LibraryProjects/">
+    <Project Path="../../GumCommon/GumCommon.csproj" />
+    <Project Path="../../MonoGameGum/MonoGameGum.csproj" />
+    <Project Path="../../Runtimes/GumShapes/MonoGameGumShapes.csproj" />
+  </Folder>
   <Project Path="MonoGameGumShapesGallery.csproj" />
 </Solution>

--- a/Samples/MonoGameGumShapesGallery/Screens/CirclesScreen.cs
+++ b/Samples/MonoGameGumShapesGallery/Screens/CirclesScreen.cs
@@ -40,6 +40,7 @@ internal class CirclesScreen : FrameworkElement
         root.AddChild(BuildSection("StrokeWidth (1, 2, 4, 8 px)", BuildStrokeWidthRow()));
         root.AddChild(BuildSection("Alignment inside a 220x100 frame (Top / Center / Bottom)", BuildAlignmentRow()));
         root.AddChild(BuildSection("Gradients (linear / radial / diagonal / centered)", BuildGradientRow()));
+        root.AddChild(BuildSection("Antialiasing (default ON, then OFF) — 1 px stroke makes the bloom obvious (#2798)", BuildAntialiasingRow()));
     }
 
     static ContainerRuntime BuildSection(string label, GraphicalUiElement body)
@@ -190,6 +191,32 @@ internal class CirclesScreen : FrameworkElement
         radial.GradientInnerRadius = 0;
         radial.GradientOuterRadius = 28;
         row.AddChild(radial);
+
+        return row;
+    }
+
+    // Issue #2798 visual acceptance: two pairs (filled disk + 1 px outline ring), once with
+    // IsAntialiased = true (the default — soft edges) and once false (crisp pixels).
+    // The 1 px stroke makes the AA bloom obvious.
+    static ContainerRuntime BuildAntialiasingRow()
+    {
+        ContainerRuntime row = BuildHorizontalRow();
+
+        foreach (bool aa in new[] { true, false })
+        {
+            CircleRuntime filled = new();
+            filled.Radius = 28;
+            filled.FillColor = Color.Goldenrod;
+            filled.IsAntialiased = aa;
+            row.AddChild(filled);
+
+            CircleRuntime ring = new();
+            ring.Radius = 28;
+            ring.StrokeColor = Color.White;
+            ring.StrokeWidth = 1;
+            ring.IsAntialiased = aa;
+            row.AddChild(ring);
+        }
 
         return row;
     }

--- a/Samples/SilkNetGum/SilkNetGum/Program.cs
+++ b/Samples/SilkNetGum/SilkNetGum/Program.cs
@@ -42,8 +42,8 @@ unsafe class Program
     static SKCanvas canvas;
     static SKPaint paintFromFile;
 
-    static int windowWidth = 1024;
-    static int windowHeight = 768;
+    static int windowWidth = 1400;
+    static int windowHeight = 900;
 
     #endregion
 

--- a/Samples/SilkNetGum/SilkNetGum/Screens/CirclesScreen.cs
+++ b/Samples/SilkNetGum/SilkNetGum/Screens/CirclesScreen.cs
@@ -37,6 +37,7 @@ internal class CirclesScreen : GraphicalUiElement
         root.Children.Add(BuildSection("StrokeWidth (1, 2, 4, 8 px)", BuildStrokeWidthRow()));
         root.Children.Add(BuildSection("Alignment inside a 220x100 frame (Top / Center / Bottom)", BuildAlignmentRow()));
         root.Children.Add(BuildSection("Gradients (linear / radial / diagonal / centered)", BuildGradientRow()));
+        root.Children.Add(BuildSection("Antialiasing (default ON, then OFF) — 1 px stroke makes the bloom obvious (#2798)", BuildAntialiasingRow()));
         root.Children.Add(BuildSection("Known limitation: FillColor + StrokeColor on the same instance — only the most-recently-set one renders today (see #2790).", BuildBothColorsRow()));
     }
 
@@ -213,6 +214,32 @@ internal class CirclesScreen : GraphicalUiElement
         fillWins.StrokeWidth = 4;
         fillWins.FillColor = SKColors.Gold;
         row.Children.Add(fillWins);
+
+        return row;
+    }
+
+    // Issue #2798 visual acceptance: two pairs (filled disk + 1 px outline ring), once with
+    // IsAntialiased = true (the default — soft edges) and once false (crisp pixels). On Skia
+    // this flips SKPaint.IsAntialias on the contained renderable.
+    static ContainerRuntime BuildAntialiasingRow()
+    {
+        ContainerRuntime row = BuildHorizontalRow();
+
+        foreach (bool aa in new[] { true, false })
+        {
+            CircleRuntime filled = new();
+            filled.Radius = 28;
+            filled.FillColor = SKColors.Goldenrod;
+            filled.IsAntialiased = aa;
+            row.Children.Add(filled);
+
+            CircleRuntime ring = new();
+            ring.Radius = 28;
+            ring.StrokeColor = SKColors.White;
+            ring.StrokeWidth = 1;
+            ring.IsAntialiased = aa;
+            row.Children.Add(ring);
+        }
 
         return row;
     }

--- a/Tests/MonoGameGum.Shapes.Tests/CircleRuntimeTests.cs
+++ b/Tests/MonoGameGum.Shapes.Tests/CircleRuntimeTests.cs
@@ -100,6 +100,26 @@ public class CircleRuntimeTests
         stroke.GradientInnerRadius.ShouldBe(4);
     }
 
+    // Issue #2798: IsAntialiased pushes through to both slots so a single setter flips AA on
+    // fill and stroke together. Default true matches Apos.Shapes' own default. The push
+    // happens via PreRender (matching how StrokeWidth/StrokeDashLength flow); fire the hook
+    // explicitly here to mirror the renderer's PreRender walk.
+    [Fact]
+    public void IsAntialiased_PushedViaPreRender_ToBothFillAndStrokeSlots()
+    {
+        CircleRuntime sut = new();
+
+        sut.IsAntialiased = false;
+
+        Circle fill = (Circle)sut.RenderableComponent;
+        Circle stroke = (Circle)fill.Children[0];
+        IRenderable asFillRenderable = fill;
+        asFillRenderable.PreRender();
+
+        fill.IsAntialiased.ShouldBeFalse();
+        stroke.IsAntialiased.ShouldBeFalse();
+    }
+
     [Fact]
     public void LoadOrderRecovery_AfterRegistryResetAndRecall_StillBindsAposCircles()
     {


### PR DESCRIPTION
@
Closes #2798.

Adds an `IAntialiasedRenderable` opt-in interface (under `#if XNALIKE`) and implements it on the optional MonoGameGumShapes `Circle` (property bag inherited from `RenderableShapeBase`, so only an interface declaration is needed). `CircleRuntime` gains an `IsAntialiased` pass-through (default `true`, matching Apos.Shapes own default), pushed to both `_fill` and `_stroke` each frame in `PreRender` — mirroring how `AposShapeRuntime.PreRender` pushes the flag onto its contained renderable.

`DefaultStrokedCircleRenderable` deliberately does NOT implement `IAntialiasedRenderable`: `LineCircle` has no AA concept, so without the optional package the setter round-trips on the runtimes backing field but produces no visual effect — the documented graceful-degradation pattern established for `FillColor` in #2768 and gradients in #2791.

## Scope note — Skia side included

The issue body scopes this to MG/Raylib, but the user asked for visual acceptance on both the Apos.Shapes sample (`MonoGameGumShapesGallery`) and the Skia sample (`SilkNetGum`). On Skia, `SKPaint.IsAntialias` was previously hardcoded to `true` in `RenderableShapeBase`, so I extended the same control there: `RenderableShapeBase` gained an `IsAntialiased` field (default `true`) that drives the paint, and `SkiaShapeRuntime` exposes the same property name so the Skia `CircleRuntime` has API parity with the MG one. This keeps the cross-backend surface consistent — the same user code now drives AA on both backends.

## Samples

- `Samples/MonoGameGumShapesGallery/Screens/CirclesScreen.cs`: new "Antialiasing" row with a filled disk + 1 px stroke pair, once with AA on and once with AA off. The 1 px stroke makes the bloom obvious.
- `Samples/SilkNetGum/SilkNetGum/Screens/CirclesScreen.cs`: mirror row exercising the Skia path.

## Tests

- `MonoGameGum.Tests.Runtimes.CircleRuntimeTests.IsAntialiased_RoundTripsBackingField_WhenNoAntialiasedCapableSlot` — no-Apos round-trip (default `true`, settable `false`).
- `MonoGameGum.Shapes.Tests.CircleRuntimeTests.IsAntialiased_PushedViaPreRender_ToBothFillAndStrokeSlots` — Apos-backed two-slot push through `PreRender`.

Both test suites pass: 1498 + 34.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@