### PR TITLE
Phase 2 (static drain): SettingsManager singleton -> ISettingsManager plugin instance

### DIFF
--- a/Gum/StateAnimationPlugin/MainStateAnimationPlugin.cs
+++ b/Gum/StateAnimationPlugin/MainStateAnimationPlugin.cs
@@ -44,7 +44,7 @@ public class MainStateAnimationPlugin : PluginBase
     private readonly AnimationFilePathService _animationFilePathService;
     private readonly ElementDeleteService _elementDeleteService;
     private readonly RenameManager _renameManager;
-    private readonly SettingsManager _settingsManager;
+    private readonly ISettingsManager _settingsManager;
     private readonly IProjectState _projectState;
     private readonly AnimationCollectionViewModelManager _animationCollectionViewModelManager;
     ElementAnimationsViewModel? _viewModel;
@@ -97,7 +97,7 @@ public class MainStateAnimationPlugin : PluginBase
         _animationFilePathService = new AnimationFilePathService();
         _elementDeleteService = new ElementDeleteService(_animationFilePathService);
         _renameManager = RenameManager.Self;
-        _settingsManager = SettingsManager.Self;
+        _settingsManager = new SettingsManager();
         _projectState = Locator.GetRequiredService<IProjectState>();
         _animationCollectionViewModelManager = AnimationCollectionViewModelManager.Self;
     }

--- a/Gum/StateAnimationPlugin/Managers/ISettingsManager.cs
+++ b/Gum/StateAnimationPlugin/Managers/ISettingsManager.cs
@@ -1,0 +1,26 @@
+using StateAnimationPlugin.Models;
+
+namespace StateAnimationPlugin.Managers
+{
+    /// <summary>
+    /// Loads and persists the State Animation plugin's global settings.
+    /// </summary>
+    public interface ISettingsManager
+    {
+        /// <summary>
+        /// The current global settings. Populated by <see cref="LoadOrCreateSettings"/> and
+        /// persisted by <see cref="SaveSettings"/>.
+        /// </summary>
+        AnimationPluginSettings GlobalSettings { get; }
+
+        /// <summary>
+        /// Loads the global settings from disk, falling back to defaults when no settings file exists.
+        /// </summary>
+        void LoadOrCreateSettings();
+
+        /// <summary>
+        /// Writes the current global settings to disk, creating the containing directory if needed.
+        /// </summary>
+        void SaveSettings();
+    }
+}

--- a/Gum/StateAnimationPlugin/Managers/SettingsManager.cs
+++ b/Gum/StateAnimationPlugin/Managers/SettingsManager.cs
@@ -1,57 +1,66 @@
-﻿using Gum.Managers;
 using Newtonsoft.Json;
 using StateAnimationPlugin.Models;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using ToolsUtilities;
 
 namespace StateAnimationPlugin.Managers
 {
-    public class SettingsManager : Singleton<SettingsManager>
+    /// <summary>
+    /// Loads and persists the State Animation plugin's global settings to a JSON file.
+    /// Instantiated by <see cref="MainStateAnimationPlugin"/>; not an app-wide service.
+    /// </summary>
+    public class SettingsManager : ISettingsManager
     {
-        public AnimationPluginSettings GlobalSettings { get; private set; } = new();
+        private readonly FilePath _globalSettingsFilePath;
 
-        FilePath GlobalSettingsFilePath
+        /// <inheritdoc/>
+        public AnimationPluginSettings GlobalSettings { get; private set; }
+
+        /// <summary>
+        /// Creates a new <see cref="SettingsManager"/>.
+        /// </summary>
+        /// <param name="globalSettingsFilePath">
+        /// The file the global settings are read from and written to. When null (the default used
+        /// by the running tool), the per-user application-data location is used.
+        /// </param>
+        public SettingsManager(FilePath? globalSettingsFilePath = null)
         {
-            get
-            {
-                return Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + 
-                    @"\Gum\AnimationPlugin\GlobalAnimationSettings.json";
-            }
+            GlobalSettings = new AnimationPluginSettings();
+            _globalSettingsFilePath = globalSettingsFilePath ?? new FilePath(
+                Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) +
+                    @"\Gum\AnimationPlugin\GlobalAnimationSettings.json");
         }
 
+        /// <inheritdoc/>
         public void LoadOrCreateSettings()
         {
-            if (GlobalSettingsFilePath.Exists())
+            if (_globalSettingsFilePath.Exists())
             {
-                var text = System.IO.File.ReadAllText(GlobalSettingsFilePath.FullPath);
+                var text = System.IO.File.ReadAllText(_globalSettingsFilePath.FullPath);
 
                 GlobalSettings = JsonConvert.DeserializeObject<AnimationPluginSettings>(text) ??
                     new AnimationPluginSettings();
             }
 
-            if(GlobalSettings == null)
+            if (GlobalSettings == null)
             {
                 GlobalSettings = new AnimationPluginSettings();
-
             }
         }
 
+        /// <inheritdoc/>
         public void SaveSettings()
         {
             var text = JsonConvert.SerializeObject(GlobalSettings);
 
-            var directory = GlobalSettingsFilePath.GetDirectoryContainingThis();
+            var directory = _globalSettingsFilePath.GetDirectoryContainingThis();
 
-            if(directory != null)
+            if (directory != null)
             {
                 System.IO.Directory.CreateDirectory(directory.FullPath);
             }
 
-            System.IO.File.WriteAllText(GlobalSettingsFilePath.FullPath, text);
+            System.IO.File.WriteAllText(_globalSettingsFilePath.FullPath, text);
         }
     }
 }

--- a/Tool/Tests/GumToolUnitTests/GumToolUnitTests.csproj
+++ b/Tool/Tests/GumToolUnitTests/GumToolUnitTests.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <!-- Matches StateAnimationPlugin's TFM so it can be referenced (it pins 10.0.19041 for SkiaSharp.Views.WPF). -->
+    <TargetFramework>net8.0-windows10.0.19041</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -29,6 +30,7 @@
     <ProjectReference Include="..\..\..\Gum\Gum.csproj" />
     <ProjectReference Include="..\..\..\Gum\GumFormsPlugin\GumFormsPlugin.csproj" />
     <ProjectReference Include="..\..\..\Gum\ImportFromGumxPlugin\ImportFromGumxPlugin.csproj" />
+    <ProjectReference Include="..\..\..\Gum\StateAnimationPlugin\StateAnimationPlugin.csproj" />
     <ProjectReference Include="..\..\..\Gum\TextureCoordinateSelectionPlugin\TextureCoordinateSelectionPlugin.csproj" />
     <ProjectReference Include="..\..\EditorTabPlugin_XNA\EditorTabPlugin_XNA.csproj" />
   </ItemGroup>

--- a/Tool/Tests/GumToolUnitTests/Plugins/StateAnimationPlugin/SettingsManagerTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/StateAnimationPlugin/SettingsManagerTests.cs
@@ -1,0 +1,68 @@
+using Shouldly;
+using StateAnimationPlugin.Managers;
+using System;
+using System.IO;
+using ToolsUtilities;
+using Xunit;
+
+namespace GumToolUnitTests.Plugins.StateAnimationPlugin;
+
+public class SettingsManagerTests : BaseTestClass
+{
+    private readonly string _tempDirectory;
+
+    public SettingsManagerTests()
+    {
+        _tempDirectory = Path.Combine(
+            Path.GetTempPath(), "GumSettingsManagerTests", Guid.NewGuid().ToString("N"));
+    }
+
+    [Fact]
+    public void LoadOrCreateSettings_leaves_defaults_when_file_missing()
+    {
+        FilePath settingsFile = new FilePath(Path.Combine(_tempDirectory, "GlobalAnimationSettings.json"));
+        SettingsManager settingsManager = new SettingsManager(settingsFile);
+
+        settingsManager.LoadOrCreateSettings();
+
+        settingsManager.GlobalSettings.ShouldNotBeNull();
+        settingsManager.GlobalSettings.FirstToSecondColumnRatio.ShouldBe(1m);
+    }
+
+    [Fact]
+    public void LoadOrCreateSettings_round_trips_saved_settings()
+    {
+        FilePath settingsFile = new FilePath(Path.Combine(_tempDirectory, "GlobalAnimationSettings.json"));
+
+        SettingsManager toSave = new SettingsManager(settingsFile);
+        toSave.GlobalSettings.FirstToSecondColumnRatio = 2.5m;
+        toSave.SaveSettings();
+
+        SettingsManager toLoad = new SettingsManager(settingsFile);
+        toLoad.LoadOrCreateSettings();
+
+        toLoad.GlobalSettings.FirstToSecondColumnRatio.ShouldBe(2.5m);
+    }
+
+    [Fact]
+    public void SaveSettings_creates_missing_directory()
+    {
+        FilePath settingsFile = new FilePath(
+            Path.Combine(_tempDirectory, "nested", "GlobalAnimationSettings.json"));
+        SettingsManager settingsManager = new SettingsManager(settingsFile);
+
+        settingsManager.SaveSettings();
+
+        File.Exists(settingsFile.FullPath).ShouldBeTrue();
+    }
+
+    public override void Dispose()
+    {
+        if (Directory.Exists(_tempDirectory))
+        {
+            Directory.Delete(_tempDirectory, recursive: true);
+        }
+
+        base.Dispose();
+    }
+}


### PR DESCRIPTION
## Phase 2 (static drain): `SettingsManager` → `ISettingsManager` plugin instance

Continues the tool UI/logic decoupling **Phase 2** (drain `.Self`/`Singleton<T>` statics to constructor injection). Prior slices: `ProjectManager` (#3253), `GumCommands`→`IRetryService` (#3275), `CommandLineManager`→`ICommandLineManager` (#3277).

This is the **first member of the StateAnimationPlugin `Singleton<T>` cluster** to be drained, and the slice that establishes the **plugin-internal instantiation** pattern for the rest of that cluster (`BitmapLoader` / `RenameManager` / `AnimationCollectionViewModelManager`).

### What changed
- `SettingsManager` no longer derives from `Singleton<SettingsManager>`. `MainStateAnimationPlugin` constructs it directly (`new SettingsManager()`) behind a new **`ISettingsManager`** interface — alongside the plugin's existing `new`-constructed `DuplicateService` / `AnimationFilePathService` / `ElementDeleteService`.
- Per `code-style.md`, it is a **plugin-specific** service, so it is instantiated **inside the plugin, not registered in `Builder.cs`** (mirrors the canonical `ITreeViewStateService`/`TreeViewStateService` precedent). The `.Self` is moved up to the plugin level, as the style rule prescribes.
- **Testability seam:** the settings file path (a hardcoded `%AppData%\Gum\AnimationPlugin\GlobalAnimationSettings.json` computed property) becomes an optional constructor parameter that **defaults to that exact path**, so the class is constructable in isolation. Pinned with 3 `SettingsManagerTests` (load/save round-trip, defaults-when-missing, directory-created-on-save).
- Boyscout: moved `GlobalSettings` init into the ctor (style rule), added braces to single-line `if`s (style rule), trimmed unused `using`s.

### Blast radius
Single consumer (`MainStateAnimationPlugin`); **no dependencies → no construction cycle** (no `Lazy<T>` needed). The other three cluster members are untouched (one-singleton-per-PR discipline).

### Build/test plumbing
`GumToolUnitTests` now references `StateAnimationPlugin`. The plugin pins `net8.0-windows10.0.19041` (for `SkiaSharp.Views.WPF`), so the test project's TFM was raised from `net8.0-windows` to match (a consumer's Windows platform version must be ≥ the referenced library's; the dev machine and CI already build the plugin, so the SDK floor is satisfied).

### Verification
- Full `GumToolUnitTests` green: **939 passed / 0 failed / 4 skipped** (baseline 936 + 3 new).
- `GumFull.sln`: **0 errors**, 0 new warnings (the changed files produce none).

### Manual test
**Not needed** — plugin-internal instance drain with no `Builder.cs`/composition-root wiring change; production `new SettingsManager()` resolves to the byte-identical default path. Compiler + the round-trip unit test are the proof.

Closes #3278

🤖 Generated with [Claude Code](https://claude.com/claude-code)
