### PR TITLE
Unify gradient Color1 with the active fill/stroke color (#3009)

### DIFF
--- a/Gum/DataTypes/GumProjectSaveExtensionMethods.cs
+++ b/Gum/DataTypes/GumProjectSaveExtensionMethods.cs
@@ -306,6 +306,77 @@ namespace Gum.DataTypes
             return didChange;
         }
 
+        /// <summary>
+        /// Issue #3009 — Circle and Rectangle no longer store a standalone gradient start color
+        /// (Red1/Green1/Blue1/Alpha1 / Color1); the gradient start is now the active body color
+        /// (FillColor when filled, StrokeColor otherwise). Strips any orphaned Red1/Green1/Blue1/
+        /// Alpha1 variables left on Circle/Rectangle elements (and Circle/Rectangle-derived
+        /// elements) and on their instances. Arc — which keeps Color1 as an obsolete back-compat
+        /// shim — and the legacy RoundedRectangle/ColoredCircle shapes are left untouched.
+        /// </summary>
+        /// <remarks>
+        /// Uses <see cref="ObjectFinder.GetRootStandardElementSave(ElementSave?)"/> to resolve the
+        /// root standard type, so it correctly targets only Circle/Rectangle (and derived) and skips
+        /// Arc / legacy shapes. Color2 (Red2/Green2/Blue2/Alpha2 — the standalone second gradient
+        /// stop) is preserved.
+        /// </remarks>
+        public static bool StripCircleRectangleGradientColor1(this GumProjectSave gumProjectSave)
+        {
+            bool didChange = false;
+            foreach (var element in gumProjectSave.AllElements)
+            {
+                // Unqualified (element-level) channels are stripped when the element itself roots
+                // at Circle/Rectangle (e.g. the standard Circle/Rectangle, or a component derived
+                // from one overriding the value in its own state).
+                bool elementIsCircleOrRectangle =
+                    IsCircleOrRectangleRoot(ObjectFinder.Self.GetRootStandardElementSave(element));
+
+                foreach (var state in element.AllStates)
+                {
+                    if (StripGradientColor1InState(state, element, elementIsCircleOrRectangle))
+                    {
+                        didChange = true;
+                    }
+                }
+            }
+            return didChange;
+        }
+
+        private static readonly string[] GradientColor1ChannelNames =
+            new[] { "Red1", "Green1", "Blue1", "Alpha1" };
+
+        private static bool IsCircleOrRectangleRoot(StandardElementSave? root)
+        {
+            return root != null && (root.Name == "Circle" || root.Name == "Rectangle");
+        }
+
+        private static bool StripGradientColor1InState(StateSave state, ElementSave element, bool elementIsCircleOrRectangle)
+        {
+            var toRemove = state.Variables
+                .Where(v => v.Name != null && GradientColor1ChannelNames.Contains(GetLastNameSegment(v.Name)))
+                .Where(v =>
+                {
+                    var sourceObject = v.SourceObject;
+                    if (string.IsNullOrEmpty(sourceObject))
+                    {
+                        // Element-level channel: strip only when this element is a Circle/Rectangle.
+                        return elementIsCircleOrRectangle;
+                    }
+                    // Instance-qualified channel: strip only when the instance roots at Circle/Rectangle.
+                    var instance = element.Instances.FirstOrDefault(i => i.Name == sourceObject);
+                    return instance != null
+                        && IsCircleOrRectangleRoot(ObjectFinder.Self.GetRootStandardElementSave(instance));
+                })
+                .ToList();
+
+            foreach (var variable in toRemove)
+            {
+                state.Variables.Remove(variable);
+            }
+
+            return toRemove.Count > 0;
+        }
+
         private static bool MigrateRadiusInState(StateSave state)
         {
             const string radiusName = "Radius";

--- a/Gum/Managers/ProjectManager.cs
+++ b/Gum/Managers/ProjectManager.cs
@@ -274,6 +274,10 @@ public class ProjectManager : IProjectManager
                 {
                     wasModified = true;
                 }
+                if (_gumProjectSave.StripCircleRectangleGradientColor1())
+                {
+                    wasModified = true;
+                }
                 if (RemoveDuplicateVariables(_gumProjectSave))
                 {
                     wasModified = true;

--- a/Gum/Managers/StandardElementsManager.cs
+++ b/Gum/Managers/StandardElementsManager.cs
@@ -407,7 +407,9 @@ public class StandardElementsManager
             // only by flipping IsFilled = false (the fill slot's gradient is gated on _isFilled
             // in SkiaShapeRuntime.RefreshSlotGradients).
             AddFillAndStrokeVariables(stateSave, category: "Rendering");
-            AddGradientVariables(stateSave);
+            // Issue #3009 — Circle drives the gradient start from the active body color, so no
+            // standalone Color1 (Red1/Green1/Blue1/Alpha1).
+            AddGradientVariables(stateSave, includeStartColor: false);
             AddDropshadowVariables(stateSave);
             AddBlendVariable(stateSave);
 
@@ -450,7 +452,9 @@ public class StandardElementsManager
             // standard can be retired; default 0 keeps the historical hard-cornered visual. Only
             // Rectangle gets this (a Circle has no corners). Gated to v3 in ShapeVariableVersionGate.
             stateSave.Variables.Add(new VariableSave { SetsValue = true, Type = "float", Value = 0.0f, Name = "CornerRadius", Category = "Rendering" });
-            AddGradientVariables(stateSave);
+            // Issue #3009 — Rectangle drives the gradient start from the active body color, so no
+            // standalone Color1 (Red1/Green1/Blue1/Alpha1).
+            AddGradientVariables(stateSave, includeStartColor: false);
             AddDropshadowVariables(stateSave);
             AddBlendVariable(stateSave);
 
@@ -1228,7 +1232,14 @@ public class StandardElementsManager
         state.Variables.Add(new VariableSave { SetsValue = true, Type = "bool", Value = true, Name = "Visible", Category = "States and Visibility" });
     }
 
-    public static void AddGradientVariables(StateSave state)
+    /// <param name="includeStartColor">
+    /// When true (the default, for Arc and the legacy ColoredCircle/RoundedRectangle/Line shapes)
+    /// the standalone gradient start color channels (Red1/Green1/Blue1/Alpha1) are added. Issue
+    /// #3009 — the two-slot Circle/Rectangle drive the gradient start from the active body color
+    /// (FillColor/StrokeColor) instead of a standalone Color1, so they pass false and these
+    /// channels are omitted entirely. Color2 (the standalone second stop) is always added.
+    /// </param>
+    public static void AddGradientVariables(StateSave state, bool includeStartColor = true)
     {
         List<object> xUnitsExclusions = new List<object>();
         xUnitsExclusions.Add(PositionUnitType.PixelsFromTop);
@@ -1265,10 +1276,15 @@ public class StandardElementsManager
         state.Variables.Add(new VariableSave { SetsValue = true, Type = "float", Value = 0f, Category = "Rendering", Name = "GradientY1" });
         state.Variables.Add(new VariableSave { SetsValue = true, Type = typeof(PositionUnitType).Name, Value = PositionUnitType.PixelsFromTop, Name = "GradientY1Units", Category = "Rendering", ExcludedValuesForEnum = yUnitsExclusions });
 
-        state.Variables.Add(new VariableSave { SetsValue = true, Type = "int", Value = 255, Name = "Alpha1", Category = "Rendering" });
-        state.Variables.Add(new VariableSave { SetsValue = true, Type = "int", Value = 255, Name = "Red1", Category = "Rendering" });
-        state.Variables.Add(new VariableSave { SetsValue = true, Type = "int", Value = 255, Name = "Green1", Category = "Rendering" });
-        state.Variables.Add(new VariableSave { SetsValue = true, Type = "int", Value = 255, Name = "Blue1", Category = "Rendering" });
+        // Issue #3009 — the standalone gradient start (Color1) only exists on Arc and the legacy
+        // shapes; Circle/Rectangle drive the start from the active body color, so they omit it.
+        if (includeStartColor)
+        {
+            state.Variables.Add(new VariableSave { SetsValue = true, Type = "int", Value = 255, Name = "Alpha1", Category = "Rendering" });
+            state.Variables.Add(new VariableSave { SetsValue = true, Type = "int", Value = 255, Name = "Red1", Category = "Rendering" });
+            state.Variables.Add(new VariableSave { SetsValue = true, Type = "int", Value = 255, Name = "Green1", Category = "Rendering" });
+            state.Variables.Add(new VariableSave { SetsValue = true, Type = "int", Value = 255, Name = "Blue1", Category = "Rendering" });
+        }
 
         state.Variables.Add(new VariableSave { SetsValue = true, Type = "float", Value = 100f, Category = "Rendering", Name = "GradientX2" });
         state.Variables.Add(new VariableSave { SetsValue = true, Type = typeof(PositionUnitType).Name, Value = PositionUnitType.PixelsFromLeft, Name = "GradientX2Units", Category = "Rendering", ExcludedValuesForEnum = xUnitsExclusions });

--- a/Gum/Plugins/InternalPlugins/VariableGrid/ShapeVariableExclusionLogic.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/ShapeVariableExclusionLogic.cs
@@ -32,11 +32,18 @@ internal class ShapeVariableExclusionLogic
 
         if (rootName == "Red" || rootName == "Green" || rootName == "Blue")
         {
-            var usesGradients = finder.GetValue(prefix + "UseGradient");
-            if (usesGradients is bool asBool && asBool)
+            // Issue #3009 — on Arc the primary Color IS the gradient start, so keep it visible when
+            // a gradient is on (the user edits Color to set the start). The legacy shapes
+            // (ColoredCircle / RoundedRectangle / Line) keep a separate Color1, so their unused
+            // solid Color is hidden under a gradient (the pre-existing behavior).
+            if (rootStandardTypeName != "Arc")
             {
-                shouldExclude = true;
-                return true;
+                var usesGradients = finder.GetValue(prefix + "UseGradient");
+                if (usesGradients is bool asBool && asBool)
+                {
+                    shouldExclude = true;
+                    return true;
+                }
             }
         }
         else if (rootName == "Red1" || rootName == "Green1" || rootName == "Blue1" || rootName == "Alpha1" ||
@@ -129,22 +136,13 @@ internal class ShapeVariableExclusionLogic
         if (hasSeparateFillAndStroke &&
             (rootName == "FillRed" || rootName == "FillGreen" || rootName == "FillBlue" || rootName == "FillAlpha"))
         {
-            // Hidden when IsFilled = false (no fill drawn) or when UseGradient = true
-            // (gradient paints the fill slot, the solid fill channels are unused). Stroke
-            // channels stay visible regardless of UseGradient — gradient targets fill only.
+            // Hidden only when IsFilled = false (no fill drawn). Issue #3009 — the FillColor IS the
+            // gradient start when the shape is filled (Circle/Rectangle no longer have a standalone
+            // Color1), so the fill channels stay visible when UseGradient is on; the user sets the
+            // gradient start by editing FillColor. (They used to be hidden under UseGradient when
+            // the gradient had its own Color1.)
             var isFilled = finder.GetValue(prefix + "IsFilled");
-            if (isFilled is false)
-            {
-                shouldExclude = true;
-                return true;
-            }
-            var usesGradient = finder.GetValue(prefix + "UseGradient");
-            if (usesGradient is true)
-            {
-                shouldExclude = true;
-                return true;
-            }
-            shouldExclude = false;
+            shouldExclude = isFilled is false;
             return true;
         }
 

--- a/Gum/Plugins/InternalPlugins/VariableGrid/ShapeVariableExclusionLogic.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/ShapeVariableExclusionLogic.cs
@@ -18,6 +18,18 @@ internal class ShapeVariableExclusionLogic
     public bool GetIfShapeVariableIsExcluded(string rootName, RecursiveVariableFinder finder,
         string? rootStandardTypeName, string prefix, out bool shouldExclude)
     {
+        // Issue #3009 — Arc's gradient start is now its primary Color; the Red1/Green1/Blue1/Alpha1
+        // surface is kept only as obsolete back-compat shims (mapping onto Color), so hide all four
+        // from Arc's grid entirely, leaving Arc a single primary Color. Circle/Rectangle don't have
+        // these variables at all (StandardElementsManager omits them); the legacy ColoredCircle/
+        // RoundedRectangle keep their standalone Color1, gated by UseGradient in the branch below.
+        if (rootStandardTypeName == "Arc" &&
+            (rootName == "Red1" || rootName == "Green1" || rootName == "Blue1" || rootName == "Alpha1"))
+        {
+            shouldExclude = true;
+            return true;
+        }
+
         if (rootName == "Red" || rootName == "Green" || rootName == "Blue")
         {
             var usesGradients = finder.GetValue(prefix + "UseGradient");

--- a/Gum/Plugins/InternalPlugins/VariableGrid/ShapeVariableVersionGate.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/ShapeVariableVersionGate.cs
@@ -63,10 +63,9 @@ internal class ShapeVariableVersionGate
         "GradientOuterRadiusUnits",
         // Rounded corners (Rectangle only — absorbed from the retired RoundedRectangle standard)
         "CornerRadius",
-        "Red1",
-        "Green1",
-        "Blue1",
-        "Alpha1",
+        // Issue #3009 — Circle/Rectangle no longer expose the standalone gradient start
+        // (Red1/Green1/Blue1/Alpha1); the start is the active body color, so there is no such
+        // variable to gate. Color2 (Red2/Green2/Blue2/Alpha2) remains the standalone second stop.
         "Red2",
         "Green2",
         "Blue2",

--- a/MonoGameGum.Tests/DataTypes/GumProjectSaveTests.cs
+++ b/MonoGameGum.Tests/DataTypes/GumProjectSaveTests.cs
@@ -420,6 +420,83 @@ public class GumProjectSaveTests : BaseTestClass
         state.Variables.ShouldNotContain(v => v.Name.EndsWith(".Width"));
     }
 
+    // Issue #3009 — Circle/Rectangle dropped the standalone gradient start (Red1/Green1/Blue1/
+    // Alpha1); the start is now the active body color. The migration strips orphaned …1 channels
+    // from Circle/Rectangle elements and instances, while leaving Arc (which keeps Color1 as an
+    // obsolete shim) and Color2 untouched.
+    private static GumProjectSave MakeProjectWithShapeStandards()
+    {
+        GumProjectSave project = new GumProjectSave();
+        foreach (string standardName in new[] { "Circle", "Rectangle", "Arc" })
+        {
+            StandardElementSave standard = new StandardElementSave { Name = standardName };
+            standard.States.Add(new Gum.DataTypes.Variables.StateSave { Name = "Default" });
+            project.StandardElements.Add(standard);
+        }
+        return project;
+    }
+
+    [Fact]
+    public void StripCircleRectangleGradientColor1_RemovesChannels_OnCircleInstance_KeepsColor2()
+    {
+        GumProjectSave project = MakeProjectWithShapeStandards();
+        ComponentSave component = new ComponentSave { Name = "MyComponent" };
+        component.Instances.Add(new InstanceSave { Name = "CircleInstance", BaseType = "Circle" });
+        Gum.DataTypes.Variables.StateSave state = new Gum.DataTypes.Variables.StateSave { Name = "Default" };
+        state.Variables.Add(new VariableSave { Name = "CircleInstance.Red1", Type = "int", Value = 10, SetsValue = true });
+        state.Variables.Add(new VariableSave { Name = "CircleInstance.Green1", Type = "int", Value = 20, SetsValue = true });
+        state.Variables.Add(new VariableSave { Name = "CircleInstance.Blue1", Type = "int", Value = 30, SetsValue = true });
+        state.Variables.Add(new VariableSave { Name = "CircleInstance.Alpha1", Type = "int", Value = 40, SetsValue = true });
+        state.Variables.Add(new VariableSave { Name = "CircleInstance.Red2", Type = "int", Value = 50, SetsValue = true });
+        component.States.Add(state);
+        project.Components.Add(component);
+        Gum.Managers.ObjectFinder.Self.GumProjectSave = project;
+
+        bool changed = project.StripCircleRectangleGradientColor1();
+
+        changed.ShouldBeTrue();
+        state.Variables.ShouldNotContain(v => v.Name == "CircleInstance.Red1");
+        state.Variables.ShouldNotContain(v => v.Name == "CircleInstance.Green1");
+        state.Variables.ShouldNotContain(v => v.Name == "CircleInstance.Blue1");
+        state.Variables.ShouldNotContain(v => v.Name == "CircleInstance.Alpha1");
+        state.Variables.ShouldContain(v => v.Name == "CircleInstance.Red2");
+    }
+
+    [Fact]
+    public void StripCircleRectangleGradientColor1_RemovesUnqualifiedChannels_OnRectangleStandardElement()
+    {
+        GumProjectSave project = MakeProjectWithShapeStandards();
+        StandardElementSave rectangle = project.StandardElements.First(s => s.Name == "Rectangle");
+        Gum.DataTypes.Variables.StateSave state = rectangle.States.First();
+        state.Variables.Add(new VariableSave { Name = "Red1", Type = "int", Value = 1, SetsValue = true });
+        state.Variables.Add(new VariableSave { Name = "Alpha1", Type = "int", Value = 2, SetsValue = true });
+        Gum.Managers.ObjectFinder.Self.GumProjectSave = project;
+
+        bool changed = project.StripCircleRectangleGradientColor1();
+
+        changed.ShouldBeTrue();
+        state.Variables.ShouldNotContain(v => v.Name == "Red1");
+        state.Variables.ShouldNotContain(v => v.Name == "Alpha1");
+    }
+
+    [Fact]
+    public void StripCircleRectangleGradientColor1_LeavesArcInstance_Untouched()
+    {
+        GumProjectSave project = MakeProjectWithShapeStandards();
+        ComponentSave component = new ComponentSave { Name = "MyComponent" };
+        component.Instances.Add(new InstanceSave { Name = "ArcInstance", BaseType = "Arc" });
+        Gum.DataTypes.Variables.StateSave state = new Gum.DataTypes.Variables.StateSave { Name = "Default" };
+        state.Variables.Add(new VariableSave { Name = "ArcInstance.Red1", Type = "int", Value = 10, SetsValue = true });
+        component.States.Add(state);
+        project.Components.Add(component);
+        Gum.Managers.ObjectFinder.Self.GumProjectSave = project;
+
+        bool changed = project.StripCircleRectangleGradientColor1();
+
+        changed.ShouldBeFalse();
+        state.Variables.ShouldContain(v => v.Name == "ArcInstance.Red1");
+    }
+
     [Fact]
     public void V1GumxFormat_DeserializesScreenReferenceNamesCorrectly()
     {

--- a/MonoGameGum.Tests/Runtimes/CircleRuntimeTests.cs
+++ b/MonoGameGum.Tests/Runtimes/CircleRuntimeTests.cs
@@ -132,6 +132,9 @@ public class CircleRuntimeTests : BaseTestClass
     // slot is DefaultStrokedCircleRenderable (does not implement IGradientedRenderable). The
     // gradient setters must round-trip on the runtime so user code is forward-compatible with
     // a later install of the package, but produce no visual effect today.
+    // Issue #3009 — Color1 is no longer a standalone runtime value (the gradient start is the
+    // active body color), so it's not part of this round-trip set; Color2 and the coordinate/
+    // radius fields still round-trip.
     [Fact]
     public void Gradient_RoundTripsBackingFields_WhenNoGradientCapableSlot()
     {
@@ -139,7 +142,6 @@ public class CircleRuntimeTests : BaseTestClass
 
         sut.UseGradient = true;
         sut.GradientType = GradientType.Radial;
-        sut.Color1 = Color.Red;
         sut.Color2 = Color.Blue;
         sut.GradientX1 = 1;
         sut.GradientY1 = 2;
@@ -153,7 +155,6 @@ public class CircleRuntimeTests : BaseTestClass
 
         sut.UseGradient.ShouldBeTrue();
         sut.GradientType.ShouldBe(GradientType.Radial);
-        sut.Color1.ShouldBe(Color.Red);
         sut.Color2.ShouldBe(Color.Blue);
         sut.GradientX1.ShouldBe(1);
         sut.GradientY1.ShouldBe(2);

--- a/MonoGameGum/GueDeriving/CircleRuntime.cs
+++ b/MonoGameGum/GueDeriving/CircleRuntime.cs
@@ -283,6 +283,7 @@ public class CircleRuntime : GraphicalUiElement
         {
             _fillColor = value;
             ContainedLineCircle.FillColor = value;
+            SyncGradientStart();
             NotifyPropertyChanged();
         }
     }
@@ -325,6 +326,7 @@ public class CircleRuntime : GraphicalUiElement
         {
             _strokeColor = value;
             ContainedLineCircle.StrokeColor = value;
+            SyncGradientStart();
             NotifyPropertyChanged();
         }
     }
@@ -364,6 +366,8 @@ public class CircleRuntime : GraphicalUiElement
         set
         {
             ContainedLineCircle.IsFilled = value;
+            // Issue #3009 — re-route the gradient start to the now-active body color.
+            SyncGradientStart();
             NotifyPropertyChanged();
         }
     }
@@ -390,15 +394,12 @@ public class CircleRuntime : GraphicalUiElement
         }
     }
 
-    /// <inheritdoc cref="Gum.Renderables.LineCircle.Color1"/>
-    public Color Color1
+    // Issue #3009 — Circle/Rectangle no longer expose a standalone gradient Color1. The gradient
+    // start mirrors the active body color (FillColor when filled, StrokeColor otherwise), synced
+    // from the FillColor / StrokeColor / IsFilled setters into the renderable's Color1.
+    void SyncGradientStart()
     {
-        get => ContainedLineCircle.Color1;
-        set
-        {
-            ContainedLineCircle.Color1 = value;
-            NotifyPropertyChanged();
-        }
+        ContainedLineCircle.Color1 = ContainedLineCircle.IsFilled ? _fillColor : _strokeColor;
     }
 
     /// <inheritdoc cref="Gum.Renderables.LineCircle.Color2"/>
@@ -509,6 +510,8 @@ public class CircleRuntime : GraphicalUiElement
             {
                 _fill.Color = _isFilled ? _fillColor : new Color(0, 0, 0, 0);
             }
+            // Issue #3009 — the fill slot's gradient start mirrors FillColor (no standalone Color1).
+            SyncGradientStart();
             NotifyPropertyChanged();
         }
     }
@@ -587,6 +590,8 @@ public class CircleRuntime : GraphicalUiElement
         {
             _strokeColor = value;
             _stroke.Color = value;
+            // Issue #3009 — the stroke slot's gradient start mirrors StrokeColor (no standalone Color1).
+            SyncGradientStart();
             NotifyPropertyChanged();
         }
     }
@@ -723,6 +728,31 @@ public class CircleRuntime : GraphicalUiElement
         if (inactive != null) inactive.UseGradient = false;
     }
 
+    // Issue #3009 — the gradient START stop is the slot's own solid body color; Circle/Rectangle
+    // no longer carry a standalone Color1. Each slot mirrors its solid color into its
+    // Red1/Green1/Blue1/Alpha1 so the gradient start equals the color the shape was already
+    // showing (no jump when UseGradient toggles), and the dropshadow alpha — which the Apos
+    // renderable scales by the slot's Color.A — converges onto the gradient start alpha. Called
+    // from the FillColor / StrokeColor setters and the constructor; the UseGradient gate routing
+    // stays in SyncGradientToTarget.
+    void SyncGradientStart()
+    {
+        if (_fill is IGradientedRenderable fillGrad)
+        {
+            fillGrad.Red1 = _fillColor.R;
+            fillGrad.Green1 = _fillColor.G;
+            fillGrad.Blue1 = _fillColor.B;
+            fillGrad.Alpha1 = _fillColor.A;
+        }
+        if (_stroke is IGradientedRenderable strokeGrad)
+        {
+            strokeGrad.Red1 = _strokeColor.R;
+            strokeGrad.Green1 = _strokeColor.G;
+            strokeGrad.Blue1 = _strokeColor.B;
+            strokeGrad.Alpha1 = _strokeColor.A;
+        }
+    }
+
     bool _useGradient;
     /// <summary>
     /// When <c>true</c>, the gradient color/coordinate properties drive rendering instead of
@@ -754,69 +784,10 @@ public class CircleRuntime : GraphicalUiElement
         }
     }
 
-    int _alpha1 = 255;
-    public int Alpha1
-    {
-        get => _alpha1;
-        set
-        {
-            _alpha1 = value;
-            if (_fill is IGradientedRenderable fillGrad) fillGrad.Alpha1 = value;
-            if (_stroke is IGradientedRenderable strokeGrad) strokeGrad.Alpha1 = value;
-            NotifyPropertyChanged();
-        }
-    }
-
-    int _red1;
-    public int Red1
-    {
-        get => _red1;
-        set
-        {
-            _red1 = value;
-            if (_fill is IGradientedRenderable fillGrad) fillGrad.Red1 = value;
-            if (_stroke is IGradientedRenderable strokeGrad) strokeGrad.Red1 = value;
-            NotifyPropertyChanged();
-        }
-    }
-
-    int _green1;
-    public int Green1
-    {
-        get => _green1;
-        set
-        {
-            _green1 = value;
-            if (_fill is IGradientedRenderable fillGrad) fillGrad.Green1 = value;
-            if (_stroke is IGradientedRenderable strokeGrad) strokeGrad.Green1 = value;
-            NotifyPropertyChanged();
-        }
-    }
-
-    int _blue1;
-    public int Blue1
-    {
-        get => _blue1;
-        set
-        {
-            _blue1 = value;
-            if (_fill is IGradientedRenderable fillGrad) fillGrad.Blue1 = value;
-            if (_stroke is IGradientedRenderable strokeGrad) strokeGrad.Blue1 = value;
-            NotifyPropertyChanged();
-        }
-    }
-
-    public Color Color1
-    {
-        get => new Color(_red1, _green1, _blue1, _alpha1);
-        set
-        {
-            Red1 = value.R;
-            Green1 = value.G;
-            Blue1 = value.B;
-            Alpha1 = value.A;
-        }
-    }
+    // Issue #3009 — the gradient start (Red1/Green1/Blue1/Alpha1 / Color1) is no longer stored on
+    // the runtime. It is driven from the active body color via SyncGradientStart(); the standalone
+    // Color1 surface was dropped for Circle/Rectangle (gradient support is unshipped, so no data to
+    // preserve). Color2 below remains the only standalone gradient color.
 
     int _alpha2 = 255;
     public int Alpha2
@@ -1704,6 +1675,52 @@ public class CircleRuntime : GraphicalUiElement
         set => base.Blue = value;
     }
 
+    // Issue #3009 — the gradient START stop is the active body color (FillColor when filled,
+    // StrokeColor otherwise), driven by the base's two-slot SyncGradientStartToBody. The standalone
+    // Color1 surface inherited from SkiaShapeRuntime is therefore unsupported on the new fill+stroke
+    // Circle/Rectangle: shadow it as an error so consumers are steered to FillColor / StrokeColor
+    // (mirrors the XNALIKE hard-drop and the Color/Red/Green/Blue obsolete shadows above). The
+    // members stay live on the base for the legacy single-color shapes (Arc, RoundedRectangle, ...).
+    /// <summary>Obsolete: the gradient start is the active body color. Set <see cref="SkiaShapeRuntime.FillColor"/> / <see cref="SkiaShapeRuntime.StrokeColor"/>. See issue #3009.</summary>
+    [Obsolete("The gradient start is the active body color (FillColor when filled, StrokeColor otherwise). Set FillColor / StrokeColor instead of Color1. See issue #3009.", error: true)]
+    public new SKColor Color1
+    {
+        get => base.Color1;
+        set => base.Color1 = value;
+    }
+
+    /// <inheritdoc cref="Color1"/>
+    [Obsolete("The gradient start is the active body color (FillColor when filled, StrokeColor otherwise). Set FillColor / StrokeColor instead of Red1. See issue #3009.", error: true)]
+    public new int Red1
+    {
+        get => base.Red1;
+        set => base.Red1 = value;
+    }
+
+    /// <inheritdoc cref="Color1"/>
+    [Obsolete("The gradient start is the active body color (FillColor when filled, StrokeColor otherwise). Set FillColor / StrokeColor instead of Green1. See issue #3009.", error: true)]
+    public new int Green1
+    {
+        get => base.Green1;
+        set => base.Green1 = value;
+    }
+
+    /// <inheritdoc cref="Color1"/>
+    [Obsolete("The gradient start is the active body color (FillColor when filled, StrokeColor otherwise). Set FillColor / StrokeColor instead of Blue1. See issue #3009.", error: true)]
+    public new int Blue1
+    {
+        get => base.Blue1;
+        set => base.Blue1 = value;
+    }
+
+    /// <inheritdoc cref="Color1"/>
+    [Obsolete("The gradient start is the active body color (FillColor when filled, StrokeColor otherwise). Set FillColor / StrokeColor instead of Alpha1. See issue #3009.", error: true)]
+    public new int Alpha1
+    {
+        get => base.Alpha1;
+        set => base.Alpha1 = value;
+    }
+
     /// <summary>
     /// Isotropic blur radius in pixels for the dropshadow. The plain <see cref="CircleRuntime"/>
     /// dropshadow blur is a single scalar by design (issue #2761 new-shape contract), mirroring
@@ -1835,6 +1852,11 @@ public class CircleRuntime : GraphicalUiElement
             Width = 32;
             Height = 32;
 
+            // Issue #3009 — seed each slot's gradient start from its (white) body color so flipping
+            // UseGradient on a freshly-constructed circle starts from white rather than a stale
+            // default, matching the no-jump contract.
+            SyncGradientStart();
+
             // Dropshadow defaults mirror SkiaShapeRuntime: opaque black, slight downward
             // offset, slight Y blur. HasDropshadow is false so the values are inert until
             // toggled on at runtime, at which point a visible shadow appears without further
@@ -1902,6 +1924,8 @@ public class CircleRuntime : GraphicalUiElement
             circle.StrokeColor = _strokeColor;
             circle.FillColor = _fillColor;
             circle.IsFilled = false;
+            // Issue #3009 — seed the gradient start from the (white) body color.
+            SyncGradientStart();
 #endif
 #endif
             Width = 32;

--- a/MonoGameGum/GueDeriving/CircleRuntime.cs
+++ b/MonoGameGum/GueDeriving/CircleRuntime.cs
@@ -282,10 +282,20 @@ public class CircleRuntime : GraphicalUiElement
         set
         {
             _fillColor = value;
-            ContainedLineCircle.FillColor = value;
+            PushFillColorToRenderable();
             SyncGradientStart();
             NotifyPropertyChanged();
         }
+    }
+
+    // Issue #3009 follow-up — gate the renderable's fill color by IsFilled so a stroke-only circle
+    // (IsFilled = false) leaves the renderable's FillColor null and its fill pass (which runs when
+    // FillColor.HasValue || IsFilled) stays off — a fresh circle is outline-only. Mirrors how the
+    // Apos/Skia two-slot model pushes a transparent fill when the shape isn't filled; previously
+    // the default opaque-white FillColor was pushed unconditionally, filling every default circle.
+    void PushFillColorToRenderable()
+    {
+        ContainedLineCircle.FillColor = ContainedLineCircle.IsFilled ? (Color?)_fillColor : null;
     }
 
     /// <summary>Red channel of <see cref="FillColor"/>.</summary>
@@ -366,7 +376,9 @@ public class CircleRuntime : GraphicalUiElement
         set
         {
             ContainedLineCircle.IsFilled = value;
-            // Issue #3009 — re-route the gradient start to the now-active body color.
+            // Issue #3009 — re-gate the renderable fill color and re-route the gradient start to
+            // the now-active body color.
+            PushFillColorToRenderable();
             SyncGradientStart();
             NotifyPropertyChanged();
         }
@@ -1922,9 +1934,10 @@ public class CircleRuntime : GraphicalUiElement
             // defaults to opaque white and IsFilled defaults to false → a fresh circle renders
             // as a stroke-only outline; flipping IsFilled = true paints it white.
             circle.StrokeColor = _strokeColor;
-            circle.FillColor = _fillColor;
             circle.IsFilled = false;
-            // Issue #3009 — seed the gradient start from the (white) body color.
+            // Issue #3009 — gate the fill color by IsFilled (null when not filled) so a fresh
+            // circle is a stroke-only outline, and seed the gradient start from the body color.
+            PushFillColorToRenderable();
             SyncGradientStart();
 #endif
 #endif

--- a/MonoGameGum/GueDeriving/RectangleRuntime.cs
+++ b/MonoGameGum/GueDeriving/RectangleRuntime.cs
@@ -253,6 +253,7 @@ public class RectangleRuntime : GraphicalUiElement
         {
             _fillColor = value;
             ContainedLineRectangle.FillColor = value;
+            SyncGradientStart();
             NotifyPropertyChanged();
         }
     }
@@ -295,6 +296,7 @@ public class RectangleRuntime : GraphicalUiElement
         {
             _strokeColor = value;
             ContainedLineRectangle.StrokeColor = value;
+            SyncGradientStart();
             NotifyPropertyChanged();
         }
     }
@@ -334,6 +336,8 @@ public class RectangleRuntime : GraphicalUiElement
         set
         {
             ContainedLineRectangle.IsFilled = value;
+            // Issue #3009 — re-route the gradient start to the now-active body color.
+            SyncGradientStart();
             NotifyPropertyChanged();
         }
     }
@@ -371,15 +375,12 @@ public class RectangleRuntime : GraphicalUiElement
         }
     }
 
-    /// <inheritdoc cref="Gum.Renderables.LineRectangle.Color1"/>
-    public Color Color1
+    // Issue #3009 — Circle/Rectangle no longer expose a standalone gradient Color1. The gradient
+    // start mirrors the active body color (FillColor when filled, StrokeColor otherwise), synced
+    // from the FillColor / StrokeColor / IsFilled setters into the renderable's Color1.
+    void SyncGradientStart()
     {
-        get => ContainedLineRectangle.Color1;
-        set
-        {
-            ContainedLineRectangle.Color1 = value;
-            NotifyPropertyChanged();
-        }
+        ContainedLineRectangle.Color1 = ContainedLineRectangle.IsFilled ? _fillColor : _strokeColor;
     }
 
     /// <inheritdoc cref="Gum.Renderables.LineRectangle.Color2"/>
@@ -721,6 +722,8 @@ public class RectangleRuntime : GraphicalUiElement
             {
                 _fill.Color = _isFilled ? _fillColor : new Color(0, 0, 0, 0);
             }
+            // Issue #3009 — the fill slot's gradient start mirrors FillColor (no standalone Color1).
+            SyncGradientStart();
             NotifyPropertyChanged();
         }
     }
@@ -797,6 +800,8 @@ public class RectangleRuntime : GraphicalUiElement
         {
             _strokeColor = value;
             _stroke.Color = value;
+            // Issue #3009 — the stroke slot's gradient start mirrors StrokeColor (no standalone Color1).
+            SyncGradientStart();
             NotifyPropertyChanged();
         }
     }
@@ -1001,6 +1006,31 @@ public class RectangleRuntime : GraphicalUiElement
         if (inactive != null) inactive.UseGradient = false;
     }
 
+    // Issue #3009 — the gradient START stop is the slot's own solid body color; Circle/Rectangle
+    // no longer carry a standalone Color1. Each slot mirrors its solid color into its
+    // Red1/Green1/Blue1/Alpha1 so the gradient start equals the color the shape was already
+    // showing (no jump when UseGradient toggles), and the dropshadow alpha — which the Apos
+    // renderable scales by the slot's Color.A — converges onto the gradient start alpha. Called
+    // from the FillColor / StrokeColor setters and the constructor; the UseGradient gate routing
+    // stays in SyncGradientToTarget.
+    void SyncGradientStart()
+    {
+        if (_fill is IGradientedRenderable fillGrad)
+        {
+            fillGrad.Red1 = _fillColor.R;
+            fillGrad.Green1 = _fillColor.G;
+            fillGrad.Blue1 = _fillColor.B;
+            fillGrad.Alpha1 = _fillColor.A;
+        }
+        if (_stroke is IGradientedRenderable strokeGrad)
+        {
+            strokeGrad.Red1 = _strokeColor.R;
+            strokeGrad.Green1 = _strokeColor.G;
+            strokeGrad.Blue1 = _strokeColor.B;
+            strokeGrad.Alpha1 = _strokeColor.A;
+        }
+    }
+
     bool _useGradient;
     /// <inheritdoc cref="CircleRuntime.UseGradient"/>
     public bool UseGradient
@@ -1027,69 +1057,10 @@ public class RectangleRuntime : GraphicalUiElement
         }
     }
 
-    int _alpha1 = 255;
-    public int Alpha1
-    {
-        get => _alpha1;
-        set
-        {
-            _alpha1 = value;
-            if (_fill is IGradientedRenderable fillGrad) fillGrad.Alpha1 = value;
-            if (_stroke is IGradientedRenderable strokeGrad) strokeGrad.Alpha1 = value;
-            NotifyPropertyChanged();
-        }
-    }
-
-    int _red1;
-    public int Red1
-    {
-        get => _red1;
-        set
-        {
-            _red1 = value;
-            if (_fill is IGradientedRenderable fillGrad) fillGrad.Red1 = value;
-            if (_stroke is IGradientedRenderable strokeGrad) strokeGrad.Red1 = value;
-            NotifyPropertyChanged();
-        }
-    }
-
-    int _green1;
-    public int Green1
-    {
-        get => _green1;
-        set
-        {
-            _green1 = value;
-            if (_fill is IGradientedRenderable fillGrad) fillGrad.Green1 = value;
-            if (_stroke is IGradientedRenderable strokeGrad) strokeGrad.Green1 = value;
-            NotifyPropertyChanged();
-        }
-    }
-
-    int _blue1;
-    public int Blue1
-    {
-        get => _blue1;
-        set
-        {
-            _blue1 = value;
-            if (_fill is IGradientedRenderable fillGrad) fillGrad.Blue1 = value;
-            if (_stroke is IGradientedRenderable strokeGrad) strokeGrad.Blue1 = value;
-            NotifyPropertyChanged();
-        }
-    }
-
-    public Color Color1
-    {
-        get => new Color(_red1, _green1, _blue1, _alpha1);
-        set
-        {
-            Red1 = value.R;
-            Green1 = value.G;
-            Blue1 = value.B;
-            Alpha1 = value.A;
-        }
-    }
+    // Issue #3009 — the gradient start (Red1/Green1/Blue1/Alpha1 / Color1) is no longer stored on
+    // the runtime. It is driven from the active body color via SyncGradientStart(); the standalone
+    // Color1 surface was dropped for Circle/Rectangle (gradient support is unshipped, so no data to
+    // preserve). Color2 below remains the only standalone gradient color.
 
     int _alpha2 = 255;
     public int Alpha2
@@ -1693,6 +1664,51 @@ public class RectangleRuntime : GraphicalUiElement
         set => base.Blue = value;
     }
 
+    // Issue #3009 — the gradient START stop is the active body color (FillColor when filled,
+    // StrokeColor otherwise), driven by the base's two-slot SyncGradientStartToBody. The standalone
+    // Color1 surface inherited from SkiaShapeRuntime is unsupported on the new fill+stroke
+    // Rectangle: shadow it as an error so consumers are steered to FillColor / StrokeColor (mirrors
+    // the XNALIKE hard-drop). The members stay live on the base for legacy single-color shapes.
+    /// <summary>Obsolete: the gradient start is the active body color. Set <see cref="SkiaShapeRuntime.FillColor"/> / <see cref="SkiaShapeRuntime.StrokeColor"/>. See issue #3009.</summary>
+    [Obsolete("The gradient start is the active body color (FillColor when filled, StrokeColor otherwise). Set FillColor / StrokeColor instead of Color1. See issue #3009.", error: true)]
+    public new SKColor Color1
+    {
+        get => base.Color1;
+        set => base.Color1 = value;
+    }
+
+    /// <inheritdoc cref="Color1"/>
+    [Obsolete("The gradient start is the active body color (FillColor when filled, StrokeColor otherwise). Set FillColor / StrokeColor instead of Red1. See issue #3009.", error: true)]
+    public new int Red1
+    {
+        get => base.Red1;
+        set => base.Red1 = value;
+    }
+
+    /// <inheritdoc cref="Color1"/>
+    [Obsolete("The gradient start is the active body color (FillColor when filled, StrokeColor otherwise). Set FillColor / StrokeColor instead of Green1. See issue #3009.", error: true)]
+    public new int Green1
+    {
+        get => base.Green1;
+        set => base.Green1 = value;
+    }
+
+    /// <inheritdoc cref="Color1"/>
+    [Obsolete("The gradient start is the active body color (FillColor when filled, StrokeColor otherwise). Set FillColor / StrokeColor instead of Blue1. See issue #3009.", error: true)]
+    public new int Blue1
+    {
+        get => base.Blue1;
+        set => base.Blue1 = value;
+    }
+
+    /// <inheritdoc cref="Color1"/>
+    [Obsolete("The gradient start is the active body color (FillColor when filled, StrokeColor otherwise). Set FillColor / StrokeColor instead of Alpha1. See issue #3009.", error: true)]
+    public new int Alpha1
+    {
+        get => base.Alpha1;
+        set => base.Alpha1 = value;
+    }
+
     /// <inheritdoc cref="CircleRuntime.DropshadowBlur"/>
     public float DropshadowBlur
     {
@@ -1855,6 +1871,11 @@ public class RectangleRuntime : GraphicalUiElement
             Width = 50;
             Height = 50;
 
+            // Issue #3009 — seed each slot's gradient start from its (white) body color so flipping
+            // UseGradient on a freshly-constructed rectangle starts from white, matching the
+            // no-jump contract.
+            SyncGradientStart();
+
             // Issue #2818 (mirror of CircleRuntime #2797): pre-seed opaque-black dropshadow
             // with a slight downward offset/blur so toggling HasDropshadow = true at runtime
             // produces a visible shadow without further setup.
@@ -1931,6 +1952,8 @@ public class RectangleRuntime : GraphicalUiElement
             rectangle.StrokeColor = _strokeColor;
             rectangle.FillColor = _fillColor;
             rectangle.IsFilled = false;
+            // Issue #3009 — seed the gradient start from the (white) body color.
+            SyncGradientStart();
 #endif
 
             Width = 50;

--- a/MonoGameGum/GueDeriving/RectangleRuntime.cs
+++ b/MonoGameGum/GueDeriving/RectangleRuntime.cs
@@ -252,10 +252,21 @@ public class RectangleRuntime : GraphicalUiElement
         set
         {
             _fillColor = value;
-            ContainedLineRectangle.FillColor = value;
+            PushFillColorToRenderable();
             SyncGradientStart();
             NotifyPropertyChanged();
         }
+    }
+
+    // Issue #3009 follow-up — gate the renderable's fill color by IsFilled so a stroke-only
+    // rectangle (IsFilled = false) leaves the renderable's FillColor null and its fill pass (which
+    // runs when FillColor.HasValue || IsFilled) stays off — a fresh rectangle is outline-only.
+    // Mirrors how the Apos/Skia two-slot model pushes a transparent fill when the shape isn't
+    // filled; previously the default opaque-white FillColor was pushed unconditionally, filling
+    // every default rectangle.
+    void PushFillColorToRenderable()
+    {
+        ContainedLineRectangle.FillColor = ContainedLineRectangle.IsFilled ? (Color?)_fillColor : null;
     }
 
     /// <summary>Red channel of <see cref="FillColor"/>.</summary>
@@ -336,7 +347,9 @@ public class RectangleRuntime : GraphicalUiElement
         set
         {
             ContainedLineRectangle.IsFilled = value;
-            // Issue #3009 — re-route the gradient start to the now-active body color.
+            // Issue #3009 — re-gate the renderable fill color and re-route the gradient start to
+            // the now-active body color.
+            PushFillColorToRenderable();
             SyncGradientStart();
             NotifyPropertyChanged();
         }
@@ -1950,9 +1963,10 @@ public class RectangleRuntime : GraphicalUiElement
             // defaults to opaque white and IsFilled defaults to false → a fresh rectangle
             // renders as a stroke-only outline; flipping IsFilled = true paints it white.
             rectangle.StrokeColor = _strokeColor;
-            rectangle.FillColor = _fillColor;
             rectangle.IsFilled = false;
-            // Issue #3009 — seed the gradient start from the (white) body color.
+            // Issue #3009 — gate the fill color by IsFilled (null when not filled) so a fresh
+            // rectangle is a stroke-only outline, and seed the gradient start from the body color.
+            PushFillColorToRenderable();
             SyncGradientStart();
 #endif
 

--- a/Runtimes/SkiaGum/CustomSetPropertyOnRenderable.cs
+++ b/Runtimes/SkiaGum/CustomSetPropertyOnRenderable.cs
@@ -381,6 +381,29 @@ public class CustomSetPropertyOnRenderable
                     }
                     handled = true;
                     break;
+                // Issue #3009 — Arc maps the legacy gradient-start channels (Red1/Green1/Blue1/
+                // Alpha1) onto the primary Color (the unified "gradient start = body color" model).
+                // Old .gumx data set these independently; route them to the primary so they load
+                // onto Color. Gum applies variables alphabetically, so the …1 channels apply after
+                // the solid ones and win — the accepted lossy case (UseGradient = false with an
+                // explicitly-different Color1) is pinned by ArcRuntimeTests. PreRender then mirrors
+                // the primary into the renderable's gradient-start channels for the gradient pass.
+                case nameof(RenderableShapeBase.Red1):
+                    asArc.Red = (int)value;
+                    handled = true;
+                    break;
+                case nameof(RenderableShapeBase.Green1):
+                    asArc.Green = (int)value;
+                    handled = true;
+                    break;
+                case nameof(RenderableShapeBase.Blue1):
+                    asArc.Blue = (int)value;
+                    handled = true;
+                    break;
+                case nameof(RenderableShapeBase.Alpha1):
+                    asArc.Alpha = (int)value;
+                    handled = true;
+                    break;
             }
             if (!handled)
             {

--- a/Runtimes/SkiaGum/GueDeriving/ArcRuntime.cs
+++ b/Runtimes/SkiaGum/GueDeriving/ArcRuntime.cs
@@ -605,6 +605,60 @@ public class ArcRuntime
         set => base.DropshadowBlurY = value;
     }
 
+    // Issue #3009 — Arc's gradient START stop is now its primary Color (the unified "gradient start
+    // = body color" model that Circle/Rectangle adopt via SyncGradientStartToBody). The legacy
+    // standalone gradient-start surface (Color1 / Red1 / Green1 / Blue1 / Alpha1) is kept only as
+    // [Obsolete] back-compat shims that map onto the primary Color, so old code compiles and old
+    // .gumx data — which set these channels independently — keeps loading (see
+    // CustomSetPropertyOnRenderable and the migration loss-case analysis on issue #3009). The
+    // obsoletes are slated for removal ~Nov 2026, after which Color1 leaves Arc entirely. The
+    // renderable's gradient-start channels are kept in lockstep with the primary color in PreRender.
+
+    /// <summary>Obsolete: Arc's gradient start is its primary <c>Color</c>; this maps onto Color for back-compat. See issue #3009.</summary>
+    [Obsolete("Arc's gradient start is now its primary Color — set Color (or Red/Green/Blue/Alpha) instead. Color1 maps onto Color for backward compatibility and will be removed ~Nov 2026. See issue #3009.")]
+#if SKIA
+    public new SKColor Color1
+    {
+        get => new SKColor((byte)Red, (byte)Green, (byte)Blue, (byte)Alpha);
+        set { Red = value.Red; Green = value.Green; Blue = value.Blue; Alpha = value.Alpha; }
+    }
+#else
+    public new Microsoft.Xna.Framework.Color Color1
+    {
+        get => new Microsoft.Xna.Framework.Color(Red, Green, Blue, Alpha);
+        set { Red = value.R; Green = value.G; Blue = value.B; Alpha = value.A; }
+    }
+#endif
+
+    /// <inheritdoc cref="Color1"/>
+    [Obsolete("Arc's gradient start is now its primary Color — set Color (or Red) instead. Red1 maps onto Color for backward compatibility and will be removed ~Nov 2026. See issue #3009.")]
+    public new int Red1 { get => Red; set => Red = value; }
+
+    /// <inheritdoc cref="Color1"/>
+    [Obsolete("Arc's gradient start is now its primary Color — set Color (or Green) instead. Green1 maps onto Color for backward compatibility and will be removed ~Nov 2026. See issue #3009.")]
+    public new int Green1 { get => Green; set => Green = value; }
+
+    /// <inheritdoc cref="Color1"/>
+    [Obsolete("Arc's gradient start is now its primary Color — set Color (or Blue) instead. Blue1 maps onto Color for backward compatibility and will be removed ~Nov 2026. See issue #3009.")]
+    public new int Blue1 { get => Blue; set => Blue = value; }
+
+    /// <inheritdoc cref="Color1"/>
+    [Obsolete("Arc's gradient start is now its primary Color — set Color (or Alpha) instead. Alpha1 maps onto Color for backward compatibility and will be removed ~Nov 2026. See issue #3009.")]
+    public new int Alpha1 { get => Alpha; set => Alpha = value; }
+
+    /// <inheritdoc/>
+    public override void PreRender()
+    {
+        base.PreRender();
+        // Issue #3009 — mirror the primary Color into the renderable's gradient-start channels each
+        // frame so the gradient start follows the body color regardless of how it was set (legacy
+        // Color1/Red1 shims, state changes, animation, or .gumx load via CustomSetPropertyOnRenderable).
+        ContainedArc.Red1 = ContainedArc.Red;
+        ContainedArc.Green1 = ContainedArc.Green;
+        ContainedArc.Blue1 = ContainedArc.Blue;
+        ContainedArc.Alpha1 = ContainedArc.Alpha;
+    }
+
     /// <summary>
     /// Initializes a new ArcRuntime. When <paramref name="fullInstantiation"/> is true (the
     /// default), an underlying <c>Arc</c> renderable is created and default values are applied
@@ -641,10 +695,10 @@ public class ArcRuntime
             StartAngle = 0;
             SweepAngle = 90;
 
-            Red1 = 255;
-            Green1 = 255;
-            Blue1 = 255;
-
+            // Issue #3009 — the gradient start is the primary Color (White, set above) and is
+            // synced into the renderable's start channels in PreRender, so the old explicit
+            // Red1/Green1/Blue1 = 255 seed is no longer needed. Color2 (the second stop) remains
+            // an independent standalone gradient color.
             Red2 = 255;
             Green2 = 255;
             Blue2 = 0;

--- a/Runtimes/SkiaGum/GueDeriving/SkiaShapeRuntime.cs
+++ b/Runtimes/SkiaGum/GueDeriving/SkiaShapeRuntime.cs
@@ -156,6 +156,30 @@ public abstract class SkiaShapeRuntime : InteractiveGue
         }
     }
 
+    // Issue #3009 — in two-slot mode (Circle/Rectangle) the gradient START stop is the slot's own
+    // solid body color: the fill slot mirrors FillColor, the stroke slot mirrors StrokeColor into
+    // its Red1/Green1/Blue1/Alpha1. This removes the solid↔gradient color jump when toggling
+    // UseGradient (the start already equals the color the shape was showing) and converges the
+    // dropshadow alpha onto the gradient start. Legacy single-slot shapes (Arc, RoundedRectangle,
+    // ColoredCircle, Polygon, ...) are NOT two-slot, so they keep their explicit standalone Color1
+    // (set through the base Color1 / Red1.. members) and this is a no-op for them.
+    void SyncGradientStartToBody()
+    {
+        if (StrokeRenderable == null)
+        {
+            return;
+        }
+        ContainedRenderable.Red1 = _fillColor.Red;
+        ContainedRenderable.Green1 = _fillColor.Green;
+        ContainedRenderable.Blue1 = _fillColor.Blue;
+        ContainedRenderable.Alpha1 = _fillColor.Alpha;
+
+        StrokeRenderable.Red1 = _strokeColor.Red;
+        StrokeRenderable.Green1 = _strokeColor.Green;
+        StrokeRenderable.Blue1 = _strokeColor.Blue;
+        StrokeRenderable.Alpha1 = _strokeColor.Alpha;
+    }
+
     #region Solid colors
 
     public new int Alpha
@@ -271,6 +295,8 @@ public abstract class SkiaShapeRuntime : InteractiveGue
             ContainedRenderable.IsFilled = _isFilled;
             ContainedRenderable.Color = pushed;
         }
+        // Issue #3009 — keep each slot's gradient start in lockstep with its body color (two-slot only).
+        SyncGradientStartToBody();
     }
 
     SKColor _strokeColor = SKColors.White;
@@ -303,6 +329,8 @@ public abstract class SkiaShapeRuntime : InteractiveGue
                 ContainedRenderable.IsFilled = false;
                 ContainedRenderable.Color = value;
             }
+            // Issue #3009 — keep the stroke slot's gradient start in lockstep with StrokeColor (two-slot only).
+            SyncGradientStartToBody();
             RefreshSlotGradients();
         }
     }

--- a/Samples/GumShapesGallery/GumShapesGalleryCommon/Screens/CirclesScreen.cs
+++ b/Samples/GumShapesGallery/GumShapesGalleryCommon/Screens/CirclesScreen.cs
@@ -179,11 +179,10 @@ internal class CirclesScreen : FrameworkElement
         // Linear horizontal: white → blue
         CircleRuntime linearH = new();
         linearH.Radius = 28;
-        linearH.FillColor = Color.White; // fill mode; gradient overrides solid color
+        linearH.FillColor = Color.White; // gradient start stop is the fill color
         linearH.IsFilled = true;
         linearH.UseGradient = true;
         linearH.GradientType = GradientType.Linear;
-        linearH.Color1 = Color.White;
         linearH.Color2 = Color.SteelBlue;
         linearH.GradientX1 = 0; linearH.GradientY1 = 0;
         linearH.GradientX2 = 56; linearH.GradientY2 = 0;
@@ -192,11 +191,10 @@ internal class CirclesScreen : FrameworkElement
         // Linear vertical: gold → crimson
         CircleRuntime linearV = new();
         linearV.Radius = 28;
-        linearV.FillColor = Color.White;
+        linearV.FillColor = Color.Gold;
         linearV.IsFilled = true;
         linearV.UseGradient = true;
         linearV.GradientType = GradientType.Linear;
-        linearV.Color1 = Color.Gold;
         linearV.Color2 = Color.Crimson;
         linearV.GradientX1 = 0; linearV.GradientY1 = 0;
         linearV.GradientX2 = 0; linearV.GradientY2 = 56;
@@ -205,11 +203,10 @@ internal class CirclesScreen : FrameworkElement
         // Linear diagonal: cyan → magenta
         CircleRuntime linearD = new();
         linearD.Radius = 28;
-        linearD.FillColor = Color.White;
+        linearD.FillColor = Color.Cyan;
         linearD.IsFilled = true;
         linearD.UseGradient = true;
         linearD.GradientType = GradientType.Linear;
-        linearD.Color1 = Color.Cyan;
         linearD.Color2 = Color.Magenta;
         linearD.GradientX1 = 0; linearD.GradientY1 = 0;
         linearD.GradientX2 = 56; linearD.GradientY2 = 56;
@@ -222,7 +219,6 @@ internal class CirclesScreen : FrameworkElement
         radial.IsFilled = true;
         radial.UseGradient = true;
         radial.GradientType = GradientType.Radial;
-        radial.Color1 = Color.White;
         radial.Color2 = Color.DarkGreen;
         radial.GradientX1 = 28; radial.GradientY1 = 28;
         radial.GradientInnerRadius = 0;
@@ -547,18 +543,21 @@ internal class CirclesScreen : FrameworkElement
         circle.XUnits = Gum.Converters.GeneralUnitType.PixelsFromMiddle;
         circle.YOrigin = VerticalAlignment.Center;
         circle.YUnits = Gum.Converters.GeneralUnitType.PixelsFromMiddle;
+        // The gradient start stop is the active body color: FillColor when filled,
+        // StrokeColor when only stroked. Set the appropriate slot to Black so the
+        // gradient starts dark in both variants.
         if (filled)
         {
-            circle.FillColor = Color.White;
+            circle.FillColor = Color.Black;
             circle.IsFilled = true;
         }
         else
         {
             circle.IsFilled = false;
+            circle.StrokeColor = Color.Black;
         }
         circle.UseGradient = true;
         circle.GradientType = GradientType.Linear;
-        circle.Color1 = Color.Black;
         circle.Color2 = Color.White;
         circle.GradientX1 = 0; circle.GradientY1 = 0;
         circle.GradientX2 = 20; circle.GradientY2 = 0;

--- a/Samples/GumShapesGallery/GumShapesGalleryCommon/Screens/RectanglesScreen.cs
+++ b/Samples/GumShapesGallery/GumShapesGalleryCommon/Screens/RectanglesScreen.cs
@@ -226,7 +226,6 @@ internal class RectanglesScreen : FrameworkElement
         linearH.IsFilled = true;
         linearH.UseGradient = true;
         linearH.GradientType = GradientType.Linear;
-        linearH.Color1 = Color.White;
         linearH.Color2 = Color.SteelBlue;
         linearH.GradientX1 = 0; linearH.GradientY1 = 0;
         linearH.GradientX2 = 70; linearH.GradientY2 = 0;
@@ -234,11 +233,10 @@ internal class RectanglesScreen : FrameworkElement
 
         RectangleRuntime linearV = new();
         linearV.Width = 70; linearV.Height = 50;
-        linearV.FillColor = Color.White;
+        linearV.FillColor = Color.Gold;
         linearV.IsFilled = true;
         linearV.UseGradient = true;
         linearV.GradientType = GradientType.Linear;
-        linearV.Color1 = Color.Gold;
         linearV.Color2 = Color.Crimson;
         linearV.GradientX1 = 0; linearV.GradientY1 = 0;
         linearV.GradientX2 = 0; linearV.GradientY2 = 50;
@@ -246,11 +244,10 @@ internal class RectanglesScreen : FrameworkElement
 
         RectangleRuntime linearD = new();
         linearD.Width = 70; linearD.Height = 50;
-        linearD.FillColor = Color.White;
+        linearD.FillColor = Color.Cyan;
         linearD.IsFilled = true;
         linearD.UseGradient = true;
         linearD.GradientType = GradientType.Linear;
-        linearD.Color1 = Color.Cyan;
         linearD.Color2 = Color.Magenta;
         linearD.GradientX1 = 0; linearD.GradientY1 = 0;
         linearD.GradientX2 = 70; linearD.GradientY2 = 50;
@@ -262,7 +259,6 @@ internal class RectanglesScreen : FrameworkElement
         radial.IsFilled = true;
         radial.UseGradient = true;
         radial.GradientType = GradientType.Radial;
-        radial.Color1 = Color.White;
         radial.Color2 = Color.DarkGreen;
         radial.GradientX1 = 35; radial.GradientY1 = 25;
         radial.GradientInnerRadius = 0;
@@ -479,18 +475,21 @@ internal class RectanglesScreen : FrameworkElement
         rect.XUnits = Gum.Converters.GeneralUnitType.PixelsFromMiddle;
         rect.YOrigin = VerticalAlignment.Center;
         rect.YUnits = Gum.Converters.GeneralUnitType.PixelsFromMiddle;
+        // The gradient start stop is the active body color: FillColor when filled,
+        // StrokeColor when only stroked. Set the appropriate slot to Black so the
+        // gradient starts dark in both variants.
         if (filled)
         {
-            rect.FillColor = Color.White;
+            rect.FillColor = Color.Black;
             rect.IsFilled = true;
         }
         else
         {
             rect.IsFilled = false;
+            rect.StrokeColor = Color.Black;
         }
         rect.UseGradient = true;
         rect.GradientType = GradientType.Linear;
-        rect.Color1 = Color.Black;
         rect.Color2 = Color.White;
         rect.GradientX1 = 0; rect.GradientY1 = 0;
         rect.GradientX2 = 20; rect.GradientY2 = 0;

--- a/Samples/GumShapesGallery/GumShapesGalleryCommon/Screens/RectanglesScreen.cs
+++ b/Samples/GumShapesGallery/GumShapesGalleryCommon/Screens/RectanglesScreen.cs
@@ -100,7 +100,6 @@ internal class RectanglesScreen : FrameworkElement
             RectangleRuntime rect = new();
             rect.Width = width;
             rect.Height = 40;
-            rect.CornerRadius = 10;
             rect.StrokeWidth = 1;
             rect.StrokeColor = Color.White;
             rect.IsAntialiased = true;

--- a/Samples/SilkNetGum/SilkNetGum/Screens/CirclesScreen.cs
+++ b/Samples/SilkNetGum/SilkNetGum/Screens/CirclesScreen.cs
@@ -169,11 +169,10 @@ internal class CirclesScreen : GraphicalUiElement
         // Linear horizontal: white → blue
         CircleRuntime linearH = new();
         linearH.Radius = 28;
-        linearH.FillColor = SKColors.White; // fill mode; gradient overrides solid color
+        linearH.FillColor = SKColors.White; // gradient start stop is the fill color
         linearH.IsFilled = true;
         linearH.UseGradient = true;
         linearH.GradientType = GradientType.Linear;
-        linearH.Color1 = SKColors.White;
         linearH.Color2 = SKColors.SteelBlue;
         linearH.GradientX1 = 0; linearH.GradientY1 = 0;
         linearH.GradientX2 = 56; linearH.GradientY2 = 0;
@@ -182,11 +181,10 @@ internal class CirclesScreen : GraphicalUiElement
         // Linear vertical: yellow → red
         CircleRuntime linearV = new();
         linearV.Radius = 28;
-        linearV.FillColor = SKColors.White;
+        linearV.FillColor = SKColors.Gold;
         linearV.IsFilled = true;
         linearV.UseGradient = true;
         linearV.GradientType = GradientType.Linear;
-        linearV.Color1 = SKColors.Gold;
         linearV.Color2 = SKColors.Crimson;
         linearV.GradientX1 = 0; linearV.GradientY1 = 0;
         linearV.GradientX2 = 0; linearV.GradientY2 = 56;
@@ -195,11 +193,10 @@ internal class CirclesScreen : GraphicalUiElement
         // Linear diagonal: cyan → magenta
         CircleRuntime linearD = new();
         linearD.Radius = 28;
-        linearD.FillColor = SKColors.White;
+        linearD.FillColor = SKColors.Cyan;
         linearD.IsFilled = true;
         linearD.UseGradient = true;
         linearD.GradientType = GradientType.Linear;
-        linearD.Color1 = SKColors.Cyan;
         linearD.Color2 = SKColors.Magenta;
         linearD.GradientX1 = 0; linearD.GradientY1 = 0;
         linearD.GradientX2 = 56; linearD.GradientY2 = 56;
@@ -212,7 +209,6 @@ internal class CirclesScreen : GraphicalUiElement
         radial.IsFilled = true;
         radial.UseGradient = true;
         radial.GradientType = GradientType.Radial;
-        radial.Color1 = SKColors.White;
         radial.Color2 = SKColors.DarkGreen;
         radial.GradientX1 = 28; radial.GradientY1 = 28;
         radial.GradientInnerRadius = 0;
@@ -526,18 +522,21 @@ internal class CirclesScreen : GraphicalUiElement
         circle.XUnits = Gum.Converters.GeneralUnitType.PixelsFromMiddle;
         circle.YOrigin = VerticalAlignment.Center;
         circle.YUnits = Gum.Converters.GeneralUnitType.PixelsFromMiddle;
+        // The gradient start stop is the active body color: FillColor when filled,
+        // StrokeColor when only stroked. Set the appropriate slot to Black so the
+        // gradient starts dark in both variants.
         if (filled)
         {
-            circle.FillColor = SKColors.White;
+            circle.FillColor = SKColors.Black;
             circle.IsFilled = true;
         }
         else
         {
             circle.IsFilled = false;
+            circle.StrokeColor = SKColors.Black;
         }
         circle.UseGradient = true;
         circle.GradientType = GradientType.Linear;
-        circle.Color1 = SKColors.Black;
         circle.Color2 = SKColors.White;
         circle.GradientX1 = 0; circle.GradientY1 = 0;
         circle.GradientX2 = 20; circle.GradientY2 = 0;

--- a/Samples/SilkNetGum/SilkNetGum/Screens/RectanglesScreen.cs
+++ b/Samples/SilkNetGum/SilkNetGum/Screens/RectanglesScreen.cs
@@ -225,11 +225,10 @@ internal class RectanglesScreen : GraphicalUiElement
         // Linear horizontal: white → blue
         RectangleRuntime linearH = new();
         linearH.Width = 70; linearH.Height = 50;
-        linearH.FillColor = SKColors.White; // fill mode; gradient overrides solid color
+        linearH.FillColor = SKColors.White; // gradient start stop is the fill color
         linearH.IsFilled = true;
         linearH.UseGradient = true;
         linearH.GradientType = GradientType.Linear;
-        linearH.Color1 = SKColors.White;
         linearH.Color2 = SKColors.SteelBlue;
         linearH.GradientX1 = 0; linearH.GradientY1 = 0;
         linearH.GradientX2 = 70; linearH.GradientY2 = 0;
@@ -238,11 +237,10 @@ internal class RectanglesScreen : GraphicalUiElement
         // Linear vertical: gold → crimson
         RectangleRuntime linearV = new();
         linearV.Width = 70; linearV.Height = 50;
-        linearV.FillColor = SKColors.White;
+        linearV.FillColor = SKColors.Gold;
         linearV.IsFilled = true;
         linearV.UseGradient = true;
         linearV.GradientType = GradientType.Linear;
-        linearV.Color1 = SKColors.Gold;
         linearV.Color2 = SKColors.Crimson;
         linearV.GradientX1 = 0; linearV.GradientY1 = 0;
         linearV.GradientX2 = 0; linearV.GradientY2 = 50;
@@ -251,11 +249,10 @@ internal class RectanglesScreen : GraphicalUiElement
         // Linear diagonal: cyan → magenta
         RectangleRuntime linearD = new();
         linearD.Width = 70; linearD.Height = 50;
-        linearD.FillColor = SKColors.White;
+        linearD.FillColor = SKColors.Cyan;
         linearD.IsFilled = true;
         linearD.UseGradient = true;
         linearD.GradientType = GradientType.Linear;
-        linearD.Color1 = SKColors.Cyan;
         linearD.Color2 = SKColors.Magenta;
         linearD.GradientX1 = 0; linearD.GradientY1 = 0;
         linearD.GradientX2 = 70; linearD.GradientY2 = 50;
@@ -268,7 +265,6 @@ internal class RectanglesScreen : GraphicalUiElement
         radial.IsFilled = true;
         radial.UseGradient = true;
         radial.GradientType = GradientType.Radial;
-        radial.Color1 = SKColors.White;
         radial.Color2 = SKColors.DarkGreen;
         radial.GradientX1 = 35; radial.GradientY1 = 25;
         radial.GradientInnerRadius = 0;
@@ -352,18 +348,21 @@ internal class RectanglesScreen : GraphicalUiElement
         rect.XUnits = Gum.Converters.GeneralUnitType.PixelsFromMiddle;
         rect.YOrigin = VerticalAlignment.Center;
         rect.YUnits = Gum.Converters.GeneralUnitType.PixelsFromMiddle;
+        // The gradient start stop is the active body color: FillColor when filled,
+        // StrokeColor when only stroked. Set the appropriate slot to Black so the
+        // gradient starts dark in both variants.
         if (filled)
         {
-            rect.FillColor = SKColors.White;
+            rect.FillColor = SKColors.Black;
             rect.IsFilled = true;
         }
         else
         {
             rect.IsFilled = false;
+            rect.StrokeColor = SKColors.Black;
         }
         rect.UseGradient = true;
         rect.GradientType = GradientType.Linear;
-        rect.Color1 = SKColors.Black;
         rect.Color2 = SKColors.White;
         rect.GradientX1 = 0; rect.GradientY1 = 0;
         rect.GradientX2 = 20; rect.GradientY2 = 0;

--- a/Samples/raylib/Screens/CirclesScreen.cs
+++ b/Samples/raylib/Screens/CirclesScreen.cs
@@ -229,11 +229,10 @@ internal class CirclesScreen : FrameworkElement
         circle.YUnits = GeneralUnitType.PixelsFromMiddle;
         // Filled cell — light up the fill slot with an opaque color so the gradient renders
         // on the fill. raylib's outline-only case is handled by BuildRotationOutlineUnsupportedRow.
-        circle.FillColor = Color.White;
+        circle.FillColor = Color.Black;
         circle.IsFilled = true;
         circle.UseGradient = true;
         circle.GradientType = GradientType.Linear;
-        circle.Color1 = Color.Black;
         circle.Color2 = Color.White;
         circle.GradientX1 = 0; circle.GradientY1 = 0;
         circle.GradientX2 = 20; circle.GradientY2 = 0;
@@ -283,7 +282,6 @@ internal class CirclesScreen : FrameworkElement
         linearH.IsFilled = true;
         linearH.UseGradient = true;
         linearH.GradientType = GradientType.Linear;
-        linearH.Color1 = Color.White;
         linearH.Color2 = new Color(70, 130, 180, 255);
         linearH.GradientX1 = 0; linearH.GradientY1 = 0;
         linearH.GradientX2 = 56; linearH.GradientY2 = 0;
@@ -292,11 +290,10 @@ internal class CirclesScreen : FrameworkElement
         // Linear vertical: gold → crimson, top to bottom.
         CircleRuntime linearV = new();
         linearV.Radius = 28;
-        linearV.FillColor = Color.White;
+        linearV.FillColor = new Color(255, 215, 0, 255);
         linearV.IsFilled = true;
         linearV.UseGradient = true;
         linearV.GradientType = GradientType.Linear;
-        linearV.Color1 = new Color(255, 215, 0, 255);
         linearV.Color2 = new Color(220, 20, 60, 255);
         linearV.GradientX1 = 0; linearV.GradientY1 = 0;
         linearV.GradientX2 = 0; linearV.GradientY2 = 56;
@@ -305,11 +302,10 @@ internal class CirclesScreen : FrameworkElement
         // Linear diagonal: cyan → magenta, top-left to bottom-right.
         CircleRuntime linearD = new();
         linearD.Radius = 28;
-        linearD.FillColor = Color.White;
+        linearD.FillColor = new Color(0, 255, 255, 255);
         linearD.IsFilled = true;
         linearD.UseGradient = true;
         linearD.GradientType = GradientType.Linear;
-        linearD.Color1 = new Color(0, 255, 255, 255);
         linearD.Color2 = new Color(255, 0, 255, 255);
         linearD.GradientX1 = 0; linearD.GradientY1 = 0;
         linearD.GradientX2 = 56; linearD.GradientY2 = 56;
@@ -322,7 +318,6 @@ internal class CirclesScreen : FrameworkElement
         radial.IsFilled = true;
         radial.UseGradient = true;
         radial.GradientType = GradientType.Radial;
-        radial.Color1 = Color.White;
         radial.Color2 = new Color(0, 100, 0, 255);
         radial.GradientX1 = 28; radial.GradientY1 = 28;
         radial.GradientInnerRadius = 0;

--- a/Samples/raylib/Screens/RectanglesScreen.cs
+++ b/Samples/raylib/Screens/RectanglesScreen.cs
@@ -248,7 +248,6 @@ internal class RectanglesScreen : FrameworkElement
         linearH.IsFilled = true;
         linearH.UseGradient = true;
         linearH.GradientType = GradientType.Linear;
-        linearH.Color1 = Color.White;
         linearH.Color2 = new Color(70, 130, 180, 255);
         linearH.GradientX1 = 0; linearH.GradientY1 = 0;
         linearH.GradientX2 = 70; linearH.GradientY2 = 0;
@@ -257,11 +256,10 @@ internal class RectanglesScreen : FrameworkElement
         // Linear vertical: gold → crimson, top to bottom.
         RectangleRuntime linearV = new();
         linearV.Width = 70; linearV.Height = 50;
-        linearV.FillColor = Color.White;
+        linearV.FillColor = new Color(255, 215, 0, 255);
         linearV.IsFilled = true;
         linearV.UseGradient = true;
         linearV.GradientType = GradientType.Linear;
-        linearV.Color1 = new Color(255, 215, 0, 255);
         linearV.Color2 = new Color(220, 20, 60, 255);
         linearV.GradientX1 = 0; linearV.GradientY1 = 0;
         linearV.GradientX2 = 0; linearV.GradientY2 = 50;
@@ -270,11 +268,10 @@ internal class RectanglesScreen : FrameworkElement
         // Linear diagonal: cyan → magenta, top-left to bottom-right.
         RectangleRuntime linearD = new();
         linearD.Width = 70; linearD.Height = 50;
-        linearD.FillColor = Color.White;
+        linearD.FillColor = new Color(0, 255, 255, 255);
         linearD.IsFilled = true;
         linearD.UseGradient = true;
         linearD.GradientType = GradientType.Linear;
-        linearD.Color1 = new Color(0, 255, 255, 255);
         linearD.Color2 = new Color(255, 0, 255, 255);
         linearD.GradientX1 = 0; linearD.GradientY1 = 0;
         linearD.GradientX2 = 70; linearD.GradientY2 = 50;
@@ -287,7 +284,6 @@ internal class RectanglesScreen : FrameworkElement
         radial.IsFilled = true;
         radial.UseGradient = true;
         radial.GradientType = GradientType.Radial;
-        radial.Color1 = Color.White;
         radial.Color2 = new Color(0, 100, 0, 255);
         radial.GradientX1 = 35; radial.GradientY1 = 25;
         radial.GradientInnerRadius = 0;
@@ -389,11 +385,10 @@ internal class RectanglesScreen : FrameworkElement
         rect.YUnits = GeneralUnitType.PixelsFromMiddle;
         // Filled cell — light up the fill slot so the gradient renders on the fill. raylib's
         // outline-only case is handled by BuildRotationOutlineUnsupportedRow.
-        rect.FillColor = Color.White;
+        rect.FillColor = Color.Black;
         rect.IsFilled = true;
         rect.UseGradient = true;
         rect.GradientType = GradientType.Linear;
-        rect.Color1 = Color.Black;
         rect.Color2 = Color.White;
         rect.GradientX1 = 0; rect.GradientY1 = 0;
         rect.GradientX2 = 20; rect.GradientY2 = 0;

--- a/Tests/MonoGameGum.Shapes.Tests/CircleRuntimeTests.cs
+++ b/Tests/MonoGameGum.Shapes.Tests/CircleRuntimeTests.cs
@@ -185,10 +185,12 @@ public class CircleRuntimeTests
     // Load-order contract guard for #2761 / #2768: if any of the four factory registrations
     // moves back inside the _registered guard in AposShapeRuntime, this catches the
     // regression. After Reset + re-call, a new CircleRuntime must still bind Apos Circles.
-    // Issue #2791: gradient coordinate/color props push through to BOTH Apos Circles so the values
-    // round-trip on either slot. The UseGradient GATE, however, routes to the active body slot
-    // (fill when IsFilled, else stroke — see UseGradient_When* tests). IsFilled is set true here so
-    // the gate lands deterministically on the fill; the shared params are inert on the stroke.
+    // Issue #2791 / #3009: gradient coordinate and Color2 props push through to BOTH Apos Circles
+    // so the values round-trip on either slot. The gradient START is per-slot now — each slot
+    // mirrors its own body color (see UseGradient_GradientStart_* tests) rather than a shared
+    // standalone Color1. The UseGradient GATE routes to the active body slot (fill when IsFilled,
+    // else stroke — see UseGradient_When* tests). IsFilled is set true here so the gate lands
+    // deterministically on the fill; the shared params are inert on the stroke.
     [Fact]
     public void Gradient_PropertiesPushedToBothFillAndStrokeSlots()
     {
@@ -197,7 +199,6 @@ public class CircleRuntimeTests
 
         sut.UseGradient = true;
         sut.GradientType = GradientType.Linear;
-        sut.Color1 = Color.Red;
         sut.Color2 = Color.Blue;
         sut.GradientX2 = 56;
         sut.GradientInnerRadius = 4;
@@ -210,8 +211,6 @@ public class CircleRuntimeTests
         stroke.UseGradient.ShouldBeFalse();
         fill.GradientType.ShouldBe(GradientType.Linear);
         stroke.GradientType.ShouldBe(GradientType.Linear);
-        fill.Red1.ShouldBe(Color.Red.R);
-        stroke.Red1.ShouldBe(Color.Red.R);
         fill.Blue2.ShouldBe(Color.Blue.B);
         stroke.Blue2.ShouldBe(Color.Blue.B);
         fill.GradientX2.ShouldBe(56);
@@ -235,9 +234,7 @@ public class CircleRuntimeTests
         sut.FillColor = Color.Red;
         sut.StrokeColor = Color.White;
         sut.StrokeWidth = 4f;
-        sut.Color1 = Color.Blue;
         sut.Color2 = Color.Green;
-        sut.Alpha1 = 255;
         sut.Alpha2 = 255;
 
         sut.UseGradient = true;
@@ -263,9 +260,7 @@ public class CircleRuntimeTests
         sut.IsFilled = false;
         sut.StrokeColor = Color.White;
         sut.StrokeWidth = 4f;
-        sut.Color1 = Color.Blue;
         sut.Color2 = Color.Green;
-        sut.Alpha1 = 255;
         sut.Alpha2 = 255;
 
         sut.UseGradient = true;
@@ -288,9 +283,7 @@ public class CircleRuntimeTests
         sut.Height = 56;
         sut.StrokeColor = Color.White;
         sut.StrokeWidth = 4f;
-        sut.Color1 = Color.Blue;
         sut.Color2 = Color.Green;
-        sut.Alpha1 = 255;
         sut.Alpha2 = 255;
         sut.UseGradient = true;
 
@@ -1089,5 +1082,83 @@ public class CircleRuntimeTests
         sut.FillColor.ShouldBe(new Color(60, 70, 80, 255));
         Circle fill = (Circle)sut.RenderableComponent;
         fill.Color.ShouldBe(new Color(60, 70, 80, 255));
+    }
+
+    // Issue #3009 — Circle/Rectangle no longer store a standalone gradient Color1. The gradient
+    // start stop is the ACTIVE body color: FillColor when IsFilled, StrokeColor when stroke-only.
+    // This removes the solid↔gradient color jump when toggling UseGradient (the start already
+    // equals the solid the shape was showing) and converges the dropshadow alpha (which scales by
+    // the renderable's Color.A) onto the gradient start alpha. Each slot mirrors its own solid
+    // color into its Red1/Green1/Blue1/Alpha1 start, so both fill and stroke can carry the
+    // correct gradient start simultaneously.
+
+    [Fact]
+    public void UseGradient_GradientStart_MirrorsFillColor_WhenFilled()
+    {
+        CircleRuntime sut = new();
+        sut.IsFilled = true;
+        sut.FillColor = new Color(10, 20, 30, 200);
+
+        sut.UseGradient = true;
+
+        Circle fill = (Circle)sut.RenderableComponent;
+        fill.Red1.ShouldBe(10);
+        fill.Green1.ShouldBe(20);
+        fill.Blue1.ShouldBe(30);
+        fill.Alpha1.ShouldBe(200);
+    }
+
+    [Fact]
+    public void UseGradient_GradientStart_MirrorsStrokeColor_WhenStrokeOnly()
+    {
+        CircleRuntime sut = new();
+        sut.IsFilled = false;
+        sut.StrokeColor = new Color(40, 50, 60, 70);
+
+        sut.UseGradient = true;
+
+        Circle fill = (Circle)sut.RenderableComponent;
+        Circle stroke = (Circle)fill.Children[0];
+        stroke.Red1.ShouldBe(40);
+        stroke.Green1.ShouldBe(50);
+        stroke.Blue1.ShouldBe(60);
+        stroke.Alpha1.ShouldBe(70);
+    }
+
+    // No-jump contract: changing the body color while the gradient is on updates the gradient
+    // start in lockstep, so there is never a stale start color left behind.
+    [Fact]
+    public void FillColor_WhenChangedUnderGradient_UpdatesGradientStart()
+    {
+        CircleRuntime sut = new();
+        sut.IsFilled = true;
+        sut.UseGradient = true;
+
+        sut.FillColor = new Color(1, 2, 3, 4);
+
+        Circle fill = (Circle)sut.RenderableComponent;
+        fill.Red1.ShouldBe(1);
+        fill.Green1.ShouldBe(2);
+        fill.Blue1.ShouldBe(3);
+        fill.Alpha1.ShouldBe(4);
+    }
+
+    // Dropshadow alpha converges onto the gradient start alpha: the renderable's solid Color.A
+    // (which EffectiveDropshadowColor scales by) now equals the gradient start alpha, because both
+    // are the body color.
+    [Fact]
+    public void Dropshadow_AlphaTracksGradientStart_WhenFilledGradient()
+    {
+        CircleRuntime sut = new();
+        sut.IsFilled = true;
+        sut.FillColor = new Color(255, 0, 0, 128);
+        sut.UseGradient = true;
+        sut.HasDropshadow = true;
+        sut.DropshadowColor = new Color(0, 0, 0, 255);
+
+        Circle fill = (Circle)sut.RenderableComponent;
+        fill.Alpha1.ShouldBe(128);
+        // EffectiveDropshadowColor.A = 255 * (Color.A = 128) / 255 = 128
+        fill.EffectiveDropshadowColor.A.ShouldBe((byte)128);
     }
 }

--- a/Tests/MonoGameGum.Shapes.Tests/RectangleRuntimeTests.cs
+++ b/Tests/MonoGameGum.Shapes.Tests/RectangleRuntimeTests.cs
@@ -161,9 +161,7 @@ public class RectangleRuntimeTests
         sut.FillColor = Color.Red;
         sut.StrokeColor = Color.White;
         sut.StrokeWidth = 4f;
-        sut.Color1 = Color.Blue;
         sut.Color2 = Color.Green;
-        sut.Alpha1 = 255;
         sut.Alpha2 = 255;
 
         sut.UseGradient = true;
@@ -187,9 +185,7 @@ public class RectangleRuntimeTests
         sut.IsFilled = false;
         sut.StrokeColor = Color.White;
         sut.StrokeWidth = 4f;
-        sut.Color1 = Color.Blue;
         sut.Color2 = Color.Green;
-        sut.Alpha1 = 255;
         sut.Alpha2 = 255;
 
         sut.UseGradient = true;
@@ -210,9 +206,7 @@ public class RectangleRuntimeTests
         RectangleRuntime sut = new();
         sut.StrokeColor = Color.White;
         sut.StrokeWidth = 4f;
-        sut.Color1 = Color.Blue;
         sut.Color2 = Color.Green;
-        sut.Alpha1 = 255;
         sut.Alpha2 = 255;
         sut.UseGradient = true;
 
@@ -375,11 +369,13 @@ public class RectangleRuntimeTests
         stroke.IsAntialiased.ShouldBeTrue();
     }
 
-    // Issue #2818: gradient coordinate/color props push through to BOTH Apos RoundedRectangles so
-    // the values round-trip on either slot. The UseGradient GATE, however, routes to the active
-    // body slot (fill when IsFilled, else stroke — see UseGradient_When* tests). IsFilled is set
-    // true here so the gate lands deterministically on the fill; the shared params are inert on
-    // the stroke while its gate is off.
+    // Issue #2818 / #3009: gradient coordinate and Color2 props push through to BOTH Apos
+    // RoundedRectangles so the values round-trip on either slot. The gradient START is per-slot now
+    // — each slot mirrors its own body color (see UseGradient_GradientStart_* tests) rather than a
+    // shared standalone Color1. The UseGradient GATE routes to the active body slot (fill when
+    // IsFilled, else stroke — see UseGradient_When* tests). IsFilled is set true here so the gate
+    // lands deterministically on the fill; the shared params are inert on the stroke while its
+    // gate is off.
     [Fact]
     public void Gradient_PropertiesPushedToBothFillAndStrokeSlots()
     {
@@ -388,7 +384,6 @@ public class RectangleRuntimeTests
 
         sut.UseGradient = true;
         sut.GradientType = GradientType.Linear;
-        sut.Color1 = Color.Red;
         sut.Color2 = Color.Blue;
         sut.GradientX2 = 56;
         sut.GradientInnerRadius = 4;
@@ -401,14 +396,79 @@ public class RectangleRuntimeTests
         stroke.UseGradient.ShouldBeFalse();
         fill.GradientType.ShouldBe(GradientType.Linear);
         stroke.GradientType.ShouldBe(GradientType.Linear);
-        fill.Red1.ShouldBe(Color.Red.R);
-        stroke.Red1.ShouldBe(Color.Red.R);
         fill.Blue2.ShouldBe(Color.Blue.B);
         stroke.Blue2.ShouldBe(Color.Blue.B);
         fill.GradientX2.ShouldBe(56);
         stroke.GradientX2.ShouldBe(56);
         fill.GradientInnerRadius.ShouldBe(4);
         stroke.GradientInnerRadius.ShouldBe(4);
+    }
+
+    // Issue #3009 — gradient start mirrors the active body color (parallel of the CircleRuntime
+    // tests). FillColor when filled, StrokeColor when stroke-only; dropshadow alpha converges onto
+    // the start because both equal the body color.
+    [Fact]
+    public void UseGradient_GradientStart_MirrorsFillColor_WhenFilled()
+    {
+        RectangleRuntime sut = new();
+        sut.IsFilled = true;
+        sut.FillColor = new Color(10, 20, 30, 200);
+
+        sut.UseGradient = true;
+
+        RoundedRectangle fill = (RoundedRectangle)sut.RenderableComponent;
+        fill.Red1.ShouldBe(10);
+        fill.Green1.ShouldBe(20);
+        fill.Blue1.ShouldBe(30);
+        fill.Alpha1.ShouldBe(200);
+    }
+
+    [Fact]
+    public void UseGradient_GradientStart_MirrorsStrokeColor_WhenStrokeOnly()
+    {
+        RectangleRuntime sut = new();
+        sut.IsFilled = false;
+        sut.StrokeColor = new Color(40, 50, 60, 70);
+
+        sut.UseGradient = true;
+
+        RoundedRectangle fill = (RoundedRectangle)sut.RenderableComponent;
+        RoundedRectangle stroke = (RoundedRectangle)fill.Children[0];
+        stroke.Red1.ShouldBe(40);
+        stroke.Green1.ShouldBe(50);
+        stroke.Blue1.ShouldBe(60);
+        stroke.Alpha1.ShouldBe(70);
+    }
+
+    [Fact]
+    public void FillColor_WhenChangedUnderGradient_UpdatesGradientStart()
+    {
+        RectangleRuntime sut = new();
+        sut.IsFilled = true;
+        sut.UseGradient = true;
+
+        sut.FillColor = new Color(1, 2, 3, 4);
+
+        RoundedRectangle fill = (RoundedRectangle)sut.RenderableComponent;
+        fill.Red1.ShouldBe(1);
+        fill.Green1.ShouldBe(2);
+        fill.Blue1.ShouldBe(3);
+        fill.Alpha1.ShouldBe(4);
+    }
+
+    [Fact]
+    public void Dropshadow_AlphaTracksGradientStart_WhenFilledGradient()
+    {
+        RectangleRuntime sut = new();
+        sut.IsFilled = true;
+        sut.FillColor = new Color(255, 0, 0, 128);
+        sut.UseGradient = true;
+        sut.HasDropshadow = true;
+        sut.DropshadowColor = new Color(0, 0, 0, 255);
+
+        RoundedRectangle fill = (RoundedRectangle)sut.RenderableComponent;
+        fill.Alpha1.ShouldBe(128);
+        fill.EffectiveDropshadowColor.A.ShouldBe((byte)128);
     }
 
     // Issue #2818: dropshadow pushes to the fill slot only (with fallback to stroke when fill

--- a/Tests/RaylibGum.Tests/Runtimes/CircleRuntimeTests.cs
+++ b/Tests/RaylibGum.Tests/Runtimes/CircleRuntimeTests.cs
@@ -192,16 +192,20 @@ public class CircleRuntimeTests : BaseTestClass
         inner.DropshadowBlurY.ShouldBe(4f);
     }
 
+    // Issue #3009 — Circle/Rectangle no longer expose a standalone gradient Color1. The gradient
+    // start mirrors the active body color (FillColor when filled, StrokeColor otherwise) and is
+    // pushed into the contained LineCircle's Color1. Color2 remains the standalone second stop.
     [Fact]
-    public void Gradient_PropertiesRoundTrip_AndPushToContainedRenderable()
+    public void Gradient_StartMirrorsBodyColor_AndPushesToContainedRenderable()
     {
         CircleRuntime sut = new();
-        Color c1 = new Color(255, 0, 0, 255);
+        Color fill = new Color(255, 0, 0, 255);
         Color c2 = new Color(0, 0, 255, 255);
 
+        sut.IsFilled = true;
+        sut.FillColor = fill;
         sut.UseGradient = true;
         sut.GradientType = GradientType.Radial;
-        sut.Color1 = c1;
         sut.Color2 = c2;
 
         sut.UseGradient.ShouldBeTrue();
@@ -210,6 +214,7 @@ public class CircleRuntimeTests : BaseTestClass
         inner.UseGradient.ShouldBeTrue();
         inner.GradientType.ShouldBe(GradientType.Radial);
         inner.Color1.R.ShouldBe((byte)255);
+        inner.Color1.A.ShouldBe((byte)255);
         inner.Color2.B.ShouldBe((byte)255);
     }
 

--- a/Tests/RaylibGum.Tests/Runtimes/CircleRuntimeTests.cs
+++ b/Tests/RaylibGum.Tests/Runtimes/CircleRuntimeTests.cs
@@ -13,6 +13,46 @@ namespace RaylibGum.Tests.Runtimes;
 
 public class CircleRuntimeTests : BaseTestClass
 {
+    // Issue #3009 follow-up — a stroke-only circle (IsFilled = false, only StrokeColor set) must
+    // render outline-only on raylib. The renderable's fill pass runs when `FillColor.HasValue ||
+    // IsFilled`, so the runtime must leave the renderable's FillColor null when the shape isn't
+    // filled (it previously pushed the default opaque-white FillColor unconditionally, filling
+    // every default circle).
+    [Fact]
+    public void StrokeOnly_DefaultCircle_DoesNotFill()
+    {
+        CircleRuntime sut = new();
+        sut.StrokeColor = new Color(255, 255, 255, 255);
+
+        LineCircle inner = (LineCircle)sut.RenderableComponent!;
+        inner.IsFilled.ShouldBeFalse();
+        inner.FillColor.HasValue.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsFilledTrue_PushesFillColorToRenderable()
+    {
+        CircleRuntime sut = new();
+        sut.FillColor = new Color(10, 20, 30, 255);
+        sut.IsFilled = true;
+
+        LineCircle inner = (LineCircle)sut.RenderableComponent!;
+        inner.FillColor.HasValue.ShouldBeTrue();
+        inner.FillColor!.Value.R.ShouldBe((byte)10);
+    }
+
+    [Fact]
+    public void IsFilledToggledOff_ClearsRenderableFillColor()
+    {
+        CircleRuntime sut = new();
+        sut.FillColor = new Color(10, 20, 30, 255);
+        sut.IsFilled = true;
+        sut.IsFilled = false;
+
+        LineCircle inner = (LineCircle)sut.RenderableComponent!;
+        inner.FillColor.HasValue.ShouldBeFalse();
+    }
+
     [Fact]
     public void Alpha_ShouldDefaultTo255()
     {
@@ -109,6 +149,9 @@ public class CircleRuntimeTests : BaseTestClass
         CircleRuntime sut = new();
         Color expected = new Color(10, 20, 30, 200);
 
+        // Issue #3009 — IsFilled gates the fill (consistent with Apos/Skia), so the fill color
+        // reaches the renderable only when the shape is filled.
+        sut.IsFilled = true;
         sut.FillColor = expected;
 
         sut.FillColor.R.ShouldBe((byte)10);

--- a/Tests/RaylibGum.Tests/Runtimes/RectangleRuntimeTests.cs
+++ b/Tests/RaylibGum.Tests/Runtimes/RectangleRuntimeTests.cs
@@ -13,6 +13,47 @@ namespace RaylibGum.Tests.Runtimes;
 
 public class RectangleRuntimeTests : BaseTestClass
 {
+    // Issue #3009 follow-up — a stroke-only rectangle (IsFilled = false, only StrokeColor set) must
+    // render outline-only on raylib. The renderable's fill pass runs when `FillColor.HasValue ||
+    // IsFilled`, so the runtime must leave the renderable's FillColor null when the shape isn't
+    // filled. It previously pushed the default opaque-white FillColor unconditionally, which made
+    // every default rectangle fill white (mirrors how Apos/Skia push a transparent fill when not
+    // filled).
+    [Fact]
+    public void StrokeOnly_DefaultRectangle_DoesNotFill()
+    {
+        RectangleRuntime sut = new();
+        sut.StrokeColor = new Color(255, 255, 255, 255);
+
+        LineRectangle inner = (LineRectangle)sut.RenderableComponent!;
+        inner.IsFilled.ShouldBeFalse();
+        inner.FillColor.HasValue.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsFilledTrue_PushesFillColorToRenderable()
+    {
+        RectangleRuntime sut = new();
+        sut.FillColor = new Color(10, 20, 30, 255);
+        sut.IsFilled = true;
+
+        LineRectangle inner = (LineRectangle)sut.RenderableComponent!;
+        inner.FillColor.HasValue.ShouldBeTrue();
+        inner.FillColor!.Value.R.ShouldBe((byte)10);
+    }
+
+    [Fact]
+    public void IsFilledToggledOff_ClearsRenderableFillColor()
+    {
+        RectangleRuntime sut = new();
+        sut.FillColor = new Color(10, 20, 30, 255);
+        sut.IsFilled = true;
+        sut.IsFilled = false;
+
+        LineRectangle inner = (LineRectangle)sut.RenderableComponent!;
+        inner.FillColor.HasValue.ShouldBeFalse();
+    }
+
     [Fact]
     public void Alpha_ShouldDefaultTo255()
     {
@@ -107,6 +148,9 @@ public class RectangleRuntimeTests : BaseTestClass
         RectangleRuntime sut = new();
         Color expected = new Color(10, 20, 30, 200);
 
+        // Issue #3009 — IsFilled gates the fill (consistent with Apos/Skia), so the fill color
+        // reaches the renderable only when the shape is filled.
+        sut.IsFilled = true;
         sut.FillColor = expected;
 
         sut.FillColor.R.ShouldBe((byte)10);

--- a/Tests/RaylibGum.Tests/Runtimes/RectangleRuntimeTests.cs
+++ b/Tests/RaylibGum.Tests/Runtimes/RectangleRuntimeTests.cs
@@ -215,16 +215,20 @@ public class RectangleRuntimeTests : BaseTestClass
         inner.DropshadowBlurY.ShouldBe(4f);
     }
 
+    // Issue #3009 — Circle/Rectangle no longer expose a standalone gradient Color1. The gradient
+    // start mirrors the active body color (FillColor when filled, StrokeColor otherwise) and is
+    // pushed into the contained LineRectangle's Color1. Color2 remains the standalone second stop.
     [Fact]
-    public void Gradient_PropertiesRoundTrip_AndPushToContainedRenderable()
+    public void Gradient_StartMirrorsBodyColor_AndPushesToContainedRenderable()
     {
         RectangleRuntime sut = new();
-        Color c1 = new Color(255, 0, 0, 255);
+        Color fill = new Color(255, 0, 0, 255);
         Color c2 = new Color(0, 0, 255, 255);
 
+        sut.IsFilled = true;
+        sut.FillColor = fill;
         sut.UseGradient = true;
         sut.GradientType = GradientType.Radial;
-        sut.Color1 = c1;
         sut.Color2 = c2;
 
         sut.UseGradient.ShouldBeTrue();
@@ -233,6 +237,7 @@ public class RectangleRuntimeTests : BaseTestClass
         inner.UseGradient.ShouldBeTrue();
         inner.GradientType.ShouldBe(GradientType.Radial);
         inner.Color1.R.ShouldBe((byte)255);
+        inner.Color1.A.ShouldBe((byte)255);
         inner.Color2.B.ShouldBe((byte)255);
     }
 

--- a/Tests/SkiaGum.Tests/GueDeriving/ArcRuntimeTests.cs
+++ b/Tests/SkiaGum.Tests/GueDeriving/ArcRuntimeTests.cs
@@ -1,5 +1,7 @@
 ﻿using Gum.GueDeriving;
+using Gum.Wireframe;
 using Shouldly;
+using SkiaGum;
 using SkiaGum.Renderables;
 using System;
 using System.Collections.Generic;
@@ -9,6 +11,13 @@ namespace SkiaGum.Tests.GueDeriving;
 
 public class ArcRuntimeTests
 {
+    public ArcRuntimeTests()
+    {
+        // Route SetProperty through the production dispatcher so the .gumx-load path (which maps
+        // Arc's legacy Red1/Green1/Blue1/Alpha1 onto the primary Color, issue #3009) is exercised.
+        GraphicalUiElement.SetPropertyOnRenderable = CustomSetPropertyOnRenderable.SetPropertyOnRenderable;
+    }
+
     // #2949: ArcRuntime exposes a single isotropic DropshadowBlur (mirroring CSS box-shadow /
     // Figma / Photoshop). Setting the scalar fans the value out to both axes; asserted on the
     // renderable's per-axis blur (which stays a real API at the renderable layer), not the
@@ -99,5 +108,71 @@ public class ArcRuntimeTests
         arcRuntime.PreRender();
 
         containedArc.StrokeWidth.ShouldBe(10);
+    }
+
+    // Issue #3009 — Arc's gradient start is now its primary Color (the unified "gradient start =
+    // body color" model). The renderable's gradient-start channels (Red1/Green1/Blue1/Alpha1) are
+    // synced from the primary color each frame in PreRender so the start follows the color
+    // regardless of how it was set.
+    [Fact]
+    public void GradientStart_MirrorsPrimaryColor_AfterPreRender()
+    {
+        ArcRuntime arcRuntime = new();
+        arcRuntime.Red = 10;
+        arcRuntime.Green = 20;
+        arcRuntime.Blue = 30;
+        arcRuntime.Alpha = 40;
+
+        arcRuntime.PreRender();
+
+        Arc containedArc = (Arc)arcRuntime.RenderableComponent;
+        containedArc.Red1.ShouldBe(10);
+        containedArc.Green1.ShouldBe(20);
+        containedArc.Blue1.ShouldBe(30);
+        containedArc.Alpha1.ShouldBe(40);
+    }
+
+    // Issue #3009 — the obsolete Red1/Green1/Blue1/Alpha1 / Color1 shims map onto the primary
+    // Color so old code keeps compiling and behaving sensibly (the standalone gradient start was
+    // collapsed onto the body color).
+    [Fact]
+    public void Red1Shim_MapsToPrimaryColor()
+    {
+#pragma warning disable CS0618 // exercising the obsolete back-compat shim on purpose
+        ArcRuntime arcRuntime = new();
+
+        arcRuntime.Red1 = 77;
+
+        arcRuntime.Red.ShouldBe(77);
+        arcRuntime.Red1.ShouldBe(77);
+#pragma warning restore CS0618
+    }
+
+    // Issue #3009 — Arc back-compat loss case (pinned per the locked design). Old Arc data sets
+    // the solid color channels (Color/Red/Green/Blue/Alpha) AND the legacy gradient-start channels
+    // (Red1/Green1/Blue1/Alpha1) independently. Both now remap onto the primary Color, and Gum
+    // applies variables alphabetically — so the …1 channels apply AFTER the solid ones and win.
+    // When UseGradient was false and Color1 was explicitly different from Color, the solid now
+    // shows the old Color1 (the documented, accepted lossy outcome).
+    [Fact]
+    public void Load_Color1WinsOverColor_OnPrimary_DocumentingLossyCase()
+    {
+        ArcRuntime arcRuntime = new();
+
+        // Solid channels apply first (alphabetical): an opaque blue.
+        arcRuntime.SetProperty("Alpha", 255);
+        arcRuntime.SetProperty("Blue", 200);
+        arcRuntime.SetProperty("Green", 0);
+        arcRuntime.SetProperty("Red", 0);
+        // …1 channels apply after and win (remapped onto the primary Color): an opaque red.
+        arcRuntime.SetProperty("Alpha1", 255);
+        arcRuntime.SetProperty("Blue1", 0);
+        arcRuntime.SetProperty("Green1", 0);
+        arcRuntime.SetProperty("Red1", 255);
+
+        // Primary color reflects the …1 values (Color1 wins) — the accepted lossy outcome.
+        arcRuntime.Red.ShouldBe(255);
+        arcRuntime.Green.ShouldBe(0);
+        arcRuntime.Blue.ShouldBe(0);
     }
 }

--- a/Tests/SkiaGum.Tests/GueDeriving/CircleRuntimeTests.cs
+++ b/Tests/SkiaGum.Tests/GueDeriving/CircleRuntimeTests.cs
@@ -335,17 +335,36 @@ public class CircleRuntimeTests
         fillSlot.UseGradient.ShouldBeTrue();
     }
 
+    // Issue #3009 — Circle/Rectangle no longer carry a standalone gradient Color1. Each slot's
+    // gradient start mirrors its own solid body color: the fill slot follows FillColor, the stroke
+    // slot follows StrokeColor. This removes the solid↔gradient jump on UseGradient toggle and
+    // converges the dropshadow alpha onto the gradient start.
     [Fact]
-    public void Color1_MirrorsToBothSlots()
+    public void GradientStart_MirrorsFillColor_OnFillSlot()
     {
         CircleRuntime sut = new();
-        sut.Color1 = new SKColor(10, 20, 30, 40);
+        sut.IsFilled = true;
+        sut.FillColor = new SKColor(10, 20, 30, 40);
+
+        Circle fillSlot = (Circle)sut.RenderableComponent;
+        fillSlot.Red1.ShouldBe(10);
+        fillSlot.Green1.ShouldBe(20);
+        fillSlot.Blue1.ShouldBe(30);
+        fillSlot.Alpha1.ShouldBe(40);
+    }
+
+    [Fact]
+    public void GradientStart_MirrorsStrokeColor_OnStrokeSlot()
+    {
+        CircleRuntime sut = new();
+        sut.StrokeColor = new SKColor(40, 50, 60, 70);
 
         Circle fillSlot = (Circle)sut.RenderableComponent;
         Circle strokeSlot = (Circle)fillSlot.Children.Single();
-        fillSlot.Red1.ShouldBe(10);
-        strokeSlot.Red1.ShouldBe(10);
-        strokeSlot.Alpha1.ShouldBe(40);
+        strokeSlot.Red1.ShouldBe(40);
+        strokeSlot.Green1.ShouldBe(50);
+        strokeSlot.Blue1.ShouldBe(60);
+        strokeSlot.Alpha1.ShouldBe(70);
     }
 
     // #2790: dropshadow routes to fill when FillColor is set (shadow underneath the disk reads

--- a/Tests/SkiaGum.Tests/GueDeriving/RectangleRuntimeTests.cs
+++ b/Tests/SkiaGum.Tests/GueDeriving/RectangleRuntimeTests.cs
@@ -55,17 +55,35 @@ public class RectangleRuntimeTests
         cloneStroke.ShouldNotBeSameAs(sourceStroke);
     }
 
+    // Issue #3009 — Circle/Rectangle no longer carry a standalone gradient Color1. Each slot's
+    // gradient start mirrors its own solid body color: the fill slot follows FillColor, the stroke
+    // slot follows StrokeColor.
     [Fact]
-    public void Color1_MirrorsToBothSlots()
+    public void GradientStart_MirrorsFillColor_OnFillSlot()
     {
         RectangleRuntime sut = new();
-        sut.Color1 = new SKColor(10, 20, 30, 40);
+        sut.IsFilled = true;
+        sut.FillColor = new SKColor(10, 20, 30, 40);
+
+        RoundedRectangle fillSlot = (RoundedRectangle)sut.RenderableComponent;
+        fillSlot.Red1.ShouldBe(10);
+        fillSlot.Green1.ShouldBe(20);
+        fillSlot.Blue1.ShouldBe(30);
+        fillSlot.Alpha1.ShouldBe(40);
+    }
+
+    [Fact]
+    public void GradientStart_MirrorsStrokeColor_OnStrokeSlot()
+    {
+        RectangleRuntime sut = new();
+        sut.StrokeColor = new SKColor(40, 50, 60, 70);
 
         RoundedRectangle fillSlot = (RoundedRectangle)sut.RenderableComponent;
         RoundedRectangle strokeSlot = (RoundedRectangle)fillSlot.Children.Single();
-        fillSlot.Red1.ShouldBe(10);
-        strokeSlot.Red1.ShouldBe(10);
-        strokeSlot.Alpha1.ShouldBe(40);
+        strokeSlot.Red1.ShouldBe(40);
+        strokeSlot.Green1.ShouldBe(50);
+        strokeSlot.Blue1.ShouldBe(60);
+        strokeSlot.Alpha1.ShouldBe(70);
     }
 
     [Fact]

--- a/Themes/Gum.Themes.ForestGlade.MonoGame/ComboBoxVisual.cs
+++ b/Themes/Gum.Themes.ForestGlade.MonoGame/ComboBoxVisual.cs
@@ -74,7 +74,6 @@ public class ComboBoxVisual : BaseComboBoxVisual
         fill.HeightUnits = DimensionUnitType.RelativeToParent;
         ForestGladeLeaf.ApplyMedium(fill);
         fill.IsFilled = true;
-        fill.FillColor = ForestGladePalette.InputFill;
         fill.StrokeWidth = 0;
         // Same vertical dark gradient as the TextBox decoration so the closed
         // ComboBox reads as a sibling input chrome.
@@ -88,7 +87,7 @@ public class ComboBoxVisual : BaseComboBoxVisual
         fill.GradientY2Units = GeneralUnitType.PixelsFromLarge;
         fill.GradientX2 = 0f;
         fill.GradientY2 = 0f;
-        fill.Color1 = new Color(2, 22, 25);
+        fill.FillColor = new Color(2, 22, 25);
         fill.Color2 = new Color(4, 36, 40);
         return fill;
     }
@@ -202,8 +201,7 @@ public class ComboBoxVisual : BaseComboBoxVisual
     private void Apply(Color border, Color text, Color glyph, bool ring, bool fillDisabled)
     {
         Color baseFill = fillDisabled ? ForestGladePalette.InputFillDisabled : ForestGladePalette.InputFill;
-        _fill.FillColor = baseFill;
-        _fill.Color1 = Darken(baseFill, 0.65f);
+        _fill.FillColor = Darken(baseFill, 0.65f);
         _fill.Color2 = baseFill;
         _border.StrokeColor = border;
         TextInstance.Color = text;

--- a/Themes/Gum.Themes.ForestGlade.MonoGame/ForestGladeButtonChrome.cs
+++ b/Themes/Gum.Themes.ForestGlade.MonoGame/ForestGladeButtonChrome.cs
@@ -240,7 +240,7 @@ internal sealed class ForestGladeButtonChrome
         Color shadow, float shadowOffsetY, float shadowBlur,
         Color text, Color textShadow, bool ring)
     {
-        Fill.Color1 = fillTop;
+        Fill.FillColor = fillTop;
         Fill.Color2 = fillBottom;
         Border.StrokeColor = border;
         Fill.DropshadowColor = shadow;

--- a/Themes/Gum.Themes.ForestGlade.MonoGame/ForestGladeTextInputDecoration.cs
+++ b/Themes/Gum.Themes.ForestGlade.MonoGame/ForestGladeTextInputDecoration.cs
@@ -65,7 +65,6 @@ internal sealed class ForestGladeTextInputDecoration
         fill.HeightUnits = DimensionUnitType.RelativeToParent;
         ForestGladeLeaf.ApplyMedium(fill);
         fill.IsFilled = true;
-        fill.FillColor = ForestGladePalette.InputFill;
         fill.StrokeWidth = 0;
         // CSS .fg-input: linear-gradient(180deg, rgba(0,0,0,.30), rgba(0,0,0,.18))
         // over the canopy background — translates to a vertical gradient on
@@ -80,7 +79,7 @@ internal sealed class ForestGladeTextInputDecoration
         fill.GradientY2Units = GeneralUnitType.PixelsFromLarge;
         fill.GradientX2 = 0f;
         fill.GradientY2 = 0f;
-        fill.Color1 = new Color(2, 22, 25);
+        fill.FillColor = new Color(2, 22, 25);
         fill.Color2 = new Color(4, 36, 40);
         return fill;
     }
@@ -168,10 +167,10 @@ internal sealed class ForestGladeTextInputDecoration
     private void Apply(TextBoxBaseVisual host, Color fill, Color border, Color text,
         Color placeholder, Color caret, Color selection, bool haloVisible, bool glow)
     {
-        _fill.FillColor = fill;
         // Recompute the vertical gradient stops from the state's base fill so
-        // each state stays subtly darker at the top than the bottom.
-        _fill.Color1 = Darken(fill, 0.65f);
+        // each state stays subtly darker at the top than the bottom. The
+        // gradient start is the fill color itself.
+        _fill.FillColor = Darken(fill, 0.65f);
         _fill.Color2 = fill;
         _fill.HasDropshadow = glow;
         if (glow)

--- a/Themes/Gum.Themes.ForestGlade.MonoGame/ListBoxItemVisual.cs
+++ b/Themes/Gum.Themes.ForestGlade.MonoGame/ListBoxItemVisual.cs
@@ -127,7 +127,7 @@ public class ListBoxItemVisual : BaseListBoxItemVisual
 
     private void ApplyPalette(Color fillLeft, Color fillRight, Color text, bool stripe)
     {
-        _fill.Color1 = fillLeft;
+        _fill.FillColor = fillLeft;
         _fill.Color2 = fillRight;
         TextInstance.Color = text;
         _selectionStripe.Visible = stripe;

--- a/Themes/Gum.Themes.ForestGlade.MonoGame/ScrollBarThumbVisual.cs
+++ b/Themes/Gum.Themes.ForestGlade.MonoGame/ScrollBarThumbVisual.cs
@@ -49,7 +49,6 @@ public class ScrollBarThumbVisual : InteractiveGue
         body.HeightUnits = DimensionUnitType.RelativeToParent;
         ForestGladeLeaf.ApplySmall(body);
         body.IsFilled = true;
-        body.FillColor = ForestGladePalette.ScrollThumb;
         body.StrokeWidth = 0;
         // CSS .fg-sb-thm linear-gradient(180deg, rgba(71,246,65,.55), rgba(0,140,46,.55))
         // — vertical, leaf-bright at top fading to canopy-lit at the bottom.
@@ -63,7 +62,7 @@ public class ScrollBarThumbVisual : InteractiveGue
         body.GradientY2Units = GeneralUnitType.PixelsFromLarge;
         body.GradientX2 = 0f;
         body.GradientY2 = 0f;
-        body.Color1 = new Color(71, 246, 65, 200);
+        body.FillColor = new Color(71, 246, 65, 200);
         body.Color2 = new Color(0, 140, 46, 200);
         return body;
     }
@@ -104,7 +103,6 @@ public class ScrollBarThumbVisual : InteractiveGue
     private void ApplyGradient(Color top, Color bottom, bool gradient)
     {
         _body.UseGradient = gradient;
-        _body.Color1 = top;
         _body.Color2 = bottom;
         _body.FillColor = top;
     }

--- a/Themes/Gum.Themes.ForestGlade.MonoGame/SliderThumbVisual.cs
+++ b/Themes/Gum.Themes.ForestGlade.MonoGame/SliderThumbVisual.cs
@@ -70,7 +70,7 @@ public class SliderThumbVisual : InteractiveGue
         // (PixelsFromMiddle with a small negative offset).
         body.UseGradient = true;
         body.GradientType = GradientType.Radial;
-        body.Color1 = ForestGladeColors.SunPale;
+        body.FillColor = ForestGladeColors.SunPale;
         body.Color2 = new Color(0, 140, 46); // CSS #008c2e outer stop
         // 35% / 30% from top-left on an 18 px circle ≈ ~-2.7 / -3.6 from middle.
         body.GradientX1Units = GeneralUnitType.PixelsFromMiddle;
@@ -179,7 +179,6 @@ public class SliderThumbVisual : InteractiveGue
     private void Apply(Color centre, Color edge, Color border, bool gradient, bool ring, bool showShadow, float blur)
     {
         _body.UseGradient = gradient;
-        _body.Color1 = centre;
         _body.Color2 = edge;
         _body.FillColor = centre;
         _body.HasDropshadow = showShadow;

--- a/Themes/Gum.Themes.ForestGlade.MonoGame/SliderVisual.cs
+++ b/Themes/Gum.Themes.ForestGlade.MonoGame/SliderVisual.cs
@@ -165,7 +165,7 @@ public class SliderVisual : BaseSliderVisual
     private void ApplyTrack(Color trackFill, Color fillLeft, Color fillRight)
     {
         _track.FillColor = trackFill;
-        _fill.Color1 = fillLeft;
+        _fill.FillColor = fillLeft;
         _fill.Color2 = fillRight;
     }
 }

--- a/Tool/Tests/GumToolUnitTests/Managers/StandardElementsManagerTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Managers/StandardElementsManagerTests.cs
@@ -84,10 +84,13 @@ public class StandardElementsManagerTests : BaseTestClass
 
         state.Variables.Any(v => v.Name == "UseGradient").ShouldBeTrue();
         state.Variables.Any(v => v.Name == "GradientType").ShouldBeTrue();
-        state.Variables.Any(v => v.Name == "Red1").ShouldBeTrue();
-        state.Variables.Any(v => v.Name == "Green1").ShouldBeTrue();
-        state.Variables.Any(v => v.Name == "Blue1").ShouldBeTrue();
-        state.Variables.Any(v => v.Name == "Alpha1").ShouldBeTrue();
+        // Issue #3009 — Circle/Rectangle no longer expose the standalone gradient start
+        // (Red1/Green1/Blue1/Alpha1); the gradient start is the active body color (FillColor when
+        // filled, StrokeColor otherwise). Color2 (the standalone second stop) remains.
+        state.Variables.Any(v => v.Name == "Red1").ShouldBeFalse();
+        state.Variables.Any(v => v.Name == "Green1").ShouldBeFalse();
+        state.Variables.Any(v => v.Name == "Blue1").ShouldBeFalse();
+        state.Variables.Any(v => v.Name == "Alpha1").ShouldBeFalse();
         state.Variables.Any(v => v.Name == "Red2").ShouldBeTrue();
         state.Variables.Any(v => v.Name == "Green2").ShouldBeTrue();
         state.Variables.Any(v => v.Name == "Blue2").ShouldBeTrue();

--- a/Tool/Tests/GumToolUnitTests/Plugins/InternalPlugins/VariableGrid/ShapeVariableExclusionLogicTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/InternalPlugins/VariableGrid/ShapeVariableExclusionLogicTests.cs
@@ -74,6 +74,66 @@ public class ShapeVariableExclusionLogicTests
         shouldExclude.ShouldBeFalse();
     }
 
+    // Issue #3009 — on Circle/Rectangle the FillColor IS the gradient start (when filled), so the
+    // fill channels must stay visible when a gradient is on — the user sets the gradient start by
+    // editing FillColor. (Under the old standalone-Color1 model they were hidden when UseGradient
+    // was true; that's now wrong.)
+    [Theory]
+    [InlineData("FillRed")]
+    [InlineData("FillGreen")]
+    [InlineData("FillBlue")]
+    [InlineData("FillAlpha")]
+    public void FillChannels_StayVisible_WhenGradientOn_AndFilled(string variableName)
+    {
+        var finder = MakeFinder(("IsFilled", true), ("UseGradient", true), ("StrokeWidth", 2f));
+
+        _logic.GetIfShapeVariableIsExcluded(variableName, finder, "Circle", "", out bool shouldExclude);
+        shouldExclude.ShouldBeFalse();
+    }
+
+    // Stroke-only (IsFilled = false): the gradient start is StrokeColor, so the fill channels are
+    // meaningless and stay hidden regardless of UseGradient.
+    [Theory]
+    [InlineData("FillRed")]
+    [InlineData("FillAlpha")]
+    public void FillChannels_Hidden_WhenNotFilled(string variableName)
+    {
+        var finder = MakeFinder(("IsFilled", false), ("UseGradient", true), ("StrokeWidth", 2f));
+
+        _logic.GetIfShapeVariableIsExcluded(variableName, finder, "Circle", "", out bool shouldExclude)
+            .ShouldBeTrue();
+        shouldExclude.ShouldBeTrue();
+    }
+
+    // Issue #3009 — Arc's gradient start is its primary Color, so the Color channels must stay
+    // visible when a gradient is on (the user sets the start by editing Color). Under the old
+    // model the solid Color was unused while a gradient drew, so it was hidden.
+    [Theory]
+    [InlineData("Red")]
+    [InlineData("Green")]
+    [InlineData("Blue")]
+    public void Arc_KeepsPrimaryColorVisible_WhenGradientOn(string variableName)
+    {
+        var finder = MakeFinder(("UseGradient", true));
+
+        _logic.GetIfShapeVariableIsExcluded(variableName, finder, "Arc", "", out bool shouldExclude);
+        shouldExclude.ShouldBeFalse();
+    }
+
+    // The legacy ColoredCircle / RoundedRectangle keep a separate Color1 for the gradient start, so
+    // their unused solid Color is still hidden when a gradient is on (pre-existing behavior).
+    [Theory]
+    [InlineData("ColoredCircle")]
+    [InlineData("RoundedRectangle")]
+    public void LegacyShapes_HideSolidColor_WhenGradientOn(string standardType)
+    {
+        var finder = MakeFinder(("UseGradient", true));
+
+        _logic.GetIfShapeVariableIsExcluded("Red", finder, standardType, "", out bool shouldExclude)
+            .ShouldBeTrue();
+        shouldExclude.ShouldBeTrue();
+    }
+
     // Issue #3009 — Arc's gradient start is its primary Color; the Red1/Green1/Blue1/Alpha1 surface
     // is kept only as obsolete back-compat shims, so it is always hidden from Arc's grid (even with
     // a gradient on), leaving Arc a single primary Color.

--- a/Tool/Tests/GumToolUnitTests/Plugins/InternalPlugins/VariableGrid/ShapeVariableExclusionLogicTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/InternalPlugins/VariableGrid/ShapeVariableExclusionLogicTests.cs
@@ -74,6 +74,36 @@ public class ShapeVariableExclusionLogicTests
         shouldExclude.ShouldBeFalse();
     }
 
+    // Issue #3009 — Arc's gradient start is its primary Color; the Red1/Green1/Blue1/Alpha1 surface
+    // is kept only as obsolete back-compat shims, so it is always hidden from Arc's grid (even with
+    // a gradient on), leaving Arc a single primary Color.
+    [Theory]
+    [InlineData("Red1")]
+    [InlineData("Green1")]
+    [InlineData("Blue1")]
+    [InlineData("Alpha1")]
+    public void Arc_AlwaysHidesGradientStartChannels(string variableName)
+    {
+        var finder = MakeFinder(("UseGradient", true));
+
+        _logic.GetIfShapeVariableIsExcluded(variableName, finder, "Arc", "", out bool shouldExclude)
+            .ShouldBeTrue();
+        shouldExclude.ShouldBeTrue();
+    }
+
+    // The legacy ColoredCircle / RoundedRectangle keep their standalone Color1 (unchanged by
+    // #3009): the gradient start channels stay visible when a gradient is on.
+    [Theory]
+    [InlineData("ColoredCircle")]
+    [InlineData("RoundedRectangle")]
+    public void LegacyShapes_ShowGradientStartChannels_WhenGradientOn(string standardType)
+    {
+        var finder = MakeFinder(("UseGradient", true));
+
+        _logic.GetIfShapeVariableIsExcluded("Red1", finder, standardType, "", out bool shouldExclude);
+        shouldExclude.ShouldBeFalse();
+    }
+
     private static RecursiveVariableFinder MakeFinder(params (string name, object value)[] variables)
     {
         var element = new ComponentSave { Name = "Test" };

--- a/Tool/Tests/GumToolUnitTests/Plugins/InternalPlugins/VariableGrid/ShapeVariableVersionGateTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/InternalPlugins/VariableGrid/ShapeVariableVersionGateTests.cs
@@ -36,7 +36,9 @@ public class ShapeVariableVersionGateTests
     [InlineData("GradientX2Units")]
     [InlineData("GradientInnerRadius")]
     [InlineData("GradientOuterRadiusUnits")]
-    [InlineData("Red1")]
+    // Issue #3009 — Circle/Rectangle no longer expose the standalone gradient start
+    // (Red1/Green1/Blue1/Alpha1); the start is the active body color, so there is no such variable
+    // to gate. Color2 (Red2/Green2/Blue2/Alpha2) remains the standalone second stop and is gated.
     [InlineData("Alpha2")]
     // CornerRadius (Rectangle-only v3 surface absorbed from the retired RoundedRectangle)
     [InlineData("CornerRadius")]

--- a/Tools/Gum.ProjectServices/Templates/Default/Standards/Circle.gutx
+++ b/Tools/Gum.ProjectServices/Templates/Default/Standards/Circle.gutx
@@ -3,17 +3,11 @@
   <Name>Circle</Name>
   <State>
     <Name>Default</Name>
-    <Variable Type="int" Name="Alpha1" Category="Rendering" SetsValue="true">
-      <Value xsi:type="xsd:int">255</Value>
-    </Variable>
     <Variable Type="int" Name="Alpha2" Category="Rendering" SetsValue="true">
       <Value xsi:type="xsd:int">255</Value>
     </Variable>
     <Variable Type="Blend" Name="Blend" Category="Rendering" SetsValue="true">
       <Value xsi:type="xsd:int">0</Value>
-    </Variable>
-    <Variable Type="int" Name="Blue1" Category="Rendering" SetsValue="true">
-      <Value xsi:type="xsd:int">255</Value>
     </Variable>
     <Variable Type="int" Name="Blue2" Category="Rendering" SetsValue="true">
       <Value xsi:type="xsd:int">0</Value>
@@ -93,9 +87,6 @@
     <Variable Type="PositionUnitType" Name="GradientY2Units" Category="Rendering" SetsValue="true">
       <Value xsi:type="xsd:int">1</Value>
     </Variable>
-    <Variable Type="int" Name="Green1" Category="Rendering" SetsValue="true">
-      <Value xsi:type="xsd:int">255</Value>
-    </Variable>
     <Variable Type="int" Name="Green2" Category="Rendering" SetsValue="true">
       <Value xsi:type="xsd:int">255</Value>
     </Variable>
@@ -122,9 +113,6 @@
     <Variable Type="float?" Name="MinHeight" Category="Dimensions" SetsValue="true" />
     <Variable Type="float?" Name="MinWidth" Category="Dimensions" SetsValue="true" />
     <Variable Type="string" Name="Parent" Category="Parent" SetsValue="true" />
-    <Variable Type="int" Name="Red1" Category="Rendering" SetsValue="true">
-      <Value xsi:type="xsd:int">255</Value>
-    </Variable>
     <Variable Type="int" Name="Red2" Category="Rendering" SetsValue="true">
       <Value xsi:type="xsd:int">255</Value>
     </Variable>

--- a/Tools/Gum.ProjectServices/Templates/Default/Standards/Rectangle.gutx
+++ b/Tools/Gum.ProjectServices/Templates/Default/Standards/Rectangle.gutx
@@ -3,17 +3,11 @@
   <Name>Rectangle</Name>
   <State>
     <Name>Default</Name>
-    <Variable Type="int" Name="Alpha1" Category="Rendering" SetsValue="true">
-      <Value xsi:type="xsd:int">255</Value>
-    </Variable>
     <Variable Type="int" Name="Alpha2" Category="Rendering" SetsValue="true">
       <Value xsi:type="xsd:int">255</Value>
     </Variable>
     <Variable Type="Blend" Name="Blend" Category="Rendering" SetsValue="true">
       <Value xsi:type="xsd:int">0</Value>
-    </Variable>
-    <Variable Type="int" Name="Blue1" Category="Rendering" SetsValue="true">
-      <Value xsi:type="xsd:int">255</Value>
     </Variable>
     <Variable Type="int" Name="Blue2" Category="Rendering" SetsValue="true">
       <Value xsi:type="xsd:int">0</Value>
@@ -96,9 +90,6 @@
     <Variable Type="PositionUnitType" Name="GradientY2Units" Category="Rendering" SetsValue="true">
       <Value xsi:type="xsd:int">1</Value>
     </Variable>
-    <Variable Type="int" Name="Green1" Category="Rendering" SetsValue="true">
-      <Value xsi:type="xsd:int">255</Value>
-    </Variable>
     <Variable Type="int" Name="Green2" Category="Rendering" SetsValue="true">
       <Value xsi:type="xsd:int">255</Value>
     </Variable>
@@ -125,9 +116,6 @@
     <Variable Type="float?" Name="MinHeight" Category="Dimensions" SetsValue="true" />
     <Variable Type="float?" Name="MinWidth" Category="Dimensions" SetsValue="true" />
     <Variable Type="string" Name="Parent" Category="Parent" SetsValue="true" />
-    <Variable Type="int" Name="Red1" Category="Rendering" SetsValue="true">
-      <Value xsi:type="xsd:int">255</Value>
-    </Variable>
     <Variable Type="int" Name="Red2" Category="Rendering" SetsValue="true">
       <Value xsi:type="xsd:int">255</Value>
     </Variable>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Standards/Circle.gutx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Standards/Circle.gutx
@@ -3,17 +3,11 @@
   <Name>Circle</Name>
   <State>
     <Name>Default</Name>
-    <Variable Type="int" Name="Alpha1" Category="Rendering" SetsValue="true">
-      <Value xsi:type="xsd:int">255</Value>
-    </Variable>
     <Variable Type="int" Name="Alpha2" Category="Rendering" SetsValue="true">
       <Value xsi:type="xsd:int">255</Value>
     </Variable>
     <Variable Type="Blend" Name="Blend" Category="Rendering" SetsValue="true">
       <Value xsi:type="xsd:int">0</Value>
-    </Variable>
-    <Variable Type="int" Name="Blue1" Category="Rendering" SetsValue="true">
-      <Value xsi:type="xsd:int">255</Value>
     </Variable>
     <Variable Type="int" Name="Blue2" Category="Rendering" SetsValue="true">
       <Value xsi:type="xsd:int">0</Value>
@@ -93,9 +87,6 @@
     <Variable Type="PositionUnitType" Name="GradientY2Units" Category="Rendering" SetsValue="true">
       <Value xsi:type="xsd:int">1</Value>
     </Variable>
-    <Variable Type="int" Name="Green1" Category="Rendering" SetsValue="true">
-      <Value xsi:type="xsd:int">255</Value>
-    </Variable>
     <Variable Type="int" Name="Green2" Category="Rendering" SetsValue="true">
       <Value xsi:type="xsd:int">255</Value>
     </Variable>
@@ -122,9 +113,6 @@
     <Variable Type="float?" Name="MinHeight" Category="Dimensions" SetsValue="true" />
     <Variable Type="float?" Name="MinWidth" Category="Dimensions" SetsValue="true" />
     <Variable Type="string" Name="Parent" Category="Parent" SetsValue="true" />
-    <Variable Type="int" Name="Red1" Category="Rendering" SetsValue="true">
-      <Value xsi:type="xsd:int">255</Value>
-    </Variable>
     <Variable Type="int" Name="Red2" Category="Rendering" SetsValue="true">
       <Value xsi:type="xsd:int">255</Value>
     </Variable>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Standards/Rectangle.gutx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Standards/Rectangle.gutx
@@ -3,17 +3,11 @@
   <Name>Rectangle</Name>
   <State>
     <Name>Default</Name>
-    <Variable Type="int" Name="Alpha1" Category="Rendering" SetsValue="true">
-      <Value xsi:type="xsd:int">255</Value>
-    </Variable>
     <Variable Type="int" Name="Alpha2" Category="Rendering" SetsValue="true">
       <Value xsi:type="xsd:int">255</Value>
     </Variable>
     <Variable Type="Blend" Name="Blend" Category="Rendering" SetsValue="true">
       <Value xsi:type="xsd:int">0</Value>
-    </Variable>
-    <Variable Type="int" Name="Blue1" Category="Rendering" SetsValue="true">
-      <Value xsi:type="xsd:int">255</Value>
     </Variable>
     <Variable Type="int" Name="Blue2" Category="Rendering" SetsValue="true">
       <Value xsi:type="xsd:int">0</Value>
@@ -96,9 +90,6 @@
     <Variable Type="PositionUnitType" Name="GradientY2Units" Category="Rendering" SetsValue="true">
       <Value xsi:type="xsd:int">1</Value>
     </Variable>
-    <Variable Type="int" Name="Green1" Category="Rendering" SetsValue="true">
-      <Value xsi:type="xsd:int">255</Value>
-    </Variable>
     <Variable Type="int" Name="Green2" Category="Rendering" SetsValue="true">
       <Value xsi:type="xsd:int">255</Value>
     </Variable>
@@ -125,9 +116,6 @@
     <Variable Type="float?" Name="MinHeight" Category="Dimensions" SetsValue="true" />
     <Variable Type="float?" Name="MinWidth" Category="Dimensions" SetsValue="true" />
     <Variable Type="string" Name="Parent" Category="Parent" SetsValue="true" />
-    <Variable Type="int" Name="Red1" Category="Rendering" SetsValue="true">
-      <Value xsi:type="xsd:int">255</Value>
-    </Variable>
     <Variable Type="int" Name="Red2" Category="Rendering" SetsValue="true">
       <Value xsi:type="xsd:int">255</Value>
     </Variable>

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Standards/Circle.gutx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Standards/Circle.gutx
@@ -3,17 +3,11 @@
   <Name>Circle</Name>
   <State>
     <Name>Default</Name>
-    <Variable Type="int" Name="Alpha1" Category="Rendering" SetsValue="true">
-      <Value xsi:type="xsd:int">255</Value>
-    </Variable>
     <Variable Type="int" Name="Alpha2" Category="Rendering" SetsValue="true">
       <Value xsi:type="xsd:int">255</Value>
     </Variable>
     <Variable Type="Blend" Name="Blend" Category="Rendering" SetsValue="true">
       <Value xsi:type="xsd:int">0</Value>
-    </Variable>
-    <Variable Type="int" Name="Blue1" Category="Rendering" SetsValue="true">
-      <Value xsi:type="xsd:int">255</Value>
     </Variable>
     <Variable Type="int" Name="Blue2" Category="Rendering" SetsValue="true">
       <Value xsi:type="xsd:int">0</Value>
@@ -93,9 +87,6 @@
     <Variable Type="PositionUnitType" Name="GradientY2Units" Category="Rendering" SetsValue="true">
       <Value xsi:type="xsd:int">1</Value>
     </Variable>
-    <Variable Type="int" Name="Green1" Category="Rendering" SetsValue="true">
-      <Value xsi:type="xsd:int">255</Value>
-    </Variable>
     <Variable Type="int" Name="Green2" Category="Rendering" SetsValue="true">
       <Value xsi:type="xsd:int">255</Value>
     </Variable>
@@ -122,9 +113,6 @@
     <Variable Type="float?" Name="MinHeight" Category="Dimensions" SetsValue="true" />
     <Variable Type="float?" Name="MinWidth" Category="Dimensions" SetsValue="true" />
     <Variable Type="string" Name="Parent" Category="Parent" SetsValue="true" />
-    <Variable Type="int" Name="Red1" Category="Rendering" SetsValue="true">
-      <Value xsi:type="xsd:int">255</Value>
-    </Variable>
     <Variable Type="int" Name="Red2" Category="Rendering" SetsValue="true">
       <Value xsi:type="xsd:int">255</Value>
     </Variable>

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Standards/Rectangle.gutx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Standards/Rectangle.gutx
@@ -3,17 +3,11 @@
   <Name>Rectangle</Name>
   <State>
     <Name>Default</Name>
-    <Variable Type="int" Name="Alpha1" Category="Rendering" SetsValue="true">
-      <Value xsi:type="xsd:int">255</Value>
-    </Variable>
     <Variable Type="int" Name="Alpha2" Category="Rendering" SetsValue="true">
       <Value xsi:type="xsd:int">255</Value>
     </Variable>
     <Variable Type="Blend" Name="Blend" Category="Rendering" SetsValue="true">
       <Value xsi:type="xsd:int">0</Value>
-    </Variable>
-    <Variable Type="int" Name="Blue1" Category="Rendering" SetsValue="true">
-      <Value xsi:type="xsd:int">255</Value>
     </Variable>
     <Variable Type="int" Name="Blue2" Category="Rendering" SetsValue="true">
       <Value xsi:type="xsd:int">0</Value>
@@ -96,9 +90,6 @@
     <Variable Type="PositionUnitType" Name="GradientY2Units" Category="Rendering" SetsValue="true">
       <Value xsi:type="xsd:int">1</Value>
     </Variable>
-    <Variable Type="int" Name="Green1" Category="Rendering" SetsValue="true">
-      <Value xsi:type="xsd:int">255</Value>
-    </Variable>
     <Variable Type="int" Name="Green2" Category="Rendering" SetsValue="true">
       <Value xsi:type="xsd:int">255</Value>
     </Variable>
@@ -125,9 +116,6 @@
     <Variable Type="float?" Name="MinHeight" Category="Dimensions" SetsValue="true" />
     <Variable Type="float?" Name="MinWidth" Category="Dimensions" SetsValue="true" />
     <Variable Type="string" Name="Parent" Category="Parent" SetsValue="true" />
-    <Variable Type="int" Name="Red1" Category="Rendering" SetsValue="true">
-      <Value xsi:type="xsd:int">255</Value>
-    </Variable>
     <Variable Type="int" Name="Red2" Category="Rendering" SetsValue="true">
       <Value xsi:type="xsd:int">255</Value>
     </Variable>

--- a/docs/code/standard-visuals/shapes-apos.shapes.md
+++ b/docs/code/standard-visuals/shapes-apos.shapes.md
@@ -143,9 +143,8 @@ public class Game1 : Game
         rectangle.AddToRoot();
         rectangle.X = 100;
         rectangle.CornerRadius = 15;
-        rectangle.FillColor = Color.White; // light the fill up so the gradient draws
+        rectangle.FillColor = Color.Blue; // the fill color is the gradient start, so light it up
         rectangle.UseGradient = true;
-        rectangle.Color1 = Color.Blue;
         rectangle.Color2 = Color.Green;
 
         var arc = new ArcRuntime();
@@ -220,21 +219,19 @@ A `CircleRuntime` also exposes a `Radius` property, but sizing through `Width` /
 
 ### Gradient
 
-When `UseGradient` is `true`, the shape is filled with a gradient between `Color1` and `Color2` instead of the solid `FillColor`. The endpoints (`GradientX1`/`GradientY1` and `GradientX2`/`GradientY2`) define the gradient vector for `Linear` gradients; for `Radial` gradients only the start point and the radius properties are used.
+When `UseGradient` is `true`, the shape is filled with a gradient between the shape's fill/stroke color and `Color2` instead of a solid color. The gradient **start** color is the shape's active body color — `FillColor` when `IsFilled` is `true`, or `StrokeColor` when the shape is outline-only — and `Color2` is the **end** color. The endpoints (`GradientX1`/`GradientY1` and `GradientX2`/`GradientY2`) define the gradient vector for `Linear` gradients; for `Radial` gradients only the start point and the radius properties are used.
 
 | Property | Type | Description |
 | --- | --- | --- |
 | `UseGradient` | `bool` | If `true`, the gradient properties drive the fill. If `false`, the solid `FillColor` is used. |
 | `GradientType` | `GradientType` | `Linear` (the default) or `Radial`. |
-| `Color1` | `Color` | The first gradient color. Shortcut for setting `Red1`, `Green1`, `Blue1`, and `Alpha1`. |
-| `Red1`, `Green1`, `Blue1`, `Alpha1` | `int` | Channels for the first gradient color (0–255). |
-| `Color2` | `Color` | The second gradient color. Shortcut for setting `Red2`, `Green2`, `Blue2`, and `Alpha2`. |
+| `Color2` | `Color` | The second (end) gradient color. The start color is the shape's `FillColor` (or `StrokeColor` when outline-only). Shortcut for setting `Red2`, `Green2`, `Blue2`, and `Alpha2`. |
 | `Red2`, `Green2`, `Blue2`, `Alpha2` | `int` | Channels for the second gradient color (0–255). |
 | `GradientX1`, `GradientY1` | `float` | Coordinates of the gradient start point. Interpretation depends on the matching `Units` value. |
 | `GradientX1Units`, `GradientY1Units` | `GeneralUnitType` | Coordinate system used to interpret `GradientX1` / `GradientY1`. |
 | `GradientX2`, `GradientY2` | `float` | Coordinates of the gradient end point (`Linear` gradients only). |
 | `GradientX2Units`, `GradientY2Units` | `GeneralUnitType` | Coordinate system used to interpret `GradientX2` / `GradientY2`. |
-| `GradientInnerRadius` | `float` | Inner radius (`Radial` gradients only). Inside this radius the shape is filled with `Color1`. |
+| `GradientInnerRadius` | `float` | Inner radius (`Radial` gradients only). Inside this radius the shape is filled with the start color. |
 | `GradientInnerRadiusUnits` | `DimensionUnitType` | Unit type for `GradientInnerRadius`. `Absolute` (pixels), `PercentageOfParent` (percentage of the shape's `Width`, so `100` = `Width`), or `RelativeToParent` (pixel offset from the shape's `Width`, so `0` = `Width` and `-10` = `Width − 10`). The shape's natural inscribed radius is `Width / 2` — to fit a circle inside the shape, use `50` (`PercentageOfParent`) or `-Width/2` (`RelativeToParent`). |
 | `GradientOuterRadius` | `float` | Outer radius at which the gradient has fully blended to `Color2` (`Radial` gradients only). |
 | `GradientOuterRadiusUnits` | `DimensionUnitType` | Unit type for `GradientOuterRadius`. Same options as `GradientInnerRadiusUnits`. |
@@ -297,9 +294,8 @@ var rectangle = new RectangleRuntime();
 rectangle.Width = 200;
 rectangle.Height = 80;
 rectangle.CornerRadius = 12;
-rectangle.FillColor = Color.White; // light up the fill so the gradient draws
+rectangle.FillColor = Color.Blue; // the fill color is the gradient start, so light it up
 rectangle.UseGradient = true;
-rectangle.Color1 = Color.Blue;
 rectangle.Color2 = Color.Green;
 container.Children.Add(rectangle);
 ```

--- a/docs/gum-tool/gum-elements/shape-properties/use-gradient.md
+++ b/docs/gum-tool/gum-elements/shape-properties/use-gradient.md
@@ -14,13 +14,19 @@ If this value is set to true, then additional properties appear for controlling 
 
 <figure><img src="../../../.gitbook/assets/30_04 46 05.png" alt=""><figcaption><p>Rectangle with Use Gradient set to true showing gradient values</p></figcaption></figure>
 
-### Color1 and Color 2
+### Gradient start color and Color2
 
-Gradients create a smooth interpolation of color from Color 1 to Color2.
+A gradient creates a smooth interpolation from a start color to **Color2**.
 
-Changing these values adjusts the gradient start and end colors.
+For **Circle**, **Rectangle**, and **Arc**, the gradient starts from the shape's own color — for Circle and Rectangle that is the **Fill** color when the shape is filled or the **Stroke** color when it is outline-only, and for Arc it is the shape's **Color**. To adjust where the gradient begins, change that color; to adjust where it ends, change **Color2**. Because the start is the color the shape already shows, turning **Use Gradient** on and off does not produce a sudden color change.
+
+The older **ColoredCircle** and **RoundedRectangle** shapes instead expose a dedicated **Color1** for the gradient start.
 
 <figure><img src="../../../.gitbook/assets/30_04 48 09.gif" alt=""><figcaption><p>Gradient Color values</p></figcaption></figure>
+
+{% hint style="info" %}
+Earlier preview builds gave **Circle** and **Rectangle** a separate **Color1** for the gradient start. The start is now the shape's **Fill**/**Stroke** color, so **Color1** no longer appears for these shapes. **Arc** likewise derives its gradient start from its **Color**.
+{% endhint %}
 
 ### Gradient X1 and 2, Gradient Y1 and 2
 

--- a/docs/gum-tool/upgrading/migrating-to-2026-june.md
+++ b/docs/gum-tool/upgrading/migrating-to-2026-june.md
@@ -430,7 +430,7 @@ var circle = new CircleRuntime();
 circle.Width = 56;
 circle.Height = 56;
 circle.UseGradient = true;
-circle.Color1 = Color.Black;
+circle.FillColor = Color.Black;
 circle.Color2 = Color.White;
 // Gradient appeared on the fill on Apos and raylib — even though FillColor
 // defaults to transparent, which is supposed to hide the fill.
@@ -442,13 +442,55 @@ circle.Color2 = Color.White;
 var circle = new CircleRuntime();
 circle.Width = 56;
 circle.Height = 56;
-circle.FillColor = Color.White;   // light the fill up — opaque, RGB irrelevant
+circle.FillColor = Color.Black;   // light the fill up and set the gradient start
 circle.UseGradient = true;
-circle.Color1 = Color.Black;
 circle.Color2 = Color.White;
 ```
 
-The RGB of `FillColor` doesn't matter — the gradient overrides the per-pixel color. Only the alpha gates whether the fill paints at all. `StrokeColor` works the same way for the outline on backends that support gradient-on-stroke (Skia and Apos.Shapes; raylib's outline is solid only).
+Only the alpha of `FillColor` gates whether the fill paints at all. `StrokeColor` works the same way for the outline on backends that support gradient-on-stroke (Skia and Apos.Shapes; raylib's outline is solid only).
+
+### Breaking: `Color1` removed from `CircleRuntime` / `RectangleRuntime` — gradient start is now the fill/stroke color
+
+Issue #3009 — `CircleRuntime` and `RectangleRuntime` no longer have a standalone gradient **start** color. Previously the gradient ran between a dedicated `Color1` (`Red1` / `Green1` / `Blue1` / `Alpha1`) and `Color2`. Now the gradient **start** stop is the shape's active body color — `FillColor` when `IsFilled` is `true`, or `StrokeColor` when the shape is outline-only — and `Color2` (`Red2` / `Green2` / `Blue2` / `Alpha2`) remains the only standalone gradient color (the **end** stop). This removes the redundancy of having a fill color and a separate gradient-start color that had to be kept in sync.
+
+On the XNA-likes (MonoGame / FNA / KNI) and raylib, `Color1` / `Red1` / `Green1` / `Blue1` / `Alpha1` are **removed** from `CircleRuntime` / `RectangleRuntime` — code referencing them no longer compiles. On Skia the same members are `[Obsolete(error: true)]`, so they also fail to compile.
+
+To migrate, drop the `Color1` assignment and set the start color through `FillColor` (light up the fill so the gradient draws) — or through `StrokeColor` for an outline-only shape:
+
+❌ Old:
+
+```csharp
+// Initialize
+var circle = new CircleRuntime();
+circle.Width = 56;
+circle.Height = 56;
+circle.UseGradient = true;
+circle.Color1 = Color.Black;   // gradient start
+circle.Color2 = Color.White;   // gradient end
+circle.AddToRoot();
+```
+
+✅ New:
+
+```csharp
+// Initialize
+var circle = new CircleRuntime();
+circle.Width = 56;
+circle.Height = 56;
+circle.IsFilled = true;          // ensure the fill (and thus the start color) draws
+circle.FillColor = Color.Black;  // gradient start is now the fill color
+circle.UseGradient = true;
+circle.Color2 = Color.White;     // gradient end
+circle.AddToRoot();
+```
+
+For an outline-only shape (`IsFilled = false`), set `StrokeColor` as the start color instead.
+
+{% hint style="info" %}
+**`ArcRuntime` keeps `Color1` as an obsolete alias.** Arc's gradient start is its primary `Color`, so `Color1` (`Red1` / `Green1` / `Blue1` / `Alpha1`) survives on `ArcRuntime` only as a `[Obsolete]` (warning) back-compat shim that maps onto `Color`. New Arc code should use `Color` for the gradient start. The alias is expected to be removed around November 2026.
+
+The legacy `ColoredCircleRuntime` and `RoundedRectangleRuntime` are **unchanged** — they keep their real `Color1` gradient-start property.
+{% endhint %}
 
 ### Forms controls moved to GumCommon — input types widened
 


### PR DESCRIPTION
## Summary

Collapses the standalone gradient `Color1` (`Red1`/`Green1`/`Blue1`/`Alpha1`) on **Circle** and **Rectangle** so the gradient **start stop is the active body color** — `FillColor` when `IsFilled`, `StrokeColor` when stroke-only. `Color2` remains the only standalone gradient color. New mental model: *a shape has a primary color (its fill/stroke), plus an optional second color for a gradient.*

This removes the startling solid↔gradient color jump when toggling `UseGradient`, and — because the Apos renderable scales the dropshadow by the slot's `Color.A` and reads the gradient start from `Red1..Alpha1` — converges the dropshadow alpha onto the gradient start alpha (the reported "shadow tracks the wrong opacity" symptom).

Closes #3009.

## Approach by area

**Runtime (cross-platform parity: Apos/MonoGame, Skia, Raylib; Sokol compiles):**
- **XNALIKE & Raylib** (`MonoGameGum/GueDeriving/CircleRuntime.cs`, `RectangleRuntime.cs`): dropped the standalone `Color1`/`Red1..Alpha1` members; added `SyncGradientStart()` (called from the `FillColor`/`StrokeColor`/`IsFilled` setters + constructor) that mirrors each slot's body color into its renderable gradient-start channels.
- **Skia** (`SkiaShapeRuntime`): added a two-slot-gated `SyncGradientStartToBody()` invoked from the shared color/fill setters (legacy single-slot shapes unaffected); Circle/Rectangle `[Obsolete(error)]` `new`-shadow `Color1`/`Red1..Alpha1` to steer callers to `FillColor`/`StrokeColor`.
- **Arc** (`Runtimes/SkiaGum/GueDeriving/ArcRuntime.cs`): the **only** shape needing back-compat. Keeps `Color1`/`Red1..Alpha1` as `[Obsolete]` shims mapping onto the primary `Color`; a `PreRender` override mirrors the primary color into the renderable's gradient-start channels. `CustomSetPropertyOnRenderable` routes the old Arc channel names onto the primary `Color`. Removal of the obsoletes targeted for ~Nov 2026.
- Legacy `ColoredCircleRuntime` / `RoundedRectangleRuntime` left unchanged.

**Tool:** `StandardElementsManager.AddGradientVariables` omits the start channels for Circle/Rectangle (parameterized); `ShapeVariableExclusionLogic` always hides `Red1..Alpha1` for Arc (leaving Arc a single primary `Color`) while legacy shapes keep their UseGradient-gated `Color1`; `ShapeVariableVersionGate` drops the `…1` channels from the v3 surface. The composite `Color1` swatch is dropped automatically (channels absent for Circle/Rectangle, excluded for Arc).

**Data migration:** `StripCircleRectangleGradientColor1` removes orphaned `Red1/Green1/Blue1/Alpha1` from Circle/Rectangle elements and instances on load (resolves the root standard via `ObjectFinder`, so Arc and legacy shapes are skipped), wired into `ProjectManager` alongside the radius migration with `wasModified` re-save.

**Standards / themes / samples / docs:** Regenerated the six Circle/Rectangle `.gutx` standards (Default, FormsTemplate, Bubblegum). Migrated the ForestGlade theme visuals and the gallery / raylib / SilkNet sample screens from `.Color1` to `.FillColor`. Updated `use-gradient.md`, `shapes-apos.shapes.md`, and `migrating-to-2026-june.md`.

**Versioning:** `GumSyntaxVersion` left at 2 (per maintainer decision); the v3 `GumxVersions.ShapeVariableExpansion` surface is edited in place (unshipped).

## ⚠️ Arc lossy migration — needs your sign-off

Per the locked design, the single accepted lossy case is pinned by a test rather than engineered around. Old Arc data set the solid channels (`Color`/`Red`/…) **and** the legacy start channels (`Red1`/…) independently. Both now remap onto the primary `Color`, and Gum applies variables **alphabetically** — so the `…1` channels apply *after* the solid ones and **win**:

| Old Arc case | Result | Visible loss |
|---|---|---|
| `UseGradient = true` | start = old `Color1`, end = `Color2` | No |
| Solid only, gradient untouched | `Red1…` at default → not serialized | No |
| `UseGradient = false` **and** `Color1` explicitly ≠ `Color` | solid now shows old `Color1` | **Yes** (rare) |

Pinned by `ArcRuntimeTests.Load_Color1WinsOverColor_OnPrimary_DocumentingLossyCase`. Please confirm the lossy outcome is acceptable.

## Out of scope (follow-ups)
- Max-of-stop-alphas dropshadow fix / Apos↔Skia shadow divergence.
- `RoundedRectangle`/`ColoredCircle` retirement.

## Verification
Built `GumFull.sln` (0 errors). Green: MonoGameGum.Tests (1585), MonoGameGum.Shapes.Tests (202), SkiaGum.Tests (185), RaylibGum.Tests (134), Gum.ProjectServices.Tests (248), GumToolUnitTests (790). `AllLibraries.sln`/FNA and Sokol rely on CI (FNA submodule not present locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
