### PR TITLE
Add UI/logic decoupling plan and ADRs 0003/0004 to Direction/

### DIFF
--- a/.claude/skills/refactoring-direction/SKILL.md
+++ b/.claude/skills/refactoring-direction/SKILL.md
@@ -24,6 +24,8 @@ When refactoring Gum code, **always move toward instances, interfaces, and dedic
 
 If the reason you're tempted to make something `static` is "so a test can call it without constructing the owner," the right answer is the opposite: keep it instance, and either (a) construct the owner in the test with stub dependencies, or (b) extract the logic into a new small class that's cheap to construct. The test's friction is a signal that the owner has too many responsibilities, not that the method should be static.
 
+**An extraction-for-testability is not done until the extracted unit has a test.** When you pull logic into a new class/service/ViewModel/utility specifically to make it testable, add the test before considering the refactor complete — test-first if the move also changes behavior, or a *characterization (pinning) test* capturing current behavior if the move preserves it. Do not let the [tdd](../tdd/SKILL.md) skill's refactor/rename exemption talk you out of it: extracting a new unit is not a pure rename, and an extracted-but-untested seam wastes the entire point of the extraction.
+
 ## Before refactoring across runtimes
 
 If a refactor touches shared runtime/rendering code (`GumCommon`, `RenderingLibrary`, anything under `Runtimes/`, or `MonoGameGum`), read [gum-runtime-topology](../gum-runtime-topology/SKILL.md) first. The same source is compiled into many assemblies and into FlatRedBall via shared projects, so "builds clean in `AllLibraries.sln`" does not mean "didn't break a consumer" (the WPF runtime and FRB are not in that solution).

--- a/.claude/skills/tdd/SKILL.md
+++ b/.claude/skills/tdd/SKILL.md
@@ -20,3 +20,5 @@ No "the cause is obvious, I'll skip the test" exception — that reasoning is ho
 Run the test yourself via Bash. A failure you only reasoned about is not a failure.
 
 Exceptions: docs, csproj/projitems plumbing, pure renames, dead-code removal, cosmetic edits. When in doubt, write the test.
+
+Note: **extracting logic into a new class/service/ViewModel is not a pure rename.** Even when the move preserves behavior, pin the new unit with a characterization test — see [refactoring-direction](../refactoring-direction/SKILL.md). The exemption above is for renames and cosmetics, not for relocating logic into a newly-testable seam.

--- a/Direction/decisions/0003-decouple-tool-ui-from-logic.md
+++ b/Direction/decisions/0003-decouple-tool-ui-from-logic.md
@@ -1,0 +1,53 @@
+# 0003. Decouple the Gum tool's UI from its application logic
+
+- **Status:** Accepted
+- **Date:** 2026-06-20
+- **Deciders:** Victor Chelaru, Claude
+
+## Context
+
+The Gum tool is built on WPF + WinForms + KNI and has been gradually migrating toward
+constructor-injected services and MVVM. A possible **cross-platform (Mac/Linux) editor via
+Avalonia** is an unresolved strategic bet (see the roadmap **Later** item and `open-questions.md`):
+high ceiling, high cost, not yet scoped. The question is how to proceed *under that uncertainty*
+without either committing prematurely to a large rewrite or letting the tool stay un-testable and
+welded to one UI framework.
+
+A mapping of the codebase found that WPF itself is a thin, already-half-abstracted layer; the
+heavier coupling is WinForms, concentrated in two load-bearing subsystems (the render/editor host
+and the element tree), plus pervasive static singleton access (~475 `.Self` calls) and ~35
+ViewModels that reach into `System.Windows.*`. Detail and the phased plan live in
+`ui-decoupling-plan.md`.
+
+## Decision
+
+We will continue **decoupling UI from application logic as a no-regret investment**, structured so
+that **every phase pays off on maintenance, testability, and contributor-friendliness alone** —
+and so that the Avalonia swap is **deferred to a measured prototype (Phase 5)**, never a
+prerequisite.
+
+The target end-state is a **headless net8.0 assembly** (grown from `Gum.ProjectServices`, or a new
+`Gum.Core`) that holds tool logic with **no WPF/WinForms reference**, so that the **compiler — not
+convention — enforces** the logic↔view boundary.
+
+## Consequences
+
+- **Easier:** logic becomes unit-testable without standing up the UI; the contribution barrier
+  drops (bus-factor insurance for a solo-maintained project); the Avalonia decision becomes
+  data-driven and cheap to either enter or skip.
+- **Harder / cost:** sustained refactoring effort. The ~475 `.Self` statics and the two WinForms
+  subsystems are genuine multi-week work, not cleanup.
+- **Watch-out:** half-done migrations leave confusing debris (the state-tree migration already did
+  this). The standing rule: a subsystem is not migrated until its old-tech references are *gone*,
+  not merely bypassed.
+- **Follow-up:** the ViewModel-type question this surfaced is decided separately in **ADR-0004**.
+
+## Alternatives considered
+
+- **Commit to Avalonia now.** Rejected: a large bet on a new audience that is not yet scoped;
+  premature, and it would mean rewriting against still-coupled logic.
+- **Do nothing / leave coupled.** Rejected: forecloses the cross-platform option and keeps the
+  logic untestable and maintenance-hostile.
+- **Convention-only separation** (keep everything in one `net8.0-windows` assembly, rely on
+  discipline not to import WPF in logic). Rejected: convention does not hold over years under a
+  solo maintainer; a project-reference boundary is the only durable enforcement.

--- a/Direction/decisions/0004-viewmodels-expose-neutral-presentation-state.md
+++ b/Direction/decisions/0004-viewmodels-expose-neutral-presentation-state.md
@@ -1,0 +1,57 @@
+# 0004. ViewModels expose resolved display state in neutral types (Presentation Model)
+
+- **Status:** Accepted
+- **Date:** 2026-06-20
+- **Deciders:** Victor Chelaru, Claude
+
+## Context
+
+Conventional MVVM pushes display-formatting decisions (when is something visible? what color is
+it?) into XAML value converters, leaving ViewModels holding only raw data. That makes the
+formatting *decisions* — which are real logic — effectively untestable.
+
+Gum's ViewModels instead **resolve display state directly** (a deliberate choice, good for
+testability). Today they do so in **WPF types** (`Visibility`, `Color`, `Brush`,
+`WriteableBitmap`). That pins those ~35 ViewModels to the `net8.0-windows` / `UseWPF` assembly and
+would **defeat the compiler-enforced boundary** established in ADR-0003 — they could not move into
+the headless assembly.
+
+A common assumption is that keeping WPF types is fine because porting them to Avalonia later is
+"mechanical." That holds for **`Color`** (near-identical struct) but **not** for the rest:
+Avalonia has **no `Visibility` enum** (it uses a `bool IsVisible` — a semantic 3-state→2-state
+change, per binding site), and `Brush` / `WriteableBitmap` are not namespace swaps. So the
+expensive, common cases are exactly where "mechanical" fails.
+
+## Decision
+
+We will **keep resolving display state in ViewModels** (the **Presentation Model** pattern,
+deliberately chosen over converter-based MVVM for testability) — but express it in
+**framework-neutral types** so the ViewModels remain eligible for the headless assembly:
+
+- **visibility → `bool`** (also Avalonia's native model, and *less* code than the WPF enum)
+- **color → Gum's native color type** (`RenderingLibrary` already has one)
+- **brush → resolve to a color** in the ViewModel; the view builds the brush
+- **pixel / image data → `byte[]` or a Gum image type**; the view builds the bitmap
+
+Framework types (`System.Windows.*`, later `Avalonia.*`) appear **only in a thin converter / view
+layer**. A one-off, single-consumer ViewModel that is permanently a view concern may keep a
+framework type **by explicit, documented exception** — never as the default.
+
+## Consequences
+
+- **Easier:** full testability of the formatting decisions is retained; the ViewModels become
+  movable into the headless assembly; a future UI swap touches **one converter layer, not ~35
+  ViewModels**. `bool` visibility is a strict improvement *today* (cleaner asserts, stock
+  `BoolToVisibilityConverter` for WPF).
+- **Harder / cost:** a small neutral-type + converter layer to maintain; marginally more ceremony
+  than using WPF types directly. Accepted because the common types are cheap or already exist
+  (`bool` is free; Gum owns a color type).
+- This refines Phase 3 of `ui-decoupling-plan.md` from "remove `System.Windows` from VMs" to
+  "expose resolved state in neutral types."
+
+## Alternatives considered
+
+- **Keep WPF types in ViewModels** (the original proposal). Rejected: pins ~35 ViewModels out of
+  the headless assembly and rests on a "mechanical port" assumption that holds only for `Color`.
+- **Pure converter-based MVVM** (no resolved state in the VM at all). Rejected: sacrifices the
+  testability of the formatting decisions, which is the entire reason for resolving in the VM.

--- a/Direction/decisions/README.md
+++ b/Direction/decisions/README.md
@@ -22,3 +22,5 @@ re-litigating it.
 |------|--------------------------------------------------|----------|------------|
 | [0001](0001-track-direction-in-checked-in-markdown.md) | Track project direction in checked-in Markdown | Accepted | 2026-06-20 |
 | [0002](0002-target-code-first-frameworks-not-engines.md) | Target code-first C# frameworks, not full engines | Accepted | 2026-06-20 |
+| [0003](0003-decouple-tool-ui-from-logic.md) | Decouple the Gum tool's UI from its application logic | Accepted | 2026-06-20 |
+| [0004](0004-viewmodels-expose-neutral-presentation-state.md) | ViewModels expose resolved display state in neutral types | Accepted | 2026-06-20 |

--- a/Direction/roadmap.md
+++ b/Direction/roadmap.md
@@ -27,6 +27,10 @@ Horizons describe *confidence and proximity*, not fixed dates:
   Avalonia (the Mac/Linux editor bet), this is the key enabler; if it doesn't, it still improves
   testability (logic becomes unit-testable without the UI), maintainability, and contributor
   friendliness — valuable under every branch of the editor decision.
+  - **Plan & decisions:** the phased approach lives in [`ui-decoupling-plan.md`](ui-decoupling-plan.md);
+    the architecture calls are recorded in
+    [ADR-0003](decisions/0003-decouple-tool-ui-from-logic.md) (the approach) and
+    [ADR-0004](decisions/0004-viewmodels-expose-neutral-presentation-state.md) (the ViewModel rule).
 
 ## Next
 

--- a/Direction/ui-decoupling-plan.md
+++ b/Direction/ui-decoupling-plan.md
@@ -1,0 +1,88 @@
+# Gum Tool — UI / Logic Decoupling Plan
+
+> Living document. The detail behind the **Now** roadmap item *"Decouple UI from logic in the Gum
+> tool."* Phases move and evolve as reality changes — this is intent, not a contract. Date
+> significant changes. Created 2026-06-20.
+>
+> Point-in-time decisions are captured separately (append-only): **ADR-0003** (the approach) and
+> **ADR-0004** (the ViewModel rule).
+
+## Why — and why it's no-regret
+
+The goal is **not "remove WPF."** It is: make application logic stop depending on the view, and
+let the compiler enforce it. Every phase below pays off on **maintenance, testability, and
+contributor-friendliness alone** — independent of whether Gum ever ships an Avalonia editor. The
+actual Avalonia swap (the Mac/Linux editor bet) is a *separate* reach decision, deferred to a
+measured prototype at the end, never a prerequisite. See ADR-0003.
+
+## Where the tool actually is today (grounding)
+
+The premise "swap WPF for Avalonia" mis-locates the cost. The mapping found:
+
+- **WPF's footprint is thin and already half-abstracted.** There is a real Microsoft.Extensions
+  DI Generic-Host composition root, a genuinely headless `Gum.ProjectServices` assembly (net8.0,
+  cannot reference WPF), an `IDispatcher`/`IDialogService` seam, and a real unit-test suite.
+- **The real entanglement is WinForms**, concentrated in **two load-bearing subsystems**: the KNI
+  render/editor host (`GraphicsDeviceControl` + the input library) and the element tree
+  (`MultiSelectTreeView` + the ~3k-line `ElementTreeViewManager`). Everything else is shallow:
+  one true WinForms `Form`, the `Keys` enum for hotkeys, `DataObject`/`DragDropEffects` for
+  drag-drop, and vestigial glue left by the already-migrated state tree.
+- **Cross-cutting drag:** ~475 `.Self` static calls across ~103 files, and ~35 ViewModels that
+  reach into `System.Windows.*`.
+- **The biggest asset:** the renderer is **render-to-texture + CPU readback**, not a swapchain
+  presenting to an HWND. It already hands any host a portable CPU pixel buffer — so the hard part
+  of embedding a GPU surface in a new UI framework (airspace, HWND interop, swapchain present)
+  **does not exist here.** Any framework that can blit a bitmap can host the Gum canvas.
+
+## The phases
+
+Each lists its goal, the payoff if Avalonia never ships, and the main risk.
+
+**Phase 0 — Instrument the burn-down.** Establish a measurable coupling budget (counts of `.Self`
+calls, `System.Windows.*` usages in VMs, inline dialog/`MessageBox` sites, WinForms-type leaks in
+interfaces) and, ideally, a guard test that fails when a VM imports `System.Windows`. *Payoff:*
+turns "we're decoupling" into a number that can't silently regress. *Risk:* trivial.
+
+**Phase 1 — Kill the shallow scatter & seal the leaky seams.** Gum-owned key enum to replace
+`Keys`; abstract drag-drop off the WinForms types; move the lone `Form` and the inline dialogs
+behind `IDialogService`; stop the "abstraction" interfaces from returning view types; delete the
+vestigial state-tree glue. *Payoff:* removes the WinForms flag from several projects; clears real
+debt. *Risk:* low; wide but shallow.
+
+**Phase 2 — Drain the statics.** Migrate `.Self` call sites to constructor injection; retire the
+`Locator` fallback. *Payoff:* the biggest single lever on testability and the contribution
+barrier (bus-factor insurance). *Risk:* high volume, low per-change risk.
+
+**Phase 3 — Extract logic into the headless assembly.** Move WPF-free logic into a net8.0 assembly
+so the boundary is compiler-enforced. Convert the ViewModels that reach into `System.Windows.*` to
+neutral types per **ADR-0004**. *Payoff:* the testability ceiling jumps; the boundary becomes a
+guarantee. *Risk:* medium; the VM conversion is the bulk.
+
+**Phase 4 — The two WinForms subsystems** (the real cost; multi-week each, can overlap).
+- *4a — Element tree:* decouple `ElementTreeViewManager` from `TreeNode`; the already-migrated
+  state tree is the proven template.
+- *4b — Rendering host:* formalize a host contract around `SystemManagers.Initialize(GraphicsDevice)`
+  plus pixel-buffer-out / input-in, and lift the cursor/keyboard off the WinForms control. The
+  `3218-skiasharp-host-model` work is the prototype. *Payoff (even on WPF):* lets the
+  `WindowsFormsHost` airspace/focus hacks be deleted.
+
+**Phase 5 — The actual bet (deferred, and only now decidable).** Build *one* real Avalonia screen
+(the tree, or the canvas on the Skia host) against the now-unchanged logic. **Measure** the
+effort, then decide the reach-vs-cost question (see `open-questions.md` and the roadmap **Later**
+item) with data instead of a guess.
+
+## Ordering rationale
+
+The order is chosen so each phase de-risks the next: instrument before changing (Phase 0 is the
+ruler); drain statics before extracting the assembly (Phase 2 → 3), because a half-global object
+graph can't cleanly move; seal the interface seams before any view swap (Phase 1 → 5). Avalonia is
+last because only then is its cost measurable rather than guessed.
+
+**Motivation caveat (deliberate deviation from strict risk-order):** the rendering host (4b) is
+both the most fun and already in flight. It may run as a *parallel refuel track* alongside the
+Phase 0–2 grind — kept as a **prototype** so it doesn't force the assembly split before Phase 3 is
+ready. For a solo-maintained project, protecting maintainer engagement outranks strict sequencing.
+
+**Migration discipline:** a subsystem is not "migrated" until the old-tech references are *gone*,
+not merely bypassed. The state-tree migration left vestigial WinForms-typed glue behind — exactly
+the kind of debris that taxes the next contributor. Finish each migration.

--- a/Direction/ui-decoupling-plan.md
+++ b/Direction/ui-decoupling-plan.md
@@ -71,6 +71,21 @@ guarantee. *Risk:* medium; the VM conversion is the bulk.
 effort, then decide the reach-vs-cost question (see `open-questions.md` and the roadmap **Later**
 item) with data instead of a guess.
 
+## Definition of done — every change lands a *tested* unit
+
+This effort's payoff *is* testability, so the bar for every change is not just "logic moved out of
+the view" but "logic moved into a unit that now has a test." Specifically:
+
+- **Each change migrates code into a testable class** — a service, ViewModel, or utility — not
+  merely shuffled within a view-bound class.
+- **TDD it when the change adds or alters behavior:** failing test first, then the change.
+- **Pin it when the change is behavior-preserving:** a pure extraction/move still gets a
+  *characterization (pinning) test* on the newly-extracted unit afterward — even though a pure
+  refactor would otherwise be test-exempt. An extracted-but-untested seam has done the hard part
+  and skipped the reward; capitalizing on the new seam is the whole point.
+
+The operational *how* lives in the `tdd` and `refactoring-direction` skills.
+
 ## Ordering rationale
 
 The order is chosen so each phase de-risks the next: instrument before changing (Phase 0 is the


### PR DESCRIPTION
## What

Adds the phased plan and decision records for the **Now** roadmap item *"Decouple UI from logic in
the Gum tool,"* under `Direction/`.

Contents:
- **`Direction/ui-decoupling-plan.md`** (living) — the detail behind the roadmap item: a grounding
  snapshot of where the tool actually sits today (WPF is thin and half-abstracted; the real
  coupling is WinForms in two load-bearing subsystems + ~475 `.Self` statics + ~35 VMs reaching
  into `System.Windows.*`; the renderer's render-to-texture readback is a major portability asset),
  the **6 phases** (instrument → scatter cleanup → drain statics → headless extraction → the two
  WinForms subsystems → a deferred, measured Avalonia prototype), and the ordering rationale.
- **ADR-0003** — *Decouple the Gum tool's UI from its application logic.* The no-regret approach:
  every phase pays off on maintenance/testability/contributor grounds alone; the Avalonia swap is
  deferred to a measured prototype (Phase 5), never a prerequisite; the end-state is a headless
  net8.0 assembly so the **compiler** enforces the logic↔view boundary.
- **ADR-0004** — *ViewModels expose resolved display state in neutral types (Presentation Model).*
  Keep resolving display state in VMs (testable), but in neutral types (`bool`, Gum color, `byte[]`)
  rather than WPF types — so the VMs stay headless-assembly-eligible and a future UI swap touches
  one converter layer, not ~35 VMs.

Also links the new docs from the existing roadmap **Now** item and adds both ADRs to the decisions
index.

## Why

Captures the strategy/decisions from a design discussion so the reasoning survives context clears
and is reviewable, before any of the actual decoupling code work begins. Docs-only; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
