### PR TITLE
Docs: right-to-left stacking + gum-user-question-triage skill

### DIFF
--- a/.claude/skills/gum-user-question-triage/SKILL.md
+++ b/.claude/skills/gum-user-question-triage/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: gum-user-question-triage
+description: Answering Discord/GitHub user questions — search skills→docs→code, cite the docs URL, suggest doc/API fixes with confidence, or file an issue. Triggers: pasted user question, "how do I", GitHub issue triage, "answer this person".
+---
+
+# Answering User Questions
+
+Use when the user pastes a question from someone (Discord text, a GitHub issue, a `#N` reference) or asks you to help answer a person. Goal: a short reply they can paste back, grounded in a citable docs URL, plus a fix suggestion when docs or the API fall short.
+
+## 1. Classify First
+
+- **Usage question** ("how do I…", "does Gum support…", "why does X happen", "where is Y") → this skill handles it.
+- **Bug report, feature request, or concrete task** → fall through to the normal issue-driven workflow in `CLAUDE.local.md`. (A usage question can *still* end in an issue — see step 4 — but that's a docs/API gap we surface, not a defect the user reported.)
+
+For a **GitHub issue**, read both `gh issue view <num>` and `gh issue view <num> --comments` before deciding — comments often reclassify the ask.
+
+## 2. Where to Look: skills orient, docs cite, code confirms
+
+These are **roles, not a strict sequence** — you'll often touch all three in one pass. The point is what each is *for*:
+
+- **Skills** (`.claude/skills/`) **orient** — short, flag the gotchas, point you at the right doc page / source file. **Skills are internal scaffolding — never link or paste a skill to a user.**
+- **Docs** (`docs/`) **cite** — the page you give the user. Use `docs/SUMMARY.md` as the index. This is what produces the URL.
+- **Code** **confirms** — verifies the real behavior and locates where a doc *should* exist or where the API is wrong.
+
+If a skill or code answers the "why" but **no doc does**, that's a docs-gap signal (outcome C below).
+
+## 3. The Four Outcomes
+
+| Found | Outcome |
+|---|---|
+| **A. Clear doc answer** | Answer the user, prepend the docs URL. Done. |
+| **B. Weak doc answer** (correct but confusing, buried, missing a gotcha) | Answer + propose a doc improvement (reorg, wording, add the gotcha). |
+| **C. Answer only in code, docs missing** | Answer from code + propose where in `docs/` it should be documented. |
+| **D. Code is the problem** (confusing/contradictory names, missing or broken feature) | Answer honestly + propose an API fix. This is the case most likely to become an issue. |
+
+## 4. Always Produce
+
+1. **A paste-able reply** — human voice, no AI padding. Lead with the answer, include the docs URL when one exists, keep it to a few sentences. Point to the [Discord](https://discord.gg/EvqwmSQuBz) or a GitHub issue only when genuinely useful.
+2. **Confidence + justification** for any doc/API fix you propose (rubric below).
+3. **An issue** — only for outcomes C/D, and only *after* the user agrees. Then `gh issue create` with a descriptive title (reference related issue numbers like `#3163` when relevant). No template or label is required; labels are freeform and often omitted.
+
+## Confidence Rubric (for proposed fixes)
+
+- **High** — must justify: cite the contradicting doc/code, the broken behavior, or the duplicated/missing content. Don't claim High without the evidence.
+- **Medium** — plausible improvement, some judgment involved (wording, placement).
+- **Low** — a hunch worth raising; flag the uncertainty.
+
+## Approval Gate
+
+Propose first, act after sign-off. **Do not** edit `docs/`, change code, or run `gh issue create` until the user agrees. (Per the user's standing preference: doc fixes are proposed, then applied on approval.)
+
+## Building the Docs URL
+
+Published base: `https://docs.flatredball.com/gum/`. The path mirrors the `docs/` tree:
+
+- `docs/code/controls/listbox.md` → `https://docs.flatredball.com/gum/code/controls/listbox` (drop `.md`)
+- A folder's `README.md` → the folder path itself: `docs/gum-tool/setup/README.md` → `.../gum-tool/setup`
+- Heading anchor = heading lowercased, spaces→`-`, punctuation stripped: `## Keyboard and Gamepad Navigation` → `#keyboard-and-gamepad-navigation`
+
+Full example: `https://docs.flatredball.com/gum/code/controls/listbox#keyboard-and-gamepad-navigation`
+
+## Pointers
+
+- Doc-fix mechanics (SUMMARY.md, GitBook syntax, tone, tool-vs-code split) → `gum-docs-writing`. Don't restate them here.
+- Issue-creation / branch / worktree / PR flow → `CLAUDE.local.md`.
+- Domain skills (`gum-layout`, `gum-forms-*`, `gum-runtime-*`, etc.) are your first-pass index in step 2.

--- a/.claude/skills/gum-user-question-triage/SKILL.md
+++ b/.claude/skills/gum-user-question-triage/SKILL.md
@@ -14,6 +14,12 @@ Use when the user pastes a question from someone (Discord text, a GitHub issue, 
 
 For a **GitHub issue**, read both `gh issue view <num>` and `gh issue view <num> --comments` before deciding — comments often reclassify the ask.
 
+**Then decide the surface — tool or code.** The docs split into the **Gum Tool** (`docs/gum-tool/`, the WYSIWYG editor — menus, properties, editor workflows) and **Code** (`docs/code/`, runtime C# APIs). The *same* question usually has a different answer in each, so don't assume. (Tool cues: "in the editor", a menu/property/tab name, a screenshot. Code cues: C#, "in code", a class or method name.)
+
+- **Obvious which surface** → answer for that one only.
+- **Not obvious** → treat it as possibly both: run two investigations (`docs/gum-tool/` *and* `docs/code/`) and give two answers.
+- **Investigation is hard or hinges on what they meant** → ask the user to clarify the surface (and specifics) before digging deep.
+
 ## 2. Where to Look: skills orient, docs cite, code confirms
 
 These are **roles, not a strict sequence** — you'll often touch all three in one pass. The point is what each is *for*:

--- a/docs/code/layout/stacking.md
+++ b/docs/code/layout/stacking.md
@@ -104,14 +104,18 @@ for(int i = 0; i < 10; i++)
 
 Notice that since the `StackPanel` has had `Anchor(Anchor.Center)` called, it remains centered as it wraps and expands horizontally.
 
-## Bottom-Up Stacking
+## Bottom-Up and Right-to-Left Stacking
 
 A `StackPanel's` `Visual` only provides two possible stacking modes:
 
 * `ChildrenLayout.TopToBottomStack` (default)
 * `ChildrenLayout.LeftToRightStack`&#x20;
 
-By combining Dock and ChildrenLayout, we can create bottom-up and right-to-left stacking. The following code shows how to create a bottom-up stack similar to a chat room or command line:
+There is no dedicated "bottom-up" or "right-to-left" mode, but you can create either by combining `Anchor` (or `Dock`) with `ChildrenLayout`. In both cases the `StackPanel` is anchored to one edge, so it stays pinned to that edge and grows in the opposite direction as children are added.
+
+### Bottom-Up Stacking
+
+The following code creates a bottom-up stack similar to a chat room or command line. The `StackPanel` is anchored to the bottom, so newly-added children appear at the bottom and older children are pushed up:
 
 ```csharp
 // Class scope
@@ -145,6 +149,47 @@ protected override void Update(GameTime gameTime)
 ```
 
 <figure><img src="../../.gitbook/assets/17_19 12 47.gif" alt=""><figcaption><p>Bottom-up stack</p></figcaption></figure>
+
+### Right-to-Left Stacking
+
+Right-to-left stacking uses the same approach horizontally: set `ChildrenLayout` to `LeftToRightStack` and anchor the `StackPanel` to the right. The stack stays pinned to the right edge and grows toward the left as children are added, so the newest item appears on the right:
+
+```csharp
+// Class scope
+StackPanel stackPanel;
+
+protected override void Initialize()
+{
+    GumUI.Initialize(this);
+
+    stackPanel = new StackPanel();
+    stackPanel.AddToRoot();
+    stackPanel.Anchor(Gum.Wireframe.Anchor.Right);
+    stackPanel.Visual.ChildrenLayout =
+        Gum.Managers.ChildrenLayout.LeftToRightStack;
+
+    base.Initialize();
+}
+
+protected override void Update(GameTime gameTime)
+{
+    GumUI.Update(gameTime);
+
+    if(GumUI.Keyboard.KeyPushed(Microsoft.Xna.Framework.Input.Keys.Enter))
+    {
+        var label = new Label();
+        stackPanel.AddChild(label);
+        int index = stackPanel.Children.Count;
+        label.Text = $"Item {index}";
+    }
+
+    base.Update(gameTime);
+}
+```
+
+{% hint style="warning" %}
+TODO: Add a gif showing right-to-left stacking (newest item appearing on the right, older items pushed to the left).
+{% endhint %}
 
 ## Evenly-Sized Stacked Children
 


### PR DESCRIPTION
Bundles a docs fix with the skill that produced it.

## Docs: right-to-left stacking

A user asked whether a right-to-left `StackPanel` is possible. The **Bottom-Up Stacking** section in `docs/code/layout/stacking.md` already claimed *"we can create bottom-up and right-to-left stacking"* but only demonstrated bottom-up, leaving the right-to-left recipe unexplained.

- Renamed the section to **Bottom-Up and Right-to-Left Stacking** and split bottom-up and right-to-left into their own `###` subsections.
- Clarified the intro: there is no dedicated mode; both are composed from `Anchor`/`Dock` + `ChildrenLayout`, anchoring the stack to one edge so it grows in the opposite direction.
- Added a right-to-left example (`LeftToRightStack` + `Anchor.Right`) mirroring the bottom-up example. `Anchor.Right` is the horizontal mirror of the `Anchor.Bottom` used for bottom-up, so the stack pins to the right edge and grows leftward as children are added.
- Added a visible `{% hint %}` placeholder for a right-to-left demo gif (none exists yet).

## Skill: gum-user-question-triage

Adds a procedure skill for answering user questions from Discord/GitHub: classify usage-question vs issue-flow, look in skills/docs/code (skills orient, docs cite, code confirms), branch into one of four outcomes, and always produce a paste-able reply plus confidence-rated fix suggestions. The docs fix above was produced by running this flow, so the two are bundled per the repo's "improve guidance files alongside the work" convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
