### PR TITLE
Docs: make code-only Forms tutorial cross-platform (MonoGame + Raylib) (#3178)

### DIFF
--- a/.claude/skills/gum-docs-writing/SKILL.md
+++ b/.claude/skills/gum-docs-writing/SKILL.md
@@ -158,6 +158,8 @@ protected override void Initialize()
 
 **Platform-agnostic by default:** prefer `// Initialize` over MonoGame-specific phrasing unless the page is explicitly MonoGame-only. This supports Raylib and other runtimes.
 
+**Irreducible per-platform syntax → tabs, don't ask.** First try to collapse a sample to a single platform-neutral form. When the syntax genuinely *cannot* collapse — most often because a member's **type** differs per backend (e.g. `KeyCombo.PushedKey` / `KeyEventArgs.Key` is XNA `Microsoft.Xna.Framework.Input.Keys` on MonoGame but `Gum.Forms.Input.Keys` on Raylib, same names/values but distinct types; or a host skeleton that's a `Game` subclass vs a `Program.Main` loop) — wrap just those blocks in GitBook `{% tabs %}` with one `{% tab %}` per platform (e.g. `MonoGame` / `Raylib`). This is the standard, expected treatment for irreducible divergence; use it without asking. Keep the surrounding prose shared above/below the tabs — only the code that truly differs goes inside.
+
 ## XnaFiddle Links
 
 For adding or updating XnaFiddle interactive links, see [xnafiddle.md](xnafiddle.md).

--- a/.claude/skills/gum-service/SKILL.md
+++ b/.claude/skills/gum-service/SKILL.md
@@ -9,6 +9,8 @@ description: GumService — runtime entry point for MonoGame/Raylib/KNI/FNA. Tri
 
 `GumService` is the runtime-facing API that game developers use to initialize, update, and draw Gum UI. It lives in `MonoGameGum/GumService.cs` (compiled for XNALIKE, RAYLIB via `#if`) under the `Gum` namespace (since issue #3119 / syntax version 3). Legacy `MonoGameGum.GumService` / `RaylibGum.GumService` names are permanent `[Obsolete]` subclass shims in `MonoGameGum/GumServiceCompat.cs` (linked into `RaylibGum.csproj`). `WindowZoomMode`, `GumHotReloadManager`, and related hot-reload types also live in `namespace Gum`.
 
+**The soft migration is intentional and finished — do not flag it as incomplete.** What matters is what the **user types**: new code uses `using Gum;` and types the service as `GumService` (= `Gum.GumService`) with no `using MonoGameGum;` / `using RaylibGum;` — that is 100% future-proof. `Gum.GumService.Default` is *deliberately* typed as the derived `[Obsolete]` shim so legacy `using MonoGameGum;` / `using RaylibGum;` declarations keep compiling; the user never names the obsolete type, so the modern path is warning-free. Do **not** propose "completing" this by retyping `Default` to `Gum.GumService` or removing the shims — that would break back-compat and is not planned (stable for the foreseeable future). The fact that `Default`'s declared type is an obsolete shim is not a problem and must not be raised as a follow-up.
+
 **Not the CLI.** `Gum.Cli` / `Gum.ProjectServices` are separate tools for headless project validation and codegen.
 
 ## Lifecycle

--- a/docs/code/getting-started/setup/adding-initializing-gum/raylib-raylib-cs.md
+++ b/docs/code/getting-started/setup/adding-initializing-gum/raylib-raylib-cs.md
@@ -131,13 +131,3 @@ public static void Main()
 ```
 
 <figure><img src="../../../../.gitbook/assets/10_07 36 10.gif" alt=""><figcaption><p>Button in raylib responding to clicks</p></figcaption></figure>
-
-{% hint style="warning" %}
-As of August 2025 the raylib implementation is missing a few controls. Specifically the controls that are not present are:
-
-* PasswordBox
-
-Additionally, raylib Gum does not currently read input from keyboards or gamepads.
-
-If your game needs these capabilities, or if you would like to help contribute to develop them, please post on our [GitHub issues](https://github.com/vchelaru/Gum/issues) or [join our Discord](https://discord.gg/uQSam6w36d).
-{% endhint %}

--- a/docs/code/getting-started/setup/adding-initializing-gum/raylib-raylib-cs.md
+++ b/docs/code/getting-started/setup/adding-initializing-gum/raylib-raylib-cs.md
@@ -77,11 +77,11 @@ public class Program
 </strong>
         while (!Raylib.WindowShouldClose())
         {
+<strong>            GumUI.Update(Raylib.GetTime());
+</strong>
             Raylib.BeginDrawing();
             Raylib.ClearBackground(Raylib_cs.Color.SkyBlue);
-
-<strong>            GumUI.Update(Raylib.GetTime());
-</strong><strong>            GumUI.Draw();
+<strong>            GumUI.Draw();
 </strong>
             Raylib.EndDrawing();
         }

--- a/docs/code/getting-started/tutorials/code-only-gum-forms-tutorial/creating-new-controls.md
+++ b/docs/code/getting-started/tutorials/code-only-gum-forms-tutorial/creating-new-controls.md
@@ -20,7 +20,7 @@ using Gum.Forms.Controls;
 using Gum.GueDeriving;
 using Gum.Forms.DefaultVisuals;
 
-namespace MonoGameAndGum.Components;
+namespace MyGame.Components;
 
 // By inheriting from Panel we get a
 // Visual object automatically instead
@@ -200,18 +200,14 @@ For more information on working with NineSliceRuntime, see the [NineSliceRuntime
 
 `TextInputDialog` includes a `Label` named `prompt`. This is defined at class scope so that the prompt can be assigned per-instance.
 
-For example, we could change our code in Game1 to set the prompt text as shown in the following code block:
+For example, we could set the prompt text in our initialization code as shown in the following code block:
 
 ```csharp
-protected override void Initialize()
-{
-    GumUi.Initialize(this);
-
-    var dialog = new TextInputDialog();
-    dialog.AddToRoot();
-    dialog.Anchor(Gum.Wireframe.Anchor.Center);
-    dialog.PromptText = "Enter character name:";
-}
+// Initialize
+var dialog = new TextInputDialog();
+dialog.AddToRoot();
+dialog.Anchor(Gum.Wireframe.Anchor.Center);
+dialog.PromptText = "Enter character name:";
 ```
 
 [Try on XnaFiddle.NET](https://xnafiddle.net/#code=H4sIAAAAAAAAA51V3U_bMBB_719h9SmVJgs2nqiYVJpR0MZAtMBeTXJNrLp25DgtH-J_39lJEydNxVhfGt_nz3fn3xU5lwm5VlLN2BpmxXo8KJwIP-mF0ut8T0CnShqtRK3xvOmsgBA036B83zGEJSuEeeB5wUROH77VEXikVa6Whv6RjF5oDLZVevWBms40y1IeIZBBVjwJHpFIsDwnC3g2VzIrTMiZUAk5JbdMghi8DQj-frEnECTTap0Z9LSiyjs32qa7dSobxClLL_tLwJCz75UrtQbjWpfv6cgZ2TBRQGnz3srUQRiMOplMynP6yGOTYpSvJ-O24hJ4kppKU6s2TJMnFq0SrQoZo1bClvzmEuaYEe4KafgaglEn1iSOpykXcdC4eiaNkIYqWgW2l49cw9L2wInoBRei38NestCASObmRWBl6SQyfAP2BHSeaW5gngKYXu9JlomXuWEGgj73-mLU9XbUKQSXErTTVIXASNHKCfwSNGaIh0W2-2fk-KjXYCKjVOlOCUohnYI0oA_Wtoni4yxnpcLnpvIAtDpO6eEZtcdt-MOiIAZPp8NOQazwXD1X2Rbl6aN8lZN_r1JSz-bRvqp83qXFveQmRzNbtJAZtnjJAHkAB1HmXEmrtiJ6B4LZ3i7ULdNYy-5YF8Yo-al2NnPd-Ppj2ki9zp_0G9xojpgQoJJo5J3opdL8FemQiQ5itTp3ASq45SE4AKDGuvPy7Haiusc3P7utjZiMQPxPPt_Ts_XFdd6pEw53bPbe4Vy7AI6Rae1_RbQ7eg5hg-_0mkmW4HQmNWk7m2I9B2319vP-ynJoI9ttjDZNu1TBiLzVsapb9yYM7FMcjWsC1spAZCAmagNa8xjIRvGYXOEoIhfzV9gjYweMegY24hfS3mYPoO1E41LzCmm7E5c7qHl3Ld5vbEs725uFulPK9Ok-w0CVT7PMGoKIUqZZZL8kRjgd-vybg3_TUXt5HajdfRZbmrZ9WeDTJkn10V_Iyro26mTvV3-AINRs-w_5W_NBpwKYDqZK2PIpLZdCbUGf48r2MJWYXfwuUifcw_k--AsSDKA7VAkAAA)

--- a/docs/code/getting-started/tutorials/code-only-gum-forms-tutorial/forms-controls.md
+++ b/docs/code/getting-started/tutorials/code-only-gum-forms-tutorial/forms-controls.md
@@ -16,7 +16,7 @@ Forms controls are a collection of classes which provide common UI behavior. You
 * StackPanel
 * TextBox
 
-All controls are in the `MonoGameGum.Forms.Controls` namespace.
+All controls are in the `Gum.Forms.Controls` namespace.
 
 {% hint style="info" %}
 Forms naming is based on naming from WPF. If you are familiar with WPF or similar libraries like Avalonia, you may find many of the names and concepts familiar.

--- a/docs/code/getting-started/tutorials/code-only-gum-forms-tutorial/input-in-forms.md
+++ b/docs/code/getting-started/tutorials/code-only-gum-forms-tutorial/input-in-forms.md
@@ -228,6 +228,8 @@ The keyboard's tab and shift+tab keys are used to move focus between forms contr
 
 For example, the following code adds the ability to tab by pressing the up and down arrows on the keyboard.
 
+{% tabs %}
+{% tab title="MonoGame" %}
 ```csharp
 // Initialize
 FrameworkElement.KeyboardsForUiControl.Add(GumService.Default.Keyboard);
@@ -251,6 +253,34 @@ for (int i = 0; i < 3; i++)
     mainPanel.AddChild(button);
 }
 ```
+{% endtab %}
+
+{% tab title="Raylib" %}
+```csharp
+// Initialize
+FrameworkElement.KeyboardsForUiControl.Add(GumService.Default.Keyboard);
+FrameworkElement.TabKeyCombos.Add(new KeyCombo()
+{
+    PushedKey = Gum.Forms.Input.Keys.Down
+});
+FrameworkElement.TabReverseKeyCombos.Add(new KeyCombo()
+{
+    PushedKey = Gum.Forms.Input.Keys.Up
+});
+
+var mainPanel = new StackPanel();
+mainPanel.AddToRoot();
+mainPanel.Spacing = 6;
+for (int i = 0; i < 3; i++)
+{
+    var button = new Button();
+    button.Text = $"Button {i + 1}";
+    if (i == 0) button.IsFocused = true;
+    mainPanel.AddChild(button);
+}
+```
+{% endtab %}
+{% endtabs %}
 [Try on XnaFiddle.NET](https://xnafiddle.net/#snippet=H4sIAAAAAAAACrVSTUvDQBC991cMwUNKZVEED2oP2lopIpR-gIdcNsnELk1myu6mVUv-u5M0bRX06F6GfW_mvWHf7joAwdg9lUVwA96WeF4Dhow3OjefKGiw0RYKbWiiCXPoA-EWZl4nqwYIu7cRHWl1n6ZznjL7Bh9ZXeCW7eoxxwLJq2f8iFnb1I3YLsyAyVtuhkJZYYZ2YxJUQ8x0mZ-af1Wa61j4ARcxu0agXuuAhN2IdhGBnEnplpgKIZu_mMSy48yrV9LqKKnGtC4bO6eGvKWIqr8sp7hB6_A_nBfr1vf7c87WOjH0JgrXwmRsITTkwQhwcSvlDq6k9Hon1zqtuPSeqY3qobk0cdT8nlNzfPfScBYFex52BnpwWUVB22cysYK--HQPM2NJLSkdpjJY_5W280f4g6XJ03A_UFtWQafqfAE2d5mXZgIAAA)
 
 `TabKeyCombos` and `TabReverseKeyCombos` are lists and automatically include tab and shift+tab. You can clear these lists if you would like to prevent the tab key from moving focus.
@@ -259,6 +289,8 @@ Adding a KeyCombo to either of these lists enables navigation with these keys gl
 
 Tabbing on a case by case basis can be performed by subscribing to individual control events as shown in the following code. Only the `Button` instances have left/right key tabbing while the `Slider` does not tab with left/right so that it can use the arrow keys to change its value:
 
+{% tabs %}
+{% tab title="MonoGame" %}
 ```csharp
 // Initialize
 var mainPanel = new StackPanel();
@@ -287,8 +319,41 @@ void HandleTabKeyDown(object sender, KeyEventArgs args)
         ((FrameworkElement)sender).HandleTab(TabDirection.Up);
     }
 }
-
 ```
+{% endtab %}
+
+{% tab title="Raylib" %}
+```csharp
+// Initialize
+var mainPanel = new StackPanel();
+mainPanel.AddToRoot();
+
+var slider = new Slider();
+mainPanel.AddChild(slider);
+
+var button = new Button();
+button.IsFocused = true;
+button.KeyDown += HandleTabKeyDown;
+mainPanel.AddChild(button);
+
+var button2 = new Button();
+button2.KeyDown += HandleTabKeyDown;
+mainPanel.AddChild(button2);
+
+void HandleTabKeyDown(object sender, KeyEventArgs args)
+{
+    if(args.Key == Gum.Forms.Input.Keys.Right)
+    {
+        ((FrameworkElement)sender).HandleTab(TabDirection.Down);
+    }
+    else if(args.Key == Gum.Forms.Input.Keys.Left)
+    {
+        ((FrameworkElement)sender).HandleTab(TabDirection.Up);
+    }
+}
+```
+{% endtab %}
+{% endtabs %}
 [Try on XnaFiddle.NET](https://xnafiddle.net/#snippet=H4sIAAAAAAAACq2Ry27CMBBF93yFlZWjIi9YtsqC8mhRW6niIXWRjRNPwMUZI9sBtYh_r52kUEG7QbWURL6eO_fEs-8QEk3sQ1VGt8SZCrpBkCid5Ep-glejLTek5BJfOYIiCUHYkZnj-boWaHyX4vGY9YWY66nWrtbHhpew02Y9UlACOvYEH5nmRtixNgs50OiMrk3UI8zAbGUObAgFr9SpOHRKMWBYJQWYb4Z6c5k_WEklaFN6smaVcxpb6329qa2NziaeKK8sCF8R7uF04imGeofkJiGPHIWCOc9a7ffkxnee3PsrundtQq-N0FJc-KjO3iF3xAL6W-gSL4-2fgB9s7SE-1ec4j5F4pcsaBACBUkS8iJzo60uHHtDzo4DZBPcVPVILJvK5cr5BsHdNgmL0vNxx018zI541D9DaTya9FcbSMNPBPeh-YCycAXSMxT_QrTY_OA5RJ1D5wvjsOY0IgMAAA)
 
 <figure><img src="../../../../.gitbook/assets/16_06 37 17.gif" alt=""><figcaption><p>Tabbing with left/right on Button, but using left/right to change Slider value</p></figcaption></figure>

--- a/docs/code/getting-started/tutorials/code-only-gum-forms-tutorial/setup.md
+++ b/docs/code/getting-started/tutorials/code-only-gum-forms-tutorial/setup.md
@@ -10,36 +10,68 @@ This tutorial uses Gum's default visuals to keep the dependency footprint minima
 
 ## Introduction
 
-This tutorial walks you through turning an empty MonoGame project into a code-only Gum project, which acts as a starting point for the rest of the tutorials.
+This tutorial walks you through turning an empty MonoGame or Raylib project into a code-only Gum project, which acts as a starting point for the rest of the tutorials.
 
 This tutorial covers:
 
 * Adding Gum NuGet packages
-* Modifying your Game class to support Gum and Gum Forms
+* Adding the code to initialize, update, and draw Gum
 * Adding your first Gum control (Button)
+
+Everything after you have a root container is identical across MonoGame and Raylib. The only part that differs is the host application skeleton on this Setup page — once Gum is initialized, the rest of the tutorial series is fully shared.
 
 ## Adding Gum NuGet Packages
 
-Before writing any code, we must add the Gum NuGet package. Add the Gum.MonoGame package to your game. For more information see the [Setup page](https://docs.flatredball.com/gum/code/monogame/setup).
+Before writing any code, add the Gum NuGet package for your platform.
 
-Once you are finished, your game project should reference the `Gum.MonoGame` project.
+{% tabs %}
+{% tab title="MonoGame" %}
+Add the `Gum.MonoGame` package to your game. For more information see the [MonoGame/KNI/FNA setup page](../../setup/adding-initializing-gum/monogame-kni-fna/README.md).
+
+Once you are finished, your game project should reference the `Gum.MonoGame` package.
 
 <figure><img src="../../../../.gitbook/assets/NuGetGum.png" alt=""><figcaption><p>Gum.MonoGame NuGet package</p></figcaption></figure>
+{% endtab %}
+
+{% tab title="Raylib" %}
+Add the `Gum.raylib` package to your game ([https://www.nuget.org/packages/Gum.raylib](https://www.nuget.org/packages/Gum.raylib)). For more information see the [raylib setup page](../../setup/adding-initializing-gum/raylib-raylib-cs.md).
+
+Modify csproj:
+
+```xml
+<PackageReference Include="Gum.raylib" />
+```
+
+Or add through the command line:
+
+```bash
+dotnet add package Gum.raylib
+```
+{% endtab %}
+{% endtabs %}
 
 ## Adding Gum to Your Game
 
-Gum requires a few lines of code to get started. A simplified Game class with the required calls would look like the following code:
+Gum requires a few lines of code to get started. The host application skeleton differs by platform — MonoGame uses a `Game` subclass whose `Initialize`/`Update`/`Draw` methods the framework calls for you, while Raylib uses a `Program.Main` with a game loop you own. The Gum calls themselves are the same on both backends: initialize once, then update and draw each frame.
 
+A simplified host with the required calls would look like the following code:
+
+{% tabs %}
+{% tab title="MonoGame" %}
 ```csharp
+using Microsoft.Xna.Framework;
+using Gum;
 using Gum.Forms;
 using Gum.Forms.Controls;
+
+namespace MyGumProject;
 
 public class Game1 : Game
 {
     private GraphicsDeviceManager _graphics;
-    
+
     GumService GumUI => GumService.Default;
-    
+
     public Game1()
     {
         _graphics = new GraphicsDeviceManager(this);
@@ -50,10 +82,10 @@ public class Game1 : Game
     protected override void Initialize()
     {
         GumUI.Initialize(this);
-            
+
         var mainPanel = new StackPanel();
         mainPanel.AddToRoot();
-        
+
         base.Initialize();
     }
 
@@ -71,64 +103,94 @@ public class Game1 : Game
     }
 }
 ```
+{% endtab %}
+
+{% tab title="Raylib" %}
+```csharp
+using Gum;
+using Gum.Forms;
+using Gum.Forms.Controls;
+using Raylib_cs;
+
+namespace MyGumProject;
+
+public class Program
+{
+    static GumService GumUI => GumService.Default;
+
+    // STAThread is required if you deploy using NativeAOT on Windows - See https://github.com/raylib-cs/raylib-cs/issues/301
+    [STAThread]
+    public static void Main()
+    {
+        const int screenWidth = 800;
+        const int screenHeight = 450;
+
+        Raylib.InitWindow(screenWidth, screenHeight, "Gum Sample");
+        Raylib.SetTargetFPS(60);
+
+        // This tells Gum to use the entire screen
+        GumUI.CanvasWidth = screenWidth;
+        GumUI.CanvasHeight = screenHeight;
+
+        GumUI.Initialize();
+
+        var mainPanel = new StackPanel();
+        mainPanel.AddToRoot();
+
+        while (!Raylib.WindowShouldClose())
+        {
+            Raylib.BeginDrawing();
+            Raylib.ClearBackground(Raylib_cs.Color.SkyBlue);
+
+            GumUI.Update(Raylib.GetTime());
+            GumUI.Draw();
+
+            Raylib.EndDrawing();
+        }
+        Raylib.CloseWindow();
+    }
+}
+```
+{% endtab %}
+{% endtabs %}
 
 The code above includes the following sections:
 
-* Initialize - The Initialize method prepares Gum for use. It must be called one time for every Gum project.
-* Once Gum is initialized, we can create controls such as the `StackPanel` which contains all other controls. By calling `AddToRoot`, the `mainPanel` is drawn and receives input. All items added to the `StackPanel` will also be drawn and receive input, so we only need to call `AddToRoot` on the `StackPanel`.
+* Initialize - the initialization code prepares Gum for use. It must be called one time for every Gum project. Once Gum is initialized, we can create controls such as the `StackPanel` which contains all other controls. By calling `AddToRoot`, the `mainPanel` is drawn and receives input. All items added to the `StackPanel` will also be drawn and receive input, so we only need to call `AddToRoot` on the `StackPanel`.
 
 ```csharp
 // Initialize
-GumUI.Initialize(this);
 var mainPanel = new StackPanel();
 mainPanel.AddToRoot();
 ```
 
 * Update - this updates the internal keyboard, mouse, and gamepad instances and applies default behavior to any forms components. For example, if a `Button` is added to the `StackPanel`, this code is responsible for checking if the cursor is overlapping the `Button` and adjusting the highlight/pressed state appropriately.
 
-```csharp
-// Update
-GumUI.Update(gameTime);
-```
+* Draw - this draws all Gum objects to the screen. This does not yet perform any drawing since `StackPanels` are invisible, but we'll be adding controls later in this tutorial.
 
-* Draw - this method draws all Gum objects to the screen. This method does not yet perform any drawing since `StackPanels` are invisible, but we'll be adding controls later in this tutorial.
+We can run our project to see a blank screen filled with the clear color.
 
-```csharp
-// Draw
-GumUI.Draw();
-```
-
-We can run our project to see a blank (cornflower blue) screen.
-
-<figure><img src="../../../../.gitbook/assets/image (2) (1).png" alt=""><figcaption><p>Empty MonoGame project</p></figcaption></figure>
+<figure><img src="../../../../.gitbook/assets/image (2) (1).png" alt=""><figcaption><p>Empty project</p></figcaption></figure>
 
 ### Adding Controls
 
-Now that we have Gum running, we can add controls to our `StackPanel` (`mainPanel`). The following code in Initialize adds a `Button` which responds to being clicked by modifying its `Text` property:
+Now that we have Gum running, we can add controls to our `StackPanel` (`mainPanel`). The following code adds a `Button` which responds to being clicked by modifying its `Text` property. Add it right after `mainPanel` is created:
 
-<pre class="language-csharp"><code class="lang-csharp">protected override void Initialize()
-{
-    GumUI.Initialize(this);
-
-    var mainPanel = new StackPanel();
-    mainPanel.Visual.AddToRoot();
-
-<strong>    // Creates a button instance
-</strong><strong>    var button = new Button();
-</strong><strong>    // Adds the button as a child so that it is drawn and has its
-</strong><strong>    // events raised
-</strong><strong>    mainPanel.AddChild(button);
-</strong><strong>    // Initial button text before being clicked
-</strong><strong>    button.Text = "Click Me";
-</strong><strong>    // Makes the button wider so the text fits
-</strong><strong>    button.Width = 350;
-</strong><strong>    // Click event can be handled with a lambda
-</strong><strong>    button.Click += (_, _) =>
-</strong><strong>        button.Text = $"Clicked at {System.DateTime.Now}";
-</strong>
-    base.Initialize();
-}
-</code></pre>
+```csharp
+// Initialize
+// Creates a button instance
+var button = new Button();
+// Adds the button as a child so that it is drawn and has its
+// events raised
+mainPanel.AddChild(button);
+// Initial button text before being clicked
+button.Text = "Click Me";
+// Makes the button wider so the text fits
+button.Width = 350;
+// Click event can be handled with a lambda
+button.Click += (_, _) =>
+    button.Text = $"Clicked at {System.DateTime.Now}";
+```
 
 [Try on XnaFiddle.NET](https://xnafiddle.net/#snippet=H4sIAAAAAAAAA12NSwvCMBCE_8oSPFSQUBQvSg--EA-KaNGLINEsdGmagN34xP9uH6LibWfmm9mHmOVTn4kenzy2BFliUobuKHrirE6QKbJLZdFABBYvsGZ1TCsjaPZ39hPLDeVeGTnQOnYr57iKy4WDZ3b2XR9W4q9adEYJGR3UaBnWl4zxykVz58Ow3R4ZOqYwx1p9oS1pTgqq0w2_Zg1X6DCCYN-CfROiUncm__ONn33UoBge61vOmMmxYowpQ7lwl-f7r3i-AEs5ZmU0AQAA)
 

--- a/docs/code/getting-started/tutorials/code-only-gum-forms-tutorial/setup.md
+++ b/docs/code/getting-started/tutorials/code-only-gum-forms-tutorial/setup.md
@@ -139,12 +139,12 @@ public class Program
 
         while (!Raylib.WindowShouldClose())
         {
+            // Update game/UI state first, then render it.
+            GumUI.Update(Raylib.GetTime());
+
             Raylib.BeginDrawing();
             Raylib.ClearBackground(Raylib_cs.Color.SkyBlue);
-
-            GumUI.Update(Raylib.GetTime());
             GumUI.Draw();
-
             Raylib.EndDrawing();
         }
         Raylib.CloseWindow();


### PR DESCRIPTION
## Summary

Makes the **code-only Gum Forms tutorial** cross-platform (MonoGame + Raylib) instead of MonoGame-only. The `MonoGameGum`→`Gum` namespace unification plus Raylib reaching feature parity (keyboard/gamepad input, PasswordBox) make a single shared tutorial viable — the only real divergence is the host-app skeleton on the Setup page.

Verified the three load-bearing claims against current `main` before writing:
- **Rename is live** — docs/code already resolve `using Gum;` (`Gum.GumService`, `Gum.Forms.Controls`).
- **Raylib PasswordBox** — shared via GumCommon; V3 default visual is ungated and registered for RAYLIB.
- **Raylib keyboard + gamepad** — real implementations (`Keyboard.cs`, `FormsUtilities.UpdateGamepads` `#elif RAYLIB`), wired per-frame.

Both Setup skeletons use the **modern `using Gum;`** service namespace (not the obsolete `using MonoGameGum;` / `using RaylibGum;` shims). Confirmed by proof-by-shipped-build: `FontPlayground.MonoGame` and `FontPlayground.Raylib` already compile that exact pattern, including Raylib using `using Gum;` with no `using RaylibGum;` for the service.

## Changes

- **`setup.md`** — platform tabs (MonoGame / Raylib) for the divergent host skeleton only (NuGet, host class, `Initialize`/`Update`/`Draw`, clear color). Shared prose stays shared; the post-root control code is single-source.
- **`forms-controls.md`** — `MonoGameGum.Forms.Controls` → `Gum.Forms.Controls`.
- **`creating-new-controls.md`** — "in Game1" and `MonoGameAndGum.Components` neutralized; host-method wrapper collapsed to a `// Initialize` snippet.
- **`input-in-forms.md`** — the two tab-key samples wrapped in MonoGame/Raylib tabs, because `KeyCombo.PushedKey` / `KeyEventArgs.Key` are the platform-aliased `Keys` type (XNA `Microsoft.Xna.Framework.Input.Keys` vs `Gum.Forms.Input.Keys`, same names/values, different type — irreducible).
- **`raylib-raylib-cs.md`** — removed the stale caveat ("missing PasswordBox… does not read input from keyboards or gamepads"). Audited nearby raylib pages; no other in-scope stale claims.

## Guidance files (bundled per repo convention)

- **`gum-service` skill** — records that the GumService soft migration is intentional and finished: modern `using Gum;` code is future-proof, and `Default` being typed as the obsolete shim must not be raised as a follow-up.
- **`gum-docs-writing` skill** — use platform tabs for irreducible per-platform syntax (don't ask).

## Out of scope (separate follow-up issues)

- Modernizing the **shipped reference/setup docs** still teaching `using MonoGameGum;` / `using RaylibGum;`.
- A pass on the **Samples/** project code to the `Gum` namespace.

## Verification

Docs-only change. Verified: GitBook `{% tabs %}`/`{% tab %}` balance, code-sample accuracy against source APIs, and the `using Gum;` pattern via shipped CI-built samples. No runtime/visual aspect beyond GitBook rendering.

Closes #3178

🤖 Generated with [Claude Code](https://claude.com/claude-code)
