### PR TITLE
Phase 1: introduce GumKey enum; retype KeyCombination.Key off WinForms (PR A)

### DIFF
--- a/Gum/Input/GumKey.cs
+++ b/Gum/Input/GumKey.cs
@@ -1,0 +1,38 @@
+namespace Gum.Input;
+
+/// <summary>
+/// Gum's framework-neutral keyboard key identity, used by <see cref="Gum.Managers.KeyCombination"/>
+/// to describe hotkey bindings without referencing WinForms, WPF, or any rendering framework.
+/// </summary>
+/// <remarks>
+/// Each member's integer value is defined equal to its Win32 virtual-key code — the same integers
+/// WinForms <c>System.Windows.Forms.Keys</c> and XNA <c>Microsoft.Xna.Framework.Input.Keys</c> use —
+/// so converting to a framework key type is a pure cast. This invariant is pinned by
+/// <c>GumKeyTests.GumKey_Values_MatchWinFormsVirtualKeyCodes</c>; if a value ever drifts from the
+/// VK code, that test fails. Add members here as Gum binds new keys.
+/// </remarks>
+public enum GumKey
+{
+    Delete = 0x2E,
+
+    Left = 0x25,
+    Up = 0x26,
+    Right = 0x27,
+    Down = 0x28,
+
+    C = 0x43,
+    F = 0x46,
+    V = 0x56,
+    X = 0x58,
+    Y = 0x59,
+    Z = 0x5A,
+
+    Add = 0x6B,
+    Subtract = 0x6D,
+
+    F2 = 0x71,
+    F12 = 0x7B,
+
+    Oemplus = 0xBB,
+    OemMinus = 0xBD,
+}

--- a/Gum/Managers/HotkeyManager.cs
+++ b/Gum/Managers/HotkeyManager.cs
@@ -2,6 +2,7 @@ using Gum.Commands;
 using Gum.Controls;
 using Gum.DataTypes;
 using Gum.Dialogs;
+using Gum.Input;
 using Gum.Logic;
 using Gum.Plugins;
 using Gum.PropertyGridHelpers;
@@ -24,16 +25,19 @@ namespace Gum.Managers;
 #region KeyCombination Class
 public class KeyCombination
 {
-    public Keys? Key { get; set; }
+    public GumKey? Key { get; set; }
     public bool IsCtrlDown { get; set; }
     public bool IsShiftDown { get; set; }
     public bool IsAltDown { get; set; }
 
-    public static KeyCombination Pressed(Keys key) => new KeyCombination { Key = key };
-    public static KeyCombination Ctrl(Keys key) => new KeyCombination { Key = key, IsCtrlDown = true };
-    public static KeyCombination Alt(Keys? key = null) => new KeyCombination { Key = key, IsAltDown = true };
-    public static KeyCombination Shift(Keys? key = null) => new KeyCombination { Key = key, IsShiftDown = true };
+    public static KeyCombination Pressed(GumKey key) => new KeyCombination { Key = key };
+    public static KeyCombination Ctrl(GumKey key) => new KeyCombination { Key = key, IsCtrlDown = true };
+    public static KeyCombination Alt(GumKey? key = null) => new KeyCombination { Key = key, IsAltDown = true };
+    public static KeyCombination Shift(GumKey? key = null) => new KeyCombination { Key = key, IsShiftDown = true };
 
+    // GumKey values are defined equal to Win32 virtual-key codes (pinned by GumKeyTests),
+    // so converting the bound key to the WinForms Keys enum is a pure cast.
+    private Keys ToWinFormsKey(GumKey key) => (Keys)(int)key;
 
     public bool IsPressed(KeyEventArgs args)
     {
@@ -41,7 +45,7 @@ public class KeyCombination
         if (IsShiftDown && (args.Modifiers & Keys.Shift) != Keys.Shift) return false;
         if (IsAltDown && (args.Modifiers & Keys.Alt) != Keys.Alt) return false;
 
-        return Key == null || args.KeyCode == Key;
+        return Key == null || args.KeyCode == ToWinFormsKey(Key.Value);
     }
 
     public bool IsPressed(System.Windows.Input.KeyEventArgs args)
@@ -56,7 +60,7 @@ public class KeyCombination
         }
         else
         {
-            var expectedWpfKey = System.Windows.Input.KeyInterop.KeyFromVirtualKey((int)Key);
+            var expectedWpfKey = System.Windows.Input.KeyInterop.KeyFromVirtualKey((int)Key.Value);
             return args.Key == expectedWpfKey || args.SystemKey == expectedWpfKey;
 
         }
@@ -74,7 +78,7 @@ public class KeyCombination
             }
             else
             {
-                return keyData == (Keys.Alt | Key);
+                return keyData == (Keys.Alt | ToWinFormsKey(Key.Value));
             }
         }
         else
@@ -94,7 +98,7 @@ public class KeyCombination
             if (IsShiftDown && !shiftDown) return false;
             if (IsAltDown && !altDown) return false;
 
-            return Key == null || extracted == Key;
+            return Key == null || extracted == ToWinFormsKey(Key.Value);
 
         }
 
@@ -106,7 +110,7 @@ public class KeyCombination
         if (IsShiftDown && (Control.ModifierKeys & Keys.Shift) != Keys.Shift) return false;
         if (IsAltDown && (Control.ModifierKeys & Keys.Alt) != Keys.Alt) return false;
 
-        return Key == null || (Control.ModifierKeys & Keys.KeyCode) == Key;
+        return Key == null || (Control.ModifierKeys & Keys.KeyCode) == ToWinFormsKey(Key.Value);
     }
 
     public override string ToString()
@@ -150,32 +154,32 @@ public class KeyCombination
 
 public class HotkeyManager : IHotkeyManager
 {
-    public KeyCombination Delete { get; private set; } = KeyCombination.Pressed(Keys.Delete);
-    public KeyCombination Copy { get; private set; } = KeyCombination.Ctrl(Keys.C);
-    public KeyCombination Paste { get; private set; } = KeyCombination.Ctrl(Keys.V);
-    public KeyCombination Cut { get; private set; } = KeyCombination.Ctrl(Keys.X);
-    public KeyCombination Undo { get; private set; } = KeyCombination.Ctrl(Keys.Z);
-    public KeyCombination Redo { get; private set; } = KeyCombination.Ctrl(Keys.Y);
+    public KeyCombination Delete { get; private set; } = KeyCombination.Pressed(GumKey.Delete);
+    public KeyCombination Copy { get; private set; } = KeyCombination.Ctrl(GumKey.C);
+    public KeyCombination Paste { get; private set; } = KeyCombination.Ctrl(GumKey.V);
+    public KeyCombination Cut { get; private set; } = KeyCombination.Ctrl(GumKey.X);
+    public KeyCombination Undo { get; private set; } = KeyCombination.Ctrl(GumKey.Z);
+    public KeyCombination Redo { get; private set; } = KeyCombination.Ctrl(GumKey.Y);
 
     public KeyCombination RedoAlt { get; private set; } = new KeyCombination()
     {
         IsCtrlDown = true,
         IsShiftDown = true,
-        Key = Keys.Z
+        Key = GumKey.Z
     };
 
-    public KeyCombination ReorderUp { get; private set; } = KeyCombination.Alt(Keys.Up);
-    public KeyCombination ReorderDown { get; private set; } = KeyCombination.Alt(Keys.Down);
-    public KeyCombination GoToDefinition { get; private set; } = KeyCombination.Pressed(Keys.F12);
-    public KeyCombination Search { get; private set; } = KeyCombination.Ctrl(Keys.F);
-    public KeyCombination NudgeUp { get; private set; } = KeyCombination.Pressed(Keys.Up);
-    public KeyCombination NudgeDown { get; private set; } = KeyCombination.Pressed(Keys.Down);
-    public KeyCombination NudgeRight { get; private set; } = KeyCombination.Pressed(Keys.Right);
-    public KeyCombination NudgeLeft { get; private set; } = KeyCombination.Pressed(Keys.Left);
-    public KeyCombination NudgeUp5 { get; private set; } = KeyCombination.Shift(Keys.Up);
-    public KeyCombination NudgeDown5 { get; private set; } = KeyCombination.Shift(Keys.Down);
-    public KeyCombination NudgeRight5 { get; private set; } = KeyCombination.Shift(Keys.Right);
-    public KeyCombination NudgeLeft5 { get; private set; } = KeyCombination.Shift(Keys.Left);
+    public KeyCombination ReorderUp { get; private set; } = KeyCombination.Alt(GumKey.Up);
+    public KeyCombination ReorderDown { get; private set; } = KeyCombination.Alt(GumKey.Down);
+    public KeyCombination GoToDefinition { get; private set; } = KeyCombination.Pressed(GumKey.F12);
+    public KeyCombination Search { get; private set; } = KeyCombination.Ctrl(GumKey.F);
+    public KeyCombination NudgeUp { get; private set; } = KeyCombination.Pressed(GumKey.Up);
+    public KeyCombination NudgeDown { get; private set; } = KeyCombination.Pressed(GumKey.Down);
+    public KeyCombination NudgeRight { get; private set; } = KeyCombination.Pressed(GumKey.Right);
+    public KeyCombination NudgeLeft { get; private set; } = KeyCombination.Pressed(GumKey.Left);
+    public KeyCombination NudgeUp5 { get; private set; } = KeyCombination.Shift(GumKey.Up);
+    public KeyCombination NudgeDown5 { get; private set; } = KeyCombination.Shift(GumKey.Down);
+    public KeyCombination NudgeRight5 { get; private set; } = KeyCombination.Shift(GumKey.Right);
+    public KeyCombination NudgeLeft5 { get; private set; } = KeyCombination.Shift(GumKey.Left);
 
     public KeyCombination LockMovementToAxis { get; private set; } = KeyCombination.Shift();
     public KeyCombination MaintainResizeAspectRatio { get; private set; } = KeyCombination.Shift();
@@ -183,18 +187,18 @@ public class HotkeyManager : IHotkeyManager
     public KeyCombination MultiSelect { get; private set; } = KeyCombination.Shift();
     public KeyCombination ResizeFromCenter { get; private set; } = KeyCombination.Alt();
 
-    public KeyCombination MoveCameraLeft { get; private set; } = KeyCombination.Ctrl(Keys.Left);
-    public KeyCombination MoveCameraRight { get; private set; } = KeyCombination.Ctrl(Keys.Right);
-    public KeyCombination MoveCameraUp { get; private set; } = KeyCombination.Ctrl(Keys.Up);
-    public KeyCombination MoveCameraDown { get; private set; } = KeyCombination.Ctrl(Keys.Down);
+    public KeyCombination MoveCameraLeft { get; private set; } = KeyCombination.Ctrl(GumKey.Left);
+    public KeyCombination MoveCameraRight { get; private set; } = KeyCombination.Ctrl(GumKey.Right);
+    public KeyCombination MoveCameraUp { get; private set; } = KeyCombination.Ctrl(GumKey.Up);
+    public KeyCombination MoveCameraDown { get; private set; } = KeyCombination.Ctrl(GumKey.Down);
 
-    public KeyCombination ZoomCameraIn { get; private set; } = KeyCombination.Ctrl(Keys.Add);
-    public KeyCombination ZoomCameraInAlternative { get; private set; } = KeyCombination.Ctrl(Keys.Oemplus);
+    public KeyCombination ZoomCameraIn { get; private set; } = KeyCombination.Ctrl(GumKey.Add);
+    public KeyCombination ZoomCameraInAlternative { get; private set; } = KeyCombination.Ctrl(GumKey.Oemplus);
 
-    public KeyCombination ZoomCameraOut { get; private set; } = KeyCombination.Ctrl(Keys.Subtract);
-    public KeyCombination ZoomCameraOutAlternative { get; private set; } = KeyCombination.Ctrl(Keys.OemMinus);
+    public KeyCombination ZoomCameraOut { get; private set; } = KeyCombination.Ctrl(GumKey.Subtract);
+    public KeyCombination ZoomCameraOutAlternative { get; private set; } = KeyCombination.Ctrl(GumKey.OemMinus);
 
-    public KeyCombination Rename { get; private set; } = KeyCombination.Pressed(Keys.F2);
+    public KeyCombination Rename { get; private set; } = KeyCombination.Pressed(GumKey.F2);
 
     // If adding any new keys here, modify HotkeyViewModel
 
@@ -210,6 +214,7 @@ public class HotkeyManager : IHotkeyManager
     private readonly IUndoManager _undoManager;
     private readonly IEditCommands _editCommands;
     private readonly IReorderLogic _reorderLogic;
+    private readonly IPluginManager _pluginManager;
 
 
     public HotkeyManager(IGuiCommands guiCommands,
@@ -222,7 +227,8 @@ public class HotkeyManager : IHotkeyManager
         ICopyPasteLogic copyPasteLogic,
         IUndoManager undoManager,
         IEditCommands editCommands,
-        IReorderLogic reorderLogic)
+        IReorderLogic reorderLogic,
+        IPluginManager pluginManager)
     {
         _copyPasteLogic = copyPasteLogic;
         _guiCommands = guiCommands;
@@ -235,6 +241,7 @@ public class HotkeyManager : IHotkeyManager
         _undoManager = undoManager;
         _editCommands = editCommands;
         _reorderLogic = reorderLogic;
+        _pluginManager = pluginManager;
     }
 
     #region App Wide Keys
@@ -451,7 +458,7 @@ public class HotkeyManager : IHotkeyManager
 
     bool _isNudging;
 
-    public bool ProcessCmdKeyWireframe(ref Message msg, Keys keyData)
+    public bool ProcessCmdKeyWireframe(Keys keyData)
     {
         bool handled = false;
 
@@ -507,11 +514,11 @@ public class HotkeyManager : IHotkeyManager
             handled = true;
             if(nudgeX != 0)
             {
-                PluginManager.Self.VariableSet(element, instance, "X", oldX);
+                _pluginManager.VariableSet(element, instance, "X", oldX);
             }
             if(nudgeY != 0)
             {
-                PluginManager.Self.VariableSet(element, instance, "Y", oldY);
+                _pluginManager.VariableSet(element, instance, "Y", oldY);
             }
         }
         return handled;

--- a/Gum/Managers/IHotkeyManager.cs
+++ b/Gum/Managers/IHotkeyManager.cs
@@ -44,5 +44,5 @@ public interface IHotkeyManager
     void HandleKeyDownElementTreeView(System.Windows.Forms.KeyEventArgs e);
     void HandleEditorKeyDown(System.Windows.Forms.KeyEventArgs e);
     void HandleKeyUpWireframe(System.Windows.Forms.KeyEventArgs e);
-    bool ProcessCmdKeyWireframe(ref System.Windows.Forms.Message msg, System.Windows.Forms.Keys keyData);
+    bool ProcessCmdKeyWireframe(System.Windows.Forms.Keys keyData);
 }

--- a/Tool/EditorTabPlugin_XNA/Views/WireframeControl.cs
+++ b/Tool/EditorTabPlugin_XNA/Views/WireframeControl.cs
@@ -123,7 +123,7 @@ public class WireframeControl : GraphicsDeviceControl
 
     protected override bool ProcessCmdKey(ref Message msg, Keys keyData)
     {
-        bool handled = _hotkeyManager.ProcessCmdKeyWireframe(ref msg, keyData);
+        bool handled = _hotkeyManager.ProcessCmdKeyWireframe(keyData);
 
         if (handled)
         {

--- a/Tool/Tests/GumToolUnitTests/Input/GumKeyTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Input/GumKeyTests.cs
@@ -1,0 +1,21 @@
+using Gum.Input;
+using Shouldly;
+using WinFormsKeys = System.Windows.Forms.Keys;
+
+namespace GumToolUnitTests.Input;
+
+public class GumKeyTests : BaseTestClass
+{
+    [Fact]
+    public void GumKey_Values_MatchWinFormsVirtualKeyCodes()
+    {
+        // Every GumKey member's integer value must equal the Win32 virtual-key code — the same integer
+        // WinForms Keys uses — so converting GumKey to a framework key type stays a pure cast. If a
+        // value ever drifts from the VK code (or a member is added with a mismatched value), this fails.
+        foreach (GumKey gumKey in Enum.GetValues<GumKey>())
+        {
+            WinFormsKeys winFormsKey = Enum.Parse<WinFormsKeys>(gumKey.ToString());
+            ((int)gumKey).ShouldBe((int)winFormsKey, $"GumKey.{gumKey} must equal Keys.{gumKey}");
+        }
+    }
+}

--- a/Tool/Tests/GumToolUnitTests/Managers/HotkeyManagerTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Managers/HotkeyManagerTests.cs
@@ -1,6 +1,10 @@
 using Gum.Commands;
+using Gum.DataTypes;
+using Gum.DataTypes.Variables;
+using Gum.Input;
 using Gum.Logic;
 using Gum.Managers;
+using Gum.Plugins;
 using Gum.Plugins.InternalPlugins.VariableGrid;
 using Gum.Services;
 using Gum.Services.Dialogs;
@@ -25,6 +29,7 @@ public class HotkeyManagerTests : BaseTestClass
     private readonly Mock<IUndoManager> _undoManager;
     private readonly Mock<IEditCommands> _editCommands;
     private readonly Mock<IReorderLogic> _reorderLogic;
+    private readonly Mock<IPluginManager> _pluginManager;
     private readonly HotkeyManager _hotkeyManager;
 
     public HotkeyManagerTests()
@@ -40,6 +45,7 @@ public class HotkeyManagerTests : BaseTestClass
         _undoManager = new Mock<IUndoManager>();
         _editCommands = new Mock<IEditCommands>();
         _reorderLogic = new Mock<IReorderLogic>();
+        _pluginManager = new Mock<IPluginManager>();
 
         _hotkeyManager = new HotkeyManager(
             _guiCommands.Object,
@@ -52,15 +58,104 @@ public class HotkeyManagerTests : BaseTestClass
             _copyPasteLogic.Object,
             _undoManager.Object,
             _editCommands.Object,
-            _reorderLogic.Object
+            _reorderLogic.Object,
+            _pluginManager.Object
         );
+    }
+
+    [Fact]
+    public void IsPressed_KeyData_NudgeUp5_RequiresShift()
+    {
+        // NudgeUp5 is Shift+Up: the Shift modifier bit is required.
+        _hotkeyManager.NudgeUp5.IsPressed(System.Windows.Forms.Keys.Shift | System.Windows.Forms.Keys.Up).ShouldBeTrue();
+        _hotkeyManager.NudgeUp5.IsPressed(System.Windows.Forms.Keys.Up).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsPressed_KeyData_NudgeUp_MatchesUp_AndIgnoresShiftBit()
+    {
+        // NudgeUp is a plain Up with no modifier requirement. The keyData flags overload must
+        // strip modifier bits to extract the key code, so Shift+Up still matches the key part.
+        _hotkeyManager.NudgeUp.IsPressed(System.Windows.Forms.Keys.Up).ShouldBeTrue();
+        _hotkeyManager.NudgeUp.IsPressed(System.Windows.Forms.Keys.Down).ShouldBeFalse();
+        _hotkeyManager.NudgeUp.IsPressed(System.Windows.Forms.Keys.Shift | System.Windows.Forms.Keys.Up).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsPressed_KeyData_ReorderUp_MatchesAltPlusKey()
+    {
+        // ReorderUp is Alt+Up: matches only when both the Alt flag and the Up key code are present.
+        _hotkeyManager.ReorderUp.IsPressed(System.Windows.Forms.Keys.Alt | System.Windows.Forms.Keys.Up).ShouldBeTrue();
+        _hotkeyManager.ReorderUp.IsPressed(System.Windows.Forms.Keys.Up).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsPressed_KeyData_ResizeFromCenter_MatchesAltOnly()
+    {
+        // ResizeFromCenter is Alt with no key: matches the bare Alt modifier, not Alt+other.
+        _hotkeyManager.ResizeFromCenter.IsPressed(System.Windows.Forms.Keys.Alt).ShouldBeTrue();
+        _hotkeyManager.ResizeFromCenter.IsPressed(System.Windows.Forms.Keys.Alt | System.Windows.Forms.Keys.C).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsPressed_KeyEventArgs_Copy_RequiresCtrlPlusC()
+    {
+        _hotkeyManager.Copy.IsPressed(new System.Windows.Forms.KeyEventArgs(System.Windows.Forms.Keys.C | System.Windows.Forms.Keys.Control)).ShouldBeTrue();
+        _hotkeyManager.Copy.IsPressed(new System.Windows.Forms.KeyEventArgs(System.Windows.Forms.Keys.C)).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsPressed_KeyEventArgs_Delete_MatchesDelete()
+    {
+        _hotkeyManager.Delete.IsPressed(new System.Windows.Forms.KeyEventArgs(System.Windows.Forms.Keys.Delete)).ShouldBeTrue();
+        _hotkeyManager.Delete.IsPressed(new System.Windows.Forms.KeyEventArgs(System.Windows.Forms.Keys.C)).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ProcessCmdKeyWireframe_Arrow_NudgesOnePixel_AndRaisesVariableSet()
+    {
+        (ComponentSave element, InstanceSave instance) = SetUpSelectedInstance(x: 10f, y: 20f);
+
+        bool handled = _hotkeyManager.ProcessCmdKeyWireframe(System.Windows.Forms.Keys.Up);
+
+        handled.ShouldBeTrue();
+        _elementCommands.Verify(e => e.MoveSelectedObjectsBy(0f, -1f), Times.Once);
+        _undoManager.Verify(u => u.RecordState(), Times.Once);
+        // Only the moved axis (Y) raises VariableSet, carrying the pre-move value.
+        _pluginManager.Verify(p => p.VariableSet(element, instance, "Y", 20f), Times.Once);
+        _pluginManager.Verify(
+            p => p.VariableSet(It.IsAny<ElementSave>(), It.IsAny<InstanceSave>(), "X", It.IsAny<object>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public void ProcessCmdKeyWireframe_LockedInstance_DoesNothing()
+    {
+        SetUpSelectedInstance(x: 10f, y: 20f, locked: true);
+
+        bool handled = _hotkeyManager.ProcessCmdKeyWireframe(System.Windows.Forms.Keys.Up);
+
+        handled.ShouldBeFalse();
+        _elementCommands.Verify(e => e.MoveSelectedObjectsBy(It.IsAny<float>(), It.IsAny<float>()), Times.Never);
+        _undoManager.Verify(u => u.RecordState(), Times.Never);
+    }
+
+    [Fact]
+    public void ProcessCmdKeyWireframe_ShiftArrow_NudgesFivePixels()
+    {
+        SetUpSelectedInstance(x: 10f, y: 20f);
+
+        bool handled = _hotkeyManager.ProcessCmdKeyWireframe(System.Windows.Forms.Keys.Shift | System.Windows.Forms.Keys.Up);
+
+        handled.ShouldBeTrue();
+        _elementCommands.Verify(e => e.MoveSelectedObjectsBy(0f, -5f), Times.Once);
     }
 
     [Fact]
     public void ZoomCameraIn_KeyCombination_ShouldBeCtrlPlus()
     {
         // Verify zoom hotkey configuration
-        _hotkeyManager.ZoomCameraIn.Key.ShouldBe(System.Windows.Forms.Keys.Add);
+        _hotkeyManager.ZoomCameraIn.Key.ShouldBe(GumKey.Add);
         _hotkeyManager.ZoomCameraIn.IsCtrlDown.ShouldBeTrue();
     }
 
@@ -68,7 +163,7 @@ public class HotkeyManagerTests : BaseTestClass
     public void ZoomCameraInAlternative_KeyCombination_ShouldBeCtrlOemPlus()
     {
         // Verify alternative zoom hotkey configuration
-        _hotkeyManager.ZoomCameraInAlternative.Key.ShouldBe(System.Windows.Forms.Keys.Oemplus);
+        _hotkeyManager.ZoomCameraInAlternative.Key.ShouldBe(GumKey.Oemplus);
         _hotkeyManager.ZoomCameraInAlternative.IsCtrlDown.ShouldBeTrue();
     }
 
@@ -76,7 +171,7 @@ public class HotkeyManagerTests : BaseTestClass
     public void ZoomCameraOut_KeyCombination_ShouldBeCtrlMinus()
     {
         // Verify zoom out hotkey configuration
-        _hotkeyManager.ZoomCameraOut.Key.ShouldBe(System.Windows.Forms.Keys.Subtract);
+        _hotkeyManager.ZoomCameraOut.Key.ShouldBe(GumKey.Subtract);
         _hotkeyManager.ZoomCameraOut.IsCtrlDown.ShouldBeTrue();
     }
 
@@ -84,7 +179,26 @@ public class HotkeyManagerTests : BaseTestClass
     public void ZoomCameraOutAlternative_KeyCombination_ShouldBeCtrlOemMinus()
     {
         // Verify alternative zoom out hotkey configuration
-        _hotkeyManager.ZoomCameraOutAlternative.Key.ShouldBe(System.Windows.Forms.Keys.OemMinus);
+        _hotkeyManager.ZoomCameraOutAlternative.Key.ShouldBe(GumKey.OemMinus);
         _hotkeyManager.ZoomCameraOutAlternative.IsCtrlDown.ShouldBeTrue();
+    }
+
+    private (ComponentSave element, InstanceSave instance) SetUpSelectedInstance(float x, float y, bool locked = false)
+    {
+        ComponentSave element = new ComponentSave();
+        element.States.Add(new StateSave());
+        element.DefaultState.ParentContainer = element;
+
+        InstanceSave instance = new InstanceSave { Name = "MyInstance", BaseType = "Container" };
+        instance.Locked = locked;
+        element.Instances.Add(instance);
+
+        element.DefaultState.SetValue("MyInstance.X", x);
+        element.DefaultState.SetValue("MyInstance.Y", y);
+
+        _selectedState.Setup(s => s.SelectedInstance).Returns(instance);
+        _selectedState.Setup(s => s.SelectedElement).Returns(element);
+
+        return (element, instance);
     }
 }


### PR DESCRIPTION
## What & why

Phase 1 close-out slice (PR A) of the UI/logic decoupling effort (umbrella #3225). Design brief: `.claude/designs/direction-ui-decoupling/keys-dragdrop-slice-proposal.md` (§4 PR A; decisions locked §8).

`KeyCombination.Key` was typed `System.Windows.Forms.Keys?`, leaking WinForms into the hotkey **data surface** (`IHotkeyManager`, `HotkeyViewModel`, test setup). This introduces a Gum-owned, framework-neutral `GumKey` enum and retypes `KeyCombination.Key` onto it.

## Changes

- **New `GumKey` enum** (`Gum/Input/GumKey.cs`) — covers the 17 keys Gum binds. Member **values equal the Win32 virtual-key codes** (the same integers WinForms `Keys` and XNA `Keys` use), so every framework conversion stays a pure cast. Member **names match** the WinForms `Keys` names so the hotkey-help `ToString()` display is byte-for-byte unchanged.
- **Retype `KeyCombination.Key`** `Keys?` → `GumKey?`, plus the `Pressed/Ctrl/Alt/Shift` factories and `HotkeyManager`'s ~33 initializers. The four `IsPressed` overloads **keep their WinForms/WPF/`keyData` parameter types** (no call-site sweep — that's deferred PR C) and convert via a single `ToWinFormsKey` helper.
- **Drop the dead `ref Message`** from `ProcessCmdKeyWireframe(ref Message, Keys)` → `ProcessCmdKeyWireframe(Keys)`; `WireframeControl.ProcessCmdKey` no longer forwards `ref msg`. The param was never read.
- **Drain the lone `PluginManager.Self.VariableSet`** in `HandleNudge` into a constructor-injected `IPluginManager` (already DI-registered; no construction cycle) so the nudge path is unit-testable.

## Tests (`KeyCombination` was essentially uncovered)

- VK round-trip: `(int)GumKey.X == (int)Keys.X` for **every** member (guards drift; verified red when a value is perturbed).
- `IsPressed(Keys keyData)` flags semantics — `Shift|key`, `Alt`-only, `Alt|key`, key-code extraction (highest-value pin). Authored **green pre-refactor**, still green after → behavior preserved.
- `IsPressed(WinForms.KeyEventArgs)` — Ctrl+key gating, plain key.
- Nudge via `ProcessCmdKeyWireframe`: arrow → 1px, Shift+arrow → 5px, locked instance → no-op, `VariableSet` raised for the moved axis (verified red when `VariableSet` is suppressed).
- Existing `HotkeyManagerTests` updated to assert `GumKey`.

Full `GumToolUnitTests` suite: **921 passed, 4 skipped (pre-existing), 0 failed.** `GumFull.sln` builds clean.

## Scope / classification

Behavior-preserving (VK-aligned casts are identical to today). The WPF `IsPressed` overload's true-branch isn't unit-tested (requires a live `PresentationSource`) — covered by the VK round-trip + manual test. Out of scope: PR B (drag-drop neutralization) and PR C (neutralize handler method signatures + `IModifierKeyState`), tracked separately.

## Manual test — needed (hotkey cluster)

Launch `GumFull.sln` → run `Gum`, open a project with a Screen + a few instances:
1. **Tree view:** `Del` deletes; `Ctrl+C/V/X` copy/paste/cut; `Ctrl+Z`/`Ctrl+Y`/`Ctrl+Shift+Z` undo/redo; `F2` rename; `F12` go-to-definition; `Alt+Up`/`Alt+Down` reorder; `Ctrl+F` focuses search.
2. **Canvas:** select instance → arrow nudges 1px, `Shift+arrow` 5px (single undo entry per nudge release); lock the instance → arrows do nothing.
3. **App-wide:** `Ctrl++`/`Ctrl+-` font zoom; `Tab` toggles tool visibility.

Closes #3265.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
