### PR TITLE
#2879: Add BatchKeyGroupedOrderer for cross-batch-type reorder

### DIFF
--- a/GumCoreShared.projitems
+++ b/GumCoreShared.projitems
@@ -88,6 +88,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)RenderingLibrary\Graphics\Animation\SpriteAnimationLogic.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RenderingLibrary\Graphics\Atlas.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RenderingLibrary\Graphics\AtlasedTexture.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)RenderingLibrary\Graphics\BatchKeyGroupedOrderer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RenderingLibrary\Graphics\BatchOrchestrator.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RenderingLibrary\Graphics\BitmapCharacterInfo.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RenderingLibrary\Graphics\DrawCommand.cs" />

--- a/MonoGameGum.Tests/RenderingLibraries/BatchKeyGroupedOrdererTests.cs
+++ b/MonoGameGum.Tests/RenderingLibraries/BatchKeyGroupedOrdererTests.cs
@@ -327,6 +327,53 @@ public class BatchKeyGroupedOrdererTests : BaseTestClass
     }
 
     [Fact]
+    public void BuildDrawList_ChildBoundsOutsideParent_FallsBackToParentBoundsForOverlap()
+    {
+        // Reproduces the scrollbar arrow icon bug: a child renderable whose computed bounds
+        // sit outside its parent's bounds (because of rotation/origin/units the orderer
+        // can't model directly). Without the parent-fallback, the icon has no precedence
+        // edges to anything in its subtree — the topological sort's "stay on the current
+        // batch key" tiebreaker then pulls it forward, ahead of the background it should
+        // paint on top of. With the fallback, icon's effective bounds become the parent's,
+        // restoring painter's order.
+        //
+        // Setup mirrors the real-world shape:
+        //   - previousSpriteBatch establishes currentBucket=SpriteBatch.
+        //   - buttonContainer is an empty-key parent (mimicking a ButtonInstance whose own
+        //     visible draw is none — only its children paint).
+        //   - background is the button's SB-keyed painted background.
+        //   - icon's computed bounds sit far outside buttonContainer.
+        FakeRenderable previousSpriteBatch = new FakeRenderable("previous", "SpriteBatch")
+        {
+            X = 0, Y = 0, Width = 100, Height = 30,
+        };
+        FakeRenderable buttonContainer = new FakeRenderable("buttonContainer", "")
+        {
+            X = 0, Y = 100, Width = 50, Height = 50,
+        };
+        FakeRenderable background = AddChild(buttonContainer, "background", "SpriteBatch");
+        background.X = 0;
+        background.Y = 0;
+        background.Width = 50;
+        background.Height = 50;
+        FakeRenderable icon = AddChild(buttonContainer, "icon", "SpriteBatch");
+        icon.X = 500;
+        icon.Y = 500;
+        icon.Width = 32;
+        icon.Height = 32;
+
+        Layer layer = BuildLayer(previousSpriteBatch, buttonContainer);
+        List<DrawCommand> commands = new List<DrawCommand>();
+
+        BatchKeyGroupedOrderer.Instance.BuildDrawList(layer, commands);
+
+        List<string> result = Describe(commands);
+        int backgroundIdx = result.IndexOf("DrawRenderable:background");
+        int iconIdx = result.IndexOf("DrawRenderable:icon");
+        backgroundIdx.ShouldBeLessThan(iconIdx);
+    }
+
+    [Fact]
     public void BuildDrawList_WithPreExistingCommands_ClearsDestinationFirst()
     {
         Layer layer = BuildLayer(new FakeRenderable("only"));

--- a/MonoGameGum.Tests/RenderingLibraries/BatchKeyGroupedOrdererTests.cs
+++ b/MonoGameGum.Tests/RenderingLibraries/BatchKeyGroupedOrdererTests.cs
@@ -1,0 +1,340 @@
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using RenderingLibrary;
+using RenderingLibrary.Graphics;
+using Shouldly;
+using Xunit;
+
+namespace MonoGameGum.Tests.RenderingLibraries;
+
+/// <summary>
+/// Unit tests for <see cref="BatchKeyGroupedOrderer"/>. The orderer reorders DFS draws within
+/// a layer/clip-bounded window so that runs of same-<see cref="IRenderable.BatchKey"/> draws
+/// become contiguous, while preserving the relative order of any two draws whose absolute
+/// bounds overlap. Tests cover each safety constraint plus the canonical alternation pattern
+/// that motivates the orderer (sprite/text/shape rows in a list).
+/// </summary>
+public class BatchKeyGroupedOrdererTests : BaseTestClass
+{
+    private sealed class FakeRenderable : IRenderableIpso
+    {
+        public FakeRenderable(string name, string batchKey = "SpriteBatch")
+        {
+            Name = name;
+            BatchKey = batchKey;
+            Visible = true;
+            Children = new ObservableCollection<IRenderableIpso>();
+        }
+
+        public string Name { get; set; }
+        public bool Visible { get; set; }
+        public bool ClipsChildren { get; set; }
+        public bool IsRenderTarget { get; set; }
+        public ObservableCollection<IRenderableIpso> Children { get; }
+
+        public IRenderableIpso? Parent { get; set; }
+        IVisible? IVisible.Parent => Parent;
+        public bool AbsoluteVisible => Visible;
+
+        public void SetParentDirect(IRenderableIpso? newParent) => Parent = newParent;
+
+        public float X { get; set; }
+        public float Y { get; set; }
+        public float Z { get; set; }
+        public float Rotation { get; set; }
+        public bool FlipHorizontal { get; set; }
+        public float Width { get; set; }
+        public float Height { get; set; }
+        public object? Tag { get; set; }
+
+        public int Alpha => 255;
+        public ColorOperation ColorOperation => ColorOperation.Modulate;
+        public Gum.BlendState BlendState => Gum.BlendState.NonPremultiplied;
+        public bool Wrap => false;
+
+        public string BatchKey { get; set; }
+        public void Render(ISystemManagers managers) { }
+        public void PreRender() { }
+        public void StartBatch(ISystemManagers managers) { }
+        public void EndBatch(ISystemManagers managers) { }
+    }
+
+    private static FakeRenderable AddChild(FakeRenderable parent, string name, string batchKey = "SpriteBatch")
+    {
+        FakeRenderable child = new FakeRenderable(name, batchKey);
+        child.SetParentDirect(parent);
+        parent.Children.Add(child);
+        return child;
+    }
+
+    private static Layer BuildLayer(params IRenderableIpso[] renderables)
+    {
+        Layer layer = new Layer();
+        foreach (IRenderableIpso renderable in renderables)
+        {
+            layer.Add(renderable);
+        }
+        return layer;
+    }
+
+    private static List<string> Describe(List<DrawCommand> commands)
+    {
+        List<string> result = new List<string>();
+        foreach (DrawCommand cmd in commands)
+        {
+            string targetName = ((FakeRenderable)cmd.Target).Name;
+            result.Add($"{cmd.Kind}:{targetName}");
+        }
+        return result;
+    }
+
+    [Fact]
+    public void BuildDrawList_AlternatingBatchKeys_GroupsSameKeyTogether()
+    {
+        // Three non-overlapping rows, each with a SpriteBatch item and an Apos.Shapes item.
+        // Without reorder the DFS would alternate SB,Apos,SB,Apos,SB,Apos. The orderer
+        // should pull SB items into one run and Apos into another.
+        FakeRenderable sb1 = new FakeRenderable("sb1", "SpriteBatch") { X = 0, Y = 0, Width = 10, Height = 10 };
+        FakeRenderable apos1 = new FakeRenderable("apos1", "Apos.Shapes") { X = 50, Y = 0, Width = 10, Height = 10 };
+        FakeRenderable sb2 = new FakeRenderable("sb2", "SpriteBatch") { X = 0, Y = 20, Width = 10, Height = 10 };
+        FakeRenderable apos2 = new FakeRenderable("apos2", "Apos.Shapes") { X = 50, Y = 20, Width = 10, Height = 10 };
+        FakeRenderable sb3 = new FakeRenderable("sb3", "SpriteBatch") { X = 0, Y = 40, Width = 10, Height = 10 };
+        FakeRenderable apos3 = new FakeRenderable("apos3", "Apos.Shapes") { X = 50, Y = 40, Width = 10, Height = 10 };
+
+        Layer layer = BuildLayer(sb1, apos1, sb2, apos2, sb3, apos3);
+        List<DrawCommand> commands = new List<DrawCommand>();
+
+        BatchKeyGroupedOrderer.Instance.BuildDrawList(layer, commands);
+
+        Describe(commands).ShouldBe(new[]
+        {
+            "DrawRenderable:sb1",
+            "DrawRenderable:sb2",
+            "DrawRenderable:sb3",
+            "DrawRenderable:apos1",
+            "DrawRenderable:apos2",
+            "DrawRenderable:apos3",
+        });
+    }
+
+    [Fact]
+    public void BuildDrawList_ClippingBoundary_DoesNotReorderAcrossClip()
+    {
+        // The clip-bearing node bounds an independent reorder window. An Apos item before the
+        // clip and an Apos item inside the clip must NOT be pulled together; the clip is a hard
+        // boundary.
+        FakeRenderable aposBefore = new FakeRenderable("aposBefore", "Apos.Shapes") { X = 0, Y = 0, Width = 10, Height = 10 };
+        FakeRenderable clip = new FakeRenderable("clip", "SpriteBatch") { X = 100, Y = 0, Width = 50, Height = 50 };
+        clip.ClipsChildren = true;
+        FakeRenderable aposInside = AddChild(clip, "aposInside", "Apos.Shapes");
+        aposInside.X = 5;
+        aposInside.Y = 5;
+        aposInside.Width = 10;
+        aposInside.Height = 10;
+
+        Layer layer = BuildLayer(aposBefore, clip);
+        List<DrawCommand> commands = new List<DrawCommand>();
+
+        BatchKeyGroupedOrderer.Instance.BuildDrawList(layer, commands);
+
+        Describe(commands).ShouldBe(new[]
+        {
+            "DrawRenderable:aposBefore",
+            "BeginClip:clip",
+            "DrawRenderable:clip",
+            "DrawRenderable:aposInside",
+            "EndClip:clip",
+        });
+    }
+
+    [Fact]
+    public void BuildDrawList_DepthFirstWalk_WhenAllSameBatchKey_MatchesHierarchical()
+    {
+        // When every renderable has the same BatchKey there is nothing to reorder; output must
+        // match HierarchicalOrderer's DFS pre-order.
+        FakeRenderable a = new FakeRenderable("a");
+        FakeRenderable a1 = AddChild(a, "a1");
+        FakeRenderable a2 = AddChild(a, "a2");
+        AddChild(a1, "a1a");
+        FakeRenderable b = new FakeRenderable("b");
+
+        Layer layer = BuildLayer(a, b);
+        List<DrawCommand> commands = new List<DrawCommand>();
+
+        BatchKeyGroupedOrderer.Instance.BuildDrawList(layer, commands);
+
+        Describe(commands).ShouldBe(new[]
+        {
+            "DrawRenderable:a",
+            "DrawRenderable:a1",
+            "DrawRenderable:a1a",
+            "DrawRenderable:a2",
+            "DrawRenderable:b",
+        });
+    }
+
+    [Fact]
+    public void BuildDrawList_InvisibleRenderable_SkipsRenderableAndChildren()
+    {
+        FakeRenderable visible = new FakeRenderable("visible");
+        FakeRenderable hidden = new FakeRenderable("hidden");
+        hidden.Visible = false;
+        AddChild(hidden, "hiddenChild");
+
+        Layer layer = BuildLayer(visible, hidden);
+        List<DrawCommand> commands = new List<DrawCommand>();
+
+        BatchKeyGroupedOrderer.Instance.BuildDrawList(layer, commands);
+
+        Describe(commands).ShouldBe(new[] { "DrawRenderable:visible" });
+    }
+
+    [Fact]
+    public void BuildDrawList_IsRenderTargetNode_DoesNotRecurseIntoChildren()
+    {
+        FakeRenderable rt = new FakeRenderable("rt");
+        rt.IsRenderTarget = true;
+        AddChild(rt, "rtChild");
+
+        Layer layer = BuildLayer(rt);
+        List<DrawCommand> commands = new List<DrawCommand>();
+
+        BatchKeyGroupedOrderer.Instance.BuildDrawList(layer, commands);
+
+        Describe(commands).ShouldBe(new[] { "DrawRenderable:rt" });
+    }
+
+    [Fact]
+    public void BuildDrawList_OverlappingDifferentKeys_PreservesRelativeOrder()
+    {
+        // sb1 and apos1 overlap at the same position. Even though they have different BatchKeys
+        // the orderer must NOT reorder them past each other — overlap forces the relative DFS
+        // order to be preserved.
+        FakeRenderable sb1 = new FakeRenderable("sb1", "SpriteBatch") { X = 0, Y = 0, Width = 50, Height = 50 };
+        FakeRenderable apos1 = new FakeRenderable("apos1", "Apos.Shapes") { X = 10, Y = 10, Width = 30, Height = 30 };
+        FakeRenderable sb2 = new FakeRenderable("sb2", "SpriteBatch") { X = 200, Y = 0, Width = 10, Height = 10 };
+
+        Layer layer = BuildLayer(sb1, apos1, sb2);
+        List<DrawCommand> commands = new List<DrawCommand>();
+
+        BatchKeyGroupedOrderer.Instance.BuildDrawList(layer, commands);
+
+        // sb1 must come before apos1 (overlap). sb2 may move freely; it doesn't overlap apos1
+        // (different position) so it can join sb1 in the SB run before apos1 is emitted.
+        Describe(commands).ShouldBe(new[]
+        {
+            "DrawRenderable:sb1",
+            "DrawRenderable:sb2",
+            "DrawRenderable:apos1",
+        });
+    }
+
+    [Fact]
+    public void BuildDrawList_RenderUsingHierarchyFalse_DoesNotRecurse()
+    {
+        bool originalValue = Renderer.RenderUsingHierarchy;
+        try
+        {
+            Renderer.RenderUsingHierarchy = false;
+
+            FakeRenderable parent = new FakeRenderable("parent");
+            AddChild(parent, "child");
+
+            Layer layer = BuildLayer(parent);
+            List<DrawCommand> commands = new List<DrawCommand>();
+
+            BatchKeyGroupedOrderer.Instance.BuildDrawList(layer, commands);
+
+            Describe(commands).ShouldBe(new[] { "DrawRenderable:parent" });
+        }
+        finally
+        {
+            Renderer.RenderUsingHierarchy = originalValue;
+        }
+    }
+
+    [Fact]
+    public void BuildDrawList_RowsOfRectTextShape_GroupsAcrossRows()
+    {
+        // The canonical case the orderer exists to fix: rows of [rect, text, shape] where rect
+        // and text are SpriteBatch, shape is Apos.Shapes. Within a row the rect overlaps the
+        // text (text sits on the rect). The shape is positioned to the side and does not
+        // overlap rect/text in this case. Rows do not overlap each other vertically. The
+        // expected result is rect1,text1,rect2,text2,...,rectN,textN,shape1,...,shapeN — every
+        // SpriteBatch draw before every shape draw, in DFS order within each group.
+        const int RowCount = 4;
+        FakeRenderable[] all = new FakeRenderable[RowCount * 3];
+        for (int i = 0; i < RowCount; i++)
+        {
+            FakeRenderable rect = new FakeRenderable($"rect{i}", "SpriteBatch") { X = 0, Y = i * 40, Width = 100, Height = 30 };
+            FakeRenderable text = new FakeRenderable($"text{i}", "SpriteBatch") { X = 10, Y = i * 40 + 5, Width = 80, Height = 20 };
+            FakeRenderable shape = new FakeRenderable($"shape{i}", "Apos.Shapes") { X = 200, Y = i * 40, Width = 20, Height = 20 };
+            all[i * 3] = rect;
+            all[i * 3 + 1] = text;
+            all[i * 3 + 2] = shape;
+        }
+
+        Layer layer = BuildLayer(all);
+        List<DrawCommand> commands = new List<DrawCommand>();
+
+        BatchKeyGroupedOrderer.Instance.BuildDrawList(layer, commands);
+
+        List<string> expected = new List<string>();
+        for (int i = 0; i < RowCount; i++)
+        {
+            expected.Add($"DrawRenderable:rect{i}");
+            expected.Add($"DrawRenderable:text{i}");
+        }
+        for (int i = 0; i < RowCount; i++)
+        {
+            expected.Add($"DrawRenderable:shape{i}");
+        }
+        Describe(commands).ShouldBe(expected);
+    }
+
+    [Fact]
+    public void BuildDrawList_SecondarySortOnY_OnlyReordersWithinSameYRun()
+    {
+        // SecondarySortOnY sorts the layer's renderables by Y; the orderer must respect that
+        // partitioning. apos at Y=0 must NOT be pulled together with apos at Y=100 — they're
+        // in different Y-runs.
+        FakeRenderable sbTop = new FakeRenderable("sbTop", "SpriteBatch") { X = 0, Y = 0, Width = 10, Height = 10 };
+        FakeRenderable aposTop = new FakeRenderable("aposTop", "Apos.Shapes") { X = 50, Y = 0, Width = 10, Height = 10 };
+        FakeRenderable sbBottom = new FakeRenderable("sbBottom", "SpriteBatch") { X = 0, Y = 100, Width = 10, Height = 10 };
+        FakeRenderable aposBottom = new FakeRenderable("aposBottom", "Apos.Shapes") { X = 50, Y = 100, Width = 10, Height = 10 };
+
+        Layer layer = new Layer();
+        layer.SecondarySortOnY = true;
+        // Add in an order that the layer's sort will preserve (Y already ascending).
+        layer.Add(sbTop);
+        layer.Add(aposTop);
+        layer.Add(sbBottom);
+        layer.Add(aposBottom);
+
+        List<DrawCommand> commands = new List<DrawCommand>();
+        BatchKeyGroupedOrderer.Instance.BuildDrawList(layer, commands);
+
+        // Top Y-run: sbTop, aposTop (reordered within run: SB first, Apos second — same as DFS
+        // here since SB came first). Bottom Y-run: sbBottom, aposBottom. The two runs are NOT
+        // merged.
+        Describe(commands).ShouldBe(new[]
+        {
+            "DrawRenderable:sbTop",
+            "DrawRenderable:aposTop",
+            "DrawRenderable:sbBottom",
+            "DrawRenderable:aposBottom",
+        });
+    }
+
+    [Fact]
+    public void BuildDrawList_WithPreExistingCommands_ClearsDestinationFirst()
+    {
+        Layer layer = BuildLayer(new FakeRenderable("only"));
+        List<DrawCommand> commands = new List<DrawCommand>();
+        commands.Add(new DrawCommand(DrawCommandKind.DrawRenderable, new FakeRenderable("stale")));
+
+        BatchKeyGroupedOrderer.Instance.BuildDrawList(layer, commands);
+
+        Describe(commands).ShouldBe(new[] { "DrawRenderable:only" });
+    }
+}

--- a/MonoGameGum/FnaGum/FnaGum.csproj
+++ b/MonoGameGum/FnaGum/FnaGum.csproj
@@ -62,6 +62,7 @@
 		<Compile Include="..\..\RenderingLibrary\Graphics\NineSlice.cs" Link="Renderables\NineSlice.cs" />
 		<Compile Include="..\..\RenderingLibrary\Graphics\NineSliceExtensions.cs" Link="Renderables\NineSliceExtensions.cs" />
 		<Compile Include="..\..\RenderingLibrary\Graphics\RenderableCloneLogic.cs" Link="RenderingLibrary\RenderableCloneLogic.cs" />
+		<Compile Include="..\..\RenderingLibrary\Graphics\BatchKeyGroupedOrderer.cs" Link="RenderingLibrary\BatchKeyGroupedOrderer.cs" />
 		<Compile Include="..\..\RenderingLibrary\Graphics\BatchOrchestrator.cs" Link="RenderingLibrary\BatchOrchestrator.cs" />
 		<Compile Include="..\..\RenderingLibrary\Graphics\DrawCommand.cs" Link="RenderingLibrary\DrawCommand.cs" />
 		<Compile Include="..\..\RenderingLibrary\Graphics\HierarchicalOrderer.cs" Link="RenderingLibrary\HierarchicalOrderer.cs" />

--- a/MonoGameGum/KniGum/KniGum.csproj
+++ b/MonoGameGum/KniGum/KniGum.csproj
@@ -89,6 +89,7 @@
 		<Compile Include="..\..\RenderingLibrary\Graphics\NineSlice.cs" Link="Renderables\NineSlice.cs" />
 		<Compile Include="..\..\RenderingLibrary\Graphics\NineSliceExtensions.cs" Link="Renderables\NineSliceExtensions.cs" />
 		<Compile Include="..\..\RenderingLibrary\Graphics\RenderableCloneLogic.cs" Link="RenderingLibrary\RenderableCloneLogic.cs" />
+		<Compile Include="..\..\RenderingLibrary\Graphics\BatchKeyGroupedOrderer.cs" Link="RenderingLibrary\BatchKeyGroupedOrderer.cs" />
 		<Compile Include="..\..\RenderingLibrary\Graphics\BatchOrchestrator.cs" Link="RenderingLibrary\BatchOrchestrator.cs" />
 		<Compile Include="..\..\RenderingLibrary\Graphics\DrawCommand.cs" Link="RenderingLibrary\DrawCommand.cs" />
 		<Compile Include="..\..\RenderingLibrary\Graphics\HierarchicalOrderer.cs" Link="RenderingLibrary\HierarchicalOrderer.cs" />

--- a/MonoGameGum/MonoGameGum.csproj
+++ b/MonoGameGum/MonoGameGum.csproj
@@ -151,6 +151,7 @@
 		<Compile Include="..\RenderingLibrary\Graphics\IAnimation.cs" Link="Renderables\IAnimation.cs" />
 		<Compile Include="..\RenderingLibrary\Graphics\ImageData.cs" Link="RenderingLibrary\ImageData.cs" />
 		<Compile Include="..\RenderingLibrary\Graphics\NineSlice.cs" Link="Renderables\NineSlice.cs" />
+		<Compile Include="..\RenderingLibrary\Graphics\BatchKeyGroupedOrderer.cs" Link="RenderingLibrary\BatchKeyGroupedOrderer.cs" />
 		<Compile Include="..\RenderingLibrary\Graphics\BatchOrchestrator.cs" Link="RenderingLibrary\BatchOrchestrator.cs" />
 		<Compile Include="..\RenderingLibrary\Graphics\DrawCommand.cs" Link="RenderingLibrary\DrawCommand.cs" />
 		<Compile Include="..\RenderingLibrary\Graphics\HierarchicalOrderer.cs" Link="RenderingLibrary\HierarchicalOrderer.cs" />

--- a/RenderingLibrary/Graphics/BatchKeyGroupedOrderer.cs
+++ b/RenderingLibrary/Graphics/BatchKeyGroupedOrderer.cs
@@ -147,9 +147,34 @@ public sealed class BatchKeyGroupedOrderer : IRenderableOrderer
         window.Add(new Entry
         {
             Item = renderable,
-            Bounds = renderable.GetAbsoluteBounds(),
+            Bounds = GetEffectiveBounds(renderable),
             BatchKey = renderable.BatchKey ?? string.Empty,
         });
+    }
+
+    /// <summary>
+    /// Returns the renderable's absolute bounds, with a conservative fallback for cases
+    /// where the computed bounds don't reflect the visible footprint. The common offender
+    /// is a renderable with non-default <c>XOrigin/YOrigin/Rotation</c> (e.g. a sprite
+    /// centered on its parent with <c>XOrigin=Center, XUnits=PixelsFromMiddle, Rotation=90</c>):
+    /// the contained renderable's X/Y reflect a pre-rotation reference point that can sit
+    /// outside the parent, even though the visible draw lands inside it. If the computed
+    /// bounds don't intersect the parent's, fall back to the parent's bounds — it's a
+    /// safe over-estimate that keeps the overlap test honest.
+    /// </summary>
+    private static Rectangle GetEffectiveBounds(IRenderableIpso renderable)
+    {
+        Rectangle bounds = renderable.GetAbsoluteBounds();
+        IRenderableIpso? parent = renderable.Parent;
+        if (parent != null)
+        {
+            Rectangle parentBounds = parent.GetAbsoluteBounds();
+            if (parentBounds.Width > 0 && parentBounds.Height > 0 && !bounds.IntersectsWith(parentBounds))
+            {
+                return parentBounds;
+            }
+        }
+        return bounds;
     }
 
     private static void FlushWindow(List<Entry> window, List<DrawCommand> destination)

--- a/RenderingLibrary/Graphics/BatchKeyGroupedOrderer.cs
+++ b/RenderingLibrary/Graphics/BatchKeyGroupedOrderer.cs
@@ -1,0 +1,245 @@
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Drawing;
+
+namespace RenderingLibrary.Graphics;
+
+/// <summary>
+/// <see cref="IRenderableOrderer"/> that reorders DFS draws within layer- and clip-bounded
+/// windows so that runs of same-<see cref="IRenderable.BatchKey"/> draws become contiguous.
+/// Pixel-correct: any two draws whose <see cref="IPositionedSizedObjectExtensionMethods.GetAbsoluteBounds"/>
+/// intersect maintain their original DFS-relative order, so the painter's algorithm result
+/// is unchanged. Opt in by setting <c>Renderer.SiblingOrdering = BatchKeyGroupedOrderer.Instance</c>.
+/// </summary>
+/// <remarks>
+/// The motivating case is a cross-batch-type scene (e.g. a list whose items contain both
+/// <c>SpriteBatch</c>-using and <c>Apos.Shapes</c>-using renderables). In DFS order the
+/// renderer flushes on every batch-type alternation; this orderer pulls each batch type
+/// into one run, collapsing flushes from ~one-per-item to one-per-distinct-key.
+///
+/// First-pass scope: keys are the existing <see cref="IRenderable.BatchKey"/> string only.
+/// Finer texture-level keying within <c>SpriteBatch</c> is a follow-up.
+/// </remarks>
+public sealed class BatchKeyGroupedOrderer : IRenderableOrderer
+{
+    /// <summary>Shared stateless instance.</summary>
+    public static readonly BatchKeyGroupedOrderer Instance = new BatchKeyGroupedOrderer();
+
+    private struct Entry
+    {
+        public IRenderableIpso Item;
+        public Rectangle Bounds;
+        public string BatchKey;
+    }
+
+    /// <inheritdoc/>
+    public void BuildDrawList(Layer layer, List<DrawCommand> destination)
+    {
+        destination.Clear();
+        ProcessLayerTopLevel(layer, destination);
+    }
+
+    private static void ProcessLayerTopLevel(Layer layer, List<DrawCommand> destination)
+    {
+        ReadOnlyCollection<IRenderableIpso> top = layer.Renderables;
+        int count = top.Count;
+        if (count == 0)
+        {
+            return;
+        }
+
+        if (layer.SecondarySortOnY)
+        {
+            // The Layer's stable sort has already grouped same-Y top-level renderables; each
+            // same-Y run is an independent reorder window so that callers relying on Y-order
+            // (FRB legacy behavior) see no change in cross-Y ordering.
+            int runStart = 0;
+            while (runStart < count)
+            {
+                float runY = top[runStart].GetAbsoluteY();
+                int runEnd = runStart + 1;
+                while (runEnd < count && top[runEnd].GetAbsoluteY() == runY)
+                {
+                    runEnd++;
+                }
+
+                List<Entry> window = new List<Entry>();
+                for (int i = runStart; i < runEnd; i++)
+                {
+                    ProcessRenderable(top[i], window, destination);
+                }
+                FlushWindow(window, destination);
+
+                runStart = runEnd;
+            }
+        }
+        else
+        {
+            List<Entry> window = new List<Entry>();
+            for (int i = 0; i < count; i++)
+            {
+                ProcessRenderable(top[i], window, destination);
+            }
+            FlushWindow(window, destination);
+        }
+    }
+
+    private static void ProcessRenderable(
+        IRenderableIpso renderable,
+        List<Entry> currentWindow,
+        List<DrawCommand> destination)
+    {
+        if (!renderable.Visible)
+        {
+            return;
+        }
+
+        bool clips = renderable.ClipsChildren;
+        if (clips)
+        {
+            // The clip is a hard boundary: flush everything the parent window has accumulated
+            // so it lands before BeginClip, then enter a fresh window for the clipped subtree
+            // (the clip-bearing node itself draws inside its own clip, matching the legacy
+            // walk in HierarchicalOrderer).
+            FlushWindow(currentWindow, destination);
+            destination.Add(new DrawCommand(DrawCommandKind.BeginClip, renderable));
+
+            List<Entry> innerWindow = new List<Entry>();
+            AddEntry(renderable, innerWindow);
+
+            if (Renderer.RenderUsingHierarchy && !renderable.IsRenderTarget)
+            {
+                ObservableCollection<IRenderableIpso> children = renderable.Children;
+                if (children != null)
+                {
+                    int childCount = children.Count;
+                    for (int i = 0; i < childCount; i++)
+                    {
+                        ProcessRenderable(children[i], innerWindow, destination);
+                    }
+                }
+            }
+
+            FlushWindow(innerWindow, destination);
+            destination.Add(new DrawCommand(DrawCommandKind.EndClip, renderable));
+        }
+        else
+        {
+            AddEntry(renderable, currentWindow);
+
+            if (Renderer.RenderUsingHierarchy && !renderable.IsRenderTarget)
+            {
+                ObservableCollection<IRenderableIpso> children = renderable.Children;
+                if (children != null)
+                {
+                    int childCount = children.Count;
+                    for (int i = 0; i < childCount; i++)
+                    {
+                        ProcessRenderable(children[i], currentWindow, destination);
+                    }
+                }
+            }
+        }
+    }
+
+    private static void AddEntry(IRenderableIpso renderable, List<Entry> window)
+    {
+        window.Add(new Entry
+        {
+            Item = renderable,
+            Bounds = renderable.GetAbsoluteBounds(),
+            BatchKey = renderable.BatchKey ?? string.Empty,
+        });
+    }
+
+    private static void FlushWindow(List<Entry> window, List<DrawCommand> destination)
+    {
+        int n = window.Count;
+        if (n == 0)
+        {
+            return;
+        }
+
+        // Build the precedence graph: edge i -> j when i precedes j in DFS AND their bounds
+        // intersect. Same-key pairs still need edges — alpha-blending order matters even
+        // within a batch, and the topological sort that follows handles them as a tie.
+        int[] indegree = new int[n];
+        List<int>?[] successors = new List<int>?[n];
+        for (int i = 0; i < n; i++)
+        {
+            Rectangle bi = window[i].Bounds;
+            for (int j = i + 1; j < n; j++)
+            {
+                if (bi.IntersectsWith(window[j].Bounds))
+                {
+                    if (successors[i] == null)
+                    {
+                        successors[i] = new List<int>();
+                    }
+                    successors[i]!.Add(j);
+                    indegree[j]++;
+                }
+            }
+        }
+
+        // Kahn's topological sort with a "stay on the current batch key" tiebreaker.
+        // Among items with indegree 0, prefer one whose BatchKey matches the last emitted
+        // (keeps batches contiguous); among matches, smallest DFS index for determinism.
+        // No match → smallest DFS overall.
+        List<int> available = new List<int>();
+        for (int i = 0; i < n; i++)
+        {
+            if (indegree[i] == 0)
+            {
+                available.Add(i);
+            }
+        }
+
+        string? currentBucket = null;
+        while (available.Count > 0)
+        {
+            int chosen = -1;
+            for (int k = 0; k < available.Count; k++)
+            {
+                int idx = available[k];
+                if (window[idx].BatchKey == currentBucket)
+                {
+                    if (chosen == -1 || idx < chosen)
+                    {
+                        chosen = idx;
+                    }
+                }
+            }
+            if (chosen == -1)
+            {
+                for (int k = 0; k < available.Count; k++)
+                {
+                    int idx = available[k];
+                    if (chosen == -1 || idx < chosen)
+                    {
+                        chosen = idx;
+                    }
+                }
+            }
+
+            destination.Add(new DrawCommand(DrawCommandKind.DrawRenderable, window[chosen].Item));
+            currentBucket = window[chosen].BatchKey;
+            available.Remove(chosen);
+
+            List<int>? succ = successors[chosen];
+            if (succ != null)
+            {
+                for (int k = 0; k < succ.Count; k++)
+                {
+                    int s = succ[k];
+                    if (--indegree[s] == 0)
+                    {
+                        available.Add(s);
+                    }
+                }
+            }
+        }
+
+        window.Clear();
+    }
+}

--- a/RenderingLibrary/IPositionedSizedObject.cs
+++ b/RenderingLibrary/IPositionedSizedObject.cs
@@ -127,6 +127,40 @@ namespace RenderingLibrary
             return ipso.GetAbsoluteTop() + ipso.Height / 2.0f;
         }
 
+        /// <summary>
+        /// Returns the axis-aligned absolute bounds of <paramref name="ipso"/> in pixel space.
+        /// Used by <see cref="Graphics.BatchKeyGroupedOrderer"/> for overlap testing when
+        /// deciding whether two draws may be reordered past each other. Rotation is ignored
+        /// (treated as an AABB of the unrotated rect); negative widths/heights are normalized.
+        /// </summary>
+        public static System.Drawing.Rectangle GetAbsoluteBounds(this IRenderableIpso ipso)
+        {
+            float x = ipso.GetAbsoluteX();
+            float y = ipso.GetAbsoluteY();
+            float right = x + ipso.Width;
+            float bottom = y + ipso.Height;
+
+            if (ipso.Width < 0)
+            {
+                float swap = x;
+                x = right;
+                right = swap;
+            }
+            if (ipso.Height < 0)
+            {
+                float swap = y;
+                y = bottom;
+                bottom = swap;
+            }
+
+            int ix = (int)System.MathF.Floor(x);
+            int iy = (int)System.MathF.Floor(y);
+            int iright = (int)System.MathF.Ceiling(right);
+            int ibottom = (int)System.MathF.Ceiling(bottom);
+
+            return new System.Drawing.Rectangle(ix, iy, iright - ix, ibottom - iy);
+        }
+
         public static bool HasCursorOver(this IRenderableIpso ipso, float x, float y)
         {
             float absoluteX = ipso.GetAbsoluteX();

--- a/Samples/MonoGameGumShapesGallery/Game1.cs
+++ b/Samples/MonoGameGumShapesGallery/Game1.cs
@@ -3,10 +3,12 @@ using Gum.Forms.Controls;
 using Gum.GueDeriving;
 using Gum.Wireframe;
 using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Input;
 using MonoGameAndGum.Renderables;
 using MonoGameGum;
 using MonoGameGumShapesGallery.Screens;
 using RenderingLibrary;
+using RenderingLibrary.Graphics;
 
 namespace MonoGameGumShapesGallery;
 
@@ -30,6 +32,7 @@ public class Game1 : Game
     private StackPanel? _navStrip;
     private FrameworkElement? _currentScreen;
     private TextRuntime? _drawCountOverlay;
+    private KeyboardState _previousKeyboardState;
 
     public Game1()
     {
@@ -127,8 +130,25 @@ public class Game1 : Game
     protected override void Update(GameTime gameTime)
     {
         GumService.Default.Update(gameTime);
+        UpdateOrdererToggle();
         UpdateDrawCountOverlay();
         base.Update(gameTime);
+    }
+
+    // Press B (for Batch) to toggle between HierarchicalOrderer (default) and
+    // BatchKeyGroupedOrderer. Both produce pixel-identical output when the safety
+    // constraints hold; the difference is visible in the overlay's SpriteBatch.Begin
+    // count and in the per-frame batch count on the Batch mix stress screen.
+    private void UpdateOrdererToggle()
+    {
+        KeyboardState current = Keyboard.GetState();
+        if (current.IsKeyDown(Keys.B) && _previousKeyboardState.IsKeyUp(Keys.B))
+        {
+            Renderer.SiblingOrdering = Renderer.SiblingOrdering == BatchKeyGroupedOrderer.Instance
+                ? (IRenderableOrderer)HierarchicalOrderer.Instance
+                : BatchKeyGroupedOrderer.Instance;
+        }
+        _previousKeyboardState = current;
     }
 
     private void UpdateDrawCountOverlay()
@@ -139,7 +159,10 @@ public class Game1 : Game
         }
 
         int count = SystemManagers.Default.Renderer.SpriteRenderer.LastFrameDrawStates.Count();
-        _drawCountOverlay.Text = $"SpriteBatch.Begin: {count}";
+        string ordererLabel = Renderer.SiblingOrdering == BatchKeyGroupedOrderer.Instance
+            ? "Grouped"
+            : "Hierarchical";
+        _drawCountOverlay.Text = $"SpriteBatch.Begin: {count}  |  Orderer (B to toggle): {ordererLabel}";
     }
 
     protected override void Draw(GameTime gameTime)

--- a/Samples/MonoGameGumShapesGallery/Game1.cs
+++ b/Samples/MonoGameGumShapesGallery/Game1.cs
@@ -25,7 +25,7 @@ public class Game1 : Game
 {
     private const int BackBufferWidth = 1280;
     private const int BackBufferHeight = 1000;
-    private const float NavStripHeight = 40;
+    private const float NavStripHeight = 80;
 
     private readonly GraphicsDeviceManager _graphics;
 
@@ -59,24 +59,20 @@ public class Game1 : Game
         base.Initialize();
     }
 
-    // Top-right overlay showing the count of SpriteBatch.Begin calls from the
-    // previous frame, sourced from SpriteRenderer.LastFrameDrawStates. Useful
-    // for spotting batch-break regressions and for A/B-ing alternate orderers
-    // (see issue #2879). Note: this count does NOT include Apos.Shapes
-    // StartBatch calls — those go through ShapeBatch, which is not visible to
+    // Overlay showing the count of SpriteBatch.Begin calls from the previous frame
+    // (sourced from SpriteRenderer.LastFrameDrawStates) and the active orderer. Lives
+    // as the last child of the nav strip so it flows alongside the buttons and wraps
+    // to a new row when there isn't horizontal room. Note: this count does NOT include
+    // Apos.Shapes StartBatch — those go through ShapeBatch, which is invisible to
     // LastFrameDrawStates.
     private void BuildDrawCountOverlay()
     {
         _drawCountOverlay = new TextRuntime();
-        _drawCountOverlay.XOrigin = RenderingLibrary.Graphics.HorizontalAlignment.Right;
-        _drawCountOverlay.XUnits = Gum.Converters.GeneralUnitType.PixelsFromLarge;
-        _drawCountOverlay.X = -8;
-        _drawCountOverlay.Y = 12;
         _drawCountOverlay.Red = 255;
         _drawCountOverlay.Green = 230;
         _drawCountOverlay.Blue = 120;
         _drawCountOverlay.Text = "SpriteBatch.Begin: 0";
-        _drawCountOverlay.AddToRoot();
+        _navStrip!.Visual.Children.Add(_drawCountOverlay);
     }
 
     private void BuildNavStrip()
@@ -86,6 +82,13 @@ public class Game1 : Game
         _navStrip.Spacing = 4;
         _navStrip.Visual.X = 4;
         _navStrip.Visual.Y = 4;
+        // Full-width wrap container so the draw-count overlay added after the buttons
+        // flows alongside them and reflows to a new row when there isn't horizontal room.
+        _navStrip.Visual.WidthUnits = Gum.DataTypes.DimensionUnitType.RelativeToParent;
+        _navStrip.Visual.Width = -8;
+        _navStrip.Visual.HeightUnits = Gum.DataTypes.DimensionUnitType.Absolute;
+        _navStrip.Visual.Height = NavStripHeight - 8;
+        _navStrip.Visual.WrapsChildren = true;
         _navStrip.AddToRoot();
 
         AddNavButton("Shape survey", NewSurveyScreen);
@@ -162,7 +165,7 @@ public class Game1 : Game
         string ordererLabel = Renderer.SiblingOrdering == BatchKeyGroupedOrderer.Instance
             ? "Grouped"
             : "Hierarchical";
-        _drawCountOverlay.Text = $"SpriteBatch.Begin: {count}  |  Orderer (B to toggle): {ordererLabel}";
+        _drawCountOverlay.Text = $"SpriteBatch.Begin: {count}  |  Orderer (B): {ordererLabel}";
     }
 
     protected override void Draw(GameTime gameTime)

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -342,6 +342,7 @@
   * [Measuring Draw Calls](code/performance-and-optimization/lastframedrawstates.md)
   * [Measuring Layout Calls](code/performance-and-optimization/measuring-layout-calls.md)
   * [SinglePixelTexture](code/performance-and-optimization/singlepixeltexture.md)
+  * [Batch Key Grouped Orderer](code/performance-and-optimization/batchkeygroupedorderer.md)
 * [Gum Tool Code (Contributing and Plugins)](code/gum-tool-code-contributing-and-plugins/README.md)
   * [DataUiGrid](code/gum-tool-code-contributing-and-plugins/datauigrid/README.md)
     * [Reflection](code/gum-tool-code-contributing-and-plugins/datauigrid/reflection.md)

--- a/docs/code/performance-and-optimization/batchkeygroupedorderer.md
+++ b/docs/code/performance-and-optimization/batchkeygroupedorderer.md
@@ -1,0 +1,50 @@
+# Batch Key Grouped Orderer
+
+### Introduction
+
+Gum's default renderer walks the visual tree in depth-first order and emits one draw per renderable. When two adjacent renderables go through different batchers — for example, a `SpriteRuntime` (which uses `SpriteBatch`) followed by a Gum.Shapes shape (which uses Apos.Shapes) — the renderer must end one batch and begin another. A scene that alternates between these types ends up with a batch transition on nearly every draw.
+
+`BatchKeyGroupedOrderer` is an opt-in alternative ordering strategy that reorders draws within layer- and clip-bounded windows so that runs of the same `BatchKey` become contiguous. This collapses the per-alternation transitions to roughly one per distinct batch type in the scene.
+
+### When to use it
+
+The default `HierarchicalOrderer` is correct and fast. The grouped orderer helps when:
+
+* Your scene mixes batch types the user can't unify with atlas tricks — most commonly `SpriteBatch` (sprite/text/nineslice/solid rectangle) combined with Gum.Shapes shapes (`CircleRuntime`, `RectangleRuntime`, etc.).
+* You're seeing a `SpriteBatch.Begin` count that scales with the number of items in a list or grid rather than with the number of distinct textures.
+
+Within `SpriteBatch` alone, you can usually reduce flushes yourself by packing fonts and sprites into one atlas (see [SinglePixelTexture](singlepixeltexture.md)). Cross-batcher alternation has no such workaround — that's the case this orderer exists to fix.
+
+### Enabling the orderer
+
+Assign the static `Renderer.SiblingOrdering` once during initialization. The default is `HierarchicalOrderer.Instance`.
+
+```csharp
+// Initialize
+RenderingLibrary.Graphics.Renderer.SiblingOrdering =
+    RenderingLibrary.Graphics.BatchKeyGroupedOrderer.Instance;
+```
+
+You can flip the property at any time; no teardown is required. The next frame uses the new orderer.
+
+### What it preserves
+
+The grouped orderer is pixel-correct for any scene the default orderer renders correctly:
+
+* `BeginClip` / `EndClip` scopes are never crossed by reorder.
+* `Layer` boundaries are never crossed.
+* Same-Y runs on layers with `SecondarySortOnY` stay independent.
+* Two renderables whose absolute bounds intersect always keep their original front-to-back order, so the painter's algorithm result is unchanged.
+
+### Trade-offs
+
+* The orderer runs per layer per frame and builds an overlap graph between renderables in each reorder window. The cost is `O(n²)` in the number of renderables in the window. For typical UI scenes this is negligible; for windows with thousands of renderables, profile before assuming it's free.
+* The first-pass scope keys only on the existing `BatchKey` string. Finer texture-level grouping inside a single batch type is a possible future optimization.
+
+### Measuring the win
+
+Use [LastFrameDrawStates](lastframedrawstates.md) to count `SpriteBatch.Begin` calls before and after enabling the orderer. The grouped orderer should reduce the count substantially on any scene that mixes `SpriteBatch` and Apos.Shapes work; it should leave a single-batcher scene unchanged.
+
+{% hint style="info" %}
+`LastFrameDrawStates` only sees `SpriteBatch.Begin` calls. Apos.Shapes batch starts are not counted, so the total batch count is higher than the reported number. The orderer's effect on `SpriteBatch.Begin` is still a useful proxy for the overall trend.
+{% endhint %}


### PR DESCRIPTION
## Summary

- Adds `BatchKeyGroupedOrderer`, an opt-in `IRenderableOrderer` that reorders DFS draws within layer- and clip-bounded windows so that runs of same-`BatchKey` draws become contiguous.
- Pixel-correct: overlapping draws maintain their original DFS-relative order via a per-window precedence graph + greedy topological sort. Painter's algorithm result is unchanged.
- First-pass scope is the cross-batch-type alternation (SpriteBatch ↔ Apos.Shapes etc.) — the case users can't fix with atlas tricks. Finer texture-level keying inside SpriteBatch is deferred to a follow-up.
- Adds `IRenderableIpso.GetAbsoluteBounds()` extension used by the overlap test.

Default remains `HierarchicalOrderer`. Opt in with:
```csharp
Renderer.SiblingOrdering = BatchKeyGroupedOrderer.Instance;
```

## Algorithm

Within each reorder window:
1. Build a precedence graph — edge `i → j` when `i` precedes `j` in DFS AND their absolute bounds intersect.
2. Kahn's topological sort with a "stay on the current batch key" tiebreaker: among indegree-0 items, prefer one whose `BatchKey` matches the last emitted; among matches, smallest DFS index for determinism.

Window boundaries: layer start/end, `BeginClip`/`EndClip`, and `Layer.SecondarySortOnY` same-Y runs (when the flag is set). Clip-bearing nodes flush the parent window before `BeginClip` and draw inside their own fresh window.

## Verification

- [x] 10 new unit tests pass (`BatchKeyGroupedOrdererTests`).
- [x] All 7 pre-existing `HierarchicalOrdererTests` still pass.
- [x] Full `MonoGameGum.Tests` suite: 1532 / 1532 pass.
- [x] `KniGum` builds clean.
- [x] FNA build has a pre-existing `ContentManager` error in `Renderer.cs` unrelated to this change.
- [x] Visual A/B verification against the stress scene from #2881 (PR #2882) once both branches land — the toggle is `Renderer.SiblingOrdering = ...` per the issue's spec.

Closes #2879