### PR TITLE
NineSliceRuntime Bucket 4 (#2908): document XNA-only per-slice texture model as a permanent gate

### DIFF
--- a/MonoGameGum/GueDeriving/NineSliceRuntime.cs
+++ b/MonoGameGum/GueDeriving/NineSliceRuntime.cs
@@ -273,6 +273,15 @@ public class NineSliceRuntime : InteractiveGue
     }
 #endif
 
+    // Bucket 4 (#2908) decision: the XNA NineSlice renderable keeps nine separate Sprites,
+    // each able to hold its OWN texture (the old "nine separate image files" model — the
+    // _tl/_t/_tr/... suffixed files loaded via SetTexturesUsingPattern). That per-slice
+    // texture model is a legacy approach we no longer support and was never carried to the
+    // single-texture Raylib/Skia/Sokol renderables. We are NOT teaching those backends about
+    // per-slice textures, nor adding a single-texture facade to the XNA renderable, so this
+    // stays a permanent #if XNALIKE gate: on XNA we read the shared texture back through
+    // TopLeftTexture and broadcast writes to all nine slices via SetSingleTexture, while every
+    // other backend has a single Texture property. The branch is the model mismatch, not drift.
     public Texture2D? Texture
     {
         get


### PR DESCRIPTION
## Bucket 4 — the last open bucket of #2908

Resolves the **texture-model mismatch**: the XNA `NineSlice` renderable keeps nine separate `Sprite`s — each able to hold its *own* texture (the legacy "nine separate image files" model: the `_tl`/`_t`/`_tr`/… suffixed files loaded via `SetTexturesUsingPattern`). Raylib/Skia/Sokol renderables keep a single `Texture`. That mismatch is why `NineSliceRuntime.Texture`'s getter/setter still branches `#if XNALIKE` (read via `TopLeftTexture`, write via `SetSingleTexture` on XNA; single `Texture` property elsewhere).

### Decision

**Do not support the nine-texture model on any runtime.** It's an old approach we no longer support, and it was never carried to the single-texture backends. We are **not** teaching Raylib/Skia per-slice textures, and **not** adding a single-texture facade to the XNA renderable. The `#if XNALIKE` gate is therefore accepted as a **permanent, documented gate** — the same resolution shape as the Bucket 1 items in #3107. The branch encodes a real model mismatch, not historical drift.

### Change

Comment-only. Adds a rationale block above the `Texture` getter/setter in `MonoGameGum/GueDeriving/NineSliceRuntime.cs` explaining why the gate is permanent. No behavior change, no renderable edits, no public API change. `MonoGameGum` builds clean (0 errors; no new warnings).

### Bucket status — all four now resolved

| Bucket | Status |
|---|---|
| Bucket 1 — XNA-typed surface | Done (#3107) |
| Bucket 2 — animation on Skia/Raylib | Done (#2911 / #2909) |
| Bucket 3 — Raylib renderable capability gaps | Done (#3106 / #3105) |
| **Bucket 4 — texture-model mismatch** | **Done (this PR)** |

### Note

Issue #2908 was auto-closed when #3107 merged; reopened so this PR closes it cleanly.

The orthogonal `#if SOKOL` `NotifyPropertyChanged()` calls in the unified Animation region are **intentionally left in place** — they're independent of the four buckets.

Closes #2908

🤖 Generated with [Claude Code](https://claude.com/claude-code)
