### PR TITLE
Phase 2 (static drain): MainStateAnimationPlugin Locator ctor -> [ImportingConstructor]

### DIFF
--- a/Direction/ui-decoupling-plan.md
+++ b/Direction/ui-decoupling-plan.md
@@ -255,7 +255,7 @@ instead of the ctor still drains the same way — **relocate the assignment into
   already imported. **Kept `using Gum.Services;`** — `Locator` was *not* its only use: the plugin
   references `UiBaseFontSizeChangedMessage` (in `Gum.Services`) via `IRecipient<…>`. No accessibility
   bump needed — all three new bridges are public and registered in `Builder.cs`.
-- **this PR (2026-06-24)** — MainStateAnimationPlugin
+- **#3329 (2026-06-24)** — MainStateAnimationPlugin
   (`StateAnimationPlugin/MainStateAnimationPlugin.cs`) — was omitted from the triage below entirely.
   **Zero new bridges** — all six ctor-time deps (`ISelectedState`, `INameVerifier`, `IMessenger`,
   `IOutputManager`, `IFileWatchManager`, `IProjectState`) were already in the block (`INameVerifier`
@@ -276,7 +276,7 @@ instead of the ctor still drains the same way — **relocate the assignment into
   `ElementTreeViewManager` cycle was scouted and found benign), `MainCodeOutputPlugin` (#3328 —
   finished a partial conversion that already had a 2-param `[ImportingConstructor]`; only 4 new
   bridges, not the ~5 estimated, since #3327 already bridged `IOutputManager`; no cycle),
-  `MainStateAnimationPlugin` (this PR — never catalogued here; zero new bridges since all six ctor
+  `MainStateAnimationPlugin` (#3329 — never catalogued here; zero new bridges since all six ctor
   deps were already bridged, and its construction cycle was already broken by a VM factory closure).
   `MainEditorTabPlugin` is the one substantive plugin ctor-drain that remains.
 - **Scouted and left as out-of-scope** (no ctor/`StartUp` lookup to relocate — re-confirm before

--- a/Direction/ui-decoupling-plan.md
+++ b/Direction/ui-decoupling-plan.md
@@ -236,7 +236,7 @@ instead of the ctor still drains the same way — **relocate the assignment into
   No cycle-break and no accessibility bump needed — all five interfaces are public and registered in
   `Builder.cs`. Also fixed a stale bullet in the `refactoring-specialist` agent file that claimed
   plugins can't receive DI.
-- **this PR (2026-06-24)** — MainTreeViewPlugin (third heavy). **Three new bridges:** concrete
+- **#3327 (2026-06-24)** — MainTreeViewPlugin (third heavy). **Three new bridges:** concrete
   `ElementTreeViewManager` (the ~3k-line WinForms tree manager — registered concrete with no interface
   in `Builder.cs`, drained from a `.Self` static back in #3286), `IUserProjectSettingsManager`, and
   `IOutputManager`. Its other four ctor-time deps (`ISelectedState`, `IMessenger`, `IErrorChecker`,
@@ -255,6 +255,17 @@ instead of the ctor still drains the same way — **relocate the assignment into
   already imported. **Kept `using Gum.Services;`** — `Locator` was *not* its only use: the plugin
   references `UiBaseFontSizeChangedMessage` (in `Gum.Services`) via `IRecipient<…>`. No accessibility
   bump needed — all three new bridges are public and registered in `Builder.cs`.
+- **this PR (2026-06-24)** — MainStateAnimationPlugin
+  (`StateAnimationPlugin/MainStateAnimationPlugin.cs`) — was omitted from the triage below entirely.
+  **Zero new bridges** — all six ctor-time deps (`ISelectedState`, `INameVerifier`, `IMessenger`,
+  `IOutputManager`, `IFileWatchManager`, `IProjectState`) were already in the block (`INameVerifier`
+  arrived with #3328, the other five long-standing). Converted the parameterless ctor (six `Locator`
+  lines) to an `[ImportingConstructor]`. **No cycle-break needed:** the ctor inline-constructs
+  `AnimationCollectionViewModelManager` ↔ `ElementAnimationsViewModel` ↔ `RenameManager`, but that
+  construction cycle is already broken by the existing `_animationVmFactory` closure (it reads the
+  fields lazily at invoke-time, *after* both are assigned) — plain `new`, not a `Locator` call, so the
+  drain left it untouched. Dropped `using Gum.Services;` (Locator was its only use). No accessibility
+  bump — all six deps are public and registered in `Builder.cs`.
 
 ### Remaining plugin targets (triage ledger — prune as drained)
 
@@ -262,9 +273,11 @@ instead of the ctor still drains the same way — **relocate the assignment into
   self-injection cycle risk).** Remaining: `MainEditorTabPlugin` (~12; Tool/EditorTabPlugin_XNA —
   keep this one its own PR). Drained: `MainPropertiesWindowPlugin` (#3325),
   `MainTextureCoordinatePlugin` + `MainStatePlugin` (#3326), `MainTreeViewPlugin` (#3327 — the
-  `ElementTreeViewManager` cycle was scouted and found benign), `MainCodeOutputPlugin` (this PR —
+  `ElementTreeViewManager` cycle was scouted and found benign), `MainCodeOutputPlugin` (#3328 —
   finished a partial conversion that already had a 2-param `[ImportingConstructor]`; only 4 new
-  bridges, not the ~5 estimated, since #3327 already bridged `IOutputManager`; no cycle).
+  bridges, not the ~5 estimated, since #3327 already bridged `IOutputManager`; no cycle),
+  `MainStateAnimationPlugin` (this PR — never catalogued here; zero new bridges since all six ctor
+  deps were already bridged, and its construction cycle was already broken by a VM factory closure).
   `MainEditorTabPlugin` is the one substantive plugin ctor-drain that remains.
 - **Scouted and left as out-of-scope** (no ctor/`StartUp` lookup to relocate — re-confirm before
   re-touching): `MainBehaviorsPlugin` (already ctor-clean; only `Locator<PluginManager>()` in an event

--- a/Gum/StateAnimationPlugin/MainStateAnimationPlugin.cs
+++ b/Gum/StateAnimationPlugin/MainStateAnimationPlugin.cs
@@ -10,7 +10,6 @@ using Gum.Messages;
 using Gum.Plugins;
 using Gum.Plugins.BaseClasses;
 using Gum.Responses;
-using Gum.Services;
 using Gum.Services.Dialogs;
 using Gum.StateAnimation.SaveClasses;
 using Gum.ToolStates;
@@ -90,14 +89,21 @@ public class MainStateAnimationPlugin : PluginBase
 
     #region StartUp/ShutDown
 
-    public MainStateAnimationPlugin()
+    [ImportingConstructor]
+    public MainStateAnimationPlugin(
+        ISelectedState selectedState,
+        INameVerifier nameVerifier,
+        IMessenger messenger,
+        IOutputManager outputManager,
+        IFileWatchManager fileWatchManager,
+        IProjectState projectState)
     {
-        _selectedState = Locator.GetRequiredService<ISelectedState>();
-        _nameVerifier = Locator.GetRequiredService<INameVerifier>();
-        _messenger = Locator.GetRequiredService<IMessenger>();
-        _outputManager = Locator.GetRequiredService<IOutputManager>();
-        _fileWatchManager = Locator.GetRequiredService<IFileWatchManager>();
-        _projectState = Locator.GetRequiredService<IProjectState>();
+        _selectedState = selectedState;
+        _nameVerifier = nameVerifier;
+        _messenger = messenger;
+        _outputManager = outputManager;
+        _fileWatchManager = fileWatchManager;
+        _projectState = projectState;
 
         _animationFilePathService = new AnimationFilePathService(_selectedState);
         _duplicateService = new DuplicateService();


### PR DESCRIPTION
## Phase 2 (static drain): `MainStateAnimationPlugin`

Continues the plugin ctor-drain series (#3319–#3328). `MainStateAnimationPlugin` had a parameterless constructor that service-located six dependencies via `Locator.GetRequiredService<T>()`:

- `ISelectedState`
- `INameVerifier`
- `IMessenger`
- `IOutputManager`
- `IFileWatchManager`
- `IProjectState`

These are now relocated to an `[ImportingConstructor]` taking the six as parameters; the `Locator` calls are deleted.

### Bridges

**Zero new bridges needed.** All six services were already exported into the plugin MEF container in `PluginManager.LoadPlugins` (`INameVerifier` arrived with #3328; the other five are long-standing). Verified each is present — no duplicates added.

### Cycle

No cycle-break (`Lazy<T>`) needed. The ctor inline-constructs `AnimationCollectionViewModelManager` ↔ `ElementAnimationsViewModel` ↔ `RenameManager`, but that construction cycle is already broken by the existing `_animationVmFactory` closure, which reads the fields lazily at invoke-time (after both are assigned). That's plain `new`, not a `Locator` call, so the drain left it untouched.

### Other

- Dropped the now-unused `using Gum.Services;` (`Locator` was its only use in this file).
- Updated the Phase 2 ledger (`Direction/ui-decoupling-plan.md`): recorded this plugin as drained — it had been omitted from the triage entirely — and finalized the stale `this PR` labels left by the now-merged #3327/#3328.

### Verification

- `dotnet build GumFull.sln` — succeeds, 0 errors.
- Manual smoke: open Gum, select an element with animations, confirm the State Animation window still populates and behaves normally (the plugin must construct via MEF for this to work).

Scope is deliberately narrow: only ctor-time `Locator` lookups were relocated; no method-body lookups existed to touch. Does **not** touch `Tool/Tests/GumToolUnitTests/` (separate test work in flight).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
