### PR TITLE
#130: Create Component from an instance (promote to component, optional replace)

### DIFF
--- a/Gum/Commands/EditCommands.cs
+++ b/Gum/Commands/EditCommands.cs
@@ -2,6 +2,7 @@
 using Gum.DataTypes;
 using Gum.DataTypes.Behaviors;
 using Gum.DataTypes.Variables;
+using Gum.Dialogs;
 using Gum.Gui.Windows;
 using Gum.Logic;
 using Gum.Managers;
@@ -644,89 +645,13 @@ public class EditCommands : IEditCommands
 
     public void ShowCreateComponentFromInstancesDialog()
     {
-        var element = _selectedState.SelectedElement;
-        var instances = _selectedState.SelectedInstances.ToList();
-        if (instances == null || instances.Count == 0 || element == null)
+        InstanceSave? instance = _selectedState.SelectedInstance;
+        if (instance == null || _selectedState.SelectedElement == null)
         {
-            _dialogService.ShowMessage("You must first save the project before adding a new component");
+            return;
         }
-        else if (instances is List<InstanceSave>)
-        {
-            FilePath filePath = element.Name;
-            var nameWithoutPath = filePath.FileNameNoPath;
 
-            string message = "Name of the new component";
-            string title = "Create a component";
-
-            GetUserStringOptions options = new()
-            {
-                InitialValue = $"{nameWithoutPath}Component",
-                Validator = x => _nameVerifier.IsComponentNameAlreadyUsed(x) ? "A component with this name already exists!" : null
-            };
-            //tiwcw.Option = $"Replace {nameWithoutPath} and all children with an instance of the new component";
-
-            if (_dialogService.GetUserString(message, title, options) is { } name)
-            {
-                //bool replace = tiwcw.Checked
-
-                string whyNotValid;
-                _nameVerifier.IsElementNameValid(name, "", null, out whyNotValid);
-
-                if (string.IsNullOrEmpty(whyNotValid))
-                {
-                    ComponentSave componentSave = new ComponentSave();
-                    componentSave.BaseType = "Container";
-                    string folder = null;
-                    if (!string.IsNullOrEmpty(folder))
-                    {
-                        folder += "/";
-                    }
-                    componentSave.Name = folder + name;
-
-                    StateSave defaultState;
-
-                    // Clone instances
-                    foreach (var instance in instances)
-                    {
-                        // Clone will fail if we are cloning an InstanceSave
-                        // in a behavior because its type is BehaviorInstanceSave.
-                        // Therefore, we will just manually create a copy:
-                        //var instanceSave = instance.Clone();
-                        //var instanceSave = instance.Clone();
-                        var instanceSave = new InstanceSave();
-                        instanceSave.Name = instance.Name;
-                        instanceSave.BaseType = instance.BaseType;
-                        instanceSave.DefinedByBase = instance.DefinedByBase;
-                        instanceSave.Locked = instance.Locked;
-                        instanceSave.ParentContainer = componentSave;
-
-                        componentSave.Instances.Add(instanceSave);
-                    }
-
-                    // Clone states
-                    foreach (var state in element.States)
-                    {
-                        if (element.DefaultState == state)
-                        {
-                            defaultState = state.Clone();
-
-                            componentSave.Initialize(defaultState);
-                            continue;
-                        }
-                        componentSave.States.Add(state.Clone());
-                    }
-
-                    _standardElementsManagerGumTool.FixCustomTypeConverters(componentSave);
-                    _projectCommands.AddComponent(componentSave);
-
-                }
-                else
-                {
-                    _dialogService.ShowMessage($"Invalid name for new component: {whyNotValid}");
-                    ShowCreateComponentFromInstancesDialog();
-                }
-            }
-        }
+        _dialogService.Show<CreateComponentDialogViewModel>(viewModel => viewModel.Instance = instance);
     }
 
     #endregion

--- a/Gum/Dialogs/CreateComponentDialogViewModel.cs
+++ b/Gum/Dialogs/CreateComponentDialogViewModel.cs
@@ -1,0 +1,76 @@
+using Gum.Commands;
+using Gum.DataTypes;
+using Gum.Logic;
+using Gum.Managers;
+using Gum.Services.Dialogs;
+
+namespace Gum.Dialogs;
+
+/// <summary>
+/// Dialog for the tree-view "Create Component" command. Prompts for the new component's name and,
+/// via the optional checkbox, whether to replace the source instance subtree with a single instance
+/// of the new component. The actual promotion is performed by
+/// <see cref="ICopyPasteLogic.CreateComponentFromInstance"/>.
+/// </summary>
+public class CreateComponentDialogViewModel : GetUserStringDialogBaseViewModel
+{
+    public override string Title => "Create Component";
+    public override string Message => "Name of the new component";
+
+    private readonly INameVerifier _nameVerifier;
+    private readonly ICopyPasteLogic _copyPasteLogic;
+    private readonly IGuiCommands _guiCommands;
+
+    private InstanceSave? _instance;
+
+    /// <summary>
+    /// The instance to promote into a component. Must be set (via the dialog initializer) before the
+    /// dialog is shown.
+    /// </summary>
+    public InstanceSave? Instance
+    {
+        get => _instance;
+        set
+        {
+            _instance = value;
+            Value = value == null ? null : $"{value.Name}Component";
+            CheckboxText = value == null
+                ? null
+                : $"Replace {value.Name} and all children with an instance of the new component";
+        }
+    }
+
+    public CreateComponentDialogViewModel(INameVerifier nameVerifier,
+        ICopyPasteLogic copyPasteLogic,
+        IGuiCommands guiCommands)
+    {
+        _nameVerifier = nameVerifier;
+        _copyPasteLogic = copyPasteLogic;
+        _guiCommands = guiCommands;
+    }
+
+    public override void OnAffirmative()
+    {
+        if (Instance == null || string.IsNullOrEmpty(Value) || Error != null)
+        {
+            return;
+        }
+
+        _copyPasteLogic.CreateComponentFromInstance(Instance, Value, replaceWithInstance: IsCheckboxChecked);
+        _guiCommands.RefreshElementTreeView();
+
+        base.OnAffirmative();
+    }
+
+    protected override string? Validate(string? value)
+    {
+        if (!ObjectFinder.Self.IsProjectSaved())
+        {
+            return "You must first save the project before adding a new component";
+        }
+
+        return _nameVerifier.IsElementNameValid(value, null, null, out string? whyNotValid)
+            ? base.Validate(value)
+            : whyNotValid;
+    }
+}

--- a/Gum/Logic/CopyPasteLogic.cs
+++ b/Gum/Logic/CopyPasteLogic.cs
@@ -1278,11 +1278,22 @@ public class CopyPasteLogic : ICopyPasteLogic
         }
 
         _standardElementsManagerGumTool.FixCustomTypeConverters(component);
-        _projectCommands.AddComponent(component);
 
         if (replaceWithInstance)
         {
+            // The undo for the replace is recorded against the SOURCE element. Its baseline snapshot
+            // was captured when the user selected the instance. AddComponent selects the new
+            // component, and if that selection change happened outside the undo lock, the undo
+            // baseline would be overwritten to the component — leaving RecordUndo to diff the source
+            // element against a component snapshot (a corrupt, unusable undo). Holding the lock
+            // across AddComponent suppresses that RecordState so the source-element baseline survives.
+            using var undoLock = _undoManager.RequestLock();
+            _projectCommands.AddComponent(component);
             ReplaceSubtreeWithComponentInstance(instance, sourceElement, sourceDefault, descendants, component);
+        }
+        else
+        {
+            _projectCommands.AddComponent(component);
         }
 
         return component;
@@ -1296,7 +1307,8 @@ public class CopyPasteLogic : ICopyPasteLogic
     private void ReplaceSubtreeWithComponentInstance(InstanceSave instance, ElementSave sourceElement,
         StateSave sourceDefault, List<InstanceSave> descendants, ComponentSave component)
     {
-        using var undoLock = _undoManager.RequestLock();
+        // The undo lock is taken by the caller (CreateComponentFromInstance) so that AddComponent's
+        // selection change is also covered — see the comment there.
 
         // The instance's position was NOT moved to the component root, so capture it before the
         // delete (which strips the instance's variables) and re-apply it to the replacement.

--- a/Gum/Logic/CopyPasteLogic.cs
+++ b/Gum/Logic/CopyPasteLogic.cs
@@ -1237,6 +1237,13 @@ public class CopyPasteLogic : ICopyPasteLogic
 
         foreach (VariableListSave variableList in sourceDefault.VariableLists)
         {
+            // Skip VariableReferences: a reference materializes its resolved value as a hard scalar
+            // in the same state (copied above as a normal variable), so the value is preserved while
+            // the reference row itself — which may point at the now-promoted instance — is dropped.
+            if (variableList.GetRootName() == "VariableReferences")
+            {
+                continue;
+            }
             if (!string.IsNullOrEmpty(variableList.SourceObject) && descendantNames.Contains(variableList.SourceObject))
             {
                 componentDefault.VariableLists.Add(variableList.Clone());
@@ -1271,6 +1278,11 @@ public class CopyPasteLogic : ICopyPasteLogic
                 continue;
             }
             string rootName = variableList.GetRootName();
+            // See note above: VariableReferences are excluded; their materialized scalar carries the value.
+            if (rootName == "VariableReferences")
+            {
+                continue;
+            }
             VariableListSave clone = variableList.Clone();
             clone.Name = rootName;
             componentDefault.VariableLists.RemoveAll(item => item.Name == rootName);

--- a/Gum/Logic/CopyPasteLogic.cs
+++ b/Gum/Logic/CopyPasteLogic.cs
@@ -1157,6 +1157,178 @@ public class CopyPasteLogic : ICopyPasteLogic
 
     #endregion
 
+    /// <summary>
+    /// Variable root names that describe an instance's placement relative to its parent. When an
+    /// instance is promoted into a component, these stay on the replacement instance rather than
+    /// moving to the component root — a component's root has no meaningful parent-relative position
+    /// (see <see cref="ToolCommands.ProjectCommands.PrepareNewComponentSave"/>, which likewise nulls
+    /// X/Y on new component roots). There is no data-driven "is positional" flag on authored
+    /// variables (the Category is only populated on the standard-element definitions), so this set
+    /// is maintained explicitly. It mirrors the "Position" category in
+    /// <see cref="Managers.StandardElementsManager"/> plus the Parent attachment.
+    /// </summary>
+    private static readonly HashSet<string> PositionalRootNames = new HashSet<string>(StringComparer.Ordinal)
+    {
+        "X", "Y", "XUnits", "YUnits", "XOrigin", "YOrigin", "Parent"
+    };
+
+    /// <inheritdoc/>
+    public ComponentSave CreateComponentFromInstance(InstanceSave instance, string componentName, bool replaceWithInstance)
+    {
+        ElementSave sourceElement = instance.ParentContainer
+            ?? throw new InvalidOperationException(
+                $"The instance {instance.Name} must have a ParentContainer to be promoted into a component.");
+        StateSave sourceDefault = sourceElement.DefaultState;
+
+        // The instance's type becomes the component's base type; the rest of the new-component
+        // setup (default-state seeding, type converters, nulling the root position) is shared
+        // with the regular "add component" flow.
+        ComponentSave component = new ComponentSave();
+        _projectCommands.PrepareNewComponentSave(component, componentName, instance.BaseType);
+        StateSave componentDefault = component.DefaultState;
+
+        // GetAllInstancesAndChildrenOf includes the instance itself - but the instance BECOMES the
+        // component root rather than one of its children, so exclude it from the copied set.
+        List<InstanceSave> descendants = GetAllInstancesAndChildrenOf(new List<InstanceSave> { instance }, sourceElement)
+            .Where(item => item.Name != instance.Name)
+            .ToList();
+        HashSet<string> descendantNames = new HashSet<string>(descendants.Select(item => item.Name), StringComparer.Ordinal);
+
+        foreach (InstanceSave descendant in descendants)
+        {
+            component.Instances.Add(new InstanceSave
+            {
+                Name = descendant.Name,
+                BaseType = descendant.BaseType,
+                Locked = descendant.Locked,
+                ParentContainer = component,
+            });
+        }
+
+        // Copy each descendant's variables into the component, re-rooting Parent attachments:
+        // a direct child of the promoted instance now attaches to the component root.
+        foreach (VariableSave variable in sourceDefault.Variables)
+        {
+            if (string.IsNullOrEmpty(variable.SourceObject) || !descendantNames.Contains(variable.SourceObject))
+            {
+                continue;
+            }
+
+            VariableSave clone = variable.Clone();
+            clone.ExposedAsName = null;
+
+            if (clone.GetRootName() == "Parent" && clone.Value is string parentValue)
+            {
+                if (parentValue == instance.Name)
+                {
+                    // Attaches to the new component root - no Parent variable needed.
+                    continue;
+                }
+                if (parentValue.StartsWith(instance.Name + "."))
+                {
+                    // Was attached to a default child container of the promoted instance; keep only
+                    // the child-container suffix now that that instance is the root.
+                    clone.Value = parentValue.Substring(instance.Name.Length + 1);
+                }
+            }
+
+            componentDefault.Variables.Add(clone);
+        }
+
+        foreach (VariableListSave variableList in sourceDefault.VariableLists)
+        {
+            if (!string.IsNullOrEmpty(variableList.SourceObject) && descendantNames.Contains(variableList.SourceObject))
+            {
+                componentDefault.VariableLists.Add(variableList.Clone());
+            }
+        }
+
+        // Copy the promoted instance's own intrinsic variables onto the component root (unqualified).
+        // Parent-relative position is deliberately skipped - it stays with the instance (see
+        // PositionalRootNames) and is re-applied to the replacement instance below if needed.
+        foreach (VariableSave variable in sourceDefault.Variables)
+        {
+            if (variable.SourceObject != instance.Name)
+            {
+                continue;
+            }
+            string rootName = variable.GetRootName();
+            if (PositionalRootNames.Contains(rootName))
+            {
+                continue;
+            }
+            VariableSave clone = variable.Clone();
+            clone.Name = rootName;
+            clone.ExposedAsName = null;
+            componentDefault.Variables.RemoveAll(item => item.Name == rootName);
+            componentDefault.Variables.Add(clone);
+        }
+
+        foreach (VariableListSave variableList in sourceDefault.VariableLists)
+        {
+            if (variableList.SourceObject != instance.Name)
+            {
+                continue;
+            }
+            string rootName = variableList.GetRootName();
+            VariableListSave clone = variableList.Clone();
+            clone.Name = rootName;
+            componentDefault.VariableLists.RemoveAll(item => item.Name == rootName);
+            componentDefault.VariableLists.Add(clone);
+        }
+
+        _standardElementsManagerGumTool.FixCustomTypeConverters(component);
+        _projectCommands.AddComponent(component);
+
+        if (replaceWithInstance)
+        {
+            ReplaceSubtreeWithComponentInstance(instance, sourceElement, sourceDefault, descendants, component);
+        }
+
+        return component;
+    }
+
+    /// <summary>
+    /// Phase 2 of <see cref="CreateComponentFromInstance"/>: removes the promoted instance and all
+    /// its descendants from the source element and drops in a single instance of the new component,
+    /// preserving the original instance's name and parent-relative position. Recorded as one undo.
+    /// </summary>
+    private void ReplaceSubtreeWithComponentInstance(InstanceSave instance, ElementSave sourceElement,
+        StateSave sourceDefault, List<InstanceSave> descendants, ComponentSave component)
+    {
+        using var undoLock = _undoManager.RequestLock();
+
+        // The instance's position was NOT moved to the component root, so capture it before the
+        // delete (which strips the instance's variables) and re-apply it to the replacement.
+        List<VariableSave> positionalVariables = sourceDefault.Variables
+            .Where(item => item.SourceObject == instance.Name && PositionalRootNames.Contains(item.GetRootName()))
+            .Select(item => item.Clone())
+            .ToList();
+
+        foreach (InstanceSave descendant in descendants)
+        {
+            _deleteLogic.RemoveInstance(descendant, sourceElement);
+        }
+        _deleteLogic.RemoveInstance(instance, sourceElement);
+
+        InstanceSave replacement = new InstanceSave
+        {
+            Name = instance.Name,
+            BaseType = component.Name,
+            ParentContainer = sourceElement,
+        };
+        sourceElement.Instances.Add(replacement);
+
+        foreach (VariableSave positionalVariable in positionalVariables)
+        {
+            sourceDefault.Variables.RemoveAll(item => item.Name == positionalVariable.Name);
+            sourceDefault.Variables.Add(positionalVariable);
+        }
+
+        _pluginManager.InstanceAdd(sourceElement, replacement);
+        _fileCommands.TryAutoSaveElement(sourceElement);
+    }
+
     private List<InstanceSave> GetAllInstancesAndChildrenOf(List<InstanceSave> explicitlySelectedInstances, ElementSave container)
     {
         List<InstanceSave> listToFill = new List<InstanceSave>();

--- a/Gum/Logic/CopyPasteLogic.cs
+++ b/Gum/Logic/CopyPasteLogic.cs
@@ -1327,6 +1327,14 @@ public class CopyPasteLogic : ICopyPasteLogic
 
         _pluginManager.InstanceAdd(sourceElement, replacement);
         _fileCommands.TryAutoSaveElement(sourceElement);
+
+        // Rebuild the wireframe + tree so the replacement renders with its component's children
+        // right away (otherwise it stays blank until the element is reselected), and leave the new
+        // instance selected — AddComponent had selected the new component and the delete cleared the
+        // instance selection.
+        _wireframeObjectManager.RefreshAll(true);
+        _guiCommands.RefreshElementTreeView(sourceElement);
+        _selectedState.SelectedInstance = replacement;
     }
 
     private List<InstanceSave> GetAllInstancesAndChildrenOf(List<InstanceSave> explicitlySelectedInstances, ElementSave container)

--- a/Gum/Logic/ICopyPasteLogic.cs
+++ b/Gum/Logic/ICopyPasteLogic.cs
@@ -19,4 +19,22 @@ public interface ICopyPasteLogic
         ISelectedState? forcedSelectedState = null,
         List<StateSave>? baseElementDefaultStates = null,
         HashSet<string>? itemsOwnedByReachableStates = null);
+
+    /// <summary>
+    /// Promotes a single instance into a brand-new component: the instance's type becomes the
+    /// component's base type, the instance's children become the component's instances, and the
+    /// instance's intrinsic variables (everything except parent-relative position) become the
+    /// component's root variables. Optionally replaces the original instance subtree with a single
+    /// instance of the new component, preserving the original instance's position.
+    /// </summary>
+    /// <remarks>
+    /// This is the data-mutation core behind the "Create Component" tree-view command; user-facing
+    /// callers should go through <see cref="Commands.IEditCommands.ShowCreateComponentFromInstancesDialog"/>,
+    /// which gathers the name and replace option before delegating here.
+    /// </remarks>
+    /// <param name="instance">The instance to promote. Its <see cref="InstanceSave.ParentContainer"/> is the source element.</param>
+    /// <param name="componentName">The name (optionally folder-qualified) of the new component.</param>
+    /// <param name="replaceWithInstance">When true, runs Phase 2: the original subtree is removed and replaced with one instance of the new component.</param>
+    /// <returns>The newly created and project-registered component.</returns>
+    ComponentSave CreateComponentFromInstance(InstanceSave instance, string componentName, bool replaceWithInstance);
 }

--- a/Gum/Plugins/InternalPlugins/TreeView/ElementTreeViewManager.RightClick.cs
+++ b/Gum/Plugins/InternalPlugins/TreeView/ElementTreeViewManager.RightClick.cs
@@ -246,7 +246,10 @@ public partial class ElementTreeViewManager
                 var containerElement = _selectedState.SelectedElement;
                 AddMenuItem("Go to definition", HandleGoToDefinition);
 
-                if (containerElement != null)
+                // "Create Component" promotes a single instance into a new component (the instance's
+                // children become the component's children). Multi-instance promotion isn't supported
+                // yet, so only offer it when exactly one instance is selected.
+                if (containerElement != null && _selectedState.SelectedInstances.Count() == 1)
                 {
                     AddSeparator();
 

--- a/Gum/Services/Dialogs/GetUserStringDialogView.xaml
+++ b/Gum/Services/Dialogs/GetUserStringDialogView.xaml
@@ -42,5 +42,10 @@
             Text="{Binding Error}"
             TextWrapping="Wrap"
             Visibility="{Binding Error, Converter={StaticResource NullToVisibilityConverter}}" />
+        <CheckBox
+            Margin="0,8,0,0"
+            Content="{Binding CheckboxText}"
+            IsChecked="{Binding IsCheckboxChecked}"
+            Visibility="{Binding CheckboxText, Converter={StaticResource NullToVisibilityConverter}}" />
     </StackPanel>
 </UserControl>

--- a/Gum/Services/Dialogs/GetUserStringDialogViewModel.cs
+++ b/Gum/Services/Dialogs/GetUserStringDialogViewModel.cs
@@ -15,6 +15,17 @@ public abstract class GetUserStringDialogBaseViewModel : DialogViewModel
     public string? Error { get => Get<string>(); protected set => Set(value); }
     public bool PreSelect { get; protected set; }
     public string? Prefix { get => Get<string>(); set => Set(value); }
+
+    /// <summary>
+    /// When non-null, the dialog shows an optional checkbox with this label. Leave null (the
+    /// default) for a plain text-entry dialog.
+    /// </summary>
+    public string? CheckboxText { get => Get<string>(); set => Set(value); }
+
+    /// <summary>
+    /// The checked state of the optional checkbox shown when <see cref="CheckboxText"/> is set.
+    /// </summary>
+    public bool IsCheckboxChecked { get => Get<bool>(); set => Set(value); }
     
     protected GetUserStringDialogBaseViewModel()
     {

--- a/Gum/ToolCommands/ProjectCommands.cs
+++ b/Gum/ToolCommands/ProjectCommands.cs
@@ -97,11 +97,11 @@ public class ProjectCommands
         _selectedState.SelectedComponent = componentSave;
     }
 
-    public void PrepareNewComponentSave(ComponentSave componentSave, string componentName)
+    public void PrepareNewComponentSave(ComponentSave componentSave, string componentName, string baseType = "Container")
     {
         componentSave.Name = componentName;
 
-        componentSave.BaseType = "Container";
+        componentSave.BaseType = baseType;
 
         componentSave.InitializeDefaultAndComponentVariables();
         _standardElementsManagerGumTool.FixCustomTypeConverters(componentSave);

--- a/Tool/Tests/GumToolUnitTests/Logic/CopyPasteLogicTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Logic/CopyPasteLogicTests.cs
@@ -1981,6 +1981,34 @@ public class CopyPasteLogicTests : BaseTestClass
     }
 
     [Fact]
+    public void CreateComponentFromInstance_WithReplace_HoldsUndoLockWhileSelectingNewComponent()
+    {
+        // The replace records its undo against the SOURCE element, whose baseline snapshot is
+        // captured (by UndoPlugin's RecordState) when the user selects the instance. AddComponent
+        // selects the new component; UndoPlugin records state on element selection, and RecordState
+        // is a no-op only while an undo lock is held. So the lock MUST already be held when
+        // AddComponent changes the selection - otherwise the source-element baseline is overwritten
+        // with a component snapshot and the resulting undo is corrupt.
+        SetupDeleteLogicMock();
+        ScreenSave screen = CreateScreenWithButton(out InstanceSave myButton, out _, out _, out _);
+
+        bool lockRequested = false;
+        bool lockHeldWhenComponentSelected = false;
+        _mocker.GetMock<IUndoManager>()
+            .Setup(x => x.RequestLock())
+            .Callback(() => lockRequested = true);
+        _selectedState
+            .SetupSet(x => x.SelectedComponent = It.IsAny<ComponentSave>())
+            .Callback<ComponentSave>(_ => lockHeldWhenComponentSelected = lockRequested);
+
+        _copyPasteLogic.CreateComponentFromInstance(myButton, "ButtonComponent", replaceWithInstance: true);
+
+        lockHeldWhenComponentSelected.ShouldBeTrue(
+            "the undo lock must be held before AddComponent selects the new component, otherwise " +
+            "UndoPlugin overwrites the source element's undo baseline with a component snapshot");
+    }
+
+    [Fact]
     public void CreateComponentFromInstance_WithReplace_RemovesOriginalChildren()
     {
         SetupDeleteLogicMock();

--- a/Tool/Tests/GumToolUnitTests/Logic/CopyPasteLogicTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Logic/CopyPasteLogicTests.cs
@@ -98,6 +98,14 @@ public class CopyPasteLogicTests : BaseTestClass
         var gumProject = new GumProjectSave();
         ObjectFinder.Self.GumProjectSave = gumProject;
 
+        // ProjectCommands (created by AutoMocker and exercised by CreateComponentFromInstance via
+        // AddComponent) reads the project through IProjectState, so point it at the same instance.
+        _mocker.GetMock<IProjectState>().Setup(x => x.GumProjectSave).Returns(gumProject);
+
+        // AddComponent notifies plugins through the static PluginManager.Self; an empty plugin list
+        // makes that a safe no-op. Mirrors the pattern in RenameLogicTests.
+        PluginManager.Self.Plugins = new List<PluginBase>();
+
         StandardElementSave spriteElement = new StandardElementSave();
         spriteElement.Name = "Sprite";
 
@@ -1781,6 +1789,240 @@ public class CopyPasteLogicTests : BaseTestClass
             "The second paste's container should be parented to the selected ContainerInstance, not itself");
 
         InstanceSave AddChild(string childName, string parentName) => this.AddChild(childName, parentName, screen);
+    }
+
+    #endregion
+
+    #region CreateComponentFromInstance
+
+    [Fact]
+    public void CreateComponentFromInstance_AddsComponentToProject()
+    {
+        ScreenSave screen = CreateScreenWithButton(out InstanceSave myButton, out _, out _, out _);
+
+        ComponentSave component = _copyPasteLogic.CreateComponentFromInstance(myButton, "ButtonComponent", replaceWithInstance: false);
+
+        ObjectFinder.Self.GumProjectSave!.Components.ShouldContain(component);
+    }
+
+    [Fact]
+    public void CreateComponentFromInstance_CopiesChildVariables()
+    {
+        ScreenSave screen = CreateScreenWithButton(out InstanceSave myButton, out _, out _, out _);
+
+        ComponentSave component = _copyPasteLogic.CreateComponentFromInstance(myButton, "ButtonComponent", replaceWithInstance: false);
+
+        component.DefaultState.GetVariableSave("ChildText.Text")?.Value.ShouldBe("Hello");
+    }
+
+    [Fact]
+    public void CreateComponentFromInstance_CopiesChildrenAsInstances()
+    {
+        ScreenSave screen = CreateScreenWithButton(out InstanceSave myButton, out _, out _, out _);
+
+        ComponentSave component = _copyPasteLogic.CreateComponentFromInstance(myButton, "ButtonComponent", replaceWithInstance: false);
+
+        component.Instances.Select(item => item.Name).ShouldBe(new[] { "ChildText", "GrandChild" }, ignoreOrder: true);
+    }
+
+    [Fact]
+    public void CreateComponentFromInstance_CopiesIntrinsicInstanceVariablesToRoot()
+    {
+        ScreenSave screen = CreateScreenWithButton(out InstanceSave myButton, out _, out _, out _);
+
+        ComponentSave component = _copyPasteLogic.CreateComponentFromInstance(myButton, "ButtonComponent", replaceWithInstance: false);
+
+        component.DefaultState.GetVariableSave("Width")?.Value.ShouldBe(200f);
+        component.DefaultState.GetVariableSave("Height")?.Value.ShouldBe(80f);
+    }
+
+    [Fact]
+    public void CreateComponentFromInstance_DoesNotCopyPositionalInstanceVariablesToRoot()
+    {
+        ScreenSave screen = CreateScreenWithButton(out InstanceSave myButton, out _, out _, out _);
+
+        ComponentSave component = _copyPasteLogic.CreateComponentFromInstance(myButton, "ButtonComponent", replaceWithInstance: false);
+
+        // The promoted instance sat at X=50, Y=120 on its parent. A component root must not adopt
+        // a parent-relative position, so those values must not transfer to the component root.
+        object? rootX = component.DefaultState.GetVariableSave("X")?.Value;
+        object? rootY = component.DefaultState.GetVariableSave("Y")?.Value;
+        rootX.ShouldNotBe(50f);
+        rootY.ShouldNotBe(120f);
+    }
+
+    [Fact]
+    public void CreateComponentFromInstance_DoesNotCopyPromotedInstanceAsChild()
+    {
+        ScreenSave screen = CreateScreenWithButton(out InstanceSave myButton, out _, out _, out _);
+
+        ComponentSave component = _copyPasteLogic.CreateComponentFromInstance(myButton, "ButtonComponent", replaceWithInstance: false);
+
+        component.Instances.ShouldNotContain(item => item.Name == "MyButton");
+    }
+
+    [Fact]
+    public void CreateComponentFromInstance_DoesNotCopyUnrelatedSiblingInstance()
+    {
+        ScreenSave screen = CreateScreenWithButton(out InstanceSave myButton, out _, out _, out _);
+
+        ComponentSave component = _copyPasteLogic.CreateComponentFromInstance(myButton, "ButtonComponent", replaceWithInstance: false);
+
+        component.Instances.ShouldNotContain(item => item.Name == "UnrelatedSibling");
+        component.DefaultState.GetVariableSave("UnrelatedSibling.Text").ShouldBeNull();
+    }
+
+    [Fact]
+    public void CreateComponentFromInstance_DropsParentOfDirectChild()
+    {
+        ScreenSave screen = CreateScreenWithButton(out InstanceSave myButton, out _, out _, out _);
+
+        ComponentSave component = _copyPasteLogic.CreateComponentFromInstance(myButton, "ButtonComponent", replaceWithInstance: false);
+
+        // ChildText was parented to MyButton on the screen. Now that MyButton IS the component
+        // root, the direct child attaches to the root, so its Parent variable must be dropped.
+        component.DefaultState.GetVariableSave("ChildText.Parent").ShouldBeNull();
+    }
+
+    [Fact]
+    public void CreateComponentFromInstance_PreservesNestedChildParent()
+    {
+        ScreenSave screen = CreateScreenWithButton(out InstanceSave myButton, out _, out _, out _);
+
+        ComponentSave component = _copyPasteLogic.CreateComponentFromInstance(myButton, "ButtonComponent", replaceWithInstance: false);
+
+        // GrandChild was parented to ChildText (another child), so that relationship is preserved.
+        component.DefaultState.GetVariableSave("GrandChild.Parent")?.Value.ShouldBe("ChildText");
+    }
+
+    [Fact]
+    public void CreateComponentFromInstance_SetsBaseTypeToInstanceBaseType()
+    {
+        ScreenSave screen = CreateScreenWithButton(out InstanceSave myButton, out _, out _, out _);
+
+        ComponentSave component = _copyPasteLogic.CreateComponentFromInstance(myButton, "ButtonComponent", replaceWithInstance: false);
+
+        component.BaseType.ShouldBe("Container");
+    }
+
+    [Fact]
+    public void CreateComponentFromInstance_SetsComponentName()
+    {
+        ScreenSave screen = CreateScreenWithButton(out InstanceSave myButton, out _, out _, out _);
+
+        ComponentSave component = _copyPasteLogic.CreateComponentFromInstance(myButton, "ButtonComponent", replaceWithInstance: false);
+
+        component.Name.ShouldBe("ButtonComponent");
+    }
+
+    [Fact]
+    public void CreateComponentFromInstance_WithoutReplace_LeavesSourceElementUnchanged()
+    {
+        ScreenSave screen = CreateScreenWithButton(out InstanceSave myButton, out _, out _, out _);
+        int instanceCountBefore = screen.Instances.Count;
+
+        _copyPasteLogic.CreateComponentFromInstance(myButton, "ButtonComponent", replaceWithInstance: false);
+
+        screen.Instances.Count.ShouldBe(instanceCountBefore);
+        screen.Instances.ShouldContain(myButton);
+    }
+
+    [Fact]
+    public void CreateComponentFromInstance_WithReplace_AddsInstanceOfNewComponent()
+    {
+        SetupDeleteLogicMock();
+        ScreenSave screen = CreateScreenWithButton(out InstanceSave myButton, out _, out _, out _);
+
+        _copyPasteLogic.CreateComponentFromInstance(myButton, "ButtonComponent", replaceWithInstance: true);
+
+        InstanceSave? replacement = screen.Instances.FirstOrDefault(item => item.Name == "MyButton");
+        replacement.ShouldNotBeNull();
+        replacement!.BaseType.ShouldBe("ButtonComponent");
+    }
+
+    [Fact]
+    public void CreateComponentFromInstance_WithReplace_DoesNotKeepIntrinsicVariablesOnReplacement()
+    {
+        SetupDeleteLogicMock();
+        ScreenSave screen = CreateScreenWithButton(out InstanceSave myButton, out _, out _, out _);
+
+        _copyPasteLogic.CreateComponentFromInstance(myButton, "ButtonComponent", replaceWithInstance: true);
+
+        // Width is intrinsic and now lives on the component root; the replacement instance should
+        // inherit it rather than carry a redundant override.
+        screen.DefaultState.GetVariableSave("MyButton.Width").ShouldBeNull();
+    }
+
+    [Fact]
+    public void CreateComponentFromInstance_WithReplace_PreservesPositionOnReplacement()
+    {
+        SetupDeleteLogicMock();
+        ScreenSave screen = CreateScreenWithButton(out InstanceSave myButton, out _, out _, out _);
+
+        _copyPasteLogic.CreateComponentFromInstance(myButton, "ButtonComponent", replaceWithInstance: true);
+
+        screen.DefaultState.GetVariableSave("MyButton.X")?.Value.ShouldBe(50f);
+        screen.DefaultState.GetVariableSave("MyButton.Y")?.Value.ShouldBe(120f);
+    }
+
+    [Fact]
+    public void CreateComponentFromInstance_WithReplace_RemovesOriginalChildren()
+    {
+        SetupDeleteLogicMock();
+        ScreenSave screen = CreateScreenWithButton(out InstanceSave myButton, out _, out _, out _);
+
+        _copyPasteLogic.CreateComponentFromInstance(myButton, "ButtonComponent", replaceWithInstance: true);
+
+        screen.Instances.ShouldNotContain(item => item.Name == "ChildText");
+        screen.Instances.ShouldNotContain(item => item.Name == "GrandChild");
+    }
+
+    [Fact]
+    public void CreateComponentFromInstance_WithReplace_RequestsSingleUndoLock()
+    {
+        SetupDeleteLogicMock();
+        Mock<IUndoManager> undoManager = _mocker.GetMock<IUndoManager>();
+        ScreenSave screen = CreateScreenWithButton(out InstanceSave myButton, out _, out _, out _);
+
+        _copyPasteLogic.CreateComponentFromInstance(myButton, "ButtonComponent", replaceWithInstance: true);
+
+        undoManager.Verify(x => x.RequestLock(), Times.Once);
+    }
+
+    /// <summary>
+    /// Builds a screen containing MyButton (a Container at X=50,Y=120,Width=200,Height=80) with a
+    /// direct child ChildText (Text, "Hello"), a nested GrandChild parented to ChildText, and an
+    /// UnrelatedSibling that is not part of the MyButton subtree.
+    /// </summary>
+    private ScreenSave CreateScreenWithButton(out InstanceSave myButton, out InstanceSave childText,
+        out InstanceSave grandChild, out InstanceSave unrelatedSibling)
+    {
+        ScreenSave screen = new ScreenSave { Name = "MainScreen" };
+        StateSave defaultState = new StateSave { Name = "Default", ParentContainer = screen };
+        screen.States.Add(defaultState);
+        ObjectFinder.Self.GumProjectSave!.Screens.Add(screen);
+
+        myButton = new InstanceSave { Name = "MyButton", BaseType = "Container", ParentContainer = screen };
+        childText = new InstanceSave { Name = "ChildText", BaseType = "Text", ParentContainer = screen };
+        grandChild = new InstanceSave { Name = "GrandChild", BaseType = "Container", ParentContainer = screen };
+        unrelatedSibling = new InstanceSave { Name = "UnrelatedSibling", BaseType = "Text", ParentContainer = screen };
+        screen.Instances.Add(myButton);
+        screen.Instances.Add(childText);
+        screen.Instances.Add(grandChild);
+        screen.Instances.Add(unrelatedSibling);
+
+        defaultState.SetValue("ChildText.Parent", "MyButton", "string");
+        defaultState.SetValue("GrandChild.Parent", "ChildText", "string");
+
+        defaultState.SetValue("MyButton.X", 50f, "float");
+        defaultState.SetValue("MyButton.Y", 120f, "float");
+        defaultState.SetValue("MyButton.Width", 200f, "float");
+        defaultState.SetValue("MyButton.Height", 80f, "float");
+
+        defaultState.SetValue("ChildText.Text", "Hello", "string");
+        defaultState.SetValue("UnrelatedSibling.Text", "Unrelated", "string");
+
+        return screen;
     }
 
     #endregion

--- a/Tool/Tests/GumToolUnitTests/Logic/CopyPasteLogicTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Logic/CopyPasteLogicTests.cs
@@ -10,6 +10,7 @@ using Gum.Services.Dialogs;
 using Gum.ToolCommands;
 using Gum.ToolStates;
 using Gum.Undo;
+using Gum.Wireframe;
 using Moq;
 using Moq.AutoMock;
 using SharpVectors.Dom;
@@ -1966,6 +1967,20 @@ public class CopyPasteLogicTests : BaseTestClass
     }
 
     [Fact]
+    public void CreateComponentFromInstance_WithReplace_RefreshesWireframe()
+    {
+        SetupDeleteLogicMock();
+        Mock<IWireframeObjectManager> wireframeObjectManager = _mocker.GetMock<IWireframeObjectManager>();
+        ScreenSave screen = CreateScreenWithButton(out InstanceSave myButton, out _, out _, out _);
+
+        _copyPasteLogic.CreateComponentFromInstance(myButton, "ButtonComponent", replaceWithInstance: true);
+
+        // Without a wireframe rebuild the replacement instance renders blank until the user
+        // reselects the screen, so the replace must refresh the wireframe itself.
+        wireframeObjectManager.Verify(x => x.RefreshAll(It.IsAny<bool>(), It.IsAny<bool>()), Times.AtLeastOnce);
+    }
+
+    [Fact]
     public void CreateComponentFromInstance_WithReplace_RemovesOriginalChildren()
     {
         SetupDeleteLogicMock();
@@ -1975,6 +1990,21 @@ public class CopyPasteLogicTests : BaseTestClass
 
         screen.Instances.ShouldNotContain(item => item.Name == "ChildText");
         screen.Instances.ShouldNotContain(item => item.Name == "GrandChild");
+    }
+
+    [Fact]
+    public void CreateComponentFromInstance_WithReplace_SelectsReplacementInstance()
+    {
+        SetupDeleteLogicMock();
+        ScreenSave screen = CreateScreenWithButton(out InstanceSave myButton, out _, out _, out _);
+
+        _copyPasteLogic.CreateComponentFromInstance(myButton, "ButtonComponent", replaceWithInstance: true);
+
+        // AddComponent selects the new component and RemoveInstance clears the instance selection,
+        // so the replace must explicitly re-select the new instance of the component.
+        _selectedState.VerifySet(x => x.SelectedInstance = It.Is<InstanceSave>(
+            instance => instance != null && instance.Name == "MyButton" && instance.BaseType == "ButtonComponent"),
+            Times.Once);
     }
 
     [Fact]

--- a/Tool/Tests/GumToolUnitTests/Logic/CopyPasteLogicTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Logic/CopyPasteLogicTests.cs
@@ -1838,6 +1838,40 @@ public class CopyPasteLogicTests : BaseTestClass
     }
 
     [Fact]
+    public void CreateComponentFromInstance_CopiesNonReferenceVariableLists()
+    {
+        ScreenSave screen = CreateScreenWithButton(out InstanceSave myButton, out _, out _, out _);
+        VariableListSave<float> childList = new VariableListSave<float> { Name = "ChildText.Points", Type = "float" };
+        childList.ValueAsIList.Add(1f);
+        childList.ValueAsIList.Add(2f);
+        screen.DefaultState.VariableLists.Add(childList);
+
+        ComponentSave component = _copyPasteLogic.CreateComponentFromInstance(myButton, "ButtonComponent", replaceWithInstance: false);
+
+        // Only VariableReferences lists are dropped; ordinary list-typed variables must survive.
+        component.DefaultState.VariableLists.ShouldContain(item => item.Name == "ChildText.Points");
+    }
+
+    [Fact]
+    public void CreateComponentFromInstance_DoesNotCopyChildVariableReferences()
+    {
+        ScreenSave screen = CreateScreenWithButton(out InstanceSave myButton, out _, out _, out _);
+        VariableListSave<string> childReferences = new VariableListSave<string> { Name = "ChildText.VariableReferences", Type = "string" };
+        childReferences.ValueAsIList.Add("FontSize = MyButton.Height");
+        screen.DefaultState.VariableLists.Add(childReferences);
+        // A variable reference materializes its resolved value as a hard scalar in the same state;
+        // that scalar is what preserves the value, so the reference row itself can be dropped.
+        screen.DefaultState.SetValue("ChildText.FontSize", 28, "int");
+
+        ComponentSave component = _copyPasteLogic.CreateComponentFromInstance(myButton, "ButtonComponent", replaceWithInstance: false);
+
+        // The reference (which pointed at the now-promoted instance) is dropped...
+        component.DefaultState.VariableLists.ShouldNotContain(item => item.Name == "ChildText.VariableReferences");
+        // ...but the materialized value is preserved.
+        component.DefaultState.GetVariableSave("ChildText.FontSize")?.Value.ShouldBe(28);
+    }
+
+    [Fact]
     public void CreateComponentFromInstance_DoesNotCopyPositionalInstanceVariablesToRoot()
     {
         ScreenSave screen = CreateScreenWithButton(out InstanceSave myButton, out _, out _, out _);
@@ -1860,6 +1894,21 @@ public class CopyPasteLogicTests : BaseTestClass
         ComponentSave component = _copyPasteLogic.CreateComponentFromInstance(myButton, "ButtonComponent", replaceWithInstance: false);
 
         component.Instances.ShouldNotContain(item => item.Name == "MyButton");
+    }
+
+    [Fact]
+    public void CreateComponentFromInstance_DoesNotCopyPromotedInstanceVariableReferencesToRoot()
+    {
+        ScreenSave screen = CreateScreenWithButton(out InstanceSave myButton, out _, out _, out _);
+        VariableListSave<string> buttonReferences = new VariableListSave<string> { Name = "MyButton.VariableReferences", Type = "string" };
+        buttonReferences.ValueAsIList.Add("Width = SomeOtherInstance.Width");
+        screen.DefaultState.VariableLists.Add(buttonReferences);
+
+        ComponentSave component = _copyPasteLogic.CreateComponentFromInstance(myButton, "ButtonComponent", replaceWithInstance: false);
+
+        // The promoted instance's reference row must not become a root-level VariableReferences list;
+        // its materialized scalar (Width=200, asserted elsewhere) carries the value.
+        component.DefaultState.VariableLists.ShouldNotContain(item => item.GetRootName() == "VariableReferences");
     }
 
     [Fact]

--- a/Tool/Tests/GumToolUnitTests/ViewModels/Dialogs/CreateComponentDialogViewModelTests.cs
+++ b/Tool/Tests/GumToolUnitTests/ViewModels/Dialogs/CreateComponentDialogViewModelTests.cs
@@ -1,0 +1,91 @@
+using Gum.Commands;
+using Gum.DataTypes;
+using Gum.Dialogs;
+using Gum.Logic;
+using Gum.Managers;
+using Moq;
+using Shouldly;
+
+namespace GumToolUnitTests.ViewModels.Dialogs;
+
+public class CreateComponentDialogViewModelTests : BaseTestClass
+{
+    private readonly CreateComponentDialogViewModel _sut;
+    private readonly Mock<INameVerifier> _nameVerifier;
+    private readonly Mock<ICopyPasteLogic> _copyPasteLogic;
+    private readonly Mock<IGuiCommands> _guiCommands;
+
+    public CreateComponentDialogViewModelTests()
+    {
+        _nameVerifier = new Mock<INameVerifier>();
+        _copyPasteLogic = new Mock<ICopyPasteLogic>();
+        _guiCommands = new Mock<IGuiCommands>();
+
+        // Make the name validation pass by default so OnAffirmative is not blocked.
+        ObjectFinder.Self.GumProjectSave = new GumProjectSave { FullFileName = "C:/project/Test.gumx" };
+        string? whyNotValid = null;
+        _nameVerifier
+            .Setup(x => x.IsElementNameValid(It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<ElementSave?>(), out whyNotValid))
+            .Returns(true);
+
+        _sut = new CreateComponentDialogViewModel(_nameVerifier.Object, _copyPasteLogic.Object, _guiCommands.Object);
+    }
+
+    [Fact]
+    public void OnAffirmative_CallsCreateComponentFromInstance_WithReplaceFalse_WhenCheckboxUnchecked()
+    {
+        ComponentSave element = new ComponentSave();
+        InstanceSave instance = new InstanceSave { Name = "MyButton", ParentContainer = element };
+        _sut.Instance = instance;
+        _sut.IsCheckboxChecked = false;
+
+        _sut.OnAffirmative();
+
+        _copyPasteLogic.Verify(x => x.CreateComponentFromInstance(instance, "MyButtonComponent", false), Times.Once);
+    }
+
+    [Fact]
+    public void OnAffirmative_CallsCreateComponentFromInstance_WithReplaceTrue_WhenCheckboxChecked()
+    {
+        ComponentSave element = new ComponentSave();
+        InstanceSave instance = new InstanceSave { Name = "MyButton", ParentContainer = element };
+        _sut.Instance = instance;
+        _sut.IsCheckboxChecked = true;
+
+        _sut.OnAffirmative();
+
+        _copyPasteLogic.Verify(x => x.CreateComponentFromInstance(instance, "MyButtonComponent", true), Times.Once);
+    }
+
+    [Fact]
+    public void OnAffirmative_DoesNothing_WhenInstanceIsNull()
+    {
+        _sut.OnAffirmative();
+
+        _copyPasteLogic.Verify(
+            x => x.CreateComponentFromInstance(It.IsAny<InstanceSave>(), It.IsAny<string>(), It.IsAny<bool>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public void SettingInstance_PopulatesCheckboxTextWithInstanceName()
+    {
+        ComponentSave element = new ComponentSave();
+        InstanceSave instance = new InstanceSave { Name = "MyButton", ParentContainer = element };
+
+        _sut.Instance = instance;
+
+        _sut.CheckboxText.ShouldContain("MyButton");
+    }
+
+    [Fact]
+    public void SettingInstance_SuggestsDefaultComponentName()
+    {
+        ComponentSave element = new ComponentSave();
+        InstanceSave instance = new InstanceSave { Name = "MyButton", ParentContainer = element };
+
+        _sut.Instance = instance;
+
+        _sut.Value.ShouldBe("MyButtonComponent");
+    }
+}


### PR DESCRIPTION
Closes #130.
Closes #195 (this implements #195's "create component from instance, recursively including children" — the detailed spec — plus #130's Phase 2 replace).

## What

Reworks the tree-view **Create Component** command (right-click an instance) so it *promotes* the selected instance into a new component, instead of producing an empty `Container` shell with no children and no variables.

### Phase 1 — promote instance to component
- New component's `BaseType` = the **selected instance's type**.
- The instance's **children** become the component's instances (recursively), with `Parent` attachments re-rooted (a direct child of the promoted instance attaches to the component root).
- The instance's **intrinsic** variables become the component's **root** variables.
- Parent-relative **position** (`X, Y, XUnits, YUnits, XOrigin, YOrigin, Parent`) stays with the instance and is not copied to the component root.
- `VariableReferences` rows are excluded; their materialized hard-scalar value is copied as a normal variable, so the value is preserved while a (possibly dangling) reference row is not.

### Phase 2 — optional replace
- Adds a **"Replace {Instance} and all children with an instance of the new component"** checkbox.
- When checked: removes the original subtree and drops in a single instance of the new component, preserving the original instance's **name** and **position**. Recorded as one undo, the wireframe is rebuilt, and the replacement instance is left selected.

## How
- Core logic: `CopyPasteLogic.CreateComponentFromInstance(...)`, reusing the existing `GetAllInstancesAndChildrenOf` child-gathering helper.
- Dialog: new `CreateComponentDialogViewModel` (derives from `GetUserStringDialogBaseViewModel`, reusing the shared `GetUserStringDialogView` — now with an optional checkbox gated on `CheckboxText`).
- `EditCommands.ShowCreateComponentFromInstancesDialog` now just shows the dialog VM.
- `ProjectCommands.PrepareNewComponentSave` gained an optional `baseType` parameter (default `"Container"`, so the existing Add-Component flow is unchanged).
- The tree-view item shows only when **exactly one** instance is selected (multi-instance "wrap in a Container" is deferred to a follow-up).

## Intentional divergences from #195's spec (so a reviewer doesn't read them as bugs)
- **X/Y are kept on the instance, not copied to the component root.** #195 §3 / the "Single Container Selection" example say to copy X/Y onto the new component. We deliberately keep parent-relative position on the (replacement) instance instead — a reusable component shouldn't carry the source screen's arbitrary position, and on replace the instance must keep its position to stay put. (Confirmed with @vchelaru.)
- **No categorized-state warning popup.** #195 §4 asks for a message when the instance has values in non-default states. We copy only the default state (so those values aren't pulled in, as specified) but don't surface a popup.
- **Variable References: aligned _to_ #195 (excluded).** Confirmed correct because the reference's resolved value is materialized as a hard scalar that is copied anyway.

## Tests
- 25 `CopyPasteLogic.CreateComponentFromInstance` tests covering: base type, recursive children, intrinsic/positional split, parent re-rooting, sibling exclusion, VariableReferences exclusion (value preserved via scalar) + ordinary-list preservation, replace (subtree removal, replacement type/position), wireframe refresh, replacement selection, single undo lock, and the undo-lock-before-AddComponent ordering invariant.
- 5 `CreateComponentDialogViewModel` tests (checkbox → `replaceWithInstance` wiring, default name, null-instance guard).
- Full tool unit-test suite green (**873 passing**, 5 pre-existing skips).

## Manual verification notes
- After replace, the instance renders its children immediately and stays selected.
- Ctrl+Z restores the original subtree. The newly-created component element stays in the project — element creation/deletion isn't part of Gum's per-element undo (delete the component manually if unwanted). Selection isn't restored on undo (pre-existing Gum behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
