### PR TITLE
Handle int/string -> enum and Nullable<enum> in SetPropertyThroughReflection (#2924)

### DIFF
--- a/GumRuntime/GraphicalUiElement.cs
+++ b/GumRuntime/GraphicalUiElement.cs
@@ -6125,24 +6125,46 @@ public partial class GraphicalUiElement : IRenderableIpso, IVisible, INotifyProp
     {
         System.Reflection.PropertyInfo? propertyInfo = mContainedObjectAsIpso.GetType().GetProperty(propertyName);
 
-        if (propertyInfo != null && propertyInfo.CanWrite)
+        if (propertyInfo == null || !propertyInfo.CanWrite)
         {
+            return;
+        }
 
-            if (value != null && value.GetType() != propertyInfo.PropertyType)
+        if (value != null && value.GetType() != propertyInfo.PropertyType)
+        {
+            // This is the data-driven path (ApplyState → SetProperty → reflection); strongly-typed
+            // C# setters never reach it. .gumx serializes enums as their underlying int (and
+            // hand-written files sometimes by name), and many renderable properties are declared
+            // Nullable<T> (e.g. Blend? on Sprite/NineSlice). Convert.ChangeType handles neither: it
+            // throws on int/string → enum and cannot produce a Nullable<T>. So convert against the
+            // underlying T — routing enums through Enum.ToObject / Enum.Parse — and let the boxed T
+            // assign cleanly into a Nullable<T> property via SetValue.
+            Type targetType = Nullable.GetUnderlyingType(propertyInfo.PropertyType) ?? propertyInfo.PropertyType;
+            if (value.GetType() != targetType)
             {
-                // For a Nullable<T> target (e.g. Blend? on Sprite/NineSlice), convert against the
-                // underlying T. Convert.ChangeType cannot produce a Nullable<T> (it throws
-                // InvalidCastException), but a boxed T assigns cleanly into a Nullable<T> property
-                // via SetValue. This is the data-driven path (ApplyState → SetProperty → reflection);
-                // strongly-typed C# setters never reach it.
-                Type targetType = Nullable.GetUnderlyingType(propertyInfo.PropertyType) ?? propertyInfo.PropertyType;
-                if (value.GetType() != targetType)
+                try
                 {
-                    value = System.Convert.ChangeType(value, targetType);
+                    if (targetType.IsEnum)
+                    {
+                        value = value is string enumName
+                            ? Enum.Parse(targetType, enumName, ignoreCase: true)
+                            : Enum.ToObject(targetType, value);
+                    }
+                    else
+                    {
+                        value = System.Convert.ChangeType(value, targetType);
+                    }
+                }
+                catch
+                {
+                    // One bad variable (incompatible type, undefined enum name, out-of-range value)
+                    // must not tear down the entire screen load — skip this assignment.
+                    return;
                 }
             }
-            propertyInfo.SetValue(mContainedObjectAsIpso, value, null);
         }
+
+        propertyInfo.SetValue(mContainedObjectAsIpso, value, null);
     }
 
     /// <summary>

--- a/MonoGameGum.Tests/Runtimes/SetPropertyThroughReflectionTests.cs
+++ b/MonoGameGum.Tests/Runtimes/SetPropertyThroughReflectionTests.cs
@@ -1,0 +1,131 @@
+using Gum.Wireframe;
+using RenderingLibrary.Graphics;
+using Shouldly;
+using Xunit;
+
+namespace MonoGameGum.Tests.Runtimes;
+
+/// <summary>
+/// Covers the conversions <see cref="GraphicalUiElement.SetPropertyThroughReflection"/>
+/// must handle for the data-driven (.gumx → ApplyState → SetProperty) path: enums are
+/// serialized as their underlying int (or, in hand-written files, by name), and many
+/// renderable properties are declared <c>Nullable&lt;T&gt;</c>. Before this was fixed,
+/// every backend worked around the same two gaps individually (see issue #2924).
+/// </summary>
+public class SetPropertyThroughReflectionTests : BaseTestClass
+{
+    private enum SampleEnum
+    {
+        Zero = 0,
+        One = 1,
+        Two = 2,
+    }
+
+    /// <summary>
+    /// A minimal <see cref="IRenderableIpso"/> exposing the property shapes the reflection
+    /// setter must convert into: a plain enum, a nullable enum, a plain int, and a nullable float.
+    /// </summary>
+    private class ReflectionTargetRenderable : InvisibleRenderable
+    {
+        public SampleEnum EnumValue { get; set; }
+        public SampleEnum? NullableEnumValue { get; set; }
+        public int IntValue { get; set; }
+        public float? NullableFloatValue { get; set; }
+    }
+
+    private static void SetProperty(ReflectionTargetRenderable renderable, string propertyName, object value) =>
+        GraphicalUiElement.SetPropertyThroughReflection(renderable, new GraphicalUiElement(), propertyName, value);
+
+    [Fact]
+    public void SetProperty_EnumToNullableEnum_ShouldAssignValue()
+    {
+        // The #2923 case: .gumx serializes a Blend? variable as the non-nullable Blend enum.
+        ReflectionTargetRenderable renderable = new ReflectionTargetRenderable();
+        SetProperty(renderable, nameof(ReflectionTargetRenderable.NullableEnumValue), SampleEnum.Two);
+        renderable.NullableEnumValue.ShouldBe(SampleEnum.Two);
+    }
+
+    [Fact]
+    public void SetProperty_FloatToNullableFloat_ShouldWrapInNullable()
+    {
+        ReflectionTargetRenderable renderable = new ReflectionTargetRenderable();
+        SetProperty(renderable, nameof(ReflectionTargetRenderable.NullableFloatValue), 8f);
+        renderable.NullableFloatValue.ShouldBe(8f);
+    }
+
+    [Fact]
+    public void SetProperty_IntOutOfEnumRange_ShouldNotThrowAndAssignRawValue()
+    {
+        // Enum.ToObject accepts any int — even undeclared members — so a stale enum int in
+        // a .gumx assigns a raw underlying value rather than tearing down the screen load.
+        ReflectionTargetRenderable renderable = new ReflectionTargetRenderable();
+        Should.NotThrow(() => SetProperty(renderable, nameof(ReflectionTargetRenderable.EnumValue), 999));
+        ((int)renderable.EnumValue).ShouldBe(999);
+    }
+
+    [Fact]
+    public void SetProperty_IntToEnum_ShouldAssignEnumValue()
+    {
+        ReflectionTargetRenderable renderable = new ReflectionTargetRenderable();
+        SetProperty(renderable, nameof(ReflectionTargetRenderable.EnumValue), 1);
+        renderable.EnumValue.ShouldBe(SampleEnum.One);
+    }
+
+    [Fact]
+    public void SetProperty_IntToNullableEnum_ShouldAssignEnumValue()
+    {
+        ReflectionTargetRenderable renderable = new ReflectionTargetRenderable();
+        SetProperty(renderable, nameof(ReflectionTargetRenderable.NullableEnumValue), 2);
+        renderable.NullableEnumValue.ShouldBe(SampleEnum.Two);
+    }
+
+    [Fact]
+    public void SetProperty_PlainInt_ShouldRoundTrip()
+    {
+        ReflectionTargetRenderable renderable = new ReflectionTargetRenderable();
+        SetProperty(renderable, nameof(ReflectionTargetRenderable.IntValue), 3);
+        renderable.IntValue.ShouldBe(3);
+    }
+
+    [Fact]
+    public void SetProperty_StringToEnum_ShouldBeCaseInsensitive()
+    {
+        ReflectionTargetRenderable renderable = new ReflectionTargetRenderable();
+        SetProperty(renderable, nameof(ReflectionTargetRenderable.EnumValue), "two");
+        renderable.EnumValue.ShouldBe(SampleEnum.Two);
+    }
+
+    [Fact]
+    public void SetProperty_StringToEnum_ShouldParseEnumName()
+    {
+        ReflectionTargetRenderable renderable = new ReflectionTargetRenderable();
+        SetProperty(renderable, nameof(ReflectionTargetRenderable.EnumValue), "One");
+        renderable.EnumValue.ShouldBe(SampleEnum.One);
+    }
+
+    [Fact]
+    public void SetProperty_StringToNullableEnum_ShouldParseEnumName()
+    {
+        ReflectionTargetRenderable renderable = new ReflectionTargetRenderable();
+        SetProperty(renderable, nameof(ReflectionTargetRenderable.NullableEnumValue), "Two");
+        renderable.NullableEnumValue.ShouldBe(SampleEnum.Two);
+    }
+
+    [Fact]
+    public void SetProperty_UnknownProperty_ShouldNotThrow()
+    {
+        // A bad variable name in .gumx shouldn't abort loading.
+        ReflectionTargetRenderable renderable = new ReflectionTargetRenderable();
+        Should.NotThrow(() => SetProperty(renderable, "ThisPropertyDoesNotExist", 42));
+    }
+
+    [Fact]
+    public void SetProperty_UnparseableStringToEnum_ShouldNotThrowAndLeaveDefault()
+    {
+        // A value that can't be converted (name not in the enum) is skipped rather than
+        // throwing — one bad variable must not tear down the entire screen load.
+        ReflectionTargetRenderable renderable = new ReflectionTargetRenderable();
+        Should.NotThrow(() => SetProperty(renderable, nameof(ReflectionTargetRenderable.EnumValue), "NotAMember"));
+        renderable.EnumValue.ShouldBe(SampleEnum.Zero);
+    }
+}

--- a/Runtimes/SkiaGum/CustomSetPropertyOnRenderable.cs
+++ b/Runtimes/SkiaGum/CustomSetPropertyOnRenderable.cs
@@ -98,21 +98,12 @@ public class CustomSetPropertyOnRenderable
             case nameof(RenderableShapeBase.Alpha):
                 renderableBase.Alpha = (int)value;
                 return true;
-            // .gumx stores Blend as the non-nullable Gum.RenderingLibrary.Blend enum.
-            // SetPropertyThroughReflection's Convert.ChangeType fallback throws on
-            // enum -> Nullable<enum> (Skia's Blend?), so the assignment has to land here. See
-            // the SilkNetGum sample crash that prompted the Skia branch — every Standards/*.gutx
-            // with a default Blend variable hit the reflection path before this case was added.
-            //
-            // Issue #2937: the Apos.Shapes side (MonoGameGumShapes / KniGumShapes) now also has
-            // a Blend property on its RenderableShapeBase, so it gets its own arm. The type
-            // differs per platform (Skia: Blend?, Apos: non-nullable Gum.RenderingLibrary.Blend),
-            // hence the gate rather than a shared case.
-#if SKIA
-            case nameof(RenderableShapeBase.Blend):
-                renderableBase.Blend = (Blend)value;
-                return true;
-#else
+            // Skia's Blend? is now handled by core SetPropertyThroughReflection, which converts
+            // enum -> Nullable<enum> (issue #2924), so the former SKIA Blend arm here was removed.
+            // The Apos.Shapes arm (MonoGameGumShapes / KniGumShapes, issue #2937) is kept: it's a
+            // non-nullable Blend on a different renderable surface whose runtime does extra
+            // forwarding/translation, so it's left explicit pending a separate audit.
+#if !SKIA
             case nameof(RenderableShapeBase.Blend):
                 renderableBase.Blend = (Gum.RenderingLibrary.Blend)value;
                 return true;
@@ -970,15 +961,11 @@ public class CustomSetPropertyOnRenderable
                 handled = TrySetPropertyOnPolygon(asPolygon, graphicalUiElement, propertyName, value);
             }
         }
-        // Catch-all for RenderableShapeBase derivatives that have no dedicated branch
-        // above (SolidRectangle, LineRectangle, LineGrid, etc.). Without this, those types
-        // skip TrySetPropertiesOnRenderableBase entirely and any RenderableShapeBase property
-        // — most notably Blend? — falls through to SetPropertyThroughReflection's
-        // Convert.ChangeType, which throws on enum -> Nullable<enum>.
-        if (!handled && containedObjectAsIpso is RenderableShapeBase asShapeBase)
-        {
-            handled = TrySetPropertiesOnRenderableBase(asShapeBase, graphicalUiElement, propertyName, value);
-        }
+        // RenderableShapeBase derivatives with no dedicated branch above (SolidRectangle,
+        // LineRectangle, LineGrid, etc.) fall through to the reflection helper below. Core
+        // SetPropertyThroughReflection now converts enum -> Nullable<enum> (issue #2924), so the
+        // #2923 catch-all that routed them through TrySetPropertiesOnRenderableBase purely to
+        // handle Blend? is no longer needed.
         if (!handled)
         {
             GraphicalUiElement.SetPropertyThroughReflection(containedObjectAsIpso, graphicalUiElement, propertyName, value);

--- a/Runtimes/SokolGum/CustomSetPropertyOnRenderable.cs
+++ b/Runtimes/SokolGum/CustomSetPropertyOnRenderable.cs
@@ -66,86 +66,13 @@ public static class CustomSetPropertyOnRenderable
             handled = extra(renderable, element, propertyName, value);
 
         if (!handled)
-            SetPropertyWithEnumConversion(renderable, element, propertyName, value);
-    }
-
-    /// <summary>
-    /// Reflection fallback that closes two gaps in Gum's core
-    /// <see cref="GraphicalUiElement.SetPropertyThroughReflection"/>: (1) int
-    /// values can't be directly assigned to enum-typed properties, and (2)
-    /// primitive values can't be directly assigned to <see cref="Nullable{T}"/>
-    /// properties. <c>.gumx</c> stores enum variables as their underlying int
-    /// and nullable floats as plain floats, so these two conversions come up
-    /// constantly. Handling them here keeps alignment/overflow/units enums
-    /// and nullable-float properties (like NineSlice's custom border width)
-    /// working without special-casing each one.
-    ///
-    /// If the conversion throws (incompatible types, value out of range,
-    /// undefined enum backing), we fall through to the core reflection
-    /// helper rather than propagate — that matches the behaviour of the
-    /// core path for most other mismatches, so a single bad variable
-    /// doesn't tear down the entire screen load.
-    /// </summary>
-    private static void SetPropertyWithEnumConversion(
-        IRenderableIpso renderable,
-        GraphicalUiElement element,
-        string propertyName,
-        object value)
-    {
-        var prop = renderable.GetType().GetProperty(propertyName);
-        if (prop is not null && prop.CanWrite && value is not null)
         {
-            var targetType = prop.PropertyType;
-
-            if (targetType.IsEnum)
-            {
-                if (value.GetType().IsPrimitive)
-                {
-                    try
-                    {
-                        prop.SetValue(renderable, Enum.ToObject(targetType, value));
-                        return;
-                    }
-                    catch { /* fall through to base reflection helper */ }
-                }
-                else if (value is string enumName)
-                {
-                    // Hand-written .gumx or externally-produced project files
-                    // sometimes store enum values by name ("Center") instead
-                    // of int. Core Gum doesn't handle this conversion either,
-                    // so covering it here closes that compat gap.
-                    try
-                    {
-                        prop.SetValue(renderable, Enum.Parse(targetType, enumName, ignoreCase: true));
-                        return;
-                    }
-                    catch { /* fall through — name not in enum or ambiguous */ }
-                }
-            }
-
-            var underlyingNullable = Nullable.GetUnderlyingType(targetType);
-            if (underlyingNullable is not null)
-            {
-                try
-                {
-                    object? converted;
-                    if (underlyingNullable.IsEnum)
-                    {
-                        converted = value is string enumStr
-                            ? Enum.Parse(underlyingNullable, enumStr, ignoreCase: true)
-                            : Enum.ToObject(underlyingNullable, value);
-                    }
-                    else
-                    {
-                        converted = Convert.ChangeType(value, underlyingNullable);
-                    }
-                    prop.SetValue(renderable, converted);
-                    return;
-                }
-                catch { /* fall through — incompatible primitive → Nullable<T> conversion */ }
-            }
+            // int/string → enum and primitive → Nullable<T> conversions used to be handled by a
+            // local SetPropertyWithEnumConversion wrapper here. Core Gum's SetPropertyThroughReflection
+            // now performs the same conversions (and swallows conversion failures), so the wrapper
+            // was removed — see issue #2924.
+            GraphicalUiElement.SetPropertyThroughReflection(renderable, element, propertyName, value);
         }
-        GraphicalUiElement.SetPropertyThroughReflection(renderable, element, propertyName, value);
     }
 
     /// <summary>


### PR DESCRIPTION
Closes #2924.

## What

`GraphicalUiElement.SetPropertyThroughReflection` is the core reflection setter the data-driven path (`.gumx` → `ApplyState` → `SetProperty`) uses. Its `Convert.ChangeType` fallback threw on two conversions that path hits constantly:

1. **`int → enum` / `string → enum`** — `.gumx` serializes enums as their underlying int (and hand-written files sometimes by name).
2. **`primitive → Nullable<enum>`** (e.g. `int → Blend?`).

Every backend had its own workaround for this. The fix moves the conversion into the core method, mirroring what SokolGum already did:

- Convert against the underlying `T` (`Nullable.GetUnderlyingType`).
- Route enums through `Enum.ToObject` (numeric) / `Enum.Parse(..., ignoreCase: true)` (string).
- Catch conversion failures and skip the single assignment, so one bad variable can't tear down an entire screen load.

(The `enum → Nullable<enum>` case — value already the enum — was already handled in #2923 and is kept covered by a regression test.)

## Knock-on cleanups (per the issue)

- **SokolGum** — removed the now-redundant `SetPropertyWithEnumConversion` wrapper; it calls core directly.
- **SkiaGum** — removed the `#if SKIA` `Blend?` `case` and the #2923 `RenderableShapeBase` catch-all. Audit confirmed the catch-all's only *live* effect was Blend (pre-#2923, unbranched shapes routed everything through core reflection, which would have *thrown* on gradient-unit enum mismatches — so those types provably never receive those vars). Core now handles `Blend?`, and `BlendTests` covers the unbranched-shape path.

## Kept deliberately (audit-before-delete)

- **MG** `Blend` branches do real translation (`Blend → XNA BlendState` via `ToBlendState()`, assigned to a differently-named `BlendState` property) that core reflection can't reproduce. Left in place.
- **SkiaGum's Apos `#else` Blend arm** — different renderable surface with extra runtime forwarding; left explicit pending a separate audit.
- **Raylib** already had no active Blend branch (commented out).

## Tests

- New `MonoGameGum.Tests/Runtimes/SetPropertyThroughReflectionTests.cs` — 11 cases covering `int/string → enum`, `int/string → Nullable<enum>`, `enum → Nullable<enum>`, `float → Nullable<float>`, plain int, out-of-range int (raw assign, no throw), unknown property, and the unparseable-value failure-skip path. Verified red before the fix (7 failing with `InvalidCastException`), green after.
- `MonoGameGum.Tests` (1687), `SkiaGum.Tests` (185), `MonoGameGum.Shapes.Tests` (202) all green.

## Note

`SokolGum.Tests` could not be built/run in my environment (the `SokolGum` project is missing its native Sokol interop bindings — pre-existing, unrelated to this change). The SokolGum edit was validated by inspection: each `SokolGum.Tests` assertion matches core's new behavior exactly. Please run `SokolGum.Tests` on a machine with the native bindings before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
