### PR TITLE
Fix Gum scissor under FRB letterboxed resize + add Clip screen to MonoGame sample

### DIFF
--- a/MonoGameGum.Tests/RenderingLibraries/CameraTests.cs
+++ b/MonoGameGum.Tests/RenderingLibraries/CameraTests.cs
@@ -1,7 +1,9 @@
 ﻿using RenderingLibrary;
+using RenderingLibrary.Graphics;
 using Shouldly;
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Linq;
 using System.Numerics;
 using System.Text;
@@ -12,6 +14,82 @@ namespace MonoGameGum.Tests.RenderingLibraries;
 
 public class CameraTests : BaseTestClass
 {
+    // Minimal IRenderableIpso whose GetAbsoluteLeft/Right/Top/Bottom (extension methods over
+    // X/Y/Width/Height) return predictable values. Used to drive GetScissorRectangleFor in
+    // isolation from any real Gum runtime element.
+    private sealed class StubRenderable : IRenderableIpso
+    {
+        public StubRenderable()
+        {
+            Children = new ObservableCollection<IRenderableIpso>();
+        }
+
+        public float X { get; set; }
+        public float Y { get; set; }
+        public float Z { get; set; }
+        public float Width { get; set; }
+        public float Height { get; set; }
+        public float Rotation { get; set; }
+        public bool FlipHorizontal { get; set; }
+        public string? Name { get; set; }
+        public object? Tag { get; set; }
+        public bool Visible { get; set; } = true;
+        public bool AbsoluteVisible => Visible;
+        public bool ClipsChildren { get; set; }
+        public bool IsRenderTarget => false;
+        public ObservableCollection<IRenderableIpso> Children { get; }
+        public IRenderableIpso? Parent { get; set; }
+        IVisible? IVisible.Parent => Parent;
+        public int Alpha => 255;
+        public ColorOperation ColorOperation => ColorOperation.Modulate;
+        public Gum.BlendState BlendState => Gum.BlendState.NonPremultiplied;
+        public bool Wrap => false;
+        public string BatchKey => "SpriteBatch";
+        public void SetParentDirect(IRenderableIpso? newParent) => Parent = newParent;
+        public void Render(ISystemManagers managers) { }
+        public void PreRender() { }
+        public void StartBatch(ISystemManagers managers) { }
+        public void EndBatch(ISystemManagers managers) { }
+    }
+
+    [Fact]
+    public void GetScissorRectangleFor_WithClientLeftTop_ShouldProduceBackbufferRelativeRectAndClampToViewportExtent()
+    {
+        // Regression test for the FRB letterbox-resize bug: when the camera has a non-zero
+        // ClientLeft/ClientTop (Viewport offset), the returned scissor must live in absolute
+        // backbuffer coordinates AND must clamp to [ClientLeft, ClientLeft + ClientWidth] —
+        // not [0, ClientWidth]. The old clamp would chop the right/bottom of any element
+        // that extended past the (still viewport-local) ClientWidth, making the scissor track
+        // the wrong region after a letterboxed resize. This test exercises the non-FRB
+        // codepath only; the FRB-specific offset-shift inside #if FRB is verified by
+        // running the real FRB integration (see KidDefense repro).
+        Camera _sut = new Camera();
+        _sut.ClientLeft = 100;
+        _sut.ClientTop = 50;
+        _sut.ClientWidth = 800;
+        _sut.ClientHeight = 600;
+        _sut.CameraCenterOnScreen = CameraCenterOnScreen.TopLeft;
+
+        // Element spans world [50, 1000) x [25, 800) — past the right/bottom of the viewport.
+        StubRenderable ipso = new StubRenderable();
+        ipso.X = 50;
+        ipso.Y = 25;
+        ipso.Width = 950;
+        ipso.Height = 775;
+
+        System.Drawing.Rectangle scissor = _sut.GetScissorRectangleFor(layer: null!, ipso);
+
+        // Left/Top: WorldToScreen adds ClientLeft/Top under MonoGame, so 50 + 100 = 150 and
+        // 25 + 50 = 75 — already backbuffer-relative, inside the viewport, unclamped.
+        scissor.Left.ShouldBe(150);
+        scissor.Top.ShouldBe(75);
+
+        // Right/Bottom: world right = 1000, screen right = 1100. The new clamp caps at
+        // ClientLeft + ClientWidth = 900 (was 800 under the old [0, ClientWidth] clamp).
+        scissor.Right.ShouldBe(900);
+        scissor.Bottom.ShouldBe(650);
+    }
+
     [Fact]
     public void NoSetFromMatrixCall_ShouldPreserveExplicitlySetCameraValues()
     {

--- a/RenderingLibrary/Camera.cs
+++ b/RenderingLibrary/Camera.cs
@@ -305,7 +305,7 @@ namespace RenderingLibrary
         {
             if (ipso == null)
             {
-                return new System.Drawing.Rectangle(0, 0, camera.ClientWidth, camera.ClientHeight);
+                return new System.Drawing.Rectangle(camera.ClientLeft, camera.ClientTop, camera.ClientWidth, camera.ClientHeight);
             }
 
             float worldX = ipso.GetAbsoluteLeft();
@@ -321,6 +321,16 @@ namespace RenderingLibrary
                 camera.WorldToScreen(worldX, worldY, out screenX, out screenY);
             }
 
+#if FRB
+            // Layer.WorldToScreen / Camera.WorldToScreen intentionally skip the ClientLeft/Top
+            // offset under FRB so FRB's own renderer doesn't double-apply it for sprite geometry.
+            // But GraphicsDevice.ScissorRectangle is backbuffer-relative, not viewport-local, so
+            // we have to add the offset back here or the scissor lands at backbuffer (0,0) when
+            // the FRB camera DestinationRectangle is letterboxed away from the origin.
+            screenX += camera.ClientLeft;
+            screenY += camera.ClientTop;
+#endif
+
             int left = global::RenderingLibrary.Math.MathFunctions.RoundToInt(screenX);
             int top = global::RenderingLibrary.Math.MathFunctions.RoundToInt(screenY);
 
@@ -335,19 +345,23 @@ namespace RenderingLibrary
                 camera.WorldToScreen(worldX, worldY, out screenX, out screenY);
             }
 
+#if FRB
+            screenX += camera.ClientLeft;
+            screenY += camera.ClientTop;
+#endif
+
             int right = global::RenderingLibrary.Math.MathFunctions.RoundToInt(screenX);
             int bottom = global::RenderingLibrary.Math.MathFunctions.RoundToInt(screenY);
 
-            left = System.Math.Max(0, left);
-            top = System.Math.Max(0, top);
-            right = System.Math.Max(0, right);
-            bottom = System.Math.Max(0, bottom);
+            int minX = camera.ClientLeft;
+            int maxX = camera.ClientLeft + camera.ClientWidth;
+            int minY = camera.ClientTop;
+            int maxY = camera.ClientTop + camera.ClientHeight;
 
-            left = System.Math.Min(left, camera.ClientWidth);
-            right = System.Math.Min(right, camera.ClientWidth);
-
-            top = System.Math.Min(top, camera.ClientHeight);
-            bottom = System.Math.Min(bottom, camera.ClientHeight);
+            left = System.Math.Clamp(left, minX, maxX);
+            right = System.Math.Clamp(right, minX, maxX);
+            top = System.Math.Clamp(top, minY, maxY);
+            bottom = System.Math.Clamp(bottom, minY, maxY);
 
             int width = System.Math.Max(0, right - left);
             int height = System.Math.Max(0, bottom - top);

--- a/Samples/MonoGameGumInCode/MonoGameGumInCode/Game1.cs
+++ b/Samples/MonoGameGumInCode/MonoGameGumInCode/Game1.cs
@@ -63,6 +63,7 @@ namespace MonoGameGumInCode
             AddNavButton("Mixed", () => ShowScreen<MixedScreen>());
             AddNavButton("Invisible", () => ShowScreen<InvisibleScreen>());
             AddNavButton("NineSlice", () => ShowScreen<NineSliceScreen>());
+            AddNavButton("Clip", () => ShowScreen<ClipScreen>());
 
             AddFitModeRadio("Zoom", isChecked: true, () => GumService.Default.EnableZoomToWindow());
             AddFitModeRadio("Expand", isChecked: false, () => GumService.Default.EnableExpandToWindow());

--- a/Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/ClipScreen.cs
+++ b/Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/ClipScreen.cs
@@ -1,0 +1,241 @@
+using Gum.DataTypes;
+using Gum.Forms.Controls;
+using Gum.GueDeriving;
+using Gum.Wireframe;
+using Microsoft.Xna.Framework;
+
+namespace MonoGameGumInCode.Screens;
+
+// Visual demo for ClipsChildren. Each scenario places oversized content inside a
+// fixed-size frame so the difference between clipped and unclipped is obvious. The
+// frame around each scenario is itself a RectangleRuntime sibling (not the clipping
+// parent), so the frame outline remains visible even when its neighbor clips.
+internal class ClipScreen : FrameworkElement
+{
+    public ClipScreen() : base(new ContainerRuntime())
+    {
+        Dock(Gum.Wireframe.Dock.Fill);
+
+        ContainerRuntime root = new();
+        root.ChildrenLayout = Gum.Managers.ChildrenLayout.TopToBottomStack;
+        root.StackSpacing = 16;
+        root.X = 8;
+        root.Y = 8;
+        AddChild(root);
+
+        root.AddChild(BuildSection(
+            "ClipsChildren off vs on (same oversized content)",
+            BuildClipToggleRow()));
+
+        root.AddChild(BuildSection(
+            "Overflow on all four sides (single clipped frame)",
+            BuildAllSidesOverflow()));
+
+        root.AddChild(BuildSection(
+            "Nested clips (inner frame clips, outer frame also clips)",
+            BuildNestedClips()));
+
+        root.AddChild(BuildSection(
+            "Mixed content clipped (rectangle, text, circle)",
+            BuildMixedContent()));
+    }
+
+    static ContainerRuntime BuildSection(string label, GraphicalUiElement body)
+    {
+        ContainerRuntime section = new();
+        section.ChildrenLayout = Gum.Managers.ChildrenLayout.TopToBottomStack;
+        section.StackSpacing = 4;
+        section.WidthUnits = DimensionUnitType.RelativeToChildren;
+        section.HeightUnits = DimensionUnitType.RelativeToChildren;
+        section.Width = 0;
+        section.Height = 0;
+
+        TextRuntime header = new();
+        header.Text = label;
+        section.AddChild(header);
+        section.AddChild(body);
+        return section;
+    }
+
+    static ContainerRuntime BuildHorizontalRow()
+    {
+        ContainerRuntime row = new();
+        row.ChildrenLayout = Gum.Managers.ChildrenLayout.LeftToRightStack;
+        row.StackSpacing = 16;
+        row.WidthUnits = DimensionUnitType.RelativeToChildren;
+        row.HeightUnits = DimensionUnitType.RelativeToChildren;
+        row.Width = 0;
+        row.Height = 0;
+        return row;
+    }
+
+    static ContainerRuntime BuildClipToggleRow()
+    {
+        ContainerRuntime row = BuildHorizontalRow();
+        row.AddChild(BuildOverflowFrame(clipsChildren: false));
+        row.AddChild(BuildOverflowFrame(clipsChildren: true));
+        return row;
+    }
+
+    // 160x100 frame holding a 220x140 child that extends past the bottom-right corner.
+    // With ClipsChildren=false the child paints across siblings; with =true it is cropped
+    // to the frame's bounds.
+    static ContainerRuntime BuildOverflowFrame(bool clipsChildren)
+    {
+        ContainerRuntime frame = new();
+        frame.Width = 160;
+        frame.Height = 100;
+        frame.ClipsChildren = clipsChildren;
+
+        RectangleRuntime border = new();
+        border.WidthUnits = DimensionUnitType.RelativeToParent;
+        border.HeightUnits = DimensionUnitType.RelativeToParent;
+        border.Width = 0;
+        border.Height = 0;
+        border.StrokeColor = Color.White;
+        border.StrokeWidth = 1;
+        frame.AddChild(border);
+
+        RectangleRuntime oversized = new();
+        oversized.Width = 220;
+        oversized.Height = 140;
+        oversized.FillColor = clipsChildren ? new Color(60, 120, 60) : new Color(120, 60, 60);
+        frame.AddChild(oversized);
+
+        TextRuntime label = new();
+        label.Text = clipsChildren ? "ClipsChildren = true" : "ClipsChildren = false";
+        label.X = 4;
+        label.Y = 4;
+        frame.AddChild(label);
+
+        return frame;
+    }
+
+    static ContainerRuntime BuildAllSidesOverflow()
+    {
+        ContainerRuntime frame = new();
+        frame.Width = 240;
+        frame.Height = 160;
+        frame.ClipsChildren = true;
+
+        RectangleRuntime border = new();
+        border.WidthUnits = DimensionUnitType.RelativeToParent;
+        border.HeightUnits = DimensionUnitType.RelativeToParent;
+        border.Width = 0;
+        border.Height = 0;
+        border.StrokeColor = Color.White;
+        border.StrokeWidth = 1;
+        frame.AddChild(border);
+
+        // Four rectangles, one poking out each edge.
+        AddPokingRect(frame, x: -40, y: 60, w: 100, h: 40, Color.Crimson);   // left edge
+        AddPokingRect(frame, x: 180, y: 60, w: 100, h: 40, Color.Goldenrod); // right edge
+        AddPokingRect(frame, x: 90, y: -30, w: 60, h: 80, Color.SeaGreen);   // top edge
+        AddPokingRect(frame, x: 90, y: 120, w: 60, h: 80, Color.MediumPurple); // bottom edge
+
+        return frame;
+    }
+
+    static void AddPokingRect(ContainerRuntime parent, float x, float y, float w, float h, Color color)
+    {
+        RectangleRuntime rect = new();
+        rect.X = x;
+        rect.Y = y;
+        rect.Width = w;
+        rect.Height = h;
+        rect.FillColor = color;
+        parent.AddChild(rect);
+    }
+
+    static ContainerRuntime BuildNestedClips()
+    {
+        ContainerRuntime outer = new();
+        outer.Width = 280;
+        outer.Height = 180;
+        outer.ClipsChildren = true;
+
+        RectangleRuntime outerBorder = new();
+        outerBorder.WidthUnits = DimensionUnitType.RelativeToParent;
+        outerBorder.HeightUnits = DimensionUnitType.RelativeToParent;
+        outerBorder.Width = 0;
+        outerBorder.Height = 0;
+        outerBorder.StrokeColor = Color.White;
+        outerBorder.StrokeWidth = 1;
+        outer.AddChild(outerBorder);
+
+        // Inner clip is positioned so part of it sits outside the outer clip — confirms
+        // the outer scissor still trims the inner frame's border + contents.
+        ContainerRuntime inner = new();
+        inner.X = 180;
+        inner.Y = 40;
+        inner.Width = 160;
+        inner.Height = 120;
+        inner.ClipsChildren = true;
+        outer.AddChild(inner);
+
+        RectangleRuntime innerBorder = new();
+        innerBorder.WidthUnits = DimensionUnitType.RelativeToParent;
+        innerBorder.HeightUnits = DimensionUnitType.RelativeToParent;
+        innerBorder.Width = 0;
+        innerBorder.Height = 0;
+        innerBorder.StrokeColor = Color.Yellow;
+        innerBorder.StrokeWidth = 1;
+        inner.AddChild(innerBorder);
+
+        // Child inside inner clip that overflows the inner — gets clipped by the inner
+        // scissor. The portion of `inner` outside `outer` is then clipped by the outer
+        // scissor, so even an "overflowing" child can only ever paint into the outer
+        // clip's intersection with the inner clip.
+        RectangleRuntime nestedOverflow = new();
+        nestedOverflow.X = -20;
+        nestedOverflow.Y = -20;
+        nestedOverflow.Width = 220;
+        nestedOverflow.Height = 180;
+        nestedOverflow.FillColor = new Color(60, 90, 140);
+        inner.AddChild(nestedOverflow);
+
+        return outer;
+    }
+
+    static ContainerRuntime BuildMixedContent()
+    {
+        ContainerRuntime frame = new();
+        frame.Width = 260;
+        frame.Height = 140;
+        frame.ClipsChildren = true;
+
+        RectangleRuntime border = new();
+        border.WidthUnits = DimensionUnitType.RelativeToParent;
+        border.HeightUnits = DimensionUnitType.RelativeToParent;
+        border.Width = 0;
+        border.Height = 0;
+        border.StrokeColor = Color.White;
+        border.StrokeWidth = 1;
+        frame.AddChild(border);
+
+        RectangleRuntime tile = new();
+        tile.X = -30;
+        tile.Y = 20;
+        tile.Width = 140;
+        tile.Height = 100;
+        tile.FillColor = new Color(80, 80, 140);
+        frame.AddChild(tile);
+
+        // Text wider than the frame — clipping crops the right side of the glyphs.
+        TextRuntime text = new();
+        text.X = 8;
+        text.Y = 4;
+        text.Text = "Long text that runs past the right edge of the frame";
+        frame.AddChild(text);
+
+        // Circle hanging off the lower-right corner.
+        CircleRuntime circle = new();
+        circle.X = 220;
+        circle.Y = 100;
+        circle.Radius = 40;
+        circle.StrokeColor = Color.Goldenrod;
+        frame.AddChild(circle);
+
+        return frame;
+    }
+}


### PR DESCRIPTION
## Summary

Two related pieces of work on Gum's clipping path:

1. **Bug fix** — `GraphicalUiElement.ClipsChildren` rendered correctly in standalone MonoGame but broke under FRB1 when the game window was resized with a fixed aspect ratio (letterboxed). The clip rect stopped tracking the new viewport bounds, leaving clipped content cropped at the old / wrong screen region.
2. **Sample** — new `ClipScreen` in `MonoGameGumInCode` so the feature has a visible demo page alongside the existing Rectangles / Circles / NineSlice screens.

## Root cause of the FRB bug

`Layer.WorldToScreen` / `Camera.WorldToScreen` deliberately skip the `ClientLeft/ClientTop` offset under `#if FRB`, because FRB's own renderer transform already accounts for the viewport offset for sprite geometry — adding it would double-apply. That's correct for normal rendering but **not** for `GetScissorRectangleFor`: `GraphicsDevice.ScissorRectangle` is in backbuffer coordinates, not viewport-local. The moment FRB's `Camera.Main.DestinationRectangle` gets a non-zero X/Y from a letterboxed resize, the scissor landed at the wrong backbuffer location. Standalone MonoGame doesn't hit this because its `Viewport.X/Y` is normally zero.

A secondary, related issue: `GetScissorRectangleFor` clamped to `[0, ClientWidth]` / `[0, ClientHeight]` rather than `[ClientLeft, ClientLeft + ClientWidth]` / `[ClientTop, ClientTop + ClientHeight]`, so even on non-FRB the right/bottom of any scissor was being chopped whenever `ClientLeft/Top != 0` (custom MonoGame viewport offsets, split-screen).

## Fix

In `RenderingLibrary/Camera.cs` `GetScissorRectangleFor`:
- Under `#if FRB`, add `ClientLeft/ClientTop` back to `screenX/screenY` after each `WorldToScreen` call so the scissor ends up in absolute backbuffer space.
- Replace the `[0, ClientWidth]` / `[0, ClientHeight]` clamps with `[ClientLeft, ClientLeft + ClientWidth]` / `[ClientTop, ClientTop + ClientHeight]`. Reduces to the old behavior whenever `ClientLeft/Top = 0`, strict improvement when they are not.

## Risk

Audited every runtime that consumes `GetScissorRectangleFor` (MonoGame, KNI, FNA, raylib, Sokol, Skia, Skia.WPF, FRB) and every assignment of `Camera.ClientLeft/Top` in the codebase. Outside of FRB and the MonoGame Renderer, no runtime ever sets `ClientLeft/Top`, so they remain at 0 and the clamp change is identity. The MonoGame render-target pre-render scope explicitly sets `ClientLeft = 0` while it owns the camera, so that path is unaffected. The `#if FRB` offset shift only compiles into FRB builds.

## Test plan

- [x] Unit test added at `MonoGameGum.Tests/RenderingLibraries/CameraTests.cs` — sets `ClientLeft=100, ClientTop=50, ClientWidth=800, ClientHeight=600` and asserts the scissor's corners (absolute backbuffer coords) and the new clamp range. Pins the non-FRB code path; the `#if FRB` branch isn't compiled into `MonoGameGum.Tests`, so it's verified via the real FRB integration repro below.
- [x] Manual repro in `KidDefense` (FRB game with fixed-aspect-ratio letterboxed resize) — confirmed by author that the clip now follows the resized window.
- [x] Manual smoke of new `ClipScreen` in the `MonoGameGumInCode` sample on standalone MonoGame.
- [x] `dotnet build` on `GumCore.DesktopGlNet6` (FRB build) and `MonoGameGum` (standalone build) — both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)