### PR TITLE
#2720: Route RectangleRuntime CornerRadius + per-corner radii in SetProperty (runtime-side)

### DIFF
--- a/Runtimes/SkiaGum/CustomSetPropertyOnRenderable.cs
+++ b/Runtimes/SkiaGum/CustomSetPropertyOnRenderable.cs
@@ -338,6 +338,48 @@ public class CustomSetPropertyOnRenderable
                     }
                     handled = true;
                     break;
+                // Issue #2720: route CornerRadius and per-corner radii to RectangleRuntime when
+                // that's the GUE. RectangleRuntime stores these on the runtime and mirrors to
+                // fill+stroke slots in its setter (plus Skia re-pushes them each frame in
+                // PreRender for ScreenPixel scaling). Writing them straight to the renderable
+                // would be clobbered the next time the runtime touched the property — or, on
+                // Skia, on the very next frame. RoundedRectangleRuntime is frozen and does not
+                // need its own arm (no new functionality lands on it).
+                case nameof(RectangleRuntime.CornerRadius):
+                    if (graphicalUiElement is RectangleRuntime rectCornerRuntime)
+                    {
+                        rectCornerRuntime.CornerRadius = (float)value;
+                        handled = true;
+                    }
+                    break;
+                case nameof(RectangleRuntime.CustomRadiusTopLeft):
+                    if (graphicalUiElement is RectangleRuntime rectTLRuntime)
+                    {
+                        rectTLRuntime.CustomRadiusTopLeft = (float?)value;
+                        handled = true;
+                    }
+                    break;
+                case nameof(RectangleRuntime.CustomRadiusTopRight):
+                    if (graphicalUiElement is RectangleRuntime rectTRRuntime)
+                    {
+                        rectTRRuntime.CustomRadiusTopRight = (float?)value;
+                        handled = true;
+                    }
+                    break;
+                case nameof(RectangleRuntime.CustomRadiusBottomLeft):
+                    if (graphicalUiElement is RectangleRuntime rectBLRuntime)
+                    {
+                        rectBLRuntime.CustomRadiusBottomLeft = (float?)value;
+                        handled = true;
+                    }
+                    break;
+                case nameof(RectangleRuntime.CustomRadiusBottomRight):
+                    if (graphicalUiElement is RectangleRuntime rectBRRuntime)
+                    {
+                        rectBRRuntime.CustomRadiusBottomRight = (float?)value;
+                        handled = true;
+                    }
+                    break;
             }
             if (!handled)
             {

--- a/Tests/MonoGameGum.Shapes.Tests/RectangleRuntimeTests.cs
+++ b/Tests/MonoGameGum.Shapes.Tests/RectangleRuntimeTests.cs
@@ -273,6 +273,75 @@ public class RectangleRuntimeTests
         stroke.CustomRadiusBottomRight.ShouldBe(4f);
     }
 
+    // Issue #2720: per-corner radii set via the string path (SetProperty) must land on the
+    // runtime, not on the renderable. The runtime's setter immediately mirrors to fill+stroke,
+    // and (more importantly) any later setter on the runtime — or PreRender on Skia — pushes
+    // the runtime's stored value onto the renderable, so a string-path write that landed on
+    // the renderable directly would be silently clobbered. Mirrors the StrokeWidth regression
+    // pattern from #2629 (ArcRuntime).
+    [Fact]
+    public void CornerRadius_OnRectangleRuntime_ShouldLandOnRuntime_WhenSetThroughSetProperty()
+    {
+        RectangleRuntime sut = new();
+
+        sut.SetProperty("CornerRadius", 8f);
+
+        sut.CornerRadius.ShouldBe(8f);
+    }
+
+    [Fact]
+    public void CustomRadiusTopLeft_OnRectangleRuntime_ShouldLandOnRuntime_WhenSetThroughSetProperty()
+    {
+        RectangleRuntime sut = new();
+
+        sut.SetProperty("CustomRadiusTopLeft", (float?)9f);
+
+        sut.CustomRadiusTopLeft.ShouldBe(9f);
+    }
+
+    [Fact]
+    public void CustomRadiusTopRight_OnRectangleRuntime_ShouldLandOnRuntime_WhenSetThroughSetProperty()
+    {
+        RectangleRuntime sut = new();
+
+        sut.SetProperty("CustomRadiusTopRight", (float?)10f);
+
+        sut.CustomRadiusTopRight.ShouldBe(10f);
+    }
+
+    [Fact]
+    public void CustomRadiusBottomLeft_OnRectangleRuntime_ShouldLandOnRuntime_WhenSetThroughSetProperty()
+    {
+        RectangleRuntime sut = new();
+
+        sut.SetProperty("CustomRadiusBottomLeft", (float?)11f);
+
+        sut.CustomRadiusBottomLeft.ShouldBe(11f);
+    }
+
+    [Fact]
+    public void CustomRadiusBottomRight_OnRectangleRuntime_ShouldLandOnRuntime_WhenSetThroughSetProperty()
+    {
+        RectangleRuntime sut = new();
+
+        sut.SetProperty("CustomRadiusBottomRight", (float?)12f);
+
+        sut.CustomRadiusBottomRight.ShouldBe(12f);
+    }
+
+    // Null = inherit from CornerRadius. The string path must accept null without throwing and
+    // must clear the override on the runtime.
+    [Fact]
+    public void CustomRadiusTopLeft_OnRectangleRuntime_ShouldAcceptNull_WhenSetThroughSetProperty()
+    {
+        RectangleRuntime sut = new();
+        sut.CustomRadiusTopLeft = 5f;
+
+        sut.SetProperty("CustomRadiusTopLeft", null);
+
+        sut.CustomRadiusTopLeft.ShouldBeNull();
+    }
+
     // Issue #2818: Clone re-resolves fresh fill/stroke slots so the clone is independent.
     [Fact]
     public void Clone_BothSlots_AreFreshFactoryInstances_NotShallowCopiesOfSource()

--- a/Tests/SkiaGum.Tests/GueDeriving/RectangleRuntimeTests.cs
+++ b/Tests/SkiaGum.Tests/GueDeriving/RectangleRuntimeTests.cs
@@ -104,6 +104,71 @@ public class RectangleRuntimeTests
         strokeSlot.CornerRadius.ShouldBe(8f);
     }
 
+    // Issue #2720: per-corner radii set via the string path (SetProperty) must land on the
+    // runtime, not on the renderable. The runtime's setter mirrors to fill+stroke, and PreRender
+    // pushes the runtime's stored value to the renderable each frame, so a string-path write
+    // that landed on the renderable directly would be silently clobbered.
+    [Fact]
+    public void CornerRadius_OnRectangleRuntime_ShouldLandOnRuntime_WhenSetThroughSetProperty()
+    {
+        RectangleRuntime sut = new();
+
+        sut.SetProperty("CornerRadius", 8f);
+
+        sut.CornerRadius.ShouldBe(8f);
+    }
+
+    [Fact]
+    public void CustomRadiusTopLeft_OnRectangleRuntime_ShouldLandOnRuntime_WhenSetThroughSetProperty()
+    {
+        RectangleRuntime sut = new();
+
+        sut.SetProperty("CustomRadiusTopLeft", (float?)9f);
+
+        sut.CustomRadiusTopLeft.ShouldBe(9f);
+    }
+
+    [Fact]
+    public void CustomRadiusTopRight_OnRectangleRuntime_ShouldLandOnRuntime_WhenSetThroughSetProperty()
+    {
+        RectangleRuntime sut = new();
+
+        sut.SetProperty("CustomRadiusTopRight", (float?)10f);
+
+        sut.CustomRadiusTopRight.ShouldBe(10f);
+    }
+
+    [Fact]
+    public void CustomRadiusBottomLeft_OnRectangleRuntime_ShouldLandOnRuntime_WhenSetThroughSetProperty()
+    {
+        RectangleRuntime sut = new();
+
+        sut.SetProperty("CustomRadiusBottomLeft", (float?)11f);
+
+        sut.CustomRadiusBottomLeft.ShouldBe(11f);
+    }
+
+    [Fact]
+    public void CustomRadiusBottomRight_OnRectangleRuntime_ShouldLandOnRuntime_WhenSetThroughSetProperty()
+    {
+        RectangleRuntime sut = new();
+
+        sut.SetProperty("CustomRadiusBottomRight", (float?)12f);
+
+        sut.CustomRadiusBottomRight.ShouldBe(12f);
+    }
+
+    [Fact]
+    public void CustomRadiusTopLeft_OnRectangleRuntime_ShouldAcceptNull_WhenSetThroughSetProperty()
+    {
+        RectangleRuntime sut = new();
+        sut.CustomRadiusTopLeft = 5f;
+
+        sut.SetProperty("CustomRadiusTopLeft", null);
+
+        sut.CustomRadiusTopLeft.ShouldBeNull();
+    }
+
     [Fact]
     public void PerCornerRadii_PushedToBothSlots_InPreRender()
     {


### PR DESCRIPTION
First slice of #2720 — runtime-side plumbing only. No tool / variable-grid changes in this PR; those land separately.

## Summary

- `CustomSetPropertyOnRenderable` (the shared `Runtimes/SkiaGum/CustomSetPropertyOnRenderable.cs`, compiled into both the Skia and MonoGameGumShapes/KniGumShapes paths) now routes `CornerRadius`, `CustomRadiusTopLeft`, `CustomRadiusTopRight`, `CustomRadiusBottomLeft`, and `CustomRadiusBottomRight` to `RectangleRuntime` when that's the GUE.
- The runtime stores these locally and mirrors them to its fill + stroke slots on assignment; Skia's `PreRender` also re-pushes them each frame for ScreenPixel scaling. Writing them via reflection to the underlying renderable was getting clobbered.
- Mirrors the existing `StrokeWidth` / `StrokeDashLength` / `StrokeGapLength` runtime-routing pattern on the `RoundedRectangleRuntime` arm.
- `RoundedRectangleRuntime` is `[Obsolete]` and frozen — no new arms added there.
- Raylib is out of scope: `RectangleRuntime` is linked into RaylibGum and exposes the properties at the API surface, but raylib's `DrawRectangleRounded` only takes a uniform `roundness`. Per-corner rendering on Raylib would need a renderer-side rewrite of `LineRectangle.cs` (manual path construction); tracked separately.

## Test plan

- [x] New regression tests in `Tests/MonoGameGum.Shapes.Tests/RectangleRuntimeTests.cs` (6 cases) and `Tests/SkiaGum.Tests/GueDeriving/RectangleRuntimeTests.cs` (6 cases) covering each of the five properties via `SetProperty` plus a null-clears-override case.
- [x] Tests fail without the routing change (verified — values land on renderable, runtime stays at 0/null).
- [x] Tests pass with the routing change.
- [x] Full `MonoGameGum.Shapes.Tests` (68 tests) and `SkiaGum.Tests` (150 tests) suites pass — no regressions.

Closes #2720 only after the tool-side variable registration + codegen follow-up lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)