### PR TITLE
Docs: reframe CircleRuntime/RectangleRuntime onto FillColor/StrokeColor

### DIFF
--- a/docs/code/standard-visuals/circleruntime.md
+++ b/docs/code/standard-visuals/circleruntime.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-`CircleRuntime` draws a circle (or ellipse) with a **fill** and an **outline (stroke)**. Its size is controlled by `Radius` (or by `Width` and `Height` for an ellipse). The fill is set by `FillColor`; the outline is set by `StrokeColor` and `StrokeWidth`. On top of fill and outline, a `CircleRuntime` can also render a gradient, a drop shadow, and a dashed outline.
+`CircleRuntime` draws a circle with a **fill** and an **outline (stroke)**. The circle is sized to fit within its `Width` × `Height` bounds. The fill is set by `FillColor`; the outline is set by `StrokeColor` and `StrokeWidth`. On top of fill and outline, a `CircleRuntime` can also render a gradient, a drop shadow, and a dashed outline.
 
 A freshly-constructed `CircleRuntime` renders as a **stroke-only outline** — `FillColor` defaults to transparent, `StrokeColor` defaults to white, and `StrokeWidth` defaults to `1`. Assign a visible `FillColor` to light up the fill, or set `StrokeWidth` to `0` to hide the outline.
 
@@ -19,7 +19,8 @@ The following code creates an outlined `CircleRuntime`:
 ```csharp
 // Initialize
 var circle = new CircleRuntime();
-circle.Radius = 64;
+circle.Width = 128;
+circle.Height = 128;
 circle.StrokeColor = Color.Green; // This is a Microsoft.Xna.Framework.Color
 container.Children.Add(circle);
 ```
@@ -31,7 +32,8 @@ To fill the circle, assign a visible `FillColor`. On MonoGame, KNI, and FNA the 
 ```csharp
 // Initialize
 var circle = new CircleRuntime();
-circle.Radius = 64;
+circle.Width = 128;
+circle.Height = 128;
 circle.FillColor = Color.Green; // light up the fill
 container.Children.Add(circle);
 ```

--- a/docs/code/standard-visuals/circleruntime.md
+++ b/docs/code/standard-visuals/circleruntime.md
@@ -2,18 +2,42 @@
 
 ## Introduction
 
-The CircleRuntime object can be used to draw a single-pixel-wide circle. It can display any color.
+`CircleRuntime` draws a circle (or ellipse) with a **fill** and an **outline (stroke)**. Its size is controlled by `Radius` (or by `Width` and `Height` for an ellipse). The fill is set by `FillColor`; the outline is set by `StrokeColor` and `StrokeWidth`. On top of fill and outline, a `CircleRuntime` can also render a gradient, a drop shadow, and a dashed outline.
+
+A freshly-constructed `CircleRuntime` renders as a **stroke-only outline** — `FillColor` defaults to transparent, `StrokeColor` defaults to white, and `StrokeWidth` defaults to `1`. Assign a visible `FillColor` to light up the fill, or set `StrokeWidth` to `0` to hide the outline.
+
+For the full property surface — fill, outline, gradient, drop shadow, dashed stroke, and the platform/package requirements — see the [Shapes](shapes-apos.shapes.md) page. The examples below cover the common cases.
+
+{% hint style="info" %}
+On MonoGame, KNI, and FNA the outline and geometry render out of the box, but the **fill** and the richer effects (gradient, drop shadow, dashed stroke, anti-aliasing) only draw once the `Gum.Shapes.<platform>` package is added — otherwise they are stored and round-trip but silently do not draw. Skia, .NET MAUI, and raylib support the full surface natively. See the [Shapes](shapes-apos.shapes.md) page for setup.
+{% endhint %}
 
 ### Code Example
 
-The following code creates a CircleRuntime:
+The following code creates an outlined `CircleRuntime`:
 
 ```csharp
 // Initialize
 var circle = new CircleRuntime();
 circle.Radius = 64;
-circle.Color = Color.Green; // This is a Microsoft.Xna.Framework.Color
+circle.StrokeColor = Color.Green; // This is a Microsoft.Xna.Framework.Color
 container.Children.Add(circle);
 ```
 
-<figure><img src="../../.gitbook/assets/07_06 14 58.png" alt=""><figcaption><p>Creen circle</p></figcaption></figure>
+<figure><img src="../../.gitbook/assets/07_06 14 58.png" alt=""><figcaption><p>Green outlined circle</p></figcaption></figure>
+
+To fill the circle, assign a visible `FillColor`. On MonoGame, KNI, and FNA the fill requires the shape support package (see the [Shapes](shapes-apos.shapes.md) page):
+
+```csharp
+// Initialize
+var circle = new CircleRuntime();
+circle.Radius = 64;
+circle.FillColor = Color.Green; // light up the fill
+container.Children.Add(circle);
+```
+
+## Legacy color members
+
+{% hint style="warning" %}
+The `Color`, `Red`, `Green`, `Blue`, and `Alpha` members are obsolete and are being phased out. They write the **stroke** color (`CircleRuntime` was historically outline-only) and are kept only for backward compatibility. Use `StrokeColor` for the outline and `FillColor` for the fill instead. For the property mapping and the automated code fix, see [Migrating to 2026 June](../../gum-tool/upgrading/migrating-to-2026-june.md).
+{% endhint %}

--- a/docs/code/standard-visuals/rectangleruntime.md
+++ b/docs/code/standard-visuals/rectangleruntime.md
@@ -1,18 +1,46 @@
 # RectangleRuntime
 
-The RectangleRuntime object can be used to draw a single-pixel-wide rectangle. It can either have a solid outline or dotted, and can display any color. RectangleRuntimes only draw outlines. For filled rectangles see the [ColoredRectangleRuntime](coloredrectangleruntime.md) type.
+## Introduction
+
+`RectangleRuntime` draws a rectangle with a **fill** and an **outline (stroke)**, plus an optional uniform `CornerRadius` for rounded corners. Its size is controlled by `Width` and `Height`. The fill is set by `FillColor`; the outline is set by `StrokeColor` and `StrokeWidth`. On top of fill and outline, a `RectangleRuntime` can also render a gradient, a drop shadow, and a dashed outline.
+
+A freshly-constructed `RectangleRuntime` renders as a **stroke-only outline** — `FillColor` defaults to transparent, `StrokeColor` defaults to white, and `StrokeWidth` defaults to `1`. Assign a visible `FillColor` to light up the fill, or set `StrokeWidth` to `0` to hide the outline.
+
+For the full property surface — fill, outline, corner radius, gradient, drop shadow, dashed stroke, and the platform/package requirements — see the [Shapes](shapes-apos.shapes.md) page. The examples below cover the common cases.
+
+{% hint style="info" %}
+On MonoGame, KNI, and FNA the outline and geometry render out of the box, but the **fill** and the richer effects (gradient, drop shadow, dashed stroke, anti-aliasing) only draw once the `Gum.Shapes.<platform>` package is added — otherwise they are stored and round-trip but silently do not draw. Skia, .NET MAUI, and raylib support the full surface natively. See the [Shapes](shapes-apos.shapes.md) page for setup.
+{% endhint %}
 
 ### Code Example
 
-The following code creates a RectangleRuntime:
+The following code creates an outlined `RectangleRuntime`:
 
 ```csharp
 // Initialize
-var lineRectangle = new RectangleRuntime();
-lineRectangle.Width = 120;
-lineRectangle.Height = 24;
-lineRectangle.Color = Color.Pink;  // This is a Microsoft.Xna.Framework.Color
-container.Children.Add(lineRectangle);
+var rectangle = new RectangleRuntime();
+rectangle.Width = 120;
+rectangle.Height = 24;
+rectangle.StrokeColor = Color.Pink; // This is a Microsoft.Xna.Framework.Color
+container.Children.Add(rectangle);
 ```
 
-<figure><img src="../../.gitbook/assets/WideRectOverBlue.png" alt=""><figcaption><p>RectangleRuntime instantiated in code</p></figcaption></figure>
+<figure><img src="../../.gitbook/assets/WideRectOverBlue.png" alt=""><figcaption><p>Pink outlined rectangle</p></figcaption></figure>
+
+To fill the rectangle and round its corners, assign a visible `FillColor` and a `CornerRadius`. On MonoGame, KNI, and FNA the fill requires the shape support package (see the [Shapes](shapes-apos.shapes.md) page):
+
+```csharp
+// Initialize
+var rectangle = new RectangleRuntime();
+rectangle.Width = 120;
+rectangle.Height = 24;
+rectangle.CornerRadius = 8;
+rectangle.FillColor = Color.Pink; // light up the fill
+container.Children.Add(rectangle);
+```
+
+## Legacy color members
+
+{% hint style="warning" %}
+The `Color`, `Red`, `Green`, `Blue`, and `Alpha` members are obsolete and are being phased out. They write the **stroke** color (`RectangleRuntime` was historically outline-only) and are kept only for backward compatibility. Use `StrokeColor` for the outline and `FillColor` for the fill instead. For the property mapping and the automated code fix, see [Migrating to 2026 June](../../gum-tool/upgrading/migrating-to-2026-june.md).
+{% endhint %}

--- a/docs/code/standard-visuals/shapes-apos.shapes.md
+++ b/docs/code/standard-visuals/shapes-apos.shapes.md
@@ -4,7 +4,7 @@
 
 GumUI supports rendering vector shapes as visuals. The two primary shape runtimes are:
 
-* `CircleRuntime` — a circle (or ellipse) sized by `Width` and `Height` (or `Radius`).
+* `CircleRuntime` — a circle sized to fit within its `Width` × `Height` bounds.
 * `RectangleRuntime` — a rectangle with an optional uniform or per-corner `CornerRadius`.
 
 Each shape has a **fill** and an **outline (stroke)**. The fill is controlled by `FillColor` (and `IsFilled`); the outline is controlled by `StrokeColor`, `StrokeWidth`, and `StrokeWidthUnits`. On top of fill and outline, shapes can render a gradient, a drop shadow, and a dashed outline.
@@ -135,7 +135,8 @@ public class Game1 : Game
 
         var circle = new CircleRuntime();
         circle.AddToRoot();
-        circle.Radius = 50;
+        circle.Width = 100;
+        circle.Height = 100;
         circle.FillColor = Color.Red;
 
         var rectangle = new RectangleRuntime();
@@ -181,7 +182,7 @@ public class Game1 : Game
 
 * **Fill** — `FillColor` sets the fill color; `FillRed` / `FillGreen` / `FillBlue` / `FillAlpha` set individual channels (0–255). `IsFilled = false` hides the fill. By default `FillColor` is transparent, so a freshly-constructed shape renders as an outline only — assign a visible `FillColor` to light up the fill.
 * **Outline (stroke)** — `StrokeColor` sets the outline color (with `StrokeRed` / `StrokeGreen` / `StrokeBlue` / `StrokeAlpha` channels); `StrokeWidth` controls thickness and `StrokeWidthUnits` controls how that thickness is interpreted. `StrokeWidth = 0` hides the outline.
-* **Geometry** — `CircleRuntime` is sized by `Width` / `Height` (or `Radius`); `RectangleRuntime` is sized by `Width` / `Height` with an optional uniform or per-corner `CornerRadius`.
+* **Geometry** — `CircleRuntime` is sized to fit within its `Width` / `Height` bounds; `RectangleRuntime` is sized by `Width` / `Height` with an optional uniform or per-corner `CornerRadius`.
 
 The gradient, drop shadow, and dashed-outline properties match the names in the tables below.
 
@@ -271,7 +272,7 @@ Defaults: `Width` = `Height` = 100, `StartAngle` = 0, `SweepAngle` = 90, `IsEndR
 
 ### ColoredCircleRuntime
 
-`ColoredCircleRuntime` draws a circle (or ellipse) sized by its `Width` and `Height`. It does not add any properties beyond the common set — its size is controlled by `Width`/`Height`, and its appearance is controlled by the common color, gradient, drop shadow, and fill/stroke properties.
+`ColoredCircleRuntime` draws a circle sized to fit within its `Width` and `Height` bounds. It does not add any properties beyond the common set — its size is controlled by `Width`/`Height`, and its appearance is controlled by the common color, gradient, drop shadow, and fill/stroke properties.
 
 Defaults: `Width` = `Height` = 100, `IsFilled` = `true`, `StrokeWidth` = 1, `Color` = `White`.
 


### PR DESCRIPTION
## Summary

The `CircleRuntime` / `RectangleRuntime` **code-doc** pages still described the old single-pixel `.Color`, outline-only API. That now contradicts the reframed [Shapes](../blob/main/docs/code/standard-visuals/shapes-apos.shapes.md) page (merged in #2988): on `main`, both runtimes are full **fill + outline (stroke)** shapes (Rectangle adds an optional `CornerRadius`), and the legacy `.Color` / channel members are `[Obsolete]`.

This steers both pages onto the current API.

## Changes

- Reframe each intro around `FillColor` / `StrokeColor` / `StrokeWidth` and the stroke-only default visual (transparent fill, white stroke, `StrokeWidth = 1`).
- Keep the existing outline screenshots by basing the **primary** example on `StrokeColor` (renders without the shape support package); add a **fill** example noting the `Gum.Shapes.<platform>` requirement on MonoGame/KNI/FNA.
- Mark the legacy `Color` / `Red` / `Green` / `Blue` / `Alpha` members as obsolete / going-away and link the June migration guide.
- Drop the stale "for filled rectangles see `ColoredRectangleRuntime`" pointer — `RectangleRuntime` now fills itself.
- Point to the Shapes page for the full property surface (gradient, drop shadow, dashed stroke, etc.), which is documented in a separate later pass.

## Notes

Scoped intentionally as a **reframe**, not a full property reference — the comprehensive `CircleRuntime` / `RectangleRuntime` property tables are a separate upcoming doc pass. Code-only change; verified the property names, defaults, and obsolete attributes against the runtime classes on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)