### PR TITLE
Obsolete legacy Color/Radius members on Circle/Rectangle runtimes across all backends

### DIFF
--- a/MonoGameGum/GueDeriving/CircleRuntime.cs
+++ b/MonoGameGum/GueDeriving/CircleRuntime.cs
@@ -104,6 +104,7 @@ public class CircleRuntime : GraphicalUiElement
         }
     }
 #elif !SKIA
+    [Obsolete("Use FillColor or StrokeColor instead. See migration guide for issue #2761.")]
     public int Alpha
     {
         get => ContainedLineCircle.Color.A;
@@ -132,6 +133,7 @@ public class CircleRuntime : GraphicalUiElement
         }
     }
 #elif !SKIA
+    [Obsolete("Use FillColor or StrokeColor instead. See migration guide for issue #2761.")]
     public int Red
     {
         get => ContainedLineCircle.Color.R;
@@ -160,6 +162,7 @@ public class CircleRuntime : GraphicalUiElement
         }
     }
 #elif !SKIA
+    [Obsolete("Use FillColor or StrokeColor instead. See migration guide for issue #2761.")]
     public int Green
     {
         get => ContainedLineCircle.Color.G;
@@ -188,6 +191,7 @@ public class CircleRuntime : GraphicalUiElement
         }
     }
 #elif !SKIA
+    [Obsolete("Use FillColor or StrokeColor instead. See migration guide for issue #2761.")]
     public int Blue
     {
         get => ContainedLineCircle.Color.B;
@@ -199,6 +203,12 @@ public class CircleRuntime : GraphicalUiElement
     }
 #endif
 
+    /// <summary>
+    /// Obsolete: set <c>Width</c> and <c>Height</c> instead. Retained for back-compat — the
+    /// setter now only proxies size (sets <c>Width</c> = <c>Height</c> = <c>Radius</c> * 2) and
+    /// pushes the radius to the renderable. See the June 2026 migration guide (issue #2761).
+    /// </summary>
+    [Obsolete("Set Width and Height instead (Radius now proxies Width = Height = Radius * 2). See migration guide for issue #2761.")]
     public float Radius
     {
 #if XNALIKE
@@ -238,6 +248,7 @@ public class CircleRuntime : GraphicalUiElement
         }
     }
 #elif !SKIA
+    [Obsolete("Use FillColor or StrokeColor instead. See migration guide for issue #2761.")]
     public Color Color
     {
         get => ContainedLineCircle.Color;
@@ -1640,6 +1651,44 @@ public class CircleRuntime : GraphicalUiElement
     /// to the contained <see cref="Circle"/>.
     /// </summary>
     protected override RenderableShapeBase ContainedRenderable => ContainedLineCircle;
+
+    // Unified-API cleanup: CircleRuntime is a new fill+stroke shape, so the single-color legacy
+    // members it inherits from SkiaShapeRuntime (the base for ALL Skia shapes) are obsolete on
+    // this surface — users typed as CircleRuntime are steered to FillColor / StrokeColor, the
+    // same way the XNA-like and raylib surfaces do it. The members stay live on the base for the
+    // legacy single-color shapes (Arc, RoundedRectangle, ColoredCircle, ...). Color is already
+    // [Obsolete] on the base, so only Red/Green/Blue/Alpha need shadowing here.
+    /// <summary>Obsolete: use <see cref="SkiaShapeRuntime.FillColor"/> or <see cref="SkiaShapeRuntime.StrokeColor"/>.</summary>
+    [Obsolete("Use FillColor or StrokeColor instead. See migration guide for issue #2761.")]
+    public new int Alpha
+    {
+        get => base.Alpha;
+        set => base.Alpha = value;
+    }
+
+    /// <inheritdoc cref="Alpha"/>
+    [Obsolete("Use FillColor or StrokeColor instead. See migration guide for issue #2761.")]
+    public new int Red
+    {
+        get => base.Red;
+        set => base.Red = value;
+    }
+
+    /// <inheritdoc cref="Alpha"/>
+    [Obsolete("Use FillColor or StrokeColor instead. See migration guide for issue #2761.")]
+    public new int Green
+    {
+        get => base.Green;
+        set => base.Green = value;
+    }
+
+    /// <inheritdoc cref="Alpha"/>
+    [Obsolete("Use FillColor or StrokeColor instead. See migration guide for issue #2761.")]
+    public new int Blue
+    {
+        get => base.Blue;
+        set => base.Blue = value;
+    }
 
     /// <summary>
     /// Isotropic blur radius in pixels for the dropshadow. The plain <see cref="CircleRuntime"/>

--- a/MonoGameGum/GueDeriving/RectangleRuntime.cs
+++ b/MonoGameGum/GueDeriving/RectangleRuntime.cs
@@ -566,6 +566,7 @@ public class RectangleRuntime : GraphicalUiElement
         }
     }
 #elif !SKIA
+    [Obsolete("Use FillColor or StrokeColor instead. See migration guide for issue #2768.")]
     public int Alpha
     {
         get => ContainedLineRectangle.Color.A;
@@ -591,6 +592,7 @@ public class RectangleRuntime : GraphicalUiElement
         }
     }
 #elif !SKIA
+    [Obsolete("Use FillColor or StrokeColor instead. See migration guide for issue #2768.")]
     public int Red
     {
         get => ContainedLineRectangle.Color.R;
@@ -616,6 +618,7 @@ public class RectangleRuntime : GraphicalUiElement
         }
     }
 #elif !SKIA
+    [Obsolete("Use FillColor or StrokeColor instead. See migration guide for issue #2768.")]
     public int Green
     {
         get => ContainedLineRectangle.Color.G;
@@ -641,6 +644,7 @@ public class RectangleRuntime : GraphicalUiElement
         }
     }
 #elif !SKIA
+    [Obsolete("Use FillColor or StrokeColor instead. See migration guide for issue #2768.")]
     public int Blue
     {
         get => ContainedLineRectangle.Color.B;
@@ -671,7 +675,9 @@ public class RectangleRuntime : GraphicalUiElement
             NotifyPropertyChanged();
         }
 #elif RAYLIB || SOKOL
+        [Obsolete("Use FillColor or StrokeColor instead. See migration guide for issue #2768.")]
         get => ContainedLineRectangle.Color;
+        [Obsolete("Use FillColor or StrokeColor instead. See migration guide for issue #2768.")]
         set
         {
             ContainedLineRectangle.Color = value;
@@ -1607,6 +1613,44 @@ public class RectangleRuntime : GraphicalUiElement
     /// contained RoundedRectangle. Issue #2814 / #2818.
     /// </summary>
     protected override RenderableShapeBase ContainedRenderable => ContainedLineRectangle;
+
+    // Unified-API cleanup: RectangleRuntime is a new fill+stroke shape, so the single-color
+    // legacy members it inherits from SkiaShapeRuntime (the base for ALL Skia shapes) are
+    // obsolete on this surface — users typed as RectangleRuntime are steered to FillColor /
+    // StrokeColor, matching the XNA-like and raylib surfaces. The members stay live on the base
+    // for the legacy single-color shapes (Arc, RoundedRectangle, ColoredCircle, ...). Color is
+    // already [Obsolete] on the base, so only Red/Green/Blue/Alpha need shadowing here.
+    /// <summary>Obsolete: use <see cref="SkiaShapeRuntime.FillColor"/> or <see cref="SkiaShapeRuntime.StrokeColor"/>.</summary>
+    [Obsolete("Use FillColor or StrokeColor instead. See migration guide for issue #2768.")]
+    public new int Alpha
+    {
+        get => base.Alpha;
+        set => base.Alpha = value;
+    }
+
+    /// <inheritdoc cref="Alpha"/>
+    [Obsolete("Use FillColor or StrokeColor instead. See migration guide for issue #2768.")]
+    public new int Red
+    {
+        get => base.Red;
+        set => base.Red = value;
+    }
+
+    /// <inheritdoc cref="Alpha"/>
+    [Obsolete("Use FillColor or StrokeColor instead. See migration guide for issue #2768.")]
+    public new int Green
+    {
+        get => base.Green;
+        set => base.Green = value;
+    }
+
+    /// <inheritdoc cref="Alpha"/>
+    [Obsolete("Use FillColor or StrokeColor instead. See migration guide for issue #2768.")]
+    public new int Blue
+    {
+        get => base.Blue;
+        set => base.Blue = value;
+    }
 
     /// <inheritdoc cref="CircleRuntime.DropshadowBlur"/>
     public float DropshadowBlur

--- a/Tests/MonoGameGum.Shapes.Tests/CircleRuntimeTests.cs
+++ b/Tests/MonoGameGum.Shapes.Tests/CircleRuntimeTests.cs
@@ -331,8 +331,8 @@ public class CircleRuntimeTests
         sut.StrokeColor = Color.Blue;
 #pragma warning disable CS0618 // exercising deprecated legacy routing on purpose
         sut.Color = Color.Lime;
-#pragma warning restore CS0618
         sut.Radius = 25f;
+#pragma warning restore CS0618
         sut.IsFilled = false;
         sut.StrokeWidth = 0;
 

--- a/Tests/RaylibGum.Tests/Runtimes/CircleRuntimeTests.cs
+++ b/Tests/RaylibGum.Tests/Runtimes/CircleRuntimeTests.cs
@@ -4,6 +4,11 @@ using Raylib_cs;
 using RenderingLibrary.Graphics;
 using Shouldly;
 
+// CircleRuntime's legacy single-color members (Color/Red/Green/Blue/Alpha) and Radius are now
+// [Obsolete] under the unified fill/stroke API, but this file exists to pin their back-compat
+// routing on the raylib backend — so CS0618 is silenced for the whole file.
+#pragma warning disable CS0618
+
 namespace RaylibGum.Tests.Runtimes;
 
 public class CircleRuntimeTests : BaseTestClass

--- a/Tests/RaylibGum.Tests/Runtimes/RectangleRuntimeTests.cs
+++ b/Tests/RaylibGum.Tests/Runtimes/RectangleRuntimeTests.cs
@@ -4,6 +4,11 @@ using Raylib_cs;
 using RenderingLibrary.Graphics;
 using Shouldly;
 
+// RectangleRuntime's legacy single-color members (Color/Red/Green/Blue/Alpha) are now
+// [Obsolete] under the unified fill/stroke API, but this file exists to pin their back-compat
+// routing on the raylib backend — so CS0618 is silenced for the whole file.
+#pragma warning disable CS0618
+
 namespace RaylibGum.Tests.Runtimes;
 
 public class RectangleRuntimeTests : BaseTestClass

--- a/Tests/SkiaGum.Tests/GueDeriving/CircleRuntimeTests.cs
+++ b/Tests/SkiaGum.Tests/GueDeriving/CircleRuntimeTests.cs
@@ -98,7 +98,9 @@ public class CircleRuntimeTests
     public void Radius_ShouldBe16_ByDefault()
     {
         CircleRuntime sut = new();
+#pragma warning disable CS0618 // Radius is obsolete (use Width/Height); pinning the default here
         sut.Radius.ShouldBe(16);
+#pragma warning restore CS0618
     }
 
     [Fact]

--- a/docs/gum-tool/upgrading/migrating-to-2026-june.md
+++ b/docs/gum-tool/upgrading/migrating-to-2026-june.md
@@ -266,7 +266,8 @@ circle.AddToRoot();
 
 ```csharp
 CircleRuntime circle = new CircleRuntime();
-circle.Radius = 50; // or set Width = 100; Height = 100;
+circle.Width = 100;  // restore the previous Skia default (Radius is now obsolete)
+circle.Height = 100;
 circle.AddToRoot();
 ```
 
@@ -379,6 +380,43 @@ The `Gum.Analyzers` package ships an automated code fix (`GUM002`) — place the
 
 The obsolete types will remain in place until at least the December 2026 release. After that window, they may be marked `[Obsolete(error: true)]` in a subsequent release, breaking compilation for any code still using them.
 
+### Legacy single-color members and `Radius` on `CircleRuntime` / `RectangleRuntime` are now `[Obsolete]`
+
+`CircleRuntime` and `RectangleRuntime` are the new fill + stroke shapes, so their inherited single-color members — `Color`, `Red`, `Green`, `Blue`, `Alpha` — and `CircleRuntime.Radius` are superseded by the fill/stroke color API and by `Width` / `Height`. Each is now `[Obsolete]` on **every** backend (MonoGame, FNA, KNI, Raylib, Skia). Existing code keeps compiling, but each reference now produces a `CS0618` compiler warning.
+
+{% hint style="info" %}
+These members were already obsolete on the XNA-likes (MonoGame / FNA / KNI) earlier in this cycle; the June 2026 change extends the same deprecation to Raylib and Skia so the two shapes present one consistent API. If you build for Raylib or Skia you may see new `CS0618` warnings on code that compiled cleanly before.
+{% endhint %}
+
+The deprecation applies only to `CircleRuntime` / `RectangleRuntime`. The same members stay non-obsolete on the legacy single-color shapes (`ColoredCircleRuntime`, `RoundedRectangleRuntime`, `ArcRuntime`, etc.), where they remain the primary API — on Skia those shapes share the `SkiaShapeRuntime` base, which is deliberately left unchanged.
+
+| Member | Replacement |
+| --- | --- |
+| `Color` | `StrokeColor` (the legacy `Color` painted the outline) — or `FillColor` for a filled shape |
+| `Red` / `Green` / `Blue` / `Alpha` | `StrokeRed` / `StrokeGreen` / `StrokeBlue` / `StrokeAlpha` — or the matching `Fill…` channels for a filled shape |
+| `CircleRuntime.Radius` | `Width` / `Height` (the setter already proxies `Width = Height = Radius * 2`) |
+
+❌ Old:
+
+```csharp
+// Initialize
+var circle = new CircleRuntime();
+circle.Radius = 28;          // obsolete
+circle.Color = Color.Yellow; // obsolete legacy single-color member (painted the outline)
+circle.AddToRoot();
+```
+
+✅ New:
+
+```csharp
+// Initialize
+var circle = new CircleRuntime();
+circle.Width = 56;
+circle.Height = 56;
+circle.StrokeColor = Color.Yellow; // or FillColor for a filled disc
+circle.AddToRoot();
+```
+
 ### Breaking: `UseGradient` no longer paints over a transparent fill
 
 Issue #2956 — `UseGradient` is a *pattern* flag, not a *visibility* flag. A fill or outline whose effective color alpha is 0 (e.g. the default-transparent fill on a stroke-only plain `CircleRuntime` / `RectangleRuntime`) no longer paints its gradient. This brings the Apos.Shapes (MonoGame/FNA/KNI) and raylib backends in line with the SkiaGum backend, which has always enforced this naturally — `SKPaint.Color.alpha` modulates the shader output, so a transparent paint color suppresses the gradient.
@@ -389,7 +427,8 @@ Before the fix, the same code rendered differently across backends: Apos and ray
 
 ```csharp
 var circle = new CircleRuntime();
-circle.Radius = 28;
+circle.Width = 56;
+circle.Height = 56;
 circle.UseGradient = true;
 circle.Color1 = Color.Black;
 circle.Color2 = Color.White;
@@ -401,7 +440,8 @@ circle.Color2 = Color.White;
 
 ```csharp
 var circle = new CircleRuntime();
-circle.Radius = 28;
+circle.Width = 56;
+circle.Height = 56;
 circle.FillColor = Color.White;   // light the fill up — opaque, RGB irrelevant
 circle.UseGradient = true;
 circle.Color1 = Color.Black;


### PR DESCRIPTION
## What

`CircleRuntime` and `RectangleRuntime` are the new fill+stroke shapes. Their inherited single-color legacy members — `Color` / `Red` / `Green` / `Blue` / `Alpha` — and Circle's `Radius` are superseded by `FillColor` / `StrokeColor` and `Width` / `Height`. They were previously `[Obsolete]` **only under XNALIKE**, so the same member warned on MonoGame but not on raylib or Skia — an inconsistent public API across backends.

This unifies the deprecation across **every** backend so the two new shapes present one API everywhere.

## How

- **`Radius` (Circle):** `[Obsolete]` is now unconditional (was XNALIKE-gated). The setter is unchanged — it still proxies `Width = Height = Radius * 2`.
- **raylib / sokol (`#elif !SKIA`):** added `[Obsolete]` to `Color` / `Red` / `Green` / `Blue` / `Alpha`.
- **Skia:** these members are inherited from `SkiaShapeRuntime`, the base for **all** Skia shapes. Rather than obsolete them on the base (which would wrongly hit the legacy single-color shapes — Arc, RoundedRectangle, ColoredCircle, …), the two new shapes **shadow** `Red` / `Green` / `Blue` / `Alpha` with `new` + `[Obsolete]` (mirroring the existing `DropshadowBlurX`/`Y` pattern in these files). `Color` is already `[Obsolete]` on the base, so it needs no shadow. The base stays untouched — legacy shapes keep these as their primary, non-obsolete API.

No runtime behavior changes — these are compile-time annotations only.

## Verification

Built MonoGameGum, RaylibGum, and SkiaGum (covering all three code paths — XNALIKE, `!SKIA`, SKIA). All existing Circle/Rectangle runtime tests pass:

| Project | Result |
|---|---|
| MonoGameGum.Tests | 35 passed |
| MonoGameGum.Shapes.Tests | 100 passed |
| RaylibGum.Tests | 38 passed |
| SkiaGum.Tests | 73 passed |

Zero new compiler warnings. `CS0618` is silenced only in the raylib/Skia tests that intentionally pin the legacy back-compat routing (file-level for the raylib legacy-surface test files, one scoped line in Skia), following the existing `MonoGameGum.Tests` convention.

## Notes

- The Gum tool (KNI = XNALIKE) compiles these files; the only newly-obsolete member on XNALIKE is `Radius`, and its lone tool-side write is already inside a `#pragma warning disable CS0618` dispatch block, so the tool stays warning-free. `GumFull.sln` was not built (FNA/Sokol submodules aren't checked out in the worktree), but no unsuppressed tool usage of any affected member exists.
- Sokol shares raylib's `!SKIA` path; its source has no usages of these members and `SokolGum` doesn't build in this environment (pre-existing missing native deps), so it couldn't be exercised directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
