### PR TITLE
Docs: explain GumBatch's relationship with the Camera

### DIFF
--- a/docs/code/layout/resizing-the-game-window.md
+++ b/docs/code/layout/resizing-the-game-window.md
@@ -185,6 +185,10 @@ As with the expand example, `Root.UpdateLayout()` is only needed if your game lo
 
 <figure><img src="../../.gitbook/assets/20_07 03 01.gif" alt=""><figcaption><p>Gum responding to resizes by zooming and adjusting canvas sizes</p></figcaption></figure>
 
+{% hint style="info" %}
+`Renderer.Camera.Zoom` also affects immediate-mode drawing with GumBatch, since GumBatch renders through the same camera. See [Relationship with the Camera](../rendering/gumbatch.md#relationship-with-the-camera).
+{% endhint %}
+
 ## RenderTargets, Scaling, and Offsets
 
 Gum can be drawn to a RenderTarget2D which can then be drawn with a SpriteBatch. By using a RenderTarget2D, the entire contents of Gum can be scaled, offset, and even rotated. This type of offset can break interaction unless the Cursor is adjusted in response to these changes by setting its `TransformMatrix`. For more information see the [Cursor TransformMatrix page](../gum-code-reference/cursor/transformmatrix.md).

--- a/docs/code/rendering/gumbatch.md
+++ b/docs/code/rendering/gumbatch.md
@@ -19,6 +19,18 @@ Core.GumBatch.End();
 ```
 {% endhint %}
 
+### Relationship with the Camera
+
+GumBatch draws through the same `Camera` as the rest of Gum — the one at `GumService.Default.Renderer.Camera`. It does **not** ignore the camera: the camera's `Zoom`, `Position` (`X` and `Y`), and `CameraCenterOnScreen` all apply to everything you draw between `Begin` and `End`. So if you zoom the camera to handle a window resize (see [Resolution and Resizing the Game Window](../layout/resizing-the-game-window.md)), your GumBatch output zooms along with the rest of your UI.
+
+`Begin` also refreshes the camera's client dimensions from the current `GraphicsDevice.Viewport` on every call, so GumBatch always matches the live viewport size.
+
+`Begin` accepts an optional transform: `Begin(Matrix)`. This matrix **composes on top of** the camera transform rather than replacing it — the effective transform is your matrix multiplied with the camera's view.
+
+{% hint style="warning" %}
+Because the matrix composes on top of the camera, setting `Camera.Zoom` to a non-default value **and** passing a scaling matrix to `Begin(Matrix)` applies the scale twice. Drive scaling from a single source: either leave the matrix off and use `Camera.Zoom`, or pass a matrix and keep `Camera.Zoom` at `1`.
+{% endhint %}
+
 ### Rendering TextRuntimes
 
 The most flexible way to draw text with GumBatch is to create a `TextRuntime`. TextRuntimes support all of Gum's layout rules — wrapping, alignment, rotation, sizing — and integrate with Gum's font system so you can set `Font` and `FontSize` directly and let KernSmith create the atlas on demand.


### PR DESCRIPTION
## What

Documents how GumBatch (immediate-mode rendering) relates to Gum's `Camera`. This came out of a question about whether GumBatch ignores the camera — it does **not**.

## Findings

GumBatch renders through the same `Renderer.Camera` as retained-mode Gum rendering (they share one camera instance via `SystemManagers.Default.Renderer`):

- `GumBatch.Begin` refreshes `Camera.Client*` from the live `GraphicsDevice.Viewport`, then routes through `Renderer.Begin` → `SpriteRenderer.BeginSpriteBatch`, which builds the view from `Camera.GetTransformationMatrix`.
- So the camera's `Zoom`, `Position` (`X`/`Y`), and `CameraCenterOnScreen` all apply to GumBatch draws.
- The optional `Begin(Matrix)` transform **composes on top of** the camera view (`yourMatrix * cameraView`) rather than replacing it — so setting both `Camera.Zoom` and a scaling matrix double-applies the scale.

## Changes

- **`docs/code/rendering/gumbatch.md`** — new "Relationship with the Camera" section covering the above, including the double-zoom warning.
- **`docs/code/layout/resizing-the-game-window.md`** — info hint in the Manual Zoom section noting that `Camera.Zoom` also affects GumBatch, linking to the new section.

Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
