### PR TITLE
Document content-loading API, relocate shared LoaderManager, add runtime-topology skill

### DIFF
--- a/.claude/skills/gum-runtime-topology/SKILL.md
+++ b/.claude/skills/gum-runtime-topology/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: gum-runtime-topology
+description: Map of Gum's render-backend projects and every place that compiles shared Gum source. Triggers: moving/renaming/deleting runtime or GumCommon/RenderingLibrary files, AllLibraries.sln, SkiaGum.Wpf, FRB GumCoreShared/Forms shproj, duplicate same-FQN build errors, "what must I rebuild after a runtime refactor."
+---
+
+# Gum Runtime Topology
+
+Gum has **no single "runtime" assembly**. The same `RenderingLibrary.*` / `GumCommon` source is compiled into many assemblies via three different source-sharing mechanisms, and is also consumed by FlatRedBall (FRB), a **separate repo**. A refactor that builds clean in `AllLibraries.sln` can still break the WPF runtime or FRB. Before moving/renaming/deleting any shared file, check it against every surface below.
+
+> FRB is a separate git repo, but Gum and FRB are always checked out side by side (`GitHub/Gum` and `GitHub/FlatRedBall`), so `../FlatRedBall/...` reaches FRB from the Gum repo root.
+
+## Compilation surfaces — rebuild/verify ALL for a runtime-level refactor
+
+| Surface | What it is | Notes |
+|---|---|---|
+| `AllLibraries.sln` | All render backends + `GumCommon` + shapes + themes + CLI + ProjectServices + tests | **Must compile on Mac**, so it EXCLUDES Windows-only projects. The broad verify command — but not complete. |
+| `Runtimes/SkiaGum.Wpf/SkiaGum.Wpf.csproj` | WPF host for the Skia runtime | **NOT in AllLibraries** (WPF can't build on Mac). Build separately on Windows. The single easiest runtime to forget. |
+| `GumFull.sln` | The Gum tool (KNI-based) + plugins | Tool work; `$(SolutionDir)` post-builds require the solution, not a bare csproj. |
+| `GumCoreShared.shproj` | Gum-side shared project (imports `GumCoreShared.projitems`) | Source-shares Gum core into FRB. The file lists live in the `.projitems`. |
+| `../FlatRedBall/FRBDK/Glue/GumPlugin/GumPlugin/GumCoreShared.FlatRedBall.shproj` | FRB-side core consumer | FRB multi-targets down to **net6.0** — gate net7+ BCL APIs. |
+| `../FlatRedBall/Engines/Forms/FlatRedBall.Forms/FlatRedBall.Forms.Shared/FlatRedBall.Forms.Shared.shproj` | FRB-side Forms consumer | Picks up `MonoGameGum/Forms/**` files individually; new/renamed Forms files must be registered here. |
+
+## Render backends
+
+XNA-family (`MonoGameGum`, `KniGum`, `FnaGum`), `RaylibGum`, `SkiaGum` (+ hosts `SkiaGum.Maui`, `SkiaGum.Wpf`), `SokolGum`. Shape runtimes: `MonoGameGumShapes`/`KniGumShapes` (Apos.Shapes) ↔ `SkiaGum` pair. For the per-runtime file-sharing/unification pattern see [gum-cross-platform-unification](../gum-cross-platform-unification/SKILL.md).
+
+## Three source-sharing mechanisms (each is a separate landmine)
+
+1. **GumCommon project reference.** `GumCommon` is the runtime-agnostic core (net8.0, no XNA/WPF). It cherry-picks files from `RenderingLibrary/`, `GumDataTypes/`, `ToolsUtilities/` via `<Compile Include="..\X" Link="..."/>` **and globs its own folder**. MonoGame/Raylib/Skia/Sokol reference it as a project.
+2. **Cross-project file links.** `GueDeriving` runtimes are canonical in `MonoGameGum/GueDeriving/` and `<Compile Include ... Link>`-ed into the Raylib/Skia/Sokol csprojs. These are **deliberately excluded** from `GumCoreShared.projitems` (FRB generates its own runtime classes).
+3. **FRB shared projects** (the two `../FlatRedBall/...shproj` above) — source-sharing for an out-of-repo consumer on a net6 floor.
+
+## Landmines
+
+- **`RenderingLibrary` is not a built assembly.** It's a source directory distributed by links/projitems, so `RenderingLibrary.*` types exist in *several* compiled assemblies at once.
+- **Same-FQN forks.** Because of the above, two files can define the same `RenderingLibrary.X` type for different consumers and silently diverge. Confirmed example: `GumCommon/Content/LoaderManager.cs` (XNA-free; used by every GumCommon-referencing runtime) vs `RenderingLibrary/Content/LoaderManager.cs` (XNA-coupled — `InvalidTexture`, `Initialize`, `LoadOrInvalid`; compiled only by `GumCoreShared.projitems` + FRB `GumPlugin.csproj`). Editing one does not touch the other; placing both in one compilation is a duplicate-type error.
+- **Moving a file between a glob'd folder and a linked location requires a csproj edit.** GumCommon and the runtime projects glob their own folders; external shared files are explicit links. (E.g. relocating the shared `LoaderManager` into `GumCommon/Content/` meant dropping its explicit `<Compile Include>` link and removing SkiaGum's `<Compile Remove>`.)
+- **projitems / Forms / net6 sync.** Adding/renaming/deleting files under `GumCommon/` or `MonoGameGum/` (and Forms files) has sync obligations to the FRB shared projects, with explicit exceptions (the LoaderManager fork, `GueDeriving`). These rules are authoritative in the coder agent (`.claude/agents/coder.md`) — follow them there, don't restate.
+
+## Cross-references
+- [gum-cross-platform-unification](../gum-cross-platform-unification/SKILL.md) — per-runtime file unification (`#if`/links).
+- `.claude/agents/coder.md` — projitems/Forms/net6 sync rules (authoritative).

--- a/.claude/skills/refactoring-direction/SKILL.md
+++ b/.claude/skills/refactoring-direction/SKILL.md
@@ -24,6 +24,10 @@ When refactoring Gum code, **always move toward instances, interfaces, and dedic
 
 If the reason you're tempted to make something `static` is "so a test can call it without constructing the owner," the right answer is the opposite: keep it instance, and either (a) construct the owner in the test with stub dependencies, or (b) extract the logic into a new small class that's cheap to construct. The test's friction is a signal that the owner has too many responsibilities, not that the method should be static.
 
+## Before refactoring across runtimes
+
+If a refactor touches shared runtime/rendering code (`GumCommon`, `RenderingLibrary`, anything under `Runtimes/`, or `MonoGameGum`), read [gum-runtime-topology](../gum-runtime-topology/SKILL.md) first. The same source is compiled into many assemblies and into FlatRedBall via shared projects, so "builds clean in `AllLibraries.sln`" does not mean "didn't break a consumer" (the WPF runtime and FRB are not in that solution).
+
 ## Why this matters in Gum
 
 Gum's tool code is mid-migration from static singletons (`PluginManager.Self`, `*Manager.Self`, etc.) to constructor-injected services. Every new `static` is a step backward and undoes that migration's payoff. The runtime libraries are similar: `GraphicalUiElement` is already bloated, and the project memory explicitly calls out "avoid adding new properties/methods directly to this class — prefer separate controller/manager classes." The direction in this skill is the same direction the rest of the codebase is moving.

--- a/GumCommon/Content/LoaderManager.cs
+++ b/GumCommon/Content/LoaderManager.cs
@@ -4,13 +4,33 @@ using System.Linq;
 
 namespace RenderingLibrary.Content;
 
+/// <summary>
+/// SkiaGum implementation that owns the texture/content cache and the active
+/// <see cref="IContentLoader"/>. All SkiaGum asset loading flows through here: callers use
+/// <see cref="LoadContent{T}"/> / <see cref="TryLoadContent{T}"/>, which delegate to
+/// <see cref="ContentLoader"/>.
+/// </summary>
 public class LoaderManager
 {
+    #region Enums
+
+    /// <summary>
+    /// Controls what happens when content is added to the cache under a name that already exists.
+    /// </summary>
     public enum ExistingContentBehavior
     {
+        /// <summary>
+        /// Throw an exception if content is already cached under the same name.
+        /// </summary>
         ThrowException,
+
+        /// <summary>
+        /// Replace the existing cached content with the new content.
+        /// </summary>
         Replace
     }
+
+    #endregion
 
     #region Fields
 
@@ -21,6 +41,9 @@ public class LoaderManager
 
     #region Properties
 
+    /// <summary>
+    /// The shared singleton instance.
+    /// </summary>
     public static LoaderManager Self
     {
         get
@@ -33,6 +56,11 @@ public class LoaderManager
         }
     }
 
+    /// <summary>
+    /// The active content-loading strategy that <see cref="LoadContent{T}"/> and
+    /// <see cref="TryLoadContent{T}"/> delegate to. Assign your own <see cref="IContentLoader"/> to
+    /// customize asset resolution.
+    /// </summary>
     public IContentLoader ContentLoader
     {
         get;
@@ -47,8 +75,17 @@ public class LoaderManager
     bool mCacheTextures = true;
     Dictionary<string, IDisposable> mCachedDisposables = new Dictionary<string, IDisposable>(StringComparer.OrdinalIgnoreCase);
 
+    /// <summary>
+    /// The currently cached content, keyed by standardized (case-insensitive) file path. Read-only;
+    /// use <see cref="AddDisposable"/> / <see cref="Dispose(string)"/> to modify the cache.
+    /// </summary>
     public IReadOnlyDictionary<string, IDisposable> CachedDisposables => mCachedDisposables;
 
+    /// <summary>
+    /// Whether loaded textures are cached and reused. When set to <c>false</c>, the entire cache is
+    /// immediately disposed and cleared, so any still-referenced textures become invalid. Defaults to
+    /// <c>true</c>.
+    /// </summary>
     public bool CacheTextures
     {
         get { return mCacheTextures; }
@@ -72,6 +109,16 @@ public class LoaderManager
     #endregion
 
 
+    /// <summary>
+    /// Loads content of type <typeparamref name="T"/> by delegating to the active
+    /// <see cref="ContentLoader"/>.
+    /// </summary>
+    /// <remarks>
+    /// This method does not cache; it forwards to <see cref="ContentLoader"/>. Caching is the loader's
+    /// responsibility (it calls <see cref="GetDisposable"/> before loading and <see cref="AddDisposable"/>
+    /// after), because each backend's caching and disposal model differs and only the loader knows which
+    /// applies.
+    /// </remarks>
     public T LoadContent<T>(string contentName)
     {
 #if FULL_DIAGNOSTICS
@@ -84,6 +131,11 @@ public class LoaderManager
         return ContentLoader.LoadContent<T>(contentName);
     }
 
+    /// <summary>
+    /// Attempts to load content of type <typeparamref name="T"/> by delegating to
+    /// <see cref="ContentLoader"/>, returning <c>default(T)</c> instead of throwing when the content
+    /// cannot be loaded. As with <see cref="LoadContent{T}"/>, caching is handled by the loader.
+    /// </summary>
     public T TryLoadContent<T>(string contentName)
     {
 
@@ -97,6 +149,10 @@ public class LoaderManager
         return ContentLoader.TryLoadContent<T>(contentName);
     }
 
+    /// <summary>
+    /// Returns the cached asset of type <typeparamref name="T"/> stored under <paramref name="contentName"/>,
+    /// or <c>default(T)</c> if none is cached. Unlike <see cref="LoadContent{T}"/>, this never loads from disk.
+    /// </summary>
     public T TryGetCachedDisposable<T>(string contentName)
     {
         if (mCachedDisposables.ContainsKey(contentName))
@@ -109,6 +165,10 @@ public class LoaderManager
         }
     }
 
+    /// <summary>
+    /// Returns the cached asset stored under <paramref name="name"/>, or <c>null</c> if none is cached.
+    /// Called by <see cref="IContentLoader"/> implementations to check the cache before loading.
+    /// </summary>
     public IDisposable? GetDisposable(string name)
     {
         if (mCachedDisposables.ContainsKey(name))
@@ -121,6 +181,13 @@ public class LoaderManager
         }
     }
 
+    /// <summary>
+    /// Adds a loaded, disposable asset to the cache under the given (standardized) name. Called by
+    /// <see cref="IContentLoader"/> implementations after a successful load.
+    /// </summary>
+    /// <param name="name">The cache key, typically a standardized absolute file path.</param>
+    /// <param name="disposable">The loaded asset to cache.</param>
+    /// <param name="existingContentBehavior">Whether to throw or replace when <paramref name="name"/> is already cached.</param>
     public void AddDisposable(string name, IDisposable disposable, ExistingContentBehavior existingContentBehavior = ExistingContentBehavior.ThrowException)
     {
 #if FULL_DIAGNOSTICS
@@ -140,6 +207,9 @@ public class LoaderManager
         }
     }
 
+    /// <summary>
+    /// Disposes every cached asset and empties the cache.
+    /// </summary>
     public void DisposeAndClear()
     {
         foreach (var item in mCachedDisposables.Values)
@@ -150,6 +220,10 @@ public class LoaderManager
         mCachedDisposables.Clear();
     }
 
+    /// <summary>
+    /// Disposes the cached asset stored under <paramref name="name"/> and removes it from the cache.
+    /// Does nothing if no asset is cached under that name.
+    /// </summary>
     public void Dispose(string name)
     {
         if (mCachedDisposables.ContainsKey(name))
@@ -159,6 +233,10 @@ public class LoaderManager
         }
     }
 
+    /// <summary>
+    /// Removes the given asset from the cache without disposing it. Useful for long-lived assets (such
+    /// as a default font) that should survive a cache clear and remain owned by the caller.
+    /// </summary>
     public void RemoveWithoutDisposing(IDisposable disposable)
     {
         var kvp = mCachedDisposables.FirstOrDefault(item => item.Value == disposable);

--- a/GumCommon/GumCommon.csproj
+++ b/GumCommon/GumCommon.csproj
@@ -102,7 +102,6 @@
 		<Compile Include="..\RenderingLibrary\IGumService.cs" Link="RenderingLibrary\IGumService.cs" />
 		<Compile Include="..\RenderingLibrary\INativeTextInput.cs" Link="RenderingLibrary\INativeTextInput.cs" />
 		<Compile Include="..\RenderingLibrary\ISystemManagers.cs" Link="RenderingLibrary\ISystemManagers.cs" />
-		<Compile Include="..\Runtimes\SkiaGum\Content\LoaderManager.cs" Link="Content\LoaderManager.cs" />
 		<Compile Include="..\ToolsUtilities\**\*.cs" Link="Utilities\%(RecursiveDir)%(Filename)%(Extension)" />
 	</ItemGroup>
 

--- a/RenderingLibrary/Content/ContentLoader.cs
+++ b/RenderingLibrary/Content/ContentLoader.cs
@@ -28,6 +28,7 @@ public class ContentLoader : IContentLoader
 
     //List<Atlas> atlases = new List<Atlas>();
 
+    /// <inheritdoc/>
     public T LoadContent<T>(string contentName)
     {
         if(typeof(T) == typeof(Texture2D))
@@ -54,6 +55,7 @@ public class ContentLoader : IContentLoader
         }
     }
 
+    /// <inheritdoc/>
     public T? TryLoadContent<T>( string contentName)
     {
         bool knownType = false;

--- a/RenderingLibrary/Content/IContentLoader.cs
+++ b/RenderingLibrary/Content/IContentLoader.cs
@@ -1,12 +1,49 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 
-namespace RenderingLibrary.Content
-{
-    public interface IContentLoader
-    {
-        T LoadContent<T>(string contentName);
+namespace RenderingLibrary.Content;
 
-        T TryLoadContent<T>(string contentName);
-    }
+/// <summary>
+/// Strategy for turning a content name (typically a file path) into a loaded asset such as a
+/// texture or font. Each rendering backend (MonoGame/KNI/FNA, Raylib, Skia, and so on) ships its
+/// own implementation.
+/// </summary>
+/// <remarks>
+/// The active loader is held by <see cref="LoaderManager.ContentLoader"/>; assign your own
+/// implementation there to customize how Gum resolves assets — for example, to load from a custom
+/// asset store, or to hand back an asset your game engine has already loaded so the same texture is
+/// not loaded into memory twice. A custom loader typically wraps (delegates to) the built-in loader
+/// for any content name it does not handle, so default loading and caching are preserved.
+/// <para>
+/// Implementations are responsible for their own caching. See the remarks on
+/// <see cref="LoaderManager.LoadContent{T}"/> for why caching lives in the loader rather than in
+/// <see cref="LoaderManager"/>.
+/// </para>
+/// </remarks>
+public interface IContentLoader
+{
+    /// <summary>
+    /// Loads content of the requested type by name, throwing if the type is unsupported or the
+    /// content cannot be loaded.
+    /// </summary>
+    /// <typeparam name="T">The asset type to load, such as a texture.</typeparam>
+    /// <param name="contentName">
+    /// The content name, typically a file path resolved relative to
+    /// <see cref="ToolsUtilities.FileManager.RelativeDirectory"/>.
+    /// </param>
+    /// <returns>The loaded asset.</returns>
+    T LoadContent<T>(string contentName);
+
+    /// <summary>
+    /// Attempts to load content of the requested type by name, returning the type's default value
+    /// (for example <c>null</c> for reference types) instead of throwing when the content is
+    /// missing or cannot be loaded.
+    /// </summary>
+    /// <typeparam name="T">The asset type to load, such as a texture.</typeparam>
+    /// <param name="contentName">
+    /// The content name, typically a file path resolved relative to
+    /// <see cref="ToolsUtilities.FileManager.RelativeDirectory"/>.
+    /// </param>
+    /// <returns>The loaded asset, or <c>default(T)</c> if it could not be loaded.</returns>
+    T TryLoadContent<T>(string contentName);
 }

--- a/RenderingLibrary/Content/LoaderManager.cs
+++ b/RenderingLibrary/Content/LoaderManager.cs
@@ -10,11 +10,32 @@ using Matrix = System.Numerics.Matrix4x4;
 
 namespace RenderingLibrary.Content
 {
+    /// <summary>
+    /// Owns the shared texture/content cache and the active <see cref="IContentLoader"/>. All Gum
+    /// runtime asset loading flows through here: callers use <see cref="LoadContent{T}"/> /
+    /// <see cref="TryLoadContent{T}"/>, which delegate to <see cref="ContentLoader"/>.
+    /// </summary>
+    /// <remarks>
+    /// To customize how content names resolve to assets (a custom asset store, or an engine resource
+    /// that is already in memory), assign your own loader to <see cref="ContentLoader"/>.
+    /// The cache itself is a dictionary of <see cref="IDisposable"/> keyed by standardized file path;
+    /// see <see cref="LoadContent{T}"/> for why the cache is populated by the loader rather than here.
+    /// </remarks>
     public class LoaderManager
     {
+        /// <summary>
+        /// Controls what happens when content is added to the cache under a name that already exists.
+        /// </summary>
         public enum ExistingContentBehavior
         {
+            /// <summary>
+            /// Throw an exception if content is already cached under the same name.
+            /// </summary>
             ThrowException,
+
+            /// <summary>
+            /// Replace the existing cached content with the new content.
+            /// </summary>
             Replace
         }
 
@@ -26,6 +47,10 @@ namespace RenderingLibrary.Content
         
         Dictionary<string, IDisposable> mCachedDisposables = new Dictionary<string, IDisposable>(StringComparer.OrdinalIgnoreCase);
 
+        /// <summary>
+        /// The currently cached content, keyed by standardized (case-insensitive) file path. Read-only;
+        /// use <see cref="AddDisposable"/> / <see cref="Dispose(string)"/> to modify the cache.
+        /// </summary>
         public IReadOnlyDictionary<string, IDisposable> CachedDisposables => mCachedDisposables;
 
         ContentManager mContentManager;
@@ -36,12 +61,22 @@ namespace RenderingLibrary.Content
 
         #region Properties
 
+        /// <summary>
+        /// The active content-loading strategy that <see cref="LoadContent{T}"/> and
+        /// <see cref="TryLoadContent{T}"/> delegate to. Each backend sets a default loader during
+        /// initialization; assign your own <see cref="IContentLoader"/> to customize asset resolution.
+        /// </summary>
         public IContentLoader ContentLoader
         {
             get;
             set;
         }
 
+        /// <summary>
+        /// Whether loaded textures are cached and reused. When set to <c>false</c>, the entire cache is
+        /// immediately disposed and cleared, so any still-referenced textures become invalid; setting it
+        /// back to <c>true</c> forces subsequent loads to go to disk again.
+        /// </summary>
         public bool CacheTextures
         {
             get { return mCacheTextures; }
@@ -62,7 +97,15 @@ namespace RenderingLibrary.Content
             }
         }
 
+        /// <summary>
+        /// A placeholder texture (red X) returned by <see cref="LoadOrInvalid"/> when a requested
+        /// texture cannot be loaded.
+        /// </summary>
         public Texture2D InvalidTexture => Sprite.InvalidTexture;
+
+        /// <summary>
+        /// The shared singleton instance.
+        /// </summary>
         public static LoaderManager Self
         {
             get
@@ -75,12 +118,21 @@ namespace RenderingLibrary.Content
             }
         }
 
+        /// <summary>
+        /// Obsolete. Use <see cref="Text.DefaultFont"/> instead.
+        /// </summary>
         [Obsolete("Use Text.DefaultFont instead")]
         public SpriteFont DefaultFont => Text.DefaultFont;
 
+        /// <summary>
+        /// Obsolete. Use <see cref="Text.DefaultBitmapFont"/> instead.
+        /// </summary>
         [Obsolete("Use Text.DefaultBitmapFont instead")]
         public BitmapFont DefaultBitmapFont => Text.DefaultBitmapFont;
 
+        /// <summary>
+        /// The file extensions (without leading dot) that Gum treats as loadable textures.
+        /// </summary>
         public IEnumerable<string> ValidTextureExtensions
         {
             get
@@ -98,6 +150,13 @@ namespace RenderingLibrary.Content
 
         #region Methods
 
+        /// <summary>
+        /// Adds a loaded, disposable asset to the cache under the given (standardized) name. Called by
+        /// <see cref="IContentLoader"/> implementations after a successful load.
+        /// </summary>
+        /// <param name="name">The cache key, typically a standardized absolute file path.</param>
+        /// <param name="disposable">The loaded asset to cache.</param>
+        /// <param name="existingContentBehavior">Whether to throw or replace when <paramref name="name"/> is already cached.</param>
         public void AddDisposable(string name, IDisposable disposable, ExistingContentBehavior existingContentBehavior = ExistingContentBehavior.ThrowException)
         {
             if(existingContentBehavior == ExistingContentBehavior.ThrowException)
@@ -110,6 +169,10 @@ namespace RenderingLibrary.Content
             }
         }
 
+        /// <summary>
+        /// Disposes the cached asset stored under <paramref name="name"/> and removes it from the cache.
+        /// Does nothing if no asset is cached under that name.
+        /// </summary>
         public void Dispose(string name)
         {
             if(mCachedDisposables.ContainsKey(name))
@@ -119,6 +182,10 @@ namespace RenderingLibrary.Content
             }
         }
 
+        /// <summary>
+        /// Returns the cached asset stored under <paramref name="name"/>, or <c>null</c> if none is cached.
+        /// Called by <see cref="IContentLoader"/> implementations to check the cache before loading.
+        /// </summary>
         public IDisposable GetDisposable(string name)
         {
             if (mCachedDisposables.ContainsKey(name))
@@ -131,6 +198,14 @@ namespace RenderingLibrary.Content
             }
         }
 
+        /// <summary>
+        /// Creates the <see cref="InvalidTexture"/> placeholder and loads the default font. Called
+        /// internally during runtime setup; game code typically does not need to call this directly.
+        /// </summary>
+        /// <param name="invalidTextureLocation">Optional path to a texture used as the invalid-texture placeholder; a generated red-X texture is used when null or missing.</param>
+        /// <param name="defaultFontLocation">Path to the default font (a <c>.fnt</c> bitmap font or a content-pipeline <c>SpriteFont</c>); defaults to "hudFont" when null.</param>
+        /// <param name="serviceProvider">The service provider used to create the internal <see cref="ContentManager"/>.</param>
+        /// <param name="managers">The <see cref="SystemManagers"/> providing the graphics device.</param>
         public void Initialize(string invalidTextureLocation, string defaultFontLocation, IServiceProvider serviceProvider, SystemManagers managers)
         {
             if (mContentManager == null)
@@ -177,6 +252,10 @@ namespace RenderingLibrary.Content
             }
         }
 
+        /// <summary>
+        /// Loads a texture by name, returning <see cref="InvalidTexture"/> (and the exception text via
+        /// <paramref name="errorMessage"/>) instead of throwing when the load fails.
+        /// </summary>
         public Texture2D LoadOrInvalid(string fileName, SystemManagers managers, out string errorMessage)
         {
             Texture2D toReturn;
@@ -194,6 +273,10 @@ namespace RenderingLibrary.Content
             return toReturn;
         }
 
+        /// <summary>
+        /// Returns the cached asset of type <typeparamref name="T"/> stored under <paramref name="contentName"/>,
+        /// or <c>default(T)</c> if none is cached. Unlike <see cref="LoadContent{T}"/>, this never loads from disk.
+        /// </summary>
         public T TryGetCachedDisposable<T>(string contentName)
         {
             if (mCachedDisposables.ContainsKey(contentName))
@@ -206,6 +289,9 @@ namespace RenderingLibrary.Content
             }
         }
 
+        /// <summary>
+        /// Disposes every cached asset and empties the cache.
+        /// </summary>
         public void DisposeAndClear()
         {
             foreach (var item in mCachedDisposables.Values)
@@ -217,6 +303,11 @@ namespace RenderingLibrary.Content
             mContentManager = null;
         }
 
+        /// <summary>
+        /// Attempts to load content of type <typeparamref name="T"/> by delegating to
+        /// <see cref="ContentLoader"/>, returning <c>default(T)</c> instead of throwing when the content
+        /// cannot be loaded. As with <see cref="LoadContent{T}"/>, caching is handled by the loader.
+        /// </summary>
         public T TryLoadContent<T>( string contentName)
         {
 
@@ -229,6 +320,34 @@ namespace RenderingLibrary.Content
             return ContentLoader.TryLoadContent<T>(contentName);
         }
 
+        /// <summary>
+        /// Loads content of type <typeparamref name="T"/> by delegating to the active
+        /// <see cref="ContentLoader"/>.
+        /// </summary>
+        /// <remarks>
+        /// This method does not cache; it simply forwards to <see cref="ContentLoader"/>. Caching is the
+        /// loader's responsibility (it calls <see cref="GetDisposable"/> before loading and
+        /// <see cref="AddDisposable"/> after) rather than being handled here. The cache logic lives in the
+        /// loader, not in <see cref="LoaderManager"/>, because each backend's caching and disposal model
+        /// differs and only the loader knows which applies:
+        /// <list type="bullet">
+        /// <item><description>
+        /// Some loaders do their own caching entirely. For example, FlatRedBall's loader delegates to its
+        /// own ContentManager, so this cache is bypassed; caching here too would double-cache and create
+        /// disposal-ownership conflicts.
+        /// </description></item>
+        /// <item><description>
+        /// Some backends (Raylib, Sokol) cache a disposable wrapper around a value-type texture/font and
+        /// must unwrap it on a cache hit — a wrap/unwrap step a generic cache here cannot perform.
+        /// </description></item>
+        /// <item><description>
+        /// Some backends (Skia) cache in a separate object with their own per-type caches and do not use
+        /// this cache at all.
+        /// </description></item>
+        /// </list>
+        /// The cache key is also the standardized, <see cref="ToolsUtilities.FileManager.RelativeDirectory"/>-resolved
+        /// path, which is computed inside the loader; only the raw name is available here.
+        /// </remarks>
         public T LoadContent<T>(string contentName)
         {
 #if DEBUG

--- a/Runtimes/RaylibGum/RenderingLibrary/ContentLoader.cs
+++ b/Runtimes/RaylibGum/RenderingLibrary/ContentLoader.cs
@@ -11,8 +11,14 @@ using static Raylib_cs.Raylib;
 
 namespace RenderingLibrary.Content;
 
+/// <summary>
+/// Raylib implementation of <see cref="IContentLoader"/>. Loads textures and fonts via Raylib and
+/// caches them through <see cref="LoaderManager"/> (wrapped in disposable wrappers, since Raylib's
+/// texture/font types are value types).
+/// </summary>
 public class ContentLoader : IContentLoader
 {
+    /// <inheritdoc/>
     public T LoadContent<T>(string contentName)
     {
         if (typeof(T) == typeof(Texture2D))
@@ -187,6 +193,7 @@ public class ContentLoader : IContentLoader
         }
     }
 
+    /// <inheritdoc/>
     public T TryLoadContent<T>(string contentName)
     {
         if (typeof(T) == typeof(Texture2D))

--- a/Runtimes/SkiaGum/SkiaGum.csproj
+++ b/Runtimes/SkiaGum/SkiaGum.csproj
@@ -33,10 +33,6 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<Compile Remove="Content\LoaderManager.cs" />
-	</ItemGroup>
-
-	<ItemGroup>
 		<Compile Include="..\..\Gum\RenderingLibrary\IPositionedSizedObjectExtensionMethods.cs">
 			<Link>RenderingLibrary\IPositionedSizedObjectExtensionMethods.cs</Link>
 		</Compile>

--- a/docs/code/files-and-fonts/file-loading.md
+++ b/docs/code/files-and-fonts/file-loading.md
@@ -102,3 +102,77 @@ Sprite2.SourceFile = "MyFile.png"; // This also goes to disk to load the file
 ```
 
 Be careful setting CacheTextures to false since all existing textures will be disposed. This means that if you have loaded textures which are still being referenced by runtime objects, you will get an exception if those are still being drawn after setting CacheTextures to false.
+
+### Customizing How Content Loads
+
+By default Gum resolves a `SourceFile` name to a texture by reading a file from disk (relative to `FileManager.RelativeDirectory`). You can replace this behavior with your own logic — for example, to load assets from a custom store, or to hand back a texture your game engine has *already* loaded so the same image isn't loaded into memory twice.
+
+Gum performs all of its loading through an `IContentLoader`, which has two methods:
+
+```csharp
+// Class scope
+public interface IContentLoader
+{
+    T LoadContent<T>(string contentName);
+    T TryLoadContent<T>(string contentName);
+}
+```
+
+The active loader is held by `LoaderManager.Self.ContentLoader`. Each runtime (MonoGame, Raylib, and so on) installs a default loader during initialization. To customize loading, assign your own implementation to that property. **This is the same property and the same `IContentLoader` interface on every backend**, so the approach is identical across MonoGame, KNI, FNA, and Raylib.
+
+#### Wrapping the Built-in Loader
+
+The cleanest approach is to *wrap* the built-in loader: intercept only the content names you care about, and forward everything else to the default loader. This keeps Gum's normal file loading — and its texture caching — working for all the assets you don't handle yourself.
+
+```csharp
+// Class scope
+public class CustomContentLoader : RenderingLibrary.Content.IContentLoader
+{
+    RenderingLibrary.Content.IContentLoader _defaultLoader;
+
+    public CustomContentLoader(RenderingLibrary.Content.IContentLoader defaultLoader)
+    {
+        _defaultLoader = defaultLoader;
+    }
+
+    public T LoadContent<T>(string contentName)
+    {
+        // typeof(T) is the standard way to branch in an IContentLoader.
+        if (typeof(T) == typeof(Texture2D) &&
+            MyAssetSource.TryGetTexture(contentName, out Texture2D texture))
+        {
+            return (T)(object)texture;
+        }
+
+        // Forward everything else so default loading and caching still apply.
+        return _defaultLoader.LoadContent<T>(contentName);
+    }
+
+    public T TryLoadContent<T>(string contentName)
+    {
+        if (typeof(T) == typeof(Texture2D) &&
+            MyAssetSource.TryGetTexture(contentName, out Texture2D texture))
+        {
+            return (T)(object)texture;
+        }
+
+        return _defaultLoader.TryLoadContent<T>(contentName);
+    }
+}
+```
+
+Install it after Gum has initialized (so the default loader exists to wrap) but before any content loads:
+
+```csharp
+// Initialize
+var loaderManager = RenderingLibrary.Content.LoaderManager.Self;
+loaderManager.ContentLoader = new CustomContentLoader(loaderManager.ContentLoader);
+```
+
+{% hint style="warning" %}
+Texture caching lives inside the content loader, not above it. A custom `IContentLoader` that does **not** delegate to the built-in loader will bypass Gum's cache (`LoaderManager.CacheTextures`) entirely — every load goes straight to your code. Wrapping the built-in loader, as shown above, preserves caching for the names you forward. If your custom source already manages its own assets, that's usually fine — you simply don't need Gum's cache for those.
+{% endhint %}
+
+#### Loading Through the MonoGame Content Pipeline
+
+On the XNA-family backends (MonoGame/KNI/FNA), the built-in `ContentLoader` also exposes an `XnaContentManager` property. When set, files referenced without an extension are loaded as content-pipeline (`.xnb`) assets through that `ContentManager`. This is an XNA-only convenience; there is no equivalent on Raylib, which has no content pipeline.


### PR DESCRIPTION
## What this does

Part of #3001 (allow injection of a custom content/texture loader). After research, we decided the right move is to **document the existing `IContentLoader` injection seam** rather than add new API — so this PR is docs + XML docs, plus two pieces of cleanup that came out of the investigation.

Closes #3001.

## Changes

### Docs + XML docs
- XML docs on `IContentLoader`, both `LoaderManager` copies, and the MonoGame/Raylib `ContentLoader` implementations.
- The **cache-split rationale** is captured in `<remarks>` on `LoaderManager.LoadContent<T>` — why caching lives in the loader, not in `LoaderManager` (some loaders self-cache, e.g. FRB; some backends wrap value-type textures in disposables; some cache in a separate object).
- New **"Customizing How Content Loads"** section in `docs/code/files-and-fonts/file-loading.md`: the `LoaderManager.Self.ContentLoader` swap and the **decorator pattern** (wrap the built-in loader so default loading and caching are preserved), plus a note that `XnaContentManager` is an XNA-only convenience.

### Relocate the shared `LoaderManager`
- Moved `Runtimes/SkiaGum/Content/LoaderManager.cs` → `GumCommon/Content/LoaderManager.cs` (git-rename, history preserved). The file was misnamed by location — it's the XNA-free `LoaderManager` compiled into **GumCommon** and used by every GumCommon-referencing runtime, not a Skia-specific file.
- Dropped the explicit cross-project `<Compile Include … Link>` in `GumCommon.csproj` (now globbed from its real home) and removed SkiaGum's now-pointless `<Compile Remove>`.
- The XNA-coupled `RenderingLibrary/Content/LoaderManager.cs` (FRB/legacy) is intentionally untouched.

### New `gum-runtime-topology` skill
- Maps every compilation surface a runtime refactor must verify: `AllLibraries.sln`, the **Mac-excluded** `SkiaGum.Wpf`, `GumFull.sln`, and the three FRB shared projects — plus the same-FQN-fork landmines (e.g. the two `LoaderManager`s). Cross-linked from `refactoring-direction`.

## Verification
- `GumCommon`, `MonoGameGum`, `RaylibGum`, `SkiaGum`, and `SkiaGum.Wpf` all build with **0 errors** and no new doc-comment warnings. (`AllLibraries.sln` itself wasn't built here because the worktree's `fna/` submodule isn't populated — unrelated to these changes.)

## Related follow-ups (filed separately, not in this PR)
- #3032 — remove the dead `AtlasedTexture`/`Atlas` surface (Gum core + the FRB GumPlugin bridge).
- #3033 — Raylib content loading bypasses `FileManager.CustomGetStreamFromFile` (stream-hook gap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
