### PR TITLE
Add render-state-change counter and wire up Performance plugin

### DIFF
--- a/Gum/PerformanceMeasurementPlugin/MainPlugin.cs
+++ b/Gum/PerformanceMeasurementPlugin/MainPlugin.cs
@@ -8,8 +8,6 @@ using System.ComponentModel.Composition;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using Gum.Commands;
-using Gum.Services;
 
 namespace PerformanceMeasurementPlugin
 {
@@ -17,7 +15,6 @@ namespace PerformanceMeasurementPlugin
     public class MainPlugin : PluginBase
     {
         PerformanceView view;
-        private readonly IGuiCommands _guiCommands;
 
         public override string FriendlyName
         {
@@ -29,19 +26,12 @@ namespace PerformanceMeasurementPlugin
             get { return new Version(1, 1); }
         }
 
-        public MainPlugin()
-        {
-            _guiCommands = Locator.GetRequiredService<IGuiCommands>();
-        }
-
         public override void StartUp()
         {
             view = new PerformanceView();
             view.DataContext = new PerformanceViewModel();
 
-            // This doesn't work currently so we're not going to show it, it just gets in the way.
-            //_guiCommands.AddControl(view, "Performance");
-
+            AddControl(view, "Performance", Gum.TabLocation.RightBottom);
         }
 
         public override bool ShutDown(Gum.Plugins.PluginShutDownReason shutDownReason)

--- a/Gum/PerformanceMeasurementPlugin/MainPlugin.cs
+++ b/Gum/PerformanceMeasurementPlugin/MainPlugin.cs
@@ -1,4 +1,5 @@
 ﻿using Gum;
+using Gum.Plugins;
 using Gum.Plugins.BaseClasses;
 using PerformanceMeasurementPlugin.ViewModels;
 using PerformanceMeasurementPlugin.Views;
@@ -31,7 +32,12 @@ namespace PerformanceMeasurementPlugin
             view = new PerformanceView();
             view.DataContext = new PerformanceViewModel();
 
-            AddControl(view, "Performance", Gum.TabLocation.RightBottom);
+            // This is a diagnostic tab, so it should not claim the default RightBottom
+            // selection. The tab manager auto-selects the first tab added at a location when
+            // none is selected yet; deselecting here lets another tab (e.g. Errors) hold focus
+            // regardless of plugin load order.
+            PluginTab tab = AddControl(view, "Performance", Gum.TabLocation.RightBottom);
+            tab.IsSelected = false;
         }
 
         public override bool ShutDown(Gum.Plugins.PluginShutDownReason shutDownReason)

--- a/Gum/PerformanceMeasurementPlugin/MainPlugin.cs
+++ b/Gum/PerformanceMeasurementPlugin/MainPlugin.cs
@@ -1,5 +1,4 @@
 ﻿using Gum;
-using Gum.Plugins;
 using Gum.Plugins.BaseClasses;
 using PerformanceMeasurementPlugin.ViewModels;
 using PerformanceMeasurementPlugin.Views;
@@ -32,12 +31,7 @@ namespace PerformanceMeasurementPlugin
             view = new PerformanceView();
             view.DataContext = new PerformanceViewModel();
 
-            // This is a diagnostic tab, so it should not claim the default RightBottom
-            // selection. The tab manager auto-selects the first tab added at a location when
-            // none is selected yet; deselecting here lets another tab (e.g. Errors) hold focus
-            // regardless of plugin load order.
-            PluginTab tab = AddControl(view, "Performance", Gum.TabLocation.RightBottom);
-            tab.IsSelected = false;
+            AddControl(view, "Performance", Gum.TabLocation.RightBottom);
         }
 
         public override bool ShutDown(Gum.Plugins.PluginShutDownReason shutDownReason)

--- a/Gum/PerformanceMeasurementPlugin/PerformanceMeasurementPlugin.csproj
+++ b/Gum/PerformanceMeasurementPlugin/PerformanceMeasurementPlugin.csproj
@@ -16,6 +16,11 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Gum.csproj" />
+    <!-- The tool's KNI runtime defines the concrete RenderingLibrary.Graphics.Renderer and
+         SystemManagers used by the editor. Referenced for compile-time access to
+         Renderer.SpriteRenderer / RenderStateChangeStatistics; at runtime the assembly is
+         already loaded by EditorTabPlugin_XNA, so the post-build copies only this plugin's dll. -->
+    <ProjectReference Include="..\..\MonoGameGum\KniGum\KniGum.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Page Update="Views\PerformanceView.xaml">

--- a/Gum/PerformanceMeasurementPlugin/ViewModels/PerformanceViewModel.cs
+++ b/Gum/PerformanceMeasurementPlugin/ViewModels/PerformanceViewModel.cs
@@ -52,8 +52,8 @@ public class PerformanceViewModel : INotifyPropertyChanged
     /// <summary>
     /// True when the renderer regroups same-BatchKey draws into contiguous runs
     /// (<see cref="BatchKeyGroupedOrderer"/>), reducing batch flushes at the cost of a reorder
-    /// pass. Setting this swaps the global <see cref="Renderer.SiblingOrdering"/> and forces a
-    /// redraw so the effect (and the begin counts above) update immediately.
+    /// pass. Setting this swaps the global <see cref="Renderer.SiblingOrdering"/>; the editor
+    /// renders continuously, so the next frame (and the begin counts above) reflect the change.
     /// </summary>
     public bool SortByBatchKey
     {
@@ -69,7 +69,6 @@ public class PerformanceViewModel : INotifyPropertyChanged
                 ? BatchKeyGroupedOrderer.Instance
                 : HierarchicalOrderer.Instance;
 
-            SystemManagers.Default?.InvalidateSurface();
             RaiseAllChanged();
         }
     }

--- a/Gum/PerformanceMeasurementPlugin/ViewModels/PerformanceViewModel.cs
+++ b/Gum/PerformanceMeasurementPlugin/ViewModels/PerformanceViewModel.cs
@@ -1,52 +1,53 @@
-﻿using RenderingLibrary;
+using RenderingLibrary;
+using RenderingLibrary.Graphics;
 using System;
-using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows.Threading;
 
 namespace PerformanceMeasurementPlugin.ViewModels;
 
+/// <summary>
+/// Surfaces the editor's per-frame render-state-change counts so the cost of different
+/// visuals can be compared (notably SpriteBatch-backed vs Apos.Shapes-backed). Polls the
+/// active <see cref="Renderer"/> on a timer and raises change notifications for the bound view.
+/// </summary>
 public class PerformanceViewModel : INotifyPropertyChanged
 {
     DispatcherTimer mTimer;
 
-    public int DrawCallCount
-    {
-        get
-        {
-            if (ISystemManagers.Default != null)
-            {
-                // to do: need to replace this with proper calls
-                return -1;
-            }
-            else
-            {
-                return 0;
-            }
-        }
-    }
+    /// <summary>
+    /// SpriteBatch begins in the last frame — one per render-state change (texture/clip/blend/
+    /// transform). Sourced from <see cref="SpriteRenderer.LastFrameDrawStates"/>.
+    /// </summary>
+    public int SpriteBatchBeginCount => Renderer?.SpriteRenderer?.LastFrameDrawStates.Count() ?? 0;
 
-    public event PropertyChangedEventHandler PropertyChanged;
+    /// <summary>
+    /// Apos.Shapes ShapeBatch begins in the last frame. These live on a separate GPU command
+    /// stream from the SpriteBatch, so each one is an extra batch flush that shape-backed
+    /// visuals add over SpriteBatch-only visuals.
+    /// </summary>
+    public int ShapeBatchBeginCount => Renderer?.RenderStateChangeStatistics?.ShapeBatchBeginCount ?? 0;
+
+    /// <summary>The combined batch begins across both command streams in the last frame.</summary>
+    public int TotalRenderStateChanges => SpriteBatchBeginCount + ShapeBatchBeginCount;
+
+    private static Renderer? Renderer => SystemManagers.Default?.Renderer;
+
+    public event PropertyChangedEventHandler? PropertyChanged;
 
     public PerformanceViewModel()
     {
         mTimer = new DispatcherTimer();
         mTimer.Tick += HandleTick;
-        mTimer.Interval = TimeSpan.FromSeconds(1);
+        mTimer.Interval = TimeSpan.FromMilliseconds(500);
 
         mTimer.Start();
     }
 
     private void HandleTick(object? sender, EventArgs e)
     {
-        if(PropertyChanged != null)
-        {
-            PropertyChanged(this, new PropertyChangedEventArgs("DrawCallCount"));
-        }
+        // Null property name asks WPF to re-read every bound property on this VM.
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(null));
     }
-
-
 }

--- a/Gum/PerformanceMeasurementPlugin/ViewModels/PerformanceViewModel.cs
+++ b/Gum/PerformanceMeasurementPlugin/ViewModels/PerformanceViewModel.cs
@@ -11,6 +11,7 @@ namespace PerformanceMeasurementPlugin.ViewModels;
 /// Surfaces the editor's per-frame render-state-change counts so the cost of different
 /// visuals can be compared (notably SpriteBatch-backed vs Apos.Shapes-backed). Polls the
 /// active <see cref="Renderer"/> on a timer and raises change notifications for the bound view.
+/// Also exposes the global sibling-ordering mode so it can be toggled live.
 /// </summary>
 public class PerformanceViewModel : INotifyPropertyChanged
 {
@@ -20,19 +21,60 @@ public class PerformanceViewModel : INotifyPropertyChanged
     /// SpriteBatch begins in the last frame — one per render-state change (texture/clip/blend/
     /// transform). Sourced from <see cref="SpriteRenderer.LastFrameDrawStates"/>.
     /// </summary>
-    public int SpriteBatchBeginCount => Renderer?.SpriteRenderer?.LastFrameDrawStates.Count() ?? 0;
+    public int SpriteBatchBeginCount => ActiveRenderer?.SpriteRenderer?.LastFrameDrawStates.Count() ?? 0;
 
     /// <summary>
     /// Apos.Shapes ShapeBatch begins in the last frame. These live on a separate GPU command
     /// stream from the SpriteBatch, so each one is an extra batch flush that shape-backed
     /// visuals add over SpriteBatch-only visuals.
     /// </summary>
-    public int ShapeBatchBeginCount => Renderer?.RenderStateChangeStatistics?.ShapeBatchBeginCount ?? 0;
+    public int ShapeBatchBeginCount => ActiveRenderer?.RenderStateChangeStatistics?.ShapeBatchBeginCount ?? 0;
 
     /// <summary>The combined batch begins across both command streams in the last frame.</summary>
     public int TotalRenderStateChanges => SpriteBatchBeginCount + ShapeBatchBeginCount;
 
-    private static Renderer? Renderer => SystemManagers.Default?.Renderer;
+    /// <summary>
+    /// True when the renderer walks siblings depth-first (the legacy
+    /// <see cref="HierarchicalOrderer"/>). Mutually exclusive with <see cref="SortByBatchKey"/>.
+    /// </summary>
+    public bool RenderDepthFirst
+    {
+        get => !SortByBatchKey;
+        set
+        {
+            if (value)
+            {
+                SortByBatchKey = false;
+            }
+        }
+    }
+
+    /// <summary>
+    /// True when the renderer regroups same-BatchKey draws into contiguous runs
+    /// (<see cref="BatchKeyGroupedOrderer"/>), reducing batch flushes at the cost of a reorder
+    /// pass. Setting this swaps the global <see cref="Renderer.SiblingOrdering"/> and forces a
+    /// redraw so the effect (and the begin counts above) update immediately.
+    /// </summary>
+    public bool SortByBatchKey
+    {
+        get => ReferenceEquals(Renderer.SiblingOrdering, BatchKeyGroupedOrderer.Instance);
+        set
+        {
+            if (value == SortByBatchKey)
+            {
+                return;
+            }
+
+            Renderer.SiblingOrdering = value
+                ? BatchKeyGroupedOrderer.Instance
+                : HierarchicalOrderer.Instance;
+
+            SystemManagers.Default?.InvalidateSurface();
+            RaiseAllChanged();
+        }
+    }
+
+    private static Renderer? ActiveRenderer => SystemManagers.Default?.Renderer;
 
     public event PropertyChangedEventHandler? PropertyChanged;
 
@@ -46,6 +88,11 @@ public class PerformanceViewModel : INotifyPropertyChanged
     }
 
     private void HandleTick(object? sender, EventArgs e)
+    {
+        RaiseAllChanged();
+    }
+
+    private void RaiseAllChanged()
     {
         // Null property name asks WPF to re-read every bound property on this VM.
         PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(null));

--- a/Gum/PerformanceMeasurementPlugin/Views/PerformanceView.xaml
+++ b/Gum/PerformanceMeasurementPlugin/Views/PerformanceView.xaml
@@ -1,24 +1,32 @@
-﻿<UserControl
+<UserControl
     x:Class="PerformanceMeasurementPlugin.Views.PerformanceView"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    d:DesignHeight="300"
+    d:DesignHeight="120"
     d:DesignWidth="300"
     mc:Ignorable="d">
-    <Grid>
+    <Grid Margin="4">
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="Auto" />
-            <ColumnDefinition />
+            <ColumnDefinition Width="*" />
         </Grid.ColumnDefinitions>
 
         <Grid.RowDefinitions>
-            <RowDefinition />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
 
-        <Label Grid.Column="0">Draw calls:</Label>
-        <Label Grid.Column="1" Content="{Binding DrawCallCount}" />
+        <Label Grid.Row="0" Grid.Column="0">SpriteBatch begins:</Label>
+        <Label Grid.Row="0" Grid.Column="1" Content="{Binding SpriteBatchBeginCount}" />
+
+        <Label Grid.Row="1" Grid.Column="0">Apos.Shapes begins:</Label>
+        <Label Grid.Row="1" Grid.Column="1" Content="{Binding ShapeBatchBeginCount}" />
+
+        <Label Grid.Row="2" Grid.Column="0" FontWeight="Bold">Total render-state changes:</Label>
+        <Label Grid.Row="2" Grid.Column="1" FontWeight="Bold" Content="{Binding TotalRenderStateChanges}" />
 
     </Grid>
 </UserControl>

--- a/Gum/PerformanceMeasurementPlugin/Views/PerformanceView.xaml
+++ b/Gum/PerformanceMeasurementPlugin/Views/PerformanceView.xaml
@@ -4,29 +4,45 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    d:DesignHeight="120"
+    d:DesignHeight="200"
     d:DesignWidth="300"
     mc:Ignorable="d">
-    <Grid Margin="4">
-        <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="Auto" />
-            <ColumnDefinition Width="*" />
-        </Grid.ColumnDefinitions>
+    <StackPanel Margin="4">
+        <Grid>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
 
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
-        </Grid.RowDefinitions>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
 
-        <Label Grid.Row="0" Grid.Column="0">SpriteBatch begins:</Label>
-        <Label Grid.Row="0" Grid.Column="1" Content="{Binding SpriteBatchBeginCount}" />
+            <Label Grid.Row="0" Grid.Column="0">SpriteBatch begins:</Label>
+            <Label Grid.Row="0" Grid.Column="1" Content="{Binding SpriteBatchBeginCount}" />
 
-        <Label Grid.Row="1" Grid.Column="0">Apos.Shapes begins:</Label>
-        <Label Grid.Row="1" Grid.Column="1" Content="{Binding ShapeBatchBeginCount}" />
+            <Label Grid.Row="1" Grid.Column="0">Apos.Shapes begins:</Label>
+            <Label Grid.Row="1" Grid.Column="1" Content="{Binding ShapeBatchBeginCount}" />
 
-        <Label Grid.Row="2" Grid.Column="0" FontWeight="Bold">Total render-state changes:</Label>
-        <Label Grid.Row="2" Grid.Column="1" FontWeight="Bold" Content="{Binding TotalRenderStateChanges}" />
+            <Label Grid.Row="2" Grid.Column="0" FontWeight="Bold">Total render-state changes:</Label>
+            <Label Grid.Row="2" Grid.Column="1" FontWeight="Bold" Content="{Binding TotalRenderStateChanges}" />
+        </Grid>
 
-    </Grid>
+        <Separator Margin="0,6" />
+
+        <Label FontWeight="Bold">Sibling render order:</Label>
+        <RadioButton
+            Margin="8,2,0,2"
+            Content="Depth-first (hierarchical)"
+            GroupName="RenderOrder"
+            IsChecked="{Binding RenderDepthFirst, Mode=TwoWay}" />
+        <RadioButton
+            Margin="8,2,0,2"
+            Content="Sort by batch"
+            GroupName="RenderOrder"
+            IsChecked="{Binding SortByBatchKey, Mode=TwoWay}" />
+
+    </StackPanel>
 </UserControl>

--- a/Gum/PerformanceMeasurementPlugin/Views/PerformanceView.xaml
+++ b/Gum/PerformanceMeasurementPlugin/Views/PerformanceView.xaml
@@ -8,6 +8,20 @@
     d:DesignWidth="300"
     mc:Ignorable="d">
     <StackPanel Margin="4">
+        <Label FontWeight="Bold">Sibling render order:</Label>
+        <RadioButton
+            Margin="8,2,0,2"
+            Content="Depth-first (hierarchical)"
+            GroupName="RenderOrder"
+            IsChecked="{Binding RenderDepthFirst, Mode=TwoWay}" />
+        <RadioButton
+            Margin="8,2,0,2"
+            Content="Sort by batch"
+            GroupName="RenderOrder"
+            IsChecked="{Binding SortByBatchKey, Mode=TwoWay}" />
+
+        <Separator Margin="0,6" />
+
         <Grid>
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="Auto" />
@@ -29,20 +43,6 @@
             <Label Grid.Row="2" Grid.Column="0" FontWeight="Bold">Total render-state changes:</Label>
             <Label Grid.Row="2" Grid.Column="1" FontWeight="Bold" Content="{Binding TotalRenderStateChanges}" />
         </Grid>
-
-        <Separator Margin="0,6" />
-
-        <Label FontWeight="Bold">Sibling render order:</Label>
-        <RadioButton
-            Margin="8,2,0,2"
-            Content="Depth-first (hierarchical)"
-            GroupName="RenderOrder"
-            IsChecked="{Binding RenderDepthFirst, Mode=TwoWay}" />
-        <RadioButton
-            Margin="8,2,0,2"
-            Content="Sort by batch"
-            GroupName="RenderOrder"
-            IsChecked="{Binding SortByBatchKey, Mode=TwoWay}" />
 
     </StackPanel>
 </UserControl>

--- a/GumCoreShared.projitems
+++ b/GumCoreShared.projitems
@@ -123,6 +123,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)RenderingLibrary\Graphics\NineSlice.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RenderingLibrary\Graphics\NineSliceExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RenderingLibrary\Graphics\Renderer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)RenderingLibrary\Graphics\RenderStateChangeStatistics.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RenderingLibrary\Graphics\RenderTargetService.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RenderingLibrary\Graphics\RendererSettings.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RenderingLibrary\Graphics\SortableLayer.cs" />

--- a/MonoGameGum.Tests/RenderingLibraries/RenderStateChangeStatisticsTests.cs
+++ b/MonoGameGum.Tests/RenderingLibraries/RenderStateChangeStatisticsTests.cs
@@ -1,0 +1,45 @@
+using RenderingLibrary.Graphics;
+using Shouldly;
+using Xunit;
+
+namespace MonoGameGum.Tests.RenderingLibraries;
+
+/// <summary>
+/// Unit tests for <see cref="RenderStateChangeStatistics"/> — the per-frame counter of
+/// ShapeBatch (Apos.Shapes) begins. Device-free: the counter is a plain accumulator, so the
+/// increment/reset contract can be pinned without a MonoGame device. The wiring that drives
+/// it (ShapeRenderer recording begins, Renderer.Draw resetting each frame) is covered
+/// elsewhere.
+/// </summary>
+public class RenderStateChangeStatisticsTests : BaseTestClass
+{
+    [Fact]
+    public void RecordShapeBatchBegin_Twice_CountIsTwo()
+    {
+        RenderStateChangeStatistics statistics = new();
+
+        statistics.RecordShapeBatchBegin();
+        statistics.RecordShapeBatchBegin();
+
+        statistics.ShapeBatchBeginCount.ShouldBe(2);
+    }
+
+    [Fact]
+    public void Reset_AfterRecording_ZeroesCount()
+    {
+        RenderStateChangeStatistics statistics = new();
+        statistics.RecordShapeBatchBegin();
+
+        statistics.Reset();
+
+        statistics.ShapeBatchBeginCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public void ShapeBatchBeginCount_OnNewInstance_IsZero()
+    {
+        RenderStateChangeStatistics statistics = new();
+
+        statistics.ShapeBatchBeginCount.ShouldBe(0);
+    }
+}

--- a/MonoGameGum/FnaGum/FnaGum.csproj
+++ b/MonoGameGum/FnaGum/FnaGum.csproj
@@ -68,6 +68,7 @@
 		<Compile Include="..\..\RenderingLibrary\Graphics\HierarchicalOrderer.cs" Link="RenderingLibrary\HierarchicalOrderer.cs" />
 		<Compile Include="..\..\RenderingLibrary\Graphics\IRenderableOrderer.cs" Link="RenderingLibrary\IRenderableOrderer.cs" />
 		<Compile Include="..\..\RenderingLibrary\Graphics\Renderer.cs" Link="RenderingLibrary\Renderer.cs" />
+		<Compile Include="..\..\RenderingLibrary\Graphics\RenderStateChangeStatistics.cs" Link="RenderingLibrary\RenderStateChangeStatistics.cs" />
 		<Compile Include="..\..\RenderingLibrary\Graphics\RenderTargetService.cs" Link="RenderingLibrary\RenderTargetService.cs" />
 		<Compile Include="..\..\RenderingLibrary\Graphics\Sprite.cs" Link="Renderables\Sprite.cs" />
 		<Compile Include="..\..\RenderingLibrary\Graphics\SpriteBatchRenderableBase.cs" Link="Renderables\SpriteBatchRenderableBase.cs" />

--- a/MonoGameGum/KniGum/KniGum.csproj
+++ b/MonoGameGum/KniGum/KniGum.csproj
@@ -95,6 +95,7 @@
 		<Compile Include="..\..\RenderingLibrary\Graphics\HierarchicalOrderer.cs" Link="RenderingLibrary\HierarchicalOrderer.cs" />
 		<Compile Include="..\..\RenderingLibrary\Graphics\IRenderableOrderer.cs" Link="RenderingLibrary\IRenderableOrderer.cs" />
 		<Compile Include="..\..\RenderingLibrary\Graphics\Renderer.cs" Link="RenderingLibrary\Renderer.cs" />
+		<Compile Include="..\..\RenderingLibrary\Graphics\RenderStateChangeStatistics.cs" Link="RenderingLibrary\RenderStateChangeStatistics.cs" />
 		<Compile Include="..\..\RenderingLibrary\Graphics\RenderTargetService.cs" Link="RenderingLibrary\RenderTargetService.cs" />
 		<Compile Include="..\..\RenderingLibrary\Graphics\Sprite.cs" Link="Renderables\Sprite.cs" />
 		<Compile Include="..\..\RenderingLibrary\Graphics\SpriteBatchRenderableBase.cs" Link="RenderingLibrary\SpriteBatchRenderableBase.cs" />

--- a/MonoGameGum/MonoGameGum.csproj
+++ b/MonoGameGum/MonoGameGum.csproj
@@ -211,6 +211,7 @@
 		<Compile Include="..\RenderingLibrary\Graphics\HierarchicalOrderer.cs" Link="RenderingLibrary\HierarchicalOrderer.cs" />
 		<Compile Include="..\RenderingLibrary\Graphics\IRenderableOrderer.cs" Link="RenderingLibrary\IRenderableOrderer.cs" />
 		<Compile Include="..\RenderingLibrary\Graphics\Renderer.cs" Link="RenderingLibrary\Renderer.cs" />
+		<Compile Include="..\RenderingLibrary\Graphics\RenderStateChangeStatistics.cs" Link="RenderingLibrary\RenderStateChangeStatistics.cs" />
 		<Compile Include="..\RenderingLibrary\Graphics\RenderTargetService.cs" Link="RenderingLibrary\RenderTargetService.cs" />
 		<Compile Include="..\RenderingLibrary\Graphics\Sprite.cs" Link="Renderables\Sprite.cs" />
 		<Compile Include="..\RenderingLibrary\Graphics\SpriteBatchRenderableBase.cs" Link="Renderables\SpriteBatchRenderableBase.cs" />

--- a/RenderingLibrary/Graphics/RenderStateChangeStatistics.cs
+++ b/RenderingLibrary/Graphics/RenderStateChangeStatistics.cs
@@ -1,0 +1,40 @@
+namespace RenderingLibrary.Graphics
+{
+    /// <summary>
+    /// Per-frame counters for render-state changes that the existing
+    /// <see cref="SpriteRenderer.LastFrameDrawStates"/> does not capture — specifically the
+    /// Apos.Shapes <c>ShapeBatch</c> begins, which live on a separate GPU command stream from
+    /// the SpriteBatch. Used to measure how much shape rendering adds to a frame (e.g. comparing
+    /// SpriteBatch-backed visuals against Apos.Shapes-backed ones).
+    /// <para>
+    /// Owned by <see cref="Renderer"/> and reset at the start of each <see cref="Renderer.Draw(SystemManagers)"/>,
+    /// so after a frame the counts describe just-completed frame, mirroring
+    /// <see cref="SpriteRenderer.LastFrameDrawStates"/>.
+    /// </para>
+    /// </summary>
+    public class RenderStateChangeStatistics
+    {
+        /// <summary>
+        /// The number of Apos.Shapes <c>ShapeBatch.Begin</c> calls recorded since the last
+        /// <see cref="Reset"/>. Each begin is a GPU state change that flushes the previous batch.
+        /// </summary>
+        public int ShapeBatchBeginCount { get; private set; }
+
+        /// <summary>
+        /// Records one ShapeBatch begin. Called from the Apos.Shapes runtime whenever it opens
+        /// (or re-opens) its ShapeBatch.
+        /// </summary>
+        public void RecordShapeBatchBegin()
+        {
+            ShapeBatchBeginCount++;
+        }
+
+        /// <summary>
+        /// Clears all counters. Called once per frame at the start of <see cref="Renderer.Draw(SystemManagers)"/>.
+        /// </summary>
+        public void Reset()
+        {
+            ShapeBatchBeginCount = 0;
+        }
+    }
+}

--- a/RenderingLibrary/Graphics/Renderer.cs
+++ b/RenderingLibrary/Graphics/Renderer.cs
@@ -205,6 +205,13 @@ public class Renderer : IRenderer
     }
 
     /// <summary>
+    /// Per-frame counters for render-state changes that <see cref="SpriteRenderer.LastFrameDrawStates"/>
+    /// does not capture — currently the Apos.Shapes <c>ShapeBatch</c> begins, which live on a
+    /// separate GPU command stream. Reset at the start of each <see cref="Draw(SystemManagers)"/>.
+    /// </summary>
+    public RenderStateChangeStatistics RenderStateChangeStatistics { get; private set; }
+
+    /// <summary>
     /// Controls which XNA BlendState is used for the Rendering Library's Blend.Normal value.
     /// </summary>
     /// <remarks>
@@ -270,6 +277,7 @@ public class Renderer : IRenderer
         _layers = new List<Layer>();
         _layersReadOnly = new ReadOnlyCollection<Layer>(_layers);
         mCamera = new RenderingLibrary.Camera();
+        RenderStateChangeStatistics = new RenderStateChangeStatistics();
 
     }
 
@@ -1082,6 +1090,7 @@ public class Renderer : IRenderer
     public void ClearPerformanceRecordingVariables()
     {
         spriteRenderer.ClearPerformanceRecordingVariables();
+        RenderStateChangeStatistics.Reset();
     }
 
     /// <summary>

--- a/Runtimes/GumShapes/Renderables/RenderableShapeBase.cs
+++ b/Runtimes/GumShapes/Renderables/RenderableShapeBase.cs
@@ -877,7 +877,7 @@ public abstract class RenderableShapeBase : RenderableBase, Gum.GueDeriving.IBle
         // SpriteBatchStack re-Begins SpriteBatch on a blend/scissor change while keeping one
         // logical batch. GetEffectiveXnaBlendState returns null for Normal, so Begin keeps its
         // AlphaBlend default (the historical behavior).
-        ShapeRenderer.BeginBatch(view, rasterizerState, this);
+        ShapeRenderer.BeginBatch(view, rasterizerState, this, managers?.Renderer?.RenderStateChangeStatistics);
     }
 
     public override void EndBatch(ISystemManagers systemManagers)

--- a/Runtimes/GumShapes/Renderables/ShapeRenderer.cs
+++ b/Runtimes/GumShapes/Renderables/ShapeRenderer.cs
@@ -2,6 +2,7 @@
 using Microsoft.Xna.Framework.Content;
 using Microsoft.Xna.Framework.Graphics;
 using MonoGameGum;
+using RenderingLibrary.Graphics;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -34,6 +35,11 @@ public class ShapeRenderer
     Gum.RenderingLibrary.Blend _currentBlend;
     bool _isBatchBegun;
 
+    // Per-frame ShapeBatch begin counter, owned by the active Renderer and reset each frame.
+    // Captured in BeginBatch so EnsureBlend's mid-run re-begins are counted too. Null when the
+    // batch was opened without a Renderer in scope (e.g. unit tests), making the records no-ops.
+    RenderStateChangeStatistics? _statistics;
+
     public ShapeBatch ShapeBatch
     {
         get
@@ -47,12 +53,14 @@ public class ShapeRenderer
     /// the begin parameters so a later <see cref="EnsureBlend"/> can re-open with a different
     /// blend mid-run. Called by the batch owner from <c>RenderableShapeBase.StartBatch</c>.
     /// </summary>
-    public void BeginBatch(Microsoft.Xna.Framework.Matrix? view, RasterizerState? rasterizerState, RenderableShapeBase shape)
+    public void BeginBatch(Microsoft.Xna.Framework.Matrix? view, RasterizerState? rasterizerState, RenderableShapeBase shape, RenderStateChangeStatistics? statistics)
     {
         _currentView = view;
         _currentRasterizerState = rasterizerState;
         _currentBlend = shape.Blend;
         _isBatchBegun = true;
+        _statistics = statistics;
+        _statistics?.RecordShapeBatchBegin();
         _sb.Begin(view: view, blendState: shape.GetEffectiveXnaBlendState(), rasterizerState: rasterizerState);
     }
 
@@ -72,6 +80,7 @@ public class ShapeRenderer
         }
         _sb.End();
         _currentBlend = shape.Blend;
+        _statistics?.RecordShapeBatchBegin();
         _sb.Begin(view: _currentView, blendState: shape.GetEffectiveXnaBlendState(), rasterizerState: _currentRasterizerState);
     }
 

--- a/Runtimes/RaylibGum/RaylibGum.csproj
+++ b/Runtimes/RaylibGum/RaylibGum.csproj
@@ -153,6 +153,7 @@
 		<Compile Include="..\..\MonoGameGum\Input\Cursor.Forms.cs" Link="Input\Cursor.Forms.cs" />
 		<Compile Include="..\..\MonoGameGum\Input\CursorExtensions.cs" Link="Input\CursorExtensions.cs" />
 		<Compile Include="..\..\MonoGameGum\Renderables\RenderableCreator.cs" Link="Renderables\RenderableCreator.cs" />
+		<Compile Include="..\..\RenderingLibrary\Graphics\RenderStateChangeStatistics.cs" Link="RenderingLibrary\RenderStateChangeStatistics.cs" />
 		<Compile Include="..\..\RenderingLibrary\Graphics\RenderTargetService.cs" Link="RenderingLibrary\RenderTargetService.cs" />
 		<Compile Include="..\..\RenderingLibrary\Graphics\TextExtensions.cs" Link="Renderables\TextExtensions.cs" />
 		<Compile Include="..\..\MonoGameGum\Forms\DefaultFromFileVisuals\*.cs" Link="Forms\DefaultFromFileVisuals\%(Filename)%(Extension)" />

--- a/Tests/MonoGameGum.IntegrationTests/MonoGameGum/Rendering/RenderStateChangeStatisticsResetTests.cs
+++ b/Tests/MonoGameGum.IntegrationTests/MonoGameGum/Rendering/RenderStateChangeStatisticsResetTests.cs
@@ -1,0 +1,69 @@
+using Microsoft.Xna.Framework;
+using RenderingLibrary;
+using RenderingLibrary.Content;
+using RenderingLibrary.Graphics;
+using Shouldly;
+using Xunit;
+
+namespace MonoGameGum.IntegrationTests.MonoGameGum.Rendering;
+
+/// <summary>
+/// Pins that <see cref="Renderer.Draw(SystemManagers)"/> clears
+/// <see cref="Renderer.RenderStateChangeStatistics"/> at the start of every frame, so the
+/// ShapeBatch begin count describes the just-completed frame rather than accumulating across
+/// frames — mirroring how <c>SpriteRenderer.LastFrameDrawStates</c> is reset in the same method.
+/// </summary>
+public class RenderStateChangeStatisticsResetTests : BaseTestClass
+{
+    [Fact]
+    public void Draw_ResetsShapeBatchBeginCount()
+    {
+        using MinimalGame game = new();
+        game.RunOneFrame();
+
+        Renderer renderer = SystemManagers.Default.Renderer;
+        renderer.RenderStateChangeStatistics.RecordShapeBatchBegin();
+        renderer.RenderStateChangeStatistics.ShapeBatchBeginCount.ShouldBe(1);
+
+        renderer.Draw(SystemManagers.Default);
+
+        renderer.RenderStateChangeStatistics.ShapeBatchBeginCount.ShouldBe(0);
+    }
+
+    /// <summary>
+    /// Minimal Game host that initializes a fresh <see cref="GumService"/> per test.
+    /// We don't draw real content — we just need a live <see cref="SystemManagers.Default"/>
+    /// whose <see cref="Renderer.Draw(SystemManagers)"/> can be invoked.
+    /// </summary>
+    private class MinimalGame : Game
+    {
+        private readonly GraphicsDeviceManager _graphics;
+        public GumService GumService { get; }
+
+        public MinimalGame()
+        {
+            LoaderManager.Self?.DisposeAndClear();
+            _graphics = new GraphicsDeviceManager(this);
+            GumService = new GumService();
+        }
+
+        protected override void Initialize()
+        {
+            base.Initialize();
+            GumService.Initialize(this, Gum.Forms.DefaultVisualsVersion.V2);
+        }
+
+        protected override void Update(GameTime gameTime) { }
+        protected override void Draw(GameTime gameTime) => GraphicsDevice.Clear(Color.CornflowerBlue);
+
+        protected override void Dispose(bool disposing)
+        {
+            if (GumService.IsInitialized)
+            {
+                GumService.Uninitialize();
+            }
+            LoaderManager.Self?.DisposeAndClear();
+            base.Dispose(disposing);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Surfaces per-frame GPU batch-begin counts in the editor so the cost of Apos.Shapes-backed visuals can be measured against SpriteBatch-backed ones (e.g. `ColoredRectangle` vs `Rectangle`/shapes). This is a prerequisite diagnostic for the phase-2 Apos.Shapes default work.

### Background
`SpriteRenderer.LastFrameDrawStates` already counts every SpriteBatch render-state change per frame (reset in `Renderer.Draw`), but it only sees the **SpriteBatch** command stream. Apos.Shapes runs on a **separate `ShapeBatch` stream** that nothing counted. The `PerformanceMeasurementPlugin` existed but was a disabled stub (tab commented out, ViewModel returned `-1`).

### Changes
- **New `RenderStateChangeStatistics`** (`RenderingLibrary/Graphics`) — counts Apos.Shapes `ShapeBatch` begins. Owned by `Renderer`, reset each frame in `Draw` next to the existing SpriteBatch reset.
- **`ShapeRenderer`** records every `ShapeBatch.Begin` (`BeginBatch` + mid-run `EnsureBlend` re-begins), matching `LastFrameDrawStates`' every-begin semantics. The active `Renderer`'s statistics object is passed in from `RenderableShapeBase.StartBatch`.
- **`PerformanceMeasurementPlugin`** now shows SpriteBatch begins, Apos.Shapes begins, and the total; the tab is re-enabled. Added a `KniGum` project reference so the plugin can resolve the concrete `Renderer` (the post-build copies only the plugin dll, so no duplicate runtime assembly is shipped).
- New file registered in `GumCoreShared.projitems` and the four backend csprojs that compile `Renderer.cs` (MonoGameGum, KniGum, FnaGum, RaylibGum).

### Tests
- Unit: `RenderStateChangeStatisticsTests` (increment/reset, device-free).
- Integration: `RenderStateChangeStatisticsResetTests` (per-frame reset via `Renderer.Draw`).
- The `ShapeRenderer`→record delegation is device-bound (consistent with how `MonoGameGum.Shapes.Tests` excludes ShapeBatch draws from unit tests) and is verified by running the tool.
- All suites green: MonoGameGum.Tests 1574, Shapes 160, Integration 25. `GumFull.sln` builds clean.

## Test plan
- [ ] Open the **Performance** tab (bottom-right) in the tool.
- [ ] A form built with `ColoredRectangle` (SpriteBatch) keeps the Apos.Shapes count at 0.
- [ ] A form built with `Rectangle`/Apos shapes shows the Apos.Shapes count rising; total reflects both streams.

🤖 Generated with [Claude Code](https://claude.com/claude-code)