### PR TITLE
Fix Apos.Shapes Circle/Rectangle rendering: fill bleed, AA zoom inset, gradient stroke

### DIFF
--- a/Gum/Controls/ColorDisplay.xaml.cs
+++ b/Gum/Controls/ColorDisplay.xaml.cs
@@ -234,23 +234,29 @@ namespace Gum.Controls.DataUi
             var isColorSame = false;
 
 #if XNA
+            // InstanceMember.Value is null when multi-selecting instances whose colors differ; pattern
+            // matching leaves isColorSame false in that case so the picked color is applied to all.
             if (mInstancePropertyType == typeof(Microsoft.Xna.Framework.Color))
             {
-                var colorPack = (uint)(colorArgs.Color.R | (colorArgs.Color.G << 8) | (colorArgs.Color.B << 16) | (colorArgs.Color.A << 24));
-                var prevColor = (Microsoft.Xna.Framework.Color)InstanceMember.Value;
-                isColorSame = colorPack == prevColor.PackedValue;
+                if (InstanceMember.Value is Microsoft.Xna.Framework.Color prevColor)
+                {
+                    var colorPack = (uint)(colorArgs.Color.R | (colorArgs.Color.G << 8) | (colorArgs.Color.B << 16) | (colorArgs.Color.A << 24));
+                    isColorSame = colorPack == prevColor.PackedValue;
+                }
             }
-            else 
-#endif     
+            else
+#endif
             if (mInstancePropertyType == typeof(System.Drawing.Color))
             {
-                var prevColor = (System.Drawing.Color)InstanceMember.Value;
-                var newColor = colorArgs.Color;
+                if (InstanceMember.Value is System.Drawing.Color prevColor)
+                {
+                    var newColor = colorArgs.Color;
 
-                isColorSame = newColor.A == prevColor.A &&
-                    newColor.R == prevColor.R &&
-                    newColor.G == prevColor.G &&
-                newColor.B == prevColor.B;
+                    isColorSame = newColor.A == prevColor.A &&
+                        newColor.R == prevColor.R &&
+                        newColor.G == prevColor.G &&
+                        newColor.B == prevColor.B;
+                }
             }
             if (isColorSame) return;
 

--- a/MonoGameGum/GueDeriving/CircleRuntime.cs
+++ b/MonoGameGum/GueDeriving/CircleRuntime.cs
@@ -565,6 +565,9 @@ public class CircleRuntime : GraphicalUiElement
             // shadow flag and the inactive slot releases it. Otherwise toggling IsFilled
             // either ghosts the previous target or never wakes the new one up.
             SyncDropshadowToTarget();
+            // Gradient routing also depends on IsFilled: the gradient paints the active body
+            // (fill when filled, stroke when stroke-only), so re-route on toggle.
+            SyncGradientToTarget();
             NotifyPropertyChanged();
         }
     }
@@ -701,11 +704,24 @@ public class CircleRuntime : GraphicalUiElement
 
     // Issue #2791: gradient pass-through. Backing fields live on the runtime so values
     // round-trip even when neither slot implements IGradientedRenderable (e.g. core-only stroke
-    // = DefaultStrokedCircleRenderable, no fill). Setters push to whichever slot(s) implement
-    // it. Pushing to both slots matches Skia's single-renderable behavior, where fill mode and
-    // dashed-stroke mode both consult the same gradient parameters; an Apos-backed
-    // CircleRuntime with both FillColor and StrokeColor + UseGradient = true renders a
-    // gradient-filled disk with a gradient stroke sharing the same gradient.
+    // = DefaultStrokedCircleRenderable, no fill). The coordinate/color setters push to whichever
+    // slot(s) implement it so the values round-trip on either; the UseGradient GATE routes to the
+    // active body slot (see SyncGradientToTarget). The gradient is the active body's paint — a
+    // gradient on the other slot would share the single gradient and composite invisibly, so the
+    // inactive slot renders solid.
+
+    // Routes the gradient gate to the ACTIVE body slot — the fill when IsFilled, the stroke when
+    // stroke-only — and forces the inactive slot's gate off. Mirrors SyncDropshadowToTarget. Re-run
+    // from both the UseGradient and IsFilled setters so toggling IsFilled re-routes the gate.
+    void SyncGradientToTarget()
+    {
+        var fillGrad = _fill as IGradientedRenderable;
+        var strokeGrad = _stroke as IGradientedRenderable;
+        var active = _isFilled ? fillGrad : strokeGrad;
+        var inactive = _isFilled ? strokeGrad : fillGrad;
+        if (active != null) active.UseGradient = _useGradient;
+        if (inactive != null) inactive.UseGradient = false;
+    }
 
     bool _useGradient;
     /// <summary>
@@ -720,8 +736,7 @@ public class CircleRuntime : GraphicalUiElement
         set
         {
             _useGradient = value;
-            if (_fill is IGradientedRenderable fillGrad) fillGrad.UseGradient = value;
-            if (_stroke is IGradientedRenderable strokeGrad) strokeGrad.UseGradient = value;
+            SyncGradientToTarget();
             NotifyPropertyChanged();
         }
     }

--- a/MonoGameGum/GueDeriving/IFilledRectangleRenderable.cs
+++ b/MonoGameGum/GueDeriving/IFilledRectangleRenderable.cs
@@ -40,5 +40,16 @@ public interface IFilledRectangleRenderable : IRenderable
 
     /// <inheritdoc cref="CustomRadiusTopLeft"/>
     float? CustomRadiusBottomRight { get; set; }
+
+    /// <summary>
+    /// Pixels to inset each side of the rendered fill (rectangle analog of
+    /// <see cref="IFilledCircleRenderable.FillRadiusInset"/>, issue #2834). Pushed by
+    /// <see cref="RectangleRuntime.PreRender"/> when the stroke slot is visible alongside the
+    /// fill — pulling the fill's outer edge inside the stroke's band so a semi-transparent
+    /// stroke shows the background through it, not the fill. Applied at render time only;
+    /// Width/Height stay layout-owned. Honored by Apos.Shapes' RoundedRectangle; stored but
+    /// not rendered on the core default (SolidRectangle).
+    /// </summary>
+    float FillInset { get; set; }
 }
 #endif

--- a/MonoGameGum/GueDeriving/RectangleRuntime.cs
+++ b/MonoGameGum/GueDeriving/RectangleRuntime.cs
@@ -775,6 +775,9 @@ public class RectangleRuntime : GraphicalUiElement
             }
             // Dropshadow routing depends on IsFilled — see CircleRuntime for the rationale.
             SyncDropshadowToTarget();
+            // Gradient routing also depends on IsFilled: the gradient paints the active body
+            // (fill when filled, stroke when stroke-only), so re-route on toggle.
+            SyncGradientToTarget();
             NotifyPropertyChanged();
         }
     }
@@ -983,6 +986,21 @@ public class RectangleRuntime : GraphicalUiElement
     // even when neither slot implements IGradientedRenderable (core defaults wrap SolidRectangle
     // / LineRectangle, no gradient concept). Setters push to whichever slot(s) implement it.
 
+    // Routes the gradient gate to the ACTIVE body slot — the fill when IsFilled, the stroke when
+    // stroke-only — and forces the inactive slot's gate off. Mirrors SyncDropshadowToTarget: a
+    // single gradient is the active body's paint, so the other slot renders solid (its StrokeColor
+    // / FillColor) rather than sharing the gradient and compositing invisibly over it. Re-run from
+    // both the UseGradient and IsFilled setters so toggling IsFilled re-routes the gate.
+    void SyncGradientToTarget()
+    {
+        var fillGrad = _fill as IGradientedRenderable;
+        var strokeGrad = _stroke as IGradientedRenderable;
+        var active = _isFilled ? fillGrad : strokeGrad;
+        var inactive = _isFilled ? strokeGrad : fillGrad;
+        if (active != null) active.UseGradient = _useGradient;
+        if (inactive != null) inactive.UseGradient = false;
+    }
+
     bool _useGradient;
     /// <inheritdoc cref="CircleRuntime.UseGradient"/>
     public bool UseGradient
@@ -991,8 +1009,7 @@ public class RectangleRuntime : GraphicalUiElement
         set
         {
             _useGradient = value;
-            if (_fill is IGradientedRenderable fillGrad) fillGrad.UseGradient = value;
-            if (_stroke is IGradientedRenderable strokeGrad) strokeGrad.UseGradient = value;
+            SyncGradientToTarget();
             NotifyPropertyChanged();
         }
     }
@@ -1571,6 +1588,29 @@ public class RectangleRuntime : GraphicalUiElement
         _stroke.CustomRadiusTopRight = topRight;
         _stroke.CustomRadiusBottomLeft = bottomLeft;
         _stroke.CustomRadiusBottomRight = bottomRight;
+
+        // Mirror of CircleRuntime.PreRender's FillRadiusInset push (#2834). When both slots are
+        // visible, inset the fill so its outer edge sits inside the stroke's opaque band —
+        // otherwise a filled rectangle with a semi-transparent stroke shows the FILL through the
+        // stroke instead of the background. Pushed via FillInset rather than mutating
+        // fill.Width/Height (the fill IS the runtime's contained sizing object; mutating Width
+        // would feed back into layout and shrink the rectangle each frame). Inset per side =
+        // AA-compensated stroke width, floored at the AA contribution for hairline strokes.
+        // Gated on stroke visibility: alpha 0 OR StrokeWidth 0 means no stroke is drawn, and an
+        // inset would render a thin background gap where the stroke would have been.
+        if (_fill != null)
+        {
+            float fillInset = 0f;
+            if (_stroke.Color.A > 0 && _strokeWidth > 0)
+            {
+                fillInset = renderableStrokeWidth;
+                if (_isAntialiased && _stroke is IAntialiasedRenderable)
+                {
+                    fillInset = Math.Max(fillInset, aposAaContributionWorld);
+                }
+            }
+            _fill.FillInset = fillInset;
+        }
     }
 
     /// <inheritdoc/>

--- a/MonoGameGum/Renderables/DefaultFilledRectangleRenderable.cs
+++ b/MonoGameGum/Renderables/DefaultFilledRectangleRenderable.cs
@@ -44,5 +44,10 @@ public class DefaultFilledRectangleRenderable : SolidRectangle, IFilledRectangle
     public float? CustomRadiusTopRight { get; set; }
     public float? CustomRadiusBottomLeft { get; set; }
     public float? CustomRadiusBottomRight { get; set; }
+
+    // Stored but not rendered: SolidRectangle always draws at its full Width/Height. The
+    // fill-inset visual (hiding the fill under a transparent stroke band) is an Apos.Shapes
+    // feature; the core path keeps its historical full-edge fill. Set for round-tripping.
+    public float FillInset { get; set; }
 }
 #endif

--- a/Runtimes/GumShapes/Renderables/Circle.cs
+++ b/Runtimes/GumShapes/Renderables/Circle.cs
@@ -88,6 +88,25 @@ public class Circle : RenderableShapeBase,
         return System.Math.Max(0f, radius - FillRadiusInset);
     }
 
+    /// <summary>
+    /// Insets the draw circle by the pixel-center AA alignment offset
+    /// (<see cref="RenderableShapeBase.GetAntiAliasWorldOffset"/>): the radius shrinks by the
+    /// offset while the center stays FIXED, so every edge insets symmetrically. Shifting the
+    /// center (the original <c>center += 0.5</c>) insets the top/left edge by twice the offset
+    /// and leaves the bottom/right flush, biasing the whole disk down and right (visible
+    /// spill-over when zoomed out). Scaled by <paramref name="cameraZoom"/> so the inset holds a
+    /// constant on-screen size. Returns the circle unchanged when antialiasing is off.
+    /// </summary>
+    public (Vector2 center, float radius) ApplyAntiAliasInset(Vector2 center, float radius, int antiAliasSize, float cameraZoom)
+    {
+        var offset = GetAntiAliasWorldOffset(antiAliasSize, cameraZoom);
+        if (offset == 0f)
+        {
+            return (center, radius);
+        }
+        return (center, radius - offset);
+    }
+
     public override void Render(ISystemManagers managers)
     {
         // Issue #2950 follow-up — stroke-only Circle with StrokeWidth = 0 would otherwise draw
@@ -119,6 +138,10 @@ public class Circle : RenderableShapeBase,
 
         var radius = System.Math.Min(Width, Height) / 2.0f;
 
+        // Resolve camera zoom once: it scales the pixel-center AA inset (RenderInternal) and the
+        // dropshadow halo/geometry so both hold a constant on-screen size as the tool zooms.
+        var cameraZoom = (managers as RenderingLibrary.SystemManagers)?.Renderer?.Camera?.Zoom ?? 1f;
+
         if(HasDropshadow)
         {
             var shadowLeft = absoluteLeft + DropshadowOffsetX + DropshadowBlurX;
@@ -133,8 +156,6 @@ public class Circle : RenderableShapeBase,
             // the shadow disappears entirely).
             (float shadowStrokeWidth, Color shadowColor) =
                 ComputeStrokeShadowDrawParameters(EffectiveDropshadowColor);
-
-            var cameraZoom = (managers as RenderingLibrary.SystemManagers)?.Renderer?.Camera?.Zoom ?? 1f;
 
             float shadowRadius;
             int shadowAaSize;
@@ -174,10 +195,11 @@ public class Circle : RenderableShapeBase,
                 shadowAaSize,
                 shadowStrokeWidth,
                 rotationRadians,
+                cameraZoom,
                 shadowColor);
         }
 
-        RenderInternal(sb, absoluteLeft, absoluteTop, center, radius, IsAntialiased ? 1 : 0, StrokeWidth, rotationRadians);
+        RenderInternal(sb, absoluteLeft, absoluteTop, center, radius, IsAntialiased ? 1 : 0, StrokeWidth, rotationRadians, cameraZoom);
     }
 
     private void RenderInternal(ShapeBatch sb,
@@ -188,6 +210,7 @@ public class Circle : RenderableShapeBase,
         int antiAliasSize,
         float strokeWidth,
         float rotationRadians,
+        float cameraZoom,
         Color? forcedColor = null)
     {
         if (!IsFilled && StrokeDashLength > 0 && StrokeGapLength > 0 && strokeWidth > 0 && radius > 0)
@@ -196,13 +219,10 @@ public class Circle : RenderableShapeBase,
             return;
         }
 
-        // See RoundedRectangle for more info
-        if (antiAliasSize != 0)
-        {
-            center.X += .5f;
-            center.Y += .5f;
-            radius -= .5f;
-        }
+        // See RoundedRectangle for more info. The offset is half a SCREEN pixel, so it is divided
+        // by cameraZoom (via ApplyAntiAliasInset) — otherwise the inset grows in world space as
+        // the tool zooms in and the circle pulls visibly inward.
+        (center, radius) = ApplyAntiAliasInset(center, radius, antiAliasSize, cameraZoom);
 
         if (IsFilled)
         {

--- a/Runtimes/GumShapes/Renderables/RenderableShapeBase.cs
+++ b/Runtimes/GumShapes/Renderables/RenderableShapeBase.cs
@@ -791,6 +791,24 @@ public abstract class RenderableShapeBase : RenderableBase, Gum.GueDeriving.IBle
     }
 
     /// <summary>
+    /// The pixel-center alignment offset, in WORLD units, applied to a shape's edge before an
+    /// antialiased Apos draw so the AA gradient samples crisply against the SCREEN pixel grid
+    /// (Apos.Shapes issue #12). The raw value is half a SCREEN pixel; like the AA halo (#2936)
+    /// it must be divided by <paramref name="cameraZoom"/> so it holds a constant on-screen size.
+    /// Applied in world units without this division, the inset grows as the camera zooms in,
+    /// pulling fills and strokes visibly inward — a filled shape no longer reaches the edge of an
+    /// equally-sized NineSlice/sprite. Returns 0 when antialiasing is off (<paramref name="antiAliasSize"/> == 0).
+    /// </summary>
+    public static float GetAntiAliasWorldOffset(int antiAliasSize, float cameraZoom)
+    {
+        if (antiAliasSize == 0 || cameraZoom <= 0f)
+        {
+            return 0f;
+        }
+        return 0.5f / cameraZoom;
+    }
+
+    /// <summary>
     /// Adjusts a top-left position so that Apos.Shapes' center-based rotation
     /// produces the same result as rotating around the top-left corner.
     /// </summary>

--- a/Runtimes/GumShapes/Renderables/RoundedRectangle.cs
+++ b/Runtimes/GumShapes/Renderables/RoundedRectangle.cs
@@ -58,6 +58,60 @@ public class RoundedRectangle : RenderableShapeBase,
     public float? CustomRadiusBottomRight { get; set; }
     public float? CustomRadiusBottomLeft { get; set; }
 
+    /// <inheritdoc/>
+    /// <remarks>
+    /// Rectangle analog of <see cref="Circle.FillRadiusInset"/> (#2834). Pushed by
+    /// <see cref="Gum.GueDeriving.RectangleRuntime.PreRender"/> on the fill slot only when a
+    /// visible stroke is present. Applied as a symmetric inset at render time via
+    /// <see cref="ComputeFillDrawRect"/>; Width/Height are left untouched so the layout system
+    /// stays the sole source of size truth (mutating Width here would feed back into layout
+    /// because the fill instance is the runtime's contained sizing object).
+    /// </remarks>
+    public float FillInset { get; set; }
+
+    /// <summary>
+    /// Insets the fill draw rect by <see cref="FillInset"/> on every side, keeping the rect
+    /// centered (so the shape doesn't drift) and clamping each dimension at 0 rather than
+    /// inverting. Mirrors <see cref="Circle.ComputeFillDrawRadius"/>: only the body pass
+    /// consumes the inset; the shadow pass (<paramref name="isShadowPass"/>) draws at full size
+    /// so its outer edge lines up with the body's outer edge (#2958). Centering keeps it
+    /// correct under rotation — Apos rotates the rect around <c>position + size/2</c>, which the
+    /// symmetric inset leaves unchanged.
+    /// </summary>
+    public (Vector2 position, Vector2 size) ComputeFillDrawRect(Vector2 position, Vector2 size, bool isShadowPass)
+    {
+        if (isShadowPass || FillInset <= 0f)
+        {
+            return (position, size);
+        }
+
+        var newSize = new Vector2(
+            System.Math.Max(0f, size.X - 2f * FillInset),
+            System.Math.Max(0f, size.Y - 2f * FillInset));
+        var newPosition = new Vector2(
+            position.X + (size.X - newSize.X) / 2f,
+            position.Y + (size.Y - newSize.Y) / 2f);
+        return (newPosition, newSize);
+    }
+
+    /// <summary>
+    /// Insets the draw rect by the pixel-center AA alignment offset
+    /// (<see cref="RenderableShapeBase.GetAntiAliasWorldOffset"/>): the top-left moves in by the
+    /// offset and each dimension shrinks by twice it, keeping the rect centered. Scaled by
+    /// <paramref name="cameraZoom"/> so the inset stays a constant on-screen size at any zoom.
+    /// Returns the rect unchanged when antialiasing is off.
+    /// </summary>
+    public (Vector2 position, Vector2 size) ApplyAntiAliasInset(Vector2 position, Vector2 size, int antiAliasSize, float cameraZoom)
+    {
+        var offset = GetAntiAliasWorldOffset(antiAliasSize, cameraZoom);
+        if (offset == 0f)
+        {
+            return (position, size);
+        }
+        return (new Vector2(position.X + offset, position.Y + offset),
+                new Vector2(size.X - 2f * offset, size.Y - 2f * offset));
+    }
+
     /// <summary>
     /// Issue #2979 — dropshadow draw size, AA halo, and alpha scale for a rectangle of nominal
     /// <paramref name="hostSize"/>, mirroring <see cref="Circle"/>'s split (#2950/#2977).
@@ -125,6 +179,10 @@ public class RoundedRectangle : RenderableShapeBase,
 
         var size = new Microsoft.Xna.Framework.Vector2(Width, Height);
 
+        // Resolve camera zoom once: it scales the pixel-center AA inset (RenderInternal) and the
+        // dropshadow halo/geometry so both hold a constant on-screen size as the tool zooms.
+        var cameraZoom = (managers as RenderingLibrary.SystemManagers)?.Renderer?.Camera?.Zoom ?? 1f;
+
         if(HasDropshadow)
         {
             // Issue #2950 — when stroke <= blur on a stroke-only RoundedRectangle, fade the
@@ -135,7 +193,6 @@ public class RoundedRectangle : RenderableShapeBase,
             // Issue #2979 — strict-anchor shadow geometry (filled disk anchor / stroke centerline
             // anchor), mirroring Circle.Render. Replaces the old naive `size -= blur` that drove
             // the outline inward as blur grew. aaSize is world-anchored (scaled by camera zoom).
-            var cameraZoom = (managers as RenderingLibrary.SystemManagers)?.Renderer?.Camera?.Zoom ?? 1f;
             (Vector2 dropshadowSize, int shadowAaSize, float shadowAlphaScale) =
                 ComputeShadowDrawParameters(size, shadowStrokeWidth, cameraZoom);
             if (shadowAlphaScale < 1f)
@@ -154,10 +211,11 @@ public class RoundedRectangle : RenderableShapeBase,
                 shadowAaSize,
                 shadowStrokeWidth,
                 rotationRadians,
+                cameraZoom,
                 forcedColor: shadowColor);
         }
 
-        RenderInternal(sb, absoluteLeft, absoluteTop, size, IsAntialiased ? 1 : 0, StrokeWidth, rotationRadians);
+        RenderInternal(sb, absoluteLeft, absoluteTop, size, IsAntialiased ? 1 : 0, StrokeWidth, rotationRadians, cameraZoom);
     }
 
     private void RenderInternal(Apos.Shapes.ShapeBatch sb,
@@ -167,6 +225,7 @@ public class RoundedRectangle : RenderableShapeBase,
         int antiAliasSize,
         float strokeWidth,
         float rotationRadians,
+        float cameraZoom,
         Color? forcedColor = null)
     {
         if (!IsFilled && StrokeDashLength > 0 && StrokeGapLength > 0 && strokeWidth > 0
@@ -192,32 +251,35 @@ public class RoundedRectangle : RenderableShapeBase,
         // when shapes have a stroke thickness of 1 at the Gum level with anti aliasing. This renders wiht
         // an epsilon value of 0.01, with an anti-alias size of 1. By offsetting, the sampling of the antialias
         // gradient in the shader happens right at the start of the gradient, making for solid beautiful lines.
-        if(antiAliasSize != 0)
-        {
-            position.X += .5f;
-            position.Y += .5f;
-            size.X -= 1f;
-            size.Y -= 1f;
-        }
+        // The offset is half a SCREEN pixel, so it is divided by cameraZoom (via ApplyAntiAliasInset) —
+        // otherwise the inset grows in world space as the tool zooms in and the shape pulls visibly
+        // inward from an equally-sized NineSlice.
+        (position, size) = ApplyAntiAliasInset(position, size, antiAliasSize, cameraZoom);
 
         if (IsFilled)
         {
+            // Pull the fill's outer edge inside the companion stroke band (#2834 rectangle
+            // analog) so a semi-transparent stroke shows the background through it, not the
+            // fill. The shadow pass (forcedColor != null) must NOT inherit the inset, or its
+            // outer edge falls short of the body's outer edge (#2958).
+            var (fillPosition, fillSize) = ComputeFillDrawRect(position, size, isShadowPass: forcedColor != null);
+
             if (ShouldPaintGradient(forcedColor))
             {
                 var gradient = base.GetGradient(absoluteLeft, absoluteTop, rotationRadians);
 
                 if (hasCustomCorners)
-                    sb.DrawRectangle(position, size, gradient, gradient, thickness, corners, rotationRadians, antiAliasSize);
+                    sb.DrawRectangle(fillPosition, fillSize, gradient, gradient, thickness, corners, rotationRadians, antiAliasSize);
                 else
-                    sb.DrawRectangle(position, size, gradient, gradient, thickness, CornerRadius, rotationRadians, antiAliasSize);
+                    sb.DrawRectangle(fillPosition, fillSize, gradient, gradient, thickness, CornerRadius, rotationRadians, antiAliasSize);
             }
             else
             {
                 var color = forcedColor ?? Color;
                 if (hasCustomCorners)
-                    sb.DrawRectangle(position, size, color, color, thickness, corners, rotationRadians, antiAliasSize);
+                    sb.DrawRectangle(fillPosition, fillSize, color, color, thickness, corners, rotationRadians, antiAliasSize);
                 else
-                    sb.DrawRectangle(position, size, color, color, thickness, CornerRadius, rotationRadians, antiAliasSize);
+                    sb.DrawRectangle(fillPosition, fillSize, color, color, thickness, CornerRadius, rotationRadians, antiAliasSize);
             }
         }
         else

--- a/Tests/MonoGameGum.Shapes.Tests/CircleRenderableTests.cs
+++ b/Tests/MonoGameGum.Shapes.Tests/CircleRenderableTests.cs
@@ -440,6 +440,50 @@ public class CircleRenderableTests
     // outer edge, leaving a visible ring of missing shadow under the stroke (worse at higher
     // camera zoom because the inset is in world units).
 
+    // The pixel-center AA inset shrinks the radius by half a SCREEN pixel (divided by cameraZoom,
+    // mirror of RoundedRectangle / #2936) so a filled circle's inset doesn't grow as the tool
+    // zooms. The center must stay FIXED: shifting it down/right (the old center += 0.5) insets the
+    // top/left edge by twice the offset while leaving the bottom/right edge flush, biasing the
+    // whole circle down and right (visible spill-over when zoomed out). Keeping the center fixed
+    // insets every edge symmetrically.
+
+    [Fact]
+    public void ApplyAntiAliasInset_AaOff_ReturnsUnchanged()
+    {
+        Circle sut = new();
+
+        (Vector2 center, float radius) =
+            sut.ApplyAntiAliasInset(new Vector2(50, 50), radius: 25f, antiAliasSize: 0, cameraZoom: 1f);
+
+        center.ShouldBe(new Vector2(50, 50));
+        radius.ShouldBe(25f);
+    }
+
+    [Fact]
+    public void ApplyAntiAliasInset_AaOn_Zoom1_ShrinksRadiusHalfScreenPixel_CenterFixed()
+    {
+        Circle sut = new();
+
+        (Vector2 center, float radius) =
+            sut.ApplyAntiAliasInset(new Vector2(50, 50), radius: 25f, antiAliasSize: 1, cameraZoom: 1f);
+
+        // Center unchanged — no down/right bias; radius shrinks half a screen pixel.
+        center.ShouldBe(new Vector2(50f, 50f));
+        radius.ShouldBe(24.5f);
+    }
+
+    [Fact]
+    public void ApplyAntiAliasInset_AaOn_Zoom2_ShrinksRadiusScaledToScreenPixel_CenterFixed()
+    {
+        Circle sut = new();
+
+        (Vector2 center, float radius) =
+            sut.ApplyAntiAliasInset(new Vector2(50, 50), radius: 25f, antiAliasSize: 1, cameraZoom: 2f);
+
+        center.ShouldBe(new Vector2(50f, 50f));
+        radius.ShouldBe(24.75f);
+    }
+
     [Fact]
     public void ComputeFillDrawRadius_BodyPass_NoInset_ReturnsRadius()
     {

--- a/Tests/MonoGameGum.Shapes.Tests/CircleRuntimeTests.cs
+++ b/Tests/MonoGameGum.Shapes.Tests/CircleRuntimeTests.cs
@@ -185,12 +185,15 @@ public class CircleRuntimeTests
     // Load-order contract guard for #2761 / #2768: if any of the four factory registrations
     // moves back inside the _registered guard in AposShapeRuntime, this catches the
     // regression. After Reset + re-call, a new CircleRuntime must still bind Apos Circles.
-    // Issue #2791: gradient props on CircleRuntime push through to both Apos Circles so a single
-    // gradient can paint fill and stroke at once (matches Skia's single-renderable behavior).
+    // Issue #2791: gradient coordinate/color props push through to BOTH Apos Circles so the values
+    // round-trip on either slot. The UseGradient GATE, however, routes to the active body slot
+    // (fill when IsFilled, else stroke — see UseGradient_When* tests). IsFilled is set true here so
+    // the gate lands deterministically on the fill; the shared params are inert on the stroke.
     [Fact]
     public void Gradient_PropertiesPushedToBothFillAndStrokeSlots()
     {
         CircleRuntime sut = new();
+        sut.IsFilled = true;
 
         sut.UseGradient = true;
         sut.GradientType = GradientType.Linear;
@@ -204,7 +207,7 @@ public class CircleRuntimeTests
         Circle stroke = (Circle)fill.Children[0];
 
         fill.UseGradient.ShouldBeTrue();
-        stroke.UseGradient.ShouldBeTrue();
+        stroke.UseGradient.ShouldBeFalse();
         fill.GradientType.ShouldBe(GradientType.Linear);
         stroke.GradientType.ShouldBe(GradientType.Linear);
         fill.Red1.ShouldBe(Color.Red.R);
@@ -215,6 +218,92 @@ public class CircleRuntimeTests
         stroke.GradientX2.ShouldBe(56);
         fill.GradientInnerRadius.ShouldBe(4);
         stroke.GradientInnerRadius.ShouldBe(4);
+    }
+
+    // The gradient paints the ACTIVE body: the fill when IsFilled, the stroke when stroke-only.
+    // The inactive slot renders solid (its gradient gate stays off) so the two never share the
+    // single gradient and composite invisibly.
+    //
+    // Filled: gradient fills the disk, stroke renders its solid StrokeColor.
+    [Fact]
+    public void UseGradient_WhenFilled_RoutesGradientToFill_StrokeSolid()
+    {
+        CircleRuntime sut = new();
+        sut.Width = 56;
+        sut.Height = 56;
+        sut.IsFilled = true;
+        sut.FillColor = Color.Red;
+        sut.StrokeColor = Color.White;
+        sut.StrokeWidth = 4f;
+        sut.Color1 = Color.Blue;
+        sut.Color2 = Color.Green;
+        sut.Alpha1 = 255;
+        sut.Alpha2 = 255;
+
+        sut.UseGradient = true;
+
+        Circle fill = (Circle)sut.RenderableComponent;
+        Circle stroke = (Circle)fill.Children[0];
+
+        fill.UseGradient.ShouldBeTrue();
+        stroke.UseGradient.ShouldBeFalse();
+        stroke.ShouldPaintGradient(forcedColor: null).ShouldBeFalse();
+        stroke.Color.ShouldBe(Color.White);
+    }
+
+    // Stroke-only (IsFilled = false): the gradient paints the stroke; the (invisible) fill slot's
+    // gate is off. Without this the gradient rendered on the gated-transparent fill while the
+    // stroke showed solid — the reported bug.
+    [Fact]
+    public void UseGradient_WhenStrokeOnly_RoutesGradientToStroke_FillOff()
+    {
+        CircleRuntime sut = new();
+        sut.Width = 56;
+        sut.Height = 56;
+        sut.IsFilled = false;
+        sut.StrokeColor = Color.White;
+        sut.StrokeWidth = 4f;
+        sut.Color1 = Color.Blue;
+        sut.Color2 = Color.Green;
+        sut.Alpha1 = 255;
+        sut.Alpha2 = 255;
+
+        sut.UseGradient = true;
+
+        Circle fill = (Circle)sut.RenderableComponent;
+        Circle stroke = (Circle)fill.Children[0];
+
+        stroke.UseGradient.ShouldBeTrue();
+        stroke.ShouldPaintGradient(forcedColor: null).ShouldBeTrue();
+        fill.UseGradient.ShouldBeFalse();
+    }
+
+    // Toggling IsFilled re-routes the gradient to the new active slot (mirror of the dropshadow
+    // SyncDropshadowToTarget re-routing), so the gate is never stranded on the wrong slot.
+    [Fact]
+    public void UseGradient_IsFilledToggle_RoutesGradientToActiveSlot()
+    {
+        CircleRuntime sut = new();
+        sut.Width = 56;
+        sut.Height = 56;
+        sut.StrokeColor = Color.White;
+        sut.StrokeWidth = 4f;
+        sut.Color1 = Color.Blue;
+        sut.Color2 = Color.Green;
+        sut.Alpha1 = 255;
+        sut.Alpha2 = 255;
+        sut.UseGradient = true;
+
+        Circle fill = (Circle)sut.RenderableComponent;
+        Circle stroke = (Circle)fill.Children[0];
+
+        sut.IsFilled = true;
+        fill.UseGradient.ShouldBeTrue();
+        stroke.UseGradient.ShouldBeFalse();
+
+        sut.IsFilled = false;
+        fill.UseGradient.ShouldBeFalse();
+        stroke.UseGradient.ShouldBeTrue();
     }
 
     // Issue #2797: dropshadow pushes to the fill slot only (with fallback to stroke when fill
@@ -927,9 +1016,9 @@ public class CircleRuntimeTests
     // special-cases the legacy single-slot properties (Color/Red/Green/Blue/Alpha/Radius);
     // every other property falls through to reflection on the *contained renderable*. For a
     // two-slot CircleRuntime the contained renderable is the fill slot, so two-slot variables
-    // (UseGradient, IsFilled, FillColor, StrokeColor, etc.) only reach the fill slot — the
-    // stroke slot never sees them. Visible symptom: `UseGradient = true` + `IsFilled = false`
-    // makes the stroke render solid because the stroke slot's UseGradient never flipped.
+    // (UseGradient, IsFilled, FillColor, StrokeColor, etc.) would only reach the fill slot if they
+    // fell through to reflection — bypassing the runtime side effects (IsFilled zeroing the fill
+    // alpha, StrokeColor writing the stroke slot, the runtime backing fields used for round-trip).
     //
     // These tests pin the contract that SetProperty routes through the *runtime's* typed
     // setters for two-slot variables. Each test confirms a runtime-level side effect that
@@ -937,7 +1026,7 @@ public class CircleRuntimeTests
     // the contained renderable).
 
     [Fact]
-    public void SetProperty_UseGradient_ForwardsToBothSlots()
+    public void SetProperty_UseGradient_RoutesThroughRuntimeSetter()
     {
         CircleRuntime sut = new();
 
@@ -945,8 +1034,13 @@ public class CircleRuntimeTests
 
         Circle fill = (Circle)sut.RenderableComponent;
         Circle stroke = (Circle)fill.Children[0];
-        fill.UseGradient.ShouldBeTrue();
+        // Routed through the runtime setter: the backing field is set and the gradient gate routes
+        // to the active body slot. IsFilled defaults false (stroke-only), so the gate lands on the
+        // stroke. Reflection writing straight to the contained fill renderable would leave the
+        // backing field (sut.UseGradient) false and never touch the stroke slot.
+        sut.UseGradient.ShouldBeTrue();
         stroke.UseGradient.ShouldBeTrue();
+        fill.UseGradient.ShouldBeFalse();
     }
 
     [Fact]

--- a/Tests/MonoGameGum.Shapes.Tests/RectangleRuntimeTests.cs
+++ b/Tests/MonoGameGum.Shapes.Tests/RectangleRuntimeTests.cs
@@ -79,6 +79,155 @@ public class RectangleRuntimeTests
         stroke.CustomRadiusBottomRight.ShouldBe(4f);
     }
 
+    // FillInset is the rectangle analog of CircleRuntime's FillRadiusInset (#2834): when both
+    // fill and stroke are visible, PreRender pushes an inset onto the fill slot so the fill's
+    // outer edge sits inside the stroke's band. Without it a filled rectangle with a
+    // semi-transparent stroke shows the FILL through the stroke instead of the background —
+    // the reported bug. Inset equals the AA-compensated stroke width: 4 - 1 (Apos AA halo) = 3.
+    [Fact]
+    public void FillInset_AaOn_WhenStrokeVisible_PushedAaCompensatedStrokeWidthInPreRender()
+    {
+        RectangleRuntime sut = new();
+        sut.Width = 100;
+        sut.Height = 60;
+        sut.IsFilled = true;
+        sut.FillColor = Color.Red;
+        sut.StrokeColor = Color.White;
+        sut.StrokeWidth = 4f;
+        sut.StrokeWidthUnits = DimensionUnitType.Absolute;
+        sut.IsAntialiased = true;
+
+        RoundedRectangle fill = (RoundedRectangle)sut.RenderableComponent;
+        IRenderable asFillRenderable = fill;
+        asFillRenderable.PreRender();
+
+        fill.FillInset.ShouldBe(3f);
+    }
+
+    // At hairline strokes (StrokeWidth = 1, AA on) the AA-compensated stroke width is sub-pixel
+    // epsilon, but the AA halo is still 1 px. Inset must be floored at the AA contribution (1 px)
+    // so the fill's outer AA halo doesn't overlap the stroke's AA range.
+    [Fact]
+    public void FillInset_AaOn_AtHairlineStroke_FlooredAtAaContribution()
+    {
+        RectangleRuntime sut = new();
+        sut.Width = 100;
+        sut.Height = 60;
+        sut.IsFilled = true;
+        sut.FillColor = Color.Red;
+        sut.StrokeColor = Color.White;
+        sut.StrokeWidth = 1f;
+        sut.StrokeWidthUnits = DimensionUnitType.Absolute;
+        sut.IsAntialiased = true;
+
+        RoundedRectangle fill = (RoundedRectangle)sut.RenderableComponent;
+        IRenderable asFillRenderable = fill;
+        asFillRenderable.PreRender();
+
+        fill.FillInset.ShouldBe(1f);
+    }
+
+    // When the stroke is invisible (StrokeWidth == 0) the fill renders at full size — no inset,
+    // no background ring where the stroke would have been.
+    [Fact]
+    public void FillInset_WhenStrokeInvisible_StaysZero()
+    {
+        RectangleRuntime sut = new();
+        sut.Width = 100;
+        sut.Height = 60;
+        sut.IsFilled = true;
+        sut.FillColor = Color.Red;
+        sut.StrokeColor = Color.White;
+        sut.StrokeWidth = 0f;
+        sut.StrokeWidthUnits = DimensionUnitType.Absolute;
+
+        RoundedRectangle fill = (RoundedRectangle)sut.RenderableComponent;
+        IRenderable asFillRenderable = fill;
+        asFillRenderable.PreRender();
+
+        fill.FillInset.ShouldBe(0f);
+    }
+
+    // The gradient paints the ACTIVE body: the fill when IsFilled, the stroke when stroke-only.
+    // Whichever slot is not the active body renders solid (its gradient gate stays off) so the two
+    // never share the single gradient and composite invisibly.
+    //
+    // Filled: gradient fills the body, stroke renders its solid StrokeColor.
+    [Fact]
+    public void UseGradient_WhenFilled_RoutesGradientToFill_StrokeSolid()
+    {
+        RectangleRuntime sut = new();
+        sut.IsFilled = true;
+        sut.FillColor = Color.Red;
+        sut.StrokeColor = Color.White;
+        sut.StrokeWidth = 4f;
+        sut.Color1 = Color.Blue;
+        sut.Color2 = Color.Green;
+        sut.Alpha1 = 255;
+        sut.Alpha2 = 255;
+
+        sut.UseGradient = true;
+
+        RoundedRectangle fill = (RoundedRectangle)sut.RenderableComponent;
+        RoundedRectangle stroke = (RoundedRectangle)fill.Children[0];
+
+        fill.UseGradient.ShouldBeTrue();
+        stroke.UseGradient.ShouldBeFalse();
+        stroke.ShouldPaintGradient(forcedColor: null).ShouldBeFalse();
+        stroke.Color.ShouldBe(Color.White);
+    }
+
+    // Stroke-only (IsFilled = false): the gradient paints the stroke; the (invisible) fill slot's
+    // gate is off. Without this the gradient rendered on the gated-transparent fill while the
+    // stroke showed solid — the reported bug.
+    [Fact]
+    public void UseGradient_WhenStrokeOnly_RoutesGradientToStroke_FillOff()
+    {
+        RectangleRuntime sut = new();
+        sut.IsFilled = false;
+        sut.StrokeColor = Color.White;
+        sut.StrokeWidth = 4f;
+        sut.Color1 = Color.Blue;
+        sut.Color2 = Color.Green;
+        sut.Alpha1 = 255;
+        sut.Alpha2 = 255;
+
+        sut.UseGradient = true;
+
+        RoundedRectangle fill = (RoundedRectangle)sut.RenderableComponent;
+        RoundedRectangle stroke = (RoundedRectangle)fill.Children[0];
+
+        stroke.UseGradient.ShouldBeTrue();
+        stroke.ShouldPaintGradient(forcedColor: null).ShouldBeTrue();
+        fill.UseGradient.ShouldBeFalse();
+    }
+
+    // Toggling IsFilled re-routes the gradient to the new active slot (mirror of the dropshadow
+    // SyncDropshadowToTarget re-routing), so the gate is never stranded on the wrong slot.
+    [Fact]
+    public void UseGradient_IsFilledToggle_RoutesGradientToActiveSlot()
+    {
+        RectangleRuntime sut = new();
+        sut.StrokeColor = Color.White;
+        sut.StrokeWidth = 4f;
+        sut.Color1 = Color.Blue;
+        sut.Color2 = Color.Green;
+        sut.Alpha1 = 255;
+        sut.Alpha2 = 255;
+        sut.UseGradient = true;
+
+        RoundedRectangle fill = (RoundedRectangle)sut.RenderableComponent;
+        RoundedRectangle stroke = (RoundedRectangle)fill.Children[0];
+
+        sut.IsFilled = true;
+        fill.UseGradient.ShouldBeTrue();
+        stroke.UseGradient.ShouldBeFalse();
+
+        sut.IsFilled = false;
+        fill.UseGradient.ShouldBeFalse();
+        stroke.UseGradient.ShouldBeTrue();
+    }
+
     // Issue #2925 (Phase 0 parity) — ScreenPixel was previously a Skia-only honor (Apos parity gap
     // noted in RoundedRectangleRuntime.cs:80, 124). At Camera.Zoom = 2 the resolved radius is
     // raw / zoom so the rounded corner holds a constant on-screen pixel size as the camera zooms,
@@ -226,12 +375,16 @@ public class RectangleRuntimeTests
         stroke.IsAntialiased.ShouldBeTrue();
     }
 
-    // Issue #2818: gradient props on RectangleRuntime push through to both Apos RoundedRectangles
-    // so a single gradient can paint fill and stroke at once (mirror of CircleRuntime #2791).
+    // Issue #2818: gradient coordinate/color props push through to BOTH Apos RoundedRectangles so
+    // the values round-trip on either slot. The UseGradient GATE, however, routes to the active
+    // body slot (fill when IsFilled, else stroke — see UseGradient_When* tests). IsFilled is set
+    // true here so the gate lands deterministically on the fill; the shared params are inert on
+    // the stroke while its gate is off.
     [Fact]
     public void Gradient_PropertiesPushedToBothFillAndStrokeSlots()
     {
         RectangleRuntime sut = new();
+        sut.IsFilled = true;
 
         sut.UseGradient = true;
         sut.GradientType = GradientType.Linear;
@@ -245,7 +398,7 @@ public class RectangleRuntimeTests
         RoundedRectangle stroke = (RoundedRectangle)fill.Children[0];
 
         fill.UseGradient.ShouldBeTrue();
-        stroke.UseGradient.ShouldBeTrue();
+        stroke.UseGradient.ShouldBeFalse();
         fill.GradientType.ShouldBe(GradientType.Linear);
         stroke.GradientType.ShouldBe(GradientType.Linear);
         fill.Red1.ShouldBe(Color.Red.R);

--- a/Tests/MonoGameGum.Shapes.Tests/RoundedRectangleRenderableTests.cs
+++ b/Tests/MonoGameGum.Shapes.Tests/RoundedRectangleRenderableTests.cs
@@ -14,6 +14,107 @@ namespace MonoGameGum.Shapes.Tests;
 // rectangles anchor the band centerline at the body stroke centerline (only the AA halo grows).
 public class RoundedRectangleRenderableTests
 {
+    // Issue (Apos.Shapes filled-rectangle transparent-stroke bleed) — FillInset is the
+    // rectangle analog of Circle.FillRadiusInset (#2834): pull the filled body's outer edge
+    // inside the companion stroke band so a semi-transparent stroke shows the background
+    // through it, not the fill. The body pass shrinks symmetrically about the center (so the
+    // shape stays put); the shadow pass must NOT inherit the inset, or the shadow comes up
+    // short of the body's outer edge (mirror of #2958 on the circle).
+
+    [Fact]
+    public void ComputeFillDrawRect_BodyPass_NoInset_ReturnsRect()
+    {
+        RoundedRectangle sut = new() { FillInset = 0f };
+
+        (Vector2 position, Vector2 size) =
+            sut.ComputeFillDrawRect(new Vector2(10, 10), new Vector2(100, 60), isShadowPass: false);
+
+        position.ShouldBe(new Vector2(10, 10));
+        size.ShouldBe(new Vector2(100, 60));
+    }
+
+    [Fact]
+    public void ComputeFillDrawRect_BodyPass_WithInset_ShrinksAndRecentersAboutCenter()
+    {
+        RoundedRectangle sut = new() { FillInset = 4f };
+
+        (Vector2 position, Vector2 size) =
+            sut.ComputeFillDrawRect(new Vector2(10, 10), new Vector2(100, 60), isShadowPass: false);
+
+        // Each side pulls in by FillInset → size shrinks by 2 * inset, top-left moves in by inset.
+        size.ShouldBe(new Vector2(92, 52));
+        position.ShouldBe(new Vector2(14, 14));
+    }
+
+    [Fact]
+    public void ComputeFillDrawRect_BodyPass_InsetExceedsHalfDimension_ClampsToZero()
+    {
+        RoundedRectangle sut = new() { FillInset = 60f };
+
+        (Vector2 _, Vector2 size) =
+            sut.ComputeFillDrawRect(new Vector2(10, 10), new Vector2(100, 50), isShadowPass: false);
+
+        // 100 - 120 and 50 - 120 both clamp to 0 rather than inverting the rect.
+        size.X.ShouldBe(0f);
+        size.Y.ShouldBe(0f);
+    }
+
+    [Fact]
+    public void ComputeFillDrawRect_ShadowPass_IgnoresInset()
+    {
+        RoundedRectangle sut = new() { FillInset = 4f };
+
+        (Vector2 position, Vector2 size) =
+            sut.ComputeFillDrawRect(new Vector2(10, 10), new Vector2(100, 60), isShadowPass: true);
+
+        position.ShouldBe(new Vector2(10, 10));
+        size.ShouldBe(new Vector2(100, 60));
+    }
+
+    // Bug: the pixel-center AA offset (position += 0.5, size -= 1) that aligns an antialiased
+    // edge to the SCREEN pixel grid (Apos issue #12) was applied in WORLD units, ignoring camera
+    // zoom. Like the AA halo (#2936) it must be divided by cameraZoom so it stays a constant
+    // on-screen size — otherwise a filled rectangle inset visibly grows as the Gum tool zooms in
+    // and the fill pulls away from an equally-sized NineSlice. At zoom 1 the values match the
+    // historical 0.5 / 1.0.
+
+    [Fact]
+    public void ApplyAntiAliasInset_AaOff_ReturnsUnchanged()
+    {
+        RoundedRectangle sut = new();
+
+        (Vector2 position, Vector2 size) =
+            sut.ApplyAntiAliasInset(new Vector2(10, 10), new Vector2(100, 60), antiAliasSize: 0, cameraZoom: 1f);
+
+        position.ShouldBe(new Vector2(10, 10));
+        size.ShouldBe(new Vector2(100, 60));
+    }
+
+    [Fact]
+    public void ApplyAntiAliasInset_AaOn_Zoom1_InsetsHalfScreenPixel()
+    {
+        RoundedRectangle sut = new();
+
+        (Vector2 position, Vector2 size) =
+            sut.ApplyAntiAliasInset(new Vector2(10, 10), new Vector2(100, 60), antiAliasSize: 1, cameraZoom: 1f);
+
+        position.ShouldBe(new Vector2(10.5f, 10.5f));
+        size.ShouldBe(new Vector2(99f, 59f));
+    }
+
+    [Fact]
+    public void ApplyAntiAliasInset_AaOn_Zoom2_InsetScaledToScreenPixel()
+    {
+        RoundedRectangle sut = new();
+
+        (Vector2 position, Vector2 size) =
+            sut.ApplyAntiAliasInset(new Vector2(10, 10), new Vector2(100, 60), antiAliasSize: 1, cameraZoom: 2f);
+
+        // Half a SCREEN pixel = 0.25 world units at zoom 2; the full trim is twice that.
+        position.ShouldBe(new Vector2(10.25f, 10.25f));
+        size.ShouldBe(new Vector2(99.5f, 59.5f));
+    }
+
     [Fact]
     public void ComputeShadowDrawParameters_Filled_ZeroBlur_SizeUnchanged()
     {


### PR DESCRIPTION
## Summary

A batch of Apos.Shapes Circle/Rectangle rendering fixes found while exercising the new fill/stroke/gradient shape surface. Each fix was developed test-first.

## Fixes

1. **Filled rectangle + transparent stroke showed the fill through the stroke.** Added a `FillInset` to the Apos `RoundedRectangle` (rectangle analog of `Circle.FillRadiusInset`, #2834) and pushed it from `RectangleRuntime.PreRender` when a visible stroke is present, so the fill's outer edge sits inside the stroke band — a semi-transparent stroke now shows the background, not the fill. Core `DefaultFilledRectangleRenderable` stores it as a no-op (graceful degradation).

2. **The AA pixel-center inset ignored camera zoom.** The half-pixel edge offset that aligns an antialiased edge to the screen pixel grid was applied in *world* units, so the inset grew on screen as the tool zoomed in and fills/strokes crept inward from an equally-sized NineSlice. Extracted `RenderableShapeBase.GetAntiAliasWorldOffset` and per-shape `ApplyAntiAliasInset`, dividing the offset by camera zoom (same pattern as the #2936 AA-halo conversion). At zoom 1 the values are unchanged.

3. **Circle had a down/right rendering bias.** The circle's AA inset shifted the center down/right while shrinking the radius, insetting the top/left edge twice and leaving the bottom/right flush (visible spill-over when zoomed out). Now the radius shrinks with the center held fixed, so every edge insets symmetrically.

4. **Gradient routing for fill vs stroke.** `UseGradient` previously pushed the gradient gate to both slots, so a gradient stroke shared the fill's single gradient and composited invisibly. The gradient now paints the **active body** slot — the fill when `IsFilled`, the stroke when stroke-only — and the inactive slot renders solid. Result: a gradient fill keeps a visible solid stroke, and a stroke-only shape renders the gradient on its stroke. Routing re-syncs on `IsFilled` toggle (mirrors the existing dropshadow routing).

## Also included

- **`ColorDisplay.xaml.cs` — null-safe color comparison.** `InstanceMember.Value` is null when multiple selected instances have different colors; the comparison now pattern-matches the cast so it doesn't unbox null, leaving `isColorSame` false (the picked color applies to all). Unrelated to the shape work but bundled here.

## Tests

Developed test-first (red → green). `MonoGameGum.Shapes.Tests` 194 passing; `MonoGameGum.Tests` Circle/Rectangle runtime tests 35 passing. No new compiler warnings. The changed renderable source is shared by `MonoGameGumShapes` and `KniGumShapes`, so the fixes reach the Gum tool (KNI) as well.

## Notes

- Shape source touched: `Runtimes/GumShapes/Renderables/{Circle,RoundedRectangle,RenderableShapeBase}.cs`, `MonoGameGum/GueDeriving/{CircleRuntime,RectangleRuntime,IFilledRectangleRenderable}.cs`, `MonoGameGum/Renderables/DefaultFilledRectangleRenderable.cs`, plus the corresponding Shapes tests.
- Related follow-ups captured separately: #3009 (unify gradient Color1 with the active fill/stroke color), and a discussed-but-unfiled limitation around semi-transparent stroke seams over a fill (would need single-pass Apos rendering).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
