### PR TITLE
#3140: Add Version 3 section to 'Upgrading File (GUMX) Version' doc

### DIFF
--- a/docs/gum-tool/upgrading/upgrading-file-gumx-version.md
+++ b/docs/gum-tool/upgrading/upgrading-file-gumx-version.md
@@ -73,3 +73,19 @@ The savings are both in file size, but also in line number which makes comparing
 * SplashScreenGum Screen: 63 -> 37 lines
 * PlayerHud Component: 2646 -> 1309 lines
 * Circle Standard Element File: 165 -> 72 lines
+
+## Version 3
+
+**Required Gum Tool Version**: 2026 May (or later)
+
+This version unlocks the expanded **Circle** and **Rectangle** shape variables — fill, gradient, drop shadow, stroke-and-fill, and antialiasing — along with the Circle `Radius` -> `Width`/`Height` change. The tool only shows these new variable categories for projects at version 3 or later, so a project still at version 2 keeps the new shape variables hidden even on a tool build that supports them.
+
+✅No manual changes are needed to your project beyond changing the version number.
+
+Unlike Version 2, which is a real XML-format change requiring a **File** -> **Save All** to rewrite every file, Version 3 uses the **same XML format** as Version 2. The version bump exists only to unlock the new variable surface and to make older tool builds refuse the file rather than silently dropping the new variables on the next save. There is **no format conversion or Save All step** — you only change the `<Version>` number.
+
+❗Be sure that your entire team is using the new version of Gum (2026 May or later) before making this upgrade. As with Version 2, mixing tool versions across a team can produce a "hybrid" file which can break a project.
+
+{% hint style="info" %}
+New projects created with the 2026 May tool (or later) are stamped Version 3 automatically. Only projects created before this release need the manual bump.
+{% endhint %}


### PR DESCRIPTION
## Summary

Adds a **Version 3** section to `docs/gum-tool/upgrading/upgrading-file-gumx-version.md`, which previously documented only Version 1 and Version 2.

Version 3 (`GumxVersions.ShapeVariableExpansion = 3`) is the gate that unlocks the expanded Circle/Rectangle shape variable surface (fill, gradient, drop shadow, stroke-and-fill, antialiasing) plus the Circle `Radius` → `Width`/`Height` change. A pre-existing v1/v2 project had no instructions telling the user how or why to bump to v3.

## What the new section covers

- **Required Gum Tool Version**: 2026 May (or later).
- **What it unlocks**: the new Circle/Rectangle shape variable categories, which the tool only shows for v3+ projects.
- **Key difference from V2**: V3 uses the *same* XML format as V2 — the bump only unlocks the new variable surface and makes older tool builds refuse the file rather than silently dropping new variables on save. So there is **no format conversion / Save All step**, just changing the `<Version>` number.
- **Team-coordination caveat**: get the whole team on a 2026 May+ tool before bumping, to avoid hybrid files (mirrors the V2 guidance).
- A dated `{% hint %}` noting new projects are stamped v3 automatically.

No SUMMARY.md change is needed — the page is already in the nav.

Closes #3140

🤖 Generated with [Claude Code](https://claude.com/claude-code)
