### PR TITLE
#3127: Fix sprite drag+drop tree view icon and eliminate Container->Sprite conversion

### DIFF
--- a/Tool/EditorTabPlugin_XNA/MainEditorTabPlugin.cs
+++ b/Tool/EditorTabPlugin_XNA/MainEditorTabPlugin.cs
@@ -962,8 +962,7 @@ internal class MainEditorTabPlugin : PriorityPlugin, IRecipient<UiBaseFontSizeCh
         nameToAdd = StringFunctions.MakeStringUnique(nameToAdd, existingNames);
 
         InstanceSave instance =
-            _elementCommands.AddInstance(element, nameToAdd);
-        instance.BaseType = baseType;
+            _elementCommands.AddInstance(element, nameToAdd, baseType);
 
         _dragDropManager.SetInstanceToPosition(worldX, worldY, instance);
 


### PR DESCRIPTION
## Summary

- Fixes sprite drag+drop: when dragging a texture file onto the wireframe, the instance is now created directly with the correct BaseType (e.g. "Sprite") instead of first creating a Container and then reassigning BaseType afterward.
- This resolves both issues from #3127:
  1. **Tree view icon now correct** — AddInstance fires the tree view refresh; since the instance already has BaseType = "Sprite" at that point, the correct icon is shown immediately.
  2. **No more Container → Sprite conversion** — Eliminated the wasteful two-step creation pattern.

## Change

AddNewInstanceForDrop in MainEditorTabPlugin.cs now passes aseType as the third argument to AddInstance, using the existing overload that accepts the type directly. The instance.BaseType = baseType post-assignment line is removed.

Closes #3127