### PR TITLE
Documentation updates: fix verifiable broken links

### DIFF
--- a/docs/code/files-and-fonts/file-loading.md
+++ b/docs/code/files-and-fonts/file-loading.md
@@ -12,7 +12,7 @@ When a file is added to a Gum project, the Gum UI tool checks the location of th
 
 If all of your project files are located relative to the .gumx root project file, then your project should be portable, and all referenced files will be automatically resolved for you when instantiating Screens and Components from your Gum project.
 
-The Gum runtime library performs all of its loading from-file, so all of your files must be present in the destination directory. As explained in the [Loading .gumx](/broken/pages/PGWmyRmXA6uMwNXuO6Aa) page, all of your files should be set to **Copy if newer** in Visual Studio.
+The Gum runtime library performs all of its loading from-file, so all of your files must be present in the destination directory. As explained in the [Loading .gumx](../getting-started/setup/loading-a-gum-project-.gumx.md) page, all of your files should be set to **Copy if newer** in Visual Studio.
 
 <figure><img src="../../.gitbook/assets/image (4) (1) (1) (1) (1) (1) (1) (1).png" alt=""><figcaption><p>bear.png file set to Copy if newer</p></figcaption></figure>
 

--- a/docs/code/getting-started/setup/adding-initializing-gum/raylib-raylib-cs.md
+++ b/docs/code/getting-started/setup/adding-initializing-gum/raylib-raylib-cs.md
@@ -110,7 +110,7 @@ GumExpressionService.Initialize();
 
 If linking to source instead of NuGet, add `<Gum Root>/Runtimes/GumExpressions/GumExpressions.csproj` to your solution.
 
-For more information, see the [Runtime Variable References](../../../../styling/runtime-variable-references.md) page.
+For more information, see the [Runtime Variable References](../../../styling/runtime-variable-references.md) page.
 
 ## Adding a Button (Testing the Setup)
 

--- a/docs/code/monogame/README.md
+++ b/docs/code/monogame/README.md
@@ -36,7 +36,7 @@ Gum is an _object oriented_ design tool, so projects can contain reusable compon
 
 <figure><img src="../../.gitbook/assets/image (34).png" alt=""><figcaption><p>PauseMenu in Gum</p></figcaption></figure>
 
-Gum produces a set of XML files (and PNG/FNT files for fonts) which can be added to any MonoGame project and loaded with a few lines of code. For information on loading projects, see the [Loading .gumx (Gum Project)](/broken/pages/PGWmyRmXA6uMwNXuO6Aa) page.
+Gum produces a set of XML files (and PNG/FNT files for fonts) which can be added to any MonoGame project and loaded with a few lines of code. For information on loading projects, see the [Loading .gumx (Gum Project)](../getting-started/setup/loading-a-gum-project-.gumx.md) page.
 
 <figure><img src="../../.gitbook/assets/image (35).png" alt=""><figcaption><p>Example Gum project in Windows Explorer</p></figcaption></figure>
 

--- a/docs/code/standard-visuals/roundedrectangleruntime/README.md
+++ b/docs/code/standard-visuals/roundedrectangleruntime/README.md
@@ -5,7 +5,7 @@
 RoundedRectangleRuntime can be used to draw a solid (filled) or outlined rectangle of any color. As the name suggests, it supports rounded corners.
 
 {% hint style="warning" %}
-RoundedRectangleRuntime requires using SkiaGum. For more information on platform support, see the [SkiaGum Platform Support](/broken/pages/mV6KPzqVt1YWQDowoJmY) page.
+RoundedRectangleRuntime requires using SkiaGum. For more information on platform support, see the [SkiaGum Platform Support](../../../gum-tool/gum-elements/skia-standard-elements/shapes-platform-support.md) page.
 {% endhint %}
 
 ## Code Example


### PR DESCRIPTION
Fixes four broken documentation links whose intended targets are provable. A link checker surfaced a larger set of broken links; only the ones that can be verified against the repo or git history are changed here. The rest are left untouched and tracked separately for manual review, because their original targets were deleted from GitBook and cannot be confirmed.

## Fixed (verified)

- **RoundedRectangleRuntime -> Shapes Platform Support** (`docs/code/standard-visuals/roundedrectangleruntime/README.md`): repointed the `/broken/pages/mV6KPzqVt1YWQDowoJmY` stub to `shapes-platform-support.md`. The same stub id was already remapped to that page in the Skia Standard Elements README, so the target is confirmed.
- **Loading .gumx** (`docs/code/files-and-fonts/file-loading.md` and `docs/code/monogame/README.md`): repointed the `/broken/pages/PGWmyRmXA6uMwNXuO6Aa` stub to `loading-a-gum-project-.gumx.md`. The pre-broken anchor (`#adding-the-gum-project-files-to-your-.csproj`) matches that page's heading.
- **Runtime Variable References** (`docs/code/getting-started/setup/adding-initializing-gum/raylib-raylib-cs.md`): the relative path had one extra `../`; corrected to the unique matching file `code/styling/runtime-variable-references.md`.

## Not changed (need a human decision)

The remaining broken links found by the checker are left as-is. Their targets were deleted from GitBook and a correct destination cannot be verified, or no destination page exists at all (for example the `gum-skills/` folder, the ColoredRectangle gradient page, and an empty XnaFiddle placeholder). A full list of these, with the page and line each lives on plus a best-guess target where one exists, has been shared separately for review.