### PR TITLE
Phase 2 (static drain): MainDuplicateVariablePlugin Locator ctor -> ctor-injected IDialogService

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,17 +70,11 @@ There is a dedicated later phase for draining the remaining `.Self` singletons w
 
 **`ObjectFinder.Self` is the exception.** It is intentionally still a static singleton across the entire codebase (tool, runtimes, tests). There is no `IObjectFinder` interface, and replacing it is a project-wide refactor — do not attempt it as drive-by cleanup. Calls to `ObjectFinder.Self.GetBaseElements(...)`, `ObjectFinder.Self.GetDefaultChildName(...)`, etc. are acceptable in any context.
 
-## Searching C# Code — Use the Roslyn Analyzer, Not Grep
+## Searching C# Code
 
-For any **semantic** question about C# code, use the Roslyn-backed LSP tool, **not** `Grep`/`grep`. The LSP resolves the actual symbol; grep only matches text, which forces you to hand-classify the hits (is this a registered service, a plugin, a view, a converter?) — an error-prone step that has produced wrong conclusions before (e.g. naming a class as a refactor target when it had zero matching calls). Reach for the LSP operation that fits the question:
+There is **no Roslyn/LSP semantic search in this environment** — the local LSP plugin was unreliable (slow workspace-load races on this large repo) and has been disabled. Use `Grep` for searches, and delegate broad "who references/calls/implements this" sweeps to the `Explore` agent, which reads excerpts and can distinguish definitions from uses.
 
-- **"Where is this defined?"** → `goToDefinition`
-- **"What are *all* the references to this symbol?"** → `findReferences`
-- **"Who calls this / what's the construction path?"** (e.g. hunting a DI construction cycle) → `prepareCallHierarchy` + `incomingCalls` / `outgoingCalls`
-- **"What implements this interface / overrides this member?"** → `goToImplementation`
-- **"Find a type or member by name across the solution"** → `workspaceSymbol`
-
-`Grep` is still correct for **non-semantic** text searches — string literals, comments, `.csproj`/XML/config, build/log output, or finding an initial foothold before you have a symbol. The line is simple: once the question is *about a symbol* (who defines/references/calls/implements it), switch to Roslyn.
+Because grep matches **text, not symbols**, classify hits before drawing conclusions — a name match doesn't tell you whether it's a definition, a registered service, a plugin, a view, or a converter. Trusting raw match counts has produced wrong conclusions before (e.g. naming a class as a refactor target when it had zero *real* call sites). Read the surrounding code at each hit, and distinguish declarations (`class Foo`, the `Foo(` ctor, `: Foo` bases) from usages, rather than counting matches.
 
 ## Investigating Third-Party Libraries
 

--- a/Gum/Plugins/InternalPlugins/DuplicateVariablePlugin/MainDuplicateVariablePlugin.cs
+++ b/Gum/Plugins/InternalPlugins/DuplicateVariablePlugin/MainDuplicateVariablePlugin.cs
@@ -4,7 +4,6 @@ using Gum.Plugins.BaseClasses;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Text;
-using Gum.Services;
 using Gum.Services.Dialogs;
 
 namespace Gum.Plugins.InternalPlugins.DuplicateVariablePlugin
@@ -14,9 +13,10 @@ namespace Gum.Plugins.InternalPlugins.DuplicateVariablePlugin
     {
         private readonly IDialogService _dialogService;
         
-        public MainDuplicateVariablePlugin()
+        [ImportingConstructor]
+        public MainDuplicateVariablePlugin(IDialogService dialogService)
         {
-            _dialogService = Locator.GetRequiredService<IDialogService>();
+            _dialogService = dialogService;
         }
         
         public override void StartUp()


### PR DESCRIPTION
## Phase 2 (static drain): MainDuplicateVariablePlugin

Continues the Phase 2 static drain. Converts `MainDuplicateVariablePlugin`'s parameterless constructor — which service-located its single dependency via `Locator.GetRequiredService<IDialogService>()` — to an `[ImportingConstructor]` that injects `IDialogService`.

`IDialogService` is already one of the nine shared services bridged into the plugin MEF container in `PluginManager.LoadPlugins` (`batch.AddExportedValue<T>(...)`), so **no new bridge line is required** — the drain just moves this plugin from service-location to injection. This is the cleanest possible drain target (zero not-bridged constructor dependencies).

Also removes the now-unused `using Gum.Services;` (`Locator` was its only consumer in this file).

### Guidance file (rides along per repo policy)
Updates `CLAUDE.md`'s "Searching C# Code" section to reflect that the Roslyn/LSP semantic-search plugin is disabled in this environment — use `Grep` plus the `Explore` agent instead. Bundled here per the repo's "Improving Guidance Files Alongside Work" rule.

### Verification
- `dotnet build GumFull.sln` — succeeds, 0 errors.
- Behavior-preserving DI rewiring, structurally identical to the four `[ImportingConstructor]` conversions in #3313. No callers construct the plugin directly (MEF-discovered via `[Export(typeof(PluginBase))]`), so nothing else changes.
- Runtime all-clear: tool launches with all tabs/menus present and no "Error loading plugins" dialog (MEF composition resolves `IDialogService`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
