### PR TITLE
#2938: Non-nullable Fill/Stroke + IsFilled + channel-decomp ints on Circle/Rectangle runtimes

### DIFF
--- a/MonoGameGum.Tests/Runtimes/CircleRuntimeTests.cs
+++ b/MonoGameGum.Tests/Runtimes/CircleRuntimeTests.cs
@@ -45,6 +45,27 @@ public class CircleRuntimeTests : BaseTestClass
     }
 
     [Fact]
+    public void FillChannelSetters_ComposeFillColor()
+    {
+        CircleRuntime sut = new();
+
+        sut.FillRed = 11;
+        sut.FillGreen = 22;
+        sut.FillBlue = 33;
+        sut.FillAlpha = 44;
+
+        sut.FillColor.ShouldBe(new Color(11, 22, 33, 44));
+    }
+
+    [Fact]
+    public void FillColor_DefaultsToWhite()
+    {
+        CircleRuntime sut = new();
+
+        sut.FillColor.ShouldBe(Color.White);
+    }
+
+    [Fact]
     public void FillColor_RoundTripsBackingField_WhenFillSlotIsNull()
     {
         CircleRuntime sut = new();
@@ -55,6 +76,52 @@ public class CircleRuntimeTests : BaseTestClass
         // re-create the runtime) honors the user's color. Without the package, no visual
         // effect — see DefaultStrokedCircleRenderable remarks.
         sut.FillColor.ShouldBe(Color.Red);
+    }
+
+    [Fact]
+    public void IsFilled_DefaultsToTrue()
+    {
+        CircleRuntime sut = new();
+
+        sut.IsFilled.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsFilled_RoundTripsBackingField_WhenFillSlotNull()
+    {
+        CircleRuntime sut = new();
+
+        sut.IsFilled = false;
+        sut.IsFilled.ShouldBeFalse();
+        // Renderable stays the stroke default — there's no fill slot to hide visually.
+        sut.RenderableComponent.ShouldBeOfType<DefaultStrokedCircleRenderable>();
+
+        sut.IsFilled = true;
+        sut.IsFilled.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void StrokeChannelSetters_ComposeStrokeColor()
+    {
+        CircleRuntime sut = new();
+
+        sut.StrokeRed = 11;
+        sut.StrokeGreen = 22;
+        sut.StrokeBlue = 33;
+        sut.StrokeAlpha = 44;
+
+        sut.StrokeColor.ShouldBe(new Color(11, 22, 33, 44));
+    }
+
+    [Fact]
+    public void StrokeColor_DefaultsToWhite()
+    {
+        CircleRuntime sut = new();
+
+        sut.StrokeColor.ShouldBe(Color.White);
+
+        sut.StrokeColor = Color.Lime;
+        sut.StrokeColor.ShouldBe(Color.Lime);
     }
 
     // Issue #2791 graceful-degradation contract: with no MonoGameGumShapes package the stroke
@@ -213,8 +280,8 @@ public class CircleRuntimeTests : BaseTestClass
         sut.StrokeColor = Color.Blue;
         sut.Color = Color.Lime;
         sut.Radius = 25f;
-        sut.FillColor = null;
-        sut.StrokeColor = null;
+        sut.IsFilled = false;
+        sut.StrokeWidth = 0;
 
         sut.RenderableComponent.ShouldBeSameAs(original);
     }

--- a/MonoGameGum.Tests/Runtimes/CircleRuntimeTests.cs
+++ b/MonoGameGum.Tests/Runtimes/CircleRuntimeTests.cs
@@ -57,12 +57,16 @@ public class CircleRuntimeTests : BaseTestClass
         sut.FillColor.ShouldBe(new Color(11, 22, 33, 44));
     }
 
+    // Issue #2938 (regression fix) — FillColor defaults to transparent (alpha 0) so a
+    // freshly-constructed runtime renders as a stroke-only outline, preserving the pre-#2938
+    // ctor visual. IsFilled is true by default; assigning FillColor to a visible color lights
+    // the fill up without flipping IsFilled.
     [Fact]
-    public void FillColor_DefaultsToWhite()
+    public void FillColor_DefaultsToTransparent()
     {
         CircleRuntime sut = new();
 
-        sut.FillColor.ShouldBe(Color.White);
+        sut.FillColor.ShouldBe(new Color(0, 0, 0, 0));
     }
 
     [Fact]

--- a/MonoGameGum.Tests/Runtimes/RectangleRuntimeTests.cs
+++ b/MonoGameGum.Tests/Runtimes/RectangleRuntimeTests.cs
@@ -112,10 +112,78 @@ public class RectangleRuntimeTests : BaseTestClass
         sut.CornerRadius = 12f;
         sut.Width = 100;
         sut.Height = 60;
-        sut.FillColor = null;
-        sut.StrokeColor = null;
+        // Issue #2938 — FillColor/StrokeColor are non-nullable; visibility is gated via
+        // IsFilled (fill) and StrokeWidth = 0 (stroke).
+        sut.IsFilled = false;
+        sut.StrokeWidth = 0;
 
         sut.RenderableComponent.ShouldBeSameAs(original);
         ((DefaultFilledRectangleRenderable)sut.RenderableComponent).Children[0].ShouldBeSameAs(originalStroke);
+    }
+
+    // Issue #2938 — RectangleRuntime mirrors CircleRuntime's Pass 1 defaults: FillColor and
+    // StrokeColor are non-nullable (defaulting to white) and IsFilled defaults to true. Visual
+    // result: a freshly-constructed RectangleRuntime renders as a solid white block with a 1 px
+    // white outline.
+    [Fact]
+    public void FillColor_DefaultsToWhite()
+    {
+        RectangleRuntime sut = new();
+
+        sut.FillColor.ShouldBe(Color.White);
+    }
+
+    [Fact]
+    public void StrokeColor_DefaultsToWhite()
+    {
+        RectangleRuntime sut = new();
+
+        sut.StrokeColor.ShouldBe(Color.White);
+    }
+
+    [Fact]
+    public void IsFilled_DefaultsToTrue()
+    {
+        RectangleRuntime sut = new();
+
+        sut.IsFilled.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsFilled_RoundTripsBackingField()
+    {
+        RectangleRuntime sut = new();
+
+        sut.IsFilled = false;
+        sut.IsFilled.ShouldBeFalse();
+
+        sut.IsFilled = true;
+        sut.IsFilled.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void FillChannelSetters_ComposeFillColor()
+    {
+        RectangleRuntime sut = new();
+
+        sut.FillRed = 11;
+        sut.FillGreen = 22;
+        sut.FillBlue = 33;
+        sut.FillAlpha = 44;
+
+        sut.FillColor.ShouldBe(new Color(11, 22, 33, 44));
+    }
+
+    [Fact]
+    public void StrokeChannelSetters_ComposeStrokeColor()
+    {
+        RectangleRuntime sut = new();
+
+        sut.StrokeRed = 11;
+        sut.StrokeGreen = 22;
+        sut.StrokeBlue = 33;
+        sut.StrokeAlpha = 44;
+
+        sut.StrokeColor.ShouldBe(new Color(11, 22, 33, 44));
     }
 }

--- a/MonoGameGum.Tests/Runtimes/RectangleRuntimeTests.cs
+++ b/MonoGameGum.Tests/Runtimes/RectangleRuntimeTests.cs
@@ -121,16 +121,15 @@ public class RectangleRuntimeTests : BaseTestClass
         ((DefaultFilledRectangleRenderable)sut.RenderableComponent).Children[0].ShouldBeSameAs(originalStroke);
     }
 
-    // Issue #2938 — RectangleRuntime mirrors CircleRuntime's Pass 1 defaults: FillColor and
-    // StrokeColor are non-nullable (defaulting to white) and IsFilled defaults to true. Visual
-    // result: a freshly-constructed RectangleRuntime renders as a solid white block with a 1 px
-    // white outline.
+    // Issue #2938 (regression fix) — FillColor defaults to transparent (alpha 0) so a
+    // freshly-constructed runtime renders as a stroke-only outline (pre-#2938 visual).
+    // IsFilled is true by default; assigning FillColor to a visible color lights the fill up.
     [Fact]
-    public void FillColor_DefaultsToWhite()
+    public void FillColor_DefaultsToTransparent()
     {
         RectangleRuntime sut = new();
 
-        sut.FillColor.ShouldBe(Color.White);
+        sut.FillColor.ShouldBe(new Color(0, 0, 0, 0));
     }
 
     [Fact]

--- a/MonoGameGum/GueDeriving/CircleRuntime.cs
+++ b/MonoGameGum/GueDeriving/CircleRuntime.cs
@@ -259,7 +259,9 @@ public class CircleRuntime : GraphicalUiElement
     // properties at all yet; the raylib sample (CirclesScreen) renders only the supported
     // sections.
 
-    Color _fillColor = new Color((byte)255, (byte)255, (byte)255, (byte)255);
+    // Issue #2938 regression fix — transparent default so a freshly-constructed CircleRuntime
+    // renders as a stroke-only outline (existing raylib gallery / cross-backend samples).
+    Color _fillColor = new Color((byte)0, (byte)0, (byte)0, (byte)0);
 
     /// <inheritdoc cref="Gum.Renderables.LineCircle.FillColor"/>
     public Color FillColor
@@ -466,12 +468,20 @@ public class CircleRuntime : GraphicalUiElement
 #endif
 
 #if XNALIKE
-    Color _fillColor = Color.White;
+    // Issue #2938 regression fix: FillColor defaults to transparent (alpha 0) so a freshly-
+    // constructed CircleRuntime renders as a stroke-only outline — matching the pre-#2938
+    // visual that all existing sample code assumes ("construct + only set StrokeColor").
+    // IsFilled is true by default; the gate semantics still work — explicitly setting
+    // FillColor to a visible color lights the fill up. Setting IsFilled = false zeros the
+    // fill slot's alpha regardless of FillColor.
+    Color _fillColor = new Color(0, 0, 0, 0);
 
     /// <summary>
     /// Color of the filled disk. Painted into the fill slot when <see cref="IsFilled"/> is
     /// <c>true</c>; ignored visually when <c>IsFilled</c> is <c>false</c> (the fill slot is
-    /// pushed a transparent color so only the stroke draws).
+    /// pushed a transparent color so only the stroke draws). Defaults to transparent so a
+    /// freshly-constructed runtime renders a stroke-only outline; assign a visible color to
+    /// light the fill up (IsFilled is already true by default).
     /// </summary>
     /// <remarks>
     /// Visual fill requires a fill-capable <see cref="IFilledCircleRenderable"/> implementation —
@@ -1635,11 +1645,12 @@ public class CircleRuntime : GraphicalUiElement
                 SetContainedObject(_stroke);
             }
 
-            // Initial defaults — stroke white, fill white (gated by IsFilled = true), radius
-            // 16, layout 32x32. Issue #2938: FillColor defaults to white and IsFilled defaults
-            // to true so a freshly-constructed CircleRuntime renders a solid white disc when
-            // backed by Apos.Shapes; without the package the fill slot is null and only the
-            // white stroke draws (the same visual as before).
+            // Initial defaults — stroke white, fill transparent (IsFilled = true so the gate
+            // is open, but the color is alpha-0 so nothing visible draws), radius 16, layout
+            // 32x32. Issue #2938 (regression fix): a freshly-constructed CircleRuntime renders
+            // as a stroke-only outline — matching the pre-#2938 visual that existing sample
+            // code (raylib gallery, GumShapesGallery, SilkNetGum) assumes. Setting FillColor to
+            // a visible color lights up the fill without needing to also flip IsFilled.
             _stroke.Color = _strokeColor;
             _stroke.Radius = 16;
             if (_fill != null)
@@ -1679,12 +1690,12 @@ public class CircleRuntime : GraphicalUiElement
             // single-slot legacy model (last-non-null-setter-wins).
             SetStrokeRenderable(new ContainedCircleType());
 
-            // Issue #2938 defaults: white fill + white stroke. Base IsFilled defaults to true,
-            // so a fresh CircleRuntime renders as a solid white disc with a white outline —
-            // matching the XNALIKE branch (Apos-backed solid + outline). Pre-#2938 the Skia
-            // default was an invisible fill + white stroke; that hide-the-fill semantic now
-            // lives on IsFilled, leaving FillColor itself round-tripping a canonical white.
-            FillColor = SKColors.White;
+            // Issue #2938 (regression fix): FillColor defaults to transparent (alpha 0) +
+            // white stroke. IsFilled defaults to true so the gate is open, but the transparent
+            // color means a freshly-constructed runtime renders as a stroke-only outline —
+            // matching the pre-#2938 visual that existing sample code assumes. Assigning
+            // FillColor to a visible color lights up the fill without flipping IsFilled.
+            FillColor = new SKColor(0, 0, 0, 0);
             StrokeColor = SKColors.White;
             StrokeWidth = 1;
             StrokeWidthUnits = DimensionUnitType.ScreenPixel;
@@ -1705,10 +1716,12 @@ public class CircleRuntime : GraphicalUiElement
             // it null there so the existing outline-via-Color path keeps working unchanged.
             // Same fix landed for RectangleRuntime earlier in this PR.
             //
-            // #2938 — push runtime-held FillColor / StrokeColor / IsFilled defaults onto the
-            // renderable so the runtime properties report consistent state at construction.
-            // FillColor defaults to white and IsFilled defaults to true → a fresh circle
-            // renders as a white disc with a white stroke (matching the XNALIKE branch).
+            // #2938 (regression fix) — push runtime-held FillColor / StrokeColor / IsFilled
+            // defaults onto the renderable so the runtime properties report consistent state at
+            // construction. FillColor defaults to transparent (alpha 0) and IsFilled defaults
+            // to true → a fresh circle renders as a stroke-only outline (matching the pre-#2938
+            // visual that the raylib gallery / cross-backend samples assume). Assigning
+            // FillColor to a visible color lights up the fill without flipping IsFilled.
             circle.StrokeColor = _strokeColor;
             circle.FillColor = _fillColor;
             circle.IsFilled = true;

--- a/MonoGameGum/GueDeriving/CircleRuntime.cs
+++ b/MonoGameGum/GueDeriving/CircleRuntime.cs
@@ -259,26 +259,88 @@ public class CircleRuntime : GraphicalUiElement
     // properties at all yet; the raylib sample (CirclesScreen) renders only the supported
     // sections.
 
+    Color _fillColor = new Color((byte)255, (byte)255, (byte)255, (byte)255);
+
     /// <inheritdoc cref="Gum.Renderables.LineCircle.FillColor"/>
-    public Color? FillColor
+    public Color FillColor
     {
-        get => ContainedLineCircle.FillColor;
+        get => _fillColor;
         set
         {
+            _fillColor = value;
             ContainedLineCircle.FillColor = value;
             NotifyPropertyChanged();
         }
     }
 
-    /// <inheritdoc cref="Gum.Renderables.LineCircle.StrokeColor"/>
-    public Color? StrokeColor
+    /// <summary>Red channel of <see cref="FillColor"/>.</summary>
+    public int FillRed
     {
-        get => ContainedLineCircle.StrokeColor;
+        get => _fillColor.R;
+        set => FillColor = new Color((byte)value, _fillColor.G, _fillColor.B, _fillColor.A);
+    }
+
+    /// <summary>Green channel of <see cref="FillColor"/>.</summary>
+    public int FillGreen
+    {
+        get => _fillColor.G;
+        set => FillColor = new Color(_fillColor.R, (byte)value, _fillColor.B, _fillColor.A);
+    }
+
+    /// <summary>Blue channel of <see cref="FillColor"/>.</summary>
+    public int FillBlue
+    {
+        get => _fillColor.B;
+        set => FillColor = new Color(_fillColor.R, _fillColor.G, (byte)value, _fillColor.A);
+    }
+
+    /// <summary>Alpha channel of <see cref="FillColor"/>.</summary>
+    public int FillAlpha
+    {
+        get => _fillColor.A;
+        set => FillColor = new Color(_fillColor.R, _fillColor.G, _fillColor.B, (byte)value);
+    }
+
+    Color _strokeColor = new Color((byte)255, (byte)255, (byte)255, (byte)255);
+
+    /// <inheritdoc cref="Gum.Renderables.LineCircle.StrokeColor"/>
+    public Color StrokeColor
+    {
+        get => _strokeColor;
         set
         {
+            _strokeColor = value;
             ContainedLineCircle.StrokeColor = value;
             NotifyPropertyChanged();
         }
+    }
+
+    /// <summary>Red channel of <see cref="StrokeColor"/>.</summary>
+    public int StrokeRed
+    {
+        get => _strokeColor.R;
+        set => StrokeColor = new Color((byte)value, _strokeColor.G, _strokeColor.B, _strokeColor.A);
+    }
+
+    /// <summary>Green channel of <see cref="StrokeColor"/>.</summary>
+    public int StrokeGreen
+    {
+        get => _strokeColor.G;
+        set => StrokeColor = new Color(_strokeColor.R, (byte)value, _strokeColor.B, _strokeColor.A);
+    }
+
+    /// <summary>Blue channel of <see cref="StrokeColor"/>.</summary>
+    public int StrokeBlue
+    {
+        get => _strokeColor.B;
+        set => StrokeColor = new Color(_strokeColor.R, _strokeColor.G, (byte)value, _strokeColor.A);
+    }
+
+    /// <summary>Alpha channel of <see cref="StrokeColor"/>.</summary>
+    public int StrokeAlpha
+    {
+        get => _strokeColor.A;
+        set => StrokeColor = new Color(_strokeColor.R, _strokeColor.G, _strokeColor.B, (byte)value);
     }
 
     /// <inheritdoc cref="Gum.Renderables.LineCircle.IsFilled"/>
@@ -404,11 +466,12 @@ public class CircleRuntime : GraphicalUiElement
 #endif
 
 #if XNALIKE
-    Color? _fillColor;
+    Color _fillColor = Color.White;
 
     /// <summary>
-    /// Color of the filled disk. When set non-null, the fill slot is painted with this color.
-    /// When set null, the fill slot is hidden (alpha 0) so only the stroke draws.
+    /// Color of the filled disk. Painted into the fill slot when <see cref="IsFilled"/> is
+    /// <c>true</c>; ignored visually when <c>IsFilled</c> is <c>false</c> (the fill slot is
+    /// pushed a transparent color so only the stroke draws).
     /// </summary>
     /// <remarks>
     /// Visual fill requires a fill-capable <see cref="IFilledCircleRenderable"/> implementation —
@@ -417,7 +480,7 @@ public class CircleRuntime : GraphicalUiElement
     /// round-trips so getter results are consistent and a later install of MonoGameGumShapes
     /// (re-creating the runtime) will honor the stored color.
     /// </remarks>
-    public Color? FillColor
+    public Color FillColor
     {
         get => _fillColor;
         set
@@ -425,29 +488,108 @@ public class CircleRuntime : GraphicalUiElement
             _fillColor = value;
             if (_fill != null)
             {
-                _fill.Color = value ?? new Color(0, 0, 0, 0);
+                _fill.Color = _isFilled ? _fillColor : new Color(0, 0, 0, 0);
             }
             NotifyPropertyChanged();
         }
     }
 
-    Color? _strokeColor = Color.White;
+    /// <summary>Red channel of <see cref="FillColor"/>.</summary>
+    public int FillRed
+    {
+        get => _fillColor.R;
+        set => FillColor = new Color((byte)value, _fillColor.G, _fillColor.B, _fillColor.A);
+    }
+
+    /// <summary>Green channel of <see cref="FillColor"/>.</summary>
+    public int FillGreen
+    {
+        get => _fillColor.G;
+        set => FillColor = new Color(_fillColor.R, (byte)value, _fillColor.B, _fillColor.A);
+    }
+
+    /// <summary>Blue channel of <see cref="FillColor"/>.</summary>
+    public int FillBlue
+    {
+        get => _fillColor.B;
+        set => FillColor = new Color(_fillColor.R, _fillColor.G, (byte)value, _fillColor.A);
+    }
+
+    /// <summary>Alpha channel of <see cref="FillColor"/>.</summary>
+    public int FillAlpha
+    {
+        get => _fillColor.A;
+        set => FillColor = new Color(_fillColor.R, _fillColor.G, _fillColor.B, (byte)value);
+    }
+
+    bool _isFilled = true;
+
+    /// <summary>
+    /// Gates fill rendering. When <c>true</c> (the default) the fill slot is painted with
+    /// <see cref="FillColor"/>. When <c>false</c> the fill slot is pushed a transparent color
+    /// so only the stroke draws — used to render a stroke-only outline without dropping
+    /// <see cref="FillColor"/>. Stroke visibility is gated separately by
+    /// <see cref="StrokeWidth"/> (0 hides stroke).
+    /// </summary>
+    public bool IsFilled
+    {
+        get => _isFilled;
+        set
+        {
+            _isFilled = value;
+            if (_fill != null)
+            {
+                _fill.Color = _isFilled ? _fillColor : new Color(0, 0, 0, 0);
+            }
+            NotifyPropertyChanged();
+        }
+    }
+
+    Color _strokeColor = Color.White;
 
     /// <summary>
     /// Color of the outline. Defaults to white so a freshly-constructed CircleRuntime renders
-    /// the same visible outline as legacy code did. <c>null</c> hides the stroke (alpha 0) so
-    /// only the fill draws. The stroke slot is always non-null on supported backends — core
-    /// ships <see cref="DefaultStrokedCircleRenderable"/> as the default.
+    /// the same visible outline as legacy code did. Set <see cref="StrokeWidth"/> to 0 to hide
+    /// the stroke. The stroke slot is always non-null on supported backends — core ships
+    /// <see cref="DefaultStrokedCircleRenderable"/> as the default.
     /// </summary>
-    public Color? StrokeColor
+    public Color StrokeColor
     {
         get => _strokeColor;
         set
         {
             _strokeColor = value;
-            _stroke.Color = value ?? new Color(0, 0, 0, 0);
+            _stroke.Color = value;
             NotifyPropertyChanged();
         }
+    }
+
+    /// <summary>Red channel of <see cref="StrokeColor"/>.</summary>
+    public int StrokeRed
+    {
+        get => _strokeColor.R;
+        set => StrokeColor = new Color((byte)value, _strokeColor.G, _strokeColor.B, _strokeColor.A);
+    }
+
+    /// <summary>Green channel of <see cref="StrokeColor"/>.</summary>
+    public int StrokeGreen
+    {
+        get => _strokeColor.G;
+        set => StrokeColor = new Color(_strokeColor.R, (byte)value, _strokeColor.B, _strokeColor.A);
+    }
+
+    /// <summary>Blue channel of <see cref="StrokeColor"/>.</summary>
+    public int StrokeBlue
+    {
+        get => _strokeColor.B;
+        set => StrokeColor = new Color(_strokeColor.R, _strokeColor.G, (byte)value, _strokeColor.A);
+    }
+
+    /// <summary>Alpha channel of <see cref="StrokeColor"/>.</summary>
+    public int StrokeAlpha
+    {
+        get => _strokeColor.A;
+        set => StrokeColor = new Color(_strokeColor.R, _strokeColor.G, _strokeColor.B, (byte)value);
     }
 
     float _strokeWidth = 1;
@@ -1113,13 +1255,14 @@ public class CircleRuntime : GraphicalUiElement
         // strokes push a sub-pixel epsilon to Apos so the AA halo (still ~1 px) dominates
         // and would re-create the overlap without the floor.
         //
-        // Gated on stroke alpha > 0: a hidden stroke (StrokeColor = null sets alpha 0)
-        // shouldn't inset the fill, or fill-only mode would render a thin background ring
-        // where the stroke would have been.
+        // Gated on stroke visibility: alpha 0 OR StrokeWidth 0 means the stroke isn't drawn,
+        // and inset would render a thin background ring where the stroke would have been.
+        // Issue #2938 made StrokeWidth = 0 the canonical hide-stroke gate (StrokeColor is now
+        // non-nullable); the alpha guard stays as the pre-existing #2834 path.
         if (_fill != null)
         {
             float fillRadiusInset = 0f;
-            if (_stroke.Color.A > 0)
+            if (_stroke.Color.A > 0 && _strokeWidth > 0)
             {
                 fillRadiusInset = renderableStrokeWidth;
                 if (_isAntialiased && _stroke is IAntialiasedRenderable)
@@ -1172,6 +1315,11 @@ public class CircleRuntime : GraphicalUiElement
         }
 
         toReturn.StrokeColor = toReturn.StrokeColor;
+        // Issue #2938 — re-fire FillColor / IsFilled so the freshly-built fill slot picks up
+        // the user's values; MemberwiseClone copied the backing fields but the new slot was
+        // constructed in its default state.
+        toReturn.FillColor = toReturn.FillColor;
+        toReturn.IsFilled = toReturn.IsFilled;
         if (toReturn._fill != null)
         {
             toReturn._stroke.Radius = toReturn._fill.Radius;
@@ -1487,13 +1635,16 @@ public class CircleRuntime : GraphicalUiElement
                 SetContainedObject(_stroke);
             }
 
-            // Initial defaults — stroke white, no fill, radius 16, layout 32x32. Fill alpha 0
-            // until the user sets FillColor so it doesn't paint over the stroke at startup.
-            _stroke.Color = Color.White;
+            // Initial defaults — stroke white, fill white (gated by IsFilled = true), radius
+            // 16, layout 32x32. Issue #2938: FillColor defaults to white and IsFilled defaults
+            // to true so a freshly-constructed CircleRuntime renders a solid white disc when
+            // backed by Apos.Shapes; without the package the fill slot is null and only the
+            // white stroke draws (the same visual as before).
+            _stroke.Color = _strokeColor;
             _stroke.Radius = 16;
             if (_fill != null)
             {
-                _fill.Color = new Color(0, 0, 0, 0);
+                _fill.Color = _isFilled ? _fillColor : new Color(0, 0, 0, 0);
                 _fill.Radius = 16;
             }
             Width = 32;
@@ -1528,9 +1679,12 @@ public class CircleRuntime : GraphicalUiElement
             // single-slot legacy model (last-non-null-setter-wins).
             SetStrokeRenderable(new ContainedCircleType());
 
-            // Defaults: invisible fill, white stroke — matches the pre-#2790 visual where the
-            // single Circle was set to StrokeColor = White (which forced IsFilled = false).
-            FillColor = null;
+            // Issue #2938 defaults: white fill + white stroke. Base IsFilled defaults to true,
+            // so a fresh CircleRuntime renders as a solid white disc with a white outline —
+            // matching the XNALIKE branch (Apos-backed solid + outline). Pre-#2938 the Skia
+            // default was an invisible fill + white stroke; that hide-the-fill semantic now
+            // lives on IsFilled, leaving FillColor itself round-tripping a canonical white.
+            FillColor = SKColors.White;
             StrokeColor = SKColors.White;
             StrokeWidth = 1;
             StrokeWidthUnits = DimensionUnitType.ScreenPixel;
@@ -1550,7 +1704,14 @@ public class CircleRuntime : GraphicalUiElement
             // but kept them on Skia. SOKOL renderable doesn't expose StrokeColor yet — leave
             // it null there so the existing outline-via-Color path keeps working unchanged.
             // Same fix landed for RectangleRuntime earlier in this PR.
-            circle.StrokeColor = ColorExtensions.White;
+            //
+            // #2938 — push runtime-held FillColor / StrokeColor / IsFilled defaults onto the
+            // renderable so the runtime properties report consistent state at construction.
+            // FillColor defaults to white and IsFilled defaults to true → a fresh circle
+            // renders as a white disc with a white stroke (matching the XNALIKE branch).
+            circle.StrokeColor = _strokeColor;
+            circle.FillColor = _fillColor;
+            circle.IsFilled = true;
 #endif
 #endif
             Width = 32;

--- a/MonoGameGum/GueDeriving/RectangleRuntime.cs
+++ b/MonoGameGum/GueDeriving/RectangleRuntime.cs
@@ -1725,11 +1725,17 @@ public class RectangleRuntime : GraphicalUiElement
 
             // Defaults: transparent fill, white stroke — RectangleRuntime's historical
             // outline-only visual, now expressed as IsFilled = true (base default) + FillColor
-            // alpha 0 (base field default after the #2938 regression fix). Symmetric with
-            // CircleRuntime's Skia branch: assigning FillColor to a visible color lights up the
-            // fill without flipping IsFilled. Pre-#2938 the Skia branch flipped IsFilled = false
-            // explicitly; that broke gallery code which does `frame.FillColor = darkGray;`
-            // without setting IsFilled.
+            // alpha 0. Symmetric with CircleRuntime's Skia branch: assigning FillColor to a
+            // visible color lights up the fill without flipping IsFilled. Pre-#2938 the Skia
+            // branch flipped IsFilled = false explicitly; that broke gallery code which does
+            // `frame.FillColor = darkGray;` without setting IsFilled.
+            //
+            // FillColor must be explicitly assigned here even though the field default is
+            // transparent: SkiaShapeRuntime.PushFillColorToSlot only runs from the FillColor /
+            // IsFilled property setters, never from field init. Without this line the Skia
+            // RoundedRectangle renderable retains its own constructor default (white) and the
+            // rectangle renders as a solid white block. Mirrors CircleRuntime's Skia ctor.
+            FillColor = new SKColor(0, 0, 0, 0);
             StrokeColor = SKColors.White;
             StrokeWidth = 1;
             StrokeWidthUnits = DimensionUnitType.ScreenPixel;

--- a/MonoGameGum/GueDeriving/RectangleRuntime.cs
+++ b/MonoGameGum/GueDeriving/RectangleRuntime.cs
@@ -235,26 +235,93 @@ public class RectangleRuntime : GraphicalUiElement
     // implement any of this; when it gains support, lift the relevant blocks into RAYLIB ||
     // SOKOL (mirror the CircleRuntime pattern).
 
+    Color _fillColor = new Color((byte)255, (byte)255, (byte)255, (byte)255);
+
     /// <inheritdoc cref="Gum.Renderables.LineRectangle.FillColor"/>
-    public Color? FillColor
+    /// <remarks>
+    /// Issue #2938 — non-nullable since the visibility gate moved to <see cref="IsFilled"/>.
+    /// Defaults to white; combined with the white <see cref="StrokeColor"/> default a freshly-
+    /// constructed RectangleRuntime renders as a solid white block with a 1 px white outline.
+    /// </remarks>
+    public Color FillColor
     {
-        get => ContainedLineRectangle.FillColor;
+        get => _fillColor;
         set
         {
+            _fillColor = value;
             ContainedLineRectangle.FillColor = value;
             NotifyPropertyChanged();
         }
     }
 
-    /// <inheritdoc cref="Gum.Renderables.LineRectangle.StrokeColor"/>
-    public Color? StrokeColor
+    /// <summary>Red channel of <see cref="FillColor"/>.</summary>
+    public int FillRed
     {
-        get => ContainedLineRectangle.StrokeColor;
+        get => _fillColor.R;
+        set => FillColor = new Color((byte)value, _fillColor.G, _fillColor.B, _fillColor.A);
+    }
+
+    /// <summary>Green channel of <see cref="FillColor"/>.</summary>
+    public int FillGreen
+    {
+        get => _fillColor.G;
+        set => FillColor = new Color(_fillColor.R, (byte)value, _fillColor.B, _fillColor.A);
+    }
+
+    /// <summary>Blue channel of <see cref="FillColor"/>.</summary>
+    public int FillBlue
+    {
+        get => _fillColor.B;
+        set => FillColor = new Color(_fillColor.R, _fillColor.G, (byte)value, _fillColor.A);
+    }
+
+    /// <summary>Alpha channel of <see cref="FillColor"/>.</summary>
+    public int FillAlpha
+    {
+        get => _fillColor.A;
+        set => FillColor = new Color(_fillColor.R, _fillColor.G, _fillColor.B, (byte)value);
+    }
+
+    Color _strokeColor = new Color((byte)255, (byte)255, (byte)255, (byte)255);
+
+    /// <inheritdoc cref="Gum.Renderables.LineRectangle.StrokeColor"/>
+    public Color StrokeColor
+    {
+        get => _strokeColor;
         set
         {
+            _strokeColor = value;
             ContainedLineRectangle.StrokeColor = value;
             NotifyPropertyChanged();
         }
+    }
+
+    /// <summary>Red channel of <see cref="StrokeColor"/>.</summary>
+    public int StrokeRed
+    {
+        get => _strokeColor.R;
+        set => StrokeColor = new Color((byte)value, _strokeColor.G, _strokeColor.B, _strokeColor.A);
+    }
+
+    /// <summary>Green channel of <see cref="StrokeColor"/>.</summary>
+    public int StrokeGreen
+    {
+        get => _strokeColor.G;
+        set => StrokeColor = new Color(_strokeColor.R, (byte)value, _strokeColor.B, _strokeColor.A);
+    }
+
+    /// <summary>Blue channel of <see cref="StrokeColor"/>.</summary>
+    public int StrokeBlue
+    {
+        get => _strokeColor.B;
+        set => StrokeColor = new Color(_strokeColor.R, _strokeColor.G, (byte)value, _strokeColor.A);
+    }
+
+    /// <summary>Alpha channel of <see cref="StrokeColor"/>.</summary>
+    public int StrokeAlpha
+    {
+        get => _strokeColor.A;
+        set => StrokeColor = new Color(_strokeColor.R, _strokeColor.G, _strokeColor.B, (byte)value);
     }
 
     /// <inheritdoc cref="Gum.Renderables.LineRectangle.IsFilled"/>
@@ -624,14 +691,22 @@ public class RectangleRuntime : GraphicalUiElement
 #endif
 
 #if XNALIKE
-    Color? _fillColor;
+    Color _fillColor = Color.White;
 
     /// <summary>
-    /// Color of the filled rectangle. <c>null</c> hides the fill (alpha 0). Pushed to the
-    /// fill slot when non-null. Both core (<see cref="DefaultFilledRectangleRenderable"/>)
+    /// Color of the filled rectangle. Pushed to the fill slot when <see cref="IsFilled"/> is
+    /// <c>true</c>; when <c>IsFilled</c> is <c>false</c> the fill slot is pushed a transparent
+    /// color so only the stroke draws. Both core (<see cref="DefaultFilledRectangleRenderable"/>)
     /// and MonoGameGumShapes (<c>RoundedRectangle</c> with <c>IsFilled = true</c>) honor this.
     /// </summary>
-    public Color? FillColor
+    /// <remarks>
+    /// Issue #2938 — non-nullable since the visibility gate moved to <see cref="IsFilled"/>.
+    /// Defaults to white so a freshly-constructed RectangleRuntime renders as a solid white
+    /// block; combined with the white <see cref="StrokeColor"/> default the visual is a white
+    /// block with a 1 px white outline (matching CircleRuntime Pass 1 + StandardElementsManager
+    /// <c>IsFilled = true</c> default).
+    /// </remarks>
+    public Color FillColor
     {
         get => _fillColor;
         set
@@ -639,29 +714,108 @@ public class RectangleRuntime : GraphicalUiElement
             _fillColor = value;
             if (_fill != null)
             {
-                _fill.Color = value ?? new Color(0, 0, 0, 0);
+                _fill.Color = _isFilled ? _fillColor : new Color(0, 0, 0, 0);
             }
             NotifyPropertyChanged();
         }
     }
 
-    Color? _strokeColor = Color.White;
+    /// <summary>Red channel of <see cref="FillColor"/>.</summary>
+    public int FillRed
+    {
+        get => _fillColor.R;
+        set => FillColor = new Color((byte)value, _fillColor.G, _fillColor.B, _fillColor.A);
+    }
+
+    /// <summary>Green channel of <see cref="FillColor"/>.</summary>
+    public int FillGreen
+    {
+        get => _fillColor.G;
+        set => FillColor = new Color(_fillColor.R, (byte)value, _fillColor.B, _fillColor.A);
+    }
+
+    /// <summary>Blue channel of <see cref="FillColor"/>.</summary>
+    public int FillBlue
+    {
+        get => _fillColor.B;
+        set => FillColor = new Color(_fillColor.R, _fillColor.G, (byte)value, _fillColor.A);
+    }
+
+    /// <summary>Alpha channel of <see cref="FillColor"/>.</summary>
+    public int FillAlpha
+    {
+        get => _fillColor.A;
+        set => FillColor = new Color(_fillColor.R, _fillColor.G, _fillColor.B, (byte)value);
+    }
+
+    bool _isFilled = true;
+
+    /// <summary>
+    /// Gates fill rendering. When <c>true</c> (the default) the fill slot is painted with
+    /// <see cref="FillColor"/>. When <c>false</c> the fill slot is pushed a transparent color
+    /// so only the stroke draws — used to render a stroke-only outline without dropping
+    /// <see cref="FillColor"/>. Stroke visibility is gated separately by
+    /// <see cref="StrokeWidth"/> (0 hides stroke).
+    /// </summary>
+    public bool IsFilled
+    {
+        get => _isFilled;
+        set
+        {
+            _isFilled = value;
+            if (_fill != null)
+            {
+                _fill.Color = _isFilled ? _fillColor : new Color(0, 0, 0, 0);
+            }
+            NotifyPropertyChanged();
+        }
+    }
+
+    Color _strokeColor = Color.White;
 
     /// <summary>
     /// Color of the outline. Defaults to white so a freshly-constructed RectangleRuntime
-    /// renders the same visible outline as legacy code did. <c>null</c> hides the stroke
-    /// (alpha 0). The stroke slot is always non-null on XNA-like backends — core ships
+    /// renders the same visible outline as legacy code did. Set <see cref="StrokeWidth"/> to 0
+    /// to hide the stroke. The stroke slot is always non-null on XNA-like backends — core ships
     /// <see cref="DefaultStrokedRectangleRenderable"/> as the default.
     /// </summary>
-    public Color? StrokeColor
+    public Color StrokeColor
     {
         get => _strokeColor;
         set
         {
             _strokeColor = value;
-            _stroke.Color = value ?? new Color(0, 0, 0, 0);
+            _stroke.Color = value;
             NotifyPropertyChanged();
         }
+    }
+
+    /// <summary>Red channel of <see cref="StrokeColor"/>.</summary>
+    public int StrokeRed
+    {
+        get => _strokeColor.R;
+        set => StrokeColor = new Color((byte)value, _strokeColor.G, _strokeColor.B, _strokeColor.A);
+    }
+
+    /// <summary>Green channel of <see cref="StrokeColor"/>.</summary>
+    public int StrokeGreen
+    {
+        get => _strokeColor.G;
+        set => StrokeColor = new Color(_strokeColor.R, (byte)value, _strokeColor.B, _strokeColor.A);
+    }
+
+    /// <summary>Blue channel of <see cref="StrokeColor"/>.</summary>
+    public int StrokeBlue
+    {
+        get => _strokeColor.B;
+        set => StrokeColor = new Color(_strokeColor.R, _strokeColor.G, (byte)value, _strokeColor.A);
+    }
+
+    /// <summary>Alpha channel of <see cref="StrokeColor"/>.</summary>
+    public int StrokeAlpha
+    {
+        get => _strokeColor.A;
+        set => StrokeColor = new Color(_strokeColor.R, _strokeColor.G, _strokeColor.B, (byte)value);
     }
 
     float _strokeWidth = 1;
@@ -1392,6 +1546,11 @@ public class RectangleRuntime : GraphicalUiElement
         }
 
         toReturn.StrokeColor = toReturn.StrokeColor;
+        // Issue #2938 — re-fire FillColor / IsFilled so the freshly-built fill slot picks up
+        // the user's values; MemberwiseClone copied the backing fields but the new slot was
+        // constructed in its default state.
+        toReturn.FillColor = toReturn.FillColor;
+        toReturn.IsFilled = toReturn.IsFilled;
         return toReturn;
     }
 #endif
@@ -1519,10 +1678,15 @@ public class RectangleRuntime : GraphicalUiElement
                 SetContainedObject(_stroke);
             }
 
-            _stroke.Color = Color.White;
+            // Initial defaults — stroke white, fill white (gated by IsFilled = true), layout
+            // 50x50. Issue #2938: FillColor defaults to white and IsFilled defaults to true so
+            // a freshly-constructed RectangleRuntime renders as a solid white block with a
+            // 1 px white outline — matching CircleRuntime's Pass 1 default and the
+            // StandardElementsManager IsFilled = true default.
+            _stroke.Color = _strokeColor;
             if (_fill != null)
             {
-                _fill.Color = new Color(0, 0, 0, 0);
+                _fill.Color = _isFilled ? _fillColor : new Color(0, 0, 0, 0);
             }
             Width = 50;
             Height = 50;
@@ -1554,8 +1718,10 @@ public class RectangleRuntime : GraphicalUiElement
             SetStrokeRenderable(new ContainedLineRectangle { CornerRadius = 0 });
 
             // Defaults: invisible fill, white stroke - supplies RectangleRuntime historical
-            // outline-only visual, now via the dedicated stroke slot.
-            FillColor = null;
+            // outline-only visual, now via the dedicated stroke slot. Issue #2938: FillColor
+            // is non-nullable; hide the fill via IsFilled = false (round-tripping a canonical
+            // FillColor so toggling IsFilled back on restores a sensible color).
+            IsFilled = false;
             StrokeColor = SKColors.White;
             StrokeWidth = 1;
             StrokeWidthUnits = DimensionUnitType.ScreenPixel;
@@ -1583,7 +1749,14 @@ public class RectangleRuntime : GraphicalUiElement
             // StrokeColor yet — leave it null there so the existing outline-via-Color path
             // (LineRectangle.Render falls back to Color when StrokeColor is null and no fill
             // is requested) keeps working unchanged.
-            rectangle.StrokeColor = ColorExtensions.White;
+            //
+            // #2938 — push runtime-held FillColor / StrokeColor / IsFilled defaults onto the
+            // renderable so the runtime properties report consistent state at construction.
+            // FillColor defaults to white and IsFilled defaults to true → a fresh rectangle
+            // renders as a white block with a white stroke (matching the XNALIKE branch).
+            rectangle.StrokeColor = _strokeColor;
+            rectangle.FillColor = _fillColor;
+            rectangle.IsFilled = true;
 #endif
 
             Width = 50;

--- a/MonoGameGum/GueDeriving/RectangleRuntime.cs
+++ b/MonoGameGum/GueDeriving/RectangleRuntime.cs
@@ -235,13 +235,17 @@ public class RectangleRuntime : GraphicalUiElement
     // implement any of this; when it gains support, lift the relevant blocks into RAYLIB ||
     // SOKOL (mirror the CircleRuntime pattern).
 
-    Color _fillColor = new Color((byte)255, (byte)255, (byte)255, (byte)255);
+    // Issue #2938 regression fix — transparent default so a freshly-constructed RectangleRuntime
+    // renders as a stroke-only outline (matches pre-#2938 visual the gallery / cross-backend
+    // samples assume).
+    Color _fillColor = new Color((byte)0, (byte)0, (byte)0, (byte)0);
 
     /// <inheritdoc cref="Gum.Renderables.LineRectangle.FillColor"/>
     /// <remarks>
     /// Issue #2938 — non-nullable since the visibility gate moved to <see cref="IsFilled"/>.
-    /// Defaults to white; combined with the white <see cref="StrokeColor"/> default a freshly-
-    /// constructed RectangleRuntime renders as a solid white block with a 1 px white outline.
+    /// Defaults to transparent (alpha 0) so a freshly-constructed runtime renders a
+    /// stroke-only outline; IsFilled is true by default so assigning a visible color lights
+    /// up the fill without flipping IsFilled.
     /// </remarks>
     public Color FillColor
     {
@@ -691,20 +695,21 @@ public class RectangleRuntime : GraphicalUiElement
 #endif
 
 #if XNALIKE
-    Color _fillColor = Color.White;
+    // Issue #2938 regression fix: FillColor defaults to transparent (alpha 0) so a freshly-
+    // constructed RectangleRuntime renders as a stroke-only outline — matching the pre-#2938
+    // visual that existing sample code (gallery frames) assumes. IsFilled is true by default;
+    // assigning FillColor to a visible color lights up the fill without flipping IsFilled.
+    Color _fillColor = new Color(0, 0, 0, 0);
 
     /// <summary>
     /// Color of the filled rectangle. Pushed to the fill slot when <see cref="IsFilled"/> is
     /// <c>true</c>; when <c>IsFilled</c> is <c>false</c> the fill slot is pushed a transparent
     /// color so only the stroke draws. Both core (<see cref="DefaultFilledRectangleRenderable"/>)
     /// and MonoGameGumShapes (<c>RoundedRectangle</c> with <c>IsFilled = true</c>) honor this.
+    /// Defaults to transparent so a freshly-constructed runtime renders a stroke-only outline.
     /// </summary>
     /// <remarks>
     /// Issue #2938 — non-nullable since the visibility gate moved to <see cref="IsFilled"/>.
-    /// Defaults to white so a freshly-constructed RectangleRuntime renders as a solid white
-    /// block; combined with the white <see cref="StrokeColor"/> default the visual is a white
-    /// block with a 1 px white outline (matching CircleRuntime Pass 1 + StandardElementsManager
-    /// <c>IsFilled = true</c> default).
     /// </remarks>
     public Color FillColor
     {
@@ -1678,11 +1683,12 @@ public class RectangleRuntime : GraphicalUiElement
                 SetContainedObject(_stroke);
             }
 
-            // Initial defaults — stroke white, fill white (gated by IsFilled = true), layout
-            // 50x50. Issue #2938: FillColor defaults to white and IsFilled defaults to true so
-            // a freshly-constructed RectangleRuntime renders as a solid white block with a
-            // 1 px white outline — matching CircleRuntime's Pass 1 default and the
-            // StandardElementsManager IsFilled = true default.
+            // Initial defaults — stroke white, fill transparent (IsFilled = true so the gate is
+            // open, but FillColor alpha = 0 so nothing visible draws), layout 50x50. Issue
+            // #2938 (regression fix): a freshly-constructed RectangleRuntime renders as a
+            // stroke-only outline — matching the pre-#2938 visual that existing sample code
+            // (gallery frames, sample backgrounds) assumes. Assigning FillColor to a visible
+            // color lights up the fill without flipping IsFilled.
             _stroke.Color = _strokeColor;
             if (_fill != null)
             {
@@ -1717,11 +1723,13 @@ public class RectangleRuntime : GraphicalUiElement
 
             SetStrokeRenderable(new ContainedLineRectangle { CornerRadius = 0 });
 
-            // Defaults: invisible fill, white stroke - supplies RectangleRuntime historical
-            // outline-only visual, now via the dedicated stroke slot. Issue #2938: FillColor
-            // is non-nullable; hide the fill via IsFilled = false (round-tripping a canonical
-            // FillColor so toggling IsFilled back on restores a sensible color).
-            IsFilled = false;
+            // Defaults: transparent fill, white stroke — RectangleRuntime's historical
+            // outline-only visual, now expressed as IsFilled = true (base default) + FillColor
+            // alpha 0 (base field default after the #2938 regression fix). Symmetric with
+            // CircleRuntime's Skia branch: assigning FillColor to a visible color lights up the
+            // fill without flipping IsFilled. Pre-#2938 the Skia branch flipped IsFilled = false
+            // explicitly; that broke gallery code which does `frame.FillColor = darkGray;`
+            // without setting IsFilled.
             StrokeColor = SKColors.White;
             StrokeWidth = 1;
             StrokeWidthUnits = DimensionUnitType.ScreenPixel;
@@ -1750,10 +1758,11 @@ public class RectangleRuntime : GraphicalUiElement
             // (LineRectangle.Render falls back to Color when StrokeColor is null and no fill
             // is requested) keeps working unchanged.
             //
-            // #2938 — push runtime-held FillColor / StrokeColor / IsFilled defaults onto the
-            // renderable so the runtime properties report consistent state at construction.
-            // FillColor defaults to white and IsFilled defaults to true → a fresh rectangle
-            // renders as a white block with a white stroke (matching the XNALIKE branch).
+            // #2938 (regression fix) — push runtime-held FillColor / StrokeColor / IsFilled
+            // defaults onto the renderable so the runtime properties report consistent state at
+            // construction. FillColor defaults to transparent and IsFilled defaults to true →
+            // a fresh rectangle renders as a stroke-only outline (matching the pre-#2938
+            // visual that existing sample code assumes).
             rectangle.StrokeColor = _strokeColor;
             rectangle.FillColor = _fillColor;
             rectangle.IsFilled = true;

--- a/Runtimes/SkiaGum/GueDeriving/SkiaShapeRuntime.cs
+++ b/Runtimes/SkiaGum/GueDeriving/SkiaShapeRuntime.cs
@@ -195,14 +195,19 @@ public abstract class SkiaShapeRuntime : InteractiveGue
         set => ContainedRenderable.Color = value;
     }
 
-    SKColor _fillColor = SKColors.White;
+    // Issue #2938 regression fix: defaults to transparent (alpha 0) so a freshly-constructed
+    // shape runtime renders as a stroke-only outline (matching pre-#2938 visual). IsFilled is
+    // true by default so the gate is open — assigning FillColor to a visible color lights up
+    // the fill without flipping IsFilled.
+    SKColor _fillColor = new SKColor(0, 0, 0, 0);
 
     /// <summary>
     /// Color of the filled disk/shape. Non-nullable since issue #2938 — use <see cref="IsFilled"/>
     /// to hide the fill rather than nulling the color. When <see cref="IsFilled"/> is <c>true</c>
     /// (the default) the fill slot renders with this color; when <c>false</c> the fill slot's
     /// alpha is forced to 0 while the backing color round-trips so toggling <see cref="IsFilled"/>
-    /// back on restores the previously-set color.
+    /// back on restores the previously-set color. Defaults to transparent (alpha 0) preserving
+    /// the historical stroke-only ctor visual.
     /// </summary>
     /// <remarks>
     /// When the runtime opts into two-slot composition (issue #2790) via

--- a/Runtimes/SkiaGum/GueDeriving/SkiaShapeRuntime.cs
+++ b/Runtimes/SkiaGum/GueDeriving/SkiaShapeRuntime.cs
@@ -139,15 +139,16 @@ public abstract class SkiaShapeRuntime : InteractiveGue
         if (StrokeRenderable != null)
         {
             // Two-slot: each slot is gated independently so a gradient lights up only where the
-            // user lit up a color (issue #2790).
-            ContainedRenderable.UseGradient = _useGradient && _fillColor != null;
-            StrokeRenderable.UseGradient = _useGradient && _strokeColor != null;
+            // user lit up a color (issue #2790). Issue #2938: fill activity is now gated by
+            // IsFilled (FillColor is non-nullable), stroke activity by StrokeWidth > 0.
+            ContainedRenderable.UseGradient = _useGradient && _isFilled;
+            StrokeRenderable.UseGradient = _useGradient && StrokeWidth > 0;
         }
         else
         {
             // Single-slot: the contained renderable IS the active slot regardless of whether
             // the user routed through the legacy Color setter, FillColor, or StrokeColor.
-            // Gating here on _fillColor != null silently suppressed gradients on every
+            // Gating here on FillColor / IsFilled silently suppressed gradients on every
             // single-slot shape used via the legacy Color API (Arc, RoundedRectangle, Polygon,
             // ColoredCircle, Line, LineGrid) — that was a regression from #2790; this branch
             // restores the pre-#2790 pass-through.
@@ -194,61 +195,86 @@ public abstract class SkiaShapeRuntime : InteractiveGue
         set => ContainedRenderable.Color = value;
     }
 
-    SKColor? _fillColor;
+    SKColor _fillColor = SKColors.White;
 
     /// <summary>
-    /// Color of the filled disk/shape. When set non-null, the contained renderable switches to
-    /// filled mode and renders with this color. When set null, the runtime falls back to stroke
-    /// (or, if <see cref="StrokeColor"/> is also null, alpha-0 / invisible).
+    /// Color of the filled disk/shape. Non-nullable since issue #2938 — use <see cref="IsFilled"/>
+    /// to hide the fill rather than nulling the color. When <see cref="IsFilled"/> is <c>true</c>
+    /// (the default) the fill slot renders with this color; when <c>false</c> the fill slot's
+    /// alpha is forced to 0 while the backing color round-trips so toggling <see cref="IsFilled"/>
+    /// back on restores the previously-set color.
     /// </summary>
     /// <remarks>
     /// When the runtime opts into two-slot composition (issue #2790) via
     /// <see cref="SetStrokeRenderable"/>, <see cref="FillColor"/> writes only to the dedicated
     /// fill slot and renders simultaneously with <see cref="StrokeColor"/>. When the runtime
-    /// stays on the legacy single-slot model (no stroke renderable registered), fill and stroke
-    /// share the contained renderable's color + IsFilled toggle and the most-recently-set non-null
-    /// value wins.
+    /// stays on the legacy single-slot model, fill and stroke share the contained renderable's
+    /// color + IsFilled toggle.
     /// </remarks>
-    public SKColor? FillColor
+    public SKColor FillColor
     {
         get => _fillColor;
         set
         {
             _fillColor = value;
-            if (StrokeRenderable != null)
-            {
-                // Two-slot: fill slot is locked to IsFilled = true; null FillColor alpha-0s it
-                // while leaving the stroke slot untouched.
-                ContainedRenderable.IsFilled = true;
-                ContainedRenderable.Color = value ?? new SKColor(0, 0, 0, 0);
-            }
-            else if (value is SKColor fill)
-            {
-                ContainedRenderable.IsFilled = true;
-                ContainedRenderable.Color = fill;
-            }
-            else if (_strokeColor is SKColor stroke)
-            {
-                // Fill cleared but a stroke is still set — keep the stroke visible.
-                ContainedRenderable.IsFilled = false;
-                ContainedRenderable.Color = stroke;
-            }
-            else
-            {
-                // Neither set — hide via alpha 0 so the runtime is fully invisible without
-                // tearing down the renderable.
-                ContainedRenderable.Color = new SKColor(0, 0, 0, 0);
-            }
+            PushFillColorToSlot();
             RefreshSlotGradients();
         }
     }
 
-    SKColor? _strokeColor;
+    /// <summary>Red channel of <see cref="FillColor"/>.</summary>
+    public int FillRed
+    {
+        get => _fillColor.Red;
+        set => FillColor = new SKColor((byte)value, _fillColor.Green, _fillColor.Blue, _fillColor.Alpha);
+    }
+
+    /// <summary>Green channel of <see cref="FillColor"/>.</summary>
+    public int FillGreen
+    {
+        get => _fillColor.Green;
+        set => FillColor = new SKColor(_fillColor.Red, (byte)value, _fillColor.Blue, _fillColor.Alpha);
+    }
+
+    /// <summary>Blue channel of <see cref="FillColor"/>.</summary>
+    public int FillBlue
+    {
+        get => _fillColor.Blue;
+        set => FillColor = new SKColor(_fillColor.Red, _fillColor.Green, (byte)value, _fillColor.Alpha);
+    }
+
+    /// <summary>Alpha channel of <see cref="FillColor"/>.</summary>
+    public int FillAlpha
+    {
+        get => _fillColor.Alpha;
+        set => FillColor = new SKColor(_fillColor.Red, _fillColor.Green, _fillColor.Blue, (byte)value);
+    }
+
+    void PushFillColorToSlot()
+    {
+        SKColor pushed = _isFilled ? _fillColor : new SKColor(0, 0, 0, 0);
+        if (StrokeRenderable != null)
+        {
+            // Two-slot: fill slot is locked to IsFilled = true; IsFilled = false alpha-0s the
+            // fill slot while leaving the stroke slot untouched.
+            ContainedRenderable.IsFilled = true;
+            ContainedRenderable.Color = pushed;
+        }
+        else
+        {
+            // Single-slot legacy model: fill and stroke share the contained renderable.
+            ContainedRenderable.IsFilled = _isFilled;
+            ContainedRenderable.Color = pushed;
+        }
+    }
+
+    SKColor _strokeColor = SKColors.White;
 
     /// <summary>
-    /// Color of the stroked outline. When set non-null, the contained renderable switches to
-    /// stroke mode and renders with this color. When set null, the runtime falls back to fill
-    /// (or, if <see cref="FillColor"/> is also null, alpha-0 / invisible).
+    /// Color of the stroked outline. Non-nullable since issue #2938 — use <see cref="StrokeWidth"/>
+    /// set to 0 to hide the stroke rather than nulling the color. In two-slot mode the stroke
+    /// slot always renders this color; visibility is gated by <see cref="StrokeWidth"/> at draw
+    /// time.
     /// </summary>
     /// <remarks>
     /// When the runtime opts into two-slot composition (issue #2790) via
@@ -257,7 +283,7 @@ public abstract class SkiaShapeRuntime : InteractiveGue
     /// stays on the legacy single-slot model, fill and stroke share the contained renderable's
     /// color + IsFilled toggle.
     /// </remarks>
-    public SKColor? StrokeColor
+    public SKColor StrokeColor
     {
         get => _strokeColor;
         set
@@ -265,26 +291,43 @@ public abstract class SkiaShapeRuntime : InteractiveGue
             _strokeColor = value;
             if (StrokeRenderable != null)
             {
-                // Two-slot: stroke slot is locked to IsFilled = false; null StrokeColor alpha-0s
-                // it while leaving the fill slot untouched.
-                StrokeRenderable.Color = value ?? new SKColor(0, 0, 0, 0);
-            }
-            else if (value is SKColor stroke)
-            {
-                ContainedRenderable.IsFilled = false;
-                ContainedRenderable.Color = stroke;
-            }
-            else if (_fillColor is SKColor fill)
-            {
-                ContainedRenderable.IsFilled = true;
-                ContainedRenderable.Color = fill;
+                StrokeRenderable.Color = value;
             }
             else
             {
-                ContainedRenderable.Color = new SKColor(0, 0, 0, 0);
+                ContainedRenderable.IsFilled = false;
+                ContainedRenderable.Color = value;
             }
             RefreshSlotGradients();
         }
+    }
+
+    /// <summary>Red channel of <see cref="StrokeColor"/>.</summary>
+    public int StrokeRed
+    {
+        get => _strokeColor.Red;
+        set => StrokeColor = new SKColor((byte)value, _strokeColor.Green, _strokeColor.Blue, _strokeColor.Alpha);
+    }
+
+    /// <summary>Green channel of <see cref="StrokeColor"/>.</summary>
+    public int StrokeGreen
+    {
+        get => _strokeColor.Green;
+        set => StrokeColor = new SKColor(_strokeColor.Red, (byte)value, _strokeColor.Blue, _strokeColor.Alpha);
+    }
+
+    /// <summary>Blue channel of <see cref="StrokeColor"/>.</summary>
+    public int StrokeBlue
+    {
+        get => _strokeColor.Blue;
+        set => StrokeColor = new SKColor(_strokeColor.Red, _strokeColor.Green, (byte)value, _strokeColor.Alpha);
+    }
+
+    /// <summary>Alpha channel of <see cref="StrokeColor"/>.</summary>
+    public int StrokeAlpha
+    {
+        get => _strokeColor.Alpha;
+        set => StrokeColor = new SKColor(_strokeColor.Red, _strokeColor.Green, _strokeColor.Blue, (byte)value);
     }
     #endregion
 
@@ -471,17 +514,23 @@ public abstract class SkiaShapeRuntime : InteractiveGue
 
     #region Filled/Stroke
 
+    bool _isFilled = true;
+
     /// <summary>
-    /// Obsolete: use <see cref="FillColor"/> or <see cref="StrokeColor"/>. Legacy member that
-    /// flips the contained renderable between filled and stroked modes. The new fill/stroke
-    /// split (issue #2785) supersedes this single-toggle by letting the caller specify the
-    /// color directly per slot.
+    /// Gates fill rendering. When <c>true</c> (the default since issue #2938) the fill slot is
+    /// painted with <see cref="FillColor"/>; when <c>false</c> the fill slot's alpha is forced
+    /// to 0 so only the stroke draws. Mirrors the XNALIKE <c>CircleRuntime.IsFilled</c> gate.
+    /// Stroke visibility is gated separately by <see cref="StrokeWidth"/> (0 hides stroke).
     /// </summary>
-    [Obsolete("Use FillColor or StrokeColor instead. See issue #2785; full fill+stroke composition arrives in #2790.")]
     public bool IsFilled
     {
-        get => ContainedRenderable.IsFilled;
-        set => ContainedRenderable.IsFilled = value;
+        get => _isFilled;
+        set
+        {
+            _isFilled = value;
+            PushFillColorToSlot();
+            RefreshSlotGradients();
+        }
     }
 
     // This should NOT modify the contained renderable stroke width directly.
@@ -634,7 +683,7 @@ public abstract class SkiaShapeRuntime : InteractiveGue
     /// otherwise fall back to stroke. Single-slot runtimes always pick the contained renderable.
     /// </summary>
     RenderableShapeBase DropshadowTarget =>
-        StrokeRenderable == null || _fillColor != null
+        StrokeRenderable == null || _isFilled
             ? ContainedRenderable
             : StrokeRenderable;
 

--- a/Samples/MauiSkiaGum/MainPage.xaml.cs
+++ b/Samples/MauiSkiaGum/MainPage.xaml.cs
@@ -93,8 +93,9 @@ namespace MauiSkiaGum
             disc.FillColor = SKColors.Red;
             // CircleRuntime defaults to a 1 px white outline (#2790 two-slot defaults).
             // The pre-#2771 ColoredCircleRuntime had no stroke slot, so suppress the
-            // outline to preserve the original solid-disc visual.
-            disc.StrokeColor = null;
+            // outline to preserve the original solid-disc visual. Since #2938 the canonical
+            // "hide stroke" gate is StrokeWidth = 0 (StrokeColor is non-nullable now).
+            disc.StrokeWidth = 0;
 
             var arc = new ArcRuntime();
             container.AddChild(arc);
@@ -140,8 +141,9 @@ namespace MauiSkiaGum
             MainStack.AddChild(circle);
             circle.FillColor = SKColors.Red;
             // Suppress the default 1 px white outline (see #2771 migration note) to
-            // match the pre-migration ColoredCircleRuntime visual.
-            circle.StrokeColor = null;
+            // match the pre-migration ColoredCircleRuntime visual. Since #2938 the canonical
+            // "hide stroke" gate is StrokeWidth = 0 (StrokeColor is non-nullable now).
+            circle.StrokeWidth = 0;
             circle.Width = 30;
             circle.Height = 30;
 

--- a/Tests/MonoGameGum.Shapes.Tests/CircleRuntimeTests.cs
+++ b/Tests/MonoGameGum.Shapes.Tests/CircleRuntimeTests.cs
@@ -479,9 +479,9 @@ public class CircleRuntimeTests
     // as a solid white disc instead of a stroke-only outline.
     //
     // The fix must keep "Color" reaching _stroke.Color (matching pre-Apos behavior). After
-    // #2938 the fill defaults to opaque white instead of transparent — the IsFilled gate
-    // controls visibility — so we only assert the legacy routing target (stroke), not the
-    // fill's default color.
+    // the #2938 regression fix the fill defaults to transparent (alpha 0) — IsFilled gates
+    // visibility but the color itself stays alpha 0 until the user lights it up — so the
+    // legacy stroke routing must leave fill untouched (still alpha 0).
     [Fact]
     public void SetProperty_Color_RoutesToStroke_NotFill()
     {
@@ -492,7 +492,7 @@ public class CircleRuntimeTests
         Circle fill = (Circle)sut.RenderableComponent;
         Circle stroke = (Circle)fill.Children[0];
         stroke.Color.ShouldBe(new Color(255, 0, 0, 255));
-        fill.Color.ShouldBe(Color.White);
+        fill.Color.ShouldBe(new Color(0, 0, 0, 0));
     }
 
     [Fact]
@@ -505,7 +505,7 @@ public class CircleRuntimeTests
         Circle fill = (Circle)sut.RenderableComponent;
         Circle stroke = (Circle)fill.Children[0];
         stroke.Color.A.ShouldBe((byte)128);
-        fill.Color.ShouldBe(Color.White);
+        fill.Color.ShouldBe(new Color(0, 0, 0, 0));
     }
 
     // Issue #2938 — IsFilled now gates fill visibility. Setting IsFilled = false should push

--- a/Tests/MonoGameGum.Shapes.Tests/CircleRuntimeTests.cs
+++ b/Tests/MonoGameGum.Shapes.Tests/CircleRuntimeTests.cs
@@ -115,9 +115,9 @@ public class CircleRuntimeTests
         fill.FillRadiusInset.ShouldBe(1f);
     }
 
-    // When the stroke is invisible (StrokeColor = null sets alpha 0) the fill should render
-    // at full radius — no inset, no background ring where the stroke would have been. This
-    // guards against fill-only mode rendering with an unwanted gap.
+    // When the stroke is invisible (StrokeWidth == 0) the fill should render at full radius —
+    // no inset, no background ring where the stroke would have been. This guards against
+    // fill-only mode rendering with an unwanted gap.
     [Fact]
     public void FillRadiusInset_WhenStrokeInvisible_StaysZero()
     {
@@ -125,8 +125,8 @@ public class CircleRuntimeTests
         sut.Width = 56;
         sut.Height = 56;
         sut.FillColor = Color.Red;
-        sut.StrokeColor = null;
-        sut.StrokeWidth = 4f;
+        sut.StrokeColor = Color.White;
+        sut.StrokeWidth = 0f;
         sut.StrokeWidthUnits = DimensionUnitType.Absolute;
 
         Circle fill = (Circle)sut.RenderableComponent;
@@ -302,8 +302,8 @@ public class CircleRuntimeTests
         sut.Color = Color.Lime;
 #pragma warning restore CS0618
         sut.Radius = 25f;
-        sut.FillColor = null;
-        sut.StrokeColor = null;
+        sut.IsFilled = false;
+        sut.StrokeWidth = 0;
 
         sut.RenderableComponent.ShouldBeSameAs(originalFill);
         ((Circle)sut.RenderableComponent).Children[0].ShouldBeSameAs(originalStroke);
@@ -478,9 +478,10 @@ public class CircleRuntimeTests
     // instead of the stroke renderable. Result: a freshly-loaded default Circle renders
     // as a solid white disc instead of a stroke-only outline.
     //
-    // The fix must keep "Color" reaching _stroke.Color (matching pre-Apos behavior) and
-    // leave _fill.Color at its transparent constructor default until FillColor is set
-    // explicitly.
+    // The fix must keep "Color" reaching _stroke.Color (matching pre-Apos behavior). After
+    // #2938 the fill defaults to opaque white instead of transparent — the IsFilled gate
+    // controls visibility — so we only assert the legacy routing target (stroke), not the
+    // fill's default color.
     [Fact]
     public void SetProperty_Color_RoutesToStroke_NotFill()
     {
@@ -491,7 +492,7 @@ public class CircleRuntimeTests
         Circle fill = (Circle)sut.RenderableComponent;
         Circle stroke = (Circle)fill.Children[0];
         stroke.Color.ShouldBe(new Color(255, 0, 0, 255));
-        fill.Color.ShouldBe(new Color(0, 0, 0, 0));
+        fill.Color.ShouldBe(Color.White);
     }
 
     [Fact]
@@ -504,6 +505,64 @@ public class CircleRuntimeTests
         Circle fill = (Circle)sut.RenderableComponent;
         Circle stroke = (Circle)fill.Children[0];
         stroke.Color.A.ShouldBe((byte)128);
-        fill.Color.ShouldBe(new Color(0, 0, 0, 0));
+        fill.Color.ShouldBe(Color.White);
+    }
+
+    // Issue #2938 — IsFilled now gates fill visibility. Setting IsFilled = false should push
+    // a transparent color into the fill slot so only the stroke draws.
+    [Fact]
+    public void IsFilled_False_HidesFillSlot()
+    {
+        CircleRuntime sut = new();
+        sut.FillColor = Color.Red;
+
+        sut.IsFilled = false;
+
+        Circle fill = (Circle)sut.RenderableComponent;
+        fill.Color.A.ShouldBe((byte)0);
+    }
+
+    // Setting IsFilled back to true after toggling it off should restore the fill slot's
+    // color to the runtime's FillColor (the backing field round-trips through IsFilled
+    // changes; the renderable color follows the gate).
+    [Fact]
+    public void IsFilled_True_AfterFalse_RestoresFillColor()
+    {
+        CircleRuntime sut = new();
+        sut.FillColor = Color.Red;
+        sut.IsFilled = false;
+
+        sut.IsFilled = true;
+
+        Circle fill = (Circle)sut.RenderableComponent;
+        fill.Color.ShouldBe(Color.Red);
+    }
+
+    [Fact]
+    public void FillChannelSetters_PushToFillSlot()
+    {
+        CircleRuntime sut = new();
+
+        sut.FillRed = 10;
+        sut.FillGreen = 20;
+        sut.FillBlue = 30;
+        sut.FillAlpha = 200;
+
+        Circle fill = (Circle)sut.RenderableComponent;
+        fill.Color.ShouldBe(new Color(10, 20, 30, 200));
+    }
+
+    [Fact]
+    public void StrokeChannelSetters_PushToStrokeSlot()
+    {
+        CircleRuntime sut = new();
+
+        sut.StrokeRed = 10;
+        sut.StrokeGreen = 20;
+        sut.StrokeBlue = 30;
+        sut.StrokeAlpha = 200;
+
+        Circle stroke = (Circle)((Circle)sut.RenderableComponent).Children[0];
+        stroke.Color.ShouldBe(new Color(10, 20, 30, 200));
     }
 }

--- a/Tests/MonoGameGum.Shapes.Tests/RectangleRuntimeTests.cs
+++ b/Tests/MonoGameGum.Shapes.Tests/RectangleRuntimeTests.cs
@@ -468,7 +468,9 @@ public class RectangleRuntimeTests
         RoundedRectangle fill = (RoundedRectangle)sut.RenderableComponent;
         RoundedRectangle stroke = (RoundedRectangle)fill.Children[0];
         stroke.Color.ShouldBe(new Color(255, 0, 0, 255));
-        fill.Color.ShouldBe(new Color(0, 0, 0, 0));
+        // Issue #2938 — fill defaults to white (IsFilled = true); the legacy Color setter only
+        // touches stroke, so fill stays at its default rather than being recolored.
+        fill.Color.ShouldBe(Color.White);
     }
 
     [Fact]
@@ -481,6 +483,64 @@ public class RectangleRuntimeTests
         RoundedRectangle fill = (RoundedRectangle)sut.RenderableComponent;
         RoundedRectangle stroke = (RoundedRectangle)fill.Children[0];
         stroke.Color.A.ShouldBe((byte)128);
-        fill.Color.ShouldBe(new Color(0, 0, 0, 0));
+        // Issue #2938 — fill defaults to white (IsFilled = true); the legacy Alpha setter only
+        // touches stroke, so fill stays at its default rather than being recolored.
+        fill.Color.ShouldBe(Color.White);
+    }
+
+    // Issue #2938 — IsFilled now gates fill visibility (mirror of CircleRuntime Pass 1).
+    // Setting IsFilled = false pushes a transparent color into the fill slot so only the
+    // stroke draws; toggling back to true restores the runtime's FillColor.
+    [Fact]
+    public void IsFilled_False_HidesFillSlot()
+    {
+        RectangleRuntime sut = new();
+        sut.FillColor = Color.Red;
+
+        sut.IsFilled = false;
+
+        RoundedRectangle fill = (RoundedRectangle)sut.RenderableComponent;
+        fill.Color.A.ShouldBe((byte)0);
+    }
+
+    [Fact]
+    public void IsFilled_True_AfterFalse_RestoresFillColor()
+    {
+        RectangleRuntime sut = new();
+        sut.FillColor = Color.Red;
+        sut.IsFilled = false;
+
+        sut.IsFilled = true;
+
+        RoundedRectangle fill = (RoundedRectangle)sut.RenderableComponent;
+        fill.Color.ShouldBe(Color.Red);
+    }
+
+    [Fact]
+    public void FillChannelSetters_PushToFillSlot()
+    {
+        RectangleRuntime sut = new();
+
+        sut.FillRed = 10;
+        sut.FillGreen = 20;
+        sut.FillBlue = 30;
+        sut.FillAlpha = 200;
+
+        RoundedRectangle fill = (RoundedRectangle)sut.RenderableComponent;
+        fill.Color.ShouldBe(new Color(10, 20, 30, 200));
+    }
+
+    [Fact]
+    public void StrokeChannelSetters_PushToStrokeSlot()
+    {
+        RectangleRuntime sut = new();
+
+        sut.StrokeRed = 10;
+        sut.StrokeGreen = 20;
+        sut.StrokeBlue = 30;
+        sut.StrokeAlpha = 200;
+
+        RoundedRectangle stroke = (RoundedRectangle)((RoundedRectangle)sut.RenderableComponent).Children[0];
+        stroke.Color.ShouldBe(new Color(10, 20, 30, 200));
     }
 }

--- a/Tests/MonoGameGum.Shapes.Tests/RectangleRuntimeTests.cs
+++ b/Tests/MonoGameGum.Shapes.Tests/RectangleRuntimeTests.cs
@@ -468,9 +468,10 @@ public class RectangleRuntimeTests
         RoundedRectangle fill = (RoundedRectangle)sut.RenderableComponent;
         RoundedRectangle stroke = (RoundedRectangle)fill.Children[0];
         stroke.Color.ShouldBe(new Color(255, 0, 0, 255));
-        // Issue #2938 — fill defaults to white (IsFilled = true); the legacy Color setter only
-        // touches stroke, so fill stays at its default rather than being recolored.
-        fill.Color.ShouldBe(Color.White);
+        // Issue #2938 (regression fix) — fill defaults to transparent (alpha 0); the legacy
+        // Color setter only touches stroke, so fill stays at its default rather than being
+        // recolored.
+        fill.Color.ShouldBe(new Color(0, 0, 0, 0));
     }
 
     [Fact]
@@ -483,9 +484,10 @@ public class RectangleRuntimeTests
         RoundedRectangle fill = (RoundedRectangle)sut.RenderableComponent;
         RoundedRectangle stroke = (RoundedRectangle)fill.Children[0];
         stroke.Color.A.ShouldBe((byte)128);
-        // Issue #2938 — fill defaults to white (IsFilled = true); the legacy Alpha setter only
-        // touches stroke, so fill stays at its default rather than being recolored.
-        fill.Color.ShouldBe(Color.White);
+        // Issue #2938 (regression fix) — fill defaults to transparent (alpha 0); the legacy
+        // Alpha setter only touches stroke, so fill stays at its default rather than being
+        // recolored.
+        fill.Color.ShouldBe(new Color(0, 0, 0, 0));
     }
 
     // Issue #2938 — IsFilled now gates fill visibility (mirror of CircleRuntime Pass 1).

--- a/Tests/RaylibGum.Tests/Runtimes/CircleRuntimeTests.cs
+++ b/Tests/RaylibGum.Tests/Runtimes/CircleRuntimeTests.cs
@@ -88,13 +88,14 @@ public class CircleRuntimeTests : BaseTestClass
         // FillColor still render with a visible 1 px white outline (e.g. the gallery's Modes
         // and Alignment rows). Raylib must match or fill-only cells render without the outline
         // Skia draws. Same fix landed for RectangleRuntime in this PR.
+        // #2938 — runtime FillColor/StrokeColor are now non-nullable Color (defaulting to
+        // white) with IsFilled / StrokeWidth = 0 as the visibility gates.
         CircleRuntime sut = new();
 
-        sut.StrokeColor.ShouldNotBeNull();
-        sut.StrokeColor!.Value.R.ShouldBe((byte)255);
-        sut.StrokeColor!.Value.G.ShouldBe((byte)255);
-        sut.StrokeColor!.Value.B.ShouldBe((byte)255);
-        sut.StrokeColor!.Value.A.ShouldBe((byte)255);
+        sut.StrokeColor.R.ShouldBe((byte)255);
+        sut.StrokeColor.G.ShouldBe((byte)255);
+        sut.StrokeColor.B.ShouldBe((byte)255);
+        sut.StrokeColor.A.ShouldBe((byte)255);
     }
 
     [Fact]
@@ -105,8 +106,7 @@ public class CircleRuntimeTests : BaseTestClass
 
         sut.FillColor = expected;
 
-        sut.FillColor.ShouldNotBeNull();
-        sut.FillColor!.Value.R.ShouldBe((byte)10);
+        sut.FillColor.R.ShouldBe((byte)10);
         ((LineCircle)sut.RenderableComponent!).FillColor.ShouldNotBeNull();
         ((LineCircle)sut.RenderableComponent!).FillColor!.Value.R.ShouldBe((byte)10);
     }
@@ -119,7 +119,7 @@ public class CircleRuntimeTests : BaseTestClass
 
         sut.StrokeColor = expected;
 
-        sut.StrokeColor.ShouldNotBeNull();
+        sut.StrokeColor.G.ShouldBe((byte)50);
         ((LineCircle)sut.RenderableComponent!).StrokeColor.ShouldNotBeNull();
         ((LineCircle)sut.RenderableComponent!).StrokeColor!.Value.G.ShouldBe((byte)50);
     }

--- a/Tests/RaylibGum.Tests/Runtimes/RectangleRuntimeTests.cs
+++ b/Tests/RaylibGum.Tests/Runtimes/RectangleRuntimeTests.cs
@@ -104,8 +104,7 @@ public class RectangleRuntimeTests : BaseTestClass
 
         sut.FillColor = expected;
 
-        sut.FillColor.ShouldNotBeNull();
-        sut.FillColor!.Value.R.ShouldBe((byte)10);
+        sut.FillColor.R.ShouldBe((byte)10);
         ((LineRectangle)sut.RenderableComponent!).FillColor.ShouldNotBeNull();
         ((LineRectangle)sut.RenderableComponent!).FillColor!.Value.R.ShouldBe((byte)10);
     }
@@ -118,7 +117,7 @@ public class RectangleRuntimeTests : BaseTestClass
 
         sut.StrokeColor = expected;
 
-        sut.StrokeColor.ShouldNotBeNull();
+        sut.StrokeColor.G.ShouldBe((byte)50);
         ((LineRectangle)sut.RenderableComponent!).StrokeColor.ShouldNotBeNull();
         ((LineRectangle)sut.RenderableComponent!).StrokeColor!.Value.G.ShouldBe((byte)50);
     }
@@ -158,13 +157,14 @@ public class RectangleRuntimeTests : BaseTestClass
         // so cells that set only FillColor still render with a visible 1 px white outline
         // (e.g. the gallery's Modes row first cell). Raylib must match or fill-only cells
         // render without the outline Skia draws.
+        // #2938 — runtime FillColor/StrokeColor are now non-nullable Color (defaulting to
+        // white) with IsFilled / StrokeWidth = 0 as the visibility gates.
         RectangleRuntime sut = new();
 
-        sut.StrokeColor.ShouldNotBeNull();
-        sut.StrokeColor!.Value.R.ShouldBe((byte)255);
-        sut.StrokeColor!.Value.G.ShouldBe((byte)255);
-        sut.StrokeColor!.Value.B.ShouldBe((byte)255);
-        sut.StrokeColor!.Value.A.ShouldBe((byte)255);
+        sut.StrokeColor.R.ShouldBe((byte)255);
+        sut.StrokeColor.G.ShouldBe((byte)255);
+        sut.StrokeColor.B.ShouldBe((byte)255);
+        sut.StrokeColor.A.ShouldBe((byte)255);
     }
 
     [Fact]

--- a/Tests/SkiaGum.Tests/GueDeriving/CircleRuntimeTests.cs
+++ b/Tests/SkiaGum.Tests/GueDeriving/CircleRuntimeTests.cs
@@ -34,11 +34,57 @@ public class CircleRuntimeTests
         sut.Height.ShouldBe(32);
     }
 
+    // Issue #2938 — FillColor / StrokeColor are non-nullable on Skia, mirroring the XNALIKE
+    // CircleRuntime. The fill-hidden gate is IsFilled (defaults to true); stroke-hidden gate
+    // is StrokeWidth = 0.
     [Fact]
-    public void FillColor_ShouldBeNull_ByDefault()
+    public void FillColor_ShouldBeWhite_ByDefault()
     {
         CircleRuntime sut = new();
-        sut.FillColor.ShouldBeNull();
+        sut.FillColor.ShouldBe(SKColors.White);
+    }
+
+    [Fact]
+    public void IsFilled_ShouldBeTrue_ByDefault()
+    {
+        CircleRuntime sut = new();
+        sut.IsFilled.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsFilled_False_ZeroesFillSlotAlpha()
+    {
+        CircleRuntime sut = new();
+        sut.FillColor = SKColors.Red;
+
+        sut.IsFilled = false;
+
+        Circle fillSlot = (Circle)sut.RenderableComponent;
+        fillSlot.Color.Alpha.ShouldBe((byte)0);
+    }
+
+    [Fact]
+    public void FillChannelSetters_ComposeFillColor()
+    {
+        CircleRuntime sut = new();
+        sut.FillRed = 10;
+        sut.FillGreen = 20;
+        sut.FillBlue = 30;
+        sut.FillAlpha = 40;
+
+        sut.FillColor.ShouldBe(new SKColor(10, 20, 30, 40));
+    }
+
+    [Fact]
+    public void StrokeChannelSetters_ComposeStrokeColor()
+    {
+        CircleRuntime sut = new();
+        sut.StrokeRed = 11;
+        sut.StrokeGreen = 22;
+        sut.StrokeBlue = 33;
+        sut.StrokeAlpha = 44;
+
+        sut.StrokeColor.ShouldBe(new SKColor(11, 22, 33, 44));
     }
 
     [Fact]
@@ -169,8 +215,8 @@ public class CircleRuntimeTests
         fillSlot.FillRadiusInset.ShouldBe(4f);
     }
 
-    // FillColor = null (default) leaves the fill slot invisible — no need to inset; the
-    // setter never had a visible fill to bleed against.
+    // Issue #2938 — stroke is hidden via StrokeWidth = 0 (StrokeColor is non-nullable now).
+    // No stroke means no halo overlap to inset against.
     [Fact]
     public void FillRadiusInset_WhenStrokeInvisible_StaysZero()
     {
@@ -178,8 +224,7 @@ public class CircleRuntimeTests
         sut.Width = 56;
         sut.Height = 56;
         sut.FillColor = SKColors.Red;
-        sut.StrokeColor = null;
-        sut.StrokeWidth = 4;
+        sut.StrokeWidth = 0;
         sut.StrokeWidthUnits = Gum.DataTypes.DimensionUnitType.Absolute;
 
         sut.PreRender();
@@ -228,12 +273,14 @@ public class CircleRuntimeTests
     }
 
     // #2790: UseGradient is a single user knob that applies to whichever slots are active.
-    // FillColor null => fill slot stays gradient-off even when UseGradient = true; otherwise
-    // SKPaint.Shader would override the alpha-0 fill color and the gradient would render anyway.
+    // Issue #2938 — fill activity is gated by IsFilled (FillColor is non-nullable), stroke
+    // activity by StrokeWidth > 0; SKPaint.Shader otherwise overrides the alpha-0 fill color
+    // and the gradient would render anyway.
     [Fact]
-    public void UseGradient_FillColorNull_FillSlotStaysOff()
+    public void UseGradient_IsFilledFalse_FillSlotStaysOff()
     {
         CircleRuntime sut = new();
+        sut.IsFilled = false;
         sut.UseGradient = true;
 
         Circle fillSlot = (Circle)sut.RenderableComponent;
@@ -243,10 +290,22 @@ public class CircleRuntimeTests
     }
 
     [Fact]
-    public void UseGradient_BothColorsSet_BothSlotsOn()
+    public void UseGradient_StrokeWidthZero_StrokeSlotStaysOff()
     {
         CircleRuntime sut = new();
-        sut.FillColor = SKColors.White;
+        sut.StrokeWidth = 0;
+        sut.UseGradient = true;
+
+        Circle fillSlot = (Circle)sut.RenderableComponent;
+        Circle strokeSlot = (Circle)fillSlot.Children.Single();
+        fillSlot.UseGradient.ShouldBeTrue();
+        strokeSlot.UseGradient.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void UseGradient_DefaultsBothSlotsOn()
+    {
+        CircleRuntime sut = new();
         sut.UseGradient = true;
 
         Circle fillSlot = (Circle)sut.RenderableComponent;
@@ -256,14 +315,15 @@ public class CircleRuntimeTests
     }
 
     [Fact]
-    public void SettingFillColor_AfterUseGradientTrue_LightsUpFillSlotGradient()
+    public void SettingIsFilledTrue_AfterUseGradientTrue_LightsUpFillSlotGradient()
     {
         CircleRuntime sut = new();
+        sut.IsFilled = false;
         sut.UseGradient = true;
         Circle fillSlot = (Circle)sut.RenderableComponent;
         fillSlot.UseGradient.ShouldBeFalse();
 
-        sut.FillColor = SKColors.White;
+        sut.IsFilled = true;
 
         fillSlot.UseGradient.ShouldBeTrue();
     }
@@ -299,11 +359,12 @@ public class CircleRuntimeTests
         strokeSlot.HasDropshadow.ShouldBeFalse();
     }
 
+    // Issue #2938 — when IsFilled = false, the shadow routes to the stroke slot.
     [Fact]
-    public void Dropshadow_FillColorNull_AppliesToStrokeSlot()
+    public void Dropshadow_IsFilledFalse_AppliesToStrokeSlot()
     {
         CircleRuntime sut = new();
-        // FillColor stays null by default; StrokeColor stays white by default.
+        sut.IsFilled = false;
         sut.HasDropshadow = true;
 
         sut.PreRender();
@@ -397,7 +458,7 @@ public class CircleRuntimeTests
         Circle strokeSlot = (Circle)fillSlot.Children.Single();
         fillSlot.HasDropshadow.ShouldBeTrue();
 
-        sut.FillColor = null;
+        sut.IsFilled = false;
         sut.PreRender();
 
         fillSlot.HasDropshadow.ShouldBeFalse();

--- a/Tests/SkiaGum.Tests/GueDeriving/CircleRuntimeTests.cs
+++ b/Tests/SkiaGum.Tests/GueDeriving/CircleRuntimeTests.cs
@@ -38,10 +38,10 @@ public class CircleRuntimeTests
     // CircleRuntime. The fill-hidden gate is IsFilled (defaults to true); stroke-hidden gate
     // is StrokeWidth = 0.
     [Fact]
-    public void FillColor_ShouldBeWhite_ByDefault()
+    public void FillColor_ShouldBeTransparent_ByDefault()
     {
         CircleRuntime sut = new();
-        sut.FillColor.ShouldBe(SKColors.White);
+        sut.FillColor.ShouldBe(new SKColor(0, 0, 0, 0));
     }
 
     [Fact]

--- a/Tests/SkiaGum.Tests/GueDeriving/RectangleRuntimeTests.cs
+++ b/Tests/SkiaGum.Tests/GueDeriving/RectangleRuntimeTests.cs
@@ -193,13 +193,13 @@ public class RectangleRuntimeTests
         strokeSlot.CustomRadiusBottomRight.ShouldBe(4f);
     }
 
-    // Issue #2938 — IsFilled gates dropshadow routing. RectangleRuntime defaults to
-    // IsFilled = false (stroke-only historical visual), so the shadow lands on the stroke slot
-    // by default.
+    // Issue #2938 — IsFilled gates dropshadow routing. When IsFilled = false, the shadow lands
+    // on the stroke slot (a stroke-only ring still casts a shadow).
     [Fact]
     public void Dropshadow_IsFilledFalse_AppliesToStrokeSlot()
     {
         RectangleRuntime sut = new();
+        sut.IsFilled = false;
         sut.HasDropshadow = true;
 
         sut.PreRender();
@@ -245,13 +245,22 @@ public class RectangleRuntimeTests
         strokeSlot.HasDropshadow.ShouldBeTrue();
     }
 
-    // Issue #2938 — RectangleRuntime mirrors the historical Skia default of an invisible fill
-    // (now expressed as IsFilled = false rather than FillColor = null).
+    // Issue #2938 (regression fix) — RectangleRuntime preserves the historical Skia default of
+    // an invisible fill via FillColor = transparent (alpha 0). IsFilled is true by default
+    // (base behavior), so the gate is open — assigning FillColor to a visible color lights the
+    // fill up without needing to flip IsFilled.
     [Fact]
-    public void IsFilled_ShouldBeFalse_ByDefault()
+    public void FillColor_ShouldBeTransparent_ByDefault()
     {
         RectangleRuntime sut = new();
-        sut.IsFilled.ShouldBeFalse();
+        sut.FillColor.ShouldBe(new SKColor(0, 0, 0, 0));
+    }
+
+    [Fact]
+    public void IsFilled_ShouldBeTrue_ByDefault()
+    {
+        RectangleRuntime sut = new();
+        sut.IsFilled.ShouldBeTrue();
     }
 
     // Issue #2938 — per-channel ints compose into FillColor via the same setter pipeline
@@ -353,13 +362,13 @@ public class RectangleRuntimeTests
         strokeSlot.IsOffsetAppliedForStroke.ShouldBeTrue();
     }
 
-    // Issue #2938 — IsFilled gates the fill-slot gradient. RectangleRuntime defaults to
-    // IsFilled = false so the fill-slot gradient starts off; toggling IsFilled = true lights
-    // it up.
+    // Issue #2938 — IsFilled gates the fill-slot gradient. With IsFilled = false the fill-slot
+    // gradient stays off even when UseGradient = true; toggling IsFilled = true lights it up.
     [Fact]
     public void SettingIsFilledTrue_AfterUseGradientTrue_LightsUpFillSlotGradient()
     {
         RectangleRuntime sut = new();
+        sut.IsFilled = false;
         sut.UseGradient = true;
         RoundedRectangle fillSlot = (RoundedRectangle)sut.RenderableComponent;
         fillSlot.UseGradient.ShouldBeFalse();
@@ -423,13 +432,13 @@ public class RectangleRuntimeTests
         strokeSlot.UseGradient.ShouldBeTrue();
     }
 
-    // Issue #2938 — IsFilled gates the fill-slot gradient. RectangleRuntime defaults to
-    // IsFilled = false so the fill slot stays off; the stroke slot lights up because the
-    // default StrokeWidth is 1.
+    // Issue #2938 — IsFilled gates the fill-slot gradient. With IsFilled = false the fill slot
+    // stays off; the stroke slot lights up because the default StrokeWidth is 1.
     [Fact]
     public void UseGradient_IsFilledFalse_FillSlotStaysOff()
     {
         RectangleRuntime sut = new();
+        sut.IsFilled = false;
         sut.UseGradient = true;
 
         RoundedRectangle fillSlot = (RoundedRectangle)sut.RenderableComponent;

--- a/Tests/SkiaGum.Tests/GueDeriving/RectangleRuntimeTests.cs
+++ b/Tests/SkiaGum.Tests/GueDeriving/RectangleRuntimeTests.cs
@@ -23,6 +23,7 @@ public class RectangleRuntimeTests
     public void Clone_MutatingClone_DoesNotMutateSource()
     {
         RectangleRuntime source = new();
+        source.IsFilled = true;
         source.FillColor = SKColors.Red;
         source.StrokeColor = SKColors.Blue;
 
@@ -192,8 +193,11 @@ public class RectangleRuntimeTests
         strokeSlot.CustomRadiusBottomRight.ShouldBe(4f);
     }
 
+    // Issue #2938 — IsFilled gates dropshadow routing. RectangleRuntime defaults to
+    // IsFilled = false (stroke-only historical visual), so the shadow lands on the stroke slot
+    // by default.
     [Fact]
-    public void Dropshadow_FillColorNull_AppliesToStrokeSlot()
+    public void Dropshadow_IsFilledFalse_AppliesToStrokeSlot()
     {
         RectangleRuntime sut = new();
         sut.HasDropshadow = true;
@@ -207,9 +211,10 @@ public class RectangleRuntimeTests
     }
 
     [Fact]
-    public void Dropshadow_FillColorSet_AppliesToFillSlot()
+    public void Dropshadow_IsFilledTrue_AppliesToFillSlot()
     {
         RectangleRuntime sut = new();
+        sut.IsFilled = true;
         sut.FillColor = SKColors.Red;
         sut.HasDropshadow = true;
 
@@ -225,6 +230,7 @@ public class RectangleRuntimeTests
     public void Dropshadow_TargetSwitch_ClearsPreviousSlot()
     {
         RectangleRuntime sut = new();
+        sut.IsFilled = true;
         sut.FillColor = SKColors.Red;
         sut.HasDropshadow = true;
         sut.PreRender();
@@ -232,24 +238,55 @@ public class RectangleRuntimeTests
         RoundedRectangle strokeSlot = (RoundedRectangle)fillSlot.Children.Single();
         fillSlot.HasDropshadow.ShouldBeTrue();
 
-        sut.FillColor = null;
+        sut.IsFilled = false;
         sut.PreRender();
 
         fillSlot.HasDropshadow.ShouldBeFalse();
         strokeSlot.HasDropshadow.ShouldBeTrue();
     }
 
+    // Issue #2938 — RectangleRuntime mirrors the historical Skia default of an invisible fill
+    // (now expressed as IsFilled = false rather than FillColor = null).
     [Fact]
-    public void FillColor_ShouldBeNull_ByDefault()
+    public void IsFilled_ShouldBeFalse_ByDefault()
     {
         RectangleRuntime sut = new();
-        sut.FillColor.ShouldBeNull();
+        sut.IsFilled.ShouldBeFalse();
+    }
+
+    // Issue #2938 — per-channel ints compose into FillColor via the same setter pipeline
+    // that round-trips through the fill slot.
+    [Fact]
+    public void FillChannelSetters_ComposeFillColor()
+    {
+        RectangleRuntime sut = new();
+        sut.FillRed = 10;
+        sut.FillGreen = 20;
+        sut.FillBlue = 30;
+        sut.FillAlpha = 40;
+
+        sut.FillColor.ShouldBe(new SKColor(10, 20, 30, 40));
+    }
+
+    // Issue #2938 — per-channel ints compose into StrokeColor via the same setter pipeline
+    // that round-trips through the stroke slot.
+    [Fact]
+    public void StrokeChannelSetters_ComposeStrokeColor()
+    {
+        RectangleRuntime sut = new();
+        sut.StrokeRed = 11;
+        sut.StrokeGreen = 22;
+        sut.StrokeBlue = 33;
+        sut.StrokeAlpha = 44;
+
+        sut.StrokeColor.ShouldBe(new SKColor(11, 22, 33, 44));
     }
 
     [Fact]
     public void FillColorAndStrokeColor_BothSet_PaintsEachSlotIndependently()
     {
         RectangleRuntime sut = new();
+        sut.IsFilled = true;
         sut.FillColor = SKColors.Crimson;
         sut.StrokeColor = SKColors.Cyan;
 
@@ -266,6 +303,7 @@ public class RectangleRuntimeTests
     public void FillColorAndStrokeColor_SetInReverseOrder_StillPaintsBothSlots()
     {
         RectangleRuntime sut = new();
+        sut.IsFilled = true;
         sut.StrokeColor = SKColors.Magenta;
         sut.FillColor = SKColors.Gold;
 
@@ -315,15 +353,18 @@ public class RectangleRuntimeTests
         strokeSlot.IsOffsetAppliedForStroke.ShouldBeTrue();
     }
 
+    // Issue #2938 — IsFilled gates the fill-slot gradient. RectangleRuntime defaults to
+    // IsFilled = false so the fill-slot gradient starts off; toggling IsFilled = true lights
+    // it up.
     [Fact]
-    public void SettingFillColor_AfterUseGradientTrue_LightsUpFillSlotGradient()
+    public void SettingIsFilledTrue_AfterUseGradientTrue_LightsUpFillSlotGradient()
     {
         RectangleRuntime sut = new();
         sut.UseGradient = true;
         RoundedRectangle fillSlot = (RoundedRectangle)sut.RenderableComponent;
         fillSlot.UseGradient.ShouldBeFalse();
 
-        sut.FillColor = SKColors.White;
+        sut.IsFilled = true;
 
         fillSlot.UseGradient.ShouldBeTrue();
     }
@@ -370,10 +411,10 @@ public class RectangleRuntimeTests
     }
 
     [Fact]
-    public void UseGradient_BothColorsSet_BothSlotsOn()
+    public void UseGradient_BothSlotsActive_BothSlotsOn()
     {
         RectangleRuntime sut = new();
-        sut.FillColor = SKColors.White;
+        sut.IsFilled = true;
         sut.UseGradient = true;
 
         RoundedRectangle fillSlot = (RoundedRectangle)sut.RenderableComponent;
@@ -382,8 +423,11 @@ public class RectangleRuntimeTests
         strokeSlot.UseGradient.ShouldBeTrue();
     }
 
+    // Issue #2938 — IsFilled gates the fill-slot gradient. RectangleRuntime defaults to
+    // IsFilled = false so the fill slot stays off; the stroke slot lights up because the
+    // default StrokeWidth is 1.
     [Fact]
-    public void UseGradient_FillColorNull_FillSlotStaysOff()
+    public void UseGradient_IsFilledFalse_FillSlotStaysOff()
     {
         RectangleRuntime sut = new();
         sut.UseGradient = true;

--- a/Tests/SkiaGum.Tests/GueDeriving/RectangleRuntimeTests.cs
+++ b/Tests/SkiaGum.Tests/GueDeriving/RectangleRuntimeTests.cs
@@ -256,6 +256,22 @@ public class RectangleRuntimeTests
         sut.FillColor.ShouldBe(new SKColor(0, 0, 0, 0));
     }
 
+    // Regression guard for the gallery breakage caught after PR #2939's first fix attempt:
+    // SkiaShapeRuntime.PushFillColorToSlot only runs from the FillColor / IsFilled setters,
+    // never from field init. If the ctor relies on the field default and skips the explicit
+    // FillColor assignment, the Skia RoundedRectangle renderable retains its own
+    // constructor default (SKColors.White at RoundedRectangle.cs:23) and the rectangle
+    // renders as a solid white block. The runtime property reports the transparent default
+    // — so the existing default test passes — while the actual visual is wrong. This test
+    // asserts the renderable's Color directly so the bug can't reappear silently.
+    [Fact]
+    public void FillRenderableColor_ShouldBeTransparent_ByDefault()
+    {
+        RectangleRuntime sut = new();
+        RoundedRectangle fill = (RoundedRectangle)sut.RenderableComponent;
+        fill.Color.ShouldBe(new SKColor(0, 0, 0, 0));
+    }
+
     [Fact]
     public void IsFilled_ShouldBeTrue_ByDefault()
     {

--- a/docs/gum-tool/upgrading/migrating-to-2026-may.md
+++ b/docs/gum-tool/upgrading/migrating-to-2026-may.md
@@ -307,6 +307,8 @@ Earlier in this same unreleased cycle (issue #2790 / #2814) `CircleRuntime` and 
 - **Hide fill** — set `IsFilled = false` (mirrors the Skia renderable's existing `IsFilled` toggle and survives round-tripping the color value).
 - **Hide stroke** — set `StrokeWidth = 0` (a zero-width stroke is already a no-op in every backend, so this expresses intent without a separate flag).
 
+**Default visual is unchanged:** a freshly-constructed `CircleRuntime` / `RectangleRuntime` still renders as a stroke-only outline, preserving the pre-#2938 visual that existing sample code assumes ("construct + only set `StrokeColor`"). This is achieved by defaulting `FillColor` to transparent (alpha 0) while leaving `IsFilled = true`. Assigning `FillColor` to a visible color lights up the fill without flipping `IsFilled` — so existing code like `frame.FillColor = darkGray;` continues to work.
+
 The runtimes also gain channel-decomposition setters on both colors so animations and the Gum tool's variable system can drive each channel independently:
 
 - `FillRed` / `FillGreen` / `FillBlue` / `FillAlpha` — `int`, 0-255, compose into `FillColor`.

--- a/docs/gum-tool/upgrading/migrating-to-2026-may.md
+++ b/docs/gum-tool/upgrading/migrating-to-2026-may.md
@@ -294,11 +294,39 @@ The obsoleted types and their replacements:
 ```csharp
 CircleRuntime circle = new();
 circle.FillColor = Color.Red;
-circle.StrokeColor = null; // disable the default white outline
+circle.StrokeWidth = 0; // disable the default white outline
 ```
 
 The same caveat applies anywhere you migrate a fill-only `ColoredCircleRuntime` — including the Maui / Skia counter circles in the bundled samples, which add this line for the same reason.
 {% endhint %}
+
+### Breaking: `FillColor` / `StrokeColor` are now non-nullable
+
+Earlier in this same unreleased cycle (issue #2790 / #2814) `CircleRuntime` and `RectangleRuntime` briefly exposed `FillColor` and `StrokeColor` as nullable (`Color?` on XNA-likes / Raylib, `SKColor?` on Skia), with `null` meaning "hide this slot." Issue #2938 walks that back: the properties are non-nullable again, and visibility is gated by orthogonal knobs:
+
+- **Hide fill** — set `IsFilled = false` (mirrors the Skia renderable's existing `IsFilled` toggle and survives round-tripping the color value).
+- **Hide stroke** — set `StrokeWidth = 0` (a zero-width stroke is already a no-op in every backend, so this expresses intent without a separate flag).
+
+The runtimes also gain channel-decomposition setters on both colors so animations and the Gum tool's variable system can drive each channel independently:
+
+- `FillRed` / `FillGreen` / `FillBlue` / `FillAlpha` — `int`, 0-255, compose into `FillColor`.
+- `StrokeRed` / `StrokeGreen` / `StrokeBlue` / `StrokeAlpha` — `int`, 0-255, compose into `StrokeColor`.
+
+❌ Old (the brief nullable API):
+
+```csharp
+circle.FillColor = null;    // hide the fill
+circle.StrokeColor = null;  // hide the stroke
+```
+
+✅ New:
+
+```csharp
+circle.IsFilled = false;    // hide the fill
+circle.StrokeWidth = 0;     // hide the stroke
+```
+
+This is a breaking change relative to the nullable form, but only against code written against an unreleased prerelease. Released callers were on the legacy single-slot `Color` API and are unaffected.
 
 ❌ Old:
 


### PR DESCRIPTION
## Summary

Prereq for #2931. Drops the `Color?` / `SKColor?` nullable storage on `CircleRuntime` and `RectangleRuntime` across all three backends (XNALIKE, Raylib, Skia). Replaces it with:

- `Color FillColor` (non-nullable, defaults `Color.White`)
- `Color StrokeColor` (non-nullable, defaults `Color.White`)
- `bool IsFilled` (defaults `true` on XNALIKE/Raylib; `false` on Skia `RectangleRuntime` to preserve its historical stroke-only visual) -- gates fill rendering
- Stroke gate is `StrokeWidth == 0` (existing convention, no new `HasStroke` bool)
- `FillRed/Green/Blue/Alpha` + `StrokeRed/Green/Blue/Alpha` channel-decomp ints mirroring `DropshadowRed/Green/Blue/Alpha`

This unblocks #2931 surfacing Fill/Stroke variables in the variable grid using only existing UI primitives -- channel ints can't express null, but with `IsFilled` and `StrokeWidth == 0` as the gates we no longer need a new nullable-color WPF affordance.

### Scope per #2938

- `MonoGameGum/GueDeriving/CircleRuntime.cs` -- XNALIKE + Raylib + Skia branches
- `MonoGameGum/GueDeriving/RectangleRuntime.cs` -- XNALIKE + Raylib + Skia branches
- `Runtimes/SkiaGum/GueDeriving/SkiaShapeRuntime.cs` -- non-nullable `FillColor`/`StrokeColor`/`IsFilled`/channel-decomp ints land on the base so all Skia shape runtimes inherit the new API. Removes the previously `[Obsolete]` `IsFilled` on the base; the new `IsFilled` IS the canonical version.
- Out of scope (unchanged): `ArcRuntime`, `ColoredCircleRuntime`, `RoundedRectangleRuntime`, `ColoredRectangleRuntime`. They inherit the new API for free via `SkiaShapeRuntime`; their existing tests still pass.

### Visual default change

A freshly-constructed `CircleRuntime` / `RectangleRuntime` on XNALIKE/Raylib now renders as a solid white shape with a 1 px white outline (previously: stroke-only). This matches `StandardElementsManager.AddStrokeAndFilledVariables` defaults (`IsFilled = true`) so a default Circle/Rectangle dropped from the tool renders the same as one constructed directly. Skia `RectangleRuntime` keeps its historical stroke-only default (`IsFilled = false` in the ctor); Skia `CircleRuntime` follows the new default.

### Breaking change

`Color FillColor` / `Color StrokeColor` (no `?`) is source-breaking against the unreleased nullable API that landed in the same dev cycle. No `Color?` shim is included -- per #2938, the nullable variant never shipped externally. Migration: `FillColor = null` -> `IsFilled = false`; `StrokeColor = null` -> `StrokeWidth = 0`. Documented in `docs/gum-tool/upgrading/migrating-to-2026-may.md`.

### Other fanout

- `Samples/MauiSkiaGum/MainPage.xaml.cs` -- two `StrokeColor = null` sites converted to `StrokeWidth = 0`.
- Test projects updated to drop nullable handling and use the new gates: `MonoGameGum.Tests`, `MonoGameGum.Shapes.Tests`, `Tests/SkiaGum.Tests`, `Tests/RaylibGum.Tests`.

Closes #2938.

## Test plan

- [x] `dotnet test MonoGameGum.Tests` -- 1559 pass
- [x] `dotnet test Tests/MonoGameGum.Shapes.Tests` -- 86 pass
- [x] `dotnet test Tests/SkiaGum.Tests` -- 173 pass (+2 Skia Rectangle channel-decomp parity tests)
- [x] `dotnet test Tests/RaylibGum.Tests` -- 229 pass
- [x] Zero new compiler warnings on `MonoGameGum`, `SkiaGum`, `RaylibGum`
- [x] CI runs (will populate on push)

`AllLibraries.sln` was not built on the local machine (missing FNA submodule); per-csproj builds verified. CI covers the full solution.

\U0001F916 Generated with [Claude Code](https://claude.com/claude-code)