### PR TITLE
Fix raylib RectangleRuntime legacy Color to drive the rendered stroke (theme outline parity)

### DIFF
--- a/MonoGameGum/GueDeriving/RectangleRuntime.cs
+++ b/MonoGameGum/GueDeriving/RectangleRuntime.cs
@@ -683,6 +683,14 @@ public class RectangleRuntime : GraphicalUiElement
             NotifyPropertyChanged();
         }
     }
+#elif RAYLIB
+    // Alias the stroke alpha (see the Color property below for the full rationale).
+    [Obsolete("Use FillColor or StrokeColor instead. See migration guide for issue #2768.")]
+    public int Alpha
+    {
+        get => _strokeColor.A;
+        set => StrokeColor = new Color(_strokeColor.R, _strokeColor.G, _strokeColor.B, (byte)value);
+    }
 #elif !SKIA
     [Obsolete("Use FillColor or StrokeColor instead. See migration guide for issue #2768.")]
     public int Alpha
@@ -708,6 +716,14 @@ public class RectangleRuntime : GraphicalUiElement
             _stroke.Color = new Color((byte)value, current.G, current.B, current.A);
             NotifyPropertyChanged();
         }
+    }
+#elif RAYLIB
+    // Alias the stroke red channel (see the Color property below for the full rationale).
+    [Obsolete("Use FillColor or StrokeColor instead. See migration guide for issue #2768.")]
+    public int Red
+    {
+        get => _strokeColor.R;
+        set => StrokeColor = new Color((byte)value, _strokeColor.G, _strokeColor.B, _strokeColor.A);
     }
 #elif !SKIA
     [Obsolete("Use FillColor or StrokeColor instead. See migration guide for issue #2768.")]
@@ -735,6 +751,14 @@ public class RectangleRuntime : GraphicalUiElement
             NotifyPropertyChanged();
         }
     }
+#elif RAYLIB
+    // Alias the stroke green channel (see the Color property below for the full rationale).
+    [Obsolete("Use FillColor or StrokeColor instead. See migration guide for issue #2768.")]
+    public int Green
+    {
+        get => _strokeColor.G;
+        set => StrokeColor = new Color(_strokeColor.R, (byte)value, _strokeColor.B, _strokeColor.A);
+    }
 #elif !SKIA
     [Obsolete("Use FillColor or StrokeColor instead. See migration guide for issue #2768.")]
     public int Green
@@ -760,6 +784,14 @@ public class RectangleRuntime : GraphicalUiElement
             _stroke.Color = new Color(current.R, current.G, (byte)value, current.A);
             NotifyPropertyChanged();
         }
+    }
+#elif RAYLIB
+    // Alias the stroke blue channel (see the Color property below for the full rationale).
+    [Obsolete("Use FillColor or StrokeColor instead. See migration guide for issue #2768.")]
+    public int Blue
+    {
+        get => _strokeColor.B;
+        set => StrokeColor = new Color(_strokeColor.R, _strokeColor.G, (byte)value, _strokeColor.A);
     }
 #elif !SKIA
     [Obsolete("Use FillColor or StrokeColor instead. See migration guide for issue #2768.")]
@@ -792,7 +824,20 @@ public class RectangleRuntime : GraphicalUiElement
             _stroke.Color = value;
             NotifyPropertyChanged();
         }
-#elif RAYLIB || SOKOL
+#elif RAYLIB
+        // The legacy single-color surface aliases the stroke color, matching XNALIKE where Color and
+        // StrokeColor are the same _stroke.Color field. raylib's renderer draws StrokeColor ?? Color
+        // and the ctor seeds StrokeColor opaque-white, so writing the renderable's de-prioritized
+        // Color slot here (as it did before) was silently shadowed — legacy `Color = x` outlines
+        // (every Editor-theme outline) rendered white. Route through StrokeColor so the legacy write
+        // reaches the rendered slot.
+        [Obsolete("Use FillColor or StrokeColor instead. See migration guide for issue #2768.")]
+        get => _strokeColor;
+        [Obsolete("Use FillColor or StrokeColor instead. See migration guide for issue #2768.")]
+        set => StrokeColor = value;
+#elif SOKOL
+        // SOKOL's renderable has no separate StrokeColor slot, so its legacy Color IS the rendered
+        // color — keep writing it directly.
         [Obsolete("Use FillColor or StrokeColor instead. See migration guide for issue #2768.")]
         get => ContainedLineRectangle.Color;
         [Obsolete("Use FillColor or StrokeColor instead. See migration guide for issue #2768.")]

--- a/Tests/RaylibGum.Tests/Runtimes/RectangleRuntimeTests.cs
+++ b/Tests/RaylibGum.Tests/Runtimes/RectangleRuntimeTests.cs
@@ -93,6 +93,40 @@ public class RectangleRuntimeTests : BaseTestClass
         sut.Color.ShouldBe(expected);
     }
 
+    // Editor-theme outlines (ListBox/TextBox/Button/CheckBox/ComboBox) set their RectangleRuntime
+    // outline via the legacy Color property, e.g. `rectangle.Color = new Color(60, 60, 60)`. The
+    // raylib renderer draws `StrokeColor ?? Color`, and the ctor seeds StrokeColor opaque-white, so
+    // a legacy Color write landed in the de-prioritized Color slot and the outline rendered white
+    // instead of the themed gray (MonoGame was correct because there Color and StrokeColor are the
+    // same field). Legacy Color must drive the rendered stroke slot. Round-trip alone (above) did not
+    // catch this — it read back the same dead slot it wrote.
+    [Fact]
+    public void Color_Setter_ShouldDriveRenderedStrokeColor_NotBeShadowedBySeededStrokeColor()
+    {
+        RectangleRuntime sut = new();
+        sut.Color = new Color(60, 60, 60, 255);
+
+        LineRectangle inner = (LineRectangle)sut.RenderableComponent!;
+        // The renderer draws StrokeColor ?? Color, so the legacy write must reach the rendered slot.
+        Color renderedStroke = inner.StrokeColor ?? inner.Color;
+        renderedStroke.R.ShouldBe((byte)60);
+        renderedStroke.G.ShouldBe((byte)60);
+        renderedStroke.B.ShouldBe((byte)60);
+    }
+
+    // Same shadowing bug as Color, via the per-channel legacy member: a legacy channel write must
+    // reach the rendered stroke slot, not the de-prioritized Color slot.
+    [Fact]
+    public void Red_Setter_ShouldDriveRenderedStrokeColor_NotBeShadowedBySeededStrokeColor()
+    {
+        RectangleRuntime sut = new();
+        sut.Red = 60;
+
+        LineRectangle inner = (LineRectangle)sut.RenderableComponent!;
+        Color renderedStroke = inner.StrokeColor ?? inner.Color;
+        renderedStroke.R.ShouldBe((byte)60);
+    }
+
     [Fact]
     public void Green_ShouldRoundTrip()
     {


### PR DESCRIPTION
## What

Fixes raylib rendering every Editor-theme outline **white** instead of the themed gray (ListBox, TextBox, Button, CheckBox, ComboBox) — MonoGame rendered them correctly. The themes are supposed to look identical across backends.

## Root cause

Each Editor-theme outline is a `RectangleRuntime` whose color is set via the **legacy `Color`** property, e.g. `rectangle.Color = new Color(60, 60, 60)` (opaque gray — not transparent, so this is not a premultiply issue).

- **MonoGame:** `Color` and `StrokeColor` are the *same* underlying field (`_stroke.Color`), so the write reaches the rendered stroke. ✓
- **raylib:** the renderable has two separate color slots and the renderer draws `StrokeColor ?? Color`. The `RectangleRuntime` constructor seeds `StrokeColor = white` (non-null, for the "FillColor-only cells still get an outline" feature, #2757). So the legacy `Color = gray` write landed in the de-prioritized `Color` slot and the seeded white `StrokeColor` won. ✗

This silently broke the renderable's documented promise that the legacy `Color` surface "keeps working unchanged."

## Fix

raylib's legacy `Color`/`Red`/`Green`/`Blue`/`Alpha` now **alias `StrokeColor`** — matching XNALIKE where they're all the same field — instead of writing the dead `Color` slot. SOKOL, whose renderable has no separate `StrokeColor` slot, keeps the existing path.

This fixes every consumer at once (themes and user code using `.Color`) rather than rewriting five theme files, and restores the legacy shim's cross-backend contract.

## Tests

`Tests/RaylibGum.Tests/Runtimes/RectangleRuntimeTests` gains two cases pinning the **rendered** stroke slot (`StrokeColor ?? Color`) for the `Color` and per-channel setters. They fail red (`was 255`, the seeded white) before the fix and pass after. The pre-existing round-trip tests missed this because they read back the same dead slot they wrote.

Verified: MonoGame builds (the file is shared across backends; edits are `#elif RAYLIB`/`#elif SOKOL` only). No new test failures.

## Note

The themes use the obsolete `Color` property at all is a minor separate smell — the modern API is `StrokeColor`. This fix makes `Color` correct again; migrating the themes is reasonable future cleanup, not bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
