### PR TITLE
#2810: coerce enum values on import-loaded standards & elements

### DIFF
--- a/Gum/Plugins/ImportPlugin/Services/GumxSourceService.cs
+++ b/Gum/Plugins/ImportPlugin/Services/GumxSourceService.cs
@@ -1,5 +1,6 @@
 using Gum.DataTypes;
 using Gum.DataTypes.Behaviors;
+using Gum.DataTypes.Variables;
 using System;
 using System.IO;
 using System.Linq;
@@ -21,14 +22,42 @@ public class GumxSourceService
     /// </summary>
     public async Task<GumProjectSave?> LoadProjectAsync(string pathOrUrl, IProgress<(int loaded, int total)>? progress = null)
     {
+        GumProjectSave? gps;
         if (IsUrl(pathOrUrl))
         {
             pathOrUrl = NormalizeGitHubUrl(pathOrUrl);
-            return await LoadProjectFromUrlAsync(pathOrUrl, progress);
+            gps = await LoadProjectFromUrlAsync(pathOrUrl, progress);
         }
         else
         {
-            return GumProjectSave.Load(pathOrUrl, out _);
+            gps = GumProjectSave.Load(pathOrUrl, out _);
+        }
+
+        if (gps != null)
+        {
+            FixEnumerationsOnAllElements(gps);
+        }
+
+        return gps;
+    }
+
+    /// <summary>
+    /// Coerces int-on-disk enum values to their CLR enum types on every loaded element's
+    /// states. The main tool load path does this via <c>GumProjectSave.Initialize()</c>; the
+    /// import pipeline deserializes elements directly and must apply the same fix-up so that
+    /// downstream XML-string comparisons (e.g. <c>StandardComparer</c>) don't see a typed-enum
+    /// destination drift from an int source for semantically identical values. See issue #2810.
+    /// </summary>
+    private static void FixEnumerationsOnAllElements(GumProjectSave gps)
+    {
+        foreach (var element in gps.StandardElements.Cast<ElementSave>()
+            .Concat(gps.Components)
+            .Concat(gps.Screens))
+        {
+            foreach (var state in element.AllStates)
+            {
+                state.FixEnumerations();
+            }
         }
     }
 

--- a/Tool/Tests/GumToolUnitTests/Plugins/ImportFromGumxPlugin/GumxSourceServiceEnumCoercionTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/ImportFromGumxPlugin/GumxSourceServiceEnumCoercionTests.cs
@@ -1,0 +1,137 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Gum.DataTypes;
+using Gum.DataTypes.Variables;
+using Gum.Plugins.ImportPlugin.Services;
+using Gum.RenderingLibrary;
+using Shouldly;
+
+namespace GumToolUnitTests.Plugins.ImportFromGumxPlugin;
+
+/// <summary>
+/// Reproduces issue #2810: GumxSourceService didn't coerce int-on-disk enum values
+/// into their CLR enum types after deserialization. Without this fix-up, downstream
+/// XML-string comparisons (see <c>StandardComparer</c>) produce false-positive
+/// "Changed" diffs against destination standards that did go through the tool's
+/// FixEnumerations pass.
+/// </summary>
+public class GumxSourceServiceEnumCoercionTests : IDisposable
+{
+    private readonly string _sourceDir;
+    private readonly GumxSourceService _sut = new();
+
+    public GumxSourceServiceEnumCoercionTests()
+    {
+        _sourceDir = Path.Combine(Path.GetTempPath(), $"GumxSourceEnumTests_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_sourceDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_sourceDir)) Directory.Delete(_sourceDir, recursive: true);
+    }
+
+    [Fact]
+    public async Task LoadProjectAsync_StandardWithIntEnumValueOnDisk_CoercesValueToEnumType()
+    {
+        const string standardName = "TestContainer";
+        WriteStandardWithIntBlend(standardName);
+        string gumxPath = WriteGumxReferencing(standardName);
+
+        GumProjectSave? loaded = await _sut.LoadProjectAsync(gumxPath);
+
+        loaded.ShouldNotBeNull();
+        StandardElementSave standard = loaded.StandardElements.Single(s => s.Name == standardName);
+        VariableSave blend = standard.DefaultState.Variables.Single(v => v.Name == "Blend");
+        blend.Value.ShouldBeOfType<Blend>();
+        blend.Value.ShouldBe(Blend.Normal);
+    }
+
+    [Fact]
+    public async Task LoadProjectAsync_ComponentWithIntEnumValueOnDisk_CoercesValueToEnumType()
+    {
+        const string componentName = "TestComponent";
+        WriteComponentWithIntBlend(componentName);
+        string gumxPath = WriteGumxReferencingComponent(componentName);
+
+        GumProjectSave? loaded = await _sut.LoadProjectAsync(gumxPath);
+
+        loaded.ShouldNotBeNull();
+        ComponentSave component = loaded.Components.Single(c => c.Name == componentName);
+        VariableSave blend = component.DefaultState.Variables.Single(v => v.Name == "Blend");
+        blend.Value.ShouldBeOfType<Blend>();
+        blend.Value.ShouldBe(Blend.Normal);
+    }
+
+    private void WriteStandardWithIntBlend(string standardName)
+    {
+        string standardsDir = Path.Combine(_sourceDir, "Standards");
+        Directory.CreateDirectory(standardsDir);
+        string gutxPath = Path.Combine(standardsDir, $"{standardName}.{GumProjectSave.StandardExtension}");
+        File.WriteAllText(gutxPath, $@"<?xml version=""1.0"" encoding=""utf-8""?>
+<StandardElementSave xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:xsd=""http://www.w3.org/2001/XMLSchema"">
+  <Name>{standardName}</Name>
+  <State>
+    <Name>Default</Name>
+    <Variable>
+      <Type>Blend</Type>
+      <Name>Blend</Name>
+      <Value xsi:type=""xsd:int"">0</Value>
+      <SetsValue>true</SetsValue>
+    </Variable>
+  </State>
+</StandardElementSave>");
+    }
+
+    private void WriteComponentWithIntBlend(string componentName)
+    {
+        string componentsDir = Path.Combine(_sourceDir, "Components");
+        Directory.CreateDirectory(componentsDir);
+        string gucxPath = Path.Combine(componentsDir, $"{componentName}.{GumProjectSave.ComponentExtension}");
+        File.WriteAllText(gucxPath, $@"<?xml version=""1.0"" encoding=""utf-8""?>
+<ComponentSave xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:xsd=""http://www.w3.org/2001/XMLSchema"">
+  <Name>{componentName}</Name>
+  <State>
+    <Name>Default</Name>
+    <Variable>
+      <Type>Blend</Type>
+      <Name>Blend</Name>
+      <Value xsi:type=""xsd:int"">0</Value>
+      <SetsValue>true</SetsValue>
+    </Variable>
+  </State>
+</ComponentSave>");
+    }
+
+    private string WriteGumxReferencing(string standardName)
+    {
+        string gumxPath = Path.Combine(_sourceDir, "Test.gumx");
+        File.WriteAllText(gumxPath, $@"<?xml version=""1.0"" encoding=""utf-8""?>
+<GumProjectSave xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:xsd=""http://www.w3.org/2001/XMLSchema"">
+  <Version>1</Version>
+  <StandardElementReference>
+    <Name>{standardName}</Name>
+    <ElementType>Standard</ElementType>
+    <LinkType>ReferenceOriginal</LinkType>
+  </StandardElementReference>
+</GumProjectSave>");
+        return gumxPath;
+    }
+
+    private string WriteGumxReferencingComponent(string componentName)
+    {
+        string gumxPath = Path.Combine(_sourceDir, "Test.gumx");
+        File.WriteAllText(gumxPath, $@"<?xml version=""1.0"" encoding=""utf-8""?>
+<GumProjectSave xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:xsd=""http://www.w3.org/2001/XMLSchema"">
+  <Version>1</Version>
+  <ComponentReference>
+    <Name>{componentName}</Name>
+    <ElementType>Component</ElementType>
+    <LinkType>ReferenceOriginal</LinkType>
+  </ComponentReference>
+</GumProjectSave>");
+        return gumxPath;
+    }
+}


### PR DESCRIPTION
## Summary
- GumxSourceService.LoadProjectAsync now runs FixEnumerations on each loaded element's states, matching what the main tool load path does via `GumProjectSave.Initialize()`.
- Eliminates the false-positive `Changed   WidthUnits: Absolute -> 0` (etc.) entries surfaced in the Import dialog by #2779's per-variable diff. The root cause was an asymmetric coercion: the destination project had typed enums; the import source still had boxed `int` Values, so `StandardComparer`'s XML-string compare saw drift even when the values were semantically identical.
- Applied to both the URL and local-path branches, and to Standards, Components, and Screens (per the issue's audit note).

## Test plan
- [x] New `GumxSourceServiceEnumCoercionTests` covers Standard + Component with int-on-disk enum values — fail before the fix, pass after
- [x] All 37 `ImportFromGumxPlugin` tests pass
- [x] `dotnet build GumFull.sln` clean

Closes #2810

🤖 Generated with [Claude Code](https://claude.com/claude-code)