### PR TITLE
Add headless MEF composition test for all tool plugins

### DIFF
--- a/.claude/skills/gum-tool-plugins/SKILL.md
+++ b/.claude/skills/gum-tool-plugins/SKILL.md
@@ -84,3 +84,9 @@ Visualization/rendering is handled by **external** plugin projects, not by Gum.c
 **VariableSet vs. VariableSetLate**: Two events for the same change. Use `VariableSet` to respond to a change; use `VariableSetLate` for cleanup/refresh that should run after all other plugins have responded.
 
 **Finding which plugin owns a feature**: Search `StartUp()` methods for the event subscription. E.g., to find what handles `VariableSet`, grep for `VariableSet +=` in `InternalPlugins/`. The subscribing plugin is the owner.
+
+## Composition is guarded by a headless test
+
+`AllPluginsCompositionTests` (`Tool/Tests/GumToolUnitTests/Plugins/`) composes **every** plugin through MEF exactly as `PluginManager.LoadPlugins` does — the automated replacement for manually launching Gum to confirm plugins load. A missing/typo'd bridge or a bad `[ImportingConstructor]` signature fails it as a red `CompositionException`.
+
+**When draining a plugin to `[ImportingConstructor]`:** if the drain adds a *new* service to the `batch.AddExportedValue<T>(...)` list in `LoadPlugins`, mirror that type into `PluginBridgedServiceTypes.All` (same test folder) — it is a hand-maintained duplicate of that list and the test goes red otherwise. Reusing services already in the list needs no test change. (`ServiceProviderCompositionSpikeTests` resolves the same set from the real `Builder.cs` container, catching DI cycles / missing registrations.) A follow-up to extract an internal `ComposePlugins(...)` from `LoadPlugins` will delete the duplicate list.

--- a/.claude/skills/gum-unit-tests/SKILL.md
+++ b/.claude/skills/gum-unit-tests/SKILL.md
@@ -49,6 +49,15 @@ xUnit's runner is **MTA**, but WPF `FrameworkElement`s (`MenuItem`, `Menu`, `Com
 
 **Verify the real construction blocker empirically before designing around an assumed one.** A quick throwaway probe (construct the object, see what actually throws) beats reasoning: e.g. `BitmapFrame` PNG decode and most non-control VM constructors run fine on MTA, so the blocker is usually the WPF control, not the singleton/resource you suspected.
 
+## Plugin/DI composition tests (GumToolUnitTests)
+
+`AllPluginsCompositionTests` composes **every** tool plugin through MEF the way `PluginManager.LoadPlugins` does, and `ServiceProviderCompositionSpikeTests` resolves the bridged services from the real `Builder.cs` container. Two reusable techniques live there:
+
+- **Stub anything headlessly without running its constructor.** `RuntimeHelpers.GetUninitializedObject(type)` fabricates a concrete instance (even a heavy WinForms/WPF host singleton) with no ctor call; a Moq proxy covers interfaces/abstract types. Composition/DI only needs the dependency to *exist* as the right type, so this avoids STA/graphics setup entirely. (Run the composition on `RunOnSta` regardless — some plugin *constructors* still touch WPF.)
+- **Satisfy not-yet-drained plugins' direct `Locator.GetRequiredService<T>()` ctor calls** with a catch-all `IServiceProvider` registered via `Locator.Register(...)`; remove it in `Dispose` (Locator has no `Unregister` — `RenameManagerTests` shows the reflection teardown).
+
+Keep the MEF batch an **explicit** mirror of `LoadPlugins` (not a catch-all export provider) so a plugin gaining an unbridged `[ImportingConstructor]` dependency turns the test red — that regression signal is the whole point. See the `gum-tool-plugins` skill for keeping `PluginBridgedServiceTypes.All` in sync during drains.
+
 ## Integration Tests (MonoGameGum.IntegrationTests)
 
 Use this project for anything requiring a real `GraphicsDevice`. Each test creates a minimal nested `Game` subclass, calls `game.RunOneFrame()` to trigger `Initialize`, then asserts. See `Tests/MonoGameGum.IntegrationTests/MonoGameGum/GumServiceUnitTests.cs` for the established pattern. Always call `LoaderManager.Self?.DisposeAndClear()` in the `Game.Dispose` override to prevent state leaking across tests via the singleton.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,8 @@ The Gum tool has been progressively migrated to constructor-injected services (`
 
 There is a dedicated later phase for draining the remaining `.Self` singletons wholesale, but if one is **blocking the task in front of you** — typically because the class can't be unit-tested until it takes its dependencies via the constructor — drain it on the spot in the same PR rather than deferring or asking about phase timing. See the `refactoring-direction` skill for the judgment call and for breaking the DI construction cycle that the `Self`+`Initialize`+`Locator` pattern usually hides (inject the back-edge dependency as `Lazy<T>`).
 
+When draining a **plugin** ctor (`Locator`/`.Self` → `[ImportingConstructor]`), `AllPluginsCompositionTests` guards that every plugin still composes via MEF. If the drain bridges a *new* service in `PluginManager.LoadPlugins`, mirror that type into `PluginBridgedServiceTypes.All` or the test goes red — see the `gum-tool-plugins` skill.
+
 **`ObjectFinder.Self` is the exception.** It is intentionally still a static singleton across the entire codebase (tool, runtimes, tests). An `IObjectFinder` interface does exist and is even DI-registered (`Builder.cs` binds it to the `ObjectFinder.Self` instance), but the ~476 `.Self` call sites are intentionally left as-is: replacing them wholesale is a project-wide refactor — do not attempt it as drive-by cleanup. Calls to `ObjectFinder.Self.GetBaseElements(...)`, `ObjectFinder.Self.GetDefaultChildName(...)`, etc. are acceptable in any context.
 
 ## Searching C# Code

--- a/Tool/Tests/GumToolUnitTests/GumToolUnitTests.csproj
+++ b/Tool/Tests/GumToolUnitTests/GumToolUnitTests.csproj
@@ -27,10 +27,13 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\Gum\CodeOutputPlugin\CodeOutputPlugin.csproj" />
+    <ProjectReference Include="..\..\..\Gum\EventOutputPlugin\EventOutputPlugin.csproj" />
     <ProjectReference Include="..\..\..\Gum\Gum.csproj" />
     <ProjectReference Include="..\..\..\Gum\GumFormsPlugin\GumFormsPlugin.csproj" />
     <ProjectReference Include="..\..\..\Gum\ImportFromGumxPlugin\ImportFromGumxPlugin.csproj" />
+    <ProjectReference Include="..\..\..\Gum\PerformanceMeasurementPlugin\PerformanceMeasurementPlugin.csproj" />
     <ProjectReference Include="..\..\..\Gum\StateAnimationPlugin\StateAnimationPlugin.csproj" />
+    <ProjectReference Include="..\..\..\Gum\SvgPlugin\SkiaPlugin.csproj" />
     <ProjectReference Include="..\..\..\Gum\TextureCoordinateSelectionPlugin\TextureCoordinateSelectionPlugin.csproj" />
     <ProjectReference Include="..\..\EditorTabPlugin_XNA\EditorTabPlugin_XNA.csproj" />
   </ItemGroup>

--- a/Tool/Tests/GumToolUnitTests/Plugins/AllPluginsCompositionTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/AllPluginsCompositionTests.cs
@@ -1,0 +1,231 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.ComponentModel.Composition;
+using System.ComponentModel.Composition.Hosting;
+using System.ComponentModel.Composition.Primitives;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using Gum.Plugins.BaseClasses;
+using Gum.Services;
+using Moq;
+using Shouldly;
+
+namespace GumToolUnitTests.Plugins;
+
+/// <summary>
+/// Headless guard for the Phase 2 plugin-drain work: composes every Gum tool plugin through MEF the
+/// same way <see cref="Gum.Plugins.PluginManager"/> does at startup, and fails if any plugin cannot be
+/// constructed. This is the automated replacement for the manual "launch Gum and check the plugin tab"
+/// check — a missing/typo'd bridge in <c>LoadPlugins</c> or a bad <c>[ImportingConstructor]</c> signature
+/// surfaces here as a red <see cref="CompositionException"/> instead of a silent "Error loading plugins".
+///
+/// Scales up the single-plugin precedent in <see cref="PluginBaseCompositionTests"/> to the whole plugin
+/// catalog. Two stub seams stand in for the real DI container:
+///  - the MEF <see cref="CompositionBatch"/> is the explicit mirror of every service
+///    <c>LoadPlugins</c> bridges (<see cref="PluginBridgedServiceTypes"/>). Keeping it explicit (rather than a
+///    catch-all export provider) is what preserves the regression signal: a plugin that gains an
+///    <c>[ImportingConstructor]</c> dependency not present in this list — i.e. one a future drain forgot
+///    to bridge in <c>LoadPlugins</c> — turns the test red.
+///  - a catch-all <see cref="StubServiceProvider"/> registered with the <see cref="Locator"/> satisfies the
+///    direct <c>Locator.GetRequiredService&lt;T&gt;()</c> calls that not-yet-drained plugins (e.g.
+///    MainStateAnimationPlugin, MainEditorTabPlugin) still make from their constructors.
+/// </summary>
+public class AllPluginsCompositionTests : BaseTestClass
+{
+    /// <summary>
+    /// One anchor type per assembly that contributes <c>[Export(typeof(PluginBase))]</c> plugins. The Gum
+    /// executable holds the internal plugins; the rest ship as external plugin DLLs that the running tool
+    /// loads from its Plugins folder. Referencing a type forces the assembly to load so its
+    /// <see cref="AssemblyCatalog"/> sees every plugin.
+    /// </summary>
+    // global:: qualifiers are required because this test's own GumToolUnitTests.Plugins.* sub-namespaces
+    // (other plugin test folders) otherwise shadow the plugins' root namespaces. FormsFileService anchors
+    // GumFormsPlugin because its MainGumFormsPlugin entry type is internal and the assembly does not expose
+    // internals to this test project.
+    private static readonly Assembly[] PluginAssemblies =
+    {
+        typeof(Gum.Plugins.PluginManager).Assembly,
+        typeof(global::CodeOutputPlugin.MainCodeOutputPlugin).Assembly,
+        typeof(global::EventOutputPlugin.MainEventOutputPlugin).Assembly,
+        typeof(global::GumFormsPlugin.Services.FormsFileService).Assembly,
+        typeof(global::ImportFromGumxPlugin.MainImportFromGumxPlugin).Assembly,
+        typeof(global::PerformanceMeasurementPlugin.MainPlugin).Assembly,
+        typeof(global::SkiaPlugin.MainSkiaPlugin).Assembly,
+        typeof(global::StateAnimationPlugin.MainStateAnimationPlugin).Assembly,
+        typeof(global::TextureCoordinateSelectionPlugin.MainTextureCoordinatePlugin).Assembly,
+        typeof(Gum.Plugins.InternalPlugins.EditorTab.MainEditorTabPlugin).Assembly,
+    };
+
+    private static readonly MethodInfo AddExportedValueMethod = typeof(AttributedModelServices)
+        .GetMethods(BindingFlags.Public | BindingFlags.Static)
+        .Single(m => m.Name == nameof(AttributedModelServices.AddExportedValue)
+            && m.IsGenericMethodDefinition
+            && m.GetParameters().Length == 2);
+
+    private readonly StubServiceProvider _locatorStubs = new();
+
+    public AllPluginsCompositionTests()
+    {
+        // Not-yet-drained plugins still resolve services from the locator in their constructors.
+        Locator.Register(_locatorStubs);
+    }
+
+    [Fact]
+    public void AllPlugins_ComposeWithoutError()
+    {
+        // Plugin constructors (e.g. MainHotkeyPlugin building its HotkeyView) touch WPF, which requires STA;
+        // xUnit's runner is MTA.
+        RunOnSta(() =>
+        {
+            List<Type> expectedPluginTypes = DiscoverPluginExportTypes();
+            // Sanity check that the catalog is actually populated — guards against a future refactor that
+            // silently drops every plugin and leaves an all-green "0 == 0" assertion.
+            expectedPluginTypes.Count.ShouldBeGreaterThan(20);
+
+            using CompositionContainer container = BuildPluginContainer();
+
+            // Forcing the values composes every plugin; an unsatisfiable import or a throwing constructor
+            // raises a CompositionException here, which is exactly the failure this test exists to catch.
+            PluginBase[] composedPlugins = container.GetExportedValues<PluginBase>().ToArray();
+
+            HashSet<Type> composedTypes = composedPlugins.Select(plugin => plugin.GetType()).ToHashSet();
+            foreach (Type expected in expectedPluginTypes)
+            {
+                composedTypes.ShouldContain(expected);
+            }
+            composedPlugins.Length.ShouldBe(expectedPluginTypes.Count);
+        });
+    }
+
+    private CompositionContainer BuildPluginContainer()
+    {
+        AggregateCatalog catalog = new AggregateCatalog();
+        foreach (Assembly assembly in PluginAssemblies)
+        {
+            catalog.Catalogs.Add(new AssemblyCatalog(assembly));
+        }
+
+        CompositionContainer container = new CompositionContainer(catalog);
+
+        CompositionBatch batch = new CompositionBatch();
+        foreach (Type serviceType in PluginBridgedServiceTypes.All)
+        {
+            AddExportedValue(batch, serviceType, _locatorStubs.GetService(serviceType)!);
+        }
+        container.Compose(batch);
+
+        return container;
+    }
+
+    private static void AddExportedValue(CompositionBatch batch, Type contractType, object value)
+    {
+        // Equivalent to batch.AddExportedValue<contractType>(value); done reflectively so the bridged list
+        // can be data-driven. The generic argument sets the export's type identity so it matches the
+        // corresponding typed [Import]/[ImportingConstructor].
+        AddExportedValueMethod.MakeGenericMethod(contractType).Invoke(null, new[] { batch, value });
+    }
+
+    private static List<Type> DiscoverPluginExportTypes()
+    {
+        List<Type> result = new List<Type>();
+        foreach (Assembly assembly in PluginAssemblies)
+        {
+            foreach (Type type in GetLoadableTypes(assembly))
+            {
+                bool exportsPluginBase = type
+                    .GetCustomAttributes<ExportAttribute>(inherit: false)
+                    .Any(export => export.ContractType == typeof(PluginBase));
+                if (exportsPluginBase)
+                {
+                    result.Add(type);
+                }
+            }
+        }
+        return result;
+    }
+
+    private static IEnumerable<Type> GetLoadableTypes(Assembly assembly)
+    {
+        // Mirrors PluginManager.CreateResilientCatalog: a single unloadable type must not abort discovery.
+        try
+        {
+            return assembly.GetTypes();
+        }
+        catch (ReflectionTypeLoadException ex)
+        {
+            return ex.Types.OfType<Type>();
+        }
+    }
+
+    /// <summary>
+    /// Hands every requested service a throwaway stand-in: a Moq proxy for interfaces/abstract classes, and
+    /// an uninitialized instance for concrete classes. Constructors are never run, so even the heavy
+    /// WinForms/WPF-coupled concretes (ElementTreeViewManager, PropertyGridManager, ...) are produced
+    /// without touching a real graphics/UI stack. Composition only needs each dependency to exist as the
+    /// right type; the plugins under test store them and use them later in StartUp, not during construction.
+    /// </summary>
+    private sealed class StubServiceProvider : IServiceProvider
+    {
+        private readonly Dictionary<Type, object> _cache = new();
+        private readonly object _gate = new();
+
+        public object? GetService(Type serviceType)
+        {
+            lock (_gate)
+            {
+                if (!_cache.TryGetValue(serviceType, out object? stub))
+                {
+                    stub = CreateStub(serviceType);
+                    _cache[serviceType] = stub;
+                }
+                return stub;
+            }
+        }
+
+        private static object CreateStub(Type serviceType)
+        {
+            if (serviceType.IsInterface || serviceType.IsAbstract)
+            {
+                Mock mock = (Mock)Activator.CreateInstance(typeof(Mock<>).MakeGenericType(serviceType))!;
+                return mock.Object;
+            }
+
+            return RuntimeHelpers.GetUninitializedObject(serviceType);
+        }
+    }
+
+    /// <summary>
+    /// WPF controls created in some plugin constructors require an STA thread; xUnit's default runner is MTA.
+    /// Copied from RenameManagerTests/MenuStripManagerTests — there is no shared base for this helper.
+    /// </summary>
+    private static void RunOnSta(Action action)
+    {
+        Exception? caught = null;
+        Thread thread = new Thread(() =>
+        {
+            try { action(); }
+            catch (Exception ex) { caught = ex; }
+        });
+        thread.SetApartmentState(ApartmentState.STA);
+        thread.Start();
+        thread.Join();
+        if (caught != null)
+        {
+            throw new Exception("Test body threw on the STA thread.", caught);
+        }
+    }
+
+    public override void Dispose()
+    {
+        // Locator has no Unregister; remove our provider so the global static does not leak into other tests
+        // (same teardown RenameManagerTests uses).
+        PropertyInfo prop = typeof(Locator).GetProperty(
+            "ServiceProviders", BindingFlags.NonPublic | BindingFlags.Static)!;
+        List<IServiceProvider> providers = (List<IServiceProvider>)prop.GetValue(null)!;
+        providers.Remove(_locatorStubs);
+
+        base.Dispose();
+    }
+}

--- a/Tool/Tests/GumToolUnitTests/Plugins/PluginBridgedServiceTypes.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/PluginBridgedServiceTypes.cs
@@ -1,0 +1,92 @@
+// Usings mirror Gum.Plugins.PluginManager so the bridged-service typeofs below resolve against the same
+// symbols PluginManager.LoadPlugins uses.
+using System;
+using Gum.Wireframe;
+using Gum.ToolStates;
+using Gum.Managers;
+using Gum.Services;
+using Gum.Reflection;
+using Gum.ToolCommands;
+using Gum.Commands;
+using CommunityToolkit.Mvvm.Messaging;
+using Gum.Services.Dialogs;
+using Gum.Undo;
+using Gum.Localization;
+using Gum.Services.Fonts;
+using Gum.Plugins.ImportPlugin.Manager;
+using Gum.Logic;
+using Gum.Logic.FileWatch;
+using Gum.Controls;
+using Gum.Plugins.InternalPlugins.VariableGrid;
+using Gum.Plugins.InternalPlugins.Hotkey.ViewModels;
+using Gum.Plugins.InternalPlugins.TreeView;
+using Gum.PropertyGridHelpers;
+
+namespace GumToolUnitTests.Plugins;
+
+/// <summary>
+/// The full set of services <see cref="Gum.Plugins.PluginManager"/>.LoadPlugins bridges into the plugin
+/// <c>CompositionContainer</c>, in source order. Single source of truth shared by
+/// <see cref="AllPluginsCompositionTests"/> (which supplies stubs for them to MEF) and
+/// <see cref="ServiceProviderCompositionSpikeTests"/> (which resolves them from the real container).
+///
+/// This hand-duplicates the list inside <c>LoadPlugins</c>. The intended end state is to extract an internal
+/// <c>ComposePlugins(...)</c> from <c>LoadPlugins</c> so both the production code and these tests share one
+/// list and this array disappears — tracked as a FOLLOW-UP PR. Until then, a drain that bridges a new
+/// service in <c>LoadPlugins</c> must add it here too, or the composition test goes red.
+/// </summary>
+internal static class PluginBridgedServiceTypes
+{
+    internal static readonly Type[] All =
+    {
+        typeof(ISelectedState),
+        typeof(IElementCommands),
+        typeof(IUndoManager),
+        typeof(IProjectManager),
+
+        typeof(IGuiCommands),
+        typeof(IFileCommands),
+        typeof(ITabManager),
+        typeof(MenuStripManager),
+        typeof(IDialogService),
+
+        typeof(IWireframeCommands),
+        typeof(IFontManager),
+        typeof(IProjectState),
+        typeof(IImportLogic),
+        typeof(IFileWatchManager),
+
+        typeof(InheritanceLogic),
+        typeof(IFavoriteComponentManager),
+
+        typeof(MainPanelViewModel),
+        typeof(PropertyGridManager),
+        typeof(IVariableReferenceLogic),
+        typeof(IErrorChecker),
+        typeof(IMessenger),
+        typeof(FileWatchLogic),
+        typeof(PeriodicUiTimer),
+
+        typeof(IDeleteLogic),
+        typeof(HotkeyViewModel),
+        typeof(MainOutputViewModel),
+
+        typeof(IDispatcher),
+        typeof(IWireframeObjectManager),
+
+        typeof(ISetVariableLogic),
+        typeof(IHotkeyManager),
+        typeof(IEditCommands),
+        typeof(ICopyPasteLogic),
+        typeof(IVariableInCategoryPropagationLogic),
+
+        typeof(ElementTreeViewManager),
+        typeof(IUserProjectSettingsManager),
+        typeof(IOutputManager),
+
+        typeof(INameVerifier),
+        typeof(ITypeManager),
+        typeof(LocalizationService),
+        typeof(IRetryService),
+    };
+}

--- a/Tool/Tests/GumToolUnitTests/Plugins/ServiceProviderCompositionSpikeTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/ServiceProviderCompositionSpikeTests.cs
@@ -1,0 +1,41 @@
+using System;
+using Gum.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+
+namespace GumToolUnitTests.Plugins;
+
+/// <summary>
+/// Companion to <see cref="AllPluginsCompositionTests"/> that exercises the OTHER half of plugin startup:
+/// the real dependency-injection graph in <c>Gum.Services.Builder.cs</c> (<c>AddGum</c>).
+/// <see cref="AllPluginsCompositionTests"/> stubs the bridged services so it can run headlessly; this builds
+/// them for real and resolves the full <see cref="PluginBridgedServiceTypes"/> set, so a missing
+/// registration or a construction cycle introduced by an upcoming service drain fails here rather than at
+/// the tool's startup.
+///
+/// Spike result (the headless-boundary finding the task asked to establish and document): the entire
+/// bridged set resolves on the MTA test thread with no STA thread and no live WPF <c>Application</c> —
+/// including the WinForms/WPF-coupled host singletons (<c>ElementTreeViewManager</c>,
+/// <c>PropertyGridManager</c>, <c>MainPanelViewModel</c>, <c>MainOutputViewModel</c>, <c>HotkeyViewModel</c>),
+/// because each defers its control creation to the <c>Initialize()</c>/<c>StartUp()</c> second stage rather
+/// than its DI constructor. The STA boundary therefore sits ABOVE this set, at the genuine WPF roots
+/// (<c>MainWindow</c>, theming/dispatcher usage) which this spike intentionally does not resolve. If a future
+/// drain makes a bridged service require STA/WPF at construction time, this test turns red — which is the
+/// correct signal, since it would also break headless tooling (CLI, codegen) and CI.
+/// </summary>
+public class ServiceProviderCompositionSpikeTests
+{
+    [Fact]
+    public void RealContainer_ResolvesEveryBridgedService()
+    {
+        using IHost host = GumBuilder.CreateHostBuilder().Build();
+        IServiceProvider serviceProvider = host.Services;
+
+        foreach (Type serviceType in PluginBridgedServiceTypes.All)
+        {
+            serviceProvider.GetService(serviceType)
+                .ShouldNotBeNull($"{serviceType.Name} should resolve from the real Builder.cs container");
+        }
+    }
+}


### PR DESCRIPTION
## What

Automated replacement for the manual *"launch Gum and check the plugin tab"* gate used to verify the Phase 2 plugin-drain PRs. Two new headless tests in `GumToolUnitTests`:

- **`AllPluginsCompositionTests`** — composes **every** `[Export(typeof(PluginBase))]` plugin through MEF the same way `PluginManager.LoadPlugins` does at startup, and fails if any plugin can't be constructed. A missing/typo'd bridge in `LoadPlugins` or a bad `[ImportingConstructor]` signature now surfaces as a red `CompositionException` instead of the silent *"Error loading plugins / zero plugins"* a human currently eyeballs.
- **`ServiceProviderCompositionSpikeTests`** — exercises the *other* half of startup: builds the real `Builder.cs` DI graph (`AddGum` → `BuildServiceProvider`) and resolves the full bridged-service set, catching DI construction cycles / missing registrations for the upcoming service drains.

Generalizes the single-plugin precedent in `PluginBaseCompositionTests` (`TypeCatalog` + one mocked service) up to the whole catalog (`AssemblyCatalog` per plugin assembly + the full bridged set).

## How it stays a real guard, not a vacuous green

- The MEF `CompositionBatch` is the **explicit** mirror of every service `LoadPlugins` bridges (`PluginBridgedServiceTypes`, the single source of truth shared by both tests). Kept explicit rather than a catch-all export provider **on purpose**: a plugin that gains an `[ImportingConstructor]` dependency a drain forgot to bridge in `LoadPlugins` turns the test red. Verified by temporarily removing one bridge (`IDialogService`) and confirming the test goes red at the composition call.
- A catch-all `StubServiceProvider` registered with the `Locator` satisfies the direct `Locator.GetRequiredService<T>()` calls that **not-yet-drained** plugins (e.g. `MainStateAnimationPlugin`, `MainEditorTabPlugin`) still make from their constructors. Concrete stubs use `RuntimeHelpers.GetUninitializedObject` so no heavy/STA WinForms/WPF constructor ever runs — the composition only needs each dependency to *exist* as the right type.
- Composition runs on an STA thread (`RunOnSta`, copied from `RenameManagerTests`) because some plugin constructors touch WPF.

## Spike finding (the documented headless boundary)

The task anticipated STA/WinForms construction might block resolving the real container. It does **not**: the entire bridged set resolves headlessly on the MTA test thread — including the WinForms/WPF-coupled host singletons (`ElementTreeViewManager`, `PropertyGridManager`, `MainPanelViewModel`, `MainOutputViewModel`, `HotkeyViewModel`) — because each defers control creation to its `Initialize()`/`StartUp()` second stage rather than its DI constructor. The STA boundary therefore sits *above* this set, at the genuine WPF roots (`MainWindow`), which the spike intentionally does not resolve. If a future drain makes a bridged service require STA/WPF at construction time, the spike turns red — the correct signal, since that would also break headless tooling (CLI/codegen) and CI.

## Scope notes

- Adds `ProjectReference`s for `SkiaPlugin` (the SvgPlugin project), `EventOutputPlugin`, **and** `PerformanceMeasurementPlugin`. The brief named only the first two; `PerformanceMeasurementPlugin` was added because it has the same `Plugins/`-folder post-build copy as the shipped externals, so the running tool loads it too — leaving it out would be a real coverage gap in a *"compose ALL plugins"* guard.
- All changes are confined to `Tool/Tests/GumToolUnitTests/` and its `.csproj`. `Gum/Plugins/PluginManager.cs` and `Direction/ui-decoupling-plan.md` are intentionally untouched (edited concurrently elsewhere).
- **FOLLOW-UP (separate PR):** extract an internal `ComposePlugins(...)` from `LoadPlugins` so the test reuses the real bridge list and `PluginBridgedServiceTypes` can be deleted. Tracked in the class docs; doing it here would touch `PluginManager.cs`, which is out of bounds for this PR.

## Testing

- `AllPluginsCompositionTests` + `ServiceProviderCompositionSpikeTests`: green (incl. the deliberate red-check of a removed bridge).
- Full `GumToolUnitTests` suite: **982 passed, 4 skipped, 0 failed** — no cross-test pollution from the `Locator`/real-container global state.
- No new compiler warnings in the added files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
