### PR TITLE
#3123: Link Introduction to Setup page; add direct latest-release link

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,8 @@ Gum is the best Game UI Layout tool available. It provides a flexible, efficient
 
 The Gum layout engine can also be included in any .NET project without requiring the use of a particular graphical API.
 
+To download the Gum UI tool and start building your UI, see the [Setup](gum-tool/setup/README.md) page.
+
 ### Powerful WYSIWYG Editor
 
 Gum UI includes advanced layout functionality to create and preview your UI

--- a/docs/gum-tool/setup/README.md
+++ b/docs/gum-tool/setup/README.md
@@ -1,6 +1,9 @@
 # Setup
 
-Latest release and release history (including older releases):\
+Download the latest release directly:\
+[https://github.com/vchelaru/Gum/releases/latest](https://github.com/vchelaru/Gum/releases/latest)
+
+Release history (including older releases):\
 [https://github.com/vchelaru/Gum/releases](https://github.com/vchelaru/Gum/releases)
 
 Gum Source Code:\


### PR DESCRIPTION
Resolves the introduction → setup → download discoverability gap from #3123.

## Changes

- **Introduction doc** (`docs/README.md`) now links to the **Setup** page, so a new reader landing on the intro has a clear path to downloading the tool.
- **Setup page** (`docs/gum-tool/setup/README.md`) now leads with a direct link to GitHub's `/releases/latest` URL, which always redirects to the newest stable release — no more browsing the full release list to grab the current build. The full release-history link is kept below it for older versions.

Closes #3123

🤖 Generated with [Claude Code](https://claude.com/claude-code)
