### PR TITLE
#3136: Add 'Using Gum with AI' docs section

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -415,6 +415,13 @@
   * [screenshot](cli/screenshot.md)
   * [svg](cli/svg.md)
 
+## Using Gum with AI
+
+* [Using Gum with AI](ai/README.md)
+  * [MCP Documentation Server](ai/mcp-server.md)
+  * [GumCli for Agents](ai/gumcli-for-agents.md)
+  * [AI Skills](ai/ai-skills.md)
+
 ## Contributing
 
 * [Contributing](contributing/README.md)

--- a/docs/ai/README.md
+++ b/docs/ai/README.md
@@ -1,0 +1,23 @@
+# Using Gum with AI
+
+If you build game UI with the help of an AI assistant — such as Claude Code, Cursor, GitHub Copilot, or any other LLM-based coding tool — Gum gives your assistant several ways to produce correct, up-to-date output instead of relying on whatever it happened to learn during training.
+
+This section is the single home for that story. It is aimed at **developers using an AI assistant to build a Gum UI**, not at contributors working on Gum itself.
+
+## Why this matters
+
+Game UI frameworks change, and an AI assistant's training data is always somewhat stale. Left on its own, an assistant will guess at file formats, invent properties that do not exist, and produce layout that does not behave the way you expect. Gum closes that gap with three complementary pieces:
+
+* A **live documentation server** your assistant can query on demand, so its answers come from the current docs rather than memory.
+* A **command-line tool** (`gumcli`) the assistant can drive to generate code, validate projects, and render screenshots to verify its own work.
+* A set of **drop-in skills** that give the assistant concept-level guidance on how Gum projects are structured.
+
+## The pieces
+
+* [MCP Documentation Server](mcp-server.md) — connect your AI assistant directly to Gum's documentation so it can search and read authoritative guidance live.
+* [GumCli for Agents](gumcli-for-agents.md) — a recipe-oriented walkthrough of the commands an agent uses most: generating code, checking for errors, and capturing screenshots for self-verification.
+* [AI Skills](ai-skills.md) — reusable, consumer-facing skills you can drop into your project so your assistant understands Gum's file formats, layout system, and Forms controls.
+
+{% hint style="info" %}
+These pieces are complementary, not exclusive. The MCP server keeps your assistant's knowledge current, the skills give it durable context that loads automatically, and `gumcli` lets it act on a project and check the result.
+{% endhint %}

--- a/docs/ai/ai-skills.md
+++ b/docs/ai/ai-skills.md
@@ -1,0 +1,25 @@
+# AI Skills
+
+A **skill** is a small, self-contained document that teaches an AI assistant how to work in a particular area. Tools such as Claude Code load a skill automatically when its description matches what you are doing, giving the assistant durable, concept-level context it would otherwise lack — for example, how Gum's file formats are structured, how the layout system behaves, or when to reach for a Forms control versus a raw visual.
+
+Gum ships a set of **consumer-facing skills** you can drop into your own project so your assistant understands Gum without you having to explain it every time.
+
+## Getting the skills
+
+The skills live in the [`gum-skills/`](https://github.com/vchelaru/Gum/tree/main/gum-skills) folder of the Gum repository. To use them, copy the skills you want into your project's `.claude/skills/` folder (or your machine-wide `~/.claude/skills/` folder so they apply everywhere).
+
+A good starting set is the overview skill plus whichever topical skills match your work — for example layout, Forms controls, and the file format. Each skill is a folder containing a `SKILL.md` file with the standard frontmatter your assistant uses to decide when the skill is relevant.
+
+{% hint style="info" %}
+The `gum-skills/` folder is being populated incrementally. If a skill you expect is not there yet, check the folder for the current set. These consumer skills are distinct from the engine-internal skills under Gum's own `.claude/skills/`, which describe how to work *on* Gum rather than *with* it.
+{% endhint %}
+
+## Skills, the MCP server, and GumCli
+
+The three AI pieces reinforce each other:
+
+* **Skills** give your assistant durable context that loads automatically and shapes *what* it writes.
+* The [MCP Documentation Server](mcp-server.md) lets it look up authoritative, current details on demand.
+* [GumCli](gumcli-for-agents.md) lets it generate code, validate the project, and verify the result.
+
+Using all three together gives an assistant the best chance of producing correct Gum UI on the first try.

--- a/docs/ai/gumcli-for-agents.md
+++ b/docs/ai/gumcli-for-agents.md
@@ -1,0 +1,53 @@
+# GumCli for Agents
+
+[GumCli](../cli/README.md) (`gumcli`) is a cross-platform command-line tool for working with Gum projects without opening the editor. Because it is scriptable, has machine-readable output, and reports meaningful exit codes, it is the primary way an AI agent acts on a Gum project and verifies its own work.
+
+This page is a recipe-oriented tour from an agent-workflow angle. For the full reference on each command, follow the links into the [CLI](../cli/README.md) section.
+
+## Installation
+
+`gumcli` installs as a .NET global tool:
+
+```
+dotnet tool install -g GumCli
+```
+
+## Why it works well for agents
+
+* **Machine-readable output** — command results (JSON, file paths, summaries) go to **stdout**, while banners and progress chatter go to **stderr**. An agent can consume stdout directly, for example `gumcli check MyProject.gumx --json`.
+* **Meaningful exit codes** — `0` for success, `1` for errors found, `2` for a project that could not be loaded or invalid arguments. An agent can branch on the exit code instead of parsing prose.
+* **No editor required** — everything runs headless, so it fits an automated edit → validate → verify loop.
+
+## The agent loop
+
+A typical agent workflow for building or modifying a Gum UI follows three stages.
+
+### 1. Generate code
+
+If the project uses code generation, initialize the settings once, then generate strongly-typed C# for the project's screens and components. This eliminates magic strings and lets the agent reference UI elements by name.
+
+* [`codegen-init`](../cli/codegen-init.md) — write the code-generation settings into the project.
+* [`codegen`](../cli/codegen.md) — generate C# for the project's elements.
+
+### 2. Validate
+
+After editing project XML — whether by hand, with custom tooling, or via an assistant — validate it before trusting it. `check` catches the silent mistakes that are easy for an agent to make, such as misspelled element names that Gum would otherwise drop without error.
+
+* [`check`](../cli/check.md) — validate a project and report errors. A non-zero exit code tells the agent to stop and fix the problem before continuing.
+
+### 3. Verify visually
+
+Generated code that compiles is not proof the UI looks right. Rendering the result to an image gives the agent something concrete to inspect — and, with a multimodal model, to actually "see."
+
+* [`screenshot`](../cli/screenshot.md) — render a Screen or Component to a PNG. An agent can open the PNG to confirm the layout matches intent.
+* [`svg`](../cli/svg.md) — render to SVG when a vector format is preferred.
+
+## Supporting commands
+
+* [`new`](../cli/new.md) — scaffold a new Gum project.
+* [`fonts`](../cli/fonts.md) — generate missing bitmap font files referenced by the project.
+* [`pack`](../cli/pack.md) — bundle a project into a single `.gumpkg` file.
+
+{% hint style="info" %}
+Pair `gumcli` with the [MCP Documentation Server](mcp-server.md) so your assistant can look up how a command or property works while it drives the project, and with the [AI Skills](ai-skills.md) so it understands the file formats it is editing.
+{% endhint %}

--- a/docs/ai/mcp-server.md
+++ b/docs/ai/mcp-server.md
@@ -1,0 +1,66 @@
+# MCP Documentation Server
+
+Gum's documentation is available to AI assistants through a hosted **MCP server**. Connecting your assistant to it lets the assistant search and read the current Gum docs on demand, so its answers reflect the latest guidance instead of stale training data.
+
+## What is MCP?
+
+The **Model Context Protocol (MCP)** is an open standard that lets AI assistants connect to external tools and data sources. An MCP server exposes a set of capabilities — in this case, searching and fetching documentation pages — that a compatible assistant can call while it works.
+
+Most modern AI coding tools support MCP, including Claude Code, Claude Desktop, Cursor, and VS Code.
+
+## Endpoint
+
+The Gum documentation MCP server is hosted at:
+
+```
+https://docs.flatredball.com/gum/~gitbook/mcp
+```
+
+It exposes tools to **search** the documentation and **fetch** individual pages, so your assistant can look up authoritative answers about layout units, Forms controls, code generation, the file formats, and everything else covered in these docs.
+
+## Connecting your assistant
+
+### Claude Code
+
+Add the server from your terminal:
+
+```
+claude mcp add --transport http gum-docs https://docs.flatredball.com/gum/~gitbook/mcp
+```
+
+Once added, your assistant can query the Gum docs during any session. Use `claude mcp list` to confirm it is connected.
+
+### Cursor, VS Code, Claude Desktop, and other clients
+
+Most clients are configured with an `mcpServers` block in a JSON settings file. Add an entry pointing at the endpoint:
+
+```json
+{
+  "mcpServers": {
+    "gum-docs": {
+      "url": "https://docs.flatredball.com/gum/~gitbook/mcp"
+    }
+  }
+}
+```
+
+The exact file location and field names vary by client — check your tool's MCP documentation for where this config lives. Some clients label the remote-HTTP transport explicitly (for example with a `"type": "http"` field).
+
+{% hint style="info" %}
+A few clients can only launch MCP servers as local processes (stdio transport) and cannot connect to a remote URL directly. For those, bridge to the hosted server with [`mcp-remote`](https://www.npmjs.com/package/mcp-remote):
+
+```json
+{
+  "mcpServers": {
+    "gum-docs": {
+      "command": "npx",
+      "args": ["-y", "mcp-remote", "https://docs.flatredball.com/gum/~gitbook/mcp"]
+    }
+  }
+}
+```
+{% endhint %}
+
+## Using it
+
+Once connected, you do not need to do anything special — just ask your assistant Gum questions as usual. When it needs authoritative information, it can search and read the docs through the server rather than guessing. For tasks that involve writing or generating code, pair this with [GumCli for Agents](gumcli-for-agents.md) so the assistant can also act on a project and verify the result.


### PR DESCRIPTION
## What

Adds a new 5th top-level **"Using Gum with AI"** section to `docs/SUMMARY.md`, alongside Gum Tool / Code / CLI / Contributing. This gives a developer asking *"how do I use Gum with my AI assistant?"* a discoverable home, tying together the AI story that was previously scattered across CLI pages and tribal knowledge.

## Pages added (`docs/ai/`)

- **`README.md` — Overview / landing page.** The orientation page for the section: what the AI story is and a hub linking the three pieces below.
- **`mcp-server.md` — MCP Documentation Server.** Documents the **already-live** GitBook-hosted MCP endpoint (`https://docs.flatredball.com/gum/~gitbook/mcp`) and how to connect Claude Code, Cursor, VS Code, and other clients (including the `mcp-remote` bridge for stdio-only clients).
- **`gumcli-for-agents.md` — GumCli for Agents.** A recipe-oriented page framing the existing [CLI](../cli/README.md) from an agent **edit → validate → verify** workflow angle (`codegen-init`/`codegen`, `check`, `screenshot`).
- **`ai-skills.md` — AI Skills.** Surfaces the consumer-facing `gum-skills/` folder (#2700) and explains how to drop skills into `.claude/skills/`.

## Notes on scope / DoD

The epic's MCP docs server deliverable is satisfied by the **existing GitBook-hosted MCP server** rather than a new build — so no MCP server child issue is filed; the docs now point users at the live endpoint.

`gum-skills/` (#2700) is not yet shipped, so the AI Skills page links the GitHub folder forward and notes (in a hint block) that it is being populated incrementally. The skills themselves remain owned by #2700/#2704, not duplicated here.

Per the epic's "this is an epic, not a perma-tracker" guidance, future AI pages/skills/tools should each get their own focused issue.

Closes #3136

🤖 Generated with [Claude Code](https://claude.com/claude-code)
