### PR TITLE
Phase 2 (static drain): FileWatchLogic Locator calls -> ctor injection

### DIFF
--- a/Gum/Plugins/InternalPlugins/FileWatchPlugin/FileWatchLogic.cs
+++ b/Gum/Plugins/InternalPlugins/FileWatchPlugin/FileWatchLogic.cs
@@ -1,6 +1,5 @@
 ﻿using Gum.Commands;
 using Gum.Managers;
-using Gum.Services;
 using Gum.ToolStates;
 using System;
 using System.Collections.Generic;
@@ -11,17 +10,23 @@ namespace Gum.Logic.FileWatch;
 
 public class FileWatchLogic
 {
-    IFileWatchManager _fileWatchManager;
+    private readonly IFileWatchManager _fileWatchManager;
     private readonly IGuiCommands _guiCommands;
     private readonly IProjectState _projectState;
+    private readonly IProjectManager _projectManager;
 
     public bool Enabled => _fileWatchManager.Enabled;
 
-    public FileWatchLogic()
+    public FileWatchLogic(
+        IFileWatchManager fileWatchManager,
+        IGuiCommands guiCommands,
+        IProjectState projectState,
+        IProjectManager projectManager)
     {
-        _fileWatchManager = Locator.GetRequiredService<IFileWatchManager>();
-        _guiCommands = Locator.GetRequiredService<IGuiCommands>();
-        _projectState = Locator.GetRequiredService<IProjectState>();
+        _fileWatchManager = fileWatchManager;
+        _guiCommands = guiCommands;
+        _projectState = projectState;
+        _projectManager = projectManager;
     }
 
     public void HandleProjectLoaded()
@@ -36,7 +41,7 @@ public class FileWatchLogic
     public void RefreshRootDirectory()
     {
 
-        if (Locator.GetRequiredService<IProjectManager>().GumProjectSave?.FullFileName != null)
+        if (_projectManager.GumProjectSave?.FullFileName != null)
         {
             var directories = GetFileWatchRootDirectories();
             _fileWatchManager.EnableWithDirectories(directories);
@@ -86,7 +91,7 @@ public class FileWatchLogic
             }
         }
 
-        FilePath gumProjectFilePath = Locator.GetRequiredService<IProjectManager>().GumProjectSave.FullFileName;
+        FilePath gumProjectFilePath = _projectManager.GumProjectSave.FullFileName;
 
         if (gumProjectFilePath != null)
         {

--- a/Tool/Tests/GumToolUnitTests/Logic/FileWatch/FileWatchLogicTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Logic/FileWatch/FileWatchLogicTests.cs
@@ -1,0 +1,51 @@
+using Gum.Commands;
+using Gum.Logic.FileWatch;
+using Gum.Managers;
+using Gum.ToolStates;
+using Moq;
+using Xunit;
+
+namespace GumToolUnitTests.Logic.FileWatch;
+
+public class FileWatchLogicTests
+{
+    private readonly Mock<IFileWatchManager> _fileWatchManager;
+    private readonly Mock<IGuiCommands> _guiCommands;
+    private readonly Mock<IProjectState> _projectState;
+    private readonly Mock<IProjectManager> _projectManager;
+    private readonly FileWatchLogic _fileWatchLogic;
+
+    public FileWatchLogicTests()
+    {
+        _fileWatchManager = new Mock<IFileWatchManager>();
+        _guiCommands = new Mock<IGuiCommands>();
+        _projectState = new Mock<IProjectState>();
+        _projectManager = new Mock<IProjectManager>();
+
+        _fileWatchLogic = new FileWatchLogic(
+            _fileWatchManager.Object,
+            _guiCommands.Object,
+            _projectState.Object,
+            _projectManager.Object);
+    }
+
+    [Fact]
+    public void HandleProjectUnloaded_DisablesWatcher()
+    {
+        _fileWatchLogic.HandleProjectUnloaded();
+
+        _fileWatchManager.Verify(m => m.Disable(), Times.Once);
+    }
+
+    [Fact]
+    public void RefreshRootDirectory_ClearsIgnoredFilesAndDisables_WhenNoProjectLoaded()
+    {
+        // GumProjectSave defaults to null on the mock, so GumProjectSave?.FullFileName
+        // is null and RefreshRootDirectory takes the "no project" branch. This avoids
+        // GetFileWatchRootDirectories, which would require heavy ObjectFinder.Self setup.
+        _fileWatchLogic.RefreshRootDirectory();
+
+        _fileWatchManager.Verify(m => m.ClearIgnoredFiles(), Times.Once);
+        _fileWatchManager.Verify(m => m.Disable(), Times.Once);
+    }
+}


### PR DESCRIPTION
## What

Phase 2 (static drain) follow-up. `FileWatchLogic` was a DI-registered singleton (`Builder.cs`) whose parameterless constructor resolved three dependencies via `Locator` (`IFileWatchManager`, `IGuiCommands`, `IProjectState`), plus two method-body `Locator.GetRequiredService<IProjectManager>()` lookups in `RefreshRootDirectory()` and `GetFileWatchRootDirectories()`.

This converts all five `Locator` calls to **constructor injection**, adding an `IProjectManager` field.

## Why it's safe

- `FileWatchLogic` is registered as a concrete singleton and is **only ever `Locator`-resolved** — by `MainFileWatchPlugin` and `MainPropertiesWindowPlugin`. It is **never a constructor parameter** anywhere, so it's a graph leaf: injecting `IProjectManager` into it introduces no construction cycle, and no `Lazy<T>` is needed. All four injected interfaces are already registered in `Builder.cs`.
- The two plugin resolution sites stay as `Locator` — the sanctioned plugin exception (plugins are MEF-composed and can't take arbitrary ctor injection).

## Test

`FileWatchLogic` is now constructible with mocks, so this adds `FileWatchLogicTests` pinning the seam:

- `RefreshRootDirectory` with a null `GumProjectSave` takes the no-project branch and calls `ClearIgnoredFiles()` + `Disable()` on a mocked `IFileWatchManager`. This deliberately avoids the `GetFileWatchRootDirectories()` path, which needs heavy `ObjectFinder.Self` project setup.
- `HandleProjectUnloaded` calls `Disable()`.

Both pass (2/2). Built and ran via `GumToolUnitTests`.

## Boyscout

- Removed the now-dead `using Gum.Services;` (only `Locator` came from it).
- Made `_fileWatchManager` `readonly` (only assigned in the ctor), matching the other fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
