### PR TITLE
Add tool support for Sprite RenderTargetTextureSource (#3035)

### DIFF
--- a/Gum/DataTypes/StateSaveExtensionMethods.GumTool.cs
+++ b/Gum/DataTypes/StateSaveExtensionMethods.GumTool.cs
@@ -19,7 +19,11 @@ namespace Gum.DataTypes.Variables
                     variable.Name = newName + "." + variable.Name.Substring((oldName + ".").Length);
                 }
 
-                if (variable.GetRootName() == "Parent" && variable.SetsValue && variable.Value is string valueAsString && !string.IsNullOrEmpty(valueAsString))
+                // Variables whose value is an instance name (Parent, and a Sprite's render-target
+                // source) must have that value rewritten when the referenced instance is renamed, or
+                // the reference goes stale and silently resolves to nothing.
+                var rootName = variable.GetRootName();
+                if ((rootName == "Parent" || rootName == "RenderTargetTextureSource") && variable.SetsValue && variable.Value is string valueAsString && !string.IsNullOrEmpty(valueAsString))
                 {
                     if (valueAsString == oldName)
                     {

--- a/Gum/Managers/DeleteLogic.cs
+++ b/Gum/Managers/DeleteLogic.cs
@@ -893,11 +893,13 @@ public class DeleteLogic : IDeleteLogic
                     // is gone, so the variable should be removed too.
                     stateSave.Variables.RemoveAt(i);
                 }
-                else if (variable.GetRootName() == "Parent" && variable.Value is string valueAsString &&
+                else if ((variable.GetRootName() == "Parent" || variable.GetRootName() == "RenderTargetTextureSource") &&
+                         variable.Value is string valueAsString &&
                          (valueAsString == instanceToRemove.Name || valueAsString.StartsWith(instanceToRemove.Name + ".")))
                 {
-                    // This is a variable that assigns the Parent to the removed object (or a dotted reference like "Parent.Container").
-                    // Since the object is gone, the parent value shouldn't be assigned anymore.
+                    // This is a variable whose value references the removed object by name — either a Parent
+                    // assignment (or a dotted reference like "Parent.Container") or a Sprite's render-target
+                    // source. Since the object is gone, the reference shouldn't be assigned anymore.
                     stateSave.Variables.RemoveAt(i);
                 }
             }

--- a/Gum/Managers/DeleteLogic.cs
+++ b/Gum/Managers/DeleteLogic.cs
@@ -876,10 +876,10 @@ public class DeleteLogic : IDeleteLogic
     {
         element.Instances.Remove(instance);
         element.Events.RemoveAll(item => item.GetSourceObject() == instance.Name);
-        RemoveParentReferencesToInstance(instance, element);
+        RemoveReferencesToInstance(instance, element);
     }
 
-    public void RemoveParentReferencesToInstance(InstanceSave instanceToRemove, ElementSave elementToRemoveFrom)
+    public void RemoveReferencesToInstance(InstanceSave instanceToRemove, ElementSave elementToRemoveFrom)
     {
         foreach (StateSave stateSave in elementToRemoveFrom.AllStates)
         {

--- a/Gum/Managers/IDeleteLogic.cs
+++ b/Gum/Managers/IDeleteLogic.cs
@@ -15,7 +15,7 @@ public interface IDeleteLogic
     List<BehaviorSave> GetBehaviorsNeedingCategory(StateSaveCategory category, ComponentSave? componentSave);
     void Remove(StateSave stateSave);
     void RemoveInstance(InstanceSave instanceToRemove, ElementSave elementToRemoveFrom);
-    void RemoveParentReferencesToInstance(InstanceSave instanceToRemove, ElementSave elementToRemoveFrom);
+    void RemoveReferencesToInstance(InstanceSave instanceToRemove, ElementSave elementToRemoveFrom);
     void RemoveInstances(List<InstanceSave> instances, ElementSave elementToRemoveFrom);
     void RemoveState(StateSave stateSave, IStateContainer elementToRemoveFrom);
     void DeleteFolders(List<ITreeNode> folderNodes);

--- a/Gum/Managers/StandardElementsManager.cs
+++ b/Gum/Managers/StandardElementsManager.cs
@@ -241,6 +241,8 @@ public class StandardElementsManager
             AddPositioningVariables(stateSave);
             AddDimensionsVariables(stateSave, 100, 100, DimensionVariableAction.DefaultToPercentageOfFile);
             stateSave.Variables.Add(new VariableSave { SetsValue = true, Type = "string", Value = "", Name = "SourceFile", IsFile = true, Category = "Source" });
+            stateSave.Variables.Add(new VariableSave { SetsValue = true, Type = "string", Value = null, Name = "RenderTargetTextureSource", Category = "Source",
+                DetailText = "Displays the render target of another Container whose Is Render Target is checked. Takes precedence over SourceFile when set." });
             stateSave.Variables.Add(new VariableSave { SetsValue = true, Type = "bool", Value = true, Name = "Visible", Category = "States and Visibility" });
             stateSave.Variables.Add(new VariableSave { SetsValue = true, Type = "bool", Value = false, Category = "Animation", Name = "Animate" });
 

--- a/Gum/Plugins/InternalPlugins/Delete/InstanceDeletionHelper.cs
+++ b/Gum/Plugins/InternalPlugins/Delete/InstanceDeletionHelper.cs
@@ -110,7 +110,7 @@ public class InstanceDeletionHelper
         if (instance?.ParentContainer == null)
             return;
 
-        _deleteLogic.RemoveParentReferencesToInstance(instance, instance.ParentContainer);
+        _deleteLogic.RemoveReferencesToInstance(instance, instance.ParentContainer);
     }
 
     /// <summary>
@@ -130,14 +130,14 @@ public class InstanceDeletionHelper
             RecursivelyDeleteChildrenOf(child);
 
             // This child may have been removed by the main Delete command. If so, then no need
-            // to do a full removal, just remove parent references:
+            // to do a full removal, just remove references to it:
             if (parentContainer.Instances.Contains(child))
             {
                 _deleteLogic.RemoveInstance(child, parentContainer);
             }
             else
             {
-                _deleteLogic.RemoveParentReferencesToInstance(child, parentContainer);
+                _deleteLogic.RemoveReferencesToInstance(child, parentContainer);
             }
         }
     }

--- a/Gum/Plugins/InternalPlugins/VariableGrid/SetVariableLogic.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/SetVariableLogic.cs
@@ -358,6 +358,8 @@ public class SetVariableLogic : ISetVariableLogic
 
             ReactIfChangedMemberIsDefaultChildContainer(parentElement, instance, rootVariableName, oldValue);
 
+            ReactIfChangedMemberIsRenderTargetTextureSource(rootVariableName);
+
             _variableReferenceLogic.ReactIfChangedMemberIsVariableReference(instance, stateSave, rootVariableName, oldValue);
         }
         ReactIfChangedBaseType(instanceContainer, instance, stateSave, rootVariableName, oldValue);
@@ -386,6 +388,19 @@ public class SetVariableLogic : ISetVariableLogic
                 {
                     _fileCommands.TryAutoSaveObject(instanceContainer);
                 }
+            }
+        }
+    }
+
+    private void ReactIfChangedMemberIsRenderTargetTextureSource(string rootVariableName)
+    {
+        VariableSave? variable = _selectedState.SelectedVariableSave;
+
+        if (variable != null && rootVariableName == "RenderTargetTextureSource")
+        {
+            if ((variable.Value as string) == "<NONE>")
+            {
+                variable.Value = null;
             }
         }
     }

--- a/Gum/Plugins/InternalPlugins/VariableGrid/StandardElementsManager.GumTool.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/StandardElementsManager.GumTool.cs
@@ -122,6 +122,11 @@ public class StandardElementsManagerGumTool : Singleton<StandardElementsManagerG
                 variable.CustomTypeConverter = new AvailableParentsTypeConverter(selectedState);
                 variable.PropertiesToSetOnDisplayer["IsEditable"] = true;
             }
+            else if (variable.Type == "string" && variable.Name == "RenderTargetTextureSource")
+            {
+                variable.CustomTypeConverter =
+                    new AvailableRenderTargetContainersConverter(Locator.GetRequiredService<ISelectedState>());
+            }
             else if (variable.Type == "State" && variable.Name == "State")
             {
                 variable.Category = "States and Visibility";

--- a/Gum/PropertyGridHelpers/Converters/AvailableRenderTargetContainersConverter.cs
+++ b/Gum/PropertyGridHelpers/Converters/AvailableRenderTargetContainersConverter.cs
@@ -1,0 +1,65 @@
+using Gum.DataTypes;
+using Gum.ToolStates;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+
+namespace Gum.PropertyGridHelpers.Converters;
+
+/// <summary>
+/// Provides the selectable values for a Sprite's <c>RenderTargetTextureSource</c> variable: the
+/// names of sibling instances in the selected element whose effective <c>IsRenderTarget</c> value is
+/// <see langword="true"/>, plus a <c>&lt;NONE&gt;</c> entry to clear the source. Scoped to the
+/// current element because the runtime resolves the reference by name within the top-parent visual
+/// tree, so a cross-element reference could not render.
+/// </summary>
+public class AvailableRenderTargetContainersConverter : TypeConverter
+{
+    private readonly ISelectedState _selectedState;
+
+    /// <inheritdoc/>
+    public override bool GetStandardValuesSupported(ITypeDescriptorContext? context)
+    {
+        return true;
+    }
+
+    /// <inheritdoc/>
+    public override bool GetStandardValuesExclusive(ITypeDescriptorContext? context)
+    {
+        return true;
+    }
+
+    public AvailableRenderTargetContainersConverter(ISelectedState selectedState)
+    {
+        _selectedState = selectedState ?? throw new ArgumentNullException(nameof(selectedState));
+    }
+
+    /// <inheritdoc/>
+    public override StandardValuesCollection GetStandardValues(ITypeDescriptorContext? context)
+    {
+        List<string> values = new();
+        values.Add("<NONE>");
+
+        ElementSave? element = _selectedState.SelectedElement;
+
+        if (element != null)
+        {
+            foreach (InstanceSave instance in element.Instances)
+            {
+                if (instance == _selectedState.SelectedInstance)
+                {
+                    // The sprite cannot use itself as a render-target source.
+                    continue;
+                }
+
+                RecursiveVariableFinder finder = new RecursiveVariableFinder(instance, element);
+                if (finder.GetValue("IsRenderTarget") as bool? == true)
+                {
+                    values.Add(instance.Name);
+                }
+            }
+        }
+
+        return new StandardValuesCollection(values);
+    }
+}

--- a/Tests/Gum.ProjectServices.Tests/CodeGeneratorRenderTargetTextureSourceTests.cs
+++ b/Tests/Gum.ProjectServices.Tests/CodeGeneratorRenderTargetTextureSourceTests.cs
@@ -1,0 +1,149 @@
+using Gum.DataTypes;
+using Gum.DataTypes.Variables;
+using Gum.Localization;
+using Gum.Managers;
+using Gum.ProjectServices.CodeGeneration;
+using Moq;
+using Shouldly;
+using System.Linq;
+
+namespace Gum.ProjectServices.Tests;
+
+/// <summary>
+/// Tests for #3035: a Sprite's <c>RenderTargetTextureSource</c> variable stores the name of a
+/// sibling render-target Container instance. Codegen must emit a direct object-reference assignment
+/// to that instance's generated field (mirroring how the <c>Parent</c> variable resolves a sibling
+/// instance), not a string literal — <c>RenderTargetTextureSource</c> is an <c>IRenderableIpso</c>.
+/// </summary>
+public class CodeGeneratorRenderTargetTextureSourceTests : BaseTestClass
+{
+    private static CodeGenerator CreateCodeGenerator()
+    {
+        Mock<INameVerifier> mockNameVerifier = new Mock<INameVerifier>();
+        string whyNotValid;
+        CommonValidationError error;
+        mockNameVerifier
+            .Setup(v => v.IsValidCSharpName(It.IsAny<string>(), out whyNotValid, out error))
+            .Returns(true);
+        CodeGenerationNameVerifier codeGenNameVerifier = new CodeGenerationNameVerifier(mockNameVerifier.Object);
+        FixedProjectDirectoryProvider directoryProvider = new FixedProjectDirectoryProvider(projectDirectory: null);
+        CodeOutputElementSettingsManager elementSettingsManager = new CodeOutputElementSettingsManager(directoryProvider);
+        LocalizationService localizationService = new LocalizationService();
+
+        return new CodeGenerator(
+            codeGenNameVerifier,
+            localizationService,
+            elementSettingsManager,
+            directoryProvider);
+    }
+
+    private static CodeOutputProjectSettings CreateMonoGame() => new CodeOutputProjectSettings
+    {
+        OutputLibrary = OutputLibrary.MonoGame,
+        RootNamespace = "MyGame",
+    };
+
+    private static ComponentSave CreateComponent(string name, string baseType)
+    {
+        ComponentSave component = new ComponentSave { Name = name, BaseType = baseType };
+        StateSave defaultState = new StateSave { Name = "Default", ParentContainer = component };
+        component.States.Add(defaultState);
+        return component;
+    }
+
+    private static void AddVariable(ElementSave element, string name, object value, string type) =>
+        element.DefaultState.Variables.Add(new VariableSave
+        {
+            Name = name,
+            Value = value,
+            SetsValue = true,
+            Type = type,
+        });
+
+    /// <summary>
+    /// Mirrors StandardElementsManager defining RenderTargetTextureSource on the Sprite standard
+    /// element. Codegen only emits an instance variable whose root is defined on the base element.
+    /// </summary>
+    private void RegisterSpriteRenderTargetTextureSourceVariable()
+    {
+        StandardElementSave sprite = Project.StandardElements.First(item => item.Name == "Sprite");
+        AddVariable(sprite, "RenderTargetTextureSource", null, "string");
+    }
+
+    [Fact]
+    public void GetCodeForInstance_RenderTargetTextureSource_EmitsSiblingInstanceReference()
+    {
+        GumProjectSave project = Project;
+        RegisterSpriteRenderTargetTextureSourceVariable();
+
+        ComponentSave main = CreateComponent("MainComponent", "Container");
+
+        InstanceSave renderTargetContainer = new InstanceSave
+        {
+            Name = "RenderTargetContainer",
+            BaseType = "Container",
+            ParentContainer = main,
+        };
+        main.Instances.Add(renderTargetContainer);
+        AddVariable(main, "RenderTargetContainer.IsRenderTarget", true, "bool");
+
+        InstanceSave spriteInstance = new InstanceSave
+        {
+            Name = "SpriteInstance",
+            BaseType = "Sprite",
+            ParentContainer = main,
+        };
+        main.Instances.Add(spriteInstance);
+        AddVariable(main, "SpriteInstance.RenderTargetTextureSource", "RenderTargetContainer", "string");
+
+        project.Components.Add(main);
+
+        ObjectFinder.Self.GumProjectSave = project;
+        try
+        {
+            string code = CreateCodeGenerator().GetCodeForInstance(spriteInstance, main, CreateMonoGame());
+
+            // Direct object reference to the sibling instance field, not a string literal.
+            code.ShouldContain("this.SpriteInstance.RenderTargetTextureSource = this.RenderTargetContainer;");
+            code.ShouldNotContain("RenderTargetTextureSource = \"RenderTargetContainer\"");
+        }
+        finally
+        {
+            ObjectFinder.Self.GumProjectSave = null;
+        }
+    }
+
+    [Fact]
+    public void GetCodeForInstance_RenderTargetTextureSourceEmpty_EmitsNoAssignment()
+    {
+        GumProjectSave project = Project;
+        RegisterSpriteRenderTargetTextureSourceVariable();
+
+        ComponentSave main = CreateComponent("MainComponent", "Container");
+
+        InstanceSave spriteInstance = new InstanceSave
+        {
+            Name = "SpriteInstance",
+            BaseType = "Sprite",
+            ParentContainer = main,
+        };
+        main.Instances.Add(spriteInstance);
+        // Empty value: the sprite uses no render target, so nothing should be assigned (and
+        // certainly not a broken "= ;" line).
+        AddVariable(main, "SpriteInstance.RenderTargetTextureSource", "", "string");
+
+        project.Components.Add(main);
+
+        ObjectFinder.Self.GumProjectSave = project;
+        try
+        {
+            string code = CreateCodeGenerator().GetCodeForInstance(spriteInstance, main, CreateMonoGame());
+
+            code.ShouldNotContain("RenderTargetTextureSource");
+        }
+        finally
+        {
+            ObjectFinder.Self.GumProjectSave = null;
+        }
+    }
+}

--- a/Tool/Tests/GumToolUnitTests/Logic/CopyPasteLogicTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Logic/CopyPasteLogicTests.cs
@@ -1796,7 +1796,7 @@ public class CopyPasteLogicTests : BaseTestClass
             {
                 element.Instances.Remove(instanceToRemove);
 
-                // Simulate RemoveParentReferencesToInstance
+                // Simulate RemoveReferencesToInstance
                 foreach (var state in element.AllStates)
                 {
                     state.Variables.RemoveAll(item => item.SourceObject == instanceToRemove.Name);

--- a/Tool/Tests/GumToolUnitTests/Logic/RenameLogicTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Logic/RenameLogicTests.cs
@@ -90,6 +90,48 @@ public class RenameLogicTests : BaseTestClass
     }
 
     [Fact]
+    public void ReactToInstanceNameChange_UpdatesRenderTargetTextureSourceValue_WhenReferencedInstanceRenamed()
+    {
+        // A Sprite's RenderTargetTextureSource stores the name of a sibling render-target Container.
+        // Renaming that Container must rewrite the stored value, the same way Parent references are
+        // maintained — otherwise the reference goes stale and silently resolves to nothing.
+        ComponentSave element = new ComponentSave { Name = "MainComponent" };
+        StateSave defaultState = new StateSave { Name = "Default", ParentContainer = element };
+        element.States.Add(defaultState);
+
+        InstanceSave spriteInstance = new InstanceSave { Name = "SpriteInstance", BaseType = "Sprite", ParentContainer = element };
+        InstanceSave renderTargetContainer = new InstanceSave { Name = "RenderTargetContainer", BaseType = "Container", ParentContainer = element };
+        element.Instances.Add(spriteInstance);
+        element.Instances.Add(renderTargetContainer);
+
+        defaultState.Variables.Add(new VariableSave
+        {
+            Name = "SpriteInstance.RenderTargetTextureSource",
+            Value = "RenderTargetContainer",
+            SetsValue = true,
+            Type = "string",
+        });
+
+        // ReactToInstanceNameChange notifies plugins at the end; give the singleton an empty plugin
+        // list so that call is a no-op, and restore it afterward to avoid cross-test pollution.
+        IEnumerable<Gum.Plugins.BaseClasses.PluginBase> originalPlugins = Gum.Plugins.PluginManager.Self.Plugins;
+        Gum.Plugins.PluginManager.Self.Plugins = new List<Gum.Plugins.BaseClasses.PluginBase>();
+        try
+        {
+            // Simulate the rename already applied to the instance, then react to the name change.
+            renderTargetContainer.Name = "RenamedContainer";
+            defaultState.ReactToInstanceNameChange(renderTargetContainer, "RenderTargetContainer", "RenamedContainer");
+
+            VariableSave variable = defaultState.GetVariableSave("SpriteInstance.RenderTargetTextureSource");
+            (variable.Value as string).ShouldBe("RenamedContainer");
+        }
+        finally
+        {
+            Gum.Plugins.PluginManager.Self.Plugins = originalPlugins;
+        }
+    }
+
+    [Fact]
     public void ApplyElementReferences_VariableReferenceEntry_StringIsUpdated()
     {
         // After apply, a VariableReferences list entry whose right side referenced

--- a/Tool/Tests/GumToolUnitTests/Managers/DeleteLogicTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Managers/DeleteLogicTests.cs
@@ -453,6 +453,23 @@ public class DeleteLogicTests : BaseTestClass
     }
 
     [Fact]
+    public void RemoveParentReferencesToInstance_RemovesRenderTargetTextureSourceReferences()
+    {
+        // A Sprite's RenderTargetTextureSource stores the name of a sibling render-target Container.
+        // Deleting that Container must drop the dangling reference, the same way Parent references
+        // are cleaned up — otherwise a stale variable points at an instance that no longer exists.
+        var screen = CreateScreenWithInstances("RenderTargetContainer", "SpriteInstance");
+        var renderTargetContainer = screen.Instances[0];
+        screen.DefaultState.SetValue("SpriteInstance.RenderTargetTextureSource", "RenderTargetContainer", "string");
+
+        _deleteLogic.RemoveParentReferencesToInstance(renderTargetContainer, screen);
+
+        screen.DefaultState.Variables
+            .Where(v => v.GetRootName() == "RenderTargetTextureSource")
+            .ShouldBeEmpty("Render-target references to the deleted container should be removed");
+    }
+
+    [Fact]
     public void RemoveParentReferencesToInstance_WithDottedReference_RemovesIt()
     {
         var screen = CreateScreenWithInstances("Parent");

--- a/Tool/Tests/GumToolUnitTests/Managers/DeleteLogicTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Managers/DeleteLogicTests.cs
@@ -438,14 +438,14 @@ public class DeleteLogicTests : BaseTestClass
     }
 
     [Fact]
-    public void RemoveParentReferencesToInstance_RemovesParentVariables()
+    public void RemoveReferencesToInstance_RemovesParentVariables()
     {
         var screen = CreateScreenWithInstances("Parent");
         var parent = screen.Instances[0];
         AddChild(screen, "Child1", "Parent");
         AddChild(screen, "Child2", "Parent");
 
-        _deleteLogic.RemoveParentReferencesToInstance(parent, screen);
+        _deleteLogic.RemoveReferencesToInstance(parent, screen);
 
         screen.DefaultState.Variables
             .Where(v => v.GetRootName() == "Parent" && v.Value as string == "Parent")
@@ -453,7 +453,7 @@ public class DeleteLogicTests : BaseTestClass
     }
 
     [Fact]
-    public void RemoveParentReferencesToInstance_RemovesRenderTargetTextureSourceReferences()
+    public void RemoveReferencesToInstance_RemovesRenderTargetTextureSourceReferences()
     {
         // A Sprite's RenderTargetTextureSource stores the name of a sibling render-target Container.
         // Deleting that Container must drop the dangling reference, the same way Parent references
@@ -462,7 +462,7 @@ public class DeleteLogicTests : BaseTestClass
         var renderTargetContainer = screen.Instances[0];
         screen.DefaultState.SetValue("SpriteInstance.RenderTargetTextureSource", "RenderTargetContainer", "string");
 
-        _deleteLogic.RemoveParentReferencesToInstance(renderTargetContainer, screen);
+        _deleteLogic.RemoveReferencesToInstance(renderTargetContainer, screen);
 
         screen.DefaultState.Variables
             .Where(v => v.GetRootName() == "RenderTargetTextureSource")
@@ -470,13 +470,13 @@ public class DeleteLogicTests : BaseTestClass
     }
 
     [Fact]
-    public void RemoveParentReferencesToInstance_WithDottedReference_RemovesIt()
+    public void RemoveReferencesToInstance_WithDottedReference_RemovesIt()
     {
         var screen = CreateScreenWithInstances("Parent");
         var parent = screen.Instances[0];
         AddChild(screen, "Child", "Parent.Container");
 
-        _deleteLogic.RemoveParentReferencesToInstance(parent, screen);
+        _deleteLogic.RemoveReferencesToInstance(parent, screen);
 
         screen.DefaultState.Variables
             .Where(v => v.Value is string s && s.StartsWith("Parent."))

--- a/Tool/Tests/GumToolUnitTests/Plugins/InstanceDeletionHelperTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/InstanceDeletionHelperTests.cs
@@ -84,7 +84,7 @@ public class InstanceDeletionHelperTests : BaseTestClass
 
         _helper.DetachChildrenFromInstance(parent);
 
-        _deleteLogic.Verify(x => x.RemoveParentReferencesToInstance(parent, screen), Times.Once);
+        _deleteLogic.Verify(x => x.RemoveReferencesToInstance(parent, screen), Times.Once);
     }
 
     [Fact]
@@ -111,9 +111,9 @@ public class InstanceDeletionHelperTests : BaseTestClass
 
         _helper.DetachChildrenFromInstances(new[] { parent1, parent2, parent3 });
 
-        _deleteLogic.Verify(x => x.RemoveParentReferencesToInstance(parent1, screen), Times.Once);
-        _deleteLogic.Verify(x => x.RemoveParentReferencesToInstance(parent2, screen), Times.Once);
-        _deleteLogic.Verify(x => x.RemoveParentReferencesToInstance(parent3, screen), Times.Once);
+        _deleteLogic.Verify(x => x.RemoveReferencesToInstance(parent1, screen), Times.Once);
+        _deleteLogic.Verify(x => x.RemoveReferencesToInstance(parent2, screen), Times.Once);
+        _deleteLogic.Verify(x => x.RemoveReferencesToInstance(parent3, screen), Times.Once);
     }
 
     [Fact]
@@ -127,8 +127,8 @@ public class InstanceDeletionHelperTests : BaseTestClass
 
         _helper.DetachChildrenFromInstances(new[] { parent1, parent2 });
 
-        _deleteLogic.Verify(x => x.RemoveParentReferencesToInstance(parent1, screen), Times.Once);
-        _deleteLogic.Verify(x => x.RemoveParentReferencesToInstance(parent2, screen), Times.Once);
+        _deleteLogic.Verify(x => x.RemoveReferencesToInstance(parent1, screen), Times.Once);
+        _deleteLogic.Verify(x => x.RemoveReferencesToInstance(parent2, screen), Times.Once);
     }
 
     [Fact]

--- a/Tool/Tests/GumToolUnitTests/PropertyGridHelpers/Converters/AvailableRenderTargetContainersConverterTests.cs
+++ b/Tool/Tests/GumToolUnitTests/PropertyGridHelpers/Converters/AvailableRenderTargetContainersConverterTests.cs
@@ -1,0 +1,90 @@
+using Gum.DataTypes;
+using Gum.DataTypes.Variables;
+using Gum.Managers;
+using Gum.PropertyGridHelpers.Converters;
+using Gum.ToolStates;
+using Moq;
+using Shouldly;
+using System.Linq;
+
+namespace GumToolUnitTests.PropertyGridHelpers.Converters;
+
+public class AvailableRenderTargetContainersConverterTests : BaseTestClass
+{
+    private readonly Mock<ISelectedState> _selectedStateMock;
+    private AvailableRenderTargetContainersConverter _converter = null!;
+
+    public AvailableRenderTargetContainersConverterTests()
+    {
+        _selectedStateMock = new Mock<ISelectedState>();
+    }
+
+    private void CreateConverter()
+    {
+        _converter = new AvailableRenderTargetContainersConverter(_selectedStateMock.Object);
+    }
+
+    private static InstanceSave AddInstance(ElementSave element, string name, string baseType)
+    {
+        InstanceSave instance = new InstanceSave { Name = name, BaseType = baseType };
+        element.Instances.Add(instance);
+        return instance;
+    }
+
+    [Fact]
+    public void GetStandardValues_ExcludesNonRenderTargetContainers()
+    {
+        ComponentSave element = new ComponentSave();
+        element.States.Add(new StateSave());
+        element.DefaultState.ParentContainer = element;
+
+        AddInstance(element, "RenderTargetContainer", "Container");
+        AddInstance(element, "NormalContainer", "Container");
+        // Only the first container is flagged as a render target.
+        element.DefaultState.SetValue("RenderTargetContainer.IsRenderTarget", true);
+
+        _selectedStateMock.Setup(x => x.SelectedElement).Returns(element);
+        _selectedStateMock.Setup(x => x.SelectedInstance).Returns((InstanceSave?)null);
+
+        ObjectFinder.Self.GumProjectSave = new GumProjectSave();
+        CreateConverter();
+
+        var result = _converter.GetStandardValues(null);
+
+        result.Cast<string>().ShouldBe(new[] { "<NONE>", "RenderTargetContainer" });
+    }
+
+    [Fact]
+    public void GetStandardValues_ExcludesSelectedInstance()
+    {
+        ComponentSave element = new ComponentSave();
+        element.States.Add(new StateSave());
+        element.DefaultState.ParentContainer = element;
+
+        InstanceSave spriteInstance = AddInstance(element, "SpriteInstance", "Sprite");
+        AddInstance(element, "RenderTargetContainer", "Container");
+        element.DefaultState.SetValue("RenderTargetContainer.IsRenderTarget", true);
+
+        _selectedStateMock.Setup(x => x.SelectedElement).Returns(element);
+        _selectedStateMock.Setup(x => x.SelectedInstance).Returns(spriteInstance);
+
+        ObjectFinder.Self.GumProjectSave = new GumProjectSave();
+        CreateConverter();
+
+        var result = _converter.GetStandardValues(null);
+
+        result.Cast<string>().ShouldBe(new[] { "<NONE>", "RenderTargetContainer" });
+    }
+
+    [Fact]
+    public void GetStandardValues_ReturnsNoneOnly_WhenNoElementSelected()
+    {
+        _selectedStateMock.Setup(x => x.SelectedElement).Returns((ElementSave?)null);
+        CreateConverter();
+
+        var result = _converter.GetStandardValues(null);
+
+        result.Count.ShouldBe(1);
+        result[0].ShouldBe("<NONE>");
+    }
+}

--- a/Tool/Tests/GumToolUnitTests/PropertyGridHelpers/SetVariableLogicTests.cs
+++ b/Tool/Tests/GumToolUnitTests/PropertyGridHelpers/SetVariableLogicTests.cs
@@ -302,6 +302,44 @@ public class SetVariableLogicTests : BaseTestClass
     }
 
     [Fact]
+    public void ReactToPropertyValueChanged_ShouldClearRenderTargetTextureSource_WhenNoneSelected()
+    {
+        // Picking "<NONE>" in the render-target dropdown must clear the variable back to default
+        // rather than persisting the sentinel string (which would read as a set value), mirroring
+        // how Parent and DefaultChildContainer normalize "<NONE>".
+        ComponentSave container = new ComponentSave();
+        container.States.Add(new StateSave());
+        container.DefaultState.ParentContainer = container;
+
+        InstanceSave instance = new InstanceSave();
+        instance.Name = "SpriteInstance";
+        instance.BaseType = "Sprite";
+
+        container.DefaultState.SetValue("SpriteInstance.RenderTargetTextureSource", "<NONE>");
+        VariableSave variable = container.DefaultState.GetVariableSave("SpriteInstance.RenderTargetTextureSource");
+
+        Mock<ISelectedState> selectedState = mocker.GetMock<ISelectedState>();
+        selectedState
+            .Setup(x => x.SelectedStateSave)
+            .Returns(container.DefaultState);
+        selectedState
+            .Setup(x => x.SelectedVariableSave)
+            .Returns(variable);
+
+        _setVariableLogic.ReactToPropertyValueChanged(
+            "RenderTargetTextureSource",
+            null,
+            container,
+            instance,
+            container.DefaultState,
+            refresh: false,
+            recordUndo: false,
+            trySave: false);
+
+        variable.Value.ShouldBeNull();
+    }
+
+    [Fact]
     public void ReactToPropertyValueChanged_ShouldForceRefreshVariables_WhenAssigningStateOnInstance()
     {
         // Repro: BaseComponent has a category "Category1"; an instance of it is placed

--- a/Tools/Gum.ProjectServices/CodeGeneration/CodeGenerator.cs
+++ b/Tools/Gum.ProjectServices/CodeGeneration/CodeGenerator.cs
@@ -5089,6 +5089,44 @@ public class CodeGenerator
             }
         }
         #endregion
+        #region RenderTargetTextureSource
+
+        // RenderTargetTextureSource stores the name of a sibling render-target Container instance.
+        // Like Parent, it resolves to another instance, so it must be emitted as a direct object
+        // reference to that instance's generated field rather than as a string literal.
+        else if (rootName == "RenderTargetTextureSource")
+        {
+            var referencedInstanceName = variable.Value as string;
+
+            if (string.IsNullOrEmpty(referencedInstanceName))
+            {
+                // No render-target source selected; emit nothing rather than a broken assignment.
+                return " ";
+            }
+
+            var referencedInstance = context.Element.GetInstance(referencedInstanceName);
+
+            if (referencedInstance == null)
+            {
+                // The stored name no longer resolves to a sibling instance (renamed/deleted); skip
+                // rather than emit code that won't compile.
+                return " ";
+            }
+
+            var referenceInCode = "this." + _codeGenerationNameVerifier.ToCSharpName(referencedInstanceName);
+
+            // RenderTargetTextureSource is an IRenderableIpso. For MonoGameForms a non-standard
+            // instance's field is the Forms wrapper, so reach its underlying visual.
+            var referencedElement = ObjectFinder.Self.GetElementSave(referencedInstance);
+            if (context.CodeOutputProjectSettings.OutputLibrary == OutputLibrary.MonoGameForms &&
+                referencedElement is not StandardElementSave)
+            {
+                referenceInCode += ".Visual";
+            }
+
+            return $"{context.CodePrefixNoTabs}.{GetGumVariableName(variable, context)} = {referenceInCode};";
+        }
+        #endregion
         // ignored variables:
         else if (rootName == "IsXamarinFormsControl" ||
             rootName == "ExposeChildrenEvents" ||


### PR DESCRIPTION
## Summary

Adds tool-side support for pointing a Sprite at a render-target Container, so the workflow that previously only worked in code (`SpriteRuntime.RenderTargetTextureSource`) can now be set up and previewed in the WYSIWYG editor.

Closes #3035.

## What changed

- **Variable** — `StandardElementsManager` exposes a `RenderTargetTextureSource` string variable on the Sprite standard element (Source category). It takes precedence over `SourceFile` when set, matching runtime behavior (no hard mutual-exclusion).
- **Picker** — new `AvailableRenderTargetContainersConverter` provides a dropdown of sibling instances in the current element whose effective `IsRenderTarget` is `true`, plus a `<NONE>` entry. Scoped to the current element because the runtime resolves the reference by name within the top-parent visual tree, so a cross-element reference could not render.
- **Codegen** — `CodeGenerator` emits the reference as a **direct object-reference assignment** to the sibling instance's generated field (the same way `Parent` resolves a sibling), not a string literal, because `RenderTargetTextureSource` is an `IRenderableIpso`. Handles the MonoGameForms `.Visual` case and skips unresolvable/empty values.
- **Clear-to-default** — `SetVariableLogic` normalizes the `<NONE>` sentinel to `null`, so clearing the dropdown resets the variable instead of persisting `<NONE>`.
- **Rename integrity** — `ReactToInstanceNameChange` rewrites the stored value when the referenced Container is renamed (it previously only special-cased `Parent`). Without this the reference would go stale and silently resolve to nothing.
- **Delete integrity** — `RemoveParentReferencesToInstance` drops the stored reference when the referenced Container is deleted (it previously only cleaned up `Parent`). Without this a dangling variable pointing at a non-existent instance would linger.

The wireframe preview path (`SetProperty` → `CustomSetPropertyOnRenderable` → `FindByName`) and the project round-trip (plain string variable) already existed; this PR wires the tool UI, codegen, selection, rename, and delete into them.

## Decisions

- **Reference stored as the instance name (string)** — matches both the runtime `FindByName` path and the existing wireframe resolver; round-trips trivially through the `.gumx`. Because it's a name-based reference, rename integrity is handled explicitly (see above), mirroring `Parent`.
- **Sprite only** — NineSlice is intentionally deferred until a customer needs it.

## Tests

- `CodeGeneratorRenderTargetTextureSourceTests` — emits a direct sibling-instance reference; emits nothing for an empty value.
- `AvailableRenderTargetContainersConverterTests` — filters to render-target containers, excludes the selected instance, returns `<NONE>` only when no element is selected.
- `SetVariableLogicTests.ReactToPropertyValueChanged_ShouldClearRenderTargetTextureSource_WhenNoneSelected` — `<NONE>` → null normalization.
- `RenameLogicTests.ReactToInstanceNameChange_UpdatesRenderTargetTextureSourceValue_WhenReferencedInstanceRenamed` — value rewritten on rename.
- `DeleteLogicTests.RemoveParentReferencesToInstance_RemovesRenderTargetTextureSourceReferences` — dangling reference dropped on delete.

All new tests written test-first (failing → implement → green). Full regression suites green: `Gum.ProjectServices.Tests` (252), related `GumToolUnitTests` classes (74), and the existing runtime `SpriteRuntime` RenderTargetTextureSource test.

## Manual verification still recommended

The in-editor render-target **preview** relies on the existing wireframe path (covered by a runtime unit test, but not exercised through the GUI here). Worth a quick manual check that a render-target Container shows through a Sprite in the editor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

