### PR TITLE
Fix raylib fonts/stacking: cache-hit must skip the empty font cached after a failed .fnt load

### DIFF
--- a/Runtimes/RaylibGum/Renderables/CustomSetPropertyOnRenderable.cs
+++ b/Runtimes/RaylibGum/Renderables/CustomSetPropertyOnRenderable.cs
@@ -669,7 +669,17 @@ public class CustomSetPropertyOnRenderable
                     // A Raylib_cs.Font wraps an unmanaged GPU texture, so regenerating on every font
                     // property change would leak VRAM (the previous texture is never reclaimed). This
                     // is the LoaderManager cache the MonoGame path also uses.
-                    if (loaderManager.GetDisposable(fullFileName) is ManagedFont cachedManagedFont)
+                    //
+                    // Only short-circuit on a USABLE cached font (BaseSize != 0). When no FontCache .fnt
+                    // exists on disk and no stream hook supplies it, the loader caches an empty
+                    // default(Font) (BaseSize 0) under this key (ContentLoader.LoadFont). Without this
+                    // guard the early-return would hand that empty font to every text after the first
+                    // instead of falling through to the disk / system-font fallback below — so text lost
+                    // its font and, being RelativeToChildren, collapsed to zero size. Mirrors the MonoGame
+                    // path, which assigns the resolved font once at the end rather than early-returning on
+                    // any cache entry.
+                    if (loaderManager.GetDisposable(fullFileName) is ManagedFont cachedManagedFont
+                        && cachedManagedFont.Font.BaseSize != 0)
                     {
                         AssignFontIfChanged(asText, cachedManagedFont.Font);
                         return;

--- a/Tests/RaylibGum.Tests/Runtimes/TextRuntimeFontCachingRegressionTests.cs
+++ b/Tests/RaylibGum.Tests/Runtimes/TextRuntimeFontCachingRegressionTests.cs
@@ -1,0 +1,175 @@
+using Gum.DataTypes;
+using Gum.GueDeriving;
+using Gum.Managers;
+using Gum.Wireframe;
+using Raylib_cs;
+using RenderingLibrary.Content;
+using Shouldly;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using ToolsUtilities;
+using Xunit;
+
+namespace RaylibGum.Tests.Runtimes;
+
+// Regression coverage for the raylib font path rewritten in f5ad44e2b (#3173, "Raylib font parity via
+// KernSmith"). That commit added a cache-hit early-return to UpdateToFontValues. EVERY pre-existing
+// raylib font test sets LoaderManager.Self.CacheTextures = false, which makes that branch dead — so it
+// shipped untested. With caching ON (the real-world default, e.g. the Samples/raylib gallery) and no
+// FontCache .fnt files present, the branch hands every text after the first an empty (BaseSize 0) font.
+public class TextRuntimeFontCachingRegressionTests : BaseTestClass
+{
+    public TextRuntimeFontCachingRegressionTests()
+    {
+        // Mirrors TextRuntimeTests: the renderable text measure throws if no window is ready.
+        if (!Raylib.IsWindowReady())
+        {
+            Raylib.SetConfigFlags(ConfigFlags.HiddenWindow);
+            Raylib.InitWindow(800, 600, "Test Window");
+        }
+    }
+
+    // THE BUG (Samples/raylib gallery, first load): caching on, no FontCache .fnt on disk. The first
+    // text's failed .fnt load caches an empty (BaseSize 0) font under the cache key; the cache-hit
+    // early-return then returns that empty font to every later text instead of falling through to the
+    // FontFamily (system Arial) fallback the first text used. So later texts lose their font and, being
+    // RelativeToChildren, collapse to zero height — which is the "stacking is broken" symptom.
+    // Depends on system Arial (C:\Windows\Fonts\arial.ttf) for the fallback, exactly as the gallery does.
+    [Fact]
+    public void MultipleTexts_WhenFontCacheFileMissing_WithCachingOn_ShouldEachResolveAUsableFont()
+    {
+        WithCachingOnAndNoFontFiles(() =>
+        {
+            TextRuntime first = NewArial18Text("List item 1");
+            TextRuntime second = NewArial18Text("List item 2");
+            TextRuntime third = NewArial18Text("List item 3");
+
+            foreach (TextRuntime textRuntime in new[] { first, second, third })
+            {
+                Gum.Renderables.Text renderable = (Gum.Renderables.Text)textRuntime.RenderableComponent;
+                renderable.Font.BaseSize.ShouldBeGreaterThan(0,
+                    "every text must resolve a usable fallback font, not the empty (BaseSize 0) font cached after the .fnt load failed");
+                textRuntime.GetAbsoluteHeight().ShouldBeGreaterThan(0,
+                    "a text with a usable font and Height=RelativeToChildren must measure to a non-zero line height");
+            }
+        });
+    }
+
+    // Positive guard: a second text sharing an ALREADY-LOADED valid font must still take the cache-hit
+    // branch and measure to the font's full .fnt line height (21 for Font18Arial). Keeps the VRAM-reuse
+    // optimization the cache-hit was added for from being broken by the fix above.
+    [Fact]
+    public void SecondText_SharingValidCachedFont_ShouldMeasureToFntLineHeight()
+    {
+        WithFont18ArialCached(() =>
+        {
+            TextRuntime first = NewArial18Text("List item 1");
+            first.GetAbsoluteHeight().ShouldBe(21);
+
+            TextRuntime second = NewArial18Text("List item 2");
+            second.GetAbsoluteHeight().ShouldBe(21);
+        });
+    }
+
+    // Positive guard for the user-visible symptom: with valid fonts, a vertical stack must reflow to the
+    // summed line heights (2 x 21) and the second item must sit below the first.
+    [Fact]
+    public void VerticalStack_OfValidCachedFontTexts_ShouldReflowToSummedLineHeights()
+    {
+        WithFont18ArialCached(() =>
+        {
+            ContainerRuntime stack = new();
+            stack.WidthUnits = DimensionUnitType.RelativeToChildren;
+            stack.HeightUnits = DimensionUnitType.RelativeToChildren;
+            stack.Width = 0;
+            stack.Height = 0;
+            stack.ChildrenLayout = ChildrenLayout.TopToBottomStack;
+
+            TextRuntime first = NewArial18Text("List item 1");
+            TextRuntime second = NewArial18Text("List item 2");
+            stack.AddChild(first);
+            stack.AddChild(second);
+
+            stack.UpdateLayout();
+
+            first.GetAbsoluteHeight().ShouldBe(21);
+            second.GetAbsoluteHeight().ShouldBe(21);
+            stack.GetAbsoluteHeight().ShouldBe(42);
+            second.AbsoluteTop.ShouldBe(first.AbsoluteTop + 21);
+        });
+    }
+
+    private static TextRuntime NewArial18Text(string text)
+    {
+        TextRuntime textRuntime = new();
+        textRuntime.WidthUnits = DimensionUnitType.RelativeToChildren;
+        textRuntime.Width = 0;
+        textRuntime.HeightUnits = DimensionUnitType.RelativeToChildren;
+        textRuntime.Height = 0;
+        textRuntime.SetProperty("Font", "Arial");
+        textRuntime.SetProperty("FontSize", 18);
+        textRuntime.Text = text;
+        return textRuntime;
+    }
+
+    // Caching ON (real-world default) with a unique relative directory and NO stream hook: the
+    // (Arial, 18) FontCache .fnt cannot be resolved from disk or hook, so the load fails — reproducing
+    // the Samples/raylib gallery, which ships no FontCache files and relies on the FontFamily fallback.
+    private static void WithCachingOnAndNoFontFiles(Action body)
+    {
+        bool savedCacheTextures = LoaderManager.Self.CacheTextures;
+        string savedRelativeDirectory = FileManager.RelativeDirectory;
+        Func<string, Stream>? savedHook = FileManager.CustomGetStreamFromFile;
+        try
+        {
+            LoaderManager.Self.CacheTextures = true;
+            FileManager.RelativeDirectory = Path.Combine(Path.GetTempPath(),
+                "GumRaylibMissingFnt_" + Guid.NewGuid().ToString("N")).Replace('\\', '/') + "/";
+            FileManager.CustomGetStreamFromFile = null;
+
+            body();
+        }
+        finally
+        {
+            LoaderManager.Self.CacheTextures = savedCacheTextures;
+            FileManager.RelativeDirectory = savedRelativeDirectory;
+            FileManager.CustomGetStreamFromFile = savedHook;
+        }
+    }
+
+    // Serves the gold Font18Arial fixture (.fnt + page) in memory with caching ON, so the (Arial, 18)
+    // cache file resolves and a VALID font is cached. A unique relative directory keeps the cache key
+    // unique to this run so a prior test can't mask the result.
+    private static void WithFont18ArialCached(Action body)
+    {
+        string fixtureDirectory = Path.Combine(AppContext.BaseDirectory, "Content", "FontCache");
+        Dictionary<string, byte[]> inMemoryFiles = new(StringComparer.OrdinalIgnoreCase)
+        {
+            { "Font18Arial.fnt", File.ReadAllBytes(Path.Combine(fixtureDirectory, "Font18Arial.fnt")) },
+            { "Font18Arial_0.png", File.ReadAllBytes(Path.Combine(fixtureDirectory, "Font18Arial_0.png")) },
+        };
+
+        bool savedCacheTextures = LoaderManager.Self.CacheTextures;
+        string savedRelativeDirectory = FileManager.RelativeDirectory;
+        Func<string, Stream>? savedHook = FileManager.CustomGetStreamFromFile;
+        try
+        {
+            LoaderManager.Self.CacheTextures = true;
+            FileManager.RelativeDirectory = Path.Combine(Path.GetTempPath(),
+                "GumRaylibFontCacheTest_" + Guid.NewGuid().ToString("N")).Replace('\\', '/') + "/";
+            FileManager.CustomGetStreamFromFile = incomingPath =>
+                inMemoryFiles.TryGetValue(Path.GetFileName(incomingPath), out byte[]? bytes)
+                    ? new MemoryStream(bytes)
+                    : null!;
+
+            body();
+        }
+        finally
+        {
+            LoaderManager.Self.CacheTextures = savedCacheTextures;
+            FileManager.RelativeDirectory = savedRelativeDirectory;
+            FileManager.CustomGetStreamFromFile = savedHook;
+        }
+    }
+}


### PR DESCRIPTION
## What broke

On raylib, text rendered with an empty font and vertical stacks collapsed — visible on first load in the `Samples/raylib` gallery. Bisected to **`f5ad44e2b` (#3173, "Raylib font parity via KernSmith")**.

## Root cause

`f5ad44e2b` added a cache-hit early-return to the raylib `UpdateToFontValues` font path. When no FontCache `.fnt` exists on disk and no stream hook supplies it (exactly the `Samples/raylib` gallery, which loads Arial via `LoadFontEx` and ships no `.fnt`), `ContentLoader.LoadFont` caches an empty `default(Font)` (**BaseSize 0**) under the cache key.

The new early-return then handed that empty font to **every text after the first**, skipping the existing `BaseSize == 0` → system-font fallback:

```csharp
if (loaderManager.GetDisposable(fullFileName) is ManagedFont cachedManagedFont)
{
    AssignFontIfChanged(asText, cachedManagedFont.Font); // empty font!
    return;                                              // never reaches the fallback
}
```

An empty font renders nothing and, being `RelativeToChildren`, measures to **0** — so vertical stacks collapse. One root cause, two reported symptoms (broken fonts → broken font-based stacking).

## Fix

The cache-hit only short-circuits for a **usable** cached font (`BaseSize != 0`); an empty entry falls through to the fallback. This mirrors the MonoGame copy in `Gum/Wireframe/CustomSetPropertyOnRenderable.cs`, which resolves the font through the full cascade and assigns once at the end — and never had this bug.

## Tests

Adds `TextRuntimeFontCachingRegressionTests`, run with `LoaderManager.CacheTextures = true` — the real-world default that **every existing raylib font test disabled** (`CacheTextures = false`), which is why this branch shipped untested.

- `MultipleTexts_WhenFontCacheFileMissing_WithCachingOn_ShouldEachResolveAUsableFont` — the repro: red before this change, green after.
- Two positives guard valid-font cache reuse and vertical-stack reflow.

Full `RaylibGum.Tests`: **349 pass, 0 new failures**. (The 2 `Circle`/`RectangleRuntimeTests` `StrokeWidth` failures are pre-existing on `main`, verified independently, and unrelated to this change — worth a separate look.)

## Manual verification

Run `Samples/raylib`, click **Forms controls** — before: most text invisible, stacks collapsed/overlapping; after: every label/button/list item renders and columns stack correctly.

## Not included (follow-up)

The raylib cache-hit also lacks MonoGame's disposed-texture guard, so a font whose texture was unloaded after a screen rebuild could still be served stale. Separate latent issue, no repro here — left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
