### PR TITLE
Phase 2 (static drain): PropertyGridManager.InitializeEarly() Locator calls -> ctor injection

### DIFF
--- a/Gum/Plugins/InternalPlugins/VariableGrid/PropertyGridManager.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/PropertyGridManager.cs
@@ -45,6 +45,12 @@ public partial class PropertyGridManager
     private readonly TypeManager _typeManager;
     private readonly IPluginManager _pluginManager;
     private readonly IProjectState _projectState;
+    private readonly ICompositeMemberRegistry _compositeMemberRegistry;
+    private readonly INameVerifier _nameVerifier;
+    private readonly IDeleteVariableService _deleteVariableService;
+    private readonly IEditVariableService _editVariableService;
+    private readonly IHotkeyManager _hotkeyManager;
+    private readonly IVariableSaveLogic _variableSaveLogic;
     WpfDataUi.DataUiGrid mVariablesDataGrid;
     MainPropertyGrid mainControl;
 
@@ -109,7 +115,13 @@ public partial class PropertyGridManager
         TypeManager typeManager,
         IPluginManager pluginManager,
         IProjectState projectState,
-        IVariableInCategoryPropagationLogic variableInCategoryPropagationLogic)
+        IVariableInCategoryPropagationLogic variableInCategoryPropagationLogic,
+        ICompositeMemberRegistry compositeMemberRegistry,
+        INameVerifier nameVerifier,
+        IDeleteVariableService deleteVariableService,
+        IEditVariableService editVariableService,
+        IHotkeyManager hotkeyManager,
+        IVariableSaveLogic variableSaveLogic)
     {
         _selectedState = selectedState;
         _exposeVariableService = exposeVariableService;
@@ -125,6 +137,12 @@ public partial class PropertyGridManager
         _typeManager = typeManager;
         _pluginManager = pluginManager;
         _projectState = projectState;
+        _compositeMemberRegistry = compositeMemberRegistry;
+        _nameVerifier = nameVerifier;
+        _deleteVariableService = deleteVariableService;
+        _editVariableService = editVariableService;
+        _hotkeyManager = hotkeyManager;
+        _variableSaveLogic = variableSaveLogic;
         _stateSaveCategoryDisplayer = new StateSaveCategoryDisplayer(variableInCategoryPropagationLogic);
     }
 
@@ -137,12 +155,9 @@ public partial class PropertyGridManager
             _undoManager,
             _guiCommands,
             _objectFinder,
-            Locator.GetRequiredService<ICompositeMemberRegistry>(),
+            _compositeMemberRegistry,
             _dialogService,
-            Locator.GetRequiredService<Gum.Managers.INameVerifier>());
-        var deleteVariableService = Locator.GetRequiredService<IDeleteVariableService>();
-        var editVariableService = Locator.GetRequiredService<IEditVariableService>();
-        var hotkeyManager = Locator.GetRequiredService<IHotkeyManager>();
+            _nameVerifier);
 
         mPropertyGridDisplayer = new ElementSaveDisplayer(
             new SubtextLogic(),
@@ -150,11 +165,11 @@ public partial class PropertyGridManager
             _selectedState,
             _undoManager,
             _pluginManager,
-            Locator.GetRequiredService<IVariableSaveLogic>(),
-            editVariableService,
+            _variableSaveLogic,
+            _editVariableService,
             _exposeVariableService,
-            hotkeyManager,
-            deleteVariableService,
+            _hotkeyManager,
+            _deleteVariableService,
             _guiCommands,
             _fileCommands,
             _setVariableLogic,
@@ -166,7 +181,7 @@ public partial class PropertyGridManager
 
         mVariablesDataGrid = mainControl.DataGrid;
 
-        VariableViewModel = new Plugins.VariableGrid.MainControlViewModel(deleteVariableService, editVariableService);
+        VariableViewModel = new Plugins.VariableGrid.MainControlViewModel(_deleteVariableService, _editVariableService);
         VariableViewModel.AddVariableButtonVisibility = System.Windows.Visibility.Collapsed;
         mainControl.DataContext = VariableViewModel;
         mainControl.SelectedBehaviorVariableChanged += HandleBehaviorVariableSelected;


### PR DESCRIPTION
## Phase 2 (static drain): `PropertyGridManager.InitializeEarly()` Locator calls → constructor injection

Continues the static-singleton drain. `PropertyGridManager.InitializeEarly()` resolved six services through `Locator.GetRequiredService<T>()` in its method body. This promotes them to constructor-injected `readonly` fields so the class's dependencies are explicit:

- `ICompositeMemberRegistry`
- `INameVerifier`
- `IDeleteVariableService`
- `IEditVariableService`
- `IHotkeyManager`
- `IVariableSaveLogic`

The redundant local variables in `InitializeEarly()` (`deleteVariableService`, `editVariableService`, `hotkeyManager`) are removed in favor of the fields, including the second use feeding `MainControlViewModel`.

### No construction cycle introduced

All six services are already registered as singletons in `Builder.cs`. The only constructor-graph edges into `PropertyGridManager` anywhere in the codebase are `GuiCommands` and `SelectedState`, **both already injecting `Lazy<PropertyGridManager>`** (the cycle-break established in #3289). Every path from these six services back to `PropertyGridManager` runs through those already-lazy edges, so adding them as direct constructor dependencies cannot form a new cycle — no `Lazy<T>` is needed here. (`MainVariableGridPlugin` resolves `PropertyGridManager` via runtime `Locator`, which is not part of the DI construction graph.)

### Behavior

Behavior-preserving: the same singleton instances are now supplied by DI rather than the service locator.

### Verification

- `dotnet build GumFull.sln` — 0 errors.
- `GumToolUnitTests` (PropertyGridManager / EditVariableService / SelectedState / NameVerifier) — 35 passed, 0 failed.
- Static analysis confirms no DI construction cycle (above).

Manual smoke test: launch the tool, confirm it starts with no startup DI exception and the **Variables** tab populates when an element/instance is selected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
