### PR TITLE
Fix RelativeToChildren stack ignoring first child's PixelsFromSmall offset

### DIFF
--- a/GumRuntime/GraphicalUiElement.cs
+++ b/GumRuntime/GraphicalUiElement.cs
@@ -3191,14 +3191,17 @@ public partial class GraphicalUiElement : IRenderableIpso, IVisible, INotifyProp
             var asIpso = this as IPositionedSizedObject;
             return asIpso.X + asIpso.Width;
         }
-        else if (effectiveParent != null && effectiveParent.ChildrenLayout == ChildrenLayout.LeftToRightStack)
+        else if (effectiveParent != null && effectiveParent.ChildrenLayout == ChildrenLayout.LeftToRightStack
+            && mXUnits != GeneralUnitType.PixelsFromSmall)
         {
-            // The parent owns this child's X position via stacking, so the child's own
-            // XUnits/XOrigin must not feed back into the parent's width measure. Without
-            // this branch, a stacked child with XUnits = PixelsFromMiddle (or any other
-            // non-PixelsFromSmall unit) would inflate the parent's RelativeToChildren width
-            // through the GetDimensionFromEdges path below, which doubles centered widths
-            // and clamps right-anchored widths against the parent's right edge.
+            // The parent owns this child's X position via stacking, so a non-PixelsFromSmall
+            // XUnits/XOrigin must not feed back into the parent's width measure. Without this
+            // branch, a stacked child with XUnits = PixelsFromMiddle (or PixelsFromLarge) would
+            // inflate the parent's RelativeToChildren width through the GetDimensionFromEdges
+            // path below, which doubles centered widths and clamps right-anchored widths against
+            // the parent's right edge (#2896). A PixelsFromSmall X offset, by contrast, is a real
+            // additive nudge the stack applies on top of the stacked position, so it is allowed to
+            // fall through to the edge path below and grow the parent's required width.
             var asIpso = this as IPositionedSizedObject;
             return asIpso.Width;
         }
@@ -3248,11 +3251,16 @@ public partial class GraphicalUiElement : IRenderableIpso, IVisible, INotifyProp
             var asIpso = this as IPositionedSizedObject;
             return asIpso.Y + asIpso.Height;
         }
-        else if (effectiveParent != null && effectiveParent.ChildrenLayout == ChildrenLayout.TopToBottomStack)
+        else if (effectiveParent != null && effectiveParent.ChildrenLayout == ChildrenLayout.TopToBottomStack
+            && mYUnits != GeneralUnitType.PixelsFromSmall)
         {
-            // Symmetric to GetRequiredParentWidth's LeftToRightStack branch: the parent owns
-            // this child's Y position via stacking, so the child's own YUnits/YOrigin must
-            // not feed back into the parent's height measure.
+            // Symmetric to GetRequiredParentWidth's LeftToRightStack branch: the parent owns this
+            // child's Y position via stacking, so a non-PixelsFromSmall YUnits/YOrigin must not
+            // feed back into the parent's height measure (#2896 - PixelsFromMiddle doubles and
+            // PixelsFromLarge clamps through GetDimensionFromEdges). A PixelsFromSmall Y offset is
+            // a real downward nudge the stack applies on top of the stacked position, so it falls
+            // through to the edge path below and grows the parent's required height. This is what
+            // makes a RelativeToChildren stack contain a first child placed at e.g. Y = 12.
             var asIpso = this as IPositionedSizedObject;
             return asIpso.Height;
         }

--- a/MonoGameGum.Tests/Runtimes/LayoutUnitTests.cs
+++ b/MonoGameGum.Tests/Runtimes/LayoutUnitTests.cs
@@ -2308,6 +2308,100 @@ public class LayoutUnitTests : BaseTestClass
     }
 
     [Fact]
+    public void HeightRelativeToChildren_TopToBottomStack_ShouldIncludeFirstChildYOffset()
+    {
+        // Regression for the MenuFrame bug: a top-anchored Y offset on the FIRST stacked child
+        // (YUnits = PixelsFromSmall, the default) is a real downward nudge that the stack honors
+        // when positioning the child, so it must also feed into the parent's RelativeToChildren
+        // height. PR #2896 fixed centered/large-anchored children inflating the measure, but its
+        // fix discarded the child's Y entirely - including this legitimate offset. Here the single
+        // child is 32 tall at Y = 12, so its bottom edge is 44; the parent must measure to 44, not
+        // 32 (the buggy actual, which clipped the child).
+        ContainerRuntime parent = new();
+        parent.Height = 0;
+        parent.HeightUnits = DimensionUnitType.RelativeToChildren;
+        parent.ChildrenLayout = Gum.Managers.ChildrenLayout.TopToBottomStack;
+
+        ContainerRuntime child = new();
+        child.Height = 32;
+        child.HeightUnits = DimensionUnitType.Absolute;
+        child.Y = 12;
+        child.YUnits = Gum.Converters.GeneralUnitType.PixelsFromSmall;
+        parent.AddChild(child);
+
+        parent.GetAbsoluteHeight().ShouldBe(44);
+    }
+
+    [Fact]
+    public void TopToBottomStack_FirstChild_ShouldPositionAtYOffset()
+    {
+        // The first stacked child has no previous sibling to stack after, so its position is
+        // driven purely by its own top-anchored Y offset. Y = 12 must render at AbsoluteTop 12.
+        ContainerRuntime parent = new();
+        parent.Height = 200;
+        parent.HeightUnits = DimensionUnitType.Absolute;
+        parent.ChildrenLayout = Gum.Managers.ChildrenLayout.TopToBottomStack;
+
+        ContainerRuntime child = new();
+        child.Height = 32;
+        child.HeightUnits = DimensionUnitType.Absolute;
+        child.Y = 12;
+        child.YUnits = Gum.Converters.GeneralUnitType.PixelsFromSmall;
+        parent.AddChild(child);
+
+        child.AbsoluteTop.ShouldBe(12);
+    }
+
+    [Fact]
+    public void TopToBottomStack_NonFirstChild_ShouldOffsetPositionByY()
+    {
+        // A Y offset on a non-first stacked child adds to the stacked position: child2 stacks
+        // after child1's bottom (32) plus its own Y offset (5) = 37 (StackSpacing is 0 here).
+        ContainerRuntime parent = new();
+        parent.Height = 200;
+        parent.HeightUnits = DimensionUnitType.Absolute;
+        parent.ChildrenLayout = Gum.Managers.ChildrenLayout.TopToBottomStack;
+        parent.StackSpacing = 0;
+
+        ContainerRuntime child1 = new();
+        child1.Height = 32;
+        child1.HeightUnits = DimensionUnitType.Absolute;
+        parent.AddChild(child1);
+
+        ContainerRuntime child2 = new();
+        child2.Height = 20;
+        child2.HeightUnits = DimensionUnitType.Absolute;
+        child2.Y = 5;
+        child2.YUnits = Gum.Converters.GeneralUnitType.PixelsFromSmall;
+        parent.AddChild(child2);
+
+        child1.AbsoluteTop.ShouldBe(0);
+        child2.AbsoluteTop.ShouldBe(37);
+    }
+
+    [Fact]
+    public void WidthRelativeToChildren_LeftToRightStack_ShouldIncludeFirstChildXOffset()
+    {
+        // Symmetric to HeightRelativeToChildren_TopToBottomStack_ShouldIncludeFirstChildYOffset:
+        // a top-anchored X offset (XUnits = PixelsFromSmall, the default) on a LeftToRight-stacked
+        // child grows the parent's RelativeToChildren width. Child is 32 wide at X = 12, so the
+        // parent must measure to 44.
+        ContainerRuntime parent = new();
+        parent.Width = 0;
+        parent.WidthUnits = DimensionUnitType.RelativeToChildren;
+        parent.ChildrenLayout = Gum.Managers.ChildrenLayout.LeftToRightStack;
+
+        ContainerRuntime child = new();
+        child.Width = 32;
+        child.WidthUnits = DimensionUnitType.Absolute;
+        child.X = 12;
+        child.XUnits = Gum.Converters.GeneralUnitType.PixelsFromSmall;
+        parent.AddChild(child);
+
+        parent.GetAbsoluteWidth().ShouldBe(44);
+    }
+
+    [Fact]
     public void WidthRelativeToChildren_TopToBottomStack_ShouldUseWidestChild()
     {
         ContainerRuntime parent = new();


### PR DESCRIPTION
## Problem

A parent with `HeightUnits = RelativeToChildren` and `ChildrenLayout = TopToBottomStack` measured too short when its child had a top-anchored Y offset. Reproduced in `Airpig`'s `MenuFrame.gucx`: `ItemsContainer` (top-to-bottom stack, sized to children) contained a 32-tall `ButtonContainer` placed at `Y = 12`, so its effective height should have been **44** but came out **32**, clipping the child. Switching `ChildrenLayout` to `Regular` made it correct — the smoking gun pointing at the stack measure path.

The X axis (`LeftToRightStack` + `WidthUnits = RelativeToChildren`) had the **identical latent bug**.

## Root cause

PR #2896 fixed a real over-counting bug: stacked children with `PixelsFromMiddle` / `PixelsFromLarge` units inflated a `RelativeToChildren` parent, because `GetDimensionFromEdges` doubles centered offsets and clamps large-anchored ones. Its fix made `GetRequiredParentHeight` / `GetRequiredParentWidth` short-circuit to the child's bare `Height` / `Width`, **discarding the child's offset entirely**.

That over-corrected: a `PixelsFromSmall` offset (the default unit) is a *real additive nudge* the stack applies on top of the stacked position — it pushes the child down/right and must grow the parent. Discarding it is what produced the 32-instead-of-44 measure. The position pipeline already honored these offsets, so measure and position had silently diverged.

## Fix

Narrow the #2896 short-circuit to **non-`PixelsFromSmall` units only**. `PixelsFromSmall` offsets now fall through to the established edge-measuring path (restoring pre-#2896 behavior for that one unit), while `PixelsFromMiddle` / `PixelsFromLarge` keep the #2896 short-circuit. Applied symmetrically to both axes.

`GumRuntime/GraphicalUiElement.cs` — `GetRequiredParentHeight` (TopToBottomStack) and `GetRequiredParentWidth` (LeftToRightStack).

## Tests (TDD)

`MonoGameGum.Tests/Runtimes/LayoutUnitTests.cs`:

- `HeightRelativeToChildren_TopToBottomStack_ShouldIncludeFirstChildYOffset` — the core repro (red → green: 32 → 44).
- `WidthRelativeToChildren_LeftToRightStack_ShouldIncludeFirstChildXOffset` — symmetric X-axis guard.
- `TopToBottomStack_FirstChild_ShouldPositionAtYOffset` and `TopToBottomStack_NonFirstChild_ShouldOffsetPositionByY` — position regressions; both passed before *and* after, proving measure and position now agree.

The #2896 regression tests (`ShouldIgnoreChildXUnits` / `ShouldIgnoreChildYUnits`) still pass. Full `MonoGameGum.Tests` suite green: **1608 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
