### PR TITLE
#2851: Apos.Shapes dropshadow fades with body alpha (matches Skia)

### DIFF
--- a/Runtimes/GumShapes/Renderables/Arc.cs
+++ b/Runtimes/GumShapes/Renderables/Arc.cs
@@ -90,7 +90,7 @@ internal class Arc : RenderableShapeBase
                 radius: radius,
                 antiAliasSize: MathFunctions.RoundToInt(DropshadowBlurX),
                 lineThickness: StrokeWidth - DropshadowBlurX,
-                forcedColor: DropshadowColor);
+                forcedColor: EffectiveDropshadowColor);
         }
 
         RenderInternal(sb, absoluteLeft, absoluteTop, center, radius, IsAntialiased ? 1 : 0, StrokeWidth);

--- a/Runtimes/GumShapes/Renderables/Circle.cs
+++ b/Runtimes/GumShapes/Renderables/Circle.cs
@@ -85,10 +85,10 @@ public class Circle : RenderableShapeBase,
             dropshadowCenter.X += DropshadowOffsetX;
             dropshadowCenter.Y += DropshadowOffsetY;
 
-            RenderInternal(sb, shadowLeft, shadowTop, dropshadowCenter, radius - DropshadowBlurX / 2f, 
+            RenderInternal(sb, shadowLeft, shadowTop, dropshadowCenter, radius - DropshadowBlurX / 2f,
                 MathFunctions.RoundToInt(DropshadowBlurX),
                 StrokeWidth - DropshadowBlurX,
-                DropshadowColor);
+                EffectiveDropshadowColor);
         }
 
         RenderInternal(sb, absoluteLeft, absoluteTop, center, radius, IsAntialiased ? 1 : 0, StrokeWidth);

--- a/Runtimes/GumShapes/Renderables/Line.cs
+++ b/Runtimes/GumShapes/Renderables/Line.cs
@@ -35,7 +35,7 @@ internal class Line : RenderableShapeBase
             RenderInternal(sb, absoluteLeft + DropshadowOffsetX, absoluteTop + DropshadowOffsetY,
                 shadowA, shadowB,
                 antiAliasSize: MathHelper.Max(1, DropshadowBlurX),
-                forcedColor: DropshadowColor);
+                forcedColor: EffectiveDropshadowColor);
         }
 
         RenderInternal(sb, absoluteLeft, absoluteTop, a, b, antiAliasSize: IsAntialiased ? 1 : 0);

--- a/Runtimes/GumShapes/Renderables/RenderableShapeBase.cs
+++ b/Runtimes/GumShapes/Renderables/RenderableShapeBase.cs
@@ -301,6 +301,21 @@ public abstract class RenderableShapeBase : RenderableBase
         }
     }
 
+    /// <summary>
+    /// Issue #2851 — the dropshadow color actually emitted by <see cref="Circle"/> and
+    /// <see cref="RoundedRectangle"/>, with its alpha multiplied by the body's
+    /// <see cref="Color"/> alpha. Matches SkiaGum (and therefore the Gum tool/viewport),
+    /// where the shadow is an image filter on the same paint that draws the body, so reducing
+    /// the shape's alpha fades the shadow with it. Without this scaling, an Apos.Shapes
+    /// shape fading to transparent would leave an opaque shadow ghost behind.
+    /// </summary>
+    public Color EffectiveDropshadowColor =>
+        new Color(
+            _dropshadowColor.R,
+            _dropshadowColor.G,
+            _dropshadowColor.B,
+            (byte)(_dropshadowColor.A * Color.A / 255));
+
     public int DropshadowAlpha
     {
         get => DropshadowColor.A;

--- a/Runtimes/GumShapes/Renderables/RoundedRectangle.cs
+++ b/Runtimes/GumShapes/Renderables/RoundedRectangle.cs
@@ -82,7 +82,7 @@ public class RoundedRectangle : RenderableShapeBase,
                 MathFunctions.RoundToInt(DropshadowBlurX),
                 StrokeWidth - DropshadowBlurX,
                 rotationRadians,
-                forcedColor: DropshadowColor);
+                forcedColor: EffectiveDropshadowColor);
         }
 
         RenderInternal(sb, absoluteLeft, absoluteTop, size, IsAntialiased ? 1 : 0, StrokeWidth, rotationRadians);

--- a/Runtimes/RaylibGum/Renderables/LineCircle.cs
+++ b/Runtimes/RaylibGum/Renderables/LineCircle.cs
@@ -300,15 +300,20 @@ public class LineCircle : InvisibleRenderable
                 float totalExtent = 2f * bandSpan;
                 float bandThickness = totalExtent / blurRings;
                 Vector2 shadowCenter = new Vector2(shadowCx, shadowCy);
+                // Issue #2851: scale the target cumulative alpha profile by the effective
+                // shadow alpha BEFORE inverting source-over to per-band alphas. Scaling
+                // per-band alpha after the fact stacks non-linearly and overshoots.
+                float f = effectiveDropshadowColor.A / 255f;
                 float prevP = 1f;
                 for (int j = blurRings - 1; j >= 0; j--)
                 {
                     float tOuter = (j + 1f) / blurRings;
-                    float targetAlpha = System.MathF.Max(0f, 1f - tOuter);
+                    float profileAlpha = System.MathF.Max(0f, 1f - tOuter);
+                    float targetAlpha = f * profileAlpha;
                     float currP = 1f - targetAlpha;
                     float beta = prevP > 0f ? 1f - currP / prevP : 0f;
                     prevP = currP;
-                    byte circleAlpha = (byte)(effectiveDropshadowColor.A * beta);
+                    byte circleAlpha = (byte)(255f * beta + 0.5f);
                     if (circleAlpha == 0)
                     {
                         continue;
@@ -322,13 +327,21 @@ public class LineCircle : InvisibleRenderable
                     }
                 }
 
-                // Solid inner core for pixels deeper than the innermost band so they read
-                // as full-alpha shadow. Outermost band already fades to 0 so no outer core
-                // is needed.
+                // Solid inner core closes the remaining alpha gap between what the bands
+                // accumulated (prevP) and the target final alpha (1 - f). Small correction
+                // at low effective alphas; reduces to the original full-alpha plateau when
+                // f = 1. Source-over inversion: prevP * (1 - α_core) = 1 - f.
                 float innerCoreR = Radius - bandSpan;
-                if (innerCoreR > 0f)
+                if (innerCoreR > 0f && prevP > 1f - f)
                 {
-                    DrawCircle((int)shadowCx, (int)shadowCy, innerCoreR, effectiveDropshadowColor);
+                    float coreBeta = 1f - (1f - f) / prevP;
+                    byte coreAlpha = (byte)(255f * coreBeta + 0.5f);
+                    if (coreAlpha > 0)
+                    {
+                        Color coreColor = new Color(effectiveDropshadowColor.R,
+                            effectiveDropshadowColor.G, effectiveDropshadowColor.B, coreAlpha);
+                        DrawCircle((int)shadowCx, (int)shadowCy, innerCoreR, coreColor);
+                    }
                 }
             }
             else

--- a/Runtimes/RaylibGum/Renderables/LineCircle.cs
+++ b/Runtimes/RaylibGum/Renderables/LineCircle.cs
@@ -262,6 +262,17 @@ public class LineCircle : InvisibleRenderable
             float shadowCy = cy + DropshadowOffsetY;
             float blur = System.MathF.Max(DropshadowBlurX, DropshadowBlurY);
 
+            // Issue #2851: scale shadow alpha by body Color.A so fading the circle to
+            // transparent also fades the shadow. Matches SkiaGum (the Gum tool/viewport),
+            // where the shadow is an image filter on the same paint that draws the body and
+            // therefore inherits its alpha. Apos.Shapes does the same scaling on its side via
+            // RenderableShapeBase.EffectiveDropshadowColor.
+            Color effectiveDropshadowColor = new Color(
+                DropshadowColor.R,
+                DropshadowColor.G,
+                DropshadowColor.B,
+                (byte)(DropshadowColor.A * Color.A / 255));
+
             if (blur > 0f)
             {
                 // Skia's Gaussian convolution of the shape silhouette makes the silhouette
@@ -294,13 +305,13 @@ public class LineCircle : InvisibleRenderable
                     float currP = 1f - targetAlpha;
                     float beta = prevP > 0f ? 1f - currP / prevP : 0f;
                     prevP = currP;
-                    byte circleAlpha = (byte)(DropshadowColor.A * beta);
+                    byte circleAlpha = (byte)(effectiveDropshadowColor.A * beta);
                     if (circleAlpha == 0)
                     {
                         continue;
                     }
-                    Color circleColor = new Color(DropshadowColor.R, DropshadowColor.G,
-                        DropshadowColor.B, circleAlpha);
+                    Color circleColor = new Color(effectiveDropshadowColor.R, effectiveDropshadowColor.G,
+                        effectiveDropshadowColor.B, circleAlpha);
                     float r = Radius - bandSpan + (j + 1) * bandThickness;
                     if (r > 0f)
                     {
@@ -314,13 +325,13 @@ public class LineCircle : InvisibleRenderable
                 float innerCoreR = Radius - bandSpan;
                 if (innerCoreR > 0f)
                 {
-                    DrawCircle((int)shadowCx, (int)shadowCy, innerCoreR, DropshadowColor);
+                    DrawCircle((int)shadowCx, (int)shadowCy, innerCoreR, effectiveDropshadowColor);
                 }
             }
             else
             {
                 // blur = 0: hard offset silhouette, no fade.
-                DrawCircle((int)shadowCx, (int)shadowCy, Radius, DropshadowColor);
+                DrawCircle((int)shadowCx, (int)shadowCy, Radius, effectiveDropshadowColor);
             }
         }
 

--- a/Runtimes/RaylibGum/Renderables/LineCircle.cs
+++ b/Runtimes/RaylibGum/Renderables/LineCircle.cs
@@ -262,16 +262,19 @@ public class LineCircle : InvisibleRenderable
             float shadowCy = cy + DropshadowOffsetY;
             float blur = System.MathF.Max(DropshadowBlurX, DropshadowBlurY);
 
-            // Issue #2851: scale shadow alpha by body Color.A so fading the circle to
-            // transparent also fades the shadow. Matches SkiaGum (the Gum tool/viewport),
-            // where the shadow is an image filter on the same paint that draws the body and
-            // therefore inherits its alpha. Apos.Shapes does the same scaling on its side via
-            // RenderableShapeBase.EffectiveDropshadowColor.
+            // Issue #2851: scale shadow alpha by the body's effective alpha so fading the
+            // circle to transparent also fades the shadow. Matches SkiaGum (the Gum
+            // tool/viewport) and Apos.Shapes (RenderableShapeBase.EffectiveDropshadowColor).
+            // In the two-slot model the user picks the body alpha via FillColor / StrokeColor
+            // / legacy Color; we read the same precedence the fill pass below uses
+            // (FillColor ?? Color), falling back to StrokeColor when no fill is set so an
+            // outline-only shape's shadow still fades with the outline.
+            byte bodyAlpha = FillColor?.A ?? StrokeColor?.A ?? Color.A;
             Color effectiveDropshadowColor = new Color(
                 DropshadowColor.R,
                 DropshadowColor.G,
                 DropshadowColor.B,
-                (byte)(DropshadowColor.A * Color.A / 255));
+                (byte)(DropshadowColor.A * bodyAlpha / 255));
 
             if (blur > 0f)
             {

--- a/Runtimes/RaylibGum/Renderables/LineRectangle.cs
+++ b/Runtimes/RaylibGum/Renderables/LineRectangle.cs
@@ -289,6 +289,17 @@ public class LineRectangle : InvisibleRenderable
             float shadowY = oy + DropshadowOffsetY;
             float blur = MathF.Max(DropshadowBlurX, DropshadowBlurY);
 
+            // Issue #2851: scale shadow alpha by body Color.A so fading the rectangle to
+            // transparent also fades the shadow. Matches SkiaGum (the Gum tool/viewport),
+            // where the shadow is an image filter on the same paint that draws the body and
+            // therefore inherits its alpha. Apos.Shapes does the same scaling on its side via
+            // RenderableShapeBase.EffectiveDropshadowColor.
+            Color effectiveDropshadowColor = new Color(
+                DropshadowColor.R,
+                DropshadowColor.G,
+                DropshadowColor.B,
+                (byte)(DropshadowColor.A * Color.A / 255));
+
             if (blur > 0f)
             {
                 // Bands span both sides of the silhouette boundary: from -blur to +blur
@@ -314,13 +325,13 @@ public class LineRectangle : InvisibleRenderable
                     float currP = 1f - targetAlpha;
                     float beta = prevP > 0f ? 1f - currP / prevP : 0f;
                     prevP = currP;
-                    byte bandAlpha = (byte)(DropshadowColor.A * beta);
+                    byte bandAlpha = (byte)(effectiveDropshadowColor.A * beta);
                     if (bandAlpha == 0)
                     {
                         continue;
                     }
-                    Color bandColor = new Color(DropshadowColor.R, DropshadowColor.G,
-                        DropshadowColor.B, bandAlpha);
+                    Color bandColor = new Color(effectiveDropshadowColor.R, effectiveDropshadowColor.G,
+                        effectiveDropshadowColor.B, bandAlpha);
                     float inflate = -bandSpan + (j + 1) * bandThickness;
                     float bandW = w + 2f * inflate;
                     float bandH = h + 2f * inflate;
@@ -370,12 +381,12 @@ public class LineRectangle : InvisibleRenderable
                         float innerRoundness = innerMinDim > 0f
                             ? MathF.Min(1f, innerCornerR * 2f / innerMinDim)
                             : 0f;
-                        DrawRectangleRounded(innerCore, innerRoundness, roundedSegments, DropshadowColor);
+                        DrawRectangleRounded(innerCore, innerRoundness, roundedSegments, effectiveDropshadowColor);
                     }
                     else
                     {
                         DrawRectangleV(new Vector2(innerCore.X, innerCore.Y),
-                            new Vector2(innerCoreW, innerCoreH), DropshadowColor);
+                            new Vector2(innerCoreW, innerCoreH), effectiveDropshadowColor);
                     }
                 }
             }
@@ -385,11 +396,11 @@ public class LineRectangle : InvisibleRenderable
                 if (useRounded && !rotated)
                 {
                     Rectangle shadowRect = new Rectangle(shadowX, shadowY, w, h);
-                    DrawRectangleRounded(shadowRect, roundness, roundedSegments, DropshadowColor);
+                    DrawRectangleRounded(shadowRect, roundness, roundedSegments, effectiveDropshadowColor);
                 }
                 else
                 {
-                    DrawRectangleV(new Vector2(shadowX, shadowY), new Vector2(w, h), DropshadowColor);
+                    DrawRectangleV(new Vector2(shadowX, shadowY), new Vector2(w, h), effectiveDropshadowColor);
                 }
             }
         }

--- a/Runtimes/RaylibGum/Renderables/LineRectangle.cs
+++ b/Runtimes/RaylibGum/Renderables/LineRectangle.cs
@@ -320,15 +320,21 @@ public class LineRectangle : InvisibleRenderable
                 float bandSpan = blur;
                 float totalExtent = 2f * bandSpan;
                 float bandThickness = totalExtent / blurRings;
+                // Issue #2851: the target cumulative alpha profile must be scaled by the
+                // effective shadow alpha BEFORE inverting source-over to per-band alphas.
+                // Scaling per-band alpha after the fact stacks non-linearly and overshoots
+                // (a blur≠0 shadow at effective alpha 80 ended up cumulative ~0.77, not 0.31).
+                float f = effectiveDropshadowColor.A / 255f;
                 float prevP = 1f;
                 for (int j = blurRings - 1; j >= 0; j--)
                 {
                     float tOuter = (j + 1f) / blurRings;
-                    float targetAlpha = MathF.Max(0f, 1f - tOuter);
+                    float profileAlpha = MathF.Max(0f, 1f - tOuter);
+                    float targetAlpha = f * profileAlpha;
                     float currP = 1f - targetAlpha;
                     float beta = prevP > 0f ? 1f - currP / prevP : 0f;
                     prevP = currP;
-                    byte bandAlpha = (byte)(effectiveDropshadowColor.A * beta);
+                    byte bandAlpha = (byte)(255f * beta + 0.5f);
                     if (bandAlpha == 0)
                     {
                         continue;
@@ -366,30 +372,40 @@ public class LineRectangle : InvisibleRenderable
                     }
                 }
 
-                // Solid inner core for pixels deeper than the innermost band so they read
-                // as full-alpha shadow.
+                // Solid inner core closes the remaining alpha gap between what the bands
+                // accumulated (prevP after the loop) and the target final alpha (1 - f).
+                // With the scaled target profile above, this is a small correction at low
+                // effective alphas (≈3/255 when f=0.31) and the original full-alpha plateau
+                // when f=1. Source-over inversion: prevP * (1 - α_core) = 1 - f.
                 float innerCoreW = w - 2f * bandSpan;
                 float innerCoreH = h - 2f * bandSpan;
-                if (innerCoreW > 0f && innerCoreH > 0f)
+                if (innerCoreW > 0f && innerCoreH > 0f && prevP > 1f - f)
                 {
-                    Rectangle innerCore = new Rectangle(
-                        shadowX + bandSpan,
-                        shadowY + bandSpan,
-                        innerCoreW,
-                        innerCoreH);
-                    if (useRounded && !rotated)
+                    float coreBeta = 1f - (1f - f) / prevP;
+                    byte coreAlpha = (byte)(255f * coreBeta + 0.5f);
+                    if (coreAlpha > 0)
                     {
-                        float innerCornerR = MathF.Max(0f, CornerRadius - bandSpan);
-                        float innerMinDim = MathF.Min(innerCoreW, innerCoreH);
-                        float innerRoundness = innerMinDim > 0f
-                            ? MathF.Min(1f, innerCornerR * 2f / innerMinDim)
-                            : 0f;
-                        DrawRectangleRounded(innerCore, innerRoundness, roundedSegments, effectiveDropshadowColor);
-                    }
-                    else
-                    {
-                        DrawRectangleV(new Vector2(innerCore.X, innerCore.Y),
-                            new Vector2(innerCoreW, innerCoreH), effectiveDropshadowColor);
+                        Color coreColor = new Color(effectiveDropshadowColor.R,
+                            effectiveDropshadowColor.G, effectiveDropshadowColor.B, coreAlpha);
+                        Rectangle innerCore = new Rectangle(
+                            shadowX + bandSpan,
+                            shadowY + bandSpan,
+                            innerCoreW,
+                            innerCoreH);
+                        if (useRounded && !rotated)
+                        {
+                            float innerCornerR = MathF.Max(0f, CornerRadius - bandSpan);
+                            float innerMinDim = MathF.Min(innerCoreW, innerCoreH);
+                            float innerRoundness = innerMinDim > 0f
+                                ? MathF.Min(1f, innerCornerR * 2f / innerMinDim)
+                                : 0f;
+                            DrawRectangleRounded(innerCore, innerRoundness, roundedSegments, coreColor);
+                        }
+                        else
+                        {
+                            DrawRectangleV(new Vector2(innerCore.X, innerCore.Y),
+                                new Vector2(innerCoreW, innerCoreH), coreColor);
+                        }
                     }
                 }
             }

--- a/Runtimes/RaylibGum/Renderables/LineRectangle.cs
+++ b/Runtimes/RaylibGum/Renderables/LineRectangle.cs
@@ -289,16 +289,19 @@ public class LineRectangle : InvisibleRenderable
             float shadowY = oy + DropshadowOffsetY;
             float blur = MathF.Max(DropshadowBlurX, DropshadowBlurY);
 
-            // Issue #2851: scale shadow alpha by body Color.A so fading the rectangle to
-            // transparent also fades the shadow. Matches SkiaGum (the Gum tool/viewport),
-            // where the shadow is an image filter on the same paint that draws the body and
-            // therefore inherits its alpha. Apos.Shapes does the same scaling on its side via
-            // RenderableShapeBase.EffectiveDropshadowColor.
+            // Issue #2851: scale shadow alpha by the body's effective alpha so fading the
+            // rectangle to transparent also fades the shadow. Matches SkiaGum (the Gum
+            // tool/viewport) and Apos.Shapes (RenderableShapeBase.EffectiveDropshadowColor).
+            // In the two-slot model the user picks the body alpha via FillColor / StrokeColor
+            // / legacy Color; we read the same precedence the fill pass below uses
+            // (FillColor ?? Color), falling back to StrokeColor when no fill is set so an
+            // outline-only shape's shadow still fades with the outline.
+            byte bodyAlpha = FillColor?.A ?? StrokeColor?.A ?? Color.A;
             Color effectiveDropshadowColor = new Color(
                 DropshadowColor.R,
                 DropshadowColor.G,
                 DropshadowColor.B,
-                (byte)(DropshadowColor.A * Color.A / 255));
+                (byte)(DropshadowColor.A * bodyAlpha / 255));
 
             if (blur > 0f)
             {

--- a/Samples/MonoGameGumShapesGallery/Game1.cs
+++ b/Samples/MonoGameGumShapesGallery/Game1.cs
@@ -63,6 +63,7 @@ public class Game1 : Game
         AddNavButton("Shape survey", NewSurveyScreen);
         AddNavButton("Circles", () => new CirclesScreen());
         AddNavButton("Rectangles", () => new RectanglesScreen());
+        AddNavButton("Arcs", () => new ArcsScreen());
         AddNavButton("Polygons", () => new PolygonsScreen());
         AddNavButton("Gradients", () => new GradientScreen());
     }

--- a/Samples/MonoGameGumShapesGallery/Screens/ArcsScreen.cs
+++ b/Samples/MonoGameGumShapesGallery/Screens/ArcsScreen.cs
@@ -97,8 +97,8 @@ internal class ArcsScreen : FrameworkElement
         soft.Thickness = 10;
         soft.Color = Color.Goldenrod;
         soft.HasDropshadow = true;
-        soft.DropshadowOffsetX = 4;
-        soft.DropshadowOffsetY = 4;
+        soft.DropshadowOffsetX = 14;
+        soft.DropshadowOffsetY = 14;
         soft.DropshadowBlurX = 4;
         soft.DropshadowBlurY = 4;
         row.AddChild(soft);
@@ -110,8 +110,8 @@ internal class ArcsScreen : FrameworkElement
         hard.Color = Color.Goldenrod;
         hard.HasDropshadow = true;
         hard.DropshadowColor = new Color(0, 0, 0, 160);
-        hard.DropshadowOffsetX = 6;
-        hard.DropshadowOffsetY = 6;
+        hard.DropshadowOffsetX = 16;
+        hard.DropshadowOffsetY = 16;
         hard.DropshadowBlurX = 0;
         hard.DropshadowBlurY = 0;
         row.AddChild(hard);
@@ -123,8 +123,8 @@ internal class ArcsScreen : FrameworkElement
         colored.Color = Color.Goldenrod;
         colored.HasDropshadow = true;
         colored.DropshadowColor = new Color(220, 40, 160, 220);
-        colored.DropshadowOffsetX = 6;
-        colored.DropshadowOffsetY = 6;
+        colored.DropshadowOffsetX = 16;
+        colored.DropshadowOffsetY = 16;
         colored.DropshadowBlurX = 6;
         colored.DropshadowBlurY = 6;
         row.AddChild(colored);
@@ -135,8 +135,8 @@ internal class ArcsScreen : FrameworkElement
         fadedBody.Thickness = 10;
         fadedBody.Color = new Color((byte)218, (byte)165, (byte)32, (byte)80);
         fadedBody.HasDropshadow = true;
-        fadedBody.DropshadowOffsetX = 4;
-        fadedBody.DropshadowOffsetY = 4;
+        fadedBody.DropshadowOffsetX = 14;
+        fadedBody.DropshadowOffsetY = 14;
         fadedBody.DropshadowBlurX = 4;
         fadedBody.DropshadowBlurY = 4;
         row.AddChild(fadedBody);

--- a/Samples/MonoGameGumShapesGallery/Screens/ArcsScreen.cs
+++ b/Samples/MonoGameGumShapesGallery/Screens/ArcsScreen.cs
@@ -1,0 +1,146 @@
+using Gum.DataTypes;
+using Gum.Forms.Controls;
+using Gum.GueDeriving;
+using Gum.Wireframe;
+using Microsoft.Xna.Framework;
+using RenderingLibrary.Graphics;
+
+namespace MonoGameGumShapesGallery.Screens;
+
+// Issue #2851 — Arc shape survey on the Apos.Shapes side, focused on dropshadow behavior so
+// the shadow-alpha-multiplies-into-body-alpha fix has a dedicated visual home. Mirrors
+// Samples/SilkNetGum/SilkNetGum/Screens/ArcsScreen.cs (Skia side) cell-for-cell so visual
+// regressions in one backend are easy to spot against the other.
+internal class ArcsScreen : FrameworkElement
+{
+    public ArcsScreen() : base(new ContainerRuntime())
+    {
+        Dock(Gum.Wireframe.Dock.Fill);
+
+        ContainerRuntime root = new();
+        root.ChildrenLayout = Gum.Managers.ChildrenLayout.TopToBottomStack;
+        root.StackSpacing = 14;
+        root.X = 10;
+        root.Y = 10;
+        AddChild(root);
+
+        root.AddChild(BuildSection("Sweep angles (90, 180, 270, 360)", BuildSweepRow()));
+        root.AddChild(BuildSection("Dropshadow (off / soft / hard / colored / faded body)", BuildDropshadowRow()));
+    }
+
+    static ContainerRuntime BuildSection(string label, GraphicalUiElement body)
+    {
+        ContainerRuntime section = new();
+        section.ChildrenLayout = Gum.Managers.ChildrenLayout.TopToBottomStack;
+        section.StackSpacing = 4;
+        section.WidthUnits = DimensionUnitType.RelativeToChildren;
+        section.HeightUnits = DimensionUnitType.RelativeToChildren;
+        section.Width = 0;
+        section.Height = 0;
+
+        TextRuntime header = new();
+        header.Text = label;
+        header.Red = 220;
+        header.Green = 220;
+        header.Blue = 220;
+        section.AddChild(header);
+        section.AddChild(body);
+        return section;
+    }
+
+    static ContainerRuntime BuildHorizontalRow()
+    {
+        ContainerRuntime row = new();
+        row.ChildrenLayout = Gum.Managers.ChildrenLayout.LeftToRightStack;
+        row.StackSpacing = 16;
+        row.WidthUnits = DimensionUnitType.RelativeToChildren;
+        row.HeightUnits = DimensionUnitType.RelativeToChildren;
+        row.Width = 0;
+        row.Height = 0;
+        return row;
+    }
+
+    static ContainerRuntime BuildSweepRow()
+    {
+        ContainerRuntime row = BuildHorizontalRow();
+        foreach (float sweep in new[] { 90f, 180f, 270f, 360f })
+        {
+            ArcRuntime arc = new();
+            arc.Width = 60;
+            arc.Height = 60;
+            arc.SweepAngle = sweep;
+            arc.Thickness = 8;
+            arc.Color = Color.Goldenrod;
+            row.AddChild(arc);
+        }
+        return row;
+    }
+
+    // Issue #2851 visual acceptance: five cells — baseline, soft shadow, hard-offset shadow,
+    // colored shadow, and "faded body" (body alpha cut to 80, same soft-shadow config as cell
+    // two). Pre-fix the faded-body cell rendered an opaque shadow ghost behind a translucent
+    // arc; post-fix the shadow fades alongside the body, matching SkiaGum.
+    static ContainerRuntime BuildDropshadowRow()
+    {
+        ContainerRuntime row = BuildHorizontalRow();
+
+        ArcRuntime baseline = new();
+        baseline.Width = 60; baseline.Height = 60;
+        baseline.SweepAngle = 270;
+        baseline.Thickness = 10;
+        baseline.Color = Color.Goldenrod;
+        row.AddChild(baseline);
+
+        ArcRuntime soft = new();
+        soft.Width = 60; soft.Height = 60;
+        soft.SweepAngle = 270;
+        soft.Thickness = 10;
+        soft.Color = Color.Goldenrod;
+        soft.HasDropshadow = true;
+        soft.DropshadowOffsetX = 4;
+        soft.DropshadowOffsetY = 4;
+        soft.DropshadowBlurX = 4;
+        soft.DropshadowBlurY = 4;
+        row.AddChild(soft);
+
+        ArcRuntime hard = new();
+        hard.Width = 60; hard.Height = 60;
+        hard.SweepAngle = 270;
+        hard.Thickness = 10;
+        hard.Color = Color.Goldenrod;
+        hard.HasDropshadow = true;
+        hard.DropshadowColor = new Color(0, 0, 0, 160);
+        hard.DropshadowOffsetX = 6;
+        hard.DropshadowOffsetY = 6;
+        hard.DropshadowBlurX = 0;
+        hard.DropshadowBlurY = 0;
+        row.AddChild(hard);
+
+        ArcRuntime colored = new();
+        colored.Width = 60; colored.Height = 60;
+        colored.SweepAngle = 270;
+        colored.Thickness = 10;
+        colored.Color = Color.Goldenrod;
+        colored.HasDropshadow = true;
+        colored.DropshadowColor = new Color(220, 40, 160, 220);
+        colored.DropshadowOffsetX = 6;
+        colored.DropshadowOffsetY = 6;
+        colored.DropshadowBlurX = 6;
+        colored.DropshadowBlurY = 6;
+        row.AddChild(colored);
+
+        ArcRuntime fadedBody = new();
+        fadedBody.Width = 60; fadedBody.Height = 60;
+        fadedBody.SweepAngle = 270;
+        fadedBody.Thickness = 10;
+        fadedBody.Color = new Color((byte)218, (byte)165, (byte)32, (byte)80);
+        fadedBody.HasDropshadow = true;
+        fadedBody.DropshadowOffsetX = 4;
+        fadedBody.DropshadowOffsetY = 4;
+        fadedBody.DropshadowBlurX = 4;
+        fadedBody.DropshadowBlurY = 4;
+        row.AddChild(fadedBody);
+
+        return row;
+    }
+}

--- a/Samples/MonoGameGumShapesGallery/Screens/CirclesScreen.cs
+++ b/Samples/MonoGameGumShapesGallery/Screens/CirclesScreen.cs
@@ -269,8 +269,8 @@ internal class CirclesScreen : FrameworkElement
         soft.Radius = 28;
         soft.FillColor = Color.Goldenrod;
         soft.HasDropshadow = true;
-        soft.DropshadowOffsetX = 4;
-        soft.DropshadowOffsetY = 4;
+        soft.DropshadowOffsetX = 14;
+        soft.DropshadowOffsetY = 14;
         soft.DropshadowBlurX = 4;
         soft.DropshadowBlurY = 4;
         row.AddChild(soft);
@@ -281,8 +281,8 @@ internal class CirclesScreen : FrameworkElement
         hard.FillColor = Color.Goldenrod;
         hard.HasDropshadow = true;
         hard.DropshadowColor = new Color(0, 0, 0, 160);
-        hard.DropshadowOffsetX = 6;
-        hard.DropshadowOffsetY = 6;
+        hard.DropshadowOffsetX = 16;
+        hard.DropshadowOffsetY = 16;
         hard.DropshadowBlurX = 0;
         hard.DropshadowBlurY = 0;
         row.AddChild(hard);
@@ -295,8 +295,8 @@ internal class CirclesScreen : FrameworkElement
         colored.FillColor = Color.Goldenrod;
         colored.HasDropshadow = true;
         colored.DropshadowColor = new Color(220, 40, 160, 220);
-        colored.DropshadowOffsetX = 6;
-        colored.DropshadowOffsetY = 6;
+        colored.DropshadowOffsetX = 16;
+        colored.DropshadowOffsetY = 16;
         colored.DropshadowBlurX = 6;
         colored.DropshadowBlurY = 6;
         row.AddChild(colored);
@@ -309,8 +309,8 @@ internal class CirclesScreen : FrameworkElement
         fadedBody.Radius = 28;
         fadedBody.FillColor = new Color((byte)218, (byte)165, (byte)32, (byte)80);
         fadedBody.HasDropshadow = true;
-        fadedBody.DropshadowOffsetX = 4;
-        fadedBody.DropshadowOffsetY = 4;
+        fadedBody.DropshadowOffsetX = 14;
+        fadedBody.DropshadowOffsetY = 14;
         fadedBody.DropshadowBlurX = 4;
         fadedBody.DropshadowBlurY = 4;
         row.AddChild(fadedBody);

--- a/Samples/MonoGameGumShapesGallery/Screens/CirclesScreen.cs
+++ b/Samples/MonoGameGumShapesGallery/Screens/CirclesScreen.cs
@@ -301,6 +301,20 @@ internal class CirclesScreen : FrameworkElement
         colored.DropshadowBlurY = 6;
         row.AddChild(colored);
 
+        // Issue #2851 visual acceptance: same soft-shadow config as the second cell, but with
+        // the body's alpha cut to 80. The shadow must fade alongside the body — matches Skia
+        // (and therefore the Gum tool/viewport). Pre-fix the Apos.Shapes side left an opaque
+        // shadow ghost behind a translucent disk.
+        CircleRuntime fadedBody = new();
+        fadedBody.Radius = 28;
+        fadedBody.FillColor = new Color((byte)218, (byte)165, (byte)32, (byte)80);
+        fadedBody.HasDropshadow = true;
+        fadedBody.DropshadowOffsetX = 4;
+        fadedBody.DropshadowOffsetY = 4;
+        fadedBody.DropshadowBlurX = 4;
+        fadedBody.DropshadowBlurY = 4;
+        row.AddChild(fadedBody);
+
         return row;
     }
 

--- a/Samples/MonoGameGumShapesGallery/Screens/RectanglesScreen.cs
+++ b/Samples/MonoGameGumShapesGallery/Screens/RectanglesScreen.cs
@@ -328,6 +328,17 @@ internal class RectanglesScreen : FrameworkElement
         colored.DropshadowBlurY = 6;
         row.AddChild(colored);
 
+        // Issue #2851 visual acceptance — body alpha multiplies into the shadow alpha.
+        RectangleRuntime fadedBody = new();
+        fadedBody.Width = 60; fadedBody.Height = 50;
+        fadedBody.FillColor = new Color((byte)218, (byte)165, (byte)32, (byte)80);
+        fadedBody.HasDropshadow = true;
+        fadedBody.DropshadowOffsetX = 4;
+        fadedBody.DropshadowOffsetY = 4;
+        fadedBody.DropshadowBlurX = 4;
+        fadedBody.DropshadowBlurY = 4;
+        row.AddChild(fadedBody);
+
         return row;
     }
 

--- a/Samples/MonoGameGumShapesGallery/Screens/RectanglesScreen.cs
+++ b/Samples/MonoGameGumShapesGallery/Screens/RectanglesScreen.cs
@@ -300,8 +300,8 @@ internal class RectanglesScreen : FrameworkElement
         soft.Width = 60; soft.Height = 50;
         soft.FillColor = Color.Goldenrod;
         soft.HasDropshadow = true;
-        soft.DropshadowOffsetX = 4;
-        soft.DropshadowOffsetY = 4;
+        soft.DropshadowOffsetX = 14;
+        soft.DropshadowOffsetY = 14;
         soft.DropshadowBlurX = 4;
         soft.DropshadowBlurY = 4;
         row.AddChild(soft);
@@ -311,8 +311,8 @@ internal class RectanglesScreen : FrameworkElement
         hard.FillColor = Color.Goldenrod;
         hard.HasDropshadow = true;
         hard.DropshadowColor = new Color(0, 0, 0, 160);
-        hard.DropshadowOffsetX = 6;
-        hard.DropshadowOffsetY = 6;
+        hard.DropshadowOffsetX = 16;
+        hard.DropshadowOffsetY = 16;
         hard.DropshadowBlurX = 0;
         hard.DropshadowBlurY = 0;
         row.AddChild(hard);
@@ -322,8 +322,8 @@ internal class RectanglesScreen : FrameworkElement
         colored.FillColor = Color.Goldenrod;
         colored.HasDropshadow = true;
         colored.DropshadowColor = new Color(220, 40, 160, 220);
-        colored.DropshadowOffsetX = 6;
-        colored.DropshadowOffsetY = 6;
+        colored.DropshadowOffsetX = 16;
+        colored.DropshadowOffsetY = 16;
         colored.DropshadowBlurX = 6;
         colored.DropshadowBlurY = 6;
         row.AddChild(colored);
@@ -333,8 +333,8 @@ internal class RectanglesScreen : FrameworkElement
         fadedBody.Width = 60; fadedBody.Height = 50;
         fadedBody.FillColor = new Color((byte)218, (byte)165, (byte)32, (byte)80);
         fadedBody.HasDropshadow = true;
-        fadedBody.DropshadowOffsetX = 4;
-        fadedBody.DropshadowOffsetY = 4;
+        fadedBody.DropshadowOffsetX = 14;
+        fadedBody.DropshadowOffsetY = 14;
         fadedBody.DropshadowBlurX = 4;
         fadedBody.DropshadowBlurY = 4;
         row.AddChild(fadedBody);

--- a/Samples/SilkNetGum/SilkNetGum/Program.cs
+++ b/Samples/SilkNetGum/SilkNetGum/Program.cs
@@ -55,6 +55,7 @@ unsafe class Program
         () => new SilkNetGum.Screens.NineSliceScreen(),
         () => new SilkNetGum.Screens.CirclesScreen(),
         () => new SilkNetGum.Screens.RectanglesScreen(),
+        () => new SilkNetGum.Screens.ArcsScreen(),
         () => new SilkNetGum.Screens.PolygonsScreen(),
     };
 

--- a/Samples/SilkNetGum/SilkNetGum/Screens/ArcsScreen.cs
+++ b/Samples/SilkNetGum/SilkNetGum/Screens/ArcsScreen.cs
@@ -1,0 +1,139 @@
+using Gum.DataTypes;
+using Gum.GueDeriving;
+using Gum.Wireframe;
+using RenderingLibrary.Graphics;
+using SkiaSharp;
+
+namespace SilkNetGum.Screens;
+
+// Issue #2851 — Skia mirror of MonoGameGumShapesGallery/Screens/ArcsScreen.cs. Skia has
+// always faded the shadow with the body (the canonical behavior), so this screen exists for
+// visual parity with the post-#2851 MonoGame side — same cells, same parameters, so a
+// regression on either backend is easy to spot.
+internal class ArcsScreen : GraphicalUiElement
+{
+    public ArcsScreen() : base(new InvisibleRenderable())
+    {
+        ContainerRuntime root = new();
+        root.ChildrenLayout = Gum.Managers.ChildrenLayout.TopToBottomStack;
+        root.StackSpacing = 14;
+        root.X = 10;
+        root.Y = 10;
+        this.Children.Add(root);
+
+        root.Children.Add(BuildSection("Sweep angles (90, 180, 270, 360)", BuildSweepRow()));
+        root.Children.Add(BuildSection("Dropshadow (off / soft / hard / colored / faded body)", BuildDropshadowRow()));
+    }
+
+    static ContainerRuntime BuildSection(string label, GraphicalUiElement body)
+    {
+        ContainerRuntime section = new();
+        section.ChildrenLayout = Gum.Managers.ChildrenLayout.TopToBottomStack;
+        section.StackSpacing = 4;
+        section.WidthUnits = DimensionUnitType.RelativeToChildren;
+        section.HeightUnits = DimensionUnitType.RelativeToChildren;
+        section.Width = 0;
+        section.Height = 0;
+
+        TextRuntime header = new();
+        header.Text = label;
+        header.Red = 220;
+        header.Green = 220;
+        header.Blue = 220;
+        section.Children.Add(header);
+        section.Children.Add(body);
+        return section;
+    }
+
+    static ContainerRuntime BuildHorizontalRow()
+    {
+        ContainerRuntime row = new();
+        row.ChildrenLayout = Gum.Managers.ChildrenLayout.LeftToRightStack;
+        row.StackSpacing = 16;
+        row.WidthUnits = DimensionUnitType.RelativeToChildren;
+        row.HeightUnits = DimensionUnitType.RelativeToChildren;
+        row.Width = 0;
+        row.Height = 0;
+        return row;
+    }
+
+    static ContainerRuntime BuildSweepRow()
+    {
+        ContainerRuntime row = BuildHorizontalRow();
+        foreach (float sweep in new[] { 90f, 180f, 270f, 360f })
+        {
+            ArcRuntime arc = new();
+            arc.Width = 60;
+            arc.Height = 60;
+            arc.SweepAngle = sweep;
+            arc.Thickness = 8;
+            arc.Color = SKColors.Goldenrod;
+            row.Children.Add(arc);
+        }
+        return row;
+    }
+
+    static ContainerRuntime BuildDropshadowRow()
+    {
+        ContainerRuntime row = BuildHorizontalRow();
+
+        ArcRuntime baseline = new();
+        baseline.Width = 60; baseline.Height = 60;
+        baseline.SweepAngle = 270;
+        baseline.Thickness = 10;
+        baseline.Color = SKColors.Goldenrod;
+        row.Children.Add(baseline);
+
+        ArcRuntime soft = new();
+        soft.Width = 60; soft.Height = 60;
+        soft.SweepAngle = 270;
+        soft.Thickness = 10;
+        soft.Color = SKColors.Goldenrod;
+        soft.HasDropshadow = true;
+        soft.DropshadowOffsetX = 4;
+        soft.DropshadowOffsetY = 4;
+        soft.DropshadowBlurX = 4;
+        soft.DropshadowBlurY = 4;
+        row.Children.Add(soft);
+
+        ArcRuntime hard = new();
+        hard.Width = 60; hard.Height = 60;
+        hard.SweepAngle = 270;
+        hard.Thickness = 10;
+        hard.Color = SKColors.Goldenrod;
+        hard.HasDropshadow = true;
+        hard.DropshadowRed = 0; hard.DropshadowGreen = 0; hard.DropshadowBlue = 0; hard.DropshadowAlpha = 160;
+        hard.DropshadowOffsetX = 6;
+        hard.DropshadowOffsetY = 6;
+        hard.DropshadowBlurX = 0;
+        hard.DropshadowBlurY = 0;
+        row.Children.Add(hard);
+
+        ArcRuntime colored = new();
+        colored.Width = 60; colored.Height = 60;
+        colored.SweepAngle = 270;
+        colored.Thickness = 10;
+        colored.Color = SKColors.Goldenrod;
+        colored.HasDropshadow = true;
+        colored.DropshadowRed = 220; colored.DropshadowGreen = 40; colored.DropshadowBlue = 160; colored.DropshadowAlpha = 220;
+        colored.DropshadowOffsetX = 6;
+        colored.DropshadowOffsetY = 6;
+        colored.DropshadowBlurX = 6;
+        colored.DropshadowBlurY = 6;
+        row.Children.Add(colored);
+
+        ArcRuntime fadedBody = new();
+        fadedBody.Width = 60; fadedBody.Height = 60;
+        fadedBody.SweepAngle = 270;
+        fadedBody.Thickness = 10;
+        fadedBody.Color = new SKColor(218, 165, 32, 80);
+        fadedBody.HasDropshadow = true;
+        fadedBody.DropshadowOffsetX = 4;
+        fadedBody.DropshadowOffsetY = 4;
+        fadedBody.DropshadowBlurX = 4;
+        fadedBody.DropshadowBlurY = 4;
+        row.Children.Add(fadedBody);
+
+        return row;
+    }
+}

--- a/Samples/SilkNetGum/SilkNetGum/Screens/ArcsScreen.cs
+++ b/Samples/SilkNetGum/SilkNetGum/Screens/ArcsScreen.cs
@@ -90,8 +90,8 @@ internal class ArcsScreen : GraphicalUiElement
         soft.Thickness = 10;
         soft.Color = SKColors.Goldenrod;
         soft.HasDropshadow = true;
-        soft.DropshadowOffsetX = 4;
-        soft.DropshadowOffsetY = 4;
+        soft.DropshadowOffsetX = 14;
+        soft.DropshadowOffsetY = 14;
         soft.DropshadowBlurX = 4;
         soft.DropshadowBlurY = 4;
         row.Children.Add(soft);
@@ -103,8 +103,8 @@ internal class ArcsScreen : GraphicalUiElement
         hard.Color = SKColors.Goldenrod;
         hard.HasDropshadow = true;
         hard.DropshadowRed = 0; hard.DropshadowGreen = 0; hard.DropshadowBlue = 0; hard.DropshadowAlpha = 160;
-        hard.DropshadowOffsetX = 6;
-        hard.DropshadowOffsetY = 6;
+        hard.DropshadowOffsetX = 16;
+        hard.DropshadowOffsetY = 16;
         hard.DropshadowBlurX = 0;
         hard.DropshadowBlurY = 0;
         row.Children.Add(hard);
@@ -116,8 +116,8 @@ internal class ArcsScreen : GraphicalUiElement
         colored.Color = SKColors.Goldenrod;
         colored.HasDropshadow = true;
         colored.DropshadowRed = 220; colored.DropshadowGreen = 40; colored.DropshadowBlue = 160; colored.DropshadowAlpha = 220;
-        colored.DropshadowOffsetX = 6;
-        colored.DropshadowOffsetY = 6;
+        colored.DropshadowOffsetX = 16;
+        colored.DropshadowOffsetY = 16;
         colored.DropshadowBlurX = 6;
         colored.DropshadowBlurY = 6;
         row.Children.Add(colored);
@@ -128,8 +128,8 @@ internal class ArcsScreen : GraphicalUiElement
         fadedBody.Thickness = 10;
         fadedBody.Color = new SKColor(218, 165, 32, 80);
         fadedBody.HasDropshadow = true;
-        fadedBody.DropshadowOffsetX = 4;
-        fadedBody.DropshadowOffsetY = 4;
+        fadedBody.DropshadowOffsetX = 14;
+        fadedBody.DropshadowOffsetY = 14;
         fadedBody.DropshadowBlurX = 4;
         fadedBody.DropshadowBlurY = 4;
         row.Children.Add(fadedBody);

--- a/Samples/SilkNetGum/SilkNetGum/Screens/CirclesScreen.cs
+++ b/Samples/SilkNetGum/SilkNetGum/Screens/CirclesScreen.cs
@@ -381,6 +381,20 @@ internal class CirclesScreen : GraphicalUiElement
         colored.DropshadowBlurY = 6;
         row.Children.Add(colored);
 
+        // Issue #2851 visual acceptance: same soft-shadow config as the second cell, but with
+        // the body's alpha cut to 80. SkiaGum has always faded the shadow with the body (this
+        // is the canonical behavior); the cell exists here so the gallery matches the
+        // post-#2851 MonoGameGumShapes side cell-for-cell.
+        CircleRuntime fadedBody = new();
+        fadedBody.Radius = 28;
+        fadedBody.FillColor = new SKColor(218, 165, 32, 80);
+        fadedBody.HasDropshadow = true;
+        fadedBody.DropshadowOffsetX = 4;
+        fadedBody.DropshadowOffsetY = 4;
+        fadedBody.DropshadowBlurX = 4;
+        fadedBody.DropshadowBlurY = 4;
+        row.Children.Add(fadedBody);
+
         return row;
     }
 

--- a/Samples/SilkNetGum/SilkNetGum/Screens/CirclesScreen.cs
+++ b/Samples/SilkNetGum/SilkNetGum/Screens/CirclesScreen.cs
@@ -347,8 +347,8 @@ internal class CirclesScreen : GraphicalUiElement
         soft.Radius = 28;
         soft.FillColor = SKColors.Goldenrod;
         soft.HasDropshadow = true;
-        soft.DropshadowOffsetX = 4;
-        soft.DropshadowOffsetY = 4;
+        soft.DropshadowOffsetX = 14;
+        soft.DropshadowOffsetY = 14;
         soft.DropshadowBlurX = 4;
         soft.DropshadowBlurY = 4;
         row.Children.Add(soft);
@@ -361,8 +361,8 @@ internal class CirclesScreen : GraphicalUiElement
         hard.FillColor = SKColors.Goldenrod;
         hard.HasDropshadow = true;
         hard.DropshadowRed = 0; hard.DropshadowGreen = 0; hard.DropshadowBlue = 0; hard.DropshadowAlpha = 160;
-        hard.DropshadowOffsetX = 6;
-        hard.DropshadowOffsetY = 6;
+        hard.DropshadowOffsetX = 16;
+        hard.DropshadowOffsetY = 16;
         hard.DropshadowBlurX = 0;
         hard.DropshadowBlurY = 0;
         row.Children.Add(hard);
@@ -375,8 +375,8 @@ internal class CirclesScreen : GraphicalUiElement
         colored.FillColor = SKColors.Goldenrod;
         colored.HasDropshadow = true;
         colored.DropshadowRed = 220; colored.DropshadowGreen = 40; colored.DropshadowBlue = 160; colored.DropshadowAlpha = 220;
-        colored.DropshadowOffsetX = 6;
-        colored.DropshadowOffsetY = 6;
+        colored.DropshadowOffsetX = 16;
+        colored.DropshadowOffsetY = 16;
         colored.DropshadowBlurX = 6;
         colored.DropshadowBlurY = 6;
         row.Children.Add(colored);
@@ -389,8 +389,8 @@ internal class CirclesScreen : GraphicalUiElement
         fadedBody.Radius = 28;
         fadedBody.FillColor = new SKColor(218, 165, 32, 80);
         fadedBody.HasDropshadow = true;
-        fadedBody.DropshadowOffsetX = 4;
-        fadedBody.DropshadowOffsetY = 4;
+        fadedBody.DropshadowOffsetX = 14;
+        fadedBody.DropshadowOffsetY = 14;
         fadedBody.DropshadowBlurX = 4;
         fadedBody.DropshadowBlurY = 4;
         row.Children.Add(fadedBody);

--- a/Samples/SilkNetGum/SilkNetGum/Screens/RectanglesScreen.cs
+++ b/Samples/SilkNetGum/SilkNetGum/Screens/RectanglesScreen.cs
@@ -403,6 +403,17 @@ internal class RectanglesScreen : GraphicalUiElement
         colored.DropshadowBlurY = 6;
         row.Children.Add(colored);
 
+        // Issue #2851 visual acceptance — body alpha multiplies into the shadow alpha.
+        RectangleRuntime fadedBody = new();
+        fadedBody.Width = 60; fadedBody.Height = 50;
+        fadedBody.FillColor = new SKColor(218, 165, 32, 80);
+        fadedBody.HasDropshadow = true;
+        fadedBody.DropshadowOffsetX = 4;
+        fadedBody.DropshadowOffsetY = 4;
+        fadedBody.DropshadowBlurX = 4;
+        fadedBody.DropshadowBlurY = 4;
+        row.Children.Add(fadedBody);
+
         return row;
     }
 

--- a/Samples/SilkNetGum/SilkNetGum/Screens/RectanglesScreen.cs
+++ b/Samples/SilkNetGum/SilkNetGum/Screens/RectanglesScreen.cs
@@ -369,8 +369,8 @@ internal class RectanglesScreen : GraphicalUiElement
         soft.Width = 60; soft.Height = 50;
         soft.FillColor = SKColors.Goldenrod;
         soft.HasDropshadow = true;
-        soft.DropshadowOffsetX = 4;
-        soft.DropshadowOffsetY = 4;
+        soft.DropshadowOffsetX = 14;
+        soft.DropshadowOffsetY = 14;
         soft.DropshadowBlurX = 4;
         soft.DropshadowBlurY = 4;
         row.Children.Add(soft);
@@ -383,8 +383,8 @@ internal class RectanglesScreen : GraphicalUiElement
         hard.FillColor = SKColors.Goldenrod;
         hard.HasDropshadow = true;
         hard.DropshadowRed = 0; hard.DropshadowGreen = 0; hard.DropshadowBlue = 0; hard.DropshadowAlpha = 160;
-        hard.DropshadowOffsetX = 6;
-        hard.DropshadowOffsetY = 6;
+        hard.DropshadowOffsetX = 16;
+        hard.DropshadowOffsetY = 16;
         hard.DropshadowBlurX = 0;
         hard.DropshadowBlurY = 0;
         row.Children.Add(hard);
@@ -397,8 +397,8 @@ internal class RectanglesScreen : GraphicalUiElement
         colored.FillColor = SKColors.Goldenrod;
         colored.HasDropshadow = true;
         colored.DropshadowRed = 220; colored.DropshadowGreen = 40; colored.DropshadowBlue = 160; colored.DropshadowAlpha = 220;
-        colored.DropshadowOffsetX = 6;
-        colored.DropshadowOffsetY = 6;
+        colored.DropshadowOffsetX = 16;
+        colored.DropshadowOffsetY = 16;
         colored.DropshadowBlurX = 6;
         colored.DropshadowBlurY = 6;
         row.Children.Add(colored);
@@ -408,8 +408,8 @@ internal class RectanglesScreen : GraphicalUiElement
         fadedBody.Width = 60; fadedBody.Height = 50;
         fadedBody.FillColor = new SKColor(218, 165, 32, 80);
         fadedBody.HasDropshadow = true;
-        fadedBody.DropshadowOffsetX = 4;
-        fadedBody.DropshadowOffsetY = 4;
+        fadedBody.DropshadowOffsetX = 14;
+        fadedBody.DropshadowOffsetY = 14;
         fadedBody.DropshadowBlurX = 4;
         fadedBody.DropshadowBlurY = 4;
         row.Children.Add(fadedBody);

--- a/Samples/raylib/Screens/CirclesScreen.cs
+++ b/Samples/raylib/Screens/CirclesScreen.cs
@@ -436,6 +436,20 @@ internal class CirclesScreen : FrameworkElement
         colored.DropshadowBlurY = 6;
         row.Children.Add(colored);
 
+        // Issue #2851 visual acceptance: same soft-shadow config as the second cell, but with
+        // the body's alpha cut to 80. The shadow must fade alongside the body — matches Skia
+        // (and therefore the Gum tool/viewport). Pre-fix the raylib LineCircle renderable
+        // emitted DropshadowColor straight through and left an opaque shadow ghost behind.
+        CircleRuntime fadedBody = new();
+        fadedBody.Radius = 28;
+        fadedBody.FillColor = new Color((byte)218, (byte)165, (byte)32, (byte)80);
+        fadedBody.HasDropshadow = true;
+        fadedBody.DropshadowOffsetX = 4;
+        fadedBody.DropshadowOffsetY = 4;
+        fadedBody.DropshadowBlurX = 4;
+        fadedBody.DropshadowBlurY = 4;
+        row.Children.Add(fadedBody);
+
         return row;
     }
 }

--- a/Samples/raylib/Screens/CirclesScreen.cs
+++ b/Samples/raylib/Screens/CirclesScreen.cs
@@ -404,8 +404,8 @@ internal class CirclesScreen : FrameworkElement
         soft.Radius = 28;
         soft.FillColor = goldenrod;
         soft.HasDropshadow = true;
-        soft.DropshadowOffsetX = 4;
-        soft.DropshadowOffsetY = 4;
+        soft.DropshadowOffsetX = 14;
+        soft.DropshadowOffsetY = 14;
         soft.DropshadowBlurX = 4;
         soft.DropshadowBlurY = 4;
         row.Children.Add(soft);
@@ -417,8 +417,8 @@ internal class CirclesScreen : FrameworkElement
         hard.FillColor = goldenrod;
         hard.HasDropshadow = true;
         hard.DropshadowRed = 0; hard.DropshadowGreen = 0; hard.DropshadowBlue = 0; hard.DropshadowAlpha = 160;
-        hard.DropshadowOffsetX = 6;
-        hard.DropshadowOffsetY = 6;
+        hard.DropshadowOffsetX = 16;
+        hard.DropshadowOffsetY = 16;
         hard.DropshadowBlurX = 0;
         hard.DropshadowBlurY = 0;
         row.Children.Add(hard);
@@ -430,8 +430,8 @@ internal class CirclesScreen : FrameworkElement
         colored.FillColor = goldenrod;
         colored.HasDropshadow = true;
         colored.DropshadowRed = 220; colored.DropshadowGreen = 40; colored.DropshadowBlue = 160; colored.DropshadowAlpha = 220;
-        colored.DropshadowOffsetX = 6;
-        colored.DropshadowOffsetY = 6;
+        colored.DropshadowOffsetX = 16;
+        colored.DropshadowOffsetY = 16;
         colored.DropshadowBlurX = 6;
         colored.DropshadowBlurY = 6;
         row.Children.Add(colored);
@@ -444,8 +444,8 @@ internal class CirclesScreen : FrameworkElement
         fadedBody.Radius = 28;
         fadedBody.FillColor = new Color((byte)218, (byte)165, (byte)32, (byte)80);
         fadedBody.HasDropshadow = true;
-        fadedBody.DropshadowOffsetX = 4;
-        fadedBody.DropshadowOffsetY = 4;
+        fadedBody.DropshadowOffsetX = 14;
+        fadedBody.DropshadowOffsetY = 14;
         fadedBody.DropshadowBlurX = 4;
         fadedBody.DropshadowBlurY = 4;
         row.Children.Add(fadedBody);

--- a/Samples/raylib/Screens/RectanglesScreen.cs
+++ b/Samples/raylib/Screens/RectanglesScreen.cs
@@ -52,8 +52,6 @@ internal class RectanglesScreen : FrameworkElement
         left.Children.Add(BuildSection("Gradients (linear / radial / diagonal / centered)", BuildGradientRow()));
 
         right.Children.Add(BuildSection("Dropshadow (off / soft / hard offset / colored) — raylib approximates the blur via concentric rectangles (#2757)", BuildDropshadowRow()));
-        right.Children.Add(BuildSection("Diagnostic A (#2851): opaque body, hard-edged shadow, DropshadowAlpha sweep 32/64/96/128/160/192/255 — REFERENCE", BuildDiagnosticShadowAlphaSweepRow()));
-        right.Children.Add(BuildSection("Diagnostic B (#2851): hard-edged shadow at alpha 255, FillColor.A sweep 32/64/96/128/160/192/255 — should match row A above if body→shadow multiply works", BuildDiagnosticBodyAlphaSweepRow()));
         right.Children.Add(BuildSection("Dashed strokes (solid / 6/4 / 2/2 dotted / long-dash) — raylib walks the perimeter, one DrawLineEx per dash (#2757)", BuildDashedStrokeRow()));
         right.Children.Add(BuildSection("FillColor + StrokeColor on the same instance — both layers render simultaneously (#2757)", BuildBothColorsRow()));
         right.Children.Add(BuildSection("Inscribed in a 64x64 frame — stroke must stay inside the gray rectangle's bounds at every StrokeWidth (#2757)", BuildInscribedRow()));
@@ -458,55 +456,4 @@ internal class RectanglesScreen : FrameworkElement
         return row;
     }
 
-    // Diagnostic A for #2851 — reference row. Opaque goldenrod body, hard-edged (blur=0)
-    // black shadow at varying DropshadowAlpha. The shadow alpha is the dependent variable;
-    // body alpha stays 255 so nothing multiplies. Linear math = visible alpha steps.
-    static ContainerRuntime BuildDiagnosticShadowAlphaSweepRow()
-    {
-        ContainerRuntime row = BuildHorizontalRow();
-        Color goldenrod = new Color((byte)218, (byte)165, (byte)32, (byte)255);
-
-        foreach (byte shadowAlpha in new byte[] { 32, 64, 96, 128, 160, 192, 255 })
-        {
-            RectangleRuntime rect = new();
-            rect.Width = 60; rect.Height = 50;
-            rect.FillColor = goldenrod;
-            rect.HasDropshadow = true;
-            rect.DropshadowRed = 0; rect.DropshadowGreen = 0; rect.DropshadowBlue = 0;
-            rect.DropshadowAlpha = shadowAlpha;
-            rect.DropshadowOffsetX = 15;
-            rect.DropshadowOffsetY = 15;
-            rect.DropshadowBlurX = 0;
-            rect.DropshadowBlurY = 0;
-            row.Children.Add(rect);
-        }
-
-        return row;
-    }
-
-    // Diagnostic B for #2851 — the test. Body FillColor.A varies, DropshadowAlpha pinned at
-    // 255. If the body→shadow alpha multiply works, the rendered shadow alpha in cell N
-    // should equal cell N of Diagnostic A (effective = 255 * bodyA / 255 = bodyA). Mismatch
-    // = the multiply is broken or the body alpha doesn't reach the shadow path at all.
-    static ContainerRuntime BuildDiagnosticBodyAlphaSweepRow()
-    {
-        ContainerRuntime row = BuildHorizontalRow();
-
-        foreach (byte bodyAlpha in new byte[] { 32, 64, 96, 128, 160, 192, 255 })
-        {
-            RectangleRuntime rect = new();
-            rect.Width = 60; rect.Height = 50;
-            rect.FillColor = new Color((byte)218, (byte)165, (byte)32, bodyAlpha);
-            rect.HasDropshadow = true;
-            rect.DropshadowRed = 0; rect.DropshadowGreen = 0; rect.DropshadowBlue = 0;
-            rect.DropshadowAlpha = 255;
-            rect.DropshadowOffsetX = 15;
-            rect.DropshadowOffsetY = 15;
-            rect.DropshadowBlurX = 0;
-            rect.DropshadowBlurY = 0;
-            row.Children.Add(rect);
-        }
-
-        return row;
-    }
 }

--- a/Samples/raylib/Screens/RectanglesScreen.cs
+++ b/Samples/raylib/Screens/RectanglesScreen.cs
@@ -52,7 +52,8 @@ internal class RectanglesScreen : FrameworkElement
         left.Children.Add(BuildSection("Gradients (linear / radial / diagonal / centered)", BuildGradientRow()));
 
         right.Children.Add(BuildSection("Dropshadow (off / soft / hard offset / colored) — raylib approximates the blur via concentric rectangles (#2757)", BuildDropshadowRow()));
-        right.Children.Add(BuildSection("Diagnostic (#2851): opaque body, hard-edged shadow, DropshadowAlpha sweep 32/64/96/128/160/192/255", BuildDiagnosticAlphaRow()));
+        right.Children.Add(BuildSection("Diagnostic A (#2851): opaque body, hard-edged shadow, DropshadowAlpha sweep 32/64/96/128/160/192/255 — REFERENCE", BuildDiagnosticShadowAlphaSweepRow()));
+        right.Children.Add(BuildSection("Diagnostic B (#2851): hard-edged shadow at alpha 255, FillColor.A sweep 32/64/96/128/160/192/255 — should match row A above if body→shadow multiply works", BuildDiagnosticBodyAlphaSweepRow()));
         right.Children.Add(BuildSection("Dashed strokes (solid / 6/4 / 2/2 dotted / long-dash) — raylib walks the perimeter, one DrawLineEx per dash (#2757)", BuildDashedStrokeRow()));
         right.Children.Add(BuildSection("FillColor + StrokeColor on the same instance — both layers render simultaneously (#2757)", BuildBothColorsRow()));
         right.Children.Add(BuildSection("Inscribed in a 64x64 frame — stroke must stay inside the gray rectangle's bounds at every StrokeWidth (#2757)", BuildInscribedRow()));
@@ -443,12 +444,10 @@ internal class RectanglesScreen : FrameworkElement
         return row;
     }
 
-    // Diagnostic for #2851: opaque goldenrod body with a hard-edged (blur=0) black dropshadow.
-    // DropshadowAlpha sweeps 32 → 255 so the band-stacking math is probed directly. With blur=0
-    // the renderable should produce a single sharp black rectangle offset down-right; visible
-    // alpha steps between cells = math is linear. If low-alpha cells already look near-opaque,
-    // the band approximation is overshooting.
-    static ContainerRuntime BuildDiagnosticAlphaRow()
+    // Diagnostic A for #2851 — reference row. Opaque goldenrod body, hard-edged (blur=0)
+    // black shadow at varying DropshadowAlpha. The shadow alpha is the dependent variable;
+    // body alpha stays 255 so nothing multiplies. Linear math = visible alpha steps.
+    static ContainerRuntime BuildDiagnosticShadowAlphaSweepRow()
     {
         ContainerRuntime row = BuildHorizontalRow();
         Color goldenrod = new Color((byte)218, (byte)165, (byte)32, (byte)255);
@@ -461,6 +460,32 @@ internal class RectanglesScreen : FrameworkElement
             rect.HasDropshadow = true;
             rect.DropshadowRed = 0; rect.DropshadowGreen = 0; rect.DropshadowBlue = 0;
             rect.DropshadowAlpha = shadowAlpha;
+            rect.DropshadowOffsetX = 15;
+            rect.DropshadowOffsetY = 15;
+            rect.DropshadowBlurX = 0;
+            rect.DropshadowBlurY = 0;
+            row.Children.Add(rect);
+        }
+
+        return row;
+    }
+
+    // Diagnostic B for #2851 — the test. Body FillColor.A varies, DropshadowAlpha pinned at
+    // 255. If the body→shadow alpha multiply works, the rendered shadow alpha in cell N
+    // should equal cell N of Diagnostic A (effective = 255 * bodyA / 255 = bodyA). Mismatch
+    // = the multiply is broken or the body alpha doesn't reach the shadow path at all.
+    static ContainerRuntime BuildDiagnosticBodyAlphaSweepRow()
+    {
+        ContainerRuntime row = BuildHorizontalRow();
+
+        foreach (byte bodyAlpha in new byte[] { 32, 64, 96, 128, 160, 192, 255 })
+        {
+            RectangleRuntime rect = new();
+            rect.Width = 60; rect.Height = 50;
+            rect.FillColor = new Color((byte)218, (byte)165, (byte)32, bodyAlpha);
+            rect.HasDropshadow = true;
+            rect.DropshadowRed = 0; rect.DropshadowGreen = 0; rect.DropshadowBlue = 0;
+            rect.DropshadowAlpha = 255;
             rect.DropshadowOffsetX = 15;
             rect.DropshadowOffsetY = 15;
             rect.DropshadowBlurX = 0;

--- a/Samples/raylib/Screens/RectanglesScreen.cs
+++ b/Samples/raylib/Screens/RectanglesScreen.cs
@@ -400,8 +400,8 @@ internal class RectanglesScreen : FrameworkElement
         soft.Width = 60; soft.Height = 50;
         soft.FillColor = goldenrod;
         soft.HasDropshadow = true;
-        soft.DropshadowOffsetX = 4;
-        soft.DropshadowOffsetY = 4;
+        soft.DropshadowOffsetX = 14;
+        soft.DropshadowOffsetY = 14;
         soft.DropshadowBlurX = 4;
         soft.DropshadowBlurY = 4;
         row.Children.Add(soft);
@@ -411,8 +411,8 @@ internal class RectanglesScreen : FrameworkElement
         hard.FillColor = goldenrod;
         hard.HasDropshadow = true;
         hard.DropshadowRed = 0; hard.DropshadowGreen = 0; hard.DropshadowBlue = 0; hard.DropshadowAlpha = 160;
-        hard.DropshadowOffsetX = 6;
-        hard.DropshadowOffsetY = 6;
+        hard.DropshadowOffsetX = 16;
+        hard.DropshadowOffsetY = 16;
         hard.DropshadowBlurX = 0;
         hard.DropshadowBlurY = 0;
         row.Children.Add(hard);
@@ -422,8 +422,8 @@ internal class RectanglesScreen : FrameworkElement
         colored.FillColor = goldenrod;
         colored.HasDropshadow = true;
         colored.DropshadowRed = 220; colored.DropshadowGreen = 40; colored.DropshadowBlue = 160; colored.DropshadowAlpha = 220;
-        colored.DropshadowOffsetX = 6;
-        colored.DropshadowOffsetY = 6;
+        colored.DropshadowOffsetX = 16;
+        colored.DropshadowOffsetY = 16;
         colored.DropshadowBlurX = 6;
         colored.DropshadowBlurY = 6;
         row.Children.Add(colored);
@@ -433,8 +433,8 @@ internal class RectanglesScreen : FrameworkElement
         fadedBody.Width = 60; fadedBody.Height = 50;
         fadedBody.FillColor = new Color((byte)218, (byte)165, (byte)32, (byte)80);
         fadedBody.HasDropshadow = true;
-        fadedBody.DropshadowOffsetX = 4;
-        fadedBody.DropshadowOffsetY = 4;
+        fadedBody.DropshadowOffsetX = 14;
+        fadedBody.DropshadowOffsetY = 14;
         fadedBody.DropshadowBlurX = 4;
         fadedBody.DropshadowBlurY = 4;
         row.Children.Add(fadedBody);

--- a/Samples/raylib/Screens/RectanglesScreen.cs
+++ b/Samples/raylib/Screens/RectanglesScreen.cs
@@ -52,6 +52,7 @@ internal class RectanglesScreen : FrameworkElement
         left.Children.Add(BuildSection("Gradients (linear / radial / diagonal / centered)", BuildGradientRow()));
 
         right.Children.Add(BuildSection("Dropshadow (off / soft / hard offset / colored) — raylib approximates the blur via concentric rectangles (#2757)", BuildDropshadowRow()));
+        right.Children.Add(BuildSection("Diagnostic (#2851): opaque body, hard-edged shadow, DropshadowAlpha sweep 32/64/96/128/160/192/255", BuildDiagnosticAlphaRow()));
         right.Children.Add(BuildSection("Dashed strokes (solid / 6/4 / 2/2 dotted / long-dash) — raylib walks the perimeter, one DrawLineEx per dash (#2757)", BuildDashedStrokeRow()));
         right.Children.Add(BuildSection("FillColor + StrokeColor on the same instance — both layers render simultaneously (#2757)", BuildBothColorsRow()));
         right.Children.Add(BuildSection("Inscribed in a 64x64 frame — stroke must stay inside the gray rectangle's bounds at every StrokeWidth (#2757)", BuildInscribedRow()));
@@ -438,6 +439,34 @@ internal class RectanglesScreen : FrameworkElement
         fadedBody.DropshadowBlurX = 4;
         fadedBody.DropshadowBlurY = 4;
         row.Children.Add(fadedBody);
+
+        return row;
+    }
+
+    // Diagnostic for #2851: opaque goldenrod body with a hard-edged (blur=0) black dropshadow.
+    // DropshadowAlpha sweeps 32 → 255 so the band-stacking math is probed directly. With blur=0
+    // the renderable should produce a single sharp black rectangle offset down-right; visible
+    // alpha steps between cells = math is linear. If low-alpha cells already look near-opaque,
+    // the band approximation is overshooting.
+    static ContainerRuntime BuildDiagnosticAlphaRow()
+    {
+        ContainerRuntime row = BuildHorizontalRow();
+        Color goldenrod = new Color((byte)218, (byte)165, (byte)32, (byte)255);
+
+        foreach (byte shadowAlpha in new byte[] { 32, 64, 96, 128, 160, 192, 255 })
+        {
+            RectangleRuntime rect = new();
+            rect.Width = 60; rect.Height = 50;
+            rect.FillColor = goldenrod;
+            rect.HasDropshadow = true;
+            rect.DropshadowRed = 0; rect.DropshadowGreen = 0; rect.DropshadowBlue = 0;
+            rect.DropshadowAlpha = shadowAlpha;
+            rect.DropshadowOffsetX = 15;
+            rect.DropshadowOffsetY = 15;
+            rect.DropshadowBlurX = 0;
+            rect.DropshadowBlurY = 0;
+            row.Children.Add(rect);
+        }
 
         return row;
     }

--- a/Samples/raylib/Screens/RectanglesScreen.cs
+++ b/Samples/raylib/Screens/RectanglesScreen.cs
@@ -433,13 +433,27 @@ internal class RectanglesScreen : FrameworkElement
         // Issue #2851 visual acceptance — body alpha multiplies into the shadow alpha.
         RectangleRuntime fadedBody = new();
         fadedBody.Width = 60; fadedBody.Height = 50;
-        fadedBody.FillColor = new Color((byte)218, (byte)165, (byte)32, (byte)80);
+        // This seems wrong:
+        //fadedBody.FillColor = new Color((byte)218, (byte)165, (byte)32, (byte)80);
+        fadedBody.FillColor = new Color((byte)218, (byte)165, (byte)32, (byte)32);
         fadedBody.HasDropshadow = true;
         fadedBody.DropshadowOffsetX = 14;
         fadedBody.DropshadowOffsetY = 14;
         fadedBody.DropshadowBlurX = 4;
         fadedBody.DropshadowBlurY = 4;
         row.Children.Add(fadedBody);
+
+        RectangleRuntime shadowTest = new();
+        shadowTest.Width = 60; shadowTest.Height = 50;
+        // This seems wrong:
+        //fadedBody.FillColor = new Color((byte)218, (byte)165, (byte)32, (byte)80);
+        shadowTest.FillColor = new Color((byte)218, (byte)165, (byte)32, (byte)32);
+        shadowTest.HasDropshadow = true;
+        shadowTest.DropshadowOffsetX = 14;
+        shadowTest.DropshadowOffsetY = 14;
+        shadowTest.DropshadowBlurX = 0;
+        shadowTest.DropshadowBlurY = 0;
+        row.Children.Add(shadowTest);
 
         return row;
     }

--- a/Samples/raylib/Screens/RectanglesScreen.cs
+++ b/Samples/raylib/Screens/RectanglesScreen.cs
@@ -428,6 +428,17 @@ internal class RectanglesScreen : FrameworkElement
         colored.DropshadowBlurY = 6;
         row.Children.Add(colored);
 
+        // Issue #2851 visual acceptance — body alpha multiplies into the shadow alpha.
+        RectangleRuntime fadedBody = new();
+        fadedBody.Width = 60; fadedBody.Height = 50;
+        fadedBody.FillColor = new Color((byte)218, (byte)165, (byte)32, (byte)80);
+        fadedBody.HasDropshadow = true;
+        fadedBody.DropshadowOffsetX = 4;
+        fadedBody.DropshadowOffsetY = 4;
+        fadedBody.DropshadowBlurX = 4;
+        fadedBody.DropshadowBlurY = 4;
+        row.Children.Add(fadedBody);
+
         return row;
     }
 }

--- a/Tests/MonoGameGum.Shapes.Tests/CircleRenderableTests.cs
+++ b/Tests/MonoGameGum.Shapes.Tests/CircleRenderableTests.cs
@@ -1,3 +1,4 @@
+using Microsoft.Xna.Framework;
 using MonoGameAndGum.Renderables;
 using Shouldly;
 
@@ -43,5 +44,63 @@ public class CircleRenderableTests
 
         sut.Width.ShouldBe(60f);
         sut.Height.ShouldBe(60f);
+    }
+
+    // Issue #2851 — Apos.Shapes previously drew dropshadows at their own DropshadowColor
+    // alpha while ignoring the body's alpha, so a shape fading to transparent left an opaque
+    // shadow ghost behind. SkiaGum (the tool/viewport) multiplies shadow alpha by body alpha,
+    // and the two backends must agree. EffectiveDropshadowColor is the multiplied value the
+    // Render path now forwards to Apos.
+
+    [Fact]
+    public void EffectiveDropshadowColor_BodyFullyOpaque_PreservesShadowAlpha()
+    {
+        Circle sut = new()
+        {
+            Color = new Color(10, 20, 30, 255),
+            DropshadowColor = new Color(100, 110, 120, 200),
+        };
+
+        sut.EffectiveDropshadowColor.ShouldBe(new Color(100, 110, 120, 200));
+    }
+
+    [Fact]
+    public void EffectiveDropshadowColor_BodyHalfTransparent_HalvesShadowAlpha()
+    {
+        Circle sut = new()
+        {
+            Color = new Color(10, 20, 30, 128),
+            DropshadowColor = new Color(100, 110, 120, 200),
+        };
+
+        // 200 * 128 / 255 = 100 (integer truncation matches the Render path).
+        sut.EffectiveDropshadowColor.ShouldBe(new Color(100, 110, 120, 100));
+    }
+
+    [Fact]
+    public void EffectiveDropshadowColor_BodyFullyTransparent_ZeroesShadowAlpha()
+    {
+        Circle sut = new()
+        {
+            Color = new Color(10, 20, 30, 0),
+            DropshadowColor = new Color(100, 110, 120, 255),
+        };
+
+        sut.EffectiveDropshadowColor.A.ShouldBe((byte)0);
+    }
+
+    [Fact]
+    public void EffectiveDropshadowColor_PreservesShadowRgb()
+    {
+        Circle sut = new()
+        {
+            Color = new Color(10, 20, 30, 64),
+            DropshadowColor = new Color(100, 110, 120, 200),
+        };
+
+        Color effective = sut.EffectiveDropshadowColor;
+        effective.R.ShouldBe((byte)100);
+        effective.G.ShouldBe((byte)110);
+        effective.B.ShouldBe((byte)120);
     }
 }


### PR DESCRIPTION
## Summary
- Apos.Shapes shape renderables (`Circle`, `RoundedRectangle`, `Arc`, `Line`) were passing `DropshadowColor` straight through to their inner draw call as `forcedColor`, which bypasses the body's `Color.A`. SkiaGum (and therefore the Gum tool/viewport) implements the dropshadow as an image filter on the same paint, so the body's alpha already multiplies into the shadow. The two renderers disagreed: fading an Apos.Shapes shape to transparent left an opaque shadow ghost behind, while in the tool the shadow faded with the body.
- Decided per the issue's "weak lean": **multiply** is canonical (fade-out should fade the whole effect; designers who want an opaque shadow under a translucent body can encode it with explicit values).
- Added `EffectiveDropshadowColor` on `RenderableShapeBase` (RGB preserved, alpha scaled by `Color.A / 255`) and routed all four shape `Render` paths through it.

Closes #2851

## Test plan
- [x] Added 4 unit tests in `Tests/MonoGameGum.Shapes.Tests/CircleRenderableTests.cs` covering: body fully opaque (shadow alpha unchanged), body half-transparent (shadow alpha halved), body fully transparent (shadow alpha zero), and RGB preservation.
- [x] `dotnet test Tests/MonoGameGum.Shapes.Tests/MonoGameGum.Shapes.Tests.csproj` — 58/58 pass.
- [x] Visual: run the MonoGame sample with a `ColoredCircleRuntime` whose alpha animates to 0 and confirm the shadow now fades alongside the body, matching the tool's preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)