### PR TITLE
#3234: Fix stale RaylibGum stroke-width PreRender test expectations (4 -> 5)

### DIFF
--- a/.claude/skills/gum-unit-tests/SKILL.md
+++ b/.claude/skills/gum-unit-tests/SKILL.md
@@ -15,8 +15,12 @@ description: Writing unit tests in the Gum repo. Triggers: tests in Gum.ProjectS
 | `MonoGameGum.Tests.V2` | `Tests/MonoGameGum.Tests.V2/` | Tests specific to V2 default visuals |
 | `MonoGameGum.Tests.V3` | `Tests/MonoGameGum.Tests.V3/` | Tests specific to V3 default visuals |
 | `MonoGameGum.IntegrationTests` | `Tests/MonoGameGum.IntegrationTests/` | Requires a real `GraphicsDevice`: content loading, renderer teardown, full `GumService` lifecycle |
+| `RaylibGum.Tests` | `Tests/RaylibGum.Tests/` | raylib runtime (incl. the `#if RAYLIB` branches of the source-shared `GueDeriving/*Runtime.cs`) |
+| `SkiaGum.Tests` | `Tests/SkiaGum.Tests/` | Skia runtime and shape runtimes |
 
 **When in doubt, put tests in `MonoGameGum.Tests/`.** Only use V2/V3 projects for tests that exercise visual-version-specific behavior.
+
+**`RaylibGum.Tests` and `SkiaGum.Tests` are excluded from CI** (they open a window / wire a GPU pipeline on init — see `build-and-test.yaml`). A green CI run does **not** prove they pass. When you change behavior that the raylib/Skia runtimes cover — including the `#if RAYLIB`/`#if SKIA` branches of a source-shared runtime — run these projects locally yourself, and update any assertion that pins the old behavior. (Issue #3234: #3183 changed the raylib stroke-width PreRender but left these two projects' tests asserting the pre-#3183 value; CI was green, so it shipped red.)
 
 ## Key Rules
 

--- a/Tests/RaylibGum.Tests/Runtimes/CircleRuntimeTests.cs
+++ b/Tests/RaylibGum.Tests/Runtimes/CircleRuntimeTests.cs
@@ -186,10 +186,12 @@ public class CircleRuntimeTests : BaseTestClass
         sut.StrokeWidth.ShouldBe(5f);
 
         sut.PreRender();
-        // The geometric width handed to the renderable is reduced by the ~1px AA contribution
-        // (commit "Fix raylib stroke width rendering ~1px too thick vs Apos/MonoGame") so the
-        // VISIBLE width equals the nominal StrokeWidth across backends. At zoom 1 that is 5 - 1 = 4.
-        ((LineCircle)sut.RenderableComponent!).StrokeWidth.ShouldBe(4f);
+        // Issue #3183 — raylib gets NO AA compensation: the geometric width handed to the
+        // renderable IS the visible width (raylib's MSAA adds no width, unlike Apos.Shapes, which
+        // subtracts a ~1px geometric contribution then adds it back as an AA band). So PreRender
+        // pushes the nominal StrokeWidth straight through. The earlier #3179 subtraction (5 - 1 = 4)
+        // collapsed a nominal 1px ring to ~0.01px (invisible) and was reverted. At zoom 1 this is 5.
+        ((LineCircle)sut.RenderableComponent!).StrokeWidth.ShouldBe(5f);
     }
 
     [Fact]

--- a/Tests/RaylibGum.Tests/Runtimes/RectangleRuntimeTests.cs
+++ b/Tests/RaylibGum.Tests/Runtimes/RectangleRuntimeTests.cs
@@ -230,10 +230,12 @@ public class RectangleRuntimeTests : BaseTestClass
         sut.StrokeWidth.ShouldBe(5f);
 
         sut.PreRender();
-        // The geometric width handed to the renderable is reduced by the ~1px AA contribution
-        // (commit "Fix raylib stroke width rendering ~1px too thick vs Apos/MonoGame") so the
-        // VISIBLE width equals the nominal StrokeWidth across backends. At zoom 1 that is 5 - 1 = 4.
-        ((LineRectangle)sut.RenderableComponent!).LinePixelWidth.ShouldBe(4f);
+        // Issue #3183 — raylib gets NO AA compensation: the geometric width handed to the
+        // renderable IS the visible width (raylib's MSAA adds no width, unlike Apos.Shapes, which
+        // subtracts a ~1px geometric contribution then adds it back as an AA band). So PreRender
+        // pushes the nominal StrokeWidth straight through. The earlier #3179 subtraction (5 - 1 = 4)
+        // collapsed a nominal 1px outline to ~0.01px (invisible) and was reverted. At zoom 1 this is 5.
+        ((LineRectangle)sut.RenderableComponent!).LinePixelWidth.ShouldBe(5f);
     }
 
     [Fact]


### PR DESCRIPTION
Closes #3234.

## Root cause

Two `RaylibGum.Tests` were failing on `main`, both off by exactly +1px (expected 4, got 5):

- `CircleRuntimeTests.PreRender_ShouldPushStrokeWidthToContainedRenderable`
- `RectangleRuntimeTests.PreRender_ShouldPushStrokeWidthToContainedRenderable`

These are the issue's **"case 2": the test expectation was stale**, not a source regression.

- `460cffe4d` ("Fix raylib stroke width rendering ~1px too thick", #3179-era) added a ~1px AA-contribution subtraction to the raylib `PreRender`, so a nominal `StrokeWidth = 5` pushed `4` to the contained `LineCircle`/`LineRectangle`. The tests were written against that (`ShouldBe(4f)`).
- `63484b06d` (**#3183**) **deliberately reverted** that subtraction: Apos.Shapes subtracts geometry then *adds it back* as an AA band, but raylib's MSAA adds no width — so on raylib the subtraction was pure loss and collapsed a nominal 1px stroke to ~0.01px (invisible). #3183 pushes `StrokeWidth` straight through, verified pixel-for-pixel against the Apos reference by the shape-parity screenshot harness.
- The source has pushed the raw `5` since #3183. The two tests were never updated and shipped red because **`RaylibGum.Tests` is excluded from CI** (#3233 — raylib opens a window on init), so the failures never ran on a PR.

Reverting the source to make the tests pass would reintroduce the "1px strokes vanish" bug, so the correct fix is to update the tests.

## Change

- Update both expectations `4f → 5f` and rewrite the stale comments to the #3183 rationale.
- **No production code changes.**
- Per CLAUDE.md "Improving Guidance Files Alongside Work": note in the `gum-unit-tests` skill that `RaylibGum.Tests`/`SkiaGum.Tests` are CI-excluded — a green CI run doesn't prove they pass, so behavior changes covering those runtimes must run them locally (the exact gap that let this ship).

## Verification

`dotnet test Tests/RaylibGum.Tests/RaylibGum.Tests.csproj`:

- Before: the two targeted tests `Failed`.
- After: full `RaylibGum.Tests` suite **351 passed, 0 failed**.

No manual runtime/visual step: this is a test-only correction to already-shipped, harness-verified #3183 behavior — there's no new observable runtime aspect to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
