### PR TITLE
Document the Gum.Wireframe using requirement and hover-triggered animations

### DIFF
--- a/docs/code/animationruntime.md
+++ b/docs/code/animationruntime.md
@@ -18,6 +18,10 @@ Animations defined in the Gum tool can be loaded at runtime. To load and play an
 2. Obtain an `AnimationRuntime` instance from your `GraphicalUiElement` . This could be a screen or component.
 3. Call `PlayAnimation` to begin the animation.
 
+{% hint style="info" %}
+The `PlayAnimation(string)` and `PlayAnimation(int)` overloads are extension methods in the `Gum.Wireframe` namespace. If a call such as `PlayAnimation("SlideOnAndOff")` will not compile (for example "no overload for method `PlayAnimation` takes 1 argument"), add `using Gum.Wireframe;` at the top of your file.
+{% endhint %}
+
 Animations can be played on an entire screen, entire component, or an individual instance within a screen or component.
 
 For this example, the project has a screen called AnimatedScreen which contains an animation named SlideOnAndOff.
@@ -166,6 +170,26 @@ public class Game1 : Game
 {% endtabs %}
 
 <figure><img src="../.gitbook/assets/23_05 20 06.gif" alt=""><figcaption></figcaption></figure>
+
+## Playing Animations on Hover or Highlight
+
+Forms controls such as `Button` change their visual state (for example **Enabled**, **Highlighted**, **Pushed**, and **Disabled**) automatically as the user interacts with them. These state changes are applied instantly — they are not keyframe animations, and they do not call `PlayAnimation`.
+
+Keyframe animations never play on their own. To run an animation when a control is highlighted, subscribe to the visual's `RollOn` event (raised when the cursor first moves over the control) and `RollOff` event (raised when the cursor leaves), then call `PlayAnimation`:
+
+```csharp
+// Initialize
+button.Visual.RollOn += (_, _) =>
+{
+    button.Visual.PlayAnimation("Highlight");
+};
+button.Visual.RollOff += (_, _) =>
+{
+    button.Visual.PlayAnimation("Unhighlight");
+};
+```
+
+The animations named above must exist on the control — either authored in the Gum tool and loaded with `LoadAnimations`, or created in code as shown in the next section. The control still applies its built-in **Highlighted** state on `RollOn`, so use animations for additional effects on top of that state rather than as a replacement for it.
 
 ## Code Example - Animations in Code-Only Projects
 

--- a/docs/code/controls/button.md
+++ b/docs/code/controls/button.md
@@ -118,3 +118,7 @@ if(keyboard.KeyPushed(Microsoft.Xna.Framework.Input.Keys.Enter))
 }
 ```
 [Try on XnaFiddle.NET](https://xnafiddle.net/#snippet=H4sIAAAAAAACCp1TTWvjMBD9K4PpwYZg0sJeEnpom36xdAnblLbgi2KNG23sUZFkZ9vg_96R5dRJLgurg82Mn968mXneRvf2tq6iiTM1jqIKqyUaG02iy9o5TbDsXtOMMmq0knAnSJZ4Vap8HevlH8wdWCSJZgTXDZK7MG8WBD-SjLYZAZ9GGJDYqBzhHLJ6PD47e6I16Q2FYBpgqoDYXwRlgRWlz8pgYUSF6T29125gVwdhEm73tXZEh5jAMAsamP5Bk75lZl-m-5T-xI-lFkYmA40_R7J3qAPd_mBp8b_q-mgu_lG2Bx1UbcMrrCdd4F_H8JMA6baDEoSD7Uw4XCge4i-9mSxaaJSAbeBvvwnbaBQpUk6JUn0iLz_QMiPhBoIT4oSBfbkLKRf6t9ZuP_nC8B_jIX49ip-VdCvOnY73kneo3lbuCNl3E-TNDVoL1-TQgNOQ-96-hfcXuoYD_vJ836JTbqx-lzwDbsr7cN1vkOl5CY9o_CDSGRaiLgcXMLMq4h3Wp-e1XaGMH1RutNWFS19IpDfenRtt1oOJbNopTQb39xLnaAptqvDj7JiTbvbtFxjUizmEAwAA)
+
+## Animating on Hover
+
+A button changes between its **Enabled**, **Highlighted**, **Pushed**, and **Disabled** states automatically and instantly. To play a keyframe animation when the button is highlighted (for example, growing or shrinking on hover), subscribe to the visual's `RollOn` and `RollOff` events and call `PlayAnimation`. See [Playing Animations on Hover or Highlight](../animationruntime.md#playing-animations-on-hover-or-highlight) for details.


### PR DESCRIPTION
## Why

A user copied `PlayAnimation("SlideOnAndOff")` from the animation docs but hit a compile error ("no overload takes a string"). The cause: `PlayAnimation(string)` / `PlayAnimation(int)` are **extension methods** in the `Gum.Wireframe` namespace, while only `PlayAnimation(AnimationRuntime)` is an instance method. Without `using Gum.Wireframe;`, only the instance overload is visible.

The docs already included the `using` (at the top of a long sample), but it was easy to miss when copying a single line — and the docs never explained the user's actual goal: playing an animation on button highlight/hover.

## Changes

**`docs/code/animationruntime.md`**
- Added an info hint right where `PlayAnimation` is introduced, naming the `Gum.Wireframe` namespace and quoting the real CS1501 error text so a search lands there.
- Added a **Playing Animations on Hover or Highlight** section: clarifies that Forms control state swaps (Enabled/Highlighted/Pushed/Disabled) are automatic and instant, while keyframe animations are manual and never self-trigger. Includes a by-name `RollOn`/`RollOff` example and cross-references the existing code-only example rather than duplicating it.

**`docs/code/controls/button.md`**
- Added a short "Animating on Hover" pointer linking back to the animation section.

## Notes

- Docs-only; nothing to build.
- Verified `RollOn`/`RollOff` are `EventHandler?` on `InteractiveGue` (so the `(_, _)` lambda is correct), and that both files are already in `SUMMARY.md` (no nav change needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
