### PR TITLE
#2949: Collapse DropshadowBlurX/Y into a single DropshadowBlur on Arc

### DIFF
--- a/Runtimes/SkiaGum/CustomSetPropertyOnRenderable.cs
+++ b/Runtimes/SkiaGum/CustomSetPropertyOnRenderable.cs
@@ -365,6 +365,22 @@ public class CustomSetPropertyOnRenderable
                     }
                     handled = true;
                     break;
+                // #2949: the single isotropic DropshadowBlur variable must land on the runtime so
+                // its DropshadowBlur setter fans out to both per-axis shims (which SkiaShapeRuntime
+                // then pushes to the renderable in PreRender). Writing straight to the renderable
+                // would be clobbered by that PreRender push.
+                case nameof(ArcRuntime.DropshadowBlur):
+                    if (graphicalUiElement is ArcRuntime arcDropshadowBlurRuntime)
+                    {
+                        arcDropshadowBlurRuntime.DropshadowBlur = (float)value;
+                    }
+                    else
+                    {
+                        asArc.DropshadowBlurX = (float)value;
+                        asArc.DropshadowBlurY = (float)value;
+                    }
+                    handled = true;
+                    break;
             }
             if (!handled)
             {

--- a/Runtimes/SkiaGum/GueDeriving/ArcRuntime.cs
+++ b/Runtimes/SkiaGum/GueDeriving/ArcRuntime.cs
@@ -344,6 +344,22 @@ public class ArcRuntime : GraphicalUiElement
     }
 
     /// <summary>
+    /// Isotropic blur radius in pixels for the dropshadow. Convenience wrapper that pushes a
+    /// single value to both <see cref="DropshadowBlurX"/> and <see cref="DropshadowBlurY"/>
+    /// (#2949), mirroring industry convention (CSS <c>box-shadow</c>, Figma, Photoshop) where
+    /// dropshadow blur is a single scalar. Reading returns the X axis.
+    /// </summary>
+    public float DropshadowBlur
+    {
+        get => DropshadowBlurX;
+        set
+        {
+            DropshadowBlurX = value;
+            DropshadowBlurY = value;
+        }
+    }
+
+    /// <summary>
     /// Initializes a new raylib <c>ArcRuntime</c>. Constructor defaults mirror the Skia/Apos
     /// branch so cross-backend sample code starts from the same baseline (Width = Height = 100,
     /// SweepAngle = 90, Thickness = 10, Color = White, dropshadow off but pre-seeded with a
@@ -537,6 +553,23 @@ public class ArcRuntime
     {
         get => ContainedArc.IsEndRounded;
         set => ContainedArc.IsEndRounded = value;
+    }
+
+    /// <summary>
+    /// Isotropic blur radius in pixels for the dropshadow. Convenience wrapper that pushes a
+    /// single value to both the inherited <see cref="SkiaShapeRuntime.DropshadowBlurX"/> and
+    /// <see cref="SkiaShapeRuntime.DropshadowBlurY"/> (#2949). Skia natively supports per-axis
+    /// blur, but the user-facing arc surface mirrors industry convention (CSS <c>box-shadow</c>,
+    /// Figma, Photoshop) where blur is a single scalar. Reading returns the X axis.
+    /// </summary>
+    public float DropshadowBlur
+    {
+        get => DropshadowBlurX;
+        set
+        {
+            DropshadowBlurX = value;
+            DropshadowBlurY = value;
+        }
     }
 
     /// <summary>

--- a/Tests/MonoGameGum.Shapes.Tests/ArcRuntimeTests.cs
+++ b/Tests/MonoGameGum.Shapes.Tests/ArcRuntimeTests.cs
@@ -35,6 +35,35 @@ public class ArcRuntimeTests
         shape.GetEffectiveXnaBlendState().ShouldBe(Microsoft.Xna.Framework.Graphics.BlendState.Additive);
     }
 
+    // #2949: ArcRuntime exposes a single isotropic DropshadowBlur (mirroring CSS box-shadow /
+    // Figma / Photoshop). Setting it writes both per-axis shims; reading returns the X axis.
+    [Fact]
+    public void DropshadowBlur_ShouldSetBothBlurXAndY()
+    {
+        ArcRuntime sut = new ArcRuntime();
+
+        sut.DropshadowBlur = 5;
+
+        sut.DropshadowBlurX.ShouldBe(5);
+        sut.DropshadowBlurY.ShouldBe(5);
+        sut.DropshadowBlur.ShouldBe(5);
+    }
+
+    // #2949: the single DropshadowBlur variable .gumx persists must route through
+    // CustomSetPropertyOnRenderable to both per-axis blur properties on the renderable. On Apos
+    // the runtime forwards straight to the renderable, so no PreRender is needed.
+    [Fact]
+    public void DropshadowBlur_ShouldRouteToRenderable_ThroughSetProperty()
+    {
+        ArcRuntime sut = new ArcRuntime();
+
+        sut.SetProperty("DropshadowBlur", 3f);
+
+        RenderableShapeBase shape = (RenderableShapeBase)sut.RenderableComponent;
+        shape.DropshadowBlurX.ShouldBe(3f);
+        shape.DropshadowBlurY.ShouldBe(3f);
+    }
+
     // Locked in unification (issue #2728): both backends default IsEndRounded to false
     // (matches Skia's prior behavior and graphics-convention flat caps). Existing Apos
     // consumers who relied on rounded caps must now set IsEndRounded = true explicitly.

--- a/Tests/SkiaGum.Tests/GueDeriving/ArcRuntimeTests.cs
+++ b/Tests/SkiaGum.Tests/GueDeriving/ArcRuntimeTests.cs
@@ -9,6 +9,20 @@ namespace SkiaGum.Tests.GueDeriving;
 
 public class ArcRuntimeTests
 {
+    // #2949: ArcRuntime exposes a single isotropic DropshadowBlur (mirroring CSS box-shadow /
+    // Figma / Photoshop). Setting it writes both per-axis shims; reading returns the X axis.
+    [Fact]
+    public void ArcRuntime_DropshadowBlur_ShouldSetBothBlurXAndY()
+    {
+        ArcRuntime arcRuntime = new();
+
+        arcRuntime.DropshadowBlur = 5;
+
+        arcRuntime.DropshadowBlurX.ShouldBe(5);
+        arcRuntime.DropshadowBlurY.ShouldBe(5);
+        arcRuntime.DropshadowBlur.ShouldBe(5);
+    }
+
     // Locked in unification (issue #2728): dropshadow defaults are seeded on both backends so
     // ctor state is consistent. Values are inert until HasDropshadow is set true. Apos seeded
     // these before unification; Skia did not.


### PR DESCRIPTION
## Summary

Closes #2949.

Most of this issue was already satisfied by the v3 shape-variable-expansion work: plain `CircleRuntime` / `RectangleRuntime` already expose a single isotropic `DropshadowBlur`, the tool's `AddDropshadowVariables` emits only `DropshadowBlur`, the templates are migrated, and `CustomSetPropertyOnRenderable` routes the unified name for Circle/Rectangle. **Arc was the remaining gap — and a latent break.**

The Arc standard element (`StandardElementsManager`) already seeds a single `DropshadowBlur` variable, but:
- `ArcRuntime` exposed only the per-axis `DropshadowBlurX` / `DropshadowBlurY` (no unified property), and
- the `SetProperty` string path had no Arc routing for `DropshadowBlur`.

So an Arc with a dropshadow configured in-tool never rendered its blur, and codegen referenced a property that didn't exist.

## Changes

- **`ArcRuntime`** (Skia/Apos and raylib `#if` branches): add a `DropshadowBlur` convenience property that fans a single value out to both per-axis shims; reading returns the X axis. Mirrors the established `CircleRuntime` / `RectangleRuntime` pattern. `DropshadowBlurX` / `DropshadowBlurY` are kept as backward-compat shims.
- **`CustomSetPropertyOnRenderable`** (SkiaGum copy, also compile-linked into MonoGameGumShapes / KniGumShapes): route the `DropshadowBlur` variable to the runtime so `SkiaShapeRuntime.PreRender` (`ApplyDropshadow`) pushes it to the renderable without clobbering a renderable-direct write.

## Migration

No active file-format migration (per discussion on the issue). Old Arc files keep their named `DropshadowBlurX`/`Y` variables which still round-trip through the runtime shims — the same accepted-orphan precedent as the v3 color rename. The issue explicitly permits dropping Arc dropshadow on migration.

## Tests

- `Tests/MonoGameGum.Shapes.Tests/ArcRuntimeTests.cs` — Apos: `DropshadowBlur` sets both axes; `SetProperty("DropshadowBlur", ...)` routes to the renderable.
- `Tests/SkiaGum.Tests/GueDeriving/ArcRuntimeTests.cs` — Skia: `DropshadowBlur` sets both axes.

## Test plan

- [x] New Arc tests fail before the change (compile error: no `DropshadowBlur`), pass after.
- [x] `MonoGameGum.Shapes.Tests` full suite: 162 passed.
- [x] `SkiaGum.Tests` full suite: 176 passed.
- [x] `RaylibGum` builds (raylib Arc branch compiles), no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)