### PR TITLE
#2842: Add TextCategory typography states to Bubblegum Label

### DIFF
--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Controls/Label.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Controls/Label.gucx
@@ -56,8 +56,6 @@
     <Name>TextCategory</Name>
     <State>
       <Name>Tiny</Name>
-      <Variable Type="bool" Name="IsBold" SetsValue="true"><Value xsi:type="xsd:boolean">false</Value></Variable>
-      <Variable Type="bool" Name="IsItalic" SetsValue="true"><Value xsi:type="xsd:boolean">false</Value></Variable>
       <VariableList xsi:type="VariableListSaveOfString">
         <Type>string</Type>
         <Name>VariableReferences</Name>
@@ -72,8 +70,6 @@
     </State>
     <State>
       <Name>Small</Name>
-      <Variable Type="bool" Name="IsBold" SetsValue="true"><Value xsi:type="xsd:boolean">false</Value></Variable>
-      <Variable Type="bool" Name="IsItalic" SetsValue="true"><Value xsi:type="xsd:boolean">false</Value></Variable>
       <VariableList xsi:type="VariableListSaveOfString">
         <Type>string</Type>
         <Name>VariableReferences</Name>
@@ -88,8 +84,6 @@
     </State>
     <State>
       <Name>Normal</Name>
-      <Variable Type="bool" Name="IsBold" SetsValue="true"><Value xsi:type="xsd:boolean">false</Value></Variable>
-      <Variable Type="bool" Name="IsItalic" SetsValue="true"><Value xsi:type="xsd:boolean">false</Value></Variable>
       <VariableList xsi:type="VariableListSaveOfString">
         <Type>string</Type>
         <Name>VariableReferences</Name>
@@ -104,7 +98,6 @@
     </State>
     <State>
       <Name>Emphasis</Name>
-      <Variable Type="bool" Name="IsBold" SetsValue="true"><Value xsi:type="xsd:boolean">false</Value></Variable>
       <VariableList xsi:type="VariableListSaveOfString">
         <Type>string</Type>
         <Name>VariableReferences</Name>
@@ -120,7 +113,6 @@
     </State>
     <State>
       <Name>Strong</Name>
-      <Variable Type="bool" Name="IsItalic" SetsValue="true"><Value xsi:type="xsd:boolean">false</Value></Variable>
       <VariableList xsi:type="VariableListSaveOfString">
         <Type>string</Type>
         <Name>VariableReferences</Name>
@@ -136,7 +128,6 @@
     </State>
     <State>
       <Name>H3</Name>
-      <Variable Type="bool" Name="IsItalic" SetsValue="true"><Value xsi:type="xsd:boolean">false</Value></Variable>
       <VariableList xsi:type="VariableListSaveOfString">
         <Type>string</Type>
         <Name>VariableReferences</Name>
@@ -152,7 +143,6 @@
     </State>
     <State>
       <Name>H2</Name>
-      <Variable Type="bool" Name="IsItalic" SetsValue="true"><Value xsi:type="xsd:boolean">false</Value></Variable>
       <VariableList xsi:type="VariableListSaveOfString">
         <Type>string</Type>
         <Name>VariableReferences</Name>
@@ -168,7 +158,6 @@
     </State>
     <State>
       <Name>H1</Name>
-      <Variable Type="bool" Name="IsItalic" SetsValue="true"><Value xsi:type="xsd:boolean">false</Value></Variable>
       <VariableList xsi:type="VariableListSaveOfString">
         <Type>string</Type>
         <Name>VariableReferences</Name>
@@ -184,7 +173,6 @@
     </State>
     <State>
       <Name>Title</Name>
-      <Variable Type="bool" Name="IsItalic" SetsValue="true"><Value xsi:type="xsd:boolean">false</Value></Variable>
       <VariableList xsi:type="VariableListSaveOfString">
         <Type>string</Type>
         <Name>VariableReferences</Name>

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Controls/Label.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Controls/Label.gucx
@@ -29,6 +29,7 @@
       <Value xsi:type="xsd:int">61</Value>
     </Variable>
     <Variable Type="State" Name="State" Category="States and Visibility" SetsValue="true" />
+    <Variable Type="TextCategory" Name="TextCategoryState" SetsValue="false" />
     <Variable Type="float" Name="Width" Category="Dimensions" SetsValue="true">
       <Value xsi:type="xsd:float">0</Value>
     </Variable>
@@ -51,6 +52,153 @@
       </Value>
     </VariableList>
   </State>
+  <Category>
+    <Name>TextCategory</Name>
+    <State>
+      <Name>Tiny</Name>
+      <Variable Type="bool" Name="IsBold" SetsValue="true"><Value xsi:type="xsd:boolean">false</Value></Variable>
+      <Variable Type="bool" Name="IsItalic" SetsValue="true"><Value xsi:type="xsd:boolean">false</Value></Variable>
+      <VariableList xsi:type="VariableListSaveOfString">
+        <Type>string</Type>
+        <Name>VariableReferences</Name>
+        <Category>References</Category>
+        <IsFile>false</IsFile>
+        <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
+        <Value>
+          <string>Font = Components/Styles.Tiny.Font</string>
+          <string>FontSize = Components/Styles.Tiny.FontSize</string>
+        </Value>
+      </VariableList>
+    </State>
+    <State>
+      <Name>Small</Name>
+      <Variable Type="bool" Name="IsBold" SetsValue="true"><Value xsi:type="xsd:boolean">false</Value></Variable>
+      <Variable Type="bool" Name="IsItalic" SetsValue="true"><Value xsi:type="xsd:boolean">false</Value></Variable>
+      <VariableList xsi:type="VariableListSaveOfString">
+        <Type>string</Type>
+        <Name>VariableReferences</Name>
+        <Category>References</Category>
+        <IsFile>false</IsFile>
+        <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
+        <Value>
+          <string>Font = Components/Styles.Small.Font</string>
+          <string>FontSize = Components/Styles.Small.FontSize</string>
+        </Value>
+      </VariableList>
+    </State>
+    <State>
+      <Name>Normal</Name>
+      <Variable Type="bool" Name="IsBold" SetsValue="true"><Value xsi:type="xsd:boolean">false</Value></Variable>
+      <Variable Type="bool" Name="IsItalic" SetsValue="true"><Value xsi:type="xsd:boolean">false</Value></Variable>
+      <VariableList xsi:type="VariableListSaveOfString">
+        <Type>string</Type>
+        <Name>VariableReferences</Name>
+        <Category>References</Category>
+        <IsFile>false</IsFile>
+        <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
+        <Value>
+          <string>Font = Components/Styles.Normal.Font</string>
+          <string>FontSize = Components/Styles.Normal.FontSize</string>
+        </Value>
+      </VariableList>
+    </State>
+    <State>
+      <Name>Emphasis</Name>
+      <Variable Type="bool" Name="IsBold" SetsValue="true"><Value xsi:type="xsd:boolean">false</Value></Variable>
+      <VariableList xsi:type="VariableListSaveOfString">
+        <Type>string</Type>
+        <Name>VariableReferences</Name>
+        <Category>References</Category>
+        <IsFile>false</IsFile>
+        <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
+        <Value>
+          <string>Font = Components/Styles.Emphasis.Font</string>
+          <string>FontSize = Components/Styles.Emphasis.FontSize</string>
+          <string>IsItalic = Components/Styles.Emphasis.IsItalic</string>
+        </Value>
+      </VariableList>
+    </State>
+    <State>
+      <Name>Strong</Name>
+      <Variable Type="bool" Name="IsItalic" SetsValue="true"><Value xsi:type="xsd:boolean">false</Value></Variable>
+      <VariableList xsi:type="VariableListSaveOfString">
+        <Type>string</Type>
+        <Name>VariableReferences</Name>
+        <Category>References</Category>
+        <IsFile>false</IsFile>
+        <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
+        <Value>
+          <string>Font = Components/Styles.Strong.Font</string>
+          <string>FontSize = Components/Styles.Strong.FontSize</string>
+          <string>IsBold = Components/Styles.Strong.IsBold</string>
+        </Value>
+      </VariableList>
+    </State>
+    <State>
+      <Name>H3</Name>
+      <Variable Type="bool" Name="IsItalic" SetsValue="true"><Value xsi:type="xsd:boolean">false</Value></Variable>
+      <VariableList xsi:type="VariableListSaveOfString">
+        <Type>string</Type>
+        <Name>VariableReferences</Name>
+        <Category>References</Category>
+        <IsFile>false</IsFile>
+        <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
+        <Value>
+          <string>Font = Components/Styles.H3.Font</string>
+          <string>FontSize = Components/Styles.H3.FontSize</string>
+          <string>IsBold = Components/Styles.H3.IsBold</string>
+        </Value>
+      </VariableList>
+    </State>
+    <State>
+      <Name>H2</Name>
+      <Variable Type="bool" Name="IsItalic" SetsValue="true"><Value xsi:type="xsd:boolean">false</Value></Variable>
+      <VariableList xsi:type="VariableListSaveOfString">
+        <Type>string</Type>
+        <Name>VariableReferences</Name>
+        <Category>References</Category>
+        <IsFile>false</IsFile>
+        <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
+        <Value>
+          <string>Font = Components/Styles.H2.Font</string>
+          <string>FontSize = Components/Styles.H2.FontSize</string>
+          <string>IsBold = Components/Styles.H2.IsBold</string>
+        </Value>
+      </VariableList>
+    </State>
+    <State>
+      <Name>H1</Name>
+      <Variable Type="bool" Name="IsItalic" SetsValue="true"><Value xsi:type="xsd:boolean">false</Value></Variable>
+      <VariableList xsi:type="VariableListSaveOfString">
+        <Type>string</Type>
+        <Name>VariableReferences</Name>
+        <Category>References</Category>
+        <IsFile>false</IsFile>
+        <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
+        <Value>
+          <string>Font = Components/Styles.H1.Font</string>
+          <string>FontSize = Components/Styles.H1.FontSize</string>
+          <string>IsBold = Components/Styles.H1.IsBold</string>
+        </Value>
+      </VariableList>
+    </State>
+    <State>
+      <Name>Title</Name>
+      <Variable Type="bool" Name="IsItalic" SetsValue="true"><Value xsi:type="xsd:boolean">false</Value></Variable>
+      <VariableList xsi:type="VariableListSaveOfString">
+        <Type>string</Type>
+        <Name>VariableReferences</Name>
+        <Category>References</Category>
+        <IsFile>false</IsFile>
+        <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
+        <Value>
+          <string>Font = Components/Styles.Title.Font</string>
+          <string>FontSize = Components/Styles.Title.FontSize</string>
+          <string>IsBold = Components/Styles.Title.IsBold</string>
+        </Value>
+      </VariableList>
+    </State>
+  </Category>
   <Behaviors>
     <ElementBehaviorReference>
       <BehaviorName>LabelBehavior</BehaviorName>

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Controls/Label.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Controls/Label.gucx
@@ -65,6 +65,8 @@
         <Value>
           <string>Font = Components/Styles.Tiny.Font</string>
           <string>FontSize = Components/Styles.Tiny.FontSize</string>
+          <string>IsBold = Components/Styles.Tiny.IsBold</string>
+          <string>IsItalic = Components/Styles.Tiny.IsItalic</string>
         </Value>
       </VariableList>
     </State>
@@ -79,6 +81,8 @@
         <Value>
           <string>Font = Components/Styles.Small.Font</string>
           <string>FontSize = Components/Styles.Small.FontSize</string>
+          <string>IsBold = Components/Styles.Small.IsBold</string>
+          <string>IsItalic = Components/Styles.Small.IsItalic</string>
         </Value>
       </VariableList>
     </State>
@@ -93,6 +97,8 @@
         <Value>
           <string>Font = Components/Styles.Normal.Font</string>
           <string>FontSize = Components/Styles.Normal.FontSize</string>
+          <string>IsBold = Components/Styles.Normal.IsBold</string>
+          <string>IsItalic = Components/Styles.Normal.IsItalic</string>
         </Value>
       </VariableList>
     </State>
@@ -107,6 +113,7 @@
         <Value>
           <string>Font = Components/Styles.Emphasis.Font</string>
           <string>FontSize = Components/Styles.Emphasis.FontSize</string>
+          <string>IsBold = Components/Styles.Emphasis.IsBold</string>
           <string>IsItalic = Components/Styles.Emphasis.IsItalic</string>
         </Value>
       </VariableList>
@@ -123,6 +130,7 @@
           <string>Font = Components/Styles.Strong.Font</string>
           <string>FontSize = Components/Styles.Strong.FontSize</string>
           <string>IsBold = Components/Styles.Strong.IsBold</string>
+          <string>IsItalic = Components/Styles.Strong.IsItalic</string>
         </Value>
       </VariableList>
     </State>
@@ -138,6 +146,7 @@
           <string>Font = Components/Styles.H3.Font</string>
           <string>FontSize = Components/Styles.H3.FontSize</string>
           <string>IsBold = Components/Styles.H3.IsBold</string>
+          <string>IsItalic = Components/Styles.H3.IsItalic</string>
         </Value>
       </VariableList>
     </State>
@@ -153,6 +162,7 @@
           <string>Font = Components/Styles.H2.Font</string>
           <string>FontSize = Components/Styles.H2.FontSize</string>
           <string>IsBold = Components/Styles.H2.IsBold</string>
+          <string>IsItalic = Components/Styles.H2.IsItalic</string>
         </Value>
       </VariableList>
     </State>
@@ -168,6 +178,7 @@
           <string>Font = Components/Styles.H1.Font</string>
           <string>FontSize = Components/Styles.H1.FontSize</string>
           <string>IsBold = Components/Styles.H1.IsBold</string>
+          <string>IsItalic = Components/Styles.H1.IsItalic</string>
         </Value>
       </VariableList>
     </State>
@@ -183,6 +194,7 @@
           <string>Font = Components/Styles.Title.Font</string>
           <string>FontSize = Components/Styles.Title.FontSize</string>
           <string>IsBold = Components/Styles.Title.IsBold</string>
+          <string>IsItalic = Components/Styles.Title.IsItalic</string>
         </Value>
       </VariableList>
     </State>


### PR DESCRIPTION
Closes #2842

## Summary
- Adds a `TextCategory` state category to the Bubblegum `Controls/Label` template, with one state per text role defined in `Components/Styles` (Tiny, Small, Normal, Emphasis, Strong, H3, H2, H1, Title).
- Each state uses **variable references** into `Components/Styles.<Role>.Font` / `.FontSize` (and `.IsBold` / `.IsItalic` where the role defines them) so typography on a Label instance is driven by the central Styles component rather than literal font/size values.
- States explicitly set `IsBold` / `IsItalic` to `false` for roles whose Styles definition does not include those flags, so switching between roles fully resets bold/italic instead of leaving stale flags from a previous state.
- Default state behavior is unchanged (still references Strong) — adding the category alone does not alter existing Label visuals until a user picks a state.

## Scope notes
- Tool-only / data-only change: edits the project template at `Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Controls/Label.gucx`. No code-side `Styling.cs` / `LabelVisual.cs` changes.
- Bubblegum theme only in this PR. Other text-bearing controls (Button label, MenuItem, etc.) and other themes are out of scope per the issue discussion.

## Test plan
- [x] Create a new project from the Bubblegum template in the Gum tool.
- [x] Add a Label instance to a screen and confirm `TextCategoryState` appears in its variable list.
- [x] Switch through each TextCategory state and verify font size + bold/italic update to match the corresponding Styles role.
- [x] Edit a font size in `Components/Styles` (e.g. `H1.FontSize`) and confirm Labels with `TextCategoryState = H1` update accordingly.
- [x] Confirm Labels without any TextCategory state selected still render using the existing Default (Strong) styling.