### PR TITLE
Document the ListBox/ItemsControl decoration API (separators/chrome) (#3316)

### DIFF
--- a/docs/code/controls/itemscontrol.md
+++ b/docs/code/controls/itemscontrol.md
@@ -45,3 +45,7 @@ for(int i = 0; i < 20; i++)
 }
 ```
 [Try on XnaFiddle.NET](https://xnafiddle.net/#snippet=H4sIAAAAAAAACmWOPwvCMBDF90K_w5EppSJRcLE6iIN2FcElSyHRHrQJpFcFS7-7ly7-u-Udv8e7e0OaAIiyO_StWAOF3s4mgg4JqwaflrG4VwGQbNvtvaPgG9iCsw8oP5DMCs2ZN5jvjDn7k_f0b13QUM1Hlkr9WkeLt5rYW6yid_VBoiNAJqpg2XCINc8z7QbtgOcrP3WKv6UWcQctIAeMFUaRJuML5gZQPvEAAAA)
+
+## Decorations
+
+`ItemsControl` supports inert *decorations* — separators, headers, and other chrome that render between rows without becoming items. Add them with `AddDecoration`, `InsertDecorationAfter`, and `InsertDecorationBefore`. Because these methods are defined on `ItemsControl`, they are also available on `ListBox`, where the behavior and the shipped `ListBoxSeparator` visual are documented in full — see [Decorations and Separators](listbox.md#decorations-and-separators) on the ListBox page.

--- a/docs/code/controls/listbox.md
+++ b/docs/code/controls/listbox.md
@@ -296,6 +296,72 @@ listBox.DragDropReorderMode = DragDropReorderMode.Immediate;
 
 <figure><img src="../../.gitbook/assets/13_09 06 43.gif" alt=""><figcaption><p>ListBoxItems reordering</p></figcaption></figure>
 
+## Decorations and Separators
+
+A *decoration* is an inert visual — a separator line, a group header, or other chrome — that renders between rows but is not part of the list's data. A decoration lives in the ListBox's `InnerPanel.Children` alongside the row visuals, so it appears inline between items, but it belongs to **neither `Items` nor `ListBoxItems`**. As a result:
+
+* `SelectedIndex` and `SelectedObject` stay contiguous. The row after a decoration keeps its data index, so adding a decoration never shifts your indices.
+* A decoration can never be selected, clicked to select, or reached by keyboard or gamepad navigation. Clicking it does nothing, and arrow or d-pad navigation skips over it.
+
+### Adding a Separator Between Groups
+
+The shipped `ListBoxSeparator` visual is a thin, filled horizontal line you can drop between rows. Anchor it to a data item with `InsertDecorationAfter` (or `InsertDecorationBefore`):
+
+```csharp
+// Initialize
+var listBox = new ListBox();
+listBox.AddToRoot();
+listBox.X = 50;
+listBox.Y = 50;
+listBox.Width = 400;
+listBox.Height = 300;
+
+// First group
+listBox.Items.Add("Resume");
+listBox.Items.Add("Options");
+
+// Second group
+listBox.Items.Add("Quit to Menu");
+listBox.Items.Add("Quit to Desktop");
+
+// Drop a separator between the two groups, anchored to the last item of the first group.
+var separator = new ListBoxSeparator();
+listBox.InsertDecorationAfter("Options", separator);
+```
+
+[Try on XnaFiddle.NET](https://xnafiddle.net/#snippet=H4sIAAAAAAAACn2RQUvDQBCF7_kVw55aCG1BvVg8VIK1oIitoMV4WJtpM9juhN3ZRhT_u5vUkkTQ437v7Xs7O58RgJq5qd-pcxDrMa6Ad2Q2LpBnFZTB1GOClvYBqpfaQIaE9JY-MJjUXlvYkpNLfocLMFjCzeHU649T86MMJln2wHNm6dCncONs1ALL3-CRMskDPB216TXSJpeAT2qcmuEQrsg6gY1lXzTGmeDOVeW9VM3R-R2mqv2Atn5XCLFxB0MducAVm-y_zHtPAsJwi8b_nXx0JejehItWQ2K5AA0OC221sIVXlBLRgOQIUvKh28WgzSpni1kVU2lbHYal0AG8rsG6GX-QmmopTWhnLYsj7mxiZhxaScLAQQvfMFkL2vanxE1ef6yir-gbt2GNrj0CAAA)
+
+{% hint style="warning" %}
+**Screenshot placeholder:** a ListBox showing the two groups (`Resume`, `Options` above the line; `Quit to Menu`, `Quit to Desktop` below it) with the thin gray separator between them.
+{% endhint %}
+
+`ListBoxSeparator` inherits from `RectangleRuntime`, so you can tune its appearance through the inherited members — `Height`, the `Fill` color channels (`FillRed`, `FillGreen`, `FillBlue`, `FillAlpha`), and so on. A decoration does not have to be a separator: pass any `GraphicalUiElement` (for example a `Label` used as a group header) to the same methods.
+
+### Anchoring and Lifetime
+
+A decoration is **anchored to a data item**, not to a fixed position:
+
+* It follows its anchor item when the list is reordered — including the drag-and-drop reordering described in **Reordering With Drag+Drop** above.
+* It is automatically removed when its anchor item is removed from `Items`.
+
+The three add methods differ only in how the anchor is chosen:
+
+| Method | Anchor |
+|---|---|
+| `AddDecoration(visual)` | The item that is **currently last** in `Items` (the "add now" case). Items added afterward appear below the decoration. If `Items` is empty, the decoration is placed at the end of the panel. |
+| `InsertDecorationAfter(item, visual)` | Immediately **after** the given item's row. |
+| `InsertDecorationBefore(item, visual)` | Immediately **before** the given item's row. |
+
+`InsertDecorationAfter` and `InsertDecorationBefore` throw an `ArgumentException` if the anchor item is not in `Items`. Call `RemoveDecoration(visual)` to take a decoration out manually; it returns `true` if the visual was a tracked decoration. Re-adding a decoration that is already tracked re-anchors it rather than adding it twice.
+
+{% hint style="info" %}
+Because decorations stay out of `Items`, binding a ListBox to a typed `ObservableCollection<T>` remains valid with decorations present — the bound collection only ever contains your data objects. See [Items Binding (ListBox, ComboBox, ItemsControl)](../binding-viewmodels/items-binding-listbox-combobox-itemscontrol.md).
+{% endhint %}
+
+{% hint style="warning" %}
+`ListBoxSeparator` ships with the MonoGame, KNI, FNA, and Raylib runtimes. In FlatRedBall — or any project without the GueDeriving runtime visuals — pass your own `GraphicalUiElement` to `AddDecoration` / `InsertDecorationAfter` / `InsertDecorationBefore` instead.
+{% endhint %}
+
 ## Customizing with VisualTemplate
 
 The VisualTemplate lets you customize the type of ListBoxItem created for the ListBox. The following code shows how to assign a VisualTemplate to a runtime object named CustomListBoxItemRuntime:


### PR DESCRIPTION
Documents the ListBox/ItemsControl decoration API added in PR #3314 (follow-up #3305), per issue #3316.

## What changed

- **`docs/code/controls/listbox.md`** — new **Decorations and Separators** section covering:
  - `AddDecoration` / `InsertDecorationAfter` / `InsertDecorationBefore` / `RemoveDecoration` and the shipped `ListBoxSeparator` visual, with a runnable XnaFiddle example (drop a separator between two groups).
  - The key concepts: a decoration is chrome (lives in `InnerPanel.Children` but is in neither `Items` nor `ListBoxItems`), is anchored to a data item (follows reorder, removed when the item is removed), keeps `SelectedIndex` contiguous, and is never selectable or navigable.
  - The anchor-choice table for the three add methods, the `ArgumentException` on a missing anchor, and the re-anchor-on-readd behavior.
  - A note that typed `ObservableCollection<T>` binding stays valid with decorations present (links to the Items Binding page).
  - The platform caveat: `ListBoxSeparator` ships on MonoGame/KNI/FNA/Raylib; in FlatRedBall pass your own `GraphicalUiElement`.
- **`docs/code/controls/itemscontrol.md`** — brief cross-reference pointing to the ListBox section, since the API is defined on `ItemsControl` and is available there too.

## Notes

- Docs-only change. The code sample matches the encoded XnaFiddle snippet exactly; link integrity verified against the encoder output.
- Screenshot is left as a visible placeholder hint (no asset to capture from here).

Closes #3316

🤖 Generated with [Claude Code](https://claude.com/claude-code)
