### PR TITLE
Phase 0: coupling burn-down ratchet for tool UI/logic decoupling

### DIFF
--- a/Tool/Tests/GumToolUnitTests/Coupling/CouplingRatchetTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Coupling/CouplingRatchetTests.cs
@@ -1,0 +1,221 @@
+using System;
+using System.IO;
+using System.Text.Json;
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace GumToolUnitTests.Coupling;
+
+/// <summary>
+/// Locates the Gum tool source tree, runs <see cref="CouplingScanner"/> over it once, and
+/// loads the checked-in baseline. Shared across all ratchet tests via <see cref="IClassFixture{T}"/>
+/// so the (single) full-tree scan happens only once per test run.
+/// </summary>
+public sealed class CouplingScanFixture
+{
+    public CouplingMetrics Measured { get; }
+    public CouplingBaseline Baseline { get; }
+    public string ToolSourceRoot { get; }
+
+    public CouplingScanFixture()
+    {
+        string repoRoot = LocateRepoRoot();
+        ToolSourceRoot = Path.Combine(repoRoot, "Gum");
+
+        CouplingScanner scanner = new CouplingScanner();
+        Measured = scanner.ScanToolSource(ToolSourceRoot);
+
+        // Sanity floor: a found-but-degenerate tool root (empty, wrong directory, or a future
+        // source reorg) would make the scan return near-zero counts, and EVERY ratchet guard
+        // (measured <= baseline) would then pass VACUOUSLY -- 0 <= baseline is always true.
+        // Throwing here fails all ratchet tests loudly instead of going green for free. The
+        // floors sit well below today's real counts (~470 files / ~55 ViewModels) but far above
+        // zero, so they only trip on a genuinely broken scan, never on legitimate burn-down.
+        const int minimumFilesScanned = 100;
+        const int minimumViewModelFilesScanned = 10;
+        if (Measured.FilesScanned < minimumFilesScanned ||
+            Measured.ViewModelFilesScanned < minimumViewModelFilesScanned)
+        {
+            throw new InvalidOperationException(
+                $"Coupling scan looks degenerate: scanned {Measured.FilesScanned} files and " +
+                $"{Measured.ViewModelFilesScanned} ViewModel files under '{ToolSourceRoot}' " +
+                $"(floors: {minimumFilesScanned} files, {minimumViewModelFilesScanned} ViewModels). " +
+                "The scanner almost certainly pointed at the wrong root -- the ratchet guards would " +
+                "otherwise pass vacuously against an empty or incorrect tree.");
+        }
+
+        string baselinePath = Path.Combine(
+            repoRoot, "Tool", "Tests", "GumToolUnitTests", "Coupling", "coupling-baseline.json");
+        Baseline = LoadBaseline(baselinePath);
+    }
+
+    /// <summary>
+    /// Walks up from the test assembly's location until it finds the repo root, identified by the
+    /// presence of the Gum tool's main project file (<c>Gum/Gum.csproj</c>). This is robust for both
+    /// the primary checkout and a git worktree, because each worktree carries its own <c>Gum/</c>.
+    /// </summary>
+    private static string LocateRepoRoot()
+    {
+        DirectoryInfo? directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory != null)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "Gum", "Gum.csproj")))
+            {
+                return directory.FullName;
+            }
+            directory = directory.Parent;
+        }
+
+        throw new DirectoryNotFoundException(
+            "Could not locate the Gum repo root (no ancestor of " +
+            $"'{AppContext.BaseDirectory}' contains Gum/Gum.csproj). The coupling ratchet needs " +
+            "the tool source tree to scan.");
+    }
+
+    private static CouplingBaseline LoadBaseline(string baselinePath)
+    {
+        if (!File.Exists(baselinePath))
+        {
+            throw new FileNotFoundException(
+                $"Coupling baseline file not found: '{baselinePath}'.", baselinePath);
+        }
+
+        string json = File.ReadAllText(baselinePath);
+        JsonSerializerOptions options = new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true
+        };
+        CouplingBaseline? baseline = JsonSerializer.Deserialize<CouplingBaseline>(json, options);
+        if (baseline == null)
+        {
+            throw new InvalidOperationException(
+                $"Coupling baseline file '{baselinePath}' deserialized to null.");
+        }
+        return baseline;
+    }
+}
+
+/// <summary>
+/// The Phase 0 ratchet guard. Runs <see cref="CouplingScanner"/> over the real Gum tool source tree
+/// and asserts each coupling count is &lt;= its checked-in baseline. Green today; red the moment any
+/// metric regresses above baseline. A Phase 1 PR lowers a baseline (a one-line edit to
+/// coupling-baseline.json) in the same diff that removes the coupling.
+/// </summary>
+public sealed class CouplingRatchetTests : IClassFixture<CouplingScanFixture>
+{
+    private readonly CouplingScanFixture _fixture;
+    private readonly ITestOutputHelper _output;
+
+    public CouplingRatchetTests(CouplingScanFixture fixture, ITestOutputHelper output)
+    {
+        _fixture = fixture;
+        _output = output;
+    }
+
+    [Fact]
+    public void InlineDialogSites_DoNotExceedBaseline()
+    {
+        int measured = _fixture.Measured.InlineDialogSites;
+        int baseline = _fixture.Baseline.Metrics.InlineDialogSites.RatchetedBaseline;
+
+        measured.ShouldBeLessThanOrEqualTo(
+            baseline,
+            customMessage: BuildRatchetMessage("inlineDialogSites", measured, baseline));
+    }
+
+    [Fact]
+    public void InterfaceTypeLeaks_DoNotExceedBaseline()
+    {
+        int measured = _fixture.Measured.InterfaceTypeLeaks;
+        int baseline = _fixture.Baseline.Metrics.InterfaceTypeLeaks.RatchetedBaseline;
+
+        measured.ShouldBeLessThanOrEqualTo(
+            baseline,
+            customMessage: BuildRatchetMessage("interfaceTypeLeaks", measured, baseline));
+    }
+
+    /// <summary>
+    /// Not a guard -- a convenience that prints the scanner's current measurements so a Phase 1 PR
+    /// can update coupling-baseline.json without re-deriving the numbers by hand. Always passes.
+    /// </summary>
+    [Fact]
+    public void Scanner_DumpMeasuredMetrics_ForBaselineUpdates()
+    {
+        CouplingMetrics m = _fixture.Measured;
+
+        _output.WriteLine($"Tool source root      : {_fixture.ToolSourceRoot}");
+        _output.WriteLine($"Files scanned         : {m.FilesScanned}");
+        _output.WriteLine($"ViewModel files       : {m.ViewModelFilesScanned}");
+        _output.WriteLine("--- ratcheted metrics (measured vs baseline) ---");
+        _output.WriteLine(
+            $"selfStaticReferences        : {m.SelfExcludingObjectFinder} " +
+            $"(baseline {_fixture.Baseline.Metrics.SelfStaticReferences.RatchetedBaseline}) " +
+            $"[total .Self {m.SelfTotal}, ObjectFinder.Self {m.ObjectFinderSelf}]");
+        _output.WriteLine(
+            $"windowsCouplingInViewModels : {m.WindowsCouplingInViewModels} " +
+            $"(baseline {_fixture.Baseline.Metrics.WindowsCouplingInViewModels.RatchetedBaseline})");
+        _output.WriteLine(
+            $"inlineDialogSites           : {m.InlineDialogSites} " +
+            $"(baseline {_fixture.Baseline.Metrics.InlineDialogSites.RatchetedBaseline})");
+        _output.WriteLine(
+            $"interfaceTypeLeaks          : {m.InterfaceTypeLeaks} " +
+            $"(baseline {_fixture.Baseline.Metrics.InterfaceTypeLeaks.RatchetedBaseline})");
+
+        // Always-pass sentinel so the output is captured even on a green run.
+        m.FilesScanned.ShouldBeGreaterThan(0);
+    }
+
+    [Fact]
+    public void SelfReferencesExcludingObjectFinder_DoNotExceedBaseline()
+    {
+        int measured = _fixture.Measured.SelfExcludingObjectFinder;
+        int baseline = _fixture.Baseline.Metrics.SelfStaticReferences.RatchetedBaseline;
+
+        measured.ShouldBeLessThanOrEqualTo(
+            baseline,
+            customMessage: BuildRatchetMessage("selfStaticReferences", measured, baseline));
+    }
+
+    [Fact]
+    public void WindowsCouplingInViewModels_DoNotExceedBaseline()
+    {
+        int measured = _fixture.Measured.WindowsCouplingInViewModels;
+        int baseline = _fixture.Baseline.Metrics.WindowsCouplingInViewModels.RatchetedBaseline;
+
+        measured.ShouldBeLessThanOrEqualTo(
+            baseline,
+            customMessage: BuildRatchetMessage("windowsCouplingInViewModels", measured, baseline));
+    }
+
+    // Shouldly only surfaces this customMessage when the assertion FAILS (measured > baseline),
+    // so the message is unconditionally written for that case -- there is no "slack" branch to
+    // build, because a passing assertion never shows it.
+    private string BuildRatchetMessage(string metric, int measured, int baseline)
+    {
+        return $"Coupling metric '{metric}' regressed: measured {measured} > baseline {baseline}. " +
+            "New UI/logic coupling was introduced. Remove it, or (if intentional) raise the baseline " +
+            "in coupling-baseline.json with justification.";
+    }
+}
+
+/// <summary>Deserialization shape for coupling-baseline.json. Only the ratcheted numbers are read.</summary>
+public sealed class CouplingBaseline
+{
+    public CouplingBaselineMetrics Metrics { get; set; } = new CouplingBaselineMetrics();
+}
+
+/// <summary>The four ratcheted metric entries.</summary>
+public sealed class CouplingBaselineMetrics
+{
+    public CouplingBaselineEntry SelfStaticReferences { get; set; } = new CouplingBaselineEntry();
+    public CouplingBaselineEntry WindowsCouplingInViewModels { get; set; } = new CouplingBaselineEntry();
+    public CouplingBaselineEntry InlineDialogSites { get; set; } = new CouplingBaselineEntry();
+    public CouplingBaselineEntry InterfaceTypeLeaks { get; set; } = new CouplingBaselineEntry();
+}
+
+/// <summary>A single metric's ratcheted baseline (the maximum the ratchet allows).</summary>
+public sealed class CouplingBaselineEntry
+{
+    public int RatchetedBaseline { get; set; }
+}

--- a/Tool/Tests/GumToolUnitTests/Coupling/CouplingScanner.cs
+++ b/Tool/Tests/GumToolUnitTests/Coupling/CouplingScanner.cs
@@ -1,0 +1,470 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.RegularExpressions;
+
+namespace GumToolUnitTests.Coupling;
+
+/// <summary>
+/// Number of <c>.Self</c> static-singleton references found in a chunk of source,
+/// split so that the sanctioned <c>ObjectFinder.Self</c> singleton can be excluded
+/// from the ratcheted burn-down number.
+/// </summary>
+public readonly record struct SelfReferenceCount(int Total, int ObjectFinder)
+{
+    /// <summary>
+    /// The ratcheted metric: every <c>.Self</c> reference except the sanctioned
+    /// <c>ObjectFinder.Self</c> singleton (see repo CLAUDE.md), which will never be removed.
+    /// </summary>
+    public int ExcludingObjectFinder => Total - ObjectFinder;
+}
+
+/// <summary>
+/// Aggregated coupling metrics for a whole tool source tree. This is the canonical,
+/// deterministic measurement that the Phase 0 ratchet test guards.
+/// </summary>
+public sealed class CouplingMetrics
+{
+    /// <summary>Total <c>.Self</c> references across all scanned files (includes ObjectFinder).</summary>
+    public int SelfTotal { get; }
+
+    /// <summary>The sanctioned <c>ObjectFinder.Self</c> sub-count, excluded from the ratchet.</summary>
+    public int ObjectFinderSelf { get; }
+
+    /// <summary>Ratcheted <c>.Self</c> metric (#1): total minus <c>ObjectFinder.Self</c>.</summary>
+    public int SelfExcludingObjectFinder => SelfTotal - ObjectFinderSelf;
+
+    /// <summary>Ratcheted metric (#2): WPF (<c>System.Windows.*</c>) coupling tokens inside ViewModels.</summary>
+    public int WindowsCouplingInViewModels { get; }
+
+    /// <summary>Ratcheted metric (#3): inline dialog sites bypassing IDialogService.</summary>
+    public int InlineDialogSites { get; }
+
+    /// <summary>Ratcheted metric (#4): WinForms/WPF type references inside interface bodies.</summary>
+    public int InterfaceTypeLeaks { get; }
+
+    /// <summary>Count of <c>.cs</c> files scanned (excludes bin/obj). For the dashboard only.</summary>
+    public int FilesScanned { get; }
+
+    /// <summary>Count of ViewModel <c>.cs</c> files scanned. For the dashboard only.</summary>
+    public int ViewModelFilesScanned { get; }
+
+    public CouplingMetrics(
+        int selfTotal,
+        int objectFinderSelf,
+        int windowsCouplingInViewModels,
+        int inlineDialogSites,
+        int interfaceTypeLeaks,
+        int filesScanned,
+        int viewModelFilesScanned)
+    {
+        SelfTotal = selfTotal;
+        ObjectFinderSelf = objectFinderSelf;
+        WindowsCouplingInViewModels = windowsCouplingInViewModels;
+        InlineDialogSites = inlineDialogSites;
+        InterfaceTypeLeaks = interfaceTypeLeaks;
+        FilesScanned = filesScanned;
+        ViewModelFilesScanned = viewModelFilesScanned;
+    }
+}
+
+/// <summary>
+/// Source-scanning coupling-metrics scanner for the Gum tool. The methods on this class
+/// are the single canonical, deterministic definition of each Phase 0 coupling metric;
+/// there is no separate grep-based method that could diverge from it.
+/// </summary>
+/// <remarks>
+/// All metrics are raw textual scans (comments and string literals are NOT stripped) for
+/// maximum determinism and simplicity, with one exception that genuinely needs structure:
+/// metric #4 isolates <c>interface</c> bodies with a comment/string-aware brace matcher.
+/// For a ratchet (assert count &lt;= baseline) any small over-count from a commented-out
+/// occurrence is conservative: it can never let a real regression slip through, it can only
+/// make the guard marginally looser by a constant.
+/// </remarks>
+public sealed class CouplingScanner
+{
+    // Metric #1 — .Self static-singleton references.
+    // `\.Self\b` matches `.Self` only when not followed by another identifier char, so
+    // `.SelfManager` does not count. The ObjectFinder sub-count is a strict subset.
+    private readonly Regex _selfTotalRegex;
+    private readonly Regex _objectFinderSelfRegex;
+
+    // Metric #2 — System.Windows.* coupling in ViewModels.
+    // (A) every `using System.Windows*;` import line, plus
+    // (B) every whole-word occurrence of an unambiguous WPF type the VMs use unqualified.
+    // (A) and (B) never cover the same characters, so there is no double-counting.
+    // Ambiguous simple names (Color/Point/Size/Key/Control) are deliberately excluded
+    // because they collide with XNA / System.Drawing / Gum / WinForms types.
+    private readonly Regex _windowsUsingRegex;
+    private readonly Regex _wpfTypeInViewModelRegex;
+
+    // Metric #3 — inline dialog sites bypassing IDialogService.
+    private readonly Regex _messageBoxRegex;
+    private readonly Regex _windowConstructionRegex;
+
+    // Metric #4 — WinForms/WPF type references inside interface bodies.
+    // Group 1 catches any fully-qualified `System.Windows.*` reference. Group 2 catches a
+    // documented allow-list of distinctive WPF/WinForms types used unqualified; the
+    // negative lookbehind `(?<![\w.])` keeps it from also matching the qualified form
+    // (which group 1 already counts), so there is no double-counting.
+    private readonly Regex _interfaceQualifiedLeakRegex;
+    private readonly Regex _interfaceUnqualifiedLeakRegex;
+
+    // ViewModel filename rule: `*ViewModel.cs` or partial `*ViewModel.*.cs`.
+    private readonly Regex _viewModelFileRegex;
+
+    public CouplingScanner()
+    {
+        _selfTotalRegex = new Regex(@"\.Self\b", RegexOptions.Compiled);
+        _objectFinderSelfRegex = new Regex(@"\bObjectFinder\.Self\b", RegexOptions.Compiled);
+
+        _windowsUsingRegex = new Regex(
+            @"^[ \t]*using[ \t]+System\.Windows",
+            RegexOptions.Compiled | RegexOptions.Multiline);
+        _wpfTypeInViewModelRegex = new Regex(
+            @"\b(Visibility|Brushes|SolidColorBrush|Brush|Application|Dispatcher|RoutedEventArgs|BitmapImage|Thickness|FrameworkElement)\b",
+            RegexOptions.Compiled);
+
+        _messageBoxRegex = new Regex(@"MessageBox\.Show", RegexOptions.Compiled);
+        _windowConstructionRegex = new Regex(@"new\s+[\w.]*Window\s*\(", RegexOptions.Compiled);
+
+        _interfaceQualifiedLeakRegex = new Regex(@"System\.Windows\.", RegexOptions.Compiled);
+        _interfaceUnqualifiedLeakRegex = new Regex(
+            @"(?<![\w.])(FrameworkElement|FrameworkContentElement|UIElement|Spinner|DragEventArgs|KeyPressEventArgs|MouseEventArgs)\b",
+            RegexOptions.Compiled);
+
+        _viewModelFileRegex = new Regex(@"ViewModel(\.[^\\/]+)?\.cs$", RegexOptions.Compiled);
+    }
+
+    /// <summary>
+    /// Metric #1. Counts <c>.Self</c> static-singleton references and the
+    /// <c>ObjectFinder.Self</c> sub-count in a single file's source text.
+    /// </summary>
+    public SelfReferenceCount CountSelfReferences(string source)
+    {
+        int total = _selfTotalRegex.Matches(source).Count;
+        int objectFinder = _objectFinderSelfRegex.Matches(source).Count;
+        return new SelfReferenceCount(total, objectFinder);
+    }
+
+    /// <summary>
+    /// Metric #2. Counts WPF coupling tokens in a single ViewModel's source text:
+    /// every <c>using System.Windows*;</c> line plus every whole-word allow-list WPF type.
+    /// Only call this on files for which <see cref="IsViewModelFile"/> is true.
+    /// </summary>
+    public int CountWindowsCouplingInViewModel(string source)
+    {
+        int usingLines = _windowsUsingRegex.Matches(source).Count;
+        int wpfTypes = _wpfTypeInViewModelRegex.Matches(source).Count;
+        return usingLines + wpfTypes;
+    }
+
+    /// <summary>
+    /// Metric #3. Counts inline dialog sites (<c>MessageBox.Show</c> and
+    /// <c>new *Window(</c>) in a single file's source text.
+    /// </summary>
+    public int CountInlineDialogSites(string source)
+    {
+        int messageBoxes = _messageBoxRegex.Matches(source).Count;
+        int windowConstructions = _windowConstructionRegex.Matches(source).Count;
+        return messageBoxes + windowConstructions;
+    }
+
+    /// <summary>
+    /// Metric #4. Counts WinForms/WPF type references that appear inside
+    /// <c>interface</c> bodies in a single file's source text.
+    /// </summary>
+    public int CountInterfaceTypeLeaks(string source)
+    {
+        int count = 0;
+        foreach (string body in ExtractInterfaceBodies(source))
+        {
+            count += _interfaceQualifiedLeakRegex.Matches(body).Count;
+            count += _interfaceUnqualifiedLeakRegex.Matches(body).Count;
+        }
+        return count;
+    }
+
+    /// <summary>
+    /// True when <paramref name="fileName"/> is a ViewModel file by the documented
+    /// filename rule (<c>*ViewModel.cs</c> or partial <c>*ViewModel.*.cs</c>).
+    /// </summary>
+    public bool IsViewModelFile(string fileName)
+    {
+        return _viewModelFileRegex.IsMatch(fileName);
+    }
+
+    /// <summary>
+    /// True when <paramref name="relativePath"/> is part of the dialog infrastructure
+    /// (<c>Services/Dialogs/</c>), which is excluded from the inline-dialog metric.
+    /// </summary>
+    public bool IsDialogInfrastructure(string relativePath)
+    {
+        string normalized = relativePath.Replace('\\', '/');
+        return normalized.Contains("Services/Dialogs/", StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Walks every <c>.cs</c> file under <paramref name="toolSourceRoot"/> (excluding
+    /// <c>bin</c>/<c>obj</c>) and aggregates the four coupling metrics.
+    /// </summary>
+    public CouplingMetrics ScanToolSource(string toolSourceRoot)
+    {
+        if (!Directory.Exists(toolSourceRoot))
+        {
+            throw new DirectoryNotFoundException(
+                $"Tool source root not found: '{toolSourceRoot}'. " +
+                "The coupling ratchet could not locate the Gum tool source tree.");
+        }
+
+        int selfTotal = 0;
+        int objectFinderSelf = 0;
+        int windowsCoupling = 0;
+        int inlineDialogSites = 0;
+        int interfaceLeaks = 0;
+        int filesScanned = 0;
+        int viewModelFilesScanned = 0;
+
+        foreach (string path in Directory.EnumerateFiles(toolSourceRoot, "*.cs", SearchOption.AllDirectories))
+        {
+            string relativePath = Path.GetRelativePath(toolSourceRoot, path);
+            if (IsInBinOrObj(relativePath))
+            {
+                continue;
+            }
+
+            string source = File.ReadAllText(path);
+            filesScanned++;
+
+            SelfReferenceCount self = CountSelfReferences(source);
+            selfTotal += self.Total;
+            objectFinderSelf += self.ObjectFinder;
+
+            interfaceLeaks += CountInterfaceTypeLeaks(source);
+
+            if (!IsDialogInfrastructure(relativePath))
+            {
+                inlineDialogSites += CountInlineDialogSites(source);
+            }
+
+            if (IsViewModelFile(Path.GetFileName(path)))
+            {
+                viewModelFilesScanned++;
+                windowsCoupling += CountWindowsCouplingInViewModel(source);
+            }
+        }
+
+        return new CouplingMetrics(
+            selfTotal,
+            objectFinderSelf,
+            windowsCoupling,
+            inlineDialogSites,
+            interfaceLeaks,
+            filesScanned,
+            viewModelFilesScanned);
+    }
+
+    private bool IsInBinOrObj(string relativePath)
+    {
+        string[] segments = relativePath.Split('/', '\\');
+        foreach (string segment in segments)
+        {
+            if (segment.Equals("bin", StringComparison.OrdinalIgnoreCase) ||
+                segment.Equals("obj", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Returns the text of every <c>interface</c> body in <paramref name="source"/>, brace-matched
+    /// while skipping comments and string/char literals so braces inside them do not throw off
+    /// depth tracking. Interpolated strings (<c>$"{x}"</c>) are treated as a sequence of opaque
+    /// <c>"..."</c> segments rather than being parsed structurally.
+    /// <para>
+    /// KNOWN LIMITATION (under-counts -- the dangerous direction): a nested string literal inside
+    /// an interpolation hole that itself contains a <c>}</c> (e.g. <c>$"{(x ? "a}" : "b")}"</c>)
+    /// makes the matcher mistake a brace for code, prematurely closing the interface body. Any leak
+    /// declared AFTER such a default-interface-method body is then outside the captured body and is
+    /// MISSED. This is immaterial today because Gum's interfaces are signature-only (no default
+    /// method bodies, so no interpolated strings), and hardening the parser is overkill for Phase 0;
+    /// the limitation is pinned by a characterization test in CouplingScannerTests.
+    /// </para>
+    /// </summary>
+    private List<string> ExtractInterfaceBodies(string source)
+    {
+        List<string> bodies = new List<string>();
+
+        int i = 0;
+        int length = source.Length;
+        bool seekingBrace = false;
+        bool inBody = false;
+        int depth = 0;
+        int bodyStart = -1;
+
+        while (i < length)
+        {
+            char c = source[i];
+
+            // Line comment.
+            if (c == '/' && i + 1 < length && source[i + 1] == '/')
+            {
+                i += 2;
+                while (i < length && source[i] != '\n')
+                {
+                    i++;
+                }
+                continue;
+            }
+
+            // Block comment.
+            if (c == '/' && i + 1 < length && source[i + 1] == '*')
+            {
+                i += 2;
+                while (i + 1 < length && !(source[i] == '*' && source[i + 1] == '/'))
+                {
+                    i++;
+                }
+                i += 2;
+                continue;
+            }
+
+            // Verbatim string @"..." (doubled "" is an escaped quote).
+            if (c == '@' && i + 1 < length && source[i + 1] == '"')
+            {
+                i += 2;
+                while (i < length)
+                {
+                    if (source[i] == '"')
+                    {
+                        if (i + 1 < length && source[i + 1] == '"')
+                        {
+                            i += 2;
+                            continue;
+                        }
+                        i++;
+                        break;
+                    }
+                    i++;
+                }
+                continue;
+            }
+
+            // Regular (and interpolated) string "...".
+            if (c == '"')
+            {
+                i++;
+                while (i < length)
+                {
+                    if (source[i] == '\\')
+                    {
+                        i += 2;
+                        continue;
+                    }
+                    if (source[i] == '"')
+                    {
+                        i++;
+                        break;
+                    }
+                    i++;
+                }
+                continue;
+            }
+
+            // Char literal '.'.
+            if (c == '\'')
+            {
+                i++;
+                while (i < length)
+                {
+                    if (source[i] == '\\')
+                    {
+                        i += 2;
+                        continue;
+                    }
+                    if (source[i] == '\'')
+                    {
+                        i++;
+                        break;
+                    }
+                    i++;
+                }
+                continue;
+            }
+
+            // `interface` keyword in code (not while already capturing a body).
+            if (!inBody && c == 'i' && MatchesKeywordAt(source, i, "interface"))
+            {
+                seekingBrace = true;
+                i += "interface".Length;
+                continue;
+            }
+
+            if (c == '{')
+            {
+                if (inBody)
+                {
+                    depth++;
+                }
+                else if (seekingBrace)
+                {
+                    inBody = true;
+                    seekingBrace = false;
+                    depth = 1;
+                    bodyStart = i + 1;
+                }
+                i++;
+                continue;
+            }
+
+            if (c == '}')
+            {
+                if (inBody)
+                {
+                    depth--;
+                    if (depth == 0)
+                    {
+                        bodies.Add(source.Substring(bodyStart, i - bodyStart));
+                        inBody = false;
+                        bodyStart = -1;
+                    }
+                }
+                i++;
+                continue;
+            }
+
+            i++;
+        }
+
+        return bodies;
+    }
+
+    private bool MatchesKeywordAt(string source, int index, string keyword)
+    {
+        if (index + keyword.Length > source.Length)
+        {
+            return false;
+        }
+        if (string.CompareOrdinal(source, index, keyword, 0, keyword.Length) != 0)
+        {
+            return false;
+        }
+        if (index > 0 && IsWordChar(source[index - 1]))
+        {
+            return false;
+        }
+        int afterIndex = index + keyword.Length;
+        if (afterIndex < source.Length && IsWordChar(source[afterIndex]))
+        {
+            return false;
+        }
+        return true;
+    }
+
+    private bool IsWordChar(char c)
+    {
+        return char.IsLetterOrDigit(c) || c == '_';
+    }
+}

--- a/Tool/Tests/GumToolUnitTests/Coupling/CouplingScannerTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Coupling/CouplingScannerTests.cs
@@ -1,0 +1,256 @@
+using Shouldly;
+using Xunit;
+
+namespace GumToolUnitTests.Coupling;
+
+/// <summary>
+/// Pins the deterministic counting rules of <see cref="CouplingScanner"/> against small
+/// inline source samples, so the rules are proven without depending on the live tree.
+/// These are the executable specification of each Phase 0 coupling metric.
+/// </summary>
+public class CouplingScannerTests
+{
+    private readonly CouplingScanner _scanner;
+
+    public CouplingScannerTests()
+    {
+        _scanner = new CouplingScanner();
+    }
+
+    [Fact]
+    public void CountInlineDialogSites_CountsMessageBoxShowAndNamedWindowConstructions()
+    {
+        string source = @"
+class Foo
+{
+    void Bar()
+    {
+        MessageBox.Show(""hi"");
+        var w = new DeleteOptionsWindow(arg);
+        var f = new FileListWindow();
+        var p = new Window();
+    }
+}";
+
+        // 1 MessageBox.Show + 2 named *Window( + 1 bare Window( = 4
+        _scanner.CountInlineDialogSites(source).ShouldBe(4);
+    }
+
+    [Fact]
+    public void CountInlineDialogSites_DoesNotMatchUnrelatedWindowIdentifiers()
+    {
+        string source = @"
+class Foo
+{
+    void Bar()
+    {
+        var helper = new WindowHelper();
+        ActiveWindow.Focus();
+        ShowWindow();
+    }
+}";
+
+        _scanner.CountInlineDialogSites(source).ShouldBe(0);
+    }
+
+    [Fact]
+    public void CountInterfaceTypeLeaks_CountsQualifiedAndUnqualifiedTypesInsideInterfaceBodies()
+    {
+        string source = @"
+using System.Windows;
+using System.Windows.Forms;
+
+public interface ITabManager
+{
+    void AddControl(System.Windows.Forms.Control control, string title);
+    void AddElement(FrameworkElement element);
+    void RemoveTab(PluginTab plugin);
+}";
+
+        // System.Windows.Forms.Control (qualified) + FrameworkElement (unqualified) = 2
+        _scanner.CountInterfaceTypeLeaks(source).ShouldBe(2);
+    }
+
+    [Fact]
+    public void CountInterfaceTypeLeaks_CountsTwoQualifiedTypesOnASingleMember()
+    {
+        string source = @"
+public interface IHotkeyManager
+{
+    bool ProcessCmdKey(ref System.Windows.Forms.Message msg, System.Windows.Forms.Keys keyData);
+}";
+
+        // Two distinct qualified System.Windows.Forms.* references on one member = 2
+        _scanner.CountInterfaceTypeLeaks(source).ShouldBe(2);
+    }
+
+    [Fact]
+    public void CountInterfaceTypeLeaks_DoesNotCountWindowsTypesOutsideInterfaceBodies()
+    {
+        // The using directive and the class member both reference System.Windows.Forms,
+        // but neither is inside an interface body, so the leak count is 0. This mirrors
+        // ISelectedState.cs, which has a stale `using System.Windows.Forms;` but a clean body.
+        string source = @"
+using System.Windows.Forms;
+
+public interface ICleanInterface
+{
+    string Name { get; }
+}
+
+public class SomeClass
+{
+    public Control MyControl;
+    public System.Windows.Forms.Keys Pressed;
+}";
+
+        _scanner.CountInterfaceTypeLeaks(source).ShouldBe(0);
+    }
+
+    [Fact]
+    public void CountInterfaceTypeLeaks_HandlesDefaultMemberBodiesWithNestedBraces()
+    {
+        // Default interface members have bodies with nested braces; the body brace-matcher
+        // must still find the interface's closing brace and count the leak inside it.
+        string source = @"
+public interface IWithDefault
+{
+    string Name { get; }
+    public string Describe()
+    {
+        if (Name != null) { return Name; }
+        return string.Empty;
+    }
+    void Handle(System.Windows.Forms.KeyEventArgs e);
+}";
+
+        _scanner.CountInterfaceTypeLeaks(source).ShouldBe(1);
+    }
+
+    [Fact]
+    public void CountInterfaceTypeLeaks_UnderCountsLeakAfterDefaultBodyWithBraceBearingInterpolatedString()
+    {
+        // KNOWN LIMITATION pinned here (this is documented current behavior, NOT desired behavior):
+        // ExtractInterfaceBodies treats an interpolated string as opaque "..." segments. The nested
+        // string literal "a}" carries a '}' that the matcher mistakes for code, prematurely closing
+        // the interface body. The System.Windows.Forms leak declared AFTER this default-method body
+        // is therefore outside the captured body and is MISSED -- the scanner reports 0 where a
+        // perfect parser would report 1 (under-count, the dangerous direction).
+        // If anyone later hardens the parser, this assertion flips and flags the behavior change.
+        string source = @"
+public interface IPathological
+{
+    public string Describe()
+    {
+        var label = $""{(Name != null ? ""a}"" : ""b"")}"";
+        return label;
+    }
+    void Handle(System.Windows.Forms.KeyEventArgs e);
+}";
+
+        _scanner.CountInterfaceTypeLeaks(source).ShouldBe(0);
+    }
+
+    [Fact]
+    public void CountSelfReferences_CountsTotalAndObjectFinderSubcount()
+    {
+        string source = @"
+class Foo
+{
+    void Bar()
+    {
+        ObjectFinder.Self.GetElement();
+        PluginManager.Self.Do();
+        var x = Gum.ObjectFinder.Self.GumProjectSave;
+        StandardElementsManager.Self.Initialize();
+    }
+}";
+
+        SelfReferenceCount count = _scanner.CountSelfReferences(source);
+
+        count.Total.ShouldBe(4);
+        count.ObjectFinder.ShouldBe(2);
+        count.ExcludingObjectFinder.ShouldBe(2);
+    }
+
+    [Fact]
+    public void CountSelfReferences_DoesNotMatchSelfFollowedByMoreLetters()
+    {
+        string source = @"
+class Foo
+{
+    SelfManager _manager;
+    void Bar()
+    {
+        _manager.SelfManager.Do();
+        this.SelfDescribing = true;
+    }
+}";
+
+        SelfReferenceCount count = _scanner.CountSelfReferences(source);
+
+        count.Total.ShouldBe(0);
+        count.ObjectFinder.ShouldBe(0);
+    }
+
+    [Fact]
+    public void CountWindowsCouplingInViewModel_CountsUsingDirectivesAndAllowListTypes()
+    {
+        string source = @"
+using System.Windows;
+using System.Windows.Media;
+using System.Collections.Generic;
+
+public class FooViewModel
+{
+    public Visibility ButtonVisibility { get; set; }
+    public SolidColorBrush Accent { get; set; }
+    private Brush _brush;
+}";
+
+        // 2 `using System.Windows*` lines + Visibility(1) + SolidColorBrush(1) + Brush(1) = 5.
+        // Note: the property NAME `ButtonVisibility` must NOT add a count (whole-word only).
+        _scanner.CountWindowsCouplingInViewModel(source).ShouldBe(5);
+    }
+
+    [Fact]
+    public void CountWindowsCouplingInViewModel_DoesNotCountAmbiguousNonWpfTypes()
+    {
+        string source = @"
+using System.Collections.Generic;
+
+public class FooViewModel
+{
+    public Color? AccentColor { get; set; }
+    public Point Location { get; set; }
+    public Keys Pressed { get; set; }
+}";
+
+        // Color / Point / Keys are deliberately excluded (ambiguous with XNA/Gum/WinForms types).
+        _scanner.CountWindowsCouplingInViewModel(source).ShouldBe(0);
+    }
+
+    [Fact]
+    public void IsDialogInfrastructure_IsTrueOnlyForServicesDialogsFolder()
+    {
+        _scanner.IsDialogInfrastructure(@"Services\Dialogs\DialogService.cs").ShouldBeTrue();
+        _scanner.IsDialogInfrastructure("Services/Dialogs/MessageDialogViewModel.cs").ShouldBeTrue();
+        _scanner.IsDialogInfrastructure("Managers/DeleteLogic.cs").ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsViewModelFile_MatchesPlainAndPartialViewModelFiles()
+    {
+        _scanner.IsViewModelFile("AddFormsViewModel.cs").ShouldBeTrue();
+        _scanner.IsViewModelFile("AddFormsViewModel.Designer.cs").ShouldBeTrue();
+        _scanner.IsViewModelFile("ViewModel.cs").ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsViewModelFile_RejectsNonViewModelFiles()
+    {
+        _scanner.IsViewModelFile("ViewModelHelper.cs").ShouldBeFalse();
+        _scanner.IsViewModelFile("MyViewModelThing.cs").ShouldBeFalse();
+        _scanner.IsViewModelFile("DeleteLogic.cs").ShouldBeFalse();
+    }
+}

--- a/Tool/Tests/GumToolUnitTests/Coupling/coupling-baseline.json
+++ b/Tool/Tests/GumToolUnitTests/Coupling/coupling-baseline.json
@@ -1,0 +1,45 @@
+{
+  "description": "Phase 0 coupling burn-down dashboard for the Gum tool UI/logic decoupling effort (issue #3225). Each 'ratchetedBaseline' is the maximum the ratchet test (CouplingRatchetTests) allows for that metric. A Phase 1 PR that removes coupling LOWERS the relevant number here in the SAME diff that removes the coupling -- that is what makes the burn-down self-proving. The numbers are produced by CouplingScanner (the canonical, deterministic counting method); to recompute after a change run CouplingRatchetTests.Scanner_DumpMeasuredMetrics_ForBaselineUpdates and read the values from the test output.",
+  "measuredOnUtc": "2026-06-20",
+  "toolSourceRelativePath": "Gum",
+  "metrics": {
+    "selfStaticReferences": {
+      "ratchetedBaseline": 194,
+      "rule": "Count of '.Self' static-singleton references (regex \\.Self\\b, so '.SelfManager' does not count) across every .cs file under Gum/ (excluding bin/obj), MINUS the 'ObjectFinder.Self' sub-count. ObjectFinder.Self is the sanctioned static singleton (repo CLAUDE.md) that will never be removed, so it is excluded from the ratchet to keep the burn-down meaningful.",
+      "context": {
+        "totalSelf": 477,
+        "objectFinderSelfExcluded": 283,
+        "note": "ratchetedBaseline = totalSelf - objectFinderSelfExcluded."
+      }
+    },
+    "windowsCouplingInViewModels": {
+      "ratchetedBaseline": 146,
+      "rule": "Within ViewModel files only (filename matches *ViewModel.cs or partial *ViewModel.*.cs), count (A) every 'using System.Windows*;' import line PLUS (B) every whole-word occurrence of an unambiguous WPF type the VMs use unqualified: Visibility, Brush, Brushes, SolidColorBrush, Application, Dispatcher, RoutedEventArgs, BitmapImage, Thickness, FrameworkElement. (A) and (B) never overlap, so there is no double-counting. Ambiguous simple names (Color, Point, Size, Key, Control) are deliberately EXCLUDED because they collide with XNA / System.Drawing / Gum / WinForms types and would misfire. The handoff estimate (~192) counted additional ambiguous tokens; this rule is the deterministic, defensible subset.",
+      "limitation": "A count of 0 is NECESSARY-BUT-NOT-SUFFICIENT for 'the VM layer is WPF-free': because the ambiguous simple names (Color, Point, Size, Key, Control) are excluded, a ViewModel that uses a fully-qualified System.Windows.Point / System.Windows.Media.Color WITHOUT any 'using System.Windows*' line is invisible to this metric. A Phase 3 completion audit MUST also grep for fully-qualified 'System.Windows.' inside VM files, not rely on this count alone.",
+      "context": {
+        "usingDirectiveLines": 33,
+        "allowListTypeOccurrences": 113,
+        "viewModelFilesContainingWpf": 21
+      }
+    },
+    "inlineDialogSites": {
+      "ratchetedBaseline": 7,
+      "rule": "Across every .cs file under Gum/ (excluding bin/obj) EXCEPT the dialog infrastructure itself (any path under Services/Dialogs/), count 'MessageBox.Show' occurrences PLUS '*Window(' construction occurrences (regex new\\s+[\\w.]*Window\\s*\\(, which matches a bare 'new Window(', a simple 'new FooWindow(', AND a qualified 'new Ns.FooWindow('). Raw textual scan: commented-out occurrences are counted (conservative for a ratchet).",
+      "context": {
+        "messageBoxShow": 3,
+        "newWindowConstructions": 4,
+        "windowSites": "new Views.CodeWindow( (MainCodeOutputPlugin), new DeleteOptionsWindow( (DeleteLogic), new FileListWindow( (VariableListConverter), new StateAnimationPlugin.Views.MainWindow( (MainStateAnimationPlugin)",
+        "note": "2 of the 3 MessageBox.Show occurrences are currently commented out (MultiSelectTreeView has the only live one; DeleteLogic and PluginManager are commented). OpenFileDialog/SaveFileDialog (3 more inline file-dialog sites) also bypass IDialogService but are out of this metric's documented scope (MessageBox + *Window only)."
+      }
+    },
+    "interfaceTypeLeaks": {
+      "ratchetedBaseline": 11,
+      "rule": "Across every .cs file under Gum/ (excluding bin/obj), count WinForms/WPF type references that appear INSIDE an interface body (brace-matched, comment/string-aware). Two groups, no overlap: (1) any fully-qualified 'System.Windows.*' reference; (2) a documented allow-list of distinctive types used unqualified: FrameworkElement, FrameworkContentElement, UIElement, Spinner, DragEventArgs, KeyPressEventArgs, MouseEventArgs. A member referencing N leak types contributes N. Stale 'using System.Windows.Forms;' outside any interface body (e.g. ISelectedState.cs) does NOT count -- only the body is scanned. Known leaks: ITabManager (System.Windows.Forms.Control + FrameworkElement), IGuiCommands.ShowSpinner (returns WPF Spinner), IDragDropManager (DragEventArgs + KeyPressEventArgs), IHotkeyManager (5 qualified System.Windows.* refs).",
+      "limitation": "The brace matcher can UNDER-count: a leak that appears AFTER a default-interface-method body containing an interpolated string with a nested '}'-bearing string literal (e.g. $\"{(x ? \"a}\" : \"b\")}\") is missed, because the stray '}' prematurely closes the interface body. Immaterial today since Gum's interfaces are signature-only (no default method bodies); pinned by CouplingScannerTests.CountInterfaceTypeLeaks_UnderCountsLeakAfterDefaultBodyWithBraceBearingInterpolatedString.",
+      "context": {
+        "qualifiedSystemWindows": 7,
+        "unqualifiedAllowList": 4
+      }
+    }
+  }
+}


### PR DESCRIPTION
## What & why

Phase 0 of the Gum tool **UI / logic decoupling** effort (see `Direction/ui-decoupling-plan.md`, ADR-0003, ADR-0004). It instruments the coupling burn-down so the effort is **measurable** and re-coupling **cannot be merged silently**.

This is a **source-scanning architecture guard** (a "ratchet"): a unit test that reads the tool's own `.cs` source, counts four kinds of UI-framework coupling, and asserts each count stays at-or-below a checked-in baseline. A hard "zero `System.Windows` in ViewModels" rule would fail on day one (~21 VMs import it today); the ratchet instead locks in "no worse than today" and is tightened as coupling is removed.

**Test-only — zero production tool code is touched.**

## What's in it (`Tool/Tests/GumToolUnitTests/Coupling/`)

- **`CouplingScanner.cs`** — the single canonical, deterministic counting method for the four metrics. No separate grep-based method that could diverge.
- **`CouplingScannerTests.cs`** — inline-sample unit tests that pin each counting rule (the executable spec).
- **`CouplingRatchetTests.cs`** — runs the scanner over the live `Gum/` tree, asserts each count ≤ baseline; a fixture **sanity floor** fails the guards loudly rather than passing vacuously if the scan ever points at a degenerate/empty root.
- **`coupling-baseline.json`** — the checked-in burn-down dashboard (the four numbers + the documented rule for each).

## The four baselines (today)

| Metric | Baseline |
|---|---|
| `.Self` statics (excluding sanctioned `ObjectFinder.Self`) | **194** |
| `System.Windows.*` usage in ViewModels | **146** |
| Inline dialog sites bypassing `IDialogService` | **7** |
| WinForms/WPF type leaks inside interface bodies | **11** |

## How Phase 1 interacts

Each Phase 1 PR **lowers the relevant baseline in the same diff that removes the coupling** — that one-line `coupling-baseline.json` edit is what makes the burn-down self-proving (you can't claim "decoupled X" without the number actually dropping).

## Notes

- **qa independently verified the core guarantee:** lowering a baseline and injecting synthetic coupling into a real `Gum/` file both turned the ratchet red with exact predicted deltas (then reverted). It cannot go red on the unmodified tree.
- **Two documented limitations are pinned by tests:** a metric-4 brace-matcher interpolation under-count (immaterial — Gum interfaces are signature-only) and that metric-2 `count == 0` is necessary-but-not-sufficient for "WPF-free" (a Phase 3 completion audit must also grep fully-qualified `System.Windows.` in VM files).
- The handoff's `~34` inline-dialog estimate was measured down to **7** (only 1 *live* `MessageBox.Show`) — Phase 1's dialog item is correspondingly smaller.

## Test plan

`GumToolUnitTests` Coupling suite: **19 passed / 0 failed**. Full suite previously **916 passed / 5 skipped / 0 failed**, no regressions.

```
dotnet test Tool/Tests/GumToolUnitTests/GumToolUnitTests.csproj --filter "FullyQualifiedName~GumToolUnitTests.Coupling"
```

Part of #3225. *(Intentionally does not auto-close — #3225 is the umbrella tracking issue for all of Phase 0 + Phase 1.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
