### PR TITLE
#2860: Emit 'new' modifier on RegisterRuntimeType for derived components

### DIFF
--- a/Tests/Gum.ProjectServices.Tests/CodeGeneratorRegisterRuntimeTypeTests.cs
+++ b/Tests/Gum.ProjectServices.Tests/CodeGeneratorRegisterRuntimeTypeTests.cs
@@ -101,6 +101,55 @@ public class CodeGeneratorRegisterRuntimeTypeTests : BaseTestClass
     }
 
     [Fact]
+    public void DerivedComponent_EmitsNewModifierOnRegisterRuntimeType()
+    {
+        // #2860: a component derived from another component must emit `public static new void RegisterRuntimeType()`
+        // to avoid CS0108 (hiding inherited member without `new`).
+        GumProjectSave project = Project;
+        ComponentSave baseComponent = CreateComponent("MyBase", "Container");
+        ComponentSave derivedComponent = CreateComponent("MyDerived", "MyBase");
+        project.Components.Add(baseComponent);
+        project.Components.Add(derivedComponent);
+        ObjectFinder.Self.GumProjectSave = project;
+
+        try
+        {
+            string code = CreateCodeGenerator().GetGeneratedCodeForElement(
+                derivedComponent, elementSettings: null!, CreateForms());
+
+            code.ShouldContain("public static new void RegisterRuntimeType()");
+        }
+        finally
+        {
+            ObjectFinder.Self.GumProjectSave = null;
+        }
+    }
+
+    [Fact]
+    public void StandardBaseComponent_DoesNotEmitNewModifierOnRegisterRuntimeType()
+    {
+        // #2860: a component whose BaseType is a standard type (e.g. Container) has no
+        // inherited RegisterRuntimeType to hide, so `new` must not be emitted.
+        GumProjectSave project = Project;
+        ComponentSave panel = CreateComponent("Panel", "Container");
+        project.Components.Add(panel);
+        ObjectFinder.Self.GumProjectSave = project;
+
+        try
+        {
+            string code = CreateCodeGenerator().GetGeneratedCodeForElement(
+                panel, elementSettings: null!, CreateForms());
+
+            code.ShouldContain("public static void RegisterRuntimeType()");
+            code.ShouldNotContain("public static new void RegisterRuntimeType()");
+        }
+        finally
+        {
+            ObjectFinder.Self.GumProjectSave = null;
+        }
+    }
+
+    [Fact]
     public void ContainerInheritance_StillEmitsContainerRuntime()
     {
         GumProjectSave project = Project;

--- a/Tools/Gum.ProjectServices/CodeGeneration/CodeGenerator.cs
+++ b/Tools/Gum.ProjectServices/CodeGeneration/CodeGenerator.cs
@@ -1513,7 +1513,9 @@ public class CodeGenerator
             var builder = context.StringBuilder;
 
             builder.AppendLine(context.Tabs + "[System.Runtime.CompilerServices.ModuleInitializer]");
-            builder.AppendLine(context.Tabs + "public static void RegisterRuntimeType()");
+            var registerRuntimeTypeBase = ObjectFinder.Self.GetElementSave(context.Element.BaseType);
+            var registerRuntimeTypeNewModifier = registerRuntimeTypeBase is ComponentSave ? "new " : "";
+            builder.AppendLine(context.Tabs + $"public static {registerRuntimeTypeNewModifier}void RegisterRuntimeType()");
             builder.AppendLine(context.Tabs + "{");
             context.TabCount++;
 
@@ -1612,7 +1614,9 @@ public class CodeGenerator
             var builder = context.StringBuilder;
 
             builder.AppendLine(context.Tabs + "[System.Runtime.CompilerServices.ModuleInitializer]");
-            builder.AppendLine(context.Tabs + "public static void RegisterRuntimeType()");
+            var registerRuntimeTypeBase = ObjectFinder.Self.GetElementSave(context.Element.BaseType);
+            var registerRuntimeTypeNewModifier = registerRuntimeTypeBase is ComponentSave ? "new " : "";
+            builder.AppendLine(context.Tabs + $"public static {registerRuntimeTypeNewModifier}void RegisterRuntimeType()");
             builder.AppendLine(context.Tabs + "{");
             context.TabCount++;
 


### PR DESCRIPTION
## Summary
- Generated `RegisterRuntimeType()` now emits `public static new void RegisterRuntimeType()` when the component's `BaseType` resolves to another `ComponentSave`, suppressing CS0108 hiding warnings.
- Applies to both `MonoGameForms` and `MonoGame` output libraries (both code paths in `CodeGenerator.RegisterRuntimeType`).

## Test plan
- [x] New `DerivedComponent_EmitsNewModifierOnRegisterRuntimeType` test passes
- [x] New `StandardBaseComponent_DoesNotEmitNewModifierOnRegisterRuntimeType` test passes
- [x] Existing `Gum.ProjectServices.Tests` suite still green (239 passed, 2 skipped)

Closes #2860

🤖 Generated with [Claude Code](https://claude.com/claude-code)