### PR TITLE
Fix Raylib direct font-property setters not loading the font (#3093)

### DIFF
--- a/.claude/skills/gum-cross-platform-unification/SKILL.md
+++ b/.claude/skills/gum-cross-platform-unification/SKILL.md
@@ -62,6 +62,19 @@ If a runtime class exists on MonoGame, Raylib, Skia, and Sokol:
 
 This ensures changes remain reviewable, TDD stays manageable, and build errors (like those often found in Sokol) don't block the entire unification process.
 
+## Incremental Convergence: Mirror-`#if` Toward an Empty Diff
+
+The end state above (one source + `#if` + csproj link) is reached **incrementally**, by driving two still-separate per-platform copies of the same file toward byte-for-byte identical content — one corresponding block at a time. You do **not** have to convert a whole file, or even a whole method, in one pass. Pick any region that already lines up between the copies — a fragment *inside* a method is fine — and make just those lines identical. Inside-out and bottom-up are fine; top-down is not required.
+
+For each difference inside the region you're converging, apply the same two-bucket classification (historical drift vs. platform-necessary), but at the line/block level:
+
+- **Historical drift** → delete the divergence; make the lines literally identical with **no** guard. (Example for #3039: the `if (GraphicalUiElement.IsAllLayoutSuspended) { graphicalUiElement.IsFontDirty = true; return; }` deferral guard is shared layout bookkeeping that Raylib simply never got — it should become identical, un-`#if`'d, in both copies.)
+- **Platform-necessary** → wrap the same lines in mirrored `#if RAYLIB` / `#if !RAYLIB` **in both copies, at the same spot**, even though only one side's branch is live in each build. (Example: the font-*loader* body — `BitmapFont` vs `Raylib_cs.Font` — stays `#if`-gated.)
+
+Either way, the **cross-file diff for those lines goes to zero** while each platform keeps compiling its own behavior. The metric is literally `git diff --no-index <copyA> <copyB>` shrinking every PR. When it reaches empty, the two files *are* one file: delete one, add a `<Compile Include="…" Link="…">` to the orphaned csproj, done.
+
+**Gotcha that confuses fresh readers:** the canonical "home" copy can already carry `#if RAYLIB` branches that are **dead in its own current build**. `Gum/Wireframe/CustomSetPropertyOnRenderable.cs` is compiled into `MonoGameGum` (where `RAYLIB` is **not** defined), yet it contains `#if RAYLIB … namespace RaylibGum.Renderables;` scaffolding. That is intentional pre-staging for the day `RaylibGum.csproj` drops its local copy (`Runtimes/RaylibGum/Renderables/CustomSetPropertyOnRenderable.cs`) and links the home file instead. Seeing `#if RAYLIB` inside a MonoGame-compiled file is not a bug.
+
 ## Mechanical Steps
 
 1. Read all three per-platform source files end to end. Write down every difference.
@@ -78,5 +91,7 @@ This ensures changes remain reviewable, TDD stays manageable, and build errors (
 ## What This Skill Is Not
 
 Not a general refactoring guide. Not a pattern for unifying non-runtime files. Specifically: the runtime unification pattern (shared source + `#if` + csproj linking) is appropriate because the Raylib and Skia runtime projects are small wrappers around the MonoGame-style API. Do not apply this pattern to tool code, to GumCommon code (which already lives in one place and is shared differently), or to Forms controls (which are linked as a directory glob).
+
+The **convergence technique** above, however, applies to any source that *already exists as per-platform duplicate copies* heading for a single linked home — not only `GueDeriving` wrappers. The canonical non-wrapper example is the string-path dispatch/bridge file `CustomSetPropertyOnRenderable.cs` (MonoGame copy in `Gum/Wireframe/`, Raylib copy in `Runtimes/RaylibGum/Renderables/`). The "don't apply this to tool code" exclusion is about not *inventing* the source-sharing pattern for things that are genuinely single-home; it does not forbid converging files that are already duplicated per platform.
 
 This skill is also **not** the source of truth for *which* runtimes are unified. Roadmap and per-runtime status live in the (gitignored) design docs at `.claude/designs/runtime-unification/` — `RuntimeNorthStar.md` for the workstream-level roadmap, `runtime-refactoring.md` for per-runtime details. Update those when a unification lands; do not duplicate status here.

--- a/.claude/skills/refactoring-direction/SKILL.md
+++ b/.claude/skills/refactoring-direction/SKILL.md
@@ -28,6 +28,10 @@ If the reason you're tempted to make something `static` is "so a test can call i
 
 If a refactor touches shared runtime/rendering code (`GumCommon`, `RenderingLibrary`, anything under `Runtimes/`, or `MonoGameGum`), read [gum-runtime-topology](../gum-runtime-topology/SKILL.md) first. The same source is compiled into many assemblies and into FlatRedBall via shared projects, so "builds clean in `AllLibraries.sln`" does not mean "didn't break a consumer" (the WPF runtime and FRB are not in that solution).
 
+## Converging per-platform duplicate files
+
+A recurring Gum refactor is driving two (or more) per-platform copies of the same file toward byte-for-byte identical content, so they can eventually collapse to one `#if`-gated linked source. This is done incrementally — block by block, mirroring `#if RAYLIB` / `#if !RAYLIB` in *both* copies wherever a difference is genuinely platform-specific, so the cross-file diff shrinks toward empty. If you're touching code that exists as duplicated per-platform copies (e.g. `CustomSetPropertyOnRenderable.cs`, `GueDeriving/*Runtime.cs`), read [gum-cross-platform-unification](../gum-cross-platform-unification/SKILL.md) for the full technique before editing.
+
 ## Why this matters in Gum
 
 Gum's tool code is mid-migration from static singletons (`PluginManager.Self`, `*Manager.Self`, etc.) to constructor-injected services. Every new `static` is a step backward and undoes that migration's payoff. The runtime libraries are similar: `GraphicalUiElement` is already bloated, and the project memory explicitly calls out "avoid adding new properties/methods directly to this class — prefer separate controller/manager classes." The direction in this skill is the same direction the rest of the codebase is moving.

--- a/Runtimes/RaylibGum/Renderables/CustomSetPropertyOnRenderable.cs
+++ b/Runtimes/RaylibGum/Renderables/CustomSetPropertyOnRenderable.cs
@@ -463,8 +463,10 @@ public class CustomSetPropertyOnRenderable
             }
             else if (value is string fontString)
             {
-                textRenderable.FontFamily = fontString;
-
+                if (textRuntime != null)
+                {
+                    textRuntime.Font = fontString;
+                }
 
                 ReactToFontValueChange();
                 handled = true;
@@ -568,14 +570,27 @@ public class CustomSetPropertyOnRenderable
 
     };
 
-    private static void UpdateToFontValues(Text asText, GraphicalUiElement graphicalUiElement)
+    public static void UpdateToFontValues(IText text, GraphicalUiElement graphicalUiElement)
     {
+        var asText = (Text)text;
         var textRuntime = graphicalUiElement as TextRuntime;
 
         var loaderManager = global::RenderingLibrary.Content.LoaderManager.Self;
 
         if(textRuntime != null)
         {
+            // The font family and size are authoritative on the TextRuntime — both the direct
+            // property setters and the string/state path write them there. Sync them onto the
+            // renderable so its font-based fallbacks (and rendering) stay correct. This subsumes
+            // what the former HandleUpdateFontValues stub did, but also actually loads the font.
+            asText.FontFamily = textRuntime.Font;
+            // Skip the size sync when unchanged: the setter recomputes line height (a native text
+            // measure), and on the double-call string path the second pass would otherwise repeat it.
+            if (asText.FontSize != textRuntime.FontSize)
+            {
+                asText.FontSize = textRuntime.FontSize;
+            }
+
             if (textRuntime.UseCustomFont == true)
             {
                 // todo here:
@@ -588,16 +603,16 @@ public class CustomSetPropertyOnRenderable
                 {
                     fontFromGum = loaderManager.LoadContent<Raylib_cs.Font>(asText.FontFamily);
                 }
-                asText.Font = fontFromGum;
+                AssignFontIfChanged(asText, fontFromGum);
             }
             else
             {
-                if (textRuntime.FontSize > 0 && !string.IsNullOrEmpty(asText.FontFamily))
+                if (textRuntime.FontSize > 0 && !string.IsNullOrEmpty(textRuntime.Font))
                 {
 
                     string fontName = global::RenderingLibrary.Graphics.Fonts.BmfcSave.GetFontCacheFileNameFor(
                     textRuntime.FontSize,
-                    asText.FontFamily,
+                    textRuntime.Font,
                     textRuntime.OutlineThickness,
                     textRuntime.UseFontSmoothing,
                     textRuntime.IsItalic,
@@ -605,19 +620,29 @@ public class CustomSetPropertyOnRenderable
 
                     string fullFileName = ToolsUtilities.FileManager.Standardize(fontName, preserveCase: true, makeAbsolute: true);
 
-                    //font = loaderManager.GetDisposable(fullFileName) as BitmapFont;
-
-
                     var fontFromGum = loaderManager.LoadContent<Raylib_cs.Font>(fullFileName);
                     if (fontFromGum.BaseSize == 0)
                     {
                         fontFromGum = loaderManager.LoadContent<Raylib_cs.Font>(asText.FontFamily);
                     }
-                    asText.Font = fontFromGum;
+                    AssignFontIfChanged(asText, fontFromGum);
                 }
             }
         }
 
+    }
+
+    // Mirrors the MonoGame loader's `if (BitmapFont != fontToSet)` guard. A single SetProperty can
+    // reach this loader twice — once via the TextRuntime setter (UpdateFontFromProperties) and once
+    // via the explicit ReactToFontValueChange call — and with font caching on the second load is a
+    // cache hit, so skipping the redundant reassignment keeps it to one font assignment.
+    // Raylib_cs.Font is a struct, so font identity is compared via the loaded atlas texture id.
+    private static void AssignFontIfChanged(Text asText, Raylib_cs.Font font)
+    {
+        if (asText.Font.Texture.Id != font.Texture.Id)
+        {
+            asText.Font = font;
+        }
     }
 
     #endregion

--- a/Runtimes/RaylibGum/Renderables/Text.cs
+++ b/Runtimes/RaylibGum/Renderables/Text.cs
@@ -586,11 +586,6 @@ public class Text : IVisible, IRenderableIpso,
     bool IRenderableIpso.IsRenderTarget => false;
 
 
-    static Text()
-    {
-        GraphicalUiElement.UpdateFontFromProperties += HandleUpdateFontValues;
-    }
-
     public Text() : this(null)
     {
     }
@@ -603,16 +598,6 @@ public class Text : IVisible, IRenderableIpso,
         Font = DefaultFont.BaseSize > 0 ? DefaultFont : GetFontDefault();
         mChildren = new();
         Visible = true;
-    }
-
-    private static void HandleUpdateFontValues(IText text, GraphicalUiElement element)
-    {
-        var asText = text as Text;
-        if(element is TextRuntime asTextRuntime)
-        {
-            asText.FontSize = asTextRuntime.FontSize;
-
-        }
     }
 
     private void UpdateWrappedText()

--- a/Runtimes/RaylibGum/RenderingLibrary/SystemManagers.cs
+++ b/Runtimes/RaylibGum/RenderingLibrary/SystemManagers.cs
@@ -126,6 +126,11 @@ public class SystemManagers : ISystemManagers
             GraphicalUiElement.SetPropertyOnRenderable = CustomSetPropertyOnRenderable.SetPropertyOnRenderable;
             GraphicalUiElement.AddRenderableToManagers = CustomSetPropertyOnRenderable.AddRenderableToManagers;
             GraphicalUiElement.RemoveRenderableFromManagers = CustomSetPropertyOnRenderable.RemoveRenderableFromManagers;
+            // Wire the font loader here (not in a renderable's static ctor) so it is re-established on
+            // every Initialize, matching the other delegates and MonoGame's SystemManagers. GumService
+            // teardown nulls UpdateFontFromProperties; without re-wiring here, the direct font-property
+            // setters silently stop loading fonts after a teardown/reinitialize cycle.
+            GraphicalUiElement.UpdateFontFromProperties = CustomSetPropertyOnRenderable.UpdateToFontValues;
 
             // raylib seems to use a resources folder, but I don't think we should make any
             // assumptions

--- a/Tests/RaylibGum.Tests/Runtimes/TextRuntimeTests.cs
+++ b/Tests/RaylibGum.Tests/Runtimes/TextRuntimeTests.cs
@@ -1,12 +1,15 @@
 ﻿using Gum.GueDeriving;
+using RenderingLibrary.Content;
 using RenderingLibrary.Graphics;
 using Raylib_cs;
 using Shouldly;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using ToolsUtilities;
 
 namespace RaylibGum.Tests.Runtimes;
 
@@ -116,6 +119,87 @@ public class TextRuntimeTests : BaseTestClass
     public void DefaultFontSize_ShouldBe18()
     {
         TextRuntime.DefaultFontSize.ShouldBe(18);
+    }
+
+    #endregion
+
+    #region Font Loading
+
+    // #3093: font properties set through the direct C# setters (FontFamily/FontSize/...) must load
+    // the font onto the renderable exactly as the string/ApplyState path does. Differential guard:
+    // the two paths must produce an identical, laid-out Text — the same loaded atlas (proving a real
+    // font loaded, not raylib's small built-in default) AND the same measured width (proving the
+    // correct size, which an atlas/glyph count alone would not catch). The bug routed the direct
+    // setters through Text.HandleUpdateFontValues, a stub that copied FontSize but never loaded the
+    // font, so the direct-setter Text kept the default font.
+    [Fact]
+    public void Font_SetViaDirectProperties_ShouldLoadSameFontAsStatePath()
+    {
+        // Serve the gold Font18Arial fixture (and its page) purely in memory, keyed by file name,
+        // so the (Arial, 18) cache file resolves regardless of disk layout. Mirrors
+        // ContentLoaderTests' bundled-font hook.
+        string fixtureDirectory = Path.Combine(AppContext.BaseDirectory, "Content", "FontCache");
+        Dictionary<string, byte[]> inMemoryFiles = new(StringComparer.OrdinalIgnoreCase)
+        {
+            { "Font18Arial.fnt", File.ReadAllBytes(Path.Combine(fixtureDirectory, "Font18Arial.fnt")) },
+            { "Font18Arial_0.png", File.ReadAllBytes(Path.Combine(fixtureDirectory, "Font18Arial_0.png")) },
+        };
+
+        bool savedCacheTextures = LoaderManager.Self.CacheTextures;
+        string savedRelativeDirectory = FileManager.RelativeDirectory;
+        Func<string, Stream>? savedHook = FileManager.CustomGetStreamFromFile;
+        try
+        {
+            LoaderManager.Self.CacheTextures = false;
+            // Unique (non-existent) relative directory: the font's cache key (the standardized
+            // absolute path) becomes unique to this test run, so a prior test's cached
+            // "Font18Arial.fnt" can't mask the result and resolution is forced through the in-memory
+            // hook. Mirrors the GUID-path isolation in ContentLoaderTests.
+            FileManager.RelativeDirectory = Path.Combine(Path.GetTempPath(),
+                "GumRaylibDirectFontTest_" + Guid.NewGuid().ToString("N")).Replace('\\', '/') + "/";
+            FileManager.CustomGetStreamFromFile = incomingPath =>
+                inMemoryFiles.TryGetValue(Path.GetFileName(incomingPath), out byte[]? bytes)
+                    ? new MemoryStream(bytes)
+                    : null!;
+
+            // Reference: the path that already works — font set through the string / state path.
+            TextRuntime viaState = new();
+            viaState.WidthUnits = Gum.DataTypes.DimensionUnitType.RelativeToChildren;
+            viaState.HeightUnits = Gum.DataTypes.DimensionUnitType.RelativeToChildren;
+            viaState.SetProperty("Font", "Arial");
+            viaState.SetProperty("FontSize", 18);
+            viaState.Text = "Hello World";
+
+            // Subject: the identical font set through the direct C# property setters.
+            TextRuntime viaSetter = new();
+            viaSetter.WidthUnits = Gum.DataTypes.DimensionUnitType.RelativeToChildren;
+            viaSetter.HeightUnits = Gum.DataTypes.DimensionUnitType.RelativeToChildren;
+            viaSetter.FontFamily = "Arial";
+            viaSetter.FontSize = 18;
+            viaSetter.Text = "Hello World";
+
+            var stateFont = ((Gum.Renderables.Text)viaState.RenderableComponent).Font;
+            var setterFont = ((Gum.Renderables.Text)viaSetter.RenderableComponent).Font;
+
+            // Absolute: the direct-setter path actually loaded the real Font18Arial atlas (256x256,
+            // per ContentLoaderTests), not raylib's 128x128 built-in default. Asserting this on the
+            // subject directly (not just "setter == state") means the test still fails if a future
+            // regression broke BOTH paths down to the default font.
+            setterFont.Texture.Width.ShouldBe(256);
+            setterFont.Texture.Height.ShouldBe(256);
+            // Differential: the direct-setter path matches the known-good string/state path on the
+            // loaded atlas ...
+            setterFont.Texture.Width.ShouldBe(stateFont.Texture.Width);
+            setterFont.Texture.Height.ShouldBe(stateFont.Texture.Height);
+            // ... and on measured size (catches a wrong font size, which atlas size alone would not).
+            viaSetter.GetAbsoluteWidth().ShouldBe(viaState.GetAbsoluteWidth());
+        }
+        finally
+        {
+            LoaderManager.Self.CacheTextures = savedCacheTextures;
+            FileManager.RelativeDirectory = savedRelativeDirectory;
+            FileManager.CustomGetStreamFromFile = savedHook;
+        }
     }
 
     #endregion

--- a/Tests/RaylibGum.Tests/TestAssemblyInitialize.cs
+++ b/Tests/RaylibGum.Tests/TestAssemblyInitialize.cs
@@ -43,6 +43,9 @@ public class TestAssemblyInitialize : XunitTestFramework
     public static void ApplyDefaultTestState()
     {
         GraphicalUiElement.SetPropertyOnRenderable = CustomSetPropertyOnRenderable.SetPropertyOnRenderable;
+        // Re-establish the font loader here too: tests that tear down GumService null it (GumService
+        // sets UpdateFontFromProperties = null), and this bootstrap is re-run after such teardowns.
+        GraphicalUiElement.UpdateFontFromProperties = CustomSetPropertyOnRenderable.UpdateToFontValues;
 
         // Raylib's LoadEmbeddedTexture2d and MeasureTextEx both require an initialized window.
         // The window is kept hidden for the duration of the test run.


### PR DESCRIPTION
## Summary

Fixes #3093. On the Raylib runtime, setting a `TextRuntime`'s font via the **direct C# setters** (`Font`/`FontFamily`, `FontSize`, `IsBold`, `IsItalic`, `OutlineThickness`, `UseFontSmoothing`, `UseCustomFont`, `CustomFontFile`) did not load the font onto the renderable — only the string/`ApplyState` path (Gum-tool state variables) worked. Independent of layout suspension or font batching.

## Root cause

The direct setters route through the inherited `GraphicalUiElement.UpdateToFontValues()` → the `UpdateFontFromProperties` delegate. On Raylib that delegate was wired (in the `Text` static constructor) to `Text.HandleUpdateFontValues`, a stub that only copied `FontSize` and never loaded a font. The real loader (`CustomSetPropertyOnRenderable.UpdateToFontValues`) was reachable only from the string path via `ReactToFontValueChange`.

While making the regression test reliable, a second, **production** fragility surfaced: `MonoGameGum/GumService.cs` (compiled into RaylibGum) nulls `UpdateFontFromProperties` on teardown, and Raylib only re-wired it in the `Text` static constructor (runs once, can't recover). So after any GumService teardown/reinitialize the direct-setter font path silently died. MonoGame avoids this by wiring the delegate in `SystemManagers`; Raylib was missing that.

## Fix

- **Converge the loader toward MonoGame's** (one concrete step of the `CustomSetPropertyOnRenderable` cross-platform convergence): take `IText` (cast internally), source the font family/size from the `TextRuntime` (not the renderable, which the direct setters never populate), and assign through a single change-check (`AssignFontIfChanged`) mirroring MonoGame's `if (BitmapFont != fontToSet)`.
- **Wire `UpdateFontFromProperties` in `SystemManagers.Initialize`** (and the test bootstrap) alongside the other delegates, so it is re-established on every init and survives a teardown/reinitialize cycle. Removed the fragile `Text` static-constructor wiring and the stub.

### One font assignment, not two

With the delegate now loading, a single `SetProperty` reaches the loader twice (once via the `TextRuntime` setter, once via the explicit `ReactToFontValueChange`). `AssignFontIfChanged` skips the redundant reassignment (the second load is a cache hit), so it stays at one assignment in production — exactly how MonoGame's loader already behaves. The `FontSize` sync is likewise guarded to avoid a redundant native line-height measure.

## Tests

`Font_SetViaDirectProperties_ShouldLoadSameFontAsStatePath` pins both an **absolute** fact (the direct-setter path loads the real `Font18Arial` 256×256 atlas, not raylib's 128×128 default) and a **differential** one (it matches the known-good string/state path on atlas and measured size). The test bootstrap re-establishes the font delegate after GumService-teardown tests. Verified non-flaky across 35 consecutive full-suite runs (297 tests each); the Raylib sample builds clean.

## Relation to #3039

Prerequisite for #3039: now that the flush delegate (`UpdateFontRecursive` → `UpdateFontFromProperties`) points at the real loader, deferred-font flushing actually loads on Raylib — the groundwork #3039's `IsAllLayoutSuspended` deferral guard needs.

## Skill docs

Documents the incremental mirror-`#if` convergence technique (drive per-platform duplicate files toward an empty diff, block by block) in `gum-cross-platform-unification`, with a pointer from `refactoring-direction`.

Closes #3093

🤖 Generated with [Claude Code](https://claude.com/claude-code)
