### PR TITLE
Mirror copy-time selection after paste (#3269)

### DIFF
--- a/Gum/Logic/CopyPasteLogic.cs
+++ b/Gum/Logic/CopyPasteLogic.cs
@@ -477,7 +477,8 @@ public class CopyPasteLogic : ICopyPasteLogic
         {
             PasteInstanceSaves(CopiedData.CopiedInstancesRecursive, CopiedData.CopiedStates, selectedElement, _selectedState.SelectedInstance,
                 baseElementDefaultStates: CopiedData.CopiedBaseElementDefaultStates,
-                itemsOwnedByReachableStates: CopiedData.CopiedNamesOwnedByReachableStates);
+                itemsOwnedByReachableStates: CopiedData.CopiedNamesOwnedByReachableStates,
+                instancesToSelectAfterPaste: CopiedData.CopiedInstancesSelected);
         }
         else
         {
@@ -633,6 +634,10 @@ public class CopyPasteLogic : ICopyPasteLogic
     /// <param name="copiedStates"></param>
     /// <param name="targetElement"></param>
     /// <param name="selectedInstance"></param>
+    /// <param name="instancesToSelectAfterPaste">The source instances whose new copies should end up
+    /// selected after the paste. Pass the explicitly-selected (non-recursive) set so that pasting a parent
+    /// does not also leave its recursively-dragged children selected. When null, every new instance is
+    /// selected (the legacy behavior used by drag-drop and the top-level paste path).</param>
     /// <returns>The newly-created instances</returns>
     public List<InstanceSave> PasteInstanceSaves(List<InstanceSave> instancesToCopy,
         List<StateSave> copiedStates,
@@ -640,7 +645,8 @@ public class CopyPasteLogic : ICopyPasteLogic
         InstanceSave? selectedInstance,
         ISelectedState? forcedSelectedState = null,
         List<StateSave>? baseElementDefaultStates = null,
-        HashSet<string>? itemsOwnedByReachableStates = null)
+        HashSet<string>? itemsOwnedByReachableStates = null,
+        List<InstanceSave>? instancesToSelectAfterPaste = null)
     {
         /////////////////////////Early Out///////////////////////
         if (targetElement is StandardElementSave)
@@ -1036,11 +1042,42 @@ public class CopyPasteLogic : ICopyPasteLogic
         //var hasSelectionChangedStore = _hasChangedSelectionSinceCopy;
 
         isSelectionCausedByPaste = true;
-        selectedState.SelectedInstances = newInstances;
+        selectedState.SelectedInstances = GetInstancesToSelectAfterPaste(newInstances, oldNewNameDictionary, instancesToSelectAfterPaste);
         _hasChangedSelectionSinceCopy = false;
         isSelectionCausedByPaste = false;
 
         return newInstances;
+    }
+
+    // Narrows the post-paste selection to mirror what was selected at copy time. Pasting a parent
+    // also recursively duplicates its children, but only the originally-selected instances (passed in
+    // sourceInstancesToSelect) should remain selected. Falls back to selecting every new instance when
+    // no source selection is supplied (drag-drop / top-level paste) or when none of the selected source
+    // names map to a new instance (a defensive guard against odd repeat-paste states).
+    private static List<InstanceSave> GetInstancesToSelectAfterPaste(
+        List<InstanceSave> newInstances,
+        Dictionary<string, string> oldNewNameDictionary,
+        List<InstanceSave>? sourceInstancesToSelect)
+    {
+        if (sourceInstancesToSelect == null || sourceInstancesToSelect.Count == 0)
+        {
+            return newInstances;
+        }
+
+        HashSet<string> newNamesToSelect = new();
+        foreach (InstanceSave sourceInstance in sourceInstancesToSelect)
+        {
+            if (oldNewNameDictionary.TryGetValue(sourceInstance.Name, out string? newName))
+            {
+                newNamesToSelect.Add(newName);
+            }
+        }
+
+        List<InstanceSave> toSelect = newInstances
+            .Where(item => newNamesToSelect.Contains(item.Name))
+            .ToList();
+
+        return toSelect.Count > 0 ? toSelect : newInstances;
     }
 
     int GetIndexOfInstanceByName(ElementSave element, InstanceSave instance)

--- a/Gum/Logic/ICopyPasteLogic.cs
+++ b/Gum/Logic/ICopyPasteLogic.cs
@@ -18,7 +18,8 @@ public interface ICopyPasteLogic
         InstanceSave? selectedInstance,
         ISelectedState? forcedSelectedState = null,
         List<StateSave>? baseElementDefaultStates = null,
-        HashSet<string>? itemsOwnedByReachableStates = null);
+        HashSet<string>? itemsOwnedByReachableStates = null,
+        List<InstanceSave>? instancesToSelectAfterPaste = null);
 
     /// <summary>
     /// Promotes a single instance into a brand-new component: the instance's type becomes the

--- a/Tool/Tests/GumToolUnitTests/Logic/CopyPasteLogicTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Logic/CopyPasteLogicTests.cs
@@ -922,6 +922,96 @@ public class CopyPasteLogicTests : BaseTestClass
     }
 
     [Fact]
+    public void OnPaste_Instance_ParentOnlySelected_ShouldSelectOnlyNewParent()
+    {
+        /*
+         * Container  (selected at copy time)
+         *    Child
+         * Container1 <--- pasted, should be selected
+         *    Child1  <--- pasted, should NOT be selected
+         */
+
+        ScreenSave screen = CreateDefaultScreen();
+        InstanceSave container = screen.Instances[0];
+        container.Name = "Container";
+        AddChild("Child", "Container", screen);
+
+        SelectInstances(container);
+
+        _copyPasteLogic.OnCopy(CopyType.InstanceOrElement);
+        _copyPasteLogic.OnPaste(CopyType.InstanceOrElement);
+
+        screen.Instances.Count.ShouldBe(4);
+
+        _currentSelectedInstances.Count.ShouldBe(1,
+            "because only the parent was selected at copy time, so only the new parent should be selected");
+        _currentSelectedInstances[0].Name.ShouldBe("Container1");
+    }
+
+    [Fact]
+    public void OnPaste_Instance_ChildSelected_ShouldSelectOnlyNewChild()
+    {
+        /*
+         * Container
+         *    Child  (selected at copy time)
+         *       Grandchild
+         * Pasted as siblings under Container:
+         *    Child1       <--- pasted, should be selected
+         *       Grandchild1 <--- pasted, should NOT be selected
+         */
+
+        ScreenSave screen = CreateDefaultScreen();
+        InstanceSave container = screen.Instances[0];
+        container.Name = "Container";
+        InstanceSave child = AddChild("Child", "Container", screen);
+        AddChild("Grandchild", "Child", screen);
+
+        SelectInstances(child);
+
+        _copyPasteLogic.OnCopy(CopyType.InstanceOrElement);
+        _copyPasteLogic.OnPaste(CopyType.InstanceOrElement);
+
+        screen.Instances.Count.ShouldBe(5);
+
+        _currentSelectedInstances.Count.ShouldBe(1,
+            "because only the child was selected at copy time, so only the new child should be " +
+            "selected, not the grandchild that was dragged along recursively");
+        _currentSelectedInstances[0].Name.ShouldBe("Child1");
+    }
+
+    [Fact]
+    public void OnPaste_MultipleInstances_SubsetSelected_ShouldSelectOnlyNewCopiesOfSelected()
+    {
+        /*
+         * ParentA (selected at copy time)
+         *    ChildA
+         * ParentB (selected at copy time)
+         *    ChildB
+         * After paste, four new instances exist; only the two new parents should be selected.
+         */
+
+        ScreenSave screen = CreateDefaultScreen();
+        InstanceSave parentA = screen.Instances[0];
+        parentA.Name = "ParentA";
+        AddChild("ChildA", "ParentA", screen);
+
+        InstanceSave parentB = AddChild("ParentB", "", screen);
+        AddChild("ChildB", "ParentB", screen);
+
+        SelectInstances(parentA, parentB);
+
+        _copyPasteLogic.OnCopy(CopyType.InstanceOrElement);
+        _copyPasteLogic.OnPaste(CopyType.InstanceOrElement);
+
+        screen.Instances.Count.ShouldBe(8);
+
+        _currentSelectedInstances.Count.ShouldBe(2,
+            "because only the two parents were selected at copy time, not their children");
+        _currentSelectedInstances.Select(item => item.Name).OrderBy(name => name)
+            .ShouldBe(new[] { "ParentA1", "ParentB1" });
+    }
+
+    [Fact]
     public void OnPaste_InstanceWithDottedSubInstanceParent_InDifferentScreen_ShouldPreserveHierarchy()
     {
         /*

--- a/Tool/Tests/GumToolUnitTests/Logic/CopyPasteLogicTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Logic/CopyPasteLogicTests.cs
@@ -949,6 +949,37 @@ public class CopyPasteLogicTests : BaseTestClass
     }
 
     [Fact]
+    public void OnPaste_Instance_ParentAndChildSelected_ShouldSelectBothNewCopies()
+    {
+        /*
+         * Inverse guard against over-narrowing: when BOTH the parent and its child were
+         * selected at copy time, BOTH new copies should be selected after paste.
+         *
+         * Container  (selected at copy time)
+         *    Child   (selected at copy time)
+         * Container1 <--- pasted, should be selected
+         *    Child1  <--- pasted, should ALSO be selected
+         */
+
+        ScreenSave screen = CreateDefaultScreen();
+        InstanceSave container = screen.Instances[0];
+        container.Name = "Container";
+        InstanceSave child = AddChild("Child", "Container", screen);
+
+        SelectInstances(container, child);
+
+        _copyPasteLogic.OnCopy(CopyType.InstanceOrElement);
+        _copyPasteLogic.OnPaste(CopyType.InstanceOrElement);
+
+        screen.Instances.Count.ShouldBe(4);
+
+        _currentSelectedInstances.Count.ShouldBe(2,
+            "because both the parent and child were selected at copy time, so both new copies should be selected");
+        _currentSelectedInstances.Select(item => item.Name).OrderBy(name => name)
+            .ShouldBe(new[] { "Child1", "Container1" });
+    }
+
+    [Fact]
     public void OnPaste_Instance_ChildSelected_ShouldSelectOnlyNewChild()
     {
         /*

--- a/Tool/Tests/GumToolUnitTests/Managers/DragDropManagerTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Managers/DragDropManagerTests.cs
@@ -84,7 +84,8 @@ public class DragDropManagerTests : BaseTestClass
                 It.IsAny<InstanceSave?>(),
                 It.IsAny<ISelectedState?>(),
                 It.IsAny<List<StateSave>?>(),
-                It.IsAny<HashSet<string>?>()))
+                It.IsAny<HashSet<string>?>(),
+                It.IsAny<List<InstanceSave>?>()))
             .Returns(new List<InstanceSave> { draggedInstance });
 
         DropTarget dropTarget = new DropTarget(destinationComponent, null, new DropPosition.InsertAt(1));
@@ -356,7 +357,8 @@ public class DragDropManagerTests : BaseTestClass
                 It.IsAny<InstanceSave?>(),
                 It.IsAny<ISelectedState?>(),
                 It.IsAny<List<StateSave>?>(),
-                It.IsAny<HashSet<string>?>()))
+                It.IsAny<HashSet<string>?>(),
+                It.IsAny<List<InstanceSave>?>()))
             .Returns(new List<InstanceSave> { draggedInstance });
 
         DropTarget dropTarget = new DropTarget(destinationComponent, null, new DropPosition.InsertAt(1));


### PR DESCRIPTION
## Summary

Fixes the long-standing copy/paste annoyance where pasting a parent instance left **all** the newly-created instances (parent *and* its recursively-duplicated children) selected. The post-paste selection now mirrors what was selected at copy time:

- Copy with only the **parent** selected → after paste, only the new parent is selected.
- Copy with a **child** selected → after paste, only the new child is selected (not the grandchild that was dragged along recursively).
- Multi-select a **subset** → only that subset's new copies are selected.

## Cause

`PasteInstanceSaves` assigned the full `newInstances` set (parent + all descendants) to the selection. For a recursive Ctrl+V, that set is built from `CopiedInstancesRecursive`, so every duplicated instance got selected.

## Fix

`PasteInstanceSaves` gains an optional `instancesToSelectAfterPaste` parameter — the source instances whose new copies should end up selected. The recursive copy/paste path passes the already-stored `CopiedData.CopiedInstancesSelected` (the explicitly-selected, non-recursive set); the new helper `GetInstancesToSelectAfterPaste` remaps those source names through the existing `oldNewNameDictionary` to find the matching new instances.

- **Drag-drop** and the **top-level paste** path pass `null` and keep the legacy select-all behavior (top-level already pastes `CopiedInstancesSelected` itself, so it's a no-op there).
- **Defensive fallback:** if none of the selected source names map to a new instance (e.g. odd repeat-paste states), it falls back to selecting every new instance.
- The narrowing stays inside the `isSelectionCausedByPaste = true` guard so it doesn't trip `_hasChangedSelectionSinceCopy`.

## Tests

Added `CopyPasteLogicTests` coverage (red-first, then green):

- `OnPaste_Instance_ParentOnlySelected_ShouldSelectOnlyNewParent`
- `OnPaste_Instance_ChildSelected_ShouldSelectOnlyNewChild`
- `OnPaste_MultipleInstances_SubsetSelected_ShouldSelectOnlyNewCopiesOfSelected`

Full `GumToolUnitTests` suite green (924 passed, 4 pre-existing skips). The two `DragDropManagerTests` Moq setups were updated to include the new optional argument matcher (expression trees can't use optional args).

Closes #3269

🤖 Generated with [Claude Code](https://claude.com/claude-code)
