### PR TITLE
Fix behavior tool-only references polluting category states (#3055)

### DIFF
--- a/Gum/Plugins/InternalPlugins/VariableGrid/BehaviorToolOnlyReferencesApplier.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/BehaviorToolOnlyReferencesApplier.cs
@@ -27,6 +27,20 @@ public static class BehaviorToolOnlyReferencesApplier
 {
     public static void Apply(ElementSave element, StateSave stateSave)
     {
+        // Tool-only references exist solely to drive the element's resting design-time
+        // wireframe preview from FormsProperty values, and that resting preview is the
+        // default (uncategorized) state. Materializing into a categorized state bakes a
+        // category selector into a state it doesn't belong to - including the selector's
+        // own category, which produces a self-referential/circular state that re-drives
+        // the category back to its FormsProperty value on preview, clobbering the state's
+        // authored values (issue #3055). Since the references evaluate from single-valued
+        // FormsProperties, they resolve identically in every state anyway, so restricting
+        // to the default state loses nothing.
+        if (element.DefaultState == null || stateSave != element.DefaultState)
+        {
+            return;
+        }
+
         if (element is ComponentSave component)
         {
             ApplyBehaviorsOf(component, instance: null, stateSave);

--- a/Tests/Gum.ProjectServices.Tests/HeadlessErrorCheckerTests.cs
+++ b/Tests/Gum.ProjectServices.Tests/HeadlessErrorCheckerTests.cs
@@ -843,4 +843,70 @@ public class HeadlessErrorCheckerTests : BaseTestClass
     }
 
     #endregion
+
+    #region GUM0003 — Category state sets its own category's selector
+
+    [Fact]
+    public void GetErrorsFor_ShouldReportGum0003_WhenCategoryStateSetsItsOwnCategorySelector()
+    {
+        // Repro #3055: a behavior tool-only reference materialized TextBoxCategoryState into
+        // a TextBoxCategory state, so the state selects a state within its own category - a
+        // circular reference that re-drives the category when the state is applied, clobbering
+        // its authored values. This is never valid and must be surfaced.
+        ComponentSave component = new ComponentSave { Name = "Controls/TextBox", BaseType = "Container" };
+        component.States.Add(new StateSave { Name = "Default", ParentContainer = component });
+
+        StateSaveCategory textBoxCategory = new StateSaveCategory { Name = "TextBoxCategory" };
+        StateSave focusedState = new StateSave { Name = "Focused", ParentContainer = component };
+        focusedState.Variables.Add(new VariableSave
+        {
+            Name = "TextBoxCategoryState",
+            Type = "TextBoxCategory",
+            Value = "Enabled",
+            SetsValue = true
+        });
+        textBoxCategory.States.Add(focusedState);
+        component.Categories.Add(textBoxCategory);
+
+        Project.Components.Add(component);
+
+        IReadOnlyList<ErrorResult> errors = _sut.GetErrorsFor(component, Project);
+
+        ErrorResult error = errors.ShouldHaveSingleItem();
+        error.Code.ShouldBe("GUM0003");
+        error.ElementName.ShouldBe("Controls/TextBox");
+        error.Message.ShouldContain("TextBoxCategory");
+        error.Message.ShouldContain("Focused");
+        error.Severity.ShouldBe(ErrorSeverity.Warning);
+    }
+
+    [Fact]
+    public void GetErrorsFor_ShouldNotReportGum0003_WhenCategoryStateSetsChildCategorySelector()
+    {
+        // The normal cascade: a TextBoxCategory state setting a *child* instance's category
+        // selector (Border.ColorCategoryState) is the intended mechanism and must not be flagged.
+        // It is distinguished by having a SourceObject (the child), unlike the element's own selector.
+        ComponentSave component = new ComponentSave { Name = "Controls/TextBox", BaseType = "Container" };
+        component.States.Add(new StateSave { Name = "Default", ParentContainer = component });
+
+        StateSaveCategory textBoxCategory = new StateSaveCategory { Name = "TextBoxCategory" };
+        StateSave focusedState = new StateSave { Name = "Focused", ParentContainer = component };
+        focusedState.Variables.Add(new VariableSave
+        {
+            Name = "Border.ColorCategoryState",
+            Type = "ColorCategory",
+            Value = "Primary",
+            SetsValue = true
+        });
+        textBoxCategory.States.Add(focusedState);
+        component.Categories.Add(textBoxCategory);
+
+        Project.Components.Add(component);
+
+        IReadOnlyList<ErrorResult> errors = _sut.GetErrorsFor(component, Project);
+
+        errors.ShouldNotContain(e => e.Code == "GUM0003");
+    }
+
+    #endregion
 }

--- a/Tool/Tests/GumToolUnitTests/VariableGrid/BehaviorToolOnlyReferencesApplierTests.cs
+++ b/Tool/Tests/GumToolUnitTests/VariableGrid/BehaviorToolOnlyReferencesApplierTests.cs
@@ -390,6 +390,50 @@ public class BehaviorToolOnlyReferencesApplierTests : BaseTestClass
     }
 
     [Fact]
+    public void Apply_NonDefaultCategoryState_DoesNotMaterializeSelectorIntoIt()
+    {
+        // Repro #3055: the applier is invoked with whatever state is currently selected.
+        // When that state is a category state (e.g. TextBoxCategory/Focused), materializing
+        // TextBoxCategoryState into it bakes the category's own selector into one of its
+        // states - a self-referential/circular state that re-drives the category back to
+        // "Enabled" on preview, clobbering the state's authored values. Tool-only references
+        // exist only to drive the resting default-state preview, so a non-default state must
+        // be left untouched.
+        BehaviorSave behavior = new BehaviorSave { Name = "TextBoxBehavior" };
+        behavior.FormsProperties.Add(new VariableSave { Type = "bool", Name = "IsEnabled", Value = true });
+        behavior.ToolOnlyVariableReferences.Add(
+            "TextBoxCategoryState = IsEnabled ? \"Enabled\" : \"Disabled\"");
+
+        ComponentSave component = new ComponentSave { Name = "Controls/TextBox", BaseType = "Container" };
+        component.States.Add(new StateSave { Name = "Default", ParentContainer = component });
+        component.Behaviors.Add(new ElementBehaviorReference { BehaviorName = "TextBoxBehavior" });
+
+        StateSave focusedState = new StateSave { Name = "Focused", ParentContainer = component };
+        focusedState.Variables.Add(new VariableSave
+        {
+            Type = "ColorCategory",
+            Name = "Border.ColorCategoryState",
+            Value = "Primary",
+            SetsValue = true
+        });
+        component.Categories.Add(new StateSaveCategory
+        {
+            Name = "TextBoxCategory",
+            States = new List<StateSave> { focusedState }
+        });
+
+        GumProjectSave project = new GumProjectSave();
+        project.Components.Add(component);
+        project.Behaviors.Add(behavior);
+        ObjectFinder.Self.GumProjectSave = project;
+
+        BehaviorToolOnlyReferencesApplier.Apply(component, focusedState);
+
+        focusedState.Variables.ShouldNotContain(v => v.Name == "TextBoxCategoryState",
+            "a category state must not have its own category's selector materialized into it");
+    }
+
+    [Fact]
     public void Apply_BehaviorWithoutToolOnlyReferences_DoesNothing()
     {
         BehaviorSave behavior = new BehaviorSave { Name = "ButtonBehavior" };

--- a/Tools/Gum.ProjectServices/ErrorDocsRegistry.cs
+++ b/Tools/Gum.ProjectServices/ErrorDocsRegistry.cs
@@ -15,6 +15,7 @@ public class ErrorDocsRegistry : IErrorDocsRegistry
         {
             ["GUM0001"] = "gum-tool/gum-elements/behaviors#behavior-instance-requirements",
             ["GUM0002"] = "gum-tool/gum-elements/states/categories#gum0002-variable-reference-conflicts-with-explicit-set",
+            ["GUM0003"] = "gum-tool/gum-elements/states/categories#gum0003-category-state-sets-its-own-category-selector",
         };
     }
 

--- a/Tools/Gum.ProjectServices/HeadlessErrorChecker.cs
+++ b/Tools/Gum.ProjectServices/HeadlessErrorChecker.cs
@@ -108,6 +108,7 @@ public class HeadlessErrorChecker : IHeadlessErrorChecker
         errors.AddRange(GetInvalidVariableTypeErrorsFor(element));
         errors.AddRange(GetAchxOriginErrorsFor(element, project));
         errors.AddRange(GetVariableReferenceConflictErrorsFor(element));
+        errors.AddRange(GetSelfReferentialCategoryStateErrorsFor(element));
 
         foreach (var source in _additionalErrorSources)
         {
@@ -276,6 +277,57 @@ public class HeadlessErrorChecker : IHeadlessErrorChecker
         value is float || value is double || value is int || value is long || value is decimal;
 
     private static string FormatValue(object? value) => value?.ToString() ?? "(null)";
+
+    #endregion
+
+    #region GUM0003 — Category state sets its own category's selector
+
+    /// <summary>
+    /// Flags a state inside a category that sets that same category's selector variable
+    /// (e.g. a <c>TextBoxCategory</c> state assigning <c>TextBoxCategoryState</c>). Such a
+    /// self-reference is circular: applying the state re-drives the whole category, discarding
+    /// the state's own authored values. It is never valid - the runtime only avoids an infinite
+    /// loop via a recursion guard - and is the data corruption behind issue #3055.
+    /// A child instance's selector (with a SourceObject, e.g. <c>Border.ColorCategoryState</c>)
+    /// is the intended cascade and is deliberately not flagged.
+    /// </summary>
+    private static List<ErrorResult> GetSelfReferentialCategoryStateErrorsFor(ElementSave element)
+    {
+        var errors = new List<ErrorResult>();
+
+        foreach (var category in element.Categories)
+        {
+            foreach (var state in category.States)
+            {
+                foreach (var variable in state.Variables)
+                {
+                    if (!variable.SetsValue || !string.IsNullOrEmpty(variable.SourceObject))
+                    {
+                        continue;
+                    }
+
+                    if (variable.IsState(element, out _, out StateSaveCategory referencedCategory)
+                        && referencedCategory != null
+                        && referencedCategory.Name == category.Name)
+                    {
+                        errors.Add(new ErrorResult
+                        {
+                            ElementName = element.Name,
+                            Code = "GUM0003",
+                            Severity = ErrorSeverity.Warning,
+                            Message = $"Category \"{category.Name}\" state \"{state.Name}\" sets its own " +
+                                $"category selector \"{variable.Name}\". A state cannot select a state within " +
+                                $"its own category - this is a circular reference that re-drives the category " +
+                                $"when the state is applied, discarding the state's authored values. " +
+                                $"Remove \"{variable.Name}\" from this state."
+                        });
+                    }
+                }
+            }
+        }
+
+        return errors;
+    }
 
     #endregion
 

--- a/docs/gum-tool/gum-elements/states/categories.md
+++ b/docs/gum-tool/gum-elements/states/categories.md
@@ -133,3 +133,23 @@ The check fires for two cases, on every state of every Screen and Component:
 - A `VariableReferences` row inherited via an active categorized-state assignment on an instance (the `UpgradeButton` shape).
 
 `StandardElements` are skipped — their references commonly evaluate to default values whose missing materialization is the correct on-disk state, not a conflict.
+
+## GUM0003: Category State Sets Its Own Category Selector
+
+A category's selector variable (e.g. `TextBoxCategoryState` for the `TextBoxCategory` category) chooses which state in that category is active. When a state *inside* the category sets that same selector, the result is circular: applying the state re-drives the whole category, which re-applies a (possibly different) state and discards the original state's authored values. Gum surfaces this with warning code **GUM0003**.
+
+### Example
+
+`TextBox` has a `TextBoxCategory` with states `Enabled`, `Disabled`, `Highlighted`, and `Focused`. The `Focused` state sets `Border.ColorCategoryState = "Primary"` (the normal cascade onto a child instance) — but it *also* sets `TextBoxCategoryState = "Enabled"`. Selecting `Focused` immediately re-applies `Enabled`, so the border never shows the `Focused` colors.
+
+### How it got there
+
+This is not normally hand-authored. It is usually materialized data: a tool pass that drives a category selector from a Forms property (for design-time preview) wrote the selector into whichever state was selected at the time, including the category's own states. The applier no longer does this — it only materializes into the default state — but projects edited before that fix can carry the orphaned assignments.
+
+### Fixing it
+
+Remove the self-referential selector variable from the category's states. The selector belongs only on the default (uncategorized) state, where it picks the element's resting state; it should never appear inside the category it selects.
+
+### Detection scope
+
+The check fires on every Screen and Component, for any state inside a category that sets that same category's selector. A state setting a *child instance's* selector (e.g. `Border.ColorCategoryState`, which carries a source object) is the intended cascade and is not flagged.


### PR DESCRIPTION
## Problem

`TextBox` (and other Forms controls) didn't reflect their category's visual state in the Gum tool: switching the `TextBoxCategory` state updated `Border.ColorCategoryState` in the Variables grid, but the wireframe colors never changed (issue #3055).

Root cause is **persisted data pollution**, not a live override. The behavior tool-only reference

```
TextBoxCategoryState = IsEnabled ? "Enabled" : "Disabled"
```

is materialized into a state for design-time preview by `BehaviorToolOnlyReferencesApplier`, which ran against *whatever state was selected* when a variable reaction fired — including states **inside** `TextBoxCategory` itself. Authoring the per-state border colors therefore baked `TextBoxCategoryState = "Enabled"` into every `TextBoxCategory` state and saved it to disk. On preview, applying e.g. `Focused` sets `Border.ColorCategoryState`, then re-applies the self-referential `TextBoxCategoryState = "Enabled"`, which re-drives the whole category back to `Enabled` and discards the state's authored values. The runtime's `statesInStack` recursion guard prevents an infinite loop, so it surfaced as wrong visuals rather than a crash.

## Changes

**1. Source fix — stop creating the pollution.** `BehaviorToolOnlyReferencesApplier.Apply` now materializes **only into the element's default (uncategorized) state** — the resting design-time preview the feature exists to drive. The references evaluate from single-valued `FormsProperties`, so they resolve identically in every state; restricting to the default loses nothing while eliminating both the self-reference and cross-category pollution (e.g. `TextBoxCategoryState` leaking into `LineModeCategory` states).

**2. Detection — surface existing pollution.** New core check **GUM0003** in `HeadlessErrorChecker` flags any state inside a category that sets that same category's selector. Being a core (headless) check, it appears in both the tool's Errors tab and `gumcli check`. A child instance's selector (`Border.ColorCategoryState`, which carries a source object) is the intended cascade and is **not** flagged. Registered the code + a docs section.

Per discussion, this intentionally **does not auto-repair existing data** — silent migration risks unanticipated side effects, and with GUM0003 in place the manual cleanup is easy and visible. There is no "actionable/quick-fix" error infrastructure in the tool today, so GUM0003 is a plain warning with a docs link.

## Tests

TDD for both cycles (red → green):

- `BehaviorToolOnlyReferencesApplierTests.Apply_NonDefaultCategoryState_DoesNotMaterializeSelectorIntoIt`
- `HeadlessErrorCheckerTests.GetErrorsFor_ShouldReportGum0003_WhenCategoryStateSetsItsOwnCategorySelector`
- `HeadlessErrorCheckerTests.GetErrorsFor_ShouldNotReportGum0003_WhenCategoryStateSetsChildCategorySelector` (negative: the legit child cascade)

Full suites green: `Gum.ProjectServices.Tests` (254) and `GumToolUnitTests` (820), zero regressions.

Closes #3055

🤖 Generated with [Claude Code](https://claude.com/claude-code)
