### PR TITLE
Default shape FillColor to white, IsFilled to false

### DIFF
--- a/MonoGameGum.Tests/Runtimes/CircleRuntimeTests.cs
+++ b/MonoGameGum.Tests/Runtimes/CircleRuntimeTests.cs
@@ -57,16 +57,16 @@ public class CircleRuntimeTests : BaseTestClass
         sut.FillColor.ShouldBe(new Color(11, 22, 33, 44));
     }
 
-    // Issue #2938 (regression fix) — FillColor defaults to transparent (alpha 0) so a
-    // freshly-constructed runtime renders as a stroke-only outline, preserving the pre-#2938
-    // ctor visual. IsFilled is true by default; assigning FillColor to a visible color lights
-    // the fill up without flipping IsFilled.
+    // FillColor defaults to opaque white and IsFilled defaults to false, so a freshly-
+    // constructed runtime renders as a stroke-only outline (the white fill is gated off). This
+    // is the "pit of success" default: flipping IsFilled = true fills the shape white without
+    // needing to also assign FillColor.
     [Fact]
-    public void FillColor_DefaultsToTransparent()
+    public void FillColor_DefaultsToWhite()
     {
         CircleRuntime sut = new();
 
-        sut.FillColor.ShouldBe(new Color(0, 0, 0, 0));
+        sut.FillColor.ShouldBe(Color.White);
     }
 
     [Fact]
@@ -83,11 +83,11 @@ public class CircleRuntimeTests : BaseTestClass
     }
 
     [Fact]
-    public void IsFilled_DefaultsToTrue()
+    public void IsFilled_DefaultsToFalse()
     {
         CircleRuntime sut = new();
 
-        sut.IsFilled.ShouldBeTrue();
+        sut.IsFilled.ShouldBeFalse();
     }
 
     [Fact]

--- a/MonoGameGum.Tests/Runtimes/RectangleRuntimeTests.cs
+++ b/MonoGameGum.Tests/Runtimes/RectangleRuntimeTests.cs
@@ -53,6 +53,7 @@ public class RectangleRuntimeTests : BaseTestClass
         // The point of the two-slot model — bordered panel / button / card with both visible.
         RectangleRuntime sut = new();
 
+        sut.IsFilled = true;
         sut.FillColor = Color.Red;
         sut.StrokeColor = Color.Blue;
 
@@ -121,15 +122,15 @@ public class RectangleRuntimeTests : BaseTestClass
         ((DefaultFilledRectangleRenderable)sut.RenderableComponent).Children[0].ShouldBeSameAs(originalStroke);
     }
 
-    // Issue #2938 (regression fix) — FillColor defaults to transparent (alpha 0) so a
-    // freshly-constructed runtime renders as a stroke-only outline (pre-#2938 visual).
-    // IsFilled is true by default; assigning FillColor to a visible color lights the fill up.
+    // FillColor defaults to opaque white and IsFilled defaults to false, so a freshly-
+    // constructed runtime renders as a stroke-only outline (the white fill is gated off).
+    // Flipping IsFilled = true fills the shape white without needing to also assign FillColor.
     [Fact]
-    public void FillColor_DefaultsToTransparent()
+    public void FillColor_DefaultsToWhite()
     {
         RectangleRuntime sut = new();
 
-        sut.FillColor.ShouldBe(new Color(0, 0, 0, 0));
+        sut.FillColor.ShouldBe(Color.White);
     }
 
     [Fact]
@@ -141,11 +142,11 @@ public class RectangleRuntimeTests : BaseTestClass
     }
 
     [Fact]
-    public void IsFilled_DefaultsToTrue()
+    public void IsFilled_DefaultsToFalse()
     {
         RectangleRuntime sut = new();
 
-        sut.IsFilled.ShouldBeTrue();
+        sut.IsFilled.ShouldBeFalse();
     }
 
     [Fact]

--- a/MonoGameGum/GueDeriving/CircleRuntime.cs
+++ b/MonoGameGum/GueDeriving/CircleRuntime.cs
@@ -270,9 +270,10 @@ public class CircleRuntime : GraphicalUiElement
     // properties at all yet; the raylib sample (CirclesScreen) renders only the supported
     // sections.
 
-    // Issue #2938 regression fix — transparent default so a freshly-constructed CircleRuntime
-    // renders as a stroke-only outline (existing raylib gallery / cross-backend samples).
-    Color _fillColor = new Color((byte)0, (byte)0, (byte)0, (byte)0);
+    // FillColor defaults to opaque white while IsFilled defaults to false, so a freshly-
+    // constructed CircleRuntime renders as a stroke-only outline (the white fill is gated off).
+    // Flipping IsFilled = true fills it white without needing to assign FillColor.
+    Color _fillColor = new Color((byte)255, (byte)255, (byte)255, (byte)255);
 
     /// <inheritdoc cref="Gum.Renderables.LineCircle.FillColor"/>
     public Color FillColor
@@ -479,20 +480,17 @@ public class CircleRuntime : GraphicalUiElement
 #endif
 
 #if XNALIKE
-    // Issue #2938 regression fix: FillColor defaults to transparent (alpha 0) so a freshly-
-    // constructed CircleRuntime renders as a stroke-only outline — matching the pre-#2938
-    // visual that all existing sample code assumes ("construct + only set StrokeColor").
-    // IsFilled is true by default; the gate semantics still work — explicitly setting
-    // FillColor to a visible color lights the fill up. Setting IsFilled = false zeros the
-    // fill slot's alpha regardless of FillColor.
-    Color _fillColor = new Color(0, 0, 0, 0);
+    // FillColor defaults to opaque white while IsFilled defaults to false, so a freshly-
+    // constructed CircleRuntime renders as a stroke-only outline (the white fill is gated off).
+    // This is the "pit of success" default: flipping IsFilled = true fills the disk white
+    // without needing to also assign FillColor.
+    Color _fillColor = Color.White;
 
     /// <summary>
     /// Color of the filled disk. Painted into the fill slot when <see cref="IsFilled"/> is
     /// <c>true</c>; ignored visually when <c>IsFilled</c> is <c>false</c> (the fill slot is
-    /// pushed a transparent color so only the stroke draws). Defaults to transparent so a
-    /// freshly-constructed runtime renders a stroke-only outline; assign a visible color to
-    /// light the fill up (IsFilled is already true by default).
+    /// pushed a transparent color so only the stroke draws). Defaults to opaque white so that
+    /// flipping <see cref="IsFilled"/> on alone produces a visible (white) fill.
     /// </summary>
     /// <remarks>
     /// Visual fill requires a fill-capable <see cref="IFilledCircleRenderable"/> implementation —
@@ -543,14 +541,15 @@ public class CircleRuntime : GraphicalUiElement
         set => FillColor = new Color(_fillColor.R, _fillColor.G, _fillColor.B, (byte)value);
     }
 
-    bool _isFilled = true;
+    bool _isFilled = false;
 
     /// <summary>
-    /// Gates fill rendering. When <c>true</c> (the default) the fill slot is painted with
-    /// <see cref="FillColor"/>. When <c>false</c> the fill slot is pushed a transparent color
-    /// so only the stroke draws — used to render a stroke-only outline without dropping
-    /// <see cref="FillColor"/>. Stroke visibility is gated separately by
-    /// <see cref="StrokeWidth"/> (0 hides stroke).
+    /// Gates fill rendering. When <c>true</c> the fill slot is painted with
+    /// <see cref="FillColor"/>. When <c>false</c> (the default) the fill slot is pushed a
+    /// transparent color so only the stroke draws — a freshly-constructed runtime is therefore
+    /// a stroke-only outline. Because <see cref="FillColor"/> defaults to opaque white, setting
+    /// this <c>true</c> alone produces a visible white fill. Stroke visibility is gated
+    /// separately by <see cref="StrokeWidth"/> (0 hides stroke).
     /// </summary>
     public bool IsFilled
     {
@@ -1807,12 +1806,10 @@ public class CircleRuntime : GraphicalUiElement
                 SetContainedObject(_stroke);
             }
 
-            // Initial defaults — stroke white, fill transparent (IsFilled = true so the gate
-            // is open, but the color is alpha-0 so nothing visible draws), radius 16, layout
-            // 32x32. Issue #2938 (regression fix): a freshly-constructed CircleRuntime renders
-            // as a stroke-only outline — matching the pre-#2938 visual that existing sample
-            // code (raylib gallery, GumShapesGallery, SilkNetGum) assumes. Setting FillColor to
-            // a visible color lights up the fill without needing to also flip IsFilled.
+            // Initial defaults — stroke white, fill white but gated off (IsFilled = false), so
+            // the fill slot is pushed a transparent color and a freshly-constructed
+            // CircleRuntime renders as a stroke-only outline, radius 16, layout 32x32. Flipping
+            // IsFilled = true paints the fill white without needing to assign FillColor.
             _stroke.Color = _strokeColor;
             _stroke.Radius = 16;
             if (_fill != null)
@@ -1852,12 +1849,15 @@ public class CircleRuntime : GraphicalUiElement
             // single-slot legacy model (last-non-null-setter-wins).
             SetStrokeRenderable(new ContainedCircleType());
 
-            // Issue #2938 (regression fix): FillColor defaults to transparent (alpha 0) +
-            // white stroke. IsFilled defaults to true so the gate is open, but the transparent
-            // color means a freshly-constructed runtime renders as a stroke-only outline —
-            // matching the pre-#2938 visual that existing sample code assumes. Assigning
-            // FillColor to a visible color lights up the fill without flipping IsFilled.
-            FillColor = new SKColor(0, 0, 0, 0);
+            // Defaults: white fill gated off (IsFilled = false) + white stroke, so a freshly-
+            // constructed runtime renders as a stroke-only outline. Because FillColor defaults
+            // to opaque white, flipping IsFilled = true paints a white fill without assigning a
+            // color. IsFilled must be set explicitly here — the shared SkiaShapeRuntime base
+            // defaults it to true for the legacy single-color shapes. Setting IsFilled = false
+            // re-pushes a transparent color into the fill slot so the renderable doesn't keep
+            // its own white constructor default and render as a solid white disk.
+            FillColor = SKColors.White;
+            IsFilled = false;
             StrokeColor = SKColors.White;
             StrokeWidth = 1;
             StrokeWidthUnits = DimensionUnitType.ScreenPixel;
@@ -1880,15 +1880,13 @@ public class CircleRuntime : GraphicalUiElement
             // it null there so the existing outline-via-Color path keeps working unchanged.
             // Same fix landed for RectangleRuntime earlier in this PR.
             //
-            // #2938 (regression fix) — push runtime-held FillColor / StrokeColor / IsFilled
-            // defaults onto the renderable so the runtime properties report consistent state at
-            // construction. FillColor defaults to transparent (alpha 0) and IsFilled defaults
-            // to true → a fresh circle renders as a stroke-only outline (matching the pre-#2938
-            // visual that the raylib gallery / cross-backend samples assume). Assigning
-            // FillColor to a visible color lights up the fill without flipping IsFilled.
+            // Push runtime-held FillColor / StrokeColor / IsFilled defaults onto the renderable
+            // so the runtime properties report consistent state at construction. FillColor
+            // defaults to opaque white and IsFilled defaults to false → a fresh circle renders
+            // as a stroke-only outline; flipping IsFilled = true paints it white.
             circle.StrokeColor = _strokeColor;
             circle.FillColor = _fillColor;
-            circle.IsFilled = true;
+            circle.IsFilled = false;
 #endif
 #endif
             Width = 32;

--- a/MonoGameGum/GueDeriving/RectangleRuntime.cs
+++ b/MonoGameGum/GueDeriving/RectangleRuntime.cs
@@ -235,17 +235,16 @@ public class RectangleRuntime : GraphicalUiElement
     // implement any of this; when it gains support, lift the relevant blocks into RAYLIB ||
     // SOKOL (mirror the CircleRuntime pattern).
 
-    // Issue #2938 regression fix — transparent default so a freshly-constructed RectangleRuntime
-    // renders as a stroke-only outline (matches pre-#2938 visual the gallery / cross-backend
-    // samples assume).
-    Color _fillColor = new Color((byte)0, (byte)0, (byte)0, (byte)0);
+    // FillColor defaults to opaque white while IsFilled defaults to false, so a freshly-
+    // constructed RectangleRuntime renders as a stroke-only outline (the white fill is gated
+    // off). Flipping IsFilled = true fills it white without needing to assign FillColor.
+    Color _fillColor = new Color((byte)255, (byte)255, (byte)255, (byte)255);
 
     /// <inheritdoc cref="Gum.Renderables.LineRectangle.FillColor"/>
     /// <remarks>
     /// Issue #2938 — non-nullable since the visibility gate moved to <see cref="IsFilled"/>.
-    /// Defaults to transparent (alpha 0) so a freshly-constructed runtime renders a
-    /// stroke-only outline; IsFilled is true by default so assigning a visible color lights
-    /// up the fill without flipping IsFilled.
+    /// Defaults to opaque white; IsFilled is false by default so a fresh runtime is a
+    /// stroke-only outline and flipping IsFilled on alone yields a visible white fill.
     /// </remarks>
     public Color FillColor
     {
@@ -695,18 +694,19 @@ public class RectangleRuntime : GraphicalUiElement
 #endif
 
 #if XNALIKE
-    // Issue #2938 regression fix: FillColor defaults to transparent (alpha 0) so a freshly-
-    // constructed RectangleRuntime renders as a stroke-only outline — matching the pre-#2938
-    // visual that existing sample code (gallery frames) assumes. IsFilled is true by default;
-    // assigning FillColor to a visible color lights up the fill without flipping IsFilled.
-    Color _fillColor = new Color(0, 0, 0, 0);
+    // FillColor defaults to opaque white while IsFilled defaults to false, so a freshly-
+    // constructed RectangleRuntime renders as a stroke-only outline (the white fill is gated
+    // off). This is the "pit of success" default: flipping IsFilled = true fills the rectangle
+    // white without needing to also assign FillColor.
+    Color _fillColor = Color.White;
 
     /// <summary>
     /// Color of the filled rectangle. Pushed to the fill slot when <see cref="IsFilled"/> is
     /// <c>true</c>; when <c>IsFilled</c> is <c>false</c> the fill slot is pushed a transparent
     /// color so only the stroke draws. Both core (<see cref="DefaultFilledRectangleRenderable"/>)
     /// and MonoGameGumShapes (<c>RoundedRectangle</c> with <c>IsFilled = true</c>) honor this.
-    /// Defaults to transparent so a freshly-constructed runtime renders a stroke-only outline.
+    /// Defaults to opaque white so that flipping <see cref="IsFilled"/> on alone produces a
+    /// visible (white) fill.
     /// </summary>
     /// <remarks>
     /// Issue #2938 — non-nullable since the visibility gate moved to <see cref="IsFilled"/>.
@@ -753,14 +753,15 @@ public class RectangleRuntime : GraphicalUiElement
         set => FillColor = new Color(_fillColor.R, _fillColor.G, _fillColor.B, (byte)value);
     }
 
-    bool _isFilled = true;
+    bool _isFilled = false;
 
     /// <summary>
-    /// Gates fill rendering. When <c>true</c> (the default) the fill slot is painted with
-    /// <see cref="FillColor"/>. When <c>false</c> the fill slot is pushed a transparent color
-    /// so only the stroke draws — used to render a stroke-only outline without dropping
-    /// <see cref="FillColor"/>. Stroke visibility is gated separately by
-    /// <see cref="StrokeWidth"/> (0 hides stroke).
+    /// Gates fill rendering. When <c>true</c> the fill slot is painted with
+    /// <see cref="FillColor"/>. When <c>false</c> (the default) the fill slot is pushed a
+    /// transparent color so only the stroke draws — a freshly-constructed runtime is therefore
+    /// a stroke-only outline. Because <see cref="FillColor"/> defaults to opaque white, setting
+    /// this <c>true</c> alone produces a visible white fill. Stroke visibility is gated
+    /// separately by <see cref="StrokeWidth"/> (0 hides stroke).
     /// </summary>
     public bool IsFilled
     {
@@ -1802,12 +1803,10 @@ public class RectangleRuntime : GraphicalUiElement
                 SetContainedObject(_stroke);
             }
 
-            // Initial defaults — stroke white, fill transparent (IsFilled = true so the gate is
-            // open, but FillColor alpha = 0 so nothing visible draws), layout 50x50. Issue
-            // #2938 (regression fix): a freshly-constructed RectangleRuntime renders as a
-            // stroke-only outline — matching the pre-#2938 visual that existing sample code
-            // (gallery frames, sample backgrounds) assumes. Assigning FillColor to a visible
-            // color lights up the fill without flipping IsFilled.
+            // Initial defaults — stroke white, fill white but gated off (IsFilled = false), so
+            // the fill slot is pushed a transparent color and a freshly-constructed
+            // RectangleRuntime renders as a stroke-only outline, layout 50x50. Flipping
+            // IsFilled = true paints the fill white without needing to assign FillColor.
             _stroke.Color = _strokeColor;
             if (_fill != null)
             {
@@ -1842,19 +1841,19 @@ public class RectangleRuntime : GraphicalUiElement
 
             SetStrokeRenderable(new ContainedLineRectangle { CornerRadius = 0 });
 
-            // Defaults: transparent fill, white stroke — RectangleRuntime's historical
-            // outline-only visual, now expressed as IsFilled = true (base default) + FillColor
-            // alpha 0. Symmetric with CircleRuntime's Skia branch: assigning FillColor to a
-            // visible color lights up the fill without flipping IsFilled. Pre-#2938 the Skia
-            // branch flipped IsFilled = false explicitly; that broke gallery code which does
-            // `frame.FillColor = darkGray;` without setting IsFilled.
+            // Defaults: white fill gated off (IsFilled = false) + white stroke —
+            // RectangleRuntime's stroke-only outline visual. Because FillColor defaults to
+            // opaque white, flipping IsFilled = true paints a white fill without assigning a
+            // color. IsFilled must be set explicitly here (the shared SkiaShapeRuntime base
+            // defaults it to true for the legacy single-color shapes).
             //
-            // FillColor must be explicitly assigned here even though the field default is
-            // transparent: SkiaShapeRuntime.PushFillColorToSlot only runs from the FillColor /
-            // IsFilled property setters, never from field init. Without this line the Skia
-            // RoundedRectangle renderable retains its own constructor default (white) and the
-            // rectangle renders as a solid white block. Mirrors CircleRuntime's Skia ctor.
-            FillColor = new SKColor(0, 0, 0, 0);
+            // FillColor must be explicitly assigned even though the gate forces transparent:
+            // SkiaShapeRuntime.PushFillColorToSlot only runs from the FillColor / IsFilled
+            // property setters, never from field init. Setting IsFilled = false re-pushes a
+            // transparent color into the fill slot, so the RoundedRectangle renderable doesn't
+            // retain its own white constructor default and render as a solid white block.
+            FillColor = SKColors.White;
+            IsFilled = false;
             StrokeColor = SKColors.White;
             StrokeWidth = 1;
             StrokeWidthUnits = DimensionUnitType.ScreenPixel;
@@ -1885,14 +1884,13 @@ public class RectangleRuntime : GraphicalUiElement
             // (LineRectangle.Render falls back to Color when StrokeColor is null and no fill
             // is requested) keeps working unchanged.
             //
-            // #2938 (regression fix) — push runtime-held FillColor / StrokeColor / IsFilled
-            // defaults onto the renderable so the runtime properties report consistent state at
-            // construction. FillColor defaults to transparent and IsFilled defaults to true →
-            // a fresh rectangle renders as a stroke-only outline (matching the pre-#2938
-            // visual that existing sample code assumes).
+            // Push runtime-held FillColor / StrokeColor / IsFilled defaults onto the renderable
+            // so the runtime properties report consistent state at construction. FillColor
+            // defaults to opaque white and IsFilled defaults to false → a fresh rectangle
+            // renders as a stroke-only outline; flipping IsFilled = true paints it white.
             rectangle.StrokeColor = _strokeColor;
             rectangle.FillColor = _fillColor;
-            rectangle.IsFilled = true;
+            rectangle.IsFilled = false;
 #endif
 
             Width = 50;

--- a/Runtimes/GumShapes/GueDeriving/ColoredCircleRuntime.cs
+++ b/Runtimes/GumShapes/GueDeriving/ColoredCircleRuntime.cs
@@ -18,7 +18,7 @@ namespace Gum.GueDeriving;
 /// Runtime that draws a circle (or ellipse) sized by its Width and Height. Adds no properties beyond
 /// the AposShapeRuntime common set - color, gradient, drop shadow, and fill/stroke are inherited.
 /// </summary>
-[Obsolete("Use CircleRuntime with FillColor (when IsFilled is true, the default) or StrokeColor (when IsFilled is false) instead. ColoredCircleRuntime will be removed in a future release. See docs/gum-tool/upgrading/migrating-to-2026-may.md for the full migration guide.")]
+[Obsolete("Use CircleRuntime instead: set StrokeColor for an outline, or set IsFilled = true for a fill (FillColor defaults to white). ColoredCircleRuntime will be removed in a future release. See docs/gum-tool/upgrading/migrating-to-2026-may.md for the full migration guide.")]
 public class ColoredCircleRuntime : AposShapeRuntime
 {
     protected override RenderableShapeBase ContainedRenderable => ContainedCircle;

--- a/Runtimes/SkiaGum/GueDeriving/ColoredCircleRuntime.cs
+++ b/Runtimes/SkiaGum/GueDeriving/ColoredCircleRuntime.cs
@@ -12,7 +12,7 @@ namespace SkiaGum.GueDeriving;
 namespace Gum.GueDeriving;
 #endif
 
-[Obsolete("Use CircleRuntime with FillColor (when IsFilled is true, the default) or StrokeColor (when IsFilled is false) instead. ColoredCircleRuntime will be removed in a future release. See docs/gum-tool/upgrading/migrating-to-2026-may.md for the full migration guide.")]
+[Obsolete("Use CircleRuntime instead: set StrokeColor for an outline, or set IsFilled = true for a fill (FillColor defaults to white). ColoredCircleRuntime will be removed in a future release. See docs/gum-tool/upgrading/migrating-to-2026-may.md for the full migration guide.")]
 public class ColoredCircleRuntime : SkiaShapeRuntime
 {
     protected override RenderableShapeBase ContainedRenderable => ContainedCircle;

--- a/Tests/MonoGameGum.Shapes.Tests/CircleRuntimeTests.cs
+++ b/Tests/MonoGameGum.Shapes.Tests/CircleRuntimeTests.cs
@@ -61,6 +61,7 @@ public class CircleRuntimeTests
     {
         CircleRuntime sut = new();
 
+        sut.IsFilled = true;
         sut.FillColor = Color.Red;
         sut.StrokeColor = Color.Blue;
 
@@ -75,6 +76,7 @@ public class CircleRuntimeTests
     {
         CircleRuntime sut = new();
 
+        sut.IsFilled = true;
         sut.FillColor = Color.Red;
 
         Circle fill = (Circle)sut.RenderableComponent;
@@ -225,6 +227,9 @@ public class CircleRuntimeTests
     {
         CircleRuntime sut = new();
 
+        // Dropshadow routes to the fill slot only when the shape is filled; IsFilled now
+        // defaults to false, so opt the fill in to exercise the fill-slot routing.
+        sut.IsFilled = true;
         sut.HasDropshadow = true;
         sut.DropshadowColor = new Color(10, 20, 30, 40);
         sut.DropshadowOffsetX = 5;
@@ -464,6 +469,7 @@ public class CircleRuntimeTests
     public void Clone_MutatingClone_DoesNotMutateSource()
     {
         CircleRuntime source = new();
+        source.IsFilled = true;
         source.FillColor = Color.Red;
         source.StrokeColor = Color.Blue;
 
@@ -574,6 +580,7 @@ public class CircleRuntimeTests
     {
         CircleRuntime sut = new();
 
+        sut.IsFilled = true;
         sut.FillRed = 10;
         sut.FillGreen = 20;
         sut.FillBlue = 30;
@@ -981,6 +988,7 @@ public class CircleRuntimeTests
     public void SetProperty_FillColor_WritesToFillSlot()
     {
         CircleRuntime sut = new();
+        sut.IsFilled = true;
 
         sut.SetProperty("FillColor", new Color(60, 70, 80, 255));
 

--- a/Tests/MonoGameGum.Shapes.Tests/RectangleRuntimeTests.cs
+++ b/Tests/MonoGameGum.Shapes.Tests/RectangleRuntimeTests.cs
@@ -128,6 +128,7 @@ public class RectangleRuntimeTests
     {
         RectangleRuntime sut = new();
 
+        sut.IsFilled = true;
         sut.FillColor = Color.Red;
         sut.StrokeColor = Color.Blue;
 
@@ -264,6 +265,9 @@ public class RectangleRuntimeTests
     {
         RectangleRuntime sut = new();
 
+        // Dropshadow routes to the fill slot only when the shape is filled; IsFilled now
+        // defaults to false, so opt the fill in to exercise the fill-slot routing.
+        sut.IsFilled = true;
         sut.HasDropshadow = true;
         sut.DropshadowColor = new Color(10, 20, 30, 40);
         sut.DropshadowOffsetX = 5;
@@ -439,6 +443,7 @@ public class RectangleRuntimeTests
     public void Clone_MutatingClone_DoesNotMutateSource()
     {
         RectangleRuntime source = new();
+        source.IsFilled = true;
         source.FillColor = Color.Red;
         source.StrokeColor = Color.Blue;
 
@@ -521,6 +526,7 @@ public class RectangleRuntimeTests
     {
         RectangleRuntime sut = new();
 
+        sut.IsFilled = true;
         sut.FillRed = 10;
         sut.FillGreen = 20;
         sut.FillBlue = 30;

--- a/Tests/SkiaGum.Tests/GueDeriving/CircleRuntimeTests.cs
+++ b/Tests/SkiaGum.Tests/GueDeriving/CircleRuntimeTests.cs
@@ -34,21 +34,22 @@ public class CircleRuntimeTests
         sut.Height.ShouldBe(32);
     }
 
-    // Issue #2938 — FillColor / StrokeColor are non-nullable on Skia, mirroring the XNALIKE
-    // CircleRuntime. The fill-hidden gate is IsFilled (defaults to true); stroke-hidden gate
-    // is StrokeWidth = 0.
+    // FillColor / StrokeColor are non-nullable on Skia, mirroring the XNALIKE CircleRuntime.
+    // FillColor defaults to opaque white and IsFilled defaults to false, so a fresh runtime
+    // renders as a stroke-only outline (the white fill is gated off). Flipping IsFilled = true
+    // fills the shape white without needing to also assign FillColor.
     [Fact]
-    public void FillColor_ShouldBeTransparent_ByDefault()
+    public void FillColor_ShouldBeWhite_ByDefault()
     {
         CircleRuntime sut = new();
-        sut.FillColor.ShouldBe(new SKColor(0, 0, 0, 0));
+        sut.FillColor.ShouldBe(new SKColor(255, 255, 255, 255));
     }
 
     [Fact]
-    public void IsFilled_ShouldBeTrue_ByDefault()
+    public void IsFilled_ShouldBeFalse_ByDefault()
     {
         CircleRuntime sut = new();
-        sut.IsFilled.ShouldBeTrue();
+        sut.IsFilled.ShouldBeFalse();
     }
 
     [Fact]
@@ -140,6 +141,7 @@ public class CircleRuntimeTests
     public void FillColorAndStrokeColor_BothSet_PaintsEachSlotIndependently()
     {
         CircleRuntime sut = new();
+        sut.IsFilled = true;
         sut.FillColor = SKColors.Crimson;
         sut.StrokeColor = SKColors.Cyan;
 
@@ -156,6 +158,7 @@ public class CircleRuntimeTests
     public void FillColorAndStrokeColor_SetInReverseOrder_StillPaintsBothSlots()
     {
         CircleRuntime sut = new();
+        sut.IsFilled = true;
         sut.StrokeColor = SKColors.Magenta;
         sut.FillColor = SKColors.Gold;
 
@@ -295,6 +298,7 @@ public class CircleRuntimeTests
     public void UseGradient_StrokeWidthZero_StrokeSlotStaysOff()
     {
         CircleRuntime sut = new();
+        sut.IsFilled = true;
         sut.StrokeWidth = 0;
         sut.UseGradient = true;
 
@@ -308,6 +312,7 @@ public class CircleRuntimeTests
     public void UseGradient_DefaultsBothSlotsOn()
     {
         CircleRuntime sut = new();
+        sut.IsFilled = true;
         sut.UseGradient = true;
 
         Circle fillSlot = (Circle)sut.RenderableComponent;
@@ -350,6 +355,7 @@ public class CircleRuntimeTests
     public void Dropshadow_FillColorSet_AppliesToFillSlot()
     {
         CircleRuntime sut = new();
+        sut.IsFilled = true;
         sut.FillColor = SKColors.Red;
         sut.HasDropshadow = true;
 
@@ -419,6 +425,7 @@ public class CircleRuntimeTests
     public void Clone_MutatingClone_DoesNotMutateSource()
     {
         CircleRuntime source = new();
+        source.IsFilled = true;
         source.FillColor = SKColors.Red;
         source.StrokeColor = SKColors.Blue;
 
@@ -464,6 +471,7 @@ public class CircleRuntimeTests
     public void Dropshadow_TargetSwitch_ClearsPreviousSlot()
     {
         CircleRuntime sut = new();
+        sut.IsFilled = true;
         sut.FillColor = SKColors.Red;
         sut.HasDropshadow = true;
         sut.PreRender();

--- a/Tests/SkiaGum.Tests/GueDeriving/RectangleRuntimeTests.cs
+++ b/Tests/SkiaGum.Tests/GueDeriving/RectangleRuntimeTests.cs
@@ -256,25 +256,22 @@ public class RectangleRuntimeTests
         strokeSlot.HasDropshadow.ShouldBeTrue();
     }
 
-    // Issue #2938 (regression fix) — RectangleRuntime preserves the historical Skia default of
-    // an invisible fill via FillColor = transparent (alpha 0). IsFilled is true by default
-    // (base behavior), so the gate is open — assigning FillColor to a visible color lights the
-    // fill up without needing to flip IsFilled.
+    // FillColor defaults to opaque white and IsFilled defaults to false, so a fresh runtime
+    // renders as a stroke-only outline (the white fill is gated off). Flipping IsFilled = true
+    // fills the shape white without needing to also assign FillColor.
     [Fact]
-    public void FillColor_ShouldBeTransparent_ByDefault()
+    public void FillColor_ShouldBeWhite_ByDefault()
     {
         RectangleRuntime sut = new();
-        sut.FillColor.ShouldBe(new SKColor(0, 0, 0, 0));
+        sut.FillColor.ShouldBe(new SKColor(255, 255, 255, 255));
     }
 
     // Regression guard for the gallery breakage caught after PR #2939's first fix attempt:
     // SkiaShapeRuntime.PushFillColorToSlot only runs from the FillColor / IsFilled setters,
-    // never from field init. If the ctor relies on the field default and skips the explicit
-    // FillColor assignment, the Skia RoundedRectangle renderable retains its own
-    // constructor default (SKColors.White at RoundedRectangle.cs:23) and the rectangle
-    // renders as a solid white block. The runtime property reports the transparent default
-    // — so the existing default test passes — while the actual visual is wrong. This test
-    // asserts the renderable's Color directly so the bug can't reappear silently.
+    // never from field init. With IsFilled = false by default the gate forces the fill slot's
+    // renderable Color to transparent regardless of the (now white) FillColor, so a fresh
+    // rectangle still renders stroke-only rather than as a solid white block. This test asserts
+    // the renderable's Color directly so the bug can't reappear silently.
     [Fact]
     public void FillRenderableColor_ShouldBeTransparent_ByDefault()
     {
@@ -284,10 +281,10 @@ public class RectangleRuntimeTests
     }
 
     [Fact]
-    public void IsFilled_ShouldBeTrue_ByDefault()
+    public void IsFilled_ShouldBeFalse_ByDefault()
     {
         RectangleRuntime sut = new();
-        sut.IsFilled.ShouldBeTrue();
+        sut.IsFilled.ShouldBeFalse();
     }
 
     // Issue #2938 — per-channel ints compose into FillColor via the same setter pipeline

--- a/Themes/Gum.Themes.Editor.MonoGame/ExpanderVisual.cs
+++ b/Themes/Gum.Themes.Editor.MonoGame/ExpanderVisual.cs
@@ -36,6 +36,7 @@ public class ExpanderVisual : InteractiveGue
 
         var headerBackground = new RectangleRuntime();
         headerBackground.Dock(Gum.Wireframe.Dock.Fill);
+        headerBackground.IsFilled = true;
         headerBackground.FillColor = new Color(50, 50, 50);
         headerBackground.StrokeWidth = 0;
         headerContainer.Children.Add(headerBackground);

--- a/Themes/Gum.Themes.Editor.MonoGame/PropertyGridVisual.cs
+++ b/Themes/Gum.Themes.Editor.MonoGame/PropertyGridVisual.cs
@@ -112,6 +112,7 @@ public class PropertyGridVisual : ContainerRuntime
         {
             var background = new RectangleRuntime();
             background.Dock(Gum.Wireframe.Dock.Fill);
+            background.IsFilled = true;
             background.StrokeWidth = 0;
             row.Children.Add(background);
         }


### PR DESCRIPTION
## What

Make filled shapes a "pit of success": `RectangleRuntime` and `CircleRuntime` now default `FillColor = white` and `IsFilled = false` on every backend.

Previously the constructors defaulted `IsFilled = true` with a **transparent** `FillColor`, so setting `IsFilled = true` alone left the shape invisible — authors had to remember to *also* assign `FillColor`. The new defaults mean a freshly-constructed shape is still a stroke-only outline (the white fill is gated off by `IsFilled = false`), but flipping `IsFilled = true` now produces a visible white fill with no extra setup. This matches the defaults the tool's data model already used (`StandardElementsManager` seeds `IsFilled = false` + opaque white fill).

## Changes

- **Runtime (`MonoGameGum/GueDeriving/RectangleRuntime.cs`, `CircleRuntime.cs`)** — flipped the `_fillColor` / `_isFilled` field + constructor defaults across XNALIKE, RAYLIB, and SKIA. SOKOL exposes no fill API and is untouched. Updated the surrounding doc comments.
- **Tests** — updated the runtime default-assertion tests (MonoGame core, Apos, Skia) to the new defaults, and added `IsFilled = true` to the fill/gradient/dropshadow tests that relied on the old default to exercise the fill slot.
- **Obsolete messages** — corrected the now-stale `ColoredCircleRuntime` obsolete text (SkiaGum + GumShapes) that claimed `IsFilled` defaults to true.
- **Editor theme** — `ExpanderVisual` and `PropertyGridVisual` had solid fills (`FillColor` + `StrokeWidth = 0`) relying on the old default; added explicit `IsFilled = true`. Editor was the **only** bundled theme relying on the default — the other five already set `IsFilled = true` at every fill site (verified: no file sets `FillColor` without `IsFilled = true`, and no shape kills its stroke without enabling the fill).

## Verification

All runtime test suites pass: MonoGame **1582**, Apos shapes **175**, Raylib **244**, Skia **180**. SokolGum and all six bundled theme projects build clean.

## Follow-up (not in this PR)

~22 demo sample/gallery screens (`GumShapesGallery`, `MonoGameGumInCode`, `raylib`, `SilkNetGum`, Maui/WPF Skia samples) use the `FillColor`-without-`IsFilled` pattern and will render those fills invisible until they get the same `IsFilled = true` sweep. Tracked as a separate pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
