### PR TITLE
ListBox/ItemsControl decoration API: inert separators/chrome between rows (#3305)

### DIFF
--- a/MonoGameGum.Tests/Forms/ListBoxTests.cs
+++ b/MonoGameGum.Tests/Forms/ListBoxTests.cs
@@ -1794,4 +1794,209 @@ public class ListBoxTests : BaseTestClass
                 "but IsFontDirty is still true.");
         }
     }
+
+    #region Decorations (issue #3305)
+
+    [Fact]
+    public void InsertDecorationAfter_RendersBetweenRows_AndKeepsItemsAndSelectionContiguous()
+    {
+        // Issue #3305: a decoration (here a ColoredRectangle) lives in InnerPanel.Children so it
+        // renders between rows, but it is in neither Items nor ListBoxItems. SelectedIndex stays
+        // contiguous (the row after the decoration is index 2, not 3) and can never be a decoration.
+        ListBox listBox = new();
+        listBox.Items!.Add("A");
+        listBox.Items!.Add("B");
+        listBox.Items!.Add("C");
+
+        ColoredRectangleRuntime separator = new();
+        listBox.InsertDecorationAfter("B", separator);
+
+        listBox.Items!.Count.ShouldBe(3);
+        listBox.ListBoxItems.Count.ShouldBe(3);
+
+        ObservableCollection<GraphicalUiElement> panel = listBox.InnerPanel.Children;
+        panel.Count.ShouldBe(4);
+        panel[0].ShouldBe(listBox.ListBoxItems[0].Visual); // A
+        panel[1].ShouldBe(listBox.ListBoxItems[1].Visual); // B
+        panel[2].ShouldBe(separator);                      // decoration
+        panel[3].ShouldBe(listBox.ListBoxItems[2].Visual); // C
+
+        listBox.SelectedObject = "C";
+        listBox.SelectedIndex.ShouldBe(2);
+    }
+
+    [Fact]
+    public void AddDecoration_ThenAddItems_KeepsItemVisualOrderCorrect_WithBoundTypedItems()
+    {
+        // Issue #3305: the shared ItemsControl base inserts each new item's visual at its Items
+        // index into InnerPanel.Children. A decoration occupies a panel slot without an Items slot,
+        // so without index translation items added after a decoration land in the wrong panel slot.
+        // Also verifies a bound typed ObservableCollection<string> stays valid alongside decorations.
+        ObservableCollection<string> items = new() { "A", "B" };
+        ListBox listBox = new();
+        listBox.Items = items;
+
+        ColoredRectangleRuntime separator = new();
+        listBox.AddDecoration(separator); // "add now" -> after the current last item ("B")
+
+        items.Add("C");
+        items.Add("D");
+
+        ObservableCollection<GraphicalUiElement> panel = listBox.InnerPanel.Children;
+        panel.Count.ShouldBe(5);
+        panel[0].ShouldBe(listBox.ListBoxItems[0].Visual); // A
+        panel[1].ShouldBe(listBox.ListBoxItems[1].Visual); // B
+        panel[2].ShouldBe(separator);
+        panel[3].ShouldBe(listBox.ListBoxItems[2].Visual); // C
+        panel[4].ShouldBe(listBox.ListBoxItems[3].Visual); // D
+
+        items.ShouldBe(new[] { "A", "B", "C", "D" });
+        listBox.ListBoxItems.Count.ShouldBe(4);
+        listBox.ListBoxItems[2].BindingContext.ShouldBe("C");
+        listBox.ListBoxItems[3].BindingContext.ShouldBe("D");
+    }
+
+    [Fact]
+    public void Click_OnDecoration_ShouldNotChangeSelection()
+    {
+        // Issue #3305: clicking a decoration must be inert - it must not deselect the current item
+        // or raise SelectionChanged (and, by extension, must not close a parent ComboBox).
+        ListBox listBox = new();
+        listBox.AddToRoot();
+        listBox.Items!.Add("A");
+        listBox.Items!.Add("B");
+        listBox.Items!.Add("C");
+
+        ColoredRectangleRuntime separator = new();
+        separator.Height = 30;
+        listBox.InsertDecorationAfter("A", separator);
+
+        listBox.SelectedObject = "C";
+
+        int fireCount = 0;
+        listBox.SelectionChanged += (_, _) => fireCount++;
+
+        Mock<ICursor> cursor = SetupForPush();
+        float cx = separator.GetAbsoluteX() + separator.GetAbsoluteWidth() / 2;
+        float cy = separator.GetAbsoluteY() + separator.GetAbsoluteHeight() / 2;
+        cursor.Setup(c => c.XRespectingGumZoomAndBounds()).Returns(cx);
+        cursor.Setup(c => c.YRespectingGumZoomAndBounds()).Returns(cy);
+        cursor.Setup(c => c.X).Returns((int)cx);
+        cursor.Setup(c => c.Y).Returns((int)cy);
+        cursor.SetupProperty(x => x.VisualOver);
+        cursor.SetupProperty(x => x.WindowPushed);
+
+        GueInteractiveExtensionMethods.DoUiActivityRecursively(listBox.Visual, cursor.Object, null!, 0);
+
+        listBox.SelectedObject.ShouldBe("C");
+        fireCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public void DownArrow_NavigationSkipsDecoration()
+    {
+        // Issue #3305: keyboard/gamepad navigation moves through rows (ListBoxItems), so a
+        // decoration sitting between two rows is skipped - down from "A" selects "B", not the
+        // decoration.
+        ListBox listBox = new();
+        listBox.AddToRoot();
+        listBox.Items!.Add("A");
+        listBox.Items!.Add("B");
+        listBox.Items!.Add("C");
+
+        ColoredRectangleRuntime separator = new();
+        listBox.InsertDecorationAfter("A", separator);
+
+        listBox.SelectedIndex = 0;
+        listBox.DoListItemsHaveFocus = true;
+
+        Mock<IInputReceiverKeyboardMonoGame> keyboard = new();
+        keyboard.As<IInputReceiverKeyboard>()
+            .Setup(k => k.KeyTyped(Gum.Forms.Input.Keys.Down)).Returns(true);
+        keyboard.As<IInputReceiverKeyboard>()
+            .Setup(k => k.KeysTyped).Returns(new List<Gum.Forms.Input.Keys>());
+        FrameworkElement.KeyboardsForUiControl.Add(keyboard.Object);
+
+        listBox.OnFocusUpdate();
+
+        listBox.SelectedObject.ShouldBe("B");
+        listBox.SelectedIndex.ShouldBe(1);
+    }
+
+    [Fact]
+    public void RemovingAnchorItem_RemovesTheDecoration()
+    {
+        // Issue #3305: a decoration is anchored to a data item, so removing that item removes the
+        // decoration too - it never outlives the row it was attached to.
+        ListBox listBox = new();
+        listBox.Items!.Add("A");
+        listBox.Items!.Add("B");
+        listBox.Items!.Add("C");
+
+        ColoredRectangleRuntime separator = new();
+        listBox.InsertDecorationAfter("B", separator);
+
+        listBox.InnerPanel.Children.Count.ShouldBe(4);
+
+        listBox.Items!.Remove("B");
+
+        listBox.InnerPanel.Children.Count.ShouldBe(2);
+        listBox.InnerPanel.Children.Contains(separator).ShouldBeFalse();
+        separator.Parent.ShouldBeNull();
+        listBox.ListBoxItems.Count.ShouldBe(2);
+        listBox.ListBoxItems[0].BindingContext.ShouldBe("A");
+        listBox.ListBoxItems[1].BindingContext.ShouldBe("C");
+    }
+
+    [Fact]
+    public void ReorderItems_KeepsCollectionsInSync_AndDecorationFollowsAnchor()
+    {
+        // Issue #3305: reordering with a decoration present keeps Items, ListBoxItems, and
+        // InnerPanel.Children in sync, and the decoration follows its anchor item to its new spot.
+        ObservableCollection<string> items = new() { "A", "B", "C" };
+        ListBox listBox = new();
+        listBox.Items = items;
+
+        ColoredRectangleRuntime separator = new();
+        listBox.InsertDecorationAfter("A", separator); // panel: A, sep, B, C
+
+        items.Move(0, 2); // A -> end. Items: B, C, A
+
+        items.ShouldBe(new[] { "B", "C", "A" });
+        listBox.ListBoxItems.Count.ShouldBe(3);
+        listBox.ListBoxItems[0].BindingContext.ShouldBe("B");
+        listBox.ListBoxItems[1].BindingContext.ShouldBe("C");
+        listBox.ListBoxItems[2].BindingContext.ShouldBe("A");
+
+        ObservableCollection<GraphicalUiElement> panel = listBox.InnerPanel.Children;
+        panel.Count.ShouldBe(4);
+        panel[0].ShouldBe(listBox.ListBoxItems[0].Visual); // B
+        panel[1].ShouldBe(listBox.ListBoxItems[1].Visual); // C
+        panel[2].ShouldBe(listBox.ListBoxItems[2].Visual); // A
+        panel[3].ShouldBe(separator);                      // decoration followed A
+    }
+
+    [Fact]
+    public void ListBoxSeparator_UsedAsDecoration_IsInPanelButNotAnItemOrRow()
+    {
+        // Issue #3305: the shipped ListBoxSeparator convenience visual is a plain decoration - it
+        // renders in the panel but is never data (Items) or a selectable row (ListBoxItems), and
+        // RemoveDecoration takes it back out.
+        ListBox listBox = new();
+        listBox.Items!.Add("A");
+        listBox.Items!.Add("B");
+
+        ListBoxSeparator separator = new();
+        listBox.AddDecoration(separator);
+
+        listBox.InnerPanel.Children.Contains(separator).ShouldBeTrue();
+        listBox.Items!.Contains(separator).ShouldBeFalse();
+        listBox.ListBoxItems.Any(item => ReferenceEquals(item.Visual, separator)).ShouldBeFalse();
+
+        listBox.RemoveDecoration(separator).ShouldBeTrue();
+        listBox.InnerPanel.Children.Contains(separator).ShouldBeFalse();
+        separator.Parent.ShouldBeNull();
+    }
+
+    #endregion
 }

--- a/MonoGameGum.Tests/Forms/ListBoxTests.cs
+++ b/MonoGameGum.Tests/Forms/ListBoxTests.cs
@@ -1998,5 +1998,42 @@ public class ListBoxTests : BaseTestClass
         separator.Parent.ShouldBeNull();
     }
 
+    [Fact]
+    public void InsertDecorationBefore_PlacesDecorationAheadOfTheAnchorRow()
+    {
+        // Issue #3305: the Before placement puts the decoration immediately ahead of its anchor
+        // row's visual, while Items/ListBoxItems stay pure.
+        ListBox listBox = new();
+        listBox.Items!.Add("A");
+        listBox.Items!.Add("B");
+        listBox.Items!.Add("C");
+
+        ColoredRectangleRuntime separator = new();
+        listBox.InsertDecorationBefore("B", separator);
+
+        ObservableCollection<GraphicalUiElement> panel = listBox.InnerPanel.Children;
+        panel.Count.ShouldBe(4);
+        panel[0].ShouldBe(listBox.ListBoxItems[0].Visual); // A
+        panel[1].ShouldBe(separator);                      // decoration before B
+        panel[2].ShouldBe(listBox.ListBoxItems[1].Visual); // B
+        panel[3].ShouldBe(listBox.ListBoxItems[2].Visual); // C
+
+        listBox.Items!.Count.ShouldBe(3);
+        listBox.ListBoxItems.Count.ShouldBe(3);
+    }
+
+    [Fact]
+    public void InsertDecorationAfter_WithAnchorNotInItems_Throws()
+    {
+        // Issue #3305: anchoring to an item that is not in Items is a programming error and must
+        // be rejected rather than silently dropping the decoration.
+        ListBox listBox = new();
+        listBox.Items!.Add("A");
+
+        ColoredRectangleRuntime separator = new();
+
+        Should.Throw<ArgumentException>(() => listBox.InsertDecorationAfter("not-in-list", separator));
+    }
+
     #endregion
 }

--- a/MonoGameGum/Forms/Controls/ItemsControl.cs
+++ b/MonoGameGum/Forms/Controls/ItemsControl.cs
@@ -4,6 +4,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
+using System.Linq;
 
 #if FRB
 using InteractiveGue = global::Gum.Wireframe.GraphicalUiElement;
@@ -365,6 +366,274 @@ public class ItemsControl : ScrollViewer
         }
     }
 
+    #region Decorations (issue #3305)
+
+    // Decorations are inert visuals (separators, headers, chrome) that live in InnerPanel.Children
+    // so they render between rows, but are in neither Items nor (for ListBox) ListBoxItems. Each is
+    // anchored to a data item so it follows that item on reorder and is removed with it. Because a
+    // decoration occupies an InnerPanel slot without an Items slot, the Items <-> InnerPanel index
+    // mapping is no longer 1:1; the translation helpers here keep item visuals inserted, moved, and
+    // removed at the correct panel slot. Follow-up to the reference-based selection work in #556.
+
+    private class DecorationInfo
+    {
+        public GraphicalUiElement Visual = null!;
+        public object? Anchor;
+        public bool After;
+    }
+
+    private readonly List<DecorationInfo> _decorations = new();
+    private bool _isReconcilingDecorations;
+
+    /// <summary>
+    /// Adds an inert decoration (such as a separator) after the last item currently in Items. If
+    /// Items is empty the decoration is placed at the end of the panel. The decoration is never
+    /// added to Items and never becomes selectable. See issue #3305.
+    /// </summary>
+    public void AddDecoration(GraphicalUiElement visual)
+    {
+        object? anchor = items != null && items.Count > 0 ? items[items.Count - 1] : null;
+        AddDecorationInternal(visual, anchor, after: true);
+    }
+
+    /// <summary>
+    /// Adds an inert decoration immediately after the given item's row. The decoration follows the
+    /// item if the list is reordered and is removed if the item is removed. See issue #3305.
+    /// </summary>
+    public void InsertDecorationAfter(object item, GraphicalUiElement visual)
+    {
+        if (items == null || !items.Contains(item))
+        {
+            throw new ArgumentException("The anchor item is not in the Items collection.", nameof(item));
+        }
+        AddDecorationInternal(visual, item, after: true);
+    }
+
+    /// <summary>
+    /// Adds an inert decoration immediately before the given item's row. The decoration follows the
+    /// item if the list is reordered and is removed if the item is removed. See issue #3305.
+    /// </summary>
+    public void InsertDecorationBefore(object item, GraphicalUiElement visual)
+    {
+        if (items == null || !items.Contains(item))
+        {
+            throw new ArgumentException("The anchor item is not in the Items collection.", nameof(item));
+        }
+        AddDecorationInternal(visual, item, after: false);
+    }
+
+    /// <summary>
+    /// Removes a decoration previously added via <see cref="AddDecoration"/> /
+    /// <see cref="InsertDecorationAfter"/> / <see cref="InsertDecorationBefore"/>. Returns true if
+    /// the visual was a tracked decoration. See issue #3305.
+    /// </summary>
+    public bool RemoveDecoration(GraphicalUiElement visual)
+    {
+        var info = _decorations.FirstOrDefault(d => d.Visual == visual);
+        if (info == null)
+        {
+            return false;
+        }
+        _decorations.Remove(info);
+        if (visual.Parent == InnerPanel)
+        {
+            visual.Parent = null;
+        }
+        return true;
+    }
+
+    private void AddDecorationInternal(GraphicalUiElement visual, object? anchor, bool after)
+    {
+        var existing = _decorations.FirstOrDefault(d => d.Visual == visual);
+        if (existing != null)
+        {
+            // Re-anchor an already-tracked decoration rather than adding it twice.
+            existing.Anchor = anchor;
+            existing.After = after;
+        }
+        else
+        {
+            _decorations.Add(new DecorationInfo { Visual = visual, Anchor = anchor, After = after });
+            if (InnerPanel != null && visual.Parent != InnerPanel)
+            {
+                // The final position is fixed up by ReconcileDecorations; just attach for now.
+                visual.Parent = InnerPanel;
+            }
+        }
+
+        ReconcileDecorations();
+    }
+
+    /// <summary>
+    /// Whether the given InnerPanel child is a decoration rather than an item visual. Used to skip
+    /// decoration slots when translating between Items-space and InnerPanel-space indices.
+    /// </summary>
+    private bool IsDecoration(GraphicalUiElement child)
+    {
+        for (int i = 0; i < _decorations.Count; i++)
+        {
+            if (_decorations[i].Visual == child)
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Returns the InnerPanel.Children index of the item visual at the given Items-space index
+    /// (skipping decorations), or InnerPanel.Children.Count if there is no such item visual (for
+    /// example when appending). See issue #3305.
+    /// </summary>
+    private int GetPanelIndexForItemIndex(int itemIndex)
+    {
+        if (InnerPanel == null)
+        {
+            return 0;
+        }
+        var children = InnerPanel.Children;
+        int seen = 0;
+        for (int p = 0; p < children.Count; p++)
+        {
+            if (IsDecoration(children[p]))
+            {
+                continue;
+            }
+            if (seen == itemIndex)
+            {
+                return p;
+            }
+            seen++;
+        }
+        return children.Count;
+    }
+
+    /// <summary>
+    /// Moves the item visual at <paramref name="oldItemIndex"/> (Items space) so it becomes the
+    /// item visual at <paramref name="newItemIndex"/>, ignoring decoration children. Decorations
+    /// are repositioned afterward by <see cref="ReconcileDecorations"/>. See issue #3305.
+    /// </summary>
+    private void MoveItemVisual(int oldItemIndex, int newItemIndex)
+    {
+        if (InnerPanel == null)
+        {
+            return;
+        }
+        var children = InnerPanel.Children;
+        int from = GetPanelIndexForItemIndex(oldItemIndex);
+        if (from < 0 || from >= children.Count)
+        {
+            return;
+        }
+
+        // Compute the destination in post-removal index space (what ObservableCollection.Move
+        // expects): walk the item visuals other than the one being moved and find the slot the
+        // moved visual must occupy to become the newItemIndex-th item visual.
+        int to = children.Count - 1; // default: append at the end after removal
+        int seen = 0;
+        for (int p = 0; p < children.Count; p++)
+        {
+            if (p == from || IsDecoration(children[p]))
+            {
+                continue;
+            }
+            if (seen == newItemIndex)
+            {
+                to = p < from ? p : p - 1;
+                break;
+            }
+            seen++;
+        }
+
+        children.Move(from, to);
+    }
+
+    /// <summary>
+    /// Drops decorations whose anchor item was removed and repositions the survivors adjacent to
+    /// their anchor. Only decoration visuals are moved; item visuals keep their relative order so
+    /// ListBox's ListBoxItems stays aligned. See issue #3305.
+    /// </summary>
+    protected void ReconcileDecorations()
+    {
+        if (InnerPanel == null || _decorations.Count == 0 || _isReconcilingDecorations)
+        {
+            return;
+        }
+
+        _isReconcilingDecorations = true;
+        try
+        {
+            var children = InnerPanel.Children;
+
+            // Drop decorations whose anchor item is no longer present.
+            for (int i = _decorations.Count - 1; i >= 0; i--)
+            {
+                var decoration = _decorations[i];
+                bool anchorMissing = decoration.Anchor != null &&
+                    (items == null || !items.Contains(decoration.Anchor));
+                if (anchorMissing)
+                {
+                    if (decoration.Visual.Parent == InnerPanel)
+                    {
+                        decoration.Visual.Parent = null;
+                    }
+                    _decorations.RemoveAt(i);
+                }
+            }
+
+            // Detach surviving decorations so the panel holds item visuals only, in Items order
+            // (the base maintains that order). Decorations have no forms control, so removing and
+            // re-adding them does not touch Items or ListBoxItems.
+            foreach (var decoration in _decorations)
+            {
+                if (decoration.Visual.Parent == InnerPanel)
+                {
+                    decoration.Visual.Parent = null;
+                }
+            }
+
+            // Re-insert each decoration adjacent to its anchor.
+            foreach (var decoration in _decorations)
+            {
+                int insertIndex = GetDecorationInsertIndex(decoration);
+                if (insertIndex < 0)
+                {
+                    insertIndex = 0;
+                }
+                else if (insertIndex > children.Count)
+                {
+                    insertIndex = children.Count;
+                }
+                children.Insert(insertIndex, decoration.Visual);
+                decoration.Visual.Parent = InnerPanel;
+            }
+        }
+        finally
+        {
+            _isReconcilingDecorations = false;
+        }
+    }
+
+    private int GetDecorationInsertIndex(DecorationInfo decoration)
+    {
+        var children = InnerPanel!.Children;
+        if (decoration.Anchor == null)
+        {
+            return decoration.After ? children.Count : 0;
+        }
+
+        int anchorItemIndex = items?.IndexOf(decoration.Anchor) ?? -1;
+        if (anchorItemIndex < 0)
+        {
+            return children.Count;
+        }
+
+        int anchorPanelIndex = GetPanelIndexForItemIndex(anchorItemIndex);
+        return decoration.After ? anchorPanelIndex + 1 : anchorPanelIndex;
+    }
+
+    #endregion
+
     #region Event Handler methods
 
     protected virtual void HandleItemsCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
@@ -373,7 +642,13 @@ public class ItemsControl : ScrollViewer
         {
             case NotifyCollectionChangedAction.Add:
                 {
-                    int index = e.NewStartingIndex;
+                    // e.NewStartingIndex is an Items-space index. A decoration occupies an
+                    // InnerPanel.Children slot without an Items slot, so translate to the matching
+                    // panel slot (the position of the i-th item visual, skipping decorations) so a
+                    // new item added after a decoration lands in the correct place. See issue #3305.
+                    int index = _decorations.Count > 0
+                        ? GetPanelIndexForItemIndex(e.NewStartingIndex)
+                        : e.NewStartingIndex;
 
                     var shouldSuppressLayout = e.NewItems.Count > 0 && InnerPanel != null;
                     var wasSuppressed = GraphicalUiElement.IsAllLayoutSuspended;
@@ -457,11 +732,17 @@ public class ItemsControl : ScrollViewer
                 var oldIndex = e.OldStartingIndex;
                 var newIndex = e.NewStartingIndex;
 
-                object? itemToMove = default;
                 // need to move the item to the new index:
                 if (InnerPanel != null)
                 {
-                    if (oldIndex < InnerPanel.Children.Count)
+                    if (_decorations.Count > 0)
+                    {
+                        // Indices are Items-space; move only the corresponding item visual among
+                        // the item visuals, leaving decorations to be repositioned by the reconcile
+                        // pass below so they follow their anchor item. See issue #3305.
+                        MoveItemVisual(oldIndex, newIndex);
+                    }
+                    else if (oldIndex < InnerPanel.Children.Count)
                     {
                         InnerPanel.Children.Move(oldIndex, newIndex);
                     }
@@ -472,9 +753,14 @@ public class ItemsControl : ScrollViewer
                 break;
             case NotifyCollectionChangedAction.Remove:
                 {
-                    var index = e.OldStartingIndex;
+                    // e.OldStartingIndex is an Items-space index; translate to the panel slot of the
+                    // removed item's visual so a decoration occupying an earlier slot can't shift the
+                    // removal onto the wrong child. See issue #3305.
+                    var index = _decorations.Count > 0
+                        ? GetPanelIndexForItemIndex(e.OldStartingIndex)
+                        : e.OldStartingIndex;
 
-                    if (InnerPanel != null)
+                    if (InnerPanel != null && index >= 0 && index < InnerPanel.Children.Count)
                     {
                         var listItem = InnerPanel.Children[index];
                         listItem.Parent = null;
@@ -497,6 +783,13 @@ public class ItemsControl : ScrollViewer
                 break;
         }
 
+        // Items changed, so reposition decorations relative to their anchor items and drop any
+        // whose anchor was removed. See issue #3305.
+        if (_decorations.Count > 0)
+        {
+            ReconcileDecorations();
+        }
+
         ItemsCollectionChanged?.Invoke(sender, e);
     }
 
@@ -513,6 +806,18 @@ public class ItemsControl : ScrollViewer
 
     private void ClearVisualsInternal()
     {
+        // Decorations are anchored to items; clearing the items invalidates every anchor, so drop
+        // the decoration bookkeeping too (their visuals are removed by the Children.Clear below).
+        // See issue #3305.
+        foreach (var decoration in _decorations)
+        {
+            if (decoration.Visual.Parent == InnerPanel)
+            {
+                decoration.Visual.Parent = null;
+            }
+        }
+        _decorations.Clear();
+
         if (InnerPanel != null)
         {
             InnerPanel.Children!.Clear();

--- a/MonoGameGum/Forms/Controls/ListBox.cs
+++ b/MonoGameGum/Forms/Controls/ListBox.cs
@@ -927,29 +927,58 @@ public class ListBox : ItemsControl, IInputReceiver
 
                 void MoveItem(int oldIndex, int newIndex)
                 {
-                    var item = Items[oldIndex];
+                    // oldIndex/newIndex are InnerPanel.Children indices. A decoration occupies a
+                    // panel slot but is in neither Items nor ListBoxItemsInternal, so translate to
+                    // each space rather than assuming the three align. See issue #3305.
+                    var draggedListBoxItem = visual.FormsControlAsObject as ListBoxItem;
+                    var targetListBoxItem =
+                        (visual.Parent.Children[newIndex] as InteractiveGue)?.FormsControlAsObject as ListBoxItem;
+
+                    // Dropping onto a decoration (or any non-row visual) is not a reorder; ignore it.
+                    if (draggedListBoxItem == null || targetListBoxItem == null)
+                    {
+                        return;
+                    }
+
+                    int itemsOld = Items.IndexOf(draggedListBoxItem.DataObject);
+                    int itemsNew = Items.IndexOf(targetListBoxItem.DataObject);
+                    if (itemsOld < 0 || itemsNew < 0)
+                    {
+                        return;
+                    }
+
+                    var item = Items[itemsOld];
 
                     _suppressCollectionChangedToBase = true;
 
-                    Items.RemoveAt(oldIndex);
-                    Items.Insert(newIndex, item);
+                    Items.RemoveAt(itemsOld);
+                    Items.Insert(itemsNew, item);
 
                     _suppressCollectionChangedToBase = false;
 
                     var isBound = this.PropertyRegistry.GetBindingExpression(nameof(Items)) != null;
                     if (Items is not INotifyCollectionChanged || !isBound)
                     {
-                        // If we are bound, just move
-                        visual.Parent.Children.Move(oldIndex, newIndex);
-                        var itemToMove = ListBoxItemsInternal[oldIndex];
+                        // Row-space positions for ListBoxItemsInternal, computed against the
+                        // pre-move panel (decorations excluded). See issue #3305.
+                        int rowOld = CountListBoxItemsInPanelBefore(oldIndex);
+                        int rowNew = CountListBoxItemsInPanelBefore(newIndex);
 
-                        var listBoxItemReplaced = ListBoxItemsInternal[newIndex];
+                        // The panel move stays in panel space - both indices are panel indices.
+                        visual.Parent.Children.Move(oldIndex, newIndex);
+                        var itemToMove = ListBoxItemsInternal[rowOld];
+
+                        var listBoxItemReplaced = ListBoxItemsInternal[rowNew];
                         // This probably got highlighted by the cursor when dragging over it, so let's
                         // unhighlight it so it doesn't flicker:
                         listBoxItemReplaced.IsHighlighted = false;
 
-                        ListBoxItemsInternal.RemoveAt(oldIndex);
-                        ListBoxItemsInternal.Insert(newIndex, itemToMove);
+                        ListBoxItemsInternal.RemoveAt(rowOld);
+                        ListBoxItemsInternal.Insert(rowNew, itemToMove);
+
+                        // The moved item visual carried its anchor; reposition any decorations so
+                        // they stay adjacent to their anchor items. See issue #3305.
+                        ReconcileDecorations();
                     }
 
                 }

--- a/MonoGameGum/GueDeriving/ListBoxSeparator.cs
+++ b/MonoGameGum/GueDeriving/ListBoxSeparator.cs
@@ -1,0 +1,35 @@
+using Gum.DataTypes;
+
+#if FRB
+namespace MonoGameGum.GueDeriving;
+#else
+namespace Gum.GueDeriving;
+#endif
+
+/// <summary>
+/// A thin, inert horizontal line intended as a ListBox / ItemsControl decoration (see
+/// <c>ItemsControl.AddDecoration</c> and the <c>InsertDecoration*</c> methods). It is a plain
+/// visual with no forms control, so it is never added to Items or ListBoxItems and can never be
+/// selected. By default it fills the parent's width, is 2 pixels tall, and is a muted gray; tune it
+/// via the inherited <see cref="RectangleRuntime"/> members (the <c>Fill*</c> channels, Height,
+/// etc.). See issue #3305.
+/// </summary>
+public class ListBoxSeparator : RectangleRuntime
+{
+    public ListBoxSeparator()
+    {
+        // Fill the parent's width (Width 0 with RelativeToParent == match parent), 2px tall.
+        WidthUnits = DimensionUnitType.RelativeToParent;
+        Width = 0;
+        HeightUnits = DimensionUnitType.Absolute;
+        Height = 2;
+
+        // A filled bar, no outline.
+        StrokeWidth = 0;
+        IsFilled = true;
+        FillRed = 128;
+        FillGreen = 128;
+        FillBlue = 128;
+        FillAlpha = 255;
+    }
+}

--- a/Runtimes/RaylibGum/RaylibGum.csproj
+++ b/Runtimes/RaylibGum/RaylibGum.csproj
@@ -145,6 +145,7 @@
 		<Compile Include="..\SkiaGum\GueDeriving\ArcRuntime.cs" Link="GueDeriving\ArcRuntime.cs" />
 		<Compile Include="..\..\MonoGameGum\GueDeriving\NineSliceRuntime.cs" Link="GueDeriving\NineSliceRuntime.cs" />
 		<Compile Include="..\..\MonoGameGum\GueDeriving\RectangleRuntime.cs" Link="GueDeriving\RectangleRuntime.cs" />
+		<Compile Include="..\..\MonoGameGum\GueDeriving\ListBoxSeparator.cs" Link="GueDeriving\ListBoxSeparator.cs" />
 		<Compile Include="..\..\MonoGameGum\GueDeriving\PolygonRuntime.cs" Link="GueDeriving\PolygonRuntime.cs" />
 		<Compile Include="..\..\MonoGameGum\GumService.cs" Link="GumService.cs" />
 		<Compile Include="..\..\MonoGameGum\GumServiceCompat.cs" Link="GumServiceCompat.cs" />


### PR DESCRIPTION
Closes #3305. Follow-up to #556 (the reference-based selection foundation, PR #3306).

## What

A first-class way to place **inert decorations** (separators, chrome) between `ListBox` rows. A decoration lives in `InnerPanel.Children` so it renders between rows, but is in **neither `Items` nor `ListBoxItems`** — so `Items`/`SelectedIndex` stay pure data and a decoration can never be selected.

## API (on `ItemsControl`, inherited by `ListBox`)

- `AddDecoration(GraphicalUiElement visual)` — the "add now" convenience: anchors **after the current last item**.
- `InsertDecorationAfter(object item, GraphicalUiElement visual)` / `InsertDecorationBefore(object item, GraphicalUiElement visual)` — anchor to a specific data item.
- `RemoveDecoration(GraphicalUiElement visual)`.
- `ListBoxSeparator` — a shipped convenience visual (a thin filled `RectangleRuntime`).

A decoration is **anchored to its data item**: it follows the item when the list is reordered and is removed when the item is removed.

## Design decisions (the two open questions in the issue)

- **Anchoring:** anchored-to-item (per the discussion on the issue). `AddDecoration` = "add now, after the current last item."
- **API shape:** methods + a `ListBoxSeparator` type (decorations are chrome set up in code, not bindable data).

## How

Because a decoration occupies an `InnerPanel` slot without an `Items` slot, the `Items` ↔ `InnerPanel` index mapping is no longer 1:1. This was the hard part the issue called out:

- The shared **`ItemsControl`** base (which **also compiles into `FlatRedBall.Forms`**) now translates the add / remove / move item-visual indices past decoration slots, and reconciles decorations to their anchors after each `Items` change (dropping any whose anchor was removed).
- **`ListBox`'s drag-reorder** path (`HandleListBoxItemDragging.MoveItem`) translates panel indices into Items-space and row-space, so reorder with a decoration present keeps `Items`, `ListBoxItems`, and `InnerPanel.Children` in sync.
- `ListBoxSeparator` lives in `MonoGameGum/GueDeriving` (auto-included by MonoGame/KNI/FNA, explicitly linked into RaylibGum). It is **excluded from FlatRedBall and Skia** by the GueDeriving sharing convention — FRB users pass their own visual to `AddDecoration`.

## Tests

7 new `ListBoxTests` covering the issue's acceptance list:

- contiguous `SelectedIndex` across a decoration
- clicking a decoration is inert (no deselect / no `SelectionChanged`)
- keyboard nav skips decorations
- bound typed `ObservableCollection<string>` + decoration stays valid (and item-visual order stays correct when items are added after a decoration)
- removing the anchor item drops the decoration
- reorder keeps all three collections in sync, decoration follows its anchor
- `ListBoxSeparator` is in the panel but not Items/ListBoxItems; `RemoveDecoration` takes it back out

Full `MonoGameGum.Tests` green (1766). `KniGum` and `RaylibGum` build.

## Manual test

The drag-reorder-with-decoration gesture and actual rendering aren't unit-testable (heavy input simulation), so a manual demo is wired into the link-to-source scratch project (`MonoGameAndGum`, re-pointed to this branch). Run it and confirm: a thin gray separator renders between Item 2 and Item 3; clicking rows never selects the separator; keyboard arrows skip it; and drag-reordering rows works with the separator present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
