### PR TITLE
Wire RaylibGum RemoveRenderableFromManagers so RemoveFromManagers detaches visuals (#3048)

### DIFF
--- a/Runtimes/RaylibGum/Renderables/CustomSetPropertyOnRenderable.cs
+++ b/Runtimes/RaylibGum/Renderables/CustomSetPropertyOnRenderable.cs
@@ -754,4 +754,30 @@ public class CustomSetPropertyOnRenderable
             }
         }
     }
+
+    /// <summary>
+    /// Detaches <paramref name="renderable"/> from the renderer so it stops drawing. This is the
+    /// remove counterpart to <see cref="AddRenderableToManagers"/> and is wired into
+    /// <see cref="GraphicalUiElement.RemoveRenderableFromManagers"/> by <c>SystemManagers.Initialize</c>
+    /// (issue #3048). Because the Raylib add path is purely layer-based (no Sprite/Shape/TextManager),
+    /// removal just searches the renderer's layers for the renderable and removes it.
+    /// </summary>
+    public static void RemoveRenderableFromManagers(IRenderableIpso renderable, ISystemManagers iSystemManagers)
+    {
+        if (renderable == null)
+        {
+            return;
+        }
+
+        var managers = (SystemManagers)iSystemManagers;
+
+        foreach (var layer in managers.Renderer.Layers)
+        {
+            if (layer.Renderables.Contains(renderable))
+            {
+                layer.Remove(renderable);
+                return;
+            }
+        }
+    }
 }

--- a/Runtimes/RaylibGum/RenderingLibrary/SystemManagers.cs
+++ b/Runtimes/RaylibGum/RenderingLibrary/SystemManagers.cs
@@ -125,6 +125,7 @@ public class SystemManagers : ISystemManagers
 
             GraphicalUiElement.SetPropertyOnRenderable = CustomSetPropertyOnRenderable.SetPropertyOnRenderable;
             GraphicalUiElement.AddRenderableToManagers = CustomSetPropertyOnRenderable.AddRenderableToManagers;
+            GraphicalUiElement.RemoveRenderableFromManagers = CustomSetPropertyOnRenderable.RemoveRenderableFromManagers;
 
             // raylib seems to use a resources folder, but I don't think we should make any
             // assumptions

--- a/Tests/RaylibGum.Tests/Wireframe/RemoveFromManagersTests.cs
+++ b/Tests/RaylibGum.Tests/Wireframe/RemoveFromManagersTests.cs
@@ -1,0 +1,50 @@
+using Gum.GueDeriving;
+using Gum.Wireframe;
+using RenderingLibrary;
+using RenderingLibrary.Graphics;
+using Shouldly;
+
+namespace RaylibGum.Tests.Wireframe;
+
+/// <summary>
+/// Pins the symmetry of <see cref="GraphicalUiElement.AddToManagers(ISystemManagers, Layer?)"/> and
+/// <see cref="GraphicalUiElement.RemoveFromManagers"/> on the Raylib backend (issue #3048). On Raylib
+/// the contained renderable is added directly to a <see cref="Layer"/>; removal must detach it again,
+/// otherwise removed visuals keep rendering every frame.
+/// </summary>
+public class RemoveFromManagersTests : BaseTestClass
+{
+    [Fact]
+    public void AddToManagers_PutsRenderableOnLayer()
+    {
+        RectangleRuntime sut = new() { Width = 50, Height = 50 };
+
+        sut.AddToManagers(SystemManagers.Default);
+
+        IsContainedRenderableOnAnyLayer(sut).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void RemoveFromManagers_DetachesRenderableFromLayer()
+    {
+        RectangleRuntime sut = new() { Width = 50, Height = 50 };
+        sut.AddToManagers(SystemManagers.Default);
+
+        sut.RemoveFromManagers();
+
+        IsContainedRenderableOnAnyLayer(sut).ShouldBeFalse();
+    }
+
+    private static bool IsContainedRenderableOnAnyLayer(GraphicalUiElement element)
+    {
+        IRenderableIpso renderable = (IRenderableIpso)element.RenderableComponent;
+        foreach (Layer layer in SystemManagers.Default.Renderer.Layers)
+        {
+            if (layer.Renderables.Contains(renderable))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #3048. In the **RaylibGum** runtime, `GraphicalUiElement.RemoveFromManagers()` was a silent no-op: an element added with `AddToManagers(...)` kept rendering after `RemoveFromManagers()` because it was never detached from the renderer's layer.

## Root cause

`RemoveFromManagers()` detaches the contained renderable through the static `GraphicalUiElement.RemoveRenderableFromManagers` delegate. RaylibGum wired the **add** delegate but never the **remove** one, so the delegate stayed `null` and the `?.Invoke(...)` did nothing. MonoGame and Skia both wire the remove delegate — Raylib was the lone outlier (a historical inconsistency, not a platform-necessary divergence).

## Fix

- Added a layer-based `RemoveRenderableFromManagers(IRenderableIpso, ISystemManagers)` to `Runtimes/RaylibGum/Renderables/CustomSetPropertyOnRenderable.cs`, mirroring Skia's implementation (search the renderer's layers, remove). The Raylib add path is purely layer-based — no Sprite/Shape/TextManager — so removal is too.
- Wired it in `SystemManagers.Initialize` alongside the add delegate.

### Why fix rather than `[Obsolete]`

`RemoveFromManagers()` is the legitimate cleanup counterpart to the **non-obsolete** `AddToManagers(ISystemManagers, Layer?)` overload (kept for multi-instance scenarios like SkiaGum). Only the parameterless `AddToManagers()` is `[Obsolete]` (→ `AddToRoot()`). Deprecating `RemoveFromManagers` would orphan the supported add overload, wouldn't fix the runtime leak for existing callers, and is called internally (ListBox popup teardown, `GumService` cleanup). So the correct resolution is to make it work, matching MonoGame/Skia.

## Testing (TDD)

Added `Tests/RaylibGum.Tests/Wireframe/RemoveFromManagersTests.cs`:
- `AddToManagers_PutsRenderableOnLayer` — pins the add path.
- `RemoveFromManagers_DetachesRenderableFromLayer` — written first, failed for the right reason (renderable stayed on the layer), green after the fix.

Full RaylibGum.Tests suite: **259/259 passing**.

Closes #3048

🤖 Generated with [Claude Code](https://claude.com/claude-code)
