### PR TITLE
RectangleRuntime/CircleRuntime no longer require shapes (#3112)

### DIFF
--- a/Runtimes/GumShapes/GueDeriving/AposShapeRuntime.cs
+++ b/Runtimes/GumShapes/GueDeriving/AposShapeRuntime.cs
@@ -56,26 +56,40 @@ public abstract class AposShapeRuntime : GraphicalUiElement
         // backend both slots are an Apos shape — the fill factory sets IsFilled=true on its
         // instance, the stroke factory sets IsFilled=false on its instance. The runtime holds
         // both and they draw simultaneously.
+        // Issue #3112 — each slot factory only hands out an Apos shape once ShapeRenderer is
+        // actually initialized. Until then it returns null, which RenderableRegistry treats as
+        // graceful degradation: CircleRuntime / RectangleRuntime fall back to core's no-shapes
+        // default renderable (DefaultStrokedCircleRenderable / DefaultFilledRectangleRenderable).
+        // Without this gate, merely having the shapes assembly loaded — e.g. force-registered by
+        // GumService.Initialize's reflection scan on WASM, where every assembly loads up front —
+        // would route a plain Rectangle/Circle the user never opted into to an Apos renderable
+        // that throws "ShapeRenderer is null" at draw. Returning null! (not null) keeps the
+        // nullable-enabled Func<GraphicalUiElement, T> signature quiet; the registry and the
+        // runtime constructors both expect and handle null here.
         RenderableRegistry.RegisterFactory<Gum.GueDeriving.IFilledCircleRenderable>(gue =>
         {
+            if (!ShapeRenderer.Self.IsInitialized) return null!;
             var shape = new Circle { IsFilled = true };
             WireOnPreRender(shape, gue);
             return shape;
         });
         RenderableRegistry.RegisterFactory<Gum.GueDeriving.IStrokedCircleRenderable>(gue =>
         {
+            if (!ShapeRenderer.Self.IsInitialized) return null!; // #3112 gate (see above)
             var shape = new Circle { IsFilled = false };
             WireOnPreRender(shape, gue);
             return shape;
         });
         RenderableRegistry.RegisterFactory<Gum.GueDeriving.IFilledRectangleRenderable>(gue =>
         {
+            if (!ShapeRenderer.Self.IsInitialized) return null!; // #3112 gate (see above)
             var shape = new RoundedRectangle { IsFilled = true };
             WireOnPreRender(shape, gue);
             return shape;
         });
         RenderableRegistry.RegisterFactory<Gum.GueDeriving.IStrokedRectangleRenderable>(gue =>
         {
+            if (!ShapeRenderer.Self.IsInitialized) return null!; // #3112 gate (see above)
             var shape = new RoundedRectangle { IsFilled = false };
             WireOnPreRender(shape, gue);
             return shape;

--- a/Runtimes/GumShapes/Renderables/ShapeRenderer.cs
+++ b/Runtimes/GumShapes/Renderables/ShapeRenderer.cs
@@ -96,6 +96,12 @@ public class ShapeRenderer
 
     public bool IsInitialized { get; private set; }
 
+    // Issue #3112 — test-only seam. Forces IsInitialized without a real GraphicsDevice so the
+    // headless shapes unit tests can exercise the Apos two-slot model (true) or its absence
+    // (false). Production code initializes through Initialize(GraphicsDevice, ContentManager);
+    // this never runs in shipping paths. Reachable via InternalsVisibleTo("MonoGameGum.Shapes.Tests").
+    internal void SetIsInitializedForTesting(bool value) => IsInitialized = value;
+
     public static ShapeRenderer Self
     {
         get

--- a/Tests/MonoGameGum.Shapes.Tests/CircleRuntimeTests.cs
+++ b/Tests/MonoGameGum.Shapes.Tests/CircleRuntimeTests.cs
@@ -22,6 +22,10 @@ public class CircleRuntimeTests
     public CircleRuntimeTests()
     {
         AposShapeRuntime.RegisterRuntimeTypes();
+        // Issue #3112 — the slot-override factories now gate on ShapeRenderer.IsInitialized.
+        // These tests exercise the Apos two-slot model headlessly (no GraphicsDevice), so force
+        // the flag on. ShapeRendererGateTests covers the not-initialized fallback path.
+        ShapeRenderer.Self.SetIsInitializedForTesting(true);
     }
 
     // Issue #2937 — the two-slot model draws fill and stroke as separate renderables. The user

--- a/Tests/MonoGameGum.Shapes.Tests/RectangleRuntimeTests.cs
+++ b/Tests/MonoGameGum.Shapes.Tests/RectangleRuntimeTests.cs
@@ -17,6 +17,10 @@ public class RectangleRuntimeTests
     public RectangleRuntimeTests()
     {
         AposShapeRuntime.RegisterRuntimeTypes();
+        // Issue #3112 — the slot-override factories now gate on ShapeRenderer.IsInitialized.
+        // These tests exercise the Apos two-slot model headlessly (no GraphicsDevice), so force
+        // the flag on. ShapeRendererGateTests covers the not-initialized fallback path.
+        ShapeRenderer.Self.SetIsInitializedForTesting(true);
     }
 
     [Fact]

--- a/Tests/MonoGameGum.Shapes.Tests/ShapeRendererGateTests.cs
+++ b/Tests/MonoGameGum.Shapes.Tests/ShapeRendererGateTests.cs
@@ -1,0 +1,50 @@
+using Gum.GueDeriving;
+using MonoGameAndGum.Renderables;
+using MonoGameGum.Renderables;
+using RenderingLibrary.Graphics;
+using Shouldly;
+
+namespace MonoGameGum.Shapes.Tests;
+
+// Issue #3112 — a plain RectangleRuntime / CircleRuntime must NOT require the Apos.Shapes
+// ShapeRenderer. The MonoGameGumShapes package registers Apos slot-override factories for the
+// fill/stroke slots, and GumService.Initialize's reflection scan force-registers them on WASM
+// whenever the shapes assembly is merely loaded. If those factories handed out an Apos shape
+// before ShapeRenderer was initialized, the rectangle/circle would throw "ShapeRenderer is null"
+// at draw (the reported browser/KNI crash) even though the user never opted into shapes.
+//
+// The fix gates the four slot-override factories on ShapeRenderer.IsInitialized: until shapes is
+// actually initialized they return null, so the runtime falls back to core's no-shapes default
+// renderable — identical to desktop behavior when shapes was never set up.
+//
+// This class deliberately does NOT mark the ShapeRenderer initialized (mirroring the user's
+// scenario), so it must run with IsInitialized == false. It resets the flag defensively in case
+// another test in the run left a real/forced ShapeRenderer initialized.
+public class ShapeRendererGateTests
+{
+    public ShapeRendererGateTests()
+    {
+        AposShapeRuntime.RegisterRuntimeTypes();
+        ShapeRenderer.Self.SetIsInitializedForTesting(false);
+    }
+
+    [Fact]
+    public void CircleRuntime_WhenShapeRendererNotInitialized_FallsBackToCoreDefault()
+    {
+        CircleRuntime sut = new();
+
+        // Fill factory returns null (gated), so the stroke slot becomes the contained renderable:
+        // core's DefaultStrokedCircleRenderable, not an Apos Circle.
+        sut.RenderableComponent.ShouldBeOfType<DefaultStrokedCircleRenderable>();
+    }
+
+    [Fact]
+    public void RectangleRuntime_WhenShapeRendererNotInitialized_FallsBackToCoreDefault()
+    {
+        RectangleRuntime sut = new();
+
+        // Fill slot falls back to core's DefaultFilledRectangleRenderable (wraps SolidRectangle),
+        // not an Apos RoundedRectangle.
+        sut.RenderableComponent.ShouldBeOfType<DefaultFilledRectangleRenderable>();
+    }
+}


### PR DESCRIPTION
## Problem

A plain `RectangleRuntime` (and `CircleRuntime`) crashed with `ShapeRenderer is null — did you remember to call ShapeRenderer.Self.Initialize()?` on KNI/WASM (e.g. XnaFiddle), even though the user never opted into shapes. Reproduced in #3112.

### Root cause

The slots of `RectangleRuntime`/`CircleRuntime` resolve from `RenderableRegistry`. Core registers no-shapes defaults (`SolidRectangle`/`LineRectangle`-backed). The optional MonoGameGumShapes package **overrides** those slots with Apos.Shapes `RoundedRectangle`/`Circle` via `AposShapeRuntime.RegisterRuntimeTypes()`.

`GumService.Initialize` runs a reflection scan (`RegisterRuntimeTypesThroughReflection`) that invokes any static `RegisterRuntimeTypes()` on **every loaded assembly** — this exists specifically to force shape registration on WASM, where `[ModuleInitializer]` doesn't auto-fire. On WASM every assembly loads up front, so merely *bundling* `Gum.Shapes.KNI` caused the scan to register the Apos slot-override factories. But `GumService.Initialize` never initializes the `ShapeRenderer`, so the slots became Apos renderables whose `ShapeBatch` was null → crash at `Draw`.

On desktop the shapes assembly often isn't JIT-loaded at `Initialize` time, so the core defaults survive and a plain rectangle renders fine — a platform divergence (browser crashed, desktop didn't).

## Fix

Gate the four Apos slot-override factories on `ShapeRenderer.IsInitialized`. Until shapes is actually initialized they return `null`, which `RenderableRegistry` already treats as graceful degradation — the runtime constructors fall back to the core no-shapes default renderable. Result: **browser/KNI now behaves identically to desktop** — a plain rectangle renders without requiring shapes. Genuinely opting in (`ShapeRenderer.Self.Initialize(...)`) restores the Apos rounded-corner slots as before.

The element-instantiation registrations (Arc/RoundedRectangle/etc. for `.gumx` load) are **unchanged** — only the slot overrides that make a *plain* Rectangle/Circle depend on shapes are gated.

### Why not other approaches
- *Auto-initialize ShapeRenderer when the assembly is present* would make browser render Apos rounded rectangles while desktop-without-shapes renders hard-cornered core ones — **not** the same behavior, and it silently loads the Apos shader/content the user never asked for.
- *Gate at draw time* would render nothing (no-op) instead of the rectangle the user expects.

## Tool safety
`WireframeControl` initializes `ShapeRenderer` early (before building any runtimes), and `FallbackRenderableFactory` uses `is IRenderable` pattern matching that falls through to `LineRectangle` on a null return — no editor regression.

## Tests (TDD)
- New `ShapeRendererGateTests`: with the Apos factories registered but `ShapeRenderer` **not** initialized, both `RectangleRuntime` and `CircleRuntime` fall back to the core default renderable (was Apos → crash). Written first, confirmed red, then green.
- Added an internal `ShapeRenderer.SetIsInitializedForTesting` seam so the existing headless Apos two-slot tests (`RectangleRuntimeTests`/`CircleRuntimeTests`) can force the flag on without a `GraphicsDevice`.
- Full `MonoGameGum.Shapes.Tests` suite: **204 passing**. KNI variant builds clean.

Closes #3112

🤖 Generated with [Claude Code](https://claude.com/claude-code)
