### PR TITLE
#2869: Refactor drop-target plumbing with typed DropTarget

### DIFF
--- a/Gum/Managers/DragDropManager.cs
+++ b/Gum/Managers/DragDropManager.cs
@@ -580,6 +580,17 @@ public class DragDropManager : IDragDropManager
             parentName = null;
         }
 
+        // No-op when dropping an instance on a parent it already has. For
+        // Append (the kind=Into drop kind), the user's intent is "make this a
+        // child of parent" — already satisfied — so the flat-list reorder is
+        // a surprising side effect. Explicit BeforeSibling/AfterSibling drops
+        // still reorder because the user picked a specific new position.
+        if (dropTarget.Position is DropPosition.Append &&
+            ParentVariableAlreadyMatches(targetElementSave, dragDroppedInstance, parentName))
+        {
+            return;
+        }
+
         int flatListPosition = ResolveFlatListPositionForReorder(dropTarget, dragDroppedInstance);
 
         int droppedInstanceIndexBeforeMove = targetElementSave.Instances.IndexOf(dragDroppedInstance);
@@ -663,6 +674,20 @@ public class DragDropManager : IDragDropManager
             default:
                 return element.Instances.Count;
         }
+    }
+
+    private static bool ParentVariableAlreadyMatches(ElementSave element, InstanceSave instance, string? expectedParentName)
+    {
+        var currentParent = element.DefaultState.GetVariableRecursive(instance.Name + ".Parent")?.Value as string;
+        if (string.IsNullOrEmpty(expectedParentName))
+        {
+            return string.IsNullOrEmpty(currentParent);
+        }
+        // Allow the existing value to be either the parent name or a
+        // "parent.defaultChild" form (which resolves to the same parent).
+        return currentParent == expectedParentName
+            || (currentParent != null && expectedParentName.StartsWith(currentParent + "."))
+            || (currentParent != null && currentParent.StartsWith(expectedParentName + "."));
     }
 
     private static InstanceSave? FindLastSiblingOfParent(ElementSave element, InstanceSave parentInstance, InstanceSave excludeInstance)

--- a/Gum/Managers/DragDropManager.cs
+++ b/Gum/Managers/DragDropManager.cs
@@ -27,6 +27,7 @@ using System.Windows.Forms;
 using System.Windows.Navigation;
 using Gum.Extensions;
 using ToolsUtilities;
+using Gum.Plugins.InternalPlugins.TreeView;
 using Gum.Plugins.InternalPlugins.VariableGrid;
 
 namespace Gum.Managers;
@@ -149,7 +150,7 @@ public class DragDropManager : IDragDropManager
 
     #region Drop Element (like components) on TreeView
 
-    private void HandleDroppedElementSave(object draggedComponentOrElement, ITreeNode treeNodeDroppedOn, object targetTag, ITreeNode targetTreeNode, int index)
+    private void HandleDroppedElementSave(object draggedComponentOrElement, ITreeNode treeNodeDroppedOn, object targetTag, ITreeNode targetTreeNode, DropTarget? dropTarget)
     {
         ElementSave draggedAsElementSave = draggedComponentOrElement as ElementSave;
 
@@ -158,7 +159,7 @@ public class DragDropManager : IDragDropManager
 
         if (targetTag is ElementSave)
         {
-            HandleDroppedElementInElement(draggedAsElementSave, targetTag as ElementSave, null, index);
+            HandleDroppedElementInElement(draggedAsElementSave, targetTag as ElementSave, null, dropTarget);
         }
         else if (targetTag is InstanceSave)
         {
@@ -170,12 +171,12 @@ public class DragDropManager : IDragDropManager
             // When a parent is set, we normally raise an event for that. This is a tricky situation because
             // we need to set the parent before adding the object.
 
-            var newInstance = HandleDroppedElementInElement(draggedAsElementSave, targetInstance.ParentContainer, targetInstance, index);
+            var newInstance = HandleDroppedElementInElement(draggedAsElementSave, targetInstance.ParentContainer, targetInstance, dropTarget);
 
-            if(newInstance != null)
+            if(newInstance != null && dropTarget != null)
             {
                 // Since the user dropped on another instance, let's try to parent it:
-                HandleDroppingInstanceOnTarget(targetInstance, newInstance, targetInstance.ParentContainer, targetTreeNode, index);
+                HandleDroppingInstanceOnTarget(newInstance, targetTreeNode, dropTarget);
 
                 // HandleDroppingInstanceOnTarget internally calls
                 // _wireframeObjectManager.RefreshAll, but since
@@ -297,7 +298,7 @@ public class DragDropManager : IDragDropManager
         return newInstance;
     }
 
-    private InstanceSave HandleDroppedElementInElement(ElementSave draggedAsElementSave, ElementSave target, InstanceSave parentInstance, int index)
+    private InstanceSave HandleDroppedElementInElement(ElementSave draggedAsElementSave, ElementSave target, InstanceSave parentInstance, DropTarget? dropTarget)
     {
         InstanceSave newInstance = null;
 
@@ -324,10 +325,31 @@ public class DragDropManager : IDragDropManager
             // the object we dragged off.  This is so that plugins can properly use the SelectedElement.
             _selectedState.SelectedElement = target;
 
-            newInstance = _elementCommands.AddInstance(target, name, draggedAsElementSave.Name, parentInstance?.Name, index);
+            int? desiredIndex = ResolveDesiredFlatIndex(dropTarget?.Position, target);
+
+            newInstance = _elementCommands.AddInstance(target, name, draggedAsElementSave.Name, parentInstance?.Name, desiredIndex);
         }
 
         return newInstance;
+    }
+
+    /// <summary>
+    /// Translate a <see cref="DropPosition"/> into a flat-list index inside
+    /// <paramref name="element"/>.<see cref="ElementSave.Instances"/>. Returns
+    /// null for <see cref="DropPosition.Append"/>, which lets callers like
+    /// <c>AddInstance</c> use their "append to end" default path.
+    /// </summary>
+    private static int? ResolveDesiredFlatIndex(DropPosition? position, ElementSave element)
+    {
+        return position switch
+        {
+            null => null,
+            DropPosition.Append => null,
+            DropPosition.InsertAt at => Math.Clamp(at.Index, 0, element.Instances.Count),
+            DropPosition.BeforeSibling before => Math.Max(0, element.Instances.IndexOf(before.Sibling)),
+            DropPosition.AfterSibling after => element.Instances.IndexOf(after.Sibling) + 1,
+            _ => null
+        };
     }
 
     private string? GetDropElementErrorMessage(ElementSave draggedAsElementSave, ElementSave target, string errorMessage)
@@ -420,7 +442,7 @@ public class DragDropManager : IDragDropManager
 
     #region Drop Instance on TreeNode
 
-    private void HandleDroppedInstance(object draggedObject, ITreeNode targetTreeNode, int index)
+    private void HandleDroppedInstance(object draggedObject, ITreeNode targetTreeNode, DropTarget? dropTarget)
     {
         object targetObject = targetTreeNode.Tag;
 
@@ -454,8 +476,10 @@ public class DragDropManager : IDragDropManager
 
             else if (isSameElement)
             {
-                HandleDroppingInstanceOnTarget(targetObject, draggedAsInstanceSave, targetElementSave, targetTreeNode, index);
-
+                if (dropTarget != null)
+                {
+                    HandleDroppingInstanceOnTarget(draggedAsInstanceSave, targetTreeNode, dropTarget);
+                }
             }
             else
             {
@@ -497,10 +521,13 @@ public class DragDropManager : IDragDropManager
                 // long. The unit test for one case is here:
                 // DragDropManagerTests.OnNodeSortingDropped_DropInstance_ShouldInsertAtIndex_OnDifferentElement
                 var firstInstance = newInstances.FirstOrDefault();
-                if(firstInstance != null && targetElementSave.Instances.IndexOf(firstInstance) != index)
+                int desiredFlatIndex = ResolveDesiredFlatIndex(dropTarget?.Position, targetElementSave)
+                    ?? targetElementSave.Instances.Count;
+                if(firstInstance != null && targetElementSave.Instances.IndexOf(firstInstance) != desiredFlatIndex)
                 {
                     targetElementSave.Instances.Remove(firstInstance);
-                    targetElementSave.Instances.Insert(index, firstInstance);
+                    int safeIndex = Math.Min(desiredFlatIndex, targetElementSave.Instances.Count);
+                    targetElementSave.Instances.Insert(safeIndex, firstInstance);
 
                     _reorderLogic.RefreshInResponseToReorder(firstInstance);
                 }
@@ -524,107 +551,138 @@ public class DragDropManager : IDragDropManager
         _elementCommands.AddInstance(asBehaviorSave, draggedAsInstanceSave.Name, draggedAsInstanceSave.BaseType);
     }
 
-    private void HandleDroppingInstanceOnTarget(object targetObject, InstanceSave dragDroppedInstance, ElementSave targetElementSave, ITreeNode targetTreeNode, int index)
+    private void HandleDroppingInstanceOnTarget(InstanceSave dragDroppedInstance, ITreeNode? targetTreeNode, DropTarget dropTarget)
     {
-        var instanceDefinedByBase = dragDroppedInstance.DefinedByBase;
-
-        if(instanceDefinedByBase)
+        if (dragDroppedInstance.DefinedByBase)
         {
-            _dialogService.ShowMessage($"{dragDroppedInstance.Name} cannot be added as a child of {targetObject} because it is defined in a base element");
+            object describedTarget = (object?)dropTarget.ParentInstance ?? dropTarget.ParentElement;
+            _dialogService.ShowMessage($"{dragDroppedInstance.Name} cannot be added as a child of {describedTarget} because it is defined in a base element");
+            return;
+        }
+
+        ElementSave targetElementSave = dropTarget.ParentElement;
+        InstanceSave? parentInstance = dropTarget.ParentInstance;
+        string variableName = dragDroppedInstance.Name + ".Parent";
+
+        string? parentName;
+        if (parentInstance != null)
+        {
+            parentName = parentInstance.Name;
+            string defaultChild = ObjectFinder.Self.GetDefaultChildName(parentInstance, _selectedState.SelectedStateSave);
+            if (!string.IsNullOrEmpty(defaultChild))
+            {
+                parentName += "." + defaultChild;
+            }
         }
         else
         {
-            string parentName;
-            string variableName = dragDroppedInstance.Name + ".Parent";
-
-            var siblings = new List<InstanceSave>();
-
-            if (targetObject is InstanceSave targetInstance)
-            {
-                // setting the parent:
-                parentName = targetInstance.Name;
-                string defaultChild = ObjectFinder.Self.GetDefaultChildName(targetInstance, _selectedState.SelectedStateSave);
-
-                if (!string.IsNullOrEmpty(defaultChild))
-                {
-                    parentName += "." + defaultChild;
-                }
-
-                foreach(var instance in targetElementSave.Instances)
-                {
-                    var instanceParent = targetElementSave.DefaultState.GetVariableRecursive(instance.Name + ".Parent")?.Value;
-
-                    if (instanceParent is string instanceParentAsString &&
-                        (instanceParentAsString == parentName || instanceParentAsString?.StartsWith($"{parentName}.") == true))
-                    {
-                        siblings.Add(instance);
-                    }
-                }
-            }
-            else
-            {
-                // drag+drop on the container, so detach:
-                parentName = null;
-                foreach (var instance in targetElementSave.Instances)
-                {
-                    var instanceParent = targetElementSave.DefaultState.GetVariableRecursive(instance.Name + ".Parent")?.Value;
-
-                    if (instanceParent == null || (instanceParent is string instanceParentAsString && string.IsNullOrWhiteSpace(instanceParentAsString)))
-                    {
-                        siblings.Add(instance);
-                    }
-                }
-            }
-
-            // index here is the caller's "position among target's children"
-            // (0..siblings.Count). Issue #2864: ProcessDrop can pass the flat
-            // Instances.Count for the InstanceSave-tag append case, which
-            // exceeds siblings.Count. Clamp index-1 to the last sibling so an
-            // out-of-range index lands after the last child (append), rather
-            // than falling through to indexToAddAt=0 (the visible "snap to top"
-            // immediately after the new instance was correctly added at the end).
-            InstanceSave? siblingAfter = null;
-            if (index > 0 && siblings.Count > 0)
-            {
-                int siblingIndex = Math.Min(index - 1, siblings.Count - 1);
-                siblingAfter = siblings[siblingIndex];
-            }
-
-            int indexToAddAt = 0;
-
-            if(siblingAfter != null)
-            {
-                indexToAddAt = targetElementSave.Instances.IndexOf(siblingAfter) + 1;
-            }
-
-            var droppedInstanceIndexBeforeMove = targetElementSave.Instances.IndexOf(dragDroppedInstance);
-
-            if(droppedInstanceIndexBeforeMove != -1 && droppedInstanceIndexBeforeMove != indexToAddAt)
-            {
-                if(indexToAddAt > droppedInstanceIndexBeforeMove)
-                {
-                    indexToAddAt -= 1;
-                }
-                targetElementSave.Instances.RemoveAt(droppedInstanceIndexBeforeMove);
-                targetElementSave.Instances.Insert(indexToAddAt, dragDroppedInstance);
-
-                _pluginManager.InstanceReordered(dragDroppedInstance);
-            }
-
-            // Since the Parent property can only be set in the default state, we will
-            // set the Parent variable on that instead of the _selectedState.SelectedStateSave
-            var stateToAssignOn = targetElementSave.DefaultState;
-
-            // todo - this needs to request the lock for the particular element
-            using var undoLock = _undoManager.RequestLock();
-
-            var oldValue = stateToAssignOn.GetValue(variableName) as string;
-            stateToAssignOn.SetValue(variableName, parentName, "string");
-
-
-            _setVariableLogic.PropertyValueChanged("Parent", oldValue, dragDroppedInstance, targetElementSave?.DefaultState);
-            targetTreeNode?.Expand();
+            // drag+drop on the container, so detach:
+            parentName = null;
         }
+
+        int flatListPosition = ResolveFlatListPositionForReorder(dropTarget, dragDroppedInstance);
+
+        int droppedInstanceIndexBeforeMove = targetElementSave.Instances.IndexOf(dragDroppedInstance);
+
+        if (droppedInstanceIndexBeforeMove != -1 && droppedInstanceIndexBeforeMove != flatListPosition)
+        {
+            targetElementSave.Instances.RemoveAt(droppedInstanceIndexBeforeMove);
+
+            if (flatListPosition > droppedInstanceIndexBeforeMove)
+            {
+                flatListPosition -= 1;
+            }
+            if (flatListPosition > targetElementSave.Instances.Count)
+            {
+                flatListPosition = targetElementSave.Instances.Count;
+            }
+            if (flatListPosition < 0)
+            {
+                flatListPosition = 0;
+            }
+
+            targetElementSave.Instances.Insert(flatListPosition, dragDroppedInstance);
+
+            _pluginManager.InstanceReordered(dragDroppedInstance);
+        }
+
+        // Since the Parent property can only be set in the default state, we will
+        // set the Parent variable on that instead of the _selectedState.SelectedStateSave
+        var stateToAssignOn = targetElementSave.DefaultState;
+
+        // todo - this needs to request the lock for the particular element
+        using var undoLock = _undoManager.RequestLock();
+
+        var oldValue = stateToAssignOn.GetValue(variableName) as string;
+        stateToAssignOn.SetValue(variableName, parentName, "string");
+
+        _setVariableLogic.PropertyValueChanged("Parent", oldValue, dragDroppedInstance, targetElementSave.DefaultState);
+        targetTreeNode?.Expand();
+    }
+
+    /// <summary>
+    /// Computes the flat-list index inside <c>dropTarget.ParentElement.Instances</c>
+    /// at which <paramref name="dragDroppedInstance"/> should land. For
+    /// <see cref="DropPosition.Append"/> on an instance-targeted drop, this
+    /// resolves to "after the last existing sibling-child"; for a direct
+    /// element drop it resolves to "end of list" (which is the same thing
+    /// since top-level instances are by definition the last in the flat list
+    /// when the invariant holds). Self-inclusion no longer needs special
+    /// handling because the caller's Remove/Insert math adjusts for the
+    /// dragged instance being in the list.
+    /// </summary>
+    private int ResolveFlatListPositionForReorder(DropTarget dropTarget, InstanceSave dragDroppedInstance)
+    {
+        ElementSave element = dropTarget.ParentElement;
+        switch (dropTarget.Position)
+        {
+            case DropPosition.Append:
+                if (dropTarget.ParentInstance == null)
+                {
+                    return element.Instances.Count;
+                }
+                // Append-onto-Instance: place after the last existing child of
+                // ParentInstance in the flat list. Excludes the dragged instance
+                // so reorder-onto-own-parent doesn't anchor on itself.
+                InstanceSave? lastSibling = FindLastSiblingOfParent(element, dropTarget.ParentInstance, dragDroppedInstance);
+                return lastSibling != null
+                    ? element.Instances.IndexOf(lastSibling) + 1
+                    : element.Instances.IndexOf(dropTarget.ParentInstance) + 1;
+            case DropPosition.InsertAt insertAt:
+                return Math.Clamp(insertAt.Index, 0, element.Instances.Count);
+            case DropPosition.BeforeSibling before:
+            {
+                int idx = element.Instances.IndexOf(before.Sibling);
+                return idx < 0 ? element.Instances.Count : idx;
+            }
+            case DropPosition.AfterSibling after:
+            {
+                int idx = element.Instances.IndexOf(after.Sibling);
+                return idx < 0 ? element.Instances.Count : idx + 1;
+            }
+            default:
+                return element.Instances.Count;
+        }
+    }
+
+    private static InstanceSave? FindLastSiblingOfParent(ElementSave element, InstanceSave parentInstance, InstanceSave excludeInstance)
+    {
+        string parentName = parentInstance.Name;
+        InstanceSave? last = null;
+        foreach (var instance in element.Instances)
+        {
+            if (instance == excludeInstance)
+            {
+                continue;
+            }
+            var parentValue = element.DefaultState.GetVariableRecursive(instance.Name + ".Parent")?.Value;
+            if (parentValue is string parentString &&
+                (parentString == parentName || parentString.StartsWith(parentName + ".")))
+            {
+                last = instance;
+            }
+        }
+        return last;
     }
 
     public void HandleKeyPress(KeyPressEventArgs e)
@@ -636,7 +694,7 @@ public class DragDropManager : IDragDropManager
 
     #region General Functions
 
-    public bool ValidateNodeSorting(IEnumerable<ITreeNode> draggedNodes, ITreeNode? targetNode, int index)
+    public bool ValidateNodeSorting(IEnumerable<ITreeNode> draggedNodes, ITreeNode? targetNode, DropTarget? dropTarget)
     {
         if (targetNode == null) return false;
 
@@ -804,24 +862,34 @@ public class DragDropManager : IDragDropManager
         return true;
     }
 
-    public void OnNodeSortingDropped(IEnumerable<ITreeNode> draggedNodes, ITreeNode targetNode, int index)
+    public void OnNodeSortingDropped(IEnumerable<ITreeNode> draggedNodes, ITreeNode targetNode, DropTarget? dropTarget)
     {
-        // Sort so that folders come first (they restructure the tree),
-        // then InstanceSaves by descending index (so insertion order is preserved).
-        var sortedNodes = draggedNodes
-            .OrderBy(n => n.Tag == null ? 0 : 1)
-            .ThenByDescending(n => n.Tag is InstanceSave instance
-                ? instance.ParentContainer?.Instances.IndexOf(instance) ?? int.MinValue
-                : int.MinValue)
+        // Sort so that folders come first (they restructure the tree), then
+        // InstanceSaves by source index. The direction depends on DropPosition:
+        // BeforeSibling places each item *before* the anchor sibling, so the
+        // first item processed ends up earlier in the list — process ascending
+        // to preserve drag-order. Append/AfterSibling/InsertAt stack each item
+        // *at* a fixed position, so processing descending preserves drag-order.
+        bool ascendingForSiblings = dropTarget?.Position is DropPosition.BeforeSibling;
+
+        var orderedByTag = draggedNodes.OrderBy(n => n.Tag == null ? 0 : 1);
+        var sortedNodes = (ascendingForSiblings
+            ? orderedByTag.ThenBy(InstanceSourceIndex)
+            : orderedByTag.ThenByDescending(InstanceSourceIndex))
             .ToList();
 
         using var undoLock = _undoManager.RequestLock();
 
         foreach (var node in sortedNodes)
         {
-            HandleDroppedItemOnTreeView(node, targetNode, index);
+            HandleDroppedItemOnTreeView(node, targetNode, dropTarget);
         }
     }
+
+    private static int InstanceSourceIndex(ITreeNode node) =>
+        node.Tag is InstanceSave instance
+            ? instance.ParentContainer?.Instances.IndexOf(instance) ?? int.MinValue
+            : int.MinValue;
 
     private void HandleDroppedFolder(ITreeNode draggedFolderNode, ITreeNode targetNode)
     {
@@ -918,7 +986,7 @@ public class DragDropManager : IDragDropManager
         }
     }
 
-    private void HandleDroppedItemOnTreeView(ITreeNode draggedNode, ITreeNode treeNodeDroppedOn, int index)
+    private void HandleDroppedItemOnTreeView(ITreeNode draggedNode, ITreeNode treeNodeDroppedOn, DropTarget? dropTarget)
     {
         var draggedObject = draggedNode.Tag;
         Console.WriteLine($"Dropping{draggedObject} on {treeNodeDroppedOn}");
@@ -932,11 +1000,11 @@ public class DragDropManager : IDragDropManager
             }
             else if (draggedObject is ElementSave)
             {
-                HandleDroppedElementSave(draggedObject, treeNodeDroppedOn, targetTag, treeNodeDroppedOn, index);
+                HandleDroppedElementSave(draggedObject, treeNodeDroppedOn, targetTag, treeNodeDroppedOn, dropTarget);
             }
             else if (draggedObject is InstanceSave)
             {
-                HandleDroppedInstance(draggedObject, treeNodeDroppedOn, index);
+                HandleDroppedInstance(draggedObject, treeNodeDroppedOn, dropTarget);
             }
             else if(draggedObject is BehaviorSave behaviorSave)
             {
@@ -960,8 +1028,8 @@ public class DragDropManager : IDragDropManager
             // into whatever edit comes next. (issue #2658)
             using var undoLock = _undoManager.RequestLock();
 
-            var index = target.Instances.Count;
-            var newInstance = HandleDroppedElementInElement(draggedAsElementSave, target, null, index);
+            DropTarget appendTarget = new DropTarget(target, null, new DropPosition.Append());
+            var newInstance = HandleDroppedElementInElement(draggedAsElementSave, target, null, appendTarget);
 
             float worldX, worldY;
 

--- a/Gum/Managers/IDragDropManager.cs
+++ b/Gum/Managers/IDragDropManager.cs
@@ -1,4 +1,5 @@
 using Gum.DataTypes;
+using Gum.Plugins.InternalPlugins.TreeView;
 using System.Collections.Generic;
 using System.Windows.Forms;
 
@@ -17,9 +18,15 @@ public interface IDragDropManager
     bool IsValidExtensionForFileDrop(string file);
     void OnFilesDroppedInTreeView(string[] files);
     void OnNodeObjectDroppedInWireframe(object draggedObject);
-    void OnNodeSortingDropped(IEnumerable<ITreeNode> draggedNodes, ITreeNode targetNode, int index);
+    /// <summary>
+    /// Handle a drag-drop reorder. <paramref name="dropTarget"/> describes the
+    /// destination element and flat-list position; it is null for folder or
+    /// behavior drops where flat-list semantics do not apply.
+    /// </summary>
+    void OnNodeSortingDropped(IEnumerable<ITreeNode> draggedNodes, ITreeNode targetNode, DropTarget? dropTarget);
     void OnWireframeDragEnter(object? sender, DragEventArgs e);
     void SetInstanceToPosition(float worldX, float worldY, InstanceSave instance);
-    bool ValidateNodeSorting(IEnumerable<ITreeNode> draggedNodes, ITreeNode targetNode, int index);
+    /// <inheritdoc cref="OnNodeSortingDropped"/>
+    bool ValidateNodeSorting(IEnumerable<ITreeNode> draggedNodes, ITreeNode targetNode, DropTarget? dropTarget);
     void HandleKeyPress(KeyPressEventArgs e);
 }

--- a/Gum/Plugins/InternalPlugins/TreeView/DropTarget.cs
+++ b/Gum/Plugins/InternalPlugins/TreeView/DropTarget.cs
@@ -1,0 +1,49 @@
+using Gum.DataTypes;
+
+namespace Gum.Plugins.InternalPlugins.TreeView;
+
+/// <summary>
+/// Describes a drop destination resolved by the tree view onto an
+/// <see cref="ElementSave"/>'s flat <see cref="ElementSave.Instances"/> list.
+/// Replaces the overloaded <c>int index</c> that previously meant different
+/// things to different downstream consumers (issue #2869).
+/// </summary>
+/// <param name="ParentElement">
+/// The Element whose <see cref="ElementSave.Instances"/> list receives the
+/// new (or moved) instance.
+/// </param>
+/// <param name="ParentInstance">
+/// The instance the dropped object should be visually parented under (its
+/// <c>.Parent</c> variable). Null when the drop is directly on the element.
+/// </param>
+/// <param name="Position">
+/// Where in <paramref name="ParentElement"/>'s flat instance list the drop
+/// lands. See <see cref="DropPosition"/>.
+/// </param>
+public sealed record DropTarget(
+    ElementSave ParentElement,
+    InstanceSave? ParentInstance,
+    DropPosition Position);
+
+/// <summary>
+/// Position within an <see cref="ElementSave"/>'s flat
+/// <see cref="ElementSave.Instances"/> list that a drop should land at.
+/// Each variant carries the information its consumer needs — no shared
+/// <c>int</c> with conflicting meanings.
+/// </summary>
+public abstract record DropPosition
+{
+    private DropPosition() { }
+
+    /// <summary>Append to the end of the parent element's flat instances list.</summary>
+    public sealed record Append : DropPosition;
+
+    /// <summary>Insert at the given flat-list index in the parent element's instances list.</summary>
+    public sealed record InsertAt(int Index) : DropPosition;
+
+    /// <summary>Insert immediately before the given existing sibling in the flat list.</summary>
+    public sealed record BeforeSibling(InstanceSave Sibling) : DropPosition;
+
+    /// <summary>Insert immediately after the given existing sibling in the flat list.</summary>
+    public sealed record AfterSibling(InstanceSave Sibling) : DropPosition;
+}

--- a/Gum/Plugins/InternalPlugins/TreeView/ElementTreeViewManager.cs
+++ b/Gum/Plugins/InternalPlugins/TreeView/ElementTreeViewManager.cs
@@ -720,9 +720,9 @@ public partial class ElementTreeViewManager : IRecipient<ThemeChangedMessage>, I
                 if (ProcessDrop(e.TargetNode, e.Kind) is { } drop)
                 {
                     IEnumerable<ITreeNode> wrappedNodes = e.DraggedNodes.Select(n => new TreeNodeWrapper(n));
-                    ITreeNode wrappedTarget = new TreeNodeWrapper(drop.target);
+                    ITreeNode wrappedTarget = new TreeNodeWrapper(drop.TreeTarget);
 
-                    e.Allow = _dragDropManager.ValidateNodeSorting(wrappedNodes, wrappedTarget, drop.index);
+                    e.Allow = _dragDropManager.ValidateNodeSorting(wrappedNodes, wrappedTarget, drop.Drop);
                 }
             },
             onNodeSortingDropped: (_, e) =>
@@ -730,13 +730,13 @@ public partial class ElementTreeViewManager : IRecipient<ThemeChangedMessage>, I
                 if (ProcessDrop(e.TargetNode, e.Kind) is { } drop)
                 {
                     IEnumerable<ITreeNode> wrappedNodes = e.DraggedNodes.Select(n => new TreeNodeWrapper(n));
-                    ITreeNode wrappedTarget = new TreeNodeWrapper(drop.target);
+                    ITreeNode wrappedTarget = new TreeNodeWrapper(drop.TreeTarget);
 
                     e.Kind = e.Kind == MultiSelectTreeView.DropKind.None
                         ? MultiSelectTreeView.DropKind.None
                         : MultiSelectTreeView.DropKind.Into;
 
-                    _dragDropManager.OnNodeSortingDropped(wrappedNodes, wrappedTarget, drop.index);
+                    _dragDropManager.OnNodeSortingDropped(wrappedNodes, wrappedTarget, drop.Drop);
                 }
                 e.PerformNativeReorder = false;
             },
@@ -773,16 +773,20 @@ public partial class ElementTreeViewManager : IRecipient<ThemeChangedMessage>, I
     }
 
     /// <summary>
-    /// Maps a tree drop (target node + kind) to the parent tree node it should
-    /// be inserted under and the index inside that parent's collection.
+    /// Maps a tree drop (target node + kind) to the tree node that becomes the
+    /// drop's container and a typed <see cref="DropTarget"/> describing where
+    /// the dragged item lands inside that container's flat instances list.
+    /// Returns the tree node alone (with a null <see cref="DropTarget"/>) for
+    /// folder/behavior drops where flat-list semantics do not apply.
     /// Internal so it can be unit-tested without instantiating the manager.
     /// </summary>
-    internal static (int index, TreeNode target)? ProcessDrop(TreeNode? originalTarget, MultiSelectTreeView.DropKind kind)
+    internal static (TreeNode TreeTarget, DropTarget? Drop)? ProcessDrop(TreeNode? originalTarget, MultiSelectTreeView.DropKind kind)
     {
         if (originalTarget == null)
         {
             return null;
         }
+
         // Issue #2864: a drop whose visual adornment is "rectangle around the
         // row" (Into and IntoFirst both draw the same box) must append to the
         // flat Instances list the new visual will be added to — never insert
@@ -790,40 +794,44 @@ public partial class ElementTreeViewManager : IRecipient<ThemeChangedMessage>, I
         // "box vs. line": box = append, line = insert at sibling position.
         // Inserting at index 0 is still reachable as DropKind.Before on the
         // parent's first child, which draws a line.
-        //
-        // For an InstanceSave-tagged target (dropping onto another instance to
-        // parent under it), the destination list is the ParentContainer's
-        // Instances — NOT the target's tree children, which only represent the
-        // subset already parented under it. Without this, dropping a Container
-        // onto another Container lands the new instance partway through the
-        // screen's flat Instances list, behind later siblings.
-        int? index = kind switch
+        switch (kind)
         {
-            MultiSelectTreeView.DropKind.Into or MultiSelectTreeView.DropKind.IntoFirst =>
-                originalTarget.Tag switch
+            case MultiSelectTreeView.DropKind.Into:
+            case MultiSelectTreeView.DropKind.IntoFirst:
+                switch (originalTarget.Tag)
                 {
-                    ElementSave element => element.Instances.Count,
-                    InstanceSave instance when instance.ParentContainer != null
-                        => instance.ParentContainer.Instances.Count,
-                    _ => originalTarget.GetNodeCount(false)
-                },
-            MultiSelectTreeView.DropKind.After => originalTarget.Index + 1,
-            MultiSelectTreeView.DropKind.Before => originalTarget.Index,
-            _ => null
-        };
-        TreeNode? target = kind switch
-        {
-            MultiSelectTreeView.DropKind.Into or MultiSelectTreeView.DropKind.IntoFirst => originalTarget,
-            MultiSelectTreeView.DropKind.After => originalTarget.Parent,
-            MultiSelectTreeView.DropKind.Before => originalTarget.Parent,
-            _ => null
-        };
-        if (target != null && index != null)
-        {
-            return (index.Value, target);
+                    case ElementSave element:
+                        return (originalTarget, new DropTarget(element, null, new DropPosition.Append()));
+                    case InstanceSave instance when instance.ParentContainer != null:
+                        return (originalTarget, new DropTarget(instance.ParentContainer, instance, new DropPosition.Append()));
+                    default:
+                        // Folder/behavior drops: no flat-list semantics. The caller
+                        // routes by treeNode kind (IsTopComponentContainerTreeNode etc.).
+                        return (originalTarget, null);
+                }
+            case MultiSelectTreeView.DropKind.After:
+            case MultiSelectTreeView.DropKind.Before:
+            {
+                TreeNode? parent = originalTarget.Parent;
+                if (parent == null)
+                {
+                    return null;
+                }
+                if (originalTarget.Tag is InstanceSave sibling && sibling.ParentContainer != null)
+                {
+                    InstanceSave? parentInstance = parent.Tag as InstanceSave;
+                    DropPosition position = kind == MultiSelectTreeView.DropKind.Before
+                        ? new DropPosition.BeforeSibling(sibling)
+                        : new DropPosition.AfterSibling(sibling);
+                    return (parent, new DropTarget(sibling.ParentContainer, parentInstance, position));
+                }
+                // Reordering element/folder/behavior nodes does not feed an
+                // instances list — the downstream consumer reads the tree node.
+                return (parent, null);
+            }
+            default:
+                return null;
         }
-
-        return null;
     }
 
 

--- a/Tool/Tests/GumToolUnitTests/Managers/DragDropManagerTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Managers/DragDropManagerTests.cs
@@ -592,6 +592,99 @@ public class DragDropManagerTests : BaseTestClass
     }
 
     [Fact]
+    public void OnNodeSortingDropped_DropInstanceOnItsCurrentParent_IsNoOp()
+    {
+        // Dropping an instance onto its current parent must not reorder the
+        // flat list. The user's intent for "drop on parent" is "make this a
+        // child of parent" — already satisfied when the Parent variable
+        // already references that parent. Moving the instance to the end of
+        // its sibling group is a side effect of treating Append as
+        // "stack at end of siblings" unconditionally, which surprises the
+        // user (the visual jumps with no apparent reason).
+        //
+        // The reorder must still happen for explicit BeforeSibling/AfterSibling
+        // drops where the user actively chose a new position.
+        ScreenSave screen = new ScreenSave();
+        screen.Name = "MainScreen";
+        screen.States.Add(new StateSave { Name = "Default" });
+
+        InstanceSave container = new InstanceSave { Name = "Container", ParentContainer = screen };
+        screen.Instances.Add(container);
+
+        InstanceSave childA = new InstanceSave { Name = "ChildA", ParentContainer = screen };
+        screen.Instances.Add(childA);
+        screen.DefaultState.SetValue("ChildA.Parent", "Container", "string");
+
+        InstanceSave childB = new InstanceSave { Name = "ChildB", ParentContainer = screen };
+        screen.Instances.Add(childB);
+        screen.DefaultState.SetValue("ChildB.Parent", "Container", "string");
+
+        InstanceSave childC = new InstanceSave { Name = "ChildC", ParentContainer = screen };
+        screen.Instances.Add(childC);
+        screen.DefaultState.SetValue("ChildC.Parent", "Container", "string");
+
+        int originalIndexOfChildA = screen.Instances.IndexOf(childA);
+
+        _circularReferenceManager
+            .Setup(x => x.CanTypeBeAddedToElement(It.IsAny<ElementSave>(), It.IsAny<string>()))
+            .Returns(true);
+
+        _mocker.GetMock<ISelectedState>()
+            .Setup(x => x.SelectedStateSave).Returns(screen.DefaultState);
+
+        Mock<ITreeNode> draggedNode = new Mock<ITreeNode>();
+        draggedNode.Setup(x => x.Tag).Returns(childA);
+
+        Mock<ITreeNode> targetNode = new Mock<ITreeNode>();
+        targetNode.Setup(x => x.Tag).Returns(container);
+
+        // Drop ChildA onto its current parent (Container).
+        DropTarget dropTarget = new DropTarget(screen, container, new DropPosition.Append());
+        _dragDropManager.OnNodeSortingDropped(new List<ITreeNode> { draggedNode.Object }, targetNode.Object, dropTarget);
+
+        screen.Instances.IndexOf(childA).ShouldBe(originalIndexOfChildA,
+            "ChildA was already a child of Container; dropping on the parent must not reposition.");
+    }
+
+    [Fact]
+    public void OnNodeSortingDropped_DropTopLevelInstanceOnContainingElement_IsNoOp()
+    {
+        // Mirror of the parent-reaffirmation case: a top-level instance dropped
+        // onto its containing Element (no parent change) must not be reordered.
+        ScreenSave screen = new ScreenSave();
+        screen.Name = "MainScreen";
+        screen.States.Add(new StateSave { Name = "Default" });
+
+        InstanceSave first = new InstanceSave { Name = "First", ParentContainer = screen };
+        InstanceSave second = new InstanceSave { Name = "Second", ParentContainer = screen };
+        InstanceSave third = new InstanceSave { Name = "Third", ParentContainer = screen };
+        screen.Instances.Add(first);
+        screen.Instances.Add(second);
+        screen.Instances.Add(third);
+
+        int originalIndexOfFirst = screen.Instances.IndexOf(first);
+
+        _circularReferenceManager
+            .Setup(x => x.CanTypeBeAddedToElement(It.IsAny<ElementSave>(), It.IsAny<string>()))
+            .Returns(true);
+
+        _mocker.GetMock<ISelectedState>()
+            .Setup(x => x.SelectedStateSave).Returns(screen.DefaultState);
+
+        Mock<ITreeNode> draggedNode = new Mock<ITreeNode>();
+        draggedNode.Setup(x => x.Tag).Returns(first);
+
+        Mock<ITreeNode> targetNode = new Mock<ITreeNode>();
+        targetNode.Setup(x => x.Tag).Returns(screen);
+
+        DropTarget dropTarget = new DropTarget(screen, null, new DropPosition.Append());
+        _dragDropManager.OnNodeSortingDropped(new List<ITreeNode> { draggedNode.Object }, targetNode.Object, dropTarget);
+
+        screen.Instances.IndexOf(first).ShouldBe(originalIndexOfFirst,
+            "First was already a top-level instance; dropping on the element must not reposition.");
+    }
+
+    [Fact]
     public void OnNodeSortingDropped_DropElementOnInstance_PreservesFlatListInvariant()
     {
         // Issue #2869: after any drop operation, the flat Instances list must

--- a/Tool/Tests/GumToolUnitTests/Managers/DragDropManagerTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Managers/DragDropManagerTests.cs
@@ -4,6 +4,7 @@ using Gum.Logic;
 using Gum.Managers;
 using Gum.Plugins;
 using Gum.Plugins.BaseClasses;
+using Gum.Plugins.InternalPlugins.TreeView;
 using Gum.Services;
 using Gum.ToolCommands;
 using Gum.ToolStates;
@@ -86,8 +87,10 @@ public class DragDropManagerTests : BaseTestClass
                 It.IsAny<HashSet<string>?>()))
             .Returns(new List<InstanceSave> { draggedInstance });
 
+        DropTarget dropTarget = new DropTarget(destinationComponent, null, new DropPosition.InsertAt(1));
+
         // Act
-        _dragDropManager.OnNodeSortingDropped(draggedNodes, targetNode.Object, 1);
+        _dragDropManager.OnNodeSortingDropped(draggedNodes, targetNode.Object, dropTarget);
 
         // Assert
         destinationComponent.Instances[1].Name.ShouldBe("DraggedInstance");
@@ -134,8 +137,9 @@ public class DragDropManagerTests : BaseTestClass
             .Setup(x => x.CanTypeBeAddedToElement(It.IsAny<ElementSave>(), It.IsAny<string>()))
             .Returns(true);
 
-        // Act — drop at index 0 (beginning, before A)
-        _dragDropManager.OnNodeSortingDropped(draggedNodes, targetNode.Object, 0);
+        // Act — drop at beginning, i.e. before A.
+        DropTarget dropTarget = new DropTarget(element, null, new DropPosition.BeforeSibling(instanceA));
+        _dragDropManager.OnNodeSortingDropped(draggedNodes, targetNode.Object, dropTarget);
 
         // Assert — B should appear before D (relative order preserved), both at the beginning
         int indexOfB = element.Instances.IndexOf(instanceB);
@@ -187,8 +191,9 @@ public class DragDropManagerTests : BaseTestClass
             .Setup(x => x.CanTypeBeAddedToElement(It.IsAny<ElementSave>(), It.IsAny<string>()))
             .Returns(true);
 
-        // Act — drop at index 3 (after C, which is siblings[2])
-        _dragDropManager.OnNodeSortingDropped(draggedNodes, targetNode.Object, 3);
+        // Act — drop after C.
+        DropTarget dropTarget = new DropTarget(element, null, new DropPosition.AfterSibling(instanceC));
+        _dragDropManager.OnNodeSortingDropped(draggedNodes, targetNode.Object, dropTarget);
 
         // Assert — B should appear before D (relative order preserved), both after A and C
         int indexOfA = element.Instances.IndexOf(instanceA);
@@ -248,8 +253,10 @@ public class DragDropManagerTests : BaseTestClass
                 It.IsAny<HashSet<string>?>()))
             .Returns(new List<InstanceSave> { draggedInstance });
 
+        DropTarget dropTarget = new DropTarget(destinationComponent, null, new DropPosition.InsertAt(1));
+
         // Act - should not throw even with folder nodes in the list
-        _dragDropManager.OnNodeSortingDropped(draggedNodes, targetNode.Object, 1);
+        _dragDropManager.OnNodeSortingDropped(draggedNodes, targetNode.Object, dropTarget);
 
         // Assert - the tagged instance was still processed correctly despite folder node presence
         destinationComponent.Instances[1].Name.ShouldBe(draggedInstanceName);
@@ -264,7 +271,7 @@ public class DragDropManagerTests : BaseTestClass
 
         // Act
         var result = _dragDropManager.ValidateNodeSorting(
-            new[] { draggedNode.Object }, null, 0);
+            new[] { draggedNode.Object }, null, dropTarget: null);
 
         // Assert
         result.ShouldBeFalse();
@@ -285,7 +292,7 @@ public class DragDropManagerTests : BaseTestClass
         // Act - should not throw; returns false because mocked ITreeNode
         // isn't recognized as a component/screen folder by extension methods
         var result = _dragDropManager.ValidateNodeSorting(
-            new[] { folderNode.Object }, targetNode.Object, 0);
+            new[] { folderNode.Object }, targetNode.Object, dropTarget: null);
 
         // Assert
         result.ShouldBeFalse();
@@ -461,12 +468,13 @@ public class DragDropManagerTests : BaseTestClass
 
         List<ITreeNode> draggedNodes = new() { draggedNode.Object };
 
-        // ProcessDrop's Into-on-InstanceSave returns ParentContainer.Instances.Count
-        // — past the end of the siblings list. This is the index that triggers
-        // the "snap to top" before the fix.
-        int indexFromProcessDrop = screen.Instances.Count;
+        // ProcessDrop's Into-on-InstanceSave returns DropTarget(screen, leftContainer, Append).
+        // Pre-#2869 the int-index path could send Instances.Count downstream and
+        // mis-trigger the "snap to top." With the typed DropTarget the consumer
+        // resolves position from ParentInstance directly.
+        DropTarget dropTarget = new DropTarget(screen, leftContainer, new DropPosition.Append());
 
-        _dragDropManager.OnNodeSortingDropped(draggedNodes, targetNode.Object, indexFromProcessDrop);
+        _dragDropManager.OnNodeSortingDropped(draggedNodes, targetNode.Object, dropTarget);
 
         InstanceSave? newInstance = screen.Instances.FirstOrDefault(i => i.Name == "DraggedComponent1");
         newInstance.ShouldNotBeNull();
@@ -475,6 +483,156 @@ public class DragDropManagerTests : BaseTestClass
         int lastExistingChildIndex = screen.Instances.IndexOf(screen.Instances.First(i => i.Name == "Child3"));
         newIndex.ShouldBeGreaterThan(lastExistingChildIndex,
             "the dropped instance must remain after the last existing child of the target container, not snap back to index 0");
+    }
+
+    [Fact]
+    public void OnNodeSortingDropped_DropElementOnInstance_PreservesFlatListInvariant()
+    {
+        // Issue #2869: after any drop operation, the flat Instances list must
+        // satisfy the invariant "for every instance, all of its children come
+        // after it in the list." This drives render z-order — when violated,
+        // children render behind their parent (the #2864 user-visible bug).
+        ScreenSave screen = new ScreenSave();
+        screen.Name = "MainScreen";
+        screen.States.Add(new StateSave { Name = "Default" });
+
+        InstanceSave leftContainer = new InstanceSave { Name = "LeftContainer", ParentContainer = screen };
+        screen.Instances.Add(leftContainer);
+        for (int i = 0; i < 3; i++)
+        {
+            string childName = $"Child{i}";
+            InstanceSave child = new InstanceSave { Name = childName, ParentContainer = screen };
+            screen.Instances.Add(child);
+            screen.DefaultState.SetValue($"{childName}.Parent", "LeftContainer", "string");
+        }
+        for (int i = 0; i < 5; i++)
+        {
+            screen.Instances.Add(new InstanceSave { Name = $"TopLevel{i}", ParentContainer = screen });
+        }
+
+        ComponentSave draggedComponent = new ComponentSave();
+        draggedComponent.Name = "DraggedComponent";
+        draggedComponent.States.Add(new StateSave { Name = "Default" });
+
+        _circularReferenceManager
+            .Setup(x => x.CanTypeBeAddedToElement(It.IsAny<ElementSave>(), It.IsAny<string>()))
+            .Returns(true);
+
+        _mocker.GetMock<ISelectedState>()
+            .Setup(x => x.SelectedStateSave).Returns(screen.DefaultState);
+
+        _mocker.GetMock<IElementCommands>()
+            .Setup(x => x.GetUniqueNameForNewInstance(It.IsAny<ElementSave>(), It.IsAny<ElementSave>()))
+            .Returns("DraggedComponent1");
+
+        _mocker.GetMock<IElementCommands>()
+            .Setup(x => x.AddInstance(
+                It.IsAny<ElementSave>(),
+                It.IsAny<string>(),
+                It.IsAny<string?>(),
+                It.IsAny<string?>(),
+                It.IsAny<int?>()))
+            .Returns((ElementSave element, string name, string? type, string? parentName, int? desiredIndex) =>
+            {
+                InstanceSave inst = new InstanceSave
+                {
+                    Name = name,
+                    BaseType = type ?? string.Empty,
+                    ParentContainer = element
+                };
+                if (desiredIndex.HasValue)
+                {
+                    element.Instances.Insert(desiredIndex.Value, inst);
+                }
+                else
+                {
+                    element.Instances.Add(inst);
+                }
+                if (!string.IsNullOrEmpty(parentName))
+                {
+                    element.DefaultState.SetValue($"{inst.Name}.Parent", parentName, "string");
+                }
+                return inst;
+            });
+
+        Mock<ITreeNode> draggedNode = new Mock<ITreeNode>();
+        draggedNode.Setup(x => x.Tag).Returns(draggedComponent);
+
+        Mock<ITreeNode> targetNode = new Mock<ITreeNode>();
+        targetNode.Setup(x => x.Tag).Returns(leftContainer);
+
+        List<ITreeNode> draggedNodes = new() { draggedNode.Object };
+
+        DropTarget dropTarget = new DropTarget(screen, leftContainer, new DropPosition.Append());
+        _dragDropManager.OnNodeSortingDropped(draggedNodes, targetNode.Object, dropTarget);
+
+        AssertFlatListChildAfterParentInvariant(screen);
+    }
+
+    [Fact]
+    public void OnNodeSortingDropped_ReorderInstanceWithinSameParent_PreservesFlatListInvariant()
+    {
+        ScreenSave screen = new ScreenSave();
+        screen.Name = "MainScreen";
+        screen.States.Add(new StateSave { Name = "Default" });
+
+        InstanceSave container = new InstanceSave { Name = "Container", ParentContainer = screen };
+        screen.Instances.Add(container);
+        InstanceSave childA = new InstanceSave { Name = "ChildA", ParentContainer = screen };
+        screen.Instances.Add(childA);
+        screen.DefaultState.SetValue("ChildA.Parent", "Container", "string");
+        InstanceSave childB = new InstanceSave { Name = "ChildB", ParentContainer = screen };
+        screen.Instances.Add(childB);
+        screen.DefaultState.SetValue("ChildB.Parent", "Container", "string");
+        InstanceSave childC = new InstanceSave { Name = "ChildC", ParentContainer = screen };
+        screen.Instances.Add(childC);
+        screen.DefaultState.SetValue("ChildC.Parent", "Container", "string");
+
+        _circularReferenceManager
+            .Setup(x => x.CanTypeBeAddedToElement(It.IsAny<ElementSave>(), It.IsAny<string>()))
+            .Returns(true);
+
+        _mocker.GetMock<ISelectedState>()
+            .Setup(x => x.SelectedStateSave).Returns(screen.DefaultState);
+
+        // Reorder ChildC to be after ChildA (i.e. between A and B among the container's children).
+        Mock<ITreeNode> draggedNode = new Mock<ITreeNode>();
+        draggedNode.Setup(x => x.Tag).Returns(childC);
+
+        Mock<ITreeNode> targetNode = new Mock<ITreeNode>();
+        targetNode.Setup(x => x.Tag).Returns(container);
+
+        List<ITreeNode> draggedNodes = new() { draggedNode.Object };
+
+        // Place ChildC before ChildB (the second of the container's children).
+        DropTarget dropTarget = new DropTarget(screen, container, new DropPosition.BeforeSibling(childB));
+        _dragDropManager.OnNodeSortingDropped(draggedNodes, targetNode.Object, dropTarget);
+
+        AssertFlatListChildAfterParentInvariant(screen);
+    }
+
+    private static void AssertFlatListChildAfterParentInvariant(ElementSave element)
+    {
+        // For every instance I in element.Instances, every other instance whose
+        // Parent variable references I (or a default-child of I) must appear
+        // at a later flat-list index than I. Violating this swaps render order.
+        for (int i = 0; i < element.Instances.Count; i++)
+        {
+            InstanceSave parent = element.Instances[i];
+            for (int j = 0; j < element.Instances.Count; j++)
+            {
+                if (i == j) continue;
+                InstanceSave candidate = element.Instances[j];
+                object? parentValue = element.DefaultState.GetVariableRecursive(candidate.Name + ".Parent")?.Value;
+                if (parentValue is string parentString &&
+                    (parentString == parent.Name || parentString.StartsWith(parent.Name + ".")))
+                {
+                    j.ShouldBeGreaterThan(i,
+                        $"Flat-list invariant violated: {candidate.Name} (parented under {parent.Name}) " +
+                        $"appears at index {j}, before its parent at index {i}.");
+                }
+            }
+        }
     }
 
     [Fact]
@@ -491,7 +649,7 @@ public class DragDropManagerTests : BaseTestClass
 
         // Act - should not throw; folder processing gracefully skips
         // because mocked nodes don't pass IsComponentsFolderTreeNode check
-        _dragDropManager.OnNodeSortingDropped(draggedNodes, targetNode.Object, 0);
+        _dragDropManager.OnNodeSortingDropped(draggedNodes, targetNode.Object, dropTarget: null);
 
         // Assert - no exception thrown is the success condition
     }

--- a/Tool/Tests/GumToolUnitTests/Managers/DragDropManagerTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Managers/DragDropManagerTests.cs
@@ -97,6 +97,112 @@ public class DragDropManagerTests : BaseTestClass
     }
 
     [Fact]
+    public void OnNodeSortingDropped_BeforeSibling_MultipleInstances_AscendingSortPreservesSourceOrder()
+    {
+        // Issue #2869 pin: BeforeSibling anchors at a sibling whose flat-list
+        // index shifts down every time an earlier item is inserted before it.
+        // Processing items in DESCENDING source-index order (the natural
+        // "stack at a fixed position" sort) would invert drag order — the
+        // higher-source-index item lands at the original anchor, then the
+        // lower-source-index item lands in front of it. ASCENDING order is
+        // required to preserve drag order. This test guards against a
+        // "simplify OnNodeSortingDropped to always-descending" regression.
+        //
+        // Scenario: [A, B, C, D, E]; drag B(src=1) and D(src=3); drop BeforeSibling(A).
+        // Ascending: B → [B, A, C, D, E]; D → [B, D, A, C, E]. B at 0, D at 1.
+        // Descending: D → [D, A, B, C, E]; B → [D, B, A, C, E]. D at 0, B at 1. WRONG.
+        ComponentSave element = new ComponentSave();
+        element.States.Add(new StateSave());
+
+        InstanceSave instanceA = new InstanceSave { Name = "A", ParentContainer = element };
+        InstanceSave instanceB = new InstanceSave { Name = "B", ParentContainer = element };
+        InstanceSave instanceC = new InstanceSave { Name = "C", ParentContainer = element };
+        InstanceSave instanceD = new InstanceSave { Name = "D", ParentContainer = element };
+        InstanceSave instanceE = new InstanceSave { Name = "E", ParentContainer = element };
+        element.Instances.Add(instanceA);
+        element.Instances.Add(instanceB);
+        element.Instances.Add(instanceC);
+        element.Instances.Add(instanceD);
+        element.Instances.Add(instanceE);
+
+        // Arrival order is intentionally NOT source order — sort direction
+        // must be derived from source index, not arrival order.
+        Mock<ITreeNode> nodeDraggedD = new Mock<ITreeNode>();
+        nodeDraggedD.Setup(x => x.Tag).Returns(instanceD);
+        Mock<ITreeNode> nodeDraggedB = new Mock<ITreeNode>();
+        nodeDraggedB.Setup(x => x.Tag).Returns(instanceB);
+
+        Mock<ITreeNode> targetNode = new Mock<ITreeNode>();
+        targetNode.Setup(x => x.Tag).Returns(element);
+
+        List<ITreeNode> draggedNodes = new() { nodeDraggedD.Object, nodeDraggedB.Object };
+
+        _circularReferenceManager
+            .Setup(x => x.CanTypeBeAddedToElement(It.IsAny<ElementSave>(), It.IsAny<string>()))
+            .Returns(true);
+
+        DropTarget dropTarget = new DropTarget(element, null, new DropPosition.BeforeSibling(instanceA));
+
+        _dragDropManager.OnNodeSortingDropped(draggedNodes, targetNode.Object, dropTarget);
+
+        element.Instances.IndexOf(instanceB).ShouldBe(0,
+            "B (lower source index) must precede D in the result — ascending sort is required for BeforeSibling.");
+        element.Instances.IndexOf(instanceD).ShouldBe(1);
+    }
+
+    [Fact]
+    public void OnNodeSortingDropped_AfterSibling_MultipleInstances_DescendingSortPreservesSourceOrder()
+    {
+        // Issue #2869 pin: AfterSibling anchors at a sibling whose flat-list
+        // index does NOT shift when a later item is inserted after it.
+        // Processing items in DESCENDING source-index order preserves drag
+        // order — each item stacks at IndexOf(sibling)+1, and the second
+        // item displaces the first one further down the list. ASCENDING
+        // would invert drag order. This test guards against a "simplify
+        // OnNodeSortingDropped to always-ascending" regression.
+        //
+        // Scenario: [A, B, C, D, E]; drag B(src=1) and D(src=3); drop AfterSibling(C).
+        // Descending: D → [A, B, C, D, E]; B → [A, C, B, D, E]. B at 2, D at 3.
+        // Ascending: B → [A, C, B, D, E]; D → [A, C, D, B, E]. D at 2, B at 3. WRONG.
+        ComponentSave element = new ComponentSave();
+        element.States.Add(new StateSave());
+
+        InstanceSave instanceA = new InstanceSave { Name = "A", ParentContainer = element };
+        InstanceSave instanceB = new InstanceSave { Name = "B", ParentContainer = element };
+        InstanceSave instanceC = new InstanceSave { Name = "C", ParentContainer = element };
+        InstanceSave instanceD = new InstanceSave { Name = "D", ParentContainer = element };
+        InstanceSave instanceE = new InstanceSave { Name = "E", ParentContainer = element };
+        element.Instances.Add(instanceA);
+        element.Instances.Add(instanceB);
+        element.Instances.Add(instanceC);
+        element.Instances.Add(instanceD);
+        element.Instances.Add(instanceE);
+
+        Mock<ITreeNode> nodeDraggedD = new Mock<ITreeNode>();
+        nodeDraggedD.Setup(x => x.Tag).Returns(instanceD);
+        Mock<ITreeNode> nodeDraggedB = new Mock<ITreeNode>();
+        nodeDraggedB.Setup(x => x.Tag).Returns(instanceB);
+
+        Mock<ITreeNode> targetNode = new Mock<ITreeNode>();
+        targetNode.Setup(x => x.Tag).Returns(element);
+
+        // Arrival order is intentionally NOT source order.
+        List<ITreeNode> draggedNodes = new() { nodeDraggedB.Object, nodeDraggedD.Object };
+
+        _circularReferenceManager
+            .Setup(x => x.CanTypeBeAddedToElement(It.IsAny<ElementSave>(), It.IsAny<string>()))
+            .Returns(true);
+
+        DropTarget dropTarget = new DropTarget(element, null, new DropPosition.AfterSibling(instanceC));
+
+        _dragDropManager.OnNodeSortingDropped(draggedNodes, targetNode.Object, dropTarget);
+
+        element.Instances.IndexOf(instanceB).ShouldBe(2,
+            "B (lower source index) must precede D in the result — descending sort is required for AfterSibling.");
+        element.Instances.IndexOf(instanceD).ShouldBe(3);
+    }
+
+    [Fact]
     public void OnNodeSortingDropped_MultipleInstances_PreservesRelativeOrder_WhenDroppedAtBeginning()
     {
         // Arrange

--- a/Tool/Tests/GumToolUnitTests/Plugins/InternalPlugins/TreeView/ElementTreeViewManagerProcessDropTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/InternalPlugins/TreeView/ElementTreeViewManagerProcessDropTests.cs
@@ -1,6 +1,7 @@
 using CommonFormsAndControls;
 using Gum.DataTypes;
 using Gum.Managers;
+using Gum.Plugins.InternalPlugins.TreeView;
 using Shouldly;
 using System.Windows.Forms;
 using Xunit;
@@ -44,18 +45,21 @@ public class ElementTreeViewManagerProcessDropTests : BaseTestClass
         var result = ElementTreeViewManager.ProcessDrop(target, MultiSelectTreeView.DropKind.IntoFirst);
 
         result.ShouldNotBeNull();
-        result.Value.target.ShouldBe(target);
-        result.Value.index.ShouldBe(component.Instances.Count);
+        result.Value.TreeTarget.ShouldBe(target);
+        result.Value.Drop.ShouldNotBeNull();
+        result.Value.Drop!.ParentElement.ShouldBe(component);
+        result.Value.Drop!.ParentInstance.ShouldBeNull();
+        result.Value.Drop!.Position.ShouldBeOfType<DropPosition.Append>();
     }
 
     [Fact]
-    public void ProcessDrop_IntoElementSave_ReturnsInstancesCount_SoCallerAppends()
+    public void ProcessDrop_IntoElementSave_ReturnsAppendOnElement()
     {
         // Issue #2864: dropping a component into a screen tree node landed at
         // index 0 because the index path returned a tree-child-derived value
-        // that did not line up with the element's Instances list. The correct
-        // index for an "into-this-element" drop is Instances.Count — i.e.
-        // append to the end so the new visual renders on top, not behind.
+        // that did not line up with the element's Instances list. Issue #2869:
+        // the typed result eliminates the int-index ambiguity entirely — the
+        // consumer receives an Append on the element.
         ScreenSave screen = new ScreenSave();
         screen.Name = "TargetScreen";
         screen.Instances.Add(new InstanceSave { Name = "Existing1" });
@@ -67,19 +71,21 @@ public class ElementTreeViewManagerProcessDropTests : BaseTestClass
         var result = ElementTreeViewManager.ProcessDrop(target, MultiSelectTreeView.DropKind.Into);
 
         result.ShouldNotBeNull();
-        result.Value.target.ShouldBe(target);
-        result.Value.index.ShouldBe(screen.Instances.Count);
+        result.Value.TreeTarget.ShouldBe(target);
+        result.Value.Drop.ShouldNotBeNull();
+        result.Value.Drop!.ParentElement.ShouldBe(screen);
+        result.Value.Drop!.ParentInstance.ShouldBeNull();
+        result.Value.Drop!.Position.ShouldBeOfType<DropPosition.Append>();
     }
 
     [Fact]
-    public void ProcessDrop_IntoInstanceSave_ReturnsParentContainerInstancesCount_SoCallerAppends()
+    public void ProcessDrop_IntoInstanceSave_ReturnsAppendWithParentInstance()
     {
         // Issue #2864 follow-up: dropping a Container onto another Container
         // (target Tag is an InstanceSave) landed the new instance in the
-        // middle of MainScreen.Instances. The destination flat list is the
-        // ParentContainer's Instances; the index for an "into this instance"
-        // drop must be that list's count so callers append and the new visual
-        // renders on top.
+        // middle of MainScreen.Instances. Issue #2869: the typed Append +
+        // ParentInstance carries the intent without an int-index that could
+        // be reinterpreted downstream.
         ScreenSave screen = new ScreenSave();
         screen.Name = "MainScreen";
         InstanceSave leftContainer = new InstanceSave { Name = "LeftContainer", ParentContainer = screen };
@@ -100,13 +106,73 @@ public class ElementTreeViewManagerProcessDropTests : BaseTestClass
         var result = ElementTreeViewManager.ProcessDrop(target, MultiSelectTreeView.DropKind.Into);
 
         result.ShouldNotBeNull();
-        result.Value.target.ShouldBe(target);
-        result.Value.index.ShouldBe(screen.Instances.Count);
+        result.Value.TreeTarget.ShouldBe(target);
+        result.Value.Drop.ShouldNotBeNull();
+        result.Value.Drop!.ParentElement.ShouldBe(screen);
+        result.Value.Drop!.ParentInstance.ShouldBe(leftContainer);
+        result.Value.Drop!.Position.ShouldBeOfType<DropPosition.Append>();
     }
 
     [Fact]
-    public void ProcessDrop_BeforeSibling_ReturnsSiblingIndexOnParent()
+    public void ProcessDrop_BeforeInstanceSibling_ReturnsBeforeSiblingOnParent()
     {
+        ScreenSave screen = new ScreenSave();
+        screen.Name = "Screen";
+        InstanceSave first = new InstanceSave { Name = "First", ParentContainer = screen };
+        InstanceSave second = new InstanceSave { Name = "Second", ParentContainer = screen };
+        screen.Instances.Add(first);
+        screen.Instances.Add(second);
+
+        TreeNode parent = new TreeNode { Tag = screen };
+        TreeNode firstNode = parent.Nodes.Add("First");
+        firstNode.Tag = first;
+        TreeNode secondNode = parent.Nodes.Add("Second");
+        secondNode.Tag = second;
+
+        var result = ElementTreeViewManager.ProcessDrop(secondNode, MultiSelectTreeView.DropKind.Before);
+
+        result.ShouldNotBeNull();
+        result.Value.TreeTarget.ShouldBe(parent);
+        result.Value.Drop.ShouldNotBeNull();
+        result.Value.Drop!.ParentElement.ShouldBe(screen);
+        result.Value.Drop!.ParentInstance.ShouldBeNull();
+        DropPosition.BeforeSibling before = result.Value.Drop!.Position.ShouldBeOfType<DropPosition.BeforeSibling>();
+        before.Sibling.ShouldBe(second);
+    }
+
+    [Fact]
+    public void ProcessDrop_AfterInstanceSibling_ReturnsAfterSiblingOnParent()
+    {
+        ScreenSave screen = new ScreenSave();
+        screen.Name = "Screen";
+        InstanceSave first = new InstanceSave { Name = "First", ParentContainer = screen };
+        InstanceSave second = new InstanceSave { Name = "Second", ParentContainer = screen };
+        screen.Instances.Add(first);
+        screen.Instances.Add(second);
+
+        TreeNode parent = new TreeNode { Tag = screen };
+        TreeNode firstNode = parent.Nodes.Add("First");
+        firstNode.Tag = first;
+        TreeNode secondNode = parent.Nodes.Add("Second");
+        secondNode.Tag = second;
+
+        var result = ElementTreeViewManager.ProcessDrop(firstNode, MultiSelectTreeView.DropKind.After);
+
+        result.ShouldNotBeNull();
+        result.Value.TreeTarget.ShouldBe(parent);
+        result.Value.Drop.ShouldNotBeNull();
+        result.Value.Drop!.ParentElement.ShouldBe(screen);
+        result.Value.Drop!.ParentInstance.ShouldBeNull();
+        DropPosition.AfterSibling after = result.Value.Drop!.Position.ShouldBeOfType<DropPosition.AfterSibling>();
+        after.Sibling.ShouldBe(first);
+    }
+
+    [Fact]
+    public void ProcessDrop_BeforeNonInstanceSibling_ReturnsNullDrop()
+    {
+        // Reordering element nodes (or other non-InstanceSave-tagged nodes)
+        // does not feed an instances list — the downstream consumer should
+        // route by tree node alone.
         TreeNode parent = new TreeNode();
         TreeNode first = parent.Nodes.Add("First");
         TreeNode second = parent.Nodes.Add("Second");
@@ -114,21 +180,7 @@ public class ElementTreeViewManagerProcessDropTests : BaseTestClass
         var result = ElementTreeViewManager.ProcessDrop(second, MultiSelectTreeView.DropKind.Before);
 
         result.ShouldNotBeNull();
-        result.Value.target.ShouldBe(parent);
-        result.Value.index.ShouldBe(1);
-    }
-
-    [Fact]
-    public void ProcessDrop_AfterSibling_ReturnsSiblingIndexPlusOneOnParent()
-    {
-        TreeNode parent = new TreeNode();
-        TreeNode first = parent.Nodes.Add("First");
-        TreeNode second = parent.Nodes.Add("Second");
-
-        var result = ElementTreeViewManager.ProcessDrop(first, MultiSelectTreeView.DropKind.After);
-
-        result.ShouldNotBeNull();
-        result.Value.target.ShouldBe(parent);
-        result.Value.index.ShouldBe(1);
+        result.Value.TreeTarget.ShouldBe(parent);
+        result.Value.Drop.ShouldBeNull();
     }
 }


### PR DESCRIPTION
## Summary
- Replaces `int index` threading through `ProcessDrop` → `OnNodeSortingDropped` → `HandleDroppingInstanceOnTarget` with a typed `DropTarget` (ParentElement + ParentInstance + DropPosition).
- `DropPosition` is a closed hierarchy: `Append`, `InsertAt(int)`, `BeforeSibling(InstanceSave)`, `AfterSibling(InstanceSave)`. Each downstream consumer pattern-matches on the variant it cares about — no more shared `int` carrying conflicting semantics.
- `HandleDroppingInstanceOnTarget` drops the self-inclusion compensation math (`-= 1` against `droppedInstanceIndexBeforeMove`): the sibling lookup excludes the dragged instance, and the Remove/Insert sequence handles position shift cleanly.
- `OnNodeSortingDropped` picks ascending vs descending traversal based on the drop position so multi-drop drag-order is preserved for `BeforeSibling` (which anchors at a moving target) as well as for `Append`/`AfterSibling`/`InsertAt` (which anchor at a fixed position).
- Adds synthetic-fixture invariant tests asserting "for every instance in `screen.Instances`, all of its children come after it in the flat list" — the user-visible bug shape from #2864. These pass on `main` and continue to pass post-refactor.

## Test plan
- [x] `dotnet build GumFull.sln` clean
- [x] `dotnet test Tool/Tests/GumToolUnitTests/GumToolUnitTests.csproj` — 641 passed / 5 pre-existing skips / 0 failed
- [x] `dotnet test AllLibraries.sln` — all green
- [ ] Manual smoke: drop a component into a Screen / onto a Container instance / before+after a sibling instance — verify the new visual lands on top and in the expected position.

Closes #2869.