### PR TITLE
#2848: Hot reload picks up instance add/remove/retype/reorder

### DIFF
--- a/.claude/skills/gum-runtime-hot-reload/SKILL.md
+++ b/.claude/skills/gum-runtime-hot-reload/SKILL.md
@@ -51,15 +51,33 @@ The 200 ms debounce coalesces the Gum tool's multi-file save burst into one relo
 1. `CopyAndUnloadChangedFonts()` — copies changed `.fnt` files plus matching `<basename>*.png` texture pages from source `FontCache/` to bin `FontCache/`, then `LoaderManager.Dispose`s both so they reload from disk.
 2. `GumProjectSave.Load` + `Initialize`; swap into `ObjectFinder.Self.GumProjectSave`.
 3. Temporarily point `FileManager.RelativeDirectory` at the source directory, call `GumService.TryLoadAnimation` for every element, restore.
-4. Snapshot `root.Children[*].ElementSave.Name`, call `RemoveFromManagers()` + null parent on each.
-5. Look up each snapshotted name in the new project and `ToGraphicalUiElement(..., addToManagers: false)` to rebuild in original order.
-6. Fire `ReloadCompleted`.
+4. `ApplyDiff(roots, newProject, SystemManagers.Default)` — applies the in-place reconciliation walk described below.
+5. Fire `ReloadCompleted`.
+
+## ApplyDiff — In-Place Reconciliation Walk
+
+Defined on `GumHotReloadManager` and exposed `public static` for direct test use. Walks every root and, at each visual whose `ElementSave.Name` matches an element in the new project:
+
+1. Re-point `element.ElementSave` to the new project's element.
+2. **Structural diff against the new `Instances` list** (`DiffDesignTimeChildren`):
+   - Partition the visual's children into **design-time** (those with `Tag is InstanceSave`) and **everything else** (runtime-added or Tag-cleared).
+   - For each existing design-time child not present in the new `Instances`: `Parent = null` + `RemoveFromManagers()`.
+   - For each new `InstanceSave`:
+     - If a matching design-time child exists, compare its visual's `ElementSave.Name` against the new `BaseType`. Mismatch → remove+recreate (retype). Match → refresh the `Tag` to point at the new `InstanceSave` instance.
+     - If a same-named non-design-time child exists, leave it alone (runtime owns that slot). Do not create a duplicate.
+     - Otherwise call `instance.ToGraphicalUiElement(systemManagers)` and attach via `Parent = parent` + `ElementGueContainingThis = parent`.
+   - `ReorderDesignTimeChildren` walks the design-time slots in `Children` and `Move`s items so the design-time subsequence matches `newEs.Instances` order. Non-design-time children keep their slots.
+3. `SetVariablesRecursively(newEs, newEs.DefaultState)` — re-applies the new default-state values. Qualified-name variables (`MyInstance.X`, `MyInstance.Parent`, etc.) flow into the children by `Name`, which also handles reparenting and animates new instances into position.
+4. Recurse into runtime-added children only. Design-time children are skipped — their variables were already set via the parent's qualified-name walk.
 
 ## Non-Obvious Behaviors / Gotchas
 
-- **Only `Root.Children` are rebuilt.** `PopupRoot` and `ModalRoot` are untouched. Anything the game attached elsewhere will not be refreshed.
-- **Runtime state is lost.** Every rebuilt element comes back with Gum-project values only — code-set properties (`Text`, `Width`, etc.) disappear. Games that populate UI in code must rerun that logic on `ReloadCompleted`.
-- **Children added with no `ElementSave`** (pure runtime instances with `name == null`) are silently dropped — the snapshot stores their name slot but the lookup fails.
+- **`Tag` is the design-time marker.** `InstanceSave.ToGraphicalUiElement` sets `Tag = instanceSave` (`GumRuntime/InstanceSaveExtensionMethods.GumRuntime.cs:39`). If user code nulls or replaces that `Tag`, the diff treats the visual as runtime-owned: not removed, not retyped, not duplicated. Variable application via `Name` still works. Documented limitation, see `docs/code/hot-reload.md`.
+- **Retype detection uses `ElementSave.Name`, not the old `Tag.BaseType`.** This is the visual's actual built-from type, which stays stable across diffs whether the caller passed a fresh project or mutated the existing one in place — important for tests.
+- **`Root.Children` and any roots passed to `Update(IEnumerable<GraphicalUiElement>)`** are the reload surface. `PopupRoot` / `ModalRoot` are untouched.
+- **Runtime state on design-time visuals is overwritten** by `SetVariablesRecursively`. Games that mutate UI in code need to rerun that logic on `ReloadCompleted`.
+- **Children added with no `Tag`** (or with a `Tag` that isn't an `InstanceSave`) are runtime-owned and preserved. This includes ItemsControl-generated rows and anything the user constructed programmatically.
+- **Reparenting flows through the qualified `<instance>.Parent` variable** — there is no explicit reparent step in the diff. The parent state's `Foo.Parent = "Bar"` line is what re-attaches `Foo` under `Bar` during `SetVariablesRecursively`. This is why both old and new parent visuals must exist before that step runs.
 - **Textures (non-font `.png`) and `.ganx` are watched but not reloaded** in the cache-eviction sense. `.ganx` is only re-read via `TryLoadAnimation` on the new project; `.png` edits require a restart.
 - **`_changedFontFiles` is mutated off the game thread** (watcher callback). It's protected by `_fontFileLock`; any new shared state added must be similarly synchronized.
 - **`Stop()` is idempotent-safe** but does not reset other state — `GumService.Uninitialize` just nulls the manager reference afterward.

--- a/MonoGameGum.Tests/Hot/HotReloadStructuralDiffTests.cs
+++ b/MonoGameGum.Tests/Hot/HotReloadStructuralDiffTests.cs
@@ -1,0 +1,322 @@
+using Gum.DataTypes;
+using Gum.DataTypes.Variables;
+using Gum.Managers;
+using Gum.Wireframe;
+using GumRuntime;
+using RenderingLibrary;
+using RenderingLibrary.Graphics;
+using Shouldly;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace MonoGameGum.Tests.Hot;
+
+/// <summary>
+/// Drives the structural side of hot reload (issue #2848). Each test materializes an
+/// in-memory <see cref="GumProjectSave"/> through the normal runtime pipeline, mutates the
+/// project's <c>Instances</c> list (the same edits the Gum tool would persist on save),
+/// then invokes <see cref="GumHotReloadManager.ApplyDiff"/> and asserts that the live
+/// visual tree converged to the new project state.
+/// </summary>
+public class HotReloadStructuralDiffTests : BaseTestClass
+{
+    public override void Dispose()
+    {
+        ObjectFinder.Self.GumProjectSave = null;
+        base.Dispose();
+    }
+
+    #region Helpers
+
+    /// <summary>
+    /// Ensures the named standard (e.g. "Container", "ColoredRectangle") is present in the project
+    /// so <see cref="ObjectFinder"/> resolves it during instance materialization. Standards are
+    /// what drive <c>CustomCreateGraphicalComponentFunc</c> into producing a real renderable.
+    /// </summary>
+    private static void EnsureStandard(GumProjectSave project, string name)
+    {
+        if (project.StandardElements.Any(s => s.Name == name))
+        {
+            return;
+        }
+        StandardElementSave standard = new StandardElementSave { Name = name };
+        StateSave defaultState = new StateSave { Name = "Default", ParentContainer = standard };
+        standard.States.Add(defaultState);
+        project.StandardElements.Add(standard);
+    }
+
+    private static (ScreenSave screen, StateSave defaultState) BuildScreen(
+        GumProjectSave project, string name = "TestScreen")
+    {
+        ScreenSave screen = new ScreenSave { Name = name };
+        StateSave defaultState = new StateSave { Name = "Default", ParentContainer = screen };
+        screen.States.Add(defaultState);
+        project.Screens.Add(screen);
+        return (screen, defaultState);
+    }
+
+    private static InstanceSave AddInstance(
+        GumProjectSave project, ScreenSave screen, string name, string baseType = "Container")
+    {
+        EnsureStandard(project, baseType);
+        InstanceSave instance = new InstanceSave
+        {
+            Name = name,
+            BaseType = baseType,
+            ParentContainer = screen
+        };
+        screen.Instances.Add(instance);
+        return instance;
+    }
+
+    private static GraphicalUiElement? FindChildByName(GraphicalUiElement parent, string name)
+    {
+        return parent.Children.FirstOrDefault(c => c.Name == name);
+    }
+
+    #endregion
+
+    [Fact]
+    public void Add_NewInstance_AppearsInVisualTree()
+    {
+        GumProjectSave project = new GumProjectSave();
+        ObjectFinder.Self.GumProjectSave = project;
+        (ScreenSave screen, StateSave screenDefault) = BuildScreen(project);
+        AddInstance(project, screen, "Box1");
+        GraphicalUiElement screenGue = screen.ToGraphicalUiElement();
+        screenGue.Children.Count.ShouldBe(1, "sanity: initial materialization should have one child");
+
+        // Simulate copy/paste in the Gum tool: a new InstanceSave is appended to the screen
+        // and the screen's default state gains a qualified positional variable for it.
+        AddInstance(project, screen, "Box2");
+        screenDefault.Variables.Add(new VariableSave
+        {
+            Name = "Box2.X",
+            Value = 25f,
+            Type = "float",
+            SetsValue = true
+        });
+
+        GumHotReloadManager.ApplyDiff(
+            new[] { screenGue }, project, SystemManagers.Default);
+
+        screenGue.Children.Count.ShouldBe(2);
+        GraphicalUiElement? newChild = FindChildByName(screenGue, "Box2");
+        newChild.ShouldNotBeNull();
+        newChild!.Tag.ShouldBeOfType<InstanceSave>();
+        ((InstanceSave)newChild.Tag!).Name.ShouldBe("Box2");
+        newChild.X.ShouldBe(25f, "qualified-name variables on the parent should have flowed through to the new child");
+    }
+
+    [Fact]
+    public void NullTag_OnDesignTimeChild_IsTreatedAsRuntime_LimitationLocked()
+    {
+        // Locks in the documented limitation: if user code nulls the Tag, the diff treats
+        // the child as runtime-only. A still-present matching InstanceSave does NOT cause
+        // a duplicate visual to be created. If we ever revisit this (e.g. fall back to
+        // Name+ElementSave matching), this test should change accordingly.
+        GumProjectSave project = new GumProjectSave();
+        ObjectFinder.Self.GumProjectSave = project;
+        (ScreenSave screen, StateSave _) = BuildScreen(project);
+        AddInstance(project, screen, "Box1");
+        GraphicalUiElement screenGue = screen.ToGraphicalUiElement();
+        GraphicalUiElement box1 = screenGue.Children.Single();
+        box1.Tag = null;
+
+        GumHotReloadManager.ApplyDiff(
+            new[] { screenGue }, project, SystemManagers.Default);
+
+        screenGue.Children.Count.ShouldBe(1, "no extra visual should be created when Tag was cleared");
+        screenGue.Children.Single().ShouldBeSameAs(box1);
+    }
+
+    [Fact]
+    public void Preserve_RuntimeAddedChild_AcrossDiff()
+    {
+        GumProjectSave project = new GumProjectSave();
+        ObjectFinder.Self.GumProjectSave = project;
+        (ScreenSave screen, StateSave _) = BuildScreen(project);
+        AddInstance(project, screen, "Box1");
+        GraphicalUiElement screenGue = screen.ToGraphicalUiElement();
+
+        // A runtime-added child (no InstanceSave Tag) — represents UI the game code created
+        // dynamically, e.g. a list-row generated by an ItemsControl.
+        GraphicalUiElement runtimeChild = new GraphicalUiElement(new InvisibleRenderable())
+        {
+            Name = "RuntimeOnly"
+        };
+        runtimeChild.Parent = screenGue;
+
+        GumHotReloadManager.ApplyDiff(
+            new[] { screenGue }, project, SystemManagers.Default);
+
+        screenGue.Children.ShouldContain(runtimeChild);
+    }
+
+    [Fact]
+    public void Remove_DeletedInstance_DropsFromVisualTree()
+    {
+        GumProjectSave project = new GumProjectSave();
+        ObjectFinder.Self.GumProjectSave = project;
+        (ScreenSave screen, StateSave _) = BuildScreen(project);
+        AddInstance(project, screen, "Box1");
+        AddInstance(project, screen, "Box2");
+        GraphicalUiElement screenGue = screen.ToGraphicalUiElement();
+        screenGue.Children.Count.ShouldBe(2);
+
+        // Simulate deletion in the Gum tool: drop Box1 from Instances.
+        InstanceSave box1Instance = screen.Instances.Single(i => i.Name == "Box1");
+        screen.Instances.Remove(box1Instance);
+
+        GumHotReloadManager.ApplyDiff(
+            new[] { screenGue }, project, SystemManagers.Default);
+
+        screenGue.Children.Count.ShouldBe(1);
+        FindChildByName(screenGue, "Box1").ShouldBeNull();
+        FindChildByName(screenGue, "Box2").ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void Reorder_InstancesReorderedInProject_ReordersDesignTimeChildren()
+    {
+        GumProjectSave project = new GumProjectSave();
+        ObjectFinder.Self.GumProjectSave = project;
+        (ScreenSave screen, StateSave _) = BuildScreen(project);
+        AddInstance(project, screen, "Box1");
+        AddInstance(project, screen, "Box2");
+        AddInstance(project, screen, "Box3");
+        GraphicalUiElement screenGue = screen.ToGraphicalUiElement();
+        screenGue.Children.Select(c => c.Name).ToList()
+            .ShouldBe(new List<string> { "Box1", "Box2", "Box3" });
+
+        // Simulate reorder in the Gum tool: Box3 → first, others shift down.
+        InstanceSave box3 = screen.Instances.Single(i => i.Name == "Box3");
+        screen.Instances.Remove(box3);
+        screen.Instances.Insert(0, box3);
+
+        GumHotReloadManager.ApplyDiff(
+            new[] { screenGue }, project, SystemManagers.Default);
+
+        screenGue.Children.Select(c => c.Name).ToList()
+            .ShouldBe(new List<string> { "Box3", "Box1", "Box2" });
+    }
+
+    [Fact]
+    public void Reorder_LeavesRuntimeAddedSiblingsInPlace()
+    {
+        // Minimal expectation: runtime-added children keep their relative order among
+        // themselves after a design-time reorder. We do NOT assert a specific interleave
+        // between design-time and runtime children — that's an implementation detail.
+        GumProjectSave project = new GumProjectSave();
+        ObjectFinder.Self.GumProjectSave = project;
+        (ScreenSave screen, StateSave _) = BuildScreen(project);
+        AddInstance(project, screen, "Box1");
+        AddInstance(project, screen, "Box2");
+        GraphicalUiElement screenGue = screen.ToGraphicalUiElement();
+
+        GraphicalUiElement runtimeA = new GraphicalUiElement(new InvisibleRenderable()) { Name = "RuntimeA" };
+        runtimeA.Parent = screenGue;
+        GraphicalUiElement runtimeB = new GraphicalUiElement(new InvisibleRenderable()) { Name = "RuntimeB" };
+        runtimeB.Parent = screenGue;
+
+        InstanceSave box2 = screen.Instances.Single(i => i.Name == "Box2");
+        screen.Instances.Remove(box2);
+        screen.Instances.Insert(0, box2);
+
+        GumHotReloadManager.ApplyDiff(
+            new[] { screenGue }, project, SystemManagers.Default);
+
+        screenGue.Children.ShouldContain(runtimeA);
+        screenGue.Children.ShouldContain(runtimeB);
+
+        int idxA = screenGue.Children.ToList().IndexOf(runtimeA);
+        int idxB = screenGue.Children.ToList().IndexOf(runtimeB);
+        idxA.ShouldBeLessThan(idxB, "runtime-added children should keep their relative order");
+    }
+
+    [Fact]
+    public void Reparent_InstanceToAnotherInstance_AttachesUnderNewParent()
+    {
+        // Box1 starts attached to the screen (no Parent variable). After the edit, Box1 is
+        // reparented to be a child of Holder1 via the qualified Parent variable.
+        GumProjectSave project = new GumProjectSave();
+        ObjectFinder.Self.GumProjectSave = project;
+        (ScreenSave screen, StateSave screenDefault) = BuildScreen(project);
+        AddInstance(project, screen, "Holder1");
+        AddInstance(project, screen, "Box1");
+        GraphicalUiElement screenGue = screen.ToGraphicalUiElement();
+        GraphicalUiElement holderGue = FindChildByName(screenGue, "Holder1")!;
+        GraphicalUiElement box1Gue = FindChildByName(screenGue, "Box1")!;
+        box1Gue.Parent.ShouldBe(screenGue);
+
+        screenDefault.Variables.Add(new VariableSave
+        {
+            Name = "Box1.Parent",
+            Value = "Holder1",
+            Type = "string",
+            SetsValue = true
+        });
+
+        GumHotReloadManager.ApplyDiff(
+            new[] { screenGue }, project, SystemManagers.Default);
+
+        box1Gue.Parent.ShouldBe(holderGue);
+        holderGue.Children.ShouldContain(box1Gue);
+    }
+
+    [Fact]
+    public void Retype_BaseTypeChanged_ReplacesVisual()
+    {
+        GumProjectSave project = new GumProjectSave();
+        ObjectFinder.Self.GumProjectSave = project;
+        (ScreenSave screen, StateSave _) = BuildScreen(project);
+        AddInstance(project, screen, "Item1", baseType: "Container");
+        EnsureStandard(project, "ColoredRectangle");
+        GraphicalUiElement screenGue = screen.ToGraphicalUiElement();
+        GraphicalUiElement originalItem = screenGue.Children.Single();
+        originalItem.ElementSave!.Name.ShouldBe("Container");
+
+        // Simulate BaseType change in the Gum tool.
+        InstanceSave item1 = screen.Instances.Single(i => i.Name == "Item1");
+        item1.BaseType = "ColoredRectangle";
+
+        GumHotReloadManager.ApplyDiff(
+            new[] { screenGue }, project, SystemManagers.Default);
+
+        screenGue.Children.Count.ShouldBe(1);
+        GraphicalUiElement newItem = screenGue.Children.Single();
+        newItem.Name.ShouldBe("Item1");
+        newItem.ElementSave!.Name.ShouldBe("ColoredRectangle");
+        newItem.ShouldNotBeSameAs(originalItem);
+    }
+
+    [Fact]
+    public void VariableChange_OnExistingInstance_StillFlows()
+    {
+        // Sanity guard: the existing variable-reapply behavior continues to work after we
+        // layer structural diffing on top.
+        GumProjectSave project = new GumProjectSave();
+        ObjectFinder.Self.GumProjectSave = project;
+        (ScreenSave screen, StateSave screenDefault) = BuildScreen(project);
+        AddInstance(project, screen, "Box1");
+        screenDefault.Variables.Add(new VariableSave
+        {
+            Name = "Box1.X",
+            Value = 10f,
+            Type = "float",
+            SetsValue = true
+        });
+        GraphicalUiElement screenGue = screen.ToGraphicalUiElement();
+        GraphicalUiElement box1 = screenGue.Children.Single();
+        box1.X.ShouldBe(10f);
+
+        screenDefault.Variables.Single(v => v.Name == "Box1.X").Value = 99f;
+
+        GumHotReloadManager.ApplyDiff(
+            new[] { screenGue }, project, SystemManagers.Default);
+
+        box1.X.ShouldBe(99f);
+        screenGue.Children.Single().ShouldBeSameAs(box1);
+    }
+}

--- a/MonoGameGum/GumHotReloadManager.cs
+++ b/MonoGameGum/GumHotReloadManager.cs
@@ -8,6 +8,7 @@ using GumRuntime;
 using RenderingLibrary;
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
 
@@ -265,62 +266,61 @@ public class GumHotReloadManager : IGumHotReloadManager
 
         ToolsUtilities.FileManager.RelativeDirectory = savedRelativeDirectory;
 
-        var byName = new Dictionary<string, ElementSave>(StringComparer.OrdinalIgnoreCase);
-        foreach (var element in newProject.AllElements)
-        {
-            byName[element.Name] = element;
-        }
-
         System.Diagnostics.Debug.WriteLine(
             $"[HotReload] rootList.Count = {rootList.Count}");
 
-        int reappliedCount = 0;
-        int visitedCount = 0;
-        foreach (var root in rootList)
-        {
-            ReapplyRecursively(root, byName, ref reappliedCount, ref visitedCount);
-        }
+        ApplyDiff(rootList, newProject, SystemManagers.Default);
 
-        System.Diagnostics.Debug.WriteLine(
-            $"[HotReload] DONE visited={visitedCount} reapplied={reappliedCount}");
+        System.Diagnostics.Debug.WriteLine("[HotReload] DONE");
 
         ReloadCompleted?.Invoke();
     }
 
     /// <summary>
-    /// Walks the visual tree under <paramref name="element"/> and re-applies the new project's
-    /// default-state variables in place on each visual whose ElementSave matches a project element.
-    /// Preserves runtime-added children and runtime-set state — only the design-time variables are reset.
-    /// When re-applying at level N, descent skips children that came from N's design-time InstanceSaves
-    /// (those values were already covered by N's qualified-name variables like "BackInnerBorder.Width").
+    /// Applies a structural + variable diff from <paramref name="newProject"/> onto the live
+    /// visual trees in <paramref name="roots"/>. For every visual whose ElementSave name matches
+    /// an element in the project, design-time children (those whose <c>Tag</c> is an
+    /// <see cref="InstanceSave"/>) are added, removed, retyped, and reordered to match the
+    /// project's <c>Instances</c> list, and the new default-state variables are re-applied.
+    /// Runtime-added children (no <c>InstanceSave</c> tag) are left untouched. Primarily
+    /// called by <see cref="PerformReload"/>; exposed publicly for tests.
     /// </summary>
-    private void ReapplyRecursively(
+    public static void ApplyDiff(
+        IEnumerable<GraphicalUiElement> roots,
+        GumProjectSave newProject,
+        ISystemManagers systemManagers)
+    {
+        Dictionary<string, ElementSave> byName = new Dictionary<string, ElementSave>(StringComparer.OrdinalIgnoreCase);
+        foreach (ElementSave element in newProject.AllElements)
+        {
+            byName[element.Name] = element;
+        }
+
+        foreach (GraphicalUiElement root in roots.ToList())
+        {
+            ApplyDiffRecursive(root, byName, systemManagers);
+        }
+    }
+
+    private static void ApplyDiffRecursive(
         GraphicalUiElement element,
         Dictionary<string, ElementSave> byName,
-        ref int reappliedCount,
-        ref int visitedCount)
+        ISystemManagers systemManagers)
     {
-        visitedCount++;
-
-        var name = element.ElementSave?.Name;
+        string? name = element.ElementSave?.Name;
         HashSet<string>? designTimeChildNames = null;
 
-        if (name != null && byName.TryGetValue(name, out var newEs))
+        if (name != null && byName.TryGetValue(name, out ElementSave? newEs))
         {
-            // Re-point so the visual references the live project's ElementSave.
             element.ElementSave = newEs;
+
+            DiffDesignTimeChildren(element, newEs, systemManagers);
 
             if (newEs.DefaultState != null)
             {
                 element.SetVariablesRecursively(newEs, newEs.DefaultState);
-                reappliedCount++;
-                System.Diagnostics.Debug.WriteLine(
-                    $"[HotReload]   reapplied '{name}' on visual name={element.Name ?? "<null>"}");
             }
 
-            // After re-applying, do not re-enter design-time instance children — their values are
-            // owned by the parent's qualified-name variables we just set. Only descend into
-            // runtime-added children to find further matches.
             if (newEs.Instances != null)
             {
                 designTimeChildNames = new HashSet<string>(
@@ -329,7 +329,7 @@ public class GumHotReloadManager : IGumHotReloadManager
             }
         }
 
-        foreach (var child in element.Children.ToList())
+        foreach (GraphicalUiElement child in element.Children.ToList())
         {
             if (designTimeChildNames != null
                 && child.Name != null
@@ -337,7 +337,195 @@ public class GumHotReloadManager : IGumHotReloadManager
             {
                 continue;
             }
-            ReapplyRecursively(child, byName, ref reappliedCount, ref visitedCount);
+            ApplyDiffRecursive(child, byName, systemManagers);
+        }
+    }
+
+    /// <summary>
+    /// Brings <paramref name="parent"/>'s design-time children (those tagged with an
+    /// <see cref="InstanceSave"/>) into structural alignment with <paramref name="newEs"/>'s
+    /// <c>Instances</c> list: removes missing instances, creates added ones, replaces visuals
+    /// whose <c>BaseType</c> changed, and reorders the design-time slice to match the new
+    /// order. Runtime-added children (no <c>InstanceSave</c> tag) are left in place.
+    /// </summary>
+    private static void DiffDesignTimeChildren(
+        GraphicalUiElement parent,
+        ElementSave newEs,
+        ISystemManagers systemManagers)
+    {
+        // Two lookup tables: one for design-time children (Tag is InstanceSave) so we can do
+        // typed operations like retype/remove, and one keyed by Name across ALL children so
+        // we don't duplicate a runtime-claimed child (e.g. one whose Tag was nulled by user
+        // code — the documented limitation in issue #2848).
+        Dictionary<string, GraphicalUiElement> designTimeByName =
+            new Dictionary<string, GraphicalUiElement>(StringComparer.OrdinalIgnoreCase);
+        Dictionary<string, GraphicalUiElement> anyByName =
+            new Dictionary<string, GraphicalUiElement>(StringComparer.OrdinalIgnoreCase);
+        foreach (GraphicalUiElement child in parent.Children.ToList())
+        {
+            if (child.Tag is InstanceSave existingInstance && existingInstance.Name != null)
+            {
+                designTimeByName[existingInstance.Name] = child;
+            }
+            if (child.Name != null && !anyByName.ContainsKey(child.Name))
+            {
+                anyByName[child.Name] = child;
+            }
+        }
+
+        List<InstanceSave> newInstances = newEs.Instances ?? new List<InstanceSave>();
+        HashSet<string> newNames = new HashSet<string>(
+            newInstances.Where(i => i.Name != null).Select(i => i.Name!),
+            StringComparer.OrdinalIgnoreCase);
+
+        foreach (KeyValuePair<string, GraphicalUiElement> kvp in designTimeByName.ToList())
+        {
+            if (!newNames.Contains(kvp.Key))
+            {
+                DetachAndRemove(kvp.Value);
+                designTimeByName.Remove(kvp.Key);
+                anyByName.Remove(kvp.Key);
+            }
+        }
+
+        foreach (InstanceSave newInstance in newInstances)
+        {
+            if (newInstance.Name == null)
+            {
+                continue;
+            }
+
+            if (designTimeByName.TryGetValue(newInstance.Name, out GraphicalUiElement? existingChild))
+            {
+                // The existing visual's ElementSave reflects what it was actually built from;
+                // comparing the new BaseType against that catches retypes regardless of whether
+                // the caller passed a fresh project or mutated the existing one in place.
+                string? existingBaseTypeName = existingChild.ElementSave?.Name;
+                if (!string.Equals(existingBaseTypeName, newInstance.BaseType, StringComparison.Ordinal))
+                {
+                    DetachAndRemove(existingChild);
+                    designTimeByName.Remove(newInstance.Name);
+                    anyByName.Remove(newInstance.Name);
+                    GraphicalUiElement? created = CreateAndAttach(parent, newInstance, systemManagers);
+                    if (created != null)
+                    {
+                        designTimeByName[newInstance.Name] = created;
+                        anyByName[newInstance.Name] = created;
+                    }
+                }
+                else
+                {
+                    existingChild.Tag = newInstance;
+                }
+            }
+            else if (anyByName.ContainsKey(newInstance.Name))
+            {
+                // A non-design-time child already owns this name. User code is in control of
+                // that visual (or its Tag was nulled). Don't create a duplicate — the parent's
+                // qualified-name variable application will still hit it by Name during the
+                // subsequent SetVariablesRecursively call.
+                continue;
+            }
+            else
+            {
+                GraphicalUiElement? created = CreateAndAttach(parent, newInstance, systemManagers);
+                if (created != null)
+                {
+                    designTimeByName[newInstance.Name] = created;
+                    anyByName[newInstance.Name] = created;
+                }
+            }
+        }
+
+        ReorderDesignTimeChildren(parent, newInstances);
+    }
+
+    private static void DetachAndRemove(GraphicalUiElement child)
+    {
+        child.Parent = null;
+        child.RemoveFromManagers();
+    }
+
+    private static GraphicalUiElement? CreateAndAttach(
+        GraphicalUiElement parent,
+        InstanceSave newInstance,
+        ISystemManagers systemManagers)
+    {
+        GraphicalUiElement? newChild = newInstance.ToGraphicalUiElement(systemManagers);
+        if (newChild == null)
+        {
+            return null;
+        }
+
+        newChild.Parent = parent;
+        newChild.ElementGueContainingThis = parent;
+        return newChild;
+    }
+
+    /// <summary>
+    /// Reorders the design-time children of <paramref name="parent"/> so that they appear in the
+    /// same relative order as <paramref name="newInstances"/>. Runtime-added children keep their
+    /// existing slots — only the positions occupied by design-time children are reshuffled.
+    /// </summary>
+    private static void ReorderDesignTimeChildren(
+        GraphicalUiElement parent,
+        IList<InstanceSave> newInstances)
+    {
+        ObservableCollection<GraphicalUiElement> children = parent.Children;
+        if (children.Count == 0)
+        {
+            return;
+        }
+
+        List<int> designTimeSlots = new List<int>();
+        for (int i = 0; i < children.Count; i++)
+        {
+            if (children[i].Tag is InstanceSave)
+            {
+                designTimeSlots.Add(i);
+            }
+        }
+
+        if (designTimeSlots.Count == 0)
+        {
+            return;
+        }
+
+        Dictionary<string, GraphicalUiElement> designTimeByName =
+            new Dictionary<string, GraphicalUiElement>(StringComparer.OrdinalIgnoreCase);
+        foreach (int slot in designTimeSlots)
+        {
+            InstanceSave inst = (InstanceSave)children[slot].Tag!;
+            if (inst.Name != null)
+            {
+                designTimeByName[inst.Name] = children[slot];
+            }
+        }
+
+        List<GraphicalUiElement> desired = new List<GraphicalUiElement>();
+        foreach (InstanceSave inst in newInstances)
+        {
+            if (inst.Name != null
+                && designTimeByName.TryGetValue(inst.Name, out GraphicalUiElement? c))
+            {
+                desired.Add(c);
+            }
+        }
+
+        for (int i = 0; i < designTimeSlots.Count && i < desired.Count; i++)
+        {
+            int slot = designTimeSlots[i];
+            GraphicalUiElement want = desired[i];
+            if (children[slot] == want)
+            {
+                continue;
+            }
+            int currentIndex = children.IndexOf(want);
+            if (currentIndex < 0)
+            {
+                continue;
+            }
+            children.Move(currentIndex, slot);
         }
     }
 }

--- a/docs/code/hot-reload.md
+++ b/docs/code/hot-reload.md
@@ -38,7 +38,9 @@ Hot reload monitors the following Gum file types:
 | `.gutx`   | Standard element definitions |
 | `.fnt`    | Bitmap font definitions      |
 
-When any of these files change, Gum reloads the entire project and reconstructs all children of the root element from the updated definitions. This means changes to layout, styling, states, variables, component structure, and fonts are all picked up.
+When any of these files change, Gum reloads the project in place: it diffs the new definitions against the live visual tree and updates only what changed. This covers variable edits (move, resize, color, state changes) as well as structural changes — instances added by copy/paste, instances deleted, instances whose `BaseType` was changed, and instance reorders.
+
+Children added at runtime by your game code are left untouched. Hot reload identifies "design-time" children by their `Tag` — when Gum creates a visual from an `InstanceSave`, it stores the `InstanceSave` in `Tag`. Anything without an `InstanceSave` `Tag` is treated as runtime-owned and skipped.
 
 When a reload is triggered, Gum automatically copies all `.fnt` and `.png` files from the source project's `FontCache/` directory to the bin-side `FontCache/` directory, and evicts cached fonts so they are reloaded from disk.
 
@@ -48,7 +50,11 @@ Hot reload is focused on Gum element definitions. The following are **not** auto
 
 * **Textures and images** — If you change a `.png` file, the cached texture is still used. Restart the game to pick up texture changes.
 * **Animation files** — `.ganx` animation definitions are not reloaded.
-* **Runtime state** — Any properties set programmatically at runtime (e.g., changing `Text` or `Width` in code) are lost when the element is recreated. Only values defined in the Gum project are restored. See [Preserving Runtime State](#preserving-runtime-state) below for the recommended pattern.
+* **Runtime state on existing instances** — Any properties set programmatically at runtime (e.g., changing `Text` or `Width` in code) are overwritten when the corresponding design-time variables are re-applied. Only values defined in the Gum project are restored. See [Preserving Runtime State](#preserving-runtime-state) below for the recommended pattern.
+
+### Known Limitation: Cleared Tags
+
+If your code clears (`= null`) or replaces the `Tag` on a visual that was created from an `InstanceSave`, hot reload can no longer recognize it as a design-time child. It is treated as runtime-owned: not removed, not retyped, and not duplicated when the corresponding `InstanceSave` is still present in the project. The parent's qualified-name variables (`MyInstance.X`, etc.) still flow through to it by `Name`, so visible variables continue to update.
 
 ## Platform Support
 
@@ -73,10 +79,10 @@ When `EnableHotReload` is called, Gum creates a `FileSystemWatcher` on the direc
 
 1. The change is detected and a 200ms debounce timer starts. Additional changes within that window reset the timer, so rapid saves (such as the Gum tool writing multiple files at once) are coalesced into a single reload.
 2. On the next `GumService.Update` call after the debounce window, Gum reloads the project from disk.
-3. All children of the root element are removed and recreated from the updated element definitions, preserving their order.
+3. Gum walks the live visual tree and, for each visual that matches a project element by name, reconciles its design-time children with the new `Instances` list (adding, removing, retyping, and reordering as needed) and re-applies the new default-state variables. Runtime-added children are left in place.
 
 {% hint style="warning" %}
-Because elements are fully recreated during hot reload, any runtime state set in code is lost. If your game sets properties on UI elements after creation (e.g., populating a label with a score, hiding a panel), that code needs to run again after a reload.
+Re-applying design-time variables overwrites values your code set on those same properties at runtime. If your game writes to UI elements after creation (e.g., populating a label with a score, hiding a panel), that code needs to run again after a reload.
 {% endhint %}
 
 ## Preserving Runtime State


### PR DESCRIPTION
Closes #2848

## Summary

- Extends `GumHotReloadManager`'s reapply walk with a structural diff against the new project's `Instances` list.
- Copy/paste, delete, `BaseType` change, and reorder in the Gum tool now all propagate to the running game; previously only variable edits showed up.
- Adds 9 unit tests covering add, remove, retype, reorder (with and without runtime siblings), reparent, variable change, runtime-child preservation, and the Tag-cleared limitation.

## How design-time children are identified

Visuals created from an `InstanceSave` already have `Tag = instanceSave` (`GumRuntime/InstanceSaveExtensionMethods.GumRuntime.cs:39`). The diff partitions a parent's `Children` into design-time (Tag is `InstanceSave`) and everything else, and only touches the design-time slice.

A child whose `Tag` was cleared or replaced by user code is treated as runtime-owned — no duplicate is created, no remove happens. The parent's qualified-name variables (`MyInstance.X` etc.) still flow into it by `Name` during `SetVariablesRecursively`. Documented as a known limitation in `docs/code/hot-reload.md`.

## Retype detection

Compares `newInstance.BaseType` against the live visual's `ElementSave.Name` rather than the cached `Tag.BaseType`. This works whether callers pass a freshly-loaded project or mutate the same project in place (the latter matters for the in-memory tests).

## Files

- `MonoGameGum/GumHotReloadManager.cs` — new `public static ApplyDiff(...)` plus the `DiffDesignTimeChildren` / `ReorderDesignTimeChildren` helpers. `PerformReload` now calls `ApplyDiff`; the old private `ReapplyRecursively` was removed.
- `MonoGameGum.Tests/Hot/HotReloadStructuralDiffTests.cs` — new tests.
- `docs/code/hot-reload.md` — describes the in-place reconciliation and the cleared-Tag limitation; corrects stale text that still mentioned the rebuild-from-scratch flow.
- `.claude/skills/gum-runtime-hot-reload/SKILL.md` — refreshed to match current code.

## Test plan

- [x] All 1515 tests in `MonoGameGum.Tests` pass, including the 9 new structural-diff tests.
- [x] `KniGum.csproj`, `RaylibGum.csproj` build clean.
- [x] `FnaGum.csproj` has 676 pre-existing errors (V3 visuals) unrelated to this change; no `GumHotReloadManager` errors.
- [ ] In-game smoke test: copy/paste an instance in the Gum tool with the test game running, confirm the new instance appears in the running window.
- [ ] In-game smoke test: delete an instance, confirm it disappears.
- [ ] In-game smoke test: reorder instances, confirm draw order changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)