### PR TITLE
#3162/#3164: Raylib font parity via KernSmith + dynamic font playground (raylib)

### DIFF
--- a/.github/workflows/dotnet-nuget.yaml
+++ b/.github/workflows/dotnet-nuget.yaml
@@ -189,7 +189,7 @@ jobs:
         if ('${{ github.event.inputs.pkg_Expressions }}' -eq 'true') { $selected += 'Gum.Expressions' }
         if ('${{ github.event.inputs.pkg_Sokol }}' -eq 'true') { $selected += 'Gum.sokol' }
         if ('${{ github.event.inputs.pkg_GumCli }}' -eq 'true') { $selected += 'GumCli' }
-        if ('${{ github.event.inputs.pkg_KernSmith }}' -eq 'true') { $selected += 'KernSmith.GumCommon', 'KernSmith.MonoGameGum', 'KernSmith.KniGum' }
+        if ('${{ github.event.inputs.pkg_KernSmith }}' -eq 'true') { $selected += 'KernSmith.GumCommon', 'KernSmith.MonoGameGum', 'KernSmith.KniGum', 'KernSmith.RaylibGum' }
         $themesSelected = ('${{ github.event.inputs.pkg_Themes }}' -eq 'true')
 
         Write-Host "Selected packages: $($selected -join ', ')"
@@ -227,7 +227,7 @@ jobs:
         if ('${{ github.event.inputs.pkg_Expressions }}' -eq 'true') { $selected += 'Gum.Expressions' }
         if ('${{ github.event.inputs.pkg_Sokol }}' -eq 'true') { $selected += 'Gum.sokol' }
         if ('${{ github.event.inputs.pkg_GumCli }}' -eq 'true') { $selected += 'GumCli' }
-        if ('${{ github.event.inputs.pkg_KernSmith }}' -eq 'true') { $selected += 'KernSmith.GumCommon', 'KernSmith.MonoGameGum', 'KernSmith.KniGum' }
+        if ('${{ github.event.inputs.pkg_KernSmith }}' -eq 'true') { $selected += 'KernSmith.GumCommon', 'KernSmith.MonoGameGum', 'KernSmith.KniGum', 'KernSmith.RaylibGum' }
         $themesSelected = ('${{ github.event.inputs.pkg_Themes }}' -eq 'true')
 
         Write-Host "Selected packages: $($selected -join ', ')"

--- a/AllLibraries.sln
+++ b/AllLibraries.sln
@@ -129,6 +129,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "KernSmith.KniGum", "Integra
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "KernSmith.FnaGum", "Integrations\KernSmith\KernSmith.FnaGum\KernSmith.FnaGum.csproj", "{216BAD5A-2145-4FA6-99CE-15271594E778}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "KernSmith.RaylibGum", "Integrations\KernSmith\KernSmith.RaylibGum\KernSmith.RaylibGum.csproj", "{3C46766A-AB0B-44A6-A300-7CEC71F8784E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1132,6 +1134,24 @@ Global
 		{216BAD5A-2145-4FA6-99CE-15271594E778}.Release|x64.Build.0 = Release|Any CPU
 		{216BAD5A-2145-4FA6-99CE-15271594E778}.Release|x86.ActiveCfg = Release|Any CPU
 		{216BAD5A-2145-4FA6-99CE-15271594E778}.Release|x86.Build.0 = Release|Any CPU
+		{3C46766A-AB0B-44A6-A300-7CEC71F8784E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3C46766A-AB0B-44A6-A300-7CEC71F8784E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3C46766A-AB0B-44A6-A300-7CEC71F8784E}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{3C46766A-AB0B-44A6-A300-7CEC71F8784E}.Debug|x64.Build.0 = Debug|Any CPU
+		{3C46766A-AB0B-44A6-A300-7CEC71F8784E}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{3C46766A-AB0B-44A6-A300-7CEC71F8784E}.Debug|x86.Build.0 = Debug|Any CPU
+		{3C46766A-AB0B-44A6-A300-7CEC71F8784E}.Release_No_Diagnostics|Any CPU.ActiveCfg = Debug|Any CPU
+		{3C46766A-AB0B-44A6-A300-7CEC71F8784E}.Release_No_Diagnostics|Any CPU.Build.0 = Debug|Any CPU
+		{3C46766A-AB0B-44A6-A300-7CEC71F8784E}.Release_No_Diagnostics|x64.ActiveCfg = Debug|Any CPU
+		{3C46766A-AB0B-44A6-A300-7CEC71F8784E}.Release_No_Diagnostics|x64.Build.0 = Debug|Any CPU
+		{3C46766A-AB0B-44A6-A300-7CEC71F8784E}.Release_No_Diagnostics|x86.ActiveCfg = Debug|Any CPU
+		{3C46766A-AB0B-44A6-A300-7CEC71F8784E}.Release_No_Diagnostics|x86.Build.0 = Debug|Any CPU
+		{3C46766A-AB0B-44A6-A300-7CEC71F8784E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3C46766A-AB0B-44A6-A300-7CEC71F8784E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3C46766A-AB0B-44A6-A300-7CEC71F8784E}.Release|x64.ActiveCfg = Release|Any CPU
+		{3C46766A-AB0B-44A6-A300-7CEC71F8784E}.Release|x64.Build.0 = Release|Any CPU
+		{3C46766A-AB0B-44A6-A300-7CEC71F8784E}.Release|x86.ActiveCfg = Release|Any CPU
+		{3C46766A-AB0B-44A6-A300-7CEC71F8784E}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1192,6 +1212,7 @@ Global
 		{C918F1EC-C98B-4A91-BEEC-9754A3D19B9B} = {4958D7D8-4791-2CCE-6FFA-082B65933577}
 		{8846A3E6-C446-473B-9114-400B8AB4D7AE} = {4958D7D8-4791-2CCE-6FFA-082B65933577}
 		{216BAD5A-2145-4FA6-99CE-15271594E778} = {4958D7D8-4791-2CCE-6FFA-082B65933577}
+		{3C46766A-AB0B-44A6-A300-7CEC71F8784E} = {4958D7D8-4791-2CCE-6FFA-082B65933577}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {01002AE6-0158-417E-9B83-D4234361EC1B}

--- a/Integrations/KernSmith/KernSmith.GumCommon/GumFontGenerator.cs
+++ b/Integrations/KernSmith/KernSmith.GumCommon/GumFontGenerator.cs
@@ -22,19 +22,11 @@ public static class GumFontGenerator
     /// Use <see cref="RasterizerBackend.StbTrueType"/> on platforms where native
     /// libraries are unavailable (e.g., Blazor WASM).
     /// </param>
-    /// <param name="autofitTexture">
-    /// When true, KernSmith picks the smallest power-of-two texture that fits all glyphs on a
-    /// single page (overriding the BmfcSave atlas size). Single-texture backends such as raylib —
-    /// whose <c>Raylib_cs.Font</c> holds exactly one atlas — require this; otherwise large fonts
-    /// spill across multiple pages the backend cannot represent.
-    /// </param>
-    public static BmFontResult Generate(BmfcSave bmfcSave, RasterizerBackend? backend = null, bool autofitTexture = false)
+    public static BmFontResult Generate(BmfcSave bmfcSave, RasterizerBackend? backend = null)
     {
         FontGeneratorOptions options = BuildOptions(bmfcSave);
         if (backend.HasValue)
             options.Backend = backend.Value;
-        if (autofitTexture)
-            options.AutofitTexture = true;
         return string.IsNullOrEmpty(bmfcSave.FontFile)
             ? BmFont.GenerateFromSystem(bmfcSave.FontName, options)
             : BmFont.Generate(bmfcSave.FontFile, options);

--- a/Integrations/KernSmith/KernSmith.GumCommon/GumFontGenerator.cs
+++ b/Integrations/KernSmith/KernSmith.GumCommon/GumFontGenerator.cs
@@ -22,11 +22,19 @@ public static class GumFontGenerator
     /// Use <see cref="RasterizerBackend.StbTrueType"/> on platforms where native
     /// libraries are unavailable (e.g., Blazor WASM).
     /// </param>
-    public static BmFontResult Generate(BmfcSave bmfcSave, RasterizerBackend? backend = null)
+    /// <param name="autofitTexture">
+    /// When true, KernSmith picks the smallest power-of-two texture that fits all glyphs on a
+    /// single page (overriding the BmfcSave atlas size). Single-texture backends such as raylib —
+    /// whose <c>Raylib_cs.Font</c> holds exactly one atlas — require this; otherwise large fonts
+    /// spill across multiple pages the backend cannot represent.
+    /// </param>
+    public static BmFontResult Generate(BmfcSave bmfcSave, RasterizerBackend? backend = null, bool autofitTexture = false)
     {
         FontGeneratorOptions options = BuildOptions(bmfcSave);
         if (backend.HasValue)
             options.Backend = backend.Value;
+        if (autofitTexture)
+            options.AutofitTexture = true;
         return string.IsNullOrEmpty(bmfcSave.FontFile)
             ? BmFont.GenerateFromSystem(bmfcSave.FontName, options)
             : BmFont.Generate(bmfcSave.FontFile, options);

--- a/Integrations/KernSmith/KernSmith.GumCommon/KernSmith.GumCommon.csproj
+++ b/Integrations/KernSmith/KernSmith.GumCommon/KernSmith.GumCommon.csproj
@@ -26,8 +26,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="KernSmith" Version="0.15.0" />
-    <PackageReference Include="KernSmith.Rasterizers.FreeType" Version="0.15.0" />
+    <PackageReference Include="KernSmith" Version="0.15.1" />
+    <PackageReference Include="KernSmith.Rasterizers.FreeType" Version="0.15.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Integrations/KernSmith/KernSmith.RaylibGum/KernSmith.RaylibGum.csproj
+++ b/Integrations/KernSmith/KernSmith.RaylibGum/KernSmith.RaylibGum.csproj
@@ -1,0 +1,40 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <!-- Uploading KernSmith's raw RGBA atlas pages to a raylib Texture2D pins the managed
+         byte[] and writes a Raylib_cs.Image's Data pointer (see KernSmithRaylibFontCreator). -->
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <IsPackable>true</IsPackable>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+
+    <PackageId>KernSmith.RaylibGum</PackageId>
+    <Version>2026.6.15.1</Version>
+    <Authors>Kaltinril (Jeremy Swartwood), Gum Contributors</Authors>
+    <Description>Runtime bitmap font generation for raylib + Gum games using KernSmith. Generates Raylib_cs.Font instances entirely in memory — no .fnt files required. Wire up with one line: CustomSetPropertyOnRenderable.InMemoryFontCreator = new KernSmithRaylibFontCreator();</Description>
+    <PackageProjectUrl>https://github.com/vchelaru/Gum</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/vchelaru/Gum</RepositoryUrl>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageTags>kernsmith;gum;raylib;bitmap-font;font-generation;game-dev;runtime</PackageTags>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="/" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\KernSmith.GumCommon\KernSmith.GumCommon.csproj" />
+    <ProjectReference Include="..\..\..\Runtimes\RaylibGum\RaylibGum.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Raylib-cs" Version="7.0.1" />
+  </ItemGroup>
+
+</Project>

--- a/Integrations/KernSmith/KernSmith.RaylibGum/KernSmithRaylibFontCreator.cs
+++ b/Integrations/KernSmith/KernSmith.RaylibGum/KernSmithRaylibFontCreator.cs
@@ -64,16 +64,19 @@ public class KernSmithRaylibFontCreator : IRaylibFontCreator
     /// <inheritdoc/>
     public unsafe Raylib_cs.Font? TryCreateFont(BmfcSave bmfcSave)
     {
-        BmFontResult result = GumFontGenerator.Generate(bmfcSave, _backend);
+        // autofitTexture makes KernSmith pack the whole glyph set onto ONE page, sized to the
+        // smallest power-of-two that fits. raylib's Font holds a single atlas texture, so the
+        // multi-page result the default atlas produces at larger sizes can't be represented —
+        // later-page glyphs would sample the wrong texture region and render as garbage.
+        BmFontResult result = GumFontGenerator.Generate(bmfcSave, _backend, autofitTexture: true);
 
-        if (result.Pages.Count == 0)
+        // Autofit yields a single page; guard defensively (e.g. an empty glyph set) and fall back
+        // to the existing system-font path rather than render a partial atlas.
+        if (result.Pages.Count != 1)
         {
             return null;
         }
 
-        // raylib's Font has a single atlas texture, so it is inherently single-page (the existing
-        // ContentLoader bitmap-font path makes the same assumption). KernSmith packs Gum's default
-        // character ranges into one page at typical sizes; use page 0.
         AtlasPage page = result.Pages[0];
 
         Texture2D texture;

--- a/Integrations/KernSmith/KernSmith.RaylibGum/KernSmithRaylibFontCreator.cs
+++ b/Integrations/KernSmith/KernSmith.RaylibGum/KernSmithRaylibFontCreator.cs
@@ -1,0 +1,97 @@
+using KernSmith.Atlas;
+using KernSmith.Output;
+using KernSmith.Rasterizer;
+using Raylib_cs;
+using RaylibGum.Renderables;
+using RenderingLibrary.Content;
+using RenderingLibrary.Graphics.Fonts;
+
+namespace KernSmith.Gum;
+
+/// <summary>
+/// Creates <see cref="Raylib_cs.Font"/> instances in memory using KernSmith for raylib + Gum games.
+/// Rasterizes a font atlas with KernSmith and uploads it to a raylib texture — no .fnt files on disk.
+/// </summary>
+/// <remarks>
+/// Wire up once after initializing Gum:
+/// <code>CustomSetPropertyOnRenderable.InMemoryFontCreator = new KernSmithRaylibFontCreator();</code>
+/// This is the raylib counterpart to KernSmith.MonoGameGum's <c>KernSmithFontCreator</c>.
+/// </remarks>
+public class KernSmithRaylibFontCreator : IRaylibFontCreator
+{
+    private readonly RasterizerBackend? _backend;
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="KernSmithRaylibFontCreator"/>.
+    /// </summary>
+    /// <param name="backend">
+    /// Optional rasterizer backend override. When null, uses the default (FreeType). Use
+    /// <see cref="RasterizerBackend.StbTrueType"/> on platforms where native libraries are
+    /// unavailable.
+    /// </param>
+    public KernSmithRaylibFontCreator(RasterizerBackend? backend = null)
+    {
+        _backend = backend;
+    }
+
+    /// <summary>
+    /// Registers raw font data (TTF/OTF/WOFF) under a family name so that font generation can
+    /// resolve it without accessing system fonts. The <c>byte[]</c> overload is the path for
+    /// embedded theme fonts.
+    /// </summary>
+    /// <param name="familyName">Font family name (e.g., "Arial").</param>
+    /// <param name="fontData">Raw font file bytes.</param>
+    /// <param name="style">Optional style name (e.g., "Bold", "Italic"), or null for the default variant.</param>
+    /// <param name="faceIndex">TTC face index (0 for single-face font files).</param>
+    public static void RegisterFont(string familyName, byte[] fontData, string? style = null, int faceIndex = 0)
+        => BmFont.RegisterFont(familyName, fontData, style, faceIndex);
+
+    /// <summary>
+    /// Removes a previously registered font.
+    /// </summary>
+    /// <param name="familyName">Font family name.</param>
+    /// <param name="style">Optional style name, or null for the default variant.</param>
+    /// <returns>True if a font was removed.</returns>
+    public static bool UnregisterFont(string familyName, string? style = null)
+        => BmFont.UnregisterFont(familyName, style);
+
+    /// <summary>
+    /// Removes all registered fonts.
+    /// </summary>
+    public static void ClearRegisteredFonts()
+        => BmFont.ClearRegisteredFonts();
+
+    /// <inheritdoc/>
+    public unsafe Raylib_cs.Font? TryCreateFont(BmfcSave bmfcSave)
+    {
+        BmFontResult result = GumFontGenerator.Generate(bmfcSave, _backend);
+
+        if (result.Pages.Count == 0)
+        {
+            return null;
+        }
+
+        // raylib's Font has a single atlas texture, so it is inherently single-page (the existing
+        // ContentLoader bitmap-font path makes the same assumption). KernSmith packs Gum's default
+        // character ranges into one page at typical sizes; use page 0.
+        AtlasPage page = result.Pages[0];
+
+        Texture2D texture;
+        fixed (byte* pixels = page.PixelData)
+        {
+            Image image = new Image
+            {
+                Data = pixels,
+                Width = page.Width,
+                Height = page.Height,
+                Mipmaps = 1,
+                Format = Raylib_cs.PixelFormat.UncompressedR8G8B8A8,
+            };
+            // LoadTextureFromImage copies the pixels to the GPU, so the pinned pointer only needs
+            // to stay valid for the duration of this call.
+            texture = Raylib.LoadTextureFromImage(image);
+        }
+
+        return ContentLoader.BuildFontFromFntText(result.FntText, texture);
+    }
+}

--- a/Integrations/KernSmith/KernSmith.RaylibGum/KernSmithRaylibFontCreator.cs
+++ b/Integrations/KernSmith/KernSmith.RaylibGum/KernSmithRaylibFontCreator.cs
@@ -19,6 +19,13 @@ namespace KernSmith.Gum;
 /// </remarks>
 public class KernSmithRaylibFontCreator : IRaylibFontCreator
 {
+    // Atlas ceiling handed to KernSmith. KernSmith sizes each page to the smallest power-of-two
+    // that fits, UP TO this max — so a generous ceiling collapses the whole glyph set onto one page
+    // (sized to need, not to the ceiling) for any size this is used with, while staying within the
+    // GL_MAX_TEXTURE_SIZE of effectively all GPUs. The default 512x256 is too small and spills to
+    // multiple pages at larger sizes, which raylib's single-texture Font cannot represent.
+    private const int SingleAtlasMaxSize = 4096;
+
     private readonly RasterizerBackend? _backend;
 
     /// <summary>
@@ -64,14 +71,17 @@ public class KernSmithRaylibFontCreator : IRaylibFontCreator
     /// <inheritdoc/>
     public unsafe Raylib_cs.Font? TryCreateFont(BmfcSave bmfcSave)
     {
-        // autofitTexture makes KernSmith pack the whole glyph set onto ONE page, sized to the
-        // smallest power-of-two that fits. raylib's Font holds a single atlas texture, so the
-        // multi-page result the default atlas produces at larger sizes can't be represented —
-        // later-page glyphs would sample the wrong texture region and render as garbage.
-        BmFontResult result = GumFontGenerator.Generate(bmfcSave, _backend, autofitTexture: true);
+        // Force the whole glyph set onto a single page (raylib's Font is single-texture). The
+        // default 512x256 atlas spills to multiple pages at larger sizes — later-page glyphs would
+        // sample the wrong region and render as garbage — so request a generous atlas ceiling and
+        // let KernSmith size the actual page down to fit.
+        bmfcSave.OutputWidth = SingleAtlasMaxSize;
+        bmfcSave.OutputHeight = SingleAtlasMaxSize;
+        BmFontResult result = GumFontGenerator.Generate(bmfcSave, _backend);
 
-        // Autofit yields a single page; guard defensively (e.g. an empty glyph set) and fall back
-        // to the existing system-font path rather than render a partial atlas.
+        // Expected to be a single page for any practical size; guard defensively (empty glyph set,
+        // or a glyph set too large for the ceiling) and fall back to the existing system-font path
+        // rather than render a partial atlas.
         if (result.Pages.Count != 1)
         {
             return null;

--- a/Integrations/KernSmith/KernSmith.RaylibGum/KernSmithRaylibFontCreator.cs
+++ b/Integrations/KernSmith/KernSmith.RaylibGum/KernSmithRaylibFontCreator.cs
@@ -69,34 +69,59 @@ public class KernSmithRaylibFontCreator : IRaylibFontCreator
         => BmFont.ClearRegisteredFonts();
 
     /// <inheritdoc/>
-    public unsafe Raylib_cs.Font? TryCreateFont(BmfcSave bmfcSave)
+    public Raylib_cs.Font? TryCreateFont(BmfcSave bmfcSave)
     {
-        // Force the whole glyph set onto a single page (raylib's Font is single-texture). The
-        // default 512x256 atlas spills to multiple pages at larger sizes — later-page glyphs would
-        // sample the wrong region and render as garbage — so request a generous atlas ceiling and
-        // let KernSmith size the actual page down to fit.
+        // A generous atlas ceiling keeps the common case on a single page (KernSmith sizes the page
+        // down to fit within it), so most fonts take the fast path below. Larger glyph sets that
+        // still span multiple pages are merged into one texture afterward — raylib's Font is
+        // single-texture, so it can't hold a page array the way the MonoGame BitmapFont does.
         bmfcSave.OutputWidth = SingleAtlasMaxSize;
         bmfcSave.OutputHeight = SingleAtlasMaxSize;
         BmFontResult result = GumFontGenerator.Generate(bmfcSave, _backend);
 
-        // Expected to be a single page for any practical size; guard defensively (empty glyph set,
-        // or a glyph set too large for the ceiling) and fall back to the existing system-font path
-        // rather than render a partial atlas.
-        if (result.Pages.Count != 1)
+        if (result.Pages.Count == 0)
         {
             return null;
         }
 
-        AtlasPage page = result.Pages[0];
+        if (result.Pages.Count == 1)
+        {
+            AtlasPage page = result.Pages[0];
+            Texture2D texture = UploadTexture(page.PixelData, page.Width, page.Height);
+            return ContentLoader.BuildFontFromFntText(result.FntText, texture);
+        }
 
+        // Merge KernSmith's pages into a single texture. KernSmith sizes every page identically
+        // (PackResult.PageWidth/Height), so stacking them vertically is a contiguous copy and each
+        // glyph's atlas Y is shifted by its page's offset. Mirrors the MonoGame creator, which hands
+        // BitmapFont a texture array — same behavior (a usable font for any glyph set), no fallback.
+        int pageWidth = result.Pages[0].Width;
+        int pageHeight = result.Pages[0].Height;
+        int pageCount = result.Pages.Count;
+
+        byte[] merged = new byte[pageWidth * pageHeight * pageCount * 4];
+        int[] pageYOffsets = new int[pageCount];
+        for (int i = 0; i < pageCount; i++)
+        {
+            byte[] pagePixels = result.Pages[i].PixelData;
+            System.Array.Copy(pagePixels, 0, merged, i * pagePixels.Length, pagePixels.Length);
+            pageYOffsets[i] = i * pageHeight;
+        }
+
+        Texture2D mergedTexture = UploadTexture(merged, pageWidth, pageHeight * pageCount);
+        return ContentLoader.BuildFontFromFntText(result.FntText, mergedTexture, pageYOffsets);
+    }
+
+    private static unsafe Texture2D UploadTexture(byte[] pixels, int width, int height)
+    {
         Texture2D texture;
-        fixed (byte* pixels = page.PixelData)
+        fixed (byte* p = pixels)
         {
             Image image = new Image
             {
-                Data = pixels,
-                Width = page.Width,
-                Height = page.Height,
+                Data = p,
+                Width = width,
+                Height = height,
                 Mipmaps = 1,
                 Format = Raylib_cs.PixelFormat.UncompressedR8G8B8A8,
             };
@@ -104,7 +129,6 @@ public class KernSmithRaylibFontCreator : IRaylibFontCreator
             // to stay valid for the duration of this call.
             texture = Raylib.LoadTextureFromImage(image);
         }
-
-        return ContentLoader.BuildFontFromFntText(result.FntText, texture);
+        return texture;
     }
 }

--- a/Integrations/KernSmith/KernSmith.RaylibGum/README.md
+++ b/Integrations/KernSmith/KernSmith.RaylibGum/README.md
@@ -1,0 +1,19 @@
+# KernSmith.RaylibGum
+
+Runtime bitmap font generation for raylib + Gum games using KernSmith.
+
+## Overview
+
+This package generates `Raylib_cs.Font` instances entirely in memory for raylib projects that use the Gum UI framework. No `.fnt` files are required — KernSmith rasterizes the atlas, the page is uploaded to a raylib texture, and the font is assembled at runtime. This gives raylib the same dynamic-font story as MonoGame/KNI (arbitrary size, styles, outline) including effects native raylib cannot produce.
+
+### Quick Setup
+
+```csharp
+CustomSetPropertyOnRenderable.InMemoryFontCreator = new KernSmithRaylibFontCreator();
+```
+
+Once wired up, Gum will use KernSmith to generate any font it needs on the fly as `Font`/`FontSize`/`IsBold`/`IsItalic`/`OutlineThickness` change.
+
+**Target**: `net8.0`
+
+This integration is maintained in the [Gum repository](https://github.com/vchelaru/Gum) and depends on the [KernSmith](https://github.com/kaltinril/KernSmith) bitmap-font rasterizer (consumed as a NuGet package).

--- a/Runtimes/RaylibGum/Properties/AssemblyInfo.cs
+++ b/Runtimes/RaylibGum/Properties/AssemblyInfo.cs
@@ -1,0 +1,7 @@
+using System.Runtime.CompilerServices;
+
+// KernSmith.RaylibGum reuses ContentLoader.BuildFont (internal) to assemble a Raylib_cs.Font from a
+// KernSmith-rasterized atlas, instead of duplicating the glyph-mapping logic. RaylibGum sets
+// GenerateAssemblyInfo=false, so this attribute is declared in source rather than via the csproj
+// <InternalsVisibleTo> item (which the SDK only emits when assembly-info generation is enabled).
+[assembly: InternalsVisibleTo("KernSmith.RaylibGum")]

--- a/Runtimes/RaylibGum/Renderables/CustomSetPropertyOnRenderable.cs
+++ b/Runtimes/RaylibGum/Renderables/CustomSetPropertyOnRenderable.cs
@@ -655,43 +655,6 @@ public class CustomSetPropertyOnRenderable
             {
                 if (textRuntime.FontSize > 0 && !string.IsNullOrEmpty(textRuntime.Font))
                 {
-                    // Try in-memory font creation first (no disk I/O). Mirrors the MonoGame path in
-                    // Gum/Wireframe/CustomSetPropertyOnRenderable.cs: build a BmfcSave from the text
-                    // properties and ask the creator (e.g. KernSmith) to rasterize a Raylib_cs.Font.
-                    // A successful result is assigned directly; null/failure falls through to the
-                    // existing FontCache .fnt → system-font path below.
-                    if (InMemoryFontCreator != null)
-                    {
-                        try
-                        {
-                            global::RenderingLibrary.Graphics.Fonts.BmfcSave bmfcSave =
-                                new global::RenderingLibrary.Graphics.Fonts.BmfcSave();
-                            bmfcSave.FontSize = textRuntime.FontSize;
-                            bmfcSave.OutlineThickness = textRuntime.OutlineThickness;
-                            bmfcSave.UseSmoothing = textRuntime.UseFontSmoothing;
-                            bmfcSave.IsItalic = textRuntime.IsItalic;
-                            bmfcSave.IsBold = textRuntime.IsBold;
-                            bmfcSave.FontName = textRuntime.Font;
-
-                            var gumProject = ObjectFinder.Self.GumProjectSave;
-                            bmfcSave.Ranges = gumProject?.FontRanges
-                                ?? global::RenderingLibrary.Graphics.Fonts.BmfcSave.GetEffectiveDefaultRanges();
-                            bmfcSave.SpacingHorizontal = gumProject?.FontSpacingHorizontal ?? 1;
-                            bmfcSave.SpacingVertical = gumProject?.FontSpacingVertical ?? 1;
-
-                            Raylib_cs.Font? createdFont = InMemoryFontCreator.TryCreateFont(bmfcSave);
-                            if (createdFont.HasValue && createdFont.Value.BaseSize != 0)
-                            {
-                                AssignFontIfChanged(asText, createdFont.Value);
-                                return;
-                            }
-                        }
-                        catch
-                        {
-                            // Fall through to the disk / system-font path.
-                        }
-                    }
-
                     string fontName = global::RenderingLibrary.Graphics.Fonts.BmfcSave.GetFontCacheFileNameFor(
                     textRuntime.FontSize,
                     textRuntime.Font,
@@ -701,6 +664,51 @@ public class CustomSetPropertyOnRenderable
                     textRuntime.IsBold);
 
                     string fullFileName = ToolsUtilities.FileManager.Standardize(fontName, preserveCase: true, makeAbsolute: true);
+
+                    // Cache hit: reuse the already-generated/loaded font rather than regenerating.
+                    // A Raylib_cs.Font wraps an unmanaged GPU texture, so regenerating on every font
+                    // property change would leak VRAM (the previous texture is never reclaimed). This
+                    // is the LoaderManager cache the MonoGame path also uses.
+                    if (loaderManager.GetDisposable(fullFileName) is ManagedFont cachedManagedFont)
+                    {
+                        AssignFontIfChanged(asText, cachedManagedFont.Font);
+                        return;
+                    }
+
+                    // In-memory font creation (no disk I/O). The BmfcSave construction below is kept
+                    // byte-identical to the MonoGame path in Gum/Wireframe/CustomSetPropertyOnRenderable.cs;
+                    // only the created-font type (Raylib_cs.Font vs BitmapFont) and how it is cached are
+                    // necessarily platform-gated. Null/failure falls through to the FontCache .fnt path.
+                    if (InMemoryFontCreator != null)
+                    {
+                        try
+                        {
+                            BmfcSave bmfcSave = new BmfcSave();
+                            bmfcSave.FontSize = textRuntime.FontSize;
+                            bmfcSave.OutlineThickness = textRuntime.OutlineThickness;
+                            bmfcSave.UseSmoothing = textRuntime.UseFontSmoothing;
+                            bmfcSave.IsItalic = textRuntime.IsItalic;
+                            bmfcSave.IsBold = textRuntime.IsBold;
+                            bmfcSave.FontName = textRuntime.Font;
+
+                            var gumProject = ObjectFinder.Self.GumProjectSave;
+                            bmfcSave.Ranges = gumProject?.FontRanges ?? BmfcSave.GetEffectiveDefaultRanges();
+                            bmfcSave.SpacingHorizontal = gumProject?.FontSpacingHorizontal ?? 1;
+                            bmfcSave.SpacingVertical = gumProject?.FontSpacingVertical ?? 1;
+
+                            Raylib_cs.Font? createdFont = InMemoryFontCreator.TryCreateFont(bmfcSave);
+                            if (createdFont.HasValue && createdFont.Value.BaseSize != 0)
+                            {
+                                loaderManager.AddDisposable(fullFileName, new ManagedFont(createdFont.Value));
+                                AssignFontIfChanged(asText, createdFont.Value);
+                                return;
+                            }
+                        }
+                        catch
+                        {
+                            // Fall through to the disk / system-font path.
+                        }
+                    }
 
                     var fontFromGum = loaderManager.LoadContent<Raylib_cs.Font>(fullFileName);
                     if (fontFromGum.BaseSize == 0)

--- a/Runtimes/RaylibGum/Renderables/CustomSetPropertyOnRenderable.cs
+++ b/Runtimes/RaylibGum/Renderables/CustomSetPropertyOnRenderable.cs
@@ -109,6 +109,17 @@ public class CustomSetPropertyOnRenderable
     public static IInMemoryFontCreator? InMemoryFontCreator { get; set; }
 #endif
 
+#if RAYLIB
+    /// <summary>
+    /// Optional in-memory font creator. When set, font generation bypasses disk entirely — the
+    /// creator produces a <see cref="Raylib_cs.Font"/> directly from a <see cref="BmfcSave"/>
+    /// descriptor (for example, by rasterizing an atlas with KernSmith). If null or if creation
+    /// returns null, falls back to the existing disk / system-font path. Raylib parallel to the
+    /// <c>#if !RAYLIB</c> <see cref="IInMemoryFontCreator"/> property above.
+    /// </summary>
+    public static IRaylibFontCreator? InMemoryFontCreator { get; set; }
+#endif
+
     public static event Action<string>? PropertyAssignmentError;
 
 
@@ -644,6 +655,42 @@ public class CustomSetPropertyOnRenderable
             {
                 if (textRuntime.FontSize > 0 && !string.IsNullOrEmpty(textRuntime.Font))
                 {
+                    // Try in-memory font creation first (no disk I/O). Mirrors the MonoGame path in
+                    // Gum/Wireframe/CustomSetPropertyOnRenderable.cs: build a BmfcSave from the text
+                    // properties and ask the creator (e.g. KernSmith) to rasterize a Raylib_cs.Font.
+                    // A successful result is assigned directly; null/failure falls through to the
+                    // existing FontCache .fnt → system-font path below.
+                    if (InMemoryFontCreator != null)
+                    {
+                        try
+                        {
+                            global::RenderingLibrary.Graphics.Fonts.BmfcSave bmfcSave =
+                                new global::RenderingLibrary.Graphics.Fonts.BmfcSave();
+                            bmfcSave.FontSize = textRuntime.FontSize;
+                            bmfcSave.OutlineThickness = textRuntime.OutlineThickness;
+                            bmfcSave.UseSmoothing = textRuntime.UseFontSmoothing;
+                            bmfcSave.IsItalic = textRuntime.IsItalic;
+                            bmfcSave.IsBold = textRuntime.IsBold;
+                            bmfcSave.FontName = textRuntime.Font;
+
+                            var gumProject = ObjectFinder.Self.GumProjectSave;
+                            bmfcSave.Ranges = gumProject?.FontRanges
+                                ?? global::RenderingLibrary.Graphics.Fonts.BmfcSave.GetEffectiveDefaultRanges();
+                            bmfcSave.SpacingHorizontal = gumProject?.FontSpacingHorizontal ?? 1;
+                            bmfcSave.SpacingVertical = gumProject?.FontSpacingVertical ?? 1;
+
+                            Raylib_cs.Font? createdFont = InMemoryFontCreator.TryCreateFont(bmfcSave);
+                            if (createdFont.HasValue && createdFont.Value.BaseSize != 0)
+                            {
+                                AssignFontIfChanged(asText, createdFont.Value);
+                                return;
+                            }
+                        }
+                        catch
+                        {
+                            // Fall through to the disk / system-font path.
+                        }
+                    }
 
                     string fontName = global::RenderingLibrary.Graphics.Fonts.BmfcSave.GetFontCacheFileNameFor(
                     textRuntime.FontSize,

--- a/Runtimes/RaylibGum/Renderables/IRaylibFontCreator.cs
+++ b/Runtimes/RaylibGum/Renderables/IRaylibFontCreator.cs
@@ -1,0 +1,25 @@
+using RenderingLibrary.Graphics.Fonts;
+
+namespace RaylibGum.Renderables;
+
+/// <summary>
+/// Optional in-memory font creator for the Raylib runtime. When assigned to
+/// <see cref="CustomSetPropertyOnRenderable.InMemoryFontCreator"/>, font generation bypasses disk
+/// entirely — the creator produces a <see cref="Raylib_cs.Font"/> directly from a
+/// <see cref="BmfcSave"/> descriptor (for example, by rasterizing an atlas with KernSmith).
+/// </summary>
+/// <remarks>
+/// This is the Raylib parallel to <see cref="IInMemoryFontCreator"/>. The two cannot be unified:
+/// <see cref="IInMemoryFontCreator"/> returns a MonoGame-family <c>BitmapFont</c>, which Raylib's
+/// text renderer cannot draw — Raylib renders <see cref="Raylib_cs.Font"/>.
+/// </remarks>
+public interface IRaylibFontCreator
+{
+    /// <summary>
+    /// Attempts to create a <see cref="Raylib_cs.Font"/> for the given font descriptor. Returns
+    /// <c>null</c> when the font cannot be produced, so the caller falls through to the existing
+    /// disk / system-font path.
+    /// </summary>
+    /// <param name="bmfcSave">The font descriptor (family, size, style, outline, ranges, spacing).</param>
+    Raylib_cs.Font? TryCreateFont(BmfcSave bmfcSave);
+}

--- a/Runtimes/RaylibGum/RenderingLibrary/ContentLoader.cs
+++ b/Runtimes/RaylibGum/RenderingLibrary/ContentLoader.cs
@@ -216,6 +216,16 @@ public class ContentLoader : IContentLoader
         return BuildFont(parsedFontFile, pageTexture);
     }
 
+    // Entry point for in-memory font creators in other assemblies (e.g. KernSmith.RaylibGum):
+    // parse the .fnt text and assemble a raylib Font around the supplied atlas texture. Exposed
+    // (instead of BuildFont) so callers never name ParsedFontFile, which is compiled into BOTH
+    // GumCommon and RaylibGum — referencing it across the assembly boundary is an ambiguous-type
+    // (CS0433) error. See InternalsVisibleTo in Properties/AssemblyInfo.cs.
+    internal static Font BuildFontFromFntText(string fntText, Texture2D pageTexture)
+    {
+        return BuildFont(new ParsedFontFile(fntText), pageTexture);
+    }
+
     // Assembles a raylib Font from a parsed .fnt and its already-loaded atlas page. The Recs and
     // Glyphs arrays are handed to raylib, which frees them in UnloadFont (called by
     // ManagedFont.Dispose) — so they MUST be allocated with raylib's own allocator (MemAlloc).

--- a/Runtimes/RaylibGum/RenderingLibrary/ContentLoader.cs
+++ b/Runtimes/RaylibGum/RenderingLibrary/ContentLoader.cs
@@ -221,15 +221,18 @@ public class ContentLoader : IContentLoader
     // (instead of BuildFont) so callers never name ParsedFontFile, which is compiled into BOTH
     // GumCommon and RaylibGum — referencing it across the assembly boundary is an ambiguous-type
     // (CS0433) error. See InternalsVisibleTo in Properties/AssemblyInfo.cs.
-    internal static Font BuildFontFromFntText(string fntText, Texture2D pageTexture)
+    // pageYOffsets, when supplied, shifts each glyph's atlas Y by its source page's offset. This
+    // lets a single-texture consumer (KernSmith.RaylibGum) merge KernSmith's multiple atlas pages
+    // into one stacked texture and still map every glyph correctly — raylib's Font holds one texture.
+    internal static Font BuildFontFromFntText(string fntText, Texture2D pageTexture, int[]? pageYOffsets = null)
     {
-        return BuildFont(new ParsedFontFile(fntText), pageTexture);
+        return BuildFont(new ParsedFontFile(fntText), pageTexture, pageYOffsets);
     }
 
     // Assembles a raylib Font from a parsed .fnt and its already-loaded atlas page. The Recs and
     // Glyphs arrays are handed to raylib, which frees them in UnloadFont (called by
     // ManagedFont.Dispose) — so they MUST be allocated with raylib's own allocator (MemAlloc).
-    private static unsafe Font BuildFont(ParsedFontFile parsedFontFile, Texture2D pageTexture)
+    private static unsafe Font BuildFont(ParsedFontFile parsedFontFile, Texture2D pageTexture, int[]? pageYOffsets = null)
     {
         int glyphCount = parsedFontFile.Chars.Count;
 
@@ -239,7 +242,8 @@ public class ContentLoader : IContentLoader
         for (int i = 0; i < glyphCount; i++)
         {
             FontFileCharLine charLine = parsedFontFile.Chars[i];
-            recs[i] = new Rectangle(charLine.X, charLine.Y, charLine.Width, charLine.Height);
+            int recY = charLine.Y + (pageYOffsets != null ? pageYOffsets[charLine.Page] : 0);
+            recs[i] = new Rectangle(charLine.X, recY, charLine.Width, charLine.Height);
             // Image is left default — raylib's DrawTextPro renders glyphs from Recs + the atlas
             // Texture, not from per-glyph Images.
             glyphs[i] = new GlyphInfo

--- a/Samples/FontPlayground/FontPlayground.Raylib.sln
+++ b/Samples/FontPlayground/FontPlayground.Raylib.sln
@@ -1,0 +1,90 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FontPlayground.Raylib", "FontPlayground.Raylib\FontPlayground.Raylib.csproj", "{33FBAF33-63B7-41A9-8C7B-6361962383F9}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GumCommon", "..\..\GumCommon\GumCommon.csproj", "{0DC70BE4-3748-43F1-BBBA-A7693CBFDFD8}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RaylibGum", "..\..\Runtimes\RaylibGum\RaylibGum.csproj", "{138B4425-D0DF-418B-8353-441A76F6ED0E}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "KernSmith.RaylibGum", "..\..\Integrations\KernSmith\KernSmith.RaylibGum\KernSmith.RaylibGum.csproj", "{3EB88C64-2950-4FE4-84D4-C0C0B578FBF6}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "KernSmith.GumCommon", "..\..\Integrations\KernSmith\KernSmith.GumCommon\KernSmith.GumCommon.csproj", "{805FC2E1-88D7-41D9-86E3-F9AE97392D94}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{33FBAF33-63B7-41A9-8C7B-6361962383F9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{33FBAF33-63B7-41A9-8C7B-6361962383F9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{33FBAF33-63B7-41A9-8C7B-6361962383F9}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{33FBAF33-63B7-41A9-8C7B-6361962383F9}.Debug|x64.Build.0 = Debug|Any CPU
+		{33FBAF33-63B7-41A9-8C7B-6361962383F9}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{33FBAF33-63B7-41A9-8C7B-6361962383F9}.Debug|x86.Build.0 = Debug|Any CPU
+		{33FBAF33-63B7-41A9-8C7B-6361962383F9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{33FBAF33-63B7-41A9-8C7B-6361962383F9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{33FBAF33-63B7-41A9-8C7B-6361962383F9}.Release|x64.ActiveCfg = Release|Any CPU
+		{33FBAF33-63B7-41A9-8C7B-6361962383F9}.Release|x64.Build.0 = Release|Any CPU
+		{33FBAF33-63B7-41A9-8C7B-6361962383F9}.Release|x86.ActiveCfg = Release|Any CPU
+		{33FBAF33-63B7-41A9-8C7B-6361962383F9}.Release|x86.Build.0 = Release|Any CPU
+		{0DC70BE4-3748-43F1-BBBA-A7693CBFDFD8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0DC70BE4-3748-43F1-BBBA-A7693CBFDFD8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0DC70BE4-3748-43F1-BBBA-A7693CBFDFD8}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{0DC70BE4-3748-43F1-BBBA-A7693CBFDFD8}.Debug|x64.Build.0 = Debug|Any CPU
+		{0DC70BE4-3748-43F1-BBBA-A7693CBFDFD8}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{0DC70BE4-3748-43F1-BBBA-A7693CBFDFD8}.Debug|x86.Build.0 = Debug|Any CPU
+		{0DC70BE4-3748-43F1-BBBA-A7693CBFDFD8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0DC70BE4-3748-43F1-BBBA-A7693CBFDFD8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0DC70BE4-3748-43F1-BBBA-A7693CBFDFD8}.Release|x64.ActiveCfg = Release|Any CPU
+		{0DC70BE4-3748-43F1-BBBA-A7693CBFDFD8}.Release|x64.Build.0 = Release|Any CPU
+		{0DC70BE4-3748-43F1-BBBA-A7693CBFDFD8}.Release|x86.ActiveCfg = Release|Any CPU
+		{0DC70BE4-3748-43F1-BBBA-A7693CBFDFD8}.Release|x86.Build.0 = Release|Any CPU
+		{138B4425-D0DF-418B-8353-441A76F6ED0E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{138B4425-D0DF-418B-8353-441A76F6ED0E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{138B4425-D0DF-418B-8353-441A76F6ED0E}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{138B4425-D0DF-418B-8353-441A76F6ED0E}.Debug|x64.Build.0 = Debug|Any CPU
+		{138B4425-D0DF-418B-8353-441A76F6ED0E}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{138B4425-D0DF-418B-8353-441A76F6ED0E}.Debug|x86.Build.0 = Debug|Any CPU
+		{138B4425-D0DF-418B-8353-441A76F6ED0E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{138B4425-D0DF-418B-8353-441A76F6ED0E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{138B4425-D0DF-418B-8353-441A76F6ED0E}.Release|x64.ActiveCfg = Release|Any CPU
+		{138B4425-D0DF-418B-8353-441A76F6ED0E}.Release|x64.Build.0 = Release|Any CPU
+		{138B4425-D0DF-418B-8353-441A76F6ED0E}.Release|x86.ActiveCfg = Release|Any CPU
+		{138B4425-D0DF-418B-8353-441A76F6ED0E}.Release|x86.Build.0 = Release|Any CPU
+		{3EB88C64-2950-4FE4-84D4-C0C0B578FBF6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3EB88C64-2950-4FE4-84D4-C0C0B578FBF6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3EB88C64-2950-4FE4-84D4-C0C0B578FBF6}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{3EB88C64-2950-4FE4-84D4-C0C0B578FBF6}.Debug|x64.Build.0 = Debug|Any CPU
+		{3EB88C64-2950-4FE4-84D4-C0C0B578FBF6}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{3EB88C64-2950-4FE4-84D4-C0C0B578FBF6}.Debug|x86.Build.0 = Debug|Any CPU
+		{3EB88C64-2950-4FE4-84D4-C0C0B578FBF6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3EB88C64-2950-4FE4-84D4-C0C0B578FBF6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3EB88C64-2950-4FE4-84D4-C0C0B578FBF6}.Release|x64.ActiveCfg = Release|Any CPU
+		{3EB88C64-2950-4FE4-84D4-C0C0B578FBF6}.Release|x64.Build.0 = Release|Any CPU
+		{3EB88C64-2950-4FE4-84D4-C0C0B578FBF6}.Release|x86.ActiveCfg = Release|Any CPU
+		{3EB88C64-2950-4FE4-84D4-C0C0B578FBF6}.Release|x86.Build.0 = Release|Any CPU
+		{805FC2E1-88D7-41D9-86E3-F9AE97392D94}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{805FC2E1-88D7-41D9-86E3-F9AE97392D94}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{805FC2E1-88D7-41D9-86E3-F9AE97392D94}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{805FC2E1-88D7-41D9-86E3-F9AE97392D94}.Debug|x64.Build.0 = Debug|Any CPU
+		{805FC2E1-88D7-41D9-86E3-F9AE97392D94}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{805FC2E1-88D7-41D9-86E3-F9AE97392D94}.Debug|x86.Build.0 = Debug|Any CPU
+		{805FC2E1-88D7-41D9-86E3-F9AE97392D94}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{805FC2E1-88D7-41D9-86E3-F9AE97392D94}.Release|Any CPU.Build.0 = Release|Any CPU
+		{805FC2E1-88D7-41D9-86E3-F9AE97392D94}.Release|x64.ActiveCfg = Release|Any CPU
+		{805FC2E1-88D7-41D9-86E3-F9AE97392D94}.Release|x64.Build.0 = Release|Any CPU
+		{805FC2E1-88D7-41D9-86E3-F9AE97392D94}.Release|x86.ActiveCfg = Release|Any CPU
+		{805FC2E1-88D7-41D9-86E3-F9AE97392D94}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/Samples/FontPlayground/FontPlayground.Raylib/FontPlayground.Raylib.csproj
+++ b/Samples/FontPlayground/FontPlayground.Raylib/FontPlayground.Raylib.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>disable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Raylib-cs" Version="7.0.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\GumCommon\GumCommon.csproj" />
+    <ProjectReference Include="..\..\..\Runtimes\RaylibGum\RaylibGum.csproj" />
+    <ProjectReference Include="..\..\..\Integrations\KernSmith\KernSmith.RaylibGum\KernSmith.RaylibGum.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- Shared, platform-neutral playground UI (same file the MonoGame host links). -->
+    <Compile Include="..\Shared\FontPlaygroundScreen.cs" Link="FontPlaygroundScreen.cs" />
+  </ItemGroup>
+
+</Project>

--- a/Samples/FontPlayground/FontPlayground.Raylib/Program.cs
+++ b/Samples/FontPlayground/FontPlayground.Raylib/Program.cs
@@ -1,0 +1,53 @@
+using Gum;
+using KernSmith.Gum;
+using Raylib_cs;
+using RaylibGum.Renderables;
+using static Raylib_cs.Raylib;
+
+namespace FontPlayground.Raylib;
+
+/// <summary>
+/// Thin raylib host for the dynamic-font playground. All UI and live-update logic lives in the
+/// platform-neutral <see cref="FontPlaygroundScreen"/> (the same file the MonoGame host links). This
+/// host only bootstraps raylib + Gum, registers KernSmith for in-memory font generation, and pumps
+/// the raylib frame loop.
+///
+/// Fonts are generated in memory by KernSmith — no .fnt files are shipped with this sample, and both
+/// the Forms controls and the live preview text rasterize through the one creator registration.
+/// </summary>
+public static class Program
+{
+    public static void Main()
+    {
+        const int screenWidth = 1024;
+        const int screenHeight = 768;
+
+        GumService.Default.CanvasWidth = screenWidth;
+        GumService.Default.CanvasHeight = screenHeight;
+
+        SetConfigFlags(ConfigFlags.Msaa4xHint | ConfigFlags.ResizableWindow);
+        InitWindow(screenWidth, screenHeight, "Gum raylib - Dynamic Font Playground");
+
+        GumService.Default.Initialize();
+        GumService.Default.UseKeyboardDefaults();
+
+        // KernSmith generates a font for any (family, size, style) on demand — this single line is
+        // the only platform-specific difference from the MonoGame host's KernSmithFontCreator.
+        CustomSetPropertyOnRenderable.InMemoryFontCreator = new KernSmithRaylibFontCreator();
+
+        FontPlaygroundScreen.Build(GumService.Default.Root);
+
+        while (!WindowShouldClose())
+        {
+            BeginDrawing();
+            ClearBackground(new Color(30, 30, 46, 255));
+
+            GumService.Default.Update(GetTime());
+            GumService.Default.Draw();
+
+            EndDrawing();
+        }
+
+        CloseWindow();
+    }
+}

--- a/Tests/RaylibGum.Tests/RaylibGum.Tests.csproj
+++ b/Tests/RaylibGum.Tests/RaylibGum.Tests.csproj
@@ -23,6 +23,9 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\Runtimes\RaylibGum\RaylibGum.csproj" />
+    <!-- Referenced so the in-memory font creator can be exercised end-to-end (KernSmith atlas
+         generation -> raylib Texture2D upload -> Raylib_cs.Font). -->
+    <ProjectReference Include="..\..\Integrations\KernSmith\KernSmith.RaylibGum\KernSmith.RaylibGum.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tests/RaylibGum.Tests/Renderables/InMemoryFontCreatorTests.cs
+++ b/Tests/RaylibGum.Tests/Renderables/InMemoryFontCreatorTests.cs
@@ -1,0 +1,51 @@
+using Gum.GueDeriving;
+using RaylibGum.Renderables;
+using RenderingLibrary.Graphics.Fonts;
+using Shouldly;
+using Xunit;
+
+namespace RaylibGum.Tests.Renderables;
+
+public class InMemoryFontCreatorTests : BaseTestClass
+{
+    // Records what it was asked for and returns null, so UpdateToFontValues falls through to the
+    // existing disk / system-font path (no bogus Raylib_cs.Font is ever assigned to the renderable).
+    private sealed class RecordingFontCreator : IRaylibFontCreator
+    {
+        public int CallCount;
+        public BmfcSave? LastReceived;
+
+        public Raylib_cs.Font? TryCreateFont(BmfcSave bmfcSave)
+        {
+            CallCount++;
+            LastReceived = bmfcSave;
+            return null;
+        }
+    }
+
+    [Fact]
+    public void UpdateToFontValues_WhenInMemoryFontCreatorSet_ConsultsItWithCurrentFontProperties()
+    {
+        RecordingFontCreator creator = new RecordingFontCreator();
+        IRaylibFontCreator? saved = CustomSetPropertyOnRenderable.InMemoryFontCreator;
+        try
+        {
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = creator;
+
+            TextRuntime textRuntime = new TextRuntime();
+            textRuntime.Font = "Arial";
+            textRuntime.IsBold = true;
+            textRuntime.FontSize = 20;
+
+            creator.CallCount.ShouldBeGreaterThan(0);
+            creator.LastReceived.ShouldNotBeNull();
+            creator.LastReceived!.FontName.ShouldBe("Arial");
+            creator.LastReceived.FontSize.ShouldBe(20);
+            creator.LastReceived.IsBold.ShouldBeTrue();
+        }
+        finally
+        {
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = saved;
+        }
+    }
+}

--- a/Tests/RaylibGum.Tests/Renderables/KernSmithRaylibFontCreatorTests.cs
+++ b/Tests/RaylibGum.Tests/Renderables/KernSmithRaylibFontCreatorTests.cs
@@ -1,0 +1,42 @@
+using KernSmith.Gum;
+using RenderingLibrary.Graphics.Fonts;
+using Shouldly;
+using Xunit;
+
+namespace RaylibGum.Tests.Renderables;
+
+public class KernSmithRaylibFontCreatorTests : BaseTestClass
+{
+    // End-to-end regression for the multi-page atlas problem (#3164 / kaltinril/KernSmith#115): a
+    // large, outlined font must rasterize onto a SINGLE page and yield a usable Raylib_cs.Font rather
+    // than spilling across pages (which raylib's single-texture Font can't represent, so the wrapper
+    // would return null and the text would fall back to the default-size system font). This exercises
+    // the whole pipeline — KernSmith generation, the single-page atlas ceiling, the outline channel
+    // layout (which required KernSmith 0.15.1), and the raw-pixel -> Texture2D upload. It would fail
+    // on KernSmith 0.15.0, where this glyph set spilled to multiple pages.
+    [Fact]
+    public void TryCreateFont_LargeBoldItalicOutlinedFont_ProducesUsableFont()
+    {
+        KernSmithRaylibFontCreator creator = new KernSmithRaylibFontCreator();
+
+        BmfcSave bmfcSave = new BmfcSave
+        {
+            FontName = "Arial",
+            FontSize = 96,
+            IsBold = true,
+            IsItalic = true,
+            OutlineThickness = 8,
+            UseSmoothing = true,
+            Ranges = BmfcSave.GetEffectiveDefaultRanges(),
+            SpacingHorizontal = 1,
+            SpacingVertical = 1,
+        };
+
+        Raylib_cs.Font? font = creator.TryCreateFont(bmfcSave);
+
+        font.ShouldNotBeNull();
+        font!.Value.BaseSize.ShouldBe(96);
+        font.Value.GlyphCount.ShouldBeGreaterThan(0);
+        font.Value.Texture.Id.ShouldBeGreaterThan(0u);
+    }
+}


### PR DESCRIPTION
## Goal: MonoGame parity for raylib runtime fonts

The north star here is simple — **raylib fonts should work like MonoGame/KNI fonts**: same dynamic generation, same caching, same behavior, ideally the same code where the platforms allow it. Where raylib genuinely can't do what MonoGame does, we match the *behavior* and gate only the unavoidable platform-specific bits.

This PR brings raylib to parity via KernSmith (the recommended approach in #3162/#3164) and adds the raylib host for the dynamic font playground (linking the same shared screen as the MonoGame host from #3172).

Closes #3164.

> Note: this substantially advances **#3162** but does not fully close it — see "Parity status" below. #3162 stays open to track the remaining native-tier work.

## How it fits together

```
RaylibGum (the socket):
  • IRaylibFontCreator { Raylib_cs.Font? TryCreateFont(BmfcSave) }  — the Raylib parallel to the
    MonoGame-family IInMemoryFontCreator (which returns a BitmapFont raylib can't render)
  • CustomSetPropertyOnRenderable.InMemoryFontCreator (#if RAYLIB), consulted in UpdateToFontValues
    with the SAME BmfcSave construction as the MonoGame path (kept line-by-line identical), then the
    LoaderManager cache + ManagedFont store (so unmanaged GPU textures are freed) — same behavior as
    MonoGame, only the font type (Raylib_cs.Font vs BitmapFont) is platform-gated
  • ContentLoader.BuildFontFromFntText — internal (InternalsVisibleTo) glyph-assembly reuse

KernSmith.RaylibGum (the plug):
  • Implements IRaylibFontCreator: GumFontGenerator.Generate → upload page(s) to a raylib Texture2D →
    assemble a Raylib_cs.Font. Multi-page atlases are merged into one texture (raylib's Font is
    single-texture) so it produces a usable font for any glyph set with no fallback — matching the
    MonoGame creator, which hands BitmapFont a texture array. Plus a RegisterFont registry.
  • In AllLibraries.sln

Sample:
  • Samples/FontPlayground/FontPlayground.Raylib links the same platform-neutral FontPlaygroundScreen.cs
    as the MonoGame host; the only platform-specific line is the KernSmithRaylibFontCreator registration
```

## Notable details

- **Single-page atlas + KernSmith 0.15.1.** A generous atlas ceiling keeps the common case on one page; KernSmith **0.15.1** fixes the outline-channel page sizing (`AutofitTexture`/channel estimate) that previously spilled large outlined fonts across pages (kaltinril/KernSmith#115).
- **Caching parity.** raylib now checks the `LoaderManager` cache before generating and stores results as `ManagedFont` — no per-keystroke texture churn, deterministic GPU cleanup.
- **Behavioral parity, platform-gated code.** The `BmfcSave` construction is byte-identical to `Gum/Wireframe/CustomSetPropertyOnRenderable.cs`; only the font type and its caching/merge are gated (the same split as `Raylib_cs.Font` vs `BitmapFont`).

## Verification

- `RaylibGum.Tests`: socket wiring test + end-to-end generation test (large bold+italic+outline font → usable single-texture `Font`; would fail on KernSmith 0.15.0).
- Full chain builds; shared `FontPlaygroundScreen.cs` compiles unchanged on raylib; verified live in the raylib playground.

## Parity status (#3162)

**Done (this PR):** dynamic generation from properties, correct sizing, outline, bold/italic, smoothing, embedded `byte[]` fonts, multi-page handling, caching — all matching MonoGame via the KernSmith path.

**Remaining for #3162 (native fallback tier — not in this PR):**
- Un-hardcode `LoadFontEx(..., 24, ...)` so the non-creator path honors `FontSize`.
- Honor `UseFontSmoothing` natively (`Point`/`Bilinear`) without KernSmith.
- Route the custom-`.ttf` (`UseCustomFont`) branch through the in-memory creator (currently MonoGame-only).
- Outline channel rendering shader question (#3164 open item) for the non-KernSmith path.
