### PR TITLE
Phase 1: seal ITabManager — remove dead WinForms AddControl(Control) overload

### DIFF
--- a/Gum/Managers/ITabManager.cs
+++ b/Gum/Managers/ITabManager.cs
@@ -6,7 +6,6 @@ namespace Gum.Managers;
 
 public interface ITabManager
 {
-    PluginTab AddControl(System.Windows.Forms.Control control, string tabTitle, TabLocation tabLocation);
     PluginTab AddControl(FrameworkElement element, string tabTitle, TabLocation tabLocation = TabLocation.CenterBottom);
     void RemoveTab(PluginTab plugin);
 }

--- a/Gum/ViewModels/MainPanelViewModel.cs
+++ b/Gum/ViewModels/MainPanelViewModel.cs
@@ -15,7 +15,6 @@ using Gum.Plugins;
 using Gum.Services;
 using Gum.Settings;
 using Microsoft.Extensions.Options;
-using Control = System.Windows.Forms.Control;
 
 namespace Gum.Controls;
 
@@ -102,10 +101,6 @@ public class MainPanelViewModel : ViewModel, ITabManager, IRecipient<Application
             }
         }
     }
-
-    public PluginTab AddControl(System.Windows.Forms.Control control, string tabTitle,
-        TabLocation tabLocation) =>
-        AddControl(new System.Windows.Forms.Integration.WindowsFormsHost() { Child = control }, tabTitle, tabLocation);
 
     public PluginTab AddControl(FrameworkElement element, string tabTitle, TabLocation tabLocation = TabLocation.CenterBottom)
     {


### PR DESCRIPTION
Part of Phase 1 of the Gum tool UI/logic decoupling (umbrella #3225) — seal the leaky "abstraction" interfaces that name view types. Continues the seam-sealing started by #3240 (`IGuiCommands.ShowSpinner` → `ISpinner`).

## What
`ITabManager` declared two `AddControl` overloads:

```csharp
PluginTab AddControl(System.Windows.Forms.Control control, string tabTitle, TabLocation tabLocation);   // WinForms
PluginTab AddControl(FrameworkElement element, string tabTitle, TabLocation tabLocation = TabLocation.CenterBottom);  // WPF
```

The WinForms overload's implementation just wrapped the control in a `WindowsFormsHost` and forwarded to the WPF overload. This PR **removes the dead WinForms overload**, so `ITabManager` no longer names any `System.Windows.Forms` type.

## Why it's safe — the WinForms overload is dead
The plan flagged it as "may be load-bearing." It isn't. Classifying the **static (declared) type** of every `AddControl`/`CreateTab` caller — 16 call sites + the `PluginBase` forwarders + a repo-wide sweep — shows **every** caller binds to the WPF `FrameworkElement` overload:

- `PluginBase` exposes only `FrameworkElement`-typed forwarders (`AddControl(FrameworkElement)`, `CreateTab(FrameworkElement)`), so all plugin-level calls are structurally funneled to the WPF path.
- Every control passed is a WPF `System.Windows.Controls.UserControl` (`.xaml.cs`) or a WPF `System.Windows.Controls.Grid`. The "Editor" tab passes a `Grid` that merely *contains* a `WindowsFormsHost` child — not a bare host.
- Two sites use the 2-arg form, for which the 3-required-param WinForms overload isn't even a candidate.

`MainPanelViewModel` is the only implementer; there are no `ITabManager` stubs in the test project.

## Changes
- `Gum/Managers/ITabManager.cs` — remove the WinForms overload declaration.
- `Gum/ViewModels/MainPanelViewModel.cs` — remove its implementation + the now-unused `using Control = System.Windows.Forms.Control;` alias (the dead overload used the fully-qualified form; nothing else referenced the alias).

6 deletions, no additions.

## Deliberately out of scope
- **The WPF `FrameworkElement` overload stays** — it's the legitimate tab-hosting seam, and every consumer is a view-bound WPF plugin constructing a WPF control. A neutral "tab content" abstraction has no Phase-1 payoff (the plugins are view code) and belongs to a later phase.
- **The `element is WindowsFormsHost && tabTitle == "Editor"` margin hack stays** — a pre-existing WinForms-airspace workaround tied to the KNI render host = Phase 4b ("lets the `WindowsFormsHost` airspace/focus hacks be deleted"), not this slice.

## External-plugin note (maintainer FYI)
`ITabManager` is `public`. An external WinForms-based plugin could in theory have called the WinForms overload directly via the (protected) `_tabManager`. In practice external plugins use the documented `PluginBase.AddControl(FrameworkElement)` forwarder, and sealing this WinForms leak is the intent of the decoupling effort. Flagging in case you know of an external WinForms plugin that depends on it.

## Tests / verification
Behavior-preserving interface seal + dead-code removal → **test-exempt** (per the `tdd` skill; matches the #3242 / #3246 dead-code precedents). Verified by a clean `GumFull.sln` build (0 errors) — the compiler is the proof that all callers still bind to the WPF overload.

**Manual test: not needed** — compile + existing test suite. There is no runtime-observable behavior change (the removed overload was unreachable).

Closes #3248.
