### PR TITLE
Phase 2 (static drain): PropertyGridManager.Self singleton -> DI

### DIFF
--- a/Gum/Commands/GuiCommands.cs
+++ b/Gum/Commands/GuiCommands.cs
@@ -40,19 +40,23 @@ public class GuiCommands : IGuiCommands
     private readonly Lazy<ISelectedState> _lazySelectedState;
     private readonly IDispatcher _dispatcher;
     private readonly IOutputManager _outputManager;
+    // Lazy because PropertyGridManager depends on IGuiCommands; this breaks the DI construction cycle.
+    private readonly Lazy<PropertyGridManager> _lazyPropertyGridManager;
 
     private ISelectedState _selectedState => _lazySelectedState.Value;
 
     #endregion
 
     public GuiCommands(
-        Lazy<ISelectedState> lazySelectedState, 
-        IDispatcher dispatcher, 
-        IOutputManager outputManager)
+        Lazy<ISelectedState> lazySelectedState,
+        IDispatcher dispatcher,
+        IOutputManager outputManager,
+        Lazy<PropertyGridManager> lazyPropertyGridManager)
     {
         _lazySelectedState = lazySelectedState;
         _dispatcher = dispatcher;
         _outputManager = outputManager;
+        _lazyPropertyGridManager = lazyPropertyGridManager;
     }
     
     public void BroadcastRefreshBehaviorView()
@@ -78,7 +82,7 @@ public class GuiCommands : IGuiCommands
     /// </summary>
     public void RefreshVariableValues()
     {
-        PropertyGridManager.Self.RefreshVariablesDataGridValues();
+        _lazyPropertyGridManager.Value.RefreshVariablesDataGridValues();
     }
 
     public void RefreshElementTreeView()

--- a/Gum/Plugins/InternalPlugins/VariableGrid/MainVariableGridPlugin.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/MainVariableGridPlugin.cs
@@ -28,7 +28,7 @@ public class MainVariableGridPlugin : PriorityPlugin
     public MainVariableGridPlugin()
     {
         _selectedState = Locator.GetRequiredService<ISelectedState>();
-        _propertyGridManager = PropertyGridManager.Self;
+        _propertyGridManager = Locator.GetRequiredService<PropertyGridManager>();
         _variableReferenceLogic = Locator.GetRequiredService<IVariableReferenceLogic>();
         GumExpressionService.Initialize();
     }
@@ -139,7 +139,7 @@ public class MainVariableGridPlugin : PriorityPlugin
     {
         // custom states are states where an animation is playing. This slows down
         // the animation considerably so let's not do it:
-        //PropertyGridManager.Self.RefreshVariablesDataGridValues();
+        //_propertyGridManager.RefreshVariablesDataGridValues();
     }
 
     private void HandleTreeNodeSelected(TreeNode? node)

--- a/Gum/Plugins/InternalPlugins/VariableGrid/PropertyGridManager.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/PropertyGridManager.cs
@@ -48,8 +48,6 @@ public partial class PropertyGridManager
     WpfDataUi.DataUiGrid mVariablesDataGrid;
     MainPropertyGrid mainControl;
 
-    static PropertyGridManager mPropertyGridManager;
-
     ElementSaveDisplayer mPropertyGridDisplayer;
 
     //ToolStripMenuItem mExposeVariable;
@@ -83,20 +81,6 @@ public partial class PropertyGridManager
 
     #region Properties
 
-    [Obsolete("Remove this - all calls to this should instead rely on the PluginManager")]
-    public static PropertyGridManager Self
-    {
-        get
-        {
-            if (mPropertyGridManager == null)
-            {
-                mPropertyGridManager = new PropertyGridManager();
-            }
-            return mPropertyGridManager;
-        }
-    }
-
-
     public VariableSave SelectedBehaviorVariable
     {
         get
@@ -111,26 +95,37 @@ public partial class PropertyGridManager
 
     #endregion
 
-    public PropertyGridManager()
+    public PropertyGridManager(
+        ISelectedState selectedState,
+        IExposeVariableService exposeVariableService,
+        IUndoManager undoManager,
+        IGuiCommands guiCommands,
+        IFileCommands fileCommands,
+        ISetVariableLogic setVariableLogic,
+        IDialogService dialogService,
+        LocalizationService localizationService,
+        ITabManager tabManager,
+        IWireframeObjectManager wireframeObjectManager,
+        TypeManager typeManager,
+        IPluginManager pluginManager,
+        IProjectState projectState,
+        IVariableInCategoryPropagationLogic variableInCategoryPropagationLogic)
     {
-        _selectedState = Locator.GetRequiredService<ISelectedState>();
-        _exposeVariableService =
-            Locator.GetRequiredService<IExposeVariableService>();
-        _undoManager =
-            Locator.GetRequiredService<IUndoManager>();
-        _guiCommands = Locator.GetRequiredService<IGuiCommands>();
+        _selectedState = selectedState;
+        _exposeVariableService = exposeVariableService;
+        _undoManager = undoManager;
+        _guiCommands = guiCommands;
         _objectFinder = ObjectFinder.Self;
-        _setVariableLogic = Locator.GetRequiredService<ISetVariableLogic>();
-        _dialogService = Locator.GetRequiredService<IDialogService>();
-        _fileCommands = Locator.GetRequiredService<IFileCommands>();
-        _localizationService = Locator.GetRequiredService<LocalizationService>();
-        _tabManager = Locator.GetRequiredService<ITabManager>();
-        _wireframeObjectManager = Locator.GetRequiredService<IWireframeObjectManager>();
-        _typeManager = Locator.GetRequiredService<TypeManager>();
-        _pluginManager = Locator.GetRequiredService<IPluginManager>();
-        _projectState = Locator.GetRequiredService<IProjectState>();
-        _stateSaveCategoryDisplayer = new StateSaveCategoryDisplayer(
-            Locator.GetRequiredService<IVariableInCategoryPropagationLogic>());
+        _setVariableLogic = setVariableLogic;
+        _dialogService = dialogService;
+        _fileCommands = fileCommands;
+        _localizationService = localizationService;
+        _tabManager = tabManager;
+        _wireframeObjectManager = wireframeObjectManager;
+        _typeManager = typeManager;
+        _pluginManager = pluginManager;
+        _projectState = projectState;
+        _stateSaveCategoryDisplayer = new StateSaveCategoryDisplayer(variableInCategoryPropagationLogic);
     }
 
     // Normally plugins will initialize through the PluginManager. This needs to happen earlier (see where it's called for info)
@@ -180,7 +175,7 @@ public partial class PropertyGridManager
 
     private void HandleBehaviorVariableSelected(object? sender, EventArgs e)
     {
-        _selectedState.SelectedBehaviorVariable = PropertyGridManager.Self.SelectedBehaviorVariable;
+        _selectedState.SelectedBehaviorVariable = this.SelectedBehaviorVariable;
     }
 
     private void HandleAddVariable(object? sender, EventArgs e)

--- a/Gum/Plugins/InternalPlugins/VariableGrid/SetVariableLogic.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/SetVariableLogic.cs
@@ -558,7 +558,6 @@ public class SetVariableLogic : ISetVariableLogic
     private void ReactIfChangedMemberIsCustomFont(ElementSave parentElement, string changedMember, object oldValue)
     {
         // FIXME: This react needs a proper if condition
-        //PropertyGridManager.Self.RefreshUI(force: true);
     }
 
     private void ReactIfChangedMemberIsUnitType(ElementSave parentElement, string changedMember, object oldValueAsObject)

--- a/Gum/Program.cs
+++ b/Gum/Program.cs
@@ -116,7 +116,7 @@ namespace Gum
 
             // ProperGridManager before MenuStripManager. Why does it need to be initialized before MainMenuStripPlugin?
             // Is htere a way to move this to a plugin?
-            PropertyGridManager.Self.InitializeEarly();
+            services.GetRequiredService<PropertyGridManager>().InitializeEarly();
 
             PluginManager.Self.Initialize();
 

--- a/Gum/Services/Builder.cs
+++ b/Gum/Services/Builder.cs
@@ -99,6 +99,10 @@ file static class ServiceCollectionExtensions
         // Initialize() call in Program.cs (two-stage initialization); no interface is extracted because it is a
         // bloated WinForms-coupled UI class whose only consumer couples to internal/UI-typed members.
         services.AddSingleton<ElementTreeViewManager>();
+        // PropertyGridManager: drained from a static Self singleton (#3288), same pattern as ElementTreeViewManager.
+        // Concrete (no interface) because it is a bloated WinForms/WPF-coupled UI class. SelectedState and GuiCommands
+        // are both consumers AND dependencies of it, so they break the construction cycle by injecting Lazy<PropertyGridManager>.
+        services.AddSingleton<PropertyGridManager>();
 
         // singletons
         services.AddSingleton<ICircularReferenceManager, CircularReferenceManager>();

--- a/Gum/ToolStates/SelectedState.cs
+++ b/Gum/ToolStates/SelectedState.cs
@@ -27,6 +27,8 @@ public class SelectedState : ISelectedState
     private readonly IGuiCommands _guiCommands;
     private readonly PluginManager _pluginManager;
     private readonly IMessenger _messenger;
+    // Lazy because PropertyGridManager depends on ISelectedState; this breaks the DI construction cycle.
+    private readonly Lazy<PropertyGridManager> _lazyPropertyGridManager;
     SelectedStateSnapshot snapshot = new SelectedStateSnapshot();
 
     #endregion
@@ -341,11 +343,13 @@ public class SelectedState : ISelectedState
 
     public SelectedState(IGuiCommands guiCommands,
         PluginManager pluginManager,
-        IMessenger messenger)
+        IMessenger messenger,
+        Lazy<PropertyGridManager> lazyPropertyGridManager)
     {
         _guiCommands = guiCommands;
         _pluginManager = pluginManager;
         _messenger = messenger;
+        _lazyPropertyGridManager = lazyPropertyGridManager;
     }
 
     #region Instance
@@ -746,7 +750,7 @@ public class SelectedState : ISelectedState
             snapshot.SelectedBehaviorVariable = variable;
 
             // This should go through a plugin, an dshould be on the HandleSelect method
-            PropertyGridManager.Self.SelectedBehaviorVariable = variable;
+            _lazyPropertyGridManager.Value.SelectedBehaviorVariable = variable;
         }
     }
 

--- a/Tool/Tests/GumToolUnitTests/ToolStates/SelectedStateTests.cs
+++ b/Tool/Tests/GumToolUnitTests/ToolStates/SelectedStateTests.cs
@@ -7,6 +7,7 @@ using Gum.Plugins;
 using Gum.ToolStates;
 using Moq;
 using Shouldly;
+using System;
 
 namespace GumToolUnitTests.ToolStates;
 
@@ -25,7 +26,10 @@ public class SelectedStateTests : BaseTestClass
         _selectedState = new SelectedState(
             _guiCommands.Object,
             _pluginManager.Object,
-            _messenger.Object);
+            _messenger.Object,
+            // SelectedBehaviorVariable (the only PropertyGridManager use) is not exercised here,
+            // so the factory is never invoked.
+            new Lazy<PropertyGridManager>(() => null!));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Phase 2 static drain of `PropertyGridManager.Self` — the last remaining "no-interface" UI manager backed by a static `Self` singleton. Converts it to constructor injection, registers `services.AddSingleton<PropertyGridManager>()`, repoints the live consumers, and deletes `mPropertyGridManager` + the `[Obsolete]` `Self` accessor.

Same concrete-DI-no-interface pattern as `ElementTreeViewManager` (#3287): a faithful interface would force WinForms/WPF-coupled UI-typed members public for zero testability gain.

## Consumers repointed
- **`Program.cs`** — resolves from the provider for the `InitializeEarly()` call (two-stage init).
- **`MainVariableGridPlugin`** (MEF) — resolves via `Locator` (`[ImportingConstructor]` can only inject `ISelectedState`).
- **`HandleBehaviorVariableSelected`** self-reference → `this`.

## Construction-cycle handling (new vs #3287)
Unlike `ElementTreeViewManager`, two consumers are **also dependencies** of `PropertyGridManager`, so naive injection would deadlock DI construction:
- `SelectedState` (PGM injects `ISelectedState`)
- `GuiCommands` (PGM injects `IGuiCommands`)

Both cycles are broken by injecting `Lazy<PropertyGridManager>` into the **consumer** edge, per the `refactoring-direction` skill ("lazy the consumer's edge to the drained class"). `GuiCommands` already uses this exact pattern for `Lazy<ISelectedState>`. The shared open-generic `Lazy<>` registration in `Builder.cs` resolves `Lazy<PropertyGridManager>` since `PropertyGridManager` is registered.

## Out of scope
`InitializeEarly()` still has method-body `Locator.GetRequiredService<T>()` calls for services not held as fields — left for a separate cleanup to keep this a clean singleton drain (same treatment as #3287).

## Boyscout
- De-stale dead commented `.Self` refs: `MainVariableGridPlugin` → injected idiom; remove the vestigial `PropertyGridManager.Self.RefreshUI(...)` line in `SetVariableLogic` (`RefreshUI` no longer exists).
- Update `SelectedStateTests` for the new ctor param.

## Verification
- Clean `GumFull.sln` build (0 errors).
- Full `GumToolUnitTests` suite green: **949 passed, 4 skipped**.
- Behavior-preserving plumbing swap. Manual smoke test (tool launches + variable grid populates) recommended to confirm the DI graph resolves at startup — unit tests don't build the real container.

Closes #3288

🤖 Generated with [Claude Code](https://claude.com/claude-code)
