### PR TITLE
Walk categorized instance states in GetVariableListRecursive

### DIFF
--- a/Gum/DataTypes/StateSaveExtensionMethods.cs
+++ b/Gum/DataTypes/StateSaveExtensionMethods.cs
@@ -392,6 +392,50 @@ public static class StateSaveExtensionMethods
         {
             ElementSave elementContainingState = stateSave.ParentContainer;
 
+            // Most-specific-wins: if the variable is on an instance and the
+            // instance has a categorized state set in this state (e.g.
+            // TextInstance.TextCategoryState = "H1"), and that state on the
+            // instance's BaseType has the list, prefer it over the containing
+            // element's BaseType chain. This mirrors the precedence
+            // GetValueRecursive already applies for scalar Variables and lets
+            // VariableReferences cascade through categorized states.
+            if (elementContainingState != null && variableName.Contains('.'))
+            {
+                var sourceObjectName = VariableSave.GetSourceObject(variableName);
+                var instanceForStateWalk = elementContainingState.Instances
+                    .FirstOrDefault(item => item.Name == sourceObjectName);
+                if (instanceForStateWalk != null)
+                {
+                    var instanceType = ObjectFinder.Self.GetElementSave(instanceForStateWalk);
+                    if (instanceType != null)
+                    {
+                        var nameInBase = VariableSave.GetRootName(variableName);
+                        for (int i = 0; i < stateSave.Variables.Count; i++)
+                        {
+                            var instanceStateVariable = stateSave.Variables[i];
+                            if (instanceStateVariable.SourceObject == sourceObjectName &&
+                                instanceStateVariable.SetsValue &&
+                                // check this last since it's the slowest:
+                                instanceStateVariable.IsState(elementContainingState))
+                            {
+                                var matchingState = instanceType.AllStates
+                                    .FirstOrDefault(s => s.Name == (string)instanceStateVariable.Value);
+                                if (matchingState != null)
+                                {
+                                    variableListSave = matchingState.GetVariableListRecursive(nameInBase);
+                                    if (variableListSave != null) break;
+                                }
+                            }
+                        }
+                    }
+                }
+
+                if (variableListSave != null)
+                {
+                    return variableListSave;
+                }
+            }
+
             // 1. Go to the default state if it's not a default
             bool shouldGoToDefaultState = false;
             // 2. Go to the base type if the variable is on the container itself, or if the instance is DefinedByBase

--- a/Tool/Tests/GumToolUnitTests/DataTypes/StateSaveExtensionMethodsTests.cs
+++ b/Tool/Tests/GumToolUnitTests/DataTypes/StateSaveExtensionMethodsTests.cs
@@ -210,6 +210,230 @@ public class StateSaveExtensionMethodsTests : BaseTestClass
     }
 
     [Fact]
+    public void GetVariableListRecursive_OnInstance_ShouldPreferCategorizedStateOverBaseTypeList()
+    {
+        // Repro for the H1 / TextCategoryState case:
+        // - Owner derives from Button. TextInstance is DefinedByBase=true.
+        // - Button.DefaultState defines TextInstance.VariableReferences (the
+        //   "base-default" references — what the lookup currently returns).
+        // - TextInstance's BaseType is Label. Label has a TextCategory state
+        //   category with an H1 state that has its own VariableReferences.
+        // - Owner.DefaultState sets TextInstance.TextCategoryState = "H1".
+        //
+        // Per the "most specific wins" principle, the lookup should return
+        // Label.H1's VariableReferences, not Button's.
+
+        ComponentSave label = new() { Name = "Label", BaseType = "Container" };
+        StateSave labelDefault = new() { Name = "Default", ParentContainer = label };
+        label.States.Add(labelDefault);
+
+        StateSaveCategory textCategory = new() { Name = "TextCategory" };
+        StateSave h1State = new() { Name = "H1", ParentContainer = label };
+        VariableListSave<string> h1Refs = new()
+        {
+            Name = "VariableReferences",
+            Type = "string"
+        };
+        h1Refs.ValueAsIList.Add("Font = Styles.H1.Font");
+        h1Refs.ValueAsIList.Add("FontSize = Styles.H1.FontSize");
+        h1State.VariableLists.Add(h1Refs);
+        textCategory.States.Add(h1State);
+        label.Categories.Add(textCategory);
+
+        ObjectFinder.Self.GumProjectSave!.Components.Add(label);
+
+        ComponentSave button = new() { Name = "Button", BaseType = "Container" };
+        StateSave buttonDefault = new() { Name = "Default", ParentContainer = button };
+        button.States.Add(buttonDefault);
+
+        InstanceSave textInButton = new()
+        {
+            Name = "TextInstance",
+            BaseType = "Label",
+            ParentContainer = button
+        };
+        button.Instances.Add(textInButton);
+
+        VariableListSave<string> buttonRefs = new()
+        {
+            Name = "TextInstance.VariableReferences",
+            Type = "string"
+        };
+        buttonRefs.ValueAsIList.Add("Red = Styles.Black.Red");
+        buttonRefs.ValueAsIList.Add("Font = Styles.Strong.Font");
+        buttonDefault.VariableLists.Add(buttonRefs);
+
+        ObjectFinder.Self.GumProjectSave.Components.Add(button);
+
+        ComponentSave owner = new() { Name = "Owner", BaseType = "Button" };
+        StateSave ownerDefault = new() { Name = "Default", ParentContainer = owner };
+        owner.States.Add(ownerDefault);
+
+        InstanceSave textInOwner = new()
+        {
+            Name = "TextInstance",
+            BaseType = "Label",
+            DefinedByBase = true,
+            ParentContainer = owner
+        };
+        owner.Instances.Add(textInOwner);
+
+        // Set the categorized state on the instance.
+        VariableSave categoryStateVar = new()
+        {
+            Name = "TextInstance.TextCategoryState",
+            Type = "TextCategory",
+            Value = "H1",
+            SetsValue = true
+        };
+        ownerDefault.Variables.Add(categoryStateVar);
+
+        ObjectFinder.Self.GumProjectSave.Components.Add(owner);
+
+        var foundList = ownerDefault.GetVariableListRecursive("TextInstance.VariableReferences");
+
+        foundList.ShouldNotBeNull();
+        foundList!.ValueAsIList.Count.ShouldBe(2);
+        foundList.ValueAsIList[0].ShouldBe("Font = Styles.H1.Font",
+            "because the H1 state's VariableReferences is more specific than Button's base " +
+            "TextInstance.VariableReferences and should win when TextCategoryState=H1.");
+        foundList.ValueAsIList[1].ShouldBe("FontSize = Styles.H1.FontSize");
+    }
+
+    [Fact]
+    public void GetVariableListRecursive_OnInstance_NoCategorizedStateSet_ShouldFallBackToBaseTypeList()
+    {
+        // Regression guard: when no categorized state is active on the
+        // instance, the lookup should still walk the containing element's
+        // BaseType chain and return Button's TextInstance.VariableReferences.
+
+        ComponentSave label = new() { Name = "LabelNoCat", BaseType = "Container" };
+        StateSave labelDefault = new() { Name = "Default", ParentContainer = label };
+        label.States.Add(labelDefault);
+
+        ObjectFinder.Self.GumProjectSave!.Components.Add(label);
+
+        ComponentSave button = new() { Name = "ButtonNoCat", BaseType = "Container" };
+        StateSave buttonDefault = new() { Name = "Default", ParentContainer = button };
+        button.States.Add(buttonDefault);
+
+        InstanceSave textInButton = new()
+        {
+            Name = "TextInstance",
+            BaseType = "LabelNoCat",
+            ParentContainer = button
+        };
+        button.Instances.Add(textInButton);
+
+        VariableListSave<string> buttonRefs = new()
+        {
+            Name = "TextInstance.VariableReferences",
+            Type = "string"
+        };
+        buttonRefs.ValueAsIList.Add("Red = Styles.Black.Red");
+        buttonDefault.VariableLists.Add(buttonRefs);
+
+        ObjectFinder.Self.GumProjectSave.Components.Add(button);
+
+        ComponentSave owner = new() { Name = "OwnerNoCat", BaseType = "ButtonNoCat" };
+        StateSave ownerDefault = new() { Name = "Default", ParentContainer = owner };
+        owner.States.Add(ownerDefault);
+
+        InstanceSave textInOwner = new()
+        {
+            Name = "TextInstance",
+            BaseType = "LabelNoCat",
+            DefinedByBase = true,
+            ParentContainer = owner
+        };
+        owner.Instances.Add(textInOwner);
+
+        ObjectFinder.Self.GumProjectSave.Components.Add(owner);
+
+        var foundList = ownerDefault.GetVariableListRecursive("TextInstance.VariableReferences");
+
+        foundList.ShouldNotBeNull();
+        foundList!.ValueAsIList.Count.ShouldBe(1);
+        foundList.ValueAsIList[0].ShouldBe("Red = Styles.Black.Red",
+            "because no categorized state is set on TextInstance, so the lookup falls back to " +
+            "the base type's TextInstance.VariableReferences.");
+    }
+
+    [Fact]
+    public void GetVariableListRecursive_OnInstance_CategorizedStateWithoutList_ShouldFallBackToBaseTypeList()
+    {
+        // Regression guard: if a categorized state is active but that state
+        // doesn't have a VariableReferences list, the lookup should still
+        // fall back to the base type's list.
+
+        ComponentSave label = new() { Name = "LabelEmptyCat", BaseType = "Container" };
+        StateSave labelDefault = new() { Name = "Default", ParentContainer = label };
+        label.States.Add(labelDefault);
+
+        StateSaveCategory textCategory = new() { Name = "TextCategory" };
+        StateSave h1State = new() { Name = "H1", ParentContainer = label };
+        // Note: H1 does NOT have a VariableReferences list.
+        textCategory.States.Add(h1State);
+        label.Categories.Add(textCategory);
+
+        ObjectFinder.Self.GumProjectSave!.Components.Add(label);
+
+        ComponentSave button = new() { Name = "ButtonEmptyCat", BaseType = "Container" };
+        StateSave buttonDefault = new() { Name = "Default", ParentContainer = button };
+        button.States.Add(buttonDefault);
+
+        InstanceSave textInButton = new()
+        {
+            Name = "TextInstance",
+            BaseType = "LabelEmptyCat",
+            ParentContainer = button
+        };
+        button.Instances.Add(textInButton);
+
+        VariableListSave<string> buttonRefs = new()
+        {
+            Name = "TextInstance.VariableReferences",
+            Type = "string"
+        };
+        buttonRefs.ValueAsIList.Add("Red = Styles.Black.Red");
+        buttonDefault.VariableLists.Add(buttonRefs);
+
+        ObjectFinder.Self.GumProjectSave.Components.Add(button);
+
+        ComponentSave owner = new() { Name = "OwnerEmptyCat", BaseType = "ButtonEmptyCat" };
+        StateSave ownerDefault = new() { Name = "Default", ParentContainer = owner };
+        owner.States.Add(ownerDefault);
+
+        InstanceSave textInOwner = new()
+        {
+            Name = "TextInstance",
+            BaseType = "LabelEmptyCat",
+            DefinedByBase = true,
+            ParentContainer = owner
+        };
+        owner.Instances.Add(textInOwner);
+
+        VariableSave categoryStateVar = new()
+        {
+            Name = "TextInstance.TextCategoryState",
+            Type = "TextCategory",
+            Value = "H1",
+            SetsValue = true
+        };
+        ownerDefault.Variables.Add(categoryStateVar);
+
+        ObjectFinder.Self.GumProjectSave.Components.Add(owner);
+
+        var foundList = ownerDefault.GetVariableListRecursive("TextInstance.VariableReferences");
+
+        foundList.ShouldNotBeNull();
+        foundList!.ValueAsIList.Count.ShouldBe(1);
+        foundList.ValueAsIList[0].ShouldBe("Red = Styles.Black.Red",
+            "because the categorized state H1 has no VariableReferences list, the lookup " +
+            "should fall back to the base type's list.");
+    }
+
+    [Fact]
     public void GetVariableListRecursive_OnDefaultState_ShouldFindInheritedList()
     {
         // Sanity check for the lower-level helper: confirms the


### PR DESCRIPTION
## Summary

Stacked on top of #2844. When an instance has a categorized state set in the current state (e.g. `TextInstance.TextCategoryState = "H1"`), and that state on the instance's `BaseType` has its own `VariableReferences`, the lookup should prefer it over the containing element's `BaseType` chain.

**Before:** `GetVariableListRecursive`'s two branches (`shouldGoToBaseType` and `shouldGoToInstanceComponent`) were mutually exclusive. For `DefinedByBase=true` instances, `shouldGoToBaseType` always won, so the categorized-state walk never ran. Setting H1 on `UpgradeButton.TextInstance` had no visible effect on its references — the inspector kept showing Button's `TextInstance.VariableReferences` and the editor styling didn't shift.

**After:** A categorized-state walk runs first (mirroring the precedence `GetValueRecursive` already applies to scalar Variables at `StateSaveExtensionMethods.cs:103-188`). If a state variable like `TextCategoryState = "H1"` resolves to a matching state on the instance's type and that state has the list, it wins. The existing base-type / instance-type-default fall-through is unchanged, so no regression for instances without a categorized state set.

Guiding principle (per discussion): **most specific wins** — a categorized state on the instance is more specific than the containing element's BaseType list.

## Stacking

Targets `fix/variable-references-inheritance-display` (#2844). The fix only surfaces in the UI if #2844's `GetValueRecursive` change is also present, because the inspector reaches `GetVariableListRecursive` through `GetValueRecursive` on the default state. Once #2844 lands, this PR can rebase to `main` automatically.

## Test plan
- [x] New test `GetVariableListRecursive_OnInstance_ShouldPreferCategorizedStateOverBaseTypeList` — pins the H1 case.
- [x] New regression `GetVariableListRecursive_OnInstance_NoCategorizedStateSet_ShouldFallBackToBaseTypeList` — no categorized state set, base type walk still wins.
- [x] New regression `GetVariableListRecursive_OnInstance_CategorizedStateWithoutList_ShouldFallBackToBaseTypeList` — categorized state set but state has no list, base type walk still wins.
- [x] Full `GumToolUnitTests` suite passes (601 passed, 5 pre-existing skips, no regressions).
- [ ] Manual verification (UI, with #2844 merged): open `UpgradeButton.gucx`, select `TextInstance`. The `VariableReferences` row should reflect Label's H1 state (Font/FontSize/IsBold/IsItalic from Styles.H1.*) when `TextCategoryState = "H1"`. Editor preview should pick up H1's font/styling for properties not locally overridden in UpgradeButton.

🤖 Generated with [Claude Code](https://claude.com/claude-code)