### PR TITLE
Wire IGumService on SkiaGum and convert SilkNet screens to FrameworkElement (#3108)

### DIFF
--- a/.claude/skills/gum-samples/SKILL.md
+++ b/.claude/skills/gum-samples/SKILL.md
@@ -7,13 +7,15 @@ description: Where runtime-feature demo screens go. Triggers: adding a sample/de
 
 When a runtime feature needs a visual demo (so a human can eyeball it across backends), add a screen to the **three cross-backend feature samples**, keeping them aligned. Shape features are the exception — they go to the shapes gallery instead.
 
+The "**big three**" refers to the three backends below (Silk.NET/Skia, raylib, MonoGame). Note that the **XNA-likes (MonoGame, KNI) are split across two sample projects** — the feature sample *plus* the shapes gallery — for the reason explained under "Shape features" below. So "big three" counts backends, not project folders.
+
 ## The three feature samples (add here by default)
 
 | Sample | Backend | Path | Screen base / registration |
 |---|---|---|---|
 | MonoGameGumInCode | MonoGame (XNA) | `Samples/MonoGameGumInCode/MonoGameGumInCode/` | `FrameworkElement`; nav button in `Game1.BuildNavStrip` |
 | raylib gallery | raylib | `Samples/raylib/` | `FrameworkElement`; nav button in `Program.BuildNavStrip` (`Examples.Shapes` namespace) |
-| SilkNetGum | SkiaSharp via Silk.NET | `Samples/SilkNetGum/SilkNetGum/` | `GraphicalUiElement`; factory in `Program.codeScreenFactories` |
+| SilkNetGum | SkiaSharp via Silk.NET | `Samples/SilkNetGum/SilkNetGum/` | `FrameworkElement`; factory in `Program.codeScreenFactories`, keyboard nav |
 
 Each has a `Screens/` folder with one `*Screen.cs` per feature (`SpriteScreen`, `NineSliceScreen`, …). **MonoGameGumInCode is the reference** — mirror its screen section-for-section in the other two so the same screen can be opened side by side and any per-backend rendering difference stands out as a backend bug. The existing screen headers say exactly this ("Raylib mirror of …", "Mirror of MonoGameGumInCode.Screens…").
 
@@ -22,11 +24,13 @@ Each has a `Screens/` folder with one `*Screen.cs` per feature (`SpriteScreen`, 
 - **Texture paths differ.** MonoGame uses MGCB `Content/` names (`"Frame.png"`); raylib loads from disk (`"resources\\Frame.png"`, copied via the `resources\**\*.*` glob in `GumTest.csproj`); SilkNetGum loads from `Content/GumProject/`. Drop any new texture into each sample's content dir.
 - **Color types differ.** MonoGame `Microsoft.Xna.Framework.Color`, raylib `Raylib_cs.Color`, Skia `SKColor`. Pick the nearest named color per backend.
 - **Not every property exists on every backend.** A runtime property may be `#if`-gated away from a backend (see [[gum-cross-platform-unification]]). If the mirrored screen won't compile, the feature isn't wired on that backend yet — that's the actual work, not the screen.
-- **raylib screens need `using Gum.Forms.Controls;`** for `FrameworkElement`.
+- **raylib and SilkNetGum screens need `using Gum.Forms.Controls;`** for `FrameworkElement`.
 
 ## Shape features → the shapes gallery instead
 
 If the feature touches **shapes** (Circle, Rectangle, RoundedRectangle, Arc, Polygon, Line — anything from [[gum-shapes-xnb-packaging]] / the shape runtimes), do **not** add it to the three samples above. Add it to `Samples/GumShapesGallery/MonoGameGumShapesGallery/` (and its KNI siblings under `Samples/GumShapesGallery/`).
+
+**Why shapes get their own project:** raylib and Skia render shapes natively (built-in, full support), so shape demos for those backends live in the regular feature samples. XNA-likes (MonoGame, KNI) have **no built-in shape rendering** — they must be supplemented with the separate **Gum.Shapes** library, so their shape coverage lives in the dedicated `GumShapesGallery` project rather than `MonoGameGumInCode`. That's the split referenced above. This is expected to be unified eventually.
 
 ## Verification is human-driven
 

--- a/Runtimes/SkiaGum/GumService.cs
+++ b/Runtimes/SkiaGum/GumService.cs
@@ -1,8 +1,12 @@
 using Gum.DataTypes;
+using Gum.Forms.Controls;
 using Gum.Managers;
+using Gum.Threading;
 using Gum.Wireframe;
 using RenderingLibrary;
+using RenderingLibrary.Graphics;
 using Gum.GueDeriving;
+using SkiaGum.Renderables;
 using SkiaSharp;
 using System;
 using System.Collections.Generic;
@@ -13,7 +17,7 @@ using System.Threading.Tasks;
 using ToolsUtilities;
 
 namespace SkiaGum;
-public class GumService
+public class GumService : IGumService
 {
     static GumService _default;
     public static GumService Default
@@ -41,6 +45,55 @@ public class GumService
     /// become children of this container. Null until <c>Initialize</c> is called.
     /// </summary>
     public InteractiveGue Root { get; private set; }
+
+    #region IGumService implementation
+
+    // SkiaGum requires a canvas to initialize, so the host-agnostic no-arg Initialize
+    // overloads defined by IGumService are not supported — callers must use one of the
+    // Initialize(SKCanvas, ...) overloads below.
+    void IGumService.Initialize() =>
+        throw new NotSupportedException(
+            "SkiaGum requires a canvas. Call GumService.Default.Initialize(SKCanvas, ...) instead.");
+
+    void IGumService.Initialize(string gumProjectFile) =>
+        throw new NotSupportedException(
+            "SkiaGum requires a canvas. Call GumService.Default.Initialize(SKCanvas, ..., gumProjectFile) instead.");
+
+    IRenderer IGumService.Renderer => SystemManagers.Default.Renderer;
+
+    // Skia is a rendering technology, not a windowing/input system, so there is no built-in
+    // cursor and the Forms input pump (FormsUtilities) is not wired on Skia. Returning null
+    // is intentional; nothing on the Skia path consumes this today (Forms controls render via
+    // their contained visual, which needs no cursor).
+    ICursor IGumService.Cursor => null!;
+
+    float IGumService.CanvasWidth
+    {
+        get => GraphicalUiElement.CanvasWidth;
+        set => GraphicalUiElement.CanvasWidth = value;
+    }
+
+    float IGumService.CanvasHeight
+    {
+        get => GraphicalUiElement.CanvasHeight;
+        set => GraphicalUiElement.CanvasHeight = value;
+    }
+
+    /// <summary>
+    /// Queue used to defer actions onto the main loop. Pending actions are processed at
+    /// the start of each <see cref="Update"/>.
+    /// </summary>
+    public DeferredActionQueue DeferredQueue { get; private set; }
+
+    float? IGumService.GameTime => _hasReceivedUpdate ? (float?)_previousTotalSeconds : null;
+
+    // Skia has no native on-screen keyboard or OS clipboard implementation.
+    INativeTextInput? IGumService.NativeTextInput => null;
+    IGumClipboard? IGumService.Clipboard => null;
+
+    IRenderable IGumService.CreateSpriteRenderable() => new Sprite();
+
+    #endregion
 
     /// <summary>
     /// Initializes Gum for a Skia canvas, optionally loading a Gum project. The canvas
@@ -109,6 +162,15 @@ public class GumService
         Root.AddToManagers(SystemManagers.Default);
         Root.UpdateLayout();
 
+        DeferredQueue = new DeferredActionQueue();
+
+        // Wire this service as the runtime-agnostic default so GumCommon code resolves the
+        // Skia runtime the same way it does MonoGame/raylib — most importantly so that
+        // FrameworkElement.AddToRoot (which adds element.Visual to IGumService.Default.Root)
+        // works on Skia. Forms controls render via their contained visual, so this needs no
+        // input/cursor plumbing.
+        IGumService.Default = this;
+
         IsInitialized = true;
     }
 
@@ -145,6 +207,8 @@ public class GumService
     /// <param name="totalSeconds">Total elapsed time in seconds since startup.</param>
     public void Update(double totalSeconds)
     {
+        DeferredQueue?.ProcessPending();
+
         double delta = _hasReceivedUpdate ? totalSeconds - _previousTotalSeconds : 0;
         _previousTotalSeconds = totalSeconds;
         _hasReceivedUpdate = true;

--- a/Samples/SilkNetGum/SilkNetGum/Program.cs
+++ b/Samples/SilkNetGum/SilkNetGum/Program.cs
@@ -5,6 +5,7 @@ using SkiaSharp;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using RenderingLibrary;
+using Gum.Forms.Controls;
 using Gum.Wireframe;
 using Gum.GueDeriving;
 using RenderingLibrary.Graphics;
@@ -35,7 +36,8 @@ unsafe class Program
     private static void* glContext;
     private static bool running = true;
 
-    static GraphicalUiElement Root;
+    static GraphicalUiElement? currentGumxScreen;
+    static FrameworkElement? currentCodeScreen;
     static int currentScreenIndex;
     static TextRuntime instructionsText;
     static SKPaint sKPaint;
@@ -50,7 +52,7 @@ unsafe class Program
     // Code-only screens appended after every screen from the gumx, allowing the
     // sample to exercise runtime features (like the unified NineSliceRuntime) that
     // are not yet authored as Gum screens.
-    private static readonly Func<GraphicalUiElement>[] codeScreenFactories =
+    private static readonly Func<FrameworkElement>[] codeScreenFactories =
     {
         () => new SilkNetGum.Screens.NineSliceScreen(),
         () => new SilkNetGum.Screens.SpriteScreen(),
@@ -92,19 +94,25 @@ unsafe class Program
         // AddToManagers — that way GumService.Default.Update walks the screen and
         // its descendants, which is what advances AnimationChain playback on the
         // SpriteScreen's animated bear row.
-        Root?.RemoveFromRoot();
+        currentGumxScreen?.RemoveFromRoot();
+        currentGumxScreen = null;
+        currentCodeScreen?.RemoveFromRoot();
+        currentCodeScreen = null;
+
         if (currentScreenIndex < gumxScreens.Count)
         {
-            Root = gumxScreens[currentScreenIndex].ToGraphicalUiElement(SystemManagers.Default, addToManagers: false);
+            currentGumxScreen = gumxScreens[currentScreenIndex].ToGraphicalUiElement(SystemManagers.Default, addToManagers: false);
+            currentGumxScreen.AddToRoot();
+            currentGumxScreen.Width = GraphicalUiElement.CanvasWidth;
+            currentGumxScreen.Height = GraphicalUiElement.CanvasHeight;
         }
         else
         {
-            Root = codeScreenFactories[currentScreenIndex - gumxScreens.Count]();
+            // Code screens are FrameworkElement and Dock(Fill) themselves, so their visual
+            // fills the canvas without an explicit size assignment here.
+            currentCodeScreen = codeScreenFactories[currentScreenIndex - gumxScreens.Count]();
+            currentCodeScreen.AddToRoot();
         }
-        Root.AddToRoot();
-
-        Root.Width = GraphicalUiElement.CanvasWidth;
-        Root.Height = GraphicalUiElement.CanvasHeight;
     }
 
     private static void Draw()

--- a/Samples/SilkNetGum/SilkNetGum/Screens/ArcsScreen.cs
+++ b/Samples/SilkNetGum/SilkNetGum/Screens/ArcsScreen.cs
@@ -1,4 +1,5 @@
 using Gum.DataTypes;
+using Gum.Forms.Controls;
 using Gum.GueDeriving;
 using Gum.Wireframe;
 using RenderingLibrary.Graphics;
@@ -13,16 +14,18 @@ namespace SilkNetGum.Screens;
 // should land on the Apos side in the same PR. This is also the reference surface for the
 // raylib Arc port (#2866); features demonstrated here are the parity bar (chord fill is
 // Skia-specific and will not visually match raylib's wedge fill).
-internal class ArcsScreen : GraphicalUiElement
+internal class ArcsScreen : FrameworkElement
 {
-    public ArcsScreen() : base(new InvisibleRenderable())
+    public ArcsScreen() : base(new ContainerRuntime())
     {
+        Dock(Gum.Wireframe.Dock.Fill);
+
         ContainerRuntime root = new();
         root.ChildrenLayout = Gum.Managers.ChildrenLayout.LeftToRightStack;
         root.StackSpacing = 24;
         root.X = 10;
         root.Y = 10;
-        this.Children.Add(root);
+        this.AddChild(root);
 
         ContainerRuntime left = BuildColumn();
         ContainerRuntime right = BuildColumn();

--- a/Samples/SilkNetGum/SilkNetGum/Screens/CirclesScreen.cs
+++ b/Samples/SilkNetGum/SilkNetGum/Screens/CirclesScreen.cs
@@ -1,4 +1,5 @@
 using Gum.DataTypes;
+using Gum.Forms.Controls;
 using Gum.GueDeriving;
 using Gum.Wireframe;
 using RenderingLibrary.Graphics;
@@ -11,8 +12,6 @@ namespace SilkNetGum.Screens;
 // visual regressions in one backend are easy to spot against the other.
 //
 // What forces the two files apart:
-//   - Base class. Forms (FrameworkElement / Dock / AddChild) hasn't reached the Skia runtime
-//     yet, so this screen derives from GraphicalUiElement and uses Children.Add directly.
 //   - Color type. XNA Microsoft.Xna.Framework.Color becomes SKColor; named colors come from
 //     SkiaSharp.SKColors instead of Color.X.
 //   - The MonoGame CirclesScreen also uses VerticalAlignment from the FRB Forms types in its
@@ -20,10 +19,12 @@ namespace SilkNetGum.Screens;
 //
 // Everything else — section layout, sweep values, property names (Radius, StrokeColor,
 // FillColor, StrokeWidth, gradient props) — is identical to the MonoGame version.
-internal class CirclesScreen : GraphicalUiElement
+internal class CirclesScreen : FrameworkElement
 {
-    public CirclesScreen() : base(new InvisibleRenderable())
+    public CirclesScreen() : base(new ContainerRuntime())
     {
+        Dock(Gum.Wireframe.Dock.Fill);
+
         // Two-column root so the screen grows wide rather than tall as rows accumulate. No
         // ScrollViewer in SkiaGum yet, so this is the cheapest layout that works on both
         // backends (mirrored in MonoGameGumShapesGallery/Screens/CirclesScreen).
@@ -32,7 +33,7 @@ internal class CirclesScreen : GraphicalUiElement
         root.StackSpacing = 24;
         root.X = 10;
         root.Y = 10;
-        this.Children.Add(root);
+        this.AddChild(root);
 
         ContainerRuntime left = BuildColumn();
         ContainerRuntime right = BuildColumn();

--- a/Samples/SilkNetGum/SilkNetGum/Screens/NineSliceScreen.cs
+++ b/Samples/SilkNetGum/SilkNetGum/Screens/NineSliceScreen.cs
@@ -1,4 +1,5 @@
 using Gum.Content.AnimationChain;
+using Gum.Forms.Controls;
 using Gum.Graphics.Animation;
 using Gum.GueDeriving;
 using Gum.Managers;
@@ -13,14 +14,11 @@ namespace SilkNetGum.Screens;
 /// SkiaGum Silk.NET host so the two samples can be opened side by side to compare
 /// the unified <see cref="NineSliceRuntime"/> rendering between MonoGame and Skia.
 /// </summary>
-internal class NineSliceScreen : GraphicalUiElement
+internal class NineSliceScreen : FrameworkElement
 {
-    public NineSliceScreen() : base(new InvisibleRenderable())
+    public NineSliceScreen() : base(new ContainerRuntime())
     {
-        this.WidthUnits = Gum.DataTypes.DimensionUnitType.RelativeToParent;
-        this.HeightUnits = Gum.DataTypes.DimensionUnitType.RelativeToParent;
-        this.Width = 0;
-        this.Height = 0;
+        Dock(Gum.Wireframe.Dock.Fill);
 
         ContainerRuntime container = new ContainerRuntime();
         container.WidthUnits = Gum.DataTypes.DimensionUnitType.RelativeToParent;
@@ -31,7 +29,7 @@ internal class NineSliceScreen : GraphicalUiElement
         container.Height = -8;
         container.ChildrenLayout = ChildrenLayout.TopToBottomStack;
         container.StackSpacing = 4;
-        this.Children.Add(container);
+        this.AddChild(container);
 
         AddLabel(container, "Default nine-slice (Frame.png) at multiple sizes:");
         ContainerRuntime sizesRow = AddRow(container);

--- a/Samples/SilkNetGum/SilkNetGum/Screens/PolygonsScreen.cs
+++ b/Samples/SilkNetGum/SilkNetGum/Screens/PolygonsScreen.cs
@@ -1,4 +1,5 @@
 using Gum.DataTypes;
+using Gum.Forms.Controls;
 using Gum.GueDeriving;
 using Gum.Wireframe;
 using RenderingLibrary.Graphics;
@@ -15,27 +16,27 @@ namespace SilkNetGum.Screens;
 // other.
 //
 // What forces the two files apart:
-//   - Base class. Forms (FrameworkElement / Dock / AddChild) hasn't reached the Skia runtime
-//     yet, so this screen derives from GraphicalUiElement and uses Children.Add directly.
 //   - Color type. Microsoft.Xna.Framework.Color becomes SKColor; named colors come from
 //     SkiaSharp.SKColors.
 //   - Open polylines. MG's LinePolygon doesn't auto-close, so the MG screen omits the
 //     closing point. Skia's Polygon auto-closes when IsClosed = true, so this screen sets
 //     IsClosed = false on the open-polyline cells instead.
-internal class PolygonsScreen : GraphicalUiElement
+internal class PolygonsScreen : FrameworkElement
 {
     const float CellSize = 72;
     const float Center = CellSize / 2;
     const float Radius = 26;
 
-    public PolygonsScreen() : base(new InvisibleRenderable())
+    public PolygonsScreen() : base(new ContainerRuntime())
     {
+        Dock(Gum.Wireframe.Dock.Fill);
+
         ContainerRuntime root = new();
         root.ChildrenLayout = Gum.Managers.ChildrenLayout.TopToBottomStack;
         root.StackSpacing = 14;
         root.X = 10;
         root.Y = 10;
-        this.Children.Add(root);
+        this.AddChild(root);
 
         root.Children.Add(BuildSection("Common shapes (triangle, square, pentagon, hexagon)", BuildShapesRow()));
         root.Children.Add(BuildSection("StrokeWidth (1, 2, 4, 8 px) — hexagon outline", BuildStrokeWidthRow()));

--- a/Samples/SilkNetGum/SilkNetGum/Screens/RectanglesScreen.cs
+++ b/Samples/SilkNetGum/SilkNetGum/Screens/RectanglesScreen.cs
@@ -1,4 +1,5 @@
 using Gum.DataTypes;
+using Gum.Forms.Controls;
 using Gum.GueDeriving;
 using Gum.Wireframe;
 using RenderingLibrary.Graphics;
@@ -11,8 +12,6 @@ namespace SilkNetGum.Screens;
 // visual regressions in one backend are easy to spot against the other.
 //
 // What forces the two files apart:
-//   - Base class. Forms (FrameworkElement / Dock / AddChild) hasn't reached the Skia runtime
-//     yet, so this screen derives from GraphicalUiElement and uses Children.Add directly.
 //   - Color type. XNA Microsoft.Xna.Framework.Color becomes SKColor; named colors come from
 //     SkiaSharp.SKColors instead of Color.X.
 //   - CornerRadius row uses RectangleRuntime with CornerRadius on both sides as of #2771
@@ -23,10 +22,12 @@ namespace SilkNetGum.Screens;
 // Sections the MG side can't currently mirror (gated by missing API on MG RectangleRuntime
 // rather than a design difference): Gradients, Antialiasing, Dropshadow, DashedStrokes. The
 // MG header for those sections will land alongside follow-up plumbing.
-internal class RectanglesScreen : GraphicalUiElement
+internal class RectanglesScreen : FrameworkElement
 {
-    public RectanglesScreen() : base(new InvisibleRenderable())
+    public RectanglesScreen() : base(new ContainerRuntime())
     {
+        Dock(Gum.Wireframe.Dock.Fill);
+
         // Two-column root so the screen grows wide rather than tall as rows accumulate. No
         // ScrollViewer in SkiaGum yet, so this is the cheapest layout that works on both
         // backends (mirrored in MonoGameGumShapesGallery/Screens/RectanglesScreen).
@@ -35,7 +36,7 @@ internal class RectanglesScreen : GraphicalUiElement
         root.StackSpacing = 24;
         root.X = 10;
         root.Y = 10;
-        this.Children.Add(root);
+        this.AddChild(root);
 
         ContainerRuntime left = BuildColumn();
         ContainerRuntime right = BuildColumn();

--- a/Samples/SilkNetGum/SilkNetGum/Screens/SpriteScreen.cs
+++ b/Samples/SilkNetGum/SilkNetGum/Screens/SpriteScreen.cs
@@ -1,4 +1,5 @@
 using Gum.Content.AnimationChain;
+using Gum.Forms.Controls;
 using Gum.Graphics.Animation;
 using Gum.GueDeriving;
 using Gum.Managers;
@@ -19,14 +20,11 @@ namespace SilkNetGum.Screens;
 //   SubtractAlpha -> DstOut. ReplaceAlpha and MinAlpha have no clean SkiaSharp
 //   equivalent and fall through to SrcOver, so those two cells render identically
 //   to Normal — kept in the row anyway to mirror the MG layout 1:1.
-internal class SpriteScreen : GraphicalUiElement
+internal class SpriteScreen : FrameworkElement
 {
-    public SpriteScreen() : base(new InvisibleRenderable())
+    public SpriteScreen() : base(new ContainerRuntime())
     {
-        this.WidthUnits = Gum.DataTypes.DimensionUnitType.RelativeToParent;
-        this.HeightUnits = Gum.DataTypes.DimensionUnitType.RelativeToParent;
-        this.Width = 0;
-        this.Height = 0;
+        Dock(Gum.Wireframe.Dock.Fill);
 
         ContainerRuntime container = new ContainerRuntime();
         container.WidthUnits = Gum.DataTypes.DimensionUnitType.RelativeToParent;
@@ -37,7 +35,7 @@ internal class SpriteScreen : GraphicalUiElement
         container.Height = -8;
         container.ChildrenLayout = ChildrenLayout.TopToBottomStack;
         container.StackSpacing = 4;
-        this.Children.Add(container);
+        this.AddChild(container);
 
         // Default sprite at native size — PercentageOfSourceFile + Width/Height = 100
         // means "use the texture's own pixel dimensions".

--- a/Tests/SkiaGum.Tests/GumServiceTests.cs
+++ b/Tests/SkiaGum.Tests/GumServiceTests.cs
@@ -1,0 +1,33 @@
+using Gum.Forms.Controls;
+using Gum.GueDeriving;
+using RenderingLibrary;
+using Shouldly;
+using SkiaSharp;
+
+namespace SkiaGum.Tests;
+
+public class GumServiceTests
+{
+    [Fact]
+    public void FrameworkElement_AddToRoot_ShouldAddVisualToRoot()
+    {
+        using SKSurface surface = SKSurface.Create(new SKImageInfo(200, 100));
+        GumService.Default.Initialize(surface.Canvas, 200, 100);
+
+        ContainerRuntime visual = new ContainerRuntime();
+        FrameworkElement element = new FrameworkElement(visual);
+        element.AddToRoot();
+
+        GumService.Default.Root.Children.ShouldContain(visual);
+    }
+
+    [Fact]
+    public void Initialize_ShouldSetIGumServiceDefault()
+    {
+        using SKSurface surface = SKSurface.Create(new SKImageInfo(200, 100));
+        GumService.Default.Initialize(surface.Canvas, 200, 100);
+
+        IGumService.Default.ShouldNotBeNull();
+        IGumService.Default.ShouldBeSameAs(GumService.Default);
+    }
+}


### PR DESCRIPTION
## What

Wires `IGumService` onto `SkiaGum.GumService` and converts the SilkNet feature-sample screens to `FrameworkElement`, bringing the Skia sample in line with the MonoGameGumInCode reference.

Closes #3108.

## Why

`AddToRoot` for `GraphicalUiElement` was already unified across the big-three samples (MonoGame, raylib, SilkNet). The one remaining divergence was at the **Forms** layer: SilkNet screens derived from `GraphicalUiElement`, while MonoGame/raylib derive from `FrameworkElement`. That divergence existed because `SkiaGum.GumService` didn't implement `IGumService` / set `IGumService.Default`, so the GumCommon `FrameworkElement.AddToRoot` (which resolves the root via `IGumService.Default`) threw on Skia. Now that Forms controls live in GumCommon, this closes the gap.

## Changes

- **`SkiaGum.GumService : IGumService`** — assigns `IGumService.Default = this` in `Initialize`. Members Skia has no concept of (`Cursor`, `NativeTextInput`, `Clipboard`) return null; the no-arg `Initialize` overloads throw `NotSupportedException` (Skia needs a canvas). Adds `DeferredQueue` (processed each `Update`) and `CreateSpriteRenderable`.
- **SilkNet screens → `FrameworkElement`** — all six code screens (`NineSlice`, `Sprite`, `Circles`, `Rectangles`, `Arcs`, `Polygons`) now mirror the MonoGameGumInCode reference: `base(new ContainerRuntime())` + `Dock(Fill)` + `AddChild`. `Program.cs` `LoadScreen` handles both the gumx-loaded (`GraphicalUiElement`) and code (`FrameworkElement`) screens.
- **`gum-samples` skill** — SilkNet row updated to `FrameworkElement`, the `using Gum.Forms.Controls;` gotcha now covers SilkNet, plus the big-three terminology note and the shapes-gallery rationale.
- **Tests** — `SkiaGum.Tests/GumServiceTests` covers `IGumService.Default` wiring and `FrameworkElement.AddToRoot` on Skia.

## Key design note

Forms controls **never render** — a `FrameworkElement` wraps a `Visual` (`GraphicalUiElement`), and `AddToRoot` adds `element.Visual`. So converting these (non-interactive) demo screens needs only that `FrameworkElement` compiles (it's in GumCommon) + `IGumService.Default` wired. It does **not** need the Forms input pump (`FormsUtilities`/`Cursor`), which is `#if`-gated to XNALIKE + RAYLIB only. That pump is required solely for *interactive* standard controls — so navigation stays keyboard-driven here; a clickable Forms-button nav strip is a separate future port and is out of scope.

## Verification

- `SkiaGum.Tests` — 187 pass + 2 new.
- `SkiaGum.csproj` and the SilkNet sample build with no new warnings.
- **Needs a human eyeball:** the SilkNet sample is a Silk.NET/SDL app and can't be verified headlessly. Please run `Samples/SilkNetGum` and arrow through the screens to confirm they still render correctly after the `FrameworkElement` conversion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
