### PR TITLE
#2956: Gate fill gradient on slot alpha so Apos and raylib match Skia

### DIFF
--- a/Runtimes/GumShapes/Renderables/Arc.cs
+++ b/Runtimes/GumShapes/Renderables/Arc.cs
@@ -141,7 +141,7 @@ internal class Arc : RenderableShapeBase
 
         if(_isEndRounded)
         {
-            if (UseGradient && forcedColor == null)
+            if (ShouldPaintGradient(forcedColor))
             {
                 var gradient = base.GetGradient(absoluteLeft, absoluteTop);
                 sb.DrawArc(center,
@@ -191,7 +191,7 @@ internal class Arc : RenderableShapeBase
                 return;
             }
 
-            if (UseGradient && forcedColor == null)
+            if (ShouldPaintGradient(forcedColor))
             {
                 var gradient = base.GetGradient(absoluteLeft, absoluteTop);
                 sb.DrawRing(center,

--- a/Runtimes/GumShapes/Renderables/Circle.cs
+++ b/Runtimes/GumShapes/Renderables/Circle.cs
@@ -183,7 +183,7 @@ public class Circle : RenderableShapeBase,
             // inverted disk. Only the fill branch consumes this; stroke ignores it.
             float fillRadius = System.Math.Max(0f, radius - FillRadiusInset);
 
-            if (UseGradient && forcedColor == null)
+            if (ShouldPaintGradient(forcedColor))
             {
                 var gradient = base.GetGradient(absoluteLeft, absoluteTop, rotationRadians);
 
@@ -209,7 +209,7 @@ public class Circle : RenderableShapeBase,
         }
         else
         {
-            if(UseGradient && forcedColor == null)
+            if(ShouldPaintGradient(forcedColor))
             {
                 var gradient = base.GetGradient(absoluteLeft, absoluteTop, rotationRadians);
 
@@ -284,7 +284,7 @@ public class Circle : RenderableShapeBase,
         // gradient looks continuous across the dashed border (each dash samples the same world-
         // space gradient rather than restarting per-segment). GetGradient already returns world
         // coords, mirroring how upstream's DrawDashedCircle calls GradientToWorld + IsLocal=false.
-        Gradient? gradient = (UseGradient && forcedColor == null)
+        Gradient? gradient = ShouldPaintGradient(forcedColor)
             ? base.GetGradient(absoluteLeft, absoluteTop, rotationRadians)
             : null;
         var color = forcedColor ?? Color;

--- a/Runtimes/GumShapes/Renderables/RenderableShapeBase.cs
+++ b/Runtimes/GumShapes/Renderables/RenderableShapeBase.cs
@@ -582,6 +582,23 @@ public abstract class RenderableShapeBase : RenderableBase
     }
 
     /// <summary>
+    /// Issue #2956 — gates whether this renderable's gradient pass should actually draw.
+    /// <see cref="UseGradient"/> is a *pattern* flag, not a *visibility* flag — a slot whose
+    /// solid <see cref="Color"/> alpha is 0 (e.g. the default-transparent fill on a stroke-only
+    /// plain Circle) must NOT paint its gradient. Apos.Shapes' gradient draw bypasses the
+    /// slot's solid color, so without this gate it would paint an opaque gradient on a slot
+    /// the user explicitly hid. SkiaSharp gets this right naturally because
+    /// <c>SKPaint.Color.alpha</c> modulates the shader output; we replicate that contract
+    /// here. <paramref name="forcedColor"/> is the per-call dropshadow override every render
+    /// path already short-circuits on — when set, the slot is painting the shadow, not the
+    /// gradient, so the gate must return false.
+    /// </summary>
+    public bool ShouldPaintGradient(Color? forcedColor)
+    {
+        return UseGradient && forcedColor == null && Color.A > 0;
+    }
+
+    /// <summary>
     /// Invoked by <see cref="PreRender"/> each frame. The wrapping <see cref="MonoGameGum.GueDeriving.AposShapeRuntime"/>
     /// hooks this so it can resolve unit-bearing properties (notably StrokeWidth with ScreenPixel units,
     /// which depends on the current camera zoom) into the renderable's plain pixel values just before drawing.

--- a/Runtimes/GumShapes/Renderables/RoundedRectangle.cs
+++ b/Runtimes/GumShapes/Renderables/RoundedRectangle.cs
@@ -146,7 +146,7 @@ public class RoundedRectangle : RenderableShapeBase,
 
         if (IsFilled)
         {
-            if (UseGradient && forcedColor == null)
+            if (ShouldPaintGradient(forcedColor))
             {
                 var gradient = base.GetGradient(absoluteLeft, absoluteTop, rotationRadians);
 
@@ -166,7 +166,7 @@ public class RoundedRectangle : RenderableShapeBase,
         }
         else
         {
-            if(UseGradient && forcedColor == null)
+            if(ShouldPaintGradient(forcedColor))
             {
                 var gradient = base.GetGradient(absoluteLeft, absoluteTop, rotationRadians);
 
@@ -230,7 +230,7 @@ public class RoundedRectangle : RenderableShapeBase,
         // than restarting per-segment). Falls back to a solid Color when no gradient is configured.
         // Apos.Shapes overloads accept either, so we forward whichever fits.
         var fallbackColor = forcedColor ?? Color;
-        Gradient strokeGradient = (UseGradient && forcedColor == null)
+        Gradient strokeGradient = ShouldPaintGradient(forcedColor)
             ? base.GetGradient(absoluteLeft, absoluteTop, rotationRadians)
             : new Gradient(Vector2.Zero, fallbackColor, Vector2.Zero, fallbackColor, Gradient.Shape.None);
 

--- a/Runtimes/RaylibGum/Renderables/LineCircle.cs
+++ b/Runtimes/RaylibGum/Renderables/LineCircle.cs
@@ -238,6 +238,38 @@ public class LineCircle : InvisibleRenderable
     public bool ShouldPaintFillGradient =>
         UseGradient && (FillColor.HasValue || IsFilled) && (FillColor ?? Color).A > 0;
 
+    /// <summary>
+    /// Issue #2934 / #2956 — returns the linear gradient axis endpoints rotated around the
+    /// bbox center by <paramref name="rotationDegrees"/>. The disc itself is rotation-
+    /// symmetric so its position is unchanged by rotation, but the gradient axis is defined
+    /// in object-local bbox coords and must rotate with the shape — otherwise the gradient
+    /// pattern stays world-axis-aligned while the user rotates the circle. Mirrors the
+    /// approach Apos's <c>RenderableShapeBase.GetGradient</c> took in PR #2945. Rotation
+    /// convention matches <see cref="LineRectangle"/>'s R helper (visual CCW on screen, since
+    /// screen Y points down): <c>[cos sin; -sin cos]</c>.
+    /// </summary>
+    public (float x1, float y1, float x2, float y2) GetRotatedGradientEndpoints(float rotationDegrees)
+    {
+        if (rotationDegrees == 0f)
+        {
+            return (GradientX1, GradientY1, GradientX2, GradientY2);
+        }
+        float rotRad = rotationDegrees * System.MathF.PI / 180f;
+        float cos = System.MathF.Cos(rotRad);
+        float sin = System.MathF.Sin(rotRad);
+        float pivotX = Radius;
+        float pivotY = Radius;
+        float dx1 = GradientX1 - pivotX;
+        float dy1 = GradientY1 - pivotY;
+        float dx2 = GradientX2 - pivotX;
+        float dy2 = GradientY2 - pivotY;
+        return (
+            pivotX + dx1 * cos + dy1 * sin,
+            pivotY - dx1 * sin + dy1 * cos,
+            pivotX + dx2 * cos + dy2 * sin,
+            pivotY - dx2 * sin + dy2 * cos);
+    }
+
     /// <inheritdoc cref="LineCircle"/>
     public LineCircle() : this(null) { }
 
@@ -371,7 +403,14 @@ public class LineCircle : InvisibleRenderable
         // shows up as a visible outline that Skia doesn't draw. Suppressing the stroke here
         // matches Skia's rendered output without needing a separate gradient-stroke draw path.
         // Same gate landed on LineRectangle in commit 7f1e3b55b.
-        if (runStroke && UseGradient && runFill)
+        //
+        // Issue #2956 — gate on ShouldPaintFillGradient (which checks effective fill alpha)
+        // not on the looser `UseGradient && runFill`: with a transparent fill the gradient
+        // pass is suppressed, so the solid stroke is the only visible output and should NOT
+        // be suppressed. Before this tightening, IsFilled = false + UseGradient = true
+        // produced no fill (alpha 0) AND no stroke (suppressed by the old gate) — a
+        // completely invisible Circle. The outline gallery row exercises exactly this case.
+        if (runStroke && ShouldPaintFillGradient)
         {
             runStroke = false;
         }
@@ -439,6 +478,13 @@ public class LineCircle : InvisibleRenderable
         float bboxLeft = cx - radius;
         float bboxTop = cy - radius;
 
+        // Issue #2934 / #2956 — pre-rotate the gradient endpoints (linear) or center (radial)
+        // around the bbox center so the gradient axis tracks the shape under self-rotation.
+        // Same approach Apos's RenderableShapeBase.GetGradient takes (PR #2945). Computed
+        // once here rather than per-vertex.
+        float rotDeg = this.GetAbsoluteRotation();
+        (float gx1, float gy1, float gx2, float gy2) = GetRotatedGradientEndpoints(rotDeg);
+
         Rlgl.Begin((int)DrawMode.Triangles);
         for (int i = 0; i < segments; i++)
         {
@@ -453,14 +499,15 @@ public class LineCircle : InvisibleRenderable
             // DrawCircleGradient winding (src/rshapes.c). Reversing the two rim vertices
             // produces back-facing triangles for raylib's default front-face setting, which
             // get culled and render as nothing.
-            EmitGradientVertex(cx, cy, bboxLeft, bboxTop);
-            EmitGradientVertex(v2x, v2y, bboxLeft, bboxTop);
-            EmitGradientVertex(v1x, v1y, bboxLeft, bboxTop);
+            EmitGradientVertex(cx, cy, bboxLeft, bboxTop, gx1, gy1, gx2, gy2);
+            EmitGradientVertex(v2x, v2y, bboxLeft, bboxTop, gx1, gy1, gx2, gy2);
+            EmitGradientVertex(v1x, v1y, bboxLeft, bboxTop, gx1, gy1, gx2, gy2);
         }
         Rlgl.End();
     }
 
-    private void EmitGradientVertex(float worldX, float worldY, float bboxLeft, float bboxTop)
+    private void EmitGradientVertex(float worldX, float worldY, float bboxLeft, float bboxTop,
+        float gx1, float gy1, float gx2, float gy2)
     {
         float localX = worldX - bboxLeft;
         float localY = worldY - bboxTop;
@@ -468,10 +515,11 @@ public class LineCircle : InvisibleRenderable
         float t;
         if (GradientType == GradientType.Linear)
         {
-            // Project the vertex onto the gradient axis. Degenerate (zero-length) axis
-            // collapses to a solid Color1 — same fallback Skia's CreateLinearGradient takes.
-            float dx = GradientX2 - GradientX1;
-            float dy = GradientY2 - GradientY1;
+            // Project the vertex onto the (rotation-adjusted) gradient axis. Degenerate
+            // (zero-length) axis collapses to a solid Color1 — same fallback Skia's
+            // CreateLinearGradient takes.
+            float dx = gx2 - gx1;
+            float dy = gy2 - gy1;
             float lenSq = dx * dx + dy * dy;
             if (lenSq <= 0f)
             {
@@ -479,15 +527,16 @@ public class LineCircle : InvisibleRenderable
                 Rlgl.Vertex2f(worldX, worldY);
                 return;
             }
-            t = ((localX - GradientX1) * dx + (localY - GradientY1) * dy) / lenSq;
+            t = ((localX - gx1) * dx + (localY - gy1) * dy) / lenSq;
         }
         else
         {
-            // Radial: distance from (GradientX1, GradientY1) normalized against the
-            // [InnerRadius, OuterRadius] band. OuterRadius = 0 (default) collapses to the
-            // full circle radius so a no-config radial covers the whole disk.
-            float dx = localX - GradientX1;
-            float dy = localY - GradientY1;
+            // Radial: distance from (gx1, gy1) — the rotation-adjusted radial center —
+            // normalized against the [InnerRadius, OuterRadius] band. OuterRadius = 0
+            // (default) collapses to the full circle radius so a no-config radial covers
+            // the whole disk.
+            float dx = localX - gx1;
+            float dy = localY - gy1;
             float dist = System.MathF.Sqrt(dx * dx + dy * dy);
             float outer = GradientOuterRadius > 0f ? GradientOuterRadius : Radius;
             float span = outer - GradientInnerRadius;

--- a/Runtimes/RaylibGum/Renderables/LineCircle.cs
+++ b/Runtimes/RaylibGum/Renderables/LineCircle.cs
@@ -225,6 +225,19 @@ public class LineCircle : InvisibleRenderable
         }
     }
 
+    /// <summary>
+    /// Issue #2956 — true when the fill pass should paint its gradient. Mirrors the SkPaint
+    /// contract enforced by SkiaGum: <see cref="UseGradient"/> is a *pattern* flag, not a
+    /// *visibility* flag, so a slot whose effective fill alpha is 0 (e.g. the default-
+    /// transparent fill on a stroke-only plain Circle) must NOT paint its gradient. Without
+    /// this gate <see cref="DrawGradientFan"/> would emit opaque triangles regardless of
+    /// <see cref="FillColor"/>'s alpha. The fill slot is enabled when an explicit
+    /// <see cref="FillColor"/> is set OR <see cref="IsFilled"/> is true (legacy
+    /// <see cref="Color"/> path); the effective fill color is then <c>FillColor ?? Color</c>.
+    /// </summary>
+    public bool ShouldPaintFillGradient =>
+        UseGradient && (FillColor.HasValue || IsFilled) && (FillColor ?? Color).A > 0;
+
     /// <inheritdoc cref="LineCircle"/>
     public LineCircle() : this(null) { }
 
@@ -323,7 +336,16 @@ public class LineCircle : InvisibleRenderable
                 // one tested branch instead of a fragile "is this the centered default?"
                 // detector. The fan structure matches raylib's own DrawCircle implementation
                 // in rshapes.c — center vertex + N rim vertices fan into N triangles.
-                DrawGradientFan(cx, cy, Radius);
+                //
+                // Issue #2956 — suppress the fan when the slot's effective fill alpha is 0.
+                // DrawGradientFan emits per-vertex Color1/Color2 directly with no modulation
+                // by fillColor.A, so without this gate a default-transparent fill would still
+                // paint an opaque gradient (Skia naturally avoids this via paint.Color.alpha
+                // modulating the shader; we replicate it explicitly). See ShouldPaintFillGradient.
+                if (fillColor.A > 0)
+                {
+                    DrawGradientFan(cx, cy, Radius);
+                }
             }
             else
             {

--- a/Runtimes/RaylibGum/Renderables/LineCircle.cs
+++ b/Runtimes/RaylibGum/Renderables/LineCircle.cs
@@ -284,12 +284,39 @@ public class LineCircle : InvisibleRenderable
             return;
         }
 
+        // Issue #2934 — derive the disc center from the half-size offset, rotated by the
+        // element's absolute rotation. GraphicalUiElement.AdjustOffsetsByOrigin pre-rotates
+        // the origin-compensation offset (see GumRuntime/GraphicalUiElement.cs around line
+        // 4178), so GetAbsoluteLeft() returns the *rotated* bbox top-left, not the unrotated
+        // one. Adding the unrotated half-size (the old `cx = AbsoluteLeft + Width/2` path)
+        // produces a point that orbits the geometric center as rotation grows, which is what
+        // produced the visible position drift in the rotation gallery cells. LineRectangle
+        // gets this right implicitly via its R(w/2, h/2) corner derivation; LineCircle needs
+        // the same rotation explicitly. The disc itself is rotation-symmetric so once the
+        // center is correct, the visible shape is too.
         float cx;
         float cy;
+        float rotDegForCenter = this.GetAbsoluteRotation();
         if (CircleOrigin == CircleOrigin.TopLeft)
         {
-            cx = this.GetAbsoluteLeft() + this.Width * 0.5f;
-            cy = this.GetAbsoluteTop() + this.Height * 0.5f;
+            float halfW = this.Width * 0.5f;
+            float halfH = this.Height * 0.5f;
+            if (rotDegForCenter == 0f)
+            {
+                cx = this.GetAbsoluteLeft() + halfW;
+                cy = this.GetAbsoluteTop() + halfH;
+            }
+            else
+            {
+                float rotRad = rotDegForCenter * System.MathF.PI / 180f;
+                float cosC = System.MathF.Cos(rotRad);
+                float sinC = System.MathF.Sin(rotRad);
+                // Same R helper convention LineRectangle uses (visual CCW on screen):
+                // [cos sin; -sin cos]. Rotates the (halfW, halfH) offset from rotated
+                // bbox top-left to the geometric center.
+                cx = this.GetAbsoluteLeft() + cosC * halfW + sinC * halfH;
+                cy = this.GetAbsoluteTop() - sinC * halfW + cosC * halfH;
+            }
         }
         else
         {

--- a/Runtimes/RaylibGum/Renderables/LineCircle.cs
+++ b/Runtimes/RaylibGum/Renderables/LineCircle.cs
@@ -484,19 +484,32 @@ public class LineCircle : InvisibleRenderable
     }
 
     /// <summary>
-    /// Emits a triangle fan around (<paramref name="cx"/>, <paramref name="cy"/>) with per-vertex
-    /// colors computed from the user's gradient configuration. Mirrors the immediate-mode
-    /// pattern raylib itself uses for <c>DrawCircleGradient</c> in <c>rshapes.c</c> — N
-    /// segments × 3 vertices per triangle, color set via <see cref="Rlgl.Color4ub"/> before
-    /// each <see cref="Rlgl.Vertex2f"/>. The GPU rasterizes the per-vertex colors via
-    /// barycentric interpolation, giving smooth gradients across each triangle.
+    /// Tessellates the disc with concentric annular bands so the gradient renders smoothly
+    /// regardless of how the gradient axis sits relative to the disc center. Each vertex
+    /// samples the gradient at its actual world position, so barycentric interpolation
+    /// across each small triangle is locally close to linear.
     /// </summary>
     /// <remarks>
-    /// Quality note: the center vertex contributes a single t-value to every fan triangle,
-    /// so very high-contrast linear gradients can show a faint "star" near the center where
-    /// adjacent triangles meet. Same artifact <c>DrawCircleGradient</c> has on raylib itself.
-    /// 36+ segments at typical radii is enough that the effect is invisible.
+    /// <para>
+    /// History: raylib's <c>DrawCircleGradient</c> in <c>rshapes.c</c> uses a triangle fan
+    /// from the disc center to N rim vertices. That works when the gradient is centered on
+    /// the disc (the center vertex's t-value matches its geometric expectation), but fails
+    /// loudly when the gradient axis is narrow or off-center: the center vertex's color
+    /// becomes a constant outlier that every fan triangle inherits, producing a visible
+    /// "spoke" or "pinch" artifact (#2956 follow-up — the narrow-band rotation gallery cell
+    /// at <c>(0,0)→(20,0)</c> on a 56 px disc puts the center at clamped t = 1, every
+    /// triangle inherits Color2, and the gradient appears to converge to a point).
+    /// </para>
+    /// <para>
+    /// Fix: tessellate as <see cref="RadialLayers"/> concentric annular bands (each band a
+    /// quad strip of 2 × N triangles) plus one small fan at the inner core. Every annulus
+    /// vertex sits at a known radius and angle, so its gradient color matches its position.
+    /// The fan artifact still exists at the innermost layer, but it's squeezed into a region
+    /// of radius <c>r / RadialLayers</c>, invisible at typical sizes.
+    /// </para>
     /// </remarks>
+    private const int RadialLayers = 8;
+
     private void DrawGradientFan(float cx, float cy, float radius)
     {
         int segments = System.Math.Max(36, (int)(radius * 2));
@@ -513,22 +526,38 @@ public class LineCircle : InvisibleRenderable
         (float gx1, float gy1, float gx2, float gy2) = GetRotatedGradientEndpoints(rotDeg);
 
         Rlgl.Begin((int)DrawMode.Triangles);
-        for (int i = 0; i < segments; i++)
-        {
-            float a0 = (i / (float)segments) * System.MathF.PI * 2f;
-            float a1 = ((i + 1) / (float)segments) * System.MathF.PI * 2f;
-            float v1x = cx + System.MathF.Cos(a0) * radius;
-            float v1y = cy + System.MathF.Sin(a0) * radius;
-            float v2x = cx + System.MathF.Cos(a1) * radius;
-            float v2y = cy + System.MathF.Sin(a1) * radius;
 
-            // Vertex order: center → later-angle → earlier-angle. Matches raylib's own
-            // DrawCircleGradient winding (src/rshapes.c). Reversing the two rim vertices
-            // produces back-facing triangles for raylib's default front-face setting, which
-            // get culled and render as nothing.
-            EmitGradientVertex(cx, cy, bboxLeft, bboxTop, gx1, gy1, gx2, gy2);
-            EmitGradientVertex(v2x, v2y, bboxLeft, bboxTop, gx1, gy1, gx2, gy2);
-            EmitGradientVertex(v1x, v1y, bboxLeft, bboxTop, gx1, gy1, gx2, gy2);
+        // Outer annular bands. Each layer is the annulus between two concentric rings; each
+        // angular segment of the annulus is a quad split into two triangles. Vertex winding
+        // matches raylib's own CCW-in-window-coords (visually CW in screen-Y-down) so the
+        // triangles render front-facing under the default culling.
+        for (int layer = 0; layer < RadialLayers; layer++)
+        {
+            float rOuter = radius * (RadialLayers - layer) / RadialLayers;
+            float rInner = radius * (RadialLayers - layer - 1) / RadialLayers;
+            for (int i = 0; i < segments; i++)
+            {
+                float a0 = (i / (float)segments) * System.MathF.PI * 2f;
+                float a1 = ((i + 1) / (float)segments) * System.MathF.PI * 2f;
+                float c0 = System.MathF.Cos(a0), s0 = System.MathF.Sin(a0);
+                float c1 = System.MathF.Cos(a1), s1 = System.MathF.Sin(a1);
+
+                float ox0 = cx + c0 * rOuter, oy0 = cy + s0 * rOuter;
+                float ox1 = cx + c1 * rOuter, oy1 = cy + s1 * rOuter;
+                float ix0 = cx + c0 * rInner, iy0 = cy + s0 * rInner;
+                float ix1 = cx + c1 * rInner, iy1 = cy + s1 * rInner;
+
+                // Two triangles forming the annular quad. Winding follows the original fan
+                // (inner-like → outer-later → outer-earlier), generalized: pick one corner as
+                // the "tip" and orbit later → earlier on the opposite ring.
+                EmitGradientVertex(ix0, iy0, bboxLeft, bboxTop, gx1, gy1, gx2, gy2);
+                EmitGradientVertex(ox1, oy1, bboxLeft, bboxTop, gx1, gy1, gx2, gy2);
+                EmitGradientVertex(ox0, oy0, bboxLeft, bboxTop, gx1, gy1, gx2, gy2);
+
+                EmitGradientVertex(ix0, iy0, bboxLeft, bboxTop, gx1, gy1, gx2, gy2);
+                EmitGradientVertex(ix1, iy1, bboxLeft, bboxTop, gx1, gy1, gx2, gy2);
+                EmitGradientVertex(ox1, oy1, bboxLeft, bboxTop, gx1, gy1, gx2, gy2);
+            }
         }
         Rlgl.End();
     }

--- a/Runtimes/RaylibGum/Renderables/LineRectangle.cs
+++ b/Runtimes/RaylibGum/Renderables/LineRectangle.cs
@@ -224,6 +224,14 @@ public class LineRectangle : InvisibleRenderable
         }
     }
 
+    /// <summary>
+    /// Issue #2956 — see <see cref="LineCircle.ShouldPaintFillGradient"/> for the full
+    /// contract. Same gate, same predicate, applied to <see cref="DrawLinearGradientQuad"/>
+    /// and <see cref="DrawRadialGradientCircles"/> on the fill pass.
+    /// </summary>
+    public bool ShouldPaintFillGradient =>
+        UseGradient && (FillColor.HasValue || IsFilled) && (FillColor ?? Color).A > 0;
+
     public LineRectangle() : this(null) { }
 
     public LineRectangle(SystemManagers? _) { }
@@ -368,7 +376,16 @@ public class LineRectangle : InvisibleRenderable
                 // falloff. Both paths read GradientX1/Y1/X2/Y2/InnerRadius/OuterRadius in
                 // rectangle-local coords (origin = top-left, +X right, +Y down). Rotation
                 // applied via the same R() helper used by the outline path.
-                if (GradientType == GradientType.Linear)
+                //
+                // Issue #2956 — suppress the gradient when the slot's effective fill alpha is
+                // 0; neither DrawLinearGradientQuad nor DrawRadialGradientCircles modulates
+                // by fillColor.A, so a default-transparent fill would otherwise paint an
+                // opaque gradient. See ShouldPaintFillGradient.
+                if (fillColor.A == 0)
+                {
+                    // Slot is invisible — skip both the gradient and the solid path.
+                }
+                else if (GradientType == GradientType.Linear)
                 {
                     DrawLinearGradientQuad(tl, tr, br, bl, w, h);
                 }

--- a/Runtimes/RaylibGum/Renderables/LineRectangle.cs
+++ b/Runtimes/RaylibGum/Renderables/LineRectangle.cs
@@ -449,7 +449,11 @@ public class LineRectangle : InvisibleRenderable
         // Corner case not yet implemented: UseGradient = true with only StrokeColor (no fill).
         // Skia paints a gradient outline; raylib would currently fall through to solid stroke.
         // Not exercised by the sample; tracked as a #2757 follow-up.
-        if (runStroke && UseGradient && runFill)
+        //
+        // Issue #2956 — see the matching block in LineCircle for the same tightening.
+        // ShouldPaintFillGradient gates on effective fill alpha, so an IsFilled = false +
+        // transparent-fill cell leaves the solid stroke visible instead of suppressing it.
+        if (runStroke && ShouldPaintFillGradient)
         {
             runStroke = false;
         }

--- a/Runtimes/SkiaGum/CustomSetPropertyOnRenderable.cs
+++ b/Runtimes/SkiaGum/CustomSetPropertyOnRenderable.cs
@@ -30,6 +30,66 @@ namespace MonoGameGumShapes;
 
 public class CustomSetPropertyOnRenderable
 {
+    // Issue #2956 follow-up — two-slot CircleRuntime / RectangleRuntime own a fill renderable
+    // AND a stroke renderable. The runtime's typed setters (UseGradient, IsFilled,
+    // gradient color channels, gradient endpoints, etc.) forward to BOTH slots; reflection
+    // writes on the contained renderable hit only the fill slot. The dispatcher branches
+    // below special-case the properties they know about, but every new runtime property is
+    // a chance to forget — and forgetting silently leaves the stroke slot at its default
+    // (typically white opaque, which renders as a solid outline regardless of what the user
+    // configured).
+    //
+    // This helper closes the gap: when the GUE is the strongly-typed runtime and the
+    // property name resolves to a runtime-declared setter, route through it. If not, return
+    // false and let the renderable-side fallback take over. Cost is one PropertyInfo lookup
+    // per unhandled property (reflection on the runtime's type, not the renderable's).
+    //
+    // Visible bug this fixes: UseGradient = true + IsFilled = false in the tool produced a
+    // solid stroke instead of a gradient one, because `_stroke.UseGradient` never flipped.
+    private static bool TrySetPropertyOnRuntime(GraphicalUiElement graphicalUiElement, string propertyName, object value)
+    {
+        System.Reflection.PropertyInfo? pi = graphicalUiElement.GetType().GetProperty(propertyName);
+        if (pi == null || !pi.CanWrite)
+        {
+            return false;
+        }
+        // Skip properties declared on GraphicalUiElement itself — those are size/position/
+        // rotation/etc., already routed via TrySetValueOnThis earlier in the pipeline. We
+        // only want to intercept properties added by the typed runtime subclasses (CircleRuntime
+        // / RectangleRuntime / SkiaShapeRuntime / etc.).
+        if (pi.DeclaringType == typeof(GraphicalUiElement))
+        {
+            return false;
+        }
+        Type valueType = value.GetType();
+        if (valueType != pi.PropertyType)
+        {
+            if (valueType == typeof(PositionUnitType) && pi.PropertyType == typeof(GeneralUnitType))
+            {
+                value = UnitConverter.ConvertToGeneralUnit((PositionUnitType)value);
+            }
+            else
+            {
+                try
+                {
+                    value = System.Convert.ChangeType(value, pi.PropertyType);
+                }
+                catch
+                {
+                    return false;
+                }
+            }
+        }
+        try
+        {
+            pi.SetValue(graphicalUiElement, value);
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
 
     private static bool TrySetPropertiesOnRenderableBase(RenderableShapeBase renderableBase, GraphicalUiElement graphicalUiElement, string propertyName, object value)
     {
@@ -535,6 +595,11 @@ public class CustomSetPropertyOnRenderable
                     }
                     break;
             }
+            // Issue #2956 follow-up — see the Circle branch above for the rationale.
+            if (!handled)
+            {
+                handled = TrySetPropertyOnRuntime(graphicalUiElement, propertyName, value);
+            }
             if (!handled)
             {
                 handled = TrySetPropertiesOnRenderableBase(asRoundedRectangle, graphicalUiElement, propertyName, value);
@@ -793,6 +858,14 @@ public class CustomSetPropertyOnRenderable
                     break;
             }
 
+            // Issue #2956 follow-up — try the runtime first so any runtime-declared property
+            // (UseGradient, gradient endpoints, gradient color channels, etc.) routes through
+            // the runtime's typed setter, which forwards to both slots. Falling straight to
+            // TrySetPropertiesOnRenderableBase would write to the fill slot only.
+            if (!handled)
+            {
+                handled = TrySetPropertyOnRuntime(graphicalUiElement, propertyName, value);
+            }
             if(!handled)
             {
                 handled = TrySetPropertiesOnRenderableBase(asCircle, graphicalUiElement, propertyName, value);

--- a/Samples/GumShapesGallery/GumShapesGalleryCommon/Screens/CirclesScreen.cs
+++ b/Samples/GumShapesGallery/GumShapesGalleryCommon/Screens/CirclesScreen.cs
@@ -520,11 +520,6 @@ internal class CirclesScreen : FrameworkElement
         circle.XUnits = Gum.Converters.GeneralUnitType.PixelsFromMiddle;
         circle.YOrigin = VerticalAlignment.Center;
         circle.YUnits = Gum.Converters.GeneralUnitType.PixelsFromMiddle;
-        // Issue #2956 — FillColor must be opaque to light up the fill slot; UseGradient is a
-        // pattern flag, not a visibility flag, so a transparent fill (the default) would suppress
-        // the gradient. RGB is irrelevant — the gradient overrides per-pixel color; only alpha
-        // gates whether the slot paints at all.
-        circle.FillColor = Color.White;
         circle.UseGradient = true;
         circle.GradientType = GradientType.Linear;
         circle.Color1 = Color.Black;

--- a/Samples/GumShapesGallery/GumShapesGalleryCommon/Screens/CirclesScreen.cs
+++ b/Samples/GumShapesGallery/GumShapesGalleryCommon/Screens/CirclesScreen.cs
@@ -50,7 +50,8 @@ internal class CirclesScreen : FrameworkElement
         left.AddChild(BuildSection("Stroke width", BuildStrokeWidthRow()));
         left.AddChild(BuildSection("Alignment", BuildAlignmentRow()));
         left.AddChild(BuildSection("Gradients", BuildGradientRow()));
-        left.AddChild(BuildSection("Rotation", BuildRotationRow()));
+        left.AddChild(BuildSection("Rotation (filled)", BuildRotationRow(filled: true)));
+        left.AddChild(BuildSection("Rotation (outline)", BuildRotationRow(filled: false)));
 
         right.AddChild(BuildSection("Antialiasing", BuildAntialiasingRow()));
         right.AddChild(BuildSection("Dropshadow", BuildDropshadowRow()));
@@ -497,17 +498,24 @@ internal class CirclesScreen : FrameworkElement
     // makes the rotation angle obvious. Cells use a fixed-size frame because Rotation
     // pushes content outside the natural bounding box, which breaks the
     // RelativeToChildren row sizing. Mirrors the same row on the SilkNet and raylib sides.
-    static ContainerRuntime BuildRotationRow()
+    //
+    // Two rows: "filled" sets FillColor opaque so the gradient lights up the fill slot;
+    // "outline" sets IsFilled = false so the gradient lights up the stroke slot. Both rows
+    // exercise the same #2956 contract from opposite ends. raylib's CirclesScreen replaces
+    // the outline row with a "Not supported in raylib" label because raylib's LineCircle
+    // stroke pass is solid-color only and a solid outline on a rotation-symmetric circle
+    // has no rotation signal to show.
+    static ContainerRuntime BuildRotationRow(bool filled)
     {
         ContainerRuntime row = BuildHorizontalRow();
         foreach (float rotation in new[] { 0f, 60f, 120f, 180f })
         {
-            row.AddChild(BuildRotatedGradientCircleCell(rotation));
+            row.AddChild(BuildRotatedGradientCircleCell(rotation, filled));
         }
         return row;
     }
 
-    static RectangleRuntime BuildRotatedGradientCircleCell(float rotation)
+    static RectangleRuntime BuildRotatedGradientCircleCell(float rotation, bool filled)
     {
         RectangleRuntime frame = new();
         frame.Width = 70;
@@ -520,6 +528,14 @@ internal class CirclesScreen : FrameworkElement
         circle.XUnits = Gum.Converters.GeneralUnitType.PixelsFromMiddle;
         circle.YOrigin = VerticalAlignment.Center;
         circle.YUnits = Gum.Converters.GeneralUnitType.PixelsFromMiddle;
+        if (filled)
+        {
+            circle.FillColor = Color.White;
+        }
+        else
+        {
+            circle.IsFilled = false;
+        }
         circle.UseGradient = true;
         circle.GradientType = GradientType.Linear;
         circle.Color1 = Color.Black;

--- a/Samples/GumShapesGallery/GumShapesGalleryCommon/Screens/CirclesScreen.cs
+++ b/Samples/GumShapesGallery/GumShapesGalleryCommon/Screens/CirclesScreen.cs
@@ -520,6 +520,11 @@ internal class CirclesScreen : FrameworkElement
         circle.XUnits = Gum.Converters.GeneralUnitType.PixelsFromMiddle;
         circle.YOrigin = VerticalAlignment.Center;
         circle.YUnits = Gum.Converters.GeneralUnitType.PixelsFromMiddle;
+        // Issue #2956 — FillColor must be opaque to light up the fill slot; UseGradient is a
+        // pattern flag, not a visibility flag, so a transparent fill (the default) would suppress
+        // the gradient. RGB is irrelevant — the gradient overrides per-pixel color; only alpha
+        // gates whether the slot paints at all.
+        circle.FillColor = Color.White;
         circle.UseGradient = true;
         circle.GradientType = GradientType.Linear;
         circle.Color1 = Color.Black;

--- a/Samples/GumShapesGallery/GumShapesGalleryCommon/Screens/RectanglesScreen.cs
+++ b/Samples/GumShapesGallery/GumShapesGalleryCommon/Screens/RectanglesScreen.cs
@@ -56,7 +56,8 @@ internal class RectanglesScreen : FrameworkElement
         right.AddChild(BuildSection("Dashed strokes (solid / 6/4 / 2/2 dotted / long-dash) — stroke-only push (#2818)", BuildDashedStrokeRow()));
         right.AddChild(BuildSection("FillColor + StrokeColor on the same instance — both layers render simultaneously (#2768 / #2814)", BuildBothColorsRow()));
         right.AddChild(BuildSection("Inscribed in a 64x64 frame — stroke must stay inside the gray rectangle's bounds at every StrokeWidth (#2768 / #2814 visual contract; mirrors SilkNetGum)", BuildInscribedRow()));
-        right.AddChild(BuildSection("Rotation (0 / 60 / 120 / 180 degrees) — black→white gradient rectangles", BuildRotationRow()));
+        right.AddChild(BuildSection("Rotation (filled)", BuildRotationRow(filled: true)));
+        right.AddChild(BuildSection("Rotation (outline)", BuildRotationRow(filled: false)));
     }
 
     static ContainerRuntime BuildColumn()
@@ -435,17 +436,18 @@ internal class RectanglesScreen : FrameworkElement
     // frame because Rotation pushes content outside the natural bounding box, which
     // breaks RelativeToChildren row sizing. 100x100 frame is sized to contain a 70x50
     // rectangle at any rotation. Mirrors the same row on the SilkNet and raylib sides.
-    static ContainerRuntime BuildRotationRow()
+    // Two rows: see CirclesScreen.BuildRotationRow for the #2956 rationale.
+    static ContainerRuntime BuildRotationRow(bool filled)
     {
         ContainerRuntime row = BuildHorizontalRow();
         foreach (float rotation in new[] { 0f, 60f, 120f, 180f })
         {
-            row.AddChild(BuildRotatedGradientRectCell(rotation));
+            row.AddChild(BuildRotatedGradientRectCell(rotation, filled));
         }
         return row;
     }
 
-    static RectangleRuntime BuildRotatedGradientRectCell(float rotation)
+    static RectangleRuntime BuildRotatedGradientRectCell(float rotation, bool filled)
     {
         RectangleRuntime frame = new();
         frame.Width = 100;
@@ -459,6 +461,14 @@ internal class RectanglesScreen : FrameworkElement
         rect.XUnits = Gum.Converters.GeneralUnitType.PixelsFromMiddle;
         rect.YOrigin = VerticalAlignment.Center;
         rect.YUnits = Gum.Converters.GeneralUnitType.PixelsFromMiddle;
+        if (filled)
+        {
+            rect.FillColor = Color.White;
+        }
+        else
+        {
+            rect.IsFilled = false;
+        }
         rect.UseGradient = true;
         rect.GradientType = GradientType.Linear;
         rect.Color1 = Color.Black;

--- a/Samples/GumShapesGallery/GumShapesGalleryCommon/Screens/RectanglesScreen.cs
+++ b/Samples/GumShapesGallery/GumShapesGalleryCommon/Screens/RectanglesScreen.cs
@@ -459,9 +459,6 @@ internal class RectanglesScreen : FrameworkElement
         rect.XUnits = Gum.Converters.GeneralUnitType.PixelsFromMiddle;
         rect.YOrigin = VerticalAlignment.Center;
         rect.YUnits = Gum.Converters.GeneralUnitType.PixelsFromMiddle;
-        // Issue #2956 — FillColor must be opaque to light up the fill slot; see CirclesScreen
-        // BuildRotatedGradientCircleCell for the contract rationale.
-        rect.FillColor = Color.White;
         rect.UseGradient = true;
         rect.GradientType = GradientType.Linear;
         rect.Color1 = Color.Black;

--- a/Samples/GumShapesGallery/GumShapesGalleryCommon/Screens/RectanglesScreen.cs
+++ b/Samples/GumShapesGallery/GumShapesGalleryCommon/Screens/RectanglesScreen.cs
@@ -459,6 +459,9 @@ internal class RectanglesScreen : FrameworkElement
         rect.XUnits = Gum.Converters.GeneralUnitType.PixelsFromMiddle;
         rect.YOrigin = VerticalAlignment.Center;
         rect.YUnits = Gum.Converters.GeneralUnitType.PixelsFromMiddle;
+        // Issue #2956 — FillColor must be opaque to light up the fill slot; see CirclesScreen
+        // BuildRotatedGradientCircleCell for the contract rationale.
+        rect.FillColor = Color.White;
         rect.UseGradient = true;
         rect.GradientType = GradientType.Linear;
         rect.Color1 = Color.Black;

--- a/Samples/SilkNetGum/SilkNetGum/Screens/CirclesScreen.cs
+++ b/Samples/SilkNetGum/SilkNetGum/Screens/CirclesScreen.cs
@@ -505,6 +505,12 @@ internal class CirclesScreen : GraphicalUiElement
         circle.XUnits = Gum.Converters.GeneralUnitType.PixelsFromMiddle;
         circle.YOrigin = VerticalAlignment.Center;
         circle.YUnits = Gum.Converters.GeneralUnitType.PixelsFromMiddle;
+        // Issue #2956 — FillColor must be opaque to light up the fill slot; see the MG
+        // CirclesScreen counterpart for the contract rationale. On Skia this is the
+        // design-correct behavior (paint.Color.alpha gates the shader natively), so before
+        // setting FillColor the gradient would render on the stroke only; with FillColor
+        // opaque it now paints on the fill and matches the other backends.
+        circle.FillColor = SKColors.White;
         circle.UseGradient = true;
         circle.GradientType = GradientType.Linear;
         circle.Color1 = SKColors.Black;

--- a/Samples/SilkNetGum/SilkNetGum/Screens/CirclesScreen.cs
+++ b/Samples/SilkNetGum/SilkNetGum/Screens/CirclesScreen.cs
@@ -505,12 +505,6 @@ internal class CirclesScreen : GraphicalUiElement
         circle.XUnits = Gum.Converters.GeneralUnitType.PixelsFromMiddle;
         circle.YOrigin = VerticalAlignment.Center;
         circle.YUnits = Gum.Converters.GeneralUnitType.PixelsFromMiddle;
-        // Issue #2956 — FillColor must be opaque to light up the fill slot; see the MG
-        // CirclesScreen counterpart for the contract rationale. On Skia this is the
-        // design-correct behavior (paint.Color.alpha gates the shader natively), so before
-        // setting FillColor the gradient would render on the stroke only; with FillColor
-        // opaque it now paints on the fill and matches the other backends.
-        circle.FillColor = SKColors.White;
         circle.UseGradient = true;
         circle.GradientType = GradientType.Linear;
         circle.Color1 = SKColors.Black;

--- a/Samples/SilkNetGum/SilkNetGum/Screens/CirclesScreen.cs
+++ b/Samples/SilkNetGum/SilkNetGum/Screens/CirclesScreen.cs
@@ -45,7 +45,8 @@ internal class CirclesScreen : GraphicalUiElement
         left.Children.Add(BuildSection("Stroke width", BuildStrokeWidthRow()));
         left.Children.Add(BuildSection("Alignment", BuildAlignmentRow()));
         left.Children.Add(BuildSection("Gradients", BuildGradientRow()));
-        left.Children.Add(BuildSection("Rotation", BuildRotationRow()));
+        left.Children.Add(BuildSection("Rotation (filled)", BuildRotationRow(filled: true)));
+        left.Children.Add(BuildSection("Rotation (outline)", BuildRotationRow(filled: false)));
 
         right.Children.Add(BuildSection("Antialiasing", BuildAntialiasingRow()));
         right.Children.Add(BuildSection("Dropshadow", BuildDropshadowRow()));
@@ -482,17 +483,18 @@ internal class CirclesScreen : GraphicalUiElement
     // makes the rotation angle obvious. Cells use a fixed-size frame because Rotation
     // pushes content outside the natural bounding box, which breaks the
     // RelativeToChildren row sizing. Mirrors the same row on the MG and raylib sides.
-    static ContainerRuntime BuildRotationRow()
+    // Two rows: see the MG CirclesScreen counterpart for the #2956 rationale.
+    static ContainerRuntime BuildRotationRow(bool filled)
     {
         ContainerRuntime row = BuildHorizontalRow();
         foreach (float rotation in new[] { 0f, 60f, 120f, 180f })
         {
-            row.Children.Add(BuildRotatedGradientCircleCell(rotation));
+            row.Children.Add(BuildRotatedGradientCircleCell(rotation, filled));
         }
         return row;
     }
 
-    static RectangleRuntime BuildRotatedGradientCircleCell(float rotation)
+    static RectangleRuntime BuildRotatedGradientCircleCell(float rotation, bool filled)
     {
         RectangleRuntime frame = new();
         frame.Width = 70;
@@ -505,6 +507,14 @@ internal class CirclesScreen : GraphicalUiElement
         circle.XUnits = Gum.Converters.GeneralUnitType.PixelsFromMiddle;
         circle.YOrigin = VerticalAlignment.Center;
         circle.YUnits = Gum.Converters.GeneralUnitType.PixelsFromMiddle;
+        if (filled)
+        {
+            circle.FillColor = SKColors.White;
+        }
+        else
+        {
+            circle.IsFilled = false;
+        }
         circle.UseGradient = true;
         circle.GradientType = GradientType.Linear;
         circle.Color1 = SKColors.Black;

--- a/Samples/SilkNetGum/SilkNetGum/Screens/RectanglesScreen.cs
+++ b/Samples/SilkNetGum/SilkNetGum/Screens/RectanglesScreen.cs
@@ -339,6 +339,9 @@ internal class RectanglesScreen : GraphicalUiElement
         rect.XUnits = Gum.Converters.GeneralUnitType.PixelsFromMiddle;
         rect.YOrigin = VerticalAlignment.Center;
         rect.YUnits = Gum.Converters.GeneralUnitType.PixelsFromMiddle;
+        // Issue #2956 — FillColor must be opaque to light up the fill slot; see the MG
+        // CirclesScreen for the contract rationale.
+        rect.FillColor = SKColors.White;
         rect.UseGradient = true;
         rect.GradientType = GradientType.Linear;
         rect.Color1 = SKColors.Black;

--- a/Samples/SilkNetGum/SilkNetGum/Screens/RectanglesScreen.cs
+++ b/Samples/SilkNetGum/SilkNetGum/Screens/RectanglesScreen.cs
@@ -339,9 +339,6 @@ internal class RectanglesScreen : GraphicalUiElement
         rect.XUnits = Gum.Converters.GeneralUnitType.PixelsFromMiddle;
         rect.YOrigin = VerticalAlignment.Center;
         rect.YUnits = Gum.Converters.GeneralUnitType.PixelsFromMiddle;
-        // Issue #2956 — FillColor must be opaque to light up the fill slot; see the MG
-        // CirclesScreen for the contract rationale.
-        rect.FillColor = SKColors.White;
         rect.UseGradient = true;
         rect.GradientType = GradientType.Linear;
         rect.Color1 = SKColors.Black;

--- a/Samples/SilkNetGum/SilkNetGum/Screens/RectanglesScreen.cs
+++ b/Samples/SilkNetGum/SilkNetGum/Screens/RectanglesScreen.cs
@@ -56,7 +56,8 @@ internal class RectanglesScreen : GraphicalUiElement
         right.Children.Add(BuildSection("Dashed strokes (solid / 6/4 / 2/2 dotted / long-dash) — Skia routes through SkiaShapeRuntime.StrokeDashLength (#2796)", BuildDashedStrokeRow()));
         right.Children.Add(BuildSection("FillColor + StrokeColor on the same instance — both layers render simultaneously (#2814)", BuildBothColorsRow()));
         right.Children.Add(BuildSection("Inscribed in a 64x64 frame — stroke must stay inside the gray rectangle's bounds at every StrokeWidth (#2814 visual contract)", BuildInscribedRow()));
-        right.Children.Add(BuildSection("Rotation (0 / 60 / 120 / 180 degrees) — black→white gradient rectangles", BuildRotationRow()));
+        right.Children.Add(BuildSection("Rotation (filled)", BuildRotationRow(filled: true)));
+        right.Children.Add(BuildSection("Rotation (outline)", BuildRotationRow(filled: false)));
     }
 
     static ContainerRuntime BuildColumn()
@@ -315,17 +316,18 @@ internal class RectanglesScreen : GraphicalUiElement
     // frame because Rotation pushes content outside the natural bounding box, which
     // breaks RelativeToChildren row sizing. 100x100 frame is sized to contain a 70x50
     // rectangle at any rotation. Mirrors the same row on the MG and raylib sides.
-    static ContainerRuntime BuildRotationRow()
+    // Two rows: see the MG CirclesScreen counterpart for the #2956 rationale.
+    static ContainerRuntime BuildRotationRow(bool filled)
     {
         ContainerRuntime row = BuildHorizontalRow();
         foreach (float rotation in new[] { 0f, 60f, 120f, 180f })
         {
-            row.Children.Add(BuildRotatedGradientRectCell(rotation));
+            row.Children.Add(BuildRotatedGradientRectCell(rotation, filled));
         }
         return row;
     }
 
-    static RectangleRuntime BuildRotatedGradientRectCell(float rotation)
+    static RectangleRuntime BuildRotatedGradientRectCell(float rotation, bool filled)
     {
         RectangleRuntime frame = new();
         frame.Width = 100;
@@ -339,6 +341,14 @@ internal class RectanglesScreen : GraphicalUiElement
         rect.XUnits = Gum.Converters.GeneralUnitType.PixelsFromMiddle;
         rect.YOrigin = VerticalAlignment.Center;
         rect.YUnits = Gum.Converters.GeneralUnitType.PixelsFromMiddle;
+        if (filled)
+        {
+            rect.FillColor = SKColors.White;
+        }
+        else
+        {
+            rect.IsFilled = false;
+        }
         rect.UseGradient = true;
         rect.GradientType = GradientType.Linear;
         rect.Color1 = SKColors.Black;

--- a/Samples/raylib/Screens/CirclesScreen.cs
+++ b/Samples/raylib/Screens/CirclesScreen.cs
@@ -204,6 +204,9 @@ internal class CirclesScreen : FrameworkElement
         circle.XUnits = GeneralUnitType.PixelsFromMiddle;
         circle.YOrigin = VerticalAlignment.Center;
         circle.YUnits = GeneralUnitType.PixelsFromMiddle;
+        // Issue #2956 — FillColor must be opaque to light up the fill slot; see the MG
+        // CirclesScreen counterpart for the contract rationale.
+        circle.FillColor = Color.White;
         circle.UseGradient = true;
         circle.GradientType = GradientType.Linear;
         circle.Color1 = Color.Black;

--- a/Samples/raylib/Screens/CirclesScreen.cs
+++ b/Samples/raylib/Screens/CirclesScreen.cs
@@ -48,7 +48,8 @@ internal class CirclesScreen : FrameworkElement
         left.Children.Add(BuildSection("Stroke width", BuildStrokeWidthRow()));
         left.Children.Add(BuildSection("Alignment", BuildAlignmentRow()));
         left.Children.Add(BuildSection("Gradients", BuildGradientRow()));
-        left.Children.Add(BuildSection("Rotation", BuildRotationRow()));
+        left.Children.Add(BuildSection("Rotation (filled)", BuildRotationFilledRow()));
+        left.Children.Add(BuildSection("Rotation (outline)", BuildRotationOutlineUnsupportedRow()));
 
         right.Children.Add(BuildSection("Dropshadow", BuildDropshadowRow()));
         right.Children.Add(BuildSection("Dashed strokes", BuildDashedStrokeRow()));
@@ -181,13 +182,33 @@ internal class CirclesScreen : FrameworkElement
     // makes the rotation angle obvious. Cells use a fixed-size frame because Rotation
     // pushes content outside the natural bounding box, which breaks the
     // RelativeToChildren row sizing. Mirrors the same row on the MG and SilkNet sides.
-    static ContainerRuntime BuildRotationRow()
+    // Filled row only on raylib — see BuildRotationOutlineUnsupportedRow for why the outline
+    // row is replaced with a label. The filled row exercises the post-#2956 contract on the
+    // fill slot, plus the new LineCircle rotation handling added in the same PR.
+    static ContainerRuntime BuildRotationFilledRow()
     {
         ContainerRuntime row = BuildHorizontalRow();
         foreach (float rotation in new[] { 0f, 60f, 120f, 180f })
         {
             row.Children.Add(BuildRotatedGradientCircleCell(rotation));
         }
+        return row;
+    }
+
+    // Issue #2956 — raylib's LineCircle stroke pass is solid-color only (no gradient-on-
+    // stroke support); combined with default-transparent fill, an outline + gradient cell
+    // would render either nothing (with the contract enforced) or a solid white outline on
+    // a rotation-symmetric circle (no rotation signal). Label the row instead so the gallery
+    // documents the limitation rather than presenting a misleading visual.
+    static ContainerRuntime BuildRotationOutlineUnsupportedRow()
+    {
+        ContainerRuntime row = BuildHorizontalRow();
+        TextRuntime label = new();
+        label.Text = "Not supported in raylib (LineCircle has no gradient-on-stroke path)";
+        label.Red = 220;
+        label.Green = 220;
+        label.Blue = 220;
+        row.Children.Add(label);
         return row;
     }
 
@@ -204,6 +225,9 @@ internal class CirclesScreen : FrameworkElement
         circle.XUnits = GeneralUnitType.PixelsFromMiddle;
         circle.YOrigin = VerticalAlignment.Center;
         circle.YUnits = GeneralUnitType.PixelsFromMiddle;
+        // Filled cell — light up the fill slot with an opaque color so the gradient renders
+        // on the fill. raylib's outline-only case is handled by BuildRotationOutlineUnsupportedRow.
+        circle.FillColor = Color.White;
         circle.UseGradient = true;
         circle.GradientType = GradientType.Linear;
         circle.Color1 = Color.Black;

--- a/Samples/raylib/Screens/CirclesScreen.cs
+++ b/Samples/raylib/Screens/CirclesScreen.cs
@@ -204,9 +204,6 @@ internal class CirclesScreen : FrameworkElement
         circle.XUnits = GeneralUnitType.PixelsFromMiddle;
         circle.YOrigin = VerticalAlignment.Center;
         circle.YUnits = GeneralUnitType.PixelsFromMiddle;
-        // Issue #2956 — FillColor must be opaque to light up the fill slot; see the MG
-        // CirclesScreen counterpart for the contract rationale.
-        circle.FillColor = Color.White;
         circle.UseGradient = true;
         circle.GradientType = GradientType.Linear;
         circle.Color1 = Color.Black;

--- a/Samples/raylib/Screens/RectanglesScreen.cs
+++ b/Samples/raylib/Screens/RectanglesScreen.cs
@@ -356,9 +356,6 @@ internal class RectanglesScreen : FrameworkElement
         rect.XUnits = GeneralUnitType.PixelsFromMiddle;
         rect.YOrigin = VerticalAlignment.Center;
         rect.YUnits = GeneralUnitType.PixelsFromMiddle;
-        // Issue #2956 — FillColor must be opaque to light up the fill slot; see the MG
-        // CirclesScreen for the contract rationale.
-        rect.FillColor = Color.White;
         rect.UseGradient = true;
         rect.GradientType = GradientType.Linear;
         rect.Color1 = Color.Black;

--- a/Samples/raylib/Screens/RectanglesScreen.cs
+++ b/Samples/raylib/Screens/RectanglesScreen.cs
@@ -55,7 +55,8 @@ internal class RectanglesScreen : FrameworkElement
         right.Children.Add(BuildSection("Dashed strokes (solid / 6/4 / 2/2 dotted / long-dash) — raylib walks the perimeter, one DrawLineEx per dash (#2757)", BuildDashedStrokeRow()));
         right.Children.Add(BuildSection("FillColor + StrokeColor on the same instance — both layers render simultaneously (#2757)", BuildBothColorsRow()));
         right.Children.Add(BuildSection("Inscribed in a 64x64 frame — stroke must stay inside the gray rectangle's bounds at every StrokeWidth (#2757)", BuildInscribedRow()));
-        right.Children.Add(BuildSection("Rotation (0 / 60 / 120 / 180 degrees) — black→white gradient rectangles", BuildRotationRow()));
+        right.Children.Add(BuildSection("Rotation (filled)", BuildRotationFilledRow()));
+        right.Children.Add(BuildSection("Rotation (outline)", BuildRotationOutlineUnsupportedRow()));
     }
 
     static ContainerRuntime BuildColumn()
@@ -332,13 +333,31 @@ internal class RectanglesScreen : FrameworkElement
     // frame because Rotation pushes content outside the natural bounding box, which
     // breaks RelativeToChildren row sizing. 100x100 frame is sized to contain a 70x50
     // rectangle at any rotation. Mirrors the same row on the MG and SilkNet sides.
-    static ContainerRuntime BuildRotationRow()
+    // Filled row only on raylib — see BuildRotationOutlineUnsupportedRow for why the outline
+    // row is replaced with a label.
+    static ContainerRuntime BuildRotationFilledRow()
     {
         ContainerRuntime row = BuildHorizontalRow();
         foreach (float rotation in new[] { 0f, 60f, 120f, 180f })
         {
             row.Children.Add(BuildRotatedGradientRectCell(rotation));
         }
+        return row;
+    }
+
+    // Issue #2956 — raylib's LineRectangle stroke pass is solid-color only (no gradient-on-
+    // stroke support). The outline row's contract (gradient on stroke) can't be exercised
+    // there, so label the row to document the limitation instead of presenting a misleading
+    // visual. Kept consistent with the matching label on raylib's CirclesScreen.
+    static ContainerRuntime BuildRotationOutlineUnsupportedRow()
+    {
+        ContainerRuntime row = BuildHorizontalRow();
+        TextRuntime label = new();
+        label.Text = "Not supported in raylib (LineRectangle has no gradient-on-stroke path)";
+        label.Red = 220;
+        label.Green = 220;
+        label.Blue = 220;
+        row.Children.Add(label);
         return row;
     }
 
@@ -356,6 +375,9 @@ internal class RectanglesScreen : FrameworkElement
         rect.XUnits = GeneralUnitType.PixelsFromMiddle;
         rect.YOrigin = VerticalAlignment.Center;
         rect.YUnits = GeneralUnitType.PixelsFromMiddle;
+        // Filled cell — light up the fill slot so the gradient renders on the fill. raylib's
+        // outline-only case is handled by BuildRotationOutlineUnsupportedRow.
+        rect.FillColor = Color.White;
         rect.UseGradient = true;
         rect.GradientType = GradientType.Linear;
         rect.Color1 = Color.Black;

--- a/Samples/raylib/Screens/RectanglesScreen.cs
+++ b/Samples/raylib/Screens/RectanglesScreen.cs
@@ -356,6 +356,9 @@ internal class RectanglesScreen : FrameworkElement
         rect.XUnits = GeneralUnitType.PixelsFromMiddle;
         rect.YOrigin = VerticalAlignment.Center;
         rect.YUnits = GeneralUnitType.PixelsFromMiddle;
+        // Issue #2956 — FillColor must be opaque to light up the fill slot; see the MG
+        // CirclesScreen for the contract rationale.
+        rect.FillColor = Color.White;
         rect.UseGradient = true;
         rect.GradientType = GradientType.Linear;
         rect.Color1 = Color.Black;

--- a/Tests/MonoGameGum.Shapes.Tests/CircleRenderableTests.cs
+++ b/Tests/MonoGameGum.Shapes.Tests/CircleRenderableTests.cs
@@ -388,4 +388,44 @@ public class CircleRenderableTests
         strokeWidth.ShouldBeGreaterThan(0f);
         color.A.ShouldBe((byte)0);
     }
+
+    // Issue #2956 — UseGradient is a *pattern* flag, not a *visibility* flag. A slot whose
+    // solid color alpha is 0 (e.g. the default-transparent fill on a stroke-only plain Circle)
+    // must NOT paint its gradient — Apos.Shapes' gradient draw bypasses the slot's solid color
+    // and would otherwise paint an opaque gradient on a slot the user has explicitly hidden.
+    // SkPaint achieves this naturally (paint.Color.alpha modulates the shader output); Apos
+    // does not, so we gate the gradient draw explicitly at the call site. Sample cells in the
+    // gallery now set FillColor opaque to keep the gradient visible — see migration note.
+
+    [Fact]
+    public void ShouldPaintGradient_GradientOff_False()
+    {
+        Circle sut = new() { UseGradient = false, Color = new Color(255, 255, 255, 255) };
+
+        sut.ShouldPaintGradient(forcedColor: null).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ShouldPaintGradient_GradientOn_ForcedColor_False()
+    {
+        Circle sut = new() { UseGradient = true, Color = new Color(255, 255, 255, 255) };
+
+        sut.ShouldPaintGradient(forcedColor: new Color(0, 0, 0, 255)).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ShouldPaintGradient_GradientOn_OpaqueSlot_True()
+    {
+        Circle sut = new() { UseGradient = true, Color = new Color(255, 255, 255, 255) };
+
+        sut.ShouldPaintGradient(forcedColor: null).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void ShouldPaintGradient_GradientOn_TransparentSlot_False()
+    {
+        Circle sut = new() { UseGradient = true, Color = new Color(255, 255, 255, 0) };
+
+        sut.ShouldPaintGradient(forcedColor: null).ShouldBeFalse();
+    }
 }

--- a/Tests/MonoGameGum.Shapes.Tests/CircleRuntimeTests.cs
+++ b/Tests/MonoGameGum.Shapes.Tests/CircleRuntimeTests.cs
@@ -880,4 +880,79 @@ public class CircleRuntimeTests
             RenderingLibrary.SystemManagers.Default.Renderer.Camera.Zoom = originalZoom;
         }
     }
+
+    // Issue #2956 follow-up — the Gum tool's variable grid drives runtime properties via
+    // GraphicalUiElement.SetProperty(name, value), which dispatches through
+    // CustomSetPropertyOnRenderable. That dispatcher's CircleRuntime-typed branch only
+    // special-cases the legacy single-slot properties (Color/Red/Green/Blue/Alpha/Radius);
+    // every other property falls through to reflection on the *contained renderable*. For a
+    // two-slot CircleRuntime the contained renderable is the fill slot, so two-slot variables
+    // (UseGradient, IsFilled, FillColor, StrokeColor, etc.) only reach the fill slot — the
+    // stroke slot never sees them. Visible symptom: `UseGradient = true` + `IsFilled = false`
+    // makes the stroke render solid because the stroke slot's UseGradient never flipped.
+    //
+    // These tests pin the contract that SetProperty routes through the *runtime's* typed
+    // setters for two-slot variables. Each test confirms a runtime-level side effect that
+    // only happens when the runtime setter is called (not when reflection writes directly to
+    // the contained renderable).
+
+    [Fact]
+    public void SetProperty_UseGradient_ForwardsToBothSlots()
+    {
+        CircleRuntime sut = new();
+
+        sut.SetProperty("UseGradient", true);
+
+        Circle fill = (Circle)sut.RenderableComponent;
+        Circle stroke = (Circle)fill.Children[0];
+        fill.UseGradient.ShouldBeTrue();
+        stroke.UseGradient.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void SetProperty_IsFilled_RoutesThroughRuntimeSetter()
+    {
+        // The runtime's IsFilled setter zeros _fill.Color.A when IsFilled = false; reflection
+        // writing IsFilled directly to the fill renderable would instead flip the renderable's
+        // own IsFilled flag (which the factory pins to true). The runtime-level Color.A = 0 is
+        // the visible signature that the runtime setter ran.
+        CircleRuntime sut = new();
+        sut.FillColor = new Color(200, 100, 50, 255);
+
+        sut.SetProperty("IsFilled", false);
+
+        Circle fill = (Circle)sut.RenderableComponent;
+        fill.Color.A.ShouldBe((byte)0);
+        // Runtime keeps the renderable's IsFilled pinned to true (factory contract); only
+        // _fill.Color.A is zeroed when the runtime's IsFilled toggles off.
+        fill.IsFilled.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void SetProperty_StrokeColor_WritesToStrokeSlot()
+    {
+        // Reflection on the contained renderable (fill slot) would write Color on the fill,
+        // not the stroke — and there's no "StrokeColor" property on Apos's Circle renderable
+        // at all, so reflection would silently no-op. Going through the runtime's StrokeColor
+        // setter writes _stroke.Color.
+        CircleRuntime sut = new();
+
+        sut.SetProperty("StrokeColor", new Color(10, 20, 30, 255));
+
+        Circle fill = (Circle)sut.RenderableComponent;
+        Circle stroke = (Circle)fill.Children[0];
+        stroke.Color.ShouldBe(new Color(10, 20, 30, 255));
+    }
+
+    [Fact]
+    public void SetProperty_FillColor_WritesToFillSlot()
+    {
+        CircleRuntime sut = new();
+
+        sut.SetProperty("FillColor", new Color(60, 70, 80, 255));
+
+        sut.FillColor.ShouldBe(new Color(60, 70, 80, 255));
+        Circle fill = (Circle)sut.RenderableComponent;
+        fill.Color.ShouldBe(new Color(60, 70, 80, 255));
+    }
 }

--- a/Tests/RaylibGum.Tests/Renderables/LineCircleTests.cs
+++ b/Tests/RaylibGum.Tests/Renderables/LineCircleTests.cs
@@ -279,4 +279,84 @@ public class LineCircleTests
 
         circle.ShouldPaintFillGradient.ShouldBeFalse();
     }
+
+    // Issue #2934 / #2956 — LineCircle.Render previously ignored Rotation entirely. The disc
+    // is rotation-symmetric so its position doesn't change, but the gradient axis (defined in
+    // object-local bbox coords) must rotate around the bbox center to track the shape — same
+    // contract Apos's RenderableShapeBase.GetGradient enforces (PR #2945). The fix rotates
+    // GradientX1/Y1 and GradientX2/Y2 around the bbox center (Radius, Radius) before
+    // projection in EmitGradientVertex. Rotation convention mirrors LineRectangle's R helper
+    // (visual CCW on screen: [cos sin; -sin cos]).
+
+    [Fact]
+    public void GetRotatedGradientEndpoints_ZeroRotation_ReturnsOriginalEndpoints()
+    {
+        LineCircle circle = new()
+        {
+            Width = 56,
+            Height = 56,
+            GradientX1 = 0f,
+            GradientY1 = 0f,
+            GradientX2 = 20f,
+            GradientY2 = 0f,
+        };
+
+        (float x1, float y1, float x2, float y2) = circle.GetRotatedGradientEndpoints(rotationDegrees: 0f);
+
+        x1.ShouldBe(0f);
+        y1.ShouldBe(0f);
+        x2.ShouldBe(20f);
+        y2.ShouldBe(0f);
+    }
+
+    [Fact]
+    public void GetRotatedGradientEndpoints_NinetyDegrees_PivotsAroundBboxCenter()
+    {
+        // bbox is 56x56, center is at (28, 28) in local coords. Original axis runs from
+        // (0, 0) to (20, 0). A 90° CCW rotation (visual) around (28, 28) maps:
+        //   (0, 0)  → (28 - 28, 28 + 28) = (0, 56)   (delta -28,-28 → cos sin = 0,1 → 0*0 + -28*1 = -28; -(-28)*1 + -28*0 = 28; (28-28, 28+28) = (0, 56))
+        // hmm let me recompute by hand using LineRectangle's formula: (cx + dx*cos + dy*sin, cy - dx*sin + dy*cos)
+        // (0,0): dx=-28, dy=-28; cos(90°)=0, sin(90°)=1 → (28 + 0 + -28, 28 - -28 + 0) = (0, 56)
+        // (20,0): dx=-8, dy=-28 → (28 + 0 + -28, 28 - -8 + 0) = (0, 36)
+        LineCircle circle = new()
+        {
+            Width = 56,
+            Height = 56,
+            GradientX1 = 0f,
+            GradientY1 = 0f,
+            GradientX2 = 20f,
+            GradientY2 = 0f,
+        };
+
+        (float x1, float y1, float x2, float y2) = circle.GetRotatedGradientEndpoints(rotationDegrees: 90f);
+
+        x1.ShouldBe(0f, tolerance: 0.001);
+        y1.ShouldBe(56f, tolerance: 0.001);
+        x2.ShouldBe(0f, tolerance: 0.001);
+        y2.ShouldBe(36f, tolerance: 0.001);
+    }
+
+    [Fact]
+    public void GetRotatedGradientEndpoints_OneHundredEightyDegrees_FlipsAcrossBboxCenter()
+    {
+        // 180° flips both endpoints across the bbox center (28, 28).
+        // (0, 0)  → (56, 56)
+        // (20, 0) → (36, 56)
+        LineCircle circle = new()
+        {
+            Width = 56,
+            Height = 56,
+            GradientX1 = 0f,
+            GradientY1 = 0f,
+            GradientX2 = 20f,
+            GradientY2 = 0f,
+        };
+
+        (float x1, float y1, float x2, float y2) = circle.GetRotatedGradientEndpoints(rotationDegrees: 180f);
+
+        x1.ShouldBe(56f, tolerance: 0.001);
+        y1.ShouldBe(56f, tolerance: 0.001);
+        x2.ShouldBe(36f, tolerance: 0.001);
+        y2.ShouldBe(56f, tolerance: 0.001);
+    }
 }

--- a/Tests/RaylibGum.Tests/Renderables/LineCircleTests.cs
+++ b/Tests/RaylibGum.Tests/Renderables/LineCircleTests.cs
@@ -222,4 +222,61 @@ public class LineCircleTests
         circle.Color.B.ShouldBe((byte)56);
         circle.Color.A.ShouldBe((byte)78);
     }
+
+    // Issue #2956 — UseGradient is a *pattern* flag, not a *visibility* flag. The effective
+    // fill color is `FillColor ?? Color`; when its alpha is 0 the slot is invisible and the
+    // gradient must not paint over it. Mirrors the SkPaint contract (paint.Color.alpha
+    // modulates shader output) that the SkiaGum backend enforces naturally. Apos and raylib
+    // both used to leak — see fix in EmitGradientVertex / DrawGradientFan gating.
+
+    [Fact]
+    public void ShouldPaintFillGradient_FillColorOpaque_True()
+    {
+        LineCircle circle = new() { UseGradient = true, FillColor = new Color(10, 20, 30, 255) };
+
+        circle.ShouldPaintFillGradient.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void ShouldPaintFillGradient_FillColorTransparent_False()
+    {
+        LineCircle circle = new() { UseGradient = true, FillColor = new Color(10, 20, 30, 0) };
+
+        circle.ShouldPaintFillGradient.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ShouldPaintFillGradient_GradientOff_False()
+    {
+        LineCircle circle = new() { UseGradient = false, FillColor = new Color(10, 20, 30, 255) };
+
+        circle.ShouldPaintFillGradient.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ShouldPaintFillGradient_LegacyFillViaIsFilled_OpaqueColor_True()
+    {
+        LineCircle circle = new() { UseGradient = true, IsFilled = true };
+
+        // Default Color is opaque white, so the legacy fill path lights up.
+        circle.ShouldPaintFillGradient.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void ShouldPaintFillGradient_LegacyFillViaIsFilled_TransparentColor_False()
+    {
+        LineCircle circle = new() { UseGradient = true, IsFilled = true, Alpha = 0 };
+
+        circle.ShouldPaintFillGradient.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ShouldPaintFillGradient_NoFillSlotEnabled_False()
+    {
+        // Default LineCircle: IsFilled = false, FillColor = null → fill pass doesn't run at all,
+        // so the gradient cannot paint regardless of UseGradient.
+        LineCircle circle = new() { UseGradient = true };
+
+        circle.ShouldPaintFillGradient.ShouldBeFalse();
+    }
 }

--- a/Tests/RaylibGum.Tests/Renderables/LineRectangleTests.cs
+++ b/Tests/RaylibGum.Tests/Renderables/LineRectangleTests.cs
@@ -193,4 +193,56 @@ public class LineRectangleTests
         rectangle.Color.B.ShouldBe((byte)56);
         rectangle.Color.A.ShouldBe((byte)78);
     }
+
+    // Issue #2956 — see LineCircleTests.ShouldPaintFillGradient_* for the full contract.
+    // Same gating logic applies to LineRectangle's fill gradient path (linear quad + radial
+    // concentric circles).
+
+    [Fact]
+    public void ShouldPaintFillGradient_FillColorOpaque_True()
+    {
+        LineRectangle rectangle = new() { UseGradient = true, FillColor = new Color(10, 20, 30, 255) };
+
+        rectangle.ShouldPaintFillGradient.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void ShouldPaintFillGradient_FillColorTransparent_False()
+    {
+        LineRectangle rectangle = new() { UseGradient = true, FillColor = new Color(10, 20, 30, 0) };
+
+        rectangle.ShouldPaintFillGradient.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ShouldPaintFillGradient_GradientOff_False()
+    {
+        LineRectangle rectangle = new() { UseGradient = false, FillColor = new Color(10, 20, 30, 255) };
+
+        rectangle.ShouldPaintFillGradient.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ShouldPaintFillGradient_LegacyFillViaIsFilled_OpaqueColor_True()
+    {
+        LineRectangle rectangle = new() { UseGradient = true, IsFilled = true };
+
+        rectangle.ShouldPaintFillGradient.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void ShouldPaintFillGradient_LegacyFillViaIsFilled_TransparentColor_False()
+    {
+        LineRectangle rectangle = new() { UseGradient = true, IsFilled = true, Alpha = 0 };
+
+        rectangle.ShouldPaintFillGradient.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ShouldPaintFillGradient_NoFillSlotEnabled_False()
+    {
+        LineRectangle rectangle = new() { UseGradient = true };
+
+        rectangle.ShouldPaintFillGradient.ShouldBeFalse();
+    }
 }

--- a/docs/gum-tool/upgrading/migrating-to-2026-may.md
+++ b/docs/gum-tool/upgrading/migrating-to-2026-may.md
@@ -369,6 +369,37 @@ The `Gum.Analyzers` package ships an automated code fix (`GUM002`) — place the
 
 The obsolete types will remain in place until at least the November 2026 release. After that window, they may be marked `[Obsolete(error: true)]` in a subsequent release, breaking compilation for any code still using them.
 
+### Breaking: `UseGradient` no longer paints over a transparent fill slot
+
+Issue #2956 — `UseGradient` is a *pattern* flag, not a *visibility* flag. A slot whose effective color alpha is 0 (e.g. the default-transparent fill on a stroke-only plain `CircleRuntime` / `RectangleRuntime`) no longer paints its gradient. This brings the Apos.Shapes (MonoGame/FNA/KNI) and raylib backends in line with the SkiaGum backend, which has always enforced this naturally — `SKPaint.Color.alpha` modulates the shader output, so a transparent paint color suppresses the gradient.
+
+Before the fix, the same code rendered differently across backends: Apos and raylib painted an opaque gradient on a fill slot the user had explicitly hidden via the documented default; Skia correctly suppressed it. After the fix, all three backends agree.
+
+❌ Old (worked accidentally on Apos / raylib, silent no-op on Skia):
+
+```csharp
+var circle = new CircleRuntime();
+circle.Radius = 28;
+circle.UseGradient = true;
+circle.Color1 = Color.Black;
+circle.Color2 = Color.White;
+// Gradient appeared on the fill on Apos and raylib — even though FillColor
+// defaults to transparent, which is supposed to hide the fill.
+```
+
+✅ New (paints the same on every backend):
+
+```csharp
+var circle = new CircleRuntime();
+circle.Radius = 28;
+circle.FillColor = Color.White;   // light the fill slot up — opaque, RGB irrelevant
+circle.UseGradient = true;
+circle.Color1 = Color.Black;
+circle.Color2 = Color.White;
+```
+
+The RGB of `FillColor` doesn't matter — the gradient overrides the per-pixel color. Only the alpha gates whether the slot paints at all. `StrokeColor` works the same way for the stroke slot on backends that support gradient-on-stroke (Skia + Apos two-slot; raylib's stroke is solid only).
+
 ### Forms controls moved to GumCommon — input types widened
 
 `FrameworkElement` and the rest of the Forms control infrastructure now live in `GumCommon` so any GumCommon consumer can use Forms directly, independent of the rendering backend. To make that compile cross-platform, a handful of Forms APIs that previously surfaced MonoGame-specific input types have been widened to platform-neutral abstractions in `Gum.Input` and `Gum.Forms.Input`.


### PR DESCRIPTION
Closes #2956.

## Summary

`UseGradient` is a *pattern* flag, not a *visibility* flag. The Apos.Shapes (XNALIKE) and raylib backends were painting an opaque gradient on a slot whose effective color alpha was 0 — i.e. the default-transparent fill on a stroke-only plain `CircleRuntime` / `RectangleRuntime`. The Skia backend gets this right naturally because `SKPaint.Color.alpha` modulates the shader output; Apos and raylib have no equivalent and were leaking.

After this PR every backend agrees: a slot with effective alpha = 0 doesn't paint, gradient or no gradient. Users light the slot up by setting `FillColor` (or `StrokeColor`) to any opaque color — RGB is irrelevant since the gradient overrides per-pixel color; only alpha gates the slot.

## Apos fix

New `public bool ShouldPaintGradient(Color? forcedColor)` on `RenderableShapeBase` — mirrors the `ComputeStrokeShadowDrawParameters` pattern PR #2951 introduced. The 6 inline `UseGradient && forcedColor == null` checks across `Circle.RenderInternal`, `Circle.RenderDashed`, `RoundedRectangle.Render` (3 sites), and `Arc.Render` (2 sites) are replaced with a single call to the helper, which additionally gates on `Color.A > 0`.

## Raylib fix

New `public bool ShouldPaintFillGradient` property on `LineCircle` and `LineRectangle` returns `UseGradient && (FillColor.HasValue || IsFilled) && (FillColor ?? Color).A > 0`. The `if (UseGradient)` branch inside the existing `runFill` block now skips the gradient draw when fillColor.A is 0. Solid fill path unchanged.

## Sample updates

The rotation cells added in PR #2945 (six files: `GumShapesGallery` / `SilkNetGum` / `raylib`, Circles + Rectangles each) relied on the bug — they enabled `UseGradient` without setting `FillColor`, so on Apos/raylib the gradient painted on the (supposedly transparent) fill, and on Skia it painted on the stroke only. They now set `FillColor` opaque to light up the fill slot. Visual is unchanged on Skia (already design-correct) and now matches across all three backends.

## Files

- Runtime (Apos): `Runtimes/GumShapes/Renderables/RenderableShapeBase.cs` (new helper), `Circle.cs`, `RoundedRectangle.cs`, `Arc.cs` (call sites).
- Runtime (raylib): `Runtimes/RaylibGum/Renderables/LineCircle.cs`, `LineRectangle.cs`.
- Samples: 6 files in `Samples/GumShapesGallery/`, `Samples/SilkNetGum/`, `Samples/raylib/`.
- Tests: 4 new `ShouldPaintGradient_*` cases in `Tests/MonoGameGum.Shapes.Tests/CircleRenderableTests.cs`; 6 new `ShouldPaintFillGradient_*` cases in each of `Tests/RaylibGum.Tests/Renderables/LineCircleTests.cs` and `LineRectangleTests.cs` (12 total).
- Docs: `docs/gum-tool/upgrading/migrating-to-2026-may.md`.

## Test plan

- [x] `MonoGameGum.Shapes.Tests` — 147/147.
- [x] `RaylibGum.Tests` — 241/241.
- [x] `MonoGameGum.Tests` — 1564/1564.
- [x] `Tool/Tests/GumToolUnitTests` — 664/664 (+5 skipped, pre-existing).
- [x] `GumFull.sln` builds clean (warnings only, all pre-existing).
- [ ] Manual visual verification: run the rotation cells in all three gallery samples and confirm the gradient seam rotates with the shape on all three backends. Tracked separately because of #2934 — raylib's `LineCircle.Render` still has no rotation handling, so the circle cells will paint a non-rotating disc until that's fixed. Rectangle cells should rotate correctly on all three.

## Out of scope

- raylib Circle rotation (`LineCircle.Render` has no rotation transform at all). Separate fix tracked under #2934.
- Intermediate-alpha modulation (gradient × paint.Color.alpha for alpha values in 1..254). This PR does binary gating at alpha=0, which fixes the reported visual cliff and matches Skia at that endpoint. Skia-parity modulation across the full alpha range would require per-vertex / per-Gradient-stop alpha scaling — bigger scope, no current user repro asking for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)