### PR TITLE
Phase 2 (static drain): AddComponent/AddScreenDialogViewModel Locator -> ctor-injected IProjectState

### DIFF
--- a/Gum/Dialogs/AddComponentDialogViewModel.cs
+++ b/Gum/Dialogs/AddComponentDialogViewModel.cs
@@ -1,6 +1,5 @@
 ﻿using Gum.DataTypes;
 using Gum.Managers;
-using Gum.Services;
 using Gum.Services.Dialogs;
 using Gum.ToolCommands;
 using Gum.ToolStates;
@@ -17,16 +16,19 @@ public class AddComponentDialogViewModel : GetUserStringDialogBaseViewModel
     private readonly ISelectedState _selectedState;
     private readonly ProjectCommands _projectCommands;
     private readonly FileLocations _fileLocations;
+    private readonly IProjectState _projectState;
 
-    public AddComponentDialogViewModel(INameVerifier nameVerifier, 
-        ISelectedState selectedState, 
+    public AddComponentDialogViewModel(INameVerifier nameVerifier,
+        ISelectedState selectedState,
         ProjectCommands projectCommands,
-        FileLocations fileLocations)
+        FileLocations fileLocations,
+        IProjectState projectState)
     {
         _nameVerifier = nameVerifier;
         _selectedState = selectedState;
         _projectCommands = projectCommands;
         _fileLocations = fileLocations;
+        _projectState = projectState;
     }
 
     public override void OnAffirmative()
@@ -43,8 +45,7 @@ public class AddComponentDialogViewModel : GetUserStringDialogBaseViewModel
         FilePath? path = nodeToAddTo?.GetFullFilePath();
         if (nodeToAddTo == null || !nodeToAddTo.IsPartOfComponentsFolderStructure())
         {
-            var projectState = Locator.GetRequiredService<IProjectState>();
-            path = projectState.ComponentFilePath;
+            path = _projectState.ComponentFilePath;
         }
 
         if (path != null)

--- a/Gum/Dialogs/AddScreenDialogViewModel.cs
+++ b/Gum/Dialogs/AddScreenDialogViewModel.cs
@@ -1,7 +1,6 @@
 ﻿using Gum.Commands;
 using Gum.DataTypes;
 using Gum.Managers;
-using Gum.Services;
 using Gum.Services.Dialogs;
 using Gum.ToolCommands;
 using Gum.ToolStates;
@@ -20,13 +19,15 @@ public class AddScreenDialogViewModel : GetUserStringDialogBaseViewModel
     private readonly IFileCommands _fileCommands;
     private readonly ProjectCommands _projectCommands;
     private readonly FileLocations _fileLocations;
+    private readonly IProjectState _projectState;
 
-    public AddScreenDialogViewModel(INameVerifier nameVerifier, 
-        ISelectedState selectedState, 
+    public AddScreenDialogViewModel(INameVerifier nameVerifier,
+        ISelectedState selectedState,
         IGuiCommands guiCommands,
         IFileCommands fileCommands,
         ProjectCommands projectCommands,
-        FileLocations fileLocations)
+        FileLocations fileLocations,
+        IProjectState projectState)
     {
         _nameVerifier = nameVerifier;
         _selectedState = selectedState;
@@ -34,7 +35,7 @@ public class AddScreenDialogViewModel : GetUserStringDialogBaseViewModel
         _fileCommands = fileCommands;
         _projectCommands = projectCommands;
         _fileLocations = fileLocations;
-
+        _projectState = projectState;
     }
 
     public override void OnAffirmative()
@@ -52,8 +53,7 @@ public class AddScreenDialogViewModel : GetUserStringDialogBaseViewModel
 
         if (nodeToAddTo == null || !nodeToAddTo.IsPartOfScreensFolderStructure())
         {
-            var projectState = Locator.GetRequiredService<IProjectState>();
-            path = projectState.ScreenFilePath.FullPath;
+            path = _projectState.ScreenFilePath.FullPath;
         }
         
         string relativeToScreens = FileManager.MakeRelative(path, _fileLocations.ScreensFolder);

--- a/Tool/Tests/GumToolUnitTests/ViewModels/Dialogs/AddComponentDialogViewModelTests.cs
+++ b/Tool/Tests/GumToolUnitTests/ViewModels/Dialogs/AddComponentDialogViewModelTests.cs
@@ -1,0 +1,51 @@
+using Gum.DataTypes;
+using Gum.Dialogs;
+using Gum.Managers;
+using Gum.ToolCommands;
+using Gum.ToolStates;
+using Moq;
+
+namespace GumToolUnitTests.ViewModels.Dialogs;
+
+public class AddComponentDialogViewModelTests : BaseTestClass
+{
+    private readonly AddComponentDialogViewModel _sut;
+    private readonly Mock<INameVerifier> _nameVerifier;
+    private readonly Mock<ISelectedState> _selectedState;
+    private readonly Mock<IProjectState> _projectState;
+
+    public AddComponentDialogViewModelTests()
+    {
+        _nameVerifier = new Mock<INameVerifier>();
+        _selectedState = new Mock<ISelectedState>();
+        _projectState = new Mock<IProjectState>();
+
+        // Make the name validation pass so OnAffirmative is not short-circuited by an Error.
+        ObjectFinder.Self.GumProjectSave = new GumProjectSave { FullFileName = "C:/project/Test.gumx" };
+        string? whyNotValid = null;
+        _nameVerifier
+            .Setup(x => x.IsElementNameValid(It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<ElementSave?>(), out whyNotValid))
+            .Returns(true);
+
+        // With no component-folder tree node selected, OnAffirmative falls back to
+        // IProjectState.ComponentFilePath; the mock returns a null FilePath, so the method
+        // short-circuits before touching ProjectCommands/FileLocations. Those collaborators are
+        // therefore never invoked on this path - ProjectCommands is supplied as null deliberately.
+        _sut = new AddComponentDialogViewModel(
+            _nameVerifier.Object,
+            _selectedState.Object,
+            projectCommands: null!,
+            new FileLocations(),
+            _projectState.Object);
+    }
+
+    [Fact]
+    public void OnAffirmative_WhenSelectedNodeIsNotInComponentsFolder_ReadsComponentFilePathFromProjectState()
+    {
+        _sut.Value = "NewComponent";
+
+        _sut.OnAffirmative();
+
+        _projectState.Verify(x => x.ComponentFilePath, Times.Once);
+    }
+}


### PR DESCRIPTION
## What

Phase 2 static-singleton drain. `AddComponentDialogViewModel` and `AddScreenDialogViewModel` (both in `Gum/Dialogs/`) each held a single stray `Locator.GetRequiredService<IProjectState>()` inside `OnAffirmative`. Both are already DI-constructed (auto-registered as `ViewModel` transients via the reflection scan in `Builder.cs`), and `IProjectState` is already registered there (`AddSingleton<IProjectState, ProjectState>()`), so this is a direct interface injection:

- Add an `IProjectState projectState` constructor parameter + `readonly` field to each VM.
- Replace the `Locator` call with the injected `_projectState`.
- Remove the now-dead `using Gum.Services;` from both files (it only provided `Locator`).

Behavior-preserving: the DI container resolves the same `ProjectState` singleton the static `Locator` would have returned.

## Tests

Adds `AddComponentDialogViewModelTests` — a pinning test verifying that, when no components-folder tree node is selected, `OnAffirmative` reads the fallback path from the **injected** `IProjectState`. Red→green was demonstrated: with the body still on `Locator`, the test failed with `InvalidOperationException: No service for ... IProjectState has been registered` (unit tests don't register a `Locator` provider); after injecting the field it passes.

The seam is clean for the Component VM because a null `ComponentFilePath` (Moq default — `FilePath` is a reference type) short-circuits the `if (path != null)` guard before the non-mockable `ProjectCommands`/`FileLocations` work.

`AddScreenDialogViewModel` is **not** given a pinning test: its `OnAffirmative` unconditionally drives non-virtual `ProjectCommands.AddScreen` (which in turn pulls in `StandardElementsManager.Self`, real `GumProjectSave` mutation, and `FixCustomTypeConverters`), and `ScreenFilePath.FullPath` NREs on a null mock — there is no clean seam to isolate the injected read. Per the `refactoring-direction` skill ("skip where the harness would have to contort, in favor of the compiler plus a manual check"), the Screen drain — identical in shape to the Component one — is covered by the compiler, DI resolution, and the Component pinning test.

## Verification

- `dotnet build GumFull.sln` — 0 errors.
- Focused `GumToolUnitTests` run of `AddComponentDialogViewModelTests` — passes (and fails red-first when the `Locator` call is restored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
