### PR TITLE
Make Forms invalid-inheritance codegen error self-describing

### DIFF
--- a/Tests/Gum.ProjectServices.Tests/CodeGeneratorGetInheritanceTests.cs
+++ b/Tests/Gum.ProjectServices.Tests/CodeGeneratorGetInheritanceTests.cs
@@ -1,4 +1,5 @@
 using Gum.DataTypes;
+using Gum.Managers;
 using Gum.ProjectServices.CodeGeneration;
 using Newtonsoft.Json;
 using Shouldly;
@@ -132,5 +133,34 @@ public class CodeGeneratorGetInheritanceTests
         string? result = CodeGenerator.GetInheritance(screen, settings);
 
         result.ShouldBe("SomeOtherScreen");
+    }
+
+    [Fact]
+    public void GetInheritance_MonoGameForms_ComponentInheritingFromNonContainerStandard_ReturnsDescriptiveError()
+    {
+        StandardElementSave text = new StandardElementSave { Name = "Text" };
+        GumProjectSave project = new GumProjectSave();
+        project.StandardElements.Add(text);
+        ObjectFinder.Self.GumProjectSave = project;
+
+        try
+        {
+            ComponentSave component = new ComponentSave();
+            component.Name = "Components/MyTextLabel";
+            component.BaseType = "Text";
+
+            CodeOutputProjectSettings settings = new CodeOutputProjectSettings
+            {
+                OutputLibrary = OutputLibrary.MonoGameForms
+            };
+
+            string? result = CodeGenerator.GetInheritance(component, settings);
+
+            result.ShouldBe("Invalid inheritance - When using Forms codegen, Components/MyTextLabel must either inherit from Container, or must have Forms behaviors. It currently inherits from Text.");
+        }
+        finally
+        {
+            ObjectFinder.Self.GumProjectSave = null;
+        }
     }
 }

--- a/Tools/Gum.ProjectServices/CodeGeneration/CodeGenerator.cs
+++ b/Tools/Gum.ProjectServices/CodeGeneration/CodeGenerator.cs
@@ -676,7 +676,7 @@ public class CodeGenerator
                     // else it is something like a NineSlice-inheriting object, so don't return a forms inheritance
                     else if (ObjectFinder.Self.GetStandardElement(element.BaseType) != null)
                     {
-                        inheritance = "Invalid inheritance - Forms controls must either inherit from Container, or must have Forms behaviors";
+                        inheritance = $"Invalid inheritance - When using Forms codegen, {element.Name} must either inherit from Container, or must have Forms behaviors. It currently inherits from {element.BaseType}.";
                     }
                 }
 


### PR DESCRIPTION
## Summary
- When a component inherits from a standard element other than `Container` (e.g. `Text`) without Forms behaviors, the generated inheritance string used to be the same generic message for every offending component. You had to grep the project to find which `.cs` file's `partial class` line was broken.
- The message now includes the qualified component name and the actual base type, so the compile error points straight at the component that needs to be fixed.

Before:
> Invalid inheritance - Forms controls must either inherit from Container, or must have Forms behaviors

After:
> Invalid inheritance - When using Forms codegen, Components/MyTextLabel must either inherit from Container, or must have Forms behaviors. It currently inherits from Text.

## Test plan
- [x] New unit test `GetInheritance_MonoGameForms_ComponentInheritingFromNonContainerStandard_ReturnsDescriptiveError` covers the message format
- [x] Confirmed the test fails on the old message and passes after the change
- [x] Full `CodeGeneratorGetInheritanceTests` suite green (9/9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)