### PR TITLE
Apply project TextureFilter to the runtime on load (xnalikes + raylib) (#3199)

### DIFF
--- a/.claude/skills/gum-service/SKILL.md
+++ b/.claude/skills/gum-service/SKILL.md
@@ -24,6 +24,8 @@ GumService.Default.Uninitialize()
 
 `Initialize` throws if called twice without an intervening `Uninitialize`.
 
+**Only the `gumProjectFile` overload loads a project.** `Initialize(game, gumProjectFile)` loads the `.gumx` and runs the project-load path — which applies project-level settings (standard-element defaults, localization, and the project's `TextureFilter` → `Renderer.TextureFilter`, issue #3199). The `Initialize(game, DefaultVisualsVersion)` / parameterless overloads are **code-only** and never touch that path. So when manually verifying anything that depends on a loaded project, you must pass the `.gumx` path or the behavior under test never runs. The cheapest from-file smoke test is `Initialize(game, "GumProject/GumProject.gumx")` plus a `SpriteRuntime` (`SourceFileName` set, scaled up) added to `Root`.
+
 ## Singleton Pattern
 
 `Default` is lazily initialized via `??=`. `Uninitialize()` sets `_default = null`, so after teardown `GumService.Default` creates a **fresh instance** — any stored reference to the old instance is now orphaned.

--- a/MonoGameGum.Tests/TextureFilterTests.cs
+++ b/MonoGameGum.Tests/TextureFilterTests.cs
@@ -1,0 +1,72 @@
+using Gum.DataTypes;
+using Microsoft.Xna.Framework.Graphics;
+using RenderingLibrary.Graphics;
+using Shouldly;
+using Xunit;
+// Alias to the non-obsolete base type so the test doesn't reference the
+// [Obsolete] MonoGameGum.GumService shim (which unqualified GumService would
+// resolve to via the parent namespace) and trip CS0618.
+using GumService = Gum.GumService;
+
+namespace MonoGameGum.Tests;
+
+/// <summary>
+/// Covers issue #3199: the runtime should apply the project's
+/// <see cref="GumProjectSave.TextureFilter"/> to the global
+/// <see cref="Renderer.TextureFilter"/> when a project is loaded, so the editor's
+/// Texture Filter setting carries over to the game (WYSIWYG).
+/// </summary>
+public class TextureFilterTests : BaseTestClass
+{
+    public override void Dispose()
+    {
+        // Renderer.TextureFilter is global static state; restore the default so a
+        // test that flips it to Linear doesn't leak into unrelated tests.
+        Renderer.TextureFilter = TextureFilter.Point;
+        base.Dispose();
+    }
+
+    [Fact]
+    public void ApplyProjectTextureFilter_ShouldSetLinear_WhenProjectTextureFilterIsLinear()
+    {
+        Renderer.TextureFilter = TextureFilter.Point;
+        GumProjectSave project = new GumProjectSave { TextureFilter = "Linear" };
+
+        GumService.ApplyProjectTextureFilter(project);
+
+        Renderer.TextureFilter.ShouldBe(TextureFilter.Linear);
+    }
+
+    [Fact]
+    public void ApplyProjectTextureFilter_ShouldSetPoint_WhenProjectTextureFilterIsNull()
+    {
+        Renderer.TextureFilter = TextureFilter.Linear;
+        GumProjectSave project = new GumProjectSave { TextureFilter = null };
+
+        GumService.ApplyProjectTextureFilter(project);
+
+        Renderer.TextureFilter.ShouldBe(TextureFilter.Point);
+    }
+
+    [Fact]
+    public void ApplyProjectTextureFilter_ShouldSetPoint_WhenProjectTextureFilterIsPoint()
+    {
+        Renderer.TextureFilter = TextureFilter.Linear;
+        GumProjectSave project = new GumProjectSave { TextureFilter = "Point" };
+
+        GumService.ApplyProjectTextureFilter(project);
+
+        Renderer.TextureFilter.ShouldBe(TextureFilter.Point);
+    }
+
+    [Fact]
+    public void ApplyProjectTextureFilter_ShouldSetPoint_WhenProjectTextureFilterIsUnrecognized()
+    {
+        Renderer.TextureFilter = TextureFilter.Linear;
+        GumProjectSave project = new GumProjectSave { TextureFilter = "SomethingElse" };
+
+        GumService.ApplyProjectTextureFilter(project);
+
+        Renderer.TextureFilter.ShouldBe(TextureFilter.Point);
+    }
+}

--- a/MonoGameGum/GumHotReloadManager.cs
+++ b/MonoGameGum/GumHotReloadManager.cs
@@ -233,6 +233,11 @@ public class GumHotReloadManager : IGumHotReloadManager
         newProject.Initialize();
         ObjectFinder.Self.GumProjectSave = newProject;
 
+        // Re-apply the project's texture filter so editing it in the tool carries over on reload
+        // (issue #3199). On XNALIKE this takes effect on the next Draw; on raylib it affects
+        // textures loaded after this point (already-cached textures keep their prior filter).
+        GumService.ApplyProjectTextureFilter(newProject);
+
         foreach (var element in newProject.AllElements)
         {
             var defaultState = element.DefaultState;

--- a/MonoGameGum/GumService.cs
+++ b/MonoGameGum/GumService.cs
@@ -1117,7 +1117,7 @@ public class GumService : IGumService
     /// </summary>
     /// <remarks>
     /// Precedence: this runs during <c>Initialize</c>, so a per-layer
-    /// <see cref="RenderingLibrary.Layer.IsLinearFilteringEnabled"/> (when non-null) still wins, and
+    /// <c>Layer.IsLinearFilteringEnabled</c> (when non-null) still wins, and
     /// code that assigns <see cref="Renderer.TextureFilter"/> after <c>Initialize</c> returns
     /// overrides the project value. <c>"Linear"</c> is the string the editor stores for linear
     /// filtering; any other value (including null) maps to point filtering.

--- a/MonoGameGum/GumService.cs
+++ b/MonoGameGum/GumService.cs
@@ -1091,6 +1091,7 @@ public class GumService : IGumService
 
             ObjectFinder.Self.GumProjectSave = gumProject;
             gumProject.Initialize();
+            ApplyProjectTextureFilter(gumProject);
             Gum.Forms.FormsUtilities.RegisterFromFileFormRuntimeDefaults();
 
             var absoluteFile = gumProjectFile;
@@ -1107,6 +1108,33 @@ public class GumService : IGumService
         }
 
         return gumProject;
+    }
+
+    /// <summary>
+    /// Applies the project's <see cref="GumProjectSave.TextureFilter"/> setting (configured in the
+    /// editor's Project Properties) to the runtime so sprites render with the same filtering the
+    /// editor previewed (issue #3199). Called automatically during project load.
+    /// </summary>
+    /// <remarks>
+    /// Precedence: this runs during <c>Initialize</c>, so a per-layer
+    /// <see cref="RenderingLibrary.Layer.IsLinearFilteringEnabled"/> (when non-null) still wins, and
+    /// code that assigns <see cref="Renderer.TextureFilter"/> after <c>Initialize</c> returns
+    /// overrides the project value. <c>"Linear"</c> is the string the editor stores for linear
+    /// filtering; any other value (including null) maps to point filtering.
+    /// </remarks>
+    internal static void ApplyProjectTextureFilter(GumProjectSave gumProject)
+    {
+        bool useLinearFiltering = string.Equals(gumProject?.TextureFilter, "Linear", StringComparison.Ordinal);
+
+#if XNALIKE
+        Renderer.TextureFilter = useLinearFiltering ? TextureFilter.Linear : TextureFilter.Point;
+#elif RAYLIB
+        // raylib has no global sampler state; the filter is a per-texture property applied at load
+        // time, so ContentLoader reads this when creating sprite textures (see ContentLoader.cs).
+        ContentLoader.DefaultTextureFilter = useLinearFiltering
+            ? Raylib_cs.TextureFilter.Bilinear
+            : Raylib_cs.TextureFilter.Point;
+#endif
     }
 
     private void ApplyStandardElementDefaults(GumProjectSave gumProject)

--- a/Runtimes/RaylibGum/RenderingLibrary/ContentLoader.cs
+++ b/Runtimes/RaylibGum/RenderingLibrary/ContentLoader.cs
@@ -19,6 +19,15 @@ namespace RenderingLibrary.Content;
 /// </summary>
 public class ContentLoader : IContentLoader
 {
+    /// <summary>
+    /// The texture filter applied to sprite textures as they are loaded. Set from the project's
+    /// <see cref="Gum.DataTypes.GumProjectSave.TextureFilter"/> during <c>GumService.Initialize</c>
+    /// (issue #3199). Unlike the XNA-family backends, raylib has no global sampler state — filtering
+    /// is a per-texture property applied at load time — so the loaded value is read here rather than
+    /// in the Renderer. Fonts intentionally keep point filtering (see <c>Text.cs</c>).
+    /// </summary>
+    public static Raylib_cs.TextureFilter DefaultTextureFilter { get; set; } = Raylib_cs.TextureFilter.Point;
+
     /// <inheritdoc/>
     public T LoadContent<T>(string contentName)
     {
@@ -183,6 +192,9 @@ public class ContentLoader : IContentLoader
         Image image = LoadImageFromMemory(fileType, fileData);
         // LoadTextureFromImage uploads to the GPU; the CPU-side Image is no longer needed after.
         var toReturn = LoadTextureFromImage(image);
+        // Apply the project's texture filter (issue #3199). raylib defaults new textures to point
+        // filtering, so this only changes behavior when the project requested linear/bilinear.
+        SetTextureFilter(toReturn, DefaultTextureFilter);
         UnloadImage(image);
         return toReturn;
     }


### PR DESCRIPTION
Closes #3199

## Problem

The editor's **Project Properties → Texture Filter** setting (`GumProjectSave.TextureFilter`) was applied **tool-side only**. A runtime game that loaded the same project (from-file or codegen) still rendered with **Point** filtering — sprites weren't smoothed when scaled — until the developer set `Renderer.TextureFilter` in code. Surprising for WYSIWYG + codegen users.

## Fix

Apply the project's `TextureFilter` to the runtime when a project is loaded.

- **`GumService.ApplyProjectTextureFilter(GumProjectSave)`** is called from `InitializeInternal` after the project loads (covers both the from-file path **and** codegen, which still loads the `.gumx` for content), and from `GumHotReloadManager` so editing the setting in the tool carries over on reload.
- **XNALIKE (MonoGame / KNI / FNA):** sets the existing global `Renderer.TextureFilter`, which the renderer already reads per-frame.
- **raylib:** raylib has no global sampler state — filtering is a per-texture property set at load time — so a new `ContentLoader.DefaultTextureFilter` is applied via `Raylib.SetTextureFilter` when sprite textures are loaded. (Fonts keep point filtering, unchanged.)

`"Linear"` is the string the editor stores for linear filtering; any other value (including null) maps to point.

## Precedence

- Runs during `Initialize`, so a non-null per-layer `Layer.IsLinearFilteringEnabled` still wins (existing renderer behavior, unchanged).
- Code that assigns `Renderer.TextureFilter` **after** `Initialize` returns still overrides the project value (the documented workaround keeps working).
- Default projects store `"Point"`, so existing projects are unaffected — only projects explicitly set to **Linear** change behavior.

## Tests (TDD)

`MonoGameGum.Tests/TextureFilterTests.cs` — covers Linear / Point / null / unrecognized for the xnalike path (the only platform with a runtime test project). Red→green verified. Full `MonoGameGum.Tests` suite passes (1733).

## Notes

- MonoGame + KNI + RaylibGum build clean. FNA could not be built in this environment (its `Microsoft.Xna` reference isn't restored here — pre-existing, unrelated to this change); it compiles the identical XNALIKE branch as MonoGame/KNI.
- **Boyscout:** added the hot-reload re-application (one line mirroring the existing `LoadAnimationsFromProvider` call) so a changed filter carries over on `.gumx` reload. On raylib this only affects textures loaded after the reload (already-cached textures keep their prior filter); on XNALIKE it takes effect on the next Draw. Happy to drop it if you'd rather keep this strictly load-only.
- raylib still does not honor per-layer `IsLinearFilteringEnabled` (the renderer's per-layer branch is pre-existing dead/commented code). Out of scope here.
- Docs follow-up tracked separately in #3198.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
