### PR TITLE
Phase 1: neutralize drag-drop (DecideWireframeDragEffect) + delete dead HandleKeyPress

### DIFF
--- a/Gum/Managers/DragAcceptDecision.cs
+++ b/Gum/Managers/DragAcceptDecision.cs
@@ -1,0 +1,17 @@
+namespace Gum.Managers;
+
+/// <summary>
+/// The framework-neutral result of deciding whether a wireframe drag should be
+/// accepted. Produced by <see cref="IDragDropManager.DecideWireframeDragEffect"/>
+/// so the WinForms drag-enter glue in the view can set the drag effect and
+/// surface a blocked reason without the manager naming any WinForms type.
+/// </summary>
+/// <param name="Accept">
+/// True when the drag should be accepted (the view sets the Copy effect).
+/// </param>
+/// <param name="BlockedReason">
+/// A human-readable reason the drop was rejected, for the view to surface in the
+/// output window (#3128); null when the drop is accepted or there is nothing to
+/// report.
+/// </param>
+public sealed record DragAcceptDecision(bool Accept, string? BlockedReason);

--- a/Gum/Managers/DragDropManager.cs
+++ b/Gum/Managers/DragDropManager.cs
@@ -19,13 +19,8 @@ using RenderingLibrary.Content;
 using RenderingLibrary.Graphics;
 using System;
 using System.Collections.Generic;
-using System.Drawing;
 using System.IO;
 using System.Linq;
-using System.Reflection.Metadata;
-using System.Windows.Forms;
-using System.Windows.Navigation;
-using Gum.Extensions;
 using ToolsUtilities;
 using Gum.Plugins.InternalPlugins.TreeView;
 using Gum.Plugins.InternalPlugins.VariableGrid;
@@ -712,11 +707,6 @@ public class DragDropManager : IDragDropManager
         return last;
     }
 
-    public void HandleKeyPress(KeyPressEventArgs e)
-    {
-        int m = 3;
-    }
-
     #endregion
 
     #region General Functions
@@ -1093,24 +1083,25 @@ public class DragDropManager : IDragDropManager
         return null;
     }
 
-    public void OnWireframeDragEnter(object? sender, DragEventArgs e)
+    /// <inheritdoc/>
+    public DragAcceptDecision DecideWireframeDragEffect(bool hasFileDrop, bool hasNodes)
     {
-        var hasFileDrop = e.Data.GetDataPresent(DataFormats.FileDrop);
-        var fileDropBlockedReason = GetFileDropBlockedReason();
-        var canDropFile = hasFileDrop && fileDropBlockedReason == null;
+        string? fileDropBlockedReason = GetFileDropBlockedReason();
+        bool canDropFile = hasFileDrop && fileDropBlockedReason == null;
 
-        var isNodes = e.HasData<List<TreeNode>>() || e.HasData<TreeNode>();
-
-        if (canDropFile || isNodes)
+        if (canDropFile || hasNodes)
         {
-            e.Effect = DragDropEffects.Copy;
+            return new DragAcceptDecision(Accept: true, BlockedReason: null);
         }
-        else if (hasFileDrop && fileDropBlockedReason != null)
+
+        if (hasFileDrop && fileDropBlockedReason != null)
         {
             // The drop is being rejected (no Copy cursor). Surface why so an
             // otherwise-silent "drag+drop stopped working" is diagnosable (#3128).
-            _guiCommands.PrintOutput($"File drag rejected: {fileDropBlockedReason}.");
+            return new DragAcceptDecision(Accept: false, BlockedReason: fileDropBlockedReason);
         }
+
+        return new DragAcceptDecision(Accept: false, BlockedReason: null);
     }
 
     private void SaveAndRefresh()

--- a/Gum/Managers/IDragDropManager.cs
+++ b/Gum/Managers/IDragDropManager.cs
@@ -1,7 +1,6 @@
 using Gum.DataTypes;
 using Gum.Plugins.InternalPlugins.TreeView;
 using System.Collections.Generic;
-using System.Windows.Forms;
 
 namespace Gum.Managers;
 
@@ -33,9 +32,18 @@ public interface IDragDropManager
     /// behavior drops where flat-list semantics do not apply.
     /// </summary>
     void OnNodeSortingDropped(IEnumerable<ITreeNode> draggedNodes, ITreeNode targetNode, DropTarget? dropTarget);
-    void OnWireframeDragEnter(object? sender, DragEventArgs e);
+
+    /// <summary>
+    /// Decides whether a drag entering the wireframe should be accepted, given a
+    /// framework-neutral description of the drag payload. The WinForms drag-enter
+    /// glue in the view inspects the payload (file drop / node payload), calls this,
+    /// then applies the decision (sets the Copy effect, surfaces the blocked reason).
+    /// </summary>
+    /// <param name="hasFileDrop">True when the payload contains dropped files.</param>
+    /// <param name="hasNodes">True when the payload contains tree-node data.</param>
+    DragAcceptDecision DecideWireframeDragEffect(bool hasFileDrop, bool hasNodes);
+
     void SetInstanceToPosition(float worldX, float worldY, InstanceSave instance);
     /// <inheritdoc cref="OnNodeSortingDropped"/>
     bool ValidateNodeSorting(IEnumerable<ITreeNode> draggedNodes, ITreeNode targetNode, DropTarget? dropTarget);
-    void HandleKeyPress(KeyPressEventArgs e);
 }

--- a/Gum/Plugins/InternalPlugins/TreeView/ElementTreeViewCreator.cs
+++ b/Gum/Plugins/InternalPlugins/TreeView/ElementTreeViewCreator.cs
@@ -56,7 +56,6 @@ internal class ElementTreeViewCreator
     /// <param name="onAfterClickSelect">Handler for AfterClickSelect on the tree view.</param>
     /// <param name="onAfterSelect">Handler for AfterSelect on the tree view.</param>
     /// <param name="onKeyDown">Handler for KeyDown on the tree view.</param>
-    /// <param name="onKeyPress">Handler for KeyPress on the tree view.</param>
     /// <param name="onMouseClick">Handler for MouseClick on the tree view.</param>
     /// <param name="onMouseMove">Handler for mouse move (x, y) on the tree view.</param>
     /// <param name="onFontChanged">Handler for FontChanged on the tree view.</param>
@@ -75,7 +74,6 @@ internal class ElementTreeViewCreator
         TreeViewEventHandler onAfterClickSelect,
         TreeViewEventHandler onAfterSelect,
         KeyEventHandler onKeyDown,
-        KeyPressEventHandler onKeyPress,
         MouseEventHandler onMouseClick,
         Action<int, int> onMouseMove,
         EventHandler onFontChanged,
@@ -92,7 +90,7 @@ internal class ElementTreeViewCreator
         Action onDeepSearchChecked)
     {
         CreateObjectTreeView(
-            onAfterClickSelect, onAfterSelect, onKeyDown, onKeyPress,
+            onAfterClickSelect, onAfterSelect, onKeyDown,
             onMouseClick, onMouseMove, onFontChanged, onDragOver, onDragDrop,
             onQueryContinueDrag, onValidateSortingDrop, onNodeSortingDropped, onGiveFeedback);
 
@@ -180,7 +178,6 @@ internal class ElementTreeViewCreator
         TreeViewEventHandler onAfterClickSelect,
         TreeViewEventHandler onAfterSelect,
         KeyEventHandler onKeyDown,
-        KeyPressEventHandler onKeyPress,
         MouseEventHandler onMouseClick,
         Action<int, int> onMouseMove,
         EventHandler onFontChanged,
@@ -210,7 +207,6 @@ internal class ElementTreeViewCreator
         this.ObjectTreeView.AfterClickSelect += onAfterClickSelect;
         this.ObjectTreeView.AfterSelect += onAfterSelect;
         this.ObjectTreeView.KeyDown += onKeyDown;
-        this.ObjectTreeView.KeyPress += onKeyPress;
         this.ObjectTreeView.PreviewKeyDown += (_, _) => { };
         this.ObjectTreeView.MouseClick += onMouseClick;
         this.ObjectTreeView.BackColor =

--- a/Gum/Plugins/InternalPlugins/TreeView/ElementTreeViewManager.cs
+++ b/Gum/Plugins/InternalPlugins/TreeView/ElementTreeViewManager.cs
@@ -677,7 +677,6 @@ public partial class ElementTreeViewManager : IRecipient<ThemeChangedMessage>, I
             onAfterClickSelect: this.ObjectTreeView_AfterClickSelect,
             onAfterSelect: this.ObjectTreeView_AfterSelect_1,
             onKeyDown: this.ObjectTreeView_KeyDown,
-            onKeyPress: this.ObjectTreeView_KeyPress,
             onMouseClick: this.ObjectTreeView_MouseClick,
             onMouseMove: (x, y) => HandleMouseOver(x, y),
             onFontChanged: (sender, _) =>
@@ -851,11 +850,6 @@ public partial class ElementTreeViewManager : IRecipient<ThemeChangedMessage>, I
     void IRecipient<ThemeChangedMessage>.Receive(ThemeChangedMessage message)
     {
         _viewCreator.ApplyThemeColors();
-    }
-
-    private void ObjectTreeView_KeyPress(object? sender, KeyPressEventArgs e)
-    {
-        _dragDropManager.HandleKeyPress(e);
     }
 
     private void DelayExpandHoveredNode(TreeNode hoveredNode)

--- a/Tool/EditorTabPlugin_XNA/MainEditorTabPlugin.cs
+++ b/Tool/EditorTabPlugin_XNA/MainEditorTabPlugin.cs
@@ -807,7 +807,7 @@ internal class MainEditorTabPlugin : PriorityPlugin, IRecipient<UiBaseFontSizeCh
 
 
         this._wireframeControl.DragDrop += OnWireframeDrop;
-        this._wireframeControl.DragEnter += _dragDropManager.OnWireframeDragEnter;
+        this._wireframeControl.DragEnter += OnWireframeDragEnter;
         this._wireframeControl.DragOver += (sender, e) =>
         {
             // Intentionally does NOT set e.Effect. The effect is chosen once in
@@ -850,6 +850,26 @@ internal class MainEditorTabPlugin : PriorityPlugin, IRecipient<UiBaseFontSizeCh
 
         IEffectiveThemeSettings themeSettings = Locator.GetRequiredService<IThemingService>().EffectiveSettings;
         ApplyThemeSettings(themeSettings);
+    }
+
+    internal void OnWireframeDragEnter(object? sender, System.Windows.Forms.DragEventArgs e)
+    {
+        // WinForms glue only: inspect the drag payload, ask the neutral manager
+        // whether to accept it, then apply the decision. The accept/reject logic
+        // itself lives in DragDropManager.DecideWireframeDragEffect.
+        bool hasFileDrop = e.Data.GetDataPresent(System.Windows.Forms.DataFormats.FileDrop);
+        bool hasNodes = e.HasData<List<TreeNode>>() || e.HasData<TreeNode>();
+
+        DragAcceptDecision decision = _dragDropManager.DecideWireframeDragEffect(hasFileDrop, hasNodes);
+
+        if (decision.Accept)
+        {
+            e.Effect = System.Windows.Forms.DragDropEffects.Copy;
+        }
+        else if (decision.BlockedReason != null)
+        {
+            _guiCommands.PrintOutput($"File drag rejected: {decision.BlockedReason}.");
+        }
     }
 
     internal void OnWireframeDrop(object? sender, System.Windows.Forms.DragEventArgs e)

--- a/Tool/Tests/GumToolUnitTests/Managers/DragDropManagerTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Managers/DragDropManagerTests.cs
@@ -955,6 +955,60 @@ public class DragDropManagerTests : BaseTestClass
     }
 
     [Fact]
+    public void DecideWireframeDragEffect_FilesAllowed_Accepts()
+    {
+        // A file drop with a Screen/Component + state selected is allowed, so
+        // GetFileDropBlockedReason() returns null and the drop is accepted.
+        ComponentSave component = new ComponentSave { Name = "MyComponent" };
+        StateSave state = new StateSave { Name = "Default" };
+        _mocker.GetMock<ISelectedState>().Setup(x => x.SelectedElement).Returns(component);
+        _mocker.GetMock<ISelectedState>().Setup(x => x.SelectedStateSave).Returns(state);
+
+        DragAcceptDecision decision = _dragDropManager.DecideWireframeDragEffect(hasFileDrop: true, hasNodes: false);
+
+        decision.Accept.ShouldBeTrue();
+        decision.BlockedReason.ShouldBeNull();
+    }
+
+    [Fact]
+    public void DecideWireframeDragEffect_Neither_Rejects()
+    {
+        // Neither a file drop nor a node payload: nothing to accept, nothing to
+        // surface as a blocked reason.
+        DragAcceptDecision decision = _dragDropManager.DecideWireframeDragEffect(hasFileDrop: false, hasNodes: false);
+
+        decision.Accept.ShouldBeFalse();
+        decision.BlockedReason.ShouldBeNull();
+    }
+
+    [Fact]
+    public void DecideWireframeDragEffect_Nodes_Accepts()
+    {
+        // A node payload is always accepted regardless of selection state — even
+        // when a file drop would be blocked, the node drop still wins.
+        DragAcceptDecision decision = _dragDropManager.DecideWireframeDragEffect(hasFileDrop: false, hasNodes: true);
+
+        decision.Accept.ShouldBeTrue();
+        decision.BlockedReason.ShouldBeNull();
+    }
+
+    [Fact]
+    public void DecideWireframeDragEffect_FilesBlocked_RejectsAndSurfacesReason()
+    {
+        // A file drop while a Standard element is selected is blocked (#3128): the
+        // drop is rejected and the reason is surfaced so the otherwise-silent
+        // failure is diagnosable.
+        StandardElementSave standardElement = new StandardElementSave { Name = "Sprite" };
+        _mocker.GetMock<ISelectedState>().Setup(x => x.SelectedStandardElement).Returns(standardElement);
+
+        DragAcceptDecision decision = _dragDropManager.DecideWireframeDragEffect(hasFileDrop: true, hasNodes: false);
+
+        decision.Accept.ShouldBeFalse();
+        decision.BlockedReason.ShouldNotBeNull();
+        decision.BlockedReason.ShouldContain("Sprite");
+    }
+
+    [Fact]
     public void GetFileDropBlockedReason_ReturnsNull_WhenComponentAndStateSelected()
     {
         ComponentSave component = new ComponentSave { Name = "MyComponent" };


### PR DESCRIPTION
Part of the Phase-1 UI/logic decoupling effort (umbrella #3225). Drag-drop half of the Keys/drag-drop slice; sibling of PR A (#3267, merged). See `.claude/designs/direction-ui-decoupling/keys-dragdrop-slice-proposal.md` §4 "PR B".

Drag-drop was already ~90% decoupled — only two `IDragDropManager` members named a WinForms type, and one of them was dead. This finishes the job: after it, **`DragDropManager.cs` references zero WinForms types** and `IDragDropManager` is fully neutral.

## What changed

**1. Neutralize the drag-enter decision.** Extracted the accept/effect logic out of `OnWireframeDragEnter(object?, DragEventArgs)` into a pure, framework-neutral method:

```csharp
DragAcceptDecision DecideWireframeDragEffect(bool hasFileDrop, bool hasNodes);
// DragAcceptDecision { bool Accept; string? BlockedReason }
```

It reuses the already-neutral `GetFileDropBlockedReason()`. `OnWireframeDragEnter` is removed from `IDragDropManager`. The WinForms glue — `e.Data.GetDataPresent(FileDrop)`, `e.HasData<List<TreeNode>>()`, `e.Effect = DragDropEffects.Copy`, and the blocked-reason print (#3128) — now lives in the view (`MainEditorTabPlugin`), where the `DragEnter +=` wiring already was. Behavior is identical.

**2. Delete dead `HandleKeyPress`.** `HandleKeyPress(KeyPressEventArgs)` (body was literally `int m = 3;`) is removed from `IDragDropManager` + `DragDropManager`, along with the `ObjectTreeView_KeyPress` relay and the now-dead `onKeyPress` parameter chain through `ElementTreeViewManager` → `ElementTreeViewCreator` (single caller). Dead-code deletion, test-exempt (same class as #3242/#3246/#3261).

**3. Drop unused usings.** Removed `System.Windows.Forms` and `System.Drawing` (plus stray `System.Reflection.Metadata`, `System.Windows.Navigation`, and `Gum.Extensions`, whose only consumer was the removed `e.HasData<>`) from `DragDropManager.cs`.

The WinForms `TreeNode` payload inspection stays in the view — it's tied to the WinForms tree (= Phase 4a), out of scope here.

## Tests

Pinned the extracted decision (characterization, since an extraction is not a pure rename):

- files + allowed selection → Accept, no reason
- node payload → Accept (wins even when a file drop would be blocked)
- files + blocked (Standard element selected) → reject + reason surfaced (#3128)
- neither → reject, no reason

Full suite green: **929 GumToolUnitTests** (4 pre-existing skips), and `GumFull.sln` builds with 0 errors.

## Manual test — needed (drag-drop is runtime input)

1. Open a project, select a Screen/Component with a Default state → drag a `.png` from Explorer onto the canvas → **accepted** (Copy cursor), texture applies.
2. Select a Standard element (e.g. Sprite), drag a file onto the canvas → **rejected**; Output window shows `File drag rejected: a Standard element (...) is selected ...` (#3128).
3. Drag a component from the tree onto the canvas → instance added at cursor.
4. Reorder instances within the tree (before/after/into) → still correct (regression guard for the already-neutral drop paths).

## Out of scope

PR C (neutralize the hotkey *handler method signatures* via `GumKeyInput` + `IModifierKeyState`) is deferred to Phase 4b per the locked decision in the proposal §8 — not started here.

Closes #3271

🤖 Generated with [Claude Code](https://claude.com/claude-code)
