### PR TITLE
Stop behavior tool-only references from spamming default-derived selectors (#3080)

### DIFF
--- a/Gum/Plugins/InternalPlugins/VariableGrid/BehaviorToolOnlyReferencesApplier.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/BehaviorToolOnlyReferencesApplier.cs
@@ -103,6 +103,29 @@ public static class BehaviorToolOnlyReferencesApplier
             return;
         }
 
+        // Skip materializing a value identical to the resting wireframe — the value the
+        // reference produces when nothing is authored and every identifier resolves to its
+        // FormsProperty default. The resting state is the empty default state of a throwaway
+        // empty element (no instances, no base type), so every lookup falls straight through
+        // to the fallback, yielding that resting value. The element must be a fresh throwaway,
+        // not the real one: a state carrying the real element would re-resolve the element's
+        // authored default state and defeat the comparison. It also must be the element's
+        // default state (States[0]) and carry a non-null ParentContainer, or
+        // RecursiveVariableFinder/GetValueRecursive throw. When the authored result matches
+        // the resting value, the assignment carries no information beyond the resting preview,
+        // so writing it only spams the state — e.g. every Forms-control instance's
+        // "<Instance>.<X>CategoryState = Enabled" in a screen that overrode nothing
+        // (issue #3080). Only authored deviations from rest (IsEnabled = false, a checked
+        // CheckBox, etc.) are worth materializing.
+        ComponentSave restingOwner = new ComponentSave();
+        StateSave restingState = new StateSave { ParentContainer = restingOwner };
+        restingOwner.States.Add(restingState);
+        EvaluatedSyntax? resting = EvaluatedSyntax.FromSyntaxNode(rightSyntax, restingState, fallback);
+        if (resting != null && Equals(resting.Value, evaluated.Value))
+        {
+            return;
+        }
+
         string effectiveLeft = instance == null ? left : $"{instance.Name}.{left}";
         stateSave.SetValue(effectiveLeft, evaluated.Value, instance);
     }

--- a/Tool/Tests/GumToolUnitTests/VariableGrid/BehaviorToolOnlyReferencesApplierTests.cs
+++ b/Tool/Tests/GumToolUnitTests/VariableGrid/BehaviorToolOnlyReferencesApplierTests.cs
@@ -131,14 +131,64 @@ public class BehaviorToolOnlyReferencesApplierTests : BaseTestClass
     }
 
     [Fact]
-    public void Apply_StateMissingIdentifier_FallsBackToBehaviorFormsPropertyDefault()
+    public void Apply_ScreenWithUnauthoredButtonInstance_DoesNotMaterializeSelector()
     {
+        // Repro #3080: a screen/component holding many Forms-control instances (buttons,
+        // checkboxes, combos...) got every instance's category selector spammed into its
+        // state - MapCreateButton.ButtonCategoryState, IsStartingMapCheckbox.CheckBoxCategoryState,
+        // etc. - even when the instance authored nothing. The selector value derived purely
+        // from the behavior's FormsProperty default (IsEnabled = true -> "Enabled"), so it
+        // carries no information beyond the resting wireframe and must NOT be written.
+        BehaviorSave behavior = new BehaviorSave { Name = "ButtonBehavior" };
+        behavior.FormsProperties.Add(new VariableSave { Type = "bool", Name = "IsEnabled", Value = true });
+        behavior.ToolOnlyVariableReferences.Add(
+            "ButtonCategoryState = IsEnabled ? \"Enabled\" : \"Disabled\"");
+
+        ComponentSave component = new ComponentSave { Name = "Controls/ButtonStandard", BaseType = "Container" };
+        component.States.Add(new StateSave { Name = "Default", ParentContainer = component });
+        component.Behaviors.Add(new ElementBehaviorReference { BehaviorName = "ButtonBehavior" });
+
+        ScreenSave screen = new ScreenSave { Name = "TestScreen" };
+        StateSave screenDefault = new StateSave { Name = "Default", ParentContainer = screen };
+        screen.States.Add(screenDefault);
+
+        InstanceSave buttonInstance = new InstanceSave
+        {
+            Name = "ButtonInstance",
+            BaseType = "Controls/ButtonStandard",
+            ParentContainer = screen
+        };
+        screen.Instances.Add(buttonInstance);
+
+        StandardElementSave containerStandard = new StandardElementSave { Name = "Container" };
+        containerStandard.States.Add(new StateSave { Name = "Default", ParentContainer = containerStandard });
+
+        GumProjectSave project = new GumProjectSave();
+        project.StandardElements.Add(containerStandard);
+        project.Components.Add(component);
+        project.Screens.Add(screen);
+        project.Behaviors.Add(behavior);
+        ObjectFinder.Self.GumProjectSave = project;
+
+        BehaviorToolOnlyReferencesApplier.Apply(screen, screenDefault);
+
+        screenDefault.Variables.ShouldNotContain(v => v.Name == "ButtonInstance.ButtonCategoryState",
+            "an instance that authors no driving FormsProperty must not have its selector materialized into the parent state");
+    }
+
+    [Fact]
+    public void Apply_StateMissingIdentifier_DoesNotMaterializeFormsPropertyDefault()
+    {
+        // When nothing is authored, the reference resolves purely from the behavior's
+        // FormsProperty default. That value equals the resting wireframe, so materializing
+        // it into the state adds no information and only spams it (issue #3080). The default
+        // is virtual — "state-empty stays state-empty" — so the selector must not be written.
         BehaviorSave behavior = new BehaviorSave { Name = "ButtonBehavior" };
         behavior.FormsProperties.Add(new VariableSave
         {
             Type = "bool",
             Name = "IsEnabled",
-            Value = false  // declared default, drives the wireframe to "Disabled" with no instance authoring
+            Value = false
         });
         behavior.ToolOnlyVariableReferences.Add(
             "ButtonCategoryState = IsEnabled ? \"Enabled\" : \"Disabled\"");
@@ -155,7 +205,8 @@ public class BehaviorToolOnlyReferencesApplierTests : BaseTestClass
 
         BehaviorToolOnlyReferencesApplier.Apply(component, defaultState);
 
-        defaultState.GetValue("ButtonCategoryState").ShouldBe("Disabled");
+        defaultState.Variables.ShouldNotContain(v => v.Name == "ButtonCategoryState",
+            "a value derived purely from the FormsProperty default equals the resting wireframe and must not be materialized");
     }
 
     [Fact]
@@ -296,8 +347,11 @@ public class BehaviorToolOnlyReferencesApplierTests : BaseTestClass
     }
 
     [Fact]
-    public void Apply_CheckBoxStateEmpty_FallsBackToBehaviorIsCheckedFalseAndIsEnabledTrue()
+    public void Apply_CheckBoxStateEmpty_DoesNotMaterializeFormsPropertyDefault()
     {
+        // With nothing authored, every identifier resolves from the behavior's FormsProperty
+        // defaults (IsEnabled = true, IsChecked = false -> "EnabledOff"). That is the resting
+        // wireframe value, so it must not be materialized into the state (issue #3080).
         BehaviorSave behavior = BuildCheckBoxBehavior();
 
         ComponentSave component = new ComponentSave { Name = "Controls/CheckBox", BaseType = "Container" };
@@ -312,7 +366,8 @@ public class BehaviorToolOnlyReferencesApplierTests : BaseTestClass
 
         BehaviorToolOnlyReferencesApplier.Apply(component, defaultState);
 
-        defaultState.GetValue("CheckBoxCategoryState").ShouldBe("EnabledOff");
+        defaultState.Variables.ShouldNotContain(v => v.Name == "CheckBoxCategoryState",
+            "a value derived purely from the FormsProperty defaults equals the resting wireframe and must not be materialized");
     }
 
     [Fact(Timeout = 5000)]
@@ -328,7 +383,11 @@ public class BehaviorToolOnlyReferencesApplierTests : BaseTestClass
         {
             Type = "string",
             Name = "Toggle",
-            Value = "off"
+            // The FormsProperty default differs from the authored value below so the
+            // authored result ("on") is not suppressed as equal to the resting value
+            // (the resting eval reads Toggle = "on" -> "off"). Keeps this a write-and-
+            // terminate test, not a resting-skip test (issue #3080).
+            Value = "on"
         });
         // RHS reads Toggle, LHS writes Toggle.
         behavior.ToolOnlyVariableReferences.Add(
@@ -365,8 +424,11 @@ public class BehaviorToolOnlyReferencesApplierTests : BaseTestClass
         // B is evaluated against the *already-updated* A. Outcome is deterministic and
         // bounded; no recursion.
         BehaviorSave behavior = new BehaviorSave { Name = "MutualBehavior" };
-        behavior.FormsProperties.Add(new VariableSave { Type = "string", Name = "A", Value = "a0" });
-        behavior.FormsProperties.Add(new VariableSave { Type = "string", Name = "B", Value = "b0" });
+        // FormsProperty defaults differ from the authored a0/b0 below so the authored
+        // results are not suppressed as equal to the resting value (issue #3080); this
+        // stays a write-and-terminate test.
+        behavior.FormsProperties.Add(new VariableSave { Type = "string", Name = "A", Value = "dA" });
+        behavior.FormsProperties.Add(new VariableSave { Type = "string", Name = "B", Value = "dB" });
         behavior.ToolOnlyVariableReferences.Add("A = B + \"->A\"");
         behavior.ToolOnlyVariableReferences.Add("B = A + \"->B\"");
 
@@ -431,6 +493,55 @@ public class BehaviorToolOnlyReferencesApplierTests : BaseTestClass
 
         focusedState.Variables.ShouldNotContain(v => v.Name == "TextBoxCategoryState",
             "a category state must not have its own category's selector materialized into it");
+    }
+
+    [Fact]
+    public void Apply_CheckBoxInstanceAuthoringOnlyIsChecked_StillMaterializesEnabledOn()
+    {
+        // Guard for the resting-comparison fix (#3080): an instance that authors only one of
+        // several driving FormsProperties (IsChecked = true, IsEnabled left at its default) must
+        // still materialize, because the authored result ("EnabledOn") differs from the resting
+        // wireframe ("EnabledOff"). A naive "skip unless every input is authored" gate would
+        // wrongly drop this common case (a checkbox that starts checked).
+        BehaviorSave behavior = BuildCheckBoxBehavior();
+
+        ComponentSave component = new ComponentSave { Name = "Controls/CheckBox", BaseType = "Container" };
+        component.States.Add(new StateSave { Name = "Default", ParentContainer = component });
+        component.Behaviors.Add(new ElementBehaviorReference { BehaviorName = "CheckBoxBehavior" });
+
+        ScreenSave screen = new ScreenSave { Name = "TestScreen" };
+        StateSave screenDefault = new StateSave { Name = "Default", ParentContainer = screen };
+        screen.States.Add(screenDefault);
+
+        InstanceSave checkBoxInstance = new InstanceSave
+        {
+            Name = "CheckBoxInstance",
+            BaseType = "Controls/CheckBox",
+            ParentContainer = screen
+        };
+        screen.Instances.Add(checkBoxInstance);
+
+        screenDefault.Variables.Add(new VariableSave
+        {
+            Type = "bool",
+            Name = "CheckBoxInstance.IsChecked",
+            Value = true,
+            SetsValue = true
+        });
+
+        StandardElementSave containerStandard = new StandardElementSave { Name = "Container" };
+        containerStandard.States.Add(new StateSave { Name = "Default", ParentContainer = containerStandard });
+
+        GumProjectSave project = new GumProjectSave();
+        project.StandardElements.Add(containerStandard);
+        project.Components.Add(component);
+        project.Screens.Add(screen);
+        project.Behaviors.Add(behavior);
+        ObjectFinder.Self.GumProjectSave = project;
+
+        BehaviorToolOnlyReferencesApplier.Apply(screen, screenDefault);
+
+        screenDefault.GetValue("CheckBoxInstance.CheckBoxCategoryState").ShouldBe("EnabledOn");
     }
 
     [Fact]


### PR DESCRIPTION
## Problem

A screen or component holding many Forms-control instances (buttons, checkboxes, combos, text boxes…) accumulated **one materialized category selector per instance** in its state — `MapCreateButton.ButtonCategoryState`, `IsStartingMapCheckbox.CheckBoxCategoryState`, `MapLayerTypeCombo.ComboBoxCategoryState`, and so on — even when the instance overrode nothing. This is the spam in #3080:

![spam](https://github.com/user-attachments/assets/b60b4a6f-5ebf-4430-8b17-0306a08b053a)

### Root cause

`BehaviorToolOnlyReferencesApplier` runs on every variable reaction and evaluates each behavior's `ToolOnlyVariableReference` (e.g. `ButtonCategoryState = IsEnabled ? "Enabled" : "Disabled"`) for the element and for every instance with a behavior. When the driving `FormsProperty` (`IsEnabled`, `IsChecked`, …) was **not authored**, the evaluation fell back to the behavior's declared default (`IsEnabled = true → "Enabled"`), produced a non-null value, and `SetValue` materialized it anyway. With N Forms instances you got N selector assignments baked in and persisted to disk — none carrying any information beyond the resting default.

This violates the feature's own contract (the tier-3 `FormsProperty` default is *virtual* — "state-empty stays state-empty"). The prior fix #3055 narrowed materialization to the default state but did **not** stop the per-instance default-derived writes.

## Fix

Materialize a selector only when the authored result **differs from the resting wireframe** — the value the same reference produces when nothing is authored and every identifier resolves to its `FormsProperty` default.

`ApplyLine` now evaluates the right side a second time against an empty throwaway state (which forces every lookup through the fallback) and skips the `SetValue` when that resting value equals the authored result. This:

- Eliminates the spam (unauthored instances resolve to the resting value → skipped).
- Preserves every authored deviation, including **partial multi-input authoring** — a CheckBox instance that sets only `IsChecked` still materializes `EnabledOn`, because that differs from the resting `EnabledOff`.

**Scope:** stops *new* pollution only; it does not repair already-polluted projects (the `GUM0003` check continues to surface those for manual cleanup), per the chosen approach.

## Tests (TDD)

- New red test `Apply_ScreenWithUnauthoredButtonInstance_DoesNotMaterializeSelector` reproduces #3080 (failed before the fix, passes after).
- New guard `Apply_CheckBoxInstanceAuthoringOnlyIsChecked_StillMaterializesEnabledOn` pins the partial-authoring case (would fail a naive "skip unless every input authored" gate).
- Two tests that asserted the old default-derived materialization (`Apply_StateMissingIdentifier_*`, `Apply_CheckBoxStateEmpty_*`) now assert non-materialization.
- Two termination tests get `FormsProperty` defaults that differ from their authored values so they stay write-and-terminate checks.

`GumToolUnitTests`: **839 passed, 5 skipped, 0 failed.**

Closes #3080

🤖 Generated with [Claude Code](https://claude.com/claude-code)
