### PR TITLE
Phase 2 (static drain): StandardElementsManagerGumTool Locator -> ctor-injected ISelectedState

### DIFF
--- a/Gum/Plugins/InternalPlugins/VariableGrid/StandardElementsManager.GumTool.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/StandardElementsManager.GumTool.cs
@@ -4,7 +4,6 @@ using Gum.DataTypes.Variables;
 using Gum.Managers;
 using Gum.Plugins;
 using Gum.PropertyGridHelpers.Converters;
-using Gum.Services;
 using Gum.ToolStates;
 using Gum.Wireframe;
 using RenderingLibrary.Graphics;
@@ -23,15 +22,18 @@ public interface IStandardElementsManagerGumTool
     void FixCustomTypeConverters(GumProjectSave project);
     void FixCustomTypeConverters(ElementSave elementSave);
     void RefreshStateVariablesThroughPlugins();
+    void SetPreferredDisplayers(StateSave state);
 }
 
 public class StandardElementsManagerGumTool : IStandardElementsManagerGumTool
 {
     private readonly IPluginManager _pluginManager;
+    private readonly ISelectedState _selectedState;
 
-    public StandardElementsManagerGumTool(IPluginManager pluginManager)
+    public StandardElementsManagerGumTool(IPluginManager pluginManager, ISelectedState selectedState)
     {
         _pluginManager = pluginManager;
+        _selectedState = selectedState;
     }
 
     public void Initialize()
@@ -42,7 +44,7 @@ public class StandardElementsManagerGumTool : IStandardElementsManagerGumTool
             new AvailableContainedTypeConverter();
 
         defaultStates["Component"].Variables
-            .Add(new VariableSave { SetsValue = true, Type = "State", Value = null, Name = "State", CustomTypeConverter = new AvailableStatesConverter(null, Locator.GetRequiredService<ISelectedState>()) });
+            .Add(new VariableSave { SetsValue = true, Type = "State", Value = null, Name = "State", CustomTypeConverter = new AvailableStatesConverter(null, _selectedState) });
 
         foreach (var state in StandardElementsManager.Self.DefaultStates.Values)
         {
@@ -56,7 +58,7 @@ public class StandardElementsManagerGumTool : IStandardElementsManagerGumTool
 
     }
 
-    public static void SetPreferredDisplayers(StateSave state)
+    public void SetPreferredDisplayers(StateSave state)
     {
         foreach (var variable in state.Variables)
         {
@@ -125,19 +127,18 @@ public class StandardElementsManagerGumTool : IStandardElementsManagerGumTool
             }
             else if (variable.Type == "string" && variable.Name == "Parent")
             {
-                var selectedState = Locator.GetRequiredService<ISelectedState>();
-                variable.CustomTypeConverter = new AvailableParentsTypeConverter(selectedState);
+                variable.CustomTypeConverter = new AvailableParentsTypeConverter(_selectedState);
                 variable.PropertiesToSetOnDisplayer["IsEditable"] = true;
             }
             else if (variable.Type == "string" && variable.Name == "RenderTargetTextureSource")
             {
                 variable.CustomTypeConverter =
-                    new AvailableRenderTargetContainersConverter(Locator.GetRequiredService<ISelectedState>());
+                    new AvailableRenderTargetContainersConverter(_selectedState);
             }
             else if (variable.Type == "State" && variable.Name == "State")
             {
                 variable.Category = "States and Visibility";
-                variable.CustomTypeConverter = new AvailableStatesConverter(null, Locator.GetRequiredService<ISelectedState>());
+                variable.CustomTypeConverter = new AvailableStatesConverter(null, _selectedState);
             }
             else if (variable.Name == "Red" ||
                 variable.Name == "Green" ||
@@ -190,7 +191,7 @@ public class StandardElementsManagerGumTool : IStandardElementsManagerGumTool
 
             if (foundVariable != null)
             {
-                foundVariable.CustomTypeConverter = new AvailableStatesConverter(stateSaveCategory.Name, Locator.GetRequiredService<ISelectedState>());
+                foundVariable.CustomTypeConverter = new AvailableStatesConverter(stateSaveCategory.Name, _selectedState);
             }
         }
     }

--- a/Gum/SvgPlugin/Managers/DefaultStateManager.cs
+++ b/Gum/SvgPlugin/Managers/DefaultStateManager.cs
@@ -38,15 +38,19 @@ public static class DefaultStateManager
 #if GUM
     internal static void UpdateDisplayersForStandards()
     {
-        Gum.Plugins.InternalPlugins.VariableGrid.StandardElementsManagerGumTool.SetPreferredDisplayers(StandardElementsManager.GetArcState());
-        Gum.Plugins.InternalPlugins.VariableGrid.StandardElementsManagerGumTool.SetPreferredDisplayers(StandardElementsManager.GetColoredCircleState());
-        Gum.Plugins.InternalPlugins.VariableGrid.StandardElementsManagerGumTool.SetPreferredDisplayers(StandardElementsManager.GetLineState());
-        Gum.Plugins.InternalPlugins.VariableGrid.StandardElementsManagerGumTool.SetPreferredDisplayers(StandardElementsManager.GetRoundedRectangleState());
+        // SvgPlugin is a separate plugin assembly outside the main DI container, so it resolves
+        // the (now instance) StandardElementsManagerGumTool through the service Locator.
+        Gum.Plugins.InternalPlugins.VariableGrid.IStandardElementsManagerGumTool standardElementsManagerGumTool =
+            Locator.GetRequiredService<Gum.Plugins.InternalPlugins.VariableGrid.IStandardElementsManagerGumTool>();
 
-        Gum.Plugins.InternalPlugins.VariableGrid.StandardElementsManagerGumTool.SetPreferredDisplayers(GetCanvasState());
-        Gum.Plugins.InternalPlugins.VariableGrid.StandardElementsManagerGumTool.SetPreferredDisplayers(GetSvgState());
-        Gum.Plugins.InternalPlugins.VariableGrid.StandardElementsManagerGumTool.SetPreferredDisplayers(GetLottieAnimationState());
+        standardElementsManagerGumTool.SetPreferredDisplayers(StandardElementsManager.GetArcState());
+        standardElementsManagerGumTool.SetPreferredDisplayers(StandardElementsManager.GetColoredCircleState());
+        standardElementsManagerGumTool.SetPreferredDisplayers(StandardElementsManager.GetLineState());
+        standardElementsManagerGumTool.SetPreferredDisplayers(StandardElementsManager.GetRoundedRectangleState());
 
+        standardElementsManagerGumTool.SetPreferredDisplayers(GetCanvasState());
+        standardElementsManagerGumTool.SetPreferredDisplayers(GetSvgState());
+        standardElementsManagerGumTool.SetPreferredDisplayers(GetLottieAnimationState());
     }
 #endif
 

--- a/Tool/Tests/GumToolUnitTests/Logic/InheritanceLogicTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Logic/InheritanceLogicTests.cs
@@ -5,6 +5,7 @@ using Gum.Logic;
 using Gum.Managers;
 using Gum.Plugins;
 using Gum.Plugins.InternalPlugins.VariableGrid;
+using Gum.ToolStates;
 using Moq;
 using Shouldly;
 
@@ -24,7 +25,7 @@ public class InheritanceLogicTests : BaseTestClass
         _sut = new InheritanceLogic(
             _fileCommands.Object,
             _guiCommands.Object,
-            new StandardElementsManagerGumTool(new Mock<IPluginManager>().Object));
+            new StandardElementsManagerGumTool(new Mock<IPluginManager>().Object, new Mock<ISelectedState>().Object));
     }
 
     [Fact]

--- a/Tool/Tests/GumToolUnitTests/Managers/StandardElementsManagerTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Managers/StandardElementsManagerTests.cs
@@ -1,6 +1,10 @@
 using Gum.DataTypes.Variables;
 using Gum.Managers;
+using Gum.Plugins;
 using Gum.Plugins.InternalPlugins.VariableGrid;
+using Gum.PropertyGridHelpers.Converters;
+using Gum.ToolStates;
+using Moq;
 using Shouldly;
 using System.Linq;
 using WpfDataUi.Controls;
@@ -10,6 +14,9 @@ namespace GumToolUnitTests.Managers;
 
 public class StandardElementsManagerTests : BaseTestClass
 {
+    private static StandardElementsManagerGumTool CreateSut(ISelectedState? selectedState = null) =>
+        new(Mock.Of<IPluginManager>(), selectedState ?? Mock.Of<ISelectedState>());
+
     // FillAlpha / StrokeAlpha / DropshadowAlpha are 0-255 byte channels just like the legacy
     // Alpha, so they should get the same SliderDisplay with a [0, 255] range rather than a
     // plain int textbox.
@@ -22,12 +29,28 @@ public class StandardElementsManagerTests : BaseTestClass
         var state = new StateSave();
         state.Variables.Add(new VariableSave { Type = "int", Name = variableName });
 
-        StandardElementsManagerGumTool.SetPreferredDisplayers(state);
+        CreateSut().SetPreferredDisplayers(state);
 
         var variable = state.Variables.First();
         variable.PreferredDisplayer.ShouldBe(typeof(SliderDisplay));
         variable.PropertiesToSetOnDisplayer["MinValue"].ShouldBe(0.0);
         variable.PropertiesToSetOnDisplayer["MaxValue"].ShouldBe(255.0);
+    }
+
+    // Pins the static->instance drain: the Parent variable's type converter is built from the
+    // injected ISelectedState. Before the drain SetPreferredDisplayers pulled ISelectedState from
+    // the static Locator (which throws in a unit test); now it must come from the constructor.
+    [Fact]
+    public void SetPreferredDisplayers_AssignsAvailableParentsConverter_FromInjectedSelectedState()
+    {
+        StateSave state = new StateSave();
+        state.Variables.Add(new VariableSave { Type = "string", Name = "Parent" });
+
+        CreateSut().SetPreferredDisplayers(state);
+
+        VariableSave variable = state.Variables.First();
+        variable.CustomTypeConverter.ShouldBeOfType<AvailableParentsTypeConverter>();
+        variable.PropertiesToSetOnDisplayer["IsEditable"].ShouldBe(true);
     }
 
     [Theory]


### PR DESCRIPTION
## What

Phase 2 static-singleton drain. `StandardElementsManagerGumTool` held **five** `Locator.GetRequiredService<ISelectedState>()` calls, all resolving the same dependency. `ISelectedState` is already registered + MEF-exported and does **not** depend back on this class, so there is no construction cycle — drained to a single ctor-injected `ISelectedState` field. The class is already a DI-registered singleton (`AddSingleton<StandardElementsManagerGumTool>()`), so the container supplies it; no `Builder.cs` change needed.

Two of the calls were in instance methods (`Initialize`, `FixCustomTypeConverters`) → trivially use `_selectedState`.

The other three lived in `public static SetPreferredDisplayers(StateSave)`. Per the `refactoring-direction` skill (prefer instance over static), that method was converted **static → instance** and added to `IStandardElementsManagerGumTool`. Its one cross-assembly caller — `SvgPlugin`'s `DefaultStateManager` (a **separate plugin assembly** outside the main DI container) — now resolves the instance through `Locator` (a sanctioned exception for plugin assemblies) and calls the instance method. The internal `Initialize` caller and the `InheritanceLogicTests` construction were updated for the new ctor/instance API.

The dead `using Gum.Services;` was removed from the drained file.

## Tests

- The existing `SetPreferredDisplayers_AssignsByteRangeSlider_ToAlphaVariables` test now runs against an instance (via a small `CreateSut` helper).
- Adds `SetPreferredDisplayers_AssignsAvailableParentsConverter_FromInjectedSelectedState`, a pinning test that the `Parent` variable's type converter is built from the **injected** `ISelectedState`. Red→green confirmed: reverting that one line to `Locator` makes the test throw `No service for ... ISelectedState has been registered` (unit tests don't register a `Locator` provider).

## Verification

- `dotnet build GumFull.sln` — 0 errors (covers the main assembly, SvgPlugin, and tests).
- Focused `GumToolUnitTests` run of `StandardElementsManagerTests` + `InheritanceLogicTests` — 25/25 pass.

## Manual verification needed (behavior-touching: Variables tab + SvgPlugin shapes)

This converts a static helper that the Skia/Svg plugin calls cross-assembly, so a quick runtime smoke is warranted on top of the tests:

1. Open a project; in the **Variables** tab of a component, confirm the `Parent` dropdown, a `State` variable dropdown, and (on a screen/component with one) the `RenderTargetTextureSource` dropdown still populate their options.
2. With the SvgPlugin active, add a **Circle / ColoredCircle / RoundedRectangle / Arc / Line / Svg / Canvas / LottieAnimation** and confirm its angle/alpha/unit variables show the right editors (angle dial, 0–255 sliders, unit dropdowns) — i.e. `DefaultStateManager.UpdateDisplayersForStandards` still wires displayers correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
