### PR TITLE
Runtime snapshot: synthesize Components from Forms-control instances (#3073)

### DIFF
--- a/Gum/DataTypes/ElementSaveExtensionMethods.cs
+++ b/Gum/DataTypes/ElementSaveExtensionMethods.cs
@@ -43,11 +43,21 @@ namespace Gum.DataTypes
 
     public static class ElementSaveExtensionMethods
     {
-        public static bool Initialize(this ElementSave elementSave, StateSave? defaultState, bool tolerateMissingDefaultStates = false)
+        /// <summary>
+        /// Initializes an element after load: ensures a default state, back-fills variables from
+        /// <paramref name="defaultState"/>, fixes state-variable types, and initializes instances. Returns
+        /// whether anything was changed.
+        /// </summary>
+        /// <param name="modifications">
+        /// Optional. When provided, the names of any variables back-filled into the element's default state
+        /// are appended, so a caller can report which variables made a freshly-loaded element dirty.
+        /// </param>
+        public static bool Initialize(this ElementSave elementSave, StateSave? defaultState, bool tolerateMissingDefaultStates = false,
+            ICollection<string>? modifications = null)
         {
             bool wasModified = false;
 
-            if (AddAndModifyVariablesAccordingToDefault(elementSave, defaultState))
+            if (AddAndModifyVariablesAccordingToDefault(elementSave, defaultState, modifications))
             {
                 wasModified = true;
             }
@@ -104,7 +114,8 @@ namespace Gum.DataTypes
             }
         }
 
-        private static bool AddAndModifyVariablesAccordingToDefault(ElementSave elementSave, StateSave? defaultState)
+        private static bool AddAndModifyVariablesAccordingToDefault(ElementSave elementSave, StateSave? defaultState,
+            ICollection<string>? modifications = null)
         {
             bool wasModified = false;
             // Use States and not AllStates because we want to make sure we
@@ -114,6 +125,7 @@ namespace Gum.DataTypes
                 StateSave stateToAdd = defaultState.Clone();
                 elementSave.States.Add(stateToAdd);
                 wasModified = true;
+                modifications?.Add("(created default state)");
             }
             else if (elementSave.States.Count != 0 && defaultState != null)
             {
@@ -144,6 +156,7 @@ namespace Gum.DataTypes
                     if (existingVariable == null)
                     {
                         wasModified = true;
+                        modifications?.Add(variableSave.Name);
                         elementSave.DefaultState.Variables.Add(variableSave.Clone());
                     }
                     else
@@ -185,6 +198,7 @@ namespace Gum.DataTypes
                     if (existingList == null)
                     {
                         wasModified = true;
+                        modifications?.Add(variableList.Name);
                         // this type doesn't have this list yet, so let's add it
                         elementSave.DefaultState.VariableLists.Add(variableList.Clone());
                     }

--- a/Gum/DataTypes/GumProjectSaveExtensionMethods.cs
+++ b/Gum/DataTypes/GumProjectSaveExtensionMethods.cs
@@ -15,7 +15,18 @@ namespace Gum.DataTypes
         /// <param name="gumProjectSave">The GumProjectSave</param>
         /// <param name="tolerateMissingDefaultStates">Whether to tolerate missing default states. If false, 
         /// exceptions are thrown if there is a missing standard state. If true, missing states will not throw an exception.</param>
-        public static bool Initialize(this GumProjectSave gumProjectSave, bool tolerateMissingDefaultStates = false)
+        /// <summary>
+        /// Initializes a loaded project's elements (adding any missing default-state variables, parenting
+        /// states, applying the Version&lt;1 SetsValue fixup, etc.), returning whether anything changed so
+        /// the caller can decide to re-save.
+        /// </summary>
+        /// <param name="modifications">
+        /// Optional. When provided, each element this call modifies appends a short reason (e.g.
+        /// "Standard:Container", "Component:Button") so a caller can report <em>why</em> a freshly-loaded
+        /// project was considered dirty. The bool return is unchanged; pass null (default) to ignore.
+        /// </param>
+        public static bool Initialize(this GumProjectSave gumProjectSave, bool tolerateMissingDefaultStates = false,
+            ICollection<string>? modifications = null)
         {
             bool wasModified = false;
 
@@ -32,7 +43,11 @@ namespace Gum.DataTypes
                     StateSave? stateSave = StandardElementsManager.Self.GetDefaultStateFor(standardElementSave.Name);
                     // this will result in extra variables being
                     // added
-                    wasModified = standardElementSave.Initialize(stateSave) || wasModified;
+                    if (standardElementSave.Initialize(stateSave))
+                    {
+                        wasModified = true;
+                        modifications?.Add($"Standard:{standardElementSave.Name}");
+                    }
 
                     if(stateSave != null)
                     {
@@ -61,7 +76,11 @@ namespace Gum.DataTypes
             foreach (ScreenSave screenSave in gumProjectSave.Screens)
             {
                 var stateSave = StandardElementsManager.Self.GetDefaultStateFor("Screen");
-                wasModified = screenSave.Initialize(stateSave, tolerateMissingDefaultStates) || wasModified;
+                if (screenSave.Initialize(stateSave, tolerateMissingDefaultStates))
+                {
+                    wasModified = true;
+                    modifications?.Add($"Screen:{screenSave.Name}");
+                }
             }
 
 
@@ -99,11 +118,13 @@ namespace Gum.DataTypes
                 if (componentSave.Initialize(new StateSave { Name = "Default" }))
                 {
                     wasModified = true;
+                    modifications?.Add($"Component:{componentSave.Name} (default-state init)");
                 }
 
                 if (componentSave.Initialize(StandardElementsManager.Self.GetDefaultStateFor("Component")))
                 {
                     wasModified = true;
+                    modifications?.Add($"Component:{componentSave.Name} (Component-base init)");
                 }
             }
 
@@ -113,6 +134,7 @@ namespace Gum.DataTypes
                 if (behavior.Initialize())
                 {
                     wasModified = true;
+                    modifications?.Add($"Behavior:{behavior.Name}");
                 }
             }
 
@@ -155,6 +177,7 @@ namespace Gum.DataTypes
                 }
                 gumProjectSave.Version = 1;
                 wasModified = true;
+                modifications?.Add("VersionUpgradeBelow1");
             }
 
             return wasModified;

--- a/Gum/DataTypes/GumProjectSaveExtensionMethods.cs
+++ b/Gum/DataTypes/GumProjectSaveExtensionMethods.cs
@@ -115,16 +115,18 @@ namespace Gum.DataTypes
                 //    defaultStateSave = ses.DefaultState;
                 //}
 
-                if (componentSave.Initialize(new StateSave { Name = "Default" }))
+                List<string>? defaultStateAdded = modifications != null ? new List<string>() : null;
+                if (componentSave.Initialize(new StateSave { Name = "Default" }, modifications: defaultStateAdded))
                 {
                     wasModified = true;
-                    modifications?.Add($"Component:{componentSave.Name} (default-state init)");
+                    modifications?.Add($"Component:{componentSave.Name} (default-state init{FormatAddedVariables(defaultStateAdded)})");
                 }
 
-                if (componentSave.Initialize(StandardElementsManager.Self.GetDefaultStateFor("Component")))
+                List<string>? componentBaseAdded = modifications != null ? new List<string>() : null;
+                if (componentSave.Initialize(StandardElementsManager.Self.GetDefaultStateFor("Component"), modifications: componentBaseAdded))
                 {
                     wasModified = true;
-                    modifications?.Add($"Component:{componentSave.Name} (Component-base init)");
+                    modifications?.Add($"Component:{componentSave.Name} (Component-base init{FormatAddedVariables(componentBaseAdded)})");
                 }
             }
 
@@ -181,6 +183,17 @@ namespace Gum.DataTypes
             }
 
             return wasModified;
+        }
+
+        // Formats the variable names a component-Initialize pass back-filled, for the load-modification
+        // diagnostics (empty when nothing was added or when detail collection was not requested).
+        private static string FormatAddedVariables(List<string>? added)
+        {
+            if (added == null || added.Count == 0)
+            {
+                return "";
+            }
+            return "; added: " + string.Join(", ", added);
         }
 
         public static void SortElementAndBehaviors(this GumProjectSave gumProjectSave)

--- a/Gum/Managers/ProjectManager.cs
+++ b/Gum/Managers/ProjectManager.cs
@@ -243,44 +243,61 @@ public class ProjectManager : IProjectManager
 
         if (_gumProjectSave != null)
         {
-            bool wasModified = false;
+            // Each load-time repair pass that actually changes something records its name here. If the list
+            // is non-empty the project is re-saved (forcing all contained elements to disk). Carrying the
+            // names -- rather than a single bool -- makes it visible in the Output tab which pass dirtied a
+            // freshly-loaded project, which is otherwise painful to track down.
+            List<string> modifications = new List<string>();
             ObjectFinder.Self.EnableCache();
             {
 
-                wasModified = _gumProjectSave.Initialize(
+                // Initialize is the heaviest pass; have it report which specific elements it changed so a
+                // re-save's cause is identifiable rather than a bare "Initialize".
+                List<string> initializeModifications = new List<string>();
+                if (_gumProjectSave.Initialize(
                     // tolerate this so we don't immediately crash the tool
-                    tolerateMissingDefaultStates:true);
+                    tolerateMissingDefaultStates: true, initializeModifications))
+                {
+                    foreach (string reason in initializeModifications)
+                    {
+                        modifications.Add($"Initialize/{reason}");
+                    }
+                    if (initializeModifications.Count == 0)
+                    {
+                        modifications.Add("Initialize");
+                    }
+                }
                 _standardElementsManagerGumTool.FixCustomTypeConverters(_gumProjectSave);
                 RecreateMissingStandardElements();
 
                 if (RecreateMissingDefinedByBaseObjects())
                 {
-                    wasModified = true;
+                    modifications.Add(nameof(RecreateMissingDefinedByBaseObjects));
                 }
 
                 if (_gumProjectSave.AddNewStandardElementTypes())
                 {
-                    wasModified = true;
+                    modifications.Add("AddNewStandardElementTypes");
                 }
                 if (FixSlashesInNames(_gumProjectSave))
                 {
-                    wasModified = true;
+                    modifications.Add(nameof(FixSlashesInNames));
                 }
                 if (RemoveSpacesInVariables(_gumProjectSave))
                 {
-                    wasModified = true;
+                    modifications.Add(nameof(RemoveSpacesInVariables));
                 }
                 if (_gumProjectSave.MigrateCircleRadiusToWidthHeight())
                 {
-                    wasModified = true;
+                    modifications.Add("MigrateCircleRadiusToWidthHeight");
                 }
                 if (_gumProjectSave.StripCircleRectangleGradientColor1())
                 {
-                    wasModified = true;
+                    modifications.Add("StripCircleRectangleGradientColor1");
                 }
                 if (RemoveDuplicateVariables(_gumProjectSave))
                 {
-                    wasModified = true;
+                    modifications.Add(nameof(RemoveDuplicateVariables));
                 }
 
                 _gumProjectSave.FixStandardVariables();
@@ -297,7 +314,7 @@ public class ProjectManager : IProjectManager
 
             if (FixRecursiveAssignments(_gumProjectSave))
             {
-                wasModified = true;
+                modifications.Add(nameof(FixRecursiveAssignments));
             }
             PluginManager.Self.ProjectLoad(_gumProjectSave);
 
@@ -312,8 +329,10 @@ public class ProjectManager : IProjectManager
 
             _standardElementsManagerGumTool.RefreshStateVariablesThroughPlugins();
 
-            if (wasModified)
+            if (modifications.Count > 0)
             {
+                _guiCommands.PrintOutput(
+                    $"Re-saving \"{fileName}\" on load because it was modified by: {string.Join(", ", modifications)}");
                 SaveProject(forceSaveContainedElements: true);
             }
         }

--- a/GumCommon/Wireframe/RuntimeSnapshotSerializer.cs
+++ b/GumCommon/Wireframe/RuntimeSnapshotSerializer.cs
@@ -402,10 +402,15 @@ public class RuntimeSnapshotSerializer : IRuntimeSnapshotSerializer
 
     private ComponentEntry BuildComponentEntry(Type controlType, GraphicalUiElement pristine, bool shake)
     {
+        // The component derives from the baseline root's own standard type when it resolves -- e.g. a Label
+        // whose visual root is a Text (DefaultLabelRuntime : TextRuntime) becomes a Text-based component so
+        // its text/font/color are captured. InteractiveGue-rooted controls (Button, Panel, ScrollViewer)
+        // resolve to null and fall back to Container.
+        string componentBaseType = GetStandardTypeName(pristine) ?? ComponentBaseType;
         ComponentSave component = new ComponentSave
         {
             Name = MakeUniqueComponentName(controlType.Name),
-            BaseType = ComponentBaseType,
+            BaseType = componentBaseType,
         };
         StateSave componentDefault = new StateSave { Name = "Default" };
         component.States.Add(componentDefault);
@@ -413,9 +418,8 @@ public class RuntimeSnapshotSerializer : IRuntimeSnapshotSerializer
         Dictionary<GraphicalUiElement, string> nodeToInstanceName = new Dictionary<GraphicalUiElement, string>();
 
         // The baseline root maps to the component element itself: its catalog values become element-level
-        // (unqualified) default variables, exactly how a hand-authored component holds its own values. Read
-        // against the component base type so an InteractiveGue-rooted control still emits its root geometry.
-        StateSave rootState = CreateStateForType(pristine, "Default", shake, ComponentBaseType);
+        // (unqualified) default variables, read against that same resolved base type.
+        StateSave rootState = CreateStateForType(pristine, "Default", shake, componentBaseType);
         foreach (VariableSave variable in rootState.Variables)
         {
             componentDefault.Variables.Add(new VariableSave
@@ -470,9 +474,14 @@ public class RuntimeSnapshotSerializer : IRuntimeSnapshotSerializer
     {
         entry.NodeToInstanceName.TryGetValue(pristineNode, out string? componentInstanceName);
 
-        // The control root (no instance-name entry) is read against the component base type to match how it
-        // was emitted in BuildComponentEntry; inner nodes use their own resolved standard type.
-        string? typeName = componentInstanceName == null ? ComponentBaseType : GetStandardTypeName(liveNode);
+        // Match how each node was emitted in BuildComponentEntry: a node uses its own resolved standard
+        // type; the control root (no instance-name entry) falls back to the component base type when it does
+        // not resolve (an InteractiveGue-rooted control).
+        string? typeName = GetStandardTypeName(liveNode);
+        if (typeName == null && componentInstanceName == null)
+        {
+            typeName = ComponentBaseType;
+        }
         if (typeName != null && _defaultStates.TryGetValue(typeName, out StateSave? defaultStateForType))
         {
             foreach (VariableSave defaultVariable in defaultStateForType.Variables)

--- a/GumCommon/Wireframe/RuntimeSnapshotSerializer.cs
+++ b/GumCommon/Wireframe/RuntimeSnapshotSerializer.cs
@@ -39,8 +39,18 @@ public interface IRuntimeSnapshotSerializer
     ScreenSave CreateScreenSave(GraphicalUiElement root, string screenName, bool shake = false);
 
     /// <summary>
+    /// The components synthesized during the most recent <see cref="CreateScreenSave"/> call — one per
+    /// distinct Forms-control type that was collapsed from a flattened subtree into a reusable component
+    /// (e.g. a "Button" component shared by every button instance). Empty when no baseline provider was
+    /// supplied or no Forms-control subtree qualified. A caller assembling the snapshot project must add
+    /// these to <c>GumProjectSave.Components</c> (and their references).
+    /// </summary>
+    IReadOnlyList<ComponentSave> SynthesizedComponents { get; }
+
+    /// <summary>
     /// Returns the distinct, non-empty file paths referenced by "SourceFile" variables in the snapshot
-    /// (e.g. Sprite/NineSlice textures), so a caller can bundle those files alongside the project.
+    /// (e.g. Sprite/NineSlice textures), so a caller can bundle those files alongside the project. Includes
+    /// files referenced by <see cref="SynthesizedComponents"/>, not just the screen.
     /// </summary>
     IEnumerable<string> GetReferencedFiles(ScreenSave screen);
 }
@@ -50,7 +60,19 @@ public class RuntimeSnapshotSerializer : IRuntimeSnapshotSerializer
 {
     private const string RuntimeSuffix = "Runtime";
 
+    // Synthesized Forms-control components are emitted as Container-based components, and their control root
+    // is read against the Container catalog (its visual root may be an InteractiveGue subclass that does not
+    // resolve to a standard type on its own).
+    private const string ComponentBaseType = "Container";
+
     private readonly IReadOnlyDictionary<string, StateSave> _defaultStates;
+    private readonly Func<Type, GraphicalUiElement?>? _formsBaselineProvider;
+
+    // Synthesized components produced by CreateScreenSave (one per Forms-control type), and a per-type
+    // cache so repeated instances of a control share one component. Both reset at the start of every
+    // CreateScreenSave so a reused serializer does not leak state between snapshots.
+    private readonly List<ComponentSave> _synthesizedComponents;
+    private readonly Dictionary<Type, ComponentEntry?> _componentCache;
 
     /// <summary>
     /// Creates a serializer that reads runtime values against the supplied standard-element catalog.
@@ -59,10 +81,24 @@ public class RuntimeSnapshotSerializer : IRuntimeSnapshotSerializer
     /// The standard-element default states keyed by type name — the authority on which variables Gum
     /// understands per type. Typically <c>StandardElementsManager.Self.DefaultStates</c>.
     /// </param>
-    public RuntimeSnapshotSerializer(IReadOnlyDictionary<string, StateSave> defaultStates)
+    /// <param name="formsBaselineProvider">
+    /// Optional. Given a Forms-control type (e.g. <c>typeof(Button)</c>), returns a pristine baseline visual
+    /// for that control — typically <c>FrameworkElement.GetGraphicalUiElementForFrameworkElement</c>, which
+    /// instantiates the registered <c>DefaultFormsTemplates</c> entry. When supplied, Forms-control subtrees
+    /// are collapsed into synthesized components diffed against this baseline; when null, the tree is
+    /// flattened exactly as before (every node becomes a standard-element instance).
+    /// </param>
+    public RuntimeSnapshotSerializer(IReadOnlyDictionary<string, StateSave> defaultStates,
+        Func<Type, GraphicalUiElement?>? formsBaselineProvider = null)
     {
         _defaultStates = defaultStates;
+        _formsBaselineProvider = formsBaselineProvider;
+        _synthesizedComponents = new List<ComponentSave>();
+        _componentCache = new Dictionary<Type, ComponentEntry?>();
     }
+
+    /// <inheritdoc />
+    public IReadOnlyList<ComponentSave> SynthesizedComponents => _synthesizedComponents;
 
     /// <inheritdoc />
     public string? GetStandardTypeName(GraphicalUiElement element)
@@ -87,9 +123,17 @@ public class RuntimeSnapshotSerializer : IRuntimeSnapshotSerializer
     /// <inheritdoc />
     public StateSave CreateStateForNode(GraphicalUiElement element, string stateName, bool shake = false)
     {
+        return CreateStateForType(element, stateName, shake, GetStandardTypeName(element));
+    }
+
+    // Reads an element's values against an explicitly chosen standard type's catalog. CreateStateForNode
+    // uses the element's own resolved type; the component root is read against the component base type
+    // (Container) so a control root that does not itself resolve to a standard (e.g. an InteractiveGue
+    // subclass like DefaultButtonRuntime) still contributes its geometry/visibility.
+    private StateSave CreateStateForType(GraphicalUiElement element, string stateName, bool shake, string? typeName)
+    {
         StateSave state = new StateSave { Name = stateName };
 
-        string? typeName = GetStandardTypeName(element);
         if (typeName != null && _defaultStates.TryGetValue(typeName, out StateSave? defaultState))
         {
             foreach (VariableSave defaultVariable in defaultState.Variables)
@@ -133,16 +177,21 @@ public class RuntimeSnapshotSerializer : IRuntimeSnapshotSerializer
     /// <inheritdoc />
     public ScreenSave CreateScreenSave(GraphicalUiElement root, string screenName, bool shake = false)
     {
+        _synthesizedComponents.Clear();
+        _componentCache.Clear();
+
         ScreenSave screen = new ScreenSave { Name = screenName };
         StateSave defaultState = new StateSave { Name = "Default" };
         screen.States.Add(defaultState);
 
         GraphicalUiElement screenRoot = ResolveScreenRoot(root);
 
+        bool allowComponentization = _formsBaselineProvider != null;
         HashSet<string> usedNames = new HashSet<string>();
         foreach (GraphicalUiElement child in screenRoot.Children)
         {
-            AddInstanceRecursive(child, parentInstanceName: null, screen, defaultState, usedNames, shake);
+            AddInstanceRecursive(child, parentInstanceName: null, screen, defaultState, usedNames, shake,
+                allowComponentization);
         }
 
         return screen;
@@ -187,7 +236,17 @@ public class RuntimeSnapshotSerializer : IRuntimeSnapshotSerializer
     public IEnumerable<string> GetReferencedFiles(ScreenSave screen)
     {
         HashSet<string> files = new HashSet<string>();
-        foreach (StateSave state in screen.States)
+        AddReferencedFiles(screen, files);
+        foreach (ComponentSave component in _synthesizedComponents)
+        {
+            AddReferencedFiles(component, files);
+        }
+        return files;
+    }
+
+    private static void AddReferencedFiles(ElementSave element, HashSet<string> files)
+    {
+        foreach (StateSave state in element.States)
         {
             foreach (VariableSave variable in state.Variables)
             {
@@ -199,7 +258,6 @@ public class RuntimeSnapshotSerializer : IRuntimeSnapshotSerializer
                 }
             }
         }
-        return files;
     }
 
     // "SourceFile" appears instance-qualified in the screen's default state (e.g. "Sprite.SourceFile").
@@ -211,14 +269,31 @@ public class RuntimeSnapshotSerializer : IRuntimeSnapshotSerializer
     }
 
     private void AddInstanceRecursive(GraphicalUiElement element, string? parentInstanceName,
-        ScreenSave screen, StateSave defaultState, HashSet<string> usedNames, bool shake)
+        ElementSave targetElement, StateSave defaultState, HashSet<string> usedNames, bool shake,
+        bool allowComponentization, Dictionary<GraphicalUiElement, string>? nodeToInstanceName = null)
     {
+        // A Forms-control subtree can collapse into a single synthesized-component instance instead of a
+        // flattened soup of standards -- but only when doing so reproduces the live visuals exactly (see
+        // TryComponentize). Disabled while building a component's own internals so a control's baseline is
+        // not itself re-componentized.
+        if (allowComponentization
+            && element is InteractiveGue formsElement
+            && formsElement.FormsControlAsObject != null
+            && TryComponentize(formsElement, parentInstanceName, targetElement, defaultState, usedNames, shake))
+        {
+            return;
+        }
+
         string typeName = GetStandardTypeName(element) ?? "Container";
         string instanceName = GenerateUniqueName(element, typeName, usedNames);
+        if (nodeToInstanceName != null)
+        {
+            nodeToInstanceName[element] = instanceName;
+        }
 
-        screen.Instances.Add(new InstanceSave { Name = instanceName, BaseType = typeName });
+        targetElement.Instances.Add(new InstanceSave { Name = instanceName, BaseType = typeName });
 
-        // The node's catalog values become instance-qualified variables in the screen's default state.
+        // The node's catalog values become instance-qualified variables in the element's default state.
         StateSave nodeState = CreateStateForNode(element, "Default", shake);
         foreach (VariableSave variable in nodeState.Variables)
         {
@@ -232,7 +307,7 @@ public class RuntimeSnapshotSerializer : IRuntimeSnapshotSerializer
             });
         }
 
-        // Non-top-level instances record their parent; top-level instances are children of the screen.
+        // Non-top-level instances record their parent; top-level instances are children of the element.
         if (parentInstanceName != null)
         {
             defaultState.Variables.Add(new VariableSave
@@ -246,8 +321,266 @@ public class RuntimeSnapshotSerializer : IRuntimeSnapshotSerializer
 
         foreach (GraphicalUiElement child in element.Children)
         {
-            AddInstanceRecursive(child, instanceName, screen, defaultState, usedNames, shake);
+            AddInstanceRecursive(child, instanceName, targetElement, defaultState, usedNames, shake,
+                allowComponentization, nodeToInstanceName);
         }
+    }
+
+    // Attempts to emit a Forms-control subtree as a thin instance of a synthesized component plus its
+    // per-instance overrides. Returns false (so the caller flattens instead) when there is no baseline for
+    // the control type, or when the live subtree does not structurally match the baseline -- in which case
+    // componentizing would lose visuals, and the always-correct flattened form is used.
+    private bool TryComponentize(InteractiveGue element, string? parentInstanceName,
+        ElementSave targetElement, StateSave defaultState, HashSet<string> usedNames, bool shake)
+    {
+        Type controlType = element.FormsControlAsObject!.GetType();
+
+        ComponentEntry? entry = GetOrBuildComponentEntry(controlType, shake);
+        if (entry == null)
+        {
+            return false;
+        }
+
+        // Fidelity gate: only componentize when the live subtree aligns 1:1 with the pristine baseline.
+        if (!StructuralMatches(element, entry.PristineRoot))
+        {
+            return false;
+        }
+
+        // The component is only added to the output once it is actually used by an instance, so a baseline
+        // that every instance ends up rejecting never produces an orphan component.
+        if (!entry.Emitted)
+        {
+            _synthesizedComponents.Add(entry.Component);
+            entry.Emitted = true;
+        }
+
+        string instanceName = GenerateUniqueName(element, controlType.Name, usedNames);
+        targetElement.Instances.Add(new InstanceSave { Name = instanceName, BaseType = controlType.Name });
+
+        EmitOverridesRecursive(element, entry.PristineRoot, entry, instanceName, defaultState);
+
+        if (parentInstanceName != null)
+        {
+            defaultState.Variables.Add(new VariableSave
+            {
+                Name = instanceName + ".Parent",
+                Type = "string",
+                Value = parentInstanceName,
+                SetsValue = true,
+            });
+        }
+
+        return true;
+    }
+
+    // Builds (and caches) the component for a control type from its pristine baseline, or caches a miss
+    // (null) when no baseline is available. The build reads the baseline only -- never a live instance --
+    // so the component stays neutral and every instance diffs against the same canonical values.
+    private ComponentEntry? GetOrBuildComponentEntry(Type controlType, bool shake)
+    {
+        if (_componentCache.TryGetValue(controlType, out ComponentEntry? cached))
+        {
+            return cached;
+        }
+
+        GraphicalUiElement? pristine = _formsBaselineProvider?.Invoke(controlType);
+        ComponentEntry? entry = pristine == null ? null : BuildComponentEntry(controlType, pristine, shake);
+        _componentCache[controlType] = entry;
+        return entry;
+    }
+
+    private ComponentEntry BuildComponentEntry(Type controlType, GraphicalUiElement pristine, bool shake)
+    {
+        ComponentSave component = new ComponentSave { Name = controlType.Name, BaseType = ComponentBaseType };
+        StateSave componentDefault = new StateSave { Name = "Default" };
+        component.States.Add(componentDefault);
+
+        Dictionary<GraphicalUiElement, string> nodeToInstanceName = new Dictionary<GraphicalUiElement, string>();
+
+        // The baseline root maps to the component element itself: its catalog values become element-level
+        // (unqualified) default variables, exactly how a hand-authored component holds its own values. Read
+        // against the component base type so an InteractiveGue-rooted control still emits its root geometry.
+        StateSave rootState = CreateStateForType(pristine, "Default", shake, ComponentBaseType);
+        foreach (VariableSave variable in rootState.Variables)
+        {
+            componentDefault.Variables.Add(new VariableSave
+            {
+                Name = variable.Name,
+                Type = variable.Type,
+                Value = variable.Value,
+                SetsValue = true,
+                Category = variable.Category,
+            });
+        }
+
+        // The baseline's descendants become the component's (flat, parent-linked) instances.
+        HashSet<string> usedNames = new HashSet<string>();
+        foreach (GraphicalUiElement child in pristine.Children)
+        {
+            AddInstanceRecursive(child, parentInstanceName: null, component, componentDefault, usedNames,
+                shake, allowComponentization: false, nodeToInstanceName);
+        }
+
+        return new ComponentEntry(component, pristine, componentDefault, nodeToInstanceName);
+    }
+
+    // Walks the live and pristine subtrees in lockstep (StructuralMatches guarantees they align), emitting
+    // each value that differs from the baseline as an instance override. Root deltas map straight to the
+    // component element and become direct instance variables; deltas on inner nodes require a synthesized
+    // exposed variable on the component, since Gum resolves an instance variable only one level deep.
+    private void EmitOverridesRecursive(GraphicalUiElement liveNode, GraphicalUiElement pristineNode,
+        ComponentEntry entry, string instanceName, StateSave screenDefaultState)
+    {
+        entry.NodeToInstanceName.TryGetValue(pristineNode, out string? componentInstanceName);
+
+        // The control root (no instance-name entry) is read against the component base type to match how it
+        // was emitted in BuildComponentEntry; inner nodes use their own resolved standard type.
+        string? typeName = componentInstanceName == null ? ComponentBaseType : GetStandardTypeName(liveNode);
+        if (typeName != null && _defaultStates.TryGetValue(typeName, out StateSave? defaultStateForType))
+        {
+            foreach (VariableSave defaultVariable in defaultStateForType.Variables)
+            {
+                if (!liveNode.TryGetProperty(defaultVariable.Name, out object? liveValue))
+                {
+                    continue;
+                }
+                if (liveValue != null && !IsSaveSafeValue(liveValue))
+                {
+                    continue;
+                }
+
+                bool pristineHas = pristineNode.TryGetProperty(defaultVariable.Name, out object? pristineValue);
+                if (pristineHas && AreValuesEqual(liveValue, pristineValue))
+                {
+                    // Equal to the baseline -> already represented by the component; nothing to override.
+                    continue;
+                }
+
+                string overrideName;
+                if (componentInstanceName == null)
+                {
+                    overrideName = instanceName + "." + defaultVariable.Name;
+                }
+                else
+                {
+                    string internalPath = componentInstanceName + "." + defaultVariable.Name;
+                    string exposedName = EnsureExposed(entry, internalPath, defaultVariable.Type,
+                        pristineHas, pristineValue);
+                    overrideName = instanceName + "." + exposedName;
+                }
+
+                screenDefaultState.Variables.Add(new VariableSave
+                {
+                    Name = overrideName,
+                    Type = defaultVariable.Type,
+                    Value = liveValue,
+                    SetsValue = true,
+                    Category = defaultVariable.Category,
+                });
+            }
+        }
+
+        for (int i = 0; i < liveNode.Children.Count && i < pristineNode.Children.Count; i++)
+        {
+            if (liveNode.Children[i] is GraphicalUiElement liveChild
+                && pristineNode.Children[i] is GraphicalUiElement pristineChild)
+            {
+                EmitOverridesRecursive(liveChild, pristineChild, entry, instanceName, screenDefaultState);
+            }
+        }
+    }
+
+    // Ensures the component exposes the inner variable at <paramref name="internalPath"/> (e.g.
+    // "TextInstance.Text") and returns the exposed name an instance uses to override it. The exposure is
+    // declared once per path and shared by every instance of the control type.
+    private string EnsureExposed(ComponentEntry entry, string internalPath, string type,
+        bool pristineHas, object? pristineValue)
+    {
+        if (entry.ExposedNamesByPath.TryGetValue(internalPath, out string? existing))
+        {
+            return existing;
+        }
+
+        string exposedName = GenerateExposedName(internalPath, entry.UsedExposedNames);
+
+        // The exposure resolves through a component default-state variable for the inner path. It is usually
+        // already present (emitted while building the component); if the shake pruned it (value equal to the
+        // standard default), re-add it carrying the baseline value so the component still renders pristine.
+        VariableSave? componentVariable = FindVariable(entry.DefaultState, internalPath);
+        if (componentVariable == null)
+        {
+            componentVariable = new VariableSave
+            {
+                Name = internalPath,
+                Type = type,
+                Value = pristineHas ? pristineValue : null,
+                SetsValue = pristineHas,
+            };
+            entry.DefaultState.Variables.Add(componentVariable);
+        }
+        componentVariable.ExposedAsName = exposedName;
+
+        entry.ExposedNamesByPath[internalPath] = exposedName;
+        return exposedName;
+    }
+
+    // Exposed names must be a single token (an instance variable resolves only one level deep), so the
+    // dotted inner path is flattened to underscores and de-duplicated within the component.
+    private static string GenerateExposedName(string internalPath, HashSet<string> usedNames)
+    {
+        string baseName = internalPath.Replace('.', '_');
+        string candidate = baseName;
+        int suffix = 1;
+        while (!usedNames.Add(candidate))
+        {
+            candidate = baseName + suffix;
+            suffix++;
+        }
+        return candidate;
+    }
+
+    // The fidelity gate. The live and pristine subtrees match when every node shares the same standard type
+    // and the same child count/order. A mismatch (most commonly runtime-added children a control's template
+    // lacks, such as ListBox items) means componentizing would lose visuals, so the caller flattens instead.
+    private bool StructuralMatches(GraphicalUiElement live, GraphicalUiElement pristine)
+    {
+        if (GetStandardTypeName(live) != GetStandardTypeName(pristine))
+        {
+            return false;
+        }
+        if (live.Children.Count != pristine.Children.Count)
+        {
+            return false;
+        }
+        for (int i = 0; i < live.Children.Count; i++)
+        {
+            if (live.Children[i] is GraphicalUiElement liveChild
+                && pristine.Children[i] is GraphicalUiElement pristineChild)
+            {
+                if (!StructuralMatches(liveChild, pristineChild))
+                {
+                    return false;
+                }
+            }
+            else
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static VariableSave? FindVariable(StateSave state, string name)
+    {
+        foreach (VariableSave variable in state.Variables)
+        {
+            if (variable.Name == name)
+            {
+                return variable;
+            }
+        }
+        return null;
     }
 
     // Equality for the shake. Same boxed type compares directly (covers bool/string/enum/int); numeric
@@ -301,5 +634,31 @@ public class RuntimeSnapshotSerializer : IRuntimeSnapshotSerializer
             return typeName.Substring(0, typeName.Length - RuntimeSuffix.Length);
         }
         return typeName;
+    }
+
+    // The cached state for one synthesized component: the component itself, the pristine baseline tree it was
+    // built from (kept so every instance diffs against the same canonical values), the map from each baseline
+    // node to its instance name within the component (the root maps to no entry -> element-level), and the
+    // bookkeeping for exposed variables synthesized on demand.
+    private class ComponentEntry
+    {
+        public ComponentSave Component { get; }
+        public GraphicalUiElement PristineRoot { get; }
+        public StateSave DefaultState { get; }
+        public Dictionary<GraphicalUiElement, string> NodeToInstanceName { get; }
+        public Dictionary<string, string> ExposedNamesByPath { get; }
+        public HashSet<string> UsedExposedNames { get; }
+        public bool Emitted { get; set; }
+
+        public ComponentEntry(ComponentSave component, GraphicalUiElement pristineRoot, StateSave defaultState,
+            Dictionary<GraphicalUiElement, string> nodeToInstanceName)
+        {
+            Component = component;
+            PristineRoot = pristineRoot;
+            DefaultState = defaultState;
+            NodeToInstanceName = nodeToInstanceName;
+            ExposedNamesByPath = new Dictionary<string, string>();
+            UsedExposedNames = new HashSet<string>();
+        }
     }
 }

--- a/GumCommon/Wireframe/RuntimeSnapshotSerializer.cs
+++ b/GumCommon/Wireframe/RuntimeSnapshotSerializer.cs
@@ -299,7 +299,10 @@ public class RuntimeSnapshotSerializer : IRuntimeSnapshotSerializer
         targetElement.Instances.Add(new InstanceSave { Name = instanceName, BaseType = typeName });
 
         // The node's catalog values become instance-qualified variables in the element's default state.
-        StateSave nodeState = CreateStateForNode(element, "Default", shake);
+        // Read against the resolved BaseType (with the same "Container" fallback used above), not the node's
+        // own GetStandardTypeName -- an InteractiveGue-rooted Forms visual (StackPanel/ScrollViewer/Panel)
+        // resolves to null there, which would emit no geometry and leave the instance at the default size.
+        StateSave nodeState = CreateStateForType(element, "Default", shake, typeName);
         foreach (VariableSave variable in nodeState.Variables)
         {
             defaultState.Variables.Add(new VariableSave

--- a/GumCommon/Wireframe/RuntimeSnapshotSerializer.cs
+++ b/GumCommon/Wireframe/RuntimeSnapshotSerializer.cs
@@ -425,6 +425,28 @@ public class RuntimeSnapshotSerializer : IRuntimeSnapshotSerializer
             });
         }
 
+        // Seed Component-base variables the live visual cannot supply -- notably the "State" selector, which
+        // is save-time metadata with no runtime property to read. An authored component carries these, so
+        // without them the tool back-fills them on load and force-saves the whole project. Sourcing from the
+        // catalog keeps a single source of truth and auto-covers any future Component-base meta-variable.
+        if (_defaultStates.TryGetValue("Component", out StateSave? componentBaseState))
+        {
+            foreach (VariableSave baseVariable in componentBaseState.Variables)
+            {
+                if (FindVariable(componentDefault, baseVariable.Name) == null)
+                {
+                    componentDefault.Variables.Add(new VariableSave
+                    {
+                        Name = baseVariable.Name,
+                        Type = baseVariable.Type,
+                        Value = baseVariable.Value,
+                        SetsValue = baseVariable.SetsValue,
+                        Category = baseVariable.Category,
+                    });
+                }
+            }
+        }
+
         // The baseline's descendants become the component's (flat, parent-linked) instances.
         HashSet<string> usedNames = new HashSet<string>();
         foreach (GraphicalUiElement child in pristine.Children)

--- a/GumCommon/Wireframe/RuntimeSnapshotSerializer.cs
+++ b/GumCommon/Wireframe/RuntimeSnapshotSerializer.cs
@@ -68,11 +68,14 @@ public class RuntimeSnapshotSerializer : IRuntimeSnapshotSerializer
     private readonly IReadOnlyDictionary<string, StateSave> _defaultStates;
     private readonly Func<Type, GraphicalUiElement?>? _formsBaselineProvider;
 
-    // Synthesized components produced by CreateScreenSave (one per Forms-control type), and a per-type
-    // cache so repeated instances of a control share one component. Both reset at the start of every
-    // CreateScreenSave so a reused serializer does not leak state between snapshots.
+    // Synthesized components produced by CreateScreenSave (one per Forms-control type), a per-type cache so
+    // repeated instances of a control share one component, and the set of component names already taken (so
+    // two control types with the same simple name -- e.g. a Button in two different namespaces -- do not
+    // collide on one element name). All reset at the start of every CreateScreenSave so a reused serializer
+    // does not leak state between snapshots.
     private readonly List<ComponentSave> _synthesizedComponents;
     private readonly Dictionary<Type, ComponentEntry?> _componentCache;
+    private readonly HashSet<string> _usedComponentNames;
 
     /// <summary>
     /// Creates a serializer that reads runtime values against the supplied standard-element catalog.
@@ -95,6 +98,7 @@ public class RuntimeSnapshotSerializer : IRuntimeSnapshotSerializer
         _formsBaselineProvider = formsBaselineProvider;
         _synthesizedComponents = new List<ComponentSave>();
         _componentCache = new Dictionary<Type, ComponentEntry?>();
+        _usedComponentNames = new HashSet<string>();
     }
 
     /// <inheritdoc />
@@ -179,6 +183,7 @@ public class RuntimeSnapshotSerializer : IRuntimeSnapshotSerializer
     {
         _synthesizedComponents.Clear();
         _componentCache.Clear();
+        _usedComponentNames.Clear();
 
         ScreenSave screen = new ScreenSave { Name = screenName };
         StateSave defaultState = new StateSave { Name = "Default" };
@@ -355,8 +360,10 @@ public class RuntimeSnapshotSerializer : IRuntimeSnapshotSerializer
             entry.Emitted = true;
         }
 
+        // BaseType uses the component's (possibly de-collided) name, not the raw type name, so the instance
+        // resolves to the component even when two control types share a simple name.
         string instanceName = GenerateUniqueName(element, controlType.Name, usedNames);
-        targetElement.Instances.Add(new InstanceSave { Name = instanceName, BaseType = controlType.Name });
+        targetElement.Instances.Add(new InstanceSave { Name = instanceName, BaseType = entry.Component.Name });
 
         EmitOverridesRecursive(element, entry.PristineRoot, entry, instanceName, defaultState);
 
@@ -392,7 +399,11 @@ public class RuntimeSnapshotSerializer : IRuntimeSnapshotSerializer
 
     private ComponentEntry BuildComponentEntry(Type controlType, GraphicalUiElement pristine, bool shake)
     {
-        ComponentSave component = new ComponentSave { Name = controlType.Name, BaseType = ComponentBaseType };
+        ComponentSave component = new ComponentSave
+        {
+            Name = MakeUniqueComponentName(controlType.Name),
+            BaseType = ComponentBaseType,
+        };
         StateSave componentDefault = new StateSave { Name = "Default" };
         component.States.Add(componentDefault);
 
@@ -523,6 +534,20 @@ public class RuntimeSnapshotSerializer : IRuntimeSnapshotSerializer
 
         entry.ExposedNamesByPath[internalPath] = exposedName;
         return exposedName;
+    }
+
+    // Component names must be unique within the snapshot. Two distinct control types can share a simple type
+    // name (e.g. a Button in two namespaces), so the second is de-collided with a numeric suffix.
+    private string MakeUniqueComponentName(string typeName)
+    {
+        string candidate = typeName;
+        int suffix = 1;
+        while (!_usedComponentNames.Add(candidate))
+        {
+            candidate = typeName + suffix;
+            suffix++;
+        }
+        return candidate;
     }
 
     // Exposed names must be a single token (an instance variable resolves only one level deep), so the

--- a/MonoGameGum.Tests/Wireframe/RuntimeSnapshotSerializerProjectTests.cs
+++ b/MonoGameGum.Tests/Wireframe/RuntimeSnapshotSerializerProjectTests.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Gum.DataTypes;
 using Gum.DataTypes.Variables;
+using Gum.Forms.Controls;
 using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
@@ -289,6 +290,58 @@ public class RuntimeSnapshotSerializerProjectTests : BaseTestClass
             FileManager.RelativeDirectory = originalRelativeDirectory;
             DeleteTempDirectory(contentDirectory);
             DeleteTempDirectory(snapshotDirectory);
+        }
+    }
+
+    [Fact]
+    public void ExportSnapshot_ShouldSynthesizeComponentForFormsButtons()
+    {
+        // End-to-end: two live Forms Buttons should collapse into one shared "Button" component plus two
+        // thin instances, and the project must round-trip through load without errors (a missing base type
+        // for any of the component's inner standards would surface here).
+        string tempDirectory = NewTempDirectory();
+        try
+        {
+            GumService service = new();
+
+            Button okButton = new() { Name = "OkButton" };
+            okButton.Text = "OK";
+            okButton.X = 30; // a root-level geometry delta on an InteractiveGue-rooted control
+            service.Root.AddChild(okButton.Visual);
+
+            Button cancelButton = new() { Name = "CancelButton" };
+            cancelButton.Text = "Cancel";
+            service.Root.AddChild(cancelButton.Visual);
+
+            string gumxPath = Path.Combine(tempDirectory, "Live." + GumProjectSave.ProjectExtension);
+            service.ExportSnapshot(gumxPath);
+
+            GumProjectSave loaded = GumProjectSave.Load(gumxPath, out GumLoadResult loadResult);
+
+            loaded.ShouldNotBeNull();
+            loadResult.ErrorMessage.ShouldBeNullOrEmpty();
+            loadResult.MissingFiles.ShouldBeEmpty();
+
+            // One component shared by both buttons; the inner Text child is not flattened into the screen.
+            loaded.Components.Count(c => c.Name == "Button").ShouldBe(1);
+            ScreenSave loadedScreen = loaded.Screens.First(s => s.Name == "Live");
+            loadedScreen.Instances.Where(i => i.BaseType == "Button").Select(i => i.Name)
+                .ShouldBe(new[] { "OkButton", "CancelButton" }, ignoreOrder: true);
+
+            // Each instance carries its own label via the component's synthesized exposed text variable.
+            StateSave defaultState = loadedScreen.States.First(s => s.Name == "Default");
+            defaultState.Variables.Any(v => v.Name.StartsWith("OkButton.") && (v.Value as string) == "OK")
+                .ShouldBeTrue();
+            defaultState.Variables.Any(v => v.Name.StartsWith("CancelButton.") && (v.Value as string) == "Cancel")
+                .ShouldBeTrue();
+
+            // The control root's geometry survives even though DefaultButtonRuntime is not itself a standard
+            // type -- it is read against the component's Container base type.
+            defaultState.Variables.First(v => v.Name == "OkButton.X").Value.ShouldBe(30f);
+        }
+        finally
+        {
+            DeleteTempDirectory(tempDirectory);
         }
     }
 

--- a/MonoGameGum.Tests/Wireframe/RuntimeSnapshotSerializerTests.cs
+++ b/MonoGameGum.Tests/Wireframe/RuntimeSnapshotSerializerTests.cs
@@ -307,6 +307,31 @@ public class RuntimeSnapshotSerializerTests : BaseTestClass
     }
 
     [Fact]
+    public void CreateScreenSave_WithBaselineProvider_ShouldDeriveComponentFromRootStandardType()
+    {
+        // A Label-like Forms control whose visual root is a Text (DefaultLabelRuntime : TextRuntime). The
+        // synthesized component must derive from Text and capture the Text value -- not be forced to
+        // Container, which drops the text entirely so nothing renders.
+        ContainerRuntime root = new();
+        ContainerRuntime formsScreen = new() { Name = "MainMenu" };
+        formsScreen.FormsControlAsObject = new object();
+
+        TextRuntime liveLabel = new() { Name = "TextInstance" };
+        liveLabel.FormsControlAsObject = new FakeLabel();
+        liveLabel.Text = "Score: 0";
+        formsScreen.AddChild(liveLabel);
+        root.AddChild(formsScreen);
+
+        RuntimeSnapshotSerializer serializer =
+            new(StandardElementsManager.Self.DefaultStates, FakeLabelBaseline);
+        serializer.CreateScreenSave(root, "Snapshot", shake: true);
+
+        ComponentSave component = serializer.SynthesizedComponents.First(c => c.Name == "FakeLabel");
+        component.BaseType.ShouldBe("Text");
+        component.States.First(s => s.Name == "Default").Variables.ShouldContain(v => v.Name == "Text");
+    }
+
+    [Fact]
     public void CreateScreenSave_WithBaselineProvider_ShouldSynthesizeComponentForFormsControl()
     {
         ContainerRuntime root = new();
@@ -556,6 +581,23 @@ public class RuntimeSnapshotSerializerTests : BaseTestClass
     // Stand-in for a Forms control type (e.g. Button). Its type name becomes the synthesized component name.
     private class FakeButton
     {
+    }
+
+    // Stand-in for a Label-like Forms control whose visual root is a Text (like DefaultLabelRuntime).
+    private class FakeLabel
+    {
+    }
+
+    // A pristine FakeLabel template: a bare Text whose root carries the label text (no children).
+    private static GraphicalUiElement? FakeLabelBaseline(Type type)
+    {
+        if (type != typeof(FakeLabel))
+        {
+            return null;
+        }
+        TextRuntime label = new();
+        label.Text = "Label";
+        return label;
     }
 
     // Two control types that share the simple name "CollidingControl" but live in different "namespaces"

--- a/MonoGameGum.Tests/Wireframe/RuntimeSnapshotSerializerTests.cs
+++ b/MonoGameGum.Tests/Wireframe/RuntimeSnapshotSerializerTests.cs
@@ -404,6 +404,44 @@ public class RuntimeSnapshotSerializerTests : BaseTestClass
     }
 
     [Fact]
+    public void CreateScreenSave_WithBaselineProvider_ShouldUniquelyNameComponentsForSameSimpleNamedControlTypes()
+    {
+        // Two distinct control types can share a simple type name (e.g. a Button defined in two namespaces).
+        // Each must become its own uniquely-named component rather than colliding on a single element name.
+        ContainerRuntime root = new();
+        ContainerRuntime formsScreen = new() { Name = "MainMenu" };
+        formsScreen.FormsControlAsObject = new object();
+
+        ContainerRuntime widgetA = new() { Name = "WidgetA" };
+        widgetA.FormsControlAsObject = new NamespaceA.CollidingControl();
+        widgetA.AddChild(new TextRuntime { Name = "TextInstance", Text = "A" });
+
+        ContainerRuntime widgetB = new() { Name = "WidgetB" };
+        widgetB.FormsControlAsObject = new NamespaceB.CollidingControl();
+        widgetB.AddChild(new TextRuntime { Name = "TextInstance", Text = "B" });
+
+        formsScreen.AddChild(widgetA);
+        formsScreen.AddChild(widgetB);
+        root.AddChild(formsScreen);
+
+        RuntimeSnapshotSerializer serializer =
+            new(StandardElementsManager.Self.DefaultStates, CollidingControlBaseline);
+        ScreenSave screen = serializer.CreateScreenSave(root, "Snapshot", shake: true);
+
+        // Both types share the simple name "CollidingControl", but the two components get distinct names.
+        serializer.SynthesizedComponents.Count.ShouldBe(2);
+        serializer.SynthesizedComponents.Select(c => c.Name).Distinct().Count().ShouldBe(2);
+        serializer.SynthesizedComponents.ShouldAllBe(c => c.Name.StartsWith("CollidingControl"));
+
+        // Every component instance resolves to a real synthesized component by BaseType (no dangling base).
+        string[] componentNames = serializer.SynthesizedComponents.Select(c => c.Name).ToArray();
+        foreach (InstanceSave instance in screen.Instances)
+        {
+            componentNames.ShouldContain(instance.BaseType);
+        }
+    }
+
+    [Fact]
     public void CreateScreenSave_WithoutBaselineProvider_ShouldNotSynthesizeComponents()
     {
         ContainerRuntime root = new();
@@ -448,6 +486,18 @@ public class RuntimeSnapshotSerializerTests : BaseTestClass
     private static RuntimeSnapshotSerializer CreateSerializerWithButtonBaseline() =>
         new RuntimeSnapshotSerializer(StandardElementsManager.Self.DefaultStates, FakeButtonBaseline);
 
+    // Baseline for either same-simple-named colliding control type: a container with a single Text child.
+    private static GraphicalUiElement? CollidingControlBaseline(Type type)
+    {
+        if (type != typeof(NamespaceA.CollidingControl) && type != typeof(NamespaceB.CollidingControl))
+        {
+            return null;
+        }
+        ContainerRuntime control = new();
+        control.AddChild(new TextRuntime { Name = "TextInstance" });
+        return control;
+    }
+
     // Stands in for a game-authored screen/component type (e.g. "MainMenu : ContainerRuntime"). Its own
     // name is not a standard-element name, so the serializer treats it as custom rather than standard.
     private class CustomScreenRuntime : ContainerRuntime
@@ -457,5 +507,21 @@ public class RuntimeSnapshotSerializerTests : BaseTestClass
     // Stand-in for a Forms control type (e.g. Button). Its type name becomes the synthesized component name.
     private class FakeButton
     {
+    }
+
+    // Two control types that share the simple name "CollidingControl" but live in different "namespaces"
+    // (distinct declaring types), used to prove synthesized component names are de-collided.
+    private static class NamespaceA
+    {
+        internal class CollidingControl
+        {
+        }
+    }
+
+    private static class NamespaceB
+    {
+        internal class CollidingControl
+        {
+        }
     }
 }

--- a/MonoGameGum.Tests/Wireframe/RuntimeSnapshotSerializerTests.cs
+++ b/MonoGameGum.Tests/Wireframe/RuntimeSnapshotSerializerTests.cs
@@ -287,6 +287,26 @@ public class RuntimeSnapshotSerializerTests : BaseTestClass
     }
 
     [Fact]
+    public void CreateScreenSave_WithBaselineProvider_ShouldSeedComponentBaseStateVariable()
+    {
+        ContainerRuntime root = new();
+        ContainerRuntime formsScreen = new() { Name = "MainMenu" };
+        formsScreen.FormsControlAsObject = new object();
+        formsScreen.AddChild(MakeLiveButton("OkButton", "OK"));
+        root.AddChild(formsScreen);
+
+        RuntimeSnapshotSerializer serializer = CreateSerializerWithButtonBaseline();
+        serializer.CreateScreenSave(root, "Snapshot", shake: true);
+
+        // A synthesized component must carry the Component-base "State" selector variable. The live visual
+        // can't supply it (it is save-time metadata, not a runtime property), so without explicit seeding the
+        // tool back-fills it on load and force-saves the whole project.
+        ComponentSave component = serializer.SynthesizedComponents.First(c => c.Name == "FakeButton");
+        StateSave defaultState = component.States.First(s => s.Name == "Default");
+        defaultState.Variables.ShouldContain(v => v.Name == "State");
+    }
+
+    [Fact]
     public void CreateScreenSave_WithBaselineProvider_ShouldSynthesizeComponentForFormsControl()
     {
         ContainerRuntime root = new();

--- a/MonoGameGum.Tests/Wireframe/RuntimeSnapshotSerializerTests.cs
+++ b/MonoGameGum.Tests/Wireframe/RuntimeSnapshotSerializerTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using Gum.DataTypes;
 using Gum.DataTypes.Variables;
@@ -285,9 +286,176 @@ public class RuntimeSnapshotSerializerTests : BaseTestClass
         serializer.GetStandardTypeName(new GraphicalUiElement()).ShouldBeNull();
     }
 
+    [Fact]
+    public void CreateScreenSave_WithBaselineProvider_ShouldSynthesizeComponentForFormsControl()
+    {
+        ContainerRuntime root = new();
+        ContainerRuntime formsScreen = new() { Name = "MainMenu" };
+        formsScreen.FormsControlAsObject = new object();
+        formsScreen.AddChild(MakeLiveButton("OkButton", "OK"));
+        root.AddChild(formsScreen);
+
+        RuntimeSnapshotSerializer serializer = CreateSerializerWithButtonBaseline();
+        ScreenSave screen = serializer.CreateScreenSave(root, "Snapshot", shake: true);
+
+        // The button collapses to a single component instance, not a flattened soup of standards.
+        serializer.SynthesizedComponents.Select(c => c.Name).ShouldContain("FakeButton");
+        screen.Instances.Count.ShouldBe(1);
+        InstanceSave instance = screen.Instances.Single();
+        instance.Name.ShouldBe("OkButton");
+        instance.BaseType.ShouldBe("FakeButton");
+        // The button's inner Text child is owned by the component, not flattened into the screen.
+        screen.Instances.Any(i => i.Name == "TextInstance").ShouldBeFalse();
+    }
+
+    [Fact]
+    public void CreateScreenSave_WithBaselineProvider_ShouldExposeAndOverrideInternalDelta()
+    {
+        ContainerRuntime root = new();
+        ContainerRuntime formsScreen = new() { Name = "MainMenu" };
+        formsScreen.FormsControlAsObject = new object();
+        formsScreen.AddChild(MakeLiveButton("OkButton", "OK"));
+        root.AddChild(formsScreen);
+
+        RuntimeSnapshotSerializer serializer = CreateSerializerWithButtonBaseline();
+        ScreenSave screen = serializer.CreateScreenSave(root, "Snapshot", shake: true);
+
+        // The component exposes the inner TextInstance.Text so each instance can carry its own label.
+        ComponentSave component = serializer.SynthesizedComponents.First(c => c.Name == "FakeButton");
+        VariableSave exposed = component.States.First(s => s.Name == "Default").Variables
+            .First(v => v.Name == "TextInstance.Text");
+        exposed.ExposedAsName.ShouldNotBeNullOrEmpty();
+
+        // The instance overrides the exposed variable with its own value.
+        StateSave screenDefault = screen.States.First(s => s.Name == "Default");
+        VariableSave overrideVar = screenDefault.Variables.First(v => v.Name == "OkButton." + exposed.ExposedAsName);
+        overrideVar.Value.ShouldBe("OK");
+    }
+
+    [Fact]
+    public void CreateScreenSave_WithBaselineProvider_ShouldDeduplicateComponentAcrossInstances()
+    {
+        ContainerRuntime root = new();
+        ContainerRuntime formsScreen = new() { Name = "MainMenu" };
+        formsScreen.FormsControlAsObject = new object();
+        formsScreen.AddChild(MakeLiveButton("OkButton", "OK"));
+        formsScreen.AddChild(MakeLiveButton("CancelButton", "Cancel"));
+        root.AddChild(formsScreen);
+
+        RuntimeSnapshotSerializer serializer = CreateSerializerWithButtonBaseline();
+        ScreenSave screen = serializer.CreateScreenSave(root, "Snapshot", shake: true);
+
+        // Ten buttons -> one component + N thin instances; here two distinct-text buttons share one component.
+        serializer.SynthesizedComponents.Count(c => c.Name == "FakeButton").ShouldBe(1);
+        screen.Instances.Count.ShouldBe(2);
+        screen.Instances.Select(i => i.BaseType).Distinct().ShouldBe(new[] { "FakeButton" });
+
+        ComponentSave component = serializer.SynthesizedComponents.First(c => c.Name == "FakeButton");
+        string exposedName = component.States.First(s => s.Name == "Default").Variables
+            .First(v => v.Name == "TextInstance.Text").ExposedAsName!;
+        StateSave screenDefault = screen.States.First(s => s.Name == "Default");
+        screenDefault.Variables.First(v => v.Name == "OkButton." + exposedName).Value.ShouldBe("OK");
+        screenDefault.Variables.First(v => v.Name == "CancelButton." + exposedName).Value.ShouldBe("Cancel");
+    }
+
+    [Fact]
+    public void CreateScreenSave_WithBaselineProvider_ShouldEmitRootDeltaAsDirectInstanceVariable()
+    {
+        ContainerRuntime root = new();
+        ContainerRuntime formsScreen = new() { Name = "MainMenu" };
+        formsScreen.FormsControlAsObject = new object();
+        ContainerRuntime liveButton = MakeLiveButton("OkButton", "Button"); // text matches pristine -> no inner delta
+        liveButton.Width = 250; // a root-level delta
+        formsScreen.AddChild(liveButton);
+        root.AddChild(formsScreen);
+
+        RuntimeSnapshotSerializer serializer = CreateSerializerWithButtonBaseline();
+        ScreenSave screen = serializer.CreateScreenSave(root, "Snapshot", shake: true);
+
+        // Root-level deltas map straight to the component element, so they are direct single-dot instance
+        // variables with no exposure indirection.
+        StateSave screenDefault = screen.States.First(s => s.Name == "Default");
+        screenDefault.Variables.First(v => v.Name == "OkButton.Width").Value.ShouldBe(250f);
+        ComponentSave component = serializer.SynthesizedComponents.First(c => c.Name == "FakeButton");
+        component.States.First(s => s.Name == "Default").Variables.Any(v => v.ExposedAsName == "Width").ShouldBeFalse();
+    }
+
+    [Fact]
+    public void CreateScreenSave_WithBaselineProvider_ShouldFallBackToFlatteningWhenStructureDiverges()
+    {
+        ContainerRuntime root = new();
+        ContainerRuntime formsScreen = new() { Name = "MainMenu" };
+        formsScreen.FormsControlAsObject = new object();
+        // The live button has an extra child the pristine baseline lacks (e.g. a runtime-added icon).
+        ContainerRuntime liveButton = MakeLiveButton("OkButton", "OK");
+        liveButton.AddChild(new SpriteRuntime { Name = "ExtraIcon" });
+        formsScreen.AddChild(liveButton);
+        root.AddChild(formsScreen);
+
+        RuntimeSnapshotSerializer serializer = CreateSerializerWithButtonBaseline();
+        ScreenSave screen = serializer.CreateScreenSave(root, "Snapshot", shake: true);
+
+        // The fidelity gate rejects componentization (it would drop the extra child), so the subtree stays
+        // flattened exactly as it is today.
+        serializer.SynthesizedComponents.ShouldBeEmpty();
+        screen.Instances.Any(i => i.Name == "OkButton").ShouldBeTrue();
+        screen.Instances.Any(i => i.Name == "TextInstance").ShouldBeTrue();
+        screen.Instances.Any(i => i.Name == "ExtraIcon").ShouldBeTrue();
+    }
+
+    [Fact]
+    public void CreateScreenSave_WithoutBaselineProvider_ShouldNotSynthesizeComponents()
+    {
+        ContainerRuntime root = new();
+        ContainerRuntime formsScreen = new() { Name = "MainMenu" };
+        formsScreen.FormsControlAsObject = new object();
+        formsScreen.AddChild(MakeLiveButton("OkButton", "OK"));
+        root.AddChild(formsScreen);
+
+        RuntimeSnapshotSerializer serializer = CreateSerializer(); // no baseline provider
+        ScreenSave screen = serializer.CreateScreenSave(root, "Snapshot", shake: true);
+
+        serializer.SynthesizedComponents.ShouldBeEmpty();
+        // Without a baseline there is nothing to diff against, so the button stays flattened.
+        screen.Instances.Any(i => i.Name == "OkButton").ShouldBeTrue();
+        screen.Instances.Any(i => i.Name == "TextInstance").ShouldBeTrue();
+    }
+
+    private static ContainerRuntime MakeLiveButton(string name, string text)
+    {
+        ContainerRuntime button = new() { Name = name };
+        button.FormsControlAsObject = new FakeButton();
+        TextRuntime textInstance = new() { Name = "TextInstance" };
+        textInstance.Text = text;
+        button.AddChild(textInstance);
+        return button;
+    }
+
+    // A pristine FakeButton template: a container holding a single "TextInstance" Text child.
+    private static GraphicalUiElement? FakeButtonBaseline(Type type)
+    {
+        if (type != typeof(FakeButton))
+        {
+            return null;
+        }
+        ContainerRuntime button = new();
+        TextRuntime textInstance = new() { Name = "TextInstance" };
+        textInstance.Text = "Button";
+        button.AddChild(textInstance);
+        return button;
+    }
+
+    private static RuntimeSnapshotSerializer CreateSerializerWithButtonBaseline() =>
+        new RuntimeSnapshotSerializer(StandardElementsManager.Self.DefaultStates, FakeButtonBaseline);
+
     // Stands in for a game-authored screen/component type (e.g. "MainMenu : ContainerRuntime"). Its own
     // name is not a standard-element name, so the serializer treats it as custom rather than standard.
     private class CustomScreenRuntime : ContainerRuntime
+    {
+    }
+
+    // Stand-in for a Forms control type (e.g. Button). Its type name becomes the synthesized component name.
+    private class FakeButton
     {
     }
 }

--- a/MonoGameGum.Tests/Wireframe/RuntimeSnapshotSerializerTests.cs
+++ b/MonoGameGum.Tests/Wireframe/RuntimeSnapshotSerializerTests.cs
@@ -462,6 +462,35 @@ public class RuntimeSnapshotSerializerTests : BaseTestClass
     }
 
     [Fact]
+    public void CreateScreenSave_FlattenedFormsControl_ShouldCaptureGeometryAgainstContainerFallback()
+    {
+        // StackPanel/ScrollViewer/Panel visuals are InteractiveGue-rooted, so GetStandardTypeName is null.
+        // When such a control is flattened (no baseline, or it fails the fidelity gate) it still becomes a
+        // Container instance -- and must capture its geometry against that Container fallback, not emit
+        // nothing and render at the standard default (150x150 at the top-left).
+        ContainerRuntime root = new();
+        ContainerRuntime formsScreen = new() { Name = "MainMenu" };
+        formsScreen.FormsControlAsObject = new object();
+
+        InteractiveGue column = new() { Name = "LeftColumn" };
+        column.FormsControlAsObject = new object();
+        column.Width = 33;
+        column.WidthUnits = Gum.DataTypes.DimensionUnitType.Percentage;
+        formsScreen.AddChild(column);
+        root.AddChild(formsScreen);
+
+        // No baseline for the control type, so it cannot be componentized -> it flattens.
+        RuntimeSnapshotSerializer serializer =
+            new(StandardElementsManager.Self.DefaultStates, _ => null);
+        ScreenSave screen = serializer.CreateScreenSave(root, "Snapshot", shake: true);
+
+        StateSave defaultState = screen.States.First(s => s.Name == "Default");
+        defaultState.Variables.First(v => v.Name == "LeftColumn.Width").Value.ShouldBe(33f);
+        defaultState.Variables.First(v => v.Name == "LeftColumn.WidthUnits").Value
+            .ShouldBe(Gum.DataTypes.DimensionUnitType.Percentage);
+    }
+
+    [Fact]
     public void CreateScreenSave_WithoutBaselineProvider_ShouldNotSynthesizeComponents()
     {
         ContainerRuntime root = new();

--- a/MonoGameGum/GumService.cs
+++ b/MonoGameGum/GumService.cs
@@ -363,8 +363,11 @@ public class GumService : IGumService
 
         string screenName = Path.GetFileNameWithoutExtension(filePath);
 
-        // Non-null here: the guard above initializes the catalog when it was missing.
-        RuntimeSnapshotSerializer serializer = new(StandardElementsManager.Self.DefaultStates!);
+        // Non-null here: the guard above initializes the catalog when it was missing. The baseline provider
+        // lets the serializer collapse Forms-control subtrees (Button, CheckBox, ...) into synthesized
+        // components by diffing each against the control type's pristine default-template visual.
+        RuntimeSnapshotSerializer serializer = new(StandardElementsManager.Self.DefaultStates!,
+            type => FrameworkElement.GetGraphicalUiElementForFrameworkElement(type));
         ScreenSave screen = serializer.CreateScreenSave(Root, screenName, shake);
 
         GumProjectSave project = new();
@@ -390,13 +393,25 @@ public class GumService : IGumService
         project.Screens.Add(screen);
         project.ScreenReferences.Add(new ElementReference { Name = screenName, ElementType = ElementType.Screen });
 
-        EnsureReferencedStandardsExist(project, screen);
+        // Forms-control subtrees collapse into reusable components (one per control type) plus thin instances.
+        foreach (ComponentSave component in serializer.SynthesizedComponents)
+        {
+            project.Components.Add(component);
+            project.ComponentReferences.Add(
+                new ElementReference { Name = component.Name, ElementType = ElementType.Component });
+        }
+
+        EnsureReferencedStandardsExist(project, screen, serializer.SynthesizedComponents);
 
         string? directory = Path.GetDirectoryName(filePath);
         if (!string.IsNullOrEmpty(directory))
         {
             Directory.CreateDirectory(Path.Combine(directory, ElementReference.ScreenSubfolder));
             Directory.CreateDirectory(Path.Combine(directory, ElementReference.StandardSubfolder));
+            if (serializer.SynthesizedComponents.Count > 0)
+            {
+                Directory.CreateDirectory(Path.Combine(directory, ElementReference.ComponentSubfolder));
+            }
         }
 
         project.Save(filePath, saveElements: true);
@@ -410,10 +425,23 @@ public class GumService : IGumService
     // Instances may reference standard types the default seed omits -- notably deprecated ones like
     // ColoredRectangle, which new (v3) projects no longer include but an old/live tree may still contain.
     // Add any such referenced standard so the snapshot's instances don't dangle on a missing base type.
-    private static void EnsureReferencedStandardsExist(GumProjectSave project, ScreenSave screen)
+    // Synthesized components carry instances too, so their base types are checked alongside the screen's.
+    private static void EnsureReferencedStandardsExist(GumProjectSave project, ScreenSave screen,
+        IReadOnlyList<ComponentSave> components)
     {
         HashSet<string> existing = new(project.StandardElements.Select(standard => standard.Name));
-        foreach (InstanceSave instance in screen.Instances)
+
+        EnsureStandardsForInstances(project, screen.Instances, existing);
+        foreach (ComponentSave component in components)
+        {
+            EnsureStandardsForInstances(project, component.Instances, existing);
+        }
+    }
+
+    private static void EnsureStandardsForInstances(GumProjectSave project, IEnumerable<InstanceSave> instances,
+        HashSet<string> existing)
+    {
+        foreach (InstanceSave instance in instances)
         {
             string baseType = instance.BaseType;
             if (string.IsNullOrEmpty(baseType) || existing.Contains(baseType))

--- a/Samples/GameUiSamples/Game1.cs
+++ b/Samples/GameUiSamples/Game1.cs
@@ -76,6 +76,11 @@ public class Game1 : Game
             }
         }
 
+        if(GumService.Default.Keyboard.KeyPushed(Gum.Forms.Input.Keys.F1))
+        {
+            GumService.Default.ExportSnapshot("MyTestSnapshot.gumx");
+        }
+
         base.Update(gameTime);
     }
 

--- a/docs/code/debugging/runtime-snapshot.md
+++ b/docs/code/debugging/runtime-snapshot.md
@@ -40,6 +40,7 @@ You can open the Gum tool and load your exported project - whenever your project
 A snapshot reproduces the running tree as standard-element instances:
 
 * **The visual tree**, flattened into standard elements - `Container`, `Text`, `Sprite`, `NineSlice`, and so on - parented exactly as they are at runtime.
+* **Forms controls** - a control such as `Button` or `CheckBox` is recognized and collapsed into a synthesized component named after the control type, with each control becoming a thin instance of it (ten buttons share one `Button` component). Per-instance differences (the button's text, its position, ...) are kept as overrides so each instance still looks exactly as it did at runtime. Controls whose live structure does not match their default template - notably list-like controls (`ListBox`, `ComboBox`, `Menu`) that fill themselves with items at runtime - stay flattened into standard elements instead, so the snapshot always matches what you saw.
 * **The screen** - your top-level screen maps to the Gum `Screen`. When you add a single screen (such as a Forms screen) to the root, that screen's contents become the screen's instances directly, rather than nesting under an extra wrapper container.
 * **Canvas size** matching your game's current resolution, so the layout in the tool matches what you see at runtime.
 * **Referenced textures** - files referenced by `Sprite` and `NineSlice` source files are copied next to the project, preserving their relative path, so the snapshot opens self-contained.


### PR DESCRIPTION
## What

Follow-up to #3070. A runtime snapshot used to **flatten** Forms-control subtrees (Button, CheckBox, Label, Slider, …) into an anonymous soup of standard elements with no control identity. This PR collapses each Forms-control subtree into a **synthesized Gum `Component`** named after the control type, with a thin instance per control — ten buttons become one `Button` component + ten instances — so the snapshot reads structurally in the tool. Scoped to the **code-only** path (the project-loaded `ElementSave`/`Tag` path is not relied on).

## Componentization (GumCommon / `RuntimeSnapshotSerializer`)

- **Baseline source:** each component is built from the control type's *pristine default-template visual* — `FrameworkElement.GetGraphicalUiElementForFrameworkElement(type)` (the registered `DefaultFormsTemplates` entry), injected as an optional `Func<Type, GraphicalUiElement?>` (default null ⇒ existing flattening), wired in `GumService.ExportSnapshot`.
- **Diff, never read the split:** each live instance diffs against that single canonical baseline (never a sibling), so the shared component stays neutral and each instance carries only its own deltas. Root deltas become direct instance variables; inner-node deltas go through **synthesized exposed variables** (Gum resolves an instance variable only one level deep).
- **Fidelity-gated:** a subtree is componentized only when it aligns 1:1 with the baseline; controls whose live structure diverges (runtime-populated list items — `ListBox`/`ComboBox`/`Menu`) **fall back to flattening**, exactly as before. Purely additive: worst case is today's output, never visually wrong.
- **Component base type from the visual root:** the component derives from its root's resolved standard type — a `Label` (root `Text`, `DefaultLabelRuntime : TextRuntime`) becomes a `Text`-based component so its text/font/color are captured; `InteractiveGue`-rooted controls (Button/Panel/ScrollViewer) fall back to `Container`. (Forcing `Container` produced an empty `Label.gucx` that rendered nothing.)
- **Name de-collision:** two control types sharing a simple name (e.g. a `Button` in two namespaces) get distinct component names instead of colliding on one element name.
- **Component-base completeness:** synthesized components are seeded with the `Component`-base default variables the live visual can't supply (notably the `State` selector — save-time metadata with no runtime property). Without it the tool back-fills `State` on load and force-saves the whole project; seeding it makes the synthesized component match an authored one. `SetsValue=false`, so no visual impact.

## Flatten path (pre-existing #3070 bug, fixed here)

A flattened node got `BaseType = GetStandardTypeName(element) ?? "Container"` but its values were read via a path that re-derived the type with **no `"Container"` fallback**. `InteractiveGue`-rooted Forms visuals (`Panel`/`StackPanel`/`ScrollViewer` all root at a bare `InteractiveGue`) resolve to null there, so **no geometry was emitted** and the instance rendered at the standard default (150×150, top-left) — e.g. the FrbClicker columns lost their 33%/32%/33% widths and X positions. Flattened nodes now read against the same resolved `BaseType`, so geometry is captured.

## Tool-side: load-modification diagnostics (`ProjectManager` / `Initialize`)

While verifying the export, `ProjectManager.LoadProject` was force-saving all contained elements on open with no indication why. The single `wasModified` bool is now a `List<string>` of pass names, logged to the Output tab before the re-save; `GumProjectSave.Initialize` / `ElementSave.Initialize` take an optional `ICollection<string>` fill-parameter (out params can't be optional) reporting the specific element and back-filled variable names. Diagnostics only — control flow unchanged. These are what pinpointed the missing `State` variable above, and remain as a permanent aid.

## Tests

- `RuntimeSnapshotSerializerTests` (unit): synthesize component + thin instance, expose/override inner delta, de-dup across instances, root delta as a direct instance variable, structural-divergence → fallback, no componentization without a provider, same-simple-name de-collision, `Component`-base `State` seeding, flattened `InteractiveGue`-rooted geometry capture, and component base type derived from the visual root (`Text` for Label). Each new behavior was confirmed red-before-green.
- `RuntimeSnapshotSerializerProjectTests` (integration): two real Forms `Button`s export → reload with no load errors, collapse to one `Button` component + two instances, each keeping its own label and root geometry.
- Full `MonoGameGum.Tests` suite green (1729), zero new compiler warnings.

## Docs

`docs/code/debugging/runtime-snapshot.md` updated to describe Forms-control componentization and the flatten fallback.

## Split out (separate issues, not in this PR)

- #3194 — Output window justifies text; make it left-aligned/fixed-width.
- #3196 — NRE in `AvailableContainedTypeConverter.GetStandardValues` on load with a stale selection.
- #3197 — embedded sprite-sheet backgrounds render blank (no `SourceFile`); needs extracting embedded `Texture2D`s to PNG files next to the snapshot.

Closes #3073
Part of #3070.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
