### PR TITLE
Refresh error indicators when a variable is removed from a category

### DIFF
--- a/Gum/Plugins/InternalPlugins/Errors/MainErrorsPlugin.cs
+++ b/Gum/Plugins/InternalPlugins/Errors/MainErrorsPlugin.cs
@@ -1,6 +1,7 @@
 ﻿using CommunityToolkit.Mvvm.Messaging;
 using Gum.Commands;
 using Gum.DataTypes;
+using Gum.DataTypes.Variables;
 using Gum.Managers;
 using Gum.Messages;
 using Gum.Plugins.BaseClasses;
@@ -93,7 +94,16 @@ public class MainErrorsPlugin : PriorityPlugin
         this.InstanceAdd += HandleInstanceAdd;
         this.InstanceDelete += HandleInstanceDelete;
         this.VariableSet += HandleVariableSet;
+        this.VariableRemovedFromCategory += HandleVariableRemovedFromCategory;
         this.BehaviorReferencesChanged += HandleBehaviorReferencesChanged;
+    }
+
+    private void HandleVariableRemovedFromCategory(string variableName, StateSaveCategory category)
+    {
+        // Removing a variable from a category's states can clear an error (e.g. a GUM0003
+        // self-referential category state), so the Errors tab must refresh. The category
+        // belongs to the currently selected element.
+        UpdateErrorsForElement(_selectedState.SelectedElement);
     }
 
     private void HandleInstanceSelected(ElementSave element, InstanceSave instance)

--- a/Gum/Plugins/InternalPlugins/TreeView/MainTreeViewPlugin.cs
+++ b/Gum/Plugins/InternalPlugins/TreeView/MainTreeViewPlugin.cs
@@ -83,6 +83,7 @@ internal class MainTreeViewPlugin : PriorityPlugin, IRecipient<ApplicationTeardo
         this.GetSelectedNodes += HandleGetSelectedNodes;
 
         this.VariableSet += HandleVariableSet;
+        this.VariableRemovedFromCategory += HandleVariableRemovedFromCategory;
         this.HighlightTreeNode += HandleHighlightTreeNode;
         this.AfterUndo += HandleAfterUndo;
         this.InstanceDelete += HandleInstanceDelete;
@@ -313,6 +314,14 @@ internal class MainTreeViewPlugin : PriorityPlugin, IRecipient<ApplicationTeardo
         {
             _elementTreeViewManager.RefreshUi(instance);
         }
+    }
+
+    private void HandleVariableRemovedFromCategory(string variableName, StateSaveCategory category)
+    {
+        // Removing a variable from a category's states can clear an error (e.g. a GUM0003
+        // self-referential category state), so the "!" tree indicator must refresh. The
+        // category belongs to the currently selected element.
+        RefreshErrorIndicatorsForElement(_selectedState.SelectedElement);
     }
 
     private void HandleAfterUndo()


### PR DESCRIPTION
## Problem

Follow-up to #3055. With the new **GUM0003** check in place, the natural way to fix a flagged self-referential category state is to select the category and remove the offending variable from all its states via the garbage-can icon. But after doing so:

1. The red "!" error indicator next to the component in the tree view did not refresh.
2. The Errors tab did not refresh (it only cleared after de-selecting and re-selecting the element).

Root cause: the remove action (`VariableInCategoryPropagationLogic.AskRemoveVariableFromAllStatesInCategory`) fires the `VariableRemovedFromCategory` plugin event, but neither `MainTreeViewPlugin` nor `MainErrorsPlugin` subscribed to it — so neither error surface refreshed. (Re-selecting worked because `ElementSelected` *does* trigger an Errors-tab refresh.)

## Fix

Both plugins now subscribe to `VariableRemovedFromCategory` and refresh errors for the selected element (whose category was edited), mirroring how they already handle `VariableSet`:

- `MainTreeViewPlugin` → `RefreshErrorIndicatorsForElement(selectedElement)` (updates the "!" icon)
- `MainErrorsPlugin` → `UpdateErrorsForElement(selectedElement)` (updates the Errors tab)

## Testing

These plugins are MEF-exported and resolve services through the static `Locator`; they have no unit-test harness (their existing `VariableSet` subscriptions are likewise untested), so this is event wiring verified by building `GumFull.sln` (0 errors, no new warnings) and by the reporter's in-tool repro. Removing a GUM0003 variable now clears both the tree indicator and the Errors tab immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
