### PR TITLE
Phase 2 (static drain): ElementTreeViewManager Locator -> ctor-injected IDispatcher + existing IProjectState

### DIFF
--- a/Gum/Plugins/InternalPlugins/TreeView/ElementTreeViewManager.RightClick.cs
+++ b/Gum/Plugins/InternalPlugins/TreeView/ElementTreeViewManager.RightClick.cs
@@ -680,7 +680,7 @@ public partial class ElementTreeViewManager
 
     private bool GuardProjectSaved(string? reason = null)
     {
-        if (ObjectFinder.Self.GumProjectSave == null || string.IsNullOrEmpty(Locator.GetRequiredService<IProjectManager>().GumProjectSave.FullFileName))
+        if (ObjectFinder.Self.GumProjectSave == null || string.IsNullOrEmpty(_projectState.GumProjectSave.FullFileName))
         {
             _dialogService.ShowMessage("You must first save the project");
             return false;

--- a/Gum/Plugins/InternalPlugins/TreeView/ElementTreeViewManager.cs
+++ b/Gum/Plugins/InternalPlugins/TreeView/ElementTreeViewManager.cs
@@ -375,6 +375,7 @@ public partial class ElementTreeViewManager : IRecipient<ThemeChangedMessage>, I
     private readonly ICollapseToggleService _collapseToggleService;
     private readonly StandardElementsManagerGumTool _standardElementsManagerGumTool;
     private readonly PluginManager _pluginManager;
+    private readonly IDispatcher _dispatcher;
 
     public bool HasMouseOver
     {
@@ -410,7 +411,8 @@ public partial class ElementTreeViewManager : IRecipient<ThemeChangedMessage>, I
         IProjectState projectState,
         StandardElementsManagerGumTool standardElementsManagerGumTool,
         IDragDropManager dragDropManager,
-        PluginManager pluginManager)
+        PluginManager pluginManager,
+        IDispatcher dispatcher)
     {
         _selectedState = selectedState;
         _editCommands = editCommands;
@@ -434,6 +436,7 @@ public partial class ElementTreeViewManager : IRecipient<ThemeChangedMessage>, I
         _projectState = projectState;
         _standardElementsManagerGumTool = standardElementsManagerGumTool;
         _pluginManager = pluginManager;
+        _dispatcher = dispatcher;
         _collapseToggleService = new CollapseToggleService();
         _recordedSelectedInstances = new List<InstanceSave>();
         TreeNodeExtensionMethods.ElementTreeViewManager = this;
@@ -724,7 +727,7 @@ public partial class ElementTreeViewManager : IRecipient<ThemeChangedMessage>, I
             {
                 if (e.Action != DragAction.Continue)
                 {
-                    Locator.GetRequiredService<IDispatcher>().Post(() =>
+                    _dispatcher.Post(() =>
                     {
                         OnSelect(ObjectTreeView.SelectedNode);
                     });
@@ -1042,7 +1045,7 @@ public partial class ElementTreeViewManager : IRecipient<ThemeChangedMessage>, I
 
     private void AddAndRemoveScreensComponentsStandardsAndBehaviors()
     {
-        var gumProject = Locator.GetRequiredService<IProjectManager>().GumProjectSave;
+        var gumProject = _projectState.GumProjectSave;
         /////////////Early Out////////////////
         if (gumProject == null)
             return;
@@ -1056,7 +1059,7 @@ public partial class ElementTreeViewManager : IRecipient<ThemeChangedMessage>, I
 
         #region Add nodes that haven't been added yet
 
-        foreach (ScreenSave screenSave in Locator.GetRequiredService<IProjectManager>().GumProjectSave.Screens)
+        foreach (ScreenSave screenSave in gumProject.Screens)
         {
             var treeNode = GetTreeNodeFor(screenSave);
             if (treeNode == null && ShouldShow(screenSave))
@@ -1068,7 +1071,7 @@ public partial class ElementTreeViewManager : IRecipient<ThemeChangedMessage>, I
             }
         }
 
-        foreach (ComponentSave componentSave in Locator.GetRequiredService<IProjectManager>().GumProjectSave.Components)
+        foreach (ComponentSave componentSave in gumProject.Components)
         {
             if (GetTreeNodeFor(componentSave) == null && ShouldShow(componentSave))
             {
@@ -1084,7 +1087,7 @@ public partial class ElementTreeViewManager : IRecipient<ThemeChangedMessage>, I
             }
         }
 
-        foreach (StandardElementSave standardSave in Locator.GetRequiredService<IProjectManager>().GumProjectSave.StandardElements)
+        foreach (StandardElementSave standardSave in gumProject.StandardElements)
         {
             if (standardSave.Name != "Component")
             {
@@ -1095,7 +1098,7 @@ public partial class ElementTreeViewManager : IRecipient<ThemeChangedMessage>, I
             }
         }
 
-        foreach(BehaviorSave behaviorSave in Locator.GetRequiredService<IProjectManager>().GumProjectSave.Behaviors)
+        foreach(BehaviorSave behaviorSave in gumProject.Behaviors)
         {
             if(GetTreeNodeFor(behaviorSave) == null && ShouldShow(behaviorSave))
             {
@@ -1186,7 +1189,7 @@ public partial class ElementTreeViewManager : IRecipient<ThemeChangedMessage>, I
 
             if(behavior != null)
             {
-                if(behavior == null || !Locator.GetRequiredService<IProjectManager>().GumProjectSave.Behaviors.Contains(behavior) || !ShouldShow(behavior))
+                if(behavior == null || !gumProject.Behaviors.Contains(behavior) || !ShouldShow(behavior))
                 {
                     mBehaviorsTreeNode.Nodes.RemoveAt(i);
                 }
@@ -2633,6 +2636,9 @@ public static class TreeNodeExtensionMethods
             treeNode.IsTopBehaviorTreeNode()
             )
         {
+            // Locator is retained here (not ctor-injected): this is a static extension method on TreeNode,
+            // so there is no instance to hold injected IProjectManager/IDialogService fields. IProjectManager
+            // and IDialogService are both DI-registered; the only blocker to draining is the static context.
             if (Locator.GetRequiredService<IProjectManager>().GumProjectSave == null ||
                 string.IsNullOrEmpty(Locator.GetRequiredService<IProjectManager>().GumProjectSave.FullFileName))
             {


### PR DESCRIPTION
## Phase 2 (static drain): `ElementTreeViewManager` Locator → constructor injection

Continues the Phase 2 drain of `Locator.GetRequiredService<T>()` calls in the Gum tool, targeting the largest remaining registered-singleton consumer: `ElementTreeViewManager` (the central element tree view) and its `.RightClick` partial. As established when it was drained from a static `.Self` (#3286), the class keeps **no interface** — it is a bloated WinForms-coupled UI class whose only consumer couples to internal/UI-typed members — and is set up two-stage via `Initialize()` in `Program.cs`. This PR does not touch any of that.

### What was drained (instance-method calls)

| Type | Calls | Resolution |
|---|---|---|
| `IDispatcher` | 1 (in `Initialize`) | new ctor-injected `readonly IDispatcher _dispatcher` |
| `IProjectManager` | 6 (all read `.GumProjectSave`) | reuse already-injected `_projectState.GumProjectSave` |

- **`IDispatcher`** — registered in `Builder.cs` and a **DI leaf** (`AppDispatcher` has no dependencies), so it adds no construction-cycle risk.
- **`IProjectManager`** — every call only reads `.GumProjectSave`. `IProjectState` (already injected as `_projectState`) exposes `GumProjectSave` as a **pure passthrough to the same singleton `ProjectManager`** (`ProjectState.GumProjectSave => _projectManager.GumProjectSave`), so these become `_projectState.GumProjectSave` rather than adding a redundant 23rd constructor parameter that duplicates an existing one. In `AddAndRemoveScreensComponentsStandardsAndBehaviors` the calls collapse onto the method's **already-captured `gumProject` local** (the remove-region closures already used it) — making the method internally consistent.

### Left in place (with an inline note)

The Locator calls in the **static** extension method `TreeNodeExtensionMethods.GetFullFilePath` (`IProjectManager` + `IDialogService`). Both types are DI-registered; the only blocker to draining is the static context — there is no instance to hold injected fields. A comment documents this.

### DI construction cycle — none

`ElementTreeViewManager` has **in-degree 0** in the MS.DI singleton graph: its only consumer, `MainTreeViewPlugin`, is a MEF plugin (`[Export(typeof(PluginBase))]`) that resolves it via `Locator` in a parameterless constructor, **not** through the DI constructor graph. A construction cycle requires the class to be reachable from one of its own dependencies (an in-edge); there is none, so adding eager dependencies cannot close a cycle. **No `Lazy<T>` was needed.**

### Tests

Behavior-preserving drain (static `Locator` → injected field / existing field); **no pinning test added**. The drained instance methods manipulate WinForms `TreeNode`s and the class constructs `ElementTreeViewCreator`/`Cursor` in its ctor, so a unit-test seam would require ~23 mocks plus live WinForms construction — the contortion the `refactoring-direction`/`tdd` skills say to skip in favor of compiler + DI + a manual check. (The existing `ElementTreeViewManager*Tests` cover only its **static pure helpers** — `GetReselectableNodes`, `ProcessDrop` — which this PR does not touch; they still pass 11/11.)

### Verification

- `dotnet build GumFull.sln` → **0 errors**.
- `GumToolUnitTests --filter ElementTreeViewManager` → **11/11 pass**.
- **Manual tree-view check still required before merge** (central tree view): app launches; element tree populates; expand/collapse; selecting a node updates the rest of the UI; right-click context menu (add/delete/rename screen/component/folder); drag-drop reorder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
