### PR TITLE
Docs: fix broken/missing internal links across the docs site (#3238)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 <figure><img src=".gitbook/assets/gum-logo-normal-512.png" alt=""><figcaption></figcaption></figure>
 
-Gum is the best Game UI Layout tool available. It provides a flexible, efficient layout engine capable of producing virtually any layout. Gum can be used in a variety of contexts including in the [FlatRedBall game engine](https://docs.flatredball.com/gum/), [MonoGame](code/getting-started/setup/adding-initializing-gum/monogame-kni-fna/), [raylib](code/getting-started/setup/adding-initializing-gum/raylib-raylib-cs.md), and more. Gum can also be rendered on Skia so it can be used in any environment that supports Skia such as [WPF](code/getting-started/setup/adding-initializing-gum/wpf.md), [Silk.NET](code/silk.net), and Avalonia.
+Gum is the best Game UI Layout tool available. It provides a flexible, efficient layout engine capable of producing virtually any layout. Gum can be used in a variety of contexts including in the [FlatRedBall game engine](https://docs.flatredball.com/gum/), [MonoGame](code/getting-started/setup/adding-initializing-gum/monogame-kni-fna/), [raylib](code/getting-started/setup/adding-initializing-gum/raylib-raylib-cs.md), and more. Gum can also be rendered on Skia so it can be used in any environment that supports Skia such as [WPF](code/getting-started/setup/adding-initializing-gum/wpf.md), [Silk.NET](code/getting-started/setup/adding-initializing-gum/silk.net.md), and Avalonia.
 
 The Gum layout engine can also be included in any .NET project without requiring the use of a particular graphical API.
 

--- a/docs/code/controls/checkbox.md
+++ b/docs/code/controls/checkbox.md
@@ -70,7 +70,7 @@ checkBox.Text = "Three State CheckBox";
 checkBox.IsThreeState = true;
 ```
 
-[Try on XnaFiddle.NET](...)
+[Try on XnaFiddle.NET](https://xnafiddle.net/#snippet=H4sIAAAAAAAACqtW8ix2L81VsiopKk3VUcrMyyzJTMzJrEpVslIqSyxSSM5ITc52yq9QsFXISy1XcIZyNTStY_JgcnqOKSkh-UH5-SWowiGpFSVAfTFKIRlFqakKwSWJJalwE2KUkJV6FoPVQJTYKoAcY61UCwA0LOBQnQAAAA)
 
 ## CheckBox Width and Height
 

--- a/docs/code/getting-started/tutorials/gum-project-.gumx-tutorial/multiple-screens.md
+++ b/docs/code/getting-started/tutorials/gum-project-.gumx-tutorial/multiple-screens.md
@@ -21,7 +21,7 @@ This tutorial also assumes that you have set up code generation for your project
 
 If you would like a simpler starting point, feel free to delete all content in your TitleScreen in Gum, and feel free to delete all code aside from the bare minimum for your project. Be sure to keep your Root object as we'll be using that in this tutorial.
 
-For a full example of what your Game code might look like, see the start of the [Gum Forms](/broken/pages/eV3NKAEskUjucqKpK8kt#introduction) tutorial.
+For a full example of what your Game code might look like, see the start of the [Gum Forms](../gum-project-forms-tutorial/README.md#introduction) tutorial.
 {% endhint %}
 
 ### Creating Multiple Screens

--- a/docs/code/getting-started/tutorials/gum-project-.gumx-tutorial/setup.md
+++ b/docs/code/getting-started/tutorials/gum-project-.gumx-tutorial/setup.md
@@ -23,7 +23,7 @@ This tutorial presents the minimum amount of code necessary to work with Gum. Yo
 
 ## Adding Gum NuGet Packages
 
-Before writing any code, we must add the Gum nuget package. Add the `Gum.MonoGame` package to your game. For more information see the [Setup page](/broken/pages/rWdPjrCsUs4H8CwNUB2w).
+Before writing any code, we must add the Gum nuget package. Add the `Gum.MonoGame` package to your game. For more information see the [Setup page](../../setup/adding-initializing-gum/monogame-kni-fna/README.md).
 
 Once you are finished, your game project should reference the `Gum.MonoGame` project.
 

--- a/docs/code/getting-started/tutorials/gum-project-.gumx-tutorial/strongly-typed-components-using-code-generation.md
+++ b/docs/code/getting-started/tutorials/gum-project-.gumx-tutorial/strongly-typed-components-using-code-generation.md
@@ -22,7 +22,7 @@ This tutorial does not require any of the instances from the previous tutorial. 
 
 If you would like a simpler starting point, feel free to delete all content in your TitleScreen in Gum, and feel free to delete all code aside from the bare minimum for your project.
 
-For a full example of what your Game code might look like, see the start of the [Gum Forms](/broken/pages/eV3NKAEskUjucqKpK8kt#introduction) tutorial.
+For a full example of what your Game code might look like, see the start of the [Gum Forms](../gum-project-forms-tutorial/README.md#introduction) tutorial.
 {% endhint %}
 
 ## Creating a Component

--- a/docs/code/getting-started/tutorials/gum-project-forms-tutorial/setup.md
+++ b/docs/code/getting-started/tutorials/gum-project-forms-tutorial/setup.md
@@ -16,7 +16,7 @@ This tutorial presents the minimum amount of code necessary to work with Gum. Yo
 
 ## Adding Gum NuGet Packages
 
-Before writing any code, we must add the Gum NuGet package. Add the `Gum.MonoGame` package to your game. For more information see the [Setup page](/broken/pages/rWdPjrCsUs4H8CwNUB2w).
+Before writing any code, we must add the Gum NuGet package. Add the `Gum.MonoGame` package to your game. For more information see the [Setup page](../../setup/adding-initializing-gum/monogame-kni-fna/README.md).
 
 Once you are finished, your game project should reference the `Gum.MonoGame` project.
 

--- a/docs/code/monogame/README.md
+++ b/docs/code/monogame/README.md
@@ -20,8 +20,6 @@ You can clone the repository and open the projects in your favorite IDE (like Vi
 
 The direct link to the samples is here: [https://github.com/vchelaru/Gum/tree/main/Samples](https://github.com/vchelaru/Gum/tree/main/Samples)
 
-For more information about the Sample projects, see the [Samples page](/broken/pages/j0sr8sjbLY1OWWfXcQwa).
-
 ### What is the Gum UI Tool?
 
 The Gum UI Tool (usually called "Gum") is a visual editor for creating layouts using the Gum layout engine. Gum has been used on many commercial games to create all types of UI ranging from standard game HUDs to complex forms-based UIs. Gum can be used for any type of game.

--- a/docs/code/standard-visuals/coloredrectangleruntime.md
+++ b/docs/code/standard-visuals/coloredrectangleruntime.md
@@ -23,9 +23,3 @@ coloredRectangleRuntime.AddToManagers();
 ```
 
 The output is a white rectangle:
-
-### Gradient
-
-ColoredRectangleRuntime can display gradients. For information on gradients see the [ColoredRectangle gradient page](../../gum-tool/gum-elements/coloredrectangle/gradient.md).
-
-The output is a gradient rectangle:

--- a/docs/gum-tool/code-tab/runtime-generation-details.md
+++ b/docs/gum-tool/code-tab/runtime-generation-details.md
@@ -28,7 +28,7 @@ Instance properties exist regardless of which Object Instantiation Type is used,
 
 <figure><img src="../../.gitbook/assets/StandardRuntimeInstances.png" alt=""><figcaption><p>MyComponent generates a runtime with properties matching the names of its contained instances</p></figcaption></figure>
 
-The types of these properties match their types in Gum. Instances of standard elements are generated using their corresponding runtime types. For example, a Text instance generates a property of type TextRuntime. For more information about standard element runtime types, see the [Runtime Objects](broken-reference/) section.
+The types of these properties match their types in Gum. Instances of standard elements are generated using their corresponding runtime types. For example, a Text instance generates a property of type TextRuntime. For more information about standard element runtime types, see the [Standard Elements](../../code/standard-visuals/README.md) section.
 
 Instances of components are generated using their corresponding runtime types as well. For example, instances of a component named Button are generated with the type ButtonRuntime.
 

--- a/docs/gum-tool/plugins/pluginbase.export.md
+++ b/docs/gum-tool/plugins/pluginbase.export.md
@@ -30,7 +30,7 @@ The above example shows how to react to a component being exported, but it doesn
 
 The first thing that an export plugin needs to do is to access properties on an element (such as its position and size) as well as the instances contained within the element. This information is available through the ElementSave class.
 
-For more information on how to access properties and instances from the ElementSave, see the [Gum Class Overview](/broken/pages/-MiveTqhTrAT7yL-hNWT) page.
+For more information on how to access properties and instances from the ElementSave, see the [ElementSave](../../code/gum-tool-code-contributing-and-plugins/elementsave/README.md) page.
 
 ## Example Export Code
 

--- a/docs/gum-tool/upgrading/migrating-to-2025-july-28.md
+++ b/docs/gum-tool/upgrading/migrating-to-2025-july-28.md
@@ -57,4 +57,4 @@ If your game references a platform-specific library such as MonoGame, Kni, FNA, 
 
 If you do not do this, you may get error messages indicating that a class is defined in two separate projects causing ambiguity.
 
-For more information, review the document for [adding source to your game project](/broken/pages/brEbOftKY9q9zolHNbMF).
+For more information, see the **Adding Source (Optional)** section of the [setup page for your platform](../../code/getting-started/setup/adding-initializing-gum/README.md).

--- a/docs/gum-tool/upgrading/syntax-versions.md
+++ b/docs/gum-tool/upgrading/syntax-versions.md
@@ -26,7 +26,7 @@ The detected version is displayed in the Code tab under "Project-Wide Code Gener
 | 3 | 2026.6.x | Setup/boot API namespace unification (non-breaking). `GumService` (with its companions `WindowZoomMode` and the hot-reload types) moves from `MonoGameGum` / `RaylibGum` to the unified `Gum` namespace; generated code emits `using Gum;` instead of `using MonoGameGum;`. The legacy names continue to work via permanent `[Obsolete]` subclass shims, and `GumService.Default` still returns the legacy-named type so existing declarations keep compiling. `AddToRoot` / `RemoveFromRoot` become instance methods on `GraphicalUiElement` (no `using` needed at all). See issue #3119. |
 | 4 | TBD | Layout enum namespace unification (breaking). Enums like `DimensionUnitType`, `ChildrenLayout`, `HorizontalAlignment`, etc. move to a unified namespace. The bundled Roslyn analyzer provides one-click migration. |
 
-When a new syntax version is introduced, the corresponding monthly migration page will document the specific changes. See the [runtime refactoring plan](../../contributing/runtime-refactoring.md) for full details.
+When a new syntax version is introduced, the corresponding monthly migration page will document the specific changes.
 
 ## What Happens When You Upgrade
 


### PR DESCRIPTION
Closes #3238.

Resolves the broken/missing internal links found in the docs scan. All new relative links were verified to resolve to existing files.

## A. Mechanical repoints (verified targets)

| File:line | Was | Now |
|---|---|---|
| `docs/README.md` | `code/silk.net` | Silk.NET setup page |
| `…/gum-project-.gumx-tutorial/multiple-screens.md` | `/broken/pages/…#introduction` | Gum Forms tutorial `README.md#introduction` |
| `…/gum-project-.gumx-tutorial/strongly-typed-components-using-code-generation.md` | same broken ref | Gum Forms tutorial `README.md#introduction` |
| `…/gum-project-.gumx-tutorial/setup.md` | `/broken/pages/…` | MonoGame/Kni/FNA setup `README.md` |
| `…/gum-project-forms-tutorial/setup.md` | same broken ref | MonoGame/Kni/FNA setup `README.md` |
| `…/code-tab/runtime-generation-details.md` | `broken-reference/` | Standard Elements (`code/standard-visuals/README.md`) |
| `…/plugins/pluginbase.export.md` | `/broken/pages/…` | ElementSave (`…/elementsave/README.md`) |

Link text was aligned to the destination titles for the last two (page titled "Standard Elements" / "ElementSave").

## B. Decisions (confirmed with maintainer)

- **CheckBox XnaFiddle** — added a real `Try on XnaFiddle.NET` link for the three-state sample. The snippet JSON uses the same `{"IsGum":true,"initialize":"…"}` schema as the three existing working fiddles on the page (verified by decoding them), and the URL round-trips through the encoder.
- **`syntax-versions.md`** — removed the dangling "runtime refactoring plan" reference; the per-version table already links each detailed page.
- **`coloredrectangleruntime.md`** — removed the orphaned "Gradient" section: the linked page never existed, the section had no images, `use-gradient.md` explicitly excludes ColoredRectangle, and the page's hint block already steers new code to `RectangleRuntime` for gradients.
- **`monogame/README.md`** — deleted the redundant broken "Samples page" sentence; a working GitHub Samples link sits one line above.
- **`migrating-to-2025-july-28.md`** — repointed "adding source to your game project" to the per-platform setup landing page (each platform page has an **Adding Source (Optional)** section), since the migration note spans MonoGame/Kni/FNA/Skia.

## Split out / not actionable here

- **`ai-skills.md` → `gum-skills/` 404** — needs the consumer-skills content located before fixing. Tracked in #3243.
- **External FlatRedBall link** (`pages/Hcnjfd34vwMQq8ndSWqK`) — the page-id isn't present anywhere in the repo, so there's nothing to edit here; it's a live-site check.

## Verification

- All new relative links resolve to existing files (scripted check).
- The new XnaFiddle URL was inserted from the encoder output file and diff-verified against it (no corruption).
- No `/broken/pages`, `broken-reference`, or `(...)` placeholder markers remain in the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
