### PR TITLE
Cull off-screen renderables when clipped — XNA + Raylib (#2998)

### DIFF
--- a/MonoGameGum.Tests/RenderingLibraries/OffscreenCullTests.cs
+++ b/MonoGameGum.Tests/RenderingLibraries/OffscreenCullTests.cs
@@ -1,0 +1,76 @@
+using System.Drawing;
+using RenderingLibrary;
+using Shouldly;
+using Xunit;
+
+namespace MonoGameGum.Tests.RenderingLibraries;
+
+/// <summary>
+/// Tests for the off-screen render cull (#2998). This file starts with the pure geometry
+/// predicate (<see cref="CameraScissorExtensions.IsFullyOutside"/>); orderer- and renderer-level
+/// cull behavior is added alongside as the feature is wired into the walk.
+/// </summary>
+public class OffscreenCullTests : BaseTestClass
+{
+    // clip spans [100,300] x [100,300]; with a 15px margin the keep-region is [85,315] x [85,315].
+    private static readonly Rectangle Clip = new Rectangle(100, 100, 200, 200);
+    private const int Margin = 15;
+
+    [Fact]
+    public void IsFullyOutside_ShouldBeFalse_WhenBoundsOverlapClip()
+    {
+        Rectangle bounds = new Rectangle(150, 150, 50, 50);
+
+        CameraScissorExtensions.IsFullyOutside(bounds, Clip, Margin).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsFullyOutside_ShouldBeTrue_WhenBoundsFarToTheLeft()
+    {
+        Rectangle bounds = new Rectangle(0, 150, 50, 50);   // right edge = 50, well left of 85
+
+        CameraScissorExtensions.IsFullyOutside(bounds, Clip, Margin).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsFullyOutside_ShouldBeTrue_WhenBoundsFarToTheRight()
+    {
+        Rectangle bounds = new Rectangle(400, 150, 50, 50); // left edge = 400, well right of 315
+
+        CameraScissorExtensions.IsFullyOutside(bounds, Clip, Margin).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsFullyOutside_ShouldBeTrue_WhenBoundsFarAbove()
+    {
+        Rectangle bounds = new Rectangle(150, 0, 50, 50);   // bottom edge = 50, well above 85
+
+        CameraScissorExtensions.IsFullyOutside(bounds, Clip, Margin).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsFullyOutside_ShouldBeTrue_WhenBoundsFarBelow()
+    {
+        Rectangle bounds = new Rectangle(150, 400, 50, 50); // top edge = 400, well below 315
+
+        CameraScissorExtensions.IsFullyOutside(bounds, Clip, Margin).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsFullyOutside_ShouldBeFalse_WhenBoundsAreOutsideButWithinMargin()
+    {
+        // Right edge = 90, which is past the clip's left (100) but inside the 15px margin (>= 85).
+        Rectangle bounds = new Rectangle(40, 150, 50, 50);
+
+        CameraScissorExtensions.IsFullyOutside(bounds, Clip, Margin).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsFullyOutside_ShouldBeTrue_WhenBoundsAreJustBeyondMargin()
+    {
+        // Right edge = 84, one pixel past the 15px margin boundary (85).
+        Rectangle bounds = new Rectangle(40, 150, 44, 50);
+
+        CameraScissorExtensions.IsFullyOutside(bounds, Clip, Margin).ShouldBeTrue();
+    }
+}

--- a/RenderingLibrary/Camera.cs
+++ b/RenderingLibrary/Camera.cs
@@ -301,6 +301,37 @@ namespace RenderingLibrary
     /// </summary>
     public static class CameraScissorExtensions
     {
+        /// <summary>
+        /// When true (the default), the render walk skips any renderable that falls entirely outside
+        /// the active clip rectangle, along with its whole subtree — avoiding draw and render-state
+        /// work for scrolled-off content in ListBoxes, ScrollViewers, ComboBox dropdowns, and any
+        /// clipping container. Set false to render all clipped content (e.g. if a renderable's
+        /// visuals intentionally bleed far past its own bounds). See #2998.
+        /// </summary>
+        public static bool CullOffscreenWhenClipped = true;
+
+        /// <summary>
+        /// Pixels by which a renderable's bounds are expanded before the off-screen cull test, so
+        /// content that bleeds slightly past its own bounds (drop shadows, borders) is not
+        /// prematurely culled. See #2998.
+        /// </summary>
+        public const int OffscreenCullMarginInPixels = 15;
+
+        /// <summary>
+        /// Returns true when <paramref name="bounds"/> lies entirely outside <paramref name="clip"/>,
+        /// expanded outward by <paramref name="margin"/> pixels on every side. Used by the off-screen
+        /// render cull (#2998) to skip renderables that fall completely outside the active clip
+        /// rectangle. The margin absorbs content that bleeds slightly past its own bounds (drop
+        /// shadows, borders) so it is not prematurely culled.
+        /// </summary>
+        public static bool IsFullyOutside(System.Drawing.Rectangle bounds, System.Drawing.Rectangle clip, int margin)
+        {
+            return bounds.Right < clip.Left - margin
+                || bounds.Left > clip.Right + margin
+                || bounds.Bottom < clip.Top - margin
+                || bounds.Top > clip.Bottom + margin;
+        }
+
         public static System.Drawing.Rectangle GetScissorRectangleFor(this Camera camera, Layer layer, IRenderableIpso ipso)
         {
             if (ipso == null)

--- a/RenderingLibrary/Graphics/BatchKeyGroupedOrderer.cs
+++ b/RenderingLibrary/Graphics/BatchKeyGroupedOrderer.cs
@@ -33,13 +33,13 @@ public sealed class BatchKeyGroupedOrderer : IRenderableOrderer
     }
 
     /// <inheritdoc/>
-    public void BuildDrawList(Layer layer, List<DrawCommand> destination)
+    public void BuildDrawList(Layer layer, List<DrawCommand> destination, Camera? camera = null)
     {
         destination.Clear();
-        ProcessLayerTopLevel(layer, destination);
+        ProcessLayerTopLevel(layer, camera, destination);
     }
 
-    private static void ProcessLayerTopLevel(Layer layer, List<DrawCommand> destination)
+    private static void ProcessLayerTopLevel(Layer layer, Camera? camera, List<DrawCommand> destination)
     {
         ReadOnlyCollection<IRenderableIpso> top = layer.Renderables;
         int count = top.Count;
@@ -66,7 +66,7 @@ public sealed class BatchKeyGroupedOrderer : IRenderableOrderer
                 List<Entry> window = new List<Entry>();
                 for (int i = runStart; i < runEnd; i++)
                 {
-                    ProcessRenderable(top[i], window, destination);
+                    ProcessRenderable(top[i], layer, camera, null, window, destination);
                 }
                 FlushWindow(window, destination);
 
@@ -78,7 +78,7 @@ public sealed class BatchKeyGroupedOrderer : IRenderableOrderer
             List<Entry> window = new List<Entry>();
             for (int i = 0; i < count; i++)
             {
-                ProcessRenderable(top[i], window, destination);
+                ProcessRenderable(top[i], layer, camera, null, window, destination);
             }
             FlushWindow(window, destination);
         }
@@ -86,10 +86,26 @@ public sealed class BatchKeyGroupedOrderer : IRenderableOrderer
 
     private static void ProcessRenderable(
         IRenderableIpso renderable,
+        Layer layer,
+        Camera? camera,
+        Rectangle? activeClip,
         List<Entry> currentWindow,
         List<DrawCommand> destination)
     {
         if (!renderable.Visible)
+        {
+            return;
+        }
+
+        // #2998 off-screen cull: skip a renderable (and its subtree) fully outside the active
+        // clip. Gated on a non-null camera, mirroring HierarchicalOrderer — see its rationale.
+        if (camera != null
+            && activeClip.HasValue
+            && CameraScissorExtensions.CullOffscreenWhenClipped
+            && CameraScissorExtensions.IsFullyOutside(
+                camera.GetScissorRectangleFor(layer, renderable),
+                activeClip.Value,
+                CameraScissorExtensions.OffscreenCullMarginInPixels))
         {
             return;
         }
@@ -107,6 +123,14 @@ public sealed class BatchKeyGroupedOrderer : IRenderableOrderer
             List<Entry> innerWindow = new List<Entry>();
             AddEntry(renderable, innerWindow);
 
+            // Entering a clipper narrows the active clip for descendants (intersect).
+            Rectangle? childClip = activeClip;
+            if (camera != null)
+            {
+                Rectangle thisClip = camera.GetScissorRectangleFor(layer, renderable);
+                childClip = activeClip.HasValue ? Rectangle.Intersect(activeClip.Value, thisClip) : thisClip;
+            }
+
             if (Renderer.RenderUsingHierarchy && !renderable.IsRenderTarget)
             {
                 ObservableCollection<IRenderableIpso> children = renderable.Children;
@@ -115,7 +139,7 @@ public sealed class BatchKeyGroupedOrderer : IRenderableOrderer
                     int childCount = children.Count;
                     for (int i = 0; i < childCount; i++)
                     {
-                        ProcessRenderable(children[i], innerWindow, destination);
+                        ProcessRenderable(children[i], layer, camera, childClip, innerWindow, destination);
                     }
                 }
             }
@@ -135,7 +159,7 @@ public sealed class BatchKeyGroupedOrderer : IRenderableOrderer
                     int childCount = children.Count;
                     for (int i = 0; i < childCount; i++)
                     {
-                        ProcessRenderable(children[i], currentWindow, destination);
+                        ProcessRenderable(children[i], layer, camera, activeClip, currentWindow, destination);
                     }
                 }
             }

--- a/RenderingLibrary/Graphics/HierarchicalOrderer.cs
+++ b/RenderingLibrary/Graphics/HierarchicalOrderer.cs
@@ -19,19 +19,34 @@ public sealed class HierarchicalOrderer : IRenderableOrderer
     public static readonly HierarchicalOrderer Instance = new HierarchicalOrderer();
 
     /// <inheritdoc/>
-    public void BuildDrawList(Layer layer, List<DrawCommand> destination)
+    public void BuildDrawList(Layer layer, List<DrawCommand> destination, Camera? camera = null)
     {
         destination.Clear();
-        AppendRenderables(layer.Renderables, destination);
+        AppendRenderables(layer.Renderables, layer, camera, null, destination);
     }
 
-    private static void AppendRenderables(IList<IRenderableIpso> renderables, List<DrawCommand> destination)
+    private static void AppendRenderables(IList<IRenderableIpso> renderables, Layer layer, Camera? camera,
+        System.Drawing.Rectangle? activeClip, List<DrawCommand> destination)
     {
         int count = renderables.Count;
         for (int i = 0; i < count; i++)
         {
             IRenderableIpso renderable = renderables[i];
             if (!renderable.Visible)
+            {
+                continue;
+            }
+
+            // #2998 off-screen cull: when a clip is active, skip this renderable and its whole
+            // subtree if its bounds fall entirely outside the clip. Gated on a non-null camera
+            // (the render path) so the camera-less order-only unit tests are unaffected.
+            if (camera != null
+                && activeClip.HasValue
+                && CameraScissorExtensions.CullOffscreenWhenClipped
+                && CameraScissorExtensions.IsFullyOutside(
+                    camera.GetScissorRectangleFor(layer, renderable),
+                    activeClip.Value,
+                    CameraScissorExtensions.OffscreenCullMarginInPixels))
             {
                 continue;
             }
@@ -49,7 +64,17 @@ public sealed class HierarchicalOrderer : IRenderableOrderer
                 ObservableCollection<IRenderableIpso> children = renderable.Children;
                 if (children != null && children.Count > 0)
                 {
-                    AppendRenderables(children, destination);
+                    // Entering a clipper narrows the active clip for descendants (intersect, mirroring
+                    // Renderer.AdjustRenderStates). Without a camera we can't compute it, so leave it null.
+                    System.Drawing.Rectangle? childClip = activeClip;
+                    if (clips && camera != null)
+                    {
+                        System.Drawing.Rectangle thisClip = camera.GetScissorRectangleFor(layer, renderable);
+                        childClip = activeClip.HasValue
+                            ? System.Drawing.Rectangle.Intersect(activeClip.Value, thisClip)
+                            : thisClip;
+                    }
+                    AppendRenderables(children, layer, camera, childClip, destination);
                 }
             }
 

--- a/RenderingLibrary/Graphics/IRenderableOrderer.cs
+++ b/RenderingLibrary/Graphics/IRenderableOrderer.cs
@@ -15,5 +15,12 @@ public interface IRenderableOrderer
     /// <paramref name="destination"/>. Implementations MUST clear <paramref name="destination"/>
     /// before appending so the renderer can pool a single buffer across layers and frames.
     /// </summary>
-    void BuildDrawList(Layer layer, List<DrawCommand> destination);
+    /// <param name="layer">The layer whose renderables are flattened into the ordered draw commands.</param>
+    /// <param name="destination">Caller-owned buffer; cleared, then filled with the ordered commands.</param>
+    /// <param name="camera">
+    /// The render camera, used for the off-screen cull (#2998): renderables falling entirely
+    /// outside an active clip rectangle are skipped. Optional — when null (e.g. order-only unit
+    /// tests) no culling is performed and the full walk is emitted.
+    /// </param>
+    void BuildDrawList(Layer layer, List<DrawCommand> destination, Camera? camera = null);
 }

--- a/RenderingLibrary/Graphics/Renderer.cs
+++ b/RenderingLibrary/Graphics/Renderer.cs
@@ -51,6 +51,22 @@ public class Renderer : IRenderer
     /// </summary>
     public static IRenderableOrderer SiblingOrdering { get; set; } = HierarchicalOrderer.Instance;
 
+    /// <summary>
+    /// When true (the default), the render walk skips any renderable that falls entirely outside
+    /// the active clip rectangle, along with its subtree — avoiding draw and render-state work for
+    /// scrolled-off content in ListBoxes, ScrollViewers, etc. (#2998).
+    /// <para>
+    /// Treat as experimental until validated on real projects: set to false to render all clipped
+    /// content if a renderable's visuals intentionally bleed far past its own bounds. Forwards to
+    /// the backend-agnostic <see cref="CameraScissorExtensions.CullOffscreenWhenClipped"/>.
+    /// </para>
+    /// </summary>
+    public static bool CullOffscreenWhenClipped
+    {
+        get => CameraScissorExtensions.CullOffscreenWhenClipped;
+        set => CameraScissorExtensions.CullOffscreenWhenClipped = value;
+    }
+
     #region Fields
 
 
@@ -522,7 +538,7 @@ public class Renderer : IRenderer
         // by itself it produces byte-identical output via HierarchicalOrderer (the default).
         // The recursive Render/Draw helpers below remain in use for the prerender path
         // (RenderToRenderTarget) and the GumBatch immediate-mode path (Renderer.Draw).
-        SiblingOrdering.BuildDrawList(layer, _scratchCommands);
+        SiblingOrdering.BuildDrawList(layer, _scratchCommands, mCamera);
         Submit(_scratchCommands, managers, layer);
 
         _batchOrchestrator.FlushAndReset(managers);

--- a/Runtimes/RaylibGum/RenderingLibrary/Renderer.cs
+++ b/Runtimes/RaylibGum/RenderingLibrary/Renderer.cs
@@ -20,6 +20,19 @@ public class Renderer : IRenderer
     /// </summary>
     public static bool RenderUsingHierarchy = true;
 
+    /// <summary>
+    /// When true (the default), the render walk skips any renderable that falls entirely outside
+    /// the active clip rectangle, along with its subtree — avoiding draw work for scrolled-off
+    /// content in clipping containers (#2998). Experimental until validated on real projects; set
+    /// false to render all clipped content. Forwards to the backend-agnostic
+    /// <see cref="CameraScissorExtensions.CullOffscreenWhenClipped"/>.
+    /// </summary>
+    public static bool CullOffscreenWhenClipped
+    {
+        get => CameraScissorExtensions.CullOffscreenWhenClipped;
+        set => CameraScissorExtensions.CullOffscreenWhenClipped = value;
+    }
+
     List<Layer> _layers;
     ReadOnlyCollection<Layer> _layersReadOnly;
 
@@ -198,6 +211,19 @@ public class Renderer : IRenderer
 
     private void DrawGumRecursively(IRenderableIpso element, Layer layer)
     {
+        // #2998 off-screen cull: when a clip is active (the scissor stack is non-empty), skip this
+        // element and its subtree if it falls entirely outside the active clip, expanded by a small
+        // margin. Mirrors the XNA orderer cull via the same shared predicate.
+        if (CameraScissorExtensions.CullOffscreenWhenClipped
+            && _scissorStack.Count > 0
+            && CameraScissorExtensions.IsFullyOutside(
+                _camera.GetScissorRectangleFor(layer, element),
+                _scissorStack.Peek(),
+                CameraScissorExtensions.OffscreenCullMarginInPixels))
+        {
+            return;
+        }
+
         element.Render(null);
 
         if (element.ClipsChildren)

--- a/Tests/MonoGameGum.IntegrationTests/MonoGameGum/Rendering/OffscreenCullRenderTests.cs
+++ b/Tests/MonoGameGum.IntegrationTests/MonoGameGum/Rendering/OffscreenCullRenderTests.cs
@@ -1,0 +1,113 @@
+using System.Linq;
+using Microsoft.Xna.Framework;
+using Gum.GueDeriving;
+using RenderingLibrary;
+using RenderingLibrary.Content;
+using RenderingLibrary.Graphics;
+using Shouldly;
+using Xunit;
+
+namespace MonoGameGum.IntegrationTests.MonoGameGum.Rendering;
+
+/// <summary>
+/// End-to-end proof of the off-screen render cull (#2998): renders one real frame of a clipped
+/// tree (a parent clip container holding several child clip containers, each wrapping a Text) and
+/// compares the number of SpriteBatch state changes with the cull off vs on. Children scrolled
+/// outside the parent's clip rect should contribute no state changes when culling is enabled.
+/// </summary>
+public class OffscreenCullRenderTests : BaseTestClass
+{
+    [Fact]
+    public void Cull_ReducesSpriteBatchStateChanges_ForOffscreenClippedChildren()
+    {
+        using MinimalGame game = new();
+        game.RunOneFrame();
+
+        SystemManagers managers = SystemManagers.Default;
+        Renderer renderer = managers.Renderer;
+
+        // Parent clips a 200px-tall band. Six child clip containers are stacked every 100px, so
+        // two are inside the band and four are scrolled off below it (the cull targets).
+        ContainerRuntime parent = new();
+        parent.Width = 200;
+        parent.Height = 200;
+        parent.ClipsChildren = true;
+
+        for (int i = 0; i < 6; i++)
+        {
+            ContainerRuntime childClip = new();
+            childClip.Width = 180;
+            childClip.Height = 80;
+            childClip.Y = i * 100;   // 0, 100 inside; 200, 300, 400, 500 below the 200px band
+            childClip.ClipsChildren = true;
+
+            TextRuntime text = new();
+            text.Text = "Item " + i;
+            childClip.AddChild(text);
+
+            parent.AddChild(childClip);
+        }
+
+        parent.AddToManagers(managers, null);
+        parent.UpdateLayout();
+
+        try
+        {
+            // Warm up: the first Draw after RunOneFrame does one-time work (font loads, render-target
+            // setup) that inflates its state-change count. Discard it so the measured pair below
+            // differ only by the cull flag, not by first-frame warmup.
+            CameraScissorExtensions.CullOffscreenWhenClipped = false;
+            renderer.Draw(managers);
+
+            CameraScissorExtensions.CullOffscreenWhenClipped = false;
+            renderer.Draw(managers);
+            int withoutCull = renderer.SpriteRenderer.LastFrameDrawStates.Count();
+
+            CameraScissorExtensions.CullOffscreenWhenClipped = true;
+            renderer.Draw(managers);
+            int withCull = renderer.SpriteRenderer.LastFrameDrawStates.Count();
+
+            withCull.ShouldBeLessThan(withoutCull);
+        }
+        finally
+        {
+            CameraScissorExtensions.CullOffscreenWhenClipped = true;
+        }
+    }
+
+    /// <summary>
+    /// Minimal Game host that initializes a fresh <see cref="GumService"/> per test so
+    /// <see cref="Renderer.Draw(SystemManagers)"/> can be invoked against a live device.
+    /// </summary>
+    private class MinimalGame : Game
+    {
+        private readonly GraphicsDeviceManager _graphics;
+        public GumService GumService { get; }
+
+        public MinimalGame()
+        {
+            LoaderManager.Self?.DisposeAndClear();
+            _graphics = new GraphicsDeviceManager(this);
+            GumService = new GumService();
+        }
+
+        protected override void Initialize()
+        {
+            base.Initialize();
+            GumService.Initialize(this, Gum.Forms.DefaultVisualsVersion.V2);
+        }
+
+        protected override void Update(GameTime gameTime) { }
+        protected override void Draw(GameTime gameTime) => GraphicsDevice.Clear(Color.CornflowerBlue);
+
+        protected override void Dispose(bool disposing)
+        {
+            if (GumService.IsInitialized)
+            {
+                GumService.Uninitialize();
+            }
+            LoaderManager.Self?.DisposeAndClear();
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -343,6 +343,7 @@
   * [Measuring Layout Calls](code/performance-and-optimization/measuring-layout-calls.md)
   * [SinglePixelTexture](code/performance-and-optimization/singlepixeltexture.md)
   * [Batch Key Grouped Orderer](code/performance-and-optimization/batchkeygroupedorderer.md)
+  * [Culling Off-Screen Renderables](code/performance-and-optimization/culling-offscreen-renderables.md)
 * [Gum Tool Code (Contributing and Plugins)](code/gum-tool-code-contributing-and-plugins/README.md)
   * [DataUiGrid](code/gum-tool-code-contributing-and-plugins/datauigrid/README.md)
     * [Reflection](code/gum-tool-code-contributing-and-plugins/datauigrid/reflection.md)

--- a/docs/code/performance-and-optimization/culling-offscreen-renderables.md
+++ b/docs/code/performance-and-optimization/culling-offscreen-renderables.md
@@ -1,0 +1,41 @@
+# Culling Off-Screen Renderables
+
+## Introduction
+
+When content lives inside a clipping container — such as a `ListBox`, `ScrollViewer`, or any element with `ClipsChildren` set to `true` — items scrolled out of view are still walked and drawn every frame. The clip region only hides them *visually*; each off-screen item still costs a draw call, and can introduce render-state breaks (see [Measuring Draw Calls](lastframedrawstates.md)).
+
+To avoid that wasted work, Gum skips drawing any renderable that falls entirely outside the active clip region, along with all of its children. For a long list this can remove most of the per-frame draw cost, since only the handful of visible items are drawn.
+
+## How It Works
+
+* The cull only happens when a clip region is active. Content that is not inside a `ClipsChildren` container is never culled.
+* A renderable whose bounds fall completely outside the clip region is skipped, and Gum does not walk into its children either — so an off-screen list item and everything inside it cost nothing to draw.
+* A small margin is added around the clip region before the test, so content that extends slightly past its own bounds (for example a drop shadow or a border) is not clipped early.
+
+Layout and visual state still run for off-screen content, so an item that scrolls back into view is already correct — only the drawing is skipped.
+
+## Disabling the Cull
+
+The cull is on by default. You can turn it off globally:
+
+```csharp
+// Initialize
+RenderingLibrary.Graphics.Renderer.CullOffscreenWhenClipped = false;
+```
+
+Set it back to `true` to re-enable. The setting applies to the whole renderer, so set it once during initialization.
+
+## When to Disable It
+
+The cull decides what to skip from each renderable's *own* bounds. That is correct for self-contained content, but a renderable can intentionally draw outside its own bounds, for example:
+
+* A child positioned outside a non-clipping parent's bounds (deliberate overflow).
+* A large glow or shadow that extends well beyond the margin.
+
+In those cases an item sitting just past the edge of a scrolled region could be culled even though part of it should still be visible. If you see content disappear at the edge of a clipped area that should be on screen, either set `CullOffscreenWhenClipped` to `false`, or give the overflowing content a parent that clips it so its footprint stays within its bounds.
+
+{% hint style="info" %}
+**As of June 2026:** Off-screen culling is on by default but is still considered experimental while it is validated across real projects. If it causes incorrect clipping in your project, disable it with `Renderer.CullOffscreenWhenClipped = false` and please report the case.
+{% endhint %}
+
+Use [Measuring Draw Calls](lastframedrawstates.md) to confirm the reduction in draw states with the cull on versus off.


### PR DESCRIPTION
## Summary

Closes #2998.

When a clip rect is active, the render walk now **skips any renderable whose screen bounds fall entirely outside that clip — along with its whole subtree** — avoiding draw, batch, and clip-region work for content scrolled out of `ListBox`, `ScrollViewer`, `ComboBox` dropdowns, and any `ClipsChildren` container. Render-only: layout and visual state still run, so an item re-entering view is already correct.

This covers the **XNA family (MonoGame/KNI/FNA)** and **Raylib**. (Raylib was out of scope in the original issue; added here per request so both can be validated on real projects. Skia/Sokol remain out of scope — a sensible follow-up once this is proven.)

## Design notes

- **One shared decision.** `CameraScissorExtensions.IsFullyOutside(bounds, clip, margin)` is the single cull predicate; bounds come from the existing `GetScissorRectangleFor`. Every walk site calls it, so behavior can't drift between backends.
- **Subtree skip.** An off-screen renderable and its descendants are skipped outright — that's where the savings are. Each walk threads the *effective* (intersected) clip down the recursion, mirroring `Renderer.AdjustRenderStates`.
- **15px margin** (hardcoded) inflates the test so content that bleeds slightly past its own bounds (drop shadows, borders) isn't prematurely culled.
- **Known tradeoff (intentional).** A renderable that does *not* clip its children, has a child positioned **>15px past its own box**, and sits right at the clip edge can be culled even though that child would be visible. This is rare and accepted for the performance win; the off-switch and margin cover the realistic cases. If it bites in practice we can add a per-renderable opt-out.

## Off-switch (experimental)

Defaults **on**, but gated by `Renderer.CullOffscreenWhenClipped` (default `true`) so it can be disabled wholesale until it's been validated on real projects. Backed by a single backend-agnostic static; the XNA and Raylib `Renderer` types both expose the forwarding property.

## Implementation

- `CameraScissorExtensions` (in `Camera.cs`, no new file): predicate + flag + margin const.
- `IRenderableOrderer.BuildDrawList` gains a **trailing optional `Camera?`** (null ⇒ no cull) — backward-compatible with the existing order-only tests and any external caller, so no breaking signature change.
- Cull wired into both orderers (`HierarchicalOrderer` default, `BatchKeyGroupedOrderer` opt-in) and Raylib's `DrawGumRecursively` (using its existing intersected `_scissorStack`).

## Tests

- **Geometry unit tests** (`OffscreenCullTests`) — the margin/bounds predicate, all four directions + the margin boundary.
- **End-to-end state-change test** (`OffscreenCullRenderTests`, integration) — renders one real frame of a parent-clip → child-clips → `Text` tree (2 visible, 4 scrolled off) and asserts, **toggle-and-compare** on `SpriteRenderer.LastFrameDrawStates`, that culling reduces SpriteBatch state changes. (A warmup frame controls for first-frame init so the only variable is the cull flag.)
- **Raylib** has no headless render + state-change counter in its harness, so its wiring is covered by the shared predicate tests, the `AllLibraries`/`RaylibGum` build, and real-project verification rather than an automated render-count test.

Full `MonoGameGum.Tests` (1604) + integration rendering + `RaylibGum.Tests` (257) green; no new warnings. (`AllLibraries.sln` builds clean apart from the FNA submodule not being checked out in the CI worktree — unrelated to this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
