### PR TITLE
Implement controller-based UI tabbing on Raylib (#3046)

### DIFF
--- a/GumRuntime/Input/GamePad.cs
+++ b/GumRuntime/Input/GamePad.cs
@@ -1,23 +1,321 @@
 namespace Gum.Input;
 
+/// <summary>
+/// Platform-neutral gamepad data holder. This class holds input state only — it
+/// contains no platform-specific reading code. A platform driver (for example the
+/// <c>#if RAYLIB</c> branch of <c>FormsUtilities.UpdateGamepads</c>) reads native
+/// controller input each frame, pushes it in via <see cref="SetButtonState"/> /
+/// <see cref="SetLeftStickPosition"/>, then calls <see cref="Activity"/> to advance
+/// a frame. Forms code consumes the result through the <see cref="IGamePad"/> query
+/// API and never needs to know how the data was populated.
+/// </summary>
 public class GamePad : IGamePad
 {
-    // todo - this is needed to be implemented
-    public bool ButtonDown(GamepadButton button) => false;
-    public bool ButtonPushed(GamepadButton button) => false;
-    public bool ButtonReleased(GamepadButton button) => false;
+    // GamepadButton values are single-bit flags (powers of two), so each maps to a
+    // unique array index via its trailing-zero count. The largest value
+    // (LeftThumbstickRight = 0x40000000) is bit 30, so 31 slots cover every button.
+    // This mirrors MonoGameGum.Input.GamePad's bitfield-to-index scheme.
+    const int ButtonCount = 31;
 
-    public bool ButtonRepeatRate(GamepadButton button) => false;
+    const double DefaultTimeAfterPush = 0.35;
+    const double DefaultTimeBetweenRepeating = 0.12;
 
-    IAnalogStick IGamePad.LeftStick => LeftStick;
-    public AnalogStick LeftStick { get; private set; } = new();
+    // Buffer written by the setters during a frame, committed to _currentButtonDown
+    // by Activity so the current/last transition (used for pushed/released) is atomic.
+    bool[] _incomingButtonDown;
+    bool[] _currentButtonDown;
+    bool[] _lastButtonDown;
+
+    double[] _lastButtonPush;
+    double[] _lastButtonRepeatRate;
+
+    double _currentTime;
+
+    float _incomingLeftStickX;
+    float _incomingLeftStickY;
+
+    AnalogStick _leftStick;
+
+    /// <summary>
+    /// The left analog stick. Always non-null even if the physical controller has no analog stick.
+    /// </summary>
+    public AnalogStick LeftStick => _leftStick;
+
+    /// <inheritdoc/>
+    IAnalogStick IGamePad.LeftStick => _leftStick;
+
+    /// <summary>
+    /// Creates a new gamepad with all inputs in their neutral (released / centered) state.
+    /// </summary>
+    public GamePad()
+    {
+        _incomingButtonDown = new bool[ButtonCount];
+        _currentButtonDown = new bool[ButtonCount];
+        _lastButtonDown = new bool[ButtonCount];
+        _lastButtonPush = new double[ButtonCount];
+        _lastButtonRepeatRate = new double[ButtonCount];
+        _leftStick = new AnalogStick();
+    }
+
+    static int GetButtonIndex(GamepadButton button) =>
+        System.Numerics.BitOperations.TrailingZeroCount((uint)button);
+
+    #region Driver-facing setters
+
+    /// <summary>
+    /// Sets whether a button is held down for the current frame. Called by the platform
+    /// input driver for every relevant button before <see cref="Activity"/> commits the frame.
+    /// </summary>
+    public void SetButtonState(GamepadButton button, bool isDown)
+    {
+        _incomingButtonDown[GetButtonIndex(button)] = isDown;
+    }
+
+    /// <summary>
+    /// Sets the left analog stick position for the current frame, in the XNA/Gum convention
+    /// (X: -1 left to +1 right, Y: -1 down to +1 up). Called by the platform input driver
+    /// before <see cref="Activity"/> commits the frame.
+    /// </summary>
+    public void SetLeftStickPosition(float x, float y)
+    {
+        _incomingLeftStickX = x;
+        _incomingLeftStickY = y;
+    }
+
+    /// <summary>
+    /// Commits the state pushed in via the setters and advances repeat-rate timing.
+    /// Called once per frame by the platform input driver after the setters.
+    /// </summary>
+    /// <param name="time">The total elapsed game time in seconds.</param>
+    public void Activity(double time)
+    {
+        _currentTime = time;
+
+        for (int i = 0; i < ButtonCount; i++)
+        {
+            _lastButtonDown[i] = _currentButtonDown[i];
+            _currentButtonDown[i] = _incomingButtonDown[i];
+        }
+
+        for (int i = 0; i < ButtonCount; i++)
+        {
+            if (_currentButtonDown[i] && !_lastButtonDown[i])
+            {
+                _lastButtonPush[i] = time;
+            }
+        }
+
+        _leftStick.Update(_incomingLeftStickX, _incomingLeftStickY, time);
+    }
+
+    #endregion
+
+    #region IGamePad query API
+
+    /// <inheritdoc/>
+    public bool ButtonDown(GamepadButton button)
+    {
+        if (TryGetLeftStickDirection(button, out DPadDirection direction))
+        {
+            return _leftStick.AsDPadDown(direction);
+        }
+        return _currentButtonDown[GetButtonIndex(button)];
+    }
+
+    /// <inheritdoc/>
+    public bool ButtonPushed(GamepadButton button)
+    {
+        if (TryGetLeftStickDirection(button, out DPadDirection direction))
+        {
+            return _leftStick.AsDPadPushed(direction);
+        }
+        int index = GetButtonIndex(button);
+        return _currentButtonDown[index] && !_lastButtonDown[index];
+    }
+
+    /// <inheritdoc/>
+    public bool ButtonReleased(GamepadButton button)
+    {
+        int index = GetButtonIndex(button);
+        return !_currentButtonDown[index] && _lastButtonDown[index];
+    }
+
+    /// <inheritdoc/>
+    public bool ButtonRepeatRate(GamepadButton button) =>
+        ButtonRepeatRate(button, DefaultTimeAfterPush, DefaultTimeBetweenRepeating);
+
+    /// <summary>
+    /// Returns whether the button was pushed this frame, or has been held long enough to
+    /// trigger a key-repeat with the supplied timing.
+    /// </summary>
+    /// <param name="button">The button to test.</param>
+    /// <param name="timeAfterPush">Seconds to wait after the initial push before the first repeat.</param>
+    /// <param name="timeBetweenRepeating">Seconds between repeats once repeating has started.</param>
+    public bool ButtonRepeatRate(GamepadButton button, double timeAfterPush, double timeBetweenRepeating)
+    {
+        if (ButtonPushed(button))
+        {
+            return true;
+        }
+
+        int index = GetButtonIndex(button);
+
+        // If called multiple times in one frame, keep returning true for the rest of the frame.
+        bool repeatedThisFrame = _currentTime > 0 && _lastButtonRepeatRate[index] == _currentTime;
+
+        if (repeatedThisFrame ||
+            (ButtonDown(button) &&
+             _currentTime - _lastButtonPush[index] > timeAfterPush &&
+             _currentTime - _lastButtonRepeatRate[index] > timeBetweenRepeating))
+        {
+            _lastButtonRepeatRate[index] = _currentTime;
+            return true;
+        }
+
+        return false;
+    }
+
+    #endregion
+
+    // The four LeftThumbstick* buttons report the analog stick as if it were a DPad,
+    // matching MonoGameGum.Input.GamePad. All other buttons read the button array.
+    static bool TryGetLeftStickDirection(GamepadButton button, out DPadDirection direction)
+    {
+        switch (button)
+        {
+            case GamepadButton.LeftThumbstickUp: direction = DPadDirection.Up; return true;
+            case GamepadButton.LeftThumbstickDown: direction = DPadDirection.Down; return true;
+            case GamepadButton.LeftThumbstickLeft: direction = DPadDirection.Left; return true;
+            case GamepadButton.LeftThumbstickRight: direction = DPadDirection.Right; return true;
+            default: direction = DPadDirection.Up; return false;
+        }
+    }
 }
 
+/// <summary>
+/// Platform-neutral analog stick data holder. Stores the stick position pushed in by a
+/// platform driver and emulates DPad-style directional presses (with hysteresis and
+/// key-repeat) for UI navigation. Contains no platform-specific reading code.
+/// </summary>
 public class AnalogStick : IAnalogStick
 {
-    // todo - this is needed to be implemented
-    public bool AsDPadPushed(DPadDirection direction) => false;
-    public bool AsDPadPushedRepeatRate(DPadDirection direction) => false;
+    // The stick must pass DPadOnValue to register a direction, and must fall back under
+    // DPadOffValue to release it. The gap prevents rapid on/off chatter when the user
+    // holds the stick near the threshold. Mirrors MonoGameGum.Input.AnalogStick.
+    const float DPadOnValue = 0.55f;
+    const float DPadOffValue = 0.45f;
+
+    // Below this magnitude the stick is treated as centered, to ignore resting drift.
+    const float Deadzone = 0.1f;
+
+    const double DefaultTimeAfterPush = 0.35;
+    const double DefaultTimeBetweenRepeating = 0.12;
+
+    float _x;
+    float _y;
+    double _currentTime;
+
+    bool[] _lastDPadDown;
+    double[] _lastDPadPush;
+    double[] _lastDPadRepeatRate;
+
+    /// <summary>
+    /// Creates a new analog stick in its neutral (centered) state.
+    /// </summary>
+    public AnalogStick()
+    {
+        _lastDPadDown = new bool[4];
+        // Start at -1 (not 0) so the first frame at time 0 is not mistaken for a repeat.
+        _lastDPadPush = new double[4] { -1, -1, -1, -1 };
+        _lastDPadRepeatRate = new double[4] { -1, -1, -1, -1 };
+    }
+
+    /// <summary>
+    /// Returns whether the stick is currently pushed far enough toward the given direction
+    /// to count as a DPad press (with on/off hysteresis).
+    /// </summary>
+    public bool AsDPadDown(DPadDirection direction)
+    {
+        switch (direction)
+        {
+            case DPadDirection.Left:
+                return _lastDPadDown[(int)direction] ? _x < -DPadOffValue : _x < -DPadOnValue;
+            case DPadDirection.Right:
+                return _lastDPadDown[(int)direction] ? _x > DPadOffValue : _x > DPadOnValue;
+            case DPadDirection.Up:
+                return _lastDPadDown[(int)direction] ? _y > DPadOffValue : _y > DPadOnValue;
+            case DPadDirection.Down:
+                return _lastDPadDown[(int)direction] ? _y < -DPadOffValue : _y < -DPadOnValue;
+            default:
+                return false;
+        }
+    }
+
+    /// <inheritdoc/>
+    public bool AsDPadPushed(DPadDirection direction) =>
+        !_lastDPadDown[(int)direction] && AsDPadDown(direction);
+
+    /// <inheritdoc/>
+    public bool AsDPadPushedRepeatRate(DPadDirection direction) =>
+        AsDPadPushedRepeatRate(direction, DefaultTimeAfterPush, DefaultTimeBetweenRepeating);
+
+    /// <summary>
+    /// Returns whether the stick was pushed toward the direction this frame, or has been held
+    /// there long enough to trigger a key-repeat with the supplied timing.
+    /// </summary>
+    public bool AsDPadPushedRepeatRate(DPadDirection direction, double timeAfterPush, double timeBetweenRepeating)
+    {
+        if (AsDPadPushed(direction))
+        {
+            return true;
+        }
+
+        bool repeatedThisFrame = _currentTime > 0 && _lastDPadPush[(int)direction] == _currentTime;
+
+        if (repeatedThisFrame ||
+            (AsDPadDown(direction) &&
+             _currentTime - _lastDPadPush[(int)direction] > timeAfterPush &&
+             _currentTime - _lastDPadRepeatRate[(int)direction] > timeBetweenRepeating))
+        {
+            _lastDPadRepeatRate[(int)direction] = _currentTime;
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Commits the stick position for the current frame. Called by <see cref="GamePad.Activity"/>.
+    /// Position is in the XNA/Gum convention (X: -1 left to +1 right, Y: -1 down to +1 up).
+    /// </summary>
+    public void Update(float x, float y, double time)
+    {
+        _currentTime = time;
+
+        if ((x * x) + (y * y) < Deadzone * Deadzone)
+        {
+            x = 0;
+            y = 0;
+        }
+
+        // Capture the previous down-state (using the previous position) before moving to the
+        // new position, so AsDPadPushed can detect the off-to-on transition this frame.
+        _lastDPadDown[(int)DPadDirection.Up] = AsDPadDown(DPadDirection.Up);
+        _lastDPadDown[(int)DPadDirection.Down] = AsDPadDown(DPadDirection.Down);
+        _lastDPadDown[(int)DPadDirection.Left] = AsDPadDown(DPadDirection.Left);
+        _lastDPadDown[(int)DPadDirection.Right] = AsDPadDown(DPadDirection.Right);
+
+        _x = x;
+        _y = y;
+
+        for (int i = 0; i < 4; i++)
+        {
+            if (AsDPadPushed((DPadDirection)i))
+            {
+                _lastDPadPush[i] = time;
+            }
+        }
+    }
 }
 
 public enum GamepadButton

--- a/MonoGameGum/Forms/FormsUtilities.cs
+++ b/MonoGameGum/Forms/FormsUtilities.cs
@@ -23,6 +23,14 @@ using MonoGameGum.Input;
 #else
 using Gum.GueDeriving;
 using Gum.Input;
+#if RAYLIB
+// Both Gum.Input and Raylib_cs (a project-wide global using on Raylib) define a
+// GamepadButton type, so alias both to disambiguate inside the Raylib read branch
+// of UpdateGamepads.
+using GumGamepadButton = Gum.Input.GamepadButton;
+using RaylibGamepadButton = Raylib_cs.GamepadButton;
+using RaylibGamepadAxis = Raylib_cs.GamepadAxis;
+#endif
 #endif
 
 #if FRB
@@ -522,6 +530,43 @@ public class FormsUtilities
             var gamepadState = Microsoft.Xna.Framework.Input.GamePad.GetState((int)i);
 #endif
             Gamepads[i].Activity(gamepadState, time);
+        }
+#elif RAYLIB
+        // Read native Raylib controller input and push it into the platform-neutral
+        // GamePad holders. Raylib's IsGamepadButtonDown / GetGamepadAxisMovement return
+        // false / 0 for unavailable indices, so no connectivity guard is needed — a
+        // disconnected pad naturally reads as all-released and centered.
+        for (int i = 0; i < Gamepads.Length; i++)
+        {
+            var gamepad = Gamepads[i];
+
+            gamepad.SetButtonState(GumGamepadButton.DPadUp, Raylib.IsGamepadButtonDown(i, RaylibGamepadButton.LeftFaceUp));
+            gamepad.SetButtonState(GumGamepadButton.DPadDown, Raylib.IsGamepadButtonDown(i, RaylibGamepadButton.LeftFaceDown));
+            gamepad.SetButtonState(GumGamepadButton.DPadLeft, Raylib.IsGamepadButtonDown(i, RaylibGamepadButton.LeftFaceLeft));
+            gamepad.SetButtonState(GumGamepadButton.DPadRight, Raylib.IsGamepadButtonDown(i, RaylibGamepadButton.LeftFaceRight));
+
+            // Raylib's right-face buttons map to the XNA/Gum face buttons by position:
+            // RightFaceDown = A, RightFaceRight = B, RightFaceLeft = X, RightFaceUp = Y.
+            gamepad.SetButtonState(GumGamepadButton.A, Raylib.IsGamepadButtonDown(i, RaylibGamepadButton.RightFaceDown));
+            gamepad.SetButtonState(GumGamepadButton.B, Raylib.IsGamepadButtonDown(i, RaylibGamepadButton.RightFaceRight));
+            gamepad.SetButtonState(GumGamepadButton.X, Raylib.IsGamepadButtonDown(i, RaylibGamepadButton.RightFaceLeft));
+            gamepad.SetButtonState(GumGamepadButton.Y, Raylib.IsGamepadButtonDown(i, RaylibGamepadButton.RightFaceUp));
+
+            gamepad.SetButtonState(GumGamepadButton.LeftShoulder, Raylib.IsGamepadButtonDown(i, RaylibGamepadButton.LeftTrigger1));
+            gamepad.SetButtonState(GumGamepadButton.RightShoulder, Raylib.IsGamepadButtonDown(i, RaylibGamepadButton.RightTrigger1));
+
+            gamepad.SetButtonState(GumGamepadButton.Start, Raylib.IsGamepadButtonDown(i, RaylibGamepadButton.MiddleRight));
+            gamepad.SetButtonState(GumGamepadButton.Back, Raylib.IsGamepadButtonDown(i, RaylibGamepadButton.MiddleLeft));
+
+            gamepad.SetButtonState(GumGamepadButton.LeftStick, Raylib.IsGamepadButtonDown(i, RaylibGamepadButton.LeftThumb));
+            gamepad.SetButtonState(GumGamepadButton.RightStick, Raylib.IsGamepadButtonDown(i, RaylibGamepadButton.RightThumb));
+
+            // Raylib reports stick Y as positive-down; flip it to the XNA/Gum convention (positive-up).
+            float leftX = Raylib.GetGamepadAxisMovement(i, RaylibGamepadAxis.LeftX);
+            float leftY = Raylib.GetGamepadAxisMovement(i, RaylibGamepadAxis.LeftY);
+            gamepad.SetLeftStickPosition(leftX, -leftY);
+
+            gamepad.Activity(time);
         }
 #endif
 

--- a/Samples/raylib/Program.cs
+++ b/Samples/raylib/Program.cs
@@ -57,13 +57,16 @@ public class BasicShapes
 
         GumUI.Initialize();
 
-        // Enable gamepad navigation for Forms controls (see
+        // Enable gamepad + keyboard navigation for Forms controls (see
         // https://docs.flatredball.com/gum/code/events-and-interactivity/gamepad-support).
         // GumUI.Update reads the connected controller into these gamepads each frame; the
         // D-pad / left stick then move focus between controls and A activates the focused
-        // control. The starting control is given focus in FormsControlsScreen's constructor.
+        // control. UseKeyboardDefaults registers the keyboard so Tab / Shift+Tab navigate the
+        // same way. The starting control is given focus in FormsControlsScreen's constructor.
         FrameworkElement.GamePadsForUiControl.Clear();
         FrameworkElement.GamePadsForUiControl.AddRange(GumUI.Gamepads);
+
+        GumUI.UseKeyboardDefaults();
 
         // Demo the auto-fit helpers — flip via the Zoom/Expand radio buttons in the nav strip.
         GumUI.EnableZoomToWindow();

--- a/Samples/raylib/Program.cs
+++ b/Samples/raylib/Program.cs
@@ -100,12 +100,49 @@ public class BasicShapes
                 GumUI.Draw();
             }
 
+            DrawGamepadDiagnostics();
+
             EndDrawing();
 
             Thread.Sleep(12);
         }
 
         CloseWindow();
+    }
+
+    // TEMPORARY diagnostic overlay for issue #3046 — shows whether raylib sees a gamepad,
+    // its raw left-stick / D-pad / A input, and which Forms control currently has focus.
+    // Remove once controller navigation is confirmed working.
+    private static void DrawGamepadDiagnostics()
+    {
+        int y = 70;
+        const int fontSize = 18;
+
+        bool anyPad = false;
+        for (int i = 0; i < 4; i++)
+        {
+            if (!IsGamepadAvailable(i))
+            {
+                continue;
+            }
+            anyPad = true;
+            float lx = GetGamepadAxisMovement(i, GamepadAxis.LeftX);
+            float ly = GetGamepadAxisMovement(i, GamepadAxis.LeftY);
+            bool dpadDown = IsGamepadButtonDown(i, GamepadButton.LeftFaceDown);
+            bool aDown = IsGamepadButtonDown(i, GamepadButton.RightFaceDown);
+            DrawText($"Pad {i}: LX={lx:0.00} LY={ly:0.00}  DPadDown={dpadDown}  A={aDown}",
+                8, y, fontSize, Color.Yellow);
+            y += 22;
+        }
+
+        if (!anyPad)
+        {
+            DrawText("raylib sees NO gamepad (IsGamepadAvailable false for 0-3)", 8, y, fontSize, Color.Red);
+            y += 22;
+        }
+
+        string focus = InteractiveGue.CurrentInputReceiver?.GetType().Name ?? "null";
+        DrawText($"Focused control: {focus}", 8, y, fontSize, Color.Lime);
     }
 
     // Mirrors MonoGameGumShapesGallery/Game1.BuildNavStrip — horizontal Forms Button strip

--- a/Samples/raylib/Program.cs
+++ b/Samples/raylib/Program.cs
@@ -100,49 +100,12 @@ public class BasicShapes
                 GumUI.Draw();
             }
 
-            DrawGamepadDiagnostics();
-
             EndDrawing();
 
             Thread.Sleep(12);
         }
 
         CloseWindow();
-    }
-
-    // TEMPORARY diagnostic overlay for issue #3046 — shows whether raylib sees a gamepad,
-    // its raw left-stick / D-pad / A input, and which Forms control currently has focus.
-    // Remove once controller navigation is confirmed working.
-    private static void DrawGamepadDiagnostics()
-    {
-        int y = 70;
-        const int fontSize = 18;
-
-        bool anyPad = false;
-        for (int i = 0; i < 4; i++)
-        {
-            if (!IsGamepadAvailable(i))
-            {
-                continue;
-            }
-            anyPad = true;
-            float lx = GetGamepadAxisMovement(i, GamepadAxis.LeftX);
-            float ly = GetGamepadAxisMovement(i, GamepadAxis.LeftY);
-            bool dpadDown = IsGamepadButtonDown(i, GamepadButton.LeftFaceDown);
-            bool aDown = IsGamepadButtonDown(i, GamepadButton.RightFaceDown);
-            DrawText($"Pad {i}: LX={lx:0.00} LY={ly:0.00}  DPadDown={dpadDown}  A={aDown}",
-                8, y, fontSize, Color.Yellow);
-            y += 22;
-        }
-
-        if (!anyPad)
-        {
-            DrawText("raylib sees NO gamepad (IsGamepadAvailable false for 0-3)", 8, y, fontSize, Color.Red);
-            y += 22;
-        }
-
-        string focus = InteractiveGue.CurrentInputReceiver?.GetType().Name ?? "null";
-        DrawText($"Focused control: {focus}", 8, y, fontSize, Color.Lime);
     }
 
     // Mirrors MonoGameGumShapesGallery/Game1.BuildNavStrip — horizontal Forms Button strip

--- a/Samples/raylib/Program.cs
+++ b/Samples/raylib/Program.cs
@@ -52,6 +52,14 @@ public class BasicShapes
 
         GumUI.Initialize();
 
+        // Enable gamepad navigation for Forms controls (see
+        // https://docs.flatredball.com/gum/code/events-and-interactivity/gamepad-support).
+        // GumUI.Update reads the connected controller into these gamepads each frame; the
+        // D-pad / left stick then move focus between controls and A activates the focused
+        // control. The starting control is given focus in FormsControlsScreen's constructor.
+        FrameworkElement.GamePadsForUiControl.Clear();
+        FrameworkElement.GamePadsForUiControl.AddRange(GumUI.Gamepads);
+
         // Demo the auto-fit helpers — flip via the Zoom/Expand radio buttons in the nav strip.
         GumUI.EnableZoomToWindow();
         var standardTexture = SystemManagers.Default.LoadEmbeddedTexture2d("UISpriteSheet.png");

--- a/Samples/raylib/Program.cs
+++ b/Samples/raylib/Program.cs
@@ -22,6 +22,11 @@ public class BasicShapes
     static StackPanel? navStrip;
     static FrameworkElement? activeScreen;
 
+    // Set when a screen is shown so its initial gamepad focus is applied after the next
+    // GumUI.Update — ShowScreen runs inside a nav button's Click handler (during Update), and
+    // applying focus there gets cleared by the rest of that frame's input processing.
+    static bool _applyInitialFocusAfterUpdate;
+
     // Manual-camera demo state. When _useManualCamera is true the render loop calls
     // GumUI.Draw(_manualCamera) instead of GumUI.Draw(), exercising the new
     // Draw(Camera2D) overload (#2846). Arrow keys pan; mouse wheel zooms.
@@ -76,6 +81,14 @@ public class BasicShapes
             ClearBackground(new Color(51, 76, 204, 255));
 
             GumUI.Update(GetTime());
+
+            // Apply a freshly-shown screen's initial gamepad focus now that this frame's
+            // input (including the nav-button click that swapped screens) has been processed.
+            if (_applyInitialFocusAfterUpdate)
+            {
+                _applyInitialFocusAfterUpdate = false;
+                (activeScreen as FormsControlsScreen)?.FocusInitialControl();
+            }
 
             if (_useManualCamera)
             {
@@ -199,6 +212,9 @@ public class BasicShapes
         activeScreen.Visual.Y = NavStripHeight;
         activeScreen.Visual.Height = -NavStripHeight;
         activeScreen.AddToRoot();
+
+        // Defer initial gamepad focus to just after the next GumUI.Update (see field comment).
+        _applyInitialFocusAfterUpdate = true;
     }
 
     private static void InitializeStyling()

--- a/Samples/raylib/Screens/FormsControlsScreen.cs
+++ b/Samples/raylib/Screens/FormsControlsScreen.cs
@@ -4,7 +4,6 @@ using Gum.Forms;
 using Gum.Forms.Controls;
 using Gum.GueDeriving;
 using Gum.Managers;
-using Gum.Renderables;
 using Gum.Wireframe;
 using Raylib_cs;
 using RenderingLibrary.Graphics;
@@ -21,7 +20,10 @@ internal class FormsControlsScreen : FrameworkElement
     {
         Dock(Gum.Wireframe.Dock.Fill);
 
-        var container = new GraphicalUiElement(new InvisibleRenderable());
+        // Must be an InteractiveGue (ContainerRuntime), not a raw GraphicalUiElement: focus
+        // tabbing walks the focused control's parent via `Parent as InteractiveGue`, so a
+        // non-interactive parent yields no siblings and gamepad/keyboard navigation no-ops.
+        var container = new ContainerRuntime();
         this.AddChild(container);
         container.ChildrenLayout = ChildrenLayout.TopToBottomStack;
         container.WrapsChildren = true;

--- a/Samples/raylib/Screens/FormsControlsScreen.cs
+++ b/Samples/raylib/Screens/FormsControlsScreen.cs
@@ -25,7 +25,7 @@ internal class FormsControlsScreen : FrameworkElement
         this.AddChild(container);
         container.ChildrenLayout = ChildrenLayout.TopToBottomStack;
         container.WrapsChildren = true;
-        container.StackSpacing = 2;
+        container.StackSpacing = 5;
         container.Width = 0;
         container.WidthUnits = DimensionUnitType.RelativeToParent;
         container.Height = 0;

--- a/Samples/raylib/Screens/FormsControlsScreen.cs
+++ b/Samples/raylib/Screens/FormsControlsScreen.cs
@@ -15,6 +15,8 @@ namespace Examples.Shapes;
 
 internal class FormsControlsScreen : FrameworkElement
 {
+    private readonly FrameworkElement _initialFocusControl;
+
     public FormsControlsScreen() : base(new ContainerRuntime())
     {
         Dock(Gum.Wireframe.Dock.Fill);
@@ -35,10 +37,16 @@ internal class FormsControlsScreen : FrameworkElement
         button.Text = "I'm a button";
         container.AddChild(button.Visual);
 
-        // Give the first control focus so a connected gamepad has a starting point to
-        // navigate from (the gamepads themselves are registered in Program.Main). See
+        var textBox = new TextBox();
+        container.AddChild(textBox.Visual);
+        textBox.Width = 250;
+        textBox.Placeholder = "Type here…";
+
+        // The TextBox is the starting control given focus when this screen is shown (its
+        // blinking caret makes the current gamepad focus easy to see). Program applies the
+        // focus after the screen is added — see FocusInitialControl and
         // https://docs.flatredball.com/gum/code/events-and-interactivity/gamepad-support.
-        button.IsFocused = true;
+        _initialFocusControl = textBox;
 
         var checkbox = new CheckBox();
         checkbox.Width = 200;
@@ -163,6 +171,16 @@ internal class FormsControlsScreen : FrameworkElement
         };
 
         AddSwitchHint();
+    }
+
+    /// <summary>
+    /// Gives this screen's starting control input focus. Called by Program after the screen
+    /// has been added to the root and the current frame's input has been processed, so a
+    /// connected gamepad has a control to begin navigating from.
+    /// </summary>
+    public void FocusInitialControl()
+    {
+        _initialFocusControl.IsFocused = true;
     }
 
     private void AddSwitchHint()

--- a/Samples/raylib/Screens/FormsControlsScreen.cs
+++ b/Samples/raylib/Screens/FormsControlsScreen.cs
@@ -35,6 +35,11 @@ internal class FormsControlsScreen : FrameworkElement
         button.Text = "I'm a button";
         container.AddChild(button.Visual);
 
+        // Give the first control focus so a connected gamepad has a starting point to
+        // navigate from (the gamepads themselves are registered in Program.Main). See
+        // https://docs.flatredball.com/gum/code/events-and-interactivity/gamepad-support.
+        button.IsFocused = true;
+
         var checkbox = new CheckBox();
         checkbox.Width = 200;
         checkbox.Text = "Check me";
@@ -163,7 +168,7 @@ internal class FormsControlsScreen : FrameworkElement
     private void AddSwitchHint()
     {
         var hint = new TextRuntime();
-        hint.Text = "Press SPACE to switch screens";
+        hint.Text = "Gamepad: D-pad / left stick navigates, A activates";
         hint.XOrigin = HorizontalAlignment.Left;
         hint.YOrigin = VerticalAlignment.Bottom;
         hint.XUnits = GeneralUnitType.PixelsFromSmall;

--- a/Tests/RaylibGum.Tests/Forms/ControllerTabNavigationTests.cs
+++ b/Tests/RaylibGum.Tests/Forms/ControllerTabNavigationTests.cs
@@ -1,0 +1,111 @@
+using Gum.Forms.Controls;
+using Gum.GueDeriving;
+using Gum.Input;
+using Gum.Wireframe;
+
+using Shouldly;
+
+namespace RaylibGum.Tests.Forms;
+
+/// <summary>
+/// Tests for controller / gamepad focus navigation (tabbing) on Raylib. These
+/// exercise the shared <see cref="FrameworkElement.HandleGamepadNavigation"/> path
+/// driven by a real <see cref="GamePad"/> data holder — the same holder the
+/// <c>#if RAYLIB</c> branch of <c>FormsUtilities.UpdateGamepads</c> populates from
+/// Raylib input each frame. Before issue #3046, the holder returned false for every
+/// query so navigating the UI with a controller did nothing on Raylib.
+///
+/// Mirrors the harness approach in <see cref="FocusTabNavigationTests"/>: a thin
+/// <see cref="FrameworkElement"/> wired to a <see cref="ContainerRuntime"/> visual,
+/// avoiding the full <c>FormsUtilities.InitializeDefaults</c> setup.
+/// </summary>
+public class ControllerTabNavigationTests : BaseTestClass
+{
+    private sealed class GamepadNavHarness : FrameworkElement, IInputReceiver
+    {
+        public GamepadNavHarness(InteractiveGue visual) : base(visual) { }
+
+        public void InvokeHandleGamepadNavigation(IGamePad gamepad) => HandleGamepadNavigation(gamepad);
+
+        public IInputReceiver? ParentInputReceiver => null;
+
+        public void OnGainFocus() { }
+
+        public void OnLoseFocus() { }
+
+        public void OnFocusUpdate() { }
+
+        public void OnFocusUpdatePreview(RoutedEventArgs args) { }
+
+        public void DoKeyboardAction(IInputReceiverKeyboard keyboard) { }
+    }
+
+    private static GamepadNavHarness CreateHarness(ContainerRuntime parent)
+    {
+        ContainerRuntime visual = new ContainerRuntime();
+        visual.Parent = parent;
+        GamepadNavHarness harness = new GamepadNavHarness(visual);
+        return harness;
+    }
+
+    [Fact]
+    public void HandleGamepadNavigation_DPadDownPushed_MovesFocusToNextFocusableSibling()
+    {
+        ContainerRuntime root = new ContainerRuntime();
+
+        GamepadNavHarness harness1 = CreateHarness(root);
+        GamepadNavHarness harness2 = CreateHarness(root);
+
+        harness1.IsFocused = true;
+
+        GamePad gamepad = new GamePad();
+        gamepad.SetButtonState(GamepadButton.DPadDown, true);
+        gamepad.Activity(1);
+
+        harness1.InvokeHandleGamepadNavigation(gamepad);
+
+        harness1.IsFocused.ShouldBeFalse();
+        harness2.IsFocused.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void HandleGamepadNavigation_DPadUpPushed_MovesFocusToPreviousFocusableSibling()
+    {
+        ContainerRuntime root = new ContainerRuntime();
+
+        GamepadNavHarness harness1 = CreateHarness(root);
+        GamepadNavHarness harness2 = CreateHarness(root);
+
+        harness2.IsFocused = true;
+
+        GamePad gamepad = new GamePad();
+        gamepad.SetButtonState(GamepadButton.DPadUp, true);
+        gamepad.Activity(1);
+
+        harness2.InvokeHandleGamepadNavigation(gamepad);
+
+        harness2.IsFocused.ShouldBeFalse();
+        harness1.IsFocused.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void HandleGamepadNavigation_LeftStickDown_MovesFocusToNextFocusableSibling()
+    {
+        ContainerRuntime root = new ContainerRuntime();
+
+        GamepadNavHarness harness1 = CreateHarness(root);
+        GamepadNavHarness harness2 = CreateHarness(root);
+
+        harness1.IsFocused = true;
+
+        GamePad gamepad = new GamePad();
+        // XNA/Gum stick convention: down is negative Y.
+        gamepad.SetLeftStickPosition(0, -1);
+        gamepad.Activity(1);
+
+        harness1.InvokeHandleGamepadNavigation(gamepad);
+
+        harness1.IsFocused.ShouldBeFalse();
+        harness2.IsFocused.ShouldBeTrue();
+    }
+}

--- a/Tests/RaylibGum.Tests/Inputs/GamePadTests.cs
+++ b/Tests/RaylibGum.Tests/Inputs/GamePadTests.cs
@@ -1,0 +1,87 @@
+using Gum.Input;
+using Shouldly;
+
+namespace RaylibGum.Tests.Inputs;
+
+/// <summary>
+/// Tests for the platform-neutral <see cref="GamePad"/> data holder in GumCommon.
+/// The holder stores state pushed in by a platform driver (on Raylib, the
+/// <c>#if RAYLIB</c> branch of <c>FormsUtilities.UpdateGamepads</c>) via
+/// <see cref="GamePad.SetButtonState"/> / <see cref="GamePad.SetLeftStickPosition"/>
+/// and exposes it through the <see cref="IGamePad"/> query API that Forms navigation
+/// consumes. Before this holder was implemented every query returned false, so
+/// controller tabbing did nothing on Raylib (issue #3046).
+/// </summary>
+public class GamePadTests : BaseTestClass
+{
+    [Fact]
+    public void ButtonDown_ReturnsTrue_WhenButtonSetDownThisFrame()
+    {
+        GamePad sut = new GamePad();
+        sut.SetButtonState(GamepadButton.A, true);
+        sut.Activity(1);
+
+        sut.ButtonDown(GamepadButton.A).ShouldBeTrue();
+        sut.ButtonDown(GamepadButton.B).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ButtonPushed_ReturnsTrueOnlyOnTheFrameTheButtonGoesDown()
+    {
+        GamePad sut = new GamePad();
+
+        sut.SetButtonState(GamepadButton.A, true);
+        sut.Activity(1);
+        sut.ButtonPushed(GamepadButton.A).ShouldBeTrue();
+
+        // Still held the next frame -> no longer "pushed".
+        sut.SetButtonState(GamepadButton.A, true);
+        sut.Activity(2);
+        sut.ButtonPushed(GamepadButton.A).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ButtonReleased_ReturnsTrue_OnTheFrameTheButtonGoesUp()
+    {
+        GamePad sut = new GamePad();
+
+        sut.SetButtonState(GamepadButton.A, true);
+        sut.Activity(1);
+
+        sut.SetButtonState(GamepadButton.A, false);
+        sut.Activity(2);
+
+        sut.ButtonReleased(GamepadButton.A).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void ButtonRepeatRate_ReturnsTrue_OnInitialPush()
+    {
+        GamePad sut = new GamePad();
+        sut.SetButtonState(GamepadButton.DPadDown, true);
+        sut.Activity(1);
+
+        sut.ButtonRepeatRate(GamepadButton.DPadDown).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void LeftStick_AsDPadPushedRepeatRate_ReturnsTrue_WhenPushedDown()
+    {
+        GamePad sut = new GamePad();
+        // XNA/Gum stick convention: down is negative Y.
+        sut.SetLeftStickPosition(0, -1);
+        sut.Activity(1);
+
+        ((IAnalogStick)sut.LeftStick).AsDPadPushedRepeatRate(DPadDirection.Down).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void LeftStick_AsDPadPushed_ReturnsFalse_WhenInsideDeadzone()
+    {
+        GamePad sut = new GamePad();
+        sut.SetLeftStickPosition(0, -0.05f);
+        sut.Activity(1);
+
+        ((IAnalogStick)sut.LeftStick).AsDPadPushed(DPadDirection.Down).ShouldBeFalse();
+    }
+}


### PR DESCRIPTION
Closes #3046.

## Problem

Controller-based tabbing through Forms controls worked on MonoGame but did nothing on Raylib.

Two-part root cause (matching the issue's hypothesis #1):

- On the Raylib (non-`XNALIKE`) build, the concrete `Gum.Input.GamePad` in GumCommon was a dead stub — every `IGamePad` method returned `false`.
- `FormsUtilities.UpdateGamepads` only polled input under `#if XNALIKE`, so even that stub was never populated.

The shared Forms navigation code (`FrameworkElement.HandleGamepadNavigation`, the various `OnFocusUpdate` paths) already compiled and ran on Raylib — hypothesis #2 (Forms `#if`-ing out Raylib controller logic) was already solved. The navigation simply queried a gamepad that always reported "nothing pressed."

## Fix

A clean data-holder split — the input classes hold state; platform code reads native input and pushes it in:

1. **`GumRuntime/Input/GamePad.cs`** — `GamePad` / `AnalogStick` become real platform-neutral **data holders**. Setters (`SetButtonState`, `SetLeftStickPosition`) push state in; `Activity(time)` commits the frame and advances key-repeat timing; the `IGamePad` query API computes pushed/released/repeat from stored state. No platform-specific code. Logic and timing mirror `MonoGameGum.Input.GamePad` / `AnalogStick` (0.35s initial repeat, 0.12s repeat, 0.55/0.45 stick-as-DPad hysteresis).
2. **`MonoGameGum/Forms/FormsUtilities.cs`** — `UpdateGamepads` gains an `#if RAYLIB` branch that reads native Raylib input (`IsGamepadButtonDown` / `GetGamepadAxisMovement`) each frame and pushes it into the holders. `GumService.Update` already drives `UpdateGamepads` on every platform, so no `GumService` change is needed.

Non-`XNALIKE`, non-`RAYLIB` platforms (Sokol) keep the neutral all-released behavior. No new classes, no GumCommon relocation, no partials.

Runtime usage is unchanged from MonoGame: call `GumService.Default.UseGamepadDefaults()` once after `Initialize` (already available on Raylib).

## Tests

TDD — written red first, then implemented to green:

- `Tests/RaylibGum.Tests/Inputs/GamePadTests.cs` — holder semantics (down/pushed/released/repeat, stick-as-DPad, deadzone).
- `Tests/RaylibGum.Tests/Forms/ControllerTabNavigationTests.cs` — DPad and left-stick drive focus tabbing through the real holder + `HandleGamepadNavigation`.

**294/294 RaylibGum tests and 1604/1604 MonoGameGum tests pass.** RaylibGum, MonoGameGum, SkiaGum, and GumCommon all build.

## Not covered by automated tests

The `#if RAYLIB` reading branch (Raylib face-button / axis mapping) needs a physical controller to exercise; it is compile-verified against Raylib-cs 7.0.1 but should get a smoke test with a real gamepad.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
