### PR TITLE
Samples: set IsFilled = true on filled shapes after FillColor default flip

### DIFF
--- a/Samples/GumShapesGallery/GumShapesGalleryCommon/Screens/BatchMixStressScreen.cs
+++ b/Samples/GumShapesGallery/GumShapesGalleryCommon/Screens/BatchMixStressScreen.cs
@@ -70,6 +70,7 @@ internal class BatchMixStressScreen : FrameworkElement
             dot.Y = 8;
             dot.Radius = 12;
             dot.FillColor = Color.Goldenrod;
+            dot.IsFilled = true;
             row.AddChild(dot);
 
             scrollViewer.InnerPanel.Children.Add(row);

--- a/Samples/GumShapesGallery/GumShapesGalleryCommon/Screens/CirclesScreen.cs
+++ b/Samples/GumShapesGallery/GumShapesGalleryCommon/Screens/CirclesScreen.cs
@@ -128,6 +128,7 @@ internal class CirclesScreen : FrameworkElement
         CircleRuntime filled = new();
         filled.Radius = 28;
         filled.FillColor = Color.Crimson;
+        filled.IsFilled = true;
         row.AddChild(filled);
 
         CircleRuntime stroked = new();
@@ -179,6 +180,7 @@ internal class CirclesScreen : FrameworkElement
         CircleRuntime linearH = new();
         linearH.Radius = 28;
         linearH.FillColor = Color.White; // fill mode; gradient overrides solid color
+        linearH.IsFilled = true;
         linearH.UseGradient = true;
         linearH.GradientType = GradientType.Linear;
         linearH.Color1 = Color.White;
@@ -191,6 +193,7 @@ internal class CirclesScreen : FrameworkElement
         CircleRuntime linearV = new();
         linearV.Radius = 28;
         linearV.FillColor = Color.White;
+        linearV.IsFilled = true;
         linearV.UseGradient = true;
         linearV.GradientType = GradientType.Linear;
         linearV.Color1 = Color.Gold;
@@ -203,6 +206,7 @@ internal class CirclesScreen : FrameworkElement
         CircleRuntime linearD = new();
         linearD.Radius = 28;
         linearD.FillColor = Color.White;
+        linearD.IsFilled = true;
         linearD.UseGradient = true;
         linearD.GradientType = GradientType.Linear;
         linearD.Color1 = Color.Cyan;
@@ -215,6 +219,7 @@ internal class CirclesScreen : FrameworkElement
         CircleRuntime radial = new();
         radial.Radius = 28;
         radial.FillColor = Color.White;
+        radial.IsFilled = true;
         radial.UseGradient = true;
         radial.GradientType = GradientType.Radial;
         radial.Color1 = Color.White;
@@ -239,6 +244,7 @@ internal class CirclesScreen : FrameworkElement
             CircleRuntime filled = new();
             filled.Radius = 28;
             filled.FillColor = Color.Goldenrod;
+            filled.IsFilled = true;
             filled.IsAntialiased = aa;
             row.AddChild(filled);
 
@@ -265,12 +271,14 @@ internal class CirclesScreen : FrameworkElement
         CircleRuntime baseline = new();
         baseline.Radius = 28;
         baseline.FillColor = Color.Goldenrod;
+        baseline.IsFilled = true;
         row.AddChild(baseline);
 
         // Soft shadow: noticeable offset, generous blur, default opaque black.
         CircleRuntime soft = new();
         soft.Radius = 28;
         soft.FillColor = Color.Goldenrod;
+        soft.IsFilled = true;
         soft.HasDropshadow = true;
         soft.DropshadowOffsetX = 14;
         soft.DropshadowOffsetY = 14;
@@ -281,6 +289,7 @@ internal class CirclesScreen : FrameworkElement
         CircleRuntime hard = new();
         hard.Radius = 28;
         hard.FillColor = Color.Goldenrod;
+        hard.IsFilled = true;
         hard.HasDropshadow = true;
         hard.DropshadowColor = new Color(0, 0, 0, 160);
         hard.DropshadowOffsetX = 16;
@@ -294,6 +303,7 @@ internal class CirclesScreen : FrameworkElement
         CircleRuntime colored = new();
         colored.Radius = 28;
         colored.FillColor = Color.Goldenrod;
+        colored.IsFilled = true;
         colored.HasDropshadow = true;
         colored.DropshadowColor = new Color(220, 40, 160, 220);
         colored.DropshadowOffsetX = 16;
@@ -308,6 +318,7 @@ internal class CirclesScreen : FrameworkElement
         CircleRuntime fadedBody = new();
         fadedBody.Radius = 28;
         fadedBody.FillColor = new Color((byte)218, (byte)165, (byte)32, (byte)80);
+        fadedBody.IsFilled = true;
         fadedBody.HasDropshadow = true;
         fadedBody.DropshadowOffsetX = 14;
         fadedBody.DropshadowOffsetY = 14;
@@ -389,6 +400,7 @@ internal class CirclesScreen : FrameworkElement
         CircleRuntime strokeLast = new();
         strokeLast.Radius = 28;
         strokeLast.FillColor = Color.Crimson;
+        strokeLast.IsFilled = true;
         strokeLast.StrokeColor = Color.Cyan;
         strokeLast.StrokeWidth = 4;
         row.AddChild(strokeLast);
@@ -398,6 +410,7 @@ internal class CirclesScreen : FrameworkElement
         fillLast.StrokeColor = Color.Magenta;
         fillLast.StrokeWidth = 4;
         fillLast.FillColor = Color.Gold;
+        fillLast.IsFilled = true;
         row.AddChild(fillLast);
 
         return row;
@@ -418,6 +431,7 @@ internal class CirclesScreen : FrameworkElement
             CircleRuntime circle = new();
             circle.Radius = 28;
             circle.FillColor = Color.Red;
+            circle.IsFilled = true;
             circle.StrokeColor = Color.White;
             circle.StrokeWidth = strokeWidth;
             row.AddChild(circle);
@@ -461,6 +475,7 @@ internal class CirclesScreen : FrameworkElement
         frame.Width = width;
         frame.Height = height;
         frame.FillColor = new Color(60, 60, 80);
+        frame.IsFilled = true;
 
         CircleRuntime circle = new();
         circle.Width = width;
@@ -468,6 +483,7 @@ internal class CirclesScreen : FrameworkElement
         circle.WidthUnits = DimensionUnitType.Absolute;
         circle.HeightUnits = DimensionUnitType.Absolute;
         circle.FillColor = Color.SeaGreen;
+        circle.IsFilled = true;
         circle.StrokeColor = Color.Yellow;
         circle.StrokeWidth = 1;
         frame.Children.Add(circle);
@@ -480,10 +496,12 @@ internal class CirclesScreen : FrameworkElement
         frame.Width = 64;
         frame.Height = 64;
         frame.FillColor = new Color(60, 60, 80);
+        frame.IsFilled = true;
 
         CircleRuntime circle = new();
         circle.Radius = 32;
         circle.FillColor = Color.SeaGreen;
+        circle.IsFilled = true;
         circle.StrokeColor = Color.Yellow;
         circle.StrokeWidth = strokeWidth;
         circle.StrokeWidthUnits = DimensionUnitType.Absolute;
@@ -521,6 +539,7 @@ internal class CirclesScreen : FrameworkElement
         frame.Width = 70;
         frame.Height = 70;
         frame.FillColor = new Color(60, 60, 80);
+        frame.IsFilled = true;
 
         CircleRuntime circle = new();
         circle.Radius = 28;
@@ -531,6 +550,7 @@ internal class CirclesScreen : FrameworkElement
         if (filled)
         {
             circle.FillColor = Color.White;
+            circle.IsFilled = true;
         }
         else
         {
@@ -559,10 +579,12 @@ internal class CirclesScreen : FrameworkElement
         frame.Width = 128;
         frame.Height = 100;
         frame.FillColor = new Color(50, 50, 70);
+        frame.IsFilled = true;
 
         CircleRuntime circle = new();
         circle.Radius = 22;
         circle.FillColor = Color.Orange;
+        circle.IsFilled = true;
         circle.XOrigin = HorizontalAlignment.Center;
         circle.XUnits = Gum.Converters.GeneralUnitType.PixelsFromMiddle;
         circle.YOrigin = alignment;

--- a/Samples/GumShapesGallery/GumShapesGalleryCommon/Screens/ClippingScreen.cs
+++ b/Samples/GumShapesGallery/GumShapesGalleryCommon/Screens/ClippingScreen.cs
@@ -45,6 +45,7 @@ internal class ClippingScreen : FrameworkElement
         outsideClipShape.Y = 20;
         outsideClipShape.Radius = 24;
         outsideClipShape.FillColor = Color.OrangeRed;
+        outsideClipShape.IsFilled = true;
         AddChild(outsideClipShape);
 
         ScrollViewer scrollViewer = new ScrollViewer();
@@ -76,6 +77,7 @@ internal class ClippingScreen : FrameworkElement
             bg.Y = 2;
             bg.CornerRadius = 6;
             bg.FillColor = (i % 2 == 0) ? new Color(60, 60, 90) : new Color(80, 80, 120);
+            bg.IsFilled = true;
             row.AddChild(bg);
 
             CircleRuntime dot = new();
@@ -83,6 +85,7 @@ internal class ClippingScreen : FrameworkElement
             dot.Y = 8;
             dot.Radius = 12;
             dot.FillColor = Color.Goldenrod;
+            dot.IsFilled = true;
             row.AddChild(dot);
 
             TextRuntime label = new();

--- a/Samples/GumShapesGallery/GumShapesGalleryCommon/Screens/PolygonsScreen.cs
+++ b/Samples/GumShapesGallery/GumShapesGalleryCommon/Screens/PolygonsScreen.cs
@@ -89,6 +89,7 @@ internal class PolygonsScreen : FrameworkElement
         frame.Width = CellSize;
         frame.Height = CellSize;
         frame.FillColor = new Color(50, 50, 70);
+        frame.IsFilled = true;
         frame.Children.Add(polygon);
         return frame;
     }

--- a/Samples/GumShapesGallery/GumShapesGalleryCommon/Screens/RectanglesScreen.cs
+++ b/Samples/GumShapesGallery/GumShapesGalleryCommon/Screens/RectanglesScreen.cs
@@ -131,6 +131,7 @@ internal class RectanglesScreen : FrameworkElement
         RectangleRuntime filled = new();
         filled.Width = 80; filled.Height = 50;
         filled.FillColor = Color.Crimson;
+        filled.IsFilled = true;
         row.AddChild(filled);
 
         RectangleRuntime stroked = new();
@@ -142,6 +143,7 @@ internal class RectanglesScreen : FrameworkElement
         RectangleRuntime both = new();
         both.Width = 80; both.Height = 50;
         both.FillColor = new Color(40, 40, 80);
+        both.IsFilled = true;
         both.StrokeColor = Color.Yellow;
         both.StrokeWidth = 2;
         row.AddChild(both);
@@ -161,6 +163,7 @@ internal class RectanglesScreen : FrameworkElement
             RectangleRuntime rect = new();
             rect.Width = 70; rect.Height = 50;
             rect.FillColor = new Color(30, 30, 50);
+            rect.IsFilled = true;
             rect.StrokeColor = Color.LightGreen;
             rect.StrokeWidth = strokeWidth;
             row.AddChild(rect);
@@ -179,6 +182,7 @@ internal class RectanglesScreen : FrameworkElement
             RectangleRuntime rect = new();
             rect.Width = 80; rect.Height = 60;
             rect.FillColor = new Color(40, 40, 80);
+            rect.IsFilled = true;
             rect.StrokeColor = Color.Orange;
             rect.StrokeWidth = 2;
             rect.IsAntialiased = true;
@@ -197,6 +201,7 @@ internal class RectanglesScreen : FrameworkElement
         RectangleRuntime rect = new();
         rect.Width = 120; rect.Height = 70;
         rect.FillColor = new Color(40, 40, 80);
+        rect.IsFilled = true;
         rect.StrokeColor = Color.Orange;
         rect.StrokeWidth = 2;
         rect.CustomRadiusTopLeft = 20;
@@ -218,6 +223,7 @@ internal class RectanglesScreen : FrameworkElement
         RectangleRuntime linearH = new();
         linearH.Width = 70; linearH.Height = 50;
         linearH.FillColor = Color.White;
+        linearH.IsFilled = true;
         linearH.UseGradient = true;
         linearH.GradientType = GradientType.Linear;
         linearH.Color1 = Color.White;
@@ -229,6 +235,7 @@ internal class RectanglesScreen : FrameworkElement
         RectangleRuntime linearV = new();
         linearV.Width = 70; linearV.Height = 50;
         linearV.FillColor = Color.White;
+        linearV.IsFilled = true;
         linearV.UseGradient = true;
         linearV.GradientType = GradientType.Linear;
         linearV.Color1 = Color.Gold;
@@ -240,6 +247,7 @@ internal class RectanglesScreen : FrameworkElement
         RectangleRuntime linearD = new();
         linearD.Width = 70; linearD.Height = 50;
         linearD.FillColor = Color.White;
+        linearD.IsFilled = true;
         linearD.UseGradient = true;
         linearD.GradientType = GradientType.Linear;
         linearD.Color1 = Color.Cyan;
@@ -251,6 +259,7 @@ internal class RectanglesScreen : FrameworkElement
         RectangleRuntime radial = new();
         radial.Width = 70; radial.Height = 50;
         radial.FillColor = Color.White;
+        radial.IsFilled = true;
         radial.UseGradient = true;
         radial.GradientType = GradientType.Radial;
         radial.Color1 = Color.White;
@@ -273,6 +282,7 @@ internal class RectanglesScreen : FrameworkElement
             RectangleRuntime filled = new();
             filled.Width = 60; filled.Height = 50;
             filled.FillColor = Color.Goldenrod;
+            filled.IsFilled = true;
             filled.IsAntialiased = aa;
             row.AddChild(filled);
 
@@ -296,11 +306,13 @@ internal class RectanglesScreen : FrameworkElement
         RectangleRuntime baseline = new();
         baseline.Width = 60; baseline.Height = 50;
         baseline.FillColor = Color.Goldenrod;
+        baseline.IsFilled = true;
         row.AddChild(baseline);
 
         RectangleRuntime soft = new();
         soft.Width = 60; soft.Height = 50;
         soft.FillColor = Color.Goldenrod;
+        soft.IsFilled = true;
         soft.HasDropshadow = true;
         soft.DropshadowOffsetX = 14;
         soft.DropshadowOffsetY = 14;
@@ -310,6 +322,7 @@ internal class RectanglesScreen : FrameworkElement
         RectangleRuntime hard = new();
         hard.Width = 60; hard.Height = 50;
         hard.FillColor = Color.Goldenrod;
+        hard.IsFilled = true;
         hard.HasDropshadow = true;
         hard.DropshadowColor = new Color(0, 0, 0, 160);
         hard.DropshadowOffsetX = 16;
@@ -320,6 +333,7 @@ internal class RectanglesScreen : FrameworkElement
         RectangleRuntime colored = new();
         colored.Width = 60; colored.Height = 50;
         colored.FillColor = Color.Goldenrod;
+        colored.IsFilled = true;
         colored.HasDropshadow = true;
         colored.DropshadowColor = new Color(220, 40, 160, 220);
         colored.DropshadowOffsetX = 16;
@@ -331,6 +345,7 @@ internal class RectanglesScreen : FrameworkElement
         RectangleRuntime fadedBody = new();
         fadedBody.Width = 60; fadedBody.Height = 50;
         fadedBody.FillColor = new Color((byte)218, (byte)165, (byte)32, (byte)80);
+        fadedBody.IsFilled = true;
         fadedBody.HasDropshadow = true;
         fadedBody.DropshadowOffsetX = 14;
         fadedBody.DropshadowOffsetY = 14;
@@ -400,6 +415,7 @@ internal class RectanglesScreen : FrameworkElement
         RectangleRuntime strokeLast = new();
         strokeLast.Width = 80; strokeLast.Height = 50;
         strokeLast.FillColor = Color.Crimson;
+        strokeLast.IsFilled = true;
         strokeLast.StrokeColor = Color.Cyan;
         strokeLast.StrokeWidth = 4;
         row.AddChild(strokeLast);
@@ -409,6 +425,7 @@ internal class RectanglesScreen : FrameworkElement
         fillLast.StrokeColor = Color.Magenta;
         fillLast.StrokeWidth = 4;
         fillLast.FillColor = Color.Gold;
+        fillLast.IsFilled = true;
         row.AddChild(fillLast);
 
         return row;
@@ -453,6 +470,7 @@ internal class RectanglesScreen : FrameworkElement
         frame.Width = 100;
         frame.Height = 100;
         frame.FillColor = new Color(60, 60, 80);
+        frame.IsFilled = true;
 
         RectangleRuntime rect = new();
         rect.Width = 70;
@@ -464,6 +482,7 @@ internal class RectanglesScreen : FrameworkElement
         if (filled)
         {
             rect.FillColor = Color.White;
+            rect.IsFilled = true;
         }
         else
         {
@@ -486,11 +505,13 @@ internal class RectanglesScreen : FrameworkElement
         frame.Width = 64;
         frame.Height = 64;
         frame.FillColor = new Color(60, 60, 80);
+        frame.IsFilled = true;
 
         RectangleRuntime rect = new();
         rect.Width = 64;
         rect.Height = 64;
         rect.FillColor = Color.SeaGreen;
+        rect.IsFilled = true;
         rect.StrokeColor = Color.Yellow;
         rect.StrokeWidth = strokeWidth;
         rect.StrokeWidthUnits = DimensionUnitType.Absolute;
@@ -519,11 +540,13 @@ internal class RectanglesScreen : FrameworkElement
         frame.Width = 128;
         frame.Height = 100;
         frame.FillColor = new Color(50, 50, 70);
+        frame.IsFilled = true;
 
         RectangleRuntime rect = new();
         rect.Width = 50;
         rect.Height = 30;
         rect.FillColor = Color.Orange;
+        rect.IsFilled = true;
         rect.XOrigin = HorizontalAlignment.Center;
         rect.XUnits = Gum.Converters.GeneralUnitType.PixelsFromMiddle;
         rect.YOrigin = alignment;

--- a/Samples/MauiSkiaGum/MainPage.xaml.cs
+++ b/Samples/MauiSkiaGum/MainPage.xaml.cs
@@ -32,6 +32,7 @@ namespace MauiSkiaGum
             roundedRectangle.Width = 100;
             roundedRectangle.Height = 100;
             roundedRectangle.FillColor = SKColors.Blue;
+            roundedRectangle.IsFilled = true;
 
             // This is the default radius:
             roundedRectangle.CornerRadius = 20;
@@ -91,6 +92,7 @@ namespace MauiSkiaGum
             disc.Width = diameter;
             disc.Height = diameter;
             disc.FillColor = SKColors.Red;
+            disc.IsFilled = true;
             // CircleRuntime defaults to a 1 px white outline (#2790 two-slot defaults).
             // The pre-#2771 ColoredCircleRuntime had no stroke slot, so suppress the
             // outline to preserve the original solid-disc visual. Since #2938 the canonical
@@ -140,6 +142,7 @@ namespace MauiSkiaGum
             var circle = new CircleRuntime();
             MainStack.AddChild(circle);
             circle.FillColor = SKColors.Red;
+            circle.IsFilled = true;
             // Suppress the default 1 px white outline (see #2771 migration note) to
             // match the pre-migration ColoredCircleRuntime visual. Since #2938 the canonical
             // "hide stroke" gate is StrokeWidth = 0 (StrokeColor is non-nullable now).

--- a/Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/CirclesScreen.cs
+++ b/Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/CirclesScreen.cs
@@ -85,6 +85,7 @@ internal class CirclesScreen : FrameworkElement
         CircleRuntime filled = new();
         filled.Radius = 24;
         filled.FillColor = Color.Red;
+        filled.IsFilled = true;
         row.AddChild(filled);
 
         CircleRuntime stroked = new();
@@ -129,6 +130,7 @@ internal class CirclesScreen : FrameworkElement
         frame.Width = 200;
         frame.Height = 100;
         frame.FillColor = new Color(40, 40, 60);
+        frame.IsFilled = true;
 
         CircleRuntime circle = new();
         circle.Radius = 20;

--- a/Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/ClipScreen.cs
+++ b/Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/ClipScreen.cs
@@ -100,6 +100,7 @@ internal class ClipScreen : FrameworkElement
         oversized.Width = 220;
         oversized.Height = 140;
         oversized.FillColor = clipsChildren ? new Color(60, 120, 60) : new Color(120, 60, 60);
+        oversized.IsFilled = true;
         frame.AddChild(oversized);
 
         TextRuntime label = new();
@@ -144,6 +145,7 @@ internal class ClipScreen : FrameworkElement
         rect.Width = w;
         rect.Height = h;
         rect.FillColor = color;
+        rect.IsFilled = true;
         parent.AddChild(rect);
     }
 
@@ -192,6 +194,7 @@ internal class ClipScreen : FrameworkElement
         nestedOverflow.Width = 220;
         nestedOverflow.Height = 180;
         nestedOverflow.FillColor = new Color(60, 90, 140);
+        nestedOverflow.IsFilled = true;
         inner.AddChild(nestedOverflow);
 
         return outer;
@@ -219,6 +222,7 @@ internal class ClipScreen : FrameworkElement
         tile.Width = 140;
         tile.Height = 100;
         tile.FillColor = new Color(80, 80, 140);
+        tile.IsFilled = true;
         frame.AddChild(tile);
 
         // Text wider than the frame — clipping crops the right side of the glyphs.

--- a/Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/MixedScreen.cs
+++ b/Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/MixedScreen.cs
@@ -26,6 +26,7 @@ internal class MixedScreen : FrameworkElement
         filledRectangleInstance.Width = 120;
         filledRectangleInstance.Height = 24;
         filledRectangleInstance.FillColor = Color.White;
+        filledRectangleInstance.IsFilled = true;
         container.Children.Add(filledRectangleInstance);
 
         AddText(container, "This is a (line) rectangle:");
@@ -89,6 +90,7 @@ internal class MixedScreen : FrameworkElement
             rectangle.Width = 7;
             rectangle.Height = 7;
             rectangle.FillColor = Color.White;
+            rectangle.IsFilled = true;
         }
 
         container.Children.Add(stackingContainer);

--- a/Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/RectanglesScreen.cs
+++ b/Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/RectanglesScreen.cs
@@ -64,6 +64,7 @@ internal class RectanglesScreen : FrameworkElement
             rect.Width = width;
             rect.Height = 40;
             rect.FillColor = new Color(80, 80, 120);
+            rect.IsFilled = true;
             rect.StrokeColor = Color.White;
             row.AddChild(rect);
         }
@@ -79,6 +80,7 @@ internal class RectanglesScreen : FrameworkElement
             rect.Width = 60;
             rect.Height = 40;
             rect.FillColor = new Color((byte)255, (byte)255, (byte)255, alpha);
+            rect.IsFilled = true;
             row.AddChild(rect);
         }
         return row;
@@ -91,6 +93,7 @@ internal class RectanglesScreen : FrameworkElement
         RectangleRuntime filled = new();
         filled.Width = 80; filled.Height = 50;
         filled.FillColor = Color.Crimson;
+        filled.IsFilled = true;
         row.AddChild(filled);
 
         RectangleRuntime stroked = new();
@@ -102,6 +105,7 @@ internal class RectanglesScreen : FrameworkElement
         RectangleRuntime both = new();
         both.Width = 80; both.Height = 50;
         both.FillColor = new Color(40, 40, 80);
+        both.IsFilled = true;
         both.StrokeColor = Color.Yellow;
         both.StrokeWidth = 2;
         row.AddChild(both);
@@ -124,6 +128,7 @@ internal class RectanglesScreen : FrameworkElement
             RectangleRuntime rect = new();
             rect.Width = 70; rect.Height = 50;
             rect.FillColor = new Color(30, 30, 50);
+            rect.IsFilled = true;
             rect.StrokeColor = Color.LightGreen;
             rect.StrokeWidth = strokeWidth;
             row.AddChild(rect);
@@ -144,6 +149,7 @@ internal class RectanglesScreen : FrameworkElement
             rect.Width = 80;
             rect.Height = 50;
             rect.FillColor = new Color(30, 30, 50);
+            rect.IsFilled = true;
             rect.StrokeColor = Color.LightGreen;
             rect.StrokeWidth = 2;
             rect.IsAntialiased = aa;
@@ -183,11 +189,13 @@ internal class RectanglesScreen : FrameworkElement
         frame.Width = 220;
         frame.Height = 100;
         frame.FillColor = new Color(40, 40, 60);
+        frame.IsFilled = true;
 
         RectangleRuntime rect = new();
         rect.Width = 60;
         rect.Height = 30;
         rect.FillColor = Color.Orange;
+        rect.IsFilled = true;
         rect.XOrigin = HorizontalAlignment.Center;
         rect.XUnits = Gum.Converters.GeneralUnitType.PixelsFromMiddle;
         rect.YOrigin = alignment;

--- a/Samples/SilkNetGum/SilkNetGum/Screens/CirclesScreen.cs
+++ b/Samples/SilkNetGum/SilkNetGum/Screens/CirclesScreen.cs
@@ -122,6 +122,7 @@ internal class CirclesScreen : GraphicalUiElement
         CircleRuntime filled = new();
         filled.Radius = 28;
         filled.FillColor = SKColors.Crimson;
+        filled.IsFilled = true;
         row.Children.Add(filled);
 
         CircleRuntime stroked = new();
@@ -169,6 +170,7 @@ internal class CirclesScreen : GraphicalUiElement
         CircleRuntime linearH = new();
         linearH.Radius = 28;
         linearH.FillColor = SKColors.White; // fill mode; gradient overrides solid color
+        linearH.IsFilled = true;
         linearH.UseGradient = true;
         linearH.GradientType = GradientType.Linear;
         linearH.Color1 = SKColors.White;
@@ -181,6 +183,7 @@ internal class CirclesScreen : GraphicalUiElement
         CircleRuntime linearV = new();
         linearV.Radius = 28;
         linearV.FillColor = SKColors.White;
+        linearV.IsFilled = true;
         linearV.UseGradient = true;
         linearV.GradientType = GradientType.Linear;
         linearV.Color1 = SKColors.Gold;
@@ -193,6 +196,7 @@ internal class CirclesScreen : GraphicalUiElement
         CircleRuntime linearD = new();
         linearD.Radius = 28;
         linearD.FillColor = SKColors.White;
+        linearD.IsFilled = true;
         linearD.UseGradient = true;
         linearD.GradientType = GradientType.Linear;
         linearD.Color1 = SKColors.Cyan;
@@ -205,6 +209,7 @@ internal class CirclesScreen : GraphicalUiElement
         CircleRuntime radial = new();
         radial.Radius = 28;
         radial.FillColor = SKColors.White;
+        radial.IsFilled = true;
         radial.UseGradient = true;
         radial.GradientType = GradientType.Radial;
         radial.Color1 = SKColors.White;
@@ -227,6 +232,7 @@ internal class CirclesScreen : GraphicalUiElement
         CircleRuntime strokeLast = new();
         strokeLast.Radius = 28;
         strokeLast.FillColor = SKColors.Crimson;
+        strokeLast.IsFilled = true;
         strokeLast.StrokeColor = SKColors.Cyan;
         strokeLast.StrokeWidth = 4;
         row.Children.Add(strokeLast);
@@ -236,6 +242,7 @@ internal class CirclesScreen : GraphicalUiElement
         fillLast.StrokeColor = SKColors.Magenta;
         fillLast.StrokeWidth = 4;
         fillLast.FillColor = SKColors.Gold;
+        fillLast.IsFilled = true;
         row.Children.Add(fillLast);
 
         return row;
@@ -254,6 +261,7 @@ internal class CirclesScreen : GraphicalUiElement
             CircleRuntime circle = new();
             circle.Radius = 28;
             circle.FillColor = SKColors.Red;
+            circle.IsFilled = true;
             circle.StrokeColor = SKColors.White;
             circle.StrokeWidth = strokeWidth;
             row.Children.Add(circle);
@@ -296,6 +304,7 @@ internal class CirclesScreen : GraphicalUiElement
         frame.Width = width;
         frame.Height = height;
         frame.FillColor = new SKColor(60, 60, 80);
+        frame.IsFilled = true;
 
         CircleRuntime circle = new();
         circle.Width = width;
@@ -303,6 +312,7 @@ internal class CirclesScreen : GraphicalUiElement
         circle.WidthUnits = DimensionUnitType.Absolute;
         circle.HeightUnits = DimensionUnitType.Absolute;
         circle.FillColor = SKColors.SeaGreen;
+        circle.IsFilled = true;
         circle.StrokeColor = SKColors.Yellow;
         circle.StrokeWidth = 1;
         frame.Children.Add(circle);
@@ -315,10 +325,12 @@ internal class CirclesScreen : GraphicalUiElement
         frame.Width = 64;
         frame.Height = 64;
         frame.FillColor = new SKColor(60, 60, 80);
+        frame.IsFilled = true;
 
         CircleRuntime circle = new();
         circle.Radius = 32;
         circle.FillColor = SKColors.SeaGreen;
+        circle.IsFilled = true;
         circle.StrokeColor = SKColors.Yellow;
         circle.StrokeWidth = strokeWidth;
         circle.StrokeWidthUnits = DimensionUnitType.Absolute;
@@ -338,6 +350,7 @@ internal class CirclesScreen : GraphicalUiElement
             CircleRuntime filled = new();
             filled.Radius = 28;
             filled.FillColor = SKColors.Goldenrod;
+            filled.IsFilled = true;
             filled.IsAntialiased = aa;
             row.Children.Add(filled);
 
@@ -363,12 +376,14 @@ internal class CirclesScreen : GraphicalUiElement
         CircleRuntime baseline = new();
         baseline.Radius = 28;
         baseline.FillColor = SKColors.Goldenrod;
+        baseline.IsFilled = true;
         row.Children.Add(baseline);
 
         // Soft shadow: noticeable offset, generous blur, default opaque black.
         CircleRuntime soft = new();
         soft.Radius = 28;
         soft.FillColor = SKColors.Goldenrod;
+        soft.IsFilled = true;
         soft.HasDropshadow = true;
         soft.DropshadowOffsetX = 14;
         soft.DropshadowOffsetY = 14;
@@ -381,6 +396,7 @@ internal class CirclesScreen : GraphicalUiElement
         CircleRuntime hard = new();
         hard.Radius = 28;
         hard.FillColor = SKColors.Goldenrod;
+        hard.IsFilled = true;
         hard.HasDropshadow = true;
         hard.DropshadowRed = 0; hard.DropshadowGreen = 0; hard.DropshadowBlue = 0; hard.DropshadowAlpha = 160;
         hard.DropshadowOffsetX = 16;
@@ -394,6 +410,7 @@ internal class CirclesScreen : GraphicalUiElement
         CircleRuntime colored = new();
         colored.Radius = 28;
         colored.FillColor = SKColors.Goldenrod;
+        colored.IsFilled = true;
         colored.HasDropshadow = true;
         colored.DropshadowRed = 220; colored.DropshadowGreen = 40; colored.DropshadowBlue = 160; colored.DropshadowAlpha = 220;
         colored.DropshadowOffsetX = 16;
@@ -408,6 +425,7 @@ internal class CirclesScreen : GraphicalUiElement
         CircleRuntime fadedBody = new();
         fadedBody.Radius = 28;
         fadedBody.FillColor = new SKColor(218, 165, 32, 80);
+        fadedBody.IsFilled = true;
         fadedBody.HasDropshadow = true;
         fadedBody.DropshadowOffsetX = 14;
         fadedBody.DropshadowOffsetY = 14;
@@ -500,6 +518,7 @@ internal class CirclesScreen : GraphicalUiElement
         frame.Width = 70;
         frame.Height = 70;
         frame.FillColor = new SKColor(60, 60, 80);
+        frame.IsFilled = true;
 
         CircleRuntime circle = new();
         circle.Radius = 28;
@@ -510,6 +529,7 @@ internal class CirclesScreen : GraphicalUiElement
         if (filled)
         {
             circle.FillColor = SKColors.White;
+            circle.IsFilled = true;
         }
         else
         {
@@ -538,10 +558,12 @@ internal class CirclesScreen : GraphicalUiElement
         frame.Width = 128;
         frame.Height = 100;
         frame.FillColor = new SKColor(50, 50, 70);
+        frame.IsFilled = true;
 
         CircleRuntime circle = new();
         circle.Radius = 22;
         circle.FillColor = SKColors.Orange;
+        circle.IsFilled = true;
         circle.XOrigin = HorizontalAlignment.Center;
         circle.XUnits = Gum.Converters.GeneralUnitType.PixelsFromMiddle;
         circle.YOrigin = alignment;

--- a/Samples/SilkNetGum/SilkNetGum/Screens/CodeOnlyScreen.cs
+++ b/Samples/SilkNetGum/SilkNetGum/Screens/CodeOnlyScreen.cs
@@ -28,6 +28,7 @@ internal class CodeOnlyScreen : GraphicalUiElement
                 (byte)(50 + random.Next(150)),
                 (byte)(50 + random.Next(150)),
                 (byte)(50 + random.Next(150)));
+            rectangle.IsFilled = true;
 
             rectangle.Width = 50;
             rectangle.Height = 50;

--- a/Samples/SilkNetGum/SilkNetGum/Screens/PolygonsScreen.cs
+++ b/Samples/SilkNetGum/SilkNetGum/Screens/PolygonsScreen.cs
@@ -84,6 +84,7 @@ internal class PolygonsScreen : GraphicalUiElement
         frame.Width = CellSize;
         frame.Height = CellSize;
         frame.FillColor = new SKColor(50, 50, 70);
+        frame.IsFilled = true;
         frame.Children.Add(polygon);
         return frame;
     }

--- a/Samples/SilkNetGum/SilkNetGum/Screens/RectanglesScreen.cs
+++ b/Samples/SilkNetGum/SilkNetGum/Screens/RectanglesScreen.cs
@@ -127,6 +127,7 @@ internal class RectanglesScreen : GraphicalUiElement
         RectangleRuntime filled = new();
         filled.Width = 80; filled.Height = 50;
         filled.FillColor = SKColors.Crimson;
+        filled.IsFilled = true;
         row.Children.Add(filled);
 
         RectangleRuntime stroked = new();
@@ -138,6 +139,7 @@ internal class RectanglesScreen : GraphicalUiElement
         RectangleRuntime both = new();
         both.Width = 80; both.Height = 50;
         both.FillColor = new SKColor(40, 40, 80);
+        both.IsFilled = true;
         both.StrokeColor = SKColors.Yellow;
         both.StrokeWidth = 2;
         row.Children.Add(both);
@@ -187,6 +189,7 @@ internal class RectanglesScreen : GraphicalUiElement
             rect.Width = 80;
             rect.Height = 60;
             rect.FillColor = new SKColor(40, 40, 80);
+            rect.IsFilled = true;
             rect.StrokeColor = SKColors.Orange;
             rect.StrokeWidth = 2;
             rect.CornerRadius = cornerRadius;
@@ -204,6 +207,7 @@ internal class RectanglesScreen : GraphicalUiElement
         RectangleRuntime rect = new();
         rect.Width = 120; rect.Height = 70;
         rect.FillColor = new SKColor(40, 40, 80);
+        rect.IsFilled = true;
         rect.StrokeColor = SKColors.Orange;
         rect.StrokeWidth = 2;
         rect.CustomRadiusTopLeft = 20;
@@ -222,6 +226,7 @@ internal class RectanglesScreen : GraphicalUiElement
         RectangleRuntime linearH = new();
         linearH.Width = 70; linearH.Height = 50;
         linearH.FillColor = SKColors.White; // fill mode; gradient overrides solid color
+        linearH.IsFilled = true;
         linearH.UseGradient = true;
         linearH.GradientType = GradientType.Linear;
         linearH.Color1 = SKColors.White;
@@ -234,6 +239,7 @@ internal class RectanglesScreen : GraphicalUiElement
         RectangleRuntime linearV = new();
         linearV.Width = 70; linearV.Height = 50;
         linearV.FillColor = SKColors.White;
+        linearV.IsFilled = true;
         linearV.UseGradient = true;
         linearV.GradientType = GradientType.Linear;
         linearV.Color1 = SKColors.Gold;
@@ -246,6 +252,7 @@ internal class RectanglesScreen : GraphicalUiElement
         RectangleRuntime linearD = new();
         linearD.Width = 70; linearD.Height = 50;
         linearD.FillColor = SKColors.White;
+        linearD.IsFilled = true;
         linearD.UseGradient = true;
         linearD.GradientType = GradientType.Linear;
         linearD.Color1 = SKColors.Cyan;
@@ -258,6 +265,7 @@ internal class RectanglesScreen : GraphicalUiElement
         RectangleRuntime radial = new();
         radial.Width = 70; radial.Height = 50;
         radial.FillColor = SKColors.White;
+        radial.IsFilled = true;
         radial.UseGradient = true;
         radial.GradientType = GradientType.Radial;
         radial.Color1 = SKColors.White;
@@ -280,6 +288,7 @@ internal class RectanglesScreen : GraphicalUiElement
         RectangleRuntime strokeLast = new();
         strokeLast.Width = 80; strokeLast.Height = 50;
         strokeLast.FillColor = SKColors.Crimson;
+        strokeLast.IsFilled = true;
         strokeLast.StrokeColor = SKColors.Cyan;
         strokeLast.StrokeWidth = 4;
         row.Children.Add(strokeLast);
@@ -289,6 +298,7 @@ internal class RectanglesScreen : GraphicalUiElement
         fillLast.StrokeColor = SKColors.Magenta;
         fillLast.StrokeWidth = 4;
         fillLast.FillColor = SKColors.Gold;
+        fillLast.IsFilled = true;
         row.Children.Add(fillLast);
 
         return row;
@@ -333,6 +343,7 @@ internal class RectanglesScreen : GraphicalUiElement
         frame.Width = 100;
         frame.Height = 100;
         frame.FillColor = new SKColor(60, 60, 80);
+        frame.IsFilled = true;
 
         RectangleRuntime rect = new();
         rect.Width = 70;
@@ -344,6 +355,7 @@ internal class RectanglesScreen : GraphicalUiElement
         if (filled)
         {
             rect.FillColor = SKColors.White;
+            rect.IsFilled = true;
         }
         else
         {
@@ -366,11 +378,13 @@ internal class RectanglesScreen : GraphicalUiElement
         frame.Width = 64;
         frame.Height = 64;
         frame.FillColor = new SKColor(60, 60, 80);
+        frame.IsFilled = true;
 
         RectangleRuntime rect = new();
         rect.Width = 64;
         rect.Height = 64;
         rect.FillColor = SKColors.SeaGreen;
+        rect.IsFilled = true;
         rect.StrokeColor = SKColors.Yellow;
         rect.StrokeWidth = strokeWidth;
         rect.StrokeWidthUnits = DimensionUnitType.Absolute;
@@ -390,6 +404,7 @@ internal class RectanglesScreen : GraphicalUiElement
             RectangleRuntime filled = new();
             filled.Width = 60; filled.Height = 50;
             filled.FillColor = SKColors.Goldenrod;
+            filled.IsFilled = true;
             filled.IsAntialiased = aa;
             row.Children.Add(filled);
 
@@ -415,12 +430,14 @@ internal class RectanglesScreen : GraphicalUiElement
         RectangleRuntime baseline = new();
         baseline.Width = 60; baseline.Height = 50;
         baseline.FillColor = SKColors.Goldenrod;
+        baseline.IsFilled = true;
         row.Children.Add(baseline);
 
         // Soft shadow: noticeable offset, generous blur, default opaque black.
         RectangleRuntime soft = new();
         soft.Width = 60; soft.Height = 50;
         soft.FillColor = SKColors.Goldenrod;
+        soft.IsFilled = true;
         soft.HasDropshadow = true;
         soft.DropshadowOffsetX = 14;
         soft.DropshadowOffsetY = 14;
@@ -433,6 +450,7 @@ internal class RectanglesScreen : GraphicalUiElement
         RectangleRuntime hard = new();
         hard.Width = 60; hard.Height = 50;
         hard.FillColor = SKColors.Goldenrod;
+        hard.IsFilled = true;
         hard.HasDropshadow = true;
         hard.DropshadowRed = 0; hard.DropshadowGreen = 0; hard.DropshadowBlue = 0; hard.DropshadowAlpha = 160;
         hard.DropshadowOffsetX = 16;
@@ -446,6 +464,7 @@ internal class RectanglesScreen : GraphicalUiElement
         RectangleRuntime colored = new();
         colored.Width = 60; colored.Height = 50;
         colored.FillColor = SKColors.Goldenrod;
+        colored.IsFilled = true;
         colored.HasDropshadow = true;
         colored.DropshadowRed = 220; colored.DropshadowGreen = 40; colored.DropshadowBlue = 160; colored.DropshadowAlpha = 220;
         colored.DropshadowOffsetX = 16;
@@ -457,6 +476,7 @@ internal class RectanglesScreen : GraphicalUiElement
         RectangleRuntime fadedBody = new();
         fadedBody.Width = 60; fadedBody.Height = 50;
         fadedBody.FillColor = new SKColor(218, 165, 32, 80);
+        fadedBody.IsFilled = true;
         fadedBody.HasDropshadow = true;
         fadedBody.DropshadowOffsetX = 14;
         fadedBody.DropshadowOffsetY = 14;
@@ -533,11 +553,13 @@ internal class RectanglesScreen : GraphicalUiElement
         frame.Width = 128;
         frame.Height = 100;
         frame.FillColor = new SKColor(50, 50, 70);
+        frame.IsFilled = true;
 
         RectangleRuntime rect = new();
         rect.Width = 50;
         rect.Height = 30;
         rect.FillColor = SKColors.Orange;
+        rect.IsFilled = true;
         rect.XOrigin = HorizontalAlignment.Center;
         rect.XUnits = Gum.Converters.GeneralUnitType.PixelsFromMiddle;
         rect.YOrigin = alignment;

--- a/Samples/SkiaGumWpfSample/SkiaGumWpfSample/MainWindow.xaml.cs
+++ b/Samples/SkiaGumWpfSample/SkiaGumWpfSample/MainWindow.xaml.cs
@@ -34,10 +34,12 @@ namespace SkiaGumWpfSample
             var rectangle = new RectangleRuntime();
 
             rectangle.FillColor = new SkiaSharp.SKColor(50, 100, 0);
+            rectangle.IsFilled = true;
             container.Children.Add(rectangle);
 
             var rectangle2 = new RectangleRuntime();
             rectangle2.FillColor = new SkiaSharp.SKColor(200, 0, 0);
+            rectangle2.IsFilled = true;
 
             container.Children.Add(rectangle2);
 

--- a/Samples/raylib/Screens/CirclesScreen.cs
+++ b/Samples/raylib/Screens/CirclesScreen.cs
@@ -136,6 +136,7 @@ internal class CirclesScreen : FrameworkElement
         CircleRuntime filled = new();
         filled.Radius = 28;
         filled.FillColor = new Color(220, 20, 60, 255);
+        filled.IsFilled = true;
         row.Children.Add(filled);
 
         CircleRuntime stroked = new();
@@ -218,6 +219,7 @@ internal class CirclesScreen : FrameworkElement
         frame.Width = 70;
         frame.Height = 70;
         frame.FillColor = new Color(60, 60, 80, 255);
+        frame.IsFilled = true;
 
         CircleRuntime circle = new();
         circle.Radius = 28;
@@ -228,6 +230,7 @@ internal class CirclesScreen : FrameworkElement
         // Filled cell — light up the fill slot with an opaque color so the gradient renders
         // on the fill. raylib's outline-only case is handled by BuildRotationOutlineUnsupportedRow.
         circle.FillColor = Color.White;
+        circle.IsFilled = true;
         circle.UseGradient = true;
         circle.GradientType = GradientType.Linear;
         circle.Color1 = Color.Black;
@@ -245,10 +248,12 @@ internal class CirclesScreen : FrameworkElement
         frame.Width = 128;
         frame.Height = 100;
         frame.FillColor = new Color(50, 50, 70, 255);
+        frame.IsFilled = true;
 
         CircleRuntime circle = new();
         circle.Radius = 22;
         circle.FillColor = new Color(255, 165, 0, 255);
+        circle.IsFilled = true;
         circle.XOrigin = HorizontalAlignment.Center;
         circle.XUnits = GeneralUnitType.PixelsFromMiddle;
         circle.YOrigin = alignment;
@@ -275,6 +280,7 @@ internal class CirclesScreen : FrameworkElement
         CircleRuntime linearH = new();
         linearH.Radius = 28;
         linearH.FillColor = Color.White;
+        linearH.IsFilled = true;
         linearH.UseGradient = true;
         linearH.GradientType = GradientType.Linear;
         linearH.Color1 = Color.White;
@@ -287,6 +293,7 @@ internal class CirclesScreen : FrameworkElement
         CircleRuntime linearV = new();
         linearV.Radius = 28;
         linearV.FillColor = Color.White;
+        linearV.IsFilled = true;
         linearV.UseGradient = true;
         linearV.GradientType = GradientType.Linear;
         linearV.Color1 = new Color(255, 215, 0, 255);
@@ -299,6 +306,7 @@ internal class CirclesScreen : FrameworkElement
         CircleRuntime linearD = new();
         linearD.Radius = 28;
         linearD.FillColor = Color.White;
+        linearD.IsFilled = true;
         linearD.UseGradient = true;
         linearD.GradientType = GradientType.Linear;
         linearD.Color1 = new Color(0, 255, 255, 255);
@@ -311,6 +319,7 @@ internal class CirclesScreen : FrameworkElement
         CircleRuntime radial = new();
         radial.Radius = 28;
         radial.FillColor = Color.White;
+        radial.IsFilled = true;
         radial.UseGradient = true;
         radial.GradientType = GradientType.Radial;
         radial.Color1 = Color.White;
@@ -333,6 +342,7 @@ internal class CirclesScreen : FrameworkElement
         CircleRuntime strokeLast = new();
         strokeLast.Radius = 28;
         strokeLast.FillColor = new Color(220, 20, 60, 255);
+        strokeLast.IsFilled = true;
         strokeLast.StrokeColor = new Color(0, 255, 255, 255);
         strokeLast.StrokeWidth = 4;
         row.Children.Add(strokeLast);
@@ -342,6 +352,7 @@ internal class CirclesScreen : FrameworkElement
         fillLast.StrokeColor = new Color(255, 0, 255, 255);
         fillLast.StrokeWidth = 4;
         fillLast.FillColor = new Color(255, 215, 0, 255);
+        fillLast.IsFilled = true;
         row.Children.Add(fillLast);
 
         return row;
@@ -361,6 +372,7 @@ internal class CirclesScreen : FrameworkElement
             CircleRuntime circle = new();
             circle.Radius = 28;
             circle.FillColor = red;
+            circle.IsFilled = true;
             circle.StrokeColor = Color.White;
             circle.StrokeWidth = strokeWidth;
             row.Children.Add(circle);
@@ -397,6 +409,7 @@ internal class CirclesScreen : FrameworkElement
         frame.Width = width;
         frame.Height = height;
         frame.FillColor = new Color(60, 60, 80, 255);
+        frame.IsFilled = true;
 
         CircleRuntime circle = new();
         circle.Width = width;
@@ -404,6 +417,7 @@ internal class CirclesScreen : FrameworkElement
         circle.WidthUnits = DimensionUnitType.Absolute;
         circle.HeightUnits = DimensionUnitType.Absolute;
         circle.FillColor = new Color(46, 139, 87, 255);
+        circle.IsFilled = true;
         circle.StrokeColor = Color.Yellow;
         circle.StrokeWidth = 1;
         frame.Children.Add(circle);
@@ -416,10 +430,12 @@ internal class CirclesScreen : FrameworkElement
         frame.Width = 64;
         frame.Height = 64;
         frame.FillColor = new Color(60, 60, 80, 255);
+        frame.IsFilled = true;
 
         CircleRuntime circle = new();
         circle.Radius = 32;
         circle.FillColor = new Color(46, 139, 87, 255);
+        circle.IsFilled = true;
         circle.StrokeColor = new Color(255, 255, 0, 255);
         circle.StrokeWidth = strokeWidth;
         circle.StrokeWidthUnits = DimensionUnitType.Absolute;
@@ -485,12 +501,14 @@ internal class CirclesScreen : FrameworkElement
         CircleRuntime baseline = new();
         baseline.Radius = 28;
         baseline.FillColor = goldenrod;
+        baseline.IsFilled = true;
         row.Children.Add(baseline);
 
         // Soft shadow: noticeable offset, generous blur, default opaque black.
         CircleRuntime soft = new();
         soft.Radius = 28;
         soft.FillColor = goldenrod;
+        soft.IsFilled = true;
         soft.HasDropshadow = true;
         soft.DropshadowOffsetX = 14;
         soft.DropshadowOffsetY = 14;
@@ -502,6 +520,7 @@ internal class CirclesScreen : FrameworkElement
         CircleRuntime hard = new();
         hard.Radius = 28;
         hard.FillColor = goldenrod;
+        hard.IsFilled = true;
         hard.HasDropshadow = true;
         hard.DropshadowRed = 0; hard.DropshadowGreen = 0; hard.DropshadowBlue = 0; hard.DropshadowAlpha = 160;
         hard.DropshadowOffsetX = 16;
@@ -514,6 +533,7 @@ internal class CirclesScreen : FrameworkElement
         CircleRuntime colored = new();
         colored.Radius = 28;
         colored.FillColor = goldenrod;
+        colored.IsFilled = true;
         colored.HasDropshadow = true;
         colored.DropshadowRed = 220; colored.DropshadowGreen = 40; colored.DropshadowBlue = 160; colored.DropshadowAlpha = 220;
         colored.DropshadowOffsetX = 16;
@@ -528,6 +548,7 @@ internal class CirclesScreen : FrameworkElement
         CircleRuntime fadedBody = new();
         fadedBody.Radius = 28;
         fadedBody.FillColor = new Color((byte)218, (byte)165, (byte)32, (byte)80);
+        fadedBody.IsFilled = true;
         fadedBody.HasDropshadow = true;
         fadedBody.DropshadowOffsetX = 14;
         fadedBody.DropshadowOffsetY = 14;

--- a/Samples/raylib/Screens/PolygonsScreen.cs
+++ b/Samples/raylib/Screens/PolygonsScreen.cs
@@ -88,6 +88,7 @@ internal class PolygonsScreen : FrameworkElement
         frame.Width = CellSize;
         frame.Height = CellSize;
         frame.FillColor = new Color(50, 50, 70, 255);
+        frame.IsFilled = true;
         frame.Children.Add(polygon);
         return frame;
     }

--- a/Samples/raylib/Screens/RawVisualsScreen.cs
+++ b/Samples/raylib/Screens/RawVisualsScreen.cs
@@ -138,16 +138,19 @@ internal class RawVisualsScreen : FrameworkElement
         rectangle.Width = 80;
         rectangle.Height = 80;
         rectangle.FillColor = new Color(80, 160, 220, 255);
+        rectangle.IsFilled = true;
         row.AddChild(rectangle);
 
         var circle = new CircleRuntime();
         circle.Radius = 40;
         circle.FillColor = new Color(255, 100, 50, 255);
+        circle.IsFilled = true;
         row.AddChild(circle);
 
         var bigCircle = new CircleRuntime();
         bigCircle.Radius = 60;
         bigCircle.FillColor = new Color(50, 180, 80, 255);
+        bigCircle.IsFilled = true;
         row.AddChild(bigCircle);
     }
 

--- a/Samples/raylib/Screens/RectanglesScreen.cs
+++ b/Samples/raylib/Screens/RectanglesScreen.cs
@@ -138,6 +138,7 @@ internal class RectanglesScreen : FrameworkElement
         RectangleRuntime filled = new();
         filled.Width = 80; filled.Height = 50;
         filled.FillColor = new Color(220, 20, 60, 255);
+        filled.IsFilled = true;
         row.Children.Add(filled);
 
         RectangleRuntime stroked = new();
@@ -149,6 +150,7 @@ internal class RectanglesScreen : FrameworkElement
         RectangleRuntime both = new();
         both.Width = 80; both.Height = 50;
         both.FillColor = new Color(40, 40, 80, 255);
+        both.IsFilled = true;
         both.StrokeColor = new Color(255, 255, 0, 255);
         both.StrokeWidth = 2;
         row.Children.Add(both);
@@ -191,11 +193,13 @@ internal class RectanglesScreen : FrameworkElement
         frame.Width = 128;
         frame.Height = 100;
         frame.FillColor = new Color(50, 50, 70, 255);
+        frame.IsFilled = true;
 
         RectangleRuntime rect = new();
         rect.Width = 50;
         rect.Height = 30;
         rect.FillColor = new Color(255, 165, 0, 255);
+        rect.IsFilled = true;
         rect.XOrigin = HorizontalAlignment.Center;
         rect.XUnits = GeneralUnitType.PixelsFromMiddle;
         rect.YOrigin = alignment;
@@ -222,6 +226,7 @@ internal class RectanglesScreen : FrameworkElement
             rect.Width = 80;
             rect.Height = 60;
             rect.FillColor = new Color(40, 40, 80, 255);
+            rect.IsFilled = true;
             rect.StrokeColor = new Color(255, 165, 0, 255);
             rect.StrokeWidth = 2;
             rect.CornerRadius = cornerRadius;
@@ -240,6 +245,7 @@ internal class RectanglesScreen : FrameworkElement
         RectangleRuntime linearH = new();
         linearH.Width = 70; linearH.Height = 50;
         linearH.FillColor = Color.White;
+        linearH.IsFilled = true;
         linearH.UseGradient = true;
         linearH.GradientType = GradientType.Linear;
         linearH.Color1 = Color.White;
@@ -252,6 +258,7 @@ internal class RectanglesScreen : FrameworkElement
         RectangleRuntime linearV = new();
         linearV.Width = 70; linearV.Height = 50;
         linearV.FillColor = Color.White;
+        linearV.IsFilled = true;
         linearV.UseGradient = true;
         linearV.GradientType = GradientType.Linear;
         linearV.Color1 = new Color(255, 215, 0, 255);
@@ -264,6 +271,7 @@ internal class RectanglesScreen : FrameworkElement
         RectangleRuntime linearD = new();
         linearD.Width = 70; linearD.Height = 50;
         linearD.FillColor = Color.White;
+        linearD.IsFilled = true;
         linearD.UseGradient = true;
         linearD.GradientType = GradientType.Linear;
         linearD.Color1 = new Color(0, 255, 255, 255);
@@ -276,6 +284,7 @@ internal class RectanglesScreen : FrameworkElement
         RectangleRuntime radial = new();
         radial.Width = 70; radial.Height = 50;
         radial.FillColor = Color.White;
+        radial.IsFilled = true;
         radial.UseGradient = true;
         radial.GradientType = GradientType.Radial;
         radial.Color1 = Color.White;
@@ -297,6 +306,7 @@ internal class RectanglesScreen : FrameworkElement
         RectangleRuntime strokeLast = new();
         strokeLast.Width = 80; strokeLast.Height = 50;
         strokeLast.FillColor = new Color(220, 20, 60, 255);
+        strokeLast.IsFilled = true;
         strokeLast.StrokeColor = new Color(0, 255, 255, 255);
         strokeLast.StrokeWidth = 4;
         row.Children.Add(strokeLast);
@@ -306,6 +316,7 @@ internal class RectanglesScreen : FrameworkElement
         fillLast.StrokeColor = new Color(255, 0, 255, 255);
         fillLast.StrokeWidth = 4;
         fillLast.FillColor = new Color(255, 215, 0, 255);
+        fillLast.IsFilled = true;
         row.Children.Add(fillLast);
 
         return row;
@@ -367,6 +378,7 @@ internal class RectanglesScreen : FrameworkElement
         frame.Width = 100;
         frame.Height = 100;
         frame.FillColor = new Color(60, 60, 80, 255);
+        frame.IsFilled = true;
 
         RectangleRuntime rect = new();
         rect.Width = 70;
@@ -378,6 +390,7 @@ internal class RectanglesScreen : FrameworkElement
         // Filled cell — light up the fill slot so the gradient renders on the fill. raylib's
         // outline-only case is handled by BuildRotationOutlineUnsupportedRow.
         rect.FillColor = Color.White;
+        rect.IsFilled = true;
         rect.UseGradient = true;
         rect.GradientType = GradientType.Linear;
         rect.Color1 = Color.Black;
@@ -395,11 +408,13 @@ internal class RectanglesScreen : FrameworkElement
         frame.Width = 64;
         frame.Height = 64;
         frame.FillColor = new Color(60, 60, 80, 255);
+        frame.IsFilled = true;
 
         RectangleRuntime rect = new();
         rect.Width = 64;
         rect.Height = 64;
         rect.FillColor = new Color(46, 139, 87, 255);
+        rect.IsFilled = true;
         rect.StrokeColor = new Color(255, 255, 0, 255);
         rect.StrokeWidth = strokeWidth;
         rect.StrokeWidthUnits = DimensionUnitType.Absolute;
@@ -459,11 +474,13 @@ internal class RectanglesScreen : FrameworkElement
         RectangleRuntime baseline = new();
         baseline.Width = 60; baseline.Height = 50;
         baseline.FillColor = goldenrod;
+        baseline.IsFilled = true;
         row.Children.Add(baseline);
 
         RectangleRuntime soft = new();
         soft.Width = 60; soft.Height = 50;
         soft.FillColor = goldenrod;
+        soft.IsFilled = true;
         soft.HasDropshadow = true;
         soft.DropshadowOffsetX = 14;
         soft.DropshadowOffsetY = 14;
@@ -473,6 +490,7 @@ internal class RectanglesScreen : FrameworkElement
         RectangleRuntime hard = new();
         hard.Width = 60; hard.Height = 50;
         hard.FillColor = goldenrod;
+        hard.IsFilled = true;
         hard.HasDropshadow = true;
         hard.DropshadowRed = 0; hard.DropshadowGreen = 0; hard.DropshadowBlue = 0; hard.DropshadowAlpha = 160;
         hard.DropshadowOffsetX = 16;
@@ -483,6 +501,7 @@ internal class RectanglesScreen : FrameworkElement
         RectangleRuntime colored = new();
         colored.Width = 60; colored.Height = 50;
         colored.FillColor = goldenrod;
+        colored.IsFilled = true;
         colored.HasDropshadow = true;
         colored.DropshadowRed = 220; colored.DropshadowGreen = 40; colored.DropshadowBlue = 160; colored.DropshadowAlpha = 220;
         colored.DropshadowOffsetX = 16;
@@ -496,6 +515,7 @@ internal class RectanglesScreen : FrameworkElement
         // This seems wrong:
         //fadedBody.FillColor = new Color((byte)218, (byte)165, (byte)32, (byte)80);
         fadedBody.FillColor = new Color((byte)218, (byte)165, (byte)32, (byte)32);
+        fadedBody.IsFilled = true;
         fadedBody.HasDropshadow = true;
         fadedBody.DropshadowOffsetX = 14;
         fadedBody.DropshadowOffsetY = 14;
@@ -507,6 +527,7 @@ internal class RectanglesScreen : FrameworkElement
         // This seems wrong:
         //fadedBody.FillColor = new Color((byte)218, (byte)165, (byte)32, (byte)80);
         shadowTest.FillColor = new Color((byte)218, (byte)165, (byte)32, (byte)32);
+        shadowTest.IsFilled = true;
         shadowTest.HasDropshadow = true;
         shadowTest.DropshadowOffsetX = 14;
         shadowTest.DropshadowOffsetY = 14;


### PR DESCRIPTION
## What

[PR #3005](https://github.com/vchelaru/Gum/pull/3005) flipped the defaults on the unified `RectangleRuntime`/`CircleRuntime` so that `FillColor` now defaults to white and **`IsFilled` defaults to `false`**. Previously a fill rendered by default. As a result, the demo/gallery sample screens that set `.FillColor` without also setting `.IsFilled = true` now render those fills **invisible**.

This PR adds `IsFilled = true` at every filled `RectangleRuntime`/`CircleRuntime` site in the affected samples.

## Scope

- **163 `IsFilled = true` lines added across 19 screen files**, covering all backends: MonoGame, MonoGame + Apos.Shapes, raylib, Skia / Silk.NET, WPF, and Maui.
- **Left untouched** (correctly unaffected by the default flip):
  - Stroke-only shapes (they rely on the new `IsFilled = false` default).
  - `ArcRuntime` / `PolygonRuntime` (use `.Color`, not `.FillColor`).
  - Legacy `ColoredRectangleRuntime` / `ColoredCircleRuntime` / `RoundedRectangleRuntime`.
  - The two `ArcsScreen` files and `SpriteScreen` (no qualifying sites).

## Verification

Built with **0 errors** on every buildable affected sample project:

- `MonoGameGumShapesGallery`
- `MonoGameGumInCode`
- `raylib` (GumTest)
- `SilkNetGum`
- `SkiaGumWpfSample`

`MauiSkiaGum` was not built (requires the MAUI workload); its edit is identical property-assignment syntax to the WPF/Skia sample, which compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
