### PR TITLE
Phase 1: Seal IGuiCommands.ShowSpinner() view-type leak behind a neutral ISpinner abstraction

### DIFF
--- a/Direction/ui-decoupling-plan.md
+++ b/Direction/ui-decoupling-plan.md
@@ -64,7 +64,11 @@ barrier (bus-factor insurance). *Risk:* high volume, low per-change risk.
 **Phase 3 — Extract logic into the headless assembly.** Move WPF-free logic into a net8.0 assembly
 so the boundary is compiler-enforced. Convert the ViewModels that reach into `System.Windows.*` to
 neutral types per **ADR-0004**. *Payoff:* the testability ceiling jumps; the boundary becomes a
-guarantee. *Risk:* medium; the VM conversion is the bulk.
+guarantee. *Risk:* medium; the VM conversion is the bulk. *Status:* the boundary was already proven
+end-to-end by the #3229 spike (PR #3231) — `ImportTreeNodeViewModel` now lives in headless
+`Gum.ProjectServices` with its `Visibility` converted to `bool`, unit-tested with no WPF. That was a
+forward de-risk only; **bulk** VM migration remains gated on Phase 2's static drain and on deciding
+the permanent home (grow `Gum.ProjectServices` vs. a dedicated `Gum.Core`/`Gum.Presentation`).
 
 **Phase 4 — The two WinForms subsystems** (the real cost; multi-week each, can overlap).
 - *4a — Element tree:* decouple `ElementTreeViewManager` from `TreeNode`; the already-migrated

--- a/Gum/Commands/GuiCommands.cs
+++ b/Gum/Commands/GuiCommands.cs
@@ -122,7 +122,8 @@ public class GuiCommands : IGuiCommands
         PluginManager.Self.FocusSearch();
     }
 
-    public Spinner ShowSpinner()
+    /// <inheritdoc/>
+    public ISpinner ShowSpinner()
     {
         var spinner = new Gum.Controls.Spinner();
         spinner.Show();

--- a/Gum/Commands/IGuiCommands.cs
+++ b/Gum/Commands/IGuiCommands.cs
@@ -1,5 +1,4 @@
-﻿using Gum.Controls;
-using Gum.DataTypes;
+﻿using Gum.DataTypes;
 
 namespace Gum.Commands;
 public interface IGuiCommands
@@ -13,5 +12,9 @@ public interface IGuiCommands
     void PrintOutput(string output);
     void ToggleToolVisibility();
     void FocusSearch();
-    Spinner ShowSpinner();
+
+    /// <summary>
+    /// Shows a progress spinner and returns it as a framework-neutral <see cref="ISpinner"/>.
+    /// </summary>
+    ISpinner ShowSpinner();
 }

--- a/Gum/Commands/ISpinner.cs
+++ b/Gum/Commands/ISpinner.cs
@@ -1,0 +1,26 @@
+namespace Gum.Commands;
+
+/// <summary>
+/// A determinate progress indicator shown during long-running tool operations such as font
+/// generation. Framework-neutral so progress-driving logic (e.g.
+/// <see cref="Gum.Services.Fonts.ToolFontGenerationCallbacks"/>) stays free of the concrete WPF
+/// view type. The WPF implementation is <see cref="Gum.Controls.Spinner"/>.
+/// </summary>
+public interface ISpinner
+{
+    /// <summary>
+    /// Sets the total number of steps and resets completed progress to zero.
+    /// Safe to call from any thread.
+    /// </summary>
+    void SetTotal(int total);
+
+    /// <summary>
+    /// Advances completed progress by one step. Safe to call from any thread.
+    /// </summary>
+    void IncrementProgress();
+
+    /// <summary>
+    /// Hides the progress indicator.
+    /// </summary>
+    void Hide();
+}

--- a/Gum/Controls/Spinner.xaml.cs
+++ b/Gum/Controls/Spinner.xaml.cs
@@ -1,11 +1,13 @@
+using Gum.Commands;
 using System.Windows;
 
 namespace Gum.Controls;
 
 /// <summary>
-/// A progress dialog shown during font generation.
+/// A progress dialog shown during font generation. Exposed to logic as the framework-neutral
+/// <see cref="ISpinner"/>.
 /// </summary>
-public partial class Spinner : Window
+public partial class Spinner : Window, ISpinner
 {
     private int _completed;
     private int _total;
@@ -32,23 +34,20 @@ public partial class Spinner : Window
         InitializeComponent();
     }
 
-    /// <summary>
-    /// Sets the total number of fonts to generate and resets the progress bar.
-    /// Must be called from the UI thread.
-    /// </summary>
+    /// <inheritdoc/>
     public void SetTotal(int total)
     {
-        _total = total;
-        _completed = 0;
-        FontProgressBar.Maximum = total;
-        FontProgressBar.Value = 0;
-        CountLabel.Text = $"0/{total}";
+        Dispatcher.BeginInvoke(() =>
+        {
+            _total = total;
+            _completed = 0;
+            FontProgressBar.Maximum = total;
+            FontProgressBar.Value = 0;
+            CountLabel.Text = $"0/{total}";
+        });
     }
 
-    /// <summary>
-    /// Increments the completed count by one and updates the progress bar and label.
-    /// Safe to call from any thread; dispatches to the UI thread automatically.
-    /// </summary>
+    /// <inheritdoc/>
     public void IncrementProgress()
     {
         Dispatcher.BeginInvoke(() =>

--- a/Gum/Services/Fonts/ToolFontGenerationCallbacks.cs
+++ b/Gum/Services/Fonts/ToolFontGenerationCallbacks.cs
@@ -1,5 +1,4 @@
 using Gum.Commands;
-using Gum.Controls;
 using Gum.Logic.FileWatch;
 using Gum.ProjectServices.FontGeneration;
 using System;
@@ -15,7 +14,7 @@ public class ToolFontGenerationCallbacks : IFontGenerationCallbacks
 {
     private readonly IGuiCommands _guiCommands;
     private readonly IFileWatchIgnoreList _fileWatchIgnoreList;
-    private Spinner? _currentSpinner;
+    private ISpinner? _currentSpinner;
 
     public ToolFontGenerationCallbacks(IGuiCommands guiCommands, IFileWatchIgnoreList fileWatchIgnoreList)
     {
@@ -29,7 +28,7 @@ public class ToolFontGenerationCallbacks : IFontGenerationCallbacks
     /// <inheritdoc/>
     public IDisposable? ShowSpinner()
     {
-        Spinner spinner = _guiCommands.ShowSpinner();
+        ISpinner spinner = _guiCommands.ShowSpinner();
         _currentSpinner = spinner;
         return new SpinnerHandle(this, spinner);
     }
@@ -37,7 +36,7 @@ public class ToolFontGenerationCallbacks : IFontGenerationCallbacks
     /// <inheritdoc/>
     public void OnFontProgress(int completed, int total)
     {
-        Spinner? spinner = _currentSpinner;
+        ISpinner? spinner = _currentSpinner;
         if (spinner == null)
         {
             return;
@@ -45,9 +44,7 @@ public class ToolFontGenerationCallbacks : IFontGenerationCallbacks
 
         if (completed == 0)
         {
-            // SetTotal must run on the UI thread; use Invoke (synchronous) so the bar
-            // is fully initialized before any IncrementProgress calls arrive.
-            spinner.Dispatcher.BeginInvoke(() => spinner.SetTotal(total));
+            spinner.SetTotal(total);
         }
         else
         {
@@ -61,9 +58,9 @@ public class ToolFontGenerationCallbacks : IFontGenerationCallbacks
     private sealed class SpinnerHandle : IDisposable
     {
         private readonly ToolFontGenerationCallbacks _owner;
-        private readonly Spinner _spinner;
+        private readonly ISpinner _spinner;
 
-        public SpinnerHandle(ToolFontGenerationCallbacks owner, Spinner spinner)
+        public SpinnerHandle(ToolFontGenerationCallbacks owner, ISpinner spinner)
         {
             _owner = owner;
             _spinner = spinner;

--- a/Tool/Tests/GumToolUnitTests/Fonts/ToolFontGenerationCallbacksTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Fonts/ToolFontGenerationCallbacksTests.cs
@@ -1,0 +1,96 @@
+using Gum.Commands;
+using Gum.Logic.FileWatch;
+using Gum.Services.Fonts;
+using Moq;
+using Moq.AutoMock;
+using Shouldly;
+using System;
+using ToolsUtilities;
+
+namespace GumToolUnitTests.Fonts;
+
+public class ToolFontGenerationCallbacksTests
+{
+    private readonly AutoMocker _mocker;
+    private readonly Mock<IGuiCommands> _guiCommands;
+    private readonly Mock<IFileWatchIgnoreList> _fileWatchIgnoreList;
+    private readonly Mock<ISpinner> _spinner;
+    private readonly ToolFontGenerationCallbacks _callbacks;
+
+    public ToolFontGenerationCallbacksTests()
+    {
+        _mocker = new AutoMocker();
+
+        _spinner = new Mock<ISpinner>();
+        _guiCommands = _mocker.GetMock<IGuiCommands>();
+        _guiCommands.Setup(g => g.ShowSpinner()).Returns(_spinner.Object);
+        _fileWatchIgnoreList = _mocker.GetMock<IFileWatchIgnoreList>();
+
+        _callbacks = _mocker.CreateInstance<ToolFontGenerationCallbacks>();
+    }
+
+    [Fact]
+    public void OnFontProgress_DoesNothing_WhenSpinnerNotShown()
+    {
+        _callbacks.OnFontProgress(0, 5);
+
+        _spinner.Verify(s => s.SetTotal(It.IsAny<int>()), Times.Never);
+        _spinner.Verify(s => s.IncrementProgress(), Times.Never);
+    }
+
+    [Fact]
+    public void OnFontProgress_IncrementsProgress_WhenCompletedIsNonZero()
+    {
+        _callbacks.ShowSpinner();
+
+        _callbacks.OnFontProgress(2, 5);
+
+        _spinner.Verify(s => s.IncrementProgress(), Times.Once);
+        _spinner.Verify(s => s.SetTotal(It.IsAny<int>()), Times.Never);
+    }
+
+    [Fact]
+    public void OnFontProgress_SetsTotal_WhenCompletedIsZero()
+    {
+        _callbacks.ShowSpinner();
+
+        _callbacks.OnFontProgress(0, 5);
+
+        _spinner.Verify(s => s.SetTotal(5), Times.Once);
+        _spinner.Verify(s => s.IncrementProgress(), Times.Never);
+    }
+
+    [Fact]
+    public void OnIgnoreFileChange_RoutesToFileWatchIgnoreList()
+    {
+        FilePath filePath = new FilePath("C:/temp/MyFont.fnt");
+
+        _callbacks.OnIgnoreFileChange(filePath);
+
+        _fileWatchIgnoreList.Verify(f => f.IgnoreNextChangeUntil(filePath, null), Times.Once);
+    }
+
+    [Fact]
+    public void OnOutput_RoutesToGuiCommandsPrintOutput()
+    {
+        _callbacks.OnOutput("generating fonts");
+
+        _guiCommands.Verify(g => g.PrintOutput("generating fonts"), Times.Once);
+    }
+
+    [Fact]
+    public void ShowSpinner_Dispose_HidesSpinnerAndStopsFurtherProgress()
+    {
+        IDisposable? handle = _callbacks.ShowSpinner();
+        handle.ShouldNotBeNull();
+        _callbacks.OnFontProgress(0, 5);
+
+        handle!.Dispose();
+        _callbacks.OnFontProgress(0, 5);
+
+        _spinner.Verify(s => s.Hide(), Times.Once);
+        // SetTotal ran once (before dispose); the post-dispose call is a no-op because the
+        // handle cleared the spinner reference.
+        _spinner.Verify(s => s.SetTotal(5), Times.Once);
+    }
+}


### PR DESCRIPTION
Part of #3225 (Phase 1 of the UI/logic decoupling effort — kill the shallow WinForms/WPF scatter & seal leaky interface seams). Closes #3239.

## Problem
`IGuiCommands.ShowSpinner()` returned a concrete WPF view type — `Gum.Controls.Spinner`, a `Window`. An "abstraction" interface that hands back a framework view type defeats the compiler-enforced logic↔view boundary the effort is establishing (ADR-0003) and pins every consumer to WPF. This is a directly-named Phase 1 target ("stop the abstraction interfaces from returning view types").

## Change
- **New `ISpinner`** (`Gum/Commands/ISpinner.cs`) — framework-neutral progress abstraction: `SetTotal` / `IncrementProgress` / `Hide`.
- **`Spinner` implements `ISpinner`**, and `SetTotal` now self-marshals to the UI thread via the dispatcher (the marshaling moved out of the caller, matching how `IncrementProgress` already worked).
- **`IGuiCommands.ShowSpinner()` returns `ISpinner`** — the WPF type leaves the interface signature, and `IGuiCommands.cs` drops its `using Gum.Controls;`.
- **`ToolFontGenerationCallbacks` migrated onto `ISpinner`**, dropping its direct `Dispatcher` use. It is now unit-testable with no WPF dependency.

## Tests (Definition of done)
Per the effort's Definition of done, the seam is capitalized on with a test: `ToolFontGenerationCallbacksTests` pins the font-progress logic against a fake `ISpinner` — the `completed == 0` → `SetTotal` branch, the increment branch, the no-spinner and post-dispose null-guards, and the output / file-watch routing. The change is behavior-preserving, so these are characterization (pinning) tests.

- New tests: **6/6 pass**.
- Full `GumToolUnitTests` suite: **898 passed, 5 skipped, 0 failed** — no regressions from the interface signature change.

## Docs
Bundled a doc-accuracy fix: appended a status note to the Phase 3 paragraph in `Direction/ui-decoupling-plan.md` recording that the headless boundary was already proven by the #3229 spike (PR #3231 — `ImportTreeNodeViewModel` → headless `Gum.ProjectServices`, `Visibility`→`bool`, tested with no WPF), and that **bulk** VM migration stays gated on Phase 2's static drain and the permanent-home decision.

## Manual verification
Behavior-preserving (the progress spinner is unchanged from the user's view), so this is a regression confirmation rather than a new-feature check. To confirm in the running tool:
1. Build/run the Gum tool (`GumFull.sln`).
2. Load or create a project containing a `Text` with a custom font (or one whose `FontCache` is missing/stale).
3. Trigger font (re)generation — load the project, or change a font property / use "regenerate fonts".
4. Confirm the progress spinner still appears, shows the correct total, and increments to completion exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
