### PR TITLE
#3183: Fix raylib shape stroke parity (StrokeWidth=0 hairline + 1px-stroke vanish)

### DIFF
--- a/MonoGameGum/GueDeriving/CircleRuntime.cs
+++ b/MonoGameGum/GueDeriving/CircleRuntime.cs
@@ -1562,19 +1562,13 @@ public class CircleRuntime : GraphicalUiElement
             strokeWidth /= cameraZoom;
         }
 
-        // Mirror the XNALIKE/Apos PreRender's AA compensation (#2814 cross-backend parity): the
-        // backend's antialiasing widens the rendered stroke by ~1px, so the geometric width handed
-        // to the primitive is reduced by that contribution to keep the VISIBLE width equal to the
-        // nominal StrokeWidth. Without this a nominal 1px ring renders visibly thicker than the
-        // Apos/Skia backends. Same fix as RectangleRuntime.PreRender.
-        const float aaContribution = 1f;
-        const float minThicknessEpsilon = 0.01f;
-        float aaContributionWorld = aaContribution / cameraZoom;
-        float renderableStrokeWidth = strokeWidth <= 0
-            ? 0f
-            : System.Math.Max(minThicknessEpsilon, strokeWidth - aaContributionWorld);
-
-        ContainedLineCircle.StrokeWidth = renderableStrokeWidth;
+        // Issue #3183 — raylib gets NO AA compensation; see RectangleRuntime.PreRender for the full
+        // rationale. Apos subtracts a ~1px geometric contribution but adds it back as an AA band;
+        // raylib's MSAA adds no width, so the geometric width IS the visible width. Pushing
+        // StrokeWidth straight through matches the Apos reference (shape-parity harness). The prior
+        // #3179 subtraction collapsed a nominal 1px ring to ~0.01px (invisible). StrokeWidth <= 0
+        // still pushes literal 0 so LineCircle's positive-width gate suppresses the ring.
+        ContainedLineCircle.StrokeWidth = strokeWidth <= 0 ? 0f : strokeWidth;
     }
 #endif
 

--- a/MonoGameGum/GueDeriving/PolygonRuntime.cs
+++ b/MonoGameGum/GueDeriving/PolygonRuntime.cs
@@ -306,6 +306,12 @@ public class PolygonRuntime : InteractiveGue
                 strokeWidth /= camera.Zoom;
             }
         }
+        // Issue #3183 — deliberately NOT applying the RectangleRuntime/CircleRuntime AA
+        // compensation here. The shape-parity harness measured it as a net wash-to-regression for
+        // polygons: thin (1px) outlines vanish under the ~1px subtraction (moving further from the
+        // MonoGame line primitive that draws them), while thicker outlines improve only marginally.
+        // Left uncompensated until the harness shows a compensation that helps thin AND thick
+        // strokes. See the issue notes for the harness evidence.
         ContainedPolygon.LinePixelWidth = strokeWidth;
     }
 #endif

--- a/MonoGameGum/GueDeriving/PolygonRuntime.cs
+++ b/MonoGameGum/GueDeriving/PolygonRuntime.cs
@@ -306,12 +306,11 @@ public class PolygonRuntime : InteractiveGue
                 strokeWidth /= camera.Zoom;
             }
         }
-        // Issue #3183 — deliberately NOT applying the RectangleRuntime/CircleRuntime AA
-        // compensation here. The shape-parity harness measured it as a net wash-to-regression for
-        // polygons: thin (1px) outlines vanish under the ~1px subtraction (moving further from the
-        // MonoGame line primitive that draws them), while thicker outlines improve only marginally.
-        // Left uncompensated until the harness shows a compensation that helps thin AND thick
-        // strokes. See the issue notes for the harness evidence.
+        // Issue #3183 — raylib shape strokes get NO AA compensation: the geometric width handed to
+        // the primitive IS the visible width (raylib's MSAA only smooths edges, it adds no width),
+        // so pushing StrokeWidth straight through matches the MonoGame line primitive. See
+        // RectangleRuntime.PreRender for the full rationale, including why the #3179 attempt to
+        // subtract a ~1px Apos-style AA contribution made thin strokes vanish.
         ContainedPolygon.LinePixelWidth = strokeWidth;
     }
 #endif

--- a/MonoGameGum/GueDeriving/RectangleRuntime.cs
+++ b/MonoGameGum/GueDeriving/RectangleRuntime.cs
@@ -224,19 +224,16 @@ public class RectangleRuntime : GraphicalUiElement
             strokeWidth /= cameraZoom;
         }
 
-        // Mirror the XNALIKE/Apos PreRender's AA compensation (#2814 cross-backend parity): the
-        // backend's antialiasing widens the rendered stroke by ~1px, so the geometric width handed
-        // to the primitive is reduced by that contribution to keep the VISIBLE width equal to the
-        // nominal StrokeWidth. raylib's MSAA spreads the geometric edge the same way, so without
-        // this a nominal 1px border renders visibly thicker than the Apos/Skia backends.
-        const float aaContribution = 1f;
-        const float minThicknessEpsilon = 0.01f;
-        float aaContributionWorld = aaContribution / cameraZoom;
-        float renderableStrokeWidth = strokeWidth <= 0
-            ? 0f
-            : System.Math.Max(minThicknessEpsilon, strokeWidth - aaContributionWorld);
-
-        ContainedLineRectangle.LinePixelWidth = renderableStrokeWidth;
+        // Issue #3183 — raylib gets NO AA compensation (unlike the Apos/XNALIKE PreRender below).
+        // Apos.Shapes subtracts a ~1px geometric contribution but adds it back as a ~1px
+        // antialiasing band, so its VISIBLE stroke width is preserved. raylib's MSAA only smooths
+        // the edges of the geometry it is handed — it adds no width — so the geometric width IS the
+        // visible width. Pushing StrokeWidth straight through matches the Apos reference pixel-for-
+        // pixel across stroke widths (verified by the shape-parity screenshot harness). A prior
+        // attempt (#3179) mirrored Apos's subtraction here without Apos's add-back, which collapsed
+        // a nominal 1px outline to ~0.01px — invisible. StrokeWidth <= 0 still pushes literal 0 so
+        // LineRectangle's positive-width gate suppresses the stroke (the fill-only-shape fix above).
+        ContainedLineRectangle.LinePixelWidth = strokeWidth <= 0 ? 0f : strokeWidth;
     }
 #endif
 

--- a/Runtimes/RaylibGum/Renderables/LineCircle.cs
+++ b/Runtimes/RaylibGum/Renderables/LineCircle.cs
@@ -420,7 +420,12 @@ public class LineCircle : InvisibleRenderable
         // StrokeWidth) so the ring never bleeds past the nominal bounds — mirrors Skia's
         // RenderableShapeBase.IsOffsetAppliedForStroke contract, which the #2790 gallery's
         // "inscribed in 64x64 frame" row treats as the visual acceptance.
-        bool runStroke = StrokeColor.HasValue || !runFill;
+        // Issue #3183 — gate the stroke pass on a positive StrokeWidth. The default StrokeColor
+        // is non-null (white), so a fill-only disk (IsFilled = true, StrokeWidth = 0) would
+        // otherwise keep runStroke true and draw a zero/near-zero-width DrawRing in the stroke
+        // color. Mirrors the Apos RenderableShapeBase.HasVisibleOutput contract
+        // (IsFilled || StrokeWidth > 0). A fresh shape (StrokeWidth defaults to 1) keeps its ring.
+        bool runStroke = (StrokeColor.HasValue || !runFill) && StrokeWidth > 0f;
 
         // Skia parity (#2757): SkiaShapeRuntime.RefreshSlotGradients auto-gates each slot's
         // UseGradient flag by whether that slot has a non-null color, so a cell with both

--- a/Runtimes/RaylibGum/Renderables/LineRectangle.cs
+++ b/Runtimes/RaylibGum/Renderables/LineRectangle.cs
@@ -435,7 +435,15 @@ public class LineRectangle : InvisibleRenderable
         // unrotated, solid case we use DrawRectangleLinesEx which gives a proper inset thick
         // outline. Rotated or dashed paths fall back to per-edge DrawLineEx so the rotation
         // composition and dash perimeter-walk apply cleanly.
-        bool runStroke = StrokeColor.HasValue || !runFill;
+        //
+        // Issue #3183 — gate the stroke pass on a positive LinePixelWidth. The default StrokeColor
+        // is non-null (white), so a fill-only shape (IsFilled = true, StrokeWidth = 0) would
+        // otherwise keep runStroke true and raylib's DrawRectangleRoundedLinesEx paints a ~1px
+        // white hairline at width 0 (visible on the Dark Pro slider track / scrollbars). Mirrors
+        // the Apos RenderableShapeBase.HasVisibleOutput contract (IsFilled || StrokeWidth > 0),
+        // which Circle/RoundedRectangle/Arc early-return on so a zero-width stroke draws nothing.
+        // A fresh shape (StrokeWidth defaults to 1) keeps its outline.
+        bool runStroke = (StrokeColor.HasValue || !runFill) && LinePixelWidth > 0f;
 
         // Skia parity (#2757): SkiaShapeRuntime.RefreshSlotGradients auto-gates each slot's
         // UseGradient flag by whether that slot has a non-null color, so a cell with both

--- a/Runtimes/SkiaGum/GueDeriving/ArcRuntime.cs
+++ b/Runtimes/SkiaGum/GueDeriving/ArcRuntime.cs
@@ -419,13 +419,10 @@ public class ArcRuntime : GraphicalUiElement
                 thickness /= camera.Zoom;
             }
         }
-        // Issue #3183 — deliberately NOT applying the RectangleRuntime/CircleRuntime AA
-        // compensation here. The arc band is a DrawRing *filled annulus* whose visible width
-        // already equals the nominal Thickness, so subtracting a ~1px AA contribution over-thins
-        // it: the shape-parity harness measured every arc band moving visibly FURTHER from the
-        // Apos reference with the compensation applied (mean per-cell diff roughly doubling). The
-        // ~1px-too-thick problem the compensation solves is specific to DrawRectangleLinesEx-style
-        // strokes, not DrawRing bands. See the issue notes for the harness evidence.
+        // Issue #3183 — raylib shape strokes get NO AA compensation: the geometric width IS the
+        // visible width (MSAA adds none). The arc band is a DrawRing filled annulus already at the
+        // nominal Thickness, so the band width is pushed straight through. See
+        // RectangleRuntime.PreRender for the full rationale.
         ContainedLineArc.Thickness = thickness;
     }
 

--- a/Runtimes/SkiaGum/GueDeriving/ArcRuntime.cs
+++ b/Runtimes/SkiaGum/GueDeriving/ArcRuntime.cs
@@ -419,6 +419,13 @@ public class ArcRuntime : GraphicalUiElement
                 thickness /= camera.Zoom;
             }
         }
+        // Issue #3183 — deliberately NOT applying the RectangleRuntime/CircleRuntime AA
+        // compensation here. The arc band is a DrawRing *filled annulus* whose visible width
+        // already equals the nominal Thickness, so subtracting a ~1px AA contribution over-thins
+        // it: the shape-parity harness measured every arc band moving visibly FURTHER from the
+        // Apos reference with the compensation applied (mean per-cell diff roughly doubling). The
+        // ~1px-too-thick problem the compensation solves is specific to DrawRectangleLinesEx-style
+        // strokes, not DrawRing bands. See the issue notes for the harness evidence.
         ContainedLineArc.Thickness = thickness;
     }
 


### PR DESCRIPTION
Closes #3183.

Two RaylibGum shape stroke-parity fixes, both found and verified with a screenshot + pixel-diff harness comparing raylib against the MonoGame/Apos reference.

## Stacked on #3179
Base is **`3175-raylib-theme-variants`** (PR #3179). GitHub will auto-retarget this to `main` once #3179 merges. **Note:** fix #2 below *reverts* the rect/circle AA-compensation #3179 added — so it lands here as a revert-on-top. Cleaner history would be to drop that commit (`Fix raylib stroke width rendering ~1px too thick`) from #3179 directly and rebase this; either way the net result is identical.

## Fix 1 — `StrokeWidth = 0` not suppressed (white hairline on fill-only shapes)
`LineRectangle`/`LineCircle` gated the stroke pass on `StrokeColor.HasValue || !runFill` with no positive-width check. The default `StrokeColor` is white, so a fill-only shape (`IsFilled=true; StrokeWidth=0`) kept the stroke on and `DrawRectangleRoundedLinesEx`/`DrawRing` painted a ~1px white hairline at width 0 (Dark Pro slider track / scrollbars). Added a positive-width gate, mirroring Apos `HasVisibleOutput`.

Harness: rounded fill-only `StrokeWidth=0` rect went from **mean 7.11 / 64 px>128 → 0.21 / 0**.

**Bug #2 (stacking gap)** was a side-effect of this: hairlines on adjacent rounded fill-only `ScrollViewer` items filled the 2px `StackSpacing` gap. Reproduced and confirmed fixed (stacked items now show clean gaps).

## Fix 2 — nominal `StrokeWidth = 1` strokes vanished on raylib
Side-by-side eyeballing showed a 1px white outline rendering on MonoGame but **not** raylib. Root cause: #3179 mirrored the Apos `PreRender`'s ~1px AA-contribution *subtraction* onto raylib's rect/circle `PreRender`. But Apos.Shapes subtracts geometry **and adds it back as a ~1px antialiasing band**, so its visible width is preserved; **raylib's MSAA only smooths existing edges — it adds no width.** So the subtraction was pure loss: nominal 1px → `max(0.01, 1−1)` = 0.01px geometric → invisible.

Fix: push `StrokeWidth` straight through on raylib (keeping the `StrokeWidth<=0 → 0` gate that drives Fix 1). `PolygonRuntime`/`ArcRuntime` never had the compensation — comments unified to the same rationale.

Harness, raylib vs MonoGame reference:

| Cell | before (with comp) | after (no comp) |
|---|---|---|
| rect default `sw1` white | 308 px>128 (absent) | **0 px>128 (pixel-identical)** |
| rect strokes `sw2`/`sw4` | ~300 | **0 / 0** |
| rect fill+stroke `sw1/2/4/8` | ~300 each | **all 0** |
| circle rings `sw1/2/4` | ~130 | **0 (within AA noise)** |
| overall scene | 5635 px>128 | **3979 px>128** |

Remaining diff is genuine MSAA-vs-SDF residue (rounded-corner rendering, polygon thick-stroke style) — accepted.

## Verification — screenshot harness
The `#if RAYLIB` `Render`/`PreRender` paths can't run in the MonoGame test project, so verification is the harness: one **backend-agnostic shape scene** (channel-int + geometry setters only → identical on both backends) compiled into a **MonoGame/Apos reference** app and a **raylib** app, plus a pixel-diff/heatmap tool. Both apps run windowed for side-by-side eyeballing or `--capture <png>` for the diff. (Runtime/library builds green, 204 shape tests pass; the changes are `#if RAYLIB`-only.)

Harness lives under `Samples/ShapeParity/` (+ `ShapeParity.slnx` for VS) — currently **uncommitted** pending the commit-vs-throwaway call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
