### PR TITLE
Don't add ColoredCircle/RoundedRectangle Skia standards on V3+ projects (#3011)

### DIFF
--- a/Gum/GumFormsPlugin/Services/ThemeRequirements.cs
+++ b/Gum/GumFormsPlugin/Services/ThemeRequirements.cs
@@ -30,12 +30,20 @@ public sealed class ThemeRequirements
     public FontGeneratorType? FontGenerator { get; init; }
 
     /// <summary>
-    /// True when the theme uses any Skia-backed Standard (e.g. RoundedRectangle,
-    /// ColoredCircle). When set, the apply step adds the full Skia shape bundle
-    /// via <see cref="ISkiaShapeStandardsLogic.AddAllStandards"/> — Arc, Canvas,
-    /// ColoredCircle, Line, LottieAnimation, RoundedRectangle, Svg.
+    /// True when the theme uses any Skia-backed Standard (e.g. Svg, Canvas, Arc).
+    /// When set, the apply step adds the Skia shape bundle via
+    /// <see cref="ISkiaShapeStandardsLogic.AddAllStandards"/> — Arc, Canvas, Line,
+    /// LottieAnimation, Svg, plus the legacy ColoredCircle / RoundedRectangle on
+    /// pre-v3 projects only (V3+ projects use the plain Circle / Rectangle instead).
     /// </summary>
     public bool RequiresSkiaShapes { get; init; }
+
+    /// <summary>
+    /// The standard element whose presence proves the Skia shape bundle is already in the project.
+    /// Svg is used because it is added on every project version (unlike the legacy ColoredCircle /
+    /// RoundedRectangle, which are no longer added on V3+), making it a version-proof sentinel.
+    /// </summary>
+    private const string SkiaShapeBundleSentinel = "Svg";
 
     public static ThemeRequirements LoadFromThemeDirectory(string themeDirectory)
     {
@@ -87,9 +95,9 @@ public sealed class ThemeRequirements
 
     /// <summary>
     /// Compares the requirements against <paramref name="project"/> and returns
-    /// the changes the import would need to apply. <c>RoundedRectangle</c>'s
-    /// presence is the proxy for "this project already has Skia shapes" — the
-    /// apply step is idempotent so a more thorough check isn't necessary.
+    /// the changes the import would need to apply. <c>Svg</c>'s presence is the
+    /// proxy for "this project already has Skia shapes" — the apply step is
+    /// idempotent so a more thorough check isn't necessary.
     /// </summary>
     public ThemeRequirementsDiff Diff(GumProjectSave project)
     {
@@ -100,7 +108,7 @@ public sealed class ThemeRequirements
 
         bool addSkiaShapes = RequiresSkiaShapes &&
             !project.StandardElementReferences.Any(r =>
-                string.Equals(r.Name, "RoundedRectangle", StringComparison.OrdinalIgnoreCase));
+                string.Equals(r.Name, SkiaShapeBundleSentinel, StringComparison.OrdinalIgnoreCase));
 
         return new ThemeRequirementsDiff(fontGenChange, project.FontGenerator, addSkiaShapes);
     }
@@ -144,8 +152,7 @@ public sealed class ThemeRequirementsDiff
         }
         if (AddSkiaShapes)
         {
-            lines.Add("Add Skia shape Standards (Arc, Canvas, ColoredCircle, Line, " +
-                      "LottieAnimation, RoundedRectangle, Svg).");
+            lines.Add("Add Skia shape Standards (Arc, Canvas, Line, LottieAnimation, Svg).");
         }
         return lines;
     }

--- a/Gum/Logic/ISkiaShapeStandardsLogic.cs
+++ b/Gum/Logic/ISkiaShapeStandardsLogic.cs
@@ -1,8 +1,11 @@
 namespace Gum.Logic;
 
 /// <summary>
-/// Adds the Skia-backed Standard elements (Arc, Canvas, ColoredCircle, Line,
-/// LottieAnimation, RoundedRectangle, Svg) to the currently-loaded project.
+/// Adds the Skia-backed Standard elements to the currently-loaded project: Arc,
+/// Canvas, Line, LottieAnimation, Svg always, plus the legacy ColoredCircle /
+/// RoundedRectangle on pre-v3 projects only. On v3
+/// (<see cref="Gum.DataTypes.GumProjectSave.GumxVersions.ShapeVariableExpansion"/>)
+/// or later the plain Circle / Rectangle supersede those two, so they are skipped.
 /// </summary>
 /// <remarks>
 /// Historically this lived inside the SkiaPlugin, since Skia was an add-on.

--- a/Gum/Logic/SkiaShapeStandardsLogic.cs
+++ b/Gum/Logic/SkiaShapeStandardsLogic.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using System.Linq;
 using Gum.Commands;
 using Gum.DataTypes;
@@ -14,6 +16,23 @@ public class SkiaShapeStandardsLogic : ISkiaShapeStandardsLogic
 {
     private const string EmbeddedResourcePrefix = "Gum.Embedded.SkiaShapes.";
 
+    /// <summary>
+    /// The full Skia shape bundle in add order. <see cref="IsLegacyShape"/> marks the two shapes
+    /// (ColoredCircle, RoundedRectangle) that were superseded by the v3
+    /// (<see cref="GumProjectSave.GumxVersions.ShapeVariableExpansion"/>) Circle / Rectangle
+    /// variable surface and so are no longer added on V3+ projects.
+    /// </summary>
+    private static readonly (string Name, Func<StateSave> GetState, bool IsLegacyShape)[] AllStandards =
+    {
+        ("Arc", StandardElementsManager.GetArcState, false),
+        ("Canvas", StandardElementsManager.GetCanvasState, false),
+        ("ColoredCircle", StandardElementsManager.GetColoredCircleState, true),
+        ("Line", StandardElementsManager.GetLineState, false),
+        ("LottieAnimation", StandardElementsManager.GetLottieAnimationState, false),
+        ("RoundedRectangle", StandardElementsManager.GetRoundedRectangleState, true),
+        ("Svg", StandardElementsManager.GetSvgState, false),
+    };
+
     private readonly IFileCommands _fileCommands;
     private readonly StandardElementsManagerGumTool _standardElementsManagerGumTool;
     private readonly IProjectState _projectState;
@@ -28,15 +47,34 @@ public class SkiaShapeStandardsLogic : ISkiaShapeStandardsLogic
         _projectState = projectState;
     }
 
+    /// <summary>
+    /// The Skia standard element names to add for a project at <paramref name="projectVersion"/>.
+    /// On V3 (<see cref="GumProjectSave.GumxVersions.ShapeVariableExpansion"/>) or later the legacy
+    /// ColoredCircle / RoundedRectangle are omitted — the plain Circle / Rectangle absorbed their
+    /// fill / gradient / dropshadow / corner-radius surface, so adding them would only clutter the
+    /// project with superseded shapes. Pure decision logic (no project state) so it can be unit tested.
+    /// </summary>
+    internal static IReadOnlyList<string> GetStandardNamesToAdd(int projectVersion)
+    {
+        bool isV3OrLater = projectVersion >= (int)GumProjectSave.GumxVersions.ShapeVariableExpansion;
+        return AllStandards
+            .Where(standard => !isV3OrLater || !standard.IsLegacyShape)
+            .Select(standard => standard.Name)
+            .ToList();
+    }
+
     public void AddAllStandards()
     {
-        AddStandard("Arc", StandardElementsManager.GetArcState());
-        AddStandard("Canvas", StandardElementsManager.GetCanvasState());
-        AddStandard("ColoredCircle", StandardElementsManager.GetColoredCircleState());
-        AddStandard("Line", StandardElementsManager.GetLineState());
-        AddStandard("LottieAnimation", StandardElementsManager.GetLottieAnimationState());
-        AddStandard("RoundedRectangle", StandardElementsManager.GetRoundedRectangleState());
-        AddStandard("Svg", StandardElementsManager.GetSvgState());
+        int projectVersion = _projectState.GumProjectSave?.Version ?? 0;
+        HashSet<string> namesToAdd = GetStandardNamesToAdd(projectVersion).ToHashSet();
+
+        foreach ((string name, Func<StateSave> getState, _) in AllStandards)
+        {
+            if (namesToAdd.Contains(name))
+            {
+                AddStandard(name, getState());
+            }
+        }
     }
 
     private void AddStandard(string standardName, StateSave defaultState)

--- a/Tool/Tests/GumToolUnitTests/FormsPlugin/ThemeRequirementsTests.cs
+++ b/Tool/Tests/GumToolUnitTests/FormsPlugin/ThemeRequirementsTests.cs
@@ -46,12 +46,15 @@ public class ThemeRequirementsTests
     }
 
     [Fact]
-    public void Diff_SkipsSkiaShapeAdd_WhenRoundedRectangleAlreadyPresent()
+    public void Diff_SkipsSkiaShapeAdd_WhenSvgAlreadyPresent()
     {
+        // Svg is the "already has the Skia bundle" proxy: it is added on every project version
+        // (unlike the legacy RoundedRectangle / ColoredCircle, which are no longer added on V3+),
+        // so its presence is the version-proof signal that the bundle is in place.
         var project = new GumProjectSave();
         project.StandardElementReferences.Add(new ElementReference
         {
-            Name = "RoundedRectangle",
+            Name = "Svg",
             ElementType = ElementType.Standard,
         });
 
@@ -63,12 +66,31 @@ public class ThemeRequirementsTests
     }
 
     [Fact]
+    public void Diff_AddsSkiaShapes_WhenOnlyLegacyShapePresent()
+    {
+        // A V3+ project no longer gets RoundedRectangle added, so RoundedRectangle's presence must
+        // NOT be treated as proof the Skia bundle exists. A project that somehow has only the legacy
+        // shape (e.g. an old project) but not Svg should still have the bundle applied.
+        var project = new GumProjectSave();
+        project.StandardElementReferences.Add(new ElementReference
+        {
+            Name = "RoundedRectangle",
+            ElementType = ElementType.Standard,
+        });
+
+        var requirements = ThemeRequirements.Parse("RequiresSkiaShapes: true");
+
+        var diff = requirements.Diff(project);
+        diff.AddSkiaShapes.ShouldBeTrue();
+    }
+
+    [Fact]
     public void Diff_NoChanges_WhenProjectAlreadySatisfiesRequirements()
     {
         var project = new GumProjectSave { FontGenerator = FontGeneratorType.KernSmith };
         project.StandardElementReferences.Add(new ElementReference
         {
-            Name = "RoundedRectangle",
+            Name = "Svg",
             ElementType = ElementType.Standard,
         });
 

--- a/Tool/Tests/GumToolUnitTests/Logic/SkiaShapeStandardsLogicTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Logic/SkiaShapeStandardsLogicTests.cs
@@ -1,0 +1,46 @@
+using System.Collections.Generic;
+using Gum.DataTypes;
+using Gum.Logic;
+using Shouldly;
+using Xunit;
+
+namespace GumToolUnitTests.Logic;
+
+public class SkiaShapeStandardsLogicTests
+{
+    private const int OlderThanV3 = (int)GumProjectSave.GumxVersions.AttributeVersion;
+    private const int V3 = (int)GumProjectSave.GumxVersions.ShapeVariableExpansion;
+
+    [Fact]
+    public void GetStandardNamesToAdd_IncludesLegacyShapes_OnPreV3Project()
+    {
+        IReadOnlyList<string> names = SkiaShapeStandardsLogic.GetStandardNamesToAdd(OlderThanV3);
+
+        names.ShouldBe(new[]
+        {
+            "Arc", "Canvas", "ColoredCircle", "Line", "LottieAnimation", "RoundedRectangle", "Svg",
+        });
+    }
+
+    [Fact]
+    public void GetStandardNamesToAdd_OmitsLegacyShapes_OnV3Project()
+    {
+        IReadOnlyList<string> names = SkiaShapeStandardsLogic.GetStandardNamesToAdd(V3);
+
+        names.ShouldNotContain("ColoredCircle");
+        names.ShouldNotContain("RoundedRectangle");
+    }
+
+    [Fact]
+    public void GetStandardNamesToAdd_AlwaysIncludesNonLegacyShapes()
+    {
+        IReadOnlyList<string> preV3 = SkiaShapeStandardsLogic.GetStandardNamesToAdd(OlderThanV3);
+        IReadOnlyList<string> v3 = SkiaShapeStandardsLogic.GetStandardNamesToAdd(V3);
+
+        foreach (string name in new[] { "Arc", "Canvas", "Line", "LottieAnimation", "Svg" })
+        {
+            preV3.ShouldContain(name);
+            v3.ShouldContain(name);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

When adding Skia shapes to a project, the tool no longer adds the legacy `ColoredCircle` and `RoundedRectangle` standard elements on **V3 (`GumxVersions.ShapeVariableExpansion`) or later** projects. As of V3 the plain `Circle` / `Rectangle` standards absorbed the fill / gradient / dropshadow / corner-radius surface those two legacy shapes used to provide, so adding them on a V3+ project only clutters it with superseded shapes.

Closes #3011.

## What changed

- **`SkiaShapeStandardsLogic`** — `AddAllStandards` now drives off a single `AllStandards` table (name + state factory + `IsLegacyShape` flag) and a pure, unit-tested `GetStandardNamesToAdd(int projectVersion)` decision. On V3+ the two legacy shapes are omitted; `Arc` / `Canvas` / `Line` / `LottieAnimation` / `Svg` are always added. Pre-V3 projects keep getting the legacy shapes for backward compatibility. Existing legacy shapes already in a project are left untouched (skip-add only, no removal).
- **`ThemeRequirements.Diff`** — previously used "project contains `RoundedRectangle`" as the proxy for "already has the Skia bundle." That proxy breaks on V3+ once `RoundedRectangle` is no longer added (every theme apply would re-report "needs Skia shapes"). Switched the sentinel to **`Svg`**, which is added on every project version. Updated `DescribeChanges()` text and the related doc comments to match.

Both callers — **Plugins → Add Skia Standard Elements** and `ThemeRequirementsDiff.Apply` — route through `AddAllStandards`, so the single gate covers both.

## Scope

Tool-side authoring only (don't add the legacy standards when adding Skia controls to an existing project). Runtime `ColoredCircleRuntime` / `RoundedRectangleRuntime` types, the embedded `.gutx` resources, and codegen are intentionally out of scope — old projects keep working as-is.

## Testing

- New `SkiaShapeStandardsLogicTests` covers both version branches of `GetStandardNamesToAdd` (legacy shapes present pre-V3, omitted on V3+, non-legacy always present).
- Updated `ThemeRequirementsTests` for the `Svg` sentinel, including a new test asserting a project with only the legacy `RoundedRectangle` (and no `Svg`) still gets the bundle applied.
- Full `GumToolUnitTests` suite: **805 passed, 5 skipped, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
