### PR TITLE
#2993: Keep the color swatch visible when channels are exposed

### DIFF
--- a/Gum/Controls/ColorDisplay.xaml
+++ b/Gum/Controls/ColorDisplay.xaml
@@ -6,7 +6,8 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
-    <Grid x:Name="MainGrid">
+    <StackPanel>
+        <Grid x:Name="MainGrid">
         <Grid.ContextMenu>
             <ContextMenu />
         </Grid.ContextMenu>
@@ -48,5 +49,15 @@
                 TextChanged="HexTextBox_TextChanged"
                 ToolTip="Type or paste a hex color (RRGGBB or RRGGBBAA). Alpha is ignored." />
         </StackPanel>
-    </Grid>
+        </Grid>
+
+        <!--  Subtext (e.g. "Exposed as ...") mirrored from InstanceMember.DetailText, like the other displayers.  -->
+        <TextBlock
+            x:Name="HintTextBlock"
+            Margin="0,0,4,4"
+            HorizontalAlignment="Left"
+            FontSize="10"
+            TextWrapping="Wrap"
+            Visibility="Collapsed" />
+    </StackPanel>
 </UserControl>

--- a/Gum/Controls/ColorDisplay.xaml.cs
+++ b/Gum/Controls/ColorDisplay.xaml.cs
@@ -104,7 +104,7 @@ namespace Gum.Controls.DataUi
 
             this.RefreshContextMenu(MainGrid.ContextMenu);
 
-            // todo - eventually we may want a HintTextBlock. If so, add it here:
+            RefreshHintText();
 
             SuppressSettingProperty = false;
         }
@@ -208,11 +208,22 @@ namespace Gum.Controls.DataUi
 
         private void HandlePropertyChange(object? sender, PropertyChangedEventArgs e)
         {
-            if (e.PropertyName == "Value")
+            if (e.PropertyName == "Value" || e.PropertyName == nameof(InstanceMember.DetailText))
             {
                 this.Refresh();
 
             }
+        }
+
+        // Mirrors InstanceMember.DetailText into the subtext line, matching how the WpfDataUi displayers
+        // (TextBoxDisplay, SliderDisplay, etc.) surface their DetailText.
+        private void RefreshHintText()
+        {
+            string? detailText = InstanceMember?.DetailText;
+            HintTextBlock.Text = detailText;
+            HintTextBlock.Visibility = string.IsNullOrEmpty(detailText)
+                ? Visibility.Collapsed
+                : Visibility.Visible;
         }
 
         private void HandleColorChange(object? sender, RoutedEventArgs e)

--- a/Gum/Plugins/InternalPlugins/VariableGrid/CompositeMemberLogic.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/CompositeMemberLogic.cs
@@ -53,8 +53,8 @@ public class CompositeMemberLogic
     }
 
     /// <summary>
-    /// Applies every registered descriptor to every category, collapsing complete, unexposed channel
-    /// triples into composite rows.
+    /// Applies every registered descriptor to every category, collapsing each complete channel triple into a
+    /// composite row (exposed or not; exposure is surfaced via subtext and an Un-expose menu item).
     /// </summary>
     public void Apply(List<MemberCategory> categories, ElementSave element, InstanceSave? instance)
     {
@@ -87,14 +87,10 @@ public class CompositeMemberLogic
 
         foreach (CompositeTriple triple in triples)
         {
-            // Collapse condition is exposure-only: if any channel is individually exposed, leave the raw
-            // channel rows so the exposure stays visible/manageable.
-            bool anyExposed = triple.ChannelRootNames.Any((rootName) =>
-                IsChannelExposed(rootName, element, instance));
-            if (!anyExposed)
-            {
-                BuildAndInsertComposite(descriptor, category, triple, instance);
-            }
+            // Always collapse a complete triple to a swatch, even when channels are exposed. Exposure is
+            // surfaced via the composite's subtext and an Un-expose context menu item rather than by falling
+            // back to raw channel rows.
+            BuildAndInsertComposite(descriptor, category, triple, element, instance);
         }
     }
 
@@ -145,7 +141,7 @@ public class CompositeMemberLogic
     }
 
     private void BuildAndInsertComposite(CompositeMemberDescriptor descriptor, MemberCategory category,
-        CompositeTriple triple, InstanceSave? instance)
+        CompositeTriple triple, ElementSave element, InstanceSave? instance)
     {
         string compositeName = descriptor.CompositeNameFormat
             .Replace("{prefix}", triple.Prefix)
@@ -161,6 +157,15 @@ public class CompositeMemberLogic
         composite.PreferredDisplayer = descriptor.Displayer;
         composite.SupportsMakeDefault = false;
         composite.DisplayName = ToolsUtilities.StringFunctions.InsertSpacesInCamelCaseString(compositeName);
+
+        // When channels are exposed the swatch stays, but we surface the exposure as subtext so the user can
+        // see it's exposed and under which names (the raw per-channel rows used to carry this).
+        List<VariableSave> exposedChannelVariables = GetExposedChannelVariables(triple, element, instance);
+        if (exposedChannelVariables.Count > 0)
+        {
+            composite.DetailText = "Exposed as " +
+                string.Join(", ", exposedChannelVariables.Select((variable) => variable.ExposedAsName));
+        }
 
         // Single undo for the whole composite write. The undo lock must live here (Gum-side) because the
         // WpfDataUi substrate has no access to the undo manager.
@@ -200,7 +205,7 @@ public class CompositeMemberLogic
 
         composite.ContextMenuEvents.Add("Make Default", (_, _) => HandleMakeDefault(triple.ChannelMembers));
 
-        TryAddExposeMenu(composite, descriptor, triple, instance);
+        TryAddExposeMenu(composite, descriptor, triple, element, instance, exposedChannelVariables);
 
         int insertIndex = triple.ChannelMembers.Min((member) => category.Members.IndexOf(member));
         foreach (InstanceMember channelMember in triple.ChannelMembers)
@@ -223,21 +228,41 @@ public class CompositeMemberLogic
     }
 
     private void TryAddExposeMenu(CompositeInstanceMember composite, CompositeMemberDescriptor descriptor,
-        CompositeTriple triple, InstanceSave? instance)
+        CompositeTriple triple, ElementSave element, InstanceSave? instance,
+        IReadOnlyList<VariableSave> exposedChannelVariables)
     {
         if (instance == null)
         {
             return;
         }
 
-        string channelList = string.Join(", ", descriptor.ChannelRootNames);
         string compositeBaseName = descriptor.CompositeNameFormat
             .Replace("{prefix}", triple.Prefix)
             .Replace("{suffix}", triple.Suffix);
-        List<string> channelRootNames = triple.ChannelRootNames.ToList();
 
-        composite.ContextMenuEvents.Add($"Expose {compositeBaseName} ({channelList})",
-            (_, _) => HandleExpose(channelRootNames, instance));
+        if (exposedChannelVariables.Count > 0)
+        {
+            // Already exposed: offer to un-expose. The raw channel rows used to carry this action.
+            composite.ContextMenuEvents.Add($"Un-expose {compositeBaseName}",
+                (_, _) => HandleUnexpose(exposedChannelVariables, element));
+        }
+        else
+        {
+            string channelList = string.Join(", ", descriptor.ChannelRootNames);
+            List<string> channelRootNames = triple.ChannelRootNames.ToList();
+            composite.ContextMenuEvents.Add($"Expose {compositeBaseName} ({channelList})",
+                (_, _) => HandleExpose(channelRootNames, instance));
+        }
+    }
+
+    private void HandleUnexpose(IReadOnlyList<VariableSave> exposedChannelVariables, ElementSave element)
+    {
+        // One undo lock coalesces the per-channel un-expose calls into a single undo.
+        using IDisposable undoLock = _undoManager.RequestLock();
+        foreach (VariableSave exposedVariable in exposedChannelVariables)
+        {
+            _exposeVariableService.HandleUnexposeVariableClick(exposedVariable, element);
+        }
     }
 
     private void HandleExpose(IReadOnlyList<string> channelRootNames, InstanceSave instance)
@@ -312,19 +337,30 @@ public class CompositeMemberLogic
             : whyNot;
     }
 
-    private bool IsChannelExposed(string channelRootName, ElementSave element, InstanceSave? instance)
+    /// <summary>
+    /// Returns the exposed channel variables of the triple (those whose <see cref="VariableSave.ExposedAsName"/>
+    /// is set), in channel order. Empty when nothing is exposed.
+    /// </summary>
+    private List<VariableSave> GetExposedChannelVariables(CompositeTriple triple, ElementSave element,
+        InstanceSave? instance)
     {
-        VariableSave? variable;
-        if (instance != null)
+        List<VariableSave> exposed = new();
+        foreach (string channelRootName in triple.ChannelRootNames)
         {
-            variable = element.DefaultState.GetVariableSave($"{instance.Name}.{channelRootName}");
+            VariableSave? variable = GetChannelVariable(channelRootName, element, instance);
+            if (!string.IsNullOrEmpty(variable?.ExposedAsName))
+            {
+                exposed.Add(variable);
+            }
         }
-        else
-        {
-            variable = element.DefaultState.GetVariableSave(channelRootName);
-        }
+        return exposed;
+    }
 
-        return !string.IsNullOrEmpty(variable?.ExposedAsName);
+    private VariableSave? GetChannelVariable(string channelRootName, ElementSave element, InstanceSave? instance)
+    {
+        return instance != null
+            ? element.DefaultState.GetVariableSave($"{instance.Name}.{channelRootName}")
+            : element.DefaultState.GetVariableSave(channelRootName);
     }
 
     private string? GetRootVariableName(InstanceMember member, ElementSave element, InstanceSave? instance)

--- a/Tool/Tests/GumToolUnitTests/VariableGrid/CompositeMemberLogicApplyTests.cs
+++ b/Tool/Tests/GumToolUnitTests/VariableGrid/CompositeMemberLogicApplyTests.cs
@@ -95,8 +95,9 @@ public class CompositeMemberLogicApplyTests : BaseTestClass
     }
 
     [Fact]
-    public void Apply_ShouldNotCollapse_WhenAChannelIsExposed()
+    public void Apply_ShouldStillCollapse_WhenAChannelIsExposed()
     {
+        // Exposure no longer suppresses the swatch; the triple still collapses (a partially-exposed color too).
         ComponentSave component = MakeColorComponent();
         component.DefaultState.GetVariableSave("Red")!.ExposedAsName = "MyColorRed";
 
@@ -108,8 +109,72 @@ public class CompositeMemberLogicApplyTests : BaseTestClass
 
         _logic.Apply(categories, component, instance: null);
 
-        category.Members.Count.ShouldBe(3);
-        category.Members.ShouldNotContain(m => m is CompositeInstanceMember);
+        category.Members.Count.ShouldBe(1);
+        category.Members[0].ShouldBeOfType<CompositeInstanceMember>();
+    }
+
+    [Fact]
+    public void Apply_ShouldSetExposedSubtext_ListingExposedNames_WhenChannelsExposed()
+    {
+        ComponentSave component = MakeColorComponent();
+        component.DefaultState.GetVariableSave("Red")!.ExposedAsName = "MyColorRed";
+        component.DefaultState.GetVariableSave("Green")!.ExposedAsName = "MyColorGreen";
+        component.DefaultState.GetVariableSave("Blue")!.ExposedAsName = "MyColorBlue";
+
+        MemberCategory category = CategoryWith(
+            new InstanceMember("Red", null!),
+            new InstanceMember("Green", null!),
+            new InstanceMember("Blue", null!));
+        List<MemberCategory> categories = new() { category };
+
+        _logic.Apply(categories, component, instance: null);
+        CompositeInstanceMember composite = (CompositeInstanceMember)category.Members.Single();
+
+        composite.DetailText.ShouldContain("MyColorRed");
+        composite.DetailText.ShouldContain("MyColorGreen");
+        composite.DetailText.ShouldContain("MyColorBlue");
+    }
+
+    [Fact]
+    public void Apply_ShouldNotSetExposedSubtext_WhenNotExposed()
+    {
+        ComponentSave component = MakeColorComponent();
+        MemberCategory category = CategoryWith(
+            new InstanceMember("Red", null!),
+            new InstanceMember("Green", null!),
+            new InstanceMember("Blue", null!));
+        List<MemberCategory> categories = new() { category };
+
+        _logic.Apply(categories, component, instance: null);
+        CompositeInstanceMember composite = (CompositeInstanceMember)category.Members.Single();
+
+        composite.DetailText.ShouldBeNullOrEmpty();
+    }
+
+    [Fact]
+    public void Apply_ShouldOfferUnexposeNotExpose_WhenChannelsExposed()
+    {
+        InstanceSave instance = SetUpInstanceForExpose(out ComponentSave container);
+        ExposeChannelsOnInstance(container, instance);
+        CompositeInstanceMember composite = BuildInstanceComposite(container, instance);
+
+        composite.ContextMenuEvents.Keys.ShouldContain(k => k.StartsWith("Un-expose"));
+        composite.ContextMenuEvents.Keys.ShouldNotContain(k => k.StartsWith("Expose"));
+    }
+
+    [Fact]
+    public void Unexpose_ShouldUnexposeEveryExposedChannel_UnderASingleUndoLock()
+    {
+        InstanceSave instance = SetUpInstanceForExpose(out ComponentSave container);
+        ExposeChannelsOnInstance(container, instance);
+        CompositeInstanceMember composite = BuildInstanceComposite(container, instance);
+
+        string unexposeKey = composite.ContextMenuEvents.Keys.Single(k => k.StartsWith("Un-expose"));
+        composite.ContextMenuEvents[unexposeKey].Invoke(composite, null!);
+
+        _exposeVariableService.Verify(
+            x => x.HandleUnexposeVariableClick(It.IsAny<VariableSave>(), container), Times.Exactly(3));
+        _undoManager.Verify(x => x.RequestLock(), Times.Once);
     }
 
     [Fact]
@@ -247,6 +312,19 @@ public class CompositeMemberLogicApplyTests : BaseTestClass
 
         _selectedState.Setup(x => x.SelectedElement).Returns(container);
         return instance;
+    }
+
+    private static void ExposeChannelsOnInstance(ComponentSave container, InstanceSave instance, string prefix = "")
+    {
+        foreach (string token in new[] { "Red", "Green", "Blue" })
+        {
+            container.DefaultState.Variables.Add(new VariableSave
+            {
+                Name = $"{instance.Name}.{prefix}{token}",
+                Type = "int",
+                ExposedAsName = $"My{prefix}{token}",
+            });
+        }
     }
 
     private CompositeInstanceMember BuildInstanceComposite(ComponentSave container, InstanceSave instance, string prefix = "")


### PR DESCRIPTION
Closes #2993. Second of the two #2981 follow-ups (sibling of #2989 / PR #2990).

## What

Exposing a color used to flip the exposure-only collapse condition off, so the swatch reverted to three raw int rows on the instance that owns the exposed variables — "Expose Color" removed the very swatch it was invoked from. Now the swatch **always stays**, and exposure is surfaced in-place.

## How (`CompositeMemberLogic`)

- **Always collapse.** Dropped the `anyExposed` gate in `ApplyDescriptorToCategory`; a complete R/G/B triple always collapses to a swatch — including a partially-exposed color (1–2 of 3, a legacy/edge case now that Expose does all 3).
- **Subtext.** When any channel is exposed, the composite's `DetailText` lists the exposed variable name(s) (e.g. "Exposed as MyColorRed, MyColorGreen, MyColorBlue") — the info the raw rows used to carry.
- **Context menu reflects state.** `Un-expose <Color>` when exposed (un-exposes every exposed channel under one undo lock); `Expose <Color> (Red, Green, Blue)` otherwise.
- Editing the swatch still routes through the channels, so the exposure is preserved; Make Default already preserves exposure via `channel.IsDefault`.

Boyscout: the now-dead `IsChannelExposed` was replaced with `GetExposedChannelVariables` + a shared `GetChannelVariable` lookup.

## Scope

Only the **defining element's** view of the instance. When the component is later *used* as an instance elsewhere, the exposed ints (`ShapeFillRed/Green/Blue`) already re-form a triple and collapse via the affix mechanism — untouched here.

## Tests

TDD (saw the 4 new exposed-behavior tests red first): still-collapse when exposed incl. partial, exposed-subtext lists names / none when unexposed, Un-expose-not-Expose menu when exposed, un-expose all channels under a single undo. Full `GumToolUnitTests` green (782 passed, 5 pre-existing skips).

## Not covered (manual)

In-app visual verification: the swatch showing the correct color while exposed (channels with `SetsValue=false` resolve their effective value through `channel.Value`, which the composite composes from), editing writing through while keeping the exposure, and the subtext rendering. Recommend a quick tool run before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
