### PR TITLE
Suppress O(N) sibling relayout on descendant change under depends-on-children parents (#3066)

### DIFF
--- a/.claude/skills/gum-layout-engine/SKILL.md
+++ b/.claude/skills/gum-layout-engine/SKILL.md
@@ -170,6 +170,54 @@ Returns true if:
 When true, `UpdateLayout` delegates to the parent (step 3 above) instead of
 laying out the element directly. The parent will re-lay out all children.
 
+### The climb decision is structural, not value-based
+
+The climb fires on *topology* — "does the parent stack / depend on children /
+have ratio siblings" — never on whether this element's contribution to the
+parent actually changed. So a one-pixel-irrelevant change to a deeply nested
+element still delegates the whole layout to the topmost dependent ancestor,
+which re-lays out **all** its children. This is why a single change inside one
+item of an N-item stack costs O(N): there is no "did my contribution change?"
+guard before climbing.
+
+### Two climb sites, two depths
+
+- **Top climb** (early-out, step 3): delegates the *entire* layout to the
+  parent *before measuring self*, propagating with `childrenUpdateDepth + 1`.
+  This is the one that actually fires and drives full re-layout.
+- **Bottom climb** (end of `UpdateLayout`): calls the parent with
+  `UpdateLayout(false, false)` → depth **0** (parent re-measures itself but does
+  **not** re-lay out siblings). It is guarded by the *same* condition the top
+  climb already `return`ed on, so on the climb path it is effectively
+  unreachable — a known dead branch, not a second propagation.
+
+### Visibility changes propagate through TWO paths
+
+A visibility toggle does not go through one code path:
+- Becoming **invisible**: the `Visible` setter force-updates the parent
+  *directly* (when the parent stacks / auto-grids / depends on children),
+  independent of `UpdateLayout`'s climb.
+- Becoming **visible**: flows through `UpdateLayout`'s normal climb.
+
+The trap for any "skip the climb unless something changed" optimization: an
+element's **own measured size is unchanged** across a visibility toggle, but its
+**contribution to a content-sized parent** changes (full extent → 0). So a guard
+phrased as "climb only if *my* size changed" is wrong for visibility — it
+silently drops the grow-back when a size-*determining* child reappears. The
+trustworthy signal is the **parent's** size delta after the parent re-measures,
+not the changed element's own size delta. Likewise, for a resize the child's own
+size delta and its contribution coincide, but for visibility they do not.
+
+### Where the O(N) sibling cost actually lives
+
+The expensive part of a climb is the **stacking / auto-grid / ratio** relayout —
+that is what repositions every sibling. A purely *content-sized* (Regular,
+non-stacking) parent has no sibling-reposition cost; its only cost is
+re-measuring ancestors. So suppressing sibling-relayout for a stacked list
+(e.g. ListBox) requires gating the **stacking** climb, which is harder than
+gating the depends-on-children climb (it must also honor the visibility/contribution
+trap above for siblings that stack past an element).
+
 ## Performance Patterns
 
 | Optimization | What it avoids | Where |

--- a/.claude/skills/gum-layout-engine/SKILL.md
+++ b/.claude/skills/gum-layout-engine/SKILL.md
@@ -26,10 +26,12 @@ Entry point: `UpdateLayout(ParentUpdateType, int childrenUpdateDepth, XOrY?)`
    and not needed for parent update, call `MakeDirty()` and return. Invisible
    elements also exit if parent is invisible (unless render target).
 
-3. **Early out — propagate to parent** — if `updateParent` is true AND
-   `GetIfShouldCallUpdateOnParent()` is true, call `parent.UpdateLayout()` with
-   `childrenUpdateDepth + 1` and **return**. The parent's layout will update
-   this element as a child. This is how child changes bubble up.
+3. **Propagate to parent (originating call only)** — if `updateParent` AND
+   `GetIfShouldCallUpdateOnParent()`, the *originating* call (the element that
+   changed) hands off to `parent.UpdateLayout()` with `childrenUpdateDepth + 1`
+   and **returns**; the parent lays this element out as a child. A *propagated*
+   climb (already size-gated — see Upward Propagation) instead falls through and
+   re-evaluates whether to keep climbing at the end of the method.
 
 4. **Clear dirty state** — `currentDirtyState = null`. This is critical: it
    prevents double-updates during `ResumeLayoutUpdateIfDirtyRecursive` (see
@@ -61,8 +63,10 @@ Entry point: `UpdateLayout(ParentUpdateType, int childrenUpdateDepth, XOrY?)`
     all children. Children already updated in step 6 are skipped via
     `alreadyUpdated` set.
 
-12. **Post-layout dimension check** — if size changed and parent depends on
-    children, re-update dimensions. If still changed, update parent.
+12. **Post-layout dimension check + gated climb** — re-update dimensions if a
+    child change could have altered them; then, for a propagated climb, continue
+    up to the parent only if this element's own measured size or position
+    actually changed (see Upward Propagation).
 
 ### Deferred font realization (step 4.5)
 
@@ -167,56 +171,44 @@ Returns true if:
 - Parent stacks children (any non-Regular `ChildrenLayout`)
 - Any sibling uses `Ratio` width/height
 
-When true, `UpdateLayout` delegates to the parent (step 3 above) instead of
-laying out the element directly. The parent will re-lay out all children.
+When true, the *originating* call delegates to the parent (flow step 3);
+*propagated* climbs above it are additionally size-gated (see below).
 
-### The climb decision is structural, not value-based
+### Upward propagation is incremental and size-gated
 
-The climb fires on *topology* — "does the parent stack / depend on children /
-have ratio siblings" — never on whether this element's contribution to the
-parent actually changed. So a one-pixel-irrelevant change to a deeply nested
-element still delegates the whole layout to the topmost dependent ancestor,
-which re-lays out **all** its children. This is why a single change inside one
-item of an N-item stack costs O(N): there is no "did my contribution change?"
-guard before climbing.
+A change climbs one level so the parent can re-measure, then continues to the
+grandparent and beyond **only while each level's own measured size or position
+keeps changing**. When a level re-measures unchanged, propagation stops there —
+its siblings and ancestors are not relaid out. That is what keeps a change inside
+one item of an N-item stack from costing O(N-siblings).
 
-### Two climb sites, two depths
+The element that actually changed (the *originating* call) always notifies its
+parent **unconditionally**, so the parent can re-measure; only the *propagated*
+climbs above it are size-gated. The `gateClimbOnSizeChange` flag distinguishes
+the two. Why the source can't gate itself:
 
-- **Top climb** (early-out, step 3): delegates the *entire* layout to the
-  parent *before measuring self*, propagating with `childrenUpdateDepth + 1`.
-  This is the one that actually fires and drives full re-layout.
-- **Bottom climb** (end of `UpdateLayout`): calls the parent with
-  `UpdateLayout(false, false)` → depth **0** (parent re-measures itself but does
-  **not** re-lay out siblings). It is guarded by the *same* condition the top
-  climb already `return`ed on, so on the climb path it is effectively
-  unreachable — a known dead branch, not a second propagation.
+> An element's own size delta is **not** the same as its contribution to a
+> content-sized or stacking parent. The clearest case is **visibility**: size is
+> unchanged when an element is hidden or shown, but its contribution flips (full
+> extent ↔ 0). Only the parent, by re-measuring, can tell whether the change
+> matters. Gating at the source on the source's own size would silently drop
+> visibility-driven (and add/remove) changes, because the parent would never
+> re-measure.
+
+`RelativeToMaxParentOrChildren` always propagates regardless of its own delta:
+its size is the max of its content and its parent, so a content change can be
+masked by a (stale) parent size while it still feeds the parent's size.
 
 ### Visibility changes propagate through TWO paths
 
-A visibility toggle does not go through one code path:
-- Becoming **invisible**: the `Visible` setter force-updates the parent
-  *directly* (when the parent stacks / auto-grids / depends on children),
-  independent of `UpdateLayout`'s climb.
-- Becoming **visible**: flows through `UpdateLayout`'s normal climb.
+A visibility toggle is not one code path:
+- Becoming **invisible**: the `Visible` setter updates the parent *directly*
+  (when the parent stacks / auto-grids / depends on children), separately from
+  `UpdateLayout`'s climb.
+- Becoming **visible**: flows through `UpdateLayout`'s normal (originating) climb.
 
-The trap for any "skip the climb unless something changed" optimization: an
-element's **own measured size is unchanged** across a visibility toggle, but its
-**contribution to a content-sized parent** changes (full extent → 0). So a guard
-phrased as "climb only if *my* size changed" is wrong for visibility — it
-silently drops the grow-back when a size-*determining* child reappears. The
-trustworthy signal is the **parent's** size delta after the parent re-measures,
-not the changed element's own size delta. Likewise, for a resize the child's own
-size delta and its contribution coincide, but for visibility they do not.
-
-### Where the O(N) sibling cost actually lives
-
-The expensive part of a climb is the **stacking / auto-grid / ratio** relayout —
-that is what repositions every sibling. A purely *content-sized* (Regular,
-non-stacking) parent has no sibling-reposition cost; its only cost is
-re-measuring ancestors. So suppressing sibling-relayout for a stacked list
-(e.g. ListBox) requires gating the **stacking** climb, which is harder than
-gating the depends-on-children climb (it must also honor the visibility/contribution
-trap above for siblings that stack past an element).
+Both rely on the parent re-measuring — see the contribution-vs-size trap above
+for why the parent, not the toggled element, is the source of truth.
 
 ## Performance Patterns
 
@@ -233,3 +225,19 @@ trap above for siblings that stack past an element).
 
 - `UpdateLayoutCallCount` — total layout calls (incremented after parent propagation check)
 - `ChildrenUpdatingParentLayoutCalls` — times a child triggered parent relayout
+
+### Verifying propagation (and a test-isolation caution)
+
+`UpdateLayoutCallCount` deltas are how you assert propagation didn't over-fire:
+build an N-item stack, make a change that *shouldn't* affect siblings, and assert
+the delta stays flat as N grows rather than scaling. See the layout-call-count
+tests in `LayoutUnitTests`.
+
+If an engine change instead makes the **RaylibGum draw-call-count** tests fail,
+suspect pre-existing **test isolation** before suspecting your change. Those tests
+assert exact draw-call deltas and are sensitive to renderables leaked onto the
+shared layer (an `AddToManagers` with no matching `RemoveFromManagers`); combined
+with run-to-run test ordering that is flaky *on a clean tree too*. A layout change
+can shift render batching just enough to change how often the latent flake trips —
+confirm by running the suite repeatedly on the base branch before assuming you
+caused it.

--- a/GumRuntime/GraphicalUiElement.cs
+++ b/GumRuntime/GraphicalUiElement.cs
@@ -374,8 +374,10 @@ public partial class GraphicalUiElement : IRenderableIpso, IVisible, INotifyProp
 
                 if (!absoluteVisible && (GetIfParentStacks() || GetIfParentIsAutoGrid() || GetIfParentWidthHeightDependOnChildren()))
                 {
-                    // This updates the parent right away:
-                    Parent?.UpdateLayout(ParentUpdateType.IfParentStacks | ParentUpdateType.IfParentWidthHeightDependOnChildren | ParentUpdateType.IfParentIsAutoGrid, int.MaxValue / 2, null);
+                    // This updates the parent right away. #3066: gate the climb on the parent's size
+                    // delta so hiding a descendant that doesn't change the item's size doesn't relayout
+                    // every sibling in a stacking parent.
+                    Parent?.UpdateLayout(ParentUpdateType.IfParentStacks | ParentUpdateType.IfParentWidthHeightDependOnChildren | ParentUpdateType.IfParentIsAutoGrid, int.MaxValue / 2, null, gateClimbOnSizeChange: true);
 
                 }
                 VisibleChanged?.Invoke(this, EventArgs.Empty);
@@ -1862,7 +1864,12 @@ public partial class GraphicalUiElement : IRenderableIpso, IVisible, INotifyProp
     /// the update type. For example if ParentUpdateType.IfParentStacks is passed, then an update happens if the parent stacks its children.</param>
     /// <param name="childrenUpdateDepth"></param>
     /// <param name="xOrY"></param>
-    public void UpdateLayout(ParentUpdateType parentUpdateType, int childrenUpdateDepth, XOrY? xOrY = null)
+    /// <param name="gateClimbOnSizeChange">#3066: false for the originating call (the element whose
+    /// property changed / was added), which always climbs one level so its parent re-measures; true
+    /// for the propagated climbs above that, which only continue upward if their own measured size or
+    /// position actually changed. This suppresses the O(N) relayout of a parent's other children when
+    /// a descendant change does not alter the intermediate element's contribution to the parent.</param>
+    public void UpdateLayout(ParentUpdateType parentUpdateType, int childrenUpdateDepth, XOrY? xOrY = null, bool gateClimbOnSizeChange = false)
     {
         var updateParent =
             ((parentUpdateType & ParentUpdateType.All) == ParentUpdateType.All) ||
@@ -1932,11 +1939,21 @@ public partial class GraphicalUiElement : IRenderableIpso, IVisible, INotifyProp
         // should update the components
         if (updateParent && GetIfShouldCallUpdateOnParent())
         {
-            var asGue = this.Parent as GraphicalUiElement;
-            // Just climb up one and update from there
-            asGue.UpdateLayout(parentUpdateType, childrenUpdateDepth + 1);
-            ChildrenUpdatingParentLayoutCalls++;
-            return;
+            // #3066: The originating call (gateClimbOnSizeChange == false) climbs unconditionally so
+            // the parent re-measures and accounts for this change (add/remove/visibility/size/etc.) —
+            // this preserves the original eager behavior for the element that actually changed. Each
+            // propagated climb above that runs with gateClimbOnSizeChange == true and falls through to
+            // measure itself; it only continues upward (at the end of this method) if its own size or
+            // position changed, so a parent's other children aren't relaid out when nothing material
+            // changed for them.
+            if (!gateClimbOnSizeChange)
+            {
+                var asGue = this.Parent as GraphicalUiElement;
+                // Just climb up one and update from there
+                asGue.UpdateLayout(parentUpdateType, childrenUpdateDepth + 1, gateClimbOnSizeChange: true);
+                ChildrenUpdatingParentLayoutCalls++;
+                return;
+            }
         }
         // This should be *after* the return when updating the parent otherwise we double-count layouts
         UpdateLayoutCallCount++;
@@ -2236,11 +2253,29 @@ public partial class GraphicalUiElement : IRenderableIpso, IVisible, INotifyProp
             }
         }
 
-        // Eventually add more conditions here to make it fire less often
-        // like check the width/height of the parent to see if they're 0
-        if (updateParent && GetIfShouldCallUpdateOnParent())
+        // #3066: propagated climb (see the gate near the top of this method). We were reached via a
+        // descendant's climb (gateClimbOnSizeChange == true) and have now laid out locally; continue
+        // upward only if our own measured size or position actually changed. Otherwise our
+        // contribution to the parent is unchanged and relaying out the parent's other children (e.g.
+        // every sibling in a stack) would be wasted O(N) work. Without a renderable we can't measure
+        // a delta, so climb to stay safe.
+        var sizeOrPositionChanged = mContainedObjectAsIpso == null
+            || widthBeforeLayout != mContainedObjectAsIpso.Width
+            || heightBeforeLayout != mContainedObjectAsIpso.Height
+            || xBeforeLayout != mContainedObjectAsIpso.X
+            || yBeforeLayout != mContainedObjectAsIpso.Y;
+
+        // RelativeToMaxParentOrChildren takes the max of this element's own content size and its
+        // parent's size, so a content change here can be masked by the (stale) parent size — our own
+        // measured size won't change even though the parent's RelativeToChildren size must. Always
+        // climb in that case so the parent re-measures from content.
+        var dependsOnMaxOfParentOrChildren = this.WidthUnits == DimensionUnitType.RelativeToMaxParentOrChildren
+            || this.HeightUnits == DimensionUnitType.RelativeToMaxParentOrChildren;
+
+        if (gateClimbOnSizeChange && updateParent && GetIfShouldCallUpdateOnParent()
+            && (sizeOrPositionChanged || dependsOnMaxOfParentOrChildren))
         {
-            Parent?.UpdateLayout(false, false);
+            (this.Parent as GraphicalUiElement)?.UpdateLayout(parentUpdateType, childrenUpdateDepth + 1, gateClimbOnSizeChange: true);
             ChildrenUpdatingParentLayoutCalls++;
         }
         if (this.mContainedObjectAsIpso != null)

--- a/MonoGameGum.Tests/Runtimes/LayoutUnitTests.cs
+++ b/MonoGameGum.Tests/Runtimes/LayoutUnitTests.cs
@@ -2502,6 +2502,138 @@ public class LayoutUnitTests : BaseTestClass
 
     #endregion
 
+    #region Descendant Change Propagation Under Stacking (issue #3066 invariants)
+
+    // These tests pin the correctness invariants that any "suppress redundant relayout"
+    // optimization for #3066 must preserve: when a descendant of a content-sized item that
+    // lives in a stack changes, following siblings must reposition iff the item's size
+    // actually changed — and must NOT drift when it did not.
+
+    [Fact]
+    public void GrandchildResize_ChangingItemHeight_RepositionsFollowingItemsInStack()
+    {
+        ContainerRuntime stack = new();
+        stack.Height = 0;
+        stack.HeightUnits = DimensionUnitType.RelativeToChildren;
+        stack.ChildrenLayout = Gum.Managers.ChildrenLayout.TopToBottomStack;
+
+        ContainerRuntime item0 = new();
+        item0.Height = 0;
+        item0.HeightUnits = DimensionUnitType.RelativeToChildren;
+        stack.AddChild(item0);
+
+        // The size-determining descendant (a grandchild of the stack).
+        ContainerRuntime determiner = new();
+        determiner.Height = 30;
+        determiner.HeightUnits = DimensionUnitType.Absolute;
+        item0.AddChild(determiner);
+
+        ContainerRuntime item1 = new();
+        item1.Height = 0;
+        item1.HeightUnits = DimensionUnitType.RelativeToChildren;
+        stack.AddChild(item1);
+
+        ContainerRuntime item1Child = new();
+        item1Child.Height = 30;
+        item1Child.HeightUnits = DimensionUnitType.Absolute;
+        item1.AddChild(item1Child);
+
+        item1.AbsoluteTop.ShouldBe(30);
+
+        // Growing the descendant grows item0, which must push item1 down.
+        determiner.Height = 50;
+        item1.AbsoluteTop.ShouldBe(50);
+    }
+
+    [Fact]
+    public void GrandchildVisibilityToggle_ChangingItemHeight_RepositionsFollowingItemsInStack()
+    {
+        ContainerRuntime stack = new();
+        stack.Height = 0;
+        stack.HeightUnits = DimensionUnitType.RelativeToChildren;
+        stack.ChildrenLayout = Gum.Managers.ChildrenLayout.TopToBottomStack;
+
+        ContainerRuntime item0 = new();
+        item0.Height = 0;
+        item0.HeightUnits = DimensionUnitType.RelativeToChildren;
+        stack.AddChild(item0);
+
+        // The only descendant of item0, so its visibility determines item0's height.
+        ContainerRuntime determiner = new();
+        determiner.Height = 30;
+        determiner.HeightUnits = DimensionUnitType.Absolute;
+        item0.AddChild(determiner);
+
+        ContainerRuntime item1 = new();
+        item1.Height = 0;
+        item1.HeightUnits = DimensionUnitType.RelativeToChildren;
+        stack.AddChild(item1);
+
+        ContainerRuntime item1Child = new();
+        item1Child.Height = 30;
+        item1Child.HeightUnits = DimensionUnitType.Absolute;
+        item1.AddChild(item1Child);
+
+        item1.AbsoluteTop.ShouldBe(30);
+
+        // Hiding the size-determiner collapses item0 to 0, so item1 must move up.
+        determiner.Visible = false;
+        item1.AbsoluteTop.ShouldBe(0);
+
+        // Showing it again must restore item0's height and push item1 back down.
+        determiner.Visible = true;
+        item1.AbsoluteTop.ShouldBe(30);
+    }
+
+    [Fact]
+    public void GrandchildVisibilityToggle_NotChangingItemHeight_KeepsFollowingItemsInStack()
+    {
+        ContainerRuntime stack = new();
+        stack.Height = 0;
+        stack.HeightUnits = DimensionUnitType.RelativeToChildren;
+        stack.ChildrenLayout = Gum.Managers.ChildrenLayout.TopToBottomStack;
+
+        ContainerRuntime item0 = new();
+        item0.Height = 0;
+        item0.HeightUnits = DimensionUnitType.RelativeToChildren;
+        stack.AddChild(item0);
+
+        // This child determines item0's height (30).
+        ContainerRuntime sizer = new();
+        sizer.Height = 30;
+        sizer.HeightUnits = DimensionUnitType.Absolute;
+        sizer.Y = 0;
+        item0.AddChild(sizer);
+
+        // This smaller child at the same origin never determines item0's height, so toggling
+        // its visibility must NOT change item0's size or move item1.
+        ContainerRuntime nonDeterminer = new();
+        nonDeterminer.Height = 10;
+        nonDeterminer.HeightUnits = DimensionUnitType.Absolute;
+        nonDeterminer.Y = 0;
+        item0.AddChild(nonDeterminer);
+
+        ContainerRuntime item1 = new();
+        item1.Height = 0;
+        item1.HeightUnits = DimensionUnitType.RelativeToChildren;
+        stack.AddChild(item1);
+
+        ContainerRuntime item1Child = new();
+        item1Child.Height = 30;
+        item1Child.HeightUnits = DimensionUnitType.Absolute;
+        item1.AddChild(item1Child);
+
+        item1.AbsoluteTop.ShouldBe(30);
+
+        nonDeterminer.Visible = false;
+        item1.AbsoluteTop.ShouldBe(30);
+
+        nonDeterminer.Visible = true;
+        item1.AbsoluteTop.ShouldBe(30);
+    }
+
+    #endregion
+
     #region Nested Layout Propagation
 
     [Fact]
@@ -7081,6 +7213,89 @@ public class LayoutUnitTests : BaseTestClass
         // Global suspension should result in fewer layout calls
         // since changes are batched and applied once on resume
         suspendedCalls.ShouldBeLessThan(unsuspendedCalls);
+    }
+
+    // Builds an N-item TopToBottomStack of content-sized (RelativeToChildren) items. Each item
+    // has a height-determining "sizer" child (30) and a smaller "non-determiner" child (10) at the
+    // same origin, so toggling/resizing the non-determiner never changes the item's height. Returns
+    // the first item's non-determiner — the descendant whose change should NOT relayout siblings.
+    private static (ContainerRuntime stack, ContainerRuntime firstNonDeterminer) BuildStackOfContentSizedItems(int itemCount)
+    {
+        ContainerRuntime stack = new();
+        stack.Height = 0;
+        stack.HeightUnits = DimensionUnitType.RelativeToChildren;
+        stack.Width = 200;
+        stack.WidthUnits = DimensionUnitType.Absolute;
+        stack.ChildrenLayout = Gum.Managers.ChildrenLayout.TopToBottomStack;
+
+        ContainerRuntime firstNonDeterminer = null!;
+        for (int i = 0; i < itemCount; i++)
+        {
+            ContainerRuntime item = new();
+            item.Height = 0;
+            item.HeightUnits = DimensionUnitType.RelativeToChildren;
+            item.Width = 200;
+            item.WidthUnits = DimensionUnitType.Absolute;
+            stack.AddChild(item);
+
+            ContainerRuntime sizer = new();
+            sizer.Height = 30;
+            sizer.HeightUnits = DimensionUnitType.Absolute;
+            sizer.Y = 0;
+            item.AddChild(sizer);
+
+            ContainerRuntime nonDeterminer = new();
+            nonDeterminer.Height = 10;
+            nonDeterminer.HeightUnits = DimensionUnitType.Absolute;
+            nonDeterminer.Y = 0;
+            item.AddChild(nonDeterminer);
+
+            if (i == 0)
+            {
+                firstNonDeterminer = nonDeterminer;
+            }
+        }
+
+        stack.UpdateLayout();
+        return (stack, firstNonDeterminer);
+    }
+
+    [Fact]
+    public void GrandchildResize_NotChangingItemSize_DoesNotScaleLayoutCallsWithSiblingCount()
+    {
+        var (_, smallNonDeterminer) = BuildStackOfContentSizedItems(3);
+        var (_, largeNonDeterminer) = BuildStackOfContentSizedItems(30);
+
+        int before = GraphicalUiElement.UpdateLayoutCallCount;
+        smallNonDeterminer.Height = 15; // still < 30, so the item's height does not change
+        int smallDelta = GraphicalUiElement.UpdateLayoutCallCount - before;
+
+        before = GraphicalUiElement.UpdateLayoutCallCount;
+        largeNonDeterminer.Height = 15;
+        int largeDelta = GraphicalUiElement.UpdateLayoutCallCount - before;
+
+        // The work for a resize that does not change the item's size must not grow with sibling count.
+        largeDelta.ShouldBeLessThanOrEqualTo(smallDelta + 5);
+    }
+
+    [Fact]
+    public void GrandchildVisibilityToggle_NotChangingItemSize_DoesNotScaleLayoutCallsWithSiblingCount()
+    {
+        var (_, smallNonDeterminer) = BuildStackOfContentSizedItems(3);
+        var (_, largeNonDeterminer) = BuildStackOfContentSizedItems(30);
+
+        int before = GraphicalUiElement.UpdateLayoutCallCount;
+        smallNonDeterminer.Visible = false;
+        smallNonDeterminer.Visible = true;
+        int smallDelta = GraphicalUiElement.UpdateLayoutCallCount - before;
+
+        before = GraphicalUiElement.UpdateLayoutCallCount;
+        largeNonDeterminer.Visible = false;
+        largeNonDeterminer.Visible = true;
+        int largeDelta = GraphicalUiElement.UpdateLayoutCallCount - before;
+
+        // The work for a visibility toggle that does not change the item's size must not grow with sibling count.
+        largeDelta.ShouldBeLessThanOrEqualTo(smallDelta + 5);
     }
 
     #endregion

--- a/Tests/RaylibGum.Tests/BaseTestClass.cs
+++ b/Tests/RaylibGum.Tests/BaseTestClass.cs
@@ -2,6 +2,8 @@
 using Gum.Wireframe;
 using Raylib_cs;
 using Gum.Input;
+using RenderingLibrary;
+using RenderingLibrary.Graphics;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -14,6 +16,30 @@ namespace RaylibGum.Tests;
 
 public class BaseTestClass : IDisposable
 {
+    // #3066: renderables present right after the assembly bootstrap (Root + Forms defaults).
+    // Anything found on a layer beyond this set was added by a test — typically via AddToManagers
+    // without a matching RemoveFromManagers — and is swept in Dispose. Left in place, a leaked
+    // renderable persists on the shared layer and corrupts later draw-call-count assertions (the
+    // leak coalesces with other tests' content), which surfaced as order-dependent flaky failures.
+    private static readonly HashSet<IRenderableIpso> BaselineRenderables = new();
+
+    /// <summary>
+    /// Records the renderables currently on the renderer's layers as the per-test baseline. Called
+    /// once from the assembly bootstrap (and again after any Uninitialize/re-init) so Dispose can
+    /// sweep anything a test leaks beyond it.
+    /// </summary>
+    internal static void CaptureRenderableBaseline()
+    {
+        BaselineRenderables.Clear();
+        foreach (Layer layer in SystemManagers.Default.Renderer.Layers)
+        {
+            foreach (IRenderableIpso renderable in layer.Renderables)
+            {
+                BaselineRenderables.Add(renderable);
+            }
+        }
+    }
+
     public BaseTestClass()
     {
         GumService.Default.InitializeForTesting();
@@ -59,6 +85,19 @@ public class BaseTestClass : IDisposable
         InteractiveGue.ClearNextClickActions();
 
         GumService.Default.Root.Children!.Clear();
+
+        // #3066: sweep any renderables a test added straight to the renderer layers via
+        // AddToManagers without a matching RemoveFromManagers. Clearing Root.Children above does not
+        // reach those (they are not Root children), so without this they leak across tests. See
+        // BaselineRenderables.
+        foreach (Layer layer in SystemManagers.Default.Renderer.Layers)
+        {
+            List<IRenderableIpso> leaked = layer.Renderables.Where(r => !BaselineRenderables.Contains(r)).ToList();
+            foreach (IRenderableIpso renderable in leaked)
+            {
+                layer.Remove(renderable);
+            }
+        }
 
         // Why aren't these available?
         //GumService.Default.ModalRoot.Children!.Clear();

--- a/Tests/RaylibGum.Tests/TestAssemblyInitialize.cs
+++ b/Tests/RaylibGum.Tests/TestAssemblyInitialize.cs
@@ -81,6 +81,11 @@ public class TestAssemblyInitialize : XunitTestFramework
 
         GumService.Default.Root.UpdateLayout();
 
+        // #3066: record the post-bootstrap renderables (Root + Forms defaults) so BaseTestClass.Dispose
+        // can sweep anything a test leaks onto the shared layers, keeping draw-call-count tests
+        // isolated from each other regardless of run order.
+        BaseTestClass.CaptureRenderableBaseline();
+
         // Intentionally do NOT call GumService.Default.UseKeyboardDefaults() here.
         // KeyCombo.IsComboPushed returns inside the first iteration of
         // FrameworkElement.KeyboardsForUiControl, so leaving the real Raylib keyboard


### PR DESCRIPTION
Closes #3066

## Problem

`UpdateLayout` climbed to the parent at the **top** of the method — before measuring self — whenever the parent stacks, depends on children, or has ratio children. So a change to one descendant delegated the entire layout to the topmost dependent ancestor, which re-laid out **every** sibling: `O(N-siblings)` work even when the descendant's change didn't alter its contribution to the parent (the canonical case: toggling a non-size-determining child inside a `ListBoxItem` inside a `ListBox`).

## Fix

Parent-centric gating in `GraphicalUiElement.UpdateLayout`:

- The **originating** call still climbs one level unconditionally, so the parent re-measures and accounts for the change (add/remove/visibility/size all stay correct).
- Each **propagated** climb above that (`gateClimbOnSizeChange`) falls through, measures itself, and only continues upward if **its own** measured size or position actually changed — so a parent's other children aren't relaid out when nothing material changed for them.
- `RelativeToMaxParentOrChildren` always climbs: its own size can be masked by a stale parent size while its content still feeds the parent's `RelativeToChildren` size.

This collapses the no-op cases from `O(N)` to `O(1)` while leaving correctness identical (the cost is paid only when a size/position actually changes, and is bounded to the originating chain — never the siblings).

## Tests

- New layout-call-count perf tests: a non-size-changing grandchild **toggle** and **resize** no longer scale with sibling count.
- New correctness pins for descendant changes under stacking (reposition iff the item's size actually changed; no drift when it doesn't).

## Bonus: pre-existing RaylibGum test-isolation bug

While validating across backends, the RaylibGum draw-call-count tests turned out to be **flaky on the base branch too** (reproduced: a clean `main` run failed 5 tests with no source change). Root cause: `AddToManagers_PutsRenderableOnLayer` leaks a renderable onto the shared layer, and `BaseTestClass.Dispose` only cleared `Root.Children` — so the leak corrupted later draw-call-count assertions depending on xUnit's run-to-run class ordering. This change only shifted render batching enough to change *how often* the latent bug tripped.

Fixed at the infrastructure level: `Dispose` now sweeps any renderable added beyond the post-bootstrap baseline, so no test can leak onto the shared layers. Verified stable (6/6 runs with the change, 5/5 on base with just the test fix).

## Verification

All green: MonoGameGum **1620**, V2 **109**, V3 **59**, SkiaGum **185**, RaylibGum **296** (stable across repeated runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
