### PR TITLE
Phase 2 (static drain): MainInheritancePlugin + MainFavoriteComponentPlugin Locator -> [ImportingConstructor]

### DIFF
--- a/Direction/ui-decoupling-plan.md
+++ b/Direction/ui-decoupling-plan.md
@@ -129,7 +129,8 @@ Plugins are MEF parts, so they can't pull from the host DI container directly; a
 **Bridged into the plugin container as of 2026-06-23** (snapshot — trust `LoadPlugins`, not this
 line): `ISelectedState`, `IElementCommands`, `IUndoManager`, `IProjectManager`, `IGuiCommands`,
 `IFileCommands`, `ITabManager`, `MenuStripManager`, `IDialogService`, `IWireframeCommands`,
-`IFontManager`, `IProjectState`, `IImportLogic`, `IFileWatchManager`.
+`IFontManager`, `IProjectState`, `IImportLogic`, `IFileWatchManager`, `InheritanceLogic`,
+`IFavoriteComponentManager`.
 
 ### Shortcut: batch by bridge-cost — added 2026-06-23
 
@@ -148,18 +149,31 @@ instead of the ctor still drains the same way — **relocate the assignment into
 - **#3317** — MainSkiaPlugin, MainFontPlugin, MainGumFormsPlugin, MainDuplicateVariablePlugin
   (added the `IWireframeCommands` / `IFontManager` / `IProjectState` / `IImportLogic` /
   `IFileWatchManager` bridges).
-- **this PR (2026-06-23)** — AlignmentMainPlugin, MainCirclePlugin, MainParentPlugin, UndoPlugin,
+- **#3319 (2026-06-23)** — AlignmentMainPlugin, MainCirclePlugin, MainParentPlugin, UndoPlugin,
   MainMenuStripPlugin. **Added zero bridges** — every dep (`ISelectedState`, `IUndoManager`,
   concrete `MenuStripManager`) was already in the block.
+- **this PR (2026-06-23)** — MainInheritancePlugin, MainFavoriteComponentPlugin. **One bridge each:**
+  concrete `InheritanceLogic` (no `IInheritanceLogic` exists, so bridge the concrete) and interface
+  `IFavoriteComponentManager`. MainFavoriteComponentPlugin had no ctor and resolved in `StartUp`;
+  added an `[ImportingConstructor]`, moved the assignment into it, tightened the field to `readonly`.
 
 ### Remaining plugin targets (triage ledger — prune as drained)
 
-- **One new bridge each (next easy batch):** `MainInheritancePlugin` (ctor needs concrete
-  `InheritanceLogic` — check for an `IInheritanceLogic` and prefer it, else bridge the concrete);
-  `MainFavoriteComponentPlugin` (needs `IFavoriteComponentManager`; its lookup is in `StartUp`, so
-  move it into the ctor per the nuance above).
-- **Medium (1–3 new bridges, some switching a concrete to its interface):** `DeleteObjectPlugin`,
-  `MainErrorsPlugin`, `MainVariableGridPlugin`, `MainFileWatchPlugin`, `MainHideShowToolsPlugin`.
+- **Medium / next batch (1–3 new bridges each; scouted 2026-06-23 — counts below exclude deps
+  already bridged and non-ctor `Locator` calls, which stay). Ordered cheapest-first:**
+  - `MainHideShowToolsPlugin` — *cheapest, same shape as MainInheritancePlugin.* Parameterless ctor,
+    1 dep: concrete `MainPanelViewModel` (no interface). **1 new bridge.**
+  - `MainVariableGridPlugin` — parameterless ctor, 3 deps: `ISelectedState` (bridged), concrete
+    `PropertyGridManager`, `IVariableReferenceLogic`. **2 new bridges.**
+  - `MainErrorsPlugin` — no ctor; resolves in `StartUp`: `IErrorChecker`, `IMessenger`,
+    `ISelectedState` (bridged). **2 new bridges**, assignments move into a new `[ImportingConstructor]`.
+    Its `IProjectState` lookup is inside a method (not ctor-time) — leave it.
+  - `MainFileWatchPlugin` — resolves in `StartUp`: `IFileWatchManager` (bridged), concrete
+    `FileWatchLogic`, `PeriodicUiTimer`. **~2 new bridges** (confirm `PeriodicUiTimer` is ctor-time).
+  - `DeleteObjectPlugin` — *most involved.* Already `[ImportingConstructor]`; ctor body still
+    service-locates `IElementCommands` (bridged — just add a param), `IDeleteLogic` (**1 new bridge**),
+    and concrete `WireframeCommands` (prefer the bridged `IWireframeCommands` — verify it carries the
+    members used). The interface switch is the extra cost here.
 - **Heavies (own PR each — large ctors and/or `Locator.GetRequiredService<PluginManager>()`
   self-injection cycle risk):** `MainEditorTabPlugin` (Tool/EditorTabPlugin_XNA),
   `MainCodeOutputPlugin`, `MainTreeViewPlugin` (pulls the 3k-line `ElementTreeViewManager`),

--- a/Gum/Plugins/InternalPlugins/FavoriteComponentPlugin/MainFavoriteComponentPlugin.cs
+++ b/Gum/Plugins/InternalPlugins/FavoriteComponentPlugin/MainFavoriteComponentPlugin.cs
@@ -1,7 +1,6 @@
 using Gum.DataTypes;
 using Gum.Managers;
 using Gum.Plugins.BaseClasses;
-using Gum.Services;
 using System.ComponentModel.Composition;
 
 namespace Gum.Plugins.FavoriteComponentPlugin;
@@ -9,11 +8,16 @@ namespace Gum.Plugins.FavoriteComponentPlugin;
 [Export(typeof(PluginBase))]
 public class MainFavoriteComponentPlugin : PriorityPlugin
 {
-    private IFavoriteComponentManager _favoriteComponentManager;
+    private readonly IFavoriteComponentManager _favoriteComponentManager;
+
+    [ImportingConstructor]
+    public MainFavoriteComponentPlugin(IFavoriteComponentManager favoriteComponentManager)
+    {
+        _favoriteComponentManager = favoriteComponentManager;
+    }
 
     public override void StartUp()
     {
-        _favoriteComponentManager = Locator.GetRequiredService<IFavoriteComponentManager>();
         this.ElementDelete += HandleElementDelete;
         this.ElementRename += HandleElementRename;
     }

--- a/Gum/Plugins/InternalPlugins/Inheritance/MainInheritancePlugin.cs
+++ b/Gum/Plugins/InternalPlugins/Inheritance/MainInheritancePlugin.cs
@@ -2,7 +2,6 @@
 using Gum.Logic;
 using Gum.Managers;
 using Gum.Plugins.BaseClasses;
-using Gum.Services;
 using System.ComponentModel.Composition;
 
 namespace Gum.Plugins.Inheritance;
@@ -12,9 +11,10 @@ public class MainInheritancePlugin : PriorityPlugin
 {
     private readonly InheritanceLogic _inheritanceLogic;
 
-    public MainInheritancePlugin()
+    [ImportingConstructor]
+    public MainInheritancePlugin(InheritanceLogic inheritanceLogic)
     {
-        _inheritanceLogic = Locator.GetRequiredService<InheritanceLogic>();
+        _inheritanceLogic = inheritanceLogic;
     }
 
     public override void StartUp()

--- a/Gum/Plugins/PluginManager.cs
+++ b/Gum/Plugins/PluginManager.cs
@@ -31,6 +31,7 @@ using Gum.Undo;
 using Gum.Localization;
 using Gum.Services.Fonts;
 using Gum.Plugins.ImportPlugin.Manager;
+using Gum.Logic;
 using Gum.Logic.FileWatch;
 
 namespace Gum.Plugins;
@@ -849,6 +850,11 @@ public class PluginManager : IPluginManager
             batch.AddExportedValue<IProjectState>(Locator.GetRequiredService<IProjectState>());
             batch.AddExportedValue<IImportLogic>(Locator.GetRequiredService<IImportLogic>());
             batch.AddExportedValue<IFileWatchManager>(Locator.GetRequiredService<IFileWatchManager>());
+
+            // MainInheritancePlugin (InheritanceLogic) and MainFavoriteComponentPlugin
+            // (IFavoriteComponentManager) construction-time deps:
+            batch.AddExportedValue<InheritanceLogic>(Locator.GetRequiredService<InheritanceLogic>());
+            batch.AddExportedValue<IFavoriteComponentManager>(Locator.GetRequiredService<IFavoriteComponentManager>());
 
 
             var container = new CompositionContainer(catalog);


### PR DESCRIPTION
## Phase 2 static drain — two more plugin `Locator` ctors → `[ImportingConstructor]`

Continues the plugin-drain pass (after #3319). Relocates each plugin's construction-time `Locator.GetRequiredService<T>()` lookup to the composition root by bridging two services into the plugin's MEF container in `PluginManager.LoadPlugins`:

- **`InheritanceLogic`** — concrete; no `IInheritanceLogic` exists, so the concrete is bridged (same call as `MenuStripManager` last pass).
- **`IFavoriteComponentManager`** — interface (bridged in preference to the `FavoriteComponentManager` concrete).

Both already resolve via `Locator` today, so they're already registered in `Builder.cs` — **no `Builder.cs` change**.

### Per-plugin changes
- **`MainInheritancePlugin`** — parameterless ctor → `[ImportingConstructor](InheritanceLogic inheritanceLogic)`.
- **`MainFavoriteComponentPlugin`** — had no ctor and resolved in `StartUp`; added `[ImportingConstructor](IFavoriteComponentManager)`, moved the assignment into it, and tightened the field to `private readonly` (construction precedes `StartUp`, so this is behavior-preserving).
- Both drop the now-unused `using Gum.Services;`.

This **relocates** the `Locator` calls; it doesn't delete them — the count moves from the plugin bodies into the bridge block. Behavior-preserving.

### Docs
Updates the Phase 2 working-notes ledger in `Direction/ui-decoupling-plan.md`: records the drain, refreshes the bridged-services snapshot, and replaces the now-drained "one new bridge each" tier with a **scouted, cheapest-first breakdown of the medium tier** (`MainHideShowToolsPlugin` → `MainVariableGridPlugin` → `MainErrorsPlugin` → `MainFileWatchPlugin` → `DeleteObjectPlugin`) so the next batch is pre-scoped.

### Verification
- Builds clean via `GumFull.sln` (0 errors). MEF/DI wiring is type-checked.
- MEF composition is runtime-validated (a failure shows an "Error loading plugins" dialog with zero plugins) — manual smoke test: tool launches with all tabs and menus present.
- No unit tests — behavior-preserving `static`→injected conversion (per the `refactoring-direction` drain calibration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
