### PR TITLE
#2881: Add draw-count overlay and batch-mix stress screen to Shapes gallery

### DIFF
--- a/Samples/MonoGameGumShapesGallery/Game1.cs
+++ b/Samples/MonoGameGumShapesGallery/Game1.cs
@@ -1,9 +1,12 @@
+using System.Linq;
 using Gum.Forms.Controls;
+using Gum.GueDeriving;
 using Gum.Wireframe;
 using Microsoft.Xna.Framework;
 using MonoGameAndGum.Renderables;
 using MonoGameGum;
 using MonoGameGumShapesGallery.Screens;
+using RenderingLibrary;
 
 namespace MonoGameGumShapesGallery;
 
@@ -26,6 +29,7 @@ public class Game1 : Game
 
     private StackPanel? _navStrip;
     private FrameworkElement? _currentScreen;
+    private TextRuntime? _drawCountOverlay;
 
     public Game1()
     {
@@ -46,9 +50,30 @@ public class Game1 : Game
         ShapeRenderer.Self.Initialize();
 
         BuildNavStrip();
+        BuildDrawCountOverlay();
         ShowScreen(NewSurveyScreen);
 
         base.Initialize();
+    }
+
+    // Top-right overlay showing the count of SpriteBatch.Begin calls from the
+    // previous frame, sourced from SpriteRenderer.LastFrameDrawStates. Useful
+    // for spotting batch-break regressions and for A/B-ing alternate orderers
+    // (see issue #2879). Note: this count does NOT include Apos.Shapes
+    // StartBatch calls — those go through ShapeBatch, which is not visible to
+    // LastFrameDrawStates.
+    private void BuildDrawCountOverlay()
+    {
+        _drawCountOverlay = new TextRuntime();
+        _drawCountOverlay.XOrigin = RenderingLibrary.Graphics.HorizontalAlignment.Right;
+        _drawCountOverlay.XUnits = Gum.Converters.GeneralUnitType.PixelsFromLarge;
+        _drawCountOverlay.X = -8;
+        _drawCountOverlay.Y = 12;
+        _drawCountOverlay.Red = 255;
+        _drawCountOverlay.Green = 230;
+        _drawCountOverlay.Blue = 120;
+        _drawCountOverlay.Text = "SpriteBatch.Begin: 0";
+        _drawCountOverlay.AddToRoot();
     }
 
     private void BuildNavStrip()
@@ -67,6 +92,7 @@ public class Game1 : Game
         AddNavButton("Polygons", () => new PolygonsScreen());
         AddNavButton("Gradients", () => new GradientScreen());
         AddNavButton("Clipping", () => new ClippingScreen());
+        AddNavButton("Batch mix stress", () => new BatchMixStressScreen());
     }
 
     private ShapeSurveyScreen NewSurveyScreen() =>
@@ -101,7 +127,19 @@ public class Game1 : Game
     protected override void Update(GameTime gameTime)
     {
         GumService.Default.Update(gameTime);
+        UpdateDrawCountOverlay();
         base.Update(gameTime);
+    }
+
+    private void UpdateDrawCountOverlay()
+    {
+        if (_drawCountOverlay == null)
+        {
+            return;
+        }
+
+        int count = SystemManagers.Default.Renderer.SpriteRenderer.LastFrameDrawStates.Count();
+        _drawCountOverlay.Text = $"SpriteBatch.Begin: {count}";
     }
 
     protected override void Draw(GameTime gameTime)

--- a/Samples/MonoGameGumShapesGallery/Screens/BatchMixStressScreen.cs
+++ b/Samples/MonoGameGumShapesGallery/Screens/BatchMixStressScreen.cs
@@ -1,0 +1,78 @@
+using Gum.DataTypes;
+using Gum.Forms.Controls;
+using Gum.GueDeriving;
+using Gum.Wireframe;
+using Microsoft.Xna.Framework;
+
+namespace MonoGameGumShapesGallery.Screens;
+
+// Stress screen for the cross-batch-type alternation pattern that the
+// BatchKeyGroupedOrderer (issue #2879) exists to fix. Each row contains:
+//   - a ColoredRectangleRuntime (renders via SpriteBatch)
+//   - a TextRuntime              (renders via SpriteBatch)
+//   - a CircleRuntime            (renders via Apos.Shapes)
+//
+// In DFS order this produces SpriteBatch -> SpriteBatch -> Apos.Shapes per row,
+// forcing two batch transitions per row (Apos.Shapes -> SpriteBatch at the start
+// of the next row, then SpriteBatch -> Apos.Shapes mid-row). With 100 rows the
+// current renderer racks up a couple hundred batch starts; the overlay on Game1
+// shows the SpriteBatch.Begin count so before/after numbers can be compared
+// once the orderer lands.
+//
+// No texture-backed Sprite is used because the sample doesn't ship one;
+// ColoredRectangleRuntime is the same code path for batching purposes (single-
+// pixel-texture SpriteBatch draw).
+internal class BatchMixStressScreen : FrameworkElement
+{
+    private const int RowCount = 100;
+    private const float RowHeight = 40;
+    private const float RowSpacing = 4;
+
+    public BatchMixStressScreen() : base(new ContainerRuntime())
+    {
+        Dock(Gum.Wireframe.Dock.Fill);
+
+        ScrollViewer scrollViewer = new ScrollViewer();
+        scrollViewer.Dock(Gum.Wireframe.Dock.Fill);
+        scrollViewer.VerticalScrollBarVisibility = ScrollBarVisibility.Auto;
+        scrollViewer.InnerPanel.StackSpacing = RowSpacing;
+        AddChild(scrollViewer);
+
+        for (int i = 0; i < RowCount; i++)
+        {
+            ContainerRuntime row = new ContainerRuntime();
+            row.WidthUnits = DimensionUnitType.RelativeToParent;
+            row.Width = -16;
+            row.HeightUnits = DimensionUnitType.Absolute;
+            row.Height = RowHeight;
+
+            ColoredRectangleRuntime frame = new ColoredRectangleRuntime();
+            frame.WidthUnits = DimensionUnitType.RelativeToParent;
+            frame.Width = 0;
+            frame.HeightUnits = DimensionUnitType.RelativeToParent;
+            frame.Height = 0;
+            frame.Color = (i % 2 == 0) ? new Color(60, 60, 90) : new Color(80, 80, 120);
+            row.AddChild(frame);
+
+            TextRuntime label = new TextRuntime();
+            label.X = 12;
+            label.Y = 10;
+            label.Text = $"Item {i + 1}";
+            label.Red = 230;
+            label.Green = 230;
+            label.Blue = 230;
+            row.AddChild(label);
+
+            CircleRuntime dot = new CircleRuntime();
+            dot.XOrigin = RenderingLibrary.Graphics.HorizontalAlignment.Right;
+            dot.XUnits = Gum.Converters.GeneralUnitType.PixelsFromLarge;
+            dot.X = -12;
+            dot.Y = 8;
+            dot.Radius = 12;
+            dot.FillColor = Color.Goldenrod;
+            row.AddChild(dot);
+
+            scrollViewer.InnerPanel.Children.Add(row);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a `SpriteBatch.Begin: N` overlay (top-right) sourced from `SpriteRenderer.LastFrameDrawStates`, useful for spotting batch-break regressions and for A/B-ing alternate orderers.
- Adds a new "Batch mix stress" screen: 100 rows, each row alternates SpriteBatch work (`ColoredRectangleRuntime` + `TextRuntime`) with Apos.Shapes work (`CircleRuntime`). Forces the cross-batch alternation pattern that #2879's `BatchKeyGroupedOrderer` exists to fix.
- Overlay label says `SpriteBatch.Begin` because `LastFrameDrawStates` only sees `SpriteBatch.Begin` calls; Apos.Shapes `StartBatch` is not counted. Calling that out in the UI prevents misinterpretation.

This lands before #2879 so we have a baseline number to compare against once the new orderer ships.

## Test plan

- [x] `dotnet build Samples/MonoGameGumShapesGallery/MonoGameGumShapesGallery.csproj` succeeds.
- [x] Run the sample; overlay shows a non-zero count on every screen.
- [x] Navigate to "Batch mix stress" and confirm the count jumps to ~200 (one `SpriteBatch.Begin` per Apos.Shapes ↔ SpriteBatch transition in DFS order, give or take Forms-control draws).
- [x] Visually verify rows alternate background color and each row has text + a goldenrod circle on the right.

Closes #2881

🤖 Generated with [Claude Code](https://claude.com/claude-code)