### PR TITLE
#2757: raylib LineCircle fill/stroke/gradient + CirclesScreen sample

### DIFF
--- a/MonoGameGum/GueDeriving/CircleRuntime.cs
+++ b/MonoGameGum/GueDeriving/CircleRuntime.cs
@@ -335,6 +335,72 @@ public class CircleRuntime : GraphicalUiElement
             NotifyPropertyChanged();
         }
     }
+
+    /// <inheritdoc cref="Gum.Renderables.LineCircle.GradientX1"/>
+    public float GradientX1
+    {
+        get => ContainedLineCircle.GradientX1;
+        set
+        {
+            ContainedLineCircle.GradientX1 = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    /// <inheritdoc cref="Gum.Renderables.LineCircle.GradientY1"/>
+    public float GradientY1
+    {
+        get => ContainedLineCircle.GradientY1;
+        set
+        {
+            ContainedLineCircle.GradientY1 = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    /// <inheritdoc cref="Gum.Renderables.LineCircle.GradientX2"/>
+    public float GradientX2
+    {
+        get => ContainedLineCircle.GradientX2;
+        set
+        {
+            ContainedLineCircle.GradientX2 = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    /// <inheritdoc cref="Gum.Renderables.LineCircle.GradientY2"/>
+    public float GradientY2
+    {
+        get => ContainedLineCircle.GradientY2;
+        set
+        {
+            ContainedLineCircle.GradientY2 = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    /// <inheritdoc cref="Gum.Renderables.LineCircle.GradientInnerRadius"/>
+    public float GradientInnerRadius
+    {
+        get => ContainedLineCircle.GradientInnerRadius;
+        set
+        {
+            ContainedLineCircle.GradientInnerRadius = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    /// <inheritdoc cref="Gum.Renderables.LineCircle.GradientOuterRadius"/>
+    public float GradientOuterRadius
+    {
+        get => ContainedLineCircle.GradientOuterRadius;
+        set
+        {
+            ContainedLineCircle.GradientOuterRadius = value;
+            NotifyPropertyChanged();
+        }
+    }
 #endif
 
 #if XNALIKE
@@ -1119,9 +1185,11 @@ public class CircleRuntime : GraphicalUiElement
 
     /// <inheritdoc cref="PolygonRuntime.StrokeDashLength"/>
     /// <remarks>
-    /// Round-trips on Raylib/Sokol but renders as a no-op — <c>LineCircle</c> has no dash
-    /// concept. Skia honors the lengths verbatim; XNALIKE with MonoGameGumShapes routes
-    /// through the Apos stroke slot.
+    /// On Raylib (#2757) the value is pushed to the contained <see cref="Gum.Renderables.LineCircle"/>,
+    /// which renders the dashed pattern as a loop of <c>DrawRing</c> arcs. On Sokol the
+    /// renderable has no dash support yet, so the value round-trips but is visually inert.
+    /// Skia honors the lengths verbatim; XNALIKE with MonoGameGumShapes routes through the
+    /// Apos stroke slot.
     /// </remarks>
     public float StrokeDashLength
     {
@@ -1129,6 +1197,9 @@ public class CircleRuntime : GraphicalUiElement
         set
         {
             _strokeDashLength = value;
+#if RAYLIB
+            ContainedLineCircle.StrokeDashLength = value;
+#endif
             NotifyPropertyChanged();
         }
     }
@@ -1142,6 +1213,133 @@ public class CircleRuntime : GraphicalUiElement
         set
         {
             _strokeGapLength = value;
+#if RAYLIB
+            ContainedLineCircle.StrokeGapLength = value;
+#endif
+            NotifyPropertyChanged();
+        }
+    }
+
+    // #2757 dropshadow on raylib (#12 follow-up). Approximated via concentric semi-transparent
+    // rings on the renderable side — no shader, no render-to-texture. Anisotropic blur
+    // collapses to max(BlurX, BlurY); the per-axis props are kept for API parity with Skia/MG.
+    // Backing fields live on the runtime so values round-trip on Sokol (renderable has no
+    // dropshadow support there); RAYLIB pushes to the renderable.
+
+    bool _hasDropshadow;
+    /// <inheritdoc cref="Gum.Renderables.LineCircle.HasDropshadow"/>
+    public bool HasDropshadow
+    {
+        get => _hasDropshadow;
+        set
+        {
+            _hasDropshadow = value;
+#if RAYLIB
+            ContainedLineCircle.HasDropshadow = value;
+#endif
+            NotifyPropertyChanged();
+        }
+    }
+
+    Color _dropshadowColor = new Color((byte)0, (byte)0, (byte)0, (byte)255);
+    /// <inheritdoc cref="Gum.Renderables.LineCircle.DropshadowColor"/>
+    public Color DropshadowColor
+    {
+        get => _dropshadowColor;
+        set
+        {
+            _dropshadowColor = value;
+#if RAYLIB
+            ContainedLineCircle.DropshadowColor = value;
+#endif
+            NotifyPropertyChanged();
+        }
+    }
+
+    /// <summary>Alpha channel of <see cref="DropshadowColor"/>.</summary>
+    public int DropshadowAlpha
+    {
+        get => _dropshadowColor.A;
+        set => DropshadowColor = new Color(_dropshadowColor.R, _dropshadowColor.G, _dropshadowColor.B, (byte)value);
+    }
+
+    /// <summary>Red channel of <see cref="DropshadowColor"/>.</summary>
+    public int DropshadowRed
+    {
+        get => _dropshadowColor.R;
+        set => DropshadowColor = new Color((byte)value, _dropshadowColor.G, _dropshadowColor.B, _dropshadowColor.A);
+    }
+
+    /// <summary>Green channel of <see cref="DropshadowColor"/>.</summary>
+    public int DropshadowGreen
+    {
+        get => _dropshadowColor.G;
+        set => DropshadowColor = new Color(_dropshadowColor.R, (byte)value, _dropshadowColor.B, _dropshadowColor.A);
+    }
+
+    /// <summary>Blue channel of <see cref="DropshadowColor"/>.</summary>
+    public int DropshadowBlue
+    {
+        get => _dropshadowColor.B;
+        set => DropshadowColor = new Color(_dropshadowColor.R, _dropshadowColor.G, (byte)value, _dropshadowColor.A);
+    }
+
+    float _dropshadowOffsetX;
+    /// <inheritdoc cref="Gum.Renderables.LineCircle.DropshadowOffsetX"/>
+    public float DropshadowOffsetX
+    {
+        get => _dropshadowOffsetX;
+        set
+        {
+            _dropshadowOffsetX = value;
+#if RAYLIB
+            ContainedLineCircle.DropshadowOffsetX = value;
+#endif
+            NotifyPropertyChanged();
+        }
+    }
+
+    float _dropshadowOffsetY;
+    /// <inheritdoc cref="Gum.Renderables.LineCircle.DropshadowOffsetY"/>
+    public float DropshadowOffsetY
+    {
+        get => _dropshadowOffsetY;
+        set
+        {
+            _dropshadowOffsetY = value;
+#if RAYLIB
+            ContainedLineCircle.DropshadowOffsetY = value;
+#endif
+            NotifyPropertyChanged();
+        }
+    }
+
+    float _dropshadowBlurX;
+    /// <inheritdoc cref="Gum.Renderables.LineCircle.DropshadowBlurX"/>
+    public float DropshadowBlurX
+    {
+        get => _dropshadowBlurX;
+        set
+        {
+            _dropshadowBlurX = value;
+#if RAYLIB
+            ContainedLineCircle.DropshadowBlurX = value;
+#endif
+            NotifyPropertyChanged();
+        }
+    }
+
+    float _dropshadowBlurY;
+    /// <inheritdoc cref="Gum.Renderables.LineCircle.DropshadowBlurY"/>
+    public float DropshadowBlurY
+    {
+        get => _dropshadowBlurY;
+        set
+        {
+            _dropshadowBlurY = value;
+#if RAYLIB
+            ContainedLineCircle.DropshadowBlurY = value;
+#endif
             NotifyPropertyChanged();
         }
     }

--- a/MonoGameGum/GueDeriving/CircleRuntime.cs
+++ b/MonoGameGum/GueDeriving/CircleRuntime.cs
@@ -249,6 +249,94 @@ public class CircleRuntime : GraphicalUiElement
     }
 #endif
 
+#if RAYLIB
+    // Issue #2757 — surface the same property names the XNALIKE/SKIA branches expose so the
+    // cross-backend Circle gallery compiles against raylib too. Setters push to the contained
+    // LineCircle, whose Render() handles the fill/stroke/gradient composition. Visual support
+    // is intentionally a subset of MG/Skia in this pass — linear gradients, dashed strokes,
+    // dropshadow, per-shape AA, and StrokeWidthUnits scaling are not yet implemented on the
+    // raylib renderable (tracked as #2757 follow-ups). The runtime does not expose those
+    // properties at all yet; the raylib sample (CirclesScreen) renders only the supported
+    // sections.
+
+    /// <inheritdoc cref="Gum.Renderables.LineCircle.FillColor"/>
+    public Color? FillColor
+    {
+        get => ContainedLineCircle.FillColor;
+        set
+        {
+            ContainedLineCircle.FillColor = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    /// <inheritdoc cref="Gum.Renderables.LineCircle.StrokeColor"/>
+    public Color? StrokeColor
+    {
+        get => ContainedLineCircle.StrokeColor;
+        set
+        {
+            ContainedLineCircle.StrokeColor = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    /// <inheritdoc cref="Gum.Renderables.LineCircle.IsFilled"/>
+    public bool IsFilled
+    {
+        get => ContainedLineCircle.IsFilled;
+        set
+        {
+            ContainedLineCircle.IsFilled = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    /// <inheritdoc cref="Gum.Renderables.LineCircle.UseGradient"/>
+    public bool UseGradient
+    {
+        get => ContainedLineCircle.UseGradient;
+        set
+        {
+            ContainedLineCircle.UseGradient = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    /// <inheritdoc cref="Gum.Renderables.LineCircle.GradientType"/>
+    public GradientType GradientType
+    {
+        get => ContainedLineCircle.GradientType;
+        set
+        {
+            ContainedLineCircle.GradientType = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    /// <inheritdoc cref="Gum.Renderables.LineCircle.Color1"/>
+    public Color Color1
+    {
+        get => ContainedLineCircle.Color1;
+        set
+        {
+            ContainedLineCircle.Color1 = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    /// <inheritdoc cref="Gum.Renderables.LineCircle.Color2"/>
+    public Color Color2
+    {
+        get => ContainedLineCircle.Color2;
+        set
+        {
+            ContainedLineCircle.Color2 = value;
+            NotifyPropertyChanged();
+        }
+    }
+#endif
+
 #if XNALIKE
     Color? _fillColor;
 
@@ -995,11 +1083,11 @@ public class CircleRuntime : GraphicalUiElement
 
     /// <inheritdoc cref="CircleRuntime.StrokeWidth"/>
     /// <remarks>
-    /// Issue #2757 cross-backend API parity. On Raylib/Sokol the contained
-    /// <see cref="Gum.Renderables.LineCircle"/> renders via <c>DrawCircleLines</c> which is
-    /// hard-coded to a 1 px outline, so the backing field round-trips but the value is
-    /// visually inert until the renderable gains thick-stroke support — same forward-compat
-    /// pattern as MonoGameGum's <c>DefaultStrokedCircleRenderable</c> pre-Apos.Shapes.
+    /// Issue #2757 cross-backend API parity. On Raylib the value is pushed to the contained
+    /// <see cref="Gum.Renderables.LineCircle"/>, which routes thick strokes through raylib's
+    /// <c>DrawRing</c>. On Sokol the renderable has no thick-stroke support yet, so the value
+    /// round-trips but is visually inert (same forward-compat pattern as MonoGameGum's
+    /// <c>DefaultStrokedCircleRenderable</c> pre-Apos.Shapes).
     /// </remarks>
     public float StrokeWidth
     {
@@ -1007,6 +1095,9 @@ public class CircleRuntime : GraphicalUiElement
         set
         {
             _strokeWidth = value;
+#if RAYLIB
+            ContainedLineCircle.StrokeWidth = value;
+#endif
             NotifyPropertyChanged();
         }
     }

--- a/Runtimes/RaylibGum/Renderables/LineCircle.cs
+++ b/Runtimes/RaylibGum/Renderables/LineCircle.cs
@@ -1,5 +1,6 @@
 using RenderingLibrary;
 using RenderingLibrary.Graphics;
+using System.Numerics;
 using static Raylib_cs.Raylib;
 
 namespace Gum.Renderables;
@@ -13,14 +14,78 @@ public enum CircleOrigin
     TopLeft,
 }
 
-/// <summary>Stroked circle outline rendered using Raylib's DrawCircleLines.</summary>
+/// <summary>
+/// Raylib circle renderable. Originally a 1 px stroke-only outline via <c>DrawCircleLines</c>;
+/// extended in issue #2757 to also paint a filled disk, a variable-width stroke ring via
+/// <c>DrawRing</c>, and a centered radial gradient via <c>DrawCircleGradient</c>. The legacy
+/// <see cref="Color"/> / <see cref="Red"/> / <see cref="Green"/> / <see cref="Blue"/> /
+/// <see cref="Alpha"/> surface is preserved so the shared <c>CircleRuntime</c>'s raylib branch
+/// keeps working unchanged — when <see cref="FillColor"/> and <see cref="StrokeColor"/> are
+/// both <c>null</c> the render path collapses to the original behavior.
+/// </summary>
 public class LineCircle : InvisibleRenderable
 {
+    /// <inheritdoc cref="CircleOrigin"/>
     public CircleOrigin CircleOrigin { get; set; }
+
+    /// <summary>Radius in world-space pixels.</summary>
     public float Radius { get; set; }
 
+    /// <summary>
+    /// Legacy single-color slot used as the stroke color when <see cref="StrokeColor"/> is
+    /// <c>null</c>. Defaults to white so the pre-#2757 outline path renders the same as before.
+    /// </summary>
     public Color Color { get; set; } = Color.White;
 
+    /// <summary>
+    /// When <c>true</c>, draws a filled disk using <see cref="Color"/> (or <see cref="FillColor"/>
+    /// when set). Independent of the stroke pass — both fill and stroke may render in the same
+    /// <see cref="Render"/> call.
+    /// </summary>
+    public bool IsFilled { get; set; }
+
+    /// <summary>
+    /// Width of the stroke ring in world-space pixels. A value of 1 (the default) uses the
+    /// crisp <c>DrawCircleLines</c> path; larger values draw a ring via <c>DrawRing</c>.
+    /// </summary>
+    public float StrokeWidth { get; set; } = 1f;
+
+    /// <summary>
+    /// Explicit fill-pass color. When set, the fill pass runs regardless of <see cref="IsFilled"/>
+    /// — this is the raylib analog of Skia's two-slot composition (#2790). When <c>null</c>
+    /// the fill pass only runs if <see cref="IsFilled"/> is <c>true</c>, in which case
+    /// <see cref="Color"/> is used.
+    /// </summary>
+    public Color? FillColor { get; set; }
+
+    /// <summary>
+    /// Explicit stroke-pass color. When <c>null</c>, the stroke pass uses <see cref="Color"/>
+    /// (legacy behavior) — but only if no fill is rendered. When non-<c>null</c>, the stroke
+    /// always renders regardless of fill, enabling a filled disk with a contrasting outline.
+    /// </summary>
+    public Color? StrokeColor { get; set; }
+
+    /// <summary>
+    /// When <c>true</c>, the fill pass paints a centered radial gradient from <see cref="Color1"/>
+    /// at the center to <see cref="Color2"/> at the rim, via raylib's <c>DrawCircleGradient</c>.
+    /// Only <see cref="GradientType.Radial"/> is supported on raylib today — linear and
+    /// offset-center radial require a custom rlgl triangle fan (see issue #2757 follow-ups).
+    /// </summary>
+    public bool UseGradient { get; set; }
+
+    /// <summary>
+    /// Gradient mode. Only <see cref="GradientType.Radial"/> renders on raylib in this pass;
+    /// other values are accepted (the property round-trips) but fall back to a solid fill.
+    /// </summary>
+    public GradientType GradientType { get; set; }
+
+    /// <summary>Inner color for a radial gradient (painted at the circle's center).</summary>
+    public Color Color1 { get; set; } = Color.White;
+
+    /// <summary>Outer color for a radial gradient (painted at the rim).</summary>
+    public Color Color2 { get; set; } = Color.White;
+
+    /// <inheritdoc/>
     public override int Alpha
     {
         get => Color.A;
@@ -33,6 +98,7 @@ public class LineCircle : InvisibleRenderable
         }
     }
 
+    /// <summary>Red channel of the legacy <see cref="Color"/> slot.</summary>
     public int Red
     {
         get => Color.R;
@@ -45,6 +111,7 @@ public class LineCircle : InvisibleRenderable
         }
     }
 
+    /// <summary>Green channel of the legacy <see cref="Color"/> slot.</summary>
     public int Green
     {
         get => Color.G;
@@ -57,6 +124,7 @@ public class LineCircle : InvisibleRenderable
         }
     }
 
+    /// <summary>Blue channel of the legacy <see cref="Color"/> slot.</summary>
     public int Blue
     {
         get => Color.B;
@@ -69,10 +137,13 @@ public class LineCircle : InvisibleRenderable
         }
     }
 
+    /// <inheritdoc cref="LineCircle"/>
     public LineCircle() : this(null) { }
 
+    /// <inheritdoc cref="LineCircle"/>
     public LineCircle(SystemManagers? _) { }
 
+    /// <inheritdoc/>
     public override void Render(ISystemManagers managers)
     {
         if (!Visible)
@@ -93,6 +164,45 @@ public class LineCircle : InvisibleRenderable
             cy = this.GetAbsoluteTop();
         }
 
-        DrawCircleLines((int)cx, (int)cy, Radius, Color);
+        // Fill pass — runs when FillColor is set, or when IsFilled is true with no explicit
+        // FillColor (legacy Color slot supplies the fill color). Mirrors Skia's two-slot
+        // composition (#2790) where setting FillColor alone, StrokeColor alone, or both lights
+        // up the appropriate layers.
+        bool runFill = FillColor.HasValue || IsFilled;
+        if (runFill)
+        {
+            Color fillColor = FillColor ?? Color;
+            if (UseGradient && GradientType == GradientType.Radial)
+            {
+                // raylib's DrawCircleGradient interpolates Color1 at the center to Color2 at
+                // the rim — no offset-center, no inner radius. Offset and inner-radius variants
+                // need a custom rlgl triangle fan; tracked as a #2757 follow-up.
+                DrawCircleGradient((int)cx, (int)cy, Radius, Color1, Color2);
+            }
+            else
+            {
+                DrawCircle((int)cx, (int)cy, Radius, fillColor);
+            }
+        }
+
+        // Stroke pass — runs when StrokeColor is explicitly set (paired with fill), or when
+        // no fill ran (so the legacy outline path stays the default visible behavior). Stroke
+        // is inset entirely inside Radius (outer edge at Radius, inner edge at Radius -
+        // StrokeWidth) so the ring never bleeds past the nominal bounds — mirrors Skia's
+        // RenderableShapeBase.IsOffsetAppliedForStroke contract, which the #2790 gallery's
+        // "inscribed in 64x64 frame" row treats as the visual acceptance.
+        bool runStroke = StrokeColor.HasValue || !runFill;
+        if (runStroke)
+        {
+            Color strokeColor = StrokeColor ?? Color;
+            // Segment count scales with radius to keep the ring smooth at larger sizes; 36
+            // is the floor for small circles to avoid visible faceting. DrawRing is used for
+            // every stroke width (including 1 px) so the inset behavior stays uniform — the
+            // legacy DrawCircleLines path centered the line on Radius, which bled outward.
+            int segments = System.Math.Max(36, (int)(Radius * 2));
+            float innerRadius = System.Math.Max(0f, Radius - StrokeWidth);
+            DrawRing(new Vector2(cx, cy), innerRadius, Radius,
+                startAngle: 0f, endAngle: 360f, segments, strokeColor);
+        }
     }
 }

--- a/Runtimes/RaylibGum/Renderables/LineCircle.cs
+++ b/Runtimes/RaylibGum/Renderables/LineCircle.cs
@@ -66,24 +66,96 @@ public class LineCircle : InvisibleRenderable
     public Color? StrokeColor { get; set; }
 
     /// <summary>
-    /// When <c>true</c>, the fill pass paints a centered radial gradient from <see cref="Color1"/>
-    /// at the center to <see cref="Color2"/> at the rim, via raylib's <c>DrawCircleGradient</c>.
-    /// Only <see cref="GradientType.Radial"/> is supported on raylib today — linear and
-    /// offset-center radial require a custom rlgl triangle fan (see issue #2757 follow-ups).
+    /// When <c>true</c>, the fill pass paints a gradient from <see cref="Color1"/> to
+    /// <see cref="Color2"/> rather than a solid color. Both <see cref="GradientType.Linear"/>
+    /// and <see cref="GradientType.Radial"/> are supported (#2757 follow-ups #8 and #9);
+    /// rendering goes through an <c>rlgl</c> triangle fan with per-vertex colors computed
+    /// from <see cref="GradientX1"/>/<see cref="GradientY1"/>, <see cref="GradientX2"/>/<see cref="GradientY2"/>,
+    /// and (for radial) <see cref="GradientInnerRadius"/>/<see cref="GradientOuterRadius"/>.
     /// </summary>
     public bool UseGradient { get; set; }
 
     /// <summary>
-    /// Gradient mode. Only <see cref="GradientType.Radial"/> renders on raylib in this pass;
-    /// other values are accepted (the property round-trips) but fall back to a solid fill.
+    /// Gradient mode. <see cref="GradientType.Linear"/> uses (X1,Y1)→(X2,Y2) as the gradient
+    /// axis; <see cref="GradientType.Radial"/> uses (X1,Y1) as the center with InnerRadius/
+    /// OuterRadius as the falloff band.
     /// </summary>
     public GradientType GradientType { get; set; }
 
-    /// <summary>Inner color for a radial gradient (painted at the circle's center).</summary>
+    /// <summary>Start color (linear: at the axis start; radial: at the inner radius).</summary>
     public Color Color1 { get; set; } = Color.White;
 
-    /// <summary>Outer color for a radial gradient (painted at the rim).</summary>
+    /// <summary>End color (linear: at the axis end; radial: at the outer radius).</summary>
     public Color Color2 { get; set; } = Color.White;
+
+    /// <summary>
+    /// X coordinate of the gradient axis start (linear) or radial gradient center, in pixels
+    /// relative to the circle's bounding-box top-left. Default 0.
+    /// </summary>
+    public float GradientX1 { get; set; }
+
+    /// <summary>Y coordinate of <see cref="GradientX1"/>, same coord space.</summary>
+    public float GradientY1 { get; set; }
+
+    /// <summary>
+    /// X coordinate of the gradient axis end (linear only — ignored for radial).
+    /// </summary>
+    public float GradientX2 { get; set; }
+
+    /// <summary>Y coordinate of <see cref="GradientX2"/>.</summary>
+    public float GradientY2 { get; set; }
+
+    /// <summary>
+    /// Inner radius for a radial gradient — at this radius the color is <see cref="Color1"/>.
+    /// Default 0 (solid inner color at the gradient center).
+    /// </summary>
+    public float GradientInnerRadius { get; set; }
+
+    /// <summary>
+    /// Outer radius for a radial gradient — at this radius the color is <see cref="Color2"/>.
+    /// When 0 (the default), the circle's <see cref="Radius"/> is used so a default-configured
+    /// radial gradient covers the whole disk.
+    /// </summary>
+    public float GradientOuterRadius { get; set; }
+
+    /// <summary>
+    /// Length in world-space pixels of each dash segment around the ring's circumference.
+    /// A value of 0 (the default) draws a solid stroke. Both <see cref="StrokeDashLength"/>
+    /// and <see cref="StrokeGapLength"/> must be &gt; 0 for dashed rendering to engage.
+    /// Issue #2757 — implemented via a per-dash <c>DrawRing</c> arc loop.
+    /// </summary>
+    public float StrokeDashLength { get; set; }
+
+    /// <summary>
+    /// Length in world-space pixels of each gap between dashes. Ignored when
+    /// <see cref="StrokeDashLength"/> is 0.
+    /// </summary>
+    public float StrokeGapLength { get; set; }
+
+    /// <summary>
+    /// When <c>true</c>, a dropshadow pass renders behind the fill/stroke passes using
+    /// <see cref="DropshadowColor"/>, offset by <see cref="DropshadowOffsetX"/>/<see cref="DropshadowOffsetY"/>
+    /// with an isotropic blur radius of <c>max(DropshadowBlurX, DropshadowBlurY)</c>.
+    /// Issue #2757 — raylib has no shader-free blur primitive, so the blur is approximated
+    /// with concentric semi-transparent rings (raised-cosine falloff). Anisotropic blur
+    /// (BlurX ≠ BlurY) collapses to the larger of the two on raylib.
+    /// </summary>
+    public bool HasDropshadow { get; set; }
+
+    /// <summary>Color of the dropshadow disk (alpha channel scales the falloff).</summary>
+    public Color DropshadowColor { get; set; } = new Color((byte)0, (byte)0, (byte)0, (byte)255);
+
+    /// <summary>X offset of the dropshadow center in world-space pixels.</summary>
+    public float DropshadowOffsetX { get; set; }
+
+    /// <summary>Y offset of the dropshadow center in world-space pixels.</summary>
+    public float DropshadowOffsetY { get; set; }
+
+    /// <summary>Horizontal blur radius. Treated as isotropic with <see cref="DropshadowBlurY"/> on raylib.</summary>
+    public float DropshadowBlurX { get; set; }
+
+    /// <summary>Vertical blur radius. Treated as isotropic with <see cref="DropshadowBlurX"/> on raylib.</summary>
+    public float DropshadowBlurY { get; set; }
 
     /// <inheritdoc/>
     public override int Alpha
@@ -164,6 +236,41 @@ public class LineCircle : InvisibleRenderable
             cy = this.GetAbsoluteTop();
         }
 
+        // Dropshadow pre-pass — runs first so the shape draws over it. raylib has no
+        // SKImageFilter.CreateDropShadow equivalent and no shader-free blur primitive, so the
+        // blurred edge is approximated by N concentric rings of decreasing alpha around a
+        // solid core disk. Anisotropic blur collapses to max(BlurX, BlurY).
+        if (HasDropshadow && Radius > 0f)
+        {
+            float shadowCx = cx + DropshadowOffsetX;
+            float shadowCy = cy + DropshadowOffsetY;
+            float blur = System.MathF.Max(DropshadowBlurX, DropshadowBlurY);
+
+            DrawCircle((int)shadowCx, (int)shadowCy, Radius, DropshadowColor);
+
+            if (blur > 0f)
+            {
+                const int blurRings = 8;
+                Vector2 shadowCenter = new Vector2(shadowCx, shadowCy);
+                for (int i = 1; i <= blurRings; i++)
+                {
+                    float tInner = (float)(i - 1) / blurRings;
+                    float tOuter = (float)i / blurRings;
+                    float innerR = Radius + tInner * blur;
+                    float outerR = Radius + tOuter * blur;
+                    // Raised-cosine alpha at the band's outer edge — gives a smoother
+                    // Gaussian-like falloff than linear without doing any actual blur math.
+                    float alphaScale = 0.5f * (1f + System.MathF.Cos(System.MathF.PI * tOuter));
+                    byte ringAlpha = (byte)(DropshadowColor.A * alphaScale);
+                    Color ringColor = new Color(DropshadowColor.R, DropshadowColor.G,
+                        DropshadowColor.B, ringAlpha);
+                    int ringSegments = System.Math.Max(36, (int)(outerR * 2));
+                    DrawRing(shadowCenter, innerR, outerR,
+                        startAngle: 0f, endAngle: 360f, ringSegments, ringColor);
+                }
+            }
+        }
+
         // Fill pass — runs when FillColor is set, or when IsFilled is true with no explicit
         // FillColor (legacy Color slot supplies the fill color). Mirrors Skia's two-slot
         // composition (#2790) where setting FillColor alone, StrokeColor alone, or both lights
@@ -172,12 +279,17 @@ public class LineCircle : InvisibleRenderable
         if (runFill)
         {
             Color fillColor = FillColor ?? Color;
-            if (UseGradient && GradientType == GradientType.Radial)
+            if (UseGradient)
             {
-                // raylib's DrawCircleGradient interpolates Color1 at the center to Color2 at
-                // the rim — no offset-center, no inner radius. Offset and inner-radius variants
-                // need a custom rlgl triangle fan; tracked as a #2757 follow-up.
-                DrawCircleGradient((int)cx, (int)cy, Radius, Color1, Color2);
+                // #2757 follow-ups #8 (linear) and #9 (offset/inner-radius radial). Both go
+                // through an rlgl triangle fan with per-vertex colors — raylib's public
+                // DrawCircleGradient handles only centered, inner=0, outer=Radius radial, so
+                // we drop to immediate-mode for full coverage. Centered radial would still
+                // render correctly through DrawCircleGradient, but unifying the path keeps
+                // one tested branch instead of a fragile "is this the centered default?"
+                // detector. The fan structure matches raylib's own DrawCircle implementation
+                // in rshapes.c — center vertex + N rim vertices fan into N triangles.
+                DrawGradientFan(cx, cy, Radius);
             }
             else
             {
@@ -201,8 +313,129 @@ public class LineCircle : InvisibleRenderable
             // legacy DrawCircleLines path centered the line on Radius, which bled outward.
             int segments = System.Math.Max(36, (int)(Radius * 2));
             float innerRadius = System.Math.Max(0f, Radius - StrokeWidth);
-            DrawRing(new Vector2(cx, cy), innerRadius, Radius,
-                startAngle: 0f, endAngle: 360f, segments, strokeColor);
+            Vector2 center = new Vector2(cx, cy);
+            bool dashed = StrokeDashLength > 0f && StrokeGapLength > 0f && Radius > 0f;
+            if (dashed)
+            {
+                // Translate user-space dash/gap pixel lengths into arc angles around the
+                // ring's circumference. raylib has no built-in dash path effect (Skia's
+                // SKPathEffect.CreateDash, MG/Apos's RenderDashed); we emit each dash as a
+                // separate DrawRing arc instead.
+                float circumference = 2f * System.MathF.PI * Radius;
+                float dashAngleDeg = (StrokeDashLength / circumference) * 360f;
+                float gapAngleDeg = (StrokeGapLength / circumference) * 360f;
+                float patternAngleDeg = dashAngleDeg + gapAngleDeg;
+                // Per-dash segment count proportional to the dash arc — ~4° per segment is
+                // smooth at typical radii. Floor at 1 so tiny dashes (e.g. 2 px dotted) still
+                // render as at least one triangle pair.
+                int segmentsPerDash = System.Math.Max(1, (int)(dashAngleDeg / 4f));
+                float currentAngle = 0f;
+                while (currentAngle < 360f)
+                {
+                    float dashEnd = System.MathF.Min(currentAngle + dashAngleDeg, 360f);
+                    DrawRing(center, innerRadius, Radius,
+                        currentAngle, dashEnd, segmentsPerDash, strokeColor);
+                    currentAngle += patternAngleDeg;
+                }
+            }
+            else
+            {
+                DrawRing(center, innerRadius, Radius,
+                    startAngle: 0f, endAngle: 360f, segments, strokeColor);
+            }
         }
+    }
+
+    /// <summary>
+    /// Emits a triangle fan around (<paramref name="cx"/>, <paramref name="cy"/>) with per-vertex
+    /// colors computed from the user's gradient configuration. Mirrors the immediate-mode
+    /// pattern raylib itself uses for <c>DrawCircleGradient</c> in <c>rshapes.c</c> — N
+    /// segments × 3 vertices per triangle, color set via <see cref="Rlgl.Color4ub"/> before
+    /// each <see cref="Rlgl.Vertex2f"/>. The GPU rasterizes the per-vertex colors via
+    /// barycentric interpolation, giving smooth gradients across each triangle.
+    /// </summary>
+    /// <remarks>
+    /// Quality note: the center vertex contributes a single t-value to every fan triangle,
+    /// so very high-contrast linear gradients can show a faint "star" near the center where
+    /// adjacent triangles meet. Same artifact <c>DrawCircleGradient</c> has on raylib itself.
+    /// 36+ segments at typical radii is enough that the effect is invisible.
+    /// </remarks>
+    private void DrawGradientFan(float cx, float cy, float radius)
+    {
+        int segments = System.Math.Max(36, (int)(radius * 2));
+        // Gradient coords are circle-local (origin = bbox top-left). Cache the world-space
+        // bbox origin once so per-vertex projection only has to subtract.
+        float bboxLeft = cx - radius;
+        float bboxTop = cy - radius;
+
+        Rlgl.Begin((int)DrawMode.Triangles);
+        for (int i = 0; i < segments; i++)
+        {
+            float a0 = (i / (float)segments) * System.MathF.PI * 2f;
+            float a1 = ((i + 1) / (float)segments) * System.MathF.PI * 2f;
+            float v1x = cx + System.MathF.Cos(a0) * radius;
+            float v1y = cy + System.MathF.Sin(a0) * radius;
+            float v2x = cx + System.MathF.Cos(a1) * radius;
+            float v2y = cy + System.MathF.Sin(a1) * radius;
+
+            // Vertex order: center → later-angle → earlier-angle. Matches raylib's own
+            // DrawCircleGradient winding (src/rshapes.c). Reversing the two rim vertices
+            // produces back-facing triangles for raylib's default front-face setting, which
+            // get culled and render as nothing.
+            EmitGradientVertex(cx, cy, bboxLeft, bboxTop);
+            EmitGradientVertex(v2x, v2y, bboxLeft, bboxTop);
+            EmitGradientVertex(v1x, v1y, bboxLeft, bboxTop);
+        }
+        Rlgl.End();
+    }
+
+    private void EmitGradientVertex(float worldX, float worldY, float bboxLeft, float bboxTop)
+    {
+        float localX = worldX - bboxLeft;
+        float localY = worldY - bboxTop;
+
+        float t;
+        if (GradientType == GradientType.Linear)
+        {
+            // Project the vertex onto the gradient axis. Degenerate (zero-length) axis
+            // collapses to a solid Color1 — same fallback Skia's CreateLinearGradient takes.
+            float dx = GradientX2 - GradientX1;
+            float dy = GradientY2 - GradientY1;
+            float lenSq = dx * dx + dy * dy;
+            if (lenSq <= 0f)
+            {
+                Rlgl.Color4ub(Color1.R, Color1.G, Color1.B, Color1.A);
+                Rlgl.Vertex2f(worldX, worldY);
+                return;
+            }
+            t = ((localX - GradientX1) * dx + (localY - GradientY1) * dy) / lenSq;
+        }
+        else
+        {
+            // Radial: distance from (GradientX1, GradientY1) normalized against the
+            // [InnerRadius, OuterRadius] band. OuterRadius = 0 (default) collapses to the
+            // full circle radius so a no-config radial covers the whole disk.
+            float dx = localX - GradientX1;
+            float dy = localY - GradientY1;
+            float dist = System.MathF.Sqrt(dx * dx + dy * dy);
+            float outer = GradientOuterRadius > 0f ? GradientOuterRadius : Radius;
+            float span = outer - GradientInnerRadius;
+            if (span <= 0f)
+            {
+                Rlgl.Color4ub(Color2.R, Color2.G, Color2.B, Color2.A);
+                Rlgl.Vertex2f(worldX, worldY);
+                return;
+            }
+            t = (dist - GradientInnerRadius) / span;
+        }
+        if (t < 0f) t = 0f;
+        else if (t > 1f) t = 1f;
+
+        byte r = (byte)(Color1.R + (Color2.R - Color1.R) * t);
+        byte g = (byte)(Color1.G + (Color2.G - Color1.G) * t);
+        byte b = (byte)(Color1.B + (Color2.B - Color1.B) * t);
+        byte a = (byte)(Color1.A + (Color2.A - Color1.A) * t);
+        Rlgl.Color4ub(r, g, b, a);
+        Rlgl.Vertex2f(worldX, worldY);
     }
 }

--- a/Runtimes/RaylibGum/Renderables/Text.cs
+++ b/Runtimes/RaylibGum/Renderables/Text.cs
@@ -107,7 +107,16 @@ public class Text : IVisible, IRenderableIpso,
 
     bool IWrappedText.IsMidWordLineBreakEnabled => true;
 
-    //static Font defaultFont = Raylib.GetFontDefault();
+    /// <summary>
+    /// Project-wide default font for newly constructed <see cref="Text"/> renderables.
+    /// When unset (<c>BaseSize == 0</c>), the constructor falls back to raylib's built-in
+    /// pixel font via <see cref="GetFontDefault"/>. Set this once at startup — typically
+    /// after <c>LoadFontEx</c> — to make every <c>TextRuntime</c> created thereafter pick
+    /// up the chosen font, including instances that don't go through the Forms
+    /// <c>Styling</c> pipeline (e.g. raw <c>TextRuntime</c> headers in sample screens).
+    /// Issue #2757.
+    /// </summary>
+    public static Font DefaultFont { get; set; }
 
     public Vector2 Position;
     
@@ -588,7 +597,10 @@ public class Text : IVisible, IRenderableIpso,
 
     public Text(ISystemManagers? managers)
     {
-        Font = GetFontDefault();
+        // #2757 — consult the project-wide DefaultFont so non-Forms TextRuntime instances
+        // (e.g. raw section headers in sample screens) pick up the user-chosen font instead
+        // of raylib's tiny pixel default. BaseSize == 0 is the uninitialized-Font sentinel.
+        Font = DefaultFont.BaseSize > 0 ? DefaultFont : GetFontDefault();
         mChildren = new();
         Visible = true;
     }

--- a/Samples/raylib/Program.cs
+++ b/Samples/raylib/Program.cs
@@ -1,21 +1,24 @@
+using Gum.Converters;
 using Gum.Forms.Controls;
 using Gum.Forms.DefaultVisuals.V3;
 using Gum.Wireframe;
 using Raylib_cs;
 using RaylibGum;
 using RenderingLibrary;
+using RenderingLibrary.Graphics;
+using System;
+using System.Threading;
 using static Raylib_cs.Raylib;
 
 namespace Examples.Shapes;
 
 public class BasicShapes
 {
-    static Texture2D texture;
+    private const float NavStripHeight = 40;
 
     static GumService GumUI => GumService.Default;
 
-    static RawVisualsScreen rawVisualsScreen;
-    static FormsControlsScreen formsControlsScreen;
+    static StackPanel? navStrip;
     static FrameworkElement? activeScreen;
 
     public static void Main()
@@ -26,27 +29,25 @@ public class BasicShapes
         GumUI.CanvasWidth = screenWidth;
         GumUI.CanvasHeight = screenHeight;
 
-        InitWindow(screenWidth, screenHeight, "Basic shape and image drawing");
+        // 4x MSAA enables framebuffer-level antialiasing — raylib has no per-shape AA, so
+        // this is the only path to smooth circle/ring edges. Must be set BEFORE InitWindow
+        // (raylib only consults config flags at GL context creation).
+        SetConfigFlags(ConfigFlags.Msaa4xHint);
+        InitWindow(screenWidth, screenHeight, "Gum raylib gallery");
 
         GumUI.Initialize();
         var standardTexture = SystemManagers.Default.LoadEmbeddedTexture2d("UISpriteSheet.png");
 
         InitializeStyling();
-
-        rawVisualsScreen = new RawVisualsScreen();
-        formsControlsScreen = new FormsControlsScreen();
-
-        ShowScreen(rawVisualsScreen);
+        BuildNavStrip();
+        ShowScreen(() => new RawVisualsScreen());
 
         while (!WindowShouldClose())
         {
-            if (IsKeyPressed(KeyboardKey.Space))
-            {
-                ShowScreen(activeScreen == rawVisualsScreen ? formsControlsScreen : rawVisualsScreen);
-            }
-
             BeginDrawing();
-            ClearBackground(Color.SkyBlue);
+            // Matches MonoGameGumShapesGallery's clear color so visual diffs across galleries
+            // stay attributable to the shape code, not the page background.
+            ClearBackground(new Color(51, 76, 204, 255));
 
             GumUI.Update(GetTime());
             GumUI.Draw();
@@ -59,21 +60,69 @@ public class BasicShapes
         CloseWindow();
     }
 
-    private static void ShowScreen(FrameworkElement screen)
+    // Mirrors MonoGameGumShapesGallery/Game1.BuildNavStrip — horizontal Forms Button strip
+    // across the top swaps the active screen at runtime. Replaces the prior Space-key toggle
+    // so adding a screen (e.g. CirclesScreen for #2757) is a one-line registration.
+    private static void BuildNavStrip()
+    {
+        navStrip = new StackPanel();
+        navStrip.Orientation = Orientation.Horizontal;
+        navStrip.Spacing = 4;
+        navStrip.Visual.X = 4;
+        navStrip.Visual.Y = 4;
+        navStrip.AddToRoot();
+
+        AddNavButton("Raw visuals", () => new RawVisualsScreen());
+        AddNavButton("Forms controls", () => new FormsControlsScreen());
+        AddNavButton("Circles", () => new CirclesScreen());
+    }
+
+    private static void AddNavButton(string text, Func<FrameworkElement> factory)
+    {
+        Button button = new Button();
+        button.Text = text;
+        button.Click += (_, _) => ShowScreen(factory);
+        navStrip!.AddChild(button);
+    }
+
+    private static void ShowScreen(Func<FrameworkElement> factory)
     {
         if (activeScreen != null)
         {
             activeScreen.RemoveFromRoot();
         }
-        activeScreen = screen;
+
+        activeScreen = factory();
+        // Offset the screen so it doesn't sit underneath the nav strip — same trick as
+        // MonoGameGumShapesGallery/Game1.ShowScreen.
+        activeScreen.Visual.YOrigin = VerticalAlignment.Top;
+        activeScreen.Visual.YUnits = GeneralUnitType.PixelsFromSmall;
+        activeScreen.Visual.Y = NavStripHeight;
+        activeScreen.Visual.Height = -NavStripHeight;
         activeScreen.AddToRoot();
     }
 
     private static void InitializeStyling()
     {
-        var font = LoadFontEx("resources/04B_30_.TTF", 24, null, 0);
+        // Arial 18 across the board — the prior 04B_30_ pixel bubble font at 24 px made nav
+        // buttons too tall and looked out of place next to the shape gallery. raylib's
+        // LoadFontEx pulls glyph atlases from any TTF/OTF; Arial ships with Windows. If
+        // missing (non-Windows / locked-down boxes), fall back to the bundled pixel font so
+        // the sample still runs.
+        const int fontSize = 18;
+        Font font = LoadFontEx(@"C:\Windows\Fonts\arial.ttf", fontSize, null, 0);
+        if (font.BaseSize == 0)
+        {
+            font = LoadFontEx("resources/04B_30_.TTF", fontSize, null, 0);
+        }
+
+        // Drives Forms text (buttons, labels, etc.).
         Styling.ActiveStyle.Text.Normal.SetValue("Font", font);
         Styling.ActiveStyle.Text.Strong.SetValue("Font", font);
         Styling.ActiveStyle.Text.Emphasis.SetValue("Font", font);
+
+        // Drives non-Forms TextRuntime (e.g. raw section headers in CirclesScreen) — without
+        // this they fall back to raylib's GetFontDefault, which is the chunky pixel font.
+        Gum.Renderables.Text.DefaultFont = font;
     }
 }

--- a/Samples/raylib/Screens/CirclesScreen.cs
+++ b/Samples/raylib/Screens/CirclesScreen.cs
@@ -1,0 +1,270 @@
+using Gum.Converters;
+using Gum.DataTypes;
+using Gum.Forms.Controls;
+using Gum.GueDeriving;
+using Gum.Managers;
+using Gum.Wireframe;
+using Raylib_cs;
+using RenderingLibrary.Graphics;
+
+namespace Examples.Shapes;
+
+// Raylib mirror of SilkNetGum/Screens/CirclesScreen.cs (issue #2757). Structurally aligned
+// with the Skia/MG gallery so visual regressions in one backend are easy to spot against the
+// other — same section grouping, same parameter sweeps where features overlap.
+//
+// What's intentionally NOT mirrored on this pass: linear gradients, dashed strokes, per-shape
+// antialiasing toggle, and dropshadow — each requires renderer work that's tracked as a
+// #2757 follow-up. The runtime accepts the property values (round-trips) where wired, but the
+// raylib LineCircle's Render() doesn't honor them yet, so showing those sections would just
+// render the same as their non-decorated baselines and be misleading.
+internal class CirclesScreen : FrameworkElement
+{
+    public CirclesScreen() : base(new ContainerRuntime())
+    {
+        Dock(Gum.Wireframe.Dock.Fill);
+
+        // Two-column root mirrors SilkNet/MG so the screen grows wide rather than tall as
+        // rows accumulate — keeps the page legible without scrolling.
+        ContainerRuntime root = new();
+        root.ChildrenLayout = ChildrenLayout.LeftToRightStack;
+        root.StackSpacing = 24;
+        root.X = 10;
+        root.Y = 10;
+        this.AddChild(root);
+
+        ContainerRuntime left = BuildColumn();
+        ContainerRuntime right = BuildColumn();
+        root.Children.Add(left);
+        root.Children.Add(right);
+
+        left.Children.Add(BuildSection("Sizes (radius 16, 24, 32, 48) — default outline", BuildSizesRow()));
+        left.Children.Add(BuildSection("Alpha on StrokeColor (255, 192, 128, 64)", BuildAlphaRow()));
+        left.Children.Add(BuildSection("Modes: FillColor, StrokeColor, default", BuildModeRow()));
+        left.Children.Add(BuildSection("StrokeWidth (1, 2, 4, 8 px) — thick strokes via DrawRing (#2757)", BuildStrokeWidthRow()));
+
+        right.Children.Add(BuildSection("Alignment inside a 128x100 frame (Top / Center / Bottom)", BuildAlignmentRow()));
+        right.Children.Add(BuildSection("Centered radial gradient — DrawCircleGradient (#2757)", BuildRadialGradientRow()));
+        right.Children.Add(BuildSection("FillColor + StrokeColor on same instance — both layers render (#2790 parity)", BuildBothColorsRow()));
+        right.Children.Add(BuildSection("Inscribed in 64x64 frame — stroke stays inside the gray rectangle (#2790 visual contract)", BuildInscribedRow()));
+    }
+
+    static ContainerRuntime BuildColumn()
+    {
+        ContainerRuntime column = new();
+        column.ChildrenLayout = ChildrenLayout.TopToBottomStack;
+        column.StackSpacing = 14;
+        column.WidthUnits = DimensionUnitType.RelativeToChildren;
+        column.HeightUnits = DimensionUnitType.RelativeToChildren;
+        column.Width = 0;
+        column.Height = 0;
+        return column;
+    }
+
+    static ContainerRuntime BuildSection(string label, GraphicalUiElement body)
+    {
+        ContainerRuntime section = new();
+        section.ChildrenLayout = ChildrenLayout.TopToBottomStack;
+        section.StackSpacing = 4;
+        section.WidthUnits = DimensionUnitType.RelativeToChildren;
+        section.HeightUnits = DimensionUnitType.RelativeToChildren;
+        section.Width = 0;
+        section.Height = 0;
+
+        TextRuntime header = new();
+        header.Text = label;
+        header.Red = 220;
+        header.Green = 220;
+        header.Blue = 220;
+        section.Children.Add(header);
+        section.Children.Add(body);
+        return section;
+    }
+
+    static ContainerRuntime BuildHorizontalRow()
+    {
+        ContainerRuntime row = new();
+        row.ChildrenLayout = ChildrenLayout.LeftToRightStack;
+        row.StackSpacing = 16;
+        row.WidthUnits = DimensionUnitType.RelativeToChildren;
+        row.HeightUnits = DimensionUnitType.RelativeToChildren;
+        row.Width = 0;
+        row.Height = 0;
+        return row;
+    }
+
+    static ContainerRuntime BuildSizesRow()
+    {
+        ContainerRuntime row = BuildHorizontalRow();
+        foreach (float radius in new[] { 16f, 24f, 32f, 48f })
+        {
+            CircleRuntime circle = new();
+            circle.Radius = radius;
+            circle.StrokeColor = Color.White;
+            row.Children.Add(circle);
+        }
+        return row;
+    }
+
+    static ContainerRuntime BuildAlphaRow()
+    {
+        ContainerRuntime row = BuildHorizontalRow();
+        foreach (byte alpha in new byte[] { 255, 192, 128, 64 })
+        {
+            CircleRuntime circle = new();
+            circle.Radius = 24;
+            circle.StrokeColor = new Color((byte)255, (byte)255, (byte)255, alpha);
+            row.Children.Add(circle);
+        }
+        return row;
+    }
+
+    static ContainerRuntime BuildModeRow()
+    {
+        ContainerRuntime row = BuildHorizontalRow();
+
+        CircleRuntime filled = new();
+        filled.Radius = 28;
+        filled.FillColor = new Color(220, 20, 60, 255);
+        row.Children.Add(filled);
+
+        CircleRuntime stroked = new();
+        stroked.Radius = 28;
+        stroked.StrokeColor = new Color(0, 255, 255, 255);
+        stroked.StrokeWidth = 3;
+        row.Children.Add(stroked);
+
+        CircleRuntime defaultCircle = new();
+        defaultCircle.Radius = 28;
+        row.Children.Add(defaultCircle);
+
+        return row;
+    }
+
+    static ContainerRuntime BuildStrokeWidthRow()
+    {
+        ContainerRuntime row = BuildHorizontalRow();
+        foreach (float strokeWidth in new[] { 1f, 2f, 4f, 8f })
+        {
+            CircleRuntime circle = new();
+            circle.Radius = 24;
+            circle.StrokeColor = new Color(144, 238, 144, 255);
+            circle.StrokeWidth = strokeWidth;
+            row.Children.Add(circle);
+        }
+        return row;
+    }
+
+    static ContainerRuntime BuildAlignmentRow()
+    {
+        ContainerRuntime row = BuildHorizontalRow();
+        foreach (VerticalAlignment alignment in new[] { VerticalAlignment.Top, VerticalAlignment.Center, VerticalAlignment.Bottom })
+        {
+            row.Children.Add(BuildAlignmentCell(alignment));
+        }
+        return row;
+    }
+
+    static ColoredRectangleRuntime BuildAlignmentCell(VerticalAlignment alignment)
+    {
+        ColoredRectangleRuntime frame = new();
+        frame.Width = 128;
+        frame.Height = 100;
+        frame.Color = new Color(50, 50, 70, 255);
+
+        CircleRuntime circle = new();
+        circle.Radius = 22;
+        circle.FillColor = new Color(255, 165, 0, 255);
+        circle.XOrigin = HorizontalAlignment.Center;
+        circle.XUnits = GeneralUnitType.PixelsFromMiddle;
+        circle.YOrigin = alignment;
+        circle.YUnits = alignment switch
+        {
+            VerticalAlignment.Top => GeneralUnitType.PixelsFromSmall,
+            VerticalAlignment.Center => GeneralUnitType.PixelsFromMiddle,
+            VerticalAlignment.Bottom => GeneralUnitType.PixelsFromLarge,
+            _ => GeneralUnitType.PixelsFromMiddle,
+        };
+        frame.Children.Add(circle);
+        return frame;
+    }
+
+    // raylib's DrawCircleGradient is centered-radial only. Offset center and inner radius are
+    // both #2757 follow-ups (need a custom rlgl triangle fan). Showing four variations of the
+    // same centered gradient keeps the section visually distinct from the solid-fill row.
+    static ContainerRuntime BuildRadialGradientRow()
+    {
+        ContainerRuntime row = BuildHorizontalRow();
+
+        (Color inner, Color outer)[] palette = new[]
+        {
+            (Color.White, new Color(70, 130, 180, 255)),     // steel blue
+            (new Color(255, 215, 0, 255), new Color(220, 20, 60, 255)),  // gold → crimson
+            (new Color(0, 255, 255, 255), new Color(255, 0, 255, 255)),  // cyan → magenta
+            (Color.White, new Color(0, 100, 0, 255)),        // white → dark green
+        };
+
+        foreach ((Color inner, Color outer) in palette)
+        {
+            CircleRuntime circle = new();
+            circle.Radius = 28;
+            circle.FillColor = Color.White;
+            circle.UseGradient = true;
+            circle.GradientType = GradientType.Radial;
+            circle.Color1 = inner;
+            circle.Color2 = outer;
+            row.Children.Add(circle);
+        }
+        return row;
+    }
+
+    // #2790 parity: two-slot composition. Setting both FillColor and StrokeColor lights up
+    // both layers — order-independent. Each cell here should render a filled disk with a
+    // contrasting ring around it.
+    static ContainerRuntime BuildBothColorsRow()
+    {
+        ContainerRuntime row = BuildHorizontalRow();
+
+        CircleRuntime strokeLast = new();
+        strokeLast.Radius = 28;
+        strokeLast.FillColor = new Color(220, 20, 60, 255);
+        strokeLast.StrokeColor = new Color(0, 255, 255, 255);
+        strokeLast.StrokeWidth = 4;
+        row.Children.Add(strokeLast);
+
+        CircleRuntime fillLast = new();
+        fillLast.Radius = 28;
+        fillLast.StrokeColor = new Color(255, 0, 255, 255);
+        fillLast.StrokeWidth = 4;
+        fillLast.FillColor = new Color(255, 215, 0, 255);
+        row.Children.Add(fillLast);
+
+        return row;
+    }
+
+    static ContainerRuntime BuildInscribedRow()
+    {
+        ContainerRuntime row = BuildHorizontalRow();
+        foreach (float strokeWidth in new[] { 1f, 4f, 8f, 12f })
+        {
+            row.Children.Add(BuildInscribedCell(strokeWidth));
+        }
+        return row;
+    }
+
+    static ColoredRectangleRuntime BuildInscribedCell(float strokeWidth)
+    {
+        ColoredRectangleRuntime frame = new();
+        frame.Width = 64;
+        frame.Height = 64;
+        frame.Color = new Color(60, 60, 80, 255);
+
+        CircleRuntime circle = new();
+        circle.Radius = 32;
+        circle.FillColor = new Color(46, 139, 87, 255);
+        circle.StrokeColor = new Color(255, 255, 0, 255);
+        circle.StrokeWidth = strokeWidth;
+        frame.Children.Add(circle);
+        return frame;
+    }
+}

--- a/Samples/raylib/Screens/CirclesScreen.cs
+++ b/Samples/raylib/Screens/CirclesScreen.cs
@@ -44,9 +44,11 @@ internal class CirclesScreen : FrameworkElement
         left.Children.Add(BuildSection("StrokeWidth (1, 2, 4, 8 px) — thick strokes via DrawRing (#2757)", BuildStrokeWidthRow()));
 
         right.Children.Add(BuildSection("Alignment inside a 128x100 frame (Top / Center / Bottom)", BuildAlignmentRow()));
-        right.Children.Add(BuildSection("Centered radial gradient — DrawCircleGradient (#2757)", BuildRadialGradientRow()));
+        right.Children.Add(BuildSection("Gradients (linear H / V / diagonal / radial) — rlgl triangle fan (#2757)", BuildGradientRow()));
         right.Children.Add(BuildSection("FillColor + StrokeColor on same instance — both layers render (#2790 parity)", BuildBothColorsRow()));
         right.Children.Add(BuildSection("Inscribed in 64x64 frame — stroke stays inside the gray rectangle (#2790 visual contract)", BuildInscribedRow()));
+        right.Children.Add(BuildSection("Dashed strokes (solid / 6/4 / 2/2 dotted / long-dash) — DrawRing arc loop (#2757)", BuildDashedStrokeRow()));
+        right.Children.Add(BuildSection("Dropshadow (off / soft / hard offset / colored) — concentric-ring blur approximation (#2757)", BuildDropshadowRow()));
     }
 
     static ContainerRuntime BuildColumn()
@@ -189,32 +191,63 @@ internal class CirclesScreen : FrameworkElement
         return frame;
     }
 
-    // raylib's DrawCircleGradient is centered-radial only. Offset center and inner radius are
-    // both #2757 follow-ups (need a custom rlgl triangle fan). Showing four variations of the
-    // same centered gradient keeps the section visually distinct from the solid-fill row.
-    static ContainerRuntime BuildRadialGradientRow()
+    // #2757 follow-ups #8 + #9. Mirrors SilkNet's BuildGradientRow — same four cells, same
+    // gradient axis coordinates. Coords are in pixels relative to the circle's bounding-box
+    // top-left (0,0 = top-left, 2R,2R = bottom-right). raylib routes all four through an
+    // rlgl triangle fan with per-vertex colors.
+    static ContainerRuntime BuildGradientRow()
     {
         ContainerRuntime row = BuildHorizontalRow();
 
-        (Color inner, Color outer)[] palette = new[]
-        {
-            (Color.White, new Color(70, 130, 180, 255)),     // steel blue
-            (new Color(255, 215, 0, 255), new Color(220, 20, 60, 255)),  // gold → crimson
-            (new Color(0, 255, 255, 255), new Color(255, 0, 255, 255)),  // cyan → magenta
-            (Color.White, new Color(0, 100, 0, 255)),        // white → dark green
-        };
+        // Linear horizontal: white → steel blue, left edge to right edge of the 56x56 bbox.
+        CircleRuntime linearH = new();
+        linearH.Radius = 28;
+        linearH.FillColor = Color.White;
+        linearH.UseGradient = true;
+        linearH.GradientType = GradientType.Linear;
+        linearH.Color1 = Color.White;
+        linearH.Color2 = new Color(70, 130, 180, 255);
+        linearH.GradientX1 = 0; linearH.GradientY1 = 0;
+        linearH.GradientX2 = 56; linearH.GradientY2 = 0;
+        row.Children.Add(linearH);
 
-        foreach ((Color inner, Color outer) in palette)
-        {
-            CircleRuntime circle = new();
-            circle.Radius = 28;
-            circle.FillColor = Color.White;
-            circle.UseGradient = true;
-            circle.GradientType = GradientType.Radial;
-            circle.Color1 = inner;
-            circle.Color2 = outer;
-            row.Children.Add(circle);
-        }
+        // Linear vertical: gold → crimson, top to bottom.
+        CircleRuntime linearV = new();
+        linearV.Radius = 28;
+        linearV.FillColor = Color.White;
+        linearV.UseGradient = true;
+        linearV.GradientType = GradientType.Linear;
+        linearV.Color1 = new Color(255, 215, 0, 255);
+        linearV.Color2 = new Color(220, 20, 60, 255);
+        linearV.GradientX1 = 0; linearV.GradientY1 = 0;
+        linearV.GradientX2 = 0; linearV.GradientY2 = 56;
+        row.Children.Add(linearV);
+
+        // Linear diagonal: cyan → magenta, top-left to bottom-right.
+        CircleRuntime linearD = new();
+        linearD.Radius = 28;
+        linearD.FillColor = Color.White;
+        linearD.UseGradient = true;
+        linearD.GradientType = GradientType.Linear;
+        linearD.Color1 = new Color(0, 255, 255, 255);
+        linearD.Color2 = new Color(255, 0, 255, 255);
+        linearD.GradientX1 = 0; linearD.GradientY1 = 0;
+        linearD.GradientX2 = 56; linearD.GradientY2 = 56;
+        row.Children.Add(linearD);
+
+        // Radial centered: white → dark green from (28,28) with inner=0, outer=28.
+        CircleRuntime radial = new();
+        radial.Radius = 28;
+        radial.FillColor = Color.White;
+        radial.UseGradient = true;
+        radial.GradientType = GradientType.Radial;
+        radial.Color1 = Color.White;
+        radial.Color2 = new Color(0, 100, 0, 255);
+        radial.GradientX1 = 28; radial.GradientY1 = 28;
+        radial.GradientInnerRadius = 0;
+        radial.GradientOuterRadius = 28;
+        row.Children.Add(radial);
+
         return row;
     }
 
@@ -266,5 +299,105 @@ internal class CirclesScreen : FrameworkElement
         circle.StrokeWidth = strokeWidth;
         frame.Children.Add(circle);
         return frame;
+    }
+
+    // #2757 follow-up #10 — raylib mirror of SilkNet's BuildDashedStrokeRow. raylib has no
+    // built-in path-effect dash (Skia has SKPathEffect.CreateDash); LineCircle emits each
+    // dash as a separate DrawRing arc with angles computed from circumference.
+    static ContainerRuntime BuildDashedStrokeRow()
+    {
+        ContainerRuntime row = BuildHorizontalRow();
+
+        // Baseline: solid stroke (dash=0).
+        CircleRuntime solid = new();
+        solid.Radius = 28;
+        solid.StrokeColor = Color.White;
+        solid.StrokeWidth = 2;
+        row.Children.Add(solid);
+
+        // Short 6/4 dash.
+        CircleRuntime short64 = new();
+        short64.Radius = 28;
+        short64.StrokeColor = Color.White;
+        short64.StrokeWidth = 2;
+        short64.StrokeDashLength = 6;
+        short64.StrokeGapLength = 4;
+        row.Children.Add(short64);
+
+        // Tight 2/2 dotted at 1 px — framebuffer MSAA keeps edges smooth without per-shape AA.
+        CircleRuntime dotted = new();
+        dotted.Radius = 28;
+        dotted.StrokeColor = Color.White;
+        dotted.StrokeWidth = 1;
+        dotted.StrokeDashLength = 2;
+        dotted.StrokeGapLength = 2;
+        row.Children.Add(dotted);
+
+        // Long-dash motif: 12/6 with a thicker stroke.
+        CircleRuntime longDash = new();
+        longDash.Radius = 28;
+        longDash.StrokeColor = new Color(144, 238, 144, 255);
+        longDash.StrokeWidth = 3;
+        longDash.StrokeDashLength = 12;
+        longDash.StrokeGapLength = 6;
+        row.Children.Add(longDash);
+
+        return row;
+    }
+
+    // #2757 follow-up #12 — raylib mirror of SilkNet's BuildDropshadowRow. Same four cells
+    // (baseline, soft, hard offset, colored). raylib has no SKImageFilter.CreateDropShadow
+    // equivalent; the renderable approximates the blurred edge with concentric semi-transparent
+    // rings of decreasing alpha.
+    static ContainerRuntime BuildDropshadowRow()
+    {
+        ContainerRuntime row = BuildHorizontalRow();
+
+        Color goldenrod = new Color(218, 165, 32, 255);
+
+        // Baseline: no shadow.
+        CircleRuntime baseline = new();
+        baseline.Radius = 28;
+        baseline.FillColor = goldenrod;
+        row.Children.Add(baseline);
+
+        // Soft shadow: noticeable offset, generous blur, default opaque black.
+        CircleRuntime soft = new();
+        soft.Radius = 28;
+        soft.FillColor = goldenrod;
+        soft.HasDropshadow = true;
+        soft.DropshadowOffsetX = 4;
+        soft.DropshadowOffsetY = 4;
+        soft.DropshadowBlurX = 4;
+        soft.DropshadowBlurY = 4;
+        row.Children.Add(soft);
+
+        // Hard offset: bigger offset, no blur, semi-transparent black. Per-channel setters
+        // mirror SilkNet's example.
+        CircleRuntime hard = new();
+        hard.Radius = 28;
+        hard.FillColor = goldenrod;
+        hard.HasDropshadow = true;
+        hard.DropshadowRed = 0; hard.DropshadowGreen = 0; hard.DropshadowBlue = 0; hard.DropshadowAlpha = 160;
+        hard.DropshadowOffsetX = 6;
+        hard.DropshadowOffsetY = 6;
+        hard.DropshadowBlurX = 0;
+        hard.DropshadowBlurY = 0;
+        row.Children.Add(hard);
+
+        // Colored shadow: magenta cast with real offset so the cast is visible against the
+        // blue background.
+        CircleRuntime colored = new();
+        colored.Radius = 28;
+        colored.FillColor = goldenrod;
+        colored.HasDropshadow = true;
+        colored.DropshadowRed = 220; colored.DropshadowGreen = 40; colored.DropshadowBlue = 160; colored.DropshadowAlpha = 220;
+        colored.DropshadowOffsetX = 6;
+        colored.DropshadowOffsetY = 6;
+        colored.DropshadowBlurX = 6;
+        colored.DropshadowBlurY = 6;
+        row.Children.Add(colored);
+
+        return row;
     }
 }

--- a/Samples/raylib/Screens/RawVisualsScreen.cs
+++ b/Samples/raylib/Screens/RawVisualsScreen.cs
@@ -24,23 +24,8 @@ internal class RawVisualsScreen : FrameworkElement
         BuildSpritesRow(page);
 
         BuildShapesRow(page);
-        
+
         BuildNineSliceRow(page);
-
-        AddSwitchHint();
-    }
-
-    private void AddSwitchHint()
-    {
-        var hint = new TextRuntime();
-        hint.Text = "Press SPACE to switch screens";
-        hint.XOrigin = HorizontalAlignment.Left;
-        hint.YOrigin = VerticalAlignment.Bottom;
-        hint.XUnits = GeneralUnitType.PixelsFromSmall;
-        hint.YUnits = GeneralUnitType.PixelsFromLarge;
-        hint.X = 8;
-        hint.Y = -8;
-        this.AddChild(hint);
     }
 
     private static ContainerRuntime NewSection(ChildrenLayout layout, int spacing)

--- a/Tests/RaylibGum.Tests/Renderables/LineCircleTests.cs
+++ b/Tests/RaylibGum.Tests/Renderables/LineCircleTests.cs
@@ -1,0 +1,119 @@
+using Gum.Renderables;
+using Raylib_cs;
+using RenderingLibrary.Graphics;
+using Shouldly;
+
+namespace RaylibGum.Tests.Renderables;
+
+/// <summary>
+/// Issue #2757 — verifies the property surface added to <see cref="LineCircle"/> so the raylib
+/// renderable can render filled disks, thick strokes, and centered radial gradients in addition
+/// to its original 1 px outline. These tests cover defaults and property round-trip only; actual
+/// rendering paths call native raylib Draw* functions that require a GL context and are validated
+/// visually in the raylib sample's CirclesScreen.
+/// </summary>
+public class LineCircleTests
+{
+    [Fact]
+    public void Defaults_PreserveLegacyOutlineBehavior()
+    {
+        LineCircle circle = new LineCircle();
+
+        circle.IsFilled.ShouldBeFalse();
+        circle.StrokeWidth.ShouldBe(1f);
+        circle.FillColor.ShouldBeNull();
+        circle.StrokeColor.ShouldBeNull();
+        circle.UseGradient.ShouldBeFalse();
+        circle.Color.R.ShouldBe((byte)255);
+        circle.Color.G.ShouldBe((byte)255);
+        circle.Color.B.ShouldBe((byte)255);
+        circle.Color.A.ShouldBe((byte)255);
+    }
+
+    [Fact]
+    public void IsFilled_RoundTrips()
+    {
+        LineCircle circle = new LineCircle();
+
+        circle.IsFilled = true;
+
+        circle.IsFilled.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void StrokeWidth_RoundTrips()
+    {
+        LineCircle circle = new LineCircle();
+
+        circle.StrokeWidth = 4.5f;
+
+        circle.StrokeWidth.ShouldBe(4.5f);
+    }
+
+    [Fact]
+    public void FillColor_RoundTripsNullableColor()
+    {
+        LineCircle circle = new LineCircle();
+        Color expected = new Color(10, 20, 30, 40);
+
+        circle.FillColor = expected;
+
+        circle.FillColor.ShouldNotBeNull();
+        circle.FillColor!.Value.R.ShouldBe((byte)10);
+        circle.FillColor!.Value.A.ShouldBe((byte)40);
+
+        circle.FillColor = null;
+        circle.FillColor.ShouldBeNull();
+    }
+
+    [Fact]
+    public void StrokeColor_RoundTripsNullableColor()
+    {
+        LineCircle circle = new LineCircle();
+        Color expected = new Color(50, 60, 70, 80);
+
+        circle.StrokeColor = expected;
+
+        circle.StrokeColor.ShouldNotBeNull();
+        circle.StrokeColor!.Value.G.ShouldBe((byte)60);
+
+        circle.StrokeColor = null;
+        circle.StrokeColor.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Gradient_PropertiesRoundTrip()
+    {
+        LineCircle circle = new LineCircle();
+        Color c1 = new Color(255, 0, 0, 255);
+        Color c2 = new Color(0, 0, 255, 255);
+
+        circle.UseGradient = true;
+        circle.GradientType = GradientType.Radial;
+        circle.Color1 = c1;
+        circle.Color2 = c2;
+
+        circle.UseGradient.ShouldBeTrue();
+        circle.GradientType.ShouldBe(GradientType.Radial);
+        circle.Color1.R.ShouldBe((byte)255);
+        circle.Color2.B.ShouldBe((byte)255);
+    }
+
+    [Fact]
+    public void LegacyColorChannel_StillRoundTripsViaColor()
+    {
+        // Back-compat: shared CircleRuntime's raylib branch reads/writes Color, Red, Green,
+        // Blue, Alpha — preserve that path unchanged so the runtime keeps working.
+        LineCircle circle = new LineCircle();
+
+        circle.Red = 12;
+        circle.Green = 34;
+        circle.Blue = 56;
+        circle.Alpha = 78;
+
+        circle.Color.R.ShouldBe((byte)12);
+        circle.Color.G.ShouldBe((byte)34);
+        circle.Color.B.ShouldBe((byte)56);
+        circle.Color.A.ShouldBe((byte)78);
+    }
+}

--- a/Tests/RaylibGum.Tests/Renderables/LineCircleTests.cs
+++ b/Tests/RaylibGum.Tests/Renderables/LineCircleTests.cs
@@ -100,6 +100,81 @@ public class LineCircleTests
     }
 
     [Fact]
+    public void GradientAxis_PropertiesRoundTrip()
+    {
+        // #2757 follow-ups #8 (linear axis) and #9 (offset-center / inner-outer radius).
+        // The renderable holds bbox-local pixel coords; rlgl triangle fan reads them per
+        // vertex.
+        LineCircle circle = new LineCircle();
+
+        circle.GradientX1.ShouldBe(0f);
+        circle.GradientY1.ShouldBe(0f);
+        circle.GradientX2.ShouldBe(0f);
+        circle.GradientY2.ShouldBe(0f);
+        circle.GradientInnerRadius.ShouldBe(0f);
+        circle.GradientOuterRadius.ShouldBe(0f);
+
+        circle.GradientX1 = 4f;
+        circle.GradientY1 = 8f;
+        circle.GradientX2 = 56f;
+        circle.GradientY2 = 28f;
+        circle.GradientInnerRadius = 4f;
+        circle.GradientOuterRadius = 28f;
+
+        circle.GradientX1.ShouldBe(4f);
+        circle.GradientY1.ShouldBe(8f);
+        circle.GradientX2.ShouldBe(56f);
+        circle.GradientY2.ShouldBe(28f);
+        circle.GradientInnerRadius.ShouldBe(4f);
+        circle.GradientOuterRadius.ShouldBe(28f);
+    }
+
+    [Fact]
+    public void DashedStroke_PropertiesRoundTrip()
+    {
+        // #2757 follow-up #10 — dashed stroke uses StrokeDashLength + StrokeGapLength;
+        // both default to 0 (solid stroke). Both must be > 0 for the render path to engage.
+        LineCircle circle = new LineCircle();
+
+        circle.StrokeDashLength.ShouldBe(0f);
+        circle.StrokeGapLength.ShouldBe(0f);
+
+        circle.StrokeDashLength = 6f;
+        circle.StrokeGapLength = 4f;
+
+        circle.StrokeDashLength.ShouldBe(6f);
+        circle.StrokeGapLength.ShouldBe(4f);
+    }
+
+    [Fact]
+    public void Dropshadow_PropertiesRoundTrip()
+    {
+        // #2757 follow-up #12 — dropshadow defaults to off (HasDropshadow == false) with
+        // opaque-black color, zero offset/blur. All props round-trip independently.
+        LineCircle circle = new LineCircle();
+
+        circle.HasDropshadow.ShouldBeFalse();
+        circle.DropshadowColor.A.ShouldBe((byte)255);
+        circle.DropshadowOffsetX.ShouldBe(0f);
+        circle.DropshadowBlurY.ShouldBe(0f);
+
+        circle.HasDropshadow = true;
+        circle.DropshadowColor = new Color(220, 40, 160, 220);
+        circle.DropshadowOffsetX = 6f;
+        circle.DropshadowOffsetY = 4f;
+        circle.DropshadowBlurX = 6f;
+        circle.DropshadowBlurY = 4f;
+
+        circle.HasDropshadow.ShouldBeTrue();
+        circle.DropshadowColor.R.ShouldBe((byte)220);
+        circle.DropshadowColor.A.ShouldBe((byte)220);
+        circle.DropshadowOffsetX.ShouldBe(6f);
+        circle.DropshadowOffsetY.ShouldBe(4f);
+        circle.DropshadowBlurX.ShouldBe(6f);
+        circle.DropshadowBlurY.ShouldBe(4f);
+    }
+
+    [Fact]
     public void LegacyColorChannel_StillRoundTripsViaColor()
     {
         // Back-compat: shared CircleRuntime's raylib branch reads/writes Color, Red, Green,

--- a/Tests/RaylibGum.Tests/Runtimes/CircleRuntimeTests.cs
+++ b/Tests/RaylibGum.Tests/Runtimes/CircleRuntimeTests.cs
@@ -1,5 +1,7 @@
 using Gum.GueDeriving;
+using Gum.Renderables;
 using Raylib_cs;
+using RenderingLibrary.Graphics;
 using Shouldly;
 
 namespace RaylibGum.Tests.Runtimes;
@@ -73,5 +75,68 @@ public class CircleRuntimeTests : BaseTestClass
     {
         CircleRuntime sut = new();
         sut.Visible.ShouldBeTrue();
+    }
+
+    // #2757: the raylib branch now surfaces the same property names as the XNALIKE/SKIA
+    // branches so the shared CirclesScreen samples compile across backends. These tests pin
+    // the round-trip + push-to-renderable contract.
+
+    [Fact]
+    public void FillColor_RoundTrips_AndPushesToContainedRenderable()
+    {
+        CircleRuntime sut = new();
+        Color expected = new Color(10, 20, 30, 200);
+
+        sut.FillColor = expected;
+
+        sut.FillColor.ShouldNotBeNull();
+        sut.FillColor!.Value.R.ShouldBe((byte)10);
+        ((LineCircle)sut.RenderableComponent!).FillColor.ShouldNotBeNull();
+        ((LineCircle)sut.RenderableComponent!).FillColor!.Value.R.ShouldBe((byte)10);
+    }
+
+    [Fact]
+    public void StrokeColor_RoundTrips_AndPushesToContainedRenderable()
+    {
+        CircleRuntime sut = new();
+        Color expected = new Color(40, 50, 60, 255);
+
+        sut.StrokeColor = expected;
+
+        sut.StrokeColor.ShouldNotBeNull();
+        ((LineCircle)sut.RenderableComponent!).StrokeColor.ShouldNotBeNull();
+        ((LineCircle)sut.RenderableComponent!).StrokeColor!.Value.G.ShouldBe((byte)50);
+    }
+
+    [Fact]
+    public void StrokeWidth_RoundTrips_AndPushesToContainedRenderable()
+    {
+        CircleRuntime sut = new();
+
+        sut.StrokeWidth = 5f;
+
+        sut.StrokeWidth.ShouldBe(5f);
+        ((LineCircle)sut.RenderableComponent!).StrokeWidth.ShouldBe(5f);
+    }
+
+    [Fact]
+    public void Gradient_PropertiesRoundTrip_AndPushToContainedRenderable()
+    {
+        CircleRuntime sut = new();
+        Color c1 = new Color(255, 0, 0, 255);
+        Color c2 = new Color(0, 0, 255, 255);
+
+        sut.UseGradient = true;
+        sut.GradientType = GradientType.Radial;
+        sut.Color1 = c1;
+        sut.Color2 = c2;
+
+        sut.UseGradient.ShouldBeTrue();
+        sut.GradientType.ShouldBe(GradientType.Radial);
+        LineCircle inner = (LineCircle)sut.RenderableComponent!;
+        inner.UseGradient.ShouldBeTrue();
+        inner.GradientType.ShouldBe(GradientType.Radial);
+        inner.Color1.R.ShouldBe((byte)255);
+        inner.Color2.B.ShouldBe((byte)255);
     }
 }

--- a/Tests/RaylibGum.Tests/Runtimes/CircleRuntimeTests.cs
+++ b/Tests/RaylibGum.Tests/Runtimes/CircleRuntimeTests.cs
@@ -120,6 +120,53 @@ public class CircleRuntimeTests : BaseTestClass
     }
 
     [Fact]
+    public void DashedStroke_RoundTrips_AndPushesToContainedRenderable()
+    {
+        // #2757 follow-up #10. Existing #if RAYLIB || SOKOL block previously held the values
+        // as backing-field only; raylib now pushes to the renderable so the dashed render
+        // path engages.
+        CircleRuntime sut = new();
+
+        sut.StrokeDashLength = 6f;
+        sut.StrokeGapLength = 4f;
+
+        sut.StrokeDashLength.ShouldBe(6f);
+        sut.StrokeGapLength.ShouldBe(4f);
+        LineCircle inner = (LineCircle)sut.RenderableComponent!;
+        inner.StrokeDashLength.ShouldBe(6f);
+        inner.StrokeGapLength.ShouldBe(4f);
+    }
+
+    [Fact]
+    public void Dropshadow_RoundTrips_AndPushesToContainedRenderable()
+    {
+        // #2757 follow-up #12. Per-channel setters (Red/Green/Blue/Alpha) compose into
+        // DropshadowColor and push to the renderable through its setter.
+        CircleRuntime sut = new();
+
+        sut.HasDropshadow = true;
+        sut.DropshadowRed = 220;
+        sut.DropshadowGreen = 40;
+        sut.DropshadowBlue = 160;
+        sut.DropshadowAlpha = 220;
+        sut.DropshadowOffsetX = 6f;
+        sut.DropshadowOffsetY = 4f;
+        sut.DropshadowBlurX = 6f;
+        sut.DropshadowBlurY = 4f;
+
+        sut.HasDropshadow.ShouldBeTrue();
+        sut.DropshadowColor.R.ShouldBe((byte)220);
+        sut.DropshadowColor.A.ShouldBe((byte)220);
+
+        LineCircle inner = (LineCircle)sut.RenderableComponent!;
+        inner.HasDropshadow.ShouldBeTrue();
+        inner.DropshadowColor.R.ShouldBe((byte)220);
+        inner.DropshadowColor.G.ShouldBe((byte)40);
+        inner.DropshadowOffsetX.ShouldBe(6f);
+        inner.DropshadowBlurY.ShouldBe(4f);
+    }
+
+    [Fact]
     public void Gradient_PropertiesRoundTrip_AndPushToContainedRenderable()
     {
         CircleRuntime sut = new();
@@ -138,5 +185,28 @@ public class CircleRuntimeTests : BaseTestClass
         inner.GradientType.ShouldBe(GradientType.Radial);
         inner.Color1.R.ShouldBe((byte)255);
         inner.Color2.B.ShouldBe((byte)255);
+    }
+
+    [Fact]
+    public void GradientAxis_RoundTrips_AndPushesToContainedRenderable()
+    {
+        // #2757 follow-ups #8/#9 — six new axis + radius props pushed through to the
+        // renderable for the rlgl triangle-fan render path.
+        CircleRuntime sut = new();
+
+        sut.GradientX1 = 4f;
+        sut.GradientY1 = 8f;
+        sut.GradientX2 = 56f;
+        sut.GradientY2 = 28f;
+        sut.GradientInnerRadius = 4f;
+        sut.GradientOuterRadius = 28f;
+
+        LineCircle inner = (LineCircle)sut.RenderableComponent!;
+        inner.GradientX1.ShouldBe(4f);
+        inner.GradientY1.ShouldBe(8f);
+        inner.GradientX2.ShouldBe(56f);
+        inner.GradientY2.ShouldBe(28f);
+        inner.GradientInnerRadius.ShouldBe(4f);
+        inner.GradientOuterRadius.ShouldBe(28f);
     }
 }


### PR DESCRIPTION
## Summary

Brings the raylib `CircleRuntime` closer to feature parity with the MonoGame/Skia versions and adds a `CirclesScreen` to the raylib sample mirroring SilkNetGum's.

- **`LineCircle` renderable** gains `IsFilled`, variable `StrokeWidth` (via `DrawRing`), `FillColor`/`StrokeColor` two-slot composition, and centered radial gradient (`DrawCircleGradient`). Stroke is inset entirely inside the nominal `Radius` to match Skia's `IsOffsetAppliedForStroke` contract. Legacy `Color`/`Red`/`Green`/`Blue`/`Alpha` surface preserved.
- **Shared `CircleRuntime.cs`** gets an `#if RAYLIB`-gated property block routing the new props through to the contained renderable. Existing `StrokeWidth` (formerly backing-field-only on RAYLIB/SOKOL) now pushes to the renderable on RAYLIB; SOKOL stays as forward-compat round-trip.
- **Raylib sample (`Samples/raylib`)** picks up:
  - New `CirclesScreen` page mirroring `SilkNetGum/Screens/CirclesScreen.cs` (sections: sizes, alpha, modes, stroke widths, alignment, centered radial gradient, both-colors-on-one-instance, inscribed-in-frame).
  - Horizontal Forms `Button` nav strip (lifted from `MonoGameGumShapesGallery/Game1`) replacing the Space-key toggle.
  - Framebuffer 4× MSAA via `SetConfigFlags(Msaa4xHint)` — raylib's only AA path.
  - Arial 18 across the board via a new `Text.DefaultFont` static, so raw `TextRuntime` headers pick up the same font as Forms controls (previously used raylib's chunky `GetFontDefault()`).
- **Tests**: 7 new `LineCircleTests` + 4 new `CircleRuntimeTests` pinning property defaults, round-trip, and runtime→renderable wire-through. All 174 raylib tests + the MG `CircleRuntime` tests pass.

### Out of scope (tracked as follow-ups under #2757)

- Linear gradient on raylib circles (needs custom `rlgl` triangle fan)
- Offset-center / inner-radius radial gradient (same)
- Dashed/dotted strokes (`DrawCircleSector` loop)
- Dropshadow (cheap offset + RT blur for soft variant)

Per-shape anti-aliasing is treated as resolved by framebuffer MSAA — no clean raylib equivalent for the Skia-style `IsAntialiased` toggle without shader work.

## Test plan

- [x] `dotnet test Tests/RaylibGum.Tests/RaylibGum.Tests.csproj` — 174/174 pass
- [x] `dotnet test MonoGameGum.Tests/MonoGameGum.Tests.csproj --filter CircleRuntime` — 12/12 pass (XNALIKE side unchanged)
- [x] `dotnet build Runtimes/RaylibGum/RaylibGum.csproj` clean
- [x] `dotnet build MonoGameGum/MonoGameGum.csproj` clean
- [x] `dotnet build Samples/raylib/GumTest.csproj` clean
- [x] Sample runs visually verified (font, MSAA, inscribed strokes, gradient sections all render as expected)

Advances #2757 (raylib piece of the broader shape-runtime unification effort; SkiaGum Circle/Polygon/Rectangle unification tracked separately in the same issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)