### PR TITLE
#2862: Normalize -0 to +0 in dock Width/Height computations

### DIFF
--- a/Gum/Plugins/InternalPlugins/AlignmentButtons/ViewModels/AlignmentViewModel.cs
+++ b/Gum/Plugins/InternalPlugins/AlignmentButtons/ViewModels/AlignmentViewModel.cs
@@ -55,6 +55,11 @@ public class AlignmentViewModel : ViewModel
         DockMarginText = "0";
     }
 
+    // When DockMargin is 0, the expression `NormalizeNegativeZero(-DockMargin * 2)` evaluates to IEEE 754
+    // negative zero, which serializes as "-0" in the project file. Route every
+    // dock-size computation through this helper so future handlers can't reintroduce it.
+    internal static float NormalizeNegativeZero(float value) => value == 0f ? 0f : value;
+
     #region Anchor Actions
 
     public void TopLeftButton_Click()
@@ -246,7 +251,7 @@ public class AlignmentViewModel : ViewModel
             _commonControlLogic.SetXValues(global::RenderingLibrary.Graphics.HorizontalAlignment.Center, PositionUnitType.PixelsFromCenterX);
             _commonControlLogic.SetYValues(global::RenderingLibrary.Graphics.VerticalAlignment.Top, PositionUnitType.PixelsFromTop, DockMargin);
 
-            _commonControlLogic.SetAndCallReact("Width", -DockMargin * 2, "float");
+            _commonControlLogic.SetAndCallReact("Width", NormalizeNegativeZero(-DockMargin * 2), "float");
             _commonControlLogic.SetAndCallReact("WidthUnits", DimensionUnitType.RelativeToParent, typeof(DimensionUnitType).Name);
 
 
@@ -277,7 +282,7 @@ public class AlignmentViewModel : ViewModel
             _commonControlLogic.SetXValues(global::RenderingLibrary.Graphics.HorizontalAlignment.Left, PositionUnitType.PixelsFromLeft, DockMargin);
             _commonControlLogic.SetYValues(global::RenderingLibrary.Graphics.VerticalAlignment.Center, PositionUnitType.PixelsFromCenterY);
 
-            _commonControlLogic.SetAndCallReact("Height", -DockMargin * 2, "float");
+            _commonControlLogic.SetAndCallReact("Height", NormalizeNegativeZero(-DockMargin * 2), "float");
             _commonControlLogic.SetAndCallReact("HeightUnits", DimensionUnitType.RelativeToParent, typeof(DimensionUnitType).Name);
 
             _commonControlLogic.RefreshAndSave();
@@ -294,10 +299,10 @@ public class AlignmentViewModel : ViewModel
             _commonControlLogic.SetXValues(global::RenderingLibrary.Graphics.HorizontalAlignment.Center, PositionUnitType.PixelsFromCenterX);
             _commonControlLogic.SetYValues(global::RenderingLibrary.Graphics.VerticalAlignment.Center, PositionUnitType.PixelsFromCenterY);
 
-            _commonControlLogic.SetAndCallReact("Width", -DockMargin * 2, "float");
+            _commonControlLogic.SetAndCallReact("Width", NormalizeNegativeZero(-DockMargin * 2), "float");
             _commonControlLogic.SetAndCallReact("WidthUnits", DimensionUnitType.RelativeToParent, typeof(DimensionUnitType).Name);
 
-            _commonControlLogic.SetAndCallReact("Height", -DockMargin * 2, "float");
+            _commonControlLogic.SetAndCallReact("Height", NormalizeNegativeZero(-DockMargin * 2), "float");
             _commonControlLogic.SetAndCallReact("HeightUnits", DimensionUnitType.RelativeToParent, typeof(DimensionUnitType).Name);
 
             _commonControlLogic.RefreshAndSave();
@@ -314,7 +319,7 @@ public class AlignmentViewModel : ViewModel
             _commonControlLogic.SetXValues(global::RenderingLibrary.Graphics.HorizontalAlignment.Right, PositionUnitType.PixelsFromRight, -DockMargin);
             _commonControlLogic.SetYValues(global::RenderingLibrary.Graphics.VerticalAlignment.Center, PositionUnitType.PixelsFromCenterY);
 
-            _commonControlLogic.SetAndCallReact("Height", -DockMargin * 2, "float");
+            _commonControlLogic.SetAndCallReact("Height", NormalizeNegativeZero(-DockMargin * 2), "float");
             _commonControlLogic.SetAndCallReact("HeightUnits", DimensionUnitType.RelativeToParent, typeof(DimensionUnitType).Name);
 
             _commonControlLogic.RefreshAndSave();
@@ -330,7 +335,7 @@ public class AlignmentViewModel : ViewModel
             _commonControlLogic.SetXValues(global::RenderingLibrary.Graphics.HorizontalAlignment.Center, PositionUnitType.PixelsFromCenterX);
             _commonControlLogic.SetYValues(global::RenderingLibrary.Graphics.VerticalAlignment.Bottom, PositionUnitType.PixelsFromBottom, -DockMargin);
 
-            _commonControlLogic.SetAndCallReact("Width", -DockMargin * 2, "float");
+            _commonControlLogic.SetAndCallReact("Width", NormalizeNegativeZero(-DockMargin * 2), "float");
             _commonControlLogic.SetAndCallReact("WidthUnits", DimensionUnitType.RelativeToParent, typeof(DimensionUnitType).Name);
 
             _commonControlLogic.RefreshAndSave();
@@ -346,7 +351,7 @@ public class AlignmentViewModel : ViewModel
 
             _commonControlLogic.SetYValues(global::RenderingLibrary.Graphics.VerticalAlignment.Center, PositionUnitType.PixelsFromCenterY);
 
-            _commonControlLogic.SetAndCallReact("Height", -DockMargin * 2, "float");
+            _commonControlLogic.SetAndCallReact("Height", NormalizeNegativeZero(-DockMargin * 2), "float");
             _commonControlLogic.SetAndCallReact("HeightUnits", DimensionUnitType.RelativeToParent, typeof(DimensionUnitType).Name);
 
             _commonControlLogic.RefreshAndSave();
@@ -362,7 +367,7 @@ public class AlignmentViewModel : ViewModel
 
             _commonControlLogic.SetXValues(global::RenderingLibrary.Graphics.HorizontalAlignment.Center, PositionUnitType.PixelsFromCenterX);
 
-            _commonControlLogic.SetAndCallReact("Width", -DockMargin * 2, "float");
+            _commonControlLogic.SetAndCallReact("Width", NormalizeNegativeZero(-DockMargin * 2), "float");
             _commonControlLogic.SetAndCallReact("WidthUnits", DimensionUnitType.RelativeToParent, typeof(DimensionUnitType).Name);
 
             _commonControlLogic.RefreshAndSave();

--- a/Tool/Tests/GumToolUnitTests/ViewModels/AlignmentViewModelTests.cs
+++ b/Tool/Tests/GumToolUnitTests/ViewModels/AlignmentViewModelTests.cs
@@ -1,0 +1,37 @@
+using Gum.Plugins.InternalPlugins.AlignmentButtons.ViewModels;
+using Shouldly;
+
+namespace GumToolUnitTests.ViewModels;
+
+public class AlignmentViewModelTests
+{
+    [Fact]
+    public void NormalizeNegativeZero_ConvertsNegativeZeroToPositiveZero()
+    {
+        float negativeZero = -0f * 2f;
+
+        negativeZero.ShouldBe(0f);
+        float.IsNegative(negativeZero).ShouldBeTrue();
+
+        float normalized = AlignmentViewModel.NormalizeNegativeZero(negativeZero);
+
+        float.IsNegative(normalized).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void NormalizeNegativeZero_LeavesPositiveZeroAlone()
+    {
+        float normalized = AlignmentViewModel.NormalizeNegativeZero(0f);
+
+        float.IsNegative(normalized).ShouldBeFalse();
+        normalized.ShouldBe(0f);
+    }
+
+    [Fact]
+    public void NormalizeNegativeZero_LeavesNonZeroValuesUnchanged()
+    {
+        AlignmentViewModel.NormalizeNegativeZero(-5f).ShouldBe(-5f);
+        AlignmentViewModel.NormalizeNegativeZero(5f).ShouldBe(5f);
+        AlignmentViewModel.NormalizeNegativeZero(-0.001f).ShouldBe(-0.001f);
+    }
+}


### PR DESCRIPTION
## Summary
- `-DockMargin * 2f` evaluated to IEEE 754 negative zero when `DockMargin` was 0, causing Dock → Fill (and the other dock handlers) to write `-0` to `Width`/`Height`, which then serialized into the project file.
- Added `AlignmentViewModel.NormalizeNegativeZero` and routed all `-DockMargin * 2` computations in the dock handlers (`DockTop`, `DockLeft`, `DockRight`, `DockBottom`, `DockFill`, `DockFillVertically`, `DockFillHorizontally`) through it, so future handlers can't reintroduce the regression by copy-paste.
- Added unit tests in `AlignmentViewModelTests` covering the helper.

Closes #2862

## Test plan
- [x] `dotnet test GumFull.sln --filter "FullyQualifiedName~AlignmentViewModelTests"` — passes
- [x] Manual: select an instance, set DockMargin to 0, click Dock → Fill, confirm `Width`/`Height` show `0` (not `-0`) in the variables grid and that the saved project file does not contain `-0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)