### PR TITLE
#2866: Raylib Arc renderable + ArcRuntime raylib branch + sample parity

### DIFF
--- a/Runtimes/RaylibGum/RaylibGum.csproj
+++ b/Runtimes/RaylibGum/RaylibGum.csproj
@@ -121,6 +121,14 @@
 		<Compile Include="..\..\MonoGameGum\GueDeriving\SpriteRuntime.cs" Link="GueDeriving\SpriteRuntime.cs" />
 		<Compile Include="..\..\MonoGameGum\GueDeriving\TextRuntime.cs" Link="GueDeriving\TextRuntime.cs" />
 		<Compile Include="..\..\MonoGameGum\GueDeriving\CircleRuntime.cs" Link="GueDeriving\CircleRuntime.cs" />
+		<!--
+			ArcRuntime's canonical home is Runtimes/SkiaGum/GueDeriving/ (it's the
+			Skia <-> Apos.Shapes shape-runtime pair, not the MG/Raylib/Sokol axis - see
+			.claude/skills/gum-cross-platform-unification). Issue #2866 extended the
+			same file with a #if RAYLIB branch that wraps Gum.Renderables.LineArc, so
+			RaylibGum links the shared source in.
+		-->
+		<Compile Include="..\SkiaGum\GueDeriving\ArcRuntime.cs" Link="GueDeriving\ArcRuntime.cs" />
 		<Compile Include="..\..\MonoGameGum\GueDeriving\NineSliceRuntime.cs" Link="GueDeriving\NineSliceRuntime.cs" />
 		<Compile Include="..\..\MonoGameGum\GueDeriving\RectangleRuntime.cs" Link="GueDeriving\RectangleRuntime.cs" />
 		<Compile Include="..\..\MonoGameGum\GueDeriving\PolygonRuntime.cs" Link="GueDeriving\PolygonRuntime.cs" />

--- a/Runtimes/RaylibGum/Renderables/LineArc.cs
+++ b/Runtimes/RaylibGum/Renderables/LineArc.cs
@@ -1,0 +1,391 @@
+using RenderingLibrary;
+using RenderingLibrary.Graphics;
+using System.Numerics;
+using static Raylib_cs.Raylib;
+
+namespace Gum.Renderables;
+
+/// <summary>
+/// Raylib arc renderable. Issue #2866 — fills the gap that left arcs out of the raylib gallery
+/// when the rest of the shape suite landed in #2757. Models an arc as a stroked band along a
+/// circular curve inscribed in <see cref="IPositionedSizedObject.Width"/> /
+/// <see cref="IPositionedSizedObject.Height"/>; <see cref="Thickness"/> controls how wide the
+/// band is, with <c>Thickness = min(W,H)/2</c> collapsing the band to a true pie wedge (see the
+/// <see cref="Thickness"/> docs for the wedge configuration).
+/// </summary>
+/// <remarks>
+/// Single-primitive design (see #2866 PR comment): both the thin-stroke and the wedge
+/// configurations come out of one <c>DrawRing</c> call. No <c>IsFilled</c> flag, no separate
+/// fill/stroke slots — matches the post-#2891 Skia <c>Arc</c> contract where arcs are stroked
+/// only and the wedge is reached via Thickness = W/2.
+/// <para>
+/// Gradients are not implemented in this pass (deferred follow-up to #2866). The per-segment
+/// triangle-fan approach that <c>LineCircle</c> uses for radial/linear gradients on a full disk
+/// applies cleanly to a stroked arc band, but lands separately so this PR stays scoped to
+/// achieving the gallery-parity baseline.
+/// </para>
+/// </remarks>
+public class LineArc : InvisibleRenderable
+{
+    /// <summary>
+    /// Color slot used as the stroke color when <see cref="StrokeColor"/> is <c>null</c>.
+    /// Defaults to white so a freshly-constructed <see cref="LineArc"/> with no explicit color
+    /// renders visibly against the gallery's dark background.
+    /// </summary>
+    public Color Color { get; set; } = Color.White;
+
+    /// <summary>
+    /// Explicit stroke-pass color. When <c>null</c>, the stroke pass uses <see cref="Color"/>.
+    /// Matches the legacy/explicit color pattern <see cref="LineCircle"/> uses, so the shared
+    /// <c>ArcRuntime</c> raylib branch can route a single <c>StrokeColor</c> setter consistently
+    /// across both shapes.
+    /// </summary>
+    public Color? StrokeColor { get; set; }
+
+    /// <summary>
+    /// Angle, in degrees, at which the arc begins. A value of 0 points right (3 o'clock),
+    /// increasing values sweep counter-clockwise — matches the Gum convention shared with the
+    /// Skia and Apos.Shapes <c>Arc</c> renderables.
+    /// </summary>
+    public float StartAngle { get; set; }
+
+    /// <summary>
+    /// How far the arc sweeps from <see cref="StartAngle"/>, in degrees. 360 produces a full
+    /// ring. Defaults to 90, matching the post-#2891 <c>ArcRuntime</c> default.
+    /// </summary>
+    public float SweepAngle { get; set; } = 90f;
+
+    /// <summary>
+    /// Width of the stroked band along the arc curve, in pixels. See <c>ArcRuntime.Thickness</c>
+    /// for the full visual-progression docs (thin line → fat band → pie wedge at <c>W/2</c>).
+    /// Defaults to 10 to match the cross-backend <c>ArcRuntime</c> constructor default.
+    /// </summary>
+    public float Thickness { get; set; } = 10f;
+
+    /// <summary>
+    /// raylib has no per-shape stroke cap analog to Skia's <c>SKPaint.StrokeCap</c> — the
+    /// <c>DrawRing</c> primitive always produces flat (butt) radial ends. <c>IsEndRounded = true</c>
+    /// is therefore a visual no-op on raylib in this pass; the property is preserved for API
+    /// parity with the Skia/Apos branches so the shared <c>ArcRuntime</c> can push the value
+    /// uniformly. A future pass could approximate rounded caps with two <c>DrawCircleSector</c>
+    /// half-disks at each end, but the issue body does not call for it and the gallery's
+    /// end-cap row is omitted on raylib for the same reason.
+    /// </summary>
+    public bool IsEndRounded { get; set; }
+
+    /// <summary>
+    /// Length in world-space pixels of each dash segment around the arc curve. A value of 0
+    /// (the default) draws a solid stroke. Both <see cref="StrokeDashLength"/> and
+    /// <see cref="StrokeGapLength"/> must be &gt; 0 for dashed rendering to engage. Implemented
+    /// via a per-dash <c>DrawRing</c> sub-arc loop, same pattern <see cref="LineCircle"/> uses
+    /// for dashed circles.
+    /// </summary>
+    public float StrokeDashLength { get; set; }
+
+    /// <summary>
+    /// Length in world-space pixels of each gap between dashes. Ignored when
+    /// <see cref="StrokeDashLength"/> is 0.
+    /// </summary>
+    public float StrokeGapLength { get; set; }
+
+    /// <summary>
+    /// When <c>true</c>, a dropshadow pass renders behind the stroke using
+    /// <see cref="DropshadowColor"/>, offset by <see cref="DropshadowOffsetX"/> /
+    /// <see cref="DropshadowOffsetY"/>, with an isotropic blur radius of
+    /// <c>max(DropshadowBlurX, DropshadowBlurY)</c>. Approximated the same way
+    /// <see cref="LineCircle"/> approximates its dropshadow — concentric semi-transparent bands
+    /// of decreasing alpha. Inherits the band-stacking overshoot tracked in #2865; the arc
+    /// renderable will pick up the fix for free when #2865 lands its RT + separable-blur
+    /// replacement.
+    /// </summary>
+    public bool HasDropshadow { get; set; }
+
+    /// <summary>Color of the dropshadow band (alpha channel scales the falloff).</summary>
+    public Color DropshadowColor { get; set; } = new Color((byte)0, (byte)0, (byte)0, (byte)255);
+
+    /// <summary>X offset of the dropshadow band in world-space pixels.</summary>
+    public float DropshadowOffsetX { get; set; }
+
+    /// <summary>Y offset of the dropshadow band in world-space pixels.</summary>
+    public float DropshadowOffsetY { get; set; }
+
+    /// <inheritdoc cref="SkiaGum.GueDeriving.SkiaShapeRuntime.DropshadowBlurX"/>
+    /// <remarks>raylib note: treated as isotropic with <see cref="DropshadowBlurY"/> —
+    /// rendering collapses anisotropic blur to <c>max(BlurX, BlurY)</c>.</remarks>
+    public float DropshadowBlurX { get; set; }
+
+    /// <inheritdoc cref="SkiaGum.GueDeriving.SkiaShapeRuntime.DropshadowBlurX"/>
+    /// <remarks>raylib note: treated as isotropic with <see cref="DropshadowBlurX"/> —
+    /// rendering collapses anisotropic blur to <c>max(BlurX, BlurY)</c>.</remarks>
+    public float DropshadowBlurY { get; set; }
+
+    /// <inheritdoc/>
+    public override int Alpha
+    {
+        get => Color.A;
+        set
+        {
+            if (value != Color.A)
+            {
+                Color = new Color(Color.R, Color.G, Color.B, (byte)value);
+            }
+        }
+    }
+
+    /// <summary>Red channel of the legacy <see cref="Color"/> slot.</summary>
+    public int Red
+    {
+        get => Color.R;
+        set
+        {
+            if (value != Color.R)
+            {
+                Color = new Color((byte)value, Color.G, Color.B, Color.A);
+            }
+        }
+    }
+
+    /// <summary>Green channel of the legacy <see cref="Color"/> slot.</summary>
+    public int Green
+    {
+        get => Color.G;
+        set
+        {
+            if (value != Color.G)
+            {
+                Color = new Color(Color.R, (byte)value, Color.B, Color.A);
+            }
+        }
+    }
+
+    /// <summary>Blue channel of the legacy <see cref="Color"/> slot.</summary>
+    public int Blue
+    {
+        get => Color.B;
+        set
+        {
+            if (value != Color.B)
+            {
+                Color = new Color(Color.R, Color.G, (byte)value, Color.A);
+            }
+        }
+    }
+
+    /// <inheritdoc cref="LineArc"/>
+    public LineArc() : this(null) { }
+
+    /// <inheritdoc cref="LineArc"/>
+    public LineArc(SystemManagers? _) { }
+
+    /// <inheritdoc/>
+    public override void Render(ISystemManagers managers)
+    {
+        if (!Visible)
+        {
+            return;
+        }
+
+        // Curve is inscribed in the bounding box, anchored at the box's center. Mirrors the
+        // way Skia's path.AddArc(boundingRect, ...) treats the rect — the arc fits the smaller
+        // of W/H so non-square bounds still render a circular (not elliptical) arc.
+        float halfW = Width * 0.5f;
+        float halfH = Height * 0.5f;
+        float outerRadius = System.MathF.Min(halfW, halfH);
+        if (outerRadius <= 0f)
+        {
+            return;
+        }
+        // Thickness > 2 * outerRadius is undefined territory (matches the Skia/Apos contract —
+        // see ArcRuntime.Thickness docs). Clamp so the inner radius doesn't go negative and the
+        // wedge configuration (Thickness = outerRadius) still works cleanly.
+        float thickness = System.MathF.Min(Thickness, outerRadius * 2f);
+        float innerRadius = System.MathF.Max(0f, outerRadius - thickness);
+
+        float cx = this.GetAbsoluteLeft() + halfW;
+        float cy = this.GetAbsoluteTop() + halfH;
+
+        // raylib's DrawRing uses degrees with 0 at 3 o'clock and increasing angles sweeping
+        // clockwise on screen (y-down). Gum's convention is 0 at 3 o'clock with increasing
+        // angles sweeping counter-clockwise (the renderable inherits this from the Skia/Apos
+        // Arc primitives). Negate both StartAngle and SweepAngle to flip CCW→CW; raylib's
+        // DrawRing handles startAngle > endAngle by stepping with a negative delta, so the arc
+        // direction stays correct visually.
+        float startAngleDeg = -StartAngle;
+        float endAngleDeg = -StartAngle - SweepAngle;
+        int segments = ComputeSegments(outerRadius, System.MathF.Abs(SweepAngle));
+
+        Color strokeColor = StrokeColor ?? Color;
+
+        if (HasDropshadow)
+        {
+            DrawDropshadow(cx, cy, innerRadius, outerRadius, startAngleDeg, endAngleDeg,
+                segments, strokeColor.A);
+        }
+
+        bool dashed = StrokeDashLength > 0f && StrokeGapLength > 0f && SweepAngle != 0f;
+        if (dashed)
+        {
+            DrawDashed(new Vector2(cx, cy), innerRadius, outerRadius, strokeColor);
+        }
+        else
+        {
+            DrawRing(new Vector2(cx, cy), innerRadius, outerRadius,
+                startAngleDeg, endAngleDeg, segments, strokeColor);
+        }
+    }
+
+    /// <summary>
+    /// Translate the user's dash/gap pixel lengths into arc-angle sweeps along the curve and
+    /// emit one <c>DrawRing</c> per dash. raylib has no built-in path-effect dash (Skia has
+    /// <c>SKPathEffect.CreateDash</c>); the loop walks the SweepAngle in dash + gap angular
+    /// steps. Same pattern <see cref="LineCircle"/> uses for its dashed ring.
+    /// </summary>
+    private void DrawDashed(Vector2 center, float innerRadius, float outerRadius, Color strokeColor)
+    {
+        // Use the band's centerline circumference so dash pixel-lengths feel consistent at
+        // different thicknesses (matches the visual the Skia dashed-stroke path produces, which
+        // centers dashes on the stroked path).
+        float curveRadius = (innerRadius + outerRadius) * 0.5f;
+        if (curveRadius <= 0f)
+        {
+            // Wedge configuration (innerRadius = 0) — the curve has zero "length" at the
+            // center, so fall back to the outer radius. A dashed wedge is unusual anyway; this
+            // keeps the math defined rather than dividing by zero.
+            curveRadius = outerRadius;
+        }
+        float circumference = 2f * System.MathF.PI * curveRadius;
+        float dashAngleDeg = (StrokeDashLength / circumference) * 360f;
+        float gapAngleDeg = (StrokeGapLength / circumference) * 360f;
+        float patternAngleDeg = dashAngleDeg + gapAngleDeg;
+        if (patternAngleDeg <= 0f)
+        {
+            return;
+        }
+
+        // Per-dash segment count proportional to the dash arc — ~4° per segment is smooth at
+        // typical radii. Floor at 1 so tiny dashes still render at least one triangle pair.
+        int segmentsPerDash = System.Math.Max(1, (int)(dashAngleDeg / 4f));
+
+        // Walk SweepAngle in the renderable's native CCW direction, mapping each dash's
+        // [startGum, endGum] into raylib's negated angle space. Caps the loop at the absolute
+        // sweep so dashes do not overflow past the arc end.
+        float sweepAbs = System.MathF.Abs(SweepAngle);
+        float sweepSign = SweepAngle >= 0f ? 1f : -1f;
+        float currentAngle = 0f;
+        while (currentAngle < sweepAbs)
+        {
+            float dashEnd = System.MathF.Min(currentAngle + dashAngleDeg, sweepAbs);
+            float dashStartGum = StartAngle + sweepSign * currentAngle;
+            float dashEndGum = StartAngle + sweepSign * dashEnd;
+            float dashStartRl = -dashStartGum;
+            float dashEndRl = -dashEndGum;
+            DrawRing(center, innerRadius, outerRadius, dashStartRl, dashEndRl,
+                segmentsPerDash, strokeColor);
+            currentAngle += patternAngleDeg;
+        }
+    }
+
+    /// <summary>
+    /// Concentric band approximation of a blurred dropshadow silhouette. Mirrors the
+    /// <see cref="LineCircle"/> approach — same source-over inversion to land each band's
+    /// per-pixel alpha on a linear (1 - t) target profile, same #2851 body-alpha multiply, same
+    /// inheritance of the #2865 stacking overshoot. The shape difference is that the arc's
+    /// silhouette is a stroke band rather than a filled disk, so each "band" here is itself a
+    /// <c>DrawRing</c> whose width grows outward from the nominal thickness.
+    /// </summary>
+    private void DrawDropshadow(float cx, float cy, float innerRadius, float outerRadius,
+        float startAngleDeg, float endAngleDeg, int segments, byte bodyAlpha)
+    {
+        float shadowCx = cx + DropshadowOffsetX;
+        float shadowCy = cy + DropshadowOffsetY;
+        float blur = System.MathF.Max(DropshadowBlurX, DropshadowBlurY);
+
+        // Issue #2851: scale shadow alpha by the body alpha so fading the arc also fades the
+        // shadow. The renderable reads stroke alpha as "the body" — arcs have no separate fill.
+        Color effectiveDropshadowColor = new Color(
+            DropshadowColor.R,
+            DropshadowColor.G,
+            DropshadowColor.B,
+            (byte)(DropshadowColor.A * bodyAlpha / 255));
+
+        Vector2 shadowCenter = new Vector2(shadowCx, shadowCy);
+
+        if (blur <= 0f)
+        {
+            // Hard offset silhouette — single DrawRing matching the nominal band.
+            DrawRing(shadowCenter, innerRadius, outerRadius, startAngleDeg, endAngleDeg,
+                segments, effectiveDropshadowColor);
+            return;
+        }
+
+        // Match LineCircle's band layout: bands span [R - blur, R + blur] (total width 2*blur)
+        // outward from the nominal silhouette edge. For an arc band, "outward" is both
+        // directions — the outer edge expands outward, the inner edge expands inward. Each
+        // ring's width grows by 2 * (bandSpan - j*bandThickness) so the outermost (j=0) ring is
+        // the widest with the lowest alpha and the innermost (j=N-1) ring is barely wider than
+        // the nominal band with the highest alpha. The final solid-core DrawRing matches the
+        // nominal band exactly to close the alpha gap.
+        const int blurRings = 32;
+        float bandSpan = blur;
+        float totalExtent = 2f * bandSpan;
+        float bandThickness = totalExtent / blurRings;
+        float f = effectiveDropshadowColor.A / 255f;
+        float prevP = 1f;
+        for (int j = blurRings - 1; j >= 0; j--)
+        {
+            float tOuter = (j + 1f) / blurRings;
+            float profileAlpha = System.MathF.Max(0f, 1f - tOuter);
+            float targetAlpha = f * profileAlpha;
+            float currP = 1f - targetAlpha;
+            float beta = prevP > 0f ? 1f - currP / prevP : 0f;
+            prevP = currP;
+            byte bandAlpha = (byte)(255f * beta + 0.5f);
+            if (bandAlpha == 0)
+            {
+                continue;
+            }
+            Color bandColor = new Color(effectiveDropshadowColor.R, effectiveDropshadowColor.G,
+                effectiveDropshadowColor.B, bandAlpha);
+            float ringOuter = outerRadius + bandSpan - (j * bandThickness);
+            float ringInner = System.MathF.Max(0f, innerRadius - bandSpan + (j * bandThickness));
+            if (ringOuter > ringInner)
+            {
+                DrawRing(shadowCenter, ringInner, ringOuter, startAngleDeg, endAngleDeg,
+                    segments, bandColor);
+            }
+        }
+
+        // Solid core matching the nominal band closes the remaining alpha gap between the
+        // band stack's accumulated alpha (prevP) and the target final alpha (1 - f). Same
+        // source-over inversion LineCircle uses for its inner core.
+        if (prevP > 1f - f)
+        {
+            float coreBeta = 1f - (1f - f) / prevP;
+            byte coreAlpha = (byte)(255f * coreBeta + 0.5f);
+            if (coreAlpha > 0)
+            {
+                Color coreColor = new Color(effectiveDropshadowColor.R,
+                    effectiveDropshadowColor.G, effectiveDropshadowColor.B, coreAlpha);
+                DrawRing(shadowCenter, innerRadius, outerRadius, startAngleDeg, endAngleDeg,
+                    segments, coreColor);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Segment count proportional to the curve's arc length so the polyline approximation
+    /// stays smooth at large radii and wide sweeps without paying the cost of dense
+    /// tessellation on tiny / narrow arcs. ~3° per segment is the visual floor; framebuffer
+    /// MSAA covers the rest. Mirrors the segment heuristic <see cref="LineCircle"/> uses.
+    /// </summary>
+    private static int ComputeSegments(float radius, float sweepDegrees)
+    {
+        if (sweepDegrees <= 0f)
+        {
+            return 1;
+        }
+        int fromRadius = (int)(radius * 2f * (sweepDegrees / 360f));
+        int fromAngle = (int)(sweepDegrees / 3f);
+        return System.Math.Max(8, System.Math.Max(fromRadius, fromAngle));
+    }
+}

--- a/Runtimes/SkiaGum/GueDeriving/ArcRuntime.cs
+++ b/Runtimes/SkiaGum/GueDeriving/ArcRuntime.cs
@@ -1,7 +1,13 @@
 using Gum.Wireframe;
 using System;
 
-#if SKIA
+#if RAYLIB
+using Gum.DataTypes;
+using Gum.Renderables;
+using RenderingLibrary;
+using Color = Raylib_cs.Color;
+using ColorExtensions = RaylibGum.Helpers.ColorExtensions;
+#elif SKIA
 using SkiaGum.Renderables;
 using SkiaSharp;
 using RenderingLibrary.Graphics;
@@ -19,6 +25,386 @@ namespace MonoGameGum.GueDeriving;
 namespace Gum.GueDeriving;
 #endif
 
+#if RAYLIB
+/// <summary>
+/// Raylib branch of <c>ArcRuntime</c>. Wraps the <see cref="LineArc"/> renderable added in
+/// issue #2866 and exposes the cross-backend arc surface (StartAngle, SweepAngle, Thickness,
+/// IsEndRounded, dashed strokes, dropshadow) so cross-platform sample code reads the same
+/// against Skia, Apos.Shapes, and raylib. Single-slot composition — arcs have no fill mode on
+/// any backend (sealed in PR #2891).
+/// </summary>
+/// <remarks>
+/// Gradients on arcs are intentionally not exposed in this pass (deferred follow-up to #2866)
+/// — see <see cref="LineArc"/> for the renderable-side rationale. <see cref="StrokeColor"/> is
+/// the single user-facing color slot, mirroring the post-PR-#2891 Skia <c>ArcRuntime</c>'s API.
+/// </remarks>
+public class ArcRuntime : GraphicalUiElement
+{
+    LineArc containedLineArc = null!;
+    LineArc ContainedLineArc
+    {
+        get
+        {
+            if (containedLineArc == null)
+            {
+                containedLineArc = (LineArc)this.RenderableComponent!;
+            }
+            return containedLineArc;
+        }
+    }
+
+    /// <inheritdoc cref="LineArc.StartAngle"/>
+    public float StartAngle
+    {
+        get => ContainedLineArc.StartAngle;
+        set
+        {
+            ContainedLineArc.StartAngle = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    /// <inheritdoc cref="LineArc.SweepAngle"/>
+    public float SweepAngle
+    {
+        get => ContainedLineArc.SweepAngle;
+        set
+        {
+            ContainedLineArc.SweepAngle = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    /// <inheritdoc cref="LineArc.IsEndRounded"/>
+    /// <remarks>raylib does not natively support rounded end caps on <c>DrawRing</c>; the
+    /// setter round-trips and pushes through to the renderable, where it is currently a
+    /// visual no-op. Preserved for API parity with the Skia/Apos branches.</remarks>
+    public bool IsEndRounded
+    {
+        get => ContainedLineArc.IsEndRounded;
+        set
+        {
+            ContainedLineArc.IsEndRounded = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    /// <summary>
+    /// Legacy single-color slot. Routes to the renderable's <see cref="LineArc.Color"/>; used as
+    /// the stroke color when <see cref="StrokeColor"/> is <c>null</c>. Matches the cross-backend
+    /// "Color is the legacy slot, StrokeColor is the explicit modern slot" pattern that
+    /// <see cref="CircleRuntime"/> and <see cref="RectangleRuntime"/> use on raylib.
+    /// </summary>
+    public Color Color
+    {
+        get => ContainedLineArc.Color;
+        set
+        {
+            ContainedLineArc.Color = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    /// <inheritdoc cref="LineArc.StrokeColor"/>
+    public Color? StrokeColor
+    {
+        get => ContainedLineArc.StrokeColor;
+        set
+        {
+            ContainedLineArc.StrokeColor = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    /// <summary>Alpha channel of the legacy <see cref="Color"/> slot.</summary>
+    public int Alpha
+    {
+        get => ContainedLineArc.Color.A;
+        set
+        {
+            ContainedLineArc.Color = ColorExtensions.WithAlpha(ContainedLineArc.Color, (byte)value);
+            NotifyPropertyChanged();
+        }
+    }
+
+    /// <summary>Red channel of the legacy <see cref="Color"/> slot.</summary>
+    public int Red
+    {
+        get => ContainedLineArc.Color.R;
+        set
+        {
+            ContainedLineArc.Color = ColorExtensions.WithRed(ContainedLineArc.Color, (byte)value);
+            NotifyPropertyChanged();
+        }
+    }
+
+    /// <summary>Green channel of the legacy <see cref="Color"/> slot.</summary>
+    public int Green
+    {
+        get => ContainedLineArc.Color.G;
+        set
+        {
+            ContainedLineArc.Color = ColorExtensions.WithGreen(ContainedLineArc.Color, (byte)value);
+            NotifyPropertyChanged();
+        }
+    }
+
+    /// <summary>Blue channel of the legacy <see cref="Color"/> slot.</summary>
+    public int Blue
+    {
+        get => ContainedLineArc.Color.B;
+        set
+        {
+            ContainedLineArc.Color = ColorExtensions.WithBlue(ContainedLineArc.Color, (byte)value);
+            NotifyPropertyChanged();
+        }
+    }
+
+    float _thickness;
+
+    /// <summary>
+    /// Width of the stroked band along the arc curve, in <see cref="StrokeWidthUnits"/>.
+    /// <c>Thickness</c> is the canonical user-facing name on arcs and the variable the Gum
+    /// tool persists in <c>.gumx</c>; see the Skia/Apos branch of this class for the full
+    /// visual-progression docs (thin → fat → wedge at <c>Width/2</c>).
+    /// </summary>
+    public float Thickness
+    {
+        get => _thickness;
+        set
+        {
+            _thickness = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    /// <summary>
+    /// Obsolete alias for <see cref="Thickness"/> on raylib too, matching the Skia/Apos branch.
+    /// Same backing field; the obsolete marker is purely a steering hint toward the canonical
+    /// user-facing name.
+    /// </summary>
+    [Obsolete("Use Thickness instead — it's the canonical user-facing name for arc stroke weight and the variable name the Gum tool persists. StrokeWidth still works (same backing field) but new code should prefer Thickness.")]
+    public float StrokeWidth
+    {
+        get => _thickness;
+        set
+        {
+            _thickness = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    DimensionUnitType _strokeWidthUnits;
+
+    /// <inheritdoc cref="CircleRuntime.StrokeWidthUnits"/>
+    public DimensionUnitType StrokeWidthUnits
+    {
+        get => _strokeWidthUnits;
+        set
+        {
+            _strokeWidthUnits = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    float _strokeDashLength;
+
+    /// <inheritdoc cref="LineArc.StrokeDashLength"/>
+    public float StrokeDashLength
+    {
+        get => _strokeDashLength;
+        set
+        {
+            _strokeDashLength = value;
+            ContainedLineArc.StrokeDashLength = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    float _strokeGapLength;
+
+    /// <inheritdoc cref="LineArc.StrokeGapLength"/>
+    public float StrokeGapLength
+    {
+        get => _strokeGapLength;
+        set
+        {
+            _strokeGapLength = value;
+            ContainedLineArc.StrokeGapLength = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    bool _hasDropshadow;
+
+    /// <inheritdoc cref="LineArc.HasDropshadow"/>
+    public bool HasDropshadow
+    {
+        get => _hasDropshadow;
+        set
+        {
+            _hasDropshadow = value;
+            ContainedLineArc.HasDropshadow = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    Color _dropshadowColor = new Color((byte)0, (byte)0, (byte)0, (byte)255);
+
+    /// <inheritdoc cref="LineArc.DropshadowColor"/>
+    public Color DropshadowColor
+    {
+        get => _dropshadowColor;
+        set
+        {
+            _dropshadowColor = value;
+            ContainedLineArc.DropshadowColor = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    /// <summary>Alpha channel of <see cref="DropshadowColor"/>.</summary>
+    public int DropshadowAlpha
+    {
+        get => _dropshadowColor.A;
+        set => DropshadowColor = new Color(_dropshadowColor.R, _dropshadowColor.G, _dropshadowColor.B, (byte)value);
+    }
+
+    /// <summary>Red channel of <see cref="DropshadowColor"/>.</summary>
+    public int DropshadowRed
+    {
+        get => _dropshadowColor.R;
+        set => DropshadowColor = new Color((byte)value, _dropshadowColor.G, _dropshadowColor.B, _dropshadowColor.A);
+    }
+
+    /// <summary>Green channel of <see cref="DropshadowColor"/>.</summary>
+    public int DropshadowGreen
+    {
+        get => _dropshadowColor.G;
+        set => DropshadowColor = new Color(_dropshadowColor.R, (byte)value, _dropshadowColor.B, _dropshadowColor.A);
+    }
+
+    /// <summary>Blue channel of <see cref="DropshadowColor"/>.</summary>
+    public int DropshadowBlue
+    {
+        get => _dropshadowColor.B;
+        set => DropshadowColor = new Color(_dropshadowColor.R, _dropshadowColor.G, (byte)value, _dropshadowColor.A);
+    }
+
+    float _dropshadowOffsetX;
+    /// <inheritdoc cref="LineArc.DropshadowOffsetX"/>
+    public float DropshadowOffsetX
+    {
+        get => _dropshadowOffsetX;
+        set
+        {
+            _dropshadowOffsetX = value;
+            ContainedLineArc.DropshadowOffsetX = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    float _dropshadowOffsetY;
+    /// <inheritdoc cref="LineArc.DropshadowOffsetY"/>
+    public float DropshadowOffsetY
+    {
+        get => _dropshadowOffsetY;
+        set
+        {
+            _dropshadowOffsetY = value;
+            ContainedLineArc.DropshadowOffsetY = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    float _dropshadowBlurX;
+    /// <inheritdoc cref="LineArc.DropshadowBlurX"/>
+    public float DropshadowBlurX
+    {
+        get => _dropshadowBlurX;
+        set
+        {
+            _dropshadowBlurX = value;
+            ContainedLineArc.DropshadowBlurX = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    float _dropshadowBlurY;
+    /// <inheritdoc cref="LineArc.DropshadowBlurY"/>
+    public float DropshadowBlurY
+    {
+        get => _dropshadowBlurY;
+        set
+        {
+            _dropshadowBlurY = value;
+            ContainedLineArc.DropshadowBlurY = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    /// <summary>
+    /// Initializes a new raylib <c>ArcRuntime</c>. Constructor defaults mirror the Skia/Apos
+    /// branch so cross-backend sample code starts from the same baseline (Width = Height = 100,
+    /// SweepAngle = 90, Thickness = 10, Color = White, dropshadow off but pre-seeded with a
+    /// 3 px Y offset/blur). Pass <c>fullInstantiation = false</c> only when constructing through
+    /// deserialization.
+    /// </summary>
+    public ArcRuntime(bool fullInstantiation = true)
+    {
+        if (fullInstantiation)
+        {
+            LineArc arc = new();
+            SetContainedObject(arc);
+            containedLineArc = arc;
+
+            Width = 100;
+            Height = 100;
+            Thickness = 10;
+            StartAngle = 0;
+            SweepAngle = 90;
+
+            // Pre-seed dropshadow offset/blur so toggling HasDropshadow = true at runtime
+            // produces a visible shadow without further setup — same default the Skia/Apos
+            // branch lands via the SkiaShapeRuntime/AposShapeRuntime constructor.
+            DropshadowOffsetX = 0;
+            DropshadowOffsetY = 3;
+            DropshadowBlurX = 0;
+            DropshadowBlurY = 3;
+        }
+    }
+
+    /// <summary>
+    /// Pushes the stroke thickness to the contained <see cref="LineArc"/> each frame, resolving
+    /// <see cref="StrokeWidthUnits"/> against the current camera zoom so a ScreenPixel-unit
+    /// thickness holds its on-screen pixel width regardless of zoom. Mirrors the raylib
+    /// <see cref="CircleRuntime.PreRender"/> pattern.
+    /// </summary>
+    public override void PreRender()
+    {
+        float thickness = _thickness;
+        if (_strokeWidthUnits == DimensionUnitType.ScreenPixel)
+        {
+            var camera = this.EffectiveManagers?.Renderer?.Camera;
+            if (camera != null)
+            {
+                thickness /= camera.Zoom;
+            }
+        }
+        ContainedLineArc.Thickness = thickness;
+    }
+
+    /// <inheritdoc/>
+    public override GraphicalUiElement Clone()
+    {
+        ArcRuntime toReturn = (ArcRuntime)base.Clone();
+        // Drop the cached renderable reference so the clone re-resolves it against its own
+        // RenderableComponent on next access. Same pattern as the Skia/Apos branch's Clone.
+        toReturn.containedLineArc = null!;
+        return toReturn;
+    }
+}
+#else
 /// <summary>
 /// Runtime that draws a circular arc inscribed in its Width x Height bounds. Arcs are always
 /// stroked — there is no fill mode. Use <see cref="Thickness"/> to control how thick the band
@@ -26,12 +412,14 @@ namespace Gum.GueDeriving;
 /// the bounds" (see the <see cref="Thickness"/> docs for the wedge configuration).
 /// </summary>
 /// <remarks>
-/// Source-shared between SkiaGum and MonoGameGumShapes (and KniGumShapes) via a Compile/Link in
-/// the Apos-side csprojs - see <c>RoundedRectangleRuntime</c> for the same pattern. Platform
-/// differences are gated behind <c>#if SKIA</c>; the cross-platform shape (constructor defaults,
-/// StartAngle/SweepAngle/IsEndRounded properties, base wiring) is shared. Dashed strokes are
-/// only rendered on Skia (Apos.Shapes' Arc primitive lacks dashing); the <c>StrokeDashLength</c>
-/// property is exposed on both backends via the base class for API parity but no-ops on Apos.
+/// Source-shared between SkiaGum, MonoGameGumShapes / KniGumShapes, and the raylib runtime via a
+/// Compile/Link in the consuming csprojs - see <c>RoundedRectangleRuntime</c> for the same
+/// pattern. Platform differences are gated behind <c>#if SKIA</c> / <c>#if RAYLIB</c>; the raylib
+/// branch is a separate class definition above this one because it inherits from a different
+/// base (<c>GraphicalUiElement</c> directly, not <c>SkiaShapeRuntime</c>/<c>AposShapeRuntime</c>),
+/// so the property surface differs. Dashed strokes are only rendered on Skia and raylib;
+/// Apos.Shapes' Arc primitive lacks dashing, so on that backend <c>StrokeDashLength</c> is
+/// exposed via the base class for API parity but no-ops.
 /// </remarks>
 public class ArcRuntime
 #if SKIA
@@ -222,3 +610,4 @@ public class ArcRuntime
         return toReturn;
     }
 }
+#endif

--- a/Samples/SilkNetGum/SilkNetGum/SilkNetGum.csproj
+++ b/Samples/SilkNetGum/SilkNetGum/SilkNetGum.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<OutputType>Exe</OutputType>
+		<OutputType>WinExe</OutputType>
 		<TargetFramework>net8.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>

--- a/Samples/raylib/Program.cs
+++ b/Samples/raylib/Program.cs
@@ -82,6 +82,7 @@ public class BasicShapes
         AddNavButton("Circles", () => new CirclesScreen());
         AddNavButton("Rectangles", () => new RectanglesScreen());
         AddNavButton("Polygons", () => new PolygonsScreen());
+        AddNavButton("Arcs", () => new ArcsScreen());
 
         AddFitModeRadio("Zoom", isChecked: true, () => GumUI.EnableZoomToWindow());
         AddFitModeRadio("Expand", isChecked: false, () => GumUI.EnableExpandToWindow());

--- a/Samples/raylib/Screens/ArcsScreen.cs
+++ b/Samples/raylib/Screens/ArcsScreen.cs
@@ -1,0 +1,238 @@
+using Gum.DataTypes;
+using Gum.Forms.Controls;
+using Gum.GueDeriving;
+using Gum.Managers;
+using Gum.Wireframe;
+using Raylib_cs;
+using RenderingLibrary.Graphics;
+
+namespace Examples.Shapes;
+
+// Issue #2866 - raylib mirror of the post-PR-#2891 Skia ArcsScreen
+// (Samples/SilkNetGum/SilkNetGum/Screens/ArcsScreen.cs). Section order and parameter sweeps are
+// kept aligned so visual regressions in either backend are easy to spot when the two galleries
+// run side by side.
+//
+// What's intentionally NOT mirrored:
+//   * "End caps" - raylib's DrawRing only produces flat ends; rounded caps are no-ops on this
+//     backend (#2866 calls it out explicitly). A future pass could approximate rounded caps
+//     with DrawCircleSector half-disks.
+//   * "Gradients" - deferred to a follow-up; the issue comment lists it as a stretch goal.
+//   * "Antialiasing" - raylib has no per-shape AA. Framebuffer MSAA (Msaa4xHint in Program.cs)
+//     is the only AA path, so toggling IsAntialiased would render identically.
+internal class ArcsScreen : FrameworkElement
+{
+    public ArcsScreen() : base(new ContainerRuntime())
+    {
+        Dock(Gum.Wireframe.Dock.Fill);
+
+        ContainerRuntime root = new();
+        root.ChildrenLayout = ChildrenLayout.LeftToRightStack;
+        root.StackSpacing = 24;
+        root.X = 10;
+        root.Y = 10;
+        this.AddChild(root);
+
+        ContainerRuntime left = BuildColumn();
+        ContainerRuntime right = BuildColumn();
+        root.Children.Add(left);
+        root.Children.Add(right);
+
+        left.Children.Add(BuildSection("Sweep angles (90, 180, 270, 360)", BuildSweepRow()));
+        left.Children.Add(BuildSection("Thickness progression: thin -> fat -> wedge (W/2)", BuildThicknessProgressionRow()));
+
+        right.Children.Add(BuildSection("Dashed strokes", BuildDashedStrokeRow()));
+        right.Children.Add(BuildSection("Dropshadow (off / soft / hard / colored / faded body)", BuildDropshadowRow()));
+    }
+
+    static ContainerRuntime BuildColumn()
+    {
+        ContainerRuntime column = new();
+        column.ChildrenLayout = ChildrenLayout.TopToBottomStack;
+        column.StackSpacing = 14;
+        column.WidthUnits = DimensionUnitType.RelativeToChildren;
+        column.HeightUnits = DimensionUnitType.RelativeToChildren;
+        column.Width = 0;
+        column.Height = 0;
+        return column;
+    }
+
+    static ContainerRuntime BuildSection(string label, GraphicalUiElement body)
+    {
+        ContainerRuntime section = new();
+        section.ChildrenLayout = ChildrenLayout.TopToBottomStack;
+        section.StackSpacing = 4;
+        section.WidthUnits = DimensionUnitType.RelativeToChildren;
+        section.HeightUnits = DimensionUnitType.RelativeToChildren;
+        section.Width = 0;
+        section.Height = 0;
+
+        TextRuntime header = new();
+        header.Text = label;
+        header.Red = 220;
+        header.Green = 220;
+        header.Blue = 220;
+        section.Children.Add(header);
+        section.Children.Add(body);
+        return section;
+    }
+
+    static ContainerRuntime BuildHorizontalRow()
+    {
+        ContainerRuntime row = new();
+        row.ChildrenLayout = ChildrenLayout.LeftToRightStack;
+        row.StackSpacing = 16;
+        row.WidthUnits = DimensionUnitType.RelativeToChildren;
+        row.HeightUnits = DimensionUnitType.RelativeToChildren;
+        row.Width = 0;
+        row.Height = 0;
+        return row;
+    }
+
+    static ContainerRuntime BuildSweepRow()
+    {
+        ContainerRuntime row = BuildHorizontalRow();
+        foreach (float sweep in new[] { 90f, 180f, 270f, 360f })
+        {
+            ArcRuntime arc = new();
+            arc.Width = 60;
+            arc.Height = 60;
+            arc.SweepAngle = sweep;
+            arc.Thickness = 8;
+            arc.StrokeColor = new Color(218, 165, 32, 255);
+            row.Children.Add(arc);
+        }
+        return row;
+    }
+
+    // Thickness progression - last cell hits Thickness = Width / 2 (a true pie wedge). Same
+    // values as the Skia gallery so the two galleries read identically side by side.
+    static ContainerRuntime BuildThicknessProgressionRow()
+    {
+        ContainerRuntime row = BuildHorizontalRow();
+        foreach (float thickness in new[] { 2f, 8f, 18f, 30f })
+        {
+            ArcRuntime arc = new();
+            arc.Width = 60;
+            arc.Height = 60;
+            arc.SweepAngle = 90;
+            arc.Thickness = thickness;
+            arc.StrokeColor = new Color(144, 238, 144, 255);
+            row.Children.Add(arc);
+        }
+        return row;
+    }
+
+    // Mirrors the Skia gallery's dashed-stroke row - same dash/gap pairs and same Thickness
+    // values so dashed arcs look comparable across backends.
+    static ContainerRuntime BuildDashedStrokeRow()
+    {
+        ContainerRuntime row = BuildHorizontalRow();
+
+        ArcRuntime solid = new();
+        solid.Width = 60; solid.Height = 60;
+        solid.SweepAngle = 270;
+        solid.Thickness = 2;
+        solid.StrokeColor = Color.White;
+        row.Children.Add(solid);
+
+        ArcRuntime short64 = new();
+        short64.Width = 60; short64.Height = 60;
+        short64.SweepAngle = 270;
+        short64.Thickness = 2;
+        short64.StrokeColor = Color.White;
+        short64.StrokeDashLength = 6;
+        short64.StrokeGapLength = 4;
+        row.Children.Add(short64);
+
+        ArcRuntime dotted = new();
+        dotted.Width = 60; dotted.Height = 60;
+        dotted.SweepAngle = 270;
+        dotted.Thickness = 1;
+        dotted.StrokeColor = Color.White;
+        dotted.StrokeDashLength = 2;
+        dotted.StrokeGapLength = 2;
+        row.Children.Add(dotted);
+
+        ArcRuntime longDash = new();
+        longDash.Width = 60; longDash.Height = 60;
+        longDash.SweepAngle = 270;
+        longDash.Thickness = 3;
+        longDash.StrokeColor = new Color(144, 238, 144, 255);
+        longDash.StrokeDashLength = 12;
+        longDash.StrokeGapLength = 6;
+        row.Children.Add(longDash);
+
+        return row;
+    }
+
+    // Last cell is the #2851 visual acceptance: same soft-shadow config as the second cell but
+    // with the body alpha cut to 80. The shadow must fade with the body - matches Skia/MG.
+    // Pre-fix the raylib LineArc dropshadow would emit DropshadowColor straight through and
+    // leave a too-opaque shadow ghost behind.
+    static ContainerRuntime BuildDropshadowRow()
+    {
+        ContainerRuntime row = BuildHorizontalRow();
+
+        Color goldenrod = new Color(218, 165, 32, 255);
+
+        ArcRuntime baseline = new();
+        baseline.Width = 60; baseline.Height = 60;
+        baseline.SweepAngle = 270;
+        baseline.Thickness = 10;
+        baseline.StrokeColor = goldenrod;
+        row.Children.Add(baseline);
+
+        ArcRuntime soft = new();
+        soft.Width = 60; soft.Height = 60;
+        soft.SweepAngle = 270;
+        soft.Thickness = 10;
+        soft.StrokeColor = goldenrod;
+        soft.HasDropshadow = true;
+        soft.DropshadowOffsetX = 14;
+        soft.DropshadowOffsetY = 14;
+        soft.DropshadowBlurX = 4;
+        soft.DropshadowBlurY = 4;
+        row.Children.Add(soft);
+
+        ArcRuntime hard = new();
+        hard.Width = 60; hard.Height = 60;
+        hard.SweepAngle = 270;
+        hard.Thickness = 10;
+        hard.StrokeColor = goldenrod;
+        hard.HasDropshadow = true;
+        hard.DropshadowRed = 0; hard.DropshadowGreen = 0; hard.DropshadowBlue = 0; hard.DropshadowAlpha = 160;
+        hard.DropshadowOffsetX = 16;
+        hard.DropshadowOffsetY = 16;
+        hard.DropshadowBlurX = 0;
+        hard.DropshadowBlurY = 0;
+        row.Children.Add(hard);
+
+        ArcRuntime colored = new();
+        colored.Width = 60; colored.Height = 60;
+        colored.SweepAngle = 270;
+        colored.Thickness = 10;
+        colored.StrokeColor = goldenrod;
+        colored.HasDropshadow = true;
+        colored.DropshadowRed = 220; colored.DropshadowGreen = 40; colored.DropshadowBlue = 160; colored.DropshadowAlpha = 220;
+        colored.DropshadowOffsetX = 16;
+        colored.DropshadowOffsetY = 16;
+        colored.DropshadowBlurX = 6;
+        colored.DropshadowBlurY = 6;
+        row.Children.Add(colored);
+
+        ArcRuntime fadedBody = new();
+        fadedBody.Width = 60; fadedBody.Height = 60;
+        fadedBody.SweepAngle = 270;
+        fadedBody.Thickness = 10;
+        fadedBody.StrokeColor = new Color((byte)218, (byte)165, (byte)32, (byte)80);
+        fadedBody.HasDropshadow = true;
+        fadedBody.DropshadowOffsetX = 14;
+        fadedBody.DropshadowOffsetY = 14;
+        fadedBody.DropshadowBlurX = 4;
+        fadedBody.DropshadowBlurY = 4;
+        row.Children.Add(fadedBody);
+
+        return row;
+    }
+}


### PR DESCRIPTION
Closes #2866.

## Summary

- New `LineArc` renderable under `Runtimes/RaylibGum/Renderables/` paralleling `LineCircle`. Single `DrawRing` primitive for the solid path (covers thin band → fat band → pie wedge at `Thickness = W/2`), per-dash sub-arc loop for dashed strokes, concentric-band approximation for the dropshadow, and the #2851 body-alpha → shadow-alpha multiply.
- `#if RAYLIB` branch added to the shared `Runtimes/SkiaGum/GueDeriving/ArcRuntime.cs` (a separate class definition because the raylib branch inherits from `GraphicalUiElement` rather than `SkiaShapeRuntime`/`AposShapeRuntime`). `RaylibGum.csproj` source-links the shared file. `Thickness` is the canonical user-facing knob with `StrokeWidth` as the `[Obsolete]` alias — matches the post-#2891 contract.
- New `Samples/raylib/Screens/ArcsScreen.cs` mirroring the post-#2891 Skia `ArcsScreen` for sweep, Thickness progression (including the W/2 wedge), dashed strokes, and dropshadow (including faded-body for #2851). Wired into the gallery nav strip.

Also includes a small unrelated tweak (separate commit `a10c030c0`): flips the `SilkNetGum` sample's `OutputType` from `Exe` to `WinExe` so the console window stops accompanying the Skia gallery window. Carried along from a local WIP because it was already on the working tree.

## Deferred to follow-up

Per the issue comment's "stretch goal" framing and to keep the PR scoped:

- **Gradients on arcs.** The per-segment triangle-fan pattern `LineCircle` uses for radial/linear gradients on a full disk applies cleanly to a stroked arc band — separate PR.
- **Rounded end caps.** `DrawRing` only produces butt ends; rounded caps would need two `DrawCircleSector` half-disks at each terminus. `IsEndRounded` is preserved through the runtime/renderable for API parity but renders as a no-op on raylib in this pass. The Skia sample's end-cap row is omitted on raylib for the same reason.

## Test plan

- [x] `dotnet build` clean on `RaylibGum.csproj`, `SkiaGum.csproj`, `MonoGameGumShapes.csproj`, `KniGumShapes.csproj`, `Samples/raylib/GumTest.csproj`. No new warnings.
- [x] `SkiaGum.Tests` ArcRuntime/Arc tests: 7/7 pass (unchanged).
- [x] `MonoGameGum.Shapes.Tests` ArcRuntime tests: 8/8 pass (unchanged).
- [ ] **Visual verification** — run the raylib gallery (`dotnet run --project Samples/raylib/GumTest.csproj`), click the new "Arcs" nav button, and compare each row against the SilkNetGum gallery on the same rows. The Thickness wedge cell (`Thickness = 30` on a 60×60 square) should render as a true pie wedge identical to Skia's; the dropshadow row's "faded body" cell should fade the shadow alongside the goldenrod arc.

There is no raylib-side unit test project for `ArcRuntime`, so renderable behavior is verified by the gallery rather than `dotnet test`. The shared cross-platform tests (Skia + Apos) exercise the same property surface and continue to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)