### PR TITLE
Clarify parent-climb control flow in UpdateLayout (#3067)

### DIFF
--- a/GumRuntime/GraphicalUiElement.cs
+++ b/GumRuntime/GraphicalUiElement.cs
@@ -1910,7 +1910,7 @@ public partial class GraphicalUiElement : IRenderableIpso, IVisible, INotifyProp
 
         #endregion
 
-        #region Early Out - Update Parent and exit
+        #region Originating-call parent climb (early-out; see #3066)
 
         currentDirtyState = null;
 
@@ -4555,6 +4555,18 @@ public partial class GraphicalUiElement : IRenderableIpso, IVisible, INotifyProp
     }
 
 
+    /// <summary>
+    /// Returns whether a layout change on this element must notify its parent — i.e. whether the
+    /// parent's own layout structurally depends on this child: the parent content-sizes
+    /// (GetIfDimensionsDependOnChildren), stacks its children, or has any Ratio-sized sibling.
+    /// </summary>
+    /// <remarks>
+    /// This is a purely STRUCTURAL check — it does not consider whether anything actually changed.
+    /// It is called from both parent-climb sites in UpdateLayout: the unconditional originating
+    /// climb and the size-gated propagated climb (#3066). The "did anything change?" gating lives
+    /// at those call sites, not here, which is why the same predicate appears in two places with
+    /// different surrounding conditions.
+    /// </remarks>
     bool GetIfShouldCallUpdateOnParent()
     {
         var asGue = this.Parent as GraphicalUiElement;


### PR DESCRIPTION
## Summary

Documentation-only clarification of the two parent-climb blocks in `GraphicalUiElement.UpdateLayout`, the maintainability concern raised in #3067.

That issue was filed *before* #3066 landed. #3066 already resolved the underlying problem — the two climb sites are no longer guarded by an identical condition:

- the **originating** climb (top) fires only when `!gateClimbOnSizeChange`, and
- the **propagated** climb (bottom) fires only when `gateClimbOnSizeChange && ... && (sizeOrPositionChanged || dependsOnMaxOfParentOrChildren)`.

So the bottom block is reachable and intentional, not dead code. What was missing was a signpost making that now-deliberate asymmetry self-explanatory to the next reader. This PR adds it.

## Changes

- **Doc comment on `GetIfShouldCallUpdateOnParent`** — states it is a purely *structural* check (parent content-sizes / stacks / has Ratio siblings) called from *both* climb sites, and that the "did anything change?" gating lives at the call sites, not in the helper. This directly answers why the same predicate appears in two places with different surrounding conditions — the exact confusion #3067 reported.
- **Region rename** — `Early Out - Update Parent and exit` → `Originating-call parent climb (early-out; see #3066)`, since after #3066 only the originating call exits there; propagated (size-gated) climbs fall through.

## Notes

- **No behavior change.** Comments and a region header only — no logic touched.
- Relates to #3067 (left open intentionally; the issue will be closed manually with a note pointing at #3066).
- The `gum-layout-engine` skill already documents the `gateClimbOnSizeChange` originating-vs-propagated distinction and was deliberately left unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
