### PR TITLE
Document that Styling.ActiveStyle.Text styles fonts across all controls

### DIFF
--- a/docs/code/styling/code-only-styling/styling-using-activestyles.md
+++ b/docs/code/styling/code-only-styling/styling-using-activestyles.md
@@ -124,7 +124,13 @@ By changing these colors, controls are created using the new colors:
 
 ## Styling and Fonts
 
-The `Styling` object includes properties for adjusting font values. For example, the `Normal` state can be modified to change an app's font. The following code relies on KernSmith for dynamic font creation. For more information on dynamic fonts and information on using KernSmith, see the [Font Strategies](../../files-and-fonts/font-strategies.md#dynamic-kernsmith-generation) page.
+Just as `Styling.ActiveStyle.Colors` controls the colors of every control created after it is set, `Styling.ActiveStyle.Text` controls their fonts — so a single assignment restyles text across the entire project without modifying individual controls. It exposes three text states:
+
+* `Normal` — the default font, applied to the text of most controls (`Button`, `Label`, `TextBox`, `ListBoxItem`, and so on).
+* `Strong` — a bold variant, applied by `ComboBox`.
+* `Emphasis` — an italic variant (not applied by the built-in controls; available when you apply it to your own text).
+
+Set the `Font`, `FontSize`, `IsBold`, or `IsItalic` values on a state to change it. The following code relies on KernSmith for dynamic font creation. For more information on dynamic fonts and information on using KernSmith, see the [Font Strategies](../../files-and-fonts/font-strategies.md#dynamic-kernsmith-generation) page.
 
 ```csharp
 // initialize


### PR DESCRIPTION
## What

Expands the **Styling and Fonts** section of `styling-using-activestyles.md` to make clear that `Styling.ActiveStyle.Text` is the font parallel of `Styling.ActiveStyle.Colors` — a single assignment restyles text across the entire project, and the change applies to every control created afterward.

Adds the three text states and where they apply:

- `Normal` — default font for most controls' text
- `Strong` — bold variant, applied by `ComboBox`
- `Emphasis` — italic variant (not applied by the built-in controls; available for your own text)

## Why

Surfaced from a Discord question: a user already theming heavily via `ActiveStyle.Colors` asked whether there were "plans" to apply fonts the same way — not realizing `ActiveStyle.Text` already does exactly that. The Colors section has a rich "which property affects which control" table; the Fonts section only showed setting `Normal` and never stated the project-wide behavior. This closes that discoverability gap.

Docs-only change; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
