### PR TITLE
#3120: Unify MonoGameGum.{ExtensionMethods,Renderables,Forms.DefaultVisuals} into Gum.* namespaces

### DIFF
--- a/MonoGameGum.Tests/Forms/ButtonTests.cs
+++ b/MonoGameGum.Tests/Forms/ButtonTests.cs
@@ -24,7 +24,7 @@ public class ButtonTests : BaseTestClass
 
         button.Visual.ShouldNotBeNull();
 
-        button.Visual.ShouldBeOfType<MonoGameGum.Forms.DefaultVisuals.DefaultButtonRuntime>();
+        button.Visual.ShouldBeOfType<Gum.Forms.DefaultVisuals.DefaultButtonRuntime>();
     }
 
     [Fact]

--- a/MonoGameGum.Tests/Forms/ComboBoxTests.cs
+++ b/MonoGameGum.Tests/Forms/ComboBoxTests.cs
@@ -135,7 +135,7 @@ public  class ComboBoxTests : BaseTestClass
 
     public class CGComboBox : InteractiveGue
     {
-        public MonoGameGum.Forms.DefaultVisuals.DefaultListBoxRuntime? ListBoxInstance;
+        public Gum.Forms.DefaultVisuals.DefaultListBoxRuntime? ListBoxInstance;
         public RectangleRuntime? FocusedIndicator { get; private set; }
 
         public CGComboBox(bool fullInstantiation = true, bool tryCreateFormsObject = true) : base(new InvisibleRenderable())
@@ -148,7 +148,7 @@ public  class ComboBoxTests : BaseTestClass
                 var TextInstance = new TextRuntime();
                 TextInstance.Name = "TextInstance";
 
-                ListBoxInstance = new MonoGameGum.Forms.DefaultVisuals.DefaultListBoxRuntime(tryCreateFormsObject: false);
+                ListBoxInstance = new Gum.Forms.DefaultVisuals.DefaultListBoxRuntime(tryCreateFormsObject: false);
                 ListBoxInstance.Name = "ListBoxInstance";
 
 

--- a/MonoGameGum.Tests/Forms/ListBoxTests.cs
+++ b/MonoGameGum.Tests/Forms/ListBoxTests.cs
@@ -1,7 +1,6 @@
 ﻿using Gum.Forms.Controls;
 using Gum.Forms.DefaultVisuals;
 using Gum.Wireframe;
-using MonoGameGum.Forms.DefaultVisuals;
 using Gum.GueDeriving;
 using MonoGameGum.Input;
 using Moq;

--- a/MonoGameGum.Tests/Forms/ScrollBarThumbResizeTests.cs
+++ b/MonoGameGum.Tests/Forms/ScrollBarThumbResizeTests.cs
@@ -1,7 +1,7 @@
 using Gum.DataTypes;
 using Gum.Forms.Controls;
 using Gum.Wireframe;
-using MonoGameGum.Forms.DefaultVisuals;
+using Gum.Forms.DefaultVisuals;
 using Shouldly;
 using Xunit;
 

--- a/MonoGameGum.Tests/Forms/SliderThumbResizeTests.cs
+++ b/MonoGameGum.Tests/Forms/SliderThumbResizeTests.cs
@@ -1,7 +1,7 @@
 using Gum.DataTypes;
 using Gum.Forms.Controls;
 using Gum.Wireframe;
-using MonoGameGum.Forms.DefaultVisuals;
+using Gum.Forms.DefaultVisuals;
 using Shouldly;
 using Xunit;
 

--- a/MonoGameGum.Tests/Forms/TextBoxTests.cs
+++ b/MonoGameGum.Tests/Forms/TextBoxTests.cs
@@ -3,7 +3,7 @@ using Gum.Forms.Data;
 using Gum.Localization;
 using Gum.Mvvm;
 using Gum.Wireframe;
-using MonoGameGum.Forms.DefaultVisuals;
+using Gum.Forms.DefaultVisuals;
 using Gum.GueDeriving;
 using Moq;
 using Shouldly;

--- a/MonoGameGum.Tests/Runtimes/CircleRuntimeTests.cs
+++ b/MonoGameGum.Tests/Runtimes/CircleRuntimeTests.cs
@@ -2,7 +2,7 @@ using Gum.Converters;
 using Gum.DataTypes;
 using Gum.GueDeriving;
 using Microsoft.Xna.Framework;
-using MonoGameGum.Renderables;
+using Gum.Renderables;
 using RenderingLibrary.Graphics;
 using RenderingLibrary.Math.Geometry;
 using Shouldly;

--- a/MonoGameGum.Tests/Runtimes/RectangleRuntimeTests.cs
+++ b/MonoGameGum.Tests/Runtimes/RectangleRuntimeTests.cs
@@ -1,6 +1,6 @@
 using Gum.GueDeriving;
 using Microsoft.Xna.Framework;
-using MonoGameGum.Renderables;
+using Gum.Renderables;
 using RenderingLibrary.Graphics;
 using Shouldly;
 using Xunit;

--- a/MonoGameGum.Tests/Wireframe/FallbackRenderableFactoryTests.cs
+++ b/MonoGameGum.Tests/Wireframe/FallbackRenderableFactoryTests.cs
@@ -1,6 +1,6 @@
 using Gum.GueDeriving;
 using Gum.Wireframe;
-using MonoGameGum.Renderables;
+using Gum.Renderables;
 using RenderingLibrary.Graphics;
 using RenderingLibrary.Math.Geometry;
 using Shouldly;

--- a/MonoGameGum/ExtensionMethods/IReadOnlyListExtensionMethods.cs
+++ b/MonoGameGum/ExtensionMethods/IReadOnlyListExtensionMethods.cs
@@ -4,7 +4,12 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
+#if FRB
 namespace MonoGameGum.ExtensionMethods;
+#else
+namespace Gum.ExtensionMethods;
+#endif
+
 public static class IReadOnlyListExtensionMethods
 {
     public static int IndexOf<T>(this IReadOnlyList<T> self, T elementToFind)

--- a/MonoGameGum/ExtensionMethods/Shims/IReadOnlyListExtensionMethodsShim.cs
+++ b/MonoGameGum/ExtensionMethods/Shims/IReadOnlyListExtensionMethodsShim.cs
@@ -1,0 +1,34 @@
+#if !FRB
+using System;
+using System.Collections.Generic;
+
+namespace MonoGameGum.ExtensionMethods;
+
+/// <summary>
+/// Compatibility shim. The real type lives in <see cref="Gum.ExtensionMethods.IReadOnlyListExtensionMethods"/>.
+/// This forwarding class exists so existing user code with <c>using MonoGameGum.ExtensionMethods;</c>
+/// continues to compile during the deprecation window. A static extension class cannot be
+/// subclassed, so each member forwards to the real implementation instead.
+/// </summary>
+[Obsolete("Use Gum.ExtensionMethods.IReadOnlyListExtensionMethods instead. The MonoGameGum.ExtensionMethods namespace will be removed in a future release.")]
+public static class IReadOnlyListExtensionMethods
+{
+    /// <summary>
+    /// Obsolete. Use <see cref="Gum.ExtensionMethods.IReadOnlyListExtensionMethods.IndexOf{T}(IReadOnlyList{T}, T)"/>.
+    /// </summary>
+    // The body is intentionally a self-contained copy rather than a forward to the Gum.* method:
+    // forwarding would re-import the IndexOf extension surface into this (obsolete) namespace and
+    // create an ambiguous call. This shim is removed when the MonoGameGum.* namespace is retired.
+    public static int IndexOf<T>(this IReadOnlyList<T> self, T elementToFind)
+    {
+        int i = 0;
+        foreach (T element in self)
+        {
+            if (Equals(element, elementToFind))
+                return i;
+            i++;
+        }
+        return -1;
+    }
+}
+#endif

--- a/MonoGameGum/Forms/DefaultVisuals/DefaultButtonRuntime.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/DefaultButtonRuntime.cs
@@ -17,7 +17,11 @@ using System.Threading.Tasks;
 
 using Styling = Gum.Forms.DefaultVisuals.Styling;
 
+#if FRB
 namespace MonoGameGum.Forms.DefaultVisuals;
+#else
+namespace Gum.Forms.DefaultVisuals;
+#endif
 
 public class DefaultButtonRuntime : InteractiveGue
 {
@@ -57,7 +61,7 @@ public class DefaultButtonRuntime : InteractiveGue
             TextInstance.XUnits = Gum.Converters.GeneralUnitType.PixelsFromMiddle;
             TextInstance.YUnits = Gum.Converters.GeneralUnitType.PixelsFromMiddle;
             TextInstance.HorizontalAlignment = global::RenderingLibrary.Graphics.HorizontalAlignment.Center;
-            TextInstance.VerticalAlignment = RenderingLibrary.Graphics.VerticalAlignment.Center;
+            TextInstance.VerticalAlignment = global::RenderingLibrary.Graphics.VerticalAlignment.Center;
             this.Children.Add(TextInstance);
 
             FocusedIndicator = new RectangleRuntime();

--- a/MonoGameGum/Forms/DefaultVisuals/DefaultCheckboxRuntime.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/DefaultCheckboxRuntime.cs
@@ -19,7 +19,11 @@ using System.Threading.Tasks;
 using Styling = Gum.Forms.DefaultVisuals.Styling;
 
 
+#if FRB
 namespace MonoGameGum.Forms.DefaultVisuals
+#else
+namespace Gum.Forms.DefaultVisuals
+#endif
 {
     public class DefaultCheckboxRuntime : InteractiveGue
     {
@@ -57,7 +61,7 @@ namespace MonoGameGum.Forms.DefaultVisuals
                 var text = new TextRuntime();
                 text.X = 28;
                 text.Y = 0;
-                text.YOrigin = RenderingLibrary.Graphics.VerticalAlignment.Center;
+                text.YOrigin = global::RenderingLibrary.Graphics.VerticalAlignment.Center;
                 text.YUnits = Gum.Converters.GeneralUnitType.PixelsFromMiddle;
                 text.Width = -36;
                 text.Height = 0;

--- a/MonoGameGum/Forms/DefaultVisuals/DefaultComboBoxRuntime.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/DefaultComboBoxRuntime.cs
@@ -19,7 +19,11 @@ using System.Threading.Tasks;
 using Styling = Gum.Forms.DefaultVisuals.Styling;
 
 
+#if FRB
 namespace MonoGameGum.Forms.DefaultVisuals
+#else
+namespace Gum.Forms.DefaultVisuals
+#endif
 {
     public class DefaultComboBoxRuntime : InteractiveGue
     {

--- a/MonoGameGum/Forms/DefaultVisuals/DefaultLabelRuntime.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/DefaultLabelRuntime.cs
@@ -13,7 +13,11 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
+#if FRB
 namespace MonoGameGum.Forms.DefaultVisuals;
+#else
+namespace Gum.Forms.DefaultVisuals;
+#endif
 
 public class DefaultLabelRuntime : TextRuntime
 {

--- a/MonoGameGum/Forms/DefaultVisuals/DefaultListBoxItemRuntime.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/DefaultListBoxItemRuntime.cs
@@ -18,7 +18,11 @@ using System.Threading.Tasks;
 using Styling = Gum.Forms.DefaultVisuals.Styling;
 
 
+#if FRB
 namespace MonoGameGum.Forms.DefaultVisuals;
+#else
+namespace Gum.Forms.DefaultVisuals;
+#endif
 
 public class DefaultListBoxItemRuntime : InteractiveGue
 {

--- a/MonoGameGum/Forms/DefaultVisuals/DefaultListBoxRuntime.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/DefaultListBoxRuntime.cs
@@ -19,7 +19,11 @@ using System.Threading.Tasks;
 using Styling = Gum.Forms.DefaultVisuals.Styling;
 
 
+#if FRB
 namespace MonoGameGum.Forms.DefaultVisuals;
+#else
+namespace Gum.Forms.DefaultVisuals;
+#endif
 
 public class DefaultListBoxRuntime : InteractiveGue
 {

--- a/MonoGameGum/Forms/DefaultVisuals/DefaultMenuItemRuntime.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/DefaultMenuItemRuntime.cs
@@ -15,7 +15,11 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
+#if FRB
 namespace MonoGameGum.Forms.DefaultVisuals;
+#else
+namespace Gum.Forms.DefaultVisuals;
+#endif
 
 public class DefaultMenuItemRuntime : InteractiveGue
 {

--- a/MonoGameGum/Forms/DefaultVisuals/DefaultMenuRuntime.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/DefaultMenuRuntime.cs
@@ -14,7 +14,11 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
+#if FRB
 namespace MonoGameGum.Forms.DefaultVisuals;
+#else
+namespace Gum.Forms.DefaultVisuals;
+#endif
 
 internal class DefaultMenuRuntime : InteractiveGue
 {

--- a/MonoGameGum/Forms/DefaultVisuals/DefaultPasswordBoxRuntime.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/DefaultPasswordBoxRuntime.cs
@@ -5,7 +5,11 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
+#if FRB
 namespace MonoGameGum.Forms.DefaultVisuals
+#else
+namespace Gum.Forms.DefaultVisuals
+#endif
 {
     public class DefaultPasswordBoxRuntime : DefaultTextBoxBaseRuntime
     {

--- a/MonoGameGum/Forms/DefaultVisuals/DefaultRadioButtonRuntime.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/DefaultRadioButtonRuntime.cs
@@ -19,7 +19,11 @@ using System.Threading.Tasks;
 using Styling = Gum.Forms.DefaultVisuals.Styling;
 
 
+#if FRB
 namespace MonoGameGum.Forms.DefaultVisuals;
+#else
+namespace Gum.Forms.DefaultVisuals;
+#endif
 public class DefaultRadioButtonRuntime : InteractiveGue
 {
     public TextRuntime TextInstance { get; private set; }
@@ -74,7 +78,7 @@ public class DefaultRadioButtonRuntime : InteractiveGue
             var text = new TextRuntime();
             text.X = 28;
             text.Y = 0;
-            text.YOrigin = RenderingLibrary.Graphics.VerticalAlignment.Center;
+            text.YOrigin = global::RenderingLibrary.Graphics.VerticalAlignment.Center;
             text.YUnits = Gum.Converters.GeneralUnitType.PixelsFromMiddle;
             text.Width = -36;
             text.Height = 0;

--- a/MonoGameGum/Forms/DefaultVisuals/DefaultScrollBarRuntime.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/DefaultScrollBarRuntime.cs
@@ -15,7 +15,11 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
+#if FRB
 namespace MonoGameGum.Forms.DefaultVisuals;
+#else
+namespace Gum.Forms.DefaultVisuals;
+#endif
 
 public class DefaultScrollBarRuntime : InteractiveGue
 {

--- a/MonoGameGum/Forms/DefaultVisuals/DefaultScrollViewerRuntime.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/DefaultScrollViewerRuntime.cs
@@ -14,7 +14,11 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
+#if FRB
 namespace MonoGameGum.Forms.DefaultVisuals;
+#else
+namespace Gum.Forms.DefaultVisuals;
+#endif
 
 public class DefaultScrollViewerRuntime : InteractiveGue
 {

--- a/MonoGameGum/Forms/DefaultVisuals/DefaultScrollViewerRuntimeSizedToChildren.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/DefaultScrollViewerRuntimeSizedToChildren.cs
@@ -4,7 +4,11 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
+#if FRB
 namespace MonoGameGum.Forms.DefaultVisuals;
+#else
+namespace Gum.Forms.DefaultVisuals;
+#endif
 internal class DefaultScrollViewerRuntimeSizedToChildren : DefaultScrollViewerRuntime
 {
     public DefaultScrollViewerRuntimeSizedToChildren(bool fullInstantiation = true, bool tryCreateFormsObject = true) : 

--- a/MonoGameGum/Forms/DefaultVisuals/DefaultSliderRuntime.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/DefaultSliderRuntime.cs
@@ -16,7 +16,11 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
+#if FRB
 namespace MonoGameGum.Forms.DefaultVisuals
+#else
+namespace Gum.Forms.DefaultVisuals
+#endif
 {
     public class DefaultSliderRuntime : InteractiveGue
     {

--- a/MonoGameGum/Forms/DefaultVisuals/DefaultSplitterRuntime.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/DefaultSplitterRuntime.cs
@@ -15,7 +15,11 @@ using System.Threading.Tasks;
 
 using Styling = Gum.Forms.DefaultVisuals.Styling;
 
+#if FRB
 namespace MonoGameGum.Forms.DefaultVisuals;
+#else
+namespace Gum.Forms.DefaultVisuals;
+#endif
 public class DefaultSplitterRuntime : InteractiveGue
 {
     public DefaultSplitterRuntime(bool fullInstantiation = true, bool tryCreateFormsObject = true) : base(new InvisibleRenderable())

--- a/MonoGameGum/Forms/DefaultVisuals/DefaultTextBoxBaseRuntime.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/DefaultTextBoxBaseRuntime.cs
@@ -18,7 +18,11 @@ using System.Threading.Tasks;
 using Styling = Gum.Forms.DefaultVisuals.Styling;
 
 
+#if FRB
 namespace MonoGameGum.Forms.DefaultVisuals
+#else
+namespace Gum.Forms.DefaultVisuals
+#endif
 {
     public abstract class DefaultTextBoxBaseRuntime : InteractiveGue
     {

--- a/MonoGameGum/Forms/DefaultVisuals/DefaultTextBoxRuntime.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/DefaultTextBoxRuntime.cs
@@ -14,7 +14,11 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
+#if FRB
 namespace MonoGameGum.Forms.DefaultVisuals;
+#else
+namespace Gum.Forms.DefaultVisuals;
+#endif
 
 public class DefaultTextBoxRuntime : DefaultTextBoxBaseRuntime
 {

--- a/MonoGameGum/Forms/DefaultVisuals/DefaultWindowRuntime.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/DefaultWindowRuntime.cs
@@ -1,6 +1,5 @@
 #pragma warning disable CS0618, GUM001 // Default visuals intentionally use deprecated MonoGameGum.GueDeriving shim types for backward compatibility until V1/V2/V3 visuals are retired. See issue #2715.
 using Gum.Wireframe;
-using MonoGameGum;
 using Gum.Forms.Controls;
 #if XNALIKE
 using MonoGameGum.GueDeriving;
@@ -17,7 +16,11 @@ using System.Threading.Tasks;
 using Styling = Gum.Forms.DefaultVisuals.Styling;
 
 
+#if FRB
 namespace MonoGameGum.Forms.DefaultVisuals;
+#else
+namespace Gum.Forms.DefaultVisuals;
+#endif
 
 public class DefaultWindowRuntime : InteractiveGue
 {

--- a/MonoGameGum/Forms/DefaultVisuals/Shims/DefaultButtonRuntimeShim.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/Shims/DefaultButtonRuntimeShim.cs
@@ -1,0 +1,20 @@
+#if !FRB
+using System;
+
+namespace MonoGameGum.Forms.DefaultVisuals;
+
+/// <summary>
+/// Compatibility shim. The real type lives in <see cref="Gum.Forms.DefaultVisuals.DefaultButtonRuntime"/>.
+/// This derived class exists so existing user code with <c>using MonoGameGum.Forms.DefaultVisuals;</c>
+/// continues to compile during the deprecation window.
+/// </summary>
+[Obsolete("Use Gum.Forms.DefaultVisuals.DefaultButtonRuntime instead. The MonoGameGum.Forms.DefaultVisuals namespace will be removed in a future release.")]
+public class DefaultButtonRuntime : Gum.Forms.DefaultVisuals.DefaultButtonRuntime
+{
+    /// <inheritdoc/>
+    public DefaultButtonRuntime(bool fullInstantiation = true, bool tryCreateFormsObject = true)
+        : base(fullInstantiation, tryCreateFormsObject)
+    {
+    }
+}
+#endif

--- a/MonoGameGum/Forms/DefaultVisuals/Shims/DefaultCheckboxRuntimeShim.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/Shims/DefaultCheckboxRuntimeShim.cs
@@ -1,0 +1,20 @@
+#if !FRB
+using System;
+
+namespace MonoGameGum.Forms.DefaultVisuals;
+
+/// <summary>
+/// Compatibility shim. The real type lives in <see cref="Gum.Forms.DefaultVisuals.DefaultCheckboxRuntime"/>.
+/// This derived class exists so existing user code with <c>using MonoGameGum.Forms.DefaultVisuals;</c>
+/// continues to compile during the deprecation window.
+/// </summary>
+[Obsolete("Use Gum.Forms.DefaultVisuals.DefaultCheckboxRuntime instead. The MonoGameGum.Forms.DefaultVisuals namespace will be removed in a future release.")]
+public class DefaultCheckboxRuntime : Gum.Forms.DefaultVisuals.DefaultCheckboxRuntime
+{
+    /// <inheritdoc/>
+    public DefaultCheckboxRuntime(bool fullInstantiation = true, bool tryCreateFormsObject = true)
+        : base(fullInstantiation, tryCreateFormsObject)
+    {
+    }
+}
+#endif

--- a/MonoGameGum/Forms/DefaultVisuals/Shims/DefaultComboBoxRuntimeShim.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/Shims/DefaultComboBoxRuntimeShim.cs
@@ -1,0 +1,20 @@
+#if !FRB
+using System;
+
+namespace MonoGameGum.Forms.DefaultVisuals;
+
+/// <summary>
+/// Compatibility shim. The real type lives in <see cref="Gum.Forms.DefaultVisuals.DefaultComboBoxRuntime"/>.
+/// This derived class exists so existing user code with <c>using MonoGameGum.Forms.DefaultVisuals;</c>
+/// continues to compile during the deprecation window.
+/// </summary>
+[Obsolete("Use Gum.Forms.DefaultVisuals.DefaultComboBoxRuntime instead. The MonoGameGum.Forms.DefaultVisuals namespace will be removed in a future release.")]
+public class DefaultComboBoxRuntime : Gum.Forms.DefaultVisuals.DefaultComboBoxRuntime
+{
+    /// <inheritdoc/>
+    public DefaultComboBoxRuntime(bool fullInstantiation = true, bool tryCreateFormsObject = true)
+        : base(fullInstantiation, tryCreateFormsObject)
+    {
+    }
+}
+#endif

--- a/MonoGameGum/Forms/DefaultVisuals/Shims/DefaultLabelRuntimeShim.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/Shims/DefaultLabelRuntimeShim.cs
@@ -1,0 +1,20 @@
+#if !FRB
+using System;
+
+namespace MonoGameGum.Forms.DefaultVisuals;
+
+/// <summary>
+/// Compatibility shim. The real type lives in <see cref="Gum.Forms.DefaultVisuals.DefaultLabelRuntime"/>.
+/// This derived class exists so existing user code with <c>using MonoGameGum.Forms.DefaultVisuals;</c>
+/// continues to compile during the deprecation window.
+/// </summary>
+[Obsolete("Use Gum.Forms.DefaultVisuals.DefaultLabelRuntime instead. The MonoGameGum.Forms.DefaultVisuals namespace will be removed in a future release.")]
+public class DefaultLabelRuntime : Gum.Forms.DefaultVisuals.DefaultLabelRuntime
+{
+    /// <inheritdoc/>
+    public DefaultLabelRuntime(bool fullInstantiation = true, bool tryCreateFormsObject = true)
+        : base(fullInstantiation, tryCreateFormsObject)
+    {
+    }
+}
+#endif

--- a/MonoGameGum/Forms/DefaultVisuals/Shims/DefaultListBoxItemRuntimeShim.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/Shims/DefaultListBoxItemRuntimeShim.cs
@@ -1,0 +1,20 @@
+#if !FRB
+using System;
+
+namespace MonoGameGum.Forms.DefaultVisuals;
+
+/// <summary>
+/// Compatibility shim. The real type lives in <see cref="Gum.Forms.DefaultVisuals.DefaultListBoxItemRuntime"/>.
+/// This derived class exists so existing user code with <c>using MonoGameGum.Forms.DefaultVisuals;</c>
+/// continues to compile during the deprecation window.
+/// </summary>
+[Obsolete("Use Gum.Forms.DefaultVisuals.DefaultListBoxItemRuntime instead. The MonoGameGum.Forms.DefaultVisuals namespace will be removed in a future release.")]
+public class DefaultListBoxItemRuntime : Gum.Forms.DefaultVisuals.DefaultListBoxItemRuntime
+{
+    /// <inheritdoc/>
+    public DefaultListBoxItemRuntime(bool fullInstantiation = true, bool tryCreateFormsObject = true)
+        : base(fullInstantiation, tryCreateFormsObject)
+    {
+    }
+}
+#endif

--- a/MonoGameGum/Forms/DefaultVisuals/Shims/DefaultListBoxRuntimeShim.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/Shims/DefaultListBoxRuntimeShim.cs
@@ -1,0 +1,20 @@
+#if !FRB
+using System;
+
+namespace MonoGameGum.Forms.DefaultVisuals;
+
+/// <summary>
+/// Compatibility shim. The real type lives in <see cref="Gum.Forms.DefaultVisuals.DefaultListBoxRuntime"/>.
+/// This derived class exists so existing user code with <c>using MonoGameGum.Forms.DefaultVisuals;</c>
+/// continues to compile during the deprecation window.
+/// </summary>
+[Obsolete("Use Gum.Forms.DefaultVisuals.DefaultListBoxRuntime instead. The MonoGameGum.Forms.DefaultVisuals namespace will be removed in a future release.")]
+public class DefaultListBoxRuntime : Gum.Forms.DefaultVisuals.DefaultListBoxRuntime
+{
+    /// <inheritdoc/>
+    public DefaultListBoxRuntime(bool fullInstantiation = true, bool tryCreateFormsObject = true)
+        : base(fullInstantiation, tryCreateFormsObject)
+    {
+    }
+}
+#endif

--- a/MonoGameGum/Forms/DefaultVisuals/Shims/DefaultMenuItemRuntimeShim.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/Shims/DefaultMenuItemRuntimeShim.cs
@@ -1,0 +1,20 @@
+#if !FRB
+using System;
+
+namespace MonoGameGum.Forms.DefaultVisuals;
+
+/// <summary>
+/// Compatibility shim. The real type lives in <see cref="Gum.Forms.DefaultVisuals.DefaultMenuItemRuntime"/>.
+/// This derived class exists so existing user code with <c>using MonoGameGum.Forms.DefaultVisuals;</c>
+/// continues to compile during the deprecation window.
+/// </summary>
+[Obsolete("Use Gum.Forms.DefaultVisuals.DefaultMenuItemRuntime instead. The MonoGameGum.Forms.DefaultVisuals namespace will be removed in a future release.")]
+public class DefaultMenuItemRuntime : Gum.Forms.DefaultVisuals.DefaultMenuItemRuntime
+{
+    /// <inheritdoc/>
+    public DefaultMenuItemRuntime(bool fullInstantiation = true, bool tryCreateFormsObject = true)
+        : base(fullInstantiation, tryCreateFormsObject)
+    {
+    }
+}
+#endif

--- a/MonoGameGum/Forms/DefaultVisuals/Shims/DefaultPasswordBoxRuntimeShim.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/Shims/DefaultPasswordBoxRuntimeShim.cs
@@ -1,0 +1,20 @@
+#if !FRB
+using System;
+
+namespace MonoGameGum.Forms.DefaultVisuals;
+
+/// <summary>
+/// Compatibility shim. The real type lives in <see cref="Gum.Forms.DefaultVisuals.DefaultPasswordBoxRuntime"/>.
+/// This derived class exists so existing user code with <c>using MonoGameGum.Forms.DefaultVisuals;</c>
+/// continues to compile during the deprecation window.
+/// </summary>
+[Obsolete("Use Gum.Forms.DefaultVisuals.DefaultPasswordBoxRuntime instead. The MonoGameGum.Forms.DefaultVisuals namespace will be removed in a future release.")]
+public class DefaultPasswordBoxRuntime : Gum.Forms.DefaultVisuals.DefaultPasswordBoxRuntime
+{
+    /// <inheritdoc/>
+    public DefaultPasswordBoxRuntime(bool fullInstantiation = true, bool tryCreateFormsObject = true)
+        : base(fullInstantiation, tryCreateFormsObject)
+    {
+    }
+}
+#endif

--- a/MonoGameGum/Forms/DefaultVisuals/Shims/DefaultRadioButtonRuntimeShim.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/Shims/DefaultRadioButtonRuntimeShim.cs
@@ -1,0 +1,20 @@
+#if !FRB
+using System;
+
+namespace MonoGameGum.Forms.DefaultVisuals;
+
+/// <summary>
+/// Compatibility shim. The real type lives in <see cref="Gum.Forms.DefaultVisuals.DefaultRadioButtonRuntime"/>.
+/// This derived class exists so existing user code with <c>using MonoGameGum.Forms.DefaultVisuals;</c>
+/// continues to compile during the deprecation window.
+/// </summary>
+[Obsolete("Use Gum.Forms.DefaultVisuals.DefaultRadioButtonRuntime instead. The MonoGameGum.Forms.DefaultVisuals namespace will be removed in a future release.")]
+public class DefaultRadioButtonRuntime : Gum.Forms.DefaultVisuals.DefaultRadioButtonRuntime
+{
+    /// <inheritdoc/>
+    public DefaultRadioButtonRuntime(bool fullInstantiation = true, bool tryCreateFormsObject = true)
+        : base(fullInstantiation, tryCreateFormsObject)
+    {
+    }
+}
+#endif

--- a/MonoGameGum/Forms/DefaultVisuals/Shims/DefaultScrollBarRuntimeShim.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/Shims/DefaultScrollBarRuntimeShim.cs
@@ -1,0 +1,20 @@
+#if !FRB
+using System;
+
+namespace MonoGameGum.Forms.DefaultVisuals;
+
+/// <summary>
+/// Compatibility shim. The real type lives in <see cref="Gum.Forms.DefaultVisuals.DefaultScrollBarRuntime"/>.
+/// This derived class exists so existing user code with <c>using MonoGameGum.Forms.DefaultVisuals;</c>
+/// continues to compile during the deprecation window.
+/// </summary>
+[Obsolete("Use Gum.Forms.DefaultVisuals.DefaultScrollBarRuntime instead. The MonoGameGum.Forms.DefaultVisuals namespace will be removed in a future release.")]
+public class DefaultScrollBarRuntime : Gum.Forms.DefaultVisuals.DefaultScrollBarRuntime
+{
+    /// <inheritdoc/>
+    public DefaultScrollBarRuntime(bool fullInstantiation = true, bool tryCreateFormsObject = true)
+        : base(fullInstantiation, tryCreateFormsObject)
+    {
+    }
+}
+#endif

--- a/MonoGameGum/Forms/DefaultVisuals/Shims/DefaultScrollViewerRuntimeShim.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/Shims/DefaultScrollViewerRuntimeShim.cs
@@ -1,0 +1,20 @@
+#if !FRB
+using System;
+
+namespace MonoGameGum.Forms.DefaultVisuals;
+
+/// <summary>
+/// Compatibility shim. The real type lives in <see cref="Gum.Forms.DefaultVisuals.DefaultScrollViewerRuntime"/>.
+/// This derived class exists so existing user code with <c>using MonoGameGum.Forms.DefaultVisuals;</c>
+/// continues to compile during the deprecation window.
+/// </summary>
+[Obsolete("Use Gum.Forms.DefaultVisuals.DefaultScrollViewerRuntime instead. The MonoGameGum.Forms.DefaultVisuals namespace will be removed in a future release.")]
+public class DefaultScrollViewerRuntime : Gum.Forms.DefaultVisuals.DefaultScrollViewerRuntime
+{
+    /// <inheritdoc/>
+    public DefaultScrollViewerRuntime(bool fullInstantiation = true, bool tryCreateFormsObject = true)
+        : base(fullInstantiation, tryCreateFormsObject)
+    {
+    }
+}
+#endif

--- a/MonoGameGum/Forms/DefaultVisuals/Shims/DefaultSliderRuntimeShim.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/Shims/DefaultSliderRuntimeShim.cs
@@ -1,0 +1,20 @@
+#if !FRB
+using System;
+
+namespace MonoGameGum.Forms.DefaultVisuals;
+
+/// <summary>
+/// Compatibility shim. The real type lives in <see cref="Gum.Forms.DefaultVisuals.DefaultSliderRuntime"/>.
+/// This derived class exists so existing user code with <c>using MonoGameGum.Forms.DefaultVisuals;</c>
+/// continues to compile during the deprecation window.
+/// </summary>
+[Obsolete("Use Gum.Forms.DefaultVisuals.DefaultSliderRuntime instead. The MonoGameGum.Forms.DefaultVisuals namespace will be removed in a future release.")]
+public class DefaultSliderRuntime : Gum.Forms.DefaultVisuals.DefaultSliderRuntime
+{
+    /// <inheritdoc/>
+    public DefaultSliderRuntime(bool fullInstantiation = true, bool tryCreateFormsObject = true)
+        : base(fullInstantiation, tryCreateFormsObject)
+    {
+    }
+}
+#endif

--- a/MonoGameGum/Forms/DefaultVisuals/Shims/DefaultSplitterRuntimeShim.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/Shims/DefaultSplitterRuntimeShim.cs
@@ -1,0 +1,20 @@
+#if !FRB
+using System;
+
+namespace MonoGameGum.Forms.DefaultVisuals;
+
+/// <summary>
+/// Compatibility shim. The real type lives in <see cref="Gum.Forms.DefaultVisuals.DefaultSplitterRuntime"/>.
+/// This derived class exists so existing user code with <c>using MonoGameGum.Forms.DefaultVisuals;</c>
+/// continues to compile during the deprecation window.
+/// </summary>
+[Obsolete("Use Gum.Forms.DefaultVisuals.DefaultSplitterRuntime instead. The MonoGameGum.Forms.DefaultVisuals namespace will be removed in a future release.")]
+public class DefaultSplitterRuntime : Gum.Forms.DefaultVisuals.DefaultSplitterRuntime
+{
+    /// <inheritdoc/>
+    public DefaultSplitterRuntime(bool fullInstantiation = true, bool tryCreateFormsObject = true)
+        : base(fullInstantiation, tryCreateFormsObject)
+    {
+    }
+}
+#endif

--- a/MonoGameGum/Forms/DefaultVisuals/Shims/DefaultTextBoxBaseRuntimeShim.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/Shims/DefaultTextBoxBaseRuntimeShim.cs
@@ -1,0 +1,20 @@
+#if !FRB
+using System;
+
+namespace MonoGameGum.Forms.DefaultVisuals;
+
+/// <summary>
+/// Compatibility shim. The real type lives in <see cref="Gum.Forms.DefaultVisuals.DefaultTextBoxBaseRuntime"/>.
+/// This derived class exists so existing user code with <c>using MonoGameGum.Forms.DefaultVisuals;</c>
+/// continues to compile during the deprecation window. It is abstract, mirroring the real type.
+/// </summary>
+[Obsolete("Use Gum.Forms.DefaultVisuals.DefaultTextBoxBaseRuntime instead. The MonoGameGum.Forms.DefaultVisuals namespace will be removed in a future release.")]
+public abstract class DefaultTextBoxBaseRuntime : Gum.Forms.DefaultVisuals.DefaultTextBoxBaseRuntime
+{
+    /// <inheritdoc/>
+    protected DefaultTextBoxBaseRuntime(bool fullInstantiation = true, bool tryCreateFormsObject = true)
+        : base(fullInstantiation, tryCreateFormsObject)
+    {
+    }
+}
+#endif

--- a/MonoGameGum/Forms/DefaultVisuals/Shims/DefaultTextBoxRuntimeShim.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/Shims/DefaultTextBoxRuntimeShim.cs
@@ -1,0 +1,20 @@
+#if !FRB
+using System;
+
+namespace MonoGameGum.Forms.DefaultVisuals;
+
+/// <summary>
+/// Compatibility shim. The real type lives in <see cref="Gum.Forms.DefaultVisuals.DefaultTextBoxRuntime"/>.
+/// This derived class exists so existing user code with <c>using MonoGameGum.Forms.DefaultVisuals;</c>
+/// continues to compile during the deprecation window.
+/// </summary>
+[Obsolete("Use Gum.Forms.DefaultVisuals.DefaultTextBoxRuntime instead. The MonoGameGum.Forms.DefaultVisuals namespace will be removed in a future release.")]
+public class DefaultTextBoxRuntime : Gum.Forms.DefaultVisuals.DefaultTextBoxRuntime
+{
+    /// <inheritdoc/>
+    public DefaultTextBoxRuntime(bool fullInstantiation = true, bool tryCreateFormsObject = true)
+        : base(fullInstantiation, tryCreateFormsObject)
+    {
+    }
+}
+#endif

--- a/MonoGameGum/Forms/DefaultVisuals/Shims/DefaultWindowRuntimeShim.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/Shims/DefaultWindowRuntimeShim.cs
@@ -1,0 +1,20 @@
+#if !FRB
+using System;
+
+namespace MonoGameGum.Forms.DefaultVisuals;
+
+/// <summary>
+/// Compatibility shim. The real type lives in <see cref="Gum.Forms.DefaultVisuals.DefaultWindowRuntime"/>.
+/// This derived class exists so existing user code with <c>using MonoGameGum.Forms.DefaultVisuals;</c>
+/// continues to compile during the deprecation window.
+/// </summary>
+[Obsolete("Use Gum.Forms.DefaultVisuals.DefaultWindowRuntime instead. The MonoGameGum.Forms.DefaultVisuals namespace will be removed in a future release.")]
+public class DefaultWindowRuntime : Gum.Forms.DefaultVisuals.DefaultWindowRuntime
+{
+    /// <inheritdoc/>
+    public DefaultWindowRuntime(bool fullInstantiation = true, bool tryCreateFormsObject = true)
+        : base(fullInstantiation, tryCreateFormsObject)
+    {
+    }
+}
+#endif

--- a/MonoGameGum/Forms/FormsUtilities.cs
+++ b/MonoGameGum/Forms/FormsUtilities.cs
@@ -17,7 +17,7 @@ using System.Linq;
 #if XNALIKE
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
-using MonoGameGum.Forms.DefaultVisuals;
+using Gum.Forms.DefaultVisuals;
 using Gum.GueDeriving;
 using MonoGameGum.Input;
 #else

--- a/MonoGameGum/GueDeriving/CircleRuntime.cs
+++ b/MonoGameGum/GueDeriving/CircleRuntime.cs
@@ -30,7 +30,7 @@ using ColorExtensions = ToolsUtilitiesStandard.Helpers.ColorExtensions;
 using ContainedCircleType = global::RenderingLibrary.Math.Geometry.LineCircle;
 using global::RenderingLibrary.Math.Geometry;
 using Gum.DataTypes;
-using MonoGameGum.Renderables;
+using Gum.Renderables;
 #endif
 
 #if FRB
@@ -667,7 +667,7 @@ public class CircleRuntime : GraphicalUiElement
     /// <see cref="IAntialiasedRenderable"/>. Visual effect requires the optional
     /// MonoGameGumShapes (Apos.Shapes) package; without it neither slot implements the
     /// interface and the value round-trips on the runtime but renders as a no-op —
-    /// <see cref="MonoGameGum.Renderables.DefaultStrokedCircleRenderable"/> wraps
+    /// <see cref="Gum.Renderables.DefaultStrokedCircleRenderable"/> wraps
     /// <c>LineCircle</c>, which has no AA concept.
     /// </remarks>
     public bool IsAntialiased
@@ -1199,7 +1199,7 @@ public class CircleRuntime : GraphicalUiElement
     /// </summary>
     /// <remarks>
     /// Visual dashing requires the optional MonoGameGumShapes (Apos.Shapes) package; without
-    /// it the stroke slot is <see cref="MonoGameGum.Renderables.DefaultStrokedCircleRenderable"/>
+    /// it the stroke slot is <see cref="Gum.Renderables.DefaultStrokedCircleRenderable"/>
     /// (wraps <c>LineCircle</c>, no dash concept) and this setter is a visual no-op. The
     /// backing field still round-trips so user code is forward-compatible with adding the
     /// package later. Pushed each frame in <see cref="PreRender"/> with the same ScreenPixel

--- a/MonoGameGum/GueDeriving/RectangleRuntime.cs
+++ b/MonoGameGum/GueDeriving/RectangleRuntime.cs
@@ -33,7 +33,7 @@ using ColorExtensions = ToolsUtilitiesStandard.Helpers.ColorExtensions;
 using ContainedLineRectangle = global::RenderingLibrary.Math.Geometry.LineRectangle;
 using global::RenderingLibrary.Math.Geometry;
 using Gum.DataTypes;
-using MonoGameGum.Renderables;
+using Gum.Renderables;
 #endif
 
 #if FRB

--- a/MonoGameGum/Renderables/DefaultFilledRectangleRenderable.cs
+++ b/MonoGameGum/Renderables/DefaultFilledRectangleRenderable.cs
@@ -4,7 +4,11 @@ using RenderingLibrary.Graphics;
 using SysDrawColor = System.Drawing.Color;
 using XnaColor = Microsoft.Xna.Framework.Color;
 
+#if FRB
 namespace MonoGameGum.Renderables;
+#else
+namespace Gum.Renderables;
+#endif
 
 /// <summary>
 /// Core-default <see cref="IFilledRectangleRenderable"/> implementation. Draws as a solid

--- a/MonoGameGum/Renderables/DefaultStrokedCircleRenderable.cs
+++ b/MonoGameGum/Renderables/DefaultStrokedCircleRenderable.cs
@@ -3,7 +3,11 @@ using Gum.GueDeriving;
 using RenderingLibrary.Math.Geometry;
 using XnaColor = Microsoft.Xna.Framework.Color;
 
+#if FRB
 namespace MonoGameGum.Renderables;
+#else
+namespace Gum.Renderables;
+#endif
 
 /// <summary>
 /// Core-default <see cref="IStrokedCircleRenderable"/> implementation. Draws as an outline
@@ -49,8 +53,8 @@ public class DefaultStrokedCircleRenderable : LineCircle, IStrokedCircleRenderab
         // LineCircle.Color is System.Drawing.Color; the interface speaks XNA Color. Convert
         // both directions via the same extensions that CircleRuntime's legacy Color setter
         // historically used.
-        get => RenderingLibrary.Graphics.XNAExtensions.ToXNA(this.Color);
-        set => this.Color = RenderingLibrary.Graphics.XNAExtensions.ToSystemDrawing(value);
+        get => global::RenderingLibrary.Graphics.XNAExtensions.ToXNA(this.Color);
+        set => this.Color = global::RenderingLibrary.Graphics.XNAExtensions.ToSystemDrawing(value);
     }
 
     // Stored but unused: LineCircle has no stroke-width concept. Setting this is intentionally

--- a/MonoGameGum/Renderables/DefaultStrokedRectangleRenderable.cs
+++ b/MonoGameGum/Renderables/DefaultStrokedRectangleRenderable.cs
@@ -4,7 +4,11 @@ using RenderingLibrary.Graphics;
 using RenderingLibrary.Math.Geometry;
 using XnaColor = Microsoft.Xna.Framework.Color;
 
+#if FRB
 namespace MonoGameGum.Renderables;
+#else
+namespace Gum.Renderables;
+#endif
 
 /// <summary>
 /// Core-default <see cref="IStrokedRectangleRenderable"/> implementation. Draws as an outline

--- a/MonoGameGum/Renderables/Shims/DefaultFilledRectangleRenderableShim.cs
+++ b/MonoGameGum/Renderables/Shims/DefaultFilledRectangleRenderableShim.cs
@@ -1,0 +1,15 @@
+#if XNALIKE && !FRB
+using System;
+
+namespace MonoGameGum.Renderables;
+
+/// <summary>
+/// Compatibility shim. The real type lives in <see cref="Gum.Renderables.DefaultFilledRectangleRenderable"/>.
+/// This derived class exists so existing user code with <c>using MonoGameGum.Renderables;</c>
+/// continues to compile during the deprecation window.
+/// </summary>
+[Obsolete("Use Gum.Renderables.DefaultFilledRectangleRenderable instead. The MonoGameGum.Renderables namespace will be removed in a future release.")]
+public class DefaultFilledRectangleRenderable : Gum.Renderables.DefaultFilledRectangleRenderable
+{
+}
+#endif

--- a/MonoGameGum/Renderables/Shims/DefaultStrokedCircleRenderableShim.cs
+++ b/MonoGameGum/Renderables/Shims/DefaultStrokedCircleRenderableShim.cs
@@ -1,0 +1,15 @@
+#if XNALIKE && !FRB
+using System;
+
+namespace MonoGameGum.Renderables;
+
+/// <summary>
+/// Compatibility shim. The real type lives in <see cref="Gum.Renderables.DefaultStrokedCircleRenderable"/>.
+/// This derived class exists so existing user code with <c>using MonoGameGum.Renderables;</c>
+/// continues to compile during the deprecation window.
+/// </summary>
+[Obsolete("Use Gum.Renderables.DefaultStrokedCircleRenderable instead. The MonoGameGum.Renderables namespace will be removed in a future release.")]
+public class DefaultStrokedCircleRenderable : Gum.Renderables.DefaultStrokedCircleRenderable
+{
+}
+#endif

--- a/MonoGameGum/Renderables/Shims/DefaultStrokedRectangleRenderableShim.cs
+++ b/MonoGameGum/Renderables/Shims/DefaultStrokedRectangleRenderableShim.cs
@@ -1,0 +1,15 @@
+#if XNALIKE && !FRB
+using System;
+
+namespace MonoGameGum.Renderables;
+
+/// <summary>
+/// Compatibility shim. The real type lives in <see cref="Gum.Renderables.DefaultStrokedRectangleRenderable"/>.
+/// This derived class exists so existing user code with <c>using MonoGameGum.Renderables;</c>
+/// continues to compile during the deprecation window.
+/// </summary>
+[Obsolete("Use Gum.Renderables.DefaultStrokedRectangleRenderable instead. The MonoGameGum.Renderables namespace will be removed in a future release.")]
+public class DefaultStrokedRectangleRenderable : Gum.Renderables.DefaultStrokedRectangleRenderable
+{
+}
+#endif

--- a/Samples/GumFormsSample/GumFormsSampleCommon/CustomRuntimes/CustomMenuItemRuntime.cs
+++ b/Samples/GumFormsSample/GumFormsSampleCommon/CustomRuntimes/CustomMenuItemRuntime.cs
@@ -1,4 +1,4 @@
-﻿using MonoGameGum.Forms.DefaultVisuals;
+﻿using Gum.Forms.DefaultVisuals;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/Samples/GumFormsSample/GumFormsSampleCommon/CustomRuntimes/SimpleListBoxItemRuntime.cs
+++ b/Samples/GumFormsSample/GumFormsSampleCommon/CustomRuntimes/SimpleListBoxItemRuntime.cs
@@ -1,4 +1,4 @@
-﻿using MonoGameGum.Forms.DefaultVisuals;
+﻿using Gum.Forms.DefaultVisuals;
 using Gum.GueDeriving;
 using System;
 using System.Collections.Generic;

--- a/Samples/GumFormsSample/GumFormsSampleCommon/Screens/FrameworkElementExampleScreen.cs
+++ b/Samples/GumFormsSample/GumFormsSampleCommon/Screens/FrameworkElementExampleScreen.cs
@@ -89,7 +89,7 @@ namespace GumFormsSample.Screens
             CustomMenuItem.Header = "Custom Dropdown";
             var customScrollViewerVisualTemplate = new VisualTemplate(() =>
             {
-                var toReturn = new MonoGameGum.Forms.DefaultVisuals.DefaultScrollViewerRuntime();
+                var toReturn = new Gum.Forms.DefaultVisuals.DefaultScrollViewerRuntime();
                 toReturn.MakeSizedToChildren();
                 var background = toReturn.GetGraphicalUiElementByName("Background")
                     as ColoredRectangleRuntime;
@@ -173,7 +173,7 @@ namespace GumFormsSample.Screens
             stackPanel.AddChild(comboBox);
 
             // We can also create buttons through their visual type:
-            var buttonRuntime = new MonoGameGum.Forms.DefaultVisuals.DefaultButtonRuntime();
+            var buttonRuntime = new Gum.Forms.DefaultVisuals.DefaultButtonRuntime();
             buttonRuntime.Width = 100;
             buttonRuntime.Height = 50;
             buttonRuntime.TextInstance.Text = "Other Button!";

--- a/Samples/GumFormsSample/MonoGameGumFormsSample/StyledButtonRuntime.cs
+++ b/Samples/GumFormsSample/MonoGameGumFormsSample/StyledButtonRuntime.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Xna.Framework;
-using MonoGameGum.Forms.DefaultVisuals;
+using Gum.Forms.DefaultVisuals;
 
 namespace GumFormsSample
 {

--- a/Tests/MonoGameGum.Shapes.Tests/ShapeRendererGateTests.cs
+++ b/Tests/MonoGameGum.Shapes.Tests/ShapeRendererGateTests.cs
@@ -1,6 +1,6 @@
 using Gum.GueDeriving;
 using MonoGameAndGum.Renderables;
-using MonoGameGum.Renderables;
+using Gum.Renderables;
 using RenderingLibrary.Graphics;
 using Shouldly;
 

--- a/Tests/MonoGameGum.Tests.V2/Forms/DefaultVisualShimTypeTests.cs
+++ b/Tests/MonoGameGum.Tests.V2/Forms/DefaultVisualShimTypeTests.cs
@@ -13,7 +13,7 @@ public class DefaultVisualShimTypeTests : BaseTestClass
     [Fact]
     public void V1_DefaultButtonRuntime_TextInstance_ShouldBeShimType()
     {
-        var sut = new MonoGameGum.Forms.DefaultVisuals.DefaultButtonRuntime();
+        var sut = new Gum.Forms.DefaultVisuals.DefaultButtonRuntime();
 #pragma warning disable CS0618
         sut.TextInstance.ShouldBeOfType<MonoGameGum.GueDeriving.TextRuntime>();
 #pragma warning restore CS0618

--- a/docs/gum-tool/upgrading/migrating-to-2026-june.md
+++ b/docs/gum-tool/upgrading/migrating-to-2026-june.md
@@ -111,3 +111,37 @@ The per-platform `GraphicalUiElementExtensionMethods.AddToRoot / RemoveFromRoot`
 ### `MonoGameGum.ElementSaveExtensionMethods.ToGraphicalUiElement` Is Now `[Obsolete]`
 
 A back-compat forwarder in `MonoGameGum.ElementSaveExtensionMethods` now delegates to `Gum.ElementSaveExtensionMethods.ToGraphicalUiElement` and is marked `[Obsolete]`. Existing code keeps compiling with a `CS0618` warning. To migrate, add `using Gum;` and drop `using MonoGameGum;` if it is no longer needed for other symbols.
+
+### More Public Types Moved to the Unified `Gum` Namespace
+
+Continuing the namespace unification, several more public types have moved from `MonoGameGum.*` namespaces to their unified `Gum.*` equivalents so you can drop `using MonoGameGum;` from more of your code. Each is a **soft break**: a permanent `[Obsolete]` shim remains in the old `MonoGameGum.*` namespace, so existing code keeps compiling and produces a `CS0618` warning that names the new namespace.
+
+| Old namespace | New namespace | Types |
+|---|---|---|
+| `MonoGameGum.ExtensionMethods` | `Gum.ExtensionMethods` | `IReadOnlyListExtensionMethods` |
+| `MonoGameGum.Renderables` | `Gum.Renderables` | `DefaultFilledRectangleRenderable`, `DefaultStrokedCircleRenderable`, `DefaultStrokedRectangleRenderable` |
+| `MonoGameGum.Forms.DefaultVisuals` | `Gum.Forms.DefaultVisuals` | `DefaultButtonRuntime`, `DefaultCheckboxRuntime`, … `DefaultWindowRuntime` (all default-visual runtimes) |
+
+To migrate, change the `using` directive:
+
+❌ Old:
+```csharp
+using MonoGameGum.Forms.DefaultVisuals;
+
+// Initialize
+var visual = new DefaultButtonRuntime();
+```
+
+✅ New:
+```csharp
+using Gum.Forms.DefaultVisuals;
+
+// Initialize
+var visual = new DefaultButtonRuntime();
+```
+
+Because the moved type and its shim share a name, importing **both** the new `Gum.*` namespace and the old `MonoGameGum.*` namespace at the same time produces a `CS0104` ambiguity. Remove the old `MonoGameGum.*` `using` directive.
+
+{% hint style="info" %}
+The unified default visuals (for example `Gum.Forms.DefaultVisuals.DefaultButtonRuntime`) still expose their child runtimes — `TextInstance`, `Background`, and so on — as the deprecated `MonoGameGum.GueDeriving` shim types, exactly as before. If you captured those properties into shim-typed variables, that code keeps working unchanged.
+{% endhint %}


### PR DESCRIPTION
## Summary

Continues the `MonoGameGum.*` → `Gum.*` namespace unification (tracking issue #3120) so users can drop `using MonoGameGum;` from more of their code. Three groups moved, all **soft breaks** — each moved type uses the conditional-namespace pattern (`#if FRB` keeps `MonoGameGum.*` for FlatRedBall; `#else` → `Gum.*`) with a permanent `[Obsolete]` shim left in the old namespace, so existing code keeps compiling with a `CS0618` warning naming the new namespace.

| Old namespace | New namespace | Types |
|---|---|---|
| `MonoGameGum.ExtensionMethods` | `Gum.ExtensionMethods` | `IReadOnlyListExtensionMethods` |
| `MonoGameGum.Renderables` | `Gum.Renderables` | `DefaultFilledRectangleRenderable`, `DefaultStrokedCircleRenderable`, `DefaultStrokedRectangleRenderable` |
| `MonoGameGum.Forms.DefaultVisuals` | `Gum.Forms.DefaultVisuals` | the 17 `Default*Runtime` classes (`DefaultButtonRuntime` … `DefaultWindowRuntime`) |

## Notes / decisions

- **No syntax-version bump** — none of these types are emitted by the code generator, so the runtime syntax version is unchanged.
- **GueDeriving shim usage deliberately preserved.** The default visuals keep referencing the deprecated `MonoGameGum.GueDeriving` shim *types* internally (pragma kept) so they still expose shim-typed child runtimes (`TextInstance`, `Background`, …) per the #2715 back-compat contract. Repointing those `using`s to `Gum.GueDeriving` would have changed those runtime types and broken `DefaultVisualShimTypeTests` — so it was intentionally **not** done.
- **`DefaultMenuRuntime`** is `internal` (no public shim). **`DefaultTextBoxBaseRuntime`** is `public abstract` (abstract shim).
- Moving into `Gum.*` required `global::`-qualifying a few `RenderingLibrary.*` refs (to avoid `Gum.RenderingLibrary` shadowing) and dropping a legacy `using MonoGameGum;` from `DefaultWindowRuntime` (its `AddChild` is a compat forwarder to the real `Gum.Forms.Controls.FrameworkElementExt.AddChild`) to resolve a `CS0121` ambiguity. Internal/sample/test consumers were repointed.

## Deferred

The `MonoGameGum.Input` group is **not** in this PR. `Gum.Input.GamePad` / `AnalogStick` already exist in GumRuntime as platform-neutral types, so the XNA-specific MonoGame `GamePad`/`AnalogStick` can't move (name collision), and `Keyboard`/`AnalogButton` are entangled with them in shared consumer files. That work is tracked in #3137.

## Verification

- `MonoGameGum.Tests`: **1706 passed**, 0 failed (incl. `DefaultVisualShimTypeTests` #2715 contract).
- Built clean: `MonoGameGum`/`GumCommon`, `RaylibGum`, `SkiaGum`, `KniGum`. (`FnaGum` not buildable in this environment — FNA submodule absent.)
- No new compiler warnings (verified against a clean rebuild).

Closes #3120. The remaining input group is tracked separately in #3137.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

