### PR TITLE
Codegen: emit using for component BaseType namespace

### DIFF
--- a/.claude/skills/refactoring-direction/SKILL.md
+++ b/.claude/skills/refactoring-direction/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: refactoring-direction
+description: "Refactoring direction rules for Gum. Trigger when proposing or performing refactors that change how code is shaped — extracting helpers, choosing between static and instance, deciding where new logic should live. Applies to all Gum source projects."
+---
+
+# Refactoring direction
+
+When refactoring Gum code, **always move toward instances, interfaces, and dedicated single-responsibility classes**. Never move the other way.
+
+## Specific rules
+
+1. **Never promote an instance method, field, or class to `static`.** Even if the method "has no instance state right now," keep it as an instance member. Static methods are sticky — they grow callers everywhere, can't be substituted in tests, and can't be evolved without source-breaking every caller. Instance methods preserve future optionality.
+
+2. **Never demote an interface to a concrete type.** If a parameter or field is currently typed as an interface (`ISelectedState`, `IDialogService`, `IUndoManager`, etc.), keep it that way. Adding a new dependency? Inject it as an interface, not a concrete class.
+
+3. **Prefer extracting a new single-responsibility class over adding to a "god class."** `GraphicalUiElement`, `CodeGenerator`, and similar large classes should not grow. New behavior goes in a new controller/service class that the existing class composes with, even if the new class starts with one method.
+
+4. **Prefer constructor injection over `*.Self` singletons.** The Gum tool has been progressively migrating off static singletons (see project `CLAUDE.md`). Don't reverse that. `ObjectFinder.Self` is the documented exception — no other singletons should be reintroduced.
+
+## When testability is the driver
+
+If the reason you're tempted to make something `static` is "so a test can call it without constructing the owner," the right answer is the opposite: keep it instance, and either (a) construct the owner in the test with stub dependencies, or (b) extract the logic into a new small class that's cheap to construct. The test's friction is a signal that the owner has too many responsibilities, not that the method should be static.
+
+## Why this matters in Gum
+
+Gum's tool code is mid-migration from static singletons (`PluginManager.Self`, `*Manager.Self`, etc.) to constructor-injected services. Every new `static` is a step backward and undoes that migration's payoff. The runtime libraries are similar: `GraphicalUiElement` is already bloated, and the project memory explicitly calls out "avoid adding new properties/methods directly to this class — prefer separate controller/manager classes." The direction in this skill is the same direction the rest of the codebase is moving.

--- a/Tests/Gum.ProjectServices.Tests/CodeGeneratorCollectUsingsTests.cs
+++ b/Tests/Gum.ProjectServices.Tests/CodeGeneratorCollectUsingsTests.cs
@@ -1,0 +1,238 @@
+using Gum.DataTypes;
+using Gum.DataTypes.Behaviors;
+using Gum.DataTypes.Variables;
+using Gum.Localization;
+using Gum.Managers;
+using Gum.ProjectServices.CodeGeneration;
+using Moq;
+using Shouldly;
+using ToolsUtilities;
+
+namespace Gum.ProjectServices.Tests;
+
+/// <summary>
+/// Tests for <see cref="CodeGenerator.CollectUsingNamespaces"/> — verifies that the set of
+/// namespaces emitted as <c>using X;</c> lines includes the instance-derived namespaces and the
+/// component's own non-standard BaseType namespace (regression: components inheriting from a
+/// user-defined component with no matching instances were missing the BaseType using).
+/// </summary>
+public class CodeGeneratorCollectUsingsTests
+{
+    private static CodeGenerator CreateCodeGenerator()
+    {
+        Mock<INameVerifier> mockNameVerifier = new Mock<INameVerifier>();
+        CodeGenerationNameVerifier codeGenNameVerifier = new CodeGenerationNameVerifier(mockNameVerifier.Object);
+        FixedProjectDirectoryProvider directoryProvider = new FixedProjectDirectoryProvider(projectDirectory: null);
+        CodeOutputElementSettingsManager elementSettingsManager = new CodeOutputElementSettingsManager(directoryProvider);
+        LocalizationService localizationService = new LocalizationService();
+
+        return new CodeGenerator(
+            codeGenNameVerifier,
+            localizationService,
+            elementSettingsManager,
+            directoryProvider);
+    }
+
+    private static CodeOutputProjectSettings CreateProjectSettings(string rootNamespace = "MyGame")
+    {
+        return new CodeOutputProjectSettings
+        {
+            OutputLibrary = OutputLibrary.MonoGame,
+            RootNamespace = rootNamespace,
+            AppendFolderToNamespace = true,
+        };
+    }
+
+    [Fact]
+    public void Component_BaseTypeAndInstance_SameNamespace_DeduplicatedToOne()
+    {
+        // Both BaseType and an instance resolve to the same namespace -> appears exactly once.
+        ComponentSave label = new ComponentSave { Name = "BubbleGumTheme/Controls/Label" };
+        ComponentSave floatingLabel = new ComponentSave { Name = "BubbleGumTheme/Controls/FloatingLabel" };
+        floatingLabel.BaseType = "BubbleGumTheme/Controls/Label";
+
+        InstanceSave inner = new InstanceSave
+        {
+            Name = "InnerLabel",
+            BaseType = "BubbleGumTheme/Controls/Label",
+            ParentContainer = floatingLabel,
+        };
+        floatingLabel.Instances.Add(inner);
+
+        GumProjectSave project = new GumProjectSave();
+        project.Components.Add(label);
+        project.Components.Add(floatingLabel);
+        ObjectFinder.Self.GumProjectSave = project;
+
+        try
+        {
+            CodeGenerator generator = CreateCodeGenerator();
+            CodeOutputProjectSettings settings = CreateProjectSettings();
+
+            IReadOnlyList<string> usings = generator.CollectUsingNamespaces(
+                floatingLabel,
+                elementSettings: null,
+                settings,
+                resolvedSyntaxVersion: 0);
+
+            string expected = "MyGame.Components.BubbleGumTheme.Controls";
+            usings.Count(n => n == expected).ShouldBe(1);
+        }
+        finally
+        {
+            ObjectFinder.Self.GumProjectSave = null;
+        }
+    }
+
+    [Fact]
+    public void Component_BaseTypeStandardElement_DoesNotAddProjectNamespace()
+    {
+        // BaseType resolves to a StandardElementSave -> should NOT add a project-component
+        // namespace for it (standards are referenced via the GueDeriving using, not the project ns).
+        StandardElementSave container = new StandardElementSave { Name = "Container" };
+
+        ComponentSave bareComponent = new ComponentSave { Name = "Widgets/BareComponent" };
+        bareComponent.BaseType = "Container";
+
+        GumProjectSave project = new GumProjectSave();
+        project.StandardElements.Add(container);
+        project.Components.Add(bareComponent);
+        ObjectFinder.Self.GumProjectSave = project;
+
+        try
+        {
+            CodeGenerator generator = CreateCodeGenerator();
+            CodeOutputProjectSettings settings = CreateProjectSettings();
+
+            IReadOnlyList<string> usings = generator.CollectUsingNamespaces(
+                bareComponent,
+                elementSettings: null,
+                settings,
+                resolvedSyntaxVersion: 0);
+
+            usings.ShouldNotContain("MyGame.Components.Widgets");
+            usings.ShouldNotContain("MyGame.Standards");
+        }
+        finally
+        {
+            ObjectFinder.Self.GumProjectSave = null;
+        }
+    }
+
+    [Fact]
+    public void Component_WithNoInstances_BaseTypeNonStandard_IncludesBaseTypeNamespace()
+    {
+        // RED test for the bug: FloatingLabel-style component inherits from a user component
+        // in another folder and has no instances. Without the fix, the BaseType's namespace
+        // is never added and the generated code fails to compile.
+        ComponentSave label = new ComponentSave { Name = "BubbleGumTheme/Controls/Label" };
+        ComponentSave floatingLabel = new ComponentSave { Name = "Widgets/FloatingLabel" };
+        floatingLabel.BaseType = "BubbleGumTheme/Controls/Label";
+
+        GumProjectSave project = new GumProjectSave();
+        project.Components.Add(label);
+        project.Components.Add(floatingLabel);
+        ObjectFinder.Self.GumProjectSave = project;
+
+        try
+        {
+            CodeGenerator generator = CreateCodeGenerator();
+            CodeOutputProjectSettings settings = CreateProjectSettings();
+
+            IReadOnlyList<string> usings = generator.CollectUsingNamespaces(
+                floatingLabel,
+                elementSettings: null,
+                settings,
+                resolvedSyntaxVersion: 0);
+
+            usings.ShouldContain("MyGame.Components.BubbleGumTheme.Controls");
+        }
+        finally
+        {
+            ObjectFinder.Self.GumProjectSave = null;
+        }
+    }
+
+    [Fact]
+    public void Component_WithNonStandardInstance_IncludesInstanceNamespace()
+    {
+        // Pinning test: instance whose BaseType is a non-standard component in a different
+        // folder contributes its namespace.
+        ComponentSave label = new ComponentSave { Name = "BubbleGumTheme/Controls/Label" };
+
+        ComponentSave host = new ComponentSave { Name = "Widgets/Host" };
+        InstanceSave instance = new InstanceSave
+        {
+            Name = "MyLabel",
+            BaseType = "BubbleGumTheme/Controls/Label",
+            ParentContainer = host,
+        };
+        host.Instances.Add(instance);
+
+        GumProjectSave project = new GumProjectSave();
+        project.Components.Add(label);
+        project.Components.Add(host);
+        ObjectFinder.Self.GumProjectSave = project;
+
+        try
+        {
+            CodeGenerator generator = CreateCodeGenerator();
+            CodeOutputProjectSettings settings = CreateProjectSettings();
+
+            IReadOnlyList<string> usings = generator.CollectUsingNamespaces(
+                host,
+                elementSettings: null,
+                settings,
+                resolvedSyntaxVersion: 0);
+
+            usings.ShouldContain("MyGame.Components.BubbleGumTheme.Controls");
+        }
+        finally
+        {
+            ObjectFinder.Self.GumProjectSave = null;
+        }
+    }
+
+    [Fact]
+    public void Component_WithStandardInstanceOnly_DoesNotAddExtraNamespace()
+    {
+        // Pinning test: instance is a StandardElementSave (ColoredRectangle) -> no project
+        // component namespace beyond the runtime/library defaults.
+        StandardElementSave coloredRectangle = new StandardElementSave { Name = "ColoredRectangle" };
+
+        ComponentSave host = new ComponentSave { Name = "Widgets/Host" };
+        InstanceSave instance = new InstanceSave
+        {
+            Name = "Bg",
+            BaseType = "ColoredRectangle",
+            ParentContainer = host,
+        };
+        host.Instances.Add(instance);
+
+        GumProjectSave project = new GumProjectSave();
+        project.StandardElements.Add(coloredRectangle);
+        project.Components.Add(host);
+        ObjectFinder.Self.GumProjectSave = project;
+
+        try
+        {
+            CodeGenerator generator = CreateCodeGenerator();
+            CodeOutputProjectSettings settings = CreateProjectSettings();
+
+            IReadOnlyList<string> usings = generator.CollectUsingNamespaces(
+                host,
+                elementSettings: null,
+                settings,
+                resolvedSyntaxVersion: 0);
+
+            usings.ShouldNotContain("MyGame.Components.Widgets");
+            usings.ShouldNotContain("MyGame.Standards");
+            // Sanity check: the default monogame entries should be there.
+            usings.ShouldContain("MonoGameGum");
+        }
+        finally
+        {
+            ObjectFinder.Self.GumProjectSave = null;
+        }
+    }
+}

--- a/Tools/Gum.ProjectServices/CodeGeneration/CodeGenerator.cs
+++ b/Tools/Gum.ProjectServices/CodeGeneration/CodeGenerator.cs
@@ -338,45 +338,85 @@ public class CodeGenerator
 
     private void GenerateUsingStatements(CodeGenerationContext context)
     {
+        IReadOnlyList<string> neededUsings = CollectUsingNamespaces(
+            context.Element,
+            context.ElementSettings,
+            context.CodeOutputProjectSettings,
+            context.ResolvedSyntaxVersion);
 
+        foreach (var neededUsing in neededUsings)
+        {
+            context.StringBuilder.AppendLine($"using {neededUsing};");
+        }
+    }
+
+    /// <summary>
+    /// Builds the sorted set of namespaces that <see cref="GenerateUsingStatements"/> emits
+    /// <c>using X;</c> lines for. Includes the runtime-library defaults, the namespaces of any
+    /// non-standard instances, the element's own non-standard BaseType namespace, animation
+    /// namespaces when applicable, and the user-supplied project/element using statements.
+    /// </summary>
+    internal IReadOnlyList<string> CollectUsingNamespaces(
+        ElementSave element,
+        CodeOutputElementSettings? elementSettings,
+        CodeOutputProjectSettings projectSettings,
+        int resolvedSyntaxVersion)
+    {
         // This code is used to automatially add needed using statements:
         // https://github.com/vchelaru/Gum/issues/598
         HashSet<string> neededUsings = new HashSet<string>();
         neededUsings.Add("GumRuntime");
         neededUsings.Add("System.Linq");
 
-        if (context.CodeOutputProjectSettings.OutputLibrary == OutputLibrary.MonoGame ||
-            context.CodeOutputProjectSettings.OutputLibrary == OutputLibrary.MonoGameForms)
+        if (projectSettings.OutputLibrary == OutputLibrary.MonoGame ||
+            projectSettings.OutputLibrary == OutputLibrary.MonoGameForms)
         {
             neededUsings.Add("MonoGameGum");
-            neededUsings.Add(GetGueDerivingNamespace(context.ResolvedSyntaxVersion, isSkia: false));
+            neededUsings.Add(GetGueDerivingNamespace(resolvedSyntaxVersion, isSkia: false));
         }
 
-        if (context.CodeOutputProjectSettings.OutputLibrary == OutputLibrary.Skia)
+        if (projectSettings.OutputLibrary == OutputLibrary.Skia)
         {
             // https://github.com/vchelaru/Gum/issues/895
-            neededUsings.Add(GetGueDerivingNamespace(context.ResolvedSyntaxVersion, isSkia: true));
+            neededUsings.Add(GetGueDerivingNamespace(resolvedSyntaxVersion, isSkia: true));
         }
 
-        foreach (var instance in context.Element.Instances)
+        foreach (var instance in element.Instances)
         {
-            var gumType = instance.BaseType;
-
             var instanceElement = ObjectFinder.Self.GetElementSave(instance);
 
             if (instanceElement != null && instanceElement is not StandardElementSave)
             {
-                var elementNamespace = GetElementNamespace(instanceElement, context.ElementSettings, context.CodeOutputProjectSettings);
+                var elementNamespace = GetElementNamespace(instanceElement, elementSettings, projectSettings);
 
-                if (!string.IsNullOrEmpty(elementNamespace) && !neededUsings.Contains(elementNamespace))
+                if (!string.IsNullOrEmpty(elementNamespace))
                 {
                     neededUsings.Add(elementNamespace);
                 }
             }
         }
 
+        // The component's own BaseType may resolve to a non-standard element in a different
+        // namespace than any of its instances (or the component may have no instances at all).
+        // Without this, components that inherit from another user-defined component fail to
+        // compile because the base type is unresolved. See: BubbleGumTheme FloatingLabel : Label.
+        if (!string.IsNullOrEmpty(element.BaseType))
+        {
+            var baseElement = ObjectFinder.Self.GetElementSave(element.BaseType);
+
+            if (baseElement != null && baseElement is not StandardElementSave)
+            {
+                var baseNamespace = GetElementNamespace(baseElement, elementSettings, projectSettings);
+
+                if (!string.IsNullOrEmpty(baseNamespace))
+                {
+                    neededUsings.Add(baseNamespace);
+                }
+            }
+        }
+
         // Add using statements for AnimationRuntime and GetAnimation extension method if element has animations
-        if (GetElementAnimationsSave(context.Element) != null)
+        if (GetElementAnimationsSave(element) != null)
         {
             neededUsings.Add("Gum.StateAnimation.Runtime");
             neededUsings.Add("Gum.Wireframe");
@@ -384,9 +424,9 @@ public class CodeGenerator
 
         // The regex's here fix this bug:
         // https://github.com/vchelaru/Gum/issues/242
-        if (!string.IsNullOrWhiteSpace(context.CodeOutputProjectSettings?.CommonUsingStatements))
+        if (!string.IsNullOrWhiteSpace(projectSettings?.CommonUsingStatements))
         {
-            var originalString = context.CodeOutputProjectSettings.CommonUsingStatements;
+            var originalString = projectSettings.CommonUsingStatements;
 
             string result = Regex.Replace(originalString, @"(?<!\r)\n", "\r\n");
 
@@ -395,9 +435,9 @@ public class CodeGenerator
             AddUsings(splitUsings);
         }
 
-        if (!string.IsNullOrEmpty(context.ElementSettings?.UsingStatements))
+        if (!string.IsNullOrEmpty(elementSettings?.UsingStatements))
         {
-            string originalString = context.ElementSettings!.UsingStatements;
+            string originalString = elementSettings!.UsingStatements;
             string result = Regex.Replace(originalString, @"(?<!\r)\n", "\r\n");
 
             var splitUsings = result.Split("\r\n", StringSplitOptions.RemoveEmptyEntries);
@@ -423,11 +463,7 @@ public class CodeGenerator
             }
         }
 
-
-        foreach (var neededUsing in neededUsings.OrderBy(item => item))
-        {
-            context.StringBuilder.AppendLine($"using {neededUsing};");
-        }
+        return neededUsings.OrderBy(item => item).ToList();
     }
 
     #endregion


### PR DESCRIPTION
## Summary
- Generated code for a component now emits a `using` for the component's own non-standard BaseType namespace, not just for its instances.
- Repro: a component like `FloatingLabel : BubbleGumTheme/Controls/Label` with no instances previously failed to compile because `Label` was unresolved. `BigButton : Button` happened to compile only because it contained Label-typed instances that pulled the same namespace in via the instance walk.
- Refactor: `CodeGenerator.GenerateUsingStatements` now delegates namespace collection to a new instance helper `CollectUsingNamespaces`, which is the seam the tests target. Drive-by cleanups: removed a dead `gumType` local and a redundant `HashSet.Contains` guard.
- Added `.claude/skills/refactoring-direction/SKILL.md` capturing the "never promote toward static — move toward instances/interfaces/SRP classes" rule that shaped the extraction.

## Test plan
- [x] `dotnet test Tests/Gum.ProjectServices.Tests/Gum.ProjectServices.Tests.csproj` — full suite green (5 new `CodeGeneratorCollectUsingsTests`, 234 prior tests unaffected).
- [x] `dotnet build GumFull.sln` — clean.
- [x] Open the original QuestToCompileGum repro: regenerate code for `FloatingLabel` and confirm `using QuestToCompileGum.Components.BubbleGumTheme.Controls;` is present and the project compiles.
- [x] Spot-check `BigButton` still compiles (no regression for the accidentally-working case).

🤖 Generated with [Claude Code](https://claude.com/claude-code)