### PR TITLE
#2979: Port Circle dropshadow geometry to the RoundedRectangle renderable

### DIFF
--- a/Runtimes/GumShapes/Renderables/RoundedRectangle.cs
+++ b/Runtimes/GumShapes/Renderables/RoundedRectangle.cs
@@ -58,6 +58,54 @@ public class RoundedRectangle : RenderableShapeBase,
     public float? CustomRadiusBottomRight { get; set; }
     public float? CustomRadiusBottomLeft { get; set; }
 
+    /// <summary>
+    /// Issue #2979 — dropshadow draw size, AA halo, and alpha scale for a rectangle of nominal
+    /// <paramref name="hostSize"/>, mirroring <see cref="Circle"/>'s split (#2950/#2977).
+    /// Apos.Shapes' <c>DrawRectangle</c> anchors the stroke at the outer edge (like
+    /// <c>DrawCircle</c>), so a naive <c>size -= blur</c> shadow pass marches the outline inward
+    /// as blur grows — a stroke-only rectangle visibly contracts.
+    /// <list type="bullet">
+    /// <item><description><b>Filled:</b> the disk strict-anchor (<see cref="RenderableShapeBase.ComputeShadowDrawGeometry"/>),
+    /// keyed off the smaller half-dimension so the same inset applies to both axes; the 50%
+    /// alpha line lands on the original edge. Beyond <c>blur &gt; min(Width,Height)</c> the helper
+    /// truncates the inner ramp (the smaller dimension collapses to 0) and returns an alpha
+    /// scale &lt; 1 so the center fades instead of inverting.</description></item>
+    /// <item><description><b>Stroke-only:</b> anchor the band centerline at the body stroke
+    /// centerline regardless of blur — each side pulls in <c>(StrokeWidth - effectiveShadowStrokeWidth)/2</c>,
+    /// so once blur exceeds the stroke width (effective shadow stroke clamped to a ~0 epsilon by
+    /// <see cref="RenderableShapeBase.ComputeStrokeShadowDrawParameters"/>) the box stops shrinking
+    /// at <c>hostSize - StrokeWidth</c> and only the AA halo (aaSize) keeps growing.</description></item>
+    /// </list>
+    /// </summary>
+    public (Vector2 size, int aaSize, float alphaScale) ComputeShadowDrawParameters(
+        Vector2 hostSize, float effectiveShadowStrokeWidth, float cameraZoom)
+    {
+        float insetPerSide;
+        int aaSize;
+        float alphaScale;
+
+        if (IsFilled)
+        {
+            float minHalf = System.Math.Min(hostSize.X, hostSize.Y) / 2f;
+            (float effectiveRadius, int effAaSize, float effAlphaScale) =
+                ComputeShadowDrawGeometry(minHalf, cameraZoom);
+            insetPerSide = minHalf - effectiveRadius;
+            aaSize = effAaSize;
+            alphaScale = effAlphaScale;
+        }
+        else
+        {
+            insetPerSide = (StrokeWidth - effectiveShadowStrokeWidth) / 2f;
+            aaSize = GetShadowAntiAliasSize(cameraZoom);
+            alphaScale = 1f;
+        }
+
+        Vector2 size = new(
+            System.Math.Max(0f, hostSize.X - 2f * insetPerSide),
+            System.Math.Max(0f, hostSize.Y - 2f * insetPerSide));
+        return (size, aaSize, alphaScale);
+    }
+
     public override void Render(ISystemManagers managers)
     {
         // Issue #2950 follow-up — see Circle.Render for the rationale on this gate.
@@ -79,23 +127,28 @@ public class RoundedRectangle : RenderableShapeBase,
 
         if(HasDropshadow)
         {
-            var shadowLeft = absoluteLeft + DropshadowOffsetX + DropshadowBlurX/2;
-            var shadowTop = absoluteTop + DropshadowOffsetY + DropshadowBlurY/2;
-
-            // Currently apos shapes doesn't support different sizes for anti-aliasing on X and Y
-            var dropshadowSize = size;
-            dropshadowSize.X -= DropshadowBlurX;
-            dropshadowSize.Y -= DropshadowBlurX;
-
             // Issue #2950 — when stroke <= blur on a stroke-only RoundedRectangle, fade the
             // shadow's starting alpha and clamp lineThickness positive so Apos still draws.
             (float shadowStrokeWidth, Color shadowColor) =
                 ComputeStrokeShadowDrawParameters(EffectiveDropshadowColor);
 
-            // Issue #2950 — keep blur world-anchored by scaling Apos's screen-pixel-space
-            // aaSize by camera zoom (see RenderableShapeBase.GetShadowAntiAliasSize).
+            // Issue #2979 — strict-anchor shadow geometry (filled disk anchor / stroke centerline
+            // anchor), mirroring Circle.Render. Replaces the old naive `size -= blur` that drove
+            // the outline inward as blur grew. aaSize is world-anchored (scaled by camera zoom).
             var cameraZoom = (managers as RenderingLibrary.SystemManagers)?.Renderer?.Camera?.Zoom ?? 1f;
-            int shadowAaSize = GetShadowAntiAliasSize(cameraZoom);
+            (Vector2 dropshadowSize, int shadowAaSize, float shadowAlphaScale) =
+                ComputeShadowDrawParameters(size, shadowStrokeWidth, cameraZoom);
+            if (shadowAlphaScale < 1f)
+            {
+                shadowColor = new Color(
+                    shadowColor.R, shadowColor.G, shadowColor.B,
+                    (byte)(shadowColor.A * shadowAlphaScale));
+            }
+
+            // Re-center the (shrunken) shadow box on the body so only the halo extends outward;
+            // the per-side inset equals (size - dropshadowSize)/2 in each axis.
+            var shadowLeft = absoluteLeft + DropshadowOffsetX + (size.X - dropshadowSize.X) / 2f;
+            var shadowTop = absoluteTop + DropshadowOffsetY + (size.Y - dropshadowSize.Y) / 2f;
 
             RenderInternal(sb, shadowLeft, shadowTop, dropshadowSize,
                 shadowAaSize,

--- a/Tests/MonoGameGum.Shapes.Tests/RoundedRectangleRenderableTests.cs
+++ b/Tests/MonoGameGum.Shapes.Tests/RoundedRectangleRenderableTests.cs
@@ -1,0 +1,128 @@
+using Microsoft.Xna.Framework;
+using MonoGameAndGum.Renderables;
+using Shouldly;
+
+namespace MonoGameGum.Shapes.Tests;
+
+// Issue #2979 — port Circle's #2950/#2977 dropshadow geometry to the RoundedRectangle renderable
+// (the core renderable that draws the v3 Rectangle: IsFilled=true → fill slot, false → stroke
+// slot). Apos.Shapes' DrawRectangle anchors the stroke at the OUTER edge (like DrawCircle), so
+// the old naive shadow pass (size -= blur) marched the outline inward as blur grew, making a
+// stroke-only Rectangle visibly "shrink." ComputeShadowDrawParameters mirrors Circle.Render's
+// split: filled rectangles use the disk strict-anchor (ComputeShadowDrawGeometry keyed off the
+// smaller half-dimension, with the negative clamp + alpha fade at extreme blur); stroke-only
+// rectangles anchor the band centerline at the body stroke centerline (only the AA halo grows).
+public class RoundedRectangleRenderableTests
+{
+    [Fact]
+    public void ComputeShadowDrawParameters_Filled_ZeroBlur_SizeUnchanged()
+    {
+        RoundedRectangle sut = new() { IsFilled = true, DropshadowBlurX = 0f };
+
+        (Vector2 size, int aaSize, float alphaScale) =
+            sut.ComputeShadowDrawParameters(new Vector2(100, 60), effectiveShadowStrokeWidth: 0f, cameraZoom: 1f);
+
+        size.X.ShouldBe(100f);
+        size.Y.ShouldBe(60f);
+        aaSize.ShouldBe(0);
+        alphaScale.ShouldBe(1f);
+    }
+
+    [Fact]
+    public void ComputeShadowDrawParameters_Filled_StandardBlur_ShrinksByBlurEachDimension()
+    {
+        // Standard case (blur <= 2 * minHalf): minHalf = 30, blur = 10 <= 60. Each side pulls in
+        // blur/2 so the 50% line lands on the original edge (CSS box-shadow), i.e. each dimension
+        // shrinks by the full blur. aaSize = blur.
+        RoundedRectangle sut = new() { IsFilled = true, DropshadowBlurX = 10f };
+
+        (Vector2 size, int aaSize, float alphaScale) =
+            sut.ComputeShadowDrawParameters(new Vector2(100, 60), effectiveShadowStrokeWidth: 0f, cameraZoom: 1f);
+
+        size.X.ShouldBe(90f);
+        size.Y.ShouldBe(50f);
+        aaSize.ShouldBe(10);
+        alphaScale.ShouldBe(1f);
+    }
+
+    [Fact]
+    public void ComputeShadowDrawParameters_Filled_ExtremeBlur_ClampsMinDimensionAndScalesAlpha()
+    {
+        // blur > 2 * minHalf: minHalf = 25 (Height 50), blur = 200 > 50. The disk anchor truncates
+        // the inner ramp (effRadius = 0 → inset = minHalf = 25), so the min dimension collapses to
+        // 0 and alpha scales below 1. The other dimension pulls in 2 * minHalf = 50.
+        RoundedRectangle sut = new() { IsFilled = true, DropshadowBlurX = 200f };
+
+        (Vector2 size, int aaSize, float alphaScale) =
+            sut.ComputeShadowDrawParameters(new Vector2(120, 50), effectiveShadowStrokeWidth: 0f, cameraZoom: 1f);
+
+        size.Y.ShouldBe(0f);
+        size.X.ShouldBe(70f);
+        alphaScale.ShouldBeLessThan(1f);
+        aaSize.ShouldBeGreaterThan(0);
+    }
+
+    [Fact]
+    public void ComputeShadowDrawParameters_StrokeOnly_BlurLessThanStroke_ShrinksByBlur()
+    {
+        // blur < StrokeWidth: effectiveShadowStrokeWidth = StrokeWidth - blur = 10 - 4 = 6. The
+        // band centerline must stay on the body centerline, so each side pulls in
+        // (StrokeWidth - effShStroke)/2 = blur/2 = 2 → each dimension shrinks by the blur (4).
+        RoundedRectangle sut = new() { IsFilled = false, StrokeWidth = 10f, DropshadowBlurX = 4f };
+
+        (Vector2 size, int aaSize, float alphaScale) =
+            sut.ComputeShadowDrawParameters(new Vector2(100, 60), effectiveShadowStrokeWidth: 6f, cameraZoom: 1f);
+
+        size.X.ShouldBe(96f);
+        size.Y.ShouldBe(56f);
+        aaSize.ShouldBe(4);
+        alphaScale.ShouldBe(1f);
+    }
+
+    [Fact]
+    public void ComputeShadowDrawParameters_StrokeOnly_LargeBlur_AnchorsAtStrokeCenterlineNotInward()
+    {
+        // This is the #2977 bug for rectangles. At blur >= StrokeWidth,
+        // ComputeStrokeShadowDrawParameters clamps the effective shadow stroke width to a ~0
+        // epsilon. The band centerline must stay anchored at the body stroke centerline, so the
+        // shadow box shrinks by StrokeWidth (NOT by the ever-growing blur). A naive size -= blur
+        // model would keep contracting; assert it does NOT.
+        RoundedRectangle sut = new() { IsFilled = false, StrokeWidth = 10f, DropshadowBlurX = 200f };
+
+        (Vector2 size, int aaSize, float _) =
+            sut.ComputeShadowDrawParameters(new Vector2(100, 60), effectiveShadowStrokeWidth: 0.01f, cameraZoom: 1f);
+
+        // Anchored: shrink by StrokeWidth (minus the epsilon band), independent of blur.
+        size.X.ShouldBe(100f - 10f + 0.01f, tolerance: 0.001f);
+        size.Y.ShouldBe(60f - 10f + 0.01f, tolerance: 0.001f);
+        // Halo grows with blur.
+        aaSize.ShouldBe(200);
+    }
+
+    [Fact]
+    public void ComputeShadowDrawParameters_AaSizeScalesByZoom()
+    {
+        RoundedRectangle sut = new() { IsFilled = true, DropshadowBlurX = 10f };
+
+        (Vector2 _, int aaSize, float _) =
+            sut.ComputeShadowDrawParameters(new Vector2(100, 60), effectiveShadowStrokeWidth: 0f, cameraZoom: 2f);
+
+        aaSize.ShouldBe(20);
+    }
+
+    [Fact]
+    public void ComputeShadowDrawParameters_NegativeBlur_TreatedAsZero()
+    {
+        // DropshadowBlurX clamps negatives to 0 at the setter (#2977), so a negative blur renders
+        // identically to 0: no shrink, no halo.
+        RoundedRectangle sut = new() { IsFilled = true, DropshadowBlurX = -50f };
+
+        (Vector2 size, int aaSize, float alphaScale) =
+            sut.ComputeShadowDrawParameters(new Vector2(100, 60), effectiveShadowStrokeWidth: 0f, cameraZoom: 1f);
+
+        size.X.ShouldBe(100f);
+        size.Y.ShouldBe(60f);
+        aaSize.ShouldBe(0);
+        alphaScale.ShouldBe(1f);
+    }
+}


### PR DESCRIPTION
## Summary

- Ports Circle's #2950/#2977 dropshadow geometry to the **`RoundedRectangle`** core renderable — the Apos.Shapes renderable that draws the v3 `Rectangle` (`IsFilled=true` → fill slot, `false` → stroke slot).
- Apos's `DrawRectangle` anchors the stroke at the **outer edge** (like `DrawCircle`), so the old `size -= blur` shadow pass marched a stroke-only rectangle's outline **inward** as blur grew, making the shape visibly contract — the same bug #2977 fixed for Circle.
- New testable `ComputeShadowDrawParameters` helper mirrors `Circle.Render`'s split:
  - **Filled:** disk strict-anchor (`ComputeShadowDrawGeometry`, keyed off the smaller half-dimension) so the 50% alpha line lands on the original edge; at extreme blur the inner ramp truncates and alpha fades instead of inverting.
  - **Stroke-only:** anchor the band centerline at the body stroke centerline; past the stroke width the box stops shrinking at `hostSize - StrokeWidth` and only the AA halo grows.
- Renderable-layer only — no runtime, tool, or data-model changes.

## Arc: investigated, no change needed

Arc was in the original scope but draws via `DrawRing`, which is **centerline-anchored** (not outer-edge). Arc already passes the body centerline radius unchanged to the shadow pass, so its shadow is a halo centered on the body ring and never had the shrink bug. Confirmed empirically in the `GumShapesGallery` with a large-blur (50px) stroke arc: the shadow is a symmetric halo over the gold arc, not a band contracting inside it.

## Test plan

- [x] `dotnet test Tests/MonoGameGum.Shapes.Tests` — 172 pass (7 new `RoundedRectangleRenderableTests`).
- [x] Built `MonoGameGumShapesGallery` and visually verified the Rectangle dropshadow row: stroke-only big-blur rectangle stays full-size (no inward dark band), moderate blur unchanged, no inversion/crash at extreme blur.
- [x] Visually verified the Arc dropshadow row (large blur) stays centerline-anchored.

Closes #2979