### PR TITLE
Phase 2 (static drain): MainTextureCoordinatePlugin + MainStatePlugin Locator ctors -> [ImportingConstructor]

### DIFF
--- a/Direction/ui-decoupling-plan.md
+++ b/Direction/ui-decoupling-plan.md
@@ -149,7 +149,8 @@ line): `ISelectedState`, `IElementCommands`, `IUndoManager`, `IProjectManager`, 
 `IFontManager`, `IProjectState`, `IImportLogic`, `IFileWatchManager`, `InheritanceLogic`,
 `IFavoriteComponentManager`, `MainPanelViewModel`, `PropertyGridManager`, `IVariableReferenceLogic`,
 `IErrorChecker`, `IMessenger`, `FileWatchLogic`, `PeriodicUiTimer`, `IDeleteLogic`, `HotkeyViewModel`,
-`MainOutputViewModel`, `IDispatcher`, `IWireframeObjectManager`.
+`MainOutputViewModel`, `IDispatcher`, `IWireframeObjectManager`, `ISetVariableLogic`, `IHotkeyManager`,
+`IEditCommands`, `ICopyPasteLogic`, `IVariableInCategoryPropagationLogic`.
 
 ### Shortcut: batch by bridge-cost — added 2026-06-23
 
@@ -200,7 +201,7 @@ instead of the ctor still drains the same way — **relocate the assignment into
   (no in-scope lookup):** MainBehaviorsPlugin (already ctor-clean; only `Locator<PluginManager>()` in
   an event handler — the self-injection cycle smell) and MainRecentFilesPlugin (its `IProjectManager`
   lookups are all in method bodies / event handlers — keeps `using Gum.Services;`).
-- **this PR (2026-06-23)** — MainPropertiesWindowPlugin (first of the heavies). **Two new bridges:**
+- **#3325 (2026-06-23)** — MainPropertiesWindowPlugin (first of the heavies). **Two new bridges:**
   interfaces `IDispatcher` and `IWireframeObjectManager` (both namespaces already imported in
   `PluginManager.cs`, so no new `using`). Its other five ctor-time deps — `IFontManager`,
   `IWireframeCommands`, `IDialogService`, `FileWatchLogic`, `IProjectState` — were already bridged.
@@ -212,15 +213,38 @@ instead of the ctor still drains the same way — **relocate the assignment into
   in `HandlePropertyChanged` — the host-into-its-own-plugin cycle smell, not a drain target. Left the
   `[Import("LocalizationService")]` property untouched (already real DI). No cycle-break and no
   accessibility bump needed — all seven deps are public and registered in `Builder.cs`.
+- **this PR (2026-06-23)** — MainTextureCoordinatePlugin + MainStatePlugin (the two cheapest,
+  cycle-free heavies, drained together). **Deliberate deviation from the "own PR each" heavies
+  framing:** they share `IHotkeyManager` and adjoin the same bridge block, so one combined PR avoids
+  two near-identical edits to `LoadPlugins`. **Five new bridges:** `ISetVariableLogic` +
+  `IHotkeyManager` (Texture Coordinate), `IEditCommands` + `ICopyPasteLogic` +
+  `IVariableInCategoryPropagationLogic` (State); `IHotkeyManager` is shared. Only one new `using`
+  in `PluginManager.cs` (`Gum.PropertyGridHelpers`); the other four namespaces were already imported.
+  MainTextureCoordinatePlugin: parameterless ctor → `[ImportingConstructor]` (11 distinct ctor-time
+  deps); repeated services — `IGuiCommands`, `IFileCommands` — injected once and reused across the
+  `TextureCoordinateDisplayController` / `MainControlViewModel` / `ExposedTextureCoordinateLogic`
+  constructions; took `IMessenger` as a param and kept `messenger.RegisterAll(this)` at construction.
+  **Kept the lone `Locator<IObjectFinder>()`** (resolves the sanctioned `ObjectFinder.Self`, not a
+  drain target), so `using Gum.Services;` stays in that file; tightened the two injected service
+  fields to `readonly`. MainStatePlugin (already `[ImportingConstructor]`): added six params
+  (`IElementCommands`, `IEditCommands`, `IDialogService`, `IHotkeyManager`,
+  `IVariableInCategoryPropagationLogic`, `ICopyPasteLogic`) and deleted the six ctor-body `Locator`
+  lines. `IDialogService` is also PluginBase's `_dialogService` `[Import]`, but it's consumed at
+  construction (before property injection runs), so it **must** be a ctor param. `_objectFinder =
+  ObjectFinder.Self` stays (sanctioned). Dropped `using Gum.Services;` (Locator was its only use).
+  No cycle-break and no accessibility bump needed — all five interfaces are public and registered in
+  `Builder.cs`. Also fixed a stale bullet in the `refactoring-specialist` agent file that claimed
+  plugins can't receive DI.
 
 ### Remaining plugin targets (triage ledger — prune as drained)
 
 - **Heavies (own PR each — large ctors and/or `Locator.GetRequiredService<PluginManager>()`
-  self-injection cycle risk).** Easiest-first, with rough new-bridge cost (none need cycle-breaks or
-  accessibility bumps): `MainTextureCoordinatePlugin` (~2–3) → `MainStatePlugin` (~4) →
-  `MainTreeViewPlugin` (~3; pulls the 3k-line `ElementTreeViewManager`) → `MainCodeOutputPlugin` (~5)
-  → `MainEditorTabPlugin` (~12; Tool/EditorTabPlugin_XNA). `MainPropertiesWindowPlugin` drained (this
-  PR). These are the substantive plugin ctor-drain work that remains.
+  self-injection cycle risk).** Easiest-first, with rough new-bridge cost: `MainTreeViewPlugin`
+  (~3; pulls the 3k-line `ElementTreeViewManager` — before combining it with anything, verify it
+  doesn't construct/own that manager in a way that creates a DI cycle) → `MainCodeOutputPlugin`
+  (~5) → `MainEditorTabPlugin` (~12; Tool/EditorTabPlugin_XNA — keep this one its own PR). Drained:
+  `MainPropertiesWindowPlugin` (#3325), `MainTextureCoordinatePlugin` + `MainStatePlugin` (this PR).
+  These three are the substantive plugin ctor-drain work that remains.
 - **Scouted and left as out-of-scope** (no ctor/`StartUp` lookup to relocate — re-confirm before
   re-touching): `MainBehaviorsPlugin` (already ctor-clean; only `Locator<PluginManager>()` in an event
   handler — the cycle smell) and `MainRecentFilesPlugin` (only method-body/event-handler

--- a/Gum/Plugins/InternalPlugins/StatePlugin/MainStatePlugin.cs
+++ b/Gum/Plugins/InternalPlugins/StatePlugin/MainStatePlugin.cs
@@ -15,7 +15,6 @@ using System.ComponentModel.Composition;
 using System.Linq;
 using System.Windows.Forms;
 using Gum.Commands;
-using Gum.Services;
 using Gum.Services.Dialogs;
 using Gum.ToolCommands;
 using Gum.Logic;
@@ -45,16 +44,16 @@ public class MainStatePlugin : PriorityPlugin
     #region Initialize
 
     [ImportingConstructor]
-    public MainStatePlugin(ISelectedState selectedState, IGuiCommands guiCommands, IFileCommands fileCommands)
+    public MainStatePlugin(ISelectedState selectedState, IGuiCommands guiCommands, IFileCommands fileCommands,
+        IElementCommands elementCommands, IEditCommands editCommands, IDialogService dialogService,
+        IHotkeyManager hotkeyManager, IVariableInCategoryPropagationLogic variableInCategoryPropagationLogic,
+        ICopyPasteLogic copyPasteLogic)
     {
         _selectedState = selectedState;
-        var elementCommands = Locator.GetRequiredService<IElementCommands>();
-        var editCommands = Locator.GetRequiredService<IEditCommands>();
-        var dialogService = Locator.GetRequiredService<IDialogService>();
-        _hotkeyManager = Locator.GetRequiredService<IHotkeyManager>();
+        _hotkeyManager = hotkeyManager;
         _objectFinder = ObjectFinder.Self;
-        _variableInCategoryPropagationLogic = Locator.GetRequiredService<IVariableInCategoryPropagationLogic>();
-        _copyPasteLogic = Locator.GetRequiredService<ICopyPasteLogic>();
+        _variableInCategoryPropagationLogic = variableInCategoryPropagationLogic;
+        _copyPasteLogic = copyPasteLogic;
         _stateTreeViewRightClickService = new StateTreeViewRightClickService(
             _selectedState,
             elementCommands,

--- a/Gum/Plugins/PluginManager.cs
+++ b/Gum/Plugins/PluginManager.cs
@@ -36,6 +36,7 @@ using Gum.Logic.FileWatch;
 using Gum.Controls;
 using Gum.Plugins.InternalPlugins.VariableGrid;
 using Gum.Plugins.InternalPlugins.Hotkey.ViewModels;
+using Gum.PropertyGridHelpers;
 
 namespace Gum.Plugins;
 
@@ -886,6 +887,18 @@ public class PluginManager : IPluginManager
             // deps are already bridged above).
             batch.AddExportedValue<IDispatcher>(Locator.GetRequiredService<IDispatcher>());
             batch.AddExportedValue<IWireframeObjectManager>(Locator.GetRequiredService<IWireframeObjectManager>());
+
+            // Heavy-tier ctor drains (combined PR): MainTextureCoordinatePlugin and MainStatePlugin,
+            // which share IHotkeyManager. MainTextureCoordinatePlugin adds ISetVariableLogic;
+            // MainStatePlugin adds IEditCommands, ICopyPasteLogic, IVariableInCategoryPropagationLogic.
+            // Their remaining ctor-time deps (ISelectedState, IGuiCommands, IFileCommands, IElementCommands,
+            // IDialogService, IWireframeCommands, IUndoManager, ITabManager, IProjectManager,
+            // IFileWatchManager, IMessenger) are already bridged above.
+            batch.AddExportedValue<ISetVariableLogic>(Locator.GetRequiredService<ISetVariableLogic>());
+            batch.AddExportedValue<IHotkeyManager>(Locator.GetRequiredService<IHotkeyManager>());
+            batch.AddExportedValue<IEditCommands>(Locator.GetRequiredService<IEditCommands>());
+            batch.AddExportedValue<ICopyPasteLogic>(Locator.GetRequiredService<ICopyPasteLogic>());
+            batch.AddExportedValue<IVariableInCategoryPropagationLogic>(Locator.GetRequiredService<IVariableInCategoryPropagationLogic>());
 
 
             var container = new CompositionContainer(catalog);

--- a/Gum/TextureCoordinateSelectionPlugin/MainTextureCoordinatePlugin.cs
+++ b/Gum/TextureCoordinateSelectionPlugin/MainTextureCoordinatePlugin.cs
@@ -25,8 +25,8 @@ public class MainTextureCoordinatePlugin : PluginBase, IRecipient<UiBaseFontSize
     #region Fields/Properties
 
     PluginTab textureCoordinatePluginTab = default!;
-    ISelectedState _selectedState;
-    IWireframeCommands _wireframeCommands;
+    readonly ISelectedState _selectedState;
+    readonly IWireframeCommands _wireframeCommands;
     TextureCoordinateDisplayController _displayController;
     MainControlViewModel _viewModel;
     ExposedTextureCoordinateLogic _exposedCoordinateLogic;
@@ -46,33 +46,44 @@ public class MainTextureCoordinatePlugin : PluginBase, IRecipient<UiBaseFontSize
 
     #endregion
 
-    public MainTextureCoordinatePlugin()
+    [ImportingConstructor]
+    public MainTextureCoordinatePlugin(
+        ISelectedState selectedState,
+        IWireframeCommands wireframeCommands,
+        IUndoManager undoManager,
+        IGuiCommands guiCommands,
+        IFileCommands fileCommands,
+        ISetVariableLogic setVariableLogic,
+        ITabManager tabManager,
+        IHotkeyManager hotkeyManager,
+        IProjectManager projectManager,
+        IFileWatchManager fileWatchManager,
+        IMessenger messenger)
     {
-        _selectedState = Locator.GetRequiredService<ISelectedState>();
-        _wireframeCommands = Locator.GetRequiredService<IWireframeCommands>();
+        _selectedState = selectedState;
+        _wireframeCommands = wireframeCommands;
 
         _displayController = new TextureCoordinateDisplayController(
-            Locator.GetRequiredService<ISelectedState>(),
-            Locator.GetRequiredService<IUndoManager>(),
-            Locator.GetRequiredService<IGuiCommands>(),
-            Locator.GetRequiredService<IFileCommands>(),
-            Locator.GetRequiredService<ISetVariableLogic>(),
-            Locator.GetRequiredService<ITabManager>(),
-            Locator.GetRequiredService<IHotkeyManager>(),
+            selectedState,
+            undoManager,
+            guiCommands,
+            fileCommands,
+            setVariableLogic,
+            tabManager,
+            hotkeyManager,
             new ScrollBarLogicWpf());
 
         _viewModel = new (
-            Locator.GetRequiredService<IProjectManager>(),
-            Locator.GetRequiredService<IFileCommands>(),
-            Locator.GetRequiredService<IFileWatchManager>(),
-            Locator.GetRequiredService<IGuiCommands>(),
+            projectManager,
+            fileCommands,
+            fileWatchManager,
+            guiCommands,
             _displayController);
-        
 
+        messenger.RegisterAll(this);
 
-        Locator.GetRequiredService<IMessenger>().RegisterAll(this);
-
-
+        // ObjectFinder is the sanctioned static singleton; this Locator call resolves
+        // ObjectFinder.Self and is intentionally not drained.
         _exposedCoordinateLogic = new ExposedTextureCoordinateLogic(
             Locator.GetRequiredService<IObjectFinder>());
     }


### PR DESCRIPTION
## Phase 2 (static drain): two heavies — Texture Coordinate + State plugins

Continues the Phase 2 UI/logic-decoupling drain of plugin `Locator.GetRequiredService<T>()` constructor service-location to MEF `[ImportingConstructor]` injection. Drains the **two cheapest, cycle-free heavies together** — `MainTextureCoordinatePlugin` and `MainStatePlugin` — in one combined PR. They share `IHotkeyManager` and adjoin the same `PluginManager.LoadPlugins` bridge block, so combining avoids two near-identical edits to that composition root. (Deliberate deviation from the ledger's "own PR each" heavies framing — noted in the ledger entry.)

### Bridges added to `PluginManager.LoadPlugins` (5)
- `ISetVariableLogic`, `IHotkeyManager` — Texture Coordinate
- `IEditCommands`, `ICopyPasteLogic`, `IVariableInCategoryPropagationLogic` — State
- `IHotkeyManager` is shared by both.

One new `using` (`Gum.PropertyGridHelpers`); the other four namespaces were already imported. All five interfaces are already registered in `Builder.cs` (the plugins resolved them via `Locator` before), so no `Builder.cs` change.

### `MainTextureCoordinatePlugin`
Parameterless ctor → `[ImportingConstructor]` taking the 11 distinct ctor-time deps. Repeated services (`IGuiCommands`, `IFileCommands`, `ISelectedState`) are injected once and reused across the `TextureCoordinateDisplayController` / `MainControlViewModel` / `ExposedTextureCoordinateLogic` constructions. `IMessenger` is a param; `messenger.RegisterAll(this)` stays at construction. **Kept the lone `Locator<IObjectFinder>()`** (resolves the sanctioned `ObjectFinder.Self`, not a drain target), so `using Gum.Services;` stays in that file. Tightened the two injected service fields to `readonly`. `new ScrollBarLogicWpf()` left as-is.

### `MainStatePlugin`
Already `[ImportingConstructor]`; added six params (`IElementCommands`, `IEditCommands`, `IDialogService`, `IHotkeyManager`, `IVariableInCategoryPropagationLogic`, `ICopyPasteLogic`) and deleted the six ctor-body `Locator` lines. `IDialogService` is also PluginBase's `_dialogService` `[Import]` property, but it's consumed at construction (before property injection runs), so it must be a ctor param. `_objectFinder = ObjectFinder.Self` stays (sanctioned). Dropped `using Gum.Services;` (Locator was its only use).

No cycle-breaks (`Lazy<T>`) and no accessibility bumps were needed — all five interfaces are public.

### Guidance + ledger
- Fixed a stale bullet in the `refactoring-specialist` agent file that claimed plugins can't receive DI — they do, via MEF `[ImportingConstructor]`/`[Import]`, and are in scope for Phase 2.
- Updated the Phase 2 ledger in `Direction/ui-decoupling-plan.md`: added this PR's entry, renamed the prior "this PR" entry to #3325, pruned both plugins from the heavies list, and added the 5 new bridges to the bridged-services snapshot.

### Verification
- Builds clean via `GumFull.sln` (0 errors).
- Behavior-preserving static→injected swap; the compiler + DI container verify the wiring. A MEF composition failure would show an "Error loading plugins" dialog with zero plugins, so "tool opens with all tabs/menus present" is the all-clear. Manual smoke: tool opens with all tabs/menus; State panel works (select element, switch/edit states + categories, copy-paste a state); Texture Coordinate window opens and its selection rectangle drags/updates coordinates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
