### PR TITLE
#2835: Suppress Apos.Shapes content compile via .targets (import-order fix)

### DIFF
--- a/Runtimes/GumShapes/KniGumShapes.csproj
+++ b/Runtimes/GumShapes/KniGumShapes.csproj
@@ -73,6 +73,7 @@
 
 	<ItemGroup>
 		<None Include="buildTransitive\Gum.Shapes.KNI.props" Pack="true" PackagePath="buildTransitive\" />
+		<None Include="buildTransitive\Gum.Shapes.KNI.targets" Pack="true" PackagePath="buildTransitive\" />
 		<None Include="buildTransitive\Content\DesktopGL\apos-shapes.xnb" Pack="true" PackagePath="buildTransitive\Content\DesktopGL\" />
 		<None Include="buildTransitive\Content\Windows\apos-shapes.xnb" Pack="true" PackagePath="buildTransitive\Content\Windows\" />
 		<None Include="buildTransitive\Content\BlazorGL\apos-shapes.xnb" Pack="true" PackagePath="buildTransitive\Content\BlazorGL\" />

--- a/Runtimes/GumShapes/MonoGameGumShapes.csproj
+++ b/Runtimes/GumShapes/MonoGameGumShapes.csproj
@@ -63,6 +63,7 @@
 
 	<ItemGroup>
 		<None Include="buildTransitive\Gum.Shapes.MonoGame.props" Pack="true" PackagePath="buildTransitive\" />
+		<None Include="buildTransitive\Gum.Shapes.MonoGame.targets" Pack="true" PackagePath="buildTransitive\" />
 		<None Include="buildTransitive\MonoGame\Content\DesktopGL\apos-shapes.xnb" Pack="true" PackagePath="buildTransitive\MonoGame\Content\DesktopGL\" />
 		<None Include="buildTransitive\MonoGame\Content\WindowsDX\apos-shapes.xnb" Pack="true" PackagePath="buildTransitive\MonoGame\Content\WindowsDX\" />
 	</ItemGroup>

--- a/Runtimes/GumShapes/buildTransitive/Gum.Shapes.KNI.targets
+++ b/Runtimes/GumShapes/buildTransitive/Gum.Shapes.KNI.targets
@@ -1,0 +1,11 @@
+<Project>
+
+  <!-- Suppress Apos.Shapes.KNI's Content.mgcb shader compile for platforms where we
+       ship pre-built XNBs. See Gum.Shapes.MonoGame.targets for why this lives in a
+       .targets rather than the .props. Apos.Shapes.KNI uses KniContentReference
+       (not MonoGameContentReference); $(AposShapesPath) is defined the same way. -->
+  <ItemGroup Condition="'$(KniPlatform)' == 'DesktopGL' OR '$(KniPlatform)' == 'Windows' OR '$(KniPlatform)' == 'BlazorGL'">
+    <KniContentReference Remove="$(AposShapesPath)" />
+  </ItemGroup>
+
+</Project>

--- a/Runtimes/GumShapes/buildTransitive/Gum.Shapes.MonoGame.targets
+++ b/Runtimes/GumShapes/buildTransitive/Gum.Shapes.MonoGame.targets
@@ -1,0 +1,14 @@
+<Project>
+
+  <!-- Suppress Apos.Shapes' Content.mgcb shader compile for platforms where we ship
+       pre-built XNBs. Must live in a .targets file (not .props) because Apos.Shapes'
+       buildTransitive .props is imported before ours: by the time our .props sets
+       $(SkipAposShapeContent), Apos.Shapes has already added the MonoGameContentReference.
+       .targets are imported after the consuming project, so items are fully collected
+       and we can Remove the offending entry by its identity. $(AposShapesPath) is
+       defined by Apos.Shapes.props as the path to its Content.mgcb. -->
+  <ItemGroup Condition="'$(MonoGamePlatform)' == 'DesktopGL' OR '$(MonoGamePlatform)' == 'WindowsDX'">
+    <MonoGameContentReference Remove="$(AposShapesPath)" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary

- Fixes the `MSB3073` mgcb shader-compile failure that consumers of `Gum.Shapes.MonoGame` (and `Gum.Shapes.KNI`) hit even though the packages ship pre-built `apos-shapes.xnb` files for the relevant platforms.
- The existing `.props`-based `$(SkipAposShapeContent)=true` suppression doesn't work because of MSBuild import order: Apos.Shapes' buildTransitive `.props` is imported before ours (it's the leaf dependency), so the property flip happens after Apos.Shapes has already added the `MonoGameContentReference` / `KniContentReference`.
- Add a sibling `.targets` file for each package. `.targets` are imported after the consuming project, so items are fully collected and we can `Remove` the entry by its identity (`$(AposShapesPath)`, which Apos.Shapes' .props defines as the path to its `Content.mgcb`).
- Existing `.props` files are unchanged — they still do the useful work of copying the pre-built XNB to the output directory.

## Test plan

- [x] Build `MonoGameGumShapes.csproj` and `KniGumShapes.csproj` in Release — no errors.
- [x] Pack `Gum.Shapes.MonoGame` to a local feed, reference from a fresh MonoGame `DesktopGL` consumer (QuestToCompileGum) — `dotnet build` succeeds and the `mgcb` shader compile is no longer attempted.
- [ ] After a new preview package is published, re-verify by removing the local feed and pointing QuestToCompileGum at the published preview.

Closes #2835

🤖 Generated with [Claude Code](https://claude.com/claude-code)