### PR TITLE
CI: pin release-notes comparison base to the prior release tag

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -108,6 +108,29 @@ jobs:
           "prerelease=$prerelease" >> $env:GITHUB_OUTPUT
           "draft=$draft"           >> $env:GITHUB_OUTPUT
 
+      # 2b) Capture the previous release tag BEFORE this run creates its own tag, so the
+      # auto-generated release notes diff against the actual prior release. Without this,
+      # GitHub picks the comparison base itself, and the Release_<Month>_DD_YYYY tag scheme
+      # uses month *names* (which don't sort chronologically), so its guess can reach far
+      # back (e.g. a March prerelease) and dump months of unrelated PRs into the notes.
+      # checkout used fetch-depth: 0, so all tags are present; the new tag does not exist
+      # yet at this step, making the newest Release_* tag by tagger date the prior release.
+      # Only meaningful for full releases; prerelease/test keep GitHub's auto-selection.
+      - name: Capture previous release tag
+        id: prevtag
+        if: github.event.inputs.release_kind == 'release'
+        shell: pwsh
+        run: |
+          $prev = git for-each-ref --sort=-creatordate --format='%(refname:short)' 'refs/tags/Release_*' |
+                  Where-Object { $_ -ne "${{ steps.meta.outputs.tag }}" } |
+                  Select-Object -First 1
+          if ([string]::IsNullOrWhiteSpace($prev)) {
+            Write-Host "No previous Release_* tag found; GitHub will auto-select the comparison base."
+          } else {
+            Write-Host "Previous release tag for notes comparison: $prev"
+          }
+          "prev_tag=$prev" >> $env:GITHUB_OUTPUT
+
       # 3) Commit version bump on a new branch and create tag
       - name: Commit version bump, create tag, push branch+tag
         if: github.event.inputs.release_kind == 'release'
@@ -158,6 +181,10 @@ jobs:
           tag_name: ${{ steps.meta.outputs.tag }}
           name:     ${{ steps.meta.outputs.title }}
           generate_release_notes: true
+          # Pin the comparison base for release builds so the auto-notes diff against the
+          # prior release (see "Capture previous release tag"). Empty for prerelease/test,
+          # which softprops treats as omitted, leaving GitHub's auto-selection in place.
+          previous_tag: ${{ steps.prevtag.outputs.prev_tag }}
           prerelease: ${{ steps.meta.outputs.prerelease }}
           draft:      ${{ steps.meta.outputs.draft }}
           files: |


### PR DESCRIPTION
## Problem

The **Build and Release Gum Tool** workflow creates the GitHub release with `generate_release_notes: true` and **no** `previous_tag`, so GitHub chooses the comparison base for the auto-generated "What's Changed" itself. For the June 11 2026 release it reached all the way back to `PreRelease_March_26_2026` and dumped ~3 months of unrelated PRs into the body.

Root cause: the `Release_<Month>_DD_YYYY` tag scheme encodes the date with a **month name**. Month names don't sort chronologically (alphabetically "June" < "March" < "May"), so GitHub's previous-tag inference for these non-SemVer tags misfires and can land on a far-back tag.

## Fix (Option A — pin the comparison base)

`softprops/action-gh-release@v2` exposes a `previous_tag` input ("use this tag as GitHub's previous_tag_name comparison base"). This PR:

1. Adds a **Capture previous release tag** step that runs *before* this run creates its own tag, grabbing the newest existing `Release_*` tag by tagger date (`git for-each-ref --sort=-creatordate`). Since `checkout` uses `fetch-depth: 0`, all tags are present, and the new tag doesn't exist yet, so the newest match is the genuine prior release.
2. Passes that tag to the release step via `previous_tag`.

Gated to **full releases** (`release_kind == 'release'`). For `prerelease`/`test` the step is skipped, `previous_tag` resolves to an empty string, and softprops treats empty as omitted — so GitHub's auto-selection is preserved for those.

## Notes / limitations

- The glob matches `Release_*` only, so a `Hotfix_*` or `PreRelease_*` that shipped between two full releases is **not** used as the comparison base — the auto-notes would re-include that hotfix's PRs. This is a deliberate simplification: the curated `gum-monthly-release` draft (which is pasted over this body) remains the source of truth and pins its own boundary, so the auto-body only needs to be sane, not perfect. Easy to broaden later if hotfix boundaries become common.
- Validated by structural review against the existing steps; the change is YAML/CI only and runs only on the next manual `release` dispatch.
