### PR TITLE
#3166: Pack AutoGrid rows/columns when they spill past the cell minimum

### DIFF
--- a/GumRuntime/GraphicalUiElement.cs
+++ b/GumRuntime/GraphicalUiElement.cs
@@ -4432,26 +4432,44 @@ public partial class GraphicalUiElement : IRenderableIpso, IVisible, INotifyProp
     private void GetCellDimensions(int indexInSiblingList, out int xIndex, out int yIndex, out float cellWidth, out float cellHeight)
     {
         var effectiveParent = EffectiveParentGue;
-        var xRows = effectiveParent.AutoGridHorizontalCells;
-        var yRows = effectiveParent.AutoGridVerticalCells;
-        if (xRows < 1) xRows = 1;
-        if (yRows < 1) yRows = 1;
+        var columnCount = effectiveParent.AutoGridHorizontalCells;
+        var rowCount = effectiveParent.AutoGridVerticalCells;
+        if (columnCount < 1) columnCount = 1;
+        if (rowCount < 1) rowCount = 1;
+
+        var childCount = effectiveParent.Children?.Count ?? 0;
 
         if (effectiveParent.ChildrenLayout == ChildrenLayout.AutoGridHorizontal)
         {
-            xIndex = indexInSiblingList % xRows;
-            yIndex = indexInSiblingList / xRows;
+            xIndex = indexInSiblingList % columnCount;
+            yIndex = indexInSiblingList / columnCount;
+
+            // The number of columns is fixed by AutoGridHorizontalCells, but AutoGridVerticalCells
+            // is only a *minimum* row count - the grid grows more rows as children are added. The
+            // cell height must be divided by that grown row count, not by the raw (minimum)
+            // AutoGridVerticalCells; otherwise, once rows spill past the minimum, each cell ends up
+            // taller than one row and the rows spread apart with every added item. This mirrors the
+            // row count used when sizing the parent (see UpdateHeight).
+            var requiredRowCount = (int)Math.Ceiling((float)childCount / columnCount);
+            rowCount = System.Math.Max(rowCount, requiredRowCount);
         }
         else // vertical
         {
-            yIndex = indexInSiblingList % yRows;
-            xIndex = indexInSiblingList / yRows;
-        }
-        var parentWidth = effectiveParent.GetAbsoluteWidth() - (xRows - 1) * effectiveParent.StackSpacing;
-        var parentHeight = effectiveParent.GetAbsoluteHeight() - (yRows - 1) * effectiveParent.StackSpacing;
+            yIndex = indexInSiblingList % rowCount;
+            xIndex = indexInSiblingList / rowCount;
 
-        cellWidth = (parentWidth / xRows) ;
-        cellHeight = (parentHeight / yRows);
+            // Symmetric to the horizontal case: rows are fixed by AutoGridVerticalCells, while
+            // AutoGridHorizontalCells is only a minimum column count that grows with the child
+            // count. Cell width is divided by that grown column count. This mirrors the column
+            // count used when sizing the parent (see UpdateWidth).
+            var requiredColumnCount = (int)Math.Ceiling((float)childCount / rowCount);
+            columnCount = System.Math.Max(columnCount, requiredColumnCount);
+        }
+        var parentWidth = effectiveParent.GetAbsoluteWidth() - (columnCount - 1) * effectiveParent.StackSpacing;
+        var parentHeight = effectiveParent.GetAbsoluteHeight() - (rowCount - 1) * effectiveParent.StackSpacing;
+
+        cellWidth = (parentWidth / columnCount);
+        cellHeight = (parentHeight / rowCount);
 
         // January 15, 2025
         // If a parent height

--- a/MonoGameGum.Tests/Runtimes/GraphicalUiElementTests.cs
+++ b/MonoGameGum.Tests/Runtimes/GraphicalUiElementTests.cs
@@ -271,7 +271,7 @@ public class GraphicalUiElementTests : BaseTestClass
     }
 
     [Fact]
-    public void AutoGridHorizontal_ShouldSizeHeight_AccordingToColumnCount_WithSpillover()
+    public void AutoGridHorizontal_ShouldGrowHeight_AsRowsSpillPastVerticalCells()
     {
         ContainerRuntime container = new();
         container.Height = 0;
@@ -388,7 +388,7 @@ public class GraphicalUiElementTests : BaseTestClass
     }
 
     [Fact]
-    public void AutoGridVertical_ShouldSizeWidth_AccordingToRowCount_WithSpillover()
+    public void AutoGridVertical_ShouldGrowWidth_AsColumnsSpillPastHorizontalCells()
     {
         ContainerRuntime container = new();
         container.Width = 0;

--- a/MonoGameGum.Tests/Runtimes/GraphicalUiElementTests.cs
+++ b/MonoGameGum.Tests/Runtimes/GraphicalUiElementTests.cs
@@ -469,6 +469,109 @@ public class GraphicalUiElementTests : BaseTestClass
         fillContainer2.AbsoluteTop.ShouldBe(0);
     }
 
+    [Fact]
+    public void AutoGridHorizontal_ShouldPackRows_WhenRowsSpillPastVerticalCells()
+    {
+        // Repro for #3166: an AutoGridHorizontal whose height is RelativeToChildren
+        // (e.g. a ListBox InnerPanel). AutoGridVerticalCells is a *minimum* row count;
+        // once the child count needs more rows than that, the rows must stay one cell
+        // apart, not spread further apart with each added row. The parent height is
+        // sized off max(AutoGridVerticalCells, requiredRows) rows, and the cell height
+        // (which drives row offsets) must use that same row count - not the raw
+        // AutoGridVerticalCells - or rows spread once they spill past the minimum.
+        ContainerRuntime container = new();
+        container.Width = 200;
+        container.WidthUnits = DimensionUnitType.Absolute;
+        container.Height = 0;
+        container.HeightUnits = DimensionUnitType.RelativeToChildren;
+
+        container.ChildrenLayout = Gum.Managers.ChildrenLayout.AutoGridHorizontal;
+        container.AutoGridHorizontalCells = 2;
+        container.AutoGridVerticalCells = 2;
+
+        for (int i = 0; i < 6; i++)
+        {
+            ContainerRuntime child = new();
+            child.WidthUnits = DimensionUnitType.Absolute;
+            child.Width = 100;
+            child.HeightUnits = DimensionUnitType.Absolute;
+            child.Height = 100;
+            container.AddChild(child);
+        }
+
+        // 6 children in a 2-column grid => 3 rows (spilling past the 2 minimum rows),
+        // each 100 tall.
+        container.GetAbsoluteHeight().ShouldBe(300);
+
+        container.Children[0].AbsoluteX.ShouldBe(0);
+        container.Children[0].AbsoluteY.ShouldBe(0);
+
+        container.Children[1].AbsoluteX.ShouldBe(100);
+        container.Children[1].AbsoluteY.ShouldBe(0);
+
+        container.Children[2].AbsoluteX.ShouldBe(0);
+        container.Children[2].AbsoluteY.ShouldBe(100);
+
+        container.Children[3].AbsoluteX.ShouldBe(100);
+        container.Children[3].AbsoluteY.ShouldBe(100);
+
+        container.Children[4].AbsoluteX.ShouldBe(0);
+        container.Children[4].AbsoluteY.ShouldBe(200);
+
+        container.Children[5].AbsoluteX.ShouldBe(100);
+        container.Children[5].AbsoluteY.ShouldBe(200);
+    }
+
+    [Fact]
+    public void AutoGridVertical_ShouldPackColumns_WhenColumnsSpillPastHorizontalCells()
+    {
+        // Symmetric counterpart to AutoGridHorizontal_ShouldPackRows_WhenRowsSpillPastVerticalCells (#3166):
+        // an AutoGridVertical whose width is RelativeToChildren. AutoGridHorizontalCells
+        // is a *minimum* column count; once the child count needs more columns than that,
+        // the columns must stay one cell apart rather than spreading.
+        ContainerRuntime container = new();
+        container.Height = 200;
+        container.HeightUnits = DimensionUnitType.Absolute;
+        container.Width = 0;
+        container.WidthUnits = DimensionUnitType.RelativeToChildren;
+
+        container.ChildrenLayout = Gum.Managers.ChildrenLayout.AutoGridVertical;
+        container.AutoGridVerticalCells = 2;
+        container.AutoGridHorizontalCells = 2;
+
+        for (int i = 0; i < 6; i++)
+        {
+            ContainerRuntime child = new();
+            child.WidthUnits = DimensionUnitType.Absolute;
+            child.Width = 100;
+            child.HeightUnits = DimensionUnitType.Absolute;
+            child.Height = 100;
+            container.AddChild(child);
+        }
+
+        // 6 children in a 2-row grid => 3 columns (spilling past the 2 minimum columns),
+        // each 100 wide.
+        container.GetAbsoluteWidth().ShouldBe(300);
+
+        container.Children[0].AbsoluteX.ShouldBe(0);
+        container.Children[0].AbsoluteY.ShouldBe(0);
+
+        container.Children[1].AbsoluteX.ShouldBe(0);
+        container.Children[1].AbsoluteY.ShouldBe(100);
+
+        container.Children[2].AbsoluteX.ShouldBe(100);
+        container.Children[2].AbsoluteY.ShouldBe(0);
+
+        container.Children[3].AbsoluteX.ShouldBe(100);
+        container.Children[3].AbsoluteY.ShouldBe(100);
+
+        container.Children[4].AbsoluteX.ShouldBe(200);
+        container.Children[4].AbsoluteY.ShouldBe(0);
+
+        container.Children[5].AbsoluteX.ShouldBe(200);
+        container.Children[5].AbsoluteY.ShouldBe(100);
+    }
+
     #endregion
 
     #region Animation


### PR DESCRIPTION
Closes #3166.

## Problem

In an `AutoGridHorizontal` layout, children fill rows and wrap correctly for a while, but once enough children are added the **rows begin to spread apart vertically** (a growing gap) instead of staying packed. Reported via a Forms `ListBox` whose `InnerPanel` is set to `AutoGridHorizontal` (`InnerPanel` height is `RelativeToChildren`).

## Root cause

`AutoGridHorizontalCells` / `AutoGridVerticalCells` are a **minimum** cell count along the wrapping axis, not a fixed count — both default to **4**, and the grid grows more rows (horizontal) / columns (vertical) as children are added. This is the documented behavior (`docs/.../height-units.md`: *"Auto Grid Vertical Cells acts only as a minimum and not maximum"*).

The parent's `RelativeToChildren` sizing already uses `max(minimumCells, requiredCells)` rows/columns. But `GraphicalUiElement.GetCellDimensions` (which drives child positions) divided the parent extent by the **raw minimum** (`AutoGridVerticalCells`) instead of that grown count:

```csharp
cellHeight = parentHeight / yRows;   // yRows = AutoGridVerticalCells (the minimum, e.g. 4)
```

So while the row count stays at or below the minimum the two divisors are equal and everything looks fine; once rows spill past the minimum, the parent is sized for N rows but each cell is still `parentHeight / minimum`, making every cell taller than one row — the rows spread, and the gap grows with each added item. With the default minimum of 4 and 2 columns, the break appears after the 8th item (the 5th row). The same defect exists symmetrically for `AutoGridVertical` cell width.

## Fix

Divide the cell dimension by `max(minimumCells, requiredCells)` — the same count `UpdateHeight` / `UpdateWidth` use to size the parent — so cells stay one unit apart in the spillover regime. The change only affects the spillover case (`required > minimum`); below the minimum the divisor is unchanged, so the intended **padding-distribution** behavior (a non-zero `Height`/`Width` on a `RelativeToChildren` grid spreading children evenly across reserved cells) is preserved. Also renamed the misleading `xRows`/`yRows` locals to `columnCount`/`rowCount` (the old `xRows` actually held the column count).

## Tests (TDD, red → green)

Added two layout tests in `MonoGameGum.Tests` that add children until they spill past the minimum cell count and assert row/column offsets stay one cell apart:

- `AutoGridHorizontal_ShouldPackRows_WhenRowsSpillPastVerticalCells`
- `AutoGridVertical_ShouldPackColumns_WhenColumnsSpillPastHorizontalCells`

Verified red before the fix (e.g. `Children[2].AbsoluteY` was `150` instead of `100`), green after. Full `MonoGameGum.Tests` suite passes (1713 tests, 0 failures).
