### PR TITLE
Add dynamic font playground sample (MonoGame)

### DIFF
--- a/Samples/FontPlayground/FontPlayground.MonoGame.sln
+++ b/Samples/FontPlayground/FontPlayground.MonoGame.sln
@@ -1,0 +1,90 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FontPlayground.MonoGame", "FontPlayground.MonoGame\FontPlayground.MonoGame.csproj", "{491DC338-9127-47DA-9076-F2C3024DB517}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MonoGameGum", "..\..\MonoGameGum\MonoGameGum.csproj", "{5E095929-3D83-48FB-A77D-1A384A31A163}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GumCommon", "..\..\GumCommon\GumCommon.csproj", "{12C63A25-8228-46C6-B23C-9A655F281565}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "KernSmith.MonoGameGum", "..\..\Integrations\KernSmith\KernSmith.MonoGameGum\KernSmith.MonoGameGum.csproj", "{092B196F-4B1B-4BE1-8538-06E47E35AB7A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "KernSmith.GumCommon", "..\..\Integrations\KernSmith\KernSmith.GumCommon\KernSmith.GumCommon.csproj", "{51D6D892-CEFD-45E9-B7BF-B2A2D6927BE8}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{491DC338-9127-47DA-9076-F2C3024DB517}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{491DC338-9127-47DA-9076-F2C3024DB517}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{491DC338-9127-47DA-9076-F2C3024DB517}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{491DC338-9127-47DA-9076-F2C3024DB517}.Debug|x64.Build.0 = Debug|Any CPU
+		{491DC338-9127-47DA-9076-F2C3024DB517}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{491DC338-9127-47DA-9076-F2C3024DB517}.Debug|x86.Build.0 = Debug|Any CPU
+		{491DC338-9127-47DA-9076-F2C3024DB517}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{491DC338-9127-47DA-9076-F2C3024DB517}.Release|Any CPU.Build.0 = Release|Any CPU
+		{491DC338-9127-47DA-9076-F2C3024DB517}.Release|x64.ActiveCfg = Release|Any CPU
+		{491DC338-9127-47DA-9076-F2C3024DB517}.Release|x64.Build.0 = Release|Any CPU
+		{491DC338-9127-47DA-9076-F2C3024DB517}.Release|x86.ActiveCfg = Release|Any CPU
+		{491DC338-9127-47DA-9076-F2C3024DB517}.Release|x86.Build.0 = Release|Any CPU
+		{5E095929-3D83-48FB-A77D-1A384A31A163}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5E095929-3D83-48FB-A77D-1A384A31A163}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5E095929-3D83-48FB-A77D-1A384A31A163}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{5E095929-3D83-48FB-A77D-1A384A31A163}.Debug|x64.Build.0 = Debug|Any CPU
+		{5E095929-3D83-48FB-A77D-1A384A31A163}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{5E095929-3D83-48FB-A77D-1A384A31A163}.Debug|x86.Build.0 = Debug|Any CPU
+		{5E095929-3D83-48FB-A77D-1A384A31A163}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5E095929-3D83-48FB-A77D-1A384A31A163}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5E095929-3D83-48FB-A77D-1A384A31A163}.Release|x64.ActiveCfg = Release|Any CPU
+		{5E095929-3D83-48FB-A77D-1A384A31A163}.Release|x64.Build.0 = Release|Any CPU
+		{5E095929-3D83-48FB-A77D-1A384A31A163}.Release|x86.ActiveCfg = Release|Any CPU
+		{5E095929-3D83-48FB-A77D-1A384A31A163}.Release|x86.Build.0 = Release|Any CPU
+		{12C63A25-8228-46C6-B23C-9A655F281565}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{12C63A25-8228-46C6-B23C-9A655F281565}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{12C63A25-8228-46C6-B23C-9A655F281565}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{12C63A25-8228-46C6-B23C-9A655F281565}.Debug|x64.Build.0 = Debug|Any CPU
+		{12C63A25-8228-46C6-B23C-9A655F281565}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{12C63A25-8228-46C6-B23C-9A655F281565}.Debug|x86.Build.0 = Debug|Any CPU
+		{12C63A25-8228-46C6-B23C-9A655F281565}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{12C63A25-8228-46C6-B23C-9A655F281565}.Release|Any CPU.Build.0 = Release|Any CPU
+		{12C63A25-8228-46C6-B23C-9A655F281565}.Release|x64.ActiveCfg = Release|Any CPU
+		{12C63A25-8228-46C6-B23C-9A655F281565}.Release|x64.Build.0 = Release|Any CPU
+		{12C63A25-8228-46C6-B23C-9A655F281565}.Release|x86.ActiveCfg = Release|Any CPU
+		{12C63A25-8228-46C6-B23C-9A655F281565}.Release|x86.Build.0 = Release|Any CPU
+		{092B196F-4B1B-4BE1-8538-06E47E35AB7A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{092B196F-4B1B-4BE1-8538-06E47E35AB7A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{092B196F-4B1B-4BE1-8538-06E47E35AB7A}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{092B196F-4B1B-4BE1-8538-06E47E35AB7A}.Debug|x64.Build.0 = Debug|Any CPU
+		{092B196F-4B1B-4BE1-8538-06E47E35AB7A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{092B196F-4B1B-4BE1-8538-06E47E35AB7A}.Debug|x86.Build.0 = Debug|Any CPU
+		{092B196F-4B1B-4BE1-8538-06E47E35AB7A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{092B196F-4B1B-4BE1-8538-06E47E35AB7A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{092B196F-4B1B-4BE1-8538-06E47E35AB7A}.Release|x64.ActiveCfg = Release|Any CPU
+		{092B196F-4B1B-4BE1-8538-06E47E35AB7A}.Release|x64.Build.0 = Release|Any CPU
+		{092B196F-4B1B-4BE1-8538-06E47E35AB7A}.Release|x86.ActiveCfg = Release|Any CPU
+		{092B196F-4B1B-4BE1-8538-06E47E35AB7A}.Release|x86.Build.0 = Release|Any CPU
+		{51D6D892-CEFD-45E9-B7BF-B2A2D6927BE8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{51D6D892-CEFD-45E9-B7BF-B2A2D6927BE8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{51D6D892-CEFD-45E9-B7BF-B2A2D6927BE8}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{51D6D892-CEFD-45E9-B7BF-B2A2D6927BE8}.Debug|x64.Build.0 = Debug|Any CPU
+		{51D6D892-CEFD-45E9-B7BF-B2A2D6927BE8}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{51D6D892-CEFD-45E9-B7BF-B2A2D6927BE8}.Debug|x86.Build.0 = Debug|Any CPU
+		{51D6D892-CEFD-45E9-B7BF-B2A2D6927BE8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{51D6D892-CEFD-45E9-B7BF-B2A2D6927BE8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{51D6D892-CEFD-45E9-B7BF-B2A2D6927BE8}.Release|x64.ActiveCfg = Release|Any CPU
+		{51D6D892-CEFD-45E9-B7BF-B2A2D6927BE8}.Release|x64.Build.0 = Release|Any CPU
+		{51D6D892-CEFD-45E9-B7BF-B2A2D6927BE8}.Release|x86.ActiveCfg = Release|Any CPU
+		{51D6D892-CEFD-45E9-B7BF-B2A2D6927BE8}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/Samples/FontPlayground/FontPlayground.MonoGame/FontPlayground.MonoGame.csproj
+++ b/Samples/FontPlayground/FontPlayground.MonoGame/FontPlayground.MonoGame.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <RollForward>Major</RollForward>
+    <PublishReadyToRun>false</PublishReadyToRun>
+    <TieredCompilation>false</TieredCompilation>
+    <Nullable>disable</Nullable>
+    <ImplicitUsings>disable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.4.1" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\MonoGameGum\MonoGameGum.csproj" />
+    <ProjectReference Include="..\..\..\Integrations\KernSmith\KernSmith.MonoGameGum\KernSmith.MonoGameGum.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\Shared\FontPlaygroundScreen.cs" Link="FontPlaygroundScreen.cs" />
+  </ItemGroup>
+</Project>

--- a/Samples/FontPlayground/FontPlayground.MonoGame/Game1.cs
+++ b/Samples/FontPlayground/FontPlayground.MonoGame/Game1.cs
@@ -1,0 +1,64 @@
+using Gum;
+using Gum.Wireframe;
+using KernSmith.Gum;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Input;
+
+namespace FontPlayground.MonoGame;
+
+/// <summary>
+/// Thin MonoGame host for the dynamic-font playground. All UI and live-update logic lives in the
+/// platform-neutral <see cref="FontPlaygroundScreen"/> (shared via a linked source file). This host
+/// only bootstraps Gum, registers KernSmith for in-memory font generation, and pumps Update/Draw.
+///
+/// Fonts are generated in memory by KernSmith — there are no .fnt files shipped with this sample.
+/// </summary>
+public class Game1 : Game
+{
+    private readonly GraphicsDeviceManager _graphics;
+
+    public Game1()
+    {
+        _graphics = new GraphicsDeviceManager(this);
+        _graphics.PreferredBackBufferWidth = 1024;
+        _graphics.PreferredBackBufferHeight = 768;
+        Content.RootDirectory = "Content";
+        IsMouseVisible = true;
+    }
+
+    protected override void Initialize()
+    {
+        GumService.Default.Initialize(this);
+
+        // Wire up KernSmith so any TextRuntime can get a font for any (family, size, style)
+        // without a .fnt file on disk. This is what makes the live preview re-render work.
+        CustomSetPropertyOnRenderable.InMemoryFontCreator =
+            new KernSmithFontCreator(GraphicsDevice);
+
+        FontPlaygroundScreen.Build(GumService.Default.Root);
+
+        base.Initialize();
+    }
+
+    protected override void Update(GameTime gameTime)
+    {
+        if (GamePad.GetState(PlayerIndex.One).Buttons.Back == ButtonState.Pressed
+            || Keyboard.GetState().IsKeyDown(Keys.Escape))
+        {
+            Exit();
+        }
+
+        GumService.Default.Update(gameTime);
+
+        base.Update(gameTime);
+    }
+
+    protected override void Draw(GameTime gameTime)
+    {
+        GraphicsDevice.Clear(new Color(30, 30, 46));
+
+        GumService.Default.Draw();
+
+        base.Draw(gameTime);
+    }
+}

--- a/Samples/FontPlayground/FontPlayground.MonoGame/Program.cs
+++ b/Samples/FontPlayground/FontPlayground.MonoGame/Program.cs
@@ -1,0 +1,2 @@
+using var game = new FontPlayground.MonoGame.Game1();
+game.Run();

--- a/Samples/FontPlayground/Shared/FontPlaygroundScreen.cs
+++ b/Samples/FontPlayground/Shared/FontPlaygroundScreen.cs
@@ -1,0 +1,168 @@
+using System.Collections.Generic;
+using Gum.DataTypes;
+using Gum.Forms.Controls;
+using Gum.GueDeriving;
+using Gum.Wireframe;
+
+namespace FontPlayground;
+
+/// <summary>
+/// Builds the interactive dynamic-font playground UI. This class is written purely against
+/// the Gum.Forms API so it compiles unchanged on every backend (MonoGame, raylib, etc.).
+/// The host is responsible for initializing Gum and registering an
+/// <see cref="RenderingLibrary.Graphics.Fonts.IInMemoryFontCreator"/> (e.g. KernSmith) so the
+/// preview text can be re-rasterized live as the font settings change.
+/// </summary>
+public class FontPlaygroundScreen
+{
+    /// <summary>
+    /// The curated list of system font families offered in the family drop-down. These all
+    /// rasterize via KernSmith's GenerateFromSystem path on Windows; no bundled .ttf is needed.
+    /// </summary>
+    private static readonly List<string> FontFamilies = new()
+    {
+        "Arial",
+        "Times New Roman",
+        "Courier New",
+        "Verdana",
+        "Georgia",
+        "Comic Sans MS",
+    };
+
+    private ComboBox _fontFamilyComboBox = null!;
+    private Slider _fontSizeSlider = null!;
+    private Label _fontSizeLabel = null!;
+    private CheckBox _boldCheckBox = null!;
+    private CheckBox _italicCheckBox = null!;
+    private Slider _outlineSlider = null!;
+    private Label _outlineLabel = null!;
+    private CheckBox _smoothingCheckBox = null!;
+    private TextRuntime _previewText = null!;
+
+    /// <summary>
+    /// Builds the font-playground controls and preview text into the given root and wires up
+    /// live updates. Returns the created screen so the host can keep it alive if desired; the
+    /// host can also safely ignore the return value because the wired event handlers keep the
+    /// instance reachable through the visual tree.
+    /// </summary>
+    /// <param name="root">The root visual to add the playground UI to (e.g. GumService.Default.Root).</param>
+    public static FontPlaygroundScreen Build(InteractiveGue root)
+    {
+        FontPlaygroundScreen screen = new FontPlaygroundScreen();
+        screen.BuildInternal(root);
+        return screen;
+    }
+
+    private void BuildInternal(InteractiveGue root)
+    {
+        StackPanel controlsPanel = new StackPanel();
+        controlsPanel.Orientation = Orientation.Vertical;
+        controlsPanel.Spacing = 6;
+        controlsPanel.Visual.X = 16;
+        controlsPanel.Visual.Y = 16;
+        root.AddChild(controlsPanel);
+
+        // Font family
+        Label fontFamilyLabel = new Label();
+        fontFamilyLabel.Text = "Font Family";
+        controlsPanel.AddChild(fontFamilyLabel);
+
+        _fontFamilyComboBox = new ComboBox();
+        _fontFamilyComboBox.Width = 240;
+        foreach (string family in FontFamilies)
+        {
+            _fontFamilyComboBox.Items.Add(family);
+        }
+        _fontFamilyComboBox.SelectedObject = "Arial";
+        _fontFamilyComboBox.SelectionChanged += (_, _) => ApplyFontSettings();
+        controlsPanel.AddChild(_fontFamilyComboBox);
+
+        // Font size
+        _fontSizeLabel = new Label();
+        controlsPanel.AddChild(_fontSizeLabel);
+
+        _fontSizeSlider = new Slider();
+        _fontSizeSlider.Width = 240;
+        _fontSizeSlider.Minimum = 8;
+        _fontSizeSlider.Maximum = 96;
+        _fontSizeSlider.IsSnapToTickEnabled = true;
+        _fontSizeSlider.TicksFrequency = 1;
+        _fontSizeSlider.Value = 24;
+        _fontSizeSlider.ValueChanged += (_, _) => ApplyFontSettings();
+        controlsPanel.AddChild(_fontSizeSlider);
+
+        // Bold / Italic
+        _boldCheckBox = new CheckBox();
+        _boldCheckBox.Text = "Bold";
+        _boldCheckBox.Width = 240;
+        _boldCheckBox.Checked += (_, _) => ApplyFontSettings();
+        _boldCheckBox.Unchecked += (_, _) => ApplyFontSettings();
+        controlsPanel.AddChild(_boldCheckBox);
+
+        _italicCheckBox = new CheckBox();
+        _italicCheckBox.Text = "Italic";
+        _italicCheckBox.Width = 240;
+        _italicCheckBox.Checked += (_, _) => ApplyFontSettings();
+        _italicCheckBox.Unchecked += (_, _) => ApplyFontSettings();
+        controlsPanel.AddChild(_italicCheckBox);
+
+        // Outline thickness
+        _outlineLabel = new Label();
+        controlsPanel.AddChild(_outlineLabel);
+
+        _outlineSlider = new Slider();
+        _outlineSlider.Width = 240;
+        _outlineSlider.Minimum = 0;
+        _outlineSlider.Maximum = 8;
+        _outlineSlider.IsSnapToTickEnabled = true;
+        _outlineSlider.TicksFrequency = 1;
+        _outlineSlider.Value = 0;
+        _outlineSlider.ValueChanged += (_, _) => ApplyFontSettings();
+        controlsPanel.AddChild(_outlineSlider);
+
+        // Smoothing
+        _smoothingCheckBox = new CheckBox();
+        _smoothingCheckBox.Text = "Use Font Smoothing";
+        _smoothingCheckBox.Width = 240;
+        _smoothingCheckBox.IsChecked = true;
+        _smoothingCheckBox.Checked += (_, _) => ApplyFontSettings();
+        _smoothingCheckBox.Unchecked += (_, _) => ApplyFontSettings();
+        controlsPanel.AddChild(_smoothingCheckBox);
+
+        // Preview
+        _previewText = new TextRuntime();
+        _previewText.Text = "The quick brown fox 0123";
+        _previewText.X = 290;
+        _previewText.Y = 24;
+        // White text. Red/Green/Blue/Alpha are platform-neutral int properties (unlike the
+        // backend-specific Color property), so setting them here keeps this file portable.
+        _previewText.Red = 255;
+        _previewText.Green = 255;
+        _previewText.Blue = 255;
+        _previewText.Alpha = 255;
+        root.Children.Add(_previewText);
+
+        ApplyFontSettings();
+    }
+
+    /// <summary>
+    /// Pushes the current control values onto the preview <see cref="TextRuntime"/>. Each font
+    /// property setter triggers Gum's UpdateToFontValues, which asks the registered in-memory
+    /// font creator to (re)generate the atlas, producing the live re-render.
+    /// </summary>
+    private void ApplyFontSettings()
+    {
+        int fontSize = (int)_fontSizeSlider.Value;
+        int outlineThickness = (int)_outlineSlider.Value;
+
+        _fontSizeLabel.Text = $"Font Size: {fontSize}";
+        _outlineLabel.Text = $"Outline Thickness: {outlineThickness}";
+
+        _previewText.Font = _fontFamilyComboBox.SelectedObject as string ?? "Arial";
+        _previewText.FontSize = fontSize;
+        _previewText.IsBold = _boldCheckBox.IsChecked == true;
+        _previewText.IsItalic = _italicCheckBox.IsChecked == true;
+        _previewText.OutlineThickness = outlineThickness;
+        _previewText.UseFontSmoothing = _smoothingCheckBox.IsChecked == true;
+    }
+}


### PR DESCRIPTION
## What

A new interactive **dynamic font playground** sample for Gum. Pick a font family, size, bold/italic, outline thickness, and smoothing, and watch a `TextRuntime` re-render **live** — fonts are generated in memory at runtime by KernSmith, with no `.fnt` files on disk.

This is meant to be the hands-on verification surface for Gum's runtime font-generation path.

## Structure (built for cross-backend reuse)

- `Samples/FontPlayground/Shared/FontPlaygroundScreen.cs` — all the UI + live-update logic, written **purely against the Gum.Forms API** (no `#if`, no MonoGame/raylib types). A raylib host can link this exact file and share 100% of the behavior.
- `Samples/FontPlayground/FontPlayground.MonoGame/` — a thin host: `GumService.Default.Initialize(this)`, register `CustomSetPropertyOnRenderable.InMemoryFontCreator = new KernSmithFontCreator(GraphicsDevice)`, then `FontPlaygroundScreen.Build(GumService.Default.Root)`. The only platform-specific pieces are the bootstrap and that one registration line.

References the **in-repo `KernSmith.MonoGameGum` project** (merged in #3171), not the NuGet.

## How to run

```
dotnet run --project Samples/FontPlayground/FontPlayground.MonoGame
```

Escape exits.

## Notes

- Builds with 0 errors / 0 warnings (host project).
- Font families are a curated system-font list (Arial, Times New Roman, Courier New, Verdana, Georgia, Comic Sans MS) rasterized via KernSmith's `GenerateFromSystem`; no bundled `.ttf` needed.
- A follow-up will add the thin raylib host that links the same `FontPlaygroundScreen.cs`, once raylib's runtime font path reaches parity (#3162 / #3164).
