### PR TITLE
Realize deferred fonts in UpdateLayout (#2999)

### DIFF
--- a/.claude/skills/gum-layout-engine/SKILL.md
+++ b/.claude/skills/gum-layout-engine/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: gum-layout-engine
 description: Deep internals of Gum's layout engine — UpdateLayout call chain, UpdateChildren ordering, stacking pipeline, dirty state, perf. Triggers: debugging/optimizing UpdateLayout/UpdateChildren, RefreshParentRowColumnDimensionForThis, GetWhatToStackAfter, MakeDirty, ResumeLayoutUpdateIfDirtyRecursive, _cachedSiblingIndex.
-trigger_phrase: UpdateLayout internals|UpdateChildren|GetWhatToStackAfter|RefreshParentRowColumnDimensionForThis|MakeDirty|ResumeLayoutUpdateIfDirtyRecursive|_cachedSiblingIndex|layout performance|ChildrenUpdateDepth|GetIfShouldCallUpdateOnParent|UseFixedStackChildrenSize|UpdateLayoutCallCount
+trigger_phrase: UpdateLayout internals|UpdateChildren|GetWhatToStackAfter|RefreshParentRowColumnDimensionForThis|MakeDirty|ResumeLayoutUpdateIfDirtyRecursive|_cachedSiblingIndex|layout performance|ChildrenUpdateDepth|GetIfShouldCallUpdateOnParent|UseFixedStackChildrenSize|UpdateLayoutCallCount|isFontDirty|SuppressLayoutFromFontChange|font during layout
 ---
 
 # Gum Layout Engine Internals
@@ -63,6 +63,14 @@ Entry point: `UpdateLayout(ParentUpdateType, int childrenUpdateDepth, XOrY?)`
 
 12. **Post-layout dimension check** — if size changed and parent depends on
     children, re-update dimensions. If still changed, update parent.
+
+### Deferred font realization (step 4.5)
+
+Right after the parent-delegate early-out, before measuring, a node loads any font deferred while
+layout was suspended (`isFontDirty`, set under `IsAllLayoutSuspended`). This is what makes a bare
+`UpdateLayout()` realize deferred fonts. The font assignment normally calls `UpdateLayout` again
+for `RelativeToChildren` text; that call is suppressed here (`SuppressLayoutFromFontChange`) because
+this pass already sizes the element. See the **gum-property-assignment** skill for the full cascade.
 
 ## UpdateChildren Internals
 

--- a/.claude/skills/gum-property-assignment/SKILL.md
+++ b/.claude/skills/gum-property-assignment/SKILL.md
@@ -103,6 +103,15 @@ Two code paths consume `isFontDirty`:
    then recurses to children. This ordering is critical — if `mIsLayoutSuspended` were still true
    when `UpdateFontRecursive` runs, that element's font load would be skipped.
 
+3. **`UpdateLayout` itself** (#2999): each node realizes its own deferred font at the top of its
+   layout body, *before* it measures itself. So a bare `UpdateLayout()` after lifting
+   `IsAllLayoutSuspended` loads deferred fonts too — callers don't have to also call
+   `UpdateFontRecursive`. The font assignment's own follow-up `UpdateLayout` (the
+   `RelativeToChildren` branch in the string-path `UpdateToFontValues`) is suppressed during this
+   flush via `GraphicalUiElement.SuppressLayoutFromFontChange`, since the in-progress pass already
+   sizes the element; `isFontDirty` is cleared *before* the load so the suppressed re-layout can't
+   re-trigger it.
+
 ### Known gap
 
 When fonts are set via the string path (`SetProperty`) during an `ApplyState` that uses

--- a/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
+++ b/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
@@ -1581,7 +1581,14 @@ public class CustomSetPropertyOnRenderable
                 // If height is relative to children, it could be in a stack
                 graphicalUiElement.HeightUnits == DimensionUnitType.RelativeToChildren)
             {
-                graphicalUiElement.UpdateLayout();
+                // When this font load is the #2999 deferred-font flush performed from inside
+                // UpdateLayout, the enclosing layout pass already sizes this element, so this
+                // extra UpdateLayout would be redundant and re-entrant (no-arg UpdateLayout also
+                // requests a parent update). Skip it in that case.
+                if (!GraphicalUiElement.SuppressLayoutFromFontChange)
+                {
+                    graphicalUiElement.UpdateLayout();
+                }
             }
         }
 

--- a/GumRuntime/GraphicalUiElement.cs
+++ b/GumRuntime/GraphicalUiElement.cs
@@ -159,6 +159,13 @@ public partial class GraphicalUiElement : IRenderableIpso, IVisible, INotifyProp
         internal set => isFontDirty = value;
     }
 
+    // Set true while UpdateLayout realizes a deferred font (see the isFontDirty flush in
+    // UpdateLayout). While set, the font assignment in CustomSetPropertyOnRenderable skips the
+    // UpdateLayout call it would otherwise make for RelativeToChildren text — the in-progress
+    // layout pass already sizes the element, so that extra call would be redundant (and, because
+    // a no-arg UpdateLayout requests a parent update, would re-enter the current pass). See #2999.
+    internal static bool SuppressLayoutFromFontChange = false;
+
     /// <summary>
     /// The total number of layout calls that have been performed since the application has started running.
     /// This value can be used as a rough indication of the layout cost and to measure whether efforts to reduce
@@ -1935,6 +1942,26 @@ public partial class GraphicalUiElement : IRenderableIpso, IVisible, INotifyProp
         UpdateLayoutCallCount++;
 
         #endregion
+
+        // #2999 — realize any font deferred while layout was suspended, now, before this element
+        // measures itself. Font properties set under suspension only flag isFontDirty; a bare
+        // UpdateLayout() (what callers and the font-performance docs use on resume) must load the
+        // font so the element sizes from the real glyphs instead of the fallback font. isFontDirty
+        // is cleared first so the font assignment's own (suppressed) re-entrant layout can't re-load.
+        if (isFontDirty)
+        {
+            isFontDirty = false;
+            bool wasSuppressingLayoutFromFontChange = SuppressLayoutFromFontChange;
+            SuppressLayoutFromFontChange = true;
+            try
+            {
+                UpdateToFontValues();
+            }
+            finally
+            {
+                SuppressLayoutFromFontChange = wasSuppressingLayoutFromFontChange;
+            }
+        }
 
         float widthBeforeLayout = 0;
         float heightBeforeLayout = 0;

--- a/MonoGameGum.Tests/Runtimes/FontServiceTests.cs
+++ b/MonoGameGum.Tests/Runtimes/FontServiceTests.cs
@@ -382,5 +382,50 @@ public class FontServiceTests : BaseTestClass
         capturedCalls.Count.ShouldBe(2);
     }
 
+    [Fact]
+    public void UpdateLayout_ShouldFlushDeferredFontLoad_AfterGlobalSuspendBatch()
+    {
+        // Repro for #2999. Fonts set while IsAllLayoutSuspended is true are deferred
+        // (IsFontDirty). Users — and the font-performance docs — resume by calling
+        // UpdateLayout(), NOT UpdateFontRecursive(). UpdateLayout() must therefore
+        // realize the deferred font; otherwise text renders in the renderer's fallback
+        // font until something else (e.g. a hover re-applying state) loads it.
+        TextRuntime textRuntime = new();
+        List<BmfcSave> capturedCalls = StartCapturingFontCalls();
+
+        GraphicalUiElement.IsAllLayoutSuspended = true;
+        textRuntime.SetProperty("Font", "Consolas");
+        textRuntime.SetProperty("FontSize", 24);
+        GraphicalUiElement.IsAllLayoutSuspended = false;
+
+        textRuntime.UpdateLayout();
+
+        capturedCalls.Count.ShouldBe(1);
+        textRuntime.IsFontDirty.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void UpdateLayout_ShouldFlushDeferredChildFont_WhenCalledOnParent()
+    {
+        // Faithful to #2999's shape: layout suspended at a high level, a child Text
+        // populated under suspension (font deferred), then a bare UpdateLayout() on the
+        // PARENT must realize the child's font via the recursive layout pass — the user's
+        // repro resumes with ItemList.Visual.UpdateLayout(), not UpdateFontRecursive().
+        ContainerRuntime parent = new();
+        TextRuntime childText = new();
+        parent.AddChild(childText);
+        List<BmfcSave> capturedCalls = StartCapturingFontCalls();
+
+        GraphicalUiElement.IsAllLayoutSuspended = true;
+        childText.SetProperty("Font", "Consolas");
+        childText.SetProperty("FontSize", 24);
+        GraphicalUiElement.IsAllLayoutSuspended = false;
+
+        parent.UpdateLayout();
+
+        capturedCalls.Count.ShouldBe(1);
+        childText.IsFontDirty.ShouldBeFalse();
+    }
+
     #endregion
 }

--- a/MonoGameGum.Tests/Runtimes/FontServiceTests.cs
+++ b/MonoGameGum.Tests/Runtimes/FontServiceTests.cs
@@ -617,5 +617,69 @@ public class FontServiceTests : BaseTestClass
         delta.ShouldBe(1);
     }
 
+    [Fact]
+    public void UpdateLayout_ShouldFlushDeferredFontLoad_WhenFontSetViaDirectSetter()
+    {
+        // The font-performance docs use direct setters then UpdateLayout():
+        //   textRuntime.Font = ...; textRuntime.FontSize = ...; textRuntime.UpdateLayout();
+        // That path defers via the instance UpdateToFontValues (not the string SetProperty path),
+        // so it must be flushed by UpdateLayout too.
+        TextRuntime textRuntime = new();
+        List<BmfcSave> capturedCalls = StartCapturingFontCalls();
+
+        GraphicalUiElement.IsAllLayoutSuspended = true;
+        textRuntime.Font = "Consolas";
+        textRuntime.FontSize = 24;
+        GraphicalUiElement.IsAllLayoutSuspended = false;
+
+        textRuntime.UpdateLayout();
+
+        capturedCalls.Count.ShouldBe(1);
+        textRuntime.IsFontDirty.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void UpdateLayout_OnStackedChild_ShouldFlushItsDeferredFont_ViaParentReprocess()
+    {
+        // The #2999 topology is a stack. A child of a stacking parent delegates its UpdateLayout up
+        // to the parent (GetIfShouldCallUpdateOnParent), which reprocesses it as a child. The
+        // deferred-font flush must still happen through that reprocess.
+        ContainerRuntime parent = new();
+        parent.ChildrenLayout = Gum.Managers.ChildrenLayout.TopToBottomStack;
+        TextRuntime childText = new();
+        parent.AddChild(childText);
+        List<BmfcSave> capturedCalls = StartCapturingFontCalls();
+
+        GraphicalUiElement.IsAllLayoutSuspended = true;
+        childText.SetProperty("Font", "Consolas");
+        childText.SetProperty("FontSize", 24);
+        GraphicalUiElement.IsAllLayoutSuspended = false;
+
+        childText.UpdateLayout();   // delegates to the stacking parent, which reprocesses this child
+
+        capturedCalls.Count.ShouldBe(1);
+        childText.IsFontDirty.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void UpdateLayout_ShouldClearFontDirty_EvenWhenFontCannotBeResolved()
+    {
+        // Hot-path guard against a retry storm: if a deferred font can't be resolved (no FontService,
+        // unknown name), the flush must still clear isFontDirty so it isn't re-attempted on every
+        // subsequent layout.
+        CustomSetPropertyOnRenderable.FontService = null;
+        TextRuntime textRuntime = new();
+
+        GraphicalUiElement.IsAllLayoutSuspended = true;
+        textRuntime.SetProperty("Font", "NonexistentFont12345");
+        textRuntime.SetProperty("FontSize", 24);
+        GraphicalUiElement.IsAllLayoutSuspended = false;
+        textRuntime.IsFontDirty.ShouldBeTrue();   // deferred
+
+        textRuntime.UpdateLayout();
+
+        textRuntime.IsFontDirty.ShouldBeFalse();   // cleared — no per-layout retry
+    }
+
     #endregion
 }

--- a/MonoGameGum.Tests/Runtimes/FontServiceTests.cs
+++ b/MonoGameGum.Tests/Runtimes/FontServiceTests.cs
@@ -1,9 +1,13 @@
 using Gum.Wireframe;
 using Gum.GueDeriving;
+using Microsoft.Xna.Framework.Graphics;
 using Moq;
+using RenderingLibrary.Content;
+using RenderingLibrary.Graphics;
 using RenderingLibrary.Graphics.Fonts;
 using Shouldly;
 using System.Collections.Generic;
+using ToolsUtilities;
 using Xunit;
 
 namespace MonoGameGum.Tests.Runtimes;
@@ -11,6 +15,13 @@ namespace MonoGameGum.Tests.Runtimes;
 public class FontServiceTests : BaseTestClass
 {
     private readonly Mock<IRuntimeFontService> _mockFontService;
+
+    // Minimal valid .fnt header, enough for BitmapFont to construct a distinct instance from a
+    // null texture. Used to make the font actually change so the assignment's layout branch fires.
+    private const string FntPattern =
+        "info face=\"Arial\" size=-18 bold=0 italic=0 charset=\"\" unicode=1 stretchH=100 smooth=1 aa=1 padding=0,0,0,0 spacing=1,1 outline=0\n" +
+        "common lineHeight=21 base=17 scaleW=256 scaleH=256 pages=1 packed=0 alphaChnl=0 redChnl=4 greenChnl=4 blueChnl=4\r\n" +
+        "chars count=223\r\n";
 
     public FontServiceTests()
     {
@@ -572,6 +583,38 @@ public class FontServiceTests : BaseTestClass
 
         suppressedAtLoadTime.ShouldNotBeEmpty();
         suppressedAtLoadTime.ShouldAllBe(suppressed => suppressed == true);
+    }
+
+    [Fact]
+    public void DeferredFontFlush_ShouldNotReenterLayout_WhenTheFontActuallyChanges()
+    {
+        // Behavioral suppression pin using a REAL, distinct BitmapFont (registered under the cache
+        // filename the properties resolve to). Because the resolved font differs from the element's
+        // current BitmapFont, the assignment's RelativeToChildren UpdateLayout branch actually fires
+        // — unlike the mock-default case, which resolves back to DefaultBitmapFont. The flush must
+        // suppress that re-entrant layout: a standalone element runs exactly one layout pass.
+        // (Without the suppression the font assignment re-enters UpdateLayout and the delta is 2.)
+        BitmapFont distinctFont = new BitmapFont((Texture2D)null!, FntPattern);
+        LoaderManager loaderManager = LoaderManager.Self;
+        string fileName = FileManager.Standardize("FontCache\\Font24SomeFont.fnt", preserveCase: true, makeAbsolute: true);
+        loaderManager.AddDisposable(fileName, distinctFont);
+
+        TextRuntime textRuntime = new();   // RelativeToChildren default
+
+        GraphicalUiElement.IsAllLayoutSuspended = true;
+        textRuntime.SetProperty("Font", "SomeFont");
+        textRuntime.SetProperty("FontSize", 24);
+        GraphicalUiElement.IsAllLayoutSuspended = false;
+
+        int countBefore = GraphicalUiElement.UpdateLayoutCallCount;
+        textRuntime.UpdateLayout();
+        int delta = GraphicalUiElement.UpdateLayoutCallCount - countBefore;
+
+        // The distinct font was actually assigned, proving the assignment branch (and thus the
+        // suppression site) was reached — this test genuinely exercises the suppression.
+        textRuntime.BitmapFont.ShouldBe(distinctFont);
+        textRuntime.IsFontDirty.ShouldBeFalse();
+        delta.ShouldBe(1);
     }
 
     #endregion

--- a/MonoGameGum.Tests/Runtimes/FontServiceTests.cs
+++ b/MonoGameGum.Tests/Runtimes/FontServiceTests.cs
@@ -427,5 +427,152 @@ public class FontServiceTests : BaseTestClass
         childText.IsFontDirty.ShouldBeFalse();
     }
 
+    [Fact]
+    public void UpdateLayout_ShouldNotLoadFont_WhenNothingIsDirty()
+    {
+        // Hot-path guarantee: when no font is deferred (isFontDirty false), UpdateLayout must do
+        // ZERO font work. This is the steady-state case that runs on every resize/move/frame.
+        TextRuntime textRuntime = new();
+        List<BmfcSave> capturedCalls = StartCapturingFontCalls();
+        textRuntime.SetProperty("Font", "Consolas");   // not suspended -> loads now, clears dirty
+        textRuntime.SetProperty("FontSize", 24);
+        capturedCalls.Clear();                          // ignore the initial (legitimate) loads
+
+        textRuntime.UpdateLayout();
+        textRuntime.UpdateLayout();
+        textRuntime.UpdateLayout();
+
+        capturedCalls.Count.ShouldBe(0);
+        textRuntime.IsFontDirty.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void UpdateLayout_ShouldNotFlushFont_WhileStillSuspended()
+    {
+        // UpdateLayout called while IsAllLayoutSuspended is true must early-out (MakeDirty) and
+        // keep the font deferred — it must not load mid-suspension and defeat the batching.
+        TextRuntime textRuntime = new();
+        List<BmfcSave> capturedCalls = StartCapturingFontCalls();
+
+        try
+        {
+            GraphicalUiElement.IsAllLayoutSuspended = true;
+            textRuntime.SetProperty("Font", "Consolas");
+            textRuntime.SetProperty("FontSize", 24);
+
+            textRuntime.UpdateLayout();   // still suspended
+
+            capturedCalls.Count.ShouldBe(0);
+            textRuntime.IsFontDirty.ShouldBeTrue();
+        }
+        finally
+        {
+            GraphicalUiElement.IsAllLayoutSuspended = false;
+        }
+    }
+
+    [Fact]
+    public void UpdateLayout_ShouldNotFlushDeferredChildFont_WhenChildrenAreNotUpdated()
+    {
+        // Scoping pin: a shallow UpdateLayout (updateChildren: false) visits only this node, so a
+        // dirty CHILD stays deferred. The flush adds no traversal beyond what the layout requests.
+        ContainerRuntime parent = new();
+        TextRuntime childText = new();
+        parent.AddChild(childText);
+        List<BmfcSave> capturedCalls = StartCapturingFontCalls();
+
+        GraphicalUiElement.IsAllLayoutSuspended = true;
+        childText.SetProperty("Font", "Consolas");
+        childText.SetProperty("FontSize", 24);
+        GraphicalUiElement.IsAllLayoutSuspended = false;
+
+        parent.UpdateLayout(updateParent: false, updateChildren: false);
+
+        capturedCalls.Count.ShouldBe(0);
+        childText.IsFontDirty.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void UpdateLayout_ShouldFlushDeferredGrandchildFont_WhenCalledOnRoot()
+    {
+        // Deep-recursion pin: a dirty grandchild is realized by a root UpdateLayout.
+        ContainerRuntime root = new();
+        ContainerRuntime middle = new();
+        TextRuntime grandchildText = new();
+        root.AddChild(middle);
+        middle.AddChild(grandchildText);
+        List<BmfcSave> capturedCalls = StartCapturingFontCalls();
+
+        GraphicalUiElement.IsAllLayoutSuspended = true;
+        grandchildText.SetProperty("Font", "Consolas");
+        grandchildText.SetProperty("FontSize", 24);
+        GraphicalUiElement.IsAllLayoutSuspended = false;
+
+        root.UpdateLayout();
+
+        capturedCalls.Count.ShouldBe(1);
+        grandchildText.IsFontDirty.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void UpdateLayout_ShouldFlushOnlyDirtyChild_LeavingCleanSiblingUntouched()
+    {
+        // Only nodes that actually deferred a font flush; a clean sibling does no font work, and
+        // the dirty one is realized exactly once.
+        ContainerRuntime parent = new();
+        TextRuntime dirtyChild = new();
+        TextRuntime cleanChild = new();
+        parent.AddChild(dirtyChild);
+        parent.AddChild(cleanChild);
+        List<BmfcSave> capturedCalls = StartCapturingFontCalls();
+        cleanChild.SetProperty("Font", "Arial");   // not suspended -> loads now, stays clean
+        cleanChild.SetProperty("FontSize", 18);
+        capturedCalls.Clear();
+
+        GraphicalUiElement.IsAllLayoutSuspended = true;
+        dirtyChild.SetProperty("Font", "Consolas");
+        dirtyChild.SetProperty("FontSize", 24);
+        GraphicalUiElement.IsAllLayoutSuspended = false;
+
+        parent.UpdateLayout();
+
+        capturedCalls.Count.ShouldBe(1);
+        dirtyChild.IsFontDirty.ShouldBeFalse();
+        cleanChild.IsFontDirty.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void DeferredFontFlush_ShouldSuppressTheFontAssignmentLayout_DuringTheLoad()
+    {
+        // No-re-entrancy pin. Realizing a font on RelativeToChildren text normally triggers the
+        // font assignment's own UpdateLayout (the RelativeToChildren branch in
+        // CustomSetPropertyOnRenderable); during the #2999 flush that must be suppressed so the
+        // in-progress layout pass isn't re-entered. We capture SuppressLayoutFromFontChange at the
+        // moment of the load: it must be true during the flush and false for a normal load. (We
+        // assert it here rather than via a layout-count delta because the mock harness resolves to
+        // the existing DefaultBitmapFont, so the assignment's layout branch never fires to observe.)
+        TextRuntime textRuntime = new();
+        List<bool> suppressedAtLoadTime = new();
+        _mockFontService.Setup(x => x.CreateFontIfNecessary(It.IsAny<BmfcSave>()))
+            .Callback<BmfcSave>(_ => suppressedAtLoadTime.Add(GraphicalUiElement.SuppressLayoutFromFontChange));
+        CustomSetPropertyOnRenderable.FontService = _mockFontService.Object;
+
+        // Normal (non-suspended) load: the flag must be false.
+        textRuntime.SetProperty("Font", "Consolas");
+        textRuntime.SetProperty("FontSize", 18);
+        suppressedAtLoadTime.ShouldNotBeEmpty();
+        suppressedAtLoadTime.ShouldAllBe(suppressed => suppressed == false);
+        suppressedAtLoadTime.Clear();
+
+        // Deferred flush via UpdateLayout: the flag must be true while the font loads.
+        GraphicalUiElement.IsAllLayoutSuspended = true;
+        textRuntime.SetProperty("FontSize", 24);
+        GraphicalUiElement.IsAllLayoutSuspended = false;
+        textRuntime.UpdateLayout();
+
+        suppressedAtLoadTime.ShouldNotBeEmpty();
+        suppressedAtLoadTime.ShouldAllBe(suppressed => suppressed == true);
+    }
+
     #endregion
 }


### PR DESCRIPTION
## Problem

Closes #2999.

Font properties set while `GraphicalUiElement.IsAllLayoutSuspended` is `true` defer their (expensive) load by flagging `isFontDirty` instead of generating the atlas. That flag was only consumed by `ResumeLayout` / `UpdateFontRecursive` — **never by `UpdateLayout`**.

So a caller that lifts the global suspension and then resumes with a bare `UpdateLayout()` left the deferred fonts unrealized. That is exactly what the #2999 repro does:

```csharp
GraphicalUiElement.IsAllLayoutSuspended = true;
BindingContext = vm;                 // populates the list; each item's font deferred
GraphicalUiElement.IsAllLayoutSuspended = false;
ItemList.Visual.UpdateLayout();      // arranges, but never flushes the deferred fonts
```

The items rendered in the renderer's fallback font; hovering an item re-applied its state (with suspension off), which loaded the font on demand — hence "hovered items show the correct font, the rest don't." The official `docs/code/files-and-fonts/font-performance.md` guidance also resumes with `UpdateLayout()`, so users following the docs hit this too.

MonoGame defers font loads; Raylib never defers, which is why Raylib was unaffected (the asymmetry is tracked separately in #3039).

## Fix

`UpdateLayout` now realizes a node's deferred font at the top of its layout body — after the suspended/invisible and parent-delegate early-outs, **before** the node measures itself — so the element sizes from real glyphs instead of the fallback font. Because `UpdateLayout` already recurses to the requested depth, every node it visits flushes its own `isFontDirty`; nodes it is told to skip stay deferred (correct scoping, no extra traversal).

Realizing a font on `RelativeToChildren` text normally triggers the font assignment's *own* follow-up `UpdateLayout` (`CustomSetPropertyOnRenderable.UpdateToFontValues`), which — for a no-arg call that also requests a parent update — would re-enter the in-progress pass. The new `GraphicalUiElement.SuppressLayoutFromFontChange` flag suppresses that follow-up during the flush (the enclosing pass already sizes the element), and `isFontDirty` is cleared *before* the load so the suppressed re-layout can't re-trigger it. This is the measure-then-arrange ordering the deferral system was built around; `UpdateFontRecursive` (used by `WireframeObjectManager`) is unchanged.

Side effect: the existing `font-performance.md` resume pattern (`UpdateLayout()` after lifting `IsAllLayoutSuspended`) is now correct, so no doc change is needed.

## Tests

`FontServiceTests` gains:
- `UpdateLayout_ShouldFlushDeferredFontLoad_AfterGlobalSuspendBatch` — single element; verifies a bare `UpdateLayout()` realizes the deferred font (and, with the `RelativeToChildren` default, that the suppression prevents re-entrant re-loading).
- `UpdateLayout_ShouldFlushDeferredChildFont_WhenCalledOnParent` — the list/tree shape: `UpdateLayout()` on the parent realizes a child Text's deferred font via the recursive pass.

Both fail before the change (`capturedCalls.Count` 0, expected 1) and pass after. Full `MonoGameGum.Tests` (1587) green; `AllLibraries.sln` builds with 0 errors across all backends.

## Note for reviewers

`SuppressLayoutFromFontChange` is a PascalCase static flag matching its sibling `IsAllLayoutSuspended` (and the neighboring `UpdateLayoutCallCount`) rather than the `_underscore` new-field convention, since it's part of the same cross-class static-flag family. Easy to rename if you'd prefer strict adherence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
