### PR TITLE
#566: Defer invalid variable-reference dialog so the variable grid isn't left showing a stale instance

### DIFF
--- a/Gum/Plugins/InternalPlugins/VariableGrid/VariableReferenceLogic.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/VariableReferenceLogic.cs
@@ -32,6 +32,7 @@ public class VariableReferenceLogic : IVariableReferenceLogic
     private readonly IDialogService _dialogService;
     private readonly IFileCommands _fileCommands;
     private readonly ICompositeMemberRegistry _compositeMemberRegistry;
+    private readonly IDispatcher _dispatcher;
 
     #endregion
 
@@ -39,13 +40,15 @@ public class VariableReferenceLogic : IVariableReferenceLogic
         IWireframeCommands wireframeCommands,
         IDialogService dialogService,
         IFileCommands fileCommands,
-        ICompositeMemberRegistry compositeMemberRegistry)
+        ICompositeMemberRegistry compositeMemberRegistry,
+        IDispatcher dispatcher)
     {
         _guiCommands = guiCommands;
         _wireframeCommands = wireframeCommands;
         _dialogService =  dialogService;
         _fileCommands = fileCommands;
         _compositeMemberRegistry = compositeMemberRegistry;
+        _dispatcher = dispatcher;
     }
 
     public AssignmentExpressionSyntax? GetAssignmentSyntax(string item)
@@ -455,9 +458,23 @@ public class VariableReferenceLogic : IVariableReferenceLogic
 
                 if (failures.Count > 0)
                 {
-                    ShowFailureMessage(failures);
-
+                    // Comment the invalid lines synchronously so the data model is consistent
+                    // before any refresh runs.
                     CommentFailures(newDirectValue, failures);
+
+                    // Defer the failure dialog instead of showing it inline. A VariableReferences
+                    // edit is frequently committed by focus loss when the user clicks a different
+                    // instance; a synchronous modal here pumps the WPF message loop in the middle
+                    // of the commit, interleaving the pending selection change and leaving the
+                    // variable grid painted for the previously-selected instance (issue #566).
+                    // Posting at background priority lets the commit and the selection change
+                    // settle first, then shows the dialog and re-refreshes the grid against the
+                    // now-current selection.
+                    _dispatcher.Post(() =>
+                    {
+                        ShowFailureMessage(failures);
+                        _guiCommands.RefreshVariables(force: true);
+                    });
                 }
             }
         }

--- a/Tool/Tests/GumToolUnitTests/VariableGrid/VariableReferenceLogicTests.cs
+++ b/Tool/Tests/GumToolUnitTests/VariableGrid/VariableReferenceLogicTests.cs
@@ -7,6 +7,7 @@ using Gum.Services;
 using Gum.Services.Dialogs;
 using Moq;
 using Shouldly;
+using System;
 using System.Collections.Generic;
 
 namespace GumToolUnitTests.VariableGrid;
@@ -14,17 +15,22 @@ namespace GumToolUnitTests.VariableGrid;
 public class VariableReferenceLogicTests : BaseTestClass
 {
     private readonly Mock<IGuiCommands> _guiCommandsMock;
+    private readonly Mock<IDialogService> _dialogServiceMock;
+    private readonly Mock<IDispatcher> _dispatcherMock;
     private readonly VariableReferenceLogic _sut;
 
     public VariableReferenceLogicTests()
     {
         _guiCommandsMock = new Mock<IGuiCommands>();
+        _dialogServiceMock = new Mock<IDialogService>();
+        _dispatcherMock = new Mock<IDispatcher>();
         _sut = new VariableReferenceLogic(
             _guiCommandsMock.Object,
             new Mock<IWireframeCommands>().Object,
-            new Mock<IDialogService>().Object,
+            _dialogServiceMock.Object,
             new Mock<IFileCommands>().Object,
-            new CompositeMemberRegistry());
+            new CompositeMemberRegistry(),
+            _dispatcherMock.Object);
     }
 
     #region GetAssignmentSyntax
@@ -235,6 +241,57 @@ public class VariableReferenceLogicTests : BaseTestClass
     #endregion
 
     #region DoVariableReferenceReaction
+
+    [Fact]
+    public void DoVariableReferenceReaction_InvalidLine_CommentsImmediatelyButDefersFailureDialog()
+    {
+        // Repro for issue #566: an invalid VariableReferences line is committed by focus loss
+        // when the user clicks a different instance. The failure dialog used to be shown
+        // synchronously inside the reaction, which pumps the WPF message loop in the middle of
+        // the commit; that interleaves the pending selection change and leaves the variable grid
+        // painted for the previously-selected instance. The line must still be commented out
+        // synchronously (data stays consistent), but the dialog must be deferred via the
+        // dispatcher so the commit and selection change settle first.
+        GumProjectSave project = new GumProjectSave();
+        ObjectFinder.Self.GumProjectSave = project;
+
+        // "X" does not exist on the screen, so validation fails for this line.
+        ScreenSave screen = BuildScreenWithVariableReference(
+            line: "X = Y",
+            out StateSave defaultState,
+            out VariableListSave<string> varList);
+        project.Screens.Add(screen);
+
+        Action? postedAction = null;
+        _dispatcherMock.Setup(x => x.Post(It.IsAny<Action>()))
+            .Callback<Action>(action => postedAction = action);
+
+        _sut.DoVariableReferenceReaction(
+            parentElement: screen,
+            leftSideInstance: null,
+            unqualifiedMember: "VariableReferences",
+            stateSave: defaultState,
+            qualifiedName: "VariableReferences",
+            trySave: false);
+
+        // Commented synchronously so the data model is consistent regardless of the dialog.
+        varList.Value[0].ShouldStartWith("//");
+
+        // The dialog is deferred, not shown inline during the reaction.
+        _dispatcherMock.Verify(x => x.Post(It.IsAny<Action>()), Times.Once);
+        _dialogServiceMock.Verify(
+            x => x.ShowMessage(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<MessageDialogStyle?>()),
+            Times.Never);
+
+        // Once the deferred action runs (after selection settles), the dialog is shown and the
+        // grid is refreshed against the now-current selection.
+        postedAction.ShouldNotBeNull();
+        postedAction!.Invoke();
+        _dialogServiceMock.Verify(
+            x => x.ShowMessage(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<MessageDialogStyle?>()),
+            Times.Once);
+        _guiCommandsMock.Verify(x => x.RefreshVariables(true), Times.Once);
+    }
 
     [Fact]
     public void DoVariableReferenceReaction_InstanceVariableSet_PropagatesDeepReference()


### PR DESCRIPTION
Closes #566

## Problem

When an incomplete/invalid variable reference (e.g. `X = ` with no right side) is typed into an instance's `VariableReferences` and the user then **selects another instance**, the edit is committed by focus loss. The validation correctly fails and comments the line out (`//X = `), but the failure popup appears **mid-commit** and the variable grid is left displaying the just-commented data on the *newly selected* instance. Selecting around afterward self-heals it, so the underlying data was always correct — this was a display/refresh-ordering glitch.

## Root cause

`VariableReferenceLogic.DoVariableReferenceReaction` showed the failure dialog **synchronously** in the middle of the commit. A modal dialog pumps the WPF message loop, so the pending selection-change cascade interleaves with the in-flight commit, and the grid ends up painted for the previously-selected instance.

## Fix

- Comment the invalid lines **synchronously** (data model stays consistent regardless of timing).
- **Defer** the failure dialog via `IDispatcher.Post` (background priority). This lets the commit and the pending selection change finish first; the deferred action then shows the dialog and re-refreshes the grid (`RefreshVariables(force: true)`) against the now-current selection.

The deferral path only runs when a reference is invalid (the common, valid path is untouched).

## Tests

- Added `DoVariableReferenceReaction_InvalidLine_CommentsImmediatelyButDefersFailureDialog`, which asserts the line is commented synchronously, the dialog is posted (not shown inline), and the deferred action both shows the dialog and refreshes the grid. Verified red before the fix (dialog shown inline → `Post` never called) and green after.
- Full `GumToolUnitTests` suite: 874 passed, 5 pre-existing skips, 0 failures.

## Note on verification

This is a WPF message-pump / refresh-ordering bug; the unit test proves the deferral mechanism, but the end-to-end timing behavior is best confirmed in the running tool. Worth a quick manual check of the original repro steps before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
