### PR TITLE
#2927: Reserve GumxVersions v3 for shape variable expansion

### DIFF
--- a/GumDataTypes/GumProjectSave.cs
+++ b/GumDataTypes/GumProjectSave.cs
@@ -99,13 +99,29 @@ public class GumProjectSave
         /// attribute instead of a child element, producing a more compact file format.
         /// </summary>
         AttributeVersion = 2,
+
+        /// <summary>
+        /// Reserves a version slot for the expanded Circle/Rectangle variable surface
+        /// (gradient, dropshadow, stroke-and-fill, antialiasing, etc.) introduced in
+        /// the #2925/#2927 follow-up PRs. Files saved at this version use the same XML
+        /// format as <see cref="AttributeVersion"/>; the bump exists so tool builds
+        /// without the new variable definitions refuse to load the file rather than
+        /// silently dropping the new variables on the next save.
+        /// </summary>
+        ShapeVariableExpansion = 3,
     }
 
     /// <summary>
     /// The highest <see cref="GumxVersions"/> value that this version of the Gum tool supports.
     /// When a new <see cref="GumxVersions"/> value is added, update this constant to match.
     /// </summary>
-    public const int NativeVersion = (int)GumxVersions.AttributeVersion;
+    /// <remarks>
+    /// New <see cref="GumProjectSave"/> instances do NOT default to this version — see the
+    /// constructor. New projects stay at <see cref="GumxVersions.AttributeVersion"/> until
+    /// a feature gated on a higher version is actually used, so files remain readable by
+    /// older tool builds whenever they technically could be.
+    /// </remarks>
+    public const int NativeVersion = (int)GumxVersions.ShapeVariableExpansion;
 
     #region Fields
 

--- a/MonoGameGum.Tests/DataTypes/GumProjectSaveTests.cs
+++ b/MonoGameGum.Tests/DataTypes/GumProjectSaveTests.cs
@@ -348,6 +348,17 @@ public class GumProjectSaveTests : BaseTestClass
     }
 
     [Fact]
+    public void NativeVersion_MatchesShapeVariableExpansion()
+    {
+        // The v3 slot is reserved for the expanded Circle/Rectangle variable surface
+        // landing in #2925/#2927 follow-up PRs. Files saved at v3 use the same XML
+        // format as AttributeVersion; the bump only changes the rejection ceiling so
+        // tool builds without the new variable definitions refuse to silently drop them.
+        GumProjectSave.NativeVersion.ShouldBe((int)GumProjectSave.GumxVersions.ShapeVariableExpansion);
+        ((int)GumProjectSave.GumxVersions.ShapeVariableExpansion).ShouldBe(3);
+    }
+
+    [Fact]
     public void V1GumxFormat_DeserializesScreenReferenceNamesCorrectly()
     {
         const string v1Xml = """


### PR DESCRIPTION
## Summary

- Adds `GumxVersions.ShapeVariableExpansion = 3` and bumps `NativeVersion` to it.
- Reserves the v3 slot so follow-up PRs landing the expanded Circle/Rectangle variable surface (gradient, dropshadow, stroke-and-fill, antialiasing) can gate on the version without needing a coordinated tool+file bump in the same change.
- New `GumProjectSave` instances intentionally still default to `AttributeVersion` (v2), not `NativeVersion`. New projects stay readable by older tool builds until a feature that actually requires v3 is in use — matching the existing "save doesn't auto-bump" pattern documented in the `gum-project-versioning` skill.

## Scope deferred to follow-up PRs

Originally bundled with this PR per the Phase 0 handoff, but split out after investigation showed the runtime exposes `FillColor` / `StrokeColor` as `Color?` while every existing tool variable pattern uses separate-channel ints — needs design before surfacing:

- Calling existing `AddGradientVariables` / `AddDropshadowVariables` / `AddStrokeAndFilledVariables` / `AddBlendVariable` on plain `Circle` / `Rectangle` states in `StandardElementsManager`.
- Channel-decomposition design for `FillColor` / `StrokeColor` (or a `Color?` displayer).
- Variable-grid hide-when-version-lower filter (location identified: `ElementSaveDisplayer`).

Closes #2927.

## Test plan

- [x] New `GumProjectSaveTests.NativeVersion_MatchesShapeVariableExpansion` asserts the new enum value and that `NativeVersion` points to it.
- [x] Existing `NewProjectDefaultsToAttributeVersion` still passes — confirms the constructor still emits v2.
- [x] Full `MonoGameGum.Tests` suite (1547 tests) green locally.
- [x] `GumFull.sln` builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)