### PR TITLE
#2834: Inset fill radius to eliminate two-slot AA bleed (MG + Skia circles)

### DIFF
--- a/MonoGameGum/GueDeriving/CircleRuntime.cs
+++ b/MonoGameGum/GueDeriving/CircleRuntime.cs
@@ -1095,6 +1095,40 @@ public class CircleRuntime : GraphicalUiElement
             strokeSized.Height = fillSized.Height;
         }
 
+        // Issue #2834 — when both slots are visible, push a radius inset to the fill so its
+        // rendered outer AA halo sits inside the stroke's opaque band. Two separate
+        // antialiased Apos draws at the same radius composite their AA pixels, producing a
+        // red fringe outside the white stroke (the Apos symptom; Skia shows a mirror-image
+        // pink halo on the inside).
+        //
+        // We can't mutate fillSized.Width/Height to do this — the fill IS the runtime's
+        // contained sizing object, so mutating its Width feeds back into layout and the
+        // shrink accumulates each frame until the circle vanishes. Inset is pushed via the
+        // dedicated FillRadiusInset property instead; Width/Height stay layout-owned, and
+        // the Apos Circle subtracts the inset from its computed radius at render time.
+        //
+        // Inset per side = max(renderableStrokeWidth, aposAaContribution when AA on).
+        // renderableStrokeWidth alone aligns fine for thick strokes, but hairline (1 px)
+        // strokes push a sub-pixel epsilon to Apos so the AA halo (still ~1 px) dominates
+        // and would re-create the overlap without the floor.
+        //
+        // Gated on stroke alpha > 0: a hidden stroke (StrokeColor = null sets alpha 0)
+        // shouldn't inset the fill, or fill-only mode would render a thin background ring
+        // where the stroke would have been.
+        if (_fill != null)
+        {
+            float fillRadiusInset = 0f;
+            if (_stroke.Color.A > 0)
+            {
+                fillRadiusInset = renderableStrokeWidth;
+                if (_isAntialiased && _stroke is IAntialiasedRenderable)
+                {
+                    fillRadiusInset = Math.Max(fillRadiusInset, aposAaContribution);
+                }
+            }
+            _fill.FillRadiusInset = fillRadiusInset;
+        }
+
         // Do NOT call base.PreRender() — same caveat as AposShapeRuntime.PreRender. Forwarding
         // to the contained renderable's PreRender would recurse via the OnPreRender hook the
         // MonoGameGumShapes factory wires up.
@@ -1374,6 +1408,28 @@ public class CircleRuntime : GraphicalUiElement
     /// to the contained <see cref="Circle"/>.
     /// </summary>
     protected override RenderableShapeBase ContainedRenderable => ContainedLineCircle;
+
+    /// <summary>
+    /// Pushes the issue #2834 fill radius inset after the base runs its stroke-width and
+    /// W/H mirror. Inset equals the post-ScreenPixel-scaled stroke width (matching what the
+    /// base just pushed onto the stroke slot); zero when the stroke is hidden so fill-only
+    /// mode renders at full radius. Skia fits AA within the stroke thickness so no AA-bloom
+    /// adjustment is needed — the user's StrokeWidth IS the rendered thickness.
+    /// </summary>
+    public override void PreRender()
+    {
+        base.PreRender();
+
+        if (StrokeRenderable != null && ContainedLineCircle != null)
+        {
+            float fillRadiusInset = 0f;
+            if (StrokeRenderable.Color.Alpha > 0)
+            {
+                fillRadiusInset = StrokeRenderable.StrokeWidth;
+            }
+            ContainedLineCircle.FillRadiusInset = fillRadiusInset;
+        }
+    }
 
     /// <inheritdoc/>
     public override GraphicalUiElement Clone()

--- a/MonoGameGum/GueDeriving/IFilledCircleRenderable.cs
+++ b/MonoGameGum/GueDeriving/IFilledCircleRenderable.cs
@@ -25,5 +25,14 @@ public interface IFilledCircleRenderable : IRenderable
     /// its own Width/Height to <c>2 * value</c>.
     /// </summary>
     float Radius { get; set; }
+
+    /// <summary>
+    /// Pixels to subtract from the rendered radius (issue #2834). Pushed by
+    /// <see cref="CircleRuntime.PreRender"/> when the stroke slot is visible alongside the
+    /// fill — pulling the fill's outer AA halo inside the stroke's opaque band prevents
+    /// the two AA boundaries from compositing and producing a color bleed. Inset is
+    /// applied at render time only; Width/Height stay layout-owned.
+    /// </summary>
+    float FillRadiusInset { get; set; }
 }
 #endif

--- a/Runtimes/GumShapes/Renderables/Circle.cs
+++ b/Runtimes/GumShapes/Renderables/Circle.cs
@@ -61,6 +61,16 @@ public class Circle : RenderableShapeBase,
         }
     }
 
+    /// <inheritdoc/>
+    /// <remarks>
+    /// Issue #2834 — pushed by <see cref="Gum.GueDeriving.CircleRuntime.PreRender"/> on the
+    /// fill slot only when a visible stroke is present. Applied as a radius subtraction at
+    /// render time; Width/Height are left untouched so the layout system stays the sole
+    /// source of size truth (mutating Width here would feed back into layout because the
+    /// fill instance is the runtime's contained sizing object).
+    /// </remarks>
+    public float FillRadiusInset { get; set; }
+
     public override void Render(ISystemManagers managers)
     {
         var sb = ShapeRenderer.ShapeBatch;
@@ -130,13 +140,19 @@ public class Circle : RenderableShapeBase,
             // small positive epsilon (e.g. 0.01) instead of 0; the 1 px AA halo dominates and
             // the sub-pixel stroke is invisible.
 
+            // Issue #2834 — pull the fill's outer edge inside the companion stroke slot's
+            // opaque band so the two AA boundaries don't composite into a visible color
+            // bleed. Clamped at 0 so a runaway inset (larger than the radius) can't render an
+            // inverted disk. Only the fill branch consumes this; stroke ignores it.
+            float fillRadius = System.Math.Max(0f, radius - FillRadiusInset);
+
             if (UseGradient && forcedColor == null)
             {
                 var gradient = base.GetGradient(absoluteLeft, absoluteTop);
 
                 sb.DrawCircle(
                     center,
-                    radius,
+                    fillRadius,
                     gradient,
                     gradient,
                     1,
@@ -147,7 +163,7 @@ public class Circle : RenderableShapeBase,
                 var color = forcedColor ?? this.Color;
 
                 sb.DrawCircle(center,
-                    radius,
+                    fillRadius,
                     color,
                     color,
                     1,

--- a/Runtimes/SkiaGum/Renderables/Circle.cs
+++ b/Runtimes/SkiaGum/Renderables/Circle.cs
@@ -39,10 +39,26 @@ public class Circle : RenderableShapeBase, ICloneable
         }
     }
 
+    /// <summary>
+    /// Issue #2834 — pushed by <see cref="Gum.GueDeriving.CircleRuntime.PreRender"/> on the
+    /// fill slot when a visible stroke is paired with the fill. Subtracted from the rendered
+    /// radius so the fill's outer AA halo lands inside the stroke's opaque band, eliminating
+    /// the pink halo the two-slot model would otherwise produce on the inside of the stroke.
+    /// Applied at render time only; Width/Height stay layout-owned (the fill IS the runtime's
+    /// contained sizing object, so mutating its Width would feed back into layout). Ignored
+    /// when <see cref="RenderableShapeBase.IsFilled"/> is false — only the fill instance
+    /// honors the inset.
+    /// </summary>
+    public float FillRadiusInset { get; set; }
+
     public override void DrawBound(SKRect boundingRect, SKCanvas canvas, float absoluteRotation)
     {
         var paint = GetCachedPaint(boundingRect, absoluteRotation);
         var radius = System.Math.Min(boundingRect.Width, boundingRect.Height) / 2.0f;
+        if (IsFilled)
+        {
+            radius = System.Math.Max(0f, radius - FillRadiusInset);
+        }
         canvas.DrawCircle(boundingRect.MidX, boundingRect.MidY, radius, paint);
     }
 }

--- a/Samples/MonoGameGumShapesGallery/Screens/CirclesScreen.cs
+++ b/Samples/MonoGameGumShapesGallery/Screens/CirclesScreen.cs
@@ -55,6 +55,7 @@ internal class CirclesScreen : FrameworkElement
         right.AddChild(BuildSection("Dropshadow", BuildDropshadowRow()));
         right.AddChild(BuildSection("Dashed strokes", BuildDashedStrokeRow()));
         right.AddChild(BuildSection("Fill + stroke", BuildBothColorsRow()));
+        right.AddChild(BuildSection("Hairline bleed (#2834)", BuildHairlineBleedRow()));
         right.AddChild(BuildSection("Inscribed", BuildInscribedRow()));
         right.AddChild(BuildSection("Non-square aspect", BuildNonSquareRow()));
     }
@@ -401,6 +402,28 @@ internal class CirclesScreen : FrameworkElement
         fillLast.FillColor = Color.Gold;
         row.AddChild(fillLast);
 
+        return row;
+    }
+
+    // Visual repro for #2834 — hairline white stroke over a red fill. The two-slot
+    // composition draws the fill and stroke as separate antialiased renderables, so the
+    // AA pixels at the fill's outer edge overlap the AA pixels at the stroke's inner edge.
+    // 50%-white-over-50%-red composites to pink, leaving a visible halo on the inside of
+    // the ring. The artifact is ~1 px wide regardless of stroke width, so it's most
+    // obvious at 1–2 px and fades at 3–4 px. Run this row in MG, Skia, and raylib side by
+    // side to compare — Skia is the primary repro per the issue.
+    static ContainerRuntime BuildHairlineBleedRow()
+    {
+        ContainerRuntime row = BuildHorizontalRow();
+        foreach (float strokeWidth in new[] { 1f, 2f, 3f, 4f })
+        {
+            CircleRuntime circle = new();
+            circle.Radius = 28;
+            circle.FillColor = Color.Red;
+            circle.StrokeColor = Color.White;
+            circle.StrokeWidth = strokeWidth;
+            row.AddChild(circle);
+        }
         return row;
     }
 

--- a/Samples/SilkNetGum/SilkNetGum/Screens/CirclesScreen.cs
+++ b/Samples/SilkNetGum/SilkNetGum/Screens/CirclesScreen.cs
@@ -50,6 +50,7 @@ internal class CirclesScreen : GraphicalUiElement
         right.Children.Add(BuildSection("Dropshadow", BuildDropshadowRow()));
         right.Children.Add(BuildSection("Dashed strokes", BuildDashedStrokeRow()));
         right.Children.Add(BuildSection("Fill + stroke", BuildBothColorsRow()));
+        right.Children.Add(BuildSection("Hairline bleed (#2834)", BuildHairlineBleedRow()));
         right.Children.Add(BuildSection("Inscribed", BuildInscribedRow()));
         right.Children.Add(BuildSection("Non-square aspect", BuildNonSquareRow()));
     }
@@ -235,6 +236,26 @@ internal class CirclesScreen : GraphicalUiElement
         fillLast.FillColor = SKColors.Gold;
         row.Children.Add(fillLast);
 
+        return row;
+    }
+
+    // Visual repro for #2834 — hairline white stroke over a red fill, the primary surface
+    // for the issue. The fill and stroke are separate SkPaint draws, each antialiased; the
+    // semi-transparent AA pixels at the fill's outer edge composite under the
+    // semi-transparent AA pixels at the stroke's inner edge, producing a ~1 px pink halo
+    // on the inside of the ring. Most visible at 1–2 px stroke; fades at 3–4 px.
+    static ContainerRuntime BuildHairlineBleedRow()
+    {
+        ContainerRuntime row = BuildHorizontalRow();
+        foreach (float strokeWidth in new[] { 1f, 2f, 3f, 4f })
+        {
+            CircleRuntime circle = new();
+            circle.Radius = 28;
+            circle.FillColor = SKColors.Red;
+            circle.StrokeColor = SKColors.White;
+            circle.StrokeWidth = strokeWidth;
+            row.Children.Add(circle);
+        }
         return row;
     }
 

--- a/Samples/raylib/Screens/CirclesScreen.cs
+++ b/Samples/raylib/Screens/CirclesScreen.cs
@@ -52,6 +52,7 @@ internal class CirclesScreen : FrameworkElement
         right.Children.Add(BuildSection("Dropshadow", BuildDropshadowRow()));
         right.Children.Add(BuildSection("Dashed strokes", BuildDashedStrokeRow()));
         right.Children.Add(BuildSection("Fill + stroke", BuildBothColorsRow()));
+        right.Children.Add(BuildSection("Hairline bleed (#2834)", BuildHairlineBleedRow()));
         right.Children.Add(BuildSection("Inscribed", BuildInscribedRow()));
         right.Children.Add(BuildSection("Non-square aspect", BuildNonSquareRow()));
     }
@@ -277,6 +278,27 @@ internal class CirclesScreen : FrameworkElement
         fillLast.FillColor = new Color(255, 215, 0, 255);
         row.Children.Add(fillLast);
 
+        return row;
+    }
+
+    // Visual repro for #2834 — hairline white stroke over a red fill. raylib's LineCircle
+    // draws the fill (DrawCircleV) and the stroke (DrawRing arcs) as separate ops; whether
+    // the same AA-bleed shows up on raylib depends on the renderer details (framebuffer
+    // MSAA rather than per-shape AA). This row exists so the raylib output can be compared
+    // directly against the Skia and MG-shapes outputs to confirm the bleed's scope.
+    static ContainerRuntime BuildHairlineBleedRow()
+    {
+        ContainerRuntime row = BuildHorizontalRow();
+        Color red = new Color(255, 0, 0, 255);
+        foreach (float strokeWidth in new[] { 1f, 2f, 3f, 4f })
+        {
+            CircleRuntime circle = new();
+            circle.Radius = 28;
+            circle.FillColor = red;
+            circle.StrokeColor = Color.White;
+            circle.StrokeWidth = strokeWidth;
+            row.Children.Add(circle);
+        }
         return row;
     }
 

--- a/Tests/MonoGameGum.Shapes.Tests/CircleRuntimeTests.cs
+++ b/Tests/MonoGameGum.Shapes.Tests/CircleRuntimeTests.cs
@@ -65,6 +65,104 @@ public class CircleRuntimeTests
         fill.Color.ShouldBe(Color.Red);
     }
 
+    // Issue #2834 — when both fill and stroke are visible, the fill is rendered with its
+    // radius inset by FillRadiusInset so its outer AA halo sits inside the stroke's opaque
+    // band. Without this inset, fill AA and stroke AA composite at the same boundary,
+    // producing a visible color bleed (red fringe outside a white stroke on Apos). Inset
+    // equals the AA-compensated stroke width: 4 - 1 (AA contribution) = 3 px per side.
+    //
+    // The inset is pushed via FillRadiusInset rather than mutating fill.Width because the
+    // fill renderable IS the runtime's contained sizing object — mutating Width would feed
+    // back into layout and accumulate frame-over-frame until the circle vanished.
+    [Fact]
+    public void FillRadiusInset_AaOn_WhenStrokeVisible_PushedAaCompensatedStrokeWidthInPreRender()
+    {
+        CircleRuntime sut = new();
+        sut.Width = 56;
+        sut.Height = 56;
+        sut.FillColor = Color.Red;
+        sut.StrokeColor = Color.White;
+        sut.StrokeWidth = 4f;
+        sut.StrokeWidthUnits = DimensionUnitType.Absolute;
+        sut.IsAntialiased = true;
+
+        Circle fill = (Circle)sut.RenderableComponent;
+        IRenderable asFillRenderable = fill;
+        asFillRenderable.PreRender();
+
+        fill.FillRadiusInset.ShouldBe(3f);
+    }
+
+    // At hairline strokes (StrokeWidth = 1, AA on) the AA-compensated stroke width is
+    // sub-pixel epsilon, but the AA halo itself is still 1 px. Inset must be at least the AA
+    // contribution (1 px) so the fill's outer AA halo doesn't overlap the stroke's AA range.
+    [Fact]
+    public void FillRadiusInset_AaOn_AtHairlineStroke_FlooredAtAaContribution()
+    {
+        CircleRuntime sut = new();
+        sut.Width = 56;
+        sut.Height = 56;
+        sut.FillColor = Color.Red;
+        sut.StrokeColor = Color.White;
+        sut.StrokeWidth = 1f;
+        sut.StrokeWidthUnits = DimensionUnitType.Absolute;
+        sut.IsAntialiased = true;
+
+        Circle fill = (Circle)sut.RenderableComponent;
+        IRenderable asFillRenderable = fill;
+        asFillRenderable.PreRender();
+
+        fill.FillRadiusInset.ShouldBe(1f);
+    }
+
+    // When the stroke is invisible (StrokeColor = null sets alpha 0) the fill should render
+    // at full radius — no inset, no background ring where the stroke would have been. This
+    // guards against fill-only mode rendering with an unwanted gap.
+    [Fact]
+    public void FillRadiusInset_WhenStrokeInvisible_StaysZero()
+    {
+        CircleRuntime sut = new();
+        sut.Width = 56;
+        sut.Height = 56;
+        sut.FillColor = Color.Red;
+        sut.StrokeColor = null;
+        sut.StrokeWidth = 4f;
+        sut.StrokeWidthUnits = DimensionUnitType.Absolute;
+
+        Circle fill = (Circle)sut.RenderableComponent;
+        IRenderable asFillRenderable = fill;
+        asFillRenderable.PreRender();
+
+        fill.FillRadiusInset.ShouldBe(0f);
+    }
+
+    // Regression guard for the bug that triggered the FillRadiusInset approach: mutating
+    // fill.Width/Height in PreRender accumulated each frame (because the fill IS the
+    // runtime's contained sizing object) and the circle shrank to zero in ~5 frames. Calling
+    // PreRender repeatedly must leave fill.Width/Height untouched at the runtime's size.
+    [Fact]
+    public void PreRender_RepeatedCalls_DoesNotMutateFillWidthOrHeight()
+    {
+        CircleRuntime sut = new();
+        sut.Width = 56;
+        sut.Height = 56;
+        sut.FillColor = Color.Red;
+        sut.StrokeColor = Color.White;
+        sut.StrokeWidth = 4f;
+        sut.StrokeWidthUnits = DimensionUnitType.Absolute;
+        sut.IsAntialiased = true;
+
+        Circle fill = (Circle)sut.RenderableComponent;
+        IRenderable asFillRenderable = fill;
+        for (int i = 0; i < 10; i++)
+        {
+            asFillRenderable.PreRender();
+        }
+
+        fill.Width.ShouldBe(56f);
+        fill.Height.ShouldBe(56f);
+    }
+
     // Load-order contract guard for #2761 / #2768: if any of the four factory registrations
     // moves back inside the _registered guard in AposShapeRuntime, this catches the
     // regression. After Reset + re-call, a new CircleRuntime must still bind Apos Circles.

--- a/Tests/SkiaGum.Tests/GueDeriving/CircleRuntimeTests.cs
+++ b/Tests/SkiaGum.Tests/GueDeriving/CircleRuntimeTests.cs
@@ -141,6 +141,78 @@ public class CircleRuntimeTests
         strokeSlot.IsOffsetAppliedForStroke.ShouldBeTrue();
     }
 
+    // Issue #2834 — when both fill and stroke are visible, the fill is rendered with its
+    // radius inset so its outer AA halo sits inside the stroke's opaque band. Skia's stroke
+    // is inscribed inside the runtime bounds (IsOffsetAppliedForStroke shifts the stroke
+    // inward by StrokeWidth/2 so the ring spans R-sw to R). Without the inset, the stroke's
+    // inner AA edge fades from opaque white to transparent atop the still-opaque fill at
+    // that radius, producing a visible pink halo on the inside of the stroke. Inset = full
+    // stroke width (Skia fits AA within the stroke thickness, so no AA-bloom adjustment).
+    //
+    // Pushed via FillRadiusInset rather than mutating fill.Width because the fill is the
+    // runtime's contained sizing object — mutating Width would feed back into layout and
+    // accumulate frame-over-frame until the circle vanished (same trap caught on Apos).
+    [Fact]
+    public void FillRadiusInset_WhenStrokeVisible_PushedStrokeWidthInPreRender()
+    {
+        CircleRuntime sut = new();
+        sut.Width = 56;
+        sut.Height = 56;
+        sut.FillColor = SKColors.Red;
+        sut.StrokeColor = SKColors.White;
+        sut.StrokeWidth = 4;
+        sut.StrokeWidthUnits = Gum.DataTypes.DimensionUnitType.Absolute;
+
+        sut.PreRender();
+
+        Circle fillSlot = (Circle)sut.RenderableComponent;
+        fillSlot.FillRadiusInset.ShouldBe(4f);
+    }
+
+    // FillColor = null (default) leaves the fill slot invisible — no need to inset; the
+    // setter never had a visible fill to bleed against.
+    [Fact]
+    public void FillRadiusInset_WhenStrokeInvisible_StaysZero()
+    {
+        CircleRuntime sut = new();
+        sut.Width = 56;
+        sut.Height = 56;
+        sut.FillColor = SKColors.Red;
+        sut.StrokeColor = null;
+        sut.StrokeWidth = 4;
+        sut.StrokeWidthUnits = Gum.DataTypes.DimensionUnitType.Absolute;
+
+        sut.PreRender();
+
+        Circle fillSlot = (Circle)sut.RenderableComponent;
+        fillSlot.FillRadiusInset.ShouldBe(0f);
+    }
+
+    // Regression guard matching the Apos-side test — repeated PreRender calls must not
+    // accumulate mutations on the fill slot's Width/Height. The Apos attempt that mutated
+    // Width directly shrank circles to zero in ~5 frames; the FillRadiusInset approach keeps
+    // Width layout-owned.
+    [Fact]
+    public void PreRender_RepeatedCalls_DoesNotMutateFillWidthOrHeight()
+    {
+        CircleRuntime sut = new();
+        sut.Width = 56;
+        sut.Height = 56;
+        sut.FillColor = SKColors.Red;
+        sut.StrokeColor = SKColors.White;
+        sut.StrokeWidth = 4;
+        sut.StrokeWidthUnits = Gum.DataTypes.DimensionUnitType.Absolute;
+
+        Circle fillSlot = (Circle)sut.RenderableComponent;
+        for (int i = 0; i < 10; i++)
+        {
+            sut.PreRender();
+        }
+
+        fillSlot.Width.ShouldBe(56f);
+        fillSlot.Height.ShouldBe(56f);
+    }
+
     [Fact]
     public void StrokeWidth_AfterPreRender_AppliesToStrokeSlotNotFillSlot()
     {


### PR DESCRIPTION
## Summary

- Adds a `Hairline bleed (#2834)` row to the MG-shapes, Skia, and raylib `CirclesScreen` samples (white-stroke-on-red across stroke widths 1–4) so the artifact is visible side-by-side across backends.
- Fixes the two-slot fill+stroke AA-bleed on `CircleRuntime` for both Apos.Shapes (MonoGameGumShapes) and SkiaGum.
- raylib was unaffected (non-AA shape primitives + framebuffer MSAA), so it serves as the visual control.

## Why

The two-slot model (#2790) draws fill and stroke as two separate antialiased renderables at the same radius. The overlapping AA boundaries composite, producing visible color bleed:

- **Apos:** red fringe **outside** the white stroke (fill's outer AA halo extends past the stroke's outer opaque edge).
- **Skia:** pink halo **inside** the white stroke (stroke's inner AA edge fades to transparent over the still-opaque fill).

## Approach

A new `FillRadiusInset` property on the fill renderable, pushed each frame from `CircleRuntime.PreRender` when the stroke is visible. The renderable subtracts it from the rendered radius in the fill branch only — Width/Height stay layout-owned.

**Per-side inset:**
- **Apos:** `max(renderableStrokeWidth, aposAaContribution when AA on)`. The floor covers hairline strokes where the AA-compensated thickness is sub-pixel but the AA halo is still ~1 px.
- **Skia:** `StrokeWidth` (post-ScreenPixel scaling). No AA-bloom compensation needed since Skia fits AA within the stroke thickness.

**What did NOT work** (caught and reverted): mutating `fillSized.Width/Height` directly. The fill IS the runtime's contained sizing object, so the mutation fed back into layout and accumulated each frame — circles shrank to zero in ~5 frames. Both backends now have a regression test that fires 10 consecutive `PreRender` calls and asserts the fill's Width/Height are unchanged.

## Out of scope

`RectangleRuntime` (and `RoundedRectangleRuntime` while it still ships) share the same two-slot model and have the same bleed risk per the issue's "Sample audit required" section. Tracked as a follow-up to this PR.

## Test plan

- [x] `MonoGameGum.Shapes.Tests` — 62 tests pass (3 new for Apos inset).
- [x] `SkiaGum.Tests` — 137 tests pass (3 new for Skia inset).
- [x] `MonoGameGum.Tests` Circle suite — 13 tests pass.
- [x] Run `MonoGameGumShapesGallery` → CirclesScreen → confirm Hairline bleed row has clean white-on-red rings.
- [x] Run `SilkNetGum` → CirclesScreen → confirm same.
- [x] Run `raylib` GumTest → CirclesScreen → confirm unchanged (raylib was already clean).

Closes #2834

🤖 Generated with [Claude Code](https://claude.com/claude-code)