### PR TITLE
Runtime snapshot serializer foundation: live tree -> Gum project, CLI-verified (#3070)

### DIFF
--- a/GumCommon/GumCommon.csproj
+++ b/GumCommon/GumCommon.csproj
@@ -140,6 +140,7 @@
 		</Compile>
 		<Compile Include="..\GumRuntime\GraphicalUiElement.cs" Link="GraphicalUiElement.cs" />
 		<Compile Include="..\GumRuntime\GraphicalUiElement.Binding.cs" Link="GraphicalUiElement.Binding.cs" />
+		<Compile Include="..\GumRuntime\GraphicalUiElementPropertyReadExtensions.cs" Link="GraphicalUiElementPropertyReadExtensions.cs" />
 		<Compile Include="..\GumRuntime\GraphicalUiElementTreeExtensions.cs" Link="GraphicalUiElementTreeExtensions.cs" />
 		<Compile Include="..\GumRuntime\IUpdateEveryFrame.cs" Link="IUpdateEveryFrame.cs" />
 		<Compile Include="..\GumRuntime\LayoutExporter.cs" Link="Runtime\LayoutExporter.cs" />

--- a/GumCommon/Wireframe/RuntimeSnapshotSerializer.cs
+++ b/GumCommon/Wireframe/RuntimeSnapshotSerializer.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Collections.Generic;
+using Gum.DataTypes.Variables;
+
+namespace Gum.Wireframe;
+
+/// <summary>
+/// Builds Gum save data (states/variables) from a live <see cref="GraphicalUiElement"/> tree, for the
+/// runtime inspector snapshot feature (issue #3070). Which variables exist for a given node is decided
+/// by the standard-element catalog (what Gum understands), and each value is read from the live element
+/// via <see cref="GraphicalUiElementPropertyReadExtensions.TryGetProperty"/>.
+/// </summary>
+public interface IRuntimeSnapshotSerializer
+{
+    /// <summary>
+    /// Resolves the Gum standard-element type name (e.g. "Container", "Text") for a live element by
+    /// walking its runtime type hierarchy, or null if no standard type applies.
+    /// </summary>
+    string? GetStandardTypeName(GraphicalUiElement element);
+
+    /// <summary>
+    /// Creates a state holding the element's current values for every variable in its standard type's
+    /// catalog. The result is unshaken — redundant (equal-to-default) values are not yet removed.
+    /// </summary>
+    StateSave CreateStateForNode(GraphicalUiElement element, string stateName);
+}
+
+/// <inheritdoc cref="IRuntimeSnapshotSerializer" />
+public class RuntimeSnapshotSerializer : IRuntimeSnapshotSerializer
+{
+    private const string RuntimeSuffix = "Runtime";
+
+    private readonly IReadOnlyDictionary<string, StateSave> _defaultStates;
+
+    /// <summary>
+    /// Creates a serializer that reads runtime values against the supplied standard-element catalog.
+    /// </summary>
+    /// <param name="defaultStates">
+    /// The standard-element default states keyed by type name — the authority on which variables Gum
+    /// understands per type. Typically <c>StandardElementsManager.Self.DefaultStates</c>.
+    /// </param>
+    public RuntimeSnapshotSerializer(IReadOnlyDictionary<string, StateSave> defaultStates)
+    {
+        _defaultStates = defaultStates;
+    }
+
+    /// <inheritdoc />
+    public string? GetStandardTypeName(GraphicalUiElement element)
+    {
+        // Standard runtimes follow the "<StandardName>Runtime" convention (ContainerRuntime ->
+        // "Container"). Walking the base chain lets custom subclasses resolve to their nearest
+        // standard ancestor; matching against the catalog keeps the result grounded in what Gum
+        // actually understands rather than trusting the type name blindly.
+        Type? type = element.GetType();
+        while (type != null)
+        {
+            string candidate = StripRuntimeSuffix(type.Name);
+            if (_defaultStates.ContainsKey(candidate))
+            {
+                return candidate;
+            }
+            type = type.BaseType;
+        }
+        return null;
+    }
+
+    /// <inheritdoc />
+    public StateSave CreateStateForNode(GraphicalUiElement element, string stateName)
+    {
+        StateSave state = new StateSave { Name = stateName };
+
+        string? typeName = GetStandardTypeName(element);
+        if (typeName != null && _defaultStates.TryGetValue(typeName, out StateSave? defaultState))
+        {
+            foreach (VariableSave defaultVariable in defaultState.Variables)
+            {
+                // The catalog defines the name/type/category; the live element supplies the value.
+                // Variables the element cannot read (no base-set case and no reflectable property)
+                // are skipped rather than emitted with a wrong value.
+                if (element.TryGetProperty(defaultVariable.Name, out object? value))
+                {
+                    state.Variables.Add(new VariableSave
+                    {
+                        Name = defaultVariable.Name,
+                        Type = defaultVariable.Type,
+                        Value = value,
+                        SetsValue = true,
+                        Category = defaultVariable.Category,
+                    });
+                }
+            }
+        }
+
+        return state;
+    }
+
+    private static string StripRuntimeSuffix(string typeName)
+    {
+        if (typeName.Length > RuntimeSuffix.Length && typeName.EndsWith(RuntimeSuffix, StringComparison.Ordinal))
+        {
+            return typeName.Substring(0, typeName.Length - RuntimeSuffix.Length);
+        }
+        return typeName;
+    }
+}

--- a/GumCommon/Wireframe/RuntimeSnapshotSerializer.cs
+++ b/GumCommon/Wireframe/RuntimeSnapshotSerializer.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Gum.DataTypes;
 using Gum.DataTypes.Variables;
 
 namespace Gum.Wireframe;
@@ -23,6 +24,15 @@ public interface IRuntimeSnapshotSerializer
     /// catalog. The result is unshaken — redundant (equal-to-default) values are not yet removed.
     /// </summary>
     StateSave CreateStateForNode(GraphicalUiElement element, string stateName);
+
+    /// <summary>
+    /// Builds a flattened <see cref="ScreenSave"/> snapshot of the live tree rooted at
+    /// <paramref name="root"/>. Each descendant becomes a standard-element <see cref="InstanceSave"/>; the
+    /// screen's default state holds each instance's values as instance-qualified variables, and
+    /// child/parent structure is captured via the qualified "Parent" variable. The root itself maps to the
+    /// screen, not to an instance.
+    /// </summary>
+    ScreenSave CreateScreenSave(GraphicalUiElement root, string screenName);
 }
 
 /// <inheritdoc cref="IRuntimeSnapshotSerializer" />
@@ -92,6 +102,75 @@ public class RuntimeSnapshotSerializer : IRuntimeSnapshotSerializer
         }
 
         return state;
+    }
+
+    /// <inheritdoc />
+    public ScreenSave CreateScreenSave(GraphicalUiElement root, string screenName)
+    {
+        ScreenSave screen = new ScreenSave { Name = screenName };
+        StateSave defaultState = new StateSave { Name = "Default" };
+        screen.States.Add(defaultState);
+
+        HashSet<string> usedNames = new HashSet<string>();
+        foreach (GraphicalUiElement child in root.Children)
+        {
+            AddInstanceRecursive(child, parentInstanceName: null, screen, defaultState, usedNames);
+        }
+
+        return screen;
+    }
+
+    private void AddInstanceRecursive(GraphicalUiElement element, string? parentInstanceName,
+        ScreenSave screen, StateSave defaultState, HashSet<string> usedNames)
+    {
+        string typeName = GetStandardTypeName(element) ?? "Container";
+        string instanceName = GenerateUniqueName(element, typeName, usedNames);
+
+        screen.Instances.Add(new InstanceSave { Name = instanceName, BaseType = typeName });
+
+        // The node's catalog values become instance-qualified variables in the screen's default state.
+        StateSave nodeState = CreateStateForNode(element, "Default");
+        foreach (VariableSave variable in nodeState.Variables)
+        {
+            defaultState.Variables.Add(new VariableSave
+            {
+                Name = instanceName + "." + variable.Name,
+                Type = variable.Type,
+                Value = variable.Value,
+                SetsValue = true,
+                Category = variable.Category,
+            });
+        }
+
+        // Non-top-level instances record their parent; top-level instances are children of the screen.
+        if (parentInstanceName != null)
+        {
+            defaultState.Variables.Add(new VariableSave
+            {
+                Name = instanceName + ".Parent",
+                Type = "string",
+                Value = parentInstanceName,
+                SetsValue = true,
+            });
+        }
+
+        foreach (GraphicalUiElement child in element.Children)
+        {
+            AddInstanceRecursive(child, instanceName, screen, defaultState, usedNames);
+        }
+    }
+
+    private static string GenerateUniqueName(GraphicalUiElement element, string typeName, HashSet<string> usedNames)
+    {
+        string baseName = string.IsNullOrEmpty(element.Name) ? typeName : element.Name;
+        string candidate = baseName;
+        int suffix = 1;
+        while (!usedNames.Add(candidate))
+        {
+            candidate = baseName + suffix;
+            suffix++;
+        }
+        return candidate;
     }
 
     private static string StripRuntimeSuffix(string typeName)

--- a/GumDataTypes/UnitConverter.cs
+++ b/GumDataTypes/UnitConverter.cs
@@ -401,5 +401,36 @@ namespace Gum.Converters
                     throw new NotImplementedException();
             }
         }
+
+        /// <summary>
+        /// Converts a runtime <see cref="GeneralUnitType"/> back to the axis-specific
+        /// <see cref="PositionUnitType"/> the Gum tool stores. The general enum is axis-agnostic
+        /// (e.g. <see cref="GeneralUnitType.PixelsFromSmall"/> means "from left" on X and "from top"
+        /// on Y), so the axis must be supplied. This is the inverse of
+        /// <see cref="ConvertToGeneralUnit(PositionUnitType)"/>; it is best-effort, since general units
+        /// with no exact per-axis position equivalent fall back to the pixels-from-origin value.
+        /// </summary>
+        /// <param name="generalUnit">The runtime general unit to convert.</param>
+        /// <param name="isXAxis">True for the X axis (XUnits), false for the Y axis (YUnits).</param>
+        public static PositionUnitType ConvertToPositionUnit(GeneralUnitType generalUnit, bool isXAxis)
+        {
+            switch (generalUnit)
+            {
+                case GeneralUnitType.Percentage:
+                    return isXAxis ? PositionUnitType.PercentageWidth : PositionUnitType.PercentageHeight;
+                case GeneralUnitType.PixelsFromLarge:
+                    return isXAxis ? PositionUnitType.PixelsFromRight : PositionUnitType.PixelsFromBottom;
+                case GeneralUnitType.PixelsFromMiddle:
+                    return isXAxis ? PositionUnitType.PixelsFromCenterX : PositionUnitType.PixelsFromCenterY;
+                case GeneralUnitType.PixelsFromMiddleInverted:
+                    // PositionUnitType has no inverted-center on the X axis, so X falls back to center.
+                    return isXAxis ? PositionUnitType.PixelsFromCenterX : PositionUnitType.PixelsFromCenterYInverted;
+                case GeneralUnitType.PixelsFromBaseline:
+                    return PositionUnitType.PixelsFromBaseline;
+                case GeneralUnitType.PixelsFromSmall:
+                default:
+                    return isXAxis ? PositionUnitType.PixelsFromLeft : PositionUnitType.PixelsFromTop;
+            }
+        }
     }
 }

--- a/GumRuntime/GraphicalUiElementPropertyReadExtensions.cs
+++ b/GumRuntime/GraphicalUiElementPropertyReadExtensions.cs
@@ -1,0 +1,213 @@
+using System;
+using System.Collections.Concurrent;
+using System.Reflection;
+using Gum.Converters;
+
+namespace Gum.Wireframe;
+
+/// <summary>
+/// Read-side companion to <see cref="GraphicalUiElement.SetProperty(string, object?)"/>: reads the
+/// current value of a Gum variable by name. A curated switch (the "base set") handles names that do
+/// not map 1:1 to a CLR property — notably the axis-aware unit enums "XUnits"/"YUnits", which the
+/// runtime stores as <see cref="GeneralUnitType"/> but the tool stores as PositionUnitType. Every
+/// other name falls through to reflection against the element's concrete runtime type, so visual
+/// properties ("Red", "Text", "Font", ...) on TextRuntime/SpriteRuntime are read without per-type
+/// code. The set of names actually requested is governed by StandardElementsManager (what Gum
+/// understands), so reflection is only ever asked for genuine Gum variables. Kept as an extension
+/// rather than a method on <see cref="GraphicalUiElement"/> to avoid adding to that already-large class.
+/// </summary>
+public static class GraphicalUiElementPropertyReadExtensions
+{
+    /// <summary>
+    /// Attempts to read the current value of a Gum variable (e.g. "X", "Width", "WidthUnits", "Red",
+    /// "Text") by name, trying the curated base-set switch first and reflection as a fallback.
+    /// </summary>
+    /// <param name="element">The element to read from.</param>
+    /// <param name="propertyName">The Gum variable name.</param>
+    /// <param name="value">The current value when found; otherwise null.</param>
+    /// <returns>True if the property was recognized and read; otherwise false.</returns>
+    public static bool TryGetProperty(this GraphicalUiElement element, string propertyName, out object? value)
+    {
+        value = null;
+        switch (propertyName)
+        {
+            case "AutoGridHorizontalCells":
+                value = element.AutoGridHorizontalCells;
+                return true;
+            case "AutoGridVerticalCells":
+                value = element.AutoGridVerticalCells;
+                return true;
+            case "ChildrenLayout":
+            case "Children Layout":
+                value = element.ChildrenLayout;
+                return true;
+            case "ClipsChildren":
+            case "Clips Children":
+                value = element.ClipsChildren;
+                return true;
+#if !FRB && NET6_0_OR_GREATER
+            case "ExposeChildrenEvents":
+                if (element is InteractiveGue exposeChildrenEventsGue)
+                {
+                    value = exposeChildrenEventsGue.ExposeChildrenEvents;
+                    return true;
+                }
+                return false;
+#endif
+            case "FlipHorizontal":
+                value = element.FlipHorizontal;
+                return true;
+#if !FRB && NET6_0_OR_GREATER
+            case "HasEvents":
+                if (element is InteractiveGue hasEventsGue)
+                {
+                    value = hasEventsGue.HasEvents;
+                    return true;
+                }
+                return false;
+#endif
+            case "Height":
+                value = element.Height;
+                return true;
+            case "HeightUnits":
+            case "Height Units":
+                value = element.HeightUnits;
+                return true;
+            case nameof(GraphicalUiElement.IgnoredByParentSize):
+                value = element.IgnoredByParentSize;
+                return true;
+            case nameof(GraphicalUiElement.MaxHeight):
+                value = element.MaxHeight;
+                return true;
+            case nameof(GraphicalUiElement.MaxWidth):
+                value = element.MaxWidth;
+                return true;
+            case nameof(GraphicalUiElement.MinHeight):
+                value = element.MinHeight;
+                return true;
+            case nameof(GraphicalUiElement.MinWidth):
+                value = element.MinWidth;
+                return true;
+            // "Parent" is intentionally not returned as a scalar. Unlike its SetProperty counterpart
+            // (which resolves a parent-name string), parent/child structure is captured structurally
+            // when walking the tree, not read as a single value.
+            case "Rotation":
+                value = element.Rotation;
+                return true;
+            case "StackSpacing":
+                value = element.StackSpacing;
+                return true;
+            case "TextureLeft":
+            case "Texture Left":
+                value = element.TextureLeft;
+                return true;
+            case "TextureTop":
+            case "Texture Top":
+                value = element.TextureTop;
+                return true;
+            case "TextureWidth":
+            case "Texture Width":
+                value = element.TextureWidth;
+                return true;
+            case "TextureHeight":
+            case "Texture Height":
+                value = element.TextureHeight;
+                return true;
+            case "TextureWidthScale":
+            case "Texture Width Scale":
+                value = element.TextureWidthScale;
+                return true;
+            case "TextureHeightScale":
+            case "Texture Height Scale":
+                value = element.TextureHeightScale;
+                return true;
+            case "TextureAddress":
+            case "Texture Address":
+                value = element.TextureAddress;
+                return true;
+            case "Visible":
+                value = element.Visible;
+                return true;
+            case "Width":
+                value = element.Width;
+                return true;
+            case "WidthUnits":
+            case "Width Units":
+                value = element.WidthUnits;
+                return true;
+            case "X":
+                value = element.X;
+                return true;
+            case "XOrigin":
+            case "X Origin":
+                value = element.XOrigin;
+                return true;
+            case "XUnits":
+            case "X Units":
+                value = UnitConverter.ConvertToPositionUnit(element.XUnits, isXAxis: true);
+                return true;
+            case "Y":
+                value = element.Y;
+                return true;
+            case "YOrigin":
+            case "Y Origin":
+                value = element.YOrigin;
+                return true;
+            case "YUnits":
+            case "Y Units":
+                value = UnitConverter.ConvertToPositionUnit(element.YUnits, isXAxis: false);
+                return true;
+            case "Wrap":
+                value = element.Wrap;
+                return true;
+            case "WrapsChildren":
+            case "Wraps Children":
+                value = element.WrapsChildren;
+                return true;
+        }
+
+        // Not in the base set: fall through to reflection on the concrete runtime type. The caller
+        // only requests names from the StandardElementsManager catalog, so this only ever resolves
+        // genuine Gum variables (e.g. "Red", "Text", "Font" on TextRuntime/SpriteRuntime).
+        PropertyInfo? property = _propertyCache.GetOrAdd(
+            (element.GetType(), propertyName),
+            static key => ResolveReflectedProperty(key.Item1, key.Item2));
+
+        if (property != null)
+        {
+            try
+            {
+                value = property.GetValue(element);
+                return true;
+            }
+            catch (TargetInvocationException)
+            {
+                // A property getter threw; treat as unreadable rather than failing the whole read.
+            }
+        }
+
+        return false;
+    }
+
+    // Memoizes the public, readable, non-indexer property per (runtime type, Gum variable name).
+    // A null entry caches "no reflectable property" so repeated misses stay cheap.
+    private static readonly ConcurrentDictionary<(Type, string), PropertyInfo?> _propertyCache = new();
+
+    private static PropertyInfo? ResolveReflectedProperty(Type type, string propertyName)
+    {
+        try
+        {
+            PropertyInfo? property = type.GetProperty(propertyName, BindingFlags.Public | BindingFlags.Instance);
+            if (property != null && property.CanRead && property.GetIndexParameters().Length == 0)
+            {
+                return property;
+            }
+        }
+        catch (AmbiguousMatchException)
+        {
+            // Overloaded properties (e.g. SpriteRuntime.SourceFile has Texture2D? and string? variants)
+            // cannot be resolved by name alone; such names must be added to the base-set switch.
+        }
+        return null;
+    }
+}

--- a/GumRuntime/GraphicalUiElementPropertyReadExtensions.cs
+++ b/GumRuntime/GraphicalUiElementPropertyReadExtensions.cs
@@ -88,9 +88,11 @@ public static class GraphicalUiElementPropertyReadExtensions
             case nameof(GraphicalUiElement.MinWidth):
                 value = element.MinWidth;
                 return true;
-            // "Parent" is intentionally not returned as a scalar. Unlike its SetProperty counterpart
-            // (which resolves a parent-name string), parent/child structure is captured structurally
-            // when walking the tree, not read as a single value.
+            case "Parent":
+                // "Parent" is intentionally not returned as a scalar. Parent/child structure is captured
+                // structurally by the snapshot serializer (via the qualified "Parent" variable); reflecting
+                // GraphicalUiElement.Parent would return the parent object, not a Gum parent name.
+                return false;
             case "Rotation":
                 value = element.Rotation;
                 return true;

--- a/MonoGameGum.Tests/MonoGameGum.Tests.csproj
+++ b/MonoGameGum.Tests/MonoGameGum.Tests.csproj
@@ -26,6 +26,10 @@
 		<ProjectReference Include="..\MonoGameGum\MonoGameGum.csproj" />
 		<ProjectReference Include="..\Runtimes\GumExpressions\GumExpressions.csproj" />
 		<ProjectReference Include="..\Tests\MonoGameGum.TestsCommon\MonoGameGum.TestsCommon.csproj" />
+		<!-- Build-only: ensures gumcli is built (incrementally) for the snapshot CLI-check test, without
+		     importing its assembly (Gum.ProjectServices + MonoGameGum both define the Forms control types,
+		     so importing would be a CS0433 conflict). The test invokes the pre-built gumcli with no rebuild. -->
+		<ProjectReference Include="..\Tools\Gum.Cli\Gum.Cli.csproj" ReferenceOutputAssembly="false" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/MonoGameGum.Tests/Runtimes/GraphicalUiElementTests.cs
+++ b/MonoGameGum.Tests/Runtimes/GraphicalUiElementTests.cs
@@ -1952,4 +1952,133 @@ public class GraphicalUiElementTests : BaseTestClass
     }
 
     #endregion
+
+    #region Try Get Property
+
+    [Fact]
+    public void TryGetProperty_ShouldReadBoolProperty()
+    {
+        ContainerRuntime sut = new();
+        sut.Visible = false;
+
+        bool found = sut.TryGetProperty("Visible", out object? value);
+
+        found.ShouldBeTrue();
+        value.ShouldBe(false);
+    }
+
+    [Fact]
+    public void TryGetProperty_ShouldReadEnumProperty()
+    {
+        ContainerRuntime sut = new();
+        sut.WidthUnits = DimensionUnitType.RelativeToChildren;
+
+        bool found = sut.TryGetProperty("WidthUnits", out object? value);
+
+        found.ShouldBeTrue();
+        value.ShouldBe(DimensionUnitType.RelativeToChildren);
+    }
+
+    [Fact]
+    public void TryGetProperty_ShouldReadFloatProperty()
+    {
+        ContainerRuntime sut = new();
+        sut.X = 12.5f;
+
+        bool found = sut.TryGetProperty("X", out object? value);
+
+        found.ShouldBeTrue();
+        value.ShouldBe(12.5f);
+    }
+
+    [Fact]
+    public void TryGetProperty_ShouldReadNullableProperty()
+    {
+        ContainerRuntime sut = new();
+
+        bool foundDefault = sut.TryGetProperty("MaxWidth", out object? defaultValue);
+        foundDefault.ShouldBeTrue();
+        defaultValue.ShouldBeNull();
+
+        sut.MaxWidth = 250f;
+        bool found = sut.TryGetProperty("MaxWidth", out object? value);
+        found.ShouldBeTrue();
+        value.ShouldBe(250f);
+    }
+
+    [Fact]
+    public void TryGetProperty_ShouldReturnFalseForUnknownProperty()
+    {
+        ContainerRuntime sut = new();
+
+        bool found = sut.TryGetProperty("ThisIsNotARealProperty", out object? value);
+
+        found.ShouldBeFalse();
+        value.ShouldBeNull();
+    }
+
+    [Fact]
+    public void TryGetProperty_ShouldConvertXUnitsToPositionUnitType()
+    {
+        // The runtime stores units as the axis-agnostic GeneralUnitType, but the Gum tool stores
+        // XUnits as the X-axis PositionUnitType. The base-set switch converts using the axis.
+        ContainerRuntime sut = new();
+        sut.XUnits = Gum.Converters.GeneralUnitType.PixelsFromSmall;
+
+        bool found = sut.TryGetProperty("XUnits", out object? value);
+
+        found.ShouldBeTrue();
+        value.ShouldBe(Gum.Managers.PositionUnitType.PixelsFromLeft);
+    }
+
+    [Fact]
+    public void TryGetProperty_ShouldConvertYUnitsToPositionUnitType()
+    {
+        ContainerRuntime sut = new();
+        sut.YUnits = Gum.Converters.GeneralUnitType.PixelsFromSmall;
+
+        bool found = sut.TryGetProperty("YUnits", out object? value);
+
+        found.ShouldBeTrue();
+        value.ShouldBe(Gum.Managers.PositionUnitType.PixelsFromTop);
+    }
+
+    [Fact]
+    public void TryGetProperty_ShouldReadColorComponentViaReflection()
+    {
+        // "Red" is not in the base-set switch; it falls through to reflection on the concrete runtime.
+        TextRuntime text = new();
+        text.Red = 123;
+
+        bool found = text.TryGetProperty("Red", out object? value);
+
+        found.ShouldBeTrue();
+        value.ShouldBe(123);
+    }
+
+    [Fact]
+    public void TryGetProperty_ShouldReadFontViaReflection()
+    {
+        TextRuntime text = new();
+        text.Font = "SomeFont";
+
+        bool found = text.TryGetProperty("Font", out object? value);
+
+        found.ShouldBeTrue();
+        value.ShouldBe("SomeFont");
+    }
+
+    [Fact]
+    public void TryGetProperty_ShouldReadTextStringViaReflection()
+    {
+        TextRuntime text = new();
+        text.Text = "Hello";
+
+        bool found = text.TryGetProperty("Text", out object? value);
+
+        found.ShouldBeTrue();
+        value.ShouldBe("Hello");
+    }
+
+    #endregion
 }

--- a/MonoGameGum.Tests/Runtimes/GraphicalUiElementTests.cs
+++ b/MonoGameGum.Tests/Runtimes/GraphicalUiElementTests.cs
@@ -2080,5 +2080,20 @@ public class GraphicalUiElementTests : BaseTestClass
         value.ShouldBe("Hello");
     }
 
+    [Fact]
+    public void TryGetProperty_ShouldReturnFalseForParent()
+    {
+        // Parent/child structure is captured structurally by the snapshot serializer, not read as a
+        // scalar -- reflecting GraphicalUiElement.Parent would return the parent object, not a name.
+        ContainerRuntime parent = new() { Name = "Parent" };
+        ContainerRuntime child = new() { Name = "Child" };
+        parent.AddChild(child);
+
+        bool found = child.TryGetProperty("Parent", out object? value);
+
+        found.ShouldBeFalse();
+        value.ShouldBeNull();
+    }
+
     #endregion
 }

--- a/MonoGameGum.Tests/Wireframe/RuntimeSnapshotSerializerProjectTests.cs
+++ b/MonoGameGum.Tests/Wireframe/RuntimeSnapshotSerializerProjectTests.cs
@@ -1,0 +1,68 @@
+using System;
+using System.IO;
+using System.Linq;
+using Gum.DataTypes;
+using Gum.GueDeriving;
+using Gum.Managers;
+using Gum.Wireframe;
+using Shouldly;
+using Xunit;
+
+namespace MonoGameGum.Tests.Wireframe;
+
+public class RuntimeSnapshotSerializerProjectTests : BaseTestClass
+{
+    [Fact]
+    public void Snapshot_ShouldWriteProjectThatLoadsWithoutErrors()
+    {
+        StandardElementsManager.Self.Initialize();
+
+        // Build a small live tree: a panel containing a label.
+        ContainerRuntime root = new();
+        ContainerRuntime panel = new() { Name = "Panel" };
+        TextRuntime label = new() { Name = "Label" };
+        label.Text = "Hi";
+        root.AddChild(panel);
+        panel.AddChild(label);
+
+        // Serialize the tree into a screen, then assemble a full project (standards populated so the
+        // instances' BaseTypes resolve). Standards population is a composition-root concern, kept out
+        // of the catalog-injected serializer.
+        RuntimeSnapshotSerializer serializer = new(StandardElementsManager.Self.DefaultStates);
+        ScreenSave screen = serializer.CreateScreenSave(root, "Snapshot");
+
+        GumProjectSave project = new();
+        StandardElementsManager.Self.PopulateProjectWithDefaultStandards(project);
+        project.Screens.Add(screen);
+        project.ScreenReferences.Add(new ElementReference { Name = "Snapshot", ElementType = ElementType.Screen });
+
+        string tempDirectory = Path.Combine(Path.GetTempPath(), "GumSnapshotTest_" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            Directory.CreateDirectory(Path.Combine(tempDirectory, ElementReference.ScreenSubfolder));
+            Directory.CreateDirectory(Path.Combine(tempDirectory, ElementReference.StandardSubfolder));
+
+            string gumxPath = Path.Combine(tempDirectory, "Snapshot." + GumProjectSave.ProjectExtension);
+            project.Save(gumxPath, saveElements: true);
+
+            // Reload via the same deserialization core (catches malformed XML + missing files).
+            // Full Gum.ProjectServices/gumcli validation runs out-of-process: ProjectServices and
+            // MonoGameGum both compile the Forms control types, so they can't be referenced together.
+            GumProjectSave loaded = GumProjectSave.Load(gumxPath, out GumLoadResult loadResult);
+
+            loaded.ShouldNotBeNull();
+            loadResult.ErrorMessage.ShouldBeNullOrEmpty();
+            loadResult.MissingFiles.ShouldBeEmpty();
+
+            ScreenSave loadedScreen = loaded.Screens.First(s => s.Name == "Snapshot");
+            loadedScreen.Instances.Select(i => i.Name).ShouldBe(new[] { "Panel", "Label" }, ignoreOrder: true);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDirectory))
+            {
+                Directory.Delete(tempDirectory, recursive: true);
+            }
+        }
+    }
+}

--- a/MonoGameGum.Tests/Wireframe/RuntimeSnapshotSerializerProjectTests.cs
+++ b/MonoGameGum.Tests/Wireframe/RuntimeSnapshotSerializerProjectTests.cs
@@ -1,6 +1,9 @@
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using Gum.DataTypes;
 using Gum.GueDeriving;
 using Gum.Managers;
@@ -14,6 +17,77 @@ public class RuntimeSnapshotSerializerProjectTests : BaseTestClass
 {
     [Fact]
     public void Snapshot_ShouldWriteProjectThatLoadsWithoutErrors()
+    {
+        string tempDirectory = NewTempDirectory();
+        try
+        {
+            string gumxPath = BuildAndSaveSnapshot(tempDirectory);
+
+            // Reload via the same deserialization core (catches malformed XML + missing files).
+            GumProjectSave loaded = GumProjectSave.Load(gumxPath, out GumLoadResult loadResult);
+
+            loaded.ShouldNotBeNull();
+            loadResult.ErrorMessage.ShouldBeNullOrEmpty();
+            loadResult.MissingFiles.ShouldBeEmpty();
+
+            ScreenSave loadedScreen = loaded.Screens.First(s => s.Name == "Snapshot");
+            loadedScreen.Instances.Select(i => i.Name).ShouldBe(new[] { "Panel", "Label" }, ignoreOrder: true);
+        }
+        finally
+        {
+            DeleteTempDirectory(tempDirectory);
+        }
+    }
+
+    [Fact]
+    public async Task Snapshot_ShouldPassGumCliCheck()
+    {
+        // The full integrity check uses the real CLI. It runs as a separate OS process (not an
+        // in-process reference) because Gum.ProjectServices and MonoGameGum both compile the Forms
+        // control types -- referencing both in one assembly is a CS0433 conflict. A separate process
+        // has its own load context, so there is no collision.
+        string tempDirectory = NewTempDirectory();
+        try
+        {
+            string gumxPath = BuildAndSaveSnapshot(tempDirectory);
+            string cliProject = LocateGumCliCsproj();
+            string configuration = DetectBuildConfiguration();
+
+            ProcessStartInfo startInfo = new()
+            {
+                FileName = "dotnet",
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            };
+            startInfo.ArgumentList.Add("run");
+            startInfo.ArgumentList.Add("--project");
+            startInfo.ArgumentList.Add(cliProject);
+            // The build-only ProjectReference already built gumcli in this configuration; reuse it
+            // rather than rebuilding (which made this test take ~37s).
+            startInfo.ArgumentList.Add("--configuration");
+            startInfo.ArgumentList.Add(configuration);
+            startInfo.ArgumentList.Add("--no-build");
+            startInfo.ArgumentList.Add("--");
+            startInfo.ArgumentList.Add("check");
+            startInfo.ArgumentList.Add(gumxPath);
+
+            using CancellationTokenSource cts = new(TimeSpan.FromMinutes(3));
+            using Process process = Process.Start(startInfo)!;
+            string stdout = await process.StandardOutput.ReadToEndAsync(cts.Token);
+            string stderr = await process.StandardError.ReadToEndAsync(cts.Token);
+            await process.WaitForExitAsync(cts.Token);
+
+            process.ExitCode.ShouldBe(0,
+                $"gumcli check reported errors (exit {process.ExitCode}).\nSTDOUT:\n{stdout}\nSTDERR:\n{stderr}");
+        }
+        finally
+        {
+            DeleteTempDirectory(tempDirectory);
+        }
+    }
+
+    private static string BuildAndSaveSnapshot(string tempDirectory)
     {
         StandardElementsManager.Self.Initialize();
 
@@ -36,33 +110,52 @@ public class RuntimeSnapshotSerializerProjectTests : BaseTestClass
         project.Screens.Add(screen);
         project.ScreenReferences.Add(new ElementReference { Name = "Snapshot", ElementType = ElementType.Screen });
 
-        string tempDirectory = Path.Combine(Path.GetTempPath(), "GumSnapshotTest_" + Guid.NewGuid().ToString("N"));
-        try
+        Directory.CreateDirectory(Path.Combine(tempDirectory, ElementReference.ScreenSubfolder));
+        Directory.CreateDirectory(Path.Combine(tempDirectory, ElementReference.StandardSubfolder));
+
+        string gumxPath = Path.Combine(tempDirectory, "Snapshot." + GumProjectSave.ProjectExtension);
+        project.Save(gumxPath, saveElements: true);
+        return gumxPath;
+    }
+
+    private static string NewTempDirectory()
+    {
+        return Path.Combine(Path.GetTempPath(), "GumSnapshotTest_" + Guid.NewGuid().ToString("N"));
+    }
+
+    private static void DeleteTempDirectory(string tempDirectory)
+    {
+        if (Directory.Exists(tempDirectory))
         {
-            Directory.CreateDirectory(Path.Combine(tempDirectory, ElementReference.ScreenSubfolder));
-            Directory.CreateDirectory(Path.Combine(tempDirectory, ElementReference.StandardSubfolder));
-
-            string gumxPath = Path.Combine(tempDirectory, "Snapshot." + GumProjectSave.ProjectExtension);
-            project.Save(gumxPath, saveElements: true);
-
-            // Reload via the same deserialization core (catches malformed XML + missing files).
-            // Full Gum.ProjectServices/gumcli validation runs out-of-process: ProjectServices and
-            // MonoGameGum both compile the Forms control types, so they can't be referenced together.
-            GumProjectSave loaded = GumProjectSave.Load(gumxPath, out GumLoadResult loadResult);
-
-            loaded.ShouldNotBeNull();
-            loadResult.ErrorMessage.ShouldBeNullOrEmpty();
-            loadResult.MissingFiles.ShouldBeEmpty();
-
-            ScreenSave loadedScreen = loaded.Screens.First(s => s.Name == "Snapshot");
-            loadedScreen.Instances.Select(i => i.Name).ShouldBe(new[] { "Panel", "Label" }, ignoreOrder: true);
+            Directory.Delete(tempDirectory, recursive: true);
         }
-        finally
+    }
+
+    private static string LocateGumCliCsproj()
+    {
+        DirectoryInfo? directory = new(AppContext.BaseDirectory);
+        while (directory != null)
         {
-            if (Directory.Exists(tempDirectory))
+            string candidate = Path.Combine(directory.FullName, "Tools", "Gum.Cli", "Gum.Cli.csproj");
+            if (File.Exists(candidate))
             {
-                Directory.Delete(tempDirectory, recursive: true);
+                return candidate;
             }
+            directory = directory.Parent;
         }
+        throw new FileNotFoundException(
+            $"Could not locate Tools/Gum.Cli/Gum.Cli.csproj by walking up from {AppContext.BaseDirectory}.");
+    }
+
+    private static string DetectBuildConfiguration()
+    {
+        // The test runs from .../bin/<Config>/net8.0/; the build-only gumcli reference is built in the
+        // same configuration, so run that one with --no-build.
+        DirectoryInfo tfmDirectory = new(AppContext.BaseDirectory);
+        if (tfmDirectory.Parent?.Parent?.Name == "bin")
+        {
+            return tfmDirectory.Parent.Name;
+        }
+        return "Debug";
     }
 }

--- a/MonoGameGum.Tests/Wireframe/RuntimeSnapshotSerializerTests.cs
+++ b/MonoGameGum.Tests/Wireframe/RuntimeSnapshotSerializerTests.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using Gum.DataTypes;
 using Gum.DataTypes.Variables;
 using Gum.GueDeriving;
 using Gum.Managers;
@@ -39,6 +40,51 @@ public class RuntimeSnapshotSerializerTests : BaseTestClass
         VariableSave? textVariable = state.Variables.FirstOrDefault(v => v.Name == "Text");
         textVariable.ShouldNotBeNull();
         textVariable.Value.ShouldBe("Hello");
+    }
+
+    [Fact]
+    public void CreateScreenSave_ShouldFlattenTreeIntoInstancesWithBaseTypes()
+    {
+        ContainerRuntime root = new();
+        ContainerRuntime panel = new() { Name = "Panel" };
+        TextRuntime label = new() { Name = "Label" };
+        root.AddChild(panel);
+        panel.AddChild(label);
+
+        RuntimeSnapshotSerializer serializer = CreateSerializer();
+        ScreenSave screen = serializer.CreateScreenSave(root, "Snapshot");
+
+        screen.Name.ShouldBe("Snapshot");
+        screen.Instances.Select(i => i.Name).ShouldBe(new[] { "Panel", "Label" }, ignoreOrder: true);
+        screen.Instances.First(i => i.Name == "Panel").BaseType.ShouldBe("Container");
+        screen.Instances.First(i => i.Name == "Label").BaseType.ShouldBe("Text");
+    }
+
+    [Fact]
+    public void CreateScreenSave_ShouldQualifyVariablesAndLinkParents()
+    {
+        ContainerRuntime root = new();
+        ContainerRuntime panel = new() { Name = "Panel" };
+        TextRuntime label = new() { Name = "Label" };
+        label.Text = "Hi";
+        root.AddChild(panel);
+        panel.AddChild(label);
+
+        RuntimeSnapshotSerializer serializer = CreateSerializer();
+        ScreenSave screen = serializer.CreateScreenSave(root, "Snapshot");
+
+        StateSave defaultState = screen.States.First(s => s.Name == "Default");
+
+        VariableSave? labelText = defaultState.Variables.FirstOrDefault(v => v.Name == "Label.Text");
+        labelText.ShouldNotBeNull();
+        labelText.Value.ShouldBe("Hi");
+
+        VariableSave? labelParent = defaultState.Variables.FirstOrDefault(v => v.Name == "Label.Parent");
+        labelParent.ShouldNotBeNull();
+        labelParent.Value.ShouldBe("Panel");
+
+        // Top-level instances (direct children of the root/screen) have no Parent variable.
+        defaultState.Variables.Any(v => v.Name == "Panel.Parent").ShouldBeFalse();
     }
 
     [Fact]

--- a/MonoGameGum.Tests/Wireframe/RuntimeSnapshotSerializerTests.cs
+++ b/MonoGameGum.Tests/Wireframe/RuntimeSnapshotSerializerTests.cs
@@ -1,0 +1,67 @@
+using System.Linq;
+using Gum.DataTypes.Variables;
+using Gum.GueDeriving;
+using Gum.Managers;
+using Gum.Wireframe;
+using Shouldly;
+using Xunit;
+
+namespace MonoGameGum.Tests.Wireframe;
+
+public class RuntimeSnapshotSerializerTests : BaseTestClass
+{
+    private static RuntimeSnapshotSerializer CreateSerializer() =>
+        new RuntimeSnapshotSerializer(StandardElementsManager.Self.DefaultStates);
+
+    [Fact]
+    public void CreateStateForNode_ShouldReadColorComponents()
+    {
+        TextRuntime text = new();
+        text.Red = 200;
+
+        RuntimeSnapshotSerializer serializer = CreateSerializer();
+        StateSave state = serializer.CreateStateForNode(text, "Default");
+
+        VariableSave? redVariable = state.Variables.FirstOrDefault(v => v.Name == "Red");
+        redVariable.ShouldNotBeNull();
+        redVariable.Value.ShouldBe(200);
+    }
+
+    [Fact]
+    public void CreateStateForNode_ShouldReadTextValue()
+    {
+        TextRuntime text = new();
+        text.Text = "Hello";
+
+        RuntimeSnapshotSerializer serializer = CreateSerializer();
+        StateSave state = serializer.CreateStateForNode(text, "Default");
+
+        VariableSave? textVariable = state.Variables.FirstOrDefault(v => v.Name == "Text");
+        textVariable.ShouldNotBeNull();
+        textVariable.Value.ShouldBe("Hello");
+    }
+
+    [Fact]
+    public void GetStandardTypeName_ShouldResolveContainerRuntime()
+    {
+        RuntimeSnapshotSerializer serializer = CreateSerializer();
+
+        serializer.GetStandardTypeName(new ContainerRuntime()).ShouldBe("Container");
+    }
+
+    [Fact]
+    public void GetStandardTypeName_ShouldResolveTextRuntime()
+    {
+        RuntimeSnapshotSerializer serializer = CreateSerializer();
+
+        serializer.GetStandardTypeName(new TextRuntime()).ShouldBe("Text");
+    }
+
+    [Fact]
+    public void GetStandardTypeName_ShouldReturnNullForBareGraphicalUiElement()
+    {
+        RuntimeSnapshotSerializer serializer = CreateSerializer();
+
+        serializer.GetStandardTypeName(new GraphicalUiElement()).ShouldBeNull();
+    }
+}


### PR DESCRIPTION
## Summary

Foundation for the runtime UI inspector (issue #3070): the pieces that turn a **live `GraphicalUiElement` tree into a valid Gum project on disk**, plus the automated tests that prove the output is well-formed. This is the serializer groundwork for the snapshot feature — it is **part of #3070, not the whole feature** (see "Not in this PR").

The headline audience is **code-only** users (UI built in C# with no `.gumx` loaded), who today have no way to see their live tree.

## What's in this PR

- **`GraphicalUiElement.TryGetProperty` reader** (`GumRuntime/GraphicalUiElementPropertyReadExtensions.cs`) — reads a Gum variable value by name. A curated base-set switch handles names that don't map 1:1 to a CLR property (notably the axis-aware `XUnits`/`YUnits`), and everything else falls through to reflection on the concrete runtime type — so visual properties (`Red`, `Text`, `Font`, …) are read with no per-type code. Kept as an extension to avoid growing the already-large `GraphicalUiElement`.
- **`UnitConverter.ConvertToPositionUnit(GeneralUnitType, isXAxis)`** — the axis-aware inverse of `ConvertToGeneralUnit`. The runtime stores units as the axis-agnostic `GeneralUnitType`; the tool stores the axis-specific `PositionUnitType`. This is why `XUnits`/`YUnits` must be base-set cases, not reflection.
- **`RuntimeSnapshotSerializer`** (`GumCommon/Wireframe/RuntimeSnapshotSerializer.cs`) — catalog-driven, backend-agnostic, catalog injected (no singleton coupling):
  - `GetStandardTypeName` — walks the runtime type chain, strips the `Runtime` suffix, matches `StandardElementsManager` catalog keys (so the result is grounded in what Gum understands, and custom subclasses resolve to their nearest standard ancestor).
  - `CreateStateForNode` / `CreateScreenSave` — flattens the tree: each descendant becomes a standard-element `InstanceSave`, the screen's default state holds each node's catalog values as instance-qualified variables, and parent/child structure is captured via the qualified `Parent` variable.
- **Tests** (`MonoGameGum.Tests`):
  - In-memory: reader (base-set + reflection + `XUnits`/`YUnits` conversion + `Parent` exclusion), serializer (type resolution, catalog read, flatten + qualified vars + parent links).
  - Round-trip: write `.gumx`/`.gusx` to a temp dir and reload via `GumProjectSave.Load` (no errors, no missing files, expected instances).
  - **Automated `gumcli check`**: validates the output with the real CLI engine (base types, variable types, parent refs, silently-dropped-content) that can't run in-process — see "Notes".

## Not in this PR (deferred, by design)

- **The shake.** Output is currently **unshaken**: every catalog variable is emitted for every node, so files are **heavy but valid and usable** (round-trip + `gumcli check` pass). The shake (prune equal-to-default values) is a follow-up — it restores the tool's "edited" markers and shrinks files; it is an optimization, not a correctness fix.
- **`GumService.ExportSnapshot`** — the public entry point (populate standards, isolated output location, snapshot marker to prevent edit-by-mistake).
- **Tool-side open/inspect UX**, the in-game highlight overlay, and Phases 2–3 (Forms annotations / logical state; functional round-trippable export).

## Notes / design decisions

- **FRB exclusions:** the reader and serializer are deliberately left out of `GumCoreShared.projitems` — they depend on the FRB-excluded reader and FRB has no snapshot consumer. `UnitConverter`'s new method is a plain shared utility (net6-safe).
- **Automated CLI check without an assembly collision:** `Gum.ProjectServices` and `MonoGameGum` both compile the Forms control types, so they can't be referenced together in one test assembly (`CS0433`). The test runs `gumcli` as a **separate OS process** (own load context, no collision). To keep it fast, `MonoGameGum.Tests` takes a **build-only** `ProjectReference` to `Gum.Cli` (`ReferenceOutputAssembly="false"`): gumcli is built incrementally as part of the test build, and the test invokes the prebuilt binary with no rebuild — ~1s instead of ~37s.
- **Cross-platform:** `gumcli check` has no Windows dependencies (only `fonts` does); verified on Windows, and the `macos-15` CI leg exercises it on Mac.

## Testing

- `dotnet test MonoGameGum.Tests/MonoGameGum.Tests.csproj` — full suite green (1640 tests).
- The snapshot serializer is covered by in-memory, round-trip, and real-`gumcli`-check tests.

Part of #3070. This PR is the serializer foundation and intentionally does **not** close the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
