### PR TITLE
#2937: Honor Blend on Apos.Shapes shape renderables

### DIFF
--- a/MonoGameGum/GueDeriving/CircleRuntime.cs
+++ b/MonoGameGum/GueDeriving/CircleRuntime.cs
@@ -667,6 +667,26 @@ public class CircleRuntime : GraphicalUiElement
         }
     }
 
+    Gum.RenderingLibrary.Blend _blend = Gum.RenderingLibrary.Blend.Normal;
+    /// <summary>
+    /// Issue #2937 — blend mode for the circle. Pushed to BOTH slots (matching UseGradient /
+    /// IsAntialiased) because blend is folded into each renderable's BatchKey: a fill/stroke
+    /// disagreement would split them across two ShapeBatches and render the stroke with the
+    /// wrong blend. Visual effect requires the optional MonoGameGumShapes (Apos.Shapes) package;
+    /// without it the value round-trips but renders as a no-op (graceful degradation).
+    /// </summary>
+    public Gum.RenderingLibrary.Blend Blend
+    {
+        get => _blend;
+        set
+        {
+            _blend = value;
+            if (_fill is IBlendedRenderable fillBlend) fillBlend.Blend = value;
+            if (_stroke is IBlendedRenderable strokeBlend) strokeBlend.Blend = value;
+            NotifyPropertyChanged();
+        }
+    }
+
     #region Gradient
 
     // Issue #2791: gradient pass-through. Backing fields live on the runtime so values
@@ -1391,6 +1411,8 @@ public class CircleRuntime : GraphicalUiElement
         // constructed in its default state.
         toReturn.FillColor = toReturn.FillColor;
         toReturn.IsFilled = toReturn.IsFilled;
+        // Issue #2937 — re-fire Blend onto the freshly-built slots for the same reason.
+        toReturn.Blend = toReturn.Blend;
         if (toReturn._fill != null)
         {
             toReturn._stroke.Radius = toReturn._fill.Radius;

--- a/MonoGameGum/GueDeriving/IBlendedRenderable.cs
+++ b/MonoGameGum/GueDeriving/IBlendedRenderable.cs
@@ -1,0 +1,20 @@
+#if XNALIKE
+namespace Gum.GueDeriving;
+
+/// <summary>
+/// Opt-in blend surface for fill/stroke renderables in the two-slot shape runtime model
+/// (issue #2937). Implemented by the optional MonoGameGumShapes <c>Circle</c> /
+/// <c>RoundedRectangle</c> / <c>Arc</c> / <c>Line</c> (which inherit the property from
+/// <c>RenderableShapeBase</c>) so <see cref="CircleRuntime"/> and <see cref="RectangleRuntime"/>
+/// can push the blend mode to BOTH slots. Both slots must carry the same blend: blend is folded
+/// into each renderable's <c>BatchKey</c>, so a fill/stroke disagreement would split them across
+/// two ShapeBatches and render the stroke with the wrong blend. Core defaults like
+/// <see cref="MonoGameGum.Renderables.DefaultStrokedCircleRenderable"/> deliberately do NOT
+/// implement this interface — the setter round-trips on the runtime but renders as a no-op
+/// without the optional package (graceful degradation, matching <see cref="IGradientedRenderable"/>).
+/// </summary>
+public interface IBlendedRenderable
+{
+    Gum.RenderingLibrary.Blend Blend { get; set; }
+}
+#endif

--- a/MonoGameGum/GueDeriving/RectangleRuntime.cs
+++ b/MonoGameGum/GueDeriving/RectangleRuntime.cs
@@ -845,6 +845,20 @@ public class RectangleRuntime : GraphicalUiElement
         }
     }
 
+    Gum.RenderingLibrary.Blend _blend = Gum.RenderingLibrary.Blend.Normal;
+    /// <inheritdoc cref="CircleRuntime.Blend"/>
+    public Gum.RenderingLibrary.Blend Blend
+    {
+        get => _blend;
+        set
+        {
+            _blend = value;
+            if (_fill is IBlendedRenderable fillBlend) fillBlend.Blend = value;
+            if (_stroke is IBlendedRenderable strokeBlend) strokeBlend.Blend = value;
+            NotifyPropertyChanged();
+        }
+    }
+
     bool _isAntialiased = true;
 
     /// <inheritdoc cref="CircleRuntime.IsAntialiased"/>
@@ -1581,6 +1595,8 @@ public class RectangleRuntime : GraphicalUiElement
         // constructed in its default state.
         toReturn.FillColor = toReturn.FillColor;
         toReturn.IsFilled = toReturn.IsFilled;
+        // Issue #2937 — re-fire Blend onto the freshly-built slots for the same reason.
+        toReturn.Blend = toReturn.Blend;
         return toReturn;
     }
 #endif

--- a/Runtimes/GumShapes/Renderables/Arc.cs
+++ b/Runtimes/GumShapes/Renderables/Arc.cs
@@ -70,6 +70,9 @@ internal class Arc : RenderableShapeBase
             return;
         }
 
+        // Issue #2937 — re-open the shared ShapeBatch with this shape's blend if it differs.
+        ShapeRenderer.EnsureBlend(this);
+
         var sb = ShapeRenderer.ShapeBatch;
 
         var absoluteLeft = this.GetAbsoluteLeft();

--- a/Runtimes/GumShapes/Renderables/Circle.cs
+++ b/Runtimes/GumShapes/Renderables/Circle.cs
@@ -99,6 +99,10 @@ public class Circle : RenderableShapeBase,
             return;
         }
 
+        // Issue #2937 — re-open the shared ShapeBatch with this shape's blend if it differs
+        // from the one the batch is currently using (no-op when it matches).
+        ShapeRenderer.EnsureBlend(this);
+
         var sb = ShapeRenderer.ShapeBatch;
 
         var absoluteLeft = this.GetAbsoluteLeft();

--- a/Runtimes/GumShapes/Renderables/Line.cs
+++ b/Runtimes/GumShapes/Renderables/Line.cs
@@ -14,6 +14,9 @@ internal class Line : RenderableShapeBase
 
     public override void Render(ISystemManagers managers)
     {
+        // Issue #2937 — re-open the shared ShapeBatch with this shape's blend if it differs.
+        ShapeRenderer.EnsureBlend(this);
+
         var sb = ShapeRenderer.ShapeBatch;
 
         var absoluteLeft = this.GetAbsoluteLeft();

--- a/Runtimes/GumShapes/Renderables/RenderableShapeBase.cs
+++ b/Runtimes/GumShapes/Renderables/RenderableShapeBase.cs
@@ -79,26 +79,16 @@ public abstract class RenderableShapeBase : RenderableBase, Gum.GueDeriving.IBle
 
     #region Blend
 
-    private Gum.RenderingLibrary.Blend _blend = Gum.RenderingLibrary.Blend.Normal;
-    private string _batchKey = BatchKeyPrefix + Gum.RenderingLibrary.Blend.Normal;
-
     /// <summary>
     /// Issue #2937 — the blend mode used when this shape is drawn. Mirrors the Blend variable
     /// surfaced on plain Circle/Rectangle (PR #2933) and the other shape runtimes. Default
     /// <see cref="Gum.RenderingLibrary.Blend.Normal"/> preserves Apos.Shapes' historical
-    /// AlphaBlend rendering — see <see cref="GetEffectiveXnaBlendState"/>. Folded into
-    /// <see cref="BatchKey"/> so a blend change between adjacent shapes forces a fresh
-    /// ShapeBatch; the key is recomputed here on set to avoid per-frame string allocation.
+    /// AlphaBlend rendering — see <see cref="GetEffectiveXnaBlendState"/>. The blend is NOT part
+    /// of <see cref="BatchKey"/> (that names the rendering tech, not internal state); instead the
+    /// shared <see cref="ShapeRenderer"/> re-opens the ShapeBatch with this blend when a shape
+    /// draws with one different from the batch's current blend — see <c>ShapeRenderer.EnsureBlend</c>.
     /// </summary>
-    public Gum.RenderingLibrary.Blend Blend
-    {
-        get => _blend;
-        set
-        {
-            _blend = value;
-            _batchKey = BatchKeyPrefix + value;
-        }
-    }
+    public Gum.RenderingLibrary.Blend Blend { get; set; } = Gum.RenderingLibrary.Blend.Normal;
 
     /// <summary>
     /// Resolves <see cref="Blend"/> to the XNA <see cref="Microsoft.Xna.Framework.Graphics.BlendState"/>
@@ -848,12 +838,7 @@ public abstract class RenderableShapeBase : RenderableBase, Gum.GueDeriving.IBle
             pivot.Y + dx * sin + dy * cos);
     }
 
-    // Issue #2937 — blend is part of the key so the BatchOrchestrator flushes and re-Begins
-    // (capturing the new blend) when an adjacent shape's blend differs. The two-slot runtimes
-    // push the same blend to fill and stroke so a single shape's slots still share one key.
-    private const string BatchKeyPrefix = "Apos.Shapes.";
-
-    public override string BatchKey => _batchKey;
+    public override string BatchKey => "Apos.Shapes";
 
     public override void StartBatch(ISystemManagers systemManagers)
     {
@@ -886,16 +871,17 @@ public abstract class RenderableShapeBase : RenderableBase, Gum.GueDeriving.IBle
             rasterizerState = spriteRenderer.ScissorTestRasterizerState;
         }
 
-        // Issue #2937 — honor the shape's Blend. GetEffectiveXnaBlendState returns null for
-        // Normal, which keeps Begin's AlphaBlend default (the historical behavior). Adjacent
-        // shapes with different blends no longer collide: blend is part of BatchKey, so the
-        // orchestrator flushes this batch and re-Begins with the next shape's blend.
-        sb.Begin(view: view, blendState: GetEffectiveXnaBlendState(), rasterizerState: rasterizerState);
+        // Issue #2937 — open the batch with this shape's blend and remember the begin
+        // parameters so EnsureBlend (called from each shape's Render) can re-open the batch
+        // with a different blend mid-run without changing BatchKey. This mirrors how
+        // SpriteBatchStack re-Begins SpriteBatch on a blend/scissor change while keeping one
+        // logical batch. GetEffectiveXnaBlendState returns null for Normal, so Begin keeps its
+        // AlphaBlend default (the historical behavior).
+        ShapeRenderer.BeginBatch(view, rasterizerState, this);
     }
 
     public override void EndBatch(ISystemManagers systemManagers)
     {
-        var sb = ShapeRenderer.ShapeBatch;
-        sb.End();
+        ShapeRenderer.EndBatch();
     }
 }

--- a/Runtimes/GumShapes/Renderables/RenderableShapeBase.cs
+++ b/Runtimes/GumShapes/Renderables/RenderableShapeBase.cs
@@ -24,7 +24,7 @@ namespace MonoGameAndGum.Renderables;
 // implemented on the concrete shape classes (Circle, RoundedRectangle) directly, not the
 // shared base. The base no longer participates in any renderable-registry contract — only
 // the concrete shape classes do.
-public abstract class RenderableShapeBase : RenderableBase
+public abstract class RenderableShapeBase : RenderableBase, Gum.GueDeriving.IBlendedRenderable
 {
     protected ShapeRenderer ShapeRenderer => ShapeRenderer.Self;
 
@@ -79,13 +79,26 @@ public abstract class RenderableShapeBase : RenderableBase
 
     #region Blend
 
+    private Gum.RenderingLibrary.Blend _blend = Gum.RenderingLibrary.Blend.Normal;
+    private string _batchKey = BatchKeyPrefix + Gum.RenderingLibrary.Blend.Normal;
+
     /// <summary>
     /// Issue #2937 — the blend mode used when this shape is drawn. Mirrors the Blend variable
     /// surfaced on plain Circle/Rectangle (PR #2933) and the other shape runtimes. Default
     /// <see cref="Gum.RenderingLibrary.Blend.Normal"/> preserves Apos.Shapes' historical
-    /// AlphaBlend rendering — see <see cref="GetEffectiveXnaBlendState"/>.
+    /// AlphaBlend rendering — see <see cref="GetEffectiveXnaBlendState"/>. Folded into
+    /// <see cref="BatchKey"/> so a blend change between adjacent shapes forces a fresh
+    /// ShapeBatch; the key is recomputed here on set to avoid per-frame string allocation.
     /// </summary>
-    public Gum.RenderingLibrary.Blend Blend { get; set; } = Gum.RenderingLibrary.Blend.Normal;
+    public Gum.RenderingLibrary.Blend Blend
+    {
+        get => _blend;
+        set
+        {
+            _blend = value;
+            _batchKey = BatchKeyPrefix + value;
+        }
+    }
 
     /// <summary>
     /// Resolves <see cref="Blend"/> to the XNA <see cref="Microsoft.Xna.Framework.Graphics.BlendState"/>
@@ -835,7 +848,12 @@ public abstract class RenderableShapeBase : RenderableBase
             pivot.Y + dx * sin + dy * cos);
     }
 
-    public override string BatchKey => "Apos.Shapes";
+    // Issue #2937 — blend is part of the key so the BatchOrchestrator flushes and re-Begins
+    // (capturing the new blend) when an adjacent shape's blend differs. The two-slot runtimes
+    // push the same blend to fill and stroke so a single shape's slots still share one key.
+    private const string BatchKeyPrefix = "Apos.Shapes.";
+
+    public override string BatchKey => _batchKey;
 
     public override void StartBatch(ISystemManagers systemManagers)
     {
@@ -869,10 +887,9 @@ public abstract class RenderableShapeBase : RenderableBase
         }
 
         // Issue #2937 — honor the shape's Blend. GetEffectiveXnaBlendState returns null for
-        // Normal, which keeps Begin's AlphaBlend default (the historical behavior). Note:
-        // consecutive Apos shapes share one ShapeBatch (constant BatchKey), so the blend used
-        // for a run is the batch owner's — mixing Blend modes within an uninterrupted shape run
-        // is not resolved here (same pre-existing limitation as the rest of the batch state).
+        // Normal, which keeps Begin's AlphaBlend default (the historical behavior). Adjacent
+        // shapes with different blends no longer collide: blend is part of BatchKey, so the
+        // orchestrator flushes this batch and re-Begins with the next shape's blend.
         sb.Begin(view: view, blendState: GetEffectiveXnaBlendState(), rasterizerState: rasterizerState);
     }
 

--- a/Runtimes/GumShapes/Renderables/RenderableShapeBase.cs
+++ b/Runtimes/GumShapes/Renderables/RenderableShapeBase.cs
@@ -77,6 +77,35 @@ public abstract class RenderableShapeBase : RenderableBase
         }
     }
 
+    #region Blend
+
+    /// <summary>
+    /// Issue #2937 — the blend mode used when this shape is drawn. Mirrors the Blend variable
+    /// surfaced on plain Circle/Rectangle (PR #2933) and the other shape runtimes. Default
+    /// <see cref="Gum.RenderingLibrary.Blend.Normal"/> preserves Apos.Shapes' historical
+    /// AlphaBlend rendering — see <see cref="GetEffectiveXnaBlendState"/>.
+    /// </summary>
+    public Gum.RenderingLibrary.Blend Blend { get; set; } = Gum.RenderingLibrary.Blend.Normal;
+
+    /// <summary>
+    /// Resolves <see cref="Blend"/> to the XNA <see cref="Microsoft.Xna.Framework.Graphics.BlendState"/>
+    /// handed to Apos.Shapes' <c>ShapeBatch.Begin</c> in <see cref="StartBatch"/>. Returns
+    /// <c>null</c> for <see cref="Gum.RenderingLibrary.Blend.Normal"/> so <c>Begin</c> keeps its
+    /// own <c>AlphaBlend</c> default — the blend every Apos shape has rendered with since before
+    /// this property existed — leaving existing content visually unchanged. Only an explicitly
+    /// non-Normal blend (Additive, etc.) overrides it.
+    /// </summary>
+    public Microsoft.Xna.Framework.Graphics.BlendState? GetEffectiveXnaBlendState()
+    {
+        if (Blend == Gum.RenderingLibrary.Blend.Normal)
+        {
+            return null;
+        }
+        return Gum.RenderingLibrary.BlendExtensions.ToBlendState(Blend).ToXNA();
+    }
+
+    #endregion
+
     #region Gradient
 
     private bool _useGradient;
@@ -839,7 +868,12 @@ public abstract class RenderableShapeBase : RenderableBase
             rasterizerState = spriteRenderer.ScissorTestRasterizerState;
         }
 
-        sb.Begin(view: view, rasterizerState: rasterizerState);
+        // Issue #2937 — honor the shape's Blend. GetEffectiveXnaBlendState returns null for
+        // Normal, which keeps Begin's AlphaBlend default (the historical behavior). Note:
+        // consecutive Apos shapes share one ShapeBatch (constant BatchKey), so the blend used
+        // for a run is the batch owner's — mixing Blend modes within an uninterrupted shape run
+        // is not resolved here (same pre-existing limitation as the rest of the batch state).
+        sb.Begin(view: view, blendState: GetEffectiveXnaBlendState(), rasterizerState: rasterizerState);
     }
 
     public override void EndBatch(ISystemManagers systemManagers)

--- a/Runtimes/GumShapes/Renderables/RoundedRectangle.cs
+++ b/Runtimes/GumShapes/Renderables/RoundedRectangle.cs
@@ -66,6 +66,9 @@ public class RoundedRectangle : RenderableShapeBase,
             return;
         }
 
+        // Issue #2937 — re-open the shared ShapeBatch with this shape's blend if it differs.
+        ShapeRenderer.EnsureBlend(this);
+
         var sb = ShapeRenderer.ShapeBatch;
 
         var absoluteLeft = this.GetAbsoluteLeft();

--- a/Runtimes/GumShapes/Renderables/ShapeRenderer.cs
+++ b/Runtimes/GumShapes/Renderables/ShapeRenderer.cs
@@ -24,12 +24,65 @@ public class ShapeRenderer
     static ShapeRenderer _self = default!;
     ShapeBatch _sb = default!;
 
+    // Issue #2937 — mid-batch blend state, mirroring SpriteBatchStack. BatchKey identifies the
+    // tech ("Apos.Shapes"), NOT the blend, so a whole run of shapes shares one batch. When a
+    // shape draws with a blend different from the one the batch is currently using, EnsureBlend
+    // ends and re-begins the ShapeBatch with the new blend, reusing the view/rasterizer the
+    // batch was opened with (the same End/Begin trick SpriteBatchStack.ReplaceRenderStates uses).
+    Microsoft.Xna.Framework.Matrix? _currentView;
+    RasterizerState? _currentRasterizerState;
+    Gum.RenderingLibrary.Blend _currentBlend;
+    bool _isBatchBegun;
+
     public ShapeBatch ShapeBatch
     {
         get
         {
             return _sb;
         }
+    }
+
+    /// <summary>
+    /// Opens the ShapeBatch for a run of shapes with <paramref name="shape"/>'s blend, recording
+    /// the begin parameters so a later <see cref="EnsureBlend"/> can re-open with a different
+    /// blend mid-run. Called by the batch owner from <c>RenderableShapeBase.StartBatch</c>.
+    /// </summary>
+    public void BeginBatch(Microsoft.Xna.Framework.Matrix? view, RasterizerState? rasterizerState, RenderableShapeBase shape)
+    {
+        _currentView = view;
+        _currentRasterizerState = rasterizerState;
+        _currentBlend = shape.Blend;
+        _isBatchBegun = true;
+        _sb.Begin(view: view, blendState: shape.GetEffectiveXnaBlendState(), rasterizerState: rasterizerState);
+    }
+
+    /// <summary>
+    /// Ensures the open ShapeBatch is drawing with <paramref name="shape"/>'s blend. If it
+    /// differs from the blend the batch is currently using, the batch is flushed (End) and
+    /// re-opened (Begin) with the new blend, reusing the cached view/rasterizer — the same
+    /// in-place state-change mechanism <c>SpriteBatchStack</c> uses for SpriteBatch.
+    /// No-op when the blend already matches or no batch is open (e.g. unit tests with no device).
+    /// Each shape's <c>Render</c> calls this before drawing.
+    /// </summary>
+    public void EnsureBlend(RenderableShapeBase shape)
+    {
+        if (!_isBatchBegun || shape.Blend == _currentBlend)
+        {
+            return;
+        }
+        _sb.End();
+        _currentBlend = shape.Blend;
+        _sb.Begin(view: _currentView, blendState: shape.GetEffectiveXnaBlendState(), rasterizerState: _currentRasterizerState);
+    }
+
+    /// <summary>
+    /// Ends the open ShapeBatch. Called by the batch owner from <c>RenderableShapeBase.EndBatch</c>
+    /// when the BatchOrchestrator transitions away from the Apos.Shapes batch.
+    /// </summary>
+    public void EndBatch()
+    {
+        _isBatchBegun = false;
+        _sb.End();
     }
 
     public bool IsInitialized { get; private set; }

--- a/Runtimes/SkiaGum/CustomSetPropertyOnRenderable.cs
+++ b/Runtimes/SkiaGum/CustomSetPropertyOnRenderable.cs
@@ -98,19 +98,23 @@ public class CustomSetPropertyOnRenderable
             case nameof(RenderableShapeBase.Alpha):
                 renderableBase.Alpha = (int)value;
                 return true;
-#if SKIA
-            // .gumx stores Blend as the non-nullable Gum.RenderingLibrary.Blend enum, but the
-            // property is Blend?. SetPropertyThroughReflection's Convert.ChangeType fallback
-            // throws on enum -> Nullable<enum>, so the assignment has to land here. See the
-            // SilkNetGum sample crash that prompted this branch — every Standards/*.gutx with
-            // a default Blend variable hit the reflection path before this case was added.
+            // .gumx stores Blend as the non-nullable Gum.RenderingLibrary.Blend enum.
+            // SetPropertyThroughReflection's Convert.ChangeType fallback throws on
+            // enum -> Nullable<enum> (Skia's Blend?), so the assignment has to land here. See
+            // the SilkNetGum sample crash that prompted the Skia branch — every Standards/*.gutx
+            // with a default Blend variable hit the reflection path before this case was added.
             //
-            // SKIA-gated because this file is also file-linked into MonoGameGumShapes /
-            // KniGumShapes (Apos.Shapes side) where RenderableShapeBase resolves to a
-            // different type that doesn't have a Blend property — see the type alias in the
-            // file header.
+            // Issue #2937: the Apos.Shapes side (MonoGameGumShapes / KniGumShapes) now also has
+            // a Blend property on its RenderableShapeBase, so it gets its own arm. The type
+            // differs per platform (Skia: Blend?, Apos: non-nullable Gum.RenderingLibrary.Blend),
+            // hence the gate rather than a shared case.
+#if SKIA
             case nameof(RenderableShapeBase.Blend):
                 renderableBase.Blend = (Blend)value;
+                return true;
+#else
+            case nameof(RenderableShapeBase.Blend):
+                renderableBase.Blend = (Gum.RenderingLibrary.Blend)value;
                 return true;
 #endif
             case nameof(RenderableShapeBase.Alpha1):

--- a/Tests/MonoGameGum.Shapes.Tests/ArcRuntimeTests.cs
+++ b/Tests/MonoGameGum.Shapes.Tests/ArcRuntimeTests.cs
@@ -20,6 +20,21 @@ public class ArcRuntimeTests
         sut.Alpha.ShouldBe(128);
     }
 
+    // Issue #2937 — the Blend variable (.gumx pushes it via SetProperty) must land on the Apos
+    // renderable. Before the fix the dispatcher had no non-SKIA Blend case, so the value fell to
+    // reflection, found no "Blend" property on the renderable, and silently vanished.
+    [Fact]
+    public void Blend_ShouldRouteToRenderable_ThroughSetProperty()
+    {
+        ArcRuntime sut = new ArcRuntime();
+
+        sut.SetProperty("Blend", Gum.RenderingLibrary.Blend.Additive);
+
+        RenderableShapeBase shape = (RenderableShapeBase)sut.RenderableComponent;
+        shape.Blend.ShouldBe(Gum.RenderingLibrary.Blend.Additive);
+        shape.GetEffectiveXnaBlendState().ShouldBe(Microsoft.Xna.Framework.Graphics.BlendState.Additive);
+    }
+
     // Locked in unification (issue #2728): both backends default IsEndRounded to false
     // (matches Skia's prior behavior and graphics-convention flat caps). Existing Apos
     // consumers who relied on rounded caps must now set IsEndRounded = true explicitly.

--- a/Tests/MonoGameGum.Shapes.Tests/CircleRuntimeTests.cs
+++ b/Tests/MonoGameGum.Shapes.Tests/CircleRuntimeTests.cs
@@ -24,6 +24,25 @@ public class CircleRuntimeTests
         AposShapeRuntime.RegisterRuntimeTypes();
     }
 
+    // Issue #2937 — Blend folds into the renderable's BatchKey, and the two-slot model draws
+    // fill and stroke as separate renderables. If Blend only reached the fill slot, fill and
+    // stroke would carry different BatchKeys and the orchestrator would flush between them,
+    // rendering the stroke with the wrong blend. The runtime forwards Blend to BOTH slots so
+    // they share a key and batch together.
+    [Fact]
+    public void Blend_ForwardsToBothSlots_SoFillAndStrokeShareABatchKey()
+    {
+        CircleRuntime sut = new();
+
+        sut.SetProperty("Blend", Gum.RenderingLibrary.Blend.Additive);
+
+        Circle fill = (Circle)sut.RenderableComponent;
+        Circle stroke = (Circle)fill.Children[0];
+        fill.Blend.ShouldBe(Gum.RenderingLibrary.Blend.Additive);
+        stroke.Blend.ShouldBe(Gum.RenderingLibrary.Blend.Additive);
+        fill.BatchKey.ShouldBe(stroke.BatchKey);
+    }
+
     [Fact]
     public void Constructor_BindsAposCircle_AsFillContainedObject_StrokeAsChild()
     {

--- a/Tests/MonoGameGum.Shapes.Tests/CircleRuntimeTests.cs
+++ b/Tests/MonoGameGum.Shapes.Tests/CircleRuntimeTests.cs
@@ -24,13 +24,12 @@ public class CircleRuntimeTests
         AposShapeRuntime.RegisterRuntimeTypes();
     }
 
-    // Issue #2937 — Blend folds into the renderable's BatchKey, and the two-slot model draws
-    // fill and stroke as separate renderables. If Blend only reached the fill slot, fill and
-    // stroke would carry different BatchKeys and the orchestrator would flush between them,
-    // rendering the stroke with the wrong blend. The runtime forwards Blend to BOTH slots so
-    // they share a key and batch together.
+    // Issue #2937 — the two-slot model draws fill and stroke as separate renderables. The user
+    // sets one Blend for the shape, so it must reach BOTH slots: ShapeRenderer.EnsureBlend keys
+    // off each renderable's Blend, so if the stroke kept the default the batch would flip back
+    // to Normal when drawing it. The runtime forwards Blend to both slots.
     [Fact]
-    public void Blend_ForwardsToBothSlots_SoFillAndStrokeShareABatchKey()
+    public void Blend_ForwardsToBothSlots()
     {
         CircleRuntime sut = new();
 
@@ -40,7 +39,6 @@ public class CircleRuntimeTests
         Circle stroke = (Circle)fill.Children[0];
         fill.Blend.ShouldBe(Gum.RenderingLibrary.Blend.Additive);
         stroke.Blend.ShouldBe(Gum.RenderingLibrary.Blend.Additive);
-        fill.BatchKey.ShouldBe(stroke.BatchKey);
     }
 
     [Fact]

--- a/Tests/MonoGameGum.Shapes.Tests/RenderableShapeBaseTests.cs
+++ b/Tests/MonoGameGum.Shapes.Tests/RenderableShapeBaseTests.cs
@@ -36,26 +36,17 @@ public class RenderableShapeBaseTests
         shape.GetEffectiveXnaBlendState().ShouldBeNull();
     }
 
-    // Issue #2937 — blend is folded into BatchKey so the BatchOrchestrator flushes the open
-    // ShapeBatch and starts a fresh one (with the new blend) when an adjacent shape's blend
-    // differs. Without this, a whole run of Apos shapes shares one Begin and only the batch
-    // owner's blend takes effect.
+    // Issue #2937 — BatchKey names the rendering tech, NOT internal state like blend (mirroring
+    // how all SpriteBatch renderables share one key and SpriteBatchStack handles blend changes
+    // internally). Blend differences are resolved by ShapeRenderer.EnsureBlend re-opening the
+    // batch, not by splitting the key. This guards against regressing to a blend-keyed batch.
     [Fact]
-    public void BatchKey_DiffersByBlend_SoABlendChangeForcesANewBatch()
+    public void BatchKey_IsTechOnly_AndDoesNotVaryWithBlend()
     {
         TestShape normal = new();
         TestShape additive = new() { Blend = Gum.RenderingLibrary.Blend.Additive };
 
-        normal.BatchKey.ShouldNotBe(additive.BatchKey);
-    }
-
-    [Fact]
-    public void BatchKey_SameBlend_IsEqual_SoSameBlendShapesShareOneBatch()
-    {
-        TestShape a = new() { Blend = Gum.RenderingLibrary.Blend.Additive };
-        TestShape b = new() { Blend = Gum.RenderingLibrary.Blend.Additive };
-
-        a.BatchKey.ShouldBe(b.BatchKey);
+        additive.BatchKey.ShouldBe(normal.BatchKey);
     }
 
     [Fact]

--- a/Tests/MonoGameGum.Shapes.Tests/RenderableShapeBaseTests.cs
+++ b/Tests/MonoGameGum.Shapes.Tests/RenderableShapeBaseTests.cs
@@ -36,6 +36,28 @@ public class RenderableShapeBaseTests
         shape.GetEffectiveXnaBlendState().ShouldBeNull();
     }
 
+    // Issue #2937 — blend is folded into BatchKey so the BatchOrchestrator flushes the open
+    // ShapeBatch and starts a fresh one (with the new blend) when an adjacent shape's blend
+    // differs. Without this, a whole run of Apos shapes shares one Begin and only the batch
+    // owner's blend takes effect.
+    [Fact]
+    public void BatchKey_DiffersByBlend_SoABlendChangeForcesANewBatch()
+    {
+        TestShape normal = new();
+        TestShape additive = new() { Blend = Gum.RenderingLibrary.Blend.Additive };
+
+        normal.BatchKey.ShouldNotBe(additive.BatchKey);
+    }
+
+    [Fact]
+    public void BatchKey_SameBlend_IsEqual_SoSameBlendShapesShareOneBatch()
+    {
+        TestShape a = new() { Blend = Gum.RenderingLibrary.Blend.Additive };
+        TestShape b = new() { Blend = Gum.RenderingLibrary.Blend.Additive };
+
+        a.BatchKey.ShouldBe(b.BatchKey);
+    }
+
     [Fact]
     public void GetRotatedCenter_ZeroRotation_ReturnsAxisAlignedCenter()
     {

--- a/Tests/MonoGameGum.Shapes.Tests/RenderableShapeBaseTests.cs
+++ b/Tests/MonoGameGum.Shapes.Tests/RenderableShapeBaseTests.cs
@@ -12,6 +12,30 @@ namespace MonoGameGum.Shapes.Tests;
 // inspectable from a unit test.
 public class RenderableShapeBaseTests
 {
+    // Issue #2937 — Blend had no visual effect on Apos shapes because StartBatch never passed
+    // a BlendState to ShapeBatch.Begin (which then fell back to its AlphaBlend default) and the
+    // Blend variable had nowhere to land on the Apos renderable. GetEffectiveXnaBlendState is the
+    // device-free seam StartBatch consults; pinning it here avoids needing a GraphicsDevice.
+    [Fact]
+    public void GetEffectiveXnaBlendState_AdditiveBlend_ReturnsXnaAdditive()
+    {
+        TestShape shape = new() { Blend = Gum.RenderingLibrary.Blend.Additive };
+
+        shape.GetEffectiveXnaBlendState().ShouldBe(Microsoft.Xna.Framework.Graphics.BlendState.Additive);
+    }
+
+    [Fact]
+    public void GetEffectiveXnaBlendState_NormalBlend_ReturnsNullSoBeginKeepsItsAlphaBlendDefault()
+    {
+        // Normal is the default, and Apos shapes have always rendered with Begin's AlphaBlend
+        // default. Returning null (rather than NonPremultiplied) preserves that exact behavior
+        // so no existing content changes appearance.
+        TestShape shape = new();
+
+        shape.Blend.ShouldBe(Gum.RenderingLibrary.Blend.Normal);
+        shape.GetEffectiveXnaBlendState().ShouldBeNull();
+    }
+
     [Fact]
     public void GetRotatedCenter_ZeroRotation_ReturnsAxisAlignedCenter()
     {


### PR DESCRIPTION
## Summary

Fixes #2937 — `Blend = Additive` (and every other non-Normal blend) had no visual effect on Apos.Shapes-backed shapes (Circle / Rectangle / Arc / etc.).

Three gaps caused it:
- `RenderableShapeBase.StartBatch` called `ShapeBatch.Begin(view:, rasterizerState:)` and **never passed a blend state**, so Apos fell back to its `Begin` default of `AlphaBlend`.
- The `Blend` variable had **nowhere to land** on the Apos renderable — no `Blend` property, and the dispatcher's `Blend` case was `#if SKIA`-gated, so the value fell through reflection and vanished.
- All consecutive Apos shapes share one `ShapeBatch` (`BatchKey = "Apos.Shapes"`), and `Begin` is the only place blend is set — so a run of shapes only honored the batch owner's blend.

## Changes

**Apply + route**
- Add a `Blend` property and a device-free `GetEffectiveXnaBlendState()` seam to the Apos `RenderableShapeBase`.
- Route the `Blend` variable in a new non-SKIA arm of `TrySetPropertiesOnRenderableBase`.

**Mid-batch blend changes — handled inside the batch, like `SpriteBatchStack`**
- `BatchKey` stays `"Apos.Shapes"` (it names the rendering *tech*, not internal state). The shared `ShapeRenderer` now tracks the blend the `ShapeBatch` was opened with; each shape's `Render` calls `ShapeRenderer.EnsureBlend(this)`, which ends and re-`Begin`s the batch with the shape's blend (reusing the cached view/rasterizer) **only when it differs** — the same in-place state-change mechanism `SpriteBatchStack.ReplaceRenderStates` uses for `SpriteBatch`.
- Two-slot Circle/Rectangle draw fill and stroke as separate renderables; route `Blend` to **both** slots via a new `IBlendedRenderable` capability interface (mirrors `IGradientedRenderable`). The user sets one blend for the shape, and `EnsureBlend` keys off each renderable's blend, so the stroke slot must carry it too — otherwise the batch would flip back to Normal when drawing the stroke.

### Regression safety

`Blend.Normal` maps to `null`, so `Begin` keeps its historical `AlphaBlend` default and **existing content is visually unchanged**; only an explicit non-Normal blend overrides it.

## Test plan

- [x] `GetEffectiveXnaBlendState_*` — Normal→null, Additive→XNA Additive
- [x] `BatchKey_IsTechOnly_AndDoesNotVaryWithBlend` — guards against re-keying the batch on blend
- [x] `Blend_ForwardsToBothSlots` — two-slot fill+stroke both receive the blend
- [x] `Blend_ShouldRouteToRenderable_ThroughSetProperty` — full dispatcher path
- [x] `MonoGameGum.Shapes.Tests` (160), core `CircleRuntime`/`RectangleRuntime` + `BatchOrchestrator`/`BatchKeyGroupedOrderer` (53), `SkiaGum.Tests` Blend (16)
- [x] MonoGameGum / MonoGameGumShapes / KniGumShapes / SkiaGum / RaylibGum build clean
- [x] Device-level mid-batch re-`Begin` (multiple shapes, different blends, one frame) is not unit-testable without a GraphicsDevice — verify via the shapes gallery sample

Closes #2937

🤖 Generated with [Claude Code](https://claude.com/claude-code)