### PR TITLE
#2865: Raylib shadow blur via render-to-texture + separable Gaussian

### DIFF
--- a/GumCoreShared.projitems
+++ b/GumCoreShared.projitems
@@ -123,6 +123,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)RenderingLibrary\Graphics\NineSlice.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RenderingLibrary\Graphics\NineSliceExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RenderingLibrary\Graphics\Renderer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)RenderingLibrary\Graphics\RenderTargetService.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RenderingLibrary\Graphics\RendererSettings.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RenderingLibrary\Graphics\SortableLayer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RenderingLibrary\Graphics\Sprite.cs" />

--- a/MonoGameGum/FnaGum/FnaGum.csproj
+++ b/MonoGameGum/FnaGum/FnaGum.csproj
@@ -68,6 +68,7 @@
 		<Compile Include="..\..\RenderingLibrary\Graphics\HierarchicalOrderer.cs" Link="RenderingLibrary\HierarchicalOrderer.cs" />
 		<Compile Include="..\..\RenderingLibrary\Graphics\IRenderableOrderer.cs" Link="RenderingLibrary\IRenderableOrderer.cs" />
 		<Compile Include="..\..\RenderingLibrary\Graphics\Renderer.cs" Link="RenderingLibrary\Renderer.cs" />
+		<Compile Include="..\..\RenderingLibrary\Graphics\RenderTargetService.cs" Link="RenderingLibrary\RenderTargetService.cs" />
 		<Compile Include="..\..\RenderingLibrary\Graphics\Sprite.cs" Link="Renderables\Sprite.cs" />
 		<Compile Include="..\..\RenderingLibrary\Graphics\SpriteBatchRenderableBase.cs" Link="Renderables\SpriteBatchRenderableBase.cs" />
 		<Compile Include="..\..\RenderingLibrary\Graphics\SpriteBatchStack.cs" Link="RenderingLibrary\SpriteBatchStack.cs" />

--- a/MonoGameGum/KniGum/KniGum.csproj
+++ b/MonoGameGum/KniGum/KniGum.csproj
@@ -95,6 +95,7 @@
 		<Compile Include="..\..\RenderingLibrary\Graphics\HierarchicalOrderer.cs" Link="RenderingLibrary\HierarchicalOrderer.cs" />
 		<Compile Include="..\..\RenderingLibrary\Graphics\IRenderableOrderer.cs" Link="RenderingLibrary\IRenderableOrderer.cs" />
 		<Compile Include="..\..\RenderingLibrary\Graphics\Renderer.cs" Link="RenderingLibrary\Renderer.cs" />
+		<Compile Include="..\..\RenderingLibrary\Graphics\RenderTargetService.cs" Link="RenderingLibrary\RenderTargetService.cs" />
 		<Compile Include="..\..\RenderingLibrary\Graphics\Sprite.cs" Link="Renderables\Sprite.cs" />
 		<Compile Include="..\..\RenderingLibrary\Graphics\SpriteBatchRenderableBase.cs" Link="RenderingLibrary\SpriteBatchRenderableBase.cs" />
 		<Compile Include="..\..\RenderingLibrary\Graphics\SpriteBatchStack.cs" Link="RenderingLibrary\SpriteBatchStack.cs" />

--- a/MonoGameGum/MonoGameGum.csproj
+++ b/MonoGameGum/MonoGameGum.csproj
@@ -211,6 +211,7 @@
 		<Compile Include="..\RenderingLibrary\Graphics\HierarchicalOrderer.cs" Link="RenderingLibrary\HierarchicalOrderer.cs" />
 		<Compile Include="..\RenderingLibrary\Graphics\IRenderableOrderer.cs" Link="RenderingLibrary\IRenderableOrderer.cs" />
 		<Compile Include="..\RenderingLibrary\Graphics\Renderer.cs" Link="RenderingLibrary\Renderer.cs" />
+		<Compile Include="..\RenderingLibrary\Graphics\RenderTargetService.cs" Link="RenderingLibrary\RenderTargetService.cs" />
 		<Compile Include="..\RenderingLibrary\Graphics\Sprite.cs" Link="Renderables\Sprite.cs" />
 		<Compile Include="..\RenderingLibrary\Graphics\SpriteBatchRenderableBase.cs" Link="Renderables\SpriteBatchRenderableBase.cs" />
 		<Compile Include="..\RenderingLibrary\Graphics\SpriteBatchStack.cs" Link="RenderingLibrary\SpriteBatchStack.cs" />

--- a/RenderingLibrary/Graphics/RenderTargetService.cs
+++ b/RenderingLibrary/Graphics/RenderTargetService.cs
@@ -1,0 +1,126 @@
+using System.Collections.Generic;
+
+namespace RenderingLibrary.Graphics;
+
+/// <summary>
+/// Per-renderable offscreen-render-target cache shared across backends. Each renderable that
+/// needs to render to an offscreen surface (clipping, dropshadow blur, post-effects) gets its
+/// own platform-specific target, keyed by the renderable instance itself. The lifecycle hook
+/// is <see cref="ClearUnusedRenderTargetsLastFrame"/> — call it once per frame from the
+/// backend's renderer, and any renderable that wasn't seen since the last call has its target
+/// disposed. This handles removal-from-scene, resize, and visibility-toggle uniformly.
+///
+/// <para>Backends provide a subclass that supplies the platform's create / destroy / size
+/// primitives. The MonoGame side (<c>Renderer.RenderTargetService</c>) wraps <see cref="GetFor"/>
+/// in a <c>GetRenderTargetFor(GraphicsDevice, IRenderableIpso, Camera)</c> helper that derives
+/// the size from the renderable's bounds; raylib (see <c>RaylibRenderTextureService</c>) passes
+/// explicit dimensions because dropshadow blur needs padding around the shape, not just the
+/// shape bounds.</para>
+///
+/// <para>Replacement-on-resize policy: exact-size match. If the cached target's dimensions
+/// don't match the requested ones, the cached one is destroyed and a fresh one allocated.
+/// Per-renderable caching means each owner has its own target, so this doesn't churn across
+/// frames as long as the renderable's size is stable.</para>
+/// </summary>
+public abstract class RenderTargetServiceBase<TRenderTarget>
+{
+    private readonly Dictionary<IRenderableIpso, TRenderTarget> _renderTargets =
+        new Dictionary<IRenderableIpso, TRenderTarget>();
+    private readonly HashSet<IRenderableIpso> _usedThisFrame =
+        new HashSet<IRenderableIpso>();
+    private readonly List<IRenderableIpso> _keysToRemove =
+        new List<IRenderableIpso>();
+
+    /// <summary>Allocate a fresh render target of the given size in the backend.</summary>
+    protected abstract TRenderTarget Create(int width, int height);
+
+    /// <summary>Release the backend's render target. Called on resize and on
+    /// <see cref="ClearUnusedRenderTargetsLastFrame"/>.</summary>
+    protected abstract void Destroy(TRenderTarget renderTarget);
+
+    /// <summary>Width of the existing render target — compared against requested width to
+    /// detect resize.</summary>
+    protected abstract int GetWidth(TRenderTarget renderTarget);
+
+    /// <summary>Height of the existing render target — compared against requested height to
+    /// detect resize.</summary>
+    protected abstract int GetHeight(TRenderTarget renderTarget);
+
+    /// <summary>
+    /// Returns a render target sized to (width, height) for the given owner, allocating a
+    /// fresh one if none exists or resizing if the existing one's dimensions differ. Marks
+    /// the owner as "used this frame" so <see cref="ClearUnusedRenderTargetsLastFrame"/>
+    /// won't sweep it. Returns <c>default</c> for non-positive sizes.
+    /// </summary>
+    public TRenderTarget? GetFor(IRenderableIpso owner, int width, int height)
+    {
+        _usedThisFrame.Add(owner);
+        if (width <= 0 || height <= 0)
+        {
+            return default;
+        }
+
+        if (_renderTargets.TryGetValue(owner, out TRenderTarget? existing))
+        {
+            if (GetWidth(existing) != width || GetHeight(existing) != height)
+            {
+                Destroy(existing);
+                _renderTargets.Remove(owner);
+            }
+            else
+            {
+                return existing;
+            }
+        }
+
+        TRenderTarget fresh = Create(width, height);
+        _renderTargets[owner] = fresh;
+        return fresh;
+    }
+
+    /// <summary>
+    /// Returns the cached render target for this owner without allocating or marking it used.
+    /// Returns <c>default</c> if none exists. Useful when a later pass needs to read what an
+    /// earlier pass rendered without bumping the lifecycle.
+    /// </summary>
+    public TRenderTarget? TryGetExisting(IRenderableIpso owner)
+    {
+        return _renderTargets.TryGetValue(owner, out TRenderTarget? existing)
+            ? existing
+            : default;
+    }
+
+    /// <summary>
+    /// Frame-boundary sweep. Any render target whose owner wasn't passed to <see cref="GetFor"/>
+    /// since the last call gets destroyed and removed. Call this once per frame from the
+    /// backend's renderer, typically at the top of its Draw method.
+    /// </summary>
+    public void ClearUnusedRenderTargetsLastFrame()
+    {
+        _keysToRemove.Clear();
+        foreach (KeyValuePair<IRenderableIpso, TRenderTarget> entry in _renderTargets)
+        {
+            if (!_usedThisFrame.Contains(entry.Key))
+            {
+                _keysToRemove.Add(entry.Key);
+            }
+        }
+        foreach (IRenderableIpso key in _keysToRemove)
+        {
+            Destroy(_renderTargets[key]);
+            _renderTargets.Remove(key);
+        }
+        _usedThisFrame.Clear();
+    }
+
+    /// <summary>Destroys every cached render target. Call on backend shutdown.</summary>
+    public void DisposeAll()
+    {
+        foreach (TRenderTarget renderTarget in _renderTargets.Values)
+        {
+            Destroy(renderTarget);
+        }
+        _renderTargets.Clear();
+        _usedThisFrame.Clear();
+    }
+}

--- a/RenderingLibrary/Graphics/Renderer.cs
+++ b/RenderingLibrary/Graphics/Renderer.cs
@@ -1103,51 +1103,35 @@ public class Renderer : IRenderer
 
 #region RenderTargetService
 
-class RenderTargetService
+class RenderTargetService : RenderTargetServiceBase<RenderTarget2D>
 {
-    HashSet<IRenderableIpso> itemsUsingRenderTargetsThisFrame = new HashSet<IRenderableIpso>();
-    Dictionary<IRenderableIpso, RenderTarget2D> RenderTargets = new Dictionary<IRenderableIpso, RenderTarget2D>();
-    List<IRenderableIpso> keysToRemove = new List<IRenderableIpso>();
+    private GraphicsDevice? _graphicsDeviceForCreate;
 
-    public void ClearUnusedRenderTargetsLastFrame()
+    protected override RenderTarget2D Create(int width, int height)
     {
-        keysToRemove.Clear();
-
-        foreach (var item in RenderTargets)
-        {
-            if(itemsUsingRenderTargetsThisFrame.Contains(item.Key) == false)
-            {
-                keysToRemove.Add(item.Key);
-            }
-        }
-
-        foreach(var item in keysToRemove)
-        {
-            RenderTargets[item].Dispose();
-            RenderTargets.Remove(item);
-        }
-
-        itemsUsingRenderTargetsThisFrame.Clear();
+        // _graphicsDeviceForCreate is staged by GetRenderTargetFor before delegating to the
+        // base — RenderTarget2D's ctor requires a GraphicsDevice that the generic base can't
+        // know about. Cleared after Create runs so a stale reference can't be reused.
+        var device = _graphicsDeviceForCreate
+            ?? throw new System.InvalidOperationException(
+                "GraphicsDevice was not staged before Create — use GetRenderTargetFor.");
+        return new RenderTarget2D(device, width, height);
     }
 
-    public RenderTarget2D GetExistingRenderTarget(IRenderableIpso renderable)
+    protected override void Destroy(RenderTarget2D renderTarget) => renderTarget.Dispose();
+
+    protected override int GetWidth(RenderTarget2D renderTarget) => renderTarget.Width;
+
+    protected override int GetHeight(RenderTarget2D renderTarget) => renderTarget.Height;
+
+    public RenderTarget2D? GetExistingRenderTarget(IRenderableIpso renderable)
     {
-        if(RenderTargets.ContainsKey(renderable))
-        {
-            var renderTarget = RenderTargets[renderable];
-            if(renderTarget.IsDisposed == false)
-            {
-                return RenderTargets[renderable];
-            }
-        }
-        
-        return null;
+        var renderTarget = TryGetExisting(renderable);
+        return renderTarget is { IsDisposed: false } ? renderTarget : null;
     }
 
     public RenderTarget2D? GetRenderTargetFor(GraphicsDevice graphicsDevice, IRenderableIpso renderable, Camera camera)
     {
-        itemsUsingRenderTargetsThisFrame.Add(renderable);
-
         var left = renderable.GetAbsoluteLeft();
         var right = renderable.GetAbsoluteRight();
         var top = renderable.GetAbsoluteTop();
@@ -1158,42 +1142,17 @@ class RenderTargetService
         top = System.Math.Max(camera.AbsoluteTop, top);
         bottom = System.Math.Min(camera.AbsoluteBottom, bottom);
 
-        //System.Diagnostics.Debug.WriteLine($"L:{left} R:{right} T:{top} B:{bottom}");
+        var width = Math.MathFunctions.RoundToInt((right - left) * camera.Zoom);
+        var height = Math.MathFunctions.RoundToInt((bottom - top) * camera.Zoom);
 
-        var clientWidth = camera.ClientWidth;
-        var clientHeight = camera.ClientHeight;
-
-        var width = Math.MathFunctions.RoundToInt((right - left)* camera.Zoom);
-        var height = Math.MathFunctions.RoundToInt((bottom - top)* camera.Zoom);
-
-        if(width <= 0 || height <= 0)
+        _graphicsDeviceForCreate = graphicsDevice;
+        try
         {
-            return null;
+            return GetFor(renderable, width, height);
         }
-        else
+        finally
         {
-            if (RenderTargets.ContainsKey(renderable))
-            {
-                var existingRenderTarget = RenderTargets[renderable];
-                if (existingRenderTarget.Width != width || existingRenderTarget.Height != height)
-                {
-                    existingRenderTarget.Dispose();
-                    RenderTargets.Remove(renderable);
-                }
-            }
-
-
-            if (RenderTargets.ContainsKey(renderable) == false)
-            {
-                //var width = GraphicsDevice.Viewport.Width;
-                //var height = GraphicsDevice.Viewport.Height;
-                RenderTargets[renderable] = new RenderTarget2D(graphicsDevice, (int)width, (int)height);
-
-            }
-            var renderTarget = RenderTargets[renderable];
-
-            return renderTarget;
-
+            _graphicsDeviceForCreate = null;
         }
     }
 }

--- a/Runtimes/RaylibGum/RaylibGum.csproj
+++ b/Runtimes/RaylibGum/RaylibGum.csproj
@@ -145,6 +145,7 @@
 		<Compile Include="..\..\MonoGameGum\Input\Cursor.Forms.cs" Link="Input\Cursor.Forms.cs" />
 		<Compile Include="..\..\MonoGameGum\Input\CursorExtensions.cs" Link="Input\CursorExtensions.cs" />
 		<Compile Include="..\..\MonoGameGum\Renderables\RenderableCreator.cs" Link="Renderables\RenderableCreator.cs" />
+		<Compile Include="..\..\RenderingLibrary\Graphics\RenderTargetService.cs" Link="RenderingLibrary\RenderTargetService.cs" />
 		<Compile Include="..\..\RenderingLibrary\Graphics\TextExtensions.cs" Link="Renderables\TextExtensions.cs" />
 		<Compile Include="..\..\MonoGameGum\Forms\DefaultFromFileVisuals\*.cs" Link="Forms\DefaultFromFileVisuals\%(Filename)%(Extension)" />
 	</ItemGroup>

--- a/Runtimes/RaylibGum/Renderables/LineArc.cs
+++ b/Runtimes/RaylibGum/Renderables/LineArc.cs
@@ -360,12 +360,13 @@ public class LineArc : InvisibleRenderable
     }
 
     /// <summary>
-    /// Concentric band approximation of a blurred dropshadow silhouette. Mirrors the
-    /// <see cref="LineCircle"/> approach — same source-over inversion to land each band's
-    /// per-pixel alpha on a linear (1 - t) target profile, same #2851 body-alpha multiply, same
-    /// inheritance of the #2865 stacking overshoot. The shape difference is that the arc's
-    /// silhouette is a stroke band rather than a filled disk, so each "band" here is itself a
-    /// <c>DrawRing</c> whose width grows outward from the nominal thickness.
+    /// Issue #2865: render-to-texture + separable Gaussian replaces the band-stack approximation
+    /// (which inherited the same source-over inversion overshoot LineRectangle and LineCircle
+    /// did). Bounds are the conservative full-circle bbox — a tightly-fit arc bbox would save
+    /// some RT pixels on a thin sweep but needs more math; the conservative version is always
+    /// correct. The silhouette callback paints a white DrawRing matching the nominal stroke band.
+    /// Cap-in-shadow is not painted — matches the prior band approach (which didn't include
+    /// rounded caps in the shadow either), tracked as a follow-up for full Skia parity.
     /// </summary>
     private void DrawDropshadow(float cx, float cy, float innerRadius, float outerRadius,
         float startAngleDeg, float endAngleDeg, int segments, byte bodyAlpha)
@@ -382,68 +383,32 @@ public class LineArc : InvisibleRenderable
             DropshadowColor.B,
             (byte)(DropshadowColor.A * bodyAlpha / 255));
 
-        Vector2 shadowCenter = new Vector2(shadowCx, shadowCy);
-
         if (blur <= 0f)
         {
             // Hard offset silhouette — single DrawRing matching the nominal band.
-            DrawRing(shadowCenter, innerRadius, outerRadius, startAngleDeg, endAngleDeg,
-                segments, effectiveDropshadowColor);
+            DrawRing(new Vector2(shadowCx, shadowCy), innerRadius, outerRadius,
+                startAngleDeg, endAngleDeg, segments, effectiveDropshadowColor);
             return;
         }
 
-        // Match LineCircle's band layout: bands span [R - blur, R + blur] (total width 2*blur)
-        // outward from the nominal silhouette edge. For an arc band, "outward" is both
-        // directions — the outer edge expands outward, the inner edge expands inward. Each
-        // ring's width grows by 2 * (bandSpan - j*bandThickness) so the outermost (j=0) ring is
-        // the widest with the lowest alpha and the innermost (j=N-1) ring is barely wider than
-        // the nominal band with the highest alpha. The final solid-core DrawRing matches the
-        // nominal band exactly to close the alpha gap.
-        const int blurRings = 32;
-        float bandSpan = blur;
-        float totalExtent = 2f * bandSpan;
-        float bandThickness = totalExtent / blurRings;
-        float f = effectiveDropshadowColor.A / 255f;
-        float prevP = 1f;
-        for (int j = blurRings - 1; j >= 0; j--)
-        {
-            float tOuter = (j + 1f) / blurRings;
-            float profileAlpha = System.MathF.Max(0f, 1f - tOuter);
-            float targetAlpha = f * profileAlpha;
-            float currP = 1f - targetAlpha;
-            float beta = prevP > 0f ? 1f - currP / prevP : 0f;
-            prevP = currP;
-            byte bandAlpha = (byte)(255f * beta + 0.5f);
-            if (bandAlpha == 0)
+        float diameter = outerRadius * 2f;
+        Color silhouetteColor = new Color((byte)255, (byte)255, (byte)255, (byte)255);
+        global::RenderingLibrary.Graphics.Renderer.Self.ShadowBlur.Draw(
+            this,
+            shadowCx - outerRadius,
+            shadowCy - outerRadius,
+            diameter,
+            diameter,
+            blur,
+            effectiveDropshadowColor,
+            (px, py) =>
             {
-                continue;
-            }
-            Color bandColor = new Color(effectiveDropshadowColor.R, effectiveDropshadowColor.G,
-                effectiveDropshadowColor.B, bandAlpha);
-            float ringOuter = outerRadius + bandSpan - (j * bandThickness);
-            float ringInner = System.MathF.Max(0f, innerRadius - bandSpan + (j * bandThickness));
-            if (ringOuter > ringInner)
-            {
-                DrawRing(shadowCenter, ringInner, ringOuter, startAngleDeg, endAngleDeg,
-                    segments, bandColor);
-            }
-        }
-
-        // Solid core matching the nominal band closes the remaining alpha gap between the
-        // band stack's accumulated alpha (prevP) and the target final alpha (1 - f). Same
-        // source-over inversion LineCircle uses for its inner core.
-        if (prevP > 1f - f)
-        {
-            float coreBeta = 1f - (1f - f) / prevP;
-            byte coreAlpha = (byte)(255f * coreBeta + 0.5f);
-            if (coreAlpha > 0)
-            {
-                Color coreColor = new Color(effectiveDropshadowColor.R,
-                    effectiveDropshadowColor.G, effectiveDropshadowColor.B, coreAlpha);
-                DrawRing(shadowCenter, innerRadius, outerRadius, startAngleDeg, endAngleDeg,
-                    segments, coreColor);
-            }
-        }
+                DrawRing(
+                    new Vector2(px + outerRadius, py + outerRadius),
+                    innerRadius, outerRadius,
+                    startAngleDeg, endAngleDeg,
+                    segments, silhouetteColor);
+            });
     }
 
     /// <summary>

--- a/Runtimes/RaylibGum/Renderables/LineCircle.cs
+++ b/Runtimes/RaylibGum/Renderables/LineCircle.cs
@@ -278,71 +278,25 @@ public class LineCircle : InvisibleRenderable
 
             if (blur > 0f)
             {
-                // Skia's Gaussian convolution of the shape silhouette makes the silhouette
-                // BOUNDARY itself half-opaque (alpha 0.5), then fades both ways — inward to
-                // alpha 1 deep inside, outward to alpha 0 far outside. The visible halo
-                // around the offset shadow has a SOFT inner edge as a result. Previous
-                // approaches in this file drew a hard-alpha core at radius R and only faded
-                // outward, which made the visible halo's inner edge sharp and concentrated
-                // the gradient in a thin outer band — read as "gradient stops at the shape"
-                // when Skia's gradient extends through the boundary.
-                //
-                // Fix: bands span [R - blur, R + blur] (total width 2*blur), so the band at
-                // d = R has the linear profile midpoint alpha 0.5. Inner core covers only
-                // d < R - blur so deep interior stays fully opaque. Outer boundary stays at
-                // R + blur (matches user-confirmed correct edge size).
-                //
-                // Concentric filled circles drawn outside-in, per-circle alpha derived by
-                // inverting source-over blend so composite at each band lands on the target
-                // linear profile (1 - t) sampled at the band's outer edge.
-                const int blurRings = 32;
-                float bandSpan = blur;
-                float totalExtent = 2f * bandSpan;
-                float bandThickness = totalExtent / blurRings;
-                Vector2 shadowCenter = new Vector2(shadowCx, shadowCy);
-                // Issue #2851: scale the target cumulative alpha profile by the effective
-                // shadow alpha BEFORE inverting source-over to per-band alphas. Scaling
-                // per-band alpha after the fact stacks non-linearly and overshoots.
-                float f = effectiveDropshadowColor.A / 255f;
-                float prevP = 1f;
-                for (int j = blurRings - 1; j >= 0; j--)
-                {
-                    float tOuter = (j + 1f) / blurRings;
-                    float profileAlpha = System.MathF.Max(0f, 1f - tOuter);
-                    float targetAlpha = f * profileAlpha;
-                    float currP = 1f - targetAlpha;
-                    float beta = prevP > 0f ? 1f - currP / prevP : 0f;
-                    prevP = currP;
-                    byte circleAlpha = (byte)(255f * beta + 0.5f);
-                    if (circleAlpha == 0)
+                // Issue #2865: render-to-texture + separable Gaussian replaces the band stack.
+                // See LineRectangle / ShadowBlurRenderer for the full rationale — band approach
+                // overshot effective alpha by ~2.5× because per-band scaling broke the
+                // source-over inversion the band alphas were derived from.
+                float r = Radius;
+                float diameter = r * 2f;
+                Color silhouetteColor = new Color((byte)255, (byte)255, (byte)255, (byte)255);
+                global::RenderingLibrary.Graphics.Renderer.Self.ShadowBlur.Draw(
+                    this,
+                    shadowCx - r,
+                    shadowCy - r,
+                    diameter,
+                    diameter,
+                    blur,
+                    effectiveDropshadowColor,
+                    (px, py) =>
                     {
-                        continue;
-                    }
-                    Color circleColor = new Color(effectiveDropshadowColor.R, effectiveDropshadowColor.G,
-                        effectiveDropshadowColor.B, circleAlpha);
-                    float r = Radius - bandSpan + (j + 1) * bandThickness;
-                    if (r > 0f)
-                    {
-                        DrawCircleV(shadowCenter, r, circleColor);
-                    }
-                }
-
-                // Solid inner core closes the remaining alpha gap between what the bands
-                // accumulated (prevP) and the target final alpha (1 - f). Small correction
-                // at low effective alphas; reduces to the original full-alpha plateau when
-                // f = 1. Source-over inversion: prevP * (1 - α_core) = 1 - f.
-                float innerCoreR = Radius - bandSpan;
-                if (innerCoreR > 0f && prevP > 1f - f)
-                {
-                    float coreBeta = 1f - (1f - f) / prevP;
-                    byte coreAlpha = (byte)(255f * coreBeta + 0.5f);
-                    if (coreAlpha > 0)
-                    {
-                        Color coreColor = new Color(effectiveDropshadowColor.R,
-                            effectiveDropshadowColor.G, effectiveDropshadowColor.B, coreAlpha);
-                        DrawCircle((int)shadowCx, (int)shadowCy, innerCoreR, coreColor);
-                    }
-                }
+                        DrawCircleV(new Vector2(px + r, py + r), r, silhouetteColor);
+                    });
             }
             else
             {

--- a/Runtimes/RaylibGum/Renderables/LineRectangle.cs
+++ b/Runtimes/RaylibGum/Renderables/LineRectangle.cs
@@ -305,109 +305,37 @@ public class LineRectangle : InvisibleRenderable
 
             if (blur > 0f)
             {
-                // Bands span both sides of the silhouette boundary: from -blur to +blur
-                // measured perpendicular to each edge. The band at the exact silhouette
-                // boundary has linear profile midpoint alpha 0.5, matching how Skia's
-                // Gaussian convolution makes the shape silhouette boundary half-opaque.
-                // See LineCircle.Render's dropshadow comment for the full rationale —
-                // previous outer-only fade approach left the halo's inner edge sharp and
-                // the gradient compressed into a thin band; extending bands inward gives
-                // the soft inner edge Skia produces.
-                //
-                // Inner core covers pixels deeper than the innermost band so they read as
-                // full-alpha shadow.
-                const int blurRings = 32;
-                float bandSpan = blur;
-                float totalExtent = 2f * bandSpan;
-                float bandThickness = totalExtent / blurRings;
-                // Issue #2851: the target cumulative alpha profile must be scaled by the
-                // effective shadow alpha BEFORE inverting source-over to per-band alphas.
-                // Scaling per-band alpha after the fact stacks non-linearly and overshoots
-                // (a blur≠0 shadow at effective alpha 80 ended up cumulative ~0.77, not 0.31).
-                float f = effectiveDropshadowColor.A / 255f;
-                float prevP = 1f;
-                for (int j = blurRings - 1; j >= 0; j--)
-                {
-                    float tOuter = (j + 1f) / blurRings;
-                    float profileAlpha = MathF.Max(0f, 1f - tOuter);
-                    float targetAlpha = f * profileAlpha;
-                    float currP = 1f - targetAlpha;
-                    float beta = prevP > 0f ? 1f - currP / prevP : 0f;
-                    prevP = currP;
-                    byte bandAlpha = (byte)(255f * beta + 0.5f);
-                    if (bandAlpha == 0)
+                // Issue #2865: render-to-texture + separable Gaussian replaces the 32-concentric-
+                // band approximation. The old approach inverted source-over compositing to derive
+                // per-band alphas from a target profile, then scaled per-band by the user shadow
+                // alpha — but source-over is non-linear under that scale, so shadows at
+                // DropshadowAlpha < 255 came out ~2.5× too opaque. See ShadowBlurRenderer for
+                // the full rationale; the helper paints the silhouette into an offscreen RT,
+                // blurs it H+V with a Gaussian shader, and composites with the tint.
+                Color silhouetteColor = new Color((byte)255, (byte)255, (byte)255, (byte)255);
+                global::RenderingLibrary.Graphics.Renderer.Self.ShadowBlur.Draw(
+                    this,
+                    shadowX,
+                    shadowY,
+                    w,
+                    h,
+                    blur,
+                    effectiveDropshadowColor,
+                    (px, py) =>
                     {
-                        continue;
-                    }
-                    Color bandColor = new Color(effectiveDropshadowColor.R, effectiveDropshadowColor.G,
-                        effectiveDropshadowColor.B, bandAlpha);
-                    float inflate = -bandSpan + (j + 1) * bandThickness;
-                    float bandW = w + 2f * inflate;
-                    float bandH = h + 2f * inflate;
-                    if (bandW <= 0f || bandH <= 0f)
-                    {
-                        continue;
-                    }
-                    Rectangle bandRect = new Rectangle(
-                        shadowX - inflate,
-                        shadowY - inflate,
-                        bandW,
-                        bandH);
-                    if (useRounded && !rotated)
-                    {
-                        // Corner radius tracks the inflate: at the silhouette boundary
-                        // (inflate = 0) it's CornerRadius, expands outward, shrinks inward
-                        // clamped at 0.
-                        float bandCornerR = MathF.Max(0f, CornerRadius + inflate);
-                        float bandMinDim = MathF.Min(bandRect.Width, bandRect.Height);
-                        float bandRoundness = bandMinDim > 0f
-                            ? MathF.Min(1f, bandCornerR * 2f / bandMinDim)
-                            : 0f;
-                        DrawRectangleRounded(bandRect, bandRoundness, roundedSegments, bandColor);
-                    }
-                    else
-                    {
-                        DrawRectangleV(new Vector2(bandRect.X, bandRect.Y),
-                            new Vector2(bandRect.Width, bandRect.Height), bandColor);
-                    }
-                }
-
-                // Solid inner core closes the remaining alpha gap between what the bands
-                // accumulated (prevP after the loop) and the target final alpha (1 - f).
-                // With the scaled target profile above, this is a small correction at low
-                // effective alphas (≈3/255 when f=0.31) and the original full-alpha plateau
-                // when f=1. Source-over inversion: prevP * (1 - α_core) = 1 - f.
-                float innerCoreW = w - 2f * bandSpan;
-                float innerCoreH = h - 2f * bandSpan;
-                if (innerCoreW > 0f && innerCoreH > 0f && prevP > 1f - f)
-                {
-                    float coreBeta = 1f - (1f - f) / prevP;
-                    byte coreAlpha = (byte)(255f * coreBeta + 0.5f);
-                    if (coreAlpha > 0)
-                    {
-                        Color coreColor = new Color(effectiveDropshadowColor.R,
-                            effectiveDropshadowColor.G, effectiveDropshadowColor.B, coreAlpha);
-                        Rectangle innerCore = new Rectangle(
-                            shadowX + bandSpan,
-                            shadowY + bandSpan,
-                            innerCoreW,
-                            innerCoreH);
-                        if (useRounded && !rotated)
+                        if (useRounded)
                         {
-                            float innerCornerR = MathF.Max(0f, CornerRadius - bandSpan);
-                            float innerMinDim = MathF.Min(innerCoreW, innerCoreH);
-                            float innerRoundness = innerMinDim > 0f
-                                ? MathF.Min(1f, innerCornerR * 2f / innerMinDim)
-                                : 0f;
-                            DrawRectangleRounded(innerCore, innerRoundness, roundedSegments, coreColor);
+                            DrawRectangleRounded(
+                                new Rectangle(px, py, w, h),
+                                roundness,
+                                roundedSegments,
+                                silhouetteColor);
                         }
                         else
                         {
-                            DrawRectangleV(new Vector2(innerCore.X, innerCore.Y),
-                                new Vector2(innerCoreW, innerCoreH), coreColor);
+                            DrawRectangleV(new Vector2(px, py), new Vector2(w, h), silhouetteColor);
                         }
-                    }
-                }
+                    });
             }
             else
             {

--- a/Runtimes/RaylibGum/Renderables/ShadowBlurRenderer.cs
+++ b/Runtimes/RaylibGum/Renderables/ShadowBlurRenderer.cs
@@ -1,0 +1,245 @@
+using System;
+using System.Numerics;
+using Raylib_cs;
+using RenderingLibrary;
+using RenderingLibrary.Graphics;
+using static Raylib_cs.Raylib;
+
+namespace Gum.Renderables;
+
+/// <summary>
+/// Render-to-texture + separable Gaussian blur replacement for the band-stack shadow
+/// approximation in <see cref="LineRectangle"/> / <see cref="LineCircle"/> / <see cref="LineArc"/>.
+/// Issue #2865.
+///
+/// <para><b>Algorithm:</b> paint the shape's silhouette into an offscreen render texture, run
+/// a two-pass separable Gaussian (horizontal then vertical), composite the blurred mask
+/// modulated by the shadow tint. This matches what Skia's <c>SKImageFilter.CreateDropShadow</c>
+/// does internally. The prior 32-concentric-band approach inverted source-over compositing
+/// against a target alpha profile but then scaled the per-band alpha after the inversion —
+/// source-over is non-linear under scaling, so shadows at <c>DropshadowAlpha &lt; 255</c>
+/// rendered ~2.5× too opaque.</para>
+///
+/// <para><b>Lifecycle:</b> two <see cref="RenderTargetServiceBase{TRenderTarget}"/> subclasses
+/// (one each for the silhouette + V-blur target and the H-blur intermediate target) hold
+/// per-renderable RTs. Each <see cref="Draw"/> call marks its owner as used this frame; the
+/// raylib <c>Renderer</c> calls <see cref="ClearUnusedRenderTargetsLastFrame"/> at the top of
+/// every frame, so RTs are reclaimed automatically when a renderable disappears, becomes
+/// invisible, or resizes. This is the raylib counterpart to MonoGame's per-renderable
+/// RenderTargetService pattern (<see cref="RenderTargetServiceBase{T}"/>).</para>
+///
+/// <para><b>Status:</b> first render-to-texture path in the raylib runtime. The shared base
+/// class is intended to host future raylib RT consumers (clipping, post-effects) — each new
+/// consumer adds its own <see cref="RenderTargetServiceBase{TRenderTarget}"/> subclass alongside
+/// <see cref="RenderTextureService"/>.</para>
+/// </summary>
+public sealed class ShadowBlurRenderer
+{
+    // Fixed unrolled loop bound — required for GLSL ES / older desktop drivers, harmless on
+    // modern ones. Cost is O(2*MaxRadius) taps per pass, 4*MaxRadius total. With MaxRadius=32
+    // that's 128 taps per pixel.
+    public const int MaxRadius = 32;
+
+    private static readonly string FragmentShader = $@"#version 330
+in vec2 fragTexCoord;
+in vec4 fragColor;
+out vec4 finalColor;
+uniform sampler2D texture0;
+uniform vec4 colDiffuse;
+uniform vec2 direction;
+uniform float invTwoSigmaSq;
+uniform int radius;
+void main() {{
+    vec4 sum = vec4(0.0);
+    float total = 0.0;
+    for (int i = -{MaxRadius}; i <= {MaxRadius}; i++) {{
+        if (i < -radius || i > radius) continue;
+        float fi = float(i);
+        float w = exp(-fi * fi * invTwoSigmaSq);
+        sum += texture(texture0, fragTexCoord + direction * fi) * w;
+        total += w;
+    }}
+    finalColor = (sum / total) * fragColor * colDiffuse;
+}}
+";
+
+    private Shader _shader;
+    private bool _shaderLoaded;
+    private int _locDirection;
+    private int _locInvTwoSigmaSq;
+    private int _locRadius;
+
+    private readonly RenderTextureService _maskA;
+    private readonly RenderTextureService _maskB;
+
+    public ShadowBlurRenderer()
+    {
+        _maskA = new RenderTextureService();
+        _maskB = new RenderTextureService();
+    }
+
+    /// <summary>
+    /// Paints a soft-edge shadow of a shape into the current draw target.
+    /// </summary>
+    /// <param name="owner">The renderable that owns this shadow. Used as the cache key for the
+    /// per-renderable RTs — passing different shape instances keeps each shape's RT independent
+    /// (stable size across frames, automatic cleanup when the shape is removed). Pass <c>this</c>
+    /// from the renderable's <c>Render</c> method.</param>
+    /// <param name="shadowMinX">Screen-space top-left X of the shape bounds (already offset by DropshadowOffsetX).</param>
+    /// <param name="shadowMinY">Screen-space top-left Y of the shape bounds (already offset by DropshadowOffsetY).</param>
+    /// <param name="shapeW">Shape width in pixels.</param>
+    /// <param name="shapeH">Shape height in pixels.</param>
+    /// <param name="sigma">Gaussian sigma in pixels. Mirrors Skia's <c>SKImageFilter.CreateDropShadow</c> sigma.</param>
+    /// <param name="tint">Shadow color including alpha. Multiplied into the blurred mask at composite time.</param>
+    /// <param name="drawSilhouetteAt">
+    /// Callback invoked inside the offscreen render pass. Receives the RT-local top-left
+    /// coordinates the caller should paint a SOLID-WHITE silhouette of the shape at. The
+    /// silhouette's alpha is what gets blurred; its RGB must be white so the tint multiplies
+    /// cleanly at composite time.
+    /// </param>
+    public void Draw(
+        IRenderableIpso owner,
+        float shadowMinX,
+        float shadowMinY,
+        float shapeW,
+        float shapeH,
+        float sigma,
+        Color tint,
+        Action<float, float> drawSilhouetteAt)
+    {
+        if (sigma <= 0f || shapeW <= 0f || shapeH <= 0f || tint.A == 0)
+        {
+            return;
+        }
+
+        // Anything past 3σ contributes <0.5% of a Gaussian; ceil(3σ) captures the visible
+        // falloff without wasting RT area.
+        int radius = Math.Min(MaxRadius, Math.Max(1, (int)MathF.Ceiling(sigma * 3f)));
+        int rtW = (int)MathF.Ceiling(shapeW) + 2 * radius;
+        int rtH = (int)MathF.Ceiling(shapeH) + 2 * radius;
+
+        EnsureShader();
+        RenderTexture2D rtA = _maskA.GetFor(owner, rtW, rtH);
+        RenderTexture2D rtB = _maskB.GetFor(owner, rtW, rtH);
+
+        Color clear = new Color((byte)0, (byte)0, (byte)0, (byte)0);
+
+        // 1) Silhouette pass: clear RT_A and let the caller paint a white mask at (radius, radius).
+        // Default BLEND_ALPHA is fine here — opaque white onto cleared transparent black gives
+        // (1,1,1,1) inside the shape, (0,0,0,0) outside.
+        BeginTextureMode(rtA);
+        ClearBackground(clear);
+        drawSilhouetteAt(radius, radius);
+        EndTextureMode();
+
+        float invTwoSigmaSq = 1f / (2f * sigma * sigma);
+        SetShaderValue(_shader, _locInvTwoSigmaSq, invTwoSigmaSq, ShaderUniformDataType.Float);
+        SetShaderValue(_shader, _locRadius, radius, ShaderUniformDataType.Int);
+
+        // Blur + composite use AlphaPremultiply (glBlendFunc(ONE, ONE_MINUS_SRC_ALPHA)). Under
+        // BLEND_ALPHA the GPU would multiply src.rgb by src.a at every blend step; since the
+        // shader output has src.rgb == src.a == weighted_avg, each pass would square the alpha
+        // and two passes + composite would collapse the shadow to near-zero alpha.
+        // AlphaPremultiply treats the shader output as already premultiplied (true here, since
+        // the silhouette's rgb is white), so writes are 1:1 into the cleared RT and the final
+        // on-screen blend gives perceived alpha = mask_alpha * tint.a — what DropshadowAlpha
+        // specifies.
+
+        // 2) Horizontal blur RT_A -> RT_B. Direction is in texture-coordinate units (1 texel).
+        // RTs from RenderTextureService are exact-fit (no oversizing), so the standard raylib
+        // negative-height idiom Rectangle(0, 0, rtW, -rtH) reads the full upright content.
+        Vector2 hDir = new Vector2(1f / rtW, 0f);
+        BeginTextureMode(rtB);
+        ClearBackground(clear);
+        BeginBlendMode(BlendMode.AlphaPremultiply);
+        SetShaderValue(_shader, _locDirection, hDir, ShaderUniformDataType.Vec2);
+        BeginShaderMode(_shader);
+        // Negative source height flips the v range so the upright top-down content of an RT
+        // (stored bottom-up in GL coords) reads correctly.
+        DrawTextureRec(rtA.Texture, new Rectangle(0, 0, rtW, -rtH), Vector2.Zero, Color.White);
+        EndShaderMode();
+        EndBlendMode();
+        EndTextureMode();
+
+        // 3) Vertical blur RT_B -> RT_A.
+        Vector2 vDir = new Vector2(0f, 1f / rtH);
+        BeginTextureMode(rtA);
+        ClearBackground(clear);
+        BeginBlendMode(BlendMode.AlphaPremultiply);
+        SetShaderValue(_shader, _locDirection, vDir, ShaderUniformDataType.Vec2);
+        BeginShaderMode(_shader);
+        DrawTextureRec(rtB.Texture, new Rectangle(0, 0, rtW, -rtH), Vector2.Zero, Color.White);
+        EndShaderMode();
+        EndBlendMode();
+        EndTextureMode();
+
+        // 4) Composite RT_A onto the screen, tinted. shadowMinX/Y are the shape's top-left;
+        // the RT contains `radius` pixels of falloff padding around the shape, so the on-screen
+        // destination starts `radius` pixels up-and-left of that. AlphaPremultiply here too —
+        // the RT contents are in premultiplied form (rgb == a, since silhouette was white).
+        BeginBlendMode(BlendMode.AlphaPremultiply);
+        DrawTextureRec(
+            rtA.Texture,
+            new Rectangle(0, 0, rtW, -rtH),
+            new Vector2(shadowMinX - radius, shadowMinY - radius),
+            tint);
+        EndBlendMode();
+    }
+
+    /// <summary>
+    /// Frame-boundary sweep — releases the per-renderable RTs of any owner that wasn't
+    /// passed to <see cref="Draw"/> this frame. Call once per frame from the raylib renderer.
+    /// </summary>
+    public void ClearUnusedRenderTargetsLastFrame()
+    {
+        _maskA.ClearUnusedRenderTargetsLastFrame();
+        _maskB.ClearUnusedRenderTargetsLastFrame();
+    }
+
+    /// <summary>Releases all cached RTs and the blur shader. Call on renderer shutdown.</summary>
+    public void DisposeAll()
+    {
+        _maskA.DisposeAll();
+        _maskB.DisposeAll();
+        if (_shaderLoaded)
+        {
+            UnloadShader(_shader);
+            _shaderLoaded = false;
+        }
+    }
+
+    private void EnsureShader()
+    {
+        if (_shaderLoaded)
+        {
+            return;
+        }
+        _shader = LoadShaderFromMemory(null, FragmentShader);
+        _locDirection = GetShaderLocation(_shader, "direction");
+        _locInvTwoSigmaSq = GetShaderLocation(_shader, "invTwoSigmaSq");
+        _locRadius = GetShaderLocation(_shader, "radius");
+        _shaderLoaded = true;
+    }
+}
+
+/// <summary>
+/// raylib subclass of <see cref="RenderTargetServiceBase{TRenderTarget}"/> that supplies the
+/// raylib create / destroy / size primitives for <see cref="RenderTexture2D"/>. Currently only
+/// used by <see cref="ShadowBlurRenderer"/>; future raylib offscreen-rendering consumers (RT-
+/// based clipping, post-effects) should each own their own instance keyed by the renderable
+/// that owns the offscreen pass.
+/// </summary>
+internal sealed class RenderTextureService : RenderTargetServiceBase<RenderTexture2D>
+{
+    protected override RenderTexture2D Create(int width, int height) =>
+        LoadRenderTexture(width, height);
+
+    protected override void Destroy(RenderTexture2D renderTarget) =>
+        UnloadRenderTexture(renderTarget);
+
+    protected override int GetWidth(RenderTexture2D renderTarget) =>
+        renderTarget.Texture.Width;
+
+    protected override int GetHeight(RenderTexture2D renderTarget) =>
+        renderTarget.Texture.Height;
+}

--- a/Runtimes/RaylibGum/RenderingLibrary/Renderer.cs
+++ b/Runtimes/RaylibGum/RenderingLibrary/Renderer.cs
@@ -1,4 +1,5 @@
 ﻿using Gum;
+using Gum.Renderables;
 using Gum.Wireframe;
 using RenderingLibrary;
 using RenderingLibrary.Graphics;
@@ -53,6 +54,14 @@ public class Renderer : IRenderer
     Camera _camera = new Camera();
     public Camera Camera => _camera;
 
+    /// <summary>
+    /// Per-renderable shadow-blur service. Owns the Gaussian shader and the per-renderable
+    /// render textures (issue #2865). Renderables call <c>Renderer.Self.ShadowBlur.Draw(this, ...)</c>
+    /// from their <c>Render</c> method; the renderer sweeps unused entries at the top of every
+    /// frame via <see cref="ClearUnusedRenderTargetsLastFrame"/>.
+    /// </summary>
+    public ShadowBlurRenderer ShadowBlur { get; }
+
     public static BlendState NormalBlendState
     {
         get;
@@ -68,7 +77,7 @@ public class Renderer : IRenderer
         _layers = new List<Layer>();
         _layersReadOnly = new ReadOnlyCollection<Layer>(_layers);
         _layers.Add(new Layer());
-
+        ShadowBlur = new ShadowBlurRenderer();
     }
 
 
@@ -86,6 +95,11 @@ public class Renderer : IRenderer
 
     private void Draw(SystemManagers managers, List<Layer> layers)
     {
+        // Frame-boundary RT sweep — release per-renderable shadow RTs whose owner wasn't drawn
+        // last frame (renderable removed, hidden, or resized). Mirrors the MonoGame RenderTargetService
+        // pattern in RenderingLibrary/Graphics/Renderer.cs.
+        ShadowBlur.ClearUnusedRenderTargetsLastFrame();
+
         _camera.ClientWidth = Raylib.GetScreenWidth();
         _camera.ClientHeight = Raylib.GetScreenHeight();
 


### PR DESCRIPTION
## Summary

- Replaces the 32-concentric-band shadow approximation in raylib's `LineRectangle` / `LineCircle` / `LineArc` with the same render-to-texture + separable Gaussian path Skia uses internally. The band approach inverted source-over compositing against a target alpha profile and then scaled per-band alpha by the user-specified shadow alpha — source-over is non-linear under that scale, so shadows at `DropshadowAlpha < 255` with `BlurX/Y > 0` rendered ~2.5× too opaque.
- Adds a per-renderable RT lifecycle modeled on MonoGame's existing `RenderTargetService`: new generic base class in `RenderingLibrary/Graphics/RenderTargetService.cs` (shared via `GumCoreShared.projitems`), MG's existing inner service now inherits from it (public API preserved), raylib gets a `RenderTextureService` subclass used by the new `ShadowBlurRenderer`. The raylib `Renderer` sweeps unused RTs at the top of every frame, so shadow RTs are reclaimed when a renderable is removed, hidden, or resized.
- This is the first render-to-texture path in the raylib runtime. The shared base is intended to host future raylib RT consumers (clipping, post-effects).

## Test plan

- [x] `dotnet build AllLibraries.sln` clean (0 errors, no new warnings)
- [x] `dotnet build Samples/raylib/GumTest.csproj` clean
- [x] Visual: Rectangle / Circle / Arc dropshadows render with correct perceived alpha at `DropshadowAlpha < 255` and `BlurX/Y > 0` — no longer overshooting toward opaque.
- [x] Diagnostic A (hard-edged reference) vs Diagnostic B (blurred) cell-for-cell match across the alpha sweep (32/64/96/128/160/192/255) confirmed locally before removing the diagnostic rows from the consumer-facing gallery.
- [x] No per-frame RT load/unload spam in raylib console output — RTs are cached per renderable.
- [ ] FRB1 build verification (`GumCoreShared.projitems` updated; new file is BCL-only and net6-safe, MG service's public API preserved) — pending local verification at `C:\Users\vchel\Documents\GitHub\FlatRedBall\`.

## Follow-ups (not in this PR)

- `LinePolygon` has no dropshadow support today — no migration needed, but a future PR could add one through the same helper.
- Arc shadow doesn't include the rounded end caps in the silhouette (matches prior band behavior). Could be added for full Skia parity.
- GLSL shader is a string literal — no syntax highlighting. Could move to an embedded resource if it grows.
- Batch flushing: each shadow triggers ~8 raylib state changes (BeginTextureMode×3, BeginShaderMode×2, BeginBlendMode×3). Cost is per shadowed shape, not per pixel; fine for typical UI, may want measurement on dense screens.

Closes #2865.

🤖 Generated with [Claude Code](https://claude.com/claude-code)