### PR TITLE
#2873: Fix Gum.Shapes nupkg pack collision dropping DesktopGL XNB

### DIFF
--- a/.claude/skills/gum-shapes-xnb-packaging/SKILL.md
+++ b/.claude/skills/gum-shapes-xnb-packaging/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: gum-shapes-xnb-packaging
+description: How Gum.Shapes.MonoGame / Gum.Shapes.KNI ship platform-specific apos-shapes.xnb. Triggers: editing Runtimes/GumShapes/MonoGameGumShapes.csproj, Runtimes/GumShapes/KniGumShapes.csproj, anything under Runtimes/GumShapes/buildTransitive/, or shipping/republishing those packages.
+---
+
+# Gum.Shapes XNB Packaging
+
+The two shapes packages (`Gum.Shapes.MonoGame`, `Gum.Shapes.KNI`) ship a pre-built `apos-shapes.xnb` per supported graphics backend so consumers don't run the upstream Apos.Shapes shader through MGCB themselves. The same files have to reach two completely different consumer types, and that fork is where this subsystem keeps producing footguns. PR #2853 + issue #2873 are the canonical incident — read those before changing anything in this area.
+
+## Two consumer paths, one set of XNBs
+
+Each shapes csproj must serve:
+
+1. **NuGet consumers** — pick the platform-correct XNB through `buildTransitive/Gum.Shapes.{MonoGame,KNI}.props`, which has `<ItemGroup Condition="'$(MonoGamePlatform)' == '<Platform>'">` blocks that inject a `<Content>` referencing `$(MSBuildThisFileDirectory)<Platform>/apos-shapes.xnb`. The XNBs ship inside the `.nupkg` under `buildTransitive/.../<Platform>/`.
+2. **ProjectReference consumers** — developers building against Gum source. `buildTransitive/` does **not** flow through `<ProjectReference>`, so the .props is invisible to them. They get only DesktopGL, unconditionally, via a `<Content Include="..." CopyToOutputDirectory="PreserveNewest" />` item directly in the shapes csproj. WindowsDX / Windows / BlazorGL ProjectReference users override locally; the inline comment in the csproj documents that.
+
+Upstream's own buildTransitive (`Apos.Shapes` / `Apos.Shapes.KNI`) is suppressed at the package boundary via `PrivateAssets="contentfiles;analyzers;build;buildTransitive"` on its `<PackageReference>`. `compile` and `runtime` are deliberately left out so the upstream DLL still flows.
+
+## The landmine — same identity in both `<Content>` and `<None>`
+
+The DesktopGL XNB has to be present in the on-disk file AND in the .nupkg. The natural-but-wrong way to express that is two items:
+
+```xml
+<Content Include=".../DesktopGL/apos-shapes.xnb" CopyToOutputDirectory="PreserveNewest" Pack="false" />
+<None    Include=".../DesktopGL/apos-shapes.xnb" Pack="true" PackagePath="buildTransitive/.../DesktopGL/" />
+```
+
+NuGet pack resolves the same identity across item types and the `Pack="false"` wins — the XNB **silently drops out of the package**. Per-package CI doesn't notice. WindowsDX / Windows / BlazorGL XNBs, which only have a `<None>` entry, ship correctly, so the failure is also platform-selective. That regression shipped as `Gum.Shapes.MonoGame 2026.5.20.1-preview.3` (issue #2873) — all DesktopGL consumers hit `MSB3030: Could not copy ... apos-shapes.xnb because it was not found`.
+
+The fix is to **never have the same file path appear twice across `<Content>` and `<None>`**. The DesktopGL XNB is expressed as one `<Content>` item that does both jobs:
+
+```xml
+<Content Include=".../DesktopGL/apos-shapes.xnb"
+         Link="Content/apos-shapes.xnb"
+         CopyToOutputDirectory="PreserveNewest"
+         Pack="true"
+         PackagePath="buildTransitive/.../DesktopGL/" />
+```
+
+Single source of truth per file = no collision possible. The other-platform XNBs stay as `<None Pack="true">` (no ProjectReference copy is desired for them).
+
+## The safety net — `VerifyShapesNupkg` target
+
+Both csprojs declare a `RoslynCodeTaskFactory` inline task `VerifyShapesNupkgEntries` and a `<Target Name="VerifyShapesNupkg" AfterTargets="Pack">`. The target opens the produced `.nupkg` as a ZIP and asserts every required entry (props + every platform XNB) is present. If any is missing the build emits an error and exits non-zero — `dotnet pack` cannot silently produce a broken shapes package.
+
+If you find yourself adding a new platform XNB, two edits are required and both must land in the same change:
+
+1. Add the file under `Runtimes/GumShapes/buildTransitive/.../NewPlatform/apos-shapes.xnb` and a matching conditional in the relevant `Gum.Shapes.*.props`.
+2. Add the entry to the `ExpectedEntries` attribute of `VerifyShapesNupkg`. If you forget step 2, the safety net stops covering that platform — defeats the point of the target.
+
+## Don't trust local pack output without checking
+
+The verification target fails the build (non-zero exit) when an expected entry is missing, but pack still leaves the broken `.nupkg` on disk — there's no clean-up step. Before publishing, **check the exit code** of `dotnet pack` (`echo $?` / `$LASTEXITCODE`) and as a belt-and-suspenders manual check run `unzip -l <nupkg> | grep xnb` so you can see all expected entries by eye.
+
+## Related
+
+- `gum-cross-platform-unification` — explains the Apos.Shapes ↔ SkiaGum shape-runtime source-sharing pattern. The csproj that links those shared sources is the same one this skill is about.
+- `gum-project-versioning` — version bumps land in both shapes csprojs in lockstep with `Gum.MonoGame` / `Gum.KNI`.

--- a/Runtimes/GumShapes/KniGumShapes.csproj
+++ b/Runtimes/GumShapes/KniGumShapes.csproj
@@ -82,25 +82,77 @@
 
 	<ItemGroup>
 		<None Include="buildTransitive\Gum.Shapes.KNI.props" Pack="true" PackagePath="buildTransitive\" />
-		<None Include="buildTransitive\Content\DesktopGL\apos-shapes.xnb" Pack="true" PackagePath="buildTransitive\Content\DesktopGL\" />
+		<!-- DesktopGL XNB is packed via the single <Content> item below, not here. See the long comment there. -->
 		<None Include="buildTransitive\Content\Windows\apos-shapes.xnb" Pack="true" PackagePath="buildTransitive\Content\Windows\" />
 		<None Include="buildTransitive\Content\BlazorGL\apos-shapes.xnb" Pack="true" PackagePath="buildTransitive\Content\BlazorGL\" />
 	</ItemGroup>
 
 	<!--
-		ProjectReference consumers (developers building against Gum source) do not get our
-		buildTransitive/.props, so they do not get a platform-conditional Content XNB.
-		Ship the DesktopGL XNB unconditionally so the common local-dev scenario just works.
-		Pack="false" keeps this Content item out of the .nupkg — NuGet consumers already get
-		platform-correct XNBs via buildTransitive/Gum.Shapes.KNI.props. Windows/BlazorGL
-		ProjectReference users should override by adding their own Content item targeting the
-		appropriate XNB under buildTransitive/Content/.
+		DesktopGL XNB: SINGLE item that does BOTH jobs.
+		- ProjectReference consumers get it copied to their output via CopyToOutputDirectory.
+		- NuGet consumers get it packed into the .nupkg under buildTransitive/Content/DesktopGL/
+		  where buildTransitive/Gum.Shapes.KNI.props references it platform-conditionally.
+
+		DO NOT add a separate <None Include="...DesktopGL\apos-shapes.xnb" Pack="true"> item alongside
+		this. When the same file path appears as both <Content> and <None>, NuGet pack honors one
+		entry's Pack metadata and the file silently drops out of the package. See issue #2873.
+		The post-pack VerifyShapesNupkg target below enforces this can't ship broken.
+
+		Windows/BlazorGL ProjectReference users still need to override locally — those XNBs are
+		packed for NuGet consumers only (see the <None> entries above).
 	-->
 	<ItemGroup>
 		<Content Include="buildTransitive\Content\DesktopGL\apos-shapes.xnb"
 		         Link="Content\apos-shapes.xnb"
 		         CopyToOutputDirectory="PreserveNewest"
-		         Pack="false" />
+		         Pack="true"
+		         PackagePath="buildTransitive\Content\DesktopGL\" />
 	</ItemGroup>
+
+	<!--
+		Post-pack regression guard. See issue #2873.
+	-->
+	<UsingTask TaskName="VerifyShapesNupkgEntries"
+	           TaskFactory="RoslynCodeTaskFactory"
+	           AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
+		<ParameterGroup>
+			<NupkgPath ParameterType="System.String" Required="true" />
+			<ExpectedEntries ParameterType="System.String[]" Required="true" />
+		</ParameterGroup>
+		<Task>
+			<Using Namespace="System" />
+			<Using Namespace="System.IO" />
+			<Using Namespace="System.IO.Compression" />
+			<Using Namespace="System.Linq" />
+			<Code Type="Fragment" Language="cs"><![CDATA[
+				if (!File.Exists(NupkgPath))
+				{
+					Log.LogError($"VerifyShapesNupkgEntries: nupkg not found at '{NupkgPath}'.");
+					return false;
+				}
+				using (var archive = ZipFile.OpenRead(NupkgPath))
+				{
+					var entries = archive.Entries.Select(e => e.FullName.Replace('\\', '/')).ToList();
+					foreach (var expected in ExpectedEntries)
+					{
+						var normalized = expected.Replace('\\', '/');
+						if (!entries.Any(e => string.Equals(e, normalized, StringComparison.OrdinalIgnoreCase)))
+						{
+							Log.LogError($"VerifyShapesNupkgEntries: required entry '{normalized}' is MISSING from {Path.GetFileName(NupkgPath)}. Do not publish this package. See issue #2873.");
+						}
+					}
+				}
+			]]></Code>
+		</Task>
+	</UsingTask>
+
+	<Target Name="VerifyShapesNupkg" AfterTargets="Pack">
+		<PropertyGroup>
+			<_ShapesNupkgPath>$([MSBuild]::EnsureTrailingSlash($(PackageOutputAbsolutePath)))$(PackageId).$(PackageVersion).nupkg</_ShapesNupkgPath>
+		</PropertyGroup>
+		<VerifyShapesNupkgEntries
+			NupkgPath="$(_ShapesNupkgPath)"
+			ExpectedEntries="buildTransitive/Gum.Shapes.KNI.props;buildTransitive/Content/DesktopGL/apos-shapes.xnb;buildTransitive/Content/Windows/apos-shapes.xnb;buildTransitive/Content/BlazorGL/apos-shapes.xnb" />
+	</Target>
 
 </Project>

--- a/Runtimes/GumShapes/MonoGameGumShapes.csproj
+++ b/Runtimes/GumShapes/MonoGameGumShapes.csproj
@@ -52,19 +52,27 @@
 	</ItemGroup>
 
 	<!--
-		ProjectReference consumers (developers building against Gum source) do not get our
-		buildTransitive/.props, so they do not get a platform-conditional Content XNB.
-		Ship the DesktopGL XNB unconditionally so the common local-dev scenario just works.
-		Pack="false" keeps this Content item out of the .nupkg — NuGet consumers already get
-		platform-correct XNBs via buildTransitive/Gum.Shapes.MonoGame.props. WindowsDX
-		ProjectReference users should override by adding their own Content item targeting
-		buildTransitive/MonoGame/Content/WindowsDX/apos-shapes.xnb to their consuming csproj.
+		DesktopGL XNB: SINGLE item that does BOTH jobs.
+		- ProjectReference consumers get it copied to their output via CopyToOutputDirectory
+		  (they do not see our buildTransitive/.props, so they need the unconditional copy).
+		- NuGet consumers get it packed into the .nupkg under buildTransitive/MonoGame/Content/DesktopGL/
+		  where buildTransitive/Gum.Shapes.MonoGame.props references it platform-conditionally.
+
+		DO NOT add a separate <None Include="...DesktopGL\apos-shapes.xnb" Pack="true"> item alongside
+		this. When the same file path appears as both <Content> and <None>, NuGet pack honors one
+		entry's Pack metadata and the file silently drops out of the package. That regression already
+		shipped once — Gum.Shapes.MonoGame 2026.5.20.1-preview.3 (issue #2873). The post-pack
+		VerifyShapesNupkg target below exists so it cannot ship again.
+
+		WindowsDX ProjectReference users still need to override locally — the WindowsDX XNB is
+		packed for NuGet consumers only (see the <None> entry further down).
 	-->
 	<ItemGroup>
 		<Content Include="buildTransitive\MonoGame\Content\DesktopGL\apos-shapes.xnb"
 		         Link="Content\apos-shapes.xnb"
 		         CopyToOutputDirectory="PreserveNewest"
-		         Pack="false" />
+		         Pack="true"
+		         PackagePath="buildTransitive\MonoGame\Content\DesktopGL\" />
 	</ItemGroup>
 
 	<ItemGroup>
@@ -88,8 +96,57 @@
 
 	<ItemGroup>
 		<None Include="buildTransitive\Gum.Shapes.MonoGame.props" Pack="true" PackagePath="buildTransitive\" />
-		<None Include="buildTransitive\MonoGame\Content\DesktopGL\apos-shapes.xnb" Pack="true" PackagePath="buildTransitive\MonoGame\Content\DesktopGL\" />
+		<!-- DesktopGL XNB is packed via the single <Content> item above, not here. See the long comment up top. -->
 		<None Include="buildTransitive\MonoGame\Content\WindowsDX\apos-shapes.xnb" Pack="true" PackagePath="buildTransitive\MonoGame\Content\WindowsDX\" />
 	</ItemGroup>
+
+	<!--
+		Post-pack regression guard. Opens the produced .nupkg and asserts that each expected
+		entry is present. Fails the build if any is missing. Exists because
+		Gum.Shapes.MonoGame 2026.5.20.1-preview.3 shipped without the DesktopGL XNB (issue #2873)
+		due to a silent <Content>/<None> identity collision. If this target fails, do NOT publish.
+	-->
+	<UsingTask TaskName="VerifyShapesNupkgEntries"
+	           TaskFactory="RoslynCodeTaskFactory"
+	           AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
+		<ParameterGroup>
+			<NupkgPath ParameterType="System.String" Required="true" />
+			<ExpectedEntries ParameterType="System.String[]" Required="true" />
+		</ParameterGroup>
+		<Task>
+			<Using Namespace="System" />
+			<Using Namespace="System.IO" />
+			<Using Namespace="System.IO.Compression" />
+			<Using Namespace="System.Linq" />
+			<Code Type="Fragment" Language="cs"><![CDATA[
+				if (!File.Exists(NupkgPath))
+				{
+					Log.LogError($"VerifyShapesNupkgEntries: nupkg not found at '{NupkgPath}'.");
+					return false;
+				}
+				using (var archive = ZipFile.OpenRead(NupkgPath))
+				{
+					var entries = archive.Entries.Select(e => e.FullName.Replace('\\', '/')).ToList();
+					foreach (var expected in ExpectedEntries)
+					{
+						var normalized = expected.Replace('\\', '/');
+						if (!entries.Any(e => string.Equals(e, normalized, StringComparison.OrdinalIgnoreCase)))
+						{
+							Log.LogError($"VerifyShapesNupkgEntries: required entry '{normalized}' is MISSING from {Path.GetFileName(NupkgPath)}. Do not publish this package. See issue #2873.");
+						}
+					}
+				}
+			]]></Code>
+		</Task>
+	</UsingTask>
+
+	<Target Name="VerifyShapesNupkg" AfterTargets="Pack">
+		<PropertyGroup>
+			<_ShapesNupkgPath>$([MSBuild]::EnsureTrailingSlash($(PackageOutputAbsolutePath)))$(PackageId).$(PackageVersion).nupkg</_ShapesNupkgPath>
+		</PropertyGroup>
+		<VerifyShapesNupkgEntries
+			NupkgPath="$(_ShapesNupkgPath)"
+			ExpectedEntries="buildTransitive/Gum.Shapes.MonoGame.props;buildTransitive/MonoGame/Content/DesktopGL/apos-shapes.xnb;buildTransitive/MonoGame/Content/WindowsDX/apos-shapes.xnb" />
+	</Target>
 
 </Project>


### PR DESCRIPTION
## Summary

- Collapse the colliding `<Content Pack="false">` + `<None Pack="true">` pair for `DesktopGL/apos-shapes.xnb` into a single `<Content>` item in both `MonoGameGumShapes.csproj` and `KniGumShapes.csproj`. One item per file identity = NuGet pack cannot silently drop the file again. (Root cause of issue #2873; `Gum.Shapes.MonoGame 2026.5.20.1-preview.3` shipped without this XNB.)
- Add a `VerifyShapesNupkg` post-pack target to both csprojs. Opens the produced `.nupkg` as a zip and asserts every required entry (props + each platform XNB) is present. Fails the build (non-zero exit) if any is missing — regression cannot ship again.
- Add a `gum-shapes-xnb-packaging` skill explaining the two-consumer-path architecture (NuGet via buildTransitive props vs. ProjectReference via Content) and the collision landmine. Triggers on edits to the shapes csprojs and the buildTransitive/ folder.

## How this was validated

- Packed `Gum.Shapes.MonoGame` locally with the fix → `unzip -l` confirms `DesktopGL/apos-shapes.xnb` + `WindowsDX/apos-shapes.xnb` + props are all present.
- Re-introduced the broken `Pack="false"` state locally → `dotnet pack` exits 1 with the pointed VerifyShapesNupkg error message referencing this issue. Restored the fix, exit returns to 0.
- Repointed a real DesktopGL consumer (`QuestToCompileGum`) at the locally-packed shapes nupkg → builds clean, vs. `MSB3030 ... apos-shapes.xnb not found` against the published `2026.5.20.1-preview.3`.
- Packed `Gum.Shapes.KNI` locally with the same fix → DesktopGL + Windows + BlazorGL XNBs all present.

## Test plan

- [ ] Reviewer checks the two csproj diffs and confirms the DesktopGL XNB now has exactly one item per csproj.
- [ ] On the next release, confirm `dotnet pack` of both shapes csprojs exits 0 and that `unzip -l` of each `.nupkg` shows the expected XNB list.
- [ ] If a release ever fails pack with `VerifyShapesNupkgEntries: required entry 'X' is MISSING ...`, do not publish — fix the csproj first.

Closes #2873

🤖 Generated with [Claude Code](https://claude.com/claude-code)