### PR TITLE
Testing-discipline follow-ups from #3232: cover new branches + test at production defaults

### DIFF
--- a/.claude/skills/gum-unit-tests/SKILL.md
+++ b/.claude/skills/gum-unit-tests/SKILL.md
@@ -24,6 +24,10 @@ description: Writing unit tests in the Gum repo. Triggers: tests in Gum.ProjectS
 - Disable parallel execution in every test project (`[assembly: CollectionBehavior(DisableTestParallelization = true)]`) — Gum uses global singletons.
 - Use named parameters for boolean literals.
 
+## Test at production defaults
+
+When a feature's tests disable a production default for isolation (e.g. `LoaderManager.Self.CacheTextures = false`), remember that default is **on** in real apps — so any code path that only runs with it on is left untested. Treat "this test turns a production default off" as a smell: keep at least one test that exercises the path at the production default. (A raylib font regression survived review because every font test ran with caching off, which made a new cache-hit branch dead code.)
+
 ## Headless Tests (ProjectServices, MonoGameGum.Tests.V2)
 
 Read `BaseTestClass` before adding setup — it handles singleton init, a ready-made `GumProjectSave`, and `Dispose` cleanup. Don't repeat that in subclasses.

--- a/.claude/skills/tdd/SKILL.md
+++ b/.claude/skills/tdd/SKILL.md
@@ -22,3 +22,9 @@ Run the test yourself via Bash. A failure you only reasoned about is not a failu
 Exceptions: docs, csproj/projitems plumbing, pure renames, dead-code removal, cosmetic edits. When in doubt, write the test.
 
 Note: **extracting logic into a new class/service/ViewModel is not a pure rename.** Even when the move preserves behavior, pin the new unit with a characterization test — see [refactoring-direction](../refactoring-direction/SKILL.md). The exemption above is for renames and cosmetics, not for relocating logic into a newly-testable seam.
+
+## A new branch is a behavior change — cover it
+
+A cache check, early-return, guard, or "while I'm here" optimization that alters control flow needs its own test — even when it's bolted onto already-working code and isn't the feature you set out to build. These are the classic blind spot: there's no ticket for them, so nobody asks "what covers this?", and a green-only test passes with or without the branch.
+
+Red-first still applies: after adding a branch, **remove or invert it and confirm a test goes red.** If nothing fails, your change is uncovered — write the test that reaches it. (A real regression shipped exactly this way: a font-loader cache-hit early-return added alongside a feature, reached by no test because every existing font test disabled caching.)

--- a/Tests/RaylibGum.Tests/Runtimes/TextRuntimeTests.cs
+++ b/Tests/RaylibGum.Tests/Runtimes/TextRuntimeTests.cs
@@ -506,6 +506,11 @@ public class TextRuntimeTests : BaseTestClass
     // Serves the gold Font18Arial fixture (.fnt + page) purely in memory, keyed by file name, so the
     // (Arial, 18) font-cache file resolves regardless of disk layout, then restores all mutated global
     // state. Mirrors the in-memory hook setup in Font_SetViaDirectProperties.
+    //
+    // Caching is disabled here for isolation (so a prior test's cached font can't mask the result),
+    // which means helpers like this one do NOT exercise the LoaderManager cache-hit path. Caching-on
+    // coverage of the font path lives in TextRuntimeFontCachingRegressionTests — see the "test at
+    // production defaults" rule in the gum-unit-tests skill.
     private static void WithFont18Arial(Action body)
     {
         string fixtureDirectory = Path.Combine(AppContext.BaseDirectory, "Content", "FontCache");


### PR DESCRIPTION
Follow-up to #3232 (merged). That raylib font regression escaped automated testing for two reasons worth turning into durable rules:

1. The bug lived in an **incidental control-flow branch** (a cache-hit early-return added as a VRAM-leak optimization alongside the KernSmith feature) — the kind of code nobody writes a test for because there's no ticket for it.
2. **Every existing raylib font test runs with `LoaderManager.Self.CacheTextures = false`** (for isolation), which made that branch dead code — so even a reasonable font test couldn't reach it.

This PR captures both lessons where the discipline actually lives — the checked-in skills — per the repo `CLAUDE.md` "Improving Guidance Files Alongside Work" rule (the intent was to bundle these into #3232, but it merged first).

## Changes

- **`tdd` skill — "A new branch is a behavior change — cover it":** an added cache check / early-return / guard / optimization needs its own test; after adding a branch, remove or invert it and confirm a test goes red.
- **`gum-unit-tests` skill — "Test at production defaults":** when tests disable a production default for isolation (e.g. caching), keep at least one test that exercises the path at the production default; treat "this test turns a default off" as a smell.
- **`TextRuntimeTests.cs`:** a signpost comment on the caching-off `WithFont18Arial` helper pointing to the caching-on coverage in `TextRuntimeFontCachingRegressionTests`, so the trap is a documented decision rather than a silent convention.

No code-behavior change — two skill docs and one test-file comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
