### PR TITLE
Phase 2 (static drain): ElementTreeViewManager.Self singleton -> DI (#3286)

### DIFF
--- a/Gum/Commands/FileCommands.cs
+++ b/Gum/Commands/FileCommands.cs
@@ -258,11 +258,6 @@ public class FileCommands : IFileCommands
         {
             bool succeeded = true;
 
-            // April 10, 2023
-            // This is potentially slow, dishonest (SaveElement should only save the element), and prevents multi-select edit
-            // from properly creating a single undo state:
-            //UndoManager.Self.RecordUndo();
-
             bool doesProjectNeedToSave = false;
             bool shouldSave = _projectManager.AskUserForProjectNameIfNecessary(out doesProjectNeedToSave);
 

--- a/Gum/Plugins/InternalPlugins/TreeView/ElementTreeViewManager.cs
+++ b/Gum/Plugins/InternalPlugins/TreeView/ElementTreeViewManager.cs
@@ -239,8 +239,6 @@ public partial class ElementTreeViewManager : IRecipient<ThemeChangedMessage>, I
         _ => StandardElementImageIndex,
     };
 
-    static ElementTreeViewManager mSelf;
-
     // Part of the phantom right-click workaround. Subscribed in Initialize(),
     // checked in ObjectTreeView_MouseClick(). See comments at both sites.
     private MouseButtons _lastMouseDownButton;
@@ -290,18 +288,6 @@ public partial class ElementTreeViewManager : IRecipient<ThemeChangedMessage>, I
     #endregion
 
     #region Properties
-
-    public static ElementTreeViewManager Self
-    {
-        get 
-        {
-            if (mSelf == null)
-            {
-                mSelf = new ElementTreeViewManager();
-            }
-            return mSelf; 
-        }
-    }
 
     public ITreeNode? SelectedNode
     {
@@ -401,34 +387,55 @@ public partial class ElementTreeViewManager : IRecipient<ThemeChangedMessage>, I
 
     #endregion
 
-    public ElementTreeViewManager()
+    public ElementTreeViewManager(
+        ISelectedState selectedState,
+        IEditCommands editCommands,
+        IGuiCommands guiCommands,
+        IDialogService dialogService,
+        IFileCommands fileCommands,
+        IHotkeyManager hotkeyManager,
+        ITabManager tabManager,
+        ICopyPasteLogic copyPasteLogic,
+        IMessenger messenger,
+        IDeleteLogic deleteLogic,
+        IUndoManager undoManager,
+        IWireframeObjectManager wireframeObjectManager,
+        FileLocations fileLocations,
+        IElementCommands elementCommands,
+        INameVerifier nameVerifier,
+        ISetVariableLogic setVariableLogic,
+        ICircularReferenceManager circularReferenceManager,
+        IFavoriteComponentManager favoriteComponentManager,
+        IProjectState projectState,
+        StandardElementsManagerGumTool standardElementsManagerGumTool,
+        IDragDropManager dragDropManager)
     {
-        _selectedState = Locator.GetRequiredService<ISelectedState>();
-        _editCommands = Locator.GetRequiredService<IEditCommands>();
-        _guiCommands = Locator.GetRequiredService<IGuiCommands>();
-        _dialogService = Locator.GetRequiredService<IDialogService>();
-        _fileCommands = Locator.GetRequiredService<IFileCommands>();
-        _hotkeyManager = Locator.GetRequiredService<IHotkeyManager>();
-        _tabManager = Locator.GetRequiredService<ITabManager>();
-        _copyPasteLogic = Locator.GetRequiredService<ICopyPasteLogic>();
-        _messenger = Locator.GetRequiredService<IMessenger>();
+        _selectedState = selectedState;
+        _editCommands = editCommands;
+        _guiCommands = guiCommands;
+        _dialogService = dialogService;
+        _fileCommands = fileCommands;
+        _hotkeyManager = hotkeyManager;
+        _tabManager = tabManager;
+        _copyPasteLogic = copyPasteLogic;
+        _messenger = messenger;
         _messenger.RegisterAll(this);
-        _deleteLogic = Locator.GetRequiredService<IDeleteLogic>();
-        _undoManager = Locator.GetRequiredService<IUndoManager>();
-        _wireframeObjectManager = Locator.GetRequiredService<IWireframeObjectManager>();
-        _fileLocations = Locator.GetRequiredService<FileLocations>();
-        _elementCommands = Locator.GetRequiredService<IElementCommands>();
-        _nameVerifier = Locator.GetRequiredService<INameVerifier>();
-        _setVariableLogic = Locator.GetRequiredService<ISetVariableLogic>();
-        _circularReferenceManager = Locator.GetRequiredService<ICircularReferenceManager>();
-        _favoriteComponentManager = Locator.GetRequiredService<IFavoriteComponentManager>();
-        _projectState = Locator.GetRequiredService<IProjectState>();
-        _standardElementsManagerGumTool = Locator.GetRequiredService<StandardElementsManagerGumTool>();
+        _deleteLogic = deleteLogic;
+        _undoManager = undoManager;
+        _wireframeObjectManager = wireframeObjectManager;
+        _fileLocations = fileLocations;
+        _elementCommands = elementCommands;
+        _nameVerifier = nameVerifier;
+        _setVariableLogic = setVariableLogic;
+        _circularReferenceManager = circularReferenceManager;
+        _favoriteComponentManager = favoriteComponentManager;
+        _projectState = projectState;
+        _standardElementsManagerGumTool = standardElementsManagerGumTool;
         _collapseToggleService = new CollapseToggleService();
         _recordedSelectedInstances = new List<InstanceSave>();
         TreeNodeExtensionMethods.ElementTreeViewManager = this;
         AddCursor = GetAddCursor();
-        _dragDropManager = Locator.GetRequiredService<IDragDropManager>();
+        _dragDropManager = dragDropManager;
         _viewCreator = new ElementTreeViewCreator();
 
         Cursor GetAddCursor()

--- a/Gum/Plugins/InternalPlugins/TreeView/MainTreeViewPlugin.cs
+++ b/Gum/Plugins/InternalPlugins/TreeView/MainTreeViewPlugin.cs
@@ -33,7 +33,7 @@ internal class MainTreeViewPlugin : PriorityPlugin, IRecipient<ApplicationTeardo
     public MainTreeViewPlugin()
     {
         _selectedState = Locator.GetRequiredService<ISelectedState>();
-        _elementTreeViewManager = ElementTreeViewManager.Self;
+        _elementTreeViewManager = Locator.GetRequiredService<ElementTreeViewManager>();
         _userProjectSettingsManager = Locator.GetRequiredService<IUserProjectSettingsManager>();
         _messenger = Locator.GetRequiredService<IMessenger>();
 

--- a/Gum/Program.cs
+++ b/Gum/Program.cs
@@ -109,7 +109,7 @@ namespace Gum
             services.GetRequiredService<IThemingService>().ApplyInitialTheme();
             services.GetRequiredService<ITypeManager>().Initialize();
 
-            ElementTreeViewManager.Self.Initialize();
+            services.GetRequiredService<ElementTreeViewManager>().Initialize();
 
             (services.GetRequiredService<IWireframeObjectManager>() as WireframeObjectManager).Initialize();
             // This has to be initialized very early because other things depend on it.

--- a/Gum/Services/Builder.cs
+++ b/Gum/Services/Builder.cs
@@ -95,6 +95,10 @@ file static class ServiceCollectionExtensions
         services.AddSingleton<IProjectManager>(provider => provider.GetRequiredService<ProjectManager>());
         services.AddSingleton<ICommandLineManager, CommandLineManager>();
         services.AddSingleton<IProjectState, ProjectState>();
+        // ElementTreeViewManager: drained from a static Self singleton (#3286). Concrete is needed for the
+        // Initialize() call in Program.cs (two-stage initialization); no interface is extracted because it is a
+        // bloated WinForms-coupled UI class whose only consumer couples to internal/UI-typed members.
+        services.AddSingleton<ElementTreeViewManager>();
 
         // singletons
         services.AddSingleton<ICircularReferenceManager, CircularReferenceManager>();

--- a/Gum/Undo/UndoManager.cs
+++ b/Gum/Undo/UndoManager.cs
@@ -624,9 +624,6 @@ public class UndoManager : IUndoManager
 
         _fileCommands.TryAutoSaveProject();
         _fileCommands.TryAutoSaveCurrentElement();
-
-        // Don't do this anymore due to filtering through search
-        //ElementTreeViewManager.Self.VerifyComponentsAreInTreeView(Locator.GetRequiredService<IProjectManager>().GumProjectSave);
     }
 
     public bool CanRedo()

--- a/Tool/EditorTabPlugin_XNA/ScrollbarService.cs
+++ b/Tool/EditorTabPlugin_XNA/ScrollbarService.cs
@@ -102,21 +102,6 @@ public class ScrollbarService
 
     public void HandleCameraChanged()
     {
-        // I don't think we need to update
-        // the canvas width or height anymore.
-        // We do that whenever an object is selected...
-        //if (ProjectManager.Self.GumProjectSave != null)
-        //{
-
-        //    scrollBarControlLogic.SetDisplayedArea(
-        //        ProjectManager.Self.GumProjectSave.DefaultCanvasWidth,
-        //        ProjectManager.Self.GumProjectSave.DefaultCanvasHeight);
-        //}
-        //else
-        //{
-        //    scrollBarControlLogic.SetDisplayedArea(800, 600);
-        //}
-
         scrollBarControlLogic.UpdateScrollBars();
         scrollBarControlLogic.UpdateScrollBarsToCameraPosition();
     }


### PR DESCRIPTION
Closes #3286.

## Phase 2 static drain: `ElementTreeViewManager.Self` → DI

Continues the migration off static `*.Self` singletons. `ElementTreeViewManager` was **not in DI at all** — a static `Self` singleton whose parameterless constructor resolved **~21 dependencies via `Locator.GetRequiredService<T>()`** (the `Self` + Service-Locator anti-pattern this phase removes).

### Changes

- **Constructor injection** — the parameterless `Locator`-based constructor now takes its ~21 dependencies as parameters. Body is otherwise unchanged (`_messenger.RegisterAll(this)`, `new CollapseToggleService()`, `new ElementTreeViewCreator()`, `TreeNodeExtensionMethods.ElementTreeViewManager = this`, `AddCursor` all preserved). `CollapseToggleService` / `ElementTreeViewCreator` stay `new`ed — they aren't DI-registered.
- **DI registration** — `services.AddSingleton<ElementTreeViewManager>()` in `Builder.cs`. Concrete (not interface) is needed for the two-stage `Initialize()` call, matching the existing `WireframeObjectManager` pattern.
- **Repoint consumers** — `Program.cs` resolves it from the provider for `Initialize()`; `MainTreeViewPlugin` resolves it via `Locator` (it's a MEF plugin and only `ISelectedState` is exported to `[ImportingConstructor]`; field stays the concrete type).
- **Delete** `mSelf` + the `Self` accessor.

No construction cycle: nothing injects `ElementTreeViewManager` back, so it adds only out-edges to the graph.

### Why no `IElementTreeViewManager` interface

Considered and deliberately skipped. The one real consumer (`MainTreeViewPlugin`) couples to ~16 members of this bloated WinForms-backed class, including two `internal` members — `ObjectTreeView` (returns a WinForms `MultiSelectTreeView`) and `UpdateCollapseButtonSizes`. A faithful interface would force those public and leak a WinForms control type onto a public interface, for ~zero testability gain (nothing unit-tests against a mocked tree-view manager; the class itself isn't unit-testable). Same reason this class was passed over in the earlier interface-based drains (`IProjectManager`, etc., which were service-like). The ~11 method-body `Locator` calls remaining in the class are orthogonal to the singleton drain and left for a focused follow-up.

### Boyscout cleanup

Deleted vestigial dead commented-out `*.Self` references whose accessors were already removed in prior drains:
- `ScrollbarService.cs` — dead `ProjectManager.Self` canvas-update block.
- `FileCommands.cs` — dead `UndoManager.Self.RecordUndo()` note.
- `UndoManager.cs` — dead `ElementTreeViewManager.Self.VerifyComponentsAreInTreeView(...)` note.

### Verification

- Clean `GumFull.sln` build (0 errors).
- Full `GumToolUnitTests` suite: **949 passed, 0 failed, 4 skipped** (pre-existing skips). The existing `ElementTreeViewManager*Tests` exercise static helpers and don't construct the manager, so the ctor change doesn't touch them.
- Behavior-preserving plumbing swap. DI resolution + tree-view population are runtime-observable — see manual-test note on the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
