### PR TITLE
Docs: add Quick Check section to events troubleshooting page

### DIFF
--- a/.claude/skills/gum-docs-writing/SKILL.md
+++ b/.claude/skills/gum-docs-writing/SKILL.md
@@ -166,7 +166,7 @@ For adding or updating XnaFiddle interactive links, see [xnafiddle.md](xnafiddle
 
 - **No reflection** — never use `GetType()`, `typeof()`, `MemberInfo`, or any `System.Reflection` APIs in doc code samples. Use `is` pattern matching instead: `if (device is MonoGameGum.Input.Keyboard)`.
 - **Fully qualify non-Gum types** — any type that is not part of the Gum API must use its fully qualified name. For example, use `System.DateTime` not `DateTime`. Do not rely on implicit `using` statements for non-Gum types.
-- **No debug/console output** — never use `System.Diagnostics.Debug.WriteLine` (breaks in NetFiddle) or `System.Console.WriteLine` (requires user to open the diagnostics window). Instead, show side effects directly in the sample itself — e.g., update a visible label or change a property on a displayed object.
+- **Prefer visible output over console output** — by default, surface a sample's result in the UI itself (update a visible label, change a property on a displayed object) rather than logging it. This keeps the sample XnaFiddle-runnable and lets a reader see the effect — e.g. show "You clicked the button" in a `Label` instead of writing it to the output window. Avoid `System.Console.WriteLine` (requires opening the diagnostics window) and `System.Diagnostics.Debug.WriteLine` (breaks in NetFiddle) on any page intended to be fiddle-able. The one exception is a page whose subject *is* debugging — where the sample's output is a developer-facing diagnostic that nobody will fiddle (e.g. the events troubleshooting page). There, a breakpoint-and-inspect or `Debug.WriteLine` is the natural tool and is acceptable; visible-label output would be contrived.
 
 ## Gotchas
 

--- a/docs/code/events-and-interactivity/troubleshooting-events.md
+++ b/docs/code/events-and-interactivity/troubleshooting-events.md
@@ -8,6 +8,38 @@ If a control is not responding to input, its events may be suppressed for a numb
 
 Rather than walking the visual tree by hand, Gum exposes a diagnostic extension method on `Cursor` called `GetEventFailureReason` that returns a human-readable string describing why events are not being raised — or `null` if events should be working.
 
+## Quick Check
+
+If a control is not responding, paste one of the following into your update loop, put a breakpoint on the line, and hover the control while the game runs. Inspect `reason`: if it is `null`, events should be working; otherwise the string tells you exactly what is blocking them.
+
+The `GetEventFailureReason` extension methods live in the `MonoGameGum.Input` namespace, so add this `using` directive:
+
+```csharp
+using MonoGameGum.Input;
+```
+
+When you have a single control of a given type, look it up by type — no field or name required:
+
+```csharp
+// Update
+GumUI.Update(gameTime);
+
+var reason = GumUI.Cursor.GetEventFailureReason<Button>();
+// reason == null → events should be working
+// reason != null → reason describes what is blocking events
+```
+
+When you have several controls of the same type, give the one you are diagnosing a `Name` and look it up by name:
+
+```csharp
+// Update
+GumUI.Update(gameTime);
+
+var reason = GumUI.Cursor.GetEventFailureReason("ConfirmButton");
+```
+
+That is usually all you need. The rest of this page covers the remaining overloads, how to read the diagnostic output, and what to do when the cursor's position does not match the rendered UI.
+
 ## GetEventFailureReason
 
 `GetEventFailureReason` lives on the `ICursor` interface (typically `GumService.Default.Cursor`) and comes in several overloads:
@@ -21,11 +53,6 @@ Rather than walking the visual tree by hand, Gum exposes a diagnostic extension 
 | `GetEventFailureReason(InteractiveGue)` | You want to diagnose a raw visual rather than a Forms control. | `cursor.GetEventFailureReason(myVisual)` |
 
 Because the cursor's position affects the result, call this method in your update loop while attempting to interact with the control.
-
-```csharp
-// Add to using directives
-using MonoGameGum.Input; // Adds GetEventFailureReason extension methods
-```
 
 ### Looking up a control by type
 


### PR DESCRIPTION
## Summary

The events troubleshooting page is one of the most-visited Gum docs pages, but it explained `GetEventFailureReason` thoroughly *before* giving a reader a dead-simple "here's how to check" snippet. A panicked reader had to get past the intro, a five-row overload table, and a `using` note before reaching a usable call.

This PR adds a **Quick Check** section at the top of the page:

- Introduces the `using MonoGameGum.Input;` directive up front (it's now the first code on the page).
- Leads with a breakpoint-and-inspect approach — `reason` is right there in the debugger, no logging needed.
- Shows the two most common lookups: by type (`GetEventFailureReason<Button>()`) and by name (`GetEventFailureReason("ConfirmButton")`).
- Hands off into the existing deep-dive for the remaining overloads.

The now-duplicate `using` block lower in the page was removed.

## Docs code-sample rule change

The `gum-docs-writing` skill previously had a blanket "No debug/console output" rule. That ban makes sense for fiddle-able samples (the goal is to keep them XnaFiddle-runnable and surface results in a visible label), but it's contrived for a page whose entire subject *is* debugging and whose output is a developer-facing diagnostic string nobody will fiddle.

The rule is rewritten as "**Prefer visible output over console output**," keeping the visible-label default and the *why*, while carving out the principled exception for debugging-focused pages.
