### PR TITLE
#2952: Hide misleading <NULL> placeholder for multi-select conflicts

### DIFF
--- a/WpfDataUi/Controls/AngleSelectorDisplay.xaml.cs
+++ b/WpfDataUi/Controls/AngleSelectorDisplay.xaml.cs
@@ -196,7 +196,19 @@ namespace WpfDataUi.Controls
         {
             TextBox.Text = mAngle?.ToString();
 
-            if (Angle == null)
+            RefreshPlaceholderText();
+        }
+
+        private void RefreshPlaceholderText()
+        {
+            if (InstanceMember?.IsIndeterminate == true)
+            {
+                // Multiple selected instances disagree on this value. The text box is
+                // intentionally blank, so showing "<NULL>" would misleadingly imply the
+                // value is unset. The indeterminate background color is the visual cue.
+                PlaceholderText.Visibility = Visibility.Collapsed;
+            }
+            else if (Angle == null)
             {
                 PlaceholderText.Visibility = Visibility.Visible;
                 PlaceholderText.Text = "<NULL>";
@@ -394,15 +406,7 @@ namespace WpfDataUi.Controls
                 toReturn = ApplyValueResult.Success;
             }
 
-            if(Angle == null)
-            {
-                PlaceholderText.Visibility = Visibility.Visible;
-                PlaceholderText.Text = "<NULL>";
-            }
-            else
-            {
-                PlaceholderText.Visibility = Visibility.Collapsed;
-            }
+            RefreshPlaceholderText();
 
             return toReturn;
         }

--- a/WpfDataUi/Controls/TextBoxDisplay.xaml.cs
+++ b/WpfDataUi/Controls/TextBoxDisplay.xaml.cs
@@ -254,7 +254,14 @@ namespace WpfDataUi.Controls
             else
             {
                 TryGetValueOnUi(out object? valueOnInstance);
-                if (valueOnInstance == null)
+                if (InstanceMember?.IsIndeterminate == true)
+                {
+                    // Multiple selected instances disagree on this value. The text box is
+                    // intentionally blank, so showing "<NULL>" would misleadingly imply the
+                    // value is unset. The indeterminate background color is the visual cue.
+                    PlaceholderText.Visibility = Visibility.Collapsed;
+                }
+                else if (valueOnInstance == null)
                 {
                     PlaceholderText.Visibility = Visibility.Visible;
                     PlaceholderText.Text = "<NULL>";


### PR DESCRIPTION
## Summary
- When a multi-select has conflicting values for a variable, text box editors left the field blank but displayed `<NULL>` as the placeholder/watermark — implying the value was unset/null rather than simply disagreeing across instances.
- Suppress the `<NULL>` placeholder when the `InstanceMember` is indeterminate (`MultiSelectInstanceMember.IsIndeterminate`). The distinct indeterminate background color already provides the visual cue.
- Applied the same fix to `AngleSelectorDisplay` (rotation/angle editors had the identical misleading behavior); consolidated its two duplicated placeholder blocks into a single `RefreshPlaceholderText` helper.

## Test plan
- [x] Select two instances with differing `StrokeWidth` (or any numeric text-box variable) → field is blank, no `<NULL>` watermark, indeterminate background shown.
- [x] Select two instances with the *same* value → value displays normally.
- [x] Single instance with a genuinely null/unset value → still shows `<NULL>` as before.
- [x] Repeat for an angle/rotation variable to confirm `AngleSelectorDisplay` behaves the same.

Closes #2952

🤖 Generated with [Claude Code](https://claude.com/claude-code)