### PR TITLE
Move recommended Shape Support section above optional sections

### DIFF
--- a/docs/code/getting-started/setup/adding-initializing-gum/monogame-kni-fna/README.md
+++ b/docs/code/getting-started/setup/adding-initializing-gum/monogame-kni-fna/README.md
@@ -202,6 +202,58 @@ public class Game1 : Core
 {% endtab %}
 {% endtabs %}
 
+## Adding Shape Support (Recommended)
+
+Gum's `Circle` and `Rectangle` elements have a **fill** and an **outline (stroke)**. On MonoGame, KNI, and FNA, an outlined `Circle` or `Rectangle` renders out of the box — `StrokeColor`, `StrokeWidth`, `StrokeWidthUnits`, and the geometry properties (`Width`, `Height`, `Radius`, `CornerRadius`) all work with no extra package.
+
+Filling a shape and the richer effects need the shape support package. We recommend installing it for most projects so that fill, gradient, drop shadow, dashed stroke, and anti-aliasing all draw. Without it, the following properties are stored and round-trip correctly, but silently do not draw: `FillColor` (and the fill color channels), gradient (`UseGradient` and the gradient properties), drop shadow (`HasDropshadow` and the dropshadow properties), dashed stroke (`StrokeDashLength` / `StrokeGapLength`), anti-aliasing (`IsAntialiased`), and `Blend`. Nothing throws — the shape simply renders without that feature.
+
+To enable fill and effects, add the shape support package for your platform (the `Gum.Shapes.*` package, which uses Apos.Shapes under the hood):
+
+{% tabs %}
+{% tab title="MonoGame" %}
+```xml
+<PackageReference Include="Gum.Shapes.MonoGame" Version="*" />
+```
+
+Or add through command line:
+
+```bash
+dotnet add package Gum.Shapes.MonoGame
+```
+{% endtab %}
+
+{% tab title="KNI" %}
+```xml
+<PackageReference Include="Gum.Shapes.KNI" Version="*" />
+```
+
+Or add through command line:
+
+```bash
+dotnet add package Gum.Shapes.KNI
+```
+{% endtab %}
+
+{% tab title="FNA" %}
+There is no shape support NuGet package for FNA. An outlined `Circle` or `Rectangle` still renders without any package (`StrokeColor`, `StrokeWidth`, and geometry all work), but fill and the richer effects are currently available on MonoGame and KNI only.
+{% endtab %}
+{% endtabs %}
+
+Next, add the following line after `GumUI.Initialize(...)` in your `Initialize` method:
+
+```csharp
+// Initialize
+GumUI.Initialize(this);
+ShapeRenderer.Self.Initialize();
+```
+
+{% hint style="info" %}
+The fill + outline `Circle` and `Rectangle` surface ships in the June 2026 release. Before then, you can use it by building Gum from source.
+{% endhint %}
+
+For the full set of fill, outline, gradient, drop shadow, and corner-radius properties, see the [Shapes](../../../../standard-visuals/shapes-apos.shapes.md) page.
+
 ## Adding Dynamic Fonts (Optional)
 
 By default, Gum uses pre-built bitmap font (.fnt) files for text rendering. You can enable dynamic in-memory font generation using KernSmith, which lets you set `Font`, `FontSize`, `IsBold`, `IsItalic`, `OutlineThickness`, and `UseFontSmoothing` on any `TextRuntime` without needing .fnt/.png files on disk.
@@ -271,58 +323,6 @@ GumExpressionService.Initialize();
 If linking to source instead of NuGet, add `<Gum Root>/Runtimes/GumExpressions/GumExpressions.csproj` to your solution.
 
 For more information, see the [Runtime Variable References](../../../../styling/runtime-variable-references.md) page.
-
-## Adding Shape Support (Recommended)
-
-Gum's `Circle` and `Rectangle` elements have a **fill** and an **outline (stroke)**. On MonoGame, KNI, and FNA, an outlined `Circle` or `Rectangle` renders out of the box — `StrokeColor`, `StrokeWidth`, `StrokeWidthUnits`, and the geometry properties (`Width`, `Height`, `Radius`, `CornerRadius`) all work with no extra package.
-
-Filling a shape and the richer effects need the shape support package. We recommend installing it for most projects so that fill, gradient, drop shadow, dashed stroke, and anti-aliasing all draw. Without it, the following properties are stored and round-trip correctly, but silently do not draw: `FillColor` (and the fill color channels), gradient (`UseGradient` and the gradient properties), drop shadow (`HasDropshadow` and the dropshadow properties), dashed stroke (`StrokeDashLength` / `StrokeGapLength`), anti-aliasing (`IsAntialiased`), and `Blend`. Nothing throws — the shape simply renders without that feature.
-
-To enable fill and effects, add the shape support package for your platform (the `Gum.Shapes.*` package, which uses Apos.Shapes under the hood):
-
-{% tabs %}
-{% tab title="MonoGame" %}
-```xml
-<PackageReference Include="Gum.Shapes.MonoGame" Version="*" />
-```
-
-Or add through command line:
-
-```bash
-dotnet add package Gum.Shapes.MonoGame
-```
-{% endtab %}
-
-{% tab title="KNI" %}
-```xml
-<PackageReference Include="Gum.Shapes.KNI" Version="*" />
-```
-
-Or add through command line:
-
-```bash
-dotnet add package Gum.Shapes.KNI
-```
-{% endtab %}
-
-{% tab title="FNA" %}
-There is no shape support NuGet package for FNA. An outlined `Circle` or `Rectangle` still renders without any package (`StrokeColor`, `StrokeWidth`, and geometry all work), but fill and the richer effects are currently available on MonoGame and KNI only.
-{% endtab %}
-{% endtabs %}
-
-Next, add the following line after `GumUI.Initialize(...)` in your `Initialize` method:
-
-```csharp
-// Initialize
-GumUI.Initialize(this);
-ShapeRenderer.Self.Initialize();
-```
-
-{% hint style="info" %}
-The fill + outline `Circle` and `Rectangle` surface ships in the June 2026 release. Before then, you can use it by building Gum from source.
-{% endhint %}
-
-For the full set of fill, outline, gradient, drop shadow, and corner-radius properties, see the [Shapes](../../../../standard-visuals/shapes-apos.shapes.md) page.
 
 ## Adding a Button (Testing the Setup)
 


### PR DESCRIPTION
## Problem

On the **MonoGame/KNI/FNA** setup page (`docs/code/.../adding-initializing-gum/monogame-kni-fna/README.md`), the **Adding Shape Support (Recommended)** section sat *below* two `Adding ... (Optional)` sections (Dynamic Fonts, Expression Support). A reader skimming top-to-bottom hits the optional cluster, files the rest as skippable, and tabs to the button test — never registering that the shapes package is **Recommended**, not optional. The label and the position contradicted each other.

## Change

Relocated the entire **Adding Shape Support (Recommended)** section to immediately follow **Adding Gum to Game** and above the two `(Optional)` sections. New section order:

1. Adding Gum NuGet Package
2. Adding Source *(Optional)*
3. Adding Gum to Game
4. **Adding Shape Support (Recommended)** ← moved here
5. Adding Dynamic Fonts *(Optional)*
6. Adding Expression Support *(Optional)*
7. Adding a Button (Testing the Setup)

This gives a clear priority gradient — core → recommended → optional → test — and the section's `ShapeRenderer.Self.Initialize()` snippet now lands right after the Game class that defines `Initialize`.

### Why not fold it into "Adding Gum NuGet Package"?

The shapes feature is two parts: a `PackageReference` *and* a required `ShapeRenderer.Self.Initialize()` call that must come after `GumUI.Initialize(...)`. That init line can't be shown until after "Adding Gum to Game" establishes the Game class. Folding only the package up into the NuGet section would split the package-add from its activation code by two sections — worse for a linear reader. Keeping it a self-contained section, just higher, co-locates the package with the code that turns it on.

Pure move — 48 insertions / 48 deletions, no content edited. `SUMMARY.md` is unaffected (within-page move).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
