### PR TITLE
Add DrawStateSummary diagnostic for SpriteBatch begin causes

### DIFF
--- a/GumCoreShared.projitems
+++ b/GumCoreShared.projitems
@@ -92,6 +92,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)RenderingLibrary\Graphics\BatchOrchestrator.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RenderingLibrary\Graphics\BitmapCharacterInfo.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RenderingLibrary\Graphics\DrawCommand.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)RenderingLibrary\Graphics\DrawStateSummary.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RenderingLibrary\Graphics\Fonts\BitmapFont.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RenderingLibrary\Graphics\Fonts\BmfcSave.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RenderingLibrary\Graphics\Fonts\IInMemoryFontCreator.cs" />

--- a/MonoGameGum.Tests/RenderingLibraries/DrawStateSummaryTests.cs
+++ b/MonoGameGum.Tests/RenderingLibraries/DrawStateSummaryTests.cs
@@ -1,0 +1,163 @@
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using RenderingLibrary;
+using RenderingLibrary.Graphics;
+using Shouldly;
+using Xunit;
+
+namespace MonoGameGum.Tests.RenderingLibraries;
+
+/// <summary>
+/// Unit tests for <see cref="DrawStateSummary"/>, which buckets a frame's recorded
+/// <see cref="BeginParameters"/> by the cause of each SpriteBatch begin so callers can tell
+/// whether a high begin count is driven by clipping, non-clip state changes, or texture sets.
+/// </summary>
+public class DrawStateSummaryTests : BaseTestClass
+{
+    /// <summary>Minimal <see cref="IRenderableIpso"/> whose only meaningful property is <see cref="ClipsChildren"/>.</summary>
+    private sealed class FakeRenderable : IRenderableIpso
+    {
+        public FakeRenderable(bool clipsChildren)
+        {
+            ClipsChildren = clipsChildren;
+            Children = new ObservableCollection<IRenderableIpso>();
+        }
+
+        public string Name { get; set; } = "";
+        public bool Visible { get; set; }
+        public bool ClipsChildren { get; set; }
+        public bool IsRenderTarget { get; set; }
+        public ObservableCollection<IRenderableIpso> Children { get; }
+        public IRenderableIpso? Parent { get; set; }
+        IVisible? IVisible.Parent => Parent;
+        public bool AbsoluteVisible => Visible;
+        public void SetParentDirect(IRenderableIpso? newParent) => Parent = newParent;
+        public float X { get; set; }
+        public float Y { get; set; }
+        public float Z { get; set; }
+        public float Rotation { get; set; }
+        public bool FlipHorizontal { get; set; }
+        public float Width { get; set; }
+        public float Height { get; set; }
+        public object? Tag { get; set; }
+        public int Alpha => 255;
+        public ColorOperation ColorOperation => ColorOperation.Modulate;
+        public Gum.BlendState BlendState => Gum.BlendState.NonPremultiplied;
+        public bool Wrap => false;
+        public string BatchKey => "SpriteBatch";
+        public void Render(ISystemManagers managers) { }
+        public void PreRender() { }
+        public void StartBatch(ISystemManagers managers) { }
+        public void EndBatch(ISystemManagers managers) { }
+    }
+
+    private static BeginParameters MakeState(object? cause, int textureSets = 0)
+    {
+        StateChangeInfoList changeRecord = new StateChangeInfoList();
+        for (int i = 0; i < textureSets; i++)
+        {
+            changeRecord.Add(new StateChangeInfo());
+        }
+
+        return new BeginParameters
+        {
+            ObjectChangingState = cause,
+            ChangeRecord = changeRecord,
+        };
+    }
+
+    [Fact]
+    public void FromDrawStates_AttributesClipEnterAndExitToClipChanges()
+    {
+        List<BeginParameters> states = new List<BeginParameters>
+        {
+            MakeState(new FakeRenderable(clipsChildren: true)),  // clip enter
+            MakeState("Un-set ContainerRuntime Clip"),           // clip exit
+        };
+
+        DrawStateSummary summary = DrawStateSummary.FromDrawStates(states);
+
+        summary.ClipChangeBeginCount.ShouldBe(2);
+        summary.StateChangeBeginCount.ShouldBe(0);
+        summary.InitialBeginCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public void FromDrawStates_AttributesNullToInitial()
+    {
+        List<BeginParameters> states = new List<BeginParameters> { MakeState(null) };
+
+        DrawStateSummary summary = DrawStateSummary.FromDrawStates(states);
+
+        summary.InitialBeginCount.ShouldBe(1);
+        summary.ClipChangeBeginCount.ShouldBe(0);
+        summary.StateChangeBeginCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public void FromDrawStates_AttributesRenderableWithoutClipToStateChange()
+    {
+        List<BeginParameters> states = new List<BeginParameters>
+        {
+            MakeState(new FakeRenderable(clipsChildren: false)),
+        };
+
+        DrawStateSummary summary = DrawStateSummary.FromDrawStates(states);
+
+        summary.StateChangeBeginCount.ShouldBe(1);
+        summary.ClipChangeBeginCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public void FromDrawStates_BeginCountEqualsSumOfCategories()
+    {
+        List<BeginParameters> states = new List<BeginParameters>
+        {
+            MakeState(null),
+            MakeState(new FakeRenderable(clipsChildren: true)),
+            MakeState("Un-set Foo Clip"),
+            MakeState(new FakeRenderable(clipsChildren: false)),
+        };
+
+        DrawStateSummary summary = DrawStateSummary.FromDrawStates(states);
+
+        summary.BeginCount.ShouldBe(4);
+        (summary.InitialBeginCount + summary.ClipChangeBeginCount + summary.StateChangeBeginCount)
+            .ShouldBe(summary.BeginCount);
+    }
+
+    [Fact]
+    public void FromDrawStates_CarriesShapeBatchBeginCount()
+    {
+        DrawStateSummary summary = DrawStateSummary.FromDrawStates(new List<BeginParameters>(), shapeBatchBeginCount: 7);
+
+        summary.ShapeBatchBeginCount.ShouldBe(7);
+    }
+
+    [Fact]
+    public void FromDrawStates_EmptyInput_ProducesZeroCounts()
+    {
+        DrawStateSummary summary = DrawStateSummary.FromDrawStates(new List<BeginParameters>());
+
+        summary.BeginCount.ShouldBe(0);
+        summary.InitialBeginCount.ShouldBe(0);
+        summary.ClipChangeBeginCount.ShouldBe(0);
+        summary.StateChangeBeginCount.ShouldBe(0);
+        summary.TextureSetCount.ShouldBe(0);
+        summary.ShapeBatchBeginCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public void FromDrawStates_SumsTextureSetsAcrossBatches()
+    {
+        List<BeginParameters> states = new List<BeginParameters>
+        {
+            MakeState(null, textureSets: 2),
+            MakeState("Un-set Foo Clip", textureSets: 3),
+        };
+
+        DrawStateSummary summary = DrawStateSummary.FromDrawStates(states);
+
+        summary.TextureSetCount.ShouldBe(5);
+    }
+}

--- a/MonoGameGum/FnaGum/FnaGum.csproj
+++ b/MonoGameGum/FnaGum/FnaGum.csproj
@@ -65,6 +65,7 @@
 		<Compile Include="..\..\RenderingLibrary\Graphics\BatchKeyGroupedOrderer.cs" Link="RenderingLibrary\BatchKeyGroupedOrderer.cs" />
 		<Compile Include="..\..\RenderingLibrary\Graphics\BatchOrchestrator.cs" Link="RenderingLibrary\BatchOrchestrator.cs" />
 		<Compile Include="..\..\RenderingLibrary\Graphics\DrawCommand.cs" Link="RenderingLibrary\DrawCommand.cs" />
+		<Compile Include="..\..\RenderingLibrary\Graphics\DrawStateSummary.cs" Link="RenderingLibrary\DrawStateSummary.cs" />
 		<Compile Include="..\..\RenderingLibrary\Graphics\HierarchicalOrderer.cs" Link="RenderingLibrary\HierarchicalOrderer.cs" />
 		<Compile Include="..\..\RenderingLibrary\Graphics\IRenderableOrderer.cs" Link="RenderingLibrary\IRenderableOrderer.cs" />
 		<Compile Include="..\..\RenderingLibrary\Graphics\Renderer.cs" Link="RenderingLibrary\Renderer.cs" />

--- a/MonoGameGum/KniGum/KniGum.csproj
+++ b/MonoGameGum/KniGum/KniGum.csproj
@@ -92,6 +92,7 @@
 		<Compile Include="..\..\RenderingLibrary\Graphics\BatchKeyGroupedOrderer.cs" Link="RenderingLibrary\BatchKeyGroupedOrderer.cs" />
 		<Compile Include="..\..\RenderingLibrary\Graphics\BatchOrchestrator.cs" Link="RenderingLibrary\BatchOrchestrator.cs" />
 		<Compile Include="..\..\RenderingLibrary\Graphics\DrawCommand.cs" Link="RenderingLibrary\DrawCommand.cs" />
+		<Compile Include="..\..\RenderingLibrary\Graphics\DrawStateSummary.cs" Link="RenderingLibrary\DrawStateSummary.cs" />
 		<Compile Include="..\..\RenderingLibrary\Graphics\HierarchicalOrderer.cs" Link="RenderingLibrary\HierarchicalOrderer.cs" />
 		<Compile Include="..\..\RenderingLibrary\Graphics\IRenderableOrderer.cs" Link="RenderingLibrary\IRenderableOrderer.cs" />
 		<Compile Include="..\..\RenderingLibrary\Graphics\Renderer.cs" Link="RenderingLibrary\Renderer.cs" />

--- a/MonoGameGum/MonoGameGum.csproj
+++ b/MonoGameGum/MonoGameGum.csproj
@@ -208,6 +208,7 @@
 		<Compile Include="..\RenderingLibrary\Graphics\BatchKeyGroupedOrderer.cs" Link="RenderingLibrary\BatchKeyGroupedOrderer.cs" />
 		<Compile Include="..\RenderingLibrary\Graphics\BatchOrchestrator.cs" Link="RenderingLibrary\BatchOrchestrator.cs" />
 		<Compile Include="..\RenderingLibrary\Graphics\DrawCommand.cs" Link="RenderingLibrary\DrawCommand.cs" />
+		<Compile Include="..\RenderingLibrary\Graphics\DrawStateSummary.cs" Link="RenderingLibrary\DrawStateSummary.cs" />
 		<Compile Include="..\RenderingLibrary\Graphics\HierarchicalOrderer.cs" Link="RenderingLibrary\HierarchicalOrderer.cs" />
 		<Compile Include="..\RenderingLibrary\Graphics\IRenderableOrderer.cs" Link="RenderingLibrary\IRenderableOrderer.cs" />
 		<Compile Include="..\RenderingLibrary\Graphics\Renderer.cs" Link="RenderingLibrary\Renderer.cs" />

--- a/RenderingLibrary/Graphics/DrawStateSummary.cs
+++ b/RenderingLibrary/Graphics/DrawStateSummary.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Collections.Generic;
+
+namespace RenderingLibrary.Graphics
+{
+    /// <summary>
+    /// A per-frame breakdown of why <c>SpriteBatch.Begin</c> was called, derived from
+    /// <see cref="SpriteRenderer.LastFrameDrawStates"/>. Use it to diagnose what is driving a high
+    /// begin count: clipping, non-clip render-state changes (blend/color/wrap), or texture switches
+    /// within batches. <see cref="ShapeBatchBeginCount"/> surfaces the separate Apos.Shapes begin
+    /// count — the only category <see cref="BatchKeyGroupedOrderer"/> can reduce, and one that
+    /// <see cref="SpriteRenderer.LastFrameDrawStates"/> does not see.
+    /// <para>
+    /// Build one with <see cref="FromDrawStates"/>, or call <see cref="Renderer.GetDrawStateSummary"/>
+    /// for the just-completed frame.
+    /// </para>
+    /// </summary>
+    public class DrawStateSummary
+    {
+        /// <summary>Total <c>SpriteBatch.Begin</c> calls recorded for the frame — the sum of the category counts below.</summary>
+        public int BeginCount { get; private set; }
+
+        /// <summary>Begins for the first batch of a layer or render cycle. An unavoidable baseline cost.</summary>
+        public int InitialBeginCount { get; private set; }
+
+        /// <summary>
+        /// Begins caused by entering or leaving a <c>ClipsChildren</c> region. Frequently the dominant cost in
+        /// Forms-heavy UI, where each clipping container (ListBox item, ScrollViewer, etc.) forces a begin.
+        /// </summary>
+        public int ClipChangeBeginCount { get; private set; }
+
+        /// <summary>Begins caused by a non-clip render-state change: blend state, color operation, or texture wrap.</summary>
+        public int StateChangeBeginCount { get; private set; }
+
+        /// <summary>
+        /// Texture/font sets recorded within batches. These are not <c>SpriteBatch.Begin</c> calls, but each is a
+        /// GPU draw-call break inside its batch. Reduce them by atlasing sprites, fonts, and the single-pixel
+        /// texture onto shared PNGs.
+        /// </summary>
+        public int TextureSetCount { get; private set; }
+
+        /// <summary>
+        /// Apos.Shapes <c>ShapeBatch.Begin</c> calls for the frame, sourced from
+        /// <see cref="RenderStateChangeStatistics.ShapeBatchBeginCount"/>. This is the cross-batcher cost that
+        /// <see cref="BatchKeyGroupedOrderer"/> targets; when it is ~0 the grouped orderer cannot help.
+        /// </summary>
+        public int ShapeBatchBeginCount { get; private set; }
+
+        private DrawStateSummary()
+        {
+        }
+
+        /// <summary>
+        /// Buckets the supplied draw states by the cause of each begin. Pass
+        /// <see cref="SpriteRenderer.LastFrameDrawStates"/> and, optionally, the frame's
+        /// <see cref="RenderStateChangeStatistics.ShapeBatchBeginCount"/>.
+        /// </summary>
+        /// <remarks>
+        /// Cause is inferred from each begin's recorded <c>ObjectChangingState</c>: null is the initial begin,
+        /// a string is a clip-exit, a clipping <see cref="IRenderableIpso"/> is a clip-enter, and any other
+        /// renderable is a blend/color/wrap change. The clip-vs-state split is heuristic — a renderable that both
+        /// clips and changes a non-clip state in the same begin is attributed to clipping.
+        /// </remarks>
+        public static DrawStateSummary FromDrawStates(IEnumerable<BeginParameters> drawStates, int shapeBatchBeginCount = 0)
+        {
+            DrawStateSummary summary = new DrawStateSummary();
+            summary.ShapeBatchBeginCount = shapeBatchBeginCount;
+
+            foreach (BeginParameters state in drawStates)
+            {
+                summary.BeginCount++;
+
+                if (state.ChangeRecord != null)
+                {
+                    summary.TextureSetCount += state.ChangeRecord.Count;
+                }
+
+                object? cause = state.ObjectChangingState;
+                if (cause == null)
+                {
+                    summary.InitialBeginCount++;
+                }
+                else if (cause is string)
+                {
+                    // The only begin call site that passes a string is the clip-exit ("Un-set ... Clip").
+                    summary.ClipChangeBeginCount++;
+                }
+                else if (cause is IRenderableIpso ipso && ipso.ClipsChildren)
+                {
+                    summary.ClipChangeBeginCount++;
+                }
+                else
+                {
+                    summary.StateChangeBeginCount++;
+                }
+            }
+
+            return summary;
+        }
+
+        /// <inheritdoc/>
+        public override string ToString()
+        {
+            string newLine = Environment.NewLine;
+            return $"Draw State Summary: {BeginCount} SpriteBatch.Begin(s)"
+                + $"{newLine}  Initial:       {InitialBeginCount}"
+                + $"{newLine}  Clip changes:  {ClipChangeBeginCount}"
+                + $"{newLine}  State changes: {StateChangeBeginCount}"
+                + $"{newLine}  Texture sets within batches:     {TextureSetCount}"
+                + $"{newLine}  Apos.Shapes ShapeBatch.Begin(s): {ShapeBatchBeginCount}";
+        }
+    }
+}

--- a/RenderingLibrary/Graphics/Renderer.cs
+++ b/RenderingLibrary/Graphics/Renderer.cs
@@ -228,6 +228,20 @@ public class Renderer : IRenderer
     public RenderStateChangeStatistics RenderStateChangeStatistics { get; private set; }
 
     /// <summary>
+    /// Builds a <see cref="DrawStateSummary"/> for the just-completed frame, bucketing
+    /// <see cref="SpriteRenderer.LastFrameDrawStates"/> by begin cause (clip / state / texture) and folding in
+    /// the frame's Apos.Shapes begin count. Call after <see cref="Draw(SystemManagers)"/> to diagnose what is
+    /// driving the SpriteBatch.Begin count — for example, whether a high count is clipping rather than something
+    /// <see cref="BatchKeyGroupedOrderer"/> could reduce.
+    /// </summary>
+    public DrawStateSummary GetDrawStateSummary()
+    {
+        return DrawStateSummary.FromDrawStates(
+            spriteRenderer.LastFrameDrawStates,
+            RenderStateChangeStatistics.ShapeBatchBeginCount);
+    }
+
+    /// <summary>
     /// Controls which XNA BlendState is used for the Rendering Library's Blend.Normal value.
     /// </summary>
     /// <remarks>

--- a/docs/code/performance-and-optimization/batchkeygroupedorderer.md
+++ b/docs/code/performance-and-optimization/batchkeygroupedorderer.md
@@ -15,9 +15,16 @@ The default `HierarchicalOrderer` is correct and fast. The grouped orderer helps
 
 Within `SpriteBatch` alone, you can usually reduce flushes yourself by packing fonts and sprites into one atlas (see [SinglePixelTexture](singlepixeltexture.md)). Cross-batcher alternation has no such workaround — that's the case this orderer exists to fix.
 
-### Enabling the orderer
+### Choosing an orderer
 
-Assign the static `Renderer.SiblingOrdering` once during initialization. The default is `HierarchicalOrderer.Instance`.
+`Renderer.SiblingOrdering` is a swap slot: assign it one of the available orderer instances to choose how the main render pass is ordered. The shipped options are:
+
+| Set `Renderer.SiblingOrdering` to | What it does |
+|---|---|
+| `HierarchicalOrderer.Instance` *(default)* | Depth-first walk, one draw per renderable in tree order. No reordering — this is the order Gum has always used. |
+| `BatchKeyGroupedOrderer.Instance` | Reorders draws within layer- and clip-bounded windows so same-`BatchKey` runs become contiguous, cutting batch flushes. Output is pixel-identical to the default. |
+
+Note that the default and the opt-in are **different** types — `HierarchicalOrderer` versus `BatchKeyGroupedOrderer`. Assign the grouped one to turn the optimization on:
 
 ```csharp
 // Initialize
@@ -25,7 +32,7 @@ RenderingLibrary.Graphics.Renderer.SiblingOrdering =
     RenderingLibrary.Graphics.BatchKeyGroupedOrderer.Instance;
 ```
 
-You can flip the property at any time; no teardown is required. The next frame uses the new orderer.
+To switch back, assign `HierarchicalOrderer.Instance`. You can flip the property at any time; no teardown is required, and the next frame uses the new orderer.
 
 ### What it preserves
 
@@ -44,6 +51,8 @@ The grouped orderer is pixel-correct for any scene the default orderer renders c
 ### Measuring the win
 
 Use [LastFrameDrawStates](lastframedrawstates.md) to count `SpriteBatch.Begin` calls before and after enabling the orderer. The grouped orderer should reduce the count substantially on any scene that mixes `SpriteBatch` and Apos.Shapes work; it should leave a single-batcher scene unchanged.
+
+Before reaching for the orderer, confirm it can actually help: call `Renderer.GetDrawStateSummary` (see [Summarizing by cause](lastframedrawstates.md#summarizing-by-cause)) and look at the `Apos.Shapes ShapeBatch.Begin(s)` row. The orderer only collapses alternation between the `SpriteBatch` and Apos.Shapes batchers, so if that row is near zero, your begins come from clipping or texture sets instead — and the orderer will leave the count unchanged no matter what. In that case, reduce `ClipsChildren` usage or atlas your textures rather than switching orderers.
 
 {% hint style="info" %}
 `LastFrameDrawStates` only sees `SpriteBatch.Begin` calls. Apos.Shapes batch starts are not counted, so the total batch count is higher than the reported number. The orderer's effect on `SpriteBatch.Begin` is still a useful proxy for the overall trend.

--- a/docs/code/performance-and-optimization/lastframedrawstates.md
+++ b/docs/code/performance-and-optimization/lastframedrawstates.md
@@ -90,3 +90,34 @@ By Un-set ContainerRuntime Clip
 By ContainerRuntime w/ 1 Textures set(s)
 By Un-set ContainerRuntime Clip
 ```
+
+### Summarizing by cause
+
+Reading individual draw states is precise but tedious when a frame has dozens or hundreds of begins. `Renderer.GetDrawStateSummary` rolls the same data up into a count per cause, so you can see at a glance whether your begins come from clipping, non-clip render-state changes (blend/color/wrap), or texture sets within batches.
+
+```csharp
+// Draw
+DrawStateSummary summary = GumUI.SystemManagers.Renderer.GetDrawStateSummary();
+System.Diagnostics.Debug.WriteLine(summary);
+```
+
+This prints a breakdown similar to:
+
+```
+Draw State Summary: 120 SpriteBatch.Begin(s)
+  Initial:       1
+  Clip changes:  118
+  State changes: 1
+  Texture sets within batches:     40
+  Apos.Shapes ShapeBatch.Begin(s): 0
+```
+
+Use the breakdown to decide where to spend effort:
+
+* **Clip changes dominate** — each `ClipsChildren` container forces a begin on entry and another on exit. Forms controls add clipping containers freely, so a list or grid with many clipping items drives this number up. Reduce it by removing `ClipsChildren` where it isn't needed.
+* **Texture sets are high** — pack sprites, fonts, and the single-pixel texture onto shared PNGs (see [SinglePixelTexture](singlepixeltexture.md)).
+* **`Apos.Shapes` is high** — your scene mixes the `SpriteBatch` and Apos.Shapes batchers, which is the case [BatchKeyGroupedOrderer](batchkeygroupedorderer.md) targets. `SpriteBatch.Begin` counts (the other rows, and the total reported by `LastFrameDrawStates`) do not include Apos.Shapes begins, so this row is the only one the grouped orderer can reduce.
+
+{% hint style="info" %}
+The clip-versus-state split is a heuristic. Clip-exit begins are identified exactly; clip-enter begins are inferred from whether the begin's renderable clips its children. A renderable that both clips and changes a non-clip state in the same begin is counted as a clip change. The totals are exact; only the clip/state attribution is approximate.
+{% endhint %}


### PR DESCRIPTION
## What

Adds `DrawStateSummary`, a per-frame diagnostic that buckets `SpriteRenderer.LastFrameDrawStates` by the *cause* of each `SpriteBatch.Begin` so you can tell at a glance what is driving a high begin count.

`Renderer.GetDrawStateSummary()` is the one-call entry point. It combines `LastFrameDrawStates` with `RenderStateChangeStatistics.ShapeBatchBeginCount` and has a readable `ToString()`:

```
Draw State Summary: 120 SpriteBatch.Begin(s)
  Initial:       1
  Clip changes:  118
  State changes: 1
  Texture sets within batches:     40
  Apos.Shapes ShapeBatch.Begin(s): 0
```

## Why

Reading a high begin count off `LastFrameDrawStates` one entry at a time is tedious, and the list does not surface the Apos.Shapes `ShapeBatch.Begin` count at all. That shape count is the *only* category `BatchKeyGroupedOrderer` can reduce, so without it there is no way to tell whether the grouped orderer can help a given scene or whether the cost is clipping / texture sets instead.

## Notes

- **No hot-path changes.** The aggregation is read-only over data already recorded during rendering, so the delicate (and FRB1-shared) `BeginSpriteBatch` / `SpriteBatchStack` path is untouched and rendering cannot regress.
- Cause is inferred from each begin's recorded `ObjectChangingState`: null = initial, string = clip-exit, clipping renderable = clip-enter, any other renderable = blend/color/wrap. The clip-vs-state split is heuristic (documented in a hint block); the totals are exact.
- Project files kept in sync for the new `RenderingLibrary/Graphics` file: `MonoGameGum.csproj`, `KniGum.csproj`, `FnaGum.csproj`, and `GumCoreShared.projitems` (FRB1).

## Tests

- 7 new `DrawStateSummaryTests` (TDD: written red against a stub, then implemented to green).
- Full `RenderingLibraries` suite green: 101/101.

## Docs

- New "Summarizing by cause" section on `lastframedrawstates.md` with the snippet, sample output, and a how-to-act-on-it list.
- Cross-link from `batchkeygroupedorderer.md` "Measuring the win" telling you to check the `Apos.Shapes` row before switching orderers.
