### PR TITLE
Add Raylib draw-call counting and fix nullable property reflection crash

### DIFF
--- a/GumRuntime/GraphicalUiElement.cs
+++ b/GumRuntime/GraphicalUiElement.cs
@@ -6073,9 +6073,18 @@ public partial class GraphicalUiElement : IRenderableIpso, IVisible, INotifyProp
         if (propertyInfo != null && propertyInfo.CanWrite)
         {
 
-            if (value.GetType() != propertyInfo.PropertyType)
+            if (value != null && value.GetType() != propertyInfo.PropertyType)
             {
-                value = System.Convert.ChangeType(value, propertyInfo.PropertyType);
+                // For a Nullable<T> target (e.g. Blend? on Sprite/NineSlice), convert against the
+                // underlying T. Convert.ChangeType cannot produce a Nullable<T> (it throws
+                // InvalidCastException), but a boxed T assigns cleanly into a Nullable<T> property
+                // via SetValue. This is the data-driven path (ApplyState → SetProperty → reflection);
+                // strongly-typed C# setters never reach it.
+                Type targetType = Nullable.GetUnderlyingType(propertyInfo.PropertyType) ?? propertyInfo.PropertyType;
+                if (value.GetType() != targetType)
+                {
+                    value = System.Convert.ChangeType(value, targetType);
+                }
             }
             propertyInfo.SetValue(mContainedObjectAsIpso, value, null);
         }

--- a/RenderingLibrary/Graphics/RenderStateChangeStatistics.cs
+++ b/RenderingLibrary/Graphics/RenderStateChangeStatistics.cs
@@ -21,6 +21,15 @@ namespace RenderingLibrary.Graphics
         public int ShapeBatchBeginCount { get; private set; }
 
         /// <summary>
+        /// The number of GPU draw calls recorded since the last <see cref="Reset"/>. Unlike
+        /// <see cref="ShapeBatchBeginCount"/> (an XNA/Apos.Shapes-specific begin count), this is a
+        /// backend-neutral draw-call total. It is currently populated only by the raylib renderer,
+        /// which owns a <c>RenderBatch</c> and banks its authoritative draw counter at each batch
+        /// flush; other backends leave it at zero until wired.
+        /// </summary>
+        public int DrawCallCount { get; private set; }
+
+        /// <summary>
         /// Records one ShapeBatch begin. Called from the Apos.Shapes runtime whenever it opens
         /// (or re-opens) its ShapeBatch.
         /// </summary>
@@ -30,11 +39,21 @@ namespace RenderingLibrary.Graphics
         }
 
         /// <summary>
+        /// Adds <paramref name="count"/> draw calls to <see cref="DrawCallCount"/>. Called by the
+        /// raylib renderer as it banks the owned <c>RenderBatch</c>'s draw counter at each flush.
+        /// </summary>
+        public void AddDrawCalls(int count)
+        {
+            DrawCallCount += count;
+        }
+
+        /// <summary>
         /// Clears all counters. Called once per frame at the start of <see cref="Renderer.Draw(SystemManagers)"/>.
         /// </summary>
         public void Reset()
         {
             ShapeBatchBeginCount = 0;
+            DrawCallCount = 0;
         }
     }
 }

--- a/Runtimes/RaylibGum/Renderables/LineRectangle.cs
+++ b/Runtimes/RaylibGum/Renderables/LineRectangle.cs
@@ -635,7 +635,7 @@ public class LineRectangle : InvisibleRenderable
         bool useScissor = !rotated;
         if (useScissor)
         {
-            BeginScissorMode((int)ox, (int)oy, (int)MathF.Ceiling(w), (int)MathF.Ceiling(h));
+            global::RenderingLibrary.Graphics.Renderer.Self.BatchDrawCallCounter.BeginScissorMode((int)ox, (int)oy, (int)MathF.Ceiling(w), (int)MathF.Ceiling(h));
         }
 
         // Band count: 64 gives near-imperceptible stairstepping at typical UI sizes. Step in
@@ -664,7 +664,7 @@ public class LineRectangle : InvisibleRenderable
 
         if (useScissor)
         {
-            EndScissorMode();
+            global::RenderingLibrary.Graphics.Renderer.Self.BatchDrawCallCounter.EndScissorMode();
         }
     }
 

--- a/Runtimes/RaylibGum/Renderables/NineSlice.cs
+++ b/Runtimes/RaylibGum/Renderables/NineSlice.cs
@@ -242,7 +242,7 @@ public class NineSlice : RenderableBase, IAnimatable, ITextureCoordinate, IClone
 
         if (Blend.HasValue)
         {
-            BeginBlendMode(Blend.Value.ToRaylibBlendMode());
+            global::RenderingLibrary.Graphics.Renderer.Self.BatchDrawCallCounter.BeginBlendMode(Blend.Value.ToRaylibBlendMode());
         }
 
         DrawTextureNPatch(
@@ -255,7 +255,7 @@ public class NineSlice : RenderableBase, IAnimatable, ITextureCoordinate, IClone
 
         if (Blend.HasValue)
         {
-            EndBlendMode();
+            global::RenderingLibrary.Graphics.Renderer.Self.BatchDrawCallCounter.EndBlendMode();
         }
     }
 

--- a/Runtimes/RaylibGum/Renderables/ShadowBlurRenderer.cs
+++ b/Runtimes/RaylibGum/Renderables/ShadowBlurRenderer.cs
@@ -124,13 +124,18 @@ void main() {{
 
         Color clear = new Color((byte)0, (byte)0, (byte)0, (byte)0);
 
+        // Every begin/end render-target, blend, and shader state change below flushes the active
+        // render batch. Route them through the renderer's draw-call counter so the shadow's
+        // offscreen draws are banked into the frame's draw-call count (folded into the main count).
+        var counter = global::RenderingLibrary.Graphics.Renderer.Self.BatchDrawCallCounter;
+
         // 1) Silhouette pass: clear RT_A and let the caller paint a white mask at (radius, radius).
         // Default BLEND_ALPHA is fine here — opaque white onto cleared transparent black gives
         // (1,1,1,1) inside the shape, (0,0,0,0) outside.
-        BeginTextureMode(rtA);
+        counter.BeginTextureMode(rtA);
         ClearBackground(clear);
         drawSilhouetteAt(radius, radius);
-        EndTextureMode();
+        counter.EndTextureMode();
 
         float invTwoSigmaSq = 1f / (2f * sigma * sigma);
         SetShaderValue(_shader, _locInvTwoSigmaSq, invTwoSigmaSq, ShaderUniformDataType.Float);
@@ -149,41 +154,41 @@ void main() {{
         // RTs from RenderTextureService are exact-fit (no oversizing), so the standard raylib
         // negative-height idiom Rectangle(0, 0, rtW, -rtH) reads the full upright content.
         Vector2 hDir = new Vector2(1f / rtW, 0f);
-        BeginTextureMode(rtB);
+        counter.BeginTextureMode(rtB);
         ClearBackground(clear);
-        BeginBlendMode(BlendMode.AlphaPremultiply);
+        counter.BeginBlendMode(BlendMode.AlphaPremultiply);
         SetShaderValue(_shader, _locDirection, hDir, ShaderUniformDataType.Vec2);
-        BeginShaderMode(_shader);
+        counter.BeginShaderMode(_shader);
         // Negative source height flips the v range so the upright top-down content of an RT
         // (stored bottom-up in GL coords) reads correctly.
         DrawTextureRec(rtA.Texture, new Rectangle(0, 0, rtW, -rtH), Vector2.Zero, Color.White);
-        EndShaderMode();
-        EndBlendMode();
-        EndTextureMode();
+        counter.EndShaderMode();
+        counter.EndBlendMode();
+        counter.EndTextureMode();
 
         // 3) Vertical blur RT_B -> RT_A.
         Vector2 vDir = new Vector2(0f, 1f / rtH);
-        BeginTextureMode(rtA);
+        counter.BeginTextureMode(rtA);
         ClearBackground(clear);
-        BeginBlendMode(BlendMode.AlphaPremultiply);
+        counter.BeginBlendMode(BlendMode.AlphaPremultiply);
         SetShaderValue(_shader, _locDirection, vDir, ShaderUniformDataType.Vec2);
-        BeginShaderMode(_shader);
+        counter.BeginShaderMode(_shader);
         DrawTextureRec(rtB.Texture, new Rectangle(0, 0, rtW, -rtH), Vector2.Zero, Color.White);
-        EndShaderMode();
-        EndBlendMode();
-        EndTextureMode();
+        counter.EndShaderMode();
+        counter.EndBlendMode();
+        counter.EndTextureMode();
 
         // 4) Composite RT_A onto the screen, tinted. shadowMinX/Y are the shape's top-left;
         // the RT contains `radius` pixels of falloff padding around the shape, so the on-screen
         // destination starts `radius` pixels up-and-left of that. AlphaPremultiply here too —
         // the RT contents are in premultiplied form (rgb == a, since silhouette was white).
-        BeginBlendMode(BlendMode.AlphaPremultiply);
+        counter.BeginBlendMode(BlendMode.AlphaPremultiply);
         DrawTextureRec(
             rtA.Texture,
             new Rectangle(0, 0, rtW, -rtH),
             new Vector2(shadowMinX - radius, shadowMinY - radius),
             tint);
-        EndBlendMode();
+        counter.EndBlendMode();
     }
 
     /// <summary>

--- a/Runtimes/RaylibGum/Renderables/Sprite.cs
+++ b/Runtimes/RaylibGum/Renderables/Sprite.cs
@@ -164,14 +164,14 @@ public class Sprite : InvisibleRenderable, IAspectRatio, ITextureCoordinate, IAn
 
         if (Blend.HasValue)
         {
-            BeginBlendMode(Blend.Value.ToRaylibBlendMode());
+            global::RenderingLibrary.Graphics.Renderer.Self.BatchDrawCallCounter.BeginBlendMode(Blend.Value.ToRaylibBlendMode());
         }
 
         DrawTexturePro(Texture.Value, srcRect, destinationRectangle, Vector2.Zero, -absoluteRotation, Color);
 
         if (Blend.HasValue)
         {
-            EndBlendMode();
+            global::RenderingLibrary.Graphics.Renderer.Self.BatchDrawCallCounter.EndBlendMode();
         }
     }
 

--- a/Runtimes/RaylibGum/RenderingLibrary/BatchDrawCallCounter.cs
+++ b/Runtimes/RaylibGum/RenderingLibrary/BatchDrawCallCounter.cs
@@ -1,0 +1,207 @@
+using Raylib_cs;
+using System;
+using System.Runtime.InteropServices;
+
+namespace RenderingLibrary.Graphics;
+
+/// <summary>
+/// Measures the authoritative number of GPU draw calls the raylib renderer issues for a Gum
+/// render pass, by owning a private <see cref="RenderBatch"/> and reading raylib's own draw
+/// bookkeeping instead of predicting it.
+///
+/// <para><b>Why own a batch:</b> raylib's default render batch is a file-scoped <c>static</c> in
+/// rlgl with no public accessor, so its draw counter can't be read. <c>rlSetRenderBatchActive</c>
+/// lets us substitute a batch we own; raylib then accumulates draws into it with all of its real
+/// grouping rules (texture-change and draw-mode-change splits), and we read the result.</para>
+///
+/// <para><b>Why bank at each flush:</b> raylib resets the batch's <c>DrawCounter</c> to 1 on every
+/// flush (<c>rlDrawRenderBatch</c>), and a flush is forced by every scissor/blend/render-target/
+/// shader/mode change. So a single end-of-pass read would only see the last segment. Instead the
+/// renderer calls <see cref="Bank"/> immediately before each such state change; <see cref="Bank"/>
+/// counts the draw-call slots raylib actually filled this segment (slots with a non-zero vertex
+/// count — exactly what <c>rlDrawRenderBatch</c> would draw) and adds them to the active
+/// <see cref="RenderStateChangeStatistics"/>.</para>
+///
+/// <para><b>Lifecycle:</b> the owned batch is loaded lazily on first use (it needs a live GL
+/// context) and pinned for the process lifetime. Mirroring <c>ShadowBlurRenderer</c>, there is no
+/// explicit unload — raylib's <c>CloseWindow</c> reclaims the GL resources at shutdown.</para>
+/// </summary>
+public sealed unsafe class BatchDrawCallCounter
+{
+    // raylib desktop (GL 3.3) defaults for the internal batch — RL_DEFAULT_BATCH_BUFFERS and
+    // RL_DEFAULT_BATCH_BUFFER_ELEMENTS. Matching them keeps our owned batch's auto-flush behavior
+    // identical to the default batch raylib would otherwise use.
+    private const int DefaultBatchBuffers = 1;
+    private const int DefaultBatchBufferElements = 8192;
+
+    // Single-element array pinned for the process so the RenderBatch lives at a stable address:
+    // rlSetRenderBatchActive stores the pointer, so the struct must not move while it is active.
+    private RenderBatch[] _batchStorage;
+    private GCHandle _pinHandle;
+    private RenderBatch* _batch;
+    private bool _initialized;
+
+    private RenderStateChangeStatistics _statistics;
+    private bool _active;
+
+    /// <summary>
+    /// Activates the owned batch for a render pass and routes subsequent <see cref="Bank"/> calls
+    /// into <paramref name="statistics"/>. If the GL context isn't ready (so the batch can't be
+    /// loaded), counting is silently disabled for the pass and rendering proceeds normally.
+    /// The caller is responsible for resetting <paramref name="statistics"/> before the pass.
+    /// </summary>
+    public void BeginPass(RenderStateChangeStatistics statistics)
+    {
+        EnsureInitialized();
+        if (!_initialized)
+        {
+            _active = false;
+            return;
+        }
+
+        _statistics = statistics;
+        _active = true;
+        // Switching to our batch flushes whatever was queued in the previous (default) batch, so
+        // any draws issued before the Gum pass are accounted to the default batch, not ours.
+        Rlgl.SetRenderBatchActive(_batch);
+    }
+
+    /// <summary>
+    /// Counted wrapper for <see cref="Raylib.BeginMode2D"/>: banks the pending segment, then
+    /// performs the state change (which flushes the batch).
+    /// </summary>
+    public void BeginMode2D(Camera2D camera)
+    {
+        Bank();
+        Raylib.BeginMode2D(camera);
+    }
+
+    /// <summary>Counted wrapper for <see cref="Raylib.EndMode2D"/>.</summary>
+    public void EndMode2D()
+    {
+        Bank();
+        Raylib.EndMode2D();
+    }
+
+    /// <summary>Counted wrapper for <see cref="Raylib.BeginScissorMode"/>.</summary>
+    public void BeginScissorMode(int x, int y, int width, int height)
+    {
+        Bank();
+        Raylib.BeginScissorMode(x, y, width, height);
+    }
+
+    /// <summary>Counted wrapper for <see cref="Raylib.EndScissorMode"/>.</summary>
+    public void EndScissorMode()
+    {
+        Bank();
+        Raylib.EndScissorMode();
+    }
+
+    /// <summary>Counted wrapper for <see cref="Raylib.BeginBlendMode"/>.</summary>
+    public void BeginBlendMode(BlendMode mode)
+    {
+        Bank();
+        Raylib.BeginBlendMode(mode);
+    }
+
+    /// <summary>Counted wrapper for <see cref="Raylib.EndBlendMode"/>.</summary>
+    public void EndBlendMode()
+    {
+        Bank();
+        Raylib.EndBlendMode();
+    }
+
+    /// <summary>Counted wrapper for <see cref="Raylib.BeginTextureMode"/>.</summary>
+    public void BeginTextureMode(RenderTexture2D target)
+    {
+        Bank();
+        Raylib.BeginTextureMode(target);
+    }
+
+    /// <summary>Counted wrapper for <see cref="Raylib.EndTextureMode"/>.</summary>
+    public void EndTextureMode()
+    {
+        Bank();
+        Raylib.EndTextureMode();
+    }
+
+    /// <summary>Counted wrapper for <see cref="Raylib.BeginShaderMode"/>.</summary>
+    public void BeginShaderMode(Shader shader)
+    {
+        Bank();
+        Raylib.BeginShaderMode(shader);
+    }
+
+    /// <summary>Counted wrapper for <see cref="Raylib.EndShaderMode"/>.</summary>
+    public void EndShaderMode()
+    {
+        Bank();
+        Raylib.EndShaderMode();
+    }
+
+    /// <summary>
+    /// Banks the draw calls accumulated since the last flush, then ends the pass and restores
+    /// raylib's default batch. Call after the last draw of the pass.
+    /// </summary>
+    public void EndPass()
+    {
+        if (!_active)
+        {
+            return;
+        }
+
+        Bank();
+        Rlgl.SetRenderBatchActive(null);
+        _active = false;
+        _statistics = null;
+    }
+
+    /// <summary>
+    /// Counts the draw-call slots raylib filled since the previous flush and adds them to the
+    /// active statistics. Must be called immediately before any raylib state change that flushes
+    /// the batch (scissor/blend/render-target/shader/mode). No-op when counting is inactive.
+    /// </summary>
+    public void Bank()
+    {
+        if (!_active)
+        {
+            return;
+        }
+
+        int drawCounter = _batch->DrawCounter;
+        int realDrawCalls = 0;
+        for (int i = 0; i < drawCounter; i++)
+        {
+            // rlDrawRenderBatch only emits slots with vertices, and zeroes every slot's vertex
+            // count on flush — so non-empty slots in [0, DrawCounter) are exactly the GPU draws
+            // for this segment, with no stale or empty-segment overcount.
+            if (_batch->Draws[i].VertexCount > 0)
+            {
+                realDrawCalls++;
+            }
+        }
+
+        _statistics?.AddDrawCalls(realDrawCalls);
+    }
+
+    private void EnsureInitialized()
+    {
+        if (_initialized)
+        {
+            return;
+        }
+
+        // LoadRenderBatch allocates GL vertex buffers, so it requires an initialized window. If the
+        // window isn't ready yet, leave counting disabled for this pass and retry next frame.
+        if (!Raylib.IsWindowReady())
+        {
+            return;
+        }
+
+        _batchStorage = new RenderBatch[1];
+        _pinHandle = GCHandle.Alloc(_batchStorage, GCHandleType.Pinned);
+        _batch = (RenderBatch*)_pinHandle.AddrOfPinnedObject();
+        *_batch = Rlgl.LoadRenderBatch(DefaultBatchBuffers, DefaultBatchBufferElements);
+        _initialized = true;
+    }
+}

--- a/Runtimes/RaylibGum/RenderingLibrary/Renderer.cs
+++ b/Runtimes/RaylibGum/RenderingLibrary/Renderer.cs
@@ -75,6 +75,21 @@ public class Renderer : IRenderer
     /// </summary>
     public ShadowBlurRenderer ShadowBlur { get; }
 
+    /// <summary>
+    /// Per-frame render-state-change counters for this renderer, including the authoritative
+    /// <see cref="RenderStateChangeStatistics.DrawCallCount"/> measured via the owned RenderBatch.
+    /// Reset at the start of each <see cref="Draw(SystemManagers)"/> and readable afterward to
+    /// gauge how well a frame batches.
+    /// </summary>
+    public RenderStateChangeStatistics RenderStateChangeStatistics { get; private set; }
+
+    /// <summary>
+    /// Owns a private raylib <c>RenderBatch</c> and counts the GPU draw calls issued during a Gum
+    /// render pass. Renderables that issue raylib state changes (blend / scissor / render-target /
+    /// shader) must route them through this counter's wrapper methods so the count stays accurate.
+    /// </summary>
+    public BatchDrawCallCounter BatchDrawCallCounter { get; private set; }
+
     public static BlendState NormalBlendState
     {
         get;
@@ -91,6 +106,8 @@ public class Renderer : IRenderer
         _layersReadOnly = new ReadOnlyCollection<Layer>(_layers);
         _layers.Add(new Layer());
         ShadowBlur = new ShadowBlurRenderer();
+        RenderStateChangeStatistics = new RenderStateChangeStatistics();
+        BatchDrawCallCounter = new BatchDrawCallCounter();
     }
 
 
@@ -113,6 +130,10 @@ public class Renderer : IRenderer
         // pattern in RenderingLibrary/Graphics/Renderer.cs.
         ShadowBlur.ClearUnusedRenderTargetsLastFrame();
 
+        // Clear last frame's counts before the pass; the owned-batch counter repopulates
+        // DrawCallCount as it banks each flush below.
+        RenderStateChangeStatistics.Reset();
+
         _camera.ClientWidth = Raylib.GetScreenWidth();
         _camera.ClientHeight = Raylib.GetScreenHeight();
 
@@ -126,7 +147,11 @@ public class Renderer : IRenderer
             Rotation = 0,
         };
 
-        Raylib.BeginMode2D(camera2D);
+        // Substitute our owned RenderBatch for raylib's default so its draw counter can be read,
+        // then route the mode/scissor state changes below through the counter so each batch flush
+        // is banked into RenderStateChangeStatistics.DrawCallCount.
+        BatchDrawCallCounter.BeginPass(RenderStateChangeStatistics);
+        BatchDrawCallCounter.BeginMode2D(camera2D);
 
         for (int i = 0; i < layers.Count; i++)
         {
@@ -149,7 +174,8 @@ public class Renderer : IRenderer
             RenderLayer(managers, layer, prerender: false);
         }
 
-        Raylib.EndMode2D();
+        BatchDrawCallCounter.EndMode2D();
+        BatchDrawCallCounter.EndPass();
     }
     public void RenderLayer(ISystemManagers managers, Layer layer, bool prerender = true)
     {
@@ -233,7 +259,7 @@ public class Renderer : IRenderer
                 ? System.Drawing.Rectangle.Intersect(_scissorStack.Peek(), rect)
                 : rect;
             _scissorStack.Push(effective);
-            Raylib.BeginScissorMode(effective.X, effective.Y, effective.Width, effective.Height);
+            BatchDrawCallCounter.BeginScissorMode(effective.X, effective.Y, effective.Width, effective.Height);
         }
 
         if (element.Children != null)
@@ -253,11 +279,11 @@ public class Renderer : IRenderer
             if (_scissorStack.Count > 0)
             {
                 var parent = _scissorStack.Peek();
-                Raylib.BeginScissorMode(parent.X, parent.Y, parent.Width, parent.Height);
+                BatchDrawCallCounter.BeginScissorMode(parent.X, parent.Y, parent.Width, parent.Height);
             }
             else
             {
-                Raylib.EndScissorMode();
+                BatchDrawCallCounter.EndScissorMode();
             }
         }
     }

--- a/Tests/RaylibGum.Tests/Rendering/BatchDrawCallCounterTests.cs
+++ b/Tests/RaylibGum.Tests/Rendering/BatchDrawCallCounterTests.cs
@@ -1,0 +1,59 @@
+using Raylib_cs;
+using RenderingLibrary.Graphics;
+using Shouldly;
+using static Raylib_cs.Raylib;
+
+namespace RaylibGum.Tests.Rendering;
+
+/// <summary>
+/// GPU-backed isolation tests for <see cref="BatchDrawCallCounter"/>. They exercise the owned-
+/// <c>RenderBatch</c> interop directly (load / pin / activate / bank / deactivate) against the
+/// hidden raylib window opened by the test harness, independent of the full renderer walk.
+/// </summary>
+public class BatchDrawCallCounterTests : BaseTestClass
+{
+    [Fact]
+    public void BeginPass_EmptyPass_RecordsZeroDrawCalls()
+    {
+        BatchDrawCallCounter counter = new();
+        RenderStateChangeStatistics statistics = new();
+
+        BeginDrawing();
+        counter.BeginPass(statistics);
+        counter.EndPass();
+        EndDrawing();
+
+        statistics.DrawCallCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public void Bank_SingleRectangle_RecordsOneDrawCall()
+    {
+        BatchDrawCallCounter counter = new();
+        RenderStateChangeStatistics statistics = new();
+
+        BeginDrawing();
+        counter.BeginPass(statistics);
+        DrawRectangle(0, 0, 10, 10, Color.Red);
+        counter.EndPass();
+        EndDrawing();
+
+        statistics.DrawCallCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public void Bank_TwoTexturelessShapesSameMode_CoalesceToOneDrawCall()
+    {
+        BatchDrawCallCounter counter = new();
+        RenderStateChangeStatistics statistics = new();
+
+        BeginDrawing();
+        counter.BeginPass(statistics);
+        DrawRectangle(0, 0, 10, 10, Color.Red);
+        DrawRectangle(20, 20, 10, 10, Color.Blue);
+        counter.EndPass();
+        EndDrawing();
+
+        statistics.DrawCallCount.ShouldBe(1);
+    }
+}

--- a/Tests/RaylibGum.Tests/Rendering/FlushPointCoverageGuardTests.cs
+++ b/Tests/RaylibGum.Tests/Rendering/FlushPointCoverageGuardTests.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.RegularExpressions;
+using Shouldly;
+
+namespace RaylibGum.Tests.Rendering;
+
+/// <summary>
+/// Coverage guard for the draw-call counter. Every raylib state change that flushes the render
+/// batch (blend / scissor / render-target / shader / 2D-mode) must go through
+/// <c>BatchDrawCallCounter</c> so the flushed segment is banked into the draw-call count. A direct
+/// <c>Raylib.Begin*Mode</c> / <c>End*Mode</c> call anywhere else silently drops that segment and
+/// undercounts. This test scans the RaylibGum source and fails if any direct call exists outside
+/// the counter, turning a forgotten flush point into a red build instead of a silent miscount.
+/// </summary>
+public class FlushPointCoverageGuardTests
+{
+    private static readonly string[] FlushMethods =
+    {
+        "BeginMode2D", "EndMode2D",
+        "BeginScissorMode", "EndScissorMode",
+        "BeginBlendMode", "EndBlendMode",
+        "BeginTextureMode", "EndTextureMode",
+        "BeginShaderMode", "EndShaderMode",
+    };
+
+    // The one file allowed to call the raylib flush functions directly — it is the wrapper.
+    private const string WrapperFileName = "BatchDrawCallCounter.cs";
+
+    [Fact]
+    public void NoRaylibFlushCallsBypassTheCounter()
+    {
+        string sourceDirectory = FindRaylibGumSourceDirectory();
+        string methods = string.Join("|", FlushMethods);
+        // A direct raylib flush is either unqualified (called via `using static Raylib_cs.Raylib`)
+        // or `Raylib.`-qualified. A member-access call on the counter (e.g.
+        // `...BatchDrawCallCounter.BeginBlendMode(`) is preceded by a '.' and is the sanctioned
+        // path, so it is not matched.
+        Regex directCall = new(
+            $@"\bRaylib\.\s*({methods})\s*\(|(?<![\w.])({methods})\s*\(",
+            RegexOptions.Compiled);
+
+        List<string> violations = new();
+
+        foreach (string file in Directory.EnumerateFiles(sourceDirectory, "*.cs", SearchOption.AllDirectories))
+        {
+            if (Path.GetFileName(file) == WrapperFileName)
+            {
+                continue;
+            }
+            // Skip generated/build output.
+            if (file.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}")
+                || file.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}"))
+            {
+                continue;
+            }
+
+            string[] lines = File.ReadAllLines(file);
+            for (int i = 0; i < lines.Length; i++)
+            {
+                string line = lines[i];
+                string trimmed = line.TrimStart();
+                // Ignore comment lines so doc references to the method names don't trip the guard.
+                if (trimmed.StartsWith("//") || trimmed.StartsWith("*") || trimmed.StartsWith("/*"))
+                {
+                    continue;
+                }
+
+                if (directCall.IsMatch(line))
+                {
+                    violations.Add($"{Path.GetFileName(file)}:{i + 1}: {trimmed}");
+                }
+            }
+        }
+
+        violations.ShouldBeEmpty(
+            "These raylib flush calls bypass BatchDrawCallCounter and will undercount draw calls. "
+            + "Route them through Renderer.Self.BatchDrawCallCounter:" + Environment.NewLine
+            + string.Join(Environment.NewLine, violations));
+    }
+
+    private static string FindRaylibGumSourceDirectory()
+    {
+        DirectoryInfo directory = new(AppContext.BaseDirectory);
+        while (directory != null)
+        {
+            string candidate = Path.Combine(directory.FullName, "Runtimes", "RaylibGum");
+            if (Directory.Exists(candidate))
+            {
+                return candidate;
+            }
+            directory = directory.Parent;
+        }
+
+        throw new DirectoryNotFoundException(
+            "Could not locate the Runtimes/RaylibGum source directory from " + AppContext.BaseDirectory);
+    }
+}

--- a/Tests/RaylibGum.Tests/Rendering/RenderStateChangeStatisticsDrawCallTests.cs
+++ b/Tests/RaylibGum.Tests/Rendering/RenderStateChangeStatisticsDrawCallTests.cs
@@ -1,0 +1,43 @@
+using RenderingLibrary.Graphics;
+using Shouldly;
+
+namespace RaylibGum.Tests.Rendering;
+
+/// <summary>
+/// Unit tests for the <see cref="RenderStateChangeStatistics.DrawCallCount"/> accumulator added
+/// for the raylib draw-call metric. The counter is a plain accumulator, so the add/reset contract
+/// is device-free. The wiring that drives it (the raylib <c>Renderer</c> banking the owned
+/// <c>RenderBatch</c>'s draw counter each frame) is covered by the GPU-backed renderer tests.
+/// </summary>
+public class RenderStateChangeStatisticsDrawCallTests : BaseTestClass
+{
+    [Fact]
+    public void AddDrawCalls_Twice_Accumulates()
+    {
+        RenderStateChangeStatistics statistics = new();
+
+        statistics.AddDrawCalls(3);
+        statistics.AddDrawCalls(2);
+
+        statistics.DrawCallCount.ShouldBe(5);
+    }
+
+    [Fact]
+    public void DrawCallCount_OnNewInstance_IsZero()
+    {
+        RenderStateChangeStatistics statistics = new();
+
+        statistics.DrawCallCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public void Reset_AfterAdding_ZeroesDrawCallCount()
+    {
+        RenderStateChangeStatistics statistics = new();
+        statistics.AddDrawCalls(4);
+
+        statistics.Reset();
+
+        statistics.DrawCallCount.ShouldBe(0);
+    }
+}

--- a/Tests/RaylibGum.Tests/Rendering/RendererDrawCallCountTests.cs
+++ b/Tests/RaylibGum.Tests/Rendering/RendererDrawCallCountTests.cs
@@ -1,0 +1,79 @@
+using Gum.GueDeriving;
+using Raylib_cs;
+using RenderingLibrary.Graphics;
+using Shouldly;
+using static Raylib_cs.Raylib;
+
+namespace RaylibGum.Tests.Rendering;
+
+/// <summary>
+/// End-to-end tests that drive a real raylib render pass via <see cref="GumService.Default"/> and
+/// assert the authoritative draw-call count the owned <c>RenderBatch</c> reports through
+/// <see cref="Renderer.RenderStateChangeStatistics"/>. Counts are asserted as deltas against a
+/// baseline frame, and content is added as test-root children (which <c>BaseTestClass</c> clears
+/// and which reliably detach) so each test is isolated and leaves no residue for later tests.
+/// </summary>
+public class RendererDrawCallCountTests : BaseTestClass
+{
+    private static int DrawAndCountDrawCalls()
+    {
+        BeginDrawing();
+        GumService.Default.Draw();
+        EndDrawing();
+        return Renderer.Self.RenderStateChangeStatistics.DrawCallCount;
+    }
+
+    [Fact]
+    public void Draw_AddingColoredRectangle_AddsExactlyOneDrawCall()
+    {
+        int baseline = DrawAndCountDrawCalls();
+
+        ColoredRectangleRuntime rectangle = new();
+        rectangle.Width = 50;
+        rectangle.Height = 50;
+        GumService.Default.Root.Children.Add(rectangle);
+        GumService.Default.Root.UpdateLayout();
+
+        int withRectangle = DrawAndCountDrawCalls();
+
+        GumService.Default.Root.Children.Clear();
+
+        (withRectangle - baseline).ShouldBe(1);
+    }
+
+    [Fact]
+    public void Draw_ClippedContainerWithChildRectangle_CountsChildAcrossScissorFlush()
+    {
+        int baseline = DrawAndCountDrawCalls();
+
+        ContainerRuntime container = new();
+        container.Width = 100;
+        container.Height = 100;
+        container.ClipsChildren = true;
+
+        ColoredRectangleRuntime rectangle = new();
+        rectangle.Width = 50;
+        rectangle.Height = 50;
+        container.Children.Add(rectangle);
+
+        GumService.Default.Root.Children.Add(container);
+        GumService.Default.Root.UpdateLayout();
+
+        int withClippedChild = DrawAndCountDrawCalls();
+
+        GumService.Default.Root.Children.Clear();
+
+        // The container clips, so the child draws between a BeginScissorMode/EndScissorMode pair —
+        // each of which flushes the batch. The child's single draw must still be banked exactly once.
+        (withClippedChild - baseline).ShouldBe(1);
+    }
+
+    [Fact]
+    public void Draw_Twice_DoesNotAccumulateDrawCallCount()
+    {
+        int first = DrawAndCountDrawCalls();
+        int second = DrawAndCountDrawCalls();
+
+        second.ShouldBe(first);
+    }
+}

--- a/Tests/RaylibGum.Tests/Rendering/RendererDrawCallMatrixTests.cs
+++ b/Tests/RaylibGum.Tests/Rendering/RendererDrawCallMatrixTests.cs
@@ -1,0 +1,324 @@
+using Gum.GueDeriving;
+using Gum.Wireframe;
+using Raylib_cs;
+using RenderingLibrary;
+using RenderingLibrary.Graphics;
+using Shouldly;
+using static Raylib_cs.Raylib;
+
+namespace RaylibGum.Tests.Rendering;
+
+/// <summary>
+/// Comprehensive end-to-end matrix for the raylib draw-call counter. Drives a real render pass for
+/// every renderable type and asserts three properties the metric must hold:
+/// <list type="bullet">
+/// <item>every renderable type renders without crashing and contributes at least one draw call;</item>
+/// <item>multiple identical, adjacent items of a type coalesce — the count does not grow with count;</item>
+/// <item>things that genuinely break a batch (distinct textures, clip regions, drop shadows) are
+/// counted, and a mixed scene reports a stable count frame-over-frame.</item>
+/// </list>
+/// Counts are compared as whole-scene totals (each <see cref="CountWith"/> call restores the shared
+/// harness state), so the assertions are robust to whatever the test root draws as a baseline.
+/// </summary>
+public class RendererDrawCallMatrixTests : BaseTestClass
+{
+    private static int DrawAndCount()
+    {
+        BeginDrawing();
+        GumService.Default.Draw();
+        EndDrawing();
+        return Renderer.Self.RenderStateChangeStatistics.DrawCallCount;
+    }
+
+    /// <summary>
+    /// Adds the given items as adjacent children of the test root, renders one frame, returns the
+    /// draw-call count, then clears them so the next call starts from a clean (zero) baseline.
+    /// Root children are used (rather than AddToManagers) because <c>BaseTestClass</c> clears them
+    /// and they reliably detach — giving deterministic isolation between measurements.
+    /// </summary>
+    private static int CountWith(params GraphicalUiElement[] items)
+    {
+        foreach (GraphicalUiElement item in items)
+        {
+            GumService.Default.Root.Children.Add(item);
+        }
+        GumService.Default.Root.UpdateLayout();
+
+        int count = DrawAndCount();
+
+        GumService.Default.Root.Children.Clear();
+        return count;
+    }
+
+    private static Texture2D CreateTexture()
+    {
+        Image image = GenImageColor(4, 4, Color.White);
+        Texture2D texture = LoadTextureFromImage(image);
+        UnloadImage(image);
+        return texture;
+    }
+
+    private static ColoredRectangleRuntime ColoredRect() => new() { Width = 30, Height = 30 };
+    private static SpriteRuntime Sprite(Texture2D texture) => new() { Width = 30, Height = 30, Texture = texture };
+    private static NineSliceRuntime NineSlice(Texture2D texture) => new() { Width = 30, Height = 30, Texture = texture };
+    private static TextRuntime Text(string value = "Hello") => new() { Text = value };
+    private static CircleRuntime Circle() => new() { Radius = 15 };
+    private static RectangleRuntime RectangleShape() => new() { Width = 30, Height = 30 };
+    private static PolygonRuntime Polygon() => new();
+
+    // ---- Every type renders, and multiples of the same type coalesce (no count growth). ----
+
+    [Fact]
+    public void ColoredRectangle_DrawsAndMultiplesCoalesce()
+    {
+        int baseline = CountWith();
+        int one = CountWith(ColoredRect());
+        int three = CountWith(ColoredRect(), ColoredRect(), ColoredRect());
+
+        one.ShouldBeGreaterThan(baseline);
+        three.ShouldBe(one);
+    }
+
+    [Fact]
+    public void Sprite_DrawsAndMultiplesWithSameTextureCoalesce()
+    {
+        Texture2D texture = CreateTexture();
+
+        int baseline = CountWith();
+        int one = CountWith(Sprite(texture));
+        int three = CountWith(Sprite(texture), Sprite(texture), Sprite(texture));
+
+        one.ShouldBeGreaterThan(baseline);
+        three.ShouldBe(one);
+
+        UnloadTexture(texture);
+    }
+
+    [Fact]
+    public void NineSlice_DrawsAndMultiplesWithSameTextureCoalesce()
+    {
+        Texture2D texture = CreateTexture();
+
+        int baseline = CountWith();
+        int one = CountWith(NineSlice(texture));
+        int three = CountWith(NineSlice(texture), NineSlice(texture), NineSlice(texture));
+
+        one.ShouldBeGreaterThan(baseline);
+        three.ShouldBe(one);
+
+        UnloadTexture(texture);
+    }
+
+    [Fact]
+    public void Text_DrawsAndMultiplesWithSameFontCoalesce()
+    {
+        int baseline = CountWith();
+        int one = CountWith(Text());
+        int three = CountWith(Text(), Text(), Text());
+
+        one.ShouldBeGreaterThan(baseline);
+        three.ShouldBe(one);
+    }
+
+    [Fact]
+    public void Circle_DrawsAndMultiplesCoalesce()
+    {
+        int baseline = CountWith();
+        int one = CountWith(Circle());
+        int three = CountWith(Circle(), Circle(), Circle());
+
+        one.ShouldBeGreaterThan(baseline);
+        three.ShouldBe(one);
+    }
+
+    [Fact]
+    public void RectangleShape_DrawsAndMultiplesCoalesce()
+    {
+        int baseline = CountWith();
+        int one = CountWith(RectangleShape());
+        int three = CountWith(RectangleShape(), RectangleShape(), RectangleShape());
+
+        one.ShouldBeGreaterThan(baseline);
+        three.ShouldBe(one);
+    }
+
+    [Fact]
+    public void Polygon_DrawsAndMultiplesCoalesce()
+    {
+        int baseline = CountWith();
+        int one = CountWith(Polygon());
+        int three = CountWith(Polygon(), Polygon(), Polygon());
+
+        one.ShouldBeGreaterThan(baseline);
+        three.ShouldBe(one);
+    }
+
+    // ---- A real batch break (distinct textures) DOES increase the count. ----
+
+    [Fact]
+    public void Sprites_WithDistinctTextures_IncreaseCountBeyondSharedTexture()
+    {
+        Texture2D textureA = CreateTexture();
+        Texture2D textureB = CreateTexture();
+        Texture2D textureC = CreateTexture();
+
+        int shared = CountWith(Sprite(textureA), Sprite(textureA), Sprite(textureA));
+        int distinct = CountWith(Sprite(textureA), Sprite(textureB), Sprite(textureC));
+
+        distinct.ShouldBeGreaterThan(shared);
+
+        UnloadTexture(textureA);
+        UnloadTexture(textureB);
+        UnloadTexture(textureC);
+    }
+
+    // ---- Blend mode: a blended sprite wraps its draw in BeginBlendMode/EndBlendMode (both flush);
+    //      the draw must still be banked (without routing those flushes it would be lost). ----
+
+    [Fact]
+    public void BlendedSprite_RendersAndIsCountedAcrossBlendFlushes()
+    {
+        Texture2D texture = CreateTexture();
+
+        int baseline = CountWith();
+        int blended = CountWith(BlendedSprite(texture));
+
+        blended.ShouldBeGreaterThan(baseline);
+
+        UnloadTexture(texture);
+    }
+
+    private static SpriteRuntime BlendedSprite(Texture2D texture)
+    {
+        SpriteRuntime sprite = Sprite(texture);
+        sprite.Blend = global::Gum.RenderingLibrary.Blend.Additive;
+        return sprite;
+    }
+
+    // ---- Clip regions: a clipped child is still counted across the scissor flushes. ----
+
+    [Fact]
+    public void ClippedContainer_CountsChildrenAndIdenticalChildrenCoalesce()
+    {
+        int baseline = CountWith();
+        int oneChild = CountWith(ClippedContainerWith(1));
+        int threeChildren = CountWith(ClippedContainerWith(3));
+
+        oneChild.ShouldBeGreaterThan(baseline);
+        threeChildren.ShouldBe(oneChild);
+    }
+
+    private static ContainerRuntime ClippedContainerWith(int childCount)
+    {
+        ContainerRuntime container = new() { Width = 200, Height = 200 };
+        container.ClipsChildren = true;
+        for (int i = 0; i < childCount; i++)
+        {
+            container.Children.Add(ColoredRect());
+        }
+        return container;
+    }
+
+    // ---- Drop shadows: the render-target + shader path renders without crashing and is counted. ----
+
+    [Fact]
+    public void DropShadowShape_RendersWithoutCrashingAndIsCounted()
+    {
+        int baseline = CountWith();
+        int withShadow = CountWith(ShadowedRectangle());
+
+        withShadow.ShouldBeGreaterThan(baseline);
+    }
+
+    [Fact]
+    public void MultipleDropShadowShapes_RenderWithoutCrashing()
+    {
+        // Each shadow runs its own offscreen render-target + shader passes. The point here is
+        // crash-safety of repeated render-target switches inside the owned batch, plus that the
+        // count stays finite and sensible.
+        int count = CountWith(ShadowedRectangle(), ShadowedRectangle(), ShadowedRectangle());
+
+        count.ShouldBeGreaterThan(0);
+    }
+
+    private static RectangleRuntime ShadowedRectangle()
+    {
+        RectangleRuntime rectangle = new() { Width = 40, Height = 40 };
+        rectangle.HasDropshadow = true;
+        rectangle.DropshadowBlur = 5;
+        rectangle.DropshadowAlpha = 255;
+        return rectangle;
+    }
+
+    // ---- Mix and match: a rich scene renders without crashing and reports a stable count. ----
+
+    [Fact]
+    public void MixedScene_RendersWithoutCrashingAndCountIsStableAcrossFrames()
+    {
+        Texture2D texture = CreateTexture();
+
+        ContainerRuntime root = new() { Width = 400, Height = 400 };
+        root.Children.Add(Sprite(texture));
+        root.Children.Add(Sprite(texture));            // adjacent identical sprite (coalesces)
+        root.Children.Add(Text("Mixed"));
+        root.Children.Add(ColoredRect());
+        root.Children.Add(Circle());
+        root.Children.Add(RectangleShape());
+        root.Children.Add(Polygon());
+
+        ContainerRuntime clip = new() { Width = 100, Height = 100 };
+        clip.ClipsChildren = true;
+        clip.Children.Add(ColoredRect());
+        clip.Children.Add(ColoredRect());
+        root.Children.Add(clip);
+
+        root.Children.Add(ShadowedRectangle());
+
+        GumService.Default.Root.Children.Add(root);
+        GumService.Default.Root.UpdateLayout();
+
+        int firstFrame = DrawAndCount();
+        int secondFrame = DrawAndCount();
+
+        GumService.Default.Root.Children.Clear();
+        UnloadTexture(texture);
+
+        firstFrame.ShouldBeGreaterThan(0);
+        // Per-frame Reset means the count must not accumulate frame-over-frame.
+        secondFrame.ShouldBe(firstFrame);
+    }
+
+    [Fact]
+    public void MixedScene_AddingAnIdenticalAdjacentItem_DoesNotIncreaseCount()
+    {
+        Texture2D texture = CreateTexture();
+
+        int withOneSprite = CountMixedScene(texture, spriteCount: 1);
+        int withThreeSprites = CountMixedScene(texture, spriteCount: 3);
+
+        // The extra sprites are adjacent and share the texture, so they coalesce: the richer scene
+        // costs the same number of draw calls as the leaner one.
+        withThreeSprites.ShouldBe(withOneSprite);
+
+        UnloadTexture(texture);
+    }
+
+    private static int CountMixedScene(Texture2D texture, int spriteCount)
+    {
+        ContainerRuntime root = new() { Width = 400, Height = 400 };
+        for (int i = 0; i < spriteCount; i++)
+        {
+            root.Children.Add(Sprite(texture));
+        }
+        root.Children.Add(Text("Mixed"));
+        root.Children.Add(Circle());
+
+        GumService.Default.Root.Children.Add(root);
+        GumService.Default.Root.UpdateLayout();
+
+        int count = DrawAndCount();
+
+        GumService.Default.Root.Children.Clear();
+        return count;
+    }
+}

--- a/Tests/RaylibGum.Tests/Runtimes/DataDrivenBlendPropertyTests.cs
+++ b/Tests/RaylibGum.Tests/Runtimes/DataDrivenBlendPropertyTests.cs
@@ -1,0 +1,63 @@
+using Gum.GueDeriving;
+using Gum.RenderingLibrary;
+using Gum.Renderables;
+using Shouldly;
+
+namespace RaylibGum.Tests.Runtimes;
+
+/// <summary>
+/// Reproduces the data-driven property-application path that loading a .gumx project uses
+/// (<c>ApplyState</c> → <c>SetProperty(string, object)</c> → reflection), as opposed to the
+/// strongly-typed C# setters the other Blend tests use. The nullable <c>Blend?</c> renderable
+/// properties crash on this path because <c>Convert.ChangeType</c> cannot convert an enum to its
+/// <c>Nullable&lt;&gt;</c> form (issue surfaced as an InvalidCastException setting Blend on a
+/// NineSlice when constructing a Forms screen).
+/// </summary>
+public class DataDrivenBlendPropertyTests : BaseTestClass
+{
+    [Fact]
+    public void SetProperty_Blend_OnNineSlice_AppliesWithoutThrowing()
+    {
+        NineSliceRuntime sut = new();
+
+        Should.NotThrow(() => sut.SetProperty("Blend", Blend.Normal));
+
+        ((NineSlice)sut.RenderableComponent).Blend.ShouldBe(Blend.Normal);
+    }
+
+    [Fact]
+    public void SetProperty_Blend_OnSprite_AppliesWithoutThrowing()
+    {
+        SpriteRuntime sut = new();
+
+        Should.NotThrow(() => sut.SetProperty("Blend", Blend.Additive));
+
+        ((Sprite)sut.RenderableComponent).Blend.ShouldBe(Blend.Additive);
+    }
+
+    // The shape Color? properties (FillColor/StrokeColor) are the same nullable-target class as
+    // Blend? — a Color value into a Color? property would have hit the identical Convert.ChangeType
+    // crash on the data-driven path. These pin that the general Nullable<T> fix covers them too.
+
+    [Fact]
+    public void SetProperty_FillColor_OnCircle_AppliesWithoutThrowing()
+    {
+        CircleRuntime sut = new();
+        Raylib_cs.Color expected = new(10, 20, 30, 40);
+
+        Should.NotThrow(() => sut.SetProperty("FillColor", expected));
+
+        ((Gum.Renderables.LineCircle)sut.RenderableComponent).FillColor.ShouldBe(expected);
+    }
+
+    [Fact]
+    public void SetProperty_StrokeColor_OnRectangle_AppliesWithoutThrowing()
+    {
+        RectangleRuntime sut = new();
+        Raylib_cs.Color expected = new(50, 60, 70, 80);
+
+        Should.NotThrow(() => sut.SetProperty("StrokeColor", expected));
+
+        ((Gum.Renderables.LineRectangle)sut.RenderableComponent).StrokeColor.ShouldBe(expected);
+    }
+}


### PR DESCRIPTION
## What & why

Adds an **authoritative per-pass GPU draw-call count** to the Raylib renderer so developers can tell when a frame batches poorly (MonoGame already exposes per-frame render-state-change counts; Raylib had nothing).

Rather than *predict* draw calls (fragile — raylib's batching is an implementation detail), the renderer owns a private raylib `RenderBatch` via `rlSetRenderBatchActive` and reads raylib's **own** draw counter at each batch flush. The count is exposed via the new shared `RenderStateChangeStatistics.DrawCallCount` (`Renderer.Self.RenderStateChangeStatistics`), reset each frame.

## How it works

- `BatchDrawCallCounter` owns the batch (loaded lazily, pinned for the process — mirrors `ShadowBlurRenderer`'s no-explicit-unload lifecycle). At each flush it counts the draw-call slots raylib actually filled (non-empty slots in `[0, DrawCounter)` — exactly what `rlDrawRenderBatch` emits), so empty segments never over-count.
- raylib resets the draw counter on every flush, and a flush is forced by every scissor / blend / render-target / shader / 2D-mode change. So those state changes route through thin counted wrappers that bank-then-flush. This includes the drop-shadow render-target + shader passes (folded into the main count) and the gradient-clip scissor in `LineRectangle`.
- A **coverage-guard test** scans the RaylibGum source and fails the build if any raylib flush call bypasses the counter — turning a forgotten flush point into a red build instead of a silent under-count.

## Bundled fix: data-driven nullable property crash

While testing the blend path I hit a pre-existing crash unrelated to the typed API: loading a Gum project / applying a state that sets `Blend` on a NineSlice threw `InvalidCastException`. `GraphicalUiElement.SetPropertyThroughReflection` used `Convert.ChangeType`, which cannot convert an enum/value type to its `Nullable<T>` form (`Blend` → `Blend?`, `Color` → `Color?`). It now converts against the underlying type for `Nullable<T>` targets.

This is shared `GumRuntime` code (used by MonoGame/FRB too); the change is additive (only affects cases that previously threw). It fixes the same class of bug for **Sprite `Blend?`** and the shape **`FillColor`/`StrokeColor` `Color?`** properties.

## Tests (28 new)

- Owned-batch interop (load/activate/bank/deactivate, coalescing).
- Renderer integration (exact +1 per element, per-frame reset, clip-scissor banking).
- **Per-type draw-call matrix**: every renderable type renders without crashing and is counted; multiples of an identical adjacent type **coalesce** (count doesn't grow); distinct textures increase the count; clip regions, drop shadows, blend, and a mixed scene all render without crashing and report a stable count.
- Flush-point coverage guard.
- Data-driven nullable-property regression tests (Blend on Sprite/NineSlice, Color on shapes).

**RaylibGum.Tests: 285 passing. MonoGameGum.Tests: 1604 passing** (shared change verified safe).

## Notes / follow-ups

- The metric is per-`Draw` (per-`SystemManagers`), not strictly per-frame.
- Separately filed #3048 — `RemoveFromManagers()` is a silent no-op in RaylibGum (`RemoveRenderableFromManagers` never wired). Not addressed here; it only surfaced as test-hygiene noise (worked around via `Root.Children`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
