### PR TITLE
Fix MenuItem.Clicked firing continuously while mouse held (#3077)

### DIFF
--- a/MonoGameGum/Forms/Controls/MenuItem.cs
+++ b/MonoGameGum/Forms/Controls/MenuItem.cs
@@ -56,6 +56,11 @@ public class MenuItem : ItemsControl
         }
     }
 
+    // Tracks whether Clicked has already been raised for the current mouse hold so
+    // a re-fired push edge cannot raise it repeatedly while the button stays down.
+    // See HandlePush and issue #3077.
+    bool _clickRaisedDuringPush;
+
     protected List<MenuItem> MenuItemsInternal = new List<MenuItem>();
 
     GraphicalUiElement? text;
@@ -335,6 +340,10 @@ public class MenuItem : ItemsControl
     {
         IsHighlighted = false;
 
+        // The cursor left this item, so the current hold is over as far as this
+        // item is concerned - allow the next push to raise Clicked again.
+        _clickRaisedDuringPush = false;
+
         UpdateState();
     }
 
@@ -342,11 +351,20 @@ public class MenuItem : ItemsControl
     {
         if (MainCursor.LastInputDevice == InputDevice.Mouse)
         {
-            // Select on push so the sub-item popup opens immediately and can be
-            // dragged through. Clicked is raised on release (HandleClick) so it
-            // fires once per discrete click rather than every frame the button
-            // is held - see issue #3077.
+            // Menu items activate on push (matching WPF).
             IsSelected = true;
+
+            // Push (cursor.PrimaryPush) is normally a single-frame edge, but it can
+            // re-fire across frames while the button stays physically held - most
+            // notably when a Clicked handler calls Cursor.ClearInputValues(), which
+            // resets the last-frame mouse state so the very next frame reports a
+            // fresh push. Guard so Clicked is raised only once per hold; the guard
+            // is cleared on release (HandleClick) or roll-off. See issue #3077.
+            if (!_clickRaisedDuringPush)
+            {
+                _clickRaisedDuringPush = true;
+                Clicked?.Invoke(this, null);
+            }
         }
     }
 
@@ -355,10 +373,9 @@ public class MenuItem : ItemsControl
     {
         if (MainCursor.LastInputDevice == InputDevice.Mouse)
         {
-            // Visual.Click only fires on the push -> release transition while the
-            // cursor remains over the item that was pushed, so this raises Clicked
-            // exactly once per click, matching ButtonBase.
-            Clicked?.Invoke(this, null);
+            // The button was released, ending the current hold, so the next push
+            // is allowed to raise Clicked again.
+            _clickRaisedDuringPush = false;
         }
         else if (MainCursor.LastInputDevice == InputDevice.TouchScreen &&
             MainCursor.PrimaryClickNoSlide)

--- a/MonoGameGum/Forms/Controls/MenuItem.cs
+++ b/MonoGameGum/Forms/Controls/MenuItem.cs
@@ -342,22 +342,30 @@ public class MenuItem : ItemsControl
     {
         if (MainCursor.LastInputDevice == InputDevice.Mouse)
         {
+            // Select on push so the sub-item popup opens immediately and can be
+            // dragged through. Clicked is raised on release (HandleClick) so it
+            // fires once per discrete click rather than every frame the button
+            // is held - see issue #3077.
             IsSelected = true;
-            Clicked?.Invoke(this, null);
-            
         }
     }
 
 
     private void HandleClick(object sender, EventArgs args)
     {
-        if (MainCursor.LastInputDevice == InputDevice.TouchScreen &&
+        if (MainCursor.LastInputDevice == InputDevice.Mouse)
+        {
+            // Visual.Click only fires on the push -> release transition while the
+            // cursor remains over the item that was pushed, so this raises Clicked
+            // exactly once per click, matching ButtonBase.
+            Clicked?.Invoke(this, null);
+        }
+        else if (MainCursor.LastInputDevice == InputDevice.TouchScreen &&
             MainCursor.PrimaryClickNoSlide)
         {
             IsSelected = true;
 
             Clicked?.Invoke(this, null);
-
         }
     }
     #endregion

--- a/Tests/MonoGameGum.Tests.V2/Forms/MenuItemTests.cs
+++ b/Tests/MonoGameGum.Tests.V2/Forms/MenuItemTests.cs
@@ -48,12 +48,53 @@ public class MenuItemTests : BaseTestClass
     }
 
     [Fact]
+    public void Clicked_ShouldRaiseOnPush_NotOnRelease()
+    {
+        // Pins the WPF-style behavior: a MenuItem activates on push, so Clicked
+        // fires the moment the button goes down - before any release. This guards
+        // against regressing to release (push -> up) semantics.
+        Menu menu = new();
+        menu.AddToRoot();
+        menu.Name = "Menu";
+
+        MenuItem topItem = new();
+        menu.Items.Add(topItem);
+        topItem.Header = "Top Item";
+        topItem.Name = "Top Item";
+
+        int clickedCount = 0;
+        topItem.Clicked += (_, _) => clickedCount++;
+
+        Mock<ICursor> cursor = new();
+        FormsUtilities.SetCursor(cursor.Object);
+        cursor.SetupProperty(x => x.VisualOver);
+        cursor.SetupProperty(x => x.WindowPushed);
+        cursor.Setup(x => x.LastInputDevice).Returns(InputDevice.Mouse);
+
+        GumService.Default.Root.UpdateLayout();
+
+        cursor.Setup(x => x.X).Returns((int)(topItem.Visual.AbsoluteLeft + 1));
+        cursor.Setup(x => x.Y).Returns((int)(topItem.Visual.AbsoluteTop + 1));
+        cursor.Setup(x => x.XRespectingGumZoomAndBounds()).Returns((int)(topItem.Visual.AbsoluteLeft + 1));
+        cursor.Setup(x => x.YRespectingGumZoomAndBounds()).Returns((int)(topItem.Visual.AbsoluteTop + 1));
+
+        // Button goes down but is NOT released this frame.
+        cursor.Setup(x => x.PrimaryPush).Returns(true);
+        cursor.Setup(x => x.PrimaryDown).Returns(true);
+        cursor.Setup(x => x.PrimaryClick).Returns(false);
+
+        GumService.Default.Update(new Microsoft.Xna.Framework.GameTime());
+
+        clickedCount.ShouldBe(1);
+    }
+
+    [Fact]
     public void Clicked_ShouldRaiseOnce_WhenMouseButtonHeldAcrossFrames()
     {
         // Reproduces issue #3077: MenuItem.Clicked fired continuously while the
         // mouse button was held, because it was raised on the push edge and the
         // edge could re-trigger (e.g. a handler calling Cursor.ClearInputValues()).
-        // Clicked should fire exactly once per discrete click (on push -> release).
+        // Clicked still fires on push (WPF behavior) but only once per hold.
         Menu menu = new();
         menu.AddToRoot();
         menu.Name = "Menu";

--- a/Tests/MonoGameGum.Tests.V2/Forms/MenuItemTests.cs
+++ b/Tests/MonoGameGum.Tests.V2/Forms/MenuItemTests.cs
@@ -48,6 +48,59 @@ public class MenuItemTests : BaseTestClass
     }
 
     [Fact]
+    public void Clicked_ShouldRaiseOnce_WhenMouseButtonHeldAcrossFrames()
+    {
+        // Reproduces issue #3077: MenuItem.Clicked fired continuously while the
+        // mouse button was held, because it was raised on the push edge and the
+        // edge could re-trigger (e.g. a handler calling Cursor.ClearInputValues()).
+        // Clicked should fire exactly once per discrete click (on push -> release).
+        Menu menu = new();
+        menu.AddToRoot();
+        menu.Name = "Menu";
+
+        MenuItem topItem = new();
+        menu.Items.Add(topItem);
+        topItem.Header = "Top Item";
+        topItem.Name = "Top Item";
+
+        int clickedCount = 0;
+        topItem.Clicked += (_, _) => clickedCount++;
+
+        Mock<ICursor> cursor = new();
+        FormsUtilities.SetCursor(cursor.Object);
+        cursor.SetupProperty(x => x.VisualOver);
+        cursor.SetupProperty(x => x.WindowPushed);
+        cursor.Setup(x => x.LastInputDevice).Returns(InputDevice.Mouse);
+
+        GumService.Default.Root.UpdateLayout();
+
+        cursor.Setup(x => x.X).Returns((int)(topItem.Visual.AbsoluteLeft + 1));
+        cursor.Setup(x => x.Y).Returns((int)(topItem.Visual.AbsoluteTop + 1));
+        cursor.Setup(x => x.XRespectingGumZoomAndBounds()).Returns((int)(topItem.Visual.AbsoluteLeft + 1));
+        cursor.Setup(x => x.YRespectingGumZoomAndBounds()).Returns((int)(topItem.Visual.AbsoluteTop + 1));
+
+        // Hold the mouse button down across several frames. PrimaryPush stays true
+        // to emulate the edge re-triggering reported in the issue.
+        cursor.Setup(x => x.PrimaryPush).Returns(true);
+        cursor.Setup(x => x.PrimaryDown).Returns(true);
+        cursor.Setup(x => x.PrimaryClick).Returns(false);
+
+        for (int i = 0; i < 3; i++)
+        {
+            GumService.Default.Update(new Microsoft.Xna.Framework.GameTime());
+        }
+
+        // Release the button: this is the single discrete click.
+        cursor.Setup(x => x.PrimaryPush).Returns(false);
+        cursor.Setup(x => x.PrimaryDown).Returns(false);
+        cursor.Setup(x => x.PrimaryClick).Returns(true);
+
+        GumService.Default.Update(new Microsoft.Xna.Framework.GameTime());
+
+        clickedCount.ShouldBe(1);
+    }
+
+    [Fact]
     public void ClickMenuItem_ShouldRaiseClickEvent()
     {
         Menu menu = new();


### PR DESCRIPTION
## Summary

Fixes #3077 — `MenuItem.Clicked` fired continuously while the mouse button was held instead of once per click. **Push activation is preserved** (menu items activate on push, matching WPF); only the repeated firing is fixed.

## Root cause

`MenuItem` raises `Clicked` from `HandlePush` (the `cursor.PrimaryPush` edge). That edge is normally a single frame, but it can re-fire while the button stays physically held. The reported repro shows the self-sustaining loop:

1. Push → `Clicked` fires → the handler calls `Cursor.ClearInputValues()` (a common pattern, used here to stop the click leaking into the newly-opened window).
2. `ClearInputValues` resets the last-frame mouse state to *released*.
3. Next frame, `Cursor.Activity` sees last-frame Released but hardware still Pressed → reports a fresh `PrimaryPush` → `Push` fires again → `Clicked` again → `ClearInputValues` again → repeat every frame.

## Fix

Keep raising `Clicked` on **push**, but guard it with a `_clickRaisedDuringPush` flag so it fires at most once per hold. The guard is cleared when the button is released (`HandleClick`) or the cursor rolls off the item (`HandleRollOff`), so the next genuine push clicks again. `IsSelected` / popup behavior on push is unchanged; the touch path is unchanged.

## Tests (TDD, failing-first)

- `Clicked_ShouldRaiseOnce_WhenMouseButtonHeldAcrossFrames` — holds the button across several frames (emulating the re-fired push edge) and asserts `Clicked` fires once. Before the fix it fired 3×.
- `Clicked_ShouldRaiseOnPush_NotOnRelease` — **pins the WPF push behavior**: with the button down but not yet released, `Clicked` has already fired. Guards against ever regressing to release (push→up) semantics.
- Existing `ClickMenuItem_ShouldRaiseClickEvent` still passes (open-menu / sub-item flow unaffected).
- Full regression: V2 (111), V3 (59), and `MonoGameGum.Tests` (1660) all green.

Closes #3077

🤖 Generated with [Claude Code](https://claude.com/claude-code)
