### PR TITLE
Fix Forms Grid layout storm: skip rebuild on resize for plain Auto rows (#3205)

### DIFF
--- a/MonoGameGum.Tests/Forms/GridTests.cs
+++ b/MonoGameGum.Tests/Forms/GridTests.cs
@@ -976,6 +976,30 @@ public class GridTests : BaseTestClass
     }
 
     [Fact]
+    public void AutoRowWithMaxHeight_ShouldStillClamp_WhenChildResizes()
+    {
+        Grid grid = new Grid();
+        grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto, MaxHeight = 100 });
+        grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+
+        Panel child = new Panel();
+        child.Width = 50;
+        child.WidthUnits = DimensionUnitType.Absolute;
+        child.Height = 40;
+        child.HeightUnits = DimensionUnitType.Absolute;
+        grid.AddChild(child, row: 0, column: 0);
+
+        // Grow the child beyond MaxHeight via a resize. An Auto row with a Min/MaxHeight still
+        // relies on the SizeChanged-driven refresh to re-run ApplyMinMaxAutoRowHeights, so the
+        // guard that skips plain Auto rows must NOT skip this case.
+        child.Height = 200;
+
+        GraphicalUiElement rowContainer = (GraphicalUiElement)grid.Visual.Children[0];
+        rowContainer.HeightUnits.ShouldBe(DimensionUnitType.Absolute);
+        rowContainer.Height.ShouldBe(100f);
+    }
+
+    [Fact]
     public void CellContainer_InAbsoluteRow_ShouldHaveRelativeToParentHeight()
     {
         Grid grid = new Grid();
@@ -1223,6 +1247,78 @@ public class GridTests : BaseTestClass
         GridLength length = new GridLength(2, GridUnitType.Star);
 
         length.IsStar.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void PlainAutoRow_ResizeCost_ShouldMatchNonAutoRow_WhenChildResizes()
+    {
+        // A plain Auto row must rely on Gum's native RelativeToChildren propagation exactly like a
+        // Star row — neither should rebuild + reparent the whole subtree on a child resize. Compare
+        // the layout-call cost of the two; before the fix the Auto row's storm dwarfed the Star
+        // row's because OnChildSizeChanged forced a full RefreshLayout for any Auto row.
+        int autoRowDelta = MeasureNestedChildResizeLayoutCalls(useAutoRow: true);
+        int starRowDelta = MeasureNestedChildResizeLayoutCalls(useAutoRow: false);
+
+        autoRowDelta.ShouldBeLessThanOrEqualTo(starRowDelta + 4);
+    }
+
+    [Fact]
+    public void PlainAutoRow_ShouldNotRebuildCells_WhenChildSizeChanges()
+    {
+        Grid grid = new Grid();
+        grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
+        grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+
+        Panel child = new Panel();
+        child.Width = 50;
+        child.WidthUnits = DimensionUnitType.Absolute;
+        child.Height = 30;
+        child.HeightUnits = DimensionUnitType.Absolute;
+        grid.AddChild(child, row: 0, column: 0);
+
+        GraphicalUiElement rowContainer = (GraphicalUiElement)grid.Visual.Children[0];
+        GraphicalUiElement cellBefore = (GraphicalUiElement)rowContainer.Children[0];
+
+        // A plain Auto row (no Min/Max) is handled natively by Gum's RelativeToChildren
+        // propagation, so a child resize must not trigger a full Grid rebuild. RefreshLayoutCore
+        // recreates every cell container, so an unchanged cell-container instance proves no rebuild.
+        child.Height = 80;
+
+        GraphicalUiElement rowContainerAfter = (GraphicalUiElement)grid.Visual.Children[0];
+        GraphicalUiElement cellAfter = (GraphicalUiElement)rowContainerAfter.Children[0];
+        cellAfter.ShouldBeSameAs(cellBefore);
+    }
+
+    private static int MeasureNestedChildResizeLayoutCalls(bool useAutoRow)
+    {
+        Grid grid = new Grid();
+        grid.RowDefinitions.Add(new RowDefinition
+        {
+            Height = useAutoRow ? GridLength.Auto : new GridLength(1, GridUnitType.Star)
+        });
+        grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+
+        // A non-trivial nested subtree: re-parenting it (which a full rebuild does) forces a full
+        // layout pass over the whole subtree, amplifying the cost of an unnecessary refresh.
+        Panel outer = new Panel();
+        outer.Width = 100;
+        outer.WidthUnits = DimensionUnitType.Absolute;
+        outer.Height = 100;
+        outer.HeightUnits = DimensionUnitType.Absolute;
+        for (int i = 0; i < 12; i++)
+        {
+            Panel leaf = new Panel();
+            leaf.Width = 40;
+            leaf.WidthUnits = DimensionUnitType.Absolute;
+            leaf.Height = 10;
+            leaf.HeightUnits = DimensionUnitType.Absolute;
+            outer.AddChild(leaf);
+        }
+        grid.AddChild(outer, row: 0, column: 0);
+
+        int before = GraphicalUiElement.UpdateLayoutCallCount;
+        outer.Width = 123;
+        return GraphicalUiElement.UpdateLayoutCallCount - before;
     }
 
     [Fact]

--- a/MonoGameGum/Forms/Controls/Grid.cs
+++ b/MonoGameGum/Forms/Controls/Grid.cs
@@ -518,17 +518,22 @@ public class Grid :
             }
         }
 
-        bool hasAutoRow = false;
+        // A plain Auto row is RelativeToChildren, and Gum propagates RelativeToChildren height
+        // changes natively, so a child resize needs no refresh. The only resize-driven work an
+        // Auto row requires is re-applying Min/MaxHeight clamping (ApplyMinMaxAutoRowHeights);
+        // this guard mirrors that method's early-out so plain Auto rows skip the full rebuild.
+        bool needsRefreshForAutoRow = false;
         foreach (RowDefinition row in RowDefinitions)
         {
-            if (row.Height.IsAuto)
+            if (row.Height.IsAuto &&
+                (row.MinHeight > 0f || !float.IsPositiveInfinity(row.MaxHeight)))
             {
-                hasAutoRow = true;
+                needsRefreshForAutoRow = true;
                 break;
             }
         }
 
-        if (hasAutoColumn || hasAutoRow)
+        if (hasAutoColumn || needsRefreshForAutoRow)
         {
             RefreshLayout();
         }


### PR DESCRIPTION
## What

Fixes the layout storm in the experimental Forms `Grid` control (`MonoGameGum/Forms/Controls/Grid.cs`) where wrapping a non-trivial subtree in a `Grid` cell could freeze for 1–2 seconds on a single add.

Closes #3205.

## Root cause

`OnChildSizeChanged` forced a full `RefreshLayout()` — which tears down and recreates **all** cell containers and re-parents **every** child — whenever the grid had *any* `Auto` row or column. For a **plain `Auto` row** (no `Min`/`MaxHeight`) this is pure waste: the row container is `RelativeToChildren`, and Gum already propagates `RelativeToChildren` height changes natively. So every `SizeChanged` on a nested subtree rebuilt + re-parented the whole subtree, and `RelativeToChildren`/`Star` coupling turned that into a cascade.

## Fix

Guard `OnChildSizeChanged` so an `Auto` *row* only forces a refresh when it has a `Min`/`MaxHeight` to re-clamp (mirroring `ApplyMinMaxAutoRowHeights`' own early-out). `Auto` *columns* still refresh — their unified width genuinely must be recomputed on resize.

This is fix #1 from the issue (the lowest-risk, ~2-line guard). The structural rebuild-vs-reflow split (#2) and dirty-flag coalescing (#3) are deliberately left as optional follow-ups; #1 resolves the freeze on its own. The core `GraphicalUiElement` layout engine is untouched, so there is **no general-case layout perf change** — the change is confined to this one experimental control.

## Tests

All existing `GridTests` pass; full `MonoGameGum.Tests` suite green (1749 passed). Added 3 tests:

- **`PlainAutoRow_ShouldNotRebuildCells_WhenChildSizeChanges`** — deterministic regression: the cell-container instance must survive a child resize (a rebuild recreates it). Red before the fix, green after.
- **`PlainAutoRow_ResizeCost_ShouldMatchNonAutoRow_WhenChildResizes`** — the acceptance criterion from the issue, as a robust comparison rather than a wall-clock assertion: a child resize in a plain `Auto`-row grid must cost about the same in `UpdateLayoutCallCount` as the same resize in a `Star`-row grid. Before the fix the Auto-row delta was **88** vs the Star-row baseline of **13**; after, they match.
- **`AutoRowWithMaxHeight_ShouldStillClamp_WhenChildResizes`** — guards the path the fix deliberately preserves: an `Auto` row *with* a `MaxHeight` still clamps on a resize-driven refresh. Green before and after.

## Manual verification

Not done separately and not needed here: the reported symptom was purely a layout storm, and the comparative layout-call-count test measures exactly that property while the cell-identity test deterministically proves no rebuild fires. There is no visual/runtime aspect the unit tests don't already cover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
