### PR TITLE
Add Contributing docs section with the Gum release process + gum-release orchestrator skill

### DIFF
--- a/.claude/skills/gum-monthly-release/SKILL.md
+++ b/.claude/skills/gum-monthly-release/SKILL.md
@@ -285,10 +285,12 @@ The skill is done when the markdown file contains only the release notes — cur
 ## Out of scope
 
 This skill only writes the markdown draft. It does **not**:
-- Bump NuGet versions (see the `bump-nuget-version` skill)
+- Bump NuGet versions or trigger the package workflow (see `docs/contributing/building-and-releasing-gum.md`)
 - Create the git tag or trigger the GitHub Actions release workflow
 - Draft the breaking-changes migration doc (separate skill, future)
 - Run pre-release flows
+
+The full release process — and where this notes draft fits in it — is orchestrated by the `gum-release` skill.
 
 ## Iterating on the skill itself
 

--- a/.claude/skills/gum-release/SKILL.md
+++ b/.claude/skills/gum-release/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: gum-release
+description: Gum release/build orchestration — drives the in-repo release checklist and hands off the notes draft. Triggers: cutting a release, publishing the Gum NuGet packages, releasing the tool, /gum-release.
+disable-model-invocation: true
+---
+
+Invoking product-manager agent to drive the Gum release checklist.
+
+# Gum Release Orchestrator
+
+This skill is a **guided checklist driver, not full automation.** Most release steps are inherently human — taking screenshots, clicking GitHub Actions, uploading to FTP, announcing on Discord/Twitter/Bluesky. The skill's job is to walk the maintainer through the steps in order, track what's done, and invoke the one step a skill can actually do (the notes draft).
+
+## Source of truth — do not restate it here
+
+The release process lives in **[`docs/contributing/building-and-releasing-gum.md`](../../../docs/contributing/building-and-releasing-gum.md)** (published to the Gum GitBook space). That doc is canonical and maintainer-edited. **Read it at the start of every run** and follow whatever it says *today* — do not hardcode or paraphrase its steps into this skill, or the two will drift.
+
+## How to run
+
+1. **Read the doc** above and confirm the current step list with the user.
+2. **Track progress** — create one task per step (`TaskCreate`) so nothing is dropped across the long-running release, and mark each `completed` as the user confirms it.
+3. **Walk the steps in order**, one at a time. For each, state what the user needs to do (the doc has the detail) and wait for confirmation before advancing.
+4. **Hand off the automatable step.** When you reach release-notes generation, invoke the **`gum-monthly-release`** skill — it drafts the notes and is the only step with real automation. Everything else (NuGet workflow trigger, Build-and-Release workflow, screenshots, migration doc, announcements, FRB FTP upload) is the user's manual action; you confirm and check it off.
+
+## Gotchas
+
+- The two processes in the doc — **NuGet publishing** and **tool release** — are independent. Ask which the user is doing; don't assume both.
+- `gum-monthly-release` only writes the notes markdown. It does **not** bump versions, cut the tag, or trigger workflows — those are separate manual steps in the doc.
+- The **Full Changelog** compare link in the notes can only be filled after the tag exists, so it stays a placeholder until the release is cut.

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -412,3 +412,8 @@
   * [pack](cli/pack.md)
   * [screenshot](cli/screenshot.md)
   * [svg](cli/svg.md)
+
+## Contributing
+
+* [Contributing](contributing/README.md)
+  * [Building and Releasing Gum](contributing/building-and-releasing-gum.md)

--- a/docs/contributing/README.md
+++ b/docs/contributing/README.md
@@ -1,0 +1,11 @@
+# Contributing
+
+This section collects guidance for people who build, release, and maintain Gum itself — as opposed to using Gum in a project.
+
+* [Building and Releasing Gum](building-and-releasing-gum.md) — how to publish the Gum NuGet packages and cut a new release of the Gum tool, including release-notes generation, the GitHub Actions workflows, and post-release announcements.
+
+## See also
+
+Contributing guidance for extending Gum in code lives alongside the code reference:
+
+* [Gum Tool Code (Contributing and Plugins)](../code/gum-tool-code-contributing-and-plugins/README.md) — the tool-side classes (`DataUiGrid`, `ElementSave`, `GumProjectSave`, and friends) you work with when writing plugins or contributing to the editor.

--- a/docs/contributing/building-and-releasing-gum.md
+++ b/docs/contributing/building-and-releasing-gum.md
@@ -1,0 +1,40 @@
+# Building and Releasing Gum
+
+This page describes how to publish Gum's NuGet packages and how to cut a new release of the Gum tool. It is intended for maintainers. The two processes are independent — publishing NuGet packages does not require a tool release, and vice versa.
+
+## NuGet Package Publishing
+
+The Gum repository builds and uploads its NuGet packages through a GitHub Actions workflow. To publish new packages:
+
+1. Open the [dotnet-nuget workflow](https://github.com/vchelaru/Gum/actions/workflows/dotnet-nuget.yaml).
+2. Trigger the workflow manually (**Run workflow**).
+3. Select the target branch (typically `main`) and enable both publishing checkboxes.
+4. Specify the version using the format `year.month.day.build`, where `build` increments only if multiple releases occur on the same day. For preview releases, append `-preview.1`.
+
+Reference the existing versions on [nuget.org](https://www.nuget.org/packages/Gum.MonoGame/#versions-body-tab) when choosing the next version number.
+
+## Gum Tool Release
+
+A tool release is several coordinated steps: generating the release notes, running the release build, and announcing it.
+
+### 1. Generate the release notes
+
+Run the `/gum-monthly-release` skill in Claude Code from the Gum repository. It drafts the release notes from the PRs and commits since the previous release and asks for three inputs up front:
+
+* **Release tag** — following the pattern `Release_<Month>_<DD>_<YYYY>` (for example, `Release_May_31_2026`).
+* **Previous-release boundary** — the previous release tag or URL to diff `main` against.
+* **Breaking-changes migration doc URL** — the [Upgrading](../gum-tool/upgrading/README.md) page for this release, or confirmation that there are no breaking changes.
+
+The skill writes a draft to `temp/` and walks through any open questions with you. It only produces the notes draft — it does not bump versions, create the tag, or trigger the release workflow.
+
+### 2. Run the release
+
+1. Create screenshots (and GIFs) for the highlighted features.
+2. Run the [Build and Release Gum Tool workflow](https://github.com/vchelaru/Gum/actions/workflows/build-and-release.yml) with full release settings.
+3. Add the generated notes and screenshots to the GitHub release. Fill in the **Full Changelog** compare link once the tag exists.
+4. Create or update the [migration documentation](../gum-tool/upgrading/README.md) if there are breaking changes.
+5. Announce the release across the community channels: FRB Discord, MonoGame Discord, MGE Discord, Kni Discord, Twitter, Bluesky, and the MonoGame community forum.
+
+## FlatRedBall Integration
+
+Gum is a dependency in FRBDK builds, so Gum must be built and uploaded to FlatRedBall's FTP **before** running the FlatRedBall GitHub Actions. Otherwise the FRB build will pick up the previous Gum version.


### PR DESCRIPTION
## What

Migrates the Gum build/release process from the FlatRedBall GitBook space into this repo's `docs/` tree, and adds a thin orchestrator skill to drive it.

### Docs

- New top-level **Contributing** section in `docs/SUMMARY.md`.
- `docs/contributing/README.md` — section landing; cross-links the existing plugin/code-contributing docs under **Code**.
- `docs/contributing/building-and-releasing-gum.md` — the migrated process, reorganized into **NuGet Package Publishing**, **Gum Tool Release** (notes → build/release → announce), and a **FlatRedBall Integration** note. Links the two real workflows (`dotnet-nuget.yaml`, `build-and-release.yml`), keeps the `/gum-monthly-release` reference, and uses repo-relative links to the Upgrading migration docs.

### Skills

- New `gum-release` orchestrator skill — a **guided checklist driver** (not full automation). It reads the in-repo doc as the single source of truth (no restated steps, so the two can't drift), tracks progress, and hands off the one automatable step to `gum-monthly-release`.
- `gum-monthly-release` — fixed a dangling reference to a `bump-nuget-version` skill that never existed; it now points at the new doc and notes that `gum-release` orchestrates the full process.

## Why

Keeping the release process in-repo makes it versioned and reviewable, and lets the orchestrator skill `Read` a local file instead of fetching external GitBook prose — single source of truth, no drift.

## Note

The original page in the FlatRedBall GitBook space is being retired separately; this PR does not touch that repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
