### PR TITLE
#2986: Inline hex text box on the color swatch (ColorDisplay)

### DIFF
--- a/Gum/Controls/ColorDisplay.xaml
+++ b/Gum/Controls/ColorDisplay.xaml
@@ -13,6 +13,7 @@
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="Auto" />
             <ColumnDefinition Width="1*" />
+            <ColumnDefinition Width="Auto" />
         </Grid.ColumnDefinitions>
 
 
@@ -29,5 +30,23 @@
             ColorChanged="HandleColorChange"
             MouseUp="ColorPicker_MouseUp"
             PreviewMouseUp="ColorPicker_PreviewMouseUp" />
+
+        <!--  Inline hex entry: paste/type a 6- or 8-digit hex (alpha stripped) without opening the picker popup.  -->
+        <StackPanel
+            Grid.Column="2"
+            Margin="4,5,0,5"
+            VerticalAlignment="Center"
+            Orientation="Horizontal">
+            <TextBlock VerticalAlignment="Center" Text="#" />
+            <TextBox
+                x:Name="HexTextBox"
+                Width="72"
+                VerticalAlignment="Center"
+                VerticalContentAlignment="Center"
+                KeyDown="HexTextBox_KeyDown"
+                LostFocus="HexTextBox_LostFocus"
+                TextChanged="HexTextBox_TextChanged"
+                ToolTip="Type or paste a hex color (RRGGBB or RRGGBBAA). Alpha is ignored." />
+        </StackPanel>
     </Grid>
 </UserControl>

--- a/Gum/Controls/ColorDisplay.xaml.cs
+++ b/Gum/Controls/ColorDisplay.xaml.cs
@@ -23,6 +23,12 @@ namespace Gum.Controls.DataUi
         Type mInstancePropertyType;
         private bool needsToPushFullCommitOnMouseUp;
 
+        // Set in the constructor so the invalid-hex border can be cleared back to the control's themed default.
+        private readonly Brush _defaultHexBorderBrush;
+        private readonly Brush _invalidHexBorderBrush;
+        // Guards the hex text box against re-validating / re-committing while we sync it programmatically.
+        private bool _isSyncingHexText;
+
         #endregion
 
         #region Properties
@@ -61,6 +67,9 @@ namespace Gum.Controls.DataUi
         public ColorDisplay()
         {
             InitializeComponent();
+
+            _defaultHexBorderBrush = HexTextBox.BorderBrush;
+            _invalidHexBorderBrush = Brushes.Red;
         }
 
         public void Refresh(bool forceRefreshEvenIfFocused = false)
@@ -124,11 +133,12 @@ namespace Gum.Controls.DataUi
                 windowsColor.B = color.B;
 
                 this.ColorPicker.SelectedColor = windowsColor;
+                SyncHexTextFromPicker();
                 // This is beign set from the underlying data object to the UI
                 // which means the UI hasn't updated yet, so we don't want to push
                 // the value back to the UI
                 needsToPushFullCommitOnMouseUp = false;
-                 
+
                 return ApplyValueResult.Success;
             }
             else 
@@ -142,6 +152,7 @@ namespace Gum.Controls.DataUi
                 windowsColor.B = drawingColor.B;
 
                 this.ColorPicker.SelectedColor = windowsColor;
+                SyncHexTextFromPicker();
                 return ApplyValueResult.Success;
             }
             return ApplyValueResult.NotSupported;
@@ -243,6 +254,7 @@ namespace Gum.Controls.DataUi
 
             SetCurrentColorValueOnInstance(commitType);
 
+            SyncHexTextFromPicker();
         }
 
         bool isSetting = false;
@@ -290,6 +302,86 @@ namespace Gum.Controls.DataUi
             System.Diagnostics.Debug.WriteLine($"Preview Mouse up at {DateTime.Now}");
 
             e.Handled = false;
+        }
+
+        private void HexTextBox_KeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.Key == Key.Enter)
+            {
+                CommitHexText();
+                e.Handled = true;
+            }
+        }
+
+        private void HexTextBox_LostFocus(object sender, RoutedEventArgs e)
+        {
+            CommitHexText();
+        }
+
+        private void HexTextBox_TextChanged(object sender, TextChangedEventArgs e)
+        {
+            if (_isSyncingHexText)
+            {
+                return;
+            }
+            UpdateHexValidationVisual();
+        }
+
+        /// <summary>
+        /// Parses the hex text box and, if valid, applies it to the picker (preserving the current
+        /// alpha) so the existing color-change path performs a single Full commit (one undo). The
+        /// text box is then normalized to the canonical hex of the applied color; invalid input is
+        /// reverted without committing.
+        /// </summary>
+        private void CommitHexText()
+        {
+            if (HexColorParser.TryParse(HexTextBox.Text, out byte r, out byte g, out byte b))
+            {
+                Color current = ColorPicker.SelectedColor;
+                Color newColor = Color.FromArgb(current.A, r, g, b);
+                if (newColor != current)
+                {
+                    // Raises ColorChanged -> HandleColorChange, which commits Full because the mouse
+                    // is not pressed during a keyboard/focus commit -> a single undo entry.
+                    ColorPicker.SelectedColor = newColor;
+                }
+            }
+
+            // Normalize (on success) or revert (on invalid input) to the currently applied color.
+            Color applied = ColorPicker.SelectedColor;
+            SetHexText(HexColorParser.ToHexRgb(applied.R, applied.G, applied.B));
+            UpdateHexValidationVisual();
+        }
+
+        /// <summary>
+        /// Updates the hex text box to match the picker's current color, unless the user is actively
+        /// editing it (so their in-progress typing is never clobbered).
+        /// </summary>
+        private void SyncHexTextFromPicker()
+        {
+            if (HexTextBox.IsKeyboardFocusWithin)
+            {
+                return;
+            }
+
+            Color color = ColorPicker.SelectedColor;
+            SetHexText(HexColorParser.ToHexRgb(color.R, color.G, color.B));
+            UpdateHexValidationVisual();
+        }
+
+        private void SetHexText(string text)
+        {
+            _isSyncingHexText = true;
+            HexTextBox.Text = text;
+            _isSyncingHexText = false;
+        }
+
+        private void UpdateHexValidationVisual()
+        {
+            // Empty input is treated as neutral (not an error) so clearing the box to retype isn't jarring.
+            bool isNeutral = string.IsNullOrWhiteSpace(HexTextBox.Text)
+                || HexColorParser.TryParse(HexTextBox.Text, out _, out _, out _);
+            HexTextBox.BorderBrush = isNeutral ? _defaultHexBorderBrush : _invalidHexBorderBrush;
         }
     }
 }

--- a/Gum/Controls/HexColorParser.cs
+++ b/Gum/Controls/HexColorParser.cs
@@ -1,0 +1,70 @@
+using System.Globalization;
+
+namespace Gum.Controls.DataUi
+{
+    /// <summary>
+    /// Pure parsing/formatting helpers for the hex color text box on <see cref="ColorDisplay"/>.
+    /// Extracted from the WPF control so the logic is unit-testable.
+    /// </summary>
+    public static class HexColorParser
+    {
+        /// <summary>
+        /// Parses a hex color string into its red, green, and blue byte components.
+        /// Accepts 6-digit (RRGGBB) and 8-digit (RRGGBBAA) hex, with or without a leading '#',
+        /// and ignores surrounding whitespace. Any alpha component (the AA in 8-digit form) is
+        /// parsed but discarded — callers manage alpha separately.
+        /// </summary>
+        /// <returns>True if the value was a valid 6- or 8-digit hex color; otherwise false.</returns>
+        public static bool TryParse(string? hex, out byte r, out byte g, out byte b)
+        {
+            r = 0;
+            g = 0;
+            b = 0;
+
+            if (string.IsNullOrWhiteSpace(hex))
+            {
+                return false;
+            }
+
+            string trimmed = hex.Trim();
+            if (trimmed.StartsWith("#"))
+            {
+                trimmed = trimmed.Substring(1);
+            }
+
+            // Only RRGGBB and RRGGBBAA are supported; alpha is parsed below but discarded.
+            if (trimmed.Length != 6 && trimmed.Length != 8)
+            {
+                return false;
+            }
+
+            if (!TryParseComponent(trimmed.Substring(0, 2), out byte parsedR) ||
+                !TryParseComponent(trimmed.Substring(2, 2), out byte parsedG) ||
+                !TryParseComponent(trimmed.Substring(4, 2), out byte parsedB))
+            {
+                return false;
+            }
+
+            r = parsedR;
+            g = parsedG;
+            b = parsedB;
+            return true;
+        }
+
+        private static bool TryParseComponent(string twoDigitHex, out byte value)
+        {
+            // AllowHexSpecifier rejects signs and surrounding whitespace, so each two-character
+            // component is validated strictly here.
+            return byte.TryParse(twoDigitHex, NumberStyles.AllowHexSpecifier, CultureInfo.InvariantCulture, out value);
+        }
+
+        /// <summary>
+        /// Formats red, green, and blue components as a six-digit uppercase hex string
+        /// (no leading '#'), matching the form <see cref="TryParse"/> displays and accepts.
+        /// </summary>
+        public static string ToHexRgb(byte r, byte g, byte b)
+        {
+            return $"{r:X2}{g:X2}{b:X2}";
+        }
+    }
+}

--- a/Tool/Tests/GumToolUnitTests/Controls/HexColorParserTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Controls/HexColorParserTests.cs
@@ -1,0 +1,105 @@
+using Gum.Controls.DataUi;
+using Shouldly;
+
+namespace GumToolUnitTests.Controls;
+
+public class HexColorParserTests
+{
+    public static IEnumerable<object[]> InvalidHexData()
+    {
+        yield return new object[] { "" };
+        yield return new object[] { "   " };
+        yield return new object[] { "#" };
+        yield return new object[] { "12345" };    // 5 digits
+        yield return new object[] { "1234567" };   // 7 digits
+        yield return new object[] { "123456789" }; // 9 digits
+        yield return new object[] { "GGGGGG" };     // non-hex characters
+        yield return new object[] { "12 456" };     // embedded space
+        yield return new object[] { "+12345" };     // sign
+    }
+
+    [Fact]
+    public void ToHexRgb_RoundTripsThroughTryParse()
+    {
+        string formatted = HexColorParser.ToHexRgb(18, 52, 86);
+
+        bool result = HexColorParser.TryParse(formatted, out byte r, out byte g, out byte b);
+
+        result.ShouldBeTrue();
+        r.ShouldBe<byte>(18);
+        g.ShouldBe<byte>(52);
+        b.ShouldBe<byte>(86);
+    }
+
+    [Fact]
+    public void ToHexRgb_ShouldFormatAsSixUppercaseDigitsWithoutHash()
+    {
+        string formatted = HexColorParser.ToHexRgb(0, 17, 147);
+
+        formatted.ShouldBe("001193");
+    }
+
+    [Fact]
+    public void TryParse_ShouldAcceptLeadingHash()
+    {
+        bool result = HexColorParser.TryParse("#001193", out byte r, out byte g, out byte b);
+
+        result.ShouldBeTrue();
+        r.ShouldBe<byte>(0);
+        g.ShouldBe<byte>(17);
+        b.ShouldBe<byte>(147);
+    }
+
+    [Fact]
+    public void TryParse_ShouldParseEightDigitHexAndStripAlpha()
+    {
+        bool result = HexColorParser.TryParse("#0011937F", out byte r, out byte g, out byte b);
+
+        result.ShouldBeTrue();
+        r.ShouldBe<byte>(0);
+        g.ShouldBe<byte>(17);
+        b.ShouldBe<byte>(147);
+    }
+
+    [Fact]
+    public void TryParse_ShouldParseSixDigitHex()
+    {
+        bool result = HexColorParser.TryParse("FF8000", out byte r, out byte g, out byte b);
+
+        result.ShouldBeTrue();
+        r.ShouldBe<byte>(255);
+        g.ShouldBe<byte>(128);
+        b.ShouldBe<byte>(0);
+    }
+
+    [Theory]
+    [MemberData(nameof(InvalidHexData))]
+    public void TryParse_ShouldRejectInvalidInput(string input)
+    {
+        bool result = HexColorParser.TryParse(input, out byte r, out byte g, out byte b);
+
+        result.ShouldBeFalse();
+        r.ShouldBe<byte>(0);
+        g.ShouldBe<byte>(0);
+        b.ShouldBe<byte>(0);
+    }
+
+    [Fact]
+    public void TryParse_ShouldRejectNull()
+    {
+        bool result = HexColorParser.TryParse(null, out byte r, out byte g, out byte b);
+
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void TryParse_ShouldTrimSurroundingWhitespace()
+    {
+        bool result = HexColorParser.TryParse("  #001193  ", out byte r, out byte g, out byte b);
+
+        result.ShouldBeTrue();
+        r.ShouldBe<byte>(0);
+        g.ShouldBe<byte>(17);
+        b.ShouldBe<byte>(147);
+    }
+}


### PR DESCRIPTION
Closes #2986.

Follow-up to #2981 / PR #2985 (composite color swatch).

## What

Adds an inline hex text box to the variable-grid color swatch (`ColorDisplay`) so a hex value can be typed or pasted without opening the `PortableColorPicker` popup.

![layout] `Label | PortableColorPicker | # [ RRGGBB ]`

## Behavior (per the decisions in #2986)

- **Two-way / live** — the box reflects the current color and updates as the picker changes; it never clobbers in-progress typing (skips sync while `IsKeyboardFocusWithin`).
- **Commit on Enter / lost-focus** — commits by driving `ColorPicker.SelectedColor`, which routes through the control's existing single **Full** commit path, so each edit is **one undo entry**. This also sidesteps the third-party multi-undo paste bug documented in #1654 (PixiEditor/ColorPicker#60), since we own the commit rather than the popup.
- **Accepts `RRGGBB` and `RRGGBBAA`** (with or without a leading `#`) — alpha is parsed but **discarded**, because alpha stays editable in its own row (the composite excludes alpha and the picker has `ShowAlpha="False"`).
- **Invalid input** shows a red border while typing and is reverted to the live color's hex on commit (no value written). Empty input is treated as neutral.
- No 3-digit `#RGB` shorthand (out of scope).
- Scope is `ColorDisplay` only; standalone `PortableColorPicker` sites are untouched.

## Implementation

- New pure `HexColorParser` (`TryParse` / `ToHexRgb`) holds all parsing/formatting so it is unit-testable, mirroring the existing `TextBoxDisplayLogic` precedent. It is a stateless utility, so it deliberately has no interface (the interface rule targets injectable services).
- WPF event wiring stays in `ColorDisplay.xaml.cs` (genuinely untestable code-behind).

## Tests

16 `HexColorParserTests` (6-digit, 8-digit alpha strip, leading `#`, whitespace trim, null, invalid lengths/characters/signs, round-trip). Full `GumToolUnitTests.Controls` suite (33) green.

## Not covered here

In-app visual/interaction verification (paste → swatch updates, single undo, red-border on bad input) needs a manual run of the tool — recommend a QA pass before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
