### PR TITLE
Fix FRB build: gate ModalRoot modal tab-trapping under #if !FRB (+ frb-build-verification skill)

### DIFF
--- a/.claude/skills/frb-build-verification/SKILL.md
+++ b/.claude/skills/frb-build-verification/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: frb-build-verification
+description: Verify FlatRedBall (FRB1) still compiles after editing Gum source it shares. Triggers: changes under GumCommon/ or MonoGameGum/Forms/, projitems sync, the FRB compile constant, CS0246/CS0103 from FRB. Only when a FlatRedBall checkout sits beside the Gum repo.
+---
+
+# FRB Build Verification
+
+FRB1 (FlatRedBall) compiles Gum **source** (not the DLLs) under a `net6.0` target with the `FRB` constant defined, via shared `.projitems`. A change that builds fine in the Gum solutions can still break FRB1 — so when you touch shared source, build an FRB canary.
+
+The projitems-sync rules (which files FRB1 pulls, and what to update when you add/rename/delete) live in `.claude/agents/coder.md` — read that, don't duplicate it here. This skill is only about **running the build**.
+
+## Precondition — skip entirely if absent
+
+This is only doable when a **FlatRedBall checkout exists as a sibling of the Gum repo** (i.e. `<gum-repo>/../FlatRedBall/`). The cross-repo csproj imports are sibling-relative (`..\..\..\..\FlatRedBall\…`), so without that layout the build can't resolve. If the sibling is absent, **skip FRB verification and say so** — it is not a failure; the maintainer/CI covers it. Do not hardcode an absolute path; check for the sibling.
+
+## Must run from the PRIMARY checkout, never a worktree
+
+The sibling-relative imports are computed from the csproj location, and the FlatRedBall-side csprojs pull Gum source by relative path into the **primary** Gum checkout (`…\Gum\MonoGameGum\…`). A worktree under `.claude/worktrees/<branch>/` is both nested too deep (so `..\..\..\..\FlatRedBall` resolves to nothing — `MSB4019`) and not the path FRB compiles from. To FRB-verify a branch, **check that branch out in the primary Gum checkout** and build there. Worktrees cannot FRB-verify.
+
+## Canaries
+
+Pick by what you changed. Build from the primary Gum checkout (first row) / the sibling FlatRedBall repo (second row).
+
+| Changed source | Build target | Covers |
+|---|---|---|
+| `GumCommon/` (anything in `GumCoreShared.projitems`) | `GumCore/GumCoreXnaPc/GumCore.DesktopGlNet6/GumCore.DesktopGlNet6.csproj` | GumCommon shared into FRB |
+| `MonoGameGum/Forms/` (in `FlatRedBall.Forms.Shared.projitems`) | `<FlatRedBall>/Engines/Forms/FlatRedBall.Forms/FlatRedBall.Forms.DesktopGlNet6/FlatRedBall.Forms.DesktopGlNet6.csproj` | Forms shared into FRB |
+
+`GueDeriving/*Runtime`, `MonoGameGum/Renderables/`, `MonoGameGum/ExtensionMethods/`, and the `Forms/DefaultVisuals/` runtimes are **not** compiled by FRB1 (it generates its own) — changing only those needs no FRB build.
+
+## Interpreting results — baseline first
+
+`main` is sometimes already red under FRB (e.g. a shared file gained a member that lives behind `#if !FRB`, or the FRB-side projitems is out of sync). So **build the base branch first to capture the baseline errors, then build your branch and attribute only the *new* errors**. A pre-existing error that survives on both is not yours to fix here (flag it separately).
+
+Common genuinely-new breaks: a shared method/property guarded by `#if !FRB` referenced from un-guarded code (`CS0103`/`CS0246`), a `.cs` file added/renamed/deleted without updating the FRB-side projitems, or a `net7.0+` BCL API used in shared source without an `#if NET7_0_OR_GREATER` gate (FRB multi-targets down to `net6.0`).

--- a/MonoGameGum/Forms/Controls/FrameworkElement.cs
+++ b/MonoGameGum/Forms/Controls/FrameworkElement.cs
@@ -1401,6 +1401,7 @@ public class FrameworkElement : INotifyPropertyChanged
                     if(!isDominant)
 #endif
                     {
+#if !FRB
                         if (IsTopMostModal(parentVisual))
                         {
                             // The top-most modal traps tab focus: rather than climbing out to
@@ -1412,7 +1413,9 @@ public class FrameworkElement : INotifyPropertyChanged
                                 didFocusNewItem = HandleTab(tabDirection, null, parentVisual, shouldAskParent: false, loop: false);
                             }
                         }
-                        else if (parentVisual?.Parent != null)
+                        else
+#endif
+                        if (parentVisual?.Parent != null)
                         {
                             var grandparentVisual = parentVisual.Parent as InteractiveGue;
                             didFocusNewItem = HandleTab(tabDirection, parentVisual, grandparentVisual, shouldAskParent: true, loop:loop);
@@ -1463,6 +1466,7 @@ public class FrameworkElement : INotifyPropertyChanged
                     element.GamepadTabbingFocusBehavior == TabbingFocusBehavior.FocusableIfInputReceiver;
     }
 
+#if !FRB
     /// <summary>
     /// Returns whether the argument visual is the top-most (active) modal — the last visible direct
     /// child of <see cref="ModalRoot"/>. Tab focus is trapped within this element so that keyboard
@@ -1495,6 +1499,7 @@ public class FrameworkElement : INotifyPropertyChanged
 
         return false;
     }
+#endif
 
     #endregion
 


### PR DESCRIPTION
## Summary

Fixes the FlatRedBall (FRB1) build of shared Gum Forms source, and adds a skill documenting how to FRB-verify going forward.

## The bug

`FrameworkElement.ModalRoot` / `PopupRoot` are defined behind `#if !FRB` (FRB supplies its own modal handling via `GuiManager.DominantWindows`). The newer modal tab-trapping helper `IsTopMostModal` — and its call site in the tab-navigation logic — referenced `ModalRoot` **unconditionally**. Since `FrameworkElement.cs` is compiled from source into `FlatRedBall.Forms` (via `FlatRedBall.Forms.Shared.projitems`), the FRB build failed:

```
error CS0103: The name 'ModalRoot' does not exist in the current context
  MonoGameGum/Forms/Controls/FrameworkElement.cs(1474,25)
```

(`ListBox.cs` already gates its `ModalRoot` use under `#if !FRB`; this was the one site that didn't.)

## The fix

Gate `IsTopMostModal` and its call site under `#if !FRB`. Under FRB the tab logic falls through to the existing parent-climb path (no modal trapping — consistent with FRB's `DominantWindows` model). **The non-FRB build and behavior are byte-identical** — this is a preprocessor-only change.

## Verification

- Normal `MonoGameGum` build: green. Forms / focus-tab-navigation tests: **582 passed**, 0 failed.
- `FlatRedBall.Forms.DesktopGlNet6` (FRB, `net6.0`/`net8.0`): **was red on `main`, now builds green**.

## Also included: `frb-build-verification` skill

Documents how to compile-check FRB after touching shared Gum source — the two canary csprojs (`GumCore.DesktopGlNet6` for `GumCommon/`, `FlatRedBall.Forms.DesktopGlNet6` for `MonoGameGum/Forms/`), the sibling-checkout precondition (skip cleanly if absent so contributors without FRB aren't blocked), why it must run from the **primary** checkout rather than a worktree, and baseline-comparing errors since `main` can already be red.

Found while adding FRB verification for the namespace-unification work in #3138.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
