### PR TITLE
Version-gate standard-element back-fill so old projects aren't injected with v3 variables (FRB #1881)

### DIFF
--- a/.claude/skills/gum-project-versioning/SKILL.md
+++ b/.claude/skills/gum-project-versioning/SKILL.md
@@ -17,6 +17,12 @@ The `GumProjectSave` **constructor** does NOT default to `NativeVersion`. It def
 
 A **brand-new project** is the opposite case — it seeds the latest standard-element variable surface up front, so it is honestly at `NativeVersion`. The new-project factories (`ProjectManager.CreateNewProject` for the tool, `ProjectCreator.Create` for headless/CLI) therefore stamp `Version = NativeVersion` explicitly in their initializers rather than relying on the ctor default. When adding a new way to create a project, set the version there too — and bump any verbatim-copied template `.gumx` (e.g. the Forms/theme templates) only if its bundled standards actually contain the newer variable surface.
 
+### The standard-element back-fill gate — tag new standard variables (FRB #1881)
+
+On every load, `GumProjectSaveExtensionMethods.Initialize` back-fills each standard element with the tool's current `StandardElementsManager` default variables. This is **version-gated**: it skips any default variable whose `VariableSave.MinimumGumxVersion` exceeds the project's `Version`. **When you add a variable to a standard element's default state that an older runtime won't have, you MUST tag it** — pass `minimumGumxVersion:` to the `Add*Variables` helper, or set `MinimumGumxVersion = …` on the inline `new VariableSave { … }`. Pin it to the *version that introduced the surface* (e.g. `ShapeVariableExpansion`), **not** the floating `NativeVersion` — a floating tag would gate the variable out of projects that legitimately have it after the next bump.
+
+Skip the tag (leave it 0 = always back-fill) only for variables every supported runtime already has. Forgetting the tag is exactly how FRB #1881 happened: opening a pre-v3 project injected the v3 shape surface into its `.gutx`, and FRB1 (which generates its own runtime classes from the standard elements) then emitted code referencing properties its pinned older runtime lacked — a wall of CS0246. This back-fill gate is **separate from** the variable-grid display gate (`ShapeVariableVersionGate`) and the runtime `GumSyntaxVersion` codegen gate; the three don't share a list, so a new variable may need entries in more than one.
+
 ## The three load-time behaviors
 
 `ProjectManager.LoadProject` (~line 201 and ~288 per recent research) compares the file's `Version` against `NativeVersion`:

--- a/Gum/DataTypes/GumProjectSaveExtensionMethods.cs
+++ b/Gum/DataTypes/GumProjectSaveExtensionMethods.cs
@@ -41,9 +41,14 @@ namespace Gum.DataTypes
                 try
                 {
                     StateSave? stateSave = StandardElementsManager.Self.GetDefaultStateFor(standardElementSave.Name);
+                    // Skip back-filling variables newer than the loaded project's version so an
+                    // older project (e.g. a pre-v3 FRB1 project pinned to an older Gum runtime) is
+                    // left byte-stable rather than injected with standard variables its generated
+                    // runtime code can't compile against. See FlatRedBall issue #1881.
+                    StateSave? effectiveDefaultState = FilterDefaultStateForProjectVersion(stateSave, gumProjectSave.Version);
                     // this will result in extra variables being
                     // added
-                    if (standardElementSave.Initialize(stateSave))
+                    if (standardElementSave.Initialize(effectiveDefaultState))
                     {
                         wasModified = true;
                         modifications?.Add($"Standard:{standardElementSave.Name}");
@@ -296,6 +301,40 @@ namespace Gum.DataTypes
             }
         }
 
+        /// <summary>
+        /// Returns the standard-element default state to use when back-filling a loaded element,
+        /// with any variable whose <see cref="VariableSave.MinimumGumxVersion"/> exceeds
+        /// <paramref name="projectVersion"/> removed. Variables default to MinimumGumxVersion 0, so
+        /// pre-v3 variables and every non-shape standard pass through untouched (the original state
+        /// is returned with no clone). Only when a gated variable is actually present does this clone
+        /// and prune, so an older project is not injected with newer standard variables its (older,
+        /// pinned) runtime can't compile. See FlatRedBall issue #1881.
+        /// </summary>
+        private static StateSave? FilterDefaultStateForProjectVersion(StateSave? defaultState, int projectVersion)
+        {
+            if (defaultState == null)
+            {
+                return null;
+            }
+
+            // Gather the gated names off the canonical (un-cloned) default first, then prune by
+            // name — the version tag is read here, before any Clone, so the prune doesn't depend on
+            // whether StateSave.Clone preserves the transient MinimumGumxVersion.
+            HashSet<string> gatedVariableNames = defaultState.Variables
+                .Where(variable => variable.MinimumGumxVersion > projectVersion)
+                .Select(variable => variable.Name)
+                .ToHashSet();
+
+            if (gatedVariableNames.Count == 0)
+            {
+                return defaultState;
+            }
+
+            StateSave filtered = defaultState.Clone();
+            filtered.Variables.RemoveAll(variable => gatedVariableNames.Contains(variable.Name));
+            return filtered;
+        }
+
         public static void FixStandardVariables(this GumProjectSave gumProjectSave)
         {
             foreach (var element in gumProjectSave.StandardElements)
@@ -306,6 +345,14 @@ namespace Gum.DataTypes
                     foreach (var variable in defaultState.Variables)
                     {
                         var variableInLoadedElement = element.DefaultState.GetVariableSave(variable.Name);
+
+                        if (variableInLoadedElement == null)
+                        {
+                            // A version-gated variable that wasn't back-filled into this (older)
+                            // project — there is nothing on the loaded element to reconcile. See
+                            // FilterDefaultStateForProjectVersion / FRB #1881.
+                            continue;
+                        }
 
                         variableInLoadedElement.CanOnlyBeSetInDefaultState = variable.CanOnlyBeSetInDefaultState;
                         variableInLoadedElement.DesiredOrder = variable.DesiredOrder;

--- a/Gum/Managers/StandardElementsManager.cs
+++ b/Gum/Managers/StandardElementsManager.cs
@@ -241,7 +241,7 @@ public class StandardElementsManager
             AddPositioningVariables(stateSave);
             AddDimensionsVariables(stateSave, 100, 100, DimensionVariableAction.DefaultToPercentageOfFile);
             stateSave.Variables.Add(new VariableSave { SetsValue = true, Type = "string", Value = "", Name = "SourceFile", IsFile = true, Category = "Source" });
-            stateSave.Variables.Add(new VariableSave { SetsValue = true, Type = "string", Value = null, Name = "RenderTargetTextureSource", Category = "Source",
+            stateSave.Variables.Add(new VariableSave { SetsValue = true, Type = "string", Value = null, Name = "RenderTargetTextureSource", Category = "Source", MinimumGumxVersion = V3StandardSurfaceVersion,
                 DetailText = "Displays the render target of another Container whose Is Render Target is checked. Takes precedence over SourceFile when set." });
             stateSave.Variables.Add(new VariableSave { SetsValue = true, Type = "bool", Value = true, Name = "Visible", Category = "States and Visibility" });
             stateSave.Variables.Add(new VariableSave { SetsValue = true, Type = "bool", Value = false, Category = "Animation", Name = "Animate" });
@@ -318,7 +318,7 @@ public class StandardElementsManager
 
             stateSave.Variables.Add(new VariableSave { SetsValue = true, Type = "bool", Value = false, Name = "IsRenderTarget", Category = "Rendering" });
 
-            stateSave.Variables.Add(new VariableSave { SetsValue = true, Type = "string", Value = "", Name = "SourceShaderFile", IsFile = true, Category = "Rendering",
+            stateSave.Variables.Add(new VariableSave { SetsValue = true, Type = "string", Value = "", Name = "SourceShaderFile", IsFile = true, Category = "Rendering", MinimumGumxVersion = V3StandardSurfaceVersion,
                 DetailText = "A .fx post-process shader applied to this container's contents when it is drawn to the screen." });
 
             var alphaValue = CreateAlphaVariable();
@@ -411,12 +411,12 @@ public class StandardElementsManager
             // exposure must precede UseGradient so users can scope a gradient to the outline
             // only by flipping IsFilled = false (the fill slot's gradient is gated on _isFilled
             // in SkiaShapeRuntime.RefreshSlotGradients).
-            AddFillAndStrokeVariables(stateSave, category: "Rendering");
+            AddFillAndStrokeVariables(stateSave, category: "Rendering", minimumGumxVersion: V3StandardSurfaceVersion);
             // Issue #3009 — Circle drives the gradient start from the active body color, so no
             // standalone Color1 (Red1/Green1/Blue1/Alpha1).
-            AddGradientVariables(stateSave, includeStartColor: false);
-            AddDropshadowVariables(stateSave);
-            AddBlendVariable(stateSave);
+            AddGradientVariables(stateSave, includeStartColor: false, minimumGumxVersion: V3StandardSurfaceVersion);
+            AddDropshadowVariables(stateSave, minimumGumxVersion: V3StandardSurfaceVersion);
+            AddBlendVariable(stateSave, minimumGumxVersion: V3StandardSurfaceVersion);
 
             // Although rotating a circle about its center does nothing we add rotation because you can rotate it about a different origin
             AddRotationVariable(stateSave);
@@ -452,16 +452,16 @@ public class StandardElementsManager
 
             // v3 (#2929 / #2931): mirror of the Circle block above — see comment there for why
             // AddColorVariables is intentionally omitted.
-            AddFillAndStrokeVariables(stateSave, category: "Rendering");
+            AddFillAndStrokeVariables(stateSave, category: "Rendering", minimumGumxVersion: V3StandardSurfaceVersion);
             // CornerRadius absorbs the legacy RoundedRectangle's rounded-corner surface so that
             // standard can be retired; default 0 keeps the historical hard-cornered visual. Only
             // Rectangle gets this (a Circle has no corners). Gated to v3 in ShapeVariableVersionGate.
-            stateSave.Variables.Add(new VariableSave { SetsValue = true, Type = "float", Value = 0.0f, Name = "CornerRadius", Category = "Rendering" });
+            stateSave.Variables.Add(new VariableSave { SetsValue = true, Type = "float", Value = 0.0f, Name = "CornerRadius", Category = "Rendering", MinimumGumxVersion = V3StandardSurfaceVersion });
             // Issue #3009 — Rectangle drives the gradient start from the active body color, so no
             // standalone Color1 (Red1/Green1/Blue1/Alpha1).
-            AddGradientVariables(stateSave, includeStartColor: false);
-            AddDropshadowVariables(stateSave);
-            AddBlendVariable(stateSave);
+            AddGradientVariables(stateSave, includeStartColor: false, minimumGumxVersion: V3StandardSurfaceVersion);
+            AddDropshadowVariables(stateSave, minimumGumxVersion: V3StandardSurfaceVersion);
+            AddBlendVariable(stateSave, minimumGumxVersion: V3StandardSurfaceVersion);
 
             AddRotationVariable(stateSave);
 
@@ -565,7 +565,7 @@ public class StandardElementsManager
 
             stateSave.Variables.Add(new VariableSave { SetsValue = true, Type = "float?", Value = null, Name = "CustomFrameTextureCoordinateWidth", Category = "Source" });
 
-            stateSave.Variables.Add(new VariableSave { SetsValue = true, Type = "bool", Value = false, Name = "IsTilingMiddleSections", Category = "Source" });
+            stateSave.Variables.Add(new VariableSave { SetsValue = true, Type = "bool", Value = false, Name = "IsTilingMiddleSections", Category = "Source", MinimumGumxVersion = V3StandardSurfaceVersion });
 
             AddVariableReferenceList(stateSave);
 
@@ -1237,6 +1237,36 @@ public class StandardElementsManager
         state.Variables.Add(new VariableSave { SetsValue = true, Type = "bool", Value = true, Name = "Visible", Category = "States and Visibility" });
     }
 
+    // Variables that are part of the v3 native standard surface (the #2929/#2931/#2950 shape
+    // expansion on Circle/Rectangle, plus the later RenderTargetTextureSource / SourceShaderFile /
+    // IsTilingMiddleSections additions) carry this as their MinimumGumxVersion. The load-time
+    // back-fill (GumProjectSaveExtensionMethods.Initialize) skips any variable whose
+    // MinimumGumxVersion exceeds the project's version, so a pre-v3 project (e.g. an older FRB1
+    // project pinned to an older Gum runtime) is left byte-stable instead of being injected with
+    // standard variables its runtime can't compile. See FlatRedBall issue #1881.
+    private const int V3StandardSurfaceVersion = (int)GumProjectSave.GumxVersions.ShapeVariableExpansion;
+
+    // Stamps MinimumGumxVersion on the variables a default-state builder just appended (those at
+    // index >= startIndex) so the load-time back-fill can gate them by project version. A 0 version
+    // is a no-op (the default), keeping the legacy-shape call sites untouched.
+    private static void TagMinimumGumxVersion(StateSave state, int startIndex, int minimumGumxVersion)
+    {
+        if (minimumGumxVersion == 0)
+        {
+            return;
+        }
+        for (int i = startIndex; i < state.Variables.Count; i++)
+        {
+            state.Variables[i].MinimumGumxVersion = minimumGumxVersion;
+        }
+    }
+
+    /// <summary>
+    /// Appends the gradient variables (UseGradient, GradientType, the gradient endpoint positions
+    /// and units, the radial inner/outer radius, and the Color2 second stop) to a standard
+    /// element's default state. Shared by the plain Circle/Rectangle and the legacy Skia shapes.
+    /// </summary>
+    /// <param name="state">The default state to append the gradient variables to.</param>
     /// <param name="includeStartColor">
     /// When true (the default, for Arc and the legacy ColoredCircle/RoundedRectangle/Line shapes)
     /// the standalone gradient start color channels (Red1/Green1/Blue1/Alpha1) are added. Issue
@@ -1244,8 +1274,15 @@ public class StandardElementsManager
     /// (FillColor/StrokeColor) instead of a standalone Color1, so they pass false and these
     /// channels are omitted entirely. Color2 (the standalone second stop) is always added.
     /// </param>
-    public static void AddGradientVariables(StateSave state, bool includeStartColor = true)
+    /// <param name="minimumGumxVersion">
+    /// When non-zero, stamps each appended variable's <see cref="VariableSave.MinimumGumxVersion"/>
+    /// so the load-time back-fill gates them for older projects. Legacy-shape call sites pass 0
+    /// (gradients predate v3 there); the plain Circle/Rectangle pass the v3 surface version.
+    /// </param>
+    public static void AddGradientVariables(StateSave state, bool includeStartColor = true, int minimumGumxVersion = 0)
     {
+        int startIndex = state.Variables.Count;
+
         List<object> xUnitsExclusions = new List<object>();
         xUnitsExclusions.Add(PositionUnitType.PixelsFromTop);
         xUnitsExclusions.Add(PositionUnitType.PercentageHeight);
@@ -1308,11 +1345,15 @@ public class StandardElementsManager
         state.Variables.Add(new VariableSave { SetsValue = true, Type = "int", Value = 255, Name = "Red2", Category = "Rendering" });
         state.Variables.Add(new VariableSave { SetsValue = true, Type = "int", Value = 255, Name = "Green2", Category = "Rendering" });
         state.Variables.Add(new VariableSave { SetsValue = true, Type = "int", Value = 0, Name = "Blue2", Category = "Rendering" });
+
+        TagMinimumGumxVersion(state, startIndex, minimumGumxVersion);
     }
 
 
-    public static void AddDropshadowVariables(StateSave stateSave)
+    public static void AddDropshadowVariables(StateSave stateSave, int minimumGumxVersion = 0)
     {
+        int startIndex = stateSave.Variables.Count;
+
         stateSave.Variables.Add(new VariableSave { SetsValue = true, Type = "bool", Value = false, Name = "HasDropshadow", Category = "Dropshadow" });
 
         stateSave.Variables.Add(new VariableSave { SetsValue = true, Type = "float", Value = 0f, Name = "DropshadowOffsetX", Category = "Dropshadow" });
@@ -1324,6 +1365,8 @@ public class StandardElementsManager
         stateSave.Variables.Add(new VariableSave { SetsValue = true, Type = "int", Value = 0, Name = "DropshadowRed", Category = "Dropshadow" });
         stateSave.Variables.Add(new VariableSave { SetsValue = true, Type = "int", Value = 0, Name = "DropshadowGreen", Category = "Dropshadow" });
         stateSave.Variables.Add(new VariableSave { SetsValue = true, Type = "int", Value = 0, Name = "DropshadowBlue", Category = "Dropshadow" });
+
+        TagMinimumGumxVersion(stateSave, startIndex, minimumGumxVersion);
     }
 
     public static void AddStrokeAndFilledVariables(StateSave stateSave)
@@ -1346,8 +1389,10 @@ public class StandardElementsManager
     // fill, which preserves stroke-only visuals for code-only constructions): IsFilled = false
     // + opaque white fill, so the checkbox honestly says "no fill" and flipping it lights up a
     // visible fill instead of being a no-op against alpha 0.
-    public static void AddFillAndStrokeVariables(StateSave stateSave, string category = "Rendering")
+    public static void AddFillAndStrokeVariables(StateSave stateSave, string category = "Rendering", int minimumGumxVersion = 0)
     {
+        int startIndex = stateSave.Variables.Count;
+
         // Stroke section. Dashed strokes aren't supported on plain Circle / Rectangle, so unlike
         // the legacy AddStrokeAndFilledVariables there is no StrokeDashLength / StrokeGapLength here.
         stateSave.Variables.Add(new VariableSave { SetsValue = true, Type = "float", Value = 2.0f, Name = "StrokeWidth", Category = category });
@@ -1364,11 +1409,13 @@ public class StandardElementsManager
         stateSave.Variables.Add(new VariableSave { SetsValue = true, Type = "int", Value = 255, Name = "FillRed", Category = category });
         stateSave.Variables.Add(new VariableSave { SetsValue = true, Type = "int", Value = 255, Name = "FillGreen", Category = category });
         stateSave.Variables.Add(new VariableSave { SetsValue = true, Type = "int", Value = 255, Name = "FillBlue", Category = category });
+
+        TagMinimumGumxVersion(stateSave, startIndex, minimumGumxVersion);
     }
 
-    public static void AddBlendVariable(StateSave stateSave)
+    public static void AddBlendVariable(StateSave stateSave, int minimumGumxVersion = 0)
     {
-        var blendariable = new VariableSave { SetsValue = true, Type = "Blend", Value = Gum.RenderingLibrary.Blend.Normal, Name = "Blend", Category = "Rendering" };
+        var blendariable = new VariableSave { SetsValue = true, Type = "Blend", Value = Gum.RenderingLibrary.Blend.Normal, Name = "Blend", Category = "Rendering", MinimumGumxVersion = minimumGumxVersion };
 
         stateSave.Variables.Add(blendariable);
     }

--- a/GumDataTypes/Variables/VariableSave.cs
+++ b/GumDataTypes/Variables/VariableSave.cs
@@ -186,6 +186,20 @@ public class VariableSave
         set;
     }
 
+    /// <summary>
+    /// The minimum <see cref="GumProjectSave.GumxVersions"/> a project must declare for the
+    /// load-time standard-element back-fill to inject this variable. 0 (the default) means "always
+    /// back-fill". Set on the canonical default-state definitions in <c>StandardElementsManager</c>
+    /// for variables that postdate the v2 baseline (the v3 shape surface, plus
+    /// RenderTargetTextureSource / SourceShaderFile / IsTilingMiddleSections);
+    /// <c>GumProjectSaveExtensionMethods.Initialize</c> skips any whose value exceeds the project's
+    /// version so older projects (e.g. an FRB1 project pinned to an older Gum runtime) stay
+    /// byte-stable and their generated runtime code doesn't reference properties the runtime lacks.
+    /// Transient authoring metadata on the in-memory defaults; never serialized. See FRB issue #1881.
+    /// </summary>
+    [XmlIgnore]
+    public int MinimumGumxVersion { get; set; }
+
     [XmlIgnore]
     public Dictionary<string, object?> PropertiesToSetOnDisplayer { get; private set; } = new Dictionary<string, object?>();
 

--- a/Tool/Tests/GumToolUnitTests/DataTypes/StandardElementBackfillVersionGateTests.cs
+++ b/Tool/Tests/GumToolUnitTests/DataTypes/StandardElementBackfillVersionGateTests.cs
@@ -196,6 +196,28 @@ public class StandardElementBackfillVersionGateTests : BaseTestClass
         variable.MinimumGumxVersion.ShouldBe(0);
     }
 
+    [Theory]
+    // The gate only skips AUTO-injecting a gated variable into a pre-v3 standard. A value the user
+    // explicitly set on a v2 project must survive the load untouched — the back-fill never removes
+    // or rewrites a variable already present in the loaded element. (FRB #1881 maintainer call:
+    // "they should, of course, still work if they were manually set before on V2".)
+    [InlineData("Container", "SourceShaderFile", "Effects/Bloom.fx")]
+    [InlineData("Sprite", "RenderTargetTextureSource", "BackgroundContainer")]
+    public void Initialize_PreservesManuallySetGatedVariable_OnPreV3Project(
+        string standardName, string variableName, string value)
+    {
+        GumProjectSave project = MakeProjectWithBareStandard(standardName, PreV3, "Visible");
+        StateSave loadedDefault = project.StandardElements.Single(e => e.Name == standardName).DefaultState;
+        loadedDefault.Variables.Add(new VariableSave { Name = variableName, Type = "string", Value = value, SetsValue = true });
+
+        project.Initialize();
+
+        VariableSave preserved = project.StandardElements.Single(e => e.Name == standardName).DefaultState
+            .Variables.FirstOrDefault(v => v.Name == variableName);
+        preserved.ShouldNotBeNull();
+        preserved.Value.ShouldBe(value);
+    }
+
     [Fact]
     public void FixStandardVariables_DoesNotThrow_WhenGatedVariablesAreAbsent_OnPreV3Project()
     {

--- a/Tool/Tests/GumToolUnitTests/DataTypes/StandardElementBackfillVersionGateTests.cs
+++ b/Tool/Tests/GumToolUnitTests/DataTypes/StandardElementBackfillVersionGateTests.cs
@@ -1,0 +1,210 @@
+using Gum.DataTypes;
+using Gum.DataTypes.Variables;
+using Gum.Managers;
+using Shouldly;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace GumToolUnitTests.DataTypes;
+
+/// <summary>
+/// Pins the version-gated standard-element back-fill (FlatRedBall issue #1881). Opening a project
+/// runs <see cref="GumProjectSaveExtensionMethods.Initialize"/>, which back-fills each standard
+/// element with the tool's current default variables. That back-fill used to be version-unaware, so
+/// opening an old project injected the v3 shape surface (gradient / dropshadow / blend / fill+stroke
+/// channels) plus newer per-standard variables (RenderTargetTextureSource, SourceShaderFile,
+/// IsTilingMiddleSections) into its standard <c>.gutx</c> files and re-saved them. Because FRB1
+/// generates its own runtime classes from those standard elements, the regenerated runtime then
+/// referenced properties the project's pinned (older) Gum runtime doesn't have — a wall of CS0246.
+/// These tests assert a pre-v3 project is left byte-stable while a v3 project still gets the surface.
+/// </summary>
+public class StandardElementBackfillVersionGateTests : BaseTestClass
+{
+    private const int PreV3 = (int)GumProjectSave.GumxVersions.AttributeVersion;     // 2
+    private const int V3 = (int)GumProjectSave.GumxVersions.ShapeVariableExpansion;  // 3
+
+    // Variables added to the plain Circle / Rectangle in the v3 shape-variable expansion
+    // (#2929/#2931/#2950). None existed on a pre-v3 shape, and none exist on the older FRB-pinned
+    // runtime, so injecting any of them into a pre-v3 project breaks that project's generated code.
+    private static readonly string[] V3ShapeVariables =
+    {
+        // Fill + stroke channels (AddFillAndStrokeVariables)
+        "IsFilled", "FillRed", "FillGreen", "FillBlue", "FillAlpha",
+        "StrokeWidth", "StrokeRed", "StrokeGreen", "StrokeBlue", "StrokeAlpha",
+        // Gradient (AddGradientVariables)
+        "UseGradient", "GradientType",
+        "GradientX1", "GradientX1Units", "GradientY1", "GradientY1Units",
+        "GradientX2", "GradientX2Units", "GradientY2", "GradientY2Units",
+        "GradientInnerRadius", "GradientInnerRadiusUnits",
+        "GradientOuterRadius", "GradientOuterRadiusUnits",
+        "Red2", "Green2", "Blue2", "Alpha2",
+        // Dropshadow (AddDropshadowVariables)
+        "HasDropshadow", "DropshadowOffsetX", "DropshadowOffsetY", "DropshadowBlur",
+        "DropshadowAlpha", "DropshadowRed", "DropshadowGreen", "DropshadowBlue",
+        // Blend (AddBlendVariable)
+        "Blend",
+    };
+
+    // A standard element as an older tool would have saved it: a Default state holding only the
+    // pre-v3 surface for that type. The exact classic variables don't matter to these tests (the
+    // back-fill adds the rest of the non-gated surface anyway) — what matters is that the gated
+    // variables are absent to start, so we can assert the load-time back-fill does not add them.
+    private static GumProjectSave MakeProjectWithBareStandard(string standardName, int version,
+        params string[] classicVariableNames)
+    {
+        var variables = classicVariableNames
+            .Select(name => new VariableSave { Name = name, Type = "float", Value = 0f, SetsValue = true })
+            .ToList();
+
+        var standard = new StandardElementSave
+        {
+            Name = standardName,
+            States = new List<StateSave> { new StateSave { Name = "Default", Variables = variables } }
+        };
+
+        var project = new GumProjectSave { Version = version };
+        project.StandardElements.Add(standard);
+        return project;
+    }
+
+    private static StateSave DefaultStateAfterInitialize(GumProjectSave project, string standardName)
+    {
+        project.Initialize();
+        return project.StandardElements.Single(e => e.Name == standardName).DefaultState;
+    }
+
+    [Fact]
+    public void Initialize_DoesNotInjectV3ShapeVariables_IntoPreV3CircleStandard()
+    {
+        var project = MakeProjectWithBareStandard("Circle", PreV3, "Width", "Height", "Visible", "Alpha", "Blue");
+
+        var circleDefault = DefaultStateAfterInitialize(project, "Circle");
+
+        foreach (var gatedVariable in V3ShapeVariables)
+        {
+            circleDefault.Variables.Any(v => v.Name == gatedVariable).ShouldBeFalse(
+                $"A pre-v3 project must not have the v3 shape variable '{gatedVariable}' back-filled into its Circle standard.");
+        }
+    }
+
+    [Fact]
+    public void Initialize_DoesNotInjectV3ShapeVariables_IntoPreV3RectangleStandard()
+    {
+        var project = MakeProjectWithBareStandard("Rectangle", PreV3, "Width", "Height", "Visible");
+
+        var rectangleDefault = DefaultStateAfterInitialize(project, "Rectangle");
+
+        foreach (var gatedVariable in V3ShapeVariables.Append("CornerRadius"))
+        {
+            rectangleDefault.Variables.Any(v => v.Name == gatedVariable).ShouldBeFalse(
+                $"A pre-v3 project must not have the v3 shape variable '{gatedVariable}' back-filled into its Rectangle standard.");
+        }
+    }
+
+    [Fact]
+    public void Initialize_InjectsV3ShapeVariables_IntoV3CircleStandard()
+    {
+        var project = MakeProjectWithBareStandard("Circle", V3, "Width", "Height", "Visible");
+
+        var circleDefault = DefaultStateAfterInitialize(project, "Circle");
+
+        foreach (var gatedVariable in V3ShapeVariables)
+        {
+            circleDefault.Variables.Any(v => v.Name == gatedVariable).ShouldBeTrue(
+                $"A v3 project should still get the v3 shape variable '{gatedVariable}' on its Circle standard.");
+        }
+    }
+
+    [Fact]
+    public void Initialize_PreservesClassicVariables_OnPreV3CircleStandard()
+    {
+        var project = MakeProjectWithBareStandard("Circle", PreV3, "Width", "Height", "Visible", "Alpha", "Blue");
+
+        var circleDefault = DefaultStateAfterInitialize(project, "Circle");
+
+        // The classic surface the old runtime DOES support must survive the gated load untouched.
+        circleDefault.Variables.Any(v => v.Name == "Width").ShouldBeTrue();
+        circleDefault.Variables.Any(v => v.Name == "Visible").ShouldBeTrue();
+        circleDefault.Variables.Any(v => v.Name == "Alpha").ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Initialize_DoesNotInjectRenderTargetTextureSource_IntoPreV3SpriteStandard()
+    {
+        var project = MakeProjectWithBareStandard("Sprite", PreV3, "Visible");
+
+        var spriteDefault = DefaultStateAfterInitialize(project, "Sprite");
+
+        spriteDefault.Variables.Any(v => v.Name == "RenderTargetTextureSource").ShouldBeFalse();
+        // A pre-v3 Sprite still gets the rest of its classic surface back-filled.
+        spriteDefault.Variables.Any(v => v.Name == "SourceFile").ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Initialize_DoesNotInjectIsTilingMiddleSections_IntoPreV3NineSliceStandard()
+    {
+        var project = MakeProjectWithBareStandard("NineSlice", PreV3, "Visible");
+
+        var nineSliceDefault = DefaultStateAfterInitialize(project, "NineSlice");
+
+        nineSliceDefault.Variables.Any(v => v.Name == "IsTilingMiddleSections").ShouldBeFalse();
+        nineSliceDefault.Variables.Any(v => v.Name == "SourceFile").ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Initialize_DoesNotInjectSourceShaderFile_IntoPreV3ContainerStandard()
+    {
+        var project = MakeProjectWithBareStandard("Container", PreV3, "Visible");
+
+        var containerDefault = DefaultStateAfterInitialize(project, "Container");
+
+        containerDefault.Variables.Any(v => v.Name == "SourceShaderFile").ShouldBeFalse();
+    }
+
+    [Theory]
+    // The canonical default-state definitions tag their post-v2 variables with MinimumGumxVersion =
+    // v3 so the back-fill can gate them. This pins the mechanism the behavior tests above rely on.
+    [InlineData("Circle", "Blend")]
+    [InlineData("Circle", "FillRed")]
+    [InlineData("Circle", "StrokeWidth")]
+    [InlineData("Circle", "HasDropshadow")]
+    [InlineData("Circle", "UseGradient")]
+    [InlineData("Rectangle", "CornerRadius")]
+    [InlineData("Sprite", "RenderTargetTextureSource")]
+    [InlineData("NineSlice", "IsTilingMiddleSections")]
+    [InlineData("Container", "SourceShaderFile")]
+    public void DefaultState_TagsPostV2Variable_WithV3MinimumGumxVersion(string standardName, string variableName)
+    {
+        StateSave defaultState = StandardElementsManager.Self.DefaultStates[standardName];
+
+        VariableSave variable = defaultState.Variables.First(v => v.Name == variableName);
+        variable.MinimumGumxVersion.ShouldBe(V3);
+    }
+
+    [Theory]
+    // Classic, always-supported variables stay untagged (MinimumGumxVersion 0) so they are always
+    // back-filled, even into the oldest projects.
+    [InlineData("Circle", "Width")]
+    [InlineData("Circle", "Visible")]
+    [InlineData("Sprite", "SourceFile")]
+    public void DefaultState_LeavesClassicVariable_Untagged(string standardName, string variableName)
+    {
+        StateSave defaultState = StandardElementsManager.Self.DefaultStates[standardName];
+
+        VariableSave variable = defaultState.Variables.First(v => v.Name == variableName);
+        variable.MinimumGumxVersion.ShouldBe(0);
+    }
+
+    [Fact]
+    public void FixStandardVariables_DoesNotThrow_WhenGatedVariablesAreAbsent_OnPreV3Project()
+    {
+        // After the gated back-fill the loaded Circle lacks the v3 variables, but the canonical
+        // default state still lists them. FixStandardVariables reconciles per-variable metadata by
+        // looking each default variable up on the loaded element — it must tolerate the misses.
+        var project = MakeProjectWithBareStandard("Circle", PreV3, "Width", "Height", "Visible");
+        project.Initialize();
+
+        Should.NotThrow(() => project.FixStandardVariables());
+    }
+}


### PR DESCRIPTION
## Problem

Opening an old project in the current Gum tool broke the consuming game's build with a wall of `CS0246` errors. Reported against FlatRedBall: **vchelaru/FlatRedBall#1881** (screenshots there show `Circle.gutx` +299 lines, `Rectangle.gutx` +266, and `CircleRuntime.Generated.cs`/`RectangleRuntime.Generated.cs` ballooning ~1630 lines, all referencing types the project's pinned older Gum runtime doesn't have).

Root cause: the load-time back-fill is **version-unaware**. `GumProjectSave.Initialize` → `ElementSave.Initialize` → `AddAndModifyVariablesAccordingToDefault` adds every variable the tool's current `StandardElementsManager` default defines but the loaded standard element lacks — with no check against the project's `.gumx` `Version`. So opening a pre-v3 project injected:

- the v3 shape surface (gradient / dropshadow / blend / fill+stroke channels + `CornerRadius`) onto **Circle / Rectangle**, plus
- the newer `RenderTargetTextureSource` (**Sprite**), `SourceShaderFile` (**Container**), and `IsTilingMiddleSections` (**NineSlice**)

into the standard `.gutx` files and re-saved them. Because **FRB1 generates its own runtime classes from the standard elements**, the regenerated runtime then referenced properties the project's pinned older Gum runtime doesn't have. The `.gumx` version never mattered — it was only consulted by the variable-grid *display* gate (`ShapeVariableVersionGate`) and legacy-shape seeding, never by the back-fill.

## Fix

Make the back-fill version-aware via a per-variable tag:

- **`VariableSave.MinimumGumxVersion`** — new transient (`[XmlIgnore]`) tag; `0` = always back-fill.
- **`StandardElementsManager`** tags the post-v2 default-state variables with it (`ShapeVariableExpansion` = v3): threaded through the `Add{Gradient,Dropshadow,FillAndStroke,Blend}Variables` helpers for Circle/Rectangle, and set inline on the Sprite/Container/NineSlice additions. Legacy Skia shapes pass `0` (those variables predate v3 there), so they're untouched.
- **`GumProjectSaveExtensionMethods.Initialize`** filters the canonical default state by project version (`FilterDefaultStateForProjectVersion`) before back-filling. A pre-v3 project is left **byte-stable**; a v3 project still gets the full surface.
- **`FixStandardVariables`** null-guarded — it previously assumed every default variable exists on the loaded element (would NPE now that gated variables can be absent).

Pinned to `ShapeVariableExpansion`, **not** the floating `NativeVersion`, so a future version bump doesn't retroactively gate these out of projects that legitimately have them.

The gate only skips *auto-injecting* a missing variable — it never removes or rewrites a variable already present in the loaded `.gutx`, so a value the user set manually on a v2 project survives the load (covered by a test).

**Runtime appearance is unchanged.** The runtime ctor defaults (`IsFilled = true` + transparent fill) render the same outline-only visual the injected tool defaults (`IsFilled = false` + opaque fill) did, and all pre-v3 plain Circles were outline-only line circles. The runtime load path (`GumService`) therefore renders pre-v3 projects identically.

## Scope of what's gated (maintainer-confirmed)

A `git` audit of recent standard-variable additions guided which variables genuinely need gating (i.e. the pinned older runtime lacks them):

| Variable(s) | Standard | Gated to v3? |
|---|---|---|
| v3 shape surface (gradient / dropshadow / blend / fill+stroke / `CornerRadius`) | Circle / Rectangle | **Yes** |
| `IsTilingMiddleSections` | NineSlice | **Yes** |
| `RenderTargetTextureSource` (render-target source) | Sprite | **Yes** |
| `SourceShaderFile` (.fx post-process shader) | Container | **Yes** |
| `IsRenderTarget` | Container | No — runtime supports it |
| `MaxWidth` / `MaxHeight` / `MinWidth` / `MinHeight` / `MaxNumberOfLines` | Container / Text | No — core layout/text props, treated as runtime-stable |

The per-variable approach is fail-open by nature (a future un-tagged variable would slip through); the `gum-project-versioning` skill now documents the requirement so new standard variables get tagged.

## Tests

`StandardElementBackfillVersionGateTests` (22 tests, TDD red→green):

- Pre-v3 project: Circle / Rectangle do **not** gain the v3 shape surface; Sprite no `RenderTargetTextureSource`; NineSlice no `IsTilingMiddleSections`; Container no `SourceShaderFile`.
- v3 project: Circle **does** get the full v3 surface (no over-gating).
- Classic variables (Width / Visible / SourceFile) are still back-filled on pre-v3 projects.
- A v3-gated variable set **manually** on a v2 project survives the load with its value.
- The `MinimumGumxVersion` tags are present on post-v2 variables and absent (0) on classic ones.
- `FixStandardVariables` doesn't throw when gated variables are absent.

Full `GumToolUnitTests` (969) and `MonoGameGum.Tests` (1751) pass; zero new warnings.

## Note on the linked issue

The issue lives in the **FlatRedBall** repo (vchelaru/FlatRedBall#1881) while the fix is in **Gum**, so GitHub can't auto-close it from this PR — please close it manually once this merges (and after picking up the new Gum runtime in FRB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
