### PR TITLE
#2902: gumcli new path argument optional

### DIFF
--- a/Tests/Gum.Cli.Tests/NewCommandTests.cs
+++ b/Tests/Gum.Cli.Tests/NewCommandTests.cs
@@ -106,6 +106,47 @@ public class NewCommandTests : IDisposable
         Directory.Exists(Path.Combine(_tempDirectory, "Components", "Controls")).ShouldBeFalse();
     }
 
+    [Fact]
+    public void New_WithoutPath_ShouldCreateProjectInDefaultSubdirectoryUnderCurrentDirectory()
+    {
+        string originalCurrentDirectory = Directory.GetCurrentDirectory();
+        try
+        {
+            Directory.SetCurrentDirectory(_tempDirectory);
+
+            CliTestHelper result = CliTestHelper.Run("new");
+
+            result.ExitCode.ShouldBe(0);
+            string expectedGumx = Path.Combine(_tempDirectory, "GumProject", "GumProject.gumx");
+            File.Exists(expectedGumx).ShouldBeTrue();
+            result.StandardOutput.ShouldContain("Created project:");
+        }
+        finally
+        {
+            Directory.SetCurrentDirectory(originalCurrentDirectory);
+        }
+    }
+
+    [Fact]
+    public void New_WithoutPath_WhenDefaultSubdirectoryAlreadyExists_ShouldReturnExitCode2()
+    {
+        string originalCurrentDirectory = Directory.GetCurrentDirectory();
+        try
+        {
+            Directory.SetCurrentDirectory(_tempDirectory);
+
+            CliTestHelper.Run("new");
+            CliTestHelper result = CliTestHelper.Run("new");
+
+            result.ExitCode.ShouldBe(2);
+            result.StandardError.ShouldContain("already exists");
+        }
+        finally
+        {
+            Directory.SetCurrentDirectory(originalCurrentDirectory);
+        }
+    }
+
     public void Dispose()
     {
         if (Directory.Exists(_tempDirectory))

--- a/Tools/Gum.Cli/Commands/NewCommand.cs
+++ b/Tools/Gum.Cli/Commands/NewCommand.cs
@@ -16,10 +16,14 @@ public static class NewCommand
     /// </summary>
     public static Command Create()
     {
-        var pathArgument = new Argument<string>(
+        var pathArgument = new Argument<string?>(
             "path",
             "Path for the new .gumx project file. If no .gumx extension is provided, " +
-            "a project folder and file are created using the given name.");
+            "a project folder and file are created using the given name. " +
+            "If omitted, a 'GumProject' subdirectory is created in the current directory.")
+        {
+            Arity = ArgumentArity.ZeroOrOne
+        };
 
         var templateOption = new Option<string>(
             aliases: new[] { "--template", "-t" },
@@ -36,7 +40,7 @@ public static class NewCommand
 
         command.SetHandler((InvocationContext context) =>
         {
-            string path = context.ParseResult.GetValueForArgument(pathArgument);
+            string? path = context.ParseResult.GetValueForArgument(pathArgument);
             string template = context.ParseResult.GetValueForOption(templateOption) ?? "forms";
             context.ExitCode = Execute(path, template);
         });
@@ -44,7 +48,9 @@ public static class NewCommand
         return command;
     }
 
-    private static int Execute(string path, string template)
+    private const string DefaultProjectName = "GumProject";
+
+    private static int Execute(string? path, string template)
     {
         if (!string.Equals(template, "forms", StringComparison.OrdinalIgnoreCase) &&
             !string.Equals(template, "empty", StringComparison.OrdinalIgnoreCase))
@@ -55,7 +61,11 @@ public static class NewCommand
 
         string fullPath;
 
-        if (path.EndsWith(".gumx", StringComparison.OrdinalIgnoreCase))
+        if (string.IsNullOrEmpty(path))
+        {
+            fullPath = Path.GetFullPath(Path.Combine(DefaultProjectName, DefaultProjectName + ".gumx"));
+        }
+        else if (path.EndsWith(".gumx", StringComparison.OrdinalIgnoreCase))
         {
             fullPath = Path.GetFullPath(path);
         }

--- a/docs/cli/new.md
+++ b/docs/cli/new.md
@@ -1,14 +1,14 @@
 # new
 
 ```
-gumcli new <path> [--template <name>]
+gumcli new [<path>] [--template <name>]
 ```
 
-Creates a new Gum project at the specified path.
+Creates a new Gum project. The path is optional — when omitted, a `GumProject` subdirectory is created in the current directory.
 
 ## Options
 
-- `<path>` — Path for the new project. If no `.gumx` extension is given, creates `<path>/<name>.gumx` inside a new folder named `<name>`.
+- `<path>` *(optional)* — Path for the new project. If no `.gumx` extension is given, creates `<path>/<name>.gumx` inside a new folder named `<name>`. If omitted, the project is created at `./GumProject/GumProject.gumx`.
 - `--template` / `-t` — Template to use. Default: `forms`.
 
 ## Templates
@@ -34,6 +34,7 @@ Creates a minimal project with only the standard elements:
 ## Examples
 
 ```
+gumcli new
 gumcli new MyProject
 gumcli new path/to/MyProject.gumx
 gumcli new MyProject --template forms
@@ -48,5 +49,5 @@ Created project: /full/path/to/MyProject/MyProject.gumx
 
 ## Notes
 
-- Exits with code 2 if the project file already exists.
+- Exits with code 2 if the project file already exists (including when invoked with no path and a `GumProject/GumProject.gumx` is already present in the current directory).
 - Exits with code 2 if an unknown template name is given.


### PR DESCRIPTION
## Summary
- Make the `<path>` argument on `gumcli new` optional.
- When omitted, the project is created at `./GumProject/GumProject.gumx` in the current directory (subdirectory with a fixed default name, as suggested in the issue).
- Existing exit-code-2 collision behavior continues to apply, so re-running `gumcli new` without arguments in a directory that already has `GumProject/GumProject.gumx` fails safely instead of clobbering.
- Updated `docs/cli/new.md` accordingly.

Closes #2902

## Test plan
- [x] New xUnit tests in `NewCommandTests.cs` cover: no-arg creates `GumProject/GumProject.gumx` under cwd; re-running fails with exit code 2.
- [x] Full `Gum.Cli.Tests` suite passes (50/50).