### PR TITLE
Phase 1: migrate SvgExportPlugin SaveFileDialog to IDialogService

### DIFF
--- a/Gum/Plugins/InternalPlugins/SvgExportPlugin/MainSvgExportPlugin.cs
+++ b/Gum/Plugins/InternalPlugins/SvgExportPlugin/MainSvgExportPlugin.cs
@@ -2,10 +2,7 @@ using Gum.DataTypes;
 using Gum.Plugins.BaseClasses;
 using Gum.Services;
 using Gum.ToolStates;
-using System;
 using System.ComponentModel.Composition;
-using System.Diagnostics;
-using System.IO;
 using System.Windows.Controls;
 
 namespace Gum.Plugins.InternalPlugins.SvgExportPlugin;
@@ -16,11 +13,15 @@ internal class MainSvgExportPlugin : PriorityPlugin
     private MenuItem _exportSvgMenuItem;
     private readonly ISelectedState _selectedState;
     private readonly IProjectState _projectState;
+    private readonly ISvgExportCommand _svgExportCommand;
 
     public MainSvgExportPlugin()
     {
         _selectedState = Locator.GetRequiredService<ISelectedState>();
         _projectState = Locator.GetRequiredService<IProjectState>();
+        // SVG export is plugin-specific, so the command is instantiated here rather than
+        // registered app-wide. _dialogService/_guiCommands come from PluginBase's ctor.
+        _svgExportCommand = new SvgExportCommand(_dialogService, _guiCommands);
     }
 
     public override void StartUp()
@@ -72,83 +73,6 @@ internal class MainSvgExportPlugin : PriorityPlugin
             return;
         }
 
-        var dlg = new Microsoft.Win32.SaveFileDialog
-        {
-            DefaultExt = ".svg",
-            Filter = "SVG Files (*.svg)|*.svg",
-            FileName = element.Name + ".svg",
-        };
-
-        if (dlg.ShowDialog() != true)
-        {
-            return;
-        }
-
-        string gumCliPath = FindGumCliPath();
-
-        if (gumCliPath == null)
-        {
-            _guiCommands.PrintOutput("Could not find gumcli. Expected in GumCli subfolder next to Gum.exe.");
-            return;
-        }
-
-        string projectPath = projectSave.FullFileName;
-        string elementName = element.Name;
-        string outputPath = dlg.FileName;
-
-        RunGumCliSvgExport(gumCliPath, projectPath, elementName, outputPath);
-    }
-
-    private void RunGumCliSvgExport(string gumCliPath, string projectPath, string elementName, string outputPath)
-    {
-        try
-        {
-            var startInfo = new ProcessStartInfo
-            {
-                FileName = gumCliPath,
-                Arguments = $"svg \"{projectPath}\" \"{elementName}\" --output \"{outputPath}\"",
-                RedirectStandardOutput = true,
-                RedirectStandardError = true,
-                UseShellExecute = false,
-                CreateNoWindow = true,
-            };
-
-            using var process = Process.Start(startInfo);
-            if (process == null)
-            {
-                _guiCommands.PrintOutput("Failed to start gumcli process.");
-                return;
-            }
-
-            string stdout = process.StandardOutput.ReadToEnd();
-            string stderr = process.StandardError.ReadToEnd();
-            process.WaitForExit();
-
-            if (process.ExitCode == 0)
-            {
-                _guiCommands.PrintOutput(stdout.TrimEnd());
-            }
-            else
-            {
-                _guiCommands.PrintOutput($"SVG export failed (exit code {process.ExitCode}): {stderr.TrimEnd()}");
-            }
-        }
-        catch (Exception ex)
-        {
-            _guiCommands.PrintOutput($"SVG export error: {ex.Message}");
-        }
-    }
-
-    private static string? FindGumCliPath()
-    {
-        string exeDir = AppDomain.CurrentDomain.BaseDirectory;
-        string cliPath = Path.Combine(exeDir, "GumCli", "gumcli.exe");
-
-        if (File.Exists(cliPath))
-        {
-            return cliPath;
-        }
-
-        return null;
+        _svgExportCommand.ExportElementToSvg(element, projectSave);
     }
 }

--- a/Gum/Plugins/InternalPlugins/SvgExportPlugin/SvgExportCommand.cs
+++ b/Gum/Plugins/InternalPlugins/SvgExportPlugin/SvgExportCommand.cs
@@ -1,0 +1,131 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using Gum.Commands;
+using Gum.DataTypes;
+using Gum.Services.Dialogs;
+
+namespace Gum.Plugins.InternalPlugins.SvgExportPlugin;
+
+/// <summary>
+/// Orchestrates exporting an element to SVG: prompts for an output path and shells out to
+/// the gumcli tool. Called by <see cref="MainSvgExportPlugin"/>.
+/// </summary>
+internal interface ISvgExportCommand
+{
+    /// <summary>
+    /// Prompts the user for an output path and exports the given element to SVG via gumcli.
+    /// Does nothing if the user cancels the save dialog.
+    /// </summary>
+    void ExportElementToSvg(ElementSave element, GumProjectSave projectSave);
+}
+
+/// <inheritdoc/>
+internal class SvgExportCommand : ISvgExportCommand
+{
+    private readonly IDialogService _dialogService;
+    private readonly IGuiCommands _guiCommands;
+
+    public SvgExportCommand(IDialogService dialogService, IGuiCommands guiCommands)
+    {
+        _dialogService = dialogService;
+        _guiCommands = guiCommands;
+    }
+
+    /// <inheritdoc/>
+    public void ExportElementToSvg(ElementSave element, GumProjectSave projectSave)
+    {
+        string? outputPath = _dialogService.SaveFile(new SaveFileDialogOptions
+        {
+            Title = "Export to SVG",
+            Filter = "SVG Files (*.svg)|*.svg",
+            FileName = element.Name + ".svg",
+        });
+
+        if (string.IsNullOrEmpty(outputPath))
+        {
+            return;
+        }
+
+        string? gumCliPath = FindGumCliPath();
+        if (gumCliPath == null)
+        {
+            _guiCommands.PrintOutput("Could not find gumcli. Expected in GumCli subfolder next to Gum.exe.");
+            return;
+        }
+
+        RunGumCliSvgExport(gumCliPath, projectSave.FullFileName, element.Name, outputPath);
+    }
+
+    /// <summary>
+    /// Builds the gumcli argument string for an SVG export, quoting each value so paths
+    /// and element names containing spaces are passed as single arguments.
+    /// </summary>
+    internal string BuildSvgExportArguments(string projectPath, string elementName, string outputPath)
+    {
+        return $"svg \"{projectPath}\" \"{elementName}\" --output \"{outputPath}\"";
+    }
+
+    /// <summary>
+    /// Locates gumcli.exe, expected in a GumCli subfolder next to Gum.exe. Returns null if
+    /// it cannot be found. Virtual so tests can supply a deterministic result.
+    /// </summary>
+    protected virtual string? FindGumCliPath()
+    {
+        string exeDirectory = AppDomain.CurrentDomain.BaseDirectory;
+        string cliPath = Path.Combine(exeDirectory, "GumCli", "gumcli.exe");
+
+        if (File.Exists(cliPath))
+        {
+            return cliPath;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Runs gumcli to perform the SVG export and prints its output. Virtual so tests can
+    /// observe the invocation without spawning a real process.
+    /// </summary>
+    protected virtual void RunGumCliSvgExport(
+        string gumCliPath, string projectPath, string elementName, string outputPath)
+    {
+        try
+        {
+            ProcessStartInfo startInfo = new()
+            {
+                FileName = gumCliPath,
+                Arguments = BuildSvgExportArguments(projectPath, elementName, outputPath),
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+            };
+
+            using Process? process = Process.Start(startInfo);
+            if (process == null)
+            {
+                _guiCommands.PrintOutput("Failed to start gumcli process.");
+                return;
+            }
+
+            string standardOutput = process.StandardOutput.ReadToEnd();
+            string standardError = process.StandardError.ReadToEnd();
+            process.WaitForExit();
+
+            if (process.ExitCode == 0)
+            {
+                _guiCommands.PrintOutput(standardOutput.TrimEnd());
+            }
+            else
+            {
+                _guiCommands.PrintOutput(
+                    $"SVG export failed (exit code {process.ExitCode}): {standardError.TrimEnd()}");
+            }
+        }
+        catch (Exception e)
+        {
+            _guiCommands.PrintOutput($"SVG export error: {e.Message}");
+        }
+    }
+}

--- a/Tool/Tests/GumToolUnitTests/Plugins/InternalPlugins/SvgExportPlugin/SvgExportCommandTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/InternalPlugins/SvgExportPlugin/SvgExportCommandTests.cs
@@ -1,0 +1,144 @@
+using Gum.Commands;
+using Gum.DataTypes;
+using Gum.Plugins.InternalPlugins.SvgExportPlugin;
+using Gum.Services.Dialogs;
+using Moq;
+using Shouldly;
+using Xunit;
+
+namespace GumToolUnitTests.Plugins.InternalPlugins.SvgExportPlugin;
+
+public class SvgExportCommandTests : BaseTestClass
+{
+    private readonly Mock<IDialogService> _dialogService;
+    private readonly Mock<IGuiCommands> _guiCommands;
+
+    public SvgExportCommandTests()
+    {
+        _dialogService = new Mock<IDialogService>();
+        _guiCommands = new Mock<IGuiCommands>();
+    }
+
+    [Fact]
+    public void BuildSvgExportArguments_quotes_all_arguments()
+    {
+        SvgExportCommand command = new(_dialogService.Object, _guiCommands.Object);
+
+        string arguments = command.BuildSvgExportArguments(
+            "c:/my projects/Game.gumx",
+            "Main Screen",
+            "c:/out dir/Main Screen.svg");
+
+        arguments.ShouldBe(
+            "svg \"c:/my projects/Game.gumx\" \"Main Screen\" --output \"c:/out dir/Main Screen.svg\"");
+    }
+
+    [Fact]
+    public void ExportElementToSvg_does_not_run_gumcli_when_save_cancelled()
+    {
+        _dialogService
+            .Setup(d => d.SaveFile(It.IsAny<SaveFileDialogOptions?>()))
+            .Returns((string?)null);
+
+        TestableSvgExportCommand command = new(_dialogService.Object, _guiCommands.Object)
+        {
+            GumCliPathToReturn = "c:/gum/GumCli/gumcli.exe",
+        };
+
+        command.ExportElementToSvg(new ScreenSave { Name = "MyScreen" }, new GumProjectSave());
+
+        command.RunCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public void ExportElementToSvg_offers_svg_filename_and_filter_in_save_dialog()
+    {
+        SaveFileDialogOptions? captured = null;
+        _dialogService
+            .Setup(d => d.SaveFile(It.IsAny<SaveFileDialogOptions?>()))
+            .Callback<SaveFileDialogOptions?>(options => captured = options)
+            .Returns((string?)null);
+
+        TestableSvgExportCommand command = new(_dialogService.Object, _guiCommands.Object);
+
+        command.ExportElementToSvg(new ScreenSave { Name = "MyScreen" }, new GumProjectSave());
+
+        captured.ShouldNotBeNull();
+        captured!.FileName.ShouldBe("MyScreen.svg");
+        captured.Filter.ShouldBe("SVG Files (*.svg)|*.svg");
+    }
+
+    [Fact]
+    public void ExportElementToSvg_prints_error_and_skips_run_when_gumcli_missing()
+    {
+        _dialogService
+            .Setup(d => d.SaveFile(It.IsAny<SaveFileDialogOptions?>()))
+            .Returns("c:/out/MyScreen.svg");
+
+        TestableSvgExportCommand command = new(_dialogService.Object, _guiCommands.Object)
+        {
+            GumCliPathToReturn = null,
+        };
+
+        command.ExportElementToSvg(new ScreenSave { Name = "MyScreen" }, new GumProjectSave());
+
+        command.RunCount.ShouldBe(0);
+        _guiCommands.Verify(g => g.PrintOutput(It.Is<string>(s => s.Contains("gumcli"))), Times.Once);
+    }
+
+    [Fact]
+    public void ExportElementToSvg_runs_gumcli_with_chosen_path_when_available()
+    {
+        _dialogService
+            .Setup(d => d.SaveFile(It.IsAny<SaveFileDialogOptions?>()))
+            .Returns("c:/out/MyScreen.svg");
+
+        TestableSvgExportCommand command = new(_dialogService.Object, _guiCommands.Object)
+        {
+            GumCliPathToReturn = "c:/gum/GumCli/gumcli.exe",
+        };
+
+        command.ExportElementToSvg(
+            new ScreenSave { Name = "MyScreen" },
+            new GumProjectSave { FullFileName = "c:/proj/Game.gumx" });
+
+        command.RunCount.ShouldBe(1);
+        command.LastGumCliPath.ShouldBe("c:/gum/GumCli/gumcli.exe");
+        command.LastProjectPath.ShouldBe("c:/proj/Game.gumx");
+        command.LastElementName.ShouldBe("MyScreen");
+        command.LastOutputPath.ShouldBe("c:/out/MyScreen.svg");
+    }
+
+    // Stubs the two environment-bound seams (gumcli path resolution and the actual
+    // subprocess launch) so the export decision flow can be exercised deterministically
+    // without a gumcli.exe present in the test bin or a real process being spawned.
+    private sealed class TestableSvgExportCommand : SvgExportCommand
+    {
+        public TestableSvgExportCommand(IDialogService dialogService, IGuiCommands guiCommands)
+            : base(dialogService, guiCommands)
+        {
+        }
+
+        public string? GumCliPathToReturn { get; set; }
+        public int RunCount { get; private set; }
+        public string? LastGumCliPath { get; private set; }
+        public string? LastProjectPath { get; private set; }
+        public string? LastElementName { get; private set; }
+        public string? LastOutputPath { get; private set; }
+
+        protected override string? FindGumCliPath()
+        {
+            return GumCliPathToReturn;
+        }
+
+        protected override void RunGumCliSvgExport(
+            string gumCliPath, string projectPath, string elementName, string outputPath)
+        {
+            RunCount++;
+            LastGumCliPath = gumCliPath;
+            LastProjectPath = projectPath;
+            LastElementName = elementName;
+            LastOutputPath = outputPath;
+        }
+    }
+}


### PR DESCRIPTION
## What

Migrates `MainSvgExportPlugin`'s inline `Microsoft.Win32.SaveFileDialog` to the `IDialogService.SaveFile` seam (added in #3253), and extracts the SVG-export orchestration into a new, unit-tested `SvgExportCommand` / `ISvgExportCommand`.

This is the **SvgExport file-dialog** slice of the Phase 1 UI/logic decoupling effort (#3225) — wide, shallow, low-risk. It seals the WPF view-type leak (`SaveFileDialog`) inside a plugin's logic and lands a tested unit per the Phase-1 "Definition of done".

## Changes

- **`MainSvgExportPlugin`** keeps selection/project-state gating (element is `Screen`/`Component`; "No project is loaded."), then delegates to `_svgExportCommand.ExportElementToSvg(element, projectSave)`. The inline `SaveFileDialog` and the gumcli helpers move out.
- **New `SvgExportCommand` (+ `ISvgExportCommand`)** — a plugin-specific service (instantiated by the plugin, not registered in `Builder.cs`, per code-style). Constructor-injects `IDialogService` + `IGuiCommands` (both available from `PluginBase`). Owns: save-dialog prompt → gumcli path resolution → subprocess launch + output reporting.
- **Testable seams without a process framework:** `FindGumCliPath` / `RunGumCliSvgExport` are `protected virtual` instance methods, and `BuildSvgExportArguments` is a pure method. The decision flow is unit-tested by a test subclass that stubs the two environment-bound seams — no real process is spawned, no `IProcessRunner` abstraction introduced (none exists in the tool; `Process.Start` is called directly throughout).

## Tests

5 new `SvgExportCommandTests`:
- `BuildSvgExportArguments` quotes all three arguments (regression guard for paths/names with spaces).
- cancel → gumcli not run.
- save dialog is offered the `.svg` default filename + SVG filter.
- gumcli missing → error printed, run skipped.
- gumcli present → run invoked with the chosen path + args.

Full `GumToolUnitTests` green (909 passed / 0 failed / 4 skipped). `GumFull.sln` builds with **0 errors** and **0 new warnings** (the one CS8618 in the touched file on `_exportSvgMenuItem` is pre-existing).

## Behavior note

The old dialog set `DefaultExt = ".svg"`, which `SaveFileDialogOptions` does not carry. This is behavior-preserving: the SVG-only `Filter` already drives WPF's `SaveFileDialog.AddExtension` (default `true`) to append `.svg` when the user omits it.

## Manual test: needed

File dialogs are runtime-observable. Steps:
1. Build & run the Gum tool (`GumFull.sln` → `Gum`).
2. Load a project that has a Screen or Component.
3. Select a Screen or Component → the **File ▸ Export ▸ "Export {name} to SVG"** menu item is enabled.
4. Click it → a **Save File** dialog appears, filtered to `*.svg`, with the default file name `{ElementName}.svg`.
5. **Cancel** → nothing happens (no output, no file). **Pick a path** → gumcli runs and the SVG is produced; its output prints to the Output window. (If `GumCli/gumcli.exe` is absent next to `Gum.exe`, the Output shows "Could not find gumcli…".)

Closes #3254.
Part of #3225.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
