### PR TITLE
Phase 2 (static drain): PluginManager.Self singleton -> DI

### DIFF
--- a/Gum/Commands/FileCommands.cs
+++ b/Gum/Commands/FileCommands.cs
@@ -28,6 +28,7 @@ public class FileCommands : IFileCommands
     private readonly IOutputManager _outputManager;
     private readonly IProjectManager _projectManager;
     private readonly IProjectState _projectState;
+    private readonly IPluginManager _pluginManager;
 
     public FileCommands(ISelectedState selectedState,
         Lazy<IUndoManager> undoManager,
@@ -37,7 +38,8 @@ public class FileCommands : IFileCommands
         IOutputManager outputManager,
         IFileWatchIgnoreList fileWatchIgnoreList,
         IProjectManager projectManager,
-        IProjectState projectState)
+        IProjectState projectState,
+        IPluginManager pluginManager)
     {
         _selectedState = selectedState;
         _undoManager = undoManager;
@@ -48,6 +50,7 @@ public class FileCommands : IFileCommands
         _outputManager = outputManager;
         _projectManager = projectManager;
         _projectState = projectState;
+        _pluginManager = pluginManager;
 
     }
 
@@ -268,7 +271,7 @@ public class FileCommands : IFileCommands
 
             if (shouldSave)
             {
-                PluginManager.Self.BeforeSavingElementSave(elementSave);
+                _pluginManager.BeforeSavingElementSave(elementSave);
 
                 var fileName = elementSave.GetFullPathXmlFile();
 
@@ -317,11 +320,11 @@ public class FileCommands : IFileCommands
                 if (succeeded)
                 {
                     _outputManager.AddOutput("Saved " + elementSave + " to " + fileName);
-                    PluginManager.Self.AfterSavingElementSave(elementSave);
+                    _pluginManager.AfterSavingElementSave(elementSave);
                 }
             }
 
-            PluginManager.Self.Export(elementSave);
+            _pluginManager.Export(elementSave);
         }
     }
 

--- a/Gum/Commands/GuiCommands.cs
+++ b/Gum/Commands/GuiCommands.cs
@@ -42,6 +42,7 @@ public class GuiCommands : IGuiCommands
     private readonly IOutputManager _outputManager;
     // Lazy because PropertyGridManager depends on IGuiCommands; this breaks the DI construction cycle.
     private readonly Lazy<PropertyGridManager> _lazyPropertyGridManager;
+    private readonly PluginManager _pluginManager;
 
     private ISelectedState _selectedState => _lazySelectedState.Value;
 
@@ -51,17 +52,19 @@ public class GuiCommands : IGuiCommands
         Lazy<ISelectedState> lazySelectedState,
         IDispatcher dispatcher,
         IOutputManager outputManager,
-        Lazy<PropertyGridManager> lazyPropertyGridManager)
+        Lazy<PropertyGridManager> lazyPropertyGridManager,
+        PluginManager pluginManager)
     {
         _lazySelectedState = lazySelectedState;
         _dispatcher = dispatcher;
         _outputManager = outputManager;
         _lazyPropertyGridManager = lazyPropertyGridManager;
+        _pluginManager = pluginManager;
     }
     
     public void BroadcastRefreshBehaviorView()
     {
-        PluginManager.Self.RefreshBehaviorView(
+        _pluginManager.RefreshBehaviorView(
             _selectedState.SelectedElement);
     }
 
@@ -69,12 +72,12 @@ public class GuiCommands : IGuiCommands
 
     public void RefreshStateTreeView()
     {
-        PluginManager.Self.RefreshStateTreeView();
+        _pluginManager.RefreshStateTreeView();
     }
 
     public void RefreshVariables(bool force = false)
     {
-        PluginManager.Self.RefreshVariableView(force);
+        _pluginManager.RefreshVariableView(force);
     }
 
     /// <summary>
@@ -87,12 +90,12 @@ public class GuiCommands : IGuiCommands
 
     public void RefreshElementTreeView()
     {
-        PluginManager.Self.RefreshElementTreeView();
+        _pluginManager.RefreshElementTreeView();
     }
 
     public void RefreshElementTreeView(IInstanceContainer instanceContainer)
     {
-        PluginManager.Self.RefreshElementTreeView(instanceContainer);
+        _pluginManager.RefreshElementTreeView(instanceContainer);
     }
 
     #endregion
@@ -123,7 +126,7 @@ public class GuiCommands : IGuiCommands
 
     public void FocusSearch()
     {
-        PluginManager.Self.FocusSearch();
+        _pluginManager.FocusSearch();
     }
 
     /// <inheritdoc/>

--- a/Gum/Commands/WireframeCommands.cs
+++ b/Gum/Commands/WireframeCommands.cs
@@ -6,9 +6,12 @@ namespace Gum.Commands;
 public class WireframeCommands : IWireframeCommands
 {
     private readonly IWireframeObjectManager _wireframeObjectManager;
-    public WireframeCommands(IWireframeObjectManager wireframeObjectManager)
+    private readonly PluginManager _pluginManager;
+    public WireframeCommands(IWireframeObjectManager wireframeObjectManager,
+        PluginManager pluginManager)
     {
         _wireframeObjectManager = wireframeObjectManager;
+        _pluginManager = pluginManager;
     }
 
     public void Refresh(bool forceLayout = true, bool forceReloadContent = false)
@@ -23,7 +26,7 @@ public class WireframeCommands : IWireframeCommands
         set
         {
             areRulersVisible = value;
-            PluginManager.Self.WireframePropertyChanged(nameof(AreRulersVisible));
+            _pluginManager.WireframePropertyChanged(nameof(AreRulersVisible));
         }
     }
 
@@ -34,7 +37,7 @@ public class WireframeCommands : IWireframeCommands
         set
         {
             areCanvasBoundsVisible = value;
-            PluginManager.Self.WireframePropertyChanged(nameof(AreCanvasBoundsVisible));
+            _pluginManager.WireframePropertyChanged(nameof(AreCanvasBoundsVisible));
         }
     }
 
@@ -45,7 +48,7 @@ public class WireframeCommands : IWireframeCommands
         set
         {
             isBackgroundGridVisible = value;
-            PluginManager.Self.WireframePropertyChanged(nameof(IsBackgroundGridVisible));
+            _pluginManager.WireframePropertyChanged(nameof(IsBackgroundGridVisible));
         }
     }
 
@@ -57,7 +60,7 @@ public class WireframeCommands : IWireframeCommands
         set
         {
             areHighlightsVisible = value;
-            PluginManager.Self.WireframePropertyChanged(nameof(AreHighlightsVisible));
+            _pluginManager.WireframePropertyChanged(nameof(AreHighlightsVisible));
         }
     }
 }

--- a/Gum/DataTypes/StateSaveExtensionMethods.GumTool.cs
+++ b/Gum/DataTypes/StateSaveExtensionMethods.GumTool.cs
@@ -10,7 +10,7 @@ namespace Gum.DataTypes.Variables
 {
     internal static class StateSaveExtensionMethodsGumTool
     {
-        public static void ReactToInstanceNameChange(this StateSave stateSave, InstanceSave instanceSave, string oldName, string newName)
+        public static void ReactToInstanceNameChange(this StateSave stateSave, InstanceSave instanceSave, string oldName, string newName, IPluginManager pluginManager)
         {
             foreach (VariableSave variable in stateSave.Variables)
             {
@@ -48,7 +48,7 @@ namespace Gum.DataTypes.Variables
                 }
             }
 
-            PluginManager.Self.InstanceRename(instanceSave.ParentContainer, instanceSave, oldName);
+            pluginManager.InstanceRename(instanceSave.ParentContainer, instanceSave, oldName);
 
         }
 

--- a/Gum/Logic/RenameLogic.cs
+++ b/Gum/Logic/RenameLogic.cs
@@ -1008,7 +1008,7 @@ public class RenameLogic : IRenameLogic
             {
                 foreach (StateSave stateSave in _selectedState.SelectedElement.AllStates)
                 {
-                    stateSave.ReactToInstanceNameChange(instance, oldName, newName);
+                    stateSave.ReactToInstanceNameChange(instance, oldName, newName, _pluginManager);
                 }
 
                 foreach (var eventSave in _selectedState.SelectedElement.Events)

--- a/Gum/Managers/FileChangeReactionLogic.cs
+++ b/Gum/Managers/FileChangeReactionLogic.cs
@@ -92,7 +92,7 @@ namespace Gum.Managers
                 ReactToLocalizationFileChanged(file);
             }
 
-            PluginManager.Self.ReactToFileChanged(file);
+            _pluginManager.ReactToFileChanged(file);
         }
 
         private void ReactToLocalizationFileChanged(FilePath file)

--- a/Gum/Managers/ProjectManager.cs
+++ b/Gum/Managers/ProjectManager.cs
@@ -49,6 +49,7 @@ public class ProjectManager : IProjectManager
     // Lazy because CommandLineManager depends back on IProjectManager (ReadCommandLine's
     // rebuild-fonts path reads GumProjectSave) — deferring it breaks the construction cycle.
     private readonly Lazy<ICommandLineManager> _commandLineManager;
+    private readonly IPluginManager _pluginManager;
 
     #endregion
 
@@ -84,7 +85,8 @@ public class ProjectManager : IProjectManager
         Lazy<IFileWatchManager> fileWatchManager,
         IStandardElementsManagerGumTool standardElementsManagerGumTool,
         IRetryService retryService,
-        Lazy<ICommandLineManager> commandLineManager)
+        Lazy<ICommandLineManager> commandLineManager,
+        IPluginManager pluginManager)
     {
         _selectedState = selectedState;
         _elementCommands = elementCommands;
@@ -96,6 +98,7 @@ public class ProjectManager : IProjectManager
         _standardElementsManagerGumTool = standardElementsManagerGumTool;
         _retryService = retryService;
         _commandLineManager = commandLineManager;
+        _pluginManager = pluginManager;
     }
 
     public void LoadSettings()
@@ -166,7 +169,7 @@ public class ProjectManager : IProjectManager
 
         StandardElementsManager.Self.PopulateProjectWithDefaultStandards(_gumProjectSave);
 
-        PluginManager.Self.ProjectLoad(_gumProjectSave);
+        _pluginManager.ProjectLoad(_gumProjectSave);
 
         _fileCommands.Value.LoadLocalizationFile();
     }
@@ -311,7 +314,7 @@ public class ProjectManager : IProjectManager
             {
                 modifications.Add(nameof(FixRecursiveAssignments));
             }
-            PluginManager.Self.ProjectLoad(_gumProjectSave);
+            _pluginManager.ProjectLoad(_gumProjectSave);
 
             if (_gumProjectSave.Version < (int)GumProjectSave.GumxVersions.AttributeVersion)
             {
@@ -748,7 +751,7 @@ public class ProjectManager : IProjectManager
 
             if (shouldSave)
             {
-                PluginManager.Self.BeforeSavingProjectSave(GumProjectSave);
+                _pluginManager.BeforeSavingProjectSave(GumProjectSave);
 
                 _elementCommands.Value.SortVariables();
 
@@ -763,17 +766,17 @@ public class ProjectManager : IProjectManager
                     {
                         foreach (var screenSave in GumProjectSave.Screens)
                         {
-                            PluginManager.Self.BeforeSavingElementSave(screenSave);
+                            _pluginManager.BeforeSavingElementSave(screenSave);
                             _fileWatchManager.Value.IgnoreNextChangeUntil(screenSave.GetFullPathXmlFile());
                         }
                         foreach (var componentSave in GumProjectSave.Components)
                         {
-                            PluginManager.Self.BeforeSavingElementSave(componentSave);
+                            _pluginManager.BeforeSavingElementSave(componentSave);
                             _fileWatchManager.Value.IgnoreNextChangeUntil(componentSave.GetFullPathXmlFile());
                         }
                         foreach (var standardElementSave in GumProjectSave.StandardElements)
                         {
-                            PluginManager.Self.BeforeSavingElementSave(standardElementSave);
+                            _pluginManager.BeforeSavingElementSave(standardElementSave);
                             _fileWatchManager.Value.IgnoreNextChangeUntil(standardElementSave.GetFullPathXmlFile());
                         }
                     }
@@ -787,15 +790,15 @@ public class ProjectManager : IProjectManager
                     {
                         foreach (var screenSave in GumProjectSave.Screens)
                         {
-                            PluginManager.Self.AfterSavingElementSave(screenSave);
+                            _pluginManager.AfterSavingElementSave(screenSave);
                         }
                         foreach (var componentSave in GumProjectSave.Components)
                         {
-                            PluginManager.Self.AfterSavingElementSave(componentSave);
+                            _pluginManager.AfterSavingElementSave(componentSave);
                         }
                         foreach (var standardElementSave in GumProjectSave.StandardElements)
                         {
-                            PluginManager.Self.AfterSavingElementSave(standardElementSave);
+                            _pluginManager.AfterSavingElementSave(standardElementSave);
                         }
                     }
                 }
@@ -820,7 +823,7 @@ public class ProjectManager : IProjectManager
 
                 if (succeeded)
                 {
-                    PluginManager.Self.ProjectSave(GumProjectSave);
+                    _pluginManager.ProjectSave(GumProjectSave);
                     GeneralSettingsFile.AddToRecentFilesIfNew(GumProjectSave.FullFileName);
                     GeneralSettingsFile.LastProject = GumProjectSave.FullFileName;
                     GeneralSettingsFile.Save();
@@ -896,7 +899,7 @@ public class ProjectManager : IProjectManager
             {
                 GumProjectSave.FullFileName = chosenFileName!;
                 var filePath = new FilePath(chosenFileName!);
-                PluginManager.Self.ProjectLocationSet(filePath);
+                _pluginManager.ProjectLocationSet(filePath);
                 WpfDataUi.Controls.FilePickingLogic.FolderRelativeTo = filePath.GetDirectoryContainingThis().FullPath;
 
                 shouldSave = true;

--- a/Gum/Plugins/IPluginManager.cs
+++ b/Gum/Plugins/IPluginManager.cs
@@ -66,6 +66,8 @@ public interface IPluginManager
 
     void ReactToStateSaveSelected(StateSave? stateSave);
 
+    void ReactToFileChanged(FilePath filePath);
+
     void ReactToCustomStateSaveSelected(StateSave stateSave);
     void RefreshStateTreeView();
     void RefreshElementTreeView(IInstanceContainer? instanceContainer = null);

--- a/Gum/Plugins/InternalPlugins/Behaviors/MainBehaviorsPlugin.cs
+++ b/Gum/Plugins/InternalPlugins/Behaviors/MainBehaviorsPlugin.cs
@@ -180,7 +180,7 @@ public class MainBehaviorsPlugin : PriorityPlugin
                 // _elementCommands.AddBehaviorTo only raises BehaviorReferencesChanged
                 // when a real (project-existing) behavior is added. Pure removals — e.g.
                 // unchecking only a stale orphan — would otherwise leave error state stale.
-                PluginManager.Self.BehaviorReferencesChanged(component);
+                Locator.GetRequiredService<PluginManager>().BehaviorReferencesChanged(component);
             }
             viewModel.UpdateTo(component);
 

--- a/Gum/Plugins/InternalPlugins/ProjectPropertiesWindowPlugin/MainPropertiesWindowPlugin.cs
+++ b/Gum/Plugins/InternalPlugins/ProjectPropertiesWindowPlugin/MainPropertiesWindowPlugin.cs
@@ -318,7 +318,7 @@ class MainPropertiesWindowPlugin : PriorityPlugin
                 break;
         }
 
-        PluginManager.Self.ProjectPropertySet(e.PropertyName);
+        Locator.GetRequiredService<IPluginManager>().ProjectPropertySet(e.PropertyName);
 
         if (shouldSaveAndRefresh)
         {

--- a/Gum/Plugins/InternalPlugins/TreeView/ElementTreeViewManager.cs
+++ b/Gum/Plugins/InternalPlugins/TreeView/ElementTreeViewManager.cs
@@ -374,6 +374,7 @@ public partial class ElementTreeViewManager : IRecipient<ThemeChangedMessage>, I
     private readonly IProjectState _projectState;
     private readonly ICollapseToggleService _collapseToggleService;
     private readonly StandardElementsManagerGumTool _standardElementsManagerGumTool;
+    private readonly PluginManager _pluginManager;
 
     public bool HasMouseOver
     {
@@ -408,7 +409,8 @@ public partial class ElementTreeViewManager : IRecipient<ThemeChangedMessage>, I
         IFavoriteComponentManager favoriteComponentManager,
         IProjectState projectState,
         StandardElementsManagerGumTool standardElementsManagerGumTool,
-        IDragDropManager dragDropManager)
+        IDragDropManager dragDropManager,
+        PluginManager pluginManager)
     {
         _selectedState = selectedState;
         _editCommands = editCommands;
@@ -431,6 +433,7 @@ public partial class ElementTreeViewManager : IRecipient<ThemeChangedMessage>, I
         _favoriteComponentManager = favoriteComponentManager;
         _projectState = projectState;
         _standardElementsManagerGumTool = standardElementsManagerGumTool;
+        _pluginManager = pluginManager;
         _collapseToggleService = new CollapseToggleService();
         _recordedSelectedInstances = new List<InstanceSave>();
         TreeNodeExtensionMethods.ElementTreeViewManager = this;
@@ -2081,7 +2084,7 @@ public partial class ElementTreeViewManager : IRecipient<ThemeChangedMessage>, I
                 _selectedState.SelectedBehaviors = behaviors;
             }
 
-            PluginManager.Self.TreeNodeSelected(selectedTreeNode);
+            _pluginManager.TreeNodeSelected(selectedTreeNode);
 
         }
         finally
@@ -2368,9 +2371,9 @@ public partial class ElementTreeViewManager : IRecipient<ThemeChangedMessage>, I
             whatToHighlight = _wireframeObjectManager.GetRepresentation(instance, null);
         }
 
-        if(PluginManager.Self.IsInitialized)
+        if(_pluginManager.IsInitialized)
         {
-            PluginManager.Self.SetHighlightedIpso(whatToHighlight);
+            _pluginManager.SetHighlightedIpso(whatToHighlight);
         }
     }
 

--- a/Gum/Plugins/InternalPlugins/VariableGrid/DeleteVariableService.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/DeleteVariableService.cs
@@ -27,18 +27,21 @@ public class DeleteVariableService : IDeleteVariableService
     private readonly IGuiCommands _guiCommands;
     private readonly IRenameLogic _renameLogic;
     private readonly IDialogService _dialogService;
+    private readonly IPluginManager _pluginManager;
 
     public DeleteVariableService(IUndoManager undoManager,
         IFileCommands fileCommands,
         IGuiCommands guiCommands,
         IRenameLogic renameLogic,
-        IDialogService dialogService)
+        IDialogService dialogService,
+        IPluginManager pluginManager)
     {
         _undoManager = undoManager;
         _fileCommands = fileCommands;
         _guiCommands = guiCommands;
         _renameLogic = renameLogic;
         _dialogService = dialogService;
+        _pluginManager = pluginManager;
     }
 
     public bool CanDeleteVariable(VariableSave variable)
@@ -75,7 +78,7 @@ public class DeleteVariableService : IDeleteVariableService
 
             _guiCommands.RefreshVariables(force: true);
 
-            PluginManager.Self.VariableDelete(elementSave, variable.Name);
+            _pluginManager.VariableDelete(elementSave, variable.Name);
         }
     }
 

--- a/Gum/Plugins/InternalPlugins/VariableGrid/ElementSaveDisplayer.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/ElementSaveDisplayer.cs
@@ -534,7 +534,8 @@ public class ElementSaveDisplayer
                     _fileCommands,
                     _setVariableLogic,
                     _wireframeObjectManager,
-                    _typeManager);
+                    _typeManager,
+                    _pluginManager);
 
                 // moved to internal
                 //srim.SetToDefault += (memberName) => ResetVariableToDefault(srim);
@@ -682,7 +683,8 @@ public class ElementSaveDisplayer
                     _fileCommands,
                     _setVariableLogic,
                     _wireframeObjectManager,
-                    _typeManager);
+                    _typeManager,
+                    _pluginManager);
 
                 // Surface the behavior's declared default (FormsProperty.Value) so the grid
                 // reflects e.g. IsEnabled = true even before the user authors anything. The
@@ -743,7 +745,8 @@ public class ElementSaveDisplayer
             _fileCommands,
             _setVariableLogic,
             _wireframeObjectManager,
-            _typeManager
+            _typeManager,
+            _pluginManager
             );
 
         // Override the display name if specified in PropertyData

--- a/Gum/Plugins/InternalPlugins/VariableGrid/StandardElementsManager.GumTool.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/StandardElementsManager.GumTool.cs
@@ -27,6 +27,13 @@ public interface IStandardElementsManagerGumTool
 
 public class StandardElementsManagerGumTool : IStandardElementsManagerGumTool
 {
+    private readonly IPluginManager _pluginManager;
+
+    public StandardElementsManagerGumTool(IPluginManager pluginManager)
+    {
+        _pluginManager = pluginManager;
+    }
+
     public void Initialize()
     {
         var defaultStates =
@@ -199,7 +206,7 @@ public class StandardElementsManagerGumTool : IStandardElementsManagerGumTool
 #if GUM
         foreach (var kvp in StandardElementsManager.Self.DefaultStates)
         {
-            PluginManager.Self.ModifyDefaultStandardState(kvp.Key, kvp.Value);
+            _pluginManager.ModifyDefaultStandardState(kvp.Key, kvp.Value);
         }
 #endif
     }

--- a/Gum/Plugins/InternalPlugins/VariableGrid/StateReferencingInstanceMember.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/StateReferencingInstanceMember.cs
@@ -45,6 +45,7 @@ public class StateReferencingInstanceMember : InstanceMember
     private readonly ISelectedState _selectedState;
     private readonly ISetVariableLogic _setVariableLogic;
     private readonly IWireframeObjectManager _wireframeObjectManager;
+    private readonly IPluginManager _pluginManager;
     StateSave mStateSave;
     string mVariableName;
     public InstanceSave? InstanceSave { get; private set; }
@@ -264,7 +265,8 @@ public class StateReferencingInstanceMember : InstanceMember
         IFileCommands fileCommands,
         ISetVariableLogic setVariableLogic,
         IWireframeObjectManager wireframeObjectManager,
-        ITypeManager typeManager) :
+        ITypeManager typeManager,
+        IPluginManager pluginManager) :
         base(variableName, stateSave)
     {
         _editVariablesService = editVariableService;
@@ -279,6 +281,7 @@ public class StateReferencingInstanceMember : InstanceMember
         _setVariableLogic = setVariableLogic;
         _wireframeObjectManager = wireframeObjectManager;
         _typeManager = typeManager;
+        _pluginManager = pluginManager;
         StateSaveCategory = stateSaveCategory;
         InstanceSave = instanceSave;
         mStateSave = stateSave;
@@ -1065,7 +1068,7 @@ public class StateReferencingInstanceMember : InstanceMember
             _guiCommands.RefreshVariables(force: true);
             _wireframeObjectManager.RefreshAll(true);
 
-            PluginManager.Self.VariableSet(selectedElement, selectedInstance, variableName, oldValue);
+            _pluginManager.VariableSet(selectedElement, selectedInstance, variableName, oldValue);
 
             if (affectsTreeView)
             {

--- a/Gum/Plugins/InternalPlugins/VariableGrid/ViewModels/AddVariableViewModel.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/ViewModels/AddVariableViewModel.cs
@@ -48,6 +48,7 @@ public class AddVariableViewModel : DialogViewModel
     private readonly IFileCommands _fileCommands;
     private readonly INameVerifier _nameVerifier;
     private readonly IDialogService _dialogService;
+    private readonly IPluginManager _pluginManager;
 
     public List<string> AvailableTypes
     {
@@ -107,7 +108,8 @@ public class AddVariableViewModel : DialogViewModel
         IFileCommands fileCommands,
         INameVerifier nameVerifier,
         ISelectedState selectedState,
-        IDialogService dialogService)
+        IDialogService dialogService,
+        IPluginManager pluginManager)
     {
         _guiCommands = guiCommands;
         _undoManager = undoManager;
@@ -116,6 +118,7 @@ public class AddVariableViewModel : DialogViewModel
         _nameVerifier = nameVerifier;
         _selectedState = selectedState;
         _dialogService = dialogService;
+        _pluginManager = pluginManager;
 
         AvailableTypes = new List<string>();
         AvailableTypes.Add("float");
@@ -219,7 +222,7 @@ public class AddVariableViewModel : DialogViewModel
             }
             _guiCommands.RefreshVariables(force: true);
 
-            PluginManager.Self.VariableAdd(element, name);
+            _pluginManager.VariableAdd(element, name);
         }
     }
 

--- a/Gum/Plugins/PluginManager.cs
+++ b/Gum/Plugins/PluginManager.cs
@@ -87,18 +87,6 @@ public class PluginManager : IPluginManager
 
     #region Properties
 
-    public static PluginManager Self
-    {
-        get
-        {
-            if (mGlobalInstance == null)
-            {
-                mGlobalInstance = new PluginManager();
-            }
-            return mGlobalInstance;
-        }
-    }
-
     static string PluginSettingsSaveFileName
     {
         get
@@ -604,7 +592,7 @@ public class PluginManager : IPluginManager
     public void AfterRender() =>
         CallMethodOnPlugin(plugin => plugin.CallAfterRender());
 
-    internal void ReactToFileChanged(FilePath filePath) =>
+    public void ReactToFileChanged(FilePath filePath) =>
         CallMethodOnPlugin(plugin => plugin.CallReactToFileChanged(filePath));
     
 
@@ -739,6 +727,7 @@ public class PluginManager : IPluginManager
         LoadPluginSettings();
         LoadPlugins(this);
         mInstances.Add(this);
+        mGlobalInstance = this;
     }
 
     private void LoadPluginSettings()

--- a/Gum/Program.cs
+++ b/Gum/Program.cs
@@ -118,14 +118,15 @@ namespace Gum
             // Is htere a way to move this to a plugin?
             services.GetRequiredService<PropertyGridManager>().InitializeEarly();
 
-            PluginManager.Self.Initialize();
+            PluginManager pluginManager = services.GetRequiredService<PluginManager>();
+            pluginManager.Initialize();
 
             StandardElementsManager.Self.Initialize();
             StandardElementsManager.Self.CustomGetDefaultState =
-                PluginManager.Self.GetDefaultStateFor;
+                pluginManager.GetDefaultStateFor;
 
             ElementSaveExtensions.VariableChangedThroughReference +=
-                Gum.Plugins.PluginManager.Self.VariableSet;
+                pluginManager.VariableSet;
 
             Locator.GetRequiredService<StandardElementsManagerGumTool>().Initialize();
 
@@ -137,7 +138,7 @@ namespace Gum
             // does, then we need to make sure that the wireframe controls
             // are set up properly before that happens.
             // XnaInitialize is where wireframe controls are initialized.
-            PluginManager.Self.XnaInitialized();
+            pluginManager.XnaInitialized();
 
             await projectManager.Initialize();
 

--- a/Gum/PropertyGridHelpers/VariableInCategoryPropagationLogic.cs
+++ b/Gum/PropertyGridHelpers/VariableInCategoryPropagationLogic.cs
@@ -19,16 +19,19 @@ public class VariableInCategoryPropagationLogic : IVariableInCategoryPropagation
     private readonly IGuiCommands _guiCommands;
     private readonly IFileCommands _fileCommands;
     private readonly IDialogService _dialogService;
+    private readonly IPluginManager _pluginManager;
 
     public VariableInCategoryPropagationLogic(IUndoManager undoManager,
         IGuiCommands guiCommands,
         IFileCommands fileCommands,
-        IDialogService dialogService)
+        IDialogService dialogService,
+        IPluginManager pluginManager)
     {
         _undoManager = undoManager;
         _guiCommands = guiCommands;
         _fileCommands = fileCommands;
         _dialogService = dialogService;
+        _pluginManager = pluginManager;
     }
 
     public void PropagateVariablesInCategory(string memberName, ElementSave element, StateSaveCategory categoryToPropagate)
@@ -206,7 +209,7 @@ public class VariableInCategoryPropagationLogic : IVariableInCategoryPropagation
                 // we really need a refresh - something was removed.
                 _guiCommands.RefreshVariables(force:true);
 
-                PluginManager.Self.VariableRemovedFromCategory(variableName, stateCategory);
+                _pluginManager.VariableRemovedFromCategory(variableName, stateCategory);
             }
         }
     }

--- a/Gum/Services/Builder.cs
+++ b/Gum/Services/Builder.cs
@@ -85,7 +85,9 @@ file static class ServiceCollectionExtensions
 
         // static singletons
         services.AddSingleton<IObjectFinder>(ObjectFinder.Self);
-        services.AddSingleton<PluginManager>(PluginManager.Self);
+        // PluginManager: drained from a static Self singleton (#3291). DI-constructed (empty ctor); Initialize()
+        // (Program.cs) does the heavy two-stage setup and registers the global instance for the static plugin machinery.
+        services.AddSingleton<PluginManager>();
         services.AddSingleton<IPluginManager>(provider => provider.GetRequiredService<PluginManager>());
         services.AddSingleton<TypeManager>();
         services.AddSingleton<ITypeManager>(provider => provider.GetRequiredService<TypeManager>());

--- a/Gum/Services/ExposeVariableService.cs
+++ b/Gum/Services/ExposeVariableService.cs
@@ -51,6 +51,7 @@ internal class ExposeVariableService : IExposeVariableService
     private readonly INameVerifier _nameVerifier;
     private readonly IDialogService _dialogService;
     private readonly IVariableSaveLogic _variableSaveLogic;
+    private readonly IPluginManager _pluginManager;
 
     public ExposeVariableService(
         IUndoManager undoManager,
@@ -60,7 +61,8 @@ internal class ExposeVariableService : IExposeVariableService
         ISelectedState selectedState,
         INameVerifier nameVerifier,
         IDialogService dialogService,
-        IVariableSaveLogic variableSaveLogic)
+        IVariableSaveLogic variableSaveLogic,
+        IPluginManager pluginManager)
     {
         _undoManager = undoManager;
         _guiCommands = guiCommands;
@@ -70,6 +72,7 @@ internal class ExposeVariableService : IExposeVariableService
         _nameVerifier = nameVerifier;
         _dialogService = dialogService;
         _variableSaveLogic = variableSaveLogic;
+        _pluginManager = pluginManager;
     }
 
     public OptionallyAttemptedGeneralResponse<VariableSave> HandleExposeVariableClick(InstanceSave instanceSave, string rootVariableName)
@@ -185,7 +188,7 @@ internal class ExposeVariableService : IExposeVariableService
 
         variableSave.ExposedAsName = exposedName;
 
-        PluginManager.Self.VariableAdd(elementSave, exposedName);
+        _pluginManager.VariableAdd(elementSave, exposedName);
 
         _fileCommands.TryAutoSaveCurrentElement();
         _guiCommands.RefreshVariables(force: true);
@@ -280,7 +283,7 @@ internal class ExposeVariableService : IExposeVariableService
         var oldExposedName = variableSave.ExposedAsName;
         variableSave.ExposedAsName = null;
 
-        PluginManager.Self.VariableDelete(elementSave, oldExposedName);
+        _pluginManager.VariableDelete(elementSave, oldExposedName);
         _fileCommands.TryAutoSaveCurrentElement();
         _guiCommands.RefreshVariables(force: true);
     }

--- a/Gum/ToolCommands/ProjectCommands.cs
+++ b/Gum/ToolCommands/ProjectCommands.cs
@@ -18,6 +18,7 @@ public class ProjectCommands
     private readonly IProjectManager _projectManager;
     private readonly IProjectState _projectState;
     private readonly StandardElementsManagerGumTool _standardElementsManagerGumTool;
+    private readonly IPluginManager _pluginManager;
 
     #endregion
 
@@ -26,7 +27,8 @@ public class ProjectCommands
         IFileCommands fileCommands,
         IProjectManager projectManager,
         IProjectState projectState,
-        StandardElementsManagerGumTool standardElementsManagerGumTool)
+        StandardElementsManagerGumTool standardElementsManagerGumTool,
+        IPluginManager pluginManager)
     {
         _selectedState = selectedState;
         _guiCommands = guiCommands;
@@ -34,6 +36,7 @@ public class ProjectCommands
         _projectManager = projectManager;
         _projectState = projectState;
         _standardElementsManagerGumTool = standardElementsManagerGumTool;
+        _pluginManager = pluginManager;
     }
     
     #region Screens
@@ -65,7 +68,7 @@ public class ProjectCommands
         _fileCommands.TryAutoSaveProject();
         _fileCommands.TryAutoSaveElement(screenSave);
 
-        Plugins.PluginManager.Self.ElementAdd(screenSave);
+        _pluginManager.ElementAdd(screenSave);
     }
 
     #endregion
@@ -92,7 +95,7 @@ public class ProjectCommands
 
         _fileCommands.TryAutoSaveProject();
         _fileCommands.TryAutoSaveElement(componentSave);
-        Plugins.PluginManager.Self.ElementAdd(componentSave);
+        _pluginManager.ElementAdd(componentSave);
 
         _selectedState.SelectedComponent = componentSave;
     }

--- a/Tool/EditorTabPlugin_XNA/Editors/EditorContext.cs
+++ b/Tool/EditorTabPlugin_XNA/Editors/EditorContext.cs
@@ -188,7 +188,7 @@ public class EditorContext
             if (DoValuesDiffer(stateSave, possiblyChangedVariableList.Name, oldValue))
             {
                 var instance = element.GetInstance(possiblyChangedVariableList.SourceObject);
-                Gum.Plugins.PluginManager.Self.VariableSet(element, instance, possiblyChangedVariableList.GetRootName(), oldValue);
+                Locator.GetRequiredService<Gum.Plugins.IPluginManager>().VariableSet(element, instance, possiblyChangedVariableList.GetRootName(), oldValue);
             }
         }
 

--- a/Tool/EditorTabPlugin_XNA/Editors/Handlers/PolygonPointInputHandler.cs
+++ b/Tool/EditorTabPlugin_XNA/Editors/Handlers/PolygonPointInputHandler.cs
@@ -3,6 +3,8 @@ using System.Linq;
 using System.Numerics;
 using System.Windows.Forms;
 using Gum.DataTypes.Variables;
+using Gum.Plugins;
+using Gum.Services;
 using Gum.Wireframe.Editors.Visuals;
 using RenderingLibrary;
 using RenderingLibrary.Graphics;
@@ -350,7 +352,7 @@ public class PolygonPointInputHandler : InputHandlerBase
             if (oldValue != possiblyChangedVariableList)
             {
                 var instance = selectedElement?.GetInstance(possiblyChangedVariableList.SourceObject);
-                Gum.Plugins.PluginManager.Self.VariableSet(selectedElement, instance, 
+                Locator.GetRequiredService<IPluginManager>().VariableSet(selectedElement, instance,
                     possiblyChangedVariableList.GetRootName(), oldValue);
             }
         }

--- a/Tool/EditorTabPlugin_XNA/Editors/Handlers/ResizeInputHandler.cs
+++ b/Tool/EditorTabPlugin_XNA/Editors/Handlers/ResizeInputHandler.cs
@@ -8,6 +8,7 @@ using EditorTabPlugin_XNA.ExtensionMethods;
 using Gum.DataTypes;
 using Gum.DataTypes.Variables;
 using Gum.Plugins;
+using Gum.Services;
 using RenderingLibrary;
 using RenderingLibrary.Graphics;
 using RenderingLibrary.Math;
@@ -666,7 +667,7 @@ public class ResizeInputHandler : InputHandlerBase
             if (DoValuesDiffer(stateSave, possiblyChangedVariableList.Name, oldValue))
             {
                 var instance = element.GetInstance(possiblyChangedVariableList.SourceObject);
-                PluginManager.Self.VariableSet(element, instance, possiblyChangedVariableList.GetRootName(), oldValue);
+                Locator.GetRequiredService<IPluginManager>().VariableSet(element, instance, possiblyChangedVariableList.GetRootName(), oldValue);
             }
         }
 

--- a/Tool/EditorTabPlugin_XNA/MainEditorTabPlugin.cs
+++ b/Tool/EditorTabPlugin_XNA/MainEditorTabPlugin.cs
@@ -435,7 +435,7 @@ internal class MainEditorTabPlugin : PriorityPlugin, IRecipient<UiBaseFontSizeCh
 
     private void HandleHighlightedIpsoChanged(IPositionedSizedObject? ipso)
     {
-        PluginManager.Self.HighlightTreeNode(ipso);
+        Locator.GetRequiredService<PluginManager>().HighlightTreeNode(ipso);
     }
 
     private void HandleStateDelete(StateSave save)
@@ -799,7 +799,7 @@ internal class MainEditorTabPlugin : PriorityPlugin, IRecipient<UiBaseFontSizeCh
         this._wireframeControl.Parent.Resize += (_, _) =>
         {
             UpdateWireframeControlSizes();
-            PluginManager.Self.HandleWireframeResized();
+            Locator.GetRequiredService<PluginManager>().HandleWireframeResized();
         };
 
         //this._wireframeControl.MouseClick += wireframeControl1_MouseClick;
@@ -831,7 +831,7 @@ internal class MainEditorTabPlugin : PriorityPlugin, IRecipient<UiBaseFontSizeCh
         };
         _wireframeControl.CameraChanged += () =>
         {
-            PluginManager.Self.CameraChanged();
+            Locator.GetRequiredService<PluginManager>().CameraChanged();
         };
 
         this._wireframeControl.KeyDown += (o, args) =>

--- a/Tool/EditorTabPlugin_XNA/Views/WireframeControl.cs
+++ b/Tool/EditorTabPlugin_XNA/Views/WireframeControl.cs
@@ -342,7 +342,7 @@ public class WireframeControl : GraphicsDeviceControl
                 if (TopRuler.IsCursorOver == false && LeftRuler.IsCursorOver == false)
                 {
                     var shouldForceNoHighlight = mouseHasEntered == false &&
-                        PluginManager.Self.GetIfShouldSuppressRemoveEditorHighlight() == false;
+                        Locator.GetRequiredService<PluginManager>().GetIfShouldSuppressRemoveEditorHighlight() == false;
 
 
                     _selectionManager.Activity(shouldForceNoHighlight);
@@ -398,11 +398,11 @@ public class WireframeControl : GraphicsDeviceControl
         {
             GraphicsDevice.Clear(BackgroundColor);
 
-            PluginManager.Self.BeforeRender();
+            Locator.GetRequiredService<PluginManager>().BeforeRender();
 
             Renderer.Self.Draw((SystemManagers)null);
 
-            PluginManager.Self.AfterRender();
+            Locator.GetRequiredService<PluginManager>().AfterRender();
 
         }
     }

--- a/Tool/Tests/GumToolUnitTests/Logic/CopyPasteLogicTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Logic/CopyPasteLogicTests.cs
@@ -103,10 +103,6 @@ public class CopyPasteLogicTests : BaseTestClass
         // AddComponent) reads the project through IProjectState, so point it at the same instance.
         _mocker.GetMock<IProjectState>().Setup(x => x.GumProjectSave).Returns(gumProject);
 
-        // AddComponent notifies plugins through the static PluginManager.Self; an empty plugin list
-        // makes that a safe no-op. Mirrors the pattern in RenameLogicTests.
-        PluginManager.Self.Plugins = new List<PluginBase>();
-
         StandardElementSave spriteElement = new StandardElementSave();
         spriteElement.Name = "Sprite";
 

--- a/Tool/Tests/GumToolUnitTests/Logic/InheritanceLogicTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Logic/InheritanceLogicTests.cs
@@ -3,6 +3,7 @@ using Gum.DataTypes;
 using Gum.DataTypes.Behaviors;
 using Gum.Logic;
 using Gum.Managers;
+using Gum.Plugins;
 using Gum.Plugins.InternalPlugins.VariableGrid;
 using Moq;
 using Shouldly;
@@ -23,7 +24,7 @@ public class InheritanceLogicTests : BaseTestClass
         _sut = new InheritanceLogic(
             _fileCommands.Object,
             _guiCommands.Object,
-            new StandardElementsManagerGumTool());
+            new StandardElementsManagerGumTool(new Mock<IPluginManager>().Object));
     }
 
     [Fact]

--- a/Tool/Tests/GumToolUnitTests/Logic/RenameLogicTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Logic/RenameLogicTests.cs
@@ -3,6 +3,7 @@ using Gum.DataTypes.Behaviors;
 using Gum.DataTypes.Variables;
 using Gum.Logic;
 using Gum.Managers;
+using Gum.Plugins;
 using Gum.Services.Dialogs;
 using Gum.ToolStates;
 using Moq;
@@ -112,23 +113,13 @@ public class RenameLogicTests : BaseTestClass
             Type = "string",
         });
 
-        // ReactToInstanceNameChange notifies plugins at the end; give the singleton an empty plugin
-        // list so that call is a no-op, and restore it afterward to avoid cross-test pollution.
-        IEnumerable<Gum.Plugins.BaseClasses.PluginBase> originalPlugins = Gum.Plugins.PluginManager.Self.Plugins;
-        Gum.Plugins.PluginManager.Self.Plugins = new List<Gum.Plugins.BaseClasses.PluginBase>();
-        try
-        {
-            // Simulate the rename already applied to the instance, then react to the name change.
-            renderTargetContainer.Name = "RenamedContainer";
-            defaultState.ReactToInstanceNameChange(renderTargetContainer, "RenderTargetContainer", "RenamedContainer");
+        // ReactToInstanceNameChange notifies plugins at the end; a stub plugin manager makes that a no-op.
+        IPluginManager pluginManager = new Mock<IPluginManager>().Object;
+        renderTargetContainer.Name = "RenamedContainer";
+        defaultState.ReactToInstanceNameChange(renderTargetContainer, "RenderTargetContainer", "RenamedContainer", pluginManager);
 
-            VariableSave variable = defaultState.GetVariableSave("SpriteInstance.RenderTargetTextureSource");
-            (variable.Value as string).ShouldBe("RenamedContainer");
-        }
-        finally
-        {
-            Gum.Plugins.PluginManager.Self.Plugins = originalPlugins;
-        }
+        VariableSave variable = defaultState.GetVariableSave("SpriteInstance.RenderTargetTextureSource");
+        (variable.Value as string).ShouldBe("RenamedContainer");
     }
 
     [Fact]

--- a/Tool/Tests/GumToolUnitTests/Managers/ProjectManagerTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Managers/ProjectManagerTests.cs
@@ -9,6 +9,7 @@ using Gum.Commands;
 using Gum.DataTypes;
 using Gum.Logic.FileWatch;
 using Gum.Managers;
+using Gum.Plugins;
 using Gum.Plugins.InternalPlugins.VariableGrid;
 using Gum.Services;
 using Gum.Services.Dialogs;
@@ -32,6 +33,7 @@ public class ProjectManagerTests : BaseTestClass
     private readonly Mock<IStandardElementsManagerGumTool> _standardElementsManagerGumTool;
     private readonly Mock<IRetryService> _retryService;
     private readonly Mock<ICommandLineManager> _commandLineManager;
+    private readonly Mock<IPluginManager> _pluginManager;
     private readonly ProjectManager _projectManager;
 
     public ProjectManagerTests()
@@ -46,6 +48,7 @@ public class ProjectManagerTests : BaseTestClass
         _standardElementsManagerGumTool = new Mock<IStandardElementsManagerGumTool>();
         _retryService = new Mock<IRetryService>();
         _commandLineManager = new Mock<ICommandLineManager>();
+        _pluginManager = new Mock<IPluginManager>();
 
         _projectManager = new ProjectManager(
             _selectedState.Object,
@@ -57,7 +60,8 @@ public class ProjectManagerTests : BaseTestClass
             new Lazy<IFileWatchManager>(() => _fileWatchManager.Object),
             _standardElementsManagerGumTool.Object,
             _retryService.Object,
-            new Lazy<ICommandLineManager>(() => _commandLineManager.Object));
+            new Lazy<ICommandLineManager>(() => _commandLineManager.Object),
+            _pluginManager.Object);
     }
 
     [Fact]

--- a/Tool/Tests/GumToolUnitTests/VariableGrid/StateReferencingInstanceMemberTests.cs
+++ b/Tool/Tests/GumToolUnitTests/VariableGrid/StateReferencingInstanceMemberTests.cs
@@ -3,6 +3,7 @@ using Gum.Commands;
 using Gum.DataTypes;
 using Gum.DataTypes.Variables;
 using Gum.Managers;
+using Gum.Plugins;
 using Gum.Plugins.InternalPlugins.VariableGrid;
 using Gum.PropertyGridHelpers;
 using Gum.Reflection;
@@ -60,7 +61,8 @@ public class StateReferencingInstanceMemberTests
             _mocker.Get<IFileCommands>(),
             setVariableLogic.Object,
             _mocker.Get<IWireframeObjectManager>(),
-            _mocker.Get<ITypeManager>());
+            _mocker.Get<ITypeManager>(),
+            _mocker.Get<IPluginManager>());
     }
 
     [Fact]

--- a/Tool/Tests/GumToolUnitTests/ViewModels/AddVariableViewModelTests.cs
+++ b/Tool/Tests/GumToolUnitTests/ViewModels/AddVariableViewModelTests.cs
@@ -3,6 +3,7 @@ using Gum.DataTypes.Behaviors;
 using Gum.DataTypes.Variables;
 using Gum.Logic;
 using Gum.Managers;
+using Gum.Plugins;
 using Gum.Plugins.InternalPlugins.VariableGrid.ViewModels;
 using Gum.ToolCommands;
 using Gum.ToolStates;
@@ -23,6 +24,7 @@ public class AddVariableViewModelTests : BaseTestClass
     private readonly Mock<IFileCommands> _fileCommands;
     private readonly Mock<INameVerifier> _nameVerifier;
     private readonly Mock<IDialogService> _dialogService;
+    private readonly Mock<IPluginManager> _pluginManager;
     private readonly AddVariableViewModel _viewModel;
     private readonly ComponentSave _component;
 
@@ -39,6 +41,7 @@ public class AddVariableViewModelTests : BaseTestClass
         _fileCommands = new Mock<IFileCommands>();
         _nameVerifier = new Mock<INameVerifier>();
         _dialogService = new Mock<IDialogService>();
+        _pluginManager = new Mock<IPluginManager>();
 
         _selectedState.Setup(x => x.SelectedElement).Returns(_component);
         _selectedState.Setup(x => x.SelectedBehavior).Returns((BehaviorSave?)null);
@@ -55,7 +58,8 @@ public class AddVariableViewModelTests : BaseTestClass
             _fileCommands.Object,
             _nameVerifier.Object,
             _selectedState.Object,
-            _dialogService.Object);
+            _dialogService.Object,
+            _pluginManager.Object);
 
         var gumProject = new GumProjectSave();
         gumProject.Components.Add(_component);


### PR DESCRIPTION
Drains the `PluginManager.Self` static singleton to dependency injection, continuing the Phase-2 static-drain effort (#3289 PropertyGridManager, #3287 ElementTreeViewManager).

## What changed
- **`Self` removed.** `PluginManager` is now `AddSingleton<PluginManager>()` (DI-constructed via its empty constructor — zero ctor deps, so no construction cycle and no `Lazy<T>` needed). `Initialize()` (called once from `Program.cs`) does the heavy two-stage setup and now sets `mGlobalInstance = this`, preserving the static multi-instance machinery (`mInstances` / `AllPluginContainers` / `ShutDownPlugin`) still used by `PluginsDialogViewModel`.
- **65 active `PluginManager.Self` reads repointed:**
  - `IPluginManager` (interface) constructor injection for pure-interface logic/command/service/VM classes.
  - Concrete `PluginManager` injection where `internal` members are called (same assembly).
  - `Locator.GetRequiredService<…>()` in MEF plugins, XNA views/handlers, and the composition root (`Program.cs`).
  - The one static extension method (`StateSave.ReactToInstanceNameChange`) takes `IPluginManager` as a **parameter**, threaded from `RenameLogic` — no `Locator` in a static helper.
- **Only interface addition:** `ReactToFileChanged` (its consumer `FileChangeReactionLogic` already held `IPluginManager`, so the member was promoted rather than the field demoted). `IPluginManager` is implemented solely by `PluginManager`, so this is non-breaking.

## Verification
- `GumFull.sln` build clean (verified independently).
- `GumToolUnitTests`: **971 passed / 0 failed / 4 skipped** (zero regressions; baseline was 949).
- Manual smoke test: tool launches with no circular-dependency / DI-resolution exception; tree view + Variables grid populate; instance rename works (exercises the threaded `InstanceRename` path). The real DI container is not built by unit tests, so this launch check was required.

Out of scope (left intact): the static multi-instance design itself, and `Initialize()`'s `Locator` resolution of its three deps (the deliberate cycle-breaker).

Closes #3291
