### PR TITLE
Fix #3259: register Rectangle runtime in SkiaGum so it renders in SVG export

### DIFF
--- a/.claude/skills/gum-unit-tests/SKILL.md
+++ b/.claude/skills/gum-unit-tests/SKILL.md
@@ -17,6 +17,7 @@ description: Writing unit tests in the Gum repo. Triggers: tests in Gum.ProjectS
 | `MonoGameGum.IntegrationTests` | `Tests/MonoGameGum.IntegrationTests/` | Requires a real `GraphicsDevice`: content loading, renderer teardown, full `GumService` lifecycle |
 | `RaylibGum.Tests` | `Tests/RaylibGum.Tests/` | raylib runtime (incl. the `#if RAYLIB` branches of the source-shared `GueDeriving/*Runtime.cs`) |
 | `SkiaGum.Tests` | `Tests/SkiaGum.Tests/` | Skia runtime and shape runtimes |
+| `Gum.ProjectServices.SkiaGum.Tests` | `Tests/Gum.ProjectServices.SkiaGum.Tests/` | SkiaGum-backed SVG export (`SkiaGumSvgExportService`, the service behind `gumcli svg` / tool File ▸ Export); drives `SKSvgCanvas` headlessly |
 
 **When in doubt, put tests in `MonoGameGum.Tests/`.** Only use V2/V3 projects for tests that exercise visual-version-specific behavior.
 

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -166,6 +166,8 @@ jobs:
       #   - GumToolUnitTests               (WPF tool unit tests; Windows only)
       #   - Gum.Bundle.Tests               (brotli/tar/format; pure IO)
       #   - Gum.ProjectServices.Tests      (headless project loading, codegen)
+      #   - Gum.ProjectServices.SkiaGum.Tests (SkiaGum SVG export — renders into
+      #                                     SKSvgCanvas, CPU-only like SkiaGum.Tests)
       #   - Gum.Analyzers.Tests            (Roslyn analyzers; pure compilation)
       #   - Gum.Cli.Tests                  (CLI subcommand smoke tests; fonts
       #                                     tests self-gate by OS, no screenshot
@@ -241,6 +243,13 @@ jobs:
       - name: SkiaGum.Tests
         if: github.event_name != 'push' || steps.cache-workloads.outputs.cache-hit != 'true'
         run: dotnet test "Tests/SkiaGum.Tests" --configuration Release --no-build --logger "trx" --results-directory "TestResults"
+
+      # SkiaGum-backed SVG export service (gumcli svg / tool File ▸ Export). Drives
+      # SkiaGumSvgExportService end-to-end via SKSvgCanvas — CPU-only, fully headless
+      # like SkiaGum.Tests above, so it blocks on failure too. #3259
+      - name: Gum.ProjectServices.SkiaGum.Tests
+        if: github.event_name != 'push' || steps.cache-workloads.outputs.cache-hit != 'true'
+        run: dotnet test "Tests/Gum.ProjectServices.SkiaGum.Tests" --configuration Release --no-build --logger "trx" --results-directory "TestResults"
 
       # --- RaylibGum.Tests via Mesa llvmpipe software GL (Windows, #3250) ---------
       # raylib's InitWindow needs an OpenGL 3.3 context the GPU-less runners lack.

--- a/AllLibraries.sln
+++ b/AllLibraries.sln
@@ -149,6 +149,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Gum.Themes.Retro95.Raylib",
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Gum.Themes.Template.Raylib", "Themes\Gum.Themes.Template.Raylib\Gum.Themes.Template.Raylib.csproj", "{5A3BA47A-7EFC-46A5-B28F-49085E4B7A19}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Gum.ProjectServices.SkiaGum.Tests", "Tests\Gum.ProjectServices.SkiaGum.Tests\Gum.ProjectServices.SkiaGum.Tests.csproj", "{9642D9F2-2087-450A-B6DD-80A3E0A05571}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1332,6 +1334,24 @@ Global
 		{5A3BA47A-7EFC-46A5-B28F-49085E4B7A19}.Release|x64.Build.0 = Release|Any CPU
 		{5A3BA47A-7EFC-46A5-B28F-49085E4B7A19}.Release|x86.ActiveCfg = Release|Any CPU
 		{5A3BA47A-7EFC-46A5-B28F-49085E4B7A19}.Release|x86.Build.0 = Release|Any CPU
+		{9642D9F2-2087-450A-B6DD-80A3E0A05571}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9642D9F2-2087-450A-B6DD-80A3E0A05571}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9642D9F2-2087-450A-B6DD-80A3E0A05571}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{9642D9F2-2087-450A-B6DD-80A3E0A05571}.Debug|x64.Build.0 = Debug|Any CPU
+		{9642D9F2-2087-450A-B6DD-80A3E0A05571}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{9642D9F2-2087-450A-B6DD-80A3E0A05571}.Debug|x86.Build.0 = Debug|Any CPU
+		{9642D9F2-2087-450A-B6DD-80A3E0A05571}.Release_No_Diagnostics|Any CPU.ActiveCfg = Debug|Any CPU
+		{9642D9F2-2087-450A-B6DD-80A3E0A05571}.Release_No_Diagnostics|Any CPU.Build.0 = Debug|Any CPU
+		{9642D9F2-2087-450A-B6DD-80A3E0A05571}.Release_No_Diagnostics|x64.ActiveCfg = Debug|Any CPU
+		{9642D9F2-2087-450A-B6DD-80A3E0A05571}.Release_No_Diagnostics|x64.Build.0 = Debug|Any CPU
+		{9642D9F2-2087-450A-B6DD-80A3E0A05571}.Release_No_Diagnostics|x86.ActiveCfg = Debug|Any CPU
+		{9642D9F2-2087-450A-B6DD-80A3E0A05571}.Release_No_Diagnostics|x86.Build.0 = Debug|Any CPU
+		{9642D9F2-2087-450A-B6DD-80A3E0A05571}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9642D9F2-2087-450A-B6DD-80A3E0A05571}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9642D9F2-2087-450A-B6DD-80A3E0A05571}.Release|x64.ActiveCfg = Release|Any CPU
+		{9642D9F2-2087-450A-B6DD-80A3E0A05571}.Release|x64.Build.0 = Release|Any CPU
+		{9642D9F2-2087-450A-B6DD-80A3E0A05571}.Release|x86.ActiveCfg = Release|Any CPU
+		{9642D9F2-2087-450A-B6DD-80A3E0A05571}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1402,6 +1422,7 @@ Global
 		{FB9924E0-3607-4693-B472-88DCEB00B14D} = {90F7E5FD-146B-406A-C97D-A0D358256D37}
 		{80F871A3-4A72-4905-B849-62ED179B221B} = {90F7E5FD-146B-406A-C97D-A0D358256D37}
 		{5A3BA47A-7EFC-46A5-B28F-49085E4B7A19} = {90F7E5FD-146B-406A-C97D-A0D358256D37}
+		{9642D9F2-2087-450A-B6DD-80A3E0A05571} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {01002AE6-0158-417E-9B83-D4234361EC1B}

--- a/Runtimes/SkiaGum/RenderingLibrary/SystemManagers.cs
+++ b/Runtimes/SkiaGum/RenderingLibrary/SystemManagers.cs
@@ -123,9 +123,15 @@ namespace RenderingLibrary
                 "Polygon",
                 () => new PolygonRuntime());
 
-            //ElementSaveExtensions.RegisterGueInstantiation(
-            //    "Rectangle",
-            //    () => new RectangleRuntime());
+            // Issue #3259 — the v3 "Rectangle" standard type (filled/rounded/stroked) renders
+            // through RectangleRuntime, whose SKIA build wraps a RoundedRectangle fill+stroke
+            // pair (#2814/#2818). Without this registration SkiaGum created no renderable for a
+            // "Rectangle" base type, so the shape was silently dropped from SVG export (gumcli
+            // svg / tool File ▸ Export) and any SkiaGum-hosted render — only Text/Container/etc.
+            // drew. The XNALIKE/raylib backends register the same runtime in their SystemManagers.
+            ElementSaveExtensions.RegisterGueInstantiation(
+                "Rectangle",
+                () => new RectangleRuntime());
 
             ElementSaveExtensions.RegisterGueInstantiation(
                 "Sprite",

--- a/Tests/Gum.ProjectServices.SkiaGum.Tests/Gum.ProjectServices.SkiaGum.Tests.csproj
+++ b/Tests/Gum.ProjectServices.SkiaGum.Tests/Gum.ProjectServices.SkiaGum.Tests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>12.0</LangVersion>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Shouldly" Version="4.3.0" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Tools\Gum.ProjectServices\Gum.ProjectServices.csproj" />
+    <ProjectReference Include="..\..\Tools\Gum.ProjectServices.SkiaGum\Gum.ProjectServices.SkiaGum.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/Tests/Gum.ProjectServices.SkiaGum.Tests/SkiaGumSvgExportServiceTests.cs
+++ b/Tests/Gum.ProjectServices.SkiaGum.Tests/SkiaGumSvgExportServiceTests.cs
@@ -12,6 +12,12 @@ namespace Gum.ProjectServices.SkiaGum.Tests;
 /// </summary>
 public class SkiaGumSvgExportServiceTests : IDisposable
 {
+    // SVG tags emitted by SkiaSharp's SKSvgCanvas for the various shape draw calls
+    // (DrawRoundRect/DrawRect → rect, DrawPath → path, DrawOval/DrawCircle → ellipse/circle,
+    // DrawLine → line). A standard shape type that renders nothing produces none of these.
+    private static readonly string[] DrawElementTags =
+        { "<rect", "<path", "<ellipse", "<circle", "<polygon", "<line", "<image" };
+
     private readonly string _tempDirectory;
 
     public SkiaGumSvgExportServiceTests()
@@ -27,70 +33,99 @@ public class SkiaGumSvgExportServiceTests : IDisposable
     [Fact]
     public void ExportSvg_FilledRectangleScreen_ShouldContainShapeElement()
     {
-        string projectPath = CreateProjectWithRectangleScreen("RectScreen");
-        string outputPath = Path.Combine(_tempDirectory, "rect.svg");
+        string svg = ExportScreenWithInstance(
+            "Rectangle",
+            new VariableSave { Name = "ShapeInstance.X", Type = "float", Value = 10f, SetsValue = true },
+            new VariableSave { Name = "ShapeInstance.Y", Type = "float", Value = 10f, SetsValue = true },
+            new VariableSave { Name = "ShapeInstance.Width", Type = "float", Value = 100f, SetsValue = true },
+            new VariableSave { Name = "ShapeInstance.Height", Type = "float", Value = 80f, SetsValue = true },
+            new VariableSave { Name = "ShapeInstance.IsFilled", Type = "bool", Value = true, SetsValue = true },
+            new VariableSave { Name = "ShapeInstance.CornerRadius", Type = "float", Value = 18f, SetsValue = true },
+            new VariableSave { Name = "ShapeInstance.FillRed", Type = "int", Value = 0, SetsValue = true },
+            new VariableSave { Name = "ShapeInstance.FillGreen", Type = "int", Value = 7, SetsValue = true },
+            new VariableSave { Name = "ShapeInstance.FillBlue", Type = "int", Value = 255, SetsValue = true },
+            new VariableSave { Name = "ShapeInstance.FillAlpha", Type = "int", Value = 255, SetsValue = true });
 
-        SkiaGumSvgExportService service = new SkiaGumSvgExportService();
-        SvgExportResult result = service.ExportSvg(new SvgExportRequest
-        {
-            ProjectPath = projectPath,
-            ElementName = "RectScreen",
-            OutputPath = outputPath,
-        });
-
-        result.Success.ShouldBeTrue(result.ErrorMessage);
-
-        string svg = File.ReadAllText(outputPath);
         bool hasShape = svg.Contains("<rect") || svg.Contains("<path");
         hasShape.ShouldBeTrue(
             $"Expected the exported SVG to contain a rectangle shape element, but it did not.{Environment.NewLine}SVG:{Environment.NewLine}{svg}");
     }
 
+    // Broader guard for the same bug class as #3259 (a shape standard type silently dropped from
+    // SVG export because its runtime was never registered in SkiaGum). These are the v3 default
+    // standard types that self-render a visible outline from nothing but a size — so the exported
+    // SVG must contain a draw element. (The other v3 standards either render nothing by default —
+    // Container — or need content a bare instance lacks: a texture for Sprite/NineSlice, points
+    // for Polygon, a string for Text. Legacy shapes like ColoredRectangle/Arc aren't part of a v3
+    // project, so they have no base element to resolve here.)
+    [Theory]
+    [InlineData("Rectangle")]
+    [InlineData("Circle")]
+    public void ExportSvg_ShapeStandardType_ShouldRenderADrawElement(string baseType)
+    {
+        string svg = ExportScreenWithInstance(
+            baseType,
+            new VariableSave { Name = "ShapeInstance.X", Type = "float", Value = 10f, SetsValue = true },
+            new VariableSave { Name = "ShapeInstance.Y", Type = "float", Value = 10f, SetsValue = true },
+            new VariableSave { Name = "ShapeInstance.Width", Type = "float", Value = 100f, SetsValue = true },
+            new VariableSave { Name = "ShapeInstance.Height", Type = "float", Value = 80f, SetsValue = true });
+
+        bool hasDrawElement = DrawElementTags.Any(svg.Contains);
+        hasDrawElement.ShouldBeTrue(
+            $"Expected the exported SVG for a '{baseType}' instance to contain a draw element, but it did not.{Environment.NewLine}SVG:{Environment.NewLine}{svg}");
+    }
+
     /// <summary>
     /// Builds a v3 project on disk (via <see cref="ProjectCreator"/>, which seeds the standard
-    /// elements including "Rectangle") and adds a Screen containing a single filled, rounded,
-    /// blue Rectangle instance. Returns the .gumx path.
+    /// elements) with a Screen named "Screen" containing a single instance named "ShapeInstance"
+    /// of <paramref name="baseType"/> carrying the given variables, exports it to SVG, asserts the
+    /// export succeeded, and returns the SVG file contents.
     /// </summary>
-    private string CreateProjectWithRectangleScreen(string screenName)
+    private string ExportScreenWithInstance(string baseType, params VariableSave[] instanceVariables)
     {
         string projectPath = Path.Combine(_tempDirectory, "Project.gumx");
 
         ProjectCreator creator = new ProjectCreator();
         GumProjectSave project = creator.Create(projectPath);
 
-        ScreenSave screen = new ScreenSave { Name = screenName };
+        ScreenSave screen = new ScreenSave { Name = "Screen" };
         StateSave defaultState = new StateSave { Name = "Default", ParentContainer = screen };
         screen.States.Add(defaultState);
 
-        InstanceSave rectangle = new InstanceSave
+        InstanceSave instance = new InstanceSave
         {
-            Name = "RectangleInstance",
-            BaseType = "Rectangle",
+            Name = "ShapeInstance",
+            BaseType = baseType,
             ParentContainer = screen,
         };
-        screen.Instances.Add(rectangle);
+        screen.Instances.Add(instance);
 
-        defaultState.Variables.Add(new VariableSave { Name = "RectangleInstance.X", Type = "float", Value = 10f, SetsValue = true });
-        defaultState.Variables.Add(new VariableSave { Name = "RectangleInstance.Y", Type = "float", Value = 10f, SetsValue = true });
-        defaultState.Variables.Add(new VariableSave { Name = "RectangleInstance.Width", Type = "float", Value = 100f, SetsValue = true });
-        defaultState.Variables.Add(new VariableSave { Name = "RectangleInstance.Height", Type = "float", Value = 80f, SetsValue = true });
-        defaultState.Variables.Add(new VariableSave { Name = "RectangleInstance.IsFilled", Type = "bool", Value = true, SetsValue = true });
-        defaultState.Variables.Add(new VariableSave { Name = "RectangleInstance.CornerRadius", Type = "float", Value = 18f, SetsValue = true });
-        defaultState.Variables.Add(new VariableSave { Name = "RectangleInstance.FillRed", Type = "int", Value = 0, SetsValue = true });
-        defaultState.Variables.Add(new VariableSave { Name = "RectangleInstance.FillGreen", Type = "int", Value = 7, SetsValue = true });
-        defaultState.Variables.Add(new VariableSave { Name = "RectangleInstance.FillBlue", Type = "int", Value = 255, SetsValue = true });
-        defaultState.Variables.Add(new VariableSave { Name = "RectangleInstance.FillAlpha", Type = "int", Value = 255, SetsValue = true });
+        foreach (VariableSave variable in instanceVariables)
+        {
+            defaultState.Variables.Add(variable);
+        }
 
         project.Screens.Add(screen);
         project.ScreenReferences.Add(new ElementReference
         {
-            Name = screenName,
+            Name = "Screen",
             ElementType = ElementType.Screen,
         });
 
         project.Save(projectPath, saveElements: true);
 
-        return projectPath;
+        string outputPath = Path.Combine(_tempDirectory, baseType + ".svg");
+        SkiaGumSvgExportService service = new SkiaGumSvgExportService();
+        SvgExportResult result = service.ExportSvg(new SvgExportRequest
+        {
+            ProjectPath = projectPath,
+            ElementName = "Screen",
+            OutputPath = outputPath,
+        });
+
+        result.Success.ShouldBeTrue(result.ErrorMessage);
+
+        return File.ReadAllText(outputPath);
     }
 
     public void Dispose()

--- a/Tests/Gum.ProjectServices.SkiaGum.Tests/SkiaGumSvgExportServiceTests.cs
+++ b/Tests/Gum.ProjectServices.SkiaGum.Tests/SkiaGumSvgExportServiceTests.cs
@@ -52,12 +52,12 @@ public class SkiaGumSvgExportServiceTests : IDisposable
     }
 
     // Broader guard for the same bug class as #3259 (a shape standard type silently dropped from
-    // SVG export because its runtime was never registered in SkiaGum). These are the v3 default
-    // standard types that self-render a visible outline from nothing but a size — so the exported
-    // SVG must contain a draw element. (The other v3 standards either render nothing by default —
-    // Container — or need content a bare instance lacks: a texture for Sprite/NineSlice, points
-    // for Polygon, a string for Text. Legacy shapes like ColoredRectangle/Arc aren't part of a v3
-    // project, so they have no base element to resolve here.)
+    // SVG export because its runtime was never registered in SkiaGum). These are the shape standard
+    // types that ProjectCreator seeds into a v3 project AND that self-render a visible outline from
+    // nothing but a size — so the exported SVG must contain a draw element. (Arc/ColoredCircle/
+    // RoundedRectangle are current shapes too, but not part of a v3 seed — see the Arc test below
+    // for how a project that uses one carries its own standard. Container renders nothing by
+    // default; Sprite/NineSlice/Polygon/Text need content a bare instance lacks.)
     [Theory]
     [InlineData("Rectangle")]
     [InlineData("Circle")]
@@ -75,18 +75,68 @@ public class SkiaGumSvgExportServiceTests : IDisposable
             $"Expected the exported SVG for a '{baseType}' instance to contain a draw element, but it did not.{Environment.NewLine}SVG:{Environment.NewLine}{svg}");
     }
 
+    // Arc is a current shapes-library standard type (NOT deprecated — only ColoredRectangle is, per
+    // StandardElementsManager._deprecatedStandardTypeNames). Unlike Rectangle/Circle it is not part
+    // of ProjectCreator's v3 seed, so a project that uses an Arc ships its own Arc standard element.
+    // Seed one with GetArcState's real defaults (Thickness 10, StartAngle 0, SweepAngle 90) and
+    // confirm the Arc renders through SkiaGum's SVG export — i.e. its runtime is registered like
+    // Rectangle's now is. (A bare Arc instance with no seeded standard exports nothing, but that is
+    // a missing-base-element fixture condition, not a render gap.)
+    [Fact]
+    public void ExportSvg_ArcInstance_WithSeededStandard_ShouldRenderADrawElement()
+    {
+        StandardElementSave arcStandard = new StandardElementSave { Name = "Arc" };
+        StateSave arcState = new StateSave { Name = "Default", ParentContainer = arcStandard };
+        arcStandard.States.Add(arcState);
+        arcState.Variables.Add(new VariableSave { Name = "Thickness", Type = "float", Value = 10f, SetsValue = true });
+        arcState.Variables.Add(new VariableSave { Name = "StartAngle", Type = "float", Value = 0f, SetsValue = true });
+        arcState.Variables.Add(new VariableSave { Name = "SweepAngle", Type = "float", Value = 90f, SetsValue = true });
+
+        string svg = ExportScreenWithInstance(
+            "Arc",
+            new[] { arcStandard },
+            new VariableSave { Name = "ShapeInstance.X", Type = "float", Value = 10f, SetsValue = true },
+            new VariableSave { Name = "ShapeInstance.Y", Type = "float", Value = 10f, SetsValue = true },
+            new VariableSave { Name = "ShapeInstance.Width", Type = "float", Value = 100f, SetsValue = true },
+            new VariableSave { Name = "ShapeInstance.Height", Type = "float", Value = 80f, SetsValue = true });
+
+        bool hasDrawElement = DrawElementTags.Any(svg.Contains);
+        hasDrawElement.ShouldBeTrue(
+            $"Expected the exported SVG for an Arc instance to contain a draw element, but it did not.{Environment.NewLine}SVG:{Environment.NewLine}{svg}");
+    }
+
+    private string ExportScreenWithInstance(string baseType, params VariableSave[] instanceVariables) =>
+        ExportScreenWithInstance(baseType, standardsToSeed: null, instanceVariables);
+
     /// <summary>
     /// Builds a v3 project on disk (via <see cref="ProjectCreator"/>, which seeds the standard
-    /// elements) with a Screen named "Screen" containing a single instance named "ShapeInstance"
-    /// of <paramref name="baseType"/> carrying the given variables, exports it to SVG, asserts the
-    /// export succeeded, and returns the SVG file contents.
+    /// elements) plus any extra <paramref name="standardsToSeed"/>, with a Screen named "Screen"
+    /// containing a single instance named "ShapeInstance" of <paramref name="baseType"/> carrying
+    /// the given variables, exports it to SVG, asserts the export succeeded, and returns the SVG
+    /// file contents.
     /// </summary>
-    private string ExportScreenWithInstance(string baseType, params VariableSave[] instanceVariables)
+    private string ExportScreenWithInstance(
+        string baseType,
+        IEnumerable<StandardElementSave>? standardsToSeed,
+        params VariableSave[] instanceVariables)
     {
         string projectPath = Path.Combine(_tempDirectory, "Project.gumx");
 
         ProjectCreator creator = new ProjectCreator();
         GumProjectSave project = creator.Create(projectPath);
+
+        if (standardsToSeed != null)
+        {
+            foreach (StandardElementSave standard in standardsToSeed)
+            {
+                project.StandardElements.Add(standard);
+                project.StandardElementReferences.Add(new ElementReference
+                {
+                    Name = standard.Name,
+                    ElementType = ElementType.Standard,
+                });
+            }
+        }
 
         ScreenSave screen = new ScreenSave { Name = "Screen" };
         StateSave defaultState = new StateSave { Name = "Default", ParentContainer = screen };

--- a/Tests/Gum.ProjectServices.SkiaGum.Tests/SkiaGumSvgExportServiceTests.cs
+++ b/Tests/Gum.ProjectServices.SkiaGum.Tests/SkiaGumSvgExportServiceTests.cs
@@ -1,0 +1,103 @@
+using Gum.DataTypes;
+using Gum.DataTypes.Variables;
+using Gum.ProjectServices;
+using Gum.ProjectServices.SvgExport;
+using Shouldly;
+
+namespace Gum.ProjectServices.SkiaGum.Tests;
+
+/// <summary>
+/// Tests for <see cref="SkiaGumSvgExportService"/>, the SkiaGum-backed implementation of
+/// <see cref="ISvgExportService"/> that <c>gumcli svg</c> and the tool's File ▸ Export use.
+/// </summary>
+public class SkiaGumSvgExportServiceTests : IDisposable
+{
+    private readonly string _tempDirectory;
+
+    public SkiaGumSvgExportServiceTests()
+    {
+        _tempDirectory = Path.Combine(
+            Path.GetTempPath(), "GumSvgExportTests_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDirectory);
+    }
+
+    // Regression test for issue #3259: a Rectangle (filled rounded rectangle) instance was
+    // dropped entirely from the exported SVG because SkiaGum never registered a runtime for
+    // the "Rectangle" standard base type, so no renderable was created to draw.
+    [Fact]
+    public void ExportSvg_FilledRectangleScreen_ShouldContainShapeElement()
+    {
+        string projectPath = CreateProjectWithRectangleScreen("RectScreen");
+        string outputPath = Path.Combine(_tempDirectory, "rect.svg");
+
+        SkiaGumSvgExportService service = new SkiaGumSvgExportService();
+        SvgExportResult result = service.ExportSvg(new SvgExportRequest
+        {
+            ProjectPath = projectPath,
+            ElementName = "RectScreen",
+            OutputPath = outputPath,
+        });
+
+        result.Success.ShouldBeTrue(result.ErrorMessage);
+
+        string svg = File.ReadAllText(outputPath);
+        bool hasShape = svg.Contains("<rect") || svg.Contains("<path");
+        hasShape.ShouldBeTrue(
+            $"Expected the exported SVG to contain a rectangle shape element, but it did not.{Environment.NewLine}SVG:{Environment.NewLine}{svg}");
+    }
+
+    /// <summary>
+    /// Builds a v3 project on disk (via <see cref="ProjectCreator"/>, which seeds the standard
+    /// elements including "Rectangle") and adds a Screen containing a single filled, rounded,
+    /// blue Rectangle instance. Returns the .gumx path.
+    /// </summary>
+    private string CreateProjectWithRectangleScreen(string screenName)
+    {
+        string projectPath = Path.Combine(_tempDirectory, "Project.gumx");
+
+        ProjectCreator creator = new ProjectCreator();
+        GumProjectSave project = creator.Create(projectPath);
+
+        ScreenSave screen = new ScreenSave { Name = screenName };
+        StateSave defaultState = new StateSave { Name = "Default", ParentContainer = screen };
+        screen.States.Add(defaultState);
+
+        InstanceSave rectangle = new InstanceSave
+        {
+            Name = "RectangleInstance",
+            BaseType = "Rectangle",
+            ParentContainer = screen,
+        };
+        screen.Instances.Add(rectangle);
+
+        defaultState.Variables.Add(new VariableSave { Name = "RectangleInstance.X", Type = "float", Value = 10f, SetsValue = true });
+        defaultState.Variables.Add(new VariableSave { Name = "RectangleInstance.Y", Type = "float", Value = 10f, SetsValue = true });
+        defaultState.Variables.Add(new VariableSave { Name = "RectangleInstance.Width", Type = "float", Value = 100f, SetsValue = true });
+        defaultState.Variables.Add(new VariableSave { Name = "RectangleInstance.Height", Type = "float", Value = 80f, SetsValue = true });
+        defaultState.Variables.Add(new VariableSave { Name = "RectangleInstance.IsFilled", Type = "bool", Value = true, SetsValue = true });
+        defaultState.Variables.Add(new VariableSave { Name = "RectangleInstance.CornerRadius", Type = "float", Value = 18f, SetsValue = true });
+        defaultState.Variables.Add(new VariableSave { Name = "RectangleInstance.FillRed", Type = "int", Value = 0, SetsValue = true });
+        defaultState.Variables.Add(new VariableSave { Name = "RectangleInstance.FillGreen", Type = "int", Value = 7, SetsValue = true });
+        defaultState.Variables.Add(new VariableSave { Name = "RectangleInstance.FillBlue", Type = "int", Value = 255, SetsValue = true });
+        defaultState.Variables.Add(new VariableSave { Name = "RectangleInstance.FillAlpha", Type = "int", Value = 255, SetsValue = true });
+
+        project.Screens.Add(screen);
+        project.ScreenReferences.Add(new ElementReference
+        {
+            Name = screenName,
+            ElementType = ElementType.Screen,
+        });
+
+        project.Save(projectPath, saveElements: true);
+
+        return projectPath;
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDirectory))
+        {
+            Directory.Delete(_tempDirectory, recursive: true);
+        }
+    }
+}

--- a/Tests/Gum.ProjectServices.SkiaGum.Tests/TestAssemblyInitialize.cs
+++ b/Tests/Gum.ProjectServices.SkiaGum.Tests/TestAssemblyInitialize.cs
@@ -1,0 +1,4 @@
+// SkiaGum's SVG export drives process-wide statics (ObjectFinder.Self,
+// SystemManagers.Default, GumService.Default). Disable parallel execution so
+// concurrent export tests don't stomp on that shared state.
+[assembly: CollectionBehavior(DisableTestParallelization = true)]


### PR DESCRIPTION
Closes #3259.

## Problem

Exporting a Screen to SVG (File ▸ Export, which shells out to `gumcli svg` → `SkiaGumSvgExportService`) silently dropped any **Rectangle** (v3 filled/rounded rectangle) instance. Only `Text` and other registered types drew; a `Rectangle`-only screen produced an empty `<svg/>`.

## Root cause

SkiaGum builds its visual tree from two registries:

1. `RegisterGueInstantiation(name, …)` — the **primary** path, which maps a base-type name to a runtime wrapper that installs its own renderable.
2. `CustomCreateGraphicalComponentFunc` — a fallback that creates a raw renderable when the primary path produced none.

In `Runtimes/SkiaGum/RenderingLibrary/SystemManagers.cs`, the `"Rectangle" → RectangleRuntime` registration was **commented out**, and the SkiaGum fallback switch has no `"Rectangle"` case. So a `Rectangle` base type resolved to a generic `GraphicalUiElement` with a **null renderable** — nothing to draw. The sibling `"Circle" → CircleRuntime` was registered, which is why circles/text worked but rectangles didn't. The XNALIKE and raylib backends register `"Rectangle"` in their own `SystemManagers`, so the editor (KNI) and MonoGame/raylib runtimes rendered it fine — the gap was SkiaGum-only.

## Fix

Register `"Rectangle" → RectangleRuntime` in SkiaGum's `RegisterComponentRuntimeInstantiations()`. `RectangleRuntime`'s `#if SKIA` build already wraps a `RoundedRectangle` fill+stroke pair (#2814/#2818) and is already file-linked into `SkiaGum.csproj`, so **no renderable changes were needed** — the runtime just needed to be registered. This follows the architecture's guidance (new base types go through `RegisterGueInstantiation`, not the fallback switch).

## Tests

The issue asked for SVG export to be TDD'ed. Added **`Tests/Gum.ProjectServices.SkiaGum.Tests`**, a dedicated headless project that drives the real `SkiaGumSvgExportService` end-to-end (build a project via `ProjectCreator` → export to SVG → assert on the output). It contains:

- **`ExportSvg_FilledRectangleScreen_ShouldContainShapeElement`** — the #3259 regression. A Screen with one filled, rounded, blue `Rectangle`. **Red before the fix** (export succeeds but the SVG is `<svg … />` with no `<rect>`/`<path>` — exactly the reported bug), **green after**.
- **`ExportSvg_ShapeStandardType_ShouldRenderADrawElement`** (Theory: `Rectangle`, `Circle`) — broader guard for the same bug class across the v3 default shape standards that self-render from just a size. `Circle` is the close sibling two-slot runtime that could regress independently, so this protects it too.
- **`ExportSvg_ArcInstance_WithSeededStandard_ShouldRenderADrawElement`** — `Arc` coverage (see note below).

The project is dedicated (rather than folded into `SkiaGum.Tests`) to keep the runtime-test/project-services layering clean and to isolate SkiaGum's process-wide global init. It's wired into `AllLibraries.sln` and added as a blocking Bucket-A CI step (CPU-only `SKSvgCanvas`, fully headless like `SkiaGum.Tests`), and recorded in the `gum-unit-tests` skill inventory.

### Note on Arc and the other shape standards

While extending coverage I checked the other shape standard types. `Arc`, `ColoredCircle`, and `RoundedRectangle` are **current** types (only `ColoredRectangle` is deprecated, per `StandardElementsManager._deprecatedStandardTypeNames`). They aren't part of `ProjectCreator`'s v3 seed, so a *bare* instance of one exports nothing **only** because the fixture project has no matching standard element to resolve the base type — not because of a render gap. Verified that once the project carries the standard (as any real project that uses an `Arc` does), SkiaGum SVG export renders it correctly; the `Arc` test seeds the standard with `GetArcState`'s real defaults to prove it. So the only actual export bug was `Rectangle`'s missing registration, fixed above.

## Verification

- All export tests: red → green for the #3259 case; the breadth + `Arc` tests green.
- `SkiaGum.Tests`: 189/189 pass (no regressions).
- Manual end-to-end via the real CLI: `gumcli svg` on `MonoGameGumFromFile`'s `StartScreen` now emits the `Rectangle` instance as a stroked `<rect>` at its configured position/size, alongside the filled colored rectangles — before the fix those `Rectangle`-base-type instances were absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
