### PR TITLE
Fix Skia gradient regression, seal Arc chord-fill, promote Thickness API

### DIFF
--- a/Runtimes/SkiaGum/GueDeriving/ArcRuntime.cs
+++ b/Runtimes/SkiaGum/GueDeriving/ArcRuntime.cs
@@ -1,4 +1,5 @@
 using Gum.Wireframe;
+using System;
 
 #if SKIA
 using SkiaGum.Renderables;
@@ -19,8 +20,10 @@ namespace Gum.GueDeriving;
 #endif
 
 /// <summary>
-/// Runtime that draws a circular arc inscribed in its Width x Height bounds.
-/// The arc is always stroked (it is never filled); use <see cref="Thickness"/> to control its weight.
+/// Runtime that draws a circular arc inscribed in its Width x Height bounds. Arcs are always
+/// stroked — there is no fill mode. Use <see cref="Thickness"/> to control how thick the band
+/// is; thickness ranges from "thin line tracing the curve" all the way up to "pie wedge filling
+/// the bounds" (see the <see cref="Thickness"/> docs for the wedge configuration).
 /// </summary>
 /// <remarks>
 /// Source-shared between SkiaGum and MonoGameGumShapes (and KniGumShapes) via a Compile/Link in
@@ -55,12 +58,62 @@ public class ArcRuntime
     #endregion
 
     /// <summary>
-    /// Gets or sets the thickness of the arc, in pixels. Façade for <c>StrokeWidth</c> on the
-    /// base shape runtime - the value is held on the runtime so <c>PreRender</c> can apply
-    /// <c>StrokeWidthUnits</c> (e.g. ScreenPixel zoom scaling) before pushing it to the renderable
-    /// each frame.
+    /// Width of the stroked band that traces the arc curve, in pixels. <c>Thickness</c> is the
+    /// canonical user-facing name for this value on arcs — it's the variable name the Gum tool
+    /// persists in <c>.gumx</c> projects and the one shown in the Variables grid. <see cref="StrokeWidth"/>
+    /// is an alias for cross-shape code consumers and is marked obsolete on <c>ArcRuntime</c> to
+    /// steer callers toward <c>Thickness</c>.
     /// </summary>
+    /// <remarks>
+    /// <para><b>Façade</b></para>
+    /// <para>
+    /// Routes to the same backing field as <see cref="StrokeWidth"/> on the base shape runtime.
+    /// There is no second storage location; setting either name is byte-for-byte identical. The
+    /// runtime holds the value (not the renderable) so <c>PreRender</c> can apply
+    /// <c>StrokeWidthUnits</c> (e.g. ScreenPixel zoom scaling) each frame before pushing the
+    /// resolved value to the renderable.
+    /// </para>
+    /// <para><b>Visual progression as Thickness grows</b></para>
+    /// <para>
+    /// Arcs render as a stroked band centered on a curve inscribed in the bounding box. The
+    /// stroke is inset by half its width (<see cref="RenderableShapeBase.IsOffsetAppliedForStroke"/>),
+    /// so the curve's radius shrinks as <c>Thickness</c> grows. For a square arc with
+    /// <c>Width = Height = W</c>:
+    /// </para>
+    /// <list type="bullet">
+    /// <item><b>Thin (e.g. Thickness = 2)</b>: a fine line tracing the curve. Use for outlined rings.</item>
+    /// <item><b>Medium (e.g. Thickness = W / 8)</b>: the chunky band most progress-ring / dial UIs want.</item>
+    /// <item><b>Thickness = W / 2</b>: the band's inner edge collapses to a point at center and
+    /// the butt-end caps become radial edges — the arc renders as a true pie wedge (a circular
+    /// sector) filling the bounding box. This is the supported path to a "filled wedge" arc.
+    /// Set <see cref="IsEndRounded"/> = false (the default) for a clean wedge; rounded caps
+    /// distort the wedge corners.</item>
+    /// <item><b>Thickness &gt; W / 2</b>: undefined. The internal curve would have negative
+    /// radius; Skia/Apos behavior in that regime is not specified. Clamp at <c>W / 2</c>.</item>
+    /// </list>
+    /// <para><b>Gradient interaction</b></para>
+    /// <para>
+    /// Setting <see cref="SkiaShapeRuntime.UseGradient"/> = true (after seeding gradient colors
+    /// and endpoints) applies the gradient to the stroke band at any Thickness — including at
+    /// <c>Thickness = W / 2</c>, which produces a gradient-filled pie wedge.
+    /// </para>
+    /// </remarks>
     public float Thickness
+    {
+        get => base.StrokeWidth;
+        set => base.StrokeWidth = value;
+    }
+
+    /// <summary>
+    /// Obsolete on <c>ArcRuntime</c> — use <see cref="Thickness"/>. Both properties route to the
+    /// same backing field, so existing code using <c>StrokeWidth</c> still works; the obsolete
+    /// marker exists to point new callers at the canonical user-facing name. The Gum tool
+    /// persists this value as "Thickness" in <c>.gumx</c> projects and surfaces only that name
+    /// in the Variables grid; <c>StrokeWidth</c> is a cross-shape technical alias inherited
+    /// from the base shape runtime.
+    /// </summary>
+    [Obsolete("Use Thickness instead — it's the canonical user-facing name for arc stroke weight and the variable name the Gum tool persists. StrokeWidth still works (same backing field) but new code should prefer Thickness.")]
+    public new float StrokeWidth
     {
         get => base.StrokeWidth;
         set => base.StrokeWidth = value;
@@ -122,9 +175,10 @@ public class ArcRuntime
             Width = 100;
             Height = 100;
 
-            // Seed the runtime auto-property StrokeWidth so PreRender pushes the legacy Arc
-            // default (10) to the renderable instead of overwriting it with 0.
-            StrokeWidth = 10;
+            // Seed the runtime auto-property so PreRender pushes the legacy Arc default (10) to
+            // the renderable instead of overwriting it with 0. Thickness === StrokeWidth (same
+            // backing field); using Thickness here matches the canonical user-facing name.
+            Thickness = 10;
 
             // IsEndRounded intentionally left at the renderable's default of false. Locked in
             // unification (issue #2728) - this is a visible behavior change for Apos consumers

--- a/Runtimes/SkiaGum/GueDeriving/SkiaShapeRuntime.cs
+++ b/Runtimes/SkiaGum/GueDeriving/SkiaShapeRuntime.cs
@@ -136,10 +136,22 @@ public abstract class SkiaShapeRuntime : InteractiveGue
     /// </summary>
     void RefreshSlotGradients()
     {
-        ContainedRenderable.UseGradient = _useGradient && _fillColor != null;
         if (StrokeRenderable != null)
         {
+            // Two-slot: each slot is gated independently so a gradient lights up only where the
+            // user lit up a color (issue #2790).
+            ContainedRenderable.UseGradient = _useGradient && _fillColor != null;
             StrokeRenderable.UseGradient = _useGradient && _strokeColor != null;
+        }
+        else
+        {
+            // Single-slot: the contained renderable IS the active slot regardless of whether
+            // the user routed through the legacy Color setter, FillColor, or StrokeColor.
+            // Gating here on _fillColor != null silently suppressed gradients on every
+            // single-slot shape used via the legacy Color API (Arc, RoundedRectangle, Polygon,
+            // ColoredCircle, Line, LineGrid) — that was a regression from #2790; this branch
+            // restores the pre-#2790 pass-through.
+            ContainedRenderable.UseGradient = _useGradient;
         }
     }
 

--- a/Runtimes/SkiaGum/Renderables/Arc.cs
+++ b/Runtimes/SkiaGum/Renderables/Arc.cs
@@ -24,6 +24,23 @@ public class Arc : RenderableShapeBase
         set => base.StrokeWidth = value;
     }
 
+    /// <summary>
+    /// Arc renders only in stroke mode. The setter is intentionally a no-op so a stray
+    /// <c>IsFilled = true</c> (or a <c>FillColor</c> setter on <c>ArcRuntime</c> that flips
+    /// <c>IsFilled</c> as a side effect) cannot reach the chord-fill path. Skia's
+    /// <c>SKPath.AddArc</c> autocloses an open path with a straight chord from sweep-end back
+    /// to start when filled, producing a circular-segment shape with no real use case. True
+    /// pie-wedge fills are reachable via <c>Thickness = Width/2</c> on a square arc — the
+    /// stroke band collapses to a wedge. See <c>ArcRuntime.Thickness</c> for details.
+    /// Apos.Shapes' Arc primitive ignores <c>IsFilled</c> for the same reason; this keeps the
+    /// two backends behaviorally aligned.
+    /// </summary>
+    public override bool IsFilled
+    {
+        get => false;
+        set { }
+    }
+
     bool _isEndRounded;
     public bool IsEndRounded
     {
@@ -44,11 +61,11 @@ public class Arc : RenderableShapeBase
 
     protected override SKPaint GetPaint(SKRect boundingRect, float absoluteRotation)
     {
+        // base.GetPaint sets Style from IsFilled — Arc's IsFilled override pins it to false,
+        // so paint always comes back stroked. See the IsFilled override above for rationale.
         var paint = base.GetPaint(boundingRect, absoluteRotation);
         paint.StrokeCap = IsEndRounded ? SKStrokeCap.Round : SKStrokeCap.Butt;
         return paint;
-
-
     }
 
     public override void DrawBound(SKRect boundingRect, SKCanvas canvas, float absoluteRotation)

--- a/Runtimes/SkiaGum/Renderables/RenderableShapeBase.cs
+++ b/Runtimes/SkiaGum/Renderables/RenderableShapeBase.cs
@@ -428,7 +428,12 @@ public class RenderableShapeBase : IRenderableIpso, IVisible, IDisposable
 
 
     bool _isFilled = true;
-    public bool IsFilled
+    /// <summary>
+    /// Virtual so shape-specific renderables can clamp it. <see cref="Arc"/> overrides this to
+    /// always return false because Skia's <c>SKPath.AddArc</c> autocloses with a chord (a
+    /// circular-segment shape nobody wants) when filled.
+    /// </summary>
+    public virtual bool IsFilled
     {
         get => _isFilled;
         set

--- a/Samples/SilkNetGum/SilkNetGum/Screens/ArcsScreen.cs
+++ b/Samples/SilkNetGum/SilkNetGum/Screens/ArcsScreen.cs
@@ -6,23 +6,46 @@ using SkiaSharp;
 
 namespace SilkNetGum.Screens;
 
-// Issue #2851 — Skia mirror of MonoGameGumShapesGallery/Screens/ArcsScreen.cs. Skia has
-// always faded the shadow with the body (the canonical behavior), so this screen exists for
-// visual parity with the post-#2851 MonoGame side — same cells, same parameters, so a
-// regression on either backend is easy to spot.
+// Skia gallery for ArcRuntime. Mirrors the layout of CirclesScreen so the same backend can be
+// audited at a glance — every property/feature an Arc actually supports gets its own row. This
+// is the reference surface for the raylib Arc port (#2866); features demonstrated here are the
+// parity bar (chord fill is Skia-specific and will not visually match raylib's wedge fill).
 internal class ArcsScreen : GraphicalUiElement
 {
     public ArcsScreen() : base(new InvisibleRenderable())
     {
         ContainerRuntime root = new();
-        root.ChildrenLayout = Gum.Managers.ChildrenLayout.TopToBottomStack;
-        root.StackSpacing = 14;
+        root.ChildrenLayout = Gum.Managers.ChildrenLayout.LeftToRightStack;
+        root.StackSpacing = 24;
         root.X = 10;
         root.Y = 10;
         this.Children.Add(root);
 
-        root.Children.Add(BuildSection("Sweep angles (90, 180, 270, 360)", BuildSweepRow()));
-        root.Children.Add(BuildSection("Dropshadow (off / soft / hard / colored / faded body)", BuildDropshadowRow()));
+        ContainerRuntime left = BuildColumn();
+        ContainerRuntime right = BuildColumn();
+        root.Children.Add(left);
+        root.Children.Add(right);
+
+        left.Children.Add(BuildSection("Sweep angles (90, 180, 270, 360)", BuildSweepRow()));
+        left.Children.Add(BuildSection("Thickness progression: thin → fat → wedge (W/2)", BuildThicknessProgressionRow()));
+        left.Children.Add(BuildSection("End caps: butt / rounded", BuildEndCapRow()));
+        left.Children.Add(BuildSection("Gradients on arcs (including gradient wedge)", BuildStrokeGradientRow()));
+
+        right.Children.Add(BuildSection("Dashed strokes", BuildDashedStrokeRow()));
+        right.Children.Add(BuildSection("Antialiasing (AA on / AA off)", BuildAntialiasingRow()));
+        right.Children.Add(BuildSection("Dropshadow (off / soft / hard / colored / faded body)", BuildDropshadowRow()));
+    }
+
+    static ContainerRuntime BuildColumn()
+    {
+        ContainerRuntime column = new();
+        column.ChildrenLayout = Gum.Managers.ChildrenLayout.TopToBottomStack;
+        column.StackSpacing = 14;
+        column.WidthUnits = DimensionUnitType.RelativeToChildren;
+        column.HeightUnits = DimensionUnitType.RelativeToChildren;
+        column.Width = 0;
+        column.Height = 0;
+        return column;
     }
 
     static ContainerRuntime BuildSection(string label, GraphicalUiElement body)
@@ -67,8 +90,206 @@ internal class ArcsScreen : GraphicalUiElement
             arc.Height = 60;
             arc.SweepAngle = sweep;
             arc.Thickness = 8;
-            arc.Color = SKColors.Goldenrod;
+            arc.StrokeColor = SKColors.Goldenrod;
             row.Children.Add(arc);
+        }
+        return row;
+    }
+
+    // Demonstrates the visual progression as Thickness grows on a square arc. The last cell
+    // hits Thickness = Width / 2 — the band's inner edge collapses to the center and butt-end
+    // caps become radial edges, producing a true pie wedge. This is the supported path to a
+    // "filled wedge" arc on both Skia and Apos backends. See ArcRuntime.Thickness for the math.
+    static ContainerRuntime BuildThicknessProgressionRow()
+    {
+        ContainerRuntime row = BuildHorizontalRow();
+        // Square 60×60; W/2 = 30 is the wedge configuration.
+        foreach (float thickness in new[] { 2f, 8f, 18f, 30f })
+        {
+            ArcRuntime arc = new();
+            arc.Width = 60;
+            arc.Height = 60;
+            arc.SweepAngle = 90;
+            arc.Thickness = thickness;
+            arc.StrokeColor = SKColors.LightGreen;
+            row.Children.Add(arc);
+        }
+        return row;
+    }
+
+    // IsEndRounded default flipped to false in #2728 — this row pins both ends visible so the
+    // butt/round distinction is obvious. Sweep < 360 so the caps are actually present.
+    static ContainerRuntime BuildEndCapRow()
+    {
+        ContainerRuntime row = BuildHorizontalRow();
+
+        ArcRuntime butt = new();
+        butt.Width = 60; butt.Height = 60;
+        butt.SweepAngle = 180;
+        butt.Thickness = 10;
+        butt.StrokeColor = SKColors.White;
+        butt.IsEndRounded = false;
+        row.Children.Add(butt);
+
+        ArcRuntime rounded = new();
+        rounded.Width = 60; rounded.Height = 60;
+        rounded.SweepAngle = 180;
+        rounded.Thickness = 10;
+        rounded.StrokeColor = SKColors.White;
+        rounded.IsEndRounded = true;
+        row.Children.Add(rounded);
+
+        return row;
+    }
+
+    // Gradients on stroked arcs (the only mode arcs support after the chord-fill seal). Locks
+    // in two things: (a) #2790's silent gradient-suppression regression for single-slot shapes
+    // — if any cell renders solid, the regression is back; (b) the final cell is a
+    // gradient-filled pie wedge via Thickness = Width / 2, demonstrating that the wedge config
+    // composes cleanly with gradients.
+    static ContainerRuntime BuildStrokeGradientRow()
+    {
+        ContainerRuntime row = BuildHorizontalRow();
+
+        // Linear horizontal: white → blue
+        ArcRuntime linearH = new();
+        linearH.Width = 60; linearH.Height = 60;
+        linearH.SweepAngle = 270;
+        linearH.Thickness = 8;
+        linearH.StrokeColor = SKColors.White;
+        linearH.UseGradient = true;
+        linearH.GradientType = GradientType.Linear;
+        linearH.Color1 = SKColors.White;
+        linearH.Color2 = SKColors.SteelBlue;
+        linearH.GradientX1 = 0; linearH.GradientY1 = 0;
+        linearH.GradientX2 = 60; linearH.GradientY2 = 0;
+        row.Children.Add(linearH);
+
+        // Linear vertical: gold → crimson
+        ArcRuntime linearV = new();
+        linearV.Width = 60; linearV.Height = 60;
+        linearV.SweepAngle = 270;
+        linearV.Thickness = 8;
+        linearV.StrokeColor = SKColors.White;
+        linearV.UseGradient = true;
+        linearV.GradientType = GradientType.Linear;
+        linearV.Color1 = SKColors.Gold;
+        linearV.Color2 = SKColors.Crimson;
+        linearV.GradientX1 = 0; linearV.GradientY1 = 0;
+        linearV.GradientX2 = 0; linearV.GradientY2 = 60;
+        row.Children.Add(linearV);
+
+        // Linear diagonal: cyan → magenta
+        ArcRuntime linearD = new();
+        linearD.Width = 60; linearD.Height = 60;
+        linearD.SweepAngle = 270;
+        linearD.Thickness = 8;
+        linearD.StrokeColor = SKColors.White;
+        linearD.UseGradient = true;
+        linearD.GradientType = GradientType.Linear;
+        linearD.Color1 = SKColors.Cyan;
+        linearD.Color2 = SKColors.Magenta;
+        linearD.GradientX1 = 0; linearD.GradientY1 = 0;
+        linearD.GradientX2 = 60; linearD.GradientY2 = 60;
+        row.Children.Add(linearD);
+
+        // Radial centered: white → dark green
+        ArcRuntime radial = new();
+        radial.Width = 60; radial.Height = 60;
+        radial.SweepAngle = 270;
+        radial.Thickness = 8;
+        radial.StrokeColor = SKColors.White;
+        radial.UseGradient = true;
+        radial.GradientType = GradientType.Radial;
+        radial.Color1 = SKColors.White;
+        radial.Color2 = SKColors.DarkGreen;
+        radial.GradientX1 = 30; radial.GradientY1 = 30;
+        radial.GradientInnerRadius = 0;
+        radial.GradientOuterRadius = 30;
+        row.Children.Add(radial);
+
+        // Gradient-filled wedge: Thickness = Width / 2 collapses the band to a pie wedge, and
+        // the gradient applies across it. Tighter sweep so the wedge shape is unmistakable.
+        ArcRuntime wedge = new();
+        wedge.Width = 60; wedge.Height = 60;
+        wedge.SweepAngle = 90;
+        wedge.Thickness = 30; // W / 2 → wedge
+        wedge.StrokeColor = SKColors.White;
+        wedge.UseGradient = true;
+        wedge.GradientType = GradientType.Linear;
+        wedge.Color1 = SKColors.Orange;
+        wedge.Color2 = SKColors.DeepPink;
+        wedge.GradientX1 = 0; wedge.GradientY1 = 0;
+        wedge.GradientX2 = 60; wedge.GradientY2 = 60;
+        row.Children.Add(wedge);
+
+        return row;
+    }
+
+    // Mirrors the dashed-stroke row from CirclesScreen — same dash/gap pairs so a dashed arc
+    // and dashed circle stay visually comparable.
+    static ContainerRuntime BuildDashedStrokeRow()
+    {
+        ContainerRuntime row = BuildHorizontalRow();
+
+        ArcRuntime solid = new();
+        solid.Width = 60; solid.Height = 60;
+        solid.SweepAngle = 270;
+        solid.Thickness = 2;
+        solid.StrokeColor = SKColors.White;
+        row.Children.Add(solid);
+
+        ArcRuntime short64 = new();
+        short64.Width = 60; short64.Height = 60;
+        short64.SweepAngle = 270;
+        short64.Thickness = 2;
+        short64.StrokeColor = SKColors.White;
+        short64.StrokeDashLength = 6;
+        short64.StrokeGapLength = 4;
+        row.Children.Add(short64);
+
+        ArcRuntime dotted = new();
+        dotted.Width = 60; dotted.Height = 60;
+        dotted.SweepAngle = 270;
+        dotted.Thickness = 1;
+        dotted.StrokeColor = SKColors.White;
+        dotted.StrokeDashLength = 2;
+        dotted.StrokeGapLength = 2;
+        row.Children.Add(dotted);
+
+        ArcRuntime longDash = new();
+        longDash.Width = 60; longDash.Height = 60;
+        longDash.SweepAngle = 270;
+        longDash.Thickness = 3;
+        longDash.StrokeColor = SKColors.LightGreen;
+        longDash.StrokeDashLength = 12;
+        longDash.StrokeGapLength = 6;
+        row.Children.Add(longDash);
+
+        return row;
+    }
+
+    // Issue #2798 — IsAntialiased toggle. Two pairs (chord-fill + 1 px stroke), AA on then off,
+    // matching the CirclesScreen layout so the two galleries read the same.
+    static ContainerRuntime BuildAntialiasingRow()
+    {
+        ContainerRuntime row = BuildHorizontalRow();
+        foreach (bool aa in new[] { true, false })
+        {
+            ArcRuntime filled = new();
+            filled.Width = 60; filled.Height = 60;
+            filled.SweepAngle = 270;
+            filled.FillColor = SKColors.Goldenrod;
+            filled.IsAntialiased = aa;
+            row.Children.Add(filled);
+
+            ArcRuntime ring = new();
+            ring.Width = 60; ring.Height = 60;
+            ring.SweepAngle = 270;
+            ring.Thickness = 1;
+            ring.StrokeColor = SKColors.White;
+            ring.IsAntialiased = aa;
+            row.Children.Add(ring);
         }
         return row;
     }
@@ -81,14 +302,14 @@ internal class ArcsScreen : GraphicalUiElement
         baseline.Width = 60; baseline.Height = 60;
         baseline.SweepAngle = 270;
         baseline.Thickness = 10;
-        baseline.Color = SKColors.Goldenrod;
+        baseline.StrokeColor = SKColors.Goldenrod;
         row.Children.Add(baseline);
 
         ArcRuntime soft = new();
         soft.Width = 60; soft.Height = 60;
         soft.SweepAngle = 270;
         soft.Thickness = 10;
-        soft.Color = SKColors.Goldenrod;
+        soft.StrokeColor = SKColors.Goldenrod;
         soft.HasDropshadow = true;
         soft.DropshadowOffsetX = 14;
         soft.DropshadowOffsetY = 14;
@@ -100,7 +321,7 @@ internal class ArcsScreen : GraphicalUiElement
         hard.Width = 60; hard.Height = 60;
         hard.SweepAngle = 270;
         hard.Thickness = 10;
-        hard.Color = SKColors.Goldenrod;
+        hard.StrokeColor = SKColors.Goldenrod;
         hard.HasDropshadow = true;
         hard.DropshadowRed = 0; hard.DropshadowGreen = 0; hard.DropshadowBlue = 0; hard.DropshadowAlpha = 160;
         hard.DropshadowOffsetX = 16;
@@ -113,7 +334,7 @@ internal class ArcsScreen : GraphicalUiElement
         colored.Width = 60; colored.Height = 60;
         colored.SweepAngle = 270;
         colored.Thickness = 10;
-        colored.Color = SKColors.Goldenrod;
+        colored.StrokeColor = SKColors.Goldenrod;
         colored.HasDropshadow = true;
         colored.DropshadowRed = 220; colored.DropshadowGreen = 40; colored.DropshadowBlue = 160; colored.DropshadowAlpha = 220;
         colored.DropshadowOffsetX = 16;
@@ -126,7 +347,7 @@ internal class ArcsScreen : GraphicalUiElement
         fadedBody.Width = 60; fadedBody.Height = 60;
         fadedBody.SweepAngle = 270;
         fadedBody.Thickness = 10;
-        fadedBody.Color = new SKColor(218, 165, 32, 80);
+        fadedBody.StrokeColor = new SKColor(218, 165, 32, 80);
         fadedBody.HasDropshadow = true;
         fadedBody.DropshadowOffsetX = 14;
         fadedBody.DropshadowOffsetY = 14;

--- a/Tests/MonoGameGum.Shapes.Tests/ArcRuntimeTests.cs
+++ b/Tests/MonoGameGum.Shapes.Tests/ArcRuntimeTests.cs
@@ -35,17 +35,20 @@ public class ArcRuntimeTests
     // runtime auto-property. If somebody (a) breaks the façade so Thickness gets its own backing
     // field again, or (b) does a careless rename like replace-all "Thickness" -> "StrokeWidth"
     // and produces a self-recursive property, this catches it: the build either fails outright
-    // or the round-trip stops agreeing.
+    // or the round-trip stops agreeing. StrokeWidth on ArcRuntime is [Obsolete] (prefer
+    // Thickness) but the alias contract must still hold — that's exactly what this test pins.
     [Fact]
     public void Thickness_AndStrokeWidth_ShouldBeAliased_OnArcRuntime()
     {
         ArcRuntime sut = new ArcRuntime();
 
+#pragma warning disable CS0618 // Pinning the StrokeWidth alias is the whole point of this test.
         sut.Thickness = 7;
         sut.StrokeWidth.ShouldBe(7);
 
         sut.StrokeWidth = 12;
         sut.Thickness.ShouldBe(12);
+#pragma warning restore CS0618
     }
 
     // Regression for #2629 unification: the legacy default thickness of an Arc is 10. ArcRuntime
@@ -59,7 +62,9 @@ public class ArcRuntimeTests
         sut.StrokeWidthUnits = Gum.DataTypes.DimensionUnitType.Absolute;
 
         sut.Thickness.ShouldBe(10);
+#pragma warning disable CS0618 // Pinning the StrokeWidth alias is intentional here.
         sut.StrokeWidth.ShouldBe(10);
+#pragma warning restore CS0618
 
         var renderable = (IRenderable)sut.RenderableComponent;
         var shape = (RenderableShapeBase)sut.RenderableComponent;

--- a/Tests/SkiaGum.Tests/GueDeriving/ArcRuntimeTests.cs
+++ b/Tests/SkiaGum.Tests/GueDeriving/ArcRuntimeTests.cs
@@ -43,10 +43,29 @@ public class ArcRuntimeTests
     // this before unification; Skia inherited the base default. The unified ctor seeds 10 on
     // both so a freshly-constructed ArcRuntime renders visibly without consumer setup.
     [Fact]
-    public void ArcRuntime_StrokeWidth_DefaultShouldBe10()
+    public void ArcRuntime_Thickness_DefaultShouldBe10()
     {
         ArcRuntime arcRuntime = new();
-        arcRuntime.StrokeWidth.ShouldBe(10);
+        arcRuntime.Thickness.ShouldBe(10);
+    }
+
+    // Regression for the silent gradient suppression introduced by #2790 (commit 5c34a77).
+    // Before #2790, SkiaShapeRuntime.UseGradient passed straight through to the contained
+    // renderable; after #2790, RefreshSlotGradients gated it on `_fillColor != null`, which
+    // turned off gradient for every single-slot shape (Arc, RoundedRectangle, Polygon, etc.)
+    // used via the legacy `Color` API. Two-slot runtimes (Circle, Rectangle) were unaffected
+    // because their gate is per-slot and they always set FillColor/StrokeColor explicitly.
+    [Fact]
+    public void ArcRuntime_UseGradient_ShouldEnableGradientOnSingleSlotWithoutFillColor()
+    {
+        ArcRuntime arcRuntime = new();
+        Arc containedArc = (Arc)arcRuntime.RenderableComponent;
+
+        arcRuntime.UseGradient = true;
+
+        containedArc.UseGradient.ShouldBeTrue(
+            "single-slot Skia shapes must honor UseGradient even when FillColor is null " +
+            "(legacy Color API path) — regression from #2790's per-slot gate.");
     }
 
     [Fact]
@@ -55,8 +74,8 @@ public class ArcRuntimeTests
         ArcRuntime arcRuntime = new();
 
         var containedArc = (Arc)arcRuntime.RenderableComponent;
-        arcRuntime.StrokeWidth = 10;
-        containedArc.StrokeWidth.ShouldNotBe(10, "because the stroke width isn't applied until PreRender where the units are also considered");
+        arcRuntime.Thickness = 10;
+        containedArc.StrokeWidth.ShouldNotBe(10, "because the thickness isn't applied until PreRender where the units are also considered");
 
         arcRuntime.PreRender();
 

--- a/Tests/SkiaGum.Tests/Renderables/ArcTests.cs
+++ b/Tests/SkiaGum.Tests/Renderables/ArcTests.cs
@@ -1,0 +1,41 @@
+using Shouldly;
+using SkiaGum.Renderables;
+using SkiaSharp;
+
+namespace SkiaGum.Tests.Renderables;
+
+/// <summary>
+/// Renderable-level guards for the Skia <see cref="Arc"/> primitive. These cover behavior
+/// the runtime layer (<c>ArcRuntime</c>) cannot enforce on its own — anything that depends
+/// on how <c>Arc</c> constructs its paint or path.
+/// </summary>
+public class ArcTests
+{
+    // Skia's SKPath.AddArc autocloses an open path with a straight chord from the sweep
+    // endpoint back to the start when SKPaint.Style = Fill. That "circular segment" shape is
+    // a quirk of the Skia path API, not a feature anyone has asked for — the Apos.Shapes
+    // backend doesn't expose any equivalent and the Gum tool surfaces no IsFilled variable on
+    // arcs. Force Stroke style at the renderable so a stray `arc.IsFilled = true` (or a
+    // FillColor setter that flips IsFilled as a side effect) cannot produce the segment shape.
+    // True pie-wedge fills are reachable through the supported path: set Thickness = Width/2
+    // on a square arc and the stroke band collapses to a wedge.
+    [Fact]
+    public void Arc_GetPaint_ShouldAlwaysUseStrokeStyle_EvenWhenIsFilledIsTrue()
+    {
+        TestableArc arc = new();
+        arc.IsFilled = true;
+
+        using SKPaint paint = arc.InvokeGetPaint(new SKRect(0, 0, 100, 100), absoluteRotation: 0);
+
+        paint.Style.ShouldBe(
+            SKPaintStyle.Stroke,
+            "Arc must never render in Fill mode — Skia's SKPath.AddArc autocloses with a chord, " +
+            "producing a circular-segment shape that's neither a useful arc nor a useful wedge.");
+    }
+
+    private sealed class TestableArc : Arc
+    {
+        public SKPaint InvokeGetPaint(SKRect boundingRect, float absoluteRotation)
+            => GetPaint(boundingRect, absoluteRotation);
+    }
+}


### PR DESCRIPTION
## Summary

Three connected arc/shape cleanups surfaced while extending the Skia sample's `ArcRuntime` coverage in preparation for the raylib Arc port (#2866).

- **Fix gradient suppression on single-slot Skia shapes.** `SkiaShapeRuntime.RefreshSlotGradients` gated `UseGradient` on `_fillColor != null` for every shape — single-slot or two-slot. That silently disabled gradients on Arc, RoundedRectangle, Polygon, ColoredCircle, Line, and LineGrid when used via the legacy `Color` API (the pre-#2790 contract). Regressed in #2812. Fix: gate per-slot only when two-slot composition is engaged; pass through otherwise.
- **Seal Arc chord-fill.** Skia's `SKPath.AddArc` autocloses an open path with a chord from sweep-end back to start when filled, producing a circular-segment shape with no real UI use case. Apos.Shapes ignores `IsFilled` entirely; Skia did not. `RenderableShapeBase.IsFilled` is now `virtual`; `Arc` overrides it to always-false. True pie-wedge fills remain reachable via `Thickness = Width/2` on a square arc — the stroke band collapses to a wedge.
- **Promote `Thickness` as the canonical arc API.** `Thickness` and `StrokeWidth` are aliases for the same backing field. The Gum tool persists "Thickness" in `.gumx` and surfaces only that name in the Variables grid. `StrokeWidth` on `ArcRuntime` is now `[Obsolete]` (still works, same field) to steer new callers to `Thickness`. Extensive XML doc on `Thickness` covers the wedge config and gradient interaction.

## Sample

`Samples/SilkNetGum/SilkNetGum/Screens/ArcsScreen.cs` rebuilt to mirror `CirclesScreen` and exercise the full Arc surface: sweep angles, Thickness progression (thin → fat → wedge at W/2), end caps, gradients on stroke (including a gradient-filled wedge cell), dashed strokes, antialiasing, dropshadow. The gradient-stroke row pins the #2790 regression fix; the final cell is a gradient wedge demonstrating the Thickness = W/2 trick.

## Test plan

- [x] `dotnet test Tests/SkiaGum.Tests/SkiaGum.Tests.csproj` — 134/134 green, including the new `Arc_GetPaint_ShouldAlwaysUseStrokeStyle_EvenWhenIsFilledIsTrue` (chord-fill seal) and `ArcRuntime_UseGradient_ShouldEnableGradientOnSingleSlotWithoutFillColor` (#2790 regression).
- [x] `dotnet test Tests/MonoGameGum.Shapes.Tests/MonoGameGum.Shapes.Tests.csproj` — 58/58 green; existing alias test wrapped in `#pragma warning disable CS0618` to preserve coverage with the new obsolete marker.
- [x] `dotnet build Samples/SilkNetGum/SilkNetGum/SilkNetGum.csproj` — 0 warnings, 0 errors.
- [x] Visual check: run the Silk sample, open the Arcs screen, eyeball the Thickness-progression row (last cell is a true wedge), the gradient-stroke row (every cell shows a gradient — if any reads solid, the #2790 regression is back), and the gradient-wedge cell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)