### PR TITLE
Make Gum.SkiaSharp rendering-only; relocate render-only GumService to a host-owned model (#3218)

### DIFF
--- a/.claude/skills/gum-cross-platform-unification/SKILL.md
+++ b/.claude/skills/gum-cross-platform-unification/SKILL.md
@@ -81,6 +81,13 @@ Either way, the **cross-file diff for those lines goes to zero** while each plat
 
 **Gotcha that confuses fresh readers:** the canonical "home" copy can already carry `#if RAYLIB` branches that are **dead in its own current build**. `Gum/Wireframe/CustomSetPropertyOnRenderable.cs` is compiled into `MonoGameGum` (where `RAYLIB` is **not** defined), yet it contains `#if RAYLIB … namespace RaylibGum.Renderables;` scaffolding. That is intentional pre-staging for the day `RaylibGum.csproj` drops its local copy (`Runtimes/RaylibGum/Renderables/CustomSetPropertyOnRenderable.cs`) and links the home file instead. Seeing `#if RAYLIB` inside a MonoGame-compiled file is not a bug.
 
+**Gotcha — the `#nullable` context travels with the consuming project, not the file.** A
+file-linked shared source compiles under each consumer's `<Nullable>` setting, and host
+projects disagree (e.g. `SkiaGum.Wpf` has no `<Nullable>`, so a linked file's `string?`
+annotations raise CS8632 there). Put `#nullable enable` at the top of the shared file so its
+annotations stay valid and warning-free in every consumer regardless of their setting. (Issue
+#3218, relocating the render-only `GumService` into WPF/MAUI/Silk hosts with differing settings.)
+
 ## Mechanical Steps
 
 1. Read all three per-platform source files end to end. Write down every difference.
@@ -100,4 +107,4 @@ Not a general refactoring guide. Not a pattern for unifying non-runtime files. S
 
 The **convergence technique** above, however, applies to any source that *already exists as per-platform duplicate copies* heading for a single linked home — not only `GueDeriving` wrappers. The canonical non-wrapper example is the string-path dispatch/bridge file `CustomSetPropertyOnRenderable.cs` (MonoGame copy in `Gum/Wireframe/`, Raylib copy in `Runtimes/RaylibGum/Renderables/`). The "don't apply this to tool code" exclusion is about not *inventing* the source-sharing pattern for things that are genuinely single-home; it does not forbid converging files that are already duplicated per platform.
 
-This skill is also **not** the source of truth for *which* runtimes are unified. Roadmap and per-runtime status live in the (gitignored) design docs at `.claude/designs/runtime-unification/` — `RuntimeNorthStar.md` for the workstream-level roadmap, `runtime-refactoring.md` for per-runtime details. Update those when a unification lands; do not duplicate status here.
+This skill is also **not** the source of truth for *which* runtimes are unified. Roadmap and per-runtime status live in the (gitignored) design docs at `.claude/designs/runtime-unification/` — `RuntimeNorthStar.md` for the workstream-level roadmap, `RuntimeUnificationAndRefactor.md` for per-runtime details. Update those when a unification lands; do not duplicate status here.

--- a/Runtimes/SkiaGum.Maui/SkiaGum.Maui.csproj
+++ b/Runtimes/SkiaGum.Maui/SkiaGum.Maui.csproj
@@ -29,6 +29,12 @@
     <ProjectReference Include="..\..\Runtimes\SkiaGum\SkiaGum.csproj" />
   </ItemGroup>
 
+  <!-- Render-only GumService (evicted from Gum.SkiaSharp core, #3218). Shared source,
+       file-linked here so this host package ships its own Gum.GumService. -->
+  <ItemGroup>
+    <Compile Include="..\SkiaGum.Standalone\GumService.cs" Link="GumService.cs" />
+  </ItemGroup>
+
 
 	
 </Project>

--- a/Runtimes/SkiaGum.Standalone/GumService.cs
+++ b/Runtimes/SkiaGum.Standalone/GumService.cs
@@ -1,3 +1,8 @@
+// This is shared source file-linked into host projects with differing <Nullable>
+// settings (e.g. SkiaGum.Wpf does not enable it), so declare the nullable context
+// here to keep the file's annotations valid and warning-free everywhere.
+#nullable enable
+
 using Gum.DataTypes;
 using Gum.Forms.Controls;
 using Gum.Managers;
@@ -11,15 +16,20 @@ using SkiaSharp;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Security.Cryptography;
 using System.Text;
 using System.Threading.Tasks;
 using ToolsUtilities;
 
-namespace SkiaGum;
+// Render-only GumService for SkiaSharp host environments (WPF, MAUI, Silk.NET,
+// standalone bring-your-own-canvas). namespace Gum / type GumService mirrors the
+// game-host GumService (MonoGameGum/GumService.cs) so user code is portable across
+// hosts. This file is shared source: it is NOT compiled into Gum.SkiaSharp (which is
+// rendering-only) but file-linked into each host lib/sample/tool that needs it.
+// See .claude/designs/runtime-unification/GumServiceHostModel.md (issues #3218, #2738).
+namespace Gum;
 public class GumService : IGumService
 {
-    static GumService _default;
+    static GumService? _default;
     public static GumService Default
     {
         get
@@ -44,7 +54,7 @@ public class GumService : IGumService
     /// <see cref="GraphicalUiElement.AddToRoot()"/>
     /// become children of this container. Null until <c>Initialize</c> is called.
     /// </summary>
-    public InteractiveGue Root { get; private set; }
+    public InteractiveGue Root { get; private set; } = null!;
 
     #region IGumService implementation
 
@@ -83,7 +93,7 @@ public class GumService : IGumService
     /// Queue used to defer actions onto the main loop. Pending actions are processed at
     /// the start of each <see cref="Update"/>.
     /// </summary>
-    public DeferredActionQueue DeferredQueue { get; private set; }
+    public DeferredActionQueue DeferredQueue { get; private set; } = null!;
 
     float? IGumService.GameTime => _hasReceivedUpdate ? (float?)_previousTotalSeconds : null;
 
@@ -126,7 +136,7 @@ public class GumService : IGumService
         SystemManagers.Default.Initialize();
         SystemManagers.Default.Renderer.ClearsCanvas = false;
 
-        GumProjectSave gumProject = null;
+        GumProjectSave? gumProject = null;
 
         if (!string.IsNullOrEmpty(gumProjectFile))
         {

--- a/Runtimes/SkiaGum.Standalone/README.md
+++ b/Runtimes/SkiaGum.Standalone/README.md
@@ -1,0 +1,28 @@
+# SkiaGum.Standalone
+
+Shared **source** for the render-only `Gum.GumService` used by SkiaSharp host
+environments — WPF, MAUI, Silk.NET, and bring-your-own-canvas standalone apps.
+
+## Why this is source-only (no .csproj yet)
+
+`Gum.SkiaSharp` (the `SkiaGum` core library) is **rendering/layout only** — it does
+not contain a `GumService` (see issue #3218). The render-only service was evicted from
+core and relocated here. It is `namespace Gum` / type `GumService`, mirroring the
+game-host service in `MonoGameGum/GumService.cs`, so user code is portable across hosts.
+
+Each host lib / sample / tool that needs the service **file-links** `GumService.cs`:
+
+```xml
+<Compile Include="..\SkiaGum.Standalone\GumService.cs" Link="GumService.cs" />
+```
+
+This mirrors how MonoGame and raylib each compile their own copy of the game-host
+`GumService.cs` rather than referencing a shared `GumService.dll`: one `Gum.GumService`
+per host assembly, never two in one app.
+
+A `Gum.SkiaSharp.Standalone` NuGet package (which would compile this file) is deferred
+until a concrete bring-your-own-canvas consumer needs it (YAGNI). Until then the file
+has no owning project and is reached only through the links above.
+
+See `.claude/designs/runtime-unification/GumServiceHostModel.md` and issues
+#3218 (this restructure) / #2738 (the Silk.NET runtime that follows).

--- a/Runtimes/SkiaGum.Wpf/SkiaGum.Wpf.csproj
+++ b/Runtimes/SkiaGum.Wpf/SkiaGum.Wpf.csproj
@@ -15,4 +15,10 @@
     <ProjectReference Include="..\SkiaGum\SkiaGum.csproj" />
   </ItemGroup>
 
+  <!-- Render-only GumService (evicted from Gum.SkiaSharp core, #3218). Shared source,
+       file-linked here so this host lib ships its own Gum.GumService. -->
+  <ItemGroup>
+    <Compile Include="..\SkiaGum.Standalone\GumService.cs" Link="GumService.cs" />
+  </ItemGroup>
+
 </Project>

--- a/Samples/SilkNetGum/SilkNetGum/Program.cs
+++ b/Samples/SilkNetGum/SilkNetGum/Program.cs
@@ -9,7 +9,7 @@ using Gum.Forms.Controls;
 using Gum.Wireframe;
 using Gum.GueDeriving;
 using RenderingLibrary.Graphics;
-using SkiaGum;
+using Gum;
 using SilkNetGum.Screens;
 using Gum.Managers;
 using GumRuntime;
@@ -47,6 +47,8 @@ unsafe class Program
     static int windowWidth = 1400;
     static int windowHeight = 900;
 
+    static GumService GumUI => GumService.Default;
+
     #endregion
 
     // Code-only screens appended after every screen from the gumx, allowing the
@@ -64,7 +66,7 @@ unsafe class Program
 
     private static void InitializeGum(SKCanvas canvas)
     {
-        GumService.Default.Initialize(canvas, "Content/GumProject/GumProject.gumx");
+        GumUI.Initialize(canvas, "Content/GumProject/GumProject.gumx");
 
         LoadScreen(0);
 
@@ -118,7 +120,7 @@ unsafe class Program
     private static void Draw()
     {
 
-        GumService.Default.Draw();
+        GumUI.Draw();
 
         canvas.Flush();
     }
@@ -373,12 +375,17 @@ unsafe class Program
                             if (ev.Window.Event == (byte)WindowEventID.Resized)
                             {
                                 gl.Viewport(0, 0, (uint)ev.Window.Data1, (uint)ev.Window.Data2);
-                                GumService.Default.HandleResize(ev.Window.Data1, ev.Window.Data2);
+                                GumUI.HandleResize(ev.Window.Data1, ev.Window.Data2);
                             }
                             break;
                     }
                 }
 
+
+                // Per-frame Update drives AnimateSelf (and any other Forms
+                // input/activity pumps). Without this the .achx animation row
+                // on SpriteScreen shows the first frame and never advances.
+                GumUI.Update(totalTime.Elapsed.TotalSeconds);
 
 
 
@@ -391,11 +398,6 @@ unsafe class Program
                 // canvas.Clear(SKColors.Cyan);
                 //_renderer.Render(canvas);
 
-
-                // Per-frame Update drives AnimateSelf (and any other Forms
-                // input/activity pumps). Without this the .achx animation row
-                // on SpriteScreen shows the first frame and never advances.
-                GumService.Default.Update(totalTime.Elapsed.TotalSeconds);
 
                 Draw();
 

--- a/Samples/SilkNetGum/SilkNetGum/SilkNetGum.csproj
+++ b/Samples/SilkNetGum/SilkNetGum/SilkNetGum.csproj
@@ -27,6 +27,12 @@
 	  <ProjectReference Include="..\..\..\Runtimes\SkiaGum\SkiaGum.csproj" />
 	</ItemGroup>
 
+	<!-- Render-only GumService (evicted from Gum.SkiaSharp core, #3218). Shared source,
+	     file-linked here until this sample becomes the Gum.SilkNet game-host runtime (#2738). -->
+	<ItemGroup>
+	  <Compile Include="..\..\..\Runtimes\SkiaGum.Standalone\GumService.cs" Link="GumService.cs" />
+	</ItemGroup>
+
 	<ItemGroup>
 	  <None Update="Content\GumProject\**\*.*">
 	    <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/Tests/SkiaGum.Tests/GumServiceNamespaceTests.cs
+++ b/Tests/SkiaGum.Tests/GumServiceNamespaceTests.cs
@@ -1,0 +1,27 @@
+using Gum;
+using RenderingLibrary;
+using Shouldly;
+
+namespace SkiaGum.Tests;
+
+/// <summary>
+/// Locks in the GumService host model (issue #3218): the render-only Skia service is
+/// <c>Gum.GumService</c> (namespace <c>Gum</c>), mirroring the game-host MonoGameGum
+/// service so user code is portable across hosts. It is no longer
+/// <c>SkiaGum.GumService</c> — that type was evicted from the Gum.SkiaSharp core
+/// rendering library with no [Obsolete] shim.
+/// </summary>
+public class GumServiceNamespaceTests
+{
+    [Fact]
+    public void GumService_ShouldBeInGumNamespace()
+    {
+        typeof(GumService).Namespace.ShouldBe("Gum");
+    }
+
+    [Fact]
+    public void GumService_ShouldImplementIGumService()
+    {
+        typeof(IGumService).IsAssignableFrom(typeof(GumService)).ShouldBeTrue();
+    }
+}

--- a/Tests/SkiaGum.Tests/GumServiceTests.cs
+++ b/Tests/SkiaGum.Tests/GumServiceTests.cs
@@ -1,3 +1,4 @@
+using Gum;
 using Gum.Forms.Controls;
 using Gum.GueDeriving;
 using RenderingLibrary;

--- a/Tests/SkiaGum.Tests/SkiaGum.Tests.csproj
+++ b/Tests/SkiaGum.Tests/SkiaGum.Tests.csproj
@@ -18,6 +18,12 @@
 	  <ProjectReference Include="..\..\Runtimes\SkiaGum\SkiaGum.csproj" />
 	</ItemGroup>
 
+	<!-- Render-only GumService (evicted from Gum.SkiaSharp core, #3218). Shared source,
+	     file-linked so these tests exercise the relocated Gum.GumService. -->
+	<ItemGroup>
+	  <Compile Include="..\..\Runtimes\SkiaGum.Standalone\GumService.cs" Link="GumService.cs" />
+	</ItemGroup>
+
 	<ItemGroup>
 		<Using Include="Xunit" />
 	</ItemGroup>

--- a/Tools/Gum.ProjectServices.SkiaGum/Gum.ProjectServices.SkiaGum.csproj
+++ b/Tools/Gum.ProjectServices.SkiaGum/Gum.ProjectServices.SkiaGum.csproj
@@ -11,4 +11,10 @@
 		<ProjectReference Include="..\..\Runtimes\SkiaGum\SkiaGum.csproj" />
 	</ItemGroup>
 
+	<!-- Render-only GumService (evicted from Gum.SkiaSharp core, #3218). Shared source,
+	     file-linked so this headless SVG-export host can drive GumService.Initialize(canvas). -->
+	<ItemGroup>
+		<Compile Include="..\..\Runtimes\SkiaGum.Standalone\GumService.cs" Link="GumService.cs" />
+	</ItemGroup>
+
 </Project>

--- a/Tools/Gum.ProjectServices.SkiaGum/SkiaGumSvgExportService.cs
+++ b/Tools/Gum.ProjectServices.SkiaGum/SkiaGumSvgExportService.cs
@@ -4,7 +4,6 @@ using Gum.ProjectServices.SvgExport;
 using Gum.Wireframe;
 using GumRuntime;
 using RenderingLibrary;
-using SkiaGum;
 using SkiaSharp;
 using System;
 using System.IO;

--- a/docs/code/getting-started/setup/adding-initializing-gum/silk.net.md
+++ b/docs/code/getting-started/setup/adding-initializing-gum/silk.net.md
@@ -51,7 +51,7 @@ using RenderingLibrary;
 using Gum.Wireframe;
 using Gum.GueDeriving;
 using RenderingLibrary.Graphics;
-using SkiaGum;
+using Gum;
 using SilkNetGum.Screens;
 using Gum.Managers;
 using GumRuntime;


### PR DESCRIPTION
Closes #3218.

## What & why

Makes **`Gum.SkiaSharp` (SkiaGum) rendering/layout only** and moves `GumService` to a host-owned model, per `.claude/designs/runtime-unification/GumServiceHostModel.md`. This is the host-agnostic prerequisite for the Silk.NET runtime (#2738).

The render-only `GumService` is **evicted from core** and relocated to `Runtimes/SkiaGum.Standalone/GumService.cs` as **shared source** — `namespace Gum` / type `GumService`, mirroring the game-host `MonoGameGum/GumService.cs` so user code is portable across hosts. Moving the file out of the SkiaGum project folder auto-evicts it from `Gum.SkiaSharp` (SDK glob); nothing inside core referenced the type.

It is **file-linked** into every consumer that needs it (each host assembly compiles its own `Gum.GumService`, never two in one app — same model as MonoGame/raylib):

| Consumer | Role |
|---|---|
| `Runtimes/SkiaGum.Maui` | retained-host lib (`Gum.SkiaSharp.Maui` package keeps its GumService surface) |
| `Runtimes/SkiaGum.Wpf` | retained-host lib |
| `Samples/SilkNetGum` | sample (becomes the `Gum.SilkNet` game-host in #2738) |
| `Tests/SkiaGum.Tests` | test coverage for the relocated service |
| `Tools/Gum.ProjectServices.SkiaGum` | headless SVG-export tool service |

> Note: the issue said only the samples consume `SkiaGum.GumService`, but the WPF/MAUI **samples** actually don't (they draw via `SkiaGumCanvasView`/`GumSKElement`). The real consumers are the SilkNet sample, the tests, and the **tool's SVG-export service**. The retained-host **libs** still file-link the service so their packages keep offering it.

## Decisions (design left these open)

- **Source-only home, no `.Standalone` csproj yet.** The design ships the `Gum.SkiaSharp.Standalone` package lazily (YAGNI), so the file has no owning project and is reached only through links. A `README.md` in the folder explains this.
- **No `[Obsolete]` shim.** It can't cleanly live in core after eviction (it would need a working GumService there), and every in-repo consumer is updated in this PR. ⚠️ **Breaking change** for any external `Gum.SkiaSharp` package consumer using `SkiaGum.GumService` — effectively none today. A `Gum.SkiaSharp` package version bump may be warranted at release time.

## Notes

- The shared file declares `#nullable enable` because host projects disagree on `<Nullable>` (`SkiaGum.Wpf` doesn't enable it); without it the linked file raised CS8632 there. Added a matching note to the cross-platform-unification skill.
- Added `GumServiceNamespaceTests` locking in the `namespace Gum` host model.
- Updated the Silk.NET setup doc snippet (`using SkiaGum;` → `using Gum;`).

## Verification

- `SkiaGum.Tests`: **189/189 pass** (incl. relocated `GumService` + new namespace tests).
- Builds clean (zero warnings from the relocated file) for: SkiaGum core, `SkiaGum.Maui`, `SkiaGum.Wpf`, `SilkNetGum`, `SkiaGum.Tests`, `Gum.ProjectServices.SkiaGum`, and the `SkiaGumWpfSample`.
- Manual: run `Samples/SilkNetGum` and confirm screens render and the `.achx` nine-slice animation advances (exercises `Gum.GumService` Initialize/Update/Draw end-to-end).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
