### PR TITLE
Phase 2 (static drain): ToolLayerService + ToolFontService singletons -> DI

### DIFF
--- a/Tool/EditorTabPlugin_XNA/Editors/EditorContext.cs
+++ b/Tool/EditorTabPlugin_XNA/Editors/EditorContext.cs
@@ -34,6 +34,7 @@ public class EditorContext
     public IWireframeObjectManager WireframeObjectManager { get; }
     public Layer OverlayLayer { get; }
     public IUiSettingsService UiSettingsService { get; }
+    public IToolFontService ToolFontService { get; }
 
     #endregion
 
@@ -95,9 +96,11 @@ public class EditorContext
         IUiSettingsService uiSettingsService,
         Layer overlayLayer,
         Color lineColor,
-        Color textColor)
+        Color textColor,
+        IToolFontService toolFontService)
     {
         UiSettingsService = uiSettingsService;
+        ToolFontService = toolFontService;
         SelectedState = selectedState;
         SelectionManager = selectionManager;
         ElementCommands = elementCommands;

--- a/Tool/EditorTabPlugin_XNA/Editors/PolygonWireframeEditor.cs
+++ b/Tool/EditorTabPlugin_XNA/Editors/PolygonWireframeEditor.cs
@@ -71,7 +71,8 @@ public class PolygonWireframeEditor : WireframeEditor
         IUndoManager undoManager,
         IVariableInCategoryPropagationLogic variableInCategoryPropagationLogic,
         IWireframeObjectManager wireframeObjectManager,
-        IUiSettingsService uiSettingsService)
+        IUiSettingsService uiSettingsService,
+        IToolFontService toolFontService)
         : base(
               hotkeyManager,
               selectionManager,
@@ -86,7 +87,8 @@ public class PolygonWireframeEditor : WireframeEditor
               uiSettingsService,
               layer,
               System.Drawing.Color.White,
-              System.Drawing.Color.White)
+              System.Drawing.Color.White,
+              toolFontService)
     {
         this.layer = layer;
 

--- a/Tool/EditorTabPlugin_XNA/Editors/StandardWireframeEditor.cs
+++ b/Tool/EditorTabPlugin_XNA/Editors/StandardWireframeEditor.cs
@@ -95,7 +95,8 @@ public class StandardWireframeEditor : WireframeEditor
         IUndoManager undoManager,
         IVariableInCategoryPropagationLogic variableInCategoryPropagationLogic,
         IWireframeObjectManager wireframeObjectManager,
-        IUiSettingsService uiSettingsService)
+        IUiSettingsService uiSettingsService,
+        IToolFontService toolFontService)
         : base(
               hotkeyManager,
               selectionManager,
@@ -110,7 +111,8 @@ public class StandardWireframeEditor : WireframeEditor
               uiSettingsService,
               layer,
               lineColor,
-              textColor)
+              textColor,
+              toolFontService)
     {
         _elementCommands = elementCommands;
         _wireframeObjectManager = wireframeObjectManager;

--- a/Tool/EditorTabPlugin_XNA/Editors/Visuals/DimensionDisplayVisual.cs
+++ b/Tool/EditorTabPlugin_XNA/Editors/Visuals/DimensionDisplayVisual.cs
@@ -42,7 +42,7 @@ public class DimensionDisplayVisual : EditorVisualBase
         _uiSettingsService = context.UiSettingsService;
 
         var systemManagers = SystemManagers.Default;
-        var toolFontService = ToolFontService.Self;
+        var toolFontService = context.ToolFontService;
 
         // Initialize middle line
         _middleLine = new Line(systemManagers);

--- a/Tool/EditorTabPlugin_XNA/Editors/WireframeEditor.cs
+++ b/Tool/EditorTabPlugin_XNA/Editors/WireframeEditor.cs
@@ -62,7 +62,8 @@ public abstract class WireframeEditor
         IUiSettingsService uiSettingsService,
         Layer layer,
         Color lineColor,
-        Color textColor)
+        Color textColor,
+        IToolFontService toolFontService)
     {
         // Create shared EditorContext and MoveInputHandler
         _context = new EditorContext(
@@ -79,7 +80,8 @@ public abstract class WireframeEditor
             uiSettingsService,
             layer,
             lineColor,
-            textColor);
+            textColor,
+            toolFontService);
 
         _moveInputHandler = new MoveInputHandler(_context);
     }

--- a/Tool/EditorTabPlugin_XNA/MainEditorTabPlugin.cs
+++ b/Tool/EditorTabPlugin_XNA/MainEditorTabPlugin.cs
@@ -140,6 +140,8 @@ internal class MainEditorTabPlugin : PriorityPlugin, IRecipient<UiBaseFontSizeCh
     private readonly IDialogService _dialogService;
     private readonly IVariableInCategoryPropagationLogic _variableInCategoryPropagationLogic;
     private readonly IWireframeObjectManager _wireframeObjectManager;
+    private readonly IToolFontService _toolFontService;
+    private readonly IToolLayerService _toolLayerService;
 
     // Suppresses the redundant second wireframe rebuild when selecting an element forces its
     // default state (state event rebuilds) and then fires the element event for the same element.
@@ -185,6 +187,11 @@ internal class MainEditorTabPlugin : PriorityPlugin, IRecipient<UiBaseFontSizeCh
 
         _layerService = new Services.LayerService();
 
+        // Plugin-scoped services (not registered in Builder.cs): the editor tab owns the single
+        // instance of each and threads it down to the XNA objects it constructs. See issue #3294.
+        _toolFontService = new ToolFontService();
+        _toolLayerService = new ToolLayerService();
+
         _selectionManager = new SelectionManager(
             _selectedState,
             undoManager,
@@ -198,7 +205,8 @@ internal class MainEditorTabPlugin : PriorityPlugin, IRecipient<UiBaseFontSizeCh
             _elementCommands,
             _fileCommands,
             _setVariableLogic,
-            _uiSettingsService);
+            _uiSettingsService,
+            _toolFontService);
 
         _screenshotService = new ScreenshotService(_selectionManager);
         _singlePixelTextureService = new SinglePixelTextureService();
@@ -768,12 +776,14 @@ internal class MainEditorTabPlugin : PriorityPlugin, IRecipient<UiBaseFontSizeCh
 
 
         _wireframeControl.Initialize(
-            gumEditorPanel, 
-            _hotkeyManager, 
-            _selectionManager, 
+            gumEditorPanel,
+            _hotkeyManager,
+            _selectionManager,
             _dragDropManager,
             _editorViewModel,
-            _projectManager);
+            _projectManager,
+            _toolFontService,
+            _toolLayerService);
         var systemManagers = _wireframeControl.SystemManagers;
 
 
@@ -1367,7 +1377,7 @@ internal class MainEditorTabPlugin : PriorityPlugin, IRecipient<UiBaseFontSizeCh
         {
             _backgroundManager.Activity();
             _wireframeObjectManager.Activity();
-            ToolLayerService.Self.Activity();
+            _toolLayerService.Activity();
         };
 
     }

--- a/Tool/EditorTabPlugin_XNA/SelectionManager.cs
+++ b/Tool/EditorTabPlugin_XNA/SelectionManager.cs
@@ -86,6 +86,7 @@ public class SelectionManager : ISelectionManager
     private readonly IFileCommands _fileCommands;
     private readonly ISetVariableLogic _setVariableLogic;
     private readonly IUiSettingsService _uiSettingsService;
+    private readonly IToolFontService _toolFontService;
 
     public virtual bool IsOverBody
     {
@@ -213,9 +214,11 @@ public class SelectionManager : ISelectionManager
         IElementCommands elementCommands,
         IFileCommands fileCommands,
         ISetVariableLogic setVariableLogic,
-        IUiSettingsService uiSettingsService)
+        IUiSettingsService uiSettingsService,
+        IToolFontService toolFontService)
     {
         _selectedState = selectedState;
+        _toolFontService = toolFontService;
         _editingManager = editingManager;
         _undoManager = undoManager;
         _dialogService = dialogService;
@@ -820,7 +823,8 @@ public class SelectionManager : ISelectionManager
                         _undoManager,
                         _variableInCategoryPropagationLogic,
                         _wireframeObjectManager,
-                        _uiSettingsService);
+                        _uiSettingsService,
+                        _toolFontService);
                 }
             }
         }
@@ -858,7 +862,8 @@ public class SelectionManager : ISelectionManager
             _undoManager,
             _variableInCategoryPropagationLogic,
             _wireframeObjectManager,
-            _uiSettingsService);
+            _uiSettingsService,
+            _toolFontService);
     }
 
     #region New Explicit Input Processing System

--- a/Tool/EditorTabPlugin_XNA/Services/ToolFontService.cs
+++ b/Tool/EditorTabPlugin_XNA/Services/ToolFontService.cs
@@ -1,4 +1,4 @@
-﻿using RenderingLibrary;
+using RenderingLibrary;
 using RenderingLibrary.Content;
 using RenderingLibrary.Graphics;
 using System;
@@ -7,10 +7,24 @@ using System.IO;
 namespace Gum.Managers
 {
     /// <summary>
-    /// Manages fonts used by the app, as opposed to fonts used by the loaded project
+    /// Manages fonts used by the app, as opposed to fonts used by the loaded project. Plugin-scoped:
+    /// instantiated by the editor plugin (<c>MainEditorTabPlugin</c>), not registered in Builder.cs.
     /// </summary>
-    public class ToolFontService : Singleton<ToolFontService>
-        // todo - eventually move to a service locator or full DI
+    public interface IToolFontService
+    {
+        /// <summary>
+        /// The font used by editor overlay text. Null until <see cref="Initialize"/> has been called.
+        /// </summary>
+        BitmapFont ToolFont { get; }
+
+        /// <summary>
+        /// Loads the tool font from the application's content directory.
+        /// </summary>
+        void Initialize();
+    }
+
+    /// <inheritdoc cref="IToolFontService"/>
+    public class ToolFontService : IToolFontService
     {
         BitmapFont _toolFont;
         public BitmapFont ToolFont

--- a/Tool/EditorTabPlugin_XNA/Services/ToolLayerService.cs
+++ b/Tool/EditorTabPlugin_XNA/Services/ToolLayerService.cs
@@ -1,16 +1,35 @@
-﻿using RenderingLibrary;
+using RenderingLibrary;
 using RenderingLibrary.Graphics;
-using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Gum.Managers
 {
-    public class ToolLayerService : Singleton<ToolLayerService>
+    /// <summary>
+    /// Owns the top-most editor overlay layer used by the wireframe editor tab. Plugin-scoped:
+    /// instantiated by the editor plugin (<c>MainEditorTabPlugin</c>), not registered in Builder.cs.
+    /// </summary>
+    public interface IToolLayerService
     {
+        /// <summary>
+        /// The layer kept above all others, used for editor overlay visuals. Null until
+        /// <see cref="Initialize"/> has been called.
+        /// </summary>
+        Layer TopLayer { get; }
 
+        /// <summary>
+        /// Creates the top layer. Must be called after <see cref="SystemManagers.Default"/> is initialized.
+        /// </summary>
+        void Initialize();
+
+        /// <summary>
+        /// Re-adds the top layer if another plugin pushed a layer above it. Call once per frame.
+        /// </summary>
+        void Activity();
+    }
+
+    /// <inheritdoc cref="IToolLayerService"/>
+    public class ToolLayerService : IToolLayerService
+    {
         public Layer TopLayer { get; private set; }
 
         public void Initialize()
@@ -21,7 +40,7 @@ namespace Gum.Managers
         public void Activity()
         {
             // just in case another plugin adds more layers, keep this one on top:
-            if(SystemManagers.Default.Renderer.Layers.Last() != TopLayer)
+            if (SystemManagers.Default.Renderer.Layers.Last() != TopLayer)
             {
                 SystemManagers.Default.Renderer.RemoveLayer(TopLayer);
                 SystemManagers.Default.Renderer.AddLayer(TopLayer);

--- a/Tool/EditorTabPlugin_XNA/Views/DistanceArrows.cs
+++ b/Tool/EditorTabPlugin_XNA/Views/DistanceArrows.cs
@@ -12,7 +12,7 @@ namespace Gum.Wireframe
 {
     public class DistanceArrows
     {
-        private ToolLayerService _toolLayerService;
+        private IToolLayerService _toolLayerService;
         Arrow Arrow1;
         Arrow Arrow2;
 
@@ -64,7 +64,7 @@ namespace Gum.Wireframe
             }
         }
 
-        public DistanceArrows(SystemManagers systemManagers, ToolFontService toolFontService, ToolLayerService toolLayerService)
+        public DistanceArrows(SystemManagers systemManagers, IToolFontService toolFontService, IToolLayerService toolLayerService)
         {
             _toolLayerService = toolLayerService;
             Arrow1 = new Arrow();

--- a/Tool/EditorTabPlugin_XNA/Views/Ruler.cs
+++ b/Tool/EditorTabPlugin_XNA/Views/Ruler.cs
@@ -33,8 +33,8 @@ public enum RulerSide
 public class Ruler
 {
     #region Fields / Properties
-    private ToolFontService _toolFontService;
-    private ToolLayerService _toolLayerService;
+    private IToolFontService _toolFontService;
+    private IToolLayerService _toolLayerService;
     private readonly IHotkeyManager _hotkeyManager;
     GraphicsDeviceControl mControl;
     SystemManagers mManagers;
@@ -215,8 +215,8 @@ public class Ruler
     public Ruler(GraphicsDeviceControl control, 
         SystemManagers managers, 
         Cursor cursor, 
-        ToolFontService toolFontService, 
-        ToolLayerService toolLayerService, 
+        IToolFontService toolFontService,
+        IToolLayerService toolLayerService,
         LayerService layerService,
         IHotkeyManager hotkeyManager)
     {

--- a/Tool/EditorTabPlugin_XNA/Views/WireframeControl.cs
+++ b/Tool/EditorTabPlugin_XNA/Views/WireframeControl.cs
@@ -41,6 +41,8 @@ public class WireframeControl : GraphicsDeviceControl
     private IProjectManager _projectManager;
     private SelectionManager _selectionManager;
     private IDragDropManager _dragDropManager;
+    private IToolFontService _toolFontService;
+    private IToolLayerService _toolLayerService;
     LineRectangle mCanvasBounds;
 
     public Color ScreenBoundsColor = Color.LightBlue;
@@ -146,12 +148,16 @@ public class WireframeControl : GraphicsDeviceControl
         SelectionManager selectionManager,
         IDragDropManager dragDropManager,
         EditorViewModel editorViewModel,
-        IProjectManager projectManager)
+        IProjectManager projectManager,
+        IToolFontService toolFontService,
+        IToolLayerService toolLayerService)
     {
         _selectionManager = selectionManager;
         _dragDropManager = dragDropManager;
         _hotkeyManager = hotkeyManager;
         _projectManager = projectManager;
+        _toolFontService = toolFontService;
+        _toolLayerService = toolLayerService;
         try
         {
             LoaderManager.Self.ContentLoader = new ContentLoader();
@@ -175,8 +181,8 @@ public class WireframeControl : GraphicsDeviceControl
 
             InitializeDefaultTypeInstantiation();
 
-            ToolFontService.Self.Initialize();
-            ToolLayerService.Self.Initialize();
+            _toolFontService.Initialize();
+            _toolLayerService.Initialize();
 
             Renderer.TextureFilter = TextureFilter.Point;
 
@@ -282,14 +288,14 @@ public class WireframeControl : GraphicsDeviceControl
         TopRuler = new Ruler(this, 
             SystemManagers.Default,
             InputLibrary.Cursor.Self,
-            ToolFontService.Self,
-            ToolLayerService.Self,
+            _toolFontService,
+            _toolLayerService,
             layerService,
             _hotkeyManager);
         LeftRuler = new Ruler(this, SystemManagers.Default,
             InputLibrary.Cursor.Self,
-            ToolFontService.Self,
-            ToolLayerService.Self,
+            _toolFontService,
+            _toolLayerService,
             layerService,
             _hotkeyManager);
         LeftRuler.RulerSide = RulerSide.Left;

--- a/Tool/Tests/GumToolUnitTests/Wireframe/SelectionManagerHighlightTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Wireframe/SelectionManagerHighlightTests.cs
@@ -56,7 +56,8 @@ public class SelectionManagerHighlightTests : BaseTestClass
             Mock.Of<IElementCommands>(),
             Mock.Of<IFileCommands>(),
             Mock.Of<ISetVariableLogic>(),
-            Mock.Of<IUiSettingsService>());
+            Mock.Of<IUiSettingsService>(),
+            Mock.Of<IToolFontService>());
 
         _layerService = new Mock<LayerService>();
         _selectionManager.Initialize(_layerService.Object);

--- a/Tool/Tests/GumToolUnitTests/Wireframe/SelectionManagerRectangleTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Wireframe/SelectionManagerRectangleTests.cs
@@ -76,7 +76,8 @@ public class SelectionManagerRectangleTests : BaseTestClass
             Mock.Of<IElementCommands>(),
             Mock.Of<IFileCommands>(),
             Mock.Of<ISetVariableLogic>(),
-            Mock.Of<IUiSettingsService>());
+            Mock.Of<IUiSettingsService>(),
+            Mock.Of<IToolFontService>());
 
         _layerService = new Mock<LayerService>();
 


### PR DESCRIPTION
## What

Drains the two `EditorTabPlugin_XNA` static singletons — `ToolLayerService.Self` and `ToolFontService.Self` — to constructor injection. This is the last meaningful Phase-2 static-drain slice (the XNA/MEF holdout) after `PluginManager` landed in #3292.

## Why this slice is different from prior Phase-2 work

Unlike every earlier slice, these two services are **not** registered in `Gum/Services/Builder.cs`, and can't be:

- `EditorTabPlugin_XNA.csproj` references `Gum.csproj` — the dependency is one-way (**plugin → Gum**), so the Gum main assembly cannot see or construct types defined in the plugin.
- Both services depend on concrete RenderingLibrary types that exist only in `KniGum.dll` (`SystemManagers`, `Renderer`, `BitmapFont`). RenderingLibrary is source-shared: `KniGum` compiles its own copies, while `GumCommon` (Gum's only path to RenderingLibrary) compiles **only the interfaces** plus `Layer`. Gum.csproj does not reference `KniGum`.

This matches the `code-style.md` rule: *"Plugin-specific services should NOT be registered in Builder.cs. Instead, plugins should instantiate their own services directly."*

## How

- Extracted `IToolLayerService` / `IToolFontService` interfaces; both impls dropped the `Singleton<T>` base.
- `MainEditorTabPlugin` (the composition root) now owns one instance of each and threads them down:
  - into `WireframeControl.Initialize(...)` → `Ruler` → `DistanceArrows`
  - through `SelectionManager` → `WireframeEditor` → `EditorContext`, so `DimensionDisplayVisual` reads `context.ToolFontService` (mirrors how the existing `Layer` already flows that path).
- `Ruler` / `DistanceArrows` ctor params retyped concrete → interface.
- Both `SelectionManager` unit tests updated for the new ctor parameter.

No `Builder.cs` change, no `Locator` residue, no remaining `.Self` on these services.

## Verification

- `dotnet build GumFull.sln` — **0 errors**.
- `GumToolUnitTests` — **971 passed**, 0 failed, 4 pre-existing skips.
- Manual smoke (editor render path) pending maintainer confirmation: rulers + dimension display + top overlay layer.

Closes #3294.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
