### PR TITLE
Runtime snapshot: extract embedded-texture backgrounds to PNG files (#3197)

### DIFF
--- a/GumCommon/Wireframe/RuntimeSnapshotSerializer.cs
+++ b/GumCommon/Wireframe/RuntimeSnapshotSerializer.cs
@@ -172,6 +172,24 @@ public class RuntimeSnapshotSerializer : IRuntimeSnapshotSerializer
             }
             type = type.BaseType;
         }
+
+        // Fall back to the renderable's type. An element can wrap a standard renderable (Sprite/Text/
+        // NineSlice) without being the matching *Runtime -- notably a Forms Image's visual, a bare
+        // InteractiveGue whose renderable is a Sprite. Its "standard-ness" lives in the renderable, not the
+        // type name, so without this it resolves to null and flattens to a bare Container, losing the image.
+        // The renderable type names (Sprite/Text/NineSlice) match the catalog names directly. (This
+        // generalizes the Label fix -- which only covered type-name-convention roots -- to any element
+        // backed by a standard renderable, so the same class of bug does not recur per new control.)
+        Type? renderableType = element.RenderableComponent?.GetType();
+        while (renderableType != null)
+        {
+            if (_defaultStates.ContainsKey(renderableType.Name))
+            {
+                return renderableType.Name;
+            }
+            renderableType = renderableType.BaseType;
+        }
+
         return null;
     }
 

--- a/GumCommon/Wireframe/RuntimeSnapshotSerializer.cs
+++ b/GumCommon/Wireframe/RuntimeSnapshotSerializer.cs
@@ -53,6 +53,49 @@ public interface IRuntimeSnapshotSerializer
     /// files referenced by <see cref="SynthesizedComponents"/>, not just the screen.
     /// </summary>
     IEnumerable<string> GetReferencedFiles(ScreenSave screen);
+
+    /// <summary>
+    /// The texture references captured during the most recent <see cref="CreateScreenSave"/> that could not
+    /// be given a "SourceFile" path, because the live texture is embedded or runtime-generated (its
+    /// Texture2D.Name -- the source path the content loader stamps on file-backed textures -- is unset).
+    /// Each entry pairs the live texture object with the placeholder "SourceFile" <see cref="VariableSave"/>
+    /// awaiting a path. A platform layer must save each <see cref="UnresolvedTextureReference.Texture"/> to a
+    /// file and write the relative path into its <see cref="UnresolvedTextureReference.SourceFileVariable"/>;
+    /// the serializer cannot, as Texture2D saving is backend-specific. Mirrors the
+    /// <see cref="GetReferencedFiles"/> split: the platform-agnostic serializer surfaces what it cannot
+    /// resolve, the platform layer does the file I/O.
+    /// </summary>
+    IReadOnlyList<UnresolvedTextureReference> UnresolvedTextureReferences { get; }
+}
+
+/// <summary>
+/// A texture the snapshot serializer captured but could not give a "SourceFile" path, because the live
+/// texture is embedded or runtime-generated (its Texture2D.Name is unset). Surfaced via
+/// <see cref="IRuntimeSnapshotSerializer.UnresolvedTextureReferences"/> for a platform layer to save and
+/// fill. See that property for the full contract.
+/// </summary>
+public sealed class UnresolvedTextureReference
+{
+    /// <summary>
+    /// The live texture object (a backend Texture2D), kept as <see cref="object"/> so the serializer stays
+    /// platform-agnostic. The platform layer casts it to the concrete texture type to save it.
+    /// </summary>
+    public object Texture { get; }
+
+    /// <summary>
+    /// The placeholder "SourceFile" variable in the snapshot (instance-qualified in its owning state) whose
+    /// <see cref="VariableSave.Value"/> the platform layer sets to the saved texture's relative path.
+    /// </summary>
+    public VariableSave SourceFileVariable { get; }
+
+    /// <summary>
+    /// Creates a reference pairing a live texture with the placeholder variable awaiting its saved path.
+    /// </summary>
+    public UnresolvedTextureReference(object texture, VariableSave sourceFileVariable)
+    {
+        Texture = texture;
+        SourceFileVariable = sourceFileVariable;
+    }
 }
 
 /// <inheritdoc cref="IRuntimeSnapshotSerializer" />
@@ -77,6 +120,10 @@ public class RuntimeSnapshotSerializer : IRuntimeSnapshotSerializer
     private readonly Dictionary<Type, ComponentEntry?> _componentCache;
     private readonly HashSet<string> _usedComponentNames;
 
+    // Textures captured during CreateScreenSave that have no resolvable file path (embedded/generated).
+    // Reset per snapshot so a reused serializer does not leak references between snapshots.
+    private readonly List<UnresolvedTextureReference> _unresolvedTextureReferences;
+
     /// <summary>
     /// Creates a serializer that reads runtime values against the supplied standard-element catalog.
     /// </summary>
@@ -99,10 +146,14 @@ public class RuntimeSnapshotSerializer : IRuntimeSnapshotSerializer
         _synthesizedComponents = new List<ComponentSave>();
         _componentCache = new Dictionary<Type, ComponentEntry?>();
         _usedComponentNames = new HashSet<string>();
+        _unresolvedTextureReferences = new List<UnresolvedTextureReference>();
     }
 
     /// <inheritdoc />
     public IReadOnlyList<ComponentSave> SynthesizedComponents => _synthesizedComponents;
+
+    /// <inheritdoc />
+    public IReadOnlyList<UnresolvedTextureReference> UnresolvedTextureReferences => _unresolvedTextureReferences;
 
     /// <inheritdoc />
     public string? GetStandardTypeName(GraphicalUiElement element)
@@ -184,6 +235,7 @@ public class RuntimeSnapshotSerializer : IRuntimeSnapshotSerializer
         _synthesizedComponents.Clear();
         _componentCache.Clear();
         _usedComponentNames.Clear();
+        _unresolvedTextureReferences.Clear();
 
         ScreenSave screen = new ScreenSave { Name = screenName };
         StateSave defaultState = new StateSave { Name = "Default" };
@@ -265,6 +317,66 @@ public class RuntimeSnapshotSerializer : IRuntimeSnapshotSerializer
         }
     }
 
+    // Records a texture the snapshot captured coordinates for but could not give a SourceFile path, because
+    // the live texture is embedded/runtime-generated (its Texture2D.Name -- the source path the content
+    // loader stamps on file-backed textures -- is unset). Adds a placeholder SourceFile variable to the
+    // owning state and pairs it with the texture object so a platform layer can save the Texture2D to a file
+    // and fill the path. Without this the slice has valid texture coordinates but no texture to slice, so it
+    // renders blank in the tool. Shared by the screen-instance path and the component-internals path.
+    private void RecordUnresolvedTextureIfNeeded(GraphicalUiElement element, string typeName,
+        StateSave owningState, string? instanceName)
+    {
+        if (!_defaultStates.TryGetValue(typeName, out StateSave? typeDefault))
+        {
+            return;
+        }
+        VariableSave? sourceFileCatalogVariable = FindSourceFileVariable(typeDefault);
+        if (sourceFileCatalogVariable == null)
+        {
+            // Not a textured standard type (no SourceFile in its catalog) -- nothing to extract.
+            return;
+        }
+
+        string qualifiedName = instanceName == null
+            ? sourceFileCatalogVariable.Name
+            : instanceName + "." + sourceFileCatalogVariable.Name;
+
+        // A resolvable path was already emitted (file-backed texture) -- nothing to extract.
+        if (FindVariable(owningState, qualifiedName) != null)
+        {
+            return;
+        }
+
+        // No path, but the live element still has a texture: it is embedded/generated. Capture the texture
+        // and a placeholder variable (carrying the catalog's name/type/category) for the platform layer to
+        // fill once it saves a file.
+        if (element.TryGetTexture(out object? texture) && texture != null)
+        {
+            VariableSave placeholder = new VariableSave
+            {
+                Name = qualifiedName,
+                Type = sourceFileCatalogVariable.Type,
+                Value = null,
+                SetsValue = true,
+                Category = sourceFileCatalogVariable.Category,
+            };
+            owningState.Variables.Add(placeholder);
+            _unresolvedTextureReferences.Add(new UnresolvedTextureReference(texture, placeholder));
+        }
+    }
+
+    private static VariableSave? FindSourceFileVariable(StateSave state)
+    {
+        foreach (VariableSave variable in state.Variables)
+        {
+            if (variable.Name == "SourceFile" || variable.Name == "Source File")
+            {
+                return variable;
+            }
+        }
+        return null;
+    }
+
     // "SourceFile" appears instance-qualified in the screen's default state (e.g. "Sprite.SourceFile").
     private static bool IsSourceFileVariable(string variableName)
     {
@@ -314,6 +426,8 @@ public class RuntimeSnapshotSerializer : IRuntimeSnapshotSerializer
                 Category = variable.Category,
             });
         }
+
+        RecordUnresolvedTextureIfNeeded(element, typeName, defaultState, instanceName);
 
         // Non-top-level instances record their parent; top-level instances are children of the element.
         if (parentInstanceName != null)
@@ -431,6 +545,8 @@ public class RuntimeSnapshotSerializer : IRuntimeSnapshotSerializer
                 Category = variable.Category,
             });
         }
+
+        RecordUnresolvedTextureIfNeeded(pristine, componentBaseType, componentDefault, instanceName: null);
 
         // Seed Component-base variables the live visual cannot supply -- notably the "State" selector, which
         // is save-time metadata with no runtime property to read. An authored component carries these, so

--- a/GumRuntime/GraphicalUiElementPropertyReadExtensions.cs
+++ b/GumRuntime/GraphicalUiElementPropertyReadExtensions.cs
@@ -215,8 +215,22 @@ public static class GraphicalUiElementPropertyReadExtensions
     /// <returns>True when the element exposes a non-null texture; otherwise false.</returns>
     public static bool TryGetTexture(this GraphicalUiElement element, out object? texture)
     {
+        // Standard runtimes (SpriteRuntime/NineSliceRuntime) expose Texture directly on the runtime type.
         PropertyInfo? textureProperty = ResolveReflectedProperty(element.GetType(), "Texture");
         texture = textureProperty?.GetValue(element);
+        if (texture != null)
+        {
+            return true;
+        }
+
+        // A bare InteractiveGue (e.g. a Forms Image's visual) has no Texture property of its own -- the
+        // texture lives on its Sprite/NineSlice renderable. Read it from there so the snapshot still finds it.
+        object? renderable = element.RenderableComponent;
+        if (renderable != null)
+        {
+            PropertyInfo? renderableTextureProperty = ResolveReflectedProperty(renderable.GetType(), "Texture");
+            texture = renderableTextureProperty?.GetValue(renderable);
+        }
         return texture != null;
     }
 

--- a/GumRuntime/GraphicalUiElementPropertyReadExtensions.cs
+++ b/GumRuntime/GraphicalUiElementPropertyReadExtensions.cs
@@ -204,13 +204,27 @@ public static class GraphicalUiElementPropertyReadExtensions
     // A null entry caches "no reflectable property" so repeated misses stay cheap.
     private static readonly ConcurrentDictionary<(Type, string), PropertyInfo?> _propertyCache = new();
 
+    /// <summary>
+    /// Reads the live texture object (a Sprite/NineSlice ".Texture") for this element, if any, without
+    /// taking a dependency on the backend Texture2D type. The snapshot serializer uses this to detect a
+    /// texture that has no resolvable file path (an embedded/runtime-generated texture whose Name is unset)
+    /// so a platform layer can extract it to a file.
+    /// </summary>
+    /// <param name="element">The element to read from.</param>
+    /// <param name="texture">The live texture object when present; otherwise null.</param>
+    /// <returns>True when the element exposes a non-null texture; otherwise false.</returns>
+    public static bool TryGetTexture(this GraphicalUiElement element, out object? texture)
+    {
+        PropertyInfo? textureProperty = ResolveReflectedProperty(element.GetType(), "Texture");
+        texture = textureProperty?.GetValue(element);
+        return texture != null;
+    }
+
     // Recovers a Sprite/NineSlice source path from its texture's Name (stamped by the content loader on
     // load). Done by reflection so this shared reader needs no reference to the backend texture type.
     private static string? TryReadTextureName(GraphicalUiElement element)
     {
-        PropertyInfo? textureProperty = ResolveReflectedProperty(element.GetType(), "Texture");
-        object? texture = textureProperty?.GetValue(element);
-        if (texture == null)
+        if (!element.TryGetTexture(out object? texture) || texture == null)
         {
             return null;
         }

--- a/MonoGameGum.Tests/Wireframe/RuntimeSnapshotSerializerProjectTests.cs
+++ b/MonoGameGum.Tests/Wireframe/RuntimeSnapshotSerializerProjectTests.cs
@@ -294,6 +294,57 @@ public class RuntimeSnapshotSerializerProjectTests : BaseTestClass
     }
 
     [Fact]
+    public void FillUnresolvedTextureSourceFiles_ShouldDedupeByTextureAndFillPlaceholders()
+    {
+        // Two references to one shared texture instance plus one to a distinct texture: the shared texture
+        // is saved once (deduped by reference) and both its placeholders get that same path; the distinct
+        // texture gets its own. This mirrors "one UISpriteSheet.png shared by many NineSlices".
+        object sharedTexture = new();
+        object otherTexture = new();
+        VariableSave first = new() { Name = "A.SourceFile" };
+        VariableSave second = new() { Name = "B.SourceFile" };
+        VariableSave third = new() { Name = "C.SourceFile" };
+        System.Collections.Generic.List<UnresolvedTextureReference> references = new()
+        {
+            new UnresolvedTextureReference(sharedTexture, first),
+            new UnresolvedTextureReference(sharedTexture, second),
+            new UnresolvedTextureReference(otherTexture, third),
+        };
+
+        System.Collections.Generic.List<object> saved = new();
+        Gum.GumService.FillUnresolvedTextureSourceFiles(references, (texture, relativePath) =>
+        {
+            saved.Add(texture);
+            return true;
+        });
+
+        // Saved once per distinct texture instance.
+        saved.Count.ShouldBe(2);
+        // The shared texture's two placeholders resolve to the same (non-null) path; the distinct one differs.
+        first.Value.ShouldNotBeNull();
+        first.Value.ShouldBe(second.Value);
+        third.Value.ShouldNotBeNull();
+        first.Value.ShouldNotBe(third.Value);
+    }
+
+    [Fact]
+    public void FillUnresolvedTextureSourceFiles_WhenSaverDeclines_ShouldLeavePlaceholderUnset()
+    {
+        // A texture the saver cannot persist (e.g. SaveAsPng throws) must leave its placeholder null -- the
+        // slice renders blank rather than dangling on a path to a file that was never written.
+        object texture = new();
+        VariableSave placeholder = new() { Name = "A.SourceFile" };
+        System.Collections.Generic.List<UnresolvedTextureReference> references = new()
+        {
+            new UnresolvedTextureReference(texture, placeholder),
+        };
+
+        Gum.GumService.FillUnresolvedTextureSourceFiles(references, (_, _) => false);
+
+        placeholder.Value.ShouldBeNull();
+    }
+
+    [Fact]
     public void ExportSnapshot_ShouldSynthesizeComponentForFormsButtons()
     {
         // End-to-end: two live Forms Buttons should collapse into one shared "Button" component plus two

--- a/MonoGameGum.Tests/Wireframe/RuntimeSnapshotSerializerProjectTests.cs
+++ b/MonoGameGum.Tests/Wireframe/RuntimeSnapshotSerializerProjectTests.cs
@@ -294,6 +294,50 @@ public class RuntimeSnapshotSerializerProjectTests : BaseTestClass
     }
 
     [Fact]
+    public void ExportSnapshot_WithRelativeFilePath_ShouldStillProcessReferencedFiles()
+    {
+        // Regression: a bare relative file name (as the GameUiSamples F1 snapshot passes,
+        // ExportSnapshot("MyTestSnapshot.gumx")) made Path.GetDirectoryName return "", so the whole
+        // directory block -- referenced-file copying AND embedded-texture extraction -- was skipped, leaving
+        // textures unresolved (blank in the tool). The path must resolve to an absolute directory so that
+        // work runs no matter how the caller spells the path.
+        string originalRelativeDirectory = FileManager.RelativeDirectory;
+        string originalCurrentDirectory = Directory.GetCurrentDirectory();
+        string contentDirectory = NewTempDirectory();
+        string snapshotDirectory = NewTempDirectory();
+        try
+        {
+            const string relativePath = "UI/button.png";
+            string sourceFile = Path.Combine(contentDirectory, "UI", "button.png");
+            Directory.CreateDirectory(Path.GetDirectoryName(sourceFile)!);
+            File.WriteAllBytes(sourceFile, new byte[] { 1, 2, 3 });
+            FileManager.RelativeDirectory = contentDirectory;
+
+            GumService service = new();
+            SpriteRuntime sprite = new() { Name = "Sprite" };
+            Microsoft.Xna.Framework.Graphics.Texture2D texture = MakeHeadlessTexture();
+            texture.Name = relativePath;
+            sprite.Texture = texture;
+            service.Root.AddChild(sprite);
+
+            // Run with the snapshot directory as the working directory and a bare relative file name.
+            Directory.CreateDirectory(snapshotDirectory);
+            Directory.SetCurrentDirectory(snapshotDirectory);
+            service.ExportSnapshot("Live." + GumProjectSave.ProjectExtension);
+
+            // The referenced file is copied next to the snapshot (the directory block was not skipped).
+            File.Exists(Path.Combine(snapshotDirectory, "UI", "button.png")).ShouldBeTrue();
+        }
+        finally
+        {
+            Directory.SetCurrentDirectory(originalCurrentDirectory);
+            FileManager.RelativeDirectory = originalRelativeDirectory;
+            DeleteTempDirectory(contentDirectory);
+            DeleteTempDirectory(snapshotDirectory);
+        }
+    }
+
+    [Fact]
     public void FillUnresolvedTextureSourceFiles_ShouldDedupeByTextureAndFillPlaceholders()
     {
         // Two references to one shared texture instance plus one to a distinct texture: the shared texture

--- a/MonoGameGum.Tests/Wireframe/RuntimeSnapshotSerializerTests.cs
+++ b/MonoGameGum.Tests/Wireframe/RuntimeSnapshotSerializerTests.cs
@@ -331,6 +331,28 @@ public class RuntimeSnapshotSerializerTests : BaseTestClass
     }
 
     [Fact]
+    public void CreateScreenSave_SpriteRenderableBackedElement_ShouldEmitSpriteInstanceWithSourceFile()
+    {
+        // The reported FrbClicker case: purchased-item Images are a bare InteractiveGue + Sprite renderable
+        // (Forms Image's visual), not a SpriteRuntime. They must serialize as Sprite instances carrying the
+        // icon SourceFile -- not as empty Container instances (which lose the image entirely).
+        ContainerRuntime root = new();
+        Microsoft.Xna.Framework.Graphics.Texture2D texture = MakeHeadlessTexture();
+        texture.Name = "UI/icon.png";
+        RenderingLibrary.Graphics.Sprite spriteRenderable = new(texture: null);
+        spriteRenderable.Texture = texture;
+        InteractiveGue image = new(spriteRenderable) { Name = "Image" };
+        root.AddChild(image);
+
+        RuntimeSnapshotSerializer serializer = CreateSerializer();
+        ScreenSave screen = serializer.CreateScreenSave(root, "Snapshot", shake: true);
+
+        screen.Instances.First(i => i.Name == "Image").BaseType.ShouldBe("Sprite");
+        StateSave defaultState = screen.States.First(s => s.Name == "Default");
+        defaultState.Variables.First(v => v.Name == "Image.SourceFile").Value.ShouldBe("UI/icon.png");
+    }
+
+    [Fact]
     public void GetStandardTypeName_ShouldResolveContainerRuntime()
     {
         RuntimeSnapshotSerializer serializer = CreateSerializer();
@@ -352,6 +374,32 @@ public class RuntimeSnapshotSerializerTests : BaseTestClass
         RuntimeSnapshotSerializer serializer = CreateSerializer();
 
         serializer.GetStandardTypeName(new GraphicalUiElement()).ShouldBeNull();
+    }
+
+    [Fact]
+    public void GetStandardTypeName_ShouldResolveSpriteRenderableBackedElementAsSprite()
+    {
+        // A bare InteractiveGue whose renderable is a Sprite (e.g. a Forms Image's visual) does not follow
+        // the "<Standard>Runtime" type-name convention, so resolving by type name alone returns null. It must
+        // still resolve to "Sprite" via its renderable -- the same class of bug the Label fix addressed for
+        // type-name-convention roots, generalized here to renderable-backed elements.
+        RenderingLibrary.Graphics.Sprite spriteRenderable = new(texture: null);
+        InteractiveGue element = new(spriteRenderable);
+
+        RuntimeSnapshotSerializer serializer = CreateSerializer();
+
+        serializer.GetStandardTypeName(element).ShouldBe("Sprite");
+    }
+
+    [Fact]
+    public void GetStandardTypeName_ShouldResolveFormsImageVisualAsSprite()
+    {
+        // Ties the fix to the actual reported type: a real Forms Image's visual must resolve to "Sprite".
+        Gum.Forms.Controls.Image image = new();
+
+        RuntimeSnapshotSerializer serializer = CreateSerializer();
+
+        serializer.GetStandardTypeName(image.Visual).ShouldBe("Sprite");
     }
 
     [Fact]

--- a/MonoGameGum.Tests/Wireframe/RuntimeSnapshotSerializerTests.cs
+++ b/MonoGameGum.Tests/Wireframe/RuntimeSnapshotSerializerTests.cs
@@ -245,6 +245,74 @@ public class RuntimeSnapshotSerializerTests : BaseTestClass
     }
 
     [Fact]
+    public void CreateScreenSave_WhenTextureHasNoFilePath_ShouldRecordUnresolvedTextureReference()
+    {
+        // An embedded/runtime-generated texture has no Texture2D.Name (no source path the content loader
+        // stamps on file-backed textures), so the snapshot captures coordinates but can give no SourceFile.
+        // The serializer must surface the texture plus a placeholder variable for the platform layer to
+        // save the texture and fill the path -- otherwise the slice points at a texture the tool can't load.
+        ContainerRuntime root = new();
+        SpriteRuntime sprite = new() { Name = "Sprite" };
+        Microsoft.Xna.Framework.Graphics.Texture2D texture = MakeHeadlessTexture(); // Name is null
+        sprite.Texture = texture;
+        root.AddChild(sprite);
+
+        RuntimeSnapshotSerializer serializer = CreateSerializer();
+        ScreenSave screen = serializer.CreateScreenSave(root, "Snapshot", shake: true);
+
+        UnresolvedTextureReference reference = serializer.UnresolvedTextureReferences.ShouldHaveSingleItem();
+        reference.Texture.ShouldBeSameAs(texture);
+
+        // The placeholder lives in the screen default state, qualified by the instance name, awaiting a path.
+        StateSave defaultState = screen.States.First(s => s.Name == "Default");
+        VariableSave placeholder = defaultState.Variables.First(v => v.Name == "Sprite.SourceFile");
+        reference.SourceFileVariable.ShouldBeSameAs(placeholder);
+        placeholder.Value.ShouldBeNull();
+    }
+
+    [Fact]
+    public void CreateScreenSave_WhenTextureHasFilePath_ShouldNotRecordUnresolvedTextureReference()
+    {
+        // A file-backed texture carries its source path on Texture2D.Name, so SourceFile resolves normally
+        // and there is nothing to extract.
+        ContainerRuntime root = new();
+        SpriteRuntime sprite = new() { Name = "Sprite" };
+        Microsoft.Xna.Framework.Graphics.Texture2D texture = MakeHeadlessTexture();
+        texture.Name = "UI/button.png";
+        sprite.Texture = texture;
+        root.AddChild(sprite);
+
+        RuntimeSnapshotSerializer serializer = CreateSerializer();
+        ScreenSave screen = serializer.CreateScreenSave(root, "Snapshot", shake: true);
+
+        serializer.UnresolvedTextureReferences.ShouldBeEmpty();
+        StateSave defaultState = screen.States.First(s => s.Name == "Default");
+        defaultState.Variables.First(v => v.Name == "Sprite.SourceFile").Value.ShouldBe("UI/button.png");
+    }
+
+    [Fact]
+    public void CreateScreenSave_WhenTextureSharedAcrossInstances_ShouldRecordReferenceForEachSharingOneTexture()
+    {
+        // The Forms default visuals share one embedded sprite sheet across many sprites/NineSlices. Each
+        // instance records its own placeholder, but all reference the same texture instance, so the platform
+        // layer can dedupe them down to a single saved file.
+        ContainerRuntime root = new();
+        Microsoft.Xna.Framework.Graphics.Texture2D shared = MakeHeadlessTexture();
+        SpriteRuntime first = new() { Name = "First" };
+        first.Texture = shared;
+        SpriteRuntime second = new() { Name = "Second" };
+        second.Texture = shared;
+        root.AddChild(first);
+        root.AddChild(second);
+
+        RuntimeSnapshotSerializer serializer = CreateSerializer();
+        serializer.CreateScreenSave(root, "Snapshot", shake: true);
+
+        serializer.UnresolvedTextureReferences.Count.ShouldBe(2);
+        serializer.UnresolvedTextureReferences.Select(r => r.Texture).Distinct().Count().ShouldBe(1);
+    }
+
+    [Fact]
     public void GetReferencedFiles_ShouldReturnDistinctSourceFilePaths()
     {
         ContainerRuntime root = new();
@@ -533,6 +601,29 @@ public class RuntimeSnapshotSerializerTests : BaseTestClass
         screen.Instances.Any(i => i.Name == "TextInstance").ShouldBeTrue();
     }
 
+    [Fact]
+    public void CreateScreenSave_WithBaselineProvider_ShouldRecordUnresolvedTextureForComponentChild()
+    {
+        // The actual reported scenario: a Forms control (e.g. ScrollViewer) draws its Background NineSlice
+        // from the embedded sheet. When the control componentizes, that background lives in the synthesized
+        // component's default state -- and still needs its embedded texture extracted, just like a flattened
+        // sprite, or the component renders blank.
+        ContainerRuntime root = new();
+        ContainerRuntime formsScreen = new() { Name = "MainMenu" };
+        formsScreen.FormsControlAsObject = new object();
+        formsScreen.AddChild(MakeLiveTexturedControl("Widget"));
+        root.AddChild(formsScreen);
+
+        RuntimeSnapshotSerializer serializer =
+            new(StandardElementsManager.Self.DefaultStates, TexturedControlBaseline);
+        serializer.CreateScreenSave(root, "Snapshot", shake: true);
+
+        ComponentSave component = serializer.SynthesizedComponents.First(c => c.Name == "FakeTexturedControl");
+        StateSave componentDefault = component.States.First(s => s.Name == "Default");
+        componentDefault.Variables.ShouldContain(v => v.Name == "Background.SourceFile");
+        serializer.UnresolvedTextureReferences.ShouldContain(r => r.SourceFileVariable.Name == "Background.SourceFile");
+    }
+
     private static ContainerRuntime MakeLiveButton(string name, string text)
     {
         ContainerRuntime button = new() { Name = name };
@@ -542,6 +633,39 @@ public class RuntimeSnapshotSerializerTests : BaseTestClass
         button.AddChild(textInstance);
         return button;
     }
+
+    // A live textured Forms control: a container holding a single "Background" sprite whose embedded-style
+    // texture has no Name (mirrors the Forms default visuals' shared UISpriteSheet).
+    private static ContainerRuntime MakeLiveTexturedControl(string name)
+    {
+        ContainerRuntime control = new() { Name = name };
+        control.FormsControlAsObject = new FakeTexturedControl();
+        SpriteRuntime background = new() { Name = "Background" };
+        background.Texture = MakeHeadlessTexture();
+        control.AddChild(background);
+        return control;
+    }
+
+    // A pristine FakeTexturedControl template, structurally matching the live control so it componentizes.
+    private static GraphicalUiElement? TexturedControlBaseline(Type type)
+    {
+        if (type != typeof(FakeTexturedControl))
+        {
+            return null;
+        }
+        ContainerRuntime control = new();
+        SpriteRuntime background = new() { Name = "Background" };
+        background.Texture = MakeHeadlessTexture();
+        control.AddChild(background);
+        return control;
+    }
+
+    // Fabricates a Texture2D reference without a GraphicsDevice (its ctor needs one). The snapshot path only
+    // holds the reference and reads its Name; an uninitialized shell (Name == null) stands in for an embedded
+    // texture that has no resolvable file path.
+    private static Microsoft.Xna.Framework.Graphics.Texture2D MakeHeadlessTexture() =>
+        (Microsoft.Xna.Framework.Graphics.Texture2D)System.Runtime.CompilerServices.RuntimeHelpers
+            .GetUninitializedObject(typeof(Microsoft.Xna.Framework.Graphics.Texture2D));
 
     // A pristine FakeButton template: a container holding a single "TextInstance" Text child.
     private static GraphicalUiElement? FakeButtonBaseline(Type type)
@@ -585,6 +709,12 @@ public class RuntimeSnapshotSerializerTests : BaseTestClass
 
     // Stand-in for a Label-like Forms control whose visual root is a Text (like DefaultLabelRuntime).
     private class FakeLabel
+    {
+    }
+
+    // Stand-in for a Forms control whose visual carries a textured "Background" child (like the V2/V3
+    // default visuals that draw backgrounds from the embedded UISpriteSheet).
+    private class FakeTexturedControl
     {
     }
 

--- a/MonoGameGum/GumService.cs
+++ b/MonoGameGum/GumService.cs
@@ -354,6 +354,13 @@ public class GumService : IGumService
     /// </param>
     public void ExportSnapshot(string filePath, bool shake = true)
     {
+        // Resolve to an absolute path up front. A bare/relative file name (e.g. "MyTestSnapshot.gumx", as
+        // the samples pass) would otherwise make Path.GetDirectoryName below return "", skipping the whole
+        // directory block that extracts embedded textures and copies referenced files -- leaving those
+        // textures unresolved (blank in the tool). project.Save resolves relative paths against the current
+        // directory anyway, so this changes only the directory computation, not where the project is written.
+        filePath = Path.GetFullPath(filePath);
+
         // A code-only game may never have triggered standards population; ensure the catalog exists
         // before reading it (as the serializer's baseline) and writing it (as the project's standards).
         if (StandardElementsManager.Self.DefaultStates == null)

--- a/MonoGameGum/GumService.cs
+++ b/MonoGameGum/GumService.cs
@@ -412,6 +412,10 @@ public class GumService : IGumService
             {
                 Directory.CreateDirectory(Path.Combine(directory, ElementReference.ComponentSubfolder));
             }
+
+            // Save embedded/generated textures (e.g. the Forms default visuals' shared sheet) to files and
+            // fill their SourceFile paths BEFORE Save, so the written XML carries the resolved paths.
+            ExtractUnresolvedTextures(serializer, directory);
         }
 
         project.Save(filePath, saveElements: true);
@@ -462,8 +466,26 @@ public class GumService : IGumService
     // path; absolute references already resolve on their own, and missing files are skipped (logged).
     private static void CopyReferencedFiles(IRuntimeSnapshotSerializer serializer, ScreenSave screen, string snapshotDirectory)
     {
+        // Textures extracted from embedded/generated sources are already written next to the project by
+        // ExtractUnresolvedTextures, yet their now-filled SourceFile paths also surface in GetReferencedFiles.
+        // Skip them here: they don't exist under the content directory (so the copy would just log a miss),
+        // and a coincidentally same-named content file must not clobber the extracted PNG.
+        HashSet<string> extractedPaths = new();
+        foreach (UnresolvedTextureReference reference in serializer.UnresolvedTextureReferences)
+        {
+            if (reference.SourceFileVariable.Value is string extractedPath && !string.IsNullOrEmpty(extractedPath))
+            {
+                extractedPaths.Add(extractedPath);
+            }
+        }
+
         foreach (string referencedPath in serializer.GetReferencedFiles(screen))
         {
+            if (extractedPaths.Contains(referencedPath))
+            {
+                continue;
+            }
+
             if (!FileManager.IsRelative(referencedPath))
             {
                 continue;
@@ -493,6 +515,71 @@ public class GumService : IGumService
                 Directory.CreateDirectory(destinationDirectory);
             }
             File.Copy(absoluteSource, destination, overwrite: true);
+        }
+    }
+
+    // Extracts textures the serializer captured but could not resolve to a file path -- embedded or
+    // runtime-generated Texture2Ds (notably the Forms default visuals' shared UISpriteSheet) whose Name is
+    // unset, so the snapshot has valid texture coordinates but no file to slice. Saves each unique texture
+    // to a PNG next to the project and writes the relative path into its placeholder SourceFile variable so
+    // the slices render in the tool. The actual Texture2D.SaveAsPng is XNALIKE-only; on other backends the
+    // textures stay unresolved (no regression -- they were blank before this existed).
+    private static void ExtractUnresolvedTextures(IRuntimeSnapshotSerializer serializer, string snapshotDirectory)
+    {
+#if XNALIKE
+        if (serializer.UnresolvedTextureReferences.Count == 0)
+        {
+            return;
+        }
+
+        Directory.CreateDirectory(snapshotDirectory);
+
+        FillUnresolvedTextureSourceFiles(serializer.UnresolvedTextureReferences, (texture, relativePath) =>
+        {
+            if (texture is not Texture2D texture2D)
+            {
+                return false;
+            }
+            try
+            {
+                using FileStream stream = File.Create(Path.Combine(snapshotDirectory, relativePath));
+                texture2D.SaveAsPng(stream, texture2D.Width, texture2D.Height);
+                return true;
+            }
+            catch (Exception e)
+            {
+                System.Diagnostics.Debug.WriteLine($"Snapshot: failed to save embedded texture: {e.Message}");
+                return false;
+            }
+        });
+#endif
+    }
+
+    // Pure orchestration over the serializer's unresolved textures: dedupe by texture instance, give each a
+    // relative file name, persist it via the supplied saver, and write the resulting path into the placeholder
+    // SourceFile variable. The saver seam keeps the GPU-bound Texture2D.SaveAsPng out of this method so the
+    // dedup/path-fill logic is testable headlessly. A texture the saver declines (returns false) is left
+    // unresolved -- its placeholder keeps its null value, rendering blank rather than dangling on a bad path.
+    internal static void FillUnresolvedTextureSourceFiles(
+        IReadOnlyList<UnresolvedTextureReference> references, Func<object, string, bool> trySaveTexture)
+    {
+        // Dedupe by texture instance (not value): the one shared sheet -> one file, many filled placeholders.
+        Dictionary<object, string> savedRelativePaths = new(ReferenceEqualityComparer.Instance);
+        int index = 0;
+        foreach (UnresolvedTextureReference reference in references)
+        {
+            if (!savedRelativePaths.TryGetValue(reference.Texture, out string? relativePath))
+            {
+                string candidate = $"EmbeddedTexture{index}.png";
+                if (!trySaveTexture(reference.Texture, candidate))
+                {
+                    continue;
+                }
+                relativePath = candidate;
+                index++;
+                savedRelativePaths[reference.Texture] = relativePath;
+            }
+            reference.SourceFileVariable.Value = relativePath;
         }
     }
 


### PR DESCRIPTION
## What

Fixes #3197: in a runtime snapshot, Forms-control backgrounds (and other sprite-sheet visuals) built from the V2/V3 default visuals' **embedded** `UISpriteSheet` rendered **blank** in the tool.

## Root cause

`SystemManagers.LoadEmbeddedTexture2d` loads the sheet via `Texture2D.FromStream` and **never stamps `Texture2D.Name`**. The snapshot recovers a sprite's `SourceFile` from that `Name` (the source path the content loader stamps on file-backed textures), so embedded textures yield no path. The snapshot captured the texture *coordinates* but emitted **no `SourceFile`** — a NineSlice with valid coords pointing at a texture the tool can't load → blank. Affects every snapshot of code-only UI built on the shared `UISpriteSheet.png`.

## Fix

Mirrors the existing `GetReferencedFiles` / `CopyReferencedFiles` split (serializer surfaces, platform layer does the I/O):

- **`RuntimeSnapshotSerializer`** (GumCommon, platform-agnostic) now surfaces `IReadOnlyList<UnresolvedTextureReference> UnresolvedTextureReferences` — one per textured node that has a live texture object but no resolvable path. Each pairs the texture `object` with a placeholder `SourceFile` `VariableSave` it adds to the owning state. Recorded on both the screen-instance path and the component-internals path (the reported ScrollViewer `Background` lives in a synthesized component).
- **`GumService.ExportSnapshot`** (MonoGame layer) saves each unique texture to a PNG next to the project via `Texture2D.SaveAsPng` and fills the placeholder path, **deduped by texture instance** (one shared sheet → one `EmbeddedTexture0.png`). `SaveAsPng` is XNALIKE-specific, so the byte-write is `#if XNALIKE`-guarded; the dedup/fill orchestration is a testable `internal` seam (`FillUnresolvedTextureSourceFiles`). Raylib is unchanged (no regression — those were blank before).
- Adds `GraphicalUiElementPropertyReadExtensions.TryGetTexture` (reflection-based, backend-agnostic), reused by `TryReadTextureName`.
- `CopyReferencedFiles` skips extracted paths so it doesn't re-copy (or clobber) the already-written PNGs.

## Tests (TDD — written failing first)

- Serializer (GumCommon, headless): records an unresolved reference + placeholder for a texture with no path; does **not** for a file-backed texture; records one reference per instance sharing a single texture; records for a componentized control's textured `Background`.
- Platform orchestration (headless via saver seam): dedupes by texture instance and fills placeholders; a declined save leaves the placeholder null.

Full `MonoGameGum.Tests` suite (1734) green, including the `gumcli check` snapshot integration tests. RaylibGum and KniGum build clean, confirming the cross-platform `#if` split.

## Note

Because the embedded texture has no `Name`, the extracted file is named `EmbeddedTexture{N}.png` rather than `UISpriteSheet.png`; the slices render correctly regardless. A friendlier name would require stamping the embedded `Name`, which is out of scope (it would re-route `SourceFile` resolution).

Closes #3197

🤖 Generated with [Claude Code](https://claude.com/claude-code)
