### PR TITLE
Phase 2 (static drain): PluginBase Locator ctor -> MEF property-injected shared services

### DIFF
--- a/Gum/CodeOutputPlugin/MainCodeOutputPlugin.cs
+++ b/Gum/CodeOutputPlugin/MainCodeOutputPlugin.cs
@@ -71,7 +71,8 @@ public class MainCodeOutputPlugin : PluginBase
 
     #region Init/Startup
 
-    public MainCodeOutputPlugin()
+    [ImportingConstructor]
+    public MainCodeOutputPlugin(IGuiCommands guiCommands, IDialogService dialogService)
     {
         codeOutputProjectSettings = new CodeOutputProjectSettings();
 
@@ -95,13 +96,13 @@ public class MainCodeOutputPlugin : PluginBase
         _selectedState = Locator.GetRequiredService<ISelectedState>();
 
         var customCodeGenerator = new CustomCodeGenerator(_codeGenerator, _codeGenerationNameVerifier);
-        _codeGenerationService = new CodeGenerationService(_guiCommands, _codeGenerator, _dialogService, customCodeGenerator, _codeGenerationNameVerifier, _projectDirectoryProvider, Locator.GetRequiredService<IRetryService>());
+        _codeGenerationService = new CodeGenerationService(guiCommands, _codeGenerator, dialogService, customCodeGenerator, _codeGenerationNameVerifier, _projectDirectoryProvider, Locator.GetRequiredService<IRetryService>());
         _renameService = new RenameService(
             _codeGenerationService,
             _codeGenerator,
             customCodeGenerator,
             _codeGenerationNameVerifier,
-            _dialogService,
+            dialogService,
             _projectDirectoryProvider);
 
         _messenger = Locator.GetRequiredService<IMessenger>();

--- a/Gum/Plugins/BaseClasses/PluginBase.cs
+++ b/Gum/Plugins/BaseClasses/PluginBase.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.Composition;
 using System.Linq;
 using Gum.DataTypes;
 using Gum.Gui.Windows;
@@ -27,12 +28,23 @@ namespace Gum.Plugins.BaseClasses;
 
 public abstract class PluginBase : IPlugin
 {
-    protected readonly IGuiCommands _guiCommands;
-    protected readonly IFileCommands _fileCommands;
-    protected readonly ITabManager _tabManager;
-    protected readonly IDialogService _dialogService;
-    private readonly MenuStripManager _menuStripManager;
-    
+    // These shared services are supplied by MEF as property imports. They are bridged into
+    // the plugin container in PluginManager.LoadPlugins (AddExportedValue). MEF sets them
+    // after construction and before StartUp(), so reference them in StartUp()/handlers, not
+    // in a plugin constructor (a plugin needing one at construction time should inject it via
+    // its own [ImportingConstructor] instead).
+    protected IGuiCommands _guiCommands;
+    protected IFileCommands _fileCommands;
+    protected ITabManager _tabManager;
+    protected IDialogService _dialogService;
+    private MenuStripManager _menuStripManager;
+
+    [Import] public IGuiCommands GuiCommands { get => _guiCommands; set => _guiCommands = value; }
+    [Import] public IFileCommands FileCommands { get => _fileCommands; set => _fileCommands = value; }
+    [Import] public ITabManager TabManager { get => _tabManager; set => _tabManager = value; }
+    [Import] public IDialogService DialogService { get => _dialogService; set => _dialogService = value; }
+    [Import] public MenuStripManager MenuStripManager { get => _menuStripManager; set => _menuStripManager = value; }
+
     #region Events
 
     public event Action<GumProjectSave>? ProjectLoad;
@@ -250,15 +262,6 @@ public abstract class PluginBase : IPlugin
     public abstract string FriendlyName { get; }
 
     public virtual Version Version => new Version(1, 0);
-
-    protected PluginBase()
-    {
-        _guiCommands = Locator.GetRequiredService<IGuiCommands>();
-        _fileCommands = Locator.GetRequiredService<IFileCommands>();
-        _tabManager = Locator.GetRequiredService<ITabManager>();
-        _menuStripManager = Locator.GetRequiredService<MenuStripManager>();
-        _dialogService = Locator.GetRequiredService<IDialogService>();
-    }
 
     public virtual void FillTopLevelNames(ElementSave element, List<TopLevelName> names) { }
 

--- a/Gum/Plugins/InternalPlugins/Delete/DeleteObjectPlugin.cs
+++ b/Gum/Plugins/InternalPlugins/Delete/DeleteObjectPlugin.cs
@@ -27,12 +27,13 @@ public class DeleteObjectPlugin : PriorityPlugin
     private readonly IDeleteLogic _deleteLogic;
     private readonly InstanceDeletionHelper _instanceDeletionHelper;
 
-    public DeleteObjectPlugin()
+    [ImportingConstructor]
+    public DeleteObjectPlugin(IGuiCommands guiCommands, IFileCommands fileCommands)
     {
         _elementCommands = Locator.GetRequiredService<IElementCommands>();
         _wireframeCommands = Locator.GetRequiredService<WireframeCommands>();
         _deleteLogic = Locator.GetRequiredService<IDeleteLogic>();
-        _instanceDeletionHelper = new InstanceDeletionHelper(_deleteLogic, _guiCommands, _wireframeCommands, _fileCommands);
+        _instanceDeletionHelper = new InstanceDeletionHelper(_deleteLogic, guiCommands, _wireframeCommands, fileCommands);
     }
 
     public override void StartUp()

--- a/Gum/Plugins/InternalPlugins/StatePlugin/MainStatePlugin.cs
+++ b/Gum/Plugins/InternalPlugins/StatePlugin/MainStatePlugin.cs
@@ -45,7 +45,7 @@ public class MainStatePlugin : PriorityPlugin
     #region Initialize
 
     [ImportingConstructor]
-    public MainStatePlugin(ISelectedState selectedState)
+    public MainStatePlugin(ISelectedState selectedState, IGuiCommands guiCommands, IFileCommands fileCommands)
     {
         _selectedState = selectedState;
         var elementCommands = Locator.GetRequiredService<IElementCommands>();
@@ -60,8 +60,8 @@ public class MainStatePlugin : PriorityPlugin
             elementCommands,
             editCommands,
             dialogService,
-            _guiCommands,
-            _fileCommands,
+            guiCommands,
+            fileCommands,
             _copyPasteLogic);
 
         stateTreeViewModel = new StateTreeViewModel(_stateTreeViewRightClickService,

--- a/Gum/Plugins/InternalPlugins/SvgExportPlugin/MainSvgExportPlugin.cs
+++ b/Gum/Plugins/InternalPlugins/SvgExportPlugin/MainSvgExportPlugin.cs
@@ -1,6 +1,8 @@
+using Gum.Commands;
 using Gum.DataTypes;
 using Gum.Plugins.BaseClasses;
 using Gum.Services;
+using Gum.Services.Dialogs;
 using Gum.ToolStates;
 using System.ComponentModel.Composition;
 using System.Windows.Controls;
@@ -15,13 +17,15 @@ internal class MainSvgExportPlugin : PriorityPlugin
     private readonly IProjectState _projectState;
     private readonly ISvgExportCommand _svgExportCommand;
 
-    public MainSvgExportPlugin()
+    [ImportingConstructor]
+    public MainSvgExportPlugin(IDialogService dialogService, IGuiCommands guiCommands)
     {
         _selectedState = Locator.GetRequiredService<ISelectedState>();
         _projectState = Locator.GetRequiredService<IProjectState>();
         // SVG export is plugin-specific, so the command is instantiated here rather than
-        // registered app-wide. _dialogService/_guiCommands come from PluginBase's ctor.
-        _svgExportCommand = new SvgExportCommand(_dialogService, _guiCommands);
+        // registered app-wide. These services are injected (they are also property-injected
+        // into PluginBase for use in StartUp()/handlers).
+        _svgExportCommand = new SvgExportCommand(dialogService, guiCommands);
     }
 
     public override void StartUp()

--- a/Gum/Plugins/PluginManager.cs
+++ b/Gum/Plugins/PluginManager.cs
@@ -829,6 +829,14 @@ public class PluginManager : IPluginManager
             batch.AddExportedValue<IUndoManager>(Locator.GetRequiredService<IUndoManager>());
             batch.AddExportedValue<IProjectManager>(Locator.GetRequiredService<IProjectManager>());
 
+            // Shared services consumed by PluginBase (via property imports) and by individual
+            // plugins that need them at construction time (via [ImportingConstructor]).
+            batch.AddExportedValue<IGuiCommands>(Locator.GetRequiredService<IGuiCommands>());
+            batch.AddExportedValue<IFileCommands>(Locator.GetRequiredService<IFileCommands>());
+            batch.AddExportedValue<ITabManager>(Locator.GetRequiredService<ITabManager>());
+            batch.AddExportedValue<MenuStripManager>(Locator.GetRequiredService<MenuStripManager>());
+            batch.AddExportedValue<IDialogService>(Locator.GetRequiredService<IDialogService>());
+
 
             var container = new CompositionContainer(catalog);
 

--- a/Tool/Tests/GumToolUnitTests/Plugins/PluginBaseCompositionTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/PluginBaseCompositionTests.cs
@@ -1,0 +1,99 @@
+using Gum.Commands;
+using Gum.Managers;
+using Gum.Plugins.BaseClasses;
+using Gum.Services.Dialogs;
+using Moq.AutoMock;
+using Shouldly;
+using System.ComponentModel.Composition;
+using System.ComponentModel.Composition.Hosting;
+
+namespace GumToolUnitTests.Plugins;
+
+// Pins the MEF wiring that replaced PluginBase's Locator constructor: the shared services
+// are bridged into the plugin container (PluginManager.LoadPlugins) and supplied to plugins
+// via inherited [Import] properties on PluginBase, with [ImportingConstructor] still able to
+// inject the same services for plugins that need them at construction time.
+public class PluginBaseCompositionTests : BaseTestClass
+{
+    [Fact]
+    public void Compose_SatisfiesInheritedServiceImports_OnPluginWithoutImportingConstructor()
+    {
+        var services = new BridgedServices();
+
+        var plugin = ComposeSinglePlugin<PropertyInjectedTestPlugin>(services);
+
+        plugin.GuiCommands.ShouldBeSameAs(services.GuiCommands);
+        plugin.FileCommands.ShouldBeSameAs(services.FileCommands);
+        plugin.TabManager.ShouldBeSameAs(services.TabManager);
+        plugin.MenuStripManager.ShouldBeSameAs(services.MenuStripManager);
+        plugin.DialogService.ShouldBeSameAs(services.DialogService);
+    }
+
+    [Fact]
+    public void Compose_SatisfiesImportingConstructorAndInheritedImports_OnPluginWithImportingConstructor()
+    {
+        var services = new BridgedServices();
+
+        var plugin = (CtorInjectedTestPlugin)ComposeSinglePlugin<CtorInjectedTestPlugin>(services);
+
+        // The constructor-injected dependency resolves (the path used by plugins that need a
+        // service at construction time, e.g. MainStatePlugin / DeleteObjectPlugin)...
+        plugin.ConstructorInjectedGuiCommands.ShouldBeSameAs(services.GuiCommands);
+        // ...and the inherited PluginBase property imports are still satisfied alongside it.
+        plugin.DialogService.ShouldBeSameAs(services.DialogService);
+        plugin.TabManager.ShouldBeSameAs(services.TabManager);
+    }
+
+    private static PluginBase ComposeSinglePlugin<T>(BridgedServices services) where T : PluginBase
+    {
+        var catalog = new TypeCatalog(typeof(T));
+        var container = new CompositionContainer(catalog);
+
+        var batch = new CompositionBatch();
+        batch.AddExportedValue(services.GuiCommands);
+        batch.AddExportedValue(services.FileCommands);
+        batch.AddExportedValue(services.TabManager);
+        batch.AddExportedValue(services.MenuStripManager);
+        batch.AddExportedValue(services.DialogService);
+        container.Compose(batch);
+
+        return container.GetExportedValue<PluginBase>()!;
+    }
+
+    // Mirrors the five values PluginManager.LoadPlugins bridges into the plugin container.
+    private sealed class BridgedServices
+    {
+        private readonly AutoMocker _mocker = new();
+
+        public IGuiCommands GuiCommands => _mocker.GetMock<IGuiCommands>().Object;
+        public IFileCommands FileCommands => _mocker.GetMock<IFileCommands>().Object;
+        public ITabManager TabManager => _mocker.GetMock<ITabManager>().Object;
+        public IDialogService DialogService => _mocker.GetMock<IDialogService>().Object;
+        public MenuStripManager MenuStripManager { get; }
+
+        public BridgedServices()
+        {
+            MenuStripManager = _mocker.CreateInstance<MenuStripManager>();
+        }
+    }
+
+    [Export(typeof(PluginBase))]
+    public class PropertyInjectedTestPlugin : PriorityPlugin
+    {
+        public override void StartUp() { }
+    }
+
+    [Export(typeof(PluginBase))]
+    public class CtorInjectedTestPlugin : PriorityPlugin
+    {
+        public IGuiCommands ConstructorInjectedGuiCommands { get; }
+
+        [ImportingConstructor]
+        public CtorInjectedTestPlugin(IGuiCommands guiCommands)
+        {
+            ConstructorInjectedGuiCommands = guiCommands;
+        }
+
+        public override void StartUp() { }
+    }
+}


### PR DESCRIPTION
## What

Drains `PluginBase`'s parameterless constructor, which service-located five shared services via `Locator`:
`IGuiCommands`, `IFileCommands`, `ITabManager`, `MenuStripManager`, `IDialogService`.

These are now **MEF property imports** on `PluginBase`, bridged into the plugin container in `PluginManager.LoadPlugins` via `AddExportedValue` — the same pattern already used for `ISelectedState` / `IElementCommands` / `IUndoManager` / `IProjectManager`. This relocates the `Locator` calls to the composition root rather than deleting them, consistent with the rest of the Phase 2 static-singleton drain.

## Why property injection (not constructor injection through `base(...)`)

These five are *universal base-class infrastructure* used by every plugin, unlike the four already-bridged services that individual plugins inject selectively. Property-injecting them on the base means **no `base(...)` forwarding through ~34 plugin constructors**, and the implicit parameterless ctor is preserved so **externally-compiled third-party plugins keep loading** (no source/binary break).

## Leaf changes

MEF sets property imports *after* construction, so the four plugins that used these services *at construction time* now inject what they need via their own `[ImportingConstructor]`:

- `MainCodeOutputPlugin`
- `DeleteObjectPlugin`
- `MainSvgExportPlugin`
- `MainStatePlugin`

Plugins that only use the services in `StartUp()`/handlers are unchanged.

## Tests

Adds `PluginBaseCompositionTests`, pinning the MEF wiring:
1. MEF satisfies the inherited `[Import]` properties on a `PluginBase` subclass (the property-injection mechanism).
2. MEF satisfies an `[ImportingConstructor]` *alongside* the inherited property imports (the converted-plugin pattern).

`GumFull.sln` builds clean; full `GumToolUnitTests` suite green (980 passed, 4 pre-existing skips).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
