### PR TITLE
#105: Document rotating/scaling clipped contents via render-target Sprite

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -28,6 +28,7 @@
     * [Custom NineSlice](gum-tool/tutorials-and-examples/examples/custom-nineslice.md)
     * [Health Bar](gum-tool/tutorials-and-examples/examples/health-bar.md)
     * [Padding](gum-tool/tutorials-and-examples/examples/padding.md)
+    * [Rotating and Scaling Clipped Contents](gum-tool/tutorials-and-examples/examples/rotating-and-scaling-clipped-contents.md)
     * [Silhouette (Solid Colored Sprite)](gum-tool/tutorials-and-examples/examples/silhouette-solid-colored-sprite.md)
 * [Gum Elements](gum-tool/gum-elements/README.md)
   * [General Properties](gum-tool/gum-elements/general-properties/README.md)

--- a/docs/code/standard-visuals/spriteruntime/rendertargettexturesource.md
+++ b/docs/code/standard-visuals/spriteruntime/rendertargettexturesource.md
@@ -4,6 +4,10 @@
 
 The RenderTargetTextureSource property allows a Sprite to render a texture produced by a different ContainerRuntime which is drawing to a render target. This feature allows a render target to be scaled, rotated, positioned, stacked, or to use any other Gum layout functionality.
 
+{% hint style="info" %}
+To set up this same pattern in the Gum tool, see [Rotating and Scaling Clipped Contents](../../../gum-tool/tutorials-and-examples/examples/rotating-and-scaling-clipped-contents.md).
+{% endhint %}
+
 ## RenderTargetTextureSource Requirements
 
 To use RenderTargetTextureSource, the following must exist:

--- a/docs/gum-tool/gum-elements/container/is-render-target.md
+++ b/docs/gum-tool/gum-elements/container/is-render-target.md
@@ -30,5 +30,5 @@ Once a container is rendered to a render target, additional special effects can 
 * Rotating
 * Rendering portions using texture coordinates
 
-For more information see the [SpriteRuntime RenderTargetTextureSource](../../../code/standard-visuals/spriteruntime/rendertargettexturesource.md) documentation.
+For a step-by-step tool walkthrough of rotating and scaling a clipped container, see [Rotating and Scaling Clipped Contents](../../tutorials-and-examples/examples/rotating-and-scaling-clipped-contents.md). For the same pattern in code, see the [SpriteRuntime RenderTargetTextureSource](../../../code/standard-visuals/spriteruntime/rendertargettexturesource.md) documentation.
 

--- a/docs/gum-tool/gum-elements/general-properties/clips-children.md
+++ b/docs/gum-tool/gum-elements/general-properties/clips-children.md
@@ -5,3 +5,5 @@ The `Clips Children` property controls whether children of a component or contai
 ![Clips Children set to true prevents children from rendering outside of the container's bounds](<../../../.gitbook/assets/16_05 41 09.gif>)
 
 Children outside of the bounds of a container with Clips Children set to true can also be clipped by setting a container's [Is Render Target](../container/is-render-target.md) value to true.
+
+The clip region is always axis-aligned, so rotating a container that clips its children leaves the clip region unrotated. To rotate a container *and* keep its contents clipped, see [Rotating and Scaling Clipped Contents](../../tutorials-and-examples/examples/rotating-and-scaling-clipped-contents.md).

--- a/docs/gum-tool/gum-elements/general-properties/rotation.md
+++ b/docs/gum-tool/gum-elements/general-properties/rotation.md
@@ -23,3 +23,7 @@ Holding the SHIFT key snaps angles to 15 degree increments.
 The [X Origin](x-origin.md) and [Y Origin](y-origin.md) properties define the point of rotation for an object. The following animation shows how changing origin values can affect rotation.
 
 ![Objects rotate about their origin.](<../../../.gitbook/assets/16_08 14 23.gif>)
+
+{% hint style="info" %}
+Rotation does not rotate the clip region of a container that clips its children, so rotating a container with [Clips Children](clips-children.md) set to `true` will look broken. To rotate a container *and* keep its contents clipped, see [Rotating and Scaling Clipped Contents](../../tutorials-and-examples/examples/rotating-and-scaling-clipped-contents.md).
+{% endhint %}

--- a/docs/gum-tool/tutorials-and-examples/examples/rotating-and-scaling-clipped-contents.md
+++ b/docs/gum-tool/tutorials-and-examples/examples/rotating-and-scaling-clipped-contents.md
@@ -1,0 +1,46 @@
+# Rotating and Scaling Clipped Contents
+
+## Introduction
+
+The [Clips Children](../../gum-elements/general-properties/clips-children.md) and [Is Render Target](../../gum-elements/container/is-render-target.md) properties clip their children to an axis-aligned rectangle. Because the clip region stays aligned to the screen, rotating a container that clips its children leaves the clip region unrotated, so the result looks broken.
+
+To rotate (or scale) a container *and* keep its contents clipped, you render the container to a render target and display that render target through a `Sprite`. The `Sprite` can then be rotated, scaled, positioned, and stacked like any other Gum object, and the clipping rotates along with it.
+
+{% hint style="warning" %}
+**Image placeholder:** Animated gif showing a container with `Clips Children` set to `true` being rotated, with the clip region staying axis-aligned (the broken result).
+{% endhint %}
+
+## The Two-Object Pattern
+
+This effect uses two objects:
+
+1. A **Container** with **Is Render Target** set to `true`. This container holds the content you want to clip, and it clips its children automatically.
+2. A **Sprite** with its **Render Target Texture Source** set to the container above. The `Sprite` displays the container's render target and can be freely rotated and scaled.
+
+{% hint style="warning" %}
+**Image placeholder:** Screenshot of the project tree showing the render target Container and the Sprite that references it.
+{% endhint %}
+
+## Step by Step
+
+1. Create a **Container** and add the children you want to clip and rotate.
+2. Select the **Container** and set its **Is Render Target** value to `true`. Its children are now clipped to the container's bounds.
+3. Create a **Sprite**.
+4. Select the **Sprite** and set its **Render Target Texture Source** value to the container created in step 1. The dropdown lists all containers in the current element that have **Is Render Target** set to `true`.
+5. Set the **Sprite**'s [Rotation](../../gum-elements/general-properties/rotation.md) (and optionally its `Width` and `Height`) to rotate and scale the clipped contents.
+
+{% hint style="warning" %}
+**Image placeholder:** Animated gif showing the **Render Target Texture Source** dropdown being assigned and the resulting Sprite being rotated, with the clipped contents rotating correctly.
+{% endhint %}
+
+## Notes
+
+* A container with **Is Render Target** set to `true` performs its layout and rendering even when its `Visible` value is `false`. Set the source container's `Visible` to `false` to hide the original while still displaying it through the `Sprite`.
+* Children inside the render target container are not interactive while displayed through the `Sprite`, because input is handled by the original (invisible) container rather than the rotated `Sprite`.
+
+## See Also
+
+* [Clips Children](../../gum-elements/general-properties/clips-children.md)
+* [Rotation](../../gum-elements/general-properties/rotation.md)
+* [Is Render Target](../../gum-elements/container/is-render-target.md)
+* [RenderTargetTextureSource](../../../code/standard-visuals/spriteruntime/rendertargettexturesource.md) — the same pattern in code


### PR DESCRIPTION
## Summary

Documents the two-object pattern for rotating/scaling a container whose children are clipped, addressing the discoverability gap behind #105 (rotating a `Clips Children` container leaves the clip region axis-aligned, so it looks broken).

The pattern: a **Container** with **Is Render Target** = `true` (clips its children), displayed through a **Sprite** whose **Render Target Texture Source** points at that container. The Sprite can then be rotated/scaled freely and the clipping rotates with it.

## Changes (docs only)

- **New central home:** `docs/gum-tool/tutorials-and-examples/examples/rotating-and-scaling-clipped-contents.md` — tool-side walkthrough of the pattern, framed around the actual problem. Added to `SUMMARY.md` under **Examples**.
- **Cross-references** added so users hitting the limitation can find the solution:
  - `Rotation` → hint linking to the Example
  - `Clips Children` → note + link
  - `Is Render Target` → its Special Effects section now links to the Example (tool) alongside the existing code link
  - code `RenderTargetTextureSource` → links back to the tool Example

## Notes

- Image placeholders (3) are marked with visible warning-hint blocks for the maintainer to fill after merge.
- This documents the **workaround**, so it references but does **not** close #105 — the underlying request (native rotation of clipped children) remains open.
- Corrected a stale assumption from the issue thread: the tool now exposes `Render Target Texture Source` (via the render-target-container dropdown), so this is a real tool workflow, not code-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Refs #105
