### PR TITLE
Document GumSyntaxVersion in AssemblyAttributes.cs, link to docs

### DIFF
--- a/.claude/skills/gum-runtime-syntax-version/SKILL.md
+++ b/.claude/skills/gum-runtime-syntax-version/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: gum-runtime-syntax-version
+description: The integer version stamped on Gum runtime assemblies via GumSyntaxVersionAttribute, used by the tool's codegen to gate emitted code. Triggers when bumping the runtime syntax version, touching AssemblyAttributes.cs in GumCommon/MonoGameGum/RaylibGum/SkiaGum, or changing SyntaxVersionDetectionService.
+---
+
+# Gum Runtime Syntax Version
+
+Not the same thing as `.gumx` file format versioning (see `gum-project-versioning`). This is an **assembly-level** integer stamped on each runtime DLL that tells the Gum tool's codegen which conventions / namespaces / role interfaces the consumer's runtime supports.
+
+## Where it lives
+
+- Attribute type: `GumDataTypes/GumSyntaxVersionAttribute.cs`.
+- Stamped via `AssemblyAttributes.cs` in each runtime project:
+  - `GumCommon/AssemblyAttributes.cs`
+  - `MonoGameGum/AssemblyAttributes.cs` (KniGum and FnaGum csprojs glob `..\**\*.cs`, so they inherit this stamp automatically)
+  - `Runtimes/RaylibGum/AssemblyAttributes.cs`
+  - `Runtimes/SkiaGum/AssemblyAttributes.cs`
+- Detection (tool side): `Tools/Gum.ProjectServices/CodeGeneration/SyntaxVersionDetectionService.cs`.
+- Public docs / version table (the version history lives here, not in this skill):
+  `docs/gum-tool/upgrading/syntax-versions.md` — published at
+  https://docs.flatredball.com/gum/gum-tool/upgrading/syntax-versions
+
+## How detection works
+
+Reads the consumer's `.csproj`:
+1. If `ProjectReference` → finds `MonoGameGum`/`RaylibGum`/`SkiaGum`/`KniGum`/`FnaGum`, opens that project's `AssemblyAttributes.cs`, regex-parses the version.
+2. Else if `PackageReference` → locates the DLL in the NuGet cache, reads the attribute via `MetadataLoadContext`.
+3. Else manual override from `.codsj`'s `SyntaxVersion` field.
+
+**GumCommon is not on the detection scan list** — stamping it is for assembly-metadata consistency, not for codegen detection.
+
+## When to bump
+
+When the runtime surface that codegen cares about changes in a way that requires the tool to emit different code (renamed/removed role interfaces, new runtime types, namespace changes). Bump all four assemblies in lock step and add a row to the version table.
+
+## When NOT to bump
+
+Pure renderable / Forms / sample changes that the codegen doesn't pattern-match against. The version is for **codegen gates**, not a general changelog.

--- a/GumCommon/AssemblyAttributes.cs
+++ b/GumCommon/AssemblyAttributes.cs
@@ -1,3 +1,14 @@
 using Gum.DataTypes;
 
+// Gum runtime syntax version — an assembly-level integer the Gum tool's code generator reads
+// to decide which runtime conventions/namespaces to emit code against. This is NOT the .gumx
+// project file format version.
+//
+// Only bump when a runtime change forces codegen to emit different code (renamed/removed role
+// interfaces, new runtime types, namespace moves). Pure renderable/Forms/sample changes do NOT
+// bump it. When bumping, change all four runtime assemblies (GumCommon, MonoGameGum, RaylibGum,
+// SkiaGum) in lock step and add a row to the version table.
+//
+// The version history is maintained in one place — see:
+// https://docs.flatredball.com/gum/gum-tool/upgrading/syntax-versions
 [assembly: GumSyntaxVersion(Version = 2)]

--- a/MonoGameGum/AssemblyAttributes.cs
+++ b/MonoGameGum/AssemblyAttributes.cs
@@ -1,3 +1,14 @@
 using Gum.DataTypes;
 
+// Gum runtime syntax version — an assembly-level integer the Gum tool's code generator reads
+// to decide which runtime conventions/namespaces to emit code against. This is NOT the .gumx
+// project file format version.
+//
+// Only bump when a runtime change forces codegen to emit different code (renamed/removed role
+// interfaces, new runtime types, namespace moves). Pure renderable/Forms/sample changes do NOT
+// bump it. When bumping, change all four runtime assemblies (GumCommon, MonoGameGum, RaylibGum,
+// SkiaGum) in lock step and add a row to the version table.
+//
+// The version history is maintained in one place — see:
+// https://docs.flatredball.com/gum/gum-tool/upgrading/syntax-versions
 [assembly: GumSyntaxVersion(Version = 2)]

--- a/Runtimes/RaylibGum/AssemblyAttributes.cs
+++ b/Runtimes/RaylibGum/AssemblyAttributes.cs
@@ -1,3 +1,14 @@
 using Gum.DataTypes;
 
+// Gum runtime syntax version — an assembly-level integer the Gum tool's code generator reads
+// to decide which runtime conventions/namespaces to emit code against. This is NOT the .gumx
+// project file format version.
+//
+// Only bump when a runtime change forces codegen to emit different code (renamed/removed role
+// interfaces, new runtime types, namespace moves). Pure renderable/Forms/sample changes do NOT
+// bump it. When bumping, change all four runtime assemblies (GumCommon, MonoGameGum, RaylibGum,
+// SkiaGum) in lock step and add a row to the version table.
+//
+// The version history is maintained in one place — see:
+// https://docs.flatredball.com/gum/gum-tool/upgrading/syntax-versions
 [assembly: GumSyntaxVersion(Version = 2)]

--- a/Runtimes/SkiaGum/AssemblyAttributes.cs
+++ b/Runtimes/SkiaGum/AssemblyAttributes.cs
@@ -1,3 +1,14 @@
 using Gum.DataTypes;
 
+// Gum runtime syntax version — an assembly-level integer the Gum tool's code generator reads
+// to decide which runtime conventions/namespaces to emit code against. This is NOT the .gumx
+// project file format version.
+//
+// Only bump when a runtime change forces codegen to emit different code (renamed/removed role
+// interfaces, new runtime types, namespace moves). Pure renderable/Forms/sample changes do NOT
+// bump it. When bumping, change all four runtime assemblies (GumCommon, MonoGameGum, RaylibGum,
+// SkiaGum) in lock step and add a row to the version table.
+//
+// The version history is maintained in one place — see:
+// https://docs.flatredball.com/gum/gum-tool/upgrading/syntax-versions
 [assembly: GumSyntaxVersion(Version = 2)]


### PR DESCRIPTION
## What

Each runtime's `AssemblyAttributes.cs` stamped only a bare `[assembly: GumSyntaxVersion(Version = 2)]` with no explanation of what the version gates or when to bump it. This adds a concise comment to all four assemblies:

- `GumCommon/AssemblyAttributes.cs`
- `MonoGameGum/AssemblyAttributes.cs`
- `Runtimes/RaylibGum/AssemblyAttributes.cs`
- `Runtimes/SkiaGum/AssemblyAttributes.cs`

It also brings the `gum-runtime-syntax-version` skill into the repo (`.claude/skills/`), where its 45 sibling skills already live — it had been sitting only in a machine-local global skills dir, so it was neither versioned nor shared.

## Why

The only explanation of the syntax-version system lived in the docs and a skill file — neither of which someone editing the stamp is likely to have open. The comment now states the concept (an assembly-level integer the tool's code generator reads to decide which namespaces/conventions to emit against — **not** the `.gumx` file format version) and the bump rule (only when codegen must emit different code; bump all four in lock step).

## Single source of truth

The comments and the skill deliberately do **not** restate the version history. They point to the published table instead:

https://docs.flatredball.com/gum/gum-tool/upgrading/syntax-versions

so the files can't drift out of sync with each other or with the docs. (The skill covers mechanism/discipline — where the files are, how detection resolves, when to bump — which the docs don't, so there's no duplicated history to remove.)

## Testing

Comment- and docs-only change — no behavior impact. The tool's source-file detection regex (`SyntaxVersionDetectionService.ParseVersionFromSourceFile`) matches `GumSyntaxVersion(Version = N)` specifically, which the prose comment does not contain, so version detection is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
