### PR TITLE
Phase 2 (static drain): MainCodeOutputPlugin Locator ctor -> [ImportingConstructor]

### DIFF
--- a/Direction/ui-decoupling-plan.md
+++ b/Direction/ui-decoupling-plan.md
@@ -259,11 +259,13 @@ instead of the ctor still drains the same way — **relocate the assignment into
 ### Remaining plugin targets (triage ledger — prune as drained)
 
 - **Heavies (own PR each — large ctors and/or `Locator.GetRequiredService<PluginManager>()`
-  self-injection cycle risk).** Easiest-first, with rough new-bridge cost: `MainCodeOutputPlugin`
-  (~5) → `MainEditorTabPlugin` (~12; Tool/EditorTabPlugin_XNA — keep this one its own PR). Drained:
-  `MainPropertiesWindowPlugin` (#3325), `MainTextureCoordinatePlugin` + `MainStatePlugin` (#3326),
-  `MainTreeViewPlugin` (this PR — the `ElementTreeViewManager` cycle was scouted and found benign;
-  see the entry above). These two are the substantive plugin ctor-drain work that remains.
+  self-injection cycle risk).** Remaining: `MainEditorTabPlugin` (~12; Tool/EditorTabPlugin_XNA —
+  keep this one its own PR). Drained: `MainPropertiesWindowPlugin` (#3325),
+  `MainTextureCoordinatePlugin` + `MainStatePlugin` (#3326), `MainTreeViewPlugin` (#3327 — the
+  `ElementTreeViewManager` cycle was scouted and found benign), `MainCodeOutputPlugin` (this PR —
+  finished a partial conversion that already had a 2-param `[ImportingConstructor]`; only 4 new
+  bridges, not the ~5 estimated, since #3327 already bridged `IOutputManager`; no cycle).
+  `MainEditorTabPlugin` is the one substantive plugin ctor-drain that remains.
 - **Scouted and left as out-of-scope** (no ctor/`StartUp` lookup to relocate — re-confirm before
   re-touching): `MainBehaviorsPlugin` (already ctor-clean; only `Locator<PluginManager>()` in an event
   handler — the cycle smell) and `MainRecentFilesPlugin` (only method-body/event-handler
@@ -293,13 +295,14 @@ above are only the front door. Measured on this PR's base (`grep` over `Gum/` + 
   tool-DI `.Self` surface drops to ~90 (`StandardElementsManager`, `SelectedState`, `GumCommands`,
   `PluginManager`, `UnitConverter`, …).
 
-**Honest standing:** the *plugin ctor-drain* sub-workstream is mostly cleared (the easy tiers and
-all the heavies except `MainCodeOutputPlugin` and `MainEditorTabPlugin` are done; every drained heavy
-so far — Properties/TextureCoordinate/State/TreeView — turned out cycle-free, so the "cycle-prone
-tail" fear hasn't materialized; `MainEditorTabPlugin` with its ~12 deps remains the one genuinely
-large unknown). **Phase 2 as a whole is early-to-mid (~20–30%)**: the visible plugin entry points are
-getting injected, but the ~224 `Locator` fallback sites behind them are largely untouched. Don't read
-"most plugins drained" as "Phase 2 nearly done."
+**Honest standing:** the *plugin ctor-drain* sub-workstream is nearly cleared — only
+`MainEditorTabPlugin` remains. Every drained heavy so far —
+Properties/TextureCoordinate/State/TreeView/CodeOutput — turned out cycle-free, so the "cycle-prone
+tail" fear never materialized; `MainEditorTabPlugin` with its ~12 deps (and its external
+Tool/EditorTabPlugin_XNA home) is the one genuinely large unknown left. **Phase 2 as a whole is
+early-to-mid (~20–30%)**: the visible plugin entry points are getting injected, but the ~224
+`Locator` fallback sites behind them are largely untouched. Don't read "most plugins drained" as
+"Phase 2 nearly done."
 
 ## Definition of done — every change lands a *tested* unit
 

--- a/Gum/CodeOutputPlugin/MainCodeOutputPlugin.cs
+++ b/Gum/CodeOutputPlugin/MainCodeOutputPlugin.cs
@@ -72,31 +72,42 @@ public class MainCodeOutputPlugin : PluginBase
     #region Init/Startup
 
     [ImportingConstructor]
-    public MainCodeOutputPlugin(IGuiCommands guiCommands, IDialogService dialogService)
+    public MainCodeOutputPlugin(
+        IGuiCommands guiCommands,
+        IDialogService dialogService,
+        INameVerifier nameVerifier,
+        LocalizationService localizationService,
+        IProjectState projectState,
+        ITypeManager typeManager,
+        IOutputManager outputManager,
+        ISelectedState selectedState,
+        IRetryService retryService,
+        IMessenger messenger,
+        IFileCommands fileCommands)
     {
         codeOutputProjectSettings = new CodeOutputProjectSettings();
 
-        _nameVerifier = Locator.GetRequiredService<INameVerifier>();
-        _localizationService = Locator.GetRequiredService<LocalizationService>();
+        _nameVerifier = nameVerifier;
+        _localizationService = localizationService;
 
-        _projectState = Locator.GetRequiredService<IProjectState>();
+        _projectState = projectState;
         _projectDirectoryProvider = new ProjectStateDirectoryProvider(_projectState);
 
         _codeGenerationNameVerifier = new CodeGenerationNameVerifier(_nameVerifier);
         _elementSettingsManager = new CodeOutputElementSettingsManager(_projectDirectoryProvider);
-        var typeStringResolver = new ToolTypeStringResolver(Locator.GetRequiredService<ITypeManager>());
+        var typeStringResolver = new ToolTypeStringResolver(typeManager);
 
-        var codeGenLoggerForDetection = new ToolCodeGenLogger(Locator.GetRequiredService<IOutputManager>());
+        var codeGenLoggerForDetection = new ToolCodeGenLogger(outputManager);
         var syntaxVersionDetectionService = new SyntaxVersionDetectionService(codeGenLoggerForDetection);
 
         _codeGenerator = new CodeGenerator(_codeGenerationNameVerifier, _localizationService, _elementSettingsManager, _projectDirectoryProvider, typeStringResolver, syntaxVersionDetectionService);
 
         _codeGenerationFileLocationsService = new CodeGenerationFileLocationsService(_codeGenerator, _codeGenerationNameVerifier, _projectDirectoryProvider);
 
-        _selectedState = Locator.GetRequiredService<ISelectedState>();
+        _selectedState = selectedState;
 
         var customCodeGenerator = new CustomCodeGenerator(_codeGenerator, _codeGenerationNameVerifier);
-        _codeGenerationService = new CodeGenerationService(guiCommands, _codeGenerator, dialogService, customCodeGenerator, _codeGenerationNameVerifier, _projectDirectoryProvider, Locator.GetRequiredService<IRetryService>());
+        _codeGenerationService = new CodeGenerationService(guiCommands, _codeGenerator, dialogService, customCodeGenerator, _codeGenerationNameVerifier, _projectDirectoryProvider, retryService);
         _renameService = new RenameService(
             _codeGenerationService,
             _codeGenerator,
@@ -105,24 +116,24 @@ public class MainCodeOutputPlugin : PluginBase
             dialogService,
             _projectDirectoryProvider);
 
-        _messenger = Locator.GetRequiredService<IMessenger>();
-        _fileCommands = Locator.GetRequiredService<IFileCommands>();
+        _messenger = messenger;
+        _fileCommands = fileCommands;
 
-        var codeGenLogger = new ToolCodeGenLogger(Locator.GetRequiredService<IOutputManager>());
+        var codeGenLogger = new ToolCodeGenLogger(outputManager);
         _codeOutputProjectSettingsManager = new CodeOutputProjectSettingsManager(
             codeGenLogger, _projectDirectoryProvider);
 
         _parentSetLogic = new ParentSetLogic(_codeGenerator);
 
         _messenger.Register<RequestCodeGenerationMessage>(
-            this, 
+            this,
             (_, message) => HandleRequestCodeGeneration(message));
 
         viewModel = new ViewModels.CodeWindowViewModel(
-            Locator.GetRequiredService<IProjectState>(),
-            Locator.GetRequiredService<IFileCommands>(),
-            Locator.GetRequiredService<IDialogService>(),
-            Locator.GetRequiredService<IGuiCommands>(),
+            projectState,
+            fileCommands,
+            dialogService,
+            guiCommands,
             new CodeGenerationAutoSetupService());
     }
 
@@ -260,8 +271,7 @@ public class MainCodeOutputPlugin : PluginBase
         if (control == null) return;
         ///////////////////////End Early Out//////////////////
 
-        var projectState = Locator.GetRequiredService<IProjectState>();
-        if (element != null && projectState.GumProjectSave?.FullFileName != null)
+        if (element != null && _projectState.GumProjectSave?.FullFileName != null)
         {
             control.CodeOutputElementSettings = _elementSettingsManager.LoadOrCreateSettingsFor(element);
         }
@@ -490,9 +500,8 @@ public class MainCodeOutputPlugin : PluginBase
 
     private void HandleMainViewModelPropertyChanged(string? propertyName)
     {
-        var projectState = Locator.GetRequiredService<IProjectState>();
         /////////////////Early Out////////////////////
-        if(projectState.GumProjectSave == null)
+        if(_projectState.GumProjectSave == null)
         {
             return;
         }
@@ -549,9 +558,8 @@ public class MainCodeOutputPlugin : PluginBase
             {
                 if(viewModel.IsAllInProjectGenerating)
                 {
-                    var projectState = Locator.GetRequiredService<IProjectState>();
                     int numberOfElements = 0;
-                    foreach(var element in projectState.GumProjectSave.AllElements)
+                    foreach(var element in _projectState.GumProjectSave.AllElements)
                     {
                         if(element is StandardElementSave)
                         {
@@ -582,8 +590,7 @@ public class MainCodeOutputPlugin : PluginBase
 
     private void HandleGenerateAllCodeButtonClicked(bool showPopups = true)
     {
-        var projectState = Locator.GetRequiredService<IProjectState>();
-        var gumProject = projectState.GumProjectSave;
+        var gumProject = _projectState.GumProjectSave;
         foreach (var screen in gumProject.Screens)
         {
             var screenOutputSettings = _elementSettingsManager.LoadOrCreateSettingsFor(screen);

--- a/Gum/Plugins/PluginManager.cs
+++ b/Gum/Plugins/PluginManager.cs
@@ -21,6 +21,7 @@ using Gum.Wireframe;
 using Gum.ToolStates;
 using Gum.Managers;
 using Gum.Services;
+using Gum.Reflection;
 using Gum.ToolCommands;
 using RenderingLibrary;
 using System.Numerics;
@@ -910,6 +911,16 @@ public class PluginManager : IPluginManager
             batch.AddExportedValue<ElementTreeViewManager>(Locator.GetRequiredService<ElementTreeViewManager>());
             batch.AddExportedValue<IUserProjectSettingsManager>(Locator.GetRequiredService<IUserProjectSettingsManager>());
             batch.AddExportedValue<IOutputManager>(Locator.GetRequiredService<IOutputManager>());
+
+            // Heavy-tier ctor drain: MainCodeOutputPlugin. These feed the code-generation services it
+            // builds in its ctor (CodeGenerator/CodeGenerationService/etc.): INameVerifier and ITypeManager
+            // for name/type resolution, LocalizationService for generated-text handling, IRetryService for
+            // the file-write retry path. Its other ctor-time deps (IGuiCommands, IDialogService, IProjectState,
+            // IOutputManager, ISelectedState, IMessenger, IFileCommands) are bridged above.
+            batch.AddExportedValue<INameVerifier>(Locator.GetRequiredService<INameVerifier>());
+            batch.AddExportedValue<ITypeManager>(Locator.GetRequiredService<ITypeManager>());
+            batch.AddExportedValue<LocalizationService>(Locator.GetRequiredService<LocalizationService>());
+            batch.AddExportedValue<IRetryService>(Locator.GetRequiredService<IRetryService>());
 
 
             var container = new CompositionContainer(catalog);


### PR DESCRIPTION
## What

Finishes the Phase 2 static drain of `MainCodeOutputPlugin`. It already had a 2-param `[ImportingConstructor]` (`IGuiCommands`, `IDialogService`), but the ctor body still pulled the rest of its dependencies via `Locator.GetRequiredService<T>()`. Those ctor-time lookups are now constructor parameters (MEF-injected), and the plugin has **zero** `Locator` calls remaining.

## Changes

- **`MainCodeOutputPlugin.cs`** — added the remaining ctor-time deps as `[ImportingConstructor]` params: `INameVerifier`, `LocalizationService`, `IProjectState`, `ITypeManager`, `IOutputManager`, `ISelectedState`, `IRetryService`, `IMessenger`, `IFileCommands`. Dropped all ctor-body `Locator` calls.
- **`PluginManager.cs`** — added **4 new bridges** to `LoadPlugins` (`INameVerifier`, `ITypeManager`, `LocalizationService`, `IRetryService`) plus `using Gum.Reflection;`. `IOutputManager` was already bridged by #3327 and the other seven deps were already bridged, so only 4 new bridges were needed (not the ~5 originally estimated). Kept `using Gum.Services;` in the plugin — `IRetryService` lives in that namespace, so it's still required beyond `Locator`.
- **Drive-by cleanup** — replaced four method-body `Locator.GetRequiredService<IProjectState>()` re-resolutions with the already-injected `_projectState` field. `IProjectState` is a registered singleton, so this is behavior-preserving (distinct from #3325, where the kept method-body lookups had no existing injected field).
- **Ledger** (`Direction/ui-decoupling-plan.md`) — `MainCodeOutputPlugin` moves to *drained*; `MainEditorTabPlugin` is the one substantive plugin ctor-drain that remains.

## Verification

- `dotnet build GumFull.sln` — succeeds, 0 errors.
- All 11 ctor params are bridged into the MEF container, and all 4 newly-bridged types are registered singletons in `Builder.cs` — so the plugin composes at startup.
- Behavior-preserving DI plumbing; no unit test added (matches the precedent for the prior plugin ctor-drains — the compiler + DI container + manual smoke are the proof).
- Manual smoke (in VS): tool launches with the Code Output plugin enabled, the **Code** tab appears, and selecting an element shows generated code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
