### PR TITLE
#2954: Preserve multi-selection after toggling grid variables

### DIFF
--- a/Gum/Plugins/InternalPlugins/TreeView/ElementTreeViewManager.cs
+++ b/Gum/Plugins/InternalPlugins/TreeView/ElementTreeViewManager.cs
@@ -280,6 +280,13 @@ public partial class ElementTreeViewManager : IRecipient<ThemeChangedMessage>, I
     /// making reference-based searches fail.
     /// </summary>
     object? mRecordedSelectedContainer;
+
+    /// <summary>
+    /// The full set of selected instances captured at record time when more than one
+    /// instance is selected. Used to restore a multi-selection after a tree refresh so
+    /// it does not collapse to the single primary instance.
+    /// </summary>
+    List<InstanceSave> _recordedSelectedInstances;
     #endregion
 
     #region Properties
@@ -418,6 +425,7 @@ public partial class ElementTreeViewManager : IRecipient<ThemeChangedMessage>, I
         _projectState = Locator.GetRequiredService<IProjectState>();
         _standardElementsManagerGumTool = Locator.GetRequiredService<StandardElementsManagerGumTool>();
         _collapseToggleService = new CollapseToggleService();
+        _recordedSelectedInstances = new List<InstanceSave>();
         TreeNodeExtensionMethods.ElementTreeViewManager = this;
         AddCursor = GetAddCursor();
         _dragDropManager = Locator.GetRequiredService<IDragDropManager>();
@@ -1322,12 +1330,31 @@ public partial class ElementTreeViewManager : IRecipient<ThemeChangedMessage>, I
         mRecordedSelectedContainer = _selectedState.SelectedInstance != null
             ? (object?)_selectedState.SelectedBehavior ?? _selectedState.SelectedElement
             : null;
+
+        // Record the full multi-selection so a tree refresh can restore every selected
+        // instance rather than collapsing to the single primary one (issue #2954).
+        _recordedSelectedInstances = _selectedState.SelectedInstances.ToList();
     }
 
     public void SelectRecordedSelection()
     {
         try
         {
+            // Restore a multi-selection first so it isn't collapsed to the single
+            // primary instance after a tree refresh (issue #2954).
+            if (_recordedSelectedInstances.Count > 1)
+            {
+                List<TreeNode> nodes = GetReselectableNodes(
+                    _recordedSelectedInstances,
+                    instance => FindTreeNodeFor(instance, mRecordedSelectedContainer));
+
+                if (nodes.Count > 1)
+                {
+                    Select(nodes);
+                    return;
+                }
+            }
+
             if (mRecordedSelectedObject != null)
             {
                 var desiredNode = FindTreeNodeForRecordedObject();
@@ -1359,9 +1386,33 @@ public partial class ElementTreeViewManager : IRecipient<ThemeChangedMessage>, I
         }
     }
 
-    private TreeNode? FindTreeNodeForRecordedObject()
+    /// <summary>
+    /// Maps each recorded instance to its current tree node via <paramref name="nodeFinder"/>,
+    /// dropping instances that no longer have a node (e.g. deleted before the refresh) while
+    /// preserving order. Used to restore a multi-selection after a tree refresh.
+    /// </summary>
+    internal static List<TreeNode> GetReselectableNodes(
+        IReadOnlyList<InstanceSave> recordedInstances,
+        Func<InstanceSave, TreeNode?> nodeFinder)
     {
-        if (mRecordedSelectedObject is InstanceSave instanceSave)
+        List<TreeNode> nodes = new List<TreeNode>();
+        foreach (InstanceSave instance in recordedInstances)
+        {
+            TreeNode? node = nodeFinder(instance);
+            if (node != null)
+            {
+                nodes.Add(node);
+            }
+        }
+        return nodes;
+    }
+
+    private TreeNode? FindTreeNodeForRecordedObject() =>
+        FindTreeNodeFor(mRecordedSelectedObject, mRecordedSelectedContainer);
+
+    private TreeNode? FindTreeNodeFor(object? recordedObject, object? recordedContainer)
+    {
+        if (recordedObject is InstanceSave instanceSave)
         {
             var behavior = ObjectFinder.Self.GetBehaviorContainerOf(instanceSave);
             if (behavior != null)
@@ -1384,7 +1435,7 @@ public partial class ElementTreeViewManager : IRecipient<ThemeChangedMessage>, I
             // the reference is stale (undo/redo replaces instances with deep-cloned snapshots).
             // Fall back to name-based search using the container recorded before the refresh.
             if (!string.IsNullOrEmpty(instanceSave.Name) &&
-                mRecordedSelectedContainer is BehaviorSave recordedBehavior)
+                recordedContainer is BehaviorSave recordedBehavior)
             {
                 var behaviorNode = GetTreeNodeFor(recordedBehavior);
                 if (behaviorNode != null)
@@ -1393,11 +1444,11 @@ public partial class ElementTreeViewManager : IRecipient<ThemeChangedMessage>, I
 
             return null;
         }
-        else if (mRecordedSelectedObject is ElementSave elementSave)
+        else if (recordedObject is ElementSave elementSave)
         {
             return GetTreeNodeFor(elementSave);
         }
-        else if (mRecordedSelectedObject is BehaviorSave behaviorSave)
+        else if (recordedObject is BehaviorSave behaviorSave)
         {
             return GetTreeNodeFor(behaviorSave);
         }

--- a/Tool/Tests/GumToolUnitTests/Plugins/InternalPlugins/TreeView/ElementTreeViewManagerSelectionTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/InternalPlugins/TreeView/ElementTreeViewManagerSelectionTests.cs
@@ -1,0 +1,69 @@
+using CommonFormsAndControls;
+using Gum.DataTypes;
+using Gum.Managers;
+using Shouldly;
+using System;
+using System.Collections.Generic;
+using System.Windows.Forms;
+using Xunit;
+
+namespace GumToolUnitTests.Plugins.InternalPlugins.TreeView;
+
+public class ElementTreeViewManagerSelectionTests : BaseTestClass
+{
+    [Fact]
+    public void GetReselectableNodes_AllInstancesResolve_ReturnsAllInOrder()
+    {
+        // Issue #2954: a tree refresh (e.g. toggling HasDropshadow on a
+        // multi-selection) must re-select every previously-selected instance,
+        // not collapse to the first one.
+        InstanceSave first = new InstanceSave { Name = "First" };
+        InstanceSave second = new InstanceSave { Name = "Second" };
+        TreeNode firstNode = new TreeNode { Tag = first };
+        TreeNode secondNode = new TreeNode { Tag = second };
+
+        Dictionary<InstanceSave, TreeNode> lookup = new()
+        {
+            { first, firstNode },
+            { second, secondNode },
+        };
+
+        List<TreeNode> result = ElementTreeViewManager.GetReselectableNodes(
+            new List<InstanceSave> { first, second },
+            instance => lookup.TryGetValue(instance, out TreeNode? node) ? node : null);
+
+        result.ShouldBe(new[] { firstNode, secondNode });
+    }
+
+    [Fact]
+    public void GetReselectableNodes_SomeInstancesMissing_FiltersNullsPreservingOrder()
+    {
+        InstanceSave first = new InstanceSave { Name = "First" };
+        InstanceSave deleted = new InstanceSave { Name = "Deleted" };
+        InstanceSave third = new InstanceSave { Name = "Third" };
+        TreeNode firstNode = new TreeNode { Tag = first };
+        TreeNode thirdNode = new TreeNode { Tag = third };
+
+        Dictionary<InstanceSave, TreeNode> lookup = new()
+        {
+            { first, firstNode },
+            { third, thirdNode },
+        };
+
+        List<TreeNode> result = ElementTreeViewManager.GetReselectableNodes(
+            new List<InstanceSave> { first, deleted, third },
+            instance => lookup.TryGetValue(instance, out TreeNode? node) ? node : null);
+
+        result.ShouldBe(new[] { firstNode, thirdNode });
+    }
+
+    [Fact]
+    public void GetReselectableNodes_EmptyInput_ReturnsEmpty()
+    {
+        List<TreeNode> result = ElementTreeViewManager.GetReselectableNodes(
+            new List<InstanceSave>(),
+            _ => null);
+
+        result.ShouldBeEmpty();
+    }
+}


### PR DESCRIPTION
## Summary
- Multi-selecting two or more instances and toggling a variable that adds/removes dependent grid variables (e.g. `HasDropshadow` on Circles) collapsed the selection to the first instance.
- Such variables trigger a `FullGridRefresh`, which refreshes the element tree view. `RecordSelection`/`SelectRecordedSelection` (ElementTreeViewManager) recorded and restored only the single primary `SelectedInstance`.
- `RecordSelection` now captures the full `SelectedInstances` set; `SelectRecordedSelection` restores all of them via the existing `Select(List<TreeNode>)` overload when more than one instance was selected, falling back to the single-instance path otherwise.
- This is a central fix in the shared tree-refresh path, so it preserves multi-selection across **any** refresh trigger, not just `HasDropshadow`.

## Implementation notes
- Extracted a pure static helper `GetReselectableNodes(recordedInstances, nodeFinder)` that maps recorded instances to their current tree nodes, dropping any that no longer exist while preserving order. This is the unit-tested seam.
- `FindTreeNodeForRecordedObject()` was refactored into a parameterized `FindTreeNodeFor(recordedObject, recordedContainer)` so the per-instance node lookup can be reused for the multi-selection case.

## Test plan
- [x] New unit tests cover `GetReselectableNodes` (all resolve / some deleted / empty).
- [x] Full `GumToolUnitTests` suite passes (727 passed, 5 skipped).
- [x] Manual: multi-select 2+ Circles, toggle `HasDropshadow`, confirm all stay selected and subsequent edits apply to all.

Closes #2954

🤖 Generated with [Claude Code](https://claude.com/claude-code)