### PR TITLE
#2989: Single-prompt Expose for the color swatch

### DIFF
--- a/Gum/Dialogs/ExposeColorDialogView.xaml
+++ b/Gum/Dialogs/ExposeColorDialogView.xaml
@@ -1,0 +1,44 @@
+<UserControl
+    x:Class="Gum.Dialogs.ExposeColorDialogView"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:dialogs="clr-namespace:Gum.Services.Dialogs"
+    xmlns:local="clr-namespace:Gum.Dialogs"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    Width="450"
+    d:DataContext="{d:DesignInstance Type={x:Type local:ExposeColorDialogViewModel},
+                                     IsDesignTimeCreatable=False}"
+    dialogs:Dialog.DialogTitle="Expose Color"
+    mc:Ignorable="d">
+    <StackPanel>
+        <TextBlock Text="{Binding Message}" TextWrapping="Wrap" />
+        <TextBox
+            x:Name="BaseNameTextBox"
+            Margin="0,8,0,0"
+            Text="{Binding BaseName, UpdateSourceTrigger=PropertyChanged}" />
+        <TextBlock
+            Margin="0,12,0,2"
+            Style="{StaticResource Frb.Styles.TextBlock.Caption}"
+            Text="Variables to create:" />
+        <ItemsControl Margin="8,0,0,0" ItemsSource="{Binding ExposedNames}">
+            <ItemsControl.ItemTemplate>
+                <DataTemplate>
+                    <TextBlock FontWeight="Bold" Text="{Binding}" />
+                </DataTemplate>
+            </ItemsControl.ItemTemplate>
+        </ItemsControl>
+        <!--
+            The error TextBlock is always laid out (no collapse) with a MinHeight, so the window's initial
+            size-to-content already reserves room for a validation message. Without this, the error appears
+            after the window has locked to Manual sizing and the content gets a scrollbar instead.
+        -->
+        <TextBlock
+            MinHeight="32"
+            Margin="0,10,0,0"
+            Foreground="{StaticResource Frb.Brushes.Error}"
+            Style="{StaticResource Frb.Styles.TextBlock.Caption}"
+            Text="{Binding Error}"
+            TextWrapping="Wrap" />
+    </StackPanel>
+</UserControl>

--- a/Gum/Dialogs/ExposeColorDialogView.xaml.cs
+++ b/Gum/Dialogs/ExposeColorDialogView.xaml.cs
@@ -1,0 +1,16 @@
+using System.Windows.Controls;
+
+namespace Gum.Dialogs;
+
+public partial class ExposeColorDialogView : UserControl
+{
+    public ExposeColorDialogView()
+    {
+        InitializeComponent();
+        Loaded += (_, _) =>
+        {
+            BaseNameTextBox.Focus();
+            BaseNameTextBox.SelectAll();
+        };
+    }
+}

--- a/Gum/Dialogs/ExposeColorDialogViewModel.cs
+++ b/Gum/Dialogs/ExposeColorDialogViewModel.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Gum.Mvvm;
+using Gum.Services.Dialogs;
+
+namespace Gum.Dialogs;
+
+/// <summary>
+/// Backs the single-prompt "Expose color" dialog. The user edits one base name; each channel is exposed as
+/// <c>BaseName + channelRootName</c>, and the resulting names update live as a preview (<see cref="ExposedNames"/>).
+/// An empty base name is allowed and exposes the channels under their raw root names (e.g.
+/// FillRed/FillGreen/FillBlue), which is how a user gets unprefixed exposed variables.
+/// </summary>
+public class ExposeColorDialogViewModel : DialogViewModel
+{
+    private readonly IReadOnlyList<string> _channelRootNames;
+    private readonly Func<string, string?> _validateExposedName;
+
+    public string? Message { get => Get<string>(); set => Set(value); }
+
+    public string? BaseName { get => Get<string>(); set => Set(value); }
+
+    /// <summary>
+    /// The exposed name for each channel, in channel order, derived as <c>BaseName + channelRootName</c>. Shown
+    /// in the dialog as a live preview and read by the caller to perform the exposure.
+    /// </summary>
+    [DependsOn(nameof(BaseName))]
+    public IReadOnlyList<string> ExposedNames =>
+        _channelRootNames.Select(rootName => (BaseName ?? "") + rootName).ToList();
+
+    [DependsOn(nameof(BaseName))]
+    public string? Error
+    {
+        get
+        {
+            foreach (string exposedName in ExposedNames)
+            {
+                if (_validateExposedName(exposedName) is { } whyNot)
+                {
+                    return whyNot;
+                }
+            }
+            return null;
+        }
+    }
+
+    public ExposeColorDialogViewModel(
+        string defaultBaseName,
+        IReadOnlyList<string> channelRootNames,
+        Func<string, string?> validateExposedName)
+    {
+        _channelRootNames = channelRootNames;
+        _validateExposedName = validateExposedName;
+
+        AffirmativeText = "OK";
+        NegativeText = "Cancel";
+        Message = "Enter a base name for the exposed variables. Leave blank to expose them under their existing channel names.";
+
+        PropertyChanged += (_, e) =>
+        {
+            if (e.PropertyName == nameof(Error))
+            {
+                AffirmativeCommand.NotifyCanExecuteChanged();
+            }
+        };
+
+        BaseName = defaultBaseName;
+    }
+
+    public override bool CanExecuteAffirmative() => Error is null;
+}

--- a/Gum/Plugins/InternalPlugins/VariableGrid/CompositeMemberLogic.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/CompositeMemberLogic.cs
@@ -1,6 +1,7 @@
 using Gum.Commands;
 using Gum.DataTypes;
 using Gum.DataTypes.Variables;
+using Gum.Dialogs;
 using Gum.Managers;
 using Gum.Services;
 using Gum.Services.Dialogs;
@@ -250,39 +251,37 @@ public class CompositeMemberLogic
         }
         //////////////////////End Early Out/////////////////////
 
-        // Single prompt for one base name; each channel is exposed as base + channelRootName. Suffixing the
-        // full root name (e.g. "StrokeRed", not just "Red") reproduces the historical per-channel default and
-        // keeps affixed colors (Stroke/Fill/gradient) from colliding.
-        string message = $"Enter a base name. Channels {string.Join(", ", channelRootNames)} will be appended:";
-        string title = "Expose color";
+        // One prompt for a base name; each channel is exposed as base + channelRootName, previewed live in the
+        // dialog. An empty base exposes the raw root names (e.g. FillRed/FillGreen/FillBlue). Suffixing the full
+        // root name reproduces the historical per-channel default and keeps affixed colors (Stroke/Fill/gradient)
+        // from colliding. The dialog owns the name derivation (ExposedNames); we read it back here.
+        ExposeColorDialogViewModel dialogViewModel = new(
+            defaultBaseName: instance.Name,
+            channelRootNames: channelRootNames,
+            validateExposedName: (exposedName) => ValidateExposedName(exposedName, element));
 
-        GetUserStringOptions options = new()
-        {
-            InitialValue = instance.Name,
-            Validator = (baseName) => ValidateBaseName(baseName, channelRootNames, element),
-        };
-
-        if (_dialogService.GetUserString(message, title, options) is not { } enteredBaseName)
+        if (!_dialogService.Show(dialogViewModel))
         {
             // User cancelled: expose nothing.
             return;
         }
+
+        IReadOnlyList<string> exposedNames = dialogViewModel.ExposedNames;
 
         using IDisposable undoLock = _undoManager.RequestLock();
 
         List<VariableSave> toRevert = new();
         bool shouldRevert = false;
 
-        foreach (string rootName in channelRootNames)
+        for (int i = 0; i < channelRootNames.Count; i++)
         {
             if (shouldRevert)
             {
                 break;
             }
 
-            string exposedName = enteredBaseName + rootName;
             OptionallyAttemptedGeneralResponse<VariableSave> response =
-                _exposeVariableService.ExposeVariable(instance, rootName, exposedName);
+                _exposeVariableService.ExposeVariable(instance, channelRootNames[i], exposedNames[i]);
 
             if (response.DidAttempt && response.Succeeded == false)
             {
@@ -304,20 +303,13 @@ public class CompositeMemberLogic
     }
 
     /// <summary>
-    /// Validates the single base name by checking every derived channel name (base + root name). Returns the
-    /// first failure reason, or null if all derived names are valid.
+    /// Validates a single exposed channel name against the element. Returns the failure reason, or null if valid.
     /// </summary>
-    private string? ValidateBaseName(string? baseName, IReadOnlyList<string> channelRootNames, ElementSave element)
+    private string? ValidateExposedName(string exposedName, ElementSave element)
     {
-        foreach (string rootName in channelRootNames)
-        {
-            string derivedName = (baseName ?? "") + rootName;
-            if (!_nameVerifier.IsVariableNameValid(derivedName, element, null!, out string? whyNot))
-            {
-                return whyNot;
-            }
-        }
-        return null;
+        return _nameVerifier.IsVariableNameValid(exposedName, element, null!, out string? whyNot)
+            ? null
+            : whyNot;
     }
 
     private bool IsChannelExposed(string channelRootName, ElementSave element, InstanceSave? instance)

--- a/Gum/Plugins/InternalPlugins/VariableGrid/CompositeMemberLogic.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/CompositeMemberLogic.cs
@@ -3,6 +3,7 @@ using Gum.DataTypes;
 using Gum.DataTypes.Variables;
 using Gum.Managers;
 using Gum.Services;
+using Gum.Services.Dialogs;
 using Gum.ToolStates;
 using Gum.Undo;
 using System;
@@ -27,6 +28,8 @@ public class CompositeMemberLogic
     private readonly IGuiCommands _guiCommands;
     private readonly ObjectFinder _objectFinder;
     private readonly ICompositeMemberRegistry _registry;
+    private readonly IDialogService _dialogService;
+    private readonly INameVerifier _nameVerifier;
 
     public CompositeMemberLogic(
         ISelectedState selectedState,
@@ -34,7 +37,9 @@ public class CompositeMemberLogic
         IUndoManager undoManager,
         IGuiCommands guiCommands,
         ObjectFinder objectFinder,
-        ICompositeMemberRegistry registry)
+        ICompositeMemberRegistry registry,
+        IDialogService dialogService,
+        INameVerifier nameVerifier)
     {
         _selectedState = selectedState;
         _exposeVariableService = exposeVariableService;
@@ -42,6 +47,8 @@ public class CompositeMemberLogic
         _guiCommands = guiCommands;
         _objectFinder = objectFinder;
         _registry = registry;
+        _dialogService = dialogService;
+        _nameVerifier = nameVerifier;
     }
 
     /// <summary>
@@ -243,6 +250,24 @@ public class CompositeMemberLogic
         }
         //////////////////////End Early Out/////////////////////
 
+        // Single prompt for one base name; each channel is exposed as base + channelRootName. Suffixing the
+        // full root name (e.g. "StrokeRed", not just "Red") reproduces the historical per-channel default and
+        // keeps affixed colors (Stroke/Fill/gradient) from colliding.
+        string message = $"Enter a base name. Channels {string.Join(", ", channelRootNames)} will be appended:";
+        string title = "Expose color";
+
+        GetUserStringOptions options = new()
+        {
+            InitialValue = instance.Name,
+            Validator = (baseName) => ValidateBaseName(baseName, channelRootNames, element),
+        };
+
+        if (_dialogService.GetUserString(message, title, options) is not { } enteredBaseName)
+        {
+            // User cancelled: expose nothing.
+            return;
+        }
+
         using IDisposable undoLock = _undoManager.RequestLock();
 
         List<VariableSave> toRevert = new();
@@ -255,8 +280,9 @@ public class CompositeMemberLogic
                 break;
             }
 
+            string exposedName = enteredBaseName + rootName;
             OptionallyAttemptedGeneralResponse<VariableSave> response =
-                _exposeVariableService.HandleExposeVariableClick(instance, rootName);
+                _exposeVariableService.ExposeVariable(instance, rootName, exposedName);
 
             if (response.DidAttempt && response.Succeeded == false)
             {
@@ -275,6 +301,23 @@ public class CompositeMemberLogic
                 _exposeVariableService.HandleUnexposeVariableClick(variableToRevert, element);
             }
         }
+    }
+
+    /// <summary>
+    /// Validates the single base name by checking every derived channel name (base + root name). Returns the
+    /// first failure reason, or null if all derived names are valid.
+    /// </summary>
+    private string? ValidateBaseName(string? baseName, IReadOnlyList<string> channelRootNames, ElementSave element)
+    {
+        foreach (string rootName in channelRootNames)
+        {
+            string derivedName = (baseName ?? "") + rootName;
+            if (!_nameVerifier.IsVariableNameValid(derivedName, element, null!, out string? whyNot))
+            {
+                return whyNot;
+            }
+        }
+        return null;
     }
 
     private bool IsChannelExposed(string channelRootName, ElementSave element, InstanceSave? instance)

--- a/Gum/Plugins/InternalPlugins/VariableGrid/PropertyGridManager.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/PropertyGridManager.cs
@@ -142,7 +142,9 @@ public partial class PropertyGridManager
             _undoManager,
             _guiCommands,
             _objectFinder,
-            Locator.GetRequiredService<ICompositeMemberRegistry>());
+            Locator.GetRequiredService<ICompositeMemberRegistry>(),
+            _dialogService,
+            Locator.GetRequiredService<Gum.Managers.INameVerifier>());
         var deleteVariableService = Locator.GetRequiredService<IDeleteVariableService>();
         var editVariableService = Locator.GetRequiredService<IEditVariableService>();
         var hotkeyManager = Locator.GetRequiredService<IHotkeyManager>();

--- a/Gum/Services/ExposeVariableService.cs
+++ b/Gum/Services/ExposeVariableService.cs
@@ -23,7 +23,19 @@ namespace Gum.Services;
 
 public interface IExposeVariableService
 {
+    /// <summary>
+    /// Exposes a single instance variable, prompting the user for the exposed name via a dialog. Used by the
+    /// standalone "Expose Variable" row context menu.
+    /// </summary>
     OptionallyAttemptedGeneralResponse<VariableSave> HandleExposeVariableClick(InstanceSave instanceSave, string rootVariableName);
+
+    /// <summary>
+    /// Exposes a single instance variable under a caller-supplied name, without prompting. Used by callers that
+    /// already determined the exposed name (e.g. the composite color swatch's single-prompt expose, which derives
+    /// every channel's name from one shared base name).
+    /// </summary>
+    OptionallyAttemptedGeneralResponse<VariableSave> ExposeVariable(InstanceSave instanceSave, string rootVariableName, string exposedName);
+
     void HandleUnexposeVariableClick(VariableSave variableSave, ElementSave elementSave);
 }
 
@@ -87,74 +99,103 @@ internal class ExposeVariableService : IExposeVariableService
         {
             InitialValue = fullVariableName.Replace(".", "").Replace(" ", ""),
             Validator = v =>
-                _nameVerifier.IsVariableNameValid(v, _selectedState.SelectedElement, variableSave, out string whyNot)
+                _nameVerifier.IsVariableNameValid(v, _selectedState.SelectedElement, variableSave, out string? whyNot)
                     ? null
                     : whyNot
         };
 
-        var toReturn = new OptionallyAttemptedGeneralResponse<VariableSave>();
-        toReturn.DidAttempt = true;
-        toReturn.Succeeded = false;
-
         if (_dialogService.GetUserString(message, title, options) is { } result)
         {
-
-            var elementSave = _selectedState.SelectedElement;
-            // if there is an inactive variable,
-            // we should get rid of it:
-            var existingVariable = _selectedState.SelectedElement.GetVariableFromThisOrBase(result);
-
-            // there's a variable but we shouldn't consider it
-            // unless it's "Active" - inactive variables may be
-            // leftovers from a type change
-
-            using var undoLocl = _undoManager.RequestLock();
-            if (existingVariable != null)
-            {
-                var isActive = _variableSaveLogic.GetIfVariableIsActive(existingVariable, elementSave, null);
-                if (isActive == false)
-                {
-                    // gotta remove the variable:
-                    if (elementSave.DefaultState.Variables.Contains(existingVariable))
-                    {
-                        // We may need to worry about inheritance...eventually
-                        elementSave.DefaultState.Variables.Remove(existingVariable);
-                    }
-                }
-
-            }
-
-            if(variableSave == null)
-            {
-                StateSave stateToExposeOn = _selectedState.SelectedElement.DefaultState;
-
-                var variableInDefault = ObjectFinder.Self.GetRootVariable(fullVariableName, instanceSave.ParentContainer);
-
-                if(variableInDefault == null)
-                {
-                    throw new Exception($"Error getting root variable for {fullVariableName} in {instanceSave.ParentContainer}");
-                }
-
-                string variableType = variableInDefault.Type;
-                stateToExposeOn.SetValue(fullVariableName, null, instanceSave, variableType);
-
-                variableSave = stateToExposeOn.GetVariableSave(fullVariableName);
-
-                // Not sure if we need this, but setting SetsValue to false matches the old behavior when
-                // this code used to be part of validation
-                variableSave.SetsValue = false;
-            }
-
-            variableSave.ExposedAsName = result;
-
-            PluginManager.Self.VariableAdd(elementSave, result);
-
-            _fileCommands.TryAutoSaveCurrentElement();
-            _guiCommands.RefreshVariables(force: true);
-            toReturn.Data = variableSave;
-            toReturn.Succeeded = true;
+            return ApplyExposure(instanceSave, rootVariableName, variableSave, result);
         }
-        return toReturn;
+
+        // User cancelled the prompt: attempted, but nothing exposed.
+        return new OptionallyAttemptedGeneralResponse<VariableSave> { DidAttempt = true, Succeeded = false };
+    }
+
+    public OptionallyAttemptedGeneralResponse<VariableSave> ExposeVariable(InstanceSave instanceSave, string rootVariableName, string exposedName)
+    {
+        var parentElement = instanceSave.ParentContainer;
+        var variableSave = parentElement?.DefaultState.GetVariableSave(
+            $"{instanceSave.Name}.{rootVariableName}");
+
+        var canExpose = GetIfCanExpose(instanceSave, variableSave, rootVariableName);
+
+        if (canExpose.Succeeded == false)
+        {
+            _dialogService.ShowMessage(canExpose.Message);
+            return OptionallyAttemptedGeneralResponse<VariableSave>.SuccessfulWithoutAttempt;
+        }
+
+        return ApplyExposure(instanceSave, rootVariableName, variableSave, exposedName);
+    }
+
+    /// <summary>
+    /// Performs the actual exposure once the final exposed name is known. Shared by the prompt-driven
+    /// <see cref="HandleExposeVariableClick"/> and the name-supplied <see cref="ExposeVariable"/>.
+    /// </summary>
+    private OptionallyAttemptedGeneralResponse<VariableSave> ApplyExposure(InstanceSave instanceSave,
+        string rootVariableName, VariableSave? variableSave, string exposedName)
+    {
+        var fullVariableName = instanceSave.Name + "." + rootVariableName;
+        var elementSave = _selectedState.SelectedElement;
+
+        // if there is an inactive variable, we should get rid of it:
+        var existingVariable = elementSave.GetVariableFromThisOrBase(exposedName);
+
+        // there's a variable but we shouldn't consider it
+        // unless it's "Active" - inactive variables may be
+        // leftovers from a type change
+
+        using var undoLock = _undoManager.RequestLock();
+        if (existingVariable != null)
+        {
+            var isActive = _variableSaveLogic.GetIfVariableIsActive(existingVariable, elementSave, null);
+            if (isActive == false)
+            {
+                // gotta remove the variable:
+                if (elementSave.DefaultState.Variables.Contains(existingVariable))
+                {
+                    // We may need to worry about inheritance...eventually
+                    elementSave.DefaultState.Variables.Remove(existingVariable);
+                }
+            }
+        }
+
+        if (variableSave == null)
+        {
+            StateSave stateToExposeOn = elementSave.DefaultState;
+
+            var variableInDefault = ObjectFinder.Self.GetRootVariable(fullVariableName, instanceSave.ParentContainer);
+
+            if (variableInDefault == null)
+            {
+                throw new Exception($"Error getting root variable for {fullVariableName} in {instanceSave.ParentContainer}");
+            }
+
+            string variableType = variableInDefault.Type;
+            stateToExposeOn.SetValue(fullVariableName, null, instanceSave, variableType);
+
+            variableSave = stateToExposeOn.GetVariableSave(fullVariableName);
+
+            // Not sure if we need this, but setting SetsValue to false matches the old behavior when
+            // this code used to be part of validation
+            variableSave.SetsValue = false;
+        }
+
+        variableSave.ExposedAsName = exposedName;
+
+        PluginManager.Self.VariableAdd(elementSave, exposedName);
+
+        _fileCommands.TryAutoSaveCurrentElement();
+        _guiCommands.RefreshVariables(force: true);
+
+        return new OptionallyAttemptedGeneralResponse<VariableSave>
+        {
+            DidAttempt = true,
+            Succeeded = true,
+            Data = variableSave,
+        };
     }
 
     private GeneralResponse GetIfCanExpose(InstanceSave instanceSave, VariableSave variableSave, string rootVariableName)

--- a/Tool/Tests/GumToolUnitTests/Dialogs/ExposeColorDialogViewModelTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Dialogs/ExposeColorDialogViewModelTests.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections.Generic;
+using Gum.Dialogs;
+using Shouldly;
+using Xunit;
+
+namespace GumToolUnitTests.Dialogs;
+
+public class ExposeColorDialogViewModelTests
+{
+    private static readonly string[] RgbRoots = { "Red", "Green", "Blue" };
+
+    private static ExposeColorDialogViewModel Make(string baseName, IReadOnlyList<string> roots,
+        Func<string, string?>? validate = null)
+    {
+        return new ExposeColorDialogViewModel(baseName, roots, validate ?? (_ => null));
+    }
+
+    [Fact]
+    public void CanExecuteAffirmative_ShouldBeFalse_WhenANameIsInvalid()
+    {
+        ExposeColorDialogViewModel vm = Make("MyColor", RgbRoots, _ => "nope");
+        vm.CanExecuteAffirmative().ShouldBeFalse();
+    }
+
+    [Fact]
+    public void CanExecuteAffirmative_ShouldBeTrue_WhenAllNamesValid()
+    {
+        ExposeColorDialogViewModel vm = Make("MyColor", RgbRoots);
+        vm.CanExecuteAffirmative().ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Error_ShouldReturnFirstFailure_WhenANameInvalid()
+    {
+        ExposeColorDialogViewModel vm = Make("MyColor", RgbRoots,
+            name => name == "MyColorGreen" ? "bad green" : null);
+        vm.Error.ShouldBe("bad green");
+    }
+
+    [Fact]
+    public void ExposedNames_ShouldAppendEachRootToBase()
+    {
+        ExposeColorDialogViewModel vm = Make("MyColor", RgbRoots);
+        vm.ExposedNames.ShouldBe(new[] { "MyColorRed", "MyColorGreen", "MyColorBlue" });
+    }
+
+    [Fact]
+    public void ExposedNames_ShouldBeRawRootNames_WhenBaseNameEmpty()
+    {
+        ExposeColorDialogViewModel vm = Make("", new[] { "FillRed", "FillGreen", "FillBlue" });
+        vm.ExposedNames.ShouldBe(new[] { "FillRed", "FillGreen", "FillBlue" });
+    }
+
+    [Fact]
+    public void ExposedNames_ShouldUpdate_WhenBaseNameChanges()
+    {
+        ExposeColorDialogViewModel vm = Make("MyColor", RgbRoots);
+        vm.BaseName = "Other";
+        vm.ExposedNames.ShouldBe(new[] { "OtherRed", "OtherGreen", "OtherBlue" });
+    }
+}

--- a/Tool/Tests/GumToolUnitTests/VariableGrid/CompositeMemberLogicApplyTests.cs
+++ b/Tool/Tests/GumToolUnitTests/VariableGrid/CompositeMemberLogicApplyTests.cs
@@ -6,6 +6,7 @@ using Gum.DataTypes.Variables;
 using Gum.Managers;
 using Gum.Plugins.InternalPlugins.VariableGrid;
 using Gum.Services;
+using Gum.Services.Dialogs;
 using Gum.ToolStates;
 using Gum.Undo;
 using Moq;
@@ -23,6 +24,8 @@ public class CompositeMemberLogicApplyTests : BaseTestClass
     private readonly Mock<IExposeVariableService> _exposeVariableService;
     private readonly Mock<IGuiCommands> _guiCommands;
     private readonly Mock<IUndoManager> _undoManager;
+    private readonly Mock<IDialogService> _dialogService;
+    private readonly Mock<INameVerifier> _nameVerifier;
     private readonly UndoManager _realUndoManager;
     private readonly CompositeMemberLogic _logic;
 
@@ -34,6 +37,8 @@ public class CompositeMemberLogicApplyTests : BaseTestClass
         _selectedState = new Mock<ISelectedState>();
         _exposeVariableService = new Mock<IExposeVariableService>();
         _guiCommands = new Mock<IGuiCommands>();
+        _dialogService = new Mock<IDialogService>();
+        _nameVerifier = new Mock<INameVerifier>();
 
         _realUndoManager = new UndoManager(null!, null!, null!, null!, null!, null!);
         _undoManager = new Mock<IUndoManager>();
@@ -45,16 +50,18 @@ public class CompositeMemberLogicApplyTests : BaseTestClass
             _undoManager.Object,
             _guiCommands.Object,
             ObjectFinder.Self,
-            new CompositeMemberRegistry());
+            new CompositeMemberRegistry(),
+            _dialogService.Object,
+            _nameVerifier.Object);
     }
 
-    private ComponentSave MakeColorComponent()
+    private ComponentSave MakeColorComponent(string prefix = "")
     {
         ComponentSave component = new() { Name = "Colored" };
         component.States.Add(new StateSave { Name = "Default", ParentContainer = component });
-        component.DefaultState.Variables.Add(new VariableSave { Name = "Red", Type = "int", Value = 0 });
-        component.DefaultState.Variables.Add(new VariableSave { Name = "Green", Type = "int", Value = 0 });
-        component.DefaultState.Variables.Add(new VariableSave { Name = "Blue", Type = "int", Value = 0 });
+        component.DefaultState.Variables.Add(new VariableSave { Name = prefix + "Red", Type = "int", Value = 0 });
+        component.DefaultState.Variables.Add(new VariableSave { Name = prefix + "Green", Type = "int", Value = 0 });
+        component.DefaultState.Variables.Add(new VariableSave { Name = prefix + "Blue", Type = "int", Value = 0 });
         _project.Components.Add(component);
         return component;
     }
@@ -90,7 +97,7 @@ public class CompositeMemberLogicApplyTests : BaseTestClass
     public void Apply_ShouldNotCollapse_WhenAChannelIsExposed()
     {
         ComponentSave component = MakeColorComponent();
-        component.DefaultState.GetVariableSave("Red").ExposedAsName = "MyColorRed";
+        component.DefaultState.GetVariableSave("Red")!.ExposedAsName = "MyColorRed";
 
         MemberCategory category = CategoryWith(
             new InstanceMember("Red", null!),
@@ -131,17 +138,69 @@ public class CompositeMemberLogicApplyTests : BaseTestClass
         InstanceSave instance = SetUpInstanceForExpose(out ComponentSave container);
         CompositeInstanceMember composite = BuildInstanceComposite(container, instance);
 
+        SetUpPrompt(baseName: "MyColor");
         _exposeVariableService
-            .Setup(x => x.HandleExposeVariableClick(instance, It.IsAny<string>()))
-            .Returns((InstanceSave _, string root) => Attempted(succeeded: true, new VariableSave { Name = root }));
+            .Setup(x => x.ExposeVariable(instance, It.IsAny<string>(), It.IsAny<string>()))
+            .Returns((InstanceSave _, string _, string exposed) => Attempted(succeeded: true, new VariableSave { Name = exposed }));
 
         InvokeExpose(composite);
 
-        _exposeVariableService.Verify(x => x.HandleExposeVariableClick(instance, "Red"), Times.Once);
-        _exposeVariableService.Verify(x => x.HandleExposeVariableClick(instance, "Green"), Times.Once);
-        _exposeVariableService.Verify(x => x.HandleExposeVariableClick(instance, "Blue"), Times.Once);
+        _exposeVariableService.Verify(x => x.ExposeVariable(instance, "Red", "MyColorRed"), Times.Once);
+        _exposeVariableService.Verify(x => x.ExposeVariable(instance, "Green", "MyColorGreen"), Times.Once);
+        _exposeVariableService.Verify(x => x.ExposeVariable(instance, "Blue", "MyColorBlue"), Times.Once);
         _exposeVariableService.Verify(
             x => x.HandleUnexposeVariableClick(It.IsAny<VariableSave>(), It.IsAny<ElementSave>()), Times.Never);
+    }
+
+    [Fact]
+    public void Expose_ShouldPromptExactlyOnce_ForAllChannels()
+    {
+        InstanceSave instance = SetUpInstanceForExpose(out ComponentSave container);
+        CompositeInstanceMember composite = BuildInstanceComposite(container, instance);
+
+        SetUpPrompt(baseName: "MyColor");
+        _exposeVariableService
+            .Setup(x => x.ExposeVariable(instance, It.IsAny<string>(), It.IsAny<string>()))
+            .Returns((InstanceSave _, string _, string exposed) => Attempted(succeeded: true, new VariableSave { Name = exposed }));
+
+        InvokeExpose(composite);
+
+        _dialogService.Verify(
+            x => x.GetUserString(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<GetUserStringOptions>()), Times.Once);
+    }
+
+    [Fact]
+    public void Expose_ShouldSuffixFullChannelRootName_ForAffixedColors()
+    {
+        InstanceSave instance = SetUpInstanceForExpose(out ComponentSave container, prefix: "Stroke");
+        CompositeInstanceMember composite = BuildInstanceComposite(container, instance, prefix: "Stroke");
+
+        SetUpPrompt(baseName: "MyShape");
+        _exposeVariableService
+            .Setup(x => x.ExposeVariable(instance, It.IsAny<string>(), It.IsAny<string>()))
+            .Returns((InstanceSave _, string _, string exposed) => Attempted(succeeded: true, new VariableSave { Name = exposed }));
+
+        InvokeExpose(composite);
+
+        _exposeVariableService.Verify(x => x.ExposeVariable(instance, "StrokeRed", "MyShapeStrokeRed"), Times.Once);
+        _exposeVariableService.Verify(x => x.ExposeVariable(instance, "StrokeGreen", "MyShapeStrokeGreen"), Times.Once);
+        _exposeVariableService.Verify(x => x.ExposeVariable(instance, "StrokeBlue", "MyShapeStrokeBlue"), Times.Once);
+    }
+
+    [Fact]
+    public void Expose_ShouldDoNothing_WhenPromptCancelled()
+    {
+        InstanceSave instance = SetUpInstanceForExpose(out ComponentSave container);
+        CompositeInstanceMember composite = BuildInstanceComposite(container, instance);
+
+        _dialogService
+            .Setup(x => x.GetUserString(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<GetUserStringOptions>()))
+            .Returns((string?)null);
+
+        InvokeExpose(composite);
+
+        _exposeVariableService.Verify(
+            x => x.ExposeVariable(It.IsAny<InstanceSave>(), It.IsAny<string>(), It.IsAny<string>()), Times.Never);
     }
 
     [Fact]
@@ -150,23 +209,31 @@ public class CompositeMemberLogicApplyTests : BaseTestClass
         InstanceSave instance = SetUpInstanceForExpose(out ComponentSave container);
         CompositeInstanceMember composite = BuildInstanceComposite(container, instance);
 
-        VariableSave exposedRed = new() { Name = "Red" };
+        SetUpPrompt(baseName: "MyColor");
+        VariableSave exposedRed = new() { Name = "MyColorRed" };
         _exposeVariableService
-            .Setup(x => x.HandleExposeVariableClick(instance, "Red"))
+            .Setup(x => x.ExposeVariable(instance, "Red", "MyColorRed"))
             .Returns(Attempted(succeeded: true, exposedRed));
         _exposeVariableService
-            .Setup(x => x.HandleExposeVariableClick(instance, "Green"))
+            .Setup(x => x.ExposeVariable(instance, "Green", "MyColorGreen"))
             .Returns(Attempted(succeeded: false, null));
 
         InvokeExpose(composite);
 
-        _exposeVariableService.Verify(x => x.HandleExposeVariableClick(instance, "Blue"), Times.Never);
+        _exposeVariableService.Verify(x => x.ExposeVariable(instance, "Blue", "MyColorBlue"), Times.Never);
         _exposeVariableService.Verify(x => x.HandleUnexposeVariableClick(exposedRed, container), Times.Once);
     }
 
-    private InstanceSave SetUpInstanceForExpose(out ComponentSave container)
+    private void SetUpPrompt(string baseName)
     {
-        ComponentSave baseComponent = MakeColorComponent();
+        _dialogService
+            .Setup(x => x.GetUserString(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<GetUserStringOptions>()))
+            .Returns(baseName);
+    }
+
+    private InstanceSave SetUpInstanceForExpose(out ComponentSave container, string prefix = "")
+    {
+        ComponentSave baseComponent = MakeColorComponent(prefix);
 
         container = new ComponentSave { Name = "Container" };
         container.States.Add(new StateSave { Name = "Default", ParentContainer = container });
@@ -179,12 +246,12 @@ public class CompositeMemberLogicApplyTests : BaseTestClass
         return instance;
     }
 
-    private CompositeInstanceMember BuildInstanceComposite(ComponentSave container, InstanceSave instance)
+    private CompositeInstanceMember BuildInstanceComposite(ComponentSave container, InstanceSave instance, string prefix = "")
     {
         MemberCategory category = CategoryWith(
-            new InstanceMember("Red", null!),
-            new InstanceMember("Green", null!),
-            new InstanceMember("Blue", null!));
+            new InstanceMember(prefix + "Red", null!),
+            new InstanceMember(prefix + "Green", null!),
+            new InstanceMember(prefix + "Blue", null!));
         List<MemberCategory> categories = new() { category };
 
         _logic.Apply(categories, container, instance);

--- a/Tool/Tests/GumToolUnitTests/VariableGrid/CompositeMemberLogicApplyTests.cs
+++ b/Tool/Tests/GumToolUnitTests/VariableGrid/CompositeMemberLogicApplyTests.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using Gum.Commands;
 using Gum.DataTypes;
 using Gum.DataTypes.Variables;
+using Gum.Dialogs;
 using Gum.Managers;
 using Gum.Plugins.InternalPlugins.VariableGrid;
 using Gum.Services;
@@ -165,8 +166,7 @@ public class CompositeMemberLogicApplyTests : BaseTestClass
 
         InvokeExpose(composite);
 
-        _dialogService.Verify(
-            x => x.GetUserString(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<GetUserStringOptions>()), Times.Once);
+        _dialogService.Verify(x => x.Show(It.IsAny<ExposeColorDialogViewModel>()), Times.Once);
     }
 
     [Fact]
@@ -194,8 +194,8 @@ public class CompositeMemberLogicApplyTests : BaseTestClass
         CompositeInstanceMember composite = BuildInstanceComposite(container, instance);
 
         _dialogService
-            .Setup(x => x.GetUserString(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<GetUserStringOptions>()))
-            .Returns((string?)null);
+            .Setup(x => x.Show(It.IsAny<ExposeColorDialogViewModel>()))
+            .Returns(false);
 
         InvokeExpose(composite);
 
@@ -226,9 +226,12 @@ public class CompositeMemberLogicApplyTests : BaseTestClass
 
     private void SetUpPrompt(string baseName)
     {
+        // Simulate the user entering a base name and clicking OK: set BaseName on the dialog VM the logic
+        // constructs, then report an affirmative result.
         _dialogService
-            .Setup(x => x.GetUserString(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<GetUserStringOptions>()))
-            .Returns(baseName);
+            .Setup(x => x.Show(It.IsAny<ExposeColorDialogViewModel>()))
+            .Callback((ExposeColorDialogViewModel vm) => vm.BaseName = baseName)
+            .Returns(true);
     }
 
     private InstanceSave SetUpInstanceForExpose(out ComponentSave container, string prefix = "")

--- a/Tool/Tests/GumToolUnitTests/VariableGrid/CompositeMemberLogicTests.cs
+++ b/Tool/Tests/GumToolUnitTests/VariableGrid/CompositeMemberLogicTests.cs
@@ -17,7 +17,7 @@ public class CompositeMemberLogicTests
     {
         CompositeMemberRegistry registry = new();
         _colorDescriptor = registry.Descriptors[0];
-        _logic = new CompositeMemberLogic(null!, null!, null!, null!, ObjectFinder.Self, registry);
+        _logic = new CompositeMemberLogic(null!, null!, null!, null!, ObjectFinder.Self, registry, null!, null!);
     }
 
     private static Dictionary<string, InstanceMember> MembersFor(params string[] rootNames)


### PR DESCRIPTION
Closes #2989. Follow-up to #2981 (composite color swatch).

## What

Exposing a color from the variable-grid swatch used to prompt the user **three times** — once per channel (`CompositeMemberLogic.HandleExpose` looped Red → Green → Blue, each `HandleExposeVariableClick` opening its own dialog). This collapses it to **one** base-name dialog.

The user enters a single base name (default = the instance name); each channel is exposed as `base + channelRootName`:

- Plain color (`Red`/`Green`/`Blue`): base `MyShape` → `MyShapeRed`/`MyShapeGreen`/`MyShapeBlue`.
- Affixed color (`StrokeRed`/…, gradient `Red1`/…): base `MyShape` → `MyShapeStrokeRed`/… etc.

Suffixing the **full channel root name** (not just the `Red`/`Green`/`Blue` token) exactly reproduces the historical per-channel default (`InstanceName + rootName`) when the default base is accepted, and keeps Stroke/Fill/Dropshadow and gradient `…1`/`…2` colors from colliding.

## How

- **`IExposeVariableService.ExposeVariable(instance, rootVariableName, exposedName)`** — new no-dialog entry point. The post-name "apply exposure" body is extracted out of `HandleExposeVariableClick` into a shared private `ApplyExposure`, so the prompt-driven path (standalone "Expose Variable" row, unchanged) and the name-supplied path share one implementation.
- **`CompositeMemberLogic.HandleExpose`** — shows one `GetUserString` whose validator checks **every** derived channel name up front (blocks a base that yields an invalid/duplicate name), then drives `ExposeVariable` per channel under the existing single `RequestLock()` + rollback-on-failure. Cancelling the prompt exposes nothing. (`IDialogService` + `INameVerifier` injected for this.)

Preserved from before: one undo for the whole expose, all-or-nothing rollback if a channel fails. After exposing, the exposure-only collapse condition flips and the swatch reverts to raw channel rows — unchanged here; relaxing that is the other #2981 follow-up.

## Scope

Only the composite color swatch path changes. The standalone "Expose Variable" right-click on a normal row (`StateReferencingInstanceMember`) keeps its single-variable dialog. No change to the collapse condition, Make Default, set path, or the WpfDataUi substrate.

## Tests

TDD — saw the new expectations fail red before implementing. Added/updated in `CompositeMemberLogicApplyTests`: single prompt shown exactly once, derived names for plain **and** affixed colors, cancel = no-op, rollback parity. Full `GumToolUnitTests` suite green (772 passed, 5 pre-existing skips).

Boyscout: fixed an `undoLock` typo and a nullable-deref warning in the touched test.

## Not covered

In-app visual verification (the actual dialog UX, real undo grouping) — recommend a quick manual pass before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
