### PR TITLE
Document custom displayer mechanism in variable grid skill

### DIFF
--- a/.claude/skills/gum-icons/SKILL.md
+++ b/.claude/skills/gum-icons/SKILL.md
@@ -22,6 +22,8 @@ Don't mix them. A tree-view PNG is not a `GumIcon`. A `GumIcon` `PathGeometry` c
 
 The standard for any icon in the WPF tool **outside the tree view**. Replaces ad-hoc `{wpf:FluentIcon …}` usage from the FluentIcons.Wpf NuGet.
 
+These icons live *inside* WPF displayer controls (e.g. the variable grid's origin/alignment/dock toggles). For how such a displayer gets attached to a variable, see [gum-tool-variable-grid](../gum-tool-variable-grid/SKILL.md).
+
 **Components:**
 - `Gum/Content/Svg/*.svg` — authored sources.
 - `Gum/GumFigmaIconRipper/Program.cs` — console tool. Uses SharpVectors at build time only (no runtime dependency). Walks the SVG drawing tree; flattens into a primary geometry (≥95% opacity fills/strokes) and an optional `.Secondary` geometry (lower-opacity detail). Clips to a 2px live area inside a 32×32 viewBox.

--- a/.claude/skills/gum-tool-variable-grid/SKILL.md
+++ b/.claude/skills/gum-tool-variable-grid/SKILL.md
@@ -71,6 +71,22 @@ All members in the Variables tab use `StateReferencingInstanceMember` (subclass 
 
 ---
 
+## Custom Displayers (how a variable gets non-default UI)
+
+Most variables render with a default control inferred from their type. A variable gets a *different* control — slider, angle dial, alignment/origin toggles, parent dropdown — through three knobs on `InstanceMember`:
+
+- **`PreferredDisplayer`** (a `Type`) — selects which WPF control renders the row; `SingleDataUiContainer` instantiates it. This is what creates e.g. a `SliderDisplay`.
+- **`PropertiesToSetOnDisplayer`** (a `Dictionary<string, object>`) — after the control exists, the container *reflectively* sets each named property on it. A slider's `MinValue`/`MaxValue` (the "range") are just two such pushes onto a control already chosen by `PreferredDisplayer` — they do **not** create the slider on their own.
+- **`UiCreated` event** — for config that must be computed per-instance instead of a constant (see `MakeDegreesAngle`, and the WpfDataUi sample's per-character `MaxValue`).
+
+Gum's built-in variables are wired in `StandardElementsManager.GumTool.cs` (slider for color channels, angle dial, alignment, origin, parent dropdown). That file is where to look or add.
+
+> Naming trap: `MinWidth`/`MaxWidth`/`MinHeight`/`MaxHeight` in `StandardElementsManager.cs` are real runtime layout clamps — unrelated to a displayer's slider `MinValue`/`MaxValue`.
+
+The icon-based displayers (origin/alignment/dock toggles) get their glyphs from the `GumIcon` pipeline — see [gum-icons](../gum-icons/SKILL.md).
+
+---
+
 ## Refresh Trigger Flow
 
 ```

--- a/.claude/skills/skills-writer/SKILL.md
+++ b/.claude/skills/skills-writer/SKILL.md
@@ -9,6 +9,8 @@ description: Creates and updates skill files (.claude/skills/*/SKILL.md). Trigge
 
 A skill is **a map and a list of landmines** — not an encyclopedia. It points an agent at the right code and docs, and warns about things that are not obvious from reading either. If a fact is already in source or in `docs/`, the skill should *link*, not restate.
 
+Think **signpost, not explanation**: a short pointer plus a direction ("the wiring lives in X; watch out for Y"), never a lengthy walkthrough or a code dump. Brevity is a feature, not a compromise — every line is re-read into context on every load, so a skill that explains *less* but points *accurately* is doing its job better than a thorough one.
+
 ## Authoritative Sources (do not duplicate)
 
 Before writing anything, identify where the ground truth already lives:


### PR DESCRIPTION
## Summary
- Adds a **Custom Displayers** section to `gum-tool-variable-grid` explaining how a variable gets non-default UI via the three `InstanceMember` knobs: `PreferredDisplayer` (picks the control), `PropertiesToSetOnDisplayer` (reflectively configures it — e.g. a slider's `MinValue`/`MaxValue`), and the `UiCreated` event (per-instance config).
- Calls out the `MinWidth`/`MaxWidth`/`MinHeight`/`MaxHeight` naming trap (those are runtime layout clamps, unrelated to slider range).
- Cross-links `gum-icons` ↔ `gum-tool-variable-grid` so the icon-based displayers and the displayer-attachment mechanism each point at the other.
- Reinforces the "signpost, not explanation" framing in `skills-writer` (no contradiction with existing rules — the principle was already the skill's spine).

Skill-only doc change; no code touched.