### PR TITLE
Blazor load-UX fixes: real bug + 404-noise context

### DIFF
--- a/GumCommon/Bundle/GumBundleLoader.cs
+++ b/GumCommon/Bundle/GumBundleLoader.cs
@@ -6,65 +6,74 @@ using ToolsUtilities;
 namespace Gum.Bundle;
 
 /// <summary>
-/// Resolves whether a Gum project should load from loose `.gumx` + sibling files on disk
-/// or from a sibling `.gumpkg` bundle, and installs the <see cref="FileManager.CustomGetStreamFromFile"/>
-/// hook to serve bundle entries when needed. Per the bundle plan §4: loose wins when both exist
-/// (dev convenience / hot reload). Production publishes only the bundle.
+/// Resolves a Gum project path to either loose-file or bundle-backed loading based on the
+/// extension of <c>projectPath</c>: <c>.gumx</c> means loose, <c>.gumpkg</c> means bundle.
+/// No sibling probing happens — the caller's chosen extension is the single source of truth,
+/// which keeps behavior identical across desktop and streaming-only platforms (Blazor WASM,
+/// Android, iOS) where a probe would otherwise issue a guaranteed-404 HTTP request.
+/// When bundle mode is selected, installs <see cref="FileManager.CustomGetStreamFromFile"/>
+/// to serve bundle entries (composing with any pre-existing user hook as a fallback).
 /// </summary>
 public static class GumBundleLoader
 {
     /// <summary>
-    /// Inspects the directory containing <paramref name="gumxPath"/> for a sibling `.gumpkg`
-    /// and returns a <see cref="BundleResolution"/> describing which source the loader should use.
-    /// When bundle mode is selected, installs <see cref="FileManager.CustomGetStreamFromFile"/>
-    /// to serve bundle entries (composing with any pre-existing user hook as a fallback).
+    /// Returns a <see cref="BundleResolution"/> describing how to load <paramref name="projectPath"/>.
+    /// The extension picks the mode: <c>.gumx</c> = loose, <c>.gumpkg</c> = bundle. Any other
+    /// extension throws.
     /// </summary>
-    public static BundleResolution Resolve(string gumxPath)
+    public static BundleResolution Resolve(string projectPath)
     {
-        if (string.IsNullOrEmpty(gumxPath))
+        if (string.IsNullOrEmpty(projectPath))
         {
-            throw new ArgumentException("Gumx path must be non-empty.", nameof(gumxPath));
+            throw new ArgumentException("Project path must be non-empty.", nameof(projectPath));
         }
 
         // Normalize through FileManager so a relative input ("GumProject/GumProject.gumx")
         // resolves against FileManager.RelativeDirectory the same way GumProjectSave.Load
-        // will resolve it. Without this, a desktop app launching from its bin/ folder
-        // would probe ./GumProject/... while the deployed files live at ./Content/GumProject/...
-        // and the loader would fall through to loose-mode and fail with "not found".
-        string resolvedGumxPath = FileManager.IsRelative(gumxPath)
-            ? FileManager.MakeAbsolute(gumxPath)
-            : gumxPath;
+        // will resolve it.
+        string resolvedPath = FileManager.IsRelative(projectPath)
+            ? FileManager.MakeAbsolute(projectPath)
+            : projectPath;
 
-        // Loose wins when both exist (plan §4.1 / §4.2). File.Exists returns false on
-        // platforms without a real filesystem (Blazor WASM); on those targets the
-        // convention is "ship the bundle" so falling through to bundle mode is correct.
-        // Probing through CustomGetStreamFromFile would be unreliable: a host hook may
-        // succeed for any input (e.g. a CDN catch-all) and falsely claim loose exists.
-        if (File.Exists(resolvedGumxPath))
+        string extension = Path.GetExtension(resolvedPath);
+
+        if (string.Equals(extension, ".gumx", StringComparison.OrdinalIgnoreCase))
         {
-            return new BundleResolution(usedBundle: false, resolvedGumxPath: resolvedGumxPath, previousHook: null);
+            // Loose mode: hand the path straight to GumProjectSave.Load. No probing for a
+            // sibling .gumpkg — if the caller wanted a bundle they would have said so.
+            return new BundleResolution(usedBundle: false, resolvedGumxPath: resolvedPath, previousHook: null);
         }
 
-        string? directory = Path.GetDirectoryName(resolvedGumxPath);
-        string nameWithoutExtension = Path.GetFileNameWithoutExtension(resolvedGumxPath);
-        string bundlePath = string.IsNullOrEmpty(directory)
-            ? nameWithoutExtension + ".gumpkg"
-            : Path.Combine(directory!, nameWithoutExtension + ".gumpkg");
+        if (!string.Equals(extension, ".gumpkg", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new ArgumentException(
+                $"Project path '{projectPath}' must end with '.gumx' (loose) or '.gumpkg' (bundle).",
+                nameof(projectPath));
+        }
 
 #if !NET7_0_OR_GREATER
-        // .gumpkg loading requires System.Formats.Tar (net7+). On older targets fall back to
-        // loose-file resolution; downstream Load will surface a clear "not found" for the .gumx.
-        return new BundleResolution(usedBundle: false, resolvedGumxPath: resolvedGumxPath, previousHook: null);
+        // .gumpkg loading requires System.Formats.Tar (net7+).
+        throw new NotSupportedException(".gumpkg loading requires net7.0 or greater.");
 #else
+        // The bundle stores its own .gumx by name; the path we hand to GumProjectSave.Load is
+        // the sibling .gumx path, and the hook below intercepts that read so it's served from
+        // the bundle stream. Callers never need to know the .gumx name themselves.
+        string? directory = Path.GetDirectoryName(resolvedPath);
+        string nameWithoutExtension = Path.GetFileNameWithoutExtension(resolvedPath);
+        string gumxPath = string.IsNullOrEmpty(directory)
+            ? nameWithoutExtension + ".gumx"
+            : Path.Combine(directory!, nameWithoutExtension + ".gumx");
+
         // Read the bundle through the same file seam as the rest of the loader. On desktop
         // this is File.OpenRead; on TitleContainer-backed platforms (Blazor WASM / Android /
         // iOS) the host-installed CustomGetStreamFromFile hook routes the read through
-        // TitleContainer.OpenStream. If neither resolves the file, we silently return loose
-        // mode so the downstream "not found" path produces a familiar error.
-        Stream? bundleStream = TryOpenBundle(bundlePath);
+        // TitleContainer.OpenStream.
+        Stream? bundleStream = TryOpenBundle(resolvedPath);
         if (bundleStream == null)
         {
-            return new BundleResolution(usedBundle: false, resolvedGumxPath: resolvedGumxPath, previousHook: null);
+            throw new FileNotFoundException(
+                $"The Gum bundle '{resolvedPath}' was not found.",
+                resolvedPath);
         }
 
         GumBundle bundle;
@@ -99,7 +108,7 @@ public static class GumBundleLoader
                 incomingPath);
         };
 
-        return new BundleResolution(usedBundle: true, resolvedGumxPath: resolvedGumxPath, previousHook: previousHook);
+        return new BundleResolution(usedBundle: true, resolvedGumxPath: gumxPath, previousHook: previousHook);
 #endif
     }
 
@@ -193,10 +202,14 @@ public static class GumBundleLoader
 /// </summary>
 public class BundleResolution
 {
-    /// <summary>True if a `.gumpkg` was found and the bundle hook was installed.</summary>
+    /// <summary>True if the caller passed a `.gumpkg` and the bundle hook was installed.</summary>
     public bool UsedBundle { get; }
 
-    /// <summary>The path to pass to <c>GumProjectSave.Load</c>. Always the original `.gumx` path.</summary>
+    /// <summary>
+    /// The path to pass to <c>GumProjectSave.Load</c>. For loose mode this is the original
+    /// `.gumx` path; for bundle mode this is the synthetic `.gumx` path inside the bundle that
+    /// the installed hook will intercept.
+    /// </summary>
     public string ResolvedGumxPath { get; }
 
     /// <summary>

--- a/GumRuntime/GraphicalUiElement.cs
+++ b/GumRuntime/GraphicalUiElement.cs
@@ -7179,7 +7179,7 @@ public static class GraphicalUiElementExtensions
         var animation = graphicalUiElement.GetAnimation(index);
         if (animation == null)
         {
-            throw new ArgumentException(nameof(index), $"Could not find an animation at index {index}");
+            throw new ArgumentException(BuildMissingAnimationMessage(graphicalUiElement, index), nameof(index));
         }
         graphicalUiElement.ApplyAnimation(animation, timeInSeconds);
     }
@@ -7195,7 +7195,7 @@ public static class GraphicalUiElementExtensions
         var animation = graphicalUiElement.GetAnimation(name);
         if (animation == null)
         {
-            throw new ArgumentException(nameof(name), $"Could not find an animation with the name {name}");
+            throw new ArgumentException(BuildMissingAnimationMessage(graphicalUiElement, name), nameof(name));
         }
         graphicalUiElement.ApplyAnimation(animation, timeInSeconds);
     }
@@ -7229,7 +7229,7 @@ public static class GraphicalUiElementExtensions
         var animation = graphicalUiElement.GetAnimation(index);
         if (animation == null)
         {
-            throw new ArgumentException(nameof(index), $"Could not find an animation at the index {index}");
+            throw new ArgumentException(BuildMissingAnimationMessage(graphicalUiElement, index), nameof(index));
         }
         graphicalUiElement.PlayAnimation(animation);
     }
@@ -7244,9 +7244,31 @@ public static class GraphicalUiElementExtensions
         var animation = graphicalUiElement.GetAnimation(name);
         if (animation == null)
         {
-            throw new ArgumentException(nameof(name), $"Could not find an animation with the name {name}");
+            throw new ArgumentException(BuildMissingAnimationMessage(graphicalUiElement, name), nameof(name));
         }
         graphicalUiElement.PlayAnimation(animation);
+    }
+
+    private static string BuildMissingAnimationMessage(GraphicalUiElement graphicalUiElement, object searchKey)
+    {
+        var elementName = (graphicalUiElement.Tag as ElementSave)?.Name;
+        var elementSuffix = elementName != null ? $" for element '{elementName}'" : "";
+        var searchedFor = searchKey is string s ? $"name '{s}'" : $"index {searchKey}";
+
+        if (graphicalUiElement.Animations == null)
+        {
+            return $"No animations have been loaded{elementSuffix}. Did you call GumService.LoadAnimations(), " +
+                   $"and is the animation file (e.g. '{elementName ?? "<elementName>"}Animations.ganx') present? " +
+                   $"Searched for {searchedFor}.";
+        }
+
+        if (graphicalUiElement.Animations.Count == 0)
+        {
+            return $"The animation list{elementSuffix} is empty. Searched for {searchedFor}.";
+        }
+
+        var available = string.Join(", ", graphicalUiElement.Animations.Select(a => $"'{a.Name}'"));
+        return $"Could not find an animation with {searchedFor}{elementSuffix}. Available animations: {available}.";
     }
 
 

--- a/MonoGameGum.Tests/DataTypes/GumServiceBundleLoadTests.cs
+++ b/MonoGameGum.Tests/DataTypes/GumServiceBundleLoadTests.cs
@@ -12,7 +12,7 @@ using Xunit;
 namespace MonoGameGum.Tests.DataTypes;
 
 /// <summary>
-/// End-to-end tests for the loose-vs-bundle resolution rule (plan §4) layered on top of
+/// End-to-end tests for extension-based loose-vs-bundle resolution layered on top of
 /// <see cref="GumProjectSave.Load"/>. These exercise the full child-element walk, not just
 /// the .gumx, by reusing the GumProject.zip fixture that
 /// <see cref="GumProjectSaveTests.Load_ShouldLoadEntireProjectThroughCustomGetStreamFromFile_WhenAllFilesComeFromZip"/>
@@ -47,8 +47,10 @@ public class GumServiceBundleLoadTests : BaseTestClass, IDisposable
     }
 
     [Fact]
-    public void LoadProject_prefers_loose_provider_when_both_exist()
+    public void LoadProject_uses_loose_provider_when_caller_passes_gumx_extension()
     {
+        // Even when a sibling .gumpkg exists, passing the .gumx extension means loose-only.
+        // No probing happens; behavior matches the streaming-platform case.
         WriteEntriesAsLooseFiles(_projectDir);
         WriteBundle(_gumpkgPath, _entriesByRelativePath);
 
@@ -65,11 +67,11 @@ public class GumServiceBundleLoadTests : BaseTestClass, IDisposable
     }
 
     [Fact]
-    public void LoadProject_uses_bundle_provider_when_only_gumpkg_exists()
+    public void LoadProject_uses_bundle_provider_when_caller_passes_gumpkg_extension()
     {
         WriteBundle(_gumpkgPath, _entriesByRelativePath);
 
-        BundleResolution resolution = GumBundleLoader.Resolve(_gumxPath);
+        BundleResolution resolution = GumBundleLoader.Resolve(_gumpkgPath);
 
         resolution.UsedBundle.ShouldBeTrue();
         FileManager.CustomGetStreamFromFile.ShouldNotBeNull();
@@ -116,7 +118,7 @@ public class GumServiceBundleLoadTests : BaseTestClass, IDisposable
         File.Exists(_gumxPath).ShouldBeFalse();
 
         WriteBundle(_gumpkgPath, _entriesByRelativePath);
-        BundleResolution resolution = GumBundleLoader.Resolve(_gumxPath);
+        BundleResolution resolution = GumBundleLoader.Resolve(_gumpkgPath);
         resolution.UsedBundle.ShouldBeTrue();
 
         GumProjectSave? bundled = GumProjectSave.Load(resolution.ResolvedGumxPath, out GumLoadResult bundledResult);

--- a/MonoGameGum.Tests/ToolsUtilities/FileManagerTests.cs
+++ b/MonoGameGum.Tests/ToolsUtilities/FileManagerTests.cs
@@ -26,7 +26,11 @@ public class FileManagerTests : IDisposable
         var ex = Should.Throw<IOException>(() => FileManager.GetStreamForFile("anything.gumx"));
 
         ex.InnerException.ShouldBeOfType<FileNotFoundException>();
-        ((FileNotFoundException)ex.InnerException!).FileName.ShouldBe("anything.gumx");
+        // GetStreamForFile normalizes the path to absolute before invoking the hook so that
+        // it agrees with FileExists on what file is being asked for. The FileNotFoundException
+        // therefore carries the absolute path, not the original relative input.
+        ((FileNotFoundException)ex.InnerException!).FileName.ShouldEndWith("anything.gumx");
+        Path.IsPathRooted(((FileNotFoundException)ex.InnerException!).FileName).ShouldBeTrue();
     }
 
     [Fact]

--- a/MonoGameGum/GumService.cs
+++ b/MonoGameGum/GumService.cs
@@ -608,6 +608,17 @@ public class GumService : IGumService
                 "Did you call GumUI.Initialize with a valid .gumx first?");
         }
 
+        // Probe each element for a sibling .ganx (animation) file. Elements without
+        // animations are the common case, so most probes legitimately miss. On real
+        // filesystems the miss is silent; on browser/streaming platforms (Blazor WASM)
+        // each miss is logged by the browser as a 404 — that noise is expected and
+        // harmless. Surfaced here once so developers seeing the 404s in DevTools can
+        // connect them to this probe loop instead of chasing them as real failures.
+        Console.WriteLine(
+            "[Gum] Probing each project element for an optional sibling Animations.ganx file. " +
+            "On browser/streaming platforms (e.g. Blazor WASM) elements without animations " +
+            "will appear as 404s in the network/console log — those are expected and benign.");
+
         foreach (var element in project.AllElements)
         {
             var animation = TryLoadAnimation(element);
@@ -729,10 +740,9 @@ public class GumService : IGumService
 
         if (!string.IsNullOrEmpty(gumProjectFile))
         {
-            // Resolve loose-vs-bundle: if a sibling .gumpkg exists (and no loose .gumx),
-            // installs a CustomGetStreamFromFile hook that serves entries from the bundle.
-            // The hook stays installed so runtime asset loads (textures/fonts) also resolve
-            // from the bundle. Plan §4: loose wins when both exist.
+            // Resolve loose-vs-bundle off the file extension: ".gumx" = loose, ".gumpkg" = bundle.
+            // In bundle mode, installs a CustomGetStreamFromFile hook so runtime asset loads
+            // (textures/fonts) also resolve from the bundle.
             BundleResolution bundleResolution = GumBundleLoader.Resolve(gumProjectFile);
             gumProject = GumProjectSave.Load(bundleResolution.ResolvedGumxPath, out GumLoadResult loadResult);
             LastLoadResult = loadResult;

--- a/RenderingLibrary/Graphics/Renderer.cs
+++ b/RenderingLibrary/Graphics/Renderer.cs
@@ -1593,6 +1593,14 @@ public class CustomEffectManager
         }
         else
         {
+            // On platforms where we can't probe the filesystem (Blazor WASM, console targets),
+            // we have to attempt the load to find out if a shader is present. If none is shipped
+            // (the common case), the load fails and the browser logs the underlying 404. Surface
+            // a heads-up so developers seeing that 404 in DevTools recognize it as benign.
+            Console.WriteLine(
+                "[Gum] Attempting to load optional 'Content/Shader.xnb'. If your project does " +
+                "not ship a custom shader, any 404 for this file is expected and benign.");
+
             try
             {
                 Effect = mContentManager.Load<Effect>("Content/Shader");

--- a/Samples/MonoGameGumFromFile/MonoGameGumFromFile.sln
+++ b/Samples/MonoGameGumFromFile/MonoGameGumFromFile.sln
@@ -15,8 +15,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MonoGameGumFromFileAndroid"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MonoGameGumFromFileDX", "MonoGameGumFromFileDX\MonoGameGumFromFileDX.csproj", "{AABBE605-CF5A-4660-8547-F2EC5F9DB7D5}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SkiaGum", "..\..\SkiaGum\SkiaGum.csproj", "{40A1FD91-0471-68E9-ABEE-C7EF715BAD8C}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -66,14 +64,6 @@ Global
 		{AABBE605-CF5A-4660-8547-F2EC5F9DB7D5}.Release|Any CPU.Build.0 = Release|Any CPU
 		{AABBE605-CF5A-4660-8547-F2EC5F9DB7D5}.Release|x86.ActiveCfg = Release|Any CPU
 		{AABBE605-CF5A-4660-8547-F2EC5F9DB7D5}.Release|x86.Build.0 = Release|Any CPU
-		{40A1FD91-0471-68E9-ABEE-C7EF715BAD8C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{40A1FD91-0471-68E9-ABEE-C7EF715BAD8C}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{40A1FD91-0471-68E9-ABEE-C7EF715BAD8C}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{40A1FD91-0471-68E9-ABEE-C7EF715BAD8C}.Debug|x86.Build.0 = Debug|Any CPU
-		{40A1FD91-0471-68E9-ABEE-C7EF715BAD8C}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{40A1FD91-0471-68E9-ABEE-C7EF715BAD8C}.Release|Any CPU.Build.0 = Release|Any CPU
-		{40A1FD91-0471-68E9-ABEE-C7EF715BAD8C}.Release|x86.ActiveCfg = Release|Any CPU
-		{40A1FD91-0471-68E9-ABEE-C7EF715BAD8C}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -81,7 +71,6 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{A9FFAF36-A17C-4EDB-932D-8045FA64C487} = {396AC008-01EB-45BF-A732-F62D8A21B0A8}
 		{C20E31E6-FBED-4274-A510-9E27051AFFB5} = {396AC008-01EB-45BF-A732-F62D8A21B0A8}
-		{40A1FD91-0471-68E9-ABEE-C7EF715BAD8C} = {396AC008-01EB-45BF-A732-F62D8A21B0A8}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {FB5DB26F-B2AC-4C46-92E4-4D5D2A9DEA3A}

--- a/Tests/Gum.Bundle.Tests/GumBundleLoaderTests.cs
+++ b/Tests/Gum.Bundle.Tests/GumBundleLoaderTests.cs
@@ -36,12 +36,11 @@ public class GumBundleLoaderTests : IDisposable
     }
 
     [Fact]
-    public void Resolve_installs_hook_that_serves_child_element_files_from_bundle()
+    public void Resolve_with_gumpkg_extension_installs_hook_that_serves_child_element_files_from_bundle()
     {
         const string gumxXml = "<GumProjectSave />";
         byte[] childBytes = Encoding.UTF8.GetBytes("<ScreenSave Name=\"MainScreen\" />");
 
-        string gumxPath = Path.Combine(_tempDir, "Project.gumx");
         string gumpkgPath = Path.Combine(_tempDir, "Project.gumpkg");
         WriteBundle(gumpkgPath, new (string, byte[])[]
         {
@@ -49,7 +48,7 @@ public class GumBundleLoaderTests : IDisposable
             ("Screens/MainScreen.gusx", childBytes),
         });
 
-        BundleResolution resolution = GumBundleLoader.Resolve(gumxPath);
+        BundleResolution resolution = GumBundleLoader.Resolve(gumpkgPath);
 
         resolution.UsedBundle.ShouldBeTrue();
         FileManager.CustomGetStreamFromFile.ShouldNotBeNull();
@@ -67,30 +66,32 @@ public class GumBundleLoaderTests : IDisposable
     }
 
     [Fact]
-    public void Resolve_installs_hook_that_serves_gumx_from_bundle_when_only_gumpkg_exists()
+    public void Resolve_with_gumpkg_extension_returns_sibling_gumx_path_for_GumProjectSave_Load()
     {
+        // The bundle stores its .gumx by name; the resolved path handed to GumProjectSave.Load
+        // is the sibling .gumx path so the installed hook can intercept the read.
         byte[] gumxBytes = Encoding.UTF8.GetBytes("<GumProjectSave />");
-        string gumxPath = Path.Combine(_tempDir, "Project.gumx");
         string gumpkgPath = Path.Combine(_tempDir, "Project.gumpkg");
+        string expectedGumxPath = Path.Combine(_tempDir, "Project.gumx");
         WriteBundle(gumpkgPath, new (string, byte[])[]
         {
             ("Project.gumx", gumxBytes),
         });
 
-        BundleResolution resolution = GumBundleLoader.Resolve(gumxPath);
+        BundleResolution resolution = GumBundleLoader.Resolve(gumpkgPath);
 
         resolution.UsedBundle.ShouldBeTrue();
-        resolution.ResolvedGumxPath.ShouldBe(gumxPath);
+        resolution.ResolvedGumxPath.ShouldBe(expectedGumxPath);
         FileManager.CustomGetStreamFromFile.ShouldNotBeNull();
 
-        using Stream stream = FileManager.CustomGetStreamFromFile!(gumxPath);
+        using Stream stream = FileManager.CustomGetStreamFromFile!(expectedGumxPath);
         using MemoryStream copy = new MemoryStream();
         stream.CopyTo(copy);
         copy.ToArray().ShouldBe(gumxBytes);
     }
 
     [Fact]
-    public void Resolve_leaves_hook_untouched_when_only_gumx_exists()
+    public void Resolve_with_gumx_extension_leaves_hook_untouched()
     {
         string gumxPath = Path.Combine(_tempDir, "Project.gumx");
         File.WriteAllText(gumxPath, "<GumProjectSave />");
@@ -103,8 +104,11 @@ public class GumBundleLoaderTests : IDisposable
     }
 
     [Fact]
-    public void Resolve_prefers_loose_over_bundle_when_both_exist()
+    public void Resolve_with_gumx_extension_does_not_probe_for_sibling_gumpkg_even_when_present()
     {
+        // Cross-platform consistency: a .gumx caller gets loose mode regardless of whether a
+        // .gumpkg happens to sit next to it. This avoids the "works on desktop but 404s in
+        // Blazor" surprise the previous sibling-probing behavior caused.
         string gumxPath = Path.Combine(_tempDir, "Project.gumx");
         string gumpkgPath = Path.Combine(_tempDir, "Project.gumpkg");
         File.WriteAllText(gumxPath, "<GumProjectSave />");
@@ -120,7 +124,7 @@ public class GumBundleLoaderTests : IDisposable
     }
 
     [Fact]
-    public void Resolve_preserves_existing_user_hook_as_fallback_when_installing_bundle_hook()
+    public void Resolve_with_gumpkg_extension_preserves_existing_user_hook_as_fallback()
     {
         // User has their own hook installed (e.g. they're loading other content from a zip).
         // Bundle resolution must compose, not clobber: bundle entries come first, falls back
@@ -128,8 +132,8 @@ public class GumBundleLoaderTests : IDisposable
         byte[] gumxBytes = Encoding.UTF8.GetBytes("<GumProjectSave />");
         byte[] userBytes = Encoding.UTF8.GetBytes("from-user");
 
-        string gumxPath = Path.Combine(_tempDir, "Project.gumx");
         string gumpkgPath = Path.Combine(_tempDir, "Project.gumpkg");
+        string expectedGumxPath = Path.Combine(_tempDir, "Project.gumx");
         WriteBundle(gumpkgPath, new (string, byte[])[]
         {
             ("Project.gumx", gumxBytes),
@@ -143,13 +147,13 @@ public class GumBundleLoaderTests : IDisposable
         };
         FileManager.CustomGetStreamFromFile = userHook;
 
-        BundleResolution resolution = GumBundleLoader.Resolve(gumxPath);
+        BundleResolution resolution = GumBundleLoader.Resolve(gumpkgPath);
 
         resolution.UsedBundle.ShouldBeTrue();
         FileManager.CustomGetStreamFromFile.ShouldNotBeSameAs(userHook);
 
         // Bundle hit: served from bundle, user hook NOT called.
-        using (Stream s = FileManager.CustomGetStreamFromFile!(gumxPath))
+        using (Stream s = FileManager.CustomGetStreamFromFile!(expectedGumxPath))
         {
             using MemoryStream copy = new MemoryStream();
             s.CopyTo(copy);
@@ -169,15 +173,19 @@ public class GumBundleLoaderTests : IDisposable
     }
 
     [Fact]
-    public void Resolve_returns_not_found_when_neither_gumx_nor_gumpkg_exists()
+    public void Resolve_with_gumpkg_extension_throws_FileNotFoundException_when_bundle_missing()
     {
-        string gumxPath = Path.Combine(_tempDir, "Missing.gumx");
+        string gumpkgPath = Path.Combine(_tempDir, "Missing.gumpkg");
 
-        BundleResolution resolution = GumBundleLoader.Resolve(gumxPath);
+        Should.Throw<FileNotFoundException>(() => GumBundleLoader.Resolve(gumpkgPath));
+    }
 
-        resolution.UsedBundle.ShouldBeFalse();
-        resolution.ResolvedGumxPath.ShouldBe(gumxPath);
-        FileManager.CustomGetStreamFromFile.ShouldBeNull();
+    [Fact]
+    public void Resolve_throws_ArgumentException_for_unrecognized_extension()
+    {
+        string badPath = Path.Combine(_tempDir, "Project.gum");
+
+        Should.Throw<ArgumentException>(() => GumBundleLoader.Resolve(badPath));
     }
 
     private static void WriteBundle(string path, IEnumerable<(string, byte[])> entries)

--- a/ToolsUtilities/FileManager.cs
+++ b/ToolsUtilities/FileManager.cs
@@ -776,6 +776,18 @@ namespace ToolsUtilities
                 fileName = TryRemoveLeadingDotSlash(fileName);
 			    return Microsoft.Xna.Framework.TitleContainer.OpenStream(fileName);
 #else
+                // Normalize to an absolute path BEFORE handing off — both for the host-installed
+                // CustomGetStreamFromFile hook and for the direct File.OpenRead fallback. FileExists
+                // already does this via Standardize(makeAbsolute: true); keeping the two APIs in
+                // lockstep is important because callers commonly do FileExists(p) then
+                // GetStreamForFile(p). If they disagreed on path shape, the hook would see two
+                // different strings for the same logical file — the exact bug that caused
+                // ".ganx FileExists succeeds, then XmlDeserialize 404s" on Blazor WASM.
+                if (IsRelative(fileName))
+                {
+                    fileName = FileManager.MakeAbsolute(fileName);
+                }
+
                 if (CustomGetStreamFromFile != null)
                 {
                     var customStream = CustomGetStreamFromFile(fileName);
@@ -787,11 +799,6 @@ namespace ToolsUtilities
                 }
                 else
                 {
-                    if (IsRelative(fileName))
-                    {
-                        fileName = FileManager.MakeAbsolute(fileName);
-                    }
-
                     fileName = fileName.Replace('\\', Path.DirectorySeparatorChar)
                         .Replace('/', Path.DirectorySeparatorChar);
 


### PR DESCRIPTION
## Summary

Five small, independently-reviewable commits that improve Gum's loading UX, primarily on Blazor WASM. All discovered while debugging a real Blazor StocksGame project — one fixes a load-blocking bug, the rest reduce or contextualize cosmetic console noise that was sending developers down wrong rabbit-holes.

## Commits

### `Improve PlayAnimation/ApplyAnimation error messages`
The previous throw was a single `"Could not find an animation with the name X"` that conflated three distinct failure modes. Now distinguishes:
- `Animations` list is null (no .ganx loaded for this element) — explains the convention and reminds about `GumService.LoadAnimations`.
- List is empty.
- List has entries but no name match — lists the available names so typos are obvious.

Also corrects a latent bug: the original throws had `ArgumentException(paramName, message)` argument order swapped (first ctor arg is message, second is param name).

### `Dispatch GumBundleLoader.Resolve on file extension`
Removes the sibling-probing rule ("if a .gumpkg sits next to the .gumx, use the bundle"). Replaces it with explicit extension dispatch — `.gumx` means loose, `.gumpkg` means bundle, anything else throws `ArgumentException`. Same behavior on desktop and streaming platforms.

Motivation: on Blazor, sibling probing meant a guaranteed-404 HTTP request to `<project>.gumpkg` on every load of a loose project, and "loose wins when both exist" was unobservable anyway because `File.Exists` returns false. The probe was paying a universal cost for an unobservable benefit. Authors now express intent by naming the file they actually ship.

- `.gumx` → loose mode, no probe.
- `.gumpkg` → bundle mode; `FileNotFoundException` if the bundle is missing.
- `BundleResolution.ResolvedGumxPath` in bundle mode is now the synthetic sibling `.gumx` path inside the bundle (the installed hook intercepts identically).

Tests rewritten to pass the explicit extension. The "prefers loose over bundle when both exist" scenario is replaced by "passing `.gumx` skips probing even when a `.gumpkg` sits next to it" plus a new `ArgumentException` test for unrecognized extensions.

Also bundles a `Console.WriteLine` heads-up before `LoadAnimations`' per-element probe loop, explaining that 404s for elements without animations are expected on browser/streaming platforms (next item describes the equivalent for the shader).

### `Normalize path before invoking CustomGetStreamFromFile hook`
**This is the real bug** that was producing an uncaught `ManagedError` on every load in the StocksGame project.

`FileManager.GetStreamForFile` was only running `MakeAbsolute` in the no-hook branch. When a host (KNI on Blazor) installs `CustomGetStreamFromFile`, the hook received the raw caller-supplied path while `FileManager.FileExists` already standardized via `Standardize(makeAbsolute: true)`. The two APIs therefore handed the same hook two different strings for the same logical file.

Visible symptom (Blazor WASM):
1. `TryLoadAnimation` calls `FileExists("Screens/GameplayScreenAnimations.ganx")` — hook receives the absolute URL `Content/Gummy/Screens/...`, succeeds, returns true.
2. Then calls `XmlDeserialize("Screens/...")` → `GetStreamForFile` passes the raw relative path to the hook, which fetches `/Screens/...` (no `Content/Gummy/` prefix), 404s, and throws.

Fix: `MakeAbsolute` before invoking the hook, mirroring `FileExists`. Updated the `FileManagerTests` assertion that captured the previous bug (it asserted the raw relative path was preserved on the `FileNotFoundException.FileName`; now asserts `EndsWith` + `IsPathRooted`).

### `Remove stale SkiaGum reference from MonoGameGumFromFile.sln`
Unrelated tidy-up: drops the `SkiaGum` project entry, its configuration mappings, and the nesting entry from the sample's solution.

### `Annotate optional Shader.xnb load as expected on browser platforms`
On Blazor WASM, `Renderer.Initialize` falls through `_canCheckFileExists` because none of `OperatingSystem.IsWindows()`/`Linux()`/`MacOS()` are true in the browser. The optional shader load then happens, and the underlying XHR 404s if no shader is shipped — the C# try/catches it, but the browser logs the 404 in DevTools before our catch fires.

`Console.WriteLine` immediately before the load on the no-filesystem branch, labeling the 404 as benign. Uses `Console.WriteLine` (not `Debug.WriteLine`) so the message is present in Release builds too — devs with DevTools open against deployed builds are part of the audience.

## Test results

All 1547 tests in `MonoGameGum.Tests` pass; all 61 in `Gum.Bundle.Tests` pass.

## Related

Filed [#2940](https://github.com/vchelaru/Gum/issues/2940) for the bigger follow-up: promote `IGumFileProvider` to the canonical runtime file seam, give `FileManager` an enumeration API, and switch `LoadAnimations` from per-element probing to provider enumeration so bundle-mode projects on Blazor produce zero 404s. That work is out of scope for this PR but the issue captures the design decisions we reached together.

## Test plan

- [x] `dotnet test` on `MonoGameGum.Tests` — confirm 1547/1547 still passes.
- [x] `dotnet test` on `Tests/Gum.Bundle.Tests` — confirm 61/61.
- [x] Spot-check a Blazor-WASM project loads cleanly with a loose `.gumx` (no `.gumpkg` 404 in DevTools).
- [x] Spot-check that an intentional animation typo in `PlayAnimation("…")` now lists available names in the exception.
- [x] Spot-check `MonoGameGumFromFile.sln` opens without SkiaGum and builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
