### PR TITLE
Modernize obsolete RectangleRuntime single-color API in Editor theme + samples

### DIFF
--- a/Samples/KniGumInCode/KniGumInCodeCommon/KniGumInCodeGame.cs
+++ b/Samples/KniGumInCode/KniGumInCodeCommon/KniGumInCodeGame.cs
@@ -222,7 +222,8 @@ public class KniGumInCodeGame : Game
 
         polygon.Width = size;
         polygon.Height = size;
-        polygon.IsDotted = true;
+        polygon.StrokeDashLength = 2f;
+        polygon.StrokeGapLength = 2f;
         polygon.SetPoints(new System.Numerics.Vector2[]
         {
             new System.Numerics.Vector2(0, 0),

--- a/Samples/KniGumInCode/KniGumInCodeCommon/KniGumInCodeGame.cs
+++ b/Samples/KniGumInCode/KniGumInCodeCommon/KniGumInCodeGame.cs
@@ -183,7 +183,7 @@ public class KniGumInCodeGame : Game
         lineRectangle.Y = 10;
         lineRectangle.Width = 120;
         lineRectangle.Height = 24;
-        lineRectangle.Color = Color.Pink;
+        lineRectangle.StrokeColor = Color.Pink;
         container.Children.Add(lineRectangle);
 
 

--- a/Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/MixedScreen.cs
+++ b/Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/MixedScreen.cs
@@ -107,7 +107,8 @@ internal class MixedScreen : FrameworkElement
         polygon.Color = Color.Red;
 
         // width/heights are used for layout
-        polygon.IsDotted = true;
+        polygon.StrokeDashLength = 2f;
+        polygon.StrokeGapLength = 2f;
         polygon.SetPoints(new System.Numerics.Vector2[]
         {
             new System.Numerics.Vector2(30, 0),

--- a/Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/MixedScreen.cs
+++ b/Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/MixedScreen.cs
@@ -36,8 +36,8 @@ internal class MixedScreen : FrameworkElement
         lineRectangle.Y = 10;
         lineRectangle.Width = 120;
         lineRectangle.Height = 24;
-        lineRectangle.LineWidth = 5;
-        lineRectangle.Color = Color.Purple;
+        lineRectangle.StrokeWidth = 5;
+        lineRectangle.StrokeColor = Color.Purple;
         container.Children.Add(lineRectangle);
 
         AddText(container, "This is a sprite:");

--- a/Samples/raylib/Screens/RawVisualsScreen.cs
+++ b/Samples/raylib/Screens/RawVisualsScreen.cs
@@ -98,15 +98,17 @@ internal class RawVisualsScreen : FrameworkElement
         var rotatedLineRect = new RectangleRuntime();
         rotatedLineRect.Width = 80;
         rotatedLineRect.Height = 80;
-        rotatedLineRect.IsDotted = true;
-        rotatedLineRect.Color = new Color(80, 160, 200, 255);
-        rotatedLineRect.LineWidth = 1f;
+        rotatedLineRect.StrokeDashLength = 2f;
+        rotatedLineRect.StrokeGapLength = 2f;
+        rotatedLineRect.StrokeColor = new Color(80, 160, 200, 255);
+        rotatedLineRect.StrokeWidth = 1f;
         rotatedLineRect.Rotation = -20;
         row.AddChild(rotatedLineRect);
 
         var polygon = new PolygonRuntime();
         polygon.Color = new Color(80, 160, 200, 255);
-        polygon.IsDotted = true;
+        polygon.StrokeDashLength = 2f;
+        polygon.StrokeGapLength = 2f;
         polygon.SetPoints(new Vector2[]
         {
             new Vector2(0, 0),
@@ -121,7 +123,8 @@ internal class RawVisualsScreen : FrameworkElement
 
         var rotatedPolygon = new PolygonRuntime();
         rotatedPolygon.Color = new Color(80, 160, 200, 255);
-        rotatedPolygon.IsDotted = true;
+        rotatedPolygon.StrokeDashLength = 2f;
+        rotatedPolygon.StrokeGapLength = 2f;
         rotatedPolygon.SetPoints(new Vector2[]
         {
             new Vector2(0, 0),

--- a/Samples/raylib/Screens/RawVisualsScreen.cs
+++ b/Samples/raylib/Screens/RawVisualsScreen.cs
@@ -89,9 +89,10 @@ internal class RawVisualsScreen : FrameworkElement
         var lineRectangle = new RectangleRuntime();
         lineRectangle.Width = 80;
         lineRectangle.Height = 80;
-        lineRectangle.IsDotted = true;
-        lineRectangle.Color = new Color(80, 160, 200, 255);
-        lineRectangle.LineWidth = 3f;
+        lineRectangle.StrokeDashLength = 2f;
+        lineRectangle.StrokeGapLength = 2f;
+        lineRectangle.StrokeColor = new Color(80, 160, 200, 255);
+        lineRectangle.StrokeWidth = 3f;
         row.AddChild(lineRectangle);
 
         var rotatedLineRect = new RectangleRuntime();

--- a/Themes/Gum.Themes.Editor.MonoGame/ButtonVisual.cs
+++ b/Themes/Gum.Themes.Editor.MonoGame/ButtonVisual.cs
@@ -35,13 +35,13 @@ public class ButtonVisual : BaseButtonVisual
         this.States.Highlighted.Apply += () =>
         {
             rectangle.Visible = true;
-            rectangle.Color = new Color(150, 150, 150);
+            rectangle.StrokeColor = new Color(150, 150, 150);
         };
         this.States.Pushed.Apply += () =>
         {
             rectangle.Visible = true;
 
-            rectangle.Color = new Color(255, 255, 255);
+            rectangle.StrokeColor = new Color(255, 255, 255);
         };
         this.States.Disabled.Apply += () =>
         {

--- a/Themes/Gum.Themes.Editor.MonoGame/CheckBoxVisual.cs
+++ b/Themes/Gum.Themes.Editor.MonoGame/CheckBoxVisual.cs
@@ -30,23 +30,23 @@ public class CheckBoxVisual : BaseCheckBoxVisual
         this.States.HighlightedOn.Apply += () =>
         {
             rectangle.Visible = true;
-            rectangle.Color = new Color(150, 150, 150);
+            rectangle.StrokeColor = new Color(150, 150, 150);
         };
         this.States.HighlightedOff.Apply += () =>
         {
             rectangle.Visible = true;
-            rectangle.Color = new Color(150, 150, 150);
+            rectangle.StrokeColor = new Color(150, 150, 150);
         };
 
         this.States.PushedOn.Apply += () =>
         {
             rectangle.Visible = true;
-            rectangle.Color = new Color(255, 255, 255);
+            rectangle.StrokeColor = new Color(255, 255, 255);
         };
         this.States.PushedOff.Apply += () =>
         {
             rectangle.Visible = true;
-            rectangle.Color = new Color(255, 255, 255);
+            rectangle.StrokeColor = new Color(255, 255, 255);
         };
 
         this.States.DisabledOn.Apply += () =>

--- a/Themes/Gum.Themes.Editor.MonoGame/ComboBoxVisual.cs
+++ b/Themes/Gum.Themes.Editor.MonoGame/ComboBoxVisual.cs
@@ -29,12 +29,12 @@ public class ComboBoxVisual : BaseComboBoxVisual
         this.States.Highlighted.Apply += () =>
         {
             rectangle.Visible = true;
-            rectangle.Color = new Color(150, 150, 150);
+            rectangle.StrokeColor = new Color(150, 150, 150);
         };
         this.States.Pushed.Apply += () =>
         {
             rectangle.Visible = true;
-            rectangle.Color = new Color(255, 255, 255);
+            rectangle.StrokeColor = new Color(255, 255, 255);
         };
         this.States.Disabled.Apply += () =>
         {

--- a/Themes/Gum.Themes.Editor.MonoGame/ListBoxVisual.cs
+++ b/Themes/Gum.Themes.Editor.MonoGame/ListBoxVisual.cs
@@ -17,7 +17,7 @@ public class ListBoxVisual : BaseListBoxVisual
 
         var rectangle = new RectangleRuntime();
         Background.Children.Add(rectangle);
-        rectangle.Color = new Color(60, 60, 60);
+        rectangle.StrokeColor = new Color(60, 60, 60);
         rectangle.Dock(Gum.Wireframe.Dock.Fill);
     }
 }

--- a/Themes/Gum.Themes.Editor.MonoGame/TextBoxVisual.cs
+++ b/Themes/Gum.Themes.Editor.MonoGame/TextBoxVisual.cs
@@ -42,13 +42,13 @@ public class TextBoxVisual : BaseTextBoxVisual
 
         States.Highlighted.Apply += () =>
         {
-            outline.Color = new Color(150, 150, 150);
+            outline.StrokeColor = new Color(150, 150, 150);
             outline.Visible = true;
         };
 
         States.Focused.Apply += () =>
         {
-            outline.Color = new Color(192, 222, 255);
+            outline.StrokeColor = new Color(192, 222, 255);
             outline.Visible = true;
         };
     }


### PR DESCRIPTION
## What

Reference code — themes that users copy, and the in-code samples — shouldn't model the **deprecated** `RectangleRuntime`/`PolygonRuntime` single-color/legacy stroke surface. This migrates the obsolete *members* to the modern fill/stroke API:

- `Color` → `StrokeColor` (on `RectangleRuntime`; **not** on `PolygonRuntime`, whose `Color` is current)
- `LineWidth` → `StrokeWidth`
- `IsDotted = true` → `StrokeDashLength` + `StrokeGapLength`

## Scope

- **Editor theme** (`ButtonVisual`, `CheckBoxVisual`, `ComboBoxVisual`, `ListBoxVisual`, `TextBoxVisual`): `.Color` → `.StrokeColor`. Editor was the **only** theme still using the obsolete shape-color member — every other theme already colors shapes via `FillColor`/`StrokeColor` and only uses `.Color` on `TextRuntime` (not obsolete). Verified by classifying every `.Color =` across all themes by target type.
- **Three in-code samples** (`Samples/raylib/RawVisualsScreen`, `KniGumInCode`, `MonoGameGumInCode/MixedScreen`): every obsolete shape **member** removed — across both the `RectangleRuntime`s (including a second one, `rotatedLineRect`) and the `PolygonRuntime.IsDotted` usages. `PolygonRuntime.Color` is left as-is because it is **not** obsolete (distinct from the obsolete `RectangleRuntime.Color`).

## Behavior

Behavior-preserving on every backend (`StrokeColor` routes to the same stroke the obsolete `Color` did; the dotted/dash migration matches the legacy fixed-pattern dotted texture on MG/KNI and engages a real perimeter-walk dash on raylib). It also removes the CS0618 obsolete-API warnings these files emitted. As a side benefit, since `StrokeColor` always worked on raylib, this independently corrects the Editor theme's white outlines there — complementary to the runtime fix in the RectangleRuntime-color-parity PR, which fixes the legacy `Color` member for *all* consumers.

## Verified

Built the Editor theme on **MonoGame + Raylib** and the **raylib + MonoGame + KNI** samples — all succeed. Grep confirms zero obsolete shape *members* remain in the touched files.

## Intentionally excluded

Obsolete *types* — `ColoredCircleRuntime` (GumShapesGallery) and `ColoredRectangleRuntime` (HyTale's generated `BarPercent`, and a couple of `KniGumInCode` instances) — are a larger migration touching generated code and a `.gucx` project file. Left as a separate follow-up. Also untouched: `TextRuntime.Color` / `PolygonRuntime.Color` (not obsolete), generated `.cs`, docs, core dispatch, and tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
