### PR TITLE
Phase 1: migrate ImportFromGumx Browse button to IDialogService (#3263)

### DIFF
--- a/Gum/ImportFromGumxPlugin/ViewModels/ImportFromGumxViewModel.cs
+++ b/Gum/ImportFromGumxPlugin/ViewModels/ImportFromGumxViewModel.cs
@@ -158,6 +158,13 @@ public class ImportFromGumxViewModel : DialogViewModel
     /// </summary>
     public RelayCommand<ImportTreeNodeViewModel> ShowStandardDiffCommand { get; }
 
+    /// <summary>
+    /// Prompts the user (via <see cref="IDialogService"/>) for a source <c>.gumx</c> file, then
+    /// sets <see cref="SourcePath"/> and loads its preview. Bound to the "Browse..." button;
+    /// a no-op if the user cancels the picker.
+    /// </summary>
+    public AsyncRelayCommand BrowseCommand { get; }
+
     public ImportFromGumxViewModel(
         GumxSourceService sourceService,
         GumxDependencyResolver dependencyResolver,
@@ -176,6 +183,7 @@ public class ImportFromGumxViewModel : DialogViewModel
 
         LoadPreviewCommand = new AsyncRelayCommand(ExecuteLoadPreviewAsync, CanExecuteLoadPreview);
         ShowStandardDiffCommand = new RelayCommand<ImportTreeNodeViewModel>(ExecuteShowStandardDiff);
+        BrowseCommand = new AsyncRelayCommand(ExecuteBrowseAsync);
     }
 
     private void ExecuteShowStandardDiff(ImportTreeNodeViewModel? row)
@@ -185,6 +193,24 @@ public class ImportFromGumxViewModel : DialogViewModel
         StandardDiffDetailsViewModel detailsVm =
             new StandardDiffDetailsViewModel(row.DisplayName, row.StandardDiffRows);
         _dialogService.Show(detailsVm);
+    }
+
+    private async Task ExecuteBrowseAsync()
+    {
+        List<string>? selectedFiles = _dialogService.OpenFile(new OpenFileDialogOptions
+        {
+            Title = "Open Gum Project",
+            Filter = "Gum Project Files (*.gumx)|*.gumx|All Files (*.*)|*.*"
+        });
+
+        string? selectedPath = selectedFiles?.FirstOrDefault();
+        if (string.IsNullOrEmpty(selectedPath)) { return; }
+
+        SourcePath = selectedPath;
+        if (LoadPreviewCommand.CanExecute(null))
+        {
+            await LoadPreviewCommand.ExecuteAsync(null);
+        }
     }
 
     public override bool CanExecuteAffirmative() => IsPreviewLoaded && !IsLoading;

--- a/Gum/ImportFromGumxPlugin/Views/ImportFromGumxView.xaml
+++ b/Gum/ImportFromGumxPlugin/Views/ImportFromGumxView.xaml
@@ -47,11 +47,10 @@
                     VerticalContentAlignment="Center" />
 
                 <Button
-                    x:Name="BrowseButton"
                     Grid.Column="1"
                     Content="Browse..."
                     Padding="8,2"
-                    Click="OnBrowseClick"
+                    Command="{Binding BrowseCommand}"
                     Visibility="{Binding BrowseButtonVisibility}" />
             </Grid>
 

--- a/Gum/ImportFromGumxPlugin/Views/ImportFromGumxView.xaml.cs
+++ b/Gum/ImportFromGumxPlugin/Views/ImportFromGumxView.xaml.cs
@@ -1,6 +1,5 @@
 using Gum.Services.Dialogs;
 using ImportFromGumxPlugin.ViewModels;
-using Microsoft.Win32;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
@@ -16,24 +15,6 @@ public partial class ImportFromGumxView : UserControl
     public ImportFromGumxView()
     {
         InitializeComponent();
-    }
-
-    private async void OnBrowseClick(object sender, RoutedEventArgs e)
-    {
-        var dialog = new OpenFileDialog
-        {
-            Filter = "Gum Project Files (*.gumx)|*.gumx|All Files (*.*)|*.*",
-            Title = "Open Gum Project"
-        };
-
-        if (dialog.ShowDialog() == true && DataContext is ImportFromGumxViewModel vm)
-        {
-            vm.SourcePath = dialog.FileName;
-            if (vm.LoadPreviewCommand.CanExecute(null))
-            {
-                await vm.LoadPreviewCommand.ExecuteAsync(null);
-            }
-        }
     }
 
     private async void OnSourcePathKeyDown(object sender, KeyEventArgs e)

--- a/Tool/Tests/GumToolUnitTests/Plugins/ImportFromGumxPlugin/ImportFromGumxViewModelTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/ImportFromGumxPlugin/ImportFromGumxViewModelTests.cs
@@ -275,6 +275,43 @@ public class ImportFromGumxViewModelTests
         textStandardLeaf.StandardDiffRows.ShouldBeNull();
     }
 
+    // ── browse command (#3263) ────────────────────────────────────────────
+
+    [Fact]
+    public async Task BrowseCommand_Cancelled_LeavesSourcePathUnchangedAndDoesNotLoad()
+    {
+        _dialogService.OpenFileStub = _ => null;
+
+        await _sut.BrowseCommand.ExecuteAsync(null);
+
+        _dialogService.OpenFileCallCount.ShouldBe(1);
+        _sut.SourcePath.ShouldBeEmpty();
+        _sut.ErrorMessage.ShouldBeNull();
+        _sut.IsPreviewLoaded.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task BrowseCommand_FileChosen_SetsSourcePathAndAttemptsLoad()
+    {
+        // A path the user "picks" that is guaranteed not to exist, so the chained load
+        // deterministically fails (no real .gumx required).
+        string chosenPath = Path.Combine(
+            Path.GetTempPath(), "GumImportBrowseTest_" + Guid.NewGuid().ToString("N") + ".gumx");
+        _dialogService.OpenFileStub = _ => new List<string> { chosenPath };
+
+        await _sut.BrowseCommand.ExecuteAsync(null);
+
+        _dialogService.OpenFileCallCount.ShouldBe(1);
+        _dialogService.LastOpenFileOptions.ShouldNotBeNull();
+        _dialogService.LastOpenFileOptions!.Title.ShouldBe("Open Gum Project");
+        _dialogService.LastOpenFileOptions.Filter.ShouldContain("*.gumx");
+
+        _sut.SourcePath.ShouldBe(chosenPath);
+        // The browse flow chains into LoadPreviewCommand; the chosen file does not exist,
+        // so the load surfaces an error — proof the load was attempted, not skipped.
+        _sut.ErrorMessage.ShouldNotBeNullOrEmpty();
+    }
+
     // ── conflict-resolution dialog (#2644) ────────────────────────────────
 
     [Fact]
@@ -357,6 +394,10 @@ public class ImportFromGumxViewModelTests
         public ChoiceDialogViewModel? LastChoiceDialog { get; private set; }
         public int ShowChoiceCallCount { get; private set; }
 
+        public Func<OpenFileDialogOptions?, List<string>?>? OpenFileStub { get; set; }
+        public OpenFileDialogOptions? LastOpenFileOptions { get; private set; }
+        public int OpenFileCallCount { get; private set; }
+
         public MessageDialogResult ShowMessage(string message, string? title = null, MessageDialogStyle? style = null)
             => MessageDialogResult.Canceled;
         public bool Show<T>(T dialogViewModel) where T : DialogViewModel => false;
@@ -377,7 +418,12 @@ public class ImportFromGumxViewModelTests
             return false;
         }
         public string? GetUserString(string message, string? title = null, GetUserStringOptions? options = null) => null;
-        public List<string>? OpenFile(OpenFileDialogOptions? options = null) => null;
+        public List<string>? OpenFile(OpenFileDialogOptions? options = null)
+        {
+            LastOpenFileOptions = options;
+            OpenFileCallCount++;
+            return OpenFileStub?.Invoke(options);
+        }
         public string? SaveFile(SaveFileDialogOptions? options = null) => null;
     }
 


### PR DESCRIPTION
Part of the Phase 1 UI / logic decoupling effort (#3225) — "move the inline dialogs behind `IDialogService`".

## What

The **Import from .gumx** dialog's "Browse..." button opened a `Microsoft.Win32.OpenFileDialog` directly in the **view code-behind** (`ImportFromGumxView.xaml.cs` `OnBrowseClick`), then set `vm.SourcePath` and ran the preview load. That orchestration lived in the view, so it couldn't be unit-tested.

This migrates the orchestration into a testable `BrowseCommand` (`AsyncRelayCommand`) on `ImportFromGumxViewModel`:

- Calls `_dialogService.OpenFile(...)` with the `*.gumx` filter / "Open Gum Project" title.
- Takes the first returned path; no-op if the user cancels (null/empty).
- Sets `SourcePath` and awaits `LoadPreviewCommand` when executable.

This is idiomatic — the VM already calls `_dialogService.Show(...)` / `ShowChoices(...)`.

The XAML `Click="OnBrowseClick"` becomes `Command="{Binding BrowseCommand}"`; `OnBrowseClick` and the now-unused `using Microsoft.Win32;` are deleted from the code-behind (plus the dead `x:Name="BrowseButton"`, referenced nowhere).

**This was the last live inline file-dialog site in the tool** (the `ElementTreeViewManager` one was dead code, deleted in #3261; `ProjectManager` / `SvgExportPlugin` migrated in #3253 / #3256).

## Tests

Two new tests, extending the existing `FakeDialogService` with an `OpenFile` stub hook (mirrors `ChoiceDialogStub`):

- `BrowseCommand_FileChosen_SetsSourcePathAndAttemptsLoad` — verifies the dialog options (title + `*.gumx` filter), that `SourcePath` is set to the chosen path, and that the chained load was attempted.
- `BrowseCommand_Cancelled_LeavesSourcePathUnchangedAndDoesNotLoad` — cancel is a no-op.

Full `GumToolUnitTests` suite green (911 passed / 0 failed / 4 pre-existing skips), 0 new warnings.

## Out of scope (later phases)

- The VM's five `System.Windows.Visibility` properties (ADR-0004 violations) belong to the Phase 3 bulk VM neutral-type sweep.
- `MainImportFromGumxPlugin`'s hand-built `DialogWindow` + `ShowDialog()` is WPF polish (custom sizing), not a WinForms/Phase-1 issue.

## Manual test

**Needed** (it's a dialog). Launch the Gum tool, open a project, **Content → Import from .gumx...**, click **Browse...**, pick a `.gumx`, and confirm the file path populates and its preview tree loads — same as before, now driven by the VM command.

Closes #3263

🤖 Generated with [Claude Code](https://claude.com/claude-code)
