### PR TITLE
Runtime snapshot: equal-to-default shake + GumService.ExportSnapshot

### DIFF
--- a/GumCommon/Wireframe/RuntimeSnapshotSerializer.cs
+++ b/GumCommon/Wireframe/RuntimeSnapshotSerializer.cs
@@ -37,6 +37,12 @@ public interface IRuntimeSnapshotSerializer
     /// (see <see cref="CreateStateForNode"/>).
     /// </summary>
     ScreenSave CreateScreenSave(GraphicalUiElement root, string screenName, bool shake = false);
+
+    /// <summary>
+    /// Returns the distinct, non-empty file paths referenced by "SourceFile" variables in the snapshot
+    /// (e.g. Sprite/NineSlice textures), so a caller can bundle those files alongside the project.
+    /// </summary>
+    IEnumerable<string> GetReferencedFiles(ScreenSave screen);
 }
 
 /// <inheritdoc cref="IRuntimeSnapshotSerializer" />
@@ -93,6 +99,14 @@ public class RuntimeSnapshotSerializer : IRuntimeSnapshotSerializer
                 // are skipped rather than emitted with a wrong value.
                 if (element.TryGetProperty(defaultVariable.Name, out object? value))
                 {
+                    // Only values Gum can serialize belong in a snapshot. The reflection fallback can
+                    // return runtime-only objects (e.g. a Texture2D for "SourceFile") that the XML
+                    // serializer cannot write; skip those rather than crash the whole save.
+                    if (value != null && !IsSaveSafeValue(value))
+                    {
+                        continue;
+                    }
+
                     // The shake prunes values equal to the standard-element default (the in-document
                     // baseline): an omitted variable resolves to that same default via the snapshot's
                     // embedded standards, so the result is equivalent but lighter.
@@ -130,6 +144,33 @@ public class RuntimeSnapshotSerializer : IRuntimeSnapshotSerializer
         }
 
         return screen;
+    }
+
+    /// <inheritdoc />
+    public IEnumerable<string> GetReferencedFiles(ScreenSave screen)
+    {
+        HashSet<string> files = new HashSet<string>();
+        foreach (StateSave state in screen.States)
+        {
+            foreach (VariableSave variable in state.Variables)
+            {
+                if (IsSourceFileVariable(variable.Name)
+                    && variable.Value is string path
+                    && !string.IsNullOrEmpty(path))
+                {
+                    files.Add(path);
+                }
+            }
+        }
+        return files;
+    }
+
+    // "SourceFile" appears instance-qualified in the screen's default state (e.g. "Sprite.SourceFile").
+    private static bool IsSourceFileVariable(string variableName)
+    {
+        int lastDot = variableName.LastIndexOf('.');
+        string unqualified = lastDot >= 0 ? variableName.Substring(lastDot + 1) : variableName;
+        return unqualified == "SourceFile" || unqualified == "Source File";
     }
 
     private void AddInstanceRecursive(GraphicalUiElement element, string? parentInstanceName,
@@ -197,6 +238,11 @@ public class RuntimeSnapshotSerializer : IRuntimeSnapshotSerializer
 
     private static bool IsNumeric(object value) =>
         value is byte or sbyte or short or ushort or int or uint or long or ulong or float or double or decimal;
+
+    // The value kinds Gum's save format (and its XML serializer) can represent: strings, bools, the
+    // numeric primitives, and enums. Anything else (a Texture2D, a renderable, ...) must not be emitted.
+    private static bool IsSaveSafeValue(object value) =>
+        value is string || value is bool || value.GetType().IsEnum || IsNumeric(value);
 
     private static string GenerateUniqueName(GraphicalUiElement element, string typeName, HashSet<string> usedNames)
     {

--- a/GumCommon/Wireframe/RuntimeSnapshotSerializer.cs
+++ b/GumCommon/Wireframe/RuntimeSnapshotSerializer.cs
@@ -21,18 +21,22 @@ public interface IRuntimeSnapshotSerializer
 
     /// <summary>
     /// Creates a state holding the element's current values for every variable in its standard type's
-    /// catalog. The result is unshaken — redundant (equal-to-default) values are not yet removed.
+    /// catalog. When <paramref name="shake"/> is false the result is unshaken — every catalog value is
+    /// emitted (heavy but always correct). When true, values equal to the standard-element default are
+    /// pruned: an omitted variable falls back to that same default in the snapshot's embedded standards,
+    /// so the shaken state is equivalent but lighter and reads as "unedited" in the tool.
     /// </summary>
-    StateSave CreateStateForNode(GraphicalUiElement element, string stateName);
+    StateSave CreateStateForNode(GraphicalUiElement element, string stateName, bool shake = false);
 
     /// <summary>
     /// Builds a flattened <see cref="ScreenSave"/> snapshot of the live tree rooted at
     /// <paramref name="root"/>. Each descendant becomes a standard-element <see cref="InstanceSave"/>; the
     /// screen's default state holds each instance's values as instance-qualified variables, and
     /// child/parent structure is captured via the qualified "Parent" variable. The root itself maps to the
-    /// screen, not to an instance.
+    /// screen, not to an instance. When <paramref name="shake"/> is true, equal-to-default values are pruned
+    /// (see <see cref="CreateStateForNode"/>).
     /// </summary>
-    ScreenSave CreateScreenSave(GraphicalUiElement root, string screenName);
+    ScreenSave CreateScreenSave(GraphicalUiElement root, string screenName, bool shake = false);
 }
 
 /// <inheritdoc cref="IRuntimeSnapshotSerializer" />
@@ -75,7 +79,7 @@ public class RuntimeSnapshotSerializer : IRuntimeSnapshotSerializer
     }
 
     /// <inheritdoc />
-    public StateSave CreateStateForNode(GraphicalUiElement element, string stateName)
+    public StateSave CreateStateForNode(GraphicalUiElement element, string stateName, bool shake = false)
     {
         StateSave state = new StateSave { Name = stateName };
 
@@ -89,6 +93,14 @@ public class RuntimeSnapshotSerializer : IRuntimeSnapshotSerializer
                 // are skipped rather than emitted with a wrong value.
                 if (element.TryGetProperty(defaultVariable.Name, out object? value))
                 {
+                    // The shake prunes values equal to the standard-element default (the in-document
+                    // baseline): an omitted variable resolves to that same default via the snapshot's
+                    // embedded standards, so the result is equivalent but lighter.
+                    if (shake && AreValuesEqual(value, defaultVariable.Value))
+                    {
+                        continue;
+                    }
+
                     state.Variables.Add(new VariableSave
                     {
                         Name = defaultVariable.Name,
@@ -105,7 +117,7 @@ public class RuntimeSnapshotSerializer : IRuntimeSnapshotSerializer
     }
 
     /// <inheritdoc />
-    public ScreenSave CreateScreenSave(GraphicalUiElement root, string screenName)
+    public ScreenSave CreateScreenSave(GraphicalUiElement root, string screenName, bool shake = false)
     {
         ScreenSave screen = new ScreenSave { Name = screenName };
         StateSave defaultState = new StateSave { Name = "Default" };
@@ -114,14 +126,14 @@ public class RuntimeSnapshotSerializer : IRuntimeSnapshotSerializer
         HashSet<string> usedNames = new HashSet<string>();
         foreach (GraphicalUiElement child in root.Children)
         {
-            AddInstanceRecursive(child, parentInstanceName: null, screen, defaultState, usedNames);
+            AddInstanceRecursive(child, parentInstanceName: null, screen, defaultState, usedNames, shake);
         }
 
         return screen;
     }
 
     private void AddInstanceRecursive(GraphicalUiElement element, string? parentInstanceName,
-        ScreenSave screen, StateSave defaultState, HashSet<string> usedNames)
+        ScreenSave screen, StateSave defaultState, HashSet<string> usedNames, bool shake)
     {
         string typeName = GetStandardTypeName(element) ?? "Container";
         string instanceName = GenerateUniqueName(element, typeName, usedNames);
@@ -129,7 +141,7 @@ public class RuntimeSnapshotSerializer : IRuntimeSnapshotSerializer
         screen.Instances.Add(new InstanceSave { Name = instanceName, BaseType = typeName });
 
         // The node's catalog values become instance-qualified variables in the screen's default state.
-        StateSave nodeState = CreateStateForNode(element, "Default");
+        StateSave nodeState = CreateStateForNode(element, "Default", shake);
         foreach (VariableSave variable in nodeState.Variables)
         {
             defaultState.Variables.Add(new VariableSave
@@ -156,9 +168,35 @@ public class RuntimeSnapshotSerializer : IRuntimeSnapshotSerializer
 
         foreach (GraphicalUiElement child in element.Children)
         {
-            AddInstanceRecursive(child, instanceName, screen, defaultState, usedNames);
+            AddInstanceRecursive(child, instanceName, screen, defaultState, usedNames, shake);
         }
     }
+
+    // Equality for the shake. Same boxed type compares directly (covers bool/string/enum/int); numeric
+    // cross-type (e.g. an int default vs a float read) compares by value so it is not treated as "edited".
+    private static bool AreValuesEqual(object? a, object? b)
+    {
+        if (a == null)
+        {
+            return b == null;
+        }
+        if (b == null)
+        {
+            return false;
+        }
+        if (a.GetType() == b.GetType())
+        {
+            return a.Equals(b);
+        }
+        if (IsNumeric(a) && IsNumeric(b))
+        {
+            return Convert.ToDouble(a) == Convert.ToDouble(b);
+        }
+        return a.Equals(b);
+    }
+
+    private static bool IsNumeric(object value) =>
+        value is byte or sbyte or short or ushort or int or uint or long or ulong or float or double or decimal;
 
     private static string GenerateUniqueName(GraphicalUiElement element, string typeName, HashSet<string> usedNames)
     {

--- a/GumCommon/Wireframe/RuntimeSnapshotSerializer.cs
+++ b/GumCommon/Wireframe/RuntimeSnapshotSerializer.cs
@@ -137,13 +137,42 @@ public class RuntimeSnapshotSerializer : IRuntimeSnapshotSerializer
         StateSave defaultState = new StateSave { Name = "Default" };
         screen.States.Add(defaultState);
 
+        GraphicalUiElement screenRoot = ResolveScreenRoot(root);
+
         HashSet<string> usedNames = new HashSet<string>();
-        foreach (GraphicalUiElement child in root.Children)
+        foreach (GraphicalUiElement child in screenRoot.Children)
         {
             AddInstanceRecursive(child, parentInstanceName: null, screen, defaultState, usedNames, shake);
         }
 
         return screen;
+    }
+
+    // Decides which element's children become the screen's top-level instances. When the supplied root
+    // holds exactly one *authored* element (a custom type, not a standard layout element) that has
+    // children, that element is the screen the user built -- the code-only equivalent of a Gum Screen --
+    // so it is elided and its children are promoted. In every other case (multiple children at the root,
+    // a single standard-type wrapper, or a custom leaf) the root's own children are the top level.
+    private GraphicalUiElement ResolveScreenRoot(GraphicalUiElement root)
+    {
+        if (root.Children.Count == 1
+            && root.Children[0] is GraphicalUiElement onlyChild
+            && onlyChild.Children.Count > 0
+            && IsCustomType(onlyChild))
+        {
+            return onlyChild;
+        }
+        return root;
+    }
+
+    // A custom (game-authored) type's own name is not a standard-element name. Standard runtimes follow
+    // the "<StandardName>Runtime" convention and resolve directly into the catalog; a subclass such as
+    // "MainMenu : ContainerRuntime" does not. (This deliberately checks the concrete type only -- unlike
+    // GetStandardTypeName, which walks the base chain to find the nearest standard ancestor.)
+    private bool IsCustomType(GraphicalUiElement element)
+    {
+        string candidate = StripRuntimeSuffix(element.GetType().Name);
+        return !_defaultStates.ContainsKey(candidate);
     }
 
     /// <inheritdoc />

--- a/GumCommon/Wireframe/RuntimeSnapshotSerializer.cs
+++ b/GumCommon/Wireframe/RuntimeSnapshotSerializer.cs
@@ -158,12 +158,20 @@ public class RuntimeSnapshotSerializer : IRuntimeSnapshotSerializer
         if (root.Children.Count == 1
             && root.Children[0] is GraphicalUiElement onlyChild
             && onlyChild.Children.Count > 0
-            && IsCustomType(onlyChild))
+            && IsAuthoredScreenRoot(onlyChild))
         {
             return onlyChild;
         }
         return root;
     }
+
+    // A single root child is treated as the authored screen when either it is a custom type, or it
+    // carries a Forms control identity. The latter matters because a Forms screen's visual is a plain
+    // ContainerRuntime (a standard type) with FormsControlAsObject set -- its "screen-ness" lives in the
+    // Forms control, not the runtime type. A plain anonymous container is neither, so it stays an instance.
+    private bool IsAuthoredScreenRoot(GraphicalUiElement element) =>
+        IsCustomType(element)
+        || (element is InteractiveGue interactiveGue && interactiveGue.FormsControlAsObject != null);
 
     // A custom (game-authored) type's own name is not a standard-element name. Standard runtimes follow
     // the "<StandardName>Runtime" convention and resolve directly into the catalog; a subclass such as

--- a/GumRuntime/GraphicalUiElementPropertyReadExtensions.cs
+++ b/GumRuntime/GraphicalUiElementPropertyReadExtensions.cs
@@ -96,6 +96,15 @@ public static class GraphicalUiElementPropertyReadExtensions
             case "Rotation":
                 value = element.Rotation;
                 return true;
+            case "SourceFile":
+            case "Source File":
+                // The Gum "SourceFile" variable is a file path. The runtime exposes the texture object
+                // (Sprite/NineSlice ".Texture"), not the path -- but the content loader stamps the source
+                // path onto Texture2D.Name, so recover it there. Reflection keeps this reader cross-platform
+                // (no Texture2D reference here). Returns false when there is no texture, so callers skip it
+                // rather than emit a Texture2D the snapshot serializer cannot write.
+                value = TryReadTextureName(element);
+                return value != null;
             case "StackSpacing":
                 value = element.StackSpacing;
                 return true;
@@ -194,6 +203,22 @@ public static class GraphicalUiElementPropertyReadExtensions
     // Memoizes the public, readable, non-indexer property per (runtime type, Gum variable name).
     // A null entry caches "no reflectable property" so repeated misses stay cheap.
     private static readonly ConcurrentDictionary<(Type, string), PropertyInfo?> _propertyCache = new();
+
+    // Recovers a Sprite/NineSlice source path from its texture's Name (stamped by the content loader on
+    // load). Done by reflection so this shared reader needs no reference to the backend texture type.
+    private static string? TryReadTextureName(GraphicalUiElement element)
+    {
+        PropertyInfo? textureProperty = ResolveReflectedProperty(element.GetType(), "Texture");
+        object? texture = textureProperty?.GetValue(element);
+        if (texture == null)
+        {
+            return null;
+        }
+
+        PropertyInfo? nameProperty = ResolveReflectedProperty(texture.GetType(), "Name");
+        string? name = nameProperty?.GetValue(texture) as string;
+        return string.IsNullOrEmpty(name) ? null : name;
+    }
 
     private static PropertyInfo? ResolveReflectedProperty(Type type, string propertyName)
     {

--- a/MonoGameGum.Tests/Runtimes/GraphicalUiElementTests.cs
+++ b/MonoGameGum.Tests/Runtimes/GraphicalUiElementTests.cs
@@ -2007,6 +2007,51 @@ public class GraphicalUiElementTests : BaseTestClass
     }
 
     [Fact]
+    public void TryGetProperty_ShouldReadSourceFileFromTextureNameForNineSlice()
+    {
+        NineSliceRuntime sut = new();
+        sut.Texture = MakeNamedTexture("Images/Frame.png");
+
+        bool found = sut.TryGetProperty("SourceFile", out object? value);
+
+        found.ShouldBeTrue();
+        value.ShouldBe("Images/Frame.png");
+    }
+
+    [Fact]
+    public void TryGetProperty_ShouldReadSourceFileFromTextureNameForSprite()
+    {
+        SpriteRuntime sut = new();
+        sut.Texture = MakeNamedTexture("Images/Icon.png");
+
+        bool found = sut.TryGetProperty("SourceFile", out object? value);
+
+        found.ShouldBeTrue();
+        value.ShouldBe("Images/Icon.png");
+    }
+
+    [Fact]
+    public void TryGetProperty_ShouldReturnFalseForSourceFileWhenNoTexture()
+    {
+        SpriteRuntime sut = new();
+
+        bool found = sut.TryGetProperty("SourceFile", out object? value);
+
+        found.ShouldBeFalse();
+        value.ShouldBeNull();
+    }
+
+    // Fabricates a Texture2D reference (its ctor needs a GraphicsDevice we don't have headlessly) and
+    // stamps a name on it, mirroring what the content loader does when it loads a texture from a file.
+    private static Microsoft.Xna.Framework.Graphics.Texture2D MakeNamedTexture(string name)
+    {
+        var texture = (Microsoft.Xna.Framework.Graphics.Texture2D)System.Runtime.CompilerServices
+            .RuntimeHelpers.GetUninitializedObject(typeof(Microsoft.Xna.Framework.Graphics.Texture2D));
+        texture.Name = name;
+        return texture;
+    }
+
+    [Fact]
     public void TryGetProperty_ShouldReturnFalseForUnknownProperty()
     {
         ContainerRuntime sut = new();

--- a/MonoGameGum.Tests/Wireframe/RuntimeSnapshotSerializerProjectTests.cs
+++ b/MonoGameGum.Tests/Wireframe/RuntimeSnapshotSerializerProjectTests.cs
@@ -10,6 +10,7 @@ using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using Shouldly;
+using ToolsUtilities;
 using Xunit;
 
 namespace MonoGameGum.Tests.Wireframe;
@@ -165,10 +166,95 @@ public class RuntimeSnapshotSerializerProjectTests : BaseTestClass
         }
     }
 
+    [Fact]
+    public void ExportSnapshot_ShouldCopyReferencedFilesPreservingRelativePath()
+    {
+        string originalRelativeDirectory = FileManager.RelativeDirectory;
+        string contentDirectory = NewTempDirectory();
+        string snapshotDirectory = NewTempDirectory();
+        try
+        {
+            // Lay a referenced texture file under a content dir, mirroring how a game ships assets.
+            const string relativePath = "UI/button.png";
+            string sourceFile = Path.Combine(contentDirectory, "UI", "button.png");
+            Directory.CreateDirectory(Path.GetDirectoryName(sourceFile)!);
+            File.WriteAllBytes(sourceFile, new byte[] { 1, 2, 3 });
+
+            // Relative SourceFile paths resolve under here (as the content loader resolved them at load).
+            FileManager.RelativeDirectory = contentDirectory;
+
+            GumService service = new();
+            SpriteRuntime sprite = new() { Name = "Sprite" };
+            Microsoft.Xna.Framework.Graphics.Texture2D texture = MakeHeadlessTexture();
+            texture.Name = relativePath;
+            sprite.Texture = texture;
+            service.Root.AddChild(sprite);
+
+            string gumxPath = Path.Combine(snapshotDirectory, "Live." + GumProjectSave.ProjectExtension);
+            service.ExportSnapshot(gumxPath);
+
+            // The referenced file is copied next to the snapshot, preserving its relative path.
+            File.Exists(Path.Combine(snapshotDirectory, "UI", "button.png")).ShouldBeTrue();
+
+            // And the SourceFile variable points at that same relative path.
+            GumProjectSave loaded = GumProjectSave.Load(gumxPath, out _);
+            StateSave defaultState = loaded.Screens.First(s => s.Name == "Live").States.First(s => s.Name == "Default");
+            defaultState.Variables.First(v => v.Name == "Sprite.SourceFile").Value.ShouldBe(relativePath);
+        }
+        finally
+        {
+            FileManager.RelativeDirectory = originalRelativeDirectory;
+            DeleteTempDirectory(contentDirectory);
+            DeleteTempDirectory(snapshotDirectory);
+        }
+    }
+
+    [Fact]
+    public void Snapshot_ShouldSerializeEveryStandardRuntimeType()
+    {
+        // Coverage guard: a snapshot containing one of every standard runtime type must serialize and
+        // reload without error. Sprite and NineSlice carry an in-memory Texture2D -- the snapshot must
+        // not attempt to write that non-serializable object into a VariableSave. (Previously only
+        // Container and Text were ever exercised, so this whole dimension was untested.)
+        ContainerRuntime root = new();
+        root.AddChild(new ContainerRuntime { Name = "ContainerInstance" });
+        root.AddChild(new TextRuntime { Name = "TextInstance", Text = "Hi" });
+        root.AddChild(new RectangleRuntime { Name = "RectangleInstance" });
+        root.AddChild(new CircleRuntime { Name = "CircleInstance" });
+        root.AddChild(new PolygonRuntime { Name = "PolygonInstance" });
+#pragma warning disable CS0618 // ColoredRectangle is obsolete but is still a live standard type to cover.
+        root.AddChild(new ColoredRectangleRuntime { Name = "ColoredRectangleInstance" });
+#pragma warning restore CS0618
+
+        SpriteRuntime sprite = new() { Name = "SpriteInstance" };
+        sprite.Texture = MakeHeadlessTexture();
+        root.AddChild(sprite);
+
+        NineSliceRuntime nineSlice = new() { Name = "NineSliceInstance" };
+        nineSlice.Texture = MakeHeadlessTexture();
+        root.AddChild(nineSlice);
+
+        string tempDirectory = NewTempDirectory();
+        try
+        {
+            string gumxPath = SaveRootAsProject(root, tempDirectory, shake: true);
+
+            GumProjectSave loaded = GumProjectSave.Load(gumxPath, out GumLoadResult loadResult);
+
+            loaded.ShouldNotBeNull();
+            loadResult.ErrorMessage.ShouldBeNullOrEmpty();
+            loadResult.MissingFiles.ShouldBeEmpty();
+
+            loaded.Screens.First(s => s.Name == "Snapshot").Instances.Count.ShouldBe(8);
+        }
+        finally
+        {
+            DeleteTempDirectory(tempDirectory);
+        }
+    }
+
     private static string BuildAndSaveSnapshot(string tempDirectory, bool shake = false)
     {
-        StandardElementsManager.Self.Initialize();
-
         // Build a small live tree: a panel containing a label.
         ContainerRuntime root = new();
         ContainerRuntime panel = new() { Name = "Panel" };
@@ -177,9 +263,18 @@ public class RuntimeSnapshotSerializerProjectTests : BaseTestClass
         root.AddChild(panel);
         panel.AddChild(label);
 
-        // Serialize the tree into a screen, then assemble a full project (standards populated so the
-        // instances' BaseTypes resolve). Standards population is a composition-root concern, kept out
-        // of the catalog-injected serializer.
+        return SaveRootAsProject(root, tempDirectory, shake);
+    }
+
+    /// <summary>
+    /// Serializes an arbitrary live tree into a screen and assembles a full project (standards populated
+    /// so the instances' BaseTypes resolve), saving it to <paramref name="tempDirectory"/>. Standards
+    /// population is a composition-root concern, kept out of the catalog-injected serializer.
+    /// </summary>
+    private static string SaveRootAsProject(GraphicalUiElement root, string tempDirectory, bool shake)
+    {
+        StandardElementsManager.Self.Initialize();
+
         RuntimeSnapshotSerializer serializer = new(StandardElementsManager.Self.DefaultStates);
         ScreenSave screen = serializer.CreateScreenSave(root, "Snapshot", shake);
 
@@ -195,6 +290,12 @@ public class RuntimeSnapshotSerializerProjectTests : BaseTestClass
         project.Save(gumxPath, saveElements: true);
         return gumxPath;
     }
+
+    // Fabricates a Texture2D reference without a GraphicsDevice (its ctor needs one). The snapshot path
+    // only holds the reference; it is never dereferenced, so an uninitialized shell is safe here.
+    private static Microsoft.Xna.Framework.Graphics.Texture2D MakeHeadlessTexture() =>
+        (Microsoft.Xna.Framework.Graphics.Texture2D)System.Runtime.CompilerServices.RuntimeHelpers
+            .GetUninitializedObject(typeof(Microsoft.Xna.Framework.Graphics.Texture2D));
 
     private static string NewTempDirectory()
     {

--- a/MonoGameGum.Tests/Wireframe/RuntimeSnapshotSerializerProjectTests.cs
+++ b/MonoGameGum.Tests/Wireframe/RuntimeSnapshotSerializerProjectTests.cs
@@ -167,6 +167,34 @@ public class RuntimeSnapshotSerializerProjectTests : BaseTestClass
     }
 
     [Fact]
+    public void ExportSnapshot_ShouldIncludeStandardForReferencedDeprecatedColoredRectangle()
+    {
+        // New (v3) projects no longer seed ColoredRectangle (it's deprecated), but a live tree may still
+        // contain one. The snapshot must add the referenced standard so the instance's BaseType resolves
+        // rather than dangling on a missing standard element.
+        string tempDirectory = NewTempDirectory();
+        try
+        {
+            GumService service = new();
+#pragma warning disable CS0618 // ColoredRectangle is obsolete but old live trees still contain it.
+            service.Root.AddChild(new ColoredRectangleRuntime { Name = "Rect" });
+#pragma warning restore CS0618
+
+            string gumxPath = Path.Combine(tempDirectory, "Live." + GumProjectSave.ProjectExtension);
+            service.ExportSnapshot(gumxPath);
+
+            GumProjectSave loaded = GumProjectSave.Load(gumxPath, out _);
+            loaded.Screens.First(s => s.Name == "Live").Instances
+                .First(i => i.Name == "Rect").BaseType.ShouldBe("ColoredRectangle");
+            loaded.StandardElements.Any(s => s.Name == "ColoredRectangle").ShouldBeTrue();
+        }
+        finally
+        {
+            DeleteTempDirectory(tempDirectory);
+        }
+    }
+
+    [Fact]
     public void ExportSnapshot_ShouldSetCanvasSizeFromRuntimeCanvas()
     {
         // The exported project's resolution should match the live canvas (the game's resolution), not

--- a/MonoGameGum.Tests/Wireframe/RuntimeSnapshotSerializerProjectTests.cs
+++ b/MonoGameGum.Tests/Wireframe/RuntimeSnapshotSerializerProjectTests.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Gum.DataTypes;
+using Gum.DataTypes.Variables;
 using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
@@ -15,6 +16,72 @@ namespace MonoGameGum.Tests.Wireframe;
 
 public class RuntimeSnapshotSerializerProjectTests : BaseTestClass
 {
+    [Fact]
+    public void ExportSnapshot_ShouldWriteShakenLoadableProjectFromLiveRoot()
+    {
+        string tempDirectory = NewTempDirectory();
+        try
+        {
+            // Exercise the public entry point: build a live tree under a GumService's Root, then export.
+            GumService service = new();
+            ContainerRuntime panel = new() { Name = "Panel" };
+            TextRuntime label = new() { Name = "Label" };
+            label.Text = "Hi"; // differs from the standard Text default -> survives the shake
+            panel.AddChild(label);
+            service.Root.AddChild(panel);
+
+            string gumxPath = Path.Combine(tempDirectory, "Live." + GumProjectSave.ProjectExtension);
+            service.ExportSnapshot(gumxPath);
+
+            GumProjectSave loaded = GumProjectSave.Load(gumxPath, out GumLoadResult loadResult);
+
+            loaded.ShouldNotBeNull();
+            loadResult.ErrorMessage.ShouldBeNullOrEmpty();
+            loadResult.MissingFiles.ShouldBeEmpty();
+
+            // The screen is named after the file; the live tree is flattened into instances.
+            ScreenSave loadedScreen = loaded.Screens.First(s => s.Name == "Live");
+            loadedScreen.Instances.Select(i => i.Name).ShouldBe(new[] { "Panel", "Label" }, ignoreOrder: true);
+
+            // Shaken by default: the changed value survives, a default-valued one is pruned.
+            StateSave defaultState = loadedScreen.States.First(s => s.Name == "Default");
+            defaultState.Variables.ShouldContain(v => v.Name == "Label.Text");
+            defaultState.Variables.ShouldNotContain(v => v.Name == "Label.Visible");
+        }
+        finally
+        {
+            DeleteTempDirectory(tempDirectory);
+        }
+    }
+
+    [Fact]
+    public void Snapshot_Shaken_ShouldWriteProjectThatLoadsWithoutErrors()
+    {
+        string tempDirectory = NewTempDirectory();
+        try
+        {
+            string gumxPath = BuildAndSaveSnapshot(tempDirectory, shake: true);
+
+            GumProjectSave loaded = GumProjectSave.Load(gumxPath, out GumLoadResult loadResult);
+
+            loaded.ShouldNotBeNull();
+            loadResult.ErrorMessage.ShouldBeNullOrEmpty();
+            loadResult.MissingFiles.ShouldBeEmpty();
+
+            ScreenSave loadedScreen = loaded.Screens.First(s => s.Name == "Snapshot");
+            loadedScreen.Instances.Select(i => i.Name).ShouldBe(new[] { "Panel", "Label" }, ignoreOrder: true);
+
+            // Shaken: Label.Text (="Hi") differs from the default and is kept; Label.Visible matches and is pruned.
+            StateSave defaultState = loadedScreen.States.First(s => s.Name == "Default");
+            defaultState.Variables.ShouldContain(v => v.Name == "Label.Text");
+            defaultState.Variables.ShouldNotContain(v => v.Name == "Label.Visible");
+        }
+        finally
+        {
+            DeleteTempDirectory(tempDirectory);
+        }
+    }
+
     [Fact]
     public void Snapshot_ShouldWriteProjectThatLoadsWithoutErrors()
     {
@@ -40,7 +107,18 @@ public class RuntimeSnapshotSerializerProjectTests : BaseTestClass
     }
 
     [Fact]
+    public async Task Snapshot_Shaken_ShouldPassGumCliCheck()
+    {
+        await RunGumCliCheck(shake: true);
+    }
+
+    [Fact]
     public async Task Snapshot_ShouldPassGumCliCheck()
+    {
+        await RunGumCliCheck(shake: false);
+    }
+
+    private static async Task RunGumCliCheck(bool shake)
     {
         // The full integrity check uses the real CLI. It runs as a separate OS process (not an
         // in-process reference) because Gum.ProjectServices and MonoGameGum both compile the Forms
@@ -49,7 +127,7 @@ public class RuntimeSnapshotSerializerProjectTests : BaseTestClass
         string tempDirectory = NewTempDirectory();
         try
         {
-            string gumxPath = BuildAndSaveSnapshot(tempDirectory);
+            string gumxPath = BuildAndSaveSnapshot(tempDirectory, shake);
             string cliProject = LocateGumCliCsproj();
             string configuration = DetectBuildConfiguration();
 
@@ -87,7 +165,7 @@ public class RuntimeSnapshotSerializerProjectTests : BaseTestClass
         }
     }
 
-    private static string BuildAndSaveSnapshot(string tempDirectory)
+    private static string BuildAndSaveSnapshot(string tempDirectory, bool shake = false)
     {
         StandardElementsManager.Self.Initialize();
 
@@ -103,7 +181,7 @@ public class RuntimeSnapshotSerializerProjectTests : BaseTestClass
         // instances' BaseTypes resolve). Standards population is a composition-root concern, kept out
         // of the catalog-injected serializer.
         RuntimeSnapshotSerializer serializer = new(StandardElementsManager.Self.DefaultStates);
-        ScreenSave screen = serializer.CreateScreenSave(root, "Snapshot");
+        ScreenSave screen = serializer.CreateScreenSave(root, "Snapshot", shake);
 
         GumProjectSave project = new();
         StandardElementsManager.Self.PopulateProjectWithDefaultStandards(project);

--- a/MonoGameGum.Tests/Wireframe/RuntimeSnapshotSerializerProjectTests.cs
+++ b/MonoGameGum.Tests/Wireframe/RuntimeSnapshotSerializerProjectTests.cs
@@ -167,6 +167,37 @@ public class RuntimeSnapshotSerializerProjectTests : BaseTestClass
     }
 
     [Fact]
+    public void ExportSnapshot_ShouldSetCanvasSizeFromRuntimeCanvas()
+    {
+        // The exported project's resolution should match the live canvas (the game's resolution), not
+        // the 800x600 GumProjectSave default.
+        float originalWidth = GraphicalUiElement.CanvasWidth;
+        float originalHeight = GraphicalUiElement.CanvasHeight;
+        string tempDirectory = NewTempDirectory();
+        try
+        {
+            GraphicalUiElement.CanvasWidth = 1920;
+            GraphicalUiElement.CanvasHeight = 1080;
+
+            GumService service = new();
+            service.Root.AddChild(new ContainerRuntime { Name = "Panel" });
+
+            string gumxPath = Path.Combine(tempDirectory, "Live." + GumProjectSave.ProjectExtension);
+            service.ExportSnapshot(gumxPath);
+
+            GumProjectSave loaded = GumProjectSave.Load(gumxPath, out _);
+            loaded.DefaultCanvasWidth.ShouldBe(1920);
+            loaded.DefaultCanvasHeight.ShouldBe(1080);
+        }
+        finally
+        {
+            GraphicalUiElement.CanvasWidth = originalWidth;
+            GraphicalUiElement.CanvasHeight = originalHeight;
+            DeleteTempDirectory(tempDirectory);
+        }
+    }
+
+    [Fact]
     public void ExportSnapshot_ShouldCopyReferencedFilesPreservingRelativePath()
     {
         string originalRelativeDirectory = FileManager.RelativeDirectory;

--- a/MonoGameGum.Tests/Wireframe/RuntimeSnapshotSerializerTests.cs
+++ b/MonoGameGum.Tests/Wireframe/RuntimeSnapshotSerializerTests.cs
@@ -43,6 +43,62 @@ public class RuntimeSnapshotSerializerTests : BaseTestClass
     }
 
     [Fact]
+    public void CreateStateForNode_Shaken_ShouldKeepValueDifferentFromDefault()
+    {
+        // The standard Container default has Visible = true; a live element that differs must be kept.
+        ContainerRuntime container = new();
+        container.Visible = false;
+
+        RuntimeSnapshotSerializer serializer = CreateSerializer();
+        StateSave state = serializer.CreateStateForNode(container, "Default", shake: true);
+
+        state.Variables.ShouldContain(v => v.Name == "Visible");
+    }
+
+    [Fact]
+    public void CreateStateForNode_Shaken_ShouldOmitValueEqualToDefault()
+    {
+        // Visible = true matches the standard Container default, so the shake prunes it.
+        ContainerRuntime container = new();
+        container.Visible = true;
+
+        RuntimeSnapshotSerializer serializer = CreateSerializer();
+        StateSave state = serializer.CreateStateForNode(container, "Default", shake: true);
+
+        state.Variables.ShouldNotContain(v => v.Name == "Visible");
+    }
+
+    [Fact]
+    public void CreateStateForNode_Unshaken_ShouldKeepValueEqualToDefault()
+    {
+        // Without shaking, even a default-valued variable is emitted (the always-correct, heavy mode).
+        ContainerRuntime container = new();
+        container.Visible = true;
+
+        RuntimeSnapshotSerializer serializer = CreateSerializer();
+        StateSave state = serializer.CreateStateForNode(container, "Default");
+
+        state.Variables.ShouldContain(v => v.Name == "Visible");
+    }
+
+    [Fact]
+    public void CreateScreenSave_Shaken_ShouldOmitDefaultValuedQualifiedVariables()
+    {
+        ContainerRuntime root = new();
+        TextRuntime label = new() { Name = "Label" };
+        label.Text = "Hi";    // differs from the standard Text default ("Hello") -> kept
+        label.Visible = true; // matches the standard default -> pruned
+        root.AddChild(label);
+
+        RuntimeSnapshotSerializer serializer = CreateSerializer();
+        ScreenSave screen = serializer.CreateScreenSave(root, "Snapshot", shake: true);
+
+        StateSave defaultState = screen.States.First(s => s.Name == "Default");
+        defaultState.Variables.ShouldContain(v => v.Name == "Label.Text");
+        defaultState.Variables.ShouldNotContain(v => v.Name == "Label.Visible");
+    }
+
+    [Fact]
     public void CreateScreenSave_ShouldFlattenTreeIntoInstancesWithBaseTypes()
     {
         ContainerRuntime root = new();

--- a/MonoGameGum.Tests/Wireframe/RuntimeSnapshotSerializerTests.cs
+++ b/MonoGameGum.Tests/Wireframe/RuntimeSnapshotSerializerTests.cs
@@ -169,6 +169,28 @@ public class RuntimeSnapshotSerializerTests : BaseTestClass
     }
 
     [Fact]
+    public void CreateScreenSave_ShouldElideFormsScreenWrapperAndPromoteChildren()
+    {
+        // A Forms screen's visual is a plain ContainerRuntime with FormsControlAsObject set (the codegen
+        // template does exactly this). Even though it's a standard type, its Forms identity marks it as
+        // the screen, so it is elided and its children become the screen's top-level instances.
+        ContainerRuntime root = new();
+        ContainerRuntime formsScreen = new() { Name = "MainMenu" };
+        formsScreen.FormsControlAsObject = new object();
+        TextRuntime title = new() { Name = "Title" };
+        ContainerRuntime panel = new() { Name = "Panel" };
+        formsScreen.AddChild(title);
+        formsScreen.AddChild(panel);
+        root.AddChild(formsScreen);
+
+        RuntimeSnapshotSerializer serializer = CreateSerializer();
+        ScreenSave screen = serializer.CreateScreenSave(root, "Snapshot");
+
+        screen.Instances.Select(i => i.Name).ShouldBe(new[] { "Title", "Panel" }, ignoreOrder: true);
+        screen.Instances.Any(i => i.Name == "MainMenu").ShouldBeFalse();
+    }
+
+    [Fact]
     public void CreateScreenSave_ShouldKeepStandardContainerWrapperAsInstance()
     {
         // A plain ContainerRuntime is a standard layout element, not an authored screen, so it stays a

--- a/MonoGameGum.Tests/Wireframe/RuntimeSnapshotSerializerTests.cs
+++ b/MonoGameGum.Tests/Wireframe/RuntimeSnapshotSerializerTests.cs
@@ -144,6 +144,84 @@ public class RuntimeSnapshotSerializerTests : BaseTestClass
     }
 
     [Fact]
+    public void CreateScreenSave_ShouldElideCustomScreenWrapperAndPromoteChildren()
+    {
+        // Root -> [custom screen container -> items]: the authored custom type IS the screen (the
+        // code-only equivalent of a Gum Screen), so its children become the screen's top-level
+        // instances and the wrapper itself is not emitted.
+        ContainerRuntime root = new();
+        CustomScreenRuntime mainMenu = new() { Name = "MainMenu" };
+        TextRuntime title = new() { Name = "Title" };
+        ContainerRuntime panel = new() { Name = "Panel" };
+        mainMenu.AddChild(title);
+        mainMenu.AddChild(panel);
+        root.AddChild(mainMenu);
+
+        RuntimeSnapshotSerializer serializer = CreateSerializer();
+        ScreenSave screen = serializer.CreateScreenSave(root, "Snapshot");
+
+        screen.Instances.Select(i => i.Name).ShouldBe(new[] { "Title", "Panel" }, ignoreOrder: true);
+        screen.Instances.Any(i => i.Name == "MainMenu").ShouldBeFalse();
+
+        // Promoted children are top-level, so they carry no Parent variable.
+        StateSave defaultState = screen.States.First(s => s.Name == "Default");
+        defaultState.Variables.Any(v => v.Name == "Title.Parent").ShouldBeFalse();
+    }
+
+    [Fact]
+    public void CreateScreenSave_ShouldKeepStandardContainerWrapperAsInstance()
+    {
+        // A plain ContainerRuntime is a standard layout element, not an authored screen, so it stays a
+        // normal instance with its children nested under it.
+        ContainerRuntime root = new();
+        ContainerRuntime wrapper = new() { Name = "Wrapper" };
+        TextRuntime title = new() { Name = "Title" };
+        wrapper.AddChild(title);
+        root.AddChild(wrapper);
+
+        RuntimeSnapshotSerializer serializer = CreateSerializer();
+        ScreenSave screen = serializer.CreateScreenSave(root, "Snapshot");
+
+        screen.Instances.Any(i => i.Name == "Wrapper").ShouldBeTrue();
+        StateSave defaultState = screen.States.First(s => s.Name == "Default");
+        defaultState.Variables.First(v => v.Name == "Title.Parent").Value.ShouldBe("Wrapper");
+    }
+
+    [Fact]
+    public void CreateScreenSave_ShouldKeepCustomLeafAsInstance()
+    {
+        // A custom type with no children is not a screen (a screen contains things); keep it as an
+        // instance rather than collapsing it into an empty screen.
+        ContainerRuntime root = new();
+        CustomScreenRuntime lonely = new() { Name = "Lonely" };
+        root.AddChild(lonely);
+
+        RuntimeSnapshotSerializer serializer = CreateSerializer();
+        ScreenSave screen = serializer.CreateScreenSave(root, "Snapshot");
+
+        screen.Instances.Select(i => i.Name).ShouldBe(new[] { "Lonely" });
+    }
+
+    [Fact]
+    public void CreateScreenSave_ShouldKeepAllChildrenAtTopLevelWhenRootHasMultiple()
+    {
+        // With more than one element under Root there is no single "screen"; everything becomes a
+        // top-level instance, including a custom type.
+        ContainerRuntime root = new();
+        CustomScreenRuntime mainMenu = new() { Name = "MainMenu" };
+        mainMenu.AddChild(new TextRuntime { Name = "Title" });
+        ContainerRuntime extra = new() { Name = "Extra" };
+        root.AddChild(mainMenu);
+        root.AddChild(extra);
+
+        RuntimeSnapshotSerializer serializer = CreateSerializer();
+        ScreenSave screen = serializer.CreateScreenSave(root, "Snapshot");
+
+        screen.Instances.Any(i => i.Name == "MainMenu").ShouldBeTrue();
+        screen.Instances.Any(i => i.Name == "Extra").ShouldBeTrue();
+    }
+
+    [Fact]
     public void GetReferencedFiles_ShouldReturnDistinctSourceFilePaths()
     {
         ContainerRuntime root = new();
@@ -183,5 +261,11 @@ public class RuntimeSnapshotSerializerTests : BaseTestClass
         RuntimeSnapshotSerializer serializer = CreateSerializer();
 
         serializer.GetStandardTypeName(new GraphicalUiElement()).ShouldBeNull();
+    }
+
+    // Stands in for a game-authored screen/component type (e.g. "MainMenu : ContainerRuntime"). Its own
+    // name is not a standard-element name, so the serializer treats it as custom rather than standard.
+    private class CustomScreenRuntime : ContainerRuntime
+    {
     }
 }

--- a/MonoGameGum.Tests/Wireframe/RuntimeSnapshotSerializerTests.cs
+++ b/MonoGameGum.Tests/Wireframe/RuntimeSnapshotSerializerTests.cs
@@ -144,6 +144,24 @@ public class RuntimeSnapshotSerializerTests : BaseTestClass
     }
 
     [Fact]
+    public void GetReferencedFiles_ShouldReturnDistinctSourceFilePaths()
+    {
+        ContainerRuntime root = new();
+        SpriteRuntime sprite = new() { Name = "Sprite" };
+        Microsoft.Xna.Framework.Graphics.Texture2D texture =
+            (Microsoft.Xna.Framework.Graphics.Texture2D)System.Runtime.CompilerServices.RuntimeHelpers
+                .GetUninitializedObject(typeof(Microsoft.Xna.Framework.Graphics.Texture2D));
+        texture.Name = "UI/button.png";
+        sprite.Texture = texture;
+        root.AddChild(sprite);
+
+        RuntimeSnapshotSerializer serializer = CreateSerializer();
+        ScreenSave screen = serializer.CreateScreenSave(root, "Snapshot", shake: true);
+
+        serializer.GetReferencedFiles(screen).ShouldBe(new[] { "UI/button.png" });
+    }
+
+    [Fact]
     public void GetStandardTypeName_ShouldResolveContainerRuntime()
     {
         RuntimeSnapshotSerializer serializer = CreateSerializer();

--- a/MonoGameGum/GumService.cs
+++ b/MonoGameGum/GumService.cs
@@ -317,12 +317,10 @@ public class GumService : IGumService
     public InteractiveGue ModalRoot => FrameworkElement.ModalRoot;
 
     /// <summary>
-    /// Exports a snapshot of the live UI tree under <see cref="Root"/> to a Gum project at
-    /// <paramref name="filePath"/>, so it can be opened and inspected in the Gum tool. This is the
-    /// runtime inspector's headline path for code-only games, which have no design-time .gumx to open.
-    /// Each runtime element is written as a standard-element instance and the screen is named after the
-    /// file. The snapshot is read-only in practice: editing it in the tool does not round-trip back to
-    /// the running game.
+    /// Exports the live UI tree under <see cref="Root"/> to a Gum project at <paramref name="filePath"/>,
+    /// so it can be opened and inspected in the Gum tool. This is the headline path for code-only games,
+    /// which have no design-time .gumx to open. Each runtime element is written as a standard-element
+    /// instance and the screen is named after the file.
     /// </summary>
     /// <param name="filePath">
     /// Destination project (.gumx) path. Its directory receives the Screens/ and Standards/ subfolders.

--- a/MonoGameGum/GumService.cs
+++ b/MonoGameGum/GumService.cs
@@ -13,6 +13,7 @@ using RenderingLibrary.Content;
 using RenderingLibrary.Graphics;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Text;
@@ -314,6 +315,52 @@ public class GumService : IGumService
     public InteractiveGue PopupRoot => FrameworkElement.PopupRoot;
     /// <inheritdoc/>
     public InteractiveGue ModalRoot => FrameworkElement.ModalRoot;
+
+    /// <summary>
+    /// Exports a snapshot of the live UI tree under <see cref="Root"/> to a Gum project at
+    /// <paramref name="filePath"/>, so it can be opened and inspected in the Gum tool. This is the
+    /// runtime inspector's headline path for code-only games, which have no design-time .gumx to open.
+    /// Each runtime element is written as a standard-element instance and the screen is named after the
+    /// file. The snapshot is read-only in practice: editing it in the tool does not round-trip back to
+    /// the running game.
+    /// </summary>
+    /// <param name="filePath">
+    /// Destination project (.gumx) path. Its directory receives the Screens/ and Standards/ subfolders.
+    /// </param>
+    /// <param name="shake">
+    /// When true (default), values equal to the standard-element default are pruned so the artifact is
+    /// light and reads as "unedited" in the tool. When false, every value is written — heavier, but the
+    /// always-correct baseline-free form.
+    /// </param>
+    public void ExportSnapshot(string filePath, bool shake = true)
+    {
+        // A code-only game may never have triggered standards population; ensure the catalog exists
+        // before reading it (as the serializer's baseline) and writing it (as the project's standards).
+        if (StandardElementsManager.Self.DefaultStates == null)
+        {
+            StandardElementsManager.Self.Initialize();
+        }
+
+        string screenName = Path.GetFileNameWithoutExtension(filePath);
+
+        // Non-null here: the guard above initializes the catalog when it was missing.
+        RuntimeSnapshotSerializer serializer = new(StandardElementsManager.Self.DefaultStates!);
+        ScreenSave screen = serializer.CreateScreenSave(Root, screenName, shake);
+
+        GumProjectSave project = new();
+        StandardElementsManager.Self.PopulateProjectWithDefaultStandards(project);
+        project.Screens.Add(screen);
+        project.ScreenReferences.Add(new ElementReference { Name = screenName, ElementType = ElementType.Screen });
+
+        string? directory = Path.GetDirectoryName(filePath);
+        if (!string.IsNullOrEmpty(directory))
+        {
+            Directory.CreateDirectory(Path.Combine(directory, ElementReference.ScreenSubfolder));
+            Directory.CreateDirectory(Path.Combine(directory, ElementReference.StandardSubfolder));
+        }
+
+        project.Save(filePath, saveElements: true);
+    }
 
     /// <summary>
     /// Re-applies all styles on Root, PopupRoot, and ModalRoot. Call after

--- a/MonoGameGum/GumService.cs
+++ b/MonoGameGum/GumService.cs
@@ -358,6 +358,50 @@ public class GumService : IGumService
         }
 
         project.Save(filePath, saveElements: true);
+
+        if (!string.IsNullOrEmpty(directory))
+        {
+            CopyReferencedFiles(serializer, screen, directory);
+        }
+    }
+
+    // Bundles the files referenced by the snapshot (Sprite/NineSlice textures, ...) next to the project
+    // so it opens self-contained in the tool. Relative references are copied preserving their relative
+    // path; absolute references already resolve on their own, and missing files are skipped (logged).
+    private static void CopyReferencedFiles(IRuntimeSnapshotSerializer serializer, ScreenSave screen, string snapshotDirectory)
+    {
+        foreach (string referencedPath in serializer.GetReferencedFiles(screen))
+        {
+            if (!FileManager.IsRelative(referencedPath))
+            {
+                continue;
+            }
+
+            string absoluteSource;
+            try
+            {
+                absoluteSource = FileManager.MakeAbsolute(referencedPath);
+            }
+            catch (ArgumentException)
+            {
+                continue;
+            }
+
+            if (!File.Exists(absoluteSource))
+            {
+                System.Diagnostics.Debug.WriteLine($"Snapshot: referenced file not found, skipping: {referencedPath}");
+                continue;
+            }
+
+            string destination = Path.Combine(snapshotDirectory,
+                referencedPath.Replace('/', Path.DirectorySeparatorChar).Replace('\\', Path.DirectorySeparatorChar));
+            string? destinationDirectory = Path.GetDirectoryName(destination);
+            if (!string.IsNullOrEmpty(destinationDirectory))
+            {
+                Directory.CreateDirectory(destinationDirectory);
+            }
+            File.Copy(absoluteSource, destination, overwrite: true);
+        }
     }
 
     /// <summary>

--- a/MonoGameGum/GumService.cs
+++ b/MonoGameGum/GumService.cs
@@ -362,6 +362,8 @@ public class GumService : IGumService
         project.Screens.Add(screen);
         project.ScreenReferences.Add(new ElementReference { Name = screenName, ElementType = ElementType.Screen });
 
+        EnsureReferencedStandardsExist(project, screen);
+
         string? directory = Path.GetDirectoryName(filePath);
         if (!string.IsNullOrEmpty(directory))
         {
@@ -374,6 +376,28 @@ public class GumService : IGumService
         if (!string.IsNullOrEmpty(directory))
         {
             CopyReferencedFiles(serializer, screen, directory);
+        }
+    }
+
+    // Instances may reference standard types the default seed omits -- notably deprecated ones like
+    // ColoredRectangle, which new (v3) projects no longer include but an old/live tree may still contain.
+    // Add any such referenced standard so the snapshot's instances don't dangle on a missing base type.
+    private static void EnsureReferencedStandardsExist(GumProjectSave project, ScreenSave screen)
+    {
+        HashSet<string> existing = new(project.StandardElements.Select(standard => standard.Name));
+        foreach (InstanceSave instance in screen.Instances)
+        {
+            string baseType = instance.BaseType;
+            if (string.IsNullOrEmpty(baseType) || existing.Contains(baseType))
+            {
+                continue;
+            }
+
+            if (StandardElementsManager.Self.IsDefaultType(baseType))
+            {
+                StandardElementsManager.Self.AddStandardElementSaveInstance(project, baseType);
+                existing.Add(baseType);
+            }
         }
     }
 

--- a/MonoGameGum/GumService.cs
+++ b/MonoGameGum/GumService.cs
@@ -347,6 +347,18 @@ public class GumService : IGumService
 
         GumProjectSave project = new();
         StandardElementsManager.Self.PopulateProjectWithDefaultStandards(project);
+
+        // Match the project's canvas resolution to the live canvas (the game's resolution) so the
+        // snapshot lays out in the tool exactly as it did at runtime, rather than the 800x600 default.
+        if (GraphicalUiElement.CanvasWidth > 0)
+        {
+            project.DefaultCanvasWidth = (int)GraphicalUiElement.CanvasWidth;
+        }
+        if (GraphicalUiElement.CanvasHeight > 0)
+        {
+            project.DefaultCanvasHeight = (int)GraphicalUiElement.CanvasHeight;
+        }
+
         project.Screens.Add(screen);
         project.ScreenReferences.Add(new ElementReference { Name = screenName, ElementType = ElementType.Screen });
 


### PR DESCRIPTION
## What

Two increments toward the runtime UI inspector (#3070), building on the snapshot serializer **foundation** merged in #3071:

### 1. The shake (prune equal-to-default variables)

`RuntimeSnapshotSerializer.CreateStateForNode` / `CreateScreenSave` gain an optional `bool shake = false`. When `true`, a value equal to the **standard-element default** is pruned. That default is the in-document baseline — already injected into the serializer as `_defaultStates` and written into the snapshot's own `Standards/*.gutx`. An omitted variable therefore resolves to that *same* default on load, so the shaken state is **equivalent but lighter** and reads as "unedited" in the tool (instead of every variable showing the edited icon).

- Equality via a private `AreValuesEqual` (same-boxed-type direct compare for bool/string/enum/int; numeric cross-type compared as `double`).
- Default `false` preserves the always-correct heavy/unshaken mode and keeps all existing tests green.
- Only the **standard-vs-default** relation is implemented — the only one a code-only snapshot needs, since every node flattens to a standard-element instance.

### 2. `GumService.ExportSnapshot(string filePath, bool shake = true)`

The public entry point for code-only games (which have no design-time `.gumx` to open). Serializes the live `Root` tree to a Gum project: ensures `StandardElementsManager` is initialized, shakes by default, names the screen after the file, populates standards, creates the `Screens/`+`Standards/` subfolders, and saves via `GumProjectSave.Save(saveElements: true)`. Uses only GumCommon types, so it compiles for both XNALIKE and RAYLIB. It writes a plain `.gumx` to the caller's path — no special marking or isolation imposed.

### 3. Texture-bearing types + referenced-file copy (found via manual soak test)

A `NineSlice`/`Sprite` carrying a texture crashed the export — the reader returned the `Texture2D` for `SourceFile` and the XML serializer cannot write it. The snapshot tests had only ever used `Container`/`Text`, so this dimension was untested.

- **Crash fix:** the serializer skips any non-save-safe value (string/bool/numeric/enum) — defensive against any runtime object reaching a `VariableSave`.
- **`SourceFile` → path:** the reader emits the source path from `Texture2D.Name` (stamped by the content loader on load) instead of the texture object; returns false (skipped) when there is no texture.
- **Copy referenced files:** `ExportSnapshot` copies each *relative* `SourceFile` next to the `.gumx` preserving its relative path, so the snapshot opens self-contained. Absolute refs resolve on their own; missing files are skipped + logged.
- **Coverage:** a new test exercises all 8 standard types (the gap that let the crash through).

## Tests

- **4 serializer shake tests** — including a prune pair verified **red → green** (temporarily neutralizing the prune fails exactly the two "should omit" tests, proving they aren't vacuous).
- **3 project tests** — shaken load round-trip, shaken **`gumcli check`** (the inline CLI runner was refactored into a shared `RunGumCliCheck(bool shake)` so *both* modes are guarded), and an `ExportSnapshot` end-to-end (live `Root` → load → assert flatten + shake). The XNALIKE-only path is reached headlessly via a fresh `new GumService()` (its constructor is GPU-free and the `Root` collection-changed handler is a no-op on `Add`).
- Full `MonoGameGum.Tests` suite: **1653 / 1653 green**. `RaylibGum` builds (RAYLIB path of `GumService.cs`).

## Notes / deliberate scope

- **Does not close #3070** — this advances the inspector feature; the umbrella issue stays open. (It was reopened: #3071 auto-closed it via a stray `(#3070)` in the squash subject, against intent.)
- **Baseline "stamp" = the embedded standards.** The spec called for stamping the shake baseline; no separate marker was added because the snapshot already embeds the exact standards the shake compares against, so producer and consumer share the baseline by construction.
- No `GumCoreShared.projitems` changes: the serializer is intentionally FRB-excluded and `GumService.cs` isn't shared with FRB.

Part of #3070.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



