### PR TITLE
#2771: Obsolete ColoredCircle/ColoredRectangle/SolidRectangle/RoundedRectangle runtime shims

### DIFF
--- a/MonoGameGum/GueDeriving/ColoredRectangleRuntime.cs
+++ b/MonoGameGum/GueDeriving/ColoredRectangleRuntime.cs
@@ -28,6 +28,7 @@ namespace Gum.GueDeriving;
 #endif
 
 
+[Obsolete("Use RectangleRuntime with FillColor instead. ColoredRectangleRuntime will be removed in a future release. See docs/gum-tool/upgrading/migrating-to-2026-may.md for the full migration guide.")]
 public class ColoredRectangleRuntime : GraphicalUiElement
 {
     public static float DefaultWidth = 50;

--- a/Runtimes/GumShapes/GueDeriving/ColoredCircleRuntime.cs
+++ b/Runtimes/GumShapes/GueDeriving/ColoredCircleRuntime.cs
@@ -18,6 +18,7 @@ namespace Gum.GueDeriving;
 /// Runtime that draws a circle (or ellipse) sized by its Width and Height. Adds no properties beyond
 /// the AposShapeRuntime common set - color, gradient, drop shadow, and fill/stroke are inherited.
 /// </summary>
+[Obsolete("Use CircleRuntime with FillColor (when IsFilled is true, the default) or StrokeColor (when IsFilled is false) instead. ColoredCircleRuntime will be removed in a future release. See docs/gum-tool/upgrading/migrating-to-2026-may.md for the full migration guide.")]
 public class ColoredCircleRuntime : AposShapeRuntime
 {
     protected override RenderableShapeBase ContainedRenderable => ContainedCircle;

--- a/Runtimes/SkiaGum/GueDeriving/ColoredCircleRuntime.cs
+++ b/Runtimes/SkiaGum/GueDeriving/ColoredCircleRuntime.cs
@@ -4,6 +4,7 @@ using Gum.Wireframe;
 using RenderingLibrary.Graphics;
 using SkiaGum.Renderables;
 using SkiaSharp;
+using System;
 
 #if FRB
 namespace SkiaGum.GueDeriving;
@@ -11,6 +12,7 @@ namespace SkiaGum.GueDeriving;
 namespace Gum.GueDeriving;
 #endif
 
+[Obsolete("Use CircleRuntime with FillColor (when IsFilled is true, the default) or StrokeColor (when IsFilled is false) instead. ColoredCircleRuntime will be removed in a future release. See docs/gum-tool/upgrading/migrating-to-2026-may.md for the full migration guide.")]
 public class ColoredCircleRuntime : SkiaShapeRuntime
 {
     protected override RenderableShapeBase ContainedRenderable => ContainedCircle;

--- a/Runtimes/SkiaGum/GueDeriving/RoundedRectangleRuntime.cs
+++ b/Runtimes/SkiaGum/GueDeriving/RoundedRectangleRuntime.cs
@@ -2,6 +2,7 @@ using Gum.Converters;
 using Gum.DataTypes;
 using Gum.Wireframe;
 using RenderingLibrary.Graphics;
+using System;
 
 #if SKIA
 using SkiaGum.Renderables;
@@ -31,6 +32,7 @@ namespace Gum.GueDeriving;
 /// differences are gated behind <c>#if SKIA</c>; the cross-platform shape (constructor defaults,
 /// CornerRadius property, base wiring) is shared.
 /// </remarks>
+[Obsolete("Use RectangleRuntime with CornerRadius (plus FillColor / StrokeColor for the two-slot model) instead. RoundedRectangleRuntime will be removed in a future release. See docs/gum-tool/upgrading/migrating-to-2026-may.md for the full migration guide.")]
 public class RoundedRectangleRuntime
 #if SKIA
     : SkiaShapeRuntime, IClipPath

--- a/Runtimes/SkiaGum/GueDeriving/SolidRectangleRuntime.cs
+++ b/Runtimes/SkiaGum/GueDeriving/SolidRectangleRuntime.cs
@@ -1,6 +1,7 @@
 ﻿using Gum.Wireframe;
 using SkiaGum.Renderables;
 using SkiaSharp;
+using System;
 
 #if FRB
 namespace SkiaGum.GueDeriving;
@@ -8,6 +9,7 @@ namespace SkiaGum.GueDeriving;
 namespace Gum.GueDeriving;
 #endif
 
+[Obsolete("Use RectangleRuntime with FillColor instead. SolidRectangleRuntime will be removed in a future release. See docs/gum-tool/upgrading/migrating-to-2026-may.md for the full migration guide.")]
 public class SolidRectangleRuntime : InteractiveGue
 {
     SolidRectangle mContainedRectangle;

--- a/Samples/MauiSkiaGum/MainPage.xaml.cs
+++ b/Samples/MauiSkiaGum/MainPage.xaml.cs
@@ -27,11 +27,11 @@ namespace MauiSkiaGum
             MainStack.WrapsChildren = true;
             MainStack.StackSpacing = 16;
 
-            var roundedRectangle = new RoundedRectangleRuntime();
+            var roundedRectangle = new RectangleRuntime();
             MainStack.AddChild(roundedRectangle);
             roundedRectangle.Width = 100;
             roundedRectangle.Height = 100;
-            roundedRectangle.Color = SKColors.Blue;
+            roundedRectangle.FillColor = SKColors.Blue;
 
             // This is the default radius:
             roundedRectangle.CornerRadius = 20;
@@ -86,12 +86,11 @@ namespace MauiSkiaGum
             // Solid red disc behind a thick black almost-full-sweep arc filling the same
             // bounding box. The black ring should obscure most of the red disc; if the stroke
             // value didn't make it through, the red disc shows through where the ring should be.
-            var disc = new ColoredCircleRuntime();
+            var disc = new CircleRuntime();
             container.AddChild(disc);
             disc.Width = diameter;
             disc.Height = diameter;
-            disc.Color = SKColors.Red;
-            disc.IsFilled = true;
+            disc.FillColor = SKColors.Red;
 
             var arc = new ArcRuntime();
             container.AddChild(arc);
@@ -133,9 +132,9 @@ namespace MauiSkiaGum
                 CounterBtn.Text = $"Clicked {count} times";
 
 
-            var circle = new ColoredCircleRuntime();
+            var circle = new CircleRuntime();
             MainStack.AddChild(circle);
-            circle.Color = SKColors.Red;
+            circle.FillColor = SKColors.Red;
             circle.Width = 30;
             circle.Height = 30;
 

--- a/Samples/MauiSkiaGum/MainPage.xaml.cs
+++ b/Samples/MauiSkiaGum/MainPage.xaml.cs
@@ -91,6 +91,10 @@ namespace MauiSkiaGum
             disc.Width = diameter;
             disc.Height = diameter;
             disc.FillColor = SKColors.Red;
+            // CircleRuntime defaults to a 1 px white outline (#2790 two-slot defaults).
+            // The pre-#2771 ColoredCircleRuntime had no stroke slot, so suppress the
+            // outline to preserve the original solid-disc visual.
+            disc.StrokeColor = null;
 
             var arc = new ArcRuntime();
             container.AddChild(arc);
@@ -135,6 +139,9 @@ namespace MauiSkiaGum
             var circle = new CircleRuntime();
             MainStack.AddChild(circle);
             circle.FillColor = SKColors.Red;
+            // Suppress the default 1 px white outline (see #2771 migration note) to
+            // match the pre-migration ColoredCircleRuntime visual.
+            circle.StrokeColor = null;
             circle.Width = 30;
             circle.Height = 30;
 

--- a/Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/CirclesScreen.cs
+++ b/Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/CirclesScreen.cs
@@ -121,14 +121,14 @@ internal class CirclesScreen : FrameworkElement
         return row;
     }
 
-    static ColoredRectangleRuntime BuildAlignmentCell(VerticalAlignment alignment)
+    static RectangleRuntime BuildAlignmentCell(VerticalAlignment alignment)
     {
-        // ColoredRectangle is used as a visible frame so the alignment is obvious. Children
+        // RectangleRuntime is used as a visible frame so the alignment is obvious. Children
         // are positioned relative to it via YOrigin + PixelsFromSmall/Middle/Large.
-        ColoredRectangleRuntime frame = new();
+        RectangleRuntime frame = new();
         frame.Width = 200;
         frame.Height = 100;
-        frame.Color = new Color(40, 40, 60);
+        frame.FillColor = new Color(40, 40, 60);
 
         CircleRuntime circle = new();
         circle.Radius = 20;

--- a/Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/MixedScreen.cs
+++ b/Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/MixedScreen.cs
@@ -18,15 +18,15 @@ internal class MixedScreen : FrameworkElement
         container.ChildrenLayout = Gum.Managers.ChildrenLayout.TopToBottomStack;
         this.AddChild(container);
 
-        AddText(container, "This is a colored rectangle:");
+        AddText(container, "This is a filled rectangle:");
 
-        var coloredRectangleInstance = new ColoredRectangleRuntime();
-        coloredRectangleInstance.X = 10;
-        coloredRectangleInstance.Y = 10;
-        coloredRectangleInstance.Width = 120;
-        coloredRectangleInstance.Height = 24;
-        coloredRectangleInstance.Color = Color.White;
-        container.Children.Add(coloredRectangleInstance);
+        var filledRectangleInstance = new RectangleRuntime();
+        filledRectangleInstance.X = 10;
+        filledRectangleInstance.Y = 10;
+        filledRectangleInstance.Width = 120;
+        filledRectangleInstance.Height = 24;
+        filledRectangleInstance.FillColor = Color.White;
+        container.Children.Add(filledRectangleInstance);
 
         AddText(container, "This is a (line) rectangle:");
 
@@ -84,10 +84,11 @@ internal class MixedScreen : FrameworkElement
 
         for (int i = 0; i < 70; i++)
         {
-            var rectangle = new ColoredRectangleRuntime();
+            var rectangle = new RectangleRuntime();
             stackingContainer.Children.Add(rectangle);
             rectangle.Width = 7;
             rectangle.Height = 7;
+            rectangle.FillColor = Color.White;
         }
 
         container.Children.Add(stackingContainer);

--- a/Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/RectanglesScreen.cs
+++ b/Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/RectanglesScreen.cs
@@ -174,15 +174,15 @@ internal class RectanglesScreen : FrameworkElement
         return row;
     }
 
-    static ColoredRectangleRuntime BuildAlignmentCell(VerticalAlignment alignment)
+    static RectangleRuntime BuildAlignmentCell(VerticalAlignment alignment)
     {
-        // ColoredRectangle is used as the visible frame (the thing whose alignment is
-        // obvious). The inner RectangleRuntime is positioned relative to it via YOrigin
+        // Outer RectangleRuntime is used as the visible frame (the thing whose alignment
+        // is obvious). The inner RectangleRuntime is positioned relative to it via YOrigin
         // + PixelsFromSmall/Middle/Large — same convention the CirclesScreen uses.
-        ColoredRectangleRuntime frame = new();
+        RectangleRuntime frame = new();
         frame.Width = 220;
         frame.Height = 100;
-        frame.Color = new Color(40, 40, 60);
+        frame.FillColor = new Color(40, 40, 60);
 
         RectangleRuntime rect = new();
         rect.Width = 60;

--- a/Samples/SilkNetGum/SilkNetGum/Screens/CirclesScreen.cs
+++ b/Samples/SilkNetGum/SilkNetGum/Screens/CirclesScreen.cs
@@ -252,12 +252,12 @@ internal class CirclesScreen : GraphicalUiElement
         return row;
     }
 
-    static ColoredRectangleRuntime BuildInscribedCell(float strokeWidth)
+    static RectangleRuntime BuildInscribedCell(float strokeWidth)
     {
-        ColoredRectangleRuntime frame = new();
+        RectangleRuntime frame = new();
         frame.Width = 64;
         frame.Height = 64;
-        frame.Color = new SKColor(60, 60, 80);
+        frame.FillColor = new SKColor(60, 60, 80);
 
         CircleRuntime circle = new();
         circle.Radius = 32;
@@ -409,18 +409,18 @@ internal class CirclesScreen : GraphicalUiElement
         return row;
     }
 
-    static ColoredRectangleRuntime BuildAlignmentCell(VerticalAlignment alignment)
+    static RectangleRuntime BuildAlignmentCell(VerticalAlignment alignment)
     {
-        // ColoredRectangle is used as a visible frame so the alignment is obvious. Children
+        // RectangleRuntime is used as a visible frame so the alignment is obvious. Children
         // are positioned relative to it via YOrigin + PixelsFromSmall/Middle/Large.
-        ColoredRectangleRuntime frame = new();
+        RectangleRuntime frame = new();
         // Narrowed from 220 to 128 to keep the left column from forcing the page wider than
         // the right column needs (the long section labels in the right column would otherwise
         // get clipped or push the overall layout). 128 still gives 3 cells * 60 px clearance
         // for the three alignment circles plus row spacing.
         frame.Width = 128;
         frame.Height = 100;
-        frame.Color = new SKColor(50, 50, 70);
+        frame.FillColor = new SKColor(50, 50, 70);
 
         CircleRuntime circle = new();
         circle.Radius = 22;

--- a/Samples/SilkNetGum/SilkNetGum/Screens/CodeOnlyScreen.cs
+++ b/Samples/SilkNetGum/SilkNetGum/Screens/CodeOnlyScreen.cs
@@ -1,6 +1,7 @@
 ﻿using Gum.Wireframe;
 using RenderingLibrary.Graphics;
 using Gum.GueDeriving;
+using SkiaSharp;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -22,10 +23,11 @@ internal class CodeOnlyScreen : GraphicalUiElement
 
         for (int i = 0; i < 5; i++)
         {
-            var rectangle = new RoundedRectangleRuntime();
-            rectangle.Red = 50 + random.Next(150);
-            rectangle.Green = 50 + random.Next(150);
-            rectangle.Blue = 50 + random.Next(150);
+            var rectangle = new RectangleRuntime();
+            rectangle.FillColor = new SKColor(
+                (byte)(50 + random.Next(150)),
+                (byte)(50 + random.Next(150)),
+                (byte)(50 + random.Next(150)));
 
             rectangle.Width = 50;
             rectangle.Height = 50;

--- a/Samples/SilkNetGum/SilkNetGum/Screens/PolygonsScreen.cs
+++ b/Samples/SilkNetGum/SilkNetGum/Screens/PolygonsScreen.cs
@@ -78,12 +78,12 @@ internal class PolygonsScreen : GraphicalUiElement
         return row;
     }
 
-    static ColoredRectangleRuntime BuildCell(PolygonRuntime polygon)
+    static RectangleRuntime BuildCell(PolygonRuntime polygon)
     {
-        ColoredRectangleRuntime frame = new();
+        RectangleRuntime frame = new();
         frame.Width = CellSize;
         frame.Height = CellSize;
-        frame.Color = new SKColor(50, 50, 70);
+        frame.FillColor = new SKColor(50, 50, 70);
         frame.Children.Add(polygon);
         return frame;
     }

--- a/Samples/SilkNetGum/SilkNetGum/Screens/RectanglesScreen.cs
+++ b/Samples/SilkNetGum/SilkNetGum/Screens/RectanglesScreen.cs
@@ -15,9 +15,10 @@ namespace SilkNetGum.Screens;
 //     yet, so this screen derives from GraphicalUiElement and uses Children.Add directly.
 //   - Color type. XNA Microsoft.Xna.Framework.Color becomes SKColor; named colors come from
 //     SkiaSharp.SKColors instead of Color.X.
-//   - CornerRadius row uses RoundedRectangleRuntime here (the Skia two-slot rounded variant
-//     added in #2814). MG side reuses RectangleRuntime since the Apos package overrides the
-//     core rectangle slots with RoundedRectangle and CornerRadius routes through directly.
+//   - CornerRadius row uses RectangleRuntime with CornerRadius on both sides as of #2771
+//     (RoundedRectangleRuntime is now [Obsolete] pointing at the same replacement). The Skia
+//     RectangleRuntime contains a RoundedRectangle renderable internally (#2818) so radii
+//     render correctly without the Apos shapes package.
 //
 // Sections the MG side can't currently mirror (gated by missing API on MG RectangleRuntime
 // rather than a design difference): Gradients, Antialiasing, Dropshadow, DashedStrokes. The
@@ -46,7 +47,7 @@ internal class RectanglesScreen : GraphicalUiElement
         left.Children.Add(BuildSection("Modes: FillColor, StrokeColor, Fill+Stroke, default", BuildModeRow()));
         left.Children.Add(BuildSection("StrokeWidth (1, 2, 4, 8 px)", BuildStrokeWidthRow()));
         left.Children.Add(BuildSection("Alignment inside a 128x100 frame (Top / Center / Bottom)", BuildAlignmentRow()));
-        left.Children.Add(BuildSection("CornerRadius (0, 6, 16, 28) — exercises RoundedRectangleRuntime (#2814)", BuildCornerRadiusRow()));
+        left.Children.Add(BuildSection("CornerRadius (0, 6, 16, 28) — RectangleRuntime + CornerRadius (#2814, #2771)", BuildCornerRadiusRow()));
         left.Children.Add(BuildSection("Per-corner radii on RectangleRuntime (TL=20, TR=2, BR=20, BL=2 — #2818)", BuildPerCornerRow()));
         left.Children.Add(BuildSection("Gradients (linear / radial / diagonal / centered)", BuildGradientRow()));
 
@@ -171,15 +172,16 @@ internal class RectanglesScreen : GraphicalUiElement
         return row;
     }
 
-    // CornerRadius row exercises RoundedRectangleRuntime — the Skia two-slot variant added in
-    // #2814 alongside the rectangle's two-slot rework. Same fill+stroke composition, just
-    // with rounded corners.
+    // CornerRadius row exercises RectangleRuntime with CornerRadius (#2771 migration target;
+    // previously RoundedRectangleRuntime). Same fill+stroke composition, just with rounded
+    // corners — RectangleRuntime on Skia contains a RoundedRectangle internally (#2818) so
+    // radii reach the renderer the same way.
     static ContainerRuntime BuildCornerRadiusRow()
     {
         ContainerRuntime row = BuildHorizontalRow();
         foreach (float cornerRadius in new[] { 0f, 6f, 16f, 28f })
         {
-            RoundedRectangleRuntime rect = new();
+            RectangleRuntime rect = new();
             rect.Width = 80;
             rect.Height = 60;
             rect.FillColor = new SKColor(40, 40, 80);
@@ -305,12 +307,12 @@ internal class RectanglesScreen : GraphicalUiElement
         return row;
     }
 
-    static ColoredRectangleRuntime BuildInscribedCell(float strokeWidth)
+    static RectangleRuntime BuildInscribedCell(float strokeWidth)
     {
-        ColoredRectangleRuntime frame = new();
+        RectangleRuntime frame = new();
         frame.Width = 64;
         frame.Height = 64;
-        frame.Color = new SKColor(60, 60, 80);
+        frame.FillColor = new SKColor(60, 60, 80);
 
         RectangleRuntime rect = new();
         rect.Width = 64;
@@ -463,14 +465,14 @@ internal class RectanglesScreen : GraphicalUiElement
         return row;
     }
 
-    static ColoredRectangleRuntime BuildAlignmentCell(VerticalAlignment alignment)
+    static RectangleRuntime BuildAlignmentCell(VerticalAlignment alignment)
     {
-        // ColoredRectangle is used as a visible frame so the alignment is obvious. Children
+        // RectangleRuntime is used as a visible frame so the alignment is obvious. Children
         // are positioned relative to it via YOrigin + PixelsFromSmall/Middle/Large.
-        ColoredRectangleRuntime frame = new();
+        RectangleRuntime frame = new();
         frame.Width = 128;
         frame.Height = 100;
-        frame.Color = new SKColor(50, 50, 70);
+        frame.FillColor = new SKColor(50, 50, 70);
 
         RectangleRuntime rect = new();
         rect.Width = 50;

--- a/Samples/SkiaGumWpfSample/SkiaGumWpfSample/MainWindow.xaml.cs
+++ b/Samples/SkiaGumWpfSample/SkiaGumWpfSample/MainWindow.xaml.cs
@@ -31,17 +31,13 @@ namespace SkiaGumWpfSample
             SkiaElement.Children.Add(container);
 
 
-            var rectangle = new RoundedRectangleRuntime();
+            var rectangle = new RectangleRuntime();
 
-            rectangle.Red = 50;
-            rectangle.Green = 100;
-            rectangle.Blue = 0;
+            rectangle.FillColor = new SkiaSharp.SKColor(50, 100, 0);
             container.Children.Add(rectangle);
 
-            var rectangle2 = new RoundedRectangleRuntime();
-            rectangle2.Red = 200;
-            rectangle2.Green = 0;
-            rectangle2.Blue = 0;
+            var rectangle2 = new RectangleRuntime();
+            rectangle2.FillColor = new SkiaSharp.SKColor(200, 0, 0);
 
             container.Children.Add(rectangle2);
 

--- a/Samples/raylib/RaylibSample.sln
+++ b/Samples/raylib/RaylibSample.sln
@@ -1,12 +1,14 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.5.2.0
+# Visual Studio Version 18
+VisualStudioVersion = 18.6.11806.211 stable
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GumTest", "GumTest.csproj", "{1E0BB435-C50E-A2C7-CCFA-DF49C3924E5E}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GumCommon", "..\..\GumCommon\GumCommon.csproj", "{5B23E538-252F-4AD1-9149-541654225D7B}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RaylibGum", "..\..\Runtimes\RaylibGum\RaylibGum.csproj", "{6807EC07-BC95-45CD-AB76-7E322C8D7A45}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Libraries", "Libraries", "{4313C869-9260-4A30-B99B-00CFA8C35580}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -29,6 +31,10 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{5B23E538-252F-4AD1-9149-541654225D7B} = {4313C869-9260-4A30-B99B-00CFA8C35580}
+		{6807EC07-BC95-45CD-AB76-7E322C8D7A45} = {4313C869-9260-4A30-B99B-00CFA8C35580}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {4F5D3CDA-0162-4973-9D14-9F313B9DAEB4}

--- a/Samples/raylib/Screens/CirclesScreen.cs
+++ b/Samples/raylib/Screens/CirclesScreen.cs
@@ -171,12 +171,12 @@ internal class CirclesScreen : FrameworkElement
         return row;
     }
 
-    static ColoredRectangleRuntime BuildAlignmentCell(VerticalAlignment alignment)
+    static RectangleRuntime BuildAlignmentCell(VerticalAlignment alignment)
     {
-        ColoredRectangleRuntime frame = new();
+        RectangleRuntime frame = new();
         frame.Width = 128;
         frame.Height = 100;
-        frame.Color = new Color(50, 50, 70, 255);
+        frame.FillColor = new Color(50, 50, 70, 255);
 
         CircleRuntime circle = new();
         circle.Radius = 22;
@@ -289,12 +289,12 @@ internal class CirclesScreen : FrameworkElement
         return row;
     }
 
-    static ColoredRectangleRuntime BuildInscribedCell(float strokeWidth)
+    static RectangleRuntime BuildInscribedCell(float strokeWidth)
     {
-        ColoredRectangleRuntime frame = new();
+        RectangleRuntime frame = new();
         frame.Width = 64;
         frame.Height = 64;
-        frame.Color = new Color(60, 60, 80, 255);
+        frame.FillColor = new Color(60, 60, 80, 255);
 
         CircleRuntime circle = new();
         circle.Radius = 32;

--- a/Samples/raylib/Screens/PolygonsScreen.cs
+++ b/Samples/raylib/Screens/PolygonsScreen.cs
@@ -82,12 +82,12 @@ internal class PolygonsScreen : FrameworkElement
         return row;
     }
 
-    static ColoredRectangleRuntime BuildCell(PolygonRuntime polygon)
+    static RectangleRuntime BuildCell(PolygonRuntime polygon)
     {
-        ColoredRectangleRuntime frame = new();
+        RectangleRuntime frame = new();
         frame.Width = CellSize;
         frame.Height = CellSize;
-        frame.Color = new Color(50, 50, 70, 255);
+        frame.FillColor = new Color(50, 50, 70, 255);
         frame.Children.Add(polygon);
         return frame;
     }

--- a/Samples/raylib/Screens/RawVisualsScreen.cs
+++ b/Samples/raylib/Screens/RawVisualsScreen.cs
@@ -134,20 +134,20 @@ internal class RawVisualsScreen : FrameworkElement
         rotatedPolygon.Rotation = -20;
         row.AddChild(rotatedPolygon);
 
-        var rectangle = new ColoredRectangleRuntime();
+        var rectangle = new RectangleRuntime();
         rectangle.Width = 80;
         rectangle.Height = 80;
-        rectangle.Color = new Color(80, 160, 220, 255);
+        rectangle.FillColor = new Color(80, 160, 220, 255);
         row.AddChild(rectangle);
 
         var circle = new CircleRuntime();
         circle.Radius = 40;
-        circle.Color = new Color(255, 100, 50, 255);
+        circle.FillColor = new Color(255, 100, 50, 255);
         row.AddChild(circle);
 
         var bigCircle = new CircleRuntime();
         bigCircle.Radius = 60;
-        bigCircle.Color = new Color(50, 180, 80, 255);
+        bigCircle.FillColor = new Color(50, 180, 80, 255);
         row.AddChild(bigCircle);
     }
 

--- a/Samples/raylib/Screens/RectanglesScreen.cs
+++ b/Samples/raylib/Screens/RectanglesScreen.cs
@@ -183,12 +183,12 @@ internal class RectanglesScreen : FrameworkElement
         return row;
     }
 
-    static ColoredRectangleRuntime BuildAlignmentCell(VerticalAlignment alignment)
+    static RectangleRuntime BuildAlignmentCell(VerticalAlignment alignment)
     {
-        ColoredRectangleRuntime frame = new();
+        RectangleRuntime frame = new();
         frame.Width = 128;
         frame.Height = 100;
-        frame.Color = new Color(50, 50, 70, 255);
+        frame.FillColor = new Color(50, 50, 70, 255);
 
         RectangleRuntime rect = new();
         rect.Width = 50;
@@ -324,12 +324,12 @@ internal class RectanglesScreen : FrameworkElement
         return row;
     }
 
-    static ColoredRectangleRuntime BuildInscribedCell(float strokeWidth)
+    static RectangleRuntime BuildInscribedCell(float strokeWidth)
     {
-        ColoredRectangleRuntime frame = new();
+        RectangleRuntime frame = new();
         frame.Width = 64;
         frame.Height = 64;
-        frame.Color = new Color(60, 60, 80, 255);
+        frame.FillColor = new Color(60, 60, 80, 255);
 
         RectangleRuntime rect = new();
         rect.Width = 64;

--- a/docs/gum-tool/upgrading/migrating-to-2026-may.md
+++ b/docs/gum-tool/upgrading/migrating-to-2026-may.md
@@ -241,6 +241,18 @@ The obsoleted types and their replacements:
 **`ColoredCircleRuntime.Color` is a passthrough — the rendered slot depends on `IsFilled`.** The Apos constructor defaults `IsFilled = true`, so `Color` paints the **fill** in the common case. If your code sets `IsFilled = false` (outline-only circle), migrate `Color` to `StrokeColor` instead. If the circle is both filled and outlined, set `FillColor` and `StrokeColor` explicitly on the new `CircleRuntime`.
 {% endhint %}
 
+{% hint style="warning" %}
+**`CircleRuntime` ships with a default 1 px white outline.** `ColoredCircleRuntime` had no stroke slot, so a freshly-constructed `ColoredCircleRuntime` with only `Color` set rendered as a solid disc with no outline. `CircleRuntime` (#2790 two-slot model) defaults to `StrokeColor = White` so cells that only set `FillColor` still get a visible outline — which means a literal `new CircleRuntime { FillColor = Color.Red }` renders as a red disc surrounded by a thin white ring. If you want the old solid-disc visual, suppress the outline explicitly:
+
+```csharp
+CircleRuntime circle = new();
+circle.FillColor = Color.Red;
+circle.StrokeColor = null; // disable the default white outline
+```
+
+The same caveat applies anywhere you migrate a fill-only `ColoredCircleRuntime` — including the Maui / Skia counter circles in the bundled samples, which add this line for the same reason.
+{% endhint %}
+
 ❌ Old:
 
 ```csharp

--- a/docs/gum-tool/upgrading/migrating-to-2026-may.md
+++ b/docs/gum-tool/upgrading/migrating-to-2026-may.md
@@ -276,6 +276,11 @@ rounded.FillColor = new Color(0, 128, 255);
 rounded.CornerRadius = 8;
 ```
 
+For runnable examples of the replacement API surface — including `FillColor`-only, `StrokeColor`-only, combined fill + stroke, alpha, and `CornerRadius` cases — see the `MonoGameGumInCode` sample:
+
+* [`Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/CirclesScreen.cs`](../../../Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/CirclesScreen.cs) — `CircleRuntime` with `FillColor`, `StrokeColor`, default (outline-only), and alpha rows.
+* [`Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/RectanglesScreen.cs`](../../../Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/RectanglesScreen.cs) — `RectangleRuntime` with `FillColor`, `StrokeColor`, fill + stroke combined, alpha, and `CornerRadius` rows (uses the two-slot composition model that powers the migration).
+
 An automated code fix is planned via the `Gum.Analyzers` package (`GUM002`) — once published, place the cursor on the warning, trigger the lightbulb (Ctrl+.), and choose the **Change to `RectangleRuntime`** / **Change to `CircleRuntime`** fix. **Fix all in solution** will migrate the entire project at once.
 
 The obsolete types will remain in place until at least the November 2026 release. After that window, they may be marked `[Obsolete(error: true)]` in a subsequent release, breaking compilation for any code still using them.

--- a/docs/gum-tool/upgrading/migrating-to-2026-may.md
+++ b/docs/gum-tool/upgrading/migrating-to-2026-may.md
@@ -221,3 +221,61 @@ Other defaults preserved (no migration needed, listed for reference):
 - Dropshadow defaults (`DropshadowAlpha = 255`, `DropshadowOffsetY = 3`, `DropshadowBlurY = 3`) are still seeded; inert until `HasDropshadow` is set to `true`.
 
 Gradients, dropshadow, and dashed strokes remain Skia-only — those features have no equivalent on the XNA-likes / Raylib backends and stay gated behind `#if SKIA` in the shared source.
+
+### Shape runtime shims obsolete: `ColoredCircleRuntime`, `ColoredRectangleRuntime`, `SolidRectangleRuntime`, `RoundedRectangleRuntime`
+
+`CircleRuntime` and `RectangleRuntime` now cover the full fill + stroke + corner-radius surface on every backend (MonoGame, FNA, KNI, Raylib, Skia, and Apos.Shapes) via a two-slot composition model — one renderable for the fill, a second parented under it for the stroke. With that consolidation in place, the older shape runtime types that wrapped a single renderable each are now `[Obsolete]` and will be removed in a future release.
+
+Existing code continues to compile, but each reference now produces a `CS0618` compiler warning. The replacement types live alongside the obsolete ones in `Gum.GueDeriving`, so the only change at most call sites is the type name (and the property name, per the mapping below).
+
+The obsoleted types and their replacements:
+
+| Old type | Replacement | Color property mapping |
+| --- | --- | --- |
+| `ColoredCircleRuntime` (Apos + Skia) | `CircleRuntime` | `Color` → `FillColor` when `IsFilled` is `true` (the Apos default), `Color` → `StrokeColor` when `IsFilled` is `false` (see note below) |
+| `ColoredRectangleRuntime` (core, used by all XNA-likes + Raylib + Skia) | `RectangleRuntime` | `Color` → `FillColor` |
+| `SolidRectangleRuntime` (Skia) | `RectangleRuntime` | `Color` → `FillColor` |
+| `RoundedRectangleRuntime` (Apos + Skia) | `RectangleRuntime` + `CornerRadius` | `Red` / `Green` / `Blue` → `FillColor`; existing `CornerRadius` maps 1:1 |
+
+{% hint style="info" %}
+**`ColoredCircleRuntime.Color` is a passthrough — the rendered slot depends on `IsFilled`.** The Apos constructor defaults `IsFilled = true`, so `Color` paints the **fill** in the common case. If your code sets `IsFilled = false` (outline-only circle), migrate `Color` to `StrokeColor` instead. If the circle is both filled and outlined, set `FillColor` and `StrokeColor` explicitly on the new `CircleRuntime`.
+{% endhint %}
+
+❌ Old:
+
+```csharp
+var rect = new ColoredRectangleRuntime();
+rect.Color = Color.Red;
+
+var disc = new ColoredCircleRuntime(); // IsFilled = true by default
+disc.Color = Color.Yellow;
+
+var ring = new ColoredCircleRuntime();
+ring.IsFilled = false;
+ring.Color = Color.Yellow; // paints the stroke when IsFilled = false
+
+var rounded = new RoundedRectangleRuntime();
+rounded.Red = 0; rounded.Green = 128; rounded.Blue = 255;
+rounded.CornerRadius = 8;
+```
+
+✅ New:
+
+```csharp
+var rect = new RectangleRuntime();
+rect.FillColor = Color.Red;
+
+var disc = new CircleRuntime();
+disc.FillColor = Color.Yellow;
+
+var ring = new CircleRuntime();
+ring.StrokeColor = Color.Yellow;
+
+var rounded = new RectangleRuntime();
+rounded.FillColor = new Color(0, 128, 255);
+rounded.CornerRadius = 8;
+```
+
+An automated code fix is planned via the `Gum.Analyzers` package (`GUM002`) — once published, place the cursor on the warning, trigger the lightbulb (Ctrl+.), and choose the **Change to `RectangleRuntime`** / **Change to `CircleRuntime`** fix. **Fix all in solution** will migrate the entire project at once.
+
+The obsolete types will remain in place until at least the November 2026 release. After that window, they may be marked `[Obsolete(error: true)]` in a subsequent release, breaking compilation for any code still using them.

--- a/docs/gum-tool/upgrading/migrating-to-2026-may.md
+++ b/docs/gum-tool/upgrading/migrating-to-2026-may.md
@@ -276,11 +276,6 @@ rounded.FillColor = new Color(0, 128, 255);
 rounded.CornerRadius = 8;
 ```
 
-For runnable examples of the replacement API surface — including `FillColor`-only, `StrokeColor`-only, combined fill + stroke, alpha, and `CornerRadius` cases — see the `MonoGameGumInCode` sample:
-
-* [`Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/CirclesScreen.cs`](../../../Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/CirclesScreen.cs) — `CircleRuntime` with `FillColor`, `StrokeColor`, default (outline-only), and alpha rows.
-* [`Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/RectanglesScreen.cs`](../../../Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/RectanglesScreen.cs) — `RectangleRuntime` with `FillColor`, `StrokeColor`, fill + stroke combined, alpha, and `CornerRadius` rows (uses the two-slot composition model that powers the migration).
-
 An automated code fix is planned via the `Gum.Analyzers` package (`GUM002`) — once published, place the cursor on the warning, trigger the lightbulb (Ctrl+.), and choose the **Change to `RectangleRuntime`** / **Change to `CircleRuntime`** fix. **Fix all in solution** will migrate the entire project at once.
 
 The obsolete types will remain in place until at least the November 2026 release. After that window, they may be marked `[Obsolete(error: true)]` in a subsequent release, breaking compilation for any code still using them.


### PR DESCRIPTION
## Summary

Phase 3 of #2761: marks the legacy single-renderable shape runtimes `[Obsolete]` now that `CircleRuntime` and `RectangleRuntime` cover the full fill + stroke + corner-radius surface via the two-slot composition model on every backend.

Six target types across five files (RoundedRectangleRuntime's shared file covers both Apos and Skia):

* `ColoredCircleRuntime` (Apos `Runtimes/GumShapes/GueDeriving/`) → `CircleRuntime`
* `ColoredCircleRuntime` (Skia `Runtimes/SkiaGum/GueDeriving/`) → `CircleRuntime`
* `ColoredRectangleRuntime` (`MonoGameGum/GueDeriving/`, used by XNA-likes + Raylib + Skia + Sokol) → `RectangleRuntime` + `FillColor`
* `SolidRectangleRuntime` (Skia) → `RectangleRuntime` + `FillColor`
* `RoundedRectangleRuntime` (shared Apos/Skia source file) → `RectangleRuntime` + `CornerRadius`

Migration guide section added at `docs/gum-tool/upgrading/migrating-to-2026-may.md`.

## Notes / call-outs

* **Inheritance not swapped.** Issue listed base-class swaps as "if practical". Decided against — proxy-property cost outweighs benefit; the goal here is to make types obsolete, not refactor them. Falls under the issue's documented fallback.
* **Internal call sites intentionally left alone.** Roughly 849 references inside Gum (`DefaultButtonRuntime`, `DefaultCheckboxRuntime`, all Forms `DefaultVisuals`, tests) now emit `CS0618`. Migrating those depends on whether V1/V2 visuals get marked obsolete vs. spinning up V4 visuals against the new shape runtimes — a separate decision and out of scope here.
* **Issue had an incorrect semantic claim.** The issue said `ColoredCircleRuntime.Color` "paints the outline (stroke), not the fill" and instructed mapping `Color → StrokeColor`. After inspecting `SkiaShapeRuntime.Color` (a passthrough to `ContainedRenderable.Color`) and the Apos `ColoredCircleRuntime` constructor (`IsFilled = true; Color = White` by default), the actual semantic is: `Color` paints whatever slot `IsFilled` selects. The guide and obsolete messages now document both cases (`FillColor` when `IsFilled = true`, `StrokeColor` when `IsFilled = false`).
* **#2811 (GUM002 analyzer) cross-check** intentionally out of scope per the issue — that PR needs to mirror the same six targets when it lands.

## Test plan

- [x] `dotnet build` clean on `MonoGameGum`, `SkiaGum`, `RaylibGum`, `MonoGameGumShapes` (warnings only, no errors)
- [x] `dotnet test MonoGameGum.Tests/MonoGameGum.Tests.csproj` — 1506 passed, 0 failed
- [x] Reviewer eyeballs the migration guide section for tone/accuracy

Closes #2771

🤖 Generated with [Claude Code](https://claude.com/claude-code)