### PR TITLE
Add rule: use the Roslyn analyzer, not grep, for semantic C# searches

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,18 @@ There is a dedicated later phase for draining the remaining `.Self` singletons w
 
 **`ObjectFinder.Self` is the exception.** It is intentionally still a static singleton across the entire codebase (tool, runtimes, tests). There is no `IObjectFinder` interface, and replacing it is a project-wide refactor — do not attempt it as drive-by cleanup. Calls to `ObjectFinder.Self.GetBaseElements(...)`, `ObjectFinder.Self.GetDefaultChildName(...)`, etc. are acceptable in any context.
 
+## Searching C# Code — Use the Roslyn Analyzer, Not Grep
+
+For any **semantic** question about C# code, use the Roslyn-backed LSP tool, **not** `Grep`/`grep`. The LSP resolves the actual symbol; grep only matches text, which forces you to hand-classify the hits (is this a registered service, a plugin, a view, a converter?) — an error-prone step that has produced wrong conclusions before (e.g. naming a class as a refactor target when it had zero matching calls). Reach for the LSP operation that fits the question:
+
+- **"Where is this defined?"** → `goToDefinition`
+- **"What are *all* the references to this symbol?"** → `findReferences`
+- **"Who calls this / what's the construction path?"** (e.g. hunting a DI construction cycle) → `prepareCallHierarchy` + `incomingCalls` / `outgoingCalls`
+- **"What implements this interface / overrides this member?"** → `goToImplementation`
+- **"Find a type or member by name across the solution"** → `workspaceSymbol`
+
+`Grep` is still correct for **non-semantic** text searches — string literals, comments, `.csproj`/XML/config, build/log output, or finding an initial foothold before you have a symbol. The line is simple: once the question is *about a symbol* (who defines/references/calls/implements it), switch to Roslyn.
+
 ## Investigating Third-Party Libraries
 
 **Never decompile DLLs or NuGet assemblies** (no `dotnet-ildasm`, `ilspycmd`, ILSpy, dnSpy, etc.) to inspect third-party code. If you need to know the API surface of a library:


### PR DESCRIPTION
## Lock in: use the Roslyn analyzer, not grep, for C# searches

Adds a `CLAUDE.md` rule (next to "Investigating Third-Party Libraries") directing all **semantic** C# code questions — all references to a symbol, call hierarchy / DI construction-cycle paths, implementations, symbol lookup — through the Roslyn-backed LSP tool rather than `Grep`.

### Why
Grep only matches text, which forces hand-classifying each hit (registered service vs. plugin vs. view vs. converter). That step is error-prone and has produced wrong conclusions — e.g. naming a class as a refactor target when it had zero matching calls. Roslyn resolves the actual symbol and avoids that. Grep stays the right tool for non-semantic searches (string literals, comments, `.csproj`/XML, log output, finding an initial foothold).

This is a guidance-only change — no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
