### PR TITLE
#2775: Codegen targets collapsed shape runtimes at syntax version 2

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -94,6 +94,38 @@ jobs:
           dotnet restore "AllLibraries.sln" -p:IncludeAndroid=true --verbosity quiet
           dotnet build "AllLibraries.sln" --configuration Release --no-restore --verbosity quiet -p:WarningLevel=0 -p:IncludeAndroid=true
 
+      # Regenerate every harness project with GumCli and fail if the checked-in
+      # generated code is stale. This forces codegen behavior changes to ship with
+      # their regenerated output in the same PR, which the compile step below then
+      # proves still builds. GumCli exit code 1 means individual elements were
+      # skipped by the per-element error check — expected, several harness projects
+      # contain deliberately-broken fixture elements (e.g. DemoScreenGum's deleted
+      # component reference). Exit code 2+ means the project failed to load and
+      # must fail the build.
+      - name: Codegen Drift Check (Windows Only)
+        if: (github.event_name != 'push' || steps.cache-workloads.outputs.cache-hit != 'true') && runner.os == 'Windows'
+        run: |
+          dotnet build "Tools/Gum.Cli/Gum.Cli.csproj" --configuration Release --verbosity quiet -p:WarningLevel=0
+          $cli = "Tools/Gum.Cli/bin/Release/net8.0/GumCli.exe"
+          $gumxProjects = @(
+            "Tests/CodeGen_Maui_FullCodegen/Content/GumProject/CodeGenTestProject.gumx",
+            "Tests/CodeGen_MonoGame_ByReference/Content/GumProject/CodeGenTestProject.gumx",
+            "Tests/CodeGen_MonoGameForms_ByReference/Content/GumProject/CodeGenTestProject.gumx",
+            "Tests/CodeGen_MonoGameForms_Localization_ByReference/Content/GumProject/LocalizationCodeGenTestProject.gumx",
+            "Tests/CodeGen_MonoGameForms_FullCodegen/Content/CodeGenProject.gumx"
+          )
+          foreach ($gumxProject in $gumxProjects) {
+            & $cli codegen $gumxProject
+            if ($LASTEXITCODE -gt 1) { exit $LASTEXITCODE }
+          }
+          $drift = git status --porcelain -- "Tests/CodeGen_*"
+          if ($drift) {
+            Write-Host "::error::Checked-in generated code is stale. Run 'gumcli codegen' on each Tests/CodeGen_* project (or Tests/GenerateAllCodeGenProjects.bat) and commit the result."
+            Write-Host ($drift -join "`n")
+            git diff -- "Tests/CodeGen_*"
+            exit 1
+          }
+
       - name: Build Generated Code Projects (Windows Only)
         if: (github.event_name != 'push' || steps.cache-workloads.outputs.cache-hit != 'true') && runner.os == 'Windows'
         run: |
@@ -105,6 +137,9 @@ jobs:
 
           dotnet restore "Tests/CodeGen_MonoGameForms_ByReference/CodeGenProject.sln" --verbosity quiet
           dotnet build "Tests/CodeGen_MonoGameForms_ByReference/CodeGenProject.sln" --configuration Debug --no-restore --verbosity quiet -p:WarningLevel=0
+
+          dotnet restore "Tests/CodeGen_MonoGameForms_Localization_ByReference/CodeGen_MonoGameForms_Localization_ByReference.csproj" --verbosity quiet
+          dotnet build "Tests/CodeGen_MonoGameForms_Localization_ByReference/CodeGen_MonoGameForms_Localization_ByReference.csproj" --configuration Debug --no-restore --verbosity quiet -p:WarningLevel=0
 
           dotnet restore "Tests/CodeGen_MonoGameForms_FullCodegen/CodeGen_MonoGameForms_FullCodegen.sln" --verbosity quiet
           dotnet build "Tests/CodeGen_MonoGameForms_FullCodegen/CodeGen_MonoGameForms_FullCodegen.sln" --configuration Debug --no-restore --verbosity quiet -p:WarningLevel=0

--- a/MonoGameGum/GueDeriving/ColoredRectangleRuntime.cs
+++ b/MonoGameGum/GueDeriving/ColoredRectangleRuntime.cs
@@ -28,7 +28,7 @@ namespace Gum.GueDeriving;
 #endif
 
 
-[Obsolete("Use RectangleRuntime with FillColor instead. ColoredRectangleRuntime will be removed in a future release. See docs/gum-tool/upgrading/migrating-to-2026-may.md for the full migration guide.")]
+[Obsolete("Use RectangleRuntime with FillColor instead. ColoredRectangleRuntime will be removed in a future release. See docs/gum-tool/upgrading/migrating-to-2026-june.md for the full migration guide.")]
 public class ColoredRectangleRuntime : GraphicalUiElement
 {
     public static float DefaultWidth = 50;

--- a/Runtimes/GumShapes/GueDeriving/ColoredCircleRuntime.cs
+++ b/Runtimes/GumShapes/GueDeriving/ColoredCircleRuntime.cs
@@ -18,7 +18,7 @@ namespace Gum.GueDeriving;
 /// Runtime that draws a circle (or ellipse) sized by its Width and Height. Adds no properties beyond
 /// the AposShapeRuntime common set - color, gradient, drop shadow, and fill/stroke are inherited.
 /// </summary>
-[Obsolete("Use CircleRuntime instead: set StrokeColor for an outline, or set IsFilled = true for a fill (FillColor defaults to white). ColoredCircleRuntime will be removed in a future release. See docs/gum-tool/upgrading/migrating-to-2026-may.md for the full migration guide.")]
+[Obsolete("Use CircleRuntime instead: set StrokeColor for an outline, or set IsFilled = true for a fill (FillColor defaults to white). ColoredCircleRuntime will be removed in a future release. See docs/gum-tool/upgrading/migrating-to-2026-june.md for the full migration guide.")]
 public class ColoredCircleRuntime : AposShapeRuntime
 {
     protected override RenderableShapeBase ContainedRenderable => ContainedCircle;

--- a/Runtimes/SkiaGum/GueDeriving/ArcRuntime.cs
+++ b/Runtimes/SkiaGum/GueDeriving/ArcRuntime.cs
@@ -558,7 +558,7 @@ public class ArcRuntime
     /// <summary>
     /// Gets or sets whether the ends of the arc are rounded. If true, the arc has rounded caps;
     /// if false, the ends are flat. Defaults to false on both backends as of issue #2728 - see
-    /// <c>docs/gum-tool/upgrading/migrating-to-2026-may.md</c>. Existing Apos consumers who relied
+    /// <c>docs/gum-tool/upgrading/migrating-to-2026-june.md</c>. Existing Apos consumers who relied
     /// on the prior rounded default must set this to true explicitly.
     /// </summary>
     public bool IsEndRounded

--- a/Runtimes/SkiaGum/GueDeriving/ColoredCircleRuntime.cs
+++ b/Runtimes/SkiaGum/GueDeriving/ColoredCircleRuntime.cs
@@ -12,7 +12,7 @@ namespace SkiaGum.GueDeriving;
 namespace Gum.GueDeriving;
 #endif
 
-[Obsolete("Use CircleRuntime instead: set StrokeColor for an outline, or set IsFilled = true for a fill (FillColor defaults to white). ColoredCircleRuntime will be removed in a future release. See docs/gum-tool/upgrading/migrating-to-2026-may.md for the full migration guide.")]
+[Obsolete("Use CircleRuntime instead: set StrokeColor for an outline, or set IsFilled = true for a fill (FillColor defaults to white). ColoredCircleRuntime will be removed in a future release. See docs/gum-tool/upgrading/migrating-to-2026-june.md for the full migration guide.")]
 public class ColoredCircleRuntime : SkiaShapeRuntime
 {
     protected override RenderableShapeBase ContainedRenderable => ContainedCircle;

--- a/Runtimes/SkiaGum/GueDeriving/RoundedRectangleRuntime.cs
+++ b/Runtimes/SkiaGum/GueDeriving/RoundedRectangleRuntime.cs
@@ -32,7 +32,7 @@ namespace Gum.GueDeriving;
 /// differences are gated behind <c>#if SKIA</c>; the cross-platform shape (constructor defaults,
 /// CornerRadius property, base wiring) is shared.
 /// </remarks>
-[Obsolete("Use RectangleRuntime with CornerRadius (plus FillColor / StrokeColor for the two-slot model) instead. RoundedRectangleRuntime will be removed in a future release. See docs/gum-tool/upgrading/migrating-to-2026-may.md for the full migration guide.")]
+[Obsolete("Use RectangleRuntime with CornerRadius (plus FillColor / StrokeColor for the two-slot model) instead. RoundedRectangleRuntime will be removed in a future release. See docs/gum-tool/upgrading/migrating-to-2026-june.md for the full migration guide.")]
 public class RoundedRectangleRuntime
 #if SKIA
     : SkiaShapeRuntime, IClipPath

--- a/Runtimes/SkiaGum/GueDeriving/SolidRectangleRuntime.cs
+++ b/Runtimes/SkiaGum/GueDeriving/SolidRectangleRuntime.cs
@@ -9,7 +9,7 @@ namespace SkiaGum.GueDeriving;
 namespace Gum.GueDeriving;
 #endif
 
-[Obsolete("Use RectangleRuntime with FillColor instead. SolidRectangleRuntime will be removed in a future release. See docs/gum-tool/upgrading/migrating-to-2026-may.md for the full migration guide.")]
+[Obsolete("Use RectangleRuntime with FillColor instead. SolidRectangleRuntime will be removed in a future release. See docs/gum-tool/upgrading/migrating-to-2026-june.md for the full migration guide.")]
 public class SolidRectangleRuntime : InteractiveGue
 {
     SolidRectangle mContainedRectangle;

--- a/Samples/GumShapesGallery/GumShapesGalleryCommon/Screens/ShapeSurveyScreen.cs
+++ b/Samples/GumShapesGallery/GumShapesGalleryCommon/Screens/ShapeSurveyScreen.cs
@@ -187,7 +187,7 @@ internal class ShapeSurveyScreen : FrameworkElement
 
         // Same as the default but with IsEndRounded explicitly set - this is the toggle
         // existing Apos consumers must apply if they relied on the previous rounded default.
-        // Documented in docs/gum-tool/upgrading/migrating-to-2026-may.md.
+        // Documented in docs/gum-tool/upgrading/migrating-to-2026-june.md.
         ArcRuntime rounded = new ArcRuntime();
         rounded.IsEndRounded = true;
         Place(rounded, row, 1, cellW, rowH, size, size);

--- a/Tests/CodeGen_Maui_FullCodegen/Screens/ExampleScreenRuntime.Generated.cs
+++ b/Tests/CodeGen_Maui_FullCodegen/Screens/ExampleScreenRuntime.Generated.cs
@@ -9,7 +9,7 @@ using RenderingLibrary.Graphics;
 using SkiaGum.GueDeriving;
 using System.Linq;
 namespace CodeGen_Maui_FullCodegen.Screens;
-partial class ExampleScreenRuntime : Gum.Wireframe.BindableGue
+partial class ExampleScreenRuntime : Gum.Wireframe.GraphicalUiElement
 {
     public ContainerRuntime ContainerInstance { get; protected set; }
     public TextRuntime TextInstance { get; protected set; }

--- a/Tests/CodeGen_Maui_FullCodegen/Screens/With_Spaces_ScreenRuntime.Generated.cs
+++ b/Tests/CodeGen_Maui_FullCodegen/Screens/With_Spaces_ScreenRuntime.Generated.cs
@@ -9,7 +9,7 @@ using RenderingLibrary.Graphics;
 using SkiaGum.GueDeriving;
 using System.Linq;
 namespace CodeGen_Maui_FullCodegen.Screens;
-partial class With_Spaces_ScreenRuntime : Gum.Wireframe.BindableGue
+partial class With_Spaces_ScreenRuntime : Gum.Wireframe.GraphicalUiElement
 {
     public ContainerRuntime Container_With_Spaces { get; protected set; }
     public ContainerRuntime Parent_With_Spaces { get; protected set; }

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/@interface.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/@interface.Generated.cs
@@ -1,11 +1,11 @@
 //Code for interface (Container)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGenProject.Components;
@@ -16,7 +16,7 @@ partial class @interface : global::Gum.Forms.Controls.FrameworkElement
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("interface");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named interface - did you forget to load a Gum project?");

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/AnimatedComponent.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/AnimatedComponent.Generated.cs
@@ -1,12 +1,12 @@
 //Code for AnimatedComponent (Container)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.StateAnimation.Runtime;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGenProject.Components;
@@ -17,7 +17,7 @@ partial class AnimatedComponent : global::Gum.Forms.Controls.FrameworkElement
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("AnimatedComponent");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named AnimatedComponent - did you forget to load a Gum project?");

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/ComponentWithChangedTypes.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/ComponentWithChangedTypes.Generated.cs
@@ -1,11 +1,11 @@
 //Code for ComponentWithChangedTypes (Container)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGenProject.Components;
@@ -16,7 +16,7 @@ partial class ComponentWithChangedTypes : global::Gum.Forms.Controls.FrameworkEl
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("ComponentWithChangedTypes");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named ComponentWithChangedTypes - did you forget to load a Gum project?");
@@ -48,7 +48,7 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     protected override void ReactToVisualChanged()
     {
         base.ReactToVisualChanged();
-        Icon = this.Visual?.GetGraphicalUiElementByName("Icon") as global::MonoGameGum.GueDeriving.SpriteRuntime;
+        Icon = this.Visual?.GetGraphicalUiElementByName("Icon") as global::Gum.GueDeriving.SpriteRuntime;
         CustomInitialize();
     }
     //Not assigning variables because Object Instantiation Type is set to By Name rather than Fully In Code

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/ComponentWithExposedVariables.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/ComponentWithExposedVariables.Generated.cs
@@ -2,11 +2,11 @@
 using CodeGenProject.Components;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGenProject.Components;
@@ -17,7 +17,7 @@ partial class ComponentWithExposedVariables : global::Gum.Forms.Controls.Framewo
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("ComponentWithExposedVariables");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named ComponentWithExposedVariables - did you forget to load a Gum project?");

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/ContainerOfFormsObjects.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/ContainerOfFormsObjects.Generated.cs
@@ -2,11 +2,11 @@
 using CodeGenProject.Components.Controls;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGenProject.Components;
@@ -17,7 +17,7 @@ partial class ContainerOfFormsObjects : global::Gum.Forms.Controls.FrameworkElem
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("ContainerOfFormsObjects");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named ContainerOfFormsObjects - did you forget to load a Gum project?");

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/ButtonClose.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/ButtonClose.Generated.cs
@@ -2,11 +2,11 @@
 using CodeGenProject.Components.Elements;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGenProject.Components.Controls;
@@ -17,7 +17,7 @@ partial class ButtonClose : global::Gum.Forms.Controls.Button
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/ButtonClose");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/ButtonClose - did you forget to load a Gum project?");
@@ -84,9 +84,9 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     protected override void ReactToVisualChanged()
     {
         base.ReactToVisualChanged();
-        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
+        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::Gum.GueDeriving.NineSliceRuntime;
         Icon = global::Gum.Forms.GraphicalUiElementFormsExtensions.TryGetFrameworkElementByName<Icon>(this.Visual,"Icon");
-        FocusedIndicator = this.Visual?.GetGraphicalUiElementByName("FocusedIndicator") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
+        FocusedIndicator = this.Visual?.GetGraphicalUiElementByName("FocusedIndicator") as global::Gum.GueDeriving.NineSliceRuntime;
         CustomInitialize();
     }
     //Not assigning variables because Object Instantiation Type is set to By Name rather than Fully In Code

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/ButtonConfirm.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/ButtonConfirm.Generated.cs
@@ -1,11 +1,11 @@
 //Code for Controls/ButtonConfirm (Container)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGenProject.Components.Controls;
@@ -16,7 +16,7 @@ partial class ButtonConfirm : global::Gum.Forms.Controls.Button
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/ButtonConfirm");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/ButtonConfirm - did you forget to load a Gum project?");
@@ -89,9 +89,9 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     protected override void ReactToVisualChanged()
     {
         base.ReactToVisualChanged();
-        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
-        TextInstance = this.Visual?.GetGraphicalUiElementByName("TextInstance") as global::MonoGameGum.GueDeriving.TextRuntime;
-        FocusedIndicator = this.Visual?.GetGraphicalUiElementByName("FocusedIndicator") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
+        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::Gum.GueDeriving.NineSliceRuntime;
+        TextInstance = this.Visual?.GetGraphicalUiElementByName("TextInstance") as global::Gum.GueDeriving.TextRuntime;
+        FocusedIndicator = this.Visual?.GetGraphicalUiElementByName("FocusedIndicator") as global::Gum.GueDeriving.NineSliceRuntime;
         CustomInitialize();
     }
     //Not assigning variables because Object Instantiation Type is set to By Name rather than Fully In Code

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/ButtonDeny.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/ButtonDeny.Generated.cs
@@ -1,11 +1,11 @@
 //Code for Controls/ButtonDeny (Container)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGenProject.Components.Controls;
@@ -16,7 +16,7 @@ partial class ButtonDeny : global::Gum.Forms.Controls.Button
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/ButtonDeny");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/ButtonDeny - did you forget to load a Gum project?");
@@ -89,9 +89,9 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     protected override void ReactToVisualChanged()
     {
         base.ReactToVisualChanged();
-        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
-        TextInstance = this.Visual?.GetGraphicalUiElementByName("TextInstance") as global::MonoGameGum.GueDeriving.TextRuntime;
-        FocusedIndicator = this.Visual?.GetGraphicalUiElementByName("FocusedIndicator") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
+        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::Gum.GueDeriving.NineSliceRuntime;
+        TextInstance = this.Visual?.GetGraphicalUiElementByName("TextInstance") as global::Gum.GueDeriving.TextRuntime;
+        FocusedIndicator = this.Visual?.GetGraphicalUiElementByName("FocusedIndicator") as global::Gum.GueDeriving.NineSliceRuntime;
         CustomInitialize();
     }
     //Not assigning variables because Object Instantiation Type is set to By Name rather than Fully In Code

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/ButtonIcon.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/ButtonIcon.Generated.cs
@@ -2,11 +2,11 @@
 using CodeGenProject.Components.Elements;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGenProject.Components.Controls;
@@ -17,7 +17,7 @@ partial class ButtonIcon : global::Gum.Forms.Controls.Button
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/ButtonIcon");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/ButtonIcon - did you forget to load a Gum project?");
@@ -90,9 +90,9 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     protected override void ReactToVisualChanged()
     {
         base.ReactToVisualChanged();
-        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
+        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::Gum.GueDeriving.NineSliceRuntime;
         Icon = global::Gum.Forms.GraphicalUiElementFormsExtensions.TryGetFrameworkElementByName<Icon>(this.Visual,"Icon");
-        FocusedIndicator = this.Visual?.GetGraphicalUiElementByName("FocusedIndicator") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
+        FocusedIndicator = this.Visual?.GetGraphicalUiElementByName("FocusedIndicator") as global::Gum.GueDeriving.NineSliceRuntime;
         CustomInitialize();
     }
     //Not assigning variables because Object Instantiation Type is set to By Name rather than Fully In Code

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/ButtonStandard.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/ButtonStandard.Generated.cs
@@ -1,11 +1,11 @@
 //Code for Controls/ButtonStandard (Container)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGenProject.Components.Controls;
@@ -16,7 +16,7 @@ partial class ButtonStandard : global::Gum.Forms.Controls.Button
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/ButtonStandard");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/ButtonStandard - did you forget to load a Gum project?");
@@ -90,9 +90,9 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     protected override void ReactToVisualChanged()
     {
         base.ReactToVisualChanged();
-        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
-        TextInstance = this.Visual?.GetGraphicalUiElementByName("TextInstance") as global::MonoGameGum.GueDeriving.TextRuntime;
-        FocusedIndicator = this.Visual?.GetGraphicalUiElementByName("FocusedIndicator") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
+        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::Gum.GueDeriving.NineSliceRuntime;
+        TextInstance = this.Visual?.GetGraphicalUiElementByName("TextInstance") as global::Gum.GueDeriving.TextRuntime;
+        FocusedIndicator = this.Visual?.GetGraphicalUiElementByName("FocusedIndicator") as global::Gum.GueDeriving.NineSliceRuntime;
         CustomInitialize();
     }
     //Not assigning variables because Object Instantiation Type is set to By Name rather than Fully In Code

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/ButtonStandardIcon.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/ButtonStandardIcon.Generated.cs
@@ -2,11 +2,11 @@
 using CodeGenProject.Components.Elements;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGenProject.Components.Controls;
@@ -17,7 +17,7 @@ partial class ButtonStandardIcon : global::Gum.Forms.Controls.Button
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/ButtonStandardIcon");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/ButtonStandardIcon - did you forget to load a Gum project?");
@@ -97,10 +97,10 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     protected override void ReactToVisualChanged()
     {
         base.ReactToVisualChanged();
-        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
-        TextInstance = this.Visual?.GetGraphicalUiElementByName("TextInstance") as global::MonoGameGum.GueDeriving.TextRuntime;
+        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::Gum.GueDeriving.NineSliceRuntime;
+        TextInstance = this.Visual?.GetGraphicalUiElementByName("TextInstance") as global::Gum.GueDeriving.TextRuntime;
         Icon = global::Gum.Forms.GraphicalUiElementFormsExtensions.TryGetFrameworkElementByName<Icon>(this.Visual,"Icon");
-        FocusedIndicator = this.Visual?.GetGraphicalUiElementByName("FocusedIndicator") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
+        FocusedIndicator = this.Visual?.GetGraphicalUiElementByName("FocusedIndicator") as global::Gum.GueDeriving.NineSliceRuntime;
         CustomInitialize();
     }
     //Not assigning variables because Object Instantiation Type is set to By Name rather than Fully In Code

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/ButtonTab.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/ButtonTab.Generated.cs
@@ -1,11 +1,11 @@
 //Code for Controls/ButtonTab (Container)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGenProject.Components.Controls;
@@ -16,7 +16,7 @@ partial class ButtonTab : global::Gum.Forms.Controls.Button
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/ButtonTab");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/ButtonTab - did you forget to load a Gum project?");
@@ -89,9 +89,9 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     protected override void ReactToVisualChanged()
     {
         base.ReactToVisualChanged();
-        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
-        TabText = this.Visual?.GetGraphicalUiElementByName("TabText") as global::MonoGameGum.GueDeriving.TextRuntime;
-        FocusedIndicator = this.Visual?.GetGraphicalUiElementByName("FocusedIndicator") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
+        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::Gum.GueDeriving.NineSliceRuntime;
+        TabText = this.Visual?.GetGraphicalUiElementByName("TabText") as global::Gum.GueDeriving.TextRuntime;
+        FocusedIndicator = this.Visual?.GetGraphicalUiElementByName("FocusedIndicator") as global::Gum.GueDeriving.NineSliceRuntime;
         CustomInitialize();
     }
     //Not assigning variables because Object Instantiation Type is set to By Name rather than Fully In Code

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/CheckBox.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/CheckBox.Generated.cs
@@ -2,11 +2,11 @@
 using CodeGenProject.Components.Elements;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGenProject.Components.Controls;
@@ -17,7 +17,7 @@ partial class CheckBox : global::Gum.Forms.Controls.CheckBox
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/CheckBox");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/CheckBox - did you forget to load a Gum project?");
@@ -101,10 +101,10 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     protected override void ReactToVisualChanged()
     {
         base.ReactToVisualChanged();
-        CheckboxBackground = this.Visual?.GetGraphicalUiElementByName("CheckboxBackground") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
-        TextInstance = this.Visual?.GetGraphicalUiElementByName("TextInstance") as global::MonoGameGum.GueDeriving.TextRuntime;
+        CheckboxBackground = this.Visual?.GetGraphicalUiElementByName("CheckboxBackground") as global::Gum.GueDeriving.NineSliceRuntime;
+        TextInstance = this.Visual?.GetGraphicalUiElementByName("TextInstance") as global::Gum.GueDeriving.TextRuntime;
         Check = global::Gum.Forms.GraphicalUiElementFormsExtensions.TryGetFrameworkElementByName<Icon>(this.Visual,"Check");
-        FocusedIndicator = this.Visual?.GetGraphicalUiElementByName("FocusedIndicator") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
+        FocusedIndicator = this.Visual?.GetGraphicalUiElementByName("FocusedIndicator") as global::Gum.GueDeriving.NineSliceRuntime;
         CustomInitialize();
     }
     //Not assigning variables because Object Instantiation Type is set to By Name rather than Fully In Code

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/ComboBox.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/ComboBox.Generated.cs
@@ -3,11 +3,11 @@ using CodeGenProject.Components.Controls;
 using CodeGenProject.Components.Elements;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGenProject.Components.Controls;
@@ -18,7 +18,7 @@ partial class ComboBox : global::Gum.Forms.Controls.ComboBox
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/ComboBox");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/ComboBox - did you forget to load a Gum project?");
@@ -88,11 +88,11 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     protected override void ReactToVisualChanged()
     {
         base.ReactToVisualChanged();
-        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
-        TextInstance = this.Visual?.GetGraphicalUiElementByName("TextInstance") as global::MonoGameGum.GueDeriving.TextRuntime;
+        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::Gum.GueDeriving.NineSliceRuntime;
+        TextInstance = this.Visual?.GetGraphicalUiElementByName("TextInstance") as global::Gum.GueDeriving.TextRuntime;
         ListBoxInstance = global::Gum.Forms.GraphicalUiElementFormsExtensions.TryGetFrameworkElementByName<ListBox>(this.Visual,"ListBoxInstance");
         IconInstance = global::Gum.Forms.GraphicalUiElementFormsExtensions.TryGetFrameworkElementByName<Icon>(this.Visual,"IconInstance");
-        FocusedIndicator = this.Visual?.GetGraphicalUiElementByName("FocusedIndicator") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
+        FocusedIndicator = this.Visual?.GetGraphicalUiElementByName("FocusedIndicator") as global::Gum.GueDeriving.NineSliceRuntime;
         CustomInitialize();
     }
     //Not assigning variables because Object Instantiation Type is set to By Name rather than Fully In Code

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/DialogBox.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/DialogBox.Generated.cs
@@ -2,11 +2,11 @@
 using CodeGenProject.Components.Elements;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGenProject.Components.Controls;
@@ -17,7 +17,7 @@ partial class DialogBox : global::Gum.Forms.Controls.FrameworkElement
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/DialogBox");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/DialogBox - did you forget to load a Gum project?");
@@ -49,8 +49,8 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     protected override void ReactToVisualChanged()
     {
         base.ReactToVisualChanged();
-        NineSliceInstance = this.Visual?.GetGraphicalUiElementByName("NineSliceInstance") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
-        TextInstance = this.Visual?.GetGraphicalUiElementByName("TextInstance") as global::MonoGameGum.GueDeriving.TextRuntime;
+        NineSliceInstance = this.Visual?.GetGraphicalUiElementByName("NineSliceInstance") as global::Gum.GueDeriving.NineSliceRuntime;
+        TextInstance = this.Visual?.GetGraphicalUiElementByName("TextInstance") as global::Gum.GueDeriving.TextRuntime;
         ContinueIndicatorInstance = global::Gum.Forms.GraphicalUiElementFormsExtensions.TryGetFrameworkElementByName<Icon>(this.Visual,"ContinueIndicatorInstance");
         CustomInitialize();
     }

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/InputDeviceSelectionItem.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/InputDeviceSelectionItem.Generated.cs
@@ -3,11 +3,11 @@ using CodeGenProject.Components.Controls;
 using CodeGenProject.Components.Elements;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGenProject.Components.Controls;
@@ -18,7 +18,7 @@ partial class InputDeviceSelectionItem : global::Gum.Forms.Controls.FrameworkEle
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/InputDeviceSelectionItem");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/InputDeviceSelectionItem - did you forget to load a Gum project?");
@@ -81,9 +81,9 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     protected override void ReactToVisualChanged()
     {
         base.ReactToVisualChanged();
-        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
+        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::Gum.GueDeriving.NineSliceRuntime;
         IconInstance = global::Gum.Forms.GraphicalUiElementFormsExtensions.TryGetFrameworkElementByName<Icon>(this.Visual,"IconInstance");
-        TextInstance = this.Visual?.GetGraphicalUiElementByName("TextInstance") as global::MonoGameGum.GueDeriving.TextRuntime;
+        TextInstance = this.Visual?.GetGraphicalUiElementByName("TextInstance") as global::Gum.GueDeriving.TextRuntime;
         RemoveDeviceButtonInstance = global::Gum.Forms.GraphicalUiElementFormsExtensions.TryGetFrameworkElementByName<ButtonClose>(this.Visual,"RemoveDeviceButtonInstance");
         CustomInitialize();
     }

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/InputDeviceSelector.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/InputDeviceSelector.Generated.cs
@@ -2,11 +2,11 @@
 using CodeGenProject.Components.Controls;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGenProject.Components.Controls;
@@ -17,7 +17,7 @@ partial class InputDeviceSelector : global::Gum.Forms.Controls.FrameworkElement
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/InputDeviceSelector");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/InputDeviceSelector - did you forget to load a Gum project?");
@@ -56,12 +56,12 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     protected override void ReactToVisualChanged()
     {
         base.ReactToVisualChanged();
-        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
-        TextInstance = this.Visual?.GetGraphicalUiElementByName("TextInstance") as global::MonoGameGum.GueDeriving.TextRuntime;
-        TextInstance1 = this.Visual?.GetGraphicalUiElementByName("TextInstance1") as global::MonoGameGum.GueDeriving.TextRuntime;
-        ContainerInstance1 = this.Visual?.GetGraphicalUiElementByName("ContainerInstance1") as global::MonoGameGum.GueDeriving.ContainerRuntime;
-        InputDeviceContainerInstance = this.Visual?.GetGraphicalUiElementByName("InputDeviceContainerInstance") as global::MonoGameGum.GueDeriving.ContainerRuntime;
-        ContainerInstance2 = this.Visual?.GetGraphicalUiElementByName("ContainerInstance2") as global::MonoGameGum.GueDeriving.ContainerRuntime;
+        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::Gum.GueDeriving.NineSliceRuntime;
+        TextInstance = this.Visual?.GetGraphicalUiElementByName("TextInstance") as global::Gum.GueDeriving.TextRuntime;
+        TextInstance1 = this.Visual?.GetGraphicalUiElementByName("TextInstance1") as global::Gum.GueDeriving.TextRuntime;
+        ContainerInstance1 = this.Visual?.GetGraphicalUiElementByName("ContainerInstance1") as global::Gum.GueDeriving.ContainerRuntime;
+        InputDeviceContainerInstance = this.Visual?.GetGraphicalUiElementByName("InputDeviceContainerInstance") as global::Gum.GueDeriving.ContainerRuntime;
+        ContainerInstance2 = this.Visual?.GetGraphicalUiElementByName("ContainerInstance2") as global::Gum.GueDeriving.ContainerRuntime;
         InputDeviceSelectionItemInstance = global::Gum.Forms.GraphicalUiElementFormsExtensions.TryGetFrameworkElementByName<InputDeviceSelectionItem>(this.Visual,"InputDeviceSelectionItemInstance");
         InputDeviceSelectionItemInstance1 = global::Gum.Forms.GraphicalUiElementFormsExtensions.TryGetFrameworkElementByName<InputDeviceSelectionItem>(this.Visual,"InputDeviceSelectionItemInstance1");
         InputDeviceSelectionItemInstance2 = global::Gum.Forms.GraphicalUiElementFormsExtensions.TryGetFrameworkElementByName<InputDeviceSelectionItem>(this.Visual,"InputDeviceSelectionItemInstance2");

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/Keyboard.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/Keyboard.Generated.cs
@@ -3,12 +3,12 @@ using CodeGenProject.Components.Controls;
 using CodeGenProject.Components.Elements;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.StateAnimation.Runtime;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGenProject.Components.Controls;
@@ -19,7 +19,7 @@ partial class Keyboard : global::Gum.Forms.Controls.FrameworkElement
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/Keyboard");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/Keyboard - did you forget to load a Gum project?");
@@ -139,8 +139,8 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     protected override void ReactToVisualChanged()
     {
         base.ReactToVisualChanged();
-        Row1Keys = this.Visual?.GetGraphicalUiElementByName("Row1Keys") as global::MonoGameGum.GueDeriving.ContainerRuntime;
-        AllRows = this.Visual?.GetGraphicalUiElementByName("AllRows") as global::MonoGameGum.GueDeriving.ContainerRuntime;
+        Row1Keys = this.Visual?.GetGraphicalUiElementByName("Row1Keys") as global::Gum.GueDeriving.ContainerRuntime;
+        AllRows = this.Visual?.GetGraphicalUiElementByName("AllRows") as global::Gum.GueDeriving.ContainerRuntime;
         Key1 = global::Gum.Forms.GraphicalUiElementFormsExtensions.TryGetFrameworkElementByName<KeyboardKey>(this.Visual,"Key1");
         KeyQ = global::Gum.Forms.GraphicalUiElementFormsExtensions.TryGetFrameworkElementByName<KeyboardKey>(this.Visual,"KeyQ");
         KeyA = global::Gum.Forms.GraphicalUiElementFormsExtensions.TryGetFrameworkElementByName<KeyboardKey>(this.Visual,"KeyA");
@@ -187,15 +187,15 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
         Key8 = global::Gum.Forms.GraphicalUiElementFormsExtensions.TryGetFrameworkElementByName<KeyboardKey>(this.Visual,"Key8");
         Key9 = global::Gum.Forms.GraphicalUiElementFormsExtensions.TryGetFrameworkElementByName<KeyboardKey>(this.Visual,"Key9");
         Key0 = global::Gum.Forms.GraphicalUiElementFormsExtensions.TryGetFrameworkElementByName<KeyboardKey>(this.Visual,"Key0");
-        Row2Keys = this.Visual?.GetGraphicalUiElementByName("Row2Keys") as global::MonoGameGum.GueDeriving.ContainerRuntime;
-        Row3Keys = this.Visual?.GetGraphicalUiElementByName("Row3Keys") as global::MonoGameGum.GueDeriving.ContainerRuntime;
-        Row4Keys = this.Visual?.GetGraphicalUiElementByName("Row4Keys") as global::MonoGameGum.GueDeriving.ContainerRuntime;
-        Row5Keys = this.Visual?.GetGraphicalUiElementByName("Row5Keys") as global::MonoGameGum.GueDeriving.ContainerRuntime;
+        Row2Keys = this.Visual?.GetGraphicalUiElementByName("Row2Keys") as global::Gum.GueDeriving.ContainerRuntime;
+        Row3Keys = this.Visual?.GetGraphicalUiElementByName("Row3Keys") as global::Gum.GueDeriving.ContainerRuntime;
+        Row4Keys = this.Visual?.GetGraphicalUiElementByName("Row4Keys") as global::Gum.GueDeriving.ContainerRuntime;
+        Row5Keys = this.Visual?.GetGraphicalUiElementByName("Row5Keys") as global::Gum.GueDeriving.ContainerRuntime;
         KeyBackspace = global::Gum.Forms.GraphicalUiElementFormsExtensions.TryGetFrameworkElementByName<KeyboardKey>(this.Visual,"KeyBackspace");
         KeyReturn = global::Gum.Forms.GraphicalUiElementFormsExtensions.TryGetFrameworkElementByName<KeyboardKey>(this.Visual,"KeyReturn");
         KeyLeft = global::Gum.Forms.GraphicalUiElementFormsExtensions.TryGetFrameworkElementByName<KeyboardKey>(this.Visual,"KeyLeft");
         KeyRight = global::Gum.Forms.GraphicalUiElementFormsExtensions.TryGetFrameworkElementByName<KeyboardKey>(this.Visual,"KeyRight");
-        HighlightRectangle = this.Visual?.GetGraphicalUiElementByName("HighlightRectangle") as global::MonoGameGum.GueDeriving.RectangleRuntime;
+        HighlightRectangle = this.Visual?.GetGraphicalUiElementByName("HighlightRectangle") as global::Gum.GueDeriving.RectangleRuntime;
         IconInstance = global::Gum.Forms.GraphicalUiElementFormsExtensions.TryGetFrameworkElementByName<Icon>(this.Visual,"IconInstance");
         IconInstance1 = global::Gum.Forms.GraphicalUiElementFormsExtensions.TryGetFrameworkElementByName<Icon>(this.Visual,"IconInstance1");
         IconInstance2 = global::Gum.Forms.GraphicalUiElementFormsExtensions.TryGetFrameworkElementByName<Icon>(this.Visual,"IconInstance2");

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/KeyboardKey.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/KeyboardKey.Generated.cs
@@ -1,12 +1,12 @@
 //Code for Controls/KeyboardKey (Container)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.StateAnimation.Runtime;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGenProject.Components.Controls;
@@ -17,7 +17,7 @@ partial class KeyboardKey : global::Gum.Forms.Controls.Button
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/KeyboardKey");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/KeyboardKey - did you forget to load a Gum project?");
@@ -85,9 +85,9 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     protected override void ReactToVisualChanged()
     {
         base.ReactToVisualChanged();
-        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
-        TextInstance = this.Visual?.GetGraphicalUiElementByName("TextInstance") as global::MonoGameGum.GueDeriving.TextRuntime;
-        FocusedIndicator = this.Visual?.GetGraphicalUiElementByName("FocusedIndicator") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
+        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::Gum.GueDeriving.NineSliceRuntime;
+        TextInstance = this.Visual?.GetGraphicalUiElementByName("TextInstance") as global::Gum.GueDeriving.TextRuntime;
+        FocusedIndicator = this.Visual?.GetGraphicalUiElementByName("FocusedIndicator") as global::Gum.GueDeriving.NineSliceRuntime;
         CustomInitialize();
     }
     //Not assigning variables because Object Instantiation Type is set to By Name rather than Fully In Code

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/Label.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/Label.Generated.cs
@@ -1,11 +1,11 @@
 //Code for Controls/Label (Text)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGenProject.Components.Controls;
@@ -16,7 +16,7 @@ partial class Label : global::Gum.Forms.Controls.Label
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.TextRuntime();
+            var visual = new global::Gum.GueDeriving.TextRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/Label");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/Label - did you forget to load a Gum project?");

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/ListBox.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/ListBox.Generated.cs
@@ -2,11 +2,11 @@
 using CodeGenProject.Components.Controls;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGenProject.Components.Controls;
@@ -17,7 +17,7 @@ partial class ListBox : global::Gum.Forms.Controls.ListBox
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/ListBox");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/ListBox - did you forget to load a Gum project?");
@@ -86,13 +86,13 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     protected override void ReactToVisualChanged()
     {
         base.ReactToVisualChanged();
-        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
+        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::Gum.GueDeriving.NineSliceRuntime;
         VerticalScrollBarInstance = global::Gum.Forms.GraphicalUiElementFormsExtensions.TryGetFrameworkElementByName<ScrollBar>(this.Visual,"VerticalScrollBarInstance");
-        ClipContainerInstance = this.Visual?.GetGraphicalUiElementByName("ClipContainerInstance") as global::MonoGameGum.GueDeriving.ContainerRuntime;
-        InnerPanelInstance = this.Visual?.GetGraphicalUiElementByName("InnerPanelInstance") as global::MonoGameGum.GueDeriving.ContainerRuntime;
-        FocusedIndicator = this.Visual?.GetGraphicalUiElementByName("FocusedIndicator") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
-        ClipAndScrollContainer = this.Visual?.GetGraphicalUiElementByName("ClipAndScrollContainer") as global::MonoGameGum.GueDeriving.ContainerRuntime;
-        ClipContainerParent = this.Visual?.GetGraphicalUiElementByName("ClipContainerParent") as global::MonoGameGum.GueDeriving.ContainerRuntime;
+        ClipContainerInstance = this.Visual?.GetGraphicalUiElementByName("ClipContainerInstance") as global::Gum.GueDeriving.ContainerRuntime;
+        InnerPanelInstance = this.Visual?.GetGraphicalUiElementByName("InnerPanelInstance") as global::Gum.GueDeriving.ContainerRuntime;
+        FocusedIndicator = this.Visual?.GetGraphicalUiElementByName("FocusedIndicator") as global::Gum.GueDeriving.NineSliceRuntime;
+        ClipAndScrollContainer = this.Visual?.GetGraphicalUiElementByName("ClipAndScrollContainer") as global::Gum.GueDeriving.ContainerRuntime;
+        ClipContainerParent = this.Visual?.GetGraphicalUiElementByName("ClipContainerParent") as global::Gum.GueDeriving.ContainerRuntime;
         CustomInitialize();
     }
     //Not assigning variables because Object Instantiation Type is set to By Name rather than Fully In Code

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/ListBoxItem.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/ListBoxItem.Generated.cs
@@ -1,11 +1,11 @@
 //Code for Controls/ListBoxItem (Container)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGenProject.Components.Controls;
@@ -16,7 +16,7 @@ partial class ListBoxItem : global::Gum.Forms.Controls.ListBoxItem
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/ListBoxItem");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/ListBoxItem - did you forget to load a Gum project?");
@@ -87,9 +87,9 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     protected override void ReactToVisualChanged()
     {
         base.ReactToVisualChanged();
-        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
-        TextInstance = this.Visual?.GetGraphicalUiElementByName("TextInstance") as global::MonoGameGum.GueDeriving.TextRuntime;
-        FocusedIndicator = this.Visual?.GetGraphicalUiElementByName("FocusedIndicator") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
+        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::Gum.GueDeriving.NineSliceRuntime;
+        TextInstance = this.Visual?.GetGraphicalUiElementByName("TextInstance") as global::Gum.GueDeriving.TextRuntime;
+        FocusedIndicator = this.Visual?.GetGraphicalUiElementByName("FocusedIndicator") as global::Gum.GueDeriving.NineSliceRuntime;
         CustomInitialize();
     }
     //Not assigning variables because Object Instantiation Type is set to By Name rather than Fully In Code

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/Menu.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/Menu.Generated.cs
@@ -1,11 +1,11 @@
 //Code for Controls/Menu (Container)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGenProject.Components.Controls;
@@ -16,7 +16,7 @@ partial class Menu : global::Gum.Forms.Controls.Menu
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/Menu");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/Menu - did you forget to load a Gum project?");
@@ -48,8 +48,8 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     protected override void ReactToVisualChanged()
     {
         base.ReactToVisualChanged();
-        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
-        InnerPanelInstance = this.Visual?.GetGraphicalUiElementByName("InnerPanelInstance") as global::MonoGameGum.GueDeriving.ContainerRuntime;
+        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::Gum.GueDeriving.NineSliceRuntime;
+        InnerPanelInstance = this.Visual?.GetGraphicalUiElementByName("InnerPanelInstance") as global::Gum.GueDeriving.ContainerRuntime;
         CustomInitialize();
     }
     //Not assigning variables because Object Instantiation Type is set to By Name rather than Fully In Code

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/MenuItem.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/MenuItem.Generated.cs
@@ -1,11 +1,11 @@
 //Code for Controls/MenuItem (Container)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGenProject.Components.Controls;
@@ -16,7 +16,7 @@ partial class MenuItem : global::Gum.Forms.Controls.MenuItem
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/MenuItem");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/MenuItem - did you forget to load a Gum project?");
@@ -83,10 +83,10 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     protected override void ReactToVisualChanged()
     {
         base.ReactToVisualChanged();
-        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
-        TextInstance = this.Visual?.GetGraphicalUiElementByName("TextInstance") as global::MonoGameGum.GueDeriving.TextRuntime;
-        SubmenuIndicatorInstance = this.Visual?.GetGraphicalUiElementByName("SubmenuIndicatorInstance") as global::MonoGameGum.GueDeriving.TextRuntime;
-        ContainerInstance = this.Visual?.GetGraphicalUiElementByName("ContainerInstance") as global::MonoGameGum.GueDeriving.ContainerRuntime;
+        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::Gum.GueDeriving.NineSliceRuntime;
+        TextInstance = this.Visual?.GetGraphicalUiElementByName("TextInstance") as global::Gum.GueDeriving.TextRuntime;
+        SubmenuIndicatorInstance = this.Visual?.GetGraphicalUiElementByName("SubmenuIndicatorInstance") as global::Gum.GueDeriving.TextRuntime;
+        ContainerInstance = this.Visual?.GetGraphicalUiElementByName("ContainerInstance") as global::Gum.GueDeriving.ContainerRuntime;
         CustomInitialize();
     }
     //Not assigning variables because Object Instantiation Type is set to By Name rather than Fully In Code

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/Panel.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/Panel.Generated.cs
@@ -1,11 +1,11 @@
 //Code for Controls/Panel (Container)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGenProject.Components.Controls;
@@ -16,7 +16,7 @@ partial class Panel : global::Gum.Forms.Controls.Panel
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/Panel");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/Panel - did you forget to load a Gum project?");

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/PasswordBox.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/PasswordBox.Generated.cs
@@ -1,11 +1,11 @@
 //Code for Controls/PasswordBox (Container)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGenProject.Components.Controls;
@@ -16,7 +16,7 @@ partial class PasswordBox : global::Gum.Forms.Controls.PasswordBox
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/PasswordBox");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/PasswordBox - did you forget to load a Gum project?");
@@ -90,12 +90,12 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     protected override void ReactToVisualChanged()
     {
         base.ReactToVisualChanged();
-        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
-        SelectionInstance = this.Visual?.GetGraphicalUiElementByName("SelectionInstance") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
-        TextInstance = this.Visual?.GetGraphicalUiElementByName("TextInstance") as global::MonoGameGum.GueDeriving.TextRuntime;
-        PlaceholderTextInstance = this.Visual?.GetGraphicalUiElementByName("PlaceholderTextInstance") as global::MonoGameGum.GueDeriving.TextRuntime;
-        FocusedIndicator = this.Visual?.GetGraphicalUiElementByName("FocusedIndicator") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
-        CaretInstance = this.Visual?.GetGraphicalUiElementByName("CaretInstance") as global::MonoGameGum.GueDeriving.SpriteRuntime;
+        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::Gum.GueDeriving.NineSliceRuntime;
+        SelectionInstance = this.Visual?.GetGraphicalUiElementByName("SelectionInstance") as global::Gum.GueDeriving.NineSliceRuntime;
+        TextInstance = this.Visual?.GetGraphicalUiElementByName("TextInstance") as global::Gum.GueDeriving.TextRuntime;
+        PlaceholderTextInstance = this.Visual?.GetGraphicalUiElementByName("PlaceholderTextInstance") as global::Gum.GueDeriving.TextRuntime;
+        FocusedIndicator = this.Visual?.GetGraphicalUiElementByName("FocusedIndicator") as global::Gum.GueDeriving.NineSliceRuntime;
+        CaretInstance = this.Visual?.GetGraphicalUiElementByName("CaretInstance") as global::Gum.GueDeriving.SpriteRuntime;
         CustomInitialize();
     }
     //Not assigning variables because Object Instantiation Type is set to By Name rather than Fully In Code

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/PlayerJoinView.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/PlayerJoinView.Generated.cs
@@ -2,11 +2,11 @@
 using CodeGenProject.Components.Controls;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGenProject.Components.Controls;
@@ -17,7 +17,7 @@ partial class PlayerJoinView : global::Gum.Forms.Controls.FrameworkElement
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/PlayerJoinView");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/PlayerJoinView - did you forget to load a Gum project?");
@@ -51,7 +51,7 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     protected override void ReactToVisualChanged()
     {
         base.ReactToVisualChanged();
-        InnerPanelInstance = this.Visual?.GetGraphicalUiElementByName("InnerPanelInstance") as global::MonoGameGum.GueDeriving.ContainerRuntime;
+        InnerPanelInstance = this.Visual?.GetGraphicalUiElementByName("InnerPanelInstance") as global::Gum.GueDeriving.ContainerRuntime;
         PlayerJoinViewItem1 = global::Gum.Forms.GraphicalUiElementFormsExtensions.TryGetFrameworkElementByName<PlayerJoinViewItem>(this.Visual,"PlayerJoinViewItem1");
         PlayerJoinViewItem2 = global::Gum.Forms.GraphicalUiElementFormsExtensions.TryGetFrameworkElementByName<PlayerJoinViewItem>(this.Visual,"PlayerJoinViewItem2");
         PlayerJoinViewItem3 = global::Gum.Forms.GraphicalUiElementFormsExtensions.TryGetFrameworkElementByName<PlayerJoinViewItem>(this.Visual,"PlayerJoinViewItem3");

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/PlayerJoinViewItem.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/PlayerJoinViewItem.Generated.cs
@@ -2,11 +2,11 @@
 using CodeGenProject.Components.Elements;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGenProject.Components.Controls;
@@ -17,7 +17,7 @@ partial class PlayerJoinViewItem : global::Gum.Forms.Controls.FrameworkElement
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/PlayerJoinViewItem");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/PlayerJoinViewItem - did you forget to load a Gum project?");
@@ -150,8 +150,8 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     protected override void ReactToVisualChanged()
     {
         base.ReactToVisualChanged();
-        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
-        ControllerDisplayNameTextInstance = this.Visual?.GetGraphicalUiElementByName("ControllerDisplayNameTextInstance") as global::MonoGameGum.GueDeriving.TextRuntime;
+        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::Gum.GueDeriving.NineSliceRuntime;
+        ControllerDisplayNameTextInstance = this.Visual?.GetGraphicalUiElementByName("ControllerDisplayNameTextInstance") as global::Gum.GueDeriving.TextRuntime;
         InputDeviceIcon = global::Gum.Forms.GraphicalUiElementFormsExtensions.TryGetFrameworkElementByName<Icon>(this.Visual,"InputDeviceIcon");
         CustomInitialize();
     }

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/RadioButton.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/RadioButton.Generated.cs
@@ -2,11 +2,11 @@
 using CodeGenProject.Components.Elements;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGenProject.Components.Controls;
@@ -17,7 +17,7 @@ partial class RadioButton : global::Gum.Forms.Controls.RadioButton
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/RadioButton");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/RadioButton - did you forget to load a Gum project?");
@@ -94,10 +94,10 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     protected override void ReactToVisualChanged()
     {
         base.ReactToVisualChanged();
-        RadioBackground = this.Visual?.GetGraphicalUiElementByName("RadioBackground") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
+        RadioBackground = this.Visual?.GetGraphicalUiElementByName("RadioBackground") as global::Gum.GueDeriving.NineSliceRuntime;
         Radio = global::Gum.Forms.GraphicalUiElementFormsExtensions.TryGetFrameworkElementByName<Icon>(this.Visual,"Radio");
-        TextInstance = this.Visual?.GetGraphicalUiElementByName("TextInstance") as global::MonoGameGum.GueDeriving.TextRuntime;
-        FocusedIndicator = this.Visual?.GetGraphicalUiElementByName("FocusedIndicator") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
+        TextInstance = this.Visual?.GetGraphicalUiElementByName("TextInstance") as global::Gum.GueDeriving.TextRuntime;
+        FocusedIndicator = this.Visual?.GetGraphicalUiElementByName("FocusedIndicator") as global::Gum.GueDeriving.NineSliceRuntime;
         CustomInitialize();
     }
     //Not assigning variables because Object Instantiation Type is set to By Name rather than Fully In Code

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/ScrollBar.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/ScrollBar.Generated.cs
@@ -2,11 +2,11 @@
 using CodeGenProject.Components.Controls;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGenProject.Components.Controls;
@@ -17,7 +17,7 @@ partial class ScrollBar : global::Gum.Forms.Controls.ScrollBar
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/ScrollBar");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/ScrollBar - did you forget to load a Gum project?");
@@ -82,8 +82,8 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
         base.ReactToVisualChanged();
         UpButtonInstance = global::Gum.Forms.GraphicalUiElementFormsExtensions.TryGetFrameworkElementByName<ButtonIcon>(this.Visual,"UpButtonInstance");
         DownButtonInstance = global::Gum.Forms.GraphicalUiElementFormsExtensions.TryGetFrameworkElementByName<ButtonIcon>(this.Visual,"DownButtonInstance");
-        TrackInstance = this.Visual?.GetGraphicalUiElementByName("TrackInstance") as global::MonoGameGum.GueDeriving.ContainerRuntime;
-        TrackBackground = this.Visual?.GetGraphicalUiElementByName("TrackBackground") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
+        TrackInstance = this.Visual?.GetGraphicalUiElementByName("TrackInstance") as global::Gum.GueDeriving.ContainerRuntime;
+        TrackBackground = this.Visual?.GetGraphicalUiElementByName("TrackBackground") as global::Gum.GueDeriving.NineSliceRuntime;
         ThumbInstance = global::Gum.Forms.GraphicalUiElementFormsExtensions.TryGetFrameworkElementByName<ButtonStandard>(this.Visual,"ThumbInstance");
         CustomInitialize();
     }

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/ScrollViewer.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/ScrollViewer.Generated.cs
@@ -2,11 +2,11 @@
 using CodeGenProject.Components.Controls;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGenProject.Components.Controls;
@@ -17,7 +17,7 @@ partial class ScrollViewer : global::Gum.Forms.Controls.ScrollViewer
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/ScrollViewer");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/ScrollViewer - did you forget to load a Gum project?");
@@ -112,11 +112,11 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     protected override void ReactToVisualChanged()
     {
         base.ReactToVisualChanged();
-        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
+        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::Gum.GueDeriving.NineSliceRuntime;
         VerticalScrollBarInstance = global::Gum.Forms.GraphicalUiElementFormsExtensions.TryGetFrameworkElementByName<ScrollBar>(this.Visual,"VerticalScrollBarInstance");
-        ClipContainerInstance = this.Visual?.GetGraphicalUiElementByName("ClipContainerInstance") as global::MonoGameGum.GueDeriving.ContainerRuntime;
-        InnerPanelInstance = this.Visual?.GetGraphicalUiElementByName("InnerPanelInstance") as global::MonoGameGum.GueDeriving.ContainerRuntime;
-        FocusedIndicator = this.Visual?.GetGraphicalUiElementByName("FocusedIndicator") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
+        ClipContainerInstance = this.Visual?.GetGraphicalUiElementByName("ClipContainerInstance") as global::Gum.GueDeriving.ContainerRuntime;
+        InnerPanelInstance = this.Visual?.GetGraphicalUiElementByName("InnerPanelInstance") as global::Gum.GueDeriving.ContainerRuntime;
+        FocusedIndicator = this.Visual?.GetGraphicalUiElementByName("FocusedIndicator") as global::Gum.GueDeriving.NineSliceRuntime;
         CustomInitialize();
     }
     //Not assigning variables because Object Instantiation Type is set to By Name rather than Fully In Code

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/SettingsView.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/SettingsView.Generated.cs
@@ -2,11 +2,11 @@
 using CodeGenProject.Components.Controls;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGenProject.Components.Controls;
@@ -17,7 +17,7 @@ partial class SettingsView : global::Gum.Forms.Controls.FrameworkElement
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/SettingsView");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/SettingsView - did you forget to load a Gum project?");

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/Slider.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/Slider.Generated.cs
@@ -2,11 +2,11 @@
 using CodeGenProject.Components.Controls;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGenProject.Components.Controls;
@@ -17,7 +17,7 @@ partial class Slider : global::Gum.Forms.Controls.Slider
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/Slider");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/Slider - did you forget to load a Gum project?");
@@ -92,10 +92,10 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     protected override void ReactToVisualChanged()
     {
         base.ReactToVisualChanged();
-        TrackInstance = this.Visual?.GetGraphicalUiElementByName("TrackInstance") as global::MonoGameGum.GueDeriving.ContainerRuntime;
-        TrackBackground = this.Visual?.GetGraphicalUiElementByName("TrackBackground") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
+        TrackInstance = this.Visual?.GetGraphicalUiElementByName("TrackInstance") as global::Gum.GueDeriving.ContainerRuntime;
+        TrackBackground = this.Visual?.GetGraphicalUiElementByName("TrackBackground") as global::Gum.GueDeriving.NineSliceRuntime;
         ThumbInstance = global::Gum.Forms.GraphicalUiElementFormsExtensions.TryGetFrameworkElementByName<ButtonStandard>(this.Visual,"ThumbInstance");
-        FocusedIndicator = this.Visual?.GetGraphicalUiElementByName("FocusedIndicator") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
+        FocusedIndicator = this.Visual?.GetGraphicalUiElementByName("FocusedIndicator") as global::Gum.GueDeriving.NineSliceRuntime;
         CustomInitialize();
     }
     //Not assigning variables because Object Instantiation Type is set to By Name rather than Fully In Code

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/SplitterStandard.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/SplitterStandard.Generated.cs
@@ -1,11 +1,11 @@
 //Code for Controls/SplitterStandard (Container)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGenProject.Components.Controls;
@@ -16,7 +16,7 @@ partial class SplitterStandard : global::Gum.Forms.Controls.Splitter
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/SplitterStandard");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/SplitterStandard - did you forget to load a Gum project?");
@@ -47,7 +47,7 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     protected override void ReactToVisualChanged()
     {
         base.ReactToVisualChanged();
-        NineSliceInstance = this.Visual?.GetGraphicalUiElementByName("NineSliceInstance") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
+        NineSliceInstance = this.Visual?.GetGraphicalUiElementByName("NineSliceInstance") as global::Gum.GueDeriving.NineSliceRuntime;
         CustomInitialize();
     }
     //Not assigning variables because Object Instantiation Type is set to By Name rather than Fully In Code

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/StackPanel.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/StackPanel.Generated.cs
@@ -1,11 +1,11 @@
 //Code for Controls/StackPanel (Container)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGenProject.Components.Controls;
@@ -16,7 +16,7 @@ partial class StackPanel : global::Gum.Forms.Controls.StackPanel
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/StackPanel");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/StackPanel - did you forget to load a Gum project?");

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/TextBox.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/TextBox.Generated.cs
@@ -1,12 +1,12 @@
 //Code for Controls/TextBox (Container)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.StateAnimation.Runtime;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGenProject.Components.Controls;
@@ -17,7 +17,7 @@ partial class TextBox : global::Gum.Forms.Controls.TextBox
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/TextBox");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/TextBox - did you forget to load a Gum project?");
@@ -125,13 +125,13 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     protected override void ReactToVisualChanged()
     {
         base.ReactToVisualChanged();
-        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
-        ClipContainer = this.Visual?.GetGraphicalUiElementByName("ClipContainer") as global::MonoGameGum.GueDeriving.ContainerRuntime;
-        SelectionInstance = this.Visual?.GetGraphicalUiElementByName("SelectionInstance") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
-        TextInstance = this.Visual?.GetGraphicalUiElementByName("TextInstance") as global::MonoGameGum.GueDeriving.TextRuntime;
-        PlaceholderTextInstance = this.Visual?.GetGraphicalUiElementByName("PlaceholderTextInstance") as global::MonoGameGum.GueDeriving.TextRuntime;
-        FocusedIndicator = this.Visual?.GetGraphicalUiElementByName("FocusedIndicator") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
-        CaretInstance = this.Visual?.GetGraphicalUiElementByName("CaretInstance") as global::MonoGameGum.GueDeriving.SpriteRuntime;
+        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::Gum.GueDeriving.NineSliceRuntime;
+        ClipContainer = this.Visual?.GetGraphicalUiElementByName("ClipContainer") as global::Gum.GueDeriving.ContainerRuntime;
+        SelectionInstance = this.Visual?.GetGraphicalUiElementByName("SelectionInstance") as global::Gum.GueDeriving.NineSliceRuntime;
+        TextInstance = this.Visual?.GetGraphicalUiElementByName("TextInstance") as global::Gum.GueDeriving.TextRuntime;
+        PlaceholderTextInstance = this.Visual?.GetGraphicalUiElementByName("PlaceholderTextInstance") as global::Gum.GueDeriving.TextRuntime;
+        FocusedIndicator = this.Visual?.GetGraphicalUiElementByName("FocusedIndicator") as global::Gum.GueDeriving.NineSliceRuntime;
+        CaretInstance = this.Visual?.GetGraphicalUiElementByName("CaretInstance") as global::Gum.GueDeriving.SpriteRuntime;
         CustomInitialize();
     }
     //Not assigning variables because Object Instantiation Type is set to By Name rather than Fully In Code

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/Toast.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/Toast.Generated.cs
@@ -1,11 +1,11 @@
 //Code for Controls/Toast (Container)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGenProject.Components.Controls;
@@ -16,7 +16,7 @@ partial class Toast : global::Gum.Forms.Controls.FrameworkElement
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/Toast");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/Toast - did you forget to load a Gum project?");
@@ -47,8 +47,8 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     protected override void ReactToVisualChanged()
     {
         base.ReactToVisualChanged();
-        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
-        TextInstance = this.Visual?.GetGraphicalUiElementByName("TextInstance") as global::MonoGameGum.GueDeriving.TextRuntime;
+        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::Gum.GueDeriving.NineSliceRuntime;
+        TextInstance = this.Visual?.GetGraphicalUiElementByName("TextInstance") as global::Gum.GueDeriving.TextRuntime;
         CustomInitialize();
     }
     //Not assigning variables because Object Instantiation Type is set to By Name rather than Fully In Code

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/TreeView.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/TreeView.Generated.cs
@@ -2,11 +2,11 @@
 using CodeGenProject.Components.Controls;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGenProject.Components.Controls;
@@ -17,7 +17,7 @@ partial class TreeView : global::Gum.Forms.Controls.FrameworkElement
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/TreeView");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/TreeView - did you forget to load a Gum project?");
@@ -51,11 +51,11 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     protected override void ReactToVisualChanged()
     {
         base.ReactToVisualChanged();
-        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
+        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::Gum.GueDeriving.NineSliceRuntime;
         VerticalScrollBarInstance = global::Gum.Forms.GraphicalUiElementFormsExtensions.TryGetFrameworkElementByName<ScrollBar>(this.Visual,"VerticalScrollBarInstance");
-        ClipContainerInstance = this.Visual?.GetGraphicalUiElementByName("ClipContainerInstance") as global::MonoGameGum.GueDeriving.ContainerRuntime;
-        InnerPanelInstance = this.Visual?.GetGraphicalUiElementByName("InnerPanelInstance") as global::MonoGameGum.GueDeriving.ContainerRuntime;
-        FocusedIndicator = this.Visual?.GetGraphicalUiElementByName("FocusedIndicator") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
+        ClipContainerInstance = this.Visual?.GetGraphicalUiElementByName("ClipContainerInstance") as global::Gum.GueDeriving.ContainerRuntime;
+        InnerPanelInstance = this.Visual?.GetGraphicalUiElementByName("InnerPanelInstance") as global::Gum.GueDeriving.ContainerRuntime;
+        FocusedIndicator = this.Visual?.GetGraphicalUiElementByName("FocusedIndicator") as global::Gum.GueDeriving.NineSliceRuntime;
         CustomInitialize();
     }
     //Not assigning variables because Object Instantiation Type is set to By Name rather than Fully In Code

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/TreeViewItem.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/TreeViewItem.Generated.cs
@@ -2,11 +2,11 @@
 using CodeGenProject.Components.Controls;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGenProject.Components.Controls;
@@ -17,7 +17,7 @@ partial class TreeViewItem : global::Gum.Forms.Controls.FrameworkElement
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/TreeViewItem");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/TreeViewItem - did you forget to load a Gum project?");
@@ -51,7 +51,7 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
         base.ReactToVisualChanged();
         ToggleButtonInstance = global::Gum.Forms.GraphicalUiElementFormsExtensions.TryGetFrameworkElementByName<TreeViewToggle>(this.Visual,"ToggleButtonInstance");
         ListBoxItemInstance = global::Gum.Forms.GraphicalUiElementFormsExtensions.TryGetFrameworkElementByName<ListBoxItem>(this.Visual,"ListBoxItemInstance");
-        InnerPanelInstance = this.Visual?.GetGraphicalUiElementByName("InnerPanelInstance") as global::MonoGameGum.GueDeriving.ContainerRuntime;
+        InnerPanelInstance = this.Visual?.GetGraphicalUiElementByName("InnerPanelInstance") as global::Gum.GueDeriving.ContainerRuntime;
         CustomInitialize();
     }
     //Not assigning variables because Object Instantiation Type is set to By Name rather than Fully In Code

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/TreeViewToggle.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/TreeViewToggle.Generated.cs
@@ -2,12 +2,12 @@
 using CodeGenProject.Components.Elements;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.StateAnimation.Runtime;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGenProject.Components.Controls;
@@ -18,7 +18,7 @@ partial class TreeViewToggle : global::Gum.Forms.Controls.FrameworkElement
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/TreeViewToggle");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/TreeViewToggle - did you forget to load a Gum project?");
@@ -85,7 +85,7 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     protected override void ReactToVisualChanged()
     {
         base.ReactToVisualChanged();
-        NineSliceInstance = this.Visual?.GetGraphicalUiElementByName("NineSliceInstance") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
+        NineSliceInstance = this.Visual?.GetGraphicalUiElementByName("NineSliceInstance") as global::Gum.GueDeriving.NineSliceRuntime;
         IconInstance = global::Gum.Forms.GraphicalUiElementFormsExtensions.TryGetFrameworkElementByName<Icon>(this.Visual,"IconInstance");
         CustomInitialize();
     }

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/UserControl.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/UserControl.Generated.cs
@@ -1,11 +1,11 @@
 //Code for Controls/UserControl (Container)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGenProject.Components.Controls;
@@ -16,7 +16,7 @@ partial class UserControl : global::Gum.Forms.Controls.FrameworkElement
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/UserControl");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/UserControl - did you forget to load a Gum project?");
@@ -46,7 +46,7 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     protected override void ReactToVisualChanged()
     {
         base.ReactToVisualChanged();
-        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
+        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::Gum.GueDeriving.NineSliceRuntime;
         CustomInitialize();
     }
     //Not assigning variables because Object Instantiation Type is set to By Name rather than Fully In Code

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/WindowStandard.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/WindowStandard.Generated.cs
@@ -2,11 +2,11 @@
 using CodeGenProject.Components.Controls;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGenProject.Components.Controls;
@@ -17,7 +17,7 @@ partial class WindowStandard : global::Gum.Forms.Window
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/WindowStandard");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/WindowStandard - did you forget to load a Gum project?");
@@ -58,7 +58,7 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     protected override void ReactToVisualChanged()
     {
         base.ReactToVisualChanged();
-        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
+        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::Gum.GueDeriving.NineSliceRuntime;
         InnerPanelInstance = global::Gum.Forms.GraphicalUiElementFormsExtensions.TryGetFrameworkElementByName<Panel>(this.Visual,"InnerPanelInstance");
         TitleBarInstance = global::Gum.Forms.GraphicalUiElementFormsExtensions.TryGetFrameworkElementByName<Panel>(this.Visual,"TitleBarInstance");
         BorderTopLeftInstance = global::Gum.Forms.GraphicalUiElementFormsExtensions.TryGetFrameworkElementByName<Panel>(this.Visual,"BorderTopLeftInstance");

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/Elements/CautionLines.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/Elements/CautionLines.Generated.cs
@@ -1,11 +1,11 @@
 //Code for Elements/CautionLines (Container)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGenProject.Components.Elements;
@@ -16,7 +16,7 @@ partial class CautionLines : global::Gum.Forms.Controls.FrameworkElement
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Elements/CautionLines");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Elements/CautionLines - did you forget to load a Gum project?");
@@ -53,7 +53,7 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     protected override void ReactToVisualChanged()
     {
         base.ReactToVisualChanged();
-        LinesSprite = this.Visual?.GetGraphicalUiElementByName("LinesSprite") as global::MonoGameGum.GueDeriving.SpriteRuntime;
+        LinesSprite = this.Visual?.GetGraphicalUiElementByName("LinesSprite") as global::Gum.GueDeriving.SpriteRuntime;
         CustomInitialize();
     }
     //Not assigning variables because Object Instantiation Type is set to By Name rather than Fully In Code

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/Elements/Divider.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/Elements/Divider.Generated.cs
@@ -1,11 +1,11 @@
 //Code for Elements/Divider (Container)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGenProject.Components.Elements;
@@ -16,7 +16,7 @@ partial class Divider : global::Gum.Forms.Controls.FrameworkElement
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Elements/Divider");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Elements/Divider - did you forget to load a Gum project?");
@@ -48,9 +48,9 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     protected override void ReactToVisualChanged()
     {
         base.ReactToVisualChanged();
-        AccentLeft = this.Visual?.GetGraphicalUiElementByName("AccentLeft") as global::MonoGameGum.GueDeriving.SpriteRuntime;
-        Line = this.Visual?.GetGraphicalUiElementByName("Line") as global::MonoGameGum.GueDeriving.SpriteRuntime;
-        AccentRight = this.Visual?.GetGraphicalUiElementByName("AccentRight") as global::MonoGameGum.GueDeriving.SpriteRuntime;
+        AccentLeft = this.Visual?.GetGraphicalUiElementByName("AccentLeft") as global::Gum.GueDeriving.SpriteRuntime;
+        Line = this.Visual?.GetGraphicalUiElementByName("Line") as global::Gum.GueDeriving.SpriteRuntime;
+        AccentRight = this.Visual?.GetGraphicalUiElementByName("AccentRight") as global::Gum.GueDeriving.SpriteRuntime;
         CustomInitialize();
     }
     //Not assigning variables because Object Instantiation Type is set to By Name rather than Fully In Code

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/Elements/DividerHorizontal.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/Elements/DividerHorizontal.Generated.cs
@@ -1,12 +1,12 @@
 //Code for Elements/DividerHorizontal (Container)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.StateAnimation.Runtime;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGenProject.Components.Elements;
@@ -17,7 +17,7 @@ partial class DividerHorizontal : global::Gum.Forms.Controls.FrameworkElement
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Elements/DividerHorizontal");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Elements/DividerHorizontal - did you forget to load a Gum project?");
@@ -49,9 +49,9 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     protected override void ReactToVisualChanged()
     {
         base.ReactToVisualChanged();
-        AccentLeft = this.Visual?.GetGraphicalUiElementByName("AccentLeft") as global::MonoGameGum.GueDeriving.SpriteRuntime;
-        Line = this.Visual?.GetGraphicalUiElementByName("Line") as global::MonoGameGum.GueDeriving.SpriteRuntime;
-        AccentRight = this.Visual?.GetGraphicalUiElementByName("AccentRight") as global::MonoGameGum.GueDeriving.SpriteRuntime;
+        AccentLeft = this.Visual?.GetGraphicalUiElementByName("AccentLeft") as global::Gum.GueDeriving.SpriteRuntime;
+        Line = this.Visual?.GetGraphicalUiElementByName("Line") as global::Gum.GueDeriving.SpriteRuntime;
+        AccentRight = this.Visual?.GetGraphicalUiElementByName("AccentRight") as global::Gum.GueDeriving.SpriteRuntime;
         CustomInitialize();
     }
     //Not assigning variables because Object Instantiation Type is set to By Name rather than Fully In Code

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/Elements/DividerVertical.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/Elements/DividerVertical.Generated.cs
@@ -1,12 +1,12 @@
 //Code for Elements/DividerVertical (Container)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.StateAnimation.Runtime;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGenProject.Components.Elements;
@@ -17,7 +17,7 @@ partial class DividerVertical : global::Gum.Forms.Controls.FrameworkElement
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Elements/DividerVertical");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Elements/DividerVertical - did you forget to load a Gum project?");
@@ -49,9 +49,9 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     protected override void ReactToVisualChanged()
     {
         base.ReactToVisualChanged();
-        AccentTop = this.Visual?.GetGraphicalUiElementByName("AccentTop") as global::MonoGameGum.GueDeriving.SpriteRuntime;
-        Line = this.Visual?.GetGraphicalUiElementByName("Line") as global::MonoGameGum.GueDeriving.SpriteRuntime;
-        AccentRight = this.Visual?.GetGraphicalUiElementByName("AccentRight") as global::MonoGameGum.GueDeriving.SpriteRuntime;
+        AccentTop = this.Visual?.GetGraphicalUiElementByName("AccentTop") as global::Gum.GueDeriving.SpriteRuntime;
+        Line = this.Visual?.GetGraphicalUiElementByName("Line") as global::Gum.GueDeriving.SpriteRuntime;
+        AccentRight = this.Visual?.GetGraphicalUiElementByName("AccentRight") as global::Gum.GueDeriving.SpriteRuntime;
         CustomInitialize();
     }
     //Not assigning variables because Object Instantiation Type is set to By Name rather than Fully In Code

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/Elements/Icon.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/Elements/Icon.Generated.cs
@@ -1,12 +1,12 @@
 //Code for Elements/Icon (Container)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.StateAnimation.Runtime;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGenProject.Components.Elements;
@@ -17,7 +17,7 @@ partial class Icon : global::Gum.Forms.Controls.FrameworkElement
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Elements/Icon");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Elements/Icon - did you forget to load a Gum project?");
@@ -148,7 +148,7 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     protected override void ReactToVisualChanged()
     {
         base.ReactToVisualChanged();
-        IconSprite = this.Visual?.GetGraphicalUiElementByName("IconSprite") as global::MonoGameGum.GueDeriving.SpriteRuntime;
+        IconSprite = this.Visual?.GetGraphicalUiElementByName("IconSprite") as global::Gum.GueDeriving.SpriteRuntime;
         CustomInitialize();
     }
     //Not assigning variables because Object Instantiation Type is set to By Name rather than Fully In Code

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/Elements/PercentBar.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/Elements/PercentBar.Generated.cs
@@ -2,11 +2,11 @@
 using CodeGenProject.Components.Elements;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGenProject.Components.Elements;
@@ -17,7 +17,7 @@ partial class PercentBar : global::Gum.Forms.Controls.FrameworkElement
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Elements/PercentBar");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Elements/PercentBar - did you forget to load a Gum project?");
@@ -89,9 +89,9 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     protected override void ReactToVisualChanged()
     {
         base.ReactToVisualChanged();
-        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
-        BarContainer = this.Visual?.GetGraphicalUiElementByName("BarContainer") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
-        Bar = this.Visual?.GetGraphicalUiElementByName("Bar") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
+        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::Gum.GueDeriving.NineSliceRuntime;
+        BarContainer = this.Visual?.GetGraphicalUiElementByName("BarContainer") as global::Gum.GueDeriving.NineSliceRuntime;
+        Bar = this.Visual?.GetGraphicalUiElementByName("Bar") as global::Gum.GueDeriving.NineSliceRuntime;
         CautionLinesInstance = global::Gum.Forms.GraphicalUiElementFormsExtensions.TryGetFrameworkElementByName<CautionLines>(this.Visual,"CautionLinesInstance");
         VerticalLinesInstance = global::Gum.Forms.GraphicalUiElementFormsExtensions.TryGetFrameworkElementByName<VerticalLines>(this.Visual,"VerticalLinesInstance");
         CustomInitialize();

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/Elements/PercentBarIcon.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/Elements/PercentBarIcon.Generated.cs
@@ -2,11 +2,11 @@
 using CodeGenProject.Components.Elements;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGenProject.Components.Elements;
@@ -17,7 +17,7 @@ partial class PercentBarIcon : global::Gum.Forms.Controls.FrameworkElement
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Elements/PercentBarIcon");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Elements/PercentBarIcon - did you forget to load a Gum project?");
@@ -97,10 +97,10 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     protected override void ReactToVisualChanged()
     {
         base.ReactToVisualChanged();
-        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
+        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::Gum.GueDeriving.NineSliceRuntime;
         IconInstance = global::Gum.Forms.GraphicalUiElementFormsExtensions.TryGetFrameworkElementByName<Icon>(this.Visual,"IconInstance");
-        BarContainer = this.Visual?.GetGraphicalUiElementByName("BarContainer") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
-        Bar = this.Visual?.GetGraphicalUiElementByName("Bar") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
+        BarContainer = this.Visual?.GetGraphicalUiElementByName("BarContainer") as global::Gum.GueDeriving.NineSliceRuntime;
+        Bar = this.Visual?.GetGraphicalUiElementByName("Bar") as global::Gum.GueDeriving.NineSliceRuntime;
         CautionLinesInstance = global::Gum.Forms.GraphicalUiElementFormsExtensions.TryGetFrameworkElementByName<CautionLines>(this.Visual,"CautionLinesInstance");
         VerticalLinesInstance = global::Gum.Forms.GraphicalUiElementFormsExtensions.TryGetFrameworkElementByName<VerticalLines>(this.Visual,"VerticalLinesInstance");
         CustomInitialize();

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/Elements/VerticalLines.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/Elements/VerticalLines.Generated.cs
@@ -1,11 +1,11 @@
 //Code for Elements/VerticalLines (Container)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGenProject.Components.Elements;
@@ -16,7 +16,7 @@ partial class VerticalLines : global::Gum.Forms.Controls.FrameworkElement
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Elements/VerticalLines");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Elements/VerticalLines - did you forget to load a Gum project?");
@@ -53,7 +53,7 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     protected override void ReactToVisualChanged()
     {
         base.ReactToVisualChanged();
-        LinesSprite = this.Visual?.GetGraphicalUiElementByName("LinesSprite") as global::MonoGameGum.GueDeriving.SpriteRuntime;
+        LinesSprite = this.Visual?.GetGraphicalUiElementByName("LinesSprite") as global::Gum.GueDeriving.SpriteRuntime;
         CustomInitialize();
     }
     //Not assigning variables because Object Instantiation Type is set to By Name rather than Fully In Code

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/LabelContainer.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/LabelContainer.Generated.cs
@@ -2,11 +2,11 @@
 using CodeGenProject.Components.Controls;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGenProject.Components;
@@ -17,7 +17,7 @@ partial class LabelContainer : global::Gum.Forms.Controls.FrameworkElement
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("LabelContainer");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named LabelContainer - did you forget to load a Gum project?");
@@ -84,7 +84,7 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     {
         base.ReactToVisualChanged();
         LabelInstance = global::Gum.Forms.GraphicalUiElementFormsExtensions.TryGetFrameworkElementByName<Label>(this.Visual,"LabelInstance");
-        NonLabelShouldAppearAfterLabel = this.Visual?.GetGraphicalUiElementByName("NonLabelShouldAppearAfterLabel") as global::MonoGameGum.GueDeriving.ColoredRectangleRuntime;
+        NonLabelShouldAppearAfterLabel = this.Visual?.GetGraphicalUiElementByName("NonLabelShouldAppearAfterLabel") as global::Gum.GueDeriving.ColoredRectangleRuntime;
         CustomInitialize();
     }
     //Not assigning variables because Object Instantiation Type is set to By Name rather than Fully In Code

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/NineSliceComponent.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/NineSliceComponent.Generated.cs
@@ -1,11 +1,11 @@
 //Code for NineSliceComponent (Container)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGenProject.Components;
@@ -16,7 +16,7 @@ partial class NineSliceComponent : global::Gum.Forms.Controls.FrameworkElement
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("NineSliceComponent");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named NineSliceComponent - did you forget to load a Gum project?");
@@ -70,7 +70,7 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     protected override void ReactToVisualChanged()
     {
         base.ReactToVisualChanged();
-        NineSliceInstance = this.Visual?.GetGraphicalUiElementByName("NineSliceInstance") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
+        NineSliceInstance = this.Visual?.GetGraphicalUiElementByName("NineSliceInstance") as global::Gum.GueDeriving.NineSliceRuntime;
         CustomInitialize();
     }
     //Not assigning variables because Object Instantiation Type is set to By Name rather than Fully In Code

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/Spaced_Component.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/Spaced_Component.Generated.cs
@@ -1,11 +1,11 @@
 //Code for Spaced Component (Container)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGenProject.Components;
@@ -16,7 +16,7 @@ partial class Spaced_Component : global::Gum.Forms.Controls.FrameworkElement
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Spaced Component");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Spaced Component - did you forget to load a Gum project?");

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/SpriteComponent.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/SpriteComponent.Generated.cs
@@ -1,11 +1,11 @@
 //Code for SpriteComponent (Container)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGenProject.Components;
@@ -16,7 +16,7 @@ partial class SpriteComponent : global::Gum.Forms.Controls.FrameworkElement
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("SpriteComponent");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named SpriteComponent - did you forget to load a Gum project?");
@@ -87,7 +87,7 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     protected override void ReactToVisualChanged()
     {
         base.ReactToVisualChanged();
-        SpriteInstance = this.Visual?.GetGraphicalUiElementByName("SpriteInstance") as global::MonoGameGum.GueDeriving.SpriteRuntime;
+        SpriteInstance = this.Visual?.GetGraphicalUiElementByName("SpriteInstance") as global::Gum.GueDeriving.SpriteRuntime;
         CustomInitialize();
     }
     //Not assigning variables because Object Instantiation Type is set to By Name rather than Fully In Code

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/Styles.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/Styles.Generated.cs
@@ -1,11 +1,11 @@
 //Code for Styles (Container)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGenProject.Components;
@@ -16,7 +16,7 @@ partial class Styles : global::Gum.Forms.Controls.FrameworkElement
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Styles");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Styles - did you forget to load a Gum project?");
@@ -68,29 +68,29 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     protected override void ReactToVisualChanged()
     {
         base.ReactToVisualChanged();
-        Colors = this.Visual?.GetGraphicalUiElementByName("Colors") as global::MonoGameGum.GueDeriving.ContainerRuntime;
-        Black = this.Visual?.GetGraphicalUiElementByName("Black") as global::MonoGameGum.GueDeriving.ColoredRectangleRuntime;
-        DarkGray = this.Visual?.GetGraphicalUiElementByName("DarkGray") as global::MonoGameGum.GueDeriving.ColoredRectangleRuntime;
-        Gray = this.Visual?.GetGraphicalUiElementByName("Gray") as global::MonoGameGum.GueDeriving.ColoredRectangleRuntime;
-        LightGray = this.Visual?.GetGraphicalUiElementByName("LightGray") as global::MonoGameGum.GueDeriving.ColoredRectangleRuntime;
-        White = this.Visual?.GetGraphicalUiElementByName("White") as global::MonoGameGum.GueDeriving.ColoredRectangleRuntime;
-        PrimaryDark = this.Visual?.GetGraphicalUiElementByName("PrimaryDark") as global::MonoGameGum.GueDeriving.ColoredRectangleRuntime;
-        Primary = this.Visual?.GetGraphicalUiElementByName("Primary") as global::MonoGameGum.GueDeriving.ColoredRectangleRuntime;
-        PrimaryLight = this.Visual?.GetGraphicalUiElementByName("PrimaryLight") as global::MonoGameGum.GueDeriving.ColoredRectangleRuntime;
-        Success = this.Visual?.GetGraphicalUiElementByName("Success") as global::MonoGameGum.GueDeriving.ColoredRectangleRuntime;
-        Warning = this.Visual?.GetGraphicalUiElementByName("Warning") as global::MonoGameGum.GueDeriving.ColoredRectangleRuntime;
-        Danger = this.Visual?.GetGraphicalUiElementByName("Danger") as global::MonoGameGum.GueDeriving.ColoredRectangleRuntime;
-        Accent = this.Visual?.GetGraphicalUiElementByName("Accent") as global::MonoGameGum.GueDeriving.ColoredRectangleRuntime;
-        Tiny = this.Visual?.GetGraphicalUiElementByName("Tiny") as global::MonoGameGum.GueDeriving.TextRuntime;
-        Small = this.Visual?.GetGraphicalUiElementByName("Small") as global::MonoGameGum.GueDeriving.TextRuntime;
-        Normal = this.Visual?.GetGraphicalUiElementByName("Normal") as global::MonoGameGum.GueDeriving.TextRuntime;
-        Emphasis = this.Visual?.GetGraphicalUiElementByName("Emphasis") as global::MonoGameGum.GueDeriving.TextRuntime;
-        Strong = this.Visual?.GetGraphicalUiElementByName("Strong") as global::MonoGameGum.GueDeriving.TextRuntime;
-        H3 = this.Visual?.GetGraphicalUiElementByName("H3") as global::MonoGameGum.GueDeriving.TextRuntime;
-        H2 = this.Visual?.GetGraphicalUiElementByName("H2") as global::MonoGameGum.GueDeriving.TextRuntime;
-        H1 = this.Visual?.GetGraphicalUiElementByName("H1") as global::MonoGameGum.GueDeriving.TextRuntime;
-        TextStyles = this.Visual?.GetGraphicalUiElementByName("TextStyles") as global::MonoGameGum.GueDeriving.ContainerRuntime;
-        Title = this.Visual?.GetGraphicalUiElementByName("Title") as global::MonoGameGum.GueDeriving.TextRuntime;
+        Colors = this.Visual?.GetGraphicalUiElementByName("Colors") as global::Gum.GueDeriving.ContainerRuntime;
+        Black = this.Visual?.GetGraphicalUiElementByName("Black") as global::Gum.GueDeriving.ColoredRectangleRuntime;
+        DarkGray = this.Visual?.GetGraphicalUiElementByName("DarkGray") as global::Gum.GueDeriving.ColoredRectangleRuntime;
+        Gray = this.Visual?.GetGraphicalUiElementByName("Gray") as global::Gum.GueDeriving.ColoredRectangleRuntime;
+        LightGray = this.Visual?.GetGraphicalUiElementByName("LightGray") as global::Gum.GueDeriving.ColoredRectangleRuntime;
+        White = this.Visual?.GetGraphicalUiElementByName("White") as global::Gum.GueDeriving.ColoredRectangleRuntime;
+        PrimaryDark = this.Visual?.GetGraphicalUiElementByName("PrimaryDark") as global::Gum.GueDeriving.ColoredRectangleRuntime;
+        Primary = this.Visual?.GetGraphicalUiElementByName("Primary") as global::Gum.GueDeriving.ColoredRectangleRuntime;
+        PrimaryLight = this.Visual?.GetGraphicalUiElementByName("PrimaryLight") as global::Gum.GueDeriving.ColoredRectangleRuntime;
+        Success = this.Visual?.GetGraphicalUiElementByName("Success") as global::Gum.GueDeriving.ColoredRectangleRuntime;
+        Warning = this.Visual?.GetGraphicalUiElementByName("Warning") as global::Gum.GueDeriving.ColoredRectangleRuntime;
+        Danger = this.Visual?.GetGraphicalUiElementByName("Danger") as global::Gum.GueDeriving.ColoredRectangleRuntime;
+        Accent = this.Visual?.GetGraphicalUiElementByName("Accent") as global::Gum.GueDeriving.ColoredRectangleRuntime;
+        Tiny = this.Visual?.GetGraphicalUiElementByName("Tiny") as global::Gum.GueDeriving.TextRuntime;
+        Small = this.Visual?.GetGraphicalUiElementByName("Small") as global::Gum.GueDeriving.TextRuntime;
+        Normal = this.Visual?.GetGraphicalUiElementByName("Normal") as global::Gum.GueDeriving.TextRuntime;
+        Emphasis = this.Visual?.GetGraphicalUiElementByName("Emphasis") as global::Gum.GueDeriving.TextRuntime;
+        Strong = this.Visual?.GetGraphicalUiElementByName("Strong") as global::Gum.GueDeriving.TextRuntime;
+        H3 = this.Visual?.GetGraphicalUiElementByName("H3") as global::Gum.GueDeriving.TextRuntime;
+        H2 = this.Visual?.GetGraphicalUiElementByName("H2") as global::Gum.GueDeriving.TextRuntime;
+        H1 = this.Visual?.GetGraphicalUiElementByName("H1") as global::Gum.GueDeriving.TextRuntime;
+        TextStyles = this.Visual?.GetGraphicalUiElementByName("TextStyles") as global::Gum.GueDeriving.ContainerRuntime;
+        Title = this.Visual?.GetGraphicalUiElementByName("Title") as global::Gum.GueDeriving.TextRuntime;
         CustomInitialize();
     }
     //Not assigning variables because Object Instantiation Type is set to By Name rather than Fully In Code

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/TextComponent.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/TextComponent.Generated.cs
@@ -1,11 +1,11 @@
 //Code for TextComponent (Container)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGenProject.Components;
@@ -16,7 +16,7 @@ partial class TextComponent : global::Gum.Forms.Controls.FrameworkElement
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("TextComponent");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named TextComponent - did you forget to load a Gum project?");
@@ -46,7 +46,7 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     protected override void ReactToVisualChanged()
     {
         base.ReactToVisualChanged();
-        LongLineWrappingText = this.Visual?.GetGraphicalUiElementByName("LongLineWrappingText") as global::MonoGameGum.GueDeriving.TextRuntime;
+        LongLineWrappingText = this.Visual?.GetGraphicalUiElementByName("LongLineWrappingText") as global::Gum.GueDeriving.TextRuntime;
         CustomInitialize();
     }
     //Not assigning variables because Object Instantiation Type is set to By Name rather than Fully In Code

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/_123Component.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/_123Component.Generated.cs
@@ -1,11 +1,11 @@
 //Code for 123Component (Container)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGenProject.Components;
@@ -16,7 +16,7 @@ partial class _123Component : global::Gum.Forms.Controls.FrameworkElement
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("123Component");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named 123Component - did you forget to load a Gum project?");

--- a/Tests/CodeGen_MonoGameForms_ByReference/Screens/FormsScreenWithVariablesSet.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Screens/FormsScreenWithVariablesSet.Generated.cs
@@ -2,11 +2,11 @@
 using CodeGenProject.Components.Controls;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGenProject.Screens;
@@ -17,7 +17,7 @@ partial class FormsScreenWithVariablesSet : global::Gum.Forms.Controls.Framework
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("FormsScreenWithVariablesSet");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named FormsScreenWithVariablesSet - did you forget to load a Gum project?");

--- a/Tests/CodeGen_MonoGameForms_ByReference/Screens/GameScreenHud.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Screens/GameScreenHud.Generated.cs
@@ -2,11 +2,11 @@
 using CodeGenProject.Components.Controls;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGenProject.Screens;
@@ -17,7 +17,7 @@ partial class GameScreenHud : global::Gum.Forms.Controls.FrameworkElement
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("GameScreenHud");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named GameScreenHud - did you forget to load a Gum project?");

--- a/Tests/CodeGen_MonoGameForms_ByReference/Screens/GeneralScreen.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Screens/GeneralScreen.Generated.cs
@@ -3,11 +3,11 @@ using CodeGenProject.Components;
 using CodeGenProject.Components.Controls;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGenProject.Screens;
@@ -18,7 +18,7 @@ partial class GeneralScreen : global::Gum.Forms.Controls.FrameworkElement
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("GeneralScreen");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named GeneralScreen - did you forget to load a Gum project?");

--- a/Tests/CodeGen_MonoGameForms_ByReference/Screens/Spaced_Screen.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Screens/Spaced_Screen.Generated.cs
@@ -2,11 +2,11 @@
 using CodeGenProject.Components;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGenProject.Screens;
@@ -17,7 +17,7 @@ partial class Spaced_Screen : global::Gum.Forms.Controls.FrameworkElement
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Spaced Screen");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Spaced Screen - did you forget to load a Gum project?");

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/@interface.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/@interface.Generated.cs
@@ -1,11 +1,11 @@
 //Code for interface (Container)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGameForms_FullCodegen.Components;
@@ -16,7 +16,7 @@ partial class @interface : global::Gum.Forms.Controls.FrameworkElement
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("interface");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named interface - did you forget to load a Gum project?");

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/ButtonClose.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/ButtonClose.Generated.cs
@@ -2,11 +2,11 @@
 using CodeGen_MonoGameForms_FullCodegen.Components.Elements;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGameForms_FullCodegen.Components.Controls;
@@ -17,7 +17,7 @@ partial class ButtonClose : global::Gum.Forms.Controls.Button
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/ButtonClose");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/ButtonClose - did you forget to load a Gum project?");
@@ -122,14 +122,14 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     }
     protected virtual void InitializeInstances()
     {
-        Background = new global::MonoGameGum.GueDeriving.NineSliceRuntime();
+        Background = new global::Gum.GueDeriving.NineSliceRuntime();
         Background.ElementSave = ObjectFinder.Self.GetStandardElement("NineSlice");
         if (Background.ElementSave != null) Background.AddStatesAndCategoriesRecursivelyToGue(Background.ElementSave);
         if (Background.ElementSave != null) Background.SetInitialState();
         Background.Name = "Background";
         Icon = new CodeGen_MonoGameForms_FullCodegen.Components.Elements.Icon();
         Icon.Name = "Icon";
-        FocusedIndicator = new global::MonoGameGum.GueDeriving.NineSliceRuntime();
+        FocusedIndicator = new global::Gum.GueDeriving.NineSliceRuntime();
         FocusedIndicator.ElementSave = ObjectFinder.Self.GetStandardElement("NineSlice");
         if (FocusedIndicator.ElementSave != null) FocusedIndicator.AddStatesAndCategoriesRecursivelyToGue(FocusedIndicator.ElementSave);
         if (FocusedIndicator.ElementSave != null) FocusedIndicator.SetInitialState();

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/ButtonConfirm.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/ButtonConfirm.Generated.cs
@@ -1,11 +1,11 @@
 //Code for Controls/ButtonConfirm (Container)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGameForms_FullCodegen.Components.Controls;
@@ -16,7 +16,7 @@ partial class ButtonConfirm : global::Gum.Forms.Controls.Button
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/ButtonConfirm");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/ButtonConfirm - did you forget to load a Gum project?");
@@ -124,17 +124,17 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     }
     protected virtual void InitializeInstances()
     {
-        Background = new global::MonoGameGum.GueDeriving.NineSliceRuntime();
+        Background = new global::Gum.GueDeriving.NineSliceRuntime();
         Background.ElementSave = ObjectFinder.Self.GetStandardElement("NineSlice");
         if (Background.ElementSave != null) Background.AddStatesAndCategoriesRecursivelyToGue(Background.ElementSave);
         if (Background.ElementSave != null) Background.SetInitialState();
         Background.Name = "Background";
-        TextInstance = new global::MonoGameGum.GueDeriving.TextRuntime();
+        TextInstance = new global::Gum.GueDeriving.TextRuntime();
         TextInstance.ElementSave = ObjectFinder.Self.GetStandardElement("Text");
         if (TextInstance.ElementSave != null) TextInstance.AddStatesAndCategoriesRecursivelyToGue(TextInstance.ElementSave);
         if (TextInstance.ElementSave != null) TextInstance.SetInitialState();
         TextInstance.Name = "TextInstance";
-        FocusedIndicator = new global::MonoGameGum.GueDeriving.NineSliceRuntime();
+        FocusedIndicator = new global::Gum.GueDeriving.NineSliceRuntime();
         FocusedIndicator.ElementSave = ObjectFinder.Self.GetStandardElement("NineSlice");
         if (FocusedIndicator.ElementSave != null) FocusedIndicator.AddStatesAndCategoriesRecursivelyToGue(FocusedIndicator.ElementSave);
         if (FocusedIndicator.ElementSave != null) FocusedIndicator.SetInitialState();

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/ButtonDeny.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/ButtonDeny.Generated.cs
@@ -1,11 +1,11 @@
 //Code for Controls/ButtonDeny (Container)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGameForms_FullCodegen.Components.Controls;
@@ -16,7 +16,7 @@ partial class ButtonDeny : global::Gum.Forms.Controls.Button
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/ButtonDeny");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/ButtonDeny - did you forget to load a Gum project?");
@@ -124,17 +124,17 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     }
     protected virtual void InitializeInstances()
     {
-        Background = new global::MonoGameGum.GueDeriving.NineSliceRuntime();
+        Background = new global::Gum.GueDeriving.NineSliceRuntime();
         Background.ElementSave = ObjectFinder.Self.GetStandardElement("NineSlice");
         if (Background.ElementSave != null) Background.AddStatesAndCategoriesRecursivelyToGue(Background.ElementSave);
         if (Background.ElementSave != null) Background.SetInitialState();
         Background.Name = "Background";
-        TextInstance = new global::MonoGameGum.GueDeriving.TextRuntime();
+        TextInstance = new global::Gum.GueDeriving.TextRuntime();
         TextInstance.ElementSave = ObjectFinder.Self.GetStandardElement("Text");
         if (TextInstance.ElementSave != null) TextInstance.AddStatesAndCategoriesRecursivelyToGue(TextInstance.ElementSave);
         if (TextInstance.ElementSave != null) TextInstance.SetInitialState();
         TextInstance.Name = "TextInstance";
-        FocusedIndicator = new global::MonoGameGum.GueDeriving.NineSliceRuntime();
+        FocusedIndicator = new global::Gum.GueDeriving.NineSliceRuntime();
         FocusedIndicator.ElementSave = ObjectFinder.Self.GetStandardElement("NineSlice");
         if (FocusedIndicator.ElementSave != null) FocusedIndicator.AddStatesAndCategoriesRecursivelyToGue(FocusedIndicator.ElementSave);
         if (FocusedIndicator.ElementSave != null) FocusedIndicator.SetInitialState();

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/ButtonIcon.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/ButtonIcon.Generated.cs
@@ -2,11 +2,11 @@
 using CodeGen_MonoGameForms_FullCodegen.Components.Elements;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGameForms_FullCodegen.Components.Controls;
@@ -17,7 +17,7 @@ partial class ButtonIcon : global::Gum.Forms.Controls.Button
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/ButtonIcon");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/ButtonIcon - did you forget to load a Gum project?");
@@ -128,14 +128,14 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     }
     protected virtual void InitializeInstances()
     {
-        Background = new global::MonoGameGum.GueDeriving.NineSliceRuntime();
+        Background = new global::Gum.GueDeriving.NineSliceRuntime();
         Background.ElementSave = ObjectFinder.Self.GetStandardElement("NineSlice");
         if (Background.ElementSave != null) Background.AddStatesAndCategoriesRecursivelyToGue(Background.ElementSave);
         if (Background.ElementSave != null) Background.SetInitialState();
         Background.Name = "Background";
         Icon = new CodeGen_MonoGameForms_FullCodegen.Components.Elements.Icon();
         Icon.Name = "Icon";
-        FocusedIndicator = new global::MonoGameGum.GueDeriving.NineSliceRuntime();
+        FocusedIndicator = new global::Gum.GueDeriving.NineSliceRuntime();
         FocusedIndicator.ElementSave = ObjectFinder.Self.GetStandardElement("NineSlice");
         if (FocusedIndicator.ElementSave != null) FocusedIndicator.AddStatesAndCategoriesRecursivelyToGue(FocusedIndicator.ElementSave);
         if (FocusedIndicator.ElementSave != null) FocusedIndicator.SetInitialState();

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/ButtonStandard.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/ButtonStandard.Generated.cs
@@ -1,11 +1,11 @@
 //Code for Controls/ButtonStandard (Container)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGameForms_FullCodegen.Components.Controls;
@@ -16,7 +16,7 @@ partial class ButtonStandard : global::Gum.Forms.Controls.Button
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/ButtonStandard");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/ButtonStandard - did you forget to load a Gum project?");
@@ -125,17 +125,17 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     }
     protected virtual void InitializeInstances()
     {
-        Background = new global::MonoGameGum.GueDeriving.NineSliceRuntime();
+        Background = new global::Gum.GueDeriving.NineSliceRuntime();
         Background.ElementSave = ObjectFinder.Self.GetStandardElement("NineSlice");
         if (Background.ElementSave != null) Background.AddStatesAndCategoriesRecursivelyToGue(Background.ElementSave);
         if (Background.ElementSave != null) Background.SetInitialState();
         Background.Name = "Background";
-        TextInstance = new global::MonoGameGum.GueDeriving.TextRuntime();
+        TextInstance = new global::Gum.GueDeriving.TextRuntime();
         TextInstance.ElementSave = ObjectFinder.Self.GetStandardElement("Text");
         if (TextInstance.ElementSave != null) TextInstance.AddStatesAndCategoriesRecursivelyToGue(TextInstance.ElementSave);
         if (TextInstance.ElementSave != null) TextInstance.SetInitialState();
         TextInstance.Name = "TextInstance";
-        FocusedIndicator = new global::MonoGameGum.GueDeriving.NineSliceRuntime();
+        FocusedIndicator = new global::Gum.GueDeriving.NineSliceRuntime();
         FocusedIndicator.ElementSave = ObjectFinder.Self.GetStandardElement("NineSlice");
         if (FocusedIndicator.ElementSave != null) FocusedIndicator.AddStatesAndCategoriesRecursivelyToGue(FocusedIndicator.ElementSave);
         if (FocusedIndicator.ElementSave != null) FocusedIndicator.SetInitialState();

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/ButtonStandardIcon.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/ButtonStandardIcon.Generated.cs
@@ -2,11 +2,11 @@
 using CodeGen_MonoGameForms_FullCodegen.Components.Elements;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGameForms_FullCodegen.Components.Controls;
@@ -17,7 +17,7 @@ partial class ButtonStandardIcon : global::Gum.Forms.Controls.Button
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/ButtonStandardIcon");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/ButtonStandardIcon - did you forget to load a Gum project?");
@@ -140,19 +140,19 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     }
     protected virtual void InitializeInstances()
     {
-        Background = new global::MonoGameGum.GueDeriving.NineSliceRuntime();
+        Background = new global::Gum.GueDeriving.NineSliceRuntime();
         Background.ElementSave = ObjectFinder.Self.GetStandardElement("NineSlice");
         if (Background.ElementSave != null) Background.AddStatesAndCategoriesRecursivelyToGue(Background.ElementSave);
         if (Background.ElementSave != null) Background.SetInitialState();
         Background.Name = "Background";
-        TextInstance = new global::MonoGameGum.GueDeriving.TextRuntime();
+        TextInstance = new global::Gum.GueDeriving.TextRuntime();
         TextInstance.ElementSave = ObjectFinder.Self.GetStandardElement("Text");
         if (TextInstance.ElementSave != null) TextInstance.AddStatesAndCategoriesRecursivelyToGue(TextInstance.ElementSave);
         if (TextInstance.ElementSave != null) TextInstance.SetInitialState();
         TextInstance.Name = "TextInstance";
         Icon = new CodeGen_MonoGameForms_FullCodegen.Components.Elements.Icon();
         Icon.Name = "Icon";
-        FocusedIndicator = new global::MonoGameGum.GueDeriving.NineSliceRuntime();
+        FocusedIndicator = new global::Gum.GueDeriving.NineSliceRuntime();
         FocusedIndicator.ElementSave = ObjectFinder.Self.GetStandardElement("NineSlice");
         if (FocusedIndicator.ElementSave != null) FocusedIndicator.AddStatesAndCategoriesRecursivelyToGue(FocusedIndicator.ElementSave);
         if (FocusedIndicator.ElementSave != null) FocusedIndicator.SetInitialState();

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/ButtonTab.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/ButtonTab.Generated.cs
@@ -1,11 +1,11 @@
 //Code for Controls/ButtonTab (Container)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGameForms_FullCodegen.Components.Controls;
@@ -16,7 +16,7 @@ partial class ButtonTab : global::Gum.Forms.Controls.Button
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/ButtonTab");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/ButtonTab - did you forget to load a Gum project?");
@@ -128,17 +128,17 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     }
     protected virtual void InitializeInstances()
     {
-        Background = new global::MonoGameGum.GueDeriving.NineSliceRuntime();
+        Background = new global::Gum.GueDeriving.NineSliceRuntime();
         Background.ElementSave = ObjectFinder.Self.GetStandardElement("NineSlice");
         if (Background.ElementSave != null) Background.AddStatesAndCategoriesRecursivelyToGue(Background.ElementSave);
         if (Background.ElementSave != null) Background.SetInitialState();
         Background.Name = "Background";
-        TabText = new global::MonoGameGum.GueDeriving.TextRuntime();
+        TabText = new global::Gum.GueDeriving.TextRuntime();
         TabText.ElementSave = ObjectFinder.Self.GetStandardElement("Text");
         if (TabText.ElementSave != null) TabText.AddStatesAndCategoriesRecursivelyToGue(TabText.ElementSave);
         if (TabText.ElementSave != null) TabText.SetInitialState();
         TabText.Name = "TabText";
-        FocusedIndicator = new global::MonoGameGum.GueDeriving.NineSliceRuntime();
+        FocusedIndicator = new global::Gum.GueDeriving.NineSliceRuntime();
         FocusedIndicator.ElementSave = ObjectFinder.Self.GetStandardElement("NineSlice");
         if (FocusedIndicator.ElementSave != null) FocusedIndicator.AddStatesAndCategoriesRecursivelyToGue(FocusedIndicator.ElementSave);
         if (FocusedIndicator.ElementSave != null) FocusedIndicator.SetInitialState();

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/CheckBox.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/CheckBox.Generated.cs
@@ -2,11 +2,11 @@
 using CodeGen_MonoGameForms_FullCodegen.Components.Elements;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGameForms_FullCodegen.Components.Controls;
@@ -17,7 +17,7 @@ partial class CheckBox : global::Gum.Forms.Controls.CheckBox
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/CheckBox");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/CheckBox - did you forget to load a Gum project?");
@@ -248,11 +248,6 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     public Icon Check { get; protected set; }
     public NineSliceRuntime FocusedIndicator { get; protected set; }
 
-    public string Text
-    {
-        get => TextInstance.Text;
-        set => TextInstance.Text = value;
-    }
 
     public CheckBox(InteractiveGue visual) : base(visual)
     {
@@ -274,19 +269,19 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     }
     protected virtual void InitializeInstances()
     {
-        CheckboxBackground = new global::MonoGameGum.GueDeriving.NineSliceRuntime();
+        CheckboxBackground = new global::Gum.GueDeriving.NineSliceRuntime();
         CheckboxBackground.ElementSave = ObjectFinder.Self.GetStandardElement("NineSlice");
         if (CheckboxBackground.ElementSave != null) CheckboxBackground.AddStatesAndCategoriesRecursivelyToGue(CheckboxBackground.ElementSave);
         if (CheckboxBackground.ElementSave != null) CheckboxBackground.SetInitialState();
         CheckboxBackground.Name = "CheckboxBackground";
-        TextInstance = new global::MonoGameGum.GueDeriving.TextRuntime();
+        TextInstance = new global::Gum.GueDeriving.TextRuntime();
         TextInstance.ElementSave = ObjectFinder.Self.GetStandardElement("Text");
         if (TextInstance.ElementSave != null) TextInstance.AddStatesAndCategoriesRecursivelyToGue(TextInstance.ElementSave);
         if (TextInstance.ElementSave != null) TextInstance.SetInitialState();
         TextInstance.Name = "TextInstance";
         Check = new CodeGen_MonoGameForms_FullCodegen.Components.Elements.Icon();
         Check.Name = "Check";
-        FocusedIndicator = new global::MonoGameGum.GueDeriving.NineSliceRuntime();
+        FocusedIndicator = new global::Gum.GueDeriving.NineSliceRuntime();
         FocusedIndicator.ElementSave = ObjectFinder.Self.GetStandardElement("NineSlice");
         if (FocusedIndicator.ElementSave != null) FocusedIndicator.AddStatesAndCategoriesRecursivelyToGue(FocusedIndicator.ElementSave);
         if (FocusedIndicator.ElementSave != null) FocusedIndicator.SetInitialState();

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/ComboBox.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/ComboBox.Generated.cs
@@ -3,11 +3,11 @@ using CodeGen_MonoGameForms_FullCodegen.Components.Controls;
 using CodeGen_MonoGameForms_FullCodegen.Components.Elements;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGameForms_FullCodegen.Components.Controls;
@@ -18,7 +18,7 @@ partial class ComboBox : global::Gum.Forms.Controls.ComboBox
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/ComboBox");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/ComboBox - did you forget to load a Gum project?");
@@ -123,12 +123,12 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     }
     protected virtual void InitializeInstances()
     {
-        Background = new global::MonoGameGum.GueDeriving.NineSliceRuntime();
+        Background = new global::Gum.GueDeriving.NineSliceRuntime();
         Background.ElementSave = ObjectFinder.Self.GetStandardElement("NineSlice");
         if (Background.ElementSave != null) Background.AddStatesAndCategoriesRecursivelyToGue(Background.ElementSave);
         if (Background.ElementSave != null) Background.SetInitialState();
         Background.Name = "Background";
-        TextInstance = new global::MonoGameGum.GueDeriving.TextRuntime();
+        TextInstance = new global::Gum.GueDeriving.TextRuntime();
         TextInstance.ElementSave = ObjectFinder.Self.GetStandardElement("Text");
         if (TextInstance.ElementSave != null) TextInstance.AddStatesAndCategoriesRecursivelyToGue(TextInstance.ElementSave);
         if (TextInstance.ElementSave != null) TextInstance.SetInitialState();
@@ -137,7 +137,7 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
         ListBoxInstance.Name = "ListBoxInstance";
         IconInstance = new CodeGen_MonoGameForms_FullCodegen.Components.Elements.Icon();
         IconInstance.Name = "IconInstance";
-        FocusedIndicator = new global::MonoGameGum.GueDeriving.NineSliceRuntime();
+        FocusedIndicator = new global::Gum.GueDeriving.NineSliceRuntime();
         FocusedIndicator.ElementSave = ObjectFinder.Self.GetStandardElement("NineSlice");
         if (FocusedIndicator.ElementSave != null) FocusedIndicator.AddStatesAndCategoriesRecursivelyToGue(FocusedIndicator.ElementSave);
         if (FocusedIndicator.ElementSave != null) FocusedIndicator.SetInitialState();

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/DialogBox.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/DialogBox.Generated.cs
@@ -2,11 +2,11 @@
 using CodeGen_MonoGameForms_FullCodegen.Components.Elements;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGameForms_FullCodegen.Components.Controls;
@@ -17,7 +17,7 @@ partial class DialogBox : global::Gum.Forms.Controls.FrameworkElement
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/DialogBox");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/DialogBox - did you forget to load a Gum project?");
@@ -58,12 +58,12 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     }
     protected virtual void InitializeInstances()
     {
-        NineSliceInstance = new global::MonoGameGum.GueDeriving.NineSliceRuntime();
+        NineSliceInstance = new global::Gum.GueDeriving.NineSliceRuntime();
         NineSliceInstance.ElementSave = ObjectFinder.Self.GetStandardElement("NineSlice");
         if (NineSliceInstance.ElementSave != null) NineSliceInstance.AddStatesAndCategoriesRecursivelyToGue(NineSliceInstance.ElementSave);
         if (NineSliceInstance.ElementSave != null) NineSliceInstance.SetInitialState();
         NineSliceInstance.Name = "NineSliceInstance";
-        TextInstance = new global::MonoGameGum.GueDeriving.TextRuntime();
+        TextInstance = new global::Gum.GueDeriving.TextRuntime();
         TextInstance.ElementSave = ObjectFinder.Self.GetStandardElement("Text");
         if (TextInstance.ElementSave != null) TextInstance.AddStatesAndCategoriesRecursivelyToGue(TextInstance.ElementSave);
         if (TextInstance.ElementSave != null) TextInstance.SetInitialState();

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/InputDeviceSelectionItem.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/InputDeviceSelectionItem.Generated.cs
@@ -3,11 +3,11 @@ using CodeGen_MonoGameForms_FullCodegen.Components.Controls;
 using CodeGen_MonoGameForms_FullCodegen.Components.Elements;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGameForms_FullCodegen.Components.Controls;
@@ -18,7 +18,7 @@ partial class InputDeviceSelectionItem : global::Gum.Forms.Controls.FrameworkEle
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/InputDeviceSelectionItem");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/InputDeviceSelectionItem - did you forget to load a Gum project?");
@@ -91,14 +91,14 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     }
     protected virtual void InitializeInstances()
     {
-        Background = new global::MonoGameGum.GueDeriving.NineSliceRuntime();
+        Background = new global::Gum.GueDeriving.NineSliceRuntime();
         Background.ElementSave = ObjectFinder.Self.GetStandardElement("NineSlice");
         if (Background.ElementSave != null) Background.AddStatesAndCategoriesRecursivelyToGue(Background.ElementSave);
         if (Background.ElementSave != null) Background.SetInitialState();
         Background.Name = "Background";
         IconInstance = new CodeGen_MonoGameForms_FullCodegen.Components.Elements.Icon();
         IconInstance.Name = "IconInstance";
-        TextInstance = new global::MonoGameGum.GueDeriving.TextRuntime();
+        TextInstance = new global::Gum.GueDeriving.TextRuntime();
         TextInstance.ElementSave = ObjectFinder.Self.GetStandardElement("Text");
         if (TextInstance.ElementSave != null) TextInstance.AddStatesAndCategoriesRecursivelyToGue(TextInstance.ElementSave);
         if (TextInstance.ElementSave != null) TextInstance.SetInitialState();

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/InputDeviceSelector.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/InputDeviceSelector.Generated.cs
@@ -2,11 +2,11 @@
 using CodeGen_MonoGameForms_FullCodegen.Components.Controls;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGameForms_FullCodegen.Components.Controls;
@@ -17,7 +17,7 @@ partial class InputDeviceSelector : global::Gum.Forms.Controls.FrameworkElement
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/InputDeviceSelector");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/InputDeviceSelector - did you forget to load a Gum project?");
@@ -72,32 +72,32 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     }
     protected virtual void InitializeInstances()
     {
-        Background = new global::MonoGameGum.GueDeriving.NineSliceRuntime();
+        Background = new global::Gum.GueDeriving.NineSliceRuntime();
         Background.ElementSave = ObjectFinder.Self.GetStandardElement("NineSlice");
         if (Background.ElementSave != null) Background.AddStatesAndCategoriesRecursivelyToGue(Background.ElementSave);
         if (Background.ElementSave != null) Background.SetInitialState();
         Background.Name = "Background";
-        TextInstance = new global::MonoGameGum.GueDeriving.TextRuntime();
+        TextInstance = new global::Gum.GueDeriving.TextRuntime();
         TextInstance.ElementSave = ObjectFinder.Self.GetStandardElement("Text");
         if (TextInstance.ElementSave != null) TextInstance.AddStatesAndCategoriesRecursivelyToGue(TextInstance.ElementSave);
         if (TextInstance.ElementSave != null) TextInstance.SetInitialState();
         TextInstance.Name = "TextInstance";
-        TextInstance1 = new global::MonoGameGum.GueDeriving.TextRuntime();
+        TextInstance1 = new global::Gum.GueDeriving.TextRuntime();
         TextInstance1.ElementSave = ObjectFinder.Self.GetStandardElement("Text");
         if (TextInstance1.ElementSave != null) TextInstance1.AddStatesAndCategoriesRecursivelyToGue(TextInstance1.ElementSave);
         if (TextInstance1.ElementSave != null) TextInstance1.SetInitialState();
         TextInstance1.Name = "TextInstance1";
-        ContainerInstance1 = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+        ContainerInstance1 = new global::Gum.GueDeriving.ContainerRuntime();
         ContainerInstance1.ElementSave = ObjectFinder.Self.GetStandardElement("Container");
         if (ContainerInstance1.ElementSave != null) ContainerInstance1.AddStatesAndCategoriesRecursivelyToGue(ContainerInstance1.ElementSave);
         if (ContainerInstance1.ElementSave != null) ContainerInstance1.SetInitialState();
         ContainerInstance1.Name = "ContainerInstance1";
-        InputDeviceContainerInstance = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+        InputDeviceContainerInstance = new global::Gum.GueDeriving.ContainerRuntime();
         InputDeviceContainerInstance.ElementSave = ObjectFinder.Self.GetStandardElement("Container");
         if (InputDeviceContainerInstance.ElementSave != null) InputDeviceContainerInstance.AddStatesAndCategoriesRecursivelyToGue(InputDeviceContainerInstance.ElementSave);
         if (InputDeviceContainerInstance.ElementSave != null) InputDeviceContainerInstance.SetInitialState();
         InputDeviceContainerInstance.Name = "InputDeviceContainerInstance";
-        ContainerInstance2 = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+        ContainerInstance2 = new global::Gum.GueDeriving.ContainerRuntime();
         ContainerInstance2.ElementSave = ObjectFinder.Self.GetStandardElement("Container");
         if (ContainerInstance2.ElementSave != null) ContainerInstance2.AddStatesAndCategoriesRecursivelyToGue(ContainerInstance2.ElementSave);
         if (ContainerInstance2.ElementSave != null) ContainerInstance2.SetInitialState();

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/Keyboard.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/Keyboard.Generated.cs
@@ -3,12 +3,12 @@ using CodeGen_MonoGameForms_FullCodegen.Components.Controls;
 using CodeGen_MonoGameForms_FullCodegen.Components.Elements;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.StateAnimation.Runtime;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGameForms_FullCodegen.Components.Controls;
@@ -19,7 +19,7 @@ partial class Keyboard : global::Gum.Forms.Controls.FrameworkElement
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/Keyboard");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/Keyboard - did you forget to load a Gum project?");
@@ -151,12 +151,12 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     }
     protected virtual void InitializeInstances()
     {
-        Row1Keys = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+        Row1Keys = new global::Gum.GueDeriving.ContainerRuntime();
         Row1Keys.ElementSave = ObjectFinder.Self.GetStandardElement("Container");
         if (Row1Keys.ElementSave != null) Row1Keys.AddStatesAndCategoriesRecursivelyToGue(Row1Keys.ElementSave);
         if (Row1Keys.ElementSave != null) Row1Keys.SetInitialState();
         Row1Keys.Name = "Row1Keys";
-        AllRows = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+        AllRows = new global::Gum.GueDeriving.ContainerRuntime();
         AllRows.ElementSave = ObjectFinder.Self.GetStandardElement("Container");
         if (AllRows.ElementSave != null) AllRows.AddStatesAndCategoriesRecursivelyToGue(AllRows.ElementSave);
         if (AllRows.ElementSave != null) AllRows.SetInitialState();
@@ -253,22 +253,22 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
         Key9.Name = "Key9";
         Key0 = new CodeGen_MonoGameForms_FullCodegen.Components.Controls.KeyboardKey();
         Key0.Name = "Key0";
-        Row2Keys = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+        Row2Keys = new global::Gum.GueDeriving.ContainerRuntime();
         Row2Keys.ElementSave = ObjectFinder.Self.GetStandardElement("Container");
         if (Row2Keys.ElementSave != null) Row2Keys.AddStatesAndCategoriesRecursivelyToGue(Row2Keys.ElementSave);
         if (Row2Keys.ElementSave != null) Row2Keys.SetInitialState();
         Row2Keys.Name = "Row2Keys";
-        Row3Keys = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+        Row3Keys = new global::Gum.GueDeriving.ContainerRuntime();
         Row3Keys.ElementSave = ObjectFinder.Self.GetStandardElement("Container");
         if (Row3Keys.ElementSave != null) Row3Keys.AddStatesAndCategoriesRecursivelyToGue(Row3Keys.ElementSave);
         if (Row3Keys.ElementSave != null) Row3Keys.SetInitialState();
         Row3Keys.Name = "Row3Keys";
-        Row4Keys = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+        Row4Keys = new global::Gum.GueDeriving.ContainerRuntime();
         Row4Keys.ElementSave = ObjectFinder.Self.GetStandardElement("Container");
         if (Row4Keys.ElementSave != null) Row4Keys.AddStatesAndCategoriesRecursivelyToGue(Row4Keys.ElementSave);
         if (Row4Keys.ElementSave != null) Row4Keys.SetInitialState();
         Row4Keys.Name = "Row4Keys";
-        Row5Keys = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+        Row5Keys = new global::Gum.GueDeriving.ContainerRuntime();
         Row5Keys.ElementSave = ObjectFinder.Self.GetStandardElement("Container");
         if (Row5Keys.ElementSave != null) Row5Keys.AddStatesAndCategoriesRecursivelyToGue(Row5Keys.ElementSave);
         if (Row5Keys.ElementSave != null) Row5Keys.SetInitialState();
@@ -281,7 +281,7 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
         KeyLeft.Name = "KeyLeft";
         KeyRight = new CodeGen_MonoGameForms_FullCodegen.Components.Controls.KeyboardKey();
         KeyRight.Name = "KeyRight";
-        HighlightRectangle = new global::MonoGameGum.GueDeriving.RectangleRuntime();
+        HighlightRectangle = new global::Gum.GueDeriving.RectangleRuntime();
         HighlightRectangle.ElementSave = ObjectFinder.Self.GetStandardElement("Rectangle");
         if (HighlightRectangle.ElementSave != null) HighlightRectangle.AddStatesAndCategoriesRecursivelyToGue(HighlightRectangle.ElementSave);
         if (HighlightRectangle.ElementSave != null) HighlightRectangle.SetInitialState();

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/KeyboardKey.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/KeyboardKey.Generated.cs
@@ -1,12 +1,12 @@
 //Code for Controls/KeyboardKey (Container)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.StateAnimation.Runtime;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGameForms_FullCodegen.Components.Controls;
@@ -17,7 +17,7 @@ partial class KeyboardKey : global::Gum.Forms.Controls.Button
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/KeyboardKey");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/KeyboardKey - did you forget to load a Gum project?");
@@ -99,11 +99,6 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     public TextRuntime TextInstance { get; protected set; }
     public NineSliceRuntime FocusedIndicator { get; protected set; }
 
-    public override string Text
-    {
-        get => TextInstance.Text;
-        set => TextInstance.Text = value;
-    }
 
     public KeyboardKey(InteractiveGue visual) : base(visual)
     {
@@ -127,17 +122,17 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     }
     protected virtual void InitializeInstances()
     {
-        Background = new global::MonoGameGum.GueDeriving.NineSliceRuntime();
+        Background = new global::Gum.GueDeriving.NineSliceRuntime();
         Background.ElementSave = ObjectFinder.Self.GetStandardElement("NineSlice");
         if (Background.ElementSave != null) Background.AddStatesAndCategoriesRecursivelyToGue(Background.ElementSave);
         if (Background.ElementSave != null) Background.SetInitialState();
         Background.Name = "Background";
-        TextInstance = new global::MonoGameGum.GueDeriving.TextRuntime();
+        TextInstance = new global::Gum.GueDeriving.TextRuntime();
         TextInstance.ElementSave = ObjectFinder.Self.GetStandardElement("Text");
         if (TextInstance.ElementSave != null) TextInstance.AddStatesAndCategoriesRecursivelyToGue(TextInstance.ElementSave);
         if (TextInstance.ElementSave != null) TextInstance.SetInitialState();
         TextInstance.Name = "TextInstance";
-        FocusedIndicator = new global::MonoGameGum.GueDeriving.NineSliceRuntime();
+        FocusedIndicator = new global::Gum.GueDeriving.NineSliceRuntime();
         FocusedIndicator.ElementSave = ObjectFinder.Self.GetStandardElement("NineSlice");
         if (FocusedIndicator.ElementSave != null) FocusedIndicator.AddStatesAndCategoriesRecursivelyToGue(FocusedIndicator.ElementSave);
         if (FocusedIndicator.ElementSave != null) FocusedIndicator.SetInitialState();

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/Label.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/Label.Generated.cs
@@ -1,11 +1,11 @@
 //Code for Controls/Label (Text)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGameForms_FullCodegen.Components.Controls;
@@ -16,7 +16,7 @@ partial class Label : global::Gum.Forms.Controls.Label
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.TextRuntime();
+            var visual = new global::Gum.GueDeriving.TextRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/Label");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/Label - did you forget to load a Gum project?");

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/ListBox.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/ListBox.Generated.cs
@@ -2,11 +2,11 @@
 using CodeGen_MonoGameForms_FullCodegen.Components.Controls;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGameForms_FullCodegen.Components.Controls;
@@ -17,7 +17,7 @@ partial class ListBox : global::Gum.Forms.Controls.ListBox
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/ListBox");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/ListBox - did you forget to load a Gum project?");
@@ -98,34 +98,34 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     }
     protected virtual void InitializeInstances()
     {
-        Background = new global::MonoGameGum.GueDeriving.NineSliceRuntime();
+        Background = new global::Gum.GueDeriving.NineSliceRuntime();
         Background.ElementSave = ObjectFinder.Self.GetStandardElement("NineSlice");
         if (Background.ElementSave != null) Background.AddStatesAndCategoriesRecursivelyToGue(Background.ElementSave);
         if (Background.ElementSave != null) Background.SetInitialState();
         Background.Name = "Background";
         VerticalScrollBarInstance = new CodeGen_MonoGameForms_FullCodegen.Components.Controls.ScrollBar();
         VerticalScrollBarInstance.Name = "VerticalScrollBarInstance";
-        ClipContainerInstance = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+        ClipContainerInstance = new global::Gum.GueDeriving.ContainerRuntime();
         ClipContainerInstance.ElementSave = ObjectFinder.Self.GetStandardElement("Container");
         if (ClipContainerInstance.ElementSave != null) ClipContainerInstance.AddStatesAndCategoriesRecursivelyToGue(ClipContainerInstance.ElementSave);
         if (ClipContainerInstance.ElementSave != null) ClipContainerInstance.SetInitialState();
         ClipContainerInstance.Name = "ClipContainerInstance";
-        InnerPanelInstance = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+        InnerPanelInstance = new global::Gum.GueDeriving.ContainerRuntime();
         InnerPanelInstance.ElementSave = ObjectFinder.Self.GetStandardElement("Container");
         if (InnerPanelInstance.ElementSave != null) InnerPanelInstance.AddStatesAndCategoriesRecursivelyToGue(InnerPanelInstance.ElementSave);
         if (InnerPanelInstance.ElementSave != null) InnerPanelInstance.SetInitialState();
         InnerPanelInstance.Name = "InnerPanelInstance";
-        FocusedIndicator = new global::MonoGameGum.GueDeriving.NineSliceRuntime();
+        FocusedIndicator = new global::Gum.GueDeriving.NineSliceRuntime();
         FocusedIndicator.ElementSave = ObjectFinder.Self.GetStandardElement("NineSlice");
         if (FocusedIndicator.ElementSave != null) FocusedIndicator.AddStatesAndCategoriesRecursivelyToGue(FocusedIndicator.ElementSave);
         if (FocusedIndicator.ElementSave != null) FocusedIndicator.SetInitialState();
         FocusedIndicator.Name = "FocusedIndicator";
-        ClipAndScrollContainer = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+        ClipAndScrollContainer = new global::Gum.GueDeriving.ContainerRuntime();
         ClipAndScrollContainer.ElementSave = ObjectFinder.Self.GetStandardElement("Container");
         if (ClipAndScrollContainer.ElementSave != null) ClipAndScrollContainer.AddStatesAndCategoriesRecursivelyToGue(ClipAndScrollContainer.ElementSave);
         if (ClipAndScrollContainer.ElementSave != null) ClipAndScrollContainer.SetInitialState();
         ClipAndScrollContainer.Name = "ClipAndScrollContainer";
-        ClipContainerParent = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+        ClipContainerParent = new global::Gum.GueDeriving.ContainerRuntime();
         ClipContainerParent.ElementSave = ObjectFinder.Self.GetStandardElement("Container");
         if (ClipContainerParent.ElementSave != null) ClipContainerParent.AddStatesAndCategoriesRecursivelyToGue(ClipContainerParent.ElementSave);
         if (ClipContainerParent.ElementSave != null) ClipContainerParent.SetInitialState();

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/ListBoxItem.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/ListBoxItem.Generated.cs
@@ -1,11 +1,11 @@
 //Code for Controls/ListBoxItem (Container)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGameForms_FullCodegen.Components.Controls;
@@ -16,7 +16,7 @@ partial class ListBoxItem : global::Gum.Forms.Controls.ListBoxItem
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/ListBoxItem");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/ListBoxItem - did you forget to load a Gum project?");
@@ -109,17 +109,17 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     }
     protected virtual void InitializeInstances()
     {
-        Background = new global::MonoGameGum.GueDeriving.NineSliceRuntime();
+        Background = new global::Gum.GueDeriving.NineSliceRuntime();
         Background.ElementSave = ObjectFinder.Self.GetStandardElement("NineSlice");
         if (Background.ElementSave != null) Background.AddStatesAndCategoriesRecursivelyToGue(Background.ElementSave);
         if (Background.ElementSave != null) Background.SetInitialState();
         Background.Name = "Background";
-        TextInstance = new global::MonoGameGum.GueDeriving.TextRuntime();
+        TextInstance = new global::Gum.GueDeriving.TextRuntime();
         TextInstance.ElementSave = ObjectFinder.Self.GetStandardElement("Text");
         if (TextInstance.ElementSave != null) TextInstance.AddStatesAndCategoriesRecursivelyToGue(TextInstance.ElementSave);
         if (TextInstance.ElementSave != null) TextInstance.SetInitialState();
         TextInstance.Name = "TextInstance";
-        FocusedIndicator = new global::MonoGameGum.GueDeriving.NineSliceRuntime();
+        FocusedIndicator = new global::Gum.GueDeriving.NineSliceRuntime();
         FocusedIndicator.ElementSave = ObjectFinder.Self.GetStandardElement("NineSlice");
         if (FocusedIndicator.ElementSave != null) FocusedIndicator.AddStatesAndCategoriesRecursivelyToGue(FocusedIndicator.ElementSave);
         if (FocusedIndicator.ElementSave != null) FocusedIndicator.SetInitialState();

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/Menu.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/Menu.Generated.cs
@@ -1,11 +1,11 @@
 //Code for Controls/Menu (Container)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGameForms_FullCodegen.Components.Controls;
@@ -16,7 +16,7 @@ partial class Menu : global::Gum.Forms.Controls.Menu
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/Menu");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/Menu - did you forget to load a Gum project?");
@@ -63,12 +63,12 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     }
     protected virtual void InitializeInstances()
     {
-        Background = new global::MonoGameGum.GueDeriving.NineSliceRuntime();
+        Background = new global::Gum.GueDeriving.NineSliceRuntime();
         Background.ElementSave = ObjectFinder.Self.GetStandardElement("NineSlice");
         if (Background.ElementSave != null) Background.AddStatesAndCategoriesRecursivelyToGue(Background.ElementSave);
         if (Background.ElementSave != null) Background.SetInitialState();
         Background.Name = "Background";
-        InnerPanelInstance = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+        InnerPanelInstance = new global::Gum.GueDeriving.ContainerRuntime();
         InnerPanelInstance.ElementSave = ObjectFinder.Self.GetStandardElement("Container");
         if (InnerPanelInstance.ElementSave != null) InnerPanelInstance.AddStatesAndCategoriesRecursivelyToGue(InnerPanelInstance.ElementSave);
         if (InnerPanelInstance.ElementSave != null) InnerPanelInstance.SetInitialState();

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/MenuItem.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/MenuItem.Generated.cs
@@ -1,11 +1,11 @@
 //Code for Controls/MenuItem (Container)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGameForms_FullCodegen.Components.Controls;
@@ -16,7 +16,7 @@ partial class MenuItem : global::Gum.Forms.Controls.MenuItem
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/MenuItem");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/MenuItem - did you forget to load a Gum project?");
@@ -111,22 +111,22 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     }
     protected virtual void InitializeInstances()
     {
-        Background = new global::MonoGameGum.GueDeriving.NineSliceRuntime();
+        Background = new global::Gum.GueDeriving.NineSliceRuntime();
         Background.ElementSave = ObjectFinder.Self.GetStandardElement("NineSlice");
         if (Background.ElementSave != null) Background.AddStatesAndCategoriesRecursivelyToGue(Background.ElementSave);
         if (Background.ElementSave != null) Background.SetInitialState();
         Background.Name = "Background";
-        TextInstance = new global::MonoGameGum.GueDeriving.TextRuntime();
+        TextInstance = new global::Gum.GueDeriving.TextRuntime();
         TextInstance.ElementSave = ObjectFinder.Self.GetStandardElement("Text");
         if (TextInstance.ElementSave != null) TextInstance.AddStatesAndCategoriesRecursivelyToGue(TextInstance.ElementSave);
         if (TextInstance.ElementSave != null) TextInstance.SetInitialState();
         TextInstance.Name = "TextInstance";
-        SubmenuIndicatorInstance = new global::MonoGameGum.GueDeriving.TextRuntime();
+        SubmenuIndicatorInstance = new global::Gum.GueDeriving.TextRuntime();
         SubmenuIndicatorInstance.ElementSave = ObjectFinder.Self.GetStandardElement("Text");
         if (SubmenuIndicatorInstance.ElementSave != null) SubmenuIndicatorInstance.AddStatesAndCategoriesRecursivelyToGue(SubmenuIndicatorInstance.ElementSave);
         if (SubmenuIndicatorInstance.ElementSave != null) SubmenuIndicatorInstance.SetInitialState();
         SubmenuIndicatorInstance.Name = "SubmenuIndicatorInstance";
-        ContainerInstance = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+        ContainerInstance = new global::Gum.GueDeriving.ContainerRuntime();
         ContainerInstance.ElementSave = ObjectFinder.Self.GetStandardElement("Container");
         if (ContainerInstance.ElementSave != null) ContainerInstance.AddStatesAndCategoriesRecursivelyToGue(ContainerInstance.ElementSave);
         if (ContainerInstance.ElementSave != null) ContainerInstance.SetInitialState();

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/Panel.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/Panel.Generated.cs
@@ -1,11 +1,11 @@
 //Code for Controls/Panel (Container)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGameForms_FullCodegen.Components.Controls;
@@ -16,7 +16,7 @@ partial class Panel : global::Gum.Forms.Controls.Panel
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/Panel");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/Panel - did you forget to load a Gum project?");

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/PasswordBox.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/PasswordBox.Generated.cs
@@ -1,11 +1,11 @@
 //Code for Controls/PasswordBox (Container)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGameForms_FullCodegen.Components.Controls;
@@ -16,7 +16,7 @@ partial class PasswordBox : global::Gum.Forms.Controls.PasswordBox
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/PasswordBox");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/PasswordBox - did you forget to load a Gum project?");
@@ -110,32 +110,32 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     }
     protected virtual void InitializeInstances()
     {
-        Background = new global::MonoGameGum.GueDeriving.NineSliceRuntime();
+        Background = new global::Gum.GueDeriving.NineSliceRuntime();
         Background.ElementSave = ObjectFinder.Self.GetStandardElement("NineSlice");
         if (Background.ElementSave != null) Background.AddStatesAndCategoriesRecursivelyToGue(Background.ElementSave);
         if (Background.ElementSave != null) Background.SetInitialState();
         Background.Name = "Background";
-        SelectionInstance = new global::MonoGameGum.GueDeriving.NineSliceRuntime();
+        SelectionInstance = new global::Gum.GueDeriving.NineSliceRuntime();
         SelectionInstance.ElementSave = ObjectFinder.Self.GetStandardElement("NineSlice");
         if (SelectionInstance.ElementSave != null) SelectionInstance.AddStatesAndCategoriesRecursivelyToGue(SelectionInstance.ElementSave);
         if (SelectionInstance.ElementSave != null) SelectionInstance.SetInitialState();
         SelectionInstance.Name = "SelectionInstance";
-        TextInstance = new global::MonoGameGum.GueDeriving.TextRuntime();
+        TextInstance = new global::Gum.GueDeriving.TextRuntime();
         TextInstance.ElementSave = ObjectFinder.Self.GetStandardElement("Text");
         if (TextInstance.ElementSave != null) TextInstance.AddStatesAndCategoriesRecursivelyToGue(TextInstance.ElementSave);
         if (TextInstance.ElementSave != null) TextInstance.SetInitialState();
         TextInstance.Name = "TextInstance";
-        PlaceholderTextInstance = new global::MonoGameGum.GueDeriving.TextRuntime();
+        PlaceholderTextInstance = new global::Gum.GueDeriving.TextRuntime();
         PlaceholderTextInstance.ElementSave = ObjectFinder.Self.GetStandardElement("Text");
         if (PlaceholderTextInstance.ElementSave != null) PlaceholderTextInstance.AddStatesAndCategoriesRecursivelyToGue(PlaceholderTextInstance.ElementSave);
         if (PlaceholderTextInstance.ElementSave != null) PlaceholderTextInstance.SetInitialState();
         PlaceholderTextInstance.Name = "PlaceholderTextInstance";
-        FocusedIndicator = new global::MonoGameGum.GueDeriving.NineSliceRuntime();
+        FocusedIndicator = new global::Gum.GueDeriving.NineSliceRuntime();
         FocusedIndicator.ElementSave = ObjectFinder.Self.GetStandardElement("NineSlice");
         if (FocusedIndicator.ElementSave != null) FocusedIndicator.AddStatesAndCategoriesRecursivelyToGue(FocusedIndicator.ElementSave);
         if (FocusedIndicator.ElementSave != null) FocusedIndicator.SetInitialState();
         FocusedIndicator.Name = "FocusedIndicator";
-        CaretInstance = new global::MonoGameGum.GueDeriving.SpriteRuntime();
+        CaretInstance = new global::Gum.GueDeriving.SpriteRuntime();
         CaretInstance.ElementSave = ObjectFinder.Self.GetStandardElement("Sprite");
         if (CaretInstance.ElementSave != null) CaretInstance.AddStatesAndCategoriesRecursivelyToGue(CaretInstance.ElementSave);
         if (CaretInstance.ElementSave != null) CaretInstance.SetInitialState();

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/PlayerJoinView.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/PlayerJoinView.Generated.cs
@@ -2,11 +2,11 @@
 using CodeGen_MonoGameForms_FullCodegen.Components.Controls;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGameForms_FullCodegen.Components.Controls;
@@ -17,7 +17,7 @@ partial class PlayerJoinView : global::Gum.Forms.Controls.FrameworkElement
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/PlayerJoinView");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/PlayerJoinView - did you forget to load a Gum project?");
@@ -59,7 +59,7 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     }
     protected virtual void InitializeInstances()
     {
-        InnerPanelInstance = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+        InnerPanelInstance = new global::Gum.GueDeriving.ContainerRuntime();
         InnerPanelInstance.ElementSave = ObjectFinder.Self.GetStandardElement("Container");
         if (InnerPanelInstance.ElementSave != null) InnerPanelInstance.AddStatesAndCategoriesRecursivelyToGue(InnerPanelInstance.ElementSave);
         if (InnerPanelInstance.ElementSave != null) InnerPanelInstance.SetInitialState();

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/PlayerJoinViewItem.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/PlayerJoinViewItem.Generated.cs
@@ -2,11 +2,11 @@
 using CodeGen_MonoGameForms_FullCodegen.Components.Elements;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGameForms_FullCodegen.Components.Controls;
@@ -17,7 +17,7 @@ partial class PlayerJoinViewItem : global::Gum.Forms.Controls.FrameworkElement
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/PlayerJoinViewItem");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/PlayerJoinViewItem - did you forget to load a Gum project?");
@@ -193,12 +193,12 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     }
     protected virtual void InitializeInstances()
     {
-        Background = new global::MonoGameGum.GueDeriving.NineSliceRuntime();
+        Background = new global::Gum.GueDeriving.NineSliceRuntime();
         Background.ElementSave = ObjectFinder.Self.GetStandardElement("NineSlice");
         if (Background.ElementSave != null) Background.AddStatesAndCategoriesRecursivelyToGue(Background.ElementSave);
         if (Background.ElementSave != null) Background.SetInitialState();
         Background.Name = "Background";
-        ControllerDisplayNameTextInstance = new global::MonoGameGum.GueDeriving.TextRuntime();
+        ControllerDisplayNameTextInstance = new global::Gum.GueDeriving.TextRuntime();
         ControllerDisplayNameTextInstance.ElementSave = ObjectFinder.Self.GetStandardElement("Text");
         if (ControllerDisplayNameTextInstance.ElementSave != null) ControllerDisplayNameTextInstance.AddStatesAndCategoriesRecursivelyToGue(ControllerDisplayNameTextInstance.ElementSave);
         if (ControllerDisplayNameTextInstance.ElementSave != null) ControllerDisplayNameTextInstance.SetInitialState();

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/RadioButton.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/RadioButton.Generated.cs
@@ -2,11 +2,11 @@
 using CodeGen_MonoGameForms_FullCodegen.Components.Elements;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGameForms_FullCodegen.Components.Controls;
@@ -17,7 +17,7 @@ partial class RadioButton : global::Gum.Forms.Controls.RadioButton
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/RadioButton");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/RadioButton - did you forget to load a Gum project?");
@@ -171,11 +171,6 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     public TextRuntime TextInstance { get; protected set; }
     public NineSliceRuntime FocusedIndicator { get; protected set; }
 
-    public string Text
-    {
-        get => TextInstance.Text;
-        set => TextInstance.Text = value;
-    }
 
     public RadioButton(InteractiveGue visual) : base(visual)
     {
@@ -197,19 +192,19 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     }
     protected virtual void InitializeInstances()
     {
-        RadioBackground = new global::MonoGameGum.GueDeriving.NineSliceRuntime();
+        RadioBackground = new global::Gum.GueDeriving.NineSliceRuntime();
         RadioBackground.ElementSave = ObjectFinder.Self.GetStandardElement("NineSlice");
         if (RadioBackground.ElementSave != null) RadioBackground.AddStatesAndCategoriesRecursivelyToGue(RadioBackground.ElementSave);
         if (RadioBackground.ElementSave != null) RadioBackground.SetInitialState();
         RadioBackground.Name = "RadioBackground";
         Radio = new CodeGen_MonoGameForms_FullCodegen.Components.Elements.Icon();
         Radio.Name = "Radio";
-        TextInstance = new global::MonoGameGum.GueDeriving.TextRuntime();
+        TextInstance = new global::Gum.GueDeriving.TextRuntime();
         TextInstance.ElementSave = ObjectFinder.Self.GetStandardElement("Text");
         if (TextInstance.ElementSave != null) TextInstance.AddStatesAndCategoriesRecursivelyToGue(TextInstance.ElementSave);
         if (TextInstance.ElementSave != null) TextInstance.SetInitialState();
         TextInstance.Name = "TextInstance";
-        FocusedIndicator = new global::MonoGameGum.GueDeriving.NineSliceRuntime();
+        FocusedIndicator = new global::Gum.GueDeriving.NineSliceRuntime();
         FocusedIndicator.ElementSave = ObjectFinder.Self.GetStandardElement("NineSlice");
         if (FocusedIndicator.ElementSave != null) FocusedIndicator.AddStatesAndCategoriesRecursivelyToGue(FocusedIndicator.ElementSave);
         if (FocusedIndicator.ElementSave != null) FocusedIndicator.SetInitialState();

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/ScrollBar.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/ScrollBar.Generated.cs
@@ -2,11 +2,11 @@
 using CodeGen_MonoGameForms_FullCodegen.Components.Controls;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGameForms_FullCodegen.Components.Controls;
@@ -17,7 +17,7 @@ partial class ScrollBar : global::Gum.Forms.Controls.ScrollBar
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/ScrollBar");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/ScrollBar - did you forget to load a Gum project?");
@@ -85,12 +85,12 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
         UpButtonInstance.Name = "UpButtonInstance";
         DownButtonInstance = new CodeGen_MonoGameForms_FullCodegen.Components.Controls.ButtonIcon();
         DownButtonInstance.Name = "DownButtonInstance";
-        TrackInstance = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+        TrackInstance = new global::Gum.GueDeriving.ContainerRuntime();
         TrackInstance.ElementSave = ObjectFinder.Self.GetStandardElement("Container");
         if (TrackInstance.ElementSave != null) TrackInstance.AddStatesAndCategoriesRecursivelyToGue(TrackInstance.ElementSave);
         if (TrackInstance.ElementSave != null) TrackInstance.SetInitialState();
         TrackInstance.Name = "TrackInstance";
-        TrackBackground = new global::MonoGameGum.GueDeriving.NineSliceRuntime();
+        TrackBackground = new global::Gum.GueDeriving.NineSliceRuntime();
         TrackBackground.ElementSave = ObjectFinder.Self.GetStandardElement("NineSlice");
         if (TrackBackground.ElementSave != null) TrackBackground.AddStatesAndCategoriesRecursivelyToGue(TrackBackground.ElementSave);
         if (TrackBackground.ElementSave != null) TrackBackground.SetInitialState();

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/ScrollViewer.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/ScrollViewer.Generated.cs
@@ -2,11 +2,11 @@
 using CodeGen_MonoGameForms_FullCodegen.Components.Controls;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGameForms_FullCodegen.Components.Controls;
@@ -17,7 +17,7 @@ partial class ScrollViewer : global::Gum.Forms.Controls.ScrollViewer
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/ScrollViewer");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/ScrollViewer - did you forget to load a Gum project?");
@@ -114,24 +114,24 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     }
     protected virtual void InitializeInstances()
     {
-        Background = new global::MonoGameGum.GueDeriving.NineSliceRuntime();
+        Background = new global::Gum.GueDeriving.NineSliceRuntime();
         Background.ElementSave = ObjectFinder.Self.GetStandardElement("NineSlice");
         if (Background.ElementSave != null) Background.AddStatesAndCategoriesRecursivelyToGue(Background.ElementSave);
         if (Background.ElementSave != null) Background.SetInitialState();
         Background.Name = "Background";
         VerticalScrollBarInstance = new CodeGen_MonoGameForms_FullCodegen.Components.Controls.ScrollBar();
         VerticalScrollBarInstance.Name = "VerticalScrollBarInstance";
-        ClipContainerInstance = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+        ClipContainerInstance = new global::Gum.GueDeriving.ContainerRuntime();
         ClipContainerInstance.ElementSave = ObjectFinder.Self.GetStandardElement("Container");
         if (ClipContainerInstance.ElementSave != null) ClipContainerInstance.AddStatesAndCategoriesRecursivelyToGue(ClipContainerInstance.ElementSave);
         if (ClipContainerInstance.ElementSave != null) ClipContainerInstance.SetInitialState();
         ClipContainerInstance.Name = "ClipContainerInstance";
-        InnerPanelInstance = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+        InnerPanelInstance = new global::Gum.GueDeriving.ContainerRuntime();
         InnerPanelInstance.ElementSave = ObjectFinder.Self.GetStandardElement("Container");
         if (InnerPanelInstance.ElementSave != null) InnerPanelInstance.AddStatesAndCategoriesRecursivelyToGue(InnerPanelInstance.ElementSave);
         if (InnerPanelInstance.ElementSave != null) InnerPanelInstance.SetInitialState();
         InnerPanelInstance.Name = "InnerPanelInstance";
-        FocusedIndicator = new global::MonoGameGum.GueDeriving.NineSliceRuntime();
+        FocusedIndicator = new global::Gum.GueDeriving.NineSliceRuntime();
         FocusedIndicator.ElementSave = ObjectFinder.Self.GetStandardElement("NineSlice");
         if (FocusedIndicator.ElementSave != null) FocusedIndicator.AddStatesAndCategoriesRecursivelyToGue(FocusedIndicator.ElementSave);
         if (FocusedIndicator.ElementSave != null) FocusedIndicator.SetInitialState();

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/SettingsView.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/SettingsView.Generated.cs
@@ -2,11 +2,11 @@
 using CodeGen_MonoGameForms_FullCodegen.Components.Controls;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGameForms_FullCodegen.Components.Controls;
@@ -17,7 +17,7 @@ partial class SettingsView : global::Gum.Forms.Controls.FrameworkElement
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/SettingsView");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/SettingsView - did you forget to load a Gum project?");

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/Slider.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/Slider.Generated.cs
@@ -2,11 +2,11 @@
 using CodeGen_MonoGameForms_FullCodegen.Components.Controls;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGameForms_FullCodegen.Components.Controls;
@@ -17,7 +17,7 @@ partial class Slider : global::Gum.Forms.Controls.Slider
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/Slider");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/Slider - did you forget to load a Gum project?");
@@ -120,19 +120,19 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     }
     protected virtual void InitializeInstances()
     {
-        TrackInstance = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+        TrackInstance = new global::Gum.GueDeriving.ContainerRuntime();
         TrackInstance.ElementSave = ObjectFinder.Self.GetStandardElement("Container");
         if (TrackInstance.ElementSave != null) TrackInstance.AddStatesAndCategoriesRecursivelyToGue(TrackInstance.ElementSave);
         if (TrackInstance.ElementSave != null) TrackInstance.SetInitialState();
         TrackInstance.Name = "TrackInstance";
-        TrackBackground = new global::MonoGameGum.GueDeriving.NineSliceRuntime();
+        TrackBackground = new global::Gum.GueDeriving.NineSliceRuntime();
         TrackBackground.ElementSave = ObjectFinder.Self.GetStandardElement("NineSlice");
         if (TrackBackground.ElementSave != null) TrackBackground.AddStatesAndCategoriesRecursivelyToGue(TrackBackground.ElementSave);
         if (TrackBackground.ElementSave != null) TrackBackground.SetInitialState();
         TrackBackground.Name = "TrackBackground";
         ThumbInstance = new CodeGen_MonoGameForms_FullCodegen.Components.Controls.ButtonStandard();
         ThumbInstance.Name = "ThumbInstance";
-        FocusedIndicator = new global::MonoGameGum.GueDeriving.NineSliceRuntime();
+        FocusedIndicator = new global::Gum.GueDeriving.NineSliceRuntime();
         FocusedIndicator.ElementSave = ObjectFinder.Self.GetStandardElement("NineSlice");
         if (FocusedIndicator.ElementSave != null) FocusedIndicator.AddStatesAndCategoriesRecursivelyToGue(FocusedIndicator.ElementSave);
         if (FocusedIndicator.ElementSave != null) FocusedIndicator.SetInitialState();

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/SplitterStandard.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/SplitterStandard.Generated.cs
@@ -1,11 +1,11 @@
 //Code for Controls/SplitterStandard (Container)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGameForms_FullCodegen.Components.Controls;
@@ -16,7 +16,7 @@ partial class SplitterStandard : global::Gum.Forms.Controls.Splitter
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/SplitterStandard");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/SplitterStandard - did you forget to load a Gum project?");
@@ -58,7 +58,7 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     }
     protected virtual void InitializeInstances()
     {
-        NineSliceInstance = new global::MonoGameGum.GueDeriving.NineSliceRuntime();
+        NineSliceInstance = new global::Gum.GueDeriving.NineSliceRuntime();
         NineSliceInstance.ElementSave = ObjectFinder.Self.GetStandardElement("NineSlice");
         if (NineSliceInstance.ElementSave != null) NineSliceInstance.AddStatesAndCategoriesRecursivelyToGue(NineSliceInstance.ElementSave);
         if (NineSliceInstance.ElementSave != null) NineSliceInstance.SetInitialState();

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/StackPanel.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/StackPanel.Generated.cs
@@ -1,11 +1,11 @@
 //Code for Controls/StackPanel (Container)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGameForms_FullCodegen.Components.Controls;
@@ -16,7 +16,7 @@ partial class StackPanel : global::Gum.Forms.Controls.StackPanel
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/StackPanel");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/StackPanel - did you forget to load a Gum project?");

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/TextBox.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/TextBox.Generated.cs
@@ -1,12 +1,12 @@
 //Code for Controls/TextBox (Container)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.StateAnimation.Runtime;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGameForms_FullCodegen.Components.Controls;
@@ -17,7 +17,7 @@ partial class TextBox : global::Gum.Forms.Controls.TextBox
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/TextBox");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/TextBox - did you forget to load a Gum project?");
@@ -158,37 +158,37 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     }
     protected virtual void InitializeInstances()
     {
-        Background = new global::MonoGameGum.GueDeriving.NineSliceRuntime();
+        Background = new global::Gum.GueDeriving.NineSliceRuntime();
         Background.ElementSave = ObjectFinder.Self.GetStandardElement("NineSlice");
         if (Background.ElementSave != null) Background.AddStatesAndCategoriesRecursivelyToGue(Background.ElementSave);
         if (Background.ElementSave != null) Background.SetInitialState();
         Background.Name = "Background";
-        ClipContainer = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+        ClipContainer = new global::Gum.GueDeriving.ContainerRuntime();
         ClipContainer.ElementSave = ObjectFinder.Self.GetStandardElement("Container");
         if (ClipContainer.ElementSave != null) ClipContainer.AddStatesAndCategoriesRecursivelyToGue(ClipContainer.ElementSave);
         if (ClipContainer.ElementSave != null) ClipContainer.SetInitialState();
         ClipContainer.Name = "ClipContainer";
-        SelectionInstance = new global::MonoGameGum.GueDeriving.NineSliceRuntime();
+        SelectionInstance = new global::Gum.GueDeriving.NineSliceRuntime();
         SelectionInstance.ElementSave = ObjectFinder.Self.GetStandardElement("NineSlice");
         if (SelectionInstance.ElementSave != null) SelectionInstance.AddStatesAndCategoriesRecursivelyToGue(SelectionInstance.ElementSave);
         if (SelectionInstance.ElementSave != null) SelectionInstance.SetInitialState();
         SelectionInstance.Name = "SelectionInstance";
-        TextInstance = new global::MonoGameGum.GueDeriving.TextRuntime();
+        TextInstance = new global::Gum.GueDeriving.TextRuntime();
         TextInstance.ElementSave = ObjectFinder.Self.GetStandardElement("Text");
         if (TextInstance.ElementSave != null) TextInstance.AddStatesAndCategoriesRecursivelyToGue(TextInstance.ElementSave);
         if (TextInstance.ElementSave != null) TextInstance.SetInitialState();
         TextInstance.Name = "TextInstance";
-        PlaceholderTextInstance = new global::MonoGameGum.GueDeriving.TextRuntime();
+        PlaceholderTextInstance = new global::Gum.GueDeriving.TextRuntime();
         PlaceholderTextInstance.ElementSave = ObjectFinder.Self.GetStandardElement("Text");
         if (PlaceholderTextInstance.ElementSave != null) PlaceholderTextInstance.AddStatesAndCategoriesRecursivelyToGue(PlaceholderTextInstance.ElementSave);
         if (PlaceholderTextInstance.ElementSave != null) PlaceholderTextInstance.SetInitialState();
         PlaceholderTextInstance.Name = "PlaceholderTextInstance";
-        FocusedIndicator = new global::MonoGameGum.GueDeriving.NineSliceRuntime();
+        FocusedIndicator = new global::Gum.GueDeriving.NineSliceRuntime();
         FocusedIndicator.ElementSave = ObjectFinder.Self.GetStandardElement("NineSlice");
         if (FocusedIndicator.ElementSave != null) FocusedIndicator.AddStatesAndCategoriesRecursivelyToGue(FocusedIndicator.ElementSave);
         if (FocusedIndicator.ElementSave != null) FocusedIndicator.SetInitialState();
         FocusedIndicator.Name = "FocusedIndicator";
-        CaretInstance = new global::MonoGameGum.GueDeriving.SpriteRuntime();
+        CaretInstance = new global::Gum.GueDeriving.SpriteRuntime();
         CaretInstance.ElementSave = ObjectFinder.Self.GetStandardElement("Sprite");
         if (CaretInstance.ElementSave != null) CaretInstance.AddStatesAndCategoriesRecursivelyToGue(CaretInstance.ElementSave);
         if (CaretInstance.ElementSave != null) CaretInstance.SetInitialState();

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/Toast.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/Toast.Generated.cs
@@ -1,11 +1,11 @@
 //Code for Controls/Toast (Container)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGameForms_FullCodegen.Components.Controls;
@@ -16,7 +16,7 @@ partial class Toast : global::Gum.Forms.Controls.FrameworkElement
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/Toast");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/Toast - did you forget to load a Gum project?");
@@ -61,12 +61,12 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     }
     protected virtual void InitializeInstances()
     {
-        Background = new global::MonoGameGum.GueDeriving.NineSliceRuntime();
+        Background = new global::Gum.GueDeriving.NineSliceRuntime();
         Background.ElementSave = ObjectFinder.Self.GetStandardElement("NineSlice");
         if (Background.ElementSave != null) Background.AddStatesAndCategoriesRecursivelyToGue(Background.ElementSave);
         if (Background.ElementSave != null) Background.SetInitialState();
         Background.Name = "Background";
-        TextInstance = new global::MonoGameGum.GueDeriving.TextRuntime();
+        TextInstance = new global::Gum.GueDeriving.TextRuntime();
         TextInstance.ElementSave = ObjectFinder.Self.GetStandardElement("Text");
         if (TextInstance.ElementSave != null) TextInstance.AddStatesAndCategoriesRecursivelyToGue(TextInstance.ElementSave);
         if (TextInstance.ElementSave != null) TextInstance.SetInitialState();

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/TreeView.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/TreeView.Generated.cs
@@ -2,11 +2,11 @@
 using CodeGen_MonoGameForms_FullCodegen.Components.Controls;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGameForms_FullCodegen.Components.Controls;
@@ -17,7 +17,7 @@ partial class TreeView : global::Gum.Forms.Controls.FrameworkElement
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/TreeView");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/TreeView - did you forget to load a Gum project?");
@@ -57,24 +57,24 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     }
     protected virtual void InitializeInstances()
     {
-        Background = new global::MonoGameGum.GueDeriving.NineSliceRuntime();
+        Background = new global::Gum.GueDeriving.NineSliceRuntime();
         Background.ElementSave = ObjectFinder.Self.GetStandardElement("NineSlice");
         if (Background.ElementSave != null) Background.AddStatesAndCategoriesRecursivelyToGue(Background.ElementSave);
         if (Background.ElementSave != null) Background.SetInitialState();
         Background.Name = "Background";
         VerticalScrollBarInstance = new CodeGen_MonoGameForms_FullCodegen.Components.Controls.ScrollBar();
         VerticalScrollBarInstance.Name = "VerticalScrollBarInstance";
-        ClipContainerInstance = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+        ClipContainerInstance = new global::Gum.GueDeriving.ContainerRuntime();
         ClipContainerInstance.ElementSave = ObjectFinder.Self.GetStandardElement("Container");
         if (ClipContainerInstance.ElementSave != null) ClipContainerInstance.AddStatesAndCategoriesRecursivelyToGue(ClipContainerInstance.ElementSave);
         if (ClipContainerInstance.ElementSave != null) ClipContainerInstance.SetInitialState();
         ClipContainerInstance.Name = "ClipContainerInstance";
-        InnerPanelInstance = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+        InnerPanelInstance = new global::Gum.GueDeriving.ContainerRuntime();
         InnerPanelInstance.ElementSave = ObjectFinder.Self.GetStandardElement("Container");
         if (InnerPanelInstance.ElementSave != null) InnerPanelInstance.AddStatesAndCategoriesRecursivelyToGue(InnerPanelInstance.ElementSave);
         if (InnerPanelInstance.ElementSave != null) InnerPanelInstance.SetInitialState();
         InnerPanelInstance.Name = "InnerPanelInstance";
-        FocusedIndicator = new global::MonoGameGum.GueDeriving.NineSliceRuntime();
+        FocusedIndicator = new global::Gum.GueDeriving.NineSliceRuntime();
         FocusedIndicator.ElementSave = ObjectFinder.Self.GetStandardElement("NineSlice");
         if (FocusedIndicator.ElementSave != null) FocusedIndicator.AddStatesAndCategoriesRecursivelyToGue(FocusedIndicator.ElementSave);
         if (FocusedIndicator.ElementSave != null) FocusedIndicator.SetInitialState();

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/TreeViewItem.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/TreeViewItem.Generated.cs
@@ -2,11 +2,11 @@
 using CodeGen_MonoGameForms_FullCodegen.Components.Controls;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGameForms_FullCodegen.Components.Controls;
@@ -17,7 +17,7 @@ partial class TreeViewItem : global::Gum.Forms.Controls.FrameworkElement
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/TreeViewItem");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/TreeViewItem - did you forget to load a Gum project?");
@@ -63,7 +63,7 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
         ToggleButtonInstance.Name = "ToggleButtonInstance";
         ListBoxItemInstance = new CodeGen_MonoGameForms_FullCodegen.Components.Controls.ListBoxItem();
         ListBoxItemInstance.Name = "ListBoxItemInstance";
-        InnerPanelInstance = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+        InnerPanelInstance = new global::Gum.GueDeriving.ContainerRuntime();
         InnerPanelInstance.ElementSave = ObjectFinder.Self.GetStandardElement("Container");
         if (InnerPanelInstance.ElementSave != null) InnerPanelInstance.AddStatesAndCategoriesRecursivelyToGue(InnerPanelInstance.ElementSave);
         if (InnerPanelInstance.ElementSave != null) InnerPanelInstance.SetInitialState();

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/TreeViewToggle.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/TreeViewToggle.Generated.cs
@@ -2,12 +2,12 @@
 using CodeGen_MonoGameForms_FullCodegen.Components.Elements;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.StateAnimation.Runtime;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGameForms_FullCodegen.Components.Controls;
@@ -18,7 +18,7 @@ partial class TreeViewToggle : global::Gum.Forms.Controls.FrameworkElement
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/TreeViewToggle");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/TreeViewToggle - did you forget to load a Gum project?");
@@ -143,7 +143,7 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     }
     protected virtual void InitializeInstances()
     {
-        NineSliceInstance = new global::MonoGameGum.GueDeriving.NineSliceRuntime();
+        NineSliceInstance = new global::Gum.GueDeriving.NineSliceRuntime();
         NineSliceInstance.ElementSave = ObjectFinder.Self.GetStandardElement("NineSlice");
         if (NineSliceInstance.ElementSave != null) NineSliceInstance.AddStatesAndCategoriesRecursivelyToGue(NineSliceInstance.ElementSave);
         if (NineSliceInstance.ElementSave != null) NineSliceInstance.SetInitialState();

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/UserControl.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/UserControl.Generated.cs
@@ -1,11 +1,11 @@
 //Code for Controls/UserControl (Container)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGameForms_FullCodegen.Components.Controls;
@@ -16,7 +16,7 @@ partial class UserControl : global::Gum.Forms.Controls.FrameworkElement
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/UserControl");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/UserControl - did you forget to load a Gum project?");
@@ -52,7 +52,7 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     }
     protected virtual void InitializeInstances()
     {
-        Background = new global::MonoGameGum.GueDeriving.NineSliceRuntime();
+        Background = new global::Gum.GueDeriving.NineSliceRuntime();
         Background.ElementSave = ObjectFinder.Self.GetStandardElement("NineSlice");
         if (Background.ElementSave != null) Background.AddStatesAndCategoriesRecursivelyToGue(Background.ElementSave);
         if (Background.ElementSave != null) Background.SetInitialState();

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/WindowStandard.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/WindowStandard.Generated.cs
@@ -2,11 +2,11 @@
 using CodeGen_MonoGameForms_FullCodegen.Components.Controls;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGameForms_FullCodegen.Components.Controls;
@@ -17,7 +17,7 @@ partial class WindowStandard : global::Gum.Forms.Window
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/WindowStandard");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/WindowStandard - did you forget to load a Gum project?");
@@ -65,7 +65,7 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     }
     protected virtual void InitializeInstances()
     {
-        Background = new global::MonoGameGum.GueDeriving.NineSliceRuntime();
+        Background = new global::Gum.GueDeriving.NineSliceRuntime();
         Background.ElementSave = ObjectFinder.Self.GetStandardElement("NineSlice");
         if (Background.ElementSave != null) Background.AddStatesAndCategoriesRecursivelyToGue(Background.ElementSave);
         if (Background.ElementSave != null) Background.SetInitialState();

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Elements/CautionLines.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Elements/CautionLines.Generated.cs
@@ -1,11 +1,11 @@
 //Code for Elements/CautionLines (Container)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGameForms_FullCodegen.Components.Elements;
@@ -16,7 +16,7 @@ partial class CautionLines : global::Gum.Forms.Controls.FrameworkElement
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Elements/CautionLines");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Elements/CautionLines - did you forget to load a Gum project?");
@@ -62,7 +62,7 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     }
     protected virtual void InitializeInstances()
     {
-        LinesSprite = new global::MonoGameGum.GueDeriving.SpriteRuntime();
+        LinesSprite = new global::Gum.GueDeriving.SpriteRuntime();
         LinesSprite.ElementSave = ObjectFinder.Self.GetStandardElement("Sprite");
         if (LinesSprite.ElementSave != null) LinesSprite.AddStatesAndCategoriesRecursivelyToGue(LinesSprite.ElementSave);
         if (LinesSprite.ElementSave != null) LinesSprite.SetInitialState();

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Elements/Divider.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Elements/Divider.Generated.cs
@@ -1,11 +1,11 @@
 //Code for Elements/Divider (Container)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGameForms_FullCodegen.Components.Elements;
@@ -16,7 +16,7 @@ partial class Divider : global::Gum.Forms.Controls.FrameworkElement
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Elements/Divider");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Elements/Divider - did you forget to load a Gum project?");
@@ -56,17 +56,17 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     }
     protected virtual void InitializeInstances()
     {
-        AccentLeft = new global::MonoGameGum.GueDeriving.SpriteRuntime();
+        AccentLeft = new global::Gum.GueDeriving.SpriteRuntime();
         AccentLeft.ElementSave = ObjectFinder.Self.GetStandardElement("Sprite");
         if (AccentLeft.ElementSave != null) AccentLeft.AddStatesAndCategoriesRecursivelyToGue(AccentLeft.ElementSave);
         if (AccentLeft.ElementSave != null) AccentLeft.SetInitialState();
         AccentLeft.Name = "AccentLeft";
-        Line = new global::MonoGameGum.GueDeriving.SpriteRuntime();
+        Line = new global::Gum.GueDeriving.SpriteRuntime();
         Line.ElementSave = ObjectFinder.Self.GetStandardElement("Sprite");
         if (Line.ElementSave != null) Line.AddStatesAndCategoriesRecursivelyToGue(Line.ElementSave);
         if (Line.ElementSave != null) Line.SetInitialState();
         Line.Name = "Line";
-        AccentRight = new global::MonoGameGum.GueDeriving.SpriteRuntime();
+        AccentRight = new global::Gum.GueDeriving.SpriteRuntime();
         AccentRight.ElementSave = ObjectFinder.Self.GetStandardElement("Sprite");
         if (AccentRight.ElementSave != null) AccentRight.AddStatesAndCategoriesRecursivelyToGue(AccentRight.ElementSave);
         if (AccentRight.ElementSave != null) AccentRight.SetInitialState();

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Elements/DividerHorizontal.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Elements/DividerHorizontal.Generated.cs
@@ -1,12 +1,12 @@
 //Code for Elements/DividerHorizontal (Container)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.StateAnimation.Runtime;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGameForms_FullCodegen.Components.Elements;
@@ -17,7 +17,7 @@ partial class DividerHorizontal : global::Gum.Forms.Controls.FrameworkElement
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Elements/DividerHorizontal");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Elements/DividerHorizontal - did you forget to load a Gum project?");
@@ -58,17 +58,17 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     }
     protected virtual void InitializeInstances()
     {
-        AccentLeft = new global::MonoGameGum.GueDeriving.SpriteRuntime();
+        AccentLeft = new global::Gum.GueDeriving.SpriteRuntime();
         AccentLeft.ElementSave = ObjectFinder.Self.GetStandardElement("Sprite");
         if (AccentLeft.ElementSave != null) AccentLeft.AddStatesAndCategoriesRecursivelyToGue(AccentLeft.ElementSave);
         if (AccentLeft.ElementSave != null) AccentLeft.SetInitialState();
         AccentLeft.Name = "AccentLeft";
-        Line = new global::MonoGameGum.GueDeriving.SpriteRuntime();
+        Line = new global::Gum.GueDeriving.SpriteRuntime();
         Line.ElementSave = ObjectFinder.Self.GetStandardElement("Sprite");
         if (Line.ElementSave != null) Line.AddStatesAndCategoriesRecursivelyToGue(Line.ElementSave);
         if (Line.ElementSave != null) Line.SetInitialState();
         Line.Name = "Line";
-        AccentRight = new global::MonoGameGum.GueDeriving.SpriteRuntime();
+        AccentRight = new global::Gum.GueDeriving.SpriteRuntime();
         AccentRight.ElementSave = ObjectFinder.Self.GetStandardElement("Sprite");
         if (AccentRight.ElementSave != null) AccentRight.AddStatesAndCategoriesRecursivelyToGue(AccentRight.ElementSave);
         if (AccentRight.ElementSave != null) AccentRight.SetInitialState();

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Elements/DividerVertical.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Elements/DividerVertical.Generated.cs
@@ -1,12 +1,12 @@
 //Code for Elements/DividerVertical (Container)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.StateAnimation.Runtime;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGameForms_FullCodegen.Components.Elements;
@@ -17,7 +17,7 @@ partial class DividerVertical : global::Gum.Forms.Controls.FrameworkElement
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Elements/DividerVertical");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Elements/DividerVertical - did you forget to load a Gum project?");
@@ -58,17 +58,17 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     }
     protected virtual void InitializeInstances()
     {
-        AccentTop = new global::MonoGameGum.GueDeriving.SpriteRuntime();
+        AccentTop = new global::Gum.GueDeriving.SpriteRuntime();
         AccentTop.ElementSave = ObjectFinder.Self.GetStandardElement("Sprite");
         if (AccentTop.ElementSave != null) AccentTop.AddStatesAndCategoriesRecursivelyToGue(AccentTop.ElementSave);
         if (AccentTop.ElementSave != null) AccentTop.SetInitialState();
         AccentTop.Name = "AccentTop";
-        Line = new global::MonoGameGum.GueDeriving.SpriteRuntime();
+        Line = new global::Gum.GueDeriving.SpriteRuntime();
         Line.ElementSave = ObjectFinder.Self.GetStandardElement("Sprite");
         if (Line.ElementSave != null) Line.AddStatesAndCategoriesRecursivelyToGue(Line.ElementSave);
         if (Line.ElementSave != null) Line.SetInitialState();
         Line.Name = "Line";
-        AccentRight = new global::MonoGameGum.GueDeriving.SpriteRuntime();
+        AccentRight = new global::Gum.GueDeriving.SpriteRuntime();
         AccentRight.ElementSave = ObjectFinder.Self.GetStandardElement("Sprite");
         if (AccentRight.ElementSave != null) AccentRight.AddStatesAndCategoriesRecursivelyToGue(AccentRight.ElementSave);
         if (AccentRight.ElementSave != null) AccentRight.SetInitialState();

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Elements/Icon.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Elements/Icon.Generated.cs
@@ -1,12 +1,12 @@
 //Code for Elements/Icon (Container)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.StateAnimation.Runtime;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGameForms_FullCodegen.Components.Elements;
@@ -17,7 +17,7 @@ partial class Icon : global::Gum.Forms.Controls.FrameworkElement
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Elements/Icon");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Elements/Icon - did you forget to load a Gum project?");
@@ -654,7 +654,7 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     }
     protected virtual void InitializeInstances()
     {
-        IconSprite = new global::MonoGameGum.GueDeriving.SpriteRuntime();
+        IconSprite = new global::Gum.GueDeriving.SpriteRuntime();
         IconSprite.ElementSave = ObjectFinder.Self.GetStandardElement("Sprite");
         if (IconSprite.ElementSave != null) IconSprite.AddStatesAndCategoriesRecursivelyToGue(IconSprite.ElementSave);
         if (IconSprite.ElementSave != null) IconSprite.SetInitialState();

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Elements/PercentBar.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Elements/PercentBar.Generated.cs
@@ -2,11 +2,11 @@
 using CodeGen_MonoGameForms_FullCodegen.Components.Elements;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGameForms_FullCodegen.Components.Elements;
@@ -17,7 +17,7 @@ partial class PercentBar : global::Gum.Forms.Controls.FrameworkElement
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Elements/PercentBar");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Elements/PercentBar - did you forget to load a Gum project?");
@@ -101,17 +101,17 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     }
     protected virtual void InitializeInstances()
     {
-        Background = new global::MonoGameGum.GueDeriving.NineSliceRuntime();
+        Background = new global::Gum.GueDeriving.NineSliceRuntime();
         Background.ElementSave = ObjectFinder.Self.GetStandardElement("NineSlice");
         if (Background.ElementSave != null) Background.AddStatesAndCategoriesRecursivelyToGue(Background.ElementSave);
         if (Background.ElementSave != null) Background.SetInitialState();
         Background.Name = "Background";
-        BarContainer = new global::MonoGameGum.GueDeriving.NineSliceRuntime();
+        BarContainer = new global::Gum.GueDeriving.NineSliceRuntime();
         BarContainer.ElementSave = ObjectFinder.Self.GetStandardElement("NineSlice");
         if (BarContainer.ElementSave != null) BarContainer.AddStatesAndCategoriesRecursivelyToGue(BarContainer.ElementSave);
         if (BarContainer.ElementSave != null) BarContainer.SetInitialState();
         BarContainer.Name = "BarContainer";
-        Bar = new global::MonoGameGum.GueDeriving.NineSliceRuntime();
+        Bar = new global::Gum.GueDeriving.NineSliceRuntime();
         Bar.ElementSave = ObjectFinder.Self.GetStandardElement("NineSlice");
         if (Bar.ElementSave != null) Bar.AddStatesAndCategoriesRecursivelyToGue(Bar.ElementSave);
         if (Bar.ElementSave != null) Bar.SetInitialState();

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Elements/PercentBarIcon.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Elements/PercentBarIcon.Generated.cs
@@ -2,11 +2,11 @@
 using CodeGen_MonoGameForms_FullCodegen.Components.Elements;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGameForms_FullCodegen.Components.Elements;
@@ -17,7 +17,7 @@ partial class PercentBarIcon : global::Gum.Forms.Controls.FrameworkElement
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Elements/PercentBarIcon");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Elements/PercentBarIcon - did you forget to load a Gum project?");
@@ -109,19 +109,19 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     }
     protected virtual void InitializeInstances()
     {
-        Background = new global::MonoGameGum.GueDeriving.NineSliceRuntime();
+        Background = new global::Gum.GueDeriving.NineSliceRuntime();
         Background.ElementSave = ObjectFinder.Self.GetStandardElement("NineSlice");
         if (Background.ElementSave != null) Background.AddStatesAndCategoriesRecursivelyToGue(Background.ElementSave);
         if (Background.ElementSave != null) Background.SetInitialState();
         Background.Name = "Background";
         IconInstance = new CodeGen_MonoGameForms_FullCodegen.Components.Elements.Icon();
         IconInstance.Name = "IconInstance";
-        BarContainer = new global::MonoGameGum.GueDeriving.NineSliceRuntime();
+        BarContainer = new global::Gum.GueDeriving.NineSliceRuntime();
         BarContainer.ElementSave = ObjectFinder.Self.GetStandardElement("NineSlice");
         if (BarContainer.ElementSave != null) BarContainer.AddStatesAndCategoriesRecursivelyToGue(BarContainer.ElementSave);
         if (BarContainer.ElementSave != null) BarContainer.SetInitialState();
         BarContainer.Name = "BarContainer";
-        Bar = new global::MonoGameGum.GueDeriving.NineSliceRuntime();
+        Bar = new global::Gum.GueDeriving.NineSliceRuntime();
         Bar.ElementSave = ObjectFinder.Self.GetStandardElement("NineSlice");
         if (Bar.ElementSave != null) Bar.AddStatesAndCategoriesRecursivelyToGue(Bar.ElementSave);
         if (Bar.ElementSave != null) Bar.SetInitialState();

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Elements/VerticalLines.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Elements/VerticalLines.Generated.cs
@@ -1,11 +1,11 @@
 //Code for Elements/VerticalLines (Container)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGameForms_FullCodegen.Components.Elements;
@@ -16,7 +16,7 @@ partial class VerticalLines : global::Gum.Forms.Controls.FrameworkElement
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Elements/VerticalLines");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Elements/VerticalLines - did you forget to load a Gum project?");
@@ -62,7 +62,7 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     }
     protected virtual void InitializeInstances()
     {
-        LinesSprite = new global::MonoGameGum.GueDeriving.SpriteRuntime();
+        LinesSprite = new global::Gum.GueDeriving.SpriteRuntime();
         LinesSprite.ElementSave = ObjectFinder.Self.GetStandardElement("Sprite");
         if (LinesSprite.ElementSave != null) LinesSprite.AddStatesAndCategoriesRecursivelyToGue(LinesSprite.ElementSave);
         if (LinesSprite.ElementSave != null) LinesSprite.SetInitialState();

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/LegacyShapes.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/LegacyShapes.Generated.cs
@@ -1,0 +1,111 @@
+//Code for LegacyShapes (Container)
+using Gum.Converters;
+using Gum.DataTypes;
+using Gum.GueDeriving;
+using Gum.Managers;
+using Gum.Wireframe;
+using GumRuntime;
+using MonoGameGum;
+using RenderingLibrary.Graphics;
+using System.Linq;
+namespace CodeGen_MonoGameForms_FullCodegen.Components;
+partial class LegacyShapes : global::Gum.Forms.Controls.FrameworkElement
+{
+    [System.Runtime.CompilerServices.ModuleInitializer]
+    public static void RegisterRuntimeType()
+    {
+        var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
+        {
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
+            var element = ObjectFinder.Self.GetElementSave("LegacyShapes");
+#if DEBUG
+if(element == null) throw new System.InvalidOperationException("Could not find an element named LegacyShapes - did you forget to load a Gum project?");
+#endif
+            element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
+            if(createForms) visual.FormsControlAsObject = new LegacyShapes(visual);
+            return visual;
+        });
+        global::Gum.Forms.Controls.FrameworkElement.DefaultFormsTemplates[typeof(LegacyShapes)] = template;
+        ElementSaveExtensions.RegisterGueInstantiation("LegacyShapes", () => 
+        {
+            var gue = template.CreateContent(null, true) as InteractiveGue;
+            return gue;
+        });
+    }
+    public CircleRuntime FilledCircle { get; protected set; }
+    public CircleRuntime OutlineCircle { get; protected set; }
+    public RectangleRuntime RoundedCustom { get; protected set; }
+    public RectangleRuntime RoundedDefault { get; protected set; }
+
+    public LegacyShapes(InteractiveGue visual) : base(visual)
+    {
+        InitializeInstances();
+        CustomInitialize();
+    }
+    public LegacyShapes() : base(new ContainerRuntime())
+    {
+
+
+        InitializeInstances();
+
+        ApplyDefaultVariables();
+        AssignParents();
+        CustomInitialize();
+    }
+    protected virtual void InitializeInstances()
+    {
+        FilledCircle = new global::Gum.GueDeriving.CircleRuntime();
+        FilledCircle.ElementSave = ObjectFinder.Self.GetStandardElement("ColoredCircle");
+        if (FilledCircle.ElementSave != null) FilledCircle.AddStatesAndCategoriesRecursivelyToGue(FilledCircle.ElementSave);
+        if (FilledCircle.ElementSave != null) FilledCircle.SetInitialState();
+        FilledCircle.IsFilled = true;
+        FilledCircle.StrokeWidth = 0f;
+        FilledCircle.Name = "FilledCircle";
+        OutlineCircle = new global::Gum.GueDeriving.CircleRuntime();
+        OutlineCircle.ElementSave = ObjectFinder.Self.GetStandardElement("ColoredCircle");
+        if (OutlineCircle.ElementSave != null) OutlineCircle.AddStatesAndCategoriesRecursivelyToGue(OutlineCircle.ElementSave);
+        if (OutlineCircle.ElementSave != null) OutlineCircle.SetInitialState();
+        OutlineCircle.IsFilled = false;
+        OutlineCircle.StrokeWidth = 2f;
+        OutlineCircle.Name = "OutlineCircle";
+        RoundedCustom = new global::Gum.GueDeriving.RectangleRuntime();
+        RoundedCustom.ElementSave = ObjectFinder.Self.GetStandardElement("RoundedRectangle");
+        if (RoundedCustom.ElementSave != null) RoundedCustom.AddStatesAndCategoriesRecursivelyToGue(RoundedCustom.ElementSave);
+        if (RoundedCustom.ElementSave != null) RoundedCustom.SetInitialState();
+        RoundedCustom.IsFilled = true;
+        RoundedCustom.StrokeWidth = 0f;
+        RoundedCustom.CornerRadius = 5f;
+        RoundedCustom.Name = "RoundedCustom";
+        RoundedDefault = new global::Gum.GueDeriving.RectangleRuntime();
+        RoundedDefault.ElementSave = ObjectFinder.Self.GetStandardElement("RoundedRectangle");
+        if (RoundedDefault.ElementSave != null) RoundedDefault.AddStatesAndCategoriesRecursivelyToGue(RoundedDefault.ElementSave);
+        if (RoundedDefault.ElementSave != null) RoundedDefault.SetInitialState();
+        RoundedDefault.IsFilled = true;
+        RoundedDefault.StrokeWidth = 0f;
+        RoundedDefault.CornerRadius = 5f;
+        RoundedDefault.Name = "RoundedDefault";
+        base.RefreshInternalVisualReferences();
+    }
+    protected virtual void AssignParents()
+    {
+        this.AddChild(FilledCircle);
+        this.AddChild(OutlineCircle);
+        this.AddChild(RoundedCustom);
+        this.AddChild(RoundedDefault);
+    }
+    private void ApplyDefaultVariables()
+    {
+        this.FilledCircle.FillBlue = 30;
+        this.FilledCircle.FillGreen = 20;
+        this.FilledCircle.FillRed = 10;
+
+        this.OutlineCircle.IsFilled = false;
+        this.OutlineCircle.StrokeRed = 200;
+        this.OutlineCircle.StrokeWidth = 4f;
+
+        this.RoundedCustom.CornerRadius = 8f;
+
+
+    }
+    partial void CustomInitialize();
+}

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/LegacyShapes.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/LegacyShapes.cs
@@ -1,0 +1,19 @@
+using Gum.Converters;
+using Gum.DataTypes;
+using Gum.Managers;
+using Gum.Wireframe;
+
+using RenderingLibrary.Graphics;
+
+using System.Linq;
+
+namespace CodeGen_MonoGameForms_FullCodegen.Components
+{
+    partial class LegacyShapes
+    {
+        partial void CustomInitialize()
+        {
+        
+        }
+    }
+}

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Spaced_Component.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Spaced_Component.Generated.cs
@@ -1,11 +1,11 @@
 //Code for Spaced Component (Container)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGameForms_FullCodegen.Components;
@@ -16,7 +16,7 @@ partial class Spaced_Component : global::Gum.Forms.Controls.FrameworkElement
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Spaced Component");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Spaced Component - did you forget to load a Gum project?");

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Styles.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Styles.Generated.cs
@@ -1,11 +1,11 @@
 //Code for Styles (Container)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGameForms_FullCodegen.Components;
@@ -16,7 +16,7 @@ partial class Styles : global::Gum.Forms.Controls.FrameworkElement
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Styles");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Styles - did you forget to load a Gum project?");
@@ -33,18 +33,18 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
         });
     }
     public ContainerRuntime Colors { get; protected set; }
-    public ColoredRectangleRuntime Black { get; protected set; }
-    public ColoredRectangleRuntime DarkGray { get; protected set; }
-    public ColoredRectangleRuntime Gray { get; protected set; }
-    public ColoredRectangleRuntime LightGray { get; protected set; }
-    public ColoredRectangleRuntime White { get; protected set; }
-    public ColoredRectangleRuntime PrimaryDark { get; protected set; }
-    public ColoredRectangleRuntime Primary { get; protected set; }
-    public ColoredRectangleRuntime PrimaryLight { get; protected set; }
-    public ColoredRectangleRuntime Success { get; protected set; }
-    public ColoredRectangleRuntime Warning { get; protected set; }
-    public ColoredRectangleRuntime Danger { get; protected set; }
-    public ColoredRectangleRuntime Accent { get; protected set; }
+    public RectangleRuntime Black { get; protected set; }
+    public RectangleRuntime DarkGray { get; protected set; }
+    public RectangleRuntime Gray { get; protected set; }
+    public RectangleRuntime LightGray { get; protected set; }
+    public RectangleRuntime White { get; protected set; }
+    public RectangleRuntime PrimaryDark { get; protected set; }
+    public RectangleRuntime Primary { get; protected set; }
+    public RectangleRuntime PrimaryLight { get; protected set; }
+    public RectangleRuntime Success { get; protected set; }
+    public RectangleRuntime Warning { get; protected set; }
+    public RectangleRuntime Danger { get; protected set; }
+    public RectangleRuntime Accent { get; protected set; }
     public TextRuntime Tiny { get; protected set; }
     public TextRuntime Small { get; protected set; }
     public TextRuntime Normal { get; protected set; }
@@ -83,117 +83,141 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     }
     protected virtual void InitializeInstances()
     {
-        Colors = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+        Colors = new global::Gum.GueDeriving.ContainerRuntime();
         Colors.ElementSave = ObjectFinder.Self.GetStandardElement("Container");
         if (Colors.ElementSave != null) Colors.AddStatesAndCategoriesRecursivelyToGue(Colors.ElementSave);
         if (Colors.ElementSave != null) Colors.SetInitialState();
         Colors.Name = "Colors";
-        Black = new global::MonoGameGum.GueDeriving.ColoredRectangleRuntime();
+        Black = new global::Gum.GueDeriving.RectangleRuntime();
         Black.ElementSave = ObjectFinder.Self.GetStandardElement("ColoredRectangle");
         if (Black.ElementSave != null) Black.AddStatesAndCategoriesRecursivelyToGue(Black.ElementSave);
         if (Black.ElementSave != null) Black.SetInitialState();
+        Black.IsFilled = true;
+        Black.StrokeWidth = 0f;
         Black.Name = "Black";
-        DarkGray = new global::MonoGameGum.GueDeriving.ColoredRectangleRuntime();
+        DarkGray = new global::Gum.GueDeriving.RectangleRuntime();
         DarkGray.ElementSave = ObjectFinder.Self.GetStandardElement("ColoredRectangle");
         if (DarkGray.ElementSave != null) DarkGray.AddStatesAndCategoriesRecursivelyToGue(DarkGray.ElementSave);
         if (DarkGray.ElementSave != null) DarkGray.SetInitialState();
+        DarkGray.IsFilled = true;
+        DarkGray.StrokeWidth = 0f;
         DarkGray.Name = "DarkGray";
-        Gray = new global::MonoGameGum.GueDeriving.ColoredRectangleRuntime();
+        Gray = new global::Gum.GueDeriving.RectangleRuntime();
         Gray.ElementSave = ObjectFinder.Self.GetStandardElement("ColoredRectangle");
         if (Gray.ElementSave != null) Gray.AddStatesAndCategoriesRecursivelyToGue(Gray.ElementSave);
         if (Gray.ElementSave != null) Gray.SetInitialState();
+        Gray.IsFilled = true;
+        Gray.StrokeWidth = 0f;
         Gray.Name = "Gray";
-        LightGray = new global::MonoGameGum.GueDeriving.ColoredRectangleRuntime();
+        LightGray = new global::Gum.GueDeriving.RectangleRuntime();
         LightGray.ElementSave = ObjectFinder.Self.GetStandardElement("ColoredRectangle");
         if (LightGray.ElementSave != null) LightGray.AddStatesAndCategoriesRecursivelyToGue(LightGray.ElementSave);
         if (LightGray.ElementSave != null) LightGray.SetInitialState();
+        LightGray.IsFilled = true;
+        LightGray.StrokeWidth = 0f;
         LightGray.Name = "LightGray";
-        White = new global::MonoGameGum.GueDeriving.ColoredRectangleRuntime();
+        White = new global::Gum.GueDeriving.RectangleRuntime();
         White.ElementSave = ObjectFinder.Self.GetStandardElement("ColoredRectangle");
         if (White.ElementSave != null) White.AddStatesAndCategoriesRecursivelyToGue(White.ElementSave);
         if (White.ElementSave != null) White.SetInitialState();
+        White.IsFilled = true;
+        White.StrokeWidth = 0f;
         White.Name = "White";
-        PrimaryDark = new global::MonoGameGum.GueDeriving.ColoredRectangleRuntime();
+        PrimaryDark = new global::Gum.GueDeriving.RectangleRuntime();
         PrimaryDark.ElementSave = ObjectFinder.Self.GetStandardElement("ColoredRectangle");
         if (PrimaryDark.ElementSave != null) PrimaryDark.AddStatesAndCategoriesRecursivelyToGue(PrimaryDark.ElementSave);
         if (PrimaryDark.ElementSave != null) PrimaryDark.SetInitialState();
+        PrimaryDark.IsFilled = true;
+        PrimaryDark.StrokeWidth = 0f;
         PrimaryDark.Name = "PrimaryDark";
-        Primary = new global::MonoGameGum.GueDeriving.ColoredRectangleRuntime();
+        Primary = new global::Gum.GueDeriving.RectangleRuntime();
         Primary.ElementSave = ObjectFinder.Self.GetStandardElement("ColoredRectangle");
         if (Primary.ElementSave != null) Primary.AddStatesAndCategoriesRecursivelyToGue(Primary.ElementSave);
         if (Primary.ElementSave != null) Primary.SetInitialState();
+        Primary.IsFilled = true;
+        Primary.StrokeWidth = 0f;
         Primary.Name = "Primary";
-        PrimaryLight = new global::MonoGameGum.GueDeriving.ColoredRectangleRuntime();
+        PrimaryLight = new global::Gum.GueDeriving.RectangleRuntime();
         PrimaryLight.ElementSave = ObjectFinder.Self.GetStandardElement("ColoredRectangle");
         if (PrimaryLight.ElementSave != null) PrimaryLight.AddStatesAndCategoriesRecursivelyToGue(PrimaryLight.ElementSave);
         if (PrimaryLight.ElementSave != null) PrimaryLight.SetInitialState();
+        PrimaryLight.IsFilled = true;
+        PrimaryLight.StrokeWidth = 0f;
         PrimaryLight.Name = "PrimaryLight";
-        Success = new global::MonoGameGum.GueDeriving.ColoredRectangleRuntime();
+        Success = new global::Gum.GueDeriving.RectangleRuntime();
         Success.ElementSave = ObjectFinder.Self.GetStandardElement("ColoredRectangle");
         if (Success.ElementSave != null) Success.AddStatesAndCategoriesRecursivelyToGue(Success.ElementSave);
         if (Success.ElementSave != null) Success.SetInitialState();
+        Success.IsFilled = true;
+        Success.StrokeWidth = 0f;
         Success.Name = "Success";
-        Warning = new global::MonoGameGum.GueDeriving.ColoredRectangleRuntime();
+        Warning = new global::Gum.GueDeriving.RectangleRuntime();
         Warning.ElementSave = ObjectFinder.Self.GetStandardElement("ColoredRectangle");
         if (Warning.ElementSave != null) Warning.AddStatesAndCategoriesRecursivelyToGue(Warning.ElementSave);
         if (Warning.ElementSave != null) Warning.SetInitialState();
+        Warning.IsFilled = true;
+        Warning.StrokeWidth = 0f;
         Warning.Name = "Warning";
-        Danger = new global::MonoGameGum.GueDeriving.ColoredRectangleRuntime();
+        Danger = new global::Gum.GueDeriving.RectangleRuntime();
         Danger.ElementSave = ObjectFinder.Self.GetStandardElement("ColoredRectangle");
         if (Danger.ElementSave != null) Danger.AddStatesAndCategoriesRecursivelyToGue(Danger.ElementSave);
         if (Danger.ElementSave != null) Danger.SetInitialState();
+        Danger.IsFilled = true;
+        Danger.StrokeWidth = 0f;
         Danger.Name = "Danger";
-        Accent = new global::MonoGameGum.GueDeriving.ColoredRectangleRuntime();
+        Accent = new global::Gum.GueDeriving.RectangleRuntime();
         Accent.ElementSave = ObjectFinder.Self.GetStandardElement("ColoredRectangle");
         if (Accent.ElementSave != null) Accent.AddStatesAndCategoriesRecursivelyToGue(Accent.ElementSave);
         if (Accent.ElementSave != null) Accent.SetInitialState();
+        Accent.IsFilled = true;
+        Accent.StrokeWidth = 0f;
         Accent.Name = "Accent";
-        Tiny = new global::MonoGameGum.GueDeriving.TextRuntime();
+        Tiny = new global::Gum.GueDeriving.TextRuntime();
         Tiny.ElementSave = ObjectFinder.Self.GetStandardElement("Text");
         if (Tiny.ElementSave != null) Tiny.AddStatesAndCategoriesRecursivelyToGue(Tiny.ElementSave);
         if (Tiny.ElementSave != null) Tiny.SetInitialState();
         Tiny.Name = "Tiny";
-        Small = new global::MonoGameGum.GueDeriving.TextRuntime();
+        Small = new global::Gum.GueDeriving.TextRuntime();
         Small.ElementSave = ObjectFinder.Self.GetStandardElement("Text");
         if (Small.ElementSave != null) Small.AddStatesAndCategoriesRecursivelyToGue(Small.ElementSave);
         if (Small.ElementSave != null) Small.SetInitialState();
         Small.Name = "Small";
-        Normal = new global::MonoGameGum.GueDeriving.TextRuntime();
+        Normal = new global::Gum.GueDeriving.TextRuntime();
         Normal.ElementSave = ObjectFinder.Self.GetStandardElement("Text");
         if (Normal.ElementSave != null) Normal.AddStatesAndCategoriesRecursivelyToGue(Normal.ElementSave);
         if (Normal.ElementSave != null) Normal.SetInitialState();
         Normal.Name = "Normal";
-        Emphasis = new global::MonoGameGum.GueDeriving.TextRuntime();
+        Emphasis = new global::Gum.GueDeriving.TextRuntime();
         Emphasis.ElementSave = ObjectFinder.Self.GetStandardElement("Text");
         if (Emphasis.ElementSave != null) Emphasis.AddStatesAndCategoriesRecursivelyToGue(Emphasis.ElementSave);
         if (Emphasis.ElementSave != null) Emphasis.SetInitialState();
         Emphasis.Name = "Emphasis";
-        Strong = new global::MonoGameGum.GueDeriving.TextRuntime();
+        Strong = new global::Gum.GueDeriving.TextRuntime();
         Strong.ElementSave = ObjectFinder.Self.GetStandardElement("Text");
         if (Strong.ElementSave != null) Strong.AddStatesAndCategoriesRecursivelyToGue(Strong.ElementSave);
         if (Strong.ElementSave != null) Strong.SetInitialState();
         Strong.Name = "Strong";
-        H3 = new global::MonoGameGum.GueDeriving.TextRuntime();
+        H3 = new global::Gum.GueDeriving.TextRuntime();
         H3.ElementSave = ObjectFinder.Self.GetStandardElement("Text");
         if (H3.ElementSave != null) H3.AddStatesAndCategoriesRecursivelyToGue(H3.ElementSave);
         if (H3.ElementSave != null) H3.SetInitialState();
         H3.Name = "H3";
-        H2 = new global::MonoGameGum.GueDeriving.TextRuntime();
+        H2 = new global::Gum.GueDeriving.TextRuntime();
         H2.ElementSave = ObjectFinder.Self.GetStandardElement("Text");
         if (H2.ElementSave != null) H2.AddStatesAndCategoriesRecursivelyToGue(H2.ElementSave);
         if (H2.ElementSave != null) H2.SetInitialState();
         H2.Name = "H2";
-        H1 = new global::MonoGameGum.GueDeriving.TextRuntime();
+        H1 = new global::Gum.GueDeriving.TextRuntime();
         H1.ElementSave = ObjectFinder.Self.GetStandardElement("Text");
         if (H1.ElementSave != null) H1.AddStatesAndCategoriesRecursivelyToGue(H1.ElementSave);
         if (H1.ElementSave != null) H1.SetInitialState();
         H1.Name = "H1";
-        TextStyles = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+        TextStyles = new global::Gum.GueDeriving.ContainerRuntime();
         TextStyles.ElementSave = ObjectFinder.Self.GetStandardElement("Container");
         if (TextStyles.ElementSave != null) TextStyles.AddStatesAndCategoriesRecursivelyToGue(TextStyles.ElementSave);
         if (TextStyles.ElementSave != null) TextStyles.SetInitialState();
         TextStyles.Name = "TextStyles";
-        Title = new global::MonoGameGum.GueDeriving.TextRuntime();
+        Title = new global::Gum.GueDeriving.TextRuntime();
         Title.ElementSave = ObjectFinder.Self.GetStandardElement("Text");
         if (Title.ElementSave != null) Title.AddStatesAndCategoriesRecursivelyToGue(Title.ElementSave);
         if (Title.ElementSave != null) Title.SetInitialState();
@@ -240,50 +264,50 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
         this.Colors.YOrigin = global::RenderingLibrary.Graphics.VerticalAlignment.Top;
         this.Colors.YUnits = global::Gum.Converters.GeneralUnitType.PixelsFromSmall;
 
-        this.Black.Blue = 0;
-        this.Black.Green = 0;
-        this.Black.Red = 0;
+        this.Black.FillBlue = 0;
+        this.Black.FillGreen = 0;
+        this.Black.FillRed = 0;
 
-        this.DarkGray.Blue = 80;
-        this.DarkGray.Green = 70;
-        this.DarkGray.Red = 70;
+        this.DarkGray.FillBlue = 80;
+        this.DarkGray.FillGreen = 70;
+        this.DarkGray.FillRed = 70;
 
-        this.Gray.Blue = 130;
-        this.Gray.Green = 130;
-        this.Gray.Red = 130;
+        this.Gray.FillBlue = 130;
+        this.Gray.FillGreen = 130;
+        this.Gray.FillRed = 130;
 
-        this.LightGray.Blue = 170;
-        this.LightGray.Green = 170;
-        this.LightGray.Red = 170;
+        this.LightGray.FillBlue = 170;
+        this.LightGray.FillGreen = 170;
+        this.LightGray.FillRed = 170;
 
 
-        this.PrimaryDark.Blue = 137;
-        this.PrimaryDark.Green = 120;
-        this.PrimaryDark.Red = 4;
+        this.PrimaryDark.FillBlue = 137;
+        this.PrimaryDark.FillGreen = 120;
+        this.PrimaryDark.FillRed = 4;
 
-        this.Primary.Blue = 177;
-        this.Primary.Green = 159;
-        this.Primary.Red = 6;
+        this.Primary.FillBlue = 177;
+        this.Primary.FillGreen = 159;
+        this.Primary.FillRed = 6;
 
-        this.PrimaryLight.Blue = 193;
-        this.PrimaryLight.Green = 180;
-        this.PrimaryLight.Red = 74;
+        this.PrimaryLight.FillBlue = 193;
+        this.PrimaryLight.FillGreen = 180;
+        this.PrimaryLight.FillRed = 74;
 
-        this.Success.Blue = 48;
-        this.Success.Green = 167;
-        this.Success.Red = 62;
+        this.Success.FillBlue = 48;
+        this.Success.FillGreen = 167;
+        this.Success.FillRed = 62;
 
-        this.Warning.Blue = 25;
-        this.Warning.Green = 171;
-        this.Warning.Red = 232;
+        this.Warning.FillBlue = 25;
+        this.Warning.FillGreen = 171;
+        this.Warning.FillRed = 232;
 
-        this.Danger.Blue = 41;
-        this.Danger.Green = 18;
-        this.Danger.Red = 212;
+        this.Danger.FillBlue = 41;
+        this.Danger.FillGreen = 18;
+        this.Danger.FillRed = 212;
 
-        this.Accent.Blue = 138;
-        this.Accent.Green = 48;
-        this.Accent.Red = 140;
+        this.Accent.FillBlue = 138;
+        this.Accent.FillGreen = 48;
+        this.Accent.FillRed = 140;
 
         this.Tiny.FontSize = 10;
         this.Tiny.Text = @"Tiny";

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/_123Component.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/_123Component.Generated.cs
@@ -1,11 +1,11 @@
 //Code for 123Component (Container)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGameForms_FullCodegen.Components;
@@ -16,7 +16,7 @@ partial class _123Component : global::Gum.Forms.Controls.FrameworkElement
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("123Component");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named 123Component - did you forget to load a Gum project?");

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Content/CodeGenProject.gumx
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Content/CodeGenProject.gumx
@@ -303,6 +303,11 @@
     <LinkType>ReferenceOriginal</LinkType>
   </ComponentReference>
   <ComponentReference>
+    <Name>LegacyShapes</Name>
+    <ElementType>Component</ElementType>
+    <LinkType>ReferenceOriginal</LinkType>
+  </ComponentReference>
+  <ComponentReference>
     <Name>Spaced Component</Name>
     <ElementType>Component</ElementType>
     <LinkType>ReferenceOriginal</LinkType>
@@ -314,6 +319,11 @@
   </ComponentReference>
   <StandardElementReference>
     <Name>Circle</Name>
+    <ElementType>Standard</ElementType>
+    <LinkType>ReferenceOriginal</LinkType>
+  </StandardElementReference>
+  <StandardElementReference>
+    <Name>ColoredCircle</Name>
     <ElementType>Standard</ElementType>
     <LinkType>ReferenceOriginal</LinkType>
   </StandardElementReference>
@@ -344,6 +354,11 @@
   </StandardElementReference>
   <StandardElementReference>
     <Name>Rectangle</Name>
+    <ElementType>Standard</ElementType>
+    <LinkType>ReferenceOriginal</LinkType>
+  </StandardElementReference>
+  <StandardElementReference>
+    <Name>RoundedRectangle</Name>
     <ElementType>Standard</ElementType>
     <LinkType>ReferenceOriginal</LinkType>
   </StandardElementReference>

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Content/Components/LegacyShapes.gucx
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Content/Components/LegacyShapes.gucx
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ComponentSave xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <Name>LegacyShapes</Name>
+  <BaseType>Container</BaseType>
+  <State>
+    <Name>Default</Name>
+    <Variable>
+      <Type>int</Type>
+      <Name>FilledCircle.Blue</Name>
+      <Value xsi:type="xsd:int">30</Value>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>int</Type>
+      <Name>FilledCircle.Green</Name>
+      <Value xsi:type="xsd:int">20</Value>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>int</Type>
+      <Name>FilledCircle.Red</Name>
+      <Value xsi:type="xsd:int">10</Value>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>bool</Type>
+      <Name>OutlineCircle.IsFilled</Name>
+      <Value xsi:type="xsd:boolean">false</Value>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>int</Type>
+      <Name>OutlineCircle.Red</Name>
+      <Value xsi:type="xsd:int">200</Value>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>float</Type>
+      <Name>OutlineCircle.StrokeWidth</Name>
+      <Value xsi:type="xsd:float">4</Value>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>float</Type>
+      <Name>RoundedCustom.CornerRadius</Name>
+      <Value xsi:type="xsd:float">8</Value>
+      <SetsValue>true</SetsValue>
+    </Variable>
+  </State>
+  <Instance>
+    <Name>FilledCircle</Name>
+    <BaseType>ColoredCircle</BaseType>
+    <DefinedByBase>false</DefinedByBase>
+  </Instance>
+  <Instance>
+    <Name>OutlineCircle</Name>
+    <BaseType>ColoredCircle</BaseType>
+    <DefinedByBase>false</DefinedByBase>
+  </Instance>
+  <Instance>
+    <Name>RoundedCustom</Name>
+    <BaseType>RoundedRectangle</BaseType>
+    <DefinedByBase>false</DefinedByBase>
+  </Instance>
+  <Instance>
+    <Name>RoundedDefault</Name>
+    <BaseType>RoundedRectangle</BaseType>
+    <DefinedByBase>false</DefinedByBase>
+  </Instance>
+</ComponentSave>

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Content/Standards/ColoredCircle.gutx
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Content/Standards/ColoredCircle.gutx
@@ -1,0 +1,450 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<StandardElementSave xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <Name>ColoredCircle</Name>
+  <State>
+    <Name>Default</Name>
+    <Variable>
+      <Type>int</Type>
+      <Name>Alpha</Name>
+      <Value xsi:type="xsd:int">255</Value>
+      <Category>Rendering</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>int</Type>
+      <Name>Alpha1</Name>
+      <Value xsi:type="xsd:int">255</Value>
+      <Category>Rendering</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>int</Type>
+      <Name>Alpha2</Name>
+      <Value xsi:type="xsd:int">255</Value>
+      <Category>Rendering</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>Blend</Type>
+      <Name>Blend</Name>
+      <Value xsi:type="xsd:int">0</Value>
+      <Category>Rendering</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>int</Type>
+      <Name>Blue</Name>
+      <Value xsi:type="xsd:int">255</Value>
+      <Category>Rendering</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>int</Type>
+      <Name>Blue1</Name>
+      <Value xsi:type="xsd:int">255</Value>
+      <Category>Rendering</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>int</Type>
+      <Name>Blue2</Name>
+      <Value xsi:type="xsd:int">0</Value>
+      <Category>Rendering</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>int</Type>
+      <Name>DropshadowAlpha</Name>
+      <Value xsi:type="xsd:int">255</Value>
+      <Category>Dropshadow</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>int</Type>
+      <Name>DropshadowBlue</Name>
+      <Value xsi:type="xsd:int">0</Value>
+      <Category>Dropshadow</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>float</Type>
+      <Name>DropshadowBlurX</Name>
+      <Value xsi:type="xsd:float">0</Value>
+      <Category>Dropshadow</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>float</Type>
+      <Name>DropshadowBlurY</Name>
+      <Value xsi:type="xsd:float">3</Value>
+      <Category>Dropshadow</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>int</Type>
+      <Name>DropshadowGreen</Name>
+      <Value xsi:type="xsd:int">0</Value>
+      <Category>Dropshadow</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>float</Type>
+      <Name>DropshadowOffsetX</Name>
+      <Value xsi:type="xsd:float">0</Value>
+      <Category>Dropshadow</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>float</Type>
+      <Name>DropshadowOffsetY</Name>
+      <Value xsi:type="xsd:float">3</Value>
+      <Category>Dropshadow</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>int</Type>
+      <Name>DropshadowRed</Name>
+      <Value xsi:type="xsd:int">0</Value>
+      <Category>Dropshadow</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>bool</Type>
+      <Name>ExposeChildrenEvents</Name>
+      <Value xsi:type="xsd:boolean">false</Value>
+      <Category>Behavior</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>bool</Type>
+      <Name>FlipHorizontal</Name>
+      <Value xsi:type="xsd:boolean">false</Value>
+      <Category>Flip and Rotation</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>bool</Type>
+      <Name>FlipVertical</Name>
+      <Value xsi:type="xsd:boolean">false</Value>
+      <Category>Flip and Rotation</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>float</Type>
+      <Name>GradientInnerRadius</Name>
+      <Value xsi:type="xsd:float">50</Value>
+      <Category>Rendering</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>DimensionUnitType</Type>
+      <Name>GradientInnerRadiusUnits</Name>
+      <Value xsi:type="xsd:int">0</Value>
+      <Category>Rendering</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>float</Type>
+      <Name>GradientOuterRadius</Name>
+      <Value xsi:type="xsd:float">100</Value>
+      <Category>Rendering</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>DimensionUnitType</Type>
+      <Name>GradientOuterRadiusUnits</Name>
+      <Value xsi:type="xsd:int">0</Value>
+      <Category>Rendering</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>GradientType</Type>
+      <Name>GradientType</Name>
+      <Value xsi:type="xsd:int">0</Value>
+      <Category>Rendering</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>float</Type>
+      <Name>GradientX1</Name>
+      <Value xsi:type="xsd:float">0</Value>
+      <Category>Rendering</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>PositionUnitType</Type>
+      <Name>GradientX1Units</Name>
+      <Value xsi:type="xsd:int">0</Value>
+      <Category>Rendering</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>float</Type>
+      <Name>GradientX2</Name>
+      <Value xsi:type="xsd:float">100</Value>
+      <Category>Rendering</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>PositionUnitType</Type>
+      <Name>GradientX2Units</Name>
+      <Value xsi:type="xsd:int">0</Value>
+      <Category>Rendering</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>float</Type>
+      <Name>GradientY1</Name>
+      <Value xsi:type="xsd:float">0</Value>
+      <Category>Rendering</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>PositionUnitType</Type>
+      <Name>GradientY1Units</Name>
+      <Value xsi:type="xsd:int">1</Value>
+      <Category>Rendering</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>float</Type>
+      <Name>GradientY2</Name>
+      <Value xsi:type="xsd:float">100</Value>
+      <Category>Rendering</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>PositionUnitType</Type>
+      <Name>GradientY2Units</Name>
+      <Value xsi:type="xsd:int">1</Value>
+      <Category>Rendering</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>int</Type>
+      <Name>Green</Name>
+      <Value xsi:type="xsd:int">255</Value>
+      <Category>Rendering</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>int</Type>
+      <Name>Green1</Name>
+      <Value xsi:type="xsd:int">255</Value>
+      <Category>Rendering</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>int</Type>
+      <Name>Green2</Name>
+      <Value xsi:type="xsd:int">255</Value>
+      <Category>Rendering</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>string</Type>
+      <Name>Guide</Name>
+      <Category>Position</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>bool</Type>
+      <Name>HasDropshadow</Name>
+      <Value xsi:type="xsd:boolean">false</Value>
+      <Category>Dropshadow</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>bool</Type>
+      <Name>HasEvents</Name>
+      <Value xsi:type="xsd:boolean">false</Value>
+      <Category>Behavior</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>float</Type>
+      <Name>Height</Name>
+      <Value xsi:type="xsd:float">100</Value>
+      <Category>Dimensions</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>DimensionUnitType</Type>
+      <Name>HeightUnits</Name>
+      <Value xsi:type="xsd:int">0</Value>
+      <Category>Dimensions</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>bool</Type>
+      <Name>IgnoredByParentSize</Name>
+      <Value xsi:type="xsd:boolean">false</Value>
+      <Category>Parent</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>bool</Type>
+      <Name>IsFilled</Name>
+      <Value xsi:type="xsd:boolean">true</Value>
+      <Category>Stroke and Fill</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>float?</Type>
+      <Name>MaxHeight</Name>
+      <Category>Dimensions</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>float?</Type>
+      <Name>MaxWidth</Name>
+      <Category>Dimensions</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>float?</Type>
+      <Name>MinHeight</Name>
+      <Category>Dimensions</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>float?</Type>
+      <Name>MinWidth</Name>
+      <Category>Dimensions</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>string</Type>
+      <Name>Parent</Name>
+      <Category>Parent</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>int</Type>
+      <Name>Red</Name>
+      <Value xsi:type="xsd:int">255</Value>
+      <Category>Rendering</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>int</Type>
+      <Name>Red1</Name>
+      <Value xsi:type="xsd:int">255</Value>
+      <Category>Rendering</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>int</Type>
+      <Name>Red2</Name>
+      <Value xsi:type="xsd:int">255</Value>
+      <Category>Rendering</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>float</Type>
+      <Name>Rotation</Name>
+      <Value xsi:type="xsd:float">0</Value>
+      <Category>Flip and Rotation</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>State</Type>
+      <Name>State</Name>
+      <Value xsi:type="xsd:string">Default</Value>
+      <SetsValue>false</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>float</Type>
+      <Name>StrokeWidth</Name>
+      <Value xsi:type="xsd:float">2</Value>
+      <Category>Stroke and Fill</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>bool</Type>
+      <Name>UseGradient</Name>
+      <Value xsi:type="xsd:boolean">false</Value>
+      <Category>Rendering</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>bool</Type>
+      <Name>Visible</Name>
+      <Value xsi:type="xsd:boolean">true</Value>
+      <Category>States and Visibility</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>float</Type>
+      <Name>Width</Name>
+      <Value xsi:type="xsd:float">100</Value>
+      <Category>Dimensions</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>DimensionUnitType</Type>
+      <Name>WidthUnits</Name>
+      <Value xsi:type="xsd:int">0</Value>
+      <Category>Dimensions</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>bool</Type>
+      <Name>Wrap</Name>
+      <Value xsi:type="xsd:boolean">false</Value>
+      <Category>Source</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>float</Type>
+      <Name>X</Name>
+      <Value xsi:type="xsd:float">0</Value>
+      <Category>Position</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>HorizontalAlignment</Type>
+      <Name>XOrigin</Name>
+      <Value xsi:type="xsd:int">0</Value>
+      <Category>Position</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>PositionUnitType</Type>
+      <Name>XUnits</Name>
+      <Value xsi:type="xsd:int">0</Value>
+      <Category>Position</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>float</Type>
+      <Name>Y</Name>
+      <Value xsi:type="xsd:float">0</Value>
+      <Category>Position</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>VerticalAlignment</Type>
+      <Name>YOrigin</Name>
+      <Value xsi:type="xsd:int">0</Value>
+      <Category>Position</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>PositionUnitType</Type>
+      <Name>YUnits</Name>
+      <Value xsi:type="xsd:int">1</Value>
+      <Category>Position</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <VariableList xsi:type="VariableListSaveOfString">
+      <Type>string</Type>
+      <Name>VariableReferences</Name>
+      <Category>References</Category>
+      <IsFile>false</IsFile>
+      <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
+      <Value />
+    </VariableList>
+  </State>
+  <Behaviors />
+</StandardElementSave>

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Content/Standards/RoundedRectangle.gutx
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Content/Standards/RoundedRectangle.gutx
@@ -1,0 +1,437 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<StandardElementSave xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <Name>RoundedRectangle</Name>
+  <State>
+    <Name>Default</Name>
+    <Variable>
+      <Type>int</Type>
+      <Name>Alpha</Name>
+      <Value xsi:type="xsd:int">255</Value>
+      <Category>Rendering</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>int</Type>
+      <Name>Alpha1</Name>
+      <Value xsi:type="xsd:int">255</Value>
+      <Category>Rendering</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>int</Type>
+      <Name>Alpha2</Name>
+      <Value xsi:type="xsd:int">255</Value>
+      <Category>Rendering</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>Blend</Type>
+      <Name>Blend</Name>
+      <Value xsi:type="xsd:int">0</Value>
+      <Category>Rendering</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>int</Type>
+      <Name>Blue</Name>
+      <Value xsi:type="xsd:int">255</Value>
+      <Category>Rendering</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>int</Type>
+      <Name>Blue1</Name>
+      <Value xsi:type="xsd:int">255</Value>
+      <Category>Rendering</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>int</Type>
+      <Name>Blue2</Name>
+      <Value xsi:type="xsd:int">0</Value>
+      <Category>Rendering</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>bool</Type>
+      <Name>ClipsChildren</Name>
+      <Value xsi:type="xsd:boolean">false</Value>
+      <Category>Children</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>float</Type>
+      <Name>CornerRadius</Name>
+      <Value xsi:type="xsd:float">5</Value>
+      <Category>Dimensions</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>int</Type>
+      <Name>DropshadowAlpha</Name>
+      <Value xsi:type="xsd:int">255</Value>
+      <Category>Dropshadow</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>int</Type>
+      <Name>DropshadowBlue</Name>
+      <Value xsi:type="xsd:int">0</Value>
+      <Category>Dropshadow</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>float</Type>
+      <Name>DropshadowBlurX</Name>
+      <Value xsi:type="xsd:float">0</Value>
+      <Category>Dropshadow</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>float</Type>
+      <Name>DropshadowBlurY</Name>
+      <Value xsi:type="xsd:float">3</Value>
+      <Category>Dropshadow</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>int</Type>
+      <Name>DropshadowGreen</Name>
+      <Value xsi:type="xsd:int">0</Value>
+      <Category>Dropshadow</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>float</Type>
+      <Name>DropshadowOffsetX</Name>
+      <Value xsi:type="xsd:float">0</Value>
+      <Category>Dropshadow</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>float</Type>
+      <Name>DropshadowOffsetY</Name>
+      <Value xsi:type="xsd:float">3</Value>
+      <Category>Dropshadow</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>int</Type>
+      <Name>DropshadowRed</Name>
+      <Value xsi:type="xsd:int">0</Value>
+      <Category>Dropshadow</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>bool</Type>
+      <Name>ExposeChildrenEvents</Name>
+      <Value xsi:type="xsd:boolean">false</Value>
+      <Category>Behavior</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>float</Type>
+      <Name>GradientInnerRadius</Name>
+      <Value xsi:type="xsd:float">50</Value>
+      <Category>Rendering</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>DimensionUnitType</Type>
+      <Name>GradientInnerRadiusUnits</Name>
+      <Value xsi:type="xsd:int">0</Value>
+      <Category>Rendering</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>float</Type>
+      <Name>GradientOuterRadius</Name>
+      <Value xsi:type="xsd:float">100</Value>
+      <Category>Rendering</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>DimensionUnitType</Type>
+      <Name>GradientOuterRadiusUnits</Name>
+      <Value xsi:type="xsd:int">0</Value>
+      <Category>Rendering</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>GradientType</Type>
+      <Name>GradientType</Name>
+      <Value xsi:type="xsd:int">0</Value>
+      <Category>Rendering</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>float</Type>
+      <Name>GradientX1</Name>
+      <Value xsi:type="xsd:float">0</Value>
+      <Category>Rendering</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>PositionUnitType</Type>
+      <Name>GradientX1Units</Name>
+      <Value xsi:type="xsd:int">0</Value>
+      <Category>Rendering</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>float</Type>
+      <Name>GradientX2</Name>
+      <Value xsi:type="xsd:float">100</Value>
+      <Category>Rendering</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>PositionUnitType</Type>
+      <Name>GradientX2Units</Name>
+      <Value xsi:type="xsd:int">0</Value>
+      <Category>Rendering</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>float</Type>
+      <Name>GradientY1</Name>
+      <Value xsi:type="xsd:float">0</Value>
+      <Category>Rendering</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>PositionUnitType</Type>
+      <Name>GradientY1Units</Name>
+      <Value xsi:type="xsd:int">1</Value>
+      <Category>Rendering</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>float</Type>
+      <Name>GradientY2</Name>
+      <Value xsi:type="xsd:float">100</Value>
+      <Category>Rendering</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>PositionUnitType</Type>
+      <Name>GradientY2Units</Name>
+      <Value xsi:type="xsd:int">1</Value>
+      <Category>Rendering</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>int</Type>
+      <Name>Green</Name>
+      <Value xsi:type="xsd:int">255</Value>
+      <Category>Rendering</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>int</Type>
+      <Name>Green1</Name>
+      <Value xsi:type="xsd:int">255</Value>
+      <Category>Rendering</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>int</Type>
+      <Name>Green2</Name>
+      <Value xsi:type="xsd:int">255</Value>
+      <Category>Rendering</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>bool</Type>
+      <Name>HasDropshadow</Name>
+      <Value xsi:type="xsd:boolean">false</Value>
+      <Category>Dropshadow</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>bool</Type>
+      <Name>HasEvents</Name>
+      <Value xsi:type="xsd:boolean">false</Value>
+      <Category>Behavior</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>float</Type>
+      <Name>Height</Name>
+      <Value xsi:type="xsd:float">100</Value>
+      <Category>Dimensions</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>DimensionUnitType</Type>
+      <Name>HeightUnits</Name>
+      <Value xsi:type="xsd:int">0</Value>
+      <Category>Dimensions</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>bool</Type>
+      <Name>IgnoredByParentSize</Name>
+      <Value xsi:type="xsd:boolean">false</Value>
+      <Category>Parent</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>bool</Type>
+      <Name>IsFilled</Name>
+      <Value xsi:type="xsd:boolean">true</Value>
+      <Category>Stroke and Fill</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>float?</Type>
+      <Name>MaxHeight</Name>
+      <Category>Dimensions</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>float?</Type>
+      <Name>MaxWidth</Name>
+      <Category>Dimensions</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>float?</Type>
+      <Name>MinHeight</Name>
+      <Category>Dimensions</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>float?</Type>
+      <Name>MinWidth</Name>
+      <Category>Dimensions</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>string</Type>
+      <Name>Parent</Name>
+      <Category>Parent</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>int</Type>
+      <Name>Red</Name>
+      <Value xsi:type="xsd:int">255</Value>
+      <Category>Rendering</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>int</Type>
+      <Name>Red1</Name>
+      <Value xsi:type="xsd:int">255</Value>
+      <Category>Rendering</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>int</Type>
+      <Name>Red2</Name>
+      <Value xsi:type="xsd:int">255</Value>
+      <Category>Rendering</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>float</Type>
+      <Name>Rotation</Name>
+      <Value xsi:type="xsd:float">0</Value>
+      <Category>Flip and Rotation</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>State</Type>
+      <Name>State</Name>
+      <Value xsi:type="xsd:string">Default</Value>
+      <SetsValue>false</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>float</Type>
+      <Name>StrokeWidth</Name>
+      <Value xsi:type="xsd:float">2</Value>
+      <Category>Stroke and Fill</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>bool</Type>
+      <Name>UseGradient</Name>
+      <Value xsi:type="xsd:boolean">false</Value>
+      <Category>Rendering</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>bool</Type>
+      <Name>Visible</Name>
+      <Value xsi:type="xsd:boolean">true</Value>
+      <Category>States and Visibility</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>float</Type>
+      <Name>Width</Name>
+      <Value xsi:type="xsd:float">100</Value>
+      <Category>Dimensions</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>DimensionUnitType</Type>
+      <Name>WidthUnits</Name>
+      <Value xsi:type="xsd:int">0</Value>
+      <Category>Dimensions</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>float</Type>
+      <Name>X</Name>
+      <Value xsi:type="xsd:float">0</Value>
+      <Category>Position</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>HorizontalAlignment</Type>
+      <Name>XOrigin</Name>
+      <Value xsi:type="xsd:int">0</Value>
+      <Category>Position</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>PositionUnitType</Type>
+      <Name>XUnits</Name>
+      <Value xsi:type="xsd:int">0</Value>
+      <Category>Position</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>float</Type>
+      <Name>Y</Name>
+      <Value xsi:type="xsd:float">0</Value>
+      <Category>Position</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>VerticalAlignment</Type>
+      <Name>YOrigin</Name>
+      <Value xsi:type="xsd:int">0</Value>
+      <Category>Position</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <Variable>
+      <Type>PositionUnitType</Type>
+      <Name>YUnits</Name>
+      <Value xsi:type="xsd:int">1</Value>
+      <Category>Position</Category>
+      <SetsValue>true</SetsValue>
+    </Variable>
+    <VariableList xsi:type="VariableListSaveOfString">
+      <Type>string</Type>
+      <Name>VariableReferences</Name>
+      <Category>References</Category>
+      <IsFile>false</IsFile>
+      <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
+      <Value />
+    </VariableList>
+  </State>
+  <Behaviors />
+</StandardElementSave>

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Screens/FormsScreen.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Screens/FormsScreen.Generated.cs
@@ -2,11 +2,11 @@
 using CodeGen_MonoGameForms_FullCodegen.Components.Controls;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGameForms_FullCodegen.Screens;
@@ -17,7 +17,7 @@ partial class FormsScreen : global::Gum.Forms.Controls.FrameworkElement
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("FormsScreen");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named FormsScreen - did you forget to load a Gum project?");

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Screens/GeneralScreen.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Screens/GeneralScreen.Generated.cs
@@ -2,11 +2,11 @@
 using CodeGen_MonoGameForms_FullCodegen.Components.Controls;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGameForms_FullCodegen.Screens;
@@ -17,7 +17,7 @@ partial class GeneralScreen : global::Gum.Forms.Controls.FrameworkElement
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("GeneralScreen");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named GeneralScreen - did you forget to load a Gum project?");
@@ -93,7 +93,7 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     }
     protected virtual void InitializeInstances()
     {
-        CircleInstance = new global::MonoGameGum.GueDeriving.CircleRuntime();
+        CircleInstance = new global::Gum.GueDeriving.CircleRuntime();
         CircleInstance.ElementSave = ObjectFinder.Self.GetStandardElement("Circle");
         if (CircleInstance.ElementSave != null) CircleInstance.AddStatesAndCategoriesRecursivelyToGue(CircleInstance.ElementSave);
         if (CircleInstance.ElementSave != null) CircleInstance.SetInitialState();

--- a/Tests/CodeGen_MonoGame_ByReference/Components/Controls/ButtonCloseRuntime.Generated.cs
+++ b/Tests/CodeGen_MonoGame_ByReference/Components/Controls/ButtonCloseRuntime.Generated.cs
@@ -2,11 +2,11 @@
 using CodeGen_MonoGame_ByReference.Components.Elements;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGame_ByReference.Components.Controls;
@@ -74,9 +74,9 @@ partial class ButtonCloseRuntime : ContainerRuntime
         {
             FormsControlAsObject = new global::Gum.Forms.Controls.Button(this);
         }
-        Background = this.GetGraphicalUiElementByName("Background") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
+        Background = this.GetGraphicalUiElementByName("Background") as global::Gum.GueDeriving.NineSliceRuntime;
         Icon = this.GetGraphicalUiElementByName("Icon") as CodeGen_MonoGame_ByReference.Components.Elements.IconRuntime;
-        FocusedIndicator = this.GetGraphicalUiElementByName("FocusedIndicator") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
+        FocusedIndicator = this.GetGraphicalUiElementByName("FocusedIndicator") as global::Gum.GueDeriving.NineSliceRuntime;
         CustomInitialize();
     }
     //Not assigning variables because Object Instantiation Type is set to By Name rather than Fully In Code

--- a/Tests/CodeGen_MonoGame_ByReference/Components/Controls/ButtonConfirmRuntime.Generated.cs
+++ b/Tests/CodeGen_MonoGame_ByReference/Components/Controls/ButtonConfirmRuntime.Generated.cs
@@ -1,11 +1,11 @@
 //Code for Controls/ButtonConfirm (Container)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGame_ByReference.Components.Controls;
@@ -79,9 +79,9 @@ partial class ButtonConfirmRuntime : ContainerRuntime
         {
             FormsControlAsObject = new global::Gum.Forms.Controls.Button(this);
         }
-        Background = this.GetGraphicalUiElementByName("Background") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
-        TextInstance = this.GetGraphicalUiElementByName("TextInstance") as global::MonoGameGum.GueDeriving.TextRuntime;
-        FocusedIndicator = this.GetGraphicalUiElementByName("FocusedIndicator") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
+        Background = this.GetGraphicalUiElementByName("Background") as global::Gum.GueDeriving.NineSliceRuntime;
+        TextInstance = this.GetGraphicalUiElementByName("TextInstance") as global::Gum.GueDeriving.TextRuntime;
+        FocusedIndicator = this.GetGraphicalUiElementByName("FocusedIndicator") as global::Gum.GueDeriving.NineSliceRuntime;
         CustomInitialize();
     }
     //Not assigning variables because Object Instantiation Type is set to By Name rather than Fully In Code

--- a/Tests/CodeGen_MonoGame_ByReference/Components/Controls/ButtonDenyRuntime.Generated.cs
+++ b/Tests/CodeGen_MonoGame_ByReference/Components/Controls/ButtonDenyRuntime.Generated.cs
@@ -1,11 +1,11 @@
 //Code for Controls/ButtonDeny (Container)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGame_ByReference.Components.Controls;
@@ -79,9 +79,9 @@ partial class ButtonDenyRuntime : ContainerRuntime
         {
             FormsControlAsObject = new global::Gum.Forms.Controls.Button(this);
         }
-        Background = this.GetGraphicalUiElementByName("Background") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
-        TextInstance = this.GetGraphicalUiElementByName("TextInstance") as global::MonoGameGum.GueDeriving.TextRuntime;
-        FocusedIndicator = this.GetGraphicalUiElementByName("FocusedIndicator") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
+        Background = this.GetGraphicalUiElementByName("Background") as global::Gum.GueDeriving.NineSliceRuntime;
+        TextInstance = this.GetGraphicalUiElementByName("TextInstance") as global::Gum.GueDeriving.TextRuntime;
+        FocusedIndicator = this.GetGraphicalUiElementByName("FocusedIndicator") as global::Gum.GueDeriving.NineSliceRuntime;
         CustomInitialize();
     }
     //Not assigning variables because Object Instantiation Type is set to By Name rather than Fully In Code

--- a/Tests/CodeGen_MonoGame_ByReference/Components/Controls/ButtonIconRuntime.Generated.cs
+++ b/Tests/CodeGen_MonoGame_ByReference/Components/Controls/ButtonIconRuntime.Generated.cs
@@ -2,11 +2,11 @@
 using CodeGen_MonoGame_ByReference.Components.Elements;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGame_ByReference.Components.Controls;
@@ -79,9 +79,9 @@ partial class ButtonIconRuntime : ContainerRuntime
         {
             FormsControlAsObject = new global::Gum.Forms.Controls.Button(this);
         }
-        Background = this.GetGraphicalUiElementByName("Background") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
+        Background = this.GetGraphicalUiElementByName("Background") as global::Gum.GueDeriving.NineSliceRuntime;
         Icon = this.GetGraphicalUiElementByName("Icon") as CodeGen_MonoGame_ByReference.Components.Elements.IconRuntime;
-        FocusedIndicator = this.GetGraphicalUiElementByName("FocusedIndicator") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
+        FocusedIndicator = this.GetGraphicalUiElementByName("FocusedIndicator") as global::Gum.GueDeriving.NineSliceRuntime;
         CustomInitialize();
     }
     //Not assigning variables because Object Instantiation Type is set to By Name rather than Fully In Code

--- a/Tests/CodeGen_MonoGame_ByReference/Components/Controls/ButtonStandardIconRuntime.Generated.cs
+++ b/Tests/CodeGen_MonoGame_ByReference/Components/Controls/ButtonStandardIconRuntime.Generated.cs
@@ -2,11 +2,11 @@
 using CodeGen_MonoGame_ByReference.Components.Elements;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGame_ByReference.Components.Controls;
@@ -86,10 +86,10 @@ partial class ButtonStandardIconRuntime : ContainerRuntime
         {
             FormsControlAsObject = new global::Gum.Forms.Controls.Button(this);
         }
-        Background = this.GetGraphicalUiElementByName("Background") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
-        TextInstance = this.GetGraphicalUiElementByName("TextInstance") as global::MonoGameGum.GueDeriving.TextRuntime;
+        Background = this.GetGraphicalUiElementByName("Background") as global::Gum.GueDeriving.NineSliceRuntime;
+        TextInstance = this.GetGraphicalUiElementByName("TextInstance") as global::Gum.GueDeriving.TextRuntime;
         Icon = this.GetGraphicalUiElementByName("Icon") as CodeGen_MonoGame_ByReference.Components.Elements.IconRuntime;
-        FocusedIndicator = this.GetGraphicalUiElementByName("FocusedIndicator") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
+        FocusedIndicator = this.GetGraphicalUiElementByName("FocusedIndicator") as global::Gum.GueDeriving.NineSliceRuntime;
         CustomInitialize();
     }
     //Not assigning variables because Object Instantiation Type is set to By Name rather than Fully In Code

--- a/Tests/CodeGen_MonoGame_ByReference/Components/Controls/ButtonStandardRuntime.Generated.cs
+++ b/Tests/CodeGen_MonoGame_ByReference/Components/Controls/ButtonStandardRuntime.Generated.cs
@@ -1,11 +1,11 @@
 //Code for Controls/ButtonStandard (Container)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGame_ByReference.Components.Controls;
@@ -80,9 +80,9 @@ partial class ButtonStandardRuntime : ContainerRuntime
         {
             FormsControlAsObject = new global::Gum.Forms.Controls.Button(this);
         }
-        Background = this.GetGraphicalUiElementByName("Background") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
-        TextInstance = this.GetGraphicalUiElementByName("TextInstance") as global::MonoGameGum.GueDeriving.TextRuntime;
-        FocusedIndicator = this.GetGraphicalUiElementByName("FocusedIndicator") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
+        Background = this.GetGraphicalUiElementByName("Background") as global::Gum.GueDeriving.NineSliceRuntime;
+        TextInstance = this.GetGraphicalUiElementByName("TextInstance") as global::Gum.GueDeriving.TextRuntime;
+        FocusedIndicator = this.GetGraphicalUiElementByName("FocusedIndicator") as global::Gum.GueDeriving.NineSliceRuntime;
         CustomInitialize();
     }
     //Not assigning variables because Object Instantiation Type is set to By Name rather than Fully In Code

--- a/Tests/CodeGen_MonoGame_ByReference/Components/Controls/ButtonTabRuntime.Generated.cs
+++ b/Tests/CodeGen_MonoGame_ByReference/Components/Controls/ButtonTabRuntime.Generated.cs
@@ -1,11 +1,11 @@
 //Code for Controls/ButtonTab (Container)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGame_ByReference.Components.Controls;
@@ -79,9 +79,9 @@ partial class ButtonTabRuntime : ContainerRuntime
         {
             FormsControlAsObject = new global::Gum.Forms.Controls.Button(this);
         }
-        Background = this.GetGraphicalUiElementByName("Background") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
-        TabText = this.GetGraphicalUiElementByName("TabText") as global::MonoGameGum.GueDeriving.TextRuntime;
-        FocusedIndicator = this.GetGraphicalUiElementByName("FocusedIndicator") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
+        Background = this.GetGraphicalUiElementByName("Background") as global::Gum.GueDeriving.NineSliceRuntime;
+        TabText = this.GetGraphicalUiElementByName("TabText") as global::Gum.GueDeriving.TextRuntime;
+        FocusedIndicator = this.GetGraphicalUiElementByName("FocusedIndicator") as global::Gum.GueDeriving.NineSliceRuntime;
         CustomInitialize();
     }
     //Not assigning variables because Object Instantiation Type is set to By Name rather than Fully In Code

--- a/Tests/CodeGen_MonoGame_ByReference/Components/Controls/CheckBoxRuntime.Generated.cs
+++ b/Tests/CodeGen_MonoGame_ByReference/Components/Controls/CheckBoxRuntime.Generated.cs
@@ -2,11 +2,11 @@
 using CodeGen_MonoGame_ByReference.Components.Elements;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGame_ByReference.Components.Controls;
@@ -96,10 +96,10 @@ partial class CheckBoxRuntime : ContainerRuntime
         {
             FormsControlAsObject = new global::Gum.Forms.Controls.CheckBox(this);
         }
-        CheckboxBackground = this.GetGraphicalUiElementByName("CheckboxBackground") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
-        TextInstance = this.GetGraphicalUiElementByName("TextInstance") as global::MonoGameGum.GueDeriving.TextRuntime;
+        CheckboxBackground = this.GetGraphicalUiElementByName("CheckboxBackground") as global::Gum.GueDeriving.NineSliceRuntime;
+        TextInstance = this.GetGraphicalUiElementByName("TextInstance") as global::Gum.GueDeriving.TextRuntime;
         Check = this.GetGraphicalUiElementByName("Check") as CodeGen_MonoGame_ByReference.Components.Elements.IconRuntime;
-        FocusedIndicator = this.GetGraphicalUiElementByName("FocusedIndicator") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
+        FocusedIndicator = this.GetGraphicalUiElementByName("FocusedIndicator") as global::Gum.GueDeriving.NineSliceRuntime;
         CustomInitialize();
     }
     //Not assigning variables because Object Instantiation Type is set to By Name rather than Fully In Code

--- a/Tests/CodeGen_MonoGame_ByReference/Components/Controls/ComboBoxRuntime.Generated.cs
+++ b/Tests/CodeGen_MonoGame_ByReference/Components/Controls/ComboBoxRuntime.Generated.cs
@@ -3,11 +3,11 @@ using CodeGen_MonoGame_ByReference.Components.Controls;
 using CodeGen_MonoGame_ByReference.Components.Elements;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGame_ByReference.Components.Controls;
@@ -78,11 +78,11 @@ partial class ComboBoxRuntime : ContainerRuntime
         {
             FormsControlAsObject = new global::Gum.Forms.Controls.ComboBox(this);
         }
-        Background = this.GetGraphicalUiElementByName("Background") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
-        TextInstance = this.GetGraphicalUiElementByName("TextInstance") as global::MonoGameGum.GueDeriving.TextRuntime;
+        Background = this.GetGraphicalUiElementByName("Background") as global::Gum.GueDeriving.NineSliceRuntime;
+        TextInstance = this.GetGraphicalUiElementByName("TextInstance") as global::Gum.GueDeriving.TextRuntime;
         ListBoxInstance = this.GetGraphicalUiElementByName("ListBoxInstance") as CodeGen_MonoGame_ByReference.Components.Controls.ListBoxRuntime;
         IconInstance = this.GetGraphicalUiElementByName("IconInstance") as CodeGen_MonoGame_ByReference.Components.Elements.IconRuntime;
-        FocusedIndicator = this.GetGraphicalUiElementByName("FocusedIndicator") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
+        FocusedIndicator = this.GetGraphicalUiElementByName("FocusedIndicator") as global::Gum.GueDeriving.NineSliceRuntime;
         CustomInitialize();
     }
     //Not assigning variables because Object Instantiation Type is set to By Name rather than Fully In Code

--- a/Tests/CodeGen_MonoGame_ByReference/Components/Controls/DialogBoxRuntime.Generated.cs
+++ b/Tests/CodeGen_MonoGame_ByReference/Components/Controls/DialogBoxRuntime.Generated.cs
@@ -2,11 +2,11 @@
 using CodeGen_MonoGame_ByReference.Components.Elements;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGame_ByReference.Components.Controls;
@@ -34,8 +34,8 @@ partial class DialogBoxRuntime : ContainerRuntime
     }
     public override void AfterFullCreation()
     {
-        NineSliceInstance = this.GetGraphicalUiElementByName("NineSliceInstance") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
-        TextInstance = this.GetGraphicalUiElementByName("TextInstance") as global::MonoGameGum.GueDeriving.TextRuntime;
+        NineSliceInstance = this.GetGraphicalUiElementByName("NineSliceInstance") as global::Gum.GueDeriving.NineSliceRuntime;
+        TextInstance = this.GetGraphicalUiElementByName("TextInstance") as global::Gum.GueDeriving.TextRuntime;
         ContinueIndicatorInstance = this.GetGraphicalUiElementByName("ContinueIndicatorInstance") as CodeGen_MonoGame_ByReference.Components.Elements.IconRuntime;
         CustomInitialize();
     }

--- a/Tests/CodeGen_MonoGame_ByReference/Components/Controls/InputDeviceSelectionItemRuntime.Generated.cs
+++ b/Tests/CodeGen_MonoGame_ByReference/Components/Controls/InputDeviceSelectionItemRuntime.Generated.cs
@@ -3,11 +3,11 @@ using CodeGen_MonoGame_ByReference.Components.Controls;
 using CodeGen_MonoGame_ByReference.Components.Elements;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGame_ByReference.Components.Controls;
@@ -66,9 +66,9 @@ partial class InputDeviceSelectionItemRuntime : ContainerRuntime
     }
     public override void AfterFullCreation()
     {
-        Background = this.GetGraphicalUiElementByName("Background") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
+        Background = this.GetGraphicalUiElementByName("Background") as global::Gum.GueDeriving.NineSliceRuntime;
         IconInstance = this.GetGraphicalUiElementByName("IconInstance") as CodeGen_MonoGame_ByReference.Components.Elements.IconRuntime;
-        TextInstance = this.GetGraphicalUiElementByName("TextInstance") as global::MonoGameGum.GueDeriving.TextRuntime;
+        TextInstance = this.GetGraphicalUiElementByName("TextInstance") as global::Gum.GueDeriving.TextRuntime;
         RemoveDeviceButtonInstance = this.GetGraphicalUiElementByName("RemoveDeviceButtonInstance") as CodeGen_MonoGame_ByReference.Components.Controls.ButtonCloseRuntime;
         CustomInitialize();
     }

--- a/Tests/CodeGen_MonoGame_ByReference/Components/Controls/InputDeviceSelectorRuntime.Generated.cs
+++ b/Tests/CodeGen_MonoGame_ByReference/Components/Controls/InputDeviceSelectorRuntime.Generated.cs
@@ -2,11 +2,11 @@
 using CodeGen_MonoGame_ByReference.Components.Controls;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGame_ByReference.Components.Controls;
@@ -41,12 +41,12 @@ partial class InputDeviceSelectorRuntime : ContainerRuntime
     }
     public override void AfterFullCreation()
     {
-        Background = this.GetGraphicalUiElementByName("Background") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
-        TextInstance = this.GetGraphicalUiElementByName("TextInstance") as global::MonoGameGum.GueDeriving.TextRuntime;
-        TextInstance1 = this.GetGraphicalUiElementByName("TextInstance1") as global::MonoGameGum.GueDeriving.TextRuntime;
-        ContainerInstance1 = this.GetGraphicalUiElementByName("ContainerInstance1") as global::MonoGameGum.GueDeriving.ContainerRuntime;
-        InputDeviceContainerInstance = this.GetGraphicalUiElementByName("InputDeviceContainerInstance") as global::MonoGameGum.GueDeriving.ContainerRuntime;
-        ContainerInstance2 = this.GetGraphicalUiElementByName("ContainerInstance2") as global::MonoGameGum.GueDeriving.ContainerRuntime;
+        Background = this.GetGraphicalUiElementByName("Background") as global::Gum.GueDeriving.NineSliceRuntime;
+        TextInstance = this.GetGraphicalUiElementByName("TextInstance") as global::Gum.GueDeriving.TextRuntime;
+        TextInstance1 = this.GetGraphicalUiElementByName("TextInstance1") as global::Gum.GueDeriving.TextRuntime;
+        ContainerInstance1 = this.GetGraphicalUiElementByName("ContainerInstance1") as global::Gum.GueDeriving.ContainerRuntime;
+        InputDeviceContainerInstance = this.GetGraphicalUiElementByName("InputDeviceContainerInstance") as global::Gum.GueDeriving.ContainerRuntime;
+        ContainerInstance2 = this.GetGraphicalUiElementByName("ContainerInstance2") as global::Gum.GueDeriving.ContainerRuntime;
         InputDeviceSelectionItemInstance = this.GetGraphicalUiElementByName("InputDeviceSelectionItemInstance") as CodeGen_MonoGame_ByReference.Components.Controls.InputDeviceSelectionItemRuntime;
         InputDeviceSelectionItemInstance1 = this.GetGraphicalUiElementByName("InputDeviceSelectionItemInstance1") as CodeGen_MonoGame_ByReference.Components.Controls.InputDeviceSelectionItemRuntime;
         InputDeviceSelectionItemInstance2 = this.GetGraphicalUiElementByName("InputDeviceSelectionItemInstance2") as CodeGen_MonoGame_ByReference.Components.Controls.InputDeviceSelectionItemRuntime;

--- a/Tests/CodeGen_MonoGame_ByReference/Components/Controls/KeyboardKeyRuntime.Generated.cs
+++ b/Tests/CodeGen_MonoGame_ByReference/Components/Controls/KeyboardKeyRuntime.Generated.cs
@@ -1,12 +1,12 @@
 //Code for Controls/KeyboardKey (Container)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.StateAnimation.Runtime;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGame_ByReference.Components.Controls;
@@ -80,9 +80,9 @@ partial class KeyboardKeyRuntime : ContainerRuntime
         {
             FormsControlAsObject = new global::Gum.Forms.Controls.Button(this);
         }
-        Background = this.GetGraphicalUiElementByName("Background") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
-        TextInstance = this.GetGraphicalUiElementByName("TextInstance") as global::MonoGameGum.GueDeriving.TextRuntime;
-        FocusedIndicator = this.GetGraphicalUiElementByName("FocusedIndicator") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
+        Background = this.GetGraphicalUiElementByName("Background") as global::Gum.GueDeriving.NineSliceRuntime;
+        TextInstance = this.GetGraphicalUiElementByName("TextInstance") as global::Gum.GueDeriving.TextRuntime;
+        FocusedIndicator = this.GetGraphicalUiElementByName("FocusedIndicator") as global::Gum.GueDeriving.NineSliceRuntime;
         CustomInitialize();
     }
     //Not assigning variables because Object Instantiation Type is set to By Name rather than Fully In Code

--- a/Tests/CodeGen_MonoGame_ByReference/Components/Controls/KeyboardRuntime.Generated.cs
+++ b/Tests/CodeGen_MonoGame_ByReference/Components/Controls/KeyboardRuntime.Generated.cs
@@ -3,12 +3,12 @@ using CodeGen_MonoGame_ByReference.Components.Controls;
 using CodeGen_MonoGame_ByReference.Components.Elements;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.StateAnimation.Runtime;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGame_ByReference.Components.Controls;
@@ -124,8 +124,8 @@ partial class KeyboardRuntime : ContainerRuntime
     }
     public override void AfterFullCreation()
     {
-        Row1Keys = this.GetGraphicalUiElementByName("Row1Keys") as global::MonoGameGum.GueDeriving.ContainerRuntime;
-        AllRows = this.GetGraphicalUiElementByName("AllRows") as global::MonoGameGum.GueDeriving.ContainerRuntime;
+        Row1Keys = this.GetGraphicalUiElementByName("Row1Keys") as global::Gum.GueDeriving.ContainerRuntime;
+        AllRows = this.GetGraphicalUiElementByName("AllRows") as global::Gum.GueDeriving.ContainerRuntime;
         Key1 = this.GetGraphicalUiElementByName("Key1") as CodeGen_MonoGame_ByReference.Components.Controls.KeyboardKeyRuntime;
         KeyQ = this.GetGraphicalUiElementByName("KeyQ") as CodeGen_MonoGame_ByReference.Components.Controls.KeyboardKeyRuntime;
         KeyA = this.GetGraphicalUiElementByName("KeyA") as CodeGen_MonoGame_ByReference.Components.Controls.KeyboardKeyRuntime;
@@ -172,15 +172,15 @@ partial class KeyboardRuntime : ContainerRuntime
         Key8 = this.GetGraphicalUiElementByName("Key8") as CodeGen_MonoGame_ByReference.Components.Controls.KeyboardKeyRuntime;
         Key9 = this.GetGraphicalUiElementByName("Key9") as CodeGen_MonoGame_ByReference.Components.Controls.KeyboardKeyRuntime;
         Key0 = this.GetGraphicalUiElementByName("Key0") as CodeGen_MonoGame_ByReference.Components.Controls.KeyboardKeyRuntime;
-        Row2Keys = this.GetGraphicalUiElementByName("Row2Keys") as global::MonoGameGum.GueDeriving.ContainerRuntime;
-        Row3Keys = this.GetGraphicalUiElementByName("Row3Keys") as global::MonoGameGum.GueDeriving.ContainerRuntime;
-        Row4Keys = this.GetGraphicalUiElementByName("Row4Keys") as global::MonoGameGum.GueDeriving.ContainerRuntime;
-        Row5Keys = this.GetGraphicalUiElementByName("Row5Keys") as global::MonoGameGum.GueDeriving.ContainerRuntime;
+        Row2Keys = this.GetGraphicalUiElementByName("Row2Keys") as global::Gum.GueDeriving.ContainerRuntime;
+        Row3Keys = this.GetGraphicalUiElementByName("Row3Keys") as global::Gum.GueDeriving.ContainerRuntime;
+        Row4Keys = this.GetGraphicalUiElementByName("Row4Keys") as global::Gum.GueDeriving.ContainerRuntime;
+        Row5Keys = this.GetGraphicalUiElementByName("Row5Keys") as global::Gum.GueDeriving.ContainerRuntime;
         KeyBackspace = this.GetGraphicalUiElementByName("KeyBackspace") as CodeGen_MonoGame_ByReference.Components.Controls.KeyboardKeyRuntime;
         KeyReturn = this.GetGraphicalUiElementByName("KeyReturn") as CodeGen_MonoGame_ByReference.Components.Controls.KeyboardKeyRuntime;
         KeyLeft = this.GetGraphicalUiElementByName("KeyLeft") as CodeGen_MonoGame_ByReference.Components.Controls.KeyboardKeyRuntime;
         KeyRight = this.GetGraphicalUiElementByName("KeyRight") as CodeGen_MonoGame_ByReference.Components.Controls.KeyboardKeyRuntime;
-        HighlightRectangle = this.GetGraphicalUiElementByName("HighlightRectangle") as global::MonoGameGum.GueDeriving.RectangleRuntime;
+        HighlightRectangle = this.GetGraphicalUiElementByName("HighlightRectangle") as global::Gum.GueDeriving.RectangleRuntime;
         IconInstance = this.GetGraphicalUiElementByName("IconInstance") as CodeGen_MonoGame_ByReference.Components.Elements.IconRuntime;
         IconInstance1 = this.GetGraphicalUiElementByName("IconInstance1") as CodeGen_MonoGame_ByReference.Components.Elements.IconRuntime;
         IconInstance2 = this.GetGraphicalUiElementByName("IconInstance2") as CodeGen_MonoGame_ByReference.Components.Elements.IconRuntime;

--- a/Tests/CodeGen_MonoGame_ByReference/Components/Controls/LabelRuntime.Generated.cs
+++ b/Tests/CodeGen_MonoGame_ByReference/Components/Controls/LabelRuntime.Generated.cs
@@ -1,15 +1,15 @@
 //Code for Controls/Label (Text)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGame_ByReference.Components.Controls;
-partial class LabelRuntime : global::MonoGameGum.GueDeriving.TextRuntime
+partial class LabelRuntime : global::Gum.GueDeriving.TextRuntime
 {
     [System.Runtime.CompilerServices.ModuleInitializer]
     public static void RegisterRuntimeType()

--- a/Tests/CodeGen_MonoGame_ByReference/Components/Controls/ListBoxItemRuntime.Generated.cs
+++ b/Tests/CodeGen_MonoGame_ByReference/Components/Controls/ListBoxItemRuntime.Generated.cs
@@ -1,11 +1,11 @@
 //Code for Controls/ListBoxItem (Container)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGame_ByReference.Components.Controls;
@@ -77,9 +77,9 @@ partial class ListBoxItemRuntime : ContainerRuntime
         {
             FormsControlAsObject = new global::Gum.Forms.Controls.ListBoxItem(this);
         }
-        Background = this.GetGraphicalUiElementByName("Background") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
-        TextInstance = this.GetGraphicalUiElementByName("TextInstance") as global::MonoGameGum.GueDeriving.TextRuntime;
-        FocusedIndicator = this.GetGraphicalUiElementByName("FocusedIndicator") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
+        Background = this.GetGraphicalUiElementByName("Background") as global::Gum.GueDeriving.NineSliceRuntime;
+        TextInstance = this.GetGraphicalUiElementByName("TextInstance") as global::Gum.GueDeriving.TextRuntime;
+        FocusedIndicator = this.GetGraphicalUiElementByName("FocusedIndicator") as global::Gum.GueDeriving.NineSliceRuntime;
         CustomInitialize();
     }
     //Not assigning variables because Object Instantiation Type is set to By Name rather than Fully In Code

--- a/Tests/CodeGen_MonoGame_ByReference/Components/Controls/ListBoxRuntime.Generated.cs
+++ b/Tests/CodeGen_MonoGame_ByReference/Components/Controls/ListBoxRuntime.Generated.cs
@@ -2,11 +2,11 @@
 using CodeGen_MonoGame_ByReference.Components.Controls;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGame_ByReference.Components.Controls;
@@ -76,13 +76,13 @@ partial class ListBoxRuntime : ContainerRuntime
         {
             FormsControlAsObject = new global::Gum.Forms.Controls.ListBox(this);
         }
-        Background = this.GetGraphicalUiElementByName("Background") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
+        Background = this.GetGraphicalUiElementByName("Background") as global::Gum.GueDeriving.NineSliceRuntime;
         VerticalScrollBarInstance = this.GetGraphicalUiElementByName("VerticalScrollBarInstance") as CodeGen_MonoGame_ByReference.Components.Controls.ScrollBarRuntime;
-        ClipContainerInstance = this.GetGraphicalUiElementByName("ClipContainerInstance") as global::MonoGameGum.GueDeriving.ContainerRuntime;
-        InnerPanelInstance = this.GetGraphicalUiElementByName("InnerPanelInstance") as global::MonoGameGum.GueDeriving.ContainerRuntime;
-        FocusedIndicator = this.GetGraphicalUiElementByName("FocusedIndicator") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
-        ClipAndScrollContainer = this.GetGraphicalUiElementByName("ClipAndScrollContainer") as global::MonoGameGum.GueDeriving.ContainerRuntime;
-        ClipContainerParent = this.GetGraphicalUiElementByName("ClipContainerParent") as global::MonoGameGum.GueDeriving.ContainerRuntime;
+        ClipContainerInstance = this.GetGraphicalUiElementByName("ClipContainerInstance") as global::Gum.GueDeriving.ContainerRuntime;
+        InnerPanelInstance = this.GetGraphicalUiElementByName("InnerPanelInstance") as global::Gum.GueDeriving.ContainerRuntime;
+        FocusedIndicator = this.GetGraphicalUiElementByName("FocusedIndicator") as global::Gum.GueDeriving.NineSliceRuntime;
+        ClipAndScrollContainer = this.GetGraphicalUiElementByName("ClipAndScrollContainer") as global::Gum.GueDeriving.ContainerRuntime;
+        ClipContainerParent = this.GetGraphicalUiElementByName("ClipContainerParent") as global::Gum.GueDeriving.ContainerRuntime;
         CustomInitialize();
     }
     //Not assigning variables because Object Instantiation Type is set to By Name rather than Fully In Code

--- a/Tests/CodeGen_MonoGame_ByReference/Components/Controls/MenuItemRuntime.Generated.cs
+++ b/Tests/CodeGen_MonoGame_ByReference/Components/Controls/MenuItemRuntime.Generated.cs
@@ -1,11 +1,11 @@
 //Code for Controls/MenuItem (Container)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGame_ByReference.Components.Controls;
@@ -73,10 +73,10 @@ partial class MenuItemRuntime : ContainerRuntime
         {
             FormsControlAsObject = new global::Gum.Forms.Controls.MenuItem(this);
         }
-        Background = this.GetGraphicalUiElementByName("Background") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
-        TextInstance = this.GetGraphicalUiElementByName("TextInstance") as global::MonoGameGum.GueDeriving.TextRuntime;
-        SubmenuIndicatorInstance = this.GetGraphicalUiElementByName("SubmenuIndicatorInstance") as global::MonoGameGum.GueDeriving.TextRuntime;
-        ContainerInstance = this.GetGraphicalUiElementByName("ContainerInstance") as global::MonoGameGum.GueDeriving.ContainerRuntime;
+        Background = this.GetGraphicalUiElementByName("Background") as global::Gum.GueDeriving.NineSliceRuntime;
+        TextInstance = this.GetGraphicalUiElementByName("TextInstance") as global::Gum.GueDeriving.TextRuntime;
+        SubmenuIndicatorInstance = this.GetGraphicalUiElementByName("SubmenuIndicatorInstance") as global::Gum.GueDeriving.TextRuntime;
+        ContainerInstance = this.GetGraphicalUiElementByName("ContainerInstance") as global::Gum.GueDeriving.ContainerRuntime;
         CustomInitialize();
     }
     //Not assigning variables because Object Instantiation Type is set to By Name rather than Fully In Code

--- a/Tests/CodeGen_MonoGame_ByReference/Components/Controls/MenuRuntime.Generated.cs
+++ b/Tests/CodeGen_MonoGame_ByReference/Components/Controls/MenuRuntime.Generated.cs
@@ -1,11 +1,11 @@
 //Code for Controls/Menu (Container)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGame_ByReference.Components.Controls;
@@ -38,8 +38,8 @@ partial class MenuRuntime : ContainerRuntime
         {
             FormsControlAsObject = new global::Gum.Forms.Controls.Menu(this);
         }
-        Background = this.GetGraphicalUiElementByName("Background") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
-        InnerPanelInstance = this.GetGraphicalUiElementByName("InnerPanelInstance") as global::MonoGameGum.GueDeriving.ContainerRuntime;
+        Background = this.GetGraphicalUiElementByName("Background") as global::Gum.GueDeriving.NineSliceRuntime;
+        InnerPanelInstance = this.GetGraphicalUiElementByName("InnerPanelInstance") as global::Gum.GueDeriving.ContainerRuntime;
         CustomInitialize();
     }
     //Not assigning variables because Object Instantiation Type is set to By Name rather than Fully In Code

--- a/Tests/CodeGen_MonoGame_ByReference/Components/Controls/PanelRuntime.Generated.cs
+++ b/Tests/CodeGen_MonoGame_ByReference/Components/Controls/PanelRuntime.Generated.cs
@@ -1,11 +1,11 @@
 //Code for Controls/Panel (Container)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGame_ByReference.Components.Controls;

--- a/Tests/CodeGen_MonoGame_ByReference/Components/Controls/PasswordBoxRuntime.Generated.cs
+++ b/Tests/CodeGen_MonoGame_ByReference/Components/Controls/PasswordBoxRuntime.Generated.cs
@@ -1,11 +1,11 @@
 //Code for Controls/PasswordBox (Container)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGame_ByReference.Components.Controls;
@@ -80,12 +80,12 @@ partial class PasswordBoxRuntime : ContainerRuntime
         {
             FormsControlAsObject = new global::Gum.Forms.Controls.PasswordBox(this);
         }
-        Background = this.GetGraphicalUiElementByName("Background") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
-        SelectionInstance = this.GetGraphicalUiElementByName("SelectionInstance") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
-        TextInstance = this.GetGraphicalUiElementByName("TextInstance") as global::MonoGameGum.GueDeriving.TextRuntime;
-        PlaceholderTextInstance = this.GetGraphicalUiElementByName("PlaceholderTextInstance") as global::MonoGameGum.GueDeriving.TextRuntime;
-        FocusedIndicator = this.GetGraphicalUiElementByName("FocusedIndicator") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
-        CaretInstance = this.GetGraphicalUiElementByName("CaretInstance") as global::MonoGameGum.GueDeriving.SpriteRuntime;
+        Background = this.GetGraphicalUiElementByName("Background") as global::Gum.GueDeriving.NineSliceRuntime;
+        SelectionInstance = this.GetGraphicalUiElementByName("SelectionInstance") as global::Gum.GueDeriving.NineSliceRuntime;
+        TextInstance = this.GetGraphicalUiElementByName("TextInstance") as global::Gum.GueDeriving.TextRuntime;
+        PlaceholderTextInstance = this.GetGraphicalUiElementByName("PlaceholderTextInstance") as global::Gum.GueDeriving.TextRuntime;
+        FocusedIndicator = this.GetGraphicalUiElementByName("FocusedIndicator") as global::Gum.GueDeriving.NineSliceRuntime;
+        CaretInstance = this.GetGraphicalUiElementByName("CaretInstance") as global::Gum.GueDeriving.SpriteRuntime;
         CustomInitialize();
     }
     //Not assigning variables because Object Instantiation Type is set to By Name rather than Fully In Code

--- a/Tests/CodeGen_MonoGame_ByReference/Components/Controls/PlayerJoinViewItemRuntime.Generated.cs
+++ b/Tests/CodeGen_MonoGame_ByReference/Components/Controls/PlayerJoinViewItemRuntime.Generated.cs
@@ -2,11 +2,11 @@
 using CodeGen_MonoGame_ByReference.Components.Elements;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGame_ByReference.Components.Controls;
@@ -135,8 +135,8 @@ partial class PlayerJoinViewItemRuntime : ContainerRuntime
     }
     public override void AfterFullCreation()
     {
-        Background = this.GetGraphicalUiElementByName("Background") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
-        ControllerDisplayNameTextInstance = this.GetGraphicalUiElementByName("ControllerDisplayNameTextInstance") as global::MonoGameGum.GueDeriving.TextRuntime;
+        Background = this.GetGraphicalUiElementByName("Background") as global::Gum.GueDeriving.NineSliceRuntime;
+        ControllerDisplayNameTextInstance = this.GetGraphicalUiElementByName("ControllerDisplayNameTextInstance") as global::Gum.GueDeriving.TextRuntime;
         InputDeviceIcon = this.GetGraphicalUiElementByName("InputDeviceIcon") as CodeGen_MonoGame_ByReference.Components.Elements.IconRuntime;
         CustomInitialize();
     }

--- a/Tests/CodeGen_MonoGame_ByReference/Components/Controls/PlayerJoinViewRuntime.Generated.cs
+++ b/Tests/CodeGen_MonoGame_ByReference/Components/Controls/PlayerJoinViewRuntime.Generated.cs
@@ -2,11 +2,11 @@
 using CodeGen_MonoGame_ByReference.Components.Controls;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGame_ByReference.Components.Controls;
@@ -36,7 +36,7 @@ partial class PlayerJoinViewRuntime : ContainerRuntime
     }
     public override void AfterFullCreation()
     {
-        InnerPanelInstance = this.GetGraphicalUiElementByName("InnerPanelInstance") as global::MonoGameGum.GueDeriving.ContainerRuntime;
+        InnerPanelInstance = this.GetGraphicalUiElementByName("InnerPanelInstance") as global::Gum.GueDeriving.ContainerRuntime;
         PlayerJoinViewItem1 = this.GetGraphicalUiElementByName("PlayerJoinViewItem1") as CodeGen_MonoGame_ByReference.Components.Controls.PlayerJoinViewItemRuntime;
         PlayerJoinViewItem2 = this.GetGraphicalUiElementByName("PlayerJoinViewItem2") as CodeGen_MonoGame_ByReference.Components.Controls.PlayerJoinViewItemRuntime;
         PlayerJoinViewItem3 = this.GetGraphicalUiElementByName("PlayerJoinViewItem3") as CodeGen_MonoGame_ByReference.Components.Controls.PlayerJoinViewItemRuntime;

--- a/Tests/CodeGen_MonoGame_ByReference/Components/Controls/RadioButtonRuntime.Generated.cs
+++ b/Tests/CodeGen_MonoGame_ByReference/Components/Controls/RadioButtonRuntime.Generated.cs
@@ -2,11 +2,11 @@
 using CodeGen_MonoGame_ByReference.Components.Elements;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGame_ByReference.Components.Controls;
@@ -89,10 +89,10 @@ partial class RadioButtonRuntime : ContainerRuntime
         {
             FormsControlAsObject = new global::Gum.Forms.Controls.RadioButton(this);
         }
-        RadioBackground = this.GetGraphicalUiElementByName("RadioBackground") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
+        RadioBackground = this.GetGraphicalUiElementByName("RadioBackground") as global::Gum.GueDeriving.NineSliceRuntime;
         Radio = this.GetGraphicalUiElementByName("Radio") as CodeGen_MonoGame_ByReference.Components.Elements.IconRuntime;
-        TextInstance = this.GetGraphicalUiElementByName("TextInstance") as global::MonoGameGum.GueDeriving.TextRuntime;
-        FocusedIndicator = this.GetGraphicalUiElementByName("FocusedIndicator") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
+        TextInstance = this.GetGraphicalUiElementByName("TextInstance") as global::Gum.GueDeriving.TextRuntime;
+        FocusedIndicator = this.GetGraphicalUiElementByName("FocusedIndicator") as global::Gum.GueDeriving.NineSliceRuntime;
         CustomInitialize();
     }
     //Not assigning variables because Object Instantiation Type is set to By Name rather than Fully In Code

--- a/Tests/CodeGen_MonoGame_ByReference/Components/Controls/ScrollBarRuntime.Generated.cs
+++ b/Tests/CodeGen_MonoGame_ByReference/Components/Controls/ScrollBarRuntime.Generated.cs
@@ -2,11 +2,11 @@
 using CodeGen_MonoGame_ByReference.Components.Controls;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGame_ByReference.Components.Controls;
@@ -72,8 +72,8 @@ partial class ScrollBarRuntime : ContainerRuntime
         }
         UpButtonInstance = this.GetGraphicalUiElementByName("UpButtonInstance") as CodeGen_MonoGame_ByReference.Components.Controls.ButtonIconRuntime;
         DownButtonInstance = this.GetGraphicalUiElementByName("DownButtonInstance") as CodeGen_MonoGame_ByReference.Components.Controls.ButtonIconRuntime;
-        TrackInstance = this.GetGraphicalUiElementByName("TrackInstance") as global::MonoGameGum.GueDeriving.ContainerRuntime;
-        TrackBackground = this.GetGraphicalUiElementByName("TrackBackground") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
+        TrackInstance = this.GetGraphicalUiElementByName("TrackInstance") as global::Gum.GueDeriving.ContainerRuntime;
+        TrackBackground = this.GetGraphicalUiElementByName("TrackBackground") as global::Gum.GueDeriving.NineSliceRuntime;
         ThumbInstance = this.GetGraphicalUiElementByName("ThumbInstance") as CodeGen_MonoGame_ByReference.Components.Controls.ButtonStandardRuntime;
         CustomInitialize();
     }

--- a/Tests/CodeGen_MonoGame_ByReference/Components/Controls/ScrollViewerRuntime.Generated.cs
+++ b/Tests/CodeGen_MonoGame_ByReference/Components/Controls/ScrollViewerRuntime.Generated.cs
@@ -2,11 +2,11 @@
 using CodeGen_MonoGame_ByReference.Components.Controls;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGame_ByReference.Components.Controls;
@@ -102,11 +102,11 @@ partial class ScrollViewerRuntime : ContainerRuntime
         {
             FormsControlAsObject = new global::Gum.Forms.Controls.ScrollViewer(this);
         }
-        Background = this.GetGraphicalUiElementByName("Background") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
+        Background = this.GetGraphicalUiElementByName("Background") as global::Gum.GueDeriving.NineSliceRuntime;
         VerticalScrollBarInstance = this.GetGraphicalUiElementByName("VerticalScrollBarInstance") as CodeGen_MonoGame_ByReference.Components.Controls.ScrollBarRuntime;
-        ClipContainerInstance = this.GetGraphicalUiElementByName("ClipContainerInstance") as global::MonoGameGum.GueDeriving.ContainerRuntime;
-        InnerPanelInstance = this.GetGraphicalUiElementByName("InnerPanelInstance") as global::MonoGameGum.GueDeriving.ContainerRuntime;
-        FocusedIndicator = this.GetGraphicalUiElementByName("FocusedIndicator") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
+        ClipContainerInstance = this.GetGraphicalUiElementByName("ClipContainerInstance") as global::Gum.GueDeriving.ContainerRuntime;
+        InnerPanelInstance = this.GetGraphicalUiElementByName("InnerPanelInstance") as global::Gum.GueDeriving.ContainerRuntime;
+        FocusedIndicator = this.GetGraphicalUiElementByName("FocusedIndicator") as global::Gum.GueDeriving.NineSliceRuntime;
         CustomInitialize();
     }
     //Not assigning variables because Object Instantiation Type is set to By Name rather than Fully In Code

--- a/Tests/CodeGen_MonoGame_ByReference/Components/Controls/SettingsViewRuntime.Generated.cs
+++ b/Tests/CodeGen_MonoGame_ByReference/Components/Controls/SettingsViewRuntime.Generated.cs
@@ -2,11 +2,11 @@
 using CodeGen_MonoGame_ByReference.Components.Controls;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGame_ByReference.Components.Controls;

--- a/Tests/CodeGen_MonoGame_ByReference/Components/Controls/SliderRuntime.Generated.cs
+++ b/Tests/CodeGen_MonoGame_ByReference/Components/Controls/SliderRuntime.Generated.cs
@@ -2,11 +2,11 @@
 using CodeGen_MonoGame_ByReference.Components.Controls;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGame_ByReference.Components.Controls;
@@ -82,10 +82,10 @@ partial class SliderRuntime : ContainerRuntime
         {
             FormsControlAsObject = new global::Gum.Forms.Controls.Slider(this);
         }
-        TrackInstance = this.GetGraphicalUiElementByName("TrackInstance") as global::MonoGameGum.GueDeriving.ContainerRuntime;
-        TrackBackground = this.GetGraphicalUiElementByName("TrackBackground") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
+        TrackInstance = this.GetGraphicalUiElementByName("TrackInstance") as global::Gum.GueDeriving.ContainerRuntime;
+        TrackBackground = this.GetGraphicalUiElementByName("TrackBackground") as global::Gum.GueDeriving.NineSliceRuntime;
         ThumbInstance = this.GetGraphicalUiElementByName("ThumbInstance") as CodeGen_MonoGame_ByReference.Components.Controls.ButtonStandardRuntime;
-        FocusedIndicator = this.GetGraphicalUiElementByName("FocusedIndicator") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
+        FocusedIndicator = this.GetGraphicalUiElementByName("FocusedIndicator") as global::Gum.GueDeriving.NineSliceRuntime;
         CustomInitialize();
     }
     //Not assigning variables because Object Instantiation Type is set to By Name rather than Fully In Code

--- a/Tests/CodeGen_MonoGame_ByReference/Components/Controls/SplitterStandardRuntime.Generated.cs
+++ b/Tests/CodeGen_MonoGame_ByReference/Components/Controls/SplitterStandardRuntime.Generated.cs
@@ -1,11 +1,11 @@
 //Code for Controls/SplitterStandard (Container)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGame_ByReference.Components.Controls;
@@ -37,7 +37,7 @@ partial class SplitterStandardRuntime : ContainerRuntime
         {
             FormsControlAsObject = new global::Gum.Forms.Controls.Splitter(this);
         }
-        NineSliceInstance = this.GetGraphicalUiElementByName("NineSliceInstance") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
+        NineSliceInstance = this.GetGraphicalUiElementByName("NineSliceInstance") as global::Gum.GueDeriving.NineSliceRuntime;
         CustomInitialize();
     }
     //Not assigning variables because Object Instantiation Type is set to By Name rather than Fully In Code

--- a/Tests/CodeGen_MonoGame_ByReference/Components/Controls/StackPanelRuntime.Generated.cs
+++ b/Tests/CodeGen_MonoGame_ByReference/Components/Controls/StackPanelRuntime.Generated.cs
@@ -1,11 +1,11 @@
 //Code for Controls/StackPanel (Container)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGame_ByReference.Components.Controls;

--- a/Tests/CodeGen_MonoGame_ByReference/Components/Controls/TextBoxRuntime.Generated.cs
+++ b/Tests/CodeGen_MonoGame_ByReference/Components/Controls/TextBoxRuntime.Generated.cs
@@ -1,12 +1,12 @@
 //Code for Controls/TextBox (Container)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.StateAnimation.Runtime;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGame_ByReference.Components.Controls;
@@ -130,13 +130,13 @@ partial class TextBoxRuntime : ContainerRuntime
         {
             FormsControlAsObject = new global::Gum.Forms.Controls.TextBox(this);
         }
-        Background = this.GetGraphicalUiElementByName("Background") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
-        ClipContainer = this.GetGraphicalUiElementByName("ClipContainer") as global::MonoGameGum.GueDeriving.ContainerRuntime;
-        SelectionInstance = this.GetGraphicalUiElementByName("SelectionInstance") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
-        TextInstance = this.GetGraphicalUiElementByName("TextInstance") as global::MonoGameGum.GueDeriving.TextRuntime;
-        PlaceholderTextInstance = this.GetGraphicalUiElementByName("PlaceholderTextInstance") as global::MonoGameGum.GueDeriving.TextRuntime;
-        FocusedIndicator = this.GetGraphicalUiElementByName("FocusedIndicator") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
-        CaretInstance = this.GetGraphicalUiElementByName("CaretInstance") as global::MonoGameGum.GueDeriving.SpriteRuntime;
+        Background = this.GetGraphicalUiElementByName("Background") as global::Gum.GueDeriving.NineSliceRuntime;
+        ClipContainer = this.GetGraphicalUiElementByName("ClipContainer") as global::Gum.GueDeriving.ContainerRuntime;
+        SelectionInstance = this.GetGraphicalUiElementByName("SelectionInstance") as global::Gum.GueDeriving.NineSliceRuntime;
+        TextInstance = this.GetGraphicalUiElementByName("TextInstance") as global::Gum.GueDeriving.TextRuntime;
+        PlaceholderTextInstance = this.GetGraphicalUiElementByName("PlaceholderTextInstance") as global::Gum.GueDeriving.TextRuntime;
+        FocusedIndicator = this.GetGraphicalUiElementByName("FocusedIndicator") as global::Gum.GueDeriving.NineSliceRuntime;
+        CaretInstance = this.GetGraphicalUiElementByName("CaretInstance") as global::Gum.GueDeriving.SpriteRuntime;
         CustomInitialize();
     }
     //Not assigning variables because Object Instantiation Type is set to By Name rather than Fully In Code

--- a/Tests/CodeGen_MonoGame_ByReference/Components/Controls/ToastRuntime.Generated.cs
+++ b/Tests/CodeGen_MonoGame_ByReference/Components/Controls/ToastRuntime.Generated.cs
@@ -1,11 +1,11 @@
 //Code for Controls/Toast (Container)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGame_ByReference.Components.Controls;
@@ -32,8 +32,8 @@ partial class ToastRuntime : ContainerRuntime
     }
     public override void AfterFullCreation()
     {
-        Background = this.GetGraphicalUiElementByName("Background") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
-        TextInstance = this.GetGraphicalUiElementByName("TextInstance") as global::MonoGameGum.GueDeriving.TextRuntime;
+        Background = this.GetGraphicalUiElementByName("Background") as global::Gum.GueDeriving.NineSliceRuntime;
+        TextInstance = this.GetGraphicalUiElementByName("TextInstance") as global::Gum.GueDeriving.TextRuntime;
         CustomInitialize();
     }
     //Not assigning variables because Object Instantiation Type is set to By Name rather than Fully In Code

--- a/Tests/CodeGen_MonoGame_ByReference/Components/Controls/TreeViewItemRuntime.Generated.cs
+++ b/Tests/CodeGen_MonoGame_ByReference/Components/Controls/TreeViewItemRuntime.Generated.cs
@@ -2,11 +2,11 @@
 using CodeGen_MonoGame_ByReference.Components.Controls;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGame_ByReference.Components.Controls;
@@ -36,7 +36,7 @@ partial class TreeViewItemRuntime : ContainerRuntime
     {
         ToggleButtonInstance = this.GetGraphicalUiElementByName("ToggleButtonInstance") as CodeGen_MonoGame_ByReference.Components.Controls.TreeViewToggleRuntime;
         ListBoxItemInstance = this.GetGraphicalUiElementByName("ListBoxItemInstance") as CodeGen_MonoGame_ByReference.Components.Controls.ListBoxItemRuntime;
-        InnerPanelInstance = this.GetGraphicalUiElementByName("InnerPanelInstance") as global::MonoGameGum.GueDeriving.ContainerRuntime;
+        InnerPanelInstance = this.GetGraphicalUiElementByName("InnerPanelInstance") as global::Gum.GueDeriving.ContainerRuntime;
         CustomInitialize();
     }
     //Not assigning variables because Object Instantiation Type is set to By Name rather than Fully In Code

--- a/Tests/CodeGen_MonoGame_ByReference/Components/Controls/TreeViewRuntime.Generated.cs
+++ b/Tests/CodeGen_MonoGame_ByReference/Components/Controls/TreeViewRuntime.Generated.cs
@@ -2,11 +2,11 @@
 using CodeGen_MonoGame_ByReference.Components.Controls;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGame_ByReference.Components.Controls;
@@ -36,11 +36,11 @@ partial class TreeViewRuntime : ContainerRuntime
     }
     public override void AfterFullCreation()
     {
-        Background = this.GetGraphicalUiElementByName("Background") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
+        Background = this.GetGraphicalUiElementByName("Background") as global::Gum.GueDeriving.NineSliceRuntime;
         VerticalScrollBarInstance = this.GetGraphicalUiElementByName("VerticalScrollBarInstance") as CodeGen_MonoGame_ByReference.Components.Controls.ScrollBarRuntime;
-        ClipContainerInstance = this.GetGraphicalUiElementByName("ClipContainerInstance") as global::MonoGameGum.GueDeriving.ContainerRuntime;
-        InnerPanelInstance = this.GetGraphicalUiElementByName("InnerPanelInstance") as global::MonoGameGum.GueDeriving.ContainerRuntime;
-        FocusedIndicator = this.GetGraphicalUiElementByName("FocusedIndicator") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
+        ClipContainerInstance = this.GetGraphicalUiElementByName("ClipContainerInstance") as global::Gum.GueDeriving.ContainerRuntime;
+        InnerPanelInstance = this.GetGraphicalUiElementByName("InnerPanelInstance") as global::Gum.GueDeriving.ContainerRuntime;
+        FocusedIndicator = this.GetGraphicalUiElementByName("FocusedIndicator") as global::Gum.GueDeriving.NineSliceRuntime;
         CustomInitialize();
     }
     //Not assigning variables because Object Instantiation Type is set to By Name rather than Fully In Code

--- a/Tests/CodeGen_MonoGame_ByReference/Components/Controls/TreeViewToggleRuntime.Generated.cs
+++ b/Tests/CodeGen_MonoGame_ByReference/Components/Controls/TreeViewToggleRuntime.Generated.cs
@@ -2,12 +2,12 @@
 using CodeGen_MonoGame_ByReference.Components.Elements;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.StateAnimation.Runtime;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGame_ByReference.Components.Controls;
@@ -70,7 +70,7 @@ partial class TreeViewToggleRuntime : ContainerRuntime
     }
     public override void AfterFullCreation()
     {
-        NineSliceInstance = this.GetGraphicalUiElementByName("NineSliceInstance") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
+        NineSliceInstance = this.GetGraphicalUiElementByName("NineSliceInstance") as global::Gum.GueDeriving.NineSliceRuntime;
         IconInstance = this.GetGraphicalUiElementByName("IconInstance") as CodeGen_MonoGame_ByReference.Components.Elements.IconRuntime;
         CustomInitialize();
     }

--- a/Tests/CodeGen_MonoGame_ByReference/Components/Controls/UserControlRuntime.Generated.cs
+++ b/Tests/CodeGen_MonoGame_ByReference/Components/Controls/UserControlRuntime.Generated.cs
@@ -1,11 +1,11 @@
 //Code for Controls/UserControl (Container)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGame_ByReference.Components.Controls;
@@ -31,7 +31,7 @@ partial class UserControlRuntime : ContainerRuntime
     }
     public override void AfterFullCreation()
     {
-        Background = this.GetGraphicalUiElementByName("Background") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
+        Background = this.GetGraphicalUiElementByName("Background") as global::Gum.GueDeriving.NineSliceRuntime;
         CustomInitialize();
     }
     //Not assigning variables because Object Instantiation Type is set to By Name rather than Fully In Code

--- a/Tests/CodeGen_MonoGame_ByReference/Components/Controls/WindowStandardRuntime.Generated.cs
+++ b/Tests/CodeGen_MonoGame_ByReference/Components/Controls/WindowStandardRuntime.Generated.cs
@@ -2,11 +2,11 @@
 using CodeGen_MonoGame_ByReference.Components.Controls;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGame_ByReference.Components.Controls;
@@ -48,7 +48,7 @@ partial class WindowStandardRuntime : ContainerRuntime
         {
             FormsControlAsObject = new global::Gum.Forms.Window(this);
         }
-        Background = this.GetGraphicalUiElementByName("Background") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
+        Background = this.GetGraphicalUiElementByName("Background") as global::Gum.GueDeriving.NineSliceRuntime;
         InnerPanelInstance = this.GetGraphicalUiElementByName("InnerPanelInstance") as CodeGen_MonoGame_ByReference.Components.Controls.PanelRuntime;
         TitleBarInstance = this.GetGraphicalUiElementByName("TitleBarInstance") as CodeGen_MonoGame_ByReference.Components.Controls.PanelRuntime;
         BorderTopLeftInstance = this.GetGraphicalUiElementByName("BorderTopLeftInstance") as CodeGen_MonoGame_ByReference.Components.Controls.PanelRuntime;

--- a/Tests/CodeGen_MonoGame_ByReference/Components/Elements/CautionLinesRuntime.Generated.cs
+++ b/Tests/CodeGen_MonoGame_ByReference/Components/Elements/CautionLinesRuntime.Generated.cs
@@ -1,11 +1,11 @@
 //Code for Elements/CautionLines (Container)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGame_ByReference.Components.Elements;
@@ -42,7 +42,7 @@ partial class CautionLinesRuntime : ContainerRuntime
     }
     public override void AfterFullCreation()
     {
-        LinesSprite = this.GetGraphicalUiElementByName("LinesSprite") as global::MonoGameGum.GueDeriving.SpriteRuntime;
+        LinesSprite = this.GetGraphicalUiElementByName("LinesSprite") as global::Gum.GueDeriving.SpriteRuntime;
         CustomInitialize();
     }
     //Not assigning variables because Object Instantiation Type is set to By Name rather than Fully In Code

--- a/Tests/CodeGen_MonoGame_ByReference/Components/Elements/DividerHorizontalRuntime.Generated.cs
+++ b/Tests/CodeGen_MonoGame_ByReference/Components/Elements/DividerHorizontalRuntime.Generated.cs
@@ -1,12 +1,12 @@
 //Code for Elements/DividerHorizontal (Container)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.StateAnimation.Runtime;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGame_ByReference.Components.Elements;
@@ -34,9 +34,9 @@ partial class DividerHorizontalRuntime : ContainerRuntime
     }
     public override void AfterFullCreation()
     {
-        AccentLeft = this.GetGraphicalUiElementByName("AccentLeft") as global::MonoGameGum.GueDeriving.SpriteRuntime;
-        Line = this.GetGraphicalUiElementByName("Line") as global::MonoGameGum.GueDeriving.SpriteRuntime;
-        AccentRight = this.GetGraphicalUiElementByName("AccentRight") as global::MonoGameGum.GueDeriving.SpriteRuntime;
+        AccentLeft = this.GetGraphicalUiElementByName("AccentLeft") as global::Gum.GueDeriving.SpriteRuntime;
+        Line = this.GetGraphicalUiElementByName("Line") as global::Gum.GueDeriving.SpriteRuntime;
+        AccentRight = this.GetGraphicalUiElementByName("AccentRight") as global::Gum.GueDeriving.SpriteRuntime;
         CustomInitialize();
     }
     //Not assigning variables because Object Instantiation Type is set to By Name rather than Fully In Code

--- a/Tests/CodeGen_MonoGame_ByReference/Components/Elements/DividerRuntime.Generated.cs
+++ b/Tests/CodeGen_MonoGame_ByReference/Components/Elements/DividerRuntime.Generated.cs
@@ -1,11 +1,11 @@
 //Code for Elements/Divider (Container)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGame_ByReference.Components.Elements;
@@ -33,9 +33,9 @@ partial class DividerRuntime : ContainerRuntime
     }
     public override void AfterFullCreation()
     {
-        AccentLeft = this.GetGraphicalUiElementByName("AccentLeft") as global::MonoGameGum.GueDeriving.SpriteRuntime;
-        Line = this.GetGraphicalUiElementByName("Line") as global::MonoGameGum.GueDeriving.SpriteRuntime;
-        AccentRight = this.GetGraphicalUiElementByName("AccentRight") as global::MonoGameGum.GueDeriving.SpriteRuntime;
+        AccentLeft = this.GetGraphicalUiElementByName("AccentLeft") as global::Gum.GueDeriving.SpriteRuntime;
+        Line = this.GetGraphicalUiElementByName("Line") as global::Gum.GueDeriving.SpriteRuntime;
+        AccentRight = this.GetGraphicalUiElementByName("AccentRight") as global::Gum.GueDeriving.SpriteRuntime;
         CustomInitialize();
     }
     //Not assigning variables because Object Instantiation Type is set to By Name rather than Fully In Code

--- a/Tests/CodeGen_MonoGame_ByReference/Components/Elements/DividerVerticalRuntime.Generated.cs
+++ b/Tests/CodeGen_MonoGame_ByReference/Components/Elements/DividerVerticalRuntime.Generated.cs
@@ -1,12 +1,12 @@
 //Code for Elements/DividerVertical (Container)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.StateAnimation.Runtime;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGame_ByReference.Components.Elements;
@@ -34,9 +34,9 @@ partial class DividerVerticalRuntime : ContainerRuntime
     }
     public override void AfterFullCreation()
     {
-        AccentTop = this.GetGraphicalUiElementByName("AccentTop") as global::MonoGameGum.GueDeriving.SpriteRuntime;
-        Line = this.GetGraphicalUiElementByName("Line") as global::MonoGameGum.GueDeriving.SpriteRuntime;
-        AccentRight = this.GetGraphicalUiElementByName("AccentRight") as global::MonoGameGum.GueDeriving.SpriteRuntime;
+        AccentTop = this.GetGraphicalUiElementByName("AccentTop") as global::Gum.GueDeriving.SpriteRuntime;
+        Line = this.GetGraphicalUiElementByName("Line") as global::Gum.GueDeriving.SpriteRuntime;
+        AccentRight = this.GetGraphicalUiElementByName("AccentRight") as global::Gum.GueDeriving.SpriteRuntime;
         CustomInitialize();
     }
     //Not assigning variables because Object Instantiation Type is set to By Name rather than Fully In Code

--- a/Tests/CodeGen_MonoGame_ByReference/Components/Elements/IconRuntime.Generated.cs
+++ b/Tests/CodeGen_MonoGame_ByReference/Components/Elements/IconRuntime.Generated.cs
@@ -1,12 +1,12 @@
 //Code for Elements/Icon (Container)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.StateAnimation.Runtime;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGame_ByReference.Components.Elements;
@@ -137,7 +137,7 @@ partial class IconRuntime : ContainerRuntime
     }
     public override void AfterFullCreation()
     {
-        IconSprite = this.GetGraphicalUiElementByName("IconSprite") as global::MonoGameGum.GueDeriving.SpriteRuntime;
+        IconSprite = this.GetGraphicalUiElementByName("IconSprite") as global::Gum.GueDeriving.SpriteRuntime;
         CustomInitialize();
     }
     //Not assigning variables because Object Instantiation Type is set to By Name rather than Fully In Code

--- a/Tests/CodeGen_MonoGame_ByReference/Components/Elements/PercentBarIconRuntime.Generated.cs
+++ b/Tests/CodeGen_MonoGame_ByReference/Components/Elements/PercentBarIconRuntime.Generated.cs
@@ -2,11 +2,11 @@
 using CodeGen_MonoGame_ByReference.Components.Elements;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGame_ByReference.Components.Elements;
@@ -89,10 +89,10 @@ partial class PercentBarIconRuntime : ContainerRuntime
     }
     public override void AfterFullCreation()
     {
-        Background = this.GetGraphicalUiElementByName("Background") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
+        Background = this.GetGraphicalUiElementByName("Background") as global::Gum.GueDeriving.NineSliceRuntime;
         IconInstance = this.GetGraphicalUiElementByName("IconInstance") as CodeGen_MonoGame_ByReference.Components.Elements.IconRuntime;
-        BarContainer = this.GetGraphicalUiElementByName("BarContainer") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
-        Bar = this.GetGraphicalUiElementByName("Bar") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
+        BarContainer = this.GetGraphicalUiElementByName("BarContainer") as global::Gum.GueDeriving.NineSliceRuntime;
+        Bar = this.GetGraphicalUiElementByName("Bar") as global::Gum.GueDeriving.NineSliceRuntime;
         CautionLinesInstance = this.GetGraphicalUiElementByName("CautionLinesInstance") as CodeGen_MonoGame_ByReference.Components.Elements.CautionLinesRuntime;
         VerticalLinesInstance = this.GetGraphicalUiElementByName("VerticalLinesInstance") as CodeGen_MonoGame_ByReference.Components.Elements.VerticalLinesRuntime;
         CustomInitialize();

--- a/Tests/CodeGen_MonoGame_ByReference/Components/Elements/PercentBarRuntime.Generated.cs
+++ b/Tests/CodeGen_MonoGame_ByReference/Components/Elements/PercentBarRuntime.Generated.cs
@@ -2,11 +2,11 @@
 using CodeGen_MonoGame_ByReference.Components.Elements;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGame_ByReference.Components.Elements;
@@ -78,9 +78,9 @@ partial class PercentBarRuntime : ContainerRuntime
     }
     public override void AfterFullCreation()
     {
-        Background = this.GetGraphicalUiElementByName("Background") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
-        BarContainer = this.GetGraphicalUiElementByName("BarContainer") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
-        Bar = this.GetGraphicalUiElementByName("Bar") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
+        Background = this.GetGraphicalUiElementByName("Background") as global::Gum.GueDeriving.NineSliceRuntime;
+        BarContainer = this.GetGraphicalUiElementByName("BarContainer") as global::Gum.GueDeriving.NineSliceRuntime;
+        Bar = this.GetGraphicalUiElementByName("Bar") as global::Gum.GueDeriving.NineSliceRuntime;
         CautionLinesInstance = this.GetGraphicalUiElementByName("CautionLinesInstance") as CodeGen_MonoGame_ByReference.Components.Elements.CautionLinesRuntime;
         VerticalLinesInstance = this.GetGraphicalUiElementByName("VerticalLinesInstance") as CodeGen_MonoGame_ByReference.Components.Elements.VerticalLinesRuntime;
         CustomInitialize();

--- a/Tests/CodeGen_MonoGame_ByReference/Components/Elements/VerticalLinesRuntime.Generated.cs
+++ b/Tests/CodeGen_MonoGame_ByReference/Components/Elements/VerticalLinesRuntime.Generated.cs
@@ -1,11 +1,11 @@
 //Code for Elements/VerticalLines (Container)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGame_ByReference.Components.Elements;
@@ -42,7 +42,7 @@ partial class VerticalLinesRuntime : ContainerRuntime
     }
     public override void AfterFullCreation()
     {
-        LinesSprite = this.GetGraphicalUiElementByName("LinesSprite") as global::MonoGameGum.GueDeriving.SpriteRuntime;
+        LinesSprite = this.GetGraphicalUiElementByName("LinesSprite") as global::Gum.GueDeriving.SpriteRuntime;
         CustomInitialize();
     }
     //Not assigning variables because Object Instantiation Type is set to By Name rather than Fully In Code

--- a/Tests/CodeGen_MonoGame_ByReference/Components/Spaced_ComponentRuntime.Generated.cs
+++ b/Tests/CodeGen_MonoGame_ByReference/Components/Spaced_ComponentRuntime.Generated.cs
@@ -1,11 +1,11 @@
 //Code for Spaced Component (Container)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGame_ByReference.Components;

--- a/Tests/CodeGen_MonoGame_ByReference/Components/StylesRuntime.Generated.cs
+++ b/Tests/CodeGen_MonoGame_ByReference/Components/StylesRuntime.Generated.cs
@@ -1,11 +1,11 @@
 //Code for Styles (Container)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGame_ByReference.Components;
@@ -53,29 +53,29 @@ partial class StylesRuntime : ContainerRuntime
     }
     public override void AfterFullCreation()
     {
-        Colors = this.GetGraphicalUiElementByName("Colors") as global::MonoGameGum.GueDeriving.ContainerRuntime;
-        Black = this.GetGraphicalUiElementByName("Black") as global::MonoGameGum.GueDeriving.ColoredRectangleRuntime;
-        DarkGray = this.GetGraphicalUiElementByName("DarkGray") as global::MonoGameGum.GueDeriving.ColoredRectangleRuntime;
-        Gray = this.GetGraphicalUiElementByName("Gray") as global::MonoGameGum.GueDeriving.ColoredRectangleRuntime;
-        LightGray = this.GetGraphicalUiElementByName("LightGray") as global::MonoGameGum.GueDeriving.ColoredRectangleRuntime;
-        White = this.GetGraphicalUiElementByName("White") as global::MonoGameGum.GueDeriving.ColoredRectangleRuntime;
-        PrimaryDark = this.GetGraphicalUiElementByName("PrimaryDark") as global::MonoGameGum.GueDeriving.ColoredRectangleRuntime;
-        Primary = this.GetGraphicalUiElementByName("Primary") as global::MonoGameGum.GueDeriving.ColoredRectangleRuntime;
-        PrimaryLight = this.GetGraphicalUiElementByName("PrimaryLight") as global::MonoGameGum.GueDeriving.ColoredRectangleRuntime;
-        Success = this.GetGraphicalUiElementByName("Success") as global::MonoGameGum.GueDeriving.ColoredRectangleRuntime;
-        Warning = this.GetGraphicalUiElementByName("Warning") as global::MonoGameGum.GueDeriving.ColoredRectangleRuntime;
-        Danger = this.GetGraphicalUiElementByName("Danger") as global::MonoGameGum.GueDeriving.ColoredRectangleRuntime;
-        Accent = this.GetGraphicalUiElementByName("Accent") as global::MonoGameGum.GueDeriving.ColoredRectangleRuntime;
-        Tiny = this.GetGraphicalUiElementByName("Tiny") as global::MonoGameGum.GueDeriving.TextRuntime;
-        Small = this.GetGraphicalUiElementByName("Small") as global::MonoGameGum.GueDeriving.TextRuntime;
-        Normal = this.GetGraphicalUiElementByName("Normal") as global::MonoGameGum.GueDeriving.TextRuntime;
-        Emphasis = this.GetGraphicalUiElementByName("Emphasis") as global::MonoGameGum.GueDeriving.TextRuntime;
-        Strong = this.GetGraphicalUiElementByName("Strong") as global::MonoGameGum.GueDeriving.TextRuntime;
-        H3 = this.GetGraphicalUiElementByName("H3") as global::MonoGameGum.GueDeriving.TextRuntime;
-        H2 = this.GetGraphicalUiElementByName("H2") as global::MonoGameGum.GueDeriving.TextRuntime;
-        H1 = this.GetGraphicalUiElementByName("H1") as global::MonoGameGum.GueDeriving.TextRuntime;
-        TextStyles = this.GetGraphicalUiElementByName("TextStyles") as global::MonoGameGum.GueDeriving.ContainerRuntime;
-        Title = this.GetGraphicalUiElementByName("Title") as global::MonoGameGum.GueDeriving.TextRuntime;
+        Colors = this.GetGraphicalUiElementByName("Colors") as global::Gum.GueDeriving.ContainerRuntime;
+        Black = this.GetGraphicalUiElementByName("Black") as global::Gum.GueDeriving.ColoredRectangleRuntime;
+        DarkGray = this.GetGraphicalUiElementByName("DarkGray") as global::Gum.GueDeriving.ColoredRectangleRuntime;
+        Gray = this.GetGraphicalUiElementByName("Gray") as global::Gum.GueDeriving.ColoredRectangleRuntime;
+        LightGray = this.GetGraphicalUiElementByName("LightGray") as global::Gum.GueDeriving.ColoredRectangleRuntime;
+        White = this.GetGraphicalUiElementByName("White") as global::Gum.GueDeriving.ColoredRectangleRuntime;
+        PrimaryDark = this.GetGraphicalUiElementByName("PrimaryDark") as global::Gum.GueDeriving.ColoredRectangleRuntime;
+        Primary = this.GetGraphicalUiElementByName("Primary") as global::Gum.GueDeriving.ColoredRectangleRuntime;
+        PrimaryLight = this.GetGraphicalUiElementByName("PrimaryLight") as global::Gum.GueDeriving.ColoredRectangleRuntime;
+        Success = this.GetGraphicalUiElementByName("Success") as global::Gum.GueDeriving.ColoredRectangleRuntime;
+        Warning = this.GetGraphicalUiElementByName("Warning") as global::Gum.GueDeriving.ColoredRectangleRuntime;
+        Danger = this.GetGraphicalUiElementByName("Danger") as global::Gum.GueDeriving.ColoredRectangleRuntime;
+        Accent = this.GetGraphicalUiElementByName("Accent") as global::Gum.GueDeriving.ColoredRectangleRuntime;
+        Tiny = this.GetGraphicalUiElementByName("Tiny") as global::Gum.GueDeriving.TextRuntime;
+        Small = this.GetGraphicalUiElementByName("Small") as global::Gum.GueDeriving.TextRuntime;
+        Normal = this.GetGraphicalUiElementByName("Normal") as global::Gum.GueDeriving.TextRuntime;
+        Emphasis = this.GetGraphicalUiElementByName("Emphasis") as global::Gum.GueDeriving.TextRuntime;
+        Strong = this.GetGraphicalUiElementByName("Strong") as global::Gum.GueDeriving.TextRuntime;
+        H3 = this.GetGraphicalUiElementByName("H3") as global::Gum.GueDeriving.TextRuntime;
+        H2 = this.GetGraphicalUiElementByName("H2") as global::Gum.GueDeriving.TextRuntime;
+        H1 = this.GetGraphicalUiElementByName("H1") as global::Gum.GueDeriving.TextRuntime;
+        TextStyles = this.GetGraphicalUiElementByName("TextStyles") as global::Gum.GueDeriving.ContainerRuntime;
+        Title = this.GetGraphicalUiElementByName("Title") as global::Gum.GueDeriving.TextRuntime;
         CustomInitialize();
     }
     //Not assigning variables because Object Instantiation Type is set to By Name rather than Fully In Code

--- a/Tests/GenerateAllCodeGenProjects.bat
+++ b/Tests/GenerateAllCodeGenProjects.bat
@@ -1,17 +1,24 @@
 @echo off
+rem Regenerates the checked-in generated code for every CodeGen_* harness project.
+rem Uses GumCli — the same path CI's "Codegen Drift Check" step uses — so local
+rem regeneration and CI verification can never diverge. Commit the resulting
+rem diff; CI fails if checked-in generated code is stale.
+
+dotnet build "%~dp0..\Tools\Gum.Cli\Gum.Cli.csproj" --configuration Release || exit /b 1
+set CLI=%~dp0..\Tools\Gum.Cli\bin\Release\net8.0\GumCli.exe
 
 echo 0/100 Starting to generate...
-%~dp0../Gum/bin/Debug/Gum.exe %~dp0CodeGen_Maui_FullCodegen/Content/GumProject/CodeGenTestProject.gumx --generatecode
-echo 20/100 generated CodeGen_Maui_FullCodegen 
+"%CLI%" codegen %~dp0CodeGen_Maui_FullCodegen/Content/GumProject/CodeGenTestProject.gumx
+echo 20/100 generated CodeGen_Maui_FullCodegen
 
-%~dp0../Gum/bin/Debug/Gum.exe %~dp0CodeGen_MonoGame_ByReference/Content/GumProject/CodeGenTestProject.gumx --generatecode
-echo 40/100 generated CodeGen_MonoGame_ByReference 
+"%CLI%" codegen %~dp0CodeGen_MonoGame_ByReference/Content/GumProject/CodeGenTestProject.gumx
+echo 40/100 generated CodeGen_MonoGame_ByReference
 
-%~dp0../Gum/bin/Debug/Gum.exe %~dp0CodeGen_MonoGameForms_ByReference/Content/GumProject/CodeGenTestProject.gumx --generatecode
+"%CLI%" codegen %~dp0CodeGen_MonoGameForms_ByReference/Content/GumProject/CodeGenTestProject.gumx
 echo 60/100 generated CodeGen_MonoGameForms_ByReference
 
-%~dp0../Gum/bin/Debug/Gum.exe %~dp0CodeGen_MonoGameForms_Localization_ByReference/Content/GumProject/LocalizationCodeGenTestProject.gumx --generatecode
+"%CLI%" codegen %~dp0CodeGen_MonoGameForms_Localization_ByReference/Content/GumProject/LocalizationCodeGenTestProject.gumx
 echo 80/100 generated CodeGen_MonoGameForms_Localization_ByReference
 
-%~dp0../Gum/bin/Debug/Gum.exe %~dp0CodeGen_MonoGameForms_FullCodegen/Content/CodeGenProject.gumx --generatecode
+"%CLI%" codegen %~dp0CodeGen_MonoGameForms_FullCodegen/Content/CodeGenProject.gumx
 echo 100/100 generated CodeGen_MonoGameForms_FullCodegen

--- a/Tests/Gum.ProjectServices.Tests/CodeGeneratorCollapsedShapeTests.cs
+++ b/Tests/Gum.ProjectServices.Tests/CodeGeneratorCollapsedShapeTests.cs
@@ -1,0 +1,439 @@
+using Gum.DataTypes;
+using Gum.DataTypes.Variables;
+using Gum.Localization;
+using Gum.Managers;
+using Gum.ProjectServices.CodeGeneration;
+using Moq;
+using Shouldly;
+using System.Linq;
+
+namespace Gum.ProjectServices.Tests;
+
+/// <summary>
+/// Tests for #2775: when the resolved runtime syntax version is &gt;= 2, MonoGame codegen emits the
+/// collapsed two-slot shape runtimes (<c>CircleRuntime</c> / <c>RectangleRuntime</c>) for the legacy
+/// <c>ColoredCircle</c> / <c>ColoredRectangle</c> / <c>RoundedRectangle</c> standard elements, and
+/// translates their single-color variables to the fill/stroke channel properties. Versions below 2,
+/// FindByName instantiation, and non-MonoGame output libraries keep the legacy emission.
+/// </summary>
+public class CodeGeneratorCollapsedShapeTests : BaseTestClass
+{
+    private static CodeGenerator CreateCodeGenerator()
+    {
+        Mock<INameVerifier> mockNameVerifier = new Mock<INameVerifier>();
+        string whyNotValid;
+        CommonValidationError error;
+        mockNameVerifier
+            .Setup(v => v.IsValidCSharpName(It.IsAny<string>(), out whyNotValid, out error))
+            .Returns(true);
+        CodeGenerationNameVerifier codeGenNameVerifier = new CodeGenerationNameVerifier(mockNameVerifier.Object);
+        FixedProjectDirectoryProvider directoryProvider = new FixedProjectDirectoryProvider(projectDirectory: null);
+        CodeOutputElementSettingsManager elementSettingsManager = new CodeOutputElementSettingsManager(directoryProvider);
+        LocalizationService localizationService = new LocalizationService();
+
+        return new CodeGenerator(
+            codeGenNameVerifier,
+            localizationService,
+            elementSettingsManager,
+            directoryProvider);
+    }
+
+    private static CodeOutputProjectSettings CreateMonoGameSettings(string syntaxVersion) => new CodeOutputProjectSettings
+    {
+        OutputLibrary = OutputLibrary.MonoGame,
+        RootNamespace = "MyGame",
+        SyntaxVersion = syntaxVersion,
+    };
+
+    private static ComponentSave CreateComponent(string name, string baseType)
+    {
+        ComponentSave component = new ComponentSave { Name = name, BaseType = baseType };
+        StateSave defaultState = new StateSave { Name = "Default", ParentContainer = component };
+        component.States.Add(defaultState);
+        return component;
+    }
+
+    private static void AddVariable(ElementSave element, string name, object? value, string type) =>
+        element.DefaultState.Variables.Add(new VariableSave
+        {
+            Name = name,
+            Value = value,
+            SetsValue = true,
+            Type = type,
+        });
+
+    /// <summary>
+    /// Mirrors the variables StandardElementsManager defines on the legacy shape standard elements.
+    /// Codegen only emits an instance variable whose root is defined on the base element, so the
+    /// base must declare every variable a test sets on an instance.
+    /// </summary>
+    private static void AddLegacyShapeVariables(ElementSave element, bool includeStrokeAndFill, bool includeCornerRadius)
+    {
+        AddVariable(element, "Red", 255, "int");
+        AddVariable(element, "Green", 255, "int");
+        AddVariable(element, "Blue", 255, "int");
+        AddVariable(element, "Alpha", 255, "int");
+        AddVariable(element, "Red1", 255, "int");
+        AddVariable(element, "Green1", 255, "int");
+        AddVariable(element, "Blue1", 255, "int");
+        AddVariable(element, "Alpha1", 255, "int");
+
+        if (includeStrokeAndFill)
+        {
+            AddVariable(element, "IsFilled", true, "bool");
+            AddVariable(element, "StrokeWidth", 2.0f, "float");
+        }
+
+        if (includeCornerRadius)
+        {
+            AddVariable(element, "CornerRadius", 5.0f, "float");
+        }
+    }
+
+    private StandardElementSave AddColoredCircleStandard()
+    {
+        StandardElementSave element = new StandardElementSave { Name = "ColoredCircle" };
+        StateSave defaultState = new StateSave { Name = "Default", ParentContainer = element };
+        element.States.Add(defaultState);
+        AddLegacyShapeVariables(element, includeStrokeAndFill: true, includeCornerRadius: false);
+        Project.StandardElements.Add(element);
+        return element;
+    }
+
+    private StandardElementSave AddRoundedRectangleStandard()
+    {
+        StandardElementSave element = new StandardElementSave { Name = "RoundedRectangle" };
+        StateSave defaultState = new StateSave { Name = "Default", ParentContainer = element };
+        element.States.Add(defaultState);
+        AddLegacyShapeVariables(element, includeStrokeAndFill: true, includeCornerRadius: true);
+        Project.StandardElements.Add(element);
+        return element;
+    }
+
+    private void AddColoredRectangleVariables()
+    {
+        StandardElementSave element = Project.StandardElements.First(item => item.Name == "ColoredRectangle");
+        AddLegacyShapeVariables(element, includeStrokeAndFill: false, includeCornerRadius: false);
+    }
+
+    /// <summary>
+    /// Builds a component containing a single instance of the given legacy shape type and returns
+    /// the generated code for that instance.
+    /// </summary>
+    private string GenerateInstanceCode(
+        string shapeBaseType,
+        string instanceName,
+        CodeOutputProjectSettings settings,
+        params (string variableName, object value, string type)[] instanceVariables)
+    {
+        ComponentSave main = CreateComponent("MainComponent", "Container");
+
+        InstanceSave shapeInstance = new InstanceSave
+        {
+            Name = instanceName,
+            BaseType = shapeBaseType,
+            ParentContainer = main,
+        };
+        main.Instances.Add(shapeInstance);
+
+        foreach ((string variableName, object value, string type) in instanceVariables)
+        {
+            AddVariable(main, $"{instanceName}.{variableName}", value, type);
+        }
+
+        Project.Components.Add(main);
+
+        ObjectFinder.Self.GumProjectSave = Project;
+        try
+        {
+            return CreateCodeGenerator().GetCodeForInstance(shapeInstance, main, settings);
+        }
+        finally
+        {
+            ObjectFinder.Self.GumProjectSave = null;
+        }
+    }
+
+    [Fact]
+    public void GetCodeForInstance_ColoredCircle_FindByNameV2_KeepsLegacyRuntime()
+    {
+        AddColoredCircleStandard();
+        CodeOutputProjectSettings settings = CreateMonoGameSettings("2");
+        settings.ObjectInstantiationType = ObjectInstantiationType.FindByName;
+
+        string code = GenerateInstanceCode("ColoredCircle", "CircleInstance", settings);
+
+        code.ShouldContain("new global::Gum.GueDeriving.ColoredCircleRuntime();");
+        code.ShouldNotContain("new global::Gum.GueDeriving.CircleRuntime();");
+    }
+
+    [Fact]
+    public void GetCodeForInstance_ColoredCircle_SkiaV2_KeepsLegacyRuntime()
+    {
+        AddColoredCircleStandard();
+        CodeOutputProjectSettings settings = new CodeOutputProjectSettings
+        {
+            OutputLibrary = OutputLibrary.Skia,
+            RootNamespace = "MyGame",
+            SyntaxVersion = "2",
+        };
+
+        string code = GenerateInstanceCode("ColoredCircle", "CircleInstance", settings);
+
+        code.ShouldContain("new global::Gum.GueDeriving.ColoredCircleRuntime();");
+        code.ShouldNotContain("new global::Gum.GueDeriving.CircleRuntime();");
+    }
+
+    [Fact]
+    public void GetCodeForInstance_ColoredCircle_V1_KeepsLegacyRuntimeAndColorVariables()
+    {
+        AddColoredCircleStandard();
+
+        string code = GenerateInstanceCode(
+            "ColoredCircle",
+            "CircleInstance",
+            CreateMonoGameSettings("1"),
+            ("Red", 10, "int"));
+
+        code.ShouldContain("new global::Gum.GueDeriving.ColoredCircleRuntime();");
+        code.ShouldContain("CircleInstance.Red = 10;");
+        code.ShouldNotContain("CircleInstance.FillRed");
+        code.ShouldNotContain("CircleInstance.IsFilled = true;");
+    }
+
+    [Fact]
+    public void GetCodeForInstance_ColoredCircle_V2_DropsGradientStartColor()
+    {
+        AddColoredCircleStandard();
+
+        string code = GenerateInstanceCode(
+            "ColoredCircle",
+            "CircleInstance",
+            CreateMonoGameSettings("2"),
+            ("Red1", 100, "int"),
+            ("Alpha1", 200, "int"));
+
+        code.ShouldNotContain("Red1");
+        code.ShouldNotContain("Alpha1");
+    }
+
+    [Fact]
+    public void GetCodeForInstance_ColoredCircle_V2_EmitsCircleRuntime()
+    {
+        AddColoredCircleStandard();
+
+        string code = GenerateInstanceCode("ColoredCircle", "CircleInstance", CreateMonoGameSettings("2"));
+
+        code.ShouldContain("public CircleRuntime CircleInstance");
+        code.ShouldContain("new global::Gum.GueDeriving.CircleRuntime();");
+        code.ShouldNotContain("ColoredCircleRuntime");
+    }
+
+    [Fact]
+    public void GetCodeForInstance_ColoredCircle_V2_EmitsFilledBaselineBlock()
+    {
+        AddColoredCircleStandard();
+
+        string code = GenerateInstanceCode("ColoredCircle", "CircleInstance", CreateMonoGameSettings("2"));
+
+        code.ShouldContain("CircleInstance.IsFilled = true;");
+        code.ShouldContain("CircleInstance.StrokeWidth = 0f;");
+    }
+
+    [Fact]
+    public void GetCodeForInstance_ColoredCircle_V2_Filled_DropsStrokeWidth()
+    {
+        AddColoredCircleStandard();
+
+        string code = GenerateInstanceCode(
+            "ColoredCircle",
+            "CircleInstance",
+            CreateMonoGameSettings("2"),
+            ("StrokeWidth", 5.0f, "float"));
+
+        code.ShouldNotContain("StrokeWidth = 5");
+    }
+
+    [Fact]
+    public void GetCodeForInstance_ColoredCircle_V2_Filled_RoutesColorChannelsToFill()
+    {
+        AddColoredCircleStandard();
+
+        string code = GenerateInstanceCode(
+            "ColoredCircle",
+            "CircleInstance",
+            CreateMonoGameSettings("2"),
+            ("Red", 10, "int"),
+            ("Green", 20, "int"),
+            ("Blue", 30, "int"),
+            ("Alpha", 40, "int"));
+
+        code.ShouldContain("CircleInstance.FillRed = 10;");
+        code.ShouldContain("CircleInstance.FillGreen = 20;");
+        code.ShouldContain("CircleInstance.FillBlue = 30;");
+        code.ShouldContain("CircleInstance.FillAlpha = 40;");
+        code.ShouldNotContain("CircleInstance.Red = 10;");
+    }
+
+    [Fact]
+    public void GetCodeForInstance_ColoredCircle_V2_KeepsLegacyElementSaveLookup()
+    {
+        AddColoredCircleStandard();
+
+        string code = GenerateInstanceCode("ColoredCircle", "CircleInstance", CreateMonoGameSettings("2"));
+
+        // States and categories still come from the legacy .gumx standard element.
+        code.ShouldContain("GetStandardElement(\"ColoredCircle\")");
+    }
+
+    [Fact]
+    public void GetCodeForInstance_ColoredCircle_V2_NotFilled_KeepsStrokeWidth()
+    {
+        AddColoredCircleStandard();
+
+        string code = GenerateInstanceCode(
+            "ColoredCircle",
+            "CircleInstance",
+            CreateMonoGameSettings("2"),
+            ("IsFilled", false, "bool"),
+            ("StrokeWidth", 5.0f, "float"));
+
+        code.ShouldContain("CircleInstance.IsFilled = false;");
+        code.ShouldContain("StrokeWidth = 5");
+    }
+
+    [Fact]
+    public void GetCodeForInstance_ColoredCircle_V2_NotFilled_RoutesColorChannelsToStroke()
+    {
+        AddColoredCircleStandard();
+
+        string code = GenerateInstanceCode(
+            "ColoredCircle",
+            "CircleInstance",
+            CreateMonoGameSettings("2"),
+            ("IsFilled", false, "bool"),
+            ("Red", 10, "int"));
+
+        code.ShouldContain("CircleInstance.StrokeRed = 10;");
+        code.ShouldNotContain("CircleInstance.FillRed");
+        code.ShouldNotContain("CircleInstance.Red = 10;");
+    }
+
+    [Fact]
+    public void GetCodeForInstance_ColoredRectangle_V2_EmitsRectangleRuntimeAndFillChannels()
+    {
+        AddColoredRectangleVariables();
+
+        string code = GenerateInstanceCode(
+            "ColoredRectangle",
+            "RectangleInstance",
+            CreateMonoGameSettings("2"),
+            ("Red", 10, "int"));
+
+        code.ShouldContain("new global::Gum.GueDeriving.RectangleRuntime();");
+        code.ShouldNotContain("ColoredRectangleRuntime");
+        code.ShouldContain("RectangleInstance.FillRed = 10;");
+        code.ShouldContain("RectangleInstance.IsFilled = true;");
+        code.ShouldContain("RectangleInstance.StrokeWidth = 0f;");
+    }
+
+    [Fact]
+    public void GetCodeForInstance_RoundedRectangle_V2_CornerRadiusExplicit_PassesThrough()
+    {
+        AddRoundedRectangleStandard();
+
+        string code = GenerateInstanceCode(
+            "RoundedRectangle",
+            "RoundedInstance",
+            CreateMonoGameSettings("2"),
+            ("CornerRadius", 8.0f, "float"));
+
+        code.ShouldContain("RoundedInstance.CornerRadius = 8");
+    }
+
+    [Fact]
+    public void GetCodeForInstance_RoundedRectangle_V2_EmitsCornerRadiusBaseline()
+    {
+        AddRoundedRectangleStandard();
+
+        string code = GenerateInstanceCode("RoundedRectangle", "RoundedInstance", CreateMonoGameSettings("2"));
+
+        // Legacy RoundedRectangle defaulted CornerRadius to 5; the collapsed RectangleRuntime
+        // defaults to 0, so the baseline must carry the legacy default.
+        code.ShouldContain("RoundedInstance.CornerRadius = 5f;");
+    }
+
+    [Fact]
+    public void GetCodeForInstance_RoundedRectangle_V2_EmitsRectangleRuntime()
+    {
+        AddRoundedRectangleStandard();
+
+        string code = GenerateInstanceCode("RoundedRectangle", "RoundedInstance", CreateMonoGameSettings("2"));
+
+        code.ShouldContain("public RectangleRuntime RoundedInstance");
+        code.ShouldContain("new global::Gum.GueDeriving.RectangleRuntime();");
+        code.ShouldNotContain("RoundedRectangleRuntime");
+    }
+
+    [Fact]
+    public void GetInheritance_ColoredCircle_V1_KeepsLegacyRuntime()
+    {
+        AddColoredCircleStandard();
+        ObjectFinder.Self.GumProjectSave = Project;
+
+        try
+        {
+            ComponentSave component = CreateComponent("MyShape", "ColoredCircle");
+
+            string? result = CodeGenerator.GetInheritance(component, CreateMonoGameSettings("1"), resolvedSyntaxVersion: 1);
+
+            result.ShouldBe("global::Gum.GueDeriving.ColoredCircleRuntime");
+        }
+        finally
+        {
+            ObjectFinder.Self.GumProjectSave = null;
+        }
+    }
+
+    [Fact]
+    public void GetInheritance_ColoredCircle_V2_FindByName_KeepsLegacyRuntime()
+    {
+        AddColoredCircleStandard();
+        ObjectFinder.Self.GumProjectSave = Project;
+
+        try
+        {
+            ComponentSave component = CreateComponent("MyShape", "ColoredCircle");
+            CodeOutputProjectSettings settings = CreateMonoGameSettings("2");
+            settings.ObjectInstantiationType = ObjectInstantiationType.FindByName;
+
+            string? result = CodeGenerator.GetInheritance(component, settings, resolvedSyntaxVersion: 2);
+
+            result.ShouldBe("global::Gum.GueDeriving.ColoredCircleRuntime");
+        }
+        finally
+        {
+            ObjectFinder.Self.GumProjectSave = null;
+        }
+    }
+
+    [Fact]
+    public void GetInheritance_ColoredCircle_V2_ReturnsCircleRuntime()
+    {
+        AddColoredCircleStandard();
+        ObjectFinder.Self.GumProjectSave = Project;
+
+        try
+        {
+            ComponentSave component = CreateComponent("MyShape", "ColoredCircle");
+
+            string? result = CodeGenerator.GetInheritance(component, CreateMonoGameSettings("2"), resolvedSyntaxVersion: 2);
+
+            result.ShouldBe("global::Gum.GueDeriving.CircleRuntime");
+        }
+        finally
+        {
+            ObjectFinder.Self.GumProjectSave = null;
+        }
+    }
+}

--- a/Tests/Gum.ProjectServices.Tests/CodeGeneratorRenderTargetTextureSourceTests.cs
+++ b/Tests/Gum.ProjectServices.Tests/CodeGeneratorRenderTargetTextureSourceTests.cs
@@ -51,7 +51,7 @@ public class CodeGeneratorRenderTargetTextureSourceTests : BaseTestClass
         return component;
     }
 
-    private static void AddVariable(ElementSave element, string name, object value, string type) =>
+    private static void AddVariable(ElementSave element, string name, object? value, string type) =>
         element.DefaultState.Variables.Add(new VariableSave
         {
             Name = name,

--- a/Tests/MonoGameGum.Shapes.Tests/ArcRuntimeTests.cs
+++ b/Tests/MonoGameGum.Shapes.Tests/ArcRuntimeTests.cs
@@ -71,7 +71,7 @@ public class ArcRuntimeTests
     // Locked in unification (issue #2728): both backends default IsEndRounded to false
     // (matches Skia's prior behavior and graphics-convention flat caps). Existing Apos
     // consumers who relied on rounded caps must now set IsEndRounded = true explicitly.
-    // See docs/gum-tool/upgrading/migrating-to-2026-may.md.
+    // See docs/gum-tool/upgrading/migrating-to-2026-june.md.
     [Fact]
     public void IsEndRounded_DefaultShouldBeFalse()
     {

--- a/Tools/Gum.Analyzers/NamespaceMigrationAnalyzer.cs
+++ b/Tools/Gum.Analyzers/NamespaceMigrationAnalyzer.cs
@@ -24,7 +24,7 @@ public sealed class NamespaceMigrationAnalyzer : DiagnosticAnalyzer
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
         description: "Types from this namespace have been moved to a new namespace as part of the Gum namespace unification. Use the code fix to update automatically.",
-        helpLinkUri: "https://docs.flatredball.com/gum/gum-tool/upgrading/migrating-to-2026-may");
+        helpLinkUri: "https://docs.flatredball.com/gum/gum-tool/upgrading/migrating-to-2026-june");
 
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
         ImmutableArray.Create(MovedTypeRule);

--- a/Tools/Gum.Analyzers/ObsoleteShapeRuntimeAnalyzer.cs
+++ b/Tools/Gum.Analyzers/ObsoleteShapeRuntimeAnalyzer.cs
@@ -31,7 +31,7 @@ public sealed class ObsoleteShapeRuntimeAnalyzer : DiagnosticAnalyzer
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
         description: "ColoredCircleRuntime / ColoredRectangleRuntime / RoundedRectangleRuntime / SolidRectangleRuntime were collapsed into CircleRuntime / RectangleRuntime by the two-slot fill/stroke model. The code fix rewrites the type name and (where mechanically safe) the Color property to FillColor or StrokeColor.",
-        helpLinkUri: "https://docs.flatredball.com/gum/gum-tool/upgrading/migrating-to-2026-may");
+        helpLinkUri: "https://docs.flatredball.com/gum/gum-tool/upgrading/migrating-to-2026-june");
 
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
         ImmutableArray.Create(ObsoleteShapeRuntimeRule);

--- a/Tools/Gum.ProjectServices/CodeGeneration/CodeGenerator.cs
+++ b/Tools/Gum.ProjectServices/CodeGeneration/CodeGenerator.cs
@@ -262,6 +262,7 @@ public class CodeGenerator
     private readonly CodeOutputElementSettingsManager _elementSettingsManager;
     private readonly IProjectDirectoryProvider _projectDirectoryProvider;
     private readonly ISyntaxVersionDetectionService? _syntaxVersionDetectionService;
+    private readonly ICollapsedShapeCodeGenLogic _collapsedShapeLogic;
 
     /// <summary>
     /// The current project directory (folder containing the .gumx file). Read lazily from the
@@ -293,6 +294,7 @@ public class CodeGenerator
         _projectDirectoryProvider = projectDirectoryProvider;
         _typeStringResolver = typeStringResolver;
         _syntaxVersionDetectionService = syntaxVersionDetectionService;
+        _collapsedShapeLogic = new CollapsedShapeCodeGenLogic();
     }
 
     /// <summary>
@@ -604,7 +606,19 @@ public class CodeGenerator
             }
 
             string suffix = visualApi == VisualApi.Gum ? "Runtime" : "";
-            className = _codeGenerationNameVerifier.ToCSharpName($"{strippedType}{suffix}", out isPrefixed);
+
+            // #2775 — at syntax version >= 2 the legacy single-color shape standards emit the
+            // collapsed two-slot runtimes. Standard elements only: a component could legally
+            // share a legacy shape's name.
+            string? collapsedName = null;
+            if (visualApi == VisualApi.Gum &&
+                typeof(StandardElementSave).IsAssignableFrom(elementType) &&
+                _collapsedShapeLogic.ShouldCollapse(strippedType, context.ResolvedSyntaxVersion, context.CodeOutputProjectSettings))
+            {
+                collapsedName = _collapsedShapeLogic.TryGetCollapsedRuntimeName(strippedType);
+            }
+
+            className = _codeGenerationNameVerifier.ToCSharpName(collapsedName ?? $"{strippedType}{suffix}", out isPrefixed);
         }
 
         className = className == null ? string.Empty : _codeGenerationNameVerifier.ToCSharpName(className);
@@ -690,7 +704,13 @@ public class CodeGenerator
                 var standardElement = ObjectFinder.Self.GetStandardElement(element.BaseType);
                 if(standardElement != null)
                 {
-                    inheritance = "global::" + GetGueDerivingNamespace(resolvedSyntaxVersion, isSkia: false) + "." + element.BaseType + "Runtime";
+                    // Constructed locally because GetInheritance is static and cannot use the
+                    // injected _collapsedShapeLogic.
+                    ICollapsedShapeCodeGenLogic collapsedShapeLogic = new CollapsedShapeCodeGenLogic();
+                    string runtimeName = collapsedShapeLogic.ShouldCollapse(element.BaseType, resolvedSyntaxVersion, projectSettings)
+                        ? collapsedShapeLogic.TryGetCollapsedRuntimeName(element.BaseType)!
+                        : element.BaseType + "Runtime";
+                    inheritance = "global::" + GetGueDerivingNamespace(resolvedSyntaxVersion, isSkia: false) + "." + runtimeName;
                 }
                 else
                 {
@@ -1460,6 +1480,20 @@ public class CodeGenerator
 
 
                 context.StringBuilder.AppendLine($"{tabs}if ({instanceName}.ElementSave != null) {instanceName}.SetInitialState();");
+
+                // #2775 — SetInitialState applies the legacy default state, whose single-color
+                // variables route to the stroke slot on the collapsed runtimes (#2938 semantics).
+                // Re-establish the legacy shape's default visual; explicit instance variables
+                // follow in ApplyDefaultVariables and override these.
+                if (instanceElement is StandardElementSave standardInstanceElement &&
+                    _collapsedShapeLogic.ShouldCollapse(standardInstanceElement.Name, context.ResolvedSyntaxVersion, context.CodeOutputProjectSettings))
+                {
+                    bool effectiveIsFilled = _collapsedShapeLogic.GetEffectiveIsFilled(context.Element, instance, standardInstanceElement);
+                    foreach (string assignment in _collapsedShapeLogic.GetBaselineAssignments(standardInstanceElement.Name, effectiveIsFilled))
+                    {
+                        context.StringBuilder.AppendLine($"{tabs}{instanceName}.{assignment}");
+                    }
+                }
             }
         }
 
@@ -5070,6 +5104,14 @@ public class CodeGenerator
     {
         InstanceSave? instance = context.Instance;
         var rootName = variable.GetRootName();
+
+        // #2775 — variables with no target on the collapsed shape runtimes are skipped entirely.
+        if (TryGetCollapsedShapeVariableContext(context, out bool collapsedShapeIsFilled) &&
+            _collapsedShapeLogic.ShouldDropVariable(rootName.Replace(" ", ""), collapsedShapeIsFilled))
+        {
+            return " ";
+        }
+
         #region Parent
 
         if (rootName == "Parent" && instance != null)
@@ -5182,7 +5224,7 @@ public class CodeGenerator
         return null;
     }
 
-    private static string GetGumVariableName(VariableSave variable, CodeGenerationContext context)
+    private string GetGumVariableName(VariableSave variable, CodeGenerationContext context)
     {
 #if DEBUG
         if (variable == null)
@@ -5208,8 +5250,45 @@ public class CodeGenerator
             }
         }
 
+        string rootName = variable.GetRootName().Replace(" ", "");
 
-        return variable.GetRootName().Replace(" ", "");
+        // #2775 — legacy single-color shape variables route to the collapsed runtimes'
+        // fill/stroke channel properties.
+        if (TryGetCollapsedShapeVariableContext(context, out bool effectiveIsFilled))
+        {
+            rootName = _collapsedShapeLogic.TranslateVariableRootName(rootName, effectiveIsFilled);
+        }
+
+        return rootName;
+    }
+
+    /// <summary>
+    /// Returns true when the variable owner currently being generated (the instance's base
+    /// element, or the generated element's own base type) is a legacy shape standard element
+    /// whose emission is collapsed (#2775), along with its effective IsFilled value.
+    /// </summary>
+    private bool TryGetCollapsedShapeVariableContext(CodeGenerationContext context, out bool effectiveIsFilled)
+    {
+        effectiveIsFilled = true;
+
+        ElementSave? shapeElement = null;
+        if (context.Instance != null)
+        {
+            shapeElement = ObjectFinder.Self.GetElementSave(context.Instance);
+        }
+        else if (!string.IsNullOrEmpty(context.Element?.BaseType))
+        {
+            shapeElement = ObjectFinder.Self.GetStandardElement(context.Element.BaseType);
+        }
+
+        if (shapeElement is not StandardElementSave standardElement ||
+            !_collapsedShapeLogic.ShouldCollapse(standardElement.Name, context.ResolvedSyntaxVersion, context.CodeOutputProjectSettings))
+        {
+            return false;
+        }
+
+        effectiveIsFilled = _collapsedShapeLogic.GetEffectiveIsFilled(context.Element, context.Instance, standardElement);
+        return true;
     }
 
 

--- a/Tools/Gum.ProjectServices/CodeGeneration/CollapsedShapeCodeGenLogic.cs
+++ b/Tools/Gum.ProjectServices/CodeGeneration/CollapsedShapeCodeGenLogic.cs
@@ -1,0 +1,129 @@
+using Gum.DataTypes;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Gum.ProjectServices.CodeGeneration;
+
+/// <inheritdoc cref="ICollapsedShapeCodeGenLogic"/>
+public class CollapsedShapeCodeGenLogic : ICollapsedShapeCodeGenLogic
+{
+    /// <summary>
+    /// The runtime syntax version that introduced the collapsed shape runtimes (#2774 / PR #2910).
+    /// Below this version, codegen keeps emitting the legacy types so existing pipelines don't
+    /// churn at runtime-upgrade time.
+    /// </summary>
+    public const int CollapsedShapeSyntaxVersion = 2;
+
+    /// <inheritdoc/>
+    public bool ShouldCollapse(string? standardElementName, int resolvedSyntaxVersion, CodeOutputProjectSettings? projectSettings)
+    {
+        if (projectSettings == null)
+        {
+            return false;
+        }
+
+        bool isMonoGameFamily = projectSettings.OutputLibrary == OutputLibrary.MonoGame ||
+            projectSettings.OutputLibrary == OutputLibrary.MonoGameForms;
+
+        // FindByName casts must match what the runtime .gumx loader instantiates, which is still
+        // the legacy type — only fully-in-code instantiation may target the collapsed runtimes.
+        return resolvedSyntaxVersion >= CollapsedShapeSyntaxVersion &&
+            isMonoGameFamily &&
+            projectSettings.ObjectInstantiationType == ObjectInstantiationType.FullyInCode &&
+            TryGetCollapsedRuntimeName(standardElementName) != null;
+    }
+
+    /// <inheritdoc/>
+    public string? TryGetCollapsedRuntimeName(string? standardElementName) => standardElementName switch
+    {
+        "ColoredCircle" => "CircleRuntime",
+        "ColoredRectangle" => "RectangleRuntime",
+        "RoundedRectangle" => "RectangleRuntime",
+        _ => null,
+    };
+
+    /// <inheritdoc/>
+    public bool GetEffectiveIsFilled(ElementSave? container, InstanceSave? instance, ElementSave shapeElement)
+    {
+        string variableName = instance == null ? "IsFilled" : $"{instance.Name}.IsFilled";
+        object? explicitValue = container?.DefaultState?.Variables
+            .FirstOrDefault(item => item.Name == variableName && item.SetsValue)?.Value;
+        if (explicitValue is bool explicitIsFilled)
+        {
+            return explicitIsFilled;
+        }
+
+        object? shapeDefaultValue = shapeElement.DefaultState?.Variables
+            .FirstOrDefault(item => item.Name == "IsFilled")?.Value;
+        if (shapeDefaultValue is bool shapeDefaultIsFilled)
+        {
+            return shapeDefaultIsFilled;
+        }
+
+        // ColoredRectangle defines no IsFilled variable — it is always filled.
+        return true;
+    }
+
+    /// <inheritdoc/>
+    public string TranslateVariableRootName(string rootName, bool effectiveIsFilled)
+    {
+        string channelPrefix = effectiveIsFilled ? "Fill" : "Stroke";
+        return rootName switch
+        {
+            "Red" => channelPrefix + "Red",
+            "Green" => channelPrefix + "Green",
+            "Blue" => channelPrefix + "Blue",
+            "Alpha" => channelPrefix + "Alpha",
+            _ => rootName,
+        };
+    }
+
+    /// <inheritdoc/>
+    public bool ShouldDropVariable(string rootName, bool effectiveIsFilled)
+    {
+        // Legacy standalone gradient start color: the collapsed shapes derive the gradient start
+        // from the active body color (#3009), so these have no target property.
+        if (rootName is "Red1" or "Green1" or "Blue1" or "Alpha1")
+        {
+            return true;
+        }
+
+        // Legacy filled shapes rendered no stroke, and the baseline block zeroes StrokeWidth.
+        // Passing explicit stroke values through would draw an outline that never existed.
+        if (effectiveIsFilled && rootName is "StrokeWidth" or "StrokeDashLength" or "StrokeGapLength")
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <inheritdoc/>
+    public IEnumerable<string> GetBaselineAssignments(string standardElementName, bool effectiveIsFilled)
+    {
+        // The collapsed runtimes construct as a stroke-only outline with a transparent (but
+        // opaque-white-valued) fill; the legacy shapes constructed as the inverse. Flipping
+        // IsFilled paints the white fill, matching the legacy default disc, and zeroing
+        // StrokeWidth removes the outline the legacy shapes never drew. These run after
+        // SetInitialState(), whose legacy single-color variables route to the stroke slot
+        // on the collapsed runtimes (#2938 semantics); explicit instance variables follow in
+        // ApplyDefaultVariables and override per-channel values.
+        if (effectiveIsFilled)
+        {
+            yield return "IsFilled = true;";
+            yield return "StrokeWidth = 0f;";
+        }
+        else
+        {
+            yield return "IsFilled = false;";
+            // Legacy outline default width.
+            yield return "StrokeWidth = 2f;";
+        }
+
+        if (standardElementName == "RoundedRectangle")
+        {
+            // Legacy RoundedRectangle default; the collapsed RectangleRuntime defaults to 0.
+            yield return "CornerRadius = 5f;";
+        }
+    }
+}

--- a/Tools/Gum.ProjectServices/CodeGeneration/ICollapsedShapeCodeGenLogic.cs
+++ b/Tools/Gum.ProjectServices/CodeGeneration/ICollapsedShapeCodeGenLogic.cs
@@ -1,0 +1,55 @@
+using Gum.DataTypes;
+using System.Collections.Generic;
+
+namespace Gum.ProjectServices.CodeGeneration;
+
+/// <summary>
+/// Decides when and how code generation targets the collapsed two-slot shape runtimes
+/// (<c>CircleRuntime</c> / <c>RectangleRuntime</c>) in place of the legacy
+/// <c>ColoredCircle</c> / <c>ColoredRectangle</c> / <c>RoundedRectangle</c> standard elements,
+/// and how their single-color variables translate to the fill/stroke channel properties.
+/// Issue #2775; gated on runtime syntax version 2 (#2774).
+/// </summary>
+public interface ICollapsedShapeCodeGenLogic
+{
+    /// <summary>
+    /// Returns whether generated code for the given standard element should target the collapsed
+    /// runtime type. True only when the element is a legacy shape, the resolved syntax version is
+    /// at or above the collapse version, the output library is MonoGame or MonoGameForms, and
+    /// instantiation is fully-in-code.
+    /// </summary>
+    bool ShouldCollapse(string? standardElementName, int resolvedSyntaxVersion, CodeOutputProjectSettings? projectSettings);
+
+    /// <summary>
+    /// Returns the collapsed runtime class name for a legacy shape standard element name
+    /// (for example <c>CircleRuntime</c> for <c>ColoredCircle</c>), or null when the element is
+    /// not a legacy shape.
+    /// </summary>
+    string? TryGetCollapsedRuntimeName(string? standardElementName);
+
+    /// <summary>
+    /// Resolves the effective <c>IsFilled</c> for a legacy shape: the value explicitly set in the
+    /// container's default state if present, else the shape standard element's default, else true.
+    /// This drives whether the legacy single-color variables route to the fill or stroke channels.
+    /// </summary>
+    bool GetEffectiveIsFilled(ElementSave? container, InstanceSave? instance, ElementSave shapeElement);
+
+    /// <summary>
+    /// Translates a legacy shape variable root name to its collapsed-runtime property name
+    /// (for example <c>Red</c> becomes <c>FillRed</c> or <c>StrokeRed</c>). Returns the name
+    /// unchanged when no translation applies.
+    /// </summary>
+    string TranslateVariableRootName(string rootName, bool effectiveIsFilled);
+
+    /// <summary>
+    /// Returns whether a legacy shape variable has no target on the collapsed runtime and must be
+    /// skipped entirely (gradient start color always; stroke variables when the shape is filled).
+    /// </summary>
+    bool ShouldDropVariable(string rootName, bool effectiveIsFilled);
+
+    /// <summary>
+    /// Returns the property assignments (for example <c>IsFilled = true;</c>) that re-establish
+    /// the legacy shape's default visual on a freshly-constructed collapsed runtime.
+    /// </summary>
+    IEnumerable<string> GetBaselineAssignments(string standardElementName, bool effectiveIsFilled);
+}

--- a/docs/gum-tool/upgrading/migrating-to-2026-june.md
+++ b/docs/gum-tool/upgrading/migrating-to-2026-june.md
@@ -380,6 +380,25 @@ The `Gum.Analyzers` package ships an automated code fix (`GUM002`) — place the
 
 The obsolete types will remain in place until at least the December 2026 release. After that window, they may be marked `[Obsolete(error: true)]` in a subsequent release, breaking compilation for any code still using them.
 
+### Code generation targets the collapsed shapes at syntax version 2
+
+Code generation (the Gum tool's **Code** tab and `gumcli codegen`) now emits the collapsed shape runtimes for the legacy shape standard elements. When the detected [syntax version](syntax-versions.md) is 2 or higher, the project's output library is MonoGame or MonoGameForms, and object instantiation is fully-in-code, regenerating produces:
+
+| `.gumx` standard element | Generated type before | Generated type now |
+| --- | --- | --- |
+| `ColoredCircle` | `ColoredCircleRuntime` | `CircleRuntime` |
+| `ColoredRectangle` | `ColoredRectangleRuntime` | `RectangleRuntime` |
+| `RoundedRectangle` | `RoundedRectangleRuntime` | `RectangleRuntime` |
+
+Generated color variables follow the mapping above: `Red`/`Green`/`Blue`/`Alpha` emit as the `Fill...` channel properties, or the `Stroke...` channels when the shape's `IsFilled` is false. Generated code preserves the legacy visual by assigning `IsFilled` and `StrokeWidth` (and `CornerRadius` for `RoundedRectangle`) explicitly, so a regenerated project renders the same as before.
+
+After regenerating, update any hand-written code that references the generated fields:
+
+* **Declared types** — code like `ColoredCircleRuntime circle = Screen.MyCircle;` no longer compiles, because the generated field is now typed `CircleRuntime`. The `GUM002` code fix updates these — use **Fix all in solution**.
+* **Runtime casts** — code like `GetGraphicalUiElementByName("MyCircle") as ColoredCircleRuntime` still compiles but returns null at runtime, because the generated object is now a `CircleRuntime`. The analyzer cannot fix casts automatically; search for `as ColoredCircleRuntime` (and the rectangle equivalents) and change the cast to the collapsed type.
+
+Projects using `FindByName` instantiation are unaffected — generated code keeps referencing the legacy types there, because runtime `.gumx` loading still creates them. Projects whose runtime reports a syntax version below 2 also keep the previous output. See [Syntax Versions](syntax-versions.md) for how the version is detected and how to override it.
+
 ### Legacy single-color members and `Radius` on `CircleRuntime` / `RectangleRuntime` are now `[Obsolete]`
 
 `CircleRuntime` and `RectangleRuntime` are the new fill + stroke shapes, so their inherited single-color members — `Color`, `Red`, `Green`, `Blue`, `Alpha` — and `CircleRuntime.Radius` are superseded by the fill/stroke color API and by `Width` / `Height`. Each is now `[Obsolete]` on **every** backend (MonoGame, FNA, KNI, Raylib, Skia). Existing code keeps compiling, but each reference now produces a `CS0618` compiler warning.


### PR DESCRIPTION
Closes #2775

Implements the design spec now on the issue (stub → spec design pass done as part of this work; see the issue body for the full rationale), **plus end-to-end compile verification: the codegen harness goldens are regenerated and CI now enforces they stay fresh.**

## What changes

At resolved runtime syntax version **>= 2** (#2774 / PR #2910), with `OutputLibrary` MonoGame or MonoGameForms and `ObjectInstantiationType.FullyInCode`, codegen emits the collapsed two-slot shape runtimes for the legacy shape standard elements:

| `.gumx` standard element | < v2 emits | >= v2 emits |
|---|---|---|
| `ColoredCircle` | `ColoredCircleRuntime` | `CircleRuntime` |
| `ColoredRectangle` | `ColoredRectangleRuntime` | `RectangleRuntime` |
| `RoundedRectangle` | `RoundedRectangleRuntime` | `RectangleRuntime` |

- **Variable translation**, driven by the instance's *effective `IsFilled`* (explicit variable if set, else the legacy default `true`): `Red/Green/Blue/Alpha` → `FillRed/…/FillAlpha` when filled, `StrokeRed/…/StrokeAlpha` when not.
- **Drops:** `Red1/Green1/Blue1/Alpha1` always (no target — collapsed shapes derive the gradient start from the body color, #3009); `StrokeWidth`/`StrokeDashLength`/`StrokeGapLength` when filled (legacy filled shapes drew no stroke).
- **Baseline block** after the emitted `SetInitialState()` re-establishes the legacy default visual (`IsFilled` + `StrokeWidth`, plus `CornerRadius = 5f` for `RoundedRectangle`) — necessary because `SetInitialState` applies the legacy default state whose single-color variables route to the *stroke* slot on the collapsed runtimes (#2938 semantics).
- **Inheritance**: components whose `BaseType` is a legacy shape inherit the collapsed runtime under the same gate.
- **Unchanged:** FindByName (the runtime `.gumx` loader still instantiates the legacy types, so the generated `as` casts must keep matching), Skia output library, versions < 2, and the `ElementSave = GetStandardElement("ColoredCircle")` lookup (states machinery still keys off the legacy element).

## Implementation

New `CollapsedShapeCodeGenLogic` (+ `ICollapsedShapeCodeGenLogic`) in `Tools/Gum.ProjectServices/CodeGeneration/` holds the gate, type map, variable translation, drop list, and baseline emission; `CodeGenerator` composes it rather than growing the logic inline. `GetGumVariableName` was demoted from `static` to instance (all callers were already instance methods) so translation flows through the single existing choke point; drops reuse the established `return " "` skip convention in `TryGetFullGumLineReplacement`. `CodeGenerator.GetInheritance` is static, so it constructs the logic locally — noted in a comment.

## Verification

**Unit (TDD):** `CodeGeneratorCollapsedShapeTests` (18 tests) written first and run red (10 failing for the right reasons, 8 gate-preserving invariants green), then implementation to green. Gum.ProjectServices.Tests: **272 passed, 0 failed**; Gum.Analyzers.Tests 18, MonoGameGum.Shapes.Tests 204.

**End-to-end (compile-level):** the `Tests/CodeGen_*` golden harness is regenerated with GumCli and all five projects build:

- `CodeGen_MonoGameForms_FullCodegen` shows the real flip in its committed diff — `Styles` (six `ColoredRectangle` instances → `RectangleRuntime` + `FillRed/FillGreen/FillBlue` + baseline) — and gains a new **`LegacyShapes` component** covering filled `ColoredCircle`, outline `ColoredCircle` (`IsFilled=false` → `Stroke*` routing + `StrokeWidth` passthrough), and `RoundedRectangle` with default and explicit `CornerRadius`. Its `LegacyShapes.Generated.cs` is the canonical review artifact for the emission.
- The ByReference (FindByName) projects regenerate with **legacy shape types preserved** — the gate proven on real projects.
- The bulk of the golden diff is the goldens catching up to the **v1 namespace flip** (`MonoGameGum.GueDeriving` → `Gum.GueDeriving`) they had silently missed — demonstrating the staleness gap this PR closes. The two Maui screens also pick up the `DefaultScreenBase` fallback change (`BindableGue` → `GraphicalUiElement`; both screens have empty custom partials and no external references).

**CI enforcement (new):** `build-and-test.yaml` gains a **Codegen Drift Check** step (Windows job, before the harness compile step): regenerates every harness project via `gumcli codegen` and fails if the checked-in generated code is stale. GumCli exit 1 (deliberately-broken fixture elements, e.g. `DemoScreenGum`) is tolerated; exit 2+ (load failure) fails the build. Regeneration was verified deterministic (second run byte-identical). From now on, any codegen behavior change must ship its regenerated goldens in the same PR, and the compile step proves they build.

Also: `GenerateAllCodeGenProjects.bat` now drives GumCli instead of a Debug build of the WPF tool, so local regeneration and CI use the identical path; the previously-unbuilt `CodeGen_MonoGameForms_Localization_ByReference` project is added to the CI compile step.

## Drive-bys

- Stale `migrating-to-2026-may.md` pointers (the guide was renamed to `migrating-to-2026-june.md`) fixed across `[Obsolete]` messages, analyzer `helpLinkUri`s, and comments — 10 files.
- Nullable annotation fix in `CodeGeneratorRenderTargetTextureSourceTests.AddVariable` (CS8625).

## Follow-up candidates (not in this PR)

- Migration-guide callout for the runtime-cast hole (`as ColoredCircleRuntime` against generated instances returns null post-flip) and a codegen section in the June guide.
- FindByName collapse — blocked on a runtime-side `.gumx` loader collapse (tool-side standard-element track).
- Optional runtime visual-parity test in MonoGameGum.Tests (baseline sequence vs legacy constructor visual).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
