### PR TITLE
docs: direct BitmapFont construction via KernSmith + advanced font effects

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -322,6 +322,7 @@
     * [Fonts on Web](code/files-and-fonts/fonts-web.md)
     * [Font Localization](code/files-and-fonts/font-localization.md)
     * [Font Cache](code/files-and-fonts/font-cache.md)
+    * [Advanced Font Effects](code/files-and-fonts/advanced-font-effects.md)
   * [File Loading](code/files-and-fonts/file-loading.md)
   * [BitmapFont](code/files-and-fonts/bitmapfont.md)
   * [Content Using Embedded Resources](code/files-and-fonts/content-using-embedded-resources.md)

--- a/docs/code/files-and-fonts/advanced-font-effects.md
+++ b/docs/code/files-and-fonts/advanced-font-effects.md
@@ -1,0 +1,223 @@
+# Advanced Font Effects
+
+## Introduction
+
+KernSmith can generate fonts with effects that the `TextRuntime` property surface does not expose — outline color, drop shadows, gradient fills, SDF, color fonts, custom glyph subsets, and a choice of rasterizer backend. These all live on `KernSmith.FontGeneratorOptions`, but `BmfcSave` (the descriptor that drives the property path) only carries a small slice of those fields.
+
+This page catalogs the effects available today and shows the `FontGeneratorOptions` fields that drive each one.
+
+{% hint style="info" %}
+These effects require constructing a `BitmapFont` via KernSmith yourself and assigning it directly to `TextRuntime.BitmapFont`. They are not reachable through `Font`, `FontSize`, `OutlineThickness`, or any other `TextRuntime` property — `BmfcSave` does not carry the fields they need.
+
+For the full construction walkthrough (helper method, channel layout caveat, and `BmfcSave`-vs-from-scratch flows), see [Font Strategies — Direct BitmapFont Assignment](font-strategies.md#direct-bitmapfont-assignment). This page focuses on the per-effect options without repeating that setup.
+{% endhint %}
+
+## Baseline Setup
+
+Each sample on this page assumes a small `CreateBitmapFont(BmFontResult, GraphicsDevice)` helper that wraps a `BmFontResult` into a `BitmapFont` — one `Texture2D` per atlas page, then the `BitmapFont(Texture2D[], string)` constructor. The helper body lives in [Font Strategies — From KernSmith with Custom Options](font-strategies.md#from-kernsmith-with-custom-options); copy it from there.
+
+The samples below show only the `FontGeneratorOptions` mutation and the generate-and-assign step. Adapt the starting options either by building from `BmfcSave` via `GumFontGenerator.BuildOptions` or by constructing `FontGeneratorOptions` directly — both flows are covered in the same section.
+
+## Outline Color
+
+`TextRuntime.OutlineThickness` controls outline width but not outline color — outlines on the property-driven path are always black. To pick the color, set `OutlineR/G/B` alongside `Outline`:
+
+```csharp
+// Initialize
+var options = KernSmith.Gum.GumFontGenerator.BuildOptions(bmfcSave);
+options.Outline = 2;
+options.OutlineR = 255;
+options.OutlineG = 64;
+options.OutlineB = 64;
+
+KernSmith.BmFontResult result =
+    KernSmith.BmFont.GenerateFromSystem(bmfcSave.FontName, options);
+BitmapFont bitmapFont = CreateBitmapFont(result, GraphicsDevice);
+```
+
+Outlined fonts use a different channel layout than unoutlined fonts. `GumFontGenerator.BuildOptions` selects the right layout automatically based on `bmfcSave.OutlineThickness`. If you start from a `bmfcSave` with `OutlineThickness = 0` and then bump `options.Outline` to a non-zero value, also set the outlined-text channel layout explicitly:
+
+```csharp
+// Initialize
+options.Channels = new KernSmith.Output.ChannelConfig(
+    Alpha: KernSmith.Output.ChannelContent.Outline,
+    Red:   KernSmith.Output.ChannelContent.Glyph,
+    Green: KernSmith.Output.ChannelContent.Glyph,
+    Blue:  KernSmith.Output.ChannelContent.Glyph);
+```
+
+## Drop Shadow
+
+Drop shadows are baked into the atlas itself — the glyph and its shadow render in a single draw call. Set `ShadowOffsetX/Y` to position the shadow, `ShadowR/G/B` for color, and optionally `ShadowOpacity`, `ShadowBlur`, and `HardShadow`:
+
+```csharp
+// Initialize
+var options = KernSmith.Gum.GumFontGenerator.BuildOptions(bmfcSave);
+options.ShadowOffsetX = 2;
+options.ShadowOffsetY = 2;
+options.ShadowR = 0;
+options.ShadowG = 0;
+options.ShadowB = 0;
+options.ShadowOpacity = 0.6f;
+options.ShadowBlur = 3;          // 0 for a hard-edged shadow
+options.HardShadow = false;      // true uses a binarized silhouette
+
+KernSmith.BmFontResult result =
+    KernSmith.BmFont.GenerateFromSystem(bmfcSave.FontName, options);
+BitmapFont bitmapFont = CreateBitmapFont(result, GraphicsDevice);
+```
+
+Because the shadow is baked into the glyph's own atlas cell, you may need to increase `Padding` to give the shadow room — otherwise blurred shadows can clip at the cell edge.
+
+## Gradient Fill
+
+Gradient fills run vertically by default (top color to bottom color). Set both start and end colors and KernSmith fills each glyph with the gradient:
+
+```csharp
+// Initialize
+var options = KernSmith.Gum.GumFontGenerator.BuildOptions(bmfcSave);
+options.GradientStartR = 255;
+options.GradientStartG = 220;
+options.GradientStartB = 0;      // gold at the top
+options.GradientEndR = 200;
+options.GradientEndG = 120;
+options.GradientEndB = 0;        // amber at the bottom
+options.GradientAngle = 90f;     // 90 = top-to-bottom
+options.GradientMidpoint = 0.5f;
+
+KernSmith.BmFontResult result =
+    KernSmith.BmFont.GenerateFromSystem(bmfcSave.FontName, options);
+BitmapFont bitmapFont = CreateBitmapFont(result, GraphicsDevice);
+```
+
+`GradientAngle` rotates the gradient direction; `GradientMidpoint` (0.0–1.0) biases where the two colors meet.
+
+## SDF Rendering
+
+Signed distance field (SDF) fonts encode glyph shapes as distance fields rather than rasterized pixels. SDF atlases scale up smoothly and can support runtime effects like dynamic outlines — but only if the renderer is set up to consume SDF data. Set `options.Sdf = true` to generate one:
+
+```csharp
+// Initialize
+var options = KernSmith.Gum.GumFontGenerator.BuildOptions(bmfcSave);
+options.Sdf = true;
+
+KernSmith.BmFontResult result =
+    KernSmith.BmFont.GenerateFromSystem(bmfcSave.FontName, options);
+BitmapFont bitmapFont = CreateBitmapFont(result, GraphicsDevice);
+```
+
+{% hint style="warning" %}
+Gum's default text renderer samples the atlas as a normal alpha-blended texture. An SDF atlas rendered this way will look soft or washed out rather than crisp. Consuming SDF properly requires a custom shader that does the distance-field cutoff. Generate-and-assign works today; the visual quality benefits depend on rendering setup that may not exist in your project. If you're not already using SDF shaders elsewhere, prefer a higher-resolution non-SDF atlas instead.
+{% endhint %}
+
+## Custom Character Sets
+
+`BmfcSave.Ranges` controls the character set on the property-driven path, but its format is the BMFont range string. For richer subsetting — for example a UI that only needs digits and a few specific glyphs, or a CJK build with hand-curated codepoints — use `CharacterSet` directly:
+
+```csharp
+// Initialize
+var options = KernSmith.Gum.GumFontGenerator.BuildOptions(bmfcSave);
+options.Characters = KernSmith.Font.CharacterSet.FromChars(new[]
+{
+    '0','1','2','3','4','5','6','7','8','9',
+    '.',':','-','+','%','/',
+});
+
+KernSmith.BmFontResult result =
+    KernSmith.BmFont.GenerateFromSystem(bmfcSave.FontName, options);
+BitmapFont bitmapFont = CreateBitmapFont(result, GraphicsDevice);
+```
+
+A tightly-subsetted atlas can be dramatically smaller than the default ASCII set — useful for a HUD font that only ever shows numbers, or a CJK font where you've pre-scanned your localization tables.
+
+## Custom Glyphs
+
+`CustomGlyphs` lets you inject raw pixel data for specific codepoints — handy for inserting button-prompt icons (gamepad face buttons, key glyphs) into a normal text run so they flow inline with the surrounding text:
+
+```csharp
+// Initialize
+var options = KernSmith.Gum.GumFontGenerator.BuildOptions(bmfcSave);
+options.CustomGlyphs = new Dictionary<int, KernSmith.CustomGlyph>
+{
+    [0xE000] = new KernSmith.CustomGlyph(/* raw pixel data, width, height, etc. */),
+};
+```
+
+See the `KernSmith.CustomGlyph` type for the exact constructor surface — it expects raw pixel bytes, not an encoded PNG.
+
+## Color Fonts (Emoji)
+
+For fonts with COLR/CPAL tables (color emoji fonts, color icon fonts), set `ColorFont = true`. `ColorPaletteIndex` selects a palette when the font ships multiple:
+
+```csharp
+// Initialize
+var options = KernSmith.Gum.GumFontGenerator.BuildOptions(bmfcSave);
+options.ColorFont = true;
+options.ColorPaletteIndex = 0;
+
+KernSmith.BmFontResult result =
+    KernSmith.BmFont.GenerateFromSystem("Noto Color Emoji", options);
+BitmapFont bitmapFont = CreateBitmapFont(result, GraphicsDevice);
+```
+
+## Backend Selection (FreeType vs StbTrueType)
+
+KernSmith uses FreeType by default for glyph rasterization. FreeType produces the best results but requires a native library to be present. On platforms where that's a problem — most notably Blazor WASM — switch to the managed StbTrueType backend:
+
+```csharp
+// Initialize
+var options = KernSmith.Gum.GumFontGenerator.BuildOptions(bmfcSave);
+options.Backend = KernSmith.Rasterizer.RasterizerBackend.StbTrueType;
+
+KernSmith.BmFontResult result =
+    KernSmith.BmFont.GenerateFromSystem(bmfcSave.FontName, options);
+BitmapFont bitmapFont = CreateBitmapFont(result, GraphicsDevice);
+```
+
+`GumFontGenerator.Generate` also takes a `RasterizerBackend?` argument as a shortcut for the same effect when you're not customizing other options.
+
+## Variation Axes
+
+Variable fonts expose continuous axes (weight, width, slant, optical size, etc.) keyed by four-character tags. Pin axes to specific values via `VariationAxes`:
+
+```csharp
+// Initialize
+var options = KernSmith.Gum.GumFontGenerator.BuildOptions(bmfcSave);
+options.VariationAxes = new Dictionary<string, float>
+{
+    ["wght"] = 650f,   // weight between regular (400) and bold (700)
+    ["wdth"] = 110f,   // slightly extended width
+};
+
+KernSmith.BmFontResult result =
+    KernSmith.BmFont.GenerateFromSystem("Inter", options);
+BitmapFont bitmapFont = CreateBitmapFont(result, GraphicsDevice);
+```
+
+## Super-Sampling
+
+`SuperSampleLevel` renders glyphs at N times the requested size then downscales for smoother edges. Useful for large display text where the default rasterization looks a bit chunky:
+
+```csharp
+// Initialize
+var options = KernSmith.Gum.GumFontGenerator.BuildOptions(bmfcSave);
+options.SuperSampleLevel = 2;  // 1 = off, valid range 1-4
+```
+
+Higher super-sampling levels cost proportionally more memory during generation.
+
+## Hinting
+
+By default KernSmith enables FreeType's hinting, which improves crispness at small sizes. For large display sizes or stylized fonts you may prefer the smoother unhinted curves:
+
+```csharp
+// Initialize
+var options = KernSmith.Gum.GumFontGenerator.BuildOptions(bmfcSave);
+options.EnableHinting = false;
+```
+
+## Related Pages
+
+* [Font Strategies — Direct BitmapFont Assignment](font-strategies.md#direct-bitmapfont-assignment) — full construction walkthrough.
+* [BitmapFont](bitmapfont.md) — the runtime type these samples produce.
+* [TextRuntime Fonts](../standard-visuals/textruntime/fonts.md) — the property surface these effects bypass.

--- a/docs/code/files-and-fonts/bitmapfont.md
+++ b/docs/code/files-and-fonts/bitmapfont.md
@@ -6,6 +6,18 @@
 
 For information on loading and assigning fonts, see the [Fonts](fonts.md) page.
 
+## Construction Sources
+
+A `BitmapFont` can be built from several sources:
+
+* **A `.fnt` file path** — `new BitmapFont("path/to/font.fnt")` loads the descriptor from disk and resolves the page textures relative to it.
+* **A `Texture2D[]` plus an `.fnt` text string** — `new BitmapFont(textures, fntText)` skips disk I/O entirely. This is the constructor used when generating fonts via KernSmith, where the page textures and `.fnt` metadata both live in memory.
+* **Embedded resources, network responses, or custom pipelines** — load the bytes yourself, then feed the resulting textures and `.fnt` text into the in-memory constructor above.
+
+A single `BitmapFont` instance can be assigned to any number of `TextRuntime`s via `TextRuntime.BitmapFont`. The atlas textures are shared, so reuse costs nothing extra at draw time.
+
+For the full strategy comparison — when to assign a `BitmapFont` directly vs. drive fonts through `TextRuntime` properties — see [Font Strategies — Direct BitmapFont Assignment](font-strategies.md#direct-bitmapfont-assignment). For effects only available through direct construction (outline color, drop shadows, gradients, SDF, color fonts), see [Advanced Font Effects](advanced-font-effects.md).
+
 ## Measuring Text
 
 The BitmapFont class is ultimately responsible for measuring text. Although the TextRuntime instance does provide many functions for measurement and positioning, the BitmapFont class can give more detailed information if necessary.

--- a/docs/code/files-and-fonts/font-strategies.md
+++ b/docs/code/files-and-fonts/font-strategies.md
@@ -215,7 +215,18 @@ The easiest way to mark all content as "Copy to Output Directory" is to use wild
 
 ## Direct BitmapFont Assignment
 
-You can load a `BitmapFont` yourself and assign it directly, bypassing the font property system entirely:
+You can construct a `BitmapFont` yourself and assign it directly, bypassing the font property system entirely. Two sources for the `BitmapFont` are common:
+
+* [From a .fnt file on disk](#from-a-fnt-file-on-disk) — when you already have a baked atlas.
+* [From KernSmith with custom options](#from-kernsmith-with-custom-options) — when you want visual effects (outline color, shadows, gradients, SDF, color fonts, custom glyph subsets) or backend control that the `TextRuntime` property surface does not expose.
+
+{% hint style="warning" %}
+Once a `BitmapFont` is assigned directly, do not set font component properties (`Font`, `FontSize`, etc.) or `UseCustomFont` on the same `TextRuntime`. Those properties trigger the font loading system, which overwrites the directly assigned `BitmapFont`.
+{% endhint %}
+
+### From a .fnt File on Disk
+
+Load a `BitmapFont` from a `.fnt` file (and its companion `.png` page textures) and assign it:
 
 ```csharp
 // Initialize
@@ -226,14 +237,119 @@ text.Text = "Hello, I am using a directly assigned font";
 text.AddToRoot();
 ```
 
-{% hint style="warning" %}
-Once a `BitmapFont` is assigned directly, do not set font component properties (`Font`, `FontSize`, etc.) or `UseCustomFont` on the same `TextRuntime`. Those properties trigger the font loading system, which overwrites the directly assigned `BitmapFont`.
+### From KernSmith with Custom Options
+
+`TextRuntime` exposes only a subset of the options KernSmith actually supports (`Font`, `FontSize`, `IsBold`, `IsItalic`, `OutlineThickness`, `UseFontSmoothing`). To use effects like outline color, drop shadows, gradient fills, SDF, color fonts, custom glyph subsets, or a non-default rasterizer backend, build a `BitmapFont` yourself by calling KernSmith directly, then assign it.
+
+For the full catalog of effects available through this path, see [Advanced Font Effects](advanced-font-effects.md).
+
+{% hint style="info" %}
+This path requires the KernSmith package for your runtime (`KernSmith.MonoGameGum` or `KernSmith.KniGum`). The bridge type `GumFontGenerator` lives in `KernSmith.GumCommon`, which is a transitive dependency.
 {% endhint %}
+
+#### Flow 1: Start from a BmfcSave, mutate options, then generate
+
+This is the most common flow. `BmfcSave` carries the same font descriptor `TextRuntime` uses internally — start there so size, style, charset, and smoothing match your normal text, then layer in the extras KernSmith supports:
+
+```csharp
+// Initialize
+var bmfcSave = new BmfcSave
+{
+    FontName = "Arial",
+    FontSize = 32,
+    IsBold = true,
+};
+
+var options = KernSmith.Gum.GumFontGenerator.BuildOptions(bmfcSave);
+
+// Layer in effects not exposed via TextRuntime / BmfcSave:
+options.Outline = 2;
+options.OutlineR = 255;
+options.OutlineG = 64;
+options.OutlineB = 64;
+
+KernSmith.BmFontResult result = KernSmith.BmFont.GenerateFromSystem(
+    bmfcSave.FontName, options);
+
+BitmapFont bitmapFont = CreateBitmapFont(result, GraphicsDevice);
+
+var text = new TextRuntime();
+text.BitmapFont = bitmapFont;
+text.Text = "Outlined in red";
+text.AddToRoot();
+```
+
+The helper that wraps a `BmFontResult` into a `BitmapFont` is the same pattern `KernSmithFontCreator.TryCreateFont` uses internally — one `Texture2D` per atlas page, then the `BitmapFont(Texture2D[], string)` constructor:
+
+```csharp
+// Class scope
+static BitmapFont CreateBitmapFont(KernSmith.BmFontResult result,
+    Microsoft.Xna.Framework.Graphics.GraphicsDevice graphicsDevice)
+{
+    var textures = new Microsoft.Xna.Framework.Graphics.Texture2D[result.Pages.Count];
+    for (int i = 0; i < result.Pages.Count; i++)
+    {
+        KernSmith.Atlas.AtlasPage page = result.Pages[i];
+        var texture = new Microsoft.Xna.Framework.Graphics.Texture2D(
+            graphicsDevice, page.Width, page.Height, false,
+            Microsoft.Xna.Framework.Graphics.SurfaceFormat.Color);
+        texture.SetData(page.PixelData);
+        textures[i] = texture;
+    }
+    return new BitmapFont(textures, result.FntText);
+}
+```
+
+#### Flow 2: Build FontGeneratorOptions from scratch
+
+If you don't have a `BmfcSave` to start from — for example you're constructing a one-off display font for a title screen — build the options directly:
+
+```csharp
+// Initialize
+var options = new KernSmith.FontGeneratorOptions
+{
+    Size = 48,
+    Bold = true,
+    Characters = KernSmith.Font.CharacterSet.Ascii,
+    // Match the channel layout Gum's renderer expects for unoutlined text:
+    Channels = new KernSmith.Output.ChannelConfig(
+        Alpha: KernSmith.Output.ChannelContent.Glyph,
+        Red:   KernSmith.Output.ChannelContent.One,
+        Green: KernSmith.Output.ChannelContent.One,
+        Blue:  KernSmith.Output.ChannelContent.One),
+};
+
+KernSmith.BmFontResult result =
+    KernSmith.BmFont.GenerateFromSystem("Arial", options);
+
+BitmapFont bitmapFont = CreateBitmapFont(result, GraphicsDevice);
+```
+
+{% hint style="info" %}
+The `Channels` setting matters. Gum's text renderer expects a specific channel layout: alpha = glyph (RGB = 1) when there is no outline, and alpha = outline (RGB = glyph) when there is one. `GumFontGenerator.BuildOptions` sets this for you — if you build options from scratch you must set it yourself or text will render incorrectly.
+{% endhint %}
+
+#### Sharing One BitmapFont Across Many TextRuntimes
+
+A single `BitmapFont` instance can be assigned to any number of `TextRuntime`s. Generate once, assign many times — there is no per-runtime regeneration cost and the underlying atlas textures are shared:
+
+```csharp
+// Initialize
+BitmapFont titleFont = CreateBitmapFont(result, GraphicsDevice);
+
+foreach (var label in titleLabels)
+{
+    label.BitmapFont = titleFont;
+}
+```
 
 ### When to Use This Strategy
 
 * You want a single `BitmapFont` instance shared across many `TextRuntime`s without each one re-loading from disk.
 * You're loading fonts from a non-standard source (embedded resource, network, custom pipeline) and want to keep the load step out of the property-driven path.
+* You need effects that `TextRuntime` does not expose — outline color, drop shadows, gradient fills, SDF, color fonts, or custom glyph subsets. See [Advanced Font Effects](advanced-font-effects.md).
+* You need a custom character set that doesn't match any `BmfcSave.Ranges` value you'd want to ship.
+* You need to override the rasterizer backend — for example forcing `RasterizerBackend.StbTrueType` on Blazor WASM where the native FreeType library isn't available.
 
 ## Build-Time Font Cache
 

--- a/docs/code/files-and-fonts/fonts.md
+++ b/docs/code/files-and-fonts/fonts.md
@@ -53,6 +53,10 @@ The Gum tool generates these atlases automatically while you edit your project. 
 * [Font Localization](font-localization.md) — current behavior, known limitations, and the per-locale design that's coming.
 * [Font Cache](font-cache.md) — the build-time `.fnt` atlas system, naming convention, and when to use it.
 
+## Need Outline Color, Shadows, or Gradients?
+
+The strategies above all drive fonts through `TextRuntime`'s property surface, which exposes only a subset of what KernSmith can actually generate. If you want outline color (not just thickness), drop shadows, gradient fills, SDF, color fonts, custom glyph subsets, or a non-default rasterizer backend, build a `BitmapFont` via KernSmith yourself and assign it directly. See [Advanced Font Effects](advanced-font-effects.md) for the per-effect catalog and [Font Strategies — Direct BitmapFont Assignment](font-strategies.md#direct-bitmapfont-assignment) for the construction walkthrough.
+
 ## Known Limitations
 
 The following items are not yet supported. None of them are dealbreakers for shipping a game, but they're worth knowing about so you can plan around them:


### PR DESCRIPTION
## Summary

Surfaces the BitmapFont-construction path that unlocks KernSmith features not reachable through `TextRuntime` properties. `BmfcSave` only carries a small slice of `FontGeneratorOptions`, so effects like outline color, drop shadows, gradient fills, SDF, color fonts, and custom glyphs are invisible to users who only read the property-driven docs — even though KernSmith already supports them today.

## Changes

- **`font-strategies.md`** — split the thin "Direct BitmapFont Assignment" section into two named sub-strategies:
  - *From a `.fnt` file on disk* (existing content, preserved).
  - *From KernSmith with custom options* (new) — covers both starting from `BmfcSave` via `GumFontGenerator.BuildOptions` and building `FontGeneratorOptions` from scratch, with the `CreateBitmapFont` helper and a shared-instance example.
- **`advanced-font-effects.md`** (new) — per-effect catalog: outline color, drop shadow, gradient fill, SDF (with renderer-support caveat), custom character sets, custom glyphs, color fonts, backend selection, variation axes, super-sampling, hinting. References the helper from the strategies page rather than duplicating it.
- **`bitmapfont.md`** — adds a Construction Sources section pointing at the strategy and effects pages. Measurement reference preserved.
- **`fonts.md`** — adds a short callout near the bottom for "Need outline color, shadows, or gradients?"
- **`SUMMARY.md`** — registers the new page.

## Test plan

- [ ] GitBook build renders without broken links or hint-tag errors
- [ ] New page reachable from the Fonts subsection in the sidebar
- [ ] Cross-links between `font-strategies.md`, `advanced-font-effects.md`, `bitmapfont.md`, and `fonts.md` resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)