### PR TITLE
#2875: Fix stale Auto/Manual prompt on Code tab after project load

### DIFF
--- a/Gum/CodeOutputPlugin/ViewModels/CodeWindowViewModel.cs
+++ b/Gum/CodeOutputPlugin/ViewModels/CodeWindowViewModel.cs
@@ -227,6 +227,27 @@ public class CodeWindowViewModel : ViewModel
         }
     }
 
+    /// <summary>
+    /// Returns whether the Code tab should display the "Manual / Auto" setup prompt
+    /// rather than the populated code-generation settings grid. True when the project
+    /// has a sibling/ancestor .csproj but the user has not yet picked a CodeProjectRoot
+    /// and has not explicitly chosen manual setup.
+    /// </summary>
+    public bool ShouldShowSetup(CodeOutputProjectSettings? settings, bool hasClickedManualSetup)
+    {
+        if (hasClickedManualSetup)
+        {
+            return false;
+        }
+
+        if (!string.IsNullOrEmpty(settings?.CodeProjectRoot))
+        {
+            return false;
+        }
+
+        return GetCsprojDirectoryAboveGumx() != null;
+    }
+
     public bool HandleAutoSetupClicked(CodeOutputProjectSettings codeOutputProjectSettings)
     {
         var projectFilePath = _projectState.GumProjectSave?.FullFileName;

--- a/Gum/CodeOutputPlugin/Views/CodeWindow.xaml.cs
+++ b/Gum/CodeOutputPlugin/Views/CodeWindow.xaml.cs
@@ -38,9 +38,27 @@ public partial class CodeWindow : UserControl
 
     CodeWindowViewModel ViewModel => (CodeWindowViewModel)DataContext!;
 
+    CodeOutputProjectSettings? codeOutputProjectSettings;
+
     public CodeOutputProjectSettings? CodeOutputProjectSettings
     {
-        get; set;
+        get => codeOutputProjectSettings;
+        set
+        {
+            // Setter triggers FullRefreshDataGrid because NeedsSetup (which
+            // toggles between the Auto/Manual prompt and the populated settings
+            // grid) is recomputed during the refresh. The plugin wires this
+            // property up after LoadCodeSettingsFile has already fired a
+            // refresh, so without this we'd evaluate NeedsSetup against a
+            // stale (null) CodeOutputProjectSettings and leave the prompt
+            // showing even when CodeProjectRoot is populated (#2875).
+            if (codeOutputProjectSettings == value)
+            {
+                return;
+            }
+            codeOutputProjectSettings = value;
+            FullRefreshDataGrid();
+        }
     }
 
     CodeOutputElementSettings? codeOutputElementSettings;
@@ -202,16 +220,7 @@ public partial class CodeWindow : UserControl
         // in the future this could have a property for selecting folder, but until then....
         //member.PreferredDisplayer = typeof(FileSelectionDisplay);
 
-        //var value = member.Value as string;
-        //if(string.IsNullOrEmpty(value))
-        //{
-        //    // let's see if we have a csproj:
-        var csproj = ViewModel.GetCsprojDirectoryAboveGumx();
-
-        ViewModel.NeedsSetup =
-            csproj != null &&
-            string.IsNullOrEmpty(CodeOutputProjectSettings?.CodeProjectRoot) &&
-            !HasClickedManualSetup;
+        ViewModel.NeedsSetup = ViewModel.ShouldShowSetup(CodeOutputProjectSettings, HasClickedManualSetup);
 
         return member;
     }

--- a/Tool/Tests/GumToolUnitTests/Plugins/CodeOutputPlugins/CodeWindowViewModelTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/CodeOutputPlugins/CodeWindowViewModelTests.cs
@@ -1,4 +1,4 @@
-﻿using Gum.ProjectServices.CodeGeneration;
+using Gum.ProjectServices.CodeGeneration;
 using CodeOutputPlugin.ViewModels;
 using Gum.Commands;
 using Gum.DataTypes;
@@ -12,6 +12,7 @@ using Moq.AutoMock;
 using Shouldly;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -29,6 +30,104 @@ public class CodeWindowViewModelTests
         _mocker = new AutoMocker();
         _viewModel = _mocker.CreateInstance<CodeWindowViewModel>();
 
+    }
+
+    [Fact]
+    public void ShouldShowSetup_ReturnsTrue_WhenCsprojAboveGumxAndCodeProjectRootEmpty()
+    {
+        string gumDirectory = @"C:\game\Content\GumProject\";
+        string csprojDirectory = @"C:\game\";
+
+        SetupCsprojDiscovery(gumDirectory, csprojDirectory);
+
+        CodeOutputProjectSettings settings = new CodeOutputProjectSettings { CodeProjectRoot = string.Empty };
+
+        bool result = _viewModel.ShouldShowSetup(settings, hasClickedManualSetup: false);
+
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void ShouldShowSetup_ReturnsFalse_WhenCodeProjectRootIsPopulated()
+    {
+        string gumDirectory = @"C:\game\Content\GumProject\";
+        string csprojDirectory = @"C:\game\";
+
+        SetupCsprojDiscovery(gumDirectory, csprojDirectory);
+
+        CodeOutputProjectSettings settings = new CodeOutputProjectSettings { CodeProjectRoot = @"..\..\" };
+
+        bool result = _viewModel.ShouldShowSetup(settings, hasClickedManualSetup: false);
+
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ShouldShowSetup_ReturnsTrue_WhenSettingsIsNullButCsprojExists()
+    {
+        string gumDirectory = @"C:\game\Content\GumProject\";
+        string csprojDirectory = @"C:\game\";
+
+        SetupCsprojDiscovery(gumDirectory, csprojDirectory);
+
+        bool result = _viewModel.ShouldShowSetup(settings: null, hasClickedManualSetup: false);
+
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void ShouldShowSetup_ReturnsFalse_WhenManualSetupHasBeenClicked()
+    {
+        string gumDirectory = @"C:\game\Content\GumProject\";
+        string csprojDirectory = @"C:\game\";
+
+        SetupCsprojDiscovery(gumDirectory, csprojDirectory);
+
+        CodeOutputProjectSettings settings = new CodeOutputProjectSettings { CodeProjectRoot = string.Empty };
+
+        bool result = _viewModel.ShouldShowSetup(settings, hasClickedManualSetup: true);
+
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ShouldShowSetup_ReturnsFalse_WhenNoCsprojExistsAboveGumx()
+    {
+        string gumDirectory = @"C:\game\Content\GumProject\";
+
+        _mocker.GetMock<IProjectState>()
+            .Setup(p => p.ProjectDirectory)
+            .Returns(gumDirectory);
+        _mocker.GetMock<IFileCommands>()
+            .Setup(f => f.GetFiles(It.IsAny<string>()))
+            .Returns(Array.Empty<string>());
+
+        CodeOutputProjectSettings settings = new CodeOutputProjectSettings { CodeProjectRoot = string.Empty };
+
+        bool result = _viewModel.ShouldShowSetup(settings, hasClickedManualSetup: false);
+
+        result.ShouldBeFalse();
+    }
+
+    private void SetupCsprojDiscovery(string gumDirectory, string csprojDirectory)
+    {
+        _mocker.GetMock<IProjectState>()
+            .Setup(p => p.ProjectDirectory)
+            .Returns(gumDirectory);
+
+        Mock<IFileCommands> fileCommandsMock = _mocker.GetMock<IFileCommands>();
+        FilePath csprojPath = new FilePath(csprojDirectory);
+        fileCommandsMock
+            .Setup(f => f.GetFiles(It.IsAny<string>()))
+            .Returns<string>(path =>
+            {
+                FilePath asFilePath = new FilePath(path);
+                if (asFilePath == csprojPath)
+                {
+                    return new[] { Path.Combine(csprojDirectory, "Game.csproj") };
+                }
+                return Array.Empty<string>();
+            });
     }
 
 }


### PR DESCRIPTION
## Summary

- Move the Code tab's `NeedsSetup` calculation onto `CodeWindowViewModel.ShouldShowSetup` so it's unit-testable.
- Make `CodeWindow.CodeOutputProjectSettings` a real setter that re-fires `FullRefreshDataGrid`, removing the order-dependence that left the Auto/Manual prompt showing for projects with a populated `CodeProjectRoot`.

## Why

`MainCodeOutputPlugin.HandleElementSelected` calls `LoadCodeSettingsFile` (which assigns `CodeOutputElementSettings` and triggers `FullRefreshDataGrid`) *before* `RefreshCodeDisplay` pushes `codeOutputProjectSettings` onto the control. The previous auto-property setter had no side effect, so `NeedsSetup` was evaluated against a stale (null) `CodeOutputProjectSettings` and the Auto/Manual prompt stuck. Cloned projects like QuestToCompileGum (which save `CodeProjectRoot: "..\..\\"`) saw the prompt instead of the populated settings grid.

## Test plan

- [x] Unit tests cover the four branches of `ShouldShowSetup` (csproj + empty root → true, populated root → false, manual clicked → false, no csproj → false, plus null settings preserves prior behavior).
- [x] Full `GumFull.sln` test suite still green.
- [ ] Manual: open QuestToCompileGum's Gum project in the tool; Code tab should show the populated codegen settings grid, not the Auto/Manual buttons.

Closes #2875

🤖 Generated with [Claude Code](https://claude.com/claude-code)