### PR TITLE
Phase 2 (static drain): ImportComponent/ImportBehaviorDialog Locator -> ctor-injected IProjectManager

### DIFF
--- a/Gum/Plugins/ImportPlugin/ViewModel/ImportBehaviorDialog.cs
+++ b/Gum/Plugins/ImportPlugin/ViewModel/ImportBehaviorDialog.cs
@@ -1,7 +1,6 @@
 ﻿using Gum.Commands;
 using Gum.Managers;
 using Gum.Plugins.ImportPlugin.Manager;
-using Gum.Services;
 using Gum.Services.Dialogs;
 using Gum.ToolStates;
 using System.Collections.Generic;
@@ -19,6 +18,7 @@ public class ImportBehaviorDialog : ImportBaseDialogViewModel
     private readonly ISelectedState _selectedState;
     private readonly IImportLogic _importLogic;
     private readonly IProjectState _projectState;
+    private readonly IProjectManager _projectManager;
 
     public override string Title => "Import Behavior";
     public override string BrowseFileFilter => "Behavior Files (*.behaviors)|*.behaviors";
@@ -29,8 +29,8 @@ public class ImportBehaviorDialog : ImportBaseDialogViewModel
         ISelectedState selectedState,
         IDialogService dialogService,
         IImportLogic importLogic,
-        IProjectState projectState
-
+        IProjectState projectState,
+        IProjectManager projectManager
         ) : base(dialogService)
     {
         _fileCommands = fileCommands;
@@ -38,6 +38,7 @@ public class ImportBehaviorDialog : ImportBaseDialogViewModel
         _selectedState = selectedState;
         _importLogic = importLogic;
         _projectState = projectState;
+        _projectManager = projectManager;
 
         List<FilePath> behaviorFilesNotInProject = FileManager.GetAllFilesInDirectory(
             _projectState.BehaviorFilePath.FullPath, "behx")
@@ -61,7 +62,7 @@ public class ImportBehaviorDialog : ImportBaseDialogViewModel
         BehaviorSave lastImportedBehavior = null;
 
         string desiredDirectory = FileManager.GetDirectory(
-            Locator.GetRequiredService<IProjectManager>().GumProjectSave.FullFileName) + "Behaviors/";
+            _projectManager.GumProjectSave.FullFileName) + "Behaviors/";
 
         foreach (string file in SelectedFiles)
         {

--- a/Gum/Plugins/ImportPlugin/ViewModel/ImportComponentDialog.cs
+++ b/Gum/Plugins/ImportPlugin/ViewModel/ImportComponentDialog.cs
@@ -1,7 +1,6 @@
 ﻿using Gum.Commands;
 using Gum.Managers;
 using Gum.Plugins.ImportPlugin.Manager;
-using Gum.Services;
 using Gum.Services.Dialogs;
 using Gum.ToolStates;
 using System.Collections.Generic;
@@ -30,14 +29,15 @@ public class ImportComponentDialog : ImportBaseDialogViewModel
         ISelectedState selectedState,
         IDialogService dialogService,
         IImportLogic importLogic,
-        IProjectState projectState)
+        IProjectState projectState,
+        IProjectManager projectManager)
         : base(dialogService)
     {
         _fileCommands = fileCommands;
         _guiCommands = guiCommands;
         _selectedState = selectedState;
         _importLogic = importLogic;
-        _projectManager = Locator.GetRequiredService<IProjectManager>();
+        _projectManager = projectManager;
         _projectState = projectState;
 
         List<FilePath> componentFilesNotInProject = FileManager.GetAllFilesInDirectory(

--- a/Tool/Tests/GumToolUnitTests/ViewModels/Dialogs/ImportBehaviorDialogTests.cs
+++ b/Tool/Tests/GumToolUnitTests/ViewModels/Dialogs/ImportBehaviorDialogTests.cs
@@ -1,0 +1,60 @@
+using Gum.Commands;
+using Gum.DataTypes;
+using Gum.Managers;
+using Gum.Plugins.ImportPlugin.Manager;
+using Gum.Plugins.ImportPlugin.ViewModel;
+using Gum.Services.Dialogs;
+using Gum.ToolStates;
+using Moq;
+using ToolsUtilities;
+
+namespace GumToolUnitTests.ViewModels.Dialogs;
+
+public class ImportBehaviorDialogTests : BaseTestClass
+{
+    private readonly Mock<IFileCommands> _fileCommands;
+    private readonly Mock<IGuiCommands> _guiCommands;
+    private readonly Mock<ISelectedState> _selectedState;
+    private readonly Mock<IDialogService> _dialogService;
+    private readonly Mock<IImportLogic> _importLogic;
+    private readonly Mock<IProjectState> _projectState;
+    private readonly Mock<IProjectManager> _projectManager;
+    private readonly GumProjectSave _gumProjectSave;
+
+    public ImportBehaviorDialogTests()
+    {
+        _fileCommands = new Mock<IFileCommands>();
+        _guiCommands = new Mock<IGuiCommands>();
+        _selectedState = new Mock<ISelectedState>();
+        _dialogService = new Mock<IDialogService>();
+        _importLogic = new Mock<IImportLogic>();
+        _projectState = new Mock<IProjectState>();
+        _projectManager = new Mock<IProjectManager>();
+        _gumProjectSave = new GumProjectSave { FullFileName = "C:/project/Test.gumx" };
+
+        // The constructor scans the behaviors folder (returns empty for a non-existent dir)
+        // and reads the project's existing behaviors, so those reads must not throw.
+        _projectState.Setup(x => x.BehaviorFilePath).Returns(new FilePath("C:/project/Behaviors/"));
+        _projectState.Setup(x => x.GumProjectSave).Returns(_gumProjectSave);
+        _projectManager.Setup(x => x.GumProjectSave).Returns(_gumProjectSave);
+    }
+
+    private ImportBehaviorDialog CreateSut() => new(
+        _fileCommands.Object,
+        _guiCommands.Object,
+        _selectedState.Object,
+        _dialogService.Object,
+        _importLogic.Object,
+        _projectState.Object,
+        _projectManager.Object);
+
+    [Fact]
+    public void OnAffirmative_ReadsGumProjectSaveFromInjectedProjectManager()
+    {
+        ImportBehaviorDialog sut = CreateSut();
+
+        sut.OnAffirmative();
+
+        _projectManager.Verify(x => x.GumProjectSave, Times.Once);
+    }
+}

--- a/Tool/Tests/GumToolUnitTests/ViewModels/Dialogs/ImportComponentDialogTests.cs
+++ b/Tool/Tests/GumToolUnitTests/ViewModels/Dialogs/ImportComponentDialogTests.cs
@@ -1,0 +1,60 @@
+using Gum.Commands;
+using Gum.DataTypes;
+using Gum.Managers;
+using Gum.Plugins.ImportPlugin.Manager;
+using Gum.Plugins.ImportPlugin.ViewModel;
+using Gum.Services.Dialogs;
+using Gum.ToolStates;
+using Moq;
+using ToolsUtilities;
+
+namespace GumToolUnitTests.ViewModels.Dialogs;
+
+public class ImportComponentDialogTests : BaseTestClass
+{
+    private readonly Mock<IFileCommands> _fileCommands;
+    private readonly Mock<IGuiCommands> _guiCommands;
+    private readonly Mock<ISelectedState> _selectedState;
+    private readonly Mock<IDialogService> _dialogService;
+    private readonly Mock<IImportLogic> _importLogic;
+    private readonly Mock<IProjectState> _projectState;
+    private readonly Mock<IProjectManager> _projectManager;
+    private readonly GumProjectSave _gumProjectSave;
+
+    public ImportComponentDialogTests()
+    {
+        _fileCommands = new Mock<IFileCommands>();
+        _guiCommands = new Mock<IGuiCommands>();
+        _selectedState = new Mock<ISelectedState>();
+        _dialogService = new Mock<IDialogService>();
+        _importLogic = new Mock<IImportLogic>();
+        _projectState = new Mock<IProjectState>();
+        _projectManager = new Mock<IProjectManager>();
+        _gumProjectSave = new GumProjectSave { FullFileName = "C:/project/Test.gumx" };
+
+        // The constructor scans the components folder (returns empty for a non-existent dir)
+        // and reads the project's existing components, so those reads must not throw.
+        _projectState.Setup(x => x.ComponentFilePath).Returns(new FilePath("C:/project/Components/"));
+        _projectState.Setup(x => x.GumProjectSave).Returns(_gumProjectSave);
+        _projectManager.Setup(x => x.GumProjectSave).Returns(_gumProjectSave);
+    }
+
+    private ImportComponentDialog CreateSut() => new(
+        _fileCommands.Object,
+        _guiCommands.Object,
+        _selectedState.Object,
+        _dialogService.Object,
+        _importLogic.Object,
+        _projectState.Object,
+        _projectManager.Object);
+
+    [Fact]
+    public void OnAffirmative_ReadsGumProjectSaveFromInjectedProjectManager()
+    {
+        ImportComponentDialog sut = CreateSut();
+
+        sut.OnAffirmative();
+
+        _projectManager.Verify(x => x.GumProjectSave, Times.Once);
+    }
+}


### PR DESCRIPTION
## What

Phase 2 static-singleton drain. `ImportComponentDialog` and `ImportBehaviorDialog` (both in `Gum/Plugins/ImportPlugin/ViewModel/`, compiled into the main `Gum.csproj`) each held a single stray `Locator.GetRequiredService<IProjectManager>()` — a constructor field-init in `ImportComponentDialog`, an inline call in `ImportBehaviorDialog.OnAffirmative`. Both are `DialogService`-resolved (`_dialogService.Show<ImportComponentDialog>()` / `Show<ImportBehaviorDialog>()`), already inject their other dependencies, and `IProjectManager` is already registered in `Builder.cs`, so this is a direct interface injection:

- Add an `IProjectManager projectManager` constructor parameter (+ a `readonly` field — `ImportBehaviorDialog` had none) and use it instead of `Locator`.
- Remove the now-dead `using Gum.Services;` from both files.

Behavior-preserving: the DI container resolves the same `ProjectManager` singleton the static `Locator` would have returned.

## Tests

Adds pinning tests for **both** VMs. Red→green was demonstrated: pre-drain the injected `IProjectManager` mock is unused and the `Locator` call throws `No service for ... IProjectManager has been registered` — in the **constructor** for `ImportComponentDialog`, in `OnAffirmative` for `ImportBehaviorDialog` — and post-drain each reads the injected mock's `GumProjectSave`.

Unlike the AddScreen sibling in #3302, the seam is clean here: the constructors' folder scan (`FileManager.GetAllFilesInDirectory`) returns empty for a non-existent directory, and `OnAffirmative`'s downstream work goes through mockable interfaces (`IImportLogic`, `IGuiCommands`, etc.) rather than a non-virtual concrete — so both VMs are cheap to construct and exercise with mocked deps.

## Verification

- `dotnet build GumFull.sln` — 0 errors.
- Focused `GumToolUnitTests` run of both `Import*DialogTests` — 2/2 pass (and fail red-first when the `Locator` calls are restored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
