### PR TITLE
Stop missing textures from throwing on wireframe rebuild (#3075)

### DIFF
--- a/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
+++ b/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
@@ -427,14 +427,23 @@ public class CustomSetPropertyOnRenderable
                         texture =
                             loaderManager.LoadContent<Microsoft.Xna.Framework.Graphics.Texture2D>(value);
                     }
-                    catch (Exception e)
+                    catch (Exception)
                     {
+                        // Treated the same as a missing file below.
+                        texture = null;
+                    }
+
+                    if (texture == null)
+                    {
+                        // On desktop the loader returns null for a missing file instead of throwing, and a
+                        // genuine load error is funneled here too. Honor MissingFileBehavior; otherwise fall
+                        // back to the invalid-texture placeholder, matching the prior catch behavior.
                         if (GraphicalUiElement.MissingFileBehavior == MissingFileBehavior.ThrowException)
                         {
                             string message = $"Error setting SourceFile on NineSlice named {nineSlice.Name}:\n{value}";
                             throw new System.IO.FileNotFoundException(message);
                         }
-                        // do nothing?
+                        texture = Sprite.InvalidTexture;
                     }
                     nineSlice.SetSingleTexture(texture);
 
@@ -1923,18 +1932,28 @@ public class CustomSetPropertyOnRenderable
                 // We used to check if the file exists. But internally something may
                 // alias a file. Ultimately the content loader should make that decision,
                 // not the GUE
+                Microsoft.Xna.Framework.Graphics.Texture2D? texture = null;
+                Exception? loadException = null;
                 try
                 {
-                    sprite.Texture = loaderManager.LoadContent<Microsoft.Xna.Framework.Graphics.Texture2D>(value);
+                    texture = loaderManager.LoadContent<Microsoft.Xna.Framework.Graphics.Texture2D>(value);
                 }
                 catch (Exception ex)
                 // Jan 1, 2025 - we used to only catch certain types of exceptions, but this list keeps growing as there
                 // are a variety of types of crashes that can occur. NineSlice catches all exceptions, so let's just do that!
                 //when (ex is System.IO.FileNotFoundException or System.IO.DirectoryNotFoundException or WebException or IOException)
                 {
+                    loadException = ex;
+                }
+
+                if (texture == null)
+                {
+                    // On desktop the loader returns null for a missing file instead of throwing, and a
+                    // genuine load error is funneled here too (loadException). Report it the same way the
+                    // catch used to.
                     string message = $"Error setting SourceFile on Sprite";
 
-                    if(graphicalUiElement.Tag != null)
+                    if (graphicalUiElement.Tag != null)
                     {
                         message += $" in {graphicalUiElement.Tag}";
                     }
@@ -1943,16 +1962,20 @@ public class CustomSetPropertyOnRenderable
                     message += "\nThe current relative directory is:\n" + ToolsUtilities.FileManager.RelativeDirectory;
                     if (GraphicalUiElement.MissingFileBehavior == MissingFileBehavior.ThrowException)
                     {
-                        if(ObjectFinder.Self.GumProjectSave == null)
+                        if (ObjectFinder.Self.GumProjectSave == null)
                         {
                             message += "\nNo Gum project has been loaded";
                         }
 
-                        throw new System.IO.FileNotFoundException(message, ex);
+                        throw new System.IO.FileNotFoundException(message, loadException);
                     }
                     sprite.Texture = null;
 
-                    PropertyAssignmentError?.Invoke(message + "\n" + ex.ToString());
+                    PropertyAssignmentError?.Invoke(loadException != null ? message + "\n" + loadException.ToString() : message);
+                }
+                else
+                {
+                    sprite.Texture = texture;
                 }
                 graphicalUiElement.UpdateLayout();
             }

--- a/MonoGameGum.Tests/RenderingLibraries/ContentLoaderTests.cs
+++ b/MonoGameGum.Tests/RenderingLibraries/ContentLoaderTests.cs
@@ -1,3 +1,4 @@
+using Microsoft.Xna.Framework.Graphics;
 using RenderingLibrary.Content;
 using Shouldly;
 using Xunit;
@@ -6,6 +7,23 @@ namespace MonoGameGum.Tests.RenderingLibraries;
 
 public class ContentLoaderTests : BaseTestClass
 {
+    [Fact]
+    public void LoadContent_MissingFileOnDesktop_ReturnsNullWithoutThrowing()
+    {
+        // Regression test for the missing-texture exception storm (issue #3075). On desktop the loader
+        // used to fall into File.OpenRead for a missing file, throwing a (caught) exception per missing
+        // file on every wireframe rebuild. With a debugger attached, those first-chance exceptions made
+        // selecting a screen with many missing files take tens of seconds. The loader now detects the
+        // missing file up front (File.Exists) and returns null instead of throwing.
+        ContentLoader contentLoader = new ContentLoader();
+
+        Texture2D result = null;
+        Should.NotThrow(() =>
+            result = contentLoader.LoadContent<Texture2D>("file_that_does_not_exist_3075.png"));
+
+        result.ShouldBeNull();
+    }
+
     [Fact]
     public void ResolveContentManagerAssetName_Android_DotSlashRelativePath()
     {

--- a/RenderingLibrary/Content/ContentLoader.cs
+++ b/RenderingLibrary/Content/ContentLoader.cs
@@ -121,7 +121,7 @@ public class ContentLoader : IContentLoader
         {
             toReturn = LoadTextureFromFile(fileName, managers);
         }
-        if (LoaderManager.Self.CacheTextures)
+        if (LoaderManager.Self.CacheTextures && toReturn != null)
         {
             LoaderManager.Self.AddDisposable(fileNameStandardized, toReturn);
         }
@@ -181,7 +181,7 @@ public class ContentLoader : IContentLoader
     /// <param name="fileName">The filename to load</param>
     /// <param name="managers">The optional SystemManagers to use when loading the file to obtain a GraphicsDevice</param>
     /// <returns>The loaded Texture2D</returns>
-    private Texture2D LoadTextureFromFile(string fileName, SystemManagers? managers = null)
+    private Texture2D? LoadTextureFromFile(string fileName, SystemManagers? managers = null)
     {
         string fileNameStandardized = FileManager.Standardize(fileName, true, false);
 
@@ -191,6 +191,25 @@ public class ContentLoader : IContentLoader
 
             fileNameStandardized = FileManager.RemoveDotDotSlash(fileNameStandardized);
         }
+
+#if XNALIKE && !FRB
+        // On desktop OSes File.Exists is authoritative, so we can detect a missing file up front and
+        // return null instead of falling into File.OpenRead, which throws (and is caught) once per
+        // missing file on every wireframe rebuild. Those throws are cheap at runtime, but they produce
+        // a first-chance exception per missing file; with a debugger attached that makes selecting a
+        // screen full of missing files take tens of seconds in the Gum tool (issue #3075). We skip the
+        // shortcut when an XnaContentManager is present (it can alias a content-pipeline asset that has
+        // no loose file on disk) and on non-desktop platforms (web/mobile resolve files through
+        // TitleContainer or a host stream hook, where File.Exists is not authoritative). Mirrors the
+        // desktop guard in Renderer.Initialize.
+        bool canCheckFileExists = OperatingSystem.IsWindows()
+            || OperatingSystem.IsLinux()
+            || OperatingSystem.IsMacOS();
+        if (canCheckFileExists && XnaContentManager == null && !System.IO.File.Exists(fileNameStandardized))
+        {
+            return null;
+        }
+#endif
 
         Texture2D toReturn;
         string extension = FileManager.GetExtension(fileName);

--- a/RenderingLibrary/Content/LoaderManager.cs
+++ b/RenderingLibrary/Content/LoaderManager.cs
@@ -270,6 +270,13 @@ namespace RenderingLibrary.Content
                 toReturn = InvalidTexture;
             }
 
+            // On desktop the loader returns null for a missing file instead of throwing. Preserve this
+            // method's contract of returning InvalidTexture (rather than null) when the load fails.
+            if (toReturn == null)
+            {
+                toReturn = InvalidTexture;
+            }
+
             return toReturn;
         }
 

--- a/RenderingLibrary/Graphics/Fonts/BitmapFont.cs
+++ b/RenderingLibrary/Graphics/Fonts/BitmapFont.cs
@@ -203,6 +203,14 @@ public class BitmapFont : IDisposable
                 // If aliased, the internal loader may redirect. Let it do its job:
                 //if (ToolsUtilities.FileManager.FileExists(mTextureNames[i]))
                 mTextures[i] = global::RenderingLibrary.Content.LoaderManager.Self.LoadContent<Texture2D>(mTextureNames[i]);
+
+                // On desktop the loader returns null for a missing file instead of throwing; fall back to
+                // the invalid-texture placeholder so a missing font page doesn't NRE downstream.
+                if (mTextures[i] == null)
+                {
+                    // InvalidTexture is initialized at startup, so it is non-null here.
+                    mTextures[i] = RenderingLibrary.Graphics.Sprite.InvalidTexture!;
+                }
             }
         }
     }
@@ -228,6 +236,14 @@ public class BitmapFont : IDisposable
         else
         {
             mTextures[0] = global::RenderingLibrary.Content.LoaderManager.Self.LoadContent<Texture2D>(textureFile);
+
+            // On desktop the loader returns null for a missing file instead of throwing; fall back to
+            // the invalid-texture placeholder so the mTextures[0].Name access below doesn't NRE.
+            if (mTextures[0] == null)
+            {
+                // InvalidTexture is initialized at startup, so it is non-null here.
+                mTextures[0] = RenderingLibrary.Graphics.Sprite.InvalidTexture!;
+            }
         }
 
         mTextureNames[0] = mTextures[0].Name;

--- a/RenderingLibrary/Graphics/TextureFlipAnimation.cs
+++ b/RenderingLibrary/Graphics/TextureFlipAnimation.cs
@@ -88,7 +88,10 @@ namespace RenderingLibrary.Graphics
 
             foreach (string fileName in list)
             {
-                toReturn.TextureList.Add(global::RenderingLibrary.Content.LoaderManager.Self.LoadContent<Texture2D>(fileName));
+                // On desktop the loader returns null for a missing file instead of throwing; substitute the
+                // invalid-texture placeholder so a null entry doesn't NRE while the animation plays.
+                Texture2D loaded = global::RenderingLibrary.Content.LoaderManager.Self.LoadContent<Texture2D>(fileName);
+                toReturn.TextureList.Add(loaded ?? Sprite.InvalidTexture);
             }
             return toReturn;
         }


### PR DESCRIPTION
## What

Selecting a screen in the tool rebuilds the entire wireframe (`WireframeObjectManager.RefreshAll`), which recreates every `GraphicalUiElement` and re-applies every texture source. For a **missing** texture file, `ContentLoader.LoadTextureFromFile` fell into `File.OpenRead` and threw — caught, but thrown — **once per missing file, on every rebuild**.

Those throws are cheap at runtime, but each one fires a *first-chance exception*. With a debugger attached, selecting a screen full of missing files (e.g. the HyTale inventory sample) took **tens of seconds**; detaching the debugger dropped it to a few seconds. The cost was the throw/catch storm, not the O(n²) variable resolution the issue body originally theorized.

## Fix

On desktop OSes — where `File.Exists` is authoritative — the loader now detects a missing file up front and returns `null` instead of throwing. The shortcut is deliberately skipped when:

- an `XnaContentManager` is present (it can alias a content-pipeline `.xnb` asset that has no loose file on disk), and
- the platform is web/mobile (Blazor/`TitleContainer`/host stream hook), where `File.Exists` lies — those paths attempt the load exactly as before.

This mirrors the existing desktop guard in `Renderer.Initialize`.

Callers were updated to treat a `null` return as the existing missing-file outcome:

- **Sprite / NineSlice assign sites** preserve `InvalidTexture`, `MissingFileBehavior` (including `ThrowException`), and the `PropertyAssignmentError` notification.
- **`BitmapFont`, `LoaderManager.LoadOrInvalid`, `TextureFlipAnimation`** fall back to `InvalidTexture` so a `null` can't turn a clear missing-file error into an `NullReferenceException`.

`TryLoadContent` still returns `null` for a missing file (it did before via throw→catch), so existence probes such as NineSlice pattern detection are unaffected.

## Note on the issue

The diagnosis here differs from issue #3075's original root-cause section (O(n²) variable resolution). Profiling showed the dominant cost for screen selection is the missing-texture throw storm, not variable scans. A separate, smaller variable-resolution cost may still exist under the remaining few seconds, but it is out of scope for this change. See the comment on the issue for detail.

## Testing

- New regression test `ContentLoaderTests.LoadContent_MissingFileOnDesktop_ReturnsNullWithoutThrowing` (red before, green after).
- Full `MonoGameGum.Tests` suite green (1676 passed).
- Zero new compiler warnings introduced.
- Manually verified in the tool: warm screen selection on the repro project is dramatically faster (tens of seconds → a few seconds) with the debugger attached.

Closes #3075

🤖 Generated with [Claude Code](https://claude.com/claude-code)
