### PR TITLE
Encapsulate defaults-only expression evaluation to remove the throwaway-element footgun (#3082)

### DIFF
--- a/.claude/skills/gum-tool-variable-references/SKILL.md
+++ b/.claude/skills/gum-tool-variable-references/SKILL.md
@@ -113,6 +113,8 @@ A separate variable-reference flavor lives on `BehaviorSave.ToolOnlyVariableRefe
 
 The applier passes a `fallback` resolver into `EvaluatedSyntax.FromSyntaxNode` so identifiers not authored on state fall back to the behavior's `FormsProperty.Value` declarations (mirrors WPF DependencyProperty default values). Plumbed through `RecursiveVariableFinder.Fallback` — any caller that needs the same "default-when-state-empty" shape can use it.
 
+**Evaluating "defaults-only" (footgun):** To ask "what would this resolve to with *nothing* authored?", do **not** pass an empty `StateSave` to `FromSyntaxNode` — `RecursiveVariableFinder` resolves by name through `ParentContainer`, so an empty state owned by a real element still leaks that element's authored values (routes to its `DefaultState`). Call `EvaluatedSyntax.FromSyntaxNodeUsingDefaultsOnly(node, fallback)` instead; it owns the state with a throwaway empty element so every identifier falls through to the `fallback`. The applier uses this for the "skip if equal to resting wireframe" check (issue #3082).
+
 ## Known Gaps
 
 - **Font generation:** `CollectRequiredFonts` (in `HeadlessFontGenerationService`) and `RecursiveVariableFinder` do not resolve variable references. If a font property (Font, FontSize, etc.) is set via a variable reference, the font file may not be generated for that value. The tool-time path works because `VariableChangedThroughReference` fires `PluginManager.VariableSet`, but headless/CLI font generation could miss these. (See issue #2414)

--- a/Gum/DataTypes/RecursiveVariableFinder.cs
+++ b/Gum/DataTypes/RecursiveVariableFinder.cs
@@ -115,6 +115,17 @@ public class RecursiveVariableFinder : IVariableFinder
         ContainerType = VariableContainerType.StateSave;
     }
 
+    /// <remarks>
+    /// The supplied <paramref name="stateSave"/> is resolved <i>by name</i> through its
+    /// <c>ParentContainer</c>, not treated as a standalone bag of values: the finder records
+    /// <c>ParentContainer</c> plus the state's <c>Name</c>, and <c>GetVariableRecursive</c> routes any
+    /// non-default state up to the owning element's <c>DefaultState</c>. The <c>ParentContainer</c>
+    /// must therefore be non-null (enforced under <c>FULL_DIAGNOSTICS</c>), and lookups dereference
+    /// <c>ParentContainer.DefaultState</c>. A consequence worth calling out: an <i>empty</i> state owned
+    /// by a real element still resolves that element's authored values — to evaluate "with nothing
+    /// authored" the state must be owned by a throwaway element whose only state is its own
+    /// <c>DefaultState</c>. See <c>EvaluatedSyntax.FromSyntaxNodeUsingDefaultsOnly</c> (issue #3082).
+    /// </remarks>
     public RecursiveVariableFinder(StateSave stateSave)
     {
 #if FULL_DIAGNOSTICS

--- a/Gum/DataTypes/StateSaveExtensionMethods.cs
+++ b/Gum/DataTypes/StateSaveExtensionMethods.cs
@@ -31,9 +31,18 @@ public static class StateSaveExtensionMethods
     }
 
     /// <summary>
-    /// Returns the value of the variable name from this state. If not found, will follow inheritance to find 
+    /// Returns the value of the variable name from this state. If not found, will follow inheritance to find
     /// the value from the base.
     /// </summary>
+    /// <remarks>
+    /// Resolution is anchored on <paramref name="stateSave"/>'s <c>ParentContainer</c>, which is
+    /// dereferenced for inheritance: when <paramref name="stateSave"/> is not the element's own
+    /// <c>DefaultState</c>, the walk routes through <c>ParentContainer.DefaultState</c> to find the
+    /// authored value. As a result an <i>empty</i> non-default state owned by a real element still
+    /// returns that element's authored values — to evaluate "with nothing authored" the state must be
+    /// owned by a throwaway element whose only state is its own <c>DefaultState</c>. See
+    /// <c>EvaluatedSyntax.FromSyntaxNodeUsingDefaultsOnly</c> (issue #3082).
+    /// </remarks>
     /// <param name="stateSave">The state in the current element.</param>
     /// <param name="variableName">The variable name</param>
     /// <returns>The value found recursively, where the most-derived value has priority.</returns>

--- a/Gum/Plugins/InternalPlugins/VariableGrid/BehaviorToolOnlyReferencesApplier.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/BehaviorToolOnlyReferencesApplier.cs
@@ -105,22 +105,14 @@ public static class BehaviorToolOnlyReferencesApplier
 
         // Skip materializing a value identical to the resting wireframe — the value the
         // reference produces when nothing is authored and every identifier resolves to its
-        // FormsProperty default. The resting state is the empty default state of a throwaway
-        // empty element (no instances, no base type), so every lookup falls straight through
-        // to the fallback, yielding that resting value. The element must be a fresh throwaway,
-        // not the real one: a state carrying the real element would re-resolve the element's
-        // authored default state and defeat the comparison. It also must be the element's
-        // default state (States[0]) and carry a non-null ParentContainer, or
-        // RecursiveVariableFinder/GetValueRecursive throw. When the authored result matches
-        // the resting value, the assignment carries no information beyond the resting preview,
-        // so writing it only spams the state — e.g. every Forms-control instance's
+        // FormsProperty default. When the authored result matches that resting value, the
+        // assignment carries no information beyond the resting preview, so writing it only
+        // spams the state — e.g. every Forms-control instance's
         // "<Instance>.<X>CategoryState = Enabled" in a screen that overrode nothing
         // (issue #3080). Only authored deviations from rest (IsEnabled = false, a checked
-        // CheckBox, etc.) are worth materializing.
-        ComponentSave restingOwner = new ComponentSave();
-        StateSave restingState = new StateSave { ParentContainer = restingOwner };
-        restingOwner.States.Add(restingState);
-        EvaluatedSyntax? resting = EvaluatedSyntax.FromSyntaxNode(rightSyntax, restingState, fallback);
+        // CheckBox, etc.) are worth materializing. The throwaway-element ceremony required to
+        // evaluate "with nothing authored" lives in FromSyntaxNodeUsingDefaultsOnly (issue #3082).
+        EvaluatedSyntax? resting = EvaluatedSyntax.FromSyntaxNodeUsingDefaultsOnly(rightSyntax, fallback);
         if (resting != null && Equals(resting.Value, evaluated.Value))
         {
             return;

--- a/Runtimes/GumExpressions/EvaluatedSyntax.cs
+++ b/Runtimes/GumExpressions/EvaluatedSyntax.cs
@@ -39,6 +39,19 @@ public class EvaluatedSyntax
 
     #region Parse
 
+    /// <summary>
+    /// Evaluates a parsed right-side expression, resolving unqualified identifiers against
+    /// <paramref name="stateForUnqualifiedRightSide"/>.
+    /// </summary>
+    /// <param name="syntaxNode">The Roslyn syntax node for the right side of an assignment.</param>
+    /// <param name="stateForUnqualifiedRightSide">State used to resolve identifiers. Note that this
+    /// is <b>not</b> the source of truth: <see cref="Gum.DataTypes.RecursiveVariableFinder"/> re-derives
+    /// values <i>by name</i> through this state's <c>ParentContainer</c>, and <c>GetVariableRecursive</c>
+    /// routes any non-default state to the owning element's <c>DefaultState</c>. Consequently an
+    /// <i>empty</i> state owned by a real element still resolves that element's authored values —
+    /// passing one will silently defeat a "what would this resolve to with nothing authored?"
+    /// comparison. To evaluate with nothing authored, use
+    /// <see cref="FromSyntaxNodeUsingDefaultsOnly"/> instead of hand-rolling a throwaway state.</param>
     /// <param name="fallback">Optional resolver consulted when a bare identifier
     /// or member-access lookup against <paramref name="stateForUnqualifiedRightSide"/>
     /// returns null. The Forms-property-promotion apply pipeline uses this to fall
@@ -47,6 +60,36 @@ public class EvaluatedSyntax
     public static EvaluatedSyntax FromSyntaxNode(SyntaxNode syntaxNode, StateSave stateForUnqualifiedRightSide, Func<string, object?>? fallback = null)
     {
         return Evaluate(syntaxNode, stateForUnqualifiedRightSide, fallback);
+    }
+
+    /// <summary>
+    /// Evaluates a parsed right-side expression as if <b>nothing were authored</b>: every identifier
+    /// resolves through <paramref name="fallback"/> (e.g. a behavior's <c>FormsProperty.Value</c>
+    /// defaults) rather than any real element's state. Use this to answer "what would this resolve to
+    /// with nothing authored?" — for instance, to compare an authored result against the resting
+    /// wireframe value and skip materializing a redundant assignment.
+    /// </summary>
+    /// <remarks>
+    /// This exists because <see cref="FromSyntaxNode"/> cannot be made to ignore authored data simply
+    /// by passing an empty state: <see cref="Gum.DataTypes.RecursiveVariableFinder"/> resolves by name
+    /// through the state's <c>ParentContainer</c>, so an empty state owned by a real element leaks that
+    /// element's authored values. The isolation is achieved by owning the state with a throwaway empty
+    /// element (no instances, no base type) whose only state <i>is</i> its <c>DefaultState</c> — so
+    /// <c>GetVariableRecursive</c> never short-circuits to a different state's authored values, finds
+    /// nothing, and falls through to <paramref name="fallback"/>. The element must be a fresh throwaway
+    /// (not the real one), its state must be the element's default state, and the state's
+    /// <c>ParentContainer</c> must be non-null, or <c>RecursiveVariableFinder</c>/<c>GetValueRecursive</c>
+    /// throw. Encapsulating all of that here keeps the constraint impossible to get subtly wrong at a
+    /// call site (see issue #3082).
+    /// </remarks>
+    /// <param name="syntaxNode">The Roslyn syntax node for the right side of an assignment.</param>
+    /// <param name="fallback">Resolver consulted for every identifier, since no state authors any value.</param>
+    public static EvaluatedSyntax FromSyntaxNodeUsingDefaultsOnly(SyntaxNode syntaxNode, Func<string, object?>? fallback)
+    {
+        ComponentSave restingOwner = new ComponentSave();
+        StateSave restingState = new StateSave { ParentContainer = restingOwner };
+        restingOwner.States.Add(restingState);
+        return Evaluate(syntaxNode, restingState, fallback);
     }
 
     private static EvaluatedSyntax Evaluate(SyntaxNode syntaxNode, StateSave stateForUnqualifiedRightSide, Func<string, object?>? fallback = null)

--- a/Tests/GumExpressions.Tests/EvaluatedSyntaxTests.cs
+++ b/Tests/GumExpressions.Tests/EvaluatedSyntaxTests.cs
@@ -734,6 +734,74 @@ public class EvaluatedSyntaxTests : BaseTestClass
 
     #endregion
 
+    #region DefaultsOnlyEvaluation
+
+    // These tests pin the "evaluate with nothing authored" (defaults-only) behavior of
+    // FromSyntaxNode and the FromSyntaxNodeUsingDefaultsOnly helper that encapsulates it.
+    //
+    // The footgun (see issue #3082): the StateSave handed to FromSyntaxNode is NOT the
+    // source of truth. RecursiveVariableFinder re-derives values by name through
+    // someState.ParentContainer, and GetVariableRecursive routes any non-default state to
+    // the element's DefaultState. So an *empty* state owned by a real element still leaks
+    // that element's authored values, silently defeating a defaults-only comparison.
+
+    private static EvaluatedSyntax EvaluateWithFallback(string expression, StateSave state, Func<string, object?> fallback)
+    {
+        string csharp = EvaluatedSyntax.ConvertToCSharpSyntax(expression);
+        Microsoft.CodeAnalysis.SyntaxNode syntax = SyntaxFactory.ParseExpression(csharp);
+        return EvaluatedSyntax.FromSyntaxNode(syntax, state, fallback);
+    }
+
+    [Fact]
+    public void FromSyntaxNode_EmptyStateOwnedByRealElement_LeaksAuthoredValue()
+    {
+        // The element authors IsEnabled = false in its default state. The fallback (mimicking a
+        // FormsProperty default) says IsEnabled = true. Evaluating against an empty state that is
+        // *owned by the real element* should leak the authored false, NOT use the fallback — this
+        // is the footgun the defaults-only helper exists to avoid.
+        ComponentSave realElement = new ComponentSave { Name = "RealElement" };
+        StateSave defaultState = new StateSave { Name = "Default", ParentContainer = realElement };
+        defaultState.Variables.Add(new VariableSave
+        {
+            Name = "IsEnabled",
+            Value = false,
+            Type = "bool",
+            SetsValue = true
+        });
+        realElement.States.Add(defaultState);
+
+        StateSave emptyStateOnRealElement = new StateSave { Name = "Empty", ParentContainer = realElement };
+
+        Func<string, object?> fallback = name => name == "IsEnabled" ? true : null;
+
+        EvaluatedSyntax result = EvaluateWithFallback(
+            "IsEnabled ? \"Enabled\" : \"Disabled\"", emptyStateOnRealElement, fallback);
+
+        result.ShouldNotBeNull();
+        // Leaks the element's authored false -> "Disabled", instead of the fallback's true -> "Enabled".
+        result.Value.ShouldBe("Disabled");
+    }
+
+    [Fact]
+    public void FromSyntaxNodeUsingDefaultsOnly_AuthoredValueOnRealElement_DoesNotLeak()
+    {
+        // Same fallback as the leak test, but the helper isolates from any real element's authored
+        // values: every identifier resolves through the fallback, so IsEnabled -> true -> "Enabled".
+        // This is the sharp guard: the leak test above proves a hand-rolled empty state leaks; this
+        // proves the helper does not.
+        Func<string, object?> fallback = name => name == "IsEnabled" ? true : null;
+
+        string csharp = EvaluatedSyntax.ConvertToCSharpSyntax("IsEnabled ? \"Enabled\" : \"Disabled\"");
+        Microsoft.CodeAnalysis.SyntaxNode syntax = SyntaxFactory.ParseExpression(csharp);
+
+        EvaluatedSyntax result = EvaluatedSyntax.FromSyntaxNodeUsingDefaultsOnly(syntax, fallback);
+
+        result.ShouldNotBeNull();
+        result.Value.ShouldBe("Enabled");
+    }
+
+    #endregion
+
     #region EnumStringEquality
 
     // Variable references like "ScrollBarVisibilityState = VerticalScrollBarVisibility == \"Hidden\" ? ..."


### PR DESCRIPTION
Closes #3082.

## What & why

Evaluating a variable-reference expression "with nothing authored" (every identifier resolving to its `FormsProperty` default) is a footgun, because the `StateSave` handed to `EvaluatedSyntax.FromSyntaxNode` is **not** the source of truth: `RecursiveVariableFinder` re-derives values *by name* through the state's `ParentContainer`, and `GetVariableRecursive` routes any non-default state up to the owning element's `DefaultState`. So an *empty* state owned by a real element still leaks that element's authored values — silently defeating a defaults-only comparison. This cost several debugging cycles in #3081, where the workaround was an inlined 4-line throwaway-element ceremony plus a paragraph-long comment.

## Changes

- **New factory** `EvaluatedSyntax.FromSyntaxNodeUsingDefaultsOnly(node, fallback)` builds the throwaway empty element internally and documents *why* in one place. The footgun now lives in exactly one spot and can't be gotten subtly wrong at a call site.
- **`BehaviorToolOnlyReferencesApplier.ApplyLine`** calls the helper; the inlined ceremony and its long comment are gone.
- **XML docs** added to `FromSyntaxNode` (the `stateForUnqualifiedRightSide` param is resolved by name; points at the defaults-only factory) and `<remarks>` on the `RecursiveVariableFinder` `StateSave` ctor and `GetValueRecursive` (the non-null `ParentContainer` requirement and `DefaultState` deref read as intentional now). Documenting all of `FromSyntaxNode`'s params also clears the pre-existing CS1573 warnings.
- **Skill note** in `gum-tool-variable-references` describing the defaults-only pattern and pointing at the factory.

Pure refactor + docs — **no behavior change intended**.

## Tests

A direct guard in `EvaluatedSyntaxTests` (sharper than the indirect applier tests from #3081):
- `FromSyntaxNode_EmptyStateOwnedByRealElement_LeaksAuthoredValue` — pins the footgun: an empty state on a *real* element leaks the authored value.
- `FromSyntaxNodeUsingDefaultsOnly_AuthoredValueOnRealElement_DoesNotLeak` — proves the helper isolates, falling through to the fallback.

Verification:
- `dotnet test Tests/GumExpressions.Tests` — 59 passed.
- `dotnet build GumFull.sln` — 0 errors, no new warnings in changed files.
- `dotnet test GumToolUnitTests --filter BehaviorToolOnlyReferencesApplier` — 15 passed (no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
