### PR TITLE
Collapse new-shape dropshadow blur to a scalar; deprecate per-axis on Arc

### DIFF
--- a/MonoGameGum/GueDeriving/CircleRuntime.cs
+++ b/MonoGameGum/GueDeriving/CircleRuntime.cs
@@ -1642,20 +1642,43 @@ public class CircleRuntime : GraphicalUiElement
     protected override RenderableShapeBase ContainedRenderable => ContainedLineCircle;
 
     /// <summary>
-    /// Isotropic blur radius in pixels for the dropshadow. Convenience wrapper that pushes a
-    /// single value to both the inherited <see cref="SkiaShapeRuntime.DropshadowBlurX"/> and
-    /// <see cref="SkiaShapeRuntime.DropshadowBlurY"/>. Skia natively supports per-axis blur,
-    /// but the plain <see cref="CircleRuntime"/> surface mirrors industry convention (CSS
-    /// <c>box-shadow</c>, Figma, Photoshop) where blur is a single scalar.
+    /// Isotropic blur radius in pixels for the dropshadow. The plain <see cref="CircleRuntime"/>
+    /// dropshadow blur is a single scalar by design (issue #2761 new-shape contract), mirroring
+    /// industry convention (CSS <c>box-shadow</c>, Figma, Photoshop). Skia natively supports
+    /// per-axis blur, so this pushes the value to both the inherited per-axis fields; the
+    /// per-axis members are hidden/obsolete on this surface (see below).
     /// </summary>
     public float DropshadowBlur
     {
-        get => DropshadowBlurX;
+        get => base.DropshadowBlurX;
         set
         {
-            DropshadowBlurX = value;
-            DropshadowBlurY = value;
+            base.DropshadowBlurX = value;
+            base.DropshadowBlurY = value;
         }
+    }
+
+    /// <summary>
+    /// Obsolete on the plain <see cref="CircleRuntime"/> — use <see cref="DropshadowBlur"/>.
+    /// Hidden shadow of the inherited per-axis blur, kept only so existing code compiles; the
+    /// new-shape contract exposes a single scalar (per-axis blur stays on the legacy Skia shapes
+    /// like <c>RoundedRectangleRuntime</c> / <c>ColoredCircleRuntime</c>).
+    /// </summary>
+    [Obsolete("Use DropshadowBlur (scalar). The plain Circle dropshadow blur is a single isotropic value by design.")]
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public new float DropshadowBlurX
+    {
+        get => base.DropshadowBlurX;
+        set => base.DropshadowBlurX = value;
+    }
+
+    /// <inheritdoc cref="DropshadowBlurX"/>
+    [Obsolete("Use DropshadowBlur (scalar). The plain Circle dropshadow blur is a single isotropic value by design.")]
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public new float DropshadowBlurY
+    {
+        get => base.DropshadowBlurY;
+        set => base.DropshadowBlurY = value;
     }
 
     /// <summary>
@@ -1792,9 +1815,11 @@ public class CircleRuntime : GraphicalUiElement
 
             // Dropshadow is off by default; pre-seed alpha + offset/blur so toggling
             // HasDropshadow = true at runtime produces a visible shadow without further setup.
+            // Use the scalar DropshadowBlur (isotropic 3) so the default matches MonoGame/raylib;
+            // the previous DropshadowBlurY-only seed left the scalar getter (X axis) reading 0.
             DropshadowAlpha = 255;
             DropshadowOffsetY = 3;
-            DropshadowBlurY = 3;
+            DropshadowBlur = 3;
 #else
             circle.CircleOrigin = CircleOrigin.TopLeft;
             circle.Color = ColorExtensions.White;

--- a/MonoGameGum/GueDeriving/RectangleRuntime.cs
+++ b/MonoGameGum/GueDeriving/RectangleRuntime.cs
@@ -1611,12 +1611,35 @@ public class RectangleRuntime : GraphicalUiElement
     /// <inheritdoc cref="CircleRuntime.DropshadowBlur"/>
     public float DropshadowBlur
     {
-        get => DropshadowBlurX;
+        get => base.DropshadowBlurX;
         set
         {
-            DropshadowBlurX = value;
-            DropshadowBlurY = value;
+            base.DropshadowBlurX = value;
+            base.DropshadowBlurY = value;
         }
+    }
+
+    /// <summary>
+    /// Obsolete on the plain <see cref="RectangleRuntime"/> — use <see cref="DropshadowBlur"/>.
+    /// Hidden shadow of the inherited per-axis blur, kept only so existing code compiles; the
+    /// new-shape contract exposes a single scalar (per-axis blur stays on the legacy Skia shapes
+    /// like <c>RoundedRectangleRuntime</c> / <c>ColoredCircleRuntime</c>).
+    /// </summary>
+    [Obsolete("Use DropshadowBlur (scalar). The plain Rectangle dropshadow blur is a single isotropic value by design.")]
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public new float DropshadowBlurX
+    {
+        get => base.DropshadowBlurX;
+        set => base.DropshadowBlurX = value;
+    }
+
+    /// <inheritdoc cref="DropshadowBlurX"/>
+    [Obsolete("Use DropshadowBlur (scalar). The plain Rectangle dropshadow blur is a single isotropic value by design.")]
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public new float DropshadowBlurY
+    {
+        get => base.DropshadowBlurY;
+        set => base.DropshadowBlurY = value;
     }
 
     /// <summary>
@@ -1793,10 +1816,12 @@ public class RectangleRuntime : GraphicalUiElement
             StrokeWidthUnits = DimensionUnitType.ScreenPixel;
 
             // Dropshadow off by default; pre-seed alpha/offset/blur so toggling HasDropshadow =
-            // true at runtime produces a visible shadow without further setup.
+            // true at runtime produces a visible shadow without further setup. Use the scalar
+            // DropshadowBlur (isotropic 3) so the default matches MonoGame/raylib; the previous
+            // DropshadowBlurY-only seed left the scalar getter (X axis) reading 0.
             DropshadowAlpha = 255;
             DropshadowOffsetY = 3;
-            DropshadowBlurY = 3;
+            DropshadowBlur = 3;
 
             Width = 50;
             Height = 50;

--- a/Runtimes/SkiaGum/GueDeriving/ArcRuntime.cs
+++ b/Runtimes/SkiaGum/GueDeriving/ArcRuntime.cs
@@ -318,7 +318,11 @@ public class ArcRuntime : GraphicalUiElement
     }
 
     float _dropshadowBlurX;
-    /// <inheritdoc cref="LineArc.DropshadowBlurX"/>
+    /// <summary>
+    /// Deprecated on <c>ArcRuntime</c> — use <see cref="DropshadowBlur"/> (scalar). Kept
+    /// functional for back-compat; the arc surface is moving to a single isotropic blur.
+    /// </summary>
+    [Obsolete("Use DropshadowBlur (scalar). Per-axis blur is deprecated on ArcRuntime; the arc dropshadow blur is a single isotropic value.")]
     public float DropshadowBlurX
     {
         get => _dropshadowBlurX;
@@ -331,7 +335,8 @@ public class ArcRuntime : GraphicalUiElement
     }
 
     float _dropshadowBlurY;
-    /// <inheritdoc cref="LineArc.DropshadowBlurY"/>
+    /// <inheritdoc cref="DropshadowBlurX"/>
+    [Obsolete("Use DropshadowBlur (scalar). Per-axis blur is deprecated on ArcRuntime; the arc dropshadow blur is a single isotropic value.")]
     public float DropshadowBlurY
     {
         get => _dropshadowBlurY;
@@ -344,18 +349,21 @@ public class ArcRuntime : GraphicalUiElement
     }
 
     /// <summary>
-    /// Isotropic blur radius in pixels for the dropshadow. Convenience wrapper that pushes a
-    /// single value to both <see cref="DropshadowBlurX"/> and <see cref="DropshadowBlurY"/>
-    /// (#2949), mirroring industry convention (CSS <c>box-shadow</c>, Figma, Photoshop) where
-    /// dropshadow blur is a single scalar. Reading returns the X axis.
+    /// Isotropic blur radius in pixels for the dropshadow. The user-facing arc surface mirrors
+    /// industry convention (CSS <c>box-shadow</c>, Figma, Photoshop) where dropshadow blur is a
+    /// single scalar (#2949). Pushes the value to both per-axis fields (deprecated on this
+    /// surface) and the contained <see cref="LineArc"/>. Reading returns the X axis.
     /// </summary>
     public float DropshadowBlur
     {
-        get => DropshadowBlurX;
+        get => _dropshadowBlurX;
         set
         {
-            DropshadowBlurX = value;
-            DropshadowBlurY = value;
+            _dropshadowBlurX = value;
+            _dropshadowBlurY = value;
+            ContainedLineArc.DropshadowBlurX = value;
+            ContainedLineArc.DropshadowBlurY = value;
+            NotifyPropertyChanged();
         }
     }
 
@@ -382,11 +390,15 @@ public class ArcRuntime : GraphicalUiElement
 
             // Pre-seed dropshadow offset/blur so toggling HasDropshadow = true at runtime
             // produces a visible shadow without further setup — same default the Skia/Apos
-            // branch lands via the SkiaShapeRuntime/AposShapeRuntime constructor.
+            // branch lands via the SkiaShapeRuntime/AposShapeRuntime constructor. Anisotropic
+            // seed (X = 0, Y = 3) is intentional; per-axis is deprecated but DropshadowBlur
+            // (scalar) can't express the asymmetry.
             DropshadowOffsetX = 0;
             DropshadowOffsetY = 3;
+#pragma warning disable CS0618
             DropshadowBlurX = 0;
             DropshadowBlurY = 3;
+#pragma warning restore CS0618
         }
     }
 
@@ -556,20 +568,41 @@ public class ArcRuntime
     }
 
     /// <summary>
-    /// Isotropic blur radius in pixels for the dropshadow. Convenience wrapper that pushes a
-    /// single value to both the inherited <see cref="SkiaShapeRuntime.DropshadowBlurX"/> and
-    /// <see cref="SkiaShapeRuntime.DropshadowBlurY"/> (#2949). Skia natively supports per-axis
-    /// blur, but the user-facing arc surface mirrors industry convention (CSS <c>box-shadow</c>,
-    /// Figma, Photoshop) where blur is a single scalar. Reading returns the X axis.
+    /// Isotropic blur radius in pixels for the dropshadow. The user-facing arc surface mirrors
+    /// industry convention (CSS <c>box-shadow</c>, Figma, Photoshop) where blur is a single
+    /// scalar (#2949); this pushes the value to both inherited per-axis fields. Skia natively
+    /// supports per-axis blur, so the per-axis members remain functional but are deprecated on
+    /// the arc surface (see below). Reading returns the X axis.
     /// </summary>
     public float DropshadowBlur
     {
-        get => DropshadowBlurX;
+        get => base.DropshadowBlurX;
         set
         {
-            DropshadowBlurX = value;
-            DropshadowBlurY = value;
+            base.DropshadowBlurX = value;
+            base.DropshadowBlurY = value;
         }
+    }
+
+    /// <summary>
+    /// Deprecated on <c>ArcRuntime</c> — use <see cref="DropshadowBlur"/> (scalar). Kept
+    /// functional (forwards to the inherited per-axis blur) for back-compat; the arc surface is
+    /// moving to a single isotropic blur. Per-axis blur stays as the real API on the legacy Skia
+    /// shapes (<c>RoundedRectangleRuntime</c> / <c>ColoredCircleRuntime</c>).
+    /// </summary>
+    [Obsolete("Use DropshadowBlur (scalar). Per-axis blur is deprecated on ArcRuntime; the arc dropshadow blur is a single isotropic value.")]
+    public new float DropshadowBlurX
+    {
+        get => base.DropshadowBlurX;
+        set => base.DropshadowBlurX = value;
+    }
+
+    /// <inheritdoc cref="DropshadowBlurX"/>
+    [Obsolete("Use DropshadowBlur (scalar). Per-axis blur is deprecated on ArcRuntime; the arc dropshadow blur is a single isotropic value.")]
+    public new float DropshadowBlurY
+    {
+        get => base.DropshadowBlurY;
+        set => base.DropshadowBlurY = value;
     }
 
     /// <summary>
@@ -626,8 +659,13 @@ public class ArcRuntime
 
             DropshadowOffsetX = 0;
             DropshadowOffsetY = 3;
+            // Anisotropic seed (X = 0, Y = 3) is intentional — the arc's default shadow blurs
+            // only vertically. Per-axis is deprecated on the public surface but kept here for
+            // that default; DropshadowBlur (scalar) can't express the asymmetry.
+#pragma warning disable CS0618
             DropshadowBlurX = 0;
             DropshadowBlurY = 3;
+#pragma warning restore CS0618
         }
     }
 

--- a/Samples/GumShapesGallery/GumShapesGalleryCommon/Screens/ArcsScreen.cs
+++ b/Samples/GumShapesGallery/GumShapesGalleryCommon/Screens/ArcsScreen.cs
@@ -331,8 +331,7 @@ internal class ArcsScreen : FrameworkElement
         soft.HasDropshadow = true;
         soft.DropshadowOffsetX = 14;
         soft.DropshadowOffsetY = 14;
-        soft.DropshadowBlurX = 4;
-        soft.DropshadowBlurY = 4;
+        soft.DropshadowBlur = 4;
         row.AddChild(soft);
 
         ArcRuntime hard = new();
@@ -344,8 +343,7 @@ internal class ArcsScreen : FrameworkElement
         hard.DropshadowColor = new Color(0, 0, 0, 160);
         hard.DropshadowOffsetX = 16;
         hard.DropshadowOffsetY = 16;
-        hard.DropshadowBlurX = 0;
-        hard.DropshadowBlurY = 0;
+        hard.DropshadowBlur = 0;
         row.AddChild(hard);
 
         ArcRuntime colored = new();
@@ -357,8 +355,7 @@ internal class ArcsScreen : FrameworkElement
         colored.DropshadowColor = new Color(220, 40, 160, 220);
         colored.DropshadowOffsetX = 16;
         colored.DropshadowOffsetY = 16;
-        colored.DropshadowBlurX = 6;
-        colored.DropshadowBlurY = 6;
+        colored.DropshadowBlur = 6;
         row.AddChild(colored);
 
         ArcRuntime fadedBody = new();
@@ -369,8 +366,7 @@ internal class ArcsScreen : FrameworkElement
         fadedBody.HasDropshadow = true;
         fadedBody.DropshadowOffsetX = 14;
         fadedBody.DropshadowOffsetY = 14;
-        fadedBody.DropshadowBlurX = 4;
-        fadedBody.DropshadowBlurY = 4;
+        fadedBody.DropshadowBlur = 4;
         row.AddChild(fadedBody);
 
         return row;

--- a/Samples/SilkNetGum/SilkNetGum/Screens/ArcsScreen.cs
+++ b/Samples/SilkNetGum/SilkNetGum/Screens/ArcsScreen.cs
@@ -316,8 +316,7 @@ internal class ArcsScreen : GraphicalUiElement
         soft.HasDropshadow = true;
         soft.DropshadowOffsetX = 14;
         soft.DropshadowOffsetY = 14;
-        soft.DropshadowBlurX = 4;
-        soft.DropshadowBlurY = 4;
+        soft.DropshadowBlur = 4;
         row.Children.Add(soft);
 
         ArcRuntime hard = new();
@@ -329,8 +328,7 @@ internal class ArcsScreen : GraphicalUiElement
         hard.DropshadowRed = 0; hard.DropshadowGreen = 0; hard.DropshadowBlue = 0; hard.DropshadowAlpha = 160;
         hard.DropshadowOffsetX = 16;
         hard.DropshadowOffsetY = 16;
-        hard.DropshadowBlurX = 0;
-        hard.DropshadowBlurY = 0;
+        hard.DropshadowBlur = 0;
         row.Children.Add(hard);
 
         ArcRuntime colored = new();
@@ -342,8 +340,7 @@ internal class ArcsScreen : GraphicalUiElement
         colored.DropshadowRed = 220; colored.DropshadowGreen = 40; colored.DropshadowBlue = 160; colored.DropshadowAlpha = 220;
         colored.DropshadowOffsetX = 16;
         colored.DropshadowOffsetY = 16;
-        colored.DropshadowBlurX = 6;
-        colored.DropshadowBlurY = 6;
+        colored.DropshadowBlur = 6;
         row.Children.Add(colored);
 
         ArcRuntime fadedBody = new();
@@ -354,8 +351,7 @@ internal class ArcsScreen : GraphicalUiElement
         fadedBody.HasDropshadow = true;
         fadedBody.DropshadowOffsetX = 14;
         fadedBody.DropshadowOffsetY = 14;
-        fadedBody.DropshadowBlurX = 4;
-        fadedBody.DropshadowBlurY = 4;
+        fadedBody.DropshadowBlur = 4;
         row.Children.Add(fadedBody);
 
         return row;

--- a/Samples/raylib/Screens/ArcsScreen.cs
+++ b/Samples/raylib/Screens/ArcsScreen.cs
@@ -217,8 +217,7 @@ internal class ArcsScreen : FrameworkElement
         soft.HasDropshadow = true;
         soft.DropshadowOffsetX = 14;
         soft.DropshadowOffsetY = 14;
-        soft.DropshadowBlurX = 4;
-        soft.DropshadowBlurY = 4;
+        soft.DropshadowBlur = 4;
         row.Children.Add(soft);
 
         ArcRuntime hard = new();
@@ -230,8 +229,7 @@ internal class ArcsScreen : FrameworkElement
         hard.DropshadowRed = 0; hard.DropshadowGreen = 0; hard.DropshadowBlue = 0; hard.DropshadowAlpha = 160;
         hard.DropshadowOffsetX = 16;
         hard.DropshadowOffsetY = 16;
-        hard.DropshadowBlurX = 0;
-        hard.DropshadowBlurY = 0;
+        hard.DropshadowBlur = 0;
         row.Children.Add(hard);
 
         ArcRuntime colored = new();
@@ -243,8 +241,7 @@ internal class ArcsScreen : FrameworkElement
         colored.DropshadowRed = 220; colored.DropshadowGreen = 40; colored.DropshadowBlue = 160; colored.DropshadowAlpha = 220;
         colored.DropshadowOffsetX = 16;
         colored.DropshadowOffsetY = 16;
-        colored.DropshadowBlurX = 6;
-        colored.DropshadowBlurY = 6;
+        colored.DropshadowBlur = 6;
         row.Children.Add(colored);
 
         ArcRuntime fadedBody = new();
@@ -255,8 +252,7 @@ internal class ArcsScreen : FrameworkElement
         fadedBody.HasDropshadow = true;
         fadedBody.DropshadowOffsetX = 14;
         fadedBody.DropshadowOffsetY = 14;
-        fadedBody.DropshadowBlurX = 4;
-        fadedBody.DropshadowBlurY = 4;
+        fadedBody.DropshadowBlur = 4;
         row.Children.Add(fadedBody);
 
         // Issue #2895 acceptance cell: rounded-cap arc at body alpha 80, NO dropshadow. Locks in

--- a/Tests/MonoGameGum.Shapes.Tests/ArcRuntimeTests.cs
+++ b/Tests/MonoGameGum.Shapes.Tests/ArcRuntimeTests.cs
@@ -36,16 +36,20 @@ public class ArcRuntimeTests
     }
 
     // #2949: ArcRuntime exposes a single isotropic DropshadowBlur (mirroring CSS box-shadow /
-    // Figma / Photoshop). Setting it writes both per-axis shims; reading returns the X axis.
+    // Figma / Photoshop). Setting the scalar fans the value out to both axes; asserted on the
+    // rendered shadow halo (GetShadowAntiAliasSize, the X axis) and the renderable's Y blur,
+    // not the deprecated per-axis runtime members. On Apos the runtime forwards straight to the
+    // renderable, so no PreRender is needed.
     [Fact]
-    public void DropshadowBlur_ShouldSetBothBlurXAndY()
+    public void DropshadowBlur_ShouldSetBothAxesOnRenderable()
     {
         ArcRuntime sut = new ArcRuntime();
 
         sut.DropshadowBlur = 5;
 
-        sut.DropshadowBlurX.ShouldBe(5);
-        sut.DropshadowBlurY.ShouldBe(5);
+        RenderableShapeBase shape = (RenderableShapeBase)sut.RenderableComponent;
+        shape.GetShadowAntiAliasSize(cameraZoom: 1f).ShouldBe(5);
+        shape.DropshadowBlurY.ShouldBe(5f);
         sut.DropshadowBlur.ShouldBe(5);
     }
 

--- a/Tests/MonoGameGum.Shapes.Tests/CircleRuntimeTests.cs
+++ b/Tests/MonoGameGum.Shapes.Tests/CircleRuntimeTests.cs
@@ -238,7 +238,7 @@ public class CircleRuntimeTests
         fill.DropshadowColor.ShouldBe(new Color(10, 20, 30, 40));
         fill.DropshadowOffsetX.ShouldBe(5);
         fill.DropshadowOffsetY.ShouldBe(7);
-        fill.DropshadowBlurX.ShouldBe(2);
+        fill.GetShadowAntiAliasSize(cameraZoom: 1f).ShouldBe(2);
 
         // Stroke must stay shadow-free — see XML remarks on IDropshadowRenderable.
         stroke.HasDropshadow.ShouldBeFalse();
@@ -792,7 +792,7 @@ public class CircleRuntimeTests
         Circle stroke = (Circle)fill.Children[0];
         stroke.DropshadowOffsetX.ShouldBe(19f);
         stroke.DropshadowOffsetY.ShouldBe(11f);
-        stroke.DropshadowBlurX.ShouldBe(3f);
+        stroke.GetShadowAntiAliasSize(cameraZoom: 1f).ShouldBe(3);
     }
 
     [Fact]

--- a/Tests/MonoGameGum.Shapes.Tests/RectangleRuntimeTests.cs
+++ b/Tests/MonoGameGum.Shapes.Tests/RectangleRuntimeTests.cs
@@ -277,7 +277,7 @@ public class RectangleRuntimeTests
         fill.DropshadowColor.ShouldBe(new Color(10, 20, 30, 40));
         fill.DropshadowOffsetX.ShouldBe(5);
         fill.DropshadowOffsetY.ShouldBe(7);
-        fill.DropshadowBlurX.ShouldBe(2);
+        fill.GetShadowAntiAliasSize(cameraZoom: 1f).ShouldBe(2);
 
         stroke.HasDropshadow.ShouldBeFalse();
     }
@@ -716,7 +716,7 @@ public class RectangleRuntimeTests
         RoundedRectangle stroke = (RoundedRectangle)fill.Children[0];
         stroke.DropshadowOffsetX.ShouldBe(19f);
         stroke.DropshadowOffsetY.ShouldBe(11f);
-        stroke.DropshadowBlurX.ShouldBe(3f);
+        stroke.GetShadowAntiAliasSize(cameraZoom: 1f).ShouldBe(3);
     }
 
     [Fact]

--- a/Tests/SkiaGum.Tests/GueDeriving/ArcRuntimeTests.cs
+++ b/Tests/SkiaGum.Tests/GueDeriving/ArcRuntimeTests.cs
@@ -10,16 +10,21 @@ namespace SkiaGum.Tests.GueDeriving;
 public class ArcRuntimeTests
 {
     // #2949: ArcRuntime exposes a single isotropic DropshadowBlur (mirroring CSS box-shadow /
-    // Figma / Photoshop). Setting it writes both per-axis shims; reading returns the X axis.
+    // Figma / Photoshop). Setting the scalar fans the value out to both axes; asserted on the
+    // renderable's per-axis blur (which stays a real API at the renderable layer), not the
+    // deprecated per-axis runtime members. Skia pushes blur to the renderable in PreRender
+    // (ApplyDropshadow).
     [Fact]
-    public void ArcRuntime_DropshadowBlur_ShouldSetBothBlurXAndY()
+    public void ArcRuntime_DropshadowBlur_ShouldSetBothAxesOnRenderable()
     {
         ArcRuntime arcRuntime = new();
 
         arcRuntime.DropshadowBlur = 5;
+        arcRuntime.PreRender();
 
-        arcRuntime.DropshadowBlurX.ShouldBe(5);
-        arcRuntime.DropshadowBlurY.ShouldBe(5);
+        RenderableShapeBase shape = (RenderableShapeBase)arcRuntime.RenderableComponent;
+        shape.DropshadowBlurX.ShouldBe(5f);
+        shape.DropshadowBlurY.ShouldBe(5f);
         arcRuntime.DropshadowBlur.ShouldBe(5);
     }
 

--- a/Tests/SkiaGum.Tests/GueDeriving/CircleRuntimeTests.cs
+++ b/Tests/SkiaGum.Tests/GueDeriving/CircleRuntimeTests.cs
@@ -447,6 +447,17 @@ public class CircleRuntimeTests
         sut.DropshadowAlpha.ShouldBe(40);
     }
 
+    // Scalar-blur collapse: the plain Circle exposes a single isotropic DropshadowBlur. The Skia
+    // ctor seeds it to 3 so a freshly-constructed runtime matches MonoGame/raylib (where the
+    // scalar already defaults to 3). Previously the Skia ctor seeded only the Y axis, leaving the
+    // scalar getter (which reads the X axis) reporting 0 — a cross-backend inconsistency.
+    [Fact]
+    public void DropshadowBlur_ShouldBe3_ByDefault()
+    {
+        CircleRuntime sut = new();
+        sut.DropshadowBlur.ShouldBe(3);
+    }
+
     [Fact]
     public void Dropshadow_TargetSwitch_ClearsPreviousSlot()
     {

--- a/Tests/SkiaGum.Tests/GueDeriving/RectangleRuntimeTests.cs
+++ b/Tests/SkiaGum.Tests/GueDeriving/RectangleRuntimeTests.cs
@@ -193,6 +193,17 @@ public class RectangleRuntimeTests
         strokeSlot.CustomRadiusBottomRight.ShouldBe(4f);
     }
 
+    // Scalar-blur collapse: the plain Rectangle exposes a single isotropic DropshadowBlur. The
+    // Skia ctor seeds it to 3 so a freshly-constructed runtime matches MonoGame/raylib (where the
+    // scalar already defaults to 3). Previously the Skia ctor seeded only the Y axis, leaving the
+    // scalar getter (which reads the X axis) reporting 0 — a cross-backend inconsistency.
+    [Fact]
+    public void DropshadowBlur_ShouldBe3_ByDefault()
+    {
+        RectangleRuntime sut = new();
+        sut.DropshadowBlur.ShouldBe(3);
+    }
+
     // Issue #2938 — IsFilled gates dropshadow routing. When IsFilled = false, the shadow lands
     // on the stroke slot (a stroke-only ring still casts a shadow).
     [Fact]


### PR DESCRIPTION
## Summary
- The plain **Circle/Rectangle** new-shape contract now exposes only the scalar `DropshadowBlur`. On Skia these runtimes inherited public `DropshadowBlurX/Y` from `SkiaShapeRuntime`; they're now `new [Obsolete]` + `EditorBrowsable(Never)` shims forwarding to the base. The Skia constructors seed `DropshadowBlur = 3` (isotropic) instead of `DropshadowBlurY = 3` alone — fixing a cross-backend inconsistency where `circle.DropshadowBlur` read back **0** on Skia despite a visible Y blur (MonoGame/raylib already defaulted the scalar to 3).
- **`ArcRuntime`** already exposed the scalar (#2949); its per-axis `DropshadowBlurX/Y` are now `[Obsolete]` on the Skia/Apos branch (`new`-shadowing the inherited members) and the raylib branch (its own members), steering callers to the scalar. Arc keeps its genuinely anisotropic default (X=0, Y=3), so per-axis stays functional.
- Per-axis blur is intentionally **untouched** on the legacy shapes (`RoundedRectangleRuntime`, `ColoredCircleRuntime`) and at the renderable layer (Apos/Skia `RenderableShapeBase`) — Skia's `SKImageFilter.CreateDropShadow` takes real per-axis sigmas.
- Test sweep (bucket 3 from the #2977 review): runtime tests moved off the per-axis fields onto the scalar input + `GetShadowAntiAliasSize` (Apos) / renderable per-axis (Skia). Added Skia default-`DropshadowBlur`==3 tests.
- Sample `ArcsScreen`s (GumShapesGallery, SilkNet, raylib) migrated to the scalar.

## Test plan
- [x] `MonoGameGum.Shapes.Tests` (Apos) — 111 pass
- [x] `SkiaGum.Tests` — 80 pass
- [x] `RaylibGum.Tests` — 128 pass
- [x] `MonoGameGum.Tests` Circle/Rectangle — 33 pass
- [x] No new compiler warnings introduced (per-axis internal seeds suppressed with scoped `#pragma warning disable CS0618`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)