### PR TITLE
#3174: Enable Menu/MenuItem/PasswordBox/Image Forms controls on raylib

### DIFF
--- a/MonoGameGum/Forms/FormsUtilities.cs
+++ b/MonoGameGum/Forms/FormsUtilities.cs
@@ -196,7 +196,7 @@ public class FormsUtilities
                 TryAdd(typeof(Label), (_, c) => new DefaultVisuals.V3.LabelVisual(tryCreateFormsObject: c));
                 TryAdd(typeof(ListBox), (_, c) => new DefaultVisuals.V3.ListBoxVisual(tryCreateFormsObject: c));
                 TryAdd(typeof(ListBoxItem), (_, c) => new DefaultVisuals.V3.ListBoxItemVisual(tryCreateFormsObject: c));
-#if XNALIKE || FRB
+#if XNALIKE || FRB || RAYLIB
                 TryAdd(typeof(Menu), (_, c) => new DefaultVisuals.V3.MenuVisual(tryCreateFormsObject: c));
                 TryAdd(typeof(MenuItem), (_, c) => new DefaultVisuals.V3.MenuItemVisual(tryCreateFormsObject: c));
                 TryAdd(typeof(PasswordBox), (_, c) => new DefaultVisuals.V3.PasswordBoxVisual(tryCreateFormsObject: c));

--- a/Runtimes/RaylibGum/RaylibGum.csproj
+++ b/Runtimes/RaylibGum/RaylibGum.csproj
@@ -110,6 +110,9 @@
 		<Compile Include="..\..\MonoGameGum\Forms\DefaultVisuals\V3\LabelVisual.cs" Link="Forms\DefaultVisuals\V3\LabelVisual.cs" />
 		<Compile Include="..\..\MonoGameGum\Forms\DefaultVisuals\V3\ListBoxItemVisual.cs" Link="Forms\DefaultVisuals\V3\ListBoxItemVisual.cs" />
 		<Compile Include="..\..\MonoGameGum\Forms\DefaultVisuals\V3\ListBoxVisual.cs" Link="Forms\DefaultVisuals\V3\ListBoxVisual.cs" />
+		<Compile Include="..\..\MonoGameGum\Forms\DefaultVisuals\V3\MenuItemVisual.cs" Link="Forms\DefaultVisuals\V3\MenuItemVisual.cs" />
+		<Compile Include="..\..\MonoGameGum\Forms\DefaultVisuals\V3\MenuVisual.cs" Link="Forms\DefaultVisuals\V3\MenuVisual.cs" />
+		<Compile Include="..\..\MonoGameGum\Forms\DefaultVisuals\V3\PasswordBoxVisual.cs" Link="Forms\DefaultVisuals\V3\PasswordBoxVisual.cs" />
 		<Compile Include="..\..\MonoGameGum\Forms\DefaultVisuals\V3\RadioButtonVisual.cs" Link="Forms\DefaultVisuals\V3\RadioButtonVisual.cs" />
 		<Compile Include="..\..\MonoGameGum\Forms\DefaultVisuals\V3\ScrollBarVisual.cs" Link="Forms\DefaultVisuals\V3\ScrollBarVisual.cs" />
 		<Compile Include="..\..\MonoGameGum\Forms\DefaultVisuals\V3\ScrollViewerVisual.cs" Link="Forms\DefaultVisuals\V3\ScrollViewerVisual.cs" />

--- a/Runtimes/RaylibGum/RaylibGum.csproj
+++ b/Runtimes/RaylibGum/RaylibGum.csproj
@@ -165,6 +165,16 @@
 	</ItemGroup>
 
 	<ItemGroup>
+	  <!--
+	    Image, Menu, MenuItem, and PasswordBox are owned by GumCommon (migrated in PR #2887)
+	    and arrive here via the GumCommon ProjectReference below - exactly like Button,
+	    ListBox, FrameworkElement, etc. in the larger Remove block further down. These four
+	    are Removed for the SAME reason: the Forms\Controls\**\*.cs glob above would otherwise
+	    compile a second copy alongside GumCommon's, producing duplicate types across two
+	    assemblies (the IAnimatable double-type class of bug). A Remove here means "already
+	    provided by GumCommon, don't double-compile" - it does NOT mean these control classes
+	    are excluded from raylib. They are fully available via the GumCommon reference.
+	  -->
 	  <Compile Remove="..\..\MonoGameGum\Forms\Controls\Image.cs" />
 	  <Compile Remove="..\..\MonoGameGum\Forms\Controls\Menu.cs" />
 	  <Compile Remove="..\..\MonoGameGum\Forms\Controls\MenuItem.cs" />

--- a/Samples/raylib/Screens/FormsControlsScreen.cs
+++ b/Samples/raylib/Screens/FormsControlsScreen.cs
@@ -127,6 +127,32 @@ internal class FormsControlsScreen : FrameworkElement
             comboBox.Items.Add($"Item {i}");
         }
 
+        // Menu / MenuItem / PasswordBox / Image route through the V3 default visuals that
+        // were enabled on raylib in issue #3174 — included here so the gallery exercises them.
+        var menu = new Menu();
+        container.AddChild(menu.Visual);
+        var fileMenuItem = new MenuItem { Header = "File" };
+        fileMenuItem.Items.Add(new MenuItem { Header = "New" });
+        fileMenuItem.Items.Add(new MenuItem { Header = "Open" });
+        var recentMenuItem = new MenuItem { Header = "Recent" };
+        recentMenuItem.Items.Add(new MenuItem { Header = "Project A" });
+        recentMenuItem.Items.Add(new MenuItem { Header = "Project B" });
+        fileMenuItem.Items.Add(recentMenuItem);
+        menu.Items.Add(fileMenuItem);
+        var editMenuItem = new MenuItem { Header = "Edit" };
+        editMenuItem.Items.Add(new MenuItem { Header = "Copy" });
+        editMenuItem.Items.Add(new MenuItem { Header = "Paste" });
+        menu.Items.Add(editMenuItem);
+
+        var passwordBox = new PasswordBox();
+        container.AddChild(passwordBox.Visual);
+        passwordBox.Width = 250;
+        passwordBox.Placeholder = "Password…";
+
+        var image = new Gum.Forms.Controls.Image();
+        container.AddChild(image.Visual);
+        image.Source = "resources\\gum-logo-normal-64.png";
+
         var splitterStackPanel = new StackPanel();
         container.AddChild(splitterStackPanel);
         splitterStackPanel.Spacing = 1;

--- a/Samples/raylib/Screens/FormsControlsScreen.cs
+++ b/Samples/raylib/Screens/FormsControlsScreen.cs
@@ -20,13 +20,16 @@ internal class FormsControlsScreen : FrameworkElement
     {
         Dock(Gum.Wireframe.Dock.Fill);
 
+        // Root layout: a vertical stack holding the Menu at the very top (just below the nav
+        // strip) and, beneath it, a two-column row. Splitting the controls across two columns
+        // keeps them from spilling off the bottom on smaller resolutions.
+        //
         // Must be an InteractiveGue (ContainerRuntime), not a raw GraphicalUiElement: focus
         // tabbing walks the focused control's parent via `Parent as InteractiveGue`, so a
         // non-interactive parent yields no siblings and gamepad/keyboard navigation no-ops.
         var container = new ContainerRuntime();
         this.AddChild(container);
         container.ChildrenLayout = ChildrenLayout.TopToBottomStack;
-        container.WrapsChildren = true;
         container.StackSpacing = 5;
         container.Width = 0;
         container.WidthUnits = DimensionUnitType.RelativeToParent;
@@ -34,13 +37,47 @@ internal class FormsControlsScreen : FrameworkElement
         container.HeightUnits = DimensionUnitType.RelativeToParent;
         container.ClipsChildren = true;
 
+        // Menu / MenuItem / PasswordBox / Image route through the V3 default visuals that
+        // were enabled on raylib in issue #3174 — included here so the gallery exercises them.
+        // The Menu sits at the very top so its drop-down submenus have room to open below it.
+        var menu = new Menu();
+        container.AddChild(menu.Visual);
+        var fileMenuItem = new MenuItem { Header = "File" };
+        fileMenuItem.Items.Add(new MenuItem { Header = "New" });
+        fileMenuItem.Items.Add(new MenuItem { Header = "Open" });
+        var recentMenuItem = new MenuItem { Header = "Recent" };
+        recentMenuItem.Items.Add(new MenuItem { Header = "Project A" });
+        recentMenuItem.Items.Add(new MenuItem { Header = "Project B" });
+        fileMenuItem.Items.Add(recentMenuItem);
+        menu.Items.Add(fileMenuItem);
+        var editMenuItem = new MenuItem { Header = "Edit" };
+        editMenuItem.Items.Add(new MenuItem { Header = "Copy" });
+        editMenuItem.Items.Add(new MenuItem { Header = "Paste" });
+        menu.Items.Add(editMenuItem);
+
+        // Two side-by-side columns beneath the menu. Fixed-width columns (rather than
+        // RelativeToChildren) keep the layout free of circular width dependencies with the
+        // StackPanels nested inside them.
+        var columns = new ContainerRuntime();
+        container.AddChild(columns);
+        columns.ChildrenLayout = ChildrenLayout.LeftToRightStack;
+        columns.StackSpacing = 20;
+        columns.Width = 0;
+        columns.WidthUnits = DimensionUnitType.RelativeToParent;
+        columns.Height = 0;
+        columns.HeightUnits = DimensionUnitType.RelativeToChildren;
+
+        var leftColumn = AddColumn(columns);
+        var rightColumn = AddColumn(columns);
+
+        // ----- Left column -----
         var button = new Button();
         button.Width = 200;
         button.Text = "I'm a button";
-        container.AddChild(button.Visual);
+        leftColumn.AddChild(button.Visual);
 
         var textBox = new TextBox();
-        container.AddChild(textBox.Visual);
+        leftColumn.AddChild(textBox.Visual);
         textBox.Width = 250;
         textBox.Placeholder = "Type here…";
 
@@ -53,10 +90,10 @@ internal class FormsControlsScreen : FrameworkElement
         var checkbox = new CheckBox();
         checkbox.Width = 200;
         checkbox.Text = "Check me";
-        container.AddChild(checkbox.Visual);
+        leftColumn.AddChild(checkbox.Visual);
 
         var slider = new Slider();
-        container.AddChild(slider.Visual);
+        leftColumn.AddChild(slider.Visual);
         slider.Minimum = 0;
         slider.Maximum = 30;
         slider.TicksFrequency = 1;
@@ -68,11 +105,11 @@ internal class FormsControlsScreen : FrameworkElement
             Debug.WriteLine($"Finished setting Value: {slider.Value}");
 
         var label = new Label();
-        container.AddChild(label.Visual);
+        leftColumn.AddChild(label.Visual);
         label.Text = "This is a Gum label";
 
         var scrollViewer = new ScrollViewer();
-        container.AddChild(scrollViewer.Visual);
+        leftColumn.AddChild(scrollViewer.Visual);
         scrollViewer.Width = 200;
         scrollViewer.Height = 200;
         scrollViewer.Visual.WidthUnits = DimensionUnitType.Absolute;
@@ -91,7 +128,7 @@ internal class FormsControlsScreen : FrameworkElement
         }
 
         var stackPanel = new StackPanel();
-        container.AddChild(stackPanel.Visual);
+        leftColumn.AddChild(stackPanel.Visual);
 
         var easyRadioButton = new RadioButton();
         stackPanel.AddChild(easyRadioButton);
@@ -105,13 +142,14 @@ internal class FormsControlsScreen : FrameworkElement
         stackPanel.AddChild(hardRadioButton);
         hardRadioButton.Text = "Hard";
 
+        // ----- Right column -----
         var listBox = new ListBox();
-        container.AddChild(listBox.Visual);
+        rightColumn.AddChild(listBox.Visual);
         listBox.Width = 300;
         listBox.Height = 200;
 
         var addButton = new Button();
-        container.AddChild(addButton.Visual);
+        rightColumn.AddChild(addButton.Visual);
         addButton.Text = "Add to ListBox";
         addButton.Click += (s, e) =>
         {
@@ -121,44 +159,28 @@ internal class FormsControlsScreen : FrameworkElement
         };
 
         var comboBox = new ComboBox();
-        container.AddChild(comboBox.Visual);
+        rightColumn.AddChild(comboBox.Visual);
         for (int i = 0; i < 10; i++)
         {
             comboBox.Items.Add($"Item {i}");
         }
 
-        // Menu / MenuItem / PasswordBox / Image route through the V3 default visuals that
-        // were enabled on raylib in issue #3174 — included here so the gallery exercises them.
-        var menu = new Menu();
-        container.AddChild(menu.Visual);
-        var fileMenuItem = new MenuItem { Header = "File" };
-        fileMenuItem.Items.Add(new MenuItem { Header = "New" });
-        fileMenuItem.Items.Add(new MenuItem { Header = "Open" });
-        var recentMenuItem = new MenuItem { Header = "Recent" };
-        recentMenuItem.Items.Add(new MenuItem { Header = "Project A" });
-        recentMenuItem.Items.Add(new MenuItem { Header = "Project B" });
-        fileMenuItem.Items.Add(recentMenuItem);
-        menu.Items.Add(fileMenuItem);
-        var editMenuItem = new MenuItem { Header = "Edit" };
-        editMenuItem.Items.Add(new MenuItem { Header = "Copy" });
-        editMenuItem.Items.Add(new MenuItem { Header = "Paste" });
-        menu.Items.Add(editMenuItem);
-
         var passwordBox = new PasswordBox();
-        container.AddChild(passwordBox.Visual);
+        rightColumn.AddChild(passwordBox.Visual);
         passwordBox.Width = 250;
         passwordBox.Placeholder = "Password…";
 
         var image = new Gum.Forms.Controls.Image();
-        container.AddChild(image.Visual);
+        rightColumn.AddChild(image.Visual);
         image.Source = "resources\\gum-logo-normal-64.png";
 
         var splitterStackPanel = new StackPanel();
-        container.AddChild(splitterStackPanel);
+        rightColumn.AddChild(splitterStackPanel);
         splitterStackPanel.Spacing = 1;
 
         var listBox1 = new ListBox();
         splitterStackPanel.AddChild(listBox1);
+        listBox1.Height = 120;
         for (int i = 0; i < 10; i++)
         {
             listBox1.Items.Add("List Item " + i);
@@ -171,6 +193,7 @@ internal class FormsControlsScreen : FrameworkElement
 
         var listBox2 = new ListBox();
         splitterStackPanel.AddChild(listBox2);
+        listBox2.Height = 120;
         for (int i = 0; i < 10; i++)
         {
             listBox2.Items.Add("List Item " + i);
@@ -199,6 +222,22 @@ internal class FormsControlsScreen : FrameworkElement
         };
 
         AddSwitchHint();
+    }
+
+    /// <summary>
+    /// Creates a fixed-width, top-to-bottom stacking column and adds it to <paramref name="parent"/>.
+    /// </summary>
+    private static ContainerRuntime AddColumn(ContainerRuntime parent)
+    {
+        var column = new ContainerRuntime();
+        parent.AddChild(column);
+        column.ChildrenLayout = ChildrenLayout.TopToBottomStack;
+        column.StackSpacing = 5;
+        column.Width = 330;
+        column.WidthUnits = DimensionUnitType.Absolute;
+        column.Height = 0;
+        column.HeightUnits = DimensionUnitType.RelativeToChildren;
+        return column;
     }
 
     /// <summary>

--- a/Tests/RaylibGum.Tests/Forms/MenuPasswordBoxAndImageTests.cs
+++ b/Tests/RaylibGum.Tests/Forms/MenuPasswordBoxAndImageTests.cs
@@ -1,0 +1,65 @@
+using Gum.Forms;
+using Gum.Forms.Controls;
+using RenderingLibrary;
+using Shouldly;
+
+namespace RaylibGum.Tests.Forms;
+
+/// <summary>
+/// Guards that the four controls enabled on raylib in issue #3174 build a usable Visual under the
+/// V3 default visuals. Menu, MenuItem, and PasswordBox route through
+/// <see cref="FrameworkElement.DefaultFormsTemplates"/>, whose registrations in
+/// <c>FormsUtilities.InitializeDefaults</c> were historically gated <c>#if XNALIKE || FRB</c> — so on
+/// raylib <c>new Menu()</c> / <c>new MenuItem()</c> / <c>new PasswordBox()</c> previously produced a
+/// null Visual. Image is not a template entry; it builds its own Visual directly (see its test).
+///
+/// Mirrors <see cref="TextBoxTests"/>: layers V3 on top of the assembly bootstrap's V2 setup and
+/// removes the V3-only registrations in Dispose.
+/// </summary>
+public class MenuPasswordBoxAndImageTests : BaseTestClass
+{
+    public MenuPasswordBoxAndImageTests()
+    {
+        FormsUtilities.InitializeDefaults(SystemManagers.Default, DefaultVisualsVersion.V3);
+    }
+
+    public override void Dispose()
+    {
+        FrameworkElement.DefaultFormsTemplates.Remove(typeof(Menu));
+        FrameworkElement.DefaultFormsTemplates.Remove(typeof(MenuItem));
+        FrameworkElement.DefaultFormsTemplates.Remove(typeof(PasswordBox));
+        base.Dispose();
+        TestAssemblyInitialize.ApplyDefaultTestState();
+    }
+
+    [Fact]
+    public void Image_Visual_IsBuilt()
+    {
+        // Image is not a DefaultFormsTemplates entry: it builds its own InteractiveGue wrapping a
+        // sprite renderable via IGumService.CreateSpriteRenderable(), which has a live #elif RAYLIB
+        // branch. This guards that path produces a usable Visual on raylib.
+        var image = new Image();
+        image.Visual.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void Menu_Visual_IsRegistered_OnV3()
+    {
+        var menu = new Menu();
+        menu.Visual.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void MenuItem_Visual_IsRegistered_OnV3()
+    {
+        var menuItem = new MenuItem();
+        menuItem.Visual.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void PasswordBox_Visual_IsRegistered_OnV3()
+    {
+        var passwordBox = new PasswordBox();
+        passwordBox.Visual.ShouldNotBeNull();
+    }
+}


### PR DESCRIPTION
Closes #3174.

## What

Enables the **Menu**, **MenuItem**, **PasswordBox**, and **Image** Forms controls on raylib under the V3 default visuals (the `Newest` default every shipped theme depends on).

## Why this was the gap (not what the original issue body said)

The control *classes* already compiled into RaylibGum via GumCommon (PR #2887) — the `<Compile Remove>` lines for them in `RaylibGum.csproj` are de-dup guards, not exclusions, and are left untouched. The real gap was the **V3 default visuals**:

- `Menu` / `MenuItem` / `PasswordBox` registrations in `FormsUtilities.InitializeDefaults` were gated `#if XNALIKE || FRB` — raylib excluded.
- The V3 `MenuVisual` / `MenuItemVisual` / `PasswordBoxVisual` files weren't source-linked into `RaylibGum.csproj`.

So on raylib `new Menu()` / `new PasswordBox()` produced a **null Visual**, and `new MenuItem()` actually **NRE'd at construction** — it fell back to the registered `ScrollViewer` template and ran `MenuItem.ReactToVisualChanged` against the wrong visual tree.

## Changes

- Widen the V3 gate to `#if XNALIKE || FRB || RAYLIB` in `FormsUtilities.cs`.
- Source-link V3 `MenuVisual` / `MenuItemVisual` / `PasswordBoxVisual` into `RaylibGum.csproj`. The visuals are backend-neutral (`NineSlice`/`Text`/`Container` runtimes, all already on raylib) — no `#if RAYLIB` divergence needed.
- **Image** needed no code change: it builds its own Visual via `IGumService.CreateSpriteRenderable()`'s live `RAYLIB` branch, with `SourceFile` loading already implemented raylib-side. Verified by test + sample.
- `Samples/raylib/GumTest` `FormsControlsScreen` now creates all four controls so the gallery exercises them at runtime.

## Scope note — V3 only

V2's `Menu`/`PasswordBox` stay raylib-gated on purpose: V2 `TextBox`/`ItemsControl` are themselves still gated off raylib, so V2 can't be made whole within this issue. V3 is what the themes need.

The four `<Compile Remove>` control-class entries are intentionally **not** touched (removing them reintroduces the duplicate-type bug).

## Testing

- New `Tests/RaylibGum.Tests/Forms/MenuPasswordBoxAndImageTests.cs` — asserts all four build a non-null Visual on V3. Red before the fix (PasswordBox null Visual; MenuItem NRE), green after.
- Full `RaylibGum.Tests` suite green (336 → 340 tests). `MonoGameGum` builds clean (the shared `FormsUtilities` edit is inert for XNALIKE — the gate was already true there).
- `Samples/raylib/GumTest` builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
