### PR TITLE
Route Raylib texture loading through FileManager stream hook (#3033)

### DIFF
--- a/Runtimes/RaylibGum/RenderingLibrary/ContentLoader.cs
+++ b/Runtimes/RaylibGum/RenderingLibrary/ContentLoader.cs
@@ -146,9 +146,26 @@ public class ContentLoader : IContentLoader
 
     private static Texture2D LoadTextureFromFile(string fileName)
     {
-        Image image = LoadImage(fileName);
-        //Transform it as a texture
+        // Route through FileManager.GetStreamForFile so the FileManager.CustomGetStreamFromFile
+        // hook is honored on Raylib the same way it is on the MonoGame-family loader. Handing the
+        // path straight to raylib's path-based LoadImage bypassed the hook entirely, so .gumpkg
+        // bundles, the GumFromZipFile sample, mobile TitleContainer redirection, and any
+        // in-memory/encrypted asset store silently failed on Raylib (#3033). raylib's in-memory
+        // LoadImageFromMemory takes the file extension (with the leading dot) to pick its decoder.
+        string fileType = "." + FileManager.GetExtension(fileName);
+
+        byte[] fileData;
+        using (var stream = FileManager.GetStreamForFile(fileName))
+        using (var memoryStream = new MemoryStream())
+        {
+            stream.CopyTo(memoryStream);
+            fileData = memoryStream.ToArray();
+        }
+
+        Image image = LoadImageFromMemory(fileType, fileData);
+        // LoadTextureFromImage uploads to the GPU; the CPU-side Image is no longer needed after.
         var toReturn = LoadTextureFromImage(image);
+        UnloadImage(image);
         return toReturn;
     }
 
@@ -198,10 +215,17 @@ public class ContentLoader : IContentLoader
     {
         if (typeof(T) == typeof(Texture2D))
         {
-            Image image = LoadImage(contentName);
-
-            //Transform it as a texture
-            return (T)(object)LoadTextureFromImage(image);
+            // Same hook-honoring path as LoadContent, but "Try" swallows load failures and returns
+            // default rather than propagating the IOException GetStreamForFile throws when missing.
+            try
+            {
+                string fileNameStandardized = StandardizeCaseSensitive(contentName);
+                return (T)(object)LoadTextureFromFile(fileNameStandardized);
+            }
+            catch
+            {
+                return default(T);
+            }
         }
         else
         {

--- a/Tests/RaylibGum.Tests/Content/ContentLoaderTests.cs
+++ b/Tests/RaylibGum.Tests/Content/ContentLoaderTests.cs
@@ -10,6 +10,85 @@ namespace RaylibGum.Tests.Content;
 
 public class ContentLoaderTests : BaseTestClass
 {
+    // Regression (#3033): the Raylib loader handed the path straight to raylib's LoadImage, which
+    // opens the file off disk itself, so FileManager.CustomGetStreamFromFile was a no-op on Raylib.
+    // Any feature built on that hook (.gumpkg bundles, the GumFromZipFile sample, mobile
+    // TitleContainer redirection, encrypted/in-memory asset stores) silently did nothing. The fix
+    // routes texture loads through FileManager.GetStreamForFile (which consults the hook) and feeds
+    // the bytes to raylib's in-memory loader. Here the texture exists ONLY via the hook — there is
+    // no file on disk at the resolved path — so a successful load proves the hook was honored.
+    [Fact]
+    public void LoadContent_WhenTextureOnlyAvailableViaCustomGetStreamFromFile_ShouldLoadFromHook()
+    {
+        byte[] pngBytes = CreatePngBytes(3, 4);
+
+        string tempRoot = Path.Combine(Path.GetTempPath(), "GumRaylibStreamHookTest_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempRoot);
+
+        string savedRelativeDirectory = FileManager.RelativeDirectory;
+        bool savedCacheTextures = LoaderManager.Self.CacheTextures;
+
+        try
+        {
+            string fileName = "hooked_only_pixel.png";
+
+            // Point RelativeDirectory at an empty temp folder so the resolved absolute path does
+            // NOT exist on disk — the hook is the only way to satisfy the load.
+            FileManager.RelativeDirectory = tempRoot.Replace('\\', '/') + "/";
+            LoaderManager.Self.CacheTextures = false;
+
+            bool hookWasInvoked = false;
+            FileManager.CustomGetStreamFromFile = requestedPath =>
+            {
+                if (requestedPath.Replace('\\', '/').EndsWith(fileName))
+                {
+                    hookWasInvoked = true;
+                    return new MemoryStream(pngBytes);
+                }
+                // null is the hook's documented "I don't have this file" signal.
+                return null!;
+            };
+
+            Texture2D loaded = LoaderManager.Self.ContentLoader.LoadContent<Texture2D>(fileName);
+
+            hookWasInvoked.ShouldBeTrue();
+            loaded.Width.ShouldBe(3);
+            loaded.Height.ShouldBe(4);
+        }
+        finally
+        {
+            FileManager.CustomGetStreamFromFile = null;
+            FileManager.RelativeDirectory = savedRelativeDirectory;
+            LoaderManager.Self.CacheTextures = savedCacheTextures;
+            if (Directory.Exists(tempRoot))
+            {
+                Directory.Delete(tempRoot, recursive: true);
+            }
+        }
+    }
+
+    // Encodes a real PNG into memory by exporting a generated image to a throwaway temp file and
+    // reading the bytes back — raylib has no public encode-to-byte[] helper exposed here, and this
+    // matches the GenImageColor/ExportImage idiom already used below.
+    private static byte[] CreatePngBytes(int width, int height)
+    {
+        string tempFile = Path.Combine(Path.GetTempPath(), "GumRaylibStreamHookSource_" + Guid.NewGuid().ToString("N") + ".png");
+        Image image = Raylib.GenImageColor(width, height, Raylib_cs.Color.Blue);
+        try
+        {
+            Raylib.ExportImage(image, tempFile);
+            return File.ReadAllBytes(tempFile);
+        }
+        finally
+        {
+            Raylib.UnloadImage(image);
+            if (File.Exists(tempFile))
+            {
+                File.Delete(tempFile);
+            }
+        }
+    }
+
     // Regression: ContentLoader.LoadTexture2D used to cache by the relative-directory-prefixed
     // name but actually call LoadImage with the bare filename, so any caller that relied on
     // FileManager.RelativeDirectory (notably AnimationChainList.ToAnimationChainList, which sets

--- a/Tests/RaylibGum.Tests/Content/ContentLoaderTests.cs
+++ b/Tests/RaylibGum.Tests/Content/ContentLoaderTests.cs
@@ -10,6 +10,41 @@ namespace RaylibGum.Tests.Content;
 
 public class ContentLoaderTests : BaseTestClass
 {
+    // Pins the missing-file semantics that changed with #3033. The old path-based LoadImage
+    // returned a silent empty Image for a missing file; routing through FileManager.GetStreamForFile
+    // means a missing file now throws (an IOException), matching the MonoGame-family loader. Callers
+    // such as Sprite source assignment wrap LoadContent in a catch and honor
+    // GraphicalUiElement.MissingFileBehavior, so this throw is the intended contract — not a leak.
+    [Fact]
+    public void LoadContent_WhenFileMissingAndNoHook_ShouldThrow()
+    {
+        string tempRoot = Path.Combine(Path.GetTempPath(), "GumRaylibMissingFileTest_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempRoot);
+
+        string savedRelativeDirectory = FileManager.RelativeDirectory;
+        bool savedCacheTextures = LoaderManager.Self.CacheTextures;
+
+        try
+        {
+            // Empty temp folder + no hook → the resolved path exists nowhere, so the load must throw.
+            FileManager.RelativeDirectory = tempRoot.Replace('\\', '/') + "/";
+            LoaderManager.Self.CacheTextures = false;
+            FileManager.CustomGetStreamFromFile = null;
+
+            Should.Throw<Exception>(() =>
+                LoaderManager.Self.ContentLoader.LoadContent<Texture2D>("does_not_exist.png"));
+        }
+        finally
+        {
+            FileManager.RelativeDirectory = savedRelativeDirectory;
+            LoaderManager.Self.CacheTextures = savedCacheTextures;
+            if (Directory.Exists(tempRoot))
+            {
+                Directory.Delete(tempRoot, recursive: true);
+            }
+        }
+    }
+
     // Regression (#3033): the Raylib loader handed the path straight to raylib's LoadImage, which
     // opens the file off disk itself, so FileManager.CustomGetStreamFromFile was a no-op on Raylib.
     // Any feature built on that hook (.gumpkg bundles, the GumFromZipFile sample, mobile
@@ -135,6 +170,92 @@ public class ContentLoaderTests : BaseTestClass
         }
         finally
         {
+            FileManager.RelativeDirectory = savedRelativeDirectory;
+            LoaderManager.Self.CacheTextures = savedCacheTextures;
+            if (Directory.Exists(tempRoot))
+            {
+                Directory.Delete(tempRoot, recursive: true);
+            }
+        }
+    }
+
+    // TryLoadContent was changed alongside #3033 to route through the same hook-honoring path as
+    // LoadContent. Its "Try" contract is to swallow load failures and return default rather than
+    // propagate the IOException GetStreamForFile throws for a missing file. Pins that no-throw path.
+    [Fact]
+    public void TryLoadContent_WhenFileMissing_ShouldReturnDefaultWithoutThrowing()
+    {
+        string tempRoot = Path.Combine(Path.GetTempPath(), "GumRaylibTryLoadMissingTest_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempRoot);
+
+        string savedRelativeDirectory = FileManager.RelativeDirectory;
+        bool savedCacheTextures = LoaderManager.Self.CacheTextures;
+
+        try
+        {
+            FileManager.RelativeDirectory = tempRoot.Replace('\\', '/') + "/";
+            LoaderManager.Self.CacheTextures = false;
+            FileManager.CustomGetStreamFromFile = null;
+
+            Texture2D loaded = default;
+            Should.NotThrow(() =>
+                loaded = LoaderManager.Self.ContentLoader.TryLoadContent<Texture2D>("does_not_exist.png"));
+
+            // default(Texture2D) is a zeroed struct — no width/height/pixels.
+            loaded.Width.ShouldBe(0);
+        }
+        finally
+        {
+            FileManager.RelativeDirectory = savedRelativeDirectory;
+            LoaderManager.Self.CacheTextures = savedCacheTextures;
+            if (Directory.Exists(tempRoot))
+            {
+                Directory.Delete(tempRoot, recursive: true);
+            }
+        }
+    }
+
+    // The companion to the missing-file case: when bytes are available only through the hook,
+    // TryLoadContent must honor it (the old implementation called raylib's path-based LoadImage and
+    // ignored the hook entirely).
+    [Fact]
+    public void TryLoadContent_WhenTextureAvailableViaCustomGetStreamFromFile_ShouldLoadFromHook()
+    {
+        byte[] pngBytes = CreatePngBytes(5, 6);
+
+        string tempRoot = Path.Combine(Path.GetTempPath(), "GumRaylibTryLoadHookTest_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempRoot);
+
+        string savedRelativeDirectory = FileManager.RelativeDirectory;
+        bool savedCacheTextures = LoaderManager.Self.CacheTextures;
+
+        try
+        {
+            string fileName = "try_hooked_pixel.png";
+            FileManager.RelativeDirectory = tempRoot.Replace('\\', '/') + "/";
+            LoaderManager.Self.CacheTextures = false;
+
+            bool hookWasInvoked = false;
+            FileManager.CustomGetStreamFromFile = requestedPath =>
+            {
+                if (requestedPath.Replace('\\', '/').EndsWith(fileName))
+                {
+                    hookWasInvoked = true;
+                    return new MemoryStream(pngBytes);
+                }
+                // null is the hook's documented "I don't have this file" signal.
+                return null!;
+            };
+
+            Texture2D loaded = LoaderManager.Self.ContentLoader.TryLoadContent<Texture2D>(fileName);
+
+            hookWasInvoked.ShouldBeTrue();
+            loaded.Width.ShouldBe(5);
+            loaded.Height.ShouldBe(6);
+        }
+        finally
+        {
+            FileManager.CustomGetStreamFromFile = null;
             FileManager.RelativeDirectory = savedRelativeDirectory;
             LoaderManager.Self.CacheTextures = savedCacheTextures;
             if (Directory.Exists(tempRoot))


### PR DESCRIPTION
## Summary

Raylib's content loader handed paths straight to raylib's path-based `LoadImage`, which opens the file off disk itself. That bypassed `ToolsUtilities.FileManager.GetStreamForFile` and its `CustomGetStreamFromFile` hook, so the hook was a **no-op on Raylib**. Any feature built on that seam worked on the MonoGame family but silently did nothing on Raylib:

- `.gumpkg` single-file bundles,
- the `GumFromZipFile` sample,
- mobile `TitleContainer` redirection,
- any encrypted / in-memory / custom asset store.

## Change

- `ContentLoader.LoadTextureFromFile` now reads bytes via `FileManager.GetStreamForFile` (which consults the hook) and feeds them to raylib's in-memory `LoadImageFromMemory(fileType, bytes)`, unifying the byte-level stream-injection story across backends.
- `TryLoadContent` is routed through the same path — it bypassed the hook too — while preserving its no-throw semantics (load failures return `default`).
- The CPU-side `Image` is now `UnloadImage`-d after the GPU texture is created.

## Tests

New `RaylibGum.Tests` case `LoadContent_WhenTextureOnlyAvailableViaCustomGetStreamFromFile_ShouldLoadFromHook` loads a texture that exists **only** via the hook (no file on disk at the resolved path), so a successful load proves the hook was honored. Written test-first: it failed (`hookWasInvoked == false`) before the fix and passes after. Full RaylibGum.Tests suite green (251 tests).

## Scope: fonts deferred

Fonts were listed in the issue but are deliberately **out of scope** here. Raylib renders text from Gum's FontCache **bitmap fonts** (`FontCache/Font18Arial.fnt`), and an AngelCode `.fnt` is a text descriptor that references its `.png` atlas page by relative path. `LoadFontFromMemory(".fnt", …)` can't resolve that page from a bundle, so honoring the hook for bundled bitmap fonts requires Gum to parse the `.fnt` itself and load the page through the now-hooked texture path — a meaningfully larger change. Tracked as a follow-up.

Closes #3033.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
