### PR TITLE
Fix multi-instance delete deselecting entire screen (#3025)

### DIFF
--- a/.claude/skills/gum-tool-delete-logic/SKILL.md
+++ b/.claude/skills/gum-tool-delete-logic/SKILL.md
@@ -38,6 +38,10 @@ Used for screens, components, behaviors, and instances. All go through one share
 | `IEditCommands` / `EditCommands` | All user-triggered deletes. Shows dialogs, acquires undo locks, then delegates to `IDeleteLogic`. Only entry point callers should use. |
 | `IDeleteLogic` / `DeleteLogic` | Pure data mutation after confirmation. `Remove*` methods do not show dialogs. `HandleDeleteCommand` is the exception — it orchestrates the DeleteOptionsWindow flow and is only called from `EditCommands.DeleteSelection`. |
 
+## Post-delete selection
+
+After removing instances, selection must fall back to a surviving sibling → parent instance → owning element, or the editor goes blank. Both the single-instance (`PerformConfirmedSingleInstanceDelete`) and multi-instance (`PerformConfirmedMixedTypeDelete`) paths funnel through one helper, `SelectAfterInstanceRemoval`.
+
 ## Callers
 
 All delete actions funnel through `IEditCommands`:

--- a/.claude/skills/skills-writer/SKILL.md
+++ b/.claude/skills/skills-writer/SKILL.md
@@ -7,9 +7,9 @@ description: Creates and updates skill files (.claude/skills/*/SKILL.md). Trigge
 
 ## Mental Model
 
-A skill is **a map and a list of landmines** — not an encyclopedia. It points an agent at the right code and docs, and warns about things that are not obvious from reading either. If a fact is already in source or in `docs/`, the skill should *link*, not restate.
+A skill is **a map and a list of landmines**, not an encyclopedia. It points an agent at the right code and docs and warns about what isn't obvious from reading them. If a fact already lives in source or `docs/`, **link, don't restate**.
 
-Think **signpost, not explanation**: a short pointer plus a direction ("the wiring lives in X; watch out for Y"), never a lengthy walkthrough or a code dump. Brevity is a feature, not a compromise — every line is re-read into context on every load, so a skill that explains *less* but points *accurately* is doing its job better than a thorough one.
+A good skill answers three things and stops: **where** the relevant code/docs live, **what gotchas** aren't obvious from reading them, and **what patterns** recur. Default to prose-free pointers and tables; include code only when the snippet is a pattern that can't be conveyed by pointing at a file. Every line is re-read into context on every load, so a skill that says *less* but points *accurately* beats a thorough one.
 
 ## Authoritative Sources (do not duplicate)
 
@@ -18,8 +18,6 @@ Before writing anything, identify where the ground truth already lives:
 - **Source code** — class outlines, property lists, method signatures, call sites.
 - **`docs/` GitBook tree** — user-facing behavior, layout rules, control APIs, tutorials. If a topic has a docs page, link to it.
 - **Other skills** — cross-reference instead of copying. (`gum-layout` and `gum-layout-engine`, for example, deliberately split shallow vs. deep.)
-
-A skill earns its place by covering what these sources *don't*: internal architecture, why pieces fit together, and gotchas.
 
 ## Process
 
@@ -58,8 +56,6 @@ Bad (boilerplate, padded):
 ```
 description: Reference guide for Gum's undo/redo system. Load this when working on undo/redo behavior, the History tab, UndoManager, UndoPlugin, UndoSnapshot, or stale reference issues after undo.
 ```
-
-Multiply by every skill, every session. It adds up.
 
 ## Include
 

--- a/Gum/Managers/DeleteLogic.cs
+++ b/Gum/Managers/DeleteLogic.cs
@@ -259,20 +259,12 @@ public class DeleteLogic : IDeleteLogic
 
         if (deletedSelection)
         {
-            var index = siblings.IndexOf(selectedInstance);
-            if (index + 1 < siblings.Count)
-            {
-                _selectedState.SelectedInstance = siblings[index + 1];
-            }
-            else if (index > 0)
-            {
-                _selectedState.SelectedInstance = siblings[index - 1];
-            }
-            else
-            {
-                // no siblings so select the container or null if none exists:
-                _selectedState.SelectedInstance = parentInstance;
-            }
+            SelectAfterInstanceRemoval(
+                siblings,
+                siblings.IndexOf(selectedInstance),
+                new List<InstanceSave> { selectedInstance },
+                parentInstance,
+                selectedElement);
         }
     }
 
@@ -416,7 +408,7 @@ public class DeleteLogic : IDeleteLogic
         if (deletableInstances.Count > 0)
         {
             DeselectInstances(deletableInstances);
-            SelectAfterMultiInstanceRemoval(anchorSiblings, anchorIndex, deletableInstances, anchorParentInstance, anchorElement);
+            SelectAfterInstanceRemoval(anchorSiblings, anchorIndex, deletableInstances, anchorParentInstance, anchorElement);
         }
 
         // 7. Refresh and save for instance parents that were not themselves deleted
@@ -437,12 +429,13 @@ public class DeleteLogic : IDeleteLogic
     }
 
     /// <summary>
-    /// Picks the selection after a multi-instance delete so the editor never goes blank
-    /// (issue #3025). Mirrors the single-instance fallback in PerformConfirmedSingleInstanceDelete:
-    /// a surviving sibling (searching forward then backward from the deleted group), otherwise the
-    /// surviving parent instance, otherwise the owning screen/component.
+    /// Picks the selection after one or more instances are removed so the editor never goes
+    /// blank (issue #3025): a surviving sibling (searching forward then backward from the
+    /// deleted group), otherwise the surviving parent instance, otherwise the owning
+    /// screen/component. Shared by both the single- and multi-instance delete paths; the
+    /// single-instance case passes a one-element <paramref name="deletedInstances"/>.
     /// </summary>
-    private void SelectAfterMultiInstanceRemoval(
+    private void SelectAfterInstanceRemoval(
         List<InstanceSave> anchorSiblings,
         int anchorIndex,
         List<InstanceSave> deletedInstances,

--- a/Gum/Managers/DeleteLogic.cs
+++ b/Gum/Managers/DeleteLogic.cs
@@ -359,6 +359,18 @@ public class DeleteLogic : IDeleteLogic
             .GroupBy(i => i.ParentContainer!)
             .ToList();
 
+        // Capture what's needed to pick a sensible post-delete selection before removal:
+        // GetSiblingsIncludingThis reads ParentContainer, which RemoveInstanceFromElement
+        // clears. Anchor on the first deletable instance whose owning element survives the
+        // delete (issue #3025 — without a fallback the editor went blank after a
+        // multi-instance delete).
+        var selectionAnchor = deletableInstances
+            .FirstOrDefault(i => i.ParentContainer != null && !elements.Contains(i.ParentContainer));
+        var anchorElement = selectionAnchor?.ParentContainer;
+        var anchorSiblings = selectionAnchor?.GetSiblingsIncludingThis() ?? new List<InstanceSave>();
+        var anchorParentInstance = selectionAnchor?.GetParentInstance();
+        var anchorIndex = selectionAnchor != null ? anchorSiblings.IndexOf(selectionAnchor) : -1;
+
         // 2. Remove instances (skip if parent element/behavior is also being deleted)
         foreach (var instance in deletableInstances)
         {
@@ -404,7 +416,7 @@ public class DeleteLogic : IDeleteLogic
         if (deletableInstances.Count > 0)
         {
             DeselectInstances(deletableInstances);
-            _selectedState.SelectedInstance = null;
+            SelectAfterMultiInstanceRemoval(anchorSiblings, anchorIndex, deletableInstances, anchorParentInstance, anchorElement);
         }
 
         // 7. Refresh and save for instance parents that were not themselves deleted
@@ -422,6 +434,61 @@ public class DeleteLogic : IDeleteLogic
         }
 
         _wireframeObjectManager.RefreshAll(true);
+    }
+
+    /// <summary>
+    /// Picks the selection after a multi-instance delete so the editor never goes blank
+    /// (issue #3025). Mirrors the single-instance fallback in PerformConfirmedSingleInstanceDelete:
+    /// a surviving sibling (searching forward then backward from the deleted group), otherwise the
+    /// surviving parent instance, otherwise the owning screen/component.
+    /// </summary>
+    private void SelectAfterMultiInstanceRemoval(
+        List<InstanceSave> anchorSiblings,
+        int anchorIndex,
+        List<InstanceSave> deletedInstances,
+        InstanceSave? anchorParentInstance,
+        ElementSave? anchorElement)
+    {
+        InstanceSave? fallback = null;
+
+        if (anchorIndex >= 0)
+        {
+            for (int i = anchorIndex + 1; i < anchorSiblings.Count && fallback == null; i++)
+            {
+                if (!deletedInstances.Contains(anchorSiblings[i]))
+                {
+                    fallback = anchorSiblings[i];
+                }
+            }
+
+            for (int i = anchorIndex - 1; i >= 0 && fallback == null; i--)
+            {
+                if (!deletedInstances.Contains(anchorSiblings[i]))
+                {
+                    fallback = anchorSiblings[i];
+                }
+            }
+        }
+
+        if (fallback == null && anchorParentInstance != null && !deletedInstances.Contains(anchorParentInstance))
+        {
+            fallback = anchorParentInstance;
+        }
+
+        if (fallback != null)
+        {
+            _selectedState.SelectedInstance = fallback;
+        }
+        else
+        {
+            // No sibling or parent instance survived — fall back to the owning
+            // screen/component so the editor still shows the element instead of going blank.
+            _selectedState.SelectedInstance = null;
+            if (anchorElement != null)
+            {
+                _selectedState.SelectedElement = anchorElement;
+            }
+        }
     }
 
     bool? ShowDeleteDialog(Array objectsToDelete, out DeleteOptionsWindow optionsWindow,

--- a/Tool/Tests/GumToolUnitTests/Managers/DeleteLogicTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Managers/DeleteLogicTests.cs
@@ -165,6 +165,47 @@ public class DeleteLogicTests : BaseTestClass
     }
 
     [Fact]
+    public void PerformConfirmedMixedTypeDelete_DeletingAllInstances_SelectsOwningElement()
+    {
+        // Issue #3025: deleting every selected instance left selection empty, so the
+        // editor went blank. With no surviving sibling, selection should fall back to
+        // the owning screen/component.
+        ScreenSave screen = CreateScreenWithInstances("InstA", "InstB");
+        TrackSelectionState();
+        List<InstanceSave> instances = screen.Instances.ToList();
+
+        _deleteLogic.PerformConfirmedMixedTypeDelete(
+            new List<ElementSave>(),
+            new List<BehaviorSave>(),
+            instances,
+            instances.Cast<object>().ToArray(),
+            optionsWindow: null);
+
+        _selectedState.Object.SelectedInstance.ShouldBeNull();
+        _selectedState.Object.SelectedElement.ShouldBe(screen);
+    }
+
+    [Fact]
+    public void PerformConfirmedMixedTypeDelete_DeletingSubsetOfInstances_SelectsRemainingSibling()
+    {
+        // Issue #3025: deleting multiple instances and confirming deselected everything,
+        // leaving the editor blank. A surviving sibling should be selected instead.
+        ScreenSave screen = CreateScreenWithInstances("InstA", "InstB", "InstC");
+        TrackSelectionState();
+        InstanceSave instC = screen.Instances.Single(i => i.Name == "InstC");
+        List<InstanceSave> toDelete = screen.Instances.Where(i => i.Name != "InstC").ToList();
+
+        _deleteLogic.PerformConfirmedMixedTypeDelete(
+            new List<ElementSave>(),
+            new List<BehaviorSave>(),
+            toDelete,
+            toDelete.Cast<object>().ToArray(),
+            optionsWindow: null);
+
+        _selectedState.Object.SelectedInstance.ShouldBe(instC);
+    }
+
+    [Fact]
     public void PerformConfirmedMixedTypeDelete_MultipleInstancesInSameElement_FiresInstancesDeleteOnPluginManager()
     {
         // Regression: deleting multiple instances at once never fired InstancesDelete on the
@@ -516,6 +557,38 @@ public class DeleteLogicTests : BaseTestClass
         // no impact section — message should only contain the item name, no extra impact text
         message.ShouldContain("sprite");
         message.ShouldNotContain("invalid");
+    }
+
+    /// <summary>
+    /// Wires the ISelectedState mock so SelectedInstance/SelectedInstances/SelectedElement
+    /// behave like the real backing store (reads reflect the most recent write), which the
+    /// post-delete selection-fallback logic depends on.
+    /// </summary>
+    private void TrackSelectionState()
+    {
+        List<InstanceSave> selectedInstances = new();
+        InstanceSave? selectedInstance = null;
+        ElementSave? selectedElement = null;
+
+        _selectedState.SetupGet(s => s.SelectedInstances).Returns(() => selectedInstances);
+        _selectedState.SetupSet(s => s.SelectedInstances = It.IsAny<IEnumerable<InstanceSave>>())
+            .Callback<IEnumerable<InstanceSave>>(value =>
+            {
+                selectedInstances = value?.ToList() ?? new();
+                selectedInstance = selectedInstances.FirstOrDefault();
+            });
+
+        _selectedState.SetupGet(s => s.SelectedInstance).Returns(() => selectedInstance);
+        _selectedState.SetupSet(s => s.SelectedInstance = It.IsAny<InstanceSave?>())
+            .Callback<InstanceSave?>(value =>
+            {
+                selectedInstance = value;
+                selectedInstances = value == null ? new() : new() { value };
+            });
+
+        _selectedState.SetupGet(s => s.SelectedElement).Returns(() => selectedElement);
+        _selectedState.SetupSet(s => s.SelectedElement = It.IsAny<ElementSave?>())
+            .Callback<ElementSave?>(value => selectedElement = value);
     }
 
     private ScreenSave CreateScreenWithInstances(params string[] instanceNames)

--- a/Tool/Tests/GumToolUnitTests/Managers/DeleteLogicTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Managers/DeleteLogicTests.cs
@@ -232,6 +232,88 @@ public class DeleteLogicTests : BaseTestClass
     }
 
     [Fact]
+    public void PerformConfirmedSingleInstanceDelete_DeletingChildWithParentInstance_SelectsParentInstance()
+    {
+        // Characterization: a child with a parent instance and no siblings under that parent
+        // falls back to the parent instance.
+        ScreenSave screen = CreateScreenWithInstances("Parent");
+        InstanceSave parent = screen.Instances[0];
+        InstanceSave child = AddChild(screen, "Child", "Parent");
+        TrackSelectionState();
+        _selectedState.Object.SelectedInstance = child;
+
+        _deleteLogic.PerformConfirmedSingleInstanceDelete(
+            selectedInstance: child,
+            selectedElement: screen,
+            selectedBehavior: null,
+            objectsDeleted: new[] { child },
+            optionsWindow: null);
+
+        _selectedState.Object.SelectedInstance.ShouldBe(parent);
+    }
+
+    [Fact]
+    public void PerformConfirmedSingleInstanceDelete_DeletingLastSibling_SelectsPreviousSibling()
+    {
+        // Characterization: deleting the last sibling falls back to the previous one.
+        ScreenSave screen = CreateScreenWithInstances("InstA", "InstB", "InstC");
+        InstanceSave instB = screen.Instances.Single(i => i.Name == "InstB");
+        InstanceSave instC = screen.Instances.Single(i => i.Name == "InstC");
+        TrackSelectionState();
+        _selectedState.Object.SelectedInstance = instC;
+
+        _deleteLogic.PerformConfirmedSingleInstanceDelete(
+            selectedInstance: instC,
+            selectedElement: screen,
+            selectedBehavior: null,
+            objectsDeleted: new[] { instC },
+            optionsWindow: null);
+
+        _selectedState.Object.SelectedInstance.ShouldBe(instB);
+    }
+
+    [Fact]
+    public void PerformConfirmedSingleInstanceDelete_DeletingMiddleSibling_SelectsNextSibling()
+    {
+        // Characterization: deleting a middle sibling falls back to the next one.
+        ScreenSave screen = CreateScreenWithInstances("InstA", "InstB", "InstC");
+        InstanceSave instB = screen.Instances.Single(i => i.Name == "InstB");
+        InstanceSave instC = screen.Instances.Single(i => i.Name == "InstC");
+        TrackSelectionState();
+        _selectedState.Object.SelectedInstance = instB;
+
+        _deleteLogic.PerformConfirmedSingleInstanceDelete(
+            selectedInstance: instB,
+            selectedElement: screen,
+            selectedBehavior: null,
+            objectsDeleted: new[] { instB },
+            optionsWindow: null);
+
+        _selectedState.Object.SelectedInstance.ShouldBe(instC);
+    }
+
+    [Fact]
+    public void PerformConfirmedSingleInstanceDelete_DeletingOnlyChildWithNoParent_KeepsOwningElementSelected()
+    {
+        // Characterization: deleting the sole top-level instance leaves no sibling or parent,
+        // so selection falls back to the owning element (instance cleared).
+        ScreenSave screen = CreateScreenWithInstances("Inst");
+        InstanceSave instance = screen.Instances[0];
+        TrackSelectionState();
+        _selectedState.Object.SelectedInstance = instance;
+
+        _deleteLogic.PerformConfirmedSingleInstanceDelete(
+            selectedInstance: instance,
+            selectedElement: screen,
+            selectedBehavior: null,
+            objectsDeleted: new[] { instance },
+            optionsWindow: null);
+
+        _selectedState.Object.SelectedInstance.ShouldBeNull();
+        _selectedState.Object.SelectedElement.ShouldBe(screen);
+    }
+
+    [Fact]
     public void PerformConfirmedSingleInstanceDelete_LiveSelectedElementIsNull_RestoresOwningElementBeforeFiringInstanceDelete()
     {
         // Reproduces the production NRE: the user has only the instance highlighted in the


### PR DESCRIPTION
## Summary

Fixes #3025. Deleting multiple selected instances and confirming with `ENTER` deselected everything, leaving the Editor tab blank.

## Cause

`DeleteLogic.PerformConfirmedMixedTypeDelete` (the multi-instance/mixed-type delete path) cleared `SelectedInstance = null` after removal with **no fallback selection**. The single-instance path (`PerformConfirmedSingleInstanceDelete`) already falls back to a sibling or the parent instance, so single deletes never went blank — only multi-instance deletes did.

## Fix

Mirror the single-instance fallback for the multi-instance case. After the selected instances are removed, selection falls back to:

1. A surviving sibling — searching forward then backward from the deleted group (matching the single-instance next/previous behavior).
2. Otherwise the surviving parent instance.
3. Otherwise the owning screen/component, so the editor still shows the element instead of going blank.

The sibling/parent/element data is captured **before** removal because `GetSiblingsIncludingThis` reads `ParentContainer`, which `RemoveInstanceFromElement` clears.

## Tests

Added two tests to `DeleteLogicTests` (TDD — both red before the fix, green after):

- `PerformConfirmedMixedTypeDelete_DeletingSubsetOfInstances_SelectsRemainingSibling`
- `PerformConfirmedMixedTypeDelete_DeletingAllInstances_SelectsOwningElement`

Full `GumToolUnitTests` suite passes (807 passed, 5 pre-existing skips).

Closes #3025

🤖 Generated with [Claude Code](https://claude.com/claude-code)
