### PR TITLE
Output window: left-align text + monospace font (#3194)

### DIFF
--- a/Gum/Plugins/InternalPlugins/Output/MainOutputPluginView.xaml
+++ b/Gum/Plugins/InternalPlugins/Output/MainOutputPluginView.xaml
@@ -32,6 +32,7 @@
       VerticalAlignment="Stretch"
       VerticalContentAlignment="Top"
       behaviors:TextBoxAutoScroll.AutoScrollToEnd="True"
+      FontFamily="Consolas"
       Style="{DynamicResource Frb.Styles.Textbox.Readonly}"
       TabIndex="0"
       Text="{Binding OutputText, Mode=OneWay}"

--- a/Gum/Themes/Frb.Styles.Variants.xaml
+++ b/Gum/Themes/Frb.Styles.Variants.xaml
@@ -18,6 +18,8 @@
         <Setter Property="IsReadOnly" Value="True" />
         <Setter Property="materialDesign:TextFieldAssist.UnderlineBrush" Value="Transparent" />
         <Setter Property="Background" Value="{DynamicResource Frb.Brushes.Background}" />
+        <!--  Force ragged-left text; the MaterialDesignTextBox base style otherwise justifies wrapped output (see issue #3194).  -->
+        <Setter Property="TextAlignment" Value="Left" />
     </Style>
 
     <Style


### PR DESCRIPTION
## What

Fixes the Gum tool's **Output window** rendering log text **fully justified** (inter-word spaces stretched flush to both margins), which made diagnostic output hard to scan and broke column/space alignment.

## Root cause

There is no `TextAlignment="Justify"` anywhere in Gum source. The Output `TextBox` is `BasedOn` MaterialDesignThemes' `MaterialDesignTextBox` style (from the NuGet package, not in our source), which is what justifies wrapped text. It's only *visible* in the Output window because that TextBox sets `TextWrapping="Wrap"` — the Code window uses `NoWrap` (horizontal scroll), so justification never showed there.

## Fix

- Add an explicit `TextAlignment="Left"` setter to the shared `Frb.Styles.Textbox.Readonly` style (`Gum/Themes/Frb.Styles.Variants.xaml`). Highest-specificity override → forces ragged-right; correct universal default for readonly diagnostic/code text; covers both the Output and Code windows and any future consumer of the style.
- Set `FontFamily="Consolas"` on the Output `TextBox` (`MainOutputPluginView.xaml`) so diagnostic / column-aligned output lines up. This matches the Code window, which already uses Consolas locally.

Font choice is intentionally left on the instance (not baked into a style named "Readonly"), parallel to how the Code window sets its font.

## Testing

Pure WPF XAML/styling change — not unit-testable. Verified `GumFull.sln` builds with 0 errors and no new warnings. Visual behavior to confirm by running the tool: Output window text is now left-aligned with uniform spacing in a monospace font.

Closes #3194

🤖 Generated with [Claude Code](https://claude.com/claude-code)
