### PR TITLE
Fix SliderDisplay clobbering out-of-range values with clamped slider position

### DIFF
--- a/Tool/Tests/GumToolUnitTests/PropertyGridHelpers/SliderDisplayRangeTests.cs
+++ b/Tool/Tests/GumToolUnitTests/PropertyGridHelpers/SliderDisplayRangeTests.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Threading;
+using Shouldly;
+using WpfDataUi;
+using WpfDataUi.Controls;
+using WpfDataUi.DataTypes;
+
+namespace GumToolUnitTests.PropertyGridHelpers;
+
+/// <summary>
+/// Verifies that <see cref="SliderDisplay"/> preserves a value that falls outside its
+/// [MinValue, MaxValue] slider range. The slider thumb may peg at the boundary, but the
+/// value the control reports must stay intact — when WPF coerces the slider position into
+/// range, that coerced position must not be echoed back over the real value (a silent
+/// data-loss bug).
+/// </summary>
+public class SliderDisplayRangeTests : BaseTestClass
+{
+    [Fact]
+    public void TrySetValueOnUi_ValueAboveMax_PreservesReportedValue()
+    {
+        RunOnSta(() =>
+        {
+            SliderDisplay display = new SliderDisplay();
+            display.MinValue = 0;
+            display.MaxValue = 255;
+
+            // Seed the slider with an in-range value so the out-of-range push below
+            // produces a real slider-value change (and thus the coercion that triggers
+            // the clobber). Without a prior in-range value the slider never moves.
+            InstanceMember member = MakeFloatMember(100f);
+            display.InstanceMember = member;
+
+            display.TrySetValueOnUi(300f);
+
+            ApplyValueResult result = display.TryGetValueOnUi(out object? shown);
+
+            result.ShouldBe(ApplyValueResult.Success);
+            Convert.ToSingle(shown).ShouldBe(300f);
+        });
+    }
+
+    [Fact]
+    public void TrySetValueOnUi_ValueBelowMin_PreservesReportedValue()
+    {
+        RunOnSta(() =>
+        {
+            SliderDisplay display = new SliderDisplay();
+            display.MinValue = 10;
+            display.MaxValue = 255;
+
+            InstanceMember member = MakeFloatMember(200f);
+            display.InstanceMember = member;
+
+            display.TrySetValueOnUi(5f);
+
+            ApplyValueResult result = display.TryGetValueOnUi(out object? shown);
+
+            result.ShouldBe(ApplyValueResult.Success);
+            Convert.ToSingle(shown).ShouldBe(5f);
+        });
+    }
+
+    private static InstanceMember MakeFloatMember(float value)
+    {
+        InstanceMember member = new InstanceMember { Name = "StrokeWidth" };
+        member.CustomGetTypeEvent += _ => typeof(float);
+        member.CustomGetEvent += _ => value;
+        return member;
+    }
+
+    /// <summary>
+    /// WPF controls require an STA thread; xUnit's default runner is MTA.
+    /// </summary>
+    private static void RunOnSta(Action action)
+    {
+        Exception? caught = null;
+        Thread thread = new Thread(() =>
+        {
+            try { action(); }
+            catch (Exception ex) { caught = ex; }
+        });
+        thread.SetApartmentState(ApartmentState.STA);
+        thread.Start();
+        thread.Join();
+        if (caught != null)
+        {
+            throw new System.Reflection.TargetInvocationException(caught);
+        }
+    }
+}

--- a/WpfDataUi/Controls/SliderDisplay.xaml.cs
+++ b/WpfDataUi/Controls/SliderDisplay.xaml.cs
@@ -72,6 +72,13 @@ namespace WpfDataUi.Controls
 
         TextBoxDisplayLogic mTextBoxLogic;
 
+        // True while we push a value into the slider ourselves. WPF coerces Slider.Value
+        // into [Minimum, Maximum], and that coercion raises ValueChanged with the clamped
+        // value. We must not echo that clamped value back into the text box, or a value
+        // outside the slider range (the text box is the source of truth) would be silently
+        // overwritten with the clamped one.
+        bool _isSettingSliderValueProgrammatically;
+
         public bool SuppressSettingProperty { get; set; }
 
         /// <summary>
@@ -313,35 +320,50 @@ namespace WpfDataUi.Controls
 
         private void SetSliderValue(object valueOnInstance)
         {
-            if (valueOnInstance is float)
+            _isSettingSliderValueProgrammatically = true;
+            try
             {
-                this.Slider.Value = (float)valueOnInstance;
+                if (valueOnInstance is float)
+                {
+                    this.Slider.Value = (float)valueOnInstance;
+                }
+                else if (valueOnInstance is double)
+                {
+                    this.Slider.Value = (double)valueOnInstance;
+                }
+                else if(valueOnInstance is int)
+                {
+                    this.Slider.Value = (int)valueOnInstance;
+                }
+                else if(valueOnInstance is decimal)
+                {
+                    this.Slider.Value = (double)(decimal)valueOnInstance;
+                }
+                else if(valueOnInstance is long)
+                {
+                    this.Slider.Value = (long)valueOnInstance;
+                }
+                else if(valueOnInstance is byte)
+                {
+                    this.Slider.Value = (byte)valueOnInstance;
+                }
             }
-            else if (valueOnInstance is double)
+            finally
             {
-                this.Slider.Value = (double)valueOnInstance;
-            }
-            else if(valueOnInstance is int)
-            {
-                this.Slider.Value = (int)valueOnInstance;
-            }
-            else if(valueOnInstance is decimal)
-            {
-                this.Slider.Value = (double)(decimal)valueOnInstance;
-            }
-            else if(valueOnInstance is long)
-            {
-                this.Slider.Value = (long)valueOnInstance;
-            }
-            else if(valueOnInstance is byte)
-            {
-                this.Slider.Value = (byte)valueOnInstance;
+                _isSettingSliderValueProgrammatically = false;
             }
         }
 
         DateTime lastSliderTime = new DateTime();
         private void Slider_ValueChanged(object? sender, RoutedPropertyChangedEventArgs<double> e)
         {
+            // Ignore changes we caused by pushing a value into the slider; only user-driven
+            // slider movement should flow back into the text box. See the field comment.
+            if (_isSettingSliderValueProgrammatically)
+            {
+                return;
+            }
+
             // This is required to prevent weird flickering on the slider. Putting 100 ms frequency limiter makes everything work just fine.
             // It's a hack but...not sure what else to do. I also have Slider_DragCompleted so the last value is always pushed.
             // Update 2 - this causes all kinds of problems if we update in realtime. 


### PR DESCRIPTION
## Summary
- `SliderDisplay` displays both a slider and a text box. When a value **outside** `[MinValue, MaxValue]` is shown, WPF coerces `Slider.Value` into range and raises `ValueChanged` with the clamped value. `Slider_ValueChanged` then echoed that clamped value back into the text box, silently overwriting the real value (e.g. `300` displayed as `255`, `5` displayed as `10`).
- This is a latent data-loss bug: the only current consumer (color channels) hard-clamps to 0–255 so values never fall outside range. It would become live the moment a slider is used where values can legitimately exceed the range (e.g. a future "soft range" slider).
- Fix: flag programmatic slider writes (`_isSettingSliderValueProgrammatically`) and ignore the resulting coerced `ValueChanged`, so only user-driven slider movement flows back into the text box.

## Test plan
- [x] New `SliderDisplayRangeTests` (STA-threaded, instantiates the real `SliderDisplay`) — `ValueAboveMax` and `ValueBelowMin` both fail before the fix (report 255 / 10) and pass after (report 300 / 5).
- [x] Full `GumToolUnitTests` suite green (683 passed, 5 pre-existing skips).

Closes nothing — logged independently of the dynamic-range feature discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)