### PR TITLE
#2857: Walk inheritance chain to pick TextRuntime in VisualTemplate

### DIFF
--- a/Tests/Gum.ProjectServices.Tests/CodeGeneratorRegisterRuntimeTypeTests.cs
+++ b/Tests/Gum.ProjectServices.Tests/CodeGeneratorRegisterRuntimeTypeTests.cs
@@ -1,0 +1,124 @@
+using Gum.DataTypes;
+using Gum.DataTypes.Variables;
+using Gum.Localization;
+using Gum.Managers;
+using Gum.ProjectServices.CodeGeneration;
+using Moq;
+using Shouldly;
+
+namespace Gum.ProjectServices.Tests;
+
+/// <summary>
+/// Tests for the <c>visual</c> runtime type emitted inside the generated
+/// <c>RegisterRuntimeType</c> / <c>VisualTemplate</c> lambda. Regression: codegen used to
+/// check only the immediate <c>BaseType</c>, so a chain like <c>MyHeader : Label : Text</c>
+/// fell back to <c>ContainerRuntime</c> instead of <c>TextRuntime</c> (#2857).
+/// </summary>
+public class CodeGeneratorRegisterRuntimeTypeTests : BaseTestClass
+{
+    private static CodeGenerator CreateCodeGenerator()
+    {
+        Mock<INameVerifier> mockNameVerifier = new Mock<INameVerifier>();
+        string whyNotValid;
+        CommonValidationError error;
+        mockNameVerifier
+            .Setup(v => v.IsValidCSharpName(It.IsAny<string>(), out whyNotValid, out error))
+            .Returns(true);
+        CodeGenerationNameVerifier codeGenNameVerifier = new CodeGenerationNameVerifier(mockNameVerifier.Object);
+        FixedProjectDirectoryProvider directoryProvider = new FixedProjectDirectoryProvider(projectDirectory: null);
+        CodeOutputElementSettingsManager elementSettingsManager = new CodeOutputElementSettingsManager(directoryProvider);
+        LocalizationService localizationService = new LocalizationService();
+
+        return new CodeGenerator(
+            codeGenNameVerifier,
+            localizationService,
+            elementSettingsManager,
+            directoryProvider);
+    }
+
+    private static CodeOutputProjectSettings CreateForms()
+    {
+        return new CodeOutputProjectSettings
+        {
+            OutputLibrary = OutputLibrary.MonoGameForms,
+            RootNamespace = "MyGame",
+        };
+    }
+
+    private static ComponentSave CreateComponent(string name, string baseType)
+    {
+        ComponentSave component = new ComponentSave { Name = name, BaseType = baseType };
+        StateSave defaultState = new StateSave { Name = "Default", ParentContainer = component };
+        component.States.Add(defaultState);
+        return component;
+    }
+
+    [Fact]
+    public void DirectTextInheritance_EmitsTextRuntime()
+    {
+        GumProjectSave project = Project;
+        ComponentSave label = CreateComponent("Label", "Text");
+        project.Components.Add(label);
+        ObjectFinder.Self.GumProjectSave = project;
+
+        try
+        {
+            string code = CreateCodeGenerator().GetGeneratedCodeForElement(
+                label, elementSettings: null!, CreateForms());
+
+            code.ShouldContain("TextRuntime();");
+            code.ShouldNotContain("ContainerRuntime();");
+        }
+        finally
+        {
+            ObjectFinder.Self.GumProjectSave = null;
+        }
+    }
+
+    [Fact]
+    public void IndirectTextInheritance_EmitsTextRuntime()
+    {
+        // Regression for #2857: MyHeader : Label : Text should walk to Text and pick TextRuntime.
+        GumProjectSave project = Project;
+        ComponentSave label = CreateComponent("Label", "Text");
+        ComponentSave myHeader = CreateComponent("MyHeader", "Label");
+        project.Components.Add(label);
+        project.Components.Add(myHeader);
+        ObjectFinder.Self.GumProjectSave = project;
+
+        try
+        {
+            string code = CreateCodeGenerator().GetGeneratedCodeForElement(
+                myHeader, elementSettings: null!, CreateForms());
+
+            code.ShouldContain("TextRuntime();");
+            code.ShouldNotContain("ContainerRuntime();");
+        }
+        finally
+        {
+            ObjectFinder.Self.GumProjectSave = null;
+        }
+    }
+
+    [Fact]
+    public void ContainerInheritance_StillEmitsContainerRuntime()
+    {
+        GumProjectSave project = Project;
+        ComponentSave panel = CreateComponent("Panel", "Container");
+        project.Components.Add(panel);
+        ObjectFinder.Self.GumProjectSave = project;
+
+        try
+        {
+            string code = CreateCodeGenerator().GetGeneratedCodeForElement(
+                panel, elementSettings: null!, CreateForms());
+
+            code.ShouldContain("ContainerRuntime();");
+            code.ShouldNotContain("TextRuntime();");
+        }
+        finally
+        {
+            ObjectFinder.Self.GumProjectSave = null;
+        }
+    }
+}

--- a/Tools/Gum.ProjectServices/CodeGeneration/CodeGenerator.cs
+++ b/Tools/Gum.ProjectServices/CodeGeneration/CodeGenerator.cs
@@ -1528,7 +1528,9 @@ public class CodeGenerator
             builder.AppendLine(context.Tabs + "{");
             context.TabCount++;
 
-            var inheritsFromText = context.Element.BaseType == "Text";
+            var rootStandard = ObjectFinder.Self.GetRootStandardElementSave(context.Element);
+            var inheritsFromText = rootStandard?.Name == "Text"
+                || (rootStandard == null && context.Element.BaseType == "Text");
             if(inheritsFromText)
             {
                 // special case for label:


### PR DESCRIPTION
## Summary
- The generated `RegisterRuntimeType` lambda only checked the immediate `BaseType`, so a chain like `MyHeader : Label : Text` resolved to `ContainerRuntime` instead of `TextRuntime`.
- Now uses `ObjectFinder.Self.GetRootStandardElementSave` to walk to the root standard element; if that root is `Text`, emit `TextRuntime`. Behavior is unchanged when no project is loaded (fallback retains the original single-level check).
- Adds `CodeGeneratorRegisterRuntimeTypeTests` covering direct inheritance, indirect inheritance (the bug), and the Container case.

Closes #2857

## Test plan
- [x] `dotnet test Tests/Gum.ProjectServices.Tests/Gum.ProjectServices.Tests.csproj` — 237 passed
- [x] Verified the indirect-inheritance test was RED before the fix and GREEN after

🤖 Generated with [Claude Code](https://claude.com/claude-code)