### PR TITLE
Docs: cross-link tool Outline Thickness page to code-side colored-outline path

### DIFF
--- a/docs/gum-tool/gum-elements/text/outlinethickness.md
+++ b/docs/gum-tool/gum-elements/text/outlinethickness.md
@@ -32,4 +32,8 @@ Outline quality tends to be better if it appears before the regular font color. 
 
 <figure><img src="../../../.gitbook/assets/image (1) (1) (1) (1) (1) (1) (1) (1) (1) (1) (1) (1).png" alt=""><figcaption><p>The first Text is using a custom Hiero font, the second is using a default font</p></figcaption></figure>
 
+{% hint style="info" %}
+If you are creating fonts in code rather than through the tool, colored outlines can be generated programmatically — no hand-editing of the .png required. See [Advanced Font Effects — Outline Color](../../../code/files-and-fonts/advanced-font-effects.md#outline-color).
+{% endhint %}
+
 For more information on custom fonts, see the [Use Custom Font](use-custom-font.md) page.


### PR DESCRIPTION
## What

Adds a cross-link from the tool-side **Outline Thickness** page (`docs/gum-tool/gum-elements/text/outlinethickness.md`) to the code-side **Advanced Font Effects — Outline Color** section.

## Why

The tool page's "Outline and Color" section only documented the *manual* ways to get a non-black outline (copy the generated font out of `FontCache` and edit the `.png` in Photoshop/Paint.NET, or build it in Hiero). It never mentioned that colored outlines can be generated **programmatically** via KernSmith's `FontGeneratorOptions` (`OutlineR/G/B`), which is documented under `code/files-and-fonts/advanced-font-effects.md`. A reader working in code had no signpost from the tool page to that path.

## Notes

- Tool/code doc split respected: the addition is a pointer (info hint), not a C# sample, so the tool page stays free of runtime API content.
- Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
