### PR TITLE
Fix Sprite SourceFile error printing 4x on screen selection (#3212)

### DIFF
--- a/Gum/Wireframe/WireframeObjectManager.cs
+++ b/Gum/Wireframe/WireframeObjectManager.cs
@@ -188,14 +188,7 @@ public partial class WireframeObjectManager : IWireframeObjectManager
 
                     if(RootGue != null)
                     {
-                        // Always set default first, then if the selected state is not the default, then apply that after:
-                        RootGue.SetVariablesRecursively(elementSave, elementSave.DefaultState);
-                        var selectedState = _selectedState.SelectedStateSave;
-                        if(selectedState != null && selectedState != elementSave.DefaultState)
-                        {
-                            RootGue.ApplyState(selectedState);
-                        }
-
+                        ApplySelectedStateAfterCreation(RootGue, elementSave);
 
                         AddAllIpsos(RootGue);
                     }
@@ -233,6 +226,24 @@ public partial class WireframeObjectManager : IWireframeObjectManager
         }
         ElementShowing = elementSave;
 
+    }
+
+    /// <summary>
+    /// Applies the selected state to a freshly created wireframe root. The default state was
+    /// already applied by <c>ToGraphicalUiElement</c> (SetInitialState) inside
+    /// CreateGraphicalUiElement, so it must not be applied a second time here.
+    /// </summary>
+    internal void ApplySelectedStateAfterCreation(GraphicalUiElement rootGue, ElementSave elementSave)
+    {
+        // The default state was already applied by ToGraphicalUiElement (SetInitialState) inside
+        // CreateGraphicalUiElement above, so it must NOT be re-applied here — doing so applied every
+        // default-state variable twice per rebuild (issue #3212). Only the selected state needs
+        // applying, and only when it differs from the default.
+        var selectedState = _selectedState.SelectedStateSave;
+        if (selectedState != null && selectedState != elementSave.DefaultState)
+        {
+            rootGue.ApplyState(selectedState);
+        }
     }
 
 

--- a/Tool/EditorTabPlugin_XNA/MainEditorTabPlugin.cs
+++ b/Tool/EditorTabPlugin_XNA/MainEditorTabPlugin.cs
@@ -141,6 +141,10 @@ internal class MainEditorTabPlugin : PriorityPlugin, IRecipient<UiBaseFontSizeCh
     private readonly IVariableInCategoryPropagationLogic _variableInCategoryPropagationLogic;
     private readonly IWireframeObjectManager _wireframeObjectManager;
 
+    // Suppresses the redundant second wireframe rebuild when selecting an element forces its
+    // default state (state event rebuilds) and then fires the element event for the same element.
+    private readonly WireframeRefreshCoordinator _wireframeRefreshCoordinator = new();
+
 
     // This is used to punch through the selected and go back up to the top. More info here:
     // https://github.com/vchelaru/Gum/issues/1810
@@ -714,11 +718,18 @@ internal class MainEditorTabPlugin : PriorityPlugin, IRecipient<UiBaseFontSizeCh
         }
     }
 
-    // todo - When a new element is selected, a new state is selected too
-    // need to only handle this 1 time. Currently there is a double-refresh
+    // When a new element is selected, its default state is selected too, so both
+    // HandleStateSelected and HandleElementSelected fire in one cascade. The redundant second
+    // rebuild is now suppressed via _wireframeRefreshCoordinator (issue #3212).
     private void HandleElementSelected(ElementSave save)
     {
-        _wireframeObjectManager.RefreshAll(forceLayout: true);
+        // Selecting an element forces its default state first, so HandleStateSelected has already
+        // rebuilt the wireframe for this element earlier in the same synchronous cascade. Skip the
+        // redundant rebuild here, but still refresh the selection visuals.
+        if (_wireframeRefreshCoordinator.ShouldRebuildOnElementSelected(save))
+        {
+            _wireframeObjectManager.RefreshAll(forceLayout: true);
+        }
 
         _selectionManager.Refresh();
 
@@ -1351,6 +1362,10 @@ internal class MainEditorTabPlugin : PriorityPlugin, IRecipient<UiBaseFontSizeCh
     private void HandleStateSelected(StateSave? save)
     {
         _wireframeObjectManager.RefreshAll(forceLayout: true);
+        // Record that this rebuild happened for the current element so the ElementSelected event
+        // that follows in the same cascade (when an element is selected) can skip its redundant
+        // rebuild. See WireframeRefreshCoordinator.
+        _wireframeRefreshCoordinator.OnStateRebuild(_selectedState.SelectedElement);
     }
 
     private void wireframeControl1_MouseDown(object? sender, MouseEventArgs e)

--- a/Tool/EditorTabPlugin_XNA/Properties/AssemblyInfo.cs
+++ b/Tool/EditorTabPlugin_XNA/Properties/AssemblyInfo.cs
@@ -2,6 +2,9 @@
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
+// Exposes internal types (e.g. WireframeRefreshCoordinator) to the tool unit test project.
+[assembly: InternalsVisibleTo("GumToolUnitTests")]
+
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.

--- a/Tool/EditorTabPlugin_XNA/WireframeRefreshCoordinator.cs
+++ b/Tool/EditorTabPlugin_XNA/WireframeRefreshCoordinator.cs
@@ -1,0 +1,48 @@
+using Gum.DataTypes;
+
+namespace Gum.Plugins.InternalPlugins.EditorTab;
+
+/// <summary>
+/// Coordinates the synchronous selection cascade between the state and element events for the
+/// wireframe. Selecting an element from the tree forces its default state first, so the cascade
+/// fires the state event (which rebuilds the wireframe) and then the element event for the same
+/// element. The element event's rebuild is therefore redundant and can be skipped — but only when
+/// the cascade was for the same element that the state rebuild just ran for. A standalone state
+/// rebuild for element A must not suppress a genuine rebuild when element B is later selected
+/// (mirrors the variable grid's issue #2615 guard via <see cref="VariableGrid.VariableGridSelectionCoordinator"/>).
+/// </summary>
+internal class WireframeRefreshCoordinator
+{
+    private bool _hasPendingStateRebuild;
+    private ElementSave? _elementFromStateRebuild;
+
+    /// <summary>
+    /// Records that the state event just rebuilt the wireframe for <paramref name="currentElement"/>.
+    /// Call this after the state-driven rebuild so the element event that follows in the same
+    /// cascade can skip its redundant rebuild.
+    /// </summary>
+    public void OnStateRebuild(ElementSave? currentElement)
+    {
+        _hasPendingStateRebuild = true;
+        _elementFromStateRebuild = currentElement;
+    }
+
+    /// <summary>
+    /// Returns <c>false</c> when the immediately-preceding state rebuild in this cascade already
+    /// rebuilt the wireframe for <paramref name="newElement"/>, meaning the element event should
+    /// skip its rebuild. Consumes the pending state rebuild so it only suppresses one element event.
+    /// </summary>
+    public bool ShouldRebuildOnElementSelected(ElementSave? newElement)
+    {
+        var skip = _hasPendingStateRebuild && newElement == _elementFromStateRebuild;
+        _hasPendingStateRebuild = false;
+        _elementFromStateRebuild = null;
+        return !skip;
+    }
+
+    public void Reset()
+    {
+        _hasPendingStateRebuild = false;
+        _elementFromStateRebuild = null;
+    }
+}

--- a/Tool/Tests/GumToolUnitTests/Plugins/InternalPlugins/EditorTab/WireframeRefreshCoordinatorTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/InternalPlugins/EditorTab/WireframeRefreshCoordinatorTests.cs
@@ -1,0 +1,66 @@
+using Gum.DataTypes;
+using Gum.Plugins.InternalPlugins.EditorTab;
+using Shouldly;
+using Xunit;
+
+namespace GumToolUnitTests.Plugins.InternalPlugins.EditorTab;
+
+public class WireframeRefreshCoordinatorTests : BaseTestClass
+{
+    private readonly WireframeRefreshCoordinator _coordinator = new();
+
+    [Fact]
+    public void ShouldRebuildOnElementSelected_consumes_pending_state_rebuild()
+    {
+        var element = new ScreenSave();
+        _coordinator.OnStateRebuild(element);
+
+        _coordinator.ShouldRebuildOnElementSelected(element).ShouldBeFalse();
+        // Second call: the pending state rebuild has been consumed, so a later element
+        // selection (a genuine new cascade) must rebuild.
+        _coordinator.ShouldRebuildOnElementSelected(element).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void ShouldRebuildOnElementSelected_returns_false_when_state_cascade_was_for_same_element()
+    {
+        // Selecting an element forces its default state first (HandleStateSelected rebuilds the
+        // wireframe), then fires ElementSelected for the same element. The second rebuild is
+        // redundant and must be skipped.
+        var element = new ScreenSave();
+        _coordinator.OnStateRebuild(element);
+
+        _coordinator.ShouldRebuildOnElementSelected(element).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ShouldRebuildOnElementSelected_returns_true_when_no_state_cascade()
+    {
+        var element = new ScreenSave();
+
+        _coordinator.ShouldRebuildOnElementSelected(element).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void ShouldRebuildOnElementSelected_returns_true_when_state_rebuild_was_for_different_element()
+    {
+        // Mirrors the variable grid's issue #2615 guard: a state rebuild recorded for element A
+        // must not suppress a genuine rebuild when element B is selected.
+        var elementA = new ScreenSave();
+        var elementB = new ScreenSave();
+        _coordinator.OnStateRebuild(elementA);
+
+        _coordinator.ShouldRebuildOnElementSelected(elementB).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Reset_clears_pending_state_rebuild()
+    {
+        var element = new ScreenSave();
+        _coordinator.OnStateRebuild(element);
+
+        _coordinator.Reset();
+
+        _coordinator.ShouldRebuildOnElementSelected(element).ShouldBeTrue();
+    }
+}

--- a/Tool/Tests/GumToolUnitTests/ToolStates/SelectedStateTests.cs
+++ b/Tool/Tests/GumToolUnitTests/ToolStates/SelectedStateTests.cs
@@ -73,6 +73,31 @@ public class SelectedStateTests : BaseTestClass
     }
 
     [Fact]
+    public void SelectedElement_FiresStateSelectedBeforeElementSelected()
+    {
+        // WireframeRefreshCoordinator (issue #3212) relies on the state event firing BEFORE the
+        // element event when an element is selected: HandleStateSelected rebuilds the wireframe and
+        // records the element, then HandleElementSelected skips its redundant rebuild for that same
+        // element. If this cascade order is ever reversed, the element rebuild would no longer be
+        // suppressed and the double-rebuild (and duplicate missing-file errors) would silently return.
+        ScreenSave screen = CreateScreen("TestScreen");
+        var invocationOrder = new List<string>();
+        _pluginManager
+            .Setup(p => p.ReactToStateSaveSelected(It.IsAny<StateSave>()))
+            .Callback(() => invocationOrder.Add(nameof(PluginManager.ReactToStateSaveSelected)));
+        _pluginManager
+            .Setup(p => p.ElementSelected(It.IsAny<ElementSave>()))
+            .Callback(() => invocationOrder.Add(nameof(PluginManager.ElementSelected)));
+
+        _selectedState.SelectedElement = screen;
+
+        invocationOrder.ShouldContain(nameof(PluginManager.ReactToStateSaveSelected));
+        invocationOrder.ShouldContain(nameof(PluginManager.ElementSelected));
+        invocationOrder.IndexOf(nameof(PluginManager.ReactToStateSaveSelected))
+            .ShouldBeLessThan(invocationOrder.IndexOf(nameof(PluginManager.ElementSelected)));
+    }
+
+    [Fact]
     public void SelectedElement_SetWhileNoInstanceSelected_DoesNotFireInstanceSelected()
     {
         // The new InstanceSelected fire-on-silent-clear should only trigger when an

--- a/Tool/Tests/GumToolUnitTests/Wireframe/WireframeObjectManagerStateApplicationTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Wireframe/WireframeObjectManagerStateApplicationTests.cs
@@ -1,0 +1,82 @@
+using Gum.Commands;
+using Gum.DataTypes;
+using Gum.DataTypes.Variables;
+using Gum.Localization;
+using Gum.Managers;
+using Gum.Plugins;
+using Gum.Services.Dialogs;
+using Gum.Services.Fonts;
+using Gum.ToolStates;
+using Gum.Wireframe;
+using Moq;
+using Shouldly;
+using Xunit;
+
+namespace GumToolUnitTests.Wireframe;
+
+/// <summary>
+/// Guards against the default state being applied twice per wireframe rebuild. The GUE returned by
+/// CreateGraphicalUiElement has already had its default state applied (ToGraphicalUiElement calls
+/// SetInitialState), so RefreshAll's post-creation step must not re-apply it. Re-applying it pushed
+/// every default-state variable to the renderable twice — e.g. a missing Sprite SourceFile reported
+/// its error twice per rebuild (issue #3212).
+/// </summary>
+public class WireframeObjectManagerStateApplicationTests : BaseTestClass
+{
+    private sealed class CountingGue : GraphicalUiElement
+    {
+        public int ApplyStateCount { get; private set; }
+
+        // Only the call count matters here; skip base application to keep the bare GUE robust.
+        public override void ApplyState(StateSave state) => ApplyStateCount++;
+    }
+
+    private readonly Mock<ISelectedState> _selectedState = new();
+    private readonly WireframeObjectManager _wireframeObjectManager;
+    private readonly ScreenSave _screen;
+    private readonly StateSave _defaultState;
+
+    public WireframeObjectManagerStateApplicationTests()
+    {
+        _screen = new ScreenSave { Name = "TestScreen" };
+        _defaultState = new StateSave { Name = "Default", ParentContainer = _screen };
+        _screen.States.Add(_defaultState);
+
+        GumProjectSave project = new();
+        project.Screens.Add(_screen);
+        ObjectFinder.Self.GumProjectSave = project;
+
+        _wireframeObjectManager = new WireframeObjectManager(
+            Mock.Of<IFontManager>(),
+            _selectedState.Object,
+            Mock.Of<IDialogService>(),
+            Mock.Of<IGuiCommands>(),
+            new LocalizationService(),
+            new Mock<PluginManager> { CallBase = false }.Object,
+            Mock.Of<IProjectState>());
+    }
+
+    [Fact]
+    public void ApplySelectedStateAfterCreation_AppliesSelectedNonDefaultStateOnce()
+    {
+        StateSave nonDefaultState = new() { Name = "Highlighted", ParentContainer = _screen };
+        _selectedState.Setup(x => x.SelectedStateSave).Returns(nonDefaultState);
+        CountingGue gue = new();
+
+        _wireframeObjectManager.ApplySelectedStateAfterCreation(gue, _screen);
+
+        // Only the selected non-default state is applied; the default is not re-applied.
+        gue.ApplyStateCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public void ApplySelectedStateAfterCreation_DoesNotReapplyDefaultState()
+    {
+        _selectedState.Setup(x => x.SelectedStateSave).Returns(_defaultState);
+        CountingGue gue = new();
+
+        _wireframeObjectManager.ApplySelectedStateAfterCreation(gue, _screen);
+
+        gue.ApplyStateCount.ShouldBe(0);
+    }
+}


### PR DESCRIPTION
Closes #3212.

## Problem

Selecting a Screen containing a Sprite whose `SourceFile` points at a missing file printed the same `Error setting SourceFile on Sprite …` block **4 times** in the Output window for a single selection.

## Root cause — two independent redundancies multiplied

`4 errors = 2 rebuilds × 2 applies-per-rebuild`.

**Factor A — redundant wireframe rebuilds per selection.** Selecting an element forces its default state first (`HandleStateSelected` → `RefreshAll(forceLayout: true)`) and then fires `ElementSelected` for the same element (`HandleElementSelected` → `RefreshAll(forceLayout: true)`). Two full rebuilds. This is the long-standing double-refresh the code already had a `// todo` for; the variable grid guards the analogous case with `VariableGridSelectionCoordinator`, but the wireframe had no equivalent.

**Factor B — redundant default-state apply per rebuild.** `WireframeObjectManager.RefreshAll` applied the default state via `SetVariablesRecursively(elementSave, DefaultState)` *after* `CreateGraphicalUiElement` — but `ToGraphicalUiElement` already applies it via `SetInitialState`, which **is** `SetVariablesRecursively(elementSave, DefaultState)` (same method, same args). So every default-state variable was pushed to the renderable twice per rebuild.

The two multiply: 2 × 2 = 4.

## Fix

- **Factor A:** new `WireframeRefreshCoordinator` (a pure pairing guard mirroring `VariableGridSelectionCoordinator`). `HandleStateSelected` records the element it rebuilt for; `HandleElementSelected` skips its rebuild when the cascade just rebuilt for that same element. Selection visuals still refresh.
- **Factor B:** extracted `ApplySelectedStateAfterCreation` and removed the redundant default re-apply. Only the selected state is applied, and only when it differs from the default. Variable references for the default state are still applied once (via `SetInitialState`), so behavior is preserved — and the second apply no longer clobbers post-creation Forms state.

Net: **4 errors → 1**, plus half the per-rebuild work on every selection (not just when a file is missing).

## Tests (TDD)

- `WireframeObjectManagerStateApplicationTests` (Factor B) was written **red first** — it asserted the default reaches the GUE once but observed `2` (and selected-state `2` instead of `1`), directly reproducing the double-apply — then went green after the one-line deletion.
- `WireframeRefreshCoordinatorTests` (Factor A) — 5 isolated tests of the pairing logic.
- `SelectedStateTests.SelectedElement_FiresStateSelectedBeforeElementSelected` — guards the load-bearing cascade order (`ReactToStateSaveSelected` before `ElementSelected`) the coordinator depends on; a reorder would otherwise silently restore the double-rebuild.
- Full `GumToolUnitTests` suite: **897 passed, 0 failed**.

Verified by hand in the tool: the missing-file error now prints once on screen selection, and rendering / element switching / state switching are unaffected.

## Bundled

- Added `[assembly: InternalsVisibleTo("GumToolUnitTests")]` to `EditorTabPlugin_XNA` so the new coordinator is unit-testable.
- Removed the stale `// todo … double-refresh` comment this resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
