### PR TITLE
Skip hidden-from-instances variables in instance-assignment codegen (#3029)

### DIFF
--- a/Tests/Gum.ProjectServices.Tests/CodeGeneratorHiddenFromInstancesTests.cs
+++ b/Tests/Gum.ProjectServices.Tests/CodeGeneratorHiddenFromInstancesTests.cs
@@ -1,0 +1,150 @@
+using Gum.DataTypes;
+using Gum.DataTypes.Variables;
+using Gum.Localization;
+using Gum.Managers;
+using Gum.ProjectServices.CodeGeneration;
+using Moq;
+using Shouldly;
+
+namespace Gum.ProjectServices.Tests;
+
+/// <summary>
+/// Tests for #3029: instance value-assignment codegen must not emit variables that are hidden from
+/// instances (e.g. a behavior tool-only reference like <c>ButtonCategoryState = IsEnabled ? "Enabled"
+/// : "Disabled"</c> that the tool materializes into the instance's state for design-time preview).
+/// At runtime the Forms control's own setter owns that visual state, so a baked assignment is at best
+/// redundant and at worst a stale double-write. Detection walks the BaseType chain so instances of a
+/// type derived from a hiding element are handled too.
+/// </summary>
+public class CodeGeneratorHiddenFromInstancesTests : BaseTestClass
+{
+    private static CodeGenerator CreateCodeGenerator()
+    {
+        Mock<INameVerifier> mockNameVerifier = new Mock<INameVerifier>();
+        string whyNotValid;
+        CommonValidationError error;
+        mockNameVerifier
+            .Setup(v => v.IsValidCSharpName(It.IsAny<string>(), out whyNotValid, out error))
+            .Returns(true);
+        CodeGenerationNameVerifier codeGenNameVerifier = new CodeGenerationNameVerifier(mockNameVerifier.Object);
+        FixedProjectDirectoryProvider directoryProvider = new FixedProjectDirectoryProvider(projectDirectory: null);
+        CodeOutputElementSettingsManager elementSettingsManager = new CodeOutputElementSettingsManager(directoryProvider);
+        LocalizationService localizationService = new LocalizationService();
+
+        return new CodeGenerator(
+            codeGenNameVerifier,
+            localizationService,
+            elementSettingsManager,
+            directoryProvider);
+    }
+
+    private static CodeOutputProjectSettings CreateMonoGame() => new CodeOutputProjectSettings
+    {
+        OutputLibrary = OutputLibrary.MonoGame,
+        RootNamespace = "MyGame",
+    };
+
+    private static ComponentSave CreateComponent(string name, string baseType)
+    {
+        ComponentSave component = new ComponentSave { Name = name, BaseType = baseType };
+        StateSave defaultState = new StateSave { Name = "Default", ParentContainer = component };
+        component.States.Add(defaultState);
+        return component;
+    }
+
+    private static void AddVariable(ElementSave element, string name, object value, string type) =>
+        element.DefaultState.Variables.Add(new VariableSave
+        {
+            Name = name,
+            Value = value,
+            SetsValue = true,
+            Type = type,
+        });
+
+    [Fact]
+    public void GetCodeForInstance_VariableHiddenFromInstances_IsNotEmitted()
+    {
+        GumProjectSave project = Project;
+
+        ComponentSave button = CreateComponent("Button", "Container");
+        button.VariablesHiddenFromInstances.Add("ButtonCategoryState");
+        AddVariable(button, "ButtonCategoryState", "Enabled", "string");
+        AddVariable(button, "Width", 50f, "float");
+        project.Components.Add(button);
+
+        ComponentSave main = CreateComponent("MainComponent", "Container");
+        InstanceSave buttonInstance = new InstanceSave
+        {
+            Name = "ButtonInstance",
+            BaseType = "Button",
+            ParentContainer = main,
+        };
+        main.Instances.Add(buttonInstance);
+        // The tool materializes both: the hidden category state (from the behavior tool-only
+        // reference) and a normal user-authored Width.
+        AddVariable(main, "ButtonInstance.ButtonCategoryState", "Enabled", "string");
+        AddVariable(main, "ButtonInstance.Width", 100f, "float");
+        project.Components.Add(main);
+
+        ObjectFinder.Self.GumProjectSave = project;
+        try
+        {
+            string code = CreateCodeGenerator().GetCodeForInstance(buttonInstance, main, CreateMonoGame());
+
+            // Anchor: the non-hidden variable still flows through the instance-assignment pass.
+            code.ShouldContain("Width = 100");
+            // The hidden-from-instances variable must not be baked into generated code.
+            code.ShouldNotContain("ButtonCategoryState");
+        }
+        finally
+        {
+            ObjectFinder.Self.GumProjectSave = null;
+        }
+    }
+
+    [Fact]
+    public void GetCodeForInstance_VariableHiddenOnBaseType_IsNotEmittedForDerivedInstance()
+    {
+        // The hiding element (Button) is the BASE of the instance's type (FancyButton). Detection
+        // must walk BaseType, mirroring ObjectFinder.IsVariableHiddenRecursively, or the redundant
+        // assignment leaks back in for instances of derived types.
+        GumProjectSave project = Project;
+
+        ComponentSave button = CreateComponent("Button", "Container");
+        button.VariablesHiddenFromInstances.Add("ButtonCategoryState");
+        AddVariable(button, "ButtonCategoryState", "Enabled", "string");
+        AddVariable(button, "Width", 50f, "float");
+        project.Components.Add(button);
+
+        // FancyButton derives from Button and does NOT itself list the variable as hidden.
+        ComponentSave fancyButton = CreateComponent("FancyButton", "Button");
+        AddVariable(fancyButton, "ButtonCategoryState", "Enabled", "string");
+        AddVariable(fancyButton, "Width", 50f, "float");
+        project.Components.Add(fancyButton);
+
+        ComponentSave main = CreateComponent("MainComponent", "Container");
+        InstanceSave fancyInstance = new InstanceSave
+        {
+            Name = "FancyInstance",
+            BaseType = "FancyButton",
+            ParentContainer = main,
+        };
+        main.Instances.Add(fancyInstance);
+        AddVariable(main, "FancyInstance.ButtonCategoryState", "Enabled", "string");
+        AddVariable(main, "FancyInstance.Width", 100f, "float");
+        project.Components.Add(main);
+
+        ObjectFinder.Self.GumProjectSave = project;
+        try
+        {
+            string code = CreateCodeGenerator().GetCodeForInstance(fancyInstance, main, CreateMonoGame());
+
+            code.ShouldContain("Width = 100");
+            code.ShouldNotContain("ButtonCategoryState");
+        }
+        finally
+        {
+            ObjectFinder.Self.GumProjectSave = null;
+        }
+    }
+}

--- a/Tools/Gum.ProjectServices/CodeGeneration/CodeGenerator.cs
+++ b/Tools/Gum.ProjectServices/CodeGeneration/CodeGenerator.cs
@@ -3999,7 +3999,7 @@ public class CodeGenerator
 
 
                 List<VariableSave> variablesForThisInstance = group
-                    .Where(item => GetIfVariableShouldBeIncludedForInstance(instance, item, baseRecursiveVariableFinder))
+                    .Where(item => GetIfVariableShouldBeIncludedForInstance(instance, item, baseRecursiveVariableFinder, baseElement))
                     .ToList();
 
 
@@ -5195,7 +5195,7 @@ public class CodeGenerator
                 var variablesToConsider = defaultState.Variables
                     .Where(item =>
                     {
-                        return GetIfVariableShouldBeIncludedForInstance(instance, item, baseRecursiveVariableFinder);
+                        return GetIfVariableShouldBeIncludedForInstance(instance, item, baseRecursiveVariableFinder, baseElement!);
                     })
                     .ToArray();
                 return variablesToConsider;
@@ -5204,7 +5204,7 @@ public class CodeGenerator
         return new VariableSave[0];
     }
 
-    private static bool GetIfVariableShouldBeIncludedForInstance(InstanceSave? instance, VariableSave item, RecursiveVariableFinder baseRecursiveVariableFinder)
+    private static bool GetIfVariableShouldBeIncludedForInstance(InstanceSave? instance, VariableSave item, RecursiveVariableFinder baseRecursiveVariableFinder, ElementSave instanceBaseElement)
     {
         var shouldInclude =
                                 item.Value != null &&
@@ -5216,6 +5216,16 @@ public class CodeGenerator
         {
             var foundVariable = baseRecursiveVariableFinder.GetVariable(item.GetRootName());
             shouldInclude = foundVariable != null;
+        }
+
+        if (shouldInclude)
+        {
+            // A variable hidden from instances (e.g. a category state materialized from a behavior
+            // tool-only reference like ButtonCategoryState = IsEnabled ? "Enabled" : "Disabled") is
+            // owned by the Forms control's own setter at runtime; baking it into instance-assignment
+            // code is redundant and a latent double-write (#3029). IsVariableHiddenRecursively walks
+            // the BaseType chain, so instances of a type derived from the hiding element are handled too.
+            shouldInclude = !ObjectFinder.Self.IsVariableHiddenRecursively(instanceBaseElement, item.GetRootName());
         }
 
         return shouldInclude;


### PR DESCRIPTION
Closes #3029.

## Summary

Code generation did not filter `VariablesHiddenFromInstances`, so a category-state value the tool materializes from a behavior tool-only reference (e.g. `ButtonInstance.ButtonCategoryState = "Enabled"`, derived from `IsEnabled`) was baked into generated instance-assignment code. At runtime the Forms control's own setter owns that visual state (`UpdateState` runs after the assignment), so the baked assignment was redundant and idempotent only by ordering accident — exactly the double-write the `BehaviorSave.ToolOnlyVariableReferences` doc comment warns against.

## Change

`CodeGenerator.GetIfVariableShouldBeIncludedForInstance` — the single filter feeding both instance value-assignment paths (`GetVariablesForValueAssignmentCode` and `FillWithVariablesInState`) — now also excludes any variable for which `ObjectFinder.IsVariableHiddenRecursively(baseElement, rootName)` returns true. Both call sites thread through the resolved instance base element.

### Why `IsVariableHiddenRecursively` rather than re-parsing the behavior reference

- It's an existing, public, tested method that already **walks the `BaseType` chain**, so instances of a type derived from a Forms control (the `ButtonBehavior` and its hidden entry live on the base, e.g. `FancyButton : Button`) are handled — the inheritance requirement called out in the issue — without duplicating the tool plugin's private `IsDrivenByBehaviorToolOnlyReference` parser into the codegen engine.
- It is the exact semantic the issue names ("VariablesHiddenFromInstances not filtered"): a variable hidden from instances should never produce an instance assignment, regardless of *why* it is hidden. The behavior-driven materialization is the only writer of such values in practice.

The canonical Forms templates always author the behavior tool-only reference LHS into `VariablesHiddenFromInstances` together (verified in `ButtonStandard.gucx`), so the two signals coincide. A behavior reference LHS that is *not* also hidden would be an authoring inconsistency (the #3028 grid would also surface it as editable) and is out of scope here.

Materialization, wireframe preview, variable cascade, and runtime are intentionally unchanged — split out from #3028, which fixed the same materialized value's Variables-grid display and left codegen untouched.

## Tests

New `CodeGeneratorHiddenFromInstancesTests` (written failing first, then made green):
- `GetCodeForInstance_VariableHiddenFromInstances_IsNotEmitted` — direct case; asserts the hidden `ButtonCategoryState` is absent while a normal `Width` assignment still flows through.
- `GetCodeForInstance_VariableHiddenOnBaseType_IsNotEmittedForDerivedInstance` — the hiding element is the base of the instance's type; verifies the `BaseType` walk.

Full `Gum.ProjectServices.Tests` suite: 250 passed, 2 skipped (pre-existing diagnostic helpers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
