### PR TITLE
Fix Build Samples: KniGumFromFile namespace, AOT win-x64 pack, MauiSkiaGum exclusion

### DIFF
--- a/.github/scripts/build-all.ps1
+++ b/.github/scripts/build-all.ps1
@@ -11,17 +11,28 @@ $ErrorActionPreference = 'Continue'
 $failures = [System.Collections.Generic.List[string]]::new()
 $successes = [System.Collections.Generic.List[string]]::new()
 
+# Solutions that can't be built by this generic windows-runner sweep and need dedicated CI.
+# MauiSkiaGum is a MAUI multi-platform app: its net9.0-windows (WinUI) head is self-contained
+# and needs the win-x64 runtime pack (NETSDK1112) the RID-less restore can't supply, and its
+# net9.0-ios head can't build on a Windows runner at all (needs a Mac). Build it in a dedicated
+# MAUI workflow instead.
+$excludeLeafNames = @('MauiSkiaGum.sln')
+
 $slns = Get-ChildItem -Path $Path -Recurse -File |
         Where-Object { $_.Extension -in '.sln', '.slnx' } |
+        Where-Object { $excludeLeafNames -notcontains $_.Name } |
         Select-Object -ExpandProperty FullName
 
 if (-not $slns) {
     Write-Warning "No .sln / .slnx files found under '$Path'."
     exit 1
-} 
+}
 else {
     Write-Host "Found $($slns.Count) solution(s):"
     $slns | ForEach-Object { Write-Host "  - $_" }
+    if ($excludeLeafNames.Count -gt 0) {
+        Write-Host "Skipping (excluded, need dedicated CI): $($excludeLeafNames -join ', ')"
+    }
 }
 
 foreach ($sln in $slns) {

--- a/.github/scripts/build-all.ps1
+++ b/.github/scripts/build-all.ps1
@@ -33,11 +33,18 @@ foreach ($sln in $slns) {
     }
 
     Write-Host "Building $(Split-Path $sln -Leaf)"
+    # PublishAot=false: a few samples set <PublishAot>true</PublishAot>. On `dotnet build`
+    # (this script never publishes) AOT does not actually compile to native — it only forces
+    # resolution of the host-RID (win-x64) runtime pack, which the RID-less `dotnet restore`
+    # above never downloads, so the build fails with "runtime pack ... was not downloaded".
+    # Disabling AOT for the build removes that pointless requirement without losing coverage,
+    # since AOT is only exercised on publish.
     dotnet build $sln `
       --configuration Release `
       --no-restore `
       --verbosity minimal `
       --property WarningLevel=0 `
+      --property PublishAot=false `
       -clp:ErrorsOnly
 
     if ($LASTEXITCODE -ne 0) {

--- a/Samples/KniGumFromFile/KniGumFromFileCommon/KniGumFromFileGame.cs
+++ b/Samples/KniGumFromFile/KniGumFromFileCommon/KniGumFromFileGame.cs
@@ -21,7 +21,7 @@ using RenderingLibrary;
 using RenderingLibrary.Graphics;
 using ToolsUtilities;
 using MonoGameGum;
-using MonoGameGum.Forms;
+using Gum.Forms;
 
 namespace KniGumFromFile;
 


### PR DESCRIPTION
Gets the **Build Samples** workflow passing on `main`. Three independent issues:

## 1. `KniGumFromFile` compile break — `FormsUtilities` moved to `Gum.Forms`
`KniGumFromFileGame.cs` imported `using MonoGameGum.Forms;`, but `FormsUtilities` now lives in `Gum.Forms` (non-FRB builds) → `CS0103`. Pre-existing break from an earlier namespace-unification PR that missed this KNI sample. Swapped the `using`; verified `KniGumFromFileCommon.csproj` builds.

## 2. AOT samples — `win-x64` runtime pack (NETSDK1112)
`KniGumInCode.DesktopGL`, `KniGumFormsSample.DesktopGL`, and `SilkNetGum` set `<PublishAot>true</PublishAot>`. On `dotnet build` the SDK resolves the host-RID (`win-x64`) runtime pack for these, which the RID-less `dotnet restore` never downloaded. Fix: build with `--property PublishAot=false`. `dotnet build` never invokes the native AOT compiler (only `publish` does), so this drops the spurious requirement without losing compile coverage.

## 3. `MauiSkiaGum` — excluded from this job (same NETSDK1112, different cause)
MauiSkiaGum is a MAUI multi-platform app. Its `net9.0-windows` (WinUI) head is self-contained and needs the win-x64 runtime pack the RID-less restore can't supply, and its `net9.0-ios` head can't build on a Windows runner at all (needs a Mac). It is **not** an AOT project, so #2's fix doesn't apply. Excluded from the generic `build-all.ps1` sweep with a logged notice — it should get a dedicated MAUI workflow if CI coverage is wanted.

`build-all.ps1` is used only by `build-samples.yaml`, so all changes are contained to the samples job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
