### PR TITLE
#3141: Stamp NativeVersion on runtime snapshot export (.gumx)

### DIFF
--- a/MonoGameGum.Tests/Wireframe/RuntimeSnapshotSerializerProjectTests.cs
+++ b/MonoGameGum.Tests/Wireframe/RuntimeSnapshotSerializerProjectTests.cs
@@ -195,6 +195,30 @@ public class RuntimeSnapshotSerializerProjectTests : BaseTestClass
     }
 
     [Fact]
+    public void ExportSnapshot_ShouldStampNativeVersion()
+    {
+        // A snapshot seeds the full default standards (the v3 shape variable surface), so it genuinely
+        // uses native-version features and must stamp NativeVersion -- not the older ctor default, which
+        // would make the tool's variable-grid version gate hide the new Circle/Rectangle shape variables.
+        string tempDirectory = NewTempDirectory();
+        try
+        {
+            GumService service = new();
+            service.Root.AddChild(new ContainerRuntime { Name = "Panel" });
+
+            string gumxPath = Path.Combine(tempDirectory, "Live." + GumProjectSave.ProjectExtension);
+            service.ExportSnapshot(gumxPath);
+
+            GumProjectSave loaded = GumProjectSave.Load(gumxPath, out _);
+            loaded.Version.ShouldBe(GumProjectSave.NativeVersion);
+        }
+        finally
+        {
+            DeleteTempDirectory(tempDirectory);
+        }
+    }
+
+    [Fact]
     public void ExportSnapshot_ShouldSetCanvasSizeFromRuntimeCanvas()
     {
         // The exported project's resolution should match the live canvas (the game's resolution), not

--- a/MonoGameGum/GumService.cs
+++ b/MonoGameGum/GumService.cs
@@ -367,6 +367,12 @@ public class GumService : IGumService
         ScreenSave screen = serializer.CreateScreenSave(Root, screenName, shake);
 
         GumProjectSave project = new();
+        // A snapshot seeds the full default standards (the current native variable surface), so it
+        // genuinely uses native-version features. Stamp NativeVersion explicitly -- the ctor default is
+        // the older fallback for legacy files lacking a <Version>, which would make the tool's
+        // variable-grid version gate hide the newer-only (v3 shape) variables. Matches the new-project
+        // factories (ProjectManager.CreateNewProject, ProjectCreator.Create).
+        project.Version = GumProjectSave.NativeVersion;
         StandardElementsManager.Self.PopulateProjectWithDefaultStandards(project);
 
         // Match the project's canvas resolution to the live canvas (the game's resolution) so the


### PR DESCRIPTION
## Summary

`GumService.ExportSnapshot` built a `GumProjectSave` and relied on the constructor's `Version` default (`AttributeVersion` = 2). That default is the correct fallback for *deserialized legacy files* that lack a `<Version>` element, but a freshly-built snapshot seeds the full default standards via `PopulateProjectWithDefaultStandards` — including the v3 shape variable surface — so it genuinely uses v3 features.

As a result, opening an exported snapshot in the Gum tool hid the new Circle/Rectangle shape variable categories (fill, gradient, drop shadow, stroke, antialiasing) behind the variable-grid version gate.

## Fix

Stamp `project.Version = GumProjectSave.NativeVersion` right after constructing the project, matching the new-project factories (`ProjectManager.CreateNewProject`, `ProjectCreator.Create`). Using `NativeVersion` rather than a hard-coded `3` tracks future bumps automatically.

## Tests (TDD)

Added `ExportSnapshot_ShouldStampNativeVersion` to `RuntimeSnapshotSerializerProjectTests`. Verified red first (`Version` was 2, expected 3), green after the fix. Full snapshot test class (10 tests, incl. the gumcli `check` integration tests) passes.

Closes #3141

🤖 Generated with [Claude Code](https://claude.com/claude-code)
