### PR TITLE
#2864: Drop on element appends instead of inserting behind existing children

### DIFF
--- a/Gum/Managers/DragDropManager.cs
+++ b/Gum/Managers/DragDropManager.cs
@@ -576,8 +576,19 @@ public class DragDropManager : IDragDropManager
                 }
             }
 
-            // in case there's some error here:
-            var siblingAfter = index > 0 && index - 1 < siblings.Count ? siblings[index - 1] : null;
+            // index here is the caller's "position among target's children"
+            // (0..siblings.Count). Issue #2864: ProcessDrop can pass the flat
+            // Instances.Count for the InstanceSave-tag append case, which
+            // exceeds siblings.Count. Clamp index-1 to the last sibling so an
+            // out-of-range index lands after the last child (append), rather
+            // than falling through to indexToAddAt=0 (the visible "snap to top"
+            // immediately after the new instance was correctly added at the end).
+            InstanceSave? siblingAfter = null;
+            if (index > 0 && siblings.Count > 0)
+            {
+                int siblingIndex = Math.Min(index - 1, siblings.Count - 1);
+                siblingAfter = siblings[siblingIndex];
+            }
 
             int indexToAddAt = 0;
 

--- a/Gum/Plugins/InternalPlugins/TreeView/ElementTreeViewManager.cs
+++ b/Gum/Plugins/InternalPlugins/TreeView/ElementTreeViewManager.cs
@@ -785,18 +785,28 @@ public partial class ElementTreeViewManager : IRecipient<ThemeChangedMessage>, I
         }
         // Issue #2864: a drop whose visual adornment is "rectangle around the
         // row" (Into and IntoFirst both draw the same box) must append to the
-        // target's children — never insert at a stale tree-child index that
-        // disagrees with the Instances list, and never silently insert at 0
-        // (which puts the new visual behind existing siblings). The user-facing
-        // distinction is "box vs. line": box = append, line = insert at
-        // sibling position. Inserting at index 0 is still reachable as
-        // DropKind.Before on the parent's first child, which draws a line.
+        // flat Instances list the new visual will be added to — never insert
+        // at a stale tree-child index. The user-facing distinction is
+        // "box vs. line": box = append, line = insert at sibling position.
+        // Inserting at index 0 is still reachable as DropKind.Before on the
+        // parent's first child, which draws a line.
+        //
+        // For an InstanceSave-tagged target (dropping onto another instance to
+        // parent under it), the destination list is the ParentContainer's
+        // Instances — NOT the target's tree children, which only represent the
+        // subset already parented under it. Without this, dropping a Container
+        // onto another Container lands the new instance partway through the
+        // screen's flat Instances list, behind later siblings.
         int? index = kind switch
         {
             MultiSelectTreeView.DropKind.Into or MultiSelectTreeView.DropKind.IntoFirst =>
-                originalTarget.Tag is ElementSave element
-                    ? element.Instances.Count
-                    : originalTarget.GetNodeCount(false),
+                originalTarget.Tag switch
+                {
+                    ElementSave element => element.Instances.Count,
+                    InstanceSave instance when instance.ParentContainer != null
+                        => instance.ParentContainer.Instances.Count,
+                    _ => originalTarget.GetNodeCount(false)
+                },
             MultiSelectTreeView.DropKind.After => originalTarget.Index + 1,
             MultiSelectTreeView.DropKind.Before => originalTarget.Index,
             _ => null

--- a/Gum/Plugins/InternalPlugins/TreeView/ElementTreeViewManager.cs
+++ b/Gum/Plugins/InternalPlugins/TreeView/ElementTreeViewManager.cs
@@ -770,36 +770,50 @@ public partial class ElementTreeViewManager : IRecipient<ThemeChangedMessage>, I
         ObjectTreeView.AfterCollapse += (_, _) => _collapseToggleService.OnNodeManuallyChanged();
 
         RefreshUi();
+    }
 
-        static (int index, TreeNode target)? ProcessDrop(TreeNode? originalTarget, MultiSelectTreeView.DropKind kind)
+    /// <summary>
+    /// Maps a tree drop (target node + kind) to the parent tree node it should
+    /// be inserted under and the index inside that parent's collection.
+    /// Internal so it can be unit-tested without instantiating the manager.
+    /// </summary>
+    internal static (int index, TreeNode target)? ProcessDrop(TreeNode? originalTarget, MultiSelectTreeView.DropKind kind)
+    {
+        if (originalTarget == null)
         {
-            if (originalTarget == null)
-            {
-                return null;
-            }
-            int? index = kind switch
-            {
-                MultiSelectTreeView.DropKind.Into => originalTarget.GetNodeCount(false),
-                MultiSelectTreeView.DropKind.After => originalTarget.Index + 1,
-                MultiSelectTreeView.DropKind.Before => originalTarget.Index,
-                MultiSelectTreeView.DropKind.IntoFirst => 0,
-                _ => null
-            };
-            TreeNode? target = kind switch
-            {
-                MultiSelectTreeView.DropKind.Into => originalTarget,
-                MultiSelectTreeView.DropKind.After => originalTarget.Parent,
-                MultiSelectTreeView.DropKind.Before => originalTarget.Parent,
-                MultiSelectTreeView.DropKind.IntoFirst => originalTarget,
-                _ => null
-            };
-            if (target != null && index != null)
-            {
-                return (index.Value, target);
-            }
-
             return null;
         }
+        // Issue #2864: a drop whose visual adornment is "rectangle around the
+        // row" (Into and IntoFirst both draw the same box) must append to the
+        // target's children — never insert at a stale tree-child index that
+        // disagrees with the Instances list, and never silently insert at 0
+        // (which puts the new visual behind existing siblings). The user-facing
+        // distinction is "box vs. line": box = append, line = insert at
+        // sibling position. Inserting at index 0 is still reachable as
+        // DropKind.Before on the parent's first child, which draws a line.
+        int? index = kind switch
+        {
+            MultiSelectTreeView.DropKind.Into or MultiSelectTreeView.DropKind.IntoFirst =>
+                originalTarget.Tag is ElementSave element
+                    ? element.Instances.Count
+                    : originalTarget.GetNodeCount(false),
+            MultiSelectTreeView.DropKind.After => originalTarget.Index + 1,
+            MultiSelectTreeView.DropKind.Before => originalTarget.Index,
+            _ => null
+        };
+        TreeNode? target = kind switch
+        {
+            MultiSelectTreeView.DropKind.Into or MultiSelectTreeView.DropKind.IntoFirst => originalTarget,
+            MultiSelectTreeView.DropKind.After => originalTarget.Parent,
+            MultiSelectTreeView.DropKind.Before => originalTarget.Parent,
+            _ => null
+        };
+        if (target != null && index != null)
+        {
+            return (index.Value, target);
+        }
+
+        return null;
     }
 
 

--- a/Tool/Tests/GumToolUnitTests/Managers/DragDropManagerTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Managers/DragDropManagerTests.cs
@@ -373,6 +373,111 @@ public class DragDropManagerTests : BaseTestClass
     }
 
     [Fact]
+    public void OnNodeSortingDropped_DropElementOnInstanceWithIndexPastSiblingCount_KeepsNewInstanceAtEnd()
+    {
+        // Issue #2864 (post-Instances.Count fix): when ProcessDrop returns a
+        // flat-list index for the InstanceSave-tag Into case, the index can
+        // exceed siblings.Count. The downstream HandleDroppingInstanceOnTarget
+        // interprets index as "position among target's children" and falls
+        // through to indexToAddAt = 0 when the index is past the end, which
+        // moves the just-inserted instance back to the front of the flat list
+        // (the user-visible "snap to top"). Out-of-range index must mean
+        // "append after the last existing sibling".
+        ScreenSave screen = new ScreenSave();
+        screen.Name = "MainScreen";
+        screen.States.Add(new StateSave { Name = "Default" });
+
+        InstanceSave leftContainer = new InstanceSave { Name = "LeftContainer", ParentContainer = screen };
+        screen.Instances.Add(leftContainer);
+        for (int i = 0; i < 4; i++)
+        {
+            string childName = $"Child{i}";
+            InstanceSave child = new InstanceSave { Name = childName, ParentContainer = screen };
+            screen.Instances.Add(child);
+            screen.DefaultState.SetValue($"{childName}.Parent", "LeftContainer", "string");
+        }
+        // Top-level instances not parented under LeftContainer — required to
+        // reproduce the bug, which only triggers when screen.Instances.Count is
+        // strictly greater than (siblings of LeftContainer).Count by more than 1.
+        for (int i = 0; i < 10; i++)
+        {
+            screen.Instances.Add(new InstanceSave { Name = $"TopLevel{i}", ParentContainer = screen });
+        }
+
+        ComponentSave draggedComponent = new ComponentSave();
+        draggedComponent.Name = "DraggedComponent";
+        draggedComponent.States.Add(new StateSave { Name = "Default" });
+
+        _circularReferenceManager
+            .Setup(x => x.CanTypeBeAddedToElement(It.IsAny<ElementSave>(), It.IsAny<string>()))
+            .Returns(true);
+
+        _mocker.GetMock<ISelectedState>()
+            .Setup(x => x.SelectedStateSave).Returns(screen.DefaultState);
+
+        _mocker.GetMock<IElementCommands>()
+            .Setup(x => x.GetUniqueNameForNewInstance(It.IsAny<ElementSave>(), It.IsAny<ElementSave>()))
+            .Returns("DraggedComponent1");
+
+        // Stand in for ElementCommands.AddInstance — actually mutate the screen
+        // (insert at desiredIndex, set Parent variable) and return the new
+        // instance, so HandleDroppingInstanceOnTarget runs against the same
+        // state ElementCommands would produce.
+        _mocker.GetMock<IElementCommands>()
+            .Setup(x => x.AddInstance(
+                It.IsAny<ElementSave>(),
+                It.IsAny<string>(),
+                It.IsAny<string?>(),
+                It.IsAny<string?>(),
+                It.IsAny<int?>()))
+            .Returns((ElementSave element, string name, string? type, string? parentName, int? desiredIndex) =>
+            {
+                InstanceSave inst = new InstanceSave
+                {
+                    Name = name,
+                    BaseType = type ?? string.Empty,
+                    ParentContainer = element
+                };
+                if (desiredIndex.HasValue)
+                {
+                    element.Instances.Insert(desiredIndex.Value, inst);
+                }
+                else
+                {
+                    element.Instances.Add(inst);
+                }
+                if (!string.IsNullOrEmpty(parentName))
+                {
+                    element.DefaultState.SetValue($"{inst.Name}.Parent", parentName, "string");
+                }
+                return inst;
+            });
+
+        Mock<ITreeNode> draggedNode = new Mock<ITreeNode>();
+        draggedNode.Setup(x => x.Tag).Returns(draggedComponent);
+
+        Mock<ITreeNode> targetNode = new Mock<ITreeNode>();
+        targetNode.Setup(x => x.Tag).Returns(leftContainer);
+
+        List<ITreeNode> draggedNodes = new() { draggedNode.Object };
+
+        // ProcessDrop's Into-on-InstanceSave returns ParentContainer.Instances.Count
+        // — past the end of the siblings list. This is the index that triggers
+        // the "snap to top" before the fix.
+        int indexFromProcessDrop = screen.Instances.Count;
+
+        _dragDropManager.OnNodeSortingDropped(draggedNodes, targetNode.Object, indexFromProcessDrop);
+
+        InstanceSave? newInstance = screen.Instances.FirstOrDefault(i => i.Name == "DraggedComponent1");
+        newInstance.ShouldNotBeNull();
+
+        int newIndex = screen.Instances.IndexOf(newInstance);
+        int lastExistingChildIndex = screen.Instances.IndexOf(screen.Instances.First(i => i.Name == "Child3"));
+        newIndex.ShouldBeGreaterThan(lastExistingChildIndex,
+            "the dropped instance must remain after the last existing child of the target container, not snap back to index 0");
+    }
+
+    [Fact]
     public void OnNodeSortingDropped_OnlyFolderNodes_DoesNotThrow()
     {
         // Arrange - only folder nodes (Tag=null), no tagged nodes

--- a/Tool/Tests/GumToolUnitTests/Plugins/InternalPlugins/TreeView/ElementTreeViewManagerProcessDropTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/InternalPlugins/TreeView/ElementTreeViewManagerProcessDropTests.cs
@@ -1,0 +1,101 @@
+using CommonFormsAndControls;
+using Gum.DataTypes;
+using Gum.Managers;
+using Shouldly;
+using System.Windows.Forms;
+using Xunit;
+
+namespace GumToolUnitTests.Plugins.InternalPlugins.TreeView;
+
+public class ElementTreeViewManagerProcessDropTests : BaseTestClass
+{
+    [Fact]
+    public void ProcessDrop_NullTarget_ReturnsNull()
+    {
+        var result = ElementTreeViewManager.ProcessDrop(null, MultiSelectTreeView.DropKind.Into);
+
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public void ProcessDrop_NoneKind_ReturnsNull()
+    {
+        TreeNode target = new TreeNode();
+
+        var result = ElementTreeViewManager.ProcessDrop(target, MultiSelectTreeView.DropKind.None);
+
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public void ProcessDrop_IntoFirstOnElementSave_AppendsSameAsInto()
+    {
+        // Issue #2864: the visual adornment for IntoFirst is identical to Into
+        // (both draw a rectangle around the row, not a between-rows line). The
+        // user cannot distinguish the two visually, so they must behave the same.
+        // Insertion at index 0 of the element is still reachable via DropKind.Before
+        // on the first child node, which shows an unambiguous line.
+        ComponentSave component = new ComponentSave();
+        component.Name = "TargetComponent";
+        component.Instances.Add(new InstanceSave { Name = "Existing" });
+
+        TreeNode target = new TreeNode { Tag = component };
+
+        var result = ElementTreeViewManager.ProcessDrop(target, MultiSelectTreeView.DropKind.IntoFirst);
+
+        result.ShouldNotBeNull();
+        result.Value.target.ShouldBe(target);
+        result.Value.index.ShouldBe(component.Instances.Count);
+    }
+
+    [Fact]
+    public void ProcessDrop_IntoElementSave_ReturnsInstancesCount_SoCallerAppends()
+    {
+        // Issue #2864: dropping a component into a screen tree node landed at
+        // index 0 because the index path returned a tree-child-derived value
+        // that did not line up with the element's Instances list. The correct
+        // index for an "into-this-element" drop is Instances.Count — i.e.
+        // append to the end so the new visual renders on top, not behind.
+        ScreenSave screen = new ScreenSave();
+        screen.Name = "TargetScreen";
+        screen.Instances.Add(new InstanceSave { Name = "Existing1" });
+        screen.Instances.Add(new InstanceSave { Name = "Existing2" });
+        screen.Instances.Add(new InstanceSave { Name = "Existing3" });
+
+        TreeNode target = new TreeNode { Tag = screen };
+
+        var result = ElementTreeViewManager.ProcessDrop(target, MultiSelectTreeView.DropKind.Into);
+
+        result.ShouldNotBeNull();
+        result.Value.target.ShouldBe(target);
+        result.Value.index.ShouldBe(screen.Instances.Count);
+    }
+
+    [Fact]
+    public void ProcessDrop_BeforeSibling_ReturnsSiblingIndexOnParent()
+    {
+        TreeNode parent = new TreeNode();
+        TreeNode first = parent.Nodes.Add("First");
+        TreeNode second = parent.Nodes.Add("Second");
+
+        var result = ElementTreeViewManager.ProcessDrop(second, MultiSelectTreeView.DropKind.Before);
+
+        result.ShouldNotBeNull();
+        result.Value.target.ShouldBe(parent);
+        result.Value.index.ShouldBe(1);
+    }
+
+    [Fact]
+    public void ProcessDrop_AfterSibling_ReturnsSiblingIndexPlusOneOnParent()
+    {
+        TreeNode parent = new TreeNode();
+        TreeNode first = parent.Nodes.Add("First");
+        TreeNode second = parent.Nodes.Add("Second");
+
+        var result = ElementTreeViewManager.ProcessDrop(first, MultiSelectTreeView.DropKind.After);
+
+        result.ShouldNotBeNull();
+        result.Value.target.ShouldBe(parent);
+        result.Value.index.ShouldBe(1);
+    }
+}

--- a/Tool/Tests/GumToolUnitTests/Plugins/InternalPlugins/TreeView/ElementTreeViewManagerProcessDropTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/InternalPlugins/TreeView/ElementTreeViewManagerProcessDropTests.cs
@@ -72,6 +72,39 @@ public class ElementTreeViewManagerProcessDropTests : BaseTestClass
     }
 
     [Fact]
+    public void ProcessDrop_IntoInstanceSave_ReturnsParentContainerInstancesCount_SoCallerAppends()
+    {
+        // Issue #2864 follow-up: dropping a Container onto another Container
+        // (target Tag is an InstanceSave) landed the new instance in the
+        // middle of MainScreen.Instances. The destination flat list is the
+        // ParentContainer's Instances; the index for an "into this instance"
+        // drop must be that list's count so callers append and the new visual
+        // renders on top.
+        ScreenSave screen = new ScreenSave();
+        screen.Name = "MainScreen";
+        InstanceSave leftContainer = new InstanceSave { Name = "LeftContainer", ParentContainer = screen };
+        screen.Instances.Add(leftContainer);
+        for (int i = 0; i < 14; i++)
+        {
+            screen.Instances.Add(new InstanceSave { Name = $"Other{i}", ParentContainer = screen });
+        }
+
+        TreeNode target = new TreeNode { Tag = leftContainer };
+        // Simulate that LeftContainer has 4 children visible in the tree view —
+        // this is what GetNodeCount(false) would have returned in the buggy path.
+        target.Nodes.Add("Child1");
+        target.Nodes.Add("Child2");
+        target.Nodes.Add("Child3");
+        target.Nodes.Add("Child4");
+
+        var result = ElementTreeViewManager.ProcessDrop(target, MultiSelectTreeView.DropKind.Into);
+
+        result.ShouldNotBeNull();
+        result.Value.target.ShouldBe(target);
+        result.Value.index.ShouldBe(screen.Instances.Count);
+    }
+
+    [Fact]
     public void ProcessDrop_BeforeSibling_ReturnsSiblingIndexOnParent()
     {
         TreeNode parent = new TreeNode();


### PR DESCRIPTION
## Summary

Fixes #2864. Dropping a component from the project tree onto a screen could land the new instance at `Instances[0]` (rendering it behind existing visuals) instead of appending to the end, depending on where in the screen's tree row the cursor was when released.

Two issues in `ElementTreeViewManager.ProcessDrop`:

- `DropKind.IntoFirst` (triggered when the cursor lands in the bottom quarter of an expanded node) returned index `0`. The visual adornment for `IntoFirst` is identical to `Into` — both draw a rectangle around the row, not a between-rows line — so the user can't distinguish them. Behavior is now unified: both append. Inserting at index 0 is still reachable explicitly via `DropKind.Before` on the parent's first child node, which draws an unambiguous line.
- `DropKind.Into` used `TreeNode.GetNodeCount(false)` as the index. That value can disagree with `ElementSave.Instances.Count` when the screen contains parented (nested) instances, since nested instances are not direct tree children. Now uses `Instances.Count` for `ElementSave`-tagged targets.

`ProcessDrop` was extracted from a static local function inside `Initialize` to an `internal static` method so it could be unit-tested through the existing `[InternalsVisibleTo(\"GumToolUnitTests\")]` on the `Gum` assembly. No behavior change beyond the bug fix.

## Test plan

- [x] New unit tests in `ElementTreeViewManagerProcessDropTests`:
  - `ProcessDrop_IntoElementSave_ReturnsInstancesCount_SoCallerAppends` — failing before the fix (returned 0), green after.
  - `ProcessDrop_IntoFirstOnElementSave_AppendsSameAsInto` — failing before the fix (returned 0), green after.
  - Sanity tests: null target, `None` kind, `Before` and `After` on siblings.
- [x] Existing `DragDropManagerTests` (8 tests) and `TreeView` test files (41 total) still pass.
- [x] Full `GumToolUnitTests` suite: 628 passed / 5 skipped (preexisting) / 0 failed.
- [ ] Manual smoke: in the tool, open a screen with at least one existing instance, expand it, drag a component from the project tree onto the screen row anywhere — confirm the new instance is appended to the end and renders on top.

Closes #2864

🤖 Generated with [Claude Code](https://claude.com/claude-code)