### PR TITLE
Analyzer pack-time bundling + #2763 docs for FindFormsControl migration

### DIFF
--- a/MonoGameGum/FnaGum/FnaGum.csproj
+++ b/MonoGameGum/FnaGum/FnaGum.csproj
@@ -126,10 +126,21 @@
 	<ItemGroup>
 		<ProjectReference Include="..\..\fna\FNA.Core.csproj" PrivateAssets="All" />
 		<ProjectReference Include="..\..\GumCommon\GumCommon.csproj" />
-		<ProjectReference Include="..\..\Tools\Gum.Analyzers\Gum.Analyzers.csproj"
-						  Condition="'$(IncludeAnalyzers)' != 'false'"
-						  OutputItemType="Analyzer"
-						  ReferenceOutputAssembly="false" />
+	</ItemGroup>
+
+	<!--
+		Bundle the Gum.Analyzers Roslyn analyzer DLL into this package so NuGet consumers
+		get GUM001 namespace-migration warnings + code fixes. This is NOT a ProjectReference
+		because we do not want source-linkers' .sln files to require Tools/Gum.Analyzers/
+		to build. The analyzer is built independently (e.g. via AllLibraries.sln /
+		GumFull.sln) and the Exists() guard makes this include a no-op if the DLL is not
+		present, so source-only builds keep working with zero impact.
+	-->
+	<ItemGroup Condition="'$(IncludeAnalyzers)' != 'false' AND Exists('..\..\Tools\Gum.Analyzers\bin\$(Configuration)\netstandard2.0\Gum.Analyzers.dll')">
+		<None Include="..\..\Tools\Gum.Analyzers\bin\$(Configuration)\netstandard2.0\Gum.Analyzers.dll"
+			  Pack="true"
+			  PackagePath="analyzers/dotnet/cs/"
+			  Visible="false" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/MonoGameGum/KniGum/KniGum.csproj
+++ b/MonoGameGum/KniGum/KniGum.csproj
@@ -158,10 +158,21 @@
 
 	<ItemGroup>
 		<ProjectReference Include="..\..\GumCommon\GumCommon.csproj" />
-		<ProjectReference Include="..\..\Tools\Gum.Analyzers\Gum.Analyzers.csproj"
-						  Condition="'$(IncludeAnalyzers)' != 'false'"
-						  OutputItemType="Analyzer"
-						  ReferenceOutputAssembly="false" />
+	</ItemGroup>
+
+	<!--
+		Bundle the Gum.Analyzers Roslyn analyzer DLL into this package so NuGet consumers
+		get GUM001 namespace-migration warnings + code fixes. This is NOT a ProjectReference
+		because we do not want source-linkers' .sln files to require Tools/Gum.Analyzers/
+		to build. The analyzer is built independently (e.g. via AllLibraries.sln /
+		GumFull.sln) and the Exists() guard makes this include a no-op if the DLL is not
+		present, so source-only builds keep working with zero impact.
+	-->
+	<ItemGroup Condition="'$(IncludeAnalyzers)' != 'false' AND Exists('..\..\Tools\Gum.Analyzers\bin\$(Configuration)\netstandard2.0\Gum.Analyzers.dll')">
+		<None Include="..\..\Tools\Gum.Analyzers\bin\$(Configuration)\netstandard2.0\Gum.Analyzers.dll"
+			  Pack="true"
+			  PackagePath="analyzers/dotnet/cs/"
+			  Visible="false" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/MonoGameGum/MonoGameGum.csproj
+++ b/MonoGameGum/MonoGameGum.csproj
@@ -191,7 +191,21 @@
 
 	<ItemGroup>
 		<ProjectReference Include="..\GumCommon\GumCommon.csproj" />
-		<ProjectReference Include="..\Tools\Gum.Analyzers\Gum.Analyzers.csproj" Condition="'$(IncludeAnalyzers)' != 'false'" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+	</ItemGroup>
+
+	<!--
+		Bundle the Gum.Analyzers Roslyn analyzer DLL into this package so NuGet consumers
+		get GUM001 namespace-migration warnings + code fixes. This is NOT a ProjectReference
+		because we do not want source-linkers' .sln files to require Tools/Gum.Analyzers/
+		to build. The analyzer is built independently (e.g. via AllLibraries.sln /
+		GumFull.sln) and the Exists() guard makes this include a no-op if the DLL is not
+		present, so source-only builds keep working with zero impact.
+	-->
+	<ItemGroup Condition="'$(IncludeAnalyzers)' != 'false' AND Exists('..\Tools\Gum.Analyzers\bin\$(Configuration)\netstandard2.0\Gum.Analyzers.dll')">
+		<None Include="..\Tools\Gum.Analyzers\bin\$(Configuration)\netstandard2.0\Gum.Analyzers.dll"
+			  Pack="true"
+			  PackagePath="analyzers/dotnet/cs/"
+			  Visible="false" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Runtimes/GumShapes/KniGumShapes.csproj
+++ b/Runtimes/GumShapes/KniGumShapes.csproj
@@ -54,10 +54,21 @@
 
 	<ItemGroup>
 	  <ProjectReference Include="..\..\MonoGameGum\KniGum\KniGum.csproj" />
-	  <ProjectReference Include="..\..\Tools\Gum.Analyzers\Gum.Analyzers.csproj"
-					    Condition="'$(IncludeAnalyzers)' != 'false'"
-					    OutputItemType="Analyzer"
-					    ReferenceOutputAssembly="false" />
+	</ItemGroup>
+
+	<!--
+		Bundle the Gum.Analyzers Roslyn analyzer DLL into this package so NuGet consumers
+		get GUM001 namespace-migration warnings + code fixes. This is NOT a ProjectReference
+		because we do not want source-linkers' .sln files to require Tools/Gum.Analyzers/
+		to build. The analyzer is built independently (e.g. via AllLibraries.sln /
+		GumFull.sln) and the Exists() guard makes this include a no-op if the DLL is not
+		present, so source-only builds keep working with zero impact.
+	-->
+	<ItemGroup Condition="'$(IncludeAnalyzers)' != 'false' AND Exists('..\..\Tools\Gum.Analyzers\bin\$(Configuration)\netstandard2.0\Gum.Analyzers.dll')">
+	  <None Include="..\..\Tools\Gum.Analyzers\bin\$(Configuration)\netstandard2.0\Gum.Analyzers.dll"
+		    Pack="true"
+		    PackagePath="analyzers/dotnet/cs/"
+		    Visible="false" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Runtimes/GumShapes/MonoGameGumShapes.csproj
+++ b/Runtimes/GumShapes/MonoGameGumShapes.csproj
@@ -44,10 +44,21 @@
 
 	<ItemGroup>
 		<ProjectReference Include="..\..\MonoGameGum\MonoGameGum.csproj" />
-		<ProjectReference Include="..\..\Tools\Gum.Analyzers\Gum.Analyzers.csproj"
-						  Condition="'$(IncludeAnalyzers)' != 'false'"
-						  OutputItemType="Analyzer"
-						  ReferenceOutputAssembly="false" />
+	</ItemGroup>
+
+	<!--
+		Bundle the Gum.Analyzers Roslyn analyzer DLL into this package so NuGet consumers
+		get GUM001 namespace-migration warnings + code fixes. This is NOT a ProjectReference
+		because we do not want source-linkers' .sln files to require Tools/Gum.Analyzers/
+		to build. The analyzer is built independently (e.g. via AllLibraries.sln /
+		GumFull.sln) and the Exists() guard makes this include a no-op if the DLL is not
+		present, so source-only builds keep working with zero impact.
+	-->
+	<ItemGroup Condition="'$(IncludeAnalyzers)' != 'false' AND Exists('..\..\Tools\Gum.Analyzers\bin\$(Configuration)\netstandard2.0\Gum.Analyzers.dll')">
+		<None Include="..\..\Tools\Gum.Analyzers\bin\$(Configuration)\netstandard2.0\Gum.Analyzers.dll"
+			  Pack="true"
+			  PackagePath="analyzers/dotnet/cs/"
+			  Visible="false" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Runtimes/RaylibGum/RaylibGum.csproj
+++ b/Runtimes/RaylibGum/RaylibGum.csproj
@@ -179,10 +179,21 @@
 
 	<ItemGroup>
 		<ProjectReference Include="..\..\GumCommon\GumCommon.csproj" />
-		<ProjectReference Include="..\..\Tools\Gum.Analyzers\Gum.Analyzers.csproj"
-						  Condition="'$(IncludeAnalyzers)' != 'false'"
-						  OutputItemType="Analyzer"
-						  ReferenceOutputAssembly="false" />
+	</ItemGroup>
+
+	<!--
+		Bundle the Gum.Analyzers Roslyn analyzer DLL into this package so NuGet consumers
+		get GUM001 namespace-migration warnings + code fixes. This is NOT a ProjectReference
+		because we do not want source-linkers' .sln files to require Tools/Gum.Analyzers/
+		to build. The analyzer is built independently (e.g. via AllLibraries.sln /
+		GumFull.sln) and the Exists() guard makes this include a no-op if the DLL is not
+		present, so source-only builds keep working with zero impact.
+	-->
+	<ItemGroup Condition="'$(IncludeAnalyzers)' != 'false' AND Exists('..\..\Tools\Gum.Analyzers\bin\$(Configuration)\netstandard2.0\Gum.Analyzers.dll')">
+		<None Include="..\..\Tools\Gum.Analyzers\bin\$(Configuration)\netstandard2.0\Gum.Analyzers.dll"
+			  Pack="true"
+			  PackagePath="analyzers/dotnet/cs/"
+			  Visible="false" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Runtimes/SkiaGum/SkiaGum.csproj
+++ b/Runtimes/SkiaGum/SkiaGum.csproj
@@ -65,10 +65,21 @@
 
 	<ItemGroup>
 		<ProjectReference Include="..\..\GumCommon\GumCommon.csproj" />
-		<ProjectReference Include="..\..\Tools\Gum.Analyzers\Gum.Analyzers.csproj"
-						  Condition="'$(IncludeAnalyzers)' != 'false'"
-						  OutputItemType="Analyzer"
-						  ReferenceOutputAssembly="false" />
+	</ItemGroup>
+
+	<!--
+		Bundle the Gum.Analyzers Roslyn analyzer DLL into this package so NuGet consumers
+		get GUM001 namespace-migration warnings + code fixes. This is NOT a ProjectReference
+		because we do not want source-linkers' .sln files to require Tools/Gum.Analyzers/
+		to build. The analyzer is built independently (e.g. via AllLibraries.sln /
+		GumFull.sln) and the Exists() guard makes this include a no-op if the DLL is not
+		present, so source-only builds keep working with zero impact.
+	-->
+	<ItemGroup Condition="'$(IncludeAnalyzers)' != 'false' AND Exists('..\..\Tools\Gum.Analyzers\bin\$(Configuration)\netstandard2.0\Gum.Analyzers.dll')">
+		<None Include="..\..\Tools\Gum.Analyzers\bin\$(Configuration)\netstandard2.0\Gum.Analyzers.dll"
+			  Pack="true"
+			  PackagePath="analyzers/dotnet/cs/"
+			  Visible="false" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/docs/code/visual-tree/finding-elements.md
+++ b/docs/code/visual-tree/finding-elements.md
@@ -76,6 +76,25 @@ Window? containingWindow = someInnerVisual.Ancestors().OfType<Window>().FirstOrD
 
 The full set on `GraphicalUiElement`: `Find<T>`, `Find<T>(name)`, `FindByName(name)`, `Descendants`, `DescendantsAndSelf`, `Ancestors`, `AncestorsAndSelf`. The Forms-layer methods are thin projections built on top of these.
 
+### Reaching From a Visual to a Forms Control
+
+`Find<T>` on `GraphicalUiElement` stays in the visual layer — it walks visual descendants and returns visuals. When you have a visual root (typically a screen or component) and need to reach a Forms control wrapping one of its visual descendants, use `FindFormsControl<T>` instead. It walks the visual tree, projects each node to its underlying Forms control (skipping pure visuals with no Forms wrapper), and returns the first match:
+
+```csharp
+// Initialize
+TextBox nameBox = screenRoot.FindFormsControl<TextBox>("NameTextBox")!;
+Button firstButton = screenRoot.FindFormsControl<Button>()!;
+FrameworkElement anyControl = screenRoot.FindFormsControlByName("OkButton")!;
+```
+
+`FindFormsControl<T>()` returns the first descendant whose Forms control is assignable to `T`. `FindFormsControl<T>(name)` adds a name filter on the underlying visual. `FindFormsControlByName(name)` matches on name only, without a type filter. All three return `null` when no match is found.
+
+This is the cross-layer counterpart to `FindVisual<T>` on `FrameworkElement` — one goes visual → Forms, the other goes Forms → visual.
+
+{% hint style="warning" %}
+`FindFormsControl<T>`, `FindFormsControl<T>(name)`, and `FindFormsControlByName(name)` are available starting in the 2026 May release.
+{% endhint %}
+
 ## Ordering
 
 `Descendants()` and the `Find*` methods enumerate **shallowest-first**, so the closest match wins. A `ListBox` has a `FocusedIndicator` near its root and another inside each `ListBoxItem`; shallowest-first returns the outer one, which is what you want.

--- a/docs/gum-tool/upgrading/migrating-to-2026-may.md
+++ b/docs/gum-tool/upgrading/migrating-to-2026-may.md
@@ -103,19 +103,46 @@ The replaced methods:
 
 The new generic methods (`Find<T>`, `OfType<T>`) match subclasses (`is T` semantics). The old methods only matched the exact type. If your code relied on the exact-type behavior, add an explicit `GetType() == typeof(T)` filter to the LINQ pipeline.
 
-❌Old:
+❌ Old:
 
 ```csharp
 var textInstance = (TextRuntime)textBox.Visual.GetChildByNameRecursively("TextInstance")!;
 ```
 
-✅New:
+✅ New:
 
 ```csharp
 TextRuntime textInstance = textBox.Visual.Find<TextRuntime>("TextInstance")!;
 ```
 
 For the full set of new methods and how they compose with LINQ, see [Finding Elements](../../code/visual-tree/finding-elements.md).
+
+### GraphicalUiElement → Forms control lookup methods replaced
+
+Two extension methods on `GraphicalUiElement` for reaching from a visual down to a Forms control are now `[Obsolete]` in favor of a single unified replacement. Existing calls keep working but now produce `CS0618` compiler warnings.
+
+The replaced methods:
+
+* `GetFrameworkElementByName<T>(name)` → `FindFormsControl<T>(name)`
+* `TryGetFrameworkElementByName<T>(name)` → `FindFormsControl<T>(name)`
+
+Both old methods migrate to the same replacement because `FindFormsControl<T>` returns `T?` — it is nullable by design and returns `null` when no match is found, so the `Try` prefix is unnecessary. The old `Get...` overload's "throw on miss" behavior was already gated behind `FULL_DIAGNOSTICS` and silently returned `null` in release builds, so the new method matches the actual runtime behavior of both old overloads.
+
+❌ Old:
+
+```csharp
+TextBox nameBox = screenRoot.GetFrameworkElementByName<TextBox>("NameTextBox");
+Button? cancel = screenRoot.TryGetFrameworkElementByName<Button>("CancelButton");
+```
+
+✅ New:
+
+```csharp
+TextBox nameBox = screenRoot.FindFormsControl<TextBox>("NameTextBox")!;
+Button? cancel = screenRoot.FindFormsControl<Button>("CancelButton");
+```
+
+For the full set of visual-to-Forms lookup methods, see [Finding Elements](../../code/visual-tree/finding-elements.md).
 
 ### Default visual changes from runtime unification
 


### PR DESCRIPTION
## Summary

Two unrelated changes bundled into one PR (quick-and-dirty per user request):

1. **Analyzer packaging** (`da5d6486d`): bundle `Gum.Analyzers` into the consumer NuGet via pack-time include instead of a `ProjectReference`, so consumers don't pull the analyzer as a transitive project dep.
2. **Docs for #2763** (`fce0a9496`): add a 2026 May migration entry for the now-obsolete `GetFrameworkElementByName` / `TryGetFrameworkElementByName` extensions, pointing at the replacement `FindFormsControl<T>(name)`. Also documents the cross-layer visual-to-Forms lookup in `finding-elements.md` behind a release-pending hint that should be removed when May ships. Normalizes pre-existing emoji-spacing inconsistency in the May doc.

Closes #2763

## Test plan

- [ ] Verify the packaged NuGet ships the analyzer DLL and a consumer project sees the analyzer warnings without pulling `Gum.Analyzers` as a project dependency.
- [ ] Spot-check the rendered migration doc on the docs site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)