### PR TITLE
Phase 2 (static drain): Skia/Font/GumForms plugin Locator ctors -> [ImportingConstructor]

### DIFF
--- a/Direction/ui-decoupling-plan.md
+++ b/Direction/ui-decoupling-plan.md
@@ -83,6 +83,54 @@ the permanent home (grow `Gum.ProjectServices` vs. a dedicated `Gum.Core`/`Gum.P
 effort, then decide the reach-vs-cost question (see `open-questions.md` and the roadmap **Later**
 item) with data instead of a guess.
 
+## Phase 2 — working notes (transient scaffolding)
+
+> **Why this section exists, and the rule that governs it.** Phase 2 is a many-pass grind — a
+> handful of `.Self`/`Locator` drains per PR — and each pass tends to re-derive the same mechanics.
+> **Rule: if you research something during a pass that a *later* pass of this phase will need too,
+> record it here** rather than re-discovering it. This is deliberately *transient* — when Phase 2
+> closes, distill anything still true into the `refactoring-direction` skill and delete the rest.
+> The permanent operational *how* lives in the skills (see the "Definition of done" note below);
+> this is only the live ledger for the in-flight work, kept here so it doesn't pollute the
+> general-purpose skill/`CLAUDE.md` with phase-specific churn. Date additions.
+>
+> **Treat this section as a flywheel — leave it faster to use after every pass.** Recording new
+> facts is only half the job. On each iteration also *prune* what's now stale or wrong, *sharpen*
+> the recipe wherever this pass hit friction, and write down the shortcut you wish you'd had at the
+> start. If a pass felt slow, that slowness is a defect *in this doc* — fix it here before moving
+> on, so each drain costs less than the one before. The explicit goal is to go faster every
+> iteration.
+
+### Draining a plugin's `Locator` constructor (MEF parts) — added 2026-06-23
+
+Plugins are MEF parts, so they can't pull from the host DI container directly; a service must be
+*bridged* into the plugin container before a plugin can inject it.
+
+- **The `batch.AddExportedValue<…>` block in `PluginManager.LoadPlugins` is the live list of
+  what's injectable into plugins.** Read it to see what's already bridged — don't re-derive the
+  set. Anything in that block can be taken as an `[ImportingConstructor]` parameter by any plugin.
+- **Recipe per plugin:** convert the parameterless ctor (which calls `Locator.GetRequiredService<T>()`)
+  to `[ImportingConstructor]` taking its ctor-time deps as parameters. For a dep already in the
+  block, just take it. For a dep *not* yet bridged, add one
+  `AddExportedValue<T>(Locator.GetRequiredService<T>())` line to the block first — this *relocates*
+  the `Locator` call to the composition root, it doesn't delete it. (If the plugin was already
+  resolving `T` via `Locator`, `T` is registered in `Builder.cs`, so the bridge resolves with no
+  new `Builder.cs` work.)
+- **Inject the interface, not the concrete.** If a field is the concrete `Foo : IFoo`, switch it to
+  `IFoo` and bridge `IFoo` (confirm the interface carries the members the plugin uses).
+- **Only ctor-time lookups are in scope.** `Locator` calls inside `StartUp`, event handlers, and
+  menu-click lambdas stay. PluginBase's inherited `[Import]` properties (`_dialogService`,
+  `_fileCommands`, `_guiCommands`, `_tabManager`, `_menuStripManager`) are set *after* construction,
+  so a ctor-needed dep must be a ctor param even when PluginBase also exposes it.
+- **Verify:** build via `GumFull.sln` (plugin post-builds need `$(SolutionDir)`), then launch the
+  tool — a MEF composition failure shows an "Error loading plugins" dialog with zero plugins, so
+  "tool opens with all tabs and menus present" is the all-clear.
+
+**Bridged into the plugin container as of 2026-06-23** (snapshot — trust `LoadPlugins`, not this
+line): `ISelectedState`, `IElementCommands`, `IUndoManager`, `IProjectManager`, `IGuiCommands`,
+`IFileCommands`, `ITabManager`, `MenuStripManager`, `IDialogService`, `IWireframeCommands`,
+`IFontManager`, `IProjectState`, `IImportLogic`, `IFileWatchManager`.
+
 ## Definition of done — every change lands a *tested* unit
 
 This effort's payoff *is* testability, so the bar for every change is not just "logic moved out of

--- a/Gum/GumFormsPlugin/MainGumFormsPlugin.cs
+++ b/Gum/GumFormsPlugin/MainGumFormsPlugin.cs
@@ -36,11 +36,14 @@ internal class MainGumFormsPlugin : PluginBase
 
     #endregion
 
-    public MainGumFormsPlugin()
+    [ImportingConstructor]
+    public MainGumFormsPlugin(
+        IImportLogic importLogic,
+        IFileWatchManager fileWatchManager)
     {
         _formsFileService = new FormsFileService();
-        _importLogic = Locator.GetRequiredService<IImportLogic>();
-        _fileWatchManager = Locator.GetRequiredService<IFileWatchManager>();
+        _importLogic = importLogic;
+        _fileWatchManager = fileWatchManager;
     }
 
     public override void StartUp()

--- a/Gum/Plugins/Fonts/MainFontPlugin.cs
+++ b/Gum/Plugins/Fonts/MainFontPlugin.cs
@@ -1,7 +1,6 @@
 ﻿using Gum.Commands;
 using Gum.DataTypes;
 using Gum.Plugins.BaseClasses;
-using Gum.Services;
 using Gum.ToolStates;
 using System;
 using System.ComponentModel.Composition;
@@ -22,12 +21,17 @@ public class MainFontPlugin : PriorityPlugin
     private readonly IDialogService _dialogService;
     private readonly IProjectState _projectState;
 
-    public MainFontPlugin()
+    [ImportingConstructor]
+    public MainFontPlugin(
+        IGuiCommands guiCommands,
+        IFontManager fontManager,
+        IDialogService dialogService,
+        IProjectState projectState)
     {
-        _guiCommands = Locator.GetRequiredService<IGuiCommands>();
-        _fontManager = Locator.GetRequiredService<IFontManager>();
-        _dialogService = Locator.GetRequiredService<IDialogService>();
-        _projectState = Locator.GetRequiredService<IProjectState>();
+        _guiCommands = guiCommands;
+        _fontManager = fontManager;
+        _dialogService = dialogService;
+        _projectState = projectState;
     }
 
     public override void StartUp()

--- a/Gum/Plugins/PluginManager.cs
+++ b/Gum/Plugins/PluginManager.cs
@@ -29,6 +29,9 @@ using CommunityToolkit.Mvvm.Messaging;
 using Gum.Services.Dialogs;
 using Gum.Undo;
 using Gum.Localization;
+using Gum.Services.Fonts;
+using Gum.Plugins.ImportPlugin.Manager;
+using Gum.Logic.FileWatch;
 
 namespace Gum.Plugins;
 
@@ -836,6 +839,16 @@ public class PluginManager : IPluginManager
             batch.AddExportedValue<ITabManager>(Locator.GetRequiredService<ITabManager>());
             batch.AddExportedValue<MenuStripManager>(Locator.GetRequiredService<MenuStripManager>());
             batch.AddExportedValue<IDialogService>(Locator.GetRequiredService<IDialogService>());
+
+            // Per-plugin services needed at construction time (via [ImportingConstructor]):
+            // MainSkiaPlugin (IWireframeCommands), MainFontPlugin (IFontManager, IProjectState),
+            // MainGumFormsPlugin (IImportLogic, IFileWatchManager). IProjectState and
+            // IFileWatchManager are also stepping stones for later, heavier plugin drains.
+            batch.AddExportedValue<IWireframeCommands>(Locator.GetRequiredService<IWireframeCommands>());
+            batch.AddExportedValue<IFontManager>(Locator.GetRequiredService<IFontManager>());
+            batch.AddExportedValue<IProjectState>(Locator.GetRequiredService<IProjectState>());
+            batch.AddExportedValue<IImportLogic>(Locator.GetRequiredService<IImportLogic>());
+            batch.AddExportedValue<IFileWatchManager>(Locator.GetRequiredService<IFileWatchManager>());
 
 
             var container = new CompositionContainer(catalog);

--- a/Gum/SvgPlugin/MainSkiaPlugin.cs
+++ b/Gum/SvgPlugin/MainSkiaPlugin.cs
@@ -33,16 +33,20 @@ namespace SkiaPlugin
         public override Version Version => new Version(1, 1);
         
         private readonly ISelectedState _selectedState;
-        private readonly WireframeCommands _wireframeCommands;
+        private readonly IWireframeCommands _wireframeCommands;
         private readonly IDialogService _dialogService;
 
         #endregion
 
-        public MainSkiaPlugin()
+        [ImportingConstructor]
+        public MainSkiaPlugin(
+            ISelectedState selectedState,
+            IWireframeCommands wireframeCommands,
+            IDialogService dialogService)
         {
-            _selectedState = Locator.GetRequiredService<ISelectedState>();
-            _wireframeCommands = Locator.GetRequiredService<WireframeCommands>();
-            _dialogService = Locator.GetRequiredService<IDialogService>();
+            _selectedState = selectedState;
+            _wireframeCommands = wireframeCommands;
+            _dialogService = dialogService;
         }
         
         public override bool ShutDown(PluginShutDownReason shutDownReason)


### PR DESCRIPTION
## What

Phase 2 (static drain) — convert three more plugins off constructor-time service location.

`MainSkiaPlugin`, `MainFontPlugin`, and `MainGumFormsPlugin` each had a parameterless constructor that resolved its dependencies via `Locator.GetRequiredService<T>()`. Each is now an `[ImportingConstructor]` taking those dependencies as parameters.

## Bridges added to the plugin MEF container

To inject the not-yet-bridged dependencies, five services were bridged into the plugin container in `PluginManager.LoadPlugins` (`batch.AddExportedValue<T>(Locator.GetRequiredService<T>())`):

- `IWireframeCommands` — Skia
- `IFontManager`, `IProjectState` — Font
- `IImportLogic`, `IFileWatchManager` — GumForms

`IProjectState` and `IFileWatchManager` are also stepping stones for later, heavier plugin drains.

## Notes

- `MainSkiaPlugin` injects the **`IWireframeCommands` interface** rather than the concrete `WireframeCommands` (matches the interface-over-concrete rule; `TextureCoordinateSelectionPlugin` already uses the same interface).
- **Only construction-time lookups are in scope.** `Locator` calls inside `StartUp`, event handlers, and menu-click lambdas (e.g. Skia's `ITypeManager`/`ISkiaShapeStandardsLogic`, GumForms' in-handler `IProjectState`) are intentionally left in place.
- Dropped a now-unused `using Gum.Services;` from `MainFontPlugin`.

## Docs

Added a transient **"Phase 2 — working notes (transient scaffolding)"** section to `Direction/ui-decoupling-plan.md` — the plugin-drain recipe, a live snapshot of what's bridged into the plugin container, and a "flywheel" rule to keep each pass of this phase faster than the last. Deliberately kept out of the general-purpose `refactoring-direction` skill / `CLAUDE.md`; to be distilled into the skill and deleted when Phase 2 closes.

## Verification

Behavior-preserving DI rewiring. `GumFull.sln` builds with 0 errors; verified by tool launch (all plugins compose — no "Error loading plugins" dialog, all tabs/menus present). No unit tests added (no behavior change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
