### PR TITLE
Fix #2955: energy-preservation falloff for extreme dropshadow blur

### DIFF
--- a/Runtimes/GumShapes/Renderables/RenderableShapeBase.cs
+++ b/Runtimes/GumShapes/Renderables/RenderableShapeBase.cs
@@ -531,10 +531,16 @@ public abstract class RenderableShapeBase : RenderableBase, Gum.GueDeriving.IBle
     /// the 50% line drift far past R (giving the "way too big" shadow that #2950 reports).
     /// In that case the helper truncates the inner ramp at <c>rDisk = 0</c>, widens aaSize
     /// to <c>R + B/2</c> so the outer edge still sits where the desired curve says, and
-    /// returns an <paramref name="alphaScale"/> &lt; 1 so the (clamped) smoothstep still
-    /// passes through both anchors (R, 0.5) and (R + B/2, 0). The cost is that the center
+    /// returns an <c>alphaScale</c> &lt; 1. The cost is that the center
     /// of the shadow is no longer 100% opaque — which is *correct*: a circle whose blur
     /// extends beyond its diameter genuinely should not have a solid black center.
+    /// </para>
+    /// <para>
+    /// Issue #2955 — that <c>alphaScale</c> also carries an energy-preservation factor
+    /// <c>(2R/B)²</c> for the <c>B &gt; 2R</c> case. Without it the anchored curve saturates the
+    /// center at ~0.5 as blur grows (a screen-filling 50% gray); the factor instead lets the
+    /// shadow fade toward a faint glow the way a true Gaussian (CSS box-shadow / Skia) does. It is
+    /// exactly 1 at <c>B = 2R</c>, so the moderate-blur branch is unaffected and continuous.
     /// </para>
     /// <para>
     /// <paramref name="cameraZoom"/> is folded into <c>effectiveAaSize</c> (which is returned
@@ -561,11 +567,21 @@ public abstract class RenderableShapeBase : RenderableBase, Gum.GueDeriving.IBle
         }
         // blur > 2R: truncate inner edge to rDisk = 0, widen aaSize to R + B/2, and scale
         // base alpha so smoothstep(0,1, R/(R + B/2)) lands the curve at α = 0.5 at r = R.
-        // alphaScale = 0.5 / (1 - smoothstep(R / aaSizeWorld)).
+        // anchorAlpha = 0.5 / (1 - smoothstep(R / aaSizeWorld)).
         float aaSizeWorld = hostRadius + blur * 0.5f;
         float t = hostRadius / aaSizeWorld;
         float smoothstep = 3f * t * t - 2f * t * t * t;
-        float alphaScale = 0.5f / (1f - smoothstep);
+        float anchorAlpha = 0.5f / (1f - smoothstep);
+        // Issue #2955 — energy preservation. anchorAlpha alone saturates the center at 0.5 as
+        // B → ∞ (a screen-filling 50% gray); a true Gaussian instead spreads the disk's fixed
+        // area-mass over an ever-larger region, so peak alpha falls as ~(2R/B)². Fold that factor
+        // in so the shadow fades toward a faint glow as blur outgrows the diameter, matching
+        // CSS box-shadow / Skia. The factor is exactly 1 at B = 2R (this branch's lower bound),
+        // so it leaves the moderate-blur curve untouched and is continuous across the boundary;
+        // for blur > 2R it is strictly < 1, so no min() clamp is needed.
+        float energyScale = 2f * hostRadius / blur;
+        energyScale *= energyScale;
+        float alphaScale = anchorAlpha * energyScale;
         return (
             0f,
             MathFunctions.RoundToInt(aaSizeWorld * cameraZoom),

--- a/Tests/MonoGameGum.Shapes.Tests/CircleRenderableTests.cs
+++ b/Tests/MonoGameGum.Shapes.Tests/CircleRenderableTests.cs
@@ -294,8 +294,13 @@ public class CircleRenderableTests
     // So the 50% line sits exactly at the host radius R (matching CSS box-shadow / Figma /
     // Photoshop). When B > 2R the inner ramp edge would be negative; Apos.Shapes clamps such
     // a radius to 0, sliding the entire ramp outward. The helper truncates the inner ramp at
-    // rDisk = 0, widens aaSize so the outer edge still sits at R + B/2, and reduces base
-    // alpha so the (still-smoothstep) curve passes through (R, 0.5) and (R + B/2, 0).
+    // rDisk = 0 and widens aaSize so the outer edge still sits at R + B/2.
+    //
+    // Issue #2955 — for B > 2R the helper also multiplies in an energy-preservation factor
+    // (2R/B)^2 so the shadow fades toward a faint glow as blur outgrows the diameter, the way a
+    // true Gaussian (which spreads fixed disk-area mass over a growing region) does — instead of
+    // saturating the center at ~0.5 (screen-filling gray). The factor is exactly 1 at B = 2R, so
+    // it changes nothing for B <= 2R and is continuous across the boundary.
     //
     // Apos's AA falloff is `3t^2 - 2t^3` (smoothstep), confirmed empirically. Because
     // smoothstep is symmetric (smoothstep(0.5) = 0.5), the standard case math is identical
@@ -341,20 +346,43 @@ public class CircleRenderableTests
     }
 
     [Fact]
-    public void ComputeShadowDrawGeometry_BlurGreaterThanTwoRadius_TruncatesAndScalesAlpha()
+    public void ComputeShadowDrawGeometry_BlurGreaterThanTwoRadius_TruncatesAndAppliesEnergyFalloff()
     {
         // User's repro: R = 36, B = 250. Expected from the math:
         //   aaSize_world = R + B/2 = 161
         //   t = R / aaSize = 36 / 161 = 0.2236
         //   smoothstep = 3t^2 - 2t^3 = 0.1276
-        //   alphaScale = 0.5 / (1 - 0.1276) = 0.5731
+        //   anchorAlpha = 0.5 / (1 - 0.1276) = 0.5731
+        //   energyScale = (2R/B)^2 = (72/250)^2 = 0.08294   (issue #2955)
+        //   alphaScale = anchorAlpha * energyScale = 0.04754
+        // 0.04754 lands right on the true-Gaussian center alpha (2R^2/B^2 ~= 0.041) instead of
+        // the old screen-filling ~0.5731. effRadius/effAaSize (the geometry) are unchanged.
         Circle sut = new() { DropshadowBlurX = 250f };
 
         (float effRadius, int effAaSize, float alphaScale) = sut.ComputeShadowDrawGeometry(hostRadius: 36f, cameraZoom: 1f);
 
         effRadius.ShouldBe(0f);
         effAaSize.ShouldBe(161);
-        alphaScale.ShouldBe(0.5731f, tolerance: 0.001f);
+        alphaScale.ShouldBe(0.04754f, tolerance: 0.001f);
+    }
+
+    [Fact]
+    public void ComputeShadowDrawGeometry_ExtremeBlur_AlphaFadesTowardZeroNotHalf()
+    {
+        // Issue #2955 regression guard. Without the energy-preservation factor the strict-anchor
+        // alphaScale saturates at ~0.5 as B -> infinity (a screen-filling 50% gray). With it, the
+        // shadow keeps fading: a larger blur must yield a strictly smaller alphaScale, and at
+        // extreme blur it must be nowhere near the old 0.5 floor.
+        Circle sut = new();
+
+        sut.DropshadowBlurX = 250f;
+        float alphaAt250 = sut.ComputeShadowDrawGeometry(hostRadius: 36f, cameraZoom: 1f).alphaScale;
+
+        sut.DropshadowBlurX = 1000f;
+        float alphaAt1000 = sut.ComputeShadowDrawGeometry(hostRadius: 36f, cameraZoom: 1f).alphaScale;
+
+        alphaAt1000.ShouldBeLessThan(alphaAt250);
+        alphaAt1000.ShouldBeLessThan(0.05f);
     }
 
     [Fact]


### PR DESCRIPTION
Closes #2955.

## What

Adds the energy-preservation alpha falloff (option 2 from the issue) so dropshadows with `blur > 2 × radius` fade toward a faint glow instead of saturating to a screen-filling 50% gray.

The strict-anchor model from PR #2951 pinned peak alpha toward ~0.5 as blur grew without bound. A true Gaussian (CSS `box-shadow` / Skia's `SKImageFilter.CreateDropShadow`, which is what the Gum tool renders with) instead spreads the disk's fixed area-mass over an ever-larger region, so peak alpha falls. This folds the `(2R/B)²` energy term into the `alphaScale` returned by `ComputeShadowDrawGeometry` for the `blur > 2R` branch.

For the issue's repro (R=36, B=250): center alpha drops from **~0.573** (RGB ~109 on white) to **~0.0475** (RGB ~243), landing right on the true-Gaussian target `2R²/B² ≈ 0.041`.

## Why it's safe

- The factor is **exactly 1 at B = 2R** (the branch's lower bound), so the moderate-blur curve — all real-world UI — is untouched and continuous across the boundary. For `blur > 2R` it is strictly `< 1`, so no `min()` clamp is needed.
- The fix lives in the shared helper, so it covers **both `Circle` and `RoundedRectangle`** (both consume its `alphaScale`). `Arc` doesn't use the strict-anchor model yet and will inherit the fix when it adopts it. (This corrects the issue's "Scope" note, which predates `RoundedRectangle` adopting the helper — it said only `Circle` had it.)

## Breaking change

As the issue flags: any project relying on the old "screen-filling at huge blur" look will render differently. Nobody hits `blur > 2R` in real UI, so the practical blast radius is nil.

## Tests

- Updated `ComputeShadowDrawGeometry_BlurGreaterThanTwoRadius_*` to pin the energy-preserved value (~0.0475).
- Added `ComputeShadowDrawGeometry_ExtremeBlur_AlphaFadesTowardZeroNotHalf` as a regression guard against the old 0.5 saturation (a larger blur must yield a strictly smaller alpha, far below 0.5).
- Full `MonoGameGum.Shapes.Tests` suite green (205/205). Both new assertions were confirmed red before the fix.

## Boyscout

Fixed a stale `CS1734` `paramref` warning in the same method's doc comment (`alphaScale` is a tuple return element, not a parameter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
