### PR TITLE
Add ScrollViewer.MouseWheelScrollSpeed, decoupled from SmallChange (#3045)

### DIFF
--- a/MonoGameGum/Forms/Controls/ScrollViewer.cs
+++ b/MonoGameGum/Forms/Controls/ScrollViewer.cs
@@ -190,6 +190,19 @@ public class ScrollViewer :
     }
 
     /// <summary>
+    /// The distance the content scrolls per mouse-wheel notch, in the same units
+    /// as <see cref="VerticalScrollBarValue"/>. Applies to both vertical scrolling
+    /// and shift+wheel horizontal scrolling. Defaults to 30.
+    /// </summary>
+    /// <remarks>
+    /// This is independent of <see cref="SmallChange"/>, which controls the scroll
+    /// bar's arrow-button / line increment; changing one does not affect the other.
+    /// Because this property lives on <see cref="ScrollViewer"/>, it is also
+    /// available on ItemsControl, ListBox, and ComboBox.
+    /// </remarks>
+    public double MouseWheelScrollSpeed { get; set; } = 30;
+
+    /// <summary>
     /// The vertical scroll bar value. Assigning this automatically scrolls
     /// the ScrollViewer to the desired location. Percentage-based scrolling
     /// can be perofrmed by using VerticalScrollBarMaximum. 
@@ -628,8 +641,7 @@ public class ScrollViewer :
             {
                 var valueBefore = verticalScrollBar.Value;
 
-                // Do we want to use the small change? Or have some separate value that the user can set?
-                verticalScrollBar.Value -= MainCursor.ZVelocity * verticalScrollBar.SmallChange;
+                verticalScrollBar.Value -= MainCursor.ZVelocity * MouseWheelScrollSpeed;
 
                 args.Handled = verticalScrollBar.Value != valueBefore;
             }
@@ -637,7 +649,7 @@ public class ScrollViewer :
             {
                 var valueBefore = horizontalScrollBar.Value;
 
-                horizontalScrollBar.Value -= MainCursor.ZVelocity * horizontalScrollBar.SmallChange;
+                horizontalScrollBar.Value -= MainCursor.ZVelocity * MouseWheelScrollSpeed;
 
                 args.Handled = horizontalScrollBar.Value != valueBefore;
             }

--- a/Tests/MonoGameGum.Tests.V2/Forms/ScrollViewerTests.cs
+++ b/Tests/MonoGameGum.Tests.V2/Forms/ScrollViewerTests.cs
@@ -49,6 +49,79 @@ public class ScrollViewerTests
     }
 
     [Fact]
+    public void MouseWheelScroll_ShouldMoveVerticalByMouseWheelScrollSpeed()
+    {
+        ScrollViewer scrollViewer = new();
+        (ScrollBar verticalBar, _) = GetScrollBars(scrollViewer);
+        verticalBar.Minimum = 0;
+        verticalBar.Maximum = 1000;
+        verticalBar.Value = 500;
+
+        scrollViewer.MouseWheelScrollSpeed = 40;
+
+        InvokeMouseWheel(scrollViewer, zVelocity: 1f);
+
+        // One notch (positive ZVelocity) subtracts MouseWheelScrollSpeed from the value.
+        verticalBar.Value.ShouldBe(460);
+    }
+
+    [Fact]
+    public void MouseWheelScroll_WithShiftHeld_ShouldMoveHorizontalByMouseWheelScrollSpeed()
+    {
+        ScrollViewer scrollViewer = new();
+        (ScrollBar verticalBar, ScrollBar horizontalBar) = GetScrollBars(scrollViewer);
+        verticalBar.Minimum = 0;
+        verticalBar.Maximum = 1000;
+        verticalBar.Value = 500;
+        horizontalBar.Minimum = 0;
+        horizontalBar.Maximum = 1000;
+        horizontalBar.Value = 500;
+
+        scrollViewer.MouseWheelScrollSpeed = 40;
+
+        Mock<IInputReceiverKeyboardMonoGame> mockKeyboard = new();
+        mockKeyboard.Setup(k => k.IsShiftDown).Returns(true);
+        FrameworkElement.KeyboardsForUiControl.Add(mockKeyboard.Object);
+        try
+        {
+            InvokeMouseWheel(scrollViewer, zVelocity: 1f);
+        }
+        finally
+        {
+            FrameworkElement.KeyboardsForUiControl.Clear();
+        }
+
+        verticalBar.Value.ShouldBe(500);
+        horizontalBar.Value.ShouldBe(460);
+    }
+
+    [Fact]
+    public void MouseWheelScrollSpeed_ShouldBeIndependentOfSmallChange()
+    {
+        ScrollViewer scrollViewer = new();
+        (ScrollBar verticalBar, _) = GetScrollBars(scrollViewer);
+        verticalBar.Minimum = 0;
+        verticalBar.Maximum = 1000;
+        verticalBar.Value = 500;
+
+        // SmallChange is the arrow-button / line increment; it must no longer
+        // affect mouse-wheel speed now that the two are decoupled.
+        scrollViewer.SmallChange = 5;
+
+        InvokeMouseWheel(scrollViewer, zVelocity: 1f);
+
+        // Moves by the default MouseWheelScrollSpeed (30), not by SmallChange (5).
+        verticalBar.Value.ShouldBe(470);
+    }
+
+    [Fact]
+    public void MouseWheelScrollSpeed_ShouldDefaultToThirty()
+    {
+        ScrollViewer scrollViewer = new();
+        scrollViewer.MouseWheelScrollSpeed.ShouldBe(30);
+    }
+
+    [Fact]
     public void ScrollViewerVisual_ShouldCreateScrollViewerForms()
     {
         var visual = new Gum.Forms.DefaultVisuals.ScrollViewerVisual();
@@ -165,6 +238,40 @@ public class ScrollViewerTests
         {
             FrameworkElement.MainCursor = previousCursor;
             FrameworkElement.MainKeyboard = previousMainKeyboard;
+        }
+    }
+
+    static (ScrollBar vertical, ScrollBar horizontal) GetScrollBars(ScrollViewer scrollViewer)
+    {
+        FieldInfo verticalField = typeof(ScrollViewer).GetField(
+            "verticalScrollBar",
+            BindingFlags.Instance | BindingFlags.NonPublic)!;
+        FieldInfo horizontalField = typeof(ScrollViewer).GetField(
+            "horizontalScrollBar",
+            BindingFlags.Instance | BindingFlags.NonPublic)!;
+        ScrollBar vertical = (ScrollBar)verticalField.GetValue(scrollViewer)!;
+        ScrollBar horizontal = (ScrollBar)horizontalField.GetValue(scrollViewer)!;
+        vertical.ShouldNotBeNull();
+        horizontal.ShouldNotBeNull();
+        return (vertical, horizontal);
+    }
+
+    static void InvokeMouseWheel(ScrollViewer scrollViewer, float zVelocity)
+    {
+        Mock<ICursor> mockCursor = new();
+        mockCursor.Setup(c => c.ZVelocity).Returns(zVelocity);
+        ICursor? previousCursor = FrameworkElement.MainCursor;
+        FrameworkElement.MainCursor = mockCursor.Object;
+        try
+        {
+            MethodInfo handler = typeof(ScrollViewer).GetMethod(
+                "HandleMouseWheelScroll",
+                BindingFlags.Instance | BindingFlags.NonPublic)!;
+            handler.Invoke(scrollViewer, new object[] { scrollViewer.Visual, new RoutedEventArgs() });
+        }
+        finally
+        {
+            FrameworkElement.MainCursor = previousCursor;
         }
     }
 }

--- a/docs/code/controls/itemscontrol.md
+++ b/docs/code/controls/itemscontrol.md
@@ -8,7 +8,7 @@
 ItemsControl is similar to ListBox, but it is more general since it does not support selection. When items are added to the Items property the ItemsControl does not create a control which inherits from ListBoxItem. Similarly, its VisualTemplate does not need to be a type which supports a ListBoxItem.
 {% endhint %}
 
-ItemsControl inherits from ScrollViewer. For more information about inherited proerties, see the [ScrollViewer](scrollviewer/) page.
+ItemsControl inherits from ScrollViewer, so it supports the same scrolling behavior, including the `MouseWheelScrollSpeed` property for tuning mouse-wheel scroll speed. For more information about inherited properties, see the [ScrollViewer](scrollviewer/README.md) page.
 
 ## Code Example: Adding to Items Property
 

--- a/docs/code/controls/listbox.md
+++ b/docs/code/controls/listbox.md
@@ -4,6 +4,8 @@
 
 The ListBox control provides a scrollable list of ListBoxItems for displaying and selecting from a list.
 
+ListBox inherits from ScrollViewer, so it supports the same scrolling behavior. This includes the `MouseWheelScrollSpeed` property, which controls how far the list scrolls per mouse-wheel notch. For details see [Mouse Wheel Scroll Speed](scrollviewer/README.md#mouse-wheel-scroll-speed) on the ScrollViewer page.
+
 ## Code Example: Adding a ListBox
 
 The following code adds items to a ListBox when a button is clicked. When an item is added, `ScrollIntoView` is called so the item is shown.

--- a/docs/code/controls/scrollviewer/README.md
+++ b/docs/code/controls/scrollviewer/README.md
@@ -43,6 +43,21 @@ ScrollViewers can be scrolled by the user using by performing any of the followi
 * Using the mouse wheel to scroll vertically
 * Using shift+mouse wheel to scroll horizontally. For more information see the [Horizontal Scrolling](horizontal-scrolling.md) page.
 
+### Mouse Wheel Scroll Speed
+
+The `MouseWheelScrollSpeed` property controls how far the content scrolls per mouse-wheel notch. It applies to both vertical scrolling and shift+wheel horizontal scrolling. Larger values scroll farther per notch; the default is `30`.
+
+```csharp
+// Initialize
+var scrollViewer = new ScrollViewer();
+// Scroll farther per wheel notch than the default of 30.
+scrollViewer.MouseWheelScrollSpeed = 60;
+```
+
+`MouseWheelScrollSpeed` is independent of `SmallChange`, which controls the distance scrolled when clicking the ScrollBar's arrow buttons. Adjusting one does not affect the other.
+
+Because `MouseWheelScrollSpeed` is defined on `ScrollViewer`, it is also available on every control that derives from it, including [ItemsControl](../itemscontrol.md), [ListBox](../listbox.md), and ComboBox.
+
 ## Code Example: Creating a ScrollViewer With Non-Forms Children
 
 The following code creates a ScrollViewer and adds ColoredRectangleRuntimes to the ScrollViewer. Any non-Forms visual object can be added to the ScrollViewer through AddChild.


### PR DESCRIPTION
## Summary

Adds a dedicated `MouseWheelScrollSpeed` property to `ScrollViewer`, decoupling mouse-wheel scroll speed from the scroll bar's `SmallChange`.

Previously `HandleMouseWheelScroll` multiplied the wheel delta by `verticalScrollBar.SmallChange` (the arrow-button / line increment, default `10`). This overloaded `SmallChange` as the wheel speed, so you couldn't tune wheel scrolling without also changing arrow-button behavior — the exact coupling flagged by the inline TODO in the source.

## What changed

- **New property:** `public double MouseWheelScrollSpeed` on `ScrollViewer`. Because it lives on the base class, it is inherited by `ItemsControl`, `ListBox`, and `ComboBox` with no per-control wiring.
- `HandleMouseWheelScroll` now multiplies by `MouseWheelScrollSpeed` on **both** the vertical and the shift+wheel horizontal paths.
- **Default is `30`** — 3× the previous effective speed (`SmallChange` default of `10`). This matches the ~3-lines-per-notch feel users expect from other platforms (WPF scrolls `SystemParameters.WheelScrollLines` = 3 lines per notch by default).
- Removed the resolved TODO comment.

## Behavioral change (heads-up)

This is a **silent behavioral change**, not a compile/binary break — nothing is removed and no signatures change:

- Projects that never set `SmallChange` now scroll **~3× faster** by default (the fix for the "scrolling is SO slow" report).
- Projects that raised `SmallChange` specifically to speed up the wheel must now set `MouseWheelScrollSpeed` instead. The `SmallChange`→wheel coupling was undocumented, so this is considered acceptable.

A single shared speed covers both axes; horizontal is only the shift+wheel path. The OS `WheelScrollLines` setting is intentionally **not** honored — a game UI library wants deterministic, designer-controlled feel (and it isn't portable to consoles/mobile).

`ScrollViewer.cs` is a shared linked source file, so this lands on the MonoGame, KNI, FNA, FRB, Raylib, and Skia runtimes from one edit.

## Tests

TDD'd in `Tests/MonoGameGum.Tests.V2/Forms/ScrollViewerTests.cs`:

- `MouseWheelScrollSpeed_ShouldDefaultToThirty`
- `MouseWheelScroll_ShouldMoveVerticalByMouseWheelScrollSpeed`
- `MouseWheelScroll_WithShiftHeld_ShouldMoveHorizontalByMouseWheelScrollSpeed`
- `MouseWheelScrollSpeed_ShouldBeIndependentOfSmallChange`

All V2 (109) and Raylib `ScrollViewerTests` pass; the existing shift-redirect regression tests are unaffected.

## Docs

- New **Mouse Wheel Scroll Speed** section on the ScrollViewer page.
- Cross-links from the `ListBox` and `ItemsControl` pages (fixed a "proerties" typo on the latter).

Closes #3045

🤖 Generated with [Claude Code](https://claude.com/claude-code)
