### PR TITLE
#2725: V3 ScrollViewer theme hooks — split refresh + OnAfterInitialize

### DIFF
--- a/MonoGameGum/Forms/DefaultVisuals/V3/ScrollViewerVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/V3/ScrollViewerVisual.cs
@@ -295,6 +295,22 @@ public class ScrollViewerVisual : InteractiveGue
             this.FormsControlAsObject = new ScrollViewer(this);
             RefreshMarginsFromScrollBarVisibility();
         }
+
+        OnAfterInitialize();
+    }
+
+    /// <summary>
+    /// Called once after the visual tree, states, and Forms control have been initialized.
+    /// Themes that subclass <see cref="ScrollViewerVisual"/> can override this to take final
+    /// ownership of layout properties (e.g. inset <see cref="ScrollAndClipContainer"/>,
+    /// reposition <see cref="VerticalScrollBarInstance"/>) without being blindsided by the
+    /// initial <see cref="RefreshMarginsFromScrollBarVisibility"/> call. Default implementation
+    /// is a no-op. Note that scroll-bar visibility state changes will still re-invoke
+    /// <see cref="RefreshClipContainerMargins"/> and <see cref="RefreshScrollBarLengths"/> later;
+    /// override those to control properties that V3 would otherwise overwrite.
+    /// </summary>
+    protected virtual void OnAfterInitialize()
+    {
     }
 
     private void CreateStates()
@@ -373,33 +389,61 @@ public class ScrollViewerVisual : InteractiveGue
 
     private void RefreshMarginsFromScrollBarVisibility()
     {
+        RefreshClipContainerMargins();
+        RefreshScrollBarLengths();
+    }
+
+    /// <summary>
+    /// Refreshes <see cref="ClipContainerContainer"/>'s Width and Height to account for the
+    /// space taken by each scroll bar. Themes can override this to take control of the clip
+    /// container's sizing independently of the scroll bars' lengths (see
+    /// <see cref="RefreshScrollBarLengths"/>).
+    /// </summary>
+    protected virtual void RefreshClipContainerMargins()
+    {
         if (VerticalScrollBarInstance.Parent == ScrollAndClipContainer)
         {
-            float margin = 0;
             // Check the parent to verify that the user hasn't removed the ScrollBar
-            if (VerticalScrollBarInstance.Visible)
-            {
-                margin = VerticalScrollBarInstance.GetAbsoluteWidth();
-            }
+            float margin = VerticalScrollBarInstance.Visible
+                ? VerticalScrollBarInstance.GetAbsoluteWidth()
+                : 0;
             ClipContainerContainer.Width = -margin;
-            if(HorizontalScrollBarInstance != null)
-            {
-                HorizontalScrollBarInstance.Width = -margin;
-            }
         }
 
         if (HorizontalScrollBarInstance.Parent == ScrollAndClipContainer)
         {
-            float margin = 0;
-            if (HorizontalScrollBarInstance.Visible)
-            {
-                margin = HorizontalScrollBarInstance.GetAbsoluteHeight();
-            }
+            float margin = HorizontalScrollBarInstance.Visible
+                ? HorizontalScrollBarInstance.GetAbsoluteHeight()
+                : 0;
             ClipContainerContainer.Height = -margin;
-            if(VerticalScrollBarInstance != null)
-            {
-                VerticalScrollBarInstance.Height = -margin;
-            }
+        }
+    }
+
+    /// <summary>
+    /// Refreshes each scroll bar's length so the two bars don't overlap in the corner —
+    /// the horizontal bar's Width is shortened by the vertical bar's width, and the
+    /// vertical bar's Height is shortened by the horizontal bar's height. Themes can
+    /// override this to take control of scroll-bar sizing independently of the clip
+    /// container's sizing (see <see cref="RefreshClipContainerMargins"/>).
+    /// </summary>
+    protected virtual void RefreshScrollBarLengths()
+    {
+        if (VerticalScrollBarInstance.Parent == ScrollAndClipContainer
+            && HorizontalScrollBarInstance != null)
+        {
+            float margin = VerticalScrollBarInstance.Visible
+                ? VerticalScrollBarInstance.GetAbsoluteWidth()
+                : 0;
+            HorizontalScrollBarInstance.Width = -margin;
+        }
+
+        if (HorizontalScrollBarInstance.Parent == ScrollAndClipContainer
+            && VerticalScrollBarInstance != null)
+        {
+            float margin = HorizontalScrollBarInstance.Visible
+                ? HorizontalScrollBarInstance.GetAbsoluteHeight()
+                : 0;
+            VerticalScrollBarInstance.Height = -margin;
         }
     }
 

--- a/Tests/MonoGameGum.Tests.V3/ScrollViewerVisualTests.cs
+++ b/Tests/MonoGameGum.Tests.V3/ScrollViewerVisualTests.cs
@@ -1,4 +1,5 @@
 ﻿using Gum.Forms.Controls;
+using Gum.Forms.DefaultVisuals.V3;
 using Gum.Wireframe;
 using Gum.GueDeriving;
 using Shouldly;
@@ -10,6 +11,83 @@ namespace MonoGameGum.Tests.V3;
 
 public class ScrollViewerVisualTests
 {
+    private class ThemedScrollViewerVisual : ScrollViewerVisual
+    {
+        public int RefreshClipContainerMarginsCallCount;
+        public int RefreshScrollBarLengthsCallCount;
+        public int OnAfterInitializeCallCount;
+
+        protected override void RefreshClipContainerMargins()
+        {
+            RefreshClipContainerMarginsCallCount++;
+            base.RefreshClipContainerMargins();
+        }
+
+        protected override void RefreshScrollBarLengths()
+        {
+            RefreshScrollBarLengthsCallCount++;
+            base.RefreshScrollBarLengths();
+        }
+
+        protected override void OnAfterInitialize()
+        {
+            OnAfterInitializeCallCount++;
+            base.OnAfterInitialize();
+        }
+    }
+
+    [Fact]
+    public void RefreshClipContainerMargins_IsVirtual_AndInvokedDuringConstruction()
+    {
+        ThemedScrollViewerVisual themed = new();
+
+        themed.RefreshClipContainerMarginsCallCount.ShouldBeGreaterThan(0);
+    }
+
+    [Fact]
+    public void RefreshScrollBarLengths_IsVirtual_AndInvokedDuringConstruction()
+    {
+        ThemedScrollViewerVisual themed = new();
+
+        themed.RefreshScrollBarLengthsCallCount.ShouldBeGreaterThan(0);
+    }
+
+    [Fact]
+    public void OnAfterInitialize_IsVirtual_AndInvokedExactlyOnceDuringConstruction()
+    {
+        ThemedScrollViewerVisual themed = new();
+
+        themed.OnAfterInitializeCallCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public void RefreshScrollBarLengths_WhenOverriddenAsNoOp_ThemeHeightSurvivesClipContainerRefresh()
+    {
+        // A theme that owns the vertical scroll bar's Height should be able to override
+        // RefreshScrollBarLengths and have its values survive when V3 re-refreshes margins.
+        ThemeOwningScrollBarHeight themed = new();
+
+        // Simulate V3 re-running its margin refresh (e.g. as it does in scroll-bar visibility states).
+        themed.InvokeRefreshClipContainerMargins();
+
+        themed.VerticalScrollBarInstance.Height.ShouldBe(-10f);
+    }
+
+    private class ThemeOwningScrollBarHeight : ScrollViewerVisual
+    {
+        public ThemeOwningScrollBarHeight()
+        {
+            VerticalScrollBarInstance.Height = -10f;
+        }
+
+        protected override void RefreshScrollBarLengths()
+        {
+            // Theme owns scroll bar lengths; intentionally skip base.
+        }
+
+        public void InvokeRefreshClipContainerMargins() => RefreshClipContainerMargins();
+    }
+
     [Fact]
     public void Children_Containers_ShouldNotHaveEvents()
     {


### PR DESCRIPTION
Closes #2725

## Summary
- Splits `RefreshMarginsFromScrollBarVisibility` on the V3 `ScrollViewerVisual` into two `protected virtual` methods: `RefreshClipContainerMargins` (sizes `ClipContainerContainer`) and `RefreshScrollBarLengths` (sizes the scroll bars so they don't overlap in the corner). Themes can now override either without losing the other.
- Adds `protected virtual OnAfterInitialize()`, called once at the end of the constructor — a documented extension point for themes to take final ownership of layout properties.

Behavior preserved: `RefreshMarginsFromScrollBarVisibility` still performs the same writes; it just delegates to the two new methods. The Forms-side state Apply wiring is untouched.

The issue listed four problem areas; this PR addresses #1 and #2 (the core ask). The orientation-state `Width`/`Height` assignment and the `GraphicalUiElement.PreRender` ergonomics smell are deferred to separate issues since fixing them risks breaking existing themes / spans a wider surface.

## Test plan
- [x] New tests in `Tests/MonoGameGum.Tests.V3/ScrollViewerVisualTests.cs`:
  - `RefreshClipContainerMargins` is virtual and invoked during construction
  - `RefreshScrollBarLengths` is virtual and invoked during construction
  - `OnAfterInitialize` is virtual and invoked exactly once during construction
  - When a theme overrides `RefreshScrollBarLengths` as a no-op, a theme-set `VerticalScrollBarInstance.Height` survives a subsequent `RefreshClipContainerMargins` call
- [x] Full `MonoGameGum.Tests.V3` suite (59 tests) green
- [x] Full `MonoGameGum.Tests` ScrollViewer Forms suite (30 tests) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)