### PR TITLE
Phase 2 (static drain): BitmapLoader singleton -> IBitmapLoader; add deferred RenameManager tests

### DIFF
--- a/.claude/skills/gum-unit-tests/SKILL.md
+++ b/.claude/skills/gum-unit-tests/SKILL.md
@@ -43,6 +43,12 @@ Every `StateSave` must have `ParentContainer` set — `GetValueRecursive` traver
 
 `InternalsVisibleTo` is set up in `Gum.ProjectServices.csproj` for `Gum.ProjectServices.Tests` — internal members are directly accessible.
 
+## WPF-touching tool code (GumToolUnitTests) needs an STA thread
+
+xUnit's runner is **MTA**, but WPF `FrameworkElement`s (`MenuItem`, `Menu`, `ComboBox`, …) throw `InvalidOperationException: The calling thread must be STA` when constructed. If a tool class news up a WPF control — often a ViewModel building right-click `MenuItem`s in its constructor — build it inside a `RunOnSta(() => { ... })` helper that runs the body on an `ApartmentState.STA` thread and rethrows. Copy the helper from `MenuStripManagerTests` / `RenameManagerTests`; there is no shared base for it.
+
+**Verify the real construction blocker empirically before designing around an assumed one.** A quick throwaway probe (construct the object, see what actually throws) beats reasoning: e.g. `BitmapFrame` PNG decode and most non-control VM constructors run fine on MTA, so the blocker is usually the WPF control, not the singleton/resource you suspected.
+
 ## Integration Tests (MonoGameGum.IntegrationTests)
 
 Use this project for anything requiring a real `GraphicsDevice`. Each test creates a minimal nested `Game` subclass, calls `game.RunOneFrame()` to trigger `Initialize`, then asserts. See `Tests/MonoGameGum.IntegrationTests/MonoGameGum/GumServiceUnitTests.cs` for the established pattern. Always call `LoaderManager.Self?.DisposeAndClear()` in the `Game.Dispose` override to prevent state leaking across tests via the singleton.

--- a/Gum/StateAnimationPlugin/MainStateAnimationPlugin.cs
+++ b/Gum/StateAnimationPlugin/MainStateAnimationPlugin.cs
@@ -50,6 +50,7 @@ public class MainStateAnimationPlugin : PluginBase
     private readonly ISettingsManager _settingsManager;
     private readonly IProjectState _projectState;
     private readonly IAnimationCollectionViewModelManager _animationCollectionViewModelManager;
+    private readonly IBitmapLoader _bitmapLoader;
     ElementAnimationsViewModel? _viewModel;
 
     StateAnimationPlugin.Views.MainWindow? _mainWindow;
@@ -102,12 +103,13 @@ public class MainStateAnimationPlugin : PluginBase
         _duplicateService = new DuplicateService();
         _elementDeleteService = new ElementDeleteService(_animationFilePathService);
         _settingsManager = new SettingsManager();
+        _bitmapLoader = new BitmapLoader();
 
         // The factory closure reads _animationCollectionViewModelManager and _renameManager lazily
         // (when invoked, after both are assigned just below), which breaks the
         // ACVMM -> ElementAnimationsViewModel -> RenameManager construction cycle without a Lazy<T>.
         _animationVmFactory = () => new ElementAnimationsViewModel(
-            _nameVerifier, _dialogService, _animationCollectionViewModelManager, _renameManager);
+            _nameVerifier, _dialogService, _animationCollectionViewModelManager, _renameManager, _bitmapLoader);
         _animationCollectionViewModelManager = new AnimationCollectionViewModelManager(
             _selectedState, _outputManager, _fileWatchManager, _animationFilePathService, _animationVmFactory);
         _renameManager = new RenameManager(
@@ -353,7 +355,7 @@ public class MainStateAnimationPlugin : PluginBase
             return;
         }
 
-        AddStateKeyframeDialog dialog = new()
+        AddStateKeyframeDialog dialog = new(_bitmapLoader)
         {
             ElementSave = _selectedState.SelectedElement
         };

--- a/Gum/StateAnimationPlugin/Managers/BitmapLoader.cs
+++ b/Gum/StateAnimationPlugin/Managers/BitmapLoader.cs
@@ -1,25 +1,32 @@
-﻿using Gum.Managers;
-using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows.Media.Imaging;
 
 namespace StateAnimationPlugin.Managers
 {
-    public class BitmapLoader : Singleton<BitmapLoader>
+    public class BitmapLoader : IBitmapLoader
     {
+        // Caches each decoded frame by resource name. This preserves the "decode once,
+        // share the frame" behavior the icons used to get from AnimatedKeyframeViewModel's
+        // static fields, now that every view model loads its icons via this instance.
+        private readonly Dictionary<string, BitmapFrame> _cache = new();
+
         public BitmapFrame LoadImage(string resourceName)
         {
+            if (_cache.TryGetValue(resourceName, out var cached))
+            {
+                return cached;
+            }
+
             Assembly thisassembly = Assembly.GetExecutingAssembly();
 
             string fullName = "StateAnimationPlugin.Resources." + resourceName;
             using (var imageStream =
                 thisassembly.GetManifestResourceStream(fullName))
             {
-                return BitmapFrame.Create(imageStream);
+                var frame = BitmapFrame.Create(imageStream);
+                _cache[resourceName] = frame;
+                return frame;
             }
         }
     }

--- a/Gum/StateAnimationPlugin/Managers/IBitmapLoader.cs
+++ b/Gum/StateAnimationPlugin/Managers/IBitmapLoader.cs
@@ -1,0 +1,14 @@
+using System.Windows.Media.Imaging;
+
+namespace StateAnimationPlugin.Managers
+{
+    /// <summary>
+    /// Loads the plugin's embedded icon resources as WPF <see cref="BitmapFrame"/>s.
+    /// Drained from the former <c>Singleton&lt;BitmapLoader&gt;</c> so the animation view
+    /// models can take it by constructor and be substituted in tests.
+    /// </summary>
+    public interface IBitmapLoader
+    {
+        BitmapFrame LoadImage(string resourceName);
+    }
+}

--- a/Gum/StateAnimationPlugin/ViewModels/AddStateKeyframeDialog.cs
+++ b/Gum/StateAnimationPlugin/ViewModels/AddStateKeyframeDialog.cs
@@ -1,5 +1,6 @@
 ﻿using Gum.DataTypes;
 using Gum.Services.Dialogs;
+using StateAnimationPlugin.Managers;
 using System.Collections.ObjectModel;
 using System.Linq;
 
@@ -7,6 +8,13 @@ namespace StateAnimationPlugin.ViewModels;
 
 internal class AddStateKeyframeDialog : DialogViewModel
 {
+    private readonly IBitmapLoader _bitmapLoader;
+
+    public AddStateKeyframeDialog(IBitmapLoader bitmapLoader)
+    {
+        _bitmapLoader = bitmapLoader;
+    }
+
     public AnimatedKeyframeViewModel? Result { get; private set; }
 
     public ElementSave? ElementSave
@@ -47,7 +55,7 @@ internal class AddStateKeyframeDialog : DialogViewModel
 
     public override void OnAffirmative()
     {
-        Result = new AnimatedKeyframeViewModel()
+        Result = new AnimatedKeyframeViewModel(_bitmapLoader)
         {
             StateName = SelectedState!,
             HasValidState = true,

--- a/Gum/StateAnimationPlugin/ViewModels/AnimatedKeyframeViewModel.cs
+++ b/Gum/StateAnimationPlugin/ViewModels/AnimatedKeyframeViewModel.cs
@@ -24,9 +24,10 @@ public class AnimatedKeyframeViewModel : ViewModel, IComparable
 
     AnimationViewModel? mSubAnimationViewModel;
 
-    static BitmapFrame mStateBitmap;
-    static BitmapFrame mAnimationBitmap;
-    static BitmapFrame mEventBitmap;
+    private readonly IBitmapLoader _bitmapLoader;
+    readonly BitmapFrame mStateBitmap;
+    readonly BitmapFrame mAnimationBitmap;
+    readonly BitmapFrame mEventBitmap;
     #endregion
 
     #region Properties
@@ -240,25 +241,25 @@ public class AnimatedKeyframeViewModel : ViewModel, IComparable
     }
 
 
-    static BitmapFrame mExclamationIcon;
+    readonly BitmapFrame mExclamationIcon;
     public BitmapFrame ExclamationIcon => mExclamationIcon;
 
     #endregion
 
     #region Methods
 
-    static AnimatedKeyframeViewModel()
+    public AnimatedKeyframeViewModel(IBitmapLoader bitmapLoader)
     {
-        mStateBitmap = BitmapLoader.Self.LoadImage("StateAnimationIcon.png");
-        mAnimationBitmap = BitmapLoader.Self.LoadImage("ReferencedAnimationIcon.png");
-        mEventBitmap = BitmapLoader.Self.LoadImage("NamedEventIcon.png");
-        mExclamationIcon = BitmapLoader.Self.LoadImage("redExclamation.png");
-
+        _bitmapLoader = bitmapLoader;
+        mStateBitmap = bitmapLoader.LoadImage("StateAnimationIcon.png");
+        mAnimationBitmap = bitmapLoader.LoadImage("ReferencedAnimationIcon.png");
+        mEventBitmap = bitmapLoader.LoadImage("NamedEventIcon.png");
+        mExclamationIcon = bitmapLoader.LoadImage("redExclamation.png");
     }
 
     public AnimatedKeyframeViewModel Clone()
     {
-        var newInstance = new AnimatedKeyframeViewModel();
+        var newInstance = new AnimatedKeyframeViewModel(_bitmapLoader);
 
         newInstance.StateName = StateName;
         newInstance.AnimationName = AnimationName;
@@ -277,9 +278,9 @@ public class AnimatedKeyframeViewModel : ViewModel, IComparable
         return newInstance;
     }
 
-    public static AnimatedKeyframeViewModel FromSave(AnimatedStateSave save, ElementSave elementSave)
+    public static AnimatedKeyframeViewModel FromSave(AnimatedStateSave save, ElementSave elementSave, IBitmapLoader bitmapLoader)
     {
-        AnimatedKeyframeViewModel toReturn = new AnimatedKeyframeViewModel();
+        AnimatedKeyframeViewModel toReturn = new AnimatedKeyframeViewModel(bitmapLoader);
 
         toReturn.StateName = save.StateName;
         toReturn.Time = save.Time;
@@ -291,9 +292,9 @@ public class AnimatedKeyframeViewModel : ViewModel, IComparable
         return toReturn;
     }
 
-    public static AnimatedKeyframeViewModel FromSave(AnimationReferenceSave save, ElementSave elementSave)
+    public static AnimatedKeyframeViewModel FromSave(AnimationReferenceSave save, ElementSave elementSave, IBitmapLoader bitmapLoader)
     {
-        AnimatedKeyframeViewModel toReturn = new AnimatedKeyframeViewModel();
+        AnimatedKeyframeViewModel toReturn = new AnimatedKeyframeViewModel(bitmapLoader);
 
         toReturn.AnimationName = save.Name;
         toReturn.Time = save.Time;
@@ -302,9 +303,9 @@ public class AnimatedKeyframeViewModel : ViewModel, IComparable
         return toReturn;
     }
 
-    public static AnimatedKeyframeViewModel FromSave(NamedEventSave save, ElementSave elementSave)
+    public static AnimatedKeyframeViewModel FromSave(NamedEventSave save, ElementSave elementSave, IBitmapLoader bitmapLoader)
     {
-        AnimatedKeyframeViewModel toReturn = new AnimatedKeyframeViewModel();
+        AnimatedKeyframeViewModel toReturn = new AnimatedKeyframeViewModel(bitmapLoader);
         toReturn.EventName = save.Name;
         toReturn.Time = save.Time;
 

--- a/Gum/StateAnimationPlugin/ViewModels/AnimationViewModel.cs
+++ b/Gum/StateAnimationPlugin/ViewModels/AnimationViewModel.cs
@@ -119,14 +119,14 @@ public partial class AnimationViewModel : ViewModel
 
     #region Methods
 
-    public AnimationViewModel()
+    public AnimationViewModel(IBitmapLoader bitmapLoader)
     {
         Keyframes = new ObservableCollection<AnimatedKeyframeViewModel>();
         Keyframes.CollectionChanged += HandleKeyframeCollectionChanged;
 
-        mLoopBitmap = BitmapLoader.Self.LoadImage("LoopIcon.png");
+        mLoopBitmap = bitmapLoader.LoadImage("LoopIcon.png");
 
-        mPlayOnceBitmap = BitmapLoader.Self.LoadImage("PlayOnceIcon.png");
+        mPlayOnceBitmap = bitmapLoader.LoadImage("PlayOnceIcon.png");
         _selectedState = Locator.GetRequiredService<ISelectedState>();
         _wireframeObjectManager = Locator.GetRequiredService<IWireframeObjectManager>();
     }
@@ -148,15 +148,15 @@ public partial class AnimationViewModel : ViewModel
         return clone;
     }
 
-    public static AnimationViewModel FromSave(AnimationSave save, ElementSave element, IAnimationCollectionViewModelManager animationCollectionViewModelManager, ElementAnimationsSave? allAnimationSaves = null)
+    public static AnimationViewModel FromSave(AnimationSave save, ElementSave element, IAnimationCollectionViewModelManager animationCollectionViewModelManager, IBitmapLoader bitmapLoader, ElementAnimationsSave? allAnimationSaves = null)
     {
-        AnimationViewModel toReturn = new AnimationViewModel();
+        AnimationViewModel toReturn = new AnimationViewModel(bitmapLoader);
         toReturn.Name = save.Name;
         toReturn.Loops = save.Loops;
 
         foreach(var eventSave in save.Events)
         {
-            var newViewModel = AnimatedKeyframeViewModel.FromSave(eventSave, element);
+            var newViewModel = AnimatedKeyframeViewModel.FromSave(eventSave, element, bitmapLoader);
 
             toReturn.Keyframes.Add(newViewModel);
         }
@@ -165,7 +165,7 @@ public partial class AnimationViewModel : ViewModel
         {
             var foundState = GetStateFromCategorizedName(stateSave.StateName, element);
 
-            var newAnimatedStateViewModel = AnimatedKeyframeViewModel.FromSave(stateSave, element);
+            var newAnimatedStateViewModel = AnimatedKeyframeViewModel.FromSave(stateSave, element, bitmapLoader);
 
             newAnimatedStateViewModel.HasValidState = foundState != null;
 
@@ -208,11 +208,11 @@ public partial class AnimationViewModel : ViewModel
                     }
                 }
             }
-            var newVm = AnimatedKeyframeViewModel.FromSave(animationReference, element);
+            var newVm = AnimatedKeyframeViewModel.FromSave(animationReference, element, bitmapLoader);
 
             if(animationSave != null && subAnimationElement != null)
             {
-                newVm.SubAnimationViewModel = AnimationViewModel.FromSave(animationSave, subAnimationElement, animationCollectionViewModelManager, subAnimationSiblings);
+                newVm.SubAnimationViewModel = AnimationViewModel.FromSave(animationSave, subAnimationElement, animationCollectionViewModelManager, bitmapLoader, subAnimationSiblings);
             }
 
 

--- a/Gum/StateAnimationPlugin/ViewModels/ElementAnimationsViewModel.cs
+++ b/Gum/StateAnimationPlugin/ViewModels/ElementAnimationsViewModel.cs
@@ -46,6 +46,7 @@ public partial class ElementAnimationsViewModel : ViewModel
     private readonly NameValidator _nameValidator;
     private readonly IAnimationCollectionViewModelManager _animationCollectionViewModelManager;
     private readonly IRenameManager _renameManager;
+    private readonly IBitmapLoader _bitmapLoader;
     private AnimatedKeyframeViewModel? _copiedKeyframe;
 
     #endregion
@@ -213,7 +214,8 @@ public partial class ElementAnimationsViewModel : ViewModel
 
 
     public ElementAnimationsViewModel(INameVerifier nameVerifier, IDialogService dialogService,
-        IAnimationCollectionViewModelManager animationCollectionViewModelManager, IRenameManager renameManager)
+        IAnimationCollectionViewModelManager animationCollectionViewModelManager, IRenameManager renameManager,
+        IBitmapLoader bitmapLoader)
     {
         ClampInterpolationVisuals = true;
         CurrentGameSpeed = "100%";
@@ -227,9 +229,9 @@ public partial class ElementAnimationsViewModel : ViewModel
         mPlayTimer.Interval = new TimeSpan(0, 0, 0, 0, mTimerFrequencyInMs);
         mPlayTimer.Tick += HandlePlayTimerTick;
 
-        mPlayBitmap = BitmapLoader.Self.LoadImage("PlayIcon.png");
+        mPlayBitmap = bitmapLoader.LoadImage("PlayIcon.png");
 
-        mStopBitmap = BitmapLoader.Self.LoadImage("StopIcon.png");
+        mStopBitmap = bitmapLoader.LoadImage("StopIcon.png");
 
         _selectedState = Locator.GetRequiredService<ISelectedState>();
         _nameVerifier = nameVerifier;
@@ -237,6 +239,7 @@ public partial class ElementAnimationsViewModel : ViewModel
         _dialogService = dialogService;
         _animationCollectionViewModelManager = animationCollectionViewModelManager;
         _renameManager = renameManager;
+        _bitmapLoader = bitmapLoader;
 
         RefreshAnimationsRightClickMenuItems();
     }
@@ -247,7 +250,7 @@ public partial class ElementAnimationsViewModel : ViewModel
 
         foreach (var animation in save.Animations)
         {
-            var vm = AnimationViewModel.FromSave(animation, element, _animationCollectionViewModelManager);
+            var vm = AnimationViewModel.FromSave(animation, element, _animationCollectionViewModelManager, _bitmapLoader);
             Animations.Add(vm);
         }
     }
@@ -604,7 +607,7 @@ public partial class ElementAnimationsViewModel : ViewModel
 
             if (_dialogService.Show(dialogViewModel))
             {
-                var newAnimation = new AnimationViewModel()
+                var newAnimation = new AnimationViewModel(_bitmapLoader)
                 {
                     Name = dialogViewModel.Name,
                     Loops = dialogViewModel.Loops
@@ -652,13 +655,13 @@ public partial class ElementAnimationsViewModel : ViewModel
             return;
         }
 
-        SubAnimationSelectionDialogViewModel window = new(_animationCollectionViewModelManager);
+        SubAnimationSelectionDialogViewModel window = new(_animationCollectionViewModelManager, _bitmapLoader);
         window.AnimationToExclude = SelectedAnimation;
         window.AnimationContainers = CreateAnimationContainers();
 
         if (_dialogService.Show(window) && window.SelectedAnimation is { } selectedAnimation)
         {
-            AnimatedKeyframeViewModel newVm = new AnimatedKeyframeViewModel();
+            AnimatedKeyframeViewModel newVm = new AnimatedKeyframeViewModel(_bitmapLoader);
             if (selectedAnimation.ContainingInstance != null)
             {
                 newVm.AnimationName = selectedAnimation.ContainingInstance.Name + "." + selectedAnimation.Name;
@@ -696,7 +699,7 @@ public partial class ElementAnimationsViewModel : ViewModel
 
         if (_dialogService.GetUserString("Enter new event name", "New event") is { } result)
         {
-            AnimatedKeyframeViewModel newVm = new AnimatedKeyframeViewModel();
+            AnimatedKeyframeViewModel newVm = new AnimatedKeyframeViewModel(_bitmapLoader);
             newVm.EventName = result;
 
             if (SelectedAnimation.SelectedKeyframe != null)

--- a/Gum/StateAnimationPlugin/ViewModels/SubAnimationSelectionDialogViewModel.cs
+++ b/Gum/StateAnimationPlugin/ViewModels/SubAnimationSelectionDialogViewModel.cs
@@ -20,6 +20,7 @@ public class SubAnimationSelectionDialogViewModel : DialogViewModel
     private readonly IAnimationFilePathService _animationFilePathService;
     private readonly IOutputManager _outputManager;
     private readonly IAnimationCollectionViewModelManager _animationCollectionViewModelManager;
+    private readonly IBitmapLoader _bitmapLoader;
 
     public List<AnimationContainerViewModel>? AnimationContainers { get; set; }
     public AnimationContainerViewModel? SelectedContainer
@@ -55,11 +56,13 @@ public class SubAnimationSelectionDialogViewModel : DialogViewModel
 
     public override bool CanExecuteAffirmative() => SelectedAnimation is not null;
 
-    public SubAnimationSelectionDialogViewModel(IAnimationCollectionViewModelManager animationCollectionViewModelManager)
+    public SubAnimationSelectionDialogViewModel(IAnimationCollectionViewModelManager animationCollectionViewModelManager,
+        IBitmapLoader bitmapLoader)
     {
         _outputManager = Locator.GetRequiredService<IOutputManager>();
         _animationFilePathService = new AnimationFilePathService(Locator.GetRequiredService<ISelectedState>());
         _animationCollectionViewModelManager = animationCollectionViewModelManager;
+        _bitmapLoader = bitmapLoader;
     }
 
 
@@ -87,7 +90,7 @@ public class SubAnimationSelectionDialogViewModel : DialogViewModel
                 foreach (var item in save.Animations)
                 {
                     AnimationViewModel toReturn = AnimationViewModel.FromSave(
-                        item, elementSave!, _animationCollectionViewModelManager);
+                        item, elementSave!, _animationCollectionViewModelManager, _bitmapLoader);
 
                     toReturn.Name = item.Name;
                     toReturn.ContainingInstance = container.InstanceSave;

--- a/Tool/Tests/GumToolUnitTests/Plugins/StateAnimationPlugin/BitmapLoaderTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/StateAnimationPlugin/BitmapLoaderTests.cs
@@ -1,0 +1,36 @@
+using Shouldly;
+using StateAnimationPlugin.Managers;
+using Xunit;
+
+namespace GumToolUnitTests.Plugins.StateAnimationPlugin;
+
+/// <summary>
+/// Characterization tests pinning <see cref="BitmapLoader"/> after it was drained from a
+/// <c>Singleton&lt;T&gt;</c> to an injectable <see cref="IBitmapLoader"/>. WPF PNG decode runs
+/// fine on the default (MTA) test thread, so no STA wrapper is needed here.
+/// </summary>
+public class BitmapLoaderTests : BaseTestClass
+{
+    [Fact]
+    public void LoadImage_caches_and_returns_the_same_frame_for_a_repeated_resource()
+    {
+        BitmapLoader loader = new BitmapLoader();
+
+        var first = loader.LoadImage("PlayIcon.png");
+        var second = loader.LoadImage("PlayIcon.png");
+
+        second.ShouldBeSameAs(first);
+    }
+
+    [Fact]
+    public void LoadImage_decodes_an_embedded_resource_into_a_frame()
+    {
+        BitmapLoader loader = new BitmapLoader();
+
+        var frame = loader.LoadImage("PlayIcon.png");
+
+        frame.ShouldNotBeNull();
+        frame.PixelWidth.ShouldBeGreaterThan(0);
+        frame.PixelHeight.ShouldBeGreaterThan(0);
+    }
+}

--- a/Tool/Tests/GumToolUnitTests/Plugins/StateAnimationPlugin/RenameManagerTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/StateAnimationPlugin/RenameManagerTests.cs
@@ -1,0 +1,197 @@
+using Gum.DataTypes;
+using Gum.DataTypes.Variables;
+using Gum.Managers;
+using Gum.Services;
+using Gum.Services.Dialogs;
+using Gum.ToolStates;
+using Gum.Wireframe;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Shouldly;
+using StateAnimationPlugin.Managers;
+using StateAnimationPlugin.ViewModels;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading;
+using Xunit;
+
+namespace GumToolUnitTests.Plugins.StateAnimationPlugin;
+
+/// <summary>
+/// Characterization tests pinning the keyframe-mutating <see cref="RenameManager"/> overloads.
+/// These were deferred when ACVMM/RenameManager were drained (#3281) because the animation view
+/// models could not be constructed in isolation. They can now: <see cref="BitmapLoader"/> is an
+/// injectable <see cref="IBitmapLoader"/> (stubbed here), the remaining ViewModel constructor
+/// dependencies are satisfied via the service locator, and <see cref="ElementAnimationsViewModel"/>'s
+/// WPF right-click <c>MenuItem</c> creation is handled by building it on an STA thread.
+/// </summary>
+public class RenameManagerTests : BaseTestClass
+{
+    private readonly IServiceProvider _testServiceProvider;
+    private readonly IBitmapLoader _bitmapLoader = Mock.Of<IBitmapLoader>();
+
+    public RenameManagerTests()
+    {
+        // AnimationViewModel/ElementAnimationsViewModel still resolve ISelectedState and
+        // IWireframeObjectManager from the locator in their constructors.
+        ServiceCollection services = new ServiceCollection();
+        services.AddSingleton(Mock.Of<ISelectedState>());
+        services.AddSingleton(Mock.Of<IWireframeObjectManager>());
+        _testServiceProvider = services.BuildServiceProvider();
+        Locator.Register(_testServiceProvider);
+    }
+
+    [Fact]
+    public void HandleRename_Animation_RenamesMatchingKeyframeAnimationNames()
+    {
+        RunOnSta(() =>
+        {
+            // GetElementsReferencing walks the project; an empty project keeps the test on the
+            // pure view-model mutation path (no file IO).
+            ObjectFinder.Self.GumProjectSave = new GumProjectSave();
+
+            AnimationViewModel animation = CreateAnimationWithKeyframes(
+                Keyframe(animationName: "OldAnim"));
+            AnimationViewModel renamed = new AnimationViewModel(_bitmapLoader) { Name = "NewAnim" };
+
+            RenameManager renameManager = CreateRenameManager();
+
+            renameManager.HandleRename(
+                renamed, "OldAnim", new[] { animation }, new ComponentSave { Name = "Foo" });
+
+            animation.Keyframes[0].AnimationName.ShouldBe("NewAnim");
+        });
+    }
+
+    [Fact]
+    public void HandleRename_Instance_RenamesQualifiedAnimationNamePrefix()
+    {
+        RunOnSta(() =>
+        {
+            ElementAnimationsViewModel viewModel = CreateViewModelWith(
+                CreateAnimationWithKeyframes(Keyframe(animationName: "OldInstance.Walk")));
+
+            RenameManager renameManager = CreateRenameManager();
+
+            renameManager.HandleRename(
+                new InstanceSave { Name = "NewInstance" }, "OldInstance", viewModel);
+
+            viewModel.Animations[0].Keyframes[0].AnimationName.ShouldBe("NewInstance.Walk");
+        });
+    }
+
+    [Fact]
+    public void HandleRename_State_RenamesMatchingKeyframeStateName()
+    {
+        RunOnSta(() =>
+        {
+            ElementAnimationsViewModel viewModel = CreateViewModelWith(
+                CreateAnimationWithKeyframes(Keyframe(stateName: "OldState")));
+
+            // No selected element -> uncategorized rename (no category prefix).
+            RenameManager renameManager = CreateRenameManager();
+
+            renameManager.HandleRename(
+                new StateSave { Name = "NewState" }, "OldState", viewModel);
+
+            viewModel.Animations[0].Keyframes[0].StateName.ShouldBe("NewState");
+        });
+    }
+
+    [Fact]
+    public void HandleRename_StateCategory_RenamesCategoryPrefixOnKeyframeStateNames()
+    {
+        RunOnSta(() =>
+        {
+            ElementAnimationsViewModel viewModel = CreateViewModelWith(
+                CreateAnimationWithKeyframes(Keyframe(stateName: "OldCategory/Idle")));
+
+            RenameManager renameManager = CreateRenameManager();
+
+            renameManager.HandleRename(
+                new StateSaveCategory { Name = "NewCategory" }, "OldCategory", viewModel);
+
+            viewModel.Animations[0].Keyframes[0].StateName.ShouldBe("NewCategory/Idle");
+        });
+    }
+
+    private AnimatedKeyframeViewModel Keyframe(string? stateName = null, string? animationName = null)
+    {
+        AnimatedKeyframeViewModel keyframe = new AnimatedKeyframeViewModel(_bitmapLoader);
+        if (stateName != null)
+        {
+            keyframe.StateName = stateName;
+        }
+        if (animationName != null)
+        {
+            keyframe.AnimationName = animationName;
+        }
+        return keyframe;
+    }
+
+    private AnimationViewModel CreateAnimationWithKeyframes(params AnimatedKeyframeViewModel[] keyframes)
+    {
+        AnimationViewModel animation = new AnimationViewModel(_bitmapLoader);
+        foreach (AnimatedKeyframeViewModel keyframe in keyframes)
+        {
+            animation.Keyframes.Add(keyframe);
+        }
+        return animation;
+    }
+
+    private ElementAnimationsViewModel CreateViewModelWith(params AnimationViewModel[] animations)
+    {
+        ElementAnimationsViewModel viewModel = new ElementAnimationsViewModel(
+            Mock.Of<INameVerifier>(),
+            Mock.Of<IDialogService>(),
+            Mock.Of<IAnimationCollectionViewModelManager>(),
+            Mock.Of<IRenameManager>(),
+            _bitmapLoader);
+        foreach (AnimationViewModel animation in animations)
+        {
+            viewModel.Animations.Add(animation);
+        }
+        return viewModel;
+    }
+
+    private static RenameManager CreateRenameManager()
+    {
+        return new RenameManager(
+            Mock.Of<ISelectedState>(),
+            Mock.Of<IOutputManager>(),
+            Mock.Of<IAnimationFilePathService>(),
+            Mock.Of<IAnimationCollectionViewModelManager>());
+    }
+
+    /// <summary>
+    /// WPF controls (the right-click MenuItems built in ElementAnimationsViewModel's constructor)
+    /// require an STA thread; xUnit's default runner is MTA.
+    /// </summary>
+    private static void RunOnSta(Action action)
+    {
+        Exception? caught = null;
+        Thread thread = new Thread(() =>
+        {
+            try { action(); }
+            catch (Exception ex) { caught = ex; }
+        });
+        thread.SetApartmentState(ApartmentState.STA);
+        thread.Start();
+        thread.Join();
+        if (caught != null)
+        {
+            throw new Exception("Test body threw on the STA thread.", caught);
+        }
+    }
+
+    public override void Dispose()
+    {
+        PropertyInfo prop = typeof(Locator).GetProperty(
+            "ServiceProviders", BindingFlags.NonPublic | BindingFlags.Static)!;
+        List<IServiceProvider> providers = (List<IServiceProvider>)prop.GetValue(null)!;
+        providers.Remove(_testServiceProvider);
+
+        base.Dispose();
+    }
+}


### PR DESCRIPTION
## Phase 2 (static drain): `BitmapLoader` → `IBitmapLoader`, plus the deferred RenameManager tests

Drains `BitmapLoader` — the **last `Singleton<T>` in the StateAnimationPlugin cluster** (after `SettingsManager` #3279, ACVMM/`RenameManager` #3281) — behind a new `IBitmapLoader`, instantiated in `MainStateAnimationPlugin` and injected into the three animation view models, their static `FromSave` factories, `Clone`, `AddStateKeyframeDialog`, and `SubAnimationSelectionDialogViewModel`.

`AnimatedKeyframeViewModel`'s **static constructor + shared static icon fields** become an instance constructor + instance fields. To keep the old "decode once, share one frame" behavior (and avoid a per-keyframe decode), `BitmapLoader` now caches each frame by resource name. Plugin-internal, so it's `new`'d in the plugin (no `Builder.cs` change), mirroring `ISettingsManager` / `IAnimationFilePathService`.

### The handoff's premise was wrong — verified empirically
The slice was teed up as "BitmapLoader is the keystone blocking the animation VMs from being constructed in tests." A probe (real `BitmapLoader`, MTA xUnit thread) showed otherwise:

| Construct | Result |
|---|---|
| `BitmapLoader.LoadImage(...)` | ✅ WPF PNG decode works headlessly |
| `new AnimationViewModel()` / `new AnimatedKeyframeViewModel()` | ✅ construct fine |
| `new ElementAnimationsViewModel(...)` | ❌ `InvalidOperationException: The calling thread must be STA` |

The only headless blocker is `ElementAnimationsViewModel`'s WPF right-click **`MenuItem` creation in its constructor**, which needs an STA thread — not BitmapLoader, not the locator. So **the BitmapLoader drain does not unblock the tests** (it's done here for Phase-2 consistency / removing the last `Singleton<T>`), and the deferred `RenameManager` keyframe-rename pinning tests left uncovered by #3281 are added **independently**, using the repo's existing `RunOnSta` STA-thread pattern with a stubbed `IBitmapLoader` and a registered `Locator` provider.

### Tests
- `RenameManagerTests` — pins the four keyframe-mutating `HandleRename` overloads (`InstanceSave`, `StateSave`, `StateSaveCategory`, `AnimationViewModel`), built on an STA thread.
- `BitmapLoaderTests` — characterizes decode + the new per-name cache.
- `gum-unit-tests` skill gains a note on STA/`RunOnSta` testing for WPF-touching tool code and on verifying the real construction blocker empirically.

### Verification
- Full `GumToolUnitTests` green: **949 passed, 4 skipped, 0 failed**.
- `GumFull.sln`: **0 errors, no new warnings**.
- Behavior-preserving (plugin-internal instantiation; the cache preserves shared-frame semantics).

**Manual test:** needed (tool-side, runtime-observable icons) — see PR conversation for steps; the change rewires all icon loading in the State Animation plugin.

Closes #3282
