### PR TITLE
Trap Tab focus within the top-most modal (#3079)

### DIFF
--- a/MonoGameGum.Tests/Forms/FrameworkElementTests.cs
+++ b/MonoGameGum.Tests/Forms/FrameworkElementTests.cs
@@ -427,6 +427,136 @@ public class FrameworkElementTests : BaseTestClass
     }
 
     [Fact]
+    public void HandleTab_ShouldNotEscapeModal_WhenTabbingPastEndOfModal()
+    {
+        // Non-modal controls behind the modal, under the regular Root:
+        StackPanel rootStack = new();
+        rootStack.AddToRoot();
+        TextBox usernameTextBox = new() { Name = "Username" };
+        rootStack.AddChild(usernameTextBox);
+        TextBox passwordTextBox = new() { Name = "Password" };
+        rootStack.AddChild(passwordTextBox);
+        Button loginButton = new() { Name = "Login" };
+        rootStack.AddChild(loginButton);
+
+        // Modal controls under ModalRoot:
+        StackPanel modalStack = new() { Name = "ModalStack" };
+        FrameworkElement.ModalRoot.Children.Add(modalStack.Visual);
+        Button okButton = new() { Name = "Ok" };
+        modalStack.AddChild(okButton);
+        Button cancelButton = new() { Name = "Cancel" };
+        modalStack.AddChild(cancelButton);
+
+        okButton.IsFocused = true;
+
+        // Ok -> Cancel:
+        okButton.HandleTab(TabDirection.Down, loop: true);
+        cancelButton.IsFocused.ShouldBeTrue();
+
+        // Cancel is the last modal control. Tabbing past it must wrap back into the
+        // modal, never escaping to the non-modal controls under Root.
+        cancelButton.HandleTab(TabDirection.Down, loop: true);
+        okButton.IsFocused.ShouldBeTrue();
+
+        usernameTextBox.IsFocused.ShouldBeFalse();
+        passwordTextBox.IsFocused.ShouldBeFalse();
+        loginButton.IsFocused.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void HandleTab_ShouldNotEscapeModal_WhenShiftTabbingPastStartOfModal()
+    {
+        // Non-modal controls behind the modal, under the regular Root:
+        StackPanel rootStack = new();
+        rootStack.AddToRoot();
+        TextBox usernameTextBox = new() { Name = "Username" };
+        rootStack.AddChild(usernameTextBox);
+        TextBox passwordTextBox = new() { Name = "Password" };
+        rootStack.AddChild(passwordTextBox);
+        Button loginButton = new() { Name = "Login" };
+        rootStack.AddChild(loginButton);
+
+        // Modal controls under ModalRoot:
+        StackPanel modalStack = new() { Name = "ModalStack" };
+        FrameworkElement.ModalRoot.Children.Add(modalStack.Visual);
+        Button okButton = new() { Name = "Ok" };
+        modalStack.AddChild(okButton);
+        Button cancelButton = new() { Name = "Cancel" };
+        modalStack.AddChild(cancelButton);
+
+        okButton.IsFocused = true;
+
+        // Ok is the first modal control. Shift+Tabbing past it must wrap to the last
+        // modal control, never escaping to the non-modal controls under Root.
+        okButton.HandleTab(TabDirection.Up, loop: true);
+        cancelButton.IsFocused.ShouldBeTrue();
+
+        usernameTextBox.IsFocused.ShouldBeFalse();
+        passwordTextBox.IsFocused.ShouldBeFalse();
+        loginButton.IsFocused.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void HandleTab_ShouldTrapFocusInTopMostModal_WhenTabbingPastEnd()
+    {
+        // Background modal (added first):
+        StackPanel backgroundModal = new() { Name = "BackgroundModal" };
+        FrameworkElement.ModalRoot.Children.Add(backgroundModal.Visual);
+        Button backgroundOk = new() { Name = "BackgroundOk" };
+        backgroundModal.AddChild(backgroundOk);
+        Button backgroundCancel = new() { Name = "BackgroundCancel" };
+        backgroundModal.AddChild(backgroundCancel);
+
+        // Top-most modal (added last) — only this one should be interactive:
+        StackPanel topModal = new() { Name = "TopModal" };
+        FrameworkElement.ModalRoot.Children.Add(topModal.Visual);
+        Button topOk = new() { Name = "TopOk" };
+        topModal.AddChild(topOk);
+        Button topCancel = new() { Name = "TopCancel" };
+        topModal.AddChild(topCancel);
+
+        topCancel.IsFocused = true;
+
+        // Tabbing past the last control of the top-most modal must wrap back into the
+        // top-most modal, never falling through to the background modal behind it.
+        topCancel.HandleTab(TabDirection.Down, loop: true);
+        topOk.IsFocused.ShouldBeTrue();
+
+        backgroundOk.IsFocused.ShouldBeFalse();
+        backgroundCancel.IsFocused.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void HandleTab_ShouldTrapFocusInTopMostModal_WhenShiftTabbingPastStart()
+    {
+        // Background modal (added first):
+        StackPanel backgroundModal = new() { Name = "BackgroundModal" };
+        FrameworkElement.ModalRoot.Children.Add(backgroundModal.Visual);
+        Button backgroundOk = new() { Name = "BackgroundOk" };
+        backgroundModal.AddChild(backgroundOk);
+        Button backgroundCancel = new() { Name = "BackgroundCancel" };
+        backgroundModal.AddChild(backgroundCancel);
+
+        // Top-most modal (added last) — only this one should be interactive:
+        StackPanel topModal = new() { Name = "TopModal" };
+        FrameworkElement.ModalRoot.Children.Add(topModal.Visual);
+        Button topOk = new() { Name = "TopOk" };
+        topModal.AddChild(topOk);
+        Button topCancel = new() { Name = "TopCancel" };
+        topModal.AddChild(topCancel);
+
+        topOk.IsFocused = true;
+
+        // Shift+Tabbing before the first control of the top-most modal must wrap to the
+        // last control of the top-most modal, never falling through to the background modal.
+        topOk.HandleTab(TabDirection.Up, loop: true);
+        topCancel.IsFocused.ShouldBeTrue();
+
+        backgroundOk.IsFocused.ShouldBeFalse();
+        backgroundCancel.IsFocused.ShouldBeFalse();
+    }
+
+    [Fact]
     public void HandleTab_ShouldNotUnfocus_OnTabOfOnlyElement()
     {
         Button playButton = new ();

--- a/MonoGameGum/Forms/Controls/FrameworkElement.cs
+++ b/MonoGameGum/Forms/Controls/FrameworkElement.cs
@@ -1401,7 +1401,18 @@ public class FrameworkElement : INotifyPropertyChanged
                     if(!isDominant)
 #endif
                     {
-                        if (parentVisual?.Parent != null)
+                        if (IsTopMostModal(parentVisual))
+                        {
+                            // The top-most modal traps tab focus: rather than climbing out to
+                            // ModalRoot (which would let focus fall through to a background modal),
+                            // wrap within this modal's own focusable controls. This mirrors mouse
+                            // input, which is routed only to the top-most modal.
+                            if (loop)
+                            {
+                                didFocusNewItem = HandleTab(tabDirection, null, parentVisual, shouldAskParent: false, loop: false);
+                            }
+                        }
+                        else if (parentVisual?.Parent != null)
                         {
                             var grandparentVisual = parentVisual.Parent as InteractiveGue;
                             didFocusNewItem = HandleTab(tabDirection, parentVisual, grandparentVisual, shouldAskParent: true, loop:loop);
@@ -1450,6 +1461,39 @@ public class FrameworkElement : INotifyPropertyChanged
                     element.IsEnabled &&
                     element.Visual.HasEvents &&
                     element.GamepadTabbingFocusBehavior == TabbingFocusBehavior.FocusableIfInputReceiver;
+    }
+
+    /// <summary>
+    /// Returns whether the argument visual is the top-most (active) modal — the last visible direct
+    /// child of <see cref="ModalRoot"/>. Tab focus is trapped within this element so that keyboard
+    /// navigation cannot fall through to background modals, mirroring the way mouse input is routed
+    /// only to the top-most modal.
+    /// </summary>
+    static bool IsTopMostModal(InteractiveGue? visual)
+    {
+        var modalRoot = ModalRoot;
+        if (visual == null || modalRoot == null || visual.Parent != modalRoot)
+        {
+            return false;
+        }
+
+        var children = modalRoot.Children;
+        if (children == null)
+        {
+            return false;
+        }
+
+        // The top-most modal is the last visible child, matching the input routing in
+        // FormsUtilities which delivers cursor input only to that element.
+        for (int i = children.Count - 1; i > -1; i--)
+        {
+            if (children[i].Visible)
+            {
+                return children[i] == visual;
+            }
+        }
+
+        return false;
     }
 
     #endregion

--- a/docs/code/events-and-interactivity/tabbing-moving-focus.md
+++ b/docs/code/events-and-interactivity/tabbing-moving-focus.md
@@ -98,6 +98,16 @@ button.IsUsingLeftAndRightGamepadDirectionsForNavigation = false;
 
 `IsUsingLeftAndRightGamepadDirectionsForNavigation` is set to true on all controls except on `Sliders`, which use left/right input for changing the `Slider`'s `Value`.
 
+## Modal Tab Trapping
+
+When you show an element modally by adding it to `GumService.Default.ModalRoot`, tab focus is confined to the controls inside that modal element. Tabbing forward past the last focusable control wraps back to the first, and Shift+Tabbing before the first control wraps to the last. Focus never escapes to the controls behind the modal under the regular `Root`.
+
+This is the keyboard and gamepad counterpart to the input blocking already described for modal popups — see [ModalRoot and PopupRoot](../gum-code-reference/gumservice-gumui/modalroot-and-popuproot.md). A modal captures all interaction until it is dismissed: mouse input is routed only to the top-most modal element, and tab focus is trapped within it.
+
+No extra setup is required. As soon as the modal element is removed from `ModalRoot`, tabbing returns to the controls under `Root`.
+
+When several elements are stacked in `ModalRoot` (for example, one modal opening another), tab focus stays within the top-most modal — the last one added. Focus does not fall through to the modals behind it, consistent with mouse input being routed only to the top-most modal. For this to work, give each modal a single root element (a container, component, or screen) so that its controls are grouped together under `ModalRoot`.
+
 ## Getting Focused Item (CurrentInputReceiver)
 
 The static `InteractiveGue.CurrentInputReceiver` returns the current item that has focus. This can be used to diagnose problems.


### PR DESCRIPTION
Closes #3079

## Summary

Issue #3079 asked whether Tab/Shift+Tab focus can escape a modal (added to `FrameworkElement.ModalRoot`) and land on non-modal controls under the regular `Root`. Following the issue's TDD definition of done, I verified the behavior with focused tests first.

**The single-modal case already works.** Focus never reaches the non-modal controls behind a modal — this is guaranteed structurally because `ModalRoot` is a separate, parentless, top-level root (a sibling of `Root`, not a descendant). `HandleTab` escapes a container only by climbing `parentVisual.Parent`, and that chain dead-ends at `ModalRoot`. This PR adds Tab + Shift+Tab regression tests pinning that behavior.

**But stacked modals leaked.** With more than one element in `ModalRoot` (the supported "one modal opens another" pattern), tabbing past the end of the **top-most** modal fell through to the **background** modal's controls. Mouse input was already isolated to the top-most modal (`FormsUtilities` routes cursor input only to the last visible child of `ModalRoot`); keyboard focus was inconsistent with that.

## Fix

A new `IsTopMostModal` guard in `FrameworkElement.HandleTab`: when the upward climb reaches the top-most modal (the last visible direct child of `ModalRoot`), focus wraps within that modal's own controls instead of climbing out to `ModalRoot` and considering sibling modals. This is the cross-platform analog of the existing `#if FRB` dominant-window guard, and it collapses to the previous correct behavior when there is only one modal. Keyboard focus now matches mouse input: only the top-most modal is interactive.

The fix lives in shared `FrameworkElement` code, so it benefits MonoGame/KNI/FNA/Raylib/Skia alike.

## Tests

Four tests in `MonoGameGum.Tests/Forms/FrameworkElementTests.cs`:

- `HandleTab_ShouldNotEscapeModal_WhenTabbingPastEndOfModal`
- `HandleTab_ShouldNotEscapeModal_WhenShiftTabbingPastStartOfModal`
- `HandleTab_ShouldTrapFocusInTopMostModal_WhenTabbingPastEnd`
- `HandleTab_ShouldTrapFocusInTopMostModal_WhenShiftTabbingPastStart`

The two stacked-modal tests fail without the fix (focus lands on the background modal) and pass with it. Full `MonoGameGum.Tests` suite is green (1664 passed).

## Docs

Adds a **Modal Tab Trapping** section to `docs/code/events-and-interactivity/tabbing-moving-focus.md` covering both the single-modal and stacked-modal behavior, cross-linked with the `ModalRoot and PopupRoot` reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
