### PR TITLE
NineSliceRuntime Bucket 1 (#2908): align MG default size, document XNA-only gates

### DIFF
--- a/.claude/skills/gum-cross-platform-unification/SKILL.md
+++ b/.claude/skills/gum-cross-platform-unification/SKILL.md
@@ -45,6 +45,10 @@ Before writing a single line of the unified file, diff these across all three pl
 
 For other disagreements: pick a default, but state the disagreement and the chosen resolution in your message before writing the code — not after in a summary. If the user disagrees, you've lost two minutes, not a release.
 
+## Never Widen an Obsolete API
+
+When a member gated under `#if` carries `[Obsolete]` (or is otherwise a deprecated back-compat shim) and a *sibling* runtime exposes it on more platforms, **do not "fix the inconsistency" by widening the obsolete member to the missing platforms.** Obsolete APIs are deprecated paths we want consumers off of — adding them to a backend that never had them plants a fresh dead surface in new code. Leave the gate at its current footprint and add a code comment explaining it is intentionally not widened. (Example: `SpriteRuntime` exposes an obsolete `Texture2D? SourceFile` on `#if !SKIA` while `NineSliceRuntime` only had it on `#if XNALIKE` — the right move was to comment both, not to widen NineSlice's. Issue #2908, Bucket 1.) This is the one asymmetry the boyscout/"two platforms agree, the outlier is wrong" heuristics do **not** apply to — for obsolete members, the narrower footprint wins.
+
 ## Lessons From Past Breakage
 
 - ColoredRectangleRuntime unification first pass promoted MG+Raylib from `GraphicalUiElement` to `InteractiveGue` to match Skia. This would have made every decorative colored rectangle in every consumer project start absorbing clicks. Caught and reverted before merge. The correct resolution was the opposite direction — correct Skia down to `GraphicalUiElement`, since nothing in a decorative rectangle should eat events.

--- a/MonoGameGum.Tests/Runtimes/NineSliceRuntimeTests.cs
+++ b/MonoGameGum.Tests/Runtimes/NineSliceRuntimeTests.cs
@@ -78,6 +78,17 @@ public class NineSliceRuntimeTests
     }
 
     [Fact]
+    public void Constructor_ShouldDefaultSizeTo100()
+    {
+        // Bucket 1 (#2908): all backends should default a NineSliceRuntime to 100x100.
+        // Previously only the non-XNALIKE backends did so; the XNALIKE ctor left
+        // Width/Height at 0, diverging from Raylib/Skia.
+        NineSliceRuntime sut = new();
+        sut.Width.ShouldBe(100);
+        sut.Height.ShouldBe(100);
+    }
+
+    [Fact]
     public void ExposeChildrenEvents_ShouldBeTrue()
     {
         NineSliceRuntime sut = new();

--- a/MonoGameGum/GueDeriving/NineSliceRuntime.cs
+++ b/MonoGameGum/GueDeriving/NineSliceRuntime.cs
@@ -46,6 +46,10 @@ namespace Gum.GueDeriving;
 public class NineSliceRuntime : InteractiveGue
 {
 #if XNALIKE
+    // Bucket 1 (#2908) decision: these per-instance defaults are an XNA-only legacy
+    // surface with no backend-neutral equivalent (texture-coordinate model). They stay
+    // a permanent #if XNALIKE gate rather than being unified or dropped — dropping the
+    // public statics would be an API break for existing MonoGame consumers.
     #region Static Defaults
 
     [Obsolete("This is not currently functional")]
@@ -90,6 +94,10 @@ public class NineSliceRuntime : InteractiveGue
     }
 
 #if XNALIKE
+    // Bucket 1 (#2908) decision: the XNA-typed BlendState surface stays a permanent
+    // #if XNALIKE gate. The backend-neutral Blend? property below is the unified API;
+    // exposing the Microsoft.Xna.Framework BlendState type cannot be done on Raylib/Skia.
+    // Mirrors SpriteRuntime, which made the same call.
     public Microsoft.Xna.Framework.Graphics.BlendState BlendState
     {
         get => ContainedNineSlice.BlendState.ToXNA();
@@ -252,6 +260,10 @@ public class NineSliceRuntime : InteractiveGue
 
     #region Source File / Texture
 
+    // Bucket 1 (#2908) decision: this obsolete shim stays XNALIKE-only and is intentionally
+    // NOT widened to Raylib/Skia. Obsolete APIs are deprecated paths we want consumers off of;
+    // adding them to backends that never had them spreads a dead surface to new code. Replace
+    // usage with Texture / SourceFileName instead.
 #if XNALIKE
     [Obsolete("Use Texture to set Texture2D, or use SourceFileName to set the file")]
     public Texture2D? SourceFile
@@ -345,18 +357,21 @@ public class NineSliceRuntime : InteractiveGue
             _containedNineSlice = new ContainedNineSliceType();
             SetContainedObject(_containedNineSlice);
 
+            // All backends default to 100x100 (#2908). Previously only the non-XNALIKE
+            // branch set this, leaving XNALIKE NineSlices at the GraphicalUiElement
+            // base default (32x32) and diverging from Raylib/Skia.
+            Width = 100;
+            Height = 100;
+
 #if XNALIKE
-            // todo - need to make this work with different relative directories...
-            //this.SourceFileName = DefaultSourceFile;
+            // Per-instance texture-coordinate defaults are an XNA-only legacy feature
+            // (see the Static Defaults region) with no backend-neutral equivalent.
             this.TextureLeft = DefaultTextureLeft;
             this.TextureTop = DefaultTextureTop;
             this.TextureWidth = DefaultTextureWidth;
             this.TextureHeight = DefaultTextureHeight;
 
             this.TextureAddress = DefaultTextureAddress;
-#else
-            Width = 100;
-            Height = 100;
 #endif
         }
     }

--- a/MonoGameGum/GueDeriving/SpriteRuntime.cs
+++ b/MonoGameGum/GueDeriving/SpriteRuntime.cs
@@ -306,6 +306,10 @@ public class SpriteRuntime : GraphicalUiElement
 
     #region Source File/Texture
 
+    // The #if gate on this obsolete Texture2D shim reflects its historical footprint and is
+    // intentionally not widened. Obsolete APIs are deprecated paths; spreading them to backends
+    // that never had them just plants a dead surface in new code. (Skia keeps a separate string
+    // SourceFile below — that one is the live API there, not the obsolete shim.) See NineSliceRuntime.
 #if !SKIA
     /// <summary>
     /// Obsolete. Use Texture instead.


### PR DESCRIPTION
## Bucket 1 of #2908 — NineSliceRuntime XNA-typed surface

Resolves the **Bucket 1** design pass on `NineSliceRuntime`'s remaining `#if XNALIKE` members, mirroring the decisions the `SpriteRuntime` sibling already settled on.

> **Does not close #2908.** That issue is a multi-bucket tracker and **Bucket 4** (per-slice 9-texture XNA model vs single-texture Raylib/Skia) is still open, so no auto-close keyword is used here on purpose.

### Decisions (per member)

| Member | Decision |
|---|---|
| Constructor default size | **Aligned to 100×100 on all backends.** The XNALIKE ctor never set `Width`/`Height`, leaving MG NineSlices at the `GraphicalUiElement` base default (**32×32**) while Raylib/Skia got 100×100. Now unconditional. |
| `BlendState` (XNA-typed) | **Permanent `#if XNALIKE` gate** + rationale comment. `Blend?` is the backend-neutral surface; the `Microsoft.Xna.Framework` type can't be exposed on Raylib/Skia. Mirrors SpriteRuntime. |
| Static Defaults block + ctor texture-coord assignments | **Permanent `#if XNALIKE` gate** + rationale comment. XNA-only legacy, no neutral equivalent, can't drop the public statics without an API break. |
| `[Obsolete] SourceFile` shim | **Stays XNALIKE-only — intentionally NOT widened** to match SpriteRuntime's wider footprint. Obsolete APIs are deprecated paths; spreading them to backends that never had them plants a dead surface in new code. Commented on **both** runtimes. |
| `Color`, `Blend?` | Already unified (single declaration, body-branched). No change. |

### Skill update

Codified the obsolete-API rule as a new **"Never Widen an Obsolete API"** section in the `gum-cross-platform-unification` skill, so future unification passes don't "fix the inconsistency" the wrong way.

### Testing

- New failing-first test `NineSliceRuntimeTests.Constructor_ShouldDefaultSizeTo100` (was 32, now 100).
- Sprite + NineSlice runtime tests pass (24).
- `RaylibGum` and `SkiaGum` (which file-link both runtimes) build clean.

No public API break on existing MonoGame consumers — the only behavior change is the MG default size 32→100, which was explicitly requested and brings MG in line with the other backends.

### Remaining on #2908

- **Bucket 4** — texture-model mismatch (own design issue, biggest blast radius).
- Sokol wrinkle — four `#if SOKOL` `NotifyPropertyChanged()` calls in the Animation region, orthogonal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
