### PR TITLE
Docs: correct tool-doc prose for the June 2026 shapes change

### DIFF
--- a/docs/gum-tool/gum-elements/circle.md
+++ b/docs/gum-tool/gum-elements/circle.md
@@ -2,6 +2,10 @@
 
 ### Introduction
 
-Circles are an outlined shape which can be used for visualizations or collision in games. Circles provide a color for their outline but they cannot be filled in.
+Circles are a shape which can be used for visualizations or collision in games. A Circle can be drawn as an outline, filled in, or both, and supports additional effects such as gradients, drop shadows, and dashed strokes. Circles are sized using their `Width` and `Height` values.
+
+{% hint style="info" %}
+The fill, gradient, and drop shadow variable categories only appear for version 3 (or later) projects. New projects use version 3 by default.
+{% endhint %}
 
 <figure><img src="../../.gitbook/assets/30_04 24 55.png" alt=""><figcaption><p>Circle in Gum using the default white color</p></figcaption></figure>

--- a/docs/gum-tool/gum-elements/coloredrectangle.md
+++ b/docs/gum-tool/gum-elements/coloredrectangle.md
@@ -1,5 +1,9 @@
 # ColoredRectangle
 
+{% hint style="warning" %}
+**ColoredRectangle is being phased out.** Use the **Rectangle** standard element instead — Rectangle covers the same solid-color fill (through its `Fill Color`) plus an outline, gradients, drop shadows, dashed strokes, and rounded corners. New projects seed Rectangle rather than ColoredRectangle. ColoredRectangle remains available so existing projects keep working, but it will be removed in a future release.
+{% endhint %}
+
 ### Introduction
 
 ColoredRectangles are used to display solid color rectangles. It can be used to provide a solid colored background or placeholders for content such as Sprites. ColoredRectangles are also useful for quickly blocking out a UI or learning about Gum's layout with a visual object.

--- a/docs/gum-tool/gum-elements/skia-standard-elements/README.md
+++ b/docs/gum-tool/gum-elements/skia-standard-elements/README.md
@@ -4,7 +4,11 @@
 
 Skia standard elements are a collection of elements which use SkiaSharp for rendering. Skia standard elements provide additional types of visuals supported by Gum, but not all runtimes support Skia standard elements.
 
-Skia adds advanced vector graphics support for shapes such as Arc, ColoredCircle, and RoundedRectangle. Skia also adds support for vector file formats such as SVG and Lottie.
+Skia adds advanced vector graphics support, including the **Arc** shape and vector file formats such as SVG and Lottie. The core **Circle** and **Rectangle** standard elements — which support fill, outline, gradients, drop shadows, dashed strokes, and (on Rectangle) rounded corners — also render at their richest on Skia.
+
+{% hint style="info" %}
+The older **ColoredCircle**, **RoundedRectangle**, and **SolidRectangle** Skia shapes are being phased out in favor of the core Circle and Rectangle standard elements. They remain available so existing projects keep working, but will be removed in a future release.
+{% endhint %}
 
 {% hint style="warning" %}
 Using Skia Standard Elements may limit which platforms can run your Gum project. For more information, see the [Shapes Platform Support](shapes-platform-support.md) page.

--- a/docs/gum-tool/gum-elements/skia-standard-elements/README.md
+++ b/docs/gum-tool/gum-elements/skia-standard-elements/README.md
@@ -4,10 +4,10 @@
 
 Skia standard elements are a collection of elements which use SkiaSharp for rendering. Skia standard elements provide additional types of visuals supported by Gum, but not all runtimes support Skia standard elements.
 
-Skia adds advanced vector graphics support, including the **Arc** shape and vector file formats such as SVG and Lottie. The core **Circle** and **Rectangle** standard elements — which support fill, outline, gradients, drop shadows, dashed strokes, and (on Rectangle) rounded corners — also render at their richest on Skia.
+Skia adds advanced vector graphics support, including the **Arc** shape and vector file formats such as SVG and Lottie.
 
 {% hint style="info" %}
-The older **ColoredCircle**, **RoundedRectangle**, and **SolidRectangle** Skia shapes are being phased out in favor of the core Circle and Rectangle standard elements. They remain available so existing projects keep working, but will be removed in a future release.
+The older **ColoredCircle**, **RoundedRectangle**, and **SolidRectangle** Skia shapes are being phased out. Use the core **Circle** and **Rectangle** standard elements instead — they support fill, outline, gradients, drop shadows, dashed strokes, and rounded corners, and are not Skia standard elements, so they work without adding Skia to your project. The old shapes remain available so existing projects keep working, but will be removed in a future release.
 {% endhint %}
 
 {% hint style="warning" %}

--- a/docs/gum-tool/gum-elements/skia-standard-elements/coloredcircle.md
+++ b/docs/gum-tool/gum-elements/skia-standard-elements/coloredcircle.md
@@ -1,8 +1,12 @@
 # ColoredCircle
 
+{% hint style="warning" %}
+**ColoredCircle is being phased out.** Use the [Circle](../circle.md) standard element instead — Circle now supports fill, outline, gradients, drop shadows, and dashed strokes on all platforms. ColoredCircle remains available so existing projects keep working, but it will be removed in a future release.
+{% endhint %}
+
 ### Introduction
 
-ColoredCircle are round shapes which can be filled in or drawn as an outline. Unlike the non-Skia Circle element, ColoredCircles can be filled in and provide more options for customizing their appearance.
+ColoredCircle are round shapes which can be filled in or drawn as an outline, with options for customizing their appearance.
 
 <figure><img src="../../../.gitbook/assets/image (143).png" alt=""><figcaption><p>A default ColoredCircle</p></figcaption></figure>
 

--- a/docs/gum-tool/gum-elements/skia-standard-elements/roundedrectangle/README.md
+++ b/docs/gum-tool/gum-elements/skia-standard-elements/roundedrectangle/README.md
@@ -1,5 +1,9 @@
 # RoundedRectangle
 
+{% hint style="warning" %}
+**RoundedRectangle is being phased out.** Use the **Rectangle** standard element instead and set its `Corner Radius` — Rectangle now supports rounded corners along with fill, outline, gradients, drop shadows, and dashed strokes on all platforms. RoundedRectangle remains available so existing projects keep working, but it will be removed in a future release.
+{% endhint %}
+
 ### Introduction
 
 RoundedRectangle is similar to a ColoredRectangle with the added functionality of supporting rounded corners.

--- a/docs/gum-tool/gum-elements/skia-standard-elements/shapes-platform-support.md
+++ b/docs/gum-tool/gum-elements/skia-standard-elements/shapes-platform-support.md
@@ -9,22 +9,30 @@ Shapes (Skia) support varies per platform. See below to see information about yo
 MonoGame and KNI projects can use the following shapes:
 
 * Arc
-* ColoredCircle
-* RoundedRectangle
+* Circle
+* Rectangle
+
+The outline (stroke) of Circle and Rectangle renders out of the box. The fill and the richer effects — gradients, drop shadows, and dashed strokes — are provided by the shape support package (`Gum.Shapes.MonoGame` or `Gum.Shapes.KNI`). Without the package those properties are saved but do not draw.
 
 Other types, such as SVG or Lottie, are not currently supported.
 
-These shapes are rendered using the Apos.Shapes library.
+For information on adding the shape support package to your project, see the [Shapes (Apos.Shapes)](../../../code/standard-visuals/shapes-apos.shapes.md) page.
 
-For information on adding Apos.Shapes to your library, see the [Shapes (Apos.Shapes)](../../../code/standard-visuals/shapes-apos.shapes.md) page.
+{% hint style="info" %}
+The older ColoredCircle, RoundedRectangle, and SolidRectangle shapes are being phased out in favor of Circle and Rectangle. They remain available so existing projects keep working, but will be removed in a future release.
+{% endhint %}
 {% endtab %}
 
 {% tab title="FNA" %}
-Apos.Shapes may work on FNA but has not been thoroughly tested. We are looking for contributors to help test this.
+FNA renders the outline (stroke) of Circle and Rectangle only. The fill and the richer effects (gradients, drop shadows, dashed strokes) are not available on FNA because there is no shape support package for it. We are looking for contributors to help expand FNA shape support.
 {% endtab %}
 
 {% tab title="Raylib" %}
-Shapes are not yet implemented in raylib. Please create an issue on GitHub or contact us on Discord if you would like to see this implemented.
+Raylib supports Circle and Rectangle — including fill, gradients, and drop shadows — natively, with no extra package required.
+
+{% hint style="info" %}
+Gradient-on-outline (a gradient applied to the stroke rather than the fill) is not yet implemented on raylib.
+{% endhint %}
 {% endtab %}
 
 {% tab title="Skia platforms (Maui, WPF, Silk.NET)" %}

--- a/docs/gum-tool/tutorials-and-examples/intro-tutorials/basics.md
+++ b/docs/gum-tool/tutorials-and-examples/intro-tutorials/basics.md
@@ -20,12 +20,12 @@ Sprite element is selected in the image above. Notice that since a **SourceFile*
 
 ### Standard Types
 
-* ![](<../../../.gitbook/assets/image (51).png>) Circle - circle outline. These are usually not used for UI, but can be used if you are defining collision in your Gum objects for a game.
-* ![](<../../../.gitbook/assets/image (53).png>) ColoredRectangle - filled-in rectangle. These are often used for solid-colored backgrounds and frames.
+* ![](<../../../.gitbook/assets/image (51).png>) Circle - a circle which can be filled in, outlined, or both. Often used for visualizations or for defining collision in your Gum objects for a game.
+* ![](<../../../.gitbook/assets/image (53).png>) ColoredRectangle - a legacy filled-in rectangle. New projects use **Rectangle** instead (which can be both filled and outlined); ColoredRectangle remains available for existing projects.
 * ![](<../../../.gitbook/assets/image (54).png>) Container - invisible object used to contain other objects. These are used to provide margins, change layouts (such as vertical vs horizontal stacking), and to organize your UI.
 * ![](<../../../.gitbook/assets/image (55).png>) NineSlice - visual object which uses nine sprites to create a resizable object from a source PNG (or portion of a PNG). The corner sprites (4) are not resized. The top, bottom, left, and right sprites are stretched on one axis. The middle sprite stretches both horizontally and vertically. These are used to create resizable frames.
 * ![](<../../../.gitbook/assets/image (56).png>) Polygon - polygon outline which can have any number of points. These are usually not used for UI, but can be used if you are defining collision in your Gum objects for a game.
-* ![](<../../../.gitbook/assets/image (57).png>) Rectangle - rectangle outline. These can be used for single-line frames or if you are defining collision in your Gum objects for a game.
+* ![](<../../../.gitbook/assets/image (57).png>) Rectangle - a rectangle which can be filled in, outlined, or both. Used for solid-colored backgrounds, frames, blocking out a UI, or for defining collision in your Gum objects for a game.
 * ![](<../../../.gitbook/assets/image (58).png>) Sprite - a visual object which displays a source PNG (or a portion of a PNG). These are used for icons, backgrounds, and other visual objects which are usually not resized dynamically.
 * ![](<../../../.gitbook/assets/image (59).png>) Text - a visual object which can display characters. These are used for any situation where text needs to be displayed such as labels and paragraphs.
 

--- a/docs/gum-tool/upgrading/migrating-to-2026-june.md
+++ b/docs/gum-tool/upgrading/migrating-to-2026-june.md
@@ -26,6 +26,14 @@ Run the upgrade `gum upgrade` or `~/bin/gum upgrade`
 {% endtab %}
 {% endtabs %}
 
+### Shape standard elements in the tool
+
+New projects now seed the **Circle** and **Rectangle** standard elements, which provide a full fill, outline, gradient, drop shadow, dashed-stroke, and corner-radius surface. The older shape standard elements — **ColoredCircle**, **ColoredRectangle**, **RoundedRectangle**, and **SolidRectangle** — are being phased out, but existing projects that use them keep working; you do not need to replace them to upgrade.
+
+{% hint style="info" %}
+The tool only shows the new Circle and Rectangle fill, gradient, and drop shadow variable categories for version 3 (or later) projects. New projects use version 3 by default.
+{% endhint %}
+
 ## Upgrading Runtime
 
 The `2026.6` NuGet packages have not yet been published. Once released, upgrade your Gum NuGet packages to the new version. For more information, see the NuGet packages for your particular platform:


### PR DESCRIPTION
Text-only corrections to the Gum **tool** docs (`docs/gum-tool/`) for the June 2026 shapes change. As of that release, **Circle** and **Rectangle** are the primary shape standard elements (full fill + outline/stroke + gradient + dropshadow + dashed-stroke + corner-radius), while **ColoredCircle**, **ColoredRectangle**, **RoundedRectangle**, and **SolidRectangle** are obsolete shims being phased out. Arc remains supported.

These are prose / info-hint fixes that need **no new screenshots** — the full screenshot-rich `circle.md` rewrite and new `rectangle.md` page remain a separate, deferred, screenshot-blocked pass.

## Changes

- **`gum-elements/circle.md`** — drop the false "cannot be filled in" claim and the old Radius framing; Circle now fills, outlines, and supports effects, sized by `Width`/`Height`. Surgical edit (full walkthrough deferred to the screenshot pass).
- **`gum-elements/skia-standard-elements/coloredcircle.md`** — going-away info block steering to Circle; remove the now-backwards "unlike the non-Skia Circle, ColoredCircles can be filled" line.
- **`gum-elements/coloredrectangle.md`** — going-away info block steering to Rectangle (`Color` -> `Fill Color`).
- **`gum-elements/skia-standard-elements/roundedrectangle/README.md`** — going-away info block steering to Rectangle + `Corner Radius`.
- **`gum-elements/skia-standard-elements/README.md`** — present Arc/Circle/Rectangle as current; mark the shims obsolete.
- **`gum-elements/skia-standard-elements/shapes-platform-support.md`** — list Circle/Rectangle, mark the shims obsolete, and correct the per-platform tabs (raylib now supported natively; FNA outline-only).
- **`tutorials-and-examples/intro-tutorials/basics.md`** — light touch on the Circle / ColoredRectangle-vs-Rectangle standard-type descriptions.
- **`upgrading/migrating-to-2026-june.md`** — short tool-side note: new projects seed Circle/Rectangle, shims still work, and the new variable categories show on v3 projects.

Obsolete shims stay listed (per the PR#2988 convention) with an info block pointing to the replacement; version-gating notes live in `{% hint %}` blocks. The Skia general-property pages and `arc/README.md` were already accurate and left untouched. No `rectangle.md` tool page exists yet, so Rectangle is referenced in bold rather than linked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
