### PR TITLE
#2837: Fire InstancesDelete from multi-instance delete path

### DIFF
--- a/Gum/Managers/DeleteLogic.cs
+++ b/Gum/Managers/DeleteLogic.cs
@@ -308,6 +308,16 @@ public class DeleteLogic : IDeleteLogic
 
         if (result != true) return;
 
+        PerformConfirmedMixedTypeDelete(elements, behaviors, deletableInstances, combinedArray, optionsWindow);
+    }
+
+    internal void PerformConfirmedMixedTypeDelete(
+        List<ElementSave> elements,
+        List<BehaviorSave> behaviors,
+        List<InstanceSave> deletableInstances,
+        Array combinedArray,
+        DeleteOptionsWindow? optionsWindow)
+    {
         // Cache behavior parents before removal (GetBehaviorContainerOf won't find them after)
         var affectedBehaviorParents = deletableInstances
             .Select(i => ObjectFinder.Self.GetBehaviorContainerOf(i))
@@ -318,7 +328,15 @@ public class DeleteLogic : IDeleteLogic
         // 1. Notify plugins before removal so they can still find children via
         //    parent reference variables (e.g. "Child.Parent = thisInstance").
         //    RemoveInstanceFromElement destroys those references, breaking GetChildrenOf.
-        _pluginManager.DeleteConfirmed(optionsWindow, combinedArray);
+        _pluginManager.DeleteConfirmed(optionsWindow!, combinedArray);
+
+        // Group instances by their (non-deleted) parent element. Used both for the
+        // post-removal InstancesDelete plugin notification and for the file-save pass below.
+        // Capture before removal so ParentContainer back-references are still intact.
+        var instancesByElementParent = deletableInstances
+            .Where(i => i.ParentContainer != null && !elements.Contains(i.ParentContainer))
+            .GroupBy(i => i.ParentContainer!)
+            .ToList();
 
         // 2. Remove instances (skip if parent element/behavior is also being deleted)
         foreach (var instance in deletableInstances)
@@ -337,19 +355,27 @@ public class DeleteLogic : IDeleteLogic
             }
         }
 
-        // 3. Remove elements
+        // 3. Notify plugins per affected parent element so listeners (e.g. the codegen
+        //    plugin that regenerates a screen's .Generated.cs) see the change. Without
+        //    this, multi-instance deletes leave plugin-owned state stale.
+        foreach (var group in instancesByElementParent)
+        {
+            _pluginManager.InstancesDelete(group.Key, group.ToArray());
+        }
+
+        // 4. Remove elements
         foreach (var element in elements)
         {
             RemoveElement(element);
         }
 
-        // 4. Remove behaviors
+        // 5. Remove behaviors
         foreach (var behavior in behaviors)
         {
             RemoveBehavior(behavior);
         }
 
-        // 5. Update selection to avoid stale references
+        // 6. Update selection to avoid stale references
         if (elements.Count > 0)
         {
             _selectedState.SelectedElement = null;
@@ -360,18 +386,12 @@ public class DeleteLogic : IDeleteLogic
             _selectedState.SelectedInstance = null;
         }
 
-        // 6. Refresh and save for instance parents that were not themselves deleted
+        // 7. Refresh and save for instance parents that were not themselves deleted
         if (deletableInstances.Count > 0)
         {
-            var affectedElementParents = deletableInstances
-                .Select(i => i.ParentContainer)
-                .Where(e => e != null && !elements.Contains(e))
-                .Distinct()
-                .ToList();
-
-            foreach (var parent in affectedElementParents)
+            foreach (var group in instancesByElementParent)
             {
-                SaveElementAfterInstanceRemoval(parent);
+                SaveElementAfterInstanceRemoval(group.Key);
             }
 
             foreach (var behavior in affectedBehaviorParents)

--- a/Tool/Tests/GumToolUnitTests/Managers/DeleteLogicTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Managers/DeleteLogicTests.cs
@@ -165,6 +165,32 @@ public class DeleteLogicTests : BaseTestClass
     }
 
     [Fact]
+    public void PerformConfirmedMixedTypeDelete_MultipleInstancesInSameElement_FiresInstancesDeleteOnPluginManager()
+    {
+        // Regression: deleting multiple instances at once never fired InstancesDelete on the
+        // plugin manager, so plugins listening for instance removal (e.g. the codegen plugin
+        // that regenerates a screen's .Generated.cs) never refreshed.
+        ScreenSave screen = CreateScreenWithInstances("InstA", "InstB");
+        List<InstanceSave> instances = screen.Instances.ToList();
+
+        _deleteLogic.PerformConfirmedMixedTypeDelete(
+            new List<ElementSave>(),
+            new List<BehaviorSave>(),
+            instances,
+            instances.Cast<object>().ToArray(),
+            optionsWindow: null);
+
+        _pluginManager.Verify(
+            p => p.InstancesDelete(
+                screen,
+                It.Is<InstanceSave[]>(arr =>
+                    arr.Length == 2 &&
+                    arr.Contains(instances[0]) &&
+                    arr.Contains(instances[1]))),
+            Times.Once);
+    }
+
+    [Fact]
     public void RemoveBehavior_RemovesBehaviorAndReferences()
     {
         BehaviorSave behavior = new BehaviorSave { Name = "TestBehavior" };


### PR DESCRIPTION
## Summary
- `DeleteLogic.HandleMixedTypeDeletion` removed instances directly via `RemoveInstanceFromElement` without raising `_pluginManager.InstancesDelete`, so plugins listening for instance removal (notably the CodeOutput plugin's `HandleInstanceDeleted` → auto-regenerate path) never fired on a multi-instance delete. A screen's `.Generated.cs` stayed stale until some other change triggered regeneration.
- The single-instance delete path already fires `InstanceDelete`, which is why the user-reported repro depended on selection shape; the bug surfaces whenever the multi-select path is taken.
- Fix: group the deletable instances by their (non-deleted) parent element once, fire `_pluginManager.InstancesDelete(parent, group)` per affected parent, and reuse the same grouping for the post-delete save pass. The post-confirmation work is extracted into `internal PerformConfirmedMixedTypeDelete` so it can be exercised without the WPF dialog.

## Test plan
- [x] New unit test `PerformConfirmedMixedTypeDelete_MultipleInstancesInSameElement_FiresInstancesDeleteOnPluginManager` (fails on `main`, passes with the fix).
- [x] `dotnet test Tool/Tests/GumToolUnitTests/GumToolUnitTests.csproj` — 581 passed, 0 failed.
- [ ] Manual: in a project with codegen set to **Generate Automatically: On Property Change**, multi-select instances on a screen and delete; verify `.Generated.cs` is updated.

Closes #2837

🤖 Generated with [Claude Code](https://claude.com/claude-code)