### PR TITLE
Keep behavior-reference-driven category state hidden from instances (#3028)

### DIFF
--- a/Gum/Plugins/InternalPlugins/VariableGrid/ElementSaveDisplayer.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/ElementSaveDisplayer.cs
@@ -976,7 +976,11 @@ public class ElementSaveDisplayer
                 var qualifiedName = instanceSave.Name + "." + defaultVariable.Name;
                 var currentState = _selectedState.SelectedStateSave;
                 var isExplicitlySet = currentState?.Variables.Any(v => v.Name == qualifiedName) == true;
-                if (!isExplicitlySet)
+                // A value materialized by a behavior tool-only reference (e.g.
+                // ButtonCategoryState = IsEnabled ? "Enabled" : "Disabled") is not user-authored,
+                // so the "explicitly set" escape hatch must not un-hide it - otherwise it surfaces
+                // as an editable combo that fights the FormsProperty driving it (issue #3028).
+                if (!isExplicitlySet || IsDrivenByBehaviorToolOnlyReference(elementSave, hiddenCheckName))
                 {
                     shouldInclude = false;
                 }
@@ -1064,6 +1068,53 @@ public class ElementSaveDisplayer
                 ToolTipText: defaultVariable.ToolTipText);
         }
         return null;
+    }
+
+    /// <summary>
+    /// True when <paramref name="variableName"/> is the left-hand side of a
+    /// <see cref="BehaviorSave.ToolOnlyVariableReferences"/> entry on any behavior of
+    /// <paramref name="elementSave"/> or of any element in its <c>BaseType</c> chain. Such a
+    /// variable is driven by a behavior reference (materialized for design-time preview) rather
+    /// than authored by the user, so the grid keeps it hidden on instances even though it carries
+    /// a value in the state. Walks inheritance like <c>ObjectFinder.IsVariableHiddenRecursively</c>
+    /// so instances of types derived from a Forms control (behavior on the base) are handled too.
+    /// Mirrors the reference-detection the state-level <c>VariableReferences</c> path already does
+    /// via <c>variablesSetThroughReference</c>.
+    /// </summary>
+    private static bool IsDrivenByBehaviorToolOnlyReference(ElementSave elementSave, string variableName)
+    {
+        var current = elementSave;
+        while (current != null)
+        {
+            foreach (var behaviorReference in current.Behaviors)
+            {
+                var behavior = ObjectFinder.Self.GetBehavior(behaviorReference);
+                if (behavior == null)
+                {
+                    continue;
+                }
+
+                foreach (var referenceLine in behavior.ToolOnlyVariableReferences)
+                {
+                    int equalsIndex = referenceLine.IndexOf('=');
+                    if (equalsIndex < 0)
+                    {
+                        continue;
+                    }
+
+                    if (referenceLine.Substring(0, equalsIndex).Trim() == variableName)
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            current = !string.IsNullOrEmpty(current.BaseType)
+                ? ObjectFinder.Self.GetElementSave(current.BaseType)
+                : null;
+        }
+
+        return false;
     }
 
 

--- a/Tool/Tests/GumToolUnitTests/PropertyGridHelpers/ElementSaveDisplayerFormsPropertiesTests.cs
+++ b/Tool/Tests/GumToolUnitTests/PropertyGridHelpers/ElementSaveDisplayerFormsPropertiesTests.cs
@@ -67,6 +67,9 @@ public class ElementSaveDisplayerFormsPropertiesTests : BaseTestClass
         _projectManagerMock.SetupGet(x => x.GumProjectSave).Returns(_project);
         var services = new ServiceCollection();
         services.AddSingleton(_projectManagerMock.Object);
+        // Static Locator path (e.g. GetVariableFromThisOrBase) resolves ISelectedState; register the
+        // same mock the displayer is constructor-injected with so both paths agree.
+        services.AddSingleton(_mocker.GetMock<ISelectedState>().Object);
         _testServiceProvider = services.BuildServiceProvider();
         Locator.Register(_testServiceProvider);
 
@@ -347,6 +350,125 @@ public class ElementSaveDisplayerFormsPropertiesTests : BaseTestClass
         categories.SelectMany(c => c.Members)
             .ShouldNotContain(m => m.Name.EndsWith("DefaultChildContainer"),
                 "DefaultChildContainer should only appear on the component itself, not on instances of it");
+    }
+
+    [Fact]
+    public void GetCategories_InstanceCategoryStateMaterializedByBehaviorToolOnlyReference_StaysHiddenFromInstance()
+    {
+        // Repro #3028: ButtonCategoryState is hidden-from-instances, but the ButtonBehavior's
+        // tool-only reference (ButtonCategoryState = IsEnabled ? "Enabled" : "Disabled") materializes
+        // a value into the instance's state. The grid's "explicitly set" escape hatch then re-surfaces
+        // it as an editable combo that fights IsEnabled. A reference-materialized value is not
+        // user-authored, so it must remain hidden.
+
+        // Component declares the category state variable, its category, and hides it from instances.
+        _buttonComponent.DefaultState.Variables.Add(new VariableSave
+        {
+            Type = "ButtonCategory",
+            Name = "ButtonCategoryState",
+            SetsValue = false
+        });
+        _buttonComponent.Categories.Add(new StateSaveCategory
+        {
+            Name = "ButtonCategory",
+            States = new List<StateSave>
+            {
+                new StateSave { Name = "Enabled" },
+                new StateSave { Name = "Disabled" }
+            }
+        });
+        _buttonComponent.VariablesHiddenFromInstances.Add("ButtonCategoryState");
+
+        // The behavior drives the category state from IsEnabled via a tool-only reference.
+        _buttonBehavior.ToolOnlyVariableReferences.Add(
+            "ButtonCategoryState = IsEnabled ? \"Enabled\" : \"Disabled\"");
+
+        // The materialized value sits in the screen's state, as it would after the applier runs.
+        _screenDefaultState.Variables.Add(new VariableSave
+        {
+            Type = "string",
+            Name = "ButtonInstance.ButtonCategoryState",
+            Value = "Enabled",
+            SetsValue = true
+        });
+
+        List<MemberCategory> categories = new List<MemberCategory>();
+
+        _displayer.GetCategories(
+            instanceOwner: _screen,
+            instance: _buttonInstance,
+            categories: categories,
+            stateSave: _screenDefaultState,
+            stateSaveCategory: null);
+
+        categories.SelectMany(c => c.Members)
+            .ShouldNotContain(m => m.Name.EndsWith("ButtonCategoryState"),
+                "a category state materialized by a behavior tool-only reference is not user-authored and must remain hidden from instances");
+    }
+
+    [Fact]
+    public void GetCategories_InstanceOfDerivedTypeWithInheritedBehaviorToolOnlyReference_StaysHiddenFromInstance()
+    {
+        // Same as the above, but the instance's type is a *derived* component whose BaseType is the
+        // button. The ButtonBehavior (and its tool-only reference) lives on the base, not on the
+        // derived type directly, so the reference-driven detection must walk the inheritance chain -
+        // mirroring IsVariableHiddenRecursively, which already walks BaseType to hide the variable.
+        _buttonComponent.DefaultState.Variables.Add(new VariableSave
+        {
+            Type = "ButtonCategory",
+            Name = "ButtonCategoryState",
+            SetsValue = false
+        });
+        _buttonComponent.Categories.Add(new StateSaveCategory
+        {
+            Name = "ButtonCategory",
+            States = new List<StateSave>
+            {
+                new StateSave { Name = "Enabled" },
+                new StateSave { Name = "Disabled" }
+            }
+        });
+        _buttonComponent.VariablesHiddenFromInstances.Add("ButtonCategoryState");
+        _buttonBehavior.ToolOnlyVariableReferences.Add(
+            "ButtonCategoryState = IsEnabled ? \"Enabled\" : \"Disabled\"");
+
+        // Derived component inherits from the button but does NOT re-declare the behavior.
+        ComponentSave derivedComponent = new ComponentSave
+        {
+            Name = "Controls/FancyButton",
+            BaseType = "Controls/ButtonStandard"
+        };
+        derivedComponent.States.Add(new StateSave { Name = "Default", ParentContainer = derivedComponent });
+        _project.Components.Add(derivedComponent);
+
+        InstanceSave fancyInstance = new InstanceSave
+        {
+            Name = "FancyInstance",
+            BaseType = "Controls/FancyButton",
+            ParentContainer = _screen
+        };
+        _screen.Instances.Add(fancyInstance);
+
+        _screenDefaultState.Variables.Add(new VariableSave
+        {
+            Type = "string",
+            Name = "FancyInstance.ButtonCategoryState",
+            Value = "Enabled",
+            SetsValue = true
+        });
+
+        List<MemberCategory> categories = new List<MemberCategory>();
+
+        _displayer.GetCategories(
+            instanceOwner: _screen,
+            instance: fancyInstance,
+            categories: categories,
+            stateSave: _screenDefaultState,
+            stateSaveCategory: null);
+
+        categories.SelectMany(c => c.Members)
+            .ShouldNotContain(m => m.Name.EndsWith("ButtonCategoryState"),
+                "a category state driven by an inherited behavior tool-only reference must remain hidden from instances of derived types");
     }
 
     [Fact]


### PR DESCRIPTION
Closes #3028.

## Problem

When a Forms control instance (e.g. a `Button`) is placed in a screen, its category-state variable (`ButtonCategoryState`) showed up — editable — in the Variables grid even though the component hides it via `<VariablesHiddenFromInstances>`. The combo fought the `IsEnabled` checkbox, and "Make Default" on it didn't stick.

## Cause

The Forms behavior declares a **tool-only variable reference** (`ButtonCategoryState = IsEnabled ? "Enabled" : "Disabled"`). The tool materializes its result as a hard scalar into the instance's state (the standard variable-reference materialization model, which drives the design-time wireframe). The grid hides `VariablesHiddenFromInstances` entries *unless* the variable is explicitly set in the current state — so the materialized value re-surfaced it. Unlike ordinary state-level `VariableReferences` (which the grid already recognizes as reference-driven), tool-only references live on the **behavior**, so the materialized scalar carried no co-located marker and looked hand-authored.

## Fix

In the grid's un-hide gate (`ElementSaveDisplayer.CreatePropertyData`), the "explicitly set" escape hatch no longer un-hides a variable whose value was materialized by a behavior tool-only reference. A new `IsDrivenByBehaviorToolOnlyReference` helper detects this by scanning the element's behaviors' `ToolOnlyVariableReferences` for a matching left-hand side — **walking the `BaseType` chain** so instances of types derived from a Forms control (behavior on the base) are handled too. This mirrors the reference-detection the state-level `VariableReferences` path already does (`variablesSetThroughReference`).

Materialization, wireframe preview, variable cascade, and runtime are intentionally **unchanged** — the value is still baked exactly as before; only the grid's display decision changes. The fix targets the value's origin, not its value.

## Tests (TDD)

- `GetCategories_InstanceCategoryStateMaterializedByBehaviorToolOnlyReference_StaysHiddenFromInstance` — direct behavior.
- `GetCategories_InstanceOfDerivedTypeWithInheritedBehaviorToolOnlyReference_StaysHiddenFromInstance` — inherited behavior; failed against the first (direct-only) implementation and drove the `BaseType`-walk.
- Both failed for the right reason before the fix and pass after. Full displayer class 11/11; related grid sweep 215 passed / 1 pre-existing skip; no new warnings.
- Minor harness fix: registered the existing `ISelectedState` mock into the test `Locator` (the category path resolves it statically).

## Follow-up

Codegen emits the same materialized category state because it doesn't filter `VariablesHiddenFromInstances` (and must also walk inheritance) — tracked separately in #3029.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
