### PR TITLE
Phase 2 (static drain): Alignment/Circle/Parent/Undo/MenuStrip plugin Locator ctors -> [ImportingConstructor]

### DIFF
--- a/Direction/ui-decoupling-plan.md
+++ b/Direction/ui-decoupling-plan.md
@@ -131,6 +131,40 @@ line): `ISelectedState`, `IElementCommands`, `IUndoManager`, `IProjectManager`, 
 `IFileCommands`, `ITabManager`, `MenuStripManager`, `IDialogService`, `IWireframeCommands`,
 `IFontManager`, `IProjectState`, `IImportLogic`, `IFileWatchManager`.
 
+### Shortcut: batch by bridge-cost — added 2026-06-23
+
+The cheapest, safest pass is the set of plugins whose **every** ctor-time dep is *already* in the
+`AddExportedValue` block. Those drain with **no `PluginManager.cs` change at all** — pure
+`[ImportingConstructor]` edits — so many fit in one homogeneous, low-risk PR. Sort the remaining
+plugins by how many *new* bridges they cost and clear the zero-cost tier first; keep the
+bridge-adding ones for their own batches. Nuance: a plugin that service-locates in `StartUp`
+instead of the ctor still drains the same way — **relocate the assignment into the
+`[ImportingConstructor]`** (construction precedes `StartUp`, so it stays behavior-preserving).
+
+### Drained so far (plugin ctor passes)
+
+- **#3313** — PluginBase shared services → MEF `[Import]` properties (the base-class drain that
+  unblocked every per-plugin ctor drain).
+- **#3317** — MainSkiaPlugin, MainFontPlugin, MainGumFormsPlugin, MainDuplicateVariablePlugin
+  (added the `IWireframeCommands` / `IFontManager` / `IProjectState` / `IImportLogic` /
+  `IFileWatchManager` bridges).
+- **this PR (2026-06-23)** — AlignmentMainPlugin, MainCirclePlugin, MainParentPlugin, UndoPlugin,
+  MainMenuStripPlugin. **Added zero bridges** — every dep (`ISelectedState`, `IUndoManager`,
+  concrete `MenuStripManager`) was already in the block.
+
+### Remaining plugin targets (triage ledger — prune as drained)
+
+- **One new bridge each (next easy batch):** `MainInheritancePlugin` (ctor needs concrete
+  `InheritanceLogic` — check for an `IInheritanceLogic` and prefer it, else bridge the concrete);
+  `MainFavoriteComponentPlugin` (needs `IFavoriteComponentManager`; its lookup is in `StartUp`, so
+  move it into the ctor per the nuance above).
+- **Medium (1–3 new bridges, some switching a concrete to its interface):** `DeleteObjectPlugin`,
+  `MainErrorsPlugin`, `MainVariableGridPlugin`, `MainFileWatchPlugin`, `MainHideShowToolsPlugin`.
+- **Heavies (own PR each — large ctors and/or `Locator.GetRequiredService<PluginManager>()`
+  self-injection cycle risk):** `MainEditorTabPlugin` (Tool/EditorTabPlugin_XNA),
+  `MainCodeOutputPlugin`, `MainTreeViewPlugin` (pulls the 3k-line `ElementTreeViewManager`),
+  `MainPropertiesWindowPlugin`, `MainStatePlugin`, `MainTextureCoordinatePlugin`.
+
 ## Definition of done — every change lands a *tested* unit
 
 This effort's payoff *is* testability, so the bar for every change is not just "logic moved out of

--- a/Gum/Plugins/InternalPlugins/AlignmentButtons/AlignmentMainPlugin.cs
+++ b/Gum/Plugins/InternalPlugins/AlignmentButtons/AlignmentMainPlugin.cs
@@ -1,5 +1,4 @@
 ﻿using Gum.Plugins.BaseClasses;
-using Gum.Services;
 using Gum.ToolStates;
 using System.ComponentModel.Composition;
 using System.Windows.Forms;
@@ -13,9 +12,10 @@ namespace Gum.Plugins.AlignmentButtons
 
         private PluginTab _tab;
 
-        public AlignmentMainPlugin()
+        [ImportingConstructor]
+        public AlignmentMainPlugin(ISelectedState selectedState)
         {
-            _selectedState = Locator.GetRequiredService<ISelectedState>();
+            _selectedState = selectedState;
         }
         
         public override void StartUp()

--- a/Gum/Plugins/InternalPlugins/CirclePlugin/MainCirclePlugin.cs
+++ b/Gum/Plugins/InternalPlugins/CirclePlugin/MainCirclePlugin.cs
@@ -1,6 +1,5 @@
 ﻿using Gum.DataTypes;
 using Gum.Plugins.BaseClasses;
-using Gum.Services;
 using Gum.ToolStates;
 using System.ComponentModel.Composition;
 
@@ -11,9 +10,10 @@ namespace Gum.Plugins.CirclePlugin
     {
         private readonly ISelectedState _selectedState;
 
-        public MainCirclePlugin()
+        [ImportingConstructor]
+        public MainCirclePlugin(ISelectedState selectedState)
         {
-            _selectedState = Locator.GetRequiredService<ISelectedState>();
+            _selectedState = selectedState;
         }
         
         public override void StartUp()

--- a/Gum/Plugins/InternalPlugins/MenuStripPlugin/MainMenuStripPlugin.cs
+++ b/Gum/Plugins/InternalPlugins/MenuStripPlugin/MainMenuStripPlugin.cs
@@ -13,7 +13,6 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Gum.Commands;
-using Gum.Services;
 
 namespace Gum.Plugins.InternalPlugins.MenuStripPlugin;
 
@@ -22,9 +21,10 @@ public class MainMenuStripPlugin : PriorityPlugin
 {
     private readonly MenuStripManager _menuStripManager;
 
-    public MainMenuStripPlugin()
+    [ImportingConstructor]
+    public MainMenuStripPlugin(MenuStripManager menuStripManager)
     {
-        _menuStripManager = Locator.GetRequiredService<MenuStripManager>();
+        _menuStripManager = menuStripManager;
     }
     
     public override void StartUp()

--- a/Gum/Plugins/InternalPlugins/ParentPlugin/MainParentPlugin.cs
+++ b/Gum/Plugins/InternalPlugins/ParentPlugin/MainParentPlugin.cs
@@ -1,7 +1,6 @@
 ﻿using Gum.DataTypes;
 using Gum.Managers;
 using Gum.Plugins.BaseClasses;
-using Gum.Services;
 using Gum.ToolStates;
 using System.ComponentModel.Composition;
 using System.Linq;
@@ -13,9 +12,10 @@ namespace Gum.Plugins.ParentPlugin
     {
         private readonly ISelectedState _selectedState;
 
-        public MainParentPlugin()
+        [ImportingConstructor]
+        public MainParentPlugin(ISelectedState selectedState)
         {
-            _selectedState = Locator.GetRequiredService<ISelectedState>();
+            _selectedState = selectedState;
         }
         
         public override void StartUp()

--- a/Gum/Undo/UndoPlugin.cs
+++ b/Gum/Undo/UndoPlugin.cs
@@ -5,7 +5,6 @@ using Gum.DataTypes.Behaviors;
 using Gum.DataTypes.Variables;
 using System;
 using Gum.ToolStates;
-using Gum.Services;
 
 namespace Gum.Undo;
 
@@ -14,10 +13,11 @@ public class UndoPlugin : PriorityPlugin
 {
     private readonly ISelectedState _selectedState;
     private readonly IUndoManager _undoManager;
-    public UndoPlugin() 
+    [ImportingConstructor]
+    public UndoPlugin(ISelectedState selectedState, IUndoManager undoManager)
     {
-        _selectedState = Locator.GetRequiredService<ISelectedState>();
-        _undoManager = Locator.GetRequiredService<IUndoManager>();
+        _selectedState = selectedState;
+        _undoManager = undoManager;
     }
 
     public override void StartUp()


### PR DESCRIPTION
## Phase 2 (static drain) — five plugin `Locator` ctors → `[ImportingConstructor]`

Continues the Phase 2 static-singleton drain. Converts five plugins' parameterless constructors — which service-located via `Locator.GetRequiredService<T>()` — to MEF `[ImportingConstructor]`s that take their constructor-time dependencies as parameters:

| Plugin | Injected dep(s) |
|---|---|
| `AlignmentMainPlugin` | `ISelectedState` |
| `MainCirclePlugin` | `ISelectedState` |
| `MainParentPlugin` | `ISelectedState` |
| `UndoPlugin` | `ISelectedState`, `IUndoManager` |
| `MainMenuStripPlugin` | `MenuStripManager` (concrete — matches the existing field type and how it's bridged) |

### Why this is a clean batch
All five dependencies were **already bridged** into the plugin MEF container in `PluginManager.LoadPlugins`, so this PR adds **zero** new `AddExportedValue` lines and touches **no** composition-root code. Each file also drops the now-unused `using Gum.Services;` (it only provided `Locator`).

Only constructor-time lookups were in scope — none of these five have `Locator` calls in `StartUp`, event handlers, or menu-click lambdas.

### Behavior-preserving
This is a pure DI rewiring (how a dependency is obtained: static `Locator` → injected field), not a behavior change. Verification:
- **Compiler** — `dotnet build GumFull.sln` succeeds with 0 errors.
- **MEF composition** — every injected type is confirmed present in the `AddExportedValue` block; a missing bridge would surface as an "Error loading plugins" dialog with zero plugins at startup. Manual smoke-test: tool launches with all tabs and menus present.

No unit tests added — behavior-preserving drain, covered by the compiler plus the DI container's startup composition (per the `refactoring-direction` skill's drain-calibration guidance).

### Guidance file
Per the repo's improve-guidance-alongside-work rule, extends the **Phase 2 working-notes ledger** in `Direction/ui-decoupling-plan.md` (the flywheel section added in #3317): records the *batch-by-bridge-cost* shortcut this pass revealed (the zero-new-bridge tier drains with no `PluginManager.cs` edit), a "drained so far" log, and a triage ledger of the remaining plugin targets (next-easy / medium / heavy) so the next pass doesn't re-derive it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
