### PR TITLE
Preserve variable grid category colors in multi-select

### DIFF
--- a/WpfDataUi/DataUiGrid.cs
+++ b/WpfDataUi/DataUiGrid.cs
@@ -677,6 +677,7 @@ public class DataUiGrid : ItemsControl, INotifyPropertyChanged
                 {
                     currentCategory = new MemberCategory();
                     currentCategory.Name = category.Name;
+                    currentCategory.HeaderColor = category.HeaderColor;
                     effectiveCategory.Add(currentCategory);
                 }
 


### PR DESCRIPTION
## Summary
- `DataUiGrid.SetMultipleCategoryLists` merges per-instance category lists into combined `MemberCategory` objects when multiple instances are selected, but it only copied `Name` — leaving `HeaderColor` null, so multi-selected category headers rendered without their colors.
- Copy `HeaderColor` from the source category when creating the merged category, matching the single-select path (which gets its color from `CategorySortAndColorLogic`).

Closes #2953

## Test plan
- [ ] Select a single instance — category headers are colored.
- [ ] Multi-select two instances — category headers retain the same colors (previously went uncolored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)