### PR TITLE
Phase 2 (static drain): MainPropertiesWindowPlugin Locator ctor -> [ImportingConstructor]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,7 @@ The Gum tool has been progressively migrated to constructor-injected services (`
 
 There is a dedicated later phase for draining the remaining `.Self` singletons wholesale, but if one is **blocking the task in front of you** — typically because the class can't be unit-tested until it takes its dependencies via the constructor — drain it on the spot in the same PR rather than deferring or asking about phase timing. See the `refactoring-direction` skill for the judgment call and for breaking the DI construction cycle that the `Self`+`Initialize`+`Locator` pattern usually hides (inject the back-edge dependency as `Lazy<T>`).
 
-**`ObjectFinder.Self` is the exception.** It is intentionally still a static singleton across the entire codebase (tool, runtimes, tests). There is no `IObjectFinder` interface, and replacing it is a project-wide refactor — do not attempt it as drive-by cleanup. Calls to `ObjectFinder.Self.GetBaseElements(...)`, `ObjectFinder.Self.GetDefaultChildName(...)`, etc. are acceptable in any context.
+**`ObjectFinder.Self` is the exception.** It is intentionally still a static singleton across the entire codebase (tool, runtimes, tests). An `IObjectFinder` interface does exist and is even DI-registered (`Builder.cs` binds it to the `ObjectFinder.Self` instance), but the ~476 `.Self` call sites are intentionally left as-is: replacing them wholesale is a project-wide refactor — do not attempt it as drive-by cleanup. Calls to `ObjectFinder.Self.GetBaseElements(...)`, `ObjectFinder.Self.GetDefaultChildName(...)`, etc. are acceptable in any context.
 
 ## Searching C# Code
 

--- a/Direction/ui-decoupling-plan.md
+++ b/Direction/ui-decoupling-plan.md
@@ -149,7 +149,7 @@ line): `ISelectedState`, `IElementCommands`, `IUndoManager`, `IProjectManager`, 
 `IFontManager`, `IProjectState`, `IImportLogic`, `IFileWatchManager`, `InheritanceLogic`,
 `IFavoriteComponentManager`, `MainPanelViewModel`, `PropertyGridManager`, `IVariableReferenceLogic`,
 `IErrorChecker`, `IMessenger`, `FileWatchLogic`, `PeriodicUiTimer`, `IDeleteLogic`, `HotkeyViewModel`,
-`MainOutputViewModel`.
+`MainOutputViewModel`, `IDispatcher`, `IWireframeObjectManager`.
 
 ### Shortcut: batch by bridge-cost — added 2026-06-23
 
@@ -184,7 +184,7 @@ instead of the ctor still drains the same way — **relocate the assignment into
   the resolution moved). Tightened the relocated fields to `readonly`; dropped a stray
   `using HarfBuzzSharp;` from VariableGrid (boyscout). Errors keeps `using Gum.Services;` (its
   per-call `IProjectState` lookup stays); FileWatch keeps it too (`PeriodicUiTimer` is in that namespace).
-- **this PR (2026-06-23)** — DeleteObjectPlugin, MainHotkeyPlugin, MainOutputPlugin,
+- **#3323 (2026-06-23)** — DeleteObjectPlugin, MainHotkeyPlugin, MainOutputPlugin,
   MainSvgExportPlugin (the whole remaining cheap/medium tier in one PR). **Three new bridges:**
   `IDeleteLogic`, transient VM `HotkeyViewModel`, singleton VM `MainOutputViewModel` (also the
   `IOutputManager` instance). DeleteObjectPlugin was already `[ImportingConstructor]`: moved its
@@ -200,14 +200,27 @@ instead of the ctor still drains the same way — **relocate the assignment into
   (no in-scope lookup):** MainBehaviorsPlugin (already ctor-clean; only `Locator<PluginManager>()` in
   an event handler — the self-injection cycle smell) and MainRecentFilesPlugin (its `IProjectManager`
   lookups are all in method bodies / event handlers — keeps `using Gum.Services;`).
+- **this PR (2026-06-23)** — MainPropertiesWindowPlugin (first of the heavies). **Two new bridges:**
+  interfaces `IDispatcher` and `IWireframeObjectManager` (both namespaces already imported in
+  `PluginManager.cs`, so no new `using`). Its other five ctor-time deps — `IFontManager`,
+  `IWireframeCommands`, `IDialogService`, `FileWatchLogic`, `IProjectState` — were already bridged.
+  Converted the parameterless ctor (seven `Locator.GetRequiredService` lines) to an
+  `[ImportingConstructor]`, and switched the field from concrete `WireframeCommands` to the bridged
+  `IWireframeCommands` (safe — only `.Refresh()` is used). **Out-of-scope lookups deliberately kept**
+  (so `using Gum.Services;` stays): the two `Locator<IProjectManager>()` method-body lookups
+  (`HandleProjectLoad`/`HandlePropertiesClicked`) and the `Locator<IPluginManager>()` self-injection
+  in `HandlePropertyChanged` — the host-into-its-own-plugin cycle smell, not a drain target. Left the
+  `[Import("LocalizationService")]` property untouched (already real DI). No cycle-break and no
+  accessibility bump needed — all seven deps are public and registered in `Builder.cs`.
 
 ### Remaining plugin targets (triage ledger — prune as drained)
 
 - **Heavies (own PR each — large ctors and/or `Locator.GetRequiredService<PluginManager>()`
-  self-injection cycle risk):** `MainEditorTabPlugin` (Tool/EditorTabPlugin_XNA),
-  `MainCodeOutputPlugin`, `MainTreeViewPlugin` (pulls the 3k-line `ElementTreeViewManager`),
-  `MainPropertiesWindowPlugin`, `MainStatePlugin`, `MainTextureCoordinatePlugin`. With the
-  cheap/medium tier now drained, these are the substantive plugin ctor-drain work that remains.
+  self-injection cycle risk).** Easiest-first, with rough new-bridge cost (none need cycle-breaks or
+  accessibility bumps): `MainTextureCoordinatePlugin` (~2–3) → `MainStatePlugin` (~4) →
+  `MainTreeViewPlugin` (~3; pulls the 3k-line `ElementTreeViewManager`) → `MainCodeOutputPlugin` (~5)
+  → `MainEditorTabPlugin` (~12; Tool/EditorTabPlugin_XNA). `MainPropertiesWindowPlugin` drained (this
+  PR). These are the substantive plugin ctor-drain work that remains.
 - **Scouted and left as out-of-scope** (no ctor/`StartUp` lookup to relocate — re-confirm before
   re-touching): `MainBehaviorsPlugin` (already ctor-clean; only `Locator<PluginManager>()` in an event
   handler — the cycle smell) and `MainRecentFilesPlugin` (only method-body/event-handler

--- a/Gum/Plugins/InternalPlugins/ProjectPropertiesWindowPlugin/MainPropertiesWindowPlugin.cs
+++ b/Gum/Plugins/InternalPlugins/ProjectPropertiesWindowPlugin/MainPropertiesWindowPlugin.cs
@@ -43,7 +43,7 @@ class MainPropertiesWindowPlugin : PriorityPlugin
     #endregion
 
     private readonly IFontManager _fontManager;
-    private readonly WireframeCommands _wireframeCommands;
+    private readonly IWireframeCommands _wireframeCommands;
     private readonly IDialogService _dialogService;
     private readonly IDispatcher _dispatcher;
     private readonly IWireframeObjectManager _wireframeObjectManager;
@@ -53,15 +53,23 @@ class MainPropertiesWindowPlugin : PriorityPlugin
 
     private PluginTab? _pluginTab;
 
-    public MainPropertiesWindowPlugin()
+    [ImportingConstructor]
+    public MainPropertiesWindowPlugin(
+        IFontManager fontManager,
+        IWireframeCommands wireframeCommands,
+        IDialogService dialogService,
+        IDispatcher dispatcher,
+        IWireframeObjectManager wireframeObjectManager,
+        FileWatchLogic fileWatchLogic,
+        IProjectState projectState)
     {
-        _fontManager = Locator.GetRequiredService<IFontManager>();
-        _wireframeCommands = Locator.GetRequiredService<WireframeCommands>();
-        _dialogService = Locator.GetRequiredService<IDialogService>();
-        _dispatcher = Locator.GetRequiredService<IDispatcher>();
-        _wireframeObjectManager = Locator.GetRequiredService<IWireframeObjectManager>();
-        _fileWatchLogic = Locator.GetRequiredService<FileWatchLogic>();
-        _projectState = Locator.GetRequiredService<IProjectState>();
+        _fontManager = fontManager;
+        _wireframeCommands = wireframeCommands;
+        _dialogService = dialogService;
+        _dispatcher = dispatcher;
+        _wireframeObjectManager = wireframeObjectManager;
+        _fileWatchLogic = fileWatchLogic;
+        _projectState = projectState;
     }
 
     public override void StartUp()

--- a/Gum/Plugins/PluginManager.cs
+++ b/Gum/Plugins/PluginManager.cs
@@ -881,6 +881,12 @@ public class PluginManager : IPluginManager
             batch.AddExportedValue<HotkeyViewModel>(Locator.GetRequiredService<HotkeyViewModel>());
             batch.AddExportedValue<MainOutputViewModel>(Locator.GetRequiredService<MainOutputViewModel>());
 
+            // Heavy-tier ctor drain: MainPropertiesWindowPlugin (IDispatcher, IWireframeObjectManager;
+            // its IFontManager / IWireframeCommands / IDialogService / FileWatchLogic / IProjectState
+            // deps are already bridged above).
+            batch.AddExportedValue<IDispatcher>(Locator.GetRequiredService<IDispatcher>());
+            batch.AddExportedValue<IWireframeObjectManager>(Locator.GetRequiredService<IWireframeObjectManager>());
+
 
             var container = new CompositionContainer(catalog);
 


### PR DESCRIPTION
## Phase 2 (static drain) — MainPropertiesWindowPlugin

Drains `MainPropertiesWindowPlugin` (first of the "heavies") off `Locator` service-location onto constructor injection, continuing the UI/logic-decoupling Phase 2 plugin ctor passes (follows #3323).

### Changes
- **`MainPropertiesWindowPlugin`** — convert the parameterless ctor (seven `Locator.GetRequiredService` lines) to an `[ImportingConstructor]` taking `IFontManager, IWireframeCommands, IDialogService, IDispatcher, IWireframeObjectManager, FileWatchLogic, IProjectState`. Switch the field from concrete `WireframeCommands` to the bridged `IWireframeCommands` (safe — only `.Refresh()` is used).
- **`PluginManager.LoadPlugins`** — add two bridges: `IDispatcher` and `IWireframeObjectManager` (both namespaces already imported, so no new `using`). The other five deps were already bridged.
- **Deliberately kept** (so `using Gum.Services;` stays): the two method-body `Locator<IProjectManager>()` lookups and the `Locator<IPluginManager>()` self-injection in `HandlePropertyChanged` — the host-into-its-own-plugin cycle smell, not a drain target. The `[Import("LocalizationService")]` property is untouched.
- No `Lazy<T>` cycle-break and no internal→public accessibility bump needed — all seven deps are public and registered in `Builder.cs`.

### Guidance-file fixes (bundled per repo policy)
- **`Direction/ui-decoupling-plan.md`** — Phase 2 ledger flywheel update: renamed the now-merged `#3323` batch entry, added this PR's entry, refreshed the bridged-services snapshot and the heavies easiest-first ordering.
- **`CLAUDE.md`** — corrected a stale parenthetical ("There is no `IObjectFinder` interface"): `IObjectFinder` does exist and is DI-registered (`Builder.cs` binds it to the `ObjectFinder.Self` instance). The `ObjectFinder.Self` sanctioned-singleton policy is preserved.

### Verification
- Builds clean via `GumFull.sln` (0 errors).
- Behavior-preserving static→injected-field swap with no extracted unit, so no new unit test (consistent with the prior plugin ctor drains; the compiler + DI container verify the wiring). Manual smoke test: tool opens with all tabs/menus; Edit→Properties opens the Project Properties window; a property that triggers a wireframe refresh still updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
