### PR TITLE
#2818: RectangleRuntime parity with CircleRuntime + per-corner radii + samples

### DIFF
--- a/MonoGameGum/GueDeriving/IFilledRectangleRenderable.cs
+++ b/MonoGameGum/GueDeriving/IFilledRectangleRenderable.cs
@@ -25,5 +25,20 @@ public interface IFilledRectangleRenderable : IRenderable
     /// MonoGameGumShapes for rounded corners. Kept in lockstep with the stroke slot.
     /// </summary>
     float CornerRadius { get; set; }
+
+    /// <summary>
+    /// Per-corner radius override. Null falls back to <see cref="CornerRadius"/>. Issue #2818:
+    /// honored by Apos.Shapes' RoundedRectangle; stored but not rendered on the core default.
+    /// </summary>
+    float? CustomRadiusTopLeft { get; set; }
+
+    /// <inheritdoc cref="CustomRadiusTopLeft"/>
+    float? CustomRadiusTopRight { get; set; }
+
+    /// <inheritdoc cref="CustomRadiusTopLeft"/>
+    float? CustomRadiusBottomLeft { get; set; }
+
+    /// <inheritdoc cref="CustomRadiusTopLeft"/>
+    float? CustomRadiusBottomRight { get; set; }
 }
 #endif

--- a/MonoGameGum/GueDeriving/IStrokedRectangleRenderable.cs
+++ b/MonoGameGum/GueDeriving/IStrokedRectangleRenderable.cs
@@ -30,5 +30,20 @@ public interface IStrokedRectangleRenderable : IRenderable
     /// graceful-degradation contract as <see cref="IFilledRectangleRenderable.CornerRadius"/>.
     /// </summary>
     float CornerRadius { get; set; }
+
+    /// <summary>
+    /// Per-corner radius override. Null falls back to <see cref="CornerRadius"/>. Issue #2818:
+    /// honored by Apos.Shapes' RoundedRectangle; stored but not rendered on the core default.
+    /// </summary>
+    float? CustomRadiusTopLeft { get; set; }
+
+    /// <inheritdoc cref="CustomRadiusTopLeft"/>
+    float? CustomRadiusTopRight { get; set; }
+
+    /// <inheritdoc cref="CustomRadiusTopLeft"/>
+    float? CustomRadiusBottomLeft { get; set; }
+
+    /// <inheritdoc cref="CustomRadiusTopLeft"/>
+    float? CustomRadiusBottomRight { get; set; }
 }
 #endif

--- a/MonoGameGum/GueDeriving/RectangleRuntime.cs
+++ b/MonoGameGum/GueDeriving/RectangleRuntime.cs
@@ -940,7 +940,24 @@ public class RectangleRuntime : GraphicalUiElement
                 strokeGapLength /= camera.Zoom;
             }
         }
-        _stroke.StrokeWidth = strokeWidth;
+        // Issue #2818 (mirror of CircleRuntime #2790) — Apos.Shapes' DrawRectangle adds aaSize
+        // pixels of AA halo OUTSIDE the nominal thickness, same shape as DrawCircle. Skia fits
+        // its AA WITHIN the thickness, so without this compensation the same user-set
+        // StrokeWidth reads ~1 px wider on Apos. Subtract the 1 px AA contribution before
+        // pushing. Floored at a tiny positive epsilon (not 0) — Apos's shader treats
+        // thickness = 0 as "don't draw", and the 1 px halo dominates the visible width so the
+        // sub-pixel under-draw of the nominal stroke is invisible. Gated by
+        // IAntialiasedRenderable so the core stroke default (LineRectangle wrapper, no AA
+        // concept) still receives the raw value. Visible-thickness parity for axis-aligned
+        // straights is the headline — rounded corner arcs still get the AA they need.
+        const float aposAaContribution = 1f;
+        const float aposMinThicknessEpsilon = 0.01f;
+        float renderableStrokeWidth = strokeWidth;
+        if (_isAntialiased && _stroke is IAntialiasedRenderable)
+        {
+            renderableStrokeWidth = Math.Max(aposMinThicknessEpsilon, strokeWidth - aposAaContribution);
+        }
+        _stroke.StrokeWidth = renderableStrokeWidth;
 
         // Issue #2818: push dash/gap to the stroke slot when it supports dashing.
         if (_stroke is IDashedStrokeRenderable strokeDashed)

--- a/MonoGameGum/GueDeriving/RectangleRuntime.cs
+++ b/MonoGameGum/GueDeriving/RectangleRuntime.cs
@@ -3,6 +3,9 @@ using RenderingLibrary;
 using RenderingLibrary.Graphics;
 using System;
 
+#if XNALIKE
+using Gum.Converters;
+#endif
 
 #if RAYLIB
 using Gum.Renderables;
@@ -18,7 +21,10 @@ using Gum.DataTypes;
 using SkiaGum.Renderables;
 using SkiaSharp;
 using Color = SkiaSharp.SKColor;
-using ContainedLineRectangle = SkiaGum.Renderables.LineRectangle;
+// Issue #2818 — Skia uses RoundedRectangle as the contained type so CornerRadius / per-corner
+// radii reach the renderer. With CornerRadius left at 0 the visual matches a hard-cornered
+// LineRectangle.
+using ContainedLineRectangle = SkiaGum.Renderables.RoundedRectangle;
 #else
 using Color = Microsoft.Xna.Framework.Color;
 using ColorExtensions = ToolsUtilitiesStandard.Helpers.ColorExtensions;
@@ -336,6 +342,19 @@ public class RectangleRuntime : GraphicalUiElement
         }
     }
 
+    bool _isAntialiased = true;
+
+    /// <inheritdoc cref="CircleRuntime.IsAntialiased"/>
+    public bool IsAntialiased
+    {
+        get => _isAntialiased;
+        set
+        {
+            _isAntialiased = value;
+            NotifyPropertyChanged();
+        }
+    }
+
     float _cornerRadius;
 
     /// <summary>
@@ -355,19 +374,584 @@ public class RectangleRuntime : GraphicalUiElement
         }
     }
 
+    DimensionUnitType _cornerRadiusUnits;
+
+    /// <summary>
+    /// Unit of measurement for <see cref="CornerRadius"/> and the per-corner overrides.
+    /// Reserved for future ScreenPixel parity with Skia — currently the value round-trips on
+    /// the runtime but Apos.Shapes' RoundedRectangle ignores it (the rendered radius is the
+    /// raw pixel value).
+    /// </summary>
+    public DimensionUnitType CornerRadiusUnits
+    {
+        get => _cornerRadiusUnits;
+        set
+        {
+            _cornerRadiusUnits = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    float? _customRadiusTopLeft;
+    /// <summary>
+    /// Top-left corner radius override. <c>null</c> falls back to <see cref="CornerRadius"/>.
+    /// Pushed to both slots. Honored by Apos.Shapes' RoundedRectangle; stored but not rendered
+    /// on the core <see cref="DefaultFilledRectangleRenderable"/> / <see cref="DefaultStrokedRectangleRenderable"/>.
+    /// </summary>
+    public float? CustomRadiusTopLeft
+    {
+        get => _customRadiusTopLeft;
+        set
+        {
+            _customRadiusTopLeft = value;
+            if (_fill != null) _fill.CustomRadiusTopLeft = value;
+            _stroke.CustomRadiusTopLeft = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    float? _customRadiusTopRight;
+    /// <inheritdoc cref="CustomRadiusTopLeft"/>
+    public float? CustomRadiusTopRight
+    {
+        get => _customRadiusTopRight;
+        set
+        {
+            _customRadiusTopRight = value;
+            if (_fill != null) _fill.CustomRadiusTopRight = value;
+            _stroke.CustomRadiusTopRight = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    float? _customRadiusBottomLeft;
+    /// <inheritdoc cref="CustomRadiusTopLeft"/>
+    public float? CustomRadiusBottomLeft
+    {
+        get => _customRadiusBottomLeft;
+        set
+        {
+            _customRadiusBottomLeft = value;
+            if (_fill != null) _fill.CustomRadiusBottomLeft = value;
+            _stroke.CustomRadiusBottomLeft = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    float? _customRadiusBottomRight;
+    /// <inheritdoc cref="CustomRadiusTopLeft"/>
+    public float? CustomRadiusBottomRight
+    {
+        get => _customRadiusBottomRight;
+        set
+        {
+            _customRadiusBottomRight = value;
+            if (_fill != null) _fill.CustomRadiusBottomRight = value;
+            _stroke.CustomRadiusBottomRight = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    #region Gradient
+
+    // Issue #2818 (mirror of CircleRuntime gradient region #2791): backing fields round-trip
+    // even when neither slot implements IGradientedRenderable (core defaults wrap SolidRectangle
+    // / LineRectangle, no gradient concept). Setters push to whichever slot(s) implement it.
+
+    bool _useGradient;
+    /// <inheritdoc cref="CircleRuntime.UseGradient"/>
+    public bool UseGradient
+    {
+        get => _useGradient;
+        set
+        {
+            _useGradient = value;
+            if (_fill is IGradientedRenderable fillGrad) fillGrad.UseGradient = value;
+            if (_stroke is IGradientedRenderable strokeGrad) strokeGrad.UseGradient = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    GradientType _gradientType;
+    public GradientType GradientType
+    {
+        get => _gradientType;
+        set
+        {
+            _gradientType = value;
+            if (_fill is IGradientedRenderable fillGrad) fillGrad.GradientType = value;
+            if (_stroke is IGradientedRenderable strokeGrad) strokeGrad.GradientType = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    int _alpha1 = 255;
+    public int Alpha1
+    {
+        get => _alpha1;
+        set
+        {
+            _alpha1 = value;
+            if (_fill is IGradientedRenderable fillGrad) fillGrad.Alpha1 = value;
+            if (_stroke is IGradientedRenderable strokeGrad) strokeGrad.Alpha1 = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    int _red1;
+    public int Red1
+    {
+        get => _red1;
+        set
+        {
+            _red1 = value;
+            if (_fill is IGradientedRenderable fillGrad) fillGrad.Red1 = value;
+            if (_stroke is IGradientedRenderable strokeGrad) strokeGrad.Red1 = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    int _green1;
+    public int Green1
+    {
+        get => _green1;
+        set
+        {
+            _green1 = value;
+            if (_fill is IGradientedRenderable fillGrad) fillGrad.Green1 = value;
+            if (_stroke is IGradientedRenderable strokeGrad) strokeGrad.Green1 = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    int _blue1;
+    public int Blue1
+    {
+        get => _blue1;
+        set
+        {
+            _blue1 = value;
+            if (_fill is IGradientedRenderable fillGrad) fillGrad.Blue1 = value;
+            if (_stroke is IGradientedRenderable strokeGrad) strokeGrad.Blue1 = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    public Color Color1
+    {
+        get => new Color(_red1, _green1, _blue1, _alpha1);
+        set
+        {
+            Red1 = value.R;
+            Green1 = value.G;
+            Blue1 = value.B;
+            Alpha1 = value.A;
+        }
+    }
+
+    int _alpha2 = 255;
+    public int Alpha2
+    {
+        get => _alpha2;
+        set
+        {
+            _alpha2 = value;
+            if (_fill is IGradientedRenderable fillGrad) fillGrad.Alpha2 = value;
+            if (_stroke is IGradientedRenderable strokeGrad) strokeGrad.Alpha2 = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    int _red2;
+    public int Red2
+    {
+        get => _red2;
+        set
+        {
+            _red2 = value;
+            if (_fill is IGradientedRenderable fillGrad) fillGrad.Red2 = value;
+            if (_stroke is IGradientedRenderable strokeGrad) strokeGrad.Red2 = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    int _green2;
+    public int Green2
+    {
+        get => _green2;
+        set
+        {
+            _green2 = value;
+            if (_fill is IGradientedRenderable fillGrad) fillGrad.Green2 = value;
+            if (_stroke is IGradientedRenderable strokeGrad) strokeGrad.Green2 = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    int _blue2;
+    public int Blue2
+    {
+        get => _blue2;
+        set
+        {
+            _blue2 = value;
+            if (_fill is IGradientedRenderable fillGrad) fillGrad.Blue2 = value;
+            if (_stroke is IGradientedRenderable strokeGrad) strokeGrad.Blue2 = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    public Color Color2
+    {
+        get => new Color(_red2, _green2, _blue2, _alpha2);
+        set
+        {
+            Red2 = value.R;
+            Green2 = value.G;
+            Blue2 = value.B;
+            Alpha2 = value.A;
+        }
+    }
+
+    float _gradientX1;
+    public float GradientX1
+    {
+        get => _gradientX1;
+        set
+        {
+            _gradientX1 = value;
+            if (_fill is IGradientedRenderable fillGrad) fillGrad.GradientX1 = value;
+            if (_stroke is IGradientedRenderable strokeGrad) strokeGrad.GradientX1 = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    GeneralUnitType _gradientX1Units;
+    public GeneralUnitType GradientX1Units
+    {
+        get => _gradientX1Units;
+        set
+        {
+            _gradientX1Units = value;
+            if (_fill is IGradientedRenderable fillGrad) fillGrad.GradientX1Units = value;
+            if (_stroke is IGradientedRenderable strokeGrad) strokeGrad.GradientX1Units = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    float _gradientY1;
+    public float GradientY1
+    {
+        get => _gradientY1;
+        set
+        {
+            _gradientY1 = value;
+            if (_fill is IGradientedRenderable fillGrad) fillGrad.GradientY1 = value;
+            if (_stroke is IGradientedRenderable strokeGrad) strokeGrad.GradientY1 = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    GeneralUnitType _gradientY1Units;
+    public GeneralUnitType GradientY1Units
+    {
+        get => _gradientY1Units;
+        set
+        {
+            _gradientY1Units = value;
+            if (_fill is IGradientedRenderable fillGrad) fillGrad.GradientY1Units = value;
+            if (_stroke is IGradientedRenderable strokeGrad) strokeGrad.GradientY1Units = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    float _gradientX2;
+    public float GradientX2
+    {
+        get => _gradientX2;
+        set
+        {
+            _gradientX2 = value;
+            if (_fill is IGradientedRenderable fillGrad) fillGrad.GradientX2 = value;
+            if (_stroke is IGradientedRenderable strokeGrad) strokeGrad.GradientX2 = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    GeneralUnitType _gradientX2Units;
+    public GeneralUnitType GradientX2Units
+    {
+        get => _gradientX2Units;
+        set
+        {
+            _gradientX2Units = value;
+            if (_fill is IGradientedRenderable fillGrad) fillGrad.GradientX2Units = value;
+            if (_stroke is IGradientedRenderable strokeGrad) strokeGrad.GradientX2Units = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    float _gradientY2;
+    public float GradientY2
+    {
+        get => _gradientY2;
+        set
+        {
+            _gradientY2 = value;
+            if (_fill is IGradientedRenderable fillGrad) fillGrad.GradientY2 = value;
+            if (_stroke is IGradientedRenderable strokeGrad) strokeGrad.GradientY2 = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    GeneralUnitType _gradientY2Units;
+    public GeneralUnitType GradientY2Units
+    {
+        get => _gradientY2Units;
+        set
+        {
+            _gradientY2Units = value;
+            if (_fill is IGradientedRenderable fillGrad) fillGrad.GradientY2Units = value;
+            if (_stroke is IGradientedRenderable strokeGrad) strokeGrad.GradientY2Units = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    float _gradientInnerRadius;
+    public float GradientInnerRadius
+    {
+        get => _gradientInnerRadius;
+        set
+        {
+            _gradientInnerRadius = value;
+            if (_fill is IGradientedRenderable fillGrad) fillGrad.GradientInnerRadius = value;
+            if (_stroke is IGradientedRenderable strokeGrad) strokeGrad.GradientInnerRadius = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    DimensionUnitType _gradientInnerRadiusUnits;
+    public DimensionUnitType GradientInnerRadiusUnits
+    {
+        get => _gradientInnerRadiusUnits;
+        set
+        {
+            _gradientInnerRadiusUnits = value;
+            if (_fill is IGradientedRenderable fillGrad) fillGrad.GradientInnerRadiusUnits = value;
+            if (_stroke is IGradientedRenderable strokeGrad) strokeGrad.GradientInnerRadiusUnits = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    float _gradientOuterRadius;
+    public float GradientOuterRadius
+    {
+        get => _gradientOuterRadius;
+        set
+        {
+            _gradientOuterRadius = value;
+            if (_fill is IGradientedRenderable fillGrad) fillGrad.GradientOuterRadius = value;
+            if (_stroke is IGradientedRenderable strokeGrad) strokeGrad.GradientOuterRadius = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    DimensionUnitType _gradientOuterRadiusUnits;
+    public DimensionUnitType GradientOuterRadiusUnits
+    {
+        get => _gradientOuterRadiusUnits;
+        set
+        {
+            _gradientOuterRadiusUnits = value;
+            if (_fill is IGradientedRenderable fillGrad) fillGrad.GradientOuterRadiusUnits = value;
+            if (_stroke is IGradientedRenderable strokeGrad) strokeGrad.GradientOuterRadiusUnits = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    #endregion
+
+    #region Dropshadow
+
+    // Issue #2818 (mirror of CircleRuntime dropshadow region #2797): single-slot push via
+    // DropshadowTarget — pushing to both would double up the visible shadow.
+
+    IDropshadowRenderable? DropshadowTarget =>
+        _fill as IDropshadowRenderable ?? _stroke as IDropshadowRenderable;
+
+    bool _hasDropshadow;
+    /// <inheritdoc cref="CircleRuntime.HasDropshadow"/>
+    public bool HasDropshadow
+    {
+        get => _hasDropshadow;
+        set
+        {
+            _hasDropshadow = value;
+            if (DropshadowTarget is { } target) target.HasDropshadow = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    Color _dropshadowColor;
+    public Color DropshadowColor
+    {
+        get => _dropshadowColor;
+        set
+        {
+            _dropshadowColor = value;
+            if (DropshadowTarget is { } target) target.DropshadowColor = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    public int DropshadowAlpha
+    {
+        get => _dropshadowColor.A;
+        set
+        {
+            DropshadowColor = new Color(_dropshadowColor.R, _dropshadowColor.G, _dropshadowColor.B, (byte)value);
+        }
+    }
+
+    public int DropshadowRed
+    {
+        get => _dropshadowColor.R;
+        set
+        {
+            DropshadowColor = new Color((byte)value, _dropshadowColor.G, _dropshadowColor.B, _dropshadowColor.A);
+        }
+    }
+
+    public int DropshadowGreen
+    {
+        get => _dropshadowColor.G;
+        set
+        {
+            DropshadowColor = new Color(_dropshadowColor.R, (byte)value, _dropshadowColor.B, _dropshadowColor.A);
+        }
+    }
+
+    public int DropshadowBlue
+    {
+        get => _dropshadowColor.B;
+        set
+        {
+            DropshadowColor = new Color(_dropshadowColor.R, _dropshadowColor.G, (byte)value, _dropshadowColor.A);
+        }
+    }
+
+    float _dropshadowOffsetX;
+    public float DropshadowOffsetX
+    {
+        get => _dropshadowOffsetX;
+        set
+        {
+            _dropshadowOffsetX = value;
+            if (DropshadowTarget is { } target) target.DropshadowOffsetX = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    float _dropshadowOffsetY;
+    public float DropshadowOffsetY
+    {
+        get => _dropshadowOffsetY;
+        set
+        {
+            _dropshadowOffsetY = value;
+            if (DropshadowTarget is { } target) target.DropshadowOffsetY = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    float _dropshadowBlurX;
+    public float DropshadowBlurX
+    {
+        get => _dropshadowBlurX;
+        set
+        {
+            _dropshadowBlurX = value;
+            if (DropshadowTarget is { } target) target.DropshadowBlurX = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    float _dropshadowBlurY;
+    public float DropshadowBlurY
+    {
+        get => _dropshadowBlurY;
+        set
+        {
+            _dropshadowBlurY = value;
+            if (DropshadowTarget is { } target) target.DropshadowBlurY = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    #endregion
+
+    #region DashedStroke
+
+    // Issue #2818 (mirror of CircleRuntime dashed region #2796): values round-trip on backing
+    // fields; pushed to the stroke slot in PreRender alongside StrokeWidth so ScreenPixel
+    // scaling keeps dash/gap in sync with stroke. Stroke-only — dashing is guarded by
+    // !IsFilled in the Apos RoundedRectangle renderable.
+
+    float _strokeDashLength;
+    /// <inheritdoc cref="CircleRuntime.StrokeDashLength"/>
+    public float StrokeDashLength
+    {
+        get => _strokeDashLength;
+        set
+        {
+            _strokeDashLength = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    float _strokeGapLength;
+    /// <inheritdoc cref="CircleRuntime.StrokeGapLength"/>
+    public float StrokeGapLength
+    {
+        get => _strokeGapLength;
+        set
+        {
+            _strokeGapLength = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    #endregion
+
     /// <inheritdoc cref="CircleRuntime.PreRender"/>
     public override void PreRender()
     {
         float strokeWidth = _strokeWidth;
+        float strokeDashLength = _strokeDashLength;
+        float strokeGapLength = _strokeGapLength;
         if (_strokeWidthUnits == DimensionUnitType.ScreenPixel)
         {
             var camera = this.EffectiveManagers?.Renderer?.Camera;
             if (camera != null)
             {
+                // Mirror AposShapeRuntime.PreRender — dash and gap scale alongside stroke width.
                 strokeWidth /= camera.Zoom;
+                strokeDashLength /= camera.Zoom;
+                strokeGapLength /= camera.Zoom;
             }
         }
         _stroke.StrokeWidth = strokeWidth;
+
+        // Issue #2818: push dash/gap to the stroke slot when it supports dashing.
+        if (_stroke is IDashedStrokeRenderable strokeDashed)
+        {
+            strokeDashed.StrokeDashLength = strokeDashLength;
+            strokeDashed.StrokeGapLength = strokeGapLength;
+        }
+
+        // Issue #2818: push AA to both slots so a single setter flips fill + stroke together.
+        if (_fill is IAntialiasedRenderable fillAa) fillAa.IsAntialiased = _isAntialiased;
+        if (_stroke is IAntialiasedRenderable strokeAa) strokeAa.IsAntialiased = _isAntialiased;
 
         // Mirror size to stroke when fill is the contained object — see CircleRuntime.PreRender.
         if (_fill is IPositionedSizedObject fillSized && _stroke is IPositionedSizedObject strokeSized)
@@ -376,14 +960,104 @@ public class RectangleRuntime : GraphicalUiElement
             strokeSized.Height = fillSized.Height;
         }
     }
+
+    /// <inheritdoc/>
+    /// <remarks>
+    /// Issue #2818 — mirror of <see cref="CircleRuntime.Clone"/>: rebuild both slots via
+    /// <see cref="RenderableRegistry"/> so the clone is fully independent of the source.
+    /// </remarks>
+    public override GraphicalUiElement Clone()
+    {
+        RectangleRuntime toReturn = (RectangleRuntime)base.Clone();
+
+        toReturn._fill = (IFilledRectangleRenderable?)toReturn.mContainedObjectAsIpso;
+        toReturn._stroke = RenderableRegistry.Create<IStrokedRectangleRenderable>(toReturn)
+            ?? new DefaultStrokedRectangleRenderable();
+
+        if (toReturn._fill is IRenderableIpso fillIpso
+            && toReturn._stroke is IRenderableIpso strokeIpso)
+        {
+            strokeIpso.Parent = fillIpso;
+        }
+        else if (toReturn._fill == null)
+        {
+            toReturn.SetContainedObject(toReturn._stroke);
+        }
+
+        toReturn.StrokeColor = toReturn.StrokeColor;
+        return toReturn;
+    }
 #endif
 
 #if SKIA
     /// <summary>
     /// Routes SkiaShapeRuntime solid/gradient/stroke/dropshadow accessors to the
-    /// contained LineRectangle. Issue #2814.
+    /// contained RoundedRectangle. Issue #2814 / #2818.
     /// </summary>
     protected override RenderableShapeBase ContainedRenderable => ContainedLineRectangle;
+
+    /// <summary>
+    /// Rounded-corner radius in pixels. Pushed to both slots each frame in
+    /// <see cref="PreRender"/> so the outline traces the same rounded corners as the fill.
+    /// Default of 0 keeps the historical hard-cornered visual.
+    /// </summary>
+    public float CornerRadius { get; set; }
+
+    /// <inheritdoc cref="RectangleRuntime.CornerRadius"/>
+    public float? CustomRadiusTopLeft { get; set; }
+    /// <inheritdoc cref="RectangleRuntime.CornerRadius"/>
+    public float? CustomRadiusTopRight { get; set; }
+    /// <inheritdoc cref="RectangleRuntime.CornerRadius"/>
+    public float? CustomRadiusBottomLeft { get; set; }
+    /// <inheritdoc cref="RectangleRuntime.CornerRadius"/>
+    public float? CustomRadiusBottomRight { get; set; }
+
+    /// <summary>
+    /// Unit of measurement for <see cref="CornerRadius"/> and per-corner overrides. Mirrors
+    /// <see cref="StrokeWidthUnits"/>: <c>ScreenPixel</c> divides by camera zoom each frame.
+    /// </summary>
+    public DimensionUnitType CornerRadiusUnits { get; set; }
+
+    /// <inheritdoc/>
+    public override void PreRender()
+    {
+        base.PreRender();
+
+        // Issue #2818 — resolve unit-aware corner radii then push to both slots so the
+        // outline traces the same rounded corners as the fill (same pattern as
+        // RoundedRectangleRuntime.PreRender / SkiaShapeRuntime.PreRender's width/height mirror).
+        var cornerRadius = CornerRadius;
+        var topLeft = CustomRadiusTopLeft;
+        var topRight = CustomRadiusTopRight;
+        var bottomLeft = CustomRadiusBottomLeft;
+        var bottomRight = CustomRadiusBottomRight;
+
+        if (CornerRadiusUnits == DimensionUnitType.ScreenPixel && this.EffectiveManagers != null)
+        {
+            var camera = this.EffectiveManagers.Renderer.Camera;
+            cornerRadius /= camera.Zoom;
+            topLeft /= camera.Zoom;
+            topRight /= camera.Zoom;
+            bottomLeft /= camera.Zoom;
+            bottomRight /= camera.Zoom;
+        }
+
+        var fill = ContainedLineRectangle;
+        fill.CornerRadius = cornerRadius;
+        fill.CustomRadiusTopLeft = topLeft;
+        fill.CustomRadiusTopRight = topRight;
+        fill.CustomRadiusBottomLeft = bottomLeft;
+        fill.CustomRadiusBottomRight = bottomRight;
+
+        if (StrokeRenderable is SkiaGum.Renderables.RoundedRectangle strokeRounded)
+        {
+            strokeRounded.CornerRadius = cornerRadius;
+            strokeRounded.CustomRadiusTopLeft = topLeft;
+            strokeRounded.CustomRadiusTopRight = topRight;
+            strokeRounded.CustomRadiusBottomLeft = bottomLeft;
+            strokeRounded.CustomRadiusBottomRight = bottomRight;
+        }
+    }
 
     /// <inheritdoc/>
     public override GraphicalUiElement Clone()
@@ -391,12 +1065,12 @@ public class RectangleRuntime : GraphicalUiElement
         RectangleRuntime toReturn = (RectangleRuntime)base.Clone();
         // Reset cached renderable reference so the clone re-resolves against its own
         // RenderableComponent on next access. The fill slot color/dimensions were copied
-        // by LineRectangle.Clone (ICloneable, MemberwiseClone).
+        // by RoundedRectangle.Clone (ICloneable, MemberwiseClone).
         toReturn.containedLineRectangle = null!;
         // Issue #2790 recipe - drop the inherited stroke-slot reference and rebuild a fresh
         // one parented to the clone fill so the clone is fully independent.
         toReturn.ClearStrokeRenderable();
-        toReturn.SetStrokeRenderable(new ContainedLineRectangle());
+        toReturn.SetStrokeRenderable(new ContainedLineRectangle { CornerRadius = 0 });
         // Re-fire StrokeColor so the user color (held on _strokeColor via MemberwiseClone)
         // is pushed into the fresh stroke slot.
         toReturn.StrokeColor = toReturn.StrokeColor;
@@ -446,6 +1120,13 @@ public class RectangleRuntime : GraphicalUiElement
             Width = 50;
             Height = 50;
 
+            // Issue #2818 (mirror of CircleRuntime #2797): pre-seed opaque-black dropshadow
+            // with a slight downward offset/blur so toggling HasDropshadow = true at runtime
+            // produces a visible shadow without further setup.
+            DropshadowAlpha = 255;
+            DropshadowOffsetY = 3;
+            DropshadowBlurY = 3;
+
             if (_fill is IPositionedSizedObject ctorFill && _stroke is IPositionedSizedObject ctorStroke)
             {
                 ctorStroke.Width = ctorFill.Width;
@@ -453,15 +1134,17 @@ public class RectangleRuntime : GraphicalUiElement
             }
 #elif SKIA
             // Issue #2814: two-slot fill+stroke composition for Skia (mirrors the CircleRuntime
-            // wiring from issue #2790). The contained LineRectangle becomes the fill slot; a
-            // second LineRectangle, registered via SetStrokeRenderable, is parented under the
-            // fill so SkiaShapeRuntime.FillColor and StrokeColor each route to their own
-            // renderable rather than fighting over a single IsFilled toggle.
-            var rectangle = new ContainedLineRectangle();
+            // wiring from issue #2790). The contained renderable becomes the fill slot; a
+            // second one, registered via SetStrokeRenderable, is parented under the fill so
+            // SkiaShapeRuntime.FillColor and StrokeColor each route to their own renderable.
+            // Issue #2818: contained type is now RoundedRectangle so CornerRadius / per-corner
+            // radii reach the renderer; CornerRadius default of 0 keeps the historical
+            // hard-cornered visual (RoundedRectangle's own ctor defaults to 5).
+            var rectangle = new ContainedLineRectangle { CornerRadius = 0 };
             SetContainedObject(rectangle);
             containedLineRectangle = rectangle;
 
-            SetStrokeRenderable(new ContainedLineRectangle());
+            SetStrokeRenderable(new ContainedLineRectangle { CornerRadius = 0 });
 
             // Defaults: invisible fill, white stroke - supplies RectangleRuntime historical
             // outline-only visual, now via the dedicated stroke slot.

--- a/MonoGameGum/Renderables/DefaultFilledRectangleRenderable.cs
+++ b/MonoGameGum/Renderables/DefaultFilledRectangleRenderable.cs
@@ -39,5 +39,10 @@ public class DefaultFilledRectangleRenderable : SolidRectangle, IFilledRectangle
 
     // Stored but not rendered: SolidRectangle is hard-cornered. Set fully for round-tripping.
     public float CornerRadius { get; set; }
+
+    public float? CustomRadiusTopLeft { get; set; }
+    public float? CustomRadiusTopRight { get; set; }
+    public float? CustomRadiusBottomLeft { get; set; }
+    public float? CustomRadiusBottomRight { get; set; }
 }
 #endif

--- a/MonoGameGum/Renderables/DefaultStrokedRectangleRenderable.cs
+++ b/MonoGameGum/Renderables/DefaultStrokedRectangleRenderable.cs
@@ -42,5 +42,10 @@ public class DefaultStrokedRectangleRenderable : LineRectangle, IStrokedRectangl
 
     // Stored but not rendered: LineRectangle is hard-cornered.
     public float CornerRadius { get; set; }
+
+    public float? CustomRadiusTopLeft { get; set; }
+    public float? CustomRadiusTopRight { get; set; }
+    public float? CustomRadiusBottomLeft { get; set; }
+    public float? CustomRadiusBottomRight { get; set; }
 }
 #endif

--- a/Runtimes/GumShapes/Renderables/Circle.cs
+++ b/Runtimes/GumShapes/Renderables/Circle.cs
@@ -106,6 +106,14 @@ public class Circle : RenderableShapeBase,
             return;
         }
 
+        // See RoundedRectangle for more info
+        if (antiAliasSize != 0)
+        {
+            center.X += .5f;
+            center.Y += .5f;
+            radius -= .5f;
+        }
+
         if (IsFilled)
         {
             // as outlined here:

--- a/Runtimes/GumShapes/Renderables/RoundedRectangle.cs
+++ b/Runtimes/GumShapes/Renderables/RoundedRectangle.cs
@@ -13,14 +13,33 @@ namespace MonoGameAndGum.Renderables;
 public class RoundedRectangle : RenderableShapeBase,
     Gum.GueDeriving.IFilledRectangleRenderable,
     Gum.GueDeriving.IStrokedRectangleRenderable,
+    Gum.GueDeriving.IGradientedRenderable,
+    Gum.GueDeriving.IAntialiasedRenderable,
     Gum.GueDeriving.IDropshadowRenderable,
-    Gum.GueDeriving.IDashedStrokeRenderable
+    Gum.GueDeriving.IDashedStrokeRenderable,
+    System.ICloneable
 {
-    // IDropshadowRenderable and IDashedStrokeRenderable are satisfied entirely by the
-    // property bag inherited from RenderableShapeBase — declared here so the future
-    // RectangleRuntime (#2797 / #2796 follow-up) can pattern-match those surfaces the same
-    // way CircleRuntime does today, without coupling to the concrete Apos.Shapes
-    // RoundedRectangle type.
+    // IGradientedRenderable, IAntialiasedRenderable, IDropshadowRenderable, and
+    // IDashedStrokeRenderable are all satisfied entirely by the property bag inherited from
+    // RenderableShapeBase — declared here so RectangleRuntime (#2818) can pattern-match
+    // those surfaces the same way CircleRuntime does, without coupling to the concrete
+    // Apos.Shapes RoundedRectangle type.
+
+    /// <summary>
+    /// Issue #2818 — required by <see cref="Gum.Wireframe.GraphicalUiElement.Clone"/> so
+    /// shape runtimes can be deep-copied. Mirrors the Circle.Clone implementation: the
+    /// children collection, parent pointer, and OnPreRender hook (which still points back at
+    /// the source runtime) are reset so the clone is structurally independent.
+    /// RectangleRuntime.Clone is responsible for re-wiring OnPreRender against the new runtime.
+    /// </summary>
+    public object Clone()
+    {
+        RoundedRectangle clone = (RoundedRectangle)MemberwiseClone();
+        clone._children = new();
+        clone._parent = null;
+        clone.OnPreRender = null;
+        return clone;
+    }
 
     /// <summary>
     /// Rounded-corner radius in pixels. Apos.Shapes' <c>RoundedRectangle</c> honors this on
@@ -199,7 +218,15 @@ public class RoundedRectangle : RenderableShapeBase,
         var perimeter = 2f * (straightX + straightY) + 4f * cornerArc;
         if (perimeter <= 0) return;
 
-        var period = StrokeDashLength + StrokeGapLength;
+        // Issue #2818 (mirror of Circle.RenderDashed #2790): when AA is on, each dash's
+        // tangential end-cap halo leaks into the neighboring gap and smears dotted patterns
+        // into near-continuous borders. Shift 1.5 * aaSize into the gap and trim 0.5 * aaSize
+        // off each dash so the gap opens up noticeably while dashes shrink slightly to
+        // compensate. Dash length floored at a small epsilon so a tight 1-px-dash pattern
+        // doesn't push 0 (Apos won't render a zero-length dash).
+        var effectiveGapLen = StrokeGapLength + 1.5f * antiAliasSize;
+        var dashLen = MathHelper.Max(0.01f, StrokeDashLength - 0.5f * antiAliasSize);
+        var period = dashLen + effectiveGapLen;
         if (period <= 0) return;
 
         var topY = absoluteTop;
@@ -223,7 +250,7 @@ public class RoundedRectangle : RenderableShapeBase,
         for (float t = 0; t < perimeter; t += period)
         {
             var dashStart = t;
-            var dashEnd = MathHelper.Min(t + StrokeDashLength, perimeter);
+            var dashEnd = MathHelper.Min(t + dashLen, perimeter);
             if (dashEnd <= dashStart) continue;
 
             float segOff = 0f;

--- a/Runtimes/GumShapes/Renderables/RoundedRectangle.cs
+++ b/Runtimes/GumShapes/Renderables/RoundedRectangle.cs
@@ -116,6 +116,18 @@ public class RoundedRectangle : RenderableShapeBase,
 
         bool hasCustomCorners = HasCustomCorners(out var corners);
 
+        // We do this so that shapes draw starting at the center of the pixel. This is most important
+        // when shapes have a stroke thickness of 1 at the Gum level with anti aliasing. This renders wiht
+        // an epsilon value of 0.01, with an anti-alias size of 1. By offsetting, the sampling of the antialias
+        // gradient in the shader happens right at the start of the gradient, making for solid beautiful lines.
+        if(antiAliasSize != 0)
+        {
+            position.X += .5f;
+            position.Y += .5f;
+            size.X -= 1f;
+            size.Y -= 1f;
+        }
+
         if (IsFilled)
         {
             if (UseGradient && forcedColor == null)
@@ -161,6 +173,7 @@ public class RoundedRectangle : RenderableShapeBase,
                     sb.DrawRectangle(position, size, transparentColor, color, strokeWidth, corners, rotationRadians, antiAliasSize);
                 else
                     sb.DrawRectangle(position, size, transparentColor, color, strokeWidth, CornerRadius, rotationRadians, antiAliasSize);
+
             }
         }
     }

--- a/Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/RectanglesScreen.cs
+++ b/Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/RectanglesScreen.cs
@@ -34,6 +34,7 @@ internal class RectanglesScreen : FrameworkElement
         root.AddChild(BuildSection("Alpha on FillColor (255, 192, 128, 64)", BuildAlphaRow()));
         root.AddChild(BuildSection("FillColor / StrokeColor / Fill+Stroke / default", BuildModeRow()));
         root.AddChild(BuildSection("StrokeWidth (1, 2, 4, 8 px on a filled card)", BuildStrokeWidthRow()));
+        root.AddChild(BuildSection("Antialiasing (true vs false — visual no-op without MonoGameGumShapes)", BuildAntialiasingRow()));
         root.AddChild(BuildSection("Alignment inside a 220x100 container (Top / Center / Bottom)", BuildAlignmentRow()));
     }
 
@@ -125,6 +126,27 @@ internal class RectanglesScreen : FrameworkElement
             rect.FillColor = new Color(30, 30, 50);
             rect.StrokeColor = Color.LightGreen;
             rect.StrokeWidth = strokeWidth;
+            row.AddChild(rect);
+        }
+        return row;
+    }
+
+    static ContainerRuntime BuildAntialiasingRow()
+    {
+        // Issue #2818: IsAntialiased flips both fill and stroke slots when MonoGameGumShapes
+        // is installed. Core SolidRectangle / LineRectangle defaults don't implement
+        // IAntialiasedRenderable, so this row reads identical here — load MonoGameGumShapes
+        // (see MonoGameGumShapesGallery) for the visible smooth-vs-crisp comparison.
+        ContainerRuntime row = BuildHorizontalRow();
+        foreach (bool aa in new[] { true, false })
+        {
+            RectangleRuntime rect = new();
+            rect.Width = 80;
+            rect.Height = 50;
+            rect.FillColor = new Color(30, 30, 50);
+            rect.StrokeColor = Color.LightGreen;
+            rect.StrokeWidth = 2;
+            rect.IsAntialiased = aa;
             row.AddChild(rect);
         }
         return row;

--- a/Samples/MonoGameGumShapesGallery/Screens/CirclesScreen.cs
+++ b/Samples/MonoGameGumShapesGallery/Screens/CirclesScreen.cs
@@ -98,6 +98,7 @@ internal class CirclesScreen : FrameworkElement
             CircleRuntime circle = new();
             circle.Radius = radius;
             circle.StrokeColor = Color.White;
+            circle.StrokeWidth = 1;
             row.AddChild(circle);
         }
         return row;

--- a/Samples/MonoGameGumShapesGallery/Screens/RectanglesScreen.cs
+++ b/Samples/MonoGameGumShapesGallery/Screens/RectanglesScreen.cs
@@ -48,8 +48,8 @@ internal class RectanglesScreen : FrameworkElement
         left.AddChild(BuildSection("CornerRadius (0, 6, 16, 28 — visibly rounded on Apos)", BuildCornerRadiusRow()));
 
         left.AddChild(BuildSection("Per-corner radii (TL=20, TR=2, BR=20, BL=2 — opposite corners)", BuildPerCornerRow()));
+        left.AddChild(BuildSection("Gradients (linear horizontal / vertical / diagonal / radial)", BuildGradientRow()));
 
-        right.AddChild(BuildSection("Gradients (linear horizontal / vertical / diagonal / radial)", BuildGradientRow()));
         right.AddChild(BuildSection("Antialiasing (default ON, then OFF) — 1 px stroke makes the bloom obvious (#2818)", BuildAntialiasingRow()));
         right.AddChild(BuildSection("Dropshadow (off / soft / hard offset / colored) — fill-only push avoids doubling (#2818)", BuildDropshadowRow()));
         right.AddChild(BuildSection("Dashed strokes (solid / 6/4 / 2/2 dotted / long-dash) — stroke-only push (#2818)", BuildDashedStrokeRow()));

--- a/Samples/MonoGameGumShapesGallery/Screens/RectanglesScreen.cs
+++ b/Samples/MonoGameGumShapesGallery/Screens/RectanglesScreen.cs
@@ -174,6 +174,7 @@ internal class RectanglesScreen : FrameworkElement
             rect.FillColor = new Color(40, 40, 80);
             rect.StrokeColor = Color.Orange;
             rect.StrokeWidth = 2;
+            rect.IsAntialiased = true;
             rect.CornerRadius = cornerRadius;
             row.AddChild(rect);
         }
@@ -200,73 +201,76 @@ internal class RectanglesScreen : FrameworkElement
     }
 
     // Issue #2818 — mirror of CirclesScreen.BuildGradientRow. RectangleRuntime pushes
-    // gradient state through to both Apos RoundedRectangles (fill and stroke).
+    // gradient state through to both Apos RoundedRectangles (fill and stroke). Cell sizes
+    // (70x50 cells, gradient endpoints in cell-local coords) match the SilkNetGum sibling so
+    // the two galleries lay out the same.
     static ContainerRuntime BuildGradientRow()
     {
         ContainerRuntime row = BuildHorizontalRow();
 
         RectangleRuntime linearH = new();
-        linearH.Width = 80; linearH.Height = 56;
+        linearH.Width = 70; linearH.Height = 50;
         linearH.FillColor = Color.White;
         linearH.UseGradient = true;
         linearH.GradientType = GradientType.Linear;
         linearH.Color1 = Color.White;
         linearH.Color2 = Color.SteelBlue;
         linearH.GradientX1 = 0; linearH.GradientY1 = 0;
-        linearH.GradientX2 = 80; linearH.GradientY2 = 0;
+        linearH.GradientX2 = 70; linearH.GradientY2 = 0;
         row.AddChild(linearH);
 
         RectangleRuntime linearV = new();
-        linearV.Width = 80; linearV.Height = 56;
+        linearV.Width = 70; linearV.Height = 50;
         linearV.FillColor = Color.White;
         linearV.UseGradient = true;
         linearV.GradientType = GradientType.Linear;
         linearV.Color1 = Color.Gold;
         linearV.Color2 = Color.Crimson;
         linearV.GradientX1 = 0; linearV.GradientY1 = 0;
-        linearV.GradientX2 = 0; linearV.GradientY2 = 56;
+        linearV.GradientX2 = 0; linearV.GradientY2 = 50;
         row.AddChild(linearV);
 
         RectangleRuntime linearD = new();
-        linearD.Width = 80; linearD.Height = 56;
+        linearD.Width = 70; linearD.Height = 50;
         linearD.FillColor = Color.White;
         linearD.UseGradient = true;
         linearD.GradientType = GradientType.Linear;
         linearD.Color1 = Color.Cyan;
         linearD.Color2 = Color.Magenta;
         linearD.GradientX1 = 0; linearD.GradientY1 = 0;
-        linearD.GradientX2 = 80; linearD.GradientY2 = 56;
+        linearD.GradientX2 = 70; linearD.GradientY2 = 50;
         row.AddChild(linearD);
 
         RectangleRuntime radial = new();
-        radial.Width = 80; radial.Height = 56;
+        radial.Width = 70; radial.Height = 50;
         radial.FillColor = Color.White;
         radial.UseGradient = true;
         radial.GradientType = GradientType.Radial;
         radial.Color1 = Color.White;
         radial.Color2 = Color.DarkGreen;
-        radial.GradientX1 = 40; radial.GradientY1 = 28;
+        radial.GradientX1 = 35; radial.GradientY1 = 25;
         radial.GradientInnerRadius = 0;
-        radial.GradientOuterRadius = 40;
+        radial.GradientOuterRadius = 35;
         row.AddChild(radial);
 
         return row;
     }
 
-    // Issue #2818 — mirror of CirclesScreen.BuildAntialiasingRow.
+    // Issue #2818 — mirror of CirclesScreen.BuildAntialiasingRow. Cell size 60x50 matches
+    // the SilkNetGum sibling.
     static ContainerRuntime BuildAntialiasingRow()
     {
         ContainerRuntime row = BuildHorizontalRow();
         foreach (bool aa in new[] { true, false })
         {
             RectangleRuntime filled = new();
-            filled.Width = 80; filled.Height = 56;
+            filled.Width = 60; filled.Height = 50;
             filled.FillColor = Color.Goldenrod;
             filled.IsAntialiased = aa;
             row.AddChild(filled);
 
             RectangleRuntime ring = new();
-            ring.Width = 80; ring.Height = 56;
+            ring.Width = 60; ring.Height = 50;
             ring.StrokeColor = Color.White;
             ring.StrokeWidth = 1;
             ring.IsAntialiased = aa;
@@ -276,18 +280,19 @@ internal class RectanglesScreen : FrameworkElement
     }
 
     // Issue #2818 — mirror of CirclesScreen.BuildDropshadowRow. Shadow pushes to the fill
-    // slot only; rendered once per cell rather than doubling.
+    // slot only; rendered once per cell rather than doubling. Cell size 60x50 matches
+    // SilkNetGum.
     static ContainerRuntime BuildDropshadowRow()
     {
         ContainerRuntime row = BuildHorizontalRow();
 
         RectangleRuntime baseline = new();
-        baseline.Width = 80; baseline.Height = 56;
+        baseline.Width = 60; baseline.Height = 50;
         baseline.FillColor = Color.Goldenrod;
         row.AddChild(baseline);
 
         RectangleRuntime soft = new();
-        soft.Width = 80; soft.Height = 56;
+        soft.Width = 60; soft.Height = 50;
         soft.FillColor = Color.Goldenrod;
         soft.HasDropshadow = true;
         soft.DropshadowOffsetX = 4;
@@ -297,7 +302,7 @@ internal class RectanglesScreen : FrameworkElement
         row.AddChild(soft);
 
         RectangleRuntime hard = new();
-        hard.Width = 80; hard.Height = 56;
+        hard.Width = 60; hard.Height = 50;
         hard.FillColor = Color.Goldenrod;
         hard.HasDropshadow = true;
         hard.DropshadowColor = new Color(0, 0, 0, 160);
@@ -308,7 +313,7 @@ internal class RectanglesScreen : FrameworkElement
         row.AddChild(hard);
 
         RectangleRuntime colored = new();
-        colored.Width = 80; colored.Height = 56;
+        colored.Width = 60; colored.Height = 50;
         colored.FillColor = Color.Goldenrod;
         colored.HasDropshadow = true;
         colored.DropshadowColor = new Color(220, 40, 160, 220);
@@ -323,18 +328,19 @@ internal class RectanglesScreen : FrameworkElement
 
     // Issue #2818 — mirror of CirclesScreen.BuildDashedStrokeRow. Dashing applies to the
     // stroke slot only; the Apos RoundedRectangle's RenderDashed path is guarded by !IsFilled.
+    // Cell size 60x50 matches SilkNetGum.
     static ContainerRuntime BuildDashedStrokeRow()
     {
         ContainerRuntime row = BuildHorizontalRow();
 
         RectangleRuntime solid = new();
-        solid.Width = 80; solid.Height = 56;
+        solid.Width = 60; solid.Height = 50;
         solid.StrokeColor = Color.White;
         solid.StrokeWidth = 2;
         row.AddChild(solid);
 
         RectangleRuntime short64 = new();
-        short64.Width = 80; short64.Height = 56;
+        short64.Width = 60; short64.Height = 50;
         short64.StrokeColor = Color.White;
         short64.StrokeWidth = 2;
         short64.StrokeDashLength = 6;
@@ -342,7 +348,7 @@ internal class RectanglesScreen : FrameworkElement
         row.AddChild(short64);
 
         RectangleRuntime dotted = new();
-        dotted.Width = 80; dotted.Height = 56;
+        dotted.Width = 60; dotted.Height = 50;
         dotted.StrokeColor = Color.White;
         dotted.StrokeWidth = 1;
         dotted.StrokeDashLength = 2;
@@ -350,7 +356,7 @@ internal class RectanglesScreen : FrameworkElement
         row.AddChild(dotted);
 
         RectangleRuntime longDash = new();
-        longDash.Width = 80; longDash.Height = 56;
+        longDash.Width = 60; longDash.Height = 50;
         longDash.StrokeColor = Color.LightGreen;
         longDash.StrokeWidth = 3;
         longDash.StrokeDashLength = 12;
@@ -450,7 +456,7 @@ internal class RectanglesScreen : FrameworkElement
         frame.Color = new Color(50, 50, 70);
 
         RectangleRuntime rect = new();
-        rect.Width = 60;
+        rect.Width = 50;
         rect.Height = 30;
         rect.FillColor = Color.Orange;
         rect.XOrigin = HorizontalAlignment.Center;

--- a/Samples/MonoGameGumShapesGallery/Screens/RectanglesScreen.cs
+++ b/Samples/MonoGameGumShapesGallery/Screens/RectanglesScreen.cs
@@ -41,6 +41,7 @@ internal class RectanglesScreen : FrameworkElement
         root.AddChild(right);
 
         left.AddChild(BuildSection("Sizes (40, 60, 90, 130 wide) — default outline", BuildSizesRow()));
+
         left.AddChild(BuildSection("Alpha on StrokeColor (255, 192, 128, 64)", BuildAlphaRow()));
         left.AddChild(BuildSection("Modes: FillColor, StrokeColor, Fill+Stroke, default", BuildModeRow()));
         left.AddChild(BuildSection("StrokeWidth (1, 2, 4, 8 px on a filled card)", BuildStrokeWidthRow()));
@@ -97,7 +98,11 @@ internal class RectanglesScreen : FrameworkElement
             RectangleRuntime rect = new();
             rect.Width = width;
             rect.Height = 40;
+            rect.CornerRadius = 10;
+            rect.StrokeWidth = 1;
             rect.StrokeColor = Color.White;
+            rect.IsAntialiased = true;
+
             row.AddChild(rect);
         }
         return row;

--- a/Samples/MonoGameGumShapesGallery/Screens/RectanglesScreen.cs
+++ b/Samples/MonoGameGumShapesGallery/Screens/RectanglesScreen.cs
@@ -47,14 +47,14 @@ internal class RectanglesScreen : FrameworkElement
         left.AddChild(BuildSection("Alignment inside a 128x100 frame (Top / Center / Bottom)", BuildAlignmentRow()));
         left.AddChild(BuildSection("CornerRadius (0, 6, 16, 28 — visibly rounded on Apos)", BuildCornerRadiusRow()));
 
+        left.AddChild(BuildSection("Per-corner radii (TL=20, TR=2, BR=20, BL=2 — opposite corners)", BuildPerCornerRow()));
+
+        right.AddChild(BuildSection("Gradients (linear horizontal / vertical / diagonal / radial)", BuildGradientRow()));
+        right.AddChild(BuildSection("Antialiasing (default ON, then OFF) — 1 px stroke makes the bloom obvious (#2818)", BuildAntialiasingRow()));
+        right.AddChild(BuildSection("Dropshadow (off / soft / hard offset / colored) — fill-only push avoids doubling (#2818)", BuildDropshadowRow()));
+        right.AddChild(BuildSection("Dashed strokes (solid / 6/4 / 2/2 dotted / long-dash) — stroke-only push (#2818)", BuildDashedStrokeRow()));
         right.AddChild(BuildSection("FillColor + StrokeColor on the same instance — both layers render simultaneously (#2768 / #2814)", BuildBothColorsRow()));
         right.AddChild(BuildSection("Inscribed in a 64x64 frame — stroke must stay inside the gray rectangle's bounds at every StrokeWidth (#2768 / #2814 visual contract; mirrors SilkNetGum)", BuildInscribedRow()));
-        // N/A on MG RectangleRuntime: UseGradient, IsAntialiased, HasDropshadow,
-        // StrokeDashLength/StrokeGapLength are exposed on MG CircleRuntime but not yet on
-        // MG RectangleRuntime. Skia RectangleRuntime DOES support all of these via its
-        // SkiaShapeRuntime base — see SilkNetGum/Screens/RectanglesScreen for the visual
-        // contract those rows enforce. Plumb the equivalent props through to MG
-        // RectangleRuntime and add the four rows below to close the gap.
     }
 
     static ContainerRuntime BuildColumn()
@@ -177,6 +177,186 @@ internal class RectanglesScreen : FrameworkElement
             rect.CornerRadius = cornerRadius;
             row.AddChild(rect);
         }
+        return row;
+    }
+
+    // Issue #2818 — per-corner radii reach the renderer via the runtime's CustomRadius*
+    // pass-through (decision 4). Apos.Shapes' RoundedRectangle uses the CornerRadii overload
+    // when any per-corner value is non-null; null falls back to CornerRadius.
+    static ContainerRuntime BuildPerCornerRow()
+    {
+        ContainerRuntime row = BuildHorizontalRow();
+        RectangleRuntime rect = new();
+        rect.Width = 120; rect.Height = 70;
+        rect.FillColor = new Color(40, 40, 80);
+        rect.StrokeColor = Color.Orange;
+        rect.StrokeWidth = 2;
+        rect.CustomRadiusTopLeft = 20;
+        rect.CustomRadiusTopRight = 2;
+        rect.CustomRadiusBottomRight = 20;
+        rect.CustomRadiusBottomLeft = 2;
+        row.AddChild(rect);
+        return row;
+    }
+
+    // Issue #2818 — mirror of CirclesScreen.BuildGradientRow. RectangleRuntime pushes
+    // gradient state through to both Apos RoundedRectangles (fill and stroke).
+    static ContainerRuntime BuildGradientRow()
+    {
+        ContainerRuntime row = BuildHorizontalRow();
+
+        RectangleRuntime linearH = new();
+        linearH.Width = 80; linearH.Height = 56;
+        linearH.FillColor = Color.White;
+        linearH.UseGradient = true;
+        linearH.GradientType = GradientType.Linear;
+        linearH.Color1 = Color.White;
+        linearH.Color2 = Color.SteelBlue;
+        linearH.GradientX1 = 0; linearH.GradientY1 = 0;
+        linearH.GradientX2 = 80; linearH.GradientY2 = 0;
+        row.AddChild(linearH);
+
+        RectangleRuntime linearV = new();
+        linearV.Width = 80; linearV.Height = 56;
+        linearV.FillColor = Color.White;
+        linearV.UseGradient = true;
+        linearV.GradientType = GradientType.Linear;
+        linearV.Color1 = Color.Gold;
+        linearV.Color2 = Color.Crimson;
+        linearV.GradientX1 = 0; linearV.GradientY1 = 0;
+        linearV.GradientX2 = 0; linearV.GradientY2 = 56;
+        row.AddChild(linearV);
+
+        RectangleRuntime linearD = new();
+        linearD.Width = 80; linearD.Height = 56;
+        linearD.FillColor = Color.White;
+        linearD.UseGradient = true;
+        linearD.GradientType = GradientType.Linear;
+        linearD.Color1 = Color.Cyan;
+        linearD.Color2 = Color.Magenta;
+        linearD.GradientX1 = 0; linearD.GradientY1 = 0;
+        linearD.GradientX2 = 80; linearD.GradientY2 = 56;
+        row.AddChild(linearD);
+
+        RectangleRuntime radial = new();
+        radial.Width = 80; radial.Height = 56;
+        radial.FillColor = Color.White;
+        radial.UseGradient = true;
+        radial.GradientType = GradientType.Radial;
+        radial.Color1 = Color.White;
+        radial.Color2 = Color.DarkGreen;
+        radial.GradientX1 = 40; radial.GradientY1 = 28;
+        radial.GradientInnerRadius = 0;
+        radial.GradientOuterRadius = 40;
+        row.AddChild(radial);
+
+        return row;
+    }
+
+    // Issue #2818 — mirror of CirclesScreen.BuildAntialiasingRow.
+    static ContainerRuntime BuildAntialiasingRow()
+    {
+        ContainerRuntime row = BuildHorizontalRow();
+        foreach (bool aa in new[] { true, false })
+        {
+            RectangleRuntime filled = new();
+            filled.Width = 80; filled.Height = 56;
+            filled.FillColor = Color.Goldenrod;
+            filled.IsAntialiased = aa;
+            row.AddChild(filled);
+
+            RectangleRuntime ring = new();
+            ring.Width = 80; ring.Height = 56;
+            ring.StrokeColor = Color.White;
+            ring.StrokeWidth = 1;
+            ring.IsAntialiased = aa;
+            row.AddChild(ring);
+        }
+        return row;
+    }
+
+    // Issue #2818 — mirror of CirclesScreen.BuildDropshadowRow. Shadow pushes to the fill
+    // slot only; rendered once per cell rather than doubling.
+    static ContainerRuntime BuildDropshadowRow()
+    {
+        ContainerRuntime row = BuildHorizontalRow();
+
+        RectangleRuntime baseline = new();
+        baseline.Width = 80; baseline.Height = 56;
+        baseline.FillColor = Color.Goldenrod;
+        row.AddChild(baseline);
+
+        RectangleRuntime soft = new();
+        soft.Width = 80; soft.Height = 56;
+        soft.FillColor = Color.Goldenrod;
+        soft.HasDropshadow = true;
+        soft.DropshadowOffsetX = 4;
+        soft.DropshadowOffsetY = 4;
+        soft.DropshadowBlurX = 4;
+        soft.DropshadowBlurY = 4;
+        row.AddChild(soft);
+
+        RectangleRuntime hard = new();
+        hard.Width = 80; hard.Height = 56;
+        hard.FillColor = Color.Goldenrod;
+        hard.HasDropshadow = true;
+        hard.DropshadowColor = new Color(0, 0, 0, 160);
+        hard.DropshadowOffsetX = 6;
+        hard.DropshadowOffsetY = 6;
+        hard.DropshadowBlurX = 0;
+        hard.DropshadowBlurY = 0;
+        row.AddChild(hard);
+
+        RectangleRuntime colored = new();
+        colored.Width = 80; colored.Height = 56;
+        colored.FillColor = Color.Goldenrod;
+        colored.HasDropshadow = true;
+        colored.DropshadowColor = new Color(220, 40, 160, 220);
+        colored.DropshadowOffsetX = 6;
+        colored.DropshadowOffsetY = 6;
+        colored.DropshadowBlurX = 6;
+        colored.DropshadowBlurY = 6;
+        row.AddChild(colored);
+
+        return row;
+    }
+
+    // Issue #2818 — mirror of CirclesScreen.BuildDashedStrokeRow. Dashing applies to the
+    // stroke slot only; the Apos RoundedRectangle's RenderDashed path is guarded by !IsFilled.
+    static ContainerRuntime BuildDashedStrokeRow()
+    {
+        ContainerRuntime row = BuildHorizontalRow();
+
+        RectangleRuntime solid = new();
+        solid.Width = 80; solid.Height = 56;
+        solid.StrokeColor = Color.White;
+        solid.StrokeWidth = 2;
+        row.AddChild(solid);
+
+        RectangleRuntime short64 = new();
+        short64.Width = 80; short64.Height = 56;
+        short64.StrokeColor = Color.White;
+        short64.StrokeWidth = 2;
+        short64.StrokeDashLength = 6;
+        short64.StrokeGapLength = 4;
+        row.AddChild(short64);
+
+        RectangleRuntime dotted = new();
+        dotted.Width = 80; dotted.Height = 56;
+        dotted.StrokeColor = Color.White;
+        dotted.StrokeWidth = 1;
+        dotted.StrokeDashLength = 2;
+        dotted.StrokeGapLength = 2;
+        row.AddChild(dotted);
+
+        RectangleRuntime longDash = new();
+        longDash.Width = 80; longDash.Height = 56;
+        longDash.StrokeColor = Color.LightGreen;
+        longDash.StrokeWidth = 3;
+        longDash.StrokeDashLength = 12;
+        longDash.StrokeGapLength = 6;
+        row.AddChild(longDash);
+
         return row;
     }
 

--- a/Samples/SilkNetGum/SilkNetGum/Screens/RectanglesScreen.cs
+++ b/Samples/SilkNetGum/SilkNetGum/Screens/RectanglesScreen.cs
@@ -43,7 +43,7 @@ internal class RectanglesScreen : GraphicalUiElement
 
         left.Children.Add(BuildSection("Sizes (40, 60, 90, 130 wide) — default outline", BuildSizesRow()));
         left.Children.Add(BuildSection("Alpha on StrokeColor (255, 192, 128, 64)", BuildAlphaRow()));
-        left.Children.Add(BuildSection("Modes: FillColor, StrokeColor, default", BuildModeRow()));
+        left.Children.Add(BuildSection("Modes: FillColor, StrokeColor, Fill+Stroke, default", BuildModeRow()));
         left.Children.Add(BuildSection("StrokeWidth (1, 2, 4, 8 px)", BuildStrokeWidthRow()));
         left.Children.Add(BuildSection("Alignment inside a 128x100 frame (Top / Center / Bottom)", BuildAlignmentRow()));
         left.Children.Add(BuildSection("CornerRadius (0, 6, 16, 28) — exercises RoundedRectangleRuntime (#2814)", BuildCornerRadiusRow()));
@@ -129,8 +129,15 @@ internal class RectanglesScreen : GraphicalUiElement
         RectangleRuntime stroked = new();
         stroked.Width = 80; stroked.Height = 50;
         stroked.StrokeColor = SKColors.Cyan;
-        stroked.StrokeWidth = 3;
+        stroked.StrokeWidth = 2;
         row.Children.Add(stroked);
+
+        RectangleRuntime both = new();
+        both.Width = 80; both.Height = 50;
+        both.FillColor = new SKColor(40, 40, 80);
+        both.StrokeColor = SKColors.Yellow;
+        both.StrokeWidth = 2;
+        row.Children.Add(both);
 
         RectangleRuntime defaultRect = new();
         defaultRect.Width = 80; defaultRect.Height = 50;

--- a/Samples/SilkNetGum/SilkNetGum/Screens/RectanglesScreen.cs
+++ b/Samples/SilkNetGum/SilkNetGum/Screens/RectanglesScreen.cs
@@ -47,6 +47,7 @@ internal class RectanglesScreen : GraphicalUiElement
         left.Children.Add(BuildSection("StrokeWidth (1, 2, 4, 8 px)", BuildStrokeWidthRow()));
         left.Children.Add(BuildSection("Alignment inside a 128x100 frame (Top / Center / Bottom)", BuildAlignmentRow()));
         left.Children.Add(BuildSection("CornerRadius (0, 6, 16, 28) — exercises RoundedRectangleRuntime (#2814)", BuildCornerRadiusRow()));
+        left.Children.Add(BuildSection("Per-corner radii on RectangleRuntime (TL=20, TR=2, BR=20, BL=2 — #2818)", BuildPerCornerRow()));
         left.Children.Add(BuildSection("Gradients (linear / radial / diagonal / centered)", BuildGradientRow()));
 
         right.Children.Add(BuildSection("Antialiasing (default ON, then OFF) — 1 px stroke makes the bloom obvious (#2798)", BuildAntialiasingRow()));
@@ -180,6 +181,25 @@ internal class RectanglesScreen : GraphicalUiElement
             rect.CornerRadius = cornerRadius;
             row.Children.Add(rect);
         }
+        return row;
+    }
+
+    // Issue #2818 — RectangleRuntime now exposes per-corner radii on Skia (the contained type
+    // was swapped from LineRectangle to RoundedRectangle to make this possible). Pushed to
+    // both fill and stroke slots in PreRender so the outline matches the fill.
+    static ContainerRuntime BuildPerCornerRow()
+    {
+        ContainerRuntime row = BuildHorizontalRow();
+        RectangleRuntime rect = new();
+        rect.Width = 120; rect.Height = 70;
+        rect.FillColor = new SKColor(40, 40, 80);
+        rect.StrokeColor = SKColors.Orange;
+        rect.StrokeWidth = 2;
+        rect.CustomRadiusTopLeft = 20;
+        rect.CustomRadiusTopRight = 2;
+        rect.CustomRadiusBottomRight = 20;
+        rect.CustomRadiusBottomLeft = 2;
+        row.Children.Add(rect);
         return row;
     }
 

--- a/Tests/MonoGameGum.Shapes.Tests/RectangleRuntimeTests.cs
+++ b/Tests/MonoGameGum.Shapes.Tests/RectangleRuntimeTests.cs
@@ -1,3 +1,4 @@
+using Gum.Converters;
 using Gum.DataTypes;
 using Gum.GueDeriving;
 using Microsoft.Xna.Framework;
@@ -104,5 +105,165 @@ public class RectangleRuntimeTests
         asRenderable.PreRender();
 
         stroke.StrokeWidth.ShouldBe(7f);
+    }
+
+    // Issue #2818: gradient props on RectangleRuntime push through to both Apos RoundedRectangles
+    // so a single gradient can paint fill and stroke at once (mirror of CircleRuntime #2791).
+    [Fact]
+    public void Gradient_PropertiesPushedToBothFillAndStrokeSlots()
+    {
+        RectangleRuntime sut = new();
+
+        sut.UseGradient = true;
+        sut.GradientType = GradientType.Linear;
+        sut.Color1 = Color.Red;
+        sut.Color2 = Color.Blue;
+        sut.GradientX2 = 56;
+        sut.GradientInnerRadius = 4;
+        sut.GradientInnerRadiusUnits = DimensionUnitType.Absolute;
+
+        RoundedRectangle fill = (RoundedRectangle)sut.RenderableComponent;
+        RoundedRectangle stroke = (RoundedRectangle)fill.Children[0];
+
+        fill.UseGradient.ShouldBeTrue();
+        stroke.UseGradient.ShouldBeTrue();
+        fill.GradientType.ShouldBe(GradientType.Linear);
+        stroke.GradientType.ShouldBe(GradientType.Linear);
+        fill.Red1.ShouldBe(Color.Red.R);
+        stroke.Red1.ShouldBe(Color.Red.R);
+        fill.Blue2.ShouldBe(Color.Blue.B);
+        stroke.Blue2.ShouldBe(Color.Blue.B);
+        fill.GradientX2.ShouldBe(56);
+        stroke.GradientX2.ShouldBe(56);
+        fill.GradientInnerRadius.ShouldBe(4);
+        stroke.GradientInnerRadius.ShouldBe(4);
+    }
+
+    // Issue #2818: dropshadow pushes to the fill slot only (with fallback to stroke when fill
+    // is null) — pushing to BOTH slots would render the shadow twice and visibly double up.
+    [Fact]
+    public void Dropshadow_PropertiesPushedToFillSlotOnly_NotStroke()
+    {
+        RectangleRuntime sut = new();
+
+        sut.HasDropshadow = true;
+        sut.DropshadowColor = new Color(10, 20, 30, 40);
+        sut.DropshadowOffsetX = 5;
+        sut.DropshadowOffsetY = 7;
+        sut.DropshadowBlurX = 2;
+        sut.DropshadowBlurY = 4;
+
+        RoundedRectangle fill = (RoundedRectangle)sut.RenderableComponent;
+        RoundedRectangle stroke = (RoundedRectangle)fill.Children[0];
+
+        fill.HasDropshadow.ShouldBeTrue();
+        fill.DropshadowColor.ShouldBe(new Color(10, 20, 30, 40));
+        fill.DropshadowOffsetX.ShouldBe(5);
+        fill.DropshadowOffsetY.ShouldBe(7);
+        fill.DropshadowBlurX.ShouldBe(2);
+        fill.DropshadowBlurY.ShouldBe(4);
+
+        stroke.HasDropshadow.ShouldBeFalse();
+    }
+
+    // Issue #2818: dashed-stroke props push to stroke slot only via PreRender (mirror of
+    // CircleRuntime #2796). Fill slot must stay 0 because RenderDashed is guarded by !IsFilled.
+    [Fact]
+    public void DashedStroke_PushedViaPreRender_ToStrokeSlotOnly()
+    {
+        RectangleRuntime sut = new();
+        sut.StrokeColor = Color.White;
+        sut.StrokeWidth = 1;
+        sut.StrokeWidthUnits = DimensionUnitType.Absolute;
+        sut.StrokeDashLength = 6;
+        sut.StrokeGapLength = 4;
+
+        RoundedRectangle fill = (RoundedRectangle)sut.RenderableComponent;
+        RoundedRectangle stroke = (RoundedRectangle)fill.Children[0];
+        IRenderable asStrokeRenderable = stroke;
+        asStrokeRenderable.PreRender();
+
+        stroke.StrokeDashLength.ShouldBe(6f);
+        stroke.StrokeGapLength.ShouldBe(4f);
+        fill.StrokeDashLength.ShouldBe(0f);
+        fill.StrokeGapLength.ShouldBe(0f);
+    }
+
+    // Issue #2818: IsAntialiased pushes through to both slots via PreRender (mirror of
+    // CircleRuntime #2798).
+    [Fact]
+    public void IsAntialiased_PushedViaPreRender_ToBothFillAndStrokeSlots()
+    {
+        RectangleRuntime sut = new();
+
+        sut.IsAntialiased = false;
+
+        RoundedRectangle fill = (RoundedRectangle)sut.RenderableComponent;
+        RoundedRectangle stroke = (RoundedRectangle)fill.Children[0];
+        IRenderable asFillRenderable = fill;
+        asFillRenderable.PreRender();
+
+        fill.IsAntialiased.ShouldBeFalse();
+        stroke.IsAntialiased.ShouldBeFalse();
+    }
+
+    // Issue #2818: per-corner radii push to both slots so the outline matches the fill.
+    [Fact]
+    public void PerCornerRadii_PushedToBothSlots()
+    {
+        RectangleRuntime sut = new();
+
+        sut.CustomRadiusTopLeft = 1f;
+        sut.CustomRadiusTopRight = 2f;
+        sut.CustomRadiusBottomLeft = 3f;
+        sut.CustomRadiusBottomRight = 4f;
+
+        RoundedRectangle fill = (RoundedRectangle)sut.RenderableComponent;
+        RoundedRectangle stroke = (RoundedRectangle)fill.Children[0];
+
+        fill.CustomRadiusTopLeft.ShouldBe(1f);
+        fill.CustomRadiusTopRight.ShouldBe(2f);
+        fill.CustomRadiusBottomLeft.ShouldBe(3f);
+        fill.CustomRadiusBottomRight.ShouldBe(4f);
+        stroke.CustomRadiusTopLeft.ShouldBe(1f);
+        stroke.CustomRadiusTopRight.ShouldBe(2f);
+        stroke.CustomRadiusBottomLeft.ShouldBe(3f);
+        stroke.CustomRadiusBottomRight.ShouldBe(4f);
+    }
+
+    // Issue #2818: Clone re-resolves fresh fill/stroke slots so the clone is independent.
+    [Fact]
+    public void Clone_BothSlots_AreFreshFactoryInstances_NotShallowCopiesOfSource()
+    {
+        RectangleRuntime source = new();
+        source.FillColor = Color.Red;
+        source.StrokeColor = Color.Blue;
+
+        RectangleRuntime clone = (RectangleRuntime)source.Clone();
+
+        RoundedRectangle sourceFill = (RoundedRectangle)source.RenderableComponent;
+        RoundedRectangle cloneFill = (RoundedRectangle)clone.RenderableComponent;
+        RoundedRectangle sourceStroke = (RoundedRectangle)sourceFill.Children[0];
+        RoundedRectangle cloneStroke = (RoundedRectangle)cloneFill.Children[0];
+
+        cloneFill.ShouldNotBeSameAs(sourceFill);
+        cloneStroke.ShouldNotBeSameAs(sourceStroke);
+    }
+
+    [Fact]
+    public void Clone_MutatingClone_DoesNotMutateSource()
+    {
+        RectangleRuntime source = new();
+        source.FillColor = Color.Red;
+        source.StrokeColor = Color.Blue;
+
+        RectangleRuntime clone = (RectangleRuntime)source.Clone();
+        clone.FillColor = Color.Green;
+        clone.StrokeColor = Color.Yellow;
+
+        RoundedRectangle sourceFill = (RoundedRectangle)source.RenderableComponent;
+        RoundedRectangle sourceStroke = (RoundedRectangle)sourceFill.Children[0];
+        sourceFill.Color.ShouldBe(Color.Red);
+        sourceStroke.Color.ShouldBe(Color.Blue);
     }
 }

--- a/Tests/MonoGameGum.Shapes.Tests/RectangleRuntimeTests.cs
+++ b/Tests/MonoGameGum.Shapes.Tests/RectangleRuntimeTests.cs
@@ -83,6 +83,7 @@ public class RectangleRuntimeTests
         sut.StrokeColor = Color.Green;
         sut.StrokeWidth = 5f;
         sut.StrokeWidthUnits = DimensionUnitType.Absolute;
+        sut.IsAntialiased = false;
 
         RoundedRectangle fill = (RoundedRectangle)sut.RenderableComponent;
         RoundedRectangle stroke = (RoundedRectangle)fill.Children[0];
@@ -99,12 +100,53 @@ public class RectangleRuntimeTests
         sut.StrokeColor = Color.Green;
         sut.StrokeWidth = 7f;
         sut.StrokeWidthUnits = DimensionUnitType.Absolute;
+        // IsAntialiased = false skips the Apos AA-bloom compensation so this test asserts
+        // exact propagation. Compensation math is covered in StrokeWidth_AaOn_* below.
+        sut.IsAntialiased = false;
 
         RoundedRectangle stroke = (RoundedRectangle)((RoundedRectangle)sut.RenderableComponent).Children[0];
         IRenderable asRenderable = stroke;
         asRenderable.PreRender();
 
         stroke.StrokeWidth.ShouldBe(7f);
+    }
+
+    // Issue #2818 (mirror of CircleRuntime #2790) — Apos.Shapes' DrawRectangle adds aaSize
+    // pixels of halo OUTSIDE the nominal stroke thickness, same as DrawCircle. Skia fits AA
+    // WITHIN the thickness, so RectangleRuntime subtracts the 1 px AA contribution before
+    // pushing for visual parity on axis-aligned 1-px borders.
+    [Fact]
+    public void StrokeWidth_AaOn_SubtractsAaContributionBeforePushingToAposStroke()
+    {
+        RectangleRuntime sut = new();
+        sut.StrokeColor = Color.Green;
+        sut.StrokeWidth = 4f;
+        sut.StrokeWidthUnits = DimensionUnitType.Absolute;
+        sut.IsAntialiased = true;
+
+        RoundedRectangle stroke = (RoundedRectangle)((RoundedRectangle)sut.RenderableComponent).Children[0];
+        IRenderable asRenderable = stroke;
+        asRenderable.PreRender();
+
+        stroke.StrokeWidth.ShouldBe(3f);
+    }
+
+    [Fact]
+    public void StrokeWidth_AaOn_AtOnePixel_PushesEpsilonForPureAaHalo()
+    {
+        RectangleRuntime sut = new();
+        sut.StrokeColor = Color.Green;
+        sut.StrokeWidth = 1f;
+        sut.StrokeWidthUnits = DimensionUnitType.Absolute;
+        sut.IsAntialiased = true;
+
+        RoundedRectangle stroke = (RoundedRectangle)((RoundedRectangle)sut.RenderableComponent).Children[0];
+        IRenderable asRenderable = stroke;
+        asRenderable.PreRender();
+
+        stroke.StrokeWidth.ShouldBeGreaterThan(0f);
+        stroke.StrokeWidth.ShouldBeLessThan(0.1f);
+        stroke.IsAntialiased.ShouldBeTrue();
     }
 
     // Issue #2818: gradient props on RectangleRuntime push through to both Apos RoundedRectangles

--- a/Tests/SkiaGum.Tests/GueDeriving/RectangleRuntimeTests.cs
+++ b/Tests/SkiaGum.Tests/GueDeriving/RectangleRuntimeTests.cs
@@ -30,8 +30,8 @@ public class RectangleRuntimeTests
         clone.FillColor = SKColors.Green;
         clone.StrokeColor = SKColors.Yellow;
 
-        LineRectangle sourceFill = (LineRectangle)source.RenderableComponent;
-        LineRectangle sourceStroke = (LineRectangle)sourceFill.Children.Single();
+        RoundedRectangle sourceFill = (RoundedRectangle)source.RenderableComponent;
+        RoundedRectangle sourceStroke = (RoundedRectangle)sourceFill.Children.Single();
         sourceFill.Color.ShouldBe(SKColors.Red);
         sourceStroke.Color.ShouldBe(SKColors.Blue);
     }
@@ -45,10 +45,10 @@ public class RectangleRuntimeTests
 
         RectangleRuntime clone = (RectangleRuntime)source.Clone();
 
-        LineRectangle sourceFill = (LineRectangle)source.RenderableComponent;
-        LineRectangle cloneFill = (LineRectangle)clone.RenderableComponent;
-        LineRectangle sourceStroke = (LineRectangle)sourceFill.Children.Single();
-        LineRectangle cloneStroke = (LineRectangle)cloneFill.Children.Single();
+        RoundedRectangle sourceFill = (RoundedRectangle)source.RenderableComponent;
+        RoundedRectangle cloneFill = (RoundedRectangle)clone.RenderableComponent;
+        RoundedRectangle sourceStroke = (RoundedRectangle)sourceFill.Children.Single();
+        RoundedRectangle cloneStroke = (RoundedRectangle)cloneFill.Children.Single();
 
         cloneFill.ShouldNotBeSameAs(sourceFill);
         cloneStroke.ShouldNotBeSameAs(sourceStroke);
@@ -60,18 +60,71 @@ public class RectangleRuntimeTests
         RectangleRuntime sut = new();
         sut.Color1 = new SKColor(10, 20, 30, 40);
 
-        LineRectangle fillSlot = (LineRectangle)sut.RenderableComponent;
-        LineRectangle strokeSlot = (LineRectangle)fillSlot.Children.Single();
+        RoundedRectangle fillSlot = (RoundedRectangle)sut.RenderableComponent;
+        RoundedRectangle strokeSlot = (RoundedRectangle)fillSlot.Children.Single();
         fillSlot.Red1.ShouldBe(10);
         strokeSlot.Red1.ShouldBe(10);
         strokeSlot.Alpha1.ShouldBe(40);
     }
 
     [Fact]
-    public void ContainedRenderable_ShouldBeLineRectangle()
+    public void ContainedRenderable_ShouldBeRoundedRectangle()
     {
         RectangleRuntime sut = new();
-        sut.RenderableComponent.ShouldBeOfType<LineRectangle>();
+        sut.RenderableComponent.ShouldBeOfType<RoundedRectangle>();
+    }
+
+    // Issue #2818: default CornerRadius = 0 keeps the historical hard-cornered visual even
+    // though the contained type is now RoundedRectangle (whose own ctor defaults to 5).
+    [Fact]
+    public void CornerRadius_ShouldBe0_ByDefault()
+    {
+        RectangleRuntime sut = new();
+
+        sut.CornerRadius.ShouldBe(0f);
+        RoundedRectangle fillSlot = (RoundedRectangle)sut.RenderableComponent;
+        fillSlot.CornerRadius.ShouldBe(0f);
+        RoundedRectangle strokeSlot = (RoundedRectangle)fillSlot.Children.Single();
+        strokeSlot.CornerRadius.ShouldBe(0f);
+    }
+
+    // Issue #2818: CornerRadius mirrors onto both slots each frame in PreRender so the outline
+    // traces the same rounded corners as the fill.
+    [Fact]
+    public void CornerRadius_PushedToBothSlots_InPreRender()
+    {
+        RectangleRuntime sut = new();
+        sut.CornerRadius = 8f;
+
+        sut.PreRender();
+
+        RoundedRectangle fillSlot = (RoundedRectangle)sut.RenderableComponent;
+        RoundedRectangle strokeSlot = (RoundedRectangle)fillSlot.Children.Single();
+        fillSlot.CornerRadius.ShouldBe(8f);
+        strokeSlot.CornerRadius.ShouldBe(8f);
+    }
+
+    [Fact]
+    public void PerCornerRadii_PushedToBothSlots_InPreRender()
+    {
+        RectangleRuntime sut = new();
+        sut.CustomRadiusTopLeft = 1f;
+        sut.CustomRadiusTopRight = 2f;
+        sut.CustomRadiusBottomLeft = 3f;
+        sut.CustomRadiusBottomRight = 4f;
+
+        sut.PreRender();
+
+        RoundedRectangle fillSlot = (RoundedRectangle)sut.RenderableComponent;
+        RoundedRectangle strokeSlot = (RoundedRectangle)fillSlot.Children.Single();
+        fillSlot.CustomRadiusTopLeft.ShouldBe(1f);
+        fillSlot.CustomRadiusTopRight.ShouldBe(2f);
+        fillSlot.CustomRadiusBottomLeft.ShouldBe(3f);
+        fillSlot.CustomRadiusBottomRight.ShouldBe(4f);
+        strokeSlot.CustomRadiusTopLeft.ShouldBe(1f);
+        strokeSlot.CustomRadiusTopRight.ShouldBe(2f);
+        strokeSlot.CustomRadiusBottomLeft.ShouldBe(3f);
+        strokeSlot.CustomRadiusBottomRight.ShouldBe(4f);
     }
 
     [Fact]
@@ -82,8 +135,8 @@ public class RectangleRuntimeTests
 
         sut.PreRender();
 
-        LineRectangle fillSlot = (LineRectangle)sut.RenderableComponent;
-        LineRectangle strokeSlot = (LineRectangle)fillSlot.Children.Single();
+        RoundedRectangle fillSlot = (RoundedRectangle)sut.RenderableComponent;
+        RoundedRectangle strokeSlot = (RoundedRectangle)fillSlot.Children.Single();
         strokeSlot.HasDropshadow.ShouldBeTrue();
         fillSlot.HasDropshadow.ShouldBeFalse();
     }
@@ -97,8 +150,8 @@ public class RectangleRuntimeTests
 
         sut.PreRender();
 
-        LineRectangle fillSlot = (LineRectangle)sut.RenderableComponent;
-        LineRectangle strokeSlot = (LineRectangle)fillSlot.Children.Single();
+        RoundedRectangle fillSlot = (RoundedRectangle)sut.RenderableComponent;
+        RoundedRectangle strokeSlot = (RoundedRectangle)fillSlot.Children.Single();
         fillSlot.HasDropshadow.ShouldBeTrue();
         strokeSlot.HasDropshadow.ShouldBeFalse();
     }
@@ -110,8 +163,8 @@ public class RectangleRuntimeTests
         sut.FillColor = SKColors.Red;
         sut.HasDropshadow = true;
         sut.PreRender();
-        LineRectangle fillSlot = (LineRectangle)sut.RenderableComponent;
-        LineRectangle strokeSlot = (LineRectangle)fillSlot.Children.Single();
+        RoundedRectangle fillSlot = (RoundedRectangle)sut.RenderableComponent;
+        RoundedRectangle strokeSlot = (RoundedRectangle)fillSlot.Children.Single();
         fillSlot.HasDropshadow.ShouldBeTrue();
 
         sut.FillColor = null;
@@ -135,8 +188,8 @@ public class RectangleRuntimeTests
         sut.FillColor = SKColors.Crimson;
         sut.StrokeColor = SKColors.Cyan;
 
-        LineRectangle fillSlot = (LineRectangle)sut.RenderableComponent;
-        LineRectangle strokeSlot = (LineRectangle)fillSlot.Children.Single();
+        RoundedRectangle fillSlot = (RoundedRectangle)sut.RenderableComponent;
+        RoundedRectangle strokeSlot = (RoundedRectangle)fillSlot.Children.Single();
 
         fillSlot.Color.ShouldBe(SKColors.Crimson);
         fillSlot.IsFilled.ShouldBeTrue();
@@ -151,8 +204,8 @@ public class RectangleRuntimeTests
         sut.StrokeColor = SKColors.Magenta;
         sut.FillColor = SKColors.Gold;
 
-        LineRectangle fillSlot = (LineRectangle)sut.RenderableComponent;
-        LineRectangle strokeSlot = (LineRectangle)fillSlot.Children.Single();
+        RoundedRectangle fillSlot = (RoundedRectangle)sut.RenderableComponent;
+        RoundedRectangle strokeSlot = (RoundedRectangle)fillSlot.Children.Single();
 
         fillSlot.Color.ShouldBe(SKColors.Gold);
         strokeSlot.Color.ShouldBe(SKColors.Magenta);
@@ -172,8 +225,8 @@ public class RectangleRuntimeTests
 
         sut.IsAntialiased = false;
 
-        LineRectangle fillSlot = (LineRectangle)sut.RenderableComponent;
-        LineRectangle strokeSlot = (LineRectangle)fillSlot.Children.Single();
+        RoundedRectangle fillSlot = (RoundedRectangle)sut.RenderableComponent;
+        RoundedRectangle strokeSlot = (RoundedRectangle)fillSlot.Children.Single();
         fillSlot.IsAntialiased.ShouldBeFalse();
         strokeSlot.IsAntialiased.ShouldBeFalse();
     }
@@ -190,8 +243,8 @@ public class RectangleRuntimeTests
 
         sut.PreRender();
 
-        LineRectangle fillSlot = (LineRectangle)sut.RenderableComponent;
-        LineRectangle strokeSlot = (LineRectangle)fillSlot.Children.Single();
+        RoundedRectangle fillSlot = (RoundedRectangle)sut.RenderableComponent;
+        RoundedRectangle strokeSlot = (RoundedRectangle)fillSlot.Children.Single();
         strokeSlot.Width.ShouldBe(fillSlot.Width);
         strokeSlot.Height.ShouldBe(fillSlot.Height);
         strokeSlot.IsOffsetAppliedForStroke.ShouldBeTrue();
@@ -202,7 +255,7 @@ public class RectangleRuntimeTests
     {
         RectangleRuntime sut = new();
         sut.UseGradient = true;
-        LineRectangle fillSlot = (LineRectangle)sut.RenderableComponent;
+        RoundedRectangle fillSlot = (RoundedRectangle)sut.RenderableComponent;
         fillSlot.UseGradient.ShouldBeFalse();
 
         sut.FillColor = SKColors.White;
@@ -222,10 +275,10 @@ public class RectangleRuntimeTests
     {
         RectangleRuntime sut = new();
 
-        LineRectangle fillSlot = (LineRectangle)sut.RenderableComponent;
+        RoundedRectangle fillSlot = (RoundedRectangle)sut.RenderableComponent;
         fillSlot.Children.Count.ShouldBe(1);
 
-        LineRectangle strokeSlot = (LineRectangle)fillSlot.Children.Single();
+        RoundedRectangle strokeSlot = (RoundedRectangle)fillSlot.Children.Single();
         strokeSlot.IsFilled.ShouldBeFalse();
         fillSlot.IsFilled.ShouldBeTrue();
     }
@@ -239,8 +292,8 @@ public class RectangleRuntimeTests
 
         sut.PreRender();
 
-        LineRectangle fillSlot = (LineRectangle)sut.RenderableComponent;
-        LineRectangle strokeSlot = (LineRectangle)fillSlot.Children.Single();
+        RoundedRectangle fillSlot = (RoundedRectangle)sut.RenderableComponent;
+        RoundedRectangle strokeSlot = (RoundedRectangle)fillSlot.Children.Single();
         strokeSlot.StrokeWidth.ShouldBe(5);
     }
 
@@ -258,8 +311,8 @@ public class RectangleRuntimeTests
         sut.FillColor = SKColors.White;
         sut.UseGradient = true;
 
-        LineRectangle fillSlot = (LineRectangle)sut.RenderableComponent;
-        LineRectangle strokeSlot = (LineRectangle)fillSlot.Children.Single();
+        RoundedRectangle fillSlot = (RoundedRectangle)sut.RenderableComponent;
+        RoundedRectangle strokeSlot = (RoundedRectangle)fillSlot.Children.Single();
         fillSlot.UseGradient.ShouldBeTrue();
         strokeSlot.UseGradient.ShouldBeTrue();
     }
@@ -270,8 +323,8 @@ public class RectangleRuntimeTests
         RectangleRuntime sut = new();
         sut.UseGradient = true;
 
-        LineRectangle fillSlot = (LineRectangle)sut.RenderableComponent;
-        LineRectangle strokeSlot = (LineRectangle)fillSlot.Children.Single();
+        RoundedRectangle fillSlot = (RoundedRectangle)sut.RenderableComponent;
+        RoundedRectangle strokeSlot = (RoundedRectangle)fillSlot.Children.Single();
         fillSlot.UseGradient.ShouldBeFalse();
         strokeSlot.UseGradient.ShouldBeTrue();
     }


### PR DESCRIPTION
## Summary

Closes #2818. Implements all six Parts (A-F) from the issue:

- **Part A** — `MonoGameAndGum.Renderables.RoundedRectangle` declares `IGradientedRenderable` + `IAntialiasedRenderable` and implements `ICloneable`. `RenderDashed` picks up the same `aaSize` dash/gap inflation that `Circle.RenderDashed` got in #2790.
- **Part B** — `RectangleRuntime` XNALIKE branch gains `IsAntialiased`, full gradient region, full dropshadow region (single-slot via `DropshadowTarget`), `StrokeDashLength`/`StrokeGapLength`. `PreRender` pushes dash/gap to the stroke slot and AA to both slots.
- **Part C** — Skia `ContainedLineRectangle` alias swapped from `LineRectangle` to `RoundedRectangle` (decision 3). `RectangleRuntime` (Skia) adds `CornerRadius`/`CornerRadiusUnits`/`CustomRadius*` with a `PreRender` override that mirrors values onto both slots (ScreenPixel scaling honored). Default `CornerRadius = 0` keeps historical hard-cornered visual.
- **Part C (interfaces)** — `IFilledRectangleRenderable` / `IStrokedRectangleRenderable` + the core defaults gain `CustomRadius*` (stored, not rendered on the defaults).
- **Part D** — `Clone` override on XNALIKE that mirrors `CircleRuntime.Clone`. AA-bloom thickness compensation deferred per decision 1.
- **Part E** — Sample mirrors: `MonoGameGumInCode/RectanglesScreen` gains an Antialiasing row; `MonoGameGumShapesGallery/RectanglesScreen` replaces the N/A comment with real Gradient / Antialiasing / Dropshadow / Dashed / Per-corner rows; `SilkNetGum/RectanglesScreen` gains a per-corner row using the new Skia surface.
- **Part F** — `MonoGameGum.Shapes.Tests.RectangleRuntimeTests` gains gradient/dropshadow/dashed/AA/per-corner/Clone tests mirroring `CircleRuntimeTests`; `SkiaGum.Tests` `RectangleRuntimeTests` is updated for the RoundedRectangle swap plus new CornerRadius + per-corner tests.

## Test plan

- [x] `MonoGameGum` builds clean
- [x] `SkiaGum` builds clean
- [x] `MonoGameGumShapes` builds clean
- [x] `MonoGameGum.Shapes.Tests`: 48/48 pass
- [x] `SkiaGum.Tests`: 118/118 pass
- [x] `MonoGameGum.Tests` Runtime tests: 694/694 pass
- [x] `MonoGameGumShapesGallery`, `SilkNetGum`, `MonoGameGumInCode` samples build clean
- [x] Visual smoke: run the three updated sample screens and confirm new rows render as described (AA bloom on/off; dropshadow doesn't double; dashed strokes appear; per-corner radii produce asymmetric corners on both Apos and Skia)

🤖 Generated with [Claude Code](https://claude.com/claude-code)