### PR TITLE
Hide stroke dash/gap and color channels in the grid when StrokeWidth = 0

### DIFF
--- a/.claude/skills/refactoring-direction/SKILL.md
+++ b/.claude/skills/refactoring-direction/SKILL.md
@@ -17,8 +17,8 @@ When refactoring Gum code, **always move toward instances, interfaces, and dedic
 
 4. **Prefer constructor injection over `*.Self` singletons.** Don't reverse the tool's migration off static singletons.
    - `ObjectFinder.Self` is the sanctioned exception — fine in new or refactored code; it won't be removed. No other singletons should be reintroduced.
-   - Plugins are MEF-composed: inject deps via an `[ImportingConstructor]`, not a plain ctor (see `MainStatePlugin`).
-   - Replacing a `Locator.GetRequiredService<T>()` call with an injected `T` is good drive-by cleanup.
+   - Plugins are MEF-composed: `[ImportingConstructor]` can inject only interfaces registered in `PluginManager.LoadPlugins` via `batch.AddExportedValue<T>` (today just `ISelectedState`). To inject anything else, register it there first; otherwise keep `Locator.GetRequiredService<T>()` in the body (see `MainStatePlugin`).
+   - Replacing a `Locator.GetRequiredService<T>()` call with an injected `T` (one already exported to MEF) is good drive-by cleanup.
 
 ## When testability is the driver
 

--- a/.claude/skills/refactoring-direction/SKILL.md
+++ b/.claude/skills/refactoring-direction/SKILL.md
@@ -15,7 +15,10 @@ When refactoring Gum code, **always move toward instances, interfaces, and dedic
 
 3. **Prefer extracting a new single-responsibility class over adding to a "god class."** `GraphicalUiElement`, `CodeGenerator`, and similar large classes should not grow. New behavior goes in a new controller/service class that the existing class composes with, even if the new class starts with one method.
 
-4. **Prefer constructor injection over `*.Self` singletons.** The Gum tool has been progressively migrating off static singletons (see project `CLAUDE.md`). Don't reverse that. `ObjectFinder.Self` is the documented exception — no other singletons should be reintroduced.
+4. **Prefer constructor injection over `*.Self` singletons.** Don't reverse the tool's migration off static singletons.
+   - `ObjectFinder.Self` is the sanctioned exception — fine in new or refactored code; it won't be removed. No other singletons should be reintroduced.
+   - Plugins are MEF-composed: inject deps via an `[ImportingConstructor]`, not a plain ctor (see `MainStatePlugin`).
+   - Replacing a `Locator.GetRequiredService<T>()` call with an injected `T` is good drive-by cleanup.
 
 ## When testability is the driver
 

--- a/Gum/Plugins/InternalPlugins/VariableGrid/ExclusionsPlugin.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/ExclusionsPlugin.cs
@@ -23,10 +23,12 @@ public class ExclusionsPlugin : PriorityPlugin
 {
     private readonly ISelectedState _selectedState;
     private ObjectFinder _objectFinder;
+    private readonly ShapeVariableExclusionLogic _shapeVariableExclusionLogic = new();
 
-    public ExclusionsPlugin()
+    [ImportingConstructor]
+    public ExclusionsPlugin(ISelectedState selectedState)
     {
-        _selectedState = Locator.GetRequiredService<ISelectedState>();
+        _selectedState = selectedState;
         _objectFinder = ObjectFinder.Self;
     }
 
@@ -71,7 +73,8 @@ public class ExclusionsPlugin : PriorityPlugin
         }
 
         // Shape gradient / dropshadow / stroke channel exclusions
-        if(GetIfShapeVariableIsExcluded(variable, rootName, finder, out bool shapeExcluded))
+        var prefix = string.IsNullOrEmpty(variable.SourceObject) ? "" : variable.SourceObject + '.';
+        if(_shapeVariableExclusionLogic.GetIfShapeVariableIsExcluded(rootName, finder, GetCurrentRootStandardTypeName(), prefix, out bool shapeExcluded))
         {
             return shapeExcluded;
         }
@@ -92,120 +95,6 @@ public class ExclusionsPlugin : PriorityPlugin
     }
 
     #region Shape Exclusions (gradient / dropshadow / stroke)
-
-    // Moved from Gum/SvgPlugin/Managers/DefaultStateManager.GetIfVariableIsExcluded — these
-    // rules historically lived in MainSkiaPlugin because gradient/dropshadow/IsFilled were
-    // Skia-only, but #2929/#2933/#2931 promoted them to plain Circle/Rectangle. The gating
-    // is shape-agnostic now, so it belongs in the general ExclusionsPlugin.
-    private bool GetIfShapeVariableIsExcluded(VariableSave variable, string rootName, RecursiveVariableFinder finder, out bool shouldExclude)
-    {
-        var prefix = string.IsNullOrEmpty(variable.SourceObject) ? "" : variable.SourceObject + '.';
-
-        if (rootName == "Red" || rootName == "Green" || rootName == "Blue")
-        {
-            var usesGradients = finder.GetValue(prefix + "UseGradient");
-            if (usesGradients is bool asBool && asBool)
-            {
-                shouldExclude = true;
-                return true;
-            }
-        }
-        else if (rootName == "Red1" || rootName == "Green1" || rootName == "Blue1" || rootName == "Alpha1" ||
-            rootName == "GradientX1" || rootName == "GradientY1" ||
-            rootName == "GradientX1Units" || rootName == "GradientY1Units" ||
-            rootName == "Red2" || rootName == "Green2" || rootName == "Blue2" || rootName == "Alpha2" ||
-            rootName == "GradientType")
-        {
-            var usesGradients = finder.GetValue(prefix + "UseGradient");
-            var effectiveUsesGradient = usesGradients is bool asBool && asBool;
-            shouldExclude = !effectiveUsesGradient;
-            return true;
-        }
-        else if (rootName == "GradientX2" || rootName == "GradientY2" || rootName == "GradientX2Units" || rootName == "GradientY2Units")
-        {
-            var usesGradients = finder.GetValue(prefix + "UseGradient");
-            var effectiveUsesGradient = usesGradients is bool asBool && asBool;
-
-            var gradientTypeAsObject = finder.GetValue(prefix + "GradientType");
-            GradientType? gradientType = gradientTypeAsObject as GradientType?;
-
-            shouldExclude = effectiveUsesGradient == false || gradientType != GradientType.Linear;
-            return true;
-        }
-        else if (rootName == "GradientInnerRadius" || rootName == "GradientOuterRadius" ||
-            rootName == "GradientInnerRadiusUnits" || rootName == "GradientOuterRadiusUnits")
-        {
-            var usesGradients = finder.GetValue(prefix + "UseGradient");
-            var effectiveUsesGradient = usesGradients is bool asBool && asBool;
-
-            var gradientTypeAsObject = finder.GetValue(prefix + "GradientType");
-            GradientType? gradientType = gradientTypeAsObject as GradientType?;
-
-            shouldExclude = effectiveUsesGradient == false || gradientType != GradientType.Radial;
-            return true;
-        }
-
-        if (rootName == "DropshadowOffsetX" || rootName == "DropshadowOffsetY" || rootName == "DropshadowBlur" ||
-            rootName == "DropshadowAlpha" || rootName == "DropshadowRed" || rootName == "DropshadowGreen" || rootName == "DropshadowBlue")
-        {
-            var hasDropshadow = finder.GetValue(prefix + "HasDropshadow");
-            var effectiveHasDropshadow = hasDropshadow is bool asBool && asBool;
-            shouldExclude = !effectiveHasDropshadow;
-            return true;
-        }
-
-        // #2931 / #2938: stroke vs. fill model is type-specific.
-        //
-        // Legacy shapes (ColoredCircle / RoundedRectangle / Arc) treat IsFilled as
-        // "fill OR stroke" — when IsFilled is true the stroke vars are meaningless and
-        // hidden. Plain Circle / Rectangle (#2938) expose fill and stroke as independent
-        // surfaces; stroke vars stay visible regardless of IsFilled, gated only by
-        // StrokeWidth = 0.
-        //
-        // Symmetric on the fill side: the channel-decomp FillRed/Green/Blue/Alpha exist
-        // only on plain Circle / Rectangle (#2931) and are meaningless when IsFilled is
-        // false.
-        var rootStandardTypeName = GetCurrentRootStandardTypeName();
-        var hasSeparateFillAndStroke = rootStandardTypeName == "Circle" || rootStandardTypeName == "Rectangle";
-
-        if (rootName == "StrokeWidth" || rootName == "StrokeDashLength" || rootName == "StrokeGapLength")
-        {
-            if (!hasSeparateFillAndStroke)
-            {
-                var isFilled = finder.GetValue(prefix + "IsFilled");
-                if (isFilled is true)
-                {
-                    shouldExclude = true;
-                    return true;
-                }
-            }
-        }
-
-        if (hasSeparateFillAndStroke &&
-            (rootName == "FillRed" || rootName == "FillGreen" || rootName == "FillBlue" || rootName == "FillAlpha"))
-        {
-            // Hidden when IsFilled = false (no fill drawn) or when UseGradient = true
-            // (gradient paints the fill slot, the solid fill channels are unused). Stroke
-            // channels stay visible regardless of UseGradient — gradient targets fill only.
-            var isFilled = finder.GetValue(prefix + "IsFilled");
-            if (isFilled is false)
-            {
-                shouldExclude = true;
-                return true;
-            }
-            var usesGradient = finder.GetValue(prefix + "UseGradient");
-            if (usesGradient is true)
-            {
-                shouldExclude = true;
-                return true;
-            }
-            shouldExclude = false;
-            return true;
-        }
-
-        shouldExclude = false;
-        return false;
-    }
 
     private string? GetCurrentRootStandardTypeName()
     {

--- a/Gum/Plugins/InternalPlugins/VariableGrid/ExclusionsPlugin.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/ExclusionsPlugin.cs
@@ -38,7 +38,7 @@ public class ExclusionsPlugin : PriorityPlugin
         this.VariableSet += HandleVariableSet;
     }
 
-    private void HandleVariableSet(ElementSave save1, InstanceSave save2, string variableName, object oldValue)
+    private void HandleVariableSet(ElementSave save1, InstanceSave? save2, string variableName, object? oldValue)
     {
         if(variableName == "ChildrenLayout")
         {
@@ -98,7 +98,7 @@ public class ExclusionsPlugin : PriorityPlugin
 
     private string? GetCurrentRootStandardTypeName()
     {
-        ElementSave element = _selectedState.SelectedElement;
+        ElementSave? element = _selectedState.SelectedElement;
 
         if (element != null && _selectedState.SelectedInstance != null)
         {
@@ -119,14 +119,14 @@ public class ExclusionsPlugin : PriorityPlugin
     {
         get
         {
-            ElementSave element = _selectedState.SelectedElement;
+            ElementSave? element = _selectedState.SelectedElement;
 
             if (element != null && _selectedState.SelectedInstance != null)
             {
                 element = ObjectFinder.Self.GetElementSave(_selectedState.SelectedInstance);
             }
 
-            ElementSave baseElement = null;
+            ElementSave? baseElement = null;
 
             if (element != null)
             {
@@ -167,7 +167,7 @@ public class ExclusionsPlugin : PriorityPlugin
         if(currentElement is ScreenSave currentScreen && _selectedState.SelectedInstance == null)
         {
             // exclude it if the value is null and there is only one screen:
-            var isOnlyScreen = _objectFinder.GumProjectSave.Screens.Count == 1;
+            var isOnlyScreen = _objectFinder.GumProjectSave?.Screens.Count == 1;
             var isEmpty = string.IsNullOrEmpty(currentScreen.BaseType);
 
             return isOnlyScreen && isEmpty;

--- a/Gum/Plugins/InternalPlugins/VariableGrid/ISetVariableLogic.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/ISetVariableLogic.cs
@@ -17,10 +17,10 @@ public interface ISetVariableLogic
 
     GeneralResponse PropertyValueChanged(string unqualifiedMemberName, object? oldValue,
         InstanceSave instance, StateSave stateContainingVariable, bool refresh = true, bool recordUndo = true,
-        bool trySave = true);
+        bool trySave = true, bool isFullCommit = true);
 
     GeneralResponse ReactToPropertyValueChanged(string unqualifiedMember, object? oldValue, IInstanceContainer instanceContainer,
-        InstanceSave instance, StateSave currentState, bool refresh, bool recordUndo = true, bool trySave = true);
+        InstanceSave instance, StateSave currentState, bool refresh, bool recordUndo = true, bool trySave = true, bool isFullCommit = true);
 
     GeneralResponse PropertyValueChangedOnBehaviorInstance(string memberName, object? oldValue,
         BehaviorSave behavior, BehaviorInstanceSave instance);

--- a/Gum/Plugins/InternalPlugins/VariableGrid/SetVariableLogic.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/SetVariableLogic.cs
@@ -60,6 +60,9 @@ public class SetVariableLogic : ISetVariableLogic
         {"GradientType",                                           VariableRefreshType.FullGridRefresh   },
         {"HasDropshadow",                                          VariableRefreshType.FullGridRefresh   },
         {"IsFilled",                                               VariableRefreshType.FullGridRefresh   },
+        // StrokeWidth = 0 hides the dash/gap and stroke-color channels. The refresh fires only
+        // on a Full commit (drag release / Enter / focus loss), not per intermediate drag tick.
+        {"StrokeWidth",                                            VariableRefreshType.FullGridRefresh   },
         // Refreshing on locked causes the grid to refresh. This is a way to update it when selecting Locked from right-click
         {"Locked",                                                  VariableRefreshType.FullGridRefresh   },
         // These are handled in the SubtextLogic

--- a/Gum/Plugins/InternalPlugins/VariableGrid/SetVariableLogic.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/SetVariableLogic.cs
@@ -135,7 +135,7 @@ public class SetVariableLogic : ISetVariableLogic
     // added instance property so we can change values even if a tree view is selected
     public GeneralResponse PropertyValueChanged(string unqualifiedMemberName, object? oldValue,
         InstanceSave instance, StateSave stateContainingVariable, bool refresh = true, bool recordUndo = true,
-        bool trySave = true)
+        bool trySave = true, bool isFullCommit = true)
     {
         IInstanceContainer? instanceContainer = null;
 
@@ -170,7 +170,7 @@ public class SetVariableLogic : ISetVariableLogic
             stateContainingVariable = containerElement.DefaultState;
         }
 
-        var response = ReactToPropertyValueChanged(unqualifiedMemberName, oldValue, instanceContainer, instance, stateContainingVariable, refresh, recordUndo: recordUndo, trySave: trySave);
+        var response = ReactToPropertyValueChanged(unqualifiedMemberName, oldValue, instanceContainer, instance, stateContainingVariable, refresh, recordUndo: recordUndo, trySave: trySave, isFullCommit: isFullCommit);
         return response;
     }
 
@@ -184,7 +184,7 @@ public class SetVariableLogic : ISetVariableLogic
     /// <param name="currentState">The state where the variable was set - the current state save</param>
     /// <param name="refresh"></param>
     public GeneralResponse ReactToPropertyValueChanged(string unqualifiedMember, object? oldValue, IInstanceContainer instanceContainer,
-        InstanceSave instance, StateSave currentState, bool refresh, bool recordUndo = true, bool trySave = true)
+        InstanceSave instance, StateSave currentState, bool refresh, bool recordUndo = true, bool trySave = true, bool isFullCommit = true)
     {
         GeneralResponse response = GeneralResponse.SuccessfulResponse;
         ObjectFinder.Self.EnableCache();
@@ -206,8 +206,6 @@ public class SetVariableLogic : ISetVariableLogic
 
             if(response.Succeeded)
             {
-                bool didSetDeepReference = false;
-
                 if (parentElement != null)
                 {
                     string qualifiedName = unqualifiedMember;
@@ -232,7 +230,7 @@ public class SetVariableLogic : ISetVariableLogic
 
                     if (refresh)
                     {
-                        RefreshInResponseToVariableChange(unqualifiedMember, oldValue, parentElement, instance, qualifiedName);
+                        RefreshInResponseToVariableChange(unqualifiedMember, oldValue, parentElement, instance, qualifiedName, isFullCommit);
 
                     }
                 }
@@ -265,8 +263,16 @@ public class SetVariableLogic : ISetVariableLogic
 
 
     void RefreshInResponseToVariableChange(string unqualifiedMember, object oldValue, ElementSave parentElement,
-        InstanceSave instance, string qualifiedName)
+        InstanceSave instance, string qualifiedName, bool isFullCommit = true)
     {
+        // This method only performs structural grid changes (rebuilding the tree view / category
+        // list, which adds or removes rows). Those must wait for a committed value: doing them on
+        // an intermediate scrub tick (e.g. dragging the StrokeWidth label) destroys the control
+        // being dragged, breaking mouse capture. The full commit on release performs the rebuild.
+        if (!isFullCommit)
+        {
+            return;
+        }
 
         var needsToRefreshEntireElement = VariablesRequiringRefresh.ContainsKey(unqualifiedMember);
 
@@ -582,8 +588,6 @@ public class SetVariableLogic : ISetVariableLogic
                 float outX = 0;
                 float outY = 0;
 
-                bool isWidthOrHeight = false;
-
                 object unitTypeAsObject = _elementCommands.GetCurrentValueForVariable(changedMember, _selectedState.SelectedInstance);
                 GeneralUnitType unitType = UnitConverter.ConvertToGeneralUnit(unitTypeAsObject);
 
@@ -602,14 +606,12 @@ public class SetVariableLogic : ISetVariableLogic
                 else if (changedMember == "WidthUnits")
                 {
                     variableToSet = "Width";
-                    isWidthOrHeight = true;
                     xOrY = XOrY.X;
 
                 }
                 else if (changedMember == "HeightUnits")
                 {
                     variableToSet = "Height";
-                    isWidthOrHeight = true;
                     xOrY = XOrY.Y;
                 }
 

--- a/Gum/Plugins/InternalPlugins/VariableGrid/SetVariableLogic.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/SetVariableLogic.cs
@@ -262,8 +262,8 @@ public class SetVariableLogic : ISetVariableLogic
     }
 
 
-    void RefreshInResponseToVariableChange(string unqualifiedMember, object oldValue, ElementSave parentElement,
-        InstanceSave instance, string qualifiedName, bool isFullCommit = true)
+    void RefreshInResponseToVariableChange(string unqualifiedMember, object? oldValue, ElementSave parentElement,
+        InstanceSave? instance, string qualifiedName, bool isFullCommit = true)
     {
         // This method only performs structural grid changes (rebuilding the tree view / category
         // list, which adds or removes rows). Those must wait for a committed value: doing them on
@@ -302,7 +302,7 @@ public class SetVariableLogic : ISetVariableLogic
         }
     }
 
-    internal static bool IsStateVariable(string unqualifiedMember, ElementSave parentElement, InstanceSave instance)
+    internal static bool IsStateVariable(string unqualifiedMember, ElementSave? parentElement, InstanceSave? instance)
     {
         if (parentElement == null)
         {
@@ -365,7 +365,7 @@ public class SetVariableLogic : ISetVariableLogic
         return response;
     }
 
-    private void ReactIfChangedBaseType(IInstanceContainer instanceContainer, InstanceSave instance, StateSave stateSave, string rootVariableName, object oldValue)
+    private void ReactIfChangedBaseType(IInstanceContainer instanceContainer, InstanceSave? instance, StateSave stateSave, string rootVariableName, object oldValue)
     {
 
         if (rootVariableName == "BaseType")
@@ -392,7 +392,7 @@ public class SetVariableLogic : ISetVariableLogic
 
     private void ReactIfChangedMemberIsDefaultChildContainer(ElementSave parentElement, InstanceSave instance, string rootVariableName, object oldValue)
     {
-        VariableSave variable = _selectedState.SelectedVariableSave;
+        VariableSave? variable = _selectedState.SelectedVariableSave;
 
         if (variable != null && rootVariableName == "DefaultChildContainer")
         {
@@ -450,7 +450,7 @@ public class SetVariableLogic : ISetVariableLogic
         if (changedMember == "Font" || changedMember == "FontSize" || changedMember == "OutlineThickness" ||
             changedMember == "UseFontSmoothing" || changedMember == "IsItalic" || changedMember == "IsBold")
         {
-            StateSave stateSave = _selectedState.SelectedStateSave;
+            StateSave? stateSave = _selectedState.SelectedStateSave;
 
             // If the user has a category selected but no state in the category, then use the default:
             if (stateSave == null && _selectedState.SelectedStateCategorySave != null)
@@ -476,14 +476,14 @@ public class SetVariableLogic : ISetVariableLogic
 
         var instancePrefix = instance != null ? $"{instance.Name}." : "";
         var variableFullName = $"{instancePrefix}{changedMember}";
-        VariableSave variable = _selectedState.SelectedStateSave?.GetVariableSave(variableFullName);
+        VariableSave? variable = _selectedState.SelectedStateSave?.GetVariableSave(variableFullName);
 
         if (variable == null || string.IsNullOrWhiteSpace(variable.Value as string))
         {
             return GeneralResponse.SuccessfulResponse;
         }
 
-        string value = variable.Value as string;
+        string? value = variable.Value as string;
 
         // Only handle .ttf file paths, not system font names like "Arial"
         if (!BmfcSave.IsFontFilePath(value))
@@ -545,8 +545,8 @@ public class SetVariableLogic : ISetVariableLogic
     private void ReactIfChangedMemberIsUnitType(ElementSave parentElement, string changedMember, object oldValueAsObject)
     {
         bool wasAnythingSet = false;
-        string variableToSet = null;
-        StateSave stateSave = _selectedState.SelectedStateSave;
+        string? variableToSet = null;
+        StateSave? stateSave = _selectedState.SelectedStateSave;
         float valueToSet = 0;
 
         var wereUnitValuesChanged =
@@ -560,7 +560,7 @@ public class SetVariableLogic : ISetVariableLogic
 
             if (UnitConverter.TryConvertToGeneralUnit(oldValueAsObject, out oldValue))
             {
-                IRenderableIpso currentIpso =
+                IRenderableIpso? currentIpso =
                     _wireframeObjectManager.GetSelectedRepresentation();
 
                 float parentWidth = ObjectFinder.Self.GumProjectSave.DefaultCanvasWidth;
@@ -646,9 +646,9 @@ public class SetVariableLogic : ISetVariableLogic
 
         if (wasAnythingSet && AttemptToPersistPositionsOnUnitChanges && !float.IsPositiveInfinity(valueToSet))
         {
-            InstanceSave instanceSave = _selectedState.SelectedInstance;
+            InstanceSave? instanceSave = _selectedState.SelectedInstance;
 
-            string unqualifiedVariableToSet = variableToSet;
+            string? unqualifiedVariableToSet = variableToSet;
             if (_selectedState.SelectedInstance != null)
             {
                 variableToSet = _selectedState.SelectedInstance.Name + "." + variableToSet;
@@ -669,7 +669,7 @@ public class SetVariableLogic : ISetVariableLogic
         }
     }
 
-    private GeneralResponse ReactIfChangedMemberIsSourceFile(ElementSave parentElement, InstanceSave instance, string changedMember, object oldValue)
+    private GeneralResponse ReactIfChangedMemberIsSourceFile(ElementSave parentElement, InstanceSave instance, string changedMember, object? oldValue)
     {
         ////////////Early Out /////////////////////////////
 
@@ -679,18 +679,21 @@ public class SetVariableLogic : ISetVariableLogic
 
         variableFullName = $"{instancePrefix}{changedMember}";
 
-        VariableSave variable = _selectedState.SelectedStateSave?.GetVariableSave(variableFullName);
+        StateSave? selectedStateSave = _selectedState.SelectedStateSave;
+        VariableSave? variable = selectedStateSave?.GetVariableSave(variableFullName);
 
         bool isSourcefile = variable?.GetRootName() == "SourceFile";
 
-        if (!isSourcefile || string.IsNullOrWhiteSpace(variable.Value as string))
+        string? sourceFileValue = variable?.Value as string;
+
+        if (variable == null || !isSourcefile || string.IsNullOrWhiteSpace(sourceFileValue))
         {
             return GeneralResponse.SuccessfulResponse;
         }
 
         ////////////End Early Out/////////////////////////
 
-        string errorMessage = GetWhySourcefileIsInvalid(variable.Value as string, parentElement, instance, changedMember);
+        string errorMessage = GetWhySourcefileIsInvalid(sourceFileValue, parentElement, instance, changedMember);
 
         if (!string.IsNullOrEmpty(errorMessage))
         {
@@ -711,16 +714,16 @@ public class SetVariableLogic : ISetVariableLogic
             else
             {
                 // Case 1: variable didn't exist before the property grid created it — remove entirely.
-                _selectedState.SelectedStateSave.Variables.Remove(variable);
+                selectedStateSave.Variables.Remove(variable);
             }
             return GeneralResponse.UnsuccessfulWith(errorMessage);
         }
         else
         {
-            string value;
+            string? value;
 
             value = variable.Value as string;
-            StateSave stateSave = _selectedState.SelectedStateSave;
+            StateSave stateSave = selectedStateSave;
 
             if (!string.IsNullOrEmpty(value))
             {
@@ -929,7 +932,7 @@ public class SetVariableLogic : ISetVariableLogic
 
     private void ReactIfChangedMemberIsParent(ElementSave parentElement, InstanceSave instance, string changedMember, object oldValue, GeneralResponse response)
     {
-        VariableSave variable = _selectedState.SelectedVariableSave;
+        VariableSave? variable = _selectedState.SelectedVariableSave;
         // Eventually need to handle tunneled variables
         if (variable != null && changedMember == "Parent" && response.Succeeded)
         {

--- a/Gum/Plugins/InternalPlugins/VariableGrid/ShapeVariableExclusionLogic.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/ShapeVariableExclusionLogic.cs
@@ -1,0 +1,148 @@
+using Gum.DataTypes;
+using RenderingLibrary.Graphics;
+
+namespace Gum.Plugins.InternalPlugins.VariableGrid;
+
+/// <summary>
+/// Pure decision logic for hiding shape variables (gradient / dropshadow / stroke / fill
+/// channels) in the variable grid for Circle / Rectangle / ColoredCircle / RoundedRectangle /
+/// Arc / Line. Kept free of services (the caller supplies the resolved standard type name and
+/// variable prefix) so it can be unit tested without a loaded project or selection state.
+/// </summary>
+internal class ShapeVariableExclusionLogic
+{
+    // Moved from ExclusionsPlugin (originally Gum/SvgPlugin/Managers/DefaultStateManager) — these
+    // rules historically lived in MainSkiaPlugin because gradient/dropshadow/IsFilled were
+    // Skia-only, but #2929/#2933/#2931 promoted them to plain Circle/Rectangle. The gating
+    // is shape-agnostic now.
+    public bool GetIfShapeVariableIsExcluded(string rootName, RecursiveVariableFinder finder,
+        string? rootStandardTypeName, string prefix, out bool shouldExclude)
+    {
+        if (rootName == "Red" || rootName == "Green" || rootName == "Blue")
+        {
+            var usesGradients = finder.GetValue(prefix + "UseGradient");
+            if (usesGradients is bool asBool && asBool)
+            {
+                shouldExclude = true;
+                return true;
+            }
+        }
+        else if (rootName == "Red1" || rootName == "Green1" || rootName == "Blue1" || rootName == "Alpha1" ||
+            rootName == "GradientX1" || rootName == "GradientY1" ||
+            rootName == "GradientX1Units" || rootName == "GradientY1Units" ||
+            rootName == "Red2" || rootName == "Green2" || rootName == "Blue2" || rootName == "Alpha2" ||
+            rootName == "GradientType")
+        {
+            var usesGradients = finder.GetValue(prefix + "UseGradient");
+            var effectiveUsesGradient = usesGradients is bool asBool && asBool;
+            shouldExclude = !effectiveUsesGradient;
+            return true;
+        }
+        else if (rootName == "GradientX2" || rootName == "GradientY2" || rootName == "GradientX2Units" || rootName == "GradientY2Units")
+        {
+            var usesGradients = finder.GetValue(prefix + "UseGradient");
+            var effectiveUsesGradient = usesGradients is bool asBool && asBool;
+
+            var gradientTypeAsObject = finder.GetValue(prefix + "GradientType");
+            GradientType? gradientType = gradientTypeAsObject as GradientType?;
+
+            shouldExclude = effectiveUsesGradient == false || gradientType != GradientType.Linear;
+            return true;
+        }
+        else if (rootName == "GradientInnerRadius" || rootName == "GradientOuterRadius" ||
+            rootName == "GradientInnerRadiusUnits" || rootName == "GradientOuterRadiusUnits")
+        {
+            var usesGradients = finder.GetValue(prefix + "UseGradient");
+            var effectiveUsesGradient = usesGradients is bool asBool && asBool;
+
+            var gradientTypeAsObject = finder.GetValue(prefix + "GradientType");
+            GradientType? gradientType = gradientTypeAsObject as GradientType?;
+
+            shouldExclude = effectiveUsesGradient == false || gradientType != GradientType.Radial;
+            return true;
+        }
+
+        if (rootName == "DropshadowOffsetX" || rootName == "DropshadowOffsetY" || rootName == "DropshadowBlur" ||
+            rootName == "DropshadowAlpha" || rootName == "DropshadowRed" || rootName == "DropshadowGreen" || rootName == "DropshadowBlue")
+        {
+            var hasDropshadow = finder.GetValue(prefix + "HasDropshadow");
+            var effectiveHasDropshadow = hasDropshadow is bool asBool && asBool;
+            shouldExclude = !effectiveHasDropshadow;
+            return true;
+        }
+
+        // #2931 / #2938: stroke vs. fill model is type-specific.
+        //
+        // Legacy shapes (ColoredCircle / RoundedRectangle / Arc) treat IsFilled as
+        // "fill OR stroke" — when IsFilled is true the stroke vars are meaningless and
+        // hidden. Plain Circle / Rectangle (#2938) expose fill and stroke as independent
+        // surfaces; stroke vars stay visible regardless of IsFilled, gated only by
+        // StrokeWidth = 0.
+        //
+        // Symmetric on the fill side: the channel-decomp FillRed/Green/Blue/Alpha exist
+        // only on plain Circle / Rectangle (#2931) and are meaningless when IsFilled is
+        // false.
+        var hasSeparateFillAndStroke = rootStandardTypeName == "Circle" || rootStandardTypeName == "Rectangle";
+
+        if (rootName == "StrokeWidth" || rootName == "StrokeDashLength" || rootName == "StrokeGapLength")
+        {
+            if (!hasSeparateFillAndStroke)
+            {
+                var isFilled = finder.GetValue(prefix + "IsFilled");
+                if (isFilled is true)
+                {
+                    shouldExclude = true;
+                    return true;
+                }
+            }
+
+            // StrokeWidth <= 0 draws no stroke (rendering gates on StrokeWidth > 0), so the
+            // dash pattern is meaningless. StrokeWidth itself stays visible so the user can
+            // re-enable the stroke.
+            if (rootName != "StrokeWidth" && IsStrokeAbsent(finder, prefix))
+            {
+                shouldExclude = true;
+                return true;
+            }
+        }
+
+        if (hasSeparateFillAndStroke &&
+            (rootName == "StrokeRed" || rootName == "StrokeGreen" || rootName == "StrokeBlue" || rootName == "StrokeAlpha"))
+        {
+            // No stroke drawn means its color channels are meaningless.
+            shouldExclude = IsStrokeAbsent(finder, prefix);
+            return true;
+        }
+
+        if (hasSeparateFillAndStroke &&
+            (rootName == "FillRed" || rootName == "FillGreen" || rootName == "FillBlue" || rootName == "FillAlpha"))
+        {
+            // Hidden when IsFilled = false (no fill drawn) or when UseGradient = true
+            // (gradient paints the fill slot, the solid fill channels are unused). Stroke
+            // channels stay visible regardless of UseGradient — gradient targets fill only.
+            var isFilled = finder.GetValue(prefix + "IsFilled");
+            if (isFilled is false)
+            {
+                shouldExclude = true;
+                return true;
+            }
+            var usesGradient = finder.GetValue(prefix + "UseGradient");
+            if (usesGradient is true)
+            {
+                shouldExclude = true;
+                return true;
+            }
+            shouldExclude = false;
+            return true;
+        }
+
+        shouldExclude = false;
+        return false;
+    }
+
+    private bool IsStrokeAbsent(RecursiveVariableFinder finder, string prefix)
+    {
+        var strokeWidth = finder.GetValue(prefix + "StrokeWidth");
+        return strokeWidth is float asFloat && asFloat <= 0f;
+    }
+}

--- a/Gum/Plugins/InternalPlugins/VariableGrid/StateReferencingInstanceMember.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/StateReferencingInstanceMember.cs
@@ -1156,7 +1156,7 @@ public class StateReferencingInstanceMember : InstanceMember
                 {
                     handledByExposedVariable = true;
 
-                    _setVariableLogic.ReactToPropertyValueChanged(variable.GetRootName(), LastOldFullCommitValue, elementSave, instanceInElement, this.StateSave, refresh: effectiveRefresh, recordUndo: effectiveRecordUndo);
+                    _setVariableLogic.ReactToPropertyValueChanged(variable.GetRootName(), LastOldFullCommitValue, elementSave, instanceInElement, this.StateSave, refresh: effectiveRefresh, recordUndo: effectiveRecordUndo, isFullCommit: commitType == SetPropertyCommitType.Full);
                 }
 
             }
@@ -1195,7 +1195,8 @@ public class StateReferencingInstanceMember : InstanceMember
                     stateToSet,
                     refresh: effectiveRefresh,
                     recordUndo: effectiveRecordUndo,
-                    trySave: trySave);
+                    trySave: trySave,
+                    isFullCommit: commitType == SetPropertyCommitType.Full);
             }
             else if (_selectedState.SelectedBehavior != null &&
                      gumElementOrInstanceSaveAsObject is BehaviorInstanceSave behaviorInstance)

--- a/Tool/Tests/GumToolUnitTests/Plugins/InternalPlugins/VariableGrid/ShapeVariableExclusionLogicTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/InternalPlugins/VariableGrid/ShapeVariableExclusionLogicTests.cs
@@ -1,0 +1,87 @@
+using Gum.DataTypes;
+using Gum.DataTypes.Variables;
+using Gum.Plugins.InternalPlugins.VariableGrid;
+using Shouldly;
+using Xunit;
+
+namespace GumToolUnitTests.Plugins.InternalPlugins.VariableGrid;
+
+public class ShapeVariableExclusionLogicTests
+{
+    private readonly ShapeVariableExclusionLogic _logic = new();
+
+    [Theory]
+    [InlineData("StrokeDashLength")]
+    [InlineData("StrokeGapLength")]
+    public void StrokeWidthZero_HidesDashAndGap_OnPlainShape(string variableName)
+    {
+        var finder = MakeFinder(("StrokeWidth", 0f));
+
+        _logic.GetIfShapeVariableIsExcluded(variableName, finder, "Circle", "", out bool shouldExclude)
+            .ShouldBeTrue();
+        shouldExclude.ShouldBeTrue();
+    }
+
+    [Theory]
+    [InlineData("StrokeDashLength")]
+    [InlineData("StrokeGapLength")]
+    public void StrokeWidthZero_HidesDashAndGap_OnLegacyStrokeShape(string variableName)
+    {
+        // Legacy ColoredCircle in stroke mode (IsFilled = false): the IsFilled gate doesn't
+        // hide stroke vars, but StrokeWidth = 0 should.
+        var finder = MakeFinder(("StrokeWidth", 0f), ("IsFilled", false));
+
+        _logic.GetIfShapeVariableIsExcluded(variableName, finder, "ColoredCircle", "", out bool shouldExclude)
+            .ShouldBeTrue();
+        shouldExclude.ShouldBeTrue();
+    }
+
+    [Theory]
+    [InlineData("StrokeRed")]
+    [InlineData("StrokeGreen")]
+    [InlineData("StrokeBlue")]
+    [InlineData("StrokeAlpha")]
+    public void StrokeWidthZero_HidesStrokeColorChannels(string variableName)
+    {
+        var finder = MakeFinder(("StrokeWidth", 0f));
+
+        _logic.GetIfShapeVariableIsExcluded(variableName, finder, "Circle", "", out bool shouldExclude)
+            .ShouldBeTrue();
+        shouldExclude.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void StrokeWidthZero_KeepsStrokeWidthItselfVisible()
+    {
+        var finder = MakeFinder(("StrokeWidth", 0f));
+
+        _logic.GetIfShapeVariableIsExcluded("StrokeWidth", finder, "Circle", "", out bool shouldExclude);
+        shouldExclude.ShouldBeFalse();
+    }
+
+    [Theory]
+    [InlineData("StrokeDashLength")]
+    [InlineData("StrokeGapLength")]
+    [InlineData("StrokeRed")]
+    [InlineData("StrokeGreen")]
+    [InlineData("StrokeBlue")]
+    [InlineData("StrokeAlpha")]
+    public void StrokeWidthPositive_ShowsStrokeChannels(string variableName)
+    {
+        var finder = MakeFinder(("StrokeWidth", 2f));
+
+        _logic.GetIfShapeVariableIsExcluded(variableName, finder, "Circle", "", out bool shouldExclude);
+        shouldExclude.ShouldBeFalse();
+    }
+
+    private static RecursiveVariableFinder MakeFinder(params (string name, object value)[] variables)
+    {
+        var element = new ComponentSave { Name = "Test" };
+        var state = new StateSave { Name = "Default", ParentContainer = element };
+        foreach (var (name, value) in variables)
+        {
+            state.Variables.Add(new VariableSave { Name = name, Value = value, SetsValue = true });
+        }
+        return new RecursiveVariableFinder(state);
+    }
+}

--- a/Tool/Tests/GumToolUnitTests/PropertyGridHelpers/SetVariableLogicTests.cs
+++ b/Tool/Tests/GumToolUnitTests/PropertyGridHelpers/SetVariableLogicTests.cs
@@ -349,6 +349,53 @@ public class SetVariableLogicTests : BaseTestClass
     }
 
     [Fact]
+    public void ReactToPropertyValueChanged_ShouldNotRebuildTreeView_WhenCommitIsIntermediate()
+    {
+        // Dragging the StrokeWidth label scrubs the value via intermediate commits. A structural
+        // rebuild (tree view + grid) per tick destroys the control being dragged and breaks the
+        // drag. The rebuild must wait for the full commit on release.
+        ScreenSave screen = new ScreenSave { Name = "MyScreen" };
+        StateSave state = new StateSave { Name = "Default", ParentContainer = screen };
+        screen.States.Add(state);
+
+        _setVariableLogic.ReactToPropertyValueChanged(
+            "StrokeWidth",
+            2f,
+            screen,
+            null,
+            state,
+            refresh: true,
+            recordUndo: false,
+            trySave: false,
+            isFullCommit: false);
+
+        mocker.GetMock<IGuiCommands>()
+            .Verify(x => x.RefreshElementTreeView(It.IsAny<ElementSave>()), Times.Never);
+    }
+
+    [Fact]
+    public void ReactToPropertyValueChanged_ShouldRebuildTreeView_WhenCommitIsFull()
+    {
+        ScreenSave screen = new ScreenSave { Name = "MyScreen" };
+        StateSave state = new StateSave { Name = "Default", ParentContainer = screen };
+        screen.States.Add(state);
+
+        _setVariableLogic.ReactToPropertyValueChanged(
+            "StrokeWidth",
+            2f,
+            screen,
+            null,
+            state,
+            refresh: true,
+            recordUndo: false,
+            trySave: false,
+            isFullCommit: true);
+
+        mocker.GetMock<IGuiCommands>()
+            .Verify(x => x.RefreshElementTreeView(It.IsAny<ElementSave>()), Times.AtLeastOnce);
+    }
+
+    [Fact]
     public void IsStateVariable_ShouldReturnTrue_WhenCategoryIsInheritedFromBaseType()
     {
         // DerivedComponent inherits from BaseComponent which defines Category1.

--- a/Tool/Tests/GumToolUnitTests/VariableGrid/StateReferencingInstanceMemberTests.cs
+++ b/Tool/Tests/GumToolUnitTests/VariableGrid/StateReferencingInstanceMemberTests.cs
@@ -34,7 +34,7 @@ public class StateReferencingInstanceMemberTests
         setVariableLogic
             .Setup(x => x.PropertyValueChanged(It.IsAny<string>(), It.IsAny<object?>(),
                 It.IsAny<InstanceSave>(), It.IsAny<StateSave>() , It.IsAny<bool>() , It.IsAny<bool>(),
-                It.IsAny<bool>()))
+                It.IsAny<bool>(), It.IsAny<bool>()))
             .Returns(GeneralResponse.SuccessfulResponse);
 
         _sut = new StateReferencingInstanceMember(

--- a/Tool/Tests/GumToolUnitTests/ViewModels/RightClickViewModelTests.cs
+++ b/Tool/Tests/GumToolUnitTests/ViewModels/RightClickViewModelTests.cs
@@ -225,7 +225,7 @@ public class RightClickViewModelTests
 
         instance.Locked.ShouldBeTrue();
         _setVariableLogic.Verify(x => x.PropertyValueChanged(
-            "Locked", false, instance, element.DefaultState, true, true, true), Times.Once);
+            "Locked", false, instance, element.DefaultState, true, true, true, It.IsAny<bool>()), Times.Once);
     }
 
     [Fact]
@@ -244,7 +244,7 @@ public class RightClickViewModelTests
 
         instance.Locked.ShouldBeFalse();
         _setVariableLogic.Verify(x => x.PropertyValueChanged(
-            "Locked", true, instance, element.DefaultState, true, true, true), Times.Once);
+            "Locked", true, instance, element.DefaultState, true, true, true, It.IsAny<bool>()), Times.Once);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- When `StrokeWidth <= 0` no stroke is drawn (rendering gates on `StrokeWidth > 0`), so the variable grid now hides `StrokeDashLength` / `StrokeGapLength` and the `StrokeR/G/B/A` channels (the latter exist only on plain Circle/Rectangle). Mirrors the existing `IsFilled = false → hide fill channels` pattern. `StrokeWidth` itself stays visible so the stroke can be re-enabled.
- Added `StrokeWidth → FullGridRefresh` so toggling it rebuilds the grid.
- **Grid-refresh fix (exposed by the above):** dragging the StrokeWidth label scrubs via intermediate commits; because `effectiveRefresh` is effectively always true (`IsCallingRefresh` defaults true), each tick was triggering the `FullGridRefresh` structural rebuild, destroying the dragged control and making the value jump. Now the commit type is threaded from `NotifyVariableLogic` into `RefreshInResponseToVariableChange`, which skips structural rebuilds on intermediate commits — the rebuild happens once on the Full commit (release). Any draggable variable in `VariablesRequiringRefresh` would have hit this.
- Refactor: extracted the shape exclusion decision out of `ExclusionsPlugin` into a dependency-free `ShapeVariableExclusionLogic` (directly unit-testable); converted `ExclusionsPlugin` to `[ImportingConstructor]` injection of `ISelectedState`.
- Cleanup: removed two unused locals in `SetVariableLogic`; documented the refactor + MEF-injection rules in the `refactoring-direction` skill.

## Test plan
- [x] New unit tests: `ShapeVariableExclusionLogicTests` (15) and `SetVariableLogicTests` drag-commit tests (2) — red before, green after.
- [x] Full `GumToolUnitTests` suite: 681 passed, 0 failed.
- [x] `GumFull.sln` builds clean.
- [ ] Manual: plain Circle/Rectangle — StrokeWidth 0 hides dash/gap + StrokeR/G/B/A and keeps StrokeWidth; back to 2 restores them.
- [ ] Manual: **drag** the StrokeWidth label across zero — value scrubs smoothly, no flicker / jump / lost grab; rows update once on release.
- [ ] Manual: regression — UseGradient / IsFilled / HasDropshadow toggles still hide/show their channels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)