### PR TITLE
Docs: clarify runtime snapshot has no passive cost but a real per-call cost

### DIFF
--- a/docs/code/debugging/runtime-snapshot.md
+++ b/docs/code/debugging/runtime-snapshot.md
@@ -21,7 +21,7 @@ GumUI.ExportSnapshot(@"C:\Temp\GumSnapshot\Snapshot.gumx");
 
 Gum serializes the live tree under its root and writes a complete project at that path: the `.gumx`, a `Screens/` folder, a `Standards/` folder, and copies of any referenced texture files. Open the `.gumx` in the Gum tool to inspect it.
 
-Exporting is on-demand and has no per-frame cost, so a common pattern is to trigger it from a debug key while the game runs:
+Exporting does work only when you call it — Gum runs no background machinery for snapshots, so frames on which you don't export cost nothing. The export itself is relatively expensive, though: it serializes the entire tree, writes several files, and copies textures to disk. Trigger it from a debug action rather than calling it unconditionally every frame — for example, on a key press while the game runs:
 
 ```csharp
 // Update


### PR DESCRIPTION
## What

Rewords one sentence on the [Runtime Snapshot](https://docs.flatredball.com/gum/code/debugging/runtime-snapshot) docs page that described exporting as "on-demand and has no per-frame cost."

## Why

Both halves of that phrasing mislead:

- **"On-demand"** is vacuous — every method runs when you call it, so the word conveys nothing.
- **"No per-frame cost"** is, read literally, false. `ExportSnapshot` serializes the entire visual tree, writes a `.gumx` plus `Screens/`/`Standards/` folders, and copies referenced textures to disk. The page's own example calls it inside the `// Update` loop, so a reader who takes "no per-frame cost" at face value is steered straight into doing exactly the expensive thing.

The only true idea in the original was the *passive* cost: frames where you don't call it pay nothing because there's no background instrumentation. The reword keeps that, but separates it from the real, disk-bound per-call cost and motivates triggering the export from a guarded debug action (the existing `KeyPushed`/F1 example).

## Change

Prose-only; the page is already in `SUMMARY.md`, so no nav change.
