### PR TITLE
Fix raylib text line height to use .fnt lineHeight (match MonoGame)

### DIFF
--- a/Runtimes/RaylibGum/Renderables/Text.cs
+++ b/Runtimes/RaylibGum/Renderables/Text.cs
@@ -86,6 +86,13 @@ public class Text : IVisible, IRenderableIpso,
     private int _lineHeightInPixels;
 
     /// <summary>
+    /// The descender height (line height minus baseline) as defined by the font, ignoring FontScale.
+    /// Recovered from the loaded .fnt's lineHeight/base; defaults to 2 for fonts without recorded
+    /// metrics (raylib's built-in default font, TTF loaded via LoadFontEx).
+    /// </summary>
+    private int _descenderHeight = 2;
+
+    /// <summary>
     /// Stores the width of the text object's texture before it has had a chance to render, not including
     /// the FontScale.
     /// </summary>
@@ -210,7 +217,23 @@ public class Text : IVisible, IRenderableIpso,
         {
             throw new InvalidOperationException("Cannot measure text because IsWindowReady() is false - did you remember to call InitWindow first?");
         }
-        _lineHeightInPixels = (int)(MeasureTextEx(_font, "M", _font.BaseSize, 0).Y + .5);
+
+        // A Gum bitmap font records its .fnt lineHeight/base when loaded (keyed by atlas texture id),
+        // because raylib's Font struct can't hold them. Use those so line height includes the
+        // descender region exactly as the MonoGame BitmapFont does — otherwise a Text (and any
+        // container sized RelativeToChildren around it, e.g. a ListBoxItem) is short by that region.
+        // Fonts without recorded metrics (raylib's built-in default, TTF via LoadFontEx) fall back to
+        // native measurement, which returns ~BaseSize.
+        if (RaylibFontMetricsRegistry.TryGet(_font.Texture.Id, out var metrics))
+        {
+            _lineHeightInPixels = metrics.LineHeight;
+            _descenderHeight = metrics.LineHeight - metrics.BaselineY;
+        }
+        else
+        {
+            _lineHeightInPixels = (int)(MeasureTextEx(_font, "M", _font.BaseSize, 0).Y + .5);
+            _descenderHeight = 2;
+        }
     }
 
     public ObservableCollection<IRenderableIpso> Children
@@ -308,7 +331,7 @@ public class Text : IVisible, IRenderableIpso,
         }
     }
 
-    public float DescenderHeight => 2;
+    public float DescenderHeight => _descenderHeight;
 
     public float FontScale { get; set; } = 1;
 

--- a/Runtimes/RaylibGum/RenderingLibrary/ContentLoader.cs
+++ b/Runtimes/RaylibGum/RenderingLibrary/ContentLoader.cs
@@ -59,7 +59,12 @@ public class ContentLoader : IContentLoader
         {
             if (isFnt)
             {
-                font = Raylib.LoadFont(contentName);
+                Font loadedFont = Raylib.LoadFont(contentName);
+                font = loadedFont;
+                // raylib's native loader discards the .fnt's lineHeight/base, so re-parse the on-disk
+                // file to record them (same registry the in-memory/KernSmith path populates via
+                // BuildFont). Keyed by atlas texture id so the Text renderable can recover them.
+                RegisterFontMetricsFromFnt(File.ReadAllText(contentName), loadedFont.Texture.Id);
             }
             else
             {
@@ -255,7 +260,7 @@ public class ContentLoader : IContentLoader
             };
         }
 
-        return new Font
+        Font font = new Font
         {
             BaseSize = parsedFontFile.Info.Size,
             GlyphCount = glyphCount,
@@ -264,6 +269,30 @@ public class ContentLoader : IContentLoader
             Recs = recs,
             Glyphs = glyphs,
         };
+
+        // raylib's Font has no lineHeight/base field, so record the .fnt's values keyed by the atlas
+        // texture id. The Text renderable uses these for line height and descender so raylib matches
+        // the MonoGame BitmapFont; without it, line height collapses to BaseSize (no descender region).
+        RaylibFontMetricsRegistry.Register(pageTexture.Id, parsedFontFile.Common.LineHeight, parsedFontFile.Common.Base);
+
+        return font;
+    }
+
+    // Parses just the lineHeight/base out of a .fnt's text and records them against the loaded font's
+    // atlas texture id. Used by the native on-disk path, which loads through raylib's own .fnt loader
+    // (so it never goes through BuildFont). A malformed .fnt simply skips registration — the Text
+    // renderable then falls back to native measurement.
+    private static void RegisterFontMetricsFromFnt(string fntText, uint textureId)
+    {
+        try
+        {
+            ParsedFontFile parsedFontFile = new ParsedFontFile(fntText);
+            RaylibFontMetricsRegistry.Register(textureId, parsedFontFile.Common.LineHeight, parsedFontFile.Common.Base);
+        }
+        catch
+        {
+            // Leave unregistered; line height falls back to MeasureTextEx in the Text renderable.
+        }
     }
 
     public static string StandardizeCaseSensitive(string fileName)

--- a/Runtimes/RaylibGum/RenderingLibrary/ManagedFont.cs
+++ b/Runtimes/RaylibGum/RenderingLibrary/ManagedFont.cs
@@ -35,6 +35,9 @@ public class ManagedFont : IDisposable
     {
         if (!disposed)
         {
+            // Drop any recorded line metrics first — raylib may reuse this texture id after UnloadFont,
+            // and a stale entry would hand the next font the wrong line height.
+            RaylibFontMetricsRegistry.Remove(Font.Texture.Id);
             Raylib_cs.Raylib.UnloadFont(Font);
             disposed = true;
         }

--- a/Runtimes/RaylibGum/RenderingLibrary/RaylibFontMetricsRegistry.cs
+++ b/Runtimes/RaylibGum/RenderingLibrary/RaylibFontMetricsRegistry.cs
@@ -1,0 +1,72 @@
+using System.Collections.Generic;
+
+namespace RenderingLibrary;
+
+/// <summary>
+/// Associates a Gum bitmap font's line-spacing metrics (the .fnt <c>lineHeight</c> and <c>base</c>)
+/// with the atlas texture id of the loaded raylib font.
+/// </summary>
+/// <remarks>
+/// raylib's <see cref="Raylib_cs.Font"/> struct carries only <c>BaseSize</c> — it has no field for a
+/// bitmap font's lineHeight/baseline — so when a Gum .fnt is assembled those values are recorded here
+/// and looked up by the <c>Text</c> renderable when it measures lines. Without this, the renderable
+/// reconstructed line height as <c>MeasureTextEx("M") ≈ BaseSize</c>, dropping the descender region
+/// that the MonoGame <c>BitmapFont.LineHeightInPixels</c> keeps — so a Text (and any container sized
+/// RelativeToChildren around it) came out shorter on raylib than MonoGame.
+///
+/// Keyed by atlas texture id because that value travels with the (copied) <see cref="Raylib_cs.Font"/>
+/// struct through LoaderManager caching and reassignment, whereas the parsed .fnt metadata is
+/// discarded. Entries are removed when the owning <see cref="ManagedFont"/> is disposed, since raylib
+/// may later reuse the freed texture id. Accessed only on the single render/content-load thread.
+/// </remarks>
+internal static class RaylibFontMetricsRegistry
+{
+    /// <summary>
+    /// The line-spacing metrics recorded for one loaded bitmap font.
+    /// </summary>
+    public readonly struct FontLineMetrics
+    {
+        /// <summary>The full line height in pixels (the .fnt <c>common lineHeight</c>).</summary>
+        public int LineHeight { get; }
+
+        /// <summary>The distance in pixels from the top of the line to the baseline (the .fnt <c>common base</c>).</summary>
+        public int BaselineY { get; }
+
+        /// <summary>Initializes a new instance of the <see cref="FontLineMetrics"/> struct.</summary>
+        public FontLineMetrics(int lineHeight, int baselineY)
+        {
+            LineHeight = lineHeight;
+            BaselineY = baselineY;
+        }
+    }
+
+    private static readonly Dictionary<uint, FontLineMetrics> _metricsByTextureId = new();
+
+    /// <summary>
+    /// Records the line metrics for the font whose atlas has the given texture id, overwriting any
+    /// prior entry for that id.
+    /// </summary>
+    public static void Register(uint textureId, int lineHeight, int baselineY)
+    {
+        _metricsByTextureId[textureId] = new FontLineMetrics(lineHeight, baselineY);
+    }
+
+    /// <summary>
+    /// Looks up the line metrics recorded for the given atlas texture id. Returns false for fonts that
+    /// were not assembled from a Gum .fnt (raylib's built-in default font, TTF loaded via LoadFontEx),
+    /// in which case callers fall back to native measurement.
+    /// </summary>
+    public static bool TryGet(uint textureId, out FontLineMetrics metrics)
+    {
+        return _metricsByTextureId.TryGetValue(textureId, out metrics);
+    }
+
+    /// <summary>
+    /// Removes the entry for the given atlas texture id. Called when the owning font is unloaded so a
+    /// reused texture id cannot return stale metrics.
+    /// </summary>
+    public static void Remove(uint textureId)
+    {
+        _metricsByTextureId.Remove(textureId);
+    }
+}

--- a/Samples/MonoGameGumThemesShowcase/MonoGameGumThemesShowcase.slnx
+++ b/Samples/MonoGameGumThemesShowcase/MonoGameGumThemesShowcase.slnx
@@ -2,6 +2,8 @@
   <Project Path="MonoGameGumThemesShowcase.csproj" />
   <Folder Name="/Libraries/">
     <Project Path="../../GumCommon/GumCommon.csproj" />
+    <Project Path="../../Integrations/KernSmith/KernSmith.GumCommon/KernSmith.GumCommon.csproj" />
+    <Project Path="../../Integrations/KernSmith/KernSmith.MonoGameGum/KernSmith.MonoGameGum.csproj" />
     <Project Path="../../MonoGameGum/MonoGameGum.csproj" />
     <Project Path="../../Runtimes/GumShapes/MonoGameGumShapes.csproj" />
   </Folder>
@@ -10,8 +12,10 @@
     <Project Path="../../Themes/Gum.Themes.DarkPro.MonoGame/Gum.Themes.DarkPro.MonoGame.csproj" />
     <Project Path="../../Themes/Gum.Themes.Editor.MonoGame/Gum.Themes.Editor.MonoGame.csproj" />
     <Project Path="../../Themes/Gum.Themes.ForestGlade.MonoGame/Gum.Themes.ForestGlade.MonoGame.csproj" />
+    <Project Path="../../Themes/Gum.Themes.Hazard.MonoGame/Gum.Themes.Hazard.MonoGame.csproj" />
     <Project Path="../../Themes/Gum.Themes.Meadow.MonoGame/Gum.Themes.Meadow.MonoGame.csproj" />
     <Project Path="../../Themes/Gum.Themes.Neon.MonoGame/Gum.Themes.Neon.MonoGame.csproj" />
     <Project Path="../../Themes/Gum.Themes.Retro95.MonoGame/Gum.Themes.Retro95.MonoGame.csproj" />
+    <Project Path="../../Themes/Gum.Themes.Template.MonoGame/Gum.Themes.Template.MonoGame.csproj" />
   </Folder>
 </Solution>

--- a/Samples/RaylibGumThemesShowcase/RaylibGumThemesShowcase.slnx
+++ b/Samples/RaylibGumThemesShowcase/RaylibGumThemesShowcase.slnx
@@ -3,9 +3,18 @@
   <Folder Name="/Libraries/">
     <Project Path="../../GumCommon/GumCommon.csproj" />
     <Project Path="../../Runtimes/RaylibGum/RaylibGum.csproj" />
+    <Project Path="../../Integrations/KernSmith/KernSmith.GumCommon/KernSmith.GumCommon.csproj" />
     <Project Path="../../Integrations/KernSmith/KernSmith.RaylibGum/KernSmith.RaylibGum.csproj" />
   </Folder>
   <Folder Name="/Themes/">
+    <Project Path="../../Themes/Gum.Themes.Bubblegum.Raylib/Gum.Themes.Bubblegum.Raylib.csproj" />
+    <Project Path="../../Themes/Gum.Themes.DarkPro.Raylib/Gum.Themes.DarkPro.Raylib.csproj" />
     <Project Path="../../Themes/Gum.Themes.Editor.Raylib/Gum.Themes.Editor.Raylib.csproj" />
+    <Project Path="../../Themes/Gum.Themes.ForestGlade.Raylib/Gum.Themes.ForestGlade.Raylib.csproj" />
+    <Project Path="../../Themes/Gum.Themes.Hazard.Raylib/Gum.Themes.Hazard.Raylib.csproj" />
+    <Project Path="../../Themes/Gum.Themes.Meadow.Raylib/Gum.Themes.Meadow.Raylib.csproj" />
+    <Project Path="../../Themes/Gum.Themes.Neon.Raylib/Gum.Themes.Neon.Raylib.csproj" />
+    <Project Path="../../Themes/Gum.Themes.Retro95.Raylib/Gum.Themes.Retro95.Raylib.csproj" />
+    <Project Path="../../Themes/Gum.Themes.Template.Raylib/Gum.Themes.Template.Raylib.csproj" />
   </Folder>
 </Solution>

--- a/Tests/RaylibGum.Tests/Content/ContentLoaderTests.cs
+++ b/Tests/RaylibGum.Tests/Content/ContentLoaderTests.cs
@@ -1,4 +1,5 @@
 using Raylib_cs;
+using RenderingLibrary;
 using RenderingLibrary.Content;
 using Shouldly;
 using System;
@@ -57,6 +58,45 @@ public class ContentLoaderTests : BaseTestClass
             Font font = LoaderManager.Self.ContentLoader.LoadContent<Font>(fntPath);
 
             font.GlyphCount.ShouldBeGreaterThan(0);
+        }
+        finally
+        {
+            LoaderManager.Self.CacheTextures = savedCacheTextures;
+            FileManager.CustomGetStreamFromFile = savedHook;
+        }
+    }
+
+    // The line-metrics registry (which lets a raylib Text recover the .fnt's lineHeight/base, since
+    // Raylib_cs.Font has no field for them) is keyed by atlas texture id. Loading a .fnt registers an
+    // entry; that entry MUST be dropped when the font is unloaded, because raylib can later hand the
+    // freed texture id to a different font — a stale entry would then give that font the wrong line
+    // height. This pins the load-registers / dispose-removes lifecycle.
+    [Fact]
+    public void ManagedFont_Dispose_ShouldRemoveRegisteredLineMetrics()
+    {
+        string fixtureDirectory = Path.Combine(AppContext.BaseDirectory, "Content", "FontCache");
+        string fntPath = Path.Combine(fixtureDirectory, "Font18Arial.fnt");
+
+        bool savedCacheTextures = LoaderManager.Self.CacheTextures;
+        Func<string, Stream>? savedHook = FileManager.CustomGetStreamFromFile;
+        try
+        {
+            // No caching: we own the only ManagedFont for this load, so disposing it is the sole
+            // UnloadFont (no cached copy to double-free) and the registry entry's lifetime is ours.
+            LoaderManager.Self.CacheTextures = false;
+            FileManager.CustomGetStreamFromFile = null;
+
+            Font font = LoaderManager.Self.ContentLoader.LoadContent<Font>(fntPath);
+            uint textureId = font.Texture.Id;
+
+            // Loaded: Font18Arial.fnt's lineHeight/base are registered against the atlas texture id.
+            RaylibFontMetricsRegistry.TryGet(textureId, out _).ShouldBeTrue();
+
+            ManagedFont managedFont = new ManagedFont(font);
+            managedFont.Dispose();
+
+            // Unloaded: the entry is gone, so a reused texture id cannot return stale metrics.
+            RaylibFontMetricsRegistry.TryGet(textureId, out _).ShouldBeFalse();
         }
         finally
         {

--- a/Tests/RaylibGum.Tests/Runtimes/TextRuntimeTests.cs
+++ b/Tests/RaylibGum.Tests/Runtimes/TextRuntimeTests.cs
@@ -437,6 +437,109 @@ public class TextRuntimeTests : BaseTestClass
 
     #endregion
 
+    #region LineHeight
+
+    // The raylib Font struct (Raylib_cs.Font) carries only BaseSize — it has no line-height or
+    // baseline field — so when a Gum .fnt bitmap font is loaded, its common.lineHeight is discarded
+    // and the Text renderable reconstructed line height as MeasureTextEx("M") ≈ BaseSize. That drops
+    // the descender region MonoGame's BitmapFont.LineHeightInPixels keeps. For the gold fixture,
+    // Font18Arial.fnt declares lineHeight=21 (base=17, size=18), so raylib reported 18 where MonoGame
+    // reports 21. Because a Text — and therefore a ListBoxItem sized RelativeToChildren — measures to
+    // its line height, raylib list items came out ~3px shorter, removing the gap below the text that
+    // MonoGame shows.
+    [Fact]
+    public void LineHeightInPixels_ShouldMatchFntLineHeight_IncludingDescenderRegion()
+    {
+        WithFont18Arial(() =>
+        {
+            TextRuntime text = new();
+            text.SetProperty("Font", "Arial");
+            text.SetProperty("FontSize", 18);
+            text.Text = "List item 1";
+
+            Gum.Renderables.Text renderable = (Gum.Renderables.Text)text.RenderableComponent;
+
+            renderable.LineHeightInPixels.ShouldBe(21);
+        });
+    }
+
+    // The descender region (lineHeight - base = 21 - 17 = 4 for Font18Arial) was hardcoded to 2 on the
+    // raylib renderable. DescenderHeight feeds text baseline anchoring in GraphicalUiElement, so it
+    // must come from the loaded font, matching the MonoGame BitmapFont (DescenderHeight = lineHeight -
+    // base) rather than a constant.
+    [Fact]
+    public void DescenderHeight_ShouldMatchFntLineHeightMinusBase()
+    {
+        WithFont18Arial(() =>
+        {
+            TextRuntime text = new();
+            text.SetProperty("Font", "Arial");
+            text.SetProperty("FontSize", 18);
+            text.Text = "List item 1";
+
+            Gum.Renderables.Text renderable = (Gum.Renderables.Text)text.RenderableComponent;
+
+            renderable.DescenderHeight.ShouldBe(4);
+        });
+    }
+
+    // The user-facing symptom: a ListBoxItem is sized RelativeToChildren to the Text inside it, so the
+    // item height tracks the Text's reported height. A single-line Text must report its font's full
+    // line height (21), not BaseSize (18) — otherwise raylib list items are 3px shorter than MonoGame
+    // and lose the gap below the text.
+    [Fact]
+    public void GetAbsoluteHeight_ForSingleLineRelativeToChildren_ShouldMatchFntLineHeight()
+    {
+        WithFont18Arial(() =>
+        {
+            TextRuntime text = new();
+            text.HeightUnits = Gum.DataTypes.DimensionUnitType.RelativeToChildren;
+            text.Height = 0;
+            text.SetProperty("Font", "Arial");
+            text.SetProperty("FontSize", 18);
+            text.Text = "List item 1";
+
+            text.GetAbsoluteHeight().ShouldBe(21);
+        });
+    }
+
+    // Serves the gold Font18Arial fixture (.fnt + page) purely in memory, keyed by file name, so the
+    // (Arial, 18) font-cache file resolves regardless of disk layout, then restores all mutated global
+    // state. Mirrors the in-memory hook setup in Font_SetViaDirectProperties.
+    private static void WithFont18Arial(Action body)
+    {
+        string fixtureDirectory = Path.Combine(AppContext.BaseDirectory, "Content", "FontCache");
+        Dictionary<string, byte[]> inMemoryFiles = new(StringComparer.OrdinalIgnoreCase)
+        {
+            { "Font18Arial.fnt", File.ReadAllBytes(Path.Combine(fixtureDirectory, "Font18Arial.fnt")) },
+            { "Font18Arial_0.png", File.ReadAllBytes(Path.Combine(fixtureDirectory, "Font18Arial_0.png")) },
+        };
+
+        bool savedCacheTextures = LoaderManager.Self.CacheTextures;
+        string savedRelativeDirectory = FileManager.RelativeDirectory;
+        Func<string, Stream>? savedHook = FileManager.CustomGetStreamFromFile;
+        try
+        {
+            LoaderManager.Self.CacheTextures = false;
+            FileManager.RelativeDirectory = Path.Combine(Path.GetTempPath(),
+                "GumRaylibLineHeightTest_" + Guid.NewGuid().ToString("N")).Replace('\\', '/') + "/";
+            FileManager.CustomGetStreamFromFile = incomingPath =>
+                inMemoryFiles.TryGetValue(Path.GetFileName(incomingPath), out byte[]? bytes)
+                    ? new MemoryStream(bytes)
+                    : null!;
+
+            body();
+        }
+        finally
+        {
+            LoaderManager.Self.CacheTextures = savedCacheTextures;
+            FileManager.RelativeDirectory = savedRelativeDirectory;
+            FileManager.CustomGetStreamFromFile = savedHook;
+        }
+    }
+
+    #endregion
+
     #region MaxNumberOfLines
 
     [Fact]


### PR DESCRIPTION
## What

Fixes raylib text rendering vertically off vs MonoGame: list-item text (and other `RelativeToChildren`-sized text containers) came out shorter on raylib, losing the gap below the text that MonoGame shows.

## Root cause

`Raylib_cs.Font` carries only `BaseSize` — it has no field for a bitmap font's `lineHeight`/`base`. When a Gum `.fnt` was loaded, `ContentLoader.BuildFont` parsed `common lineHeight`/`base` but **discarded** them, keeping only `size`. The `Text` renderable then reconstructed line height as `MeasureTextEx("M") ≈ BaseSize`, which excludes the descender region that MonoGame's `BitmapFont.LineHeightInPixels` keeps.

For the gold `Font18Arial` fixture: `lineHeight=21`, `base=17`, `size=18` — so raylib reported **18** where MonoGame reports **21**. A `ListBoxItem` sized `RelativeToChildren` tracks its child `Text`'s height, so raylib items were ~3px shorter.

## Fix

- New `RaylibFontMetricsRegistry` maps atlas **texture id → (lineHeight, base)** — texture id is the one font identity that survives the `Font` struct copy through caching/reassignment.
- Populated in `ContentLoader.BuildFont` (the choke point for both the in-memory hook path **and** KernSmith, which routes through `BuildFontFromFntText` → `BuildFont`) and in the native on-disk `LoadFont` (re-parses the `.fnt`).
- Removed in `ManagedFont.Dispose` (raylib may reuse a freed texture id).
- `Text.UpdateLineHeightInPixels` uses the registry for line height; `DescenderHeight` now returns `lineHeight - base` (was a hardcoded `2`, which feeds text baseline anchoring in `GraphicalUiElement`). Fonts with no `.fnt` (raylib's built-in default, TTF via `LoadFontEx`) fall back to the prior `MeasureTextEx` behavior.

## Tests

New `RaylibGum.Tests/Runtimes/TextRuntimeTests` cases (all green): `LineHeightInPixels == 21`, `DescenderHeight == 4`, and the user-facing `GetAbsoluteHeight() == 21` for a single-line `RelativeToChildren` text (the ListBoxItem-sizing path). Net result: raylib now uses byte-identical `.fnt` metrics to MonoGame.

## Notes

- Bundles a small prior commit on this branch (`Add missing projects to themes showcase solutions` — 2 `.slnx` files).
- `RaylibFontMetricsRegistry` is a static cache (mirrors the existing `LoaderManager.Self` in this layer) rather than an injected service, since its consumers are a static method and a struct-holding renderable with no DI container in the raylib runtime.
- Follow-up: `SokolGum`'s `Text` has the same latent hardcoded-descender issue (out of scope here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
