### PR TITLE
#2958: Skip FillRadiusInset on Circle dropshadow pass

### DIFF
--- a/Runtimes/GumShapes/Renderables/Circle.cs
+++ b/Runtimes/GumShapes/Renderables/Circle.cs
@@ -71,6 +71,23 @@ public class Circle : RenderableShapeBase,
     /// </remarks>
     public float FillRadiusInset { get; set; }
 
+    /// <summary>
+    /// Issue #2958 — the body and the dropshadow share <see cref="RenderInternal"/>, but
+    /// <see cref="FillRadiusInset"/> only applies to the body pass (it exists to hide the seam
+    /// between fill and stroke per #2834). The shadow must draw at the full <paramref name="radius"/>
+    /// so its outer edge lines up with the body's outer edge — otherwise the shadow comes up
+    /// short by <c>FillRadiusInset</c> world units (1 px at zoom = 1, more when zoomed in).
+    /// Clamped at 0 on the body pass so a runaway inset can't render an inverted disk.
+    /// </summary>
+    public float ComputeFillDrawRadius(float radius, bool isShadowPass)
+    {
+        if (isShadowPass)
+        {
+            return radius;
+        }
+        return System.Math.Max(0f, radius - FillRadiusInset);
+    }
+
     public override void Render(ISystemManagers managers)
     {
         // Issue #2950 follow-up — stroke-only Circle with StrokeWidth = 0 would otherwise draw
@@ -179,9 +196,10 @@ public class Circle : RenderableShapeBase,
 
             // Issue #2834 — pull the fill's outer edge inside the companion stroke slot's
             // opaque band so the two AA boundaries don't composite into a visible color
-            // bleed. Clamped at 0 so a runaway inset (larger than the radius) can't render an
-            // inverted disk. Only the fill branch consumes this; stroke ignores it.
-            float fillRadius = System.Math.Max(0f, radius - FillRadiusInset);
+            // bleed. Only the fill branch consumes this; stroke ignores it. Issue #2958 —
+            // the shadow pass shares this branch but must NOT inherit the inset, or its
+            // outer edge falls short of the body's outer edge.
+            float fillRadius = ComputeFillDrawRadius(radius, isShadowPass: forcedColor != null);
 
             if (ShouldPaintGradient(forcedColor))
             {

--- a/Tests/MonoGameGum.Shapes.Tests/CircleRenderableTests.cs
+++ b/Tests/MonoGameGum.Shapes.Tests/CircleRenderableTests.cs
@@ -397,6 +397,44 @@ public class CircleRenderableTests
     // does not, so we gate the gradient draw explicitly at the call site. Sample cells in the
     // gallery now set FillColor opaque to keep the gradient visible — see migration note.
 
+    // Issue #2958 — FillRadiusInset exists to pull the filled body's outer edge inside the
+    // companion stroke band (#2834). The shadow pass shares the same RenderInternal but must
+    // NOT inherit that inset — otherwise the shadow draws with a smaller radius than the body's
+    // outer edge, leaving a visible ring of missing shadow under the stroke (worse at higher
+    // camera zoom because the inset is in world units).
+
+    [Fact]
+    public void ComputeFillDrawRadius_BodyPass_NoInset_ReturnsRadius()
+    {
+        Circle sut = new() { FillRadiusInset = 0f };
+
+        sut.ComputeFillDrawRadius(radius: 50f, isShadowPass: false).ShouldBe(50f);
+    }
+
+    [Fact]
+    public void ComputeFillDrawRadius_BodyPass_WithInset_SubtractsInset()
+    {
+        Circle sut = new() { FillRadiusInset = 4f };
+
+        sut.ComputeFillDrawRadius(radius: 50f, isShadowPass: false).ShouldBe(46f);
+    }
+
+    [Fact]
+    public void ComputeFillDrawRadius_BodyPass_InsetExceedsRadius_ClampsToZero()
+    {
+        Circle sut = new() { FillRadiusInset = 60f };
+
+        sut.ComputeFillDrawRadius(radius: 50f, isShadowPass: false).ShouldBe(0f);
+    }
+
+    [Fact]
+    public void ComputeFillDrawRadius_ShadowPass_IgnoresInset()
+    {
+        Circle sut = new() { FillRadiusInset = 4f };
+
+        sut.ComputeFillDrawRadius(radius: 50f, isShadowPass: true).ShouldBe(50f);
+    }
+
     [Fact]
     public void ShouldPaintGradient_GradientOff_False()
     {


### PR DESCRIPTION
## Summary
- The body and shadow share `Circle.RenderInternal`, but `FillRadiusInset` exists only to hide the seam between fill and stroke on the body (#2834). Applying it on the shadow pass shrinks the shadow's outer edge below the body's outer edge — visible as a ring of missing shadow under the stroke (~1 px at zoom 1, more at higher zoom since the inset is in world units).
- Extracted `Circle.ComputeFillDrawRadius(radius, isShadowPass)` so the branch is unit-testable alongside the existing `ComputeStrokeShadowDrawParameters` seam.

## Test plan
- [x] New unit tests in `CircleRenderableTests` cover body pass (no inset, with inset, inset > radius clamp) and shadow pass (ignores inset)
- [x] Full `MonoGameGum.Shapes.Tests` suite still green (155 tests)
- [x] Manual repro in tool: filled Circle with `StrokeWidth = 8`, visible `StrokeColor`, `HasDropshadow`, `DropshadowOffset = (30, 30)`, `DropshadowBlur = 0`, bright `DropshadowColor` — shadow diameter should now match body's outer diameter

Closes #2958