### PR TITLE
Promote IGumFileProvider to the canonical runtime file seam (#2940)

### DIFF
--- a/.claude/skills/gum-runtime-hot-reload/SKILL.md
+++ b/.claude/skills/gum-runtime-hot-reload/SKILL.md
@@ -30,7 +30,7 @@ The watched path is the **source** `.gumx` (the file the Gum tool edits), not th
 - `_projectSourcePath` / `sourceDirectory` — where files change, where `FontCache/` is read from
 - `_binGumDirectory` — snapshot of `FileManager.RelativeDirectory` at `Start()`; where fonts are copied **to** and where the runtime loads from
 
-During `PerformReload`, `FileManager.RelativeDirectory` is temporarily swapped to the source directory so `TryLoadAnimation` resolves `.ganx` files against the live source tree, then restored. If you add any asset-resolving logic to the reload path, respect this swap — or you will read from the wrong directory.
+During `PerformReload`, animations are reloaded by enumerating `*Animations.ganx` under the source directory through a `LooseFileGumFileProvider` rooted there (via `GumService.LoadAnimationsFromProvider`). `FileManager.RelativeDirectory` is **not** swapped — the provider's root is the source directory. (This replaced an older approach that swapped `RelativeDirectory` and probed `FileManager.FileExists` per element.) If you add asset-resolving logic to the reload path, root it at the source directory yourself rather than relying on a global-state swap.
 
 ## Reload Pipeline
 
@@ -50,7 +50,7 @@ The 200 ms debounce coalesces the Gum tool's multi-file save burst into one relo
 
 1. `CopyAndUnloadChangedFonts()` — copies changed `.fnt` files plus matching `<basename>*.png` texture pages from source `FontCache/` to bin `FontCache/`, then `LoaderManager.Dispose`s both so they reload from disk.
 2. `GumProjectSave.Load` + `Initialize`; swap into `ObjectFinder.Self.GumProjectSave`.
-3. Temporarily point `FileManager.RelativeDirectory` at the source directory, call `GumService.TryLoadAnimation` for every element, restore.
+3. Reload animations: enumerate `*Animations.ganx` under the source directory via a `LooseFileGumFileProvider` and load each through `GumService.LoadAnimationsFromProvider` into the new project (no `RelativeDirectory` swap — the provider is rooted at the source dir).
 4. `ApplyDiff(roots, newProject, SystemManagers.Default)` — applies the in-place reconciliation walk described below.
 5. Fire `ReloadCompleted`.
 
@@ -78,7 +78,7 @@ Defined on `GumHotReloadManager` and exposed `public static` for direct test use
 - **Runtime state on design-time visuals is overwritten** by `SetVariablesRecursively`. Games that mutate UI in code need to rerun that logic on `ReloadCompleted`.
 - **Children added with no `Tag`** (or with a `Tag` that isn't an `InstanceSave`) are runtime-owned and preserved. This includes ItemsControl-generated rows and anything the user constructed programmatically.
 - **Reparenting flows through the qualified `<instance>.Parent` variable** — there is no explicit reparent step in the diff. The parent state's `Foo.Parent = "Bar"` line is what re-attaches `Foo` under `Bar` during `SetVariablesRecursively`. This is why both old and new parent visuals must exist before that step runs.
-- **Textures (non-font `.png`) and `.ganx` are watched but not reloaded** in the cache-eviction sense. `.ganx` is only re-read via `TryLoadAnimation` on the new project; `.png` edits require a restart.
+- **Textures (non-font `.png`) and `.ganx` are watched but not reloaded** in the cache-eviction sense. `.ganx` is only re-read by enumerating the source directory into the new project's `ElementAnimations` (via `GumService.LoadAnimationsFromProvider`); `.png` edits require a restart.
 - **`_changedFontFiles` is mutated off the game thread** (watcher callback). It's protected by `_fontFileLock`; any new shared state added must be similarly synchronized.
 - **`Stop()` is idempotent-safe** but does not reset other state — `GumService.Uninitialize` just nulls the manager reference afterward.
 - **Font cache path is built with `FileManager.Standardize(..., preserveCase: true, makeAbsolute: true)`.** The loader's cache keys are case-preserving absolute paths; any eviction added must match that exact shape or it will silently miss.

--- a/GumCommon/Bundle/CompositeGumFileProvider.cs
+++ b/GumCommon/Bundle/CompositeGumFileProvider.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace Gum.Bundle;
+
+/// <summary>
+/// <see cref="IGumFileProvider"/> that chains several providers in order: the first provider that
+/// has a file wins for <see cref="Exists"/>/<see cref="OpenRead"/>, and <see cref="EnumerateFiles"/>
+/// returns the deduped union (first occurrence wins). Gum's default loading never builds one of
+/// these — it is the explicit opt-in for advanced hosts that want mod / DLC / hot-reload overlays
+/// layered over the project's own content (e.g.
+/// <c>new CompositeGumFileProvider(resolution.FileProvider, new LooseFileGumFileProvider("./Mods"))</c>).
+/// </summary>
+public class CompositeGumFileProvider : IGumFileProvider
+{
+    private readonly IGumFileProvider[] _providers;
+
+    /// <summary>
+    /// Initializes a new <see cref="CompositeGumFileProvider"/> over <paramref name="providers"/>,
+    /// in precedence order — earlier providers shadow later ones.
+    /// </summary>
+    public CompositeGumFileProvider(params IGumFileProvider[] providers)
+    {
+        if (providers == null)
+        {
+            throw new ArgumentNullException(nameof(providers));
+        }
+        _providers = providers;
+    }
+
+    /// <inheritdoc/>
+    public bool Exists(string relativePath)
+    {
+        foreach (IGumFileProvider provider in _providers)
+        {
+            if (provider.Exists(relativePath))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /// <inheritdoc/>
+    public Stream OpenRead(string relativePath)
+    {
+        foreach (IGumFileProvider provider in _providers)
+        {
+            if (provider.Exists(relativePath))
+            {
+                return provider.OpenRead(relativePath);
+            }
+        }
+        throw new FileNotFoundException(
+            $"File '{relativePath}' was not found in any of the composed file providers.",
+            relativePath);
+    }
+
+    /// <inheritdoc/>
+    public IEnumerable<string> EnumerateFiles(string searchPattern)
+    {
+        HashSet<string> seen = new HashSet<string>(StringComparer.Ordinal);
+        foreach (IGumFileProvider provider in _providers)
+        {
+            foreach (string path in provider.EnumerateFiles(searchPattern))
+            {
+                if (seen.Add(path))
+                {
+                    yield return path;
+                }
+            }
+        }
+    }
+}

--- a/GumCommon/Bundle/GumBundleLoader.cs
+++ b/GumCommon/Bundle/GumBundleLoader.cs
@@ -17,11 +17,13 @@ namespace Gum.Bundle;
 public static class GumBundleLoader
 {
     /// <summary>
-    /// Returns a <see cref="BundleResolution"/> describing how to load <paramref name="projectPath"/>.
+    /// Returns a <see cref="ProjectResolution"/> describing how to load <paramref name="projectPath"/>.
     /// The extension picks the mode: <c>.gumx</c> = loose, <c>.gumpkg</c> = bundle. Any other
-    /// extension throws.
+    /// extension throws. The resolution always carries an <see cref="IGumFileProvider"/> — the
+    /// canonical runtime file seam — that new code (e.g. animation enumeration) should prefer over
+    /// re-deriving paths and probing <see cref="FileManager"/> per element.
     /// </summary>
-    public static BundleResolution Resolve(string projectPath)
+    public static ProjectResolution Resolve(string projectPath)
     {
         if (string.IsNullOrEmpty(projectPath))
         {
@@ -40,8 +42,18 @@ public static class GumBundleLoader
         if (string.Equals(extension, ".gumx", StringComparison.OrdinalIgnoreCase))
         {
             // Loose mode: hand the path straight to GumProjectSave.Load. No probing for a
-            // sibling .gumpkg — if the caller wanted a bundle they would have said so.
-            return new BundleResolution(usedBundle: false, resolvedGumxPath: resolvedPath, previousHook: null);
+            // sibling .gumpkg — if the caller wanted a bundle they would have said so. The
+            // CustomGetStreamFromFile hook is deliberately left untouched: on a real filesystem
+            // GetStreamForFile's File.OpenRead fallback already serves loose files, so installing
+            // an adapter would only add a stricter casing check with no upside. The provider is
+            // carried purely so new enumeration-based code (animation loading) has a seam to use.
+            string? looseDirectory = Path.GetDirectoryName(resolvedPath);
+            string looseRoot = string.IsNullOrEmpty(looseDirectory) ? "." : looseDirectory!;
+            return new ProjectResolution(
+                usedBundle: false,
+                resolvedGumxPath: resolvedPath,
+                fileProvider: new LooseFileGumFileProvider(looseRoot),
+                previousHook: null);
         }
 
         if (!string.Equals(extension, ".gumpkg", StringComparison.OrdinalIgnoreCase))
@@ -108,7 +120,11 @@ public static class GumBundleLoader
                 incomingPath);
         };
 
-        return new BundleResolution(usedBundle: true, resolvedGumxPath: gumxPath, previousHook: previousHook);
+        return new ProjectResolution(
+            usedBundle: true,
+            resolvedGumxPath: gumxPath,
+            fileProvider: provider,
+            previousHook: previousHook);
 #endif
     }
 
@@ -195,12 +211,13 @@ public static class GumBundleLoader
 }
 
 /// <summary>
-/// Result of <see cref="GumBundleLoader.Resolve"/>: whether the loader should treat the
-/// project as bundle-backed, the path to pass to <c>GumProjectSave.Load</c>, and the previous
+/// Result of <see cref="GumBundleLoader.Resolve"/>: whether the loader treated the project as
+/// bundle-backed, the path to pass to <c>GumProjectSave.Load</c>, the <see cref="IGumFileProvider"/>
+/// that owns the project's content, and the previous
 /// <see cref="FileManager.CustomGetStreamFromFile"/> hook (so callers can restore it on dispose
 /// if they need to fully unwind the install).
 /// </summary>
-public class BundleResolution
+public class ProjectResolution
 {
     /// <summary>True if the caller passed a `.gumpkg` and the bundle hook was installed.</summary>
     public bool UsedBundle { get; }
@@ -213,6 +230,15 @@ public class BundleResolution
     public string ResolvedGumxPath { get; }
 
     /// <summary>
+    /// The canonical file source for this project's content: a <see cref="BundleGumFileProvider"/>
+    /// in bundle mode, a <see cref="LooseFileGumFileProvider"/> in loose mode. New runtime code
+    /// should resolve project files through this rather than re-deriving paths and probing
+    /// <see cref="FileManager"/> per file — that path is what produces the cosmetic 404 cascade on
+    /// streaming platforms.
+    /// </summary>
+    public IGumFileProvider FileProvider { get; }
+
+    /// <summary>
     /// The <see cref="FileManager.CustomGetStreamFromFile"/> hook value at the time
     /// <see cref="GumBundleLoader.Resolve"/> ran, or <c>null</c> if none was set or bundle mode
     /// was not selected. Callers that wish to fully uninstall the bundle hook should restore
@@ -220,11 +246,12 @@ public class BundleResolution
     /// </summary>
     public Func<string, Stream>? PreviousHook { get; }
 
-    /// <summary>Initializes a new <see cref="BundleResolution"/>.</summary>
-    public BundleResolution(bool usedBundle, string resolvedGumxPath, Func<string, Stream>? previousHook)
+    /// <summary>Initializes a new <see cref="ProjectResolution"/>.</summary>
+    public ProjectResolution(bool usedBundle, string resolvedGumxPath, IGumFileProvider fileProvider, Func<string, Stream>? previousHook)
     {
         UsedBundle = usedBundle;
         ResolvedGumxPath = resolvedGumxPath;
+        FileProvider = fileProvider;
         PreviousHook = previousHook;
     }
 }

--- a/GumCoreShared.projitems
+++ b/GumCoreShared.projitems
@@ -10,6 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)GumCommon\Bundle\BundleGumFileProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)GumCommon\Bundle\CompositeGumFileProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GumCommon\Bundle\DependencyWarning.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GumCommon\Bundle\FontReferenceCollector.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GumCommon\Bundle\GlobMatcher.cs" />

--- a/MonoGameGum.Tests/DataTypes/GumServiceBundleLoadTests.cs
+++ b/MonoGameGum.Tests/DataTypes/GumServiceBundleLoadTests.cs
@@ -54,7 +54,7 @@ public class GumServiceBundleLoadTests : BaseTestClass, IDisposable
         WriteEntriesAsLooseFiles(_projectDir);
         WriteBundle(_gumpkgPath, _entriesByRelativePath);
 
-        BundleResolution resolution = GumBundleLoader.Resolve(_gumxPath);
+        ProjectResolution resolution = GumBundleLoader.Resolve(_gumxPath);
 
         resolution.UsedBundle.ShouldBeFalse();
         FileManager.CustomGetStreamFromFile.ShouldBeNull();
@@ -71,7 +71,7 @@ public class GumServiceBundleLoadTests : BaseTestClass, IDisposable
     {
         WriteBundle(_gumpkgPath, _entriesByRelativePath);
 
-        BundleResolution resolution = GumBundleLoader.Resolve(_gumpkgPath);
+        ProjectResolution resolution = GumBundleLoader.Resolve(_gumpkgPath);
 
         resolution.UsedBundle.ShouldBeTrue();
         FileManager.CustomGetStreamFromFile.ShouldNotBeNull();
@@ -90,7 +90,7 @@ public class GumServiceBundleLoadTests : BaseTestClass, IDisposable
     {
         WriteEntriesAsLooseFiles(_projectDir);
 
-        BundleResolution resolution = GumBundleLoader.Resolve(_gumxPath);
+        ProjectResolution resolution = GumBundleLoader.Resolve(_gumxPath);
 
         resolution.UsedBundle.ShouldBeFalse();
         FileManager.CustomGetStreamFromFile.ShouldBeNull();
@@ -118,7 +118,7 @@ public class GumServiceBundleLoadTests : BaseTestClass, IDisposable
         File.Exists(_gumxPath).ShouldBeFalse();
 
         WriteBundle(_gumpkgPath, _entriesByRelativePath);
-        BundleResolution resolution = GumBundleLoader.Resolve(_gumpkgPath);
+        ProjectResolution resolution = GumBundleLoader.Resolve(_gumpkgPath);
         resolution.UsedBundle.ShouldBeTrue();
 
         GumProjectSave? bundled = GumProjectSave.Load(resolution.ResolvedGumxPath, out GumLoadResult bundledResult);

--- a/MonoGameGum.Tests/DataTypes/LoadAnimationsFromProviderTests.cs
+++ b/MonoGameGum.Tests/DataTypes/LoadAnimationsFromProviderTests.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Xml.Serialization;
+using Gum.Bundle;
+using Gum.DataTypes;
+using Gum.StateAnimation.SaveClasses;
+using Shouldly;
+using ToolsUtilities;
+using Xunit;
+
+namespace MonoGameGum.Tests.DataTypes;
+
+/// <summary>
+/// Tests for <see cref="GumService.LoadAnimationsFromProvider"/>: the enumeration-based animation
+/// loader that replaced the per-element <c>FileManager.FileExists</c> probing. Driving it through an
+/// in-memory <see cref="BundleGumFileProvider"/> proves it does zero per-element I/O and derives the
+/// element name from the bundle path — including nested component folders, which the old
+/// "**/*Animations.ganx" glob (no recursive <c>**</c> support in GlobMatcher) would have missed.
+/// </summary>
+public class LoadAnimationsFromProviderTests
+{
+    [Fact]
+    public void LoadAnimationsFromProvider_loads_one_animation_file_per_ganx_and_derives_element_name_from_path()
+    {
+        IGumFileProvider provider = Provider(
+            ("Screens/MainScreenAnimations.ganx", Ganx()),
+            ("Components/Buttons/MyButtonAnimations.ganx", Ganx()));
+
+        GumProjectSave project = new GumProjectSave();
+
+        int loaded = GumService.LoadAnimationsFromProvider(project, provider);
+
+        loaded.ShouldBe(2);
+        project.ElementAnimations
+            .Select(animation => animation.ElementName)
+            .ShouldBe(new[] { "MainScreen", "Buttons/MyButton" }, ignoreOrder: true);
+    }
+
+    [Fact]
+    public void LoadAnimationsFromProvider_ignores_files_that_are_not_animation_files()
+    {
+        IGumFileProvider provider = Provider(
+            ("Screens/MainScreen.gusx", new byte[] { 1, 2, 3 }),
+            ("Screens/MainScreenAnimations.ganx", Ganx()));
+
+        GumProjectSave project = new GumProjectSave();
+
+        int loaded = GumService.LoadAnimationsFromProvider(project, provider);
+
+        loaded.ShouldBe(1);
+        project.ElementAnimations.Single().ElementName.ShouldBe("MainScreen");
+    }
+
+    [Fact]
+    public void LoadAnimationsFromProvider_loads_nothing_when_no_ganx_present()
+    {
+        IGumFileProvider provider = Provider(
+            ("Screens/MainScreen.gusx", new byte[] { 1, 2, 3 }));
+
+        GumProjectSave project = new GumProjectSave();
+
+        int loaded = GumService.LoadAnimationsFromProvider(project, provider);
+
+        loaded.ShouldBe(0);
+        project.ElementAnimations.ShouldBeEmpty();
+    }
+
+    private static byte[] Ganx()
+    {
+        ElementAnimationsSave save = new ElementAnimationsSave();
+        // Intentionally wrong: the loader must overwrite ElementName from the bundle path, not
+        // trust whatever is serialized inside the file.
+        save.ElementName = "WRONG";
+        XmlSerializer serializer = FileManager.GetXmlSerializer(typeof(ElementAnimationsSave));
+        using MemoryStream memoryStream = new MemoryStream();
+        serializer.Serialize(memoryStream, save);
+        return memoryStream.ToArray();
+    }
+
+    private static IGumFileProvider Provider(params (string path, byte[] bytes)[] entries)
+    {
+        Dictionary<string, byte[]> dictionary = new Dictionary<string, byte[]>(StringComparer.Ordinal);
+        List<string> order = new List<string>();
+        foreach ((string path, byte[] bytes) in entries)
+        {
+            dictionary[path] = bytes;
+            order.Add(path);
+        }
+        return new BundleGumFileProvider(new GumBundle(version: 1, entries: dictionary, entryPathsInOrder: order));
+    }
+}

--- a/MonoGameGum.Tests/Hot/HotReloadAnimationReloadTests.cs
+++ b/MonoGameGum.Tests/Hot/HotReloadAnimationReloadTests.cs
@@ -1,0 +1,70 @@
+using System;
+using System.IO;
+using System.Xml.Serialization;
+using Gum.DataTypes;
+using Gum.Managers;
+using Gum.StateAnimation.SaveClasses;
+using Gum.Wireframe;
+using Shouldly;
+using ToolsUtilities;
+using Xunit;
+
+namespace MonoGameGum.Tests.Hot;
+
+/// <summary>
+/// Drives the animation side of hot reload through <see cref="GumHotReloadManager.PerformReload"/>
+/// directly (bypassing the FileSystemWatcher + debounce). Reload reads animations from the live
+/// <em>source</em> directory by enumerating its <c>*Animations.ganx</c> files through a
+/// <see cref="Gum.Bundle.LooseFileGumFileProvider"/> — this replaced the old per-element
+/// <c>FileManager.FileExists</c> probe + <c>RelativeDirectory</c> swap. Empty roots keep the
+/// structural <see cref="GumHotReloadManager.ApplyDiff"/> a no-op so the test isolates the
+/// animation-loading path.
+/// </summary>
+public class HotReloadAnimationReloadTests : BaseTestClass
+{
+    [Fact]
+    public void PerformReload_loads_animations_from_the_source_directory()
+    {
+        string sourceDirectory = Path.Combine(
+            Path.GetTempPath(), "HotReloadAnimationReloadTests_" + Path.GetRandomFileName());
+        Directory.CreateDirectory(sourceDirectory);
+
+        try
+        {
+            // A minimal real project on disk is enough — the reloaded project only needs to load;
+            // the animation comes from the sibling .ganx the Gum tool would have just saved.
+            string gumxPath = Path.Combine(sourceDirectory, "Proj.gumx");
+            new GumProjectSave().Save(gumxPath, saveElements: false);
+
+            string screensDirectory = Path.Combine(sourceDirectory, "Screens");
+            Directory.CreateDirectory(screensDirectory);
+            File.WriteAllBytes(Path.Combine(screensDirectory, "MainScreenAnimations.ganx"), Ganx());
+
+            GumHotReloadManager manager = new GumHotReloadManager();
+            manager.Start(gumxPath);
+            // Release the OS watcher immediately; Start has already recorded the source path.
+            manager.Stop();
+
+            manager.PerformReload(Array.Empty<GraphicalUiElement>());
+
+            GumProjectSave reloaded = ObjectFinder.Self.GumProjectSave!;
+            reloaded.ShouldNotBeNull();
+            ElementAnimationsSave animation = reloaded.ElementAnimations.ShouldHaveSingleItem();
+            animation.ElementName.ShouldBe("MainScreen");
+        }
+        finally
+        {
+            try { Directory.Delete(sourceDirectory, recursive: true); } catch { /* best-effort */ }
+        }
+    }
+
+    private static byte[] Ganx()
+    {
+        ElementAnimationsSave save = new ElementAnimationsSave();
+        save.ElementName = "WRONG"; // loader must overwrite from the file path
+        XmlSerializer serializer = FileManager.GetXmlSerializer(typeof(ElementAnimationsSave));
+        using MemoryStream memoryStream = new MemoryStream();
+        serializer.Serialize(memoryStream, save);
+        return memoryStream.ToArray();
+    }
+}

--- a/MonoGameGum/GumHotReloadManager.cs
+++ b/MonoGameGum/GumHotReloadManager.cs
@@ -211,7 +211,9 @@ public class GumHotReloadManager : IGumHotReloadManager
         }
     }
 
-    private void PerformReload(IEnumerable<GraphicalUiElement> roots)
+    // internal (not private) so tests can drive a reload deterministically without the
+    // FileSystemWatcher + debounce. ApplyDiff is exposed for tests for the same reason.
+    internal void PerformReload(IEnumerable<GraphicalUiElement> roots)
     {
         // Materialize so we can iterate twice and so the caller's collection
         // is safe from us modifying it via the rebuild step.

--- a/MonoGameGum/GumHotReloadManager.cs
+++ b/MonoGameGum/GumHotReloadManager.cs
@@ -219,8 +219,6 @@ public class GumHotReloadManager : IGumHotReloadManager
 
         CopyAndUnloadChangedFonts();
 
-        var savedRelativeDirectory = ToolsUtilities.FileManager.RelativeDirectory;
-
         var gumxMtime = File.Exists(_projectSourcePath)
             ? File.GetLastWriteTimeUtc(_projectSourcePath).ToString("HH:mm:ss.fff")
             : "-";
@@ -247,24 +245,14 @@ public class GumHotReloadManager : IGumHotReloadManager
             }
         }
 
-        // Point at the source project directory so TryLoadAnimation finds the updated .ganx files
-        var sourceDirectory = Path.GetDirectoryName(_projectSourcePath)?.Replace('\\', '/');
-        if (sourceDirectory != null && !sourceDirectory.EndsWith("/"))
-        {
-            sourceDirectory += "/";
-        }
-        ToolsUtilities.FileManager.RelativeDirectory = sourceDirectory ?? savedRelativeDirectory;
-
-        foreach (var element in newProject.AllElements)
-        {
-            var animation = GumService.TryLoadAnimation(element);
-            if (animation != null)
-            {
-                newProject.ElementAnimations.Add(animation);
-            }
-        }
-
-        ToolsUtilities.FileManager.RelativeDirectory = savedRelativeDirectory;
+        // Reload animations from the source project directory (loose files on disk) by enumerating
+        // its *Animations.ganx files. Hot reload only ever runs against a real filesystem, so a
+        // LooseFileGumFileProvider rooted at the source directory is the right seam — no need to
+        // mutate FileManager.RelativeDirectory the way the old per-element probe did.
+        string? sourceDirectory = Path.GetDirectoryName(_projectSourcePath);
+        Gum.Bundle.LooseFileGumFileProvider animationProvider = new Gum.Bundle.LooseFileGumFileProvider(
+            string.IsNullOrEmpty(sourceDirectory) ? "." : sourceDirectory);
+        GumService.LoadAnimationsFromProvider(newProject, animationProvider);
 
         System.Diagnostics.Debug.WriteLine(
             $"[HotReload] rootList.Count = {rootList.Count}");

--- a/MonoGameGum/GumService.cs
+++ b/MonoGameGum/GumService.cs
@@ -576,6 +576,15 @@ public class GumService : IGumService
     /// </summary>
     public GumLoadResult? LastLoadResult { get; private set; }
 
+    /// <summary>
+    /// The <see cref="ProjectResolution"/> produced when the current project was loaded, or
+    /// <c>null</c> if no project file has been loaded. Carries the project's
+    /// <see cref="IGumFileProvider"/> — the canonical seam runtime code uses to read project
+    /// content (e.g. <see cref="LoadAnimations"/> enumerates animation files through it). Cleared
+    /// by <see cref="Uninitialize"/>.
+    /// </summary>
+    public ProjectResolution? CurrentProjectResolution { get; private set; }
+
 #if XNALIKE
     private Game? _game;
     public Game Game
@@ -718,9 +727,22 @@ public class GumService : IGumService
 #endif
 
     /// <summary>
-    /// Loads animations for all elements in the project.
+    /// Loads animations for all elements in the project by enumerating the project's
+    /// <c>*Animations.ganx</c> files through the loaded project's <see cref="IGumFileProvider"/>.
     /// </summary>
-    /// <exception cref="InvalidOperationException">Thrown if a Gum project hasn't been loaded first</exception>
+    /// <remarks>
+    /// This enumerates once instead of probing <see cref="FileManager.FileExists"/> per element.
+    /// In bundle mode the enumeration is an in-memory dictionary scan — zero I/O, and crucially
+    /// zero cosmetic 404s on browser/streaming platforms (Blazor WASM), where every per-element
+    /// probe was previously a guaranteed-miss HTTP request. In loose mode on a real filesystem it
+    /// is a single directory walk; loose mode on a streaming platform cannot enumerate a directory
+    /// over HTTP, so no animations load there — package the project as a <c>.gumpkg</c> to ship
+    /// animations to those platforms.
+    /// </remarks>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown if a Gum project hasn't been loaded first, or if no project file provider is available
+    /// (e.g. the project was injected directly rather than loaded via <c>Initialize(...gumProjectFile...)</c>).
+    /// </exception>
     [Obsolete("Experimental - this API may change in future versions")]
     public void LoadAnimations()
     {
@@ -733,44 +755,83 @@ public class GumService : IGumService
                 "Did you call GumUI.Initialize with a valid .gumx first?");
         }
 
-        // Probe each element for a sibling .ganx (animation) file. Elements without
-        // animations are the common case, so most probes legitimately miss. On real
-        // filesystems the miss is silent; on browser/streaming platforms (Blazor WASM)
-        // each miss is logged by the browser as a 404 — that noise is expected and
-        // harmless. Surfaced here once so developers seeing the 404s in DevTools can
-        // connect them to this probe loop instead of chasing them as real failures.
-        Console.WriteLine(
-            "[Gum] Probing each project element for an optional sibling Animations.ganx file. " +
-            "On browser/streaming platforms (e.g. Blazor WASM) elements without animations " +
-            "will appear as 404s in the network/console log — those are expected and benign.");
-
-        foreach (var element in project.AllElements)
+        ProjectResolution? resolution = CurrentProjectResolution;
+        if (resolution == null)
         {
-            var animation = TryLoadAnimation(element);
+            throw new InvalidOperationException(
+                "No project file provider is available. LoadAnimations enumerates animation files " +
+                "through the provider produced when the project is loaded — load the project via " +
+                "Initialize(...gumProjectFile...) before calling LoadAnimations.");
+        }
 
-            if (animation != null)
+        int loaded = LoadAnimationsFromProvider(project, resolution.FileProvider);
+
+        // Loose mode relies on directory enumeration, which streaming platforms (Blazor WASM)
+        // can't do over HTTP — there the enumeration silently returns nothing. Surface that once
+        // so a developer who expected animations isn't left guessing. Bundle mode never has this
+        // problem (the in-memory entry list is the manifest), so it stays quiet.
+        if (!resolution.UsedBundle && loaded == 0)
+        {
+            Console.WriteLine(
+                "[Gum] No animation (*Animations.ganx) files were found for this loosely-loaded project. " +
+                "Loose-mode animation loading enumerates the project directory, which is unavailable on " +
+                "browser/streaming platforms (e.g. Blazor WASM) — package the project as a .gumpkg to " +
+                "load animations on those platforms.");
+        }
+    }
+
+    /// <summary>
+    /// Enumerates <c>*Animations.ganx</c> files from <paramref name="provider"/>, deserializes each,
+    /// and adds the result to <paramref name="project"/>'s <see cref="GumProjectSave.ElementAnimations"/>.
+    /// The element name is derived from the file's path, not from the (stale) value serialized inside
+    /// the file. Returns the number of animation files loaded.
+    /// </summary>
+    internal static int LoadAnimationsFromProvider(GumProjectSave project, IGumFileProvider provider)
+    {
+        // Filename-only pattern (no '/'): GlobMatcher matches it against the file name regardless of
+        // directory depth, so nested component folders (Components/Buttons/MyButtonAnimations.ganx)
+        // are found. A "**/*Animations.ganx" pattern would NOT work — GlobMatcher has no recursive
+        // '**' support and would only match files exactly one folder deep.
+        int loaded = 0;
+        foreach (string path in provider.EnumerateFiles("*Animations.ganx"))
+        {
+            using Stream stream = provider.OpenRead(path);
+            ElementAnimationsSave animation = FileManager.XmlDeserializeFromStream<ElementAnimationsSave>(stream);
+            animation.ElementName = ElementNameFromPath(path);
+            project.ElementAnimations.Add(animation);
+            loaded++;
+        }
+        return loaded;
+    }
+
+    /// <summary>
+    /// Maps an animation file path back to its element name — the inverse of the
+    /// <c>{categoryFolder}/{element.Name}Animations.ganx</c> convention. Strips the
+    /// <c>Animations.ganx</c> suffix and any leading category folder so a nested component path like
+    /// <c>Components/Buttons/MyButtonAnimations.ganx</c> resolves to <c>Buttons/MyButton</c>.
+    /// </summary>
+    internal static string ElementNameFromPath(string path)
+    {
+        const string suffix = "Animations.ganx";
+        string normalized = path.Replace('\\', '/');
+
+        string withoutSuffix = normalized.EndsWith(suffix, StringComparison.OrdinalIgnoreCase)
+            ? normalized.Substring(0, normalized.Length - suffix.Length)
+            : normalized;
+
+        foreach (string categoryFolder in AnimationCategoryFolders)
+        {
+            if (withoutSuffix.StartsWith(categoryFolder, StringComparison.OrdinalIgnoreCase))
             {
-                project.ElementAnimations.Add(animation);
+                return withoutSuffix.Substring(categoryFolder.Length);
             }
         }
+
+        return withoutSuffix;
     }
 
-    internal static ElementAnimationsSave? TryLoadAnimation(ElementSave element)
-    {
-        string prefix = element is ScreenSave ? "Screens/" :
-            element is ComponentSave ? "Components/" :
-            element is StandardElementSave ? "StandardElements/" : string.Empty;
-
-        var fileName = prefix + element.Name + "Animations.ganx";
-
-        if (FileManager.FileExists(fileName))
-        {
-            var animation = FileManager.XmlDeserialize<ElementAnimationsSave>(fileName);
-            animation.ElementName = element.Name;
-            return animation;
-        }
-        return null;
-    }
+    private static readonly string[] AnimationCategoryFolders =
+        { "Screens/", "Components/", "StandardElements/" };
 
 #if XNALIKE
     /// <summary>
@@ -868,8 +929,9 @@ public class GumService : IGumService
             // Resolve loose-vs-bundle off the file extension: ".gumx" = loose, ".gumpkg" = bundle.
             // In bundle mode, installs a CustomGetStreamFromFile hook so runtime asset loads
             // (textures/fonts) also resolve from the bundle.
-            BundleResolution bundleResolution = GumBundleLoader.Resolve(gumProjectFile);
-            gumProject = GumProjectSave.Load(bundleResolution.ResolvedGumxPath, out GumLoadResult loadResult);
+            ProjectResolution projectResolution = GumBundleLoader.Resolve(gumProjectFile);
+            CurrentProjectResolution = projectResolution;
+            gumProject = GumProjectSave.Load(projectResolution.ResolvedGumxPath, out GumLoadResult loadResult);
             LastLoadResult = loadResult;
 
             if (gumProject == null || !string.IsNullOrEmpty(loadResult.ErrorMessage) || loadResult.MissingFiles.Count > 0)
@@ -1099,6 +1161,7 @@ public class GumService : IGumService
         FrameworkElement.DefaultFormsComponents.Clear();
 
         ObjectFinder.Self.GumProjectSave = null;
+        CurrentProjectResolution = null;
 
         LoaderManager.Self.DisposeAndClear();
 

--- a/Tests/Gum.Bundle.Tests/CompositeGumFileProviderTests.cs
+++ b/Tests/Gum.Bundle.Tests/CompositeGumFileProviderTests.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Gum.Bundle;
+using Shouldly;
+
+namespace Gum.Bundle.Tests;
+
+/// <summary>
+/// Tests for <see cref="CompositeGumFileProvider"/>: first-hit-wins for <c>Exists</c>/<c>OpenRead</c>,
+/// deduped union (first occurrence wins) for <c>EnumerateFiles</c>.
+/// </summary>
+public class CompositeGumFileProviderTests
+{
+    [Fact]
+    public void Exists_is_true_when_any_provider_has_the_file()
+    {
+        CompositeGumFileProvider composite = new CompositeGumFileProvider(
+            Provider(("a.txt", "first")),
+            Provider(("b.txt", "second")));
+
+        composite.Exists("a.txt").ShouldBeTrue();
+        composite.Exists("b.txt").ShouldBeTrue();
+        composite.Exists("missing.txt").ShouldBeFalse();
+    }
+
+    [Fact]
+    public void OpenRead_returns_content_from_the_first_provider_that_has_the_file()
+    {
+        // Both providers contain "shared.txt"; the first one wins (overlay precedence).
+        CompositeGumFileProvider composite = new CompositeGumFileProvider(
+            Provider(("shared.txt", "from-first")),
+            Provider(("shared.txt", "from-second")));
+
+        ReadAll(composite.OpenRead("shared.txt")).ShouldBe("from-first");
+    }
+
+    [Fact]
+    public void OpenRead_falls_through_to_a_later_provider_on_miss()
+    {
+        CompositeGumFileProvider composite = new CompositeGumFileProvider(
+            Provider(("a.txt", "from-first")),
+            Provider(("b.txt", "from-second")));
+
+        ReadAll(composite.OpenRead("b.txt")).ShouldBe("from-second");
+    }
+
+    [Fact]
+    public void OpenRead_throws_FileNotFoundException_when_no_provider_has_the_file()
+    {
+        CompositeGumFileProvider composite = new CompositeGumFileProvider(
+            Provider(("a.txt", "first")));
+
+        Should.Throw<FileNotFoundException>(() => composite.OpenRead("missing.txt"));
+    }
+
+    [Fact]
+    public void EnumerateFiles_returns_the_deduped_union_with_first_occurrence_winning()
+    {
+        CompositeGumFileProvider composite = new CompositeGumFileProvider(
+            Provider(("Screens/A.ganx", "a"), ("shared.ganx", "first")),
+            Provider(("shared.ganx", "second"), ("Components/B.ganx", "b")));
+
+        List<string> matches = composite.EnumerateFiles("*.ganx").ToList();
+
+        matches.ShouldBe(new[] { "Screens/A.ganx", "shared.ganx", "Components/B.ganx" });
+    }
+
+    [Fact]
+    public void Constructor_throws_when_providers_is_null()
+    {
+        Should.Throw<ArgumentNullException>(() => new CompositeGumFileProvider(null!));
+    }
+
+    private static IGumFileProvider Provider(params (string path, string content)[] entries)
+    {
+        Dictionary<string, byte[]> dictionary = new Dictionary<string, byte[]>(StringComparer.Ordinal);
+        List<string> order = new List<string>();
+        foreach ((string path, string content) in entries)
+        {
+            dictionary[path] = Encoding.UTF8.GetBytes(content);
+            order.Add(path);
+        }
+        return new BundleGumFileProvider(new GumBundle(version: 1, entries: dictionary, entryPathsInOrder: order));
+    }
+
+    private static string ReadAll(Stream stream)
+    {
+        using (stream)
+        using (StreamReader reader = new StreamReader(stream, Encoding.UTF8))
+        {
+            return reader.ReadToEnd();
+        }
+    }
+}

--- a/Tests/Gum.Bundle.Tests/GumBundleLoaderTests.cs
+++ b/Tests/Gum.Bundle.Tests/GumBundleLoaderTests.cs
@@ -48,9 +48,10 @@ public class GumBundleLoaderTests : IDisposable
             ("Screens/MainScreen.gusx", childBytes),
         });
 
-        BundleResolution resolution = GumBundleLoader.Resolve(gumpkgPath);
+        ProjectResolution resolution = GumBundleLoader.Resolve(gumpkgPath);
 
         resolution.UsedBundle.ShouldBeTrue();
+        resolution.FileProvider.ShouldBeOfType<BundleGumFileProvider>();
         FileManager.CustomGetStreamFromFile.ShouldNotBeNull();
 
         // The runtime loader passes absolute paths (with platform-native separators) to the
@@ -78,7 +79,7 @@ public class GumBundleLoaderTests : IDisposable
             ("Project.gumx", gumxBytes),
         });
 
-        BundleResolution resolution = GumBundleLoader.Resolve(gumpkgPath);
+        ProjectResolution resolution = GumBundleLoader.Resolve(gumpkgPath);
 
         resolution.UsedBundle.ShouldBeTrue();
         resolution.ResolvedGumxPath.ShouldBe(expectedGumxPath);
@@ -96,10 +97,11 @@ public class GumBundleLoaderTests : IDisposable
         string gumxPath = Path.Combine(_tempDir, "Project.gumx");
         File.WriteAllText(gumxPath, "<GumProjectSave />");
 
-        BundleResolution resolution = GumBundleLoader.Resolve(gumxPath);
+        ProjectResolution resolution = GumBundleLoader.Resolve(gumxPath);
 
         resolution.UsedBundle.ShouldBeFalse();
         resolution.ResolvedGumxPath.ShouldBe(gumxPath);
+        resolution.FileProvider.ShouldBeOfType<LooseFileGumFileProvider>();
         FileManager.CustomGetStreamFromFile.ShouldBeNull();
     }
 
@@ -117,7 +119,7 @@ public class GumBundleLoaderTests : IDisposable
             ("Project.gumx", Encoding.UTF8.GetBytes("<GumProjectSave />")),
         });
 
-        BundleResolution resolution = GumBundleLoader.Resolve(gumxPath);
+        ProjectResolution resolution = GumBundleLoader.Resolve(gumxPath);
 
         resolution.UsedBundle.ShouldBeFalse();
         FileManager.CustomGetStreamFromFile.ShouldBeNull();
@@ -147,7 +149,7 @@ public class GumBundleLoaderTests : IDisposable
         };
         FileManager.CustomGetStreamFromFile = userHook;
 
-        BundleResolution resolution = GumBundleLoader.Resolve(gumpkgPath);
+        ProjectResolution resolution = GumBundleLoader.Resolve(gumpkgPath);
 
         resolution.UsedBundle.ShouldBeTrue();
         FileManager.CustomGetStreamFromFile.ShouldNotBeSameAs(userHook);


### PR DESCRIPTION
Closes #2940.

## What

Makes `IGumFileProvider` the canonical runtime file seam and replaces per-element animation probing with a single provider enumeration. The cosmetic 404 cascade for `.ganx` probes on browser/streaming platforms (Blazor WASM) is gone:

- **Bundle mode** — animation loading is an in-memory dictionary scan over the bundle's entries. Zero I/O, zero 404s.
- **Loose mode on a real filesystem** — one directory walk instead of N `File.Exists` probes.
- **Loose mode on Blazor WASM** — enumeration returns empty (can't list a directory over HTTP); a single reworded heads-up is emitted only when loose-mode loading finds nothing.

## Changes

- Rename `BundleResolution` → `ProjectResolution`; expose `IGumFileProvider FileProvider` (a `BundleGumFileProvider` in bundle mode, a `LooseFileGumFileProvider` rooted at the `.gumx` dir in loose mode).
- `GumService.CurrentProjectResolution` stashes the resolution (set in `Initialize`, cleared in `Uninitialize`) — the single home for the provider.
- Extract `LoadAnimationsFromProvider` / `ElementNameFromPath`; drop the old `TryLoadAnimation` per-element probe and the misleading "expect 404s" `Console.WriteLine`.
- Migrate `GumHotReloadManager`'s animation reload to a `LooseFileGumFileProvider` rooted at the source dir — removes the `FileManager.RelativeDirectory` save/mutate/restore dance.
- Add `CompositeGumFileProvider` (first-hit-wins for `Exists`/`OpenRead`, deduped-union `EnumerateFiles`) for opt-in mod/DLC/hot-reload overlays. Gum's default loading never builds one.

## Deliberate deviations from the issue (discussed up front)

1. **§1 layering reversed.** The issue proposed adding `IGumFileProvider CustomFileProvider` + `EnumerateFiles` to `FileManager`. That inverts the dependency direction: `FileManager` lives in the net472, Gum-agnostic `ToolsUtilities` assembly and cannot reference `Gum.Bundle` types — the standalone `ToolsUtilities.csproj` would not compile. Instead, `FileManager` stays the low-level seam (its existing `CustomGetStreamFromFile` `Func` is adapted *down* to for the legacy `GumProjectSave.Load` walk), and `IGumFileProvider` sits *above* it as the canonical seam, surfaced via `GumService.CurrentProjectResolution`. `FileManager.cs` is untouched. Enumeration lives only on the provider. Net result also kills the "two parallel static delegates in lockstep" smell §1 called out — there's one delegate and one provider.
2. **Glob pattern.** Uses the filename-only `"*Animations.ganx"`, not the issue's `"**/*Animations.ganx"`. `GlobMatcher` has no recursive `**` support (it compiles `*` to `[^/]*`), so the slash form would only match elements exactly one folder deep and **miss nested component folders**. The filename-only form matches at any depth (covered by a test).

## Minor semantic note

The old loader only added animations for elements present in `AllElements`; the new loader adds an entry for every `*Animations.ganx` found. In practice a project only contains `.ganx` for real elements, so this is equivalent; an orphan file would produce an unused `ElementAnimationsSave` (harmless).

## Tests (TDD, red→green)

- `Gum.Bundle.Tests` — `ProjectResolution.FileProvider` type assertions; new `CompositeGumFileProviderTests` (6). Full suite: **67 passed**.
- `MonoGameGum.Tests` — new `LoadAnimationsFromProviderTests` (3, incl. nested-folder + non-`.ganx` filtering). Full suite: **1679 passed**.
- Builds verified: `GumCommon`, `MonoGameGum`, `RaylibGum` (the `RAYLIB` path through `GumService`), `SkiaGum`.

`GumCoreShared.projitems` updated for the new `CompositeGumFileProvider.cs` (FRB1 sync).

> Note: `AllLibraries.sln` was not built end-to-end because the `fna/` git submodule isn't populated in this worktree (unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
