### PR TITLE
Correct skill docs: shape runtimes are unified across all backends (not MonoGame/Skia-only)

### DIFF
--- a/.claude/skills/gum-cross-platform-unification/SKILL.md
+++ b/.claude/skills/gum-cross-platform-unification/SKILL.md
@@ -17,6 +17,8 @@ Shape runtimes that exist on the Apos.Shapes side (`MonoGameGumShapes` / `KniGum
 
 Why a different home: these runtimes wrap Skia-specific renderables on one side and Apos.Shapes-specific renderables on the other. Neither platform's renderable surface aligns with the MonoGame/Raylib/Sokol axis, so putting the canonical file in `MonoGameGum/GueDeriving/` would be misleading. Reference implementation: `RoundedRectangleRuntime.cs`. Platform divergence uses `#if SKIA` (no `RAYLIB` / `XNALIKE` involved on this pair).
 
+**Scope of this pair — do not over-generalize.** This Apos↔Skia pairing covers only the **Apos-specific** runtimes (`RoundedRectangleRuntime`, `ColoredCircleRuntime`, `ArcRuntime`, `LineRuntime`). It is **not** a statement that shape support is MonoGame/Skia-only or that raylib lacks shapes. The general-purpose `RectangleRuntime`/`CircleRuntime` are unified on the normal `MonoGameGum/GueDeriving/` axis (`#if RAYLIB`/`SOKOL`/`SKIA`/`XNALIKE`) and reach full filled/rounded/shadowed capability on **every** backend — raylib included (it wraps the fully-featured `LineRectangle`/`LineCircle`). See [gum-runtime-topology](../gum-runtime-topology/SKILL.md) "Shapes are NOT MonoGame/Skia-only" for the per-backend renderable table.
+
 ## Disagreements Are the Whole Job
 
 When three files diverge, every difference falls into one of two buckets:

--- a/.claude/skills/gum-runtime-topology/SKILL.md
+++ b/.claude/skills/gum-runtime-topology/SKILL.md
@@ -22,7 +22,25 @@ Gum has **no single "runtime" assembly**. The same `RenderingLibrary.*` / `GumCo
 
 ## Render backends
 
-XNA-family (`MonoGameGum`, `KniGum`, `FnaGum`), `RaylibGum`, `SkiaGum` (+ hosts `SkiaGum.Maui`, `SkiaGum.Wpf`), `SokolGum`. Shape runtimes: `MonoGameGumShapes`/`KniGumShapes` (Apos.Shapes) ↔ `SkiaGum` pair. For the per-runtime file-sharing/unification pattern see [gum-cross-platform-unification](../gum-cross-platform-unification/SKILL.md).
+XNA-family (`MonoGameGum`, `KniGum`, `FnaGum`), `RaylibGum`, `SkiaGum` (+ hosts `SkiaGum.Maui`, `SkiaGum.Wpf`), `SokolGum`. For the per-runtime file-sharing/unification pattern see [gum-cross-platform-unification](../gum-cross-platform-unification/SKILL.md).
+
+### Shapes are NOT MonoGame/Skia-only — no backend is the outlier
+
+Shape runtimes (`RectangleRuntime`/`CircleRuntime` — corner radius, two-slot fill/stroke, drop shadows, dashed strokes, gradients) are **unified across all backends, and every backend reaches full capability** via its recommended renderable; only the contained renderable differs:
+
+| Backend | Contained renderable (recommended path) |
+|---|---|
+| raylib / Sokol | `LineRectangle` / `LineCircle` |
+| Skia | `RoundedRectangle` (#2818) |
+| XNA-family **+ Apos.Shapes** (`MonoGameGumShapes`/`KniGumShapes`, recommended) | Apos `RoundedRectangle` |
+| XNA-family, no Apos | `SolidRectangle`+`LineRectangle` split — degraded fallback, no real radius/shadow |
+
+The no-Apos XNA split is a **degraded fallback, not a separate tier or an outlier**. Two traps that produced wrong conclusions here:
+
+- ⚠ **Don't infer capability from type names.** raylib's `LineRectangle`/`LineCircle` are full filled + rounded + drop-shadowed shapes (they mirror Apos/Skia — see the `<inheritdoc cref="SkiaGum...SkiaShapeRuntime">` in `Runtimes/RaylibGum/Renderables/`), despite the outline-suggesting names. A directory listing is not the API surface — read the renderable.
+- ⚠ The `MonoGameGumShapes`/`KniGumShapes` ↔ `SkiaGum` **"pair"** (in [gum-cross-platform-unification](../gum-cross-platform-unification/SKILL.md)) is only a *source-sharing* link for the **Apos-specific** `RoundedRectangleRuntime`/`ColoredCircleRuntime` types — **not** a claim that shape support is MonoGame/Skia-only or that raylib lacks it.
+
+Consequence for themes: a rounded/shadowed theme's visual code (`new RectangleRuntime { CornerRadius = …, HasDropshadow = … }`) is portable to raylib at the type level — the shape layer is a non-issue.
 
 ## Three source-sharing mechanisms (each is a separate landmine)
 


### PR DESCRIPTION
## What

Corrects two skill files that framed Gum's shape runtimes as a MonoGame/Skia-only feature, which led to a wrong conclusion in conversation: that raylib can't render rounded/drop-shadowed Forms theme visuals (and therefore couldn't ship theme NuGet packages).

## Why it was wrong

`gum-runtime-topology` line 25 described shapes as a `MonoGameGumShapes`/`KniGumShapes` (Apos.Shapes) ↔ `SkiaGum` **"pair"** — omitting raylib/Sokol entirely. That "pair" is only a *source-sharing* relationship for the **Apos-specific** types (`RoundedRectangleRuntime`, `ColoredCircleRuntime`, …), not a statement about shape capability.

Per `MonoGameGum/GueDeriving/RectangleRuntime.cs`, the general-purpose `RectangleRuntime`/`CircleRuntime` are unified across **all** backends, and each reaches full filled/rounded/drop-shadowed capability via its own renderable:

| Backend | Contained renderable (recommended path) |
|---|---|
| raylib / Sokol | `LineRectangle` / `LineCircle` (fully featured despite the outline-suggesting name) |
| Skia | `RoundedRectangle` |
| XNA-family **+ Apos.Shapes** (recommended) | Apos `RoundedRectangle` |
| XNA-family, no Apos | `SolidRectangle`+`LineRectangle` split — degraded fallback only |

No backend is the outlier.

## Changes

- **`gum-runtime-topology`**: replaced the misleading one-liner with a "Shapes are NOT MonoGame/Skia-only" section, including the per-backend renderable table and two flagged traps (type names ≠ capability; the Apos↔Skia "pair" is source-sharing of the Apos-specific types only).
- **`gum-cross-platform-unification`**: scoped the Apos↔Skia "pair" claim so it isn't read as "raylib lacks shapes," with a cross-reference to the topology table.

Docs-only (skill files); no code or build impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
