### PR TITLE
Phase 2 (static drain): EditVariableService Locator -> ctor-injected Func<AddVariableViewModel>

### DIFF
--- a/Gum/Services/EditVariableService.cs
+++ b/Gum/Services/EditVariableService.cs
@@ -10,7 +10,6 @@ using Gum.Plugins.InternalPlugins.VariableGrid.ViewModels;
 using Gum.Plugins.VariableGrid;
 using Gum.ToolCommands;
 using Gum.ToolStates;
-using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -53,18 +52,21 @@ public class EditVariableService : IEditVariableService
     private readonly IGuiCommands _guiCommands;
     private readonly IFileCommands _fileCommands;
     private readonly IUndoManager _undoManager;
+    private readonly Func<AddVariableViewModel> _addVariableViewModelFactory;
 
     public EditVariableService(IRenameLogic renameLogic,
         IDialogService dialogService,
         IGuiCommands guiCommands,
         IFileCommands fileCommands,
-        IUndoManager undoManager)
+        IUndoManager undoManager,
+        Func<AddVariableViewModel> addVariableViewModelFactory)
     {
         _renameLogic = renameLogic;
         _dialogService = dialogService;
         _guiCommands = guiCommands;
         _fileCommands = fileCommands;
         _undoManager = undoManager;
+        _addVariableViewModelFactory = addVariableViewModelFactory;
     }
 
     public void TryAddEditVariableOptions(InstanceMember instanceMember, VariableSave variableSave, IStateContainer stateListCategoryContainer)
@@ -195,7 +197,7 @@ public class EditVariableService : IEditVariableService
         }
 
         // We can re-use the logic in the AddVariableViewModel:
-        var vm = Locator.GetRequiredService<AddVariableViewModel>();
+        var vm = _addVariableViewModelFactory();
         vm.RenameType = RenameType.ExposedName;
         vm.ApplyVariableReferenceChanges(changeResponse, newName, oldName, changedElements);
 

--- a/Tool/Tests/GumToolUnitTests/Services/EditVariableServiceTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Services/EditVariableServiceTests.cs
@@ -9,12 +9,9 @@ using Gum.Services.Dialogs;
 using Gum.ToolCommands;
 using Gum.ToolStates;
 using Gum.Undo;
-using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using Moq.AutoMock;
 using Shouldly;
-using System.Collections.Generic;
-using System.Reflection;
 
 namespace GumToolUnitTests.Services;
 
@@ -26,7 +23,6 @@ public class EditVariableServiceTests : BaseTestClass
     private readonly Mock<IGuiCommands> _guiCommands;
     private readonly Mock<IFileCommands> _fileCommands;
     private readonly EditVariableService _service;
-    private readonly IServiceProvider _testServiceProvider;
 
     public EditVariableServiceTests()
     {
@@ -45,34 +41,19 @@ public class EditVariableServiceTests : BaseTestClass
             .Setup(x => x.GetUserString(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<GetUserStringOptions>()))
             .Returns("NewExposedName");
 
+        // RenameExposedVariable invokes the injected AddVariableViewModel factory to re-use its
+        // variable-reference rename logic, so supply a usable instance via the factory.
+        var addVariableVm = new AutoMocker().CreateInstance<AddVariableViewModel>();
+
         _service = new EditVariableService(
             _renameLogic.Object,
             _dialogService.Object,
             _guiCommands.Object,
             _fileCommands.Object,
-            _undoManager.Object);
-
-        // RenameExposedVariable calls Locator.GetRequiredService<AddVariableViewModel>()
-        // internally, so we must register a usable instance to avoid an exception.
-        var mocker = new AutoMocker();
-        var addVariableVm = mocker.CreateInstance<AddVariableViewModel>();
-        var services = new ServiceCollection();
-        services.AddSingleton(addVariableVm);
-        _testServiceProvider = services.BuildServiceProvider();
-        Locator.Register(_testServiceProvider);
+            _undoManager.Object,
+            () => addVariableVm);
 
         ObjectFinder.Self.GumProjectSave = new GumProjectSave();
-    }
-
-    public override void Dispose()
-    {
-        // Remove the test service provider we registered so it doesn't bleed into other tests.
-        var prop = typeof(Locator).GetProperty(
-            "ServiceProviders", BindingFlags.NonPublic | BindingFlags.Static)!;
-        var providers = (List<IServiceProvider>)prop.GetValue(null)!;
-        providers.Remove(_testServiceProvider);
-
-        base.Dispose();
     }
 
     [Fact]


### PR DESCRIPTION
## Phase 2 (static drain): EditVariableService

Drains the lone `Locator.GetRequiredService<AddVariableViewModel>()` call remaining in `EditVariableService` (in `RenameExposedVariable`, which re-uses `AddVariableViewModel`'s variable-reference rename logic).

### Change
- Inject a `Func<AddVariableViewModel>` factory via the constructor and call it instead of the service locator.
- No new `Builder.cs` registration: the existing `AddViewModelFuncFactories` scan already auto-registers any ctor `Func<...>` parameter whose result type derives from `ViewModel` (`AddVariableViewModel : DialogViewModel : ViewModel`). Same pattern as `AnimationCollectionViewModelManager`'s `Func<ElementAnimationsViewModel>`.
- Removed the now-unused `Microsoft.Extensions.DependencyInjection` using.

### Test
- `RenameExposedVariable_ShouldRequestUndoLock` (the existing pinning test for this path) now injects the factory directly, which lets the test drop the `Locator.Register` scaffolding and the reflection-based `Dispose` override that only existed to unregister the test service provider.

Behavior-preserving drain — only *how* the view model is obtained changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
