### PR TITLE
#2929: Surface gradient/dropshadow/blend variables on plain Circle and Rectangle

### DIFF
--- a/Gum/Managers/StandardElementsManager.cs
+++ b/Gum/Managers/StandardElementsManager.cs
@@ -371,6 +371,14 @@ public class StandardElementsManager
             stateSave.Variables.Add(new VariableSave { SetsValue = true, Type = "bool", Value = true, Name = "Visible", Category = "States and Visibility" });
             AddColorVariables(stateSave, true);
 
+            // v3 (#2929): gradient / dropshadow / blend route through the same SetProperty path
+            // as on ColoredCircle, picked up by CircleRuntime's existing gradient/dropshadow
+            // pass-through. AddStrokeAndFilledVariables is intentionally excluded — IsFilled
+            // is not present on XNALIKE CircleRuntime yet (tracked as a #2931 follow-up).
+            AddGradientVariables(stateSave);
+            AddDropshadowVariables(stateSave);
+            AddBlendVariable(stateSave);
+
             // Although rotating a circle about its center does nothing we add rotation because you can rotate it about a different origin
             AddRotationVariable(stateSave);
 
@@ -400,6 +408,11 @@ public class StandardElementsManager
 
             stateSave.Variables.Add(new VariableSave { SetsValue = true, Type = "bool", Value = true, Name = "Visible", Category = "States and Visibility" });
             AddColorVariables(stateSave, true);
+
+            // v3 (#2929): mirror of the Circle block above — see comment there.
+            AddGradientVariables(stateSave);
+            AddDropshadowVariables(stateSave);
+            AddBlendVariable(stateSave);
 
             AddRotationVariable(stateSave);
 

--- a/Tool/Tests/GumToolUnitTests/Managers/StandardElementsManagerTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Managers/StandardElementsManagerTests.cs
@@ -1,0 +1,57 @@
+using Gum.Managers;
+using Shouldly;
+using System.Linq;
+using Xunit;
+
+namespace GumToolUnitTests.Managers;
+
+public class StandardElementsManagerTests : BaseTestClass
+{
+    [Theory]
+    [InlineData("Circle")]
+    [InlineData("Rectangle")]
+    public void DefaultState_ExposesBlendVariable(string standardElementName)
+    {
+        var state = StandardElementsManager.Self.DefaultStates[standardElementName];
+
+        state.Variables.Any(v => v.Name == "Blend").ShouldBeTrue(
+            $"{standardElementName} default state should expose the Blend variable so v3 shape rendering can route through SetProperty.");
+    }
+
+    [Theory]
+    [InlineData("Circle")]
+    [InlineData("Rectangle")]
+    public void DefaultState_ExposesDropshadowVariables(string standardElementName)
+    {
+        var state = StandardElementsManager.Self.DefaultStates[standardElementName];
+
+        state.Variables.Any(v => v.Name == "HasDropshadow").ShouldBeTrue();
+        state.Variables.Any(v => v.Name == "DropshadowOffsetX").ShouldBeTrue();
+        state.Variables.Any(v => v.Name == "DropshadowOffsetY").ShouldBeTrue();
+        state.Variables.Any(v => v.Name == "DropshadowBlurX").ShouldBeTrue();
+        state.Variables.Any(v => v.Name == "DropshadowBlurY").ShouldBeTrue();
+        state.Variables.Any(v => v.Name == "DropshadowAlpha").ShouldBeTrue();
+        state.Variables.Any(v => v.Name == "DropshadowRed").ShouldBeTrue();
+        state.Variables.Any(v => v.Name == "DropshadowGreen").ShouldBeTrue();
+        state.Variables.Any(v => v.Name == "DropshadowBlue").ShouldBeTrue();
+    }
+
+    [Theory]
+    [InlineData("Circle")]
+    [InlineData("Rectangle")]
+    public void DefaultState_ExposesGradientVariables(string standardElementName)
+    {
+        var state = StandardElementsManager.Self.DefaultStates[standardElementName];
+
+        state.Variables.Any(v => v.Name == "UseGradient").ShouldBeTrue();
+        state.Variables.Any(v => v.Name == "GradientType").ShouldBeTrue();
+        state.Variables.Any(v => v.Name == "Red1").ShouldBeTrue();
+        state.Variables.Any(v => v.Name == "Green1").ShouldBeTrue();
+        state.Variables.Any(v => v.Name == "Blue1").ShouldBeTrue();
+        state.Variables.Any(v => v.Name == "Alpha1").ShouldBeTrue();
+        state.Variables.Any(v => v.Name == "Red2").ShouldBeTrue();
+        state.Variables.Any(v => v.Name == "Green2").ShouldBeTrue();
+        state.Variables.Any(v => v.Name == "Blue2").ShouldBeTrue();
+        state.Variables.Any(v => v.Name == "Alpha2").ShouldBeTrue();
+    }
+}


### PR DESCRIPTION
## Summary

- Calls `AddGradientVariables`, `AddDropshadowVariables`, and `AddBlendVariable` on the default state for the `Circle` and `Rectangle` standard elements in `Gum/Managers/StandardElementsManager.cs`.
- The matching runtime properties (`UseGradient`, `GradientType`, `Red1..Alpha2`, `HasDropshadow`, `DropshadowRed..Blur`, `Blend`) already exist on `CircleRuntime` / `RectangleRuntime` from prior PRs (#2791, #2797, #2818, etc.) — no runtime changes needed.
- New tests in `Tool/Tests/GumToolUnitTests/Managers/StandardElementsManagerTests.cs` verify both default states expose the new variables.

## Deferred

- **`AddStrokeAndFilledVariables`** — would add `IsFilled`, which plain `CircleRuntime` / `RectangleRuntime` only expose on RAYLIB. XNALIKE infers filled-ness from `FillColor != null`. Tracked as #2931 alongside the Fill/Stroke channel-decomposition + nullable-color UI work.
- **`FillColor` / `StrokeColor` surface** — the runtime exposes these as `Color?`, but the tool needs a new nullable-color variable grid affordance before they can land (channel-ints can't express `null`). Tracked in #2931.
- **Save-path v3 promotion** — without it, projects using the new variables silently round-trip through older tool builds. Adding promotion needs default-value comparison, state walking, and inheritance handling. Tracked in #2932.

## Test plan

- [x] New `StandardElementsManagerTests` (6 tests across Circle + Rectangle) — pass.
- [x] Full `GumToolUnitTests` suite — 651 pass / 5 skipped / 0 fail.
- [x] `MonoGameGum.Tests` — 1547 pass / 0 fail.
- [x] Open a project in the Gum tool, add a Circle / Rectangle, verify gradient + dropshadow + blend variables show up in the grid and modifying them takes visual effect.

Closes #2929

🤖 Generated with [Claude Code](https://claude.com/claude-code)