### PR TITLE
Add Copy Qualified Variable Name to Color swatch (#3061)

### DIFF
--- a/Gum/Managers/ObjectFinder.cs
+++ b/Gum/Managers/ObjectFinder.cs
@@ -861,6 +861,22 @@ public class ObjectFinder : IObjectFinder
     #endregion
 
     /// <summary>
+    /// Returns the project-qualified name of <paramref name="element"/> — the element-path prefix
+    /// (<c>Screens/</c>, <c>Components/</c>, or <c>Standards/</c>) followed by the element name, e.g.
+    /// <c>Components/MyComp</c>. This is the form used as the left part of qualified variable names and as
+    /// the element segment of variable references.
+    /// </summary>
+    public string GetQualifiedElementName(ElementSave element)
+    {
+        var prefix =
+            element is ScreenSave ? "Screens/" :
+            element is ComponentSave ? "Components/" :
+            "Standards/";
+
+        return prefix + element.Name;
+    }
+
+    /// <summary>
     /// Returns a list of TypedElementReferences which include all items that reference the argument element.
     /// </summary>
     /// <param name="element">The argument element.</param>
@@ -868,12 +884,7 @@ public class ObjectFinder : IObjectFinder
     public List<TypedElementReference> GetElementReferencesToThis(ElementSave element)
     {
         var elementName = element.Name;
-        var prefix =
-            element is ScreenSave ? "Screens/" :
-            element is ComponentSave ? "Components/" :
-            "Standards/";
-
-        var elementQualifiedName = prefix + elementName;
+        var elementQualifiedName = GetQualifiedElementName(element);
 
         List<TypedElementReference> references = new List<TypedElementReference>();
         foreach (var screen in GumProjectSave.Screens)

--- a/Gum/Plugins/InternalPlugins/VariableGrid/CompositeMemberDescriptor.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/CompositeMemberDescriptor.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Gum.Plugins.InternalPlugins.VariableGrid;
 
@@ -27,4 +28,37 @@ public record CompositeMemberDescriptor(
     Type Displayer,
     Type CompositeType,
     Func<IReadOnlyList<object?>, object> Compose,
-    Func<object, object?[]> Decompose);
+    Func<object, object?[]> Decompose)
+{
+    /// <summary>
+    /// The literal token at the heart of <see cref="CompositeNameFormat"/> — the format with the
+    /// <c>{prefix}</c>/<c>{suffix}</c> placeholders removed (e.g. <c>Color</c> from <c>{prefix}Color{suffix}</c>).
+    /// </summary>
+    private string CompositeToken => CompositeNameFormat
+        .Replace("{prefix}", string.Empty)
+        .Replace("{suffix}", string.Empty);
+
+    /// <summary>
+    /// If <paramref name="compositeName"/> is an instance of this descriptor's name format — the
+    /// <see cref="CompositeToken"/> surrounded by some prefix/suffix (e.g. <c>StrokeColor</c>, <c>Color2</c>) —
+    /// outputs the matching channel variable names in <see cref="ChannelRootNames"/> order (e.g.
+    /// <c>StrokeColor</c> -&gt; StrokeRed/StrokeGreen/StrokeBlue) and returns true; otherwise returns false.
+    /// This is the inverse of how <c>CompositeMemberLogic</c> builds the composite name from the channels.
+    /// </summary>
+    public bool TryGetChannelNames(string compositeName, out IReadOnlyList<string> channelNames)
+    {
+        string compositeToken = CompositeToken;
+        int index = compositeName.IndexOf(compositeToken, StringComparison.Ordinal);
+        if (index < 0)
+        {
+            channelNames = Array.Empty<string>();
+            return false;
+        }
+
+        string prefix = compositeName.Substring(0, index);
+        string suffix = compositeName.Substring(index + compositeToken.Length);
+
+        channelNames = ChannelRootNames.Select(token => prefix + token + suffix).ToArray();
+        return true;
+    }
+}

--- a/Gum/Plugins/InternalPlugins/VariableGrid/CompositeMemberLogic.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/CompositeMemberLogic.cs
@@ -10,6 +10,7 @@ using Gum.Undo;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Windows.Forms;
 using ToolsUtilities;
 using WpfDataUi.DataTypes;
 
@@ -225,6 +226,18 @@ public class CompositeMemberLogic
 
         composite.ContextMenuEvents.Add("Make Default", (_, _) => HandleMakeDefault(triple.ChannelMembers));
 
+        // "Copy Qualified Variable Name" copies the swatch's qualified name (e.g.
+        // Components/MyComp.MyInstance.Color) so it can be pasted as the right-hand side of a variable
+        // reference; VariableReferenceLogic expands "Color = ....Color" back into Red/Green/Blue. Scope this to
+        // the standard "Color" composite only: the color-expansion matches exactly leftSide == "Color" &&
+        // rightSide.EndsWith(".Color"), so affixed/gradient colors (StrokeColor, Color1) would produce a name
+        // the reference resolver can't expand (issue #3061).
+        if (compositeName == "Color")
+        {
+            composite.ContextMenuEvents.Add("Copy Qualified Variable Name",
+                (_, _) => Clipboard.SetText(GetCompositeQualifiedName(element, instance, compositeName)));
+        }
+
         TryAddExposeMenu(composite, descriptor, triple, element, instance, exposedChannelVariables);
 
         int insertIndex = triple.ChannelMembers.Min((member) => category.Members.IndexOf(member));
@@ -381,6 +394,22 @@ public class CompositeMemberLogic
         return instance != null
             ? element.DefaultState.GetVariableSave($"{instance.Name}.{channelRootName}")
             : element.DefaultState.GetVariableSave(channelRootName);
+    }
+
+    /// <summary>
+    /// Builds the project-qualified name of a composite swatch, e.g. <c>Components/MyComp.MyInstance.Color</c>
+    /// (or <c>Components/MyComp.Color</c> when the composite belongs to the element itself). Unlike the
+    /// per-channel rows — whose variable name already bakes in the instance name — the composite must prepend
+    /// the instance name itself. Exposed in internal scope for testing.
+    /// </summary>
+    internal string GetCompositeQualifiedName(ElementSave element, InstanceSave? instance, string compositeName)
+    {
+        string qualifiedName = _objectFinder.GetQualifiedElementName(element) + ".";
+        if (instance != null)
+        {
+            qualifiedName += instance.Name + ".";
+        }
+        return qualifiedName + compositeName;
     }
 
     private string? GetRootVariableName(InstanceMember member, ElementSave element, InstanceSave? instance)

--- a/Gum/Plugins/InternalPlugins/VariableGrid/CompositeMemberLogic.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/CompositeMemberLogic.cs
@@ -227,16 +227,12 @@ public class CompositeMemberLogic
         composite.ContextMenuEvents.Add("Make Default", (_, _) => HandleMakeDefault(triple.ChannelMembers));
 
         // "Copy Qualified Variable Name" copies the swatch's qualified name (e.g.
-        // Components/MyComp.MyInstance.Color) so it can be pasted as the right-hand side of a variable
-        // reference; VariableReferenceLogic expands "Color = ....Color" back into Red/Green/Blue. Scope this to
-        // the standard "Color" composite only: the color-expansion matches exactly leftSide == "Color" &&
-        // rightSide.EndsWith(".Color"), so affixed/gradient colors (StrokeColor, Color1) would produce a name
-        // the reference resolver can't expand (issue #3061).
-        if (compositeName == "Color")
-        {
-            composite.ContextMenuEvents.Add("Copy Qualified Variable Name",
-                (_, _) => Clipboard.SetText(GetCompositeQualifiedName(element, instance, compositeName)));
-        }
+        // Components/MyComp.MyInstance.Color, or ...StrokeColor for an affixed color) so it can be pasted as the
+        // right-hand side of a variable reference. VariableReferenceLogic expands any composite reference back
+        // into its channels via the same registry that built this swatch, so every composite color - plain,
+        // affixed (StrokeColor/FillColor), or gradient (Color2) - is a valid copy target (issue #3061).
+        composite.ContextMenuEvents.Add("Copy Qualified Variable Name",
+            (_, _) => Clipboard.SetText(GetCompositeQualifiedName(element, instance, compositeName)));
 
         TryAddExposeMenu(composite, descriptor, triple, element, instance, exposedChannelVariables);
 

--- a/Gum/Plugins/InternalPlugins/VariableGrid/StateReferencingInstanceMember.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/StateReferencingInstanceMember.cs
@@ -528,31 +528,16 @@ public class StateReferencingInstanceMember : InstanceMember
         {
             ContextMenuEvents.Add("Copy Qualified Variable Name", (sender, e) =>
             {
-                string qualifiedName;
-
-                if (ElementSave is ScreenSave)
+                if (ElementSave == null)
                 {
-                    qualifiedName = $"Screens/{ElementSave.Name}";
-                }
-                else if (ElementSave is ComponentSave)
-                {
-                    qualifiedName = $"Components/{ElementSave.Name}";
-                }
-                else
-                {
-                    qualifiedName = $"Standards/{ElementSave.Name}";
+                    return;
                 }
 
-                // no need to append instance, the variable name contains the instance name if there is an instance
-                //if(mInstanceSave != null)
-                //{
-                //    qualifiedName += "." + mInstanceSave.Name;
-                //}
-
-                qualifiedName += "." + mVariableName;
+                // No need to append the instance: mVariableName already contains the instance name when there
+                // is an instance.
+                var qualifiedName = _objectFinder.GetQualifiedElementName(ElementSave) + "." + mVariableName;
 
                 Clipboard.SetText(qualifiedName);
-
             });
         }
 

--- a/Gum/Plugins/InternalPlugins/VariableGrid/VariableReferenceLogic.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/VariableReferenceLogic.cs
@@ -31,18 +31,21 @@ public class VariableReferenceLogic : IVariableReferenceLogic
     private readonly IWireframeCommands _wireframeCommands;
     private readonly IDialogService _dialogService;
     private readonly IFileCommands _fileCommands;
+    private readonly ICompositeMemberRegistry _compositeMemberRegistry;
 
     #endregion
 
     public VariableReferenceLogic(IGuiCommands guiCommands,
         IWireframeCommands wireframeCommands,
         IDialogService dialogService,
-        IFileCommands fileCommands)
+        IFileCommands fileCommands,
+        ICompositeMemberRegistry compositeMemberRegistry)
     {
         _guiCommands = guiCommands;
         _wireframeCommands = wireframeCommands;
         _dialogService =  dialogService;
         _fileCommands = fileCommands;
+        _compositeMemberRegistry = compositeMemberRegistry;
     }
 
     public AssignmentExpressionSyntax? GetAssignmentSyntax(string item)
@@ -704,9 +707,14 @@ public class VariableReferenceLogic : IVariableReferenceLogic
                 {
                     var leftSide = split[0];
                     var rightSide = split[1];
-                    if (leftSide == "Color" && rightSide.EndsWith(".Color"))
+                    // A composite reference (e.g. "Color = X.Color", "StrokeColor = X.StrokeColor") expands into
+                    // one assignment per underlying channel. The registry knows which names are composites and
+                    // what channels they map to, so any registered composite (color today, others later) expands
+                    // with no extra control flow here.
+                    if (rightSide.EndsWith("." + leftSide) &&
+                        TryGetCompositeChannelNames(leftSide, out var channelNames))
                     {
-                        ExpandColorToRedGreenBlue(newValueAsList, i, rightSide);
+                        ExpandCompositeToChannels(newValueAsList, i, rightSide, leftSide, channelNames);
                     }
                 }
             }
@@ -780,17 +788,37 @@ public class VariableReferenceLogic : IVariableReferenceLogic
         //newValueAsList[i] = split[0] + "=" + split[1];
     }
 
-    private static void ExpandColorToRedGreenBlue(List<string> asList, int i, string rightSide)
+    /// <summary>
+    /// Returns the channel variable names for <paramref name="compositeName"/> if it matches any registered
+    /// composite descriptor (e.g. "StrokeColor" -&gt; StrokeRed/StrokeGreen/StrokeBlue); otherwise false.
+    /// </summary>
+    private bool TryGetCompositeChannelNames(string compositeName, out IReadOnlyList<string> channelNames)
     {
-        // does this thing have a color value?
-        // let's assume "no" for now, eventually may need to fix this up....
-        var withoutVariable = rightSide.Substring(0, rightSide.Length - ".Color".Length);
+        foreach (var descriptor in _compositeMemberRegistry.Descriptors)
+        {
+            if (descriptor.TryGetChannelNames(compositeName, out channelNames))
+            {
+                return true;
+            }
+        }
+
+        channelNames = Array.Empty<string>();
+        return false;
+    }
+
+    private static void ExpandCompositeToChannels(List<string> asList, int i, string rightSide,
+        string compositeName, IReadOnlyList<string> channelNames)
+    {
+        // rightSide ends with "." + compositeName (e.g. "X.StrokeColor"); strip that to get the referenced
+        // object path ("X"), then re-attach each channel name on both sides.
+        var withoutVariable = rightSide.Substring(0, rightSide.Length - ("." + compositeName).Length);
 
         asList.RemoveAt(i);
 
-        asList.Add($"Red = {withoutVariable}.Red");
-        asList.Add($"Green = {withoutVariable}.Green");
-        asList.Add($"Blue = {withoutVariable}.Blue");
+        foreach (var channelName in channelNames)
+        {
+            asList.Add($"{channelName} = {withoutVariable}.{channelName}");
+        }
     }
 
     private static string[] AddImpliedLeftSide(List<string> asList, int i, string[] split)

--- a/Gum/Plugins/InternalPlugins/VariableGrid/VariableReferenceLogic.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/VariableReferenceLogic.cs
@@ -632,7 +632,9 @@ public class VariableReferenceLogic : IVariableReferenceLogic
 
         ///////////////////End Early Out/////////////////////////////////////
 
-        bool didChange = ModifyLines(oldValue, newValueAsList, instance);
+        var ownerElement = ObjectFinder.Self.GetElementContainerOf(stateSave);
+
+        bool didChange = ModifyLines(oldValue, newValueAsList, instance, ownerElement);
 
 
         if (didChange)
@@ -646,7 +648,8 @@ public class VariableReferenceLogic : IVariableReferenceLogic
     #region Line Assignment Expansion / Modifications
 
     static char[] equalsArray = new char[] { '=' };
-    bool ModifyLines(object? oldValue, List<string> newValueAsList, InstanceSave? selectedInstance)
+    bool ModifyLines(object? oldValue, List<string> newValueAsList, InstanceSave? selectedInstance,
+        ElementSave? ownerElement)
     {
         var oldValueAsList = oldValue as List<string>;
 
@@ -710,9 +713,12 @@ public class VariableReferenceLogic : IVariableReferenceLogic
                     // A composite reference (e.g. "Color = X.Color", "StrokeColor = X.StrokeColor") expands into
                     // one assignment per underlying channel. The registry knows which names are composites and
                     // what channels they map to, so any registered composite (color today, others later) expands
-                    // with no extra control flow here.
+                    // with no extra control flow here. We only expand when the reference owner actually has those
+                    // channels - otherwise a non-composite name that merely contains the token (e.g. a literal
+                    // "BackgroundColor" variable) would be mangled into BackgroundRed/Green/Blue.
                     if (rightSide.EndsWith("." + leftSide) &&
-                        TryGetCompositeChannelNames(leftSide, out var channelNames))
+                        TryGetCompositeChannelNames(leftSide, out var channelNames) &&
+                        OwnerHasAllChannels(channelNames, selectedInstance, ownerElement))
                     {
                         ExpandCompositeToChannels(newValueAsList, i, rightSide, leftSide, channelNames);
                     }
@@ -804,6 +810,35 @@ public class VariableReferenceLogic : IVariableReferenceLogic
 
         channelNames = Array.Empty<string>();
         return false;
+    }
+
+    /// <summary>
+    /// Returns true only if the reference owner (the selected instance's type, or the owning element for an
+    /// element-level reference) declares a root variable for every channel - i.e. the composite name really is
+    /// a composite on this object. Mirrors the channel-existence check <c>CompositeMemberLogic</c> uses to
+    /// decide whether to build the swatch in the first place.
+    /// </summary>
+    private static bool OwnerHasAllChannels(IReadOnlyList<string> channelNames, InstanceSave? selectedInstance,
+        ElementSave? ownerElement)
+    {
+        var channelOwner = selectedInstance != null
+            ? ObjectFinder.Self.GetElementSave(selectedInstance)
+            : ownerElement;
+
+        if (channelOwner == null)
+        {
+            return false;
+        }
+
+        foreach (var channelName in channelNames)
+        {
+            if (ObjectFinder.Self.GetRootVariable(channelName, channelOwner) == null)
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     private static void ExpandCompositeToChannels(List<string> asList, int i, string rightSide,

--- a/Tool/Tests/GumToolUnitTests/Managers/ObjectFinderTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Managers/ObjectFinderTests.cs
@@ -1,0 +1,32 @@
+using Gum.DataTypes;
+using Gum.Managers;
+using Shouldly;
+
+namespace GumToolUnitTests.Managers;
+
+public class ObjectFinderTests : BaseTestClass
+{
+    [Fact]
+    public void GetQualifiedElementName_ShouldUseComponentsPrefix_ForComponent()
+    {
+        ComponentSave component = new() { Name = "MyComp" };
+
+        ObjectFinder.Self.GetQualifiedElementName(component).ShouldBe("Components/MyComp");
+    }
+
+    [Fact]
+    public void GetQualifiedElementName_ShouldUseScreensPrefix_ForScreen()
+    {
+        ScreenSave screen = new() { Name = "MyScreen" };
+
+        ObjectFinder.Self.GetQualifiedElementName(screen).ShouldBe("Screens/MyScreen");
+    }
+
+    [Fact]
+    public void GetQualifiedElementName_ShouldUseStandardsPrefix_ForStandard()
+    {
+        StandardElementSave standard = new() { Name = "ColoredRectangle" };
+
+        ObjectFinder.Self.GetQualifiedElementName(standard).ShouldBe("Standards/ColoredRectangle");
+    }
+}

--- a/Tool/Tests/GumToolUnitTests/VariableGrid/CompositeMemberDescriptorTests.cs
+++ b/Tool/Tests/GumToolUnitTests/VariableGrid/CompositeMemberDescriptorTests.cs
@@ -1,0 +1,56 @@
+using System.Collections.Generic;
+using Gum.Plugins.InternalPlugins.VariableGrid;
+using Shouldly;
+using Xunit;
+
+namespace GumToolUnitTests.VariableGrid;
+
+public class CompositeMemberDescriptorTests
+{
+    private readonly CompositeMemberDescriptor _colorDescriptor = new CompositeMemberRegistry().Descriptors[0];
+
+    [Fact]
+    public void TryGetChannelNames_ShouldMapAffixedColor_WithPrefix()
+    {
+        bool matched = _colorDescriptor.TryGetChannelNames("StrokeColor", out IReadOnlyList<string> channelNames);
+
+        matched.ShouldBeTrue();
+        channelNames.ShouldBe(new[] { "StrokeRed", "StrokeGreen", "StrokeBlue" });
+    }
+
+    [Fact]
+    public void TryGetChannelNames_ShouldMapAffixedColor_WithSuffix()
+    {
+        bool matched = _colorDescriptor.TryGetChannelNames("Color2", out IReadOnlyList<string> channelNames);
+
+        matched.ShouldBeTrue();
+        channelNames.ShouldBe(new[] { "Red2", "Green2", "Blue2" });
+    }
+
+    [Fact]
+    public void TryGetChannelNames_ShouldMapFillColor()
+    {
+        bool matched = _colorDescriptor.TryGetChannelNames("FillColor", out IReadOnlyList<string> channelNames);
+
+        matched.ShouldBeTrue();
+        channelNames.ShouldBe(new[] { "FillRed", "FillGreen", "FillBlue" });
+    }
+
+    [Fact]
+    public void TryGetChannelNames_ShouldMapPlainColor()
+    {
+        bool matched = _colorDescriptor.TryGetChannelNames("Color", out IReadOnlyList<string> channelNames);
+
+        matched.ShouldBeTrue();
+        channelNames.ShouldBe(new[] { "Red", "Green", "Blue" });
+    }
+
+    [Fact]
+    public void TryGetChannelNames_ShouldNotMatch_NonColorName()
+    {
+        bool matched = _colorDescriptor.TryGetChannelNames("Width", out IReadOnlyList<string> channelNames);
+
+        matched.ShouldBeFalse();
+        channelNames.ShouldBeEmpty();
+    }
+}

--- a/Tool/Tests/GumToolUnitTests/VariableGrid/CompositeMemberLogicTests.cs
+++ b/Tool/Tests/GumToolUnitTests/VariableGrid/CompositeMemberLogicTests.cs
@@ -1,5 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
+using Gum.DataTypes;
+using Gum.DataTypes.Variables;
 using Gum.Managers;
 using Gum.Plugins.InternalPlugins.VariableGrid;
 using Shouldly;
@@ -8,7 +10,7 @@ using Xunit;
 
 namespace GumToolUnitTests.VariableGrid;
 
-public class CompositeMemberLogicTests
+public class CompositeMemberLogicTests : BaseTestClass
 {
     private readonly CompositeMemberLogic _logic;
     private readonly CompositeMemberDescriptor _colorDescriptor;
@@ -28,6 +30,76 @@ public class CompositeMemberLogicTests
             result[rootName] = new InstanceMember(rootName, null!);
         }
         return result;
+    }
+
+    /// <summary>
+    /// Builds a single-category component whose default state declares the given channel variables, plus a
+    /// matching grid member per channel - enough for <see cref="CompositeMemberLogic.Apply"/> to collapse them
+    /// into a composite swatch.
+    /// </summary>
+    private static (MemberCategory category, ComponentSave element) BuildComponentWithChannels(
+        params string[] channelRootNames)
+    {
+        ComponentSave element = new() { Name = "MyComp" };
+        StateSave defaultState = new() { Name = "Default", ParentContainer = element };
+        element.States.Add(defaultState);
+
+        MemberCategory category = new();
+        foreach (string channelRootName in channelRootNames)
+        {
+            defaultState.Variables.Add(new VariableSave { Name = channelRootName, Value = 0, Type = "int" });
+            category.Members.Add(new InstanceMember(channelRootName, defaultState));
+        }
+
+        return (category, element);
+    }
+
+    private CompositeInstanceMember ApplyAndGetComposite(MemberCategory category, ComponentSave element)
+    {
+        _logic.Apply(new List<MemberCategory> { category }, element, instance: null);
+        return category.Members.OfType<CompositeInstanceMember>().Single();
+    }
+
+    [Fact]
+    public void Apply_ShouldAddCopyQualifiedVariableNameMenu_ForPlainColor()
+    {
+        (MemberCategory category, ComponentSave element) = BuildComponentWithChannels("Red", "Green", "Blue");
+
+        CompositeInstanceMember composite = ApplyAndGetComposite(category, element);
+
+        composite.ContextMenuEvents.Keys.ShouldContain("Copy Qualified Variable Name");
+    }
+
+    [Fact]
+    public void Apply_ShouldNotAddCopyQualifiedVariableNameMenu_ForAffixedColor()
+    {
+        // VariableReferenceLogic only expands a reference whose right side ends in ".Color", so affixed colors
+        // (e.g. StrokeColor) must not offer a copy item that would produce an unexpandable reference (#3061).
+        (MemberCategory category, ComponentSave element) =
+            BuildComponentWithChannels("StrokeRed", "StrokeGreen", "StrokeBlue");
+
+        CompositeInstanceMember composite = ApplyAndGetComposite(category, element);
+
+        composite.ContextMenuEvents.Keys.ShouldNotContain("Copy Qualified Variable Name");
+    }
+
+    [Fact]
+    public void GetCompositeQualifiedName_ShouldIncludeInstanceName_WhenInstanceProvided()
+    {
+        ComponentSave element = new() { Name = "MyComp" };
+        InstanceSave instance = new() { Name = "MyInstance" };
+
+        _logic.GetCompositeQualifiedName(element, instance, "Color")
+            .ShouldBe("Components/MyComp.MyInstance.Color");
+    }
+
+    [Fact]
+    public void GetCompositeQualifiedName_ShouldQualifyWithElementPrefix_WhenNoInstance()
+    {
+        ComponentSave element = new() { Name = "MyComp" };
+
+        _logic.GetCompositeQualifiedName(element, instance: null, "Color")
+            .ShouldBe("Components/MyComp.Color");
     }
 
     [Fact]

--- a/Tool/Tests/GumToolUnitTests/VariableGrid/CompositeMemberLogicTests.cs
+++ b/Tool/Tests/GumToolUnitTests/VariableGrid/CompositeMemberLogicTests.cs
@@ -71,16 +71,16 @@ public class CompositeMemberLogicTests : BaseTestClass
     }
 
     [Fact]
-    public void Apply_ShouldNotAddCopyQualifiedVariableNameMenu_ForAffixedColor()
+    public void Apply_ShouldAddCopyQualifiedVariableNameMenu_ForAffixedColor()
     {
-        // VariableReferenceLogic only expands a reference whose right side ends in ".Color", so affixed colors
-        // (e.g. StrokeColor) must not offer a copy item that would produce an unexpandable reference (#3061).
+        // VariableReferenceLogic now expands any composite color reference (StrokeColor -> Stroke channels),
+        // so affixed colors offer the copy item too.
         (MemberCategory category, ComponentSave element) =
             BuildComponentWithChannels("StrokeRed", "StrokeGreen", "StrokeBlue");
 
         CompositeInstanceMember composite = ApplyAndGetComposite(category, element);
 
-        composite.ContextMenuEvents.Keys.ShouldNotContain("Copy Qualified Variable Name");
+        composite.ContextMenuEvents.Keys.ShouldContain("Copy Qualified Variable Name");
     }
 
     [Fact]

--- a/Tool/Tests/GumToolUnitTests/VariableGrid/VariableReferenceLogicTests.cs
+++ b/Tool/Tests/GumToolUnitTests/VariableGrid/VariableReferenceLogicTests.cs
@@ -23,7 +23,8 @@ public class VariableReferenceLogicTests : BaseTestClass
             _guiCommandsMock.Object,
             new Mock<IWireframeCommands>().Object,
             new Mock<IDialogService>().Object,
-            new Mock<IFileCommands>().Object);
+            new Mock<IFileCommands>().Object,
+            new CompositeMemberRegistry());
     }
 
     #region GetAssignmentSyntax
@@ -80,7 +81,7 @@ public class VariableReferenceLogicTests : BaseTestClass
     public void ReactIfChangedMemberIsVariableReference_ColorAssignment_ExpandsToThreeEntries()
     {
         // "Background.Color" has no explicit left side, so AddImpliedLeftSide runs first,
-        // converting it to "Color = Background.Color", then ExpandColorToRedGreenBlue splits it.
+        // converting it to "Color = Background.Color", then the composite expansion splits it.
         StateSave stateSave = BuildStateWithVariableReferences("VariableReferences", "Background.Color");
 
         _sut.ReactIfChangedMemberIsVariableReference(
@@ -91,6 +92,54 @@ public class VariableReferenceLogicTests : BaseTestClass
         varList.ShouldContain("Red = Background.Red");
         varList.ShouldContain("Green = Background.Green");
         varList.ShouldContain("Blue = Background.Blue");
+    }
+
+    [Fact]
+    public void ReactIfChangedMemberIsVariableReference_FillColorAssignment_ExpandsToFillChannels()
+    {
+        // Affixed colors expand to their affixed channels, the inverse of how CompositeMemberLogic
+        // collapses FillRed/FillGreen/FillBlue into a single "FillColor" swatch.
+        StateSave stateSave = BuildStateWithVariableReferences("VariableReferences", "Background.FillColor");
+
+        _sut.ReactIfChangedMemberIsVariableReference(
+            instance: null, stateSave, changedMember: "VariableReferences", oldValue: null);
+
+        var varList = (List<string>)stateSave.GetVariableListSave("VariableReferences").ValueAsIList;
+        varList.Count.ShouldBe(3);
+        varList.ShouldContain("FillRed = Background.FillRed");
+        varList.ShouldContain("FillGreen = Background.FillGreen");
+        varList.ShouldContain("FillBlue = Background.FillBlue");
+    }
+
+    [Fact]
+    public void ReactIfChangedMemberIsVariableReference_StrokeColorAssignment_ExpandsToStrokeChannels()
+    {
+        StateSave stateSave = BuildStateWithVariableReferences("VariableReferences", "Background.StrokeColor");
+
+        _sut.ReactIfChangedMemberIsVariableReference(
+            instance: null, stateSave, changedMember: "VariableReferences", oldValue: null);
+
+        var varList = (List<string>)stateSave.GetVariableListSave("VariableReferences").ValueAsIList;
+        varList.Count.ShouldBe(3);
+        varList.ShouldContain("StrokeRed = Background.StrokeRed");
+        varList.ShouldContain("StrokeGreen = Background.StrokeGreen");
+        varList.ShouldContain("StrokeBlue = Background.StrokeBlue");
+    }
+
+    [Fact]
+    public void ReactIfChangedMemberIsVariableReference_SuffixedColorAssignment_ExpandsToSuffixedChannels()
+    {
+        // Gradient channels carry a numeric suffix (e.g. Color2 -> Red2/Green2/Blue2).
+        StateSave stateSave = BuildStateWithVariableReferences("VariableReferences", "Background.Color2");
+
+        _sut.ReactIfChangedMemberIsVariableReference(
+            instance: null, stateSave, changedMember: "VariableReferences", oldValue: null);
+
+        var varList = (List<string>)stateSave.GetVariableListSave("VariableReferences").ValueAsIList;
+        varList.Count.ShouldBe(3);
+        varList.ShouldContain("Red2 = Background.Red2");
+        varList.ShouldContain("Green2 = Background.Green2");
+        varList.ShouldContain("Blue2 = Background.Blue2");
     }
 
     [Fact]

--- a/Tool/Tests/GumToolUnitTests/VariableGrid/VariableReferenceLogicTests.cs
+++ b/Tool/Tests/GumToolUnitTests/VariableGrid/VariableReferenceLogicTests.cs
@@ -82,16 +82,16 @@ public class VariableReferenceLogicTests : BaseTestClass
     {
         // "Background.Color" has no explicit left side, so AddImpliedLeftSide runs first,
         // converting it to "Color = Background.Color", then the composite expansion splits it.
-        StateSave stateSave = BuildStateWithVariableReferences("VariableReferences", "Background.Color");
+        (StateSave defaultState, VariableListSave<string> varList) =
+            BuildOwnerWithChannelsAndReference("Background.Color", "Red", "Green", "Blue");
 
         _sut.ReactIfChangedMemberIsVariableReference(
-            instance: null, stateSave, changedMember: "VariableReferences", oldValue: null);
+            instance: null, defaultState, changedMember: "VariableReferences", oldValue: null);
 
-        var varList = (List<string>)stateSave.GetVariableListSave("VariableReferences").ValueAsIList;
-        varList.Count.ShouldBe(3);
-        varList.ShouldContain("Red = Background.Red");
-        varList.ShouldContain("Green = Background.Green");
-        varList.ShouldContain("Blue = Background.Blue");
+        varList.Value.Count.ShouldBe(3);
+        varList.Value.ShouldContain("Red = Background.Red");
+        varList.Value.ShouldContain("Green = Background.Green");
+        varList.Value.ShouldContain("Blue = Background.Blue");
     }
 
     [Fact]
@@ -99,47 +99,63 @@ public class VariableReferenceLogicTests : BaseTestClass
     {
         // Affixed colors expand to their affixed channels, the inverse of how CompositeMemberLogic
         // collapses FillRed/FillGreen/FillBlue into a single "FillColor" swatch.
-        StateSave stateSave = BuildStateWithVariableReferences("VariableReferences", "Background.FillColor");
+        (StateSave defaultState, VariableListSave<string> varList) =
+            BuildOwnerWithChannelsAndReference("Background.FillColor", "FillRed", "FillGreen", "FillBlue");
 
         _sut.ReactIfChangedMemberIsVariableReference(
-            instance: null, stateSave, changedMember: "VariableReferences", oldValue: null);
+            instance: null, defaultState, changedMember: "VariableReferences", oldValue: null);
 
-        var varList = (List<string>)stateSave.GetVariableListSave("VariableReferences").ValueAsIList;
-        varList.Count.ShouldBe(3);
-        varList.ShouldContain("FillRed = Background.FillRed");
-        varList.ShouldContain("FillGreen = Background.FillGreen");
-        varList.ShouldContain("FillBlue = Background.FillBlue");
+        varList.Value.Count.ShouldBe(3);
+        varList.Value.ShouldContain("FillRed = Background.FillRed");
+        varList.Value.ShouldContain("FillGreen = Background.FillGreen");
+        varList.Value.ShouldContain("FillBlue = Background.FillBlue");
+    }
+
+    [Fact]
+    public void ReactIfChangedMemberIsVariableReference_NonCompositeColorName_IsNotExpanded()
+    {
+        // "BackgroundColor" contains the "Color" token but the owner has no Background* channels, so it is not
+        // a real composite; it must be left intact for normal validation rather than mangled into
+        // BackgroundRed/Green/Blue.
+        (StateSave defaultState, VariableListSave<string> varList) = BuildOwnerWithChannelsAndReference(
+            "BackgroundColor = OtherInstance.BackgroundColor", "Red", "Green", "Blue");
+
+        _sut.ReactIfChangedMemberIsVariableReference(
+            instance: null, defaultState, changedMember: "VariableReferences", oldValue: null);
+
+        varList.Value.Count.ShouldBe(1);
+        varList.Value[0].ShouldBe("BackgroundColor = OtherInstance.BackgroundColor");
     }
 
     [Fact]
     public void ReactIfChangedMemberIsVariableReference_StrokeColorAssignment_ExpandsToStrokeChannels()
     {
-        StateSave stateSave = BuildStateWithVariableReferences("VariableReferences", "Background.StrokeColor");
+        (StateSave defaultState, VariableListSave<string> varList) =
+            BuildOwnerWithChannelsAndReference("Background.StrokeColor", "StrokeRed", "StrokeGreen", "StrokeBlue");
 
         _sut.ReactIfChangedMemberIsVariableReference(
-            instance: null, stateSave, changedMember: "VariableReferences", oldValue: null);
+            instance: null, defaultState, changedMember: "VariableReferences", oldValue: null);
 
-        var varList = (List<string>)stateSave.GetVariableListSave("VariableReferences").ValueAsIList;
-        varList.Count.ShouldBe(3);
-        varList.ShouldContain("StrokeRed = Background.StrokeRed");
-        varList.ShouldContain("StrokeGreen = Background.StrokeGreen");
-        varList.ShouldContain("StrokeBlue = Background.StrokeBlue");
+        varList.Value.Count.ShouldBe(3);
+        varList.Value.ShouldContain("StrokeRed = Background.StrokeRed");
+        varList.Value.ShouldContain("StrokeGreen = Background.StrokeGreen");
+        varList.Value.ShouldContain("StrokeBlue = Background.StrokeBlue");
     }
 
     [Fact]
     public void ReactIfChangedMemberIsVariableReference_SuffixedColorAssignment_ExpandsToSuffixedChannels()
     {
         // Gradient channels carry a numeric suffix (e.g. Color2 -> Red2/Green2/Blue2).
-        StateSave stateSave = BuildStateWithVariableReferences("VariableReferences", "Background.Color2");
+        (StateSave defaultState, VariableListSave<string> varList) =
+            BuildOwnerWithChannelsAndReference("Background.Color2", "Red2", "Green2", "Blue2");
 
         _sut.ReactIfChangedMemberIsVariableReference(
-            instance: null, stateSave, changedMember: "VariableReferences", oldValue: null);
+            instance: null, defaultState, changedMember: "VariableReferences", oldValue: null);
 
-        var varList = (List<string>)stateSave.GetVariableListSave("VariableReferences").ValueAsIList;
-        varList.Count.ShouldBe(3);
-        varList.ShouldContain("Red2 = Background.Red2");
-        varList.ShouldContain("Green2 = Background.Green2");
-        varList.ShouldContain("Blue2 = Background.Blue2");
+        varList.Value.Count.ShouldBe(3);
+        varList.Value.ShouldContain("Red2 = Background.Red2");
+        varList.Value.ShouldContain("Green2 = Background.Green2");
+        varList.Value.ShouldContain("Blue2 = Background.Blue2");
     }
 
     [Fact]
@@ -537,6 +553,41 @@ public class VariableReferenceLogicTests : BaseTestClass
         varList.Value.Add(item);
         stateSave.VariableLists.Add(varList);
         return stateSave;
+    }
+
+    /// <summary>
+    /// Builds a component (registered in a fresh project on <see cref="ObjectFinder"/>) whose default state
+    /// declares the given channel variables and carries a single VariableReferences line. Composite expansion
+    /// only fires when the reference owner actually has the composite's channels, so the channels must exist
+    /// for the expansion under test to run.
+    /// </summary>
+    private static (StateSave defaultState, VariableListSave<string> varList) BuildOwnerWithChannelsAndReference(
+        string referenceLine, params string[] channelNames)
+    {
+        ComponentSave element = new() { Name = "MyComp" };
+        StateSave defaultState = new() { Name = "Default", ParentContainer = element };
+        element.States.Add(defaultState);
+
+        foreach (string channelName in channelNames)
+        {
+            defaultState.Variables.Add(new VariableSave
+            {
+                Name = channelName,
+                Value = 0,
+                Type = "int",
+                SetsValue = true
+            });
+        }
+
+        VariableListSave<string> varList = new() { Type = "string", Name = "VariableReferences" };
+        varList.Value.Add(referenceLine);
+        defaultState.VariableLists.Add(varList);
+
+        GumProjectSave project = new();
+        project.Components.Add(element);
+        ObjectFinder.Self.GumProjectSave = project;
+
+        return (defaultState, varList);
     }
 
     #endregion


### PR DESCRIPTION
## Summary

Closes #3061.

Right-clicking a **Color** swatch in the Variables tab now offers **"Copy Qualified Variable Name"**, matching normal variable rows (X, Width, etc.). The copied value (e.g. `Components/MyComp.MyInstance.Color`) can be pasted as the right-hand side of a variable reference, where `VariableReferenceLogic` expands it back into the underlying channel assignments.

This works for **every composite color** — the standard `Color`, affixed colors (`StrokeColor`, `FillColor`), and gradient channels (`Color2`).

## Background

Color isn't a normal row — the `Red`/`Green`/`Blue` channel rows (which carried the copy option) are collapsed into a single swatch (`CompositeInstanceMember`) by `CompositeMemberLogic.BuildAndInsertComposite`. The composite only re-added "Make Default" and Expose/Un-expose items, so the copy option was lost.

The reference-expansion that makes a pasted color usable was also hardcoded to exactly the standard `Color` (`leftSide == "Color" && rightSide.EndsWith(".Color")`), so affixed/gradient colors couldn't be referenced even though they're real composites.

## Changes

**Copy menu item (`CompositeMemberLogic`)**
- Adds "Copy Qualified Variable Name" to every composite swatch. A new internal `GetCompositeQualifiedName` builds the qualified name, prepending the instance name (which the composite — unlike per-channel rows — must do itself).

**Generalized reference expansion**
- `CompositeMemberDescriptor.TryGetChannelNames` — the inverse of the composite naming (`{prefix}Color{suffix}` → `{prefix}Red/Green/Blue{suffix}`). Lives on the descriptor because it already owns the channel names and name format.
- `VariableReferenceLogic` now injects `ICompositeMemberRegistry` and expands **any** registered composite reference into its channels via that single source of truth, instead of hardcoding `"Color"`. Adding a future composite (e.g. `Vector2`) needs no new control flow here.

**Shared qualified-name helper (`ObjectFinder.GetQualifiedElementName`)**
- Extracts the `Screens/`/`Components/`/`Standards/` + element-name construction that was duplicated inline in `StateReferencingInstanceMember` and `GetElementReferencesToThis`. Lives on `ObjectFinder` (the sanctioned static singleton both call sites already hold) so no new dependency had to be threaded through `StateReferencingInstanceMember`'s manual construction.

Tool-only (WYSIWYG editor) change. Reference expansion is an author-time transformation, so runtime behavior is unaffected.

## Tests

TDD throughout (red → green).

- `ObjectFinderTests` — `GetQualifiedElementName` prefixes.
- `CompositeMemberDescriptorTests` — `TryGetChannelNames` for plain/affixed/suffixed colors, and non-color rejection.
- `CompositeMemberLogicTests` — copy item added for plain and affixed colors; `GetCompositeQualifiedName` qualifies with/without an instance.
- `VariableReferenceLogicTests` — `Color`, `StrokeColor`, `FillColor`, and `Color2` references each expand to the correct three channel assignments.

Full tool unit suite: **836 passed, 5 skipped, 0 failed**. No new compiler warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
