### PR TITLE
#2907: Raylib Sprite/NineSlice blend modes + unify Blend? on runtimes

### DIFF
--- a/MonoGameGum/GueDeriving/NineSliceRuntime.cs
+++ b/MonoGameGum/GueDeriving/NineSliceRuntime.cs
@@ -100,23 +100,36 @@ public class NineSliceRuntime : InteractiveGue
             NotifyPropertyChanged(nameof(Blend));
         }
     }
+#endif
 
+    /// <summary>
+    /// The Gum-specific Blend mode for the nine-slice. Null means "use the renderer's current
+    /// blend mode" (typically alpha blending).
+    /// </summary>
     public Gum.RenderingLibrary.Blend? Blend
     {
         get
         {
+#if XNALIKE
             return Gum.RenderingLibrary.BlendExtensions.ToBlend(ContainedNineSlice.BlendState);
+#else
+            return ContainedNineSlice.Blend;
+#endif
         }
         set
         {
+#if XNALIKE
             if (value.HasValue)
             {
                 BlendState = value.Value.ToBlendState().ToXNA();
             }
             // NotifyPropertyChanged handled by BlendState:
+#else
+            ContainedNineSlice.Blend = value;
+            NotifyPropertyChanged();
+#endif
         }
     }
-#endif
 
     public int Blue
     {

--- a/MonoGameGum/GueDeriving/SpriteRuntime.cs
+++ b/MonoGameGum/GueDeriving/SpriteRuntime.cs
@@ -152,25 +152,35 @@ public class SpriteRuntime : GraphicalUiElement
             NotifyPropertyChanged(nameof(Blend));
         }
     }
+#endif
 
     /// <summary>
-    /// The Gum-specific Blend mode for the sprite.
+    /// The Gum-specific Blend mode for the sprite. Null means "use the renderer's current
+    /// blend mode" (typically alpha blending).
     /// </summary>
     public Gum.RenderingLibrary.Blend? Blend
     {
         get
         {
+#if XNALIKE
             return Gum.RenderingLibrary.BlendExtensions.ToBlend(ContainedSprite.BlendState);
+#else
+            return ContainedSprite.Blend;
+#endif
         }
         set
         {
+#if XNALIKE
             if (value.HasValue)
             {
                 BlendState = value.Value.ToBlendState().ToXNA();
             }
+#else
+            ContainedSprite.Blend = value;
+            NotifyPropertyChanged();
+#endif
         }
     }
-#endif
 
     #endregion
 

--- a/Runtimes/RaylibGum/Renderables/BlendModeExtensions.cs
+++ b/Runtimes/RaylibGum/Renderables/BlendModeExtensions.cs
@@ -1,0 +1,19 @@
+using Raylib_cs;
+
+namespace Gum.Renderables;
+
+internal static class BlendModeExtensions
+{
+    public static BlendMode ToRaylibBlendMode(this global::Gum.RenderingLibrary.Blend blend)
+    {
+        // Unmapped values (Replace, ReplaceAlpha, MinAlpha, SubtractAlpha) fall through
+        // to Alpha rather than guessing a wrong raylib mode: e.g. SubtractAlpha targets the
+        // alpha channel for masking, which BlendMode.SubtractColors does not — a silent
+        // visual mismatch is worse than no effect.
+        return blend switch
+        {
+            global::Gum.RenderingLibrary.Blend.Additive => BlendMode.Additive,
+            _ => BlendMode.Alpha,
+        };
+    }
+}

--- a/Runtimes/RaylibGum/Renderables/NineSlice.cs
+++ b/Runtimes/RaylibGum/Renderables/NineSlice.cs
@@ -196,6 +196,8 @@ public class NineSlice : RenderableBase, IAnimatable, ITextureCoordinate, IClone
         get; set;
     } = Color.White;
 
+    public global::Gum.RenderingLibrary.Blend? Blend { get; set; }
+
     public override void Render(ISystemManagers managers)
     {
         if (!Visible || Texture == null) return;
@@ -238,6 +240,11 @@ public class NineSlice : RenderableBase, IAnimatable, ITextureCoordinate, IClone
 
         var absoluteRotation = this.GetAbsoluteRotation();
 
+        if (Blend.HasValue)
+        {
+            BeginBlendMode(Blend.Value.ToRaylibBlendMode());
+        }
+
         DrawTextureNPatch(
             nonNullText,
             nPatchInfo,
@@ -245,6 +252,11 @@ public class NineSlice : RenderableBase, IAnimatable, ITextureCoordinate, IClone
             Vector2.Zero,
             -absoluteRotation,
             Color);
+
+        if (Blend.HasValue)
+        {
+            EndBlendMode();
+        }
     }
 
 

--- a/Runtimes/RaylibGum/Renderables/Sprite.cs
+++ b/Runtimes/RaylibGum/Renderables/Sprite.cs
@@ -123,6 +123,8 @@ public class Sprite : InvisibleRenderable, IAspectRatio, ITextureCoordinate, IAn
         get; set;
     } = Color.White;
 
+    public global::Gum.RenderingLibrary.Blend? Blend { get; set; }
+
     public float? TextureWidth => Texture?.Width;
 
     public float? TextureHeight => Texture?.Height;
@@ -160,7 +162,17 @@ public class Sprite : InvisibleRenderable, IAspectRatio, ITextureCoordinate, IAn
             srcRect.Height = -srcRect.Height;
         }
 
+        if (Blend.HasValue)
+        {
+            BeginBlendMode(Blend.Value.ToRaylibBlendMode());
+        }
+
         DrawTexturePro(Texture.Value, srcRect, destinationRectangle, Vector2.Zero, -absoluteRotation, Color);
+
+        if (Blend.HasValue)
+        {
+            EndBlendMode();
+        }
     }
 
     public AnimationChainLogic AnimationLogic { get; } = new AnimationChainLogic();

--- a/Runtimes/SkiaGum/Renderables/NineSlice.cs
+++ b/Runtimes/SkiaGum/Renderables/NineSlice.cs
@@ -16,6 +16,10 @@ public class NineSlice : RenderableShapeBase, IAnimatable, ICloneable, ITextureC
     /// </summary>
     public AnimationChainLogic AnimationLogic { get; } = new AnimationChainLogic();
 
+    // Skia does not yet honor Blend at draw time; the property exists for API parity with the
+    // unified NineSliceRuntime, which routes its cross-platform Blend property here.
+    public Gum.RenderingLibrary.Blend? Blend { get; set; }
+
     // Nearest-neighbour sampling. Linear filtering bleeds adjacent-section texels
     // across the boundary between two sections of the nine-slice source texture,
     // producing visible seams; nearest-neighbour samples a single texel per output

--- a/Runtimes/SkiaGum/Renderables/Sprite.cs
+++ b/Runtimes/SkiaGum/Renderables/Sprite.cs
@@ -33,6 +33,10 @@ public class Sprite : RenderableShapeBase, IAspectRatio, ITextureCoordinate, IAn
 
     public SKImage? Image { get; set; }
 
+    // Skia does not yet honor Blend at draw time; the property exists for API parity with the
+    // unified SpriteRuntime, which routes its cross-platform Blend property here.
+    public Gum.RenderingLibrary.Blend? Blend { get; set; }
+
     public float? TextureWidth => Texture?.Width;
     public float? TextureHeight => Texture?.Height;
 

--- a/Runtimes/SokolGum/Renderables/NineSlice.cs
+++ b/Runtimes/SokolGum/Renderables/NineSlice.cs
@@ -38,6 +38,10 @@ public sealed class NineSlice : RenderableBase, ITextureCoordinate, IAnimatable,
     public Rectangle? SourceRectangle { get; set; }
     public Color Color = Color.White;
 
+    // Sokol does not yet honor Blend at draw time; the property exists for API parity with the
+    // unified NineSliceRuntime, which routes its cross-platform Blend property here.
+    public Gum.RenderingLibrary.Blend? Blend { get; set; }
+
     public int Alpha { get => Color.A; set => Color.A = (byte)value; }
     public int Red   { get => Color.R; set => Color.R = (byte)value; }
     public int Green { get => Color.G; set => Color.G = (byte)value; }

--- a/Samples/raylib/Screens/SpriteScreen.cs
+++ b/Samples/raylib/Screens/SpriteScreen.cs
@@ -14,9 +14,9 @@ namespace Examples.Shapes;
 // Section order and parameter sweeps match the MG version so visual regressions in one backend are
 // easy to spot against the other when both samples are run side-by-side.
 //
-// What's intentionally NOT mirrored: the Blend and alpha-only render-target Blend rows. The Blend
-// property on SpriteRuntime is currently #if XNALIKE only — raylib has no Blend surface. Tracked
-// in #2907 (SpriteRuntime: unify remaining 3 #if XNALIKE blocks).
+// The alpha-only Blend row (SubtractAlpha/ReplaceAlpha/MinAlpha) from the MG screen is intentionally
+// skipped here: raylib's BlendMode enum has no alpha-stencil equivalents, so those values fall
+// through to BlendMode.Alpha and would render identically — no useful visual signal.
 internal class SpriteScreen : FrameworkElement
 {
     public SpriteScreen() : base(new ContainerRuntime())
@@ -122,6 +122,27 @@ internal class SpriteScreen : FrameworkElement
             s.Y = 14;
             s.Rotation = angle;
             rotRow.AddChild(s);
+        }
+
+        // Blend modes — Normal/Additive/Replace from the MG screen. On raylib, Normal and Replace
+        // both map to BlendMode.Alpha (raylib has no opaque/replace variant), so they render
+        // identically; Additive is the visually distinct cell.
+        AddSectionLabel(page, "Blend, normal rendering (Normal, Additive, Replace):");
+        var blendRow = NewSection(ChildrenLayout.LeftToRightStack, spacing: 6);
+        page.AddChild(blendRow);
+        foreach (var blend in new[]
+        {
+            Gum.RenderingLibrary.Blend.Normal,
+            Gum.RenderingLibrary.Blend.Additive,
+            Gum.RenderingLibrary.Blend.Replace,
+        })
+        {
+            var s = new SpriteRuntime();
+            s.SourceFileName = "resources\\BearTexture.png";
+            s.Width = 64;
+            s.Height = 64;
+            s.Blend = blend;
+            blendRow.AddChild(s);
         }
 
         // AnimationChain-driven sprite — same .achx pipeline the MG sample uses. .achx +

--- a/Tests/RaylibGum.Tests/Runtimes/BlendTests.cs
+++ b/Tests/RaylibGum.Tests/Runtimes/BlendTests.cs
@@ -1,0 +1,65 @@
+using Gum.GueDeriving;
+using Gum.Renderables;
+using Gum.RenderingLibrary;
+using Shouldly;
+
+namespace RaylibGum.Tests.Runtimes;
+
+public class BlendTests : BaseTestClass
+{
+    [Fact]
+    public void NineSliceRuntime_Blend_DefaultsToNull()
+    {
+        NineSliceRuntime sut = new();
+        sut.Blend.ShouldBeNull();
+    }
+
+    [Fact]
+    public void NineSliceRuntime_Blend_RoundTripsThroughContainedRenderable()
+    {
+        NineSliceRuntime sut = new();
+        sut.Blend = Blend.Additive;
+
+        sut.Blend.ShouldBe(Blend.Additive);
+        ((NineSlice)sut.RenderableComponent).Blend.ShouldBe(Blend.Additive);
+    }
+
+    [Fact]
+    public void NineSliceRuntime_Blend_SetToNullClearsContainedRenderable()
+    {
+        NineSliceRuntime sut = new();
+        sut.Blend = Blend.Additive;
+        sut.Blend = null;
+
+        sut.Blend.ShouldBeNull();
+        ((NineSlice)sut.RenderableComponent).Blend.ShouldBeNull();
+    }
+
+    [Fact]
+    public void SpriteRuntime_Blend_DefaultsToNull()
+    {
+        SpriteRuntime sut = new();
+        sut.Blend.ShouldBeNull();
+    }
+
+    [Fact]
+    public void SpriteRuntime_Blend_RoundTripsThroughContainedRenderable()
+    {
+        SpriteRuntime sut = new();
+        sut.Blend = Blend.Additive;
+
+        sut.Blend.ShouldBe(Blend.Additive);
+        ((Sprite)sut.RenderableComponent).Blend.ShouldBe(Blend.Additive);
+    }
+
+    [Fact]
+    public void SpriteRuntime_Blend_SetToNullClearsContainedRenderable()
+    {
+        SpriteRuntime sut = new();
+        sut.Blend = Blend.Additive;
+        sut.Blend = null;
+
+        sut.Blend.ShouldBeNull();
+        ((Sprite)sut.RenderableComponent).Blend.ShouldBeNull();
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `Gum.Blend?` to the raylib `Sprite` and `NineSlice` renderables; `Render()` wraps the draw with `BeginBlendMode`/`EndBlendMode` when set.
- Moves `Blend?` on `SpriteRuntime`/`NineSliceRuntime` out of `#if XNALIKE` so it compiles on all backends. The XNA-typed `BlendState` property stays gated per #2907's recommendation (don't expose XNA types cross-platform).
- Adds stored-only `Blend?` shims on Skia and Sokol renderables so the unified runtimes compile; neither backend applies them at draw time yet (worth a follow-up if either grows real blend support).

## Mapping decisions

`Gum.Blend` → `Raylib_cs.BlendMode`:

- `Additive` → `BlendMode.Additive`
- everything else (`Normal`, `Replace`, `ReplaceAlpha`, `MinAlpha`, `SubtractAlpha`) → `BlendMode.Alpha`

Raylib's enum has no opaque/replace/min variants, and `SubtractAlpha` targets the alpha channel (masking) — `BlendMode.SubtractColors` subtracts RGB instead, which would be a silent visual mismatch. Fall-through to `Alpha` is safer than wrong output. Custom `rlSetBlendFactors` support is out of scope for this PR.

## Scope

- Blend only. Other `#if XNALIKE` gates in `SpriteRuntime.cs` / `NineSliceRuntime.cs` (texture model, tiling, border scale, render-target source, etc.) are untouched.
- Partially addresses the blend slice of #2908; that issue stays open for the remaining buckets.

## Test plan

- [x] `dotnet test Tests/RaylibGum.Tests/RaylibGum.Tests.csproj --filter BlendTests` — 6/6 passing
- [x] Full `RaylibGum.Tests` — 229/229 passing
- [x] `MonoGameGum.Tests` — 1542/1542 passing
- [x] `SkiaGum.Tests` — 144/144 passing
- [x] Visual smoke test in a raylib sample (an additive sprite blends as expected)

Closes #2907

🤖 Generated with [Claude Code](https://claude.com/claude-code)