### PR TITLE
#3126: Consolidate file copy dialog when drag+dropping multiple sprites

### DIFF
--- a/.claude/skills/gum-tool-dialogs/SKILL.md
+++ b/.claude/skills/gum-tool-dialogs/SKILL.md
@@ -52,6 +52,8 @@ Used by: delete confirmation only (`DeleteLogic.ShowDeleteDialog`).
 
 **Wrong system**: The most common mistake is modifying `DialogWindow.xaml` or `Dialog.cs` expecting it to affect the delete dialog. Always verify which system shows the dialog you're fixing.
 
+**File copy prompt**: The "copy or reference?" dialog shown when a SourceFile/Font path outside the project folder is assigned lives in `SetVariableLogic.AskIfShouldCopy` (`Gum/Plugins/InternalPlugins/VariableGrid/SetVariableLogic.cs`), triggered via `ReactIfChangedMemberIsSourceFile` — not in the drag-drop layer.
+
 **ScrollViewer behavior**: The `Dialog` template wraps content in a ScrollViewer. With `Auto` scrolling, child controls get infinite available height during WPF measure — so internal scroll viewers (like a TreeView) won't scroll. Set `Dialog.ScrollContent="False"` on views that need bounded height for internal scrolling.
 
 **Deferred binding**: `Dialog.OnContentChanged` binds attached properties at `DispatcherPriority.Loaded`, not immediately. Code that reads these values before the dispatch fires will see defaults.

--- a/Gum/Plugins/InternalPlugins/VariableGrid/ISetVariableLogic.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/ISetVariableLogic.cs
@@ -24,4 +24,11 @@ public interface ISetVariableLogic
 
     GeneralResponse PropertyValueChangedOnBehaviorInstance(string memberName, object? oldValue,
         BehaviorSave behavior, BehaviorInstanceSave instance);
+
+    /// <summary>
+    /// Sets a pre-made copy decision for the current batch of file drops. When non-null,
+    /// the "copy or reference?" dialog is suppressed and this value is used instead.
+    /// Pass null to clear the batch decision and restore per-file dialog prompts.
+    /// </summary>
+    void SetBatchFileCopyDecision(bool? shouldCopy);
 }

--- a/Gum/Plugins/InternalPlugins/VariableGrid/SetVariableLogic.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/SetVariableLogic.cs
@@ -91,6 +91,10 @@ public class SetVariableLogic : ISetVariableLogic
     private readonly IProjectState _projectState;
     private readonly IProjectManager _projectManager;
 
+    // When non-null, AskIfShouldCopy returns this value without showing a dialog.
+    // Used by OnWireframeDrop to consolidate the per-file copy prompt into one dialog.
+    private bool? _batchFileCopyDecision;
+
     public SetVariableLogic(ISelectedState selectedState,
         INameVerifier nameVerifier,
         IRenameLogic renameLogic,
@@ -861,8 +865,19 @@ public class SetVariableLogic : ISetVariableLogic
         return whyInvalid;
     }
 
+    /// <inheritdoc/>
+    public void SetBatchFileCopyDecision(bool? shouldCopy)
+    {
+        _batchFileCopyDecision = shouldCopy;
+    }
+
     private bool? AskIfShouldCopy(VariableSave variable, string value)
     {
+        if (_batchFileCopyDecision.HasValue)
+        {
+            return _batchFileCopyDecision.Value;
+        }
+
         bool? shouldCopy = false;
 
         // Ask the user what to do - make it relative?

--- a/Tool/EditorTabPlugin_XNA/MainEditorTabPlugin.cs
+++ b/Tool/EditorTabPlugin_XNA/MainEditorTabPlugin.cs
@@ -833,16 +833,32 @@ internal class MainEditorTabPlugin : PriorityPlugin, IRecipient<UiBaseFontSizeCh
 
         if (!handled)
         {
-            foreach (string file in files)
-            {
-                if (!_dragDropManager.IsValidExtensionForFileDrop(file))
-                    continue;
+            string[] validFiles = files
+                .Where(f => _dragDropManager.IsValidExtensionForFileDrop(f))
+                .ToArray();
 
-                string fileName = FileManager.MakeRelative(file, _fileLocations.ProjectFolder);
-                AddNewInstanceForDrop(fileName, worldX, worldY);
-                shouldUpdate = true;
+            List<string> outsideProjectFiles = validFiles
+                .Where(f => !FileManager.IsRelativeTo(f, _fileLocations.ProjectFolder))
+                .ToList();
+
+            bool cancelDrop = false;
+
+            if (outsideProjectFiles.Count >= 2)
+            {
+                cancelDrop = !HandleBatchFilesOutsideProject(outsideProjectFiles, ref validFiles);
             }
 
+            if (!cancelDrop)
+            {
+                foreach (string file in validFiles)
+                {
+                    string fileName = FileManager.MakeRelative(file, _fileLocations.ProjectFolder);
+                    AddNewInstanceForDrop(fileName, worldX, worldY);
+                    shouldUpdate = true;
+                }
+
+                _setVariableLogic.SetBatchFileCopyDecision(shouldCopy: null);
+            }
         }
         if (shouldUpdate)
         {
@@ -851,6 +867,61 @@ internal class MainEditorTabPlugin : PriorityPlugin, IRecipient<UiBaseFontSizeCh
 
             _wireframeObjectManager.RefreshAll(true);
         }
+    }
+
+    /// <summary>
+    /// Shows a single consolidated dialog for all files that are outside the project folder,
+    /// then either pre-copies them into the project folder (updating <paramref name="validFiles"/>)
+    /// or sets the batch copy decision so SetVariableLogic suppresses per-file dialogs.
+    /// </summary>
+    /// <returns>false if the user cancelled and the drop should be aborted; true otherwise.</returns>
+    private bool HandleBatchFilesOutsideProject(List<string> outsideProjectFiles, ref string[] validFiles)
+    {
+        string fileList = string.Join("\n", outsideProjectFiles.Select(System.IO.Path.GetFileName));
+        string message = $"The following {outsideProjectFiles.Count} files are outside the project folder:\n\n{fileList}\n\nWhat would you like to do?";
+
+        DialogChoices<string> choices = new()
+        {
+            ["reference-current"] = "Reference all files in their current locations",
+            ["copy-relative"] = "Copy all files to the Gum project folder and reference the copies"
+        };
+
+        string? result = _dialogService.ShowChoices(message, choices, canCancel: true);
+
+        if (result == null)
+        {
+            return false;
+        }
+
+        if (result == "copy-relative")
+        {
+            List<string> updatedFiles = validFiles.ToList();
+            foreach (string file in outsideProjectFiles)
+            {
+                string destPath = System.IO.Path.Combine(_fileLocations.ProjectFolder, System.IO.Path.GetFileName(file));
+                try
+                {
+                    System.IO.File.Copy(file, destPath, overwrite: true);
+                    int idx = updatedFiles.IndexOf(file);
+                    if (idx >= 0)
+                    {
+                        updatedFiles[idx] = destPath;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _dialogService.ShowMessage($"Error copying {System.IO.Path.GetFileName(file)}:\n{ex.Message}");
+                }
+            }
+            validFiles = updatedFiles.ToArray();
+        }
+        else
+        {
+            // "reference-current": tell SetVariableLogic not to prompt per file
+            _setVariableLogic.SetBatchFileCopyDecision(shouldCopy: false);
+        }
+
+        return true;
     }
 
     private string? GetBaseTypeForExtension(string fileName)

--- a/Tool/Tests/GumToolUnitTests/PropertyGridHelpers/SetVariableLogicTests.cs
+++ b/Tool/Tests/GumToolUnitTests/PropertyGridHelpers/SetVariableLogicTests.cs
@@ -4,6 +4,7 @@ using Gum.DataTypes.Variables;
 using Gum.Managers;
 using Gum.Plugins;
 using Gum.PropertyGridHelpers;
+using Gum.Services.Dialogs;
 using Gum.ToolStates;
 using Moq;
 using Moq.AutoMock;
@@ -14,8 +15,9 @@ namespace GumToolUnitTests.PropertyGridHelpers;
 public class SetVariableLogicTests : BaseTestClass
 {
     private readonly AutoMocker mocker;
-
+    private readonly FakeDialogService _fakeDialogService;
     private readonly SetVariableLogic _setVariableLogic;
+
     public SetVariableLogicTests()
     {
         mocker = new();
@@ -26,6 +28,9 @@ public class SetVariableLogicTests : BaseTestClass
         mocker.GetMock<IProjectState>()
             .Setup(x => x.ProjectDirectory)
             .Returns("c:/TestProject/");
+
+        _fakeDialogService = new FakeDialogService();
+        mocker.Use<IDialogService>(_fakeDialogService);
 
         _setVariableLogic = mocker.CreateInstance<SetVariableLogic>();
         StandardElementsManager.Self.Initialize();
@@ -462,6 +467,71 @@ public class SetVariableLogicTests : BaseTestClass
         bool result = SetVariableLogic.IsStateVariable("Category1State", screen, instance);
 
         result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void ReactToPropertyValueChanged_ShouldNotShowCopyDialog_WhenBatchFileCopyDecisionIsSetToFalse()
+    {
+        // A SourceFile path that resolves outside the project folder should normally
+        // trigger the "copy or reference?" dialog. With SetBatchFileCopyDecision(false),
+        // the dialog must be suppressed and the response must succeed (reference-in-place).
+        ComponentSave container = new ComponentSave();
+        container.States.Add(new StateSave());
+        container.DefaultState.ParentContainer = container;
+
+        InstanceSave instance = new InstanceSave();
+        instance.Name = "SpriteInstance";
+        instance.BaseType = "Sprite";
+
+        // "../../ExternalFolder/image.png" resolves to c:/ExternalFolder/image.png,
+        // which is outside c:/TestProject/.
+        container.DefaultState.SetValue("SpriteInstance.SourceFile", "../../ExternalFolder/image.png");
+
+        mocker.GetMock<ISelectedState>()
+            .Setup(x => x.SelectedStateSave)
+            .Returns(container.DefaultState);
+
+        _setVariableLogic.SetBatchFileCopyDecision(shouldCopy: false);
+
+        GeneralResponse response = _setVariableLogic.ReactToPropertyValueChanged(
+            "SourceFile", null, container, instance, container.DefaultState, refresh: false,
+            recordUndo: false, trySave: false);
+
+        _setVariableLogic.SetBatchFileCopyDecision(shouldCopy: null);
+
+        response.Succeeded.ShouldBeTrue();
+        _fakeDialogService.ShowChoiceCallCount.ShouldBe(0);
+    }
+
+    private class FakeDialogService : IDialogService
+    {
+        public int ShowChoiceCallCount { get; private set; }
+        public Action<ChoiceDialogViewModel>? ChoiceDialogStub { get; set; }
+
+        public MessageDialogResult ShowMessage(string message, string? title = null, MessageDialogStyle? style = null)
+            => MessageDialogResult.Canceled;
+
+        public bool Show<T>(T dialogViewModel) where T : DialogViewModel => false;
+
+        public bool Show<T>(Action<T>? initializer, out T viewModel) where T : DialogViewModel
+        {
+            if (typeof(T) == typeof(ChoiceDialogViewModel))
+            {
+                ChoiceDialogViewModel choice = new ChoiceDialogViewModel();
+                initializer?.Invoke((T)(object)choice);
+                ChoiceDialogStub?.Invoke(choice);
+                ShowChoiceCallCount++;
+                viewModel = (T)(object)choice;
+                return false;
+            }
+
+            viewModel = null!;
+            return false;
+        }
+
+        public string? GetUserString(string message, string? title = null, GetUserStringOptions? options = null) => null;
+
+        public List<string>? OpenFile(OpenFileDialogOptions? options = null) => null;
     }
 
     [Fact(Skip = "ProjectManager.Self needs to be removed")]


### PR DESCRIPTION
## Summary
- When 2+ sprite files outside the project folder are drag-dropped onto the wireframe, a single consolidated dialog now lists all files and asks the user once ("Copy all to project folder" or "Reference all in current locations") instead of prompting file-by-file.
- `ISetVariableLogic` gains `SetBatchFileCopyDecision(bool? shouldCopy)`, which `OnWireframeDrop` uses to pre-set the copy decision so `SetVariableLogic` suppresses per-file dialogs.
- Single-file drops and drops where all files are already in the project folder are unaffected.

## Test plan
- [x] Build `GumFull.sln` and launch the Gum tool
- [x] Open a project, select a component, drag 3+ PNG files from outside the project folder onto the wireframe — verify a single dialog appears listing all files with "Copy all" and "Reference all" options
- [x] Accept "Copy all" — verify files are copied to the project folder and instances are created referencing the copies
- [x] Repeat with "Reference all in current locations" — verify instances are created without extra dialogs
- [x] Cancel the dialog — verify no instances are created
- [x] Drag a single file from outside the project — verify the old per-file dialog still appears (unchanged behavior)
- [x] Run `dotnet test GumFull.sln --no-build` — all tests pass

Closes #3126

🤖 Generated with [Claude Code](https://claude.com/claude-code)
