### PR TITLE
#2942: Stop ListBox.SelectionChanged from double-firing on clicks

### DIFF
--- a/MonoGameGum.Tests/Forms/ListBoxTests.cs
+++ b/MonoGameGum.Tests/Forms/ListBoxTests.cs
@@ -62,6 +62,168 @@ public class ListBoxTests : BaseTestClass
     }
 
     [Fact]
+    public void Click_ShouldFireSelectionChangedOncePerClick()
+    {
+        // Repro for issue #2942: SelectionChanged fires once on the first click but
+        // twice on every subsequent click that changes which item is selected. The
+        // second fire comes from SyncIsSelectedFromSelectedItems detecting that the
+        // previously-selected item needs to have its IsSelected cleared.
+        ListBox listBox = new();
+        listBox.AddToRoot();
+        for (int i = 0; i < 5; i++)
+        {
+            listBox.Items!.Add(i);
+        }
+
+        int fireCount = 0;
+        listBox.SelectionChanged += (_, _) => fireCount++;
+
+        Mock<ICursor> firstCursor = SetupForPushOnItem(listBox, itemIndex: 0);
+        firstCursor.SetupProperty(x => x.VisualOver);
+        firstCursor.SetupProperty(x => x.WindowPushed);
+
+        GueInteractiveExtensionMethods.DoUiActivityRecursively(
+            listBox.Visual,
+            firstCursor.Object,
+            null!,
+            0);
+
+        fireCount.ShouldBe(1);
+
+        Mock<ICursor> secondCursor = SetupForPushOnItem(listBox, itemIndex: 1);
+        secondCursor.SetupProperty(x => x.VisualOver);
+        secondCursor.SetupProperty(x => x.WindowPushed);
+
+        GueInteractiveExtensionMethods.DoUiActivityRecursively(
+            listBox.Visual,
+            secondCursor.Object,
+            null!,
+            0);
+
+        fireCount.ShouldBe(2);
+    }
+
+    [Fact]
+    public void Click_ShouldRaiseSelectionChanged_WithExpectedArgs()
+    {
+        // Pin args content on the click path so the fix for issue #2942 doesn't
+        // accidentally drop the previously-selected item from RemovedItems.
+        ListBox listBox = new();
+        listBox.AddToRoot();
+        for (int i = 0; i < 3; i++)
+        {
+            listBox.Items!.Add("Item " + i);
+        }
+
+        listBox.SelectedIndex = 0;
+
+        SelectionChangedEventArgs? capturedArgs = null;
+        listBox.SelectionChanged += (_, args) => capturedArgs = args;
+
+        Mock<ICursor> cursor = SetupForPushOnItem(listBox, itemIndex: 1);
+        cursor.SetupProperty(x => x.VisualOver);
+        cursor.SetupProperty(x => x.WindowPushed);
+
+        GueInteractiveExtensionMethods.DoUiActivityRecursively(
+            listBox.Visual,
+            cursor.Object,
+            null!,
+            0);
+
+        capturedArgs.ShouldNotBeNull();
+        capturedArgs.AddedItems.Count.ShouldBe(1);
+        capturedArgs.AddedItems[0]!.ShouldBe("Item 1");
+        capturedArgs.RemovedItems.Count.ShouldBe(1);
+        capturedArgs.RemovedItems[0]!.ShouldBe("Item 0");
+    }
+
+    [Fact]
+    public void MultipleMode_ClickToggle_ShouldFireSelectionChangedOncePerClick()
+    {
+        // Multiple-mode toggle-off goes through HandleItemSelected and then
+        // SyncIsSelectedFromSelectedItems, which is the double-fire vector for #2942.
+        ListBox listBox = new() { SelectionMode = SelectionMode.Multiple };
+        listBox.AddToRoot();
+        for (int i = 0; i < 3; i++)
+        {
+            listBox.Items!.Add("Item " + i);
+        }
+
+        int fireCount = 0;
+        listBox.SelectionChanged += (_, _) => fireCount++;
+
+        Mock<ICursor> firstCursor = SetupForPushOnItem(listBox, itemIndex: 0);
+        firstCursor.SetupProperty(x => x.VisualOver);
+        firstCursor.SetupProperty(x => x.WindowPushed);
+
+        GueInteractiveExtensionMethods.DoUiActivityRecursively(
+            listBox.Visual,
+            firstCursor.Object,
+            null!,
+            0);
+
+        fireCount.ShouldBe(1);
+
+        // Click the same item again to toggle it off — this is where Sync detects
+        // a flipped IsSelected and (pre-fix) raises a second SelectionChanged.
+        Mock<ICursor> toggleCursor = SetupForPushOnItem(listBox, itemIndex: 0);
+        toggleCursor.SetupProperty(x => x.VisualOver);
+        toggleCursor.SetupProperty(x => x.WindowPushed);
+
+        GueInteractiveExtensionMethods.DoUiActivityRecursively(
+            listBox.Visual,
+            toggleCursor.Object,
+            null!,
+            0);
+
+        fireCount.ShouldBe(2);
+    }
+
+    [Fact]
+    public void SelectedIndex_set_ShouldFireSelectionChangedOncePerAssignment()
+    {
+        ListBox listBox = new();
+        for (int i = 0; i < 3; i++)
+        {
+            listBox.Items!.Add("Item " + i);
+        }
+
+        int fireCount = 0;
+        listBox.SelectionChanged += (_, _) => fireCount++;
+
+        listBox.SelectedIndex = 0;
+        fireCount.ShouldBe(1);
+
+        listBox.SelectedIndex = 1;
+        fireCount.ShouldBe(2);
+
+        listBox.SelectedIndex = -1;
+        fireCount.ShouldBe(3);
+    }
+
+    [Fact]
+    public void SelectedObject_set_ShouldFireSelectionChangedOncePerAssignment()
+    {
+        ListBox listBox = new();
+        for (int i = 0; i < 3; i++)
+        {
+            listBox.Items!.Add("Item " + i);
+        }
+
+        int fireCount = 0;
+        listBox.SelectionChanged += (_, _) => fireCount++;
+
+        listBox.SelectedObject = "Item 0";
+        fireCount.ShouldBe(1);
+
+        listBox.SelectedObject = "Item 1";
+        fireCount.ShouldBe(2);
+
+        listBox.SelectedObject = null;
+        fireCount.ShouldBe(3);
+    }
+
+    [Fact]
     public void Click_ShouldSelect_IfEnabled()
     {
         ListBox listBox = new();

--- a/MonoGameGum/Forms/Controls/ListBox.cs
+++ b/MonoGameGum/Forms/Controls/ListBox.cs
@@ -825,8 +825,11 @@ public class ListBox : ItemsControl, IInputReceiver
 
         _suppressSelectionSync = false;
 
-        // Sync IsSelected state for all ListBoxItems
-        SyncIsSelectedFromSelectedItems();
+        // Sync IsSelected state for all ListBoxItems. Skip raising SelectionChanged
+        // from inside the sync — this handler already raises it below with the same
+        // added/removed items, so letting Sync raise too would double-fire the event
+        // on every click that changes the selection (issue #2942).
+        SyncIsSelectedFromSelectedItems(raiseSelectionChanged: false);
 
         // Fire SelectionChanged event
         if (args.AddedItems.Count > 0 || args.RemovedItems.Count > 0)
@@ -949,7 +952,7 @@ public class ListBox : ItemsControl, IInputReceiver
     /// <summary>
     /// Synchronizes the IsSelected state of all ListBoxItems based on the SelectedItems collection.
     /// </summary>
-    private void SyncIsSelectedFromSelectedItems()
+    private void SyncIsSelectedFromSelectedItems(bool raiseSelectionChanged = true)
     {
         if (_suppressSelectionSync)
         {
@@ -988,7 +991,8 @@ public class ListBox : ItemsControl, IInputReceiver
         selectedIndex = SelectedIndex;
 
         // Fire SelectionChanged event if there were changes
-        if (selectionChangedArgs.AddedItems.Count > 0 || selectionChangedArgs.RemovedItems.Count > 0)
+        if (raiseSelectionChanged &&
+            (selectionChangedArgs.AddedItems.Count > 0 || selectionChangedArgs.RemovedItems.Count > 0))
         {
             SelectionChanged?.Invoke(this, selectionChangedArgs);
         }


### PR DESCRIPTION
Closes #2942.

## Summary
- `ListBox.HandleItemSelected` raised `SelectionChanged` once with the correct added/removed args, then called `SyncIsSelectedFromSelectedItems` which raised it again whenever it had to clear `IsSelected` on a previously-selected item. Result: one fire on the first click, two on every subsequent click — matching the user-reported 1, 3, 5, ... counter.
- Added a `raiseSelectionChanged` parameter (default `true`) to `SyncIsSelectedFromSelectedItems`. The `SelectedObject` / `SelectedIndex` setter paths keep the default — they're the only event-firer on that path so they must still raise. `HandleItemSelected` passes `false` since it raises the event itself with equivalent args.
- `SyncIsSelectedFromSelectedItems` is `private`, so no public/virtual surface changed.

## Tests
- `Click_ShouldFireSelectionChangedOncePerClick` — Single-mode click that replaces the selected item.
- `Click_ShouldRaiseSelectionChanged_WithExpectedArgs` — pins added/removed contents on a transitioning click so the fix can't silently drop the removed item.
- `MultipleMode_ClickToggle_ShouldFireSelectionChangedOncePerClick` — Multiple-mode toggle-off (the other path that flips `IsSelected` and previously double-fired).
- `SelectedIndex_set_ShouldFireSelectionChangedOncePerAssignment` and `SelectedObject_set_ShouldFireSelectionChangedOncePerAssignment` — pin the setter paths so the suppression flag can't drift to suppress those too.

## Test plan
- [x] New tests fail pre-fix for the right reason (Single repro: `fireCount was 3, want 2`; Multiple toggle: same)
- [x] New tests pass post-fix
- [x] Full `MonoGameGum.Tests` suite green (1564/1564)

🤖 Generated with [Claude Code](https://claude.com/claude-code)