### PR TITLE
Fix #3268: reduce rounded-rect fill corner radius by FillInset so fill stays concentric with stroke

### DIFF
--- a/Runtimes/GumShapes/Renderables/RoundedRectangle.cs
+++ b/Runtimes/GumShapes/Renderables/RoundedRectangle.cs
@@ -95,6 +95,44 @@ public class RoundedRectangle : RenderableShapeBase,
     }
 
     /// <summary>
+    /// Issue #3268 — corner-radius companion to <see cref="ComputeFillDrawRect"/>. Insetting the
+    /// fill by <see cref="FillInset"/> on every side moves each corner's center inward by
+    /// <c>(inset, inset)</c>; keeping the full <see cref="CornerRadius"/> there leaves the fill arc
+    /// NON-concentric with the stroke's inner edge, opening a background gap that is ~0 along the
+    /// straight edges and widest at the 45° point of each corner. Reducing the radius by the same
+    /// inset (clamped at 0) keeps the corner center fixed — the classic "inner radius = outer
+    /// radius − inset" rule — so the inset fill stays concentric with the stroke. Returns the full
+    /// radius on the shadow pass (which draws the fill at full size, see
+    /// <see cref="ComputeFillDrawRect"/>) or when there is no inset.
+    /// </summary>
+    public float ComputeFillCornerRadius(bool isShadowPass)
+    {
+        if (isShadowPass || FillInset <= 0f)
+        {
+            return CornerRadius;
+        }
+        return System.Math.Max(0f, CornerRadius - FillInset);
+    }
+
+    /// <summary>
+    /// Per-corner analog of <see cref="ComputeFillCornerRadius"/> for the <c>CustomRadius*</c> path
+    /// (#3268), in Apos.Shapes' <c>CornerRadii</c> order (top-left, top-right, bottom-right,
+    /// bottom-left). Each corner resolves its null override against <see cref="CornerRadius"/>
+    /// exactly as <see cref="HasCustomCorners"/> does, then is reduced by <see cref="FillInset"/>
+    /// (clamped at 0) on the inset body pass so all four corners stay concentric with the stroke.
+    /// Returns the full radii on the shadow pass or when there is no inset.
+    /// </summary>
+    public (float topLeft, float topRight, float bottomRight, float bottomLeft) ComputeFillCornerRadii(bool isShadowPass)
+    {
+        float inset = isShadowPass || FillInset <= 0f ? 0f : FillInset;
+        return (
+            System.Math.Max(0f, (CustomRadiusTopLeft ?? CornerRadius) - inset),
+            System.Math.Max(0f, (CustomRadiusTopRight ?? CornerRadius) - inset),
+            System.Math.Max(0f, (CustomRadiusBottomRight ?? CornerRadius) - inset),
+            System.Math.Max(0f, (CustomRadiusBottomLeft ?? CornerRadius) - inset));
+    }
+
+    /// <summary>
     /// Insets the draw rect by the pixel-center AA alignment offset
     /// (<see cref="RenderableShapeBase.GetAntiAliasWorldOffset"/>): the top-left moves in by the
     /// offset and each dimension shrinks by twice it, keeping the rect centered. Scaled by
@@ -262,24 +300,36 @@ public class RoundedRectangle : RenderableShapeBase,
             // analog) so a semi-transparent stroke shows the background through it, not the
             // fill. The shadow pass (forcedColor != null) must NOT inherit the inset, or its
             // outer edge falls short of the body's outer edge (#2958).
-            var (fillPosition, fillSize) = ComputeFillDrawRect(position, size, isShadowPass: forcedColor != null);
+            bool isShadowPass = forcedColor != null;
+            var (fillPosition, fillSize) = ComputeFillDrawRect(position, size, isShadowPass);
+
+            // Issue #3268 — shrink the corner radius by the same inset so the inset fill stays
+            // concentric with the stroke's inner edge (no gap opens at the rounded corners). Gated
+            // on isShadowPass identically to the rect inset above.
+            float fillRadius = ComputeFillCornerRadius(isShadowPass);
+            Apos.Shapes.CornerRadii fillCorners = default;
+            if (hasCustomCorners)
+            {
+                var (tl, tr, br, bl) = ComputeFillCornerRadii(isShadowPass);
+                fillCorners = new Apos.Shapes.CornerRadii(tl, tr, br, bl);
+            }
 
             if (ShouldPaintGradient(forcedColor))
             {
                 var gradient = base.GetGradient(absoluteLeft, absoluteTop, rotationRadians);
 
                 if (hasCustomCorners)
-                    sb.DrawRectangle(fillPosition, fillSize, gradient, gradient, thickness, corners, rotationRadians, antiAliasSize);
+                    sb.DrawRectangle(fillPosition, fillSize, gradient, gradient, thickness, fillCorners, rotationRadians, antiAliasSize);
                 else
-                    sb.DrawRectangle(fillPosition, fillSize, gradient, gradient, thickness, CornerRadius, rotationRadians, antiAliasSize);
+                    sb.DrawRectangle(fillPosition, fillSize, gradient, gradient, thickness, fillRadius, rotationRadians, antiAliasSize);
             }
             else
             {
                 var color = forcedColor ?? Color;
                 if (hasCustomCorners)
-                    sb.DrawRectangle(fillPosition, fillSize, color, color, thickness, corners, rotationRadians, antiAliasSize);
+                    sb.DrawRectangle(fillPosition, fillSize, color, color, thickness, fillCorners, rotationRadians, antiAliasSize);
                 else
-                    sb.DrawRectangle(fillPosition, fillSize, color, color, thickness, CornerRadius, rotationRadians, antiAliasSize);
+                    sb.DrawRectangle(fillPosition, fillSize, color, color, thickness, fillRadius, rotationRadians, antiAliasSize);
             }
         }
         else

--- a/Tests/MonoGameGum.Shapes.Tests/RoundedRectangleRenderableTests.cs
+++ b/Tests/MonoGameGum.Shapes.Tests/RoundedRectangleRenderableTests.cs
@@ -71,6 +71,126 @@ public class RoundedRectangleRenderableTests
         size.ShouldBe(new Vector2(100, 60));
     }
 
+    // Issue #3268 — concentric-corner fix. ComputeFillDrawRect insets the fill by FillInset on
+    // every side, which moves each corner's center inward by (inset, inset). Keeping the full
+    // CornerRadius there leaves the fill arc NON-concentric with the stroke's inner edge, opening
+    // a background gap that is ~0 along the straight edges and widest at the 45° point of each
+    // corner. The fix reduces the fill's corner radius by FillInset (clamped at 0) so the corner
+    // center stays put — the classic "inner radius = outer radius − inset" rule. The shadow pass
+    // draws the fill at full size (no inset), so it must keep the full radius.
+
+    [Fact]
+    public void ComputeFillCornerRadius_BodyPass_NoInset_ReturnsRadius()
+    {
+        RoundedRectangle sut = new() { CornerRadius = 18f, FillInset = 0f };
+
+        sut.ComputeFillCornerRadius(isShadowPass: false).ShouldBe(18f);
+    }
+
+    [Fact]
+    public void ComputeFillCornerRadius_BodyPass_WithInset_ReducesByInset()
+    {
+        RoundedRectangle sut = new() { CornerRadius = 18f, FillInset = 4f };
+
+        // Concentric rule: inner radius = outer radius − inset.
+        sut.ComputeFillCornerRadius(isShadowPass: false).ShouldBe(14f);
+    }
+
+    [Fact]
+    public void ComputeFillCornerRadius_BodyPass_InsetExceedsRadius_ClampsToZero()
+    {
+        RoundedRectangle sut = new() { CornerRadius = 3f, FillInset = 10f };
+
+        sut.ComputeFillCornerRadius(isShadowPass: false).ShouldBe(0f);
+    }
+
+    [Fact]
+    public void ComputeFillCornerRadius_ShadowPass_IgnoresInset()
+    {
+        RoundedRectangle sut = new() { CornerRadius = 18f, FillInset = 4f };
+
+        // Shadow fill draws at full size, so it keeps the full radius.
+        sut.ComputeFillCornerRadius(isShadowPass: true).ShouldBe(18f);
+    }
+
+    [Fact]
+    public void ComputeFillCornerRadii_BodyPass_WithInset_ReducesEachCorner()
+    {
+        RoundedRectangle sut = new()
+        {
+            CornerRadius = 18f,
+            CustomRadiusTopLeft = 20f,
+            CustomRadiusTopRight = 16f,
+            CustomRadiusBottomRight = 12f,
+            CustomRadiusBottomLeft = 8f,
+            FillInset = 4f,
+        };
+
+        var (topLeft, topRight, bottomRight, bottomLeft) = sut.ComputeFillCornerRadii(isShadowPass: false);
+
+        topLeft.ShouldBe(16f);
+        topRight.ShouldBe(12f);
+        bottomRight.ShouldBe(8f);
+        bottomLeft.ShouldBe(4f);
+    }
+
+    [Fact]
+    public void ComputeFillCornerRadii_NullCorner_FallsBackToCornerRadiusThenReduces()
+    {
+        // A null per-corner override resolves to CornerRadius (matching HasCustomCorners) and is
+        // then reduced by the inset like any other corner.
+        RoundedRectangle sut = new()
+        {
+            CornerRadius = 18f,
+            CustomRadiusTopLeft = 20f,
+            CustomRadiusTopRight = null,
+            CustomRadiusBottomRight = null,
+            CustomRadiusBottomLeft = null,
+            FillInset = 4f,
+        };
+
+        var (topLeft, topRight, bottomRight, bottomLeft) = sut.ComputeFillCornerRadii(isShadowPass: false);
+
+        topLeft.ShouldBe(16f);
+        topRight.ShouldBe(14f);   // (18 fallback) − 4
+        bottomRight.ShouldBe(14f);
+        bottomLeft.ShouldBe(14f);
+    }
+
+    [Fact]
+    public void ComputeFillCornerRadii_InsetExceedsCorner_ClampsToZero()
+    {
+        RoundedRectangle sut = new()
+        {
+            CornerRadius = 18f,
+            CustomRadiusTopLeft = 2f,
+            FillInset = 10f,
+        };
+
+        var (topLeft, _, _, _) = sut.ComputeFillCornerRadii(isShadowPass: false);
+
+        topLeft.ShouldBe(0f);
+    }
+
+    [Fact]
+    public void ComputeFillCornerRadii_ShadowPass_IgnoresInset()
+    {
+        RoundedRectangle sut = new()
+        {
+            CornerRadius = 18f,
+            CustomRadiusTopLeft = 20f,
+            FillInset = 4f,
+        };
+
+        var (topLeft, topRight, bottomRight, bottomLeft) = sut.ComputeFillCornerRadii(isShadowPass: true);
+
+        // Full size on the shadow pass → full custom radius (20) and full fallback (18).
+        topLeft.ShouldBe(20f);
+        topRight.ShouldBe(18f);
+        bottomRight.ShouldBe(18f);
+        bottomLeft.ShouldBe(18f);
+    }
+
     // Bug: the pixel-center AA offset (position += 0.5, size -= 1) that aligns an antialiased
     // edge to the SCREEN pixel grid (Apos issue #12) was applied in WORLD units, ignoring camera
     // zoom. Like the AA halo (#2936) it must be divided by cameraZoom so it stays a constant


### PR DESCRIPTION
## Summary

Fixes #3268. A filled `Rectangle` (GumShapes shader renderer) with a visible stroke and a non-zero `CornerRadius` showed a thin gap (background / dropshadow color) between the fill and the stroke's inner edge at each **rounded corner** — ~0 along the straight edges, widest at the 45° point of each corner.

## Cause

`RoundedRectangle.ComputeFillDrawRect` insets the fill by `FillInset` on every side (the #2834 transparent-stroke fix) so the fill's outer edge sits inside the opaque stroke band. That symmetric inset moves each corner's center inward by `(inset, inset)`, but the fill kept drawing with the **full** `CornerRadius`. With the center shifted and the radius unchanged, the fill's corner arc is no longer concentric with the stroke's inner arc — it pulls inside it by up to `inset·(1 − 1/√2) ≈ 0.29·strokeWidth` at the diagonal, opening the gap. The straight edges stay tight because both sit at inset `i`.

This is the classic concentric-rounded-rect rule: the inner radius must be `outerRadius − inset`.

## Fix

`RoundedRectangle` now reduces the fill draw's corner radius (and each `CustomRadius*`) by `FillInset`, clamped at 0, via two new helpers:

- `ComputeFillCornerRadius(bool isShadowPass)` — uniform `CornerRadius` path.
- `ComputeFillCornerRadii(bool isShadowPass)` — per-corner `CustomRadius*` path (resolves nulls against `CornerRadius` exactly as `HasCustomCorners`).

Both are gated on `isShadowPass` **identically to the rect inset in `ComputeFillDrawRect`**, so the full-size shadow pass (which draws the fill at full size, #2958) keeps the full radius. The stroke draw is untouched — it's the outer band and must not shrink.

The renderable is shared source compiled by both `MonoGameGumShapes` and `KniGumShapes`, so the fix lands on MonoGame and KNI (the tool's runtime) alike. The Skia rounded-rectangle path draws fill+stroke natively and has no `FillInset`, so it isn't affected. The `CircleRuntime` `FillRadiusInset` analog has no corners, so it isn't affected either.

## Tests

8 new tests in `RoundedRectangleRenderableTests` covering both helpers: no-inset / with-inset / inset-exceeds-radius (clamp to 0) / shadow-pass-ignores-inset, plus the null-corner fallback for the per-corner path. Red-first confirmed, then green. Full `MonoGameGum.Shapes.Tests` suite: 213/213 pass. `KniGumShapes` builds with 0 errors.

## Manual test

Needed (rendering change). Steps in the PR thread / handoff — open the repro rounded filled rectangle in the Gum tool built from this branch and zoom into a corner; the blue fill now meets the white stroke's inner edge cleanly all the way around.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
