### PR TITLE
#2922: Wire Skia Sprite/NineSlice Blend? through to SKPaint.BlendMode

### DIFF
--- a/Gum/SvgPlugin/SkiaPlugin.csproj
+++ b/Gum/SvgPlugin/SkiaPlugin.csproj
@@ -62,6 +62,9 @@
 	
 	
   <ItemGroup>
+    <Compile Include="..\..\Runtimes\SkiaGum\Renderables\BlendToSkBlendModeExtensions.cs">
+      <Link>Renderables\BlendToSkBlendModeExtensions.cs</Link>
+    </Compile>
     <Compile Include="..\..\Runtimes\SkiaGum\Renderables\IClipPath.cs">
       <Link>Renderables\IClipPath.cs</Link>
     </Compile>

--- a/Runtimes/SkiaGum/CustomSetPropertyOnRenderable.cs
+++ b/Runtimes/SkiaGum/CustomSetPropertyOnRenderable.cs
@@ -537,6 +537,15 @@ public class CustomSetPropertyOnRenderable
                 handled = TrySetPropertyOnPolygon(asPolygon, graphicalUiElement, propertyName, value);
             }
         }
+        // Catch-all for RenderableShapeBase derivatives that have no dedicated branch
+        // above (SolidRectangle, LineRectangle, LineGrid, etc.). Without this, those types
+        // skip TrySetPropertiesOnRenderableBase entirely and any RenderableShapeBase property
+        // — most notably Blend? — falls through to SetPropertyThroughReflection's
+        // Convert.ChangeType, which throws on enum -> Nullable<enum>.
+        if (!handled && containedObjectAsIpso is RenderableShapeBase asShapeBase)
+        {
+            handled = TrySetPropertiesOnRenderableBase(asShapeBase, graphicalUiElement, propertyName, value);
+        }
         if (!handled)
         {
             GraphicalUiElement.SetPropertyThroughReflection(containedObjectAsIpso, graphicalUiElement, propertyName, value);

--- a/Runtimes/SkiaGum/CustomSetPropertyOnRenderable.cs
+++ b/Runtimes/SkiaGum/CustomSetPropertyOnRenderable.cs
@@ -38,6 +38,14 @@ public class CustomSetPropertyOnRenderable
             case nameof(RenderableShapeBase.Alpha):
                 renderableBase.Alpha = (int)value;
                 return true;
+            // .gumx stores Blend as the non-nullable Gum.RenderingLibrary.Blend enum, but the
+            // property is Blend?. SetPropertyThroughReflection's Convert.ChangeType fallback
+            // throws on enum -> Nullable<enum>, so the assignment has to land here. See the
+            // SilkNetGum sample crash that prompted this branch — every Standards/*.gutx with
+            // a default Blend variable hit the reflection path before this case was added.
+            case nameof(RenderableShapeBase.Blend):
+                renderableBase.Blend = (Blend)value;
+                return true;
             case nameof(RenderableShapeBase.Alpha1):
                 renderableBase.Alpha1 = (int)value;
                 return true;
@@ -485,7 +493,8 @@ public class CustomSetPropertyOnRenderable
         }
         else if(containedObjectAsIpso is VectorSprite asSvg)
         {
-            //handled = TrySetPropertiesOnRenderableBase(asSvg, graphicalUiElement, propertyName, value);
+            // VectorSprite is not a RenderableShapeBase, so it stays on its dedicated handler
+            // plus the reflection fallback. No shared shape-base properties (Blend, etc.) apply.
             if(!handled)
             {
                 handled = TrySetPropertyOnSvg(asSvg, graphicalUiElement, propertyName, value);
@@ -493,6 +502,14 @@ public class CustomSetPropertyOnRenderable
         }
         else if(containedObjectAsIpso is Sprite asSprite)
         {
+            // Route base-class properties (Blend, gradient/dropshadow channels, etc.) first.
+            // These branches historically skipped TrySetPropertiesOnRenderableBase and relied
+            // on the reflection fallback, which works for int/float properties but throws on
+            // enum -> Nullable<enum> (the Blend case).
+            if(!handled)
+            {
+                handled = TrySetPropertiesOnRenderableBase(asSprite, graphicalUiElement, propertyName, value);
+            }
             if(!handled)
             {
                 handled = TrySetPropertyOnSprite(asSprite, graphicalUiElement, propertyName, value);
@@ -502,11 +519,19 @@ public class CustomSetPropertyOnRenderable
         {
             if(!handled)
             {
+                handled = TrySetPropertiesOnRenderableBase(asNineSlice, graphicalUiElement, propertyName, value);
+            }
+            if(!handled)
+            {
                 handled = TrySetPropertyOnNineSlice(asNineSlice, graphicalUiElement, propertyName, value);
             }
         }
         else if(containedObjectAsIpso is Polygon asPolygon)
         {
+            if(!handled)
+            {
+                handled = TrySetPropertiesOnRenderableBase(asPolygon, graphicalUiElement, propertyName, value);
+            }
             if(!handled)
             {
                 handled = TrySetPropertyOnPolygon(asPolygon, graphicalUiElement, propertyName, value);

--- a/Runtimes/SkiaGum/CustomSetPropertyOnRenderable.cs
+++ b/Runtimes/SkiaGum/CustomSetPropertyOnRenderable.cs
@@ -38,14 +38,21 @@ public class CustomSetPropertyOnRenderable
             case nameof(RenderableShapeBase.Alpha):
                 renderableBase.Alpha = (int)value;
                 return true;
+#if SKIA
             // .gumx stores Blend as the non-nullable Gum.RenderingLibrary.Blend enum, but the
             // property is Blend?. SetPropertyThroughReflection's Convert.ChangeType fallback
             // throws on enum -> Nullable<enum>, so the assignment has to land here. See the
             // SilkNetGum sample crash that prompted this branch — every Standards/*.gutx with
             // a default Blend variable hit the reflection path before this case was added.
+            //
+            // SKIA-gated because this file is also file-linked into MonoGameGumShapes /
+            // KniGumShapes (Apos.Shapes side) where RenderableShapeBase resolves to a
+            // different type that doesn't have a Blend property — see the type alias in the
+            // file header.
             case nameof(RenderableShapeBase.Blend):
                 renderableBase.Blend = (Blend)value;
                 return true;
+#endif
             case nameof(RenderableShapeBase.Alpha1):
                 renderableBase.Alpha1 = (int)value;
                 return true;

--- a/Runtimes/SkiaGum/Renderables/BlendToSkBlendModeExtensions.cs
+++ b/Runtimes/SkiaGum/Renderables/BlendToSkBlendModeExtensions.cs
@@ -1,0 +1,22 @@
+using SkiaSharp;
+
+namespace SkiaGum.Renderables;
+
+internal static class BlendToSkBlendModeExtensions
+{
+    // Replace, ReplaceAlpha, and MinAlpha don't have a clean SkiaSharp equivalent; falling
+    // through to SrcOver matches the precedent set by the Raylib mapping (see
+    // Runtimes/RaylibGum/Renderables/BlendModeExtensions.cs) — silently picking the wrong
+    // mode would change visuals without an obvious cause. SubtractAlpha → DstOut is the one
+    // alpha-channel variant Skia exposes directly (cuts destination alpha by source alpha).
+    public static SKBlendMode ToSKBlendMode(this Gum.RenderingLibrary.Blend blend)
+    {
+        return blend switch
+        {
+            Gum.RenderingLibrary.Blend.Additive => SKBlendMode.Plus,
+            Gum.RenderingLibrary.Blend.Replace => SKBlendMode.Src,
+            Gum.RenderingLibrary.Blend.SubtractAlpha => SKBlendMode.DstOut,
+            _ => SKBlendMode.SrcOver,
+        };
+    }
+}

--- a/Runtimes/SkiaGum/Renderables/NineSlice.cs
+++ b/Runtimes/SkiaGum/Renderables/NineSlice.cs
@@ -16,10 +16,6 @@ public class NineSlice : RenderableShapeBase, IAnimatable, ICloneable, ITextureC
     /// </summary>
     public AnimationChainLogic AnimationLogic { get; } = new AnimationChainLogic();
 
-    // Skia does not yet honor Blend at draw time; the property exists for API parity with the
-    // unified NineSliceRuntime, which routes its cross-platform Blend property here.
-    public Gum.RenderingLibrary.Blend? Blend { get; set; }
-
     // Nearest-neighbour sampling. Linear filtering bleeds adjacent-section texels
     // across the boundary between two sections of the nine-slice source texture,
     // producing visible seams; nearest-neighbour samples a single texel per output

--- a/Runtimes/SkiaGum/Renderables/RenderableShapeBase.cs
+++ b/Runtimes/SkiaGum/Renderables/RenderableShapeBase.cs
@@ -722,6 +722,14 @@ public class RenderableShapeBase : IRenderableIpso, IVisible, IDisposable
 
     public BlendState BlendState => BlendState.AlphaBlend;
 
+    /// <summary>
+    /// The Gum blend mode applied when constructing the SKPaint used to draw this renderable.
+    /// When null, the SkiaSharp default (SrcOver / standard alpha blending) is used. Values
+    /// without a clean SkiaSharp equivalent (ReplaceAlpha, MinAlpha) fall through to SrcOver
+    /// rather than approximating; see <see cref="BlendToSkBlendModeExtensions"/>.
+    /// </summary>
+    public Gum.RenderingLibrary.Blend? Blend { get; set; }
+
     public bool ClipsChildren { get; set; }
 
     SKRect _lastBoundingRect;
@@ -796,6 +804,11 @@ public class RenderableShapeBase : IRenderableIpso, IVisible, IDisposable
         {
             paint.PathEffect = SKPathEffect.CreateDash(
                 new[] { StrokeDashLength, StrokeGapLength }, phase: 0);
+        }
+
+        if (Blend.HasValue)
+        {
+            paint.BlendMode = Blend.Value.ToSKBlendMode();
         }
 
         // If you add new paint properties here, don't forget to also add them to

--- a/Runtimes/SkiaGum/Renderables/Sprite.cs
+++ b/Runtimes/SkiaGum/Renderables/Sprite.cs
@@ -33,10 +33,6 @@ public class Sprite : RenderableShapeBase, IAspectRatio, ITextureCoordinate, IAn
 
     public SKImage? Image { get; set; }
 
-    // Skia does not yet honor Blend at draw time; the property exists for API parity with the
-    // unified SpriteRuntime, which routes its cross-platform Blend property here.
-    public Gum.RenderingLibrary.Blend? Blend { get; set; }
-
     public float? TextureWidth => Texture?.Width;
     public float? TextureHeight => Texture?.Height;
 

--- a/Samples/SilkNetGum/SilkNetGum/Screens/SpriteScreen.cs
+++ b/Samples/SilkNetGum/SilkNetGum/Screens/SpriteScreen.cs
@@ -13,9 +13,12 @@ namespace SilkNetGum.Screens;
 // other two so visual regressions in one backend are easy to spot against the others
 // when all three are opened side by side.
 //
-// Skia-specific: the Blend rows from the MG screen are absent here because
-// SpriteRuntime.Blend is #if XNALIKE only (see #2907). Otherwise the surface mirrors
-// the raylib version.
+// Skia blend coverage (#2920 unified the runtime surface, #2922 wired it through to
+// SKPaint.BlendMode):
+//   Normal -> SKBlendMode.SrcOver, Additive -> Plus, Replace -> Src,
+//   SubtractAlpha -> DstOut. ReplaceAlpha and MinAlpha have no clean SkiaSharp
+//   equivalent and fall through to SrcOver, so those two cells render identically
+//   to Normal — kept in the row anyway to mirror the MG layout 1:1.
 internal class SpriteScreen : GraphicalUiElement
 {
     public SpriteScreen() : base(new InvisibleRenderable())
@@ -125,6 +128,70 @@ internal class SpriteScreen : GraphicalUiElement
             s.Y = 14;
             s.Rotation = angle;
             rotRow.Children.Add(s);
+        }
+
+        // Blend modes — see the file header for the Gum.Blend -> SKBlendMode mapping.
+        // Normal/Additive/Replace are the visually-distinct cases on Skia; the alpha-only row
+        // below covers SubtractAlpha (DstOut on Skia) plus ReplaceAlpha/MinAlpha (which fall
+        // through to SrcOver and therefore look like Normal).
+        AddLabel(container, "Blend, normal rendering (Normal, Additive, Replace):");
+        ContainerRuntime blendRow = AddRow(container);
+        foreach (Gum.RenderingLibrary.Blend blend in new[]
+        {
+            Gum.RenderingLibrary.Blend.Normal,
+            Gum.RenderingLibrary.Blend.Additive,
+            Gum.RenderingLibrary.Blend.Replace,
+        })
+        {
+            SpriteRuntime s = new SpriteRuntime();
+            s.SourceFileName = "BearTexture.png";
+            s.Width = 64;
+            s.Height = 64;
+            s.Blend = blend;
+            blendRow.Children.Add(s);
+        }
+
+        // Alpha-only blends — mirrors the MG sample's render-target Container cells.
+        // SubtractAlpha (-> SKBlendMode.DstOut) actually punches a hole on Skia.
+        // ReplaceAlpha and MinAlpha currently fall through to SrcOver (#2922's mapping)
+        // because SkiaSharp has no clean equivalent — those two cells will look like Normal.
+        AddLabel(container, "Blend, alpha-only on render-target Container (SubtractAlpha, ReplaceAlpha, MinAlpha):");
+        ContainerRuntime alphaBlendRow = AddRow(container);
+        foreach (Gum.RenderingLibrary.Blend blend in new[]
+        {
+            Gum.RenderingLibrary.Blend.SubtractAlpha,
+            Gum.RenderingLibrary.Blend.ReplaceAlpha,
+            Gum.RenderingLibrary.Blend.MinAlpha,
+        })
+        {
+            ContainerRuntime cell = new ContainerRuntime();
+            cell.IsRenderTarget = true;
+            cell.Width = 32;
+            cell.Height = 32;
+
+#pragma warning disable CS0618 // ColoredRectangleRuntime is obsolete
+            ColoredRectangleRuntime redBackground = new ColoredRectangleRuntime();
+#pragma warning restore CS0618
+            redBackground.Width = 32;
+            redBackground.Height = 32;
+            redBackground.Color = SKColors.Red;
+            // MinAlpha cell only: drop the underlying alpha so the result is visibly
+            // distinct from ReplaceAlpha — matches the MG sample's setup. Has no
+            // visible effect on Skia today since both fall through to SrcOver.
+            if (blend == Gum.RenderingLibrary.Blend.MinAlpha)
+            {
+                redBackground.Alpha = 128;
+            }
+            cell.Children.Add(redBackground);
+
+            SpriteRuntime alphaMasker = new SpriteRuntime();
+            alphaMasker.SourceFileName = "BearTexture.png";
+            alphaMasker.Width = 64;
+            alphaMasker.Height = 64;
+            alphaMasker.Blend = blend;
+            cell.Children.Add(alphaMasker);
+
+            alphaBlendRow.Children.Add(cell);
         }
 
         // AnimationChain-driven sprite — same .achx pipeline the MG/raylib samples use.

--- a/Samples/SkiaGumWpfSample/SkiaGumWpfSample/MainWindow.xaml.cs
+++ b/Samples/SkiaGumWpfSample/SkiaGumWpfSample/MainWindow.xaml.cs
@@ -1,18 +1,7 @@
 ﻿using Gum.GueDeriving;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using Gum.RenderingLibrary;
+using SkiaGum.Renderables;
 using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
 
 namespace SkiaGumWpfSample
 {
@@ -25,23 +14,43 @@ namespace SkiaGumWpfSample
         {
             InitializeComponent();
 
-            var container = new ContainerRuntime();
-            container.ChildrenLayout = Gum.Managers.ChildrenLayout.TopToBottomStack;
-            container.StackSpacing = 3;
-            SkiaElement.Children.Add(container);
+            // Issue #2922 smoke test: two overlapping rectangle pairs.
+            // Top row uses default (Normal/SrcOver) blending — the second rectangle covers the
+            // first. Bottom row sets Blend = Additive on the second rectangle — the overlapped
+            // area shows the channel-summed color (red+green = yellow) instead of just red.
+            //
+            // RectangleRuntime doesn't expose Blend on its cross-platform runtime API today
+            // (only SpriteRuntime / NineSliceRuntime do — PR #2920). Reach the Skia-side
+            // RoundedRectangle renderable directly to set Blend; this is sample-internal code,
+            // not the intended consumer pattern.
 
+            AddOverlappedPair(yOffset: 20, additive: false);
+            AddOverlappedPair(yOffset: 180, additive: true);
+        }
 
-            var rectangle = new RectangleRuntime();
+        private void AddOverlappedPair(float yOffset, bool additive)
+        {
+            var greenRect = new RectangleRuntime();
+            greenRect.X = 20;
+            greenRect.Y = yOffset;
+            greenRect.Width = 200;
+            greenRect.Height = 120;
+            greenRect.FillColor = new SkiaSharp.SKColor(0, 220, 0);
+            SkiaElement.Children.Add(greenRect);
 
-            rectangle.FillColor = new SkiaSharp.SKColor(50, 100, 0);
-            container.Children.Add(rectangle);
+            var redRect = new RectangleRuntime();
+            redRect.X = 120;
+            redRect.Y = yOffset + 30;
+            redRect.Width = 200;
+            redRect.Height = 120;
+            redRect.FillColor = new SkiaSharp.SKColor(220, 0, 0);
+            SkiaElement.Children.Add(redRect);
 
-            var rectangle2 = new RectangleRuntime();
-            rectangle2.FillColor = new SkiaSharp.SKColor(200, 0, 0);
-
-            container.Children.Add(rectangle2);
-
-
+            if (additive)
+            {
+                // Additive on Skia (#2922) maps to SKBlendMode.Plus.
+                ((RoundedRectangle)redRect.RenderableComponent!).Blend = Blend.Additive;
+            }
         }
     }
 }

--- a/Samples/SkiaGumWpfSample/SkiaGumWpfSample/MainWindow.xaml.cs
+++ b/Samples/SkiaGumWpfSample/SkiaGumWpfSample/MainWindow.xaml.cs
@@ -1,7 +1,18 @@
 ﻿using Gum.GueDeriving;
-using Gum.RenderingLibrary;
-using SkiaGum.Renderables;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
 using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
 
 namespace SkiaGumWpfSample
 {
@@ -14,43 +25,23 @@ namespace SkiaGumWpfSample
         {
             InitializeComponent();
 
-            // Issue #2922 smoke test: two overlapping rectangle pairs.
-            // Top row uses default (Normal/SrcOver) blending — the second rectangle covers the
-            // first. Bottom row sets Blend = Additive on the second rectangle — the overlapped
-            // area shows the channel-summed color (red+green = yellow) instead of just red.
-            //
-            // RectangleRuntime doesn't expose Blend on its cross-platform runtime API today
-            // (only SpriteRuntime / NineSliceRuntime do — PR #2920). Reach the Skia-side
-            // RoundedRectangle renderable directly to set Blend; this is sample-internal code,
-            // not the intended consumer pattern.
+            var container = new ContainerRuntime();
+            container.ChildrenLayout = Gum.Managers.ChildrenLayout.TopToBottomStack;
+            container.StackSpacing = 3;
+            SkiaElement.Children.Add(container);
 
-            AddOverlappedPair(yOffset: 20, additive: false);
-            AddOverlappedPair(yOffset: 180, additive: true);
-        }
 
-        private void AddOverlappedPair(float yOffset, bool additive)
-        {
-            var greenRect = new RectangleRuntime();
-            greenRect.X = 20;
-            greenRect.Y = yOffset;
-            greenRect.Width = 200;
-            greenRect.Height = 120;
-            greenRect.FillColor = new SkiaSharp.SKColor(0, 220, 0);
-            SkiaElement.Children.Add(greenRect);
+            var rectangle = new RectangleRuntime();
 
-            var redRect = new RectangleRuntime();
-            redRect.X = 120;
-            redRect.Y = yOffset + 30;
-            redRect.Width = 200;
-            redRect.Height = 120;
-            redRect.FillColor = new SkiaSharp.SKColor(220, 0, 0);
-            SkiaElement.Children.Add(redRect);
+            rectangle.FillColor = new SkiaSharp.SKColor(50, 100, 0);
+            container.Children.Add(rectangle);
 
-            if (additive)
-            {
-                // Additive on Skia (#2922) maps to SKBlendMode.Plus.
-                ((RoundedRectangle)redRect.RenderableComponent!).Blend = Blend.Additive;
-            }
+            var rectangle2 = new RectangleRuntime();
+            rectangle2.FillColor = new SkiaSharp.SKColor(200, 0, 0);
+
+            container.Children.Add(rectangle2);
+
+
         }
     }
 }

--- a/Tests/SkiaGum.Tests/Renderables/BlendTests.cs
+++ b/Tests/SkiaGum.Tests/Renderables/BlendTests.cs
@@ -1,5 +1,7 @@
 using Gum.RenderingLibrary;
+using Gum.Wireframe;
 using Shouldly;
+using SkiaGum;
 using SkiaGum.Renderables;
 using SkiaSharp;
 
@@ -123,6 +125,64 @@ public class BlendTests
         using SKPaint paint = sut.InvokeGetPaint(new SKRect(0, 0, 100, 100), absoluteRotation: 0);
 
         paint.BlendMode.ShouldBe(SKBlendMode.Plus);
+    }
+
+    // Regression tests for the .gumx loading path that bit on first sample run:
+    // a Standards/RoundedRectangle.gutx (and friends) include a "Blend" default variable
+    // typed as the Gum.RenderingLibrary.Blend enum. The .gumx loader calls SetProperty with
+    // the unboxed non-nullable enum value, which falls through to CustomSetPropertyOnRenderable.
+    // Before this branch, that path landed on GraphicalUiElement.SetPropertyThroughReflection,
+    // which calls Convert.ChangeType(enumValue, typeof(Blend?)) and throws
+    // InvalidCastException because Convert.ChangeType doesn't support Nullable<T>.
+    // Direct-property unit tests didn't cover this because they bypass the reflection path.
+    [Fact]
+    public void SetPropertyOnRenderable_BlendOnSprite_AssignsAdditive()
+    {
+        Sprite renderable = new();
+        GraphicalUiElement gue = new(renderable);
+
+        CustomSetPropertyOnRenderable.SetPropertyOnRenderable(
+            renderable, gue, nameof(RenderableShapeBase.Blend), Blend.Additive);
+
+        renderable.Blend.ShouldBe(Blend.Additive);
+    }
+
+    [Fact]
+    public void SetPropertyOnRenderable_BlendOnNineSlice_AssignsAdditive()
+    {
+        NineSlice renderable = new();
+        GraphicalUiElement gue = new(renderable);
+
+        CustomSetPropertyOnRenderable.SetPropertyOnRenderable(
+            renderable, gue, nameof(RenderableShapeBase.Blend), Blend.Additive);
+
+        renderable.Blend.ShouldBe(Blend.Additive);
+    }
+
+    [Fact]
+    public void SetPropertyOnRenderable_BlendOnRoundedRectangle_AssignsNormal()
+    {
+        // Exact reproducer for the stack trace in #2922 follow-up: Standards/RoundedRectangle.gutx
+        // sets Blend = Normal as a default variable and crashed the SilkNetGum sample on load.
+        RoundedRectangle renderable = new();
+        GraphicalUiElement gue = new(renderable);
+
+        Should.NotThrow(() => CustomSetPropertyOnRenderable.SetPropertyOnRenderable(
+            renderable, gue, nameof(RenderableShapeBase.Blend), Blend.Normal));
+
+        renderable.Blend.ShouldBe(Blend.Normal);
+    }
+
+    [Fact]
+    public void SetPropertyOnRenderable_BlendOnPolygon_AssignsAdditive()
+    {
+        Polygon renderable = new();
+        GraphicalUiElement gue = new(renderable);
+
+        CustomSetPropertyOnRenderable.SetPropertyOnRenderable(
+            renderable, gue, nameof(RenderableShapeBase.Blend), Blend.Additive);
+
+        renderable.Blend.ShouldBe(Blend.Additive);
     }
 
     private sealed class TestableSprite : Sprite

--- a/Tests/SkiaGum.Tests/Renderables/BlendTests.cs
+++ b/Tests/SkiaGum.Tests/Renderables/BlendTests.cs
@@ -173,6 +173,37 @@ public class BlendTests
         renderable.Blend.ShouldBe(Blend.Normal);
     }
 
+    // SolidRectangle (internal), LineRectangle, and LineGrid have no per-type branch in
+    // CustomSetPropertyOnRenderable.SetPropertyOnRenderableFunc — they fell straight to the
+    // reflection fallback and hit the same enum -> Nullable<enum> InvalidCastException as
+    // the named-branch types. The user-reported crash was on SolidRectangle (the renderable
+    // for SolidRectangleRuntime / the "ColoredRectangle" standard mapping in SystemManagers).
+    // LineRectangle stands in for SolidRectangle in tests since SolidRectangle is internal;
+    // both exercise the same RenderableShapeBase catch-all path.
+    [Fact]
+    public void SetPropertyOnRenderable_BlendOnLineRectangle_AssignsNormal()
+    {
+        LineRectangle renderable = new();
+        GraphicalUiElement gue = new(renderable);
+
+        Should.NotThrow(() => CustomSetPropertyOnRenderable.SetPropertyOnRenderable(
+            renderable, gue, nameof(RenderableShapeBase.Blend), Blend.Normal));
+
+        renderable.Blend.ShouldBe(Blend.Normal);
+    }
+
+    [Fact]
+    public void SetPropertyOnRenderable_BlendOnLineGrid_AssignsAdditive()
+    {
+        LineGrid renderable = new();
+        GraphicalUiElement gue = new(renderable);
+
+        CustomSetPropertyOnRenderable.SetPropertyOnRenderable(
+            renderable, gue, nameof(RenderableShapeBase.Blend), Blend.Additive);
+
+        renderable.Blend.ShouldBe(Blend.Additive);
+    }
+
     [Fact]
     public void SetPropertyOnRenderable_BlendOnPolygon_AssignsAdditive()
     {

--- a/Tests/SkiaGum.Tests/Renderables/BlendTests.cs
+++ b/Tests/SkiaGum.Tests/Renderables/BlendTests.cs
@@ -1,0 +1,145 @@
+using Gum.RenderingLibrary;
+using Shouldly;
+using SkiaGum.Renderables;
+using SkiaSharp;
+
+namespace SkiaGum.Tests.Renderables;
+
+/// <summary>
+/// Verifies that <see cref="Gum.RenderingLibrary.Blend"/> set on a Skia renderable is honored
+/// at paint construction time as <see cref="SKBlendMode"/>. Before this wiring, the property
+/// was stored on the renderable but never read, so e.g. setting <c>Blend = Additive</c>
+/// silently produced normal alpha blending.
+/// </summary>
+public class BlendTests
+{
+    [Fact]
+    public void RenderableShapeBase_Blend_DefaultsToNull()
+    {
+        TestableSprite sut = new();
+
+        sut.Blend.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Sprite_GetPaint_NullBlend_LeavesDefaultSrcOver()
+    {
+        TestableSprite sut = new();
+        sut.Blend = null;
+
+        using SKPaint paint = sut.InvokeGetPaint(new SKRect(0, 0, 100, 100), absoluteRotation: 0);
+
+        paint.BlendMode.ShouldBe(SKBlendMode.SrcOver);
+    }
+
+    [Fact]
+    public void Sprite_GetPaint_Normal_MapsToSrcOver()
+    {
+        TestableSprite sut = new();
+        sut.Blend = Blend.Normal;
+
+        using SKPaint paint = sut.InvokeGetPaint(new SKRect(0, 0, 100, 100), absoluteRotation: 0);
+
+        paint.BlendMode.ShouldBe(SKBlendMode.SrcOver);
+    }
+
+    [Fact]
+    public void Sprite_GetPaint_Additive_MapsToPlus()
+    {
+        TestableSprite sut = new();
+        sut.Blend = Blend.Additive;
+
+        using SKPaint paint = sut.InvokeGetPaint(new SKRect(0, 0, 100, 100), absoluteRotation: 0);
+
+        paint.BlendMode.ShouldBe(SKBlendMode.Plus);
+    }
+
+    [Fact]
+    public void Sprite_GetPaint_Replace_MapsToSrc()
+    {
+        TestableSprite sut = new();
+        sut.Blend = Blend.Replace;
+
+        using SKPaint paint = sut.InvokeGetPaint(new SKRect(0, 0, 100, 100), absoluteRotation: 0);
+
+        paint.BlendMode.ShouldBe(SKBlendMode.Src);
+    }
+
+    [Fact]
+    public void Sprite_GetPaint_SubtractAlpha_MapsToDstOut()
+    {
+        TestableSprite sut = new();
+        sut.Blend = Blend.SubtractAlpha;
+
+        using SKPaint paint = sut.InvokeGetPaint(new SKRect(0, 0, 100, 100), absoluteRotation: 0);
+
+        paint.BlendMode.ShouldBe(SKBlendMode.DstOut);
+    }
+
+    // ReplaceAlpha and MinAlpha have no clean SkiaSharp equivalent. Mirror the Raylib precedent
+    // (see Runtimes/RaylibGum/Renderables/BlendModeExtensions.cs) and fall through to the default
+    // SrcOver rather than picking a Skia mode that would silently change visuals.
+    [Fact]
+    public void Sprite_GetPaint_ReplaceAlpha_FallsThroughToSrcOver()
+    {
+        TestableSprite sut = new();
+        sut.Blend = Blend.ReplaceAlpha;
+
+        using SKPaint paint = sut.InvokeGetPaint(new SKRect(0, 0, 100, 100), absoluteRotation: 0);
+
+        paint.BlendMode.ShouldBe(SKBlendMode.SrcOver);
+    }
+
+    [Fact]
+    public void Sprite_GetPaint_MinAlpha_FallsThroughToSrcOver()
+    {
+        TestableSprite sut = new();
+        sut.Blend = Blend.MinAlpha;
+
+        using SKPaint paint = sut.InvokeGetPaint(new SKRect(0, 0, 100, 100), absoluteRotation: 0);
+
+        paint.BlendMode.ShouldBe(SKBlendMode.SrcOver);
+    }
+
+    // Blend lives on RenderableShapeBase so every shape derivative gets it, not just Sprite/NineSlice.
+    // Spot-check NineSlice and a non-texture shape (Circle) to lock that in.
+    [Fact]
+    public void NineSlice_GetPaint_Additive_MapsToPlus()
+    {
+        TestableNineSlice sut = new();
+        sut.Blend = Blend.Additive;
+
+        using SKPaint paint = sut.InvokeGetPaint(new SKRect(0, 0, 100, 100), absoluteRotation: 0);
+
+        paint.BlendMode.ShouldBe(SKBlendMode.Plus);
+    }
+
+    [Fact]
+    public void Circle_GetPaint_Additive_MapsToPlus()
+    {
+        TestableCircle sut = new();
+        sut.Blend = Blend.Additive;
+
+        using SKPaint paint = sut.InvokeGetPaint(new SKRect(0, 0, 100, 100), absoluteRotation: 0);
+
+        paint.BlendMode.ShouldBe(SKBlendMode.Plus);
+    }
+
+    private sealed class TestableSprite : Sprite
+    {
+        public SKPaint InvokeGetPaint(SKRect boundingRect, float absoluteRotation)
+            => GetPaint(boundingRect, absoluteRotation);
+    }
+
+    private sealed class TestableNineSlice : NineSlice
+    {
+        public SKPaint InvokeGetPaint(SKRect boundingRect, float absoluteRotation)
+            => GetPaint(boundingRect, absoluteRotation);
+    }
+
+    private sealed class TestableCircle : Circle
+    {
+        public SKPaint InvokeGetPaint(SKRect boundingRect, float absoluteRotation)
+            => GetPaint(boundingRect, absoluteRotation);
+    }
+}


### PR DESCRIPTION
## Summary

- Promotes `Blend?` from per-class `Sprite` / `NineSlice` to `RenderableShapeBase`, so every shape derivative (Sprite, NineSlice, Line, Arc, Circle, Polygon, RoundedRectangle, LineRectangle, LineGrid, SolidRectangle) honors blend without duplicating the property.
- Adds `BlendToSkBlendModeExtensions.ToSKBlendMode(...)` and applies it in `RenderableShapeBase.GetPaint` when `Blend` has a value. Default behavior unchanged when `Blend` is null.
- Before this PR the Skia `Blend?` shim added in PR #2920 was stored on the renderable but never read at draw time, so `mySprite.Blend = Blend.Additive` silently did nothing on Skia.
- Plumbs the property through the `.gumx`-loading reflection path so Standards files with a default `Blend` variable don't crash on screen load (see "Follow-on fixes" below).

## Mapping decisions

`Gum.Blend` → `SKBlendMode`, mirroring the Raylib precedent in PR #2920:

| Gum.Blend | SKBlendMode |
|---|---|
| `Normal` | `SrcOver` |
| `Additive` | `Plus` |
| `Replace` | `Src` |
| `SubtractAlpha` | `DstOut` (cuts dst alpha by src alpha — the alpha-channel mask op) |
| `ReplaceAlpha` | falls through to `SrcOver` |
| `MinAlpha` | falls through to `SrcOver` |

`ReplaceAlpha` and `MinAlpha` have no clean SkiaSharp equivalent. Picking a wrong mode would silently change visuals; falling through to `SrcOver` matches the Raylib precedent.

## Follow-on fixes (commits 2-4)

Initial commit covered the typed-property path. Running the SilkNet sample uncovered that `.gumx` loading exercises a different path that the unit tests bypassed:

```
StateSave.ApplyState
  → GraphicalUiElement.SetProperty("Blend", Blend.Normal)
  → CustomSetPropertyOnRenderable.SetPropertyOnRenderable(...)
  → no "Blend" case for shape renderables  → falls through
  → GraphicalUiElement.SetPropertyThroughReflection
  → Convert.ChangeType(Blend.Normal, typeof(Blend?))  → InvalidCastException
```

`Convert.ChangeType` does not support `Nullable<T>` targets. Standards/RoundedRectangle.gutx (and several other Standards files) ship a default `Blend = Normal` variable, so every Skia screen load that instantiated a shape standard crashed after the property landed on `RenderableShapeBase`.

Two follow-on commits fixed it on the Skia side:

1. **Add a `Blend` case to `TrySetPropertiesOnRenderableBase`** + route Sprite/NineSlice/Polygon branches through it (they had historically skipped the base helper).
2. **Add a final catch-all** for unbranched `RenderableShapeBase` derivatives (`SolidRectangle`, `LineRectangle`, `LineGrid`) before the reflection fallback — those types have no per-type branch in `SetPropertyOnRenderableFunc` at all, so the explicit route on Sprite/NineSlice/Polygon didn't help them.

The underlying defect is in core `GraphicalUiElement.SetPropertyThroughReflection` (`Convert.ChangeType` doesn't handle `Nullable<T>` targets or `int → enum`). SokolGum already wraps around it with a manual unwrap. A proper fix in core would let SokolGum's wrapper become redundant and eliminate the foot-gun for future `Nullable<EnumType>` properties on any backend — filed as **#2924**.

## Override safety

The four classes that override `GetPaint` (`Sprite`, `NineSlice`, `Line`, `Arc`) all call `base.GetPaint(...)` first and only tweak the returned paint. None sets `paint.BlendMode`, so the blend set in the base survives. `NineSlice` sets a `ColorFilter` for tinting — that's a separate concept from `BlendMode` and they compose.

## Scope

- Blend wiring only. Other Skia-renderable gaps (`Text`, `VectorSprite`, `LottieAnimation`, `CanvasRenderable` don't inherit from `RenderableShapeBase`) are noted in #2922 as out of scope.

## Sample

Updated `Samples/SilkNetGum/SilkNetGum/Screens/SpriteScreen.cs` to mirror the MonoGame `SpriteScreen` blend rows 1:1: Normal/Additive/Replace and (render-target) SubtractAlpha/ReplaceAlpha/MinAlpha. The `SkiaGumWpfSample` is left at its prior content.

## Test plan

- [x] `dotnet test Tests/SkiaGum.Tests/SkiaGum.Tests.csproj` — 166/166 passing (10 typed-property + 6 reflection-path Blend tests, plus prior coverage)
- [x] `Tests/RaylibGum.Tests/Runtimes/BlendTests.cs` — 6/6 still passing (no cross-backend regression)
- [x] `MonoGameGum.Tests` Sprite filter — 20/20 still passing
- [x] `dotnet build Runtimes/SkiaGum/SkiaGum.csproj` — clean
- [x] `dotnet build MonoGameGum/MonoGameGum.csproj` — clean
- [x] `dotnet build Runtimes/RaylibGum/RaylibGum.csproj` — clean
- [x] `dotnet build Samples/SilkNetGum/SilkNetGum/SilkNetGum.csproj` — clean
- [x] User verified SilkNetGum screen loads past the Standards reflection path

Closes #2922

🤖 Generated with [Claude Code](https://claude.com/claude-code)