### PR TITLE
#2852: Apos.Shapes Circle fits its bounding box for non-square sizes

### DIFF
--- a/Runtimes/GumShapes/Renderables/Circle.cs
+++ b/Runtimes/GumShapes/Renderables/Circle.cs
@@ -42,8 +42,9 @@ public class Circle : RenderableShapeBase,
     // concrete Apos.Shapes Circle type.
     /// <inheritdoc/>
     /// <remarks>
-    /// Apos.Shapes draws the circle as <c>Width / 2</c> centered on the renderable's
-    /// position — the diameter, not a separate radius field. Setting <see cref="Radius"/>
+    /// Issue #2852 — when Width and Height differ, the rendered radius is
+    /// <c>min(Width, Height) / 2</c> so the circle fits inside its bounding box centered,
+    /// matching SkiaGum's behavior (the Gum tool/viewport). Setting <see cref="Radius"/>
     /// keeps Width and Height in lockstep so the shape is square. Implemented to satisfy
     /// both <see cref="Gum.GueDeriving.IFilledCircleRenderable"/> and
     /// <see cref="Gum.GueDeriving.IStrokedCircleRenderable"/>; which slot any given Circle
@@ -52,7 +53,7 @@ public class Circle : RenderableShapeBase,
     /// </remarks>
     public float Radius
     {
-        get => Width / 2f;
+        get => System.Math.Min(Width, Height) / 2f;
         set
         {
             Width = value * 2;
@@ -67,11 +68,13 @@ public class Circle : RenderableShapeBase,
         var absoluteLeft = this.GetAbsoluteLeft();
         var absoluteTop = this.GetAbsoluteTop();
 
+        // Issue #2852: center on the actual bounding box and use the smaller dimension as
+        // the radius so a non-square Circle fits within its box (matches SkiaGum).
         var center = new Microsoft.Xna.Framework.Vector2(
             absoluteLeft + Width / 2.0f,
-            absoluteTop + Width / 2.0f);
+            absoluteTop + Height / 2.0f);
 
-        var radius = Width / 2.0f;
+        var radius = System.Math.Min(Width, Height) / 2.0f;
 
         if(HasDropshadow)
         {

--- a/Runtimes/RaylibGum/Renderables/LineCircle.cs
+++ b/Runtimes/RaylibGum/Renderables/LineCircle.cs
@@ -28,8 +28,20 @@ public class LineCircle : InvisibleRenderable
     /// <inheritdoc cref="CircleOrigin"/>
     public CircleOrigin CircleOrigin { get; set; }
 
-    /// <summary>Radius in world-space pixels.</summary>
-    public float Radius { get; set; }
+    /// <summary>Radius in world-space pixels. Computed from <see cref="Width"/> and
+    /// <see cref="Height"/> as <c>min(Width, Height) / 2</c> so a non-square bounding box
+    /// renders a circle that fits inside the smaller dimension, centered (#2852). The setter
+    /// keeps Width and Height in lockstep so direct Radius assignments still yield a square
+    /// shape. Mirrors the Skia and Apos.Shapes renderables.</summary>
+    public float Radius
+    {
+        get => System.Math.Min(Width, Height) / 2f;
+        set
+        {
+            Width = value * 2;
+            Height = value * 2;
+        }
+    }
 
     /// <summary>
     /// Legacy single-color slot used as the stroke color when <see cref="StrokeColor"/> is

--- a/Samples/MonoGameGumShapesGallery/Screens/CirclesScreen.cs
+++ b/Samples/MonoGameGumShapesGallery/Screens/CirclesScreen.cs
@@ -44,18 +44,19 @@ internal class CirclesScreen : FrameworkElement
 
         // Column split mirrors SilkNetGum/Screens/CirclesScreen so visual regressions in one
         // backend are easy to spot against the other.
-        left.AddChild(BuildSection("Sizes (radius 16, 24, 32, 48) — default outline", BuildSizesRow()));
-        left.AddChild(BuildSection("Alpha on StrokeColor (255, 192, 128, 64)", BuildAlphaRow()));
-        left.AddChild(BuildSection("Modes: FillColor, StrokeColor, default", BuildModeRow()));
-        left.AddChild(BuildSection("StrokeWidth (1, 2, 4, 8 px)", BuildStrokeWidthRow()));
-        left.AddChild(BuildSection("Alignment inside a 128x100 frame (Top / Center / Bottom)", BuildAlignmentRow()));
-        left.AddChild(BuildSection("Gradients (linear / radial / diagonal / centered)", BuildGradientRow()));
+        left.AddChild(BuildSection("Sizes", BuildSizesRow()));
+        left.AddChild(BuildSection("Alpha", BuildAlphaRow()));
+        left.AddChild(BuildSection("Modes", BuildModeRow()));
+        left.AddChild(BuildSection("Stroke width", BuildStrokeWidthRow()));
+        left.AddChild(BuildSection("Alignment", BuildAlignmentRow()));
+        left.AddChild(BuildSection("Gradients", BuildGradientRow()));
 
-        right.AddChild(BuildSection("Antialiasing (default ON, then OFF) — 1 px stroke makes the bloom obvious (#2798)", BuildAntialiasingRow()));
-        right.AddChild(BuildSection("Dropshadow (off / soft / hard offset / colored) — fill-only push avoids doubling (#2797)", BuildDropshadowRow()));
-        right.AddChild(BuildSection("Dashed strokes (solid / 6/4 / 2/2 dotted / long-dash) — stroke-only push (#2796)", BuildDashedStrokeRow()));
-        right.AddChild(BuildSection("FillColor + StrokeColor on the same instance — both layers render simultaneously (#2790)", BuildBothColorsRow()));
-        right.AddChild(BuildSection("Inscribed in a 64x64 frame — stroke must stay inside the gray rectangle's bounds at every StrokeWidth (#2790 visual contract; mirrors SilkNetGum)", BuildInscribedRow()));
+        right.AddChild(BuildSection("Antialiasing", BuildAntialiasingRow()));
+        right.AddChild(BuildSection("Dropshadow", BuildDropshadowRow()));
+        right.AddChild(BuildSection("Dashed strokes", BuildDashedStrokeRow()));
+        right.AddChild(BuildSection("Fill + stroke", BuildBothColorsRow()));
+        right.AddChild(BuildSection("Inscribed", BuildInscribedRow()));
+        right.AddChild(BuildSection("Non-square aspect", BuildNonSquareRow()));
     }
 
     static ContainerRuntime BuildColumn()
@@ -403,6 +404,39 @@ internal class CirclesScreen : FrameworkElement
             row.AddChild(BuildInscribedCell(strokeWidth));
         }
         return row;
+    }
+
+    // Visual acceptance for #2852 — wide, tall, and square cells sharing the same render code.
+    // The gray frame is the circle's bounding box; the circle inside must use min(W,H) for its
+    // diameter and sit centered. Before the #2852 fix, the wide cell drew a Width/2 circle
+    // overflowing the short axis with the center pushed below the box.
+    static ContainerRuntime BuildNonSquareRow()
+    {
+        ContainerRuntime row = BuildHorizontalRow();
+        foreach ((float w, float h) in new[] { (200f, 50f), (50f, 200f), (100f, 100f) })
+        {
+            row.AddChild(BuildNonSquareCell(w, h));
+        }
+        return row;
+    }
+
+    static ColoredRectangleRuntime BuildNonSquareCell(float width, float height)
+    {
+        ColoredRectangleRuntime frame = new();
+        frame.Width = width;
+        frame.Height = height;
+        frame.Color = new Color(60, 60, 80);
+
+        CircleRuntime circle = new();
+        circle.Width = width;
+        circle.Height = height;
+        circle.WidthUnits = DimensionUnitType.Absolute;
+        circle.HeightUnits = DimensionUnitType.Absolute;
+        circle.FillColor = Color.SeaGreen;
+        circle.StrokeColor = Color.Yellow;
+        circle.StrokeWidth = 1;
+        frame.Children.Add(circle);
+        return frame;
     }
 
     static ColoredRectangleRuntime BuildInscribedCell(float strokeWidth)

--- a/Samples/MonoGameGumShapesGallery/Screens/CirclesScreen.cs
+++ b/Samples/MonoGameGumShapesGallery/Screens/CirclesScreen.cs
@@ -413,7 +413,7 @@ internal class CirclesScreen : FrameworkElement
     static ContainerRuntime BuildNonSquareRow()
     {
         ContainerRuntime row = BuildHorizontalRow();
-        foreach ((float w, float h) in new[] { (200f, 50f), (50f, 200f), (100f, 100f) })
+        foreach ((float w, float h) in new[] { (200f, 50f), (50f, 120f), (100f, 100f) })
         {
             row.AddChild(BuildNonSquareCell(w, h));
         }

--- a/Samples/MonoGameGumShapesGallery/Screens/CirclesScreen.cs
+++ b/Samples/MonoGameGumShapesGallery/Screens/CirclesScreen.cs
@@ -420,12 +420,12 @@ internal class CirclesScreen : FrameworkElement
         return row;
     }
 
-    static ColoredRectangleRuntime BuildNonSquareCell(float width, float height)
+    static RectangleRuntime BuildNonSquareCell(float width, float height)
     {
-        ColoredRectangleRuntime frame = new();
+        RectangleRuntime frame = new();
         frame.Width = width;
         frame.Height = height;
-        frame.Color = new Color(60, 60, 80);
+        frame.FillColor = new Color(60, 60, 80);
 
         CircleRuntime circle = new();
         circle.Width = width;

--- a/Samples/MonoGameGumShapesGallery/Screens/CirclesScreen.cs
+++ b/Samples/MonoGameGumShapesGallery/Screens/CirclesScreen.cs
@@ -439,12 +439,12 @@ internal class CirclesScreen : FrameworkElement
         return frame;
     }
 
-    static ColoredRectangleRuntime BuildInscribedCell(float strokeWidth)
+    static RectangleRuntime BuildInscribedCell(float strokeWidth)
     {
-        ColoredRectangleRuntime frame = new();
+        RectangleRuntime frame = new();
         frame.Width = 64;
         frame.Height = 64;
-        frame.Color = new Color(60, 60, 80);
+        frame.FillColor = new Color(60, 60, 80);
 
         CircleRuntime circle = new();
         circle.Radius = 32;
@@ -456,18 +456,18 @@ internal class CirclesScreen : FrameworkElement
         return frame;
     }
 
-    static ColoredRectangleRuntime BuildAlignmentCell(VerticalAlignment alignment)
+    static RectangleRuntime BuildAlignmentCell(VerticalAlignment alignment)
     {
-        // ColoredRectangle is used as a visible frame so the alignment is obvious. Children
-        // are positioned relative to it via YOrigin + PixelsFromSmall/Middle/Large.
-        ColoredRectangleRuntime frame = new();
+        // Visible frame so the alignment is obvious. Children are positioned relative to it
+        // via YOrigin + PixelsFromSmall/Middle/Large.
+        RectangleRuntime frame = new();
         // Narrowed from 220 to 128 to keep the left column from forcing the page wider than
         // the right column needs (the long section labels in the right column would otherwise
         // get clipped or push the overall layout). 128 still gives 3 cells * 60 px clearance
         // for the three alignment circles plus row spacing.
         frame.Width = 128;
         frame.Height = 100;
-        frame.Color = new Color(50, 50, 70);
+        frame.FillColor = new Color(50, 50, 70);
 
         CircleRuntime circle = new();
         circle.Radius = 22;

--- a/Samples/MonoGameGumShapesGallery/Screens/PolygonsScreen.cs
+++ b/Samples/MonoGameGumShapesGallery/Screens/PolygonsScreen.cs
@@ -83,12 +83,12 @@ internal class PolygonsScreen : FrameworkElement
     // Builds a CellSize x CellSize backing frame and parents the supplied polygon to it so
     // the row layout has a predictable per-cell footprint. Polygon points are in the cell's
     // local space (PixelsFromSmall), centered around (Center, Center).
-    static ColoredRectangleRuntime BuildCell(PolygonRuntime polygon)
+    static RectangleRuntime BuildCell(PolygonRuntime polygon)
     {
-        ColoredRectangleRuntime frame = new();
+        RectangleRuntime frame = new();
         frame.Width = CellSize;
         frame.Height = CellSize;
-        frame.Color = new Color(50, 50, 70);
+        frame.FillColor = new Color(50, 50, 70);
         frame.Children.Add(polygon);
         return frame;
     }

--- a/Samples/MonoGameGumShapesGallery/Screens/RectanglesScreen.cs
+++ b/Samples/MonoGameGumShapesGallery/Screens/RectanglesScreen.cs
@@ -420,12 +420,12 @@ internal class RectanglesScreen : FrameworkElement
         return row;
     }
 
-    static ColoredRectangleRuntime BuildInscribedCell(float strokeWidth)
+    static RectangleRuntime BuildInscribedCell(float strokeWidth)
     {
-        ColoredRectangleRuntime frame = new();
+        RectangleRuntime frame = new();
         frame.Width = 64;
         frame.Height = 64;
-        frame.Color = new Color(60, 60, 80);
+        frame.FillColor = new Color(60, 60, 80);
 
         RectangleRuntime rect = new();
         rect.Width = 64;
@@ -450,15 +450,15 @@ internal class RectanglesScreen : FrameworkElement
         return row;
     }
 
-    static ColoredRectangleRuntime BuildAlignmentCell(VerticalAlignment alignment)
+    static RectangleRuntime BuildAlignmentCell(VerticalAlignment alignment)
     {
         // Frame size matches the Skia (SilkNetGum) RectanglesScreen sibling so the two
         // galleries lay out the same. The inner RectangleRuntime is positioned via
         // YOrigin + PixelsFromSmall/Middle/Large.
-        ColoredRectangleRuntime frame = new();
+        RectangleRuntime frame = new();
         frame.Width = 128;
         frame.Height = 100;
-        frame.Color = new Color(50, 50, 70);
+        frame.FillColor = new Color(50, 50, 70);
 
         RectangleRuntime rect = new();
         rect.Width = 50;

--- a/Samples/SilkNetGum/SilkNetGum/Screens/CirclesScreen.cs
+++ b/Samples/SilkNetGum/SilkNetGum/Screens/CirclesScreen.cs
@@ -260,7 +260,7 @@ internal class CirclesScreen : GraphicalUiElement
     static ContainerRuntime BuildNonSquareRow()
     {
         ContainerRuntime row = BuildHorizontalRow();
-        foreach ((float w, float h) in new[] { (200f, 50f), (50f, 200f), (100f, 100f) })
+        foreach ((float w, float h) in new[] { (200f, 50f), (50f, 120f), (100f, 100f) })
         {
             row.Children.Add(BuildNonSquareCell(w, h));
         }

--- a/Samples/SilkNetGum/SilkNetGum/Screens/CirclesScreen.cs
+++ b/Samples/SilkNetGum/SilkNetGum/Screens/CirclesScreen.cs
@@ -39,18 +39,19 @@ internal class CirclesScreen : GraphicalUiElement
         root.Children.Add(left);
         root.Children.Add(right);
 
-        left.Children.Add(BuildSection("Sizes (radius 16, 24, 32, 48) — default outline", BuildSizesRow()));
-        left.Children.Add(BuildSection("Alpha on StrokeColor (255, 192, 128, 64)", BuildAlphaRow()));
-        left.Children.Add(BuildSection("Modes: FillColor, StrokeColor, default", BuildModeRow()));
-        left.Children.Add(BuildSection("StrokeWidth (1, 2, 4, 8 px)", BuildStrokeWidthRow()));
-        left.Children.Add(BuildSection("Alignment inside a 128x100 frame (Top / Center / Bottom)", BuildAlignmentRow()));
-        left.Children.Add(BuildSection("Gradients (linear / radial / diagonal / centered)", BuildGradientRow()));
+        left.Children.Add(BuildSection("Sizes", BuildSizesRow()));
+        left.Children.Add(BuildSection("Alpha", BuildAlphaRow()));
+        left.Children.Add(BuildSection("Modes", BuildModeRow()));
+        left.Children.Add(BuildSection("Stroke width", BuildStrokeWidthRow()));
+        left.Children.Add(BuildSection("Alignment", BuildAlignmentRow()));
+        left.Children.Add(BuildSection("Gradients", BuildGradientRow()));
 
-        right.Children.Add(BuildSection("Antialiasing (default ON, then OFF) — 1 px stroke makes the bloom obvious (#2798)", BuildAntialiasingRow()));
-        right.Children.Add(BuildSection("Dropshadow (off / soft / hard offset / colored) — Skia draws the shadow on the single contained renderable (#2797)", BuildDropshadowRow()));
-        right.Children.Add(BuildSection("Dashed strokes (solid / 6/4 / 2/2 dotted / long-dash) — Skia routes through SkiaShapeRuntime.StrokeDashLength (#2796)", BuildDashedStrokeRow()));
-        right.Children.Add(BuildSection("FillColor + StrokeColor on the same instance — both layers render simultaneously (#2790)", BuildBothColorsRow()));
-        right.Children.Add(BuildSection("Inscribed in a 64x64 frame — stroke must stay inside the gray rectangle's bounds at every StrokeWidth (#2790 visual contract)", BuildInscribedRow()));
+        right.Children.Add(BuildSection("Antialiasing", BuildAntialiasingRow()));
+        right.Children.Add(BuildSection("Dropshadow", BuildDropshadowRow()));
+        right.Children.Add(BuildSection("Dashed strokes", BuildDashedStrokeRow()));
+        right.Children.Add(BuildSection("Fill + stroke", BuildBothColorsRow()));
+        right.Children.Add(BuildSection("Inscribed", BuildInscribedRow()));
+        right.Children.Add(BuildSection("Non-square aspect", BuildNonSquareRow()));
     }
 
     static ContainerRuntime BuildColumn()
@@ -250,6 +251,39 @@ internal class CirclesScreen : GraphicalUiElement
             row.Children.Add(BuildInscribedCell(strokeWidth));
         }
         return row;
+    }
+
+    // Visual acceptance for #2852 — wide, tall, and square cells sharing the same render code.
+    // Skia already exhibited the canonical behavior (radius = min(W,H)/2, centered); this row
+    // pairs with the matching row in MonoGameGumShapesGallery so the two backends can be
+    // compared side-by-side after the Apos.Shapes fix.
+    static ContainerRuntime BuildNonSquareRow()
+    {
+        ContainerRuntime row = BuildHorizontalRow();
+        foreach ((float w, float h) in new[] { (200f, 50f), (50f, 200f), (100f, 100f) })
+        {
+            row.Children.Add(BuildNonSquareCell(w, h));
+        }
+        return row;
+    }
+
+    static RectangleRuntime BuildNonSquareCell(float width, float height)
+    {
+        RectangleRuntime frame = new();
+        frame.Width = width;
+        frame.Height = height;
+        frame.FillColor = new SKColor(60, 60, 80);
+
+        CircleRuntime circle = new();
+        circle.Width = width;
+        circle.Height = height;
+        circle.WidthUnits = DimensionUnitType.Absolute;
+        circle.HeightUnits = DimensionUnitType.Absolute;
+        circle.FillColor = SKColors.SeaGreen;
+        circle.StrokeColor = SKColors.Yellow;
+        circle.StrokeWidth = 1;
+        frame.Children.Add(circle);
+        return frame;
     }
 
     static RectangleRuntime BuildInscribedCell(float strokeWidth)

--- a/Samples/raylib/Screens/CirclesScreen.cs
+++ b/Samples/raylib/Screens/CirclesScreen.cs
@@ -53,6 +53,7 @@ internal class CirclesScreen : FrameworkElement
         right.Children.Add(BuildSection("Dashed strokes", BuildDashedStrokeRow()));
         right.Children.Add(BuildSection("Fill + stroke", BuildBothColorsRow()));
         right.Children.Add(BuildSection("Inscribed", BuildInscribedRow()));
+        right.Children.Add(BuildSection("Non-square aspect", BuildNonSquareRow()));
     }
 
     static ContainerRuntime BuildColumn()
@@ -287,6 +288,38 @@ internal class CirclesScreen : FrameworkElement
             row.Children.Add(BuildInscribedCell(strokeWidth));
         }
         return row;
+    }
+
+    // Visual acceptance for non-square circles — wide, tall, and square cells. The gray frame
+    // is the circle's bounding box; the circle inside must use min(W,H) for its diameter and
+    // sit centered. Mirrors the matching row in MonoGameGumShapesGallery and SilkNetGum.
+    static ContainerRuntime BuildNonSquareRow()
+    {
+        ContainerRuntime row = BuildHorizontalRow();
+        foreach ((float w, float h) in new[] { (200f, 50f), (50f, 120f), (100f, 100f) })
+        {
+            row.Children.Add(BuildNonSquareCell(w, h));
+        }
+        return row;
+    }
+
+    static RectangleRuntime BuildNonSquareCell(float width, float height)
+    {
+        RectangleRuntime frame = new();
+        frame.Width = width;
+        frame.Height = height;
+        frame.FillColor = new Color(60, 60, 80, 255);
+
+        CircleRuntime circle = new();
+        circle.Width = width;
+        circle.Height = height;
+        circle.WidthUnits = DimensionUnitType.Absolute;
+        circle.HeightUnits = DimensionUnitType.Absolute;
+        circle.FillColor = new Color(46, 139, 87, 255);
+        circle.StrokeColor = Color.Yellow;
+        circle.StrokeWidth = 1;
+        frame.Children.Add(circle);
+        return frame;
     }
 
     static RectangleRuntime BuildInscribedCell(float strokeWidth)

--- a/Samples/raylib/Screens/CirclesScreen.cs
+++ b/Samples/raylib/Screens/CirclesScreen.cs
@@ -42,17 +42,17 @@ internal class CirclesScreen : FrameworkElement
         // Section order mirrors SilkNetGum/Screens/CirclesScreen.cs exactly, minus the one
         // section raylib can't currently demo (Antialiasing). That keeps the remaining rows
         // top-aligned across both windows when run side-by-side.
-        left.Children.Add(BuildSection("Sizes (radius 16, 24, 32, 48) — default outline", BuildSizesRow()));
-        left.Children.Add(BuildSection("Alpha on StrokeColor (255, 192, 128, 64)", BuildAlphaRow()));
-        left.Children.Add(BuildSection("Modes: FillColor, StrokeColor, default", BuildModeRow()));
-        left.Children.Add(BuildSection("StrokeWidth (1, 2, 4, 8 px)", BuildStrokeWidthRow()));
-        left.Children.Add(BuildSection("Alignment inside a 128x100 frame (Top / Center / Bottom)", BuildAlignmentRow()));
-        left.Children.Add(BuildSection("Gradients (linear / radial / diagonal / centered)", BuildGradientRow()));
+        left.Children.Add(BuildSection("Sizes", BuildSizesRow()));
+        left.Children.Add(BuildSection("Alpha", BuildAlphaRow()));
+        left.Children.Add(BuildSection("Modes", BuildModeRow()));
+        left.Children.Add(BuildSection("Stroke width", BuildStrokeWidthRow()));
+        left.Children.Add(BuildSection("Alignment", BuildAlignmentRow()));
+        left.Children.Add(BuildSection("Gradients", BuildGradientRow()));
 
-        right.Children.Add(BuildSection("Dropshadow (off / soft / hard offset / colored) — raylib approximates the blur via concentric rings (#2757)", BuildDropshadowRow()));
-        right.Children.Add(BuildSection("Dashed strokes (solid / 6/4 / 2/2 dotted / long-dash) — raylib emits one DrawRing arc per dash (#2757)", BuildDashedStrokeRow()));
-        right.Children.Add(BuildSection("FillColor + StrokeColor on the same instance — both layers render simultaneously (#2757)", BuildBothColorsRow()));
-        right.Children.Add(BuildSection("Inscribed in a 64x64 frame — stroke must stay inside the gray rectangle's bounds at every StrokeWidth (#2757)", BuildInscribedRow()));
+        right.Children.Add(BuildSection("Dropshadow", BuildDropshadowRow()));
+        right.Children.Add(BuildSection("Dashed strokes", BuildDashedStrokeRow()));
+        right.Children.Add(BuildSection("Fill + stroke", BuildBothColorsRow()));
+        right.Children.Add(BuildSection("Inscribed", BuildInscribedRow()));
     }
 
     static ContainerRuntime BuildColumn()

--- a/Tests/MonoGameGum.Shapes.Tests/CircleRenderableTests.cs
+++ b/Tests/MonoGameGum.Shapes.Tests/CircleRenderableTests.cs
@@ -1,0 +1,47 @@
+using MonoGameAndGum.Renderables;
+using Shouldly;
+
+namespace MonoGameGum.Shapes.Tests;
+
+// Issue #2852: when Width != Height the Apos.Shapes Circle previously sized its radius from
+// Width alone, which produced two divergent results vs Skia (the tool/viewport renderer):
+// the circle could overflow the box on the short axis, and a wide-but-short circle's center
+// landed below the box because center.Y was also derived from Width. These tests pin the
+// canonical behavior to "fit inside the bounding box, centered" — matching Skia.
+public class CircleRenderableTests
+{
+    [Fact]
+    public void Radius_WhenWidthGreaterThanHeight_UsesSmallerDimension()
+    {
+        Circle sut = new() { Width = 200, Height = 50 };
+
+        sut.Radius.ShouldBe(25f);
+    }
+
+    [Fact]
+    public void Radius_WhenHeightGreaterThanWidth_UsesSmallerDimension()
+    {
+        Circle sut = new() { Width = 50, Height = 200 };
+
+        sut.Radius.ShouldBe(25f);
+    }
+
+    [Fact]
+    public void Radius_WhenSquare_IsHalfDimension()
+    {
+        Circle sut = new() { Width = 80, Height = 80 };
+
+        sut.Radius.ShouldBe(40f);
+    }
+
+    [Fact]
+    public void Radius_Setter_KeepsWidthAndHeightSquare()
+    {
+        Circle sut = new();
+
+        sut.Radius = 30;
+
+        sut.Width.ShouldBe(60f);
+        sut.Height.ShouldBe(60f);
+    }
+}

--- a/Tests/RaylibGum.Tests/Renderables/LineCircleTests.cs
+++ b/Tests/RaylibGum.Tests/Renderables/LineCircleTests.cs
@@ -30,6 +30,37 @@ public class LineCircleTests
         circle.Color.A.ShouldBe((byte)255);
     }
 
+    // Issue #2852 — Radius is computed from min(Width, Height) / 2 so the raylib renderable
+    // renders a non-square bounding box as a circle that fits the smaller dimension, matching
+    // the Skia and Apos.Shapes renderables. The layout system sets Width/Height directly when
+    // a circle is sized by its parent, so Radius cannot be an independent field.
+    [Fact]
+    public void Radius_WhenWidthGreaterThanHeight_UsesSmallerDimension()
+    {
+        LineCircle circle = new() { Width = 200, Height = 50 };
+
+        circle.Radius.ShouldBe(25f);
+    }
+
+    [Fact]
+    public void Radius_WhenHeightGreaterThanWidth_UsesSmallerDimension()
+    {
+        LineCircle circle = new() { Width = 50, Height = 200 };
+
+        circle.Radius.ShouldBe(25f);
+    }
+
+    [Fact]
+    public void Radius_Setter_KeepsWidthAndHeightSquare()
+    {
+        LineCircle circle = new();
+
+        circle.Radius = 30;
+
+        circle.Width.ShouldBe(60f);
+        circle.Height.ShouldBe(60f);
+    }
+
     [Fact]
     public void IsFilled_RoundTrips()
     {


### PR DESCRIPTION
## Summary
- Aligns the MonoGame (Apos.Shapes) `Circle` renderable with SkiaGum's behavior: when `Width != Height`, the circle now renders with `radius = min(Width, Height) / 2` centered in the bounding box, rather than `Width / 2` with `center.Y` also derived from `Width` (which both overflowed the short axis and pushed the center outside the box).
- Updates the `Radius` getter to return `min(Width, Height) / 2`, matching what `Render` actually draws and matching the Skia renderable's getter.

## Test plan
- [x] New `CircleRenderableTests` cover the `Radius` getter for wide, tall, and square shapes plus the setter's lockstep behavior.
- [x] `dotnet test Tests/MonoGameGum.Shapes.Tests/MonoGameGum.Shapes.Tests.csproj` — 54/54 pass.

Closes #2852

🤖 Generated with [Claude Code](https://claude.com/claude-code)