### PR TITLE
Document texture filtering (Project Properties + runtime Renderer.TextureFilter)

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -314,6 +314,7 @@
 * [Rendering](code/rendering/README.md)
   * [GumBatch](code/rendering/gumbatch.md)
   * [Rendering Custom Graphics](code/rendering/rendering-custom-graphics.md)
+  * [Texture Filtering](code/rendering/texture-filtering.md)
 * [Ordering, Layers, and Popups](code/ordering-layers-and-popups/README.md)
   * [Object Order](code/ordering-layers-and-popups/object-order.md)
   * [Mixing Gum and 3D](code/ordering-layers-and-popups/mixing-gum-and-3d.md)

--- a/docs/code/rendering/texture-filtering.md
+++ b/docs/code/rendering/texture-filtering.md
@@ -38,4 +38,4 @@ This lets you, for example, keep crisp Point filtering for a pixel-art game worl
 
 ## Relationship to the Tool's Texture Filter Setting
 
-The Gum tool has a **Texture Filter** setting under [Project Properties](../../gum-tool/project-properties.md). That setting controls the **editor preview only** — it is not currently applied by the runtime when a project is loaded. To match the editor at runtime, set `Renderer.TextureFilter` in code as shown above.
+The Gum tool exposes the same Point/Linear choice as a **Texture Filter** project property — see [Project Properties](../../gum-tool/project-properties.md). To apply texture filtering at runtime, set `Renderer.TextureFilter` (or a per-layer override) in code as shown above.

--- a/docs/code/rendering/texture-filtering.md
+++ b/docs/code/rendering/texture-filtering.md
@@ -1,0 +1,41 @@
+# Texture Filtering
+
+## Introduction
+
+Texture filtering controls how Gum samples textures (sprites, NineSlices, and fonts) when they are drawn at a size that differs from their native resolution. When a texture is scaled up or down, the renderer must decide how to map source texels to screen pixels. Gum supports two modes:
+
+* **Point** — nearest-neighbor sampling. Each screen pixel takes the color of the single nearest texel, keeping edges crisp and hard. This is the right choice for pixel-art, where blurring would ruin the intended look. Point is the default.
+* **Linear** — bilinear sampling. Each screen pixel blends the nearest texels, producing a smooth, antialiased result when scaled. This suits high-resolution art and UI that is rendered at many sizes.
+
+Filtering is a **render-state setting** applied globally or per layer. It is not a property of an individual sprite — you cannot make one sprite point-filtered and another linear-filtered within the same layer.
+
+## Setting the Global Filter
+
+`Renderer.TextureFilter` is a global static that controls filtering for everything Gum draws. Set it once at startup:
+
+```csharp
+// Initialize
+RenderingLibrary.Graphics.Renderer.TextureFilter =
+    Microsoft.Xna.Framework.Graphics.TextureFilter.Linear;
+```
+
+`Renderer.TextureFilter` defaults to `Point`, so a game renders with crisp, pixel-art filtering unless you change it.
+
+## Per-Layer Override
+
+A layer can override the global filter through its `IsLinearFilteringEnabled` property, a nullable `bool`:
+
+* `true` — force Linear filtering on this layer.
+* `false` — force Point filtering on this layer.
+* `null` (default) — inherit the global `Renderer.TextureFilter`.
+
+```csharp
+// Initialize
+layer.IsLinearFilteringEnabled = true;
+```
+
+This lets you, for example, keep crisp Point filtering for a pixel-art game world while smoothing a single scaled overlay layer (or the reverse). For more on layers, see [Ordering, Layers, and Popups](../ordering-layers-and-popups/README.md).
+
+## Relationship to the Tool's Texture Filter Setting
+
+The Gum tool has a **Texture Filter** setting under [Project Properties](../../gum-tool/project-properties.md). That setting controls the **editor preview only** — it is not currently applied by the runtime when a project is loaded. To match the editor at runtime, set `Renderer.TextureFilter` in code as shown above.

--- a/docs/gum-tool/project-properties.md
+++ b/docs/gum-tool/project-properties.md
@@ -23,11 +23,9 @@ The Texture Filter property controls how sprites and other textures are sampled 
 * **Point** (default) — nearest-neighbor sampling. Each screen pixel takes the color of the single nearest texel, so edges stay crisp and hard. This is the right choice for pixel-art, where blending would soften the intended look.
 * **Linear** — bilinear sampling. Each screen pixel blends the nearest texels, producing a smoothed, antialiased result when a texture is scaled. This usually looks better for high-resolution art and for UI that is rendered at many different sizes.
 
-You can change Texture Filter at any time in **Project Properties**. The editor preview updates immediately so you can compare the two.
+You can change Texture Filter at any time in **Project Properties**. The preview updates immediately so you can compare the two.
 
-{% hint style="warning" %}
-**Texture Filter currently affects only the editor preview.** The value is saved in the project, but the runtime does not yet apply it automatically — a game that loads the project still renders with **Point** filtering until you set the filter in code. See [Texture Filtering](../code/rendering/texture-filtering.md) for how to enable Linear filtering at runtime.
-{% endhint %}
+To control texture filtering from game code, see [Texture Filtering](../code/rendering/texture-filtering.md).
 
 {% hint style="warning" %}
 Screenshot needed: a side-by-side of the same scaled sprite rendered with **Point** vs **Linear** filtering in the editor.

--- a/docs/gum-tool/project-properties.md
+++ b/docs/gum-tool/project-properties.md
@@ -16,6 +16,23 @@ Canvas Width and Height can be changed through the project properties page.
 
 ![](<../.gitbook/assets/14_15 17 26.gif>)
 
+## Texture Filter
+
+The Texture Filter property controls how sprites and other textures are sampled when they are drawn at a size that differs from their native resolution (scaled up or down). It has two values:
+
+* **Point** (default) — nearest-neighbor sampling. Each screen pixel takes the color of the single nearest texel, so edges stay crisp and hard. This is the right choice for pixel-art, where blending would soften the intended look.
+* **Linear** — bilinear sampling. Each screen pixel blends the nearest texels, producing a smoothed, antialiased result when a texture is scaled. This usually looks better for high-resolution art and for UI that is rendered at many different sizes.
+
+You can change Texture Filter at any time in **Project Properties**. The editor preview updates immediately so you can compare the two.
+
+{% hint style="warning" %}
+**Texture Filter currently affects only the editor preview.** The value is saved in the project, but the runtime does not yet apply it automatically — a game that loads the project still renders with **Point** filtering until you set the filter in code. See [Texture Filtering](../code/rendering/texture-filtering.md) for how to enable Linear filtering at runtime.
+{% endhint %}
+
+{% hint style="warning" %}
+Screenshot needed: a side-by-side of the same scaled sprite rendered with **Point** vs **Linear** filtering in the editor.
+{% endhint %}
+
 ## Localization
 
 Localization can be added to a Gum project through the Localization File file picker. For more information see the [Localization page](localization.md).


### PR DESCRIPTION
## Summary

Documents Gum's **texture filtering** (Point vs Linear), which was previously undocumented.

**Tool side — `docs/gum-tool/project-properties.md`**
- New **Texture Filter** section: `Point` (default, crisp/pixel-art) vs `Linear` (smoothed/antialiased when scaled).
- Cross-links the new code page for controlling filtering from game code.
- Visible placeholder hint for a Point-vs-Linear comparison screenshot.

**Code side — new `docs/code/rendering/texture-filtering.md`**
- Explains Point vs Linear and that filtering is a render-state setting (global / per-layer), **not** a per-sprite property.
- `Renderer.TextureFilter` — global static, type `Microsoft.Xna.Framework.Graphics.TextureFilter`, defaults to `Point`.
- `Layer.IsLinearFilteringEnabled` — nullable per-layer override; `null` falls back to the global.
- Registered in `docs/SUMMARY.md` under **Rendering**.

Cross-links resolve in both directions and all GitBook hint blocks are balanced.

Closes #3198

🤖 Generated with [Claude Code](https://claude.com/claude-code)
