### PR TITLE
Fix variable grid still showing deleted instance after deletion

### DIFF
--- a/Gum/Plugins/PluginManager.cs
+++ b/Gum/Plugins/PluginManager.cs
@@ -314,10 +314,10 @@ public class PluginManager : IPluginManager
     public void StateDelete(StateSave stateSave) =>
         CallMethodOnPlugin((plugin) => plugin.CallStateDelete(stateSave));
 
-    public void ReactToStateSaveSelected(StateSave? stateSave) =>
+    public virtual void ReactToStateSaveSelected(StateSave? stateSave) =>
         CallMethodOnPlugin((plugin) => plugin.CallReactToStateSaveSelected(stateSave));
 
-    public void ReactToCustomStateSaveSelected(StateSave stateSave) =>
+    public virtual void ReactToCustomStateSaveSelected(StateSave stateSave) =>
         CallMethodOnPlugin((plugin) => plugin.CallReactToCustomStateSaveSelected(stateSave));
 
     public void RefreshStateTreeView() =>
@@ -336,7 +336,7 @@ public class PluginManager : IPluginManager
     public void CategoryDelete(StateSaveCategory category) =>
         CallMethodOnPlugin((plugin) => plugin.CallStateCategoryDelete(category));
 
-    public void ReactToStateSaveCategorySelected(StateSaveCategory? category) =>
+    public virtual void ReactToStateSaveCategorySelected(StateSaveCategory? category) =>
         CallMethodOnPlugin((plugin) => plugin.CallReactToStateSaveCategorySelected(category));
 
     public void VariableAdd(ElementSave elementSave, string variableName) =>
@@ -351,7 +351,7 @@ public class PluginManager : IPluginManager
         CallMethodOnPlugin(plugin => plugin.CallVariableSetLate(parentElement, instance, unqualifiedChangedMemberName, oldValue), "VariableSet (Late)");
     }
 
-    public void VariableSelected(IStateContainer container, VariableSave variable) =>
+    public virtual void VariableSelected(IStateContainer container, VariableSave variable) =>
         CallMethodOnPlugin(plugin => plugin.CallVariableSelected(container, variable));
 
     public void VariableRemovedFromCategory(string variableName, StateSaveCategory category) =>
@@ -371,7 +371,7 @@ public class PluginManager : IPluginManager
     }
 
 
-    public void ElementSelected(ElementSave? elementSave) =>
+    public virtual void ElementSelected(ElementSave? elementSave) =>
         CallMethodOnPlugin(plugin => plugin.CallElementSelected(elementSave));
 
     internal void TreeNodeSelected(TreeNode? treeNode) =>
@@ -411,13 +411,13 @@ public class PluginManager : IPluginManager
         return toReturn ?? Enumerable.Empty<ITreeNode>();
     }
 
-    public void BehaviorSelected(BehaviorSave? behaviorSave) =>
+    public virtual void BehaviorSelected(BehaviorSave? behaviorSave) =>
         CallMethodOnPlugin(plugin => plugin.CallBehaviorSelected(behaviorSave));
 
-    public void BehaviorReferenceSelected(ElementBehaviorReference behaviorReference, ElementSave elementSave) =>
+    public virtual void BehaviorReferenceSelected(ElementBehaviorReference behaviorReference, ElementSave elementSave) =>
         CallMethodOnPlugin(plugin => plugin.CallBehaviorReferenceSelected(behaviorReference, elementSave));
 
-    public void BehaviorVariableSelected(VariableSave variable) =>
+    public virtual void BehaviorVariableSelected(VariableSave variable) =>
         CallMethodOnPlugin(plugin => plugin.CallBehaviorVariableSelected(variable));
     public void BehaviorCreated(BehaviorSave behavior) =>
         CallMethodOnPlugin(plugin => plugin.CallBehaviorCreated(behavior));
@@ -425,7 +425,7 @@ public class PluginManager : IPluginManager
     public void BehaviorDeleted(BehaviorSave behavior) =>
         CallMethodOnPlugin(plugin => plugin.CallBehaviorDeleted(behavior));
 
-    public void InstanceSelected(ElementSave elementSave, InstanceSave instance) =>
+    public virtual void InstanceSelected(ElementSave elementSave, InstanceSave instance) =>
         CallMethodOnPlugin(plugin => plugin.CallInstanceSelected(elementSave, instance));
 
     public virtual void InstanceAdd(ElementSave elementSave, InstanceSave instance) =>

--- a/Gum/ToolStates/SelectedState.cs
+++ b/Gum/ToolStates/SelectedState.cs
@@ -117,8 +117,14 @@ public class SelectedState : ISelectedState
         var elementsBefore = SelectedElements.ToList();
         var instancesBefore = SelectedInstances.ToList();
 
+        var instanceClearedAsSideEffect = false;
         if (value?.Count > 0)
         {
+            // Setting an element implicitly deselects any selected instance. Fire
+            // InstanceSelected with a null instance so listeners (notably the variable
+            // grid) refresh — otherwise they keep displaying the deselected instance's
+            // variables. See issue #2946.
+            instanceClearedAsSideEffect = snapshot.SelectedInstance != null;
             snapshot.SelectedInstance = null;
             snapshot.SelectedBehavior = null;
         }
@@ -143,6 +149,11 @@ public class SelectedState : ISelectedState
         {
             snapshot.SelectedBehaviorReference = null;
             UpdateToSelectedElements(value);
+        }
+
+        if (instanceClearedAsSideEffect)
+        {
+            _pluginManager.InstanceSelected(SelectedElement, null);
         }
 
         if (differ || (instancesBefore.Count > 0 && SelectedElement?.Instances.Count == 0))

--- a/Tool/Tests/GumToolUnitTests/ToolStates/SelectedStateTests.cs
+++ b/Tool/Tests/GumToolUnitTests/ToolStates/SelectedStateTests.cs
@@ -1,0 +1,112 @@
+using CommunityToolkit.Mvvm.Messaging;
+using Gum.Commands;
+using Gum.DataTypes;
+using Gum.DataTypes.Variables;
+using Gum.Managers;
+using Gum.Plugins;
+using Gum.ToolStates;
+using Moq;
+using Shouldly;
+
+namespace GumToolUnitTests.ToolStates;
+
+public class SelectedStateTests : BaseTestClass
+{
+    private readonly Mock<IGuiCommands> _guiCommands;
+    private readonly Mock<PluginManager> _pluginManager;
+    private readonly Mock<IMessenger> _messenger;
+    private readonly SelectedState _selectedState;
+
+    public SelectedStateTests()
+    {
+        _guiCommands = new Mock<IGuiCommands>();
+        _pluginManager = new Mock<PluginManager> { CallBase = false };
+        _messenger = new Mock<IMessenger>();
+        _selectedState = new SelectedState(
+            _guiCommands.Object,
+            _pluginManager.Object,
+            _messenger.Object);
+    }
+
+    [Fact]
+    public void SelectedElement_SetWhileInstanceSelected_FiresInstanceSelectedWithNull()
+    {
+        // Regression for issue #2946: when an instance is selected and the SelectedElement
+        // setter runs (e.g. DeleteLogic re-asserts the owning element after removing the
+        // instance), HandleElementsSelected silently clears snapshot.SelectedInstance
+        // without notifying listeners. The variable grid subscribes to InstanceSelected to
+        // refresh and so keeps displaying the deleted instance's variables.
+        ScreenSave screen = CreateScreen("TestScreen");
+        InstanceSave instance = AddInstance(screen, "Inst");
+
+        _selectedState.SelectedInstance = instance;
+        _pluginManager.Invocations.Clear();
+
+        // Re-asserting the same element silently clears SelectedInstance — the exact
+        // path DeleteLogic.PerformConfirmedSingleInstanceDelete hits.
+        _selectedState.SelectedElement = screen;
+
+        _pluginManager.Verify(
+            p => p.InstanceSelected(screen, null!),
+            Times.Once);
+    }
+
+    [Fact]
+    public void SelectedElement_SetToDifferentElementWhileInstanceSelected_FiresInstanceSelectedWithNull()
+    {
+        // Same gap applies when switching to a different element: the previously-selected
+        // instance is silently cleared from the snapshot. Variable-grid refresh on a
+        // different element runs via the state cascade, but listeners that need to know
+        // the *instance* deselection (independent of state) still rely on the event.
+        ScreenSave screenA = CreateScreen("ScreenA");
+        InstanceSave instance = AddInstance(screenA, "Inst");
+        ScreenSave screenB = CreateScreen("ScreenB");
+
+        _selectedState.SelectedInstance = instance;
+        _pluginManager.Invocations.Clear();
+
+        _selectedState.SelectedElement = screenB;
+
+        _pluginManager.Verify(
+            p => p.InstanceSelected(screenB, null!),
+            Times.Once);
+    }
+
+    [Fact]
+    public void SelectedElement_SetWhileNoInstanceSelected_DoesNotFireInstanceSelected()
+    {
+        // The new InstanceSelected fire-on-silent-clear should only trigger when an
+        // instance was actually selected. Setting SelectedElement with no prior instance
+        // selection must not emit a spurious InstanceSelected event.
+        ScreenSave screen = CreateScreen("TestScreen");
+
+        _selectedState.SelectedElement = screen;
+
+        _pluginManager.Verify(
+            p => p.InstanceSelected(It.IsAny<ElementSave>(), It.IsAny<InstanceSave>()),
+            Times.Never);
+    }
+
+    private static ScreenSave CreateScreen(string name)
+    {
+        ScreenSave screen = new ScreenSave { Name = name };
+        StateSave defaultState = new StateSave { Name = "Default", ParentContainer = screen };
+        screen.States.Add(defaultState);
+
+        GumProjectSave? project = ObjectFinder.Self.GumProjectSave;
+        if (project == null)
+        {
+            project = new GumProjectSave();
+            ObjectFinder.Self.GumProjectSave = project;
+        }
+        project.Screens.Add(screen);
+        return screen;
+    }
+
+    private static InstanceSave AddInstance(ScreenSave screen, string name)
+    {
+        InstanceSave instance = new InstanceSave { Name = name, ParentContainer = screen };
+        screen.Instances.Add(instance);
+        return instance;
+    }
+}


### PR DESCRIPTION
## Summary

- `SelectedState.HandleElementsSelected` silently cleared `snapshot.SelectedInstance` when an element was (re-)selected, without firing `InstanceSelected`. The variable-grid plugin subscribes to `InstanceSelected` to refresh, so it kept displaying the deleted instance's variables.
- `DeleteLogic.PerformConfirmedSingleInstanceDelete` re-asserts `SelectedElement = owningElement` mid-flow (to give plugins a valid live `SelectedElement` when `InstanceDelete` fires). That assignment hit the silent-clear path, masking the cascade.
- Fix: when element assignment clears a previously-selected instance, fire `InstanceSelected(SelectedElement, null)` so listeners can react.
- Made `PluginManager.ElementSelected`, `InstanceSelected`, `BehaviorSelected`, `BehaviorReferenceSelected`, `BehaviorVariableSelected`, `ReactToStateSaveSelected`, `ReactToStateSaveCategorySelected`, `ReactToCustomStateSaveSelected`, and `VariableSelected` virtual so the cascade is observable in unit tests via `Moq<PluginManager>`.

## TDD

New `SelectedStateTests` (TDD-first; red→green):

- `SelectedElement_SetWhileInstanceSelected_FiresInstanceSelectedWithNull` — same-element repath (DeleteLogic case).
- `SelectedElement_SetToDifferentElementWhileInstanceSelected_FiresInstanceSelectedWithNull` — element switch with instance previously selected.
- `SelectedElement_SetWhileNoInstanceSelected_DoesNotFireInstanceSelected` — sanity check: no spurious event when nothing was selected.

Closes #2946.

## Test plan

- [x] All 654 `GumToolUnitTests` pass (`dotnet test Tool/Tests/GumToolUnitTests/...`).
- [ ] Manual repro: open a screen with one instance, select it, delete it, verify the variable grid clears or shows the screen's variables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)