### PR TITLE
Fix NRE in AvailableContainedTypeConverter.GetStandardValues when SelectedElement is null (#3196)

### DIFF
--- a/Gum/PropertyGridHelpers/Converters/AvailableContainedTypeConverter.cs
+++ b/Gum/PropertyGridHelpers/Converters/AvailableContainedTypeConverter.cs
@@ -47,10 +47,13 @@ namespace Gum.PropertyGridHelpers.Converters
             }
 
             var instance = _selectedState.SelectedInstance;
-            if(instance != null)
+            var currentElement = _selectedState.SelectedElement;
+            // During a project load/refresh the grid can rebuild while selection is transiently
+            // inconsistent: SelectedInstance non-null while SelectedElement is null (the element
+            // was cleared but a stale instance reference remains). Guard both (see issue #3196).
+            if (instance != null && currentElement != null)
             {
                 var instanceName = instance.Name;
-                var currentElement = _selectedState.SelectedElement;
 
                 foreach(var otherInstance in currentElement.Instances)
                 {

--- a/Tool/Tests/GumToolUnitTests/PropertyGridHelpers/AvailableContainedTypeConverterTests.cs
+++ b/Tool/Tests/GumToolUnitTests/PropertyGridHelpers/AvailableContainedTypeConverterTests.cs
@@ -1,0 +1,62 @@
+using Gum.DataTypes;
+using Gum.Managers;
+using Gum.PropertyGridHelpers.Converters;
+using Gum.Services;
+using Gum.ToolStates;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Shouldly;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace GumToolUnitTests.PropertyGridHelpers;
+
+public class AvailableContainedTypeConverterTests : BaseTestClass
+{
+    private readonly IServiceProvider _testServiceProvider;
+    private readonly Mock<ISelectedState> _selectedStateMock;
+    private readonly Mock<IProjectManager> _projectManagerMock;
+
+    public AvailableContainedTypeConverterTests()
+    {
+        GumProjectSave project = new GumProjectSave();
+
+        _projectManagerMock = new Mock<IProjectManager>();
+        _projectManagerMock.SetupGet(x => x.GumProjectSave).Returns(project);
+
+        _selectedStateMock = new Mock<ISelectedState>();
+
+        ServiceCollection services = new ServiceCollection();
+        services.AddSingleton(_projectManagerMock.Object);
+        services.AddSingleton(_selectedStateMock.Object);
+        _testServiceProvider = services.BuildServiceProvider();
+        Locator.Register(_testServiceProvider);
+    }
+
+    public override void Dispose()
+    {
+        PropertyInfo prop = typeof(Locator).GetProperty(
+            "ServiceProviders", BindingFlags.NonPublic | BindingFlags.Static)!;
+        List<IServiceProvider> providers = (List<IServiceProvider>)prop.GetValue(null)!;
+        providers.Remove(_testServiceProvider);
+
+        base.Dispose();
+    }
+
+    [Fact]
+    public void GetStandardValues_SelectedInstanceNonNullSelectedElementNull_DoesNotThrow()
+    {
+        // Repro #3196: mid-transition during a project load/refresh, SelectedInstance can be
+        // non-null while SelectedElement is null (a stale instance reference remains after the
+        // element was cleared). The converter guarded SelectedInstance but then dereferenced
+        // SelectedElement unconditionally (foreach over currentElement.Instances) => NRE.
+        // SelectedElement is left at the mock default of null - that is the inconsistent state.
+        _selectedStateMock.SetupGet(x => x.SelectedInstance)
+            .Returns(new InstanceSave { Name = "StaleInstance" });
+
+        AvailableContainedTypeConverter converter = new AvailableContainedTypeConverter();
+
+        Should.NotThrow(() => converter.GetStandardValues(null));
+    }
+}


### PR DESCRIPTION
## Summary

Fixes a `NullReferenceException` in `AvailableContainedTypeConverter.GetStandardValues` that fires when the variable grid rebuilds (on `DataContextChanged`) during a project load/refresh while a stale selection lingers.

At that moment the selection can be transiently inconsistent: `SelectedInstance` is non-null while `SelectedElement` is null (the element was cleared but a stale instance reference remains). The converter guarded `SelectedInstance` but then dereferenced `SelectedElement` unconditionally at `foreach (var otherInstance in currentElement.Instances)`, throwing.

## Fix

Null-guard `currentElement` alongside the existing `instance` guard — targeted and low-risk, mirroring the issue's suggested fix.

```
WpfDataUi.SingleDataUiContainer.HandleDataContextChanged(...)
WpfDataUi.SingleDataUiContainer.CreateInternalControl()
StateReferencingInstanceMember.PreferredDisplayer.get()
StateReferencingInstanceMember.CustomOptions.get()
AvailableContainedTypeConverter.GetStandardValues(...)   // currentElement == null -> NRE
```

## Test

Added a `GumToolUnitTests` regression test (`AvailableContainedTypeConverterTests`) that registers mocked `ISelectedState`/`IProjectManager` via `Locator`, sets `SelectedInstance` non-null with `SelectedElement` null, and asserts `GetStandardValues` does not throw. TDD'd: red before the guard (NRE), green after. Full `GumToolUnitTests` suite passes (890 passed, 5 pre-existing skips).

Note: the deeper invariant — that `ISelectedState.SelectedInstance` should not be non-null when `SelectedElement` is null — is left for a separate, broader-blast-radius change as the issue suggests.

Closes #3196

🤖 Generated with [Claude Code](https://claude.com/claude-code)
