### PR TITLE
Add TextBox.TextChangedByUi event for user-only text changes (#3084)

### DIFF
--- a/MonoGameGum.Tests/Forms/TextBoxTests.cs
+++ b/MonoGameGum.Tests/Forms/TextBoxTests.cs
@@ -841,6 +841,34 @@ public class TextBoxTests : BaseTestClass
     }
 
     [Fact]
+    public void TextChangedByUi_ShouldNotRaise_WhenPreviewTextInputHandled()
+    {
+        TextBox textBox = new();
+        textBox.PreviewTextInput += (_, args) => args.Handled = true;
+        int byUiCount = 0;
+        textBox.TextChangedByUi += (_, _) => byUiCount++;
+
+        textBox.HandleCharEntered('a');
+
+        textBox.Text.ShouldBeNullOrEmpty("because a handled PreviewTextInput cancels the insertion");
+        byUiCount.ShouldBe(0, "because no text change occurs when PreviewTextInput is handled");
+    }
+
+    [Fact]
+    public void TextChangedByUi_ShouldNotRaise_WhenReadOnly()
+    {
+        TextBox textBox = new();
+        textBox.IsReadOnly = true;
+        int byUiCount = 0;
+        textBox.TextChangedByUi += (_, _) => byUiCount++;
+
+        textBox.HandleCharEntered('a');
+
+        textBox.Text.ShouldBeNullOrEmpty("because a read-only TextBox ignores typed input");
+        byUiCount.ShouldBe(0, "because no text change occurs on a read-only TextBox");
+    }
+
+    [Fact]
     public void TextChangedByUi_ShouldNotRaise_WhenSetTextNoTranslateCalled()
     {
         TextBox textBox = new();

--- a/MonoGameGum.Tests/Forms/TextBoxTests.cs
+++ b/MonoGameGum.Tests/Forms/TextBoxTests.cs
@@ -537,6 +537,32 @@ public class TextBoxTests : BaseTestClass
     }
 
     [Fact]
+    public void HandleBackspace_ShouldNotLocalizeText_WhenDeletingCharacter()
+    {
+        // Guards the SetTextNoTranslate -> SetTextFromUi rerouting (#3084): user edits
+        // must still bypass localization. Without it, a registered LocalizationService
+        // would translate the post-edit string and replace the user's text.
+        var mockLocalization = new Mock<ILocalizationService>();
+        mockLocalization.Setup(x => x.Translate(It.IsAny<string>())).Returns("TRANSLATED");
+        CustomSetPropertyOnRenderable.LocalizationService = mockLocalization.Object;
+
+        try
+        {
+            TextBox textBox = new();
+            textBox.HandleCharEntered('a');
+            textBox.HandleCharEntered('b');
+
+            textBox.HandleBackspace();
+
+            textBox.Text.ShouldBe("a");
+        }
+        finally
+        {
+            CustomSetPropertyOnRenderable.LocalizationService = null;
+        }
+    }
+
+    [Fact]
     public void HandleCharEntered_ShouldAddCharacter_WhenNonEnterKeyTyped()
     {
         TextBox textBox = new();
@@ -643,6 +669,32 @@ public class TextBoxTests : BaseTestClass
         textBox.IsFocused = true;
         textBox.HandleKeyDown(Gum.Forms.Input.Keys.V, false, false, isCtrlDown: true);
         textBox.Text.ShouldBe("Line1\nLine2", "because TextBox expects a single-character newline for proper caret positioning");
+    }
+
+    [Fact]
+    public void HandleKeyDown_Paste_ShouldNotLocalizeText()
+    {
+        // Companion to HandleBackspace_ShouldNotLocalizeText (#3084): the paste path was
+        // also rerouted from SetTextNoTranslate to SetTextFromUi and must keep bypassing
+        // localization so pasted content is inserted verbatim.
+        var mockLocalization = new Mock<ILocalizationService>();
+        mockLocalization.Setup(x => x.Translate(It.IsAny<string>())).Returns("TRANSLATED");
+        CustomSetPropertyOnRenderable.LocalizationService = mockLocalization.Object;
+
+        try
+        {
+            Gum.Clipboard.ClipboardImplementation.PushStringToClipboard("pasted");
+            TextBox textBox = new();
+            textBox.IsFocused = true;
+
+            textBox.HandleKeyDown(Gum.Forms.Input.Keys.V, false, false, isCtrlDown: true);
+
+            textBox.Text.ShouldBe("pasted");
+        }
+        finally
+        {
+            CustomSetPropertyOnRenderable.LocalizationService = null;
+        }
     }
 
     [Fact]

--- a/MonoGameGum.Tests/Forms/TextBoxTests.cs
+++ b/MonoGameGum.Tests/Forms/TextBoxTests.cs
@@ -789,6 +789,111 @@ public class TextBoxTests : BaseTestClass
     }
 
     [Fact]
+    public void TextChangedByUi_ShouldNotRaise_WhenSetTextNoTranslateCalled()
+    {
+        TextBox textBox = new();
+        int byUiCount = 0;
+        int textChangedCount = 0;
+        textBox.TextChangedByUi += (_, _) => byUiCount++;
+        textBox.TextChanged += (_, _) => textChangedCount++;
+
+        textBox.SetTextNoTranslate("hello");
+
+        byUiCount.ShouldBe(0, "because SetTextNoTranslate is a programmatic API, not user input");
+        textChangedCount.ShouldBe(1, "because TextChanged fires regardless of the change's source");
+    }
+
+    [Fact]
+    public void TextChangedByUi_ShouldNotRaise_WhenTextSetProgrammatically()
+    {
+        TextBox textBox = new();
+        int byUiCount = 0;
+        int textChangedCount = 0;
+        textBox.TextChangedByUi += (_, _) => byUiCount++;
+        textBox.TextChanged += (_, _) => textChangedCount++;
+
+        textBox.Text = "hello";
+
+        byUiCount.ShouldBe(0, "because assigning the Text property in code is not a user-driven change");
+        textChangedCount.ShouldBe(1, "because TextChanged fires regardless of the change's source");
+    }
+
+    [Fact]
+    public void TextChangedByUi_ShouldRaise_WhenBackspacePressed()
+    {
+        TextBox textBox = new();
+        textBox.Text = "abc";
+        textBox.CaretIndex = 3;
+        int byUiCount = 0;
+        textBox.TextChangedByUi += (_, _) => byUiCount++;
+
+        textBox.HandleBackspace();
+
+        byUiCount.ShouldBe(1, "because deleting a character via backspace is a user-driven change");
+        textBox.Text.ShouldBe("ab");
+    }
+
+    [Fact]
+    public void TextChangedByUi_ShouldRaise_WhenCharTyped()
+    {
+        TextBox textBox = new();
+        int byUiCount = 0;
+        textBox.TextChangedByUi += (_, _) => byUiCount++;
+
+        textBox.HandleCharEntered('a');
+
+        byUiCount.ShouldBe(1, "because typing a character is a user-driven change");
+    }
+
+    [Fact]
+    public void TextChangedByUi_ShouldRaise_WhenDeletePressed()
+    {
+        TextBox textBox = new();
+        textBox.Text = "abc";
+        textBox.IsFocused = true;
+        textBox.CaretIndex = 0;
+        int byUiCount = 0;
+        textBox.TextChangedByUi += (_, _) => byUiCount++;
+
+        textBox.HandleKeyDown(Gum.Forms.Input.Keys.Delete, false, false, false);
+
+        byUiCount.ShouldBe(1, "because deleting a character via the delete key is a user-driven change");
+        textBox.Text.ShouldBe("bc");
+    }
+
+    [Fact]
+    public void TextChangedByUi_ShouldRaise_WhenNativeKeyboardInputApplied()
+    {
+        NativeKeyboardAccessTextBox textBox = new();
+        int byUiCount = 0;
+        textBox.TextChangedByUi += (_, _) => byUiCount++;
+
+        textBox.InvokeSetTextFromNativeKeyboardInput("user entry");
+
+        byUiCount.ShouldBeGreaterThan(0,
+            "because text entered through the native on-screen keyboard is user-driven input");
+    }
+
+    [Fact]
+    public void TextChangedByUi_ShouldRaise_WhenTextPasted()
+    {
+        Gum.Clipboard.ClipboardImplementation.PushStringToClipboard("xyz");
+        TextBox textBox = new();
+        textBox.IsFocused = true;
+        int byUiCount = 0;
+        int textChangedCount = 0;
+        textBox.TextChangedByUi += (_, _) => byUiCount++;
+        textBox.TextChanged += (_, _) => textChangedCount++;
+
+        textBox.HandleKeyDown(Gum.Forms.Input.Keys.V, false, false, isCtrlDown: true);
+
+        textBox.Text.ShouldBe("xyz");
+        byUiCount.ShouldBeGreaterThan(0, "because pasting is a user-driven change");
+        byUiCount.ShouldBe(textChangedCount,
+            "because for user-driven changes TextChangedByUi fires with the same cadence as TextChanged");
+    }
+
+    [Fact]
     public void TextWrapping_NoWrap_ShouldRenderCorrectlyWithAcceptsReturn()
     {
         TextBox textBox = new();

--- a/MonoGameGum/Forms/Controls/TextBox.cs
+++ b/MonoGameGum/Forms/Controls/TextBox.cs
@@ -38,7 +38,7 @@ public class TextBox : TextBoxBase
     /// </summary>
     protected override void SetTextFromNativeKeyboardInput(string value)
     {
-        SetTextNoTranslate(value);
+        SetTextFromUi(value);
     }
 
     /// <summary>
@@ -93,6 +93,28 @@ public class TextBox : TextBoxBase
         }
     }
 
+    // True only while a user-initiated edit (typing, paste, backspace, delete, cut, or
+    // native-keyboard entry) is being applied. OnTextChanged reads it to decide whether to
+    // raise TextChangedByUi, so programmatic Text/SetTextNoTranslate assignments stay UI-silent.
+    private bool _isUiTextChange;
+
+    /// <summary>
+    /// Applies a user-initiated text change. Identical to <see cref="SetTextNoTranslate"/>
+    /// except that it marks the change as UI-driven so <see cref="TextChangedByUi"/> is raised.
+    /// </summary>
+    private void SetTextFromUi(string? value)
+    {
+        _isUiTextChange = true;
+        try
+        {
+            SetTextNoTranslate(value);
+        }
+        finally
+        {
+            _isUiTextChange = false;
+        }
+    }
+
     /// <summary>
     /// The maximum number of characters to display visually. Characters beyond this count
     /// are hidden but remain in the <see cref="Text"/> string. This is a display-only
@@ -136,9 +158,19 @@ public class TextBox : TextBoxBase
     #region Events
 
     /// <summary>
-    /// Event raised when the Text property changes.
+    /// Event raised when the Text property changes, regardless of the change's source.
     /// </summary>
     public event EventHandler TextChanged;
+
+    /// <summary>
+    /// Event raised when Text changes as a result of user interaction (typing, pasting,
+    /// backspace, delete, cut, or native on-screen keyboard entry). This event is not raised
+    /// when Text is changed in code, such as by assigning the <see cref="Text"/> property or
+    /// calling <see cref="SetTextNoTranslate"/>. This is the text analog of
+    /// <see cref="Primitives.RangeBase.ValueChangedByUi"/>. It is raised after the change is applied
+    /// and fires with the same cadence as <see cref="TextChanged"/> for user-driven changes.
+    /// </summary>
+    public event EventHandler TextChangedByUi;
 
     #endregion
 
@@ -238,8 +270,8 @@ public class TextBox : TextBoxBase
                     // set caretIndex before assigning Text so that the events are
                     // raised with the new caretIndex value
                     caretIndex = System.Math.Min(caretIndex + 1, textAfterAdd.Length);
-                    // Use SetTextNoTranslate because this is user-typed input
-                    SetTextNoTranslate(textAfterAdd);
+                    // Use SetTextFromUi because this is user-typed input
+                    SetTextFromUi(textAfterAdd);
                 }
             }
 
@@ -275,8 +307,8 @@ public class TextBox : TextBoxBase
 
                 var indexToDeleteTo = indexBeforeNullable ?? 0;
 
-                // Use SetTextNoTranslate because this is user-initiated editing
-                SetTextNoTranslate(Text.Remove(indexToDeleteTo, caretIndex - indexToDeleteTo));
+                // Use SetTextFromUi because this is user-initiated editing
+                SetTextFromUi(Text.Remove(indexToDeleteTo, caretIndex - indexToDeleteTo));
 
                 caretIndex = indexToDeleteTo;
                 RefreshCaretAfterEdit();
@@ -288,8 +320,8 @@ public class TextBox : TextBoxBase
                 // caret is at the end of the word, modifying the word will shift the caret to
                 // the left, and that could cause it to shift over two times.
                 caretIndex--;
-                // Use SetTextNoTranslate because this is user-initiated editing
-                SetTextNoTranslate(this.Text.Remove(whereToRemoveFrom, 1));
+                // Use SetTextFromUi because this is user-initiated editing
+                SetTextFromUi(this.Text.Remove(whereToRemoveFrom, 1));
                 RefreshCaretAfterEdit();
             }
         }
@@ -304,8 +336,8 @@ public class TextBox : TextBoxBase
         }
         else if (caretIndex < (Text?.Length ?? 0))
         {
-            // Use SetTextNoTranslate because this is user-initiated editing
-            SetTextNoTranslate(this.Text.Remove(caretIndex, 1));
+            // Use SetTextFromUi because this is user-initiated editing
+            SetTextFromUi(this.Text.Remove(caretIndex, 1));
             RefreshCaretAfterEdit();
         }
     }
@@ -363,8 +395,8 @@ public class TextBox : TextBoxBase
             }
             foreach (var character in whatToPaste)
             {
-                // Use SetTextNoTranslate because this is user-pasted input
-                SetTextNoTranslate(this.Text.Insert(caretIndex, "" + character));
+                // Use SetTextFromUi because this is user-pasted input
+                SetTextFromUi(this.Text.Insert(caretIndex, "" + character));
                 caretIndex++;
             }
 
@@ -383,8 +415,8 @@ public class TextBox : TextBoxBase
         {
             lengthToRemove = Text.Length - selectionStart;
         }
-        // Use SetTextNoTranslate because this is user-initiated editing
-        SetTextNoTranslate(Text.Remove(selectionStart, lengthToRemove));
+        // Use SetTextFromUi because this is user-initiated editing
+        SetTextFromUi(Text.Remove(selectionStart, lengthToRemove));
         CaretIndex = selectionStart;
         SelectionLength = 0;
     }
@@ -428,6 +460,11 @@ public class TextBox : TextBoxBase
         CaretIndex = System.Math.Min(CaretIndex, value?.Length ?? 0);
 
         TextChanged?.Invoke(this, EventArgs.Empty);
+
+        if (_isUiTextChange)
+        {
+            TextChangedByUi?.Invoke(this, EventArgs.Empty);
+        }
 
         UpdatePlaceholderVisibility();
 


### PR DESCRIPTION
## Summary

Adds a `TextChangedByUi` event to `TextBox`, the text analog of `RangeBase.ValueChangedByUi`. It fires **only** when `Text` changes as a result of user interaction, and **never** when `Text` is changed in code.

Closes #3084.

## What raises it

- typing (`HandleCharEntered`)
- paste (`HandlePaste`)
- backspace — single char and ctrl+word (`HandleBackspace`)
- delete (`HandleDelete`)
- cut / selection delete (`DeleteSelection`, also covering `HandleCut`)
- **native on-screen keyboard entry** (`SetTextFromNativeKeyboardInput`) — see note below

## What does NOT raise it

- the `Text` property setter
- `SetTextNoTranslate(...)` (the documented programmatic API)

`TextChanged` continues to fire for all of the above, regardless of source.

## Implementation

All user-input editing paths already routed through `SetTextNoTranslate` (to bypass localization). They now route through a private `SetTextFromUi(...)` wrapper that flips an `_isUiTextChange` flag around the call. `OnTextChanged` — the single funnel that fires `TextChanged` — raises `TextChangedByUi` only when that flag is set. So `TextChangedByUi` fires with the **same cadence** as `TextChanged`, just filtered to UI-origin changes (e.g. both fire once per pasted character, matching existing `TextChanged` behavior).

This mirrors `RangeBase`, where both `ValueChanged` and `ValueChangedByUi` live together on the class that owns `Value`. `Text` is concrete on `TextBox` (not `TextBoxBase`), so the new event lives on `TextBox` alongside `TextChanged` — not on the base. `PasswordBox` keeps its own `PasswordChanged` and is unaffected.

## Decision to confirm: native keyboard

The issue's bullet list didn't mention the native on-screen keyboard path, but I included it: on Android/iOS the native dialog is the *primary* text-input method, and excluding it would mean `TextChangedByUi` never fires for user input on mobile — a real gap, not gold-plating. It's a one-line change (`SetTextFromNativeKeyboardInput` → `SetTextFromUi`); easy to drop if you'd rather scope it out.

## Tests

7 new `TextChangedByUi_*` tests in `MonoGameGum.Tests/Forms/TextBoxTests.cs` cover: typing, backspace, delete, paste, and native-keyboard raise the event; the `Text` setter and `SetTextNoTranslate` do not (while `TextChanged` still fires). Written test-first (verified red before the wiring).

Because the user-input paths were rerouted (`SetTextNoTranslate` → `SetTextFromUi`), 2 additional tests pin that the rerouting still **bypasses localization**: `HandleBackspace_ShouldNotLocalizeText_WhenDeletingCharacter` and `HandleKeyDown_Paste_ShouldNotLocalizeText` (the typing and native-keyboard paths were already covered). With a mock `LocalizationService` registered, edits insert verbatim text rather than the translated string.

Full `MonoGameGum.Tests` suite green (1667 → now 1669 with the new tests passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
