### PR TITLE
#2797: Expose dropshadow on MG/Raylib CircleRuntime via IDropshadowRenderable

### DIFF
--- a/MonoGameGum.Tests/Runtimes/CircleRuntimeTests.cs
+++ b/MonoGameGum.Tests/Runtimes/CircleRuntimeTests.cs
@@ -95,6 +95,54 @@ public class CircleRuntimeTests : BaseTestClass
         sut.GradientOuterRadiusUnits.ShouldBe(DimensionUnitType.RelativeToParent);
     }
 
+    // Issue #2797: dropshadow graceful-degradation contract. With no MonoGameGumShapes
+    // package, neither slot implements IDropshadowRenderable. The setters must round-trip on
+    // the runtime so user code is forward-compatible with a later install of the package, but
+    // produce no visual effect today.
+    [Fact]
+    public void Dropshadow_RoundTripsBackingFields_WhenNoDropshadowCapableSlot()
+    {
+        CircleRuntime sut = new();
+
+        // Constructor seeds the same defaults as SkiaShapeRuntime so HasDropshadow = true
+        // immediately produces a visible shadow without further setup.
+        sut.DropshadowAlpha.ShouldBe(255);
+        sut.DropshadowOffsetY.ShouldBe(3);
+        sut.DropshadowBlurY.ShouldBe(3);
+        sut.HasDropshadow.ShouldBeFalse();
+
+        sut.HasDropshadow = true;
+        sut.DropshadowColor = new Color(10, 20, 30, 40);
+        sut.DropshadowOffsetX = 5;
+        sut.DropshadowOffsetY = 7;
+        sut.DropshadowBlurX = 2;
+        sut.DropshadowBlurY = 4;
+
+        sut.HasDropshadow.ShouldBeTrue();
+        sut.DropshadowColor.ShouldBe(new Color(10, 20, 30, 40));
+        sut.DropshadowRed.ShouldBe(10);
+        sut.DropshadowGreen.ShouldBe(20);
+        sut.DropshadowBlue.ShouldBe(30);
+        sut.DropshadowAlpha.ShouldBe(40);
+        sut.DropshadowOffsetX.ShouldBe(5);
+        sut.DropshadowOffsetY.ShouldBe(7);
+        sut.DropshadowBlurX.ShouldBe(2);
+        sut.DropshadowBlurY.ShouldBe(4);
+    }
+
+    [Fact]
+    public void DropshadowChannelSetters_ComposeDropshadowColor()
+    {
+        CircleRuntime sut = new();
+
+        sut.DropshadowRed = 11;
+        sut.DropshadowGreen = 22;
+        sut.DropshadowBlue = 33;
+        sut.DropshadowAlpha = 44;
+
+        sut.DropshadowColor.ShouldBe(new Color(11, 22, 33, 44));
+    }
+
     // Issue #2798: IsAntialiased graceful-degradation contract. With no MonoGameGumShapes
     // package, neither slot implements IAntialiasedRenderable. The setter must round-trip on
     // the runtime so user code is forward-compatible with a later install of the package, but

--- a/MonoGameGum/GueDeriving/CircleRuntime.cs
+++ b/MonoGameGum/GueDeriving/CircleRuntime.cs
@@ -682,6 +682,136 @@ public class CircleRuntime : GraphicalUiElement
 
     #endregion
 
+    #region Dropshadow
+
+    // Issue #2797: dropshadow pass-through. Backing fields live on the runtime so values
+    // round-trip even when neither slot implements IDropshadowRenderable (core-only stroke
+    // = DefaultStrokedCircleRenderable, no fill). Unlike gradient (#2791) and AA (#2798),
+    // which push to BOTH slots so a single setter covers fill and stroke, the shadow is
+    // drawn once per renderable — pushing to both would render the shadow twice and
+    // visibly double up. Prefer the fill slot; fall back to stroke when fill is null
+    // (Apos can shadow a stroked ring too, so a stroke-only Apos circle still gets one).
+    // The push-target helper is shared across every setter so the routing rule lives in
+    // one place.
+
+    IDropshadowRenderable? DropshadowTarget =>
+        _fill as IDropshadowRenderable ?? _stroke as IDropshadowRenderable;
+
+    bool _hasDropshadow;
+    /// <summary>
+    /// When <c>true</c>, the dropshadow color/offset/blur properties drive an extra render
+    /// pass behind the circle. Visual effect requires the optional MonoGameGumShapes
+    /// (Apos.Shapes) package; without it the value round-trips but does not render.
+    /// </summary>
+    public bool HasDropshadow
+    {
+        get => _hasDropshadow;
+        set
+        {
+            _hasDropshadow = value;
+            if (DropshadowTarget is { } target) target.HasDropshadow = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    Color _dropshadowColor;
+    public Color DropshadowColor
+    {
+        get => _dropshadowColor;
+        set
+        {
+            _dropshadowColor = value;
+            if (DropshadowTarget is { } target) target.DropshadowColor = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    public int DropshadowAlpha
+    {
+        get => _dropshadowColor.A;
+        set
+        {
+            DropshadowColor = new Color(_dropshadowColor.R, _dropshadowColor.G, _dropshadowColor.B, (byte)value);
+        }
+    }
+
+    public int DropshadowRed
+    {
+        get => _dropshadowColor.R;
+        set
+        {
+            DropshadowColor = new Color((byte)value, _dropshadowColor.G, _dropshadowColor.B, _dropshadowColor.A);
+        }
+    }
+
+    public int DropshadowGreen
+    {
+        get => _dropshadowColor.G;
+        set
+        {
+            DropshadowColor = new Color(_dropshadowColor.R, (byte)value, _dropshadowColor.B, _dropshadowColor.A);
+        }
+    }
+
+    public int DropshadowBlue
+    {
+        get => _dropshadowColor.B;
+        set
+        {
+            DropshadowColor = new Color(_dropshadowColor.R, _dropshadowColor.G, (byte)value, _dropshadowColor.A);
+        }
+    }
+
+    float _dropshadowOffsetX;
+    public float DropshadowOffsetX
+    {
+        get => _dropshadowOffsetX;
+        set
+        {
+            _dropshadowOffsetX = value;
+            if (DropshadowTarget is { } target) target.DropshadowOffsetX = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    float _dropshadowOffsetY;
+    public float DropshadowOffsetY
+    {
+        get => _dropshadowOffsetY;
+        set
+        {
+            _dropshadowOffsetY = value;
+            if (DropshadowTarget is { } target) target.DropshadowOffsetY = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    float _dropshadowBlurX;
+    public float DropshadowBlurX
+    {
+        get => _dropshadowBlurX;
+        set
+        {
+            _dropshadowBlurX = value;
+            if (DropshadowTarget is { } target) target.DropshadowBlurX = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    float _dropshadowBlurY;
+    public float DropshadowBlurY
+    {
+        get => _dropshadowBlurY;
+        set
+        {
+            _dropshadowBlurY = value;
+            if (DropshadowTarget is { } target) target.DropshadowBlurY = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    #endregion
+
     /// <summary>
     /// Pushes runtime-held stroke values to the stroke renderable each frame, resolving
     /// <see cref="StrokeWidthUnits"/> against the current camera zoom. Reached through the
@@ -788,6 +918,14 @@ public class CircleRuntime : GraphicalUiElement
             }
             Width = 32;
             Height = 32;
+
+            // Dropshadow defaults mirror SkiaShapeRuntime: opaque black, slight downward
+            // offset, slight Y blur. HasDropshadow is false so the values are inert until
+            // toggled on at runtime, at which point a visible shadow appears without further
+            // setup. Issue #2797.
+            DropshadowAlpha = 255;
+            DropshadowOffsetY = 3;
+            DropshadowBlurY = 3;
 
             // Mirror initial size to the stroke renderable when it's a child of fill — see
             // SyncStrokeSize comment in PreRender. Layout pushed Width/Height to fill but not

--- a/MonoGameGum/GueDeriving/IDropshadowRenderable.cs
+++ b/MonoGameGum/GueDeriving/IDropshadowRenderable.cs
@@ -1,0 +1,42 @@
+#if XNALIKE
+using Microsoft.Xna.Framework;
+
+namespace Gum.GueDeriving;
+
+/// <summary>
+/// Opt-in dropshadow surface for fill/stroke renderables in the two-slot shape runtime
+/// model (issue #2797). Implemented by the optional MonoGameGumShapes <c>Circle</c> /
+/// <c>RoundedRectangle</c> (the property bag is inherited from <c>RenderableShapeBase</c>)
+/// so <see cref="CircleRuntime"/> and friends can push dropshadow state through to a
+/// shadow-capable slot. Core defaults like
+/// <see cref="MonoGameGum.Renderables.DefaultStrokedCircleRenderable"/> deliberately do NOT
+/// implement this interface — <c>LineCircle</c> has no shadow concept. Setters round-trip
+/// on the runtime but render as a no-op without the optional package (graceful degradation,
+/// matching the <see cref="CircleRuntime.FillColor"/>, <see cref="IGradientedRenderable"/>,
+/// and <see cref="IAntialiasedRenderable"/> patterns).
+/// </summary>
+/// <remarks>
+/// Property names mirror <c>SkiaShapeRuntime</c> so the runtime APIs match across backends.
+/// Unlike <see cref="IGradientedRenderable"/> (which the runtime pushes to BOTH fill and
+/// stroke so a single gradient covers the filled disk and dashed-stroke ring at once), a
+/// dropshadow is drawn once per renderable — pushing the shadow params to both fill and
+/// stroke would render the shadow twice and visibly double up. The runtime prefers the fill
+/// slot and falls back to stroke when fill is null.
+/// </remarks>
+public interface IDropshadowRenderable
+{
+    bool HasDropshadow { get; set; }
+
+    Color DropshadowColor { get; set; }
+    int DropshadowAlpha { get; set; }
+    int DropshadowRed { get; set; }
+    int DropshadowGreen { get; set; }
+    int DropshadowBlue { get; set; }
+
+    float DropshadowOffsetX { get; set; }
+    float DropshadowOffsetY { get; set; }
+
+    float DropshadowBlurX { get; set; }
+    float DropshadowBlurY { get; set; }
+}
+#endif

--- a/Runtimes/GumShapes/Renderables/Circle.cs
+++ b/Runtimes/GumShapes/Renderables/Circle.cs
@@ -14,12 +14,13 @@ public class Circle : RenderableShapeBase,
     Gum.GueDeriving.IFilledCircleRenderable,
     Gum.GueDeriving.IStrokedCircleRenderable,
     Gum.GueDeriving.IGradientedRenderable,
-    Gum.GueDeriving.IAntialiasedRenderable
+    Gum.GueDeriving.IAntialiasedRenderable,
+    Gum.GueDeriving.IDropshadowRenderable
 {
-    // IGradientedRenderable and IAntialiasedRenderable are both satisfied entirely by the
-    // property bag inherited from RenderableShapeBase — every member name and type lines up.
-    // The interface declarations exist only so CircleRuntime can pattern-match on each slot
-    // without coupling to the concrete Apos.Shapes Circle type.
+    // IGradientedRenderable, IAntialiasedRenderable, and IDropshadowRenderable are all
+    // satisfied entirely by the property bag inherited from RenderableShapeBase — every
+    // member name and type lines up. The interface declarations exist only so CircleRuntime
+    // can pattern-match on each slot without coupling to the concrete Apos.Shapes Circle type.
     /// <inheritdoc/>
     /// <remarks>
     /// Apos.Shapes draws the circle as <c>Width / 2</c> centered on the renderable's

--- a/Runtimes/GumShapes/Renderables/RoundedRectangle.cs
+++ b/Runtimes/GumShapes/Renderables/RoundedRectangle.cs
@@ -12,13 +12,18 @@ namespace MonoGameAndGum.Renderables;
 
 public class RoundedRectangle : RenderableShapeBase,
     Gum.GueDeriving.IFilledRectangleRenderable,
-    Gum.GueDeriving.IStrokedRectangleRenderable
+    Gum.GueDeriving.IStrokedRectangleRenderable,
+    Gum.GueDeriving.IDropshadowRenderable
 {
+    // IDropshadowRenderable is satisfied entirely by the property bag inherited from
+    // RenderableShapeBase — declared here so the future RectangleRuntime (#2797 follow-up)
+    // can pattern-match the dropshadow surface the same way CircleRuntime does today,
+    // without coupling to the concrete Apos.Shapes RoundedRectangle type.
+
     /// <summary>
     /// Rounded-corner radius in pixels. Apos.Shapes' <c>RoundedRectangle</c> honors this on
-    /// both fill and stroke draws, so <see cref="RectangleRuntime"/> pushes the same value
-    /// to both slots. Per-corner overrides via the <c>CustomRadius*</c> properties are
-    /// unchanged.
+    /// both fill and stroke draws, so <c>RectangleRuntime</c> pushes the same value to both
+    /// slots. Per-corner overrides via the <c>CustomRadius*</c> properties are unchanged.
     /// </summary>
     public float CornerRadius { get; set; }
 

--- a/Samples/MonoGameGumShapesGallery/Screens/CirclesScreen.cs
+++ b/Samples/MonoGameGumShapesGallery/Screens/CirclesScreen.cs
@@ -41,6 +41,7 @@ internal class CirclesScreen : FrameworkElement
         root.AddChild(BuildSection("Alignment inside a 220x100 frame (Top / Center / Bottom)", BuildAlignmentRow()));
         root.AddChild(BuildSection("Gradients (linear / radial / diagonal / centered)", BuildGradientRow()));
         root.AddChild(BuildSection("Antialiasing (default ON, then OFF) — 1 px stroke makes the bloom obvious (#2798)", BuildAntialiasingRow()));
+        root.AddChild(BuildSection("Dropshadow (off / soft / hard offset / colored) — fill-only push avoids doubling (#2797)", BuildDropshadowRow()));
     }
 
     static ContainerRuntime BuildSection(string label, GraphicalUiElement body)
@@ -217,6 +218,58 @@ internal class CirclesScreen : FrameworkElement
             ring.IsAntialiased = aa;
             row.AddChild(ring);
         }
+
+        return row;
+    }
+
+    // Issue #2797 visual acceptance: four cells — first is the baseline (no shadow), the
+    // remaining three exercise different shadow configurations. The runtime pushes shadow
+    // params to the fill slot only (not the stroke), so the shadow renders once per cell
+    // rather than doubling up. Mirrored on the Skia side of the gallery.
+    static ContainerRuntime BuildDropshadowRow()
+    {
+        ContainerRuntime row = BuildHorizontalRow();
+
+        // Baseline: no shadow.
+        CircleRuntime baseline = new();
+        baseline.Radius = 28;
+        baseline.FillColor = Color.Goldenrod;
+        row.AddChild(baseline);
+
+        // Soft shadow: small offset, generous blur, default opaque black.
+        CircleRuntime soft = new();
+        soft.Radius = 28;
+        soft.FillColor = Color.Goldenrod;
+        soft.HasDropshadow = true;
+        soft.DropshadowOffsetX = 2;
+        soft.DropshadowOffsetY = 2;
+        soft.DropshadowBlurX = 4;
+        soft.DropshadowBlurY = 4;
+        row.AddChild(soft);
+
+        // Hard offset: bigger offset, no blur, semi-transparent black.
+        CircleRuntime hard = new();
+        hard.Radius = 28;
+        hard.FillColor = Color.Goldenrod;
+        hard.HasDropshadow = true;
+        hard.DropshadowColor = new Color(0, 0, 0, 160);
+        hard.DropshadowOffsetX = 6;
+        hard.DropshadowOffsetY = 6;
+        hard.DropshadowBlurX = 0;
+        hard.DropshadowBlurY = 0;
+        row.AddChild(hard);
+
+        // Colored shadow: deep blue glow underneath.
+        CircleRuntime colored = new();
+        colored.Radius = 28;
+        colored.FillColor = Color.Goldenrod;
+        colored.HasDropshadow = true;
+        colored.DropshadowColor = new Color(0, 80, 200, 200);
+        colored.DropshadowOffsetX = 0;
+        colored.DropshadowOffsetY = 0;
+        colored.DropshadowBlurX = 6;
+        colored.DropshadowBlurY = 6;
+        row.AddChild(colored);
 
         return row;
     }

--- a/Samples/SilkNetGum/SilkNetGum/Screens/CirclesScreen.cs
+++ b/Samples/SilkNetGum/SilkNetGum/Screens/CirclesScreen.cs
@@ -38,6 +38,7 @@ internal class CirclesScreen : GraphicalUiElement
         root.Children.Add(BuildSection("Alignment inside a 220x100 frame (Top / Center / Bottom)", BuildAlignmentRow()));
         root.Children.Add(BuildSection("Gradients (linear / radial / diagonal / centered)", BuildGradientRow()));
         root.Children.Add(BuildSection("Antialiasing (default ON, then OFF) — 1 px stroke makes the bloom obvious (#2798)", BuildAntialiasingRow()));
+        root.Children.Add(BuildSection("Dropshadow (off / soft / hard offset / colored) — Skia draws the shadow on the single contained renderable (#2797)", BuildDropshadowRow()));
         root.Children.Add(BuildSection("Known limitation: FillColor + StrokeColor on the same instance — only the most-recently-set one renders today (see #2790).", BuildBothColorsRow()));
     }
 
@@ -240,6 +241,59 @@ internal class CirclesScreen : GraphicalUiElement
             ring.IsAntialiased = aa;
             row.Children.Add(ring);
         }
+
+        return row;
+    }
+
+    // Issue #2797 visual acceptance: mirror of the MonoGameGumShapesGallery dropshadow row.
+    // Same four cells — baseline, soft, hard offset, colored — so visual regressions in one
+    // backend are easy to spot against the other.
+    static ContainerRuntime BuildDropshadowRow()
+    {
+        ContainerRuntime row = BuildHorizontalRow();
+
+        // Baseline: no shadow.
+        CircleRuntime baseline = new();
+        baseline.Radius = 28;
+        baseline.FillColor = SKColors.Goldenrod;
+        row.Children.Add(baseline);
+
+        // Soft shadow: small offset, generous blur, default opaque black.
+        CircleRuntime soft = new();
+        soft.Radius = 28;
+        soft.FillColor = SKColors.Goldenrod;
+        soft.HasDropshadow = true;
+        soft.DropshadowOffsetX = 2;
+        soft.DropshadowOffsetY = 2;
+        soft.DropshadowBlurX = 4;
+        soft.DropshadowBlurY = 4;
+        row.Children.Add(soft);
+
+        // Hard offset: bigger offset, no blur, semi-transparent black. Skia exposes only
+        // per-channel ints on the SkiaShapeRuntime dropshadow surface (no DropshadowColor
+        // composite), so set the channels individually here.
+        CircleRuntime hard = new();
+        hard.Radius = 28;
+        hard.FillColor = SKColors.Goldenrod;
+        hard.HasDropshadow = true;
+        hard.DropshadowRed = 0; hard.DropshadowGreen = 0; hard.DropshadowBlue = 0; hard.DropshadowAlpha = 160;
+        hard.DropshadowOffsetX = 6;
+        hard.DropshadowOffsetY = 6;
+        hard.DropshadowBlurX = 0;
+        hard.DropshadowBlurY = 0;
+        row.Children.Add(hard);
+
+        // Colored shadow: deep blue glow underneath.
+        CircleRuntime colored = new();
+        colored.Radius = 28;
+        colored.FillColor = SKColors.Goldenrod;
+        colored.HasDropshadow = true;
+        colored.DropshadowRed = 0; colored.DropshadowGreen = 80; colored.DropshadowBlue = 200; colored.DropshadowAlpha = 200;
+        colored.DropshadowOffsetX = 0;
+        colored.DropshadowOffsetY = 0;
+        colored.DropshadowBlurX = 6;
+        colored.DropshadowBlurY = 6;
+        row.Children.Add(colored);
 
         return row;
     }

--- a/Tests/MonoGameGum.Shapes.Tests/CircleRuntimeTests.cs
+++ b/Tests/MonoGameGum.Shapes.Tests/CircleRuntimeTests.cs
@@ -100,6 +100,37 @@ public class CircleRuntimeTests
         stroke.GradientInnerRadius.ShouldBe(4);
     }
 
+    // Issue #2797: dropshadow pushes to the fill slot only (with fallback to stroke when fill
+    // is null) because Apos draws one shadow per renderable — pushing to BOTH slots would
+    // render the shadow twice and visibly double up. This deliberately differs from gradient
+    // (#2791) and AA (#2798), which DO push to both slots. With both slots Apos here, the
+    // shadow lands on fill and stroke stays clean.
+    [Fact]
+    public void Dropshadow_PropertiesPushedToFillSlotOnly_NotStroke()
+    {
+        CircleRuntime sut = new();
+
+        sut.HasDropshadow = true;
+        sut.DropshadowColor = new Color(10, 20, 30, 40);
+        sut.DropshadowOffsetX = 5;
+        sut.DropshadowOffsetY = 7;
+        sut.DropshadowBlurX = 2;
+        sut.DropshadowBlurY = 4;
+
+        Circle fill = (Circle)sut.RenderableComponent;
+        Circle stroke = (Circle)fill.Children[0];
+
+        fill.HasDropshadow.ShouldBeTrue();
+        fill.DropshadowColor.ShouldBe(new Color(10, 20, 30, 40));
+        fill.DropshadowOffsetX.ShouldBe(5);
+        fill.DropshadowOffsetY.ShouldBe(7);
+        fill.DropshadowBlurX.ShouldBe(2);
+        fill.DropshadowBlurY.ShouldBe(4);
+
+        // Stroke must stay shadow-free — see XML remarks on IDropshadowRenderable.
+        stroke.HasDropshadow.ShouldBeFalse();
+    }
+
     // Issue #2798: IsAntialiased pushes through to both slots so a single setter flips AA on
     // fill and stroke together. Default true matches Apos.Shapes' own default. The push
     // happens via PreRender (matching how StrokeWidth/StrokeDashLength flow); fire the hook


### PR DESCRIPTION
Closes #2797.

## What

Adds dropshadow pass-through on the XNA-like `CircleRuntime` for parity with the Skia `CircleRuntime` (which already inherits the dropshadow surface from `SkiaShapeRuntime`). Follows the same opt-in / graceful-degradation pattern as `IGradientedRenderable` (#2791) and `IAntialiasedRenderable` (#2798).

## How

- **New `IDropshadowRenderable` interface** (`MonoGameGum/GueDeriving/IDropshadowRenderable.cs`, `#if XNALIKE`). Holds the dropshadow property bag (`HasDropshadow`, `DropshadowColor` + per-channel `DropshadowRed/Green/Blue/Alpha`, `DropshadowOffsetX/Y`, `DropshadowBlurX/Y`). Names mirror `SkiaShapeRuntime`.
- **Apos.Shapes `Circle`** declares the interface. The property bag is inherited from `RenderableShapeBase`; only the interface declaration is added.
- **Apos.Shapes `RoundedRectangle`** declares the interface too, as forward-prep for the eventual `RectangleRuntime` follow-up. Same satisfied-by-base pattern.
- **`CircleRuntime`** gains the dropshadow API under `#if XNALIKE` with backing fields on the runtime. Pushed to the **fill slot only** (with fallback to stroke when fill is null) — Apos draws one shadow per renderable, so pushing to both slots would render the shadow twice and visibly double up. This deliberately differs from gradient (#2791) and AA (#2798), which DO push to both slots. The routing rule lives in a single `DropshadowTarget` helper so every setter shares it.
- Constructor pre-seeds `DropshadowAlpha = 255`, `DropshadowOffsetY = 3`, `DropshadowBlurY = 3` to mirror `SkiaShapeRuntime`'s defaults, so toggling `HasDropshadow = true` immediately produces a visible shadow without further setup.
- **`DefaultStrokedCircleRenderable`** unchanged. Without the optional MonoGameGumShapes package, neither slot implements `IDropshadowRenderable` — dropshadow setters round-trip on the runtime's backing fields but do not render. Same graceful-degradation contract as `FillColor`.

## Samples

- `Samples/MonoGameGumShapesGallery/Screens/CirclesScreen.cs` adds a "Dropshadow" row: baseline (no shadow) / soft / hard offset / colored.
- `Samples/SilkNetGum/SilkNetGum/Screens/CirclesScreen.cs` mirrors it. Skia exposes only per-channel ints on `SkiaShapeRuntime` (no `DropshadowColor` composite), so the Skia cells set the channels individually — same visual intent.

## Tests

- `MonoGameGum.Tests/Runtimes/CircleRuntimeTests.cs` — `Dropshadow_RoundTripsBackingFields_WhenNoDropshadowCapableSlot` (also asserts the pre-seeded defaults) and `DropshadowChannelSetters_ComposeDropshadowColor`.
- `Tests/MonoGameGum.Shapes.Tests/CircleRuntimeTests.cs` — `Dropshadow_PropertiesPushedToFillSlotOnly_NotStroke` guards the fill-only-not-stroke routing rule.

Full `MonoGameGum.Tests` (1500) and `MonoGameGum.Shapes.Tests` (35) suites green; `KniGum` builds clean as a spot-check on the other XNALIKE targets.

## Boyscout

Fixed a pre-existing CS1574 on `RoundedRectangle.CornerRadius`'s doc comment (`<see cref="RectangleRuntime"/>` isn't resolvable from MonoGameGumShapes — `RectangleRuntime` lives in MonoGameGum, which MonoGameGumShapes doesn't reference). Downgraded the cref to a plain `<c>` tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
