### PR TITLE
#2801: document Font Generator (KernSmith vs BMFont) on Project Properties page

### DIFF
--- a/.claude/skills/gum-docs-writing/SKILL.md
+++ b/.claude/skills/gum-docs-writing/SKILL.md
@@ -89,6 +89,34 @@ The convention for these:
 
 The control-page note exists so that a reader troubleshooting "why doesn't my int binding take" while reading the TextBox page finds what they need without bouncing around. The feature-page section exists so that a reader learning the binding system isn't surprised later. Both audiences are real; the split avoids both blind spots without duplicating content.
 
+## Date-Specific Content Goes in Hint Blocks
+
+Anything that is only true relative to a release date — "as of <month> <year>", "before <date>", "in <version> X changed" — must live in a `{% hint %}` block, not in the body paragraphs of a section. Phrase the surrounding prose in terms of current behavior so it stays correct after the dated note is removed.
+
+Why: dated notes eventually become noise once enough time has passed (everyone reading the docs is on the new behavior). Keeping them in hint blocks gives a single, visually obvious anchor to delete later instead of forcing the author to re-read every paragraph hunting for embedded dates.
+
+Pattern:
+
+```
+The Font Generator project property controls ... There are two options:
+
+* **KernSmith** — ... This is the default for new projects.
+* **BMFont** — ... a separate external tool.
+
+{% hint style="info" %}
+**As of May 2026:** New projects default to **KernSmith**. Before this, the default was **BMFont**. Existing projects keep their current setting.
+{% endhint %}
+```
+
+Not this — date leaks into body bullets, so removing the dated context later means rewriting prose:
+
+```
+* **KernSmith** — ... Default for new projects starting in May 2026.
+* **BMFont** — ... Was the default before May 2026.
+```
+
+This applies to: "as of <date>", "starting in <date>", "before <date>", "in version X", "the May 2026 release", and any "what changed in <release>" section heading. When in doubt: if deleting the sentence later would leave the surrounding paragraph still accurate, it's safe in the body; if deleting it would leave a contradiction or dangling reference, lift it into a hint.
+
 ## Tone and Style
 
 - Second person ("you"), present tense, instructional tone.

--- a/docs/gum-tool/project-properties.md
+++ b/docs/gum-tool/project-properties.md
@@ -76,14 +76,14 @@ Gum does not check whether the font range you have added is supported in each of
 
 The Font Generator project property controls which tool Gum uses to bake `.fnt` files and PNG atlases into the project's FontCache. There are two options:
 
-* **KernSmith** — Gum's own font generator. This is the default for new projects created with Gum starting in May 2026.
-* **BMFont** — [Bitmap Font Generator](https://www.angelcode.com/products/bmfont/), an external tool. This was the default for projects created before May 2026.
-
-### What Changed in May 2026
-
-New projects default to **KernSmith**. Existing projects keep their current setting — a project saved before May 2026 that did not explicitly choose a generator continues to load as **BMFont**. There is no auto-migration; opening an older project in a newer version of the Gum tool does not switch its generator.
+* **KernSmith** — a standalone font generator that Gum integrates with. This is the default for new projects.
+* **BMFont** — [Bitmap Font Generator](https://www.angelcode.com/products/bmfont/), a separate external tool.
 
 You can change the setting at any time in **Project Properties**. The next FontCache rebuild uses the chosen generator.
+
+{% hint style="info" %}
+**As of May 2026:** New projects default to **KernSmith**. Before this, the default was **BMFont**. Existing projects keep their current setting — opening an older project in a newer version of the Gum tool does not switch its generator, and there is no auto-migration.
+{% endhint %}
 
 {% hint style="warning" %}
 Switching the Font Generator wipes and re-creates every font in the FontCache. The two generators produce slightly different output for the same `.ttf` and Font Ranges — glyph shapes, antialiasing, and reported sizes can shift a small amount. After switching, review your text in the editor to confirm everything still looks the way you expect. Because the rebuild is automatic, switching back is just as easy if you want to compare.

--- a/docs/gum-tool/project-properties.md
+++ b/docs/gum-tool/project-properties.md
@@ -72,6 +72,36 @@ Notice that the CJK characters are not supported. By contrast the Batang font fa
 
 Gum does not check whether the font range you have added is supported in each of the font faces used in your application. If you are extending your character set, you should verify that the font is supported in Bitmap Font Generator.
 
+## Font Generator
+
+The Font Generator project property controls which tool Gum uses to bake `.fnt` files and PNG atlases into the project's FontCache. There are two options:
+
+* **KernSmith** — Gum's own font generator. This is the default for new projects created with Gum starting in May 2026.
+* **BMFont** — [Bitmap Font Generator](https://www.angelcode.com/products/bmfont/), an external tool. This was the default for projects created before May 2026.
+
+### What Changed in May 2026
+
+New projects default to **KernSmith**. Existing projects keep their current setting — a project saved before May 2026 that did not explicitly choose a generator continues to load as **BMFont**. There is no auto-migration; opening an older project in a newer version of the Gum tool does not switch its generator.
+
+You can change the setting at any time in **Project Properties**. The next FontCache rebuild uses the chosen generator.
+
+{% hint style="warning" %}
+Switching the Font Generator wipes and re-creates every font in the FontCache. The two generators produce slightly different output for the same `.ttf` and Font Ranges — glyph shapes, antialiasing, and reported sizes can shift a small amount. After switching, review your text in the editor to confirm everything still looks the way you expect. Because the rebuild is automatic, switching back is just as easy if you want to compare.
+{% endhint %}
+
+### Why Pick KernSmith
+
+* **Faster font generation in the tool**, especially when editing Font Ranges or adding new fonts. KernSmith runs in-process; BMFont shells out to the external Bitmap Font Generator executable for every rebuild.
+* **Consistency between authoring and runtime.** Runtimes that perform dynamic font generation (for example web targets, where shipping a `.ttf` is smaller than shipping pre-baked atlases for large character sets) use KernSmith. Authoring with KernSmith means the glyphs you see in the editor match what the player sees at runtime. See [Fonts on Web](../code/files-and-fonts/fonts-web.md) for more on the web tradeoff, especially for CJK projects.
+* **Future feature support.** Upcoming font features such as colored outlines and gradients are planned to land on KernSmith first; BMFont's external pipeline will not receive them. These features are not yet available.
+
+### Why Someone Might Stick with BMFont
+
+* They have an existing project with an established FontCache, fine-tuned in BMFont, and don't want to rebuild it.
+* They have a specific BMFont tooling or workflow they rely on.
+
+For background on the runtime side of font generation, see [Fonts](../code/files-and-fonts/fonts.md).
+
 ## Font Spacing Horizontal and Font Spacing Vertical
 
 The Font Spacing Horizontal and Font Spacing Vertical values control the amount of space (padding) added between each letter in the generated .fnt file. These values do not affect the size of the letters in the Editor tab or at runtime, but the additional spacing can be used to separate the letters. This is important if your font rendering may end up implementing any kind of blurring to improve font appearance. This type of blurring may occur if:


### PR DESCRIPTION
Adds a new **Font Generator** section to `docs/gum-tool/project-properties.md`, slotted between **Font Ranges** and **Font Spacing** so the font-related properties stay grouped together.

The section covers:

- What **KernSmith** and **BMFont** are.
- The May 2026 default switch to KernSmith for new projects, with existing projects keeping their setting (no auto-migration). Mirrors the behavior shipped in #2789.
- A warning that switching the Font Generator wipes and rebuilds the FontCache, and that output may shift slightly between the two generators (glyph shape, antialiasing, reported sizes). Phrased loosely because we don't have a precise per-difference catalog, and the rebuild makes it easy to compare.
- Why pick KernSmith (faster in-tool generation, consistency with runtime dynamic generation on web/CJK, future feature target for colored outlines/gradients — phrased as planned, not shipped).
- Why someone might stick with BMFont (existing fine-tuned cache, established BMFont workflow).
- Cross-links to `docs/code/files-and-fonts/fonts-web.md` and `docs/code/files-and-fonts/fonts.md`.

Docs-only change. No SUMMARY.md edit needed — the page is already listed; this only adds a section to it.

Closes #2801

🤖 Generated with [Claude Code](https://claude.com/claude-code)