### PR TITLE
#2828: expose internal SpriteBatch on GumBatch for mixed rendering

### DIFF
--- a/RenderingLibrary/Graphics/Renderer.cs
+++ b/RenderingLibrary/Graphics/Renderer.cs
@@ -1059,6 +1059,16 @@ public class GumBatch
     GumBatchState State;
     SystemManagers systemManagers;
     Text internalTextForRendering;
+
+    /// <summary>
+    /// The underlying MonoGame <see cref="SpriteBatch"/> that this GumBatch wraps. Use this
+    /// to issue your own SpriteBatch draw calls between <see cref="Begin"/> and <see cref="End"/>
+    /// without having to manage a separate SpriteBatch. The instance is stable for the lifetime
+    /// of this GumBatch; Gum mutates its state (clip regions, blend, etc.) but never swaps the
+    /// instance mid-frame. Callers are responsible for any state interaction with Gum's own draws.
+    /// </summary>
+    public SpriteBatch SpriteBatch => systemManagers.Renderer.SpriteRenderer.SpriteBatch;
+
     public GumBatch()
     {
         if(SystemManagers .Default == null)

--- a/RenderingLibrary/Graphics/SpriteRenderer.cs
+++ b/RenderingLibrary/Graphics/SpriteRenderer.cs
@@ -84,6 +84,14 @@ public class SpriteRenderer
     }
 
     /// <summary>
+    /// The underlying MonoGame <see cref="SpriteBatch"/> used for all sprite and text
+    /// rendering. Exposed so consumers (e.g. <see cref="GumBatch"/> users mixing their
+    /// own draw calls with Gum's immediate-mode rendering) can issue draws into the
+    /// same batch between Begin/End without managing a second SpriteBatch.
+    /// </summary>
+    public SpriteBatch SpriteBatch => mSpriteBatch?.SpriteBatch;
+
+    /// <summary>
     /// The shared scissor-enabled RasterizerState used by Sprite clipping. Exposed so
     /// custom batches (Apos.Shapes ShapeBatch via RenderableShapeBase.StartBatch) can
     /// pass the same rasterizer state to their Begin call and produce identical scissor

--- a/Samples/MonoGameGumImmediateMode/MonoGameGumImmediateMode/Game1.cs
+++ b/Samples/MonoGameGumImmediateMode/MonoGameGumImmediateMode/Game1.cs
@@ -76,6 +76,7 @@ namespace MonoGameGumImmediateMode
             AddNavButton("TextRuntime", () => ShowScreen(new TextRuntimeScreen()));
             AddNavButton("Parent/Child", () => ShowScreen(new ParentChildScreen()));
             AddNavButton("RenderTarget", () => ShowScreen(new RenderTargetScreen()));
+            AddNavButton("Mixed Batch", () => ShowScreen(new MixedBatchScreen()));
         }
 
         private void AddNavButton(string text, Action onClick)

--- a/Samples/MonoGameGumImmediateMode/MonoGameGumImmediateMode/Screens/MixedBatchScreen.cs
+++ b/Samples/MonoGameGumImmediateMode/MonoGameGumImmediateMode/Screens/MixedBatchScreen.cs
@@ -1,0 +1,70 @@
+using Gum.GueDeriving;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using RenderingLibrary.Graphics;
+
+namespace MonoGameGumImmediateMode.Screens
+{
+    /// <summary>
+    /// Demonstrates mixing user <see cref="SpriteBatch"/> draws with Gum's immediate-mode
+    /// draws inside a single <see cref="GumBatch.Begin"/>/<see cref="GumBatch.End"/> pair
+    /// by drawing through the <see cref="GumBatch.SpriteBatch"/> property. Both sets of
+    /// draws land in the same batch, so they share sort order, blend state, and transform.
+    /// </summary>
+    public class MixedBatchScreen : IImmediateModeScreen
+    {
+        private Texture2D _pixel;
+        private ColoredRectangleRuntime _gumRectangle;
+        private TextRuntime _label;
+
+        public void Initialize(GraphicsDevice graphicsDevice)
+        {
+            // A 1x1 white texture lets us draw arbitrary solid-color rects via SpriteBatch
+            // without shipping any content assets.
+            _pixel = new Texture2D(graphicsDevice, 1, 1);
+            _pixel.SetData(new[] { Color.White });
+
+            _gumRectangle = new ColoredRectangleRuntime();
+            _gumRectangle.Width = 160;
+            _gumRectangle.Height = 80;
+            _gumRectangle.Color = Color.DarkGreen;
+            _gumRectangle.X = 60;
+            _gumRectangle.Y = 120;
+
+            _label = new TextRuntime();
+            _label.Font = "Arial";
+            _label.FontSize = 16;
+            _label.Text = "Green rect (Gum) and orange rect (SpriteBatch) share one batch";
+            _label.X = 60;
+            _label.Y = 90;
+        }
+
+        public void Draw(GumBatch gumBatch, SpriteBatch spriteBatch)
+        {
+            gumBatch.Begin();
+
+            // Gum's own draws — go through GumBatch as usual.
+            gumBatch.Draw(_gumRectangle);
+            gumBatch.Draw(_label);
+
+            // Our own SpriteBatch draws, issued through the shared SpriteBatch that
+            // GumBatch is currently in the middle of using. No second Begin/End needed.
+            gumBatch.SpriteBatch.Draw(
+                _pixel,
+                new Rectangle(240, 120, 160, 80),
+                Color.Orange);
+
+            gumBatch.SpriteBatch.Draw(
+                _pixel,
+                new Rectangle(60, 220, 340, 4),
+                Color.Black);
+
+            gumBatch.End();
+        }
+
+        public void Dispose()
+        {
+            _pixel?.Dispose();
+        }
+    }
+}

--- a/docs/code/rendering/gumbatch.md
+++ b/docs/code/rendering/gumbatch.md
@@ -203,6 +203,34 @@ protected override void Draw(GameTime gameTime)
 
 <figure><img src="../../.gitbook/assets/ButtonTextOverBlueButton.png" alt=""><figcaption><p>buttonRectangle drawn with its child buttonText</p></figcaption></figure>
 
+### Mixing with SpriteBatch
+
+GumBatch wraps an internal `SpriteBatch` and exposes it through the `SpriteBatch` property. This lets you issue your own SpriteBatch draw calls between `GumBatch.Begin` and `GumBatch.End` without managing a second batch — both your draws and Gum's draws land in the same batch, so they share sort order, blend state, and transform matrix.
+
+This is useful when you want to draw a few of your own textures alongside Gum's immediate-mode output without paying for two Begin/End pairs.
+
+```csharp
+// Draw
+gumBatch.Begin();
+
+// Your own SpriteBatch draw, sharing the batch Gum is using:
+gumBatch.SpriteBatch.Draw(
+    myTexture,
+    new Vector2(50, 50),
+    Color.White);
+
+// Gum draws into the same batch:
+gumBatch.Draw(someGumObject);
+
+gumBatch.End();
+```
+
+The underlying `SpriteBatch` instance is stable for the lifetime of the GumBatch — Gum may mutate its state (clip regions, blend, transform) but never swaps the instance — so it is safe to cache the reference if you want.
+
+{% hint style="warning" %}
+You are sharing a batch with Gum, so any state you change on the SpriteBatch directly (e.g. by calling `End` and re-issuing `Begin` with different parameters) will affect subsequent Gum draws. If you need independent state, use your own separate SpriteBatch instead.
+{% endhint %}
+
 ### RenderTargets
 
 GumBatch can be used to render Gum objects on RenderTarget2Ds, just like regular SpriteBatch calls.


### PR DESCRIPTION
## Summary
- Adds `GumBatch.SpriteBatch` (get-only) so callers mixing immediate-mode Gum draws with their own SpriteBatch draws can share one Begin/End pair instead of juggling two batch objects.
- Adds the supporting `SpriteRenderer.SpriteBatch` accessor that just bubbles up the existing `SpriteBatchStack.SpriteBatch`.
- MonoGame-only by design (lives in `RenderingLibrary`, shared with FNA/KNI which also have `SpriteBatch`). If `GumBatch` is ever ported to Raylib/Skia, the property can be `#if`'d out.

## Design notes
- The underlying `SpriteBatch` instance is stable across a `GumBatch` frame — clip regions etc. mutate properties, not the instance — so a plain property getter is safe.
- Rejected alternatives (per the issue): ~20 forwarding overloads (maintenance + per-runtime `#if` tax), constructor-injected SpriteBatch (would require threading through `Renderer`/`SpriteBatchStack`).

## Test plan
- [ ] Build verified locally (`dotnet build MonoGameGum/MonoGameGum.csproj`) — no new warnings.
- [ ] Manually verify in a sample: between `GumBatch.Begin`/`End`, issue a `gumBatch.SpriteBatch.Draw(...)` and confirm it lands in the same batch as the Gum draws.

Closes #2828

🤖 Generated with [Claude Code](https://claude.com/claude-code)