### PR TITLE
Fix drag-dropped element not parenting to target's default child slot

### DIFF
--- a/Gum/Managers/DragDropManager.cs
+++ b/Gum/Managers/DragDropManager.cs
@@ -683,11 +683,13 @@ public class DragDropManager : IDragDropManager
         {
             return string.IsNullOrEmpty(currentParent);
         }
-        // Allow the existing value to be either the parent name or a
-        // "parent.defaultChild" form (which resolves to the same parent).
-        return currentParent == expectedParentName
-            || (currentParent != null && expectedParentName.StartsWith(currentParent + "."))
-            || (currentParent != null && currentParent.StartsWith(expectedParentName + "."));
+        // Exact match only. A bare "parent" and a "parent.defaultChild" slot
+        // are different parentings (container root vs. the default child slot),
+        // so they must NOT be treated as already-matching — otherwise the
+        // early-out skips upgrading a freshly-added instance (created with the
+        // bare parent name by AddInstance) to the parent's default child slot,
+        // leaving it attached to the container root instead of the slot.
+        return currentParent == expectedParentName;
     }
 
     private static InstanceSave? FindLastSiblingOfParent(ElementSave element, InstanceSave parentInstance, InstanceSave excludeInstance)

--- a/Tool/Tests/GumToolUnitTests/Managers/DragDropManagerTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Managers/DragDropManagerTests.cs
@@ -592,6 +592,107 @@ public class DragDropManagerTests : BaseTestClass
     }
 
     [Fact]
+    public void OnNodeSortingDropped_DropElementOnInstanceWithDefaultChild_ParentsToDefaultSlot()
+    {
+        // Regression: dragging an element from the tree onto an instance whose
+        // base component declares a DefaultChildContainer must parent the new
+        // instance to "<instance>.<defaultSlot>", matching paste and
+        // right-click-add. Commit 66df81010 added an early-out in
+        // HandleDroppingInstanceOnTarget guarded by ParentVariableAlreadyMatches,
+        // whose loose prefix matching treated the bare "<instance>" parent (the
+        // value AddInstance writes) as already matching "<instance>.<slot>", so
+        // the slot upgrade was skipped and the child attached to the container
+        // root instead of its default slot.
+        GumProjectSave project = new GumProjectSave();
+        ObjectFinder.Self.GumProjectSave = project;
+
+        ComponentSave listBoxUiContainer = new ComponentSave { Name = "ListBoxUiContainer" };
+        StateSave containerDefault = new StateSave { Name = "Default", ParentContainer = listBoxUiContainer };
+        listBoxUiContainer.States.Add(containerDefault);
+        listBoxUiContainer.Instances.Add(new InstanceSave { Name = "InnerPanel", BaseType = "Container", ParentContainer = listBoxUiContainer });
+        containerDefault.SetValue("DefaultChildContainer", "InnerPanel", "string");
+        project.Components.Add(listBoxUiContainer);
+
+        ScreenSave screen = new ScreenSave { Name = "MainScreen" };
+        screen.States.Add(new StateSave { Name = "Default", ParentContainer = screen });
+        project.Screens.Add(screen);
+
+        InstanceSave listBoxInstance = new InstanceSave { Name = "ListBoxUiContainerInstance", BaseType = "ListBoxUiContainer", ParentContainer = screen };
+        screen.Instances.Add(listBoxInstance);
+
+        // Pin the precondition: the production path relies on this resolving to a
+        // non-empty slot, otherwise the test couldn't reproduce the bug.
+        ObjectFinder.Self.GetDefaultChildName(listBoxInstance, screen.DefaultState)
+            .ShouldBe("InnerPanel", "test setup must produce a default child slot");
+
+        ComponentSave draggedComponent = new ComponentSave { Name = "DraggedComponent" };
+        draggedComponent.States.Add(new StateSave { Name = "Default", ParentContainer = draggedComponent });
+
+        _circularReferenceManager
+            .Setup(x => x.CanTypeBeAddedToElement(It.IsAny<ElementSave>(), It.IsAny<string>()))
+            .Returns(true);
+
+        _mocker.GetMock<ISelectedState>()
+            .Setup(x => x.SelectedStateSave).Returns(screen.DefaultState);
+
+        _mocker.GetMock<IElementCommands>()
+            .Setup(x => x.GetUniqueNameForNewInstance(It.IsAny<ElementSave>(), It.IsAny<ElementSave>()))
+            .Returns("DraggedComponent1");
+
+        // Stand in for ElementCommands.AddInstance — mutate the screen the way the
+        // real command does (append, write the Parent variable to the bare parent
+        // name) so HandleDroppingInstanceOnTarget runs against the same state.
+        _mocker.GetMock<IElementCommands>()
+            .Setup(x => x.AddInstance(
+                It.IsAny<ElementSave>(),
+                It.IsAny<string>(),
+                It.IsAny<string?>(),
+                It.IsAny<string?>(),
+                It.IsAny<int?>()))
+            .Returns((ElementSave element, string name, string? type, string? parentName, int? desiredIndex) =>
+            {
+                InstanceSave inst = new InstanceSave
+                {
+                    Name = name,
+                    BaseType = type ?? string.Empty,
+                    ParentContainer = element
+                };
+                if (desiredIndex.HasValue)
+                {
+                    element.Instances.Insert(desiredIndex.Value, inst);
+                }
+                else
+                {
+                    element.Instances.Add(inst);
+                }
+                if (!string.IsNullOrEmpty(parentName))
+                {
+                    element.DefaultState.SetValue($"{inst.Name}.Parent", parentName, "string");
+                }
+                return inst;
+            });
+
+        Mock<ITreeNode> draggedNode = new Mock<ITreeNode>();
+        draggedNode.Setup(x => x.Tag).Returns(draggedComponent);
+
+        Mock<ITreeNode> targetNode = new Mock<ITreeNode>();
+        targetNode.Setup(x => x.Tag).Returns(listBoxInstance);
+
+        List<ITreeNode> draggedNodes = new() { draggedNode.Object };
+
+        // ProcessDrop's Into-on-InstanceSave shape (see ProcessDrop line 814).
+        DropTarget dropTarget = new DropTarget(screen, listBoxInstance, new DropPosition.Append());
+
+        // Act
+        _dragDropManager.OnNodeSortingDropped(draggedNodes, targetNode.Object, dropTarget);
+
+        // Assert
+        string? parentValue = screen.DefaultState.GetValue("DraggedComponent1.Parent") as string;
+        parentValue.ShouldBe("ListBoxUiContainerInstance.InnerPanel",
+            "the dropped instance must be parented to the target's default child slot, like paste / add do");
+    }
+
+    [Fact]
     public void OnNodeSortingDropped_DropInstanceOnItsCurrentParent_IsNoOp()
     {
         // Dropping an instance onto its current parent must not reorder the


### PR DESCRIPTION
Closes #3086

## Problem

Dragging an element from the tree view (e.g. **Standard / Container**) onto an instance whose base component declares a `DefaultChildContainer` left the newly-created instance parented to the **bare container** (`ListBoxUiContainerInstance`) instead of the container's **default child slot** (`ListBoxUiContainerInstance.InnerPanel`).

Pasting, or right-click → add, set the parent to the default slot correctly — so drag-drop was inconsistent with the other two ways of adding a child.

## Root cause

Regression from `66df81010` (#2877, "Refactor drop-target plumbing with typed DropTarget"), which added a "drop on current parent is a no-op" early-out in `HandleDroppingInstanceOnTarget`, guarded by `ParentVariableAlreadyMatches`. That helper used **loose prefix matching**:

```csharp
return currentParent == expectedParentName
    || expectedParentName.StartsWith(currentParent + ".")   // "Parent.Slot".StartsWith("Parent.") → true
    || currentParent.StartsWith(expectedParentName + ".");
```

The drop-element path creates the instance via `AddInstance(..., parentInstance?.Name, ...)` — the **bare** parent name — and relies on `HandleDroppingInstanceOnTarget` to upgrade it to the slot. The loose match treated bare `"...Instance"` as already matching `"...Instance.InnerPanel"`, so the early-out fired and the slot upgrade was skipped.

Parenting to the container **root** and to the container's **default child slot** are different parentings, so treating them as a match was semantically wrong.

## Fix

Tighten `ParentVariableAlreadyMatches` to **exact** (null/empty-equivalent) matching, dropping the two `StartsWith` branches. The early-out now fires only for a genuine no-op (re-dropping onto a parent you already fully have), and the slot upgrade proceeds for freshly-added instances.

## Tests

- **New failing-first regression test** `OnNodeSortingDropped_DropElementOnInstanceWithDefaultChild_ParentsToDefaultSlot` — the first test in the file to stand up a `GumProjectSave` with a `DefaultChildContainer`, which is what makes the bare-vs-slot distinction observable. Confirmed red before the fix (`"ListBoxUiContainerInstance"` vs expected `"ListBoxUiContainerInstance.InnerPanel"`), green after.
- The two parent-reaffirmation no-op tests added by the regressing commit (`OnNodeSortingDropped_DropInstanceOnItsCurrentParent_IsNoOp`, `OnNodeSortingDropped_DropTopLevelInstanceOnContainingElement_IsNoOp`) **still pass** — they exercise bare==bare / null==null, which exact matching preserves.
- Full `GumToolUnitTests`: **840 passed, 0 failed, 5 skipped**.

## Behavior note

With exact matching, if an existing instance is parented to the bare container (no slot) and is then re-dropped onto that container, it now snaps into the default child slot rather than being a silent no-op. This is consistent with paste/add and is the intended behavior, but it is a deliberate change from the prior loose-match no-op for that specific (previously untested) case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
