### PR TITLE
Phase 2 (static drain): ACVMM + RenameManager singletons -> constructor injection (#3280)

### DIFF
--- a/Gum/StateAnimationPlugin/MainStateAnimationPlugin.cs
+++ b/Gum/StateAnimationPlugin/MainStateAnimationPlugin.cs
@@ -4,6 +4,7 @@ using Gum;
 using Gum.Commands;
 using Gum.DataTypes;
 using Gum.DataTypes.Variables;
+using Gum.Logic.FileWatch;
 using Gum.Managers;
 using Gum.Messages;
 using Gum.Plugins;
@@ -37,16 +38,18 @@ public class MainStateAnimationPlugin : PluginBase
     private readonly ISelectedState _selectedState;
     private readonly INameVerifier _nameVerifier;
     private readonly IMessenger _messenger;
+    private readonly IOutputManager _outputManager;
+    private readonly IFileWatchManager _fileWatchManager;
     private readonly Func<ElementAnimationsViewModel> _animationVmFactory;
 
     #region Fields
     private readonly DuplicateService _duplicateService;
     private readonly AnimationFilePathService _animationFilePathService;
     private readonly ElementDeleteService _elementDeleteService;
-    private readonly RenameManager _renameManager;
+    private readonly IRenameManager _renameManager;
     private readonly ISettingsManager _settingsManager;
     private readonly IProjectState _projectState;
-    private readonly AnimationCollectionViewModelManager _animationCollectionViewModelManager;
+    private readonly IAnimationCollectionViewModelManager _animationCollectionViewModelManager;
     ElementAnimationsViewModel? _viewModel;
 
     StateAnimationPlugin.Views.MainWindow? _mainWindow;
@@ -91,15 +94,24 @@ public class MainStateAnimationPlugin : PluginBase
         _selectedState = Locator.GetRequiredService<ISelectedState>();
         _nameVerifier = Locator.GetRequiredService<INameVerifier>();
         _messenger = Locator.GetRequiredService<IMessenger>();
-
-        _animationVmFactory = () => new ElementAnimationsViewModel(_nameVerifier, _dialogService);
-        _duplicateService = new DuplicateService();
-        _animationFilePathService = new AnimationFilePathService();
-        _elementDeleteService = new ElementDeleteService(_animationFilePathService);
-        _renameManager = RenameManager.Self;
-        _settingsManager = new SettingsManager();
+        _outputManager = Locator.GetRequiredService<IOutputManager>();
+        _fileWatchManager = Locator.GetRequiredService<IFileWatchManager>();
         _projectState = Locator.GetRequiredService<IProjectState>();
-        _animationCollectionViewModelManager = AnimationCollectionViewModelManager.Self;
+
+        _animationFilePathService = new AnimationFilePathService(_selectedState);
+        _duplicateService = new DuplicateService();
+        _elementDeleteService = new ElementDeleteService(_animationFilePathService);
+        _settingsManager = new SettingsManager();
+
+        // The factory closure reads _animationCollectionViewModelManager and _renameManager lazily
+        // (when invoked, after both are assigned just below), which breaks the
+        // ACVMM -> ElementAnimationsViewModel -> RenameManager construction cycle without a Lazy<T>.
+        _animationVmFactory = () => new ElementAnimationsViewModel(
+            _nameVerifier, _dialogService, _animationCollectionViewModelManager, _renameManager);
+        _animationCollectionViewModelManager = new AnimationCollectionViewModelManager(
+            _selectedState, _outputManager, _fileWatchManager, _animationFilePathService, _animationVmFactory);
+        _renameManager = new RenameManager(
+            _selectedState, _outputManager, _animationFilePathService, _animationCollectionViewModelManager);
     }
 
     public override void StartUp()
@@ -308,7 +320,7 @@ public class MainStateAnimationPlugin : PluginBase
         }
 
         // forces a refresh:
-        _viewModel = new ElementAnimationsViewModel(_nameVerifier, _dialogService);
+        _viewModel = _animationVmFactory();
 
         RefreshViewModel();
     }
@@ -496,7 +508,7 @@ public class MainStateAnimationPlugin : PluginBase
         
         if (_viewModel == null)
         {
-            _viewModel = new(_nameVerifier, _dialogService);
+            _viewModel = _animationVmFactory();
         }
         if(currentlyReferencedElement != null)
         {

--- a/Gum/StateAnimationPlugin/Managers/AnimationCollectionViewModelManager.cs
+++ b/Gum/StateAnimationPlugin/Managers/AnimationCollectionViewModelManager.cs
@@ -1,44 +1,45 @@
-﻿using Gum.DataTypes;
+using Gum.DataTypes;
 using Gum.Logic.FileWatch;
 using Gum.Managers;
 using Gum.ToolStates;
 using Gum.StateAnimation.SaveClasses;
 using StateAnimationPlugin.ViewModels;
 using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using ToolsUtilities;
-using Gum.Services;
-using Gum.Services.Dialogs;
 
 namespace StateAnimationPlugin.Managers;
 
-public class AnimationCollectionViewModelManager : Singleton<AnimationCollectionViewModelManager>
+/// <summary>
+/// Loads and saves an element's animations, bridging the on-disk <see cref="ElementAnimationsSave"/>
+/// and the editable <see cref="ElementAnimationsViewModel"/>. Instantiated by
+/// <see cref="MainStateAnimationPlugin"/>; not an app-wide service.
+/// </summary>
+public class AnimationCollectionViewModelManager : IAnimationCollectionViewModelManager
 {
-    AnimationFilePathService _animationFilePathService;
+    private readonly IAnimationFilePathService _animationFilePathService;
     private readonly ISelectedState _selectedState;
-    private readonly INameVerifier _nameVerifier;
     private readonly IFileWatchManager _fileWatchManager;
     private readonly Func<ElementAnimationsViewModel> _animationVmFactory;
     private readonly IOutputManager _outputManager;
 
-    public AnimationCollectionViewModelManager()
+    public AnimationCollectionViewModelManager(
+        ISelectedState selectedState,
+        IOutputManager outputManager,
+        IFileWatchManager fileWatchManager,
+        IAnimationFilePathService animationFilePathService,
+        Func<ElementAnimationsViewModel> animationVmFactory)
     {
-        _animationFilePathService = new AnimationFilePathService();
-        _selectedState = Locator.GetRequiredService<ISelectedState>();
-        _nameVerifier = Locator.GetRequiredService<INameVerifier>();
-        _outputManager = Locator.GetRequiredService<IOutputManager>();
-        IDialogService dialogService = Locator.GetRequiredService<IDialogService>();
-        _fileWatchManager = Locator.GetRequiredService<IFileWatchManager>();
-        _animationVmFactory = () => new(_nameVerifier, dialogService);
+        _selectedState = selectedState;
+        _outputManager = outputManager;
+        _fileWatchManager = fileWatchManager;
+        _animationFilePathService = animationFilePathService;
+        _animationVmFactory = animationVmFactory;
     }
 
+    /// <inheritdoc/>
     public ElementAnimationsViewModel? GetAnimationCollectionViewModel(ElementSave? element)
     {
-        if(element == null)
+        if (element == null)
         {
             return null;
         }
@@ -53,21 +54,19 @@ public class AnimationCollectionViewModelManager : Singleton<AnimationCollection
         toReturn.Element = element;
 
         return toReturn;
-
     }
 
+    /// <inheritdoc/>
     public ElementAnimationsSave? GetElementAnimationsSave(ElementSave element)
     {
         ElementAnimationsSave? model = null;
         var fileName = _animationFilePathService.GetAbsoluteAnimationFileNameFor(element);
-
 
         if (fileName?.Exists() == true)
         {
             try
             {
                 model = FileManager.XmlDeserialize<ElementAnimationsSave>(fileName.FullPath);
-
             }
             catch (Exception exception)
             {
@@ -78,6 +77,7 @@ public class AnimationCollectionViewModelManager : Singleton<AnimationCollection
         return model;
     }
 
+    /// <inheritdoc/>
     public void Save(ElementAnimationsViewModel viewModel)
     {
         var currentElement = _selectedState.SelectedElement;
@@ -89,7 +89,7 @@ public class AnimationCollectionViewModelManager : Singleton<AnimationCollection
 
         var fileName = _animationFilePathService.GetAbsoluteAnimationFileNameFor(currentElement);
 
-        if(fileName != null)
+        if (fileName != null)
         {
             var save = viewModel.ToSave();
 
@@ -97,6 +97,4 @@ public class AnimationCollectionViewModelManager : Singleton<AnimationCollection
             FileManager.XmlSerialize(save, fileName.FullPath);
         }
     }
-
-
 }

--- a/Gum/StateAnimationPlugin/Managers/AnimationFilePathService.cs
+++ b/Gum/StateAnimationPlugin/Managers/AnimationFilePathService.cs
@@ -1,5 +1,4 @@
 ﻿using Gum.DataTypes;
-using Gum.Services;
 using Gum.ToolStates;
 using System;
 using System.Collections.Generic;
@@ -10,14 +9,16 @@ using ToolsUtilities;
 
 namespace StateAnimationPlugin.Managers;
 
-internal class AnimationFilePathService
+public class AnimationFilePathService : IAnimationFilePathService
 {
     private readonly ISelectedState _selectedState;
-    public AnimationFilePathService()
+
+    public AnimationFilePathService(ISelectedState selectedState)
     {
-        _selectedState = _selectedState = Locator.GetRequiredService<ISelectedState>();
+        _selectedState = selectedState;
     }
-    
+
+    /// <inheritdoc/>
     public FilePath? GetAbsoluteAnimationFileNameFor(string elementName)
     {
         var selectedElement = _selectedState.SelectedElement;
@@ -37,6 +38,7 @@ internal class AnimationFilePathService
         }
     }
 
+    /// <inheritdoc/>
     public FilePath? GetAbsoluteAnimationFileNameFor(ElementSave elementSave)
     {
         var fullPathXmlForElement = elementSave.GetFullPathXmlFile();

--- a/Gum/StateAnimationPlugin/Managers/IAnimationCollectionViewModelManager.cs
+++ b/Gum/StateAnimationPlugin/Managers/IAnimationCollectionViewModelManager.cs
@@ -1,0 +1,29 @@
+using Gum.DataTypes;
+using Gum.StateAnimation.SaveClasses;
+using StateAnimationPlugin.ViewModels;
+
+namespace StateAnimationPlugin.Managers;
+
+/// <summary>
+/// Loads and saves an element's animations, bridging the on-disk <see cref="ElementAnimationsSave"/>
+/// and the editable <see cref="ElementAnimationsViewModel"/>.
+/// </summary>
+public interface IAnimationCollectionViewModelManager
+{
+    /// <summary>
+    /// Builds an <see cref="ElementAnimationsViewModel"/> for the given element, loading any
+    /// persisted animations. Returns null when <paramref name="element"/> is null.
+    /// </summary>
+    ElementAnimationsViewModel? GetAnimationCollectionViewModel(ElementSave? element);
+
+    /// <summary>
+    /// Loads the persisted <see cref="ElementAnimationsSave"/> for the given element, or null when
+    /// there is no animation file (or it fails to deserialize).
+    /// </summary>
+    ElementAnimationsSave? GetElementAnimationsSave(ElementSave element);
+
+    /// <summary>
+    /// Persists the given view model's animations to the selected element's animation file.
+    /// </summary>
+    void Save(ElementAnimationsViewModel viewModel);
+}

--- a/Gum/StateAnimationPlugin/Managers/IAnimationFilePathService.cs
+++ b/Gum/StateAnimationPlugin/Managers/IAnimationFilePathService.cs
@@ -1,0 +1,22 @@
+using Gum.DataTypes;
+using ToolsUtilities;
+
+namespace StateAnimationPlugin.Managers;
+
+/// <summary>
+/// Resolves the absolute path of an element's animation (.ganx) file.
+/// </summary>
+public interface IAnimationFilePathService
+{
+    /// <summary>
+    /// Returns the absolute animation file path for the currently selected element, named after
+    /// <paramref name="elementName"/>. Returns null when no element is selected.
+    /// </summary>
+    FilePath? GetAbsoluteAnimationFileNameFor(string elementName);
+
+    /// <summary>
+    /// Returns the absolute animation file path for the given element, or null when the element's
+    /// XML path cannot be resolved (e.g. no project is loaded).
+    /// </summary>
+    FilePath? GetAbsoluteAnimationFileNameFor(ElementSave elementSave);
+}

--- a/Gum/StateAnimationPlugin/Managers/IRenameManager.cs
+++ b/Gum/StateAnimationPlugin/Managers/IRenameManager.cs
@@ -1,0 +1,20 @@
+using Gum.DataTypes;
+using Gum.DataTypes.Variables;
+using StateAnimationPlugin.ViewModels;
+using System.Collections.Generic;
+
+namespace StateAnimationPlugin.Managers;
+
+/// <summary>
+/// Propagates element/instance/state/animation renames into the affected animation view models and
+/// animation files.
+/// </summary>
+public interface IRenameManager
+{
+    void HandleRename(ElementSave elementSave, string oldName, ElementAnimationsViewModel viewModel);
+    void HandleRename(InstanceSave instanceSave, string oldName, ElementAnimationsViewModel viewModel);
+    void HandleRename(StateSave stateSave, string oldName, ElementAnimationsViewModel viewModel);
+    void HandleRename(StateSaveCategory category, string oldName, ElementAnimationsViewModel viewModel);
+    void HandleRename(AnimationViewModel animationViewModel, string oldAnimationName,
+        IEnumerable<AnimationViewModel> animations, ElementSave element);
+}

--- a/Gum/StateAnimationPlugin/Managers/RenameManager.cs
+++ b/Gum/StateAnimationPlugin/Managers/RenameManager.cs
@@ -15,17 +15,23 @@ using Gum.Services;
 
 namespace StateAnimationPlugin.Managers
 {
-    class RenameManager : Singleton<RenameManager>
+    public class RenameManager : IRenameManager
     {
-        private readonly AnimationFilePathService _animationFilePathService;
+        private readonly IAnimationFilePathService _animationFilePathService;
         private readonly ISelectedState _selectedState;
         private readonly IOutputManager _outputManager;
+        private readonly IAnimationCollectionViewModelManager _animationCollectionViewModelManager;
 
-        public RenameManager()
+        public RenameManager(
+            ISelectedState selectedState,
+            IOutputManager outputManager,
+            IAnimationFilePathService animationFilePathService,
+            IAnimationCollectionViewModelManager animationCollectionViewModelManager)
         {
-            _animationFilePathService = new AnimationFilePathService();
-            _selectedState = Locator.GetRequiredService<ISelectedState>();
-            _outputManager = Locator.GetRequiredService<IOutputManager>();
+            _selectedState = selectedState;
+            _outputManager = outputManager;
+            _animationFilePathService = animationFilePathService;
+            _animationCollectionViewModelManager = animationCollectionViewModelManager;
         }
 
         public void HandleRename(ElementSave elementSave, string oldName, ElementAnimationsViewModel viewModel)
@@ -46,7 +52,7 @@ namespace StateAnimationPlugin.Managers
                 {
                     if(shouldSave)
                     {
-                        AnimationCollectionViewModelManager.Self.Save(viewModel);
+                        _animationCollectionViewModelManager.Save(viewModel);
                     }
                     succeeded = true;
                 }

--- a/Gum/StateAnimationPlugin/ViewModels/AnimationViewModel.cs
+++ b/Gum/StateAnimationPlugin/ViewModels/AnimationViewModel.cs
@@ -148,7 +148,7 @@ public partial class AnimationViewModel : ViewModel
         return clone;
     }
 
-    public static AnimationViewModel FromSave(AnimationSave save, ElementSave element, ElementAnimationsSave? allAnimationSaves = null)
+    public static AnimationViewModel FromSave(AnimationSave save, ElementSave element, IAnimationCollectionViewModelManager animationCollectionViewModelManager, ElementAnimationsSave? allAnimationSaves = null)
     {
         AnimationViewModel toReturn = new AnimationViewModel();
         toReturn.Name = save.Name;
@@ -182,7 +182,7 @@ public partial class AnimationViewModel : ViewModel
             {
                 if(allAnimationSaves == null)
                 {
-                    allAnimationSaves = AnimationCollectionViewModelManager.Self.GetElementAnimationsSave(element);
+                    allAnimationSaves = animationCollectionViewModelManager.GetElementAnimationsSave(element);
                 }
 
                 animationSave = allAnimationSaves?.Animations.FirstOrDefault(item => item.Name == animationReference.RootName);
@@ -200,7 +200,7 @@ public partial class AnimationViewModel : ViewModel
 
                     if(instanceElement != null)
                     {
-                        var allAnimations = AnimationCollectionViewModelManager.Self.GetElementAnimationsSave(instanceElement);
+                        var allAnimations = animationCollectionViewModelManager.GetElementAnimationsSave(instanceElement);
 
                         animationSave = allAnimations?.Animations.FirstOrDefault(item => item.Name == animationReference.RootName);
                         subAnimationElement = instanceElement;
@@ -212,7 +212,7 @@ public partial class AnimationViewModel : ViewModel
 
             if(animationSave != null && subAnimationElement != null)
             {
-                newVm.SubAnimationViewModel = AnimationViewModel.FromSave(animationSave, subAnimationElement, subAnimationSiblings);
+                newVm.SubAnimationViewModel = AnimationViewModel.FromSave(animationSave, subAnimationElement, animationCollectionViewModelManager, subAnimationSiblings);
             }
 
 
@@ -463,7 +463,7 @@ public static class ListExtension
 
 public static class AnimationSaveExtensions
 {
-    public static float GetLength(this AnimationSave animation, ElementSave elementSave, ElementAnimationsSave allAnimationSaves)
+    public static float GetLength(this AnimationSave animation, ElementSave elementSave, ElementAnimationsSave allAnimationSaves, IAnimationCollectionViewModelManager animationCollectionViewModelManager)
     {
         float lastState = animation.States.Max(item => item.Time);
 
@@ -491,7 +491,7 @@ public static class AnimationSaveExtensions
 
                         if(instanceElement != null)
                         {
-                            var instanceAnimations = AnimationCollectionViewModelManager.Self.GetElementAnimationsSave(instanceElement);
+                            var instanceAnimations = animationCollectionViewModelManager.GetElementAnimationsSave(instanceElement);
 
                             subAnimationSave = instanceAnimations?.Animations.FirstOrDefault(item => item.Name == subAnimation.RootName);
                             subAnimationElement = instanceElement;
@@ -504,7 +504,7 @@ public static class AnimationSaveExtensions
                 {
                     endOfLastSubAnimation = 
                         System.Math.Max( endOfLastSubAnimation,
-                        subAnimation.Time + subAnimationSave.GetLength(subAnimationElement, subAnimationSiblings));
+                        subAnimation.Time + subAnimationSave.GetLength(subAnimationElement, subAnimationSiblings, animationCollectionViewModelManager));
                 }
             }
         }

--- a/Gum/StateAnimationPlugin/ViewModels/ElementAnimationsViewModel.cs
+++ b/Gum/StateAnimationPlugin/ViewModels/ElementAnimationsViewModel.cs
@@ -44,6 +44,8 @@ public partial class ElementAnimationsViewModel : ViewModel
     private readonly INameVerifier _nameVerifier;
     private readonly IDialogService _dialogService;
     private readonly NameValidator _nameValidator;
+    private readonly IAnimationCollectionViewModelManager _animationCollectionViewModelManager;
+    private readonly IRenameManager _renameManager;
     private AnimatedKeyframeViewModel? _copiedKeyframe;
 
     #endregion
@@ -210,7 +212,8 @@ public partial class ElementAnimationsViewModel : ViewModel
     #endregion
 
 
-    public ElementAnimationsViewModel(INameVerifier nameVerifier, IDialogService dialogService)
+    public ElementAnimationsViewModel(INameVerifier nameVerifier, IDialogService dialogService,
+        IAnimationCollectionViewModelManager animationCollectionViewModelManager, IRenameManager renameManager)
     {
         ClampInterpolationVisuals = true;
         CurrentGameSpeed = "100%";
@@ -232,6 +235,8 @@ public partial class ElementAnimationsViewModel : ViewModel
         _nameVerifier = nameVerifier;
         _nameValidator = new NameValidator(_nameVerifier);
         _dialogService = dialogService;
+        _animationCollectionViewModelManager = animationCollectionViewModelManager;
+        _renameManager = renameManager;
 
         RefreshAnimationsRightClickMenuItems();
     }
@@ -242,7 +247,7 @@ public partial class ElementAnimationsViewModel : ViewModel
 
         foreach (var animation in save.Animations)
         {
-            var vm = AnimationViewModel.FromSave(animation, element);
+            var vm = AnimationViewModel.FromSave(animation, element, _animationCollectionViewModelManager);
             Animations.Add(vm);
         }
     }
@@ -374,7 +379,7 @@ public partial class ElementAnimationsViewModel : ViewModel
             var oldAnimationName = SelectedAnimation.Name;
             SelectedAnimation.Name = result;
 
-            StateAnimationPlugin.Managers.RenameManager.Self.HandleRename(
+            _renameManager.HandleRename(
                 SelectedAnimation, 
                 oldAnimationName, Animations, Element);
         }
@@ -442,7 +447,7 @@ public partial class ElementAnimationsViewModel : ViewModel
         var copyOfAnimation = SelectedAnimation.Clone();
 
         copyOfAnimation.Name = $"Copy of {copyOfAnimation.Name}";
-        StateAnimationPlugin.Managers.RenameManager.Self.HandleRename(
+        _renameManager.HandleRename(
             copyOfAnimation,
             SelectedAnimation.Name, Animations, Element);
 
@@ -627,7 +632,7 @@ public partial class ElementAnimationsViewModel : ViewModel
             var instanceElement = ObjectFinder.Self.GetElementSave(instance);
             if (instanceElement != null)
             {
-                var animationSave = AnimationCollectionViewModelManager.Self.GetElementAnimationsSave(instanceElement);
+                var animationSave = _animationCollectionViewModelManager.GetElementAnimationsSave(instanceElement);
                 if (animationSave != null && animationSave.Animations.Count != 0)
                 {
                     acvm = new AnimationContainerViewModel(_selectedState.SelectedElement, instance);
@@ -647,7 +652,7 @@ public partial class ElementAnimationsViewModel : ViewModel
             return;
         }
 
-        SubAnimationSelectionDialogViewModel window = new();
+        SubAnimationSelectionDialogViewModel window = new(_animationCollectionViewModelManager);
         window.AnimationToExclude = SelectedAnimation;
         window.AnimationContainers = CreateAnimationContainers();
 

--- a/Gum/StateAnimationPlugin/ViewModels/SubAnimationSelectionDialogViewModel.cs
+++ b/Gum/StateAnimationPlugin/ViewModels/SubAnimationSelectionDialogViewModel.cs
@@ -2,6 +2,7 @@
 using Gum.Managers;
 using Gum.Services.Dialogs;
 using Gum.StateAnimation.SaveClasses;
+using Gum.ToolStates;
 using StateAnimationPlugin.Managers;
 using System;
 using System.Collections.Generic;
@@ -16,8 +17,9 @@ namespace StateAnimationPlugin.ViewModels;
 
 public class SubAnimationSelectionDialogViewModel : DialogViewModel
 {
-    private readonly AnimationFilePathService _animationFilePathService = new();
+    private readonly IAnimationFilePathService _animationFilePathService;
     private readonly IOutputManager _outputManager;
+    private readonly IAnimationCollectionViewModelManager _animationCollectionViewModelManager;
 
     public List<AnimationContainerViewModel>? AnimationContainers { get; set; }
     public AnimationContainerViewModel? SelectedContainer
@@ -53,9 +55,11 @@ public class SubAnimationSelectionDialogViewModel : DialogViewModel
 
     public override bool CanExecuteAffirmative() => SelectedAnimation is not null;
 
-    public SubAnimationSelectionDialogViewModel()
+    public SubAnimationSelectionDialogViewModel(IAnimationCollectionViewModelManager animationCollectionViewModelManager)
     {
         _outputManager = Locator.GetRequiredService<IOutputManager>();
+        _animationFilePathService = new AnimationFilePathService(Locator.GetRequiredService<ISelectedState>());
+        _animationCollectionViewModelManager = animationCollectionViewModelManager;
     }
 
 
@@ -83,7 +87,7 @@ public class SubAnimationSelectionDialogViewModel : DialogViewModel
                 foreach (var item in save.Animations)
                 {
                     AnimationViewModel toReturn = AnimationViewModel.FromSave(
-                        item, elementSave!);
+                        item, elementSave!, _animationCollectionViewModelManager);
 
                     toReturn.Name = item.Name;
                     toReturn.ContainingInstance = container.InstanceSave;

--- a/Tool/Tests/GumToolUnitTests/Plugins/StateAnimationPlugin/AnimationCollectionViewModelManagerTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/StateAnimationPlugin/AnimationCollectionViewModelManagerTests.cs
@@ -1,0 +1,111 @@
+using Gum.DataTypes;
+using Gum.Logic.FileWatch;
+using Gum.Managers;
+using Gum.StateAnimation.SaveClasses;
+using Gum.ToolStates;
+using Moq;
+using Shouldly;
+using StateAnimationPlugin.Managers;
+using System;
+using System.IO;
+using ToolsUtilities;
+using Xunit;
+
+namespace GumToolUnitTests.Plugins.StateAnimationPlugin;
+
+/// <summary>
+/// Characterization tests pinning <see cref="AnimationCollectionViewModelManager"/>'s animation-file
+/// load behavior after it was drained from a Singleton to constructor injection. The file-path
+/// resolution is mocked via <see cref="IAnimationFilePathService"/> so these run without a loaded
+/// project or the service locator.
+/// </summary>
+public class AnimationCollectionViewModelManagerTests : BaseTestClass
+{
+    private readonly string _tempDirectory;
+    private readonly Mock<IAnimationFilePathService> _animationFilePathService;
+    private readonly Mock<ISelectedState> _selectedState;
+    private readonly Mock<IOutputManager> _outputManager;
+    private readonly Mock<IFileWatchManager> _fileWatchManager;
+    private readonly AnimationCollectionViewModelManager _manager;
+
+    public AnimationCollectionViewModelManagerTests()
+    {
+        _tempDirectory = Path.Combine(
+            Path.GetTempPath(), "GumAcvmmTests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDirectory);
+
+        _animationFilePathService = new Mock<IAnimationFilePathService>();
+        _selectedState = new Mock<ISelectedState>();
+        _outputManager = new Mock<IOutputManager>();
+        _fileWatchManager = new Mock<IFileWatchManager>();
+
+        _manager = new AnimationCollectionViewModelManager(
+            _selectedState.Object,
+            _outputManager.Object,
+            _fileWatchManager.Object,
+            _animationFilePathService.Object,
+            () => throw new InvalidOperationException(
+                "The animation view model factory should not be invoked by these tests."));
+    }
+
+    [Fact]
+    public void GetAnimationCollectionViewModel_returns_null_for_null_element()
+    {
+        _manager.GetAnimationCollectionViewModel(null).ShouldBeNull();
+    }
+
+    [Fact]
+    public void GetElementAnimationsSave_deserializes_existing_file()
+    {
+        ComponentSave element = new ComponentSave { Name = "Foo" };
+        FilePath ganxPath = new FilePath(Path.Combine(_tempDirectory, "FooAnimations.ganx"));
+
+        ElementAnimationsSave toWrite = new ElementAnimationsSave { ElementName = "Foo" };
+        toWrite.Animations.Add(new AnimationSave { Name = "Walk", Loops = true });
+        FileManager.XmlSerialize(toWrite, ganxPath.FullPath);
+
+        _animationFilePathService
+            .Setup(x => x.GetAbsoluteAnimationFileNameFor(It.IsAny<ElementSave>()))
+            .Returns(ganxPath);
+
+        ElementAnimationsSave? loaded = _manager.GetElementAnimationsSave(element);
+
+        loaded.ShouldNotBeNull();
+        loaded.Animations.Count.ShouldBe(1);
+        loaded.Animations[0].Name.ShouldBe("Walk");
+        loaded.Animations[0].Loops.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GetElementAnimationsSave_returns_null_when_file_missing()
+    {
+        ComponentSave element = new ComponentSave { Name = "Foo" };
+        FilePath missing = new FilePath(Path.Combine(_tempDirectory, "FooAnimations.ganx"));
+        _animationFilePathService
+            .Setup(x => x.GetAbsoluteAnimationFileNameFor(It.IsAny<ElementSave>()))
+            .Returns(missing);
+
+        _manager.GetElementAnimationsSave(element).ShouldBeNull();
+    }
+
+    [Fact]
+    public void GetElementAnimationsSave_returns_null_when_path_is_null()
+    {
+        ComponentSave element = new ComponentSave { Name = "Foo" };
+        _animationFilePathService
+            .Setup(x => x.GetAbsoluteAnimationFileNameFor(It.IsAny<ElementSave>()))
+            .Returns((FilePath?)null);
+
+        _manager.GetElementAnimationsSave(element).ShouldBeNull();
+    }
+
+    public override void Dispose()
+    {
+        if (Directory.Exists(_tempDirectory))
+        {
+            Directory.Delete(_tempDirectory, recursive: true);
+        }
+
+        base.Dispose();
+    }
+}


### PR DESCRIPTION
## Phase 2 (static drain): ACVMM + RenameManager singletons → constructor injection

Continues the Phase 2 static-singleton drain. Prior slices: `ProjectManager` (#3253), `GumCommands`→`IRetryService` (#3275), `CommandLineManager`→`ICommandLineManager` (#3277), `SettingsManager`→`ISettingsManager` (#3279). This slice drains the next two members of the **StateAnimationPlugin `Singleton<T>` cluster**.

Closes #3280.

### Why these two together
`AnimationCollectionViewModelManager` (ACVMM) and `RenameManager` are coupled and cannot be cleanly split:
- `ElementAnimationsViewModel` consumes **both** `AnimationCollectionViewModelManager.Self` and `RenameManager.Self`.
- `RenameManager.Self.Save(...)` reaches into ACVMM, so removing `ACVMM.Self` breaks `RenameManager` unless it also takes ACVMM by constructor.
- Keeping `RenameManager` a singleton and feeding it ACVMM via a settable property / `Initialize` would reintroduce the `Self`+`Initialize` two-stage pattern this phase removes — so both drain here (per `refactoring-direction`: drain a small, cycle-free *blocking* singleton on the spot).

### What changed
- **`AnimationCollectionViewModelManager`** → `IAnimationCollectionViewModelManager`, constructor-injecting `ISelectedState`, `IOutputManager`, `IFileWatchManager`, `IAnimationFilePathService`, and the `ElementAnimationsViewModel` factory. (`INameVerifier`/`IDialogService` are no longer needed here — they moved into the plugin's factory closure.)
- **`RenameManager`** → `IRenameManager`, constructor-injecting `ISelectedState`, `IOutputManager`, `IAnimationFilePathService`, and the ACVMM instance.
- **`AnimationFilePathService`** → `IAnimationFilePathService`, constructor-injecting `ISelectedState` (its parameterless `Locator` ctor is gone). This was draining a *blocking* dependency — ACVMM newed one up internally, so the internal `Locator` call prevented constructing ACVMM in isolation for a test.
- **Static threading:** `AnimationViewModel.FromSave` and the (dead) `AnimationSaveExtensions.GetLength` now take `IAnimationCollectionViewModelManager` as a parameter instead of reaching `…​.Self`. `ElementAnimationsViewModel`, `MainStateAnimationPlugin`, and `SubAnimationSelectionDialogViewModel` thread the injected instance through.
- **Plugin wiring:** `MainStateAnimationPlugin` constructs all three behind their interfaces (plugin-internal, not in `Builder.cs`). The previously-dead `_animationVmFactory` field is now the single `ElementAnimationsViewModel` construction point.

### No `Lazy<T>` needed
The `ACVMM → ElementAnimationsViewModel → RenameManager` construction cycle is broken by the factory **closure**: it reads the manager fields lazily (when invoked, after both are assigned), so eager construction stays linear (ACVMM → RenameManager). The cycle the tracking note anticipated for `RenameManager` does not exist — `RenameManager` never constructs view models.

### Tests
- New `AnimationCollectionViewModelManagerTests` pins ACVMM's `GetElementAnimationsSave` load path (existing-file deserialize, missing-file → null, null-path → null, null-element → null) via a mocked `IAnimationFilePathService`, so it runs with no project or service locator.
- Full `GumToolUnitTests` green: **943 passed, 4 skipped (pre-existing), 0 failed**.
- `GumFull.sln`: **0 errors, no new warnings**.

### Out of scope
`BitmapLoader` — the cluster's third `Singleton<T>`, used in both VM constructors. Independent of this drain (it doesn't block ACVMM/RenameManager construction) and awkward to isolate (returns WPF `BitmapFrame`s from embedded resources); deferred to its own slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
