### PR TITLE
Modernize hand-written samples to `using Gum;` and normalize raylib loop order (#3222)

### DIFF
--- a/Samples/FnaGum/FnaSample/Game1.cs
+++ b/Samples/FnaGum/FnaSample/Game1.cs
@@ -7,7 +7,7 @@ using System.Linq;
 
 using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Input;
-using MonoGameGum;
+using Gum;
 using Gum.GueDeriving;
 using Gum.Forms.Controls;
 using Gum.Wireframe;

--- a/Samples/FontPlayground/FontPlayground.Raylib/Program.cs
+++ b/Samples/FontPlayground/FontPlayground.Raylib/Program.cs
@@ -39,10 +39,11 @@ public static class Program
 
         while (!WindowShouldClose())
         {
+            GumService.Default.Update(GetTime());
+
             BeginDrawing();
             ClearBackground(new Color(30, 30, 46, 255));
 
-            GumService.Default.Update(GetTime());
             GumService.Default.Draw();
 
             EndDrawing();

--- a/Samples/GameUiSamples/Components/GameTitleScreenComponents/TitleScreenButton.cs
+++ b/Samples/GameUiSamples/Components/GameTitleScreenComponents/TitleScreenButton.cs
@@ -10,7 +10,7 @@ using System.Linq;
 using MonoGameGum.GueDeriving;
 using Gum.Forms.Controls;
 using Gum.Forms;
-using MonoGameGum;
+using Gum;
 namespace GameUiSamples.Components;
 
 partial class TitleScreenButton

--- a/Samples/GameUiSamples/Components/HollowKnightComponents/Currency.cs
+++ b/Samples/GameUiSamples/Components/HollowKnightComponents/Currency.cs
@@ -9,7 +9,7 @@ using System.Linq;
 
 using MonoGameGum.GueDeriving;
 using System;
-using MonoGameGum;
+using Gum;
 using Microsoft.Xna.Framework;
 namespace GameUiSamples.Components;
 

--- a/Samples/GameUiSamples/Components/HyTaleComponents/HyTaleHotBar.cs
+++ b/Samples/GameUiSamples/Components/HyTaleComponents/HyTaleHotBar.cs
@@ -2,7 +2,7 @@ using GameUiSamples.Data;
 using Gum.Forms.Controls;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Input;
-using MonoGameGum;
+using Gum;
 using MonoGameGum.ExtensionMethods;
 using System;
 using System.Collections.Generic;

--- a/Samples/GameUiSamples/Components/StardewComponents/Hotbar.cs
+++ b/Samples/GameUiSamples/Components/StardewComponents/Hotbar.cs
@@ -9,7 +9,7 @@ using System.Linq;
 
 using MonoGameGum.GueDeriving;
 using System;
-using MonoGameGum;
+using Gum;
 using Microsoft.Xna.Framework.Input;
 using Gum.Forms.Controls;
 using MonoGameGum.ExtensionMethods;

--- a/Samples/GameUiSamples/Game1.cs
+++ b/Samples/GameUiSamples/Game1.cs
@@ -5,7 +5,7 @@ using GumRuntime;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Input;
-using MonoGameGum;
+using Gum;
 using Gum.Forms.Controls;
 using RenderingLibrary;
 using System;

--- a/Samples/GameUiSamples/Screens/GameTitleScreen.cs
+++ b/Samples/GameUiSamples/Screens/GameTitleScreen.cs
@@ -9,7 +9,7 @@ using System.Linq;
 
 using MonoGameGum.GueDeriving;
 using Microsoft.Xna.Framework;
-using MonoGameGum;
+using Gum;
 using Gum.Forms.Controls;
 using System;
 using Gum.Forms;

--- a/Samples/GameUiSamples/Screens/HollowKnightHudScreen.cs
+++ b/Samples/GameUiSamples/Screens/HollowKnightHudScreen.cs
@@ -9,7 +9,7 @@ using System.Linq;
 
 using MonoGameGum.GueDeriving;
 using System;
-using MonoGameGum;
+using Gum;
 using GameUiSamples.Components;
 using Microsoft.Xna.Framework;
 using Gum.Forms.Controls;

--- a/Samples/GameUiSamples/Screens/HyTaleHotbarScreen.cs
+++ b/Samples/GameUiSamples/Screens/HyTaleHotbarScreen.cs
@@ -6,7 +6,7 @@ using Gum.DataTypes;
 using Gum.Managers;
 using Gum.Wireframe;
 using Microsoft.Xna.Framework;
-using MonoGameGum;
+using Gum;
 using MonoGameGum.GueDeriving;
 using RenderingLibrary.Graphics;
 using System;

--- a/Samples/GameUiSamples/Screens/HyTaleInventoryScreen.cs
+++ b/Samples/GameUiSamples/Screens/HyTaleInventoryScreen.cs
@@ -2,7 +2,7 @@ using GameUiSamples.Components;
 using GameUiSamples.Services;
 using Gum.Wireframe;
 using Microsoft.Xna.Framework;
-using MonoGameGum;
+using Gum;
 using RenderingLibrary.Graphics;
 using System;
 using System.Linq;

--- a/Samples/GameUiSamples/Screens/MainMenu.cs
+++ b/Samples/GameUiSamples/Screens/MainMenu.cs
@@ -11,7 +11,7 @@ using MonoGameGum.GueDeriving;
 using System;
 using GameUiSamples.Screens.FrbClicker;
 using Gum.Forms.Controls;
-using MonoGameGum;
+using Gum;
 namespace GameUiSamples.Screens;
 
 partial class MainMenu

--- a/Samples/GameUiSamples/Screens/StardewHotbarScreen.cs
+++ b/Samples/GameUiSamples/Screens/StardewHotbarScreen.cs
@@ -8,7 +8,7 @@ using RenderingLibrary.Graphics;
 using System.Linq;
 
 using MonoGameGum.GueDeriving;
-using MonoGameGum;
+using Gum;
 using RenderingLibrary;
 using GameUiSamples.Components;
 using Microsoft.Xna.Framework;

--- a/Samples/GameUiSamples/Screens/StardewInventoryScreen.cs
+++ b/Samples/GameUiSamples/Screens/StardewInventoryScreen.cs
@@ -12,7 +12,7 @@ using RenderingLibrary;
 using System;
 using GameUiSamples.Services;
 using Microsoft.Xna.Framework;
-using MonoGameGum;
+using Gum;
 using GameUiSamples.Components;
 using MonoGameGum.Forms;
 using MonoGameGum.ExtensionMethods;

--- a/Samples/GumFormsSample/GumFormsSampleCommon/CustomForms/ColorComponentSlider.cs
+++ b/Samples/GumFormsSample/GumFormsSampleCommon/CustomForms/ColorComponentSlider.cs
@@ -1,6 +1,6 @@
 ﻿using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
-using MonoGameGum;
+using Gum;
 using Gum.Forms.Controls;
 using Gum.GueDeriving;
 using System;

--- a/Samples/GumFormsSample/GumFormsSampleCommon/GumFormsSampleGame.cs
+++ b/Samples/GumFormsSample/GumFormsSampleCommon/GumFormsSampleGame.cs
@@ -4,7 +4,7 @@ using GumFormsSample.Screens;
 using GumFormsSample.Services;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
-using MonoGameGum;
+using Gum;
 using Gum.Forms.Controls;
 using System;
 

--- a/Samples/GumFormsSample/GumFormsSampleCommon/Screens/DemoScreenGumRuntime.cs
+++ b/Samples/GumFormsSample/GumFormsSampleCommon/Screens/DemoScreenGumRuntime.cs
@@ -2,7 +2,7 @@
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
-using MonoGameGum;
+using Gum;
 using Gum.Forms;
 using Gum.Forms.Controls;
 using RenderingLibrary;

--- a/Samples/GumFormsSample/GumFormsSampleCommon/Services/InputService.cs
+++ b/Samples/GumFormsSample/GumFormsSampleCommon/Services/InputService.cs
@@ -1,5 +1,5 @@
 ﻿using Microsoft.Xna.Framework.Input;
-using MonoGameGum;
+using Gum;
 using MonoGameGum.Forms;
 using System;
 using System.Collections.Generic;

--- a/Samples/GumFormsSample/GumFormsSampleCommon/Services/RenderService.cs
+++ b/Samples/GumFormsSample/GumFormsSampleCommon/Services/RenderService.cs
@@ -1,6 +1,6 @@
 ﻿using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
-using MonoGameGum;
+using Gum;
 using RenderingLibrary;
 using System;
 using System.Collections.Generic;

--- a/Samples/GumFromZipFile/Game1.cs
+++ b/Samples/GumFromZipFile/Game1.cs
@@ -4,7 +4,7 @@ using GumRuntime;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Input;
-using MonoGameGum;
+using Gum;
 using RenderingLibrary;
 using System;
 using System.Collections.Generic;

--- a/Samples/GumShapesGallery/GumShapesGalleryCommon/GumShapesGalleryGame.cs
+++ b/Samples/GumShapesGallery/GumShapesGalleryCommon/GumShapesGalleryGame.cs
@@ -6,7 +6,7 @@ using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Input;
 using MonoGameAndGum.Renderables;
-using MonoGameGum;
+using Gum;
 using GumShapesGallery.Screens;
 using RenderingLibrary;
 using RenderingLibrary.Graphics;

--- a/Samples/KniGumFromFile/KniGumFromFileCommon/KniGumFromFileGame.cs
+++ b/Samples/KniGumFromFile/KniGumFromFileCommon/KniGumFromFileGame.cs
@@ -20,7 +20,7 @@ using KniGumFromFile.ComponentRuntimes;
 using RenderingLibrary;
 using RenderingLibrary.Graphics;
 using ToolsUtilities;
-using MonoGameGum;
+using Gum;
 using Gum.Forms;
 
 namespace KniGumFromFile;

--- a/Samples/KniGumInCode/KniGumInCodeCommon/KniGumInCodeGame.cs
+++ b/Samples/KniGumInCode/KniGumInCodeCommon/KniGumInCodeGame.cs
@@ -10,7 +10,7 @@ using Gum.GueDeriving;
 using RenderingLibrary;
 using RenderingLibrary.Graphics;
 using Gum.Wireframe;
-using MonoGameGum;
+using Gum;
 using Gum.Forms.Controls;
 
 namespace KniGumInCode;

--- a/Samples/MonoGameGumCodeGeneration/Game1.cs
+++ b/Samples/MonoGameGumCodeGeneration/Game1.cs
@@ -1,6 +1,6 @@
 ﻿using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
-using MonoGameGum;
+using Gum;
 using Gum.Forms.Controls;
 using MonoGameGumCodeGeneration.Screens;
 

--- a/Samples/MonoGameGumFromFile/MonoGameGumFromFile/Game1.cs
+++ b/Samples/MonoGameGumFromFile/MonoGameGumFromFile/Game1.cs
@@ -6,7 +6,7 @@ using GumRuntime;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Input;
-using MonoGameGum;
+using Gum;
 using MonoGameGum.Forms;
 using Gum.GueDeriving;
 using MonoGameGum.Input;

--- a/Samples/MonoGameGumImmediateMode/MonoGameGumImmediateMode/Game1.cs
+++ b/Samples/MonoGameGumImmediateMode/MonoGameGumImmediateMode/Game1.cs
@@ -6,7 +6,7 @@ using KernSmith.Gum;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Input;
-using MonoGameGum;
+using Gum;
 using MonoGameGumImmediateMode.Screens;
 using RenderingLibrary;
 using RenderingLibrary.Graphics;

--- a/Samples/MonoGameGumInCode/MonoGameGumInCode/Game1.cs
+++ b/Samples/MonoGameGumInCode/MonoGameGumInCode/Game1.cs
@@ -3,7 +3,7 @@ using Gum.Wireframe;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Input;
-using MonoGameGum;
+using Gum;
 using MonoGameGumInCode.Screens;
 using RenderingLibrary;
 

--- a/Samples/MonoGameGumThemesShowcase/Game1.cs
+++ b/Samples/MonoGameGumThemesShowcase/Game1.cs
@@ -11,7 +11,7 @@ using Gum.Themes.Template;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Input;
-using MonoGameGum;
+using Gum;
 using MonoGameGumThemesShowcase.Screens;
 
 namespace MonoGameGumThemesShowcase;

--- a/Samples/RaylibGumThemesShowcase/Program.cs
+++ b/Samples/RaylibGumThemesShowcase/Program.cs
@@ -83,10 +83,11 @@ public static class Program
         {
             HandleInput();
 
+            GumService.Default.Update(GetTime());
+
             BeginDrawing();
             ClearBackground(_clearColor);
 
-            GumService.Default.Update(GetTime());
             GumService.Default.Draw();
 
             EndDrawing();

--- a/Samples/raylib/Program.cs
+++ b/Samples/raylib/Program.cs
@@ -2,8 +2,8 @@ using Gum.Converters;
 using Gum.Forms.Controls;
 using Gum.Forms.DefaultVisuals.V3;
 using Gum.Wireframe;
+using Gum;
 using Raylib_cs;
-using RaylibGum;
 using RenderingLibrary;
 using RenderingLibrary.Graphics;
 using System;
@@ -78,11 +78,6 @@ public class BasicShapes
 
         while (!WindowShouldClose())
         {
-            BeginDrawing();
-            // Matches MonoGameGumShapesGallery's clear color so visual diffs across galleries
-            // stay attributable to the shape code, not the page background.
-            ClearBackground(new Color(51, 76, 204, 255));
-
             GumUI.Update(GetTime());
 
             // Apply a freshly-shown screen's initial gamepad focus now that this frame's
@@ -96,6 +91,15 @@ public class BasicShapes
             if (_useManualCamera)
             {
                 UpdateManualCameraFromInput();
+            }
+
+            BeginDrawing();
+            // Matches MonoGameGumShapesGallery's clear color so visual diffs across galleries
+            // stay attributable to the shape code, not the page background.
+            ClearBackground(new Color(51, 76, 204, 255));
+
+            if (_useManualCamera)
+            {
                 GumUI.Draw(_manualCamera);
             }
             else


### PR DESCRIPTION
Closes #3222.

## What

Modernizes **hand-written** sample code to the future-proof `using Gum;` namespace, dropping the obsolete `using MonoGameGum;` / `using RaylibGum;` (the legacy `GumService` namespaces are permanent `[Obsolete]` shims — see #3119). Also normalizes the raylib game-loop order.

## Changes

- **Namespace sweep (28 hand-written files):** `using MonoGameGum;` / `using RaylibGum;` → `using Gum;` across sample entry points and screens (raylib, FNA, KNI, MonoGame, shapes gallery, forms sample, GameUiSamples, etc.).
- **`*.Generated.cs` left untouched** — those ~190 hits are tool codegen output whose namespace is governed by `GumSyntaxVersion`; hand-editing them would be overwritten on regen (per the issue).
- **raylib game-loop order normalized** in `Samples/raylib/Program.cs`, `FontPlayground.Raylib`, and `RaylibGumThemesShowcase`: `GumService.Default.Update(...)` now runs **before** `BeginDrawing()` so the draw block brackets only rendering (Update → BeginDrawing → ClearBackground → Draw → EndDrawing). Matches the docs corrected in #3219.

## Dependency

The two `GameUiSamples` inventory screens (`StardewInventoryScreen`, `HyTaleInventoryScreen`) call `GumService.Default.PopupRoot.AddChild(formsControl)` and contain a user component named `StackPanel`. They modernize collision-free thanks to the `GraphicalUiElement.AddChild`/`RemoveChild` **instance methods** added in #3226 (merged to main, included here). Without that, importing `Gum.Forms.Controls` for `AddChild` would collide (CS0104) with the user `StackPanel`.

## Verification

Built green (0 errors): `Samples/raylib`, `GameUiSamples`, `GumFormsSample` (MonoGame + KNI), `MonoGameGumInCode`, `MonoGameGumThemesShowcase`, `RaylibGumThemesShowcase`, `MonoGameGumImmediateMode`, `MonoGameGumCodeGeneration`, `MonoGameGumFromFile`, `GumFromZipFile`, `GumShapesGallery`, `FontPlayground.Raylib`, `KniGumInCode`, `KniGumFromFile`. The raylib build is the CS0121 canary (imports both `Gum` and `Gum.Forms.Controls` and calls `gue.AddChild`) — green confirms the instance method resolves ambiguity-free.

`FnaGum` was not built: its FNA submodule is uninitialized in this environment (repo guidance says not to initialize it for non-FNA changes). It is `XNALIKE` — the same compile family as the green MonoGame/KNI samples — and its change is the identical one-line `using` swap.
