### PR TITLE
Bundle Gum.Analyzers via pack-time include instead of ProjectReference

### DIFF
--- a/MonoGameGum/FnaGum/FnaGum.csproj
+++ b/MonoGameGum/FnaGum/FnaGum.csproj
@@ -126,10 +126,21 @@
 	<ItemGroup>
 		<ProjectReference Include="..\..\fna\FNA.Core.csproj" PrivateAssets="All" />
 		<ProjectReference Include="..\..\GumCommon\GumCommon.csproj" />
-		<ProjectReference Include="..\..\Tools\Gum.Analyzers\Gum.Analyzers.csproj"
-						  Condition="'$(IncludeAnalyzers)' != 'false'"
-						  OutputItemType="Analyzer"
-						  ReferenceOutputAssembly="false" />
+	</ItemGroup>
+
+	<!--
+		Bundle the Gum.Analyzers Roslyn analyzer DLL into this package so NuGet consumers
+		get GUM001 namespace-migration warnings + code fixes. This is NOT a ProjectReference
+		because we do not want source-linkers' .sln files to require Tools/Gum.Analyzers/
+		to build. The analyzer is built independently (e.g. via AllLibraries.sln /
+		GumFull.sln) and the Exists() guard makes this include a no-op if the DLL is not
+		present, so source-only builds keep working with zero impact.
+	-->
+	<ItemGroup Condition="'$(IncludeAnalyzers)' != 'false' AND Exists('..\..\Tools\Gum.Analyzers\bin\$(Configuration)\netstandard2.0\Gum.Analyzers.dll')">
+		<None Include="..\..\Tools\Gum.Analyzers\bin\$(Configuration)\netstandard2.0\Gum.Analyzers.dll"
+			  Pack="true"
+			  PackagePath="analyzers/dotnet/cs/"
+			  Visible="false" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/MonoGameGum/KniGum/KniGum.csproj
+++ b/MonoGameGum/KniGum/KniGum.csproj
@@ -158,10 +158,21 @@
 
 	<ItemGroup>
 		<ProjectReference Include="..\..\GumCommon\GumCommon.csproj" />
-		<ProjectReference Include="..\..\Tools\Gum.Analyzers\Gum.Analyzers.csproj"
-						  Condition="'$(IncludeAnalyzers)' != 'false'"
-						  OutputItemType="Analyzer"
-						  ReferenceOutputAssembly="false" />
+	</ItemGroup>
+
+	<!--
+		Bundle the Gum.Analyzers Roslyn analyzer DLL into this package so NuGet consumers
+		get GUM001 namespace-migration warnings + code fixes. This is NOT a ProjectReference
+		because we do not want source-linkers' .sln files to require Tools/Gum.Analyzers/
+		to build. The analyzer is built independently (e.g. via AllLibraries.sln /
+		GumFull.sln) and the Exists() guard makes this include a no-op if the DLL is not
+		present, so source-only builds keep working with zero impact.
+	-->
+	<ItemGroup Condition="'$(IncludeAnalyzers)' != 'false' AND Exists('..\..\Tools\Gum.Analyzers\bin\$(Configuration)\netstandard2.0\Gum.Analyzers.dll')">
+		<None Include="..\..\Tools\Gum.Analyzers\bin\$(Configuration)\netstandard2.0\Gum.Analyzers.dll"
+			  Pack="true"
+			  PackagePath="analyzers/dotnet/cs/"
+			  Visible="false" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/MonoGameGum/MonoGameGum.csproj
+++ b/MonoGameGum/MonoGameGum.csproj
@@ -191,7 +191,21 @@
 
 	<ItemGroup>
 		<ProjectReference Include="..\GumCommon\GumCommon.csproj" />
-		<ProjectReference Include="..\Tools\Gum.Analyzers\Gum.Analyzers.csproj" Condition="'$(IncludeAnalyzers)' != 'false'" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+	</ItemGroup>
+
+	<!--
+		Bundle the Gum.Analyzers Roslyn analyzer DLL into this package so NuGet consumers
+		get GUM001 namespace-migration warnings + code fixes. This is NOT a ProjectReference
+		because we do not want source-linkers' .sln files to require Tools/Gum.Analyzers/
+		to build. The analyzer is built independently (e.g. via AllLibraries.sln /
+		GumFull.sln) and the Exists() guard makes this include a no-op if the DLL is not
+		present, so source-only builds keep working with zero impact.
+	-->
+	<ItemGroup Condition="'$(IncludeAnalyzers)' != 'false' AND Exists('..\Tools\Gum.Analyzers\bin\$(Configuration)\netstandard2.0\Gum.Analyzers.dll')">
+		<None Include="..\Tools\Gum.Analyzers\bin\$(Configuration)\netstandard2.0\Gum.Analyzers.dll"
+			  Pack="true"
+			  PackagePath="analyzers/dotnet/cs/"
+			  Visible="false" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Runtimes/GumShapes/KniGumShapes.csproj
+++ b/Runtimes/GumShapes/KniGumShapes.csproj
@@ -54,10 +54,21 @@
 
 	<ItemGroup>
 	  <ProjectReference Include="..\..\MonoGameGum\KniGum\KniGum.csproj" />
-	  <ProjectReference Include="..\..\Tools\Gum.Analyzers\Gum.Analyzers.csproj"
-					    Condition="'$(IncludeAnalyzers)' != 'false'"
-					    OutputItemType="Analyzer"
-					    ReferenceOutputAssembly="false" />
+	</ItemGroup>
+
+	<!--
+		Bundle the Gum.Analyzers Roslyn analyzer DLL into this package so NuGet consumers
+		get GUM001 namespace-migration warnings + code fixes. This is NOT a ProjectReference
+		because we do not want source-linkers' .sln files to require Tools/Gum.Analyzers/
+		to build. The analyzer is built independently (e.g. via AllLibraries.sln /
+		GumFull.sln) and the Exists() guard makes this include a no-op if the DLL is not
+		present, so source-only builds keep working with zero impact.
+	-->
+	<ItemGroup Condition="'$(IncludeAnalyzers)' != 'false' AND Exists('..\..\Tools\Gum.Analyzers\bin\$(Configuration)\netstandard2.0\Gum.Analyzers.dll')">
+	  <None Include="..\..\Tools\Gum.Analyzers\bin\$(Configuration)\netstandard2.0\Gum.Analyzers.dll"
+		    Pack="true"
+		    PackagePath="analyzers/dotnet/cs/"
+		    Visible="false" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Runtimes/GumShapes/MonoGameGumShapes.csproj
+++ b/Runtimes/GumShapes/MonoGameGumShapes.csproj
@@ -44,10 +44,21 @@
 
 	<ItemGroup>
 		<ProjectReference Include="..\..\MonoGameGum\MonoGameGum.csproj" />
-		<ProjectReference Include="..\..\Tools\Gum.Analyzers\Gum.Analyzers.csproj"
-						  Condition="'$(IncludeAnalyzers)' != 'false'"
-						  OutputItemType="Analyzer"
-						  ReferenceOutputAssembly="false" />
+	</ItemGroup>
+
+	<!--
+		Bundle the Gum.Analyzers Roslyn analyzer DLL into this package so NuGet consumers
+		get GUM001 namespace-migration warnings + code fixes. This is NOT a ProjectReference
+		because we do not want source-linkers' .sln files to require Tools/Gum.Analyzers/
+		to build. The analyzer is built independently (e.g. via AllLibraries.sln /
+		GumFull.sln) and the Exists() guard makes this include a no-op if the DLL is not
+		present, so source-only builds keep working with zero impact.
+	-->
+	<ItemGroup Condition="'$(IncludeAnalyzers)' != 'false' AND Exists('..\..\Tools\Gum.Analyzers\bin\$(Configuration)\netstandard2.0\Gum.Analyzers.dll')">
+		<None Include="..\..\Tools\Gum.Analyzers\bin\$(Configuration)\netstandard2.0\Gum.Analyzers.dll"
+			  Pack="true"
+			  PackagePath="analyzers/dotnet/cs/"
+			  Visible="false" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Runtimes/RaylibGum/RaylibGum.csproj
+++ b/Runtimes/RaylibGum/RaylibGum.csproj
@@ -179,10 +179,21 @@
 
 	<ItemGroup>
 		<ProjectReference Include="..\..\GumCommon\GumCommon.csproj" />
-		<ProjectReference Include="..\..\Tools\Gum.Analyzers\Gum.Analyzers.csproj"
-						  Condition="'$(IncludeAnalyzers)' != 'false'"
-						  OutputItemType="Analyzer"
-						  ReferenceOutputAssembly="false" />
+	</ItemGroup>
+
+	<!--
+		Bundle the Gum.Analyzers Roslyn analyzer DLL into this package so NuGet consumers
+		get GUM001 namespace-migration warnings + code fixes. This is NOT a ProjectReference
+		because we do not want source-linkers' .sln files to require Tools/Gum.Analyzers/
+		to build. The analyzer is built independently (e.g. via AllLibraries.sln /
+		GumFull.sln) and the Exists() guard makes this include a no-op if the DLL is not
+		present, so source-only builds keep working with zero impact.
+	-->
+	<ItemGroup Condition="'$(IncludeAnalyzers)' != 'false' AND Exists('..\..\Tools\Gum.Analyzers\bin\$(Configuration)\netstandard2.0\Gum.Analyzers.dll')">
+		<None Include="..\..\Tools\Gum.Analyzers\bin\$(Configuration)\netstandard2.0\Gum.Analyzers.dll"
+			  Pack="true"
+			  PackagePath="analyzers/dotnet/cs/"
+			  Visible="false" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Runtimes/SkiaGum/SkiaGum.csproj
+++ b/Runtimes/SkiaGum/SkiaGum.csproj
@@ -65,10 +65,21 @@
 
 	<ItemGroup>
 		<ProjectReference Include="..\..\GumCommon\GumCommon.csproj" />
-		<ProjectReference Include="..\..\Tools\Gum.Analyzers\Gum.Analyzers.csproj"
-						  Condition="'$(IncludeAnalyzers)' != 'false'"
-						  OutputItemType="Analyzer"
-						  ReferenceOutputAssembly="false" />
+	</ItemGroup>
+
+	<!--
+		Bundle the Gum.Analyzers Roslyn analyzer DLL into this package so NuGet consumers
+		get GUM001 namespace-migration warnings + code fixes. This is NOT a ProjectReference
+		because we do not want source-linkers' .sln files to require Tools/Gum.Analyzers/
+		to build. The analyzer is built independently (e.g. via AllLibraries.sln /
+		GumFull.sln) and the Exists() guard makes this include a no-op if the DLL is not
+		present, so source-only builds keep working with zero impact.
+	-->
+	<ItemGroup Condition="'$(IncludeAnalyzers)' != 'false' AND Exists('..\..\Tools\Gum.Analyzers\bin\$(Configuration)\netstandard2.0\Gum.Analyzers.dll')">
+		<None Include="..\..\Tools\Gum.Analyzers\bin\$(Configuration)\netstandard2.0\Gum.Analyzers.dll"
+			  Pack="true"
+			  PackagePath="analyzers/dotnet/cs/"
+			  Visible="false" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
## Summary

- Removes the `Gum.Analyzers` `ProjectReference` from all seven runtime csprojs (`MonoGameGum`, `KniGum`, `FnaGum`, `SkiaGum`, `RaylibGum`, `MonoGameGumShapes`, `KniGumShapes`).
- Replaces it with a pack-time `<None Include=... Pack="true" PackagePath="analyzers/dotnet/cs/" />` that embeds the already-built analyzer DLL into each runtime's `.nupkg`.
- Gated by `'$(IncludeAnalyzers)' != 'false' AND Exists('...Gum.Analyzers.dll')` so source-only builds silently skip the include with zero impact.

## Why

The `ProjectReference` made `Tools/Gum.Analyzers/Gum.Analyzers.csproj` a hard build-time dependency for anyone whose `.sln` pulled a runtime csproj in by source — including users with their own `.sln`s and older Gum forks whose slns predate the analyzer project. Slns that did not include `Gum.Analyzers` failed to build because the analyzer DLL was never produced. This is a real distribution problem and breaks projects that worked before.

## Tradeoff

Source-linkers no longer receive the `GUM001` migration warning directly. The `[Obsolete]` `CS0618` warnings on the `SkiaGum.GueDeriving` / `MonoGameGum.GueDeriving` shims remain the migration nudge for that audience. NuGet consumers are unaffected — official pack flows still build the analyzer via `AllLibraries.sln` / `GumFull.sln` before packing, and the resulting nupkg includes `analyzers/dotnet/cs/Gum.Analyzers.dll`.

## Test plan

- [x] `dotnet build AllLibraries.sln -c Release -p:ExcludeIOS=true -p:ExcludeAndroid=true` — 0 errors
- [x] Verified `Gum.SkiaSharp.2026.4.5.1.nupkg` contains `analyzers/dotnet/cs/Gum.Analyzers.dll`
- [x] CI green
- [x] Verify a consumer NuGet install still surfaces `GUM001` on `using MonoGameGum.GueDeriving;`

🤖 Generated with [Claude Code](https://claude.com/claude-code)