### PR TITLE
#3153: Detect git conflict markers on project/element load and report a clear error

### DIFF
--- a/Tests/Gum.ProjectServices.Tests/ProjectLoaderTests.cs
+++ b/Tests/Gum.ProjectServices.Tests/ProjectLoaderTests.cs
@@ -515,6 +515,66 @@ public class ProjectLoaderTests
     }
 
     [Fact]
+    public void Load_ShouldReportError_WhenElementFileContainsGitConflictMarkers()
+    {
+        string tempDir = Path.Combine(Path.GetTempPath(), "GumLoaderTest_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        string gumxPath = Path.Combine(tempDir, "Test.gumx");
+        try
+        {
+            ProjectCreator creator = new ProjectCreator();
+            creator.Create(gumxPath);
+
+            string componentDir = Path.Combine(tempDir, "Components");
+
+            // A healthy sibling component that must remain unaffected.
+            File.WriteAllText(Path.Combine(componentDir, "GoodComponent.gucx"), """
+                <?xml version="1.0" encoding="utf-8"?>
+                <ComponentSave xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+                  <Name>GoodComponent</Name>
+                  <BaseType>Container</BaseType>
+                </ComponentSave>
+                """);
+
+            // A component file left with unresolved git conflict markers (invalid XML).
+            File.WriteAllText(Path.Combine(componentDir, "ConflictComponent.gucx"), """
+                <?xml version="1.0" encoding="utf-8"?>
+                <ComponentSave xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+                  <Name>ConflictComponent</Name>
+                <<<<<<< HEAD
+                  <BaseType>Container</BaseType>
+                =======
+                  <BaseType>Sprite</BaseType>
+                >>>>>>> other-branch
+                </ComponentSave>
+                """);
+
+            string gumxContent = File.ReadAllText(gumxPath);
+            gumxContent = gumxContent.Replace("</GumProjectSave>",
+                """  <ComponentReference Name="GoodComponent" />""" + "\n" +
+                """  <ComponentReference Name="ConflictComponent" />""" + "\n</GumProjectSave>");
+            File.WriteAllText(gumxPath, gumxContent);
+
+            ProjectLoadResult result = _sut.Load(gumxPath);
+
+            // Project still loads; the healthy sibling is present and error-free.
+            result.Success.ShouldBeTrue();
+            result.Project!.Components.ShouldContain(c => c.Name == "GoodComponent");
+            result.LoadErrors.ShouldNotContain(e => e.ElementName == "GoodComponent");
+
+            // The conflicted element gets a clear, dedicated conflict-marker error.
+            result.LoadErrors.ShouldContain(e =>
+                e.ElementName == "ConflictComponent" &&
+                e.Severity == ErrorSeverity.Error &&
+                e.Message.Contains("conflict marker"));
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
     public void Load_ShouldReturnError_WhenFileDoesNotExist()
     {
         ProjectLoadResult result = _sut.Load("C:/nonexistent/path/project.gumx");
@@ -531,6 +591,38 @@ public class ProjectLoaderTests
 
         result.Success.ShouldBeFalse();
         result.Project.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Load_ShouldReturnFatalError_WhenGumxContainsGitConflictMarkers()
+    {
+        string tempDir = Path.Combine(Path.GetTempPath(), "GumCliTest_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        string gumxPath = Path.Combine(tempDir, "Conflicted.gumx");
+        try
+        {
+            File.WriteAllText(gumxPath, """
+                <?xml version="1.0" encoding="utf-8"?>
+                <GumProjectSave>
+                <<<<<<< HEAD
+                  <DefaultCanvasWidth>800</DefaultCanvasWidth>
+                =======
+                  <DefaultCanvasWidth>1024</DefaultCanvasWidth>
+                >>>>>>> other-branch
+                </GumProjectSave>
+                """);
+
+            ProjectLoadResult result = _sut.Load(gumxPath);
+
+            result.Success.ShouldBeFalse();
+            result.Project.ShouldBeNull();
+            result.ErrorMessage.ShouldNotBeNullOrEmpty();
+            result.ErrorMessage!.ShouldContain("conflict marker");
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
     }
 
     [Fact]

--- a/Tools/Gum.ProjectServices/ProjectLoader.cs
+++ b/Tools/Gum.ProjectServices/ProjectLoader.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using Gum.DataTypes;
 using Gum.DataTypes.Behaviors;
 using Gum.Managers;
@@ -23,6 +24,15 @@ public class ProjectLoader : IProjectLoader
 
         string projectDirectory = Path.GetDirectoryName(Path.GetFullPath(filePath)) ?? "";
 
+        // A merge/rebase can leave git conflict markers in the .gumx, which makes it invalid XML.
+        // Detect that here, before deserialization, so the user gets an actionable message instead
+        // of the parser's cryptic line/column error. A conflicted .gumx can't load, so this is fatal.
+        if (ContainsGitConflictMarkers(File.ReadAllText(filePath)))
+        {
+            result.ErrorMessage = ConflictMarkerMessage(Path.GetFileName(filePath));
+            return result;
+        }
+
         StandardElementsManager.Self.Initialize();
         // INTERIM: bridges shapes (Arc/ColoredCircle/RoundedRectangle/Line) and Skia
         // (Canvas/Svg/LottieAnimation) into headless loading. Remove once these are
@@ -42,8 +52,19 @@ public class ProjectLoader : IProjectLoader
             else
             {
                 project.Initialize();
-                result.LoadErrors.AddRange(
-                    ParseElementLoadErrors(gumLoadResult.ErrorMessage));
+
+                var elementLoadErrors = ParseElementLoadErrors(gumLoadResult.ErrorMessage);
+                var conflictErrors = DetectConflictMarkers(project, projectDirectory);
+
+                // A conflicted element file is invalid XML, so it ALSO failed to deserialize and
+                // produced a cryptic "Malformed XML" entry via ParseElementLoadErrors. Drop those
+                // duplicates so the clear conflict-marker message is the only error for that element.
+                var conflictElementNames = new HashSet<string>(
+                    conflictErrors.Select(e => e.ElementName));
+                elementLoadErrors.RemoveAll(e => conflictElementNames.Contains(e.ElementName));
+
+                result.LoadErrors.AddRange(elementLoadErrors);
+                result.LoadErrors.AddRange(conflictErrors);
                 result.LoadErrors.AddRange(
                     ConvertMissingFiles(gumLoadResult.MissingFiles, projectDirectory));
                 result.LoadErrors.AddRange(
@@ -230,6 +251,77 @@ public class ProjectLoader : IProjectLoader
 
         return errors;
     }
+
+    /// <summary>
+    /// Scans each referenced element/behavior file for unresolved git conflict markers and reports
+    /// an <see cref="ErrorSeverity.Error"/> per conflicted file. Iterates the project's references
+    /// (not the loaded element lists) because a conflicted file is invalid XML and never makes it
+    /// into those lists. Mirrors the per-element error model used by <see cref="DetectSilentlyDroppedContent"/>.
+    /// </summary>
+    private static List<ErrorResult> DetectConflictMarkers(
+        GumProjectSave project, string projectDirectory)
+    {
+        var errors = new List<ErrorResult>();
+
+        void Check(string name, string subfolder, string extension)
+        {
+            string path = Path.Combine(projectDirectory, subfolder, name + "." + extension);
+            if (File.Exists(path) && ContainsGitConflictMarkers(File.ReadAllText(path)))
+            {
+                errors.Add(new ErrorResult
+                {
+                    ElementName = name,
+                    Message = ConflictMarkerMessage(name + "." + extension),
+                    Severity = ErrorSeverity.Error
+                });
+            }
+        }
+
+        foreach (var reference in project.ScreenReferences)
+        {
+            Check(reference.Name, ElementReference.ScreenSubfolder, GumProjectSave.ScreenExtension);
+        }
+        foreach (var reference in project.ComponentReferences)
+        {
+            Check(reference.Name, ElementReference.ComponentSubfolder, GumProjectSave.ComponentExtension);
+        }
+        foreach (var reference in project.StandardElementReferences)
+        {
+            Check(reference.Name, ElementReference.StandardSubfolder, GumProjectSave.StandardExtension);
+        }
+        foreach (var reference in project.BehaviorReferences)
+        {
+            Check(reference.Name, BehaviorReference.Subfolder, BehaviorReference.Extension);
+        }
+
+        return errors;
+    }
+
+    /// <summary>
+    /// Returns true if the raw file text contains an unresolved git conflict marker. Git always
+    /// writes the markers (<c>&lt;&lt;&lt;&lt;&lt;&lt;&lt;</c>, <c>=======</c>, <c>&gt;&gt;&gt;&gt;&gt;&gt;&gt;</c>)
+    /// at the start of a line; valid Gum XML never does (angle brackets in content are escaped),
+    /// so a start-of-line match is an unambiguous signal with effectively no false positives.
+    /// </summary>
+    private static bool ContainsGitConflictMarkers(string content)
+    {
+        foreach (string line in content.Split('\n'))
+        {
+            if (line.StartsWith("<<<<<<<") ||
+                line.StartsWith("=======") ||
+                line.StartsWith(">>>>>>>"))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>Builds the shared, actionable conflict-marker error message for the given file.</summary>
+    private static string ConflictMarkerMessage(string fileName) =>
+        $"{fileName} contains unresolved git conflict markers (<<<<<<< / ======= / >>>>>>>). " +
+        "Resolve the conflict in your editor (e.g. VS Code) and reload.";
 
     /// <summary>
     /// Converts missing file paths into <see cref="ErrorResult"/> entries with Warning severity.


### PR DESCRIPTION
Closes #3153

## Problem

When a Gum file (`.gumx`, `.gusx`, `.gucx`, `.gutx`, `.behx`) contains unresolved git conflict markers (`<<<<<<<` / `=======` / `>>>>>>>`) left by a merge or rebase, it is no longer valid XML. Previously this surfaced as a generic `error in XML document (line, col)` deserialization failure, giving no hint that an unresolved merge conflict was the real cause.

## Change

`ProjectLoader` now scans raw file text for conflict markers **before** XML deserialization, so the clear message wins over the parser's cryptic one:

- **Main `.gumx`** — a conflict is fatal (the project can't load). Reports an actionable message naming the markers instead of the parser error, and stops.
- **Element/behavior files** — follows the existing per-element error model: the rest of the project still loads, and the conflicted element gets an `Error`-severity entry (the ❗ marker) naming the conflict markers; sibling elements are unaffected. The cryptic `Malformed XML` entry that the failed element parse would otherwise produce is deduped away so only the clear conflict message remains.

Detection is a start-of-line marker scan — git always writes the markers at column 0, and valid Gum XML never does (angle brackets in content are escaped), so there are effectively no false positives.

Because this lives in the headless `ProjectLoader`, both the tool's Errors tab and `gumcli check` benefit, consistent with the existing error-checker design (`DetectSilentlyDroppedContent`).

## Tests

Added to `ProjectLoaderTests`:
- `.gumx` with conflict markers → fatal load error whose message names the conflict markers.
- An element file with conflict markers → project still loads; `Error`-severity entry naming the conflict markers for that element; a healthy sibling component is present and error-free.

Full `Gum.ProjectServices.Tests` suite: 295 passed, 2 skipped (pre-existing helpers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
