### PR TITLE
Add Direction/ project-direction docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,10 @@ This project (Gum) provides UI solutions for game developers using C#. It includ
 * Runtime libraries for various platforms including MonoGame, KNI, and FNA. Also SkiaSharp and raylib.
 * A tool also called Gum or Gum UI or Gum UI tool which is a WYSIWYG editor for game UI
 
+## Project Direction
+
+High-level direction for Gum — vision, roadmap, open strategic questions, and decision records (ADRs) — lives in `Direction/` at the repo root. **For any discussion of Gum's high-level goals, roadmap, or strategic decisions, read `Direction/README.md` first**, then the specific file for the topic. This is the strategy layer (*what* and *why*); it is separate from the operational guidance in this file and in the skills/agents (*how*), and from the published user-facing docs in `docs/`.
+
 ## Agent Workflow
 
 For every task, invoke the appropriate agent from `.claude/agents/` before proceeding. The agent's instructions provide guidelines for how the task should be performed. Before doing any work, announce which agent you are using such as "Invoking coder agent for this task..."

--- a/Direction/README.md
+++ b/Direction/README.md
@@ -1,0 +1,45 @@
+# Gum — Project Direction
+
+This folder holds the **high-level direction** for Gum: the vision (north star), the
+roadmap (priorities over time), open strategic questions, and a log of decisions.
+
+It is the **strategy layer** — *what* we're building and *why*. That is distinct from:
+
+- the **operational guidance** in `CLAUDE.md`, `.claude/agents/`, and `.claude/skills/`,
+  which covers *how* to do the work correctly; and
+- the **published, user-facing docs** in `docs/` — nothing here ships to users.
+
+## Read this first (after a context clear)
+
+If you are starting or resuming a discussion about Gum's direction, read this README,
+then open only the file relevant to the topic. You do not need to load everything at once.
+
+## Files
+
+- **`history.md`** — brief grounding history: where Gum came from. Read-once context; append
+  new eras as they happen.
+- **`ecosystem.md`** — present-tense snapshot of how Gum grows (partnerships, integrations) and
+  the runtimes that define its reach.
+- **`vision.md`** — the north star: what Gum is for, who it serves, the principles we hold.
+  *Living* — edited in place; git history is the record of how it evolved.
+- **`roadmap.md`** — priorities across Now / Next / Later horizons.
+  *Living* — revisited regularly; move items between horizons as reality changes.
+- **`open-questions.md`** — unresolved strategic questions. When one is resolved, record the
+  resolution as an ADR and link it.
+- **`decisions/`** — **Architecture Decision Records (ADRs)**: append-only, numbered records
+  of significant decisions. See `decisions/README.md`.
+
+## Two lifecycles (why this is a collection, not one doc)
+
+- **Living docs** (`vision`, `roadmap`, `open-questions`) change continuously. Edit them in
+  place and rely on git for history.
+- **Decisions** are point-in-time. Do **not** rewrite a past decision. If thinking changes,
+  add a *new* ADR and mark the old one `Superseded by NNNN`. The trail of reasoning is the value.
+
+## How to maintain
+
+- Date significant changes. Use the real current date (provided in session context) — don't guess.
+- Prefer short, direct prose. Link between files rather than duplicating content.
+- When a roadmap item or open question is settled by a real decision, write an ADR and link it
+  from the source.
+- Improvements to *how* we work belong in the relevant skill / agent / `CLAUDE.md`, not here.

--- a/Direction/decisions/0000-template.md
+++ b/Direction/decisions/0000-template.md
@@ -1,0 +1,23 @@
+# NNNN. <Title of the decision>
+
+- **Status:** Proposed | Accepted | Superseded by NNNN | Deprecated
+- **Date:** YYYY-MM-DD
+- **Deciders:** <who was involved>
+
+## Context
+
+<The forces at play: the problem, the constraints, and what makes this a decision worth
+recording. What is true today that pushes us to decide now.>
+
+## Decision
+
+<The decision, stated plainly and in active voice: "We will …".>
+
+## Consequences
+
+<What becomes easier and what becomes harder as a result. Trade-offs accepted, follow-ups
+created, things to revisit later.>
+
+## Alternatives considered
+
+<Other options weighed, and why they were not chosen.>

--- a/Direction/decisions/0001-track-direction-in-checked-in-markdown.md
+++ b/Direction/decisions/0001-track-direction-in-checked-in-markdown.md
@@ -1,0 +1,41 @@
+# 0001. Track project direction in checked-in Markdown
+
+- **Status:** Accepted
+- **Date:** 2026-06-20
+- **Deciders:** Victor Chelaru, Claude
+
+## Context
+
+Gum needs a durable place to develop high-level direction — vision, roadmap, and strategic
+decisions — over a long-running effort spanning many working sessions. Context is cleared
+periodically, so the system must let a fresh session get back up to speed from files alone.
+
+Options considered ranged from a single maintained document to a vectorized / wiki knowledge
+base accessed via a third-party MCP integration. The project also has an established preference
+that persistent knowledge live in versioned, checked-in files (`CLAUDE.md`, agents, skills)
+rather than opaque external systems.
+
+## Decision
+
+We will keep project direction as a small collection of checked-in Markdown files under
+`Direction/` at the repo root: living `vision.md`, `roadmap.md`, and `open-questions.md`, plus
+an append-only `decisions/` ADR log, fronted by a `README.md` index. A pointer in `CLAUDE.md`
+makes the folder discoverable at the start of every session so it survives context clears.
+
+## Consequences
+
+- Direction is **versioned** (git history shows how thinking evolved), **reviewable** (diffs /
+  PRs), and **transparent** (load the whole thing; nothing is hidden).
+- No external infrastructure or MCP / vector-DB dependency to operate or keep in sync.
+- The split between living docs and append-only decisions must be maintained by hand —
+  discipline, not tooling, keeps them separate.
+- If the corpus ever grows beyond what fits comfortably in context (many repos, thousands of
+  documents), revisit whether a retrieval / search layer is warranted. We are far from that.
+
+## Alternatives considered
+
+- **Single growing document** — simplest, but mixes the living and point-in-time lifecycles and
+  degrades as it grows; rejected in favor of a structured collection that loads piecemeal.
+- **Vectorized wiki / knowledge base via MCP plugin** — sacrifices versioning, reviewability,
+  and transparency, and adds operational complexity, to solve a scale problem this project does
+  not have; rejected.

--- a/Direction/decisions/0002-target-code-first-frameworks-not-engines.md
+++ b/Direction/decisions/0002-target-code-first-frameworks-not-engines.md
@@ -1,0 +1,50 @@
+# 0002. Target code-first C# frameworks, not full engines
+
+- **Status:** Accepted
+- **Date:** 2026-06-20
+- **Deciders:** Victor Chelaru, Claude
+
+## Context
+
+Gum is a UI authoring tool plus runtime libraries for C# game development. The two largest C#
+game-development environments are **Unity** and **Godot**, and Gum supports neither. It does
+support MonoGame (and MonoGame-based engines such as FlatRedBall), KNI, FNA, raylib, and
+SkiaSharp-based hosts.
+
+This is not incidental. Unity and Godot are full **engines**: they ship their own native UI
+systems (Unity's uGUI / UI Toolkit; Godot's Control nodes), an editor, and a scene system. The
+environments Gum *does* support are code-first **frameworks / libraries** that ship **no UI
+solution at all** — which is precisely the gap Gum fills.
+
+A "support Unity / Godot" strategy is tempting because they are the biggest audiences, but it
+would mean (a) competing against an entrenched, good-enough native default in someone else's
+house, and (b) taking on the highest-burden growth possible for a solo-maintained project: two
+large, fast-moving hosts, each a permanent maintenance tax, for users who mostly will not switch.
+That is the opposite of "reach with sublinear cost" (see the private maintainer-sustainability
+strategy).
+
+## Decision
+
+Gum deliberately targets **code-first C# game frameworks** (MonoGame and MonoGame-based engines
+such as FlatRedBall, KNI, FNA, raylib) and **SkiaSharp-based app hosts**, and **does not target
+full engines that ship their own UI (Unity, Godot)**. This boundary holds **for now, and may
+become permanent**; it is revisited only if a compelling low-cost path or overwhelming demand
+appears.
+
+## Consequences
+
+- Sharper, more honest positioning — "the UI for C# frameworks that don't have one," not
+  "universal C# UI." This clarifies the mission, the audience, and the scope at once.
+- Engineering effort and the maintenance budget stay focused on the framework segment, consistent
+  with solo-maintainer sustainability.
+- The cost: Gum forgoes the two largest *raw* C# gamedev audiences. We accept that "biggest
+  audience" is not the same as "winnable audience."
+- Not a permanent ban: this is a current boundary, re-openable via a superseding ADR.
+
+## Alternatives considered
+
+- **Add Unity and/or Godot runtimes** — maximal reach, but maximal maintenance burden against an
+  entrenched native default; rejected as misaligned with a solo-maintained project's
+  sustainability.
+- **Stay silent on scope** — leaves the boundary looking like an oversight rather than a choice;
+  rejected in favor of stating it explicitly.

--- a/Direction/decisions/README.md
+++ b/Direction/decisions/README.md
@@ -1,0 +1,24 @@
+# Decision Records (ADRs)
+
+An **Architecture Decision Record (ADR)** captures one significant decision: the context that
+forced it, the decision made, and the consequences. ADRs are **append-only** — once accepted, a
+record is not rewritten. If a decision is reversed or changed, write a *new* ADR and mark this
+one `Superseded by NNNN`.
+
+This convention exists so the *reasoning* behind direction survives context clears, the passage
+of time, and new collaborators — you can always answer "why is it this way?" without
+re-litigating it.
+
+## Conventions
+
+- Filename: `NNNN-short-kebab-title.md`, zero-padded and sequential (`0001-…`, `0002-…`).
+- Copy `0000-template.md` to start a new record.
+- Status flow: `Proposed` → `Accepted` → optionally `Superseded by NNNN` / `Deprecated`.
+- One decision per ADR. Small and focused beats comprehensive.
+
+## Index
+
+| #    | Title                                            | Status   | Date       |
+|------|--------------------------------------------------|----------|------------|
+| [0001](0001-track-direction-in-checked-in-markdown.md) | Track project direction in checked-in Markdown | Accepted | 2026-06-20 |
+| [0002](0002-target-code-first-frameworks-not-engines.md) | Target code-first C# frameworks, not full engines | Accepted | 2026-06-20 |

--- a/Direction/ecosystem.md
+++ b/Direction/ecosystem.md
@@ -1,0 +1,38 @@
+# Gum — Ecosystem & Reach
+
+> Grounding context: how Gum grows today — partnerships, vertical integration, and the runtimes
+> that determine where it can be used. A present-tense snapshot; update as the ecosystem shifts.
+> See `history.md` for how Gum got here.
+
+## Growth channels & partnerships
+
+- **MonoGame (official).** Featured in the official MonoGame 2D documentation, and used in
+  MonoGame's 3D sample project, *Ascent*. The single biggest adoption driver.
+- **XnaFiddle.net.** Featured in this online "IDE" / playground (also maintained by the Gum
+  author), lowering the barrier to trying Gum in the browser.
+- **Community content.** Social posts and streamers / YouTubers creating Gum videos.
+
+## Integrations (vertical integration)
+
+Partnering with focused libraries so Gum users get capabilities without leaving the ecosystem:
+
+- **Apos.Shapes** — shape rendering.
+- **ShadowDusk** — shader compilation (newer partner library).
+- **KernSmith** — dynamic font creation (newer partner library).
+
+## Runtime reach
+
+Gum's reach is bounded by which host runtimes it supports and how mature each is. Two axes blur
+together in the word "runtime": the **rendering backend** (how pixels get drawn) and the **host
+platform/windowing runtime** (where the app actually runs). A runtime can be strong on one axis
+and weak on the other.
+
+Current state:
+
+- **MonoGame** — most mature; the primary runtime.
+- **raylib** — advanced; close to parity with the MonoGame runtime.
+- **Skia** — advanced on the *rendering* axis.
+- **Silk.NET** — lacking; an example of a host runtime that still needs significant work.
+- **KNI / FNA** — MonoGame-family runtimes.
+
+Expanding and maturing additional runtimes is an active strategy for growing Gum's reach.

--- a/Direction/history.md
+++ b/Direction/history.md
@@ -1,0 +1,20 @@
+# Gum — A Brief History
+
+> Grounding context for direction discussions: where Gum came from. Kept deliberately brief;
+> append new eras as they happen. Dates are approximate.
+
+- **~2011 — Origin (Utah game studio).** Built as an in-house UI solution, then open-sourced in
+  the hope others would adopt it. The studio's effort wound down after a few months and the
+  project sat dormant.
+- **~2013 — EA / Tetris Blitz.** Picked up at EA and given a second life, with a large number of
+  improvements over ~1.5 years. That project ended, but Gum emerged substantially stronger.
+- **~2015 — FlatRedBall.** Adopted as the UI solution for FlatRedBall, driving steady growth for
+  several years.
+- **~2019 — Tula (mobile apps).** Used for mobile apps, which produced the **Skia** rendering
+  side of Gum.
+- **~2024 — Gum + MonoGame.** The MonoGame runtime became a first-class library and gave Gum a
+  huge popularity boost (a large jump in GitHub stars). Gum became the default UI for most
+  MonoGame projects.
+
+**Today:** Gum + MonoGame is the most popular UI combination for MonoGame. The single biggest
+driver of that adoption is Gum's inclusion in the official MonoGame 2D tutorial.

--- a/Direction/open-questions.md
+++ b/Direction/open-questions.md
@@ -1,0 +1,36 @@
+# Gum — Open Strategic Questions
+
+> Questions that shape direction. When one is settled by a real decision, record it as an ADR in
+> `decisions/` and move it to the **Resolved** list below with a link. Keep these **strategic**
+> (direction-shaping). Tactical to-dos belong in GitHub issues.
+
+## Open
+
+- **Cross-platform (Mac/Linux) editor — pursue?** Highest-ceiling bet (unlocks the OS-locked-out
+  slice of the MonoGame audience), but highest cost (WPF → cross-platform; permanent maintenance
+  step-up). Could be built on Gum's own Avalonia/Skia stack (dogfooding). Needs a dedicated
+  scoping pass before committing. Currently parked in `roadmap.md` → Later. The UI/logic decoupling
+  now in flight is no-regret groundwork that lowers the cost of a future "yes," so this decision
+  can be deferred without blocking progress.
+- **raylib — real audience, or just finish-and-ride-goodwill?** Committing to raylib as a
+  strategic audience would justify raylib codegen and deeper investment; current lean is to finish
+  the runtime cheaply and *not* chase it (small audience, low attention — ride the 3rd-party video
+  and maintainer goodwill as low-cost cross-promotion instead).
+- **Platform strategy.** Which runtimes are first-class vs. best-effort, and how is parity
+  prioritized across MonoGame / KNI / FNA / Skia / raylib? (Sharper now that each runtime is
+  understood as a permanent maintenance tax — see the private growth strategy.)
+- **Tool vs. code-first.** How do we balance investment between the WYSIWYG tool and
+  code-only / code-generation workflows?
+- **Scope boundaries (beyond engines).** Full engines are settled (ADR-0002); what *other*
+  boundaries should Gum name as explicitly out of scope?
+
+## Resolved
+
+- **North star / mission** — settled (2026-06-20): *"Gum is the visual UI editor and
+  cross-framework runtime for code-first C# game frameworks — the ones that ship no UI of their
+  own."* See `vision.md` (mission).
+- **Primary audience** — settled (2026-06-20): MonoGame indie / hobbyist devs are primary;
+  FlatRedBall (via FRB2 on the MonoGame runtime) continuing; SkiaSharp app devs distinct; raylib
+  emerging. See `vision.md` ("Who it's for"). The earlier "cross-engine teams" idea was retracted.
+- **Scope: full engines** — settled (2026-06-20): Unity and Godot are deliberately out, for now
+  and possibly permanently. See `decisions/0002-target-code-first-frameworks-not-engines.md`.

--- a/Direction/roadmap.md
+++ b/Direction/roadmap.md
@@ -1,0 +1,72 @@
+# Gum — Roadmap
+
+> Living document. Items move between horizons as reality changes — this is intent, not a
+> contract. Date significant changes. Last updated 2026-06-20.
+
+Horizons describe *confidence and proximity*, not fixed dates:
+
+- **Now** — actively being worked, or next up.
+- **Next** — intended and reasonably committed, but not yet started.
+- **Later** — directionally wanted; not yet scoped.
+
+## Now
+
+- **Web-runnable Gum demos on MonoGame / KNI.** 1–2 *showcase-quality*, linkable in-browser demos
+  (KNI is the actual web / WASM target; MonoGame proper has no first-class web build). Treat them
+  as **marketing collateral** — droppable in Discord / social / docs — not just sample code.
+  - Double as a **themes showcase** (users are already asking how to work with the UI themes), so
+    this one artifact covers samples + themes documentation + web demo.
+  - Wire through **XnaFiddle** for edit-and-run-in-the-browser — a funnel only Gum has.
+  - **Scope discipline:** stay in "samples / demos on KNI's existing web target." Do *not* drift
+    into open-ended web-platform plumbing (WASM perf, web fonts, input quirks). Let platform fixes
+    be *pulled* by a real blocker, not pushed speculatively.
+
+- **Decouple UI from logic in the Gum tool.** (Agent-driven, in parallel with the web demos.)
+  Separate the WPF UI layer from application / business logic — continuing the tool's existing
+  move to constructor-injected services. **A no-regret move:** if Gum later goes cross-platform via
+  Avalonia (the Mac/Linux editor bet), this is the key enabler; if it doesn't, it still improves
+  testability (logic becomes unit-testable without the UI), maintainability, and contributor
+  friendliness — valuable under every branch of the editor decision.
+
+## Next
+
+- **Finish the raylib runtime's last ~10%** (shader support, advanced gamepad, other minor gaps).
+  Cheap completion for a clean "raylib fully supported" story — then stop. Not a growth focus:
+  small audience, low current attention; ride the 3rd-party video and maintainer goodwill as
+  low-cost cross-promotion. (Whether raylib becomes a *real* strategic bet is an open question.)
+
+## Later
+
+- **Cross-platform (Mac / Linux) WYSIWYG editor.** Highest *ceiling* of any option — it unlocks the
+  OS-locked-out slice of the **strong** (MonoGame) audience, not a new small one — but also the
+  highest cost (the tool is WPF; cross-platform means a major lift and a permanent maintenance
+  step-up). Could be built on Gum's own Avalonia / Skia stack (ultimate dogfooding). **Needs a
+  dedicated scoping pass before committing** — see `open-questions.md`. The UI/logic decoupling now
+  in flight (see **Now**) is the enabling groundwork that lowers the cost of a future "yes."
+
+## Parked (deliberately not now)
+
+- **Silk.NET game-readiness** (the full interactive Forms-controls layer) — high cost vs. thin
+  demand (a single voice). Revisit only if real demand appears.
+- **raylib codegen** — gated on first deciding raylib is a real strategic audience; don't build it
+  speculatively.
+
+## Strategic threads
+
+Cross-cutting reasoning behind the items above (the "why"):
+
+- **Deepen the strong (MonoGame) audience before expanding into new ones.** Serving a new small
+  audience costs about the same as serving the strong one and returns far less.
+- **Diversify acquisition *channels* within that audience** (web demos, samples, videos, XnaFiddle,
+  social) to reduce dependence on the single MonoGame-tutorial channel — *not* by chasing new
+  audiences.
+- **Growth must be sublinear in ongoing cost** — favor low-maintenance-tail wins; treat each new
+  runtime as a permanent N-way tax.
+- **Dogfooding** (FRB2, own games) as a refuel + quality thread — improves Gum-on-MonoGame and
+  keeps the solo maintainer engaged.
+- **Prefer no-regret enabling investments under uncertainty.** When a big bet is unresolved (e.g.
+  the Mac/Linux editor), favor groundwork that pays off whether or not you take the bet — like
+  decoupling UI from logic, which improves the codebase regardless *and* cheapens the bet.
+
+(The candid maintainer-sustainability reasoning behind these lives in the private strategy file —
+see Gum's `CLAUDE.local.md` for the pointer.)

--- a/Direction/vision.md
+++ b/Direction/vision.md
@@ -1,0 +1,64 @@
+# Gum — Vision
+
+> **Status: scaffold.** This is the north star, filled in collaboratively over time. The
+> sections below are prompts — replace the *italic placeholders* with real content. Edit in
+> place; git tracks how the vision evolves.
+
+## What Gum is
+
+Gum provides UI solutions for game developers using C#: a platform-agnostic layout and control
+core, runtime libraries for MonoGame, KNI, FNA, SkiaSharp, and raylib, and a WYSIWYG editor
+(the Gum tool) for authoring game UI.
+
+## Mission / north star
+
+> Settled 2026-06-20.
+
+**Gum is the visual UI editor and cross-framework runtime for code-first C# game frameworks — the
+ones that ship no UI of their own.**
+
+In practice: author UI visually in the Gum tool, then run it on MonoGame (and MonoGame-based
+engines such as FlatRedBall), KNI, FNA, and raylib, plus SkiaSharp-based app hosts (WPF, Avalonia,
+MAUI). Gum deliberately serves *frameworks*, not full **engines** (Unity, Godot) that already ship
+their own UI — see `decisions/0002-target-code-first-frameworks-not-engines.md`. Portability and
+reach *within that segment* are the through-line of Gum's history and what has kept it alive across
+changing owners.
+
+## Who it's for
+
+All of Gum's users share one trait: they are **code-first C# developers whose framework ships no
+UI of its own.** Specifically:
+
+- **Primary (now):** MonoGame indie / hobbyist developers — the center of gravity, driven by Gum's
+  inclusion in the official MonoGame 2D tutorial. When priorities conflict, this audience wins.
+- **Continuing:** FlatRedBall users — FRB2 uses Gum as its UI on the same MonoGame runtime, so the
+  relationship carries forward at essentially zero marginal cost.
+- **Distinct:** SkiaSharp app developers (WPF / Avalonia / MAUI) — often building *application* UI
+  rather than games, a somewhat different user.
+- **Emerging:** raylib-cs developers, as that runtime matures toward MonoGame parity.
+
+## Principles
+
+*The values that guide decisions — what we optimize for and what we refuse to trade away.
+Candidates: cross-platform parity, ease of getting started, WYSIWYG fidelity, runtime
+performance, backward compatibility.*
+
+## Constraints
+
+- **Solo-maintained.** Gum is currently maintained primarily by one person, so **maintainer
+  sustainability is a first-class design constraint**: direction favors work that grows reach
+  without growing maintenance burden faster than a very small team can carry. This is a statement
+  of good stewardship — it is *why* Gum leans on leverage, contributor-friendliness, and keeping
+  the per-change cost low across runtimes.
+
+## Scope — what Gum is *not*
+
+- **Not a UI layer for full engines.** Unity and Godot ship their own native UI; Gum deliberately
+  does not target them — for now, possibly permanently. See
+  `decisions/0002-target-code-first-frameworks-not-engines.md`.
+
+*(Other boundaries will be added here as they are decided.)*
+
+## What sets Gum apart
+
+*Differentiators versus the alternatives (engine-native UI, other UI middleware). Why choose Gum?*


### PR DESCRIPTION
## What

Adds a checked-in **project-direction layer** under `Direction/` — the strategy ("what" and "why")
that sits alongside the operational guidance in `CLAUDE.md` / skills / agents and the user-facing
`docs/`.

Contents:
- `README.md` — index + how the folder is maintained (living docs vs. append-only decisions)
- `history.md` — brief grounding history of Gum
- `ecosystem.md` — how Gum grows (partnerships, integrations) and runtime reach
- `vision.md` — mission, audience, principles, constraints, scope
- `roadmap.md` — Now / Next / Later + strategic threads
- `open-questions.md` — open strategic questions + a resolved log
- `decisions/` — Architecture Decision Records (ADRs) + template

## Key decisions captured

- **Mission:** Gum is the visual UI editor and cross-framework runtime for code-first C# game
  frameworks — the ones that ship no UI of their own.
- **ADR-0001:** track direction in checked-in Markdown (not a vector DB).
- **ADR-0002:** target code-first frameworks, not full engines (Unity / Godot deliberately out,
  for now).
- **Roadmap → Now:** web-runnable demos on MonoGame / KNI; decouple UI from logic in the tool
  (a no-regret enabler for a possible cross-platform editor).

Docs-only change; no code touched. Also adds a `Project Direction` pointer in `CLAUDE.md` for
discoverability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
