### PR TITLE
Add in-tool toggle for off-screen culling (#2998 follow-up)

### DIFF
--- a/Gum/PerformanceMeasurementPlugin/ViewModels/PerformanceViewModel.cs
+++ b/Gum/PerformanceMeasurementPlugin/ViewModels/PerformanceViewModel.cs
@@ -73,6 +73,27 @@ public class PerformanceViewModel : INotifyPropertyChanged
         }
     }
 
+    /// <summary>
+    /// Toggles the global off-screen render cull (<see cref="Renderer.CullOffscreenWhenClipped"/>):
+    /// when on, renderables that fall entirely outside an active clip region — and their children —
+    /// are skipped. The editor renders continuously, so the begin counts above reflect the change on
+    /// the next frame. Exposed here to validate the (experimental) cull against real projects (#2998).
+    /// </summary>
+    public bool CullOffscreenWhenClipped
+    {
+        get => Renderer.CullOffscreenWhenClipped;
+        set
+        {
+            if (value == Renderer.CullOffscreenWhenClipped)
+            {
+                return;
+            }
+
+            Renderer.CullOffscreenWhenClipped = value;
+            RaiseAllChanged();
+        }
+    }
+
     private static Renderer? ActiveRenderer => SystemManagers.Default?.Renderer;
 
     public event PropertyChangedEventHandler? PropertyChanged;

--- a/Gum/PerformanceMeasurementPlugin/Views/PerformanceView.xaml
+++ b/Gum/PerformanceMeasurementPlugin/Views/PerformanceView.xaml
@@ -20,6 +20,12 @@
             GroupName="RenderOrder"
             IsChecked="{Binding SortByBatchKey, Mode=TwoWay}" />
 
+        <Label Margin="0,6,0,0" FontWeight="Bold">Off-screen culling:</Label>
+        <CheckBox
+            Margin="8,2,0,2"
+            Content="Cull content outside clip regions"
+            IsChecked="{Binding CullOffscreenWhenClipped, Mode=TwoWay}" />
+
         <Separator Margin="0,6" />
 
         <Grid>


### PR DESCRIPTION
## Summary

Follow-up to #3041 (#2998). That PR added the runtime `Renderer.CullOffscreenWhenClipped` flag (default on) for the off-screen render cull. This adds a checkbox to the **Performance Measurement** plugin so the cull can be toggled **live inside the editor**, right next to the SpriteBatch / Apos.Shapes begin-count readouts.

The editor runs on the KNI runtime, which shares the XNA-family render path the cull lives in, so toggling here exercises the real cull code. Pairing the toggle with the begin counts makes it a one-click A/B test: flip it off vs on while viewing a clipped, scrolled layout and watch the render-state-change count (and visually check for any premature clipping at clip edges).

## Changes

- `PerformanceViewModel.CullOffscreenWhenClipped` — a get/set property forwarding to `Renderer.CullOffscreenWhenClipped`, mirroring the existing `SortByBatchKey` toggle.
- A **"Cull content outside clip regions"** checkbox in `PerformanceView.xaml`.

## Verification

Plugin code compiles. (Building the plugin csproj directly fails only on the `$(SolutionDir)` post-build copy, as documented for tool projects — no compile errors.) Tool-side change with no automated tests, consistent with the existing untested toggles in this VM; the real verification is running the tool and using the toggle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
