### PR TITLE
#3039: Defer Raylib font loading under IsAllLayoutSuspended (converge deferral guard with MonoGame copy)

### DIFF
--- a/Runtimes/RaylibGum/Renderables/CustomSetPropertyOnRenderable.cs
+++ b/Runtimes/RaylibGum/Renderables/CustomSetPropertyOnRenderable.cs
@@ -572,6 +572,41 @@ public class CustomSetPropertyOnRenderable
 
     public static void UpdateToFontValues(IText text, GraphicalUiElement graphicalUiElement)
     {
+        // Font deferred-loading system
+        //
+        // This method is the set-by-string path for font properties (Font, FontSize, IsBold, etc.)
+        // reached via SetProperty -> SetPropertyOnRenderable -> TrySetPropertyOnText.
+        // The direct-property-setter path goes through GraphicalUiElement.UpdateToFontValues() instead.
+        //
+        // KNOWN GAP: the two paths handle suspension differently:
+        //   - GUE.UpdateToFontValues() defers for BOTH IsAllLayoutSuspended and IsLayoutSuspended.
+        //   - This static method only defers for IsAllLayoutSuspended (see reason below).
+        //   This means that when fonts are set by string during ApplyState (which uses instance-level
+        //   SuspendLayout, not IsAllLayoutSuspended), those font loads still happen immediately.
+        //   Fixing that gap requires resolving the cascading-layout issue described below.
+        //
+        // January 28, 2025 - why we cannot simply early-return for IsLayoutSuspended:
+        // If we defer here, bitmap values are not assigned until layout is later resumed via
+        // ResumeLayoutUpdateIfDirtyRecursive. At that point mIsLayoutSuspended is already false,
+        // so when UpdateFontRecursive assigns the BitmapFont to a Text with Width or Height
+        // RelativeToChildren, it triggers UpdateLayout which cascades up through parents that have
+        // already completed their own layout pass. This causes redundant layout calls throughout
+        // a list box or any deeply nested stack. Solving this would require suppressing that
+        // UpdateLayout call inside UpdateToFontValues when called from UpdateFontRecursive, or
+        // performing a single top-down layout pass at the end rather than cascading bottom-up.
+        //
+        // IsAllLayoutSuspended is safe to defer because:
+        //   a) WireframeObjectManager calls RootGue.UpdateFontRecursive() before RootGue.UpdateLayout(),
+        //      so any per-element UpdateLayout calls triggered by font assignment are immediately
+        //      superseded by the full UpdateLayout pass.
+        //   b) mIsLayoutSuspended is always false during IsAllLayoutSuspended (ApplyState skips
+        //      SuspendLayout when the global flag is set), so there is no cascading risk.
+        if (GraphicalUiElement.IsAllLayoutSuspended)
+        {
+            graphicalUiElement.IsFontDirty = true;
+            return;
+        }
+
         var asText = (Text)text;
         var textRuntime = graphicalUiElement as TextRuntime;
 

--- a/Tests/RaylibGum.Tests/Runtimes/TextRuntimeTests.cs
+++ b/Tests/RaylibGum.Tests/Runtimes/TextRuntimeTests.cs
@@ -1,4 +1,5 @@
 ﻿using Gum.GueDeriving;
+using Gum.Wireframe;
 using RenderingLibrary.Content;
 using RenderingLibrary.Graphics;
 using Raylib_cs;
@@ -196,6 +197,74 @@ public class TextRuntimeTests : BaseTestClass
         }
         finally
         {
+            LoaderManager.Self.CacheTextures = savedCacheTextures;
+            FileManager.RelativeDirectory = savedRelativeDirectory;
+            FileManager.CustomGetStreamFromFile = savedHook;
+        }
+    }
+
+    // #3039: the string / state set path (SetProperty -> CustomSetPropertyOnRenderable.UpdateToFontValues)
+    // must honor IsAllLayoutSuspended and DEFER the font load, exactly as the MonoGame/Tool path does, so
+    // the documented font-batching optimization (docs/.../font-performance.md) is real on Raylib too.
+    // Before the fix this path loaded eagerly on every setter, making the batch a no-op and "accidentally"
+    // masking #2999. Note the font *property* setters already defer (they route through the shared
+    // GraphicalUiElement.UpdateToFontValues, which sets IsFontDirty), so IsFontDirty alone cannot tell the
+    // two builds apart — the discriminator is whether the eager LOAD happened. Detection: the load resolves
+    // the font-cache file through FileManager.CustomGetStreamFromFile; a unique (non-existent) font name +
+    // relative directory guarantees no cache hit and no on-disk file, so any request for that font during
+    // suspension proves the (now-removed) eager load ran.
+    [Fact]
+    public void StringSetPath_ShouldDeferFontLoad_WhenIsAllLayoutSuspended()
+    {
+        string uniqueFontName = "GumDeferFontTest_" + Guid.NewGuid().ToString("N");
+
+        bool savedCacheTextures = LoaderManager.Self.CacheTextures;
+        string savedRelativeDirectory = FileManager.RelativeDirectory;
+        Func<string, Stream>? savedHook = FileManager.CustomGetStreamFromFile;
+        bool savedSuspended = GraphicalUiElement.IsAllLayoutSuspended;
+        try
+        {
+            LoaderManager.Self.CacheTextures = false;
+            // Unique relative directory: the font's cache key (its standardized absolute path) becomes
+            // unique to this run, so a prior test's cache can't mask the result and resolution is forced
+            // through the in-memory hook. Mirrors the GUID-path isolation in ContentLoaderTests.
+            FileManager.RelativeDirectory = Path.Combine(Path.GetTempPath(),
+                "GumRaylibDeferFontTest_" + Guid.NewGuid().ToString("N")).Replace('\\', '/') + "/";
+
+            int fontRequestCount = 0;
+            FileManager.CustomGetStreamFromFile = incomingPath =>
+            {
+                if (incomingPath.Contains(uniqueFontName, StringComparison.OrdinalIgnoreCase))
+                {
+                    fontRequestCount++;
+                }
+                // null is the hook's documented "I don't have this file" signal.
+                return null!;
+            };
+
+            // Construct before suspending so the constructor's own (default Arial) load isn't counted —
+            // it uses a different name and so never increments the counter anyway.
+            TextRuntime textRuntime = new();
+
+            GraphicalUiElement.IsAllLayoutSuspended = true;
+            textRuntime.SetProperty("Font", uniqueFontName);
+            textRuntime.SetProperty("FontSize", 23);
+
+            // Deferred: no eager load happened while globally suspended.
+            fontRequestCount.ShouldBe(0);
+            textRuntime.IsFontDirty.ShouldBeTrue();
+
+            // Resume and flush: the single coalesced load now resolves the font, proving the deferral is
+            // realized rather than silently dropped (the #2999 failure mode).
+            GraphicalUiElement.IsAllLayoutSuspended = false;
+            textRuntime.UpdateFontRecursive();
+
+            fontRequestCount.ShouldBeGreaterThan(0);
+            textRuntime.IsFontDirty.ShouldBeFalse();
+        }
+        finally
+        {
+            GraphicalUiElement.IsAllLayoutSuspended = savedSuspended;
             LoaderManager.Self.CacheTextures = savedCacheTextures;
             FileManager.RelativeDirectory = savedRelativeDirectory;
             FileManager.CustomGetStreamFromFile = savedHook;

--- a/Tests/RaylibGum.Tests/Runtimes/TextRuntimeTests.cs
+++ b/Tests/RaylibGum.Tests/Runtimes/TextRuntimeTests.cs
@@ -213,11 +213,109 @@ public class TextRuntimeTests : BaseTestClass
     // the font-cache file through FileManager.CustomGetStreamFromFile; a unique (non-existent) font name +
     // relative directory guarantees no cache hit and no on-disk file, so any request for that font during
     // suspension proves the (now-removed) eager load ran.
+    //
+    // These tests mirror the MonoGame contract pinned in MonoGameGum.Tests FontServiceTests
+    // (StringSetPath_*/UpdateLayout_*), so the two runtimes are proven to behave identically.
     [Fact]
     public void StringSetPath_ShouldDeferFontLoad_WhenIsAllLayoutSuspended()
     {
-        string uniqueFontName = "GumDeferFontTest_" + Guid.NewGuid().ToString("N");
+        string uniqueFontName = NewUniqueFontName();
+        WithFontLoadRecording(uniqueFontName, fontRequestCount =>
+        {
+            // Construct before suspending so the constructor's own (default Arial) load isn't counted —
+            // it uses a different name and so never increments the counter anyway.
+            TextRuntime textRuntime = new();
 
+            GraphicalUiElement.IsAllLayoutSuspended = true;
+            textRuntime.SetProperty("Font", uniqueFontName);
+            textRuntime.SetProperty("FontSize", 23);
+
+            // Deferred: no eager load happened while globally suspended.
+            fontRequestCount().ShouldBe(0);
+            textRuntime.IsFontDirty.ShouldBeTrue();
+
+            // Resume and flush: the single coalesced load now resolves the font, proving the deferral is
+            // realized rather than silently dropped (the #2999 failure mode).
+            GraphicalUiElement.IsAllLayoutSuspended = false;
+            textRuntime.UpdateFontRecursive();
+
+            fontRequestCount().ShouldBeGreaterThan(0);
+            textRuntime.IsFontDirty.ShouldBeFalse();
+        });
+    }
+
+    // Baseline guarding the guard: it is gated ONLY on the suspension flag. With no suspension the string
+    // path must still load immediately — otherwise the fix would silently break the normal render path.
+    [Fact]
+    public void StringSetPath_ShouldLoadFontImmediately_WhenNotSuspended()
+    {
+        string uniqueFontName = NewUniqueFontName();
+        WithFontLoadRecording(uniqueFontName, fontRequestCount =>
+        {
+            TextRuntime textRuntime = new();
+
+            textRuntime.SetProperty("Font", uniqueFontName);
+
+            fontRequestCount().ShouldBeGreaterThan(0);
+            textRuntime.IsFontDirty.ShouldBeFalse();
+        });
+    }
+
+    // Repro shape for #2999. Users — and the font-performance docs — resume a suspended batch with
+    // UpdateLayout(), NOT UpdateFontRecursive(). UpdateLayout() must therefore realize the deferred font;
+    // otherwise text renders in the fallback font until something else re-applies state. Mirrors
+    // MonoGame's UpdateLayout_ShouldFlushDeferredFontLoad_AfterGlobalSuspendBatch.
+    [Fact]
+    public void UpdateLayout_ShouldFlushDeferredFontLoad_AfterGlobalSuspendBatch()
+    {
+        string uniqueFontName = NewUniqueFontName();
+        WithFontLoadRecording(uniqueFontName, fontRequestCount =>
+        {
+            TextRuntime textRuntime = new();
+
+            GraphicalUiElement.IsAllLayoutSuspended = true;
+            textRuntime.SetProperty("Font", uniqueFontName);
+            textRuntime.SetProperty("FontSize", 23);
+            GraphicalUiElement.IsAllLayoutSuspended = false;
+
+            textRuntime.UpdateLayout();
+
+            fontRequestCount().ShouldBeGreaterThan(0);
+            textRuntime.IsFontDirty.ShouldBeFalse();
+        });
+    }
+
+    // Documents (and pins on Raylib) the intentional KNOWN GAP described in the comment block now shared
+    // verbatim with the MonoGame copy of UpdateToFontValues: the static string path defers ONLY for the
+    // global IsAllLayoutSuspended flag, NOT for per-instance SuspendLayout. So a string set under instance
+    // suspension still loads eagerly. Mirrors MonoGame's
+    // StringSetPath_ShouldNotDeferFontGeneration_WhenOnlyInstanceLayoutSuspended — proving the copied
+    // comment's claim is true on Raylib, not just transcribed.
+    [Fact]
+    public void StringSetPath_ShouldNotDeferFontLoad_WhenOnlyInstanceLayoutSuspended()
+    {
+        string uniqueFontName = NewUniqueFontName();
+        WithFontLoadRecording(uniqueFontName, fontRequestCount =>
+        {
+            TextRuntime textRuntime = new();
+
+            textRuntime.SuspendLayout();
+            textRuntime.SetProperty("Font", uniqueFontName);
+
+            fontRequestCount().ShouldBeGreaterThan(0);
+        });
+    }
+
+    private static string NewUniqueFontName() => "GumDeferFontTest_" + Guid.NewGuid().ToString("N");
+
+    // Installs a font-load recording environment and runs <paramref name="body"/> with a callback that
+    // returns how many times a font whose name contains <paramref name="uniqueFontName"/> has been
+    // requested. A unique relative directory + a hook that serves nothing (returns null, the documented
+    // "I don't have this file" signal) guarantee no cache hit and no on-disk file, so every count is a
+    // genuine load attempt. All mutated global state is restored on exit. Mirrors the GUID-path isolation
+    // in ContentLoaderTests and the StartCapturingFontCalls helper in MonoGame's FontServiceTests.
+    private static void WithFontLoadRecording(string uniqueFontName, Action<Func<int>> body)
+    {
         bool savedCacheTextures = LoaderManager.Self.CacheTextures;
         string savedRelativeDirectory = FileManager.RelativeDirectory;
         Func<string, Stream>? savedHook = FileManager.CustomGetStreamFromFile;
@@ -225,9 +323,6 @@ public class TextRuntimeTests : BaseTestClass
         try
         {
             LoaderManager.Self.CacheTextures = false;
-            // Unique relative directory: the font's cache key (its standardized absolute path) becomes
-            // unique to this run, so a prior test's cache can't mask the result and resolution is forced
-            // through the in-memory hook. Mirrors the GUID-path isolation in ContentLoaderTests.
             FileManager.RelativeDirectory = Path.Combine(Path.GetTempPath(),
                 "GumRaylibDeferFontTest_" + Guid.NewGuid().ToString("N")).Replace('\\', '/') + "/";
 
@@ -238,29 +333,10 @@ public class TextRuntimeTests : BaseTestClass
                 {
                     fontRequestCount++;
                 }
-                // null is the hook's documented "I don't have this file" signal.
                 return null!;
             };
 
-            // Construct before suspending so the constructor's own (default Arial) load isn't counted —
-            // it uses a different name and so never increments the counter anyway.
-            TextRuntime textRuntime = new();
-
-            GraphicalUiElement.IsAllLayoutSuspended = true;
-            textRuntime.SetProperty("Font", uniqueFontName);
-            textRuntime.SetProperty("FontSize", 23);
-
-            // Deferred: no eager load happened while globally suspended.
-            fontRequestCount.ShouldBe(0);
-            textRuntime.IsFontDirty.ShouldBeTrue();
-
-            // Resume and flush: the single coalesced load now resolves the font, proving the deferral is
-            // realized rather than silently dropped (the #2999 failure mode).
-            GraphicalUiElement.IsAllLayoutSuspended = false;
-            textRuntime.UpdateFontRecursive();
-
-            fontRequestCount.ShouldBeGreaterThan(0);
-            textRuntime.IsFontDirty.ShouldBeFalse();
+            body(() => fontRequestCount);
         }
         finally
         {


### PR DESCRIPTION
## Summary

Raylib's `CustomSetPropertyOnRenderable.UpdateToFontValues` (the static set-by-string path) loaded fonts **eagerly** even while `GraphicalUiElement.IsAllLayoutSuspended == true`, unlike the MonoGame/Tool copy which **defers** (sets `IsFontDirty = true` and returns; the load is flushed later by a single `UpdateFontRecursive()` pass).

Consequences this fixes:
1. The documented font-batching optimization (`docs/.../font-performance.md`) was a **no-op on Raylib** — every font setter triggered an eager load, so wrapping setters in `IsAllLayoutSuspended = true/false` coalesced nothing.
2. Cross-runtime behavioral divergence: identical user code behaved differently on MonoGame vs Raylib, and Raylib "accidentally" sidestepped #2999 purely by never deferring.

## Fix

Add the `IsAllLayoutSuspended` deferral guard to the Raylib copy.

Per the `gum-cross-platform-unification` convergence technique — which names **this file** as the canonical non-wrapper example and uses **this very guard** as its #3039 worked example — the guard **plus its full explanatory comment** are copied **verbatim, un-`#if`'d** from the MonoGame copy. That ~34-line region is now **byte-for-byte identical** between `Gum/Wireframe/CustomSetPropertyOnRenderable.cs` and `Runtimes/RaylibGum/Renderables/CustomSetPropertyOnRenderable.cs` — one region converged toward eventual single-source. The font-loader body below the guard stays platform-divergent (`BitmapFont` vs `Raylib_cs.Font`) and will be mirror-`#if`'d in a later increment, per the skill's "one region at a time" rule.

## Why this is safe now

Prerequisite #3095 wired Raylib's `UpdateFontFromProperties` delegate to the real loader, so the deferred flush (`UpdateFontRecursive` → `UpdateFontFromProperties`) actually realizes the font. Before #3095 this guard would have regressed Raylib (deferred fonts would flush through a stub and never load).

## Testing

New `RaylibGum.Tests` test `StringSetPath_ShouldDeferFontLoad_WhenIsAllLayoutSuspended`. Note: the font *property* setters already defer `IsFontDirty` via the shared `GraphicalUiElement.UpdateToFontValues`, so `IsFontDirty` alone cannot distinguish the two builds — the real discriminator is whether the eager **load** ran. The test observes the load via `FileManager.CustomGetStreamFromFile` (unique font name + relative directory ⇒ no cache hit, no on-disk file), asserting **0 font requests during suspension**, then a flush load after resume (proving the deferral is realized, not silently dropped — the #2999 failure mode).

- Verified the test **fails for the right reason** before the fix (`fontRequestCount should be 0 but was 2`) and passes after.
- Full `RaylibGum.Tests` suite: **329 passed**.
- `MonoGameGum.Tests` `FontServiceTests` (shared deferral contract): **29 passed**.

Closes #3039.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
