### PR TITLE
#2925: Apos.Shapes-backed Circle/Rectangle/Arc rendering in the Gum tool

### DIFF
--- a/FlatRedBall.SpecializedXnaControls/FlatRedBall.SpecializedXnaControls.csproj
+++ b/FlatRedBall.SpecializedXnaControls/FlatRedBall.SpecializedXnaControls.csproj
@@ -24,9 +24,9 @@
 	  <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-	  <PackageReference Include="nkast.Xna.Framework" Version="4.1.9001" />
-	  <PackageReference Include="nkast.Xna.Framework.Game" Version="4.1.9001" />
-	  <PackageReference Include="nkast.Xna.Framework.Graphics" Version="4.1.9001.1" />
+	  <PackageReference Include="nkast.Xna.Framework" Version="4.2.9001" />
+	  <PackageReference Include="nkast.Xna.Framework.Game" Version="4.2.9001" />
+	  <PackageReference Include="nkast.Xna.Framework.Graphics" Version="4.2.9001" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="ImageRegionSelectionControl.cs">

--- a/Gum.sln
+++ b/Gum.sln
@@ -69,6 +69,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Runtimes", "Runtimes", "{BB
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GumExpressions", "Runtimes\GumExpressions\GumExpressions.csproj", "{B0049C36-D9A3-4393-811E-CA395CA4F04F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "KniGumShapes", "Runtimes\GumShapes\KniGumShapes.csproj", "{0ACB5541-4EE9-B119-BD9A-78E237974418}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -415,6 +417,18 @@ Global
 		{B0049C36-D9A3-4393-811E-CA395CA4F04F}.Release|x64.Build.0 = Release|Any CPU
 		{B0049C36-D9A3-4393-811E-CA395CA4F04F}.Release|x86.ActiveCfg = Release|Any CPU
 		{B0049C36-D9A3-4393-811E-CA395CA4F04F}.Release|x86.Build.0 = Release|Any CPU
+		{0ACB5541-4EE9-B119-BD9A-78E237974418}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0ACB5541-4EE9-B119-BD9A-78E237974418}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0ACB5541-4EE9-B119-BD9A-78E237974418}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{0ACB5541-4EE9-B119-BD9A-78E237974418}.Debug|x64.Build.0 = Debug|Any CPU
+		{0ACB5541-4EE9-B119-BD9A-78E237974418}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{0ACB5541-4EE9-B119-BD9A-78E237974418}.Debug|x86.Build.0 = Debug|Any CPU
+		{0ACB5541-4EE9-B119-BD9A-78E237974418}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0ACB5541-4EE9-B119-BD9A-78E237974418}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0ACB5541-4EE9-B119-BD9A-78E237974418}.Release|x64.ActiveCfg = Release|Any CPU
+		{0ACB5541-4EE9-B119-BD9A-78E237974418}.Release|x64.Build.0 = Release|Any CPU
+		{0ACB5541-4EE9-B119-BD9A-78E237974418}.Release|x86.ActiveCfg = Release|Any CPU
+		{0ACB5541-4EE9-B119-BD9A-78E237974418}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -447,6 +461,7 @@ Global
 		{C0D5299A-850D-40B1-942F-D2317813EE7B} = {A1B2C3D4-E5F6-7890-ABCD-EF1234567890}
 		{A564335F-C0A3-47C0-BEA0-7DA23F7C3E9A} = {E9BDDA50-D0CD-4172-959F-66E2C1DFEB50}
 		{B0049C36-D9A3-4393-811E-CA395CA4F04F} = {BB4FD3E1-BF37-801A-7591-DC4DC6E3BB2D}
+		{0ACB5541-4EE9-B119-BD9A-78E237974418} = {C66AD07F-C683-4C24-8E6B-20638ACC3A25}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {691B2E2F-58CB-4FD2-8480-695E8DE0CCE2}

--- a/Gum/Gum.csproj
+++ b/Gum/Gum.csproj
@@ -399,10 +399,10 @@
 		<PackageReference Include="System.Drawing.Common" Version="10.0.0" />
 		<PackageReference Include="System.Management" Version="9.0.3" />
 
-		<PackageReference Include="nkast.Xna.Framework" Version="4.1.9001" />
-		<PackageReference Include="nkast.Xna.Framework.Graphics" Version="4.1.9001.1" />
-		<PackageReference Include="nkast.Xna.Framework.Input" Version="4.1.9001" />
-		<PackageReference Include="nkast.Kni.Platform.WinForms.DX11" Version="4.1.9001" />
+		<PackageReference Include="nkast.Xna.Framework" Version="4.2.9001" />
+		<PackageReference Include="nkast.Xna.Framework.Graphics" Version="4.2.9001" />
+		<PackageReference Include="nkast.Xna.Framework.Input" Version="4.2.9001" />
+		<PackageReference Include="nkast.Kni.Platform.WinForms.DX11" Version="4.2.9001" />
 		<PackageReference Include="System.Resources.Extensions" Version="9.0.5" />
 		<PackageReference Include="MaterialDesignThemes" Version="5.1.0" />
 	</ItemGroup>

--- a/Gum/SvgPlugin/MainSkiaPlugin.cs
+++ b/Gum/SvgPlugin/MainSkiaPlugin.cs
@@ -173,9 +173,12 @@ namespace SkiaPlugin
         {
             switch (type)
             {
-                case "Arc": return new SkiaTexturedRenderable(new RenderableShapeAdapter(new Arc()));
+                // Arc is intentionally NOT handled here: issue #2925 hands the Arc standard
+                // type to the Apos.Shapes-backed ArcRuntime registered by AposShapeRuntime
+                // (Runtimes/GumShapes/GueDeriving/AposShapeRuntime.cs) so the tool and MonoGame
+                // runtime stay on a single rendering path. The Skia Arc renderable class remains
+                // compiled but unwired by design (option A).
                 case "Canvas": return new SkiaTexturedRenderable(new RenderableCanvas());
-
                 case "ColoredCircle": return new SkiaTexturedRenderable(new RenderableShapeAdapter(new Circle()));
                 case "Line": return new SkiaTexturedRenderable(new RenderableShapeAdapter(new Line()));
                 case "LottieAnimation": return new SkiaTexturedRenderable(new RenderableLottieAnimation());

--- a/Gum/SvgPlugin/SkiaPlugin.csproj
+++ b/Gum/SvgPlugin/SkiaPlugin.csproj
@@ -25,8 +25,8 @@
     <None Remove="SkiaInGumShared\obj\**" />
   </ItemGroup>
   <ItemGroup>
-	  <PackageReference Include="nkast.Xna.Framework" Version="4.1.9001" />
-	  <PackageReference Include="nkast.Xna.Framework.Graphics" Version="4.1.9001.1" />
+	  <PackageReference Include="nkast.Xna.Framework" Version="4.2.9001" />
+	  <PackageReference Include="nkast.Xna.Framework.Graphics" Version="4.2.9001" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\MonoGameGum\KniGum\KniGum.csproj" />

--- a/Gum/TextureCoordinateSelectionPlugin/TextureCoordinateSelectionPlugin.csproj
+++ b/Gum/TextureCoordinateSelectionPlugin/TextureCoordinateSelectionPlugin.csproj
@@ -21,8 +21,8 @@
     <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-	  <PackageReference Include="nkast.Xna.Framework" Version="4.1.9001" />
-	  <PackageReference Include="nkast.Xna.Framework.Graphics" Version="4.1.9001.1" />
+	  <PackageReference Include="nkast.Xna.Framework" Version="4.2.9001" />
+	  <PackageReference Include="nkast.Xna.Framework.Graphics" Version="4.2.9001" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\FlatRedBall.SpecializedXnaControls\FlatRedBall.SpecializedXnaControls.csproj" />

--- a/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
+++ b/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
@@ -120,13 +120,27 @@ public class CustomSetPropertyOnRenderable
     {
         bool handled = false;
 
-        // First try special-casing.  
+        // First try special-casing.
 
         if (renderableIpso is Text renderableText)
         {
             handled = TrySetPropertyOnText(renderableText, graphicalUiElement, propertyName, value);
         }
 #if XNALIKE
+        // Issue #2925 — dispatch by RUNTIME type for CircleRuntime / RectangleRuntime before
+        // falling through to the renderable-type tree. Both runtimes now own two renderable
+        // slots (fill + stroke) and their mContainedObjectAsIpso may be the fill slot, so a
+        // renderable-type-only dispatch lands legacy "Color" / "Alpha" / "Red" / etc. on the
+        // wrong slot. Routing through the runtime's typed property setters keeps each variable
+        // landing where its pre-two-slot equivalent did, independent of which slot is contained.
+        else if (graphicalUiElement is Gum.GueDeriving.CircleRuntime circleRuntime)
+        {
+            handled = TrySetPropertyOnCircleRuntime(circleRuntime, propertyName, value);
+        }
+        else if (graphicalUiElement is Gum.GueDeriving.RectangleRuntime rectangleRuntime)
+        {
+            handled = TrySetPropertyOnRectangleRuntime(rectangleRuntime, propertyName, value);
+        }
         else if (renderableIpso is LineCircle)
         {
             handled = TrySetPropertyOnLineCircle(renderableIpso, graphicalUiElement, propertyName, value);
@@ -2164,4 +2178,102 @@ public class CustomSetPropertyOnRenderable
 
         return fontFilePath;
     }
+
+#if XNALIKE
+    // Issue #2925 — legacy variable routing for the two-slot CircleRuntime. The legacy
+    // properties (Color/Alpha/Red/Green/Blue) on the runtime are intentionally obsolete and
+    // already route to the stroke slot internally, preserving pre-two-slot behavior. Going
+    // through them here means the helper does not need to know which slot is the contained
+    // object or which backend produced the renderable.
+    private static bool TrySetPropertyOnCircleRuntime(Gum.GueDeriving.CircleRuntime circleRuntime, string propertyName, object value)
+    {
+#pragma warning disable CS0618 // legacy obsolete properties are the public surface this dispatch was written against
+        switch (propertyName)
+        {
+            case "Color":
+                if (value is System.Drawing.Color drawingColor)
+                {
+                    circleRuntime.Color = new Microsoft.Xna.Framework.Color(drawingColor.R, drawingColor.G, drawingColor.B, drawingColor.A);
+                }
+                else if (value is Microsoft.Xna.Framework.Color xnaColor)
+                {
+                    circleRuntime.Color = xnaColor;
+                }
+                else
+                {
+                    return false;
+                }
+                return true;
+            case "Alpha":
+                circleRuntime.Alpha = (int)value;
+                return true;
+            case "Red":
+                circleRuntime.Red = (int)value;
+                return true;
+            case "Green":
+                circleRuntime.Green = (int)value;
+                return true;
+            case "Blue":
+                circleRuntime.Blue = (int)value;
+                return true;
+            case "Radius":
+                circleRuntime.Radius = (float)value;
+                return true;
+        }
+        return false;
+#pragma warning restore CS0618
+    }
+
+    // Issue #2925 — same pattern for RectangleRuntime.
+    private static bool TrySetPropertyOnRectangleRuntime(Gum.GueDeriving.RectangleRuntime rectangleRuntime, string propertyName, object value)
+    {
+#pragma warning disable CS0618
+        switch (propertyName)
+        {
+            case "Color":
+                if (value is System.Drawing.Color drawingColor)
+                {
+                    rectangleRuntime.Color = new Microsoft.Xna.Framework.Color(drawingColor.R, drawingColor.G, drawingColor.B, drawingColor.A);
+                }
+                else if (value is Microsoft.Xna.Framework.Color xnaColor)
+                {
+                    rectangleRuntime.Color = xnaColor;
+                }
+                else
+                {
+                    return false;
+                }
+                return true;
+            case "Alpha":
+                rectangleRuntime.Alpha = (int)value;
+                return true;
+            case "Red":
+                rectangleRuntime.Red = (int)value;
+                return true;
+            case "Green":
+                rectangleRuntime.Green = (int)value;
+                return true;
+            case "Blue":
+                rectangleRuntime.Blue = (int)value;
+                return true;
+            case "CornerRadius":
+                rectangleRuntime.CornerRadius = (float)value;
+                return true;
+            case "CustomRadiusTopLeft":
+                rectangleRuntime.CustomRadiusTopLeft = (float?)value;
+                return true;
+            case "CustomRadiusTopRight":
+                rectangleRuntime.CustomRadiusTopRight = (float?)value;
+                return true;
+            case "CustomRadiusBottomLeft":
+                rectangleRuntime.CustomRadiusBottomLeft = (float?)value;
+                return true;
+            case "CustomRadiusBottomRight":
+                rectangleRuntime.CustomRadiusBottomRight = (float?)value;
+                return true;
+        }
+        return false;
+#pragma warning restore CS0618
+    }
+#endif
 }

--- a/Gum/Wireframe/FallbackRenderableFactory.cs
+++ b/Gum/Wireframe/FallbackRenderableFactory.cs
@@ -1,3 +1,4 @@
+using Gum.GueDeriving;
 using RenderingLibrary;
 using RenderingLibrary.Graphics;
 using System;
@@ -127,11 +128,38 @@ namespace Gum.Wireframe
                     break;
 
                 case "Rectangle":
+#if MONOGAME || FNA || KNI
+                    // Issue #2925 — prefer a registry-supplied stroked rectangle (Apos.Shapes
+                    // RoundedRectangle when MonoGameGumShapes is loaded) over the legacy
+                    // LineRectangle. The IStrokedRectangleRenderable interface is XNALIKE-only
+                    // (registry is shared via GumCommon but the interface ships under #if XNALIKE
+                    // in MonoGameGum), so RAYLIB/SOKOL fall through to the unconditional legacy
+                    // path below. In XNALIKE builds the core default factory
+                    // (DefaultStrokedRectangleRenderable, a LineRectangle subclass) is registered
+                    // at module load; tests that call RenderableRegistry.Reset() will see null
+                    // here and fall through to the legacy path.
+                    if (RenderableRegistry.Create<IStrokedRectangleRenderable>() is IRenderable registryRectangle)
+                    {
+                        containedObject = registryRectangle;
+                        break;
+                    }
+#endif
                     LineRectangle rectangle = new LineRectangle(systemManagers);
                     rectangle.IsDotted = false;
                     containedObject = rectangle;
                     break;
                 case "Circle":
+#if MONOGAME || FNA || KNI
+                    // Issue #2925 — prefer a registry-supplied stroked circle (Apos.Shapes Circle
+                    // when MonoGameGumShapes is loaded) over the legacy LineCircle so the tool
+                    // and runtime render the same Apos-backed shape that the MonoGameGum
+                    // CircleRuntime constructor resolves. Same XNALIKE gating as Rectangle above.
+                    if (RenderableRegistry.Create<IStrokedCircleRenderable>() is IRenderable registryCircle)
+                    {
+                        containedObject = registryCircle;
+                        break;
+                    }
+#endif
                     LineCircle circle = new LineCircle(systemManagers);
                     circle.CircleOrigin = CircleOrigin.TopLeft;
                     containedObject = circle;

--- a/InputLibrary/InputLibrary.csproj
+++ b/InputLibrary/InputLibrary.csproj
@@ -11,9 +11,9 @@
 
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="nkast.Xna.Framework" Version="4.1.9001" />
-		<PackageReference Include="nkast.Xna.Framework.Graphics" Version="4.1.9001.1" />
-		<PackageReference Include="nkast.Xna.Framework.Input" Version="4.1.9001" />
+		<PackageReference Include="nkast.Xna.Framework" Version="4.2.9001" />
+		<PackageReference Include="nkast.Xna.Framework.Graphics" Version="4.2.9001" />
+		<PackageReference Include="nkast.Xna.Framework.Input" Version="4.2.9001" />
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="Microsoft.CSharp" Version="4.7.0" />

--- a/MonoGameGum.Tests/Runtimes/ElementSaveExtensions.cs
+++ b/MonoGameGum.Tests/Runtimes/ElementSaveExtensions.cs
@@ -3,12 +3,14 @@ using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using Gum.GueDeriving;
+using RenderingLibrary;
 using RenderingLibrary.Graphics;
 using Shouldly;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
+using System.Reflection;
 using System.Security.Cryptography;
 using System.Text;
 using System.Threading.Tasks;
@@ -63,6 +65,51 @@ public class ElementSaveExtensionsTests : IDisposable
 
         var runtime = ElementSaveExtensions.CreateGueForElement(element);
         runtime.Name.ShouldBe("Registered Gue Type");
+    }
+
+    // Issue #2925 — SystemManagers.RegisterComponentRuntimeInstantiations is the canonical
+    // primary-registry hook for the MonoGame/KNI/FNA backends; everything the Apos.Shapes
+    // package overrides must be reached through it, otherwise CircleRuntime is bypassed in
+    // favor of FallbackRenderableFactory's LineCircle. Method is private, so we invoke it
+    // via reflection — same pattern other tests use for SystemManagers internals.
+    [Fact]
+    public void RegisterComponentRuntimeInstantiations_ShouldRegisterCircleRuntime_ForCircleBaseType()
+    {
+        InvokeRegisterComponentRuntimeInstantiations();
+
+        var element = new StandardElementSave { Name = "Circle" };
+
+        var created = ElementSaveExtensions.CreateGueForElement(element);
+
+        // RegisterComponentRuntimeInstantiations constructs the obsolete-shim subclass
+        // (MonoGameGum.GueDeriving.CircleRuntime) during the deprecation window — see the
+        // file-level comment on SystemManagers.cs. Use ShouldBeAssignableTo so the test
+        // pins the base contract without coupling to the shim type.
+        created.ShouldBeAssignableTo<CircleRuntime>();
+    }
+
+    // Symmetric coverage for Rectangle — the registration already exists, but until now no
+    // test pinned it, which is how Circle's omission slipped past review.
+    [Fact]
+    public void RegisterComponentRuntimeInstantiations_ShouldRegisterRectangleRuntime_ForRectangleBaseType()
+    {
+        InvokeRegisterComponentRuntimeInstantiations();
+
+        var element = new StandardElementSave { Name = "Rectangle" };
+
+        var created = ElementSaveExtensions.CreateGueForElement(element);
+
+        created.ShouldBeAssignableTo<RectangleRuntime>();
+    }
+
+    private static void InvokeRegisterComponentRuntimeInstantiations()
+    {
+        var managers = new SystemManagers();
+        var method = typeof(SystemManagers).GetMethod(
+            "RegisterComponentRuntimeInstantiations",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+        method.ShouldNotBeNull("RegisterComponentRuntimeInstantiations must exist on SystemManagers.");
+        method!.Invoke(managers, parameters: null);
     }
 
     [Fact]

--- a/MonoGameGum.Tests/Wireframe/FallbackRenderableFactoryTests.cs
+++ b/MonoGameGum.Tests/Wireframe/FallbackRenderableFactoryTests.cs
@@ -1,4 +1,6 @@
+using Gum.GueDeriving;
 using Gum.Wireframe;
+using MonoGameGum.Renderables;
 using RenderingLibrary.Graphics;
 using RenderingLibrary.Math.Geometry;
 using Shouldly;
@@ -22,10 +24,31 @@ public class FallbackRenderableFactoryTests : BaseTestClass
     }
 
     [Fact]
-    public void TryHandleAsBaseType_Circle_ReturnsLineCircle()
+    public void TryHandleAsBaseType_Circle_ReturnsLineCircle_WhenNoRegistryFactory()
     {
+        // BaseTestClass.Dispose runs RenderableRegistry.Reset(), so each test starts with no
+        // factories. Without a registered IStrokedCircleRenderable factory, the fallback's
+        // legacy LineCircle path must still fire so the tool keeps rendering circles when
+        // MonoGameGumShapes is not in use.
         IRenderable result = FallbackRenderableFactory.TryHandleAsBaseType("Circle", null);
         result.ShouldBeOfType<LineCircle>();
+    }
+
+    [Fact]
+    public void TryHandleAsBaseType_Circle_PrefersRegistryFactory_OverLegacyLineCircle()
+    {
+        // Issue #2925: the tool's editor wireframe path (EditorTabPlugin_XNA.HandleCreate
+        // RenderableForType) calls TryHandleAsBaseType for "Circle". When MonoGameGumShapes
+        // is loaded it registers an Apos.Shapes-backed IStrokedCircleRenderable factory;
+        // the fallback must ask the registry first so the user sees the Apos.Shapes
+        // shader-drawn circle (smooth at any zoom) rather than the legacy LineCircle's
+        // polygon segments.
+        RegistryStrokedCircleSentinel sentinel = new();
+        RenderableRegistry.RegisterFactory<IStrokedCircleRenderable>(() => sentinel);
+
+        IRenderable result = FallbackRenderableFactory.TryHandleAsBaseType("Circle", null);
+
+        result.ShouldBeSameAs(sentinel);
     }
 
     [Fact]
@@ -87,10 +110,24 @@ public class FallbackRenderableFactoryTests : BaseTestClass
     }
 
     [Fact]
-    public void TryHandleAsBaseType_Rectangle_ReturnsLineRectangle()
+    public void TryHandleAsBaseType_Rectangle_ReturnsLineRectangle_WhenNoRegistryFactory()
     {
         IRenderable result = FallbackRenderableFactory.TryHandleAsBaseType("Rectangle", null);
         result.ShouldBeOfType<LineRectangle>();
+    }
+
+    [Fact]
+    public void TryHandleAsBaseType_Rectangle_PrefersRegistryFactory_OverLegacyLineRectangle()
+    {
+        // Issue #2925 mirror of the Circle test above: the Apos.Shapes-backed
+        // IStrokedRectangleRenderable factory must override the legacy LineRectangle in the
+        // tool's wireframe path when MonoGameGumShapes is loaded.
+        RegistryStrokedRectangleSentinel sentinel = new();
+        RenderableRegistry.RegisterFactory<IStrokedRectangleRenderable>(() => sentinel);
+
+        IRenderable result = FallbackRenderableFactory.TryHandleAsBaseType("Rectangle", null);
+
+        result.ShouldBeSameAs(sentinel);
     }
 
     [Fact]
@@ -115,4 +152,12 @@ public class FallbackRenderableFactoryTests : BaseTestClass
         IRenderable result = FallbackRenderableFactory.TryHandleAsBaseType("SomeCustomComponent", null);
         result.ShouldBeNull();
     }
+
+    // Sentinel subclass of the core default so ShouldBeSameAs can verify the registry
+    // factory's instance is the exact reference returned by the fallback. Subclassing
+    // DefaultStrokedCircleRenderable means we inherit the full IStrokedCircleRenderable +
+    // IRenderable surface without re-implementing it for the test.
+    private sealed class RegistryStrokedCircleSentinel : DefaultStrokedCircleRenderable { }
+
+    private sealed class RegistryStrokedRectangleSentinel : DefaultStrokedRectangleRenderable { }
 }

--- a/MonoGameGum/GueDeriving/CircleRuntime.cs
+++ b/MonoGameGum/GueDeriving/CircleRuntime.cs
@@ -431,12 +431,13 @@ public class CircleRuntime : GraphicalUiElement
         }
     }
 
-    Color? _strokeColor;
+    Color? _strokeColor = Color.White;
 
     /// <summary>
-    /// Color of the outline. <c>null</c> hides the stroke (alpha 0) so only the fill draws.
-    /// The stroke slot is always non-null on supported backends — core ships
-    /// <see cref="DefaultStrokedCircleRenderable"/> as the default.
+    /// Color of the outline. Defaults to white so a freshly-constructed CircleRuntime renders
+    /// the same visible outline as legacy code did. <c>null</c> hides the stroke (alpha 0) so
+    /// only the fill draws. The stroke slot is always non-null on supported backends — core
+    /// ships <see cref="DefaultStrokedCircleRenderable"/> as the default.
     /// </summary>
     public Color? StrokeColor
     {

--- a/MonoGameGum/GueDeriving/RectangleRuntime.cs
+++ b/MonoGameGum/GueDeriving/RectangleRuntime.cs
@@ -645,11 +645,12 @@ public class RectangleRuntime : GraphicalUiElement
         }
     }
 
-    Color? _strokeColor;
+    Color? _strokeColor = Color.White;
 
     /// <summary>
-    /// Color of the outline. <c>null</c> hides the stroke (alpha 0). The stroke slot is
-    /// always non-null on XNA-like backends — core ships
+    /// Color of the outline. Defaults to white so a freshly-constructed RectangleRuntime
+    /// renders the same visible outline as legacy code did. <c>null</c> hides the stroke
+    /// (alpha 0). The stroke slot is always non-null on XNA-like backends — core ships
     /// <see cref="DefaultStrokedRectangleRenderable"/> as the default.
     /// </summary>
     public Color? StrokeColor
@@ -725,9 +726,10 @@ public class RectangleRuntime : GraphicalUiElement
 
     /// <summary>
     /// Unit of measurement for <see cref="CornerRadius"/> and the per-corner overrides.
-    /// Reserved for future ScreenPixel parity with Skia — currently the value round-trips on
-    /// the runtime but Apos.Shapes' RoundedRectangle ignores it (the rendered radius is the
-    /// raw pixel value).
+    /// <c>Absolute</c> renders the raw pixel value; <c>ScreenPixel</c> divides each radius by
+    /// the camera zoom each frame in <see cref="PreRender"/> so corners hold a constant
+    /// on-screen size as the camera zooms — matching Skia and <see cref="StrokeWidthUnits"/>
+    /// (issue #2925 Phase 0 parity).
     /// </summary>
     public DimensionUnitType CornerRadiusUnits
     {
@@ -1325,6 +1327,45 @@ public class RectangleRuntime : GraphicalUiElement
             strokeSized.Width = fillSized.Width;
             strokeSized.Height = fillSized.Height;
         }
+
+        // Issue #2925 (Phase 0) — resolve unit-aware corner radii each frame so ScreenPixel
+        // holds a constant on-screen size at non-1 camera zoom. Mirrors the Skia branch in
+        // RoundedRectangleRuntime.PreRender / RectangleRuntime SKIA PreRender. The setters
+        // already pushed the raw values into both slots; this pass overwrites them with the
+        // resolved values when the camera is available. Under Absolute (or with no camera)
+        // the resolved values equal the raw values so the slot state is unchanged.
+        float cornerRadius = _cornerRadius;
+        float? topLeft = _customRadiusTopLeft;
+        float? topRight = _customRadiusTopRight;
+        float? bottomLeft = _customRadiusBottomLeft;
+        float? bottomRight = _customRadiusBottomRight;
+
+        if (_cornerRadiusUnits == DimensionUnitType.ScreenPixel)
+        {
+            var camera = this.EffectiveManagers?.Renderer?.Camera;
+            if (camera != null)
+            {
+                cornerRadius /= camera.Zoom;
+                topLeft /= camera.Zoom;
+                topRight /= camera.Zoom;
+                bottomLeft /= camera.Zoom;
+                bottomRight /= camera.Zoom;
+            }
+        }
+
+        if (_fill != null)
+        {
+            _fill.CornerRadius = cornerRadius;
+            _fill.CustomRadiusTopLeft = topLeft;
+            _fill.CustomRadiusTopRight = topRight;
+            _fill.CustomRadiusBottomLeft = bottomLeft;
+            _fill.CustomRadiusBottomRight = bottomRight;
+        }
+        _stroke.CornerRadius = cornerRadius;
+        _stroke.CustomRadiusTopLeft = topLeft;
+        _stroke.CustomRadiusTopRight = topRight;
+        _stroke.CustomRadiusBottomLeft = bottomLeft;
+        _stroke.CustomRadiusBottomRight = bottomRight;
     }
 
     /// <inheritdoc/>

--- a/RenderingLibrary/SystemManagers.cs
+++ b/RenderingLibrary/SystemManagers.cs
@@ -386,6 +386,10 @@ public partial class SystemManagers : ISystemManagers
         // and that cast only succeeds when the instance is the shim itself.
 #pragma warning disable CS0618 // Type or member is obsolete
         ElementSaveExtensions.RegisterGueInstantiation(
+            "Circle",
+            () => new CircleRuntime());
+
+        ElementSaveExtensions.RegisterGueInstantiation(
             "ColoredRectangle",
             () => new ColoredRectangleRuntime());
 

--- a/Runtimes/GumShapes/Renderables/Arc.cs
+++ b/Runtimes/GumShapes/Renderables/Arc.cs
@@ -69,9 +69,13 @@ internal class Arc : RenderableShapeBase
         var absoluteLeft = this.GetAbsoluteLeft();
         var absoluteTop = this.GetAbsoluteTop();
 
-        var center = new Microsoft.Xna.Framework.Vector2(
-            absoluteLeft + Width / 2.0f,
-            absoluteTop + Width / 2.0f);
+        // Issue #2925 — same rotation handling as Circle.Render: rotate the (Width/2, Width/2)
+        // offset from the GUE's top-left origin to the arc center. The arc's StartAngle is also
+        // offset by the absolute rotation in RenderInternal so the swept arc orients correctly
+        // when the GUE is rotated. Preserves the original convention of using Width for both
+        // axes (arcs are drawn in a square box keyed off Width).
+        var rotationRadians = MathHelper.ToRadians(-this.GetAbsoluteRotation());
+        var center = GetRotatedCenter(absoluteLeft, absoluteTop, Width, Width, rotationRadians);
 
         var radius = Width / 2 - StrokeWidth / 2;
 
@@ -106,9 +110,12 @@ internal class Arc : RenderableShapeBase
         float lineThickness,
         Color? forcedColor = null)
     {
-        var startAngleRadians = MathHelper.ToRadians(-StartAngle);
+        // Issue #2925 — offset the swept arc by the GUE's absolute rotation so the arc tilts
+        // with its bounding box. Matches the negate-and-add convention StartAngle already uses.
+        var absoluteRotation = this.GetAbsoluteRotation();
+        var startAngleRadians = MathHelper.ToRadians(-StartAngle - absoluteRotation);
         float endAngleRadians = 0;
-        endAngleRadians = MathHelper.ToRadians(-StartAngle - SweepAngle);
+        endAngleRadians = MathHelper.ToRadians(-StartAngle - SweepAngle - absoluteRotation);
 
         if (startAngleRadians > endAngleRadians)
         {

--- a/Runtimes/GumShapes/Renderables/Circle.cs
+++ b/Runtimes/GumShapes/Renderables/Circle.cs
@@ -78,11 +78,14 @@ public class Circle : RenderableShapeBase,
         var absoluteLeft = this.GetAbsoluteLeft();
         var absoluteTop = this.GetAbsoluteTop();
 
-        // Issue #2852: center on the actual bounding box and use the smaller dimension as
-        // the radius so a non-square Circle fits within its box (matches SkiaGum).
-        var center = new Microsoft.Xna.Framework.Vector2(
-            absoluteLeft + Width / 2.0f,
-            absoluteTop + Height / 2.0f);
+        // Issue #2925 — rotation is around the GUE's top-left origin (Gum convention), so the
+        // (Width/2, Height/2) offset from top-left to circle center must be rotated by the
+        // absolute rotation. DrawCircle has no rotation parameter (a true circle is rotation-
+        // symmetric, so only the center position needs rotating). Issue #2852: also center on
+        // the actual bounding box and use the smaller dimension as the radius so a non-square
+        // Circle fits within its box (matches SkiaGum).
+        var rotationRadians = MathHelper.ToRadians(-this.GetAbsoluteRotation());
+        var center = GetRotatedCenter(absoluteLeft, absoluteTop, Width, Height, rotationRadians);
 
         var radius = System.Math.Min(Width, Height) / 2.0f;
 

--- a/Runtimes/GumShapes/Renderables/RenderableShapeBase.cs
+++ b/Runtimes/GumShapes/Renderables/RenderableShapeBase.cs
@@ -630,6 +630,31 @@ public abstract class RenderableShapeBase : RenderableBase
             topLeft.Y + rotatedCy - halfH);
     }
 
+    /// <summary>
+    /// Compute the absolute center of a shape whose top-left is at <paramref name="absoluteLeft"/>,
+    /// <paramref name="absoluteTop"/>, taking rotation around the top-left origin into account
+    /// (Gum's default rotation pivot). Issue #2925 — used by <see cref="Circle.Render"/> and
+    /// <see cref="Arc.Render"/>; <see cref="RoundedRectangle"/> handles its own rotation via
+    /// <c>ShapeBatch.DrawRectangle</c>'s rotation parameter and does not call this.
+    /// </summary>
+    /// <param name="rotationRadians">Already negated to match the rendering convention
+    /// (negative of the GUE's degrees-based Rotation).</param>
+    public static Vector2 GetRotatedCenter(float absoluteLeft, float absoluteTop, float width, float height, float rotationRadians)
+    {
+        if (rotationRadians == 0)
+        {
+            return new Vector2(absoluteLeft + width / 2.0f, absoluteTop + height / 2.0f);
+        }
+
+        var halfW = width / 2.0f;
+        var halfH = height / 2.0f;
+        var cos = (float)System.Math.Cos(rotationRadians);
+        var sin = (float)System.Math.Sin(rotationRadians);
+        return new Vector2(
+            absoluteLeft + halfW * cos - halfH * sin,
+            absoluteTop + halfW * sin + halfH * cos);
+    }
+
     public override string BatchKey => "Apos.Shapes";
 
     public override void StartBatch(ISystemManagers systemManagers)

--- a/Tests/MonoGameGum.Shapes.Tests/CircleRuntimeTests.cs
+++ b/Tests/MonoGameGum.Shapes.Tests/CircleRuntimeTests.cs
@@ -469,4 +469,41 @@ public class CircleRuntimeTests
         stroke.StrokeDashLength.ShouldBe(6f);
         stroke.StrokeGapLength.ShouldBe(4f);
     }
+
+    // Issue #2925 — when MonoGameGumShapes is loaded, CircleRuntime's constructor sets
+    // the fill renderable (Apos Circle with IsFilled=true) as mContainedObjectAsIpso.
+    // The tool's variable-application path dispatches on the contained renderable via
+    // CustomSetPropertyOnRenderable, so the legacy "Color" variable (historically the
+    // stroke color on a LineCircle-backed Circle) now writes to the FILL renderable
+    // instead of the stroke renderable. Result: a freshly-loaded default Circle renders
+    // as a solid white disc instead of a stroke-only outline.
+    //
+    // The fix must keep "Color" reaching _stroke.Color (matching pre-Apos behavior) and
+    // leave _fill.Color at its transparent constructor default until FillColor is set
+    // explicitly.
+    [Fact]
+    public void SetProperty_Color_RoutesToStroke_NotFill()
+    {
+        CircleRuntime sut = new();
+
+        sut.SetProperty("Color", System.Drawing.Color.FromArgb(255, 255, 0, 0));
+
+        Circle fill = (Circle)sut.RenderableComponent;
+        Circle stroke = (Circle)fill.Children[0];
+        stroke.Color.ShouldBe(new Color(255, 0, 0, 255));
+        fill.Color.ShouldBe(new Color(0, 0, 0, 0));
+    }
+
+    [Fact]
+    public void SetProperty_Alpha_RoutesToStroke_NotFill()
+    {
+        CircleRuntime sut = new();
+
+        sut.SetProperty("Alpha", 128);
+
+        Circle fill = (Circle)sut.RenderableComponent;
+        Circle stroke = (Circle)fill.Children[0];
+        stroke.Color.A.ShouldBe((byte)128);
+        fill.Color.ShouldBe(new Color(0, 0, 0, 0));
+    }
 }

--- a/Tests/MonoGameGum.Shapes.Tests/RectangleRuntimeTests.cs
+++ b/Tests/MonoGameGum.Shapes.Tests/RectangleRuntimeTests.cs
@@ -47,6 +47,82 @@ public class RectangleRuntimeTests
         stroke.CornerRadius.ShouldBe(8f);
     }
 
+    // Issue #2925 (Phase 0 parity) — under Absolute units the post-PreRender corner radii on both
+    // slots match the raw runtime values. Skia already does this (RoundedRectangleRuntime.cs
+    // PreRender SKIA branch); the Apos side previously pushed in the setter only and never
+    // re-resolved in PreRender, so this guards the new resolution path.
+    [Fact]
+    public void CornerRadiusUnits_Absolute_PreRender_PushesRawValueToBothSlots()
+    {
+        RectangleRuntime sut = new();
+        sut.CornerRadius = 8f;
+        sut.CustomRadiusTopLeft = 1f;
+        sut.CustomRadiusTopRight = 2f;
+        sut.CustomRadiusBottomLeft = 3f;
+        sut.CustomRadiusBottomRight = 4f;
+        sut.CornerRadiusUnits = DimensionUnitType.Absolute;
+
+        RoundedRectangle fill = (RoundedRectangle)sut.RenderableComponent;
+        RoundedRectangle stroke = (RoundedRectangle)fill.Children[0];
+        IRenderable asFillRenderable = fill;
+        asFillRenderable.PreRender();
+
+        fill.CornerRadius.ShouldBe(8f);
+        stroke.CornerRadius.ShouldBe(8f);
+        fill.CustomRadiusTopLeft.ShouldBe(1f);
+        stroke.CustomRadiusTopLeft.ShouldBe(1f);
+        fill.CustomRadiusTopRight.ShouldBe(2f);
+        stroke.CustomRadiusTopRight.ShouldBe(2f);
+        fill.CustomRadiusBottomLeft.ShouldBe(3f);
+        stroke.CustomRadiusBottomLeft.ShouldBe(3f);
+        fill.CustomRadiusBottomRight.ShouldBe(4f);
+        stroke.CustomRadiusBottomRight.ShouldBe(4f);
+    }
+
+    // Issue #2925 (Phase 0 parity) — ScreenPixel was previously a Skia-only honor (Apos parity gap
+    // noted in RoundedRectangleRuntime.cs:80, 124). At Camera.Zoom = 2 the resolved radius is
+    // raw / zoom so the rounded corner holds a constant on-screen pixel size as the camera zooms,
+    // matching the existing StrokeWidthUnits.ScreenPixel behavior in AposShapeRuntime.PreRender.
+    // Skia's RoundedRectangleRuntime.PreRender already does this; bringing the Apos branch into
+    // parity is the whole of Phase 0's RectangleRuntime work.
+    [Fact]
+    public void CornerRadiusUnits_ScreenPixel_DividesByCameraZoom_OnBothSlots()
+    {
+        float originalZoom = RenderingLibrary.SystemManagers.Default.Renderer.Camera.Zoom;
+        try
+        {
+            RectangleRuntime sut = new();
+            sut.AddToManagers(RenderingLibrary.SystemManagers.Default, null);
+            sut.CornerRadius = 8f;
+            sut.CustomRadiusTopLeft = 1f;
+            sut.CustomRadiusTopRight = 2f;
+            sut.CustomRadiusBottomLeft = 3f;
+            sut.CustomRadiusBottomRight = 4f;
+            sut.CornerRadiusUnits = DimensionUnitType.ScreenPixel;
+            RenderingLibrary.SystemManagers.Default.Renderer.Camera.Zoom = 2f;
+
+            RoundedRectangle fill = (RoundedRectangle)sut.RenderableComponent;
+            RoundedRectangle stroke = (RoundedRectangle)fill.Children[0];
+            IRenderable asFillRenderable = fill;
+            asFillRenderable.PreRender();
+
+            fill.CornerRadius.ShouldBe(4f);
+            stroke.CornerRadius.ShouldBe(4f);
+            fill.CustomRadiusTopLeft.ShouldBe(0.5f);
+            stroke.CustomRadiusTopLeft.ShouldBe(0.5f);
+            fill.CustomRadiusTopRight.ShouldBe(1f);
+            stroke.CustomRadiusTopRight.ShouldBe(1f);
+            fill.CustomRadiusBottomLeft.ShouldBe(1.5f);
+            stroke.CustomRadiusBottomLeft.ShouldBe(1.5f);
+            fill.CustomRadiusBottomRight.ShouldBe(2f);
+            stroke.CustomRadiusBottomRight.ShouldBe(2f);
+        }
+        finally
+        {
+            RenderingLibrary.SystemManagers.Default.Renderer.Camera.Zoom = originalZoom;
+        }
+    }
+
     [Fact]
     public void FillAndStroke_DrawSimultaneously_BothColorsRoundTrip()
     {
@@ -376,5 +452,35 @@ public class RectangleRuntimeTests
         RoundedRectangle sourceStroke = (RoundedRectangle)sourceFill.Children[0];
         sourceFill.Color.ShouldBe(Color.Red);
         sourceStroke.Color.ShouldBe(Color.Blue);
+    }
+
+    // Issue #2925 — same bug as CircleRuntime: constructor sets the fill renderable as
+    // mContainedObjectAsIpso, so the tool's variable-application path routes the legacy
+    // "Color" / "Alpha" variables to the FILL renderable instead of stroke. Result: a
+    // default Rectangle renders as a solid white box instead of a stroke-only outline.
+    [Fact]
+    public void SetProperty_Color_RoutesToStroke_NotFill()
+    {
+        RectangleRuntime sut = new();
+
+        sut.SetProperty("Color", System.Drawing.Color.FromArgb(255, 255, 0, 0));
+
+        RoundedRectangle fill = (RoundedRectangle)sut.RenderableComponent;
+        RoundedRectangle stroke = (RoundedRectangle)fill.Children[0];
+        stroke.Color.ShouldBe(new Color(255, 0, 0, 255));
+        fill.Color.ShouldBe(new Color(0, 0, 0, 0));
+    }
+
+    [Fact]
+    public void SetProperty_Alpha_RoutesToStroke_NotFill()
+    {
+        RectangleRuntime sut = new();
+
+        sut.SetProperty("Alpha", 128);
+
+        RoundedRectangle fill = (RoundedRectangle)sut.RenderableComponent;
+        RoundedRectangle stroke = (RoundedRectangle)fill.Children[0];
+        stroke.Color.A.ShouldBe((byte)128);
+        fill.Color.ShouldBe(new Color(0, 0, 0, 0));
     }
 }

--- a/Tests/MonoGameGum.Shapes.Tests/RenderableShapeBaseTests.cs
+++ b/Tests/MonoGameGum.Shapes.Tests/RenderableShapeBaseTests.cs
@@ -1,0 +1,57 @@
+using MonoGameAndGum.Renderables;
+using Microsoft.Xna.Framework;
+using Shouldly;
+
+namespace MonoGameGum.Shapes.Tests;
+
+// Issue #2925 — Circle/Arc Render compute the absolute center by rotating the (W/2, H/2)
+// offset from the GUE's top-left origin around the top-left (Gum's default rotation pivot).
+// These tests pin the math behind GetRotatedCenter independent of the rest of the Render
+// pipeline, since the actual draw output (a call into Apos.Shapes ShapeBatch) is not
+// inspectable from a unit test.
+public class RenderableShapeBaseTests
+{
+    [Fact]
+    public void GetRotatedCenter_ZeroRotation_ReturnsAxisAlignedCenter()
+    {
+        Vector2 result = RenderableShapeBase.GetRotatedCenter(100f, 200f, 40f, 60f, 0f);
+
+        result.X.ShouldBe(120f);
+        result.Y.ShouldBe(230f);
+    }
+
+    [Fact]
+    public void GetRotatedCenter_NinetyDegrees_ShiftsCenterAlongRotatedAxes()
+    {
+        // 90° rotation: x' = x*cos - y*sin = -halfH ; y' = x*sin + y*cos = halfW
+        // halfW = 20, halfH = 30  =>  offset = (-30, 20)  =>  center = (70, 220)
+        var rotation = (float)System.Math.PI / 2f;
+
+        Vector2 result = RenderableShapeBase.GetRotatedCenter(100f, 200f, 40f, 60f, rotation);
+
+        result.X.ShouldBe(70f, tolerance: 0.001f);
+        result.Y.ShouldBe(220f, tolerance: 0.001f);
+    }
+
+    [Fact]
+    public void GetRotatedCenter_OneEightyDegrees_PutsCenterOppositeTopLeft()
+    {
+        // 180° rotation: center should be at top-left minus half-dimensions.
+        var rotation = (float)System.Math.PI;
+
+        Vector2 result = RenderableShapeBase.GetRotatedCenter(100f, 200f, 40f, 60f, rotation);
+
+        result.X.ShouldBe(80f, tolerance: 0.001f);   // 100 - 20
+        result.Y.ShouldBe(170f, tolerance: 0.001f);  // 200 - 30
+    }
+
+    [Fact]
+    public void GetRotatedCenter_SquareBox_ZeroRotation_MatchesUnrotatedFormula()
+    {
+        // Sanity check: a square Circle's center at zero rotation is exactly (left + r, top + r).
+        Vector2 result = RenderableShapeBase.GetRotatedCenter(0f, 0f, 32f, 32f, 0f);
+
+        result.X.ShouldBe(16f);
+        result.Y.ShouldBe(16f);
+    }
+}

--- a/Tool/EditorTabPlugin_XNA/EditorTabPlugin_XNA.csproj
+++ b/Tool/EditorTabPlugin_XNA/EditorTabPlugin_XNA.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<TargetFramework>net8.0-windows</TargetFramework>
 
@@ -39,19 +39,27 @@
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-		<PackageReference Include="nkast.Kni.Platform.WinForms.DX11" Version="4.1.9001" />
-		<PackageReference Include="nkast.Xna.Framework.Input" Version="4.1.9001" />
+		<PackageReference Include="nkast.Kni.Platform.WinForms.DX11" Version="4.2.9001" />
+		<PackageReference Include="nkast.Xna.Framework.Input" Version="4.2.9001" />
 		<PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
 		<ProjectReference Include="..\..\FlatRedBall.SpecializedXnaControls\FlatRedBall.SpecializedXnaControls.csproj" />
 		<ProjectReference Include="..\..\Gum\Gum.csproj" />
 		<ProjectReference Include="..\..\MonoGameGum\KniGum\KniGum.csproj" />
+		<!--
+			KniGumShapes brings the Apos.Shapes-backed Circle / RoundedRectangle / Arc / Line renderables
+			into the tool. Without this reference the assembly is never loaded, its [ModuleInitializer]
+			never fires, AposShapeRuntime.RegisterRuntimeTypes is never called, and the RenderableRegistry
+			hands back the LineCircle-based defaults when the wireframe constructs a Circle/Rectangle
+			runtime — i.e. Apos shapes never appear in the editor. See issue #2925.
+		-->
+		<ProjectReference Include="..\..\Runtimes\GumShapes\KniGumShapes.csproj" />
 		<ProjectReference Include="..\..\XnaAndWinforms\XnaAndWinforms.csproj" />
 
-		<PackageReference Include="nkast.Xna.Framework" Version="4.1.9001" />
-		<PackageReference Include="nkast.Xna.Framework.Graphics" Version="4.1.9001.1" />
-		
+		<PackageReference Include="nkast.Xna.Framework" Version="4.2.9001" />
+		<PackageReference Include="nkast.Xna.Framework.Graphics" Version="4.2.9001" />
+
 	</ItemGroup>
 	<Target Name="PostBuild" AfterTargets="PostBuildEvent">
-	  <Exec Command="&#xD;&#xA;echo Copying to &quot;$(SolutionDir)Gum\bin\$(ConfigurationName)\Plugins\$(TargetName)\&quot;&#xD;&#xA;&#xD;&#xA;IF NOT EXIST &quot;$(SolutionDir)Gum\bin\$(ConfigurationName)\Plugins\$(TargetName)&quot; md &quot;$(SolutionDir)Gum\bin\$(ConfigurationName)\Plugins\$(TargetName)\&quot;&#xD;&#xA;copy &quot;$(TargetPath)&quot; &quot;$(SolutionDir)Gum\bin\$(ConfigurationName)\Plugins\$(TargetName)&quot;&#xD;&#xA;copy &quot;$(TargetDir)$(TargetName).pdb&quot; &quot;$(SolutionDir)Gum\bin\$(ConfigurationName)\Plugins\$(TargetName)&quot;&#xD;&#xA;copy &quot;$(TargetDir)XnaAndWinforms.dll&quot; &quot;$(SolutionDir)Gum\bin\$(ConfigurationName)\Plugins\$(TargetName)&quot;&#xD;&#xA;copy &quot;$(TargetDir)KniGum.dll&quot; &quot;$(SolutionDir)Gum\bin\$(ConfigurationName)\Plugins\$(TargetName)&quot;&#xD;&#xA;copy &quot;$(TargetDir)Xna*.dll&quot; &quot;$(SolutionDir)Gum\bin\$(ConfigurationName)\Plugins\$(TargetName)&quot;" />
+	  <Exec Command="&#xD;&#xA;echo Copying to &quot;$(SolutionDir)Gum\bin\$(ConfigurationName)\Plugins\$(TargetName)\&quot;&#xD;&#xA;&#xD;&#xA;IF NOT EXIST &quot;$(SolutionDir)Gum\bin\$(ConfigurationName)\Plugins\$(TargetName)&quot; md &quot;$(SolutionDir)Gum\bin\$(ConfigurationName)\Plugins\$(TargetName)\&quot;&#xD;&#xA;copy &quot;$(TargetPath)&quot; &quot;$(SolutionDir)Gum\bin\$(ConfigurationName)\Plugins\$(TargetName)&quot;&#xD;&#xA;copy &quot;$(TargetDir)$(TargetName).pdb&quot; &quot;$(SolutionDir)Gum\bin\$(ConfigurationName)\Plugins\$(TargetName)&quot;&#xD;&#xA;copy &quot;$(TargetDir)XnaAndWinforms.dll&quot; &quot;$(SolutionDir)Gum\bin\$(ConfigurationName)\Plugins\$(TargetName)&quot;&#xD;&#xA;copy &quot;$(TargetDir)KniGum.dll&quot; &quot;$(SolutionDir)Gum\bin\$(ConfigurationName)\Plugins\$(TargetName)&quot;&#xD;&#xA;copy &quot;$(TargetDir)KniGumShapes.dll&quot; &quot;$(SolutionDir)Gum\bin\$(ConfigurationName)\Plugins\$(TargetName)&quot;&#xD;&#xA;copy &quot;$(TargetDir)Apos.Shapes.KNI.dll&quot; &quot;$(SolutionDir)Gum\bin\$(ConfigurationName)\Plugins\$(TargetName)&quot;&#xD;&#xA;copy &quot;$(TargetDir)FontStashSharp*.dll&quot; &quot;$(SolutionDir)Gum\bin\$(ConfigurationName)\Plugins\$(TargetName)&quot;&#xD;&#xA;copy &quot;$(TargetDir)Xna*.dll&quot; &quot;$(SolutionDir)Gum\bin\$(ConfigurationName)\Plugins\$(TargetName)&quot;&#xD;&#xA;IF NOT EXIST &quot;$(SolutionDir)Gum\bin\$(ConfigurationName)\Content&quot; md &quot;$(SolutionDir)Gum\bin\$(ConfigurationName)\Content\&quot;&#xD;&#xA;copy &quot;$(SolutionDir)Runtimes\GumShapes\buildTransitive\Content\Windows\apos-shapes.xnb&quot; &quot;$(SolutionDir)Gum\bin\$(ConfigurationName)\Content\&quot;" />
 	</Target>
 </Project>

--- a/Tool/EditorTabPlugin_XNA/Views/WireframeControl.cs
+++ b/Tool/EditorTabPlugin_XNA/Views/WireframeControl.cs
@@ -9,7 +9,9 @@ using Gum.Services.Dialogs;
 using Gum.ToolCommands;
 using Gum.Wireframe;
 using GumRuntime;
+using Microsoft.Xna.Framework.Content;
 using Microsoft.Xna.Framework.Graphics;
+using MonoGameAndGum.Renderables;
 using Gum.GueDeriving;
 using RenderingLibrary;
 using RenderingLibrary.Content;
@@ -157,6 +159,20 @@ public class WireframeControl : GraphicsDeviceControl
             SystemManagers.Default = new SystemManagers();
             SystemManagers.Default.Initialize(GraphicsDevice);
 
+            // Touching a type from KniGumShapes here forces the assembly to load, which fires its
+            // [ModuleInitializer] -> AposShapeRuntime.RegisterRuntimeTypes (registers Apos.Shapes-backed
+            // factories with RenderableRegistry). Then we initialize the ShapeBatch so those shapes
+            // actually have a renderer to draw into. Without this, Circle/Rectangle runtimes in the
+            // tool fall back to LineCircle/LineRectangle defaults. See issue #2925.
+            //
+            // ContentManager is rooted at "Content" because the apos-shapes.xnb ships at
+            // <tool-bin>\Content\apos-shapes.xnb (see EditorTabPlugin_XNA.csproj PostBuild).
+            if (!ShapeRenderer.Self.IsInitialized)
+            {
+                ContentManager shapesContentManager = new ContentManager(Services, "Content");
+                ShapeRenderer.Self.Initialize(GraphicsDevice, shapesContentManager);
+            }
+
             InitializeDefaultTypeInstantiation();
 
             ToolFontService.Self.Initialize();
@@ -226,14 +242,20 @@ public class WireframeControl : GraphicsDeviceControl
     private void InitializeDefaultTypeInstantiation()
     {
         ElementSaveExtensions.RegisterGueInstantiation(
+            "Circle",
+            () => new CircleRuntime());
+
+        ElementSaveExtensions.RegisterGueInstantiation(
             "ColoredRectangle",
             () => new ColoredRectangleRuntime());
-
-
 
         ElementSaveExtensions.RegisterGueInstantiation(
             "Polygon",
             () => new PolygonRuntime());
+
+        ElementSaveExtensions.RegisterGueInstantiation(
+            "Rectangle",
+            () => new RectangleRuntime(systemManagers: this.SystemManagers));
 
         ElementSaveExtensions.RegisterGueInstantiation(
             "Sprite",

--- a/XnaAndWinforms/XnaAndWinforms.csproj
+++ b/XnaAndWinforms/XnaAndWinforms.csproj
@@ -14,8 +14,8 @@
 
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="nkast.Xna.Framework" Version="4.1.9001" />
-		<PackageReference Include="nkast.Xna.Framework.Graphics" Version="4.1.9001.1" />
+		<PackageReference Include="nkast.Xna.Framework" Version="4.2.9001" />
+		<PackageReference Include="nkast.Xna.Framework.Graphics" Version="4.2.9001" />
 	</ItemGroup>
 	<ItemGroup>
 		<Compile Update="GraphicsDeviceControl.cs">


### PR DESCRIPTION
## Summary

Make plain `Circle` and `Rectangle` standard elements render via Apos.Shapes in the Gum tool (Arc moved too). Replaces the legacy `LineCircle` / `LineRectangle` paths and removes `Arc` from the Skia plugin's factory. Aligns the tool's rendering with the MonoGame runtime, which is already on Apos.Shapes.

This is Phase 0 of a multi-phase plan tracked in #2925 — gets the rendering working end-to-end with existing properties, before Phase 2 adds new variables (`FillColor`, `StrokeWidth`, gradient, dropshadow, etc.) to the variable grid gated by a `.gumx` v3 bump.

## What landed

**Tool wiring (`EditorTabPlugin_XNA`)** — ProjectReference to `KniGumShapes`, PostBuild copies of the runtime DLLs and the Windows apos-shapes.xnb, explicit `ShapeRenderer.Self.Initialize` call in `WireframeControl.Initialize`, and `Circle`/`Rectangle` added to the tool's `InitializeDefaultTypeInstantiation` list alongside `Text` / `Sprite`.

**Variable routing (`CustomSetPropertyOnRenderable`)** — GUE-type dispatch for `CircleRuntime` / `RectangleRuntime` ahead of the renderable-type tree. Legacy `Color` / `Alpha` / `Red` / `Green` / `Blue` / `Radius` / `CornerRadius` / `CustomRadius*` now route through the runtime's typed setters (which know about the two-slot model and write to the correct slot), independent of which renderable is the contained object. Without this, legacy `Color` was landing on the fill slot and producing a solid white disc on default Circles.

**`FallbackRenderableFactory`** — consults `RenderableRegistry` first for `Circle` and `Rectangle`. Belt-and-suspenders for any consumer that still hits the fallback.

**Renderable rotation** — new shared `RenderableShapeBase.GetRotatedCenter` helper used by `Circle.Render` and `Arc.Render` so they rotate the `(W/2, H/2)` offset from the GUE's top-left origin. Arc also offsets its swept angles by the absolute rotation. `RoundedRectangle` was already rotation-aware via `DrawRectangle`'s rotation parameter.

**Defaults and bug fixes**
- `CircleRuntime` / `RectangleRuntime`: `_strokeColor` field defaults to `Color.White` so the property value matches the constructor's `_stroke.Color = Color.White`.
- `RectangleRuntime.PreRender`: resolve `CornerRadius` / `CustomRadius*` against camera zoom when `CornerRadiusUnits == ScreenPixel` (was XNALIKE-broken).
- `RenderingLibrary.SystemManagers`: register `CircleRuntime` in the canonical `RegisterComponentRuntimeInstantiations` list (was conspicuously absent next to `Rectangle` / `Text` / `Sprite`).

**Version alignment** — `nkast.Xna.Framework` family bumped from `4.1.9001` to `4.2.9001` across the tool stack (`Gum`, `EditorTabPlugin_XNA`, `XnaAndWinforms`, `InputLibrary`, `SkiaPlugin`, `TextureCoordinateSelectionPlugin`, `FlatRedBall.SpecializedXnaControls`) to match `KniGum` / `KniGumShapes`. Required for the Apos.Shapes shader XNB to parse — 4.1 fails with `"This does not appear to be an MGFX effect file"`.

## Test plan
- [x] `dotnet test Tests/MonoGameGum.Shapes.Tests/MonoGameGum.Shapes.Tests.csproj` — 78/78 passing (8 new tests for the routing + rotation paths).
- [x] `dotnet test MonoGameGum.Tests/MonoGameGum.Tests.csproj` — 1546/1546 passing (no runtime regressions).
- [x] `dotnet build GumFull.sln` — clean.
- [x] Manual: default Circle renders as legacy white outline (no fill); rotating around top-left offsets the position correctly; existing v2 projects open with Circle/Rectangle visuals identical to pre-PR.

Closes #2925

🤖 Generated with [Claude Code](https://claude.com/claude-code)