### PR TITLE
Fix Apos.Shapes gradient not rotating with shape

### DIFF
--- a/Runtimes/GumShapes/Renderables/Circle.cs
+++ b/Runtimes/GumShapes/Renderables/Circle.cs
@@ -101,10 +101,11 @@ public class Circle : RenderableShapeBase,
             RenderInternal(sb, shadowLeft, shadowTop, dropshadowCenter, radius - DropshadowBlurX / 2f,
                 MathFunctions.RoundToInt(DropshadowBlurX),
                 StrokeWidth - DropshadowBlurX,
+                rotationRadians,
                 EffectiveDropshadowColor);
         }
 
-        RenderInternal(sb, absoluteLeft, absoluteTop, center, radius, IsAntialiased ? 1 : 0, StrokeWidth);
+        RenderInternal(sb, absoluteLeft, absoluteTop, center, radius, IsAntialiased ? 1 : 0, StrokeWidth, rotationRadians);
     }
 
     private void RenderInternal(ShapeBatch sb,
@@ -114,11 +115,12 @@ public class Circle : RenderableShapeBase,
         float radius,
         int antiAliasSize,
         float strokeWidth,
+        float rotationRadians,
         Color? forcedColor = null)
     {
         if (!IsFilled && StrokeDashLength > 0 && StrokeGapLength > 0 && strokeWidth > 0 && radius > 0)
         {
-            RenderDashed(sb, absoluteLeft, absoluteTop, center, radius, antiAliasSize, strokeWidth, forcedColor);
+            RenderDashed(sb, absoluteLeft, absoluteTop, center, radius, antiAliasSize, strokeWidth, rotationRadians, forcedColor);
             return;
         }
 
@@ -151,7 +153,7 @@ public class Circle : RenderableShapeBase,
 
             if (UseGradient && forcedColor == null)
             {
-                var gradient = base.GetGradient(absoluteLeft, absoluteTop);
+                var gradient = base.GetGradient(absoluteLeft, absoluteTop, rotationRadians);
 
                 sb.DrawCircle(
                     center,
@@ -177,7 +179,7 @@ public class Circle : RenderableShapeBase,
         {
             if(UseGradient && forcedColor == null)
             {
-                var gradient = base.GetGradient(absoluteLeft, absoluteTop);
+                var gradient = base.GetGradient(absoluteLeft, absoluteTop, rotationRadians);
 
                 var transparentGradient = gradient;
                 transparentGradient.AC = new Color((int)gradient.AC.R, gradient.AC.G, gradient.AC.B, 0);
@@ -222,6 +224,7 @@ public class Circle : RenderableShapeBase,
         float radius,
         int antiAliasSize,
         float strokeWidth,
+        float rotationRadians,
         Color? forcedColor)
     {
         // Apos.Shapes 0.6.x DrawRing parameter naming is misleading - despite being called
@@ -250,7 +253,7 @@ public class Circle : RenderableShapeBase,
         // space gradient rather than restarting per-segment). GetGradient already returns world
         // coords, mirroring how upstream's DrawDashedCircle calls GradientToWorld + IsLocal=false.
         Gradient? gradient = (UseGradient && forcedColor == null)
-            ? base.GetGradient(absoluteLeft, absoluteTop)
+            ? base.GetGradient(absoluteLeft, absoluteTop, rotationRadians)
             : null;
         var color = forcedColor ?? Color;
 

--- a/Runtimes/GumShapes/Renderables/RenderableShapeBase.cs
+++ b/Runtimes/GumShapes/Renderables/RenderableShapeBase.cs
@@ -479,7 +479,7 @@ public abstract class RenderableShapeBase : RenderableBase
         OnPreRender?.Invoke();
     }
 
-    protected Gradient GetGradient(float absoluteLeft, float absoluteTop)
+    protected Gradient GetGradient(float absoluteLeft, float absoluteTop, float rotationRadians = 0f)
     {
         var firstColor = new Microsoft.Xna.Framework.Color(
                 (byte)Red1, (byte)Green1, (byte)Blue1, (byte)Alpha1);
@@ -516,6 +516,14 @@ public abstract class RenderableShapeBase : RenderableBase
         }
 
 
+        // The gradient is object-space-anchored: endpoints are computed in unrotated
+        // bounding-box coordinates above, then rotated around the GUE rotation pivot
+        // (absoluteLeft, absoluteTop) so the gradient travels with the shape as it
+        // rotates. Apos.Shapes interprets the endpoints in world coords (IsLocal=false,
+        // the default) and does NOT itself rotate the gradient with the shape's rotation
+        // parameter, so the rotation has to be applied here before construction.
+        var pivot = new Vector2(absoluteLeft, absoluteTop);
+
         if(_gradientType == GradientType.Linear)
         {
             var effectiveGradientX2 = absoluteLeft + GradientX2;
@@ -545,11 +553,10 @@ public abstract class RenderableShapeBase : RenderableBase
                     break;
             }
 
-            return new Gradient(new Vector2(effectiveGradientX1, effectiveGradientY1),
-                firstColor,
-                new Vector2(effectiveGradientX2, effectiveGradientY2),
-                secondColor
-                );
+            var pointA = RotateAround(new Vector2(effectiveGradientX1, effectiveGradientY1), pivot, rotationRadians);
+            var pointB = RotateAround(new Vector2(effectiveGradientX2, effectiveGradientY2), pivot, rotationRadians);
+
+            return new Gradient(pointA, firstColor, pointB, secondColor);
         }
         else
         {
@@ -559,30 +566,16 @@ public abstract class RenderableShapeBase : RenderableBase
             var effectiveGradientX2 = effectiveGradientX1 + effectiveOuterRadius;
             var effectiveGradientY2 = effectiveGradientY1;
 
-            return new Gradient(new Vector2(effectiveGradientX1, effectiveGradientY1),
+            var pointA = RotateAround(new Vector2(effectiveGradientX1, effectiveGradientY1), pivot, rotationRadians);
+            var pointB = RotateAround(new Vector2(effectiveGradientX2, effectiveGradientY2), pivot, rotationRadians);
+
+            return new Gradient(pointA,
                 firstColor,
-                new Vector2(effectiveGradientX2, effectiveGradientY2),
+                pointB,
                 secondColor,
                 s:Gradient.Shape.Radial,
                 aOffset:effectiveInnerRadius);
         }
-
-        // todo - eventually support rotation
-        //var rectToUse = boundingRect;
-        //if (absoluteRotation != 0)
-        //{
-        //    rectToUse = Unrotate(boundingRect, absoluteRotation);
-        //}
-        //else
-        //{
-        //    // If we apply rotation, then the camera coordinates are adjusted such that the gradient coordiantes are relative to the object.
-        //    // Otherwise, they are not so we need to offset:
-        //    effectiveGradientX1 += rectToUse.Left;
-        //    effectiveGradientY1 += rectToUse.Top;
-        //    effectiveGradientX2 += rectToUse.Left;
-        //    effectiveGradientY2 += rectToUse.Top;
-        //}
-
     }
 
     internal static float ResolveRadius(float value, DimensionUnitType units, float width)
@@ -653,6 +646,28 @@ public abstract class RenderableShapeBase : RenderableBase
         return new Vector2(
             absoluteLeft + halfW * cos - halfH * sin,
             absoluteTop + halfW * sin + halfH * cos);
+    }
+
+    /// <summary>
+    /// Rotates <paramref name="point"/> around <paramref name="pivot"/> by
+    /// <paramref name="rotationRadians"/>. Shared math used by the dashed-stroke perimeter
+    /// walk (RoundedRectangle) and by <see cref="GetGradient"/> when rotating gradient
+    /// endpoints so the gradient stays anchored to object-local space instead of the
+    /// unrotated bounding box.
+    /// </summary>
+    public static Vector2 RotateAround(Vector2 point, Vector2 pivot, float rotationRadians)
+    {
+        if (rotationRadians == 0f)
+        {
+            return point;
+        }
+        var cos = (float)System.Math.Cos(rotationRadians);
+        var sin = (float)System.Math.Sin(rotationRadians);
+        var dx = point.X - pivot.X;
+        var dy = point.Y - pivot.Y;
+        return new Vector2(
+            pivot.X + dx * cos - dy * sin,
+            pivot.Y + dx * sin + dy * cos);
     }
 
     public override string BatchKey => "Apos.Shapes";

--- a/Runtimes/GumShapes/Renderables/RoundedRectangle.cs
+++ b/Runtimes/GumShapes/Renderables/RoundedRectangle.cs
@@ -132,7 +132,7 @@ public class RoundedRectangle : RenderableShapeBase,
         {
             if (UseGradient && forcedColor == null)
             {
-                var gradient = base.GetGradient(absoluteLeft, absoluteTop);
+                var gradient = base.GetGradient(absoluteLeft, absoluteTop, rotationRadians);
 
                 if (hasCustomCorners)
                     sb.DrawRectangle(position, size, gradient, gradient, thickness, corners, rotationRadians, antiAliasSize);
@@ -152,7 +152,7 @@ public class RoundedRectangle : RenderableShapeBase,
         {
             if(UseGradient && forcedColor == null)
             {
-                var gradient = base.GetGradient(absoluteLeft, absoluteTop);
+                var gradient = base.GetGradient(absoluteLeft, absoluteTop, rotationRadians);
 
                 var transparentGradient = gradient;
                 transparentGradient.AC = new Color((int)gradient.AC.R, gradient.AC.G, gradient.AC.B, 0);
@@ -215,7 +215,7 @@ public class RoundedRectangle : RenderableShapeBase,
         // Apos.Shapes overloads accept either, so we forward whichever fits.
         var fallbackColor = forcedColor ?? Color;
         Gradient strokeGradient = (UseGradient && forcedColor == null)
-            ? base.GetGradient(absoluteLeft, absoluteTop)
+            ? base.GetGradient(absoluteLeft, absoluteTop, rotationRadians)
             : new Gradient(Vector2.Zero, fallbackColor, Vector2.Zero, fallbackColor, Gradient.Shape.None);
 
         var halfT = strokeWidth / 2f;

--- a/Samples/GumShapesGallery/GumShapesGalleryCommon/Screens/CirclesScreen.cs
+++ b/Samples/GumShapesGallery/GumShapesGalleryCommon/Screens/CirclesScreen.cs
@@ -50,6 +50,7 @@ internal class CirclesScreen : FrameworkElement
         left.AddChild(BuildSection("Stroke width", BuildStrokeWidthRow()));
         left.AddChild(BuildSection("Alignment", BuildAlignmentRow()));
         left.AddChild(BuildSection("Gradients", BuildGradientRow()));
+        left.AddChild(BuildSection("Rotation", BuildRotationRow()));
 
         right.AddChild(BuildSection("Antialiasing", BuildAntialiasingRow()));
         right.AddChild(BuildSection("Dropshadow", BuildDropshadowRow()));
@@ -489,6 +490,47 @@ internal class CirclesScreen : FrameworkElement
         circle.StrokeColor = Color.Yellow;
         circle.StrokeWidth = strokeWidth;
         circle.StrokeWidthUnits = DimensionUnitType.Absolute;
+        frame.Children.Add(circle);
+        return frame;
+    }
+
+    // Rotation row — black→white horizontal gradient on circles, rotated in 60° steps
+    // (0/60/120/180). Plain circles are rotation-symmetric, so the gradient is what makes
+    // the rotation visible. Endpoints are 0→20 px (less than the 56 px diameter) so the
+    // transition is concentrated in a narrow band — the resulting hard light/dark edge
+    // makes the rotation angle obvious. Cells use a fixed-size frame because Rotation
+    // pushes content outside the natural bounding box, which breaks the
+    // RelativeToChildren row sizing. Mirrors the same row on the SilkNet and raylib sides.
+    static ContainerRuntime BuildRotationRow()
+    {
+        ContainerRuntime row = BuildHorizontalRow();
+        foreach (float rotation in new[] { 0f, 60f, 120f, 180f })
+        {
+            row.AddChild(BuildRotatedGradientCircleCell(rotation));
+        }
+        return row;
+    }
+
+    static RectangleRuntime BuildRotatedGradientCircleCell(float rotation)
+    {
+        RectangleRuntime frame = new();
+        frame.Width = 70;
+        frame.Height = 70;
+        frame.FillColor = new Color(60, 60, 80);
+
+        CircleRuntime circle = new();
+        circle.Radius = 28;
+        circle.XOrigin = HorizontalAlignment.Center;
+        circle.XUnits = Gum.Converters.GeneralUnitType.PixelsFromMiddle;
+        circle.YOrigin = VerticalAlignment.Center;
+        circle.YUnits = Gum.Converters.GeneralUnitType.PixelsFromMiddle;
+        circle.UseGradient = true;
+        circle.GradientType = GradientType.Linear;
+        circle.Color1 = Color.Black;
+        circle.Color2 = Color.White;
+        circle.GradientX1 = 0; circle.GradientY1 = 0;
+        circle.GradientX2 = 20; circle.GradientY2 = 0;
+        circle.Rotation = rotation;
         frame.Children.Add(circle);
         return frame;
     }

--- a/Samples/GumShapesGallery/GumShapesGalleryCommon/Screens/RectanglesScreen.cs
+++ b/Samples/GumShapesGallery/GumShapesGalleryCommon/Screens/RectanglesScreen.cs
@@ -56,6 +56,7 @@ internal class RectanglesScreen : FrameworkElement
         right.AddChild(BuildSection("Dashed strokes (solid / 6/4 / 2/2 dotted / long-dash) — stroke-only push (#2818)", BuildDashedStrokeRow()));
         right.AddChild(BuildSection("FillColor + StrokeColor on the same instance — both layers render simultaneously (#2768 / #2814)", BuildBothColorsRow()));
         right.AddChild(BuildSection("Inscribed in a 64x64 frame — stroke must stay inside the gray rectangle's bounds at every StrokeWidth (#2768 / #2814 visual contract; mirrors SilkNetGum)", BuildInscribedRow()));
+        right.AddChild(BuildSection("Rotation (0 / 60 / 120 / 180 degrees) — black→white gradient rectangles", BuildRotationRow()));
     }
 
     static ContainerRuntime BuildColumn()
@@ -429,6 +430,48 @@ internal class RectanglesScreen : FrameworkElement
             row.AddChild(BuildInscribedCell(strokeWidth));
         }
         return row;
+    }
+
+    // Rotation row — black→white horizontal gradient on rectangles, rotated in 60° steps
+    // (0/60/120/180). Gradient endpoints are 0→20 px (less than the 70 px width) so the
+    // transition is concentrated in a narrow band; the resulting hard light/dark edge
+    // makes the rotation angle obvious. Cells wrap each rotated rectangle in a fixed-size
+    // frame because Rotation pushes content outside the natural bounding box, which
+    // breaks RelativeToChildren row sizing. 100x100 frame is sized to contain a 70x50
+    // rectangle at any rotation. Mirrors the same row on the SilkNet and raylib sides.
+    static ContainerRuntime BuildRotationRow()
+    {
+        ContainerRuntime row = BuildHorizontalRow();
+        foreach (float rotation in new[] { 0f, 60f, 120f, 180f })
+        {
+            row.AddChild(BuildRotatedGradientRectCell(rotation));
+        }
+        return row;
+    }
+
+    static RectangleRuntime BuildRotatedGradientRectCell(float rotation)
+    {
+        RectangleRuntime frame = new();
+        frame.Width = 100;
+        frame.Height = 100;
+        frame.FillColor = new Color(60, 60, 80);
+
+        RectangleRuntime rect = new();
+        rect.Width = 70;
+        rect.Height = 50;
+        rect.XOrigin = HorizontalAlignment.Center;
+        rect.XUnits = Gum.Converters.GeneralUnitType.PixelsFromMiddle;
+        rect.YOrigin = VerticalAlignment.Center;
+        rect.YUnits = Gum.Converters.GeneralUnitType.PixelsFromMiddle;
+        rect.UseGradient = true;
+        rect.GradientType = GradientType.Linear;
+        rect.Color1 = Color.Black;
+        rect.Color2 = Color.White;
+        rect.GradientX1 = 0; rect.GradientY1 = 0;
+        rect.GradientX2 = 20; rect.GradientY2 = 0;
+        rect.Rotation = rotation;
+        frame.Children.Add(rect);
+        return frame;
     }
 
     static RectangleRuntime BuildInscribedCell(float strokeWidth)

--- a/Samples/SilkNetGum/SilkNetGum/Screens/CirclesScreen.cs
+++ b/Samples/SilkNetGum/SilkNetGum/Screens/CirclesScreen.cs
@@ -45,6 +45,7 @@ internal class CirclesScreen : GraphicalUiElement
         left.Children.Add(BuildSection("Stroke width", BuildStrokeWidthRow()));
         left.Children.Add(BuildSection("Alignment", BuildAlignmentRow()));
         left.Children.Add(BuildSection("Gradients", BuildGradientRow()));
+        left.Children.Add(BuildSection("Rotation", BuildRotationRow()));
 
         right.Children.Add(BuildSection("Antialiasing", BuildAntialiasingRow()));
         right.Children.Add(BuildSection("Dropshadow", BuildDropshadowRow()));
@@ -476,6 +477,47 @@ internal class CirclesScreen : GraphicalUiElement
         row.Width = 0;
         row.Height = 0;
         return row;
+    }
+
+    // Rotation row — black→white horizontal gradient on circles, rotated in 60° steps
+    // (0/60/120/180). Plain circles are rotation-symmetric, so the gradient is what makes
+    // the rotation visible. Endpoints are 0→20 px (less than the 56 px diameter) so the
+    // transition is concentrated in a narrow band — the resulting hard light/dark edge
+    // makes the rotation angle obvious. Cells use a fixed-size frame because Rotation
+    // pushes content outside the natural bounding box, which breaks the
+    // RelativeToChildren row sizing. Mirrors the same row on the MG and raylib sides.
+    static ContainerRuntime BuildRotationRow()
+    {
+        ContainerRuntime row = BuildHorizontalRow();
+        foreach (float rotation in new[] { 0f, 60f, 120f, 180f })
+        {
+            row.Children.Add(BuildRotatedGradientCircleCell(rotation));
+        }
+        return row;
+    }
+
+    static RectangleRuntime BuildRotatedGradientCircleCell(float rotation)
+    {
+        RectangleRuntime frame = new();
+        frame.Width = 70;
+        frame.Height = 70;
+        frame.FillColor = new SKColor(60, 60, 80);
+
+        CircleRuntime circle = new();
+        circle.Radius = 28;
+        circle.XOrigin = HorizontalAlignment.Center;
+        circle.XUnits = Gum.Converters.GeneralUnitType.PixelsFromMiddle;
+        circle.YOrigin = VerticalAlignment.Center;
+        circle.YUnits = Gum.Converters.GeneralUnitType.PixelsFromMiddle;
+        circle.UseGradient = true;
+        circle.GradientType = GradientType.Linear;
+        circle.Color1 = SKColors.Black;
+        circle.Color2 = SKColors.White;
+        circle.GradientX1 = 0; circle.GradientY1 = 0;
+        circle.GradientX2 = 20; circle.GradientY2 = 0;
+        circle.Rotation = rotation;
+        frame.Children.Add(circle);
+        return frame;
     }
 
     static RectangleRuntime BuildAlignmentCell(VerticalAlignment alignment)

--- a/Samples/SilkNetGum/SilkNetGum/Screens/RectanglesScreen.cs
+++ b/Samples/SilkNetGum/SilkNetGum/Screens/RectanglesScreen.cs
@@ -56,6 +56,7 @@ internal class RectanglesScreen : GraphicalUiElement
         right.Children.Add(BuildSection("Dashed strokes (solid / 6/4 / 2/2 dotted / long-dash) — Skia routes through SkiaShapeRuntime.StrokeDashLength (#2796)", BuildDashedStrokeRow()));
         right.Children.Add(BuildSection("FillColor + StrokeColor on the same instance — both layers render simultaneously (#2814)", BuildBothColorsRow()));
         right.Children.Add(BuildSection("Inscribed in a 64x64 frame — stroke must stay inside the gray rectangle's bounds at every StrokeWidth (#2814 visual contract)", BuildInscribedRow()));
+        right.Children.Add(BuildSection("Rotation (0 / 60 / 120 / 180 degrees) — black→white gradient rectangles", BuildRotationRow()));
     }
 
     static ContainerRuntime BuildColumn()
@@ -305,6 +306,48 @@ internal class RectanglesScreen : GraphicalUiElement
             row.Children.Add(BuildInscribedCell(strokeWidth));
         }
         return row;
+    }
+
+    // Rotation row — black→white horizontal gradient on rectangles, rotated in 60° steps
+    // (0/60/120/180). Gradient endpoints are 0→20 px (less than the 70 px width) so the
+    // transition is concentrated in a narrow band; the resulting hard light/dark edge
+    // makes the rotation angle obvious. Cells wrap each rotated rectangle in a fixed-size
+    // frame because Rotation pushes content outside the natural bounding box, which
+    // breaks RelativeToChildren row sizing. 100x100 frame is sized to contain a 70x50
+    // rectangle at any rotation. Mirrors the same row on the MG and raylib sides.
+    static ContainerRuntime BuildRotationRow()
+    {
+        ContainerRuntime row = BuildHorizontalRow();
+        foreach (float rotation in new[] { 0f, 60f, 120f, 180f })
+        {
+            row.Children.Add(BuildRotatedGradientRectCell(rotation));
+        }
+        return row;
+    }
+
+    static RectangleRuntime BuildRotatedGradientRectCell(float rotation)
+    {
+        RectangleRuntime frame = new();
+        frame.Width = 100;
+        frame.Height = 100;
+        frame.FillColor = new SKColor(60, 60, 80);
+
+        RectangleRuntime rect = new();
+        rect.Width = 70;
+        rect.Height = 50;
+        rect.XOrigin = HorizontalAlignment.Center;
+        rect.XUnits = Gum.Converters.GeneralUnitType.PixelsFromMiddle;
+        rect.YOrigin = VerticalAlignment.Center;
+        rect.YUnits = Gum.Converters.GeneralUnitType.PixelsFromMiddle;
+        rect.UseGradient = true;
+        rect.GradientType = GradientType.Linear;
+        rect.Color1 = SKColors.Black;
+        rect.Color2 = SKColors.White;
+        rect.GradientX1 = 0; rect.GradientY1 = 0;
+        rect.GradientX2 = 20; rect.GradientY2 = 0;
+        rect.Rotation = rotation;
+        frame.Children.Add(rect);
+        return frame;
     }
 
     static RectangleRuntime BuildInscribedCell(float strokeWidth)

--- a/Samples/raylib/Screens/CirclesScreen.cs
+++ b/Samples/raylib/Screens/CirclesScreen.cs
@@ -48,6 +48,7 @@ internal class CirclesScreen : FrameworkElement
         left.Children.Add(BuildSection("Stroke width", BuildStrokeWidthRow()));
         left.Children.Add(BuildSection("Alignment", BuildAlignmentRow()));
         left.Children.Add(BuildSection("Gradients", BuildGradientRow()));
+        left.Children.Add(BuildSection("Rotation", BuildRotationRow()));
 
         right.Children.Add(BuildSection("Dropshadow", BuildDropshadowRow()));
         right.Children.Add(BuildSection("Dashed strokes", BuildDashedStrokeRow()));
@@ -171,6 +172,47 @@ internal class CirclesScreen : FrameworkElement
             row.Children.Add(BuildAlignmentCell(alignment));
         }
         return row;
+    }
+
+    // Rotation row — black→white horizontal gradient on circles, rotated in 60° steps
+    // (0/60/120/180). Plain circles are rotation-symmetric, so the gradient is what makes
+    // the rotation visible. Endpoints are 0→20 px (less than the 56 px diameter) so the
+    // transition is concentrated in a narrow band — the resulting hard light/dark edge
+    // makes the rotation angle obvious. Cells use a fixed-size frame because Rotation
+    // pushes content outside the natural bounding box, which breaks the
+    // RelativeToChildren row sizing. Mirrors the same row on the MG and SilkNet sides.
+    static ContainerRuntime BuildRotationRow()
+    {
+        ContainerRuntime row = BuildHorizontalRow();
+        foreach (float rotation in new[] { 0f, 60f, 120f, 180f })
+        {
+            row.Children.Add(BuildRotatedGradientCircleCell(rotation));
+        }
+        return row;
+    }
+
+    static RectangleRuntime BuildRotatedGradientCircleCell(float rotation)
+    {
+        RectangleRuntime frame = new();
+        frame.Width = 70;
+        frame.Height = 70;
+        frame.FillColor = new Color(60, 60, 80, 255);
+
+        CircleRuntime circle = new();
+        circle.Radius = 28;
+        circle.XOrigin = HorizontalAlignment.Center;
+        circle.XUnits = GeneralUnitType.PixelsFromMiddle;
+        circle.YOrigin = VerticalAlignment.Center;
+        circle.YUnits = GeneralUnitType.PixelsFromMiddle;
+        circle.UseGradient = true;
+        circle.GradientType = GradientType.Linear;
+        circle.Color1 = Color.Black;
+        circle.Color2 = Color.White;
+        circle.GradientX1 = 0; circle.GradientY1 = 0;
+        circle.GradientX2 = 20; circle.GradientY2 = 0;
+        circle.Rotation = rotation;
+        frame.Children.Add(circle);
+        return frame;
     }
 
     static RectangleRuntime BuildAlignmentCell(VerticalAlignment alignment)

--- a/Samples/raylib/Screens/RectanglesScreen.cs
+++ b/Samples/raylib/Screens/RectanglesScreen.cs
@@ -55,6 +55,7 @@ internal class RectanglesScreen : FrameworkElement
         right.Children.Add(BuildSection("Dashed strokes (solid / 6/4 / 2/2 dotted / long-dash) — raylib walks the perimeter, one DrawLineEx per dash (#2757)", BuildDashedStrokeRow()));
         right.Children.Add(BuildSection("FillColor + StrokeColor on the same instance — both layers render simultaneously (#2757)", BuildBothColorsRow()));
         right.Children.Add(BuildSection("Inscribed in a 64x64 frame — stroke must stay inside the gray rectangle's bounds at every StrokeWidth (#2757)", BuildInscribedRow()));
+        right.Children.Add(BuildSection("Rotation (0 / 60 / 120 / 180 degrees) — black→white gradient rectangles", BuildRotationRow()));
     }
 
     static ContainerRuntime BuildColumn()
@@ -322,6 +323,48 @@ internal class RectanglesScreen : FrameworkElement
             row.Children.Add(BuildInscribedCell(strokeWidth));
         }
         return row;
+    }
+
+    // Rotation row — black→white horizontal gradient on rectangles, rotated in 60° steps
+    // (0/60/120/180). Gradient endpoints are 0→20 px (less than the 70 px width) so the
+    // transition is concentrated in a narrow band; the resulting hard light/dark edge
+    // makes the rotation angle obvious. Cells wrap each rotated rectangle in a fixed-size
+    // frame because Rotation pushes content outside the natural bounding box, which
+    // breaks RelativeToChildren row sizing. 100x100 frame is sized to contain a 70x50
+    // rectangle at any rotation. Mirrors the same row on the MG and SilkNet sides.
+    static ContainerRuntime BuildRotationRow()
+    {
+        ContainerRuntime row = BuildHorizontalRow();
+        foreach (float rotation in new[] { 0f, 60f, 120f, 180f })
+        {
+            row.Children.Add(BuildRotatedGradientRectCell(rotation));
+        }
+        return row;
+    }
+
+    static RectangleRuntime BuildRotatedGradientRectCell(float rotation)
+    {
+        RectangleRuntime frame = new();
+        frame.Width = 100;
+        frame.Height = 100;
+        frame.FillColor = new Color(60, 60, 80, 255);
+
+        RectangleRuntime rect = new();
+        rect.Width = 70;
+        rect.Height = 50;
+        rect.XOrigin = HorizontalAlignment.Center;
+        rect.XUnits = GeneralUnitType.PixelsFromMiddle;
+        rect.YOrigin = VerticalAlignment.Center;
+        rect.YUnits = GeneralUnitType.PixelsFromMiddle;
+        rect.UseGradient = true;
+        rect.GradientType = GradientType.Linear;
+        rect.Color1 = Color.Black;
+        rect.Color2 = Color.White;
+        rect.GradientX1 = 0; rect.GradientY1 = 0;
+        rect.GradientX2 = 20; rect.GradientY2 = 0;
+        rect.Rotation = rotation;
+        frame.Children.Add(rect);
+        return frame;
     }
 
     static RectangleRuntime BuildInscribedCell(float strokeWidth)

--- a/Tests/MonoGameGum.Shapes.Tests/RenderableShapeBaseTests.cs
+++ b/Tests/MonoGameGum.Shapes.Tests/RenderableShapeBaseTests.cs
@@ -1,6 +1,7 @@
 using MonoGameAndGum.Renderables;
 using Microsoft.Xna.Framework;
 using Shouldly;
+using Apos.Shapes;
 
 namespace MonoGameGum.Shapes.Tests;
 
@@ -53,5 +54,142 @@ public class RenderableShapeBaseTests
 
         result.X.ShouldBe(16f);
         result.Y.ShouldBe(16f);
+    }
+
+    // RotateAround — rotates a point around an arbitrary pivot. Shared math used both for the
+    // dashed-stroke perimeter walk and for rotating gradient endpoints with the shape so the
+    // gradient stays anchored to object-local space rather than the unrotated bounding box.
+    [Fact]
+    public void RotateAround_ZeroRotation_ReturnsPointUnchanged()
+    {
+        Vector2 result = RenderableShapeBase.RotateAround(new Vector2(10f, 20f), new Vector2(5f, 5f), 0f);
+        result.X.ShouldBe(10f, tolerance: 0.001f);
+        result.Y.ShouldBe(20f, tolerance: 0.001f);
+    }
+
+    [Fact]
+    public void RotateAround_PointAtPivot_StaysAtPivot()
+    {
+        Vector2 pivot = new(100f, 200f);
+        Vector2 result = RenderableShapeBase.RotateAround(pivot, pivot, (float)System.Math.PI / 4f);
+        result.X.ShouldBe(100f, tolerance: 0.001f);
+        result.Y.ShouldBe(200f, tolerance: 0.001f);
+    }
+
+    [Fact]
+    public void RotateAround_NinetyDegrees_RotatesCorrectly()
+    {
+        // 90° CCW around origin: (1, 0) -> (0, 1).  Around pivot (100, 100), the offset (10, 0)
+        // becomes (0, 10), so the point (110, 100) lands at (100, 110).
+        Vector2 result = RenderableShapeBase.RotateAround(new Vector2(110f, 100f), new Vector2(100f, 100f), (float)System.Math.PI / 2f);
+        result.X.ShouldBe(100f, tolerance: 0.001f);
+        result.Y.ShouldBe(110f, tolerance: 0.001f);
+    }
+
+    // GetGradient — object-space anchoring fix. Before this fix, the gradient endpoints were
+    // computed in unrotated bounding-box coordinates and passed unchanged to Apos.Shapes, so
+    // the gradient pattern stayed axis-aligned while the rendered shape rotated underneath
+    // (visible repro: rotation row in the gradient gallery samples). After the fix, endpoints
+    // are rotated around the shape's rotation pivot (the GUE top-left origin, per Gum
+    // convention) so the gradient travels with the shape.
+    [Fact]
+    public void GetGradient_ZeroRotation_PreservesPreRotationEndpoints()
+    {
+        // Regression guard: with rotation = 0, the rotation-aware call must return the same
+        // endpoints as the legacy axis-aligned computation. Shape at absolute (100, 200),
+        // gradient from local (0,0) to local (20, 0).
+        TestShape shape = new()
+        {
+            Width = 70f,
+            Height = 50f,
+            UseGradient = true,
+            GradientX1 = 0f,
+            GradientY1 = 0f,
+            GradientX2 = 20f,
+            GradientY2 = 0f,
+            Red1 = 0, Green1 = 0, Blue1 = 0, Alpha1 = 255,
+            Red2 = 255, Green2 = 255, Blue2 = 255, Alpha2 = 255,
+        };
+
+        Gradient gradient = shape.CallGetGradient(absoluteLeft: 100f, absoluteTop: 200f, rotationRadians: 0f);
+
+        gradient.AXY.X.ShouldBe(100f, tolerance: 0.001f);
+        gradient.AXY.Y.ShouldBe(200f, tolerance: 0.001f);
+        gradient.BXY.X.ShouldBe(120f, tolerance: 0.001f);
+        gradient.BXY.Y.ShouldBe(200f, tolerance: 0.001f);
+    }
+
+    [Fact]
+    public void GetGradient_NinetyDegreeRotation_RotatesEndpointsAroundTopLeft()
+    {
+        // Shape at absolute (100, 200), gradient from local (0, 0) → (20, 0). The unrotated
+        // world endpoints are (100, 200) and (120, 200). Rotating 90° CCW around the pivot
+        // (100, 200) leaves endpoint A at the pivot and moves endpoint B to (100, 220).
+        TestShape shape = new()
+        {
+            Width = 70f,
+            Height = 50f,
+            UseGradient = true,
+            GradientX1 = 0f,
+            GradientY1 = 0f,
+            GradientX2 = 20f,
+            GradientY2 = 0f,
+            Red1 = 0, Green1 = 0, Blue1 = 0, Alpha1 = 255,
+            Red2 = 255, Green2 = 255, Blue2 = 255, Alpha2 = 255,
+        };
+
+        Gradient gradient = shape.CallGetGradient(absoluteLeft: 100f, absoluteTop: 200f, rotationRadians: (float)System.Math.PI / 2f);
+
+        gradient.AXY.X.ShouldBe(100f, tolerance: 0.001f);
+        gradient.AXY.Y.ShouldBe(200f, tolerance: 0.001f);
+        gradient.BXY.X.ShouldBe(100f, tolerance: 0.001f);
+        gradient.BXY.Y.ShouldBe(220f, tolerance: 0.001f);
+    }
+
+    [Fact]
+    public void GetGradient_RadialGradient_RotatesCenterAndKeepsRadiusVectorAligned()
+    {
+        // Radial gradient: A = center, B = (center + outerRadius along +X). Rotating 180°
+        // around the top-left pivot should swing the center to the opposite side and keep
+        // the radius extent vector reflected accordingly.
+        TestShape shape = new()
+        {
+            Width = 56f,
+            Height = 56f,
+            UseGradient = true,
+            GradientType = global::RenderingLibrary.Graphics.GradientType.Radial,
+            GradientX1 = 28f,
+            GradientY1 = 28f,
+            // Radius set via GradientOuterRadius (absolute units default)
+            Red1 = 0, Green1 = 0, Blue1 = 0, Alpha1 = 255,
+            Red2 = 255, Green2 = 255, Blue2 = 255, Alpha2 = 255,
+        };
+        shape.SetOuterRadiusAbsolute(28f);
+
+        // Shape at (0, 0): center is at world (28, 28); B = center + (28, 0) = (56, 28).
+        // 180° around (0, 0): A → (-28, -28), B → (-56, -28).
+        Gradient gradient = shape.CallGetGradient(absoluteLeft: 0f, absoluteTop: 0f, rotationRadians: (float)System.Math.PI);
+
+        gradient.AXY.X.ShouldBe(-28f, tolerance: 0.001f);
+        gradient.AXY.Y.ShouldBe(-28f, tolerance: 0.001f);
+        gradient.BXY.X.ShouldBe(-56f, tolerance: 0.001f);
+        gradient.BXY.Y.ShouldBe(-28f, tolerance: 0.001f);
+    }
+
+    // Test-only subclass exposing the protected GetGradient so a unit test can drive endpoint
+    // math without going through the runtime/layout system. Width/Height are already public
+    // on RenderableBase, so they're settable via object initializer directly.
+    private class TestShape : RenderableShapeBase
+    {
+        public override void Render(global::RenderingLibrary.ISystemManagers managers) { }
+
+        public void SetOuterRadiusAbsolute(float radius)
+        {
+            GradientOuterRadius = radius;
+            GradientOuterRadiusUnits = Gum.DataTypes.DimensionUnitType.Absolute;
+        }
+
+        public Gradient CallGetGradient(float absoluteLeft, float absoluteTop, float rotationRadians)
+            => GetGradient(absoluteLeft, absoluteTop, rotationRadians);
     }
 }


### PR DESCRIPTION
Gradient endpoints were computed in unrotated bounding-box coordinates and passed to Apos.Shapes as world-space points (IsLocal=false). Apos rotates the primitive via its rotation parameter but does not rotate the gradient itself, so the gradient pattern stayed axis-aligned while the shape rotated underneath.

GetGradient now takes a rotationRadians argument and rotates both endpoints around the GUE rotation pivot (absoluteLeft, absoluteTop) before returning the Gradient, so the gradient travels with the shape in object-local space. Threaded the parameter through the three Circle and three RoundedRectangle call sites; extracted a public static RotateAround helper on the shape base for the shared math.

Added a Rotation row to the Circles and Rectangles screens of all three gradient gallery samples (MonoGame, SilkNet/Skia, raylib) using a hard black/white narrow-band gradient stepped 0/60/120/180 degrees so the rotation effect is immediately visible. Doubles as the visual repro for the bug.

Tests: 6 new unit tests in RenderableShapeBaseTests cover the new RotateAround helper and the rotation behavior of GetGradient (linear + radial), plus a zero-rotation regression guard. All 92 shape tests pass.