### PR TITLE
#731: Resolve loose content from macOS .app bundle Resources directory

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -230,3 +230,38 @@ jobs:
           path: "TestResults/*.trx"
           reporter: dotnet-trx
           fail-on-error: true
+
+      # End-to-end verification for issue #731: Gum looked for loose content relative to the executable,
+      # which is wrong inside a macOS .app bundle (exe in Contents/MacOS/, content in Contents/Resources/).
+      # The unit tests above cover the path-rebasing logic on every OS; this step is the only thing that
+      # exercises the real bundle layout by publishing a tiny harness, assembling a genuine .app, and
+      # running it from Contents/MacOS/. The harness exits non-zero if Gum fails to resolve the content,
+      # so `set -e` turns that into a failed build. This is what removes the need to test #731 by hand.
+      - name: macOS .app bundle content resolution (issue #731)
+        if: runner.os == 'macOS' && (github.event_name != 'push' || steps.cache-workloads.outputs.cache-hit != 'true')
+        run: |
+          set -euo pipefail
+
+          ARCH=$(uname -m)
+          if [ "$ARCH" = "arm64" ]; then RID="osx-arm64"; else RID="osx-x64"; fi
+          echo "Publishing #731 harness for $RID"
+
+          dotnet publish Tests/MacOSBundle.Harness/MacOSBundle.Harness.csproj -c Release -r "$RID" --self-contained true -o "$RUNNER_TEMP/harness-publish"
+
+          APP="$RUNNER_TEMP/MacOSBundleHarness.app"
+          rm -rf "$APP"
+          mkdir -p "$APP/Contents/MacOS" "$APP/Contents/Resources/Content"
+
+          # Executable + runtime live in Contents/MacOS/.
+          cp -R "$RUNNER_TEMP/harness-publish/." "$APP/Contents/MacOS/"
+
+          # Content ships ONLY in Contents/Resources/ — the layout that broke #731. The harness also
+          # asserts the file is absent next to the executable, so the bundle rebase is genuinely tested.
+          # The fix keys off the Contents/MacOS -> Contents/Resources path relationship via
+          # AppContext.BaseDirectory, so no Info.plist / NSBundle wiring is required.
+          printf 'gum-bundle-ok' > "$APP/Contents/Resources/Content/macos-bundle-test.txt"
+
+          chmod +x "$APP/Contents/MacOS/MacOSBundle.Harness"
+
+          echo "Running harness from inside the .app bundle (its exit code is the assertion)..."
+          "$APP/Contents/MacOS/MacOSBundle.Harness"

--- a/MonoGameGum.Tests/ToolsUtilities/FileManagerTests.cs
+++ b/MonoGameGum.Tests/ToolsUtilities/FileManagerTests.cs
@@ -62,4 +62,77 @@ public class FileManagerTests : IDisposable
         text.ShouldBe("Test content A");
         text2.ShouldBe("Test content A2");
     }
+
+    // --- macOS .app bundle content resolution (issue #731) ---------------------------------------
+    // In a macOS .app bundle the executable lives in <Bundle>.app/Contents/MacOS/ but loose content
+    // ships in <Bundle>.app/Contents/Resources/. GetMacOSBundleResourcesPath is the pure path-math
+    // seam that rebases an exe-relative absolute path onto the sibling Resources directory. It is OS-
+    // and filesystem-agnostic (it takes the exe directory as a parameter), so these tests exercise the
+    // real fix logic on every CI OS, not just macos-15. The end-to-end "launch from a real .app" check
+    // lives in the macOS-only CI step.
+
+    private static string Bundle(params string[] segments) =>
+        Path.DirectorySeparatorChar + string.Join(Path.DirectorySeparatorChar, segments);
+
+    [Fact]
+    public void GetMacOSBundleResourcesPath_ShouldRebaseOntoResources_WhenExeIsInMacOSBundle()
+    {
+        string exeDirectory = Bundle("Apps", "MyGame.app", "Contents", "MacOS") + Path.DirectorySeparatorChar;
+        string absolutePath = exeDirectory + Path.Combine("Content", "fonts", "test.fnt");
+
+        string? result = FileManager.GetMacOSBundleResourcesPath(absolutePath, exeDirectory);
+
+        result.ShouldBe(Bundle("Apps", "MyGame.app", "Contents", "Resources", "Content", "fonts", "test.fnt"));
+    }
+
+    [Fact]
+    public void GetMacOSBundleResourcesPath_ShouldReturnNull_WhenExeIsNotInBundle()
+    {
+        string exeDirectory = Bundle("Apps", "MyGame") + Path.DirectorySeparatorChar;
+        string absolutePath = exeDirectory + Path.Combine("Content", "fonts", "test.fnt");
+
+        FileManager.GetMacOSBundleResourcesPath(absolutePath, exeDirectory).ShouldBeNull();
+    }
+
+    [Fact]
+    public void GetMacOSBundleResourcesPath_ShouldReturnNull_WhenPathIsNotUnderExeDirectory()
+    {
+        string exeDirectory = Bundle("Apps", "MyGame.app", "Contents", "MacOS") + Path.DirectorySeparatorChar;
+        string absolutePath = Bundle("SomewhereElse", "Content", "fonts", "test.fnt");
+
+        FileManager.GetMacOSBundleResourcesPath(absolutePath, exeDirectory).ShouldBeNull();
+    }
+
+    [Fact]
+    public void GetMacOSBundleResourcesPath_ShouldResolveRealFile_WhenContentShippedInResources()
+    {
+        // Build a real .app directory layout in a temp dir: content physically in Resources, nothing
+        // under MacOS. This proves the rebased path points at the actual on-disk file.
+        string bundleRoot = Path.Combine(Path.GetTempPath(), "GumBundleTest_" + Guid.NewGuid().ToString("N"));
+        string exeDirectory = Path.Combine(bundleRoot, "MyGame.app", "Contents", "MacOS") + Path.DirectorySeparatorChar;
+        string resourcesContentDirectory = Path.Combine(bundleRoot, "MyGame.app", "Contents", "Resources", "Content", "fonts");
+        try
+        {
+            Directory.CreateDirectory(exeDirectory);
+            Directory.CreateDirectory(resourcesContentDirectory);
+            string realFile = Path.Combine(resourcesContentDirectory, "test.fnt");
+            File.WriteAllText(realFile, "font data");
+
+            string exeRelativePath = exeDirectory + Path.Combine("Content", "fonts", "test.fnt");
+            File.Exists(exeRelativePath).ShouldBeFalse();
+
+            string? rebased = FileManager.GetMacOSBundleResourcesPath(exeRelativePath, exeDirectory);
+
+            rebased.ShouldNotBeNull();
+            File.Exists(rebased).ShouldBeTrue();
+            File.ReadAllText(rebased!).ShouldBe("font data");
+        }
+        finally
+        {
+            if (Directory.Exists(bundleRoot))
+            {
+                Directory.Delete(bundleRoot, recursive: true);
+            }
+        }
+    }
 }

--- a/RenderingLibrary/Content/ContentLoader.cs
+++ b/RenderingLibrary/Content/ContentLoader.cs
@@ -205,7 +205,18 @@ public class ContentLoader : IContentLoader
         bool canCheckFileExists = OperatingSystem.IsWindows()
             || OperatingSystem.IsLinux()
             || OperatingSystem.IsMacOS();
-        if (canCheckFileExists && XnaContentManager == null && !System.IO.File.Exists(fileNameStandardized))
+
+        bool existsOnDisk = System.IO.File.Exists(fileNameStandardized);
+        if (!existsOnDisk && OperatingSystem.IsMacOS())
+        {
+            // In a macOS .app bundle, content ships in Contents/Resources/ rather than next to the
+            // executable, so a file missing at the exe-relative path may still exist there. Don't bail
+            // early in that case; GetStreamForFile below performs the same rebase when opening (issue #731).
+            string? resourcesPath = FileManager.GetMacOSBundleResourcesPath(fileNameStandardized, FileManager.ExeLocation);
+            existsOnDisk = resourcesPath != null && System.IO.File.Exists(resourcesPath);
+        }
+
+        if (canCheckFileExists && XnaContentManager == null && !existsOnDisk)
         {
             return null;
         }

--- a/Tests/MacOSBundle.Harness/MacOSBundle.Harness.csproj
+++ b/Tests/MacOSBundle.Harness/MacOSBundle.Harness.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    End-to-end harness for issue #731. This project is NOT part of any solution and is not a unit-test
+    project: it is published and packaged into a real macOS .app bundle by the macOS CI job, then run
+    from Contents/MacOS/ to prove Gum resolves loose content shipped in Contents/Resources/. See the
+    "macOS .app bundle content resolution (issue #731)" step in .github/workflows/build-and-test.yaml.
+  -->
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <AssemblyName>MacOSBundle.Harness</AssemblyName>
+    <RootNamespace>MacOSBundle.Harness</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\GumCommon\GumCommon.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Tests/MacOSBundle.Harness/Program.cs
+++ b/Tests/MacOSBundle.Harness/Program.cs
@@ -1,0 +1,59 @@
+using System;
+using System.IO;
+using ToolsUtilities;
+
+// End-to-end check for issue #731: when launched from inside a macOS .app bundle, Gum must resolve
+// loose content that ships in Contents/Resources/ even though the executable lives in Contents/MacOS/.
+// The macOS CI job publishes this harness, packages it into a real .app, and runs it from
+// Contents/MacOS/. It returns 0 when content is resolved correctly and non-zero otherwise, so the CI
+// step asserts purely on the process exit code.
+
+const string relativeContentPath = "Content/macos-bundle-test.txt";
+const string expectedContents = "gum-bundle-ok";
+
+Console.WriteLine($"[macOS bundle harness] ExeLocation = {FileManager.ExeLocation}");
+
+if (!OperatingSystem.IsMacOS())
+{
+    return Fail("expected to run on macOS.");
+}
+
+// The exe-relative path must NOT exist on disk; otherwise the bundle layout isn't being exercised
+// and a pass would prove nothing.
+string exeRelativeAbsolute = FileManager.ExeLocation + relativeContentPath.Replace('/', Path.DirectorySeparatorChar);
+if (File.Exists(exeRelativeAbsolute))
+{
+    return Fail($"content unexpectedly present next to the executable at '{exeRelativeAbsolute}'; " +
+        "the bundle layout is not being tested.");
+}
+
+// FileExists must rebase onto Contents/Resources/ and find the file there.
+if (!FileManager.FileExists(relativeContentPath))
+{
+    return Fail($"FileManager.FileExists could not find '{relativeContentPath}' in the bundle's Resources directory.");
+}
+
+// FromFileText goes through GetStreamForFile, the same path a custom .fnt load uses.
+string actualContents;
+try
+{
+    actualContents = FileManager.FromFileText(relativeContentPath).Trim();
+}
+catch (Exception e)
+{
+    return Fail($"FileManager.FromFileText threw resolving '{relativeContentPath}': {e}");
+}
+
+if (actualContents != expectedContents)
+{
+    return Fail($"content mismatch. Expected '{expectedContents}', got '{actualContents}'.");
+}
+
+Console.WriteLine("[macOS bundle harness] PASS: resolved content from Contents/Resources/ via Gum's FileManager.");
+return 0;
+
+static int Fail(string message)
+{
+    Console.Error.WriteLine($"[macOS bundle harness] FAIL: {message}");
+    return 1;
+}

--- a/ToolsUtilities/FileManager.cs
+++ b/ToolsUtilities/FileManager.cs
@@ -170,6 +170,19 @@ namespace ToolsUtilities
                         return true;
                     }
 
+#if NET6_0_OR_GREATER
+                    // macOS .app bundles ship loose content in Contents/Resources/ rather than next to
+                    // the executable in Contents/MacOS/, so probe the rebased path as well (issue #731).
+                    if (System.OperatingSystem.IsMacOS())
+                    {
+                        string? resourcesPath = GetMacOSBundleResourcesPath(fileName, ExeLocation);
+                        if (resourcesPath != null && File.Exists(resourcesPath))
+                        {
+                            return true;
+                        }
+                    }
+#endif
+
                     // A host (e.g. Gum's own bundle loader, or a game-installed asset zip)
                     // may resolve files that aren't on the real filesystem. Probe through
                     // the same seam GetStreamForFile uses so consumers like the deferred-
@@ -504,6 +517,49 @@ namespace ToolsUtilities
             return Standardize(pathToMakeAbsolute, true, true);// RelativeDirectory + pathToMakeAbsolute;
         }
 
+        /// <summary>
+        /// Rebases an executable-relative absolute path onto the sibling <c>Contents/Resources/</c>
+        /// directory of a macOS <c>.app</c> bundle. In a bundle the executable lives in
+        /// <c>&lt;Bundle&gt;.app/Contents/MacOS/</c> but loose content typically ships in
+        /// <c>&lt;Bundle&gt;.app/Contents/Resources/</c>, so a path resolved relative to the executable
+        /// directory will not find content that was placed in Resources (issue #731).
+        /// </summary>
+        /// <param name="absolutePath">An absolute path that was resolved relative to the executable directory.</param>
+        /// <param name="exeDirectory">The executable directory (typically <see cref="ExeLocation"/>), expected to end in <c>Contents/MacOS/</c>.</param>
+        /// <returns>
+        /// The equivalent path under <c>Contents/Resources/</c>, or <see langword="null"/> if
+        /// <paramref name="exeDirectory"/> is not a <c>Contents/MacOS/</c> bundle directory or
+        /// <paramref name="absolutePath"/> does not live under it. This is pure path math with no OS or
+        /// filesystem dependency; callers gate invocation on macOS and probe the returned path's existence.
+        /// </returns>
+        public static string? GetMacOSBundleResourcesPath(string absolutePath, string exeDirectory)
+        {
+            if (string.IsNullOrEmpty(absolutePath) || string.IsNullOrEmpty(exeDirectory))
+            {
+                return null;
+            }
+
+            char separator = Path.DirectorySeparatorChar;
+            absolutePath = absolutePath.Replace('\\', separator).Replace('/', separator);
+            exeDirectory = exeDirectory.Replace('\\', separator).Replace('/', separator);
+
+            string macOsSuffix = $"{separator}Contents{separator}MacOS{separator}";
+            if (!exeDirectory.EndsWith(macOsSuffix, StringComparison.OrdinalIgnoreCase))
+            {
+                return null;
+            }
+
+            // Only rebase paths that actually resolve under the executable directory.
+            if (!absolutePath.StartsWith(exeDirectory, StringComparison.OrdinalIgnoreCase))
+            {
+                return null;
+            }
+
+            string resourcesDirectory = exeDirectory.Substring(0, exeDirectory.Length - macOsSuffix.Length)
+                + $"{separator}Contents{separator}Resources{separator}";
+            return resourcesDirectory + absolutePath.Substring(exeDirectory.Length);
+        }
+
         public static string MakeRelative(string pathToMakeRelative, string pathToMakeRelativeTo)
         {
             return MakeRelative(pathToMakeRelative, pathToMakeRelativeTo, false);
@@ -802,6 +858,20 @@ namespace ToolsUtilities
                 {
                     fileName = fileName.Replace('\\', Path.DirectorySeparatorChar)
                         .Replace('/', Path.DirectorySeparatorChar);
+
+#if NET6_0_OR_GREATER
+                    // In a macOS .app bundle the executable is in Contents/MacOS/ but loose content
+                    // ships in Contents/Resources/. Gum anchored fileName on the executable directory,
+                    // so if it isn't there, retry against the bundle's Resources directory (issue #731).
+                    if (System.OperatingSystem.IsMacOS() && !File.Exists(fileName))
+                    {
+                        string? resourcesPath = GetMacOSBundleResourcesPath(fileName, ExeLocation);
+                        if (resourcesPath != null && File.Exists(resourcesPath))
+                        {
+                            fileName = resourcesPath;
+                        }
+                    }
+#endif
 
                     return System.IO.File.OpenRead(fileName);
                 }


### PR DESCRIPTION
Closes #731.

## Problem

Gum resolves loose content (`CustomFontFile`, sprite textures, etc.) relative to the executable directory (`FileManager.ExeLocation` → `AppContext.BaseDirectory`). Inside a macOS `.app` bundle the executable lives in `Contents/MacOS/` but content ships in `Contents/Resources/`, so anything placed there was never found — text silently fell back to the default font, sprites to the invalid-texture placeholder. MonoGame's own pipeline content avoids this because `TitleContainer` rebases onto `NSBundle.MainBundle.ResourcePath`; Gum's direct file loading never went through that.

## Fix

Fixed at the Gum level so **every** backend benefits (MonoGame, KNI, FNA, Raylib, Skia) — RaylibGum/SkiaGum on macOS have the same bug and no `TitleContainer` to lean on.

- `FileManager.GetMacOSBundleResourcesPath(absolutePath, exeDirectory)` — a pure path-math helper that rebases a `Contents/MacOS/` path onto the sibling `Contents/Resources/`. It keys off `AppContext.BaseDirectory`, **not** `NSBundle`, so it needs no platform assembly and is unit-testable on any OS.
- `FileManager.FileExists` / `GetStreamForFile` probe the rebased path on macOS when the exe-relative path misses (covers both the `.fnt` read and texture-page loads, which both flow through `GetStreamForFile`).
- `ContentLoader`'s desktop `File.Exists` short-circuit no longer bails early for the bundle layout.

The documented workaround (placing content next to the executable in `Contents/MacOS/`) keeps working — the Resources path is only a fallback.

## Verification — answering "can we test this on CI mac?"

The repo already runs a `macos-15` CI job, so the answer is yes, two layers:

1. **Deterministic unit tests** (`FileManagerTests`) — cover the rebasing logic on every CI OS (Windows + macOS), including a real temp-directory bundle layout proving the rebased path points at the on-disk file. Full headless suite: **1711/1711 green**, no new warnings.
2. **True end-to-end** — a new macOS-only step in `build-and-test.yaml` publishes the new `Tests/MacOSBundle.Harness` project, assembles a genuine `.app`, places content **only** in `Contents/Resources/`, and runs the harness from `Contents/MacOS/`. The harness also asserts the file is *absent* next to the executable (so the rebase is genuinely exercised) and exits non-zero — failing the build — if Gum can't resolve it. This removes the need to test #731 by hand on a Mac.

Builds verified locally across all backends: MonoGame (via `MonoGameGum.Tests`), KNI, Raylib, Skia.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
