### PR TITLE
Docs: teach `using Gum;` for GumService in setup/tutorial pages (#3221)

### DIFF
--- a/docs/code/about/gum-in-code.md
+++ b/docs/code/about/gum-in-code.md
@@ -12,7 +12,7 @@ Gum can be used fully in code. A code-only setup requires minimal code. The foll
 </strong><strong>using Gum.Wireframe;
 </strong>using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
-<strong>using MonoGameGum;
+<strong>using Gum;
 </strong>using System;
 
 namespace MonoGameAndGum;

--- a/docs/code/animationruntime.md
+++ b/docs/code/animationruntime.md
@@ -102,7 +102,7 @@ public class Game1 : Game
 
 {% tab title="No Generated Code" %}
 <pre class="language-csharp"><code class="lang-csharp">using Gum.Wireframe; // for PlayAnimation extension method
-using MonoGameGum; // needed for ToGraphicalUiElement() extension method
+using Gum; // for GumService and the ToGraphicalUiElement() extension method
 
 public class Game1 : Game
 {

--- a/docs/code/binding-viewmodels/items-binding-listbox-combobox-itemscontrol.md
+++ b/docs/code/binding-viewmodels/items-binding-listbox-combobox-itemscontrol.md
@@ -227,7 +227,7 @@ using Gum.Mvvm;
 using Gum.Wireframe;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
-using MonoGameGum;
+using Gum;
 using Gum.GueDeriving;
 using System.Collections.ObjectModel;
 

--- a/docs/code/getting-started/setup/adding-initializing-gum/monogame-kni-fna/README.md
+++ b/docs/code/getting-started/setup/adding-initializing-gum/monogame-kni-fna/README.md
@@ -125,7 +125,7 @@ Add code to your Game class to Initialize, Update, and Draw Gum as shown in the 
 
 <pre class="language-csharp"><code class="lang-csharp">using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
-<strong>using MonoGameGum;
+<strong>using Gum;
 </strong><strong>using Gum.Forms;
 </strong><strong>using Gum.Forms.Controls;
 </strong>
@@ -170,7 +170,7 @@ public class Game1 : Game
 {% tab title="Core (Nez)" %}
 Next, add code to your Core-inheriting class to Initialize, Update, and Draw Gum as shown in the following code block:
 
-<pre class="language-csharp"><code class="lang-csharp"><strong>using MonoGameGum;
+<pre class="language-csharp"><code class="lang-csharp"><strong>using Gum;
 </strong><strong>using Gum.Forms;
 </strong>
 public class Game1 : Core

--- a/docs/code/getting-started/setup/adding-initializing-gum/raylib-raylib-cs.md
+++ b/docs/code/getting-started/setup/adding-initializing-gum/raylib-raylib-cs.md
@@ -51,7 +51,7 @@ Add code to your Program class to Initialize, Update, and Draw Gum as shown in t
 
 <pre class="language-csharp"><code class="lang-csharp"><strong>using Gum.Forms.Controls;
 </strong><strong>using Gum.Wireframe;
-</strong><strong>using RaylibGum;
+</strong><strong>using Gum;
 </strong>using Raylib_cs;
 namespace raylibExample1;
 

--- a/docs/code/getting-started/setup/setup-for-gumbatch.md
+++ b/docs/code/getting-started/setup/setup-for-gumbatch.md
@@ -44,7 +44,7 @@ using Gum.Wireframe;
 using KernSmith.Gum;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
-using MonoGameGum;
+using Gum;
 using RenderingLibrary.Graphics;
 using RenderingLibrary.Graphics.Fonts;
 
@@ -63,7 +63,7 @@ public class Game1 : Game
 
     protected override void Initialize()
     {
-        MonoGameGum.GumService.Default.Initialize(this);
+        GumService.Default.Initialize(this);
 
         CustomSetPropertyOnRenderable.InMemoryFontCreator =
             new KernSmithFontCreator(GraphicsDevice);

--- a/docs/code/getting-started/tutorials/gum-project-.gumx-tutorial/gum-screens.md
+++ b/docs/code/getting-started/tutorials/gum-project-.gumx-tutorial/gum-screens.md
@@ -91,7 +91,7 @@ We can modify the displayed string by getting an instance of the Text and modify
 
 <pre class="language-diff"><code class="lang-diff">protected override void Initialize()
 {
-    var gumProject = MonoGameGum.GumService.Default.Initialize(
+    var gumProject = GumService.Default.Initialize(
         this,
         // This is relative to Content:
         "GumProject/GumProject.gumx");      
@@ -119,7 +119,7 @@ We can also interact with Forms objects in code. The base type for all Forms obj
 ```diff
 protected override void Initialize()
 {
-    var gumProject = MonoGameGum.GumService.Default.Initialize(
+    var gumProject = GumService.Default.Initialize(
         this,
         // This is relative to Content:
         "GumProject/GumProject.gumx");      

--- a/docs/code/getting-started/tutorials/gum-project-.gumx-tutorial/setup.md
+++ b/docs/code/getting-started/tutorials/gum-project-.gumx-tutorial/setup.md
@@ -122,7 +122,7 @@ The steps to do this are:
 Now that we have a Gum project added to the .csproj, we can load the Gum project. We need to add code to Initialize, Update, and Draw. A simplified Game class with these calls would look like the following code:
 
 ```csharp
-using MonoGameGum;
+using Gum;
 
 public class Game1 : Game
 {

--- a/docs/code/getting-started/tutorials/gum-project-forms-tutorial/multiple-screens.md
+++ b/docs/code/getting-started/tutorials/gum-project-forms-tutorial/multiple-screens.md
@@ -121,7 +121,7 @@ Add a Click handler to our button which removes the existing screen and creates 
 {% tabs %}
 {% tab title="Full Code" %}
 ```csharp
-using MonoGameGum;
+using Gum;
 
 partial class Screen1
 {
@@ -140,7 +140,7 @@ partial class Screen1
 
 {% tab title="Diff" %}
 ```diff
-using MonoGameGum;
+using Gum;
 
 partial class Screen1
 {
@@ -161,7 +161,7 @@ partial class Screen1
 {% tabs %}
 {% tab title="Full Code" %}
 ```csharp
-using MonoGameGum;
+using Gum;
 
 partial class Screen2
 {
@@ -179,7 +179,7 @@ partial class Screen2
 {% endtab %}
 
 {% tab title="Diff" %}
-<pre class="language-diff"><code class="lang-diff">using MonoGameGum;
+<pre class="language-diff"><code class="lang-diff">using Gum;
 
 partial class Screen2
 {

--- a/docs/code/getting-started/tutorials/gum-project-forms-tutorial/setup.md
+++ b/docs/code/getting-started/tutorials/gum-project-forms-tutorial/setup.md
@@ -143,7 +143,7 @@ Now that we have a Gum project added to the .csproj, we can load the Gum project
 {% tabs %}
 {% tab title="Full Code" %}
 ```csharp
-using MonoGameGum;
+using Gum;
 
 public class Game1 : Game
 {
@@ -184,7 +184,7 @@ public class Game1 : Game
 
 {% tab title="Diff" %}
 ```diff
-using MonoGameGum;
+using Gum;
 
 public class Game1 : Game
 {

--- a/docs/code/gum-code-reference/cursor/transformmatrix.md
+++ b/docs/code/gum-code-reference/cursor/transformmatrix.md
@@ -11,7 +11,7 @@ public class Game1 : Game
 {
     private GraphicsDeviceManager _graphics;
 
-    GumService GumUI => MonoGameGum.GumService.Default;
+    GumService GumUI => GumService.Default;
 
     SpriteBatch _spriteBatch;
     RenderTarget2D _renderTarget;


### PR DESCRIPTION
## Summary

Sweeps the shipped setup / reference / tutorial docs to teach the unified **`using Gum;`** namespace for `GumService`, replacing the obsolete `using MonoGameGum;` / `using RaylibGum;` subclass-shim namespaces. Those names have been permanent `[Obsolete]` forwarders since the #3119 namespace unification (syntax version 3); new code should use `using Gum;`. This makes the reference pages consistent with the already-modern code-only Forms tutorial (#3219).

After this PR, **no `MonoGameGum.GumService` / `RaylibGum.GumService` references remain anywhere under `docs/code`.**

## Files changed

The 9 candidates from the issue:

- `about/gum-in-code.md`
- `animationruntime.md`
- `binding-viewmodels/items-binding-listbox-combobox-itemscontrol.md`
- `getting-started/setup/adding-initializing-gum/monogame-kni-fna/README.md` (both the Game and Core/Nez blocks)
- `getting-started/setup/adding-initializing-gum/raylib-raylib-cs.md` (`using RaylibGum;` → `using Gum;`)
- `getting-started/setup/setup-for-gumbatch.md`
- `getting-started/tutorials/gum-project-.gumx-tutorial/setup.md`
- `getting-started/tutorials/gum-project-forms-tutorial/setup.md`
- `getting-started/tutorials/gum-project-forms-tutorial/multiple-screens.md`

Plus two `GumService` stragglers found during the sweep (not on the issue's original list, folded in for completeness):

- `getting-started/tutorials/gum-project-.gumx-tutorial/gum-screens.md` — dequalified `MonoGameGum.GumService.Default` → `GumService.Default` (2 spots)
- `gum-code-reference/cursor/transformmatrix.md` — dequalified `=> MonoGameGum.GumService.Default;` → `=> GumService.Default;`

The migration/upgrade pages that document the legacy names on purpose were left untouched, as the issue directed.

## Two non-mechanical spots

- **`setup-for-gumbatch.md`** also had a fully-qualified `MonoGameGum.GumService.Default.Initialize(this)` in the body. Dequalified it to `GumService.Default.Initialize(this)` so the page isn't left half-migrated. (Verified the other bare symbols in that block, `GumBatch` and `CustomSetPropertyOnRenderable`, resolve via the already-present `using RenderingLibrary.Graphics;` and `using Gum.Wireframe;` — `using MonoGameGum;` was only ever supplying `GumService` there.)
- **`animationruntime.md`** carried a `// needed for ToGraphicalUiElement() extension method` comment, which was the reason to suspect this file needed `using MonoGameGum;`. **It does not.** The no-arg `ToGraphicalUiElement()` convenience overload already lives in **namespace `Gum`** (`Gum.ElementSaveExtensionMethods` in `MonoGameGum/GumService.cs`); the `MonoGameGum`/`RaylibGum` version is just an `[Obsolete]` forwarder whose own attribute says *"Use Gum.ElementSaveExtensionMethods.ToGraphicalUiElement instead (via `using Gum;`)."* So `using Gum;` supplies both `GumService` and the extension, and the comment was updated accordingly.

## Out of scope

The remaining `MonoGameGum.Input.*` / `MonoGameGum.Forms.*` references on other pages are a separate namespace question (input / Forms types), not `GumService`, and are intentionally left for a follow-up.

## Verification

Docs-only. Each swapped `using` was checked against source: `GumService` and the `ToGraphicalUiElement()` convenience overload both live in namespace `Gum`, and `AddToRoot()` on generated screens is an instance method (no `using` dependency). No code block relied on a bare symbol that exists only in the `MonoGameGum`/`RaylibGum` namespace.

Closes #3221

🤖 Generated with [Claude Code](https://claude.com/claude-code)
