### PR TITLE
Migrate bundled themes off legacy shape runtimes onto RectangleRuntime/CircleRuntime

### DIFF
--- a/.claude/skills/gum-theming/SKILL.md
+++ b/.claude/skills/gum-theming/SKILL.md
@@ -14,7 +14,7 @@ A theme restyles Forms controls by subclassing each V3 default visual, swapping 
 1. Wire KernSmith if the theme uses dynamic fonts: `CustomSetPropertyOnRenderable.InMemoryFontCreator = new KernSmithFontCreator(gd);`
 2. `BmfcSave.AddCharacters("…")` for any non-ASCII glyphs visuals will render. Must come before any text rendering — KernSmith only bakes characters it knows about at atlas-creation time.
 3. Register embedded TTFs via `KernSmithFontCreator.RegisterFont(family, bytes, style)`. See "Icon fonts" below.
-4. If your visuals use Apos.Shapes runtimes (`RoundedRectangleRuntime`, `ColoredCircleRuntime`, etc.), `if (!ShapeRenderer.Self.IsInitialized) ShapeRenderer.Self.Initialize();` — consumers shouldn't have to know your theme reaches for shapes internally.
+4. If your visuals use `RectangleRuntime` / `CircleRuntime` features backed by Apos.Shapes (rounded corners, circles, drop shadows — i.e. the `MonoGameGumShapes` package), `if (!ShapeRenderer.Self.IsInitialized) ShapeRenderer.Self.Initialize();` — consumers shouldn't have to know your theme reaches for shapes internally.
 5. Populate `Styling.ActiveStyle` (Text.Normal/Strong, Colors, optional SpriteSheet override) and `FrameworkElement.DefaultFormsTemplates[typeof(Button)] = new VisualTemplate((_, c) => new MyButtonVisual(tryCreateFormsObject: c));` for each restyled control.
 
 ## Visual-primitive options
@@ -32,7 +32,7 @@ Pick what matches the design. The replacement pattern below applies regardless o
 Each visual subclasses `Gum.Forms.DefaultVisuals.V3.*Visual`. In its constructor:
 
 1. **Detach** the children you're replacing — typically `Background.Parent = null; FocusedIndicator.Parent = null;` (and `ClipContainer.Parent = null;` for TextBox-style controls — see "ClipContainer reordering").
-2. **Add** the replacement children — NineSlice with new textures, Apos shapes, ColoredRectangles, whatever fits.
+2. **Add** the replacement children — NineSlice with new textures, `RectangleRuntime` / `CircleRuntime` shapes, whatever fits. (Mind the split fill/stroke surface: a fresh `RectangleRuntime`/`CircleRuntime` defaults to a *transparent fill + 1px white outline*, so a solid fill needs `FillColor = c; StrokeWidth = 0;` and an outline/ring needs `IsFilled = false; StrokeColor = c;`. `CornerRadius` rounds a Rectangle; both are Apos-backed when `MonoGameGumShapes` is referenced.)
 3. **Reattach** anything you detached for ordering reasons (TextInstance, ClipContainer) last so it renders on top of the new background layer.
 4. **Re-wire state callbacks with `=` (not `+=`)** so the base's color-pumping into the now-detached children is fully replaced. Each `States.{Enabled, Highlighted, Pushed, Focused, …}.Apply` becomes a fresh lambda that mutates your replacement children.
 
@@ -44,7 +44,7 @@ Different controls have different state sets — Button has 7, TextBox has 4 (no
 
 ## Dashed strokes are built into Apos.Shapes
 
-Need a dotted / dashed outline (Win95 focus rectangle, marching-ants selection, etc.)? Don't spawn many small `ColoredRectangleRuntime` "dot" instances along the edges. `RoundedRectangleRuntime` (and the other Apos shape runtimes) expose `StrokeDashLength` and `StrokeGapLength`. Set `IsFilled = false`, `StrokeWidth = 1`, both dash properties to your desired pattern, and the shape renders as a properly-rasterized dashed stroke — one node in the render tree, sized via the usual `RelativeToParent` units, with no per-frame dot bookkeeping and no sensitivity to layout timing.
+Need a dotted / dashed outline (Win95 focus rectangle, marching-ants selection, etc.)? Don't spawn many small `RectangleRuntime` "dot" instances along the edges. `RectangleRuntime` / `CircleRuntime` (and the other Apos shape runtimes) expose `StrokeDashLength` and `StrokeGapLength`. Set `IsFilled = false`, `StrokeWidth = 1`, both dash properties to your desired pattern, and the shape renders as a properly-rasterized dashed stroke — one node in the render tree, sized via the usual `RelativeToParent` units, with no per-frame dot bookkeeping and no sensitivity to layout timing.
 
 The dotted-rectangle materialization approach (place N tiny rectangles at fixed offsets) looks superficially simpler, but ends up needing `GetAbsoluteWidth()` to compute N — and that returns stale values when the consumer sets `control.Width = X; control.IsFocused = true;` back-to-back: the state callback fires before the next layout pass, so the dot count is computed off the construction-time size. The visible artifact is a half-drawn focus rect that "self-heals" once a hover fires another state change after layout has run.
 
@@ -52,7 +52,7 @@ The dotted-rectangle materialization approach (place N tiny rectangles at fixed 
 
 `ContainerRuntime`'s constructor sets `HasEvents = true`. If you wrap a control's chrome in a sub-container to constrain a fill primitive to a sub-region of the parent (the 13×13 checkbox box inside a 200×16 CheckBox visual, a dropdown-button-sized area inside a ComboBox, the slider-track inside the SliderVisual root), that wrapper will capture clicks that should bubble up to the InteractiveGue root — the control will look right and refuse to register clicks on the wrapped area.
 
-**Why:** `Bubblegum` and `DarkPro` never hit this because their primitives are single Apos.Shapes rects positioned and sized directly on the visual root (no wrapper needed). A theme that builds its chrome from multiple ColoredRectangleRuntime strips (bevels, dotted focus rings, etc.) typically needs a sized wrapper, and that's where the gotcha bites.
+**Why:** `Bubblegum` and `DarkPro` never hit this because their primitives are single `RectangleRuntime`/`CircleRuntime` shapes positioned and sized directly on the visual root (no wrapper needed). A theme that builds its chrome from multiple `RectangleRuntime` strips (Retro 95's bevels, dotted focus rings, etc.) typically needs a sized wrapper, and that's where the gotcha bites.
 
 **How to apply:** Any time you write `new ContainerRuntime()` inside a visual subclass, immediately set `HasEvents = false` unless you specifically want that container to absorb clicks (rare — usually only the Forms-control root and explicit drag-handle InteractiveGues should). Same goes for any other `InteractiveGue`-derived wrapper you introduce.
 
@@ -89,20 +89,20 @@ Wiring (all four steps required):
 
 Size the glyph's `TextRuntime` `Absolute`, **larger** than the box it sits in (~1.5x), centered. DejaVu Sans Mono and most icon-coverage fonts aren't truly monospaced for non-Latin — symbol glyphs have wider advance widths than ASCII, and a runtime sized exactly to the box clips or drops them.
 
-Building glyphs from Apos.Shapes primitives (`LineRuntime` strokes, rotated `RoundedRectangleRuntime`s) is technically possible but rarely worth it once you have more than one or two glyphs. Stick with DejaVu unless you have a strong reason — the icon font's ~600 KB is the cheapest entry point in the theme.
+Building glyphs from Apos.Shapes primitives (`LineRuntime` strokes, rotated `RectangleRuntime`s) is technically possible but rarely worth it once you have more than one or two glyphs. Stick with DejaVu unless you have a strong reason — the icon font's ~600 KB is the cheapest entry point in the theme.
 
 ## Drop shadows: use the native Apos.Shapes API, not stacked rects
 
-Apos.Shapes runtimes (`RoundedRectangleRuntime`, `ColoredCircleRuntime`, `ArcRuntime`) expose a native Gaussian drop shadow via `AposShapeRuntime`. Use it. Do not stack progressively-larger, fainter shapes underneath the body to fake a falloff — that approach is a holdover from a misreading of the Apos.Shapes capabilities and produces visible concentric banding because each layer is a hard-edged shape.
+Apos.Shapes-backed runtimes (`RectangleRuntime`, `CircleRuntime`) expose a native Gaussian drop shadow. Use it. Do not stack progressively-larger, fainter shapes underneath the body to fake a falloff — that approach is a holdover from a misreading of the Apos.Shapes capabilities and produces visible concentric banding because each layer is a hard-edged shape.
 
 Properties (all forwarded from the runtime to the underlying renderable):
 
 - `HasDropshadow` (`bool`) — master switch. Toggle per state.
 - `DropshadowColor` (`Color`) — RGBA. Match the CSS source alpha directly (`.4 alpha = 102 / 255`).
 - `DropshadowOffsetX`, `DropshadowOffsetY` (`float`) — pixel offset of the shadow from the body.
-- `DropshadowBlurX`, `DropshadowBlurY` (`float`) — blur radius per axis. Match the CSS `box-shadow` blur radius value directly. `0` = sharp.
+- `DropshadowBlur` (`float`) — blur radius. Match the CSS `box-shadow` blur radius value directly. `0` = sharp.
 
-Set the shadow once at construction (on the same `RoundedRectangleRuntime` that paints the body fill), then flip `HasDropshadow` in state callbacks for press/disabled — exactly the way state code already toggles `Visible`. No separate child shape, no z-order to manage.
+Set the shadow once at construction (on the same `RectangleRuntime` that paints the body fill), then flip `HasDropshadow` in state callbacks for press/disabled — exactly the way state code already toggles `Visible`. No separate child shape, no z-order to manage.
 
 CSS-to-Apos translation cheatsheet — `box-shadow: <offsetX> <offsetY> <blur> rgba(<r>,<g>,<b>,<a>)` maps to:
 
@@ -110,8 +110,7 @@ CSS-to-Apos translation cheatsheet — `box-shadow: <offsetX> <offsetY> <blur> r
 fill.HasDropshadow = true;
 fill.DropshadowOffsetX = <offsetX>;
 fill.DropshadowOffsetY = <offsetY>;
-fill.DropshadowBlurX   = <blur>;
-fill.DropshadowBlurY   = <blur>;
+fill.DropshadowBlur    = <blur>;
 fill.DropshadowColor   = new Color(r, g, b, (int)(a * 255));
 ```
 
@@ -119,7 +118,7 @@ The CSS `spread` argument (the optional fourth length value) has no direct equiv
 
 **Visual fidelity vs numerical fidelity.** A 1:1 number translation will not look the same as the CSS source. Two pipeline differences stack:
 
-- **Blur kernel semantics.** CSS treats `blur-radius` roughly as Gaussian standard deviation; Apos.Shapes interprets `DropshadowBlurX/Y` differently. Same value → different falloff width → different perceived softness.
+- **Blur kernel semantics.** CSS treats `blur-radius` roughly as Gaussian standard deviation; Apos.Shapes interprets `DropshadowBlur` differently. Same value → different falloff width → different perceived softness.
 - **Color space.** Browsers composite alpha in linear RGB (perceptually correct). MonoGame / Apos.Shapes composite in sRGB. Identical alpha math reads markedly darker in a browser; the in-game render comes out fainter.
 
 Treat CSS values as a *starting point* — typically you'll bump alpha by ~1.5–2× and tweak blur by eye until the perceived weight matches the source. The Bubblegum Button shadow ended at alpha 160 / blur 12, up from the spec's 102 / 10.
@@ -151,7 +150,7 @@ The ring living outside the body means painting it on top doesn't obscure any in
 
 ## Rounded outline + rectangular clip container: paint the border last
 
-Gum's clip containers are axis-aligned rectangles. They do not clip to rounded paths. If a themed container has a rounded outline (`RoundedRectangleRuntime` border) AND a child clip container that renders content (text, list items, hovered rows with their own pink fills), naively painting the border *behind* the clip container makes content visibly poke past the rounded outline at the corners.
+Gum's clip containers are axis-aligned rectangles. They do not clip to rounded paths. If a themed container has a rounded outline (`RectangleRuntime` border with `CornerRadius`) AND a child clip container that renders content (text, list items, hovered rows with their own pink fills), naively painting the border *behind* the clip container makes content visibly poke past the rounded outline at the corners.
 
 Fix: reattach so the **border renders last** (on top of the clip container). The stroke masks the corner-region content with the theme's accent color, and the result reads as rounded clipping even though no actual rounded clipping is happening.
 
@@ -183,9 +182,9 @@ Pattern (see Bubblegum's `BubblegumTextInputDecoration` for the worked example):
 ```csharp
 internal sealed class MyTextInputDecoration
 {
-    private readonly RoundedRectangleRuntime _focusRing;
-    private readonly RoundedRectangleRuntime _fill;
-    private readonly RoundedRectangleRuntime _border;
+    private readonly RectangleRuntime _focusRing;
+    private readonly RectangleRuntime _fill;
+    private readonly RectangleRuntime _border;
 
     public MyTextInputDecoration(TextBoxBaseVisual host)
     {

--- a/Runtimes/GumShapes/Renderables/RenderableShapeBase.cs
+++ b/Runtimes/GumShapes/Renderables/RenderableShapeBase.cs
@@ -636,20 +636,27 @@ public abstract class RenderableShapeBase : RenderableBase, Gum.GueDeriving.IBle
     }
 
     /// <summary>
-    /// Issue #2956 — gates whether this renderable's gradient pass should actually draw.
-    /// <see cref="UseGradient"/> is a *pattern* flag, not a *visibility* flag — a slot whose
-    /// solid <see cref="Color"/> alpha is 0 (e.g. the default-transparent fill on a stroke-only
-    /// plain Circle) must NOT paint its gradient. Apos.Shapes' gradient draw bypasses the
-    /// slot's solid color, so without this gate it would paint an opaque gradient on a slot
-    /// the user explicitly hid. SkiaSharp gets this right naturally because
-    /// <c>SKPaint.Color.alpha</c> modulates the shader output; we replicate that contract
-    /// here. <paramref name="forcedColor"/> is the per-call dropshadow override every render
-    /// path already short-circuits on — when set, the slot is painting the shadow, not the
-    /// gradient, so the gate must return false.
+    /// Issue #2956 / #2998 — gates whether this renderable's gradient pass should actually draw.
+    /// <see cref="UseGradient"/> is a *pattern* flag, not a *visibility* flag: a gradient with two
+    /// fully-transparent stops must NOT paint (it would draw nothing useful and, on Apos, the
+    /// gradient draw otherwise produces visible output). Visibility is decided by the gradient's
+    /// OWN alpha — at least one of <see cref="Alpha1"/> / <see cref="Alpha2"/> must be &gt; 0.
+    ///
+    /// This deliberately does NOT key off the slot's solid <see cref="Color"/>. The two-slot
+    /// RectangleRuntime / CircleRuntime default their solid fill to transparent (#2938 stroke-only
+    /// default), and a gradient fill is configured purely via UseGradient + Color1/Color2, never
+    /// the solid color — so gating on <c>Color.A</c> (the original #2956 gate) suppressed legitimate
+    /// gradient fills whose solid color was simply left at the transparent default (Forest Glade
+    /// buttons / list rows). The gradient stops carry their own alpha, which is the correct and
+    /// only signal for whether the gradient is meant to show.
+    ///
+    /// <paramref name="forcedColor"/> is the per-call dropshadow override every render path already
+    /// short-circuits on — when set, the slot is painting the shadow, not the gradient, so the gate
+    /// must return false.
     /// </summary>
     public bool ShouldPaintGradient(Color? forcedColor)
     {
-        return UseGradient && forcedColor == null && Color.A > 0;
+        return UseGradient && forcedColor == null && (Alpha1 > 0 || Alpha2 > 0);
     }
 
     /// <summary>

--- a/Runtimes/RaylibGum/Renderables/LineCircle.cs
+++ b/Runtimes/RaylibGum/Renderables/LineCircle.cs
@@ -226,17 +226,20 @@ public class LineCircle : InvisibleRenderable
     }
 
     /// <summary>
-    /// Issue #2956 — true when the fill pass should paint its gradient. Mirrors the SkPaint
-    /// contract enforced by SkiaGum: <see cref="UseGradient"/> is a *pattern* flag, not a
-    /// *visibility* flag, so a slot whose effective fill alpha is 0 (e.g. the default-
-    /// transparent fill on a stroke-only plain Circle) must NOT paint its gradient. Without
-    /// this gate <see cref="DrawGradientFan"/> would emit opaque triangles regardless of
-    /// <see cref="FillColor"/>'s alpha. The fill slot is enabled when an explicit
-    /// <see cref="FillColor"/> is set OR <see cref="IsFilled"/> is true (legacy
-    /// <see cref="Color"/> path); the effective fill color is then <c>FillColor ?? Color</c>.
+    /// Issue #2998 — true when the fill pass should paint its gradient. <see cref="UseGradient"/>
+    /// is a *pattern* flag, not a *visibility* flag: visibility is decided by the gradient's OWN
+    /// alpha — at least one of <see cref="Color1"/> / <see cref="Color2"/> must be visible. It
+    /// deliberately does NOT key off the slot's solid fill alpha: the two-slot RectangleRuntime /
+    /// CircleRuntime default the solid fill transparent (#2938 stroke-only default) and configure a
+    /// gradient purely via UseGradient + Color1/Color2, so gating on <c>FillColor ?? Color</c> alpha
+    /// (the original #2956 gate) suppressed legitimate gradient fills. The fill slot must still be
+    /// enabled — an explicit <see cref="FillColor"/> is set OR <see cref="IsFilled"/> is true — but
+    /// its solid alpha is irrelevant to the gradient. Without this gate <see cref="DrawGradientFan"/>
+    /// would emit triangles whose per-vertex alpha comes only from the stops, which is exactly what
+    /// we want once the stops carry the visibility.
     /// </summary>
     public bool ShouldPaintFillGradient =>
-        UseGradient && (FillColor.HasValue || IsFilled) && (FillColor ?? Color).A > 0;
+        UseGradient && (FillColor.HasValue || IsFilled) && (Color1.A > 0 || Color2.A > 0);
 
     /// <summary>
     /// Issue #2934 / #2956 — returns the linear gradient axis endpoints rotated around the
@@ -396,12 +399,11 @@ public class LineCircle : InvisibleRenderable
                 // detector. The fan structure matches raylib's own DrawCircle implementation
                 // in rshapes.c — center vertex + N rim vertices fan into N triangles.
                 //
-                // Issue #2956 — suppress the fan when the slot's effective fill alpha is 0.
-                // DrawGradientFan emits per-vertex Color1/Color2 directly with no modulation
-                // by fillColor.A, so without this gate a default-transparent fill would still
-                // paint an opaque gradient (Skia naturally avoids this via paint.Color.alpha
-                // modulating the shader; we replicate it explicitly). See ShouldPaintFillGradient.
-                if (fillColor.A > 0)
+                // Issue #2998 — gradient visibility comes from the gradient STOP alphas, not the
+                // solid fill alpha. DrawGradientFan emits per-vertex Color1/Color2 directly, so
+                // route through ShouldPaintFillGradient (the single source of truth): a transparent
+                // solid fill with visible stops still paints; two transparent stops paint nothing.
+                if (ShouldPaintFillGradient)
                 {
                     DrawGradientFan(cx, cy, Radius);
                 }

--- a/Runtimes/RaylibGum/Renderables/LineRectangle.cs
+++ b/Runtimes/RaylibGum/Renderables/LineRectangle.cs
@@ -225,12 +225,12 @@ public class LineRectangle : InvisibleRenderable
     }
 
     /// <summary>
-    /// Issue #2956 — see <see cref="LineCircle.ShouldPaintFillGradient"/> for the full
+    /// Issue #2998 — see <see cref="LineCircle.ShouldPaintFillGradient"/> for the full
     /// contract. Same gate, same predicate, applied to <see cref="DrawLinearGradientQuad"/>
     /// and <see cref="DrawRadialGradientCircles"/> on the fill pass.
     /// </summary>
     public bool ShouldPaintFillGradient =>
-        UseGradient && (FillColor.HasValue || IsFilled) && (FillColor ?? Color).A > 0;
+        UseGradient && (FillColor.HasValue || IsFilled) && (Color1.A > 0 || Color2.A > 0);
 
     public LineRectangle() : this(null) { }
 
@@ -377,13 +377,14 @@ public class LineRectangle : InvisibleRenderable
                 // rectangle-local coords (origin = top-left, +X right, +Y down). Rotation
                 // applied via the same R() helper used by the outline path.
                 //
-                // Issue #2956 — suppress the gradient when the slot's effective fill alpha is
-                // 0; neither DrawLinearGradientQuad nor DrawRadialGradientCircles modulates
-                // by fillColor.A, so a default-transparent fill would otherwise paint an
-                // opaque gradient. See ShouldPaintFillGradient.
-                if (fillColor.A == 0)
+                // Issue #2998 — gradient visibility comes from the gradient STOP alphas, not the
+                // solid fill alpha; neither DrawLinearGradientQuad nor DrawRadialGradientCircles
+                // modulates by fillColor.A. Route through ShouldPaintFillGradient (the single source
+                // of truth) so a transparent solid fill with visible stops still paints, and two
+                // transparent stops paint nothing.
+                if (!ShouldPaintFillGradient)
                 {
-                    // Slot is invisible — skip both the gradient and the solid path.
+                    // No visible gradient stop — skip both the gradient and the solid path.
                 }
                 else if (GradientType == GradientType.Linear)
                 {

--- a/Runtimes/SkiaGum/Renderables/RenderableShapeBase.cs
+++ b/Runtimes/SkiaGum/Renderables/RenderableShapeBase.cs
@@ -798,6 +798,14 @@ public class RenderableShapeBase : IRenderableIpso, IVisible, IDisposable
         if (UseGradient)
         {
             ApplyGradientToPaint(boundingRect, paint, absoluteRotation);
+
+            // Issue #2998 — gradient visibility comes from the stop alphas (Alpha1 / Alpha2), not
+            // the solid fill color. SkiaSharp modulates a shader's output by SKPaint.Color.alpha,
+            // so leaving the (transparent-by-default) solid fill alpha in place would suppress a
+            // legitimate gradient. Force the paint opaque so the stops drive visibility — two
+            // transparent stops still render nothing. Mirrors the Apos ShouldPaintGradient and
+            // raylib ShouldPaintFillGradient gates, which also ignore the solid fill alpha.
+            paint.Color = new SKColor(paint.Color.Red, paint.Color.Green, paint.Color.Blue, 255);
         }
 
         if (!IsFilled && StrokeDashLength > 0 && StrokeGapLength > 0)

--- a/Samples/MonoGameGumThemesShowcase/Game1.cs
+++ b/Samples/MonoGameGumThemesShowcase/Game1.cs
@@ -1,3 +1,4 @@
+using System;
 using Gum.Themes.Bubblegum;
 using Gum.Themes.DarkPro;
 using Gum.Themes.Editor;
@@ -5,6 +6,7 @@ using Gum.Themes.ForestGlade;
 using Gum.Themes.Neon;
 using Gum.Themes.Retro95;
 using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Input;
 using MonoGameGum;
 using MonoGameGumThemesShowcase.Screens;
@@ -17,8 +19,27 @@ public class Game1 : Game
     GumService GumUI => GumService.Default;
 
     ShowcaseScreen _currentScreen;
+    Func<ShowcaseScreen> _currentScreenFactory;
+    ThemeOption[] _themes;
+    int _currentThemeIndex;
     KeyboardState _previousKeyboard;
     Color _clearColor;
+
+    // A selectable theme: its display name, its Apply entry point, and the
+    // backdrop color the showcase should clear to while it is active.
+    sealed class ThemeOption
+    {
+        public string Name { get; }
+        public Action<GraphicsDevice> Apply { get; }
+        public Color ClearColor { get; }
+
+        public ThemeOption(string name, Action<GraphicsDevice> apply, Color clearColor)
+        {
+            Name = name;
+            Apply = apply;
+            ClearColor = clearColor;
+        }
+    }
 
     public Game1()
     {
@@ -52,57 +73,87 @@ public class Game1 : Game
         GumUI.Initialize(this);
         GumUI.UseKeyboardDefaults();
 
-        // ---- Choose ONE theme (uncomment exactly one block) ----
+        // Press 1-6 to swap themes; the active screen is rebuilt so its
+        // controls pick up the newly-installed default templates. Editor has
+        // no named Background color, so a sensible dark surround is used; the
+        // Retro95 chrome is its Surface (battleship gray).
+        _themes = new[]
+        {
+            new ThemeOption("Forest Glade", ForestGladeTheme.Apply, ForestGladeColors.CanopyDeep),
+            new ThemeOption("Neon", NeonTheme.Apply, NeonColors.Background),
+            new ThemeOption("Dark Pro", DarkProTheme.Apply, DarkProColors.Background),
+            new ThemeOption("Bubblegum", BubblegumTheme.Apply, BubblegumColors.Background),
+            new ThemeOption("Editor", EditorTheme.Apply, new Color(40, 40, 40)),
+            new ThemeOption("Retro 95", Retro95Theme.Apply, Retro95Colors.Surface),
+        };
 
-        ForestGladeTheme.Apply(GraphicsDevice);
-        _clearColor = ForestGladeColors.CanopyDeep;
+        // F1: all controls. F2: screenshot panel.
+        _currentScreenFactory = () => new AllControlsScreen();
 
-        //NeonTheme.Apply(GraphicsDevice);
-        //_clearColor = NeonColors.Background;
-
-        //DarkProTheme.Apply(GraphicsDevice);
-        //_clearColor = DarkProColors.Background;
-
-        //BubblegumTheme.Apply(GraphicsDevice);
-        //_clearColor = BubblegumColors.Background;
-
-        //EditorTheme.Apply(GraphicsDevice);
-        //_clearColor = new Color(40, 40, 40); // Editor has no named Background; this is a sensible dark surround.
-
-        //Retro95Theme.Apply(GraphicsDevice);
-        //_clearColor = Retro95Colors.Surface; // Retro95 has no Background; Surface (battleship gray) is the chrome.
-
-        // ---------------------------------------------------------
-
-        // ---- Choose ONE screen ----
-
-        SwitchScreen(new AllControlsScreen());
-        //SwitchScreen(new ScreenshotScreen());
-
-        // ----------------------------
+        ApplyTheme(0);
+        RebuildScreen();
 
         base.Initialize();
     }
 
-    // F1: all controls. F2: screenshot panel.
-    void SwitchScreen(ShowcaseScreen newScreen)
+    // Installs the theme's default templates / styling and updates the
+    // backdrop. Callers must RebuildScreen afterward so existing controls
+    // re-resolve their visuals from the new templates.
+    void ApplyTheme(int index)
     {
+        if (index < 0 || index >= _themes.Length)
+        {
+            return;
+        }
+
+        _currentThemeIndex = index;
+        ThemeOption theme = _themes[index];
+        theme.Apply(GraphicsDevice);
+        _clearColor = theme.ClearColor;
+        Window.Title = $"Gum Theme Showcase — {index + 1}. {theme.Name}  (1-{_themes.Length} swap theme, F1/F2 swap screen)";
+    }
+
+    void RebuildScreen()
+    {
+        SwitchScreen(_currentScreenFactory);
+    }
+
+    void SwitchScreen(Func<ShowcaseScreen> factory)
+    {
+        _currentScreenFactory = factory;
         _currentScreen?.Destroy();
-        _currentScreen = newScreen;
+        _currentScreen = factory();
         _currentScreen.Build();
     }
 
     protected override void Update(GameTime gameTime)
     {
         var keyboard = Keyboard.GetState();
+
         if (keyboard.IsKeyDown(Keys.F1) && _previousKeyboard.IsKeyUp(Keys.F1))
         {
-            SwitchScreen(new AllControlsScreen());
+            SwitchScreen(() => new AllControlsScreen());
         }
         else if (keyboard.IsKeyDown(Keys.F2) && _previousKeyboard.IsKeyUp(Keys.F2))
         {
-            SwitchScreen(new ScreenshotScreen());
+            SwitchScreen(() => new ScreenshotScreen());
         }
+
+        // Number keys 1-6 swap the active theme and rebuild the current screen.
+        for (int i = 0; i < _themes.Length; i++)
+        {
+            Keys themeKey = Keys.D1 + i;
+            if (keyboard.IsKeyDown(themeKey) && _previousKeyboard.IsKeyUp(themeKey))
+            {
+                if (i != _currentThemeIndex)
+                {
+                    ApplyTheme(i);
+                    RebuildScreen();
+                }
+                break;
+            }
+        }
+
         _previousKeyboard = keyboard;
 
         GumUI.Update(gameTime);

--- a/Tests/MonoGameGum.Shapes.Tests/CircleRenderableTests.cs
+++ b/Tests/MonoGameGum.Shapes.Tests/CircleRenderableTests.cs
@@ -472,35 +472,55 @@ public class CircleRenderableTests
         sut.ComputeFillDrawRadius(radius: 50f, isShadowPass: true).ShouldBe(50f);
     }
 
+    // Issue #2998 — the gradient-visibility gate keys off the GRADIENT STOP alphas (Alpha1 /
+    // Alpha2), NOT the slot's solid Color. The new RectangleRuntime / CircleRuntime default
+    // FillColor to transparent (#2938 stroke-only default); a theme that wants a gradient fill
+    // sets UseGradient + Color1/Color2 and never touches the solid color, so gating on Color.A
+    // suppressed the gradient entirely (Forest Glade buttons / list rows went invisible). The
+    // solid color is irrelevant to whether a gradient paints — only the stops are.
+
     [Fact]
-    public void ShouldPaintGradient_GradientOff_False()
+    public void ShouldPaintGradient_BothGradientStopsTransparent_OpaqueSolid_False()
     {
-        Circle sut = new() { UseGradient = false, Color = new Color(255, 255, 255, 255) };
+        // Both stops invisible → no gradient, regardless of an opaque solid color.
+        Circle sut = new() { UseGradient = true, Color = new Color(255, 255, 255, 255), Alpha1 = 0, Alpha2 = 0 };
 
         sut.ShouldPaintGradient(forcedColor: null).ShouldBeFalse();
     }
 
     [Fact]
-    public void ShouldPaintGradient_GradientOn_ForcedColor_False()
+    public void ShouldPaintGradient_ForcedColor_False()
     {
-        Circle sut = new() { UseGradient = true, Color = new Color(255, 255, 255, 255) };
+        // forcedColor means the slot is painting a dropshadow this pass, never the gradient.
+        Circle sut = new() { UseGradient = true, Alpha1 = 255, Alpha2 = 255 };
 
         sut.ShouldPaintGradient(forcedColor: new Color(0, 0, 0, 255)).ShouldBeFalse();
     }
 
     [Fact]
-    public void ShouldPaintGradient_GradientOn_OpaqueSlot_True()
+    public void ShouldPaintGradient_GradientOff_False()
     {
-        Circle sut = new() { UseGradient = true, Color = new Color(255, 255, 255, 255) };
+        Circle sut = new() { UseGradient = false, Alpha1 = 255, Alpha2 = 255 };
+
+        sut.ShouldPaintGradient(forcedColor: null).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ShouldPaintGradient_OneGradientStopVisible_TransparentSolid_True()
+    {
+        // A single visible stop is enough; the transparent solid color must not suppress it.
+        Circle sut = new() { UseGradient = true, Color = new Color(0, 0, 0, 0), Alpha1 = 255, Alpha2 = 0 };
 
         sut.ShouldPaintGradient(forcedColor: null).ShouldBeTrue();
     }
 
     [Fact]
-    public void ShouldPaintGradient_GradientOn_TransparentSlot_False()
+    public void ShouldPaintGradient_VisibleGradientStops_TransparentSolid_True()
     {
-        Circle sut = new() { UseGradient = true, Color = new Color(255, 255, 255, 0) };
+        // The core regression repro: gradient stops are opaque but the solid fill is transparent
+        // (the new default). The gradient must still paint.
+        Circle sut = new() { UseGradient = true, Color = new Color(0, 0, 0, 0), Alpha1 = 255, Alpha2 = 255 };
 
-        sut.ShouldPaintGradient(forcedColor: null).ShouldBeFalse();
+        sut.ShouldPaintGradient(forcedColor: null).ShouldBeTrue();
     }
 }

--- a/Tests/MonoGameGum.Shapes.Tests/RoundedRectangleRenderableTests.cs
+++ b/Tests/MonoGameGum.Shapes.Tests/RoundedRectangleRenderableTests.cs
@@ -125,4 +125,25 @@ public class RoundedRectangleRenderableTests
         aaSize.ShouldBe(0);
         alphaScale.ShouldBe(1f);
     }
+
+    // Issue #2998 — gradient visibility keys off the gradient STOP alphas (Alpha1 / Alpha2), not the
+    // slot's solid Color. ShouldPaintGradient lives on the shared RenderableShapeBase (also covered
+    // by CircleRenderableTests); these duplicate the contract on RoundedRectangle because it is the
+    // shape the Forest Glade buttons / list rows actually use — the originally-reported regression.
+
+    [Fact]
+    public void ShouldPaintGradient_BothGradientStopsTransparent_OpaqueSolid_False()
+    {
+        RoundedRectangle sut = new() { UseGradient = true, Color = new Color(255, 255, 255, 255), Alpha1 = 0, Alpha2 = 0 };
+
+        sut.ShouldPaintGradient(forcedColor: null).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ShouldPaintGradient_VisibleGradientStops_TransparentSolid_True()
+    {
+        RoundedRectangle sut = new() { UseGradient = true, Color = new Color(0, 0, 0, 0), Alpha1 = 255, Alpha2 = 255 };
+
+        sut.ShouldPaintGradient(forcedColor: null).ShouldBeTrue();
+    }
 }

--- a/Tests/RaylibGum.Tests/Renderables/LineCircleTests.cs
+++ b/Tests/RaylibGum.Tests/Renderables/LineCircleTests.cs
@@ -223,24 +223,23 @@ public class LineCircleTests
         circle.Color.A.ShouldBe((byte)78);
     }
 
-    // Issue #2956 — UseGradient is a *pattern* flag, not a *visibility* flag. The effective
-    // fill color is `FillColor ?? Color`; when its alpha is 0 the slot is invisible and the
-    // gradient must not paint over it. Mirrors the SkPaint contract (paint.Color.alpha
-    // modulates shader output) that the SkiaGum backend enforces naturally. Apos and raylib
-    // both used to leak — see fix in EmitGradientVertex / DrawGradientFan gating.
+    // Issue #2998 — UseGradient is a *pattern* flag, not a *visibility* flag. Visibility is driven
+    // by the gradient STOP alphas (Color1 / Color2), NOT the slot's solid fill color. A fill slot
+    // must exist (FillColor set or IsFilled), but its solid alpha is irrelevant. Replaces the #2956
+    // gate, which keyed off `FillColor ?? Color` alpha and went invisible once RectangleRuntime /
+    // CircleRuntime defaulted the solid fill transparent (#2938 stroke-only default).
 
     [Fact]
-    public void ShouldPaintFillGradient_FillColorOpaque_True()
+    public void ShouldPaintFillGradient_BothGradientStopsTransparent_OpaqueFill_False()
     {
-        LineCircle circle = new() { UseGradient = true, FillColor = new Color(10, 20, 30, 255) };
-
-        circle.ShouldPaintFillGradient.ShouldBeTrue();
-    }
-
-    [Fact]
-    public void ShouldPaintFillGradient_FillColorTransparent_False()
-    {
-        LineCircle circle = new() { UseGradient = true, FillColor = new Color(10, 20, 30, 0) };
+        // Both stops invisible → no gradient, even with an opaque solid fill.
+        LineCircle circle = new()
+        {
+            UseGradient = true,
+            FillColor = new Color(10, 20, 30, 255),
+            Color1 = new Color(1, 2, 3, 0),
+            Color2 = new Color(4, 5, 6, 0),
+        };
 
         circle.ShouldPaintFillGradient.ShouldBeFalse();
     }
@@ -254,30 +253,62 @@ public class LineCircleTests
     }
 
     [Fact]
-    public void ShouldPaintFillGradient_LegacyFillViaIsFilled_OpaqueColor_True()
+    public void ShouldPaintFillGradient_IsFilled_VisibleStops_True()
     {
-        LineCircle circle = new() { UseGradient = true, IsFilled = true };
+        LineCircle circle = new()
+        {
+            UseGradient = true,
+            IsFilled = true,
+            Color1 = new Color(10, 20, 30, 255),
+            Color2 = new Color(40, 50, 60, 255),
+        };
 
-        // Default Color is opaque white, so the legacy fill path lights up.
         circle.ShouldPaintFillGradient.ShouldBeTrue();
-    }
-
-    [Fact]
-    public void ShouldPaintFillGradient_LegacyFillViaIsFilled_TransparentColor_False()
-    {
-        LineCircle circle = new() { UseGradient = true, IsFilled = true, Alpha = 0 };
-
-        circle.ShouldPaintFillGradient.ShouldBeFalse();
     }
 
     [Fact]
     public void ShouldPaintFillGradient_NoFillSlotEnabled_False()
     {
         // Default LineCircle: IsFilled = false, FillColor = null → fill pass doesn't run at all,
-        // so the gradient cannot paint regardless of UseGradient.
-        LineCircle circle = new() { UseGradient = true };
+        // so the gradient cannot paint regardless of UseGradient or stop alphas.
+        LineCircle circle = new()
+        {
+            UseGradient = true,
+            Color1 = new Color(10, 20, 30, 255),
+            Color2 = new Color(40, 50, 60, 255),
+        };
 
         circle.ShouldPaintFillGradient.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ShouldPaintFillGradient_OneGradientStopVisible_True()
+    {
+        LineCircle circle = new()
+        {
+            UseGradient = true,
+            IsFilled = true,
+            Color1 = new Color(10, 20, 30, 255),
+            Color2 = new Color(40, 50, 60, 0),
+        };
+
+        circle.ShouldPaintFillGradient.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void ShouldPaintFillGradient_TransparentFill_VisibleStops_True()
+    {
+        // Core regression repro: solid fill transparent (the new CircleRuntime default), gradient
+        // stops opaque → the gradient must still paint.
+        LineCircle circle = new()
+        {
+            UseGradient = true,
+            FillColor = new Color(10, 20, 30, 0),
+            Color1 = new Color(10, 20, 30, 255),
+            Color2 = new Color(40, 50, 60, 255),
+        };
+
+        circle.ShouldPaintFillGradient.ShouldBeTrue();
     }
 
     // Issue #2934 / #2956 — LineCircle.Render previously ignored Rotation entirely. The disc

--- a/Tests/RaylibGum.Tests/Renderables/LineRectangleTests.cs
+++ b/Tests/RaylibGum.Tests/Renderables/LineRectangleTests.cs
@@ -194,22 +194,23 @@ public class LineRectangleTests
         rectangle.Color.A.ShouldBe((byte)78);
     }
 
-    // Issue #2956 — see LineCircleTests.ShouldPaintFillGradient_* for the full contract.
-    // Same gating logic applies to LineRectangle's fill gradient path (linear quad + radial
-    // concentric circles).
+    // Issue #2998 — see LineCircleTests.ShouldPaintFillGradient_* for the full contract.
+    // Gradient visibility is driven by the gradient STOP alphas (Color1 / Color2), NOT the slot's
+    // solid fill color — a fill slot must exist (FillColor set or IsFilled), but its solid alpha is
+    // irrelevant. Replaces the #2956 gate (which keyed off the solid fill alpha and went invisible
+    // once RectangleRuntime defaulted FillColor transparent).
 
     [Fact]
-    public void ShouldPaintFillGradient_FillColorOpaque_True()
+    public void ShouldPaintFillGradient_BothGradientStopsTransparent_OpaqueFill_False()
     {
-        LineRectangle rectangle = new() { UseGradient = true, FillColor = new Color(10, 20, 30, 255) };
-
-        rectangle.ShouldPaintFillGradient.ShouldBeTrue();
-    }
-
-    [Fact]
-    public void ShouldPaintFillGradient_FillColorTransparent_False()
-    {
-        LineRectangle rectangle = new() { UseGradient = true, FillColor = new Color(10, 20, 30, 0) };
+        // Both stops invisible → no gradient, even with an opaque solid fill.
+        LineRectangle rectangle = new()
+        {
+            UseGradient = true,
+            FillColor = new Color(10, 20, 30, 255),
+            Color1 = new Color(1, 2, 3, 0),
+            Color2 = new Color(4, 5, 6, 0),
+        };
 
         rectangle.ShouldPaintFillGradient.ShouldBeFalse();
     }
@@ -223,26 +224,60 @@ public class LineRectangleTests
     }
 
     [Fact]
-    public void ShouldPaintFillGradient_LegacyFillViaIsFilled_OpaqueColor_True()
+    public void ShouldPaintFillGradient_IsFilled_VisibleStops_True()
     {
-        LineRectangle rectangle = new() { UseGradient = true, IsFilled = true };
+        LineRectangle rectangle = new()
+        {
+            UseGradient = true,
+            IsFilled = true,
+            Color1 = new Color(10, 20, 30, 255),
+            Color2 = new Color(40, 50, 60, 255),
+        };
 
         rectangle.ShouldPaintFillGradient.ShouldBeTrue();
     }
 
     [Fact]
-    public void ShouldPaintFillGradient_LegacyFillViaIsFilled_TransparentColor_False()
+    public void ShouldPaintFillGradient_NoFillSlotEnabled_False()
     {
-        LineRectangle rectangle = new() { UseGradient = true, IsFilled = true, Alpha = 0 };
+        // Visible stops are not enough — without a fill slot there is nothing to fill.
+        LineRectangle rectangle = new()
+        {
+            UseGradient = true,
+            Color1 = new Color(10, 20, 30, 255),
+            Color2 = new Color(40, 50, 60, 255),
+        };
 
         rectangle.ShouldPaintFillGradient.ShouldBeFalse();
     }
 
     [Fact]
-    public void ShouldPaintFillGradient_NoFillSlotEnabled_False()
+    public void ShouldPaintFillGradient_OneGradientStopVisible_True()
     {
-        LineRectangle rectangle = new() { UseGradient = true };
+        LineRectangle rectangle = new()
+        {
+            UseGradient = true,
+            IsFilled = true,
+            Color1 = new Color(10, 20, 30, 255),
+            Color2 = new Color(40, 50, 60, 0),
+        };
 
-        rectangle.ShouldPaintFillGradient.ShouldBeFalse();
+        rectangle.ShouldPaintFillGradient.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void ShouldPaintFillGradient_TransparentFill_VisibleStops_True()
+    {
+        // Core regression repro: solid fill transparent (the new RectangleRuntime default), gradient
+        // stops opaque → the gradient must still paint.
+        LineRectangle rectangle = new()
+        {
+            UseGradient = true,
+            FillColor = new Color(10, 20, 30, 0),
+            Color1 = new Color(10, 20, 30, 255),
+            Color2 = new Color(40, 50, 60, 255),
+        };
+
+        rectangle.ShouldPaintFillGradient.ShouldBeTrue();
     }
 }

--- a/Tests/SkiaGum.Tests/Renderables/GradientPaintTests.cs
+++ b/Tests/SkiaGum.Tests/Renderables/GradientPaintTests.cs
@@ -1,0 +1,56 @@
+using Shouldly;
+using SkiaGum.Renderables;
+using SkiaSharp;
+
+namespace SkiaGum.Tests.Renderables;
+
+/// <summary>
+/// Issue #2998 — the gradient's visibility is driven by its own stop alphas, not the slot's solid
+/// fill color. SkiaSharp modulates a shader's output by <c>SKPaint.Color.alpha</c>, so a gradient
+/// fill whose solid color is transparent (the new RectangleRuntime / CircleRuntime default) would
+/// be modulated to nothing. <c>GetPaint</c> forces the paint opaque whenever a gradient is active so
+/// the stop alphas carry visibility — matching the Apos <c>ShouldPaintGradient</c> and raylib
+/// <c>ShouldPaintFillGradient</c> gates. The gate lives in the shared <c>RenderableShapeBase.GetPaint</c>,
+/// so testing one concrete shape exercises every Skia shape (Arc / Line override GetPaint but call base).
+/// </summary>
+public class GradientPaintTests
+{
+    [Fact]
+    public void GetPaint_GradientWithTransparentSolidFill_PaintAlphaNotSuppressed()
+    {
+        TestableRoundedRectangle sut = new()
+        {
+            UseGradient = true,
+            Color = new SKColor(0, 0, 0, 0),
+            Alpha1 = 255,
+            Alpha2 = 255,
+        };
+
+        using SKPaint paint = sut.InvokeGetPaint(new SKRect(0, 0, 100, 100), absoluteRotation: 0);
+
+        paint.Shader.ShouldNotBeNull();
+        paint.Color.Alpha.ShouldBe((byte)255);
+    }
+
+    [Fact]
+    public void GetPaint_NoGradient_TransparentSolidFillPreserved()
+    {
+        // Without a gradient the opaque-forcing must not kick in — a transparent solid fill stays
+        // transparent (invisible solid fill).
+        TestableRoundedRectangle sut = new()
+        {
+            UseGradient = false,
+            Color = new SKColor(0, 0, 0, 0),
+        };
+
+        using SKPaint paint = sut.InvokeGetPaint(new SKRect(0, 0, 100, 100), absoluteRotation: 0);
+
+        paint.Color.Alpha.ShouldBe((byte)0);
+    }
+
+    private sealed class TestableRoundedRectangle : RoundedRectangle
+    {
+        public SKPaint InvokeGetPaint(SKRect boundingRect, float absoluteRotation)
+            => GetPaint(boundingRect, absoluteRotation);
+    }
+}

--- a/Themes/Gum.Themes.Bubblegum.MonoGame/BubblegumTextInputDecoration.cs
+++ b/Themes/Gum.Themes.Bubblegum.MonoGame/BubblegumTextInputDecoration.cs
@@ -20,9 +20,9 @@ internal sealed class BubblegumTextInputDecoration
     private const float FocusRingInset = 2f;
     private const float FocusRingThickness = 3f;
 
-    private readonly RoundedRectangleRuntime _focusRing;
-    private readonly RoundedRectangleRuntime _fill;
-    private readonly RoundedRectangleRuntime _border;
+    private readonly RectangleRuntime _focusRing;
+    private readonly RectangleRuntime _fill;
+    private readonly RectangleRuntime _border;
 
     public BubblegumTextInputDecoration(TextBoxBaseVisual host)
     {
@@ -50,9 +50,9 @@ internal sealed class BubblegumTextInputDecoration
         WireStates(host);
     }
 
-    private static RoundedRectangleRuntime CreateFill()
+    private static RectangleRuntime CreateFill()
     {
-        RoundedRectangleRuntime fill = new RoundedRectangleRuntime();
+        RectangleRuntime fill = new RectangleRuntime();
         fill.Name = "BubblegumTextInputFill";
         fill.X = 0;
         fill.Y = 0;
@@ -66,13 +66,14 @@ internal sealed class BubblegumTextInputDecoration
         fill.HeightUnits = DimensionUnitType.RelativeToParent;
         fill.CornerRadius = CornerRadius;
         fill.IsFilled = true;
-        fill.Color = BubblegumColors.Surface1;
+        fill.FillColor = BubblegumColors.Surface1;
+        fill.StrokeWidth = 0;
         return fill;
     }
 
-    private static RoundedRectangleRuntime CreateBorder()
+    private static RectangleRuntime CreateBorder()
     {
-        RoundedRectangleRuntime border = new RoundedRectangleRuntime();
+        RectangleRuntime border = new RectangleRuntime();
         border.Name = "BubblegumTextInputBorder";
         border.X = 0;
         border.Y = 0;
@@ -88,13 +89,13 @@ internal sealed class BubblegumTextInputDecoration
         border.IsFilled = false;
         border.StrokeWidth = BorderThickness;
         border.StrokeWidthUnits = DimensionUnitType.Absolute;
-        border.Color = BubblegumColors.Border;
+        border.StrokeColor = BubblegumColors.Border;
         return border;
     }
 
-    private static RoundedRectangleRuntime CreateFocusRing()
+    private static RectangleRuntime CreateFocusRing()
     {
-        RoundedRectangleRuntime ring = new RoundedRectangleRuntime();
+        RectangleRuntime ring = new RectangleRuntime();
         ring.Name = "BubblegumTextInputFocusRing";
         ring.X = 0;
         ring.Y = 0;
@@ -110,7 +111,7 @@ internal sealed class BubblegumTextInputDecoration
         ring.IsFilled = false;
         ring.StrokeWidth = FocusRingThickness;
         ring.StrokeWidthUnits = DimensionUnitType.Absolute;
-        ring.Color = BubblegumPalette.FocusRing;
+        ring.StrokeColor = BubblegumPalette.FocusRing;
         ring.Visible = false;
         return ring;
     }
@@ -141,8 +142,8 @@ internal sealed class BubblegumTextInputDecoration
     private void Apply(TextBoxBaseVisual host, Color fill, Color border, Color text,
         Color placeholder, Color caret, Color selection, bool ring)
     {
-        _fill.Color = fill;
-        _border.Color = border;
+        _fill.FillColor = fill;
+        _border.StrokeColor = border;
         host.TextInstance.Color = text;
         host.PlaceholderTextInstance.Color = placeholder;
         host.CaretInstance.Color = caret;

--- a/Themes/Gum.Themes.Bubblegum.MonoGame/BubblegumTheme.cs
+++ b/Themes/Gum.Themes.Bubblegum.MonoGame/BubblegumTheme.cs
@@ -64,8 +64,8 @@ public static class BubblegumTheme
         BmfcSave.AddCharacters("✓▼");
 
         // Bubblegum's visuals build their bodies out of Apos.Shapes-backed
-        // RoundedRectangleRuntime instances, which require ShapeRenderer to
-        // be initialized. Guard for the case where the host app already
+        // RectangleRuntime / CircleRuntime instances, which require ShapeRenderer
+        // to be initialized. Guard for the case where the host app already
         // initialized it (mixing themes / using shape runtimes elsewhere).
         if (!ShapeRenderer.Self.IsInitialized)
         {
@@ -214,5 +214,16 @@ public static class BubblegumTheme
 
         FrameworkElement.DefaultFormsTemplates[typeof(Tooltip)] =
             new VisualTemplate((_, c) => new TooltipVisual(tryCreateFormsObject: c));
+
+        // Controls Bubblegum does not restyle are pinned to their stock V3 visuals so
+        // BubblegumTheme.Apply fully specifies the template set. FrameworkElement.DefaultFormsTemplates
+        // is global static state; without re-registering these, re-applying a theme at runtime
+        // (theme switching) would leave a previously-applied theme's visual in place for these
+        // controls. These match what a single-theme Bubblegum run already falls back to.
+        FrameworkElement.DefaultFormsTemplates[typeof(ItemsControl)] =
+            new VisualTemplate((_, c) => new Gum.Forms.DefaultVisuals.V3.ItemsControlVisual(tryCreateFormsObject: c));
+
+        FrameworkElement.DefaultFormsTemplates[typeof(Gum.Forms.Controls.Games.DialogBox)] =
+            new VisualTemplate((_, c) => new Gum.Forms.DefaultVisuals.V3.DialogBoxVisual(tryCreateFormsObject: c));
     }
 }

--- a/Themes/Gum.Themes.Bubblegum.MonoGame/ButtonVisual.cs
+++ b/Themes/Gum.Themes.Bubblegum.MonoGame/ButtonVisual.cs
@@ -45,8 +45,8 @@ public class ButtonVisual : BaseButtonVisual
     private const float ShadowBlur = 12f;
     private static readonly Color ShadowColor = new Color(255, 107, 157, 160);
 
-    private readonly RoundedRectangleRuntime _focusRing;
-    private readonly RoundedRectangleRuntime _fill;
+    private readonly RectangleRuntime _focusRing;
+    private readonly RectangleRuntime _fill;
 
     public ButtonVisual(bool fullInstantiation = true, bool tryCreateFormsObject = true)
         : base(fullInstantiation, tryCreateFormsObject)
@@ -76,9 +76,9 @@ public class ButtonVisual : BaseButtonVisual
         WireStates();
     }
 
-    private static RoundedRectangleRuntime CreateFill()
+    private static RectangleRuntime CreateFill()
     {
-        RoundedRectangleRuntime fill = new RoundedRectangleRuntime();
+        RectangleRuntime fill = new RectangleRuntime();
         fill.Name = "BubblegumFill";
         fill.X = 0;
         fill.Y = 0;
@@ -92,23 +92,23 @@ public class ButtonVisual : BaseButtonVisual
         fill.HeightUnits = DimensionUnitType.RelativeToParent;
         fill.CornerRadius = CornerRadius;
         fill.IsFilled = true;
-        fill.Color = BubblegumColors.Accent;
+        fill.FillColor = BubblegumColors.Accent;
+        fill.StrokeWidth = 0;
         // Native Gaussian drop shadow — replaces the old three-layer stack.
         // Toggled per state via WireStates (off when pressed/disabled).
         fill.HasDropshadow = true;
         fill.DropshadowColor = ShadowColor;
         fill.DropshadowOffsetX = 0f;
         fill.DropshadowOffsetY = ShadowOffsetY;
-        fill.DropshadowBlurX = ShadowBlur;
-        fill.DropshadowBlurY = ShadowBlur;
+        fill.DropshadowBlur = ShadowBlur;
         return fill;
     }
 
-    private static RoundedRectangleRuntime CreateFocusRing()
+    private static RectangleRuntime CreateFocusRing()
     {
         // Sized to (parent + 2*FocusRingInset) per axis, stroked with
         // FocusRingThickness translucent accent. Visible only when focused.
-        RoundedRectangleRuntime ring = new RoundedRectangleRuntime();
+        RectangleRuntime ring = new RectangleRuntime();
         ring.Name = "BubblegumFocusRing";
         ring.X = 0;
         ring.Y = 0;
@@ -124,7 +124,7 @@ public class ButtonVisual : BaseButtonVisual
         ring.IsFilled = false;
         ring.StrokeWidth = FocusRingThickness;
         ring.StrokeWidthUnits = DimensionUnitType.Absolute;
-        ring.Color = new Color(255, 107, 157, 90); // translucent accent
+        ring.StrokeColor = new Color(255, 107, 157, 90); // translucent accent
         ring.Visible = false;
         return ring;
     }
@@ -180,7 +180,7 @@ public class ButtonVisual : BaseButtonVisual
 
     private void ApplyPalette(Color fill, Color text, bool showShadow, bool showFocusRing)
     {
-        _fill.Color = fill;
+        _fill.FillColor = fill;
         _fill.HasDropshadow = showShadow;
         TextInstance.Color = text;
         _focusRing.Visible = showFocusRing;

--- a/Themes/Gum.Themes.Bubblegum.MonoGame/CheckBoxVisual.cs
+++ b/Themes/Gum.Themes.Bubblegum.MonoGame/CheckBoxVisual.cs
@@ -31,11 +31,11 @@ public class CheckBoxVisual : BaseCheckBoxVisual
     // (which uses a slightly wider advance than ASCII Latin) doesn't get clipped.
     private const float GlyphContainerSize = 24f;
 
-    private readonly RoundedRectangleRuntime _focusRing;
-    private readonly RoundedRectangleRuntime _boxFill;
-    private readonly RoundedRectangleRuntime _boxBorder;
+    private readonly RectangleRuntime _focusRing;
+    private readonly RectangleRuntime _boxFill;
+    private readonly RectangleRuntime _boxBorder;
     private readonly TextRuntime _checkGlyph;
-    private readonly RoundedRectangleRuntime _dashIndicator;
+    private readonly RectangleRuntime _dashIndicator;
 
     public CheckBoxVisual(bool fullInstantiation = true, bool tryCreateFormsObject = true)
         : base(fullInstantiation, tryCreateFormsObject)
@@ -73,9 +73,9 @@ public class CheckBoxVisual : BaseCheckBoxVisual
         WireStates();
     }
 
-    private static RoundedRectangleRuntime CreateBoxFill()
+    private static RectangleRuntime CreateBoxFill()
     {
-        RoundedRectangleRuntime fill = new RoundedRectangleRuntime();
+        RectangleRuntime fill = new RectangleRuntime();
         fill.Name = "BubblegumBoxFill";
         fill.X = 0;
         fill.Y = 0;
@@ -89,13 +89,14 @@ public class CheckBoxVisual : BaseCheckBoxVisual
         fill.HeightUnits = DimensionUnitType.Absolute;
         fill.CornerRadius = CornerRadius;
         fill.IsFilled = true;
-        fill.Color = BubblegumColors.Surface1;
+        fill.FillColor = BubblegumColors.Surface1;
+        fill.StrokeWidth = 0;
         return fill;
     }
 
-    private static RoundedRectangleRuntime CreateBoxBorder()
+    private static RectangleRuntime CreateBoxBorder()
     {
-        RoundedRectangleRuntime border = new RoundedRectangleRuntime();
+        RectangleRuntime border = new RectangleRuntime();
         border.Name = "BubblegumBoxBorder";
         border.X = 0;
         border.Y = 0;
@@ -111,13 +112,13 @@ public class CheckBoxVisual : BaseCheckBoxVisual
         border.IsFilled = false;
         border.StrokeWidth = BorderThickness;
         border.StrokeWidthUnits = DimensionUnitType.Absolute;
-        border.Color = BubblegumColors.Border;
+        border.StrokeColor = BubblegumColors.Border;
         return border;
     }
 
-    private static RoundedRectangleRuntime CreateFocusRing()
+    private static RectangleRuntime CreateFocusRing()
     {
-        RoundedRectangleRuntime ring = new RoundedRectangleRuntime();
+        RectangleRuntime ring = new RectangleRuntime();
         ring.Name = "BubblegumBoxFocusRing";
         ring.X = -FocusRingInset;
         ring.Y = 0;
@@ -133,7 +134,7 @@ public class CheckBoxVisual : BaseCheckBoxVisual
         ring.IsFilled = false;
         ring.StrokeWidth = FocusRingThickness;
         ring.StrokeWidthUnits = DimensionUnitType.Absolute;
-        ring.Color = BubblegumPalette.FocusRing;
+        ring.StrokeColor = BubblegumPalette.FocusRing;
         ring.Visible = false;
         return ring;
     }
@@ -158,10 +159,10 @@ public class CheckBoxVisual : BaseCheckBoxVisual
         return glyph;
     }
 
-    private static RoundedRectangleRuntime CreateDashIndicator()
+    private static RectangleRuntime CreateDashIndicator()
     {
         // Indeterminate pill: 10x2 (matches .bb-ck-dash), accent-colored, centered.
-        RoundedRectangleRuntime dash = new RoundedRectangleRuntime();
+        RectangleRuntime dash = new RectangleRuntime();
         dash.Name = "BubblegumDashIndicator";
         dash.X = BoxSize / 2f;
         dash.Y = 0;
@@ -175,7 +176,8 @@ public class CheckBoxVisual : BaseCheckBoxVisual
         dash.HeightUnits = DimensionUnitType.Absolute;
         dash.CornerRadius = 1f;
         dash.IsFilled = true;
-        dash.Color = BubblegumColors.Accent;
+        dash.FillColor = BubblegumColors.Accent;
+        dash.StrokeWidth = 0;
         return dash;
     }
 
@@ -283,8 +285,8 @@ public class CheckBoxVisual : BaseCheckBoxVisual
     private void Apply(Color fill, Color border, Color text, GlyphKind glyph, bool ring,
         Color? glyphColor = null)
     {
-        _boxFill.Color = fill;
-        _boxBorder.Color = border;
+        _boxFill.FillColor = fill;
+        _boxBorder.StrokeColor = border;
         TextInstance.Color = text;
         _focusRing.Visible = ring;
         _checkGlyph.Visible = glyph == GlyphKind.Check;

--- a/Themes/Gum.Themes.Bubblegum.MonoGame/ComboBoxVisual.cs
+++ b/Themes/Gum.Themes.Bubblegum.MonoGame/ComboBoxVisual.cs
@@ -30,9 +30,9 @@ public class ComboBoxVisual : BaseComboBoxVisual
     private const float TextLeftPadding = 12f;
     private const float TextRightClearance = 4f;
 
-    private readonly RoundedRectangleRuntime _focusRing;
-    private readonly RoundedRectangleRuntime _fill;
-    private readonly RoundedRectangleRuntime _border;
+    private readonly RectangleRuntime _focusRing;
+    private readonly RectangleRuntime _fill;
+    private readonly RectangleRuntime _border;
     private readonly TextRuntime _dropdownGlyph;
 
     public ComboBoxVisual(bool fullInstantiation = true, bool tryCreateFormsObject = true)
@@ -64,9 +64,9 @@ public class ComboBoxVisual : BaseComboBoxVisual
         WireStates();
     }
 
-    private static RoundedRectangleRuntime CreateFill()
+    private static RectangleRuntime CreateFill()
     {
-        RoundedRectangleRuntime fill = new RoundedRectangleRuntime();
+        RectangleRuntime fill = new RectangleRuntime();
         fill.Name = "BubblegumComboFill";
         fill.X = 0;
         fill.Y = 0;
@@ -80,13 +80,14 @@ public class ComboBoxVisual : BaseComboBoxVisual
         fill.HeightUnits = DimensionUnitType.RelativeToParent;
         fill.CornerRadius = CornerRadius;
         fill.IsFilled = true;
-        fill.Color = BubblegumColors.Surface1;
+        fill.FillColor = BubblegumColors.Surface1;
+        fill.StrokeWidth = 0;
         return fill;
     }
 
-    private static RoundedRectangleRuntime CreateBorder()
+    private static RectangleRuntime CreateBorder()
     {
-        RoundedRectangleRuntime border = new RoundedRectangleRuntime();
+        RectangleRuntime border = new RectangleRuntime();
         border.Name = "BubblegumComboBorder";
         border.X = 0;
         border.Y = 0;
@@ -102,13 +103,13 @@ public class ComboBoxVisual : BaseComboBoxVisual
         border.IsFilled = false;
         border.StrokeWidth = BorderThickness;
         border.StrokeWidthUnits = DimensionUnitType.Absolute;
-        border.Color = BubblegumColors.Border;
+        border.StrokeColor = BubblegumColors.Border;
         return border;
     }
 
-    private static RoundedRectangleRuntime CreateFocusRing()
+    private static RectangleRuntime CreateFocusRing()
     {
-        RoundedRectangleRuntime ring = new RoundedRectangleRuntime();
+        RectangleRuntime ring = new RectangleRuntime();
         ring.Name = "BubblegumComboFocusRing";
         ring.X = 0;
         ring.Y = 0;
@@ -124,7 +125,7 @@ public class ComboBoxVisual : BaseComboBoxVisual
         ring.IsFilled = false;
         ring.StrokeWidth = FocusRingThickness;
         ring.StrokeWidthUnits = DimensionUnitType.Absolute;
-        ring.Color = BubblegumPalette.FocusRing;
+        ring.StrokeColor = BubblegumPalette.FocusRing;
         ring.Visible = false;
         return ring;
     }
@@ -188,8 +189,8 @@ public class ComboBoxVisual : BaseComboBoxVisual
 
     private void Apply(Color border, Color text, Color glyph, bool ring, bool fillDisabled)
     {
-        _fill.Color = fillDisabled ? BubblegumColors.DisabledFill : BubblegumColors.Surface1;
-        _border.Color = border;
+        _fill.FillColor = fillDisabled ? BubblegumColors.DisabledFill : BubblegumColors.Surface1;
+        _border.StrokeColor = border;
         TextInstance.Color = text;
         _dropdownGlyph.Color = glyph;
         _focusRing.Visible = ring;

--- a/Themes/Gum.Themes.Bubblegum.MonoGame/ListBoxItemVisual.cs
+++ b/Themes/Gum.Themes.Bubblegum.MonoGame/ListBoxItemVisual.cs
@@ -14,7 +14,7 @@ namespace Gum.Themes.Bubblegum;
 /// </summary>
 public class ListBoxItemVisual : BaseListBoxItemVisual
 {
-    private readonly RoundedRectangleRuntime _fill;
+    private readonly RectangleRuntime _fill;
 
     public ListBoxItemVisual(bool fullInstantiation = true, bool tryCreateFormsObject = true)
         : base(fullInstantiation, tryCreateFormsObject)
@@ -35,9 +35,9 @@ public class ListBoxItemVisual : BaseListBoxItemVisual
         WireStates();
     }
 
-    private static RoundedRectangleRuntime CreateFill()
+    private static RectangleRuntime CreateFill()
     {
-        RoundedRectangleRuntime fill = new RoundedRectangleRuntime();
+        RectangleRuntime fill = new RectangleRuntime();
         fill.Name = "BubblegumListItemFill";
         fill.X = 0;
         fill.Y = 0;
@@ -51,7 +51,8 @@ public class ListBoxItemVisual : BaseListBoxItemVisual
         fill.HeightUnits = DimensionUnitType.RelativeToParent;
         fill.CornerRadius = 0f;
         fill.IsFilled = true;
-        fill.Color = Color.Transparent;
+        fill.FillColor = Color.Transparent;
+        fill.StrokeWidth = 0;
         return fill;
     }
 
@@ -75,7 +76,7 @@ public class ListBoxItemVisual : BaseListBoxItemVisual
 
     private void ApplyPalette(Color fill, Color text)
     {
-        _fill.Color = fill;
+        _fill.FillColor = fill;
         TextInstance.Color = text;
     }
 }

--- a/Themes/Gum.Themes.Bubblegum.MonoGame/ListBoxVisual.cs
+++ b/Themes/Gum.Themes.Bubblegum.MonoGame/ListBoxVisual.cs
@@ -18,9 +18,9 @@ public class ListBoxVisual : BaseListBoxVisual
     private const float FocusRingInset = 2f;
     private const float FocusRingThickness = 3f;
 
-    private readonly RoundedRectangleRuntime _focusRing;
-    private readonly RoundedRectangleRuntime _fill;
-    private readonly RoundedRectangleRuntime _border;
+    private readonly RectangleRuntime _focusRing;
+    private readonly RectangleRuntime _fill;
+    private readonly RectangleRuntime _border;
 
     public ListBoxVisual(bool fullInstantiation = true, bool tryCreateFormsObject = true)
         : base(fullInstantiation, tryCreateFormsObject)
@@ -52,9 +52,9 @@ public class ListBoxVisual : BaseListBoxVisual
         WireStates();
     }
 
-    private static RoundedRectangleRuntime CreateFill()
+    private static RectangleRuntime CreateFill()
     {
-        RoundedRectangleRuntime fill = new RoundedRectangleRuntime();
+        RectangleRuntime fill = new RectangleRuntime();
         fill.Name = "BubblegumListBoxFill";
         fill.X = 0;
         fill.Y = 0;
@@ -68,13 +68,14 @@ public class ListBoxVisual : BaseListBoxVisual
         fill.HeightUnits = DimensionUnitType.RelativeToParent;
         fill.CornerRadius = CornerRadius;
         fill.IsFilled = true;
-        fill.Color = BubblegumColors.Surface1;
+        fill.FillColor = BubblegumColors.Surface1;
+        fill.StrokeWidth = 0;
         return fill;
     }
 
-    private static RoundedRectangleRuntime CreateBorder()
+    private static RectangleRuntime CreateBorder()
     {
-        RoundedRectangleRuntime border = new RoundedRectangleRuntime();
+        RectangleRuntime border = new RectangleRuntime();
         border.Name = "BubblegumListBoxBorder";
         border.X = 0;
         border.Y = 0;
@@ -90,13 +91,13 @@ public class ListBoxVisual : BaseListBoxVisual
         border.IsFilled = false;
         border.StrokeWidth = BorderThickness;
         border.StrokeWidthUnits = DimensionUnitType.Absolute;
-        border.Color = BubblegumColors.Border;
+        border.StrokeColor = BubblegumColors.Border;
         return border;
     }
 
-    private static RoundedRectangleRuntime CreateFocusRing()
+    private static RectangleRuntime CreateFocusRing()
     {
-        RoundedRectangleRuntime ring = new RoundedRectangleRuntime();
+        RectangleRuntime ring = new RectangleRuntime();
         ring.Name = "BubblegumListBoxFocusRing";
         ring.X = 0;
         ring.Y = 0;
@@ -112,7 +113,7 @@ public class ListBoxVisual : BaseListBoxVisual
         ring.IsFilled = false;
         ring.StrokeWidth = FocusRingThickness;
         ring.StrokeWidthUnits = DimensionUnitType.Absolute;
-        ring.Color = BubblegumPalette.FocusRing;
+        ring.StrokeColor = BubblegumPalette.FocusRing;
         ring.Visible = false;
         return ring;
     }
@@ -143,8 +144,8 @@ public class ListBoxVisual : BaseListBoxVisual
 
     private void ApplyPalette(Color border, bool showFocusRing, bool fillDisabled = false)
     {
-        _fill.Color = fillDisabled ? BubblegumColors.DisabledFill : BubblegumColors.Surface1;
-        _border.Color = border;
+        _fill.FillColor = fillDisabled ? BubblegumColors.DisabledFill : BubblegumColors.Surface1;
+        _border.StrokeColor = border;
         _focusRing.Visible = showFocusRing;
     }
 }

--- a/Themes/Gum.Themes.Bubblegum.MonoGame/MenuItemVisual.cs
+++ b/Themes/Gum.Themes.Bubblegum.MonoGame/MenuItemVisual.cs
@@ -20,7 +20,7 @@ public class MenuItemVisual : BaseMenuItemVisual
     private const float HorizontalPadding = 12f;
     private const float VerticalPadding = 6f;
 
-    private readonly ColoredRectangleRuntime _fill;
+    private readonly RectangleRuntime _fill;
 
     public MenuItemVisual(bool fullInstantiation = true, bool tryCreateFormsObject = true)
         : base(fullInstantiation, tryCreateFormsObject: false)
@@ -90,14 +90,14 @@ public class MenuItemVisual : BaseMenuItemVisual
 
     private void ApplyPalette(Color fill, Color text)
     {
-        _fill.Color = fill;
+        _fill.FillColor = fill;
         TextInstance.Color = text;
         SubmenuIndicatorInstance.Color = text;
     }
 
-    private static ColoredRectangleRuntime CreateFill()
+    private static RectangleRuntime CreateFill()
     {
-        ColoredRectangleRuntime fill = new ColoredRectangleRuntime();
+        RectangleRuntime fill = new RectangleRuntime();
         fill.Name = "BubblegumMenuItemFill";
         fill.X = 0;
         fill.Y = 0;
@@ -109,7 +109,9 @@ public class MenuItemVisual : BaseMenuItemVisual
         fill.Height = 0;
         fill.WidthUnits = DimensionUnitType.RelativeToParent;
         fill.HeightUnits = DimensionUnitType.RelativeToParent;
-        fill.Color = Color.Transparent;
+        fill.IsFilled = true;
+        fill.FillColor = Color.Transparent;
+        fill.StrokeWidth = 0;
         return fill;
     }
 }

--- a/Themes/Gum.Themes.Bubblegum.MonoGame/MenuVisual.cs
+++ b/Themes/Gum.Themes.Bubblegum.MonoGame/MenuVisual.cs
@@ -15,8 +15,8 @@ public class MenuVisual : BaseMenuVisual
 {
     private const float SeparatorHeight = 2f;
 
-    private readonly ColoredRectangleRuntime _fill;
-    private readonly ColoredRectangleRuntime _bottomSeparator;
+    private readonly RectangleRuntime _fill;
+    private readonly RectangleRuntime _bottomSeparator;
 
     public MenuVisual(bool fullInstantiation = true, bool tryCreateFormsObject = true)
         : base(fullInstantiation, tryCreateFormsObject)
@@ -33,9 +33,9 @@ public class MenuVisual : BaseMenuVisual
         AddChild(InnerPanelInstance);
     }
 
-    private static ColoredRectangleRuntime CreateFill()
+    private static RectangleRuntime CreateFill()
     {
-        ColoredRectangleRuntime fill = new ColoredRectangleRuntime();
+        RectangleRuntime fill = new RectangleRuntime();
         fill.Name = "BubblegumMenuFill";
         fill.X = 0;
         fill.Y = 0;
@@ -47,13 +47,15 @@ public class MenuVisual : BaseMenuVisual
         fill.Height = 0;
         fill.WidthUnits = DimensionUnitType.RelativeToParent;
         fill.HeightUnits = DimensionUnitType.RelativeToParent;
-        fill.Color = BubblegumColors.Surface1;
+        fill.IsFilled = true;
+        fill.FillColor = BubblegumColors.Surface1;
+        fill.StrokeWidth = 0;
         return fill;
     }
 
-    private static ColoredRectangleRuntime CreateBottomSeparator()
+    private static RectangleRuntime CreateBottomSeparator()
     {
-        ColoredRectangleRuntime separator = new ColoredRectangleRuntime();
+        RectangleRuntime separator = new RectangleRuntime();
         separator.Name = "BubblegumMenuBottomSeparator";
         separator.X = 0;
         separator.Y = 0;
@@ -65,7 +67,9 @@ public class MenuVisual : BaseMenuVisual
         separator.Height = SeparatorHeight;
         separator.WidthUnits = DimensionUnitType.RelativeToParent;
         separator.HeightUnits = DimensionUnitType.Absolute;
-        separator.Color = BubblegumColors.Border;
+        separator.IsFilled = true;
+        separator.FillColor = BubblegumColors.Border;
+        separator.StrokeWidth = 0;
         return separator;
     }
 }

--- a/Themes/Gum.Themes.Bubblegum.MonoGame/RadioButtonVisual.cs
+++ b/Themes/Gum.Themes.Bubblegum.MonoGame/RadioButtonVisual.cs
@@ -20,10 +20,10 @@ public class RadioButtonVisual : BaseRadioButtonVisual
     private const float FocusRingThickness = 3f;
     private const float BoxToLabelGap = 8f;
 
-    private readonly ColoredCircleRuntime _focusRing;
-    private readonly ColoredCircleRuntime _outerFill;
-    private readonly ColoredCircleRuntime _outerBorder;
-    private readonly ColoredCircleRuntime _innerDot;
+    private readonly CircleRuntime _focusRing;
+    private readonly CircleRuntime _outerFill;
+    private readonly CircleRuntime _outerBorder;
+    private readonly CircleRuntime _innerDot;
 
     public RadioButtonVisual(bool fullInstantiation = true, bool tryCreateFormsObject = true)
         : base(fullInstantiation, tryCreateFormsObject)
@@ -49,9 +49,9 @@ public class RadioButtonVisual : BaseRadioButtonVisual
         WireStates();
     }
 
-    private static ColoredCircleRuntime CreateOuterFill()
+    private static CircleRuntime CreateOuterFill()
     {
-        ColoredCircleRuntime c = new ColoredCircleRuntime();
+        CircleRuntime c = new CircleRuntime();
         c.Name = "BubblegumRadioOuterFill";
         c.X = 0;
         c.Y = 0;
@@ -64,13 +64,14 @@ public class RadioButtonVisual : BaseRadioButtonVisual
         c.WidthUnits = DimensionUnitType.Absolute;
         c.HeightUnits = DimensionUnitType.Absolute;
         c.IsFilled = true;
-        c.Color = BubblegumColors.Surface1;
+        c.FillColor = BubblegumColors.Surface1;
+        c.StrokeWidth = 0;
         return c;
     }
 
-    private static ColoredCircleRuntime CreateOuterBorder()
+    private static CircleRuntime CreateOuterBorder()
     {
-        ColoredCircleRuntime c = new ColoredCircleRuntime();
+        CircleRuntime c = new CircleRuntime();
         c.Name = "BubblegumRadioOuterBorder";
         c.X = 0;
         c.Y = 0;
@@ -85,13 +86,13 @@ public class RadioButtonVisual : BaseRadioButtonVisual
         c.IsFilled = false;
         c.StrokeWidth = BorderThickness;
         c.StrokeWidthUnits = DimensionUnitType.Absolute;
-        c.Color = BubblegumColors.Border;
+        c.StrokeColor = BubblegumColors.Border;
         return c;
     }
 
-    private static ColoredCircleRuntime CreateFocusRing()
+    private static CircleRuntime CreateFocusRing()
     {
-        ColoredCircleRuntime c = new ColoredCircleRuntime();
+        CircleRuntime c = new CircleRuntime();
         c.Name = "BubblegumRadioFocusRing";
         c.X = -FocusRingInset;
         c.Y = 0;
@@ -106,15 +107,15 @@ public class RadioButtonVisual : BaseRadioButtonVisual
         c.IsFilled = false;
         c.StrokeWidth = FocusRingThickness;
         c.StrokeWidthUnits = DimensionUnitType.Absolute;
-        c.Color = BubblegumPalette.FocusRing;
+        c.StrokeColor = BubblegumPalette.FocusRing;
         c.Visible = false;
         return c;
     }
 
-    private static ColoredCircleRuntime CreateInnerDot()
+    private static CircleRuntime CreateInnerDot()
     {
         const float inset = (OuterSize - InnerSize) / 2f;
-        ColoredCircleRuntime dot = new ColoredCircleRuntime();
+        CircleRuntime dot = new CircleRuntime();
         dot.Name = "BubblegumRadioInnerDot";
         dot.X = inset;
         dot.Y = 0;
@@ -127,7 +128,8 @@ public class RadioButtonVisual : BaseRadioButtonVisual
         dot.WidthUnits = DimensionUnitType.Absolute;
         dot.HeightUnits = DimensionUnitType.Absolute;
         dot.IsFilled = true;
-        dot.Color = BubblegumColors.Accent;
+        dot.FillColor = BubblegumColors.Accent;
+        dot.StrokeWidth = 0;
         dot.Visible = false;
         return dot;
     }
@@ -201,13 +203,13 @@ public class RadioButtonVisual : BaseRadioButtonVisual
     private void Apply(Color fill, Color border, Color text, bool innerVisible, bool ring,
         Color? innerColor = null)
     {
-        _outerFill.Color = fill;
-        _outerBorder.Color = border;
+        _outerFill.FillColor = fill;
+        _outerBorder.StrokeColor = border;
         TextInstance.Color = text;
         _innerDot.Visible = innerVisible;
         if (innerColor.HasValue)
         {
-            _innerDot.Color = innerColor.Value;
+            _innerDot.FillColor = innerColor.Value;
         }
         _focusRing.Visible = ring;
     }

--- a/Themes/Gum.Themes.Bubblegum.MonoGame/ScrollBarThumbVisual.cs
+++ b/Themes/Gum.Themes.Bubblegum.MonoGame/ScrollBarThumbVisual.cs
@@ -20,7 +20,7 @@ public class ScrollBarThumbVisual : InteractiveGue
 {
     private const float CornerRadius = 6f;
 
-    private readonly RoundedRectangleRuntime _body;
+    private readonly RectangleRuntime _body;
 
     private StateSaveCategory _buttonCategory = null!;
 
@@ -38,9 +38,9 @@ public class ScrollBarThumbVisual : InteractiveGue
         WireStates();
     }
 
-    private static RoundedRectangleRuntime CreateBody()
+    private static RectangleRuntime CreateBody()
     {
-        RoundedRectangleRuntime body = new RoundedRectangleRuntime();
+        RectangleRuntime body = new RectangleRuntime();
         body.Name = "BubblegumScrollThumbBody";
         body.X = 0;
         body.Y = 0;
@@ -54,7 +54,8 @@ public class ScrollBarThumbVisual : InteractiveGue
         body.HeightUnits = DimensionUnitType.RelativeToParent;
         body.CornerRadius = CornerRadius;
         body.IsFilled = true;
-        body.Color = BubblegumColors.Accent;
+        body.FillColor = BubblegumColors.Accent;
+        body.StrokeWidth = 0;
         return body;
     }
 
@@ -65,25 +66,25 @@ public class ScrollBarThumbVisual : InteractiveGue
         AddCategory(_buttonCategory);
 
         Add(_buttonCategory, FrameworkElement.EnabledStateName,
-            () => _body.Color = BubblegumColors.Accent);
+            () => _body.FillColor = BubblegumColors.Accent);
 
         Add(_buttonCategory, FrameworkElement.HighlightedStateName,
-            () => _body.Color = BubblegumColors.AccentHover);
+            () => _body.FillColor = BubblegumColors.AccentHover);
 
         Add(_buttonCategory, FrameworkElement.PushedStateName,
-            () => _body.Color = BubblegumColors.AccentDark);
+            () => _body.FillColor = BubblegumColors.AccentDark);
 
         Add(_buttonCategory, FrameworkElement.FocusedStateName,
-            () => _body.Color = BubblegumColors.Accent);
+            () => _body.FillColor = BubblegumColors.Accent);
 
         Add(_buttonCategory, FrameworkElement.HighlightedFocusedStateName,
-            () => _body.Color = BubblegumColors.AccentHover);
+            () => _body.FillColor = BubblegumColors.AccentHover);
 
         Add(_buttonCategory, FrameworkElement.DisabledStateName,
-            () => _body.Color = BubblegumColors.Disabled);
+            () => _body.FillColor = BubblegumColors.Disabled);
 
         Add(_buttonCategory, FrameworkElement.DisabledFocusedStateName,
-            () => _body.Color = BubblegumColors.Disabled);
+            () => _body.FillColor = BubblegumColors.Disabled);
     }
 
     private static void Add(StateSaveCategory category, string name, System.Action apply)

--- a/Themes/Gum.Themes.Bubblegum.MonoGame/ScrollBarVisual.cs
+++ b/Themes/Gum.Themes.Bubblegum.MonoGame/ScrollBarVisual.cs
@@ -20,8 +20,8 @@ public class ScrollBarVisual : BaseScrollBarVisual
     private const float FrameBorderThickness = 2f;
 
     private readonly ScrollBarThumbVisual _thumb;
-    private readonly RoundedRectangleRuntime _frameFill;
-    private readonly RoundedRectangleRuntime _frameBorder;
+    private readonly RectangleRuntime _frameFill;
+    private readonly RectangleRuntime _frameBorder;
     private bool _isHorizontal;
 
     public ScrollBarVisual(bool fullInstantiation = true, bool tryCreateFormsObject = true)
@@ -139,9 +139,9 @@ public class ScrollBarVisual : BaseScrollBarVisual
         }
     }
 
-    private static RoundedRectangleRuntime CreateFrameFill()
+    private static RectangleRuntime CreateFrameFill()
     {
-        RoundedRectangleRuntime fill = new RoundedRectangleRuntime();
+        RectangleRuntime fill = new RectangleRuntime();
         fill.Name = "BubblegumScrollBarFrameFill";
         fill.X = 0;
         fill.Y = 0;
@@ -155,13 +155,14 @@ public class ScrollBarVisual : BaseScrollBarVisual
         fill.HeightUnits = DimensionUnitType.RelativeToParent;
         fill.CornerRadius = FrameCornerRadius;
         fill.IsFilled = true;
-        fill.Color = BubblegumColors.Surface1;
+        fill.FillColor = BubblegumColors.Surface1;
+        fill.StrokeWidth = 0;
         return fill;
     }
 
-    private static RoundedRectangleRuntime CreateFrameBorder()
+    private static RectangleRuntime CreateFrameBorder()
     {
-        RoundedRectangleRuntime border = new RoundedRectangleRuntime();
+        RectangleRuntime border = new RectangleRuntime();
         border.Name = "BubblegumScrollBarFrameBorder";
         border.X = 0;
         border.Y = 0;
@@ -177,7 +178,7 @@ public class ScrollBarVisual : BaseScrollBarVisual
         border.IsFilled = false;
         border.StrokeWidth = FrameBorderThickness;
         border.StrokeWidthUnits = DimensionUnitType.Absolute;
-        border.Color = BubblegumColors.Border;
+        border.StrokeColor = BubblegumColors.Border;
         return border;
     }
 }

--- a/Themes/Gum.Themes.Bubblegum.MonoGame/ScrollViewerVisual.cs
+++ b/Themes/Gum.Themes.Bubblegum.MonoGame/ScrollViewerVisual.cs
@@ -19,9 +19,9 @@ public class ScrollViewerVisual : BaseScrollViewerVisual
     private const float FocusRingInset = 2f;
     private const float FocusRingThickness = 3f;
 
-    private readonly RoundedRectangleRuntime _focusRing;
-    private readonly RoundedRectangleRuntime _fill;
-    private readonly RoundedRectangleRuntime _border;
+    private readonly RectangleRuntime _focusRing;
+    private readonly RectangleRuntime _fill;
+    private readonly RectangleRuntime _border;
 
     public ScrollViewerVisual(bool fullInstantiation = true, bool tryCreateFormsObject = true)
         : base(fullInstantiation, tryCreateFormsObject)
@@ -50,9 +50,9 @@ public class ScrollViewerVisual : BaseScrollViewerVisual
         WireStates();
     }
 
-    private static RoundedRectangleRuntime CreateFill()
+    private static RectangleRuntime CreateFill()
     {
-        RoundedRectangleRuntime fill = new RoundedRectangleRuntime();
+        RectangleRuntime fill = new RectangleRuntime();
         fill.Name = "BubblegumScrollViewerFill";
         fill.X = 0;
         fill.Y = 0;
@@ -66,13 +66,14 @@ public class ScrollViewerVisual : BaseScrollViewerVisual
         fill.HeightUnits = DimensionUnitType.RelativeToParent;
         fill.CornerRadius = CornerRadius;
         fill.IsFilled = true;
-        fill.Color = BubblegumColors.Surface1;
+        fill.FillColor = BubblegumColors.Surface1;
+        fill.StrokeWidth = 0;
         return fill;
     }
 
-    private static RoundedRectangleRuntime CreateBorder()
+    private static RectangleRuntime CreateBorder()
     {
-        RoundedRectangleRuntime border = new RoundedRectangleRuntime();
+        RectangleRuntime border = new RectangleRuntime();
         border.Name = "BubblegumScrollViewerBorder";
         border.X = 0;
         border.Y = 0;
@@ -88,13 +89,13 @@ public class ScrollViewerVisual : BaseScrollViewerVisual
         border.IsFilled = false;
         border.StrokeWidth = BorderThickness;
         border.StrokeWidthUnits = DimensionUnitType.Absolute;
-        border.Color = BubblegumColors.Border;
+        border.StrokeColor = BubblegumColors.Border;
         return border;
     }
 
-    private static RoundedRectangleRuntime CreateFocusRing()
+    private static RectangleRuntime CreateFocusRing()
     {
-        RoundedRectangleRuntime ring = new RoundedRectangleRuntime();
+        RectangleRuntime ring = new RectangleRuntime();
         ring.Name = "BubblegumScrollViewerFocusRing";
         ring.X = 0;
         ring.Y = 0;
@@ -110,7 +111,7 @@ public class ScrollViewerVisual : BaseScrollViewerVisual
         ring.IsFilled = false;
         ring.StrokeWidth = FocusRingThickness;
         ring.StrokeWidthUnits = DimensionUnitType.Absolute;
-        ring.Color = BubblegumPalette.FocusRing;
+        ring.StrokeColor = BubblegumPalette.FocusRing;
         ring.Visible = false;
         return ring;
     }
@@ -119,13 +120,13 @@ public class ScrollViewerVisual : BaseScrollViewerVisual
     {
         States.Enabled.Apply = () =>
         {
-            _border.Color = BubblegumColors.Border;
+            _border.StrokeColor = BubblegumColors.Border;
             _focusRing.Visible = false;
         };
 
         States.Focused.Apply = () =>
         {
-            _border.Color = BubblegumColors.Accent;
+            _border.StrokeColor = BubblegumColors.Accent;
             _focusRing.Visible = true;
         };
     }

--- a/Themes/Gum.Themes.Bubblegum.MonoGame/SliderThumbVisual.cs
+++ b/Themes/Gum.Themes.Bubblegum.MonoGame/SliderThumbVisual.cs
@@ -33,9 +33,9 @@ public class SliderThumbVisual : InteractiveGue
     private const float ShadowBlur = 10f;
     private static readonly Color ShadowColor = new Color(255, 107, 157, 160);
 
-    private readonly ColoredCircleRuntime _focusRing;
-    private readonly ColoredCircleRuntime _body;
-    private readonly ColoredCircleRuntime _border;
+    private readonly CircleRuntime _focusRing;
+    private readonly CircleRuntime _body;
+    private readonly CircleRuntime _border;
 
     private StateSaveCategory _buttonCategory = null!;
 
@@ -59,9 +59,9 @@ public class SliderThumbVisual : InteractiveGue
         WireStates();
     }
 
-    private static ColoredCircleRuntime CreateBody()
+    private static CircleRuntime CreateBody()
     {
-        ColoredCircleRuntime body = new ColoredCircleRuntime();
+        CircleRuntime body = new CircleRuntime();
         body.Name = "BubblegumSliderThumbBody";
         body.X = 0;
         body.Y = 0;
@@ -74,21 +74,21 @@ public class SliderThumbVisual : InteractiveGue
         body.WidthUnits = DimensionUnitType.RelativeToParent;
         body.HeightUnits = DimensionUnitType.RelativeToParent;
         body.IsFilled = true;
-        body.Color = Color.White;
+        body.FillColor = Color.White;
+        body.StrokeWidth = 0;
         // Native Gaussian drop shadow under the thumb — replaces the prior
         // single-circle approximation. Toggled per state via WireStates.
         body.HasDropshadow = true;
         body.DropshadowColor = ShadowColor;
         body.DropshadowOffsetX = 0f;
         body.DropshadowOffsetY = ShadowOffsetY;
-        body.DropshadowBlurX = ShadowBlur;
-        body.DropshadowBlurY = ShadowBlur;
+        body.DropshadowBlur = ShadowBlur;
         return body;
     }
 
-    private static ColoredCircleRuntime CreateBorder()
+    private static CircleRuntime CreateBorder()
     {
-        ColoredCircleRuntime border = new ColoredCircleRuntime();
+        CircleRuntime border = new CircleRuntime();
         border.Name = "BubblegumSliderThumbBorder";
         border.X = 0;
         border.Y = 0;
@@ -103,13 +103,13 @@ public class SliderThumbVisual : InteractiveGue
         border.IsFilled = false;
         border.StrokeWidth = BorderThickness;
         border.StrokeWidthUnits = DimensionUnitType.Absolute;
-        border.Color = BubblegumColors.Accent;
+        border.StrokeColor = BubblegumColors.Accent;
         return border;
     }
 
-    private static ColoredCircleRuntime CreateFocusRing()
+    private static CircleRuntime CreateFocusRing()
     {
-        ColoredCircleRuntime ring = new ColoredCircleRuntime();
+        CircleRuntime ring = new CircleRuntime();
         ring.Name = "BubblegumSliderThumbFocusRing";
         ring.X = 0;
         ring.Y = 0;
@@ -124,7 +124,7 @@ public class SliderThumbVisual : InteractiveGue
         ring.IsFilled = false;
         ring.StrokeWidth = FocusRingThickness;
         ring.StrokeWidthUnits = DimensionUnitType.Absolute;
-        ring.Color = BubblegumPalette.FocusRing;
+        ring.StrokeColor = BubblegumPalette.FocusRing;
         ring.Visible = false;
         return ring;
     }
@@ -166,9 +166,9 @@ public class SliderThumbVisual : InteractiveGue
 
     private void Apply(Color body, Color border, bool ring, bool showShadow)
     {
-        _body.Color = body;
+        _body.FillColor = body;
         _body.HasDropshadow = showShadow;
-        _border.Color = border;
+        _border.StrokeColor = border;
         _focusRing.Visible = ring;
     }
 }

--- a/Themes/Gum.Themes.Bubblegum.MonoGame/SliderVisual.cs
+++ b/Themes/Gum.Themes.Bubblegum.MonoGame/SliderVisual.cs
@@ -20,8 +20,8 @@ public class SliderVisual : BaseSliderVisual
     private const float TrackHeight = 8f;
     private const float TrackCornerRadius = 4f;
 
-    private readonly RoundedRectangleRuntime _track;
-    private readonly RoundedRectangleRuntime _fill;
+    private readonly RectangleRuntime _track;
+    private readonly RectangleRuntime _fill;
     private readonly SliderThumbVisual _thumb;
 
     public SliderVisual(bool fullInstantiation = true, bool tryCreateFormsObject = true)
@@ -94,9 +94,9 @@ public class SliderVisual : BaseSliderVisual
         _fill.Width = (float)(pct * 100.0);
     }
 
-    private static RoundedRectangleRuntime CreateTrack()
+    private static RectangleRuntime CreateTrack()
     {
-        RoundedRectangleRuntime track = new RoundedRectangleRuntime();
+        RectangleRuntime track = new RectangleRuntime();
         track.Name = "BubblegumSliderTrack";
         track.X = 0;
         track.Y = 0;
@@ -110,13 +110,14 @@ public class SliderVisual : BaseSliderVisual
         track.HeightUnits = DimensionUnitType.Absolute;
         track.CornerRadius = TrackCornerRadius;
         track.IsFilled = true;
-        track.Color = BubblegumColors.AccentLight;
+        track.FillColor = BubblegumColors.AccentLight;
+        track.StrokeWidth = 0;
         return track;
     }
 
-    private static RoundedRectangleRuntime CreateFill()
+    private static RectangleRuntime CreateFill()
     {
-        RoundedRectangleRuntime fill = new RoundedRectangleRuntime();
+        RectangleRuntime fill = new RectangleRuntime();
         fill.Name = "BubblegumSliderFill";
         fill.X = 0;
         fill.Y = 0;
@@ -130,7 +131,8 @@ public class SliderVisual : BaseSliderVisual
         fill.HeightUnits = DimensionUnitType.Absolute;
         fill.CornerRadius = TrackCornerRadius;
         fill.IsFilled = true;
-        fill.Color = BubblegumColors.Accent;
+        fill.FillColor = BubblegumColors.Accent;
+        fill.StrokeWidth = 0;
         return fill;
     }
 
@@ -147,7 +149,7 @@ public class SliderVisual : BaseSliderVisual
 
     private void ApplyTrack(Color trackFill, Color fillBar)
     {
-        _track.Color = trackFill;
-        _fill.Color = fillBar;
+        _track.FillColor = trackFill;
+        _fill.FillColor = fillBar;
     }
 }

--- a/Themes/Gum.Themes.Bubblegum.MonoGame/SplitterVisual.cs
+++ b/Themes/Gum.Themes.Bubblegum.MonoGame/SplitterVisual.cs
@@ -13,7 +13,7 @@ namespace Gum.Themes.Bubblegum;
 /// </summary>
 public class SplitterVisual : BaseSplitterVisual
 {
-    private readonly ColoredRectangleRuntime _fill;
+    private readonly RectangleRuntime _fill;
 
     public SplitterVisual(bool fullInstantiation = true, bool tryCreateFormsObject = true)
         : base(fullInstantiation, tryCreateFormsObject)
@@ -24,9 +24,9 @@ public class SplitterVisual : BaseSplitterVisual
         AddChild(_fill);
     }
 
-    private static ColoredRectangleRuntime CreateFill()
+    private static RectangleRuntime CreateFill()
     {
-        ColoredRectangleRuntime fill = new ColoredRectangleRuntime();
+        RectangleRuntime fill = new RectangleRuntime();
         fill.Name = "BubblegumSplitterFill";
         fill.X = 0;
         fill.Y = 0;
@@ -38,7 +38,9 @@ public class SplitterVisual : BaseSplitterVisual
         fill.Height = 0;
         fill.WidthUnits = DimensionUnitType.RelativeToParent;
         fill.HeightUnits = DimensionUnitType.RelativeToParent;
-        fill.Color = BubblegumColors.AccentLight;
+        fill.IsFilled = true;
+        fill.FillColor = BubblegumColors.AccentLight;
+        fill.StrokeWidth = 0;
         return fill;
     }
 }

--- a/Themes/Gum.Themes.Bubblegum.MonoGame/ToggleButtonVisual.cs
+++ b/Themes/Gum.Themes.Bubblegum.MonoGame/ToggleButtonVisual.cs
@@ -29,9 +29,9 @@ public class ToggleButtonVisual : BaseToggleButtonVisual
     private const float ShadowBlur = 12f;
     private static readonly Color ShadowColor = new Color(255, 107, 157, 160);
 
-    private readonly RoundedRectangleRuntime _focusRing;
-    private readonly RoundedRectangleRuntime _fill;
-    private readonly RoundedRectangleRuntime _border;
+    private readonly RectangleRuntime _focusRing;
+    private readonly RectangleRuntime _fill;
+    private readonly RectangleRuntime _border;
 
     public ToggleButtonVisual(bool fullInstantiation = true, bool tryCreateFormsObject = true)
         : base(fullInstantiation, tryCreateFormsObject)
@@ -60,9 +60,9 @@ public class ToggleButtonVisual : BaseToggleButtonVisual
         WireStates();
     }
 
-    private static RoundedRectangleRuntime CreateFill()
+    private static RectangleRuntime CreateFill()
     {
-        RoundedRectangleRuntime fill = new RoundedRectangleRuntime();
+        RectangleRuntime fill = new RectangleRuntime();
         fill.Name = "BubblegumToggleFill";
         fill.X = 0;
         fill.Y = 0;
@@ -76,19 +76,19 @@ public class ToggleButtonVisual : BaseToggleButtonVisual
         fill.HeightUnits = DimensionUnitType.RelativeToParent;
         fill.CornerRadius = CornerRadius;
         fill.IsFilled = true;
-        fill.Color = BubblegumColors.Surface1;
+        fill.FillColor = BubblegumColors.Surface1;
+        fill.StrokeWidth = 0;
         fill.HasDropshadow = true;
         fill.DropshadowColor = ShadowColor;
         fill.DropshadowOffsetX = 0f;
         fill.DropshadowOffsetY = ShadowOffsetY;
-        fill.DropshadowBlurX = ShadowBlur;
-        fill.DropshadowBlurY = ShadowBlur;
+        fill.DropshadowBlur = ShadowBlur;
         return fill;
     }
 
-    private static RoundedRectangleRuntime CreateBorder()
+    private static RectangleRuntime CreateBorder()
     {
-        RoundedRectangleRuntime border = new RoundedRectangleRuntime();
+        RectangleRuntime border = new RectangleRuntime();
         border.Name = "BubblegumToggleBorder";
         border.X = 0;
         border.Y = 0;
@@ -104,13 +104,13 @@ public class ToggleButtonVisual : BaseToggleButtonVisual
         border.IsFilled = false;
         border.StrokeWidth = BorderThickness;
         border.StrokeWidthUnits = DimensionUnitType.Absolute;
-        border.Color = BubblegumColors.Border;
+        border.StrokeColor = BubblegumColors.Border;
         return border;
     }
 
-    private static RoundedRectangleRuntime CreateFocusRing()
+    private static RectangleRuntime CreateFocusRing()
     {
-        RoundedRectangleRuntime ring = new RoundedRectangleRuntime();
+        RectangleRuntime ring = new RectangleRuntime();
         ring.Name = "BubblegumToggleFocusRing";
         ring.X = 0;
         ring.Y = 0;
@@ -126,7 +126,7 @@ public class ToggleButtonVisual : BaseToggleButtonVisual
         ring.IsFilled = false;
         ring.StrokeWidth = FocusRingThickness;
         ring.StrokeWidthUnits = DimensionUnitType.Absolute;
-        ring.Color = BubblegumPalette.FocusRing;
+        ring.StrokeColor = BubblegumPalette.FocusRing;
         ring.Visible = false;
         return ring;
     }
@@ -195,9 +195,9 @@ public class ToggleButtonVisual : BaseToggleButtonVisual
 
     private void ApplyPalette(Color fill, Color border, Color text, bool showShadow, bool showFocusRing)
     {
-        _fill.Color = fill;
+        _fill.FillColor = fill;
         _fill.HasDropshadow = showShadow;
-        _border.Color = border;
+        _border.StrokeColor = border;
         TextInstance.Color = text;
         _focusRing.Visible = showFocusRing;
     }

--- a/Themes/Gum.Themes.Bubblegum.MonoGame/TooltipVisual.cs
+++ b/Themes/Gum.Themes.Bubblegum.MonoGame/TooltipVisual.cs
@@ -15,8 +15,8 @@ public class TooltipVisual : BaseTooltipVisual
     private const float CornerRadius = 8f;
     private const float BorderThickness = 2f;
 
-    private readonly RoundedRectangleRuntime _fill;
-    private readonly RoundedRectangleRuntime _border;
+    private readonly RectangleRuntime _fill;
+    private readonly RectangleRuntime _border;
 
     public TooltipVisual(bool fullInstantiation = true, bool tryCreateFormsObject = true)
         : base(fullInstantiation, tryCreateFormsObject)
@@ -34,9 +34,9 @@ public class TooltipVisual : BaseTooltipVisual
         TextInstance.Color = BubblegumColors.Text;
     }
 
-    private static RoundedRectangleRuntime CreateFill()
+    private static RectangleRuntime CreateFill()
     {
-        RoundedRectangleRuntime fill = new RoundedRectangleRuntime();
+        RectangleRuntime fill = new RectangleRuntime();
         fill.Name = "BubblegumTooltipFill";
         fill.X = 0;
         fill.Y = 0;
@@ -50,13 +50,14 @@ public class TooltipVisual : BaseTooltipVisual
         fill.HeightUnits = DimensionUnitType.RelativeToParent;
         fill.CornerRadius = CornerRadius;
         fill.IsFilled = true;
-        fill.Color = BubblegumColors.Surface1;
+        fill.FillColor = BubblegumColors.Surface1;
+        fill.StrokeWidth = 0;
         return fill;
     }
 
-    private static RoundedRectangleRuntime CreateBorder()
+    private static RectangleRuntime CreateBorder()
     {
-        RoundedRectangleRuntime border = new RoundedRectangleRuntime();
+        RectangleRuntime border = new RectangleRuntime();
         border.Name = "BubblegumTooltipBorder";
         border.X = 0;
         border.Y = 0;
@@ -72,7 +73,7 @@ public class TooltipVisual : BaseTooltipVisual
         border.IsFilled = false;
         border.StrokeWidth = BorderThickness;
         border.StrokeWidthUnits = DimensionUnitType.Absolute;
-        border.Color = BubblegumColors.Border;
+        border.StrokeColor = BubblegumColors.Border;
         return border;
     }
 }

--- a/Themes/Gum.Themes.Bubblegum.MonoGame/WindowVisual.cs
+++ b/Themes/Gum.Themes.Bubblegum.MonoGame/WindowVisual.cs
@@ -37,10 +37,10 @@ public class WindowVisual : BaseWindowVisual
     private const float ShadowBlur = 28f;
     private static readonly Color ShadowColor = new Color(180, 80, 120, 80);
 
-    private readonly RoundedRectangleRuntime _fill;
-    private readonly RoundedRectangleRuntime _border;
-    private readonly ColoredRectangleRuntime _titleBarFill;
-    private readonly ColoredRectangleRuntime _titleBarSeparator;
+    private readonly RectangleRuntime _fill;
+    private readonly RectangleRuntime _border;
+    private readonly RectangleRuntime _titleBarFill;
+    private readonly RectangleRuntime _titleBarSeparator;
 
     public WindowVisual(bool fullInstantiation = true, bool tryCreateFormsObject = true)
         : base(fullInstantiation, tryCreateFormsObject)
@@ -82,9 +82,9 @@ public class WindowVisual : BaseWindowVisual
         _titleBarSeparator.Parent = TitleBarInstance.Visual;
     }
 
-    private static RoundedRectangleRuntime CreateFill()
+    private static RectangleRuntime CreateFill()
     {
-        RoundedRectangleRuntime fill = new RoundedRectangleRuntime();
+        RectangleRuntime fill = new RectangleRuntime();
         fill.Name = "BubblegumWindowFill";
         fill.X = 0;
         fill.Y = 0;
@@ -98,20 +98,20 @@ public class WindowVisual : BaseWindowVisual
         fill.HeightUnits = DimensionUnitType.RelativeToParent;
         fill.CornerRadius = CornerRadius;
         fill.IsFilled = true;
-        fill.Color = BubblegumColors.Surface1;
+        fill.FillColor = BubblegumColors.Surface1;
+        fill.StrokeWidth = 0;
         // Native Gaussian drop shadow — replaces the prior three-layer stack.
         fill.HasDropshadow = true;
         fill.DropshadowColor = ShadowColor;
         fill.DropshadowOffsetX = 0f;
         fill.DropshadowOffsetY = ShadowOffsetY;
-        fill.DropshadowBlurX = ShadowBlur;
-        fill.DropshadowBlurY = ShadowBlur;
+        fill.DropshadowBlur = ShadowBlur;
         return fill;
     }
 
-    private static RoundedRectangleRuntime CreateBorder()
+    private static RectangleRuntime CreateBorder()
     {
-        RoundedRectangleRuntime border = new RoundedRectangleRuntime();
+        RectangleRuntime border = new RectangleRuntime();
         border.Name = "BubblegumWindowBorder";
         border.X = 0;
         border.Y = 0;
@@ -127,16 +127,16 @@ public class WindowVisual : BaseWindowVisual
         border.IsFilled = false;
         border.StrokeWidth = BorderThickness;
         border.StrokeWidthUnits = DimensionUnitType.Absolute;
-        border.Color = BubblegumColors.Border;
+        border.StrokeColor = BubblegumColors.Border;
         return border;
     }
 
-    private static ColoredRectangleRuntime CreateTitleBarFill()
+    private static RectangleRuntime CreateTitleBarFill()
     {
         // CSS uses a gradient (linear-gradient(135deg,#FF8FB8,var(--acc))); we
         // approximate with a flat Accent fill. A real gradient would need a
         // gradient-capable renderable that doesn't exist in the runtime yet.
-        ColoredRectangleRuntime fill = new ColoredRectangleRuntime();
+        RectangleRuntime fill = new RectangleRuntime();
         fill.Name = "BubblegumWindowTitleBarFill";
         fill.X = 0;
         fill.Y = 0;
@@ -148,13 +148,15 @@ public class WindowVisual : BaseWindowVisual
         fill.Height = 0;
         fill.WidthUnits = DimensionUnitType.RelativeToParent;
         fill.HeightUnits = DimensionUnitType.RelativeToParent;
-        fill.Color = BubblegumColors.Accent;
+        fill.IsFilled = true;
+        fill.FillColor = BubblegumColors.Accent;
+        fill.StrokeWidth = 0;
         return fill;
     }
 
-    private static ColoredRectangleRuntime CreateTitleBarSeparator()
+    private static RectangleRuntime CreateTitleBarSeparator()
     {
-        ColoredRectangleRuntime separator = new ColoredRectangleRuntime();
+        RectangleRuntime separator = new RectangleRuntime();
         separator.Name = "BubblegumWindowTitleBarSeparator";
         separator.X = 0;
         separator.Y = 0;
@@ -166,7 +168,9 @@ public class WindowVisual : BaseWindowVisual
         separator.Height = TitleBarSeparatorHeight;
         separator.WidthUnits = DimensionUnitType.RelativeToParent;
         separator.HeightUnits = DimensionUnitType.Absolute;
-        separator.Color = BubblegumColors.Border;
+        separator.IsFilled = true;
+        separator.FillColor = BubblegumColors.Border;
+        separator.StrokeWidth = 0;
         return separator;
     }
 }

--- a/Themes/Gum.Themes.DarkPro.MonoGame/ButtonVisual.cs
+++ b/Themes/Gum.Themes.DarkPro.MonoGame/ButtonVisual.cs
@@ -21,9 +21,9 @@ public class ButtonVisual : BaseButtonVisual
     private const float BorderThickness = 1f;
     private const float FocusRingInset = 1f;
 
-    private readonly RoundedRectangleRuntime _focusRing;
-    private readonly RoundedRectangleRuntime _fill;
-    private readonly RoundedRectangleRuntime _border;
+    private readonly RectangleRuntime _focusRing;
+    private readonly RectangleRuntime _fill;
+    private readonly RectangleRuntime _border;
 
     public ButtonVisual(bool fullInstantiation = true, bool tryCreateFormsObject = true)
         : base(fullInstantiation, tryCreateFormsObject)
@@ -55,9 +55,9 @@ public class ButtonVisual : BaseButtonVisual
         WireStates();
     }
 
-    private static RoundedRectangleRuntime CreateFill()
+    private static RectangleRuntime CreateFill()
     {
-        RoundedRectangleRuntime fill = new RoundedRectangleRuntime();
+        RectangleRuntime fill = new RectangleRuntime();
         fill.Name = "DarkProFill";
         fill.X = 0;
         fill.Y = 0;
@@ -71,13 +71,14 @@ public class ButtonVisual : BaseButtonVisual
         fill.HeightUnits = DimensionUnitType.RelativeToParent;
         fill.CornerRadius = CornerRadius;
         fill.IsFilled = true;
-        fill.Color = DarkProColors.Surface1;
+        fill.FillColor = DarkProColors.Surface1;
+        fill.StrokeWidth = 0;
         return fill;
     }
 
-    private static RoundedRectangleRuntime CreateBorder()
+    private static RectangleRuntime CreateBorder()
     {
-        RoundedRectangleRuntime border = new RoundedRectangleRuntime();
+        RectangleRuntime border = new RectangleRuntime();
         border.Name = "DarkProBorder";
         border.X = 0;
         border.Y = 0;
@@ -93,16 +94,16 @@ public class ButtonVisual : BaseButtonVisual
         border.IsFilled = false;
         border.StrokeWidth = BorderThickness;
         border.StrokeWidthUnits = DimensionUnitType.Absolute;
-        border.Color = DarkProColors.Border;
+        border.StrokeColor = DarkProColors.Border;
         return border;
     }
 
-    private static RoundedRectangleRuntime CreateFocusRing()
+    private static RectangleRuntime CreateFocusRing()
     {
         // Sized to (parent + 2px) per axis and centered, so the 1px stroke
         // sits exactly one pixel outside the border. Matches the
         // `box-shadow: 0 0 0 1px var(--acc)` effect from the mockup CSS.
-        RoundedRectangleRuntime ring = new RoundedRectangleRuntime();
+        RectangleRuntime ring = new RectangleRuntime();
         ring.Name = "DarkProFocusRing";
         ring.X = 0;
         ring.Y = 0;
@@ -118,7 +119,7 @@ public class ButtonVisual : BaseButtonVisual
         ring.IsFilled = false;
         ring.StrokeWidth = BorderThickness;
         ring.StrokeWidthUnits = DimensionUnitType.Absolute;
-        ring.Color = DarkProColors.Accent;
+        ring.StrokeColor = DarkProColors.Accent;
         ring.Visible = false;
         return ring;
     }
@@ -174,8 +175,8 @@ public class ButtonVisual : BaseButtonVisual
 
     private void ApplyPalette(Color fill, Color border, Color text, bool showFocusRing)
     {
-        _fill.Color = fill;
-        _border.Color = border;
+        _fill.FillColor = fill;
+        _border.StrokeColor = border;
         TextInstance.Color = text;
         _focusRing.Visible = showFocusRing;
     }

--- a/Themes/Gum.Themes.DarkPro.MonoGame/CheckBoxVisual.cs
+++ b/Themes/Gum.Themes.DarkPro.MonoGame/CheckBoxVisual.cs
@@ -28,11 +28,11 @@ public class CheckBoxVisual : BaseCheckBoxVisual
     // Latin but its Dingbats / Geometric Shapes glyphs are wider than the cell).
     private const float GlyphContainerSize = 24f;
 
-    private readonly RoundedRectangleRuntime _focusRing;
-    private readonly RoundedRectangleRuntime _boxFill;
-    private readonly RoundedRectangleRuntime _boxBorder;
+    private readonly RectangleRuntime _focusRing;
+    private readonly RectangleRuntime _boxFill;
+    private readonly RectangleRuntime _boxBorder;
     private readonly TextRuntime _checkGlyph;
-    private readonly RoundedRectangleRuntime _dashIndicator;
+    private readonly RectangleRuntime _dashIndicator;
 
     public CheckBoxVisual(bool fullInstantiation = true, bool tryCreateFormsObject = true)
         : base(fullInstantiation, tryCreateFormsObject)
@@ -74,9 +74,9 @@ public class CheckBoxVisual : BaseCheckBoxVisual
         WireStates();
     }
 
-    private static RoundedRectangleRuntime CreateBoxFill()
+    private static RectangleRuntime CreateBoxFill()
     {
-        RoundedRectangleRuntime fill = new RoundedRectangleRuntime();
+        RectangleRuntime fill = new RectangleRuntime();
         fill.Name = "DarkProBoxFill";
         fill.X = 0;
         fill.Y = 0;
@@ -90,13 +90,14 @@ public class CheckBoxVisual : BaseCheckBoxVisual
         fill.HeightUnits = DimensionUnitType.Absolute;
         fill.CornerRadius = CornerRadius;
         fill.IsFilled = true;
-        fill.Color = DarkProColors.Surface1;
+        fill.FillColor = DarkProColors.Surface1;
+        fill.StrokeWidth = 0;
         return fill;
     }
 
-    private static RoundedRectangleRuntime CreateBoxBorder()
+    private static RectangleRuntime CreateBoxBorder()
     {
-        RoundedRectangleRuntime border = new RoundedRectangleRuntime();
+        RectangleRuntime border = new RectangleRuntime();
         border.Name = "DarkProBoxBorder";
         border.X = 0;
         border.Y = 0;
@@ -112,15 +113,15 @@ public class CheckBoxVisual : BaseCheckBoxVisual
         border.IsFilled = false;
         border.StrokeWidth = BorderThickness;
         border.StrokeWidthUnits = DimensionUnitType.Absolute;
-        border.Color = DarkProColors.Border;
+        border.StrokeColor = DarkProColors.Border;
         return border;
     }
 
-    private static RoundedRectangleRuntime CreateFocusRing()
+    private static RectangleRuntime CreateFocusRing()
     {
         // (BoxSize + 2px) per axis, centered on the box, so the 1px stroke
         // sits exactly one pixel outside the box border.
-        RoundedRectangleRuntime ring = new RoundedRectangleRuntime();
+        RectangleRuntime ring = new RectangleRuntime();
         ring.Name = "DarkProBoxFocusRing";
         ring.X = -FocusRingInset;
         ring.Y = 0;
@@ -136,7 +137,7 @@ public class CheckBoxVisual : BaseCheckBoxVisual
         ring.IsFilled = false;
         ring.StrokeWidth = BorderThickness;
         ring.StrokeWidthUnits = DimensionUnitType.Absolute;
-        ring.Color = DarkProColors.Accent;
+        ring.StrokeColor = DarkProColors.Accent;
         ring.Visible = false;
         return ring;
     }
@@ -167,11 +168,11 @@ public class CheckBoxVisual : BaseCheckBoxVisual
         return glyph;
     }
 
-    private static RoundedRectangleRuntime CreateDashIndicator()
+    private static RectangleRuntime CreateDashIndicator()
     {
         // Indeterminate dash from the CSS spec: 8x2 pill, accent-colored,
         // centered inside the box.
-        RoundedRectangleRuntime dash = new RoundedRectangleRuntime();
+        RectangleRuntime dash = new RectangleRuntime();
         dash.Name = "DarkProDashIndicator";
         dash.X = BoxSize / 2f;
         dash.Y = 0;
@@ -185,7 +186,8 @@ public class CheckBoxVisual : BaseCheckBoxVisual
         dash.HeightUnits = DimensionUnitType.Absolute;
         dash.CornerRadius = 1f;
         dash.IsFilled = true;
-        dash.Color = DarkProColors.Accent;
+        dash.FillColor = DarkProColors.Accent;
+        dash.StrokeWidth = 0;
         return dash;
     }
 
@@ -298,8 +300,8 @@ public class CheckBoxVisual : BaseCheckBoxVisual
     private void Apply(Color fill, Color border, Color text, GlyphKind glyph, bool ring,
         Color? glyphColor = null)
     {
-        _boxFill.Color = fill;
-        _boxBorder.Color = border;
+        _boxFill.FillColor = fill;
+        _boxBorder.StrokeColor = border;
         TextInstance.Color = text;
         _focusRing.Visible = ring;
         _checkGlyph.Visible = glyph == GlyphKind.Check;

--- a/Themes/Gum.Themes.DarkPro.MonoGame/ComboBoxVisual.cs
+++ b/Themes/Gum.Themes.DarkPro.MonoGame/ComboBoxVisual.cs
@@ -34,9 +34,9 @@ public class ComboBoxVisual : BaseComboBoxVisual
     // the dropdown glyph so long item names don't visually crash into the chevron.
     private const float TextRightClearance = 4f;
 
-    private readonly RoundedRectangleRuntime _focusRing;
-    private readonly RoundedRectangleRuntime _fill;
-    private readonly RoundedRectangleRuntime _border;
+    private readonly RectangleRuntime _focusRing;
+    private readonly RectangleRuntime _fill;
+    private readonly RectangleRuntime _border;
     private readonly TextRuntime _dropdownGlyph;
 
     public ComboBoxVisual(bool fullInstantiation = true, bool tryCreateFormsObject = true)
@@ -75,9 +75,9 @@ public class ComboBoxVisual : BaseComboBoxVisual
         WireStates();
     }
 
-    private static RoundedRectangleRuntime CreateFill()
+    private static RectangleRuntime CreateFill()
     {
-        RoundedRectangleRuntime fill = new RoundedRectangleRuntime();
+        RectangleRuntime fill = new RectangleRuntime();
         fill.Name = "DarkProComboFill";
         fill.X = 0;
         fill.Y = 0;
@@ -91,13 +91,14 @@ public class ComboBoxVisual : BaseComboBoxVisual
         fill.HeightUnits = DimensionUnitType.RelativeToParent;
         fill.CornerRadius = CornerRadius;
         fill.IsFilled = true;
-        fill.Color = DarkProColors.Surface1;
+        fill.FillColor = DarkProColors.Surface1;
+        fill.StrokeWidth = 0;
         return fill;
     }
 
-    private static RoundedRectangleRuntime CreateBorder()
+    private static RectangleRuntime CreateBorder()
     {
-        RoundedRectangleRuntime border = new RoundedRectangleRuntime();
+        RectangleRuntime border = new RectangleRuntime();
         border.Name = "DarkProComboBorder";
         border.X = 0;
         border.Y = 0;
@@ -113,13 +114,13 @@ public class ComboBoxVisual : BaseComboBoxVisual
         border.IsFilled = false;
         border.StrokeWidth = BorderThickness;
         border.StrokeWidthUnits = DimensionUnitType.Absolute;
-        border.Color = DarkProColors.Border;
+        border.StrokeColor = DarkProColors.Border;
         return border;
     }
 
-    private static RoundedRectangleRuntime CreateFocusRing()
+    private static RectangleRuntime CreateFocusRing()
     {
-        RoundedRectangleRuntime ring = new RoundedRectangleRuntime();
+        RectangleRuntime ring = new RectangleRuntime();
         ring.Name = "DarkProComboFocusRing";
         ring.X = 0;
         ring.Y = 0;
@@ -135,7 +136,7 @@ public class ComboBoxVisual : BaseComboBoxVisual
         ring.IsFilled = false;
         ring.StrokeWidth = BorderThickness;
         ring.StrokeWidthUnits = DimensionUnitType.Absolute;
-        ring.Color = DarkProColors.Accent;
+        ring.StrokeColor = DarkProColors.Accent;
         ring.Visible = false;
         return ring;
     }
@@ -204,8 +205,8 @@ public class ComboBoxVisual : BaseComboBoxVisual
 
     private void Apply(Color border, Color text, Color glyph, bool ring, bool fillDisabled)
     {
-        _fill.Color = fillDisabled ? DarkProColors.DisabledFill : DarkProColors.Surface1;
-        _border.Color = border;
+        _fill.FillColor = fillDisabled ? DarkProColors.DisabledFill : DarkProColors.Surface1;
+        _border.StrokeColor = border;
         TextInstance.Color = text;
         _dropdownGlyph.Color = glyph;
         _focusRing.Visible = ring;

--- a/Themes/Gum.Themes.DarkPro.MonoGame/DarkProTextInputDecoration.cs
+++ b/Themes/Gum.Themes.DarkPro.MonoGame/DarkProTextInputDecoration.cs
@@ -23,9 +23,9 @@ internal sealed class DarkProTextInputDecoration
     private const float BorderThickness = 1f;
     private const float FocusRingInset = 1f;
 
-    private readonly RoundedRectangleRuntime _focusRing;
-    private readonly RoundedRectangleRuntime _fill;
-    private readonly RoundedRectangleRuntime _border;
+    private readonly RectangleRuntime _focusRing;
+    private readonly RectangleRuntime _fill;
+    private readonly RectangleRuntime _border;
 
     public DarkProTextInputDecoration(TextBoxBaseVisual host)
     {
@@ -52,9 +52,9 @@ internal sealed class DarkProTextInputDecoration
         WireStates(host);
     }
 
-    private static RoundedRectangleRuntime CreateFill()
+    private static RectangleRuntime CreateFill()
     {
-        RoundedRectangleRuntime fill = new RoundedRectangleRuntime();
+        RectangleRuntime fill = new RectangleRuntime();
         fill.Name = "DarkProTextInputFill";
         fill.X = 0;
         fill.Y = 0;
@@ -68,13 +68,14 @@ internal sealed class DarkProTextInputDecoration
         fill.HeightUnits = DimensionUnitType.RelativeToParent;
         fill.CornerRadius = CornerRadius;
         fill.IsFilled = true;
-        fill.Color = DarkProColors.Surface1;
+        fill.FillColor = DarkProColors.Surface1;
+        fill.StrokeWidth = 0;
         return fill;
     }
 
-    private static RoundedRectangleRuntime CreateBorder()
+    private static RectangleRuntime CreateBorder()
     {
-        RoundedRectangleRuntime border = new RoundedRectangleRuntime();
+        RectangleRuntime border = new RectangleRuntime();
         border.Name = "DarkProTextInputBorder";
         border.X = 0;
         border.Y = 0;
@@ -90,15 +91,15 @@ internal sealed class DarkProTextInputDecoration
         border.IsFilled = false;
         border.StrokeWidth = BorderThickness;
         border.StrokeWidthUnits = DimensionUnitType.Absolute;
-        border.Color = DarkProColors.Border;
+        border.StrokeColor = DarkProColors.Border;
         return border;
     }
 
-    private static RoundedRectangleRuntime CreateFocusRing()
+    private static RectangleRuntime CreateFocusRing()
     {
         // 1px stroke sitting one pixel outside the border, matching the CSS
         // `box-shadow: 0 0 0 1px var(--acc)` from the mockup.
-        RoundedRectangleRuntime ring = new RoundedRectangleRuntime();
+        RectangleRuntime ring = new RectangleRuntime();
         ring.Name = "DarkProTextInputFocusRing";
         ring.X = 0;
         ring.Y = 0;
@@ -114,7 +115,7 @@ internal sealed class DarkProTextInputDecoration
         ring.IsFilled = false;
         ring.StrokeWidth = BorderThickness;
         ring.StrokeWidthUnits = DimensionUnitType.Absolute;
-        ring.Color = DarkProColors.Accent;
+        ring.StrokeColor = DarkProColors.Accent;
         ring.Visible = false;
         return ring;
     }
@@ -154,8 +155,8 @@ internal sealed class DarkProTextInputDecoration
     private void Apply(TextBoxBaseVisual host, Color fill, Color border, Color text,
         Color placeholder, Color caret, Color selection, bool ring)
     {
-        _fill.Color = fill;
-        _border.Color = border;
+        _fill.FillColor = fill;
+        _border.StrokeColor = border;
         host.TextInstance.Color = text;
         host.PlaceholderTextInstance.Color = placeholder;
         host.CaretInstance.Color = caret;

--- a/Themes/Gum.Themes.DarkPro.MonoGame/DarkProTheme.cs
+++ b/Themes/Gum.Themes.DarkPro.MonoGame/DarkProTheme.cs
@@ -64,8 +64,8 @@ public static class DarkProTheme
         BmfcSave.AddCharacters("✓✕▾▴▲▼◀▶");
 
         // Dark Pro's visuals build their bodies out of Apos.Shapes-backed
-        // RoundedRectangleRuntime instances, which require ShapeRenderer to
-        // be initialized. Initialize here so consumers don't need to know
+        // RectangleRuntime / CircleRuntime instances, which require ShapeRenderer
+        // to be initialized. Initialize here so consumers don't need to know
         // the theme uses shapes internally. Guard for the case where the
         // host app already initialized it (e.g. mixing themes or using
         // shape runtimes elsewhere).
@@ -224,5 +224,16 @@ public static class DarkProTheme
 
         FrameworkElement.DefaultFormsTemplates[typeof(Tooltip)] =
             new VisualTemplate((_, c) => new TooltipVisual(tryCreateFormsObject: c));
+
+        // Controls Dark Pro does not restyle are pinned to their stock V3 visuals so
+        // DarkProTheme.Apply fully specifies the template set. FrameworkElement.DefaultFormsTemplates
+        // is global static state; without re-registering these, re-applying a theme at runtime
+        // (theme switching) would leave a previously-applied theme's visual in place for these
+        // controls. These match what a single-theme Dark Pro run already falls back to.
+        FrameworkElement.DefaultFormsTemplates[typeof(ItemsControl)] =
+            new VisualTemplate((_, c) => new Gum.Forms.DefaultVisuals.V3.ItemsControlVisual(tryCreateFormsObject: c));
+
+        FrameworkElement.DefaultFormsTemplates[typeof(Gum.Forms.Controls.Games.DialogBox)] =
+            new VisualTemplate((_, c) => new Gum.Forms.DefaultVisuals.V3.DialogBoxVisual(tryCreateFormsObject: c));
     }
 }

--- a/Themes/Gum.Themes.DarkPro.MonoGame/ListBoxItemVisual.cs
+++ b/Themes/Gum.Themes.DarkPro.MonoGame/ListBoxItemVisual.cs
@@ -16,7 +16,7 @@ namespace Gum.Themes.DarkPro;
 /// </summary>
 public class ListBoxItemVisual : BaseListBoxItemVisual
 {
-    private readonly RoundedRectangleRuntime _fill;
+    private readonly RectangleRuntime _fill;
 
     public ListBoxItemVisual(bool fullInstantiation = true, bool tryCreateFormsObject = true)
         : base(fullInstantiation, tryCreateFormsObject)
@@ -43,9 +43,9 @@ public class ListBoxItemVisual : BaseListBoxItemVisual
         WireStates();
     }
 
-    private static RoundedRectangleRuntime CreateFill()
+    private static RectangleRuntime CreateFill()
     {
-        RoundedRectangleRuntime fill = new RoundedRectangleRuntime();
+        RectangleRuntime fill = new RectangleRuntime();
         fill.Name = "DarkProListItemFill";
         fill.X = 0;
         fill.Y = 0;
@@ -59,7 +59,8 @@ public class ListBoxItemVisual : BaseListBoxItemVisual
         fill.HeightUnits = DimensionUnitType.RelativeToParent;
         fill.CornerRadius = 0f;
         fill.IsFilled = true;
-        fill.Color = Color.Transparent;
+        fill.FillColor = Color.Transparent;
+        fill.StrokeWidth = 0;
         return fill;
     }
 
@@ -88,7 +89,7 @@ public class ListBoxItemVisual : BaseListBoxItemVisual
 
     private void ApplyPalette(Color fill, Color text)
     {
-        _fill.Color = fill;
+        _fill.FillColor = fill;
         TextInstance.Color = text;
     }
 }

--- a/Themes/Gum.Themes.DarkPro.MonoGame/ListBoxVisual.cs
+++ b/Themes/Gum.Themes.DarkPro.MonoGame/ListBoxVisual.cs
@@ -20,9 +20,9 @@ public class ListBoxVisual : BaseListBoxVisual
     private const float BorderThickness = 1f;
     private const float FocusRingInset = 1f;
 
-    private readonly RoundedRectangleRuntime _focusRing;
-    private readonly RoundedRectangleRuntime _fill;
-    private readonly RoundedRectangleRuntime _border;
+    private readonly RectangleRuntime _focusRing;
+    private readonly RectangleRuntime _fill;
+    private readonly RectangleRuntime _border;
 
     public ListBoxVisual(bool fullInstantiation = true, bool tryCreateFormsObject = true)
         : base(fullInstantiation, tryCreateFormsObject)
@@ -59,9 +59,9 @@ public class ListBoxVisual : BaseListBoxVisual
         WireStates();
     }
 
-    private static RoundedRectangleRuntime CreateFill()
+    private static RectangleRuntime CreateFill()
     {
-        RoundedRectangleRuntime fill = new RoundedRectangleRuntime();
+        RectangleRuntime fill = new RectangleRuntime();
         fill.Name = "DarkProListBoxFill";
         fill.X = 0;
         fill.Y = 0;
@@ -75,13 +75,14 @@ public class ListBoxVisual : BaseListBoxVisual
         fill.HeightUnits = DimensionUnitType.RelativeToParent;
         fill.CornerRadius = CornerRadius;
         fill.IsFilled = true;
-        fill.Color = DarkProColors.Surface1;
+        fill.FillColor = DarkProColors.Surface1;
+        fill.StrokeWidth = 0;
         return fill;
     }
 
-    private static RoundedRectangleRuntime CreateBorder()
+    private static RectangleRuntime CreateBorder()
     {
-        RoundedRectangleRuntime border = new RoundedRectangleRuntime();
+        RectangleRuntime border = new RectangleRuntime();
         border.Name = "DarkProListBoxBorder";
         border.X = 0;
         border.Y = 0;
@@ -97,13 +98,13 @@ public class ListBoxVisual : BaseListBoxVisual
         border.IsFilled = false;
         border.StrokeWidth = BorderThickness;
         border.StrokeWidthUnits = DimensionUnitType.Absolute;
-        border.Color = DarkProColors.Border;
+        border.StrokeColor = DarkProColors.Border;
         return border;
     }
 
-    private static RoundedRectangleRuntime CreateFocusRing()
+    private static RectangleRuntime CreateFocusRing()
     {
-        RoundedRectangleRuntime ring = new RoundedRectangleRuntime();
+        RectangleRuntime ring = new RectangleRuntime();
         ring.Name = "DarkProListBoxFocusRing";
         ring.X = 0;
         ring.Y = 0;
@@ -119,7 +120,7 @@ public class ListBoxVisual : BaseListBoxVisual
         ring.IsFilled = false;
         ring.StrokeWidth = BorderThickness;
         ring.StrokeWidthUnits = DimensionUnitType.Absolute;
-        ring.Color = DarkProColors.Accent;
+        ring.StrokeColor = DarkProColors.Accent;
         ring.Visible = false;
         return ring;
     }
@@ -155,8 +156,8 @@ public class ListBoxVisual : BaseListBoxVisual
 
     private void ApplyPalette(Color border, bool showFocusRing, bool fillDisabled = false)
     {
-        _fill.Color = fillDisabled ? DarkProColors.DisabledFill : DarkProColors.Surface1;
-        _border.Color = border;
+        _fill.FillColor = fillDisabled ? DarkProColors.DisabledFill : DarkProColors.Surface1;
+        _border.StrokeColor = border;
         _focusRing.Visible = showFocusRing;
     }
 }

--- a/Themes/Gum.Themes.DarkPro.MonoGame/MenuItemVisual.cs
+++ b/Themes/Gum.Themes.DarkPro.MonoGame/MenuItemVisual.cs
@@ -30,7 +30,7 @@ public class MenuItemVisual : BaseMenuItemVisual
     private const float HorizontalPadding = 12f;
     private const float VerticalPadding = 4f;
 
-    private readonly ColoredRectangleRuntime _fill;
+    private readonly RectangleRuntime _fill;
 
     public MenuItemVisual(bool fullInstantiation = true, bool tryCreateFormsObject = true)
         : base(fullInstantiation, tryCreateFormsObject: false)
@@ -113,14 +113,14 @@ public class MenuItemVisual : BaseMenuItemVisual
 
     private void ApplyPalette(Color fill, Color text)
     {
-        _fill.Color = fill;
+        _fill.FillColor = fill;
         TextInstance.Color = text;
         SubmenuIndicatorInstance.Color = text;
     }
 
-    private static ColoredRectangleRuntime CreateFill()
+    private static RectangleRuntime CreateFill()
     {
-        ColoredRectangleRuntime fill = new ColoredRectangleRuntime();
+        RectangleRuntime fill = new RectangleRuntime();
         fill.Name = "DarkProMenuItemFill";
         fill.X = 0;
         fill.Y = 0;
@@ -132,7 +132,9 @@ public class MenuItemVisual : BaseMenuItemVisual
         fill.Height = 0;
         fill.WidthUnits = DimensionUnitType.RelativeToParent;
         fill.HeightUnits = DimensionUnitType.RelativeToParent;
-        fill.Color = Color.Transparent;
+        fill.IsFilled = true;
+        fill.FillColor = Color.Transparent;
+        fill.StrokeWidth = 0;
         return fill;
     }
 }

--- a/Themes/Gum.Themes.DarkPro.MonoGame/MenuVisual.cs
+++ b/Themes/Gum.Themes.DarkPro.MonoGame/MenuVisual.cs
@@ -16,8 +16,8 @@ public class MenuVisual : BaseMenuVisual
 {
     private const float SeparatorHeight = 1f;
 
-    private readonly ColoredRectangleRuntime _fill;
-    private readonly ColoredRectangleRuntime _bottomSeparator;
+    private readonly RectangleRuntime _fill;
+    private readonly RectangleRuntime _bottomSeparator;
 
     public MenuVisual(bool fullInstantiation = true, bool tryCreateFormsObject = true)
         : base(fullInstantiation, tryCreateFormsObject)
@@ -37,9 +37,9 @@ public class MenuVisual : BaseMenuVisual
         AddChild(InnerPanelInstance);
     }
 
-    private static ColoredRectangleRuntime CreateFill()
+    private static RectangleRuntime CreateFill()
     {
-        ColoredRectangleRuntime fill = new ColoredRectangleRuntime();
+        RectangleRuntime fill = new RectangleRuntime();
         fill.Name = "DarkProMenuFill";
         fill.X = 0;
         fill.Y = 0;
@@ -51,13 +51,15 @@ public class MenuVisual : BaseMenuVisual
         fill.Height = 0;
         fill.WidthUnits = DimensionUnitType.RelativeToParent;
         fill.HeightUnits = DimensionUnitType.RelativeToParent;
-        fill.Color = DarkProColors.Surface1;
+        fill.IsFilled = true;
+        fill.FillColor = DarkProColors.Surface1;
+        fill.StrokeWidth = 0;
         return fill;
     }
 
-    private static ColoredRectangleRuntime CreateBottomSeparator()
+    private static RectangleRuntime CreateBottomSeparator()
     {
-        ColoredRectangleRuntime separator = new ColoredRectangleRuntime();
+        RectangleRuntime separator = new RectangleRuntime();
         separator.Name = "DarkProMenuBottomSeparator";
         separator.X = 0;
         separator.Y = 0;
@@ -69,7 +71,9 @@ public class MenuVisual : BaseMenuVisual
         separator.Height = SeparatorHeight;
         separator.WidthUnits = DimensionUnitType.RelativeToParent;
         separator.HeightUnits = DimensionUnitType.Absolute;
-        separator.Color = DarkProColors.Border;
+        separator.IsFilled = true;
+        separator.FillColor = DarkProColors.Border;
+        separator.StrokeWidth = 0;
         return separator;
     }
 }

--- a/Themes/Gum.Themes.DarkPro.MonoGame/RadioButtonVisual.cs
+++ b/Themes/Gum.Themes.DarkPro.MonoGame/RadioButtonVisual.cs
@@ -11,7 +11,7 @@ namespace Gum.Themes.DarkPro;
 /// <summary>
 /// Dark Pro styled RadioButton visual. Replaces the V3 RadioButtonVisual's
 /// NineSlice circular background, sprite-based inner dot, and underline focus
-/// indicator with an Apos.Shapes ColoredCircleRuntime stack: filled outer
+/// indicator with an Apos.Shapes CircleRuntime stack: filled outer
 /// circle, 1px stroked outer ring, filled inner dot (visible when selected),
 /// and a 1px focus ring sized one pixel outside the outer ring.
 /// </summary>
@@ -23,10 +23,10 @@ public class RadioButtonVisual : BaseRadioButtonVisual
     private const float FocusRingInset = 1f;
     private const float BoxToLabelGap = 8f;
 
-    private readonly ColoredCircleRuntime _focusRing;
-    private readonly ColoredCircleRuntime _outerFill;
-    private readonly ColoredCircleRuntime _outerBorder;
-    private readonly ColoredCircleRuntime _innerDot;
+    private readonly CircleRuntime _focusRing;
+    private readonly CircleRuntime _outerFill;
+    private readonly CircleRuntime _outerBorder;
+    private readonly CircleRuntime _innerDot;
 
     public RadioButtonVisual(bool fullInstantiation = true, bool tryCreateFormsObject = true)
         : base(fullInstantiation, tryCreateFormsObject)
@@ -55,9 +55,9 @@ public class RadioButtonVisual : BaseRadioButtonVisual
         WireStates();
     }
 
-    private static ColoredCircleRuntime CreateOuterFill()
+    private static CircleRuntime CreateOuterFill()
     {
-        ColoredCircleRuntime circle = new ColoredCircleRuntime();
+        CircleRuntime circle = new CircleRuntime();
         circle.Name = "DarkProRadioOuterFill";
         circle.X = 0;
         circle.Y = 0;
@@ -70,13 +70,14 @@ public class RadioButtonVisual : BaseRadioButtonVisual
         circle.WidthUnits = DimensionUnitType.Absolute;
         circle.HeightUnits = DimensionUnitType.Absolute;
         circle.IsFilled = true;
-        circle.Color = DarkProColors.Surface1;
+        circle.FillColor = DarkProColors.Surface1;
+        circle.StrokeWidth = 0;
         return circle;
     }
 
-    private static ColoredCircleRuntime CreateOuterBorder()
+    private static CircleRuntime CreateOuterBorder()
     {
-        ColoredCircleRuntime circle = new ColoredCircleRuntime();
+        CircleRuntime circle = new CircleRuntime();
         circle.Name = "DarkProRadioOuterBorder";
         circle.X = 0;
         circle.Y = 0;
@@ -91,16 +92,16 @@ public class RadioButtonVisual : BaseRadioButtonVisual
         circle.IsFilled = false;
         circle.StrokeWidth = BorderThickness;
         circle.StrokeWidthUnits = DimensionUnitType.Absolute;
-        circle.Color = DarkProColors.Border;
+        circle.StrokeColor = DarkProColors.Border;
         return circle;
     }
 
-    private static ColoredCircleRuntime CreateFocusRing()
+    private static CircleRuntime CreateFocusRing()
     {
         // 18-px outer (16 + 2 for the 1-px ring overhang on each side).
         // The outer rings sit on parent.Left; offset the focus ring by -1 so
         // it's centered horizontally on the outer ring.
-        ColoredCircleRuntime ring = new ColoredCircleRuntime();
+        CircleRuntime ring = new CircleRuntime();
         ring.Name = "DarkProRadioFocusRing";
         ring.X = -FocusRingInset;
         ring.Y = 0;
@@ -115,18 +116,18 @@ public class RadioButtonVisual : BaseRadioButtonVisual
         ring.IsFilled = false;
         ring.StrokeWidth = BorderThickness;
         ring.StrokeWidthUnits = DimensionUnitType.Absolute;
-        ring.Color = DarkProColors.Accent;
+        ring.StrokeColor = DarkProColors.Accent;
         ring.Visible = false;
         return ring;
     }
 
-    private static ColoredCircleRuntime CreateInnerDot()
+    private static CircleRuntime CreateInnerDot()
     {
         // 8-px filled circle centered on the 16-px outer circle. Outer is at
         // parent.Left (Left origin), so the inner is offset by (Outer-Inner)/2
         // = 4 from the left.
         const float inset = (OuterSize - InnerSize) / 2f;
-        ColoredCircleRuntime dot = new ColoredCircleRuntime();
+        CircleRuntime dot = new CircleRuntime();
         dot.Name = "DarkProRadioInnerDot";
         dot.X = inset;
         dot.Y = 0;
@@ -139,7 +140,8 @@ public class RadioButtonVisual : BaseRadioButtonVisual
         dot.WidthUnits = DimensionUnitType.Absolute;
         dot.HeightUnits = DimensionUnitType.Absolute;
         dot.IsFilled = true;
-        dot.Color = DarkProColors.Accent;
+        dot.FillColor = DarkProColors.Accent;
+        dot.StrokeWidth = 0;
         dot.Visible = false;
         return dot;
     }
@@ -222,13 +224,13 @@ public class RadioButtonVisual : BaseRadioButtonVisual
     private void Apply(Color fill, Color border, Color text, bool innerVisible, bool ring,
         Color? innerColor = null)
     {
-        _outerFill.Color = fill;
-        _outerBorder.Color = border;
+        _outerFill.FillColor = fill;
+        _outerBorder.StrokeColor = border;
         TextInstance.Color = text;
         _innerDot.Visible = innerVisible;
         if (innerColor.HasValue)
         {
-            _innerDot.Color = innerColor.Value;
+            _innerDot.FillColor = innerColor.Value;
         }
         _focusRing.Visible = ring;
     }

--- a/Themes/Gum.Themes.DarkPro.MonoGame/ScrollBarThumbVisual.cs
+++ b/Themes/Gum.Themes.DarkPro.MonoGame/ScrollBarThumbVisual.cs
@@ -23,7 +23,7 @@ public class ScrollBarThumbVisual : InteractiveGue
 {
     private const float CornerRadius = 2f;
 
-    private readonly RoundedRectangleRuntime _body;
+    private readonly RectangleRuntime _body;
 
     private StateSaveCategory _buttonCategory = null!;
 
@@ -43,9 +43,9 @@ public class ScrollBarThumbVisual : InteractiveGue
         WireStates();
     }
 
-    private static RoundedRectangleRuntime CreateBody()
+    private static RectangleRuntime CreateBody()
     {
-        RoundedRectangleRuntime body = new RoundedRectangleRuntime();
+        RectangleRuntime body = new RectangleRuntime();
         body.Name = "DarkProScrollThumbBody";
         body.X = 0;
         body.Y = 0;
@@ -59,7 +59,8 @@ public class ScrollBarThumbVisual : InteractiveGue
         body.HeightUnits = DimensionUnitType.RelativeToParent;
         body.CornerRadius = CornerRadius;
         body.IsFilled = true;
-        body.Color = DarkProColors.Border;
+        body.FillColor = DarkProColors.Border;
+        body.StrokeWidth = 0;
         return body;
     }
 
@@ -70,28 +71,28 @@ public class ScrollBarThumbVisual : InteractiveGue
         AddCategory(_buttonCategory);
 
         Add(_buttonCategory, FrameworkElement.EnabledStateName,
-            () => _body.Color = DarkProColors.Border);
+            () => _body.FillColor = DarkProColors.Border);
 
         Add(_buttonCategory, FrameworkElement.HighlightedStateName,
-            () => _body.Color = DarkProColors.BorderHover);
+            () => _body.FillColor = DarkProColors.BorderHover);
 
         Add(_buttonCategory, FrameworkElement.PushedStateName,
-            () => _body.Color = DarkProColors.Muted);
+            () => _body.FillColor = DarkProColors.Muted);
 
         // No focus ring on a scroll-bar thumb — keyboard scroll focus lives
         // on the scrollable container, not the thumb itself. Match the
         // Enabled / Highlighted look so a focused thumb still de-emphasizes.
         Add(_buttonCategory, FrameworkElement.FocusedStateName,
-            () => _body.Color = DarkProColors.Border);
+            () => _body.FillColor = DarkProColors.Border);
 
         Add(_buttonCategory, FrameworkElement.HighlightedFocusedStateName,
-            () => _body.Color = DarkProColors.BorderHover);
+            () => _body.FillColor = DarkProColors.BorderHover);
 
         Add(_buttonCategory, FrameworkElement.DisabledStateName,
-            () => _body.Color = DarkProColors.DisabledBorder);
+            () => _body.FillColor = DarkProColors.DisabledBorder);
 
         Add(_buttonCategory, FrameworkElement.DisabledFocusedStateName,
-            () => _body.Color = DarkProColors.DisabledBorder);
+            () => _body.FillColor = DarkProColors.DisabledBorder);
     }
 
     private static void Add(StateSaveCategory category, string name, System.Action apply)

--- a/Themes/Gum.Themes.DarkPro.MonoGame/ScrollBarVisual.cs
+++ b/Themes/Gum.Themes.DarkPro.MonoGame/ScrollBarVisual.cs
@@ -38,8 +38,8 @@ public class ScrollBarVisual : BaseScrollBarVisual
     private const float FrameBorderThickness = 1f;
 
     private readonly ScrollBarThumbVisual _thumb;
-    private readonly RoundedRectangleRuntime _frameFill;
-    private readonly RoundedRectangleRuntime _frameBorder;
+    private readonly RectangleRuntime _frameFill;
+    private readonly RectangleRuntime _frameBorder;
     private bool _isHorizontal;
 
     public ScrollBarVisual(bool fullInstantiation = true, bool tryCreateFormsObject = true)
@@ -189,9 +189,9 @@ public class ScrollBarVisual : BaseScrollBarVisual
         }
     }
 
-    private static RoundedRectangleRuntime CreateFrameFill()
+    private static RectangleRuntime CreateFrameFill()
     {
-        RoundedRectangleRuntime fill = new RoundedRectangleRuntime();
+        RectangleRuntime fill = new RectangleRuntime();
         fill.Name = "DarkProScrollBarFrameFill";
         fill.X = 0;
         fill.Y = 0;
@@ -205,13 +205,14 @@ public class ScrollBarVisual : BaseScrollBarVisual
         fill.HeightUnits = DimensionUnitType.RelativeToParent;
         fill.CornerRadius = FrameCornerRadius;
         fill.IsFilled = true;
-        fill.Color = DarkProColors.Surface1;
+        fill.FillColor = DarkProColors.Surface1;
+        fill.StrokeWidth = 0;
         return fill;
     }
 
-    private static RoundedRectangleRuntime CreateFrameBorder()
+    private static RectangleRuntime CreateFrameBorder()
     {
-        RoundedRectangleRuntime border = new RoundedRectangleRuntime();
+        RectangleRuntime border = new RectangleRuntime();
         border.Name = "DarkProScrollBarFrameBorder";
         border.X = 0;
         border.Y = 0;
@@ -227,7 +228,7 @@ public class ScrollBarVisual : BaseScrollBarVisual
         border.IsFilled = false;
         border.StrokeWidth = FrameBorderThickness;
         border.StrokeWidthUnits = DimensionUnitType.Absolute;
-        border.Color = DarkProColors.Border;
+        border.StrokeColor = DarkProColors.Border;
         return border;
     }
 }

--- a/Themes/Gum.Themes.DarkPro.MonoGame/ScrollViewerVisual.cs
+++ b/Themes/Gum.Themes.DarkPro.MonoGame/ScrollViewerVisual.cs
@@ -23,9 +23,9 @@ public class ScrollViewerVisual : BaseScrollViewerVisual
     private const float BorderThickness = 1f;
     private const float FocusRingInset = 1f;
 
-    private readonly RoundedRectangleRuntime _focusRing;
-    private readonly RoundedRectangleRuntime _fill;
-    private readonly RoundedRectangleRuntime _border;
+    private readonly RectangleRuntime _focusRing;
+    private readonly RectangleRuntime _fill;
+    private readonly RectangleRuntime _border;
 
     public ScrollViewerVisual(bool fullInstantiation = true, bool tryCreateFormsObject = true)
         : base(fullInstantiation, tryCreateFormsObject)
@@ -57,9 +57,9 @@ public class ScrollViewerVisual : BaseScrollViewerVisual
         WireStates();
     }
 
-    private static RoundedRectangleRuntime CreateFill()
+    private static RectangleRuntime CreateFill()
     {
-        RoundedRectangleRuntime fill = new RoundedRectangleRuntime();
+        RectangleRuntime fill = new RectangleRuntime();
         fill.Name = "DarkProScrollViewerFill";
         fill.X = 0;
         fill.Y = 0;
@@ -73,13 +73,14 @@ public class ScrollViewerVisual : BaseScrollViewerVisual
         fill.HeightUnits = DimensionUnitType.RelativeToParent;
         fill.CornerRadius = CornerRadius;
         fill.IsFilled = true;
-        fill.Color = DarkProColors.Surface1;
+        fill.FillColor = DarkProColors.Surface1;
+        fill.StrokeWidth = 0;
         return fill;
     }
 
-    private static RoundedRectangleRuntime CreateBorder()
+    private static RectangleRuntime CreateBorder()
     {
-        RoundedRectangleRuntime border = new RoundedRectangleRuntime();
+        RectangleRuntime border = new RectangleRuntime();
         border.Name = "DarkProScrollViewerBorder";
         border.X = 0;
         border.Y = 0;
@@ -95,13 +96,13 @@ public class ScrollViewerVisual : BaseScrollViewerVisual
         border.IsFilled = false;
         border.StrokeWidth = BorderThickness;
         border.StrokeWidthUnits = DimensionUnitType.Absolute;
-        border.Color = DarkProColors.Border;
+        border.StrokeColor = DarkProColors.Border;
         return border;
     }
 
-    private static RoundedRectangleRuntime CreateFocusRing()
+    private static RectangleRuntime CreateFocusRing()
     {
-        RoundedRectangleRuntime ring = new RoundedRectangleRuntime();
+        RectangleRuntime ring = new RectangleRuntime();
         ring.Name = "DarkProScrollViewerFocusRing";
         ring.X = 0;
         ring.Y = 0;
@@ -117,7 +118,7 @@ public class ScrollViewerVisual : BaseScrollViewerVisual
         ring.IsFilled = false;
         ring.StrokeWidth = BorderThickness;
         ring.StrokeWidthUnits = DimensionUnitType.Absolute;
-        ring.Color = DarkProColors.Accent;
+        ring.StrokeColor = DarkProColors.Accent;
         ring.Visible = false;
         return ring;
     }
@@ -134,13 +135,13 @@ public class ScrollViewerVisual : BaseScrollViewerVisual
         // applies, but they're harmless because FocusedIndicator has no parent.
         States.Enabled.Apply = () =>
         {
-            _border.Color = DarkProColors.Border;
+            _border.StrokeColor = DarkProColors.Border;
             _focusRing.Visible = false;
         };
 
         States.Focused.Apply = () =>
         {
-            _border.Color = DarkProColors.Accent;
+            _border.StrokeColor = DarkProColors.Accent;
             _focusRing.Visible = true;
         };
     }

--- a/Themes/Gum.Themes.DarkPro.MonoGame/SliderThumbVisual.cs
+++ b/Themes/Gum.Themes.DarkPro.MonoGame/SliderThumbVisual.cs
@@ -23,8 +23,8 @@ public class SliderThumbVisual : InteractiveGue
     private const float FocusRingInset = 2f;
     private const float BorderThickness = 1f;
 
-    private readonly ColoredCircleRuntime _focusRing;
-    private readonly ColoredCircleRuntime _body;
+    private readonly CircleRuntime _focusRing;
+    private readonly CircleRuntime _body;
 
     private StateSaveCategory _buttonCategory = null!;
 
@@ -45,9 +45,9 @@ public class SliderThumbVisual : InteractiveGue
         WireStates();
     }
 
-    private static ColoredCircleRuntime CreateBody()
+    private static CircleRuntime CreateBody()
     {
-        ColoredCircleRuntime body = new ColoredCircleRuntime();
+        CircleRuntime body = new CircleRuntime();
         body.Name = "DarkProSliderThumbBody";
         body.X = 0;
         body.Y = 0;
@@ -60,15 +60,16 @@ public class SliderThumbVisual : InteractiveGue
         body.WidthUnits = DimensionUnitType.RelativeToParent;
         body.HeightUnits = DimensionUnitType.RelativeToParent;
         body.IsFilled = true;
-        body.Color = DarkProColors.Accent;
+        body.FillColor = DarkProColors.Accent;
+        body.StrokeWidth = 0;
         return body;
     }
 
-    private static ColoredCircleRuntime CreateFocusRing()
+    private static CircleRuntime CreateFocusRing()
     {
         // Sized (Size + 2 * FocusRingInset) so the 1-px stroke sits FocusRingInset
         // pixels outside the body.
-        ColoredCircleRuntime ring = new ColoredCircleRuntime();
+        CircleRuntime ring = new CircleRuntime();
         ring.Name = "DarkProSliderThumbFocusRing";
         ring.X = 0;
         ring.Y = 0;
@@ -83,7 +84,7 @@ public class SliderThumbVisual : InteractiveGue
         ring.IsFilled = false;
         ring.StrokeWidth = BorderThickness;
         ring.StrokeWidthUnits = DimensionUnitType.Absolute;
-        ring.Color = DarkProColors.Accent;
+        ring.StrokeColor = DarkProColors.Accent;
         ring.Visible = false;
         return ring;
     }
@@ -125,7 +126,7 @@ public class SliderThumbVisual : InteractiveGue
 
     private void Apply(Color body, bool ring)
     {
-        _body.Color = body;
+        _body.FillColor = body;
         _focusRing.Visible = ring;
     }
 }

--- a/Themes/Gum.Themes.DarkPro.MonoGame/SliderVisual.cs
+++ b/Themes/Gum.Themes.DarkPro.MonoGame/SliderVisual.cs
@@ -27,9 +27,9 @@ public class SliderVisual : BaseSliderVisual
     private const float TrackCornerRadius = 3f;
     private const float BorderThickness = 1f;
 
-    private readonly RoundedRectangleRuntime _track;
-    private readonly RoundedRectangleRuntime _trackBorder;
-    private readonly RoundedRectangleRuntime _fill;
+    private readonly RectangleRuntime _track;
+    private readonly RectangleRuntime _trackBorder;
+    private readonly RectangleRuntime _fill;
     private readonly SliderThumbVisual _thumb;
 
     public SliderVisual(bool fullInstantiation = true, bool tryCreateFormsObject = true)
@@ -128,9 +128,9 @@ public class SliderVisual : BaseSliderVisual
         _fill.Width = (float)(pct * 100.0);
     }
 
-    private static RoundedRectangleRuntime CreateTrack()
+    private static RectangleRuntime CreateTrack()
     {
-        RoundedRectangleRuntime track = new RoundedRectangleRuntime();
+        RectangleRuntime track = new RectangleRuntime();
         track.Name = "DarkProSliderTrack";
         track.X = 0;
         track.Y = 0;
@@ -144,13 +144,14 @@ public class SliderVisual : BaseSliderVisual
         track.HeightUnits = DimensionUnitType.Absolute;
         track.CornerRadius = TrackCornerRadius;
         track.IsFilled = true;
-        track.Color = DarkProColors.Surface2;
+        track.FillColor = DarkProColors.Surface2;
+        track.StrokeWidth = 0;
         return track;
     }
 
-    private static RoundedRectangleRuntime CreateFill()
+    private static RectangleRuntime CreateFill()
     {
-        RoundedRectangleRuntime fill = new RoundedRectangleRuntime();
+        RectangleRuntime fill = new RectangleRuntime();
         fill.Name = "DarkProSliderFill";
         fill.X = 0;
         fill.Y = 0;
@@ -165,13 +166,14 @@ public class SliderVisual : BaseSliderVisual
         fill.HeightUnits = DimensionUnitType.Absolute;
         fill.CornerRadius = TrackCornerRadius;
         fill.IsFilled = true;
-        fill.Color = DarkProColors.Accent;
+        fill.FillColor = DarkProColors.Accent;
+        fill.StrokeWidth = 0;
         return fill;
     }
 
-    private static RoundedRectangleRuntime CreateTrackBorder()
+    private static RectangleRuntime CreateTrackBorder()
     {
-        RoundedRectangleRuntime border = new RoundedRectangleRuntime();
+        RectangleRuntime border = new RectangleRuntime();
         border.Name = "DarkProSliderTrackBorder";
         border.X = 0;
         border.Y = 0;
@@ -187,7 +189,7 @@ public class SliderVisual : BaseSliderVisual
         border.IsFilled = false;
         border.StrokeWidth = BorderThickness;
         border.StrokeWidthUnits = DimensionUnitType.Absolute;
-        border.Color = DarkProColors.Border;
+        border.StrokeColor = DarkProColors.Border;
         return border;
     }
 
@@ -208,8 +210,8 @@ public class SliderVisual : BaseSliderVisual
 
     private void ApplyTrack(Color trackFill, Color border, Color fillBar)
     {
-        _track.Color = trackFill;
-        _trackBorder.Color = border;
-        _fill.Color = fillBar;
+        _track.FillColor = trackFill;
+        _trackBorder.StrokeColor = border;
+        _fill.FillColor = fillBar;
     }
 }

--- a/Themes/Gum.Themes.DarkPro.MonoGame/SplitterVisual.cs
+++ b/Themes/Gum.Themes.DarkPro.MonoGame/SplitterVisual.cs
@@ -19,7 +19,7 @@ namespace Gum.Themes.DarkPro;
 /// </summary>
 public class SplitterVisual : BaseSplitterVisual
 {
-    private readonly ColoredRectangleRuntime _fill;
+    private readonly RectangleRuntime _fill;
 
     public SplitterVisual(bool fullInstantiation = true, bool tryCreateFormsObject = true)
         : base(fullInstantiation, tryCreateFormsObject)
@@ -30,9 +30,9 @@ public class SplitterVisual : BaseSplitterVisual
         AddChild(_fill);
     }
 
-    private static ColoredRectangleRuntime CreateFill()
+    private static RectangleRuntime CreateFill()
     {
-        ColoredRectangleRuntime fill = new ColoredRectangleRuntime();
+        RectangleRuntime fill = new RectangleRuntime();
         fill.Name = "DarkProSplitterFill";
         fill.X = 0;
         fill.Y = 0;
@@ -44,7 +44,9 @@ public class SplitterVisual : BaseSplitterVisual
         fill.Height = 0;
         fill.WidthUnits = DimensionUnitType.RelativeToParent;
         fill.HeightUnits = DimensionUnitType.RelativeToParent;
-        fill.Color = DarkProColors.Border;
+        fill.IsFilled = true;
+        fill.FillColor = DarkProColors.Border;
+        fill.StrokeWidth = 0;
         return fill;
     }
 }

--- a/Themes/Gum.Themes.DarkPro.MonoGame/ToggleButtonVisual.cs
+++ b/Themes/Gum.Themes.DarkPro.MonoGame/ToggleButtonVisual.cs
@@ -19,9 +19,9 @@ public class ToggleButtonVisual : BaseToggleButtonVisual
     private const float BorderThickness = 1f;
     private const float FocusRingInset = 1f;
 
-    private readonly RoundedRectangleRuntime _focusRing;
-    private readonly RoundedRectangleRuntime _fill;
-    private readonly RoundedRectangleRuntime _border;
+    private readonly RectangleRuntime _focusRing;
+    private readonly RectangleRuntime _fill;
+    private readonly RectangleRuntime _border;
 
     public ToggleButtonVisual(bool fullInstantiation = true, bool tryCreateFormsObject = true)
         : base(fullInstantiation, tryCreateFormsObject)
@@ -53,9 +53,9 @@ public class ToggleButtonVisual : BaseToggleButtonVisual
         WireStates();
     }
 
-    private static RoundedRectangleRuntime CreateFill()
+    private static RectangleRuntime CreateFill()
     {
-        RoundedRectangleRuntime fill = new RoundedRectangleRuntime();
+        RectangleRuntime fill = new RectangleRuntime();
         fill.Name = "DarkProToggleFill";
         fill.X = 0;
         fill.Y = 0;
@@ -69,13 +69,14 @@ public class ToggleButtonVisual : BaseToggleButtonVisual
         fill.HeightUnits = DimensionUnitType.RelativeToParent;
         fill.CornerRadius = CornerRadius;
         fill.IsFilled = true;
-        fill.Color = DarkProColors.Surface1;
+        fill.FillColor = DarkProColors.Surface1;
+        fill.StrokeWidth = 0;
         return fill;
     }
 
-    private static RoundedRectangleRuntime CreateBorder()
+    private static RectangleRuntime CreateBorder()
     {
-        RoundedRectangleRuntime border = new RoundedRectangleRuntime();
+        RectangleRuntime border = new RectangleRuntime();
         border.Name = "DarkProToggleBorder";
         border.X = 0;
         border.Y = 0;
@@ -91,13 +92,13 @@ public class ToggleButtonVisual : BaseToggleButtonVisual
         border.IsFilled = false;
         border.StrokeWidth = BorderThickness;
         border.StrokeWidthUnits = DimensionUnitType.Absolute;
-        border.Color = DarkProColors.Border;
+        border.StrokeColor = DarkProColors.Border;
         return border;
     }
 
-    private static RoundedRectangleRuntime CreateFocusRing()
+    private static RectangleRuntime CreateFocusRing()
     {
-        RoundedRectangleRuntime ring = new RoundedRectangleRuntime();
+        RectangleRuntime ring = new RectangleRuntime();
         ring.Name = "DarkProToggleFocusRing";
         ring.X = 0;
         ring.Y = 0;
@@ -113,7 +114,7 @@ public class ToggleButtonVisual : BaseToggleButtonVisual
         ring.IsFilled = false;
         ring.StrokeWidth = BorderThickness;
         ring.StrokeWidthUnits = DimensionUnitType.Absolute;
-        ring.Color = DarkProColors.Accent;
+        ring.StrokeColor = DarkProColors.Accent;
         ring.Visible = false;
         return ring;
     }
@@ -183,8 +184,8 @@ public class ToggleButtonVisual : BaseToggleButtonVisual
 
     private void ApplyPalette(Color fill, Color border, Color text, bool showFocusRing)
     {
-        _fill.Color = fill;
-        _border.Color = border;
+        _fill.FillColor = fill;
+        _border.StrokeColor = border;
         TextInstance.Color = text;
         _focusRing.Visible = showFocusRing;
     }

--- a/Themes/Gum.Themes.DarkPro.MonoGame/TooltipVisual.cs
+++ b/Themes/Gum.Themes.DarkPro.MonoGame/TooltipVisual.cs
@@ -17,8 +17,8 @@ public class TooltipVisual : BaseTooltipVisual
     private const float CornerRadius = 2f;
     private const float BorderThickness = 1f;
 
-    private readonly RoundedRectangleRuntime _fill;
-    private readonly RoundedRectangleRuntime _border;
+    private readonly RectangleRuntime _fill;
+    private readonly RectangleRuntime _border;
 
     public TooltipVisual(bool fullInstantiation = true, bool tryCreateFormsObject = true)
         : base(fullInstantiation, tryCreateFormsObject)
@@ -39,9 +39,9 @@ public class TooltipVisual : BaseTooltipVisual
         TextInstance.Color = DarkProColors.Text;
     }
 
-    private static RoundedRectangleRuntime CreateFill()
+    private static RectangleRuntime CreateFill()
     {
-        RoundedRectangleRuntime fill = new RoundedRectangleRuntime();
+        RectangleRuntime fill = new RectangleRuntime();
         fill.Name = "DarkProTooltipFill";
         fill.X = 0;
         fill.Y = 0;
@@ -55,13 +55,14 @@ public class TooltipVisual : BaseTooltipVisual
         fill.HeightUnits = DimensionUnitType.RelativeToParent;
         fill.CornerRadius = CornerRadius;
         fill.IsFilled = true;
-        fill.Color = DarkProColors.Surface1;
+        fill.FillColor = DarkProColors.Surface1;
+        fill.StrokeWidth = 0;
         return fill;
     }
 
-    private static RoundedRectangleRuntime CreateBorder()
+    private static RectangleRuntime CreateBorder()
     {
-        RoundedRectangleRuntime border = new RoundedRectangleRuntime();
+        RectangleRuntime border = new RectangleRuntime();
         border.Name = "DarkProTooltipBorder";
         border.X = 0;
         border.Y = 0;
@@ -77,7 +78,7 @@ public class TooltipVisual : BaseTooltipVisual
         border.IsFilled = false;
         border.StrokeWidth = BorderThickness;
         border.StrokeWidthUnits = DimensionUnitType.Absolute;
-        border.Color = DarkProColors.Border;
+        border.StrokeColor = DarkProColors.Border;
         return border;
     }
 }

--- a/Themes/Gum.Themes.DarkPro.MonoGame/WindowVisual.cs
+++ b/Themes/Gum.Themes.DarkPro.MonoGame/WindowVisual.cs
@@ -25,10 +25,10 @@ public class WindowVisual : BaseWindowVisual
     private const float BorderThickness = 1f;
     private const float TitleBarSeparatorHeight = 1f;
 
-    private readonly RoundedRectangleRuntime _fill;
-    private readonly RoundedRectangleRuntime _border;
-    private readonly ColoredRectangleRuntime _titleBarFill;
-    private readonly ColoredRectangleRuntime _titleBarSeparator;
+    private readonly RectangleRuntime _fill;
+    private readonly RectangleRuntime _border;
+    private readonly RectangleRuntime _titleBarFill;
+    private readonly RectangleRuntime _titleBarSeparator;
 
     public WindowVisual(bool fullInstantiation = true, bool tryCreateFormsObject = true)
         : base(fullInstantiation, tryCreateFormsObject)
@@ -74,9 +74,8 @@ public class WindowVisual : BaseWindowVisual
         AddChild(BorderRightInstance.Visual);
 
         // Surface2 fill child of the title bar so the drag area is visibly
-        // chrome. GraphicalUiElement subclasses (ColoredRectangleRuntime,
-        // RoundedRectangleRuntime) don't intercept events, so this won't
-        // block the title bar's drag handling.
+        // chrome. GraphicalUiElement subclasses (RectangleRuntime) don't
+        // intercept events, so this won't block the title bar's drag handling.
         _titleBarFill = CreateTitleBarFill();
         _titleBarFill.Parent = TitleBarInstance.Visual;
 
@@ -87,9 +86,9 @@ public class WindowVisual : BaseWindowVisual
         _titleBarSeparator.Parent = TitleBarInstance.Visual;
     }
 
-    private static RoundedRectangleRuntime CreateFill()
+    private static RectangleRuntime CreateFill()
     {
-        RoundedRectangleRuntime fill = new RoundedRectangleRuntime();
+        RectangleRuntime fill = new RectangleRuntime();
         fill.Name = "DarkProWindowFill";
         fill.X = 0;
         fill.Y = 0;
@@ -103,13 +102,14 @@ public class WindowVisual : BaseWindowVisual
         fill.HeightUnits = DimensionUnitType.RelativeToParent;
         fill.CornerRadius = CornerRadius;
         fill.IsFilled = true;
-        fill.Color = DarkProColors.Surface1;
+        fill.FillColor = DarkProColors.Surface1;
+        fill.StrokeWidth = 0;
         return fill;
     }
 
-    private static RoundedRectangleRuntime CreateBorder()
+    private static RectangleRuntime CreateBorder()
     {
-        RoundedRectangleRuntime border = new RoundedRectangleRuntime();
+        RectangleRuntime border = new RectangleRuntime();
         border.Name = "DarkProWindowBorder";
         border.X = 0;
         border.Y = 0;
@@ -125,13 +125,13 @@ public class WindowVisual : BaseWindowVisual
         border.IsFilled = false;
         border.StrokeWidth = BorderThickness;
         border.StrokeWidthUnits = DimensionUnitType.Absolute;
-        border.Color = DarkProColors.Border;
+        border.StrokeColor = DarkProColors.Border;
         return border;
     }
 
-    private static ColoredRectangleRuntime CreateTitleBarFill()
+    private static RectangleRuntime CreateTitleBarFill()
     {
-        ColoredRectangleRuntime fill = new ColoredRectangleRuntime();
+        RectangleRuntime fill = new RectangleRuntime();
         fill.Name = "DarkProWindowTitleBarFill";
         fill.X = 0;
         fill.Y = 0;
@@ -143,13 +143,15 @@ public class WindowVisual : BaseWindowVisual
         fill.Height = 0;
         fill.WidthUnits = DimensionUnitType.RelativeToParent;
         fill.HeightUnits = DimensionUnitType.RelativeToParent;
-        fill.Color = DarkProColors.Surface2;
+        fill.IsFilled = true;
+        fill.FillColor = DarkProColors.Surface2;
+        fill.StrokeWidth = 0;
         return fill;
     }
 
-    private static ColoredRectangleRuntime CreateTitleBarSeparator()
+    private static RectangleRuntime CreateTitleBarSeparator()
     {
-        ColoredRectangleRuntime separator = new ColoredRectangleRuntime();
+        RectangleRuntime separator = new RectangleRuntime();
         separator.Name = "DarkProWindowTitleBarSeparator";
         separator.X = 0;
         separator.Y = 0;
@@ -161,7 +163,9 @@ public class WindowVisual : BaseWindowVisual
         separator.Height = TitleBarSeparatorHeight;
         separator.WidthUnits = DimensionUnitType.RelativeToParent;
         separator.HeightUnits = DimensionUnitType.Absolute;
-        separator.Color = DarkProColors.Border;
+        separator.IsFilled = true;
+        separator.FillColor = DarkProColors.Border;
+        separator.StrokeWidth = 0;
         return separator;
     }
 }

--- a/Themes/Gum.Themes.Editor.MonoGame/EditorTheme.cs
+++ b/Themes/Gum.Themes.Editor.MonoGame/EditorTheme.cs
@@ -68,5 +68,24 @@ public static class EditorTheme
         TryAdd(typeof(ScrollBar), (_, c) => new ScrollBarVisual(tryCreateFormsObject: c));
         TryAdd(typeof(ScrollViewer), (_, c) => new ScrollViewerVisual(tryCreateFormsObject: c));
         TryAdd(typeof(Slider), (_, c) => new SliderVisual(tryCreateFormsObject: c));
+
+        // Controls Editor does not restyle are pinned to their stock V3 visuals so that
+        // EditorTheme.Apply fully specifies the template set. FrameworkElement.DefaultFormsTemplates
+        // is global static state; without re-registering these, re-applying a theme at runtime
+        // (the showcase's 1-6 swap, or a consumer switching skins) would leave a previously-applied
+        // theme's visual in place for these controls, because Editor never overwrites their entries.
+        // These are the same visuals a single-theme Editor run already falls back to, so this is a
+        // no-op for consumers who apply Editor once.
+        TryAdd(typeof(RadioButton), (_, c) => new Gum.Forms.DefaultVisuals.V3.RadioButtonVisual(tryCreateFormsObject: c));
+        TryAdd(typeof(ToggleButton), (_, c) => new Gum.Forms.DefaultVisuals.V3.ToggleButtonVisual(tryCreateFormsObject: c));
+        TryAdd(typeof(PasswordBox), (_, c) => new Gum.Forms.DefaultVisuals.V3.PasswordBoxVisual(tryCreateFormsObject: c));
+        TryAdd(typeof(Menu), (_, c) => new Gum.Forms.DefaultVisuals.V3.MenuVisual(tryCreateFormsObject: c));
+        TryAdd(typeof(MenuItem), (_, c) => new Gum.Forms.DefaultVisuals.V3.MenuItemVisual(tryCreateFormsObject: c));
+        TryAdd(typeof(Window), (_, c) => new Gum.Forms.DefaultVisuals.V3.WindowVisual(tryCreateFormsObject: c));
+        TryAdd(typeof(Splitter), (_, c) => new Gum.Forms.DefaultVisuals.V3.SplitterVisual(tryCreateFormsObject: c));
+        TryAdd(typeof(Label), (_, c) => new Gum.Forms.DefaultVisuals.V3.LabelVisual(tryCreateFormsObject: c));
+        TryAdd(typeof(ItemsControl), (_, c) => new Gum.Forms.DefaultVisuals.V3.ItemsControlVisual(tryCreateFormsObject: c));
+        TryAdd(typeof(Tooltip), (_, c) => new Gum.Forms.DefaultVisuals.V3.TooltipVisual(tryCreateFormsObject: c));
+        TryAdd(typeof(Gum.Forms.Controls.Games.DialogBox), (_, c) => new Gum.Forms.DefaultVisuals.V3.DialogBoxVisual(tryCreateFormsObject: c));
     }
 }

--- a/Themes/Gum.Themes.Editor.MonoGame/ExpanderVisual.cs
+++ b/Themes/Gum.Themes.Editor.MonoGame/ExpanderVisual.cs
@@ -34,9 +34,10 @@ public class ExpanderVisual : InteractiveGue
         headerContainer.HeightUnits = DimensionUnitType.Absolute;
         this.Children.Add(headerContainer);
 
-        var headerBackground = new ColoredRectangleRuntime();
+        var headerBackground = new RectangleRuntime();
         headerBackground.Dock(Gum.Wireframe.Dock.Fill);
-        headerBackground.Color = new Color(50, 50, 50);
+        headerBackground.FillColor = new Color(50, 50, 50);
+        headerBackground.StrokeWidth = 0;
         headerContainer.Children.Add(headerBackground);
 
         var headerContent = new ContainerRuntime();

--- a/Themes/Gum.Themes.Editor.MonoGame/PropertyGridVisual.cs
+++ b/Themes/Gum.Themes.Editor.MonoGame/PropertyGridVisual.cs
@@ -87,10 +87,10 @@ public class PropertyGridVisual : ContainerRuntime
                 continue;
             }
 
-            var background = child.Children[0] as ColoredRectangleRuntime;
+            var background = child.Children[0] as RectangleRuntime;
             if (background != null)
             {
-                background.Color = visibleIndex % 2 == 0 ? EvenRowColor : OddRowColor;
+                background.FillColor = visibleIndex % 2 == 0 ? EvenRowColor : OddRowColor;
             }
 
             visibleIndex++;
@@ -110,8 +110,9 @@ public class PropertyGridVisual : ContainerRuntime
 
         if (AlternatingRowColorsEnabled)
         {
-            var background = new ColoredRectangleRuntime();
+            var background = new RectangleRuntime();
             background.Dock(Gum.Wireframe.Dock.Fill);
+            background.StrokeWidth = 0;
             row.Children.Add(background);
         }
 

--- a/Themes/Gum.Themes.ForestGlade.MonoGame/CheckBoxVisual.cs
+++ b/Themes/Gum.Themes.ForestGlade.MonoGame/CheckBoxVisual.cs
@@ -25,11 +25,11 @@ public class CheckBoxVisual : BaseCheckBoxVisual
     private const float DashHeight = 2f;
     private const float GlyphContainerSize = 22f;
 
-    private readonly RoundedRectangleRuntime _focusRing;
-    private readonly RoundedRectangleRuntime _boxFill;
-    private readonly RoundedRectangleRuntime _boxBorder;
+    private readonly RectangleRuntime _focusRing;
+    private readonly RectangleRuntime _boxFill;
+    private readonly RectangleRuntime _boxBorder;
     private readonly TextRuntime _checkGlyph;
-    private readonly RoundedRectangleRuntime _dashIndicator;
+    private readonly RectangleRuntime _dashIndicator;
 
     public CheckBoxVisual(bool fullInstantiation = true, bool tryCreateFormsObject = true)
         : base(fullInstantiation, tryCreateFormsObject)
@@ -66,9 +66,9 @@ public class CheckBoxVisual : BaseCheckBoxVisual
         WireStates();
     }
 
-    private static RoundedRectangleRuntime CreateBoxFill()
+    private static RectangleRuntime CreateBoxFill()
     {
-        RoundedRectangleRuntime fill = new RoundedRectangleRuntime();
+        RectangleRuntime fill = new RectangleRuntime();
         fill.Name = "ForestGladeBoxFill";
         fill.X = 0;
         fill.Y = 0;
@@ -85,13 +85,14 @@ public class CheckBoxVisual : BaseCheckBoxVisual
         // CSS .fg-cbox uses a 160deg linear gradient from rgba(232,255,117,.06) to
         // rgba(0,0,0,.35) — translucent over the canopy bg. We approximate with
         // an opaque pre-blend toward dark (canopy-deep slightly darker).
-        fill.Color = new Color(3, 28, 32);
+        fill.FillColor = new Color(3, 28, 32);
+        fill.StrokeWidth = 0;
         return fill;
     }
 
-    private static RoundedRectangleRuntime CreateBoxBorder()
+    private static RectangleRuntime CreateBoxBorder()
     {
-        RoundedRectangleRuntime border = new RoundedRectangleRuntime();
+        RectangleRuntime border = new RectangleRuntime();
         border.Name = "ForestGladeBoxBorder";
         border.X = 0;
         border.Y = 0;
@@ -109,13 +110,13 @@ public class CheckBoxVisual : BaseCheckBoxVisual
         border.StrokeWidthUnits = DimensionUnitType.Absolute;
         // CSS .fg-cbox border: rgba(232,255,117,.30). Higher alpha than .Border so
         // the box is clearly outlined against the page background.
-        border.Color = new Color(232, 255, 117, 76);
+        border.StrokeColor = new Color(232, 255, 117, 76);
         return border;
     }
 
-    private static RoundedRectangleRuntime CreateFocusRing()
+    private static RectangleRuntime CreateFocusRing()
     {
-        RoundedRectangleRuntime ring = new RoundedRectangleRuntime();
+        RectangleRuntime ring = new RectangleRuntime();
         ring.Name = "ForestGladeBoxFocusRing";
         ring.X = -FocusRingInset;
         ring.Y = 0;
@@ -137,7 +138,7 @@ public class CheckBoxVisual : BaseCheckBoxVisual
         ring.IsFilled = false;
         ring.StrokeWidth = FocusRingThickness;
         ring.StrokeWidthUnits = DimensionUnitType.Absolute;
-        ring.Color = ForestGladeColors.AccentHalo;
+        ring.StrokeColor = ForestGladeColors.AccentHalo;
         ring.Visible = false;
         return ring;
     }
@@ -162,9 +163,9 @@ public class CheckBoxVisual : BaseCheckBoxVisual
         return glyph;
     }
 
-    private static RoundedRectangleRuntime CreateDashIndicator()
+    private static RectangleRuntime CreateDashIndicator()
     {
-        RoundedRectangleRuntime dash = new RoundedRectangleRuntime();
+        RectangleRuntime dash = new RectangleRuntime();
         dash.Name = "ForestGladeDashIndicator";
         dash.X = BoxSize / 2f;
         dash.Y = 0;
@@ -178,7 +179,8 @@ public class CheckBoxVisual : BaseCheckBoxVisual
         dash.HeightUnits = DimensionUnitType.Absolute;
         dash.CornerRadius = 1f;
         dash.IsFilled = true;
-        dash.Color = ForestGladeColors.SunPale;
+        dash.FillColor = ForestGladeColors.SunPale;
+        dash.StrokeWidth = 0;
         return dash;
     }
 
@@ -296,8 +298,8 @@ public class CheckBoxVisual : BaseCheckBoxVisual
     private void Apply(Color fill, Color border, Color text, GlyphKind glyph, bool ring,
         Color? glyphColor = null)
     {
-        _boxFill.Color = fill;
-        _boxBorder.Color = border;
+        _boxFill.FillColor = fill;
+        _boxBorder.StrokeColor = border;
         TextInstance.Color = text;
         _focusRing.Visible = ring;
         _checkGlyph.Visible = glyph == GlyphKind.Check;

--- a/Themes/Gum.Themes.ForestGlade.MonoGame/ComboBoxVisual.cs
+++ b/Themes/Gum.Themes.ForestGlade.MonoGame/ComboBoxVisual.cs
@@ -26,9 +26,9 @@ public class ComboBoxVisual : BaseComboBoxVisual
     private const float TextLeftPadding = 12f;
     private const float TextRightClearance = 4f;
 
-    private readonly RoundedRectangleRuntime _focusRing;
-    private readonly RoundedRectangleRuntime _fill;
-    private readonly RoundedRectangleRuntime _border;
+    private readonly RectangleRuntime _focusRing;
+    private readonly RectangleRuntime _fill;
+    private readonly RectangleRuntime _border;
     private readonly TextRuntime _dropdownGlyph;
 
     public ComboBoxVisual(bool fullInstantiation = true, bool tryCreateFormsObject = true)
@@ -60,9 +60,9 @@ public class ComboBoxVisual : BaseComboBoxVisual
         WireStates();
     }
 
-    private static RoundedRectangleRuntime CreateFill()
+    private static RectangleRuntime CreateFill()
     {
-        RoundedRectangleRuntime fill = new RoundedRectangleRuntime();
+        RectangleRuntime fill = new RectangleRuntime();
         fill.Name = "ForestGladeComboFill";
         fill.XUnits = GeneralUnitType.PixelsFromMiddle;
         fill.YUnits = GeneralUnitType.PixelsFromMiddle;
@@ -74,7 +74,8 @@ public class ComboBoxVisual : BaseComboBoxVisual
         fill.HeightUnits = DimensionUnitType.RelativeToParent;
         ForestGladeLeaf.ApplyMedium(fill);
         fill.IsFilled = true;
-        fill.Color = ForestGladePalette.InputFill;
+        fill.FillColor = ForestGladePalette.InputFill;
+        fill.StrokeWidth = 0;
         // Same vertical dark gradient as the TextBox decoration so the closed
         // ComboBox reads as a sibling input chrome.
         fill.UseGradient = true;
@@ -92,9 +93,9 @@ public class ComboBoxVisual : BaseComboBoxVisual
         return fill;
     }
 
-    private static RoundedRectangleRuntime CreateBorder()
+    private static RectangleRuntime CreateBorder()
     {
-        RoundedRectangleRuntime border = new RoundedRectangleRuntime();
+        RectangleRuntime border = new RectangleRuntime();
         border.Name = "ForestGladeComboBorder";
         border.XUnits = GeneralUnitType.PixelsFromMiddle;
         border.YUnits = GeneralUnitType.PixelsFromMiddle;
@@ -108,14 +109,14 @@ public class ComboBoxVisual : BaseComboBoxVisual
         border.IsFilled = false;
         border.StrokeWidth = BorderThickness;
         border.StrokeWidthUnits = DimensionUnitType.Absolute;
-        border.Color = new Color(232, 255, 117, 56);
+        border.StrokeColor = new Color(232, 255, 117, 56);
         return border;
     }
 
-    private static RoundedRectangleRuntime CreateFocusRing()
+    private static RectangleRuntime CreateFocusRing()
     {
         const float halo = FocusRingInset;
-        RoundedRectangleRuntime ring = new RoundedRectangleRuntime();
+        RectangleRuntime ring = new RectangleRuntime();
         ring.Name = "ForestGladeComboFocusRing";
         ring.XUnits = GeneralUnitType.PixelsFromMiddle;
         ring.YUnits = GeneralUnitType.PixelsFromMiddle;
@@ -133,7 +134,7 @@ public class ComboBoxVisual : BaseComboBoxVisual
         ring.IsFilled = false;
         ring.StrokeWidth = FocusRingThickness;
         ring.StrokeWidthUnits = DimensionUnitType.Absolute;
-        ring.Color = ForestGladeColors.AccentHalo;
+        ring.StrokeColor = ForestGladeColors.AccentHalo;
         ring.Visible = false;
         return ring;
     }
@@ -201,10 +202,10 @@ public class ComboBoxVisual : BaseComboBoxVisual
     private void Apply(Color border, Color text, Color glyph, bool ring, bool fillDisabled)
     {
         Color baseFill = fillDisabled ? ForestGladePalette.InputFillDisabled : ForestGladePalette.InputFill;
-        _fill.Color = baseFill;
+        _fill.FillColor = baseFill;
         _fill.Color1 = Darken(baseFill, 0.65f);
         _fill.Color2 = baseFill;
-        _border.Color = border;
+        _border.StrokeColor = border;
         TextInstance.Color = text;
         _dropdownGlyph.Color = glyph;
         _focusRing.Visible = ring;

--- a/Themes/Gum.Themes.ForestGlade.MonoGame/ForestGladeButtonChrome.cs
+++ b/Themes/Gum.Themes.ForestGlade.MonoGame/ForestGladeButtonChrome.cs
@@ -35,9 +35,9 @@ internal sealed class ForestGladeButtonChrome
     public const float HoverGlowBlur = 24f;
     public const float PushedGlowBlur = 0f;
 
-    public RoundedRectangleRuntime Fill { get; }
-    public RoundedRectangleRuntime Border { get; }
-    public RoundedRectangleRuntime FocusRing { get; }
+    public RectangleRuntime Fill { get; }
+    public RectangleRuntime Border { get; }
+    public RectangleRuntime FocusRing { get; }
     public TextRuntime TextShadow { get; }
 
     private readonly TextRuntime _textInstance;
@@ -70,9 +70,9 @@ internal sealed class ForestGladeButtonChrome
         host.AddChild(textInstance);
     }
 
-    private static RoundedRectangleRuntime CreateFill()
+    private static RectangleRuntime CreateFill()
     {
-        RoundedRectangleRuntime fill = new RoundedRectangleRuntime();
+        RectangleRuntime fill = new RectangleRuntime();
         fill.Name = "ForestGladeButtonFill";
         fill.XUnits = GeneralUnitType.PixelsFromMiddle;
         fill.YUnits = GeneralUnitType.PixelsFromMiddle;
@@ -84,6 +84,7 @@ internal sealed class ForestGladeButtonChrome
         fill.HeightUnits = DimensionUnitType.RelativeToParent;
         ForestGladeLeaf.ApplyLarge(fill);
         fill.IsFilled = true;
+        fill.StrokeWidth = 0;
 
         // Vertical 2-stop linear gradient. Endpoints use PixelsFromSmall /
         // PixelsFromLarge (with value 0) rather than Percentage because the
@@ -105,14 +106,13 @@ internal sealed class ForestGladeButtonChrome
         fill.DropshadowColor = ForestGladePalette.DarkShadow;
         fill.DropshadowOffsetX = 0f;
         fill.DropshadowOffsetY = RestShadowOffsetY;
-        fill.DropshadowBlurX = RestShadowBlur;
-        fill.DropshadowBlurY = RestShadowBlur;
+        fill.DropshadowBlur = RestShadowBlur;
         return fill;
     }
 
-    private static RoundedRectangleRuntime CreateBorder()
+    private static RectangleRuntime CreateBorder()
     {
-        RoundedRectangleRuntime border = new RoundedRectangleRuntime();
+        RectangleRuntime border = new RectangleRuntime();
         border.Name = "ForestGladeButtonBorder";
         border.XUnits = GeneralUnitType.PixelsFromMiddle;
         border.YUnits = GeneralUnitType.PixelsFromMiddle;
@@ -126,13 +126,13 @@ internal sealed class ForestGladeButtonChrome
         border.IsFilled = false;
         border.StrokeWidth = BorderThickness;
         border.StrokeWidthUnits = DimensionUnitType.Absolute;
-        border.Color = ForestGladeColors.Border;
+        border.StrokeColor = ForestGladeColors.Border;
         return border;
     }
 
-    private static RoundedRectangleRuntime CreateFocusRing()
+    private static RectangleRuntime CreateFocusRing()
     {
-        RoundedRectangleRuntime ring = new RoundedRectangleRuntime();
+        RectangleRuntime ring = new RectangleRuntime();
         ring.Name = "ForestGladeButtonFocusRing";
         ring.XUnits = GeneralUnitType.PixelsFromMiddle;
         ring.YUnits = GeneralUnitType.PixelsFromMiddle;
@@ -150,7 +150,7 @@ internal sealed class ForestGladeButtonChrome
         ring.IsFilled = false;
         ring.StrokeWidth = FocusRingThickness;
         ring.StrokeWidthUnits = DimensionUnitType.Absolute;
-        ring.Color = ForestGladeColors.SunPale * 0.45f;
+        ring.StrokeColor = ForestGladeColors.SunPale * 0.45f;
         ring.Visible = false;
         return ring;
     }
@@ -242,11 +242,10 @@ internal sealed class ForestGladeButtonChrome
     {
         Fill.Color1 = fillTop;
         Fill.Color2 = fillBottom;
-        Border.Color = border;
+        Border.StrokeColor = border;
         Fill.DropshadowColor = shadow;
         Fill.DropshadowOffsetY = shadowOffsetY;
-        Fill.DropshadowBlurX = shadowBlur;
-        Fill.DropshadowBlurY = shadowBlur;
+        Fill.DropshadowBlur = shadowBlur;
         Fill.HasDropshadow = shadowBlur > 0f;
         _textInstance.Color = text;
         TextShadow.Color = textShadow;

--- a/Themes/Gum.Themes.ForestGlade.MonoGame/ForestGladeLeaf.cs
+++ b/Themes/Gum.Themes.ForestGlade.MonoGame/ForestGladeLeaf.cs
@@ -5,25 +5,25 @@ namespace Gum.Themes.ForestGlade;
 /// <summary>
 /// Forest Glade's signature corner silhouette — sharp top-left and
 /// bottom-right, rounded top-right and bottom-left. Applied uniformly to
-/// every <see cref="RoundedRectangleRuntime"/> across the theme so each
+/// every <see cref="RectangleRuntime"/> across the theme so each
 /// control reads as the same leaf shape. Sizes match the CSS
 /// <c>--leaf-sm/md/lg/xl</c> tokens.
 /// </summary>
 internal static class ForestGladeLeaf
 {
     /// <summary>CSS <c>--leaf-sm: 2px 8px 2px 8px</c> — checkboxes and small surfaces.</summary>
-    public static void ApplySmall(RoundedRectangleRuntime r) => Apply(r, 2f, 8f);
+    public static void ApplySmall(RectangleRuntime r) => Apply(r, 2f, 8f);
 
     /// <summary>CSS <c>--leaf-md: 2px 12px 2px 12px</c> — inputs, combo boxes.</summary>
-    public static void ApplyMedium(RoundedRectangleRuntime r) => Apply(r, 2f, 12f);
+    public static void ApplyMedium(RectangleRuntime r) => Apply(r, 2f, 12f);
 
     /// <summary>CSS <c>--leaf-lg: 4px 18px 4px 18px</c> — buttons, list panels.</summary>
-    public static void ApplyLarge(RoundedRectangleRuntime r) => Apply(r, 4f, 18f);
+    public static void ApplyLarge(RectangleRuntime r) => Apply(r, 4f, 18f);
 
     /// <summary>CSS <c>--leaf-xl: 6px 24px 6px 24px</c> — Window chrome.</summary>
-    public static void ApplyExtraLarge(RoundedRectangleRuntime r) => Apply(r, 6f, 24f);
+    public static void ApplyExtraLarge(RectangleRuntime r) => Apply(r, 6f, 24f);
 
-    private static void Apply(RoundedRectangleRuntime r, float sharp, float rounded)
+    private static void Apply(RectangleRuntime r, float sharp, float rounded)
     {
         // Per-corner pattern: TL & BR stay sharp (the "stem ends" of the
         // leaf), TR & BL bulge out. CornerRadius is the fallback for any

--- a/Themes/Gum.Themes.ForestGlade.MonoGame/ForestGladePalette.cs
+++ b/Themes/Gum.Themes.ForestGlade.MonoGame/ForestGladePalette.cs
@@ -11,7 +11,7 @@ namespace Gum.Themes.ForestGlade;
 internal static class ForestGladePalette
 {
     // ---- Button gradient stops (CSS .fg-btn uses three-stop linear gradients) ----
-    // Apos.Shapes supports 2-stop linear gradients on RoundedRectangleRuntime;
+    // Apos.Shapes supports 2-stop linear gradients on RectangleRuntime;
     // we use the first and last CSS stops, dropping the middle. The middle
     // tones (kept here as the legacy ButtonRestFill/etc. for any consumer
     // that referenced them) are the median of the gradient and read fine as

--- a/Themes/Gum.Themes.ForestGlade.MonoGame/ForestGladeTextInputDecoration.cs
+++ b/Themes/Gum.Themes.ForestGlade.MonoGame/ForestGladeTextInputDecoration.cs
@@ -21,9 +21,9 @@ internal sealed class ForestGladeTextInputDecoration
     private const float FocusHaloThickness = 3f;
     private const float FocusGlowBlur = 14f;
 
-    private readonly RoundedRectangleRuntime _focusHalo;
-    private readonly RoundedRectangleRuntime _fill;
-    private readonly RoundedRectangleRuntime _border;
+    private readonly RectangleRuntime _focusHalo;
+    private readonly RectangleRuntime _fill;
+    private readonly RectangleRuntime _border;
 
     public ForestGladeTextInputDecoration(TextBoxBaseVisual host)
     {
@@ -51,9 +51,9 @@ internal sealed class ForestGladeTextInputDecoration
         WireStates(host);
     }
 
-    private static RoundedRectangleRuntime CreateFill()
+    private static RectangleRuntime CreateFill()
     {
-        RoundedRectangleRuntime fill = new RoundedRectangleRuntime();
+        RectangleRuntime fill = new RectangleRuntime();
         fill.Name = "ForestGladeInputFill";
         fill.XUnits = GeneralUnitType.PixelsFromMiddle;
         fill.YUnits = GeneralUnitType.PixelsFromMiddle;
@@ -65,7 +65,8 @@ internal sealed class ForestGladeTextInputDecoration
         fill.HeightUnits = DimensionUnitType.RelativeToParent;
         ForestGladeLeaf.ApplyMedium(fill);
         fill.IsFilled = true;
-        fill.Color = ForestGladePalette.InputFill;
+        fill.FillColor = ForestGladePalette.InputFill;
+        fill.StrokeWidth = 0;
         // CSS .fg-input: linear-gradient(180deg, rgba(0,0,0,.30), rgba(0,0,0,.18))
         // over the canopy background — translates to a vertical gradient on
         // the fill with a slightly darker top blending into a lighter base.
@@ -84,9 +85,9 @@ internal sealed class ForestGladeTextInputDecoration
         return fill;
     }
 
-    private static RoundedRectangleRuntime CreateBorder()
+    private static RectangleRuntime CreateBorder()
     {
-        RoundedRectangleRuntime border = new RoundedRectangleRuntime();
+        RectangleRuntime border = new RectangleRuntime();
         border.Name = "ForestGladeInputBorder";
         border.XUnits = GeneralUnitType.PixelsFromMiddle;
         border.YUnits = GeneralUnitType.PixelsFromMiddle;
@@ -100,16 +101,16 @@ internal sealed class ForestGladeTextInputDecoration
         border.IsFilled = false;
         border.StrokeWidth = BorderThickness;
         border.StrokeWidthUnits = DimensionUnitType.Absolute;
-        border.Color = new Color(232, 255, 117, 56); // CSS .22 alpha
+        border.StrokeColor = new Color(232, 255, 117, 56); // CSS .22 alpha
         return border;
     }
 
-    private static RoundedRectangleRuntime CreateFocusHalo()
+    private static RectangleRuntime CreateFocusHalo()
     {
         // Leaf-medium with corners bumped by FocusHaloThickness so the halo
         // sits ~3 px outside the body's outer edge on every side.
         const float halo = FocusHaloThickness;
-        RoundedRectangleRuntime ring = new RoundedRectangleRuntime();
+        RectangleRuntime ring = new RectangleRuntime();
         ring.Name = "ForestGladeInputFocusHalo";
         ring.XUnits = GeneralUnitType.PixelsFromMiddle;
         ring.YUnits = GeneralUnitType.PixelsFromMiddle;
@@ -127,7 +128,7 @@ internal sealed class ForestGladeTextInputDecoration
         ring.IsFilled = false;
         ring.StrokeWidth = FocusHaloThickness;
         ring.StrokeWidthUnits = DimensionUnitType.Absolute;
-        ring.Color = ForestGladeColors.AccentHalo;
+        ring.StrokeColor = ForestGladeColors.AccentHalo;
         ring.Visible = false;
         return ring;
     }
@@ -167,7 +168,7 @@ internal sealed class ForestGladeTextInputDecoration
     private void Apply(TextBoxBaseVisual host, Color fill, Color border, Color text,
         Color placeholder, Color caret, Color selection, bool haloVisible, bool glow)
     {
-        _fill.Color = fill;
+        _fill.FillColor = fill;
         // Recompute the vertical gradient stops from the state's base fill so
         // each state stays subtly darker at the top than the bottom.
         _fill.Color1 = Darken(fill, 0.65f);
@@ -178,10 +179,9 @@ internal sealed class ForestGladeTextInputDecoration
             _fill.DropshadowColor = ForestGladePalette.GlowMedium;
             _fill.DropshadowOffsetX = 0f;
             _fill.DropshadowOffsetY = 0f;
-            _fill.DropshadowBlurX = FocusGlowBlur;
-            _fill.DropshadowBlurY = FocusGlowBlur;
+            _fill.DropshadowBlur = FocusGlowBlur;
         }
-        _border.Color = border;
+        _border.StrokeColor = border;
         host.TextInstance.Color = text;
         host.PlaceholderTextInstance.Color = placeholder;
         host.CaretInstance.Color = caret;

--- a/Themes/Gum.Themes.ForestGlade.MonoGame/ForestGladeTheme.cs
+++ b/Themes/Gum.Themes.ForestGlade.MonoGame/ForestGladeTheme.cs
@@ -78,7 +78,7 @@ public static class ForestGladeTheme
         BmfcSave.AddCharacters("✓✕▼▴▲◀▶✿•");
 
         // Forest Glade's visuals build their bodies out of Apos.Shapes-
-        // backed RoundedRectangleRuntime instances, which require
+        // backed RectangleRuntime / CircleRuntime instances, which require
         // ShapeRenderer to be initialized. Guard in case the host app
         // already initialized it.
         if (!ShapeRenderer.Self.IsInitialized)
@@ -229,5 +229,15 @@ public static class ForestGladeTheme
         FrameworkElement.DefaultFormsTemplates[typeof(Label)] =
             new VisualTemplate((_, c) => new Gum.Forms.DefaultVisuals.V3.LabelVisual(tryCreateFormsObject: c));
 
+        // Controls Forest Glade does not restyle are pinned to their stock V3 visuals so
+        // ForestGladeTheme.Apply fully specifies the template set. FrameworkElement.DefaultFormsTemplates
+        // is global static state; without re-registering these, re-applying a theme at runtime
+        // (theme switching) would leave a previously-applied theme's visual in place for these
+        // controls. These match what a single-theme Forest Glade run already falls back to.
+        FrameworkElement.DefaultFormsTemplates[typeof(ItemsControl)] =
+            new VisualTemplate((_, c) => new Gum.Forms.DefaultVisuals.V3.ItemsControlVisual(tryCreateFormsObject: c));
+
+        FrameworkElement.DefaultFormsTemplates[typeof(Gum.Forms.Controls.Games.DialogBox)] =
+            new VisualTemplate((_, c) => new Gum.Forms.DefaultVisuals.V3.DialogBoxVisual(tryCreateFormsObject: c));
     }
 }

--- a/Themes/Gum.Themes.ForestGlade.MonoGame/ListBoxItemVisual.cs
+++ b/Themes/Gum.Themes.ForestGlade.MonoGame/ListBoxItemVisual.cs
@@ -19,8 +19,8 @@ public class ListBoxItemVisual : BaseListBoxItemVisual
 {
     private const float SelectionStripeWidth = 3f;
 
-    private readonly RoundedRectangleRuntime _fill;
-    private readonly RoundedRectangleRuntime _selectionStripe;
+    private readonly RectangleRuntime _fill;
+    private readonly RectangleRuntime _selectionStripe;
 
     public ListBoxItemVisual(bool fullInstantiation = true, bool tryCreateFormsObject = true)
         : base(fullInstantiation, tryCreateFormsObject)
@@ -44,9 +44,9 @@ public class ListBoxItemVisual : BaseListBoxItemVisual
         WireStates();
     }
 
-    private static RoundedRectangleRuntime CreateFill()
+    private static RectangleRuntime CreateFill()
     {
-        RoundedRectangleRuntime fill = new RoundedRectangleRuntime();
+        RectangleRuntime fill = new RectangleRuntime();
         fill.Name = "ForestGladeListItemFill";
         fill.XUnits = GeneralUnitType.PixelsFromMiddle;
         fill.YUnits = GeneralUnitType.PixelsFromMiddle;
@@ -58,7 +58,8 @@ public class ListBoxItemVisual : BaseListBoxItemVisual
         fill.HeightUnits = DimensionUnitType.RelativeToParent;
         fill.CornerRadius = 0f;
         fill.IsFilled = true;
-        fill.Color = Color.Transparent;
+        fill.FillColor = Color.Transparent;
+        fill.StrokeWidth = 0;
         // Selected row CSS: linear-gradient(90deg, rgba(71,246,65,.22), rgba(71,246,65,.05))
         // — leaf-bright fading from left to right. Gradient is enabled here
         // and the stops are toggled per state by WireStates (transparent stops
@@ -76,9 +77,9 @@ public class ListBoxItemVisual : BaseListBoxItemVisual
         return fill;
     }
 
-    private static RoundedRectangleRuntime CreateSelectionStripe()
+    private static RectangleRuntime CreateSelectionStripe()
     {
-        RoundedRectangleRuntime stripe = new RoundedRectangleRuntime();
+        RectangleRuntime stripe = new RectangleRuntime();
         stripe.Name = "ForestGladeListItemStripe";
         stripe.X = 0f;
         stripe.XUnits = GeneralUnitType.PixelsFromSmall;
@@ -91,7 +92,8 @@ public class ListBoxItemVisual : BaseListBoxItemVisual
         stripe.HeightUnits = DimensionUnitType.RelativeToParent;
         stripe.CornerRadius = 0f;
         stripe.IsFilled = true;
-        stripe.Color = ForestGladePalette.SelectionStripe;
+        stripe.FillColor = ForestGladePalette.SelectionStripe;
+        stripe.StrokeWidth = 0;
         stripe.Visible = false;
         return stripe;
     }

--- a/Themes/Gum.Themes.ForestGlade.MonoGame/ListBoxVisual.cs
+++ b/Themes/Gum.Themes.ForestGlade.MonoGame/ListBoxVisual.cs
@@ -31,7 +31,7 @@ public class ListBoxVisual : BaseListBoxVisual
     private static readonly Color HoverBorder = new Color(232, 255, 117, 240);
     private static readonly Color DisabledBorderColor = new Color(232, 255, 117, 50);
 
-    private static void ApplyLeafShape(RoundedRectangleRuntime r)
+    private static void ApplyLeafShape(RectangleRuntime r)
     {
         r.CornerRadius = SharpRadius;
         r.CustomRadiusTopLeft = SharpRadius;
@@ -40,9 +40,9 @@ public class ListBoxVisual : BaseListBoxVisual
         r.CustomRadiusBottomLeft = RoundedRadius;
     }
 
-    private readonly RoundedRectangleRuntime _focusRing;
-    private readonly RoundedRectangleRuntime _fill;
-    private readonly RoundedRectangleRuntime _border;
+    private readonly RectangleRuntime _focusRing;
+    private readonly RectangleRuntime _fill;
+    private readonly RectangleRuntime _border;
 
     public ListBoxVisual(bool fullInstantiation = true, bool tryCreateFormsObject = true)
         : base(fullInstantiation, tryCreateFormsObject)
@@ -83,9 +83,9 @@ public class ListBoxVisual : BaseListBoxVisual
         WireStates();
     }
 
-    private static RoundedRectangleRuntime CreateFill()
+    private static RectangleRuntime CreateFill()
     {
-        RoundedRectangleRuntime fill = new RoundedRectangleRuntime();
+        RectangleRuntime fill = new RectangleRuntime();
         fill.Name = "ForestGladeListBoxFill";
         fill.XUnits = GeneralUnitType.PixelsFromMiddle;
         fill.YUnits = GeneralUnitType.PixelsFromMiddle;
@@ -97,13 +97,14 @@ public class ListBoxVisual : BaseListBoxVisual
         fill.HeightUnits = DimensionUnitType.RelativeToParent;
         ApplyLeafShape(fill);
         fill.IsFilled = true;
-        fill.Color = ForestGladePalette.InputFill;
+        fill.FillColor = ForestGladePalette.InputFill;
+        fill.StrokeWidth = 0;
         return fill;
     }
 
-    private static RoundedRectangleRuntime CreateBorder()
+    private static RectangleRuntime CreateBorder()
     {
-        RoundedRectangleRuntime border = new RoundedRectangleRuntime();
+        RectangleRuntime border = new RectangleRuntime();
         border.Name = "ForestGladeListBoxBorder";
         border.XUnits = GeneralUnitType.PixelsFromMiddle;
         border.YUnits = GeneralUnitType.PixelsFromMiddle;
@@ -117,14 +118,14 @@ public class ListBoxVisual : BaseListBoxVisual
         border.IsFilled = false;
         border.StrokeWidth = BorderThickness;
         border.StrokeWidthUnits = DimensionUnitType.Absolute;
-        border.Color = RestBorder;
+        border.StrokeColor = RestBorder;
         return border;
     }
 
-    private static RoundedRectangleRuntime CreateFocusRing()
+    private static RectangleRuntime CreateFocusRing()
     {
         const float halo = FocusRingInset;
-        RoundedRectangleRuntime ring = new RoundedRectangleRuntime();
+        RectangleRuntime ring = new RectangleRuntime();
         ring.Name = "ForestGladeListBoxFocusRing";
         ring.XUnits = GeneralUnitType.PixelsFromMiddle;
         ring.YUnits = GeneralUnitType.PixelsFromMiddle;
@@ -142,7 +143,7 @@ public class ListBoxVisual : BaseListBoxVisual
         ring.IsFilled = false;
         ring.StrokeWidth = FocusRingThickness;
         ring.StrokeWidthUnits = DimensionUnitType.Absolute;
-        ring.Color = ForestGladeColors.AccentHalo;
+        ring.StrokeColor = ForestGladeColors.AccentHalo;
         ring.Visible = false;
         return ring;
     }
@@ -162,8 +163,8 @@ public class ListBoxVisual : BaseListBoxVisual
 
     private void ApplyPalette(Color border, bool showFocusRing, bool fillDisabled = false)
     {
-        _fill.Color = fillDisabled ? ForestGladePalette.InputFillDisabled : ForestGladePalette.InputFill;
-        _border.Color = border;
+        _fill.FillColor = fillDisabled ? ForestGladePalette.InputFillDisabled : ForestGladePalette.InputFill;
+        _border.StrokeColor = border;
         _focusRing.Visible = showFocusRing;
     }
 }

--- a/Themes/Gum.Themes.ForestGlade.MonoGame/MenuItemVisual.cs
+++ b/Themes/Gum.Themes.ForestGlade.MonoGame/MenuItemVisual.cs
@@ -20,7 +20,7 @@ public class MenuItemVisual : BaseMenuItemVisual
     private const float HorizontalPadding = 12f;
     private const float VerticalPadding = 6f;
 
-    private readonly ColoredRectangleRuntime _fill;
+    private readonly RectangleRuntime _fill;
 
     public MenuItemVisual(bool fullInstantiation = true, bool tryCreateFormsObject = true)
         : base(fullInstantiation, tryCreateFormsObject: false)
@@ -92,14 +92,14 @@ public class MenuItemVisual : BaseMenuItemVisual
 
     private void ApplyPalette(Color fill, Color text)
     {
-        _fill.Color = fill;
+        _fill.FillColor = fill;
         TextInstance.Color = text;
         SubmenuIndicatorInstance.Color = text;
     }
 
-    private static ColoredRectangleRuntime CreateFill()
+    private static RectangleRuntime CreateFill()
     {
-        ColoredRectangleRuntime fill = new ColoredRectangleRuntime();
+        RectangleRuntime fill = new RectangleRuntime();
         fill.Name = "ForestGladeMenuItemFill";
         fill.XUnits = GeneralUnitType.PixelsFromMiddle;
         fill.YUnits = GeneralUnitType.PixelsFromMiddle;
@@ -109,7 +109,9 @@ public class MenuItemVisual : BaseMenuItemVisual
         fill.Height = 0;
         fill.WidthUnits = DimensionUnitType.RelativeToParent;
         fill.HeightUnits = DimensionUnitType.RelativeToParent;
-        fill.Color = Color.Transparent;
+        fill.IsFilled = true;
+        fill.FillColor = Color.Transparent;
+        fill.StrokeWidth = 0;
         return fill;
     }
 }

--- a/Themes/Gum.Themes.ForestGlade.MonoGame/MenuVisual.cs
+++ b/Themes/Gum.Themes.ForestGlade.MonoGame/MenuVisual.cs
@@ -17,8 +17,8 @@ public class MenuVisual : BaseMenuVisual
 {
     private const float SeparatorHeight = 1f;
 
-    private readonly ColoredRectangleRuntime _fill;
-    private readonly ColoredRectangleRuntime _bottomSeparator;
+    private readonly RectangleRuntime _fill;
+    private readonly RectangleRuntime _bottomSeparator;
 
     public MenuVisual(bool fullInstantiation = true, bool tryCreateFormsObject = true)
         : base(fullInstantiation, tryCreateFormsObject)
@@ -35,9 +35,9 @@ public class MenuVisual : BaseMenuVisual
         AddChild(InnerPanelInstance);
     }
 
-    private static ColoredRectangleRuntime CreateFill()
+    private static RectangleRuntime CreateFill()
     {
-        ColoredRectangleRuntime fill = new ColoredRectangleRuntime();
+        RectangleRuntime fill = new RectangleRuntime();
         fill.Name = "ForestGladeMenuFill";
         fill.XUnits = GeneralUnitType.PixelsFromMiddle;
         fill.YUnits = GeneralUnitType.PixelsFromMiddle;
@@ -47,13 +47,15 @@ public class MenuVisual : BaseMenuVisual
         fill.Height = 0;
         fill.WidthUnits = DimensionUnitType.RelativeToParent;
         fill.HeightUnits = DimensionUnitType.RelativeToParent;
-        fill.Color = ForestGladeColors.CanopyDeep;
+        fill.IsFilled = true;
+        fill.FillColor = ForestGladeColors.CanopyDeep;
+        fill.StrokeWidth = 0;
         return fill;
     }
 
-    private static ColoredRectangleRuntime CreateBottomSeparator()
+    private static RectangleRuntime CreateBottomSeparator()
     {
-        ColoredRectangleRuntime separator = new ColoredRectangleRuntime();
+        RectangleRuntime separator = new RectangleRuntime();
         separator.Name = "ForestGladeMenuBottomSeparator";
         separator.XUnits = GeneralUnitType.PixelsFromMiddle;
         separator.YUnits = GeneralUnitType.PixelsFromLarge;
@@ -63,7 +65,9 @@ public class MenuVisual : BaseMenuVisual
         separator.Height = SeparatorHeight;
         separator.WidthUnits = DimensionUnitType.RelativeToParent;
         separator.HeightUnits = DimensionUnitType.Absolute;
-        separator.Color = new Color(232, 255, 117, 51); // CSS .fg-hdr border .20
+        separator.IsFilled = true;
+        separator.FillColor = new Color(232, 255, 117, 51); // CSS .fg-hdr border .20
+        separator.StrokeWidth = 0;
         return separator;
     }
 }

--- a/Themes/Gum.Themes.ForestGlade.MonoGame/README.md
+++ b/Themes/Gum.Themes.ForestGlade.MonoGame/README.md
@@ -2,7 +2,7 @@
 
 A lush canopy / forest theme for Gum UI Forms controls. Deep teal-green canopy backdrop, saturated leaf-green fills, sunlit yellow border tints, and a signature leaf-shaped corner silhouette (sharp top-left / bottom-right, rounded top-right / bottom-left). Body text uses Nunito; the Window title bar uses Fraunces italic.
 
-The leaf silhouette uses the per-corner radii API added to Gum's `RoundedRectangleRuntime` in #2721 (requires Apos.Shapes 0.6.9 or later).
+The leaf silhouette uses the per-corner radii API on Gum's `RectangleRuntime` (requires Apos.Shapes 0.6.9 or later for the rounded-corner rendering).
 
 ## Install
 

--- a/Themes/Gum.Themes.ForestGlade.MonoGame/RadioButtonVisual.cs
+++ b/Themes/Gum.Themes.ForestGlade.MonoGame/RadioButtonVisual.cs
@@ -23,10 +23,10 @@ public class RadioButtonVisual : BaseRadioButtonVisual
     private const float FocusRingThickness = 3f;
     private const float BoxToLabelGap = 8f;
 
-    private readonly ColoredCircleRuntime _focusRing;
-    private readonly ColoredCircleRuntime _outerFill;
-    private readonly ColoredCircleRuntime _outerBorder;
-    private readonly ColoredCircleRuntime _innerDot;
+    private readonly CircleRuntime _focusRing;
+    private readonly CircleRuntime _outerFill;
+    private readonly CircleRuntime _outerBorder;
+    private readonly CircleRuntime _innerDot;
 
     public RadioButtonVisual(bool fullInstantiation = true, bool tryCreateFormsObject = true)
         : base(fullInstantiation, tryCreateFormsObject)
@@ -52,9 +52,9 @@ public class RadioButtonVisual : BaseRadioButtonVisual
         WireStates();
     }
 
-    private static ColoredCircleRuntime CreateOuterFill()
+    private static CircleRuntime CreateOuterFill()
     {
-        ColoredCircleRuntime c = new ColoredCircleRuntime();
+        CircleRuntime c = new CircleRuntime();
         c.Name = "ForestGladeRadioOuterFill";
         c.X = 0;
         c.Y = 0;
@@ -67,13 +67,14 @@ public class RadioButtonVisual : BaseRadioButtonVisual
         c.WidthUnits = DimensionUnitType.Absolute;
         c.HeightUnits = DimensionUnitType.Absolute;
         c.IsFilled = true;
-        c.Color = new Color(3, 28, 32);
+        c.FillColor = new Color(3, 28, 32);
+        c.StrokeWidth = 0;
         return c;
     }
 
-    private static ColoredCircleRuntime CreateOuterBorder()
+    private static CircleRuntime CreateOuterBorder()
     {
-        ColoredCircleRuntime c = new ColoredCircleRuntime();
+        CircleRuntime c = new CircleRuntime();
         c.Name = "ForestGladeRadioOuterBorder";
         c.X = 0;
         c.Y = 0;
@@ -88,13 +89,13 @@ public class RadioButtonVisual : BaseRadioButtonVisual
         c.IsFilled = false;
         c.StrokeWidth = BorderThickness;
         c.StrokeWidthUnits = DimensionUnitType.Absolute;
-        c.Color = new Color(232, 255, 117, 76);
+        c.StrokeColor = new Color(232, 255, 117, 76);
         return c;
     }
 
-    private static ColoredCircleRuntime CreateFocusRing()
+    private static CircleRuntime CreateFocusRing()
     {
-        ColoredCircleRuntime c = new ColoredCircleRuntime();
+        CircleRuntime c = new CircleRuntime();
         c.Name = "ForestGladeRadioFocusRing";
         c.X = -FocusRingInset;
         c.Y = 0;
@@ -109,15 +110,15 @@ public class RadioButtonVisual : BaseRadioButtonVisual
         c.IsFilled = false;
         c.StrokeWidth = FocusRingThickness;
         c.StrokeWidthUnits = DimensionUnitType.Absolute;
-        c.Color = ForestGladeColors.AccentHalo;
+        c.StrokeColor = ForestGladeColors.AccentHalo;
         c.Visible = false;
         return c;
     }
 
-    private static ColoredCircleRuntime CreateInnerDot()
+    private static CircleRuntime CreateInnerDot()
     {
         const float inset = (OuterSize - InnerSize) / 2f;
-        ColoredCircleRuntime dot = new ColoredCircleRuntime();
+        CircleRuntime dot = new CircleRuntime();
         dot.Name = "ForestGladeRadioInnerDot";
         dot.X = inset;
         dot.Y = 0;
@@ -130,7 +131,8 @@ public class RadioButtonVisual : BaseRadioButtonVisual
         dot.WidthUnits = DimensionUnitType.Absolute;
         dot.HeightUnits = DimensionUnitType.Absolute;
         dot.IsFilled = true;
-        dot.Color = ForestGladeColors.SunPale;
+        dot.FillColor = ForestGladeColors.SunPale;
+        dot.StrokeWidth = 0;
         dot.Visible = false;
         return dot;
     }
@@ -213,13 +215,13 @@ public class RadioButtonVisual : BaseRadioButtonVisual
     private void Apply(Color fill, Color border, Color text, bool innerVisible, bool ring,
         Color? innerColor = null)
     {
-        _outerFill.Color = fill;
-        _outerBorder.Color = border;
+        _outerFill.FillColor = fill;
+        _outerBorder.StrokeColor = border;
         TextInstance.Color = text;
         _innerDot.Visible = innerVisible;
         if (innerColor.HasValue)
         {
-            _innerDot.Color = innerColor.Value;
+            _innerDot.FillColor = innerColor.Value;
         }
         _focusRing.Visible = ring;
     }

--- a/Themes/Gum.Themes.ForestGlade.MonoGame/ScrollBarThumbVisual.cs
+++ b/Themes/Gum.Themes.ForestGlade.MonoGame/ScrollBarThumbVisual.cs
@@ -17,7 +17,7 @@ namespace Gum.Themes.ForestGlade;
 /// </summary>
 public class ScrollBarThumbVisual : InteractiveGue
 {
-    private readonly RoundedRectangleRuntime _body;
+    private readonly RectangleRuntime _body;
 
     private StateSaveCategory _buttonCategory = null!;
 
@@ -35,9 +35,9 @@ public class ScrollBarThumbVisual : InteractiveGue
         WireStates();
     }
 
-    private static RoundedRectangleRuntime CreateBody()
+    private static RectangleRuntime CreateBody()
     {
-        RoundedRectangleRuntime body = new RoundedRectangleRuntime();
+        RectangleRuntime body = new RectangleRuntime();
         body.Name = "ForestGladeScrollThumbBody";
         body.XUnits = GeneralUnitType.PixelsFromMiddle;
         body.YUnits = GeneralUnitType.PixelsFromMiddle;
@@ -49,7 +49,8 @@ public class ScrollBarThumbVisual : InteractiveGue
         body.HeightUnits = DimensionUnitType.RelativeToParent;
         ForestGladeLeaf.ApplySmall(body);
         body.IsFilled = true;
-        body.Color = ForestGladePalette.ScrollThumb;
+        body.FillColor = ForestGladePalette.ScrollThumb;
+        body.StrokeWidth = 0;
         // CSS .fg-sb-thm linear-gradient(180deg, rgba(71,246,65,.55), rgba(0,140,46,.55))
         // — vertical, leaf-bright at top fading to canopy-lit at the bottom.
         body.UseGradient = true;
@@ -105,7 +106,7 @@ public class ScrollBarThumbVisual : InteractiveGue
         _body.UseGradient = gradient;
         _body.Color1 = top;
         _body.Color2 = bottom;
-        _body.Color = top;
+        _body.FillColor = top;
     }
 
     private static void Add(StateSaveCategory category, string name, System.Action apply)

--- a/Themes/Gum.Themes.ForestGlade.MonoGame/ScrollBarVisual.cs
+++ b/Themes/Gum.Themes.ForestGlade.MonoGame/ScrollBarVisual.cs
@@ -20,8 +20,8 @@ public class ScrollBarVisual : BaseScrollBarVisual
     private const float FrameBorderThickness = 1f;
 
     private readonly ScrollBarThumbVisual _thumb;
-    private readonly RoundedRectangleRuntime _frameFill;
-    private readonly RoundedRectangleRuntime _frameBorder;
+    private readonly RectangleRuntime _frameFill;
+    private readonly RectangleRuntime _frameBorder;
     private bool _isHorizontal;
 
     public ScrollBarVisual(bool fullInstantiation = true, bool tryCreateFormsObject = true)
@@ -137,9 +137,9 @@ public class ScrollBarVisual : BaseScrollBarVisual
         }
     }
 
-    private static RoundedRectangleRuntime CreateFrameFill()
+    private static RectangleRuntime CreateFrameFill()
     {
-        RoundedRectangleRuntime fill = new RoundedRectangleRuntime();
+        RectangleRuntime fill = new RectangleRuntime();
         fill.Name = "ForestGladeScrollBarFrameFill";
         fill.XUnits = GeneralUnitType.PixelsFromMiddle;
         fill.YUnits = GeneralUnitType.PixelsFromMiddle;
@@ -151,13 +151,14 @@ public class ScrollBarVisual : BaseScrollBarVisual
         fill.HeightUnits = DimensionUnitType.RelativeToParent;
         ForestGladeLeaf.ApplyMedium(fill);
         fill.IsFilled = true;
-        fill.Color = ForestGladePalette.ScrollTrack;
+        fill.FillColor = ForestGladePalette.ScrollTrack;
+        fill.StrokeWidth = 0;
         return fill;
     }
 
-    private static RoundedRectangleRuntime CreateFrameBorder()
+    private static RectangleRuntime CreateFrameBorder()
     {
-        RoundedRectangleRuntime border = new RoundedRectangleRuntime();
+        RectangleRuntime border = new RectangleRuntime();
         border.Name = "ForestGladeScrollBarFrameBorder";
         border.XUnits = GeneralUnitType.PixelsFromMiddle;
         border.YUnits = GeneralUnitType.PixelsFromMiddle;
@@ -171,7 +172,7 @@ public class ScrollBarVisual : BaseScrollBarVisual
         border.IsFilled = false;
         border.StrokeWidth = FrameBorderThickness;
         border.StrokeWidthUnits = DimensionUnitType.Absolute;
-        border.Color = ForestGladeColors.Border;
+        border.StrokeColor = ForestGladeColors.Border;
         return border;
     }
 }

--- a/Themes/Gum.Themes.ForestGlade.MonoGame/ScrollViewerVisual.cs
+++ b/Themes/Gum.Themes.ForestGlade.MonoGame/ScrollViewerVisual.cs
@@ -24,7 +24,7 @@ public class ScrollViewerVisual : BaseScrollViewerVisual
     private const float FocusRingThickness = 3f;
     private static readonly Color RestBorder = new Color(232, 255, 117, 220);
 
-    private static void ApplyLeafShape(RoundedRectangleRuntime r)
+    private static void ApplyLeafShape(RectangleRuntime r)
     {
         r.CornerRadius = SharpRadius;
         r.CustomRadiusTopLeft = SharpRadius;
@@ -33,9 +33,9 @@ public class ScrollViewerVisual : BaseScrollViewerVisual
         r.CustomRadiusBottomLeft = RoundedRadius;
     }
 
-    private readonly RoundedRectangleRuntime _focusRing;
-    private readonly RoundedRectangleRuntime _fill;
-    private readonly RoundedRectangleRuntime _border;
+    private readonly RectangleRuntime _focusRing;
+    private readonly RectangleRuntime _fill;
+    private readonly RectangleRuntime _border;
 
     public ScrollViewerVisual(bool fullInstantiation = true, bool tryCreateFormsObject = true)
         : base(fullInstantiation, tryCreateFormsObject)
@@ -77,9 +77,9 @@ public class ScrollViewerVisual : BaseScrollViewerVisual
         WireStates();
     }
 
-    private static RoundedRectangleRuntime CreateFill()
+    private static RectangleRuntime CreateFill()
     {
-        RoundedRectangleRuntime fill = new RoundedRectangleRuntime();
+        RectangleRuntime fill = new RectangleRuntime();
         fill.Name = "ForestGladeScrollViewerFill";
         fill.XUnits = GeneralUnitType.PixelsFromMiddle;
         fill.YUnits = GeneralUnitType.PixelsFromMiddle;
@@ -91,13 +91,14 @@ public class ScrollViewerVisual : BaseScrollViewerVisual
         fill.HeightUnits = DimensionUnitType.RelativeToParent;
         ApplyLeafShape(fill);
         fill.IsFilled = true;
-        fill.Color = ForestGladePalette.InputFill;
+        fill.FillColor = ForestGladePalette.InputFill;
+        fill.StrokeWidth = 0;
         return fill;
     }
 
-    private static RoundedRectangleRuntime CreateBorder()
+    private static RectangleRuntime CreateBorder()
     {
-        RoundedRectangleRuntime border = new RoundedRectangleRuntime();
+        RectangleRuntime border = new RectangleRuntime();
         border.Name = "ForestGladeScrollViewerBorder";
         border.XUnits = GeneralUnitType.PixelsFromMiddle;
         border.YUnits = GeneralUnitType.PixelsFromMiddle;
@@ -111,14 +112,14 @@ public class ScrollViewerVisual : BaseScrollViewerVisual
         border.IsFilled = false;
         border.StrokeWidth = BorderThickness;
         border.StrokeWidthUnits = DimensionUnitType.Absolute;
-        border.Color = RestBorder;
+        border.StrokeColor = RestBorder;
         return border;
     }
 
-    private static RoundedRectangleRuntime CreateFocusRing()
+    private static RectangleRuntime CreateFocusRing()
     {
         const float halo = FocusRingInset;
-        RoundedRectangleRuntime ring = new RoundedRectangleRuntime();
+        RectangleRuntime ring = new RectangleRuntime();
         ring.Name = "ForestGladeScrollViewerFocusRing";
         ring.XUnits = GeneralUnitType.PixelsFromMiddle;
         ring.YUnits = GeneralUnitType.PixelsFromMiddle;
@@ -136,7 +137,7 @@ public class ScrollViewerVisual : BaseScrollViewerVisual
         ring.IsFilled = false;
         ring.StrokeWidth = FocusRingThickness;
         ring.StrokeWidthUnits = DimensionUnitType.Absolute;
-        ring.Color = ForestGladeColors.AccentHalo;
+        ring.StrokeColor = ForestGladeColors.AccentHalo;
         ring.Visible = false;
         return ring;
     }
@@ -145,13 +146,13 @@ public class ScrollViewerVisual : BaseScrollViewerVisual
     {
         States.Enabled.Apply = () =>
         {
-            _border.Color = RestBorder;
+            _border.StrokeColor = RestBorder;
             _focusRing.Visible = false;
         };
 
         States.Focused.Apply = () =>
         {
-            _border.Color = ForestGladeColors.LeafBright;
+            _border.StrokeColor = ForestGladeColors.LeafBright;
             _focusRing.Visible = true;
         };
     }

--- a/Themes/Gum.Themes.ForestGlade.MonoGame/SliderThumbVisual.cs
+++ b/Themes/Gum.Themes.ForestGlade.MonoGame/SliderThumbVisual.cs
@@ -24,9 +24,9 @@ public class SliderThumbVisual : InteractiveGue
     private const float ShadowBlur = 22f;
     private const float ShadowBlurHover = 30f;
 
-    private readonly ColoredCircleRuntime _focusRing;
-    private readonly ColoredCircleRuntime _body;
-    private readonly ColoredCircleRuntime _border;
+    private readonly CircleRuntime _focusRing;
+    private readonly CircleRuntime _body;
+    private readonly CircleRuntime _border;
 
     private StateSaveCategory _buttonCategory = null!;
 
@@ -50,9 +50,9 @@ public class SliderThumbVisual : InteractiveGue
         WireStates();
     }
 
-    private static ColoredCircleRuntime CreateBody()
+    private static CircleRuntime CreateBody()
     {
-        ColoredCircleRuntime body = new ColoredCircleRuntime();
+        CircleRuntime body = new CircleRuntime();
         body.Name = "ForestGladeSliderThumbBody";
         body.XUnits = GeneralUnitType.PixelsFromMiddle;
         body.YUnits = GeneralUnitType.PixelsFromMiddle;
@@ -63,6 +63,7 @@ public class SliderThumbVisual : InteractiveGue
         body.WidthUnits = DimensionUnitType.RelativeToParent;
         body.HeightUnits = DimensionUnitType.RelativeToParent;
         body.IsFilled = true;
+        body.StrokeWidth = 0;
         // CSS radial-gradient(circle at 35% 30%, sun-pale, leaf-bright 65%, #008c2e).
         // 2-stop approximation: sun-pale centre → canopy-lit edge. Offset of
         // 35%/30% is implemented by nudging the gradient origin off-centre
@@ -84,14 +85,13 @@ public class SliderThumbVisual : InteractiveGue
         body.DropshadowColor = ForestGladePalette.GlowMedium;
         body.DropshadowOffsetX = 0f;
         body.DropshadowOffsetY = 0f;
-        body.DropshadowBlurX = ShadowBlur;
-        body.DropshadowBlurY = ShadowBlur;
+        body.DropshadowBlur = ShadowBlur;
         return body;
     }
 
-    private static ColoredCircleRuntime CreateBorder()
+    private static CircleRuntime CreateBorder()
     {
-        ColoredCircleRuntime border = new ColoredCircleRuntime();
+        CircleRuntime border = new CircleRuntime();
         border.Name = "ForestGladeSliderThumbBorder";
         border.XUnits = GeneralUnitType.PixelsFromMiddle;
         border.YUnits = GeneralUnitType.PixelsFromMiddle;
@@ -104,13 +104,13 @@ public class SliderThumbVisual : InteractiveGue
         border.IsFilled = false;
         border.StrokeWidth = BorderThickness;
         border.StrokeWidthUnits = DimensionUnitType.Absolute;
-        border.Color = new Color(232, 255, 117, 128); // sun-pale .5 alpha
+        border.StrokeColor = new Color(232, 255, 117, 128); // sun-pale .5 alpha
         return border;
     }
 
-    private static ColoredCircleRuntime CreateFocusRing()
+    private static CircleRuntime CreateFocusRing()
     {
-        ColoredCircleRuntime ring = new ColoredCircleRuntime();
+        CircleRuntime ring = new CircleRuntime();
         ring.Name = "ForestGladeSliderThumbFocusRing";
         ring.XUnits = GeneralUnitType.PixelsFromMiddle;
         ring.YUnits = GeneralUnitType.PixelsFromMiddle;
@@ -123,7 +123,7 @@ public class SliderThumbVisual : InteractiveGue
         ring.IsFilled = false;
         ring.StrokeWidth = FocusRingThickness;
         ring.StrokeWidthUnits = DimensionUnitType.Absolute;
-        ring.Color = ForestGladeColors.AccentHalo;
+        ring.StrokeColor = ForestGladeColors.AccentHalo;
         ring.Visible = false;
         return ring;
     }
@@ -181,11 +181,10 @@ public class SliderThumbVisual : InteractiveGue
         _body.UseGradient = gradient;
         _body.Color1 = centre;
         _body.Color2 = edge;
-        _body.Color = centre;
+        _body.FillColor = centre;
         _body.HasDropshadow = showShadow;
-        _body.DropshadowBlurX = blur;
-        _body.DropshadowBlurY = blur;
-        _border.Color = border;
+        _body.DropshadowBlur = blur;
+        _border.StrokeColor = border;
         _focusRing.Visible = ring;
     }
 }

--- a/Themes/Gum.Themes.ForestGlade.MonoGame/SliderVisual.cs
+++ b/Themes/Gum.Themes.ForestGlade.MonoGame/SliderVisual.cs
@@ -19,8 +19,8 @@ public class SliderVisual : BaseSliderVisual
     private const float TrackHeight = 6f;
     private const float TrackCornerRadius = 3f;
 
-    private readonly RoundedRectangleRuntime _track;
-    private readonly RoundedRectangleRuntime _fill;
+    private readonly RectangleRuntime _track;
+    private readonly RectangleRuntime _fill;
     private readonly SliderThumbVisual _thumb;
 
     public SliderVisual(bool fullInstantiation = true, bool tryCreateFormsObject = true)
@@ -93,9 +93,9 @@ public class SliderVisual : BaseSliderVisual
         _fill.Width = (float)(pct * 100.0);
     }
 
-    private static RoundedRectangleRuntime CreateTrack()
+    private static RectangleRuntime CreateTrack()
     {
-        RoundedRectangleRuntime track = new RoundedRectangleRuntime();
+        RectangleRuntime track = new RectangleRuntime();
         track.Name = "ForestGladeSliderTrack";
         track.XUnits = GeneralUnitType.PixelsFromMiddle;
         track.YUnits = GeneralUnitType.PixelsFromMiddle;
@@ -107,13 +107,14 @@ public class SliderVisual : BaseSliderVisual
         track.HeightUnits = DimensionUnitType.Absolute;
         track.CornerRadius = TrackCornerRadius;
         track.IsFilled = true;
-        track.Color = ForestGladePalette.SliderTrack;
+        track.FillColor = ForestGladePalette.SliderTrack;
+        track.StrokeWidth = 0;
         return track;
     }
 
-    private static RoundedRectangleRuntime CreateFill()
+    private static RectangleRuntime CreateFill()
     {
-        RoundedRectangleRuntime fill = new RoundedRectangleRuntime();
+        RectangleRuntime fill = new RectangleRuntime();
         fill.Name = "ForestGladeSliderFill";
         fill.XUnits = GeneralUnitType.PixelsFromSmall;
         fill.YUnits = GeneralUnitType.PixelsFromMiddle;
@@ -125,6 +126,7 @@ public class SliderVisual : BaseSliderVisual
         fill.HeightUnits = DimensionUnitType.Absolute;
         fill.CornerRadius = TrackCornerRadius;
         fill.IsFilled = true;
+        fill.StrokeWidth = 0;
         // CSS .fg-sldr-fill: linear-gradient(90deg, canopy-lit, leaf-bright 70%, sun-pale).
         // Horizontal gradient — endpoints span left/right via PixelsFromSmall/PixelsFromLarge.
         fill.UseGradient = true;
@@ -162,7 +164,7 @@ public class SliderVisual : BaseSliderVisual
 
     private void ApplyTrack(Color trackFill, Color fillLeft, Color fillRight)
     {
-        _track.Color = trackFill;
+        _track.FillColor = trackFill;
         _fill.Color1 = fillLeft;
         _fill.Color2 = fillRight;
     }

--- a/Themes/Gum.Themes.ForestGlade.MonoGame/SplitterVisual.cs
+++ b/Themes/Gum.Themes.ForestGlade.MonoGame/SplitterVisual.cs
@@ -11,11 +11,11 @@ namespace Gum.Themes.ForestGlade;
 /// nodes — non-trivial to reproduce in shape primitives. We render the vine
 /// cord (a thin bark-colored rect down the middle) and leave the decorative
 /// leaf clusters out for v1; consumers can subclass and add leaf
-/// <c>ColoredCircleRuntime</c>s if needed.
+/// <c>CircleRuntime</c>s if needed.
 /// </summary>
 public class SplitterVisual : BaseSplitterVisual
 {
-    private readonly ColoredRectangleRuntime _fill;
+    private readonly RectangleRuntime _fill;
 
     public SplitterVisual(bool fullInstantiation = true, bool tryCreateFormsObject = true)
         : base(fullInstantiation, tryCreateFormsObject)
@@ -26,9 +26,9 @@ public class SplitterVisual : BaseSplitterVisual
         AddChild(_fill);
     }
 
-    private static ColoredRectangleRuntime CreateFill()
+    private static RectangleRuntime CreateFill()
     {
-        ColoredRectangleRuntime fill = new ColoredRectangleRuntime();
+        RectangleRuntime fill = new RectangleRuntime();
         fill.Name = "ForestGladeSplitterFill";
         fill.XUnits = GeneralUnitType.PixelsFromMiddle;
         fill.YUnits = GeneralUnitType.PixelsFromMiddle;
@@ -38,7 +38,9 @@ public class SplitterVisual : BaseSplitterVisual
         fill.Height = 0;
         fill.WidthUnits = DimensionUnitType.RelativeToParent;
         fill.HeightUnits = DimensionUnitType.RelativeToParent;
-        fill.Color = ForestGladePalette.VineCord;
+        fill.IsFilled = true;
+        fill.FillColor = ForestGladePalette.VineCord;
+        fill.StrokeWidth = 0;
         return fill;
     }
 }

--- a/Themes/Gum.Themes.ForestGlade.MonoGame/TooltipVisual.cs
+++ b/Themes/Gum.Themes.ForestGlade.MonoGame/TooltipVisual.cs
@@ -16,8 +16,8 @@ public class TooltipVisual : BaseTooltipVisual
 {
     private const float BorderThickness = 1f;
 
-    private readonly RoundedRectangleRuntime _fill;
-    private readonly RoundedRectangleRuntime _border;
+    private readonly RectangleRuntime _fill;
+    private readonly RectangleRuntime _border;
 
     public TooltipVisual(bool fullInstantiation = true, bool tryCreateFormsObject = true)
         : base(fullInstantiation, tryCreateFormsObject)
@@ -35,9 +35,9 @@ public class TooltipVisual : BaseTooltipVisual
         TextInstance.Color = ForestGladeColors.Text;
     }
 
-    private static RoundedRectangleRuntime CreateFill()
+    private static RectangleRuntime CreateFill()
     {
-        RoundedRectangleRuntime fill = new RoundedRectangleRuntime();
+        RectangleRuntime fill = new RectangleRuntime();
         fill.Name = "ForestGladeTooltipFill";
         fill.XUnits = GeneralUnitType.PixelsFromMiddle;
         fill.YUnits = GeneralUnitType.PixelsFromMiddle;
@@ -49,13 +49,14 @@ public class TooltipVisual : BaseTooltipVisual
         fill.HeightUnits = DimensionUnitType.RelativeToParent;
         ForestGladeLeaf.ApplyMedium(fill);
         fill.IsFilled = true;
-        fill.Color = ForestGladePalette.WindowBody;
+        fill.FillColor = ForestGladePalette.WindowBody;
+        fill.StrokeWidth = 0;
         return fill;
     }
 
-    private static RoundedRectangleRuntime CreateBorder()
+    private static RectangleRuntime CreateBorder()
     {
-        RoundedRectangleRuntime border = new RoundedRectangleRuntime();
+        RectangleRuntime border = new RectangleRuntime();
         border.Name = "ForestGladeTooltipBorder";
         border.XUnits = GeneralUnitType.PixelsFromMiddle;
         border.YUnits = GeneralUnitType.PixelsFromMiddle;
@@ -69,7 +70,7 @@ public class TooltipVisual : BaseTooltipVisual
         border.IsFilled = false;
         border.StrokeWidth = BorderThickness;
         border.StrokeWidthUnits = DimensionUnitType.Absolute;
-        border.Color = new Color(232, 255, 117, 56);
+        border.StrokeColor = new Color(232, 255, 117, 56);
         return border;
     }
 }

--- a/Themes/Gum.Themes.ForestGlade.MonoGame/WindowVisual.cs
+++ b/Themes/Gum.Themes.ForestGlade.MonoGame/WindowVisual.cs
@@ -20,10 +20,10 @@ public class WindowVisual : BaseWindowVisual
 
     private const float ShadowBlur = 40f;
 
-    private readonly RoundedRectangleRuntime _fill;
-    private readonly RoundedRectangleRuntime _border;
-    private readonly RoundedRectangleRuntime _titleBarFill;
-    private readonly ColoredRectangleRuntime _titleBarSeparator;
+    private readonly RectangleRuntime _fill;
+    private readonly RectangleRuntime _border;
+    private readonly RectangleRuntime _titleBarFill;
+    private readonly RectangleRuntime _titleBarSeparator;
 
     public WindowVisual(bool fullInstantiation = true, bool tryCreateFormsObject = true)
         : base(fullInstantiation, tryCreateFormsObject)
@@ -67,9 +67,9 @@ public class WindowVisual : BaseWindowVisual
         _titleBarSeparator.Parent = TitleBarInstance.Visual;
     }
 
-    private static RoundedRectangleRuntime CreateFill()
+    private static RectangleRuntime CreateFill()
     {
-        RoundedRectangleRuntime fill = new RoundedRectangleRuntime();
+        RectangleRuntime fill = new RectangleRuntime();
         fill.Name = "ForestGladeWindowFill";
         fill.XUnits = GeneralUnitType.PixelsFromMiddle;
         fill.YUnits = GeneralUnitType.PixelsFromMiddle;
@@ -81,19 +81,19 @@ public class WindowVisual : BaseWindowVisual
         fill.HeightUnits = DimensionUnitType.RelativeToParent;
         ForestGladeLeaf.ApplyExtraLarge(fill);
         fill.IsFilled = true;
-        fill.Color = ForestGladePalette.WindowBody;
+        fill.FillColor = ForestGladePalette.WindowBody;
+        fill.StrokeWidth = 0;
         fill.HasDropshadow = true;
         fill.DropshadowColor = ForestGladePalette.GlowMedium;
         fill.DropshadowOffsetX = 0f;
         fill.DropshadowOffsetY = 0f;
-        fill.DropshadowBlurX = ShadowBlur;
-        fill.DropshadowBlurY = ShadowBlur;
+        fill.DropshadowBlur = ShadowBlur;
         return fill;
     }
 
-    private static RoundedRectangleRuntime CreateBorder()
+    private static RectangleRuntime CreateBorder()
     {
-        RoundedRectangleRuntime border = new RoundedRectangleRuntime();
+        RectangleRuntime border = new RectangleRuntime();
         border.Name = "ForestGladeWindowBorder";
         border.XUnits = GeneralUnitType.PixelsFromMiddle;
         border.YUnits = GeneralUnitType.PixelsFromMiddle;
@@ -107,11 +107,11 @@ public class WindowVisual : BaseWindowVisual
         border.IsFilled = false;
         border.StrokeWidth = BorderThickness;
         border.StrokeWidthUnits = DimensionUnitType.Absolute;
-        border.Color = ForestGladeColors.Bark;
+        border.StrokeColor = ForestGladeColors.Bark;
         return border;
     }
 
-    private static RoundedRectangleRuntime CreateTitleBarFill()
+    private static RectangleRuntime CreateTitleBarFill()
     {
         // CSS spec is a wood-grain repeating gradient — represented here by
         // a single bark-soft fill so the title bar reads as warm wood
@@ -124,7 +124,7 @@ public class WindowVisual : BaseWindowVisual
         // rectangular fill would spill past the body's rounded top-right
         // corner — the 1 px body border isn't thick enough to mask 24 px
         // of spill on its own.
-        RoundedRectangleRuntime fill = new RoundedRectangleRuntime();
+        RectangleRuntime fill = new RectangleRuntime();
         fill.Name = "ForestGladeWindowTitleBarFill";
         fill.XUnits = GeneralUnitType.PixelsFromMiddle;
         fill.YUnits = GeneralUnitType.PixelsFromMiddle;
@@ -140,13 +140,14 @@ public class WindowVisual : BaseWindowVisual
         fill.CustomRadiusBottomRight = 0f;
         fill.CustomRadiusBottomLeft = 0f;
         fill.IsFilled = true;
-        fill.Color = ForestGladePalette.WindowTitleBar;
+        fill.FillColor = ForestGladePalette.WindowTitleBar;
+        fill.StrokeWidth = 0;
         return fill;
     }
 
-    private static ColoredRectangleRuntime CreateTitleBarSeparator()
+    private static RectangleRuntime CreateTitleBarSeparator()
     {
-        ColoredRectangleRuntime separator = new ColoredRectangleRuntime();
+        RectangleRuntime separator = new RectangleRuntime();
         separator.Name = "ForestGladeWindowTitleBarSeparator";
         separator.XUnits = GeneralUnitType.PixelsFromMiddle;
         separator.YUnits = GeneralUnitType.PixelsFromLarge;
@@ -157,7 +158,9 @@ public class WindowVisual : BaseWindowVisual
         separator.WidthUnits = DimensionUnitType.RelativeToParent;
         separator.HeightUnits = DimensionUnitType.Absolute;
         // CSS box-shadow: inset 0 -1px 0 rgba(232,255,117,.12)
-        separator.Color = new Color(232, 255, 117, 31);
+        separator.IsFilled = true;
+        separator.FillColor = new Color(232, 255, 117, 31);
+        separator.StrokeWidth = 0;
         return separator;
     }
 }

--- a/Themes/Gum.Themes.Neon.MonoGame/ButtonVisual.cs
+++ b/Themes/Gum.Themes.Neon.MonoGame/ButtonVisual.cs
@@ -34,9 +34,9 @@ public class ButtonVisual : BaseButtonVisual
     private const float FocusRingInset = 4f;
     private const float FocusRingThickness = 1f;
 
-    private readonly RoundedRectangleRuntime _focusRing;
-    private readonly RoundedRectangleRuntime _fill;
-    private readonly RoundedRectangleRuntime _border;
+    private readonly RectangleRuntime _focusRing;
+    private readonly RectangleRuntime _fill;
+    private readonly RectangleRuntime _border;
 
     public ButtonVisual(bool fullInstantiation = true, bool tryCreateFormsObject = true)
         : base(fullInstantiation, tryCreateFormsObject)
@@ -73,9 +73,9 @@ public class ButtonVisual : BaseButtonVisual
         WireStates();
     }
 
-    private static RoundedRectangleRuntime CreateFill()
+    private static RectangleRuntime CreateFill()
     {
-        RoundedRectangleRuntime fill = new RoundedRectangleRuntime();
+        RectangleRuntime fill = new RectangleRuntime();
         fill.Name = "NeonButtonFill";
         fill.XUnits = GeneralUnitType.PixelsFromMiddle;
         fill.YUnits = GeneralUnitType.PixelsFromMiddle;
@@ -87,19 +87,19 @@ public class ButtonVisual : BaseButtonVisual
         fill.HeightUnits = DimensionUnitType.RelativeToParent;
         fill.CornerRadius = CornerRadius;
         fill.IsFilled = true;
-        fill.Color = NeonColors.Surface1;
+        fill.FillColor = NeonColors.Surface1;
+        fill.StrokeWidth = 0;
         fill.HasDropshadow = true;
         fill.DropshadowColor = NeonPalette.GlowMedium;
         fill.DropshadowOffsetX = 0f;
         fill.DropshadowOffsetY = 0f;
-        fill.DropshadowBlurX = RestGlowBlur;
-        fill.DropshadowBlurY = RestGlowBlur;
+        fill.DropshadowBlur = RestGlowBlur;
         return fill;
     }
 
-    private static RoundedRectangleRuntime CreateBorder()
+    private static RectangleRuntime CreateBorder()
     {
-        RoundedRectangleRuntime border = new RoundedRectangleRuntime();
+        RectangleRuntime border = new RectangleRuntime();
         border.Name = "NeonButtonBorder";
         border.XUnits = GeneralUnitType.PixelsFromMiddle;
         border.YUnits = GeneralUnitType.PixelsFromMiddle;
@@ -113,13 +113,13 @@ public class ButtonVisual : BaseButtonVisual
         border.IsFilled = false;
         border.StrokeWidth = BorderThickness;
         border.StrokeWidthUnits = DimensionUnitType.Absolute;
-        border.Color = NeonColors.Accent;
+        border.StrokeColor = NeonColors.Accent;
         return border;
     }
 
-    private static RoundedRectangleRuntime CreateFocusRing()
+    private static RectangleRuntime CreateFocusRing()
     {
-        RoundedRectangleRuntime ring = new RoundedRectangleRuntime();
+        RectangleRuntime ring = new RectangleRuntime();
         ring.Name = "NeonButtonFocusRing";
         ring.XUnits = GeneralUnitType.PixelsFromMiddle;
         ring.YUnits = GeneralUnitType.PixelsFromMiddle;
@@ -133,7 +133,7 @@ public class ButtonVisual : BaseButtonVisual
         ring.IsFilled = false;
         ring.StrokeWidth = FocusRingThickness;
         ring.StrokeWidthUnits = DimensionUnitType.Absolute;
-        ring.Color = NeonPalette.FocusRing;
+        ring.StrokeColor = NeonPalette.FocusRing;
         ring.Visible = false;
         return ring;
     }
@@ -173,13 +173,12 @@ public class ButtonVisual : BaseButtonVisual
 
     private void Apply(Color fill, Color text, Color glow, float blur, bool ring)
     {
-        _fill.Color = fill;
+        _fill.FillColor = fill;
         // Border stays a constant 1 px cyan — focus emphasis is carried by
         // the separate white ring, not by border thickness.
-        _border.Color = NeonColors.Accent;
+        _border.StrokeColor = NeonColors.Accent;
         _fill.DropshadowColor = glow;
-        _fill.DropshadowBlurX = blur;
-        _fill.DropshadowBlurY = blur;
+        _fill.DropshadowBlur = blur;
         _fill.HasDropshadow = blur > 0f;
         TextInstance.Color = text;
         _focusRing.Visible = ring;

--- a/Themes/Gum.Themes.Neon.MonoGame/CheckBoxVisual.cs
+++ b/Themes/Gum.Themes.Neon.MonoGame/CheckBoxVisual.cs
@@ -31,11 +31,11 @@ public class CheckBoxVisual : BaseCheckBoxVisual
     // (which uses a slightly wider advance than ASCII Latin) doesn't get clipped.
     private const float GlyphContainerSize = 24f;
 
-    private readonly RoundedRectangleRuntime _focusRing;
-    private readonly RoundedRectangleRuntime _boxFill;
-    private readonly RoundedRectangleRuntime _boxBorder;
+    private readonly RectangleRuntime _focusRing;
+    private readonly RectangleRuntime _boxFill;
+    private readonly RectangleRuntime _boxBorder;
     private readonly TextRuntime _checkGlyph;
-    private readonly RoundedRectangleRuntime _dashIndicator;
+    private readonly RectangleRuntime _dashIndicator;
 
     public CheckBoxVisual(bool fullInstantiation = true, bool tryCreateFormsObject = true)
         : base(fullInstantiation, tryCreateFormsObject)
@@ -73,9 +73,9 @@ public class CheckBoxVisual : BaseCheckBoxVisual
         WireStates();
     }
 
-    private static RoundedRectangleRuntime CreateBoxFill()
+    private static RectangleRuntime CreateBoxFill()
     {
-        RoundedRectangleRuntime fill = new RoundedRectangleRuntime();
+        RectangleRuntime fill = new RectangleRuntime();
         fill.Name = "NeonBoxFill";
         fill.X = 0;
         fill.Y = 0;
@@ -89,13 +89,14 @@ public class CheckBoxVisual : BaseCheckBoxVisual
         fill.HeightUnits = DimensionUnitType.Absolute;
         fill.CornerRadius = CornerRadius;
         fill.IsFilled = true;
-        fill.Color = NeonColors.Surface1;
+        fill.FillColor = NeonColors.Surface1;
+        fill.StrokeWidth = 0;
         return fill;
     }
 
-    private static RoundedRectangleRuntime CreateBoxBorder()
+    private static RectangleRuntime CreateBoxBorder()
     {
-        RoundedRectangleRuntime border = new RoundedRectangleRuntime();
+        RectangleRuntime border = new RectangleRuntime();
         border.Name = "NeonBoxBorder";
         border.X = 0;
         border.Y = 0;
@@ -111,13 +112,13 @@ public class CheckBoxVisual : BaseCheckBoxVisual
         border.IsFilled = false;
         border.StrokeWidth = BorderThickness;
         border.StrokeWidthUnits = DimensionUnitType.Absolute;
-        border.Color = NeonColors.Border;
+        border.StrokeColor = NeonColors.Border;
         return border;
     }
 
-    private static RoundedRectangleRuntime CreateFocusRing()
+    private static RectangleRuntime CreateFocusRing()
     {
-        RoundedRectangleRuntime ring = new RoundedRectangleRuntime();
+        RectangleRuntime ring = new RectangleRuntime();
         ring.Name = "NeonBoxFocusRing";
         ring.X = -FocusRingInset;
         ring.Y = 0;
@@ -133,7 +134,7 @@ public class CheckBoxVisual : BaseCheckBoxVisual
         ring.IsFilled = false;
         ring.StrokeWidth = FocusRingThickness;
         ring.StrokeWidthUnits = DimensionUnitType.Absolute;
-        ring.Color = NeonPalette.FocusRing;
+        ring.StrokeColor = NeonPalette.FocusRing;
         ring.Visible = false;
         return ring;
     }
@@ -158,10 +159,10 @@ public class CheckBoxVisual : BaseCheckBoxVisual
         return glyph;
     }
 
-    private static RoundedRectangleRuntime CreateDashIndicator()
+    private static RectangleRuntime CreateDashIndicator()
     {
         // Indeterminate pill: 10x2 (matches .bb-ck-dash), accent-colored, centered.
-        RoundedRectangleRuntime dash = new RoundedRectangleRuntime();
+        RectangleRuntime dash = new RectangleRuntime();
         dash.Name = "NeonDashIndicator";
         dash.X = BoxSize / 2f;
         dash.Y = 0;
@@ -175,7 +176,8 @@ public class CheckBoxVisual : BaseCheckBoxVisual
         dash.HeightUnits = DimensionUnitType.Absolute;
         dash.CornerRadius = 1f;
         dash.IsFilled = true;
-        dash.Color = NeonColors.Accent;
+        dash.FillColor = NeonColors.Accent;
+        dash.StrokeWidth = 0;
         return dash;
     }
 
@@ -286,8 +288,8 @@ public class CheckBoxVisual : BaseCheckBoxVisual
     private void Apply(Color fill, Color border, Color text, GlyphKind glyph, bool ring,
         Color? glyphColor = null)
     {
-        _boxFill.Color = fill;
-        _boxBorder.Color = border;
+        _boxFill.FillColor = fill;
+        _boxBorder.StrokeColor = border;
         TextInstance.Color = text;
         _focusRing.Visible = ring;
         _checkGlyph.Visible = glyph == GlyphKind.Check;

--- a/Themes/Gum.Themes.Neon.MonoGame/ComboBoxVisual.cs
+++ b/Themes/Gum.Themes.Neon.MonoGame/ComboBoxVisual.cs
@@ -30,9 +30,9 @@ public class ComboBoxVisual : BaseComboBoxVisual
     private const float TextLeftPadding = 12f;
     private const float TextRightClearance = 4f;
 
-    private readonly RoundedRectangleRuntime _focusRing;
-    private readonly RoundedRectangleRuntime _fill;
-    private readonly RoundedRectangleRuntime _border;
+    private readonly RectangleRuntime _focusRing;
+    private readonly RectangleRuntime _fill;
+    private readonly RectangleRuntime _border;
     private readonly TextRuntime _dropdownGlyph;
 
     public ComboBoxVisual(bool fullInstantiation = true, bool tryCreateFormsObject = true)
@@ -64,9 +64,9 @@ public class ComboBoxVisual : BaseComboBoxVisual
         WireStates();
     }
 
-    private static RoundedRectangleRuntime CreateFill()
+    private static RectangleRuntime CreateFill()
     {
-        RoundedRectangleRuntime fill = new RoundedRectangleRuntime();
+        RectangleRuntime fill = new RectangleRuntime();
         fill.Name = "NeonComboFill";
         fill.X = 0;
         fill.Y = 0;
@@ -80,13 +80,14 @@ public class ComboBoxVisual : BaseComboBoxVisual
         fill.HeightUnits = DimensionUnitType.RelativeToParent;
         fill.CornerRadius = CornerRadius;
         fill.IsFilled = true;
-        fill.Color = NeonColors.Surface1;
+        fill.FillColor = NeonColors.Surface1;
+        fill.StrokeWidth = 0;
         return fill;
     }
 
-    private static RoundedRectangleRuntime CreateBorder()
+    private static RectangleRuntime CreateBorder()
     {
-        RoundedRectangleRuntime border = new RoundedRectangleRuntime();
+        RectangleRuntime border = new RectangleRuntime();
         border.Name = "NeonComboBorder";
         border.X = 0;
         border.Y = 0;
@@ -102,13 +103,13 @@ public class ComboBoxVisual : BaseComboBoxVisual
         border.IsFilled = false;
         border.StrokeWidth = BorderThickness;
         border.StrokeWidthUnits = DimensionUnitType.Absolute;
-        border.Color = NeonColors.Border;
+        border.StrokeColor = NeonColors.Border;
         return border;
     }
 
-    private static RoundedRectangleRuntime CreateFocusRing()
+    private static RectangleRuntime CreateFocusRing()
     {
-        RoundedRectangleRuntime ring = new RoundedRectangleRuntime();
+        RectangleRuntime ring = new RectangleRuntime();
         ring.Name = "NeonComboFocusRing";
         ring.X = 0;
         ring.Y = 0;
@@ -124,7 +125,7 @@ public class ComboBoxVisual : BaseComboBoxVisual
         ring.IsFilled = false;
         ring.StrokeWidth = FocusRingThickness;
         ring.StrokeWidthUnits = DimensionUnitType.Absolute;
-        ring.Color = NeonPalette.FocusRing;
+        ring.StrokeColor = NeonPalette.FocusRing;
         ring.Visible = false;
         return ring;
     }
@@ -191,8 +192,8 @@ public class ComboBoxVisual : BaseComboBoxVisual
 
     private void Apply(Color border, Color text, Color glyph, bool ring, bool fillDisabled)
     {
-        _fill.Color = fillDisabled ? NeonColors.Background : NeonColors.Surface1;
-        _border.Color = border;
+        _fill.FillColor = fillDisabled ? NeonColors.Background : NeonColors.Surface1;
+        _border.StrokeColor = border;
         TextInstance.Color = text;
         _dropdownGlyph.Color = glyph;
         _focusRing.Visible = ring;

--- a/Themes/Gum.Themes.Neon.MonoGame/ListBoxItemVisual.cs
+++ b/Themes/Gum.Themes.Neon.MonoGame/ListBoxItemVisual.cs
@@ -14,7 +14,7 @@ namespace Gum.Themes.Neon;
 /// </summary>
 public class ListBoxItemVisual : BaseListBoxItemVisual
 {
-    private readonly RoundedRectangleRuntime _fill;
+    private readonly RectangleRuntime _fill;
 
     public ListBoxItemVisual(bool fullInstantiation = true, bool tryCreateFormsObject = true)
         : base(fullInstantiation, tryCreateFormsObject)
@@ -35,9 +35,9 @@ public class ListBoxItemVisual : BaseListBoxItemVisual
         WireStates();
     }
 
-    private static RoundedRectangleRuntime CreateFill()
+    private static RectangleRuntime CreateFill()
     {
-        RoundedRectangleRuntime fill = new RoundedRectangleRuntime();
+        RectangleRuntime fill = new RectangleRuntime();
         fill.Name = "NeonListItemFill";
         fill.X = 0;
         fill.Y = 0;
@@ -51,7 +51,8 @@ public class ListBoxItemVisual : BaseListBoxItemVisual
         fill.HeightUnits = DimensionUnitType.RelativeToParent;
         fill.CornerRadius = 0f;
         fill.IsFilled = true;
-        fill.Color = Color.Transparent;
+        fill.FillColor = Color.Transparent;
+        fill.StrokeWidth = 0;
         return fill;
     }
 
@@ -75,7 +76,7 @@ public class ListBoxItemVisual : BaseListBoxItemVisual
 
     private void ApplyPalette(Color fill, Color text)
     {
-        _fill.Color = fill;
+        _fill.FillColor = fill;
         TextInstance.Color = text;
     }
 }

--- a/Themes/Gum.Themes.Neon.MonoGame/ListBoxVisual.cs
+++ b/Themes/Gum.Themes.Neon.MonoGame/ListBoxVisual.cs
@@ -18,9 +18,9 @@ public class ListBoxVisual : BaseListBoxVisual
     private const float FocusRingInset = 4f;
     private const float FocusRingThickness = 1f;
 
-    private readonly RoundedRectangleRuntime _focusRing;
-    private readonly RoundedRectangleRuntime _fill;
-    private readonly RoundedRectangleRuntime _border;
+    private readonly RectangleRuntime _focusRing;
+    private readonly RectangleRuntime _fill;
+    private readonly RectangleRuntime _border;
 
     public ListBoxVisual(bool fullInstantiation = true, bool tryCreateFormsObject = true)
         : base(fullInstantiation, tryCreateFormsObject)
@@ -52,9 +52,9 @@ public class ListBoxVisual : BaseListBoxVisual
         WireStates();
     }
 
-    private static RoundedRectangleRuntime CreateFill()
+    private static RectangleRuntime CreateFill()
     {
-        RoundedRectangleRuntime fill = new RoundedRectangleRuntime();
+        RectangleRuntime fill = new RectangleRuntime();
         fill.Name = "NeonListBoxFill";
         fill.X = 0;
         fill.Y = 0;
@@ -68,13 +68,14 @@ public class ListBoxVisual : BaseListBoxVisual
         fill.HeightUnits = DimensionUnitType.RelativeToParent;
         fill.CornerRadius = CornerRadius;
         fill.IsFilled = true;
-        fill.Color = NeonColors.Surface1;
+        fill.FillColor = NeonColors.Surface1;
+        fill.StrokeWidth = 0;
         return fill;
     }
 
-    private static RoundedRectangleRuntime CreateBorder()
+    private static RectangleRuntime CreateBorder()
     {
-        RoundedRectangleRuntime border = new RoundedRectangleRuntime();
+        RectangleRuntime border = new RectangleRuntime();
         border.Name = "NeonListBoxBorder";
         border.X = 0;
         border.Y = 0;
@@ -90,13 +91,13 @@ public class ListBoxVisual : BaseListBoxVisual
         border.IsFilled = false;
         border.StrokeWidth = BorderThickness;
         border.StrokeWidthUnits = DimensionUnitType.Absolute;
-        border.Color = NeonColors.Border;
+        border.StrokeColor = NeonColors.Border;
         return border;
     }
 
-    private static RoundedRectangleRuntime CreateFocusRing()
+    private static RectangleRuntime CreateFocusRing()
     {
-        RoundedRectangleRuntime ring = new RoundedRectangleRuntime();
+        RectangleRuntime ring = new RectangleRuntime();
         ring.Name = "NeonListBoxFocusRing";
         ring.X = 0;
         ring.Y = 0;
@@ -112,7 +113,7 @@ public class ListBoxVisual : BaseListBoxVisual
         ring.IsFilled = false;
         ring.StrokeWidth = FocusRingThickness;
         ring.StrokeWidthUnits = DimensionUnitType.Absolute;
-        ring.Color = NeonPalette.FocusRing;
+        ring.StrokeColor = NeonPalette.FocusRing;
         ring.Visible = false;
         return ring;
     }
@@ -143,8 +144,8 @@ public class ListBoxVisual : BaseListBoxVisual
 
     private void ApplyPalette(Color border, bool showFocusRing, bool fillDisabled = false)
     {
-        _fill.Color = fillDisabled ? NeonColors.Disabled : NeonColors.Surface1;
-        _border.Color = border;
+        _fill.FillColor = fillDisabled ? NeonColors.Disabled : NeonColors.Surface1;
+        _border.StrokeColor = border;
         _focusRing.Visible = showFocusRing;
     }
 }

--- a/Themes/Gum.Themes.Neon.MonoGame/MenuItemVisual.cs
+++ b/Themes/Gum.Themes.Neon.MonoGame/MenuItemVisual.cs
@@ -20,7 +20,7 @@ public class MenuItemVisual : BaseMenuItemVisual
     private const float HorizontalPadding = 12f;
     private const float VerticalPadding = 6f;
 
-    private readonly ColoredRectangleRuntime _fill;
+    private readonly RectangleRuntime _fill;
 
     public MenuItemVisual(bool fullInstantiation = true, bool tryCreateFormsObject = true)
         : base(fullInstantiation, tryCreateFormsObject: false)
@@ -90,14 +90,14 @@ public class MenuItemVisual : BaseMenuItemVisual
 
     private void ApplyPalette(Color fill, Color text)
     {
-        _fill.Color = fill;
+        _fill.FillColor = fill;
         TextInstance.Color = text;
         SubmenuIndicatorInstance.Color = text;
     }
 
-    private static ColoredRectangleRuntime CreateFill()
+    private static RectangleRuntime CreateFill()
     {
-        ColoredRectangleRuntime fill = new ColoredRectangleRuntime();
+        RectangleRuntime fill = new RectangleRuntime();
         fill.Name = "NeonMenuItemFill";
         fill.X = 0;
         fill.Y = 0;
@@ -109,7 +109,9 @@ public class MenuItemVisual : BaseMenuItemVisual
         fill.Height = 0;
         fill.WidthUnits = DimensionUnitType.RelativeToParent;
         fill.HeightUnits = DimensionUnitType.RelativeToParent;
-        fill.Color = Color.Transparent;
+        fill.IsFilled = true;
+        fill.FillColor = Color.Transparent;
+        fill.StrokeWidth = 0;
         return fill;
     }
 }

--- a/Themes/Gum.Themes.Neon.MonoGame/MenuVisual.cs
+++ b/Themes/Gum.Themes.Neon.MonoGame/MenuVisual.cs
@@ -15,8 +15,8 @@ public class MenuVisual : BaseMenuVisual
 {
     private const float SeparatorHeight = 2f;
 
-    private readonly ColoredRectangleRuntime _fill;
-    private readonly ColoredRectangleRuntime _bottomSeparator;
+    private readonly RectangleRuntime _fill;
+    private readonly RectangleRuntime _bottomSeparator;
 
     public MenuVisual(bool fullInstantiation = true, bool tryCreateFormsObject = true)
         : base(fullInstantiation, tryCreateFormsObject)
@@ -33,9 +33,9 @@ public class MenuVisual : BaseMenuVisual
         AddChild(InnerPanelInstance);
     }
 
-    private static ColoredRectangleRuntime CreateFill()
+    private static RectangleRuntime CreateFill()
     {
-        ColoredRectangleRuntime fill = new ColoredRectangleRuntime();
+        RectangleRuntime fill = new RectangleRuntime();
         fill.Name = "NeonMenuFill";
         fill.X = 0;
         fill.Y = 0;
@@ -47,13 +47,15 @@ public class MenuVisual : BaseMenuVisual
         fill.Height = 0;
         fill.WidthUnits = DimensionUnitType.RelativeToParent;
         fill.HeightUnits = DimensionUnitType.RelativeToParent;
-        fill.Color = NeonColors.Surface1;
+        fill.IsFilled = true;
+        fill.FillColor = NeonColors.Surface1;
+        fill.StrokeWidth = 0;
         return fill;
     }
 
-    private static ColoredRectangleRuntime CreateBottomSeparator()
+    private static RectangleRuntime CreateBottomSeparator()
     {
-        ColoredRectangleRuntime separator = new ColoredRectangleRuntime();
+        RectangleRuntime separator = new RectangleRuntime();
         separator.Name = "NeonMenuBottomSeparator";
         separator.X = 0;
         separator.Y = 0;
@@ -65,7 +67,9 @@ public class MenuVisual : BaseMenuVisual
         separator.Height = SeparatorHeight;
         separator.WidthUnits = DimensionUnitType.RelativeToParent;
         separator.HeightUnits = DimensionUnitType.Absolute;
-        separator.Color = NeonColors.Border;
+        separator.IsFilled = true;
+        separator.FillColor = NeonColors.Border;
+        separator.StrokeWidth = 0;
         return separator;
     }
 }

--- a/Themes/Gum.Themes.Neon.MonoGame/NeonTextInputDecoration.cs
+++ b/Themes/Gum.Themes.Neon.MonoGame/NeonTextInputDecoration.cs
@@ -21,8 +21,8 @@ internal sealed class NeonTextInputDecoration
     private const float CornerRadius = 1f;
     private const float BorderThickness = 1f;
 
-    private readonly RoundedRectangleRuntime _fill;
-    private readonly RoundedRectangleRuntime _border;
+    private readonly RectangleRuntime _fill;
+    private readonly RectangleRuntime _border;
 
     public NeonTextInputDecoration(TextBoxBaseVisual host)
     {
@@ -43,9 +43,9 @@ internal sealed class NeonTextInputDecoration
         WireStates(host);
     }
 
-    private static RoundedRectangleRuntime CreateFill()
+    private static RectangleRuntime CreateFill()
     {
-        RoundedRectangleRuntime fill = new RoundedRectangleRuntime();
+        RectangleRuntime fill = new RectangleRuntime();
         fill.Name = "NeonTextInputFill";
         fill.X = 0;
         fill.Y = 0;
@@ -59,13 +59,14 @@ internal sealed class NeonTextInputDecoration
         fill.HeightUnits = DimensionUnitType.RelativeToParent;
         fill.CornerRadius = CornerRadius;
         fill.IsFilled = true;
-        fill.Color = NeonColors.Surface1;
+        fill.FillColor = NeonColors.Surface1;
+        fill.StrokeWidth = 0;
         return fill;
     }
 
-    private static RoundedRectangleRuntime CreateBorder()
+    private static RectangleRuntime CreateBorder()
     {
-        RoundedRectangleRuntime border = new RoundedRectangleRuntime();
+        RectangleRuntime border = new RectangleRuntime();
         border.Name = "NeonTextInputBorder";
         border.X = 0;
         border.Y = 0;
@@ -81,7 +82,7 @@ internal sealed class NeonTextInputDecoration
         border.IsFilled = false;
         border.StrokeWidth = BorderThickness;
         border.StrokeWidthUnits = DimensionUnitType.Absolute;
-        border.Color = NeonColors.Border;
+        border.StrokeColor = NeonColors.Border;
         return border;
     }
 
@@ -115,8 +116,8 @@ internal sealed class NeonTextInputDecoration
     private void Apply(TextBoxBaseVisual host, Color fill, Color border, Color text,
         Color placeholder, Color caret, Color selection)
     {
-        _fill.Color = fill;
-        _border.Color = border;
+        _fill.FillColor = fill;
+        _border.StrokeColor = border;
         host.TextInstance.Color = text;
         host.PlaceholderTextInstance.Color = placeholder;
         host.CaretInstance.Color = caret;

--- a/Themes/Gum.Themes.Neon.MonoGame/NeonTheme.cs
+++ b/Themes/Gum.Themes.Neon.MonoGame/NeonTheme.cs
@@ -76,7 +76,7 @@ public static class NeonTheme
         BmfcSave.AddCharacters("✓✕▼▲◀▶");
 
         // Neon's visuals build their bodies out of Apos.Shapes-backed
-        // RoundedRectangleRuntime / ColoredCircleRuntime instances, which
+        // RectangleRuntime / CircleRuntime instances, which
         // require ShapeRenderer to be initialized. Guard in case the host app
         // already initialized it (mixing themes / using shape runtimes
         // elsewhere).
@@ -236,5 +236,16 @@ public static class NeonTheme
 
         FrameworkElement.DefaultFormsTemplates[typeof(Tooltip)] =
             new VisualTemplate((_, c) => new TooltipVisual(tryCreateFormsObject: c));
+
+        // Controls Neon does not restyle are pinned to their stock V3 visuals so
+        // NeonTheme.Apply fully specifies the template set. FrameworkElement.DefaultFormsTemplates
+        // is global static state; without re-registering these, re-applying a theme at runtime
+        // (theme switching) would leave a previously-applied theme's visual in place for these
+        // controls. These match what a single-theme Neon run already falls back to.
+        FrameworkElement.DefaultFormsTemplates[typeof(ItemsControl)] =
+            new VisualTemplate((_, c) => new Gum.Forms.DefaultVisuals.V3.ItemsControlVisual(tryCreateFormsObject: c));
+
+        FrameworkElement.DefaultFormsTemplates[typeof(Gum.Forms.Controls.Games.DialogBox)] =
+            new VisualTemplate((_, c) => new Gum.Forms.DefaultVisuals.V3.DialogBoxVisual(tryCreateFormsObject: c));
     }
 }

--- a/Themes/Gum.Themes.Neon.MonoGame/RadioButtonVisual.cs
+++ b/Themes/Gum.Themes.Neon.MonoGame/RadioButtonVisual.cs
@@ -20,10 +20,10 @@ public class RadioButtonVisual : BaseRadioButtonVisual
     private const float FocusRingThickness = 1f;
     private const float BoxToLabelGap = 8f;
 
-    private readonly ColoredCircleRuntime _focusRing;
-    private readonly ColoredCircleRuntime _outerFill;
-    private readonly ColoredCircleRuntime _outerBorder;
-    private readonly ColoredCircleRuntime _innerDot;
+    private readonly CircleRuntime _focusRing;
+    private readonly CircleRuntime _outerFill;
+    private readonly CircleRuntime _outerBorder;
+    private readonly CircleRuntime _innerDot;
 
     public RadioButtonVisual(bool fullInstantiation = true, bool tryCreateFormsObject = true)
         : base(fullInstantiation, tryCreateFormsObject)
@@ -49,9 +49,9 @@ public class RadioButtonVisual : BaseRadioButtonVisual
         WireStates();
     }
 
-    private static ColoredCircleRuntime CreateOuterFill()
+    private static CircleRuntime CreateOuterFill()
     {
-        ColoredCircleRuntime c = new ColoredCircleRuntime();
+        CircleRuntime c = new CircleRuntime();
         c.Name = "NeonRadioOuterFill";
         c.X = 0;
         c.Y = 0;
@@ -64,13 +64,14 @@ public class RadioButtonVisual : BaseRadioButtonVisual
         c.WidthUnits = DimensionUnitType.Absolute;
         c.HeightUnits = DimensionUnitType.Absolute;
         c.IsFilled = true;
-        c.Color = NeonColors.Surface1;
+        c.FillColor = NeonColors.Surface1;
+        c.StrokeWidth = 0;
         return c;
     }
 
-    private static ColoredCircleRuntime CreateOuterBorder()
+    private static CircleRuntime CreateOuterBorder()
     {
-        ColoredCircleRuntime c = new ColoredCircleRuntime();
+        CircleRuntime c = new CircleRuntime();
         c.Name = "NeonRadioOuterBorder";
         c.X = 0;
         c.Y = 0;
@@ -85,13 +86,13 @@ public class RadioButtonVisual : BaseRadioButtonVisual
         c.IsFilled = false;
         c.StrokeWidth = BorderThickness;
         c.StrokeWidthUnits = DimensionUnitType.Absolute;
-        c.Color = NeonColors.Border;
+        c.StrokeColor = NeonColors.Border;
         return c;
     }
 
-    private static ColoredCircleRuntime CreateFocusRing()
+    private static CircleRuntime CreateFocusRing()
     {
-        ColoredCircleRuntime c = new ColoredCircleRuntime();
+        CircleRuntime c = new CircleRuntime();
         c.Name = "NeonRadioFocusRing";
         c.X = -FocusRingInset;
         c.Y = 0;
@@ -106,15 +107,15 @@ public class RadioButtonVisual : BaseRadioButtonVisual
         c.IsFilled = false;
         c.StrokeWidth = FocusRingThickness;
         c.StrokeWidthUnits = DimensionUnitType.Absolute;
-        c.Color = NeonPalette.FocusRing;
+        c.StrokeColor = NeonPalette.FocusRing;
         c.Visible = false;
         return c;
     }
 
-    private static ColoredCircleRuntime CreateInnerDot()
+    private static CircleRuntime CreateInnerDot()
     {
         const float inset = (OuterSize - InnerSize) / 2f;
-        ColoredCircleRuntime dot = new ColoredCircleRuntime();
+        CircleRuntime dot = new CircleRuntime();
         dot.Name = "NeonRadioInnerDot";
         dot.X = inset;
         dot.Y = 0;
@@ -127,7 +128,8 @@ public class RadioButtonVisual : BaseRadioButtonVisual
         dot.WidthUnits = DimensionUnitType.Absolute;
         dot.HeightUnits = DimensionUnitType.Absolute;
         dot.IsFilled = true;
-        dot.Color = NeonColors.Accent;
+        dot.FillColor = NeonColors.Accent;
+        dot.StrokeWidth = 0;
         dot.Visible = false;
         return dot;
     }
@@ -201,13 +203,13 @@ public class RadioButtonVisual : BaseRadioButtonVisual
     private void Apply(Color fill, Color border, Color text, bool innerVisible, bool ring,
         Color? innerColor = null)
     {
-        _outerFill.Color = fill;
-        _outerBorder.Color = border;
+        _outerFill.FillColor = fill;
+        _outerBorder.StrokeColor = border;
         TextInstance.Color = text;
         _innerDot.Visible = innerVisible;
         if (innerColor.HasValue)
         {
-            _innerDot.Color = innerColor.Value;
+            _innerDot.FillColor = innerColor.Value;
         }
         _focusRing.Visible = ring;
     }

--- a/Themes/Gum.Themes.Neon.MonoGame/ScrollBarThumbVisual.cs
+++ b/Themes/Gum.Themes.Neon.MonoGame/ScrollBarThumbVisual.cs
@@ -20,7 +20,7 @@ public class ScrollBarThumbVisual : InteractiveGue
 {
     private const float CornerRadius = 1f;
 
-    private readonly RoundedRectangleRuntime _body;
+    private readonly RectangleRuntime _body;
 
     private StateSaveCategory _buttonCategory = null!;
 
@@ -38,9 +38,9 @@ public class ScrollBarThumbVisual : InteractiveGue
         WireStates();
     }
 
-    private static RoundedRectangleRuntime CreateBody()
+    private static RectangleRuntime CreateBody()
     {
-        RoundedRectangleRuntime body = new RoundedRectangleRuntime();
+        RectangleRuntime body = new RectangleRuntime();
         body.Name = "NeonScrollThumbBody";
         body.X = 0;
         body.Y = 0;
@@ -54,7 +54,8 @@ public class ScrollBarThumbVisual : InteractiveGue
         body.HeightUnits = DimensionUnitType.RelativeToParent;
         body.CornerRadius = CornerRadius;
         body.IsFilled = true;
-        body.Color = NeonPalette.ScrollThumb;
+        body.FillColor = NeonPalette.ScrollThumb;
+        body.StrokeWidth = 0;
         return body;
     }
 
@@ -67,25 +68,25 @@ public class ScrollBarThumbVisual : InteractiveGue
         // Muted steel-blue at rest. Hover/push step toward cyan but stay a
         // shade below full Accent so the scroll bar reads as secondary chrome.
         Add(_buttonCategory, FrameworkElement.EnabledStateName,
-            () => _body.Color = NeonPalette.ScrollThumb);
+            () => _body.FillColor = NeonPalette.ScrollThumb);
 
         Add(_buttonCategory, FrameworkElement.HighlightedStateName,
-            () => _body.Color = NeonPalette.ScrollThumbHover);
+            () => _body.FillColor = NeonPalette.ScrollThumbHover);
 
         Add(_buttonCategory, FrameworkElement.PushedStateName,
-            () => _body.Color = NeonPalette.ScrollThumbHover);
+            () => _body.FillColor = NeonPalette.ScrollThumbHover);
 
         Add(_buttonCategory, FrameworkElement.FocusedStateName,
-            () => _body.Color = NeonPalette.ScrollThumb);
+            () => _body.FillColor = NeonPalette.ScrollThumb);
 
         Add(_buttonCategory, FrameworkElement.HighlightedFocusedStateName,
-            () => _body.Color = NeonPalette.ScrollThumbHover);
+            () => _body.FillColor = NeonPalette.ScrollThumbHover);
 
         Add(_buttonCategory, FrameworkElement.DisabledStateName,
-            () => _body.Color = NeonColors.Disabled);
+            () => _body.FillColor = NeonColors.Disabled);
 
         Add(_buttonCategory, FrameworkElement.DisabledFocusedStateName,
-            () => _body.Color = NeonColors.Disabled);
+            () => _body.FillColor = NeonColors.Disabled);
     }
 
     private static void Add(StateSaveCategory category, string name, System.Action apply)

--- a/Themes/Gum.Themes.Neon.MonoGame/ScrollBarVisual.cs
+++ b/Themes/Gum.Themes.Neon.MonoGame/ScrollBarVisual.cs
@@ -20,8 +20,8 @@ public class ScrollBarVisual : BaseScrollBarVisual
     private const float FrameBorderThickness = 2f;
 
     private readonly ScrollBarThumbVisual _thumb;
-    private readonly RoundedRectangleRuntime _frameFill;
-    private readonly RoundedRectangleRuntime _frameBorder;
+    private readonly RectangleRuntime _frameFill;
+    private readonly RectangleRuntime _frameBorder;
     private bool _isHorizontal;
 
     public ScrollBarVisual(bool fullInstantiation = true, bool tryCreateFormsObject = true)
@@ -139,9 +139,9 @@ public class ScrollBarVisual : BaseScrollBarVisual
         }
     }
 
-    private static RoundedRectangleRuntime CreateFrameFill()
+    private static RectangleRuntime CreateFrameFill()
     {
-        RoundedRectangleRuntime fill = new RoundedRectangleRuntime();
+        RectangleRuntime fill = new RectangleRuntime();
         fill.Name = "NeonScrollBarFrameFill";
         fill.X = 0;
         fill.Y = 0;
@@ -155,13 +155,14 @@ public class ScrollBarVisual : BaseScrollBarVisual
         fill.HeightUnits = DimensionUnitType.RelativeToParent;
         fill.CornerRadius = FrameCornerRadius;
         fill.IsFilled = true;
-        fill.Color = NeonColors.Surface1;
+        fill.FillColor = NeonColors.Surface1;
+        fill.StrokeWidth = 0;
         return fill;
     }
 
-    private static RoundedRectangleRuntime CreateFrameBorder()
+    private static RectangleRuntime CreateFrameBorder()
     {
-        RoundedRectangleRuntime border = new RoundedRectangleRuntime();
+        RectangleRuntime border = new RectangleRuntime();
         border.Name = "NeonScrollBarFrameBorder";
         border.X = 0;
         border.Y = 0;
@@ -177,7 +178,7 @@ public class ScrollBarVisual : BaseScrollBarVisual
         border.IsFilled = false;
         border.StrokeWidth = FrameBorderThickness;
         border.StrokeWidthUnits = DimensionUnitType.Absolute;
-        border.Color = NeonColors.Border;
+        border.StrokeColor = NeonColors.Border;
         return border;
     }
 }

--- a/Themes/Gum.Themes.Neon.MonoGame/ScrollViewerVisual.cs
+++ b/Themes/Gum.Themes.Neon.MonoGame/ScrollViewerVisual.cs
@@ -19,9 +19,9 @@ public class ScrollViewerVisual : BaseScrollViewerVisual
     private const float FocusRingInset = 4f;
     private const float FocusRingThickness = 1f;
 
-    private readonly RoundedRectangleRuntime _focusRing;
-    private readonly RoundedRectangleRuntime _fill;
-    private readonly RoundedRectangleRuntime _border;
+    private readonly RectangleRuntime _focusRing;
+    private readonly RectangleRuntime _fill;
+    private readonly RectangleRuntime _border;
 
     public ScrollViewerVisual(bool fullInstantiation = true, bool tryCreateFormsObject = true)
         : base(fullInstantiation, tryCreateFormsObject)
@@ -50,9 +50,9 @@ public class ScrollViewerVisual : BaseScrollViewerVisual
         WireStates();
     }
 
-    private static RoundedRectangleRuntime CreateFill()
+    private static RectangleRuntime CreateFill()
     {
-        RoundedRectangleRuntime fill = new RoundedRectangleRuntime();
+        RectangleRuntime fill = new RectangleRuntime();
         fill.Name = "NeonScrollViewerFill";
         fill.X = 0;
         fill.Y = 0;
@@ -66,13 +66,14 @@ public class ScrollViewerVisual : BaseScrollViewerVisual
         fill.HeightUnits = DimensionUnitType.RelativeToParent;
         fill.CornerRadius = CornerRadius;
         fill.IsFilled = true;
-        fill.Color = NeonColors.Surface1;
+        fill.FillColor = NeonColors.Surface1;
+        fill.StrokeWidth = 0;
         return fill;
     }
 
-    private static RoundedRectangleRuntime CreateBorder()
+    private static RectangleRuntime CreateBorder()
     {
-        RoundedRectangleRuntime border = new RoundedRectangleRuntime();
+        RectangleRuntime border = new RectangleRuntime();
         border.Name = "NeonScrollViewerBorder";
         border.X = 0;
         border.Y = 0;
@@ -88,13 +89,13 @@ public class ScrollViewerVisual : BaseScrollViewerVisual
         border.IsFilled = false;
         border.StrokeWidth = BorderThickness;
         border.StrokeWidthUnits = DimensionUnitType.Absolute;
-        border.Color = NeonColors.Border;
+        border.StrokeColor = NeonColors.Border;
         return border;
     }
 
-    private static RoundedRectangleRuntime CreateFocusRing()
+    private static RectangleRuntime CreateFocusRing()
     {
-        RoundedRectangleRuntime ring = new RoundedRectangleRuntime();
+        RectangleRuntime ring = new RectangleRuntime();
         ring.Name = "NeonScrollViewerFocusRing";
         ring.X = 0;
         ring.Y = 0;
@@ -110,7 +111,7 @@ public class ScrollViewerVisual : BaseScrollViewerVisual
         ring.IsFilled = false;
         ring.StrokeWidth = FocusRingThickness;
         ring.StrokeWidthUnits = DimensionUnitType.Absolute;
-        ring.Color = NeonPalette.FocusRing;
+        ring.StrokeColor = NeonPalette.FocusRing;
         ring.Visible = false;
         return ring;
     }
@@ -119,13 +120,13 @@ public class ScrollViewerVisual : BaseScrollViewerVisual
     {
         States.Enabled.Apply = () =>
         {
-            _border.Color = NeonColors.Border;
+            _border.StrokeColor = NeonColors.Border;
             _focusRing.Visible = false;
         };
 
         States.Focused.Apply = () =>
         {
-            _border.Color = NeonColors.Accent;
+            _border.StrokeColor = NeonColors.Accent;
             _focusRing.Visible = true;
         };
     }

--- a/Themes/Gum.Themes.Neon.MonoGame/SliderThumbVisual.cs
+++ b/Themes/Gum.Themes.Neon.MonoGame/SliderThumbVisual.cs
@@ -31,9 +31,9 @@ public class SliderThumbVisual : InteractiveGue
     private const float ShadowBlur = 32f;
     private static readonly Color ShadowColor = new Color(0, 229, 255, 180);
 
-    private readonly ColoredCircleRuntime _focusRing;
-    private readonly ColoredCircleRuntime _body;
-    private readonly ColoredCircleRuntime _border;
+    private readonly CircleRuntime _focusRing;
+    private readonly CircleRuntime _body;
+    private readonly CircleRuntime _border;
 
     private StateSaveCategory _buttonCategory = null!;
 
@@ -57,9 +57,9 @@ public class SliderThumbVisual : InteractiveGue
         WireStates();
     }
 
-    private static ColoredCircleRuntime CreateBody()
+    private static CircleRuntime CreateBody()
     {
-        ColoredCircleRuntime body = new ColoredCircleRuntime();
+        CircleRuntime body = new CircleRuntime();
         body.Name = "NeonSliderThumbBody";
         body.X = 0;
         body.Y = 0;
@@ -72,21 +72,21 @@ public class SliderThumbVisual : InteractiveGue
         body.WidthUnits = DimensionUnitType.RelativeToParent;
         body.HeightUnits = DimensionUnitType.RelativeToParent;
         body.IsFilled = true;
-        body.Color = NeonColors.Surface1;
+        body.FillColor = NeonColors.Surface1;
+        body.StrokeWidth = 0;
         // Native Gaussian drop shadow under the thumb — replaces the prior
         // single-circle approximation. Toggled per state via WireStates.
         body.HasDropshadow = true;
         body.DropshadowColor = ShadowColor;
         body.DropshadowOffsetX = 0f;
         body.DropshadowOffsetY = ShadowOffsetY;
-        body.DropshadowBlurX = ShadowBlur;
-        body.DropshadowBlurY = ShadowBlur;
+        body.DropshadowBlur = ShadowBlur;
         return body;
     }
 
-    private static ColoredCircleRuntime CreateBorder()
+    private static CircleRuntime CreateBorder()
     {
-        ColoredCircleRuntime border = new ColoredCircleRuntime();
+        CircleRuntime border = new CircleRuntime();
         border.Name = "NeonSliderThumbBorder";
         border.X = 0;
         border.Y = 0;
@@ -101,13 +101,13 @@ public class SliderThumbVisual : InteractiveGue
         border.IsFilled = false;
         border.StrokeWidth = BorderThickness;
         border.StrokeWidthUnits = DimensionUnitType.Absolute;
-        border.Color = NeonColors.Accent;
+        border.StrokeColor = NeonColors.Accent;
         return border;
     }
 
-    private static ColoredCircleRuntime CreateFocusRing()
+    private static CircleRuntime CreateFocusRing()
     {
-        ColoredCircleRuntime ring = new ColoredCircleRuntime();
+        CircleRuntime ring = new CircleRuntime();
         ring.Name = "NeonSliderThumbFocusRing";
         ring.X = 0;
         ring.Y = 0;
@@ -122,7 +122,7 @@ public class SliderThumbVisual : InteractiveGue
         ring.IsFilled = false;
         ring.StrokeWidth = FocusRingThickness;
         ring.StrokeWidthUnits = DimensionUnitType.Absolute;
-        ring.Color = NeonPalette.FocusRing;
+        ring.StrokeColor = NeonPalette.FocusRing;
         ring.Visible = false;
         return ring;
     }
@@ -167,9 +167,9 @@ public class SliderThumbVisual : InteractiveGue
 
     private void Apply(Color body, Color border, bool ring, bool showShadow)
     {
-        _body.Color = body;
+        _body.FillColor = body;
         _body.HasDropshadow = showShadow;
-        _border.Color = border;
+        _border.StrokeColor = border;
         _focusRing.Visible = ring;
     }
 }

--- a/Themes/Gum.Themes.Neon.MonoGame/SliderVisual.cs
+++ b/Themes/Gum.Themes.Neon.MonoGame/SliderVisual.cs
@@ -20,8 +20,8 @@ public class SliderVisual : BaseSliderVisual
     private const float TrackHeight = 8f;
     private const float TrackCornerRadius = 2f;
 
-    private readonly RoundedRectangleRuntime _track;
-    private readonly RoundedRectangleRuntime _fill;
+    private readonly RectangleRuntime _track;
+    private readonly RectangleRuntime _fill;
     private readonly SliderThumbVisual _thumb;
 
     public SliderVisual(bool fullInstantiation = true, bool tryCreateFormsObject = true)
@@ -94,9 +94,9 @@ public class SliderVisual : BaseSliderVisual
         _fill.Width = (float)(pct * 100.0);
     }
 
-    private static RoundedRectangleRuntime CreateTrack()
+    private static RectangleRuntime CreateTrack()
     {
-        RoundedRectangleRuntime track = new RoundedRectangleRuntime();
+        RectangleRuntime track = new RectangleRuntime();
         track.Name = "NeonSliderTrack";
         track.X = 0;
         track.Y = 0;
@@ -110,13 +110,14 @@ public class SliderVisual : BaseSliderVisual
         track.HeightUnits = DimensionUnitType.Absolute;
         track.CornerRadius = TrackCornerRadius;
         track.IsFilled = true;
-        track.Color = NeonColors.AccentDim;
+        track.FillColor = NeonColors.AccentDim;
+        track.StrokeWidth = 0;
         return track;
     }
 
-    private static RoundedRectangleRuntime CreateFill()
+    private static RectangleRuntime CreateFill()
     {
-        RoundedRectangleRuntime fill = new RoundedRectangleRuntime();
+        RectangleRuntime fill = new RectangleRuntime();
         fill.Name = "NeonSliderFill";
         fill.X = 0;
         fill.Y = 0;
@@ -130,7 +131,8 @@ public class SliderVisual : BaseSliderVisual
         fill.HeightUnits = DimensionUnitType.Absolute;
         fill.CornerRadius = TrackCornerRadius;
         fill.IsFilled = true;
-        fill.Color = NeonColors.Accent;
+        fill.FillColor = NeonColors.Accent;
+        fill.StrokeWidth = 0;
         return fill;
     }
 
@@ -147,7 +149,7 @@ public class SliderVisual : BaseSliderVisual
 
     private void ApplyTrack(Color trackFill, Color fillBar)
     {
-        _track.Color = trackFill;
-        _fill.Color = fillBar;
+        _track.FillColor = trackFill;
+        _fill.FillColor = fillBar;
     }
 }

--- a/Themes/Gum.Themes.Neon.MonoGame/SplitterVisual.cs
+++ b/Themes/Gum.Themes.Neon.MonoGame/SplitterVisual.cs
@@ -13,7 +13,7 @@ namespace Gum.Themes.Neon;
 /// </summary>
 public class SplitterVisual : BaseSplitterVisual
 {
-    private readonly ColoredRectangleRuntime _fill;
+    private readonly RectangleRuntime _fill;
 
     public SplitterVisual(bool fullInstantiation = true, bool tryCreateFormsObject = true)
         : base(fullInstantiation, tryCreateFormsObject)
@@ -24,9 +24,9 @@ public class SplitterVisual : BaseSplitterVisual
         AddChild(_fill);
     }
 
-    private static ColoredRectangleRuntime CreateFill()
+    private static RectangleRuntime CreateFill()
     {
-        ColoredRectangleRuntime fill = new ColoredRectangleRuntime();
+        RectangleRuntime fill = new RectangleRuntime();
         fill.Name = "NeonSplitterFill";
         fill.X = 0;
         fill.Y = 0;
@@ -38,7 +38,9 @@ public class SplitterVisual : BaseSplitterVisual
         fill.Height = 0;
         fill.WidthUnits = DimensionUnitType.RelativeToParent;
         fill.HeightUnits = DimensionUnitType.RelativeToParent;
-        fill.Color = NeonColors.AccentDim;
+        fill.IsFilled = true;
+        fill.FillColor = NeonColors.AccentDim;
+        fill.StrokeWidth = 0;
         return fill;
     }
 }

--- a/Themes/Gum.Themes.Neon.MonoGame/ToggleButtonVisual.cs
+++ b/Themes/Gum.Themes.Neon.MonoGame/ToggleButtonVisual.cs
@@ -29,9 +29,9 @@ public class ToggleButtonVisual : BaseToggleButtonVisual
     private const float ShadowBlur = 36f;
     private static readonly Color ShadowColor = NeonPalette.GlowStrong;
 
-    private readonly RoundedRectangleRuntime _focusRing;
-    private readonly RoundedRectangleRuntime _fill;
-    private readonly RoundedRectangleRuntime _border;
+    private readonly RectangleRuntime _focusRing;
+    private readonly RectangleRuntime _fill;
+    private readonly RectangleRuntime _border;
 
     public ToggleButtonVisual(bool fullInstantiation = true, bool tryCreateFormsObject = true)
         : base(fullInstantiation, tryCreateFormsObject)
@@ -64,9 +64,9 @@ public class ToggleButtonVisual : BaseToggleButtonVisual
         WireStates();
     }
 
-    private static RoundedRectangleRuntime CreateFill()
+    private static RectangleRuntime CreateFill()
     {
-        RoundedRectangleRuntime fill = new RoundedRectangleRuntime();
+        RectangleRuntime fill = new RectangleRuntime();
         fill.Name = "NeonToggleFill";
         fill.X = 0;
         fill.Y = 0;
@@ -80,19 +80,19 @@ public class ToggleButtonVisual : BaseToggleButtonVisual
         fill.HeightUnits = DimensionUnitType.RelativeToParent;
         fill.CornerRadius = CornerRadius;
         fill.IsFilled = true;
-        fill.Color = NeonColors.Surface1;
+        fill.FillColor = NeonColors.Surface1;
+        fill.StrokeWidth = 0;
         fill.HasDropshadow = true;
         fill.DropshadowColor = ShadowColor;
         fill.DropshadowOffsetX = 0f;
         fill.DropshadowOffsetY = ShadowOffsetY;
-        fill.DropshadowBlurX = ShadowBlur;
-        fill.DropshadowBlurY = ShadowBlur;
+        fill.DropshadowBlur = ShadowBlur;
         return fill;
     }
 
-    private static RoundedRectangleRuntime CreateBorder()
+    private static RectangleRuntime CreateBorder()
     {
-        RoundedRectangleRuntime border = new RoundedRectangleRuntime();
+        RectangleRuntime border = new RectangleRuntime();
         border.Name = "NeonToggleBorder";
         border.X = 0;
         border.Y = 0;
@@ -108,13 +108,13 @@ public class ToggleButtonVisual : BaseToggleButtonVisual
         border.IsFilled = false;
         border.StrokeWidth = BorderThickness;
         border.StrokeWidthUnits = DimensionUnitType.Absolute;
-        border.Color = NeonColors.Border;
+        border.StrokeColor = NeonColors.Border;
         return border;
     }
 
-    private static RoundedRectangleRuntime CreateFocusRing()
+    private static RectangleRuntime CreateFocusRing()
     {
-        RoundedRectangleRuntime ring = new RoundedRectangleRuntime();
+        RectangleRuntime ring = new RectangleRuntime();
         ring.Name = "NeonToggleFocusRing";
         ring.X = 0;
         ring.Y = 0;
@@ -130,7 +130,7 @@ public class ToggleButtonVisual : BaseToggleButtonVisual
         ring.IsFilled = false;
         ring.StrokeWidth = FocusRingThickness;
         ring.StrokeWidthUnits = DimensionUnitType.Absolute;
-        ring.Color = NeonPalette.FocusRing;
+        ring.StrokeColor = NeonPalette.FocusRing;
         ring.Visible = false;
         return ring;
     }
@@ -203,9 +203,9 @@ public class ToggleButtonVisual : BaseToggleButtonVisual
 
     private void ApplyPalette(Color fill, Color border, Color text, bool showShadow, bool showFocusRing)
     {
-        _fill.Color = fill;
+        _fill.FillColor = fill;
         _fill.HasDropshadow = showShadow;
-        _border.Color = border;
+        _border.StrokeColor = border;
         TextInstance.Color = text;
         _focusRing.Visible = showFocusRing;
     }

--- a/Themes/Gum.Themes.Neon.MonoGame/TooltipVisual.cs
+++ b/Themes/Gum.Themes.Neon.MonoGame/TooltipVisual.cs
@@ -15,8 +15,8 @@ public class TooltipVisual : BaseTooltipVisual
     private const float CornerRadius = 1f;
     private const float BorderThickness = 2f;
 
-    private readonly RoundedRectangleRuntime _fill;
-    private readonly RoundedRectangleRuntime _border;
+    private readonly RectangleRuntime _fill;
+    private readonly RectangleRuntime _border;
 
     public TooltipVisual(bool fullInstantiation = true, bool tryCreateFormsObject = true)
         : base(fullInstantiation, tryCreateFormsObject)
@@ -34,9 +34,9 @@ public class TooltipVisual : BaseTooltipVisual
         TextInstance.Color = NeonColors.Text;
     }
 
-    private static RoundedRectangleRuntime CreateFill()
+    private static RectangleRuntime CreateFill()
     {
-        RoundedRectangleRuntime fill = new RoundedRectangleRuntime();
+        RectangleRuntime fill = new RectangleRuntime();
         fill.Name = "NeonTooltipFill";
         fill.X = 0;
         fill.Y = 0;
@@ -50,13 +50,14 @@ public class TooltipVisual : BaseTooltipVisual
         fill.HeightUnits = DimensionUnitType.RelativeToParent;
         fill.CornerRadius = CornerRadius;
         fill.IsFilled = true;
-        fill.Color = NeonColors.Surface1;
+        fill.FillColor = NeonColors.Surface1;
+        fill.StrokeWidth = 0;
         return fill;
     }
 
-    private static RoundedRectangleRuntime CreateBorder()
+    private static RectangleRuntime CreateBorder()
     {
-        RoundedRectangleRuntime border = new RoundedRectangleRuntime();
+        RectangleRuntime border = new RectangleRuntime();
         border.Name = "NeonTooltipBorder";
         border.X = 0;
         border.Y = 0;
@@ -72,7 +73,7 @@ public class TooltipVisual : BaseTooltipVisual
         border.IsFilled = false;
         border.StrokeWidth = BorderThickness;
         border.StrokeWidthUnits = DimensionUnitType.Absolute;
-        border.Color = NeonColors.Border;
+        border.StrokeColor = NeonColors.Border;
         return border;
     }
 }

--- a/Themes/Gum.Themes.Neon.MonoGame/WindowVisual.cs
+++ b/Themes/Gum.Themes.Neon.MonoGame/WindowVisual.cs
@@ -36,10 +36,10 @@ public class WindowVisual : BaseWindowVisual
     private const float ShadowBlur = 56f;
     private static readonly Color ShadowColor = new Color(0, 229, 255, 130);
 
-    private readonly RoundedRectangleRuntime _fill;
-    private readonly RoundedRectangleRuntime _border;
-    private readonly ColoredRectangleRuntime _titleBarFill;
-    private readonly ColoredRectangleRuntime _titleBarSeparator;
+    private readonly RectangleRuntime _fill;
+    private readonly RectangleRuntime _border;
+    private readonly RectangleRuntime _titleBarFill;
+    private readonly RectangleRuntime _titleBarSeparator;
 
     public WindowVisual(bool fullInstantiation = true, bool tryCreateFormsObject = true)
         : base(fullInstantiation, tryCreateFormsObject)
@@ -81,9 +81,9 @@ public class WindowVisual : BaseWindowVisual
         _titleBarSeparator.Parent = TitleBarInstance.Visual;
     }
 
-    private static RoundedRectangleRuntime CreateFill()
+    private static RectangleRuntime CreateFill()
     {
-        RoundedRectangleRuntime fill = new RoundedRectangleRuntime();
+        RectangleRuntime fill = new RectangleRuntime();
         fill.Name = "NeonWindowFill";
         fill.X = 0;
         fill.Y = 0;
@@ -97,20 +97,20 @@ public class WindowVisual : BaseWindowVisual
         fill.HeightUnits = DimensionUnitType.RelativeToParent;
         fill.CornerRadius = CornerRadius;
         fill.IsFilled = true;
-        fill.Color = NeonColors.Surface1;
+        fill.FillColor = NeonColors.Surface1;
+        fill.StrokeWidth = 0;
         // Native Gaussian drop shadow — replaces the prior three-layer stack.
         fill.HasDropshadow = true;
         fill.DropshadowColor = ShadowColor;
         fill.DropshadowOffsetX = 0f;
         fill.DropshadowOffsetY = ShadowOffsetY;
-        fill.DropshadowBlurX = ShadowBlur;
-        fill.DropshadowBlurY = ShadowBlur;
+        fill.DropshadowBlur = ShadowBlur;
         return fill;
     }
 
-    private static RoundedRectangleRuntime CreateBorder()
+    private static RectangleRuntime CreateBorder()
     {
-        RoundedRectangleRuntime border = new RoundedRectangleRuntime();
+        RectangleRuntime border = new RectangleRuntime();
         border.Name = "NeonWindowBorder";
         border.X = 0;
         border.Y = 0;
@@ -126,15 +126,15 @@ public class WindowVisual : BaseWindowVisual
         border.IsFilled = false;
         border.StrokeWidth = BorderThickness;
         border.StrokeWidthUnits = DimensionUnitType.Absolute;
-        border.Color = NeonColors.Accent;
+        border.StrokeColor = NeonColors.Accent;
         return border;
     }
 
-    private static ColoredRectangleRuntime CreateTitleBarFill()
+    private static RectangleRuntime CreateTitleBarFill()
     {
         // CSS: title bar is flat Surface2 with a cyan separator beneath it
         // (border-bottom:1px solid var(--acc)). No gradient.
-        ColoredRectangleRuntime fill = new ColoredRectangleRuntime();
+        RectangleRuntime fill = new RectangleRuntime();
         fill.Name = "NeonWindowTitleBarFill";
         fill.X = 0;
         fill.Y = 0;
@@ -151,13 +151,15 @@ public class WindowVisual : BaseWindowVisual
         // dissolved into the body. Tinting with the translucent cyan accent
         // (AccentDim) gives the bar a recognizable header weight without
         // departing from the palette.
-        fill.Color = NeonColors.AccentDim;
+        fill.IsFilled = true;
+        fill.FillColor = NeonColors.AccentDim;
+        fill.StrokeWidth = 0;
         return fill;
     }
 
-    private static ColoredRectangleRuntime CreateTitleBarSeparator()
+    private static RectangleRuntime CreateTitleBarSeparator()
     {
-        ColoredRectangleRuntime separator = new ColoredRectangleRuntime();
+        RectangleRuntime separator = new RectangleRuntime();
         separator.Name = "NeonWindowTitleBarSeparator";
         separator.X = 0;
         separator.Y = 0;
@@ -169,7 +171,9 @@ public class WindowVisual : BaseWindowVisual
         separator.Height = TitleBarSeparatorHeight;
         separator.WidthUnits = DimensionUnitType.RelativeToParent;
         separator.HeightUnits = DimensionUnitType.Absolute;
-        separator.Color = NeonColors.Accent;
+        separator.IsFilled = true;
+        separator.FillColor = NeonColors.Accent;
+        separator.StrokeWidth = 0;
         return separator;
     }
 }

--- a/Themes/Gum.Themes.Retro95.MonoGame/CheckBoxVisual.cs
+++ b/Themes/Gum.Themes.Retro95.MonoGame/CheckBoxVisual.cs
@@ -24,7 +24,7 @@ public class CheckBoxVisual : BaseCheckBoxVisual
     private readonly ContainerRuntime _boxContainer;
     private readonly Retro95Bevel _bevel;
     private readonly TextRuntime _checkGlyph;
-    private readonly ColoredRectangleRuntime _dashIndicator;
+    private readonly RectangleRuntime _dashIndicator;
     private readonly Retro95DottedFocusRect _focusRect;
 
     public CheckBoxVisual(bool fullInstantiation = true, bool tryCreateFormsObject = true)
@@ -110,9 +110,9 @@ public class CheckBoxVisual : BaseCheckBoxVisual
         return glyph;
     }
 
-    private static ColoredRectangleRuntime CreateDashIndicator()
+    private static RectangleRuntime CreateDashIndicator()
     {
-        ColoredRectangleRuntime dash = new ColoredRectangleRuntime();
+        RectangleRuntime dash = new RectangleRuntime();
         dash.Name = "Retro95CheckDash";
         dash.X = 0;
         dash.Y = 0;
@@ -124,7 +124,9 @@ public class CheckBoxVisual : BaseCheckBoxVisual
         dash.Height = DashHeight;
         dash.WidthUnits = DimensionUnitType.Absolute;
         dash.HeightUnits = DimensionUnitType.Absolute;
-        dash.Color = Retro95Colors.Selection;
+        dash.IsFilled = true;
+        dash.FillColor = Retro95Colors.Selection;
+        dash.StrokeWidth = 0;
         return dash;
     }
 

--- a/Themes/Gum.Themes.Retro95.MonoGame/ListBoxItemVisual.cs
+++ b/Themes/Gum.Themes.Retro95.MonoGame/ListBoxItemVisual.cs
@@ -13,7 +13,7 @@ namespace Gum.Themes.Retro95;
 /// </summary>
 public class ListBoxItemVisual : BaseListBoxItemVisual
 {
-    private readonly ColoredRectangleRuntime _fill;
+    private readonly RectangleRuntime _fill;
 
     public ListBoxItemVisual(bool fullInstantiation = true, bool tryCreateFormsObject = true)
         : base(fullInstantiation, tryCreateFormsObject)
@@ -22,7 +22,7 @@ public class ListBoxItemVisual : BaseListBoxItemVisual
         FocusedIndicator.Parent = null;
         TextInstance.Parent = null;
 
-        _fill = new ColoredRectangleRuntime();
+        _fill = new RectangleRuntime();
         _fill.Name = "Retro95ListItemFill";
         _fill.X = 0; _fill.Y = 0;
         _fill.XUnits = GeneralUnitType.PixelsFromMiddle;
@@ -32,7 +32,9 @@ public class ListBoxItemVisual : BaseListBoxItemVisual
         _fill.Width = 0; _fill.Height = 0;
         _fill.WidthUnits = DimensionUnitType.RelativeToParent;
         _fill.HeightUnits = DimensionUnitType.RelativeToParent;
-        _fill.Color = Color.Transparent;
+        _fill.IsFilled = true;
+        _fill.FillColor = Color.Transparent;
+        _fill.StrokeWidth = 0;
         AddChild(_fill);
 
         AddChild(TextInstance);
@@ -60,7 +62,7 @@ public class ListBoxItemVisual : BaseListBoxItemVisual
 
     private void Apply(Color fill, Color text)
     {
-        _fill.Color = fill;
+        _fill.FillColor = fill;
         TextInstance.Color = text;
     }
 }

--- a/Themes/Gum.Themes.Retro95.MonoGame/MenuItemVisual.cs
+++ b/Themes/Gum.Themes.Retro95.MonoGame/MenuItemVisual.cs
@@ -19,7 +19,7 @@ public class MenuItemVisual : BaseMenuItemVisual
     private const float HorizontalPadding = 10f;
     private const float VerticalPadding = 2f;
 
-    private readonly ColoredRectangleRuntime _fill;
+    private readonly RectangleRuntime _fill;
 
     public MenuItemVisual(bool fullInstantiation = true, bool tryCreateFormsObject = true)
         : base(fullInstantiation, tryCreateFormsObject: false)
@@ -82,14 +82,14 @@ public class MenuItemVisual : BaseMenuItemVisual
 
     private void Apply(Color fill, Color text)
     {
-        _fill.Color = fill;
+        _fill.FillColor = fill;
         TextInstance.Color = text;
         SubmenuIndicatorInstance.Color = text;
     }
 
-    private static ColoredRectangleRuntime CreateFill()
+    private static RectangleRuntime CreateFill()
     {
-        ColoredRectangleRuntime fill = new ColoredRectangleRuntime();
+        RectangleRuntime fill = new RectangleRuntime();
         fill.Name = "Retro95MenuItemFill";
         fill.X = 0; fill.Y = 0;
         fill.XUnits = GeneralUnitType.PixelsFromMiddle;
@@ -99,7 +99,9 @@ public class MenuItemVisual : BaseMenuItemVisual
         fill.Width = 0; fill.Height = 0;
         fill.WidthUnits = DimensionUnitType.RelativeToParent;
         fill.HeightUnits = DimensionUnitType.RelativeToParent;
-        fill.Color = Color.Transparent;
+        fill.IsFilled = true;
+        fill.FillColor = Color.Transparent;
+        fill.StrokeWidth = 0;
         return fill;
     }
 }

--- a/Themes/Gum.Themes.Retro95.MonoGame/MenuVisual.cs
+++ b/Themes/Gum.Themes.Retro95.MonoGame/MenuVisual.cs
@@ -14,8 +14,8 @@ public class MenuVisual : BaseMenuVisual
 {
     private const float SeparatorHeight = 1f;
 
-    private readonly ColoredRectangleRuntime _fill;
-    private readonly ColoredRectangleRuntime _bottomSeparator;
+    private readonly RectangleRuntime _fill;
+    private readonly RectangleRuntime _bottomSeparator;
 
     public MenuVisual(bool fullInstantiation = true, bool tryCreateFormsObject = true)
         : base(fullInstantiation, tryCreateFormsObject)
@@ -32,9 +32,9 @@ public class MenuVisual : BaseMenuVisual
         AddChild(InnerPanelInstance);
     }
 
-    private static ColoredRectangleRuntime CreateFill()
+    private static RectangleRuntime CreateFill()
     {
-        ColoredRectangleRuntime fill = new ColoredRectangleRuntime();
+        RectangleRuntime fill = new RectangleRuntime();
         fill.Name = "Retro95MenuFill";
         fill.X = 0; fill.Y = 0;
         fill.XUnits = GeneralUnitType.PixelsFromMiddle;
@@ -44,13 +44,15 @@ public class MenuVisual : BaseMenuVisual
         fill.Width = 0; fill.Height = 0;
         fill.WidthUnits = DimensionUnitType.RelativeToParent;
         fill.HeightUnits = DimensionUnitType.RelativeToParent;
-        fill.Color = Retro95Colors.Surface;
+        fill.IsFilled = true;
+        fill.FillColor = Retro95Colors.Surface;
+        fill.StrokeWidth = 0;
         return fill;
     }
 
-    private static ColoredRectangleRuntime CreateBottomSeparator()
+    private static RectangleRuntime CreateBottomSeparator()
     {
-        ColoredRectangleRuntime separator = new ColoredRectangleRuntime();
+        RectangleRuntime separator = new RectangleRuntime();
         separator.Name = "Retro95MenuDivider";
         separator.X = 0; separator.Y = 0;
         separator.XUnits = GeneralUnitType.PixelsFromMiddle;
@@ -61,7 +63,9 @@ public class MenuVisual : BaseMenuVisual
         separator.Height = SeparatorHeight;
         separator.WidthUnits = DimensionUnitType.RelativeToParent;
         separator.HeightUnits = DimensionUnitType.Absolute;
-        separator.Color = Retro95Colors.HairlineDivider;
+        separator.IsFilled = true;
+        separator.FillColor = Retro95Colors.HairlineDivider;
+        separator.StrokeWidth = 0;
         return separator;
     }
 }

--- a/Themes/Gum.Themes.Retro95.MonoGame/RadioButtonVisual.cs
+++ b/Themes/Gum.Themes.Retro95.MonoGame/RadioButtonVisual.cs
@@ -21,9 +21,9 @@ public class RadioButtonVisual : BaseRadioButtonVisual
     private const float BorderThickness = 1f;
     private const float BoxToLabelGap = 6f;
 
-    private readonly ColoredCircleRuntime _outerFill;
-    private readonly ColoredCircleRuntime _outerBorder;
-    private readonly ColoredCircleRuntime _innerDot;
+    private readonly CircleRuntime _outerFill;
+    private readonly CircleRuntime _outerBorder;
+    private readonly CircleRuntime _innerDot;
     private readonly Retro95DottedFocusRect _focusRect;
 
     public RadioButtonVisual(bool fullInstantiation = true, bool tryCreateFormsObject = true)
@@ -64,9 +64,9 @@ public class RadioButtonVisual : BaseRadioButtonVisual
         WireStates();
     }
 
-    private static ColoredCircleRuntime CreateCircle(string name, float size, bool filled, Color color)
+    private static CircleRuntime CreateCircle(string name, float size, bool filled, Color color)
     {
-        ColoredCircleRuntime c = new ColoredCircleRuntime();
+        CircleRuntime c = new CircleRuntime();
         c.Name = name;
         c.X = 0;
         c.Y = 0;
@@ -79,14 +79,22 @@ public class RadioButtonVisual : BaseRadioButtonVisual
         c.WidthUnits = DimensionUnitType.Absolute;
         c.HeightUnits = DimensionUnitType.Absolute;
         c.IsFilled = filled;
-        c.Color = color;
+        if (filled)
+        {
+            c.FillColor = color;
+            c.StrokeWidth = 0;
+        }
+        else
+        {
+            c.StrokeColor = color;
+        }
         return c;
     }
 
-    private static ColoredCircleRuntime CreateInnerDot()
+    private static CircleRuntime CreateInnerDot()
     {
         const float inset = (OuterSize - InnerSize) / 2f;
-        ColoredCircleRuntime dot = new ColoredCircleRuntime();
+        CircleRuntime dot = new CircleRuntime();
         dot.Name = "Retro95RadioDot";
         dot.X = inset;
         dot.Y = 0;
@@ -99,7 +107,8 @@ public class RadioButtonVisual : BaseRadioButtonVisual
         dot.WidthUnits = DimensionUnitType.Absolute;
         dot.HeightUnits = DimensionUnitType.Absolute;
         dot.IsFilled = true;
-        dot.Color = Retro95Colors.Text;
+        dot.FillColor = Retro95Colors.Text;
+        dot.StrokeWidth = 0;
         return dot;
     }
 
@@ -126,7 +135,7 @@ public class RadioButtonVisual : BaseRadioButtonVisual
 
     private void Apply(bool white, Color text, bool dotVisible, bool focus)
     {
-        _outerFill.Color = white ? Retro95Colors.WhiteFill : Retro95Colors.Surface;
+        _outerFill.FillColor = white ? Retro95Colors.WhiteFill : Retro95Colors.Surface;
         TextInstance.Color = text;
         _innerDot.Visible = dotVisible;
         if (focus) _focusRect.Show(); else _focusRect.Hide();

--- a/Themes/Gum.Themes.Retro95.MonoGame/Retro95Bevel.cs
+++ b/Themes/Gum.Themes.Retro95.MonoGame/Retro95Bevel.cs
@@ -23,7 +23,7 @@ public enum BevelMode
 }
 
 /// <summary>
-/// A Retro95 beveled chrome rectangle. Composes 8 thin <see cref="ColoredRectangleRuntime"/>
+/// A Retro95 beveled chrome rectangle. Composes 8 thin <see cref="RectangleRuntime"/>
 /// strips along the four edges to reproduce the Win95 CSS 4-layer inset box-shadow:
 /// <c>inset 1px 1px 0 #fff, inset 2px 2px 0 #DFDFDF, inset -1px -1px 0 #808080, inset -2px -2px 0 #404040</c>.
 /// <para>
@@ -36,7 +36,7 @@ public enum BevelMode
 /// The Win95 chrome has square corners by design — no <c>CornerRadius</c> property exists
 /// here. If a control needs a focus indicator, the convention is a 1-pixel dotted inset border;
 /// since the runtime has no dotted-stroke primitive, this theme approximates it with a single
-/// dark ColoredRectangleRuntime inset 4 px from the body edge (see consumers like ButtonVisual).
+/// dark RectangleRuntime inset 4 px from the body edge (see consumers like ButtonVisual).
 /// </para>
 /// </summary>
 public sealed class Retro95Bevel
@@ -44,26 +44,26 @@ public sealed class Retro95Bevel
     private const float OuterStripThickness = 1f;
     private const float InnerStripThickness = 1f;
 
-    private readonly ColoredRectangleRuntime _fill;
+    private readonly RectangleRuntime _fill;
 
     // Outer ring (1 px on each edge).
-    private readonly ColoredRectangleRuntime _outerTop;
-    private readonly ColoredRectangleRuntime _outerLeft;
-    private readonly ColoredRectangleRuntime _outerRight;
-    private readonly ColoredRectangleRuntime _outerBottom;
+    private readonly RectangleRuntime _outerTop;
+    private readonly RectangleRuntime _outerLeft;
+    private readonly RectangleRuntime _outerRight;
+    private readonly RectangleRuntime _outerBottom;
 
     // Inner ring (1 px just inside the outer ring).
-    private readonly ColoredRectangleRuntime _innerTop;
-    private readonly ColoredRectangleRuntime _innerLeft;
-    private readonly ColoredRectangleRuntime _innerRight;
-    private readonly ColoredRectangleRuntime _innerBottom;
+    private readonly RectangleRuntime _innerTop;
+    private readonly RectangleRuntime _innerLeft;
+    private readonly RectangleRuntime _innerRight;
+    private readonly RectangleRuntime _innerBottom;
 
     private Retro95Bevel(
-        ColoredRectangleRuntime fill,
-        ColoredRectangleRuntime outerTop, ColoredRectangleRuntime outerLeft,
-        ColoredRectangleRuntime outerRight, ColoredRectangleRuntime outerBottom,
-        ColoredRectangleRuntime innerTop, ColoredRectangleRuntime innerLeft,
-        ColoredRectangleRuntime innerRight, ColoredRectangleRuntime innerBottom)
+        RectangleRuntime fill,
+        RectangleRuntime outerTop, RectangleRuntime outerLeft,
+        RectangleRuntime outerRight, RectangleRuntime outerBottom,
+        RectangleRuntime innerTop, RectangleRuntime innerLeft,
+        RectangleRuntime innerRight, RectangleRuntime innerBottom)
     {
         _fill = fill;
         _outerTop = outerTop;
@@ -77,7 +77,7 @@ public sealed class Retro95Bevel
     }
 
     /// <summary>The central fill rectangle. Color defaults to <see cref="Retro95Colors.Surface"/>.</summary>
-    public ColoredRectangleRuntime Fill => _fill;
+    public RectangleRuntime Fill => _fill;
 
     /// <summary>
     /// Adds a beveled chrome block to <paramref name="parent"/>. Returns the bevel handle for
@@ -86,19 +86,19 @@ public sealed class Retro95Bevel
     /// </summary>
     public static Retro95Bevel AddTo(GraphicalUiElement parent, BevelMode mode, Color? fillColor = null)
     {
-        ColoredRectangleRuntime fill = NewStretchedRect("Retro95BevelFill");
-        fill.Color = fillColor ?? Retro95Colors.Surface;
+        RectangleRuntime fill = NewStretchedRect("Retro95BevelFill");
+        fill.FillColor = fillColor ?? Retro95Colors.Surface;
         parent.AddChild(fill);
 
-        ColoredRectangleRuntime outerTop = NewEdgeStrip("Retro95BevelOuterTop", Edge.Top, OuterStripThickness, inset: 0f);
-        ColoredRectangleRuntime outerLeft = NewEdgeStrip("Retro95BevelOuterLeft", Edge.Left, OuterStripThickness, inset: 0f);
-        ColoredRectangleRuntime outerRight = NewEdgeStrip("Retro95BevelOuterRight", Edge.Right, OuterStripThickness, inset: 0f);
-        ColoredRectangleRuntime outerBottom = NewEdgeStrip("Retro95BevelOuterBottom", Edge.Bottom, OuterStripThickness, inset: 0f);
+        RectangleRuntime outerTop = NewEdgeStrip("Retro95BevelOuterTop", Edge.Top, OuterStripThickness, inset: 0f);
+        RectangleRuntime outerLeft = NewEdgeStrip("Retro95BevelOuterLeft", Edge.Left, OuterStripThickness, inset: 0f);
+        RectangleRuntime outerRight = NewEdgeStrip("Retro95BevelOuterRight", Edge.Right, OuterStripThickness, inset: 0f);
+        RectangleRuntime outerBottom = NewEdgeStrip("Retro95BevelOuterBottom", Edge.Bottom, OuterStripThickness, inset: 0f);
 
-        ColoredRectangleRuntime innerTop = NewEdgeStrip("Retro95BevelInnerTop", Edge.Top, InnerStripThickness, inset: OuterStripThickness);
-        ColoredRectangleRuntime innerLeft = NewEdgeStrip("Retro95BevelInnerLeft", Edge.Left, InnerStripThickness, inset: OuterStripThickness);
-        ColoredRectangleRuntime innerRight = NewEdgeStrip("Retro95BevelInnerRight", Edge.Right, InnerStripThickness, inset: OuterStripThickness);
-        ColoredRectangleRuntime innerBottom = NewEdgeStrip("Retro95BevelInnerBottom", Edge.Bottom, InnerStripThickness, inset: OuterStripThickness);
+        RectangleRuntime innerTop = NewEdgeStrip("Retro95BevelInnerTop", Edge.Top, InnerStripThickness, inset: OuterStripThickness);
+        RectangleRuntime innerLeft = NewEdgeStrip("Retro95BevelInnerLeft", Edge.Left, InnerStripThickness, inset: OuterStripThickness);
+        RectangleRuntime innerRight = NewEdgeStrip("Retro95BevelInnerRight", Edge.Right, InnerStripThickness, inset: OuterStripThickness);
+        RectangleRuntime innerBottom = NewEdgeStrip("Retro95BevelInnerBottom", Edge.Bottom, InnerStripThickness, inset: OuterStripThickness);
 
         parent.AddChild(outerTop);
         parent.AddChild(outerLeft);
@@ -116,7 +116,7 @@ public sealed class Retro95Bevel
         return bevel;
     }
 
-    /// <summary>Flip the bevel's edge colors. Cheap (just sets <see cref="ColoredRectangleRuntime.Color"/>
+    /// <summary>Flip the bevel's edge colors. Cheap (just sets <see cref="RectangleRuntime.FillColor"/>
     /// on 8 thin strips); call from a state callback whenever press / inset state changes.</summary>
     public void SetMode(BevelMode mode)
     {
@@ -124,26 +124,26 @@ public sealed class Retro95Bevel
         {
             case BevelMode.Raised:
                 // top-left light, bottom-right dark
-                _outerTop.Color = Retro95Colors.HighlightOuter;
-                _outerLeft.Color = Retro95Colors.HighlightOuter;
-                _innerTop.Color = Retro95Colors.HighlightInner;
-                _innerLeft.Color = Retro95Colors.HighlightInner;
-                _outerBottom.Color = Retro95Colors.ShadowOuter;
-                _outerRight.Color = Retro95Colors.ShadowOuter;
-                _innerBottom.Color = Retro95Colors.ShadowInner;
-                _innerRight.Color = Retro95Colors.ShadowInner;
+                _outerTop.FillColor = Retro95Colors.HighlightOuter;
+                _outerLeft.FillColor = Retro95Colors.HighlightOuter;
+                _innerTop.FillColor = Retro95Colors.HighlightInner;
+                _innerLeft.FillColor = Retro95Colors.HighlightInner;
+                _outerBottom.FillColor = Retro95Colors.ShadowOuter;
+                _outerRight.FillColor = Retro95Colors.ShadowOuter;
+                _innerBottom.FillColor = Retro95Colors.ShadowInner;
+                _innerRight.FillColor = Retro95Colors.ShadowInner;
                 break;
 
             case BevelMode.Sunken:
                 // top-left dark, bottom-right light
-                _outerTop.Color = Retro95Colors.ShadowOuter;
-                _outerLeft.Color = Retro95Colors.ShadowOuter;
-                _innerTop.Color = Retro95Colors.ShadowInner;
-                _innerLeft.Color = Retro95Colors.ShadowInner;
-                _outerBottom.Color = Retro95Colors.HighlightOuter;
-                _outerRight.Color = Retro95Colors.HighlightOuter;
-                _innerBottom.Color = Retro95Colors.HighlightInner;
-                _innerRight.Color = Retro95Colors.HighlightInner;
+                _outerTop.FillColor = Retro95Colors.ShadowOuter;
+                _outerLeft.FillColor = Retro95Colors.ShadowOuter;
+                _innerTop.FillColor = Retro95Colors.ShadowInner;
+                _innerLeft.FillColor = Retro95Colors.ShadowInner;
+                _outerBottom.FillColor = Retro95Colors.HighlightOuter;
+                _outerRight.FillColor = Retro95Colors.HighlightOuter;
+                _innerBottom.FillColor = Retro95Colors.HighlightInner;
+                _innerRight.FillColor = Retro95Colors.HighlightInner;
                 break;
 
             case BevelMode.Inset:
@@ -151,38 +151,38 @@ public sealed class Retro95Bevel
                 // outer light + inner shadow on bottom-right. Same as Sunken
                 // but with the highlight/shadow swapped on the inner ring so
                 // the white inner band reads as the input fill catching light.
-                _outerTop.Color = Retro95Colors.ShadowInner;
-                _outerLeft.Color = Retro95Colors.ShadowInner;
-                _innerTop.Color = Retro95Colors.ShadowOuter;
-                _innerLeft.Color = Retro95Colors.ShadowOuter;
-                _outerBottom.Color = Retro95Colors.HighlightInner;
-                _outerRight.Color = Retro95Colors.HighlightInner;
-                _innerBottom.Color = Retro95Colors.HighlightOuter;
-                _innerRight.Color = Retro95Colors.HighlightOuter;
+                _outerTop.FillColor = Retro95Colors.ShadowInner;
+                _outerLeft.FillColor = Retro95Colors.ShadowInner;
+                _innerTop.FillColor = Retro95Colors.ShadowOuter;
+                _innerLeft.FillColor = Retro95Colors.ShadowOuter;
+                _outerBottom.FillColor = Retro95Colors.HighlightInner;
+                _outerRight.FillColor = Retro95Colors.HighlightInner;
+                _innerBottom.FillColor = Retro95Colors.HighlightOuter;
+                _innerRight.FillColor = Retro95Colors.HighlightOuter;
                 break;
 
             case BevelMode.StatusPanel:
                 // 1-pixel inverse bevel — only the outer ring is colored, inner ring matches the fill.
-                _outerTop.Color = Retro95Colors.ShadowInner;
-                _outerLeft.Color = Retro95Colors.ShadowInner;
-                _outerBottom.Color = Retro95Colors.HighlightOuter;
-                _outerRight.Color = Retro95Colors.HighlightOuter;
-                _innerTop.Color = _fill.Color;
-                _innerLeft.Color = _fill.Color;
-                _innerBottom.Color = _fill.Color;
-                _innerRight.Color = _fill.Color;
+                _outerTop.FillColor = Retro95Colors.ShadowInner;
+                _outerLeft.FillColor = Retro95Colors.ShadowInner;
+                _outerBottom.FillColor = Retro95Colors.HighlightOuter;
+                _outerRight.FillColor = Retro95Colors.HighlightOuter;
+                _innerTop.FillColor = _fill.FillColor;
+                _innerLeft.FillColor = _fill.FillColor;
+                _innerBottom.FillColor = _fill.FillColor;
+                _innerRight.FillColor = _fill.FillColor;
                 break;
         }
     }
 
     /// <summary>Set the central fill color (e.g. white for text-input fills, gray for button bodies).</summary>
-    public void SetFill(Color color) => _fill.Color = color;
+    public void SetFill(Color color) => _fill.FillColor = color;
 
     private enum Edge { Top, Left, Right, Bottom }
 
-    private static ColoredRectangleRuntime NewStretchedRect(string name)
+    private static RectangleRuntime NewStretchedRect(string name)
     {
-        ColoredRectangleRuntime r = new ColoredRectangleRuntime();
+        RectangleRuntime r = new RectangleRuntime();
         r.Name = name;
         r.X = 0; r.Y = 0;
         r.XUnits = GeneralUnitType.PixelsFromMiddle;
@@ -192,13 +192,17 @@ public sealed class Retro95Bevel
         r.Width = 0; r.Height = 0;
         r.WidthUnits = DimensionUnitType.RelativeToParent;
         r.HeightUnits = DimensionUnitType.RelativeToParent;
+        r.IsFilled = true;
+        r.StrokeWidth = 0;
         return r;
     }
 
-    private static ColoredRectangleRuntime NewEdgeStrip(string name, Edge edge, float thickness, float inset)
+    private static RectangleRuntime NewEdgeStrip(string name, Edge edge, float thickness, float inset)
     {
-        ColoredRectangleRuntime r = new ColoredRectangleRuntime();
+        RectangleRuntime r = new RectangleRuntime();
         r.Name = name;
+        r.IsFilled = true;
+        r.StrokeWidth = 0;
         switch (edge)
         {
             case Edge.Top:

--- a/Themes/Gum.Themes.Retro95.MonoGame/Retro95DottedFocusRect.cs
+++ b/Themes/Gum.Themes.Retro95.MonoGame/Retro95DottedFocusRect.cs
@@ -8,7 +8,7 @@ namespace Gum.Themes.Retro95;
 
 /// <summary>
 /// The canonical Win95 1-pixel dotted focus rectangle. Implemented as a single
-/// stroked-and-dashed <see cref="RoundedRectangleRuntime"/> with <c>CornerRadius=0</c>:
+/// stroked-and-dashed <see cref="RectangleRuntime"/> with <c>CornerRadius=0</c>:
 /// Apos.Shapes natively rasterizes the dash pattern via <c>StrokeDashLength</c> /
 /// <c>StrokeGapLength</c>, so the chrome scales cleanly with the host visual without
 /// any per-frame dot bookkeeping or sensitivity to layout timing.
@@ -30,7 +30,7 @@ public sealed class Retro95DottedFocusRect
     private const float StrokeWidth = 1f;
 
     private readonly ContainerRuntime _container;
-    private readonly RoundedRectangleRuntime _rect;
+    private readonly RectangleRuntime _rect;
 
     /// <summary>The wrapper container holding the dashed-stroke rectangle. Adjust its
     /// X/Y/Width/Height before <see cref="Show"/> to scope the focus rect to a sub-region.</summary>
@@ -58,7 +58,7 @@ public sealed class Retro95DottedFocusRect
         _container.Visible = false;
         host.AddChild(_container);
 
-        _rect = new RoundedRectangleRuntime();
+        _rect = new RectangleRuntime();
         _rect.Name = "Retro95FocusRectStroke";
         _rect.X = 0; _rect.Y = 0;
         _rect.XUnits = GeneralUnitType.PixelsFromMiddle;
@@ -75,7 +75,7 @@ public sealed class Retro95DottedFocusRect
         _rect.StrokeDashLength = DashLength;
         _rect.StrokeGapLength = GapLength;
         _rect.IsAntialiased = false;
-        _rect.Color = Retro95Colors.Text;
+        _rect.StrokeColor = Retro95Colors.Text;
         _container.AddChild(_rect);
     }
 

--- a/Themes/Gum.Themes.Retro95.MonoGame/Retro95Theme.cs
+++ b/Themes/Gum.Themes.Retro95.MonoGame/Retro95Theme.cs
@@ -64,9 +64,9 @@ public static class Retro95Theme
         // All live in the bundled DejaVu Sans Mono icon font.
         BmfcSave.AddCharacters("✓✕▼▲◀▶■");
 
-        // Retro95's RadioButton uses ColoredCircleRuntime (the only circular
+        // Retro95's RadioButton uses CircleRuntime (the only circular
         // chrome in the theme — everything else is a rectangular bevel built
-        // from ColoredRectangleRuntime strips). Apos.Shapes' ShapeRenderer
+        // from RectangleRuntime strips). Apos.Shapes' ShapeRenderer
         // must be initialized for that one control. Guarded for the case
         // where the host app already initialized it.
         if (!ShapeRenderer.Self.IsInitialized)
@@ -203,5 +203,16 @@ public static class Retro95Theme
 
         FrameworkElement.DefaultFormsTemplates[typeof(Tooltip)] =
             new VisualTemplate((_, c) => new TooltipVisual(tryCreateFormsObject: c));
+
+        // Controls Retro95 does not restyle are pinned to their stock V3 visuals so
+        // Retro95Theme.Apply fully specifies the template set. FrameworkElement.DefaultFormsTemplates
+        // is global static state; without re-registering these, re-applying a theme at runtime
+        // (theme switching) would leave a previously-applied theme's visual in place for these
+        // controls. These match what a single-theme Retro95 run already falls back to.
+        FrameworkElement.DefaultFormsTemplates[typeof(ItemsControl)] =
+            new VisualTemplate((_, c) => new Gum.Forms.DefaultVisuals.V3.ItemsControlVisual(tryCreateFormsObject: c));
+
+        FrameworkElement.DefaultFormsTemplates[typeof(Gum.Forms.Controls.Games.DialogBox)] =
+            new VisualTemplate((_, c) => new Gum.Forms.DefaultVisuals.V3.DialogBoxVisual(tryCreateFormsObject: c));
     }
 }

--- a/Themes/Gum.Themes.Retro95.MonoGame/ScrollBarVisual.cs
+++ b/Themes/Gum.Themes.Retro95.MonoGame/ScrollBarVisual.cs
@@ -51,7 +51,7 @@ public class ScrollBarVisual : BaseScrollBarVisual
         if (downBtn != null) downBtn.Parent = null;
         existingThumbContainer.Parent = null;
 
-        ColoredRectangleRuntime trackFill = NewStretched("Retro95ScrollBarTrackFill", Retro95Colors.Surface);
+        RectangleRuntime trackFill = NewStretched("Retro95ScrollBarTrackFill", Retro95Colors.Surface);
         AddChild(trackFill);
 
         if (upBtn != null) AddChild(upBtn);
@@ -208,9 +208,9 @@ public class ScrollBarVisual : BaseScrollBarVisual
         return t;
     }
 
-    private static ColoredRectangleRuntime NewStretched(string name, Microsoft.Xna.Framework.Color color)
+    private static RectangleRuntime NewStretched(string name, Microsoft.Xna.Framework.Color color)
     {
-        ColoredRectangleRuntime r = new ColoredRectangleRuntime();
+        RectangleRuntime r = new RectangleRuntime();
         r.Name = name;
         r.X = 0; r.Y = 0;
         r.XUnits = GeneralUnitType.PixelsFromMiddle;
@@ -220,7 +220,9 @@ public class ScrollBarVisual : BaseScrollBarVisual
         r.Width = 0; r.Height = 0;
         r.WidthUnits = DimensionUnitType.RelativeToParent;
         r.HeightUnits = DimensionUnitType.RelativeToParent;
-        r.Color = color;
+        r.IsFilled = true;
+        r.FillColor = color;
+        r.StrokeWidth = 0;
         return r;
     }
 }

--- a/Themes/Gum.Themes.Retro95.MonoGame/SplitterVisual.cs
+++ b/Themes/Gum.Themes.Retro95.MonoGame/SplitterVisual.cs
@@ -12,14 +12,14 @@ namespace Gum.Themes.Retro95;
 /// </summary>
 public class SplitterVisual : BaseSplitterVisual
 {
-    private readonly ColoredRectangleRuntime _fill;
+    private readonly RectangleRuntime _fill;
 
     public SplitterVisual(bool fullInstantiation = true, bool tryCreateFormsObject = true)
         : base(fullInstantiation, tryCreateFormsObject)
     {
         Background.Parent = null;
 
-        _fill = new ColoredRectangleRuntime();
+        _fill = new RectangleRuntime();
         _fill.Name = "Retro95SplitterFill";
         _fill.X = 0; _fill.Y = 0;
         _fill.XUnits = GeneralUnitType.PixelsFromMiddle;
@@ -29,7 +29,9 @@ public class SplitterVisual : BaseSplitterVisual
         _fill.Width = 0; _fill.Height = 0;
         _fill.WidthUnits = DimensionUnitType.RelativeToParent;
         _fill.HeightUnits = DimensionUnitType.RelativeToParent;
-        _fill.Color = Retro95Colors.Surface;
+        _fill.IsFilled = true;
+        _fill.FillColor = Retro95Colors.Surface;
+        _fill.StrokeWidth = 0;
         AddChild(_fill);
     }
 }

--- a/Themes/Gum.Themes.Retro95.MonoGame/TooltipVisual.cs
+++ b/Themes/Gum.Themes.Retro95.MonoGame/TooltipVisual.cs
@@ -16,11 +16,11 @@ public class TooltipVisual : BaseTooltipVisual
     // Win95 tooltip yellow ≈ #FFFFE1.
     private static readonly Color TooltipFill = new Color(255, 255, 225);
 
-    private readonly ColoredRectangleRuntime _fill;
-    private readonly ColoredRectangleRuntime _outerTop;
-    private readonly ColoredRectangleRuntime _outerBottom;
-    private readonly ColoredRectangleRuntime _outerLeft;
-    private readonly ColoredRectangleRuntime _outerRight;
+    private readonly RectangleRuntime _fill;
+    private readonly RectangleRuntime _outerTop;
+    private readonly RectangleRuntime _outerBottom;
+    private readonly RectangleRuntime _outerLeft;
+    private readonly RectangleRuntime _outerRight;
 
     public TooltipVisual(bool fullInstantiation = true, bool tryCreateFormsObject = true)
         : base(fullInstantiation, tryCreateFormsObject)
@@ -44,9 +44,9 @@ public class TooltipVisual : BaseTooltipVisual
         TextInstance.Color = Retro95Colors.Text;
     }
 
-    private static ColoredRectangleRuntime NewStretched(string name, Color color)
+    private static RectangleRuntime NewStretched(string name, Color color)
     {
-        ColoredRectangleRuntime r = new ColoredRectangleRuntime();
+        RectangleRuntime r = new RectangleRuntime();
         r.Name = name;
         r.X = 0; r.Y = 0;
         r.XUnits = GeneralUnitType.PixelsFromMiddle;
@@ -56,15 +56,19 @@ public class TooltipVisual : BaseTooltipVisual
         r.Width = 0; r.Height = 0;
         r.WidthUnits = DimensionUnitType.RelativeToParent;
         r.HeightUnits = DimensionUnitType.RelativeToParent;
-        r.Color = color;
+        r.IsFilled = true;
+        r.FillColor = color;
+        r.StrokeWidth = 0;
         return r;
     }
 
-    private static ColoredRectangleRuntime NewEdge(string name, bool horizontal, bool top)
+    private static RectangleRuntime NewEdge(string name, bool horizontal, bool top)
     {
-        ColoredRectangleRuntime r = new ColoredRectangleRuntime();
+        RectangleRuntime r = new RectangleRuntime();
         r.Name = name;
-        r.Color = Retro95Colors.Text;
+        r.IsFilled = true;
+        r.FillColor = Retro95Colors.Text;
+        r.StrokeWidth = 0;
         if (horizontal)
         {
             r.X = 0;

--- a/Themes/Gum.Themes.Retro95.MonoGame/WindowVisual.cs
+++ b/Themes/Gum.Themes.Retro95.MonoGame/WindowVisual.cs
@@ -20,7 +20,7 @@ public class WindowVisual : BaseWindowVisual
     private const float TitleBarHeight = 18f;
 
     private readonly Retro95Bevel _bodyBevel;
-    private readonly ColoredRectangleRuntime _titleBarFill;
+    private readonly RectangleRuntime _titleBarFill;
 
     public WindowVisual(bool fullInstantiation = true, bool tryCreateFormsObject = true)
         : base(fullInstantiation, tryCreateFormsObject)
@@ -76,11 +76,13 @@ public class WindowVisual : BaseWindowVisual
         AddChild(NewOutlineEdge(top: false, vertical: true));
     }
 
-    private static ColoredRectangleRuntime NewOutlineEdge(bool top, bool vertical)
+    private static RectangleRuntime NewOutlineEdge(bool top, bool vertical)
     {
-        ColoredRectangleRuntime r = new ColoredRectangleRuntime();
+        RectangleRuntime r = new RectangleRuntime();
         r.Name = "Retro95WindowOutline";
-        r.Color = Color.Black;
+        r.IsFilled = true;
+        r.FillColor = Color.Black;
+        r.StrokeWidth = 0;
         if (!vertical)
         {
             r.X = 0;
@@ -110,9 +112,9 @@ public class WindowVisual : BaseWindowVisual
         return r;
     }
 
-    private static ColoredRectangleRuntime CreateTitleBarFill()
+    private static RectangleRuntime CreateTitleBarFill()
     {
-        ColoredRectangleRuntime fill = new ColoredRectangleRuntime();
+        RectangleRuntime fill = new RectangleRuntime();
         fill.Name = "Retro95WindowTitleBarFill";
         fill.X = 0; fill.Y = 0;
         fill.XUnits = GeneralUnitType.PixelsFromMiddle;
@@ -122,7 +124,9 @@ public class WindowVisual : BaseWindowVisual
         fill.Width = 0; fill.Height = 0;
         fill.WidthUnits = DimensionUnitType.RelativeToParent;
         fill.HeightUnits = DimensionUnitType.RelativeToParent;
-        fill.Color = Retro95Colors.Selection;
+        fill.IsFilled = true;
+        fill.FillColor = Retro95Colors.Selection;
+        fill.StrokeWidth = 0;
         return fill;
     }
 }


### PR DESCRIPTION
## What

Migrates all six bundled Gum themes off the legacy Apos shape runtimes — `ColoredRectangleRuntime`, `RoundedRectangleRuntime`, `ColoredCircleRuntime` — onto the unified **`RectangleRuntime`** / **`CircleRuntime`** surface. The legacy runtimes remain as `[Obsolete]` shims (deprecated in #2997); the bundled themes simply stop reaching for them.

## The migration recipe

A freshly-constructed `RectangleRuntime`/`CircleRuntime` defaults to a **transparent fill + 1px white outline** (the #2938 stroke-only default), so each shape is reclassified by its `IsFilled`:

- **Solid fill** → `FillColor = c;` **and** `StrokeWidth = 0;` (kill the default white outline).
- **Stroke-only** (borders, focus rings) → `IsFilled = false; StrokeColor = c;`.
- **Circle** → `CircleRuntime`; **rounded rect** → `RectangleRuntime` with `CornerRadius`.
- Dashed strokes (`StrokeDashLength`/`StrokeGapLength`), native Gaussian dropshadows, and gradients carry over as-is.

## Commits (per-theme, reviewable in isolation)

- **Showcase harness** — live 1–6 theme-swap + F1/F2 screen-swap test bed (`Samples/MonoGameGumThemesShowcase`).
- **Editor**, **Bubblegum**, **Forest Glade**, **Neon**, **Dark Pro**, **Retro 95** — one commit each.
- **Gradient-gate renderer fix (#2998)** — gradient fill visibility now keys off the gradient stops' own alpha rather than the (now-transparent-by-default) solid `FillColor`, across all three backends (Apos / raylib / Skia), with tests. Without this, gradient-driven fills (Forest Glade buttons, list-row selection) went invisible after migration.
- **`gum-theming` skill** — updated to document the unified runtimes as canonical, including the split fill/stroke default surface and the scalar `DropshadowBlur`.

Each theme also **gap-pins** its un-restyled controls (including `ItemsControl` and `DialogBox`) to their V3 default visuals, so a theme fully specifies the `DefaultFormsTemplates` set — preventing one theme's visual from bleeding into the next when themes are swapped at runtime (and `DefaultFormsTemplates` is global static state).

## Verification

- Clean grep: zero legacy shape-runtime references in any theme source.
- The MonoGame showcase **and** every theme's `.Kni` project build at **0 errors**; theme source contributes **0 obsolete-shape warnings**.
- Visually confirmed across all six themes via the showcase harness.

## Known follow-up (not in this PR)

`Gum.Themes.Editor.MonoGame` still emits 16 warnings, **pre-existing and unrelated to this migration** — those files were never touched here; #2997 is what turned their `.Color` calls obsolete (they exist on `main` too). On XNA-likes the obsolete `RectangleRuntime.Color` setter routes to the *stroke*, so "fixing" them is a fill-vs-stroke behavior decision, not a mechanical warning sweep. Left for a separate, deliberate pass.
