### PR TITLE
Give FillAlpha, StrokeAlpha, DropshadowAlpha a 0-255 slider

### DIFF
--- a/Gum/Plugins/InternalPlugins/VariableGrid/StandardElementsManager.GumTool.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/StandardElementsManager.GumTool.cs
@@ -130,7 +130,7 @@ public class StandardElementsManagerGumTool : Singleton<StandardElementsManagerG
             else if (variable.Name == "Red" ||
                 variable.Name == "Green" ||
                 variable.Name == "Blue" ||
-                variable.Name == "Alpha"||
+                variable.Name == "Alpha" ||
                 variable.Name == "Red1" ||
                 variable.Name == "Green1" ||
                 variable.Name == "Blue1" ||
@@ -138,7 +138,10 @@ public class StandardElementsManagerGumTool : Singleton<StandardElementsManagerG
                 variable.Name == "Red2" ||
                 variable.Name == "Green2" ||
                 variable.Name == "Blue2" ||
-                variable.Name == "Alpha2" 
+                variable.Name == "Alpha2" ||
+                variable.Name == "FillAlpha" ||
+                variable.Name == "StrokeAlpha" ||
+                variable.Name == "DropshadowAlpha"
                 )
             {
                 variable.PropertiesToSetOnDisplayer["MinValue"] = 0.0;

--- a/Tool/Tests/GumToolUnitTests/Managers/StandardElementsManagerTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Managers/StandardElementsManagerTests.cs
@@ -1,12 +1,35 @@
+using Gum.DataTypes.Variables;
 using Gum.Managers;
+using Gum.Plugins.InternalPlugins.VariableGrid;
 using Shouldly;
 using System.Linq;
+using WpfDataUi.Controls;
 using Xunit;
 
 namespace GumToolUnitTests.Managers;
 
 public class StandardElementsManagerTests : BaseTestClass
 {
+    // FillAlpha / StrokeAlpha / DropshadowAlpha are 0-255 byte channels just like the legacy
+    // Alpha, so they should get the same SliderDisplay with a [0, 255] range rather than a
+    // plain int textbox.
+    [Theory]
+    [InlineData("FillAlpha")]
+    [InlineData("StrokeAlpha")]
+    [InlineData("DropshadowAlpha")]
+    public void SetPreferredDisplayers_AssignsByteRangeSlider_ToAlphaVariables(string variableName)
+    {
+        var state = new StateSave();
+        state.Variables.Add(new VariableSave { Type = "int", Name = variableName });
+
+        StandardElementsManagerGumTool.SetPreferredDisplayers(state);
+
+        var variable = state.Variables.First();
+        variable.PreferredDisplayer.ShouldBe(typeof(SliderDisplay));
+        variable.PropertiesToSetOnDisplayer["MinValue"].ShouldBe(0.0);
+        variable.PropertiesToSetOnDisplayer["MaxValue"].ShouldBe(255.0);
+    }
+
     [Theory]
     [InlineData("Circle")]
     [InlineData("Rectangle")]


### PR DESCRIPTION
## Summary

`FillAlpha`, `StrokeAlpha`, and `DropshadowAlpha` are `int` 0–255 byte channels, but in the Variables grid they rendered as plain int textboxes — unlike the legacy `Alpha` (and gradient `Alpha1`/`Alpha2`) which get a 0–255 `SliderDisplay`.

This adds the three names to the slider-wiring condition in `StandardElementsManagerGumTool.SetPreferredDisplayers`, so all alpha values share the same byte-range slider UI.

## Changes

- `StandardElementsManager.GumTool.cs` — add `FillAlpha`, `StrokeAlpha`, `DropshadowAlpha` to the `SliderDisplay` (MinValue 0 / MaxValue 255) branch. Also a one-char spacing fix (`"Alpha"||` → `"Alpha" ||`) in the same block.
- `StandardElementsManagerTests.cs` — new `[Theory]` verifying each alpha variable gets `SliderDisplay` with a `[0, 255]` range.

## Testing

`dotnet test GumToolUnitTests` — all 21 `StandardElementsManagerTests` pass (3 new alpha cases + existing 18).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
