### PR TITLE
#2796: expose dashed-stroke props on MG CircleRuntime via IDashedStrokeRenderable

### DIFF
--- a/MonoGameGum.Tests/Runtimes/CircleRuntimeTests.cs
+++ b/MonoGameGum.Tests/Runtimes/CircleRuntimeTests.cs
@@ -147,6 +147,26 @@ public class CircleRuntimeTests : BaseTestClass
     // package, neither slot implements IAntialiasedRenderable. The setter must round-trip on
     // the runtime so user code is forward-compatible with a later install of the package, but
     // produce no visual effect today (LineCircle has no AA concept).
+    // Issue #2796: dashed-stroke graceful-degradation contract. With no MonoGameGumShapes
+    // package, the stroke slot is DefaultStrokedCircleRenderable (wraps LineCircle, no dash
+    // concept) and does not implement IDashedStrokeRenderable. The setters must round-trip
+    // on the runtime so user code is forward-compatible with a later install of the package,
+    // but produce no visual effect today.
+    [Fact]
+    public void DashedStroke_RoundTripsBackingFields_WhenNoDashCapableSlot()
+    {
+        CircleRuntime sut = new();
+
+        sut.StrokeDashLength.ShouldBe(0f, "default 0 means solid stroke");
+        sut.StrokeGapLength.ShouldBe(0f);
+
+        sut.StrokeDashLength = 6;
+        sut.StrokeGapLength = 4;
+
+        sut.StrokeDashLength.ShouldBe(6f);
+        sut.StrokeGapLength.ShouldBe(4f);
+    }
+
     [Fact]
     public void IsAntialiased_RoundTripsBackingField_WhenNoAntialiasedCapableSlot()
     {

--- a/MonoGameGum/GueDeriving/CircleRuntime.cs
+++ b/MonoGameGum/GueDeriving/CircleRuntime.cs
@@ -812,6 +812,58 @@ public class CircleRuntime : GraphicalUiElement
 
     #endregion
 
+    #region DashedStroke
+
+    // Issue #2796: dashed-stroke pass-through. Backing fields live on the runtime so values
+    // round-trip even when the stroke slot does not implement IDashedStrokeRenderable (the
+    // core DefaultStrokedCircleRenderable wraps LineCircle, which has no dash concept).
+    // Pushed to the stroke slot only — dashing is a stroke-mode operation (Apos.Shapes'
+    // Circle.RenderDashed path is guarded by !IsFilled), and the fill slot would ignore it.
+    // The push happens in PreRender alongside StrokeWidth so ScreenPixel scaling stays in
+    // sync with camera zoom — mirroring AposShapeRuntime.PreRender, which divides all three
+    // (strokeWidth, dashLen, gapLen) by the same zoom under ScreenPixel units.
+
+    float _strokeDashLength;
+    /// <summary>
+    /// Length of each dash segment in <see cref="StrokeWidthUnits"/>. A value of 0 (the
+    /// default) produces a solid stroke; both <see cref="StrokeDashLength"/> and
+    /// <see cref="StrokeGapLength"/> must be &gt; 0 for dashed rendering to engage.
+    /// </summary>
+    /// <remarks>
+    /// Visual dashing requires the optional MonoGameGumShapes (Apos.Shapes) package; without
+    /// it the stroke slot is <see cref="MonoGameGum.Renderables.DefaultStrokedCircleRenderable"/>
+    /// (wraps <c>LineCircle</c>, no dash concept) and this setter is a visual no-op. The
+    /// backing field still round-trips so user code is forward-compatible with adding the
+    /// package later. Pushed each frame in <see cref="PreRender"/> with the same ScreenPixel
+    /// scaling as <see cref="StrokeWidth"/>.
+    /// </remarks>
+    public float StrokeDashLength
+    {
+        get => _strokeDashLength;
+        set
+        {
+            _strokeDashLength = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    float _strokeGapLength;
+    /// <summary>
+    /// Length of each gap between dashes in <see cref="StrokeWidthUnits"/>. Ignored when
+    /// <see cref="StrokeDashLength"/> is 0.
+    /// </summary>
+    public float StrokeGapLength
+    {
+        get => _strokeGapLength;
+        set
+        {
+            _strokeGapLength = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    #endregion
+
     /// <summary>
     /// Pushes runtime-held stroke values to the stroke renderable each frame, resolving
     /// <see cref="StrokeWidthUnits"/> against the current camera zoom. Reached through the
@@ -822,15 +874,31 @@ public class CircleRuntime : GraphicalUiElement
     public override void PreRender()
     {
         float strokeWidth = _strokeWidth;
+        float strokeDashLength = _strokeDashLength;
+        float strokeGapLength = _strokeGapLength;
         if (_strokeWidthUnits == DimensionUnitType.ScreenPixel)
         {
             var camera = this.EffectiveManagers?.Renderer?.Camera;
             if (camera != null)
             {
+                // Mirrors AposShapeRuntime.PreRender — dash and gap scale alongside stroke
+                // width so a "1 px dotted" pattern stays 1 px on screen regardless of zoom.
                 strokeWidth /= camera.Zoom;
+                strokeDashLength /= camera.Zoom;
+                strokeGapLength /= camera.Zoom;
             }
         }
         _stroke.StrokeWidth = strokeWidth;
+
+        // Issue #2796: push dash/gap to the stroke slot when it supports dashing. Skipped
+        // for slots that don't implement the interface (core DefaultStrokedCircleRenderable
+        // wraps LineCircle, no dash concept). Stroke-only — dashing is guarded by !IsFilled
+        // in the Apos renderable, so pushing to fill would be ignored anyway.
+        if (_stroke is IDashedStrokeRenderable strokeDashed)
+        {
+            strokeDashed.StrokeDashLength = strokeDashLength;
+            strokeDashed.StrokeGapLength = strokeGapLength;
+        }
 
         // Issue #2798: push AA to both slots so a single setter flips fill + stroke together.
         // Mirrors AposShapeRuntime.PreRender. Skipped for slots that don't implement the

--- a/MonoGameGum/GueDeriving/IDashedStrokeRenderable.cs
+++ b/MonoGameGum/GueDeriving/IDashedStrokeRenderable.cs
@@ -1,0 +1,38 @@
+#if XNALIKE
+namespace Gum.GueDeriving;
+
+/// <summary>
+/// Opt-in dashed-stroke surface for stroke renderables in the two-slot shape runtime model
+/// (issue #2796). Implemented by the optional MonoGameGumShapes <c>Circle</c> /
+/// <c>RoundedRectangle</c> (the property bag is inherited from <c>RenderableShapeBase</c>)
+/// so <see cref="CircleRuntime"/> and friends can push dashed-stroke state through to a
+/// dash-capable slot. Core defaults like
+/// <see cref="MonoGameGum.Renderables.DefaultStrokedCircleRenderable"/> deliberately do NOT
+/// implement this interface — <c>LineCircle</c> has no dash concept. Setters round-trip on
+/// the runtime but render as a no-op without the optional package (graceful degradation,
+/// matching the <see cref="CircleRuntime.FillColor"/>, <see cref="IGradientedRenderable"/>,
+/// <see cref="IAntialiasedRenderable"/>, and <see cref="IDropshadowRenderable"/> patterns).
+/// </summary>
+/// <remarks>
+/// Property names mirror <c>SkiaShapeRuntime</c> so the runtime APIs match across backends.
+/// Dashed strokes are a stroke-only concept (Apos.Shapes' <c>Circle.RenderDashed</c> path is
+/// guarded by <c>!IsFilled</c>), so the runtime pushes these values to the stroke slot only;
+/// pushing to a fill slot would be ignored anyway. The runtime pushes each frame in
+/// <c>PreRender</c> so ScreenPixel-scaled dash/gap stays in sync with the camera zoom — same
+/// pattern as <see cref="CircleRuntime.StrokeWidth"/>.
+/// </remarks>
+public interface IDashedStrokeRenderable
+{
+    /// <summary>
+    /// Length of each dash segment in pixels. A value of 0 (the default) produces a solid
+    /// stroke; both dash and gap must be &gt; 0 for dashed rendering to engage.
+    /// </summary>
+    float StrokeDashLength { get; set; }
+
+    /// <summary>
+    /// Length of each gap between dashes in pixels. Ignored when
+    /// <see cref="StrokeDashLength"/> is 0.
+    /// </summary>
+    float StrokeGapLength { get; set; }
+}
+#endif

--- a/Runtimes/GumShapes/Renderables/Circle.cs
+++ b/Runtimes/GumShapes/Renderables/Circle.cs
@@ -15,12 +15,14 @@ public class Circle : RenderableShapeBase,
     Gum.GueDeriving.IStrokedCircleRenderable,
     Gum.GueDeriving.IGradientedRenderable,
     Gum.GueDeriving.IAntialiasedRenderable,
-    Gum.GueDeriving.IDropshadowRenderable
+    Gum.GueDeriving.IDropshadowRenderable,
+    Gum.GueDeriving.IDashedStrokeRenderable
 {
-    // IGradientedRenderable, IAntialiasedRenderable, and IDropshadowRenderable are all
-    // satisfied entirely by the property bag inherited from RenderableShapeBase — every
-    // member name and type lines up. The interface declarations exist only so CircleRuntime
-    // can pattern-match on each slot without coupling to the concrete Apos.Shapes Circle type.
+    // IGradientedRenderable, IAntialiasedRenderable, IDropshadowRenderable, and
+    // IDashedStrokeRenderable are all satisfied entirely by the property bag inherited from
+    // RenderableShapeBase — every member name and type lines up. The interface declarations
+    // exist only so CircleRuntime can pattern-match on each slot without coupling to the
+    // concrete Apos.Shapes Circle type.
     /// <inheritdoc/>
     /// <remarks>
     /// Apos.Shapes draws the circle as <c>Width / 2</c> centered on the renderable's

--- a/Runtimes/GumShapes/Renderables/RoundedRectangle.cs
+++ b/Runtimes/GumShapes/Renderables/RoundedRectangle.cs
@@ -13,12 +13,14 @@ namespace MonoGameAndGum.Renderables;
 public class RoundedRectangle : RenderableShapeBase,
     Gum.GueDeriving.IFilledRectangleRenderable,
     Gum.GueDeriving.IStrokedRectangleRenderable,
-    Gum.GueDeriving.IDropshadowRenderable
+    Gum.GueDeriving.IDropshadowRenderable,
+    Gum.GueDeriving.IDashedStrokeRenderable
 {
-    // IDropshadowRenderable is satisfied entirely by the property bag inherited from
-    // RenderableShapeBase — declared here so the future RectangleRuntime (#2797 follow-up)
-    // can pattern-match the dropshadow surface the same way CircleRuntime does today,
-    // without coupling to the concrete Apos.Shapes RoundedRectangle type.
+    // IDropshadowRenderable and IDashedStrokeRenderable are satisfied entirely by the
+    // property bag inherited from RenderableShapeBase — declared here so the future
+    // RectangleRuntime (#2797 / #2796 follow-up) can pattern-match those surfaces the same
+    // way CircleRuntime does today, without coupling to the concrete Apos.Shapes
+    // RoundedRectangle type.
 
     /// <summary>
     /// Rounded-corner radius in pixels. Apos.Shapes' <c>RoundedRectangle</c> honors this on

--- a/Samples/MonoGameGumShapesGallery/Screens/CirclesScreen.cs
+++ b/Samples/MonoGameGumShapesGallery/Screens/CirclesScreen.cs
@@ -42,6 +42,7 @@ internal class CirclesScreen : FrameworkElement
         root.AddChild(BuildSection("Gradients (linear / radial / diagonal / centered)", BuildGradientRow()));
         root.AddChild(BuildSection("Antialiasing (default ON, then OFF) — 1 px stroke makes the bloom obvious (#2798)", BuildAntialiasingRow()));
         root.AddChild(BuildSection("Dropshadow (off / soft / hard offset / colored) — fill-only push avoids doubling (#2797)", BuildDropshadowRow()));
+        root.AddChild(BuildSection("Dashed strokes (solid / 6/4 / 2/2 dotted / long-dash) — stroke-only push (#2796)", BuildDashedStrokeRow()));
     }
 
     static ContainerRuntime BuildSection(string label, GraphicalUiElement body)
@@ -270,6 +271,54 @@ internal class CirclesScreen : FrameworkElement
         colored.DropshadowBlurX = 6;
         colored.DropshadowBlurY = 6;
         row.AddChild(colored);
+
+        return row;
+    }
+
+    // Issue #2796 visual acceptance: four cells stepping through dash/gap patterns. First
+    // cell is the solid-stroke baseline (dash=0). Remaining three exercise short dashes,
+    // dotted, and a long-dash motif. Dashing applies to stroke only — the runtime skips
+    // pushing dash/gap to the fill slot since Apos' Circle.RenderDashed is guarded by
+    // !IsFilled. Mirrored on the Skia side via SkiaShapeRuntime.StrokeDashLength.
+    static ContainerRuntime BuildDashedStrokeRow()
+    {
+        ContainerRuntime row = BuildHorizontalRow();
+
+        // Baseline: solid stroke (dash=0).
+        CircleRuntime solid = new();
+        solid.Radius = 28;
+        solid.StrokeColor = Color.White;
+        solid.StrokeWidth = 2;
+        row.AddChild(solid);
+
+        // Short 6/4 dash.
+        CircleRuntime short64 = new();
+        short64.Radius = 28;
+        short64.StrokeColor = Color.White;
+        short64.StrokeWidth = 2;
+        short64.StrokeDashLength = 6;
+        short64.StrokeGapLength = 4;
+        row.AddChild(short64);
+
+        // Tight 2/2 dotted. IsAntialiased=false avoids the AA bloom widening a 1 px stroke
+        // and matches the Win95-style dotted focus rect (see Themes/Retro95).
+        CircleRuntime dotted = new();
+        dotted.Radius = 28;
+        dotted.StrokeColor = Color.White;
+        dotted.StrokeWidth = 1;
+        dotted.StrokeDashLength = 2;
+        dotted.StrokeGapLength = 2;
+        dotted.IsAntialiased = false;
+        row.AddChild(dotted);
+
+        // Long-dash motif: 12/6 with a thicker stroke.
+        CircleRuntime longDash = new();
+        longDash.Radius = 28;
+        longDash.StrokeColor = Color.LightGreen;
+        longDash.StrokeWidth = 3;
+        longDash.StrokeDashLength = 12;
+        longDash.StrokeGapLength = 6;
+        row.AddChild(longDash);
 
         return row;
     }

--- a/Samples/SilkNetGum/SilkNetGum/Screens/CirclesScreen.cs
+++ b/Samples/SilkNetGum/SilkNetGum/Screens/CirclesScreen.cs
@@ -39,6 +39,7 @@ internal class CirclesScreen : GraphicalUiElement
         root.Children.Add(BuildSection("Gradients (linear / radial / diagonal / centered)", BuildGradientRow()));
         root.Children.Add(BuildSection("Antialiasing (default ON, then OFF) — 1 px stroke makes the bloom obvious (#2798)", BuildAntialiasingRow()));
         root.Children.Add(BuildSection("Dropshadow (off / soft / hard offset / colored) — Skia draws the shadow on the single contained renderable (#2797)", BuildDropshadowRow()));
+        root.Children.Add(BuildSection("Dashed strokes (solid / 6/4 / 2/2 dotted / long-dash) — Skia routes through SkiaShapeRuntime.StrokeDashLength (#2796)", BuildDashedStrokeRow()));
         root.Children.Add(BuildSection("Known limitation: FillColor + StrokeColor on the same instance — only the most-recently-set one renders today (see #2790).", BuildBothColorsRow()));
     }
 
@@ -294,6 +295,51 @@ internal class CirclesScreen : GraphicalUiElement
         colored.DropshadowBlurX = 6;
         colored.DropshadowBlurY = 6;
         row.Children.Add(colored);
+
+        return row;
+    }
+
+    // Issue #2796 mirror of the MG dashed-stroke row. Skia inherits StrokeDashLength /
+    // StrokeGapLength from SkiaShapeRuntime, so no per-runtime plumbing was added on this
+    // side — the dashing flows through the single contained renderable.
+    static ContainerRuntime BuildDashedStrokeRow()
+    {
+        ContainerRuntime row = BuildHorizontalRow();
+
+        // Baseline: solid stroke (dash=0).
+        CircleRuntime solid = new();
+        solid.Radius = 28;
+        solid.StrokeColor = SKColors.White;
+        solid.StrokeWidth = 2;
+        row.Children.Add(solid);
+
+        // Short 6/4 dash.
+        CircleRuntime short64 = new();
+        short64.Radius = 28;
+        short64.StrokeColor = SKColors.White;
+        short64.StrokeWidth = 2;
+        short64.StrokeDashLength = 6;
+        short64.StrokeGapLength = 4;
+        row.Children.Add(short64);
+
+        // Tight 2/2 dotted. IsAntialiased=false keeps a 1 px dot from blooming.
+        CircleRuntime dotted = new();
+        dotted.Radius = 28;
+        dotted.StrokeColor = SKColors.White;
+        dotted.StrokeWidth = 1;
+        dotted.StrokeDashLength = 2;
+        dotted.StrokeGapLength = 2;
+        dotted.IsAntialiased = false;
+        row.Children.Add(dotted);
+
+        // Long-dash motif: 12/6 with a thicker stroke.
+        CircleRuntime longDash = new();
+        longDash.Radius = 28;
+        longDash.StrokeColor = SKColors.LightGreen;
+        longDash.StrokeWidth = 3;
+        longDash.StrokeDashLength = 12;
+        longDash.StrokeGapLength = 6;
+        row.Children.Add(longDash);
 
         return row;
     }

--- a/Tests/MonoGameGum.Shapes.Tests/CircleRuntimeTests.cs
+++ b/Tests/MonoGameGum.Shapes.Tests/CircleRuntimeTests.cs
@@ -131,6 +131,34 @@ public class CircleRuntimeTests
         stroke.HasDropshadow.ShouldBeFalse();
     }
 
+    // Issue #2796: dashed-stroke props on CircleRuntime push to the stroke slot only (not
+    // fill). Dashing is a stroke-mode operation — the Apos Circle's RenderDashed path is
+    // guarded by !IsFilled — so pushing to fill would be ignored. Routed through PreRender
+    // so ScreenPixel-scaled dash/gap stays in sync with camera zoom alongside StrokeWidth.
+    [Fact]
+    public void DashedStroke_PushedViaPreRender_ToStrokeSlotOnly()
+    {
+        CircleRuntime sut = new();
+
+        sut.StrokeColor = Color.White;
+        sut.StrokeWidth = 1;
+        sut.StrokeWidthUnits = DimensionUnitType.Absolute;
+        sut.StrokeDashLength = 6;
+        sut.StrokeGapLength = 4;
+
+        Circle fill = (Circle)sut.RenderableComponent;
+        Circle stroke = (Circle)fill.Children[0];
+        IRenderable asStrokeRenderable = stroke;
+        asStrokeRenderable.PreRender();
+
+        stroke.StrokeDashLength.ShouldBe(6f);
+        stroke.StrokeGapLength.ShouldBe(4f);
+        // Fill is the wrong place for dashing (Apos guards RenderDashed on !IsFilled) — the
+        // runtime intentionally skips pushing dash/gap to the fill slot.
+        fill.StrokeDashLength.ShouldBe(0f);
+        fill.StrokeGapLength.ShouldBe(0f);
+    }
+
     // Issue #2798: IsAntialiased pushes through to both slots so a single setter flips AA on
     // fill and stroke together. Default true matches Apos.Shapes' own default. The push
     // happens via PreRender (matching how StrokeWidth/StrokeDashLength flow); fire the hook


### PR DESCRIPTION
Adds dashed-stroke pass-through on the XNA-like CircleRuntime for parity with the Skia CircleRuntime (which already inherits `StrokeDashLength` / `StrokeGapLength` from `SkiaShapeRuntime`). Follows the same opt-in / graceful-degradation pattern as `IGradientedRenderable` (#2791), `IAntialiasedRenderable` (#2798), and `IDropshadowRenderable` (#2797).

## Changes

- **New `IDashedStrokeRenderable` interface** under `MonoGameGum/GueDeriving/` (`#if XNALIKE`): `StrokeDashLength`, `StrokeGapLength`. Names mirror `SkiaShapeRuntime` so the runtime APIs match across backends.
- **Apos.Shapes `Circle`** declares the interface — the property bag inherited from `RenderableShapeBase` satisfies it.
- **Apos.Shapes `RoundedRectangle`** declares it too as forward-prep for the eventual `RectangleRuntime` follow-up (same pattern as the dropshadow PR).
- **`CircleRuntime`** gains the dashed-stroke API under `#if XNALIKE`. Pushed to the **stroke slot only** — Apos guards `Circle.RenderDashed` by `!IsFilled`, so pushing to fill would be ignored. Pushed in `PreRender` alongside `StrokeWidth` so ScreenPixel scaling stays in sync with camera zoom (matches `AposShapeRuntime.PreRender`, which divides all three — stroke width, dash, gap — by the same zoom).

## Routing rule (vs the four prior interfaces)

| Interface | Push target |
|---|---|
| `IGradientedRenderable` (#2791) | Both fill and stroke |
| `IAntialiasedRenderable` (#2798) | Both fill and stroke |
| `IDropshadowRenderable` (#2797) | Fill only (fallback stroke) — Apos draws one shadow per renderable |
| `IDashedStrokeRenderable` (#2796) | **Stroke only** — dashing requires `!IsFilled` |

## Galleries

- `Samples/MonoGameGumShapesGallery/Screens/CirclesScreen.cs` adds a "Dashed strokes" row (solid baseline / 6/4 dash / 2/2 dotted with AA off / 12/6 long-dash).
- `Samples/SilkNetGum/SilkNetGum/Screens/CirclesScreen.cs` mirrors it. Skia inherits `StrokeDashLength` from `SkiaShapeRuntime`, so no runtime plumbing was added on that side.

## Tests

- `MonoGameGum.Tests/Runtimes/CircleRuntimeTests.cs` — dashed round-trip with no Apos package (graceful-degradation contract).
- `Tests/MonoGameGum.Shapes.Tests/CircleRuntimeTests.cs` — guards the stroke-only-not-fill routing rule via `PreRender`.

Full `MonoGameGum.Tests` (1501) and `MonoGameGum.Shapes.Tests` (36) suites green.

Closes #2796. Related: #2791, #2797, #2798.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
