### PR TITLE
gumcli codegen: load project localization files; fix Localization harness CodeProjectRoot (#3118)

### DIFF
--- a/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/ButtonClose.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/ButtonClose.Generated.cs
@@ -2,11 +2,11 @@
 using CodeGen_MonoGameForms_Localization_ByReference.Components.Elements;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGameForms_Localization_ByReference.Components.Controls;
@@ -17,7 +17,7 @@ partial class ButtonClose : global::Gum.Forms.Controls.Button
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/ButtonClose");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/ButtonClose - did you forget to load a Gum project?");
@@ -84,9 +84,9 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     protected override void ReactToVisualChanged()
     {
         base.ReactToVisualChanged();
-        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
+        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::Gum.GueDeriving.NineSliceRuntime;
         Icon = global::Gum.Forms.GraphicalUiElementFormsExtensions.TryGetFrameworkElementByName<Icon>(this.Visual,"Icon");
-        FocusedIndicator = this.Visual?.GetGraphicalUiElementByName("FocusedIndicator") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
+        FocusedIndicator = this.Visual?.GetGraphicalUiElementByName("FocusedIndicator") as global::Gum.GueDeriving.NineSliceRuntime;
         CustomInitialize();
     }
     //Not assigning variables because Object Instantiation Type is set to By Name rather than Fully In Code

--- a/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/ButtonConfirm.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/ButtonConfirm.Generated.cs
@@ -1,11 +1,11 @@
 //Code for Controls/ButtonConfirm (Container)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGameForms_Localization_ByReference.Components.Controls;
@@ -16,7 +16,7 @@ partial class ButtonConfirm : global::Gum.Forms.Controls.Button
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/ButtonConfirm");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/ButtonConfirm - did you forget to load a Gum project?");
@@ -71,11 +71,6 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     public TextRuntime TextInstance { get; protected set; }
     public NineSliceRuntime FocusedIndicator { get; protected set; }
 
-    public override string Text
-    {
-        get => TextInstance.Text;
-        set => TextInstance.Text = value;
-    }
 
     public ButtonConfirm(InteractiveGue visual) : base(visual)
     {
@@ -89,9 +84,9 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     protected override void ReactToVisualChanged()
     {
         base.ReactToVisualChanged();
-        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
-        TextInstance = this.Visual?.GetGraphicalUiElementByName("TextInstance") as global::MonoGameGum.GueDeriving.TextRuntime;
-        FocusedIndicator = this.Visual?.GetGraphicalUiElementByName("FocusedIndicator") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
+        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::Gum.GueDeriving.NineSliceRuntime;
+        TextInstance = this.Visual?.GetGraphicalUiElementByName("TextInstance") as global::Gum.GueDeriving.TextRuntime;
+        FocusedIndicator = this.Visual?.GetGraphicalUiElementByName("FocusedIndicator") as global::Gum.GueDeriving.NineSliceRuntime;
         CustomInitialize();
     }
     //Not assigning variables because Object Instantiation Type is set to By Name rather than Fully In Code

--- a/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/ButtonDeny.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/ButtonDeny.Generated.cs
@@ -1,11 +1,11 @@
 //Code for Controls/ButtonDeny (Container)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGameForms_Localization_ByReference.Components.Controls;
@@ -16,7 +16,7 @@ partial class ButtonDeny : global::Gum.Forms.Controls.Button
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/ButtonDeny");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/ButtonDeny - did you forget to load a Gum project?");
@@ -71,11 +71,6 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     public TextRuntime TextInstance { get; protected set; }
     public NineSliceRuntime FocusedIndicator { get; protected set; }
 
-    public override string Text
-    {
-        get => TextInstance.Text;
-        set => TextInstance.Text = value;
-    }
 
     public ButtonDeny(InteractiveGue visual) : base(visual)
     {
@@ -89,9 +84,9 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     protected override void ReactToVisualChanged()
     {
         base.ReactToVisualChanged();
-        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
-        TextInstance = this.Visual?.GetGraphicalUiElementByName("TextInstance") as global::MonoGameGum.GueDeriving.TextRuntime;
-        FocusedIndicator = this.Visual?.GetGraphicalUiElementByName("FocusedIndicator") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
+        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::Gum.GueDeriving.NineSliceRuntime;
+        TextInstance = this.Visual?.GetGraphicalUiElementByName("TextInstance") as global::Gum.GueDeriving.TextRuntime;
+        FocusedIndicator = this.Visual?.GetGraphicalUiElementByName("FocusedIndicator") as global::Gum.GueDeriving.NineSliceRuntime;
         CustomInitialize();
     }
     //Not assigning variables because Object Instantiation Type is set to By Name rather than Fully In Code

--- a/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/ButtonIcon.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/ButtonIcon.Generated.cs
@@ -2,11 +2,11 @@
 using CodeGen_MonoGameForms_Localization_ByReference.Components.Elements;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGameForms_Localization_ByReference.Components.Controls;
@@ -17,7 +17,7 @@ partial class ButtonIcon : global::Gum.Forms.Controls.Button
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/ButtonIcon");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/ButtonIcon - did you forget to load a Gum project?");
@@ -90,9 +90,9 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     protected override void ReactToVisualChanged()
     {
         base.ReactToVisualChanged();
-        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
+        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::Gum.GueDeriving.NineSliceRuntime;
         Icon = global::Gum.Forms.GraphicalUiElementFormsExtensions.TryGetFrameworkElementByName<Icon>(this.Visual,"Icon");
-        FocusedIndicator = this.Visual?.GetGraphicalUiElementByName("FocusedIndicator") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
+        FocusedIndicator = this.Visual?.GetGraphicalUiElementByName("FocusedIndicator") as global::Gum.GueDeriving.NineSliceRuntime;
         CustomInitialize();
     }
     //Not assigning variables because Object Instantiation Type is set to By Name rather than Fully In Code

--- a/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/ButtonStandard.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/ButtonStandard.Generated.cs
@@ -1,11 +1,11 @@
 //Code for Controls/ButtonStandard (Container)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGameForms_Localization_ByReference.Components.Controls;
@@ -16,7 +16,7 @@ partial class ButtonStandard : global::Gum.Forms.Controls.Button
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/ButtonStandard");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/ButtonStandard - did you forget to load a Gum project?");
@@ -72,11 +72,6 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     public TextRuntime TextInstance { get; protected set; }
     public NineSliceRuntime FocusedIndicator { get; protected set; }
 
-    public override string Text
-    {
-        get => TextInstance.Text;
-        set => TextInstance.Text = value;
-    }
 
     public ButtonStandard(InteractiveGue visual) : base(visual)
     {
@@ -90,9 +85,9 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     protected override void ReactToVisualChanged()
     {
         base.ReactToVisualChanged();
-        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
-        TextInstance = this.Visual?.GetGraphicalUiElementByName("TextInstance") as global::MonoGameGum.GueDeriving.TextRuntime;
-        FocusedIndicator = this.Visual?.GetGraphicalUiElementByName("FocusedIndicator") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
+        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::Gum.GueDeriving.NineSliceRuntime;
+        TextInstance = this.Visual?.GetGraphicalUiElementByName("TextInstance") as global::Gum.GueDeriving.TextRuntime;
+        FocusedIndicator = this.Visual?.GetGraphicalUiElementByName("FocusedIndicator") as global::Gum.GueDeriving.NineSliceRuntime;
         CustomInitialize();
     }
     //Not assigning variables because Object Instantiation Type is set to By Name rather than Fully In Code

--- a/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/ButtonStandardIcon.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/ButtonStandardIcon.Generated.cs
@@ -2,11 +2,11 @@
 using CodeGen_MonoGameForms_Localization_ByReference.Components.Elements;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGameForms_Localization_ByReference.Components.Controls;
@@ -17,7 +17,7 @@ partial class ButtonStandardIcon : global::Gum.Forms.Controls.Button
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/ButtonStandardIcon");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/ButtonStandardIcon - did you forget to load a Gum project?");
@@ -79,11 +79,6 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
         set => Icon.IconCategoryState = value;
     }
 
-    public override string Text
-    {
-        get => TextInstance.Text;
-        set => TextInstance.Text = value;
-    }
 
     public ButtonStandardIcon(InteractiveGue visual) : base(visual)
     {
@@ -97,10 +92,10 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     protected override void ReactToVisualChanged()
     {
         base.ReactToVisualChanged();
-        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
-        TextInstance = this.Visual?.GetGraphicalUiElementByName("TextInstance") as global::MonoGameGum.GueDeriving.TextRuntime;
+        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::Gum.GueDeriving.NineSliceRuntime;
+        TextInstance = this.Visual?.GetGraphicalUiElementByName("TextInstance") as global::Gum.GueDeriving.TextRuntime;
         Icon = global::Gum.Forms.GraphicalUiElementFormsExtensions.TryGetFrameworkElementByName<Icon>(this.Visual,"Icon");
-        FocusedIndicator = this.Visual?.GetGraphicalUiElementByName("FocusedIndicator") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
+        FocusedIndicator = this.Visual?.GetGraphicalUiElementByName("FocusedIndicator") as global::Gum.GueDeriving.NineSliceRuntime;
         CustomInitialize();
     }
     //Not assigning variables because Object Instantiation Type is set to By Name rather than Fully In Code

--- a/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/ButtonTab.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/ButtonTab.Generated.cs
@@ -1,11 +1,11 @@
 //Code for Controls/ButtonTab (Container)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGameForms_Localization_ByReference.Components.Controls;
@@ -16,7 +16,7 @@ partial class ButtonTab : global::Gum.Forms.Controls.Button
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/ButtonTab");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/ButtonTab - did you forget to load a Gum project?");
@@ -89,9 +89,9 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     protected override void ReactToVisualChanged()
     {
         base.ReactToVisualChanged();
-        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
-        TabText = this.Visual?.GetGraphicalUiElementByName("TabText") as global::MonoGameGum.GueDeriving.TextRuntime;
-        FocusedIndicator = this.Visual?.GetGraphicalUiElementByName("FocusedIndicator") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
+        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::Gum.GueDeriving.NineSliceRuntime;
+        TabText = this.Visual?.GetGraphicalUiElementByName("TabText") as global::Gum.GueDeriving.TextRuntime;
+        FocusedIndicator = this.Visual?.GetGraphicalUiElementByName("FocusedIndicator") as global::Gum.GueDeriving.NineSliceRuntime;
         CustomInitialize();
     }
     //Not assigning variables because Object Instantiation Type is set to By Name rather than Fully In Code

--- a/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/CheckBox.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/CheckBox.Generated.cs
@@ -2,11 +2,11 @@
 using CodeGen_MonoGameForms_Localization_ByReference.Components.Elements;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGameForms_Localization_ByReference.Components.Controls;
@@ -17,7 +17,7 @@ partial class CheckBox : global::Gum.Forms.Controls.CheckBox
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/CheckBox");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/CheckBox - did you forget to load a Gum project?");
@@ -88,11 +88,6 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     public Icon InnerCheck { get; protected set; }
     public NineSliceRuntime FocusedIndicator { get; protected set; }
 
-    public string Text
-    {
-        get => TextInstance.Text;
-        set => TextInstance.Text = value;
-    }
 
     public CheckBox(InteractiveGue visual) : base(visual)
     {
@@ -106,10 +101,10 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     protected override void ReactToVisualChanged()
     {
         base.ReactToVisualChanged();
-        CheckBoxBackground = this.Visual?.GetGraphicalUiElementByName("CheckBoxBackground") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
-        TextInstance = this.Visual?.GetGraphicalUiElementByName("TextInstance") as global::MonoGameGum.GueDeriving.TextRuntime;
+        CheckBoxBackground = this.Visual?.GetGraphicalUiElementByName("CheckBoxBackground") as global::Gum.GueDeriving.NineSliceRuntime;
+        TextInstance = this.Visual?.GetGraphicalUiElementByName("TextInstance") as global::Gum.GueDeriving.TextRuntime;
         InnerCheck = global::Gum.Forms.GraphicalUiElementFormsExtensions.TryGetFrameworkElementByName<Icon>(this.Visual,"InnerCheck");
-        FocusedIndicator = this.Visual?.GetGraphicalUiElementByName("FocusedIndicator") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
+        FocusedIndicator = this.Visual?.GetGraphicalUiElementByName("FocusedIndicator") as global::Gum.GueDeriving.NineSliceRuntime;
         CustomInitialize();
     }
     //Not assigning variables because Object Instantiation Type is set to By Name rather than Fully In Code

--- a/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/ComboBox.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/ComboBox.Generated.cs
@@ -3,11 +3,11 @@ using CodeGen_MonoGameForms_Localization_ByReference.Components.Controls;
 using CodeGen_MonoGameForms_Localization_ByReference.Components.Elements;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGameForms_Localization_ByReference.Components.Controls;
@@ -18,7 +18,7 @@ partial class ComboBox : global::Gum.Forms.Controls.ComboBox
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/ComboBox");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/ComboBox - did you forget to load a Gum project?");
@@ -88,11 +88,11 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     protected override void ReactToVisualChanged()
     {
         base.ReactToVisualChanged();
-        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
-        TextInstance = this.Visual?.GetGraphicalUiElementByName("TextInstance") as global::MonoGameGum.GueDeriving.TextRuntime;
+        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::Gum.GueDeriving.NineSliceRuntime;
+        TextInstance = this.Visual?.GetGraphicalUiElementByName("TextInstance") as global::Gum.GueDeriving.TextRuntime;
         ListBoxInstance = global::Gum.Forms.GraphicalUiElementFormsExtensions.TryGetFrameworkElementByName<ListBox>(this.Visual,"ListBoxInstance");
         IconInstance = global::Gum.Forms.GraphicalUiElementFormsExtensions.TryGetFrameworkElementByName<Icon>(this.Visual,"IconInstance");
-        FocusedIndicator = this.Visual?.GetGraphicalUiElementByName("FocusedIndicator") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
+        FocusedIndicator = this.Visual?.GetGraphicalUiElementByName("FocusedIndicator") as global::Gum.GueDeriving.NineSliceRuntime;
         CustomInitialize();
     }
     //Not assigning variables because Object Instantiation Type is set to By Name rather than Fully In Code

--- a/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/DialogBox.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/DialogBox.Generated.cs
@@ -2,11 +2,11 @@
 using CodeGen_MonoGameForms_Localization_ByReference.Components.Elements;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGameForms_Localization_ByReference.Components.Controls;
@@ -17,7 +17,7 @@ partial class DialogBox : global::Gum.Forms.Controls.FrameworkElement
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/DialogBox");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/DialogBox - did you forget to load a Gum project?");
@@ -49,8 +49,8 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     protected override void ReactToVisualChanged()
     {
         base.ReactToVisualChanged();
-        NineSliceInstance = this.Visual?.GetGraphicalUiElementByName("NineSliceInstance") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
-        TextInstance = this.Visual?.GetGraphicalUiElementByName("TextInstance") as global::MonoGameGum.GueDeriving.TextRuntime;
+        NineSliceInstance = this.Visual?.GetGraphicalUiElementByName("NineSliceInstance") as global::Gum.GueDeriving.NineSliceRuntime;
+        TextInstance = this.Visual?.GetGraphicalUiElementByName("TextInstance") as global::Gum.GueDeriving.TextRuntime;
         ContinueIndicatorInstance = global::Gum.Forms.GraphicalUiElementFormsExtensions.TryGetFrameworkElementByName<Icon>(this.Visual,"ContinueIndicatorInstance");
         CustomInitialize();
     }

--- a/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/InputDeviceSelectionItem.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/InputDeviceSelectionItem.Generated.cs
@@ -3,11 +3,11 @@ using CodeGen_MonoGameForms_Localization_ByReference.Components.Controls;
 using CodeGen_MonoGameForms_Localization_ByReference.Components.Elements;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGameForms_Localization_ByReference.Components.Controls;
@@ -18,7 +18,7 @@ partial class InputDeviceSelectionItem : global::Gum.Forms.Controls.FrameworkEle
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/InputDeviceSelectionItem");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/InputDeviceSelectionItem - did you forget to load a Gum project?");
@@ -81,9 +81,9 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     protected override void ReactToVisualChanged()
     {
         base.ReactToVisualChanged();
-        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
+        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::Gum.GueDeriving.NineSliceRuntime;
         IconInstance = global::Gum.Forms.GraphicalUiElementFormsExtensions.TryGetFrameworkElementByName<Icon>(this.Visual,"IconInstance");
-        TextInstance = this.Visual?.GetGraphicalUiElementByName("TextInstance") as global::MonoGameGum.GueDeriving.TextRuntime;
+        TextInstance = this.Visual?.GetGraphicalUiElementByName("TextInstance") as global::Gum.GueDeriving.TextRuntime;
         RemoveDeviceButtonInstance = global::Gum.Forms.GraphicalUiElementFormsExtensions.TryGetFrameworkElementByName<ButtonClose>(this.Visual,"RemoveDeviceButtonInstance");
         CustomInitialize();
     }

--- a/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/InputDeviceSelector.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/InputDeviceSelector.Generated.cs
@@ -2,11 +2,11 @@
 using CodeGen_MonoGameForms_Localization_ByReference.Components.Controls;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGameForms_Localization_ByReference.Components.Controls;
@@ -17,7 +17,7 @@ partial class InputDeviceSelector : global::Gum.Forms.Controls.FrameworkElement
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/InputDeviceSelector");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/InputDeviceSelector - did you forget to load a Gum project?");
@@ -56,12 +56,12 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     protected override void ReactToVisualChanged()
     {
         base.ReactToVisualChanged();
-        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
-        TextInstance = this.Visual?.GetGraphicalUiElementByName("TextInstance") as global::MonoGameGum.GueDeriving.TextRuntime;
-        TextInstance1 = this.Visual?.GetGraphicalUiElementByName("TextInstance1") as global::MonoGameGum.GueDeriving.TextRuntime;
-        ContainerInstance1 = this.Visual?.GetGraphicalUiElementByName("ContainerInstance1") as global::MonoGameGum.GueDeriving.ContainerRuntime;
-        InputDeviceContainerInstance = this.Visual?.GetGraphicalUiElementByName("InputDeviceContainerInstance") as global::MonoGameGum.GueDeriving.ContainerRuntime;
-        ContainerInstance2 = this.Visual?.GetGraphicalUiElementByName("ContainerInstance2") as global::MonoGameGum.GueDeriving.ContainerRuntime;
+        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::Gum.GueDeriving.NineSliceRuntime;
+        TextInstance = this.Visual?.GetGraphicalUiElementByName("TextInstance") as global::Gum.GueDeriving.TextRuntime;
+        TextInstance1 = this.Visual?.GetGraphicalUiElementByName("TextInstance1") as global::Gum.GueDeriving.TextRuntime;
+        ContainerInstance1 = this.Visual?.GetGraphicalUiElementByName("ContainerInstance1") as global::Gum.GueDeriving.ContainerRuntime;
+        InputDeviceContainerInstance = this.Visual?.GetGraphicalUiElementByName("InputDeviceContainerInstance") as global::Gum.GueDeriving.ContainerRuntime;
+        ContainerInstance2 = this.Visual?.GetGraphicalUiElementByName("ContainerInstance2") as global::Gum.GueDeriving.ContainerRuntime;
         InputDeviceSelectionItemInstance = global::Gum.Forms.GraphicalUiElementFormsExtensions.TryGetFrameworkElementByName<InputDeviceSelectionItem>(this.Visual,"InputDeviceSelectionItemInstance");
         InputDeviceSelectionItemInstance1 = global::Gum.Forms.GraphicalUiElementFormsExtensions.TryGetFrameworkElementByName<InputDeviceSelectionItem>(this.Visual,"InputDeviceSelectionItemInstance1");
         InputDeviceSelectionItemInstance2 = global::Gum.Forms.GraphicalUiElementFormsExtensions.TryGetFrameworkElementByName<InputDeviceSelectionItem>(this.Visual,"InputDeviceSelectionItemInstance2");

--- a/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/ItemsControl.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/ItemsControl.Generated.cs
@@ -2,12 +2,12 @@
 using CodeGen_MonoGameForms_Localization_ByReference.Components.Controls;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.StateAnimation.Runtime;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGameForms_Localization_ByReference.Components.Controls;
@@ -18,7 +18,7 @@ partial class ItemsControl : global::Gum.Forms.Controls.ItemsControl
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/ItemsControl");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/ItemsControl - did you forget to load a Gum project?");
@@ -86,13 +86,13 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     protected override void ReactToVisualChanged()
     {
         base.ReactToVisualChanged();
-        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
+        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::Gum.GueDeriving.NineSliceRuntime;
         VerticalScrollBarInstance = global::Gum.Forms.GraphicalUiElementFormsExtensions.TryGetFrameworkElementByName<ScrollBar>(this.Visual,"VerticalScrollBarInstance");
-        ClipContainerInstance = this.Visual?.GetGraphicalUiElementByName("ClipContainerInstance") as global::MonoGameGum.GueDeriving.ContainerRuntime;
-        InnerPanelInstance = this.Visual?.GetGraphicalUiElementByName("InnerPanelInstance") as global::MonoGameGum.GueDeriving.ContainerRuntime;
-        FocusedIndicator = this.Visual?.GetGraphicalUiElementByName("FocusedIndicator") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
-        ClipAndScrollContainer = this.Visual?.GetGraphicalUiElementByName("ClipAndScrollContainer") as global::MonoGameGum.GueDeriving.ContainerRuntime;
-        ClipContainerParent = this.Visual?.GetGraphicalUiElementByName("ClipContainerParent") as global::MonoGameGum.GueDeriving.ContainerRuntime;
+        ClipContainerInstance = this.Visual?.GetGraphicalUiElementByName("ClipContainerInstance") as global::Gum.GueDeriving.ContainerRuntime;
+        InnerPanelInstance = this.Visual?.GetGraphicalUiElementByName("InnerPanelInstance") as global::Gum.GueDeriving.ContainerRuntime;
+        FocusedIndicator = this.Visual?.GetGraphicalUiElementByName("FocusedIndicator") as global::Gum.GueDeriving.NineSliceRuntime;
+        ClipAndScrollContainer = this.Visual?.GetGraphicalUiElementByName("ClipAndScrollContainer") as global::Gum.GueDeriving.ContainerRuntime;
+        ClipContainerParent = this.Visual?.GetGraphicalUiElementByName("ClipContainerParent") as global::Gum.GueDeriving.ContainerRuntime;
         CustomInitialize();
     }
     //Not assigning variables because Object Instantiation Type is set to By Name rather than Fully In Code

--- a/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/Keyboard.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/Keyboard.Generated.cs
@@ -3,12 +3,12 @@ using CodeGen_MonoGameForms_Localization_ByReference.Components.Controls;
 using CodeGen_MonoGameForms_Localization_ByReference.Components.Elements;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.StateAnimation.Runtime;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGameForms_Localization_ByReference.Components.Controls;
@@ -19,7 +19,7 @@ partial class Keyboard : global::Gum.Forms.Controls.FrameworkElement
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/Keyboard");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/Keyboard - did you forget to load a Gum project?");
@@ -139,8 +139,8 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     protected override void ReactToVisualChanged()
     {
         base.ReactToVisualChanged();
-        Row1Keys = this.Visual?.GetGraphicalUiElementByName("Row1Keys") as global::MonoGameGum.GueDeriving.ContainerRuntime;
-        AllRows = this.Visual?.GetGraphicalUiElementByName("AllRows") as global::MonoGameGum.GueDeriving.ContainerRuntime;
+        Row1Keys = this.Visual?.GetGraphicalUiElementByName("Row1Keys") as global::Gum.GueDeriving.ContainerRuntime;
+        AllRows = this.Visual?.GetGraphicalUiElementByName("AllRows") as global::Gum.GueDeriving.ContainerRuntime;
         Key1 = global::Gum.Forms.GraphicalUiElementFormsExtensions.TryGetFrameworkElementByName<KeyboardKey>(this.Visual,"Key1");
         KeyQ = global::Gum.Forms.GraphicalUiElementFormsExtensions.TryGetFrameworkElementByName<KeyboardKey>(this.Visual,"KeyQ");
         KeyA = global::Gum.Forms.GraphicalUiElementFormsExtensions.TryGetFrameworkElementByName<KeyboardKey>(this.Visual,"KeyA");
@@ -187,15 +187,15 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
         Key8 = global::Gum.Forms.GraphicalUiElementFormsExtensions.TryGetFrameworkElementByName<KeyboardKey>(this.Visual,"Key8");
         Key9 = global::Gum.Forms.GraphicalUiElementFormsExtensions.TryGetFrameworkElementByName<KeyboardKey>(this.Visual,"Key9");
         Key0 = global::Gum.Forms.GraphicalUiElementFormsExtensions.TryGetFrameworkElementByName<KeyboardKey>(this.Visual,"Key0");
-        Row2Keys = this.Visual?.GetGraphicalUiElementByName("Row2Keys") as global::MonoGameGum.GueDeriving.ContainerRuntime;
-        Row3Keys = this.Visual?.GetGraphicalUiElementByName("Row3Keys") as global::MonoGameGum.GueDeriving.ContainerRuntime;
-        Row4Keys = this.Visual?.GetGraphicalUiElementByName("Row4Keys") as global::MonoGameGum.GueDeriving.ContainerRuntime;
-        Row5Keys = this.Visual?.GetGraphicalUiElementByName("Row5Keys") as global::MonoGameGum.GueDeriving.ContainerRuntime;
+        Row2Keys = this.Visual?.GetGraphicalUiElementByName("Row2Keys") as global::Gum.GueDeriving.ContainerRuntime;
+        Row3Keys = this.Visual?.GetGraphicalUiElementByName("Row3Keys") as global::Gum.GueDeriving.ContainerRuntime;
+        Row4Keys = this.Visual?.GetGraphicalUiElementByName("Row4Keys") as global::Gum.GueDeriving.ContainerRuntime;
+        Row5Keys = this.Visual?.GetGraphicalUiElementByName("Row5Keys") as global::Gum.GueDeriving.ContainerRuntime;
         KeyBackspace = global::Gum.Forms.GraphicalUiElementFormsExtensions.TryGetFrameworkElementByName<KeyboardKey>(this.Visual,"KeyBackspace");
         KeyReturn = global::Gum.Forms.GraphicalUiElementFormsExtensions.TryGetFrameworkElementByName<KeyboardKey>(this.Visual,"KeyReturn");
         KeyLeft = global::Gum.Forms.GraphicalUiElementFormsExtensions.TryGetFrameworkElementByName<KeyboardKey>(this.Visual,"KeyLeft");
         KeyRight = global::Gum.Forms.GraphicalUiElementFormsExtensions.TryGetFrameworkElementByName<KeyboardKey>(this.Visual,"KeyRight");
-        HighlightRectangle = this.Visual?.GetGraphicalUiElementByName("HighlightRectangle") as global::MonoGameGum.GueDeriving.RectangleRuntime;
+        HighlightRectangle = this.Visual?.GetGraphicalUiElementByName("HighlightRectangle") as global::Gum.GueDeriving.RectangleRuntime;
         IconInstance = global::Gum.Forms.GraphicalUiElementFormsExtensions.TryGetFrameworkElementByName<Icon>(this.Visual,"IconInstance");
         IconInstance1 = global::Gum.Forms.GraphicalUiElementFormsExtensions.TryGetFrameworkElementByName<Icon>(this.Visual,"IconInstance1");
         IconInstance2 = global::Gum.Forms.GraphicalUiElementFormsExtensions.TryGetFrameworkElementByName<Icon>(this.Visual,"IconInstance2");

--- a/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/KeyboardKey.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/KeyboardKey.Generated.cs
@@ -1,12 +1,12 @@
 //Code for Controls/KeyboardKey (Container)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.StateAnimation.Runtime;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGameForms_Localization_ByReference.Components.Controls;
@@ -17,7 +17,7 @@ partial class KeyboardKey : global::Gum.Forms.Controls.Button
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/KeyboardKey");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/KeyboardKey - did you forget to load a Gum project?");
@@ -72,11 +72,6 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     public TextRuntime TextInstance { get; protected set; }
     public NineSliceRuntime FocusedIndicator { get; protected set; }
 
-    public override string Text
-    {
-        get => TextInstance.Text;
-        set => TextInstance.Text = value;
-    }
 
     public KeyboardKey(InteractiveGue visual) : base(visual)
     {
@@ -90,9 +85,9 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     protected override void ReactToVisualChanged()
     {
         base.ReactToVisualChanged();
-        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
-        TextInstance = this.Visual?.GetGraphicalUiElementByName("TextInstance") as global::MonoGameGum.GueDeriving.TextRuntime;
-        FocusedIndicator = this.Visual?.GetGraphicalUiElementByName("FocusedIndicator") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
+        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::Gum.GueDeriving.NineSliceRuntime;
+        TextInstance = this.Visual?.GetGraphicalUiElementByName("TextInstance") as global::Gum.GueDeriving.TextRuntime;
+        FocusedIndicator = this.Visual?.GetGraphicalUiElementByName("FocusedIndicator") as global::Gum.GueDeriving.NineSliceRuntime;
         CustomInitialize();
     }
     //Not assigning variables because Object Instantiation Type is set to By Name rather than Fully In Code

--- a/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/Label.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/Label.Generated.cs
@@ -1,11 +1,11 @@
 //Code for Controls/Label (Text)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGameForms_Localization_ByReference.Components.Controls;
@@ -16,7 +16,7 @@ partial class Label : global::Gum.Forms.Controls.Label
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.TextRuntime();
+            var visual = new global::Gum.GueDeriving.TextRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/Label");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/Label - did you forget to load a Gum project?");

--- a/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/ListBox.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/ListBox.Generated.cs
@@ -2,11 +2,11 @@
 using CodeGen_MonoGameForms_Localization_ByReference.Components.Controls;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGameForms_Localization_ByReference.Components.Controls;
@@ -17,7 +17,7 @@ partial class ListBox : global::Gum.Forms.Controls.ListBox
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/ListBox");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/ListBox - did you forget to load a Gum project?");
@@ -86,13 +86,13 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     protected override void ReactToVisualChanged()
     {
         base.ReactToVisualChanged();
-        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
+        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::Gum.GueDeriving.NineSliceRuntime;
         VerticalScrollBarInstance = global::Gum.Forms.GraphicalUiElementFormsExtensions.TryGetFrameworkElementByName<ScrollBar>(this.Visual,"VerticalScrollBarInstance");
-        ClipContainerInstance = this.Visual?.GetGraphicalUiElementByName("ClipContainerInstance") as global::MonoGameGum.GueDeriving.ContainerRuntime;
-        InnerPanelInstance = this.Visual?.GetGraphicalUiElementByName("InnerPanelInstance") as global::MonoGameGum.GueDeriving.ContainerRuntime;
-        FocusedIndicator = this.Visual?.GetGraphicalUiElementByName("FocusedIndicator") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
-        ClipAndScrollContainer = this.Visual?.GetGraphicalUiElementByName("ClipAndScrollContainer") as global::MonoGameGum.GueDeriving.ContainerRuntime;
-        ClipContainerParent = this.Visual?.GetGraphicalUiElementByName("ClipContainerParent") as global::MonoGameGum.GueDeriving.ContainerRuntime;
+        ClipContainerInstance = this.Visual?.GetGraphicalUiElementByName("ClipContainerInstance") as global::Gum.GueDeriving.ContainerRuntime;
+        InnerPanelInstance = this.Visual?.GetGraphicalUiElementByName("InnerPanelInstance") as global::Gum.GueDeriving.ContainerRuntime;
+        FocusedIndicator = this.Visual?.GetGraphicalUiElementByName("FocusedIndicator") as global::Gum.GueDeriving.NineSliceRuntime;
+        ClipAndScrollContainer = this.Visual?.GetGraphicalUiElementByName("ClipAndScrollContainer") as global::Gum.GueDeriving.ContainerRuntime;
+        ClipContainerParent = this.Visual?.GetGraphicalUiElementByName("ClipContainerParent") as global::Gum.GueDeriving.ContainerRuntime;
         CustomInitialize();
     }
     //Not assigning variables because Object Instantiation Type is set to By Name rather than Fully In Code

--- a/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/ListBoxItem.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/ListBoxItem.Generated.cs
@@ -1,11 +1,11 @@
 //Code for Controls/ListBoxItem (Container)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGameForms_Localization_ByReference.Components.Controls;
@@ -16,7 +16,7 @@ partial class ListBoxItem : global::Gum.Forms.Controls.ListBoxItem
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/ListBoxItem");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/ListBoxItem - did you forget to load a Gum project?");
@@ -87,9 +87,9 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     protected override void ReactToVisualChanged()
     {
         base.ReactToVisualChanged();
-        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
-        TextInstance = this.Visual?.GetGraphicalUiElementByName("TextInstance") as global::MonoGameGum.GueDeriving.TextRuntime;
-        FocusedIndicator = this.Visual?.GetGraphicalUiElementByName("FocusedIndicator") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
+        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::Gum.GueDeriving.NineSliceRuntime;
+        TextInstance = this.Visual?.GetGraphicalUiElementByName("TextInstance") as global::Gum.GueDeriving.TextRuntime;
+        FocusedIndicator = this.Visual?.GetGraphicalUiElementByName("FocusedIndicator") as global::Gum.GueDeriving.NineSliceRuntime;
         CustomInitialize();
     }
     //Not assigning variables because Object Instantiation Type is set to By Name rather than Fully In Code

--- a/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/Menu.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/Menu.Generated.cs
@@ -1,11 +1,11 @@
 //Code for Controls/Menu (Container)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGameForms_Localization_ByReference.Components.Controls;
@@ -16,7 +16,7 @@ partial class Menu : global::Gum.Forms.Controls.Menu
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/Menu");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/Menu - did you forget to load a Gum project?");
@@ -48,8 +48,8 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     protected override void ReactToVisualChanged()
     {
         base.ReactToVisualChanged();
-        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
-        InnerPanelInstance = this.Visual?.GetGraphicalUiElementByName("InnerPanelInstance") as global::MonoGameGum.GueDeriving.ContainerRuntime;
+        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::Gum.GueDeriving.NineSliceRuntime;
+        InnerPanelInstance = this.Visual?.GetGraphicalUiElementByName("InnerPanelInstance") as global::Gum.GueDeriving.ContainerRuntime;
         CustomInitialize();
     }
     //Not assigning variables because Object Instantiation Type is set to By Name rather than Fully In Code

--- a/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/MenuItem.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/MenuItem.Generated.cs
@@ -1,11 +1,11 @@
 //Code for Controls/MenuItem (Container)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGameForms_Localization_ByReference.Components.Controls;
@@ -16,7 +16,7 @@ partial class MenuItem : global::Gum.Forms.Controls.MenuItem
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/MenuItem");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/MenuItem - did you forget to load a Gum project?");
@@ -72,11 +72,6 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     public ContainerRuntime ContainerInstance { get; protected set; }
     public ContainerRuntime SubItemContainerInstance { get; protected set; }
 
-    public override string Header
-    {
-        get => TextInstance.Text;
-        set => TextInstance.Text = value;
-    }
 
     public MenuItem(InteractiveGue visual) : base(visual)
     {
@@ -90,11 +85,11 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     protected override void ReactToVisualChanged()
     {
         base.ReactToVisualChanged();
-        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
-        TextInstance = this.Visual?.GetGraphicalUiElementByName("TextInstance") as global::MonoGameGum.GueDeriving.TextRuntime;
-        SubmenuIndicatorInstance = this.Visual?.GetGraphicalUiElementByName("SubmenuIndicatorInstance") as global::MonoGameGum.GueDeriving.TextRuntime;
-        ContainerInstance = this.Visual?.GetGraphicalUiElementByName("ContainerInstance") as global::MonoGameGum.GueDeriving.ContainerRuntime;
-        SubItemContainerInstance = this.Visual?.GetGraphicalUiElementByName("SubItemContainerInstance") as global::MonoGameGum.GueDeriving.ContainerRuntime;
+        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::Gum.GueDeriving.NineSliceRuntime;
+        TextInstance = this.Visual?.GetGraphicalUiElementByName("TextInstance") as global::Gum.GueDeriving.TextRuntime;
+        SubmenuIndicatorInstance = this.Visual?.GetGraphicalUiElementByName("SubmenuIndicatorInstance") as global::Gum.GueDeriving.TextRuntime;
+        ContainerInstance = this.Visual?.GetGraphicalUiElementByName("ContainerInstance") as global::Gum.GueDeriving.ContainerRuntime;
+        SubItemContainerInstance = this.Visual?.GetGraphicalUiElementByName("SubItemContainerInstance") as global::Gum.GueDeriving.ContainerRuntime;
         CustomInitialize();
     }
     //Not assigning variables because Object Instantiation Type is set to By Name rather than Fully In Code

--- a/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/Panel.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/Panel.Generated.cs
@@ -1,11 +1,11 @@
 //Code for Controls/Panel (Container)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGameForms_Localization_ByReference.Components.Controls;
@@ -16,7 +16,7 @@ partial class Panel : global::Gum.Forms.Controls.Panel
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/Panel");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/Panel - did you forget to load a Gum project?");

--- a/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/PasswordBox.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/PasswordBox.Generated.cs
@@ -1,11 +1,11 @@
 //Code for Controls/PasswordBox (Container)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGameForms_Localization_ByReference.Components.Controls;
@@ -16,7 +16,7 @@ partial class PasswordBox : global::Gum.Forms.Controls.PasswordBox
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/PasswordBox");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/PasswordBox - did you forget to load a Gum project?");
@@ -91,13 +91,13 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     protected override void ReactToVisualChanged()
     {
         base.ReactToVisualChanged();
-        SelectionInstance = this.Visual?.GetGraphicalUiElementByName("SelectionInstance") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
-        TextInstance = this.Visual?.GetGraphicalUiElementByName("TextInstance") as global::MonoGameGum.GueDeriving.TextRuntime;
-        PlaceholderTextInstance = this.Visual?.GetGraphicalUiElementByName("PlaceholderTextInstance") as global::MonoGameGum.GueDeriving.TextRuntime;
-        CaretInstance = this.Visual?.GetGraphicalUiElementByName("CaretInstance") as global::MonoGameGum.GueDeriving.SpriteRuntime;
-        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
-        ClipContainer = this.Visual?.GetGraphicalUiElementByName("ClipContainer") as global::MonoGameGum.GueDeriving.ContainerRuntime;
-        FocusedIndicator = this.Visual?.GetGraphicalUiElementByName("FocusedIndicator") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
+        SelectionInstance = this.Visual?.GetGraphicalUiElementByName("SelectionInstance") as global::Gum.GueDeriving.NineSliceRuntime;
+        TextInstance = this.Visual?.GetGraphicalUiElementByName("TextInstance") as global::Gum.GueDeriving.TextRuntime;
+        PlaceholderTextInstance = this.Visual?.GetGraphicalUiElementByName("PlaceholderTextInstance") as global::Gum.GueDeriving.TextRuntime;
+        CaretInstance = this.Visual?.GetGraphicalUiElementByName("CaretInstance") as global::Gum.GueDeriving.SpriteRuntime;
+        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::Gum.GueDeriving.NineSliceRuntime;
+        ClipContainer = this.Visual?.GetGraphicalUiElementByName("ClipContainer") as global::Gum.GueDeriving.ContainerRuntime;
+        FocusedIndicator = this.Visual?.GetGraphicalUiElementByName("FocusedIndicator") as global::Gum.GueDeriving.NineSliceRuntime;
         CustomInitialize();
     }
     //Not assigning variables because Object Instantiation Type is set to By Name rather than Fully In Code

--- a/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/PlayerJoinView.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/PlayerJoinView.Generated.cs
@@ -2,11 +2,11 @@
 using CodeGen_MonoGameForms_Localization_ByReference.Components.Controls;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGameForms_Localization_ByReference.Components.Controls;
@@ -17,7 +17,7 @@ partial class PlayerJoinView : global::Gum.Forms.Controls.FrameworkElement
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/PlayerJoinView");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/PlayerJoinView - did you forget to load a Gum project?");
@@ -51,7 +51,7 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     protected override void ReactToVisualChanged()
     {
         base.ReactToVisualChanged();
-        InnerPanelInstance = this.Visual?.GetGraphicalUiElementByName("InnerPanelInstance") as global::MonoGameGum.GueDeriving.ContainerRuntime;
+        InnerPanelInstance = this.Visual?.GetGraphicalUiElementByName("InnerPanelInstance") as global::Gum.GueDeriving.ContainerRuntime;
         PlayerJoinViewItem1 = global::Gum.Forms.GraphicalUiElementFormsExtensions.TryGetFrameworkElementByName<PlayerJoinViewItem>(this.Visual,"PlayerJoinViewItem1");
         PlayerJoinViewItem2 = global::Gum.Forms.GraphicalUiElementFormsExtensions.TryGetFrameworkElementByName<PlayerJoinViewItem>(this.Visual,"PlayerJoinViewItem2");
         PlayerJoinViewItem3 = global::Gum.Forms.GraphicalUiElementFormsExtensions.TryGetFrameworkElementByName<PlayerJoinViewItem>(this.Visual,"PlayerJoinViewItem3");

--- a/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/PlayerJoinViewItem.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/PlayerJoinViewItem.Generated.cs
@@ -2,11 +2,11 @@
 using CodeGen_MonoGameForms_Localization_ByReference.Components.Elements;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGameForms_Localization_ByReference.Components.Controls;
@@ -17,7 +17,7 @@ partial class PlayerJoinViewItem : global::Gum.Forms.Controls.FrameworkElement
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/PlayerJoinViewItem");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/PlayerJoinViewItem - did you forget to load a Gum project?");
@@ -150,8 +150,8 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     protected override void ReactToVisualChanged()
     {
         base.ReactToVisualChanged();
-        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
-        ControllerDisplayNameTextInstance = this.Visual?.GetGraphicalUiElementByName("ControllerDisplayNameTextInstance") as global::MonoGameGum.GueDeriving.TextRuntime;
+        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::Gum.GueDeriving.NineSliceRuntime;
+        ControllerDisplayNameTextInstance = this.Visual?.GetGraphicalUiElementByName("ControllerDisplayNameTextInstance") as global::Gum.GueDeriving.TextRuntime;
         InputDeviceIcon = global::Gum.Forms.GraphicalUiElementFormsExtensions.TryGetFrameworkElementByName<Icon>(this.Visual,"InputDeviceIcon");
         CustomInitialize();
     }

--- a/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/RadioButton.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/RadioButton.Generated.cs
@@ -2,11 +2,11 @@
 using CodeGen_MonoGameForms_Localization_ByReference.Components.Elements;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGameForms_Localization_ByReference.Components.Controls;
@@ -17,7 +17,7 @@ partial class RadioButton : global::Gum.Forms.Controls.RadioButton
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/RadioButton");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/RadioButton - did you forget to load a Gum project?");
@@ -81,11 +81,6 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     public TextRuntime TextInstance { get; protected set; }
     public NineSliceRuntime FocusedIndicator { get; protected set; }
 
-    public string Text
-    {
-        get => TextInstance.Text;
-        set => TextInstance.Text = value;
-    }
 
     public RadioButton(InteractiveGue visual) : base(visual)
     {
@@ -99,10 +94,10 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     protected override void ReactToVisualChanged()
     {
         base.ReactToVisualChanged();
-        RadioBackground = this.Visual?.GetGraphicalUiElementByName("RadioBackground") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
+        RadioBackground = this.Visual?.GetGraphicalUiElementByName("RadioBackground") as global::Gum.GueDeriving.NineSliceRuntime;
         Radio = global::Gum.Forms.GraphicalUiElementFormsExtensions.TryGetFrameworkElementByName<Icon>(this.Visual,"Radio");
-        TextInstance = this.Visual?.GetGraphicalUiElementByName("TextInstance") as global::MonoGameGum.GueDeriving.TextRuntime;
-        FocusedIndicator = this.Visual?.GetGraphicalUiElementByName("FocusedIndicator") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
+        TextInstance = this.Visual?.GetGraphicalUiElementByName("TextInstance") as global::Gum.GueDeriving.TextRuntime;
+        FocusedIndicator = this.Visual?.GetGraphicalUiElementByName("FocusedIndicator") as global::Gum.GueDeriving.NineSliceRuntime;
         CustomInitialize();
     }
     //Not assigning variables because Object Instantiation Type is set to By Name rather than Fully In Code

--- a/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/ScrollBar.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/ScrollBar.Generated.cs
@@ -2,11 +2,11 @@
 using CodeGen_MonoGameForms_Localization_ByReference.Components.Controls;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGameForms_Localization_ByReference.Components.Controls;
@@ -17,7 +17,7 @@ partial class ScrollBar : global::Gum.Forms.Controls.ScrollBar
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/ScrollBar");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/ScrollBar - did you forget to load a Gum project?");
@@ -112,8 +112,8 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
         base.ReactToVisualChanged();
         UpButtonInstance = global::Gum.Forms.GraphicalUiElementFormsExtensions.TryGetFrameworkElementByName<ButtonIcon>(this.Visual,"UpButtonInstance");
         DownButtonInstance = global::Gum.Forms.GraphicalUiElementFormsExtensions.TryGetFrameworkElementByName<ButtonIcon>(this.Visual,"DownButtonInstance");
-        TrackInstance = this.Visual?.GetGraphicalUiElementByName("TrackInstance") as global::MonoGameGum.GueDeriving.ContainerRuntime;
-        TrackBackground = this.Visual?.GetGraphicalUiElementByName("TrackBackground") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
+        TrackInstance = this.Visual?.GetGraphicalUiElementByName("TrackInstance") as global::Gum.GueDeriving.ContainerRuntime;
+        TrackBackground = this.Visual?.GetGraphicalUiElementByName("TrackBackground") as global::Gum.GueDeriving.NineSliceRuntime;
         ThumbInstance = global::Gum.Forms.GraphicalUiElementFormsExtensions.TryGetFrameworkElementByName<ButtonStandard>(this.Visual,"ThumbInstance");
         CustomInitialize();
     }

--- a/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/ScrollViewer.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/ScrollViewer.Generated.cs
@@ -2,11 +2,11 @@
 using CodeGen_MonoGameForms_Localization_ByReference.Components.Controls;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGameForms_Localization_ByReference.Components.Controls;
@@ -17,7 +17,7 @@ partial class ScrollViewer : global::Gum.Forms.Controls.ScrollViewer
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/ScrollViewer");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/ScrollViewer - did you forget to load a Gum project?");
@@ -115,12 +115,12 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     protected override void ReactToVisualChanged()
     {
         base.ReactToVisualChanged();
-        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
+        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::Gum.GueDeriving.NineSliceRuntime;
         VerticalScrollBarInstance = global::Gum.Forms.GraphicalUiElementFormsExtensions.TryGetFrameworkElementByName<ScrollBar>(this.Visual,"VerticalScrollBarInstance");
         HorizontalScrollBarInstance = global::Gum.Forms.GraphicalUiElementFormsExtensions.TryGetFrameworkElementByName<ScrollBar>(this.Visual,"HorizontalScrollBarInstance");
-        ClipContainerInstance = this.Visual?.GetGraphicalUiElementByName("ClipContainerInstance") as global::MonoGameGum.GueDeriving.ContainerRuntime;
-        InnerPanelInstance = this.Visual?.GetGraphicalUiElementByName("InnerPanelInstance") as global::MonoGameGum.GueDeriving.ContainerRuntime;
-        FocusedIndicator = this.Visual?.GetGraphicalUiElementByName("FocusedIndicator") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
+        ClipContainerInstance = this.Visual?.GetGraphicalUiElementByName("ClipContainerInstance") as global::Gum.GueDeriving.ContainerRuntime;
+        InnerPanelInstance = this.Visual?.GetGraphicalUiElementByName("InnerPanelInstance") as global::Gum.GueDeriving.ContainerRuntime;
+        FocusedIndicator = this.Visual?.GetGraphicalUiElementByName("FocusedIndicator") as global::Gum.GueDeriving.NineSliceRuntime;
         CustomInitialize();
     }
     //Not assigning variables because Object Instantiation Type is set to By Name rather than Fully In Code

--- a/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/SettingsView.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/SettingsView.Generated.cs
@@ -2,11 +2,11 @@
 using CodeGen_MonoGameForms_Localization_ByReference.Components.Controls;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGameForms_Localization_ByReference.Components.Controls;
@@ -17,7 +17,7 @@ partial class SettingsView : global::Gum.Forms.Controls.FrameworkElement
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/SettingsView");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/SettingsView - did you forget to load a Gum project?");

--- a/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/Slider.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/Slider.Generated.cs
@@ -2,11 +2,11 @@
 using CodeGen_MonoGameForms_Localization_ByReference.Components.Controls;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGameForms_Localization_ByReference.Components.Controls;
@@ -17,7 +17,7 @@ partial class Slider : global::Gum.Forms.Controls.Slider
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/Slider");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/Slider - did you forget to load a Gum project?");
@@ -92,10 +92,10 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     protected override void ReactToVisualChanged()
     {
         base.ReactToVisualChanged();
-        TrackInstance = this.Visual?.GetGraphicalUiElementByName("TrackInstance") as global::MonoGameGum.GueDeriving.ContainerRuntime;
-        TrackBackground = this.Visual?.GetGraphicalUiElementByName("TrackBackground") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
+        TrackInstance = this.Visual?.GetGraphicalUiElementByName("TrackInstance") as global::Gum.GueDeriving.ContainerRuntime;
+        TrackBackground = this.Visual?.GetGraphicalUiElementByName("TrackBackground") as global::Gum.GueDeriving.NineSliceRuntime;
         ThumbInstance = global::Gum.Forms.GraphicalUiElementFormsExtensions.TryGetFrameworkElementByName<ButtonStandard>(this.Visual,"ThumbInstance");
-        FocusedIndicator = this.Visual?.GetGraphicalUiElementByName("FocusedIndicator") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
+        FocusedIndicator = this.Visual?.GetGraphicalUiElementByName("FocusedIndicator") as global::Gum.GueDeriving.NineSliceRuntime;
         CustomInitialize();
     }
     //Not assigning variables because Object Instantiation Type is set to By Name rather than Fully In Code

--- a/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/SplitterStandard.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/SplitterStandard.Generated.cs
@@ -1,11 +1,11 @@
 //Code for Controls/SplitterStandard (Container)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGameForms_Localization_ByReference.Components.Controls;
@@ -16,7 +16,7 @@ partial class SplitterStandard : global::Gum.Forms.Controls.Splitter
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/SplitterStandard");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/SplitterStandard - did you forget to load a Gum project?");
@@ -47,7 +47,7 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     protected override void ReactToVisualChanged()
     {
         base.ReactToVisualChanged();
-        NineSliceInstance = this.Visual?.GetGraphicalUiElementByName("NineSliceInstance") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
+        NineSliceInstance = this.Visual?.GetGraphicalUiElementByName("NineSliceInstance") as global::Gum.GueDeriving.NineSliceRuntime;
         CustomInitialize();
     }
     //Not assigning variables because Object Instantiation Type is set to By Name rather than Fully In Code

--- a/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/StackPanel.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/StackPanel.Generated.cs
@@ -1,11 +1,11 @@
 //Code for Controls/StackPanel (Container)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGameForms_Localization_ByReference.Components.Controls;
@@ -16,7 +16,7 @@ partial class StackPanel : global::Gum.Forms.Controls.StackPanel
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/StackPanel");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/StackPanel - did you forget to load a Gum project?");

--- a/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/TextBox.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/TextBox.Generated.cs
@@ -1,12 +1,12 @@
 //Code for Controls/TextBox (Container)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.StateAnimation.Runtime;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGameForms_Localization_ByReference.Components.Controls;
@@ -17,7 +17,7 @@ partial class TextBox : global::Gum.Forms.Controls.TextBox
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/TextBox");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/TextBox - did you forget to load a Gum project?");
@@ -104,29 +104,9 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     public NineSliceRuntime FocusedIndicator { get; protected set; }
     public SpriteRuntime CaretInstance { get; protected set; }
 
-    public string Placeholder
-    {
-        get => PlaceholderTextInstance.Text;
-        set => PlaceholderTextInstance.Text = value;
-    }
 
-    public int? MaxLettersToShow
-    {
-        get => TextInstance.MaxLettersToShow;
-        set => TextInstance.MaxLettersToShow = value;
-    }
 
-    public int? MaxNumberOfLines
-    {
-        get => TextInstance.MaxNumberOfLines;
-        set => TextInstance.MaxNumberOfLines = value;
-    }
 
-    public string Text
-    {
-        get => TextInstance.Text;
-        set => TextInstance.Text = value;
-    }
 
     public TextBox(InteractiveGue visual) : base(visual)
     {
@@ -140,13 +120,13 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     protected override void ReactToVisualChanged()
     {
         base.ReactToVisualChanged();
-        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
-        ClipContainer = this.Visual?.GetGraphicalUiElementByName("ClipContainer") as global::MonoGameGum.GueDeriving.ContainerRuntime;
-        SelectionInstance = this.Visual?.GetGraphicalUiElementByName("SelectionInstance") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
-        TextInstance = this.Visual?.GetGraphicalUiElementByName("TextInstance") as global::MonoGameGum.GueDeriving.TextRuntime;
-        PlaceholderTextInstance = this.Visual?.GetGraphicalUiElementByName("PlaceholderTextInstance") as global::MonoGameGum.GueDeriving.TextRuntime;
-        FocusedIndicator = this.Visual?.GetGraphicalUiElementByName("FocusedIndicator") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
-        CaretInstance = this.Visual?.GetGraphicalUiElementByName("CaretInstance") as global::MonoGameGum.GueDeriving.SpriteRuntime;
+        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::Gum.GueDeriving.NineSliceRuntime;
+        ClipContainer = this.Visual?.GetGraphicalUiElementByName("ClipContainer") as global::Gum.GueDeriving.ContainerRuntime;
+        SelectionInstance = this.Visual?.GetGraphicalUiElementByName("SelectionInstance") as global::Gum.GueDeriving.NineSliceRuntime;
+        TextInstance = this.Visual?.GetGraphicalUiElementByName("TextInstance") as global::Gum.GueDeriving.TextRuntime;
+        PlaceholderTextInstance = this.Visual?.GetGraphicalUiElementByName("PlaceholderTextInstance") as global::Gum.GueDeriving.TextRuntime;
+        FocusedIndicator = this.Visual?.GetGraphicalUiElementByName("FocusedIndicator") as global::Gum.GueDeriving.NineSliceRuntime;
+        CaretInstance = this.Visual?.GetGraphicalUiElementByName("CaretInstance") as global::Gum.GueDeriving.SpriteRuntime;
         CustomInitialize();
     }
     //Not assigning variables because Object Instantiation Type is set to By Name rather than Fully In Code

--- a/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/Toast.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/Toast.Generated.cs
@@ -1,11 +1,11 @@
 //Code for Controls/Toast (Container)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGameForms_Localization_ByReference.Components.Controls;
@@ -16,7 +16,7 @@ partial class Toast : global::Gum.Forms.Controls.FrameworkElement
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/Toast");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/Toast - did you forget to load a Gum project?");
@@ -47,8 +47,8 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     protected override void ReactToVisualChanged()
     {
         base.ReactToVisualChanged();
-        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
-        TextInstance = this.Visual?.GetGraphicalUiElementByName("TextInstance") as global::MonoGameGum.GueDeriving.TextRuntime;
+        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::Gum.GueDeriving.NineSliceRuntime;
+        TextInstance = this.Visual?.GetGraphicalUiElementByName("TextInstance") as global::Gum.GueDeriving.TextRuntime;
         CustomInitialize();
     }
     //Not assigning variables because Object Instantiation Type is set to By Name rather than Fully In Code

--- a/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/TreeView.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/TreeView.Generated.cs
@@ -2,11 +2,11 @@
 using CodeGen_MonoGameForms_Localization_ByReference.Components.Controls;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGameForms_Localization_ByReference.Components.Controls;
@@ -17,7 +17,7 @@ partial class TreeView : global::Gum.Forms.Controls.FrameworkElement
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/TreeView");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/TreeView - did you forget to load a Gum project?");
@@ -51,11 +51,11 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     protected override void ReactToVisualChanged()
     {
         base.ReactToVisualChanged();
-        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
+        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::Gum.GueDeriving.NineSliceRuntime;
         VerticalScrollBarInstance = global::Gum.Forms.GraphicalUiElementFormsExtensions.TryGetFrameworkElementByName<ScrollBar>(this.Visual,"VerticalScrollBarInstance");
-        ClipContainerInstance = this.Visual?.GetGraphicalUiElementByName("ClipContainerInstance") as global::MonoGameGum.GueDeriving.ContainerRuntime;
-        InnerPanelInstance = this.Visual?.GetGraphicalUiElementByName("InnerPanelInstance") as global::MonoGameGum.GueDeriving.ContainerRuntime;
-        FocusedIndicator = this.Visual?.GetGraphicalUiElementByName("FocusedIndicator") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
+        ClipContainerInstance = this.Visual?.GetGraphicalUiElementByName("ClipContainerInstance") as global::Gum.GueDeriving.ContainerRuntime;
+        InnerPanelInstance = this.Visual?.GetGraphicalUiElementByName("InnerPanelInstance") as global::Gum.GueDeriving.ContainerRuntime;
+        FocusedIndicator = this.Visual?.GetGraphicalUiElementByName("FocusedIndicator") as global::Gum.GueDeriving.NineSliceRuntime;
         CustomInitialize();
     }
     //Not assigning variables because Object Instantiation Type is set to By Name rather than Fully In Code

--- a/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/TreeViewItem.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/TreeViewItem.Generated.cs
@@ -2,11 +2,11 @@
 using CodeGen_MonoGameForms_Localization_ByReference.Components.Controls;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGameForms_Localization_ByReference.Components.Controls;
@@ -17,7 +17,7 @@ partial class TreeViewItem : global::Gum.Forms.Controls.FrameworkElement
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/TreeViewItem");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/TreeViewItem - did you forget to load a Gum project?");
@@ -51,7 +51,7 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
         base.ReactToVisualChanged();
         ToggleButtonInstance = global::Gum.Forms.GraphicalUiElementFormsExtensions.TryGetFrameworkElementByName<TreeViewToggle>(this.Visual,"ToggleButtonInstance");
         ListBoxItemInstance = global::Gum.Forms.GraphicalUiElementFormsExtensions.TryGetFrameworkElementByName<ListBoxItem>(this.Visual,"ListBoxItemInstance");
-        InnerPanelInstance = this.Visual?.GetGraphicalUiElementByName("InnerPanelInstance") as global::MonoGameGum.GueDeriving.ContainerRuntime;
+        InnerPanelInstance = this.Visual?.GetGraphicalUiElementByName("InnerPanelInstance") as global::Gum.GueDeriving.ContainerRuntime;
         CustomInitialize();
     }
     //Not assigning variables because Object Instantiation Type is set to By Name rather than Fully In Code

--- a/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/TreeViewToggle.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/TreeViewToggle.Generated.cs
@@ -2,12 +2,12 @@
 using CodeGen_MonoGameForms_Localization_ByReference.Components.Elements;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.StateAnimation.Runtime;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGameForms_Localization_ByReference.Components.Controls;
@@ -18,7 +18,7 @@ partial class TreeViewToggle : global::Gum.Forms.Controls.FrameworkElement
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/TreeViewToggle");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/TreeViewToggle - did you forget to load a Gum project?");
@@ -85,7 +85,7 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     protected override void ReactToVisualChanged()
     {
         base.ReactToVisualChanged();
-        NineSliceInstance = this.Visual?.GetGraphicalUiElementByName("NineSliceInstance") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
+        NineSliceInstance = this.Visual?.GetGraphicalUiElementByName("NineSliceInstance") as global::Gum.GueDeriving.NineSliceRuntime;
         IconInstance = global::Gum.Forms.GraphicalUiElementFormsExtensions.TryGetFrameworkElementByName<Icon>(this.Visual,"IconInstance");
         CustomInitialize();
     }

--- a/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/UserControl.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/UserControl.Generated.cs
@@ -1,11 +1,11 @@
 //Code for Controls/UserControl (Container)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGameForms_Localization_ByReference.Components.Controls;
@@ -16,7 +16,7 @@ partial class UserControl : global::Gum.Forms.Controls.FrameworkElement
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/UserControl");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/UserControl - did you forget to load a Gum project?");
@@ -46,7 +46,7 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     protected override void ReactToVisualChanged()
     {
         base.ReactToVisualChanged();
-        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
+        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::Gum.GueDeriving.NineSliceRuntime;
         CustomInitialize();
     }
     //Not assigning variables because Object Instantiation Type is set to By Name rather than Fully In Code

--- a/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/Window.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/Window.Generated.cs
@@ -2,12 +2,12 @@
 using CodeGen_MonoGameForms_Localization_ByReference.Components.Controls;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.StateAnimation.Runtime;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGameForms_Localization_ByReference.Components.Controls;
@@ -18,7 +18,7 @@ partial class Window : global::Gum.Forms.Window
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Controls/Window");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/Window - did you forget to load a Gum project?");
@@ -58,7 +58,7 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     protected override void ReactToVisualChanged()
     {
         base.ReactToVisualChanged();
-        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
+        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::Gum.GueDeriving.NineSliceRuntime;
         InnerPanelInstance = global::Gum.Forms.GraphicalUiElementFormsExtensions.TryGetFrameworkElementByName<Panel>(this.Visual,"InnerPanelInstance");
         TitleBarInstance = global::Gum.Forms.GraphicalUiElementFormsExtensions.TryGetFrameworkElementByName<Panel>(this.Visual,"TitleBarInstance");
         BorderTopLeftInstance = global::Gum.Forms.GraphicalUiElementFormsExtensions.TryGetFrameworkElementByName<Panel>(this.Visual,"BorderTopLeftInstance");

--- a/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Elements/CautionLines.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Elements/CautionLines.Generated.cs
@@ -1,11 +1,11 @@
 //Code for Elements/CautionLines (Container)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGameForms_Localization_ByReference.Components.Elements;
@@ -16,7 +16,7 @@ partial class CautionLines : global::Gum.Forms.Controls.FrameworkElement
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Elements/CautionLines");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Elements/CautionLines - did you forget to load a Gum project?");
@@ -53,7 +53,7 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     protected override void ReactToVisualChanged()
     {
         base.ReactToVisualChanged();
-        LinesSprite = this.Visual?.GetGraphicalUiElementByName("LinesSprite") as global::MonoGameGum.GueDeriving.SpriteRuntime;
+        LinesSprite = this.Visual?.GetGraphicalUiElementByName("LinesSprite") as global::Gum.GueDeriving.SpriteRuntime;
         CustomInitialize();
     }
     //Not assigning variables because Object Instantiation Type is set to By Name rather than Fully In Code

--- a/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Elements/Divider.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Elements/Divider.Generated.cs
@@ -1,11 +1,11 @@
 //Code for Elements/Divider (Container)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGameForms_Localization_ByReference.Components.Elements;
@@ -16,7 +16,7 @@ partial class Divider : global::Gum.Forms.Controls.FrameworkElement
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Elements/Divider");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Elements/Divider - did you forget to load a Gum project?");
@@ -48,9 +48,9 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     protected override void ReactToVisualChanged()
     {
         base.ReactToVisualChanged();
-        AccentLeft = this.Visual?.GetGraphicalUiElementByName("AccentLeft") as global::MonoGameGum.GueDeriving.SpriteRuntime;
-        Line = this.Visual?.GetGraphicalUiElementByName("Line") as global::MonoGameGum.GueDeriving.SpriteRuntime;
-        AccentRight = this.Visual?.GetGraphicalUiElementByName("AccentRight") as global::MonoGameGum.GueDeriving.SpriteRuntime;
+        AccentLeft = this.Visual?.GetGraphicalUiElementByName("AccentLeft") as global::Gum.GueDeriving.SpriteRuntime;
+        Line = this.Visual?.GetGraphicalUiElementByName("Line") as global::Gum.GueDeriving.SpriteRuntime;
+        AccentRight = this.Visual?.GetGraphicalUiElementByName("AccentRight") as global::Gum.GueDeriving.SpriteRuntime;
         CustomInitialize();
     }
     //Not assigning variables because Object Instantiation Type is set to By Name rather than Fully In Code

--- a/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Elements/DividerHorizontal.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Elements/DividerHorizontal.Generated.cs
@@ -1,12 +1,12 @@
 //Code for Elements/DividerHorizontal (Container)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.StateAnimation.Runtime;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGameForms_Localization_ByReference.Components.Elements;
@@ -17,7 +17,7 @@ partial class DividerHorizontal : global::Gum.Forms.Controls.FrameworkElement
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Elements/DividerHorizontal");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Elements/DividerHorizontal - did you forget to load a Gum project?");
@@ -49,9 +49,9 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     protected override void ReactToVisualChanged()
     {
         base.ReactToVisualChanged();
-        AccentLeft = this.Visual?.GetGraphicalUiElementByName("AccentLeft") as global::MonoGameGum.GueDeriving.SpriteRuntime;
-        Line = this.Visual?.GetGraphicalUiElementByName("Line") as global::MonoGameGum.GueDeriving.SpriteRuntime;
-        AccentRight = this.Visual?.GetGraphicalUiElementByName("AccentRight") as global::MonoGameGum.GueDeriving.SpriteRuntime;
+        AccentLeft = this.Visual?.GetGraphicalUiElementByName("AccentLeft") as global::Gum.GueDeriving.SpriteRuntime;
+        Line = this.Visual?.GetGraphicalUiElementByName("Line") as global::Gum.GueDeriving.SpriteRuntime;
+        AccentRight = this.Visual?.GetGraphicalUiElementByName("AccentRight") as global::Gum.GueDeriving.SpriteRuntime;
         CustomInitialize();
     }
     //Not assigning variables because Object Instantiation Type is set to By Name rather than Fully In Code

--- a/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Elements/DividerVertical.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Elements/DividerVertical.Generated.cs
@@ -1,12 +1,12 @@
 //Code for Elements/DividerVertical (Container)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.StateAnimation.Runtime;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGameForms_Localization_ByReference.Components.Elements;
@@ -17,7 +17,7 @@ partial class DividerVertical : global::Gum.Forms.Controls.FrameworkElement
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Elements/DividerVertical");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Elements/DividerVertical - did you forget to load a Gum project?");
@@ -49,9 +49,9 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     protected override void ReactToVisualChanged()
     {
         base.ReactToVisualChanged();
-        AccentTop = this.Visual?.GetGraphicalUiElementByName("AccentTop") as global::MonoGameGum.GueDeriving.SpriteRuntime;
-        Line = this.Visual?.GetGraphicalUiElementByName("Line") as global::MonoGameGum.GueDeriving.SpriteRuntime;
-        AccentRight = this.Visual?.GetGraphicalUiElementByName("AccentRight") as global::MonoGameGum.GueDeriving.SpriteRuntime;
+        AccentTop = this.Visual?.GetGraphicalUiElementByName("AccentTop") as global::Gum.GueDeriving.SpriteRuntime;
+        Line = this.Visual?.GetGraphicalUiElementByName("Line") as global::Gum.GueDeriving.SpriteRuntime;
+        AccentRight = this.Visual?.GetGraphicalUiElementByName("AccentRight") as global::Gum.GueDeriving.SpriteRuntime;
         CustomInitialize();
     }
     //Not assigning variables because Object Instantiation Type is set to By Name rather than Fully In Code

--- a/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Elements/Icon.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Elements/Icon.Generated.cs
@@ -1,12 +1,12 @@
 //Code for Elements/Icon (Container)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.StateAnimation.Runtime;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGameForms_Localization_ByReference.Components.Elements;
@@ -17,7 +17,7 @@ partial class Icon : global::Gum.Forms.Controls.FrameworkElement
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Elements/Icon");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Elements/Icon - did you forget to load a Gum project?");
@@ -148,7 +148,7 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     protected override void ReactToVisualChanged()
     {
         base.ReactToVisualChanged();
-        IconSprite = this.Visual?.GetGraphicalUiElementByName("IconSprite") as global::MonoGameGum.GueDeriving.SpriteRuntime;
+        IconSprite = this.Visual?.GetGraphicalUiElementByName("IconSprite") as global::Gum.GueDeriving.SpriteRuntime;
         CustomInitialize();
     }
     //Not assigning variables because Object Instantiation Type is set to By Name rather than Fully In Code

--- a/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Elements/PercentBar.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Elements/PercentBar.Generated.cs
@@ -2,11 +2,11 @@
 using CodeGen_MonoGameForms_Localization_ByReference.Components.Elements;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGameForms_Localization_ByReference.Components.Elements;
@@ -17,7 +17,7 @@ partial class PercentBar : global::Gum.Forms.Controls.FrameworkElement
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Elements/PercentBar");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Elements/PercentBar - did you forget to load a Gum project?");
@@ -89,9 +89,9 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     protected override void ReactToVisualChanged()
     {
         base.ReactToVisualChanged();
-        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
-        BarContainer = this.Visual?.GetGraphicalUiElementByName("BarContainer") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
-        Bar = this.Visual?.GetGraphicalUiElementByName("Bar") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
+        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::Gum.GueDeriving.NineSliceRuntime;
+        BarContainer = this.Visual?.GetGraphicalUiElementByName("BarContainer") as global::Gum.GueDeriving.NineSliceRuntime;
+        Bar = this.Visual?.GetGraphicalUiElementByName("Bar") as global::Gum.GueDeriving.NineSliceRuntime;
         CautionLinesInstance = global::Gum.Forms.GraphicalUiElementFormsExtensions.TryGetFrameworkElementByName<CautionLines>(this.Visual,"CautionLinesInstance");
         VerticalLinesInstance = global::Gum.Forms.GraphicalUiElementFormsExtensions.TryGetFrameworkElementByName<VerticalLines>(this.Visual,"VerticalLinesInstance");
         CustomInitialize();

--- a/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Elements/PercentBarIcon.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Elements/PercentBarIcon.Generated.cs
@@ -2,11 +2,11 @@
 using CodeGen_MonoGameForms_Localization_ByReference.Components.Elements;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGameForms_Localization_ByReference.Components.Elements;
@@ -17,7 +17,7 @@ partial class PercentBarIcon : global::Gum.Forms.Controls.FrameworkElement
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Elements/PercentBarIcon");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Elements/PercentBarIcon - did you forget to load a Gum project?");
@@ -97,10 +97,10 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     protected override void ReactToVisualChanged()
     {
         base.ReactToVisualChanged();
-        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
+        Background = this.Visual?.GetGraphicalUiElementByName("Background") as global::Gum.GueDeriving.NineSliceRuntime;
         IconInstance = global::Gum.Forms.GraphicalUiElementFormsExtensions.TryGetFrameworkElementByName<Icon>(this.Visual,"IconInstance");
-        BarContainer = this.Visual?.GetGraphicalUiElementByName("BarContainer") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
-        Bar = this.Visual?.GetGraphicalUiElementByName("Bar") as global::MonoGameGum.GueDeriving.NineSliceRuntime;
+        BarContainer = this.Visual?.GetGraphicalUiElementByName("BarContainer") as global::Gum.GueDeriving.NineSliceRuntime;
+        Bar = this.Visual?.GetGraphicalUiElementByName("Bar") as global::Gum.GueDeriving.NineSliceRuntime;
         CautionLinesInstance = global::Gum.Forms.GraphicalUiElementFormsExtensions.TryGetFrameworkElementByName<CautionLines>(this.Visual,"CautionLinesInstance");
         VerticalLinesInstance = global::Gum.Forms.GraphicalUiElementFormsExtensions.TryGetFrameworkElementByName<VerticalLines>(this.Visual,"VerticalLinesInstance");
         CustomInitialize();

--- a/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Elements/VerticalLines.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Elements/VerticalLines.Generated.cs
@@ -1,11 +1,11 @@
 //Code for Elements/VerticalLines (Container)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGameForms_Localization_ByReference.Components.Elements;
@@ -16,7 +16,7 @@ partial class VerticalLines : global::Gum.Forms.Controls.FrameworkElement
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Elements/VerticalLines");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Elements/VerticalLines - did you forget to load a Gum project?");
@@ -53,7 +53,7 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     protected override void ReactToVisualChanged()
     {
         base.ReactToVisualChanged();
-        LinesSprite = this.Visual?.GetGraphicalUiElementByName("LinesSprite") as global::MonoGameGum.GueDeriving.SpriteRuntime;
+        LinesSprite = this.Visual?.GetGraphicalUiElementByName("LinesSprite") as global::Gum.GueDeriving.SpriteRuntime;
         CustomInitialize();
     }
     //Not assigning variables because Object Instantiation Type is set to By Name rather than Fully In Code

--- a/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Styles.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Styles.Generated.cs
@@ -1,11 +1,11 @@
 //Code for Styles (Container)
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGameForms_Localization_ByReference.Components;
@@ -16,7 +16,7 @@ partial class Styles : global::Gum.Forms.Controls.FrameworkElement
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("Styles");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named Styles - did you forget to load a Gum project?");
@@ -68,29 +68,29 @@ if(element == null) throw new System.InvalidOperationException("Could not find a
     protected override void ReactToVisualChanged()
     {
         base.ReactToVisualChanged();
-        Colors = this.Visual?.GetGraphicalUiElementByName("Colors") as global::MonoGameGum.GueDeriving.ContainerRuntime;
-        Black = this.Visual?.GetGraphicalUiElementByName("Black") as global::MonoGameGum.GueDeriving.ColoredRectangleRuntime;
-        DarkGray = this.Visual?.GetGraphicalUiElementByName("DarkGray") as global::MonoGameGum.GueDeriving.ColoredRectangleRuntime;
-        Gray = this.Visual?.GetGraphicalUiElementByName("Gray") as global::MonoGameGum.GueDeriving.ColoredRectangleRuntime;
-        LightGray = this.Visual?.GetGraphicalUiElementByName("LightGray") as global::MonoGameGum.GueDeriving.ColoredRectangleRuntime;
-        White = this.Visual?.GetGraphicalUiElementByName("White") as global::MonoGameGum.GueDeriving.ColoredRectangleRuntime;
-        PrimaryDark = this.Visual?.GetGraphicalUiElementByName("PrimaryDark") as global::MonoGameGum.GueDeriving.ColoredRectangleRuntime;
-        Primary = this.Visual?.GetGraphicalUiElementByName("Primary") as global::MonoGameGum.GueDeriving.ColoredRectangleRuntime;
-        PrimaryLight = this.Visual?.GetGraphicalUiElementByName("PrimaryLight") as global::MonoGameGum.GueDeriving.ColoredRectangleRuntime;
-        Success = this.Visual?.GetGraphicalUiElementByName("Success") as global::MonoGameGum.GueDeriving.ColoredRectangleRuntime;
-        Warning = this.Visual?.GetGraphicalUiElementByName("Warning") as global::MonoGameGum.GueDeriving.ColoredRectangleRuntime;
-        Danger = this.Visual?.GetGraphicalUiElementByName("Danger") as global::MonoGameGum.GueDeriving.ColoredRectangleRuntime;
-        Accent = this.Visual?.GetGraphicalUiElementByName("Accent") as global::MonoGameGum.GueDeriving.ColoredRectangleRuntime;
-        Tiny = this.Visual?.GetGraphicalUiElementByName("Tiny") as global::MonoGameGum.GueDeriving.TextRuntime;
-        Small = this.Visual?.GetGraphicalUiElementByName("Small") as global::MonoGameGum.GueDeriving.TextRuntime;
-        Normal = this.Visual?.GetGraphicalUiElementByName("Normal") as global::MonoGameGum.GueDeriving.TextRuntime;
-        Emphasis = this.Visual?.GetGraphicalUiElementByName("Emphasis") as global::MonoGameGum.GueDeriving.TextRuntime;
-        Strong = this.Visual?.GetGraphicalUiElementByName("Strong") as global::MonoGameGum.GueDeriving.TextRuntime;
-        H3 = this.Visual?.GetGraphicalUiElementByName("H3") as global::MonoGameGum.GueDeriving.TextRuntime;
-        H2 = this.Visual?.GetGraphicalUiElementByName("H2") as global::MonoGameGum.GueDeriving.TextRuntime;
-        H1 = this.Visual?.GetGraphicalUiElementByName("H1") as global::MonoGameGum.GueDeriving.TextRuntime;
-        TextStyles = this.Visual?.GetGraphicalUiElementByName("TextStyles") as global::MonoGameGum.GueDeriving.ContainerRuntime;
-        Title = this.Visual?.GetGraphicalUiElementByName("Title") as global::MonoGameGum.GueDeriving.TextRuntime;
+        Colors = this.Visual?.GetGraphicalUiElementByName("Colors") as global::Gum.GueDeriving.ContainerRuntime;
+        Black = this.Visual?.GetGraphicalUiElementByName("Black") as global::Gum.GueDeriving.ColoredRectangleRuntime;
+        DarkGray = this.Visual?.GetGraphicalUiElementByName("DarkGray") as global::Gum.GueDeriving.ColoredRectangleRuntime;
+        Gray = this.Visual?.GetGraphicalUiElementByName("Gray") as global::Gum.GueDeriving.ColoredRectangleRuntime;
+        LightGray = this.Visual?.GetGraphicalUiElementByName("LightGray") as global::Gum.GueDeriving.ColoredRectangleRuntime;
+        White = this.Visual?.GetGraphicalUiElementByName("White") as global::Gum.GueDeriving.ColoredRectangleRuntime;
+        PrimaryDark = this.Visual?.GetGraphicalUiElementByName("PrimaryDark") as global::Gum.GueDeriving.ColoredRectangleRuntime;
+        Primary = this.Visual?.GetGraphicalUiElementByName("Primary") as global::Gum.GueDeriving.ColoredRectangleRuntime;
+        PrimaryLight = this.Visual?.GetGraphicalUiElementByName("PrimaryLight") as global::Gum.GueDeriving.ColoredRectangleRuntime;
+        Success = this.Visual?.GetGraphicalUiElementByName("Success") as global::Gum.GueDeriving.ColoredRectangleRuntime;
+        Warning = this.Visual?.GetGraphicalUiElementByName("Warning") as global::Gum.GueDeriving.ColoredRectangleRuntime;
+        Danger = this.Visual?.GetGraphicalUiElementByName("Danger") as global::Gum.GueDeriving.ColoredRectangleRuntime;
+        Accent = this.Visual?.GetGraphicalUiElementByName("Accent") as global::Gum.GueDeriving.ColoredRectangleRuntime;
+        Tiny = this.Visual?.GetGraphicalUiElementByName("Tiny") as global::Gum.GueDeriving.TextRuntime;
+        Small = this.Visual?.GetGraphicalUiElementByName("Small") as global::Gum.GueDeriving.TextRuntime;
+        Normal = this.Visual?.GetGraphicalUiElementByName("Normal") as global::Gum.GueDeriving.TextRuntime;
+        Emphasis = this.Visual?.GetGraphicalUiElementByName("Emphasis") as global::Gum.GueDeriving.TextRuntime;
+        Strong = this.Visual?.GetGraphicalUiElementByName("Strong") as global::Gum.GueDeriving.TextRuntime;
+        H3 = this.Visual?.GetGraphicalUiElementByName("H3") as global::Gum.GueDeriving.TextRuntime;
+        H2 = this.Visual?.GetGraphicalUiElementByName("H2") as global::Gum.GueDeriving.TextRuntime;
+        H1 = this.Visual?.GetGraphicalUiElementByName("H1") as global::Gum.GueDeriving.TextRuntime;
+        TextStyles = this.Visual?.GetGraphicalUiElementByName("TextStyles") as global::Gum.GueDeriving.ContainerRuntime;
+        Title = this.Visual?.GetGraphicalUiElementByName("Title") as global::Gum.GueDeriving.TextRuntime;
         CustomInitialize();
     }
     //Not assigning variables because Object Instantiation Type is set to By Name rather than Fully In Code

--- a/Tests/CodeGen_MonoGameForms_Localization_ByReference/Content/GumProject/ProjectCodeSettings.codsj
+++ b/Tests/CodeGen_MonoGameForms_Localization_ByReference/Content/GumProject/ProjectCodeSettings.codsj
@@ -1,13 +1,15 @@
 {
   "CommonUsingStatements": "using Gum.Converters;\r\nusing Gum.DataTypes;\r\nusing Gum.Managers;\r\nusing Gum.Wireframe;\r\n\r\nusing RenderingLibrary.Graphics;\r\n\r\nusing System.Linq;\r\n",
-  "CodeProjectRoot": "C:\\Users\\vchel\\Documents\\GitHub\\Gum\\Tests\\CodeGen_MonoGameForms_Localization_ByReference\\",
+  "CodeProjectRoot": "..\\..\\",
   "RootNamespace": "CodeGen_MonoGameForms_Localization_ByReference",
   "AppendFolderToNamespace": true,
   "InheritanceLocation": 1,
   "ObjectInstantiationType": 1,
-  "DefaultScreenBase": "Gum.Wireframe.BindableGue",
+  "DefaultScreenBase": "",
   "OutputLibrary": 5,
   "AdjustPixelValuesForDensity": false,
   "BaseTypesNotCodeGenerated": "",
-  "GenerateGumDataTypes": false
+  "GenerateGumDataTypes": false,
+  "SyntaxVersion": "*",
+  "Version": 1
 }

--- a/Tests/CodeGen_MonoGameForms_Localization_ByReference/Screens/MainScreen.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_Localization_ByReference/Screens/MainScreen.Generated.cs
@@ -2,11 +2,11 @@
 using CodeGen_MonoGameForms_Localization_ByReference.Components.Controls;
 using Gum.Converters;
 using Gum.DataTypes;
+using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
 using MonoGameGum;
-using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System.Linq;
 namespace CodeGen_MonoGameForms_Localization_ByReference.Screens;
@@ -17,7 +17,7 @@ partial class MainScreen : global::Gum.Forms.Controls.FrameworkElement
     {
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
-            var visual = new global::MonoGameGum.GueDeriving.ContainerRuntime();
+            var visual = new global::Gum.GueDeriving.ContainerRuntime();
             var element = ObjectFinder.Self.GetElementSave("MainScreen");
 #if DEBUG
 if(element == null) throw new System.InvalidOperationException("Could not find an element named MainScreen - did you forget to load a Gum project?");

--- a/Tests/Gum.Cli.Tests/CodegenCommandTests.cs
+++ b/Tests/Gum.Cli.Tests/CodegenCommandTests.cs
@@ -100,6 +100,91 @@ public class CodegenCommandTests : IDisposable
         contents.ShouldNotContain("\"CodeProjectRoot\": \"\"");
     }
 
+    [Fact]
+    public void Codegen_PrintsResolvedCodeProjectRoot()
+    {
+        string gumxPath = Path.Combine(_tempDirectory, "MyProject.gumx");
+        new ProjectCreator().Create(gumxPath);
+        File.WriteAllText(Path.Combine(_tempDirectory, "ProjectCodeSettings.codsj"),
+            """
+            {
+              "CodeProjectRoot": "./",
+              "RootNamespace": "TestNamespace",
+              "OutputLibrary": 5,
+              "ObjectInstantiationType": 0,
+              "SyntaxVersion": "*"
+            }
+            """);
+
+        CliTestHelper result = CliTestHelper.Run("codegen", gumxPath);
+
+        // The resolved (absolute) output root must be visible so misconfigured
+        // CodeProjectRoot values (e.g. machine-specific absolute paths) are obvious.
+        result.StandardOutput.ShouldContain(_tempDirectory);
+    }
+
+    [Fact]
+    public void Codegen_WhenProjectHasLocalizationCsv_GeneratedCodeContainsApplyLocalization()
+    {
+        string gumxPath = Path.Combine(_tempDirectory, "MyProject.gumx");
+        new ProjectCreator().Create(gumxPath);
+
+        string screenXml =
+            """
+            <?xml version="1.0" encoding="utf-8"?>
+            <ScreenSave xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+              <Name>TestScreen</Name>
+              <State>
+                <Name>Default</Name>
+                <Variable>
+                  <Type>string</Type>
+                  <Name>TextInstance.Text</Name>
+                  <Value xsi:type="xsd:string">T_OK</Value>
+                  <SetsValue>true</SetsValue>
+                </Variable>
+              </State>
+              <Instance>
+                <Name>TextInstance</Name>
+                <BaseType>Text</BaseType>
+                <DefinedByBase>false</DefinedByBase>
+              </Instance>
+            </ScreenSave>
+            """;
+        File.WriteAllText(Path.Combine(_tempDirectory, "Screens", "TestScreen.gusx"), screenXml);
+
+        File.WriteAllText(Path.Combine(_tempDirectory, "LocalizationDB.csv"),
+            "String ID,English,Spanish\nT_OK,OK,De acuerdo\n");
+
+        string gumxContent = File.ReadAllText(gumxPath);
+        gumxContent = gumxContent.Replace("</GumProjectSave>",
+            "  <ScreenReference Name=\"TestScreen\" />\n" +
+            "  <LocalizationFile>LocalizationDB.csv</LocalizationFile>\n" +
+            "</GumProjectSave>");
+        File.WriteAllText(gumxPath, gumxContent);
+
+        File.WriteAllText(Path.Combine(_tempDirectory, "ProjectCodeSettings.codsj"),
+            """
+            {
+              "CodeProjectRoot": "./",
+              "RootNamespace": "TestNamespace",
+              "OutputLibrary": 5,
+              "ObjectInstantiationType": 0,
+              "SyntaxVersion": "*"
+            }
+            """);
+
+        CliTestHelper result = CliTestHelper.Run("codegen", gumxPath);
+
+        result.ExitCode.ShouldBe(0, customMessage: result.StandardError);
+        string generatedPath = Path.Combine(_tempDirectory, "Screens", "TestScreen.Generated.cs");
+        File.Exists(generatedPath).ShouldBeTrue(
+            customMessage: "codegen should have written the generated screen file");
+        string generatedContents = File.ReadAllText(generatedPath);
+        generatedContents.ShouldContain("public void ApplyLocalization()",
+            customMessage: "the project declares a localization CSV, so codegen must load it and emit ApplyLocalization");
+        generatedContents.ShouldContain("Translate(\"T_OK\")");
+    }
+
     public void Dispose()
     {
         if (Directory.Exists(_tempDirectory))

--- a/Tests/Gum.ProjectServices.Tests/HeadlessLocalizationLoaderTests.cs
+++ b/Tests/Gum.ProjectServices.Tests/HeadlessLocalizationLoaderTests.cs
@@ -1,0 +1,179 @@
+using Gum.DataTypes;
+using Gum.Localization;
+using Gum.ProjectServices.CodeGeneration;
+using Shouldly;
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace Gum.ProjectServices.Tests;
+
+public class HeadlessLocalizationLoaderTests : IDisposable
+{
+    private readonly HeadlessLocalizationLoader _sut;
+    private readonly TestLogger _logger;
+    private readonly LocalizationService _localizationService;
+    private readonly string _tempDirectory;
+
+    public HeadlessLocalizationLoaderTests()
+    {
+        _logger = new TestLogger();
+        _sut = new HeadlessLocalizationLoader(_logger);
+        _localizationService = new LocalizationService();
+        _tempDirectory = Path.Combine(Path.GetTempPath(), "GumHeadlessLocalizationTests_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDirectory);
+    }
+
+    [Fact]
+    public void LoadLocalizationFiles_MissingCsv_LogsErrorAndDoesNotLoad()
+    {
+        GumProjectSave project = CreateProjectWithFiles("DoesNotExist.csv");
+
+        _sut.LoadLocalizationFiles(project, _tempDirectory, _localizationService);
+
+        _localizationService.HasDatabase.ShouldBeFalse();
+        _logger.Errors.ShouldContain(error => error.Contains("DoesNotExist.csv"));
+    }
+
+    [Fact]
+    public void LoadLocalizationFiles_MixedCsvAndResx_LogsErrorAndDoesNotLoad()
+    {
+        WriteCsv("Strings.csv");
+        WriteResx("Strings.resx");
+        GumProjectSave project = CreateProjectWithFiles("Strings.csv", "Strings.resx");
+
+        _sut.LoadLocalizationFiles(project, _tempDirectory, _localizationService);
+
+        _localizationService.HasDatabase.ShouldBeFalse();
+        _logger.Errors.ShouldContain(error => error.Contains("not all are .resx"));
+    }
+
+    [Fact]
+    public void LoadLocalizationFiles_MultipleCsvs_LogsErrorAndDoesNotLoad()
+    {
+        WriteCsv("First.csv");
+        WriteCsv("Second.csv");
+        GumProjectSave project = CreateProjectWithFiles("First.csv", "Second.csv");
+
+        _sut.LoadLocalizationFiles(project, _tempDirectory, _localizationService);
+
+        _localizationService.HasDatabase.ShouldBeFalse();
+        _logger.Errors.ShouldContain(error => error.Contains("not all are .resx"));
+    }
+
+    [Fact]
+    public void LoadLocalizationFiles_MultipleResxFiles_LoadsAllKeys()
+    {
+        WriteResx("First.resx", ("T_First", "First"));
+        WriteResx("Second.resx", ("T_Second", "Second"));
+        GumProjectSave project = CreateProjectWithFiles("First.resx", "Second.resx");
+
+        _sut.LoadLocalizationFiles(project, _tempDirectory, _localizationService);
+
+        _localizationService.HasDatabase.ShouldBeTrue();
+        _localizationService.Keys.ShouldContain("T_First");
+        _localizationService.Keys.ShouldContain("T_Second");
+    }
+
+    [Fact]
+    public void LoadLocalizationFiles_NoFiles_DoesNothing()
+    {
+        GumProjectSave project = new GumProjectSave();
+
+        _sut.LoadLocalizationFiles(project, _tempDirectory, _localizationService);
+
+        _localizationService.HasDatabase.ShouldBeFalse();
+        _logger.Errors.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void LoadLocalizationFiles_SingleCsv_LoadsDatabase()
+    {
+        WriteCsv("LocalizationDB.csv");
+        GumProjectSave project = CreateProjectWithFiles("LocalizationDB.csv");
+
+        _sut.LoadLocalizationFiles(project, _tempDirectory, _localizationService);
+
+        _localizationService.HasDatabase.ShouldBeTrue();
+        _localizationService.Keys.ShouldContain("T_OK");
+        _localizationService.Languages.ShouldBe(new[] { "English", "Spanish" });
+    }
+
+    [Fact]
+    public void LoadLocalizationFiles_SingleCsv_SetsCurrentLanguageFromProject()
+    {
+        WriteCsv("LocalizationDB.csv");
+        GumProjectSave project = CreateProjectWithFiles("LocalizationDB.csv");
+        project.CurrentLanguageIndex = 1;
+
+        _sut.LoadLocalizationFiles(project, _tempDirectory, _localizationService);
+
+        _localizationService.CurrentLanguage.ShouldBe(1);
+    }
+
+    [Fact]
+    public void LoadLocalizationFiles_SingleResx_LoadsDatabase()
+    {
+        WriteResx("Strings.resx", ("T_Hello", "Hello"));
+        GumProjectSave project = CreateProjectWithFiles("Strings.resx");
+
+        _sut.LoadLocalizationFiles(project, _tempDirectory, _localizationService);
+
+        _localizationService.HasDatabase.ShouldBeTrue();
+        _localizationService.Keys.ShouldContain("T_Hello");
+    }
+
+    private GumProjectSave CreateProjectWithFiles(params string[] relativeFiles)
+    {
+        GumProjectSave project = new GumProjectSave();
+        foreach (string relativeFile in relativeFiles)
+        {
+            project.LocalizationFiles.Add(relativeFile);
+        }
+        return project;
+    }
+
+    private void WriteCsv(string relativeFile)
+    {
+        File.WriteAllText(Path.Combine(_tempDirectory, relativeFile),
+            "String ID,English,Spanish\nT_OK,OK,De acuerdo\n");
+    }
+
+    private void WriteResx(string relativeFile, params (string key, string value)[] entries)
+    {
+        if (entries.Length == 0)
+        {
+            entries = new[] { ("T_OK", "OK") };
+        }
+
+        string dataElements = "";
+        foreach ((string key, string value) in entries)
+        {
+            dataElements += $"  <data name=\"{key}\" xml:space=\"preserve\"><value>{value}</value></data>\n";
+        }
+
+        File.WriteAllText(Path.Combine(_tempDirectory, relativeFile),
+            "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<root>\n" + dataElements + "</root>");
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(_tempDirectory, recursive: true);
+        }
+        catch
+        {
+            // Best effort cleanup
+        }
+    }
+
+    private class TestLogger : ICodeGenLogger
+    {
+        public List<string> Outputs { get; } = new List<string>();
+        public List<string> Errors { get; } = new List<string>();
+
+        public void PrintOutput(string message) => Outputs.Add(message);
+        public void PrintError(string message) => Errors.Add(message);
+    }
+}

--- a/Tools/Gum.Cli/Commands/CodegenCommand.cs
+++ b/Tools/Gum.Cli/Commands/CodegenCommand.cs
@@ -100,11 +100,22 @@ public static class CodegenCommand
             Console.WriteLine($"Auto-configured code generation settings (CodeProjectRoot: {projectSettings.CodeProjectRoot}, Namespace: {projectSettings.RootNamespace}).");
         }
 
+        // Print the resolved (absolute) output root so misconfigured CodeProjectRoot
+        // values (e.g. machine-specific absolute paths) are obvious in the output.
+        string resolvedCodeProjectRoot = projectSettings.CodeProjectRoot!;
+        if (!Path.IsPathRooted(resolvedCodeProjectRoot))
+        {
+            resolvedCodeProjectRoot = Path.GetFullPath(Path.Combine(projectDirectory!, resolvedCodeProjectRoot));
+        }
+        Console.WriteLine($"Generating code into {resolvedCodeProjectRoot}");
+
         // Build the codegen pipeline
         INameVerifier nameVerifier = new HeadlessNameVerifier();
         var codeGenNameVerifier = new CodeGenerationNameVerifier(nameVerifier);
         var elementSettingsManager = new CodeOutputElementSettingsManager(projectDirectoryProvider);
         var localizationService = new Gum.Localization.LocalizationService();
+        IHeadlessLocalizationLoader localizationLoader = new HeadlessLocalizationLoader(logger);
+        localizationLoader.LoadLocalizationFiles(project, projectDirectory!, localizationService);
         var syntaxVersionDetectionService = new SyntaxVersionDetectionService(logger);
         var codeGenerator = new CodeGenerator(
             codeGenNameVerifier, localizationService, elementSettingsManager, projectDirectoryProvider,

--- a/Tools/Gum.ProjectServices/HeadlessLocalizationLoader.cs
+++ b/Tools/Gum.ProjectServices/HeadlessLocalizationLoader.cs
@@ -1,0 +1,125 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Gum.DataTypes;
+using Gum.Localization;
+using Gum.ProjectServices.CodeGeneration;
+
+namespace Gum.ProjectServices;
+
+/// <inheritdoc cref="IHeadlessLocalizationLoader"/>
+public class HeadlessLocalizationLoader : IHeadlessLocalizationLoader
+{
+    private readonly ICodeGenLogger _logger;
+
+    public HeadlessLocalizationLoader(ICodeGenLogger logger)
+    {
+        _logger = logger;
+    }
+
+    /// <inheritdoc/>
+    public void LoadLocalizationFiles(GumProjectSave project, string projectDirectory, ILocalizationService localizationService)
+    {
+        // Policy mirrors the tool's FileCommands.LoadLocalizationFile and the runtime's
+        // GumService auto-load:
+        //   0 paths  -> no-op
+        //   1 path   -> dispatch by extension (single-file overloads)
+        //   2+ paths -> require all .resx; call the multi-file RESX overload.
+        //               Mixed CSV+RESX or multi-CSV is rejected because the
+        //               LocalizationService has no merge API for them.
+        List<string>? projectFiles = project.LocalizationFiles;
+        if (projectFiles == null || projectFiles.Count == 0)
+        {
+            return;
+        }
+
+        List<string> resolvedPaths = new List<string>();
+        foreach (string relative in projectFiles)
+        {
+            if (!string.IsNullOrEmpty(relative))
+            {
+                resolvedPaths.Add(Path.Combine(projectDirectory, relative));
+            }
+        }
+
+        if (resolvedPaths.Count == 0)
+        {
+            return;
+        }
+
+        try
+        {
+            if (resolvedPaths.Count == 1)
+            {
+                string fileName = resolvedPaths[0];
+
+                if (!File.Exists(fileName))
+                {
+                    _logger.PrintError($"Localization: file not found, skipping: {fileName}");
+                }
+                else if (IsResx(fileName))
+                {
+                    localizationService.AddResxDatabase(fileName);
+                }
+                else
+                {
+                    using FileStream stream = File.OpenRead(fileName);
+                    localizationService.AddCsvDatabase(stream);
+                }
+            }
+            else
+            {
+                bool allResx = true;
+                foreach (string path in resolvedPaths)
+                {
+                    if (!IsResx(path))
+                    {
+                        allResx = false;
+                        break;
+                    }
+                }
+
+                if (!allResx)
+                {
+                    _logger.PrintError(
+                        "Localization: multiple files configured but not all are .resx. " +
+                        "Mixed CSV/RESX and multi-CSV loading are not supported. Loading was skipped.");
+                }
+                else
+                {
+                    List<string> existingPaths = new List<string>();
+                    foreach (string path in resolvedPaths)
+                    {
+                        if (File.Exists(path))
+                        {
+                            existingPaths.Add(path);
+                        }
+                        else
+                        {
+                            _logger.PrintError($"Localization: file not found, skipping: {path}");
+                        }
+                    }
+
+                    if (existingPaths.Count > 0)
+                    {
+                        localizationService.AddResxDatabase(
+                            existingPaths,
+                            onWarning: message => _logger.PrintOutput("Localization warning: " + message));
+                    }
+                }
+            }
+
+            localizationService.CurrentLanguage = project.CurrentLanguageIndex;
+        }
+        catch (Exception e)
+        {
+            string joined = string.Join(", ", resolvedPaths);
+            _logger.PrintError($"Error loading localization file(s) {joined}: {e.Message}");
+        }
+    }
+
+    private static bool IsResx(string fileName)
+    {
+        return string.Equals(Path.GetExtension(fileName), ".resx", StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/Tools/Gum.ProjectServices/IHeadlessLocalizationLoader.cs
+++ b/Tools/Gum.ProjectServices/IHeadlessLocalizationLoader.cs
@@ -1,0 +1,24 @@
+using Gum.DataTypes;
+using Gum.Localization;
+
+namespace Gum.ProjectServices;
+
+/// <summary>
+/// Loads a Gum project's localization files (CSV or RESX) into an
+/// <see cref="ILocalizationService"/> in headless contexts such as the CLI,
+/// mirroring the load policy used by the Gum tool and the game runtime.
+/// </summary>
+public interface IHeadlessLocalizationLoader
+{
+    /// <summary>
+    /// Loads the localization files referenced by <paramref name="project"/> into
+    /// <paramref name="localizationService"/>, and applies the project's current
+    /// language index. Missing or unsupported file combinations are reported through
+    /// the logger and skipped without throwing.
+    /// </summary>
+    /// <param name="project">The loaded Gum project whose LocalizationFiles should be loaded.</param>
+    /// <param name="projectDirectory">The directory containing the .gumx file. Localization
+    /// file paths in the project are relative to this directory.</param>
+    /// <param name="localizationService">The service to populate.</param>
+    void LoadLocalizationFiles(GumProjectSave project, string projectDirectory, ILocalizationService localizationService);
+}


### PR DESCRIPTION
Closes #3118

## Corrected diagnosis

The issue hypothesized that gumcli's `SyntaxVersionDetectionService` resolves version 0 for the Localization harness project. Investigation showed **detection was never broken** — running gumcli against this project resolves version 2 via the `MonoGameGum` ProjectReference and emits `Gum.GueDeriving` output, same as the tool.

The actual cause: `ProjectCodeSettings.codsj` carried a **machine-specific absolute `CodeProjectRoot`** (`C:\Users\vchel\Documents\GitHub\Gum\Tests\CodeGen_MonoGameForms_Localization_ByReference\`). GumCli therefore wrote its (correct, v2) regenerated output to that absolute path — not into the checkout being regenerated. From a worktree the regeneration appears to be a byte-identical no-op (the "gumcli emits v0" observation), while the v2 output lands in the primary checkout as mystery uncommitted changes (the tool-side changes that were discarded). On CI the path doesn't match the runner workspace either, so the #3115 drift check passed **vacuously** for this project, which is why these goldens alone never picked up the v1 namespace flip.

Fixing the path then exposed a second, real gumcli gap: `CodegenCommand` constructed an **empty `LocalizationService`**, so a CLI regeneration would silently strip every `ApplyLocalization()` method and `Translate("T_...")` assignment from the goldens — defeating the purpose of this harness, which exists to compile-verify localization codegen.

## Changes

- **`HeadlessLocalizationLoader` (+ interface) in `Gum.ProjectServices`** — loads a project's `LocalizationFiles` into an `ILocalizationService` and applies `CurrentLanguageIndex`. Policy mirrors the tool's `FileCommands.LoadLocalizationFile` and the runtime's `GumService` auto-load: 0 files → no-op; 1 CSV → `AddCsvDatabase`; 1+ RESX → multi-file `AddResxDatabase` with collision warnings routed to the logger; mixed CSV+RESX / multi-CSV → error + skip; missing files logged and skipped.
- **`CodegenCommand` wires the loader** before building the codegen pipeline, so `ApplyLocalization` generation (gated on `LocalizationService.HasDatabase`) matches the tool.
- **`CodegenCommand` prints the resolved absolute output root** (`Generating code into <path>`), so a misconfigured `CodeProjectRoot` is visible instead of silently writing elsewhere.
- **Localization harness `ProjectCodeSettings.codsj`**: `CodeProjectRoot` is now relative (`..\..\`) like the sibling harnesses, plus `"SyntaxVersion": "*"` and the migrated `DefaultScreenBase`/`Version` values (what `MigrateIfNeeded` produces in memory anyway).
- **Goldens regenerated** via `Tests/GenerateAllCodeGenProjects.bat` (48 generated files): the `MonoGameGum.GueDeriving` → `Gum.GueDeriving` flip, removal of the stale generated `Text` override (the same catch-up the sibling projects got in #3115), and `ApplyLocalization`/`Translate` emission fully retained. Regeneration is idempotent (second run produces no diff) and the harness project builds with no new warnings.

## Tests (TDD)

- `CodegenCommandTests.Codegen_WhenProjectHasLocalizationCsv_GeneratedCodeContainsApplyLocalization` — red against the old CLI (generated code lacked `ApplyLocalization`), green after wiring.
- `CodegenCommandTests.Codegen_PrintsResolvedCodeProjectRoot` — red before the log line, green after.
- `HeadlessLocalizationLoaderTests` (8 tests) — CSV/RESX/missing/mixed/multi policies and `CurrentLanguage` application.
- Full suites: Gum.Cli.Tests 52/52, Gum.ProjectServices.Tests 280 passed.

The issue suggested reproducing in `SyntaxVersionDetectionServiceTests` — not applicable since detection turned out to be correct; the failing tests live at the CLI and loader level instead.

## Follow-up candidates (not in this PR)

- The localization load policy now exists in three places (tool `FileCommands`, runtime `GumService`, and this loader). Collapsing the tool onto the shared loader would change its CSV parser (CsvLibrary → CsvHelper, different comment/duplicate handling), so it needs its own change.
- The drift check can still pass vacuously for any project whose `CodeProjectRoot` escapes the workspace; if that's a concern, CI could grep the regeneration log's new `Generating code into` lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
