### PR TITLE
#2965: Default new projects to GumxVersions.ShapeVariableExpansion (3)

### DIFF
--- a/.claude/skills/gum-project-versioning/SKILL.md
+++ b/.claude/skills/gum-project-versioning/SKILL.md
@@ -7,12 +7,15 @@ description: Gum's .gumx schema versioning and migration strategy. Triggers: sha
 
 ## The GumxVersions enum
 
-Located in `GumDataTypes/GumProjectSave.cs`. Currently two entries:
+Located in `GumDataTypes/GumProjectSave.cs`. The enum gains one entry per breaking schema change; the earliest entries cover the verbose→compact XML shift, later ones reserve slots for new variable surfaces. Read the enum itself for the current list and each entry's doc comment — don't rely on a copy here.
 
-- `InitialVersion = 1` — verbose XML (names as child elements)
-- `AttributeVersion = 2` — compact XML (names as attributes on `ElementReference` / `BehaviorReference`)
+`NativeVersion` is the highest version this tool build supports / writes.
 
-`NativeVersion` is the version that the current tool writes by default. A new `GumProjectSave` is constructed at `NativeVersion`.
+### Ctor default vs. new-project factories — they intentionally differ
+
+The `GumProjectSave` **constructor** does NOT default to `NativeVersion`. It defaults to an older version on purpose: the ctor default is the fallback for deserialized files that lack a `Version` element, so a legacy file reads back as the older version and the variable-grid version gate keeps hiding newer-only variables on it.
+
+A **brand-new project** is the opposite case — it seeds the latest standard-element variable surface up front, so it is honestly at `NativeVersion`. The new-project factories (`ProjectManager.CreateNewProject` for the tool, `ProjectCreator.Create` for headless/CLI) therefore stamp `Version = NativeVersion` explicitly in their initializers rather than relying on the ctor default. When adding a new way to create a project, set the version there too — and bump any verbatim-copied template `.gumx` (e.g. the Forms/theme templates) only if its bundled standards actually contain the newer variable surface.
 
 ## The three load-time behaviors
 

--- a/Gum/Managers/ProjectManager.cs
+++ b/Gum/Managers/ProjectManager.cs
@@ -156,7 +156,12 @@ public class ProjectManager : IProjectManager
     {
         _gumProjectSave = new GumProjectSave
         {
-            FontGenerator = FontGeneratorType.KernSmith
+            FontGenerator = FontGeneratorType.KernSmith,
+            // PopulateProjectWithDefaultStandards (below) seeds the v3 shape variable surface
+            // on the standard Circle/Rectangle, so stamp the project at the matching version
+            // rather than the GumProjectSave ctor default. Without this, the variable-grid
+            // version gate hides Fill/Dropshadow/Gradient on a brand-new project.
+            Version = (int)GumProjectSave.GumxVersions.ShapeVariableExpansion
         };
         ObjectFinder.Self.GumProjectSave = _gumProjectSave;
 

--- a/GumDataTypes/GumProjectSave.cs
+++ b/GumDataTypes/GumProjectSave.cs
@@ -116,10 +116,14 @@ public class GumProjectSave
     /// When a new <see cref="GumxVersions"/> value is added, update this constant to match.
     /// </summary>
     /// <remarks>
-    /// New <see cref="GumProjectSave"/> instances do NOT default to this version — see the
-    /// constructor. New projects stay at <see cref="GumxVersions.AttributeVersion"/> until
-    /// a feature gated on a higher version is actually used, so files remain readable by
-    /// older tool builds whenever they technically could be.
+    /// The <see cref="GumProjectSave"/> constructor still defaults to
+    /// <see cref="GumxVersions.AttributeVersion"/>, NOT this value. That ctor default is the
+    /// fallback for deserialized files that lack a Version element — a legacy file must read
+    /// back as the older version so the variable-grid gate keeps hiding v3-only shape variables.
+    /// Brand-new projects are a different case: they seed the v3 shape variable surface up front,
+    /// so the new-project factories (ProjectManager.CreateNewProject and ProjectCreator.Create)
+    /// explicitly stamp this version. Marking them v3 is honest — the project genuinely uses v3
+    /// features — and lets the gate show those variables on a fresh Circle/Rectangle.
     /// </remarks>
     public const int NativeVersion = (int)GumxVersions.ShapeVariableExpansion;
 

--- a/GumDataTypes/GumProjectSave.cs
+++ b/GumDataTypes/GumProjectSave.cs
@@ -425,6 +425,15 @@ public class GumProjectSave
 
         LocalizationFiles = new List<string>();
 
+        // GOTCHA: this defaults to AttributeVersion, NOT NativeVersion, and that is deliberate.
+        // XmlSerializer runs this ctor first and then overwrites Version from the file's <Version>
+        // element. A legacy file that lacks that element keeps this default — so it MUST be an old
+        // version, otherwise the variable-grid version gate (ShapeVariableVersionGate) would stop
+        // hiding the newer-only shape variables on a legacy Circle/Rectangle.
+        // Brand-new projects are the opposite case (they seed the latest variable surface), so the
+        // new-project factories — ProjectManager.CreateNewProject and ProjectCreator.Create —
+        // explicitly stamp Version = NativeVersion instead of relying on this default.
+        // Do NOT "simplify" this to NativeVersion. See NativeVersion's remarks above.
         Version = (int)GumxVersions.AttributeVersion;
     }
 

--- a/Tests/Gum.ProjectServices.Tests/ProjectCreatorTests.cs
+++ b/Tests/Gum.ProjectServices.Tests/ProjectCreatorTests.cs
@@ -106,6 +106,30 @@ public class ProjectCreatorTests : IDisposable
     }
 
     [Fact]
+    public void Create_ShouldDefaultVersionToShapeVariableExpansion()
+    {
+        string filePath = Path.Combine(_tempDirectory, "TestProject.gumx");
+
+        GumProjectSave project = _sut.Create(filePath);
+
+        // New projects seed the v3 shape variable surface (Fill/Dropshadow/Gradient) on the
+        // standard Circle/Rectangle, so they must be stamped at the matching version. Otherwise
+        // the variable-grid version gate hides those variables on a brand-new project.
+        project.Version.ShouldBe((int)GumProjectSave.GumxVersions.ShapeVariableExpansion);
+    }
+
+    [Fact]
+    public void Create_ShouldPersistShapeVariableExpansionVersionToDisk()
+    {
+        string filePath = Path.Combine(_tempDirectory, "TestProject.gumx");
+
+        _sut.Create(filePath);
+
+        string gumxContent = File.ReadAllText(filePath);
+        gumxContent.ShouldContain($"<Version>{(int)GumProjectSave.GumxVersions.ShapeVariableExpansion}</Version>");
+    }
+
+    [Fact]
     public void Create_ShouldPersistKernSmithFontGeneratorToDisk()
     {
         string filePath = Path.Combine(_tempDirectory, "TestProject.gumx");

--- a/Tools/Gum.ProjectServices/ProjectCreator.cs
+++ b/Tools/Gum.ProjectServices/ProjectCreator.cs
@@ -46,7 +46,10 @@ public class ProjectCreator : IProjectCreator
         var project = new GumProjectSave
         {
             FontGenerator = FontGeneratorType.KernSmith,
-            FullFileName = filePath
+            FullFileName = filePath,
+            // The default standard elements seed the v3 shape variable surface, so stamp the
+            // project at the matching version rather than the GumProjectSave ctor default.
+            Version = (int)GumProjectSave.GumxVersions.ShapeVariableExpansion
         };
 
         foreach (var name in StandardElementNames)

--- a/Tools/Gum.ProjectServices/Templates/Default/CliTemplate.gumx
+++ b/Tools/Gum.ProjectServices/Templates/Default/CliTemplate.gumx
@@ -6,7 +6,7 @@
   <FontSpacingHorizontal>1</FontSpacingHorizontal>
   <UseFontCharacterFile>false</UseFontCharacterFile>
   <AutoSizeFontOutputs>false</AutoSizeFontOutputs>
-  <Version>2</Version>
+  <Version>3</Version>
   <DefaultCanvasWidth>800</DefaultCanvasWidth>
   <DefaultCanvasHeight>600</DefaultCanvasHeight>
   <CustomCanvasSizes>

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/GumProject.gumx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/GumProject.gumx
@@ -7,7 +7,7 @@
   <UseFontCharacterFile>false</UseFontCharacterFile>
   <AutoSizeFontOutputs>false</AutoSizeFontOutputs>
   <FontGenerator>KernSmith</FontGenerator>
-  <Version>2</Version>
+  <Version>3</Version>
   <DefaultCanvasWidth>1024</DefaultCanvasWidth>
   <DefaultCanvasHeight>768</DefaultCanvasHeight>
   <CustomCanvasSizes>


### PR DESCRIPTION
## Summary

Follow-up to #2930 / PR #2962. That PR added a variable-grid gate that hides the v3-only shape variable surface (Fill / Dropshadow / Gradient) on plain Circle/Rectangle when the project's `Version < 3`. But new projects seed that v3 surface while defaulting `Version` to `AttributeVersion` (2) — so the gate hid those variables on a *brand-new* project, and they could never be enabled (you can't set a hidden variable). Version 2 couldn't distinguish a fresh project from a legacy one.

This stamps newly-created projects at `GumxVersions.ShapeVariableExpansion` (3) so the signal is unambiguous: **v2 = legacy = hide**, **v3 = new = show**.

- `ProjectManager.CreateNewProject` (tool) and `ProjectCreator.Create` (headless/CLI) now set `Version = ShapeVariableExpansion` in their initializers.
- The `GumProjectSave` **ctor default stays at v2** on purpose — it's the read-back fallback for deserialized files that lack a `Version` element, so legacy files keep hiding the v3 surface.
- Bumped the **Default** (CLI) and **Bubblegum** theme template `.gumx` files, whose bundled standards carry the v3 surface.
- **FormsTemplate left at v2** — its bundled standards are still the legacy pre-v3 shapes (old `Red/Green/Blue`, `Radius`, no Fill/Dropshadow/Gradient). Bumping it would be dishonest and re-create the chicken-and-egg. Flagged as a separate follow-up (regenerate FormsTemplate standards).
- Reconciled the `NativeVersion` remarks comment and added the ctor-vs-factory distinction to the `gum-project-versioning` skill.

## Test plan

- [x] New TDD tests in `ProjectCreatorTests`: new project's `Version` == `ShapeVariableExpansion` and `<Version>3</Version>` is persisted to disk (red before the code change, green after).
- [x] `ShapeVariableVersionGate` tests (39) still pass — both directions intact (v2 hides, v3 shows).
- [x] Full `Gum.ProjectServices.Tests` (242) and `GumProjectSave`/`GumFileSerializer` tests (47) pass — no regressions. Ctor default unchanged → existing `new GumProjectSave()` callers still get v2.
- [x] `GumFull.sln` builds clean (0 errors).

Closes #2965

🤖 Generated with [Claude Code](https://claude.com/claude-code)