### PR TITLE
Docs: shape support for Circle/Rectangle + relabel 2026 May release to June

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -150,7 +150,7 @@
   * [Upgrading File (GUMX) Version](gum-tool/upgrading/upgrading-file-gumx-version.md)
   * [Syntax Versions](gum-tool/upgrading/syntax-versions.md)
     * [Syntax Version 1](gum-tool/upgrading/syntax-version-1.md)
-  * [Migrating to 2026 May](gum-tool/upgrading/migrating-to-2026-may.md)
+  * [Migrating to 2026 June](gum-tool/upgrading/migrating-to-2026-june.md)
   * [Migrating to 2026 April](gum-tool/upgrading/migrating-to-2026-april.md)
   * [Migrating to 2026 March](gum-tool/upgrading/migrating-to-2026-march.md)
   * [Migrating to 2026 February](gum-tool/upgrading/migrating-to-2026-february.md)

--- a/docs/code/getting-started/setup/adding-initializing-gum/monogame-kni-fna/README.md
+++ b/docs/code/getting-started/setup/adding-initializing-gum/monogame-kni-fna/README.md
@@ -272,6 +272,58 @@ If linking to source instead of NuGet, add `<Gum Root>/Runtimes/GumExpressions/G
 
 For more information, see the [Runtime Variable References](../../../../styling/runtime-variable-references.md) page.
 
+## Adding Shape Support (Recommended)
+
+Gum's `Circle` and `Rectangle` elements have a **fill** and an **outline (stroke)**. On MonoGame, KNI, and FNA, an outlined `Circle` or `Rectangle` renders out of the box — `StrokeColor`, `StrokeWidth`, `StrokeWidthUnits`, and the geometry properties (`Width`, `Height`, `Radius`, `CornerRadius`) all work with no extra package.
+
+Filling a shape and the richer effects need the shape support package. We recommend installing it for most projects so that fill, gradient, drop shadow, dashed stroke, and anti-aliasing all draw. Without it, the following properties are stored and round-trip correctly, but silently do not draw: `FillColor` (and the fill color channels), gradient (`UseGradient` and the gradient properties), drop shadow (`HasDropshadow` and the dropshadow properties), dashed stroke (`StrokeDashLength` / `StrokeGapLength`), anti-aliasing (`IsAntialiased`), and `Blend`. Nothing throws — the shape simply renders without that feature.
+
+To enable fill and effects, add the shape support package for your platform (the `Gum.Shapes.*` package, which uses Apos.Shapes under the hood):
+
+{% tabs %}
+{% tab title="MonoGame" %}
+```xml
+<PackageReference Include="Gum.Shapes.MonoGame" Version="*" />
+```
+
+Or add through command line:
+
+```bash
+dotnet add package Gum.Shapes.MonoGame
+```
+{% endtab %}
+
+{% tab title="KNI" %}
+```xml
+<PackageReference Include="Gum.Shapes.KNI" Version="*" />
+```
+
+Or add through command line:
+
+```bash
+dotnet add package Gum.Shapes.KNI
+```
+{% endtab %}
+
+{% tab title="FNA" %}
+There is no shape support NuGet package for FNA. An outlined `Circle` or `Rectangle` still renders without any package (`StrokeColor`, `StrokeWidth`, and geometry all work), but fill and the richer effects are currently available on MonoGame and KNI only.
+{% endtab %}
+{% endtabs %}
+
+Next, add the following line after `GumUI.Initialize(...)` in your `Initialize` method:
+
+```csharp
+// Initialize
+GumUI.Initialize(this);
+ShapeRenderer.Self.Initialize();
+```
+
+{% hint style="info" %}
+The fill + outline `Circle` and `Rectangle` surface ships in the June 2026 release. Before then, you can use it by building Gum from source.
+{% endhint %}
+
+For the full set of fill, outline, gradient, drop shadow, and corner-radius properties, see the [Shapes](../../../../standard-visuals/shapes-apos.shapes.md) page.
+
 ## Adding a Button (Testing the Setup)
 
 Gum can be tested by adding a Button after Gum is initialized. To do so, add code to create a `Button` as shown in the following block of code after Gum is initialized:

--- a/docs/code/localization.md
+++ b/docs/code/localization.md
@@ -353,7 +353,7 @@ GumUI.LocalizationService.CurrentLanguage = 2;
 ```
 
 {% hint style="info" %}
-Automatic runtime language switching requires the May 2026 Gum release or newer. On earlier versions, changing `CurrentLanguage` only affected text assigned _after_ the change — already-displayed text kept its old translation, and the only way to refresh was to recreate the screen.
+Automatic runtime language switching requires the June 2026 Gum release or newer. On earlier versions, changing `CurrentLanguage` only affected text assigned _after_ the change — already-displayed text kept its old translation, and the only way to refresh was to recreate the screen.
 {% endhint %}
 
 The refresh walks `Root`, `PopupRoot`, and `ModalRoot` and re-applies the original string ID assigned to each control's `Text`, `Header`, or `Placeholder`. State-driven text (e.g. a `Highlighted` state that sets `Text` to a different string ID) refreshes correctly because the most recently assigned string ID is what gets re-translated.

--- a/docs/code/standard-visuals/shapes-apos.shapes.md
+++ b/docs/code/standard-visuals/shapes-apos.shapes.md
@@ -2,17 +2,26 @@
 
 ## Introduction
 
-GumUI supports rendering vector shapes as visuals. The following shapes are supported.
+GumUI supports rendering vector shapes as visuals. The two primary shape runtimes are:
 
-* ArcRuntime
-* ColoredCircleRuntime
-* RoundedRectangleRuntime
+* `CircleRuntime` — a circle (or ellipse) sized by `Width` and `Height` (or `Radius`).
+* `RectangleRuntime` — a rectangle with an optional uniform or per-corner `CornerRadius`.
 
-## Adding NuGet packages
+Each shape has a **fill** and an **outline (stroke)**. The fill is controlled by `FillColor` (and `IsFilled`); the outline is controlled by `StrokeColor`, `StrokeWidth`, and `StrokeWidthUnits`. On top of fill and outline, shapes can render a gradient, a drop shadow, and a dashed outline.
+
+A third shape, `ArcRuntime`, draws a stroked circular arc. It has no direct `CircleRuntime` / `RectangleRuntime` equivalent and remains a current, supported shape.
+
+{% hint style="info" %}
+The fill + outline `CircleRuntime` / `RectangleRuntime` surface described on this page ships in the June 2026 release. Earlier releases used separate `ColoredCircleRuntime` and `RoundedRectangleRuntime` types (documented further down), which are now obsolete shims.
+{% endhint %}
+
+## Adding Shape Support (Recommended)
+
+On MonoGame, KNI, and FNA, an outlined shape (`StrokeColor`, `StrokeWidth`, `StrokeWidthUnits`) and the geometry properties (`Width`, `Height`, `Radius`, `CornerRadius`) render out of the box with no extra package. The fill and the richer effects require the shape support package for your platform (the `Gum.Shapes.*` package, which uses Apos.Shapes under the hood). We recommend installing it for most projects so that fill, gradient, drop shadow, dashed stroke, and anti-aliasing all draw. Without it, `FillColor` (and the fill channels), gradient (`UseGradient`), drop shadow (`HasDropshadow`), dashed stroke (`StrokeDashLength` / `StrokeGapLength`), anti-aliasing (`IsAntialiased`), and `Blend` are stored and round-trip but silently do not draw — nothing throws.
 
 {% tabs %}
 {% tab title="MonoGame" %}
-The Gum.Shapes.MonoGame NuGet package adds support for rendering shapes. Add the following NuGet package:
+The Gum.Shapes.MonoGame NuGet package adds fill and effect support for shapes. Add the following NuGet package:
 
 [https://www.nuget.org/packages/Gum.Shapes.MonoGame](https://www.nuget.org/packages/Gum.Shapes.MonoGame)
 
@@ -27,12 +36,10 @@ Or add through command line:
 ```bash
 dotnet add package Gum.Shapes.MonoGame
 ```
-
-Future versions of Gum may not require adding this package explicitly.
 {% endtab %}
 
 {% tab title="KNI" %}
-The Gum.Shapes.KNI NuGet package adds support for rendering shapes. Add the following NuGet package:
+The Gum.Shapes.KNI NuGet package adds fill and effect support for shapes. Add the following NuGet package:
 
 [https://www.nuget.org/packages/Gum.Shapes.KNI](https://www.nuget.org/packages/Gum.Shapes.KNI)
 
@@ -48,8 +55,6 @@ Or add through command line:
 dotnet add package Gum.Shapes.KNI
 ```
 
-Future versions of Gum may not require adding this package explicitly.
-
 {% hint style="warning" %}
 Apos.Shapes compiles a shader at compile time which is used by the library to draw shapes. As of January 2026 shader compilation is not supported on Linux for KNI. Therefore, libraries must be compiled on Windows.
 
@@ -57,12 +62,16 @@ For more information, see this issue: [https://github.com/vchelaru/Gum/issues/20
 {% endhint %}
 {% endtab %}
 
+{% tab title="FNA" %}
+There is no shape support NuGet package for FNA. An outlined `Circle` or `Rectangle` renders without any package (`StrokeColor`, `StrokeWidth`, and geometry all work), but fill and the richer effects are currently available on MonoGame and KNI only.
+{% endtab %}
+
 {% tab title=".NET MAUI" %}
-No additional setup is required to use shapes in .NET MAUI
+No additional setup is required to use shapes in .NET MAUI. The full fill, outline, gradient, drop shadow, dashed-stroke, and corner-radius surface is supported natively.
 {% endtab %}
 
 {% tab title="raylib" %}
-No additional setup is required to use shapes on raylib. The equivalent fill, stroke, gradient, dashed-stroke, drop-shadow, and corner-radius features are built into `CircleRuntime`, `RectangleRuntime`, and `PolygonRuntime` natively — no extra NuGet package or initialization is needed. The `ArcRuntime` / `ColoredCircleRuntime` / `RoundedRectangleRuntime` classes described on this page do not exist on raylib; use the equivalent base runtime instead.
+No additional setup is required to use shapes on raylib. The full surface — fill, outline (stroke), gradient, drop shadow, dashed stroke, and corner-radius — is built into `CircleRuntime` and `RectangleRuntime` natively; no extra NuGet package or initialization is needed.
 {% endtab %}
 
 {% tab title="Silk.NET" %}
@@ -73,26 +82,18 @@ No additional setup is required to use shapes in Silk.NET.
 ## Setup in Code
 
 {% tabs %}
-{% tab title="MonoGame / KNI" %}
-Whether you are using code-only or the Gum tool, you must add the following line of code in your Initialize method:
-
-If using December 2025 or earlier:
+{% tab title="MonoGame / KNI / FNA" %}
+Whether you are using code-only or the Gum tool, add the following line of code in your Initialize method, after `GumUI.Initialize(...)`:
 
 ```csharp
 // Initialize
 GumUI.Initialize(...);
-// Initialize ShapeRenderer after GumUI:
-ShapeRenderer.Self.Initialize(GraphicsDevice, Content);
-```
-
-If using January 2026 or later:
-
-```csharp
-// Initialize
-GumUI.Initialize(...);
-// Initialize ShapeRenderer after GumUI:
 ShapeRenderer.Self.Initialize();
 ```
+
+{% hint style="info" %}
+**December 2025 and earlier** used a different signature that took the graphics device and content manager: `ShapeRenderer.Self.Initialize(GraphicsDevice, Content);`. From January 2026 on, the parameterless `Initialize()` is the form to use.
+{% endhint %}
 {% endtab %}
 
 {% tab title=".NET MAUI" %}
@@ -100,7 +101,7 @@ No additional setup is needed if you have already added SkiaSharp and Gum to you
 {% endtab %}
 
 {% tab title="raylib" %}
-No additional setup is required. The equivalent shape features are built into `CircleRuntime`, `RectangleRuntime`, and `PolygonRuntime` — see those pages for their full property surface. The `ArcRuntime` / `ColoredCircleRuntime` / `RoundedRectangleRuntime` classes do not exist on raylib; use the equivalent base runtime instead.
+No additional setup is required. The full surface — fill, outline (stroke), gradient, drop shadow, dashed stroke, and corner-radius — is built into `CircleRuntime` and `RectangleRuntime` natively — see those pages for their full property surface.
 {% endtab %}
 
 {% tab title="Silk.NET" %}
@@ -129,23 +130,22 @@ public class Game1 : Game
     protected override void Initialize()
     {
         GumUI.Initialize(this);
-        // Initialize shape renderer:
-        Renderables.ShapeRenderer.Self.Initialize(GraphicsDevice, Content);
+        // Initialize shape renderer after GumUI:
+        ShapeRenderer.Self.Initialize();
 
-        GumUI.Draw();
-
-        var circle = new ColoredCircleRuntime();
+        var circle = new CircleRuntime();
         circle.AddToRoot();
-        circle.Color = Color.Red;
+        circle.Radius = 50;
+        circle.FillColor = Color.Red;
 
-        var rectangle = new RoundedRectangleRuntime();
+        var rectangle = new RectangleRuntime();
         rectangle.AddToRoot();
         rectangle.X = 100;
         rectangle.CornerRadius = 15;
+        rectangle.FillColor = Color.White; // light the fill up so the gradient draws
         rectangle.UseGradient = true;
         rectangle.Color1 = Color.Blue;
         rectangle.Color2 = Color.Green;
-        base.Initialize();
 
         var arc = new ArcRuntime();
         arc.AddToRoot();
@@ -154,6 +154,8 @@ public class Game1 : Game
         arc.Thickness = 20;
         arc.StartAngle = 0;
         arc.SweepAngle = 270;
+
+        base.Initialize();
     }
 
     protected override void Update(GameTime gameTime)
@@ -173,13 +175,31 @@ public class Game1 : Game
 
 <figure><img src="../../.gitbook/assets/06_05 57 11.png" alt=""><figcaption><p>Shapes rendered in an otherwise empty project</p></figcaption></figure>
 
-## Properties
+## CircleRuntime and RectangleRuntime
 
-All three shapes — `ArcRuntime`, `ColoredCircleRuntime`, and `RoundedRectangleRuntime` — derive from `AposShapeRuntime` and therefore share a common set of properties for color, gradient, drop shadow, and fill/stroke. Each shape additionally exposes a small number of properties unique to its geometry.
+`CircleRuntime` and `RectangleRuntime` are the current shape runtimes. Each has a **fill** and an **outline (stroke)**, plus optional gradient, drop shadow, and dashed-outline effects.
+
+* **Fill** — `FillColor` sets the fill color; `FillRed` / `FillGreen` / `FillBlue` / `FillAlpha` set individual channels (0–255). `IsFilled = false` hides the fill. By default `FillColor` is transparent, so a freshly-constructed shape renders as an outline only — assign a visible `FillColor` to light up the fill.
+* **Outline (stroke)** — `StrokeColor` sets the outline color (with `StrokeRed` / `StrokeGreen` / `StrokeBlue` / `StrokeAlpha` channels); `StrokeWidth` controls thickness and `StrokeWidthUnits` controls how that thickness is interpreted. `StrokeWidth = 0` hides the outline.
+* **Geometry** — `CircleRuntime` is sized by `Width` / `Height` (or `Radius`); `RectangleRuntime` is sized by `Width` / `Height` with an optional uniform or per-corner `CornerRadius`.
+
+The gradient, drop shadow, and dashed-outline properties match the names in the tables below.
+
+{% hint style="info" %}
+On MonoGame, KNI, and FNA the outline and geometry render without the shapes package, but the fill and effects (gradient, drop shadow, dashed stroke, anti-aliasing, `Blend`) only draw once the `Gum.Shapes.<platform>` package is added — otherwise they are silent no-ops. Skia, .NET MAUI, and raylib support the full surface natively.
+{% endhint %}
+
+## Obsolete shape runtimes
+
+{% hint style="info" %}
+**`ColoredCircleRuntime`, `RoundedRectangleRuntime`, `ColoredRectangleRuntime`, and `SolidRectangleRuntime` are obsolete shims being phased out.** Use `CircleRuntime` (for `ColoredCircleRuntime`) and `RectangleRuntime` (for the rectangle variants, with `CornerRadius` covering `RoundedRectangleRuntime`) instead. For the property mapping and the automated code fix, see [Migrating to 2026 June](../../gum-tool/upgrading/migrating-to-2026-june.md). `ArcRuntime` is **not** obsolete — it has no `CircleRuntime` / `RectangleRuntime` equivalent and remains the way to draw a circular arc.
+{% endhint %}
+
+The property tables below document the shared surface of the obsolete shims and `ArcRuntime`, which derive from `AposShapeRuntime`. The equivalent fill and outline properties on `CircleRuntime` / `RectangleRuntime` are described above.
 
 ### Common Properties
 
-These properties are available on every shape.
+These properties are available on every shape that derives from `AposShapeRuntime` (the obsolete shims and `ArcRuntime`).
 
 #### Solid Color
 
@@ -287,7 +307,7 @@ leaf.CustomRadiusBottomLeft  = 12f;
 // leaf.CustomRadiusTopLeft = null;
 ```
 
-Per-corner radii require Apos.Shapes 0.6.9 or later (which Gum.Shapes.MonoGame / Gum.Shapes.KNI depend on as of this release). The Skia backend has supported the same properties for longer.
+Per-corner radii require Apos.Shapes 0.6.9 or later (which `Gum.Shapes.MonoGame` / `Gum.Shapes.KNI` depend on as of this release). The Skia backend has supported the same properties for longer.
 
 The Gum tool's variable grid does not yet expose the four `CustomRadius*` variables — only `CornerRadius`. To use per-corner radii today, set the properties in code on the runtime instance after the visual is created. Tool-side parity is tracked in [issue #2720](https://github.com/vchelaru/Gum/issues/2720).
 

--- a/docs/code/visual-tree/finding-elements.md
+++ b/docs/code/visual-tree/finding-elements.md
@@ -92,7 +92,7 @@ FrameworkElement anyControl = screenRoot.FindFormsControlByName("OkButton")!;
 This is the cross-layer counterpart to `FindVisual<T>` on `FrameworkElement` — one goes visual → Forms, the other goes Forms → visual.
 
 {% hint style="warning" %}
-`FindFormsControl<T>`, `FindFormsControl<T>(name)`, and `FindFormsControlByName(name)` are available starting in the 2026 May release.
+`FindFormsControl<T>`, `FindFormsControl<T>(name)`, and `FindFormsControlByName(name)` are available starting in the 2026 June release.
 {% endhint %}
 
 ## Ordering

--- a/docs/gum-tool/project-properties.md
+++ b/docs/gum-tool/project-properties.md
@@ -82,7 +82,7 @@ The Font Generator project property controls which tool Gum uses to bake `.fnt` 
 You can change the setting at any time in **Project Properties**. The next FontCache rebuild uses the chosen generator.
 
 {% hint style="info" %}
-**As of May 2026:** New projects default to **KernSmith**. Before this, the default was **BMFont**. Existing projects keep their current setting — opening an older project in a newer version of the Gum tool does not switch its generator, and there is no auto-migration.
+**As of June 2026:** New projects default to **KernSmith**. Before this, the default was **BMFont**. Existing projects keep their current setting — opening an older project in a newer version of the Gum tool does not switch its generator, and there is no auto-migration.
 {% endhint %}
 
 {% hint style="warning" %}

--- a/docs/gum-tool/upgrading/migrating-to-2026-april.md
+++ b/docs/gum-tool/upgrading/migrating-to-2026-april.md
@@ -25,7 +25,7 @@ Run the upgrade `gum upgrade` or `~/bin/gum upgrade`
 
 ## Upgrading Runtime
 
-Upgrade your Gum NuGet packages to version **2026.5.2.1**. For more information, see the NuGet packages for your particular platform:
+Upgrade your Gum NuGet packages to version **2026.4.2.1**. For more information, see the NuGet packages for your particular platform:
 
 * MonoGame - [https://www.nuget.org/packages/Gum.MonoGame/](https://www.nuget.org/packages/Gum.MonoGame/)
 * KNI - [https://www.nuget.org/packages/Gum.KNI/](https://www.nuget.org/packages/Gum.KNI/)

--- a/docs/gum-tool/upgrading/migrating-to-2026-june.md
+++ b/docs/gum-tool/upgrading/migrating-to-2026-june.md
@@ -1,11 +1,11 @@
-# Migrating to 2026 May
+# Migrating to 2026 June
 
 ## Introduction
 
-This page discusses breaking changes and other considerations when migrating from `2026 April` to `2026 May`.
+This page discusses breaking changes and other considerations when migrating from `2026 April` to `2026 June`.
 
 {% hint style="warning" %}
-The `2026 May` version of Gum has not yet been released. This page is a work in progress and will be updated when the release is published. In the meantime, if you want to use the changes described below, you will need to build Gum from source.
+The `2026 June` version of Gum has not yet been released. This page is a work in progress and will be updated when the release is published. In the meantime, if you want to use the changes described below, you will need to build Gum from source.
 {% endhint %}
 
 ## Upgrading Gum Tool
@@ -28,7 +28,7 @@ Run the upgrade `gum upgrade` or `~/bin/gum upgrade`
 
 ## Upgrading Runtime
 
-The `2026.5` NuGet packages have not yet been published. Once released, upgrade your Gum NuGet packages to the new version. For more information, see the NuGet packages for your particular platform:
+The `2026.6` NuGet packages have not yet been published. Once released, upgrade your Gum NuGet packages to the new version. For more information, see the NuGet packages for your particular platform:
 
 * MonoGame - [https://www.nuget.org/packages/Gum.MonoGame/](https://www.nuget.org/packages/Gum.MonoGame/)
 * KNI - [https://www.nuget.org/packages/Gum.KNI/](https://www.nuget.org/packages/Gum.KNI/)
@@ -68,7 +68,7 @@ using Gum.GueDeriving;
 
 The `Gum.Analyzers` package ships a one-click code fix for `using` directives — place the cursor on the warning, trigger the lightbulb (Ctrl+.), and choose **Change to 'using Gum.GueDeriving'**. Use **Fix all in solution** to migrate the entire project at once.
 
-The compatibility shims will remain in place until at least the November 2026 release. After that window, they will be marked `[Obsolete(error: true)]` in a subsequent release, breaking compilation for any code still using them.
+The compatibility shims will remain in place until at least the December 2026 release. After that window, they will be marked `[Obsolete(error: true)]` in a subsequent release, breaking compilation for any code still using them.
 
 For full details, including handling of fully-qualified references and a `RenderingLibrary` namespace-shadowing gotcha, see [Syntax Version 1](syntax-version-1.md).
 
@@ -156,7 +156,7 @@ error CS0121: The call is ambiguous between the following methods or properties:
 
 If you see `CS0121` on a call like `textBox.AddToRoot();`, add `using Gum.Forms.Controls;` to the file if it isn't already there. No call-site changes are needed.
 
-❌ Old (compiles in April 2026, ambiguous in May 2026 once `Gum.Forms.Controls` is also in scope):
+❌ Old (compiles in April 2026, ambiguous in June 2026 once `Gum.Forms.Controls` is also in scope):
 
 ```csharp
 using MonoGameGum;
@@ -267,11 +267,13 @@ Other defaults preserved (no migration needed, listed for reference):
 - `IsFilled` still defaults to `false`, `StrokeWidth` still defaults to `1` with `StrokeWidthUnits = ScreenPixel`.
 - Dropshadow defaults (`DropshadowAlpha = 255`, `DropshadowOffsetY = 3`, `DropshadowBlur = 3`) are still seeded; inert until `HasDropshadow` is set to `true`. (Note: the plain `CircleRuntime` / `RectangleRuntime` expose a single isotropic `DropshadowBlur` — the older per-axis `DropshadowBlurX` / `DropshadowBlurY` properties only exist on the obsolete `ColoredCircleRuntime` / `RoundedRectangleRuntime` / `SkiaShapeRuntime` Skia surface.)
 
-Gradients, dropshadow, and dashed strokes remain Skia-only — those features have no equivalent on the XNA-likes / Raylib backends and stay gated behind `#if SKIA` in the shared source.
+These richer effects — gradient, drop shadow, and dashed strokes — are built in natively on Skia and raylib. On MonoGame and KNI they are provided by the shape support package (`Gum.Shapes.MonoGame` / `Gum.Shapes.KNI`); FNA renders the outline only. See the [Shapes](../../code/standard-visuals/shapes-apos.shapes.md) page for the per-platform matrix.
 
 ### Shape runtime shims obsolete: `ColoredCircleRuntime`, `ColoredRectangleRuntime`, `SolidRectangleRuntime`, `RoundedRectangleRuntime`
 
-`CircleRuntime` and `RectangleRuntime` now cover the full fill + stroke + corner-radius surface on every backend (MonoGame, FNA, KNI, Raylib, Skia, and Apos.Shapes) via a two-slot composition model — one renderable for the fill, a second parented under it for the stroke. With that consolidation in place, the older shape runtime types that wrapped a single renderable each are now `[Obsolete]` and will be removed in a future release.
+`CircleRuntime` and `RectangleRuntime` now cover the full fill + outline (stroke) + corner-radius surface on every backend (MonoGame, FNA, KNI, Raylib, Skia). With that consolidation in place, the older shape runtime types are now `[Obsolete]` and will be removed in a future release.
+
+On MonoGame, FNA, and KNI, the outline (`StrokeColor`, `StrokeWidth`, `StrokeWidthUnits`) renders out of the box, but the fill and the richer effects (`FillColor`, gradient, drop shadow, dashed stroke, anti-aliasing) require the shape support package. This package ships for MonoGame (`Gum.Shapes.MonoGame`) and KNI (`Gum.Shapes.KNI`) only; FNA has no shape support package, so on FNA only the outline renders. Without the package those properties round-trip but silently do not draw. On Skia and raylib the full surface is supported natively. See the [Shapes](../../code/standard-visuals/shapes-apos.shapes.md) page for the per-platform details.
 
 Existing code continues to compile, but each reference now produces a `CS0618` compiler warning. The replacement types live alongside the obsolete ones in `Gum.GueDeriving`, so the only change at most call sites is the type name (and the property name, per the mapping below).
 
@@ -285,11 +287,11 @@ The obsoleted types and their replacements:
 | `RoundedRectangleRuntime` (Apos + Skia) | `RectangleRuntime` + `CornerRadius` | `Red` / `Green` / `Blue` → `FillColor`; existing `CornerRadius` maps 1:1 |
 
 {% hint style="info" %}
-**`ColoredCircleRuntime.Color` is a passthrough — the rendered slot depends on `IsFilled`.** The Apos constructor defaults `IsFilled = true`, so `Color` paints the **fill** in the common case. If your code sets `IsFilled = false` (outline-only circle), migrate `Color` to `StrokeColor` instead. If the circle is both filled and outlined, set `FillColor` and `StrokeColor` explicitly on the new `CircleRuntime`.
+**`ColoredCircleRuntime.Color` is a passthrough — what it paints depends on `IsFilled`.** The Apos constructor defaults `IsFilled = true`, so `Color` paints the **fill** in the common case. If your code sets `IsFilled = false` (outline-only circle), migrate `Color` to `StrokeColor` instead. If the circle is both filled and outlined, set `FillColor` and `StrokeColor` explicitly on the new `CircleRuntime`.
 {% endhint %}
 
 {% hint style="warning" %}
-**`CircleRuntime` ships with a default 1 px white outline.** `ColoredCircleRuntime` had no stroke slot, so a freshly-constructed `ColoredCircleRuntime` with only `Color` set rendered as a solid disc with no outline. `CircleRuntime` (#2790 two-slot model) defaults to `StrokeColor = White` so cells that only set `FillColor` still get a visible outline — which means a literal `new CircleRuntime { FillColor = Color.Red }` renders as a red disc surrounded by a thin white ring. If you want the old solid-disc visual, suppress the outline explicitly:
+**`CircleRuntime` ships with a default 1 px white outline.** `ColoredCircleRuntime` had no outline, so a freshly-constructed `ColoredCircleRuntime` with only `Color` set rendered as a solid disc with no outline. `CircleRuntime` defaults to `StrokeColor = White` so cells that only set `FillColor` still get a visible outline — which means a literal `new CircleRuntime { FillColor = Color.Red }` renders as a red disc surrounded by a thin white ring. If you want the old solid-disc visual, suppress the outline explicitly:
 
 ```csharp
 CircleRuntime circle = new();
@@ -302,9 +304,9 @@ The same caveat applies anywhere you migrate a fill-only `ColoredCircleRuntime` 
 
 ### Breaking: `FillColor` / `StrokeColor` are now non-nullable
 
-Earlier in this same unreleased cycle (issue #2790 / #2814) `CircleRuntime` and `RectangleRuntime` briefly exposed `FillColor` and `StrokeColor` as nullable (`Color?` on XNA-likes / Raylib, `SKColor?` on Skia), with `null` meaning "hide this slot." Issue #2938 walks that back: the properties are non-nullable again, and visibility is gated by orthogonal knobs:
+Earlier in this same unreleased cycle (issue #2790 / #2814) `CircleRuntime` and `RectangleRuntime` briefly exposed `FillColor` and `StrokeColor` as nullable (`Color?` on XNA-likes / Raylib, `SKColor?` on Skia), with `null` meaning "hide the fill / outline." Issue #2938 walks that back: the properties are non-nullable again, and visibility is gated by orthogonal knobs:
 
-- **Hide fill** — set `IsFilled = false` (mirrors the Skia renderable's existing `IsFilled` toggle and survives round-tripping the color value).
+- **Hide fill** — set `IsFilled = false` (survives round-tripping the color value).
 - **Hide stroke** — set `StrokeWidth = 0` (a zero-width stroke is already a no-op in every backend, so this expresses intent without a separate flag).
 
 **Default visual is unchanged:** a freshly-constructed `CircleRuntime` / `RectangleRuntime` still renders as a stroke-only outline, preserving the pre-#2938 visual that existing sample code assumes ("construct + only set `StrokeColor`"). This is achieved by defaulting `FillColor` to transparent (alpha 0) while leaving `IsFilled = true`. Assigning `FillColor` to a visible color lights up the fill without flipping `IsFilled` — so existing code like `frame.FillColor = darkGray;` continues to work.
@@ -328,7 +330,7 @@ circle.IsFilled = false;    // hide the fill
 circle.StrokeWidth = 0;     // hide the stroke
 ```
 
-This is a breaking change relative to the nullable form, but only against code written against an unreleased prerelease. Released callers were on the legacy single-slot `Color` API and are unaffected.
+This is a breaking change relative to the nullable form, but only against code written against an unreleased prerelease. Released callers were on the legacy single-`Color` API and are unaffected.
 
 ❌ Old:
 
@@ -367,13 +369,13 @@ rounded.CornerRadius = 8;
 
 The `Gum.Analyzers` package ships an automated code fix (`GUM002`) — place the cursor on the warning, trigger the lightbulb (Ctrl+.), and choose **Replace '`ColoredCircleRuntime`' with '`CircleRuntime`'** (or the matching `RectangleRuntime` fix for the rectangle variants). The fix also renames `.Color` accesses on rewritten instances: `ColoredCircleRuntime.Color` → `CircleRuntime.StrokeColor` (matching the legacy outline-painting semantic), and `ColoredRectangleRuntime.Color` / `SolidRectangleRuntime.Color` → `RectangleRuntime.FillColor`. `RoundedRectangleRuntime` rewrites to `RectangleRuntime` with `CornerRadius` carried over unchanged. Use **Fix all in solution** to migrate the entire project at once.
 
-The obsolete types will remain in place until at least the November 2026 release. After that window, they may be marked `[Obsolete(error: true)]` in a subsequent release, breaking compilation for any code still using them.
+The obsolete types will remain in place until at least the December 2026 release. After that window, they may be marked `[Obsolete(error: true)]` in a subsequent release, breaking compilation for any code still using them.
 
-### Breaking: `UseGradient` no longer paints over a transparent fill slot
+### Breaking: `UseGradient` no longer paints over a transparent fill
 
-Issue #2956 — `UseGradient` is a *pattern* flag, not a *visibility* flag. A slot whose effective color alpha is 0 (e.g. the default-transparent fill on a stroke-only plain `CircleRuntime` / `RectangleRuntime`) no longer paints its gradient. This brings the Apos.Shapes (MonoGame/FNA/KNI) and raylib backends in line with the SkiaGum backend, which has always enforced this naturally — `SKPaint.Color.alpha` modulates the shader output, so a transparent paint color suppresses the gradient.
+Issue #2956 — `UseGradient` is a *pattern* flag, not a *visibility* flag. A fill or outline whose effective color alpha is 0 (e.g. the default-transparent fill on a stroke-only plain `CircleRuntime` / `RectangleRuntime`) no longer paints its gradient. This brings the Apos.Shapes (MonoGame/FNA/KNI) and raylib backends in line with the SkiaGum backend, which has always enforced this naturally — `SKPaint.Color.alpha` modulates the shader output, so a transparent paint color suppresses the gradient.
 
-Before the fix, the same code rendered differently across backends: Apos and raylib painted an opaque gradient on a fill slot the user had explicitly hidden via the documented default; Skia correctly suppressed it. After the fix, all three backends agree.
+Before the fix, the same code rendered differently across backends: Apos and raylib painted an opaque gradient on a fill the user had explicitly hidden via the documented default; Skia correctly suppressed it. After the fix, all three backends agree.
 
 ❌ Old (worked accidentally on Apos / raylib, silent no-op on Skia):
 
@@ -392,13 +394,13 @@ circle.Color2 = Color.White;
 ```csharp
 var circle = new CircleRuntime();
 circle.Radius = 28;
-circle.FillColor = Color.White;   // light the fill slot up — opaque, RGB irrelevant
+circle.FillColor = Color.White;   // light the fill up — opaque, RGB irrelevant
 circle.UseGradient = true;
 circle.Color1 = Color.Black;
 circle.Color2 = Color.White;
 ```
 
-The RGB of `FillColor` doesn't matter — the gradient overrides the per-pixel color. Only the alpha gates whether the slot paints at all. `StrokeColor` works the same way for the stroke slot on backends that support gradient-on-stroke (Skia + Apos two-slot; raylib's stroke is solid only).
+The RGB of `FillColor` doesn't matter — the gradient overrides the per-pixel color. Only the alpha gates whether the fill paints at all. `StrokeColor` works the same way for the outline on backends that support gradient-on-stroke (Skia and Apos.Shapes; raylib's outline is solid only).
 
 ### Forms controls moved to GumCommon — input types widened
 

--- a/docs/gum-tool/upgrading/syntax-version-1.md
+++ b/docs/gum-tool/upgrading/syntax-version-1.md
@@ -41,7 +41,7 @@ If auto-detection fails, you can pin a version manually by setting the `SyntaxVe
 
 ## Deprecation Timeline
 
-The compatibility shims will remain in place **until at least the November 2026 release** (six months after this change shipped in May 2026). After that window, the shim namespaces will be marked `[Obsolete(error: true)]` in a subsequent release, breaking compilation for any code still using them. The exact removal date will be announced in the corresponding monthly migration page.
+The compatibility shims will remain in place **until at least the December 2026 release** (six months after this change shipped in June 2026). After that window, the shim namespaces will be marked `[Obsolete(error: true)]` in a subsequent release, breaking compilation for any code still using them. The exact removal date will be announced in the corresponding monthly migration page.
 
 ## Before / After
 

--- a/docs/gum-tool/upgrading/syntax-versions.md
+++ b/docs/gum-tool/upgrading/syntax-versions.md
@@ -21,8 +21,8 @@ The detected version is displayed in the Code tab under "Project-Wide Code Gener
 | Version | Introduced | Changes |
 |---|---|---|
 | 0 | 2026.4.x | Baseline. Attribute system introduced. No breaking changes from prior releases. All existing namespace conventions are preserved. |
-| 1 | 2026.5.x | Runtime class namespace unification (non-breaking). Runtime classes like `TextRuntime`, `SpriteRuntime`, etc. move to the unified `Gum.GueDeriving` namespace. Old namespaces (`MonoGameGum.GueDeriving`, `SkiaGum.GueDeriving`) continue to work via compatibility shims marked `[Obsolete]`. See [Syntax Version 1](syntax-version-1.md) for details. |
-| 2 | 2026.5.x | Shape runtime collapse. `ColoredCircleRuntime`, `ColoredRectangleRuntime`, and `RoundedRectangleRuntime` are collapsed into `CircleRuntime` and `RectangleRuntime`, which now expose `FillColor`, `StrokeColor`, and `StrokeWidth` (and `CornerRadius` on `RectangleRuntime`). See PR #2769 / issue #2768. |
+| 1 | 2026.6.x | Runtime class namespace unification (non-breaking). Runtime classes like `TextRuntime`, `SpriteRuntime`, etc. move to the unified `Gum.GueDeriving` namespace. Old namespaces (`MonoGameGum.GueDeriving`, `SkiaGum.GueDeriving`) continue to work via compatibility shims marked `[Obsolete]`. See [Syntax Version 1](syntax-version-1.md) for details. |
+| 2 | 2026.6.x | Shape runtime collapse. `ColoredCircleRuntime`, `ColoredRectangleRuntime`, and `RoundedRectangleRuntime` are collapsed into `CircleRuntime` and `RectangleRuntime`, which now expose `FillColor`, `StrokeColor`, and `StrokeWidth` (and `CornerRadius` on `RectangleRuntime`). See PR #2769 / issue #2768. |
 | 3 | TBD | Layout enum namespace unification (breaking). Enums like `DimensionUnitType`, `ChildrenLayout`, `HorizontalAlignment`, etc. move to a unified namespace. The bundled Roslyn analyzer provides one-click migration. |
 
 When a new syntax version is introduced, the corresponding monthly migration page will document the specific changes. See the [runtime refactoring plan](../../contributing/runtime-refactoring.md) for full details.


### PR DESCRIPTION
## What

Documents the current `CircleRuntime` / `RectangleRuntime` **fill + outline** shape surface (shipping in the June 2026 release) and relabels the skipped **May 2026** release to **June 2026** across the docs.

### Shape support docs
- **Setup (`adding-initializing-gum/monogame-kni-fna`)** — new **"Adding Shape Support (Recommended)"** section: the `Gum.Shapes.*` package + the single `ShapeRenderer.Self.Initialize();` line. Apos.Shapes is treated as an implementation detail, not the headline.
- **`shapes-apos.shapes.md`** — full reframe onto `CircleRuntime` / `RectangleRuntime` (fill + outline, plain language). The legacy shims (`ColoredCircleRuntime`, `RoundedRectangleRuntime`, `ColoredRectangleRuntime`, `SolidRectangleRuntime`) are kept but flagged as obsolete/going-away; `ArcRuntime` is carved out as still current.
- Accurate per-platform / per-property story:
  - **MonoGame / KNI** — outline + geometry render with no package; fill, gradient, drop shadow, dashed stroke, anti-aliasing need the `Gum.Shapes.{MonoGame,KNI}` package (silent no-op without it, nothing throws).
  - **FNA** — no shapes package exists; outline-only.
  - **Skia, .NET MAUI, raylib** — full surface natively.

### May → June relabel
- Renamed `migrating-to-2026-may.md` → `migrating-to-2026-june.md` (+ `SUMMARY.md` entry).
- Swept remaining "May 2026" references: `project-properties.md`, `finding-elements.md`, `localization.md`, `syntax-version-1.md`.
- `syntax-versions.md`: `2026.5.x` → `2026.6.x` for syntax versions 1 and 2.
- Recomputed the shim-removal window: May + 6 mo = Nov → **June + 6 mo = Dec 2026**.
- Fixed a version typo in the April migration doc: `2026.5.2.1` → `2026.4.2.1`.

## Notes
- No linked issue.
- Sibling pages `circleruntime.md` / `rectangleruntime.md` still describe the old `.Color` single-pixel API and contradict this reframe — tracked as a separate follow-up (intentionally out of scope here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)