### PR TITLE
Make GraphicalUiElement.AddChild/RemoveChild instance methods so gue.AddChild(formsControl) works under 'using Gum;' (#3226)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,8 @@ Examples:
 
 If a runtime change is in `GumCommon` and you've already built `MonoGameGum.Tests`, that pulls in `GumCommon` and `MonoGameGum` transitively — no need to also build the solution.
 
+**Don't initialize the FNA or Sokol submodules — or build `AllLibraries.sln`, which pulls them in — unless your change actually touches FNA or Sokol code.** A fresh clone/worktree leaves these submodules uninitialized; initializing them triggers a large recursive clone (FNA → SDL/FAudio/FNA3D/…) that can cost many minutes of wall-clock for near-zero added signal. For runtime/library changes, build the individual csprojs instead: `MonoGameGum.Tests` (covers `GumCommon` + `MonoGameGum`), plus `KniGum`, `RaylibGum`, and `SkiaGum`/`SkiaGum.Wpf` as relevant (none need submodules). `FnaGum` is `XNALIKE` — the same compile family as MonoGame/KNI, so if those build it almost certainly does — and Sokol is experimental; neither justifies a submodule clone for a typical `GumCommon` change. Build `AllLibraries.sln` (after the submodules are initialized) only when the change genuinely spans FNA/Sokol.
+
 **Running focused tool unit tests (`GumToolUnitTests`).** Building this project triggers the plugin projects' post-build copy, which uses `$(SolutionDir)`. To run the csproj directly, supply it — with **backslashes** (forward slashes break the `copy`/`md` steps):
 
 ```

--- a/GumCommon/Forms/GraphicalUiElement.Forms.cs
+++ b/GumCommon/Forms/GraphicalUiElement.Forms.cs
@@ -1,0 +1,34 @@
+// Forms-aware members of GraphicalUiElement. Kept in a partial compiled ONLY into GumCommon
+// (and therefore every runtime that references it) — intentionally NOT shared to FRB via
+// GumCoreShared.projitems, mirroring GumServiceCompat.cs. FRB has its own FrameworkElement and
+// reaches the same behavior through FlatRedBall.Forms' extension methods, so it must not see
+// these. The #if !FRB (covering the using as well as the type) is defensive in case this file is
+// ever linked into an FRB-shared project — there, Gum.Forms.Controls does not exist.
+#if !FRB
+using Gum.Forms.Controls;
+
+namespace Gum.Wireframe;
+
+public partial class GraphicalUiElement
+{
+    /// <summary>
+    /// Parents the supplied Forms control under this visual by adding the control's
+    /// <see cref="FrameworkElement.Visual"/> to this element's <see cref="Children"/>.
+    /// </summary>
+    /// <remarks>
+    /// This is an <b>instance</b> method rather than an extension (the matching extension lives in
+    /// <c>Gum.Forms.Controls.FrameworkElementExt</c>) so that <c>gue.AddChild(formsControl)</c>
+    /// compiles under just <c>using Gum;</c> — with no <c>using Gum.Forms.Controls;</c>, which would
+    /// drag in the control type names (<c>Label</c>, <c>StackPanel</c>, …) and collide with
+    /// user components of the same name. Instance methods also win overload resolution over the
+    /// extension, so importing both namespaces is never ambiguous (CS0121). This supersedes the
+    /// legacy <c>using MonoGameGum;</c> / <c>using RaylibGum;</c> shim for new code.
+    /// </remarks>
+    public void AddChild(FrameworkElement child) => Children.Add(child.Visual);
+
+    /// <summary>
+    /// Removes a Forms control previously parented via <see cref="AddChild(FrameworkElement)"/>.
+    /// </summary>
+    public void RemoveChild(FrameworkElement child) => Children.Remove(child.Visual);
+}
+#endif

--- a/MonoGameGum.Tests/Forms/GraphicalUiElementFormsInstanceTests.cs
+++ b/MonoGameGum.Tests/Forms/GraphicalUiElementFormsInstanceTests.cs
@@ -1,0 +1,43 @@
+using Gum.GueDeriving;
+using MonoGameGum.Tests;
+using Shouldly;
+using Xunit;
+
+// IMPORTANT: this test lives in the Gum.Wireframe.Tests namespace (NOT MonoGameGum.Tests.*)
+// and intentionally does NOT import `Gum.Forms.Controls` or `MonoGameGum`. That restriction is
+// the whole point of issue #3226: it proves `gue.AddChild(formsControl)` / `gue.RemoveChild(...)`
+// resolve through the new INSTANCE methods on GraphicalUiElement alone — with neither the
+// `Gum.Forms.Controls.FrameworkElementExt.AddChild` extension nor the legacy `MonoGameGum`
+// (GumServiceCompat) shim in scope. The Button below is therefore referenced fully-qualified.
+//
+// Do NOT "tidy" this into the MonoGameGum.Tests.Forms namespace or add `using Gum.Forms.Controls;`:
+// the MonoGameGum namespace is an *enclosing* namespace of MonoGameGum.Tests.*, so the compat
+// AddChild extension would silently come back into scope and these tests would pass even if the
+// instance methods were deleted — defeating the regression they exist to catch.
+namespace Gum.Wireframe.Tests;
+
+public class GraphicalUiElementFormsInstanceTests : BaseTestClass
+{
+    [Fact]
+    public void AddChild_ShouldParentFormsControlVisualUnderVisual()
+    {
+        ContainerRuntime parent = new ContainerRuntime();
+        Gum.Forms.Controls.Button child = new Gum.Forms.Controls.Button();
+
+        parent.AddChild(child);
+
+        parent.Children.ShouldContain(child.Visual);
+    }
+
+    [Fact]
+    public void RemoveChild_ShouldUnparentFormsControlVisualFromVisual()
+    {
+        ContainerRuntime parent = new ContainerRuntime();
+        Gum.Forms.Controls.Button child = new Gum.Forms.Controls.Button();
+        parent.AddChild(child);
+
+        parent.RemoveChild(child);
+
+        parent.Children.ShouldNotContain(child.Visual);
+    }
+}

--- a/MonoGameGum/GumService.cs
+++ b/MonoGameGum/GumService.cs
@@ -1529,11 +1529,15 @@ public class GumService : IGumService
 #endif
 }
 
-// GraphicalUiElementExtensionMethods (AddToRoot/RemoveFromRoot/AddChild) is intentionally
-// NOT in the Gum namespace. AddToRoot/RemoveFromRoot are instance methods on
-// GraphicalUiElement, and the AddChild codegen crutch lives only in the legacy
-// namespaces (GumServiceCompat.cs) so `using Gum;` never makes gue.AddChild(formsChild)
-// ambiguous with Gum.Forms.Controls.FrameworkElementExt.AddChild. See issue #3119.
+// AddToRoot/RemoveFromRoot and AddChild/RemoveChild are all instance methods on
+// GraphicalUiElement (the latter pair added in GumCommon/Forms/GraphicalUiElement.Forms.cs),
+// so gue.AddToRoot()/gue.AddChild(formsChild) work under just `using Gum;` — no
+// Gum.Forms.Controls or legacy MonoGameGum/RaylibGum import needed, hence no collision with
+// user components named Label/StackPanel/etc. Instance methods also win overload resolution
+// over Gum.Forms.Controls.FrameworkElementExt.AddChild, so importing both namespaces is never
+// ambiguous (CS0121). The AddChild extension in GumServiceCompat.cs remains only so older
+// generated code (syntax versions 0-2) that imports the legacy namespace keeps compiling.
+// See issues #3119 and #3226.
 
 /// <summary>
 /// Convenience extensions for creating runtime visuals from loaded project elements.

--- a/docs/gum-tool/upgrading/migrating-to-2026-june.md
+++ b/docs/gum-tool/upgrading/migrating-to-2026-june.md
@@ -35,6 +35,7 @@ Most changes are **soft breaks**: a permanent `[Obsolete]` shim keeps the old na
 | `GumService` | `MonoGameGum` / `RaylibGum` | `Gum` | Soft — obsolete shim (`CS0618`) |
 | `WindowZoomMode` and hot-reload types | `MonoGameGum` / `RaylibGum` | `Gum` | **Hard** — `CS0246` (enums/types can't be shimmed) |
 | `AddToRoot` / `RemoveFromRoot` | platform extension method | instance method on `GraphicalUiElement` | None — call sites unchanged |
+| `AddChild` / `RemoveChild` (Forms control under a visual) | `Gum.Forms.Controls` extension / `MonoGameGum` shim | instance method on `GraphicalUiElement` | None — call sites unchanged |
 | `ElementSaveExtensionMethods.ToGraphicalUiElement` | `MonoGameGum` | `Gum` | Soft — obsolete forwarder (`CS0618`) |
 | `IReadOnlyListExtensionMethods`, default-filled/stroked renderables, default-visual runtimes | `MonoGameGum.ExtensionMethods` / `.Renderables` / `.Forms.DefaultVisuals` | `Gum.*` | Soft — obsolete shims (`CS0618`) |
 | `Keyboard`, `KeyboardStateProcessor`, `AnalogButton`, deadzone enums, `IInputReceiverKeyboardMonoGame` | `MonoGameGum.Input` | `Gum.Input` | Namespace move — add `using Gum.Input;` (GUM001) |
@@ -139,6 +140,14 @@ If `using Gum;` conflicts with something in your project, use the fully-qualifie
 `AddToRoot()` and `RemoveFromRoot()` are now instance methods on `GraphicalUiElement`, dispatching through `IGumService.Default`. No `using` directive is needed at all — call sites that previously needed `using MonoGameGum;` (or `using RaylibGum;` / `using SokolGum;`) solely for these methods can drop that `using` if it is not needed for other reasons.
 
 The per-platform `GraphicalUiElementExtensionMethods.AddToRoot / RemoveFromRoot` extension methods that previously lived in each platform namespace have been deleted. Since instance methods always win over extension methods in C#, call sites of the form `element.AddToRoot();` continue to compile and work identically — they now resolve to the instance method rather than the extension. No call-site changes are needed.
+
+### `AddChild` / `RemoveChild` for Forms Controls Are Now Instance Methods
+
+Parenting a Forms control under a visual — `gue.AddChild(formsControl)` / `gue.RemoveChild(formsControl)` — previously required `using Gum.Forms.Controls;` (for the `FrameworkElementExt` extension) or the legacy `using MonoGameGum;` / `using RaylibGum;` shim. Importing `Gum.Forms.Controls` drags in the Forms control type names (`Label`, `StackPanel`, …), which collide (`CS0104`) with user components named the same way.
+
+`AddChild(FrameworkElement)` and `RemoveChild(FrameworkElement)` are now also instance methods on `GraphicalUiElement`, so `gue.AddChild(formsControl)` compiles under just `using Gum;` — no Forms-control or platform `using` needed, hence no name collision. Because instance methods win overload resolution over extension methods, importing both `Gum;` and `Gum.Forms.Controls;` is never ambiguous (`CS0121`); the instance method always resolves.
+
+Unlike `AddToRoot` / `RemoveFromRoot`, the existing `Gum.Forms.Controls.FrameworkElementExt.AddChild` extension and the legacy `MonoGameGum` / `RaylibGum` shim are **not** deleted — they remain for FlatRedBall and older generated code, so no existing call sites change.
 
 ### `MonoGameGum.ElementSaveExtensionMethods.ToGraphicalUiElement` Is Now `[Obsolete]`
 


### PR DESCRIPTION
## What

Makes `AddChild(FrameworkElement)` / `RemoveChild(FrameworkElement)` **instance** methods on `GraphicalUiElement` (mirroring how `AddToRoot`/`RemoveFromRoot` became instance methods), so `gue.AddChild(formsControl)` compiles under just `using Gum;`:

- **Collision-free** — no `using Gum.Forms.Controls;`, so the Forms control type names (`Label`, `StackPanel`, …) aren't pulled in and can't collide (`CS0104`) with user components of the same name.
- **Never ambiguous** — instance methods win overload resolution over `Gum.Forms.Controls.FrameworkElementExt.AddChild`, so importing both namespaces is never `CS0121`.

This removes the last thing forcing the obsolete `MonoGameGum`/`RaylibGum` namespaces onto modern hand-written code.

## Changes

- **New** `GumCommon/Forms/GraphicalUiElement.Forms.cs` — the two instance methods (`Children.Add/Remove(child.Visual)`, identical behavior to the existing extension), guarded by `#if !FRB`.
- **`MonoGameGum/GumService.cs`** — updated the now-stale comment that said `AddChild` was intentionally kept out of the `Gum` namespace.
- **`docs/gum-tool/upgrading/migrating-to-2026-june.md`** — added a migration table row + subsection (noting that, unlike `AddToRoot`/`RemoveFromRoot`, the `AddChild` extension/shim are **not** deleted).
- **`MonoGameGum.Tests/Forms/GraphicalUiElementFormsInstanceTests.cs`** — focused TDD test for the instance `AddChild`/`RemoveChild` behavior.

## Notes on intentional decisions

- **`GraphicalUiElement.Forms.cs` is intentionally NOT in `GumCoreShared.projitems`** — this is the rare FRB-exclusion case (FRB has its own `FrameworkElement` and reaches the same behavior via `FlatRedBall.Forms` extensions), mirroring `GumServiceCompat.cs`. GumCommon auto-globs its own folder, so the file is compiled into GumCommon (and thus every runtime that references it) with no csproj edit.
- **The test lives in namespace `Gum.Wireframe.Tests` (not `MonoGameGum.Tests.*`) and imports neither `Gum.Forms.Controls` nor `MonoGameGum` on purpose** — that's what proves the call resolves through the new instance methods alone. (The `MonoGameGum` namespace is an *enclosing* namespace of `MonoGameGum.Tests.*`, so the compat shim would otherwise silently satisfy the call.) A header comment explains this so it isn't "tidied" away.
- **The 2 inventory sample files (`StardewInventoryScreen.cs`, `HyTaleInventoryScreen.cs`) are untouched** — they belong to #3222, which is stacked on this PR.
- Minor deviation from the issue's snippet: the `using Gum.Forms.Controls;` is placed **inside** the `#if !FRB` so the defensive guard actually holds if the file were ever FRB-linked (the namespace doesn't exist in FRB).

## Verification

- TDD red → green: red was `CS1503` (`Button` can't convert to `GraphicalUiElement` — no `AddChild(FrameworkElement)` in scope); green after adding the instance methods.
- `dotnet build AllLibraries.sln` — succeeded (MonoGameGum, KniGum, FnaGum, SkiaGum, RaylibGum, GumCommon).
- `dotnet build Runtimes/SkiaGum.Wpf/SkiaGum.Wpf.csproj` (not in AllLibraries) — succeeded.
- `dotnet build Samples/raylib/RaylibSample.sln` (imports **both** `Gum` and `Gum.Forms.Controls` and calls `gue.AddChild(...)` — the `CS0121` canary) — succeeded.
- `MonoGameGum.Tests` full suite — 1751 passed, 0 failed (includes the 2 new tests).
- FRB unaffected: the new file is GumCommon-only / not FRB-shared, and the edited `GumService.cs` is itself not FRB-shared — no `GumCoreShared.projitems` sync needed.

Closes #3226.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
