### PR TITLE
Phase 2 (static drain): Delete/Hotkey/Output/SvgExport plugin Locator ctors -> [ImportingConstructor]

### DIFF
--- a/Direction/ui-decoupling-plan.md
+++ b/Direction/ui-decoupling-plan.md
@@ -128,10 +128,17 @@ Plugins are MEF parts, so they can't pull from the host DI container directly; a
   lifecycle, not construction. (Live case: `MainFileWatchPlugin`'s `PeriodicUiTimer`.)
 - **`using` bookkeeping has two traps.** (1) Bridging a *concrete* type may need a new `using` in
   `PluginManager.cs` (e.g. `Gum.Controls` for `MainPanelViewModel`, `Gum.Plugins.InternalPlugins.VariableGrid`
-  for `IVariableReferenceLogic`). (2) Don't reflexively drop `using Gum.Services;` from a drained
-  plugin — it's only safe when `Locator` was the *only* thing it provided. Keep it if a
-  still-referenced lookup remains (Errors' per-call `IProjectState`) or if a bridged type lives in
-  that namespace (`PeriodicUiTimer` is in `Gum.Services`).
+  for `IVariableReferenceLogic`, `Gum.Plugins.InternalPlugins.Hotkey.ViewModels` for `HotkeyViewModel`).
+  (2) Don't reflexively drop `using Gum.Services;` from a drained plugin — it's only safe when `Locator`
+  was the *only* thing it provided. Keep it if a still-referenced lookup remains (Errors' per-call
+  `IProjectState`, RecentFiles' method-body `IProjectManager`) or if a bridged type lives in that
+  namespace (`PeriodicUiTimer` is in `Gum.Services`).
+- **Injecting an *internal* type costs an accessibility bump.** A `public [ImportingConstructor]`
+  param must be at least as accessible as the ctor, so an internal ViewModel/service injected this way
+  must be made `public` (else **CS0051**). That can cascade: **CS0053** then fires if the now-public
+  type exposes a public member whose type is still internal (e.g. a nested item-VM) — bump those too.
+  The already-injected VMs (`MainPanelViewModel`, `PropertyGridManager`) are public, so this only
+  brings the new one in line. (Live case: `HotkeyViewModel` + its exposed `HotkeyItemViewModel`.)
 - **Verify:** build via `GumFull.sln` (plugin post-builds need `$(SolutionDir)`), then launch the
   tool — a MEF composition failure shows an "Error loading plugins" dialog with zero plugins, so
   "tool opens with all tabs and menus present" is the all-clear.
@@ -141,7 +148,8 @@ line): `ISelectedState`, `IElementCommands`, `IUndoManager`, `IProjectManager`, 
 `IFileCommands`, `ITabManager`, `MenuStripManager`, `IDialogService`, `IWireframeCommands`,
 `IFontManager`, `IProjectState`, `IImportLogic`, `IFileWatchManager`, `InheritanceLogic`,
 `IFavoriteComponentManager`, `MainPanelViewModel`, `PropertyGridManager`, `IVariableReferenceLogic`,
-`IErrorChecker`, `IMessenger`, `FileWatchLogic`, `PeriodicUiTimer`.
+`IErrorChecker`, `IMessenger`, `FileWatchLogic`, `PeriodicUiTimer`, `IDeleteLogic`, `HotkeyViewModel`,
+`MainOutputViewModel`.
 
 ### Shortcut: batch by bridge-cost — added 2026-06-23
 
@@ -167,7 +175,7 @@ instead of the ctor still drains the same way — **relocate the assignment into
   concrete `InheritanceLogic` (no `IInheritanceLogic` exists, so bridge the concrete) and interface
   `IFavoriteComponentManager`. MainFavoriteComponentPlugin had no ctor and resolved in `StartUp`;
   added an `[ImportingConstructor]`, moved the assignment into it, tightened the field to `readonly`.
-- **this PR (2026-06-23)** — MainHideShowToolsPlugin, MainVariableGridPlugin, MainErrorsPlugin,
+- **#3322 (2026-06-23)** — MainHideShowToolsPlugin, MainVariableGridPlugin, MainErrorsPlugin,
   MainFileWatchPlugin. **Seven new bridges:** concretes `MainPanelViewModel`, `PropertyGridManager`,
   `FileWatchLogic` (no interfaces); interfaces `IVariableReferenceLogic`, `IErrorChecker`,
   `IMessenger`; plus transient `PeriodicUiTimer`. HideShow/VariableGrid had parameterless ctors;
@@ -176,23 +184,34 @@ instead of the ctor still drains the same way — **relocate the assignment into
   the resolution moved). Tightened the relocated fields to `readonly`; dropped a stray
   `using HarfBuzzSharp;` from VariableGrid (boyscout). Errors keeps `using Gum.Services;` (its
   per-call `IProjectState` lookup stays); FileWatch keeps it too (`PeriodicUiTimer` is in that namespace).
+- **this PR (2026-06-23)** — DeleteObjectPlugin, MainHotkeyPlugin, MainOutputPlugin,
+  MainSvgExportPlugin (the whole remaining cheap/medium tier in one PR). **Three new bridges:**
+  `IDeleteLogic`, transient VM `HotkeyViewModel`, singleton VM `MainOutputViewModel` (also the
+  `IOutputManager` instance). DeleteObjectPlugin was already `[ImportingConstructor]`: moved its
+  `IDeleteLogic`/`IWireframeCommands` lookups to params, switched the field from concrete
+  `WireframeCommands` to the bridged `IWireframeCommands` (safe — `InstanceDeletionHelper` already took
+  the interface and only `.Refresh()` is used), and **removed a dead injected `IElementCommands`**
+  (assigned, never read) plus its now-stray `using Gum.ToolCommands`. MainSvgExportPlugin (already
+  `[ImportingConstructor]`): added `ISelectedState` + `IProjectState` params — both already bridged,
+  zero new bridges. Hotkey/Output had no ctor and resolved their VM in `StartUp`; both got a new
+  `[ImportingConstructor]` with the resolution relocated (Hotkey's `HotkeyViewModel` + its exposed
+  `HotkeyItemViewModel` had to be made `public` — see the CS0051/CS0053 recipe bullet). Dropped
+  `using Gum.Services;` from all four (Locator was each one's only use of it). **Scouted but left
+  (no in-scope lookup):** MainBehaviorsPlugin (already ctor-clean; only `Locator<PluginManager>()` in
+  an event handler — the self-injection cycle smell) and MainRecentFilesPlugin (its `IProjectManager`
+  lookups are all in method bodies / event handlers — keeps `using Gum.Services;`).
 
 ### Remaining plugin targets (triage ledger — prune as drained)
 
-- **Medium / next: `DeleteObjectPlugin`** — the cheapest-first four (HideShow, VariableGrid, Errors,
-  FileWatch) are drained (see "Drained so far"). This is *the most involved of the medium tier — the
-  lone one needing an interface switch.* Already `[ImportingConstructor]`; ctor body still
-  service-locates `IElementCommands` (bridged — just add a param), `IDeleteLogic` (**1 new bridge**),
-  and concrete `WireframeCommands` (prefer the bridged `IWireframeCommands` — verify it carries the
-  members used). The interface switch is the extra cost here.
 - **Heavies (own PR each — large ctors and/or `Locator.GetRequiredService<PluginManager>()`
   self-injection cycle risk):** `MainEditorTabPlugin` (Tool/EditorTabPlugin_XNA),
   `MainCodeOutputPlugin`, `MainTreeViewPlugin` (pulls the 3k-line `ElementTreeViewManager`),
-  `MainPropertiesWindowPlugin`, `MainStatePlugin`, `MainTextureCoordinatePlugin`.
-- **Not yet scouted (triage before picking — could be cheap or could be non-ctor-only):**
-  `MainBehaviorsPlugin`, `MainHotkeyPlugin`, `MainRecentFilesPlugin`, `MainOutputPlugin`,
-  `MainSvgExportPlugin`. For each: open it, find where it calls `Locator`, and decide if it's a
-  ctor/`StartUp` lookup (in scope) or only body/event-handler lookups (out of scope — leave it).
+  `MainPropertiesWindowPlugin`, `MainStatePlugin`, `MainTextureCoordinatePlugin`. With the
+  cheap/medium tier now drained, these are the substantive plugin ctor-drain work that remains.
+- **Scouted and left as out-of-scope** (no ctor/`StartUp` lookup to relocate — re-confirm before
+  re-touching): `MainBehaviorsPlugin` (already ctor-clean; only `Locator<PluginManager>()` in an event
+  handler — the cycle smell) and `MainRecentFilesPlugin` (only method-body/event-handler
+  `IProjectManager` lookups).
 - **Grep caveat when finding undrained plugins.** `grep -rl "Locator.GetRequiredService"
   Gum/Plugins/InternalPlugins` over-reports: an already-drained plugin reappears if it kept a
   *deliberate* non-ctor lookup (e.g. `MainErrorsPlugin`'s per-call `IProjectState`). It also

--- a/Gum/Plugins/InternalPlugins/Delete/DeleteObjectPlugin.cs
+++ b/Gum/Plugins/InternalPlugins/Delete/DeleteObjectPlugin.cs
@@ -7,9 +7,7 @@ using Gum.DataTypes;
 using Gum.DataTypes.Behaviors;
 using System.Windows.Controls;
 using Gum.Commands;
-using Gum.ToolCommands;
 using ToolsUtilities;
-using Gum.Services;
 using Gum.Managers;
 
 namespace Gum.Gui.Plugins;
@@ -22,17 +20,19 @@ public class DeleteObjectPlugin : PriorityPlugin
     private GroupBox deleteGroupBox;
     private RadioButton deleteJustParent;
     private RadioButton deleteAllContainedObjects;
-    private readonly IElementCommands _elementCommands;
-    private readonly WireframeCommands _wireframeCommands;
+    private readonly IWireframeCommands _wireframeCommands;
     private readonly IDeleteLogic _deleteLogic;
     private readonly InstanceDeletionHelper _instanceDeletionHelper;
 
     [ImportingConstructor]
-    public DeleteObjectPlugin(IGuiCommands guiCommands, IFileCommands fileCommands)
+    public DeleteObjectPlugin(
+        IGuiCommands guiCommands,
+        IFileCommands fileCommands,
+        IDeleteLogic deleteLogic,
+        IWireframeCommands wireframeCommands)
     {
-        _elementCommands = Locator.GetRequiredService<IElementCommands>();
-        _wireframeCommands = Locator.GetRequiredService<WireframeCommands>();
-        _deleteLogic = Locator.GetRequiredService<IDeleteLogic>();
+        _wireframeCommands = wireframeCommands;
+        _deleteLogic = deleteLogic;
         _instanceDeletionHelper = new InstanceDeletionHelper(_deleteLogic, guiCommands, _wireframeCommands, fileCommands);
     }
 

--- a/Gum/Plugins/InternalPlugins/Hotkey/MainHotkeyPlugin.cs
+++ b/Gum/Plugins/InternalPlugins/Hotkey/MainHotkeyPlugin.cs
@@ -4,7 +4,6 @@ using System;
 using System.ComponentModel.Composition;
 using System.Windows.Controls;
 using Gum.Plugins.InternalPlugins.Hotkey.ViewModels;
-using Gum.Services;
 
 namespace Gum.Plugins.InternalPlugins.Hotkey
 {
@@ -14,13 +13,20 @@ namespace Gum.Plugins.InternalPlugins.Hotkey
         PluginTab pluginTab;
         HotkeyView hotkeyView;
         MenuItem menuItem;
+        private readonly HotkeyViewModel _hotkeyViewModel;
+
+        [ImportingConstructor]
+        public MainHotkeyPlugin(HotkeyViewModel hotkeyViewModel)
+        {
+            _hotkeyViewModel = hotkeyViewModel;
+        }
 
         public override void StartUp()
         {
             menuItem = this.AddMenuItemTo("View Hotkeys", HandleToggleTabVisibility, "View");
             hotkeyView = new Views.HotkeyView()
             {
-                DataContext = Locator.GetRequiredService<HotkeyViewModel>()
+                DataContext = _hotkeyViewModel
             };
             pluginTab = base.CreateTab(hotkeyView, "Hotkeys", TabLocation.CenterBottom);
             pluginTab.TabShown += HandleTabShown;

--- a/Gum/Plugins/InternalPlugins/Hotkey/ViewModels/HotkeyViewModel.cs
+++ b/Gum/Plugins/InternalPlugins/Hotkey/ViewModels/HotkeyViewModel.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 
 namespace Gum.Plugins.InternalPlugins.Hotkey.ViewModels
 {
-    class HotkeyViewModel : ViewModel
+    public class HotkeyViewModel : ViewModel
     {
         private IHotkeyManager _hotkeyManager;
 
@@ -68,7 +68,7 @@ namespace Gum.Plugins.InternalPlugins.Hotkey.ViewModels
         }
     }
 
-    class HotkeyItemViewModel
+    public class HotkeyItemViewModel
     {
         public string Display { get; set; }
 

--- a/Gum/Plugins/InternalPlugins/Output/MainOutputPlugin.cs
+++ b/Gum/Plugins/InternalPlugins/Output/MainOutputPlugin.cs
@@ -5,17 +5,23 @@ using System.Windows;
 using System.Windows.Media;
 using System.Windows.Controls;
 using Gum.Plugins.InternalPlugins.Output;
-using Gum.Services;
 
 namespace Gum.Plugins.Output
 {
     [Export(typeof(PluginBase))]
     class MainOutputPlugin : PriorityPlugin
     {
+        private readonly MainOutputViewModel _mainOutputViewModel;
+
+        [ImportingConstructor]
+        public MainOutputPlugin(MainOutputViewModel mainOutputViewModel)
+        {
+            _mainOutputViewModel = mainOutputViewModel;
+        }
+
         public override void StartUp()
         {
-            MainOutputViewModel viewmodel = Locator.GetRequiredService<MainOutputViewModel>();
-            MainOutputPluginView view = new() { DataContext = viewmodel, Margin = new(4)};
+            MainOutputPluginView view = new() { DataContext = _mainOutputViewModel, Margin = new(4)};
             _tabManager.AddControl(view, "Output", TabLocation.RightBottom);
         }
     }

--- a/Gum/Plugins/InternalPlugins/SvgExportPlugin/MainSvgExportPlugin.cs
+++ b/Gum/Plugins/InternalPlugins/SvgExportPlugin/MainSvgExportPlugin.cs
@@ -1,7 +1,6 @@
 using Gum.Commands;
 using Gum.DataTypes;
 using Gum.Plugins.BaseClasses;
-using Gum.Services;
 using Gum.Services.Dialogs;
 using Gum.ToolStates;
 using System.ComponentModel.Composition;
@@ -18,10 +17,14 @@ internal class MainSvgExportPlugin : PriorityPlugin
     private readonly ISvgExportCommand _svgExportCommand;
 
     [ImportingConstructor]
-    public MainSvgExportPlugin(IDialogService dialogService, IGuiCommands guiCommands)
+    public MainSvgExportPlugin(
+        IDialogService dialogService,
+        IGuiCommands guiCommands,
+        ISelectedState selectedState,
+        IProjectState projectState)
     {
-        _selectedState = Locator.GetRequiredService<ISelectedState>();
-        _projectState = Locator.GetRequiredService<IProjectState>();
+        _selectedState = selectedState;
+        _projectState = projectState;
         // SVG export is plugin-specific, so the command is instantiated here rather than
         // registered app-wide. These services are injected (they are also property-injected
         // into PluginBase for use in StartUp()/handlers).

--- a/Gum/Plugins/PluginManager.cs
+++ b/Gum/Plugins/PluginManager.cs
@@ -35,6 +35,7 @@ using Gum.Logic;
 using Gum.Logic.FileWatch;
 using Gum.Controls;
 using Gum.Plugins.InternalPlugins.VariableGrid;
+using Gum.Plugins.InternalPlugins.Hotkey.ViewModels;
 
 namespace Gum.Plugins;
 
@@ -870,6 +871,15 @@ public class PluginManager : IPluginManager
             batch.AddExportedValue<IMessenger>(Locator.GetRequiredService<IMessenger>());
             batch.AddExportedValue<FileWatchLogic>(Locator.GetRequiredService<FileWatchLogic>());
             batch.AddExportedValue<PeriodicUiTimer>(Locator.GetRequiredService<PeriodicUiTimer>());
+
+            // Cheap/medium-tier ctor drains: DeleteObjectPlugin (IDeleteLogic; its IWireframeCommands
+            // dep is already bridged above), MainHotkeyPlugin (HotkeyViewModel),
+            // MainOutputPlugin (MainOutputViewModel). HotkeyViewModel is a transient ViewModel
+            // (auto-registered via the ViewModel scan in Builder.cs); this bridges the single instance the
+            // plugin's tab consumes. MainOutputViewModel is the IOutputManager singleton.
+            batch.AddExportedValue<IDeleteLogic>(Locator.GetRequiredService<IDeleteLogic>());
+            batch.AddExportedValue<HotkeyViewModel>(Locator.GetRequiredService<HotkeyViewModel>());
+            batch.AddExportedValue<MainOutputViewModel>(Locator.GetRequiredService<MainOutputViewModel>());
 
 
             var container = new CompositionContainer(catalog);


### PR DESCRIPTION
## What

Finishes the remaining **cheap/medium plugin ctor-drain tier** of Phase 2 (UI/logic decoupling) in one reviewable PR. Each drained plugin's ctor/`StartUp` `Locator.GetRequiredService<T>()` lookups move into an `[ImportingConstructor]`, with the dependency bridged into the plugin MEF container in `PluginManager.LoadPlugins`.

**Drained (4):** `DeleteObjectPlugin`, `MainHotkeyPlugin`, `MainOutputPlugin`, `MainSvgExportPlugin`.

**Three new bridges** in `LoadPlugins`:
- `IDeleteLogic` (singleton) — for `DeleteObjectPlugin`
- `HotkeyViewModel` (transient VM, auto-registered via the `ViewModel` scan) — for `MainHotkeyPlugin`
- `MainOutputViewModel` (singleton, also the `IOutputManager` instance) — for `MainOutputPlugin`

`DeleteObjectPlugin`'s other deps (`IGuiCommands`, `IFileCommands`, `IWireframeCommands`) and `MainSvgExportPlugin`'s (`IDialogService`, `IGuiCommands`, `ISelectedState`, `IProjectState`) were already bridged.

## Notable details

- **`DeleteObjectPlugin`** — field switched from concrete `WireframeCommands` to the bridged `IWireframeCommands` (safe: `InstanceDeletionHelper` already took the interface, and `.Refresh()` is the only member used anywhere on that path). Also **removed a dead injected `IElementCommands`** field (assigned, never read) and its now-stray `using Gum.ToolCommands`.
- **`MainHotkeyPlugin`** — `HotkeyViewModel` and its exposed `HotkeyItemViewModel` were `internal`; injecting via a `public [ImportingConstructor]` requires them to be `public` (else CS0051, then CS0053 on the nested item-VM). The already-injected VMs (`MainPanelViewModel`, `PropertyGridManager`) are public, so this just brings the new one in line.
- **Dropped `using Gum.Services;`** from all four (the `Locator` reference was each one's only use of it).

## Scouted but left out of scope

- **`MainBehaviorsPlugin`** — already ctor-clean; its only `Locator` call is `GetRequiredService<PluginManager>()` in an event handler, the host-self-injection cycle smell reserved for the heavies' own PRs.
- **`MainRecentFilesPlugin`** — its `IProjectManager` lookups are all in method bodies / event handlers (not ctor/`StartUp`), so out of scope; keeps `using Gum.Services;`.

## Verification

- `dotnet build GumFull.sln` — 0 errors.
- `PluginBaseCompositionTests` (the MEF-wiring pin) — green.
- Behavior-preserving relocations, so no new unit tests (per the Phase 2 recipe). Runtime smoke check: tool launches with all tabs/menus present (a MEF composition failure would show the "Error loading plugins" dialog).

Ledger (`Direction/ui-decoupling-plan.md`) updated per the Phase 2 flywheel rule: recorded the pass, pruned the drained plugins from the triage tier, added the three bridges to the snapshot, and added a recipe bullet for the internal-VM accessibility cascade (CS0051/CS0053).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
