### PR TITLE
Surface per-channel subtext on disabled color swatch (#3058)

### DIFF
--- a/Gum/Plugins/InternalPlugins/VariableGrid/CompositeMemberLogic.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/CompositeMemberLogic.cs
@@ -158,13 +158,33 @@ public class CompositeMemberLogic
         composite.SupportsMakeDefault = false;
         composite.DisplayName = ToolsUtilities.StringFunctions.InsertSpacesInCamelCaseString(compositeName);
 
+        // Collapsing the triple removes the per-channel rows, taking their subtext with them. A channel is
+        // disabled (read-only) when it's driven by a variable reference, so surface each disabled channel's
+        // message on the swatch - otherwise the swatch is correctly disabled but with no explanation of why
+        // (issue #3058). Prefixing with the channel root name reconstructs the per-channel assignment line
+        // (e.g. "Red=A.Red") so the user sees every value being assigned individually.
+        List<string> detailSegments = new();
+        for (int i = 0; i < triple.ChannelMembers.Count; i++)
+        {
+            InstanceMember channelMember = triple.ChannelMembers[i];
+            if (channelMember.IsReadOnly && !string.IsNullOrEmpty(channelMember.DetailText))
+            {
+                detailSegments.Add(triple.ChannelRootNames[i] + channelMember.DetailText);
+            }
+        }
+
         // When channels are exposed the swatch stays, but we surface the exposure as subtext so the user can
         // see it's exposed and under which names (the raw per-channel rows used to carry this).
         List<VariableSave> exposedChannelVariables = GetExposedChannelVariables(triple, element, instance);
         if (exposedChannelVariables.Count > 0)
         {
-            composite.DetailText = "Exposed as " +
-                string.Join(", ", exposedChannelVariables.Select((variable) => variable.ExposedAsName));
+            detailSegments.Add("Exposed as " +
+                string.Join(", ", exposedChannelVariables.Select((variable) => variable.ExposedAsName)));
+        }
+
+        if (detailSegments.Count > 0)
+        {
+            composite.DetailText = string.Join("\n", detailSegments);
         }
 
         // Single undo for the whole composite write. The undo lock must live here (Gum-side) because the

--- a/Tool/Tests/GumToolUnitTests/VariableGrid/CompositeMemberLogicApplyTests.cs
+++ b/Tool/Tests/GumToolUnitTests/VariableGrid/CompositeMemberLogicApplyTests.cs
@@ -152,6 +152,33 @@ public class CompositeMemberLogicApplyTests : BaseTestClass
     }
 
     [Fact]
+    public void Apply_ShouldCombineChannelDetailText_WhenChannelsAreDisabled()
+    {
+        // A color driven by a variable reference disables (read-only) each Red/Green/Blue channel and
+        // gives each one a subtext describing its assignment. Once collapsed into the single swatch the
+        // per-channel rows are gone, so the swatch must surface the combined per-channel messages -
+        // otherwise the swatch is disabled with no explanation of why (issue #3058).
+        ComponentSave component = MakeColorComponent();
+        MemberCategory category = CategoryWith(
+            DisabledChannel("Red", "=A.Red"),
+            DisabledChannel("Green", "=A.Green"),
+            DisabledChannel("Blue", "=A.Blue"));
+        List<MemberCategory> categories = new() { category };
+
+        _logic.Apply(categories, component, instance: null);
+        CompositeInstanceMember composite = (CompositeInstanceMember)category.Members.Single();
+
+        composite.DetailText.ShouldContain("Red=A.Red");
+        composite.DetailText.ShouldContain("Green=A.Green");
+        composite.DetailText.ShouldContain("Blue=A.Blue");
+    }
+
+    private static InstanceMember DisabledChannel(string name, string detailText)
+    {
+        return new InstanceMember(name, null!) { IsReadOnly = true, DetailText = detailText };
+    }
+
+    [Fact]
     public void Apply_ShouldOfferUnexposeNotExpose_WhenChannelsExposed()
     {
         InstanceSave instance = SetUpInstanceForExpose(out ComponentSave container);


### PR DESCRIPTION
## Summary

Fixes #3058. When a Color variable is driven by a variable reference, the Variables tab correctly **disabled** the color swatch but showed **no subtext** explaining why — unlike a normal single-value variable, which shows a "set by the variable reference" detail underneath.

## Root cause

A Color reference expands into per-channel `Red`/`Green`/`Blue` assignments, so each channel row (`StateReferencingInstanceMember`) is correctly created read-only with its reference subtext in `DetailText`. `CompositeMemberLogic` then collapses those three rows into a single swatch (`CompositeInstanceMember`).

The swatch inherited the channels' **read-only** state (`CompositeInstanceMember.IsReadOnly => ChannelMembers.Any(c => c.IsReadOnly)`) — so it was disabled — but `BuildAndInsertComposite` only ever set the composite's `DetailText` for the *exposed-channel* case. The per-channel reference subtext was dropped when the rows collapsed.

## Fix

In `CompositeMemberLogic.BuildAndInsertComposite`, combine each **disabled** channel's `DetailText` onto the composite, newline-separated and prefixed by the channel root name, so it reads back as the per-channel assignment line:

```
Red=A.Red
Green=A.Green
Blue=A.Blue
```

Keying on `IsReadOnly` (rather than a concrete-type check) keeps the logic testable with a plain `InstanceMember` and naturally excludes exposure-only channels (exposure doesn't disable a channel), so the existing aggregated "Exposed as …" subtext isn't duplicated. Exposure detail is now folded into the same combined-segment list.

## Design note (per discussion)

The behavior was chosen per reviewer guidance: surface **all** the per-channel messages combined into one subtext, newline-separated, so the user sees every value being assigned individually rather than a single representative line.

One known minor corner: a channel that is *both* exposed and reference-driven would carry exposure text inside its own `DetailText`, which could overlap with the composite's aggregated "Exposed as …" line. This is a rare combination and was left as-is to keep the change focused; happy to tighten it if desired.

## Testing

TDD: added `Apply_ShouldCombineChannelDetailText_WhenChannelsAreDisabled`, confirmed it failed first (composite `DetailText` was null), then implemented. Full `CompositeMemberLogicApplyTests` (13) and the broader `VariableGrid` namespace (150) pass.

Closes #3058

🤖 Generated with [Claude Code](https://claude.com/claude-code)
