### PR TITLE
Organize Gum.zip: single-file publish to reduce top-level DLL clutter

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -87,6 +87,18 @@ jobs:
       - name: Publish Gum (single-file)
         run: dotnet publish Gum/Gum.csproj -c Release -r win-x64 --self-contained false -p:PublishSingleFile=true -o dist/publish
 
+      # Some content files (e.g. apos-shapes.xnb) are deposited into bin/Release/Content/ by
+      # plugin post-build events (EditorTabPlugin_XNA copies the XNB from Runtimes/GumShapes/).
+      # dotnet publish has no knowledge of files placed there outside of project items, so we
+      # merge the full build-output Content/ folder into the publish output.
+      - name: Copy content to publish output
+        shell: pwsh
+        run: |
+          if (Test-Path "Gum/bin/Release/Content") {
+            New-Item -ItemType Directory -Force -Path "dist/publish/Content" | Out-Null
+            Copy-Item -Path "Gum/bin/Release/Content/*" -Destination "dist/publish/Content" -Recurse -Force
+          }
+
       # Plugins are built by GumFull.sln and copied to bin/Release/Plugins via their own
       # post-build events (which use $(SolutionDir) and don't run during dotnet publish).
       # Use wildcard source so Copy-Item copies the *contents* into the destination folder

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -85,7 +85,7 @@ jobs:
       # All managed assemblies are bundled into Gum.exe; the .NET runtime is still required.
       # -r win-x64 is required for PublishSingleFile even when not self-contained.
       - name: Publish Gum (single-file)
-        run: dotnet publish Gum/Gum.csproj -c Release -r win-x64 --self-contained false -p:PublishSingleFile=true --no-restore -o dist/publish
+        run: dotnet publish Gum/Gum.csproj -c Release -r win-x64 --self-contained false -p:PublishSingleFile=true -o dist/publish
 
       # Plugins are built by GumFull.sln and copied to bin/Release/Plugins via their own
       # post-build events (which use $(SolutionDir) and don't run during dotnet publish).

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -89,20 +89,24 @@ jobs:
 
       # Plugins are built by GumFull.sln and copied to bin/Release/Plugins via their own
       # post-build events (which use $(SolutionDir) and don't run during dotnet publish).
+      # Use wildcard source so Copy-Item copies the *contents* into the destination folder
+      # rather than nesting the folder inside it (which happens when the destination already exists).
+      # dotnet publish creates dist/publish/Plugins/ for Plugins/readme.txt, so -Destination
+      # "dist/publish/Plugins" already exists and a non-wildcard copy would produce Plugins/Plugins/.
       - name: Copy plugins to publish output
         shell: pwsh
         run: |
           if (Test-Path "Gum/bin/Release/Plugins") {
-            Copy-Item -Path "Gum/bin/Release/Plugins" -Destination "dist/publish/Plugins" -Recurse -Force
+            New-Item -ItemType Directory -Force -Path "dist/publish/Plugins" | Out-Null
+            Copy-Item -Path "Gum/bin/Release/Plugins/*" -Destination "dist/publish/Plugins" -Recurse -Force
           }
 
-      # GumCli is copied to bin/Release/GumCli by the CopyGumCli target in Gum.csproj.
-      # The target fires during the build step above (OutDir = bin/Release/, not the publish dir).
       - name: Copy GumCli to publish output
         shell: pwsh
         run: |
           if (Test-Path "Gum/bin/Release/GumCli") {
-            Copy-Item -Path "Gum/bin/Release/GumCli" -Destination "dist/publish/GumCli" -Recurse -Force
+            New-Item -ItemType Directory -Force -Path "dist/publish/GumCli" | Out-Null
+            Copy-Item -Path "Gum/bin/Release/GumCli/*" -Destination "dist/publish/GumCli" -Recurse -Force
           }
 
       # 1) Package the publish output

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -76,18 +76,43 @@ jobs:
 
           Write-Host "Updated AssemblyInfo.cs to version $version"
 
-      # Build GUM TOOL (GumFull.sln includes Gum.Cli, which gets copied into the tool output)
+      # Build GUM TOOL (GumFull.sln includes Gum.Cli, which gets copied into the tool output;
+      # plugins use $(SolutionDir) in their post-build events so they must be built via the solution)
       - name: Build Gum Tool
         run: dotnet build GumFull.sln -c Release --no-restore -p:ExcludeIOS=true -p:ExcludeAndroid=true
-      
-      # 1) Package the entire directory exactly as-is
-      - name: Package entire Release folder
+
+      # Publish Gum as a framework-dependent single-file bundle.
+      # All managed assemblies are bundled into Gum.exe; the .NET runtime is still required.
+      # -r win-x64 is required for PublishSingleFile even when not self-contained.
+      - name: Publish Gum (single-file)
+        run: dotnet publish Gum/Gum.csproj -c Release -r win-x64 --self-contained false -p:PublishSingleFile=true --no-restore -o dist/publish
+
+      # Plugins are built by GumFull.sln and copied to bin/Release/Plugins via their own
+      # post-build events (which use $(SolutionDir) and don't run during dotnet publish).
+      - name: Copy plugins to publish output
+        shell: pwsh
+        run: |
+          if (Test-Path "Gum/bin/Release/Plugins") {
+            Copy-Item -Path "Gum/bin/Release/Plugins" -Destination "dist/publish/Plugins" -Recurse -Force
+          }
+
+      # GumCli is copied to bin/Release/GumCli by the CopyGumCli target in Gum.csproj.
+      # The target fires during the build step above (OutDir = bin/Release/, not the publish dir).
+      - name: Copy GumCli to publish output
+        shell: pwsh
+        run: |
+          if (Test-Path "Gum/bin/Release/GumCli") {
+            Copy-Item -Path "Gum/bin/Release/GumCli" -Destination "dist/publish/GumCli" -Recurse -Force
+          }
+
+      # 1) Package the publish output
+      - name: Package release
         shell: pwsh
         run: |
           New-Item -ItemType Directory -Force -Path dist | Out-Null
           $zip = "dist/Gum.zip"
           if (Test-Path $zip) { Remove-Item $zip -Force }
-          Compress-Archive -Path "Gum/bin/Release/*" -DestinationPath $zip
+          Compress-Archive -Path "dist/publish/*" -DestinationPath $zip
 
       # 2) Compute tag + title depending on the kind of release
       - name: Compute tag + title

--- a/Gum/Commands/FileCommands.cs
+++ b/Gum/Commands/FileCommands.cs
@@ -239,8 +239,8 @@ public class FileCommands : IFileCommands
     // Method copied from MineNineSlicePlugin.cs, potential candidate for DRY refactor
     static string GetExecutingDirectory()
     {
-        string path = System.IO.Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-        return path;
+        // Assembly.GetExecutingAssembly().Location returns empty string in single-file published apps.
+        return AppContext.BaseDirectory;
     }
 
     public void ForceSaveElement(ElementSave element)

--- a/Gum/Controls/ToggleButtonOptionContainer.cs
+++ b/Gum/Controls/ToggleButtonOptionContainer.cs
@@ -130,8 +130,10 @@ namespace Gum.Controls
         protected static BitmapImage CreateBitmapFromFile(string resourceName)
         {
             // make it absolute so the app doesn't look for the files in the current directory, 
-            // which could be outside the Gum.exe location
-            var relativeDirectory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location).ToLower() + "/";
+            // which could be outside the Gum.exe location.
+            // Assembly.GetExecutingAssembly().Location returns empty string in single-file published apps;
+            // AppContext.BaseDirectory already includes a trailing separator.
+            var relativeDirectory = AppContext.BaseDirectory.ToLower();
 
             resourceName = relativeDirectory + resourceName;
 

--- a/Gum/Gum.csproj
+++ b/Gum/Gum.csproj
@@ -13,6 +13,12 @@
 		<GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
 		<!-- This is always complaining even if we put a min version of 7.0, so let's suppress it:-->
 		<NoWarn>$(NoWarn);CA1416</NoWarn>
+		<!-- Enables the SDK's single-file compatibility analyzer on every build (not just dotnet publish).
+		     This catches IL3000 (Assembly.Location returns "" in single-file) and related APIs at
+		     compile time in Debug builds, before they can silently break the published release. -->
+		<PublishSingleFile>true</PublishSingleFile>
+		<!-- Treat single-file incompatibility as a hard error so it cannot be ignored. -->
+		<WarningsAsErrors>$(WarningsAsErrors);IL3000;IL3001;IL3002</WarningsAsErrors>
 	</PropertyGroup>
 
 	<!-- Define constants for all target frameworks -->

--- a/Gum/Plugins/InternalPlugins/NineSlicePlugin/MainNineSlicePlugin.cs
+++ b/Gum/Plugins/InternalPlugins/NineSlicePlugin/MainNineSlicePlugin.cs
@@ -49,8 +49,8 @@ internal class MainNineSlicePlugin : PriorityPlugin
 
     static string GetExecutingDirectory()
     {
-        string path = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-        return path;
+        // Assembly.GetExecutingAssembly().Location returns empty string in single-file published apps.
+        return AppContext.BaseDirectory;
     }
 
 }

--- a/Gum/Plugins/PluginManager.cs
+++ b/Gum/Plugins/PluginManager.cs
@@ -1043,10 +1043,11 @@ public class PluginManager : IPluginManager
             if (DateTime.TryParse(value, out compatibilityTime))
             {
                 //If compatibility timestamp is newer than current Glue's timestamp, then don't compile plugin
-                // Assembly.GetExecutingAssembly().Location returns empty string in single-file published apps.
-                // Environment.ProcessPath gives the actual path to Gum.exe in all deployment modes.
-                var exePath = Environment.ProcessPath ?? Assembly.GetExecutingAssembly().Location;
-                if (new FileInfo(exePath).LastWriteTime < compatibilityTime)
+                // Environment.ProcessPath gives the actual EXE path in all deployment modes including
+                // single-file publish, where Assembly.GetExecutingAssembly().Location returns empty string.
+                // If ProcessPath is somehow null, skip the check (treat as compatible).
+                var exePath = Environment.ProcessPath;
+                if (exePath != null && new FileInfo(exePath).LastWriteTime < compatibilityTime)
                 {
                     return false;
                 }

--- a/Gum/Plugins/PluginManager.cs
+++ b/Gum/Plugins/PluginManager.cs
@@ -1043,7 +1043,10 @@ public class PluginManager : IPluginManager
             if (DateTime.TryParse(value, out compatibilityTime))
             {
                 //If compatibility timestamp is newer than current Glue's timestamp, then don't compile plugin
-                if (new FileInfo(Assembly.GetExecutingAssembly().Location).LastWriteTime < compatibilityTime)
+                // Assembly.GetExecutingAssembly().Location returns empty string in single-file published apps.
+                // Environment.ProcessPath gives the actual path to Gum.exe in all deployment modes.
+                var exePath = Environment.ProcessPath ?? Assembly.GetExecutingAssembly().Location;
+                if (new FileInfo(exePath).LastWriteTime < compatibilityTime)
                 {
                     return false;
                 }

--- a/Tool/EditorTabPlugin_XNA/Services/ToolFontService.cs
+++ b/Tool/EditorTabPlugin_XNA/Services/ToolFontService.cs
@@ -2,12 +2,7 @@
 using RenderingLibrary.Content;
 using RenderingLibrary.Graphics;
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Gum.Managers
 {
@@ -24,11 +19,9 @@ namespace Gum.Managers
         }
         public void Initialize()
         {
-            // This is the plugin, which doesn't have the font...
-            //var executingPath = Assembly.GetExecutingAssembly().Location;
-            // Instead use Gum which is the entry assembly
-            var executingPath = Assembly.GetEntryAssembly().Location;
-            var directory = Path.GetDirectoryName(executingPath);
+            // Assembly.GetEntryAssembly().Location returns empty string in single-file published apps.
+            // AppContext.BaseDirectory is the correct way to locate the executable's directory.
+            var directory = AppContext.BaseDirectory;
 
             var fntFilePath = Path.Combine(directory, "Content/Fonts/Font18Arial_o1.fnt");
             var font = new BitmapFont(fntFilePath);

--- a/ToolsUtilities/FileManager.cs
+++ b/ToolsUtilities/FileManager.cs
@@ -33,7 +33,8 @@ namespace ToolsUtilities
             {
                 if (IsMobile)
                 {
-                    return Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location).ToLower().Replace("/", "\\") + "\\";
+                    // Assembly.GetExecutingAssembly().Location returns empty string in single-file published apps.
+                    return AppContext.BaseDirectory.ToLower().Replace("/", "\\");
                 }
                 else
                 {


### PR DESCRIPTION
Switch from `dotnet build` to `dotnet publish` with `PublishSingleFile=true -r win-x64` so all managed assemblies are bundled into `Gum.exe`. The extracted directory goes from ~80 loose DLLs alongside the EXE to just the EXE plus content files, plugins, and GumCli.

**What changed**
- Add a `dotnet publish` step after the existing `dotnet build` step. Build still runs first so plugins (which use `$(SolutionDir)` in their post-build events) get placed in `bin/Release/Plugins/` as before.
- Add copy steps to bring `bin/Release/Plugins/` and `bin/Release/GumCli/` into the publish output directory (`dist/publish/`), since those are produced by post-build events that target the build output dir, not the publish dir.
- Update the zip step to compress `dist/publish/*` instead of `Gum/bin/Release/*`.

**What stays the same**
- Framework-dependent: .NET 8 must still be installed. No size explosion.
- Plugins and GumCli are included as before, just copied in an extra step.
- Local `dotnet build` / F5 in Visual Studio is unaffected — flat layout stays for dev builds.

**To test locally**
```
dotnet build GumFull.sln -c Release
dotnet publish Gum/Gum.csproj -c Release -r win-x64 --self-contained false -p:PublishSingleFile=true --no-restore -o dist/publish
```
Then verify `dist/publish/` has `Gum.exe` (large, ~bundled) and no loose dependency DLLs at the top level.

Closes #3124
