### PR TITLE
Phase 2 (static drain): MainEditorTabPlugin Locator ctor -> [ImportingConstructor]

### DIFF
--- a/Direction/ui-decoupling-plan.md
+++ b/Direction/ui-decoupling-plan.md
@@ -151,7 +151,9 @@ line): `ISelectedState`, `IElementCommands`, `IUndoManager`, `IProjectManager`, 
 `IErrorChecker`, `IMessenger`, `FileWatchLogic`, `PeriodicUiTimer`, `IDeleteLogic`, `HotkeyViewModel`,
 `MainOutputViewModel`, `IDispatcher`, `IWireframeObjectManager`, `ISetVariableLogic`, `IHotkeyManager`,
 `IEditCommands`, `ICopyPasteLogic`, `IVariableInCategoryPropagationLogic`, `ElementTreeViewManager`,
-`IUserProjectSettingsManager`, `IOutputManager`.
+`IUserProjectSettingsManager`, `IOutputManager`, `INameVerifier`, `ITypeManager`, `LocalizationService`,
+`IRetryService` (these four from #3328), `IReorderLogic`, `FileLocations`, `IUiSettingsService`,
+`IThemingService`, `IDragDropManager`, `WireframeCommands` (these six from #3330).
 
 ### Shortcut: batch by bridge-cost — added 2026-06-23
 
@@ -266,19 +268,42 @@ instead of the ctor still drains the same way — **relocate the assignment into
   fields lazily at invoke-time, *after* both are assigned) — plain `new`, not a `Locator` call, so the
   drain left it untouched. Dropped `using Gum.Services;` (Locator was its only use). No accessibility
   bump — all six deps are public and registered in `Builder.cs`.
+- **#3330 (2026-06-24)** — MainEditorTabPlugin
+  (`Tool/EditorTabPlugin_XNA/MainEditorTabPlugin.cs` — the external, central editor/wireframe plugin
+  and the last substantive plugin ctor-drain). Converted the parameterless ctor (~22 `Locator` lookups)
+  to a 21-param `[ImportingConstructor]`. **Six new bridges:** interfaces `IReorderLogic`,
+  `IUiSettingsService`, `IThemingService`, `IDragDropManager`; concretes `FileLocations` and
+  `WireframeCommands`. The concrete `WireframeCommands` is distinct from the already-bridged
+  `IWireframeCommands` interface (resolves to the same singleton): the field is passed to
+  `BackgroundManager`, whose ctor takes the *concrete* type, and `BackgroundManager.cs` was outside this
+  PR's file boundary — so the "otherwise bridge concrete" branch applied instead of switching the field
+  to the interface. Four service types were resolved twice in the old ctor (`IWireframeObjectManager`,
+  `IElementCommands`, `ISetVariableLogic`, `IMessenger`) — injected once and reused (the inline
+  `EditingManager`/`SelectionManager`/`BackgroundManager` constructions now take the injected
+  fields/params). `IMessenger` is param-only (no field), used twice — `BackgroundManager` arg +
+  `messenger.RegisterAll(this)`. One new `using` in `PluginManager.cs` (`Gum.Dialogs` for
+  `IThemingService`); the other five bridge namespaces were already imported. **Sanctioned drive-by:**
+  the method-body `Locator<IThemingService>()` in `HandleXnaInitialized` now reuses the injected
+  `_themingService` field. **Kept in the body (not drain targets):** the four `Locator<PluginManager>()`
+  self-injection calls (ctor + three event handlers — the host-into-its-own-plugin cycle smell) and the
+  StartUp `Locator<IFontManager>()` (StartUp-time, not a ctor dep). `using Gum.Services;` stays (still
+  needed for `Locator` and `UiBaseFontSizeChangedMessage`). **No cycle / no `Lazy<T>`:** all 21 injected
+  deps are host-container singletons built before `LoadPlugins`, so MEF only constructs the plugin from
+  pre-built deps — same benign topology scouted in #3327. No accessibility bump — all 21 deps are public
+  and registered in `Builder.cs`. **This finishes the plugin ctor-drain pass.**
 
 ### Remaining plugin targets (triage ledger — prune as drained)
 
-- **Heavies (own PR each — large ctors and/or `Locator.GetRequiredService<PluginManager>()`
-  self-injection cycle risk).** Remaining: `MainEditorTabPlugin` (~12; Tool/EditorTabPlugin_XNA —
-  keep this one its own PR). Drained: `MainPropertiesWindowPlugin` (#3325),
-  `MainTextureCoordinatePlugin` + `MainStatePlugin` (#3326), `MainTreeViewPlugin` (#3327 — the
-  `ElementTreeViewManager` cycle was scouted and found benign), `MainCodeOutputPlugin` (#3328 —
-  finished a partial conversion that already had a 2-param `[ImportingConstructor]`; only 4 new
-  bridges, not the ~5 estimated, since #3327 already bridged `IOutputManager`; no cycle),
-  `MainStateAnimationPlugin` (#3329 — never catalogued here; zero new bridges since all six ctor
-  deps were already bridged, and its construction cycle was already broken by a VM factory closure).
-  `MainEditorTabPlugin` is the one substantive plugin ctor-drain that remains.
+- **Heavies (own PR each).** ✅ **All drained — the plugin ctor-drain pass is complete.**
+  `MainPropertiesWindowPlugin` (#3325), `MainTextureCoordinatePlugin` + `MainStatePlugin` (#3326),
+  `MainTreeViewPlugin` (#3327 — the `ElementTreeViewManager` cycle was scouted and found benign),
+  `MainCodeOutputPlugin` (#3328 — finished a partial conversion that already had a 2-param
+  `[ImportingConstructor]`; only 4 new bridges, not the ~5 estimated, since #3327 already bridged
+  `IOutputManager`; no cycle), `MainStateAnimationPlugin` (#3329 — never catalogued here; zero new
+  bridges since all six ctor deps were already bridged, and its construction cycle was already broken by
+  a VM factory closure), `MainEditorTabPlugin` (#3330 — the last and largest; 21-param ctor, six new
+  bridges, no cycle). Every drained heavy turned out cycle-free, so the "cycle-prone tail" fear never
+  materialized.
 - **Scouted and left as out-of-scope** (no ctor/`StartUp` lookup to relocate — re-confirm before
   re-touching): `MainBehaviorsPlugin` (already ctor-clean; only `Locator<PluginManager>()` in an event
   handler — the cycle smell) and `MainRecentFilesPlugin` (only method-body/event-handler
@@ -308,14 +333,16 @@ above are only the front door. Measured on this PR's base (`grep` over `Gum/` + 
   tool-DI `.Self` surface drops to ~90 (`StandardElementsManager`, `SelectedState`, `GumCommands`,
   `PluginManager`, `UnitConverter`, …).
 
-**Honest standing:** the *plugin ctor-drain* sub-workstream is nearly cleared — only
-`MainEditorTabPlugin` remains. Every drained heavy so far —
-Properties/TextureCoordinate/State/TreeView/CodeOutput — turned out cycle-free, so the "cycle-prone
-tail" fear never materialized; `MainEditorTabPlugin` with its ~12 deps (and its external
-Tool/EditorTabPlugin_XNA home) is the one genuinely large unknown left. **Phase 2 as a whole is
-early-to-mid (~20–30%)**: the visible plugin entry points are getting injected, but the ~224
-`Locator` fallback sites behind them are largely untouched. Don't read "most plugins drained" as
-"Phase 2 nearly done."
+**Honest standing:** the *plugin ctor-drain* sub-workstream is **complete** — every substantive
+plugin ctor (Properties/TextureCoordinate/State/TreeView/CodeOutput/StateAnimation/EditorTab) now
+takes its ctor-time deps via `[ImportingConstructor]`, and all turned out cycle-free, so the
+"cycle-prone tail" fear never materialized — even the largest, `MainEditorTabPlugin` (21 deps, the
+external Tool/EditorTabPlugin_XNA home), needed no `Lazy<T>`. What remains under "plugins" is only the
+deliberately-kept non-ctor lookups (the `Locator<PluginManager>()` self-injection cycle smells, and a
+few method-body/`StartUp` lookups noted above). **Phase 2 as a whole is still early-to-mid (~20–30%)**:
+the visible plugin entry points are now injected, but the ~224 `Locator` fallback sites behind them —
+inside the services those plugins consume — are largely untouched. Don't read "all plugins drained" as
+"Phase 2 nearly done"; the next front is the service-layer self-location, not more plugins.
 
 ## Definition of done — every change lands a *tested* unit
 

--- a/Direction/ui-decoupling-plan.md
+++ b/Direction/ui-decoupling-plan.md
@@ -153,7 +153,7 @@ line): `ISelectedState`, `IElementCommands`, `IUndoManager`, `IProjectManager`, 
 `IEditCommands`, `ICopyPasteLogic`, `IVariableInCategoryPropagationLogic`, `ElementTreeViewManager`,
 `IUserProjectSettingsManager`, `IOutputManager`, `INameVerifier`, `ITypeManager`, `LocalizationService`,
 `IRetryService` (these four from #3328), `IReorderLogic`, `FileLocations`, `IUiSettingsService`,
-`IThemingService`, `IDragDropManager`, `WireframeCommands` (these six from #3330).
+`IThemingService`, `IDragDropManager`, `WireframeCommands` (these six from #3331).
 
 ### Shortcut: batch by bridge-cost — added 2026-06-23
 
@@ -268,7 +268,7 @@ instead of the ctor still drains the same way — **relocate the assignment into
   fields lazily at invoke-time, *after* both are assigned) — plain `new`, not a `Locator` call, so the
   drain left it untouched. Dropped `using Gum.Services;` (Locator was its only use). No accessibility
   bump — all six deps are public and registered in `Builder.cs`.
-- **#3330 (2026-06-24)** — MainEditorTabPlugin
+- **#3331 (2026-06-24)** — MainEditorTabPlugin
   (`Tool/EditorTabPlugin_XNA/MainEditorTabPlugin.cs` — the external, central editor/wireframe plugin
   and the last substantive plugin ctor-drain). Converted the parameterless ctor (~22 `Locator` lookups)
   to a 21-param `[ImportingConstructor]`. **Six new bridges:** interfaces `IReorderLogic`,
@@ -301,7 +301,7 @@ instead of the ctor still drains the same way — **relocate the assignment into
   `[ImportingConstructor]`; only 4 new bridges, not the ~5 estimated, since #3327 already bridged
   `IOutputManager`; no cycle), `MainStateAnimationPlugin` (#3329 — never catalogued here; zero new
   bridges since all six ctor deps were already bridged, and its construction cycle was already broken by
-  a VM factory closure), `MainEditorTabPlugin` (#3330 — the last and largest; 21-param ctor, six new
+  a VM factory closure), `MainEditorTabPlugin` (#3331 — the last and largest; 21-param ctor, six new
   bridges, no cycle). Every drained heavy turned out cycle-free, so the "cycle-prone tail" fear never
   materialized.
 - **Scouted and left as out-of-scope** (no ctor/`StartUp` lookup to relocate — re-confirm before

--- a/Gum/Plugins/PluginManager.cs
+++ b/Gum/Plugins/PluginManager.cs
@@ -27,6 +27,7 @@ using RenderingLibrary;
 using System.Numerics;
 using Gum.Commands;
 using CommunityToolkit.Mvvm.Messaging;
+using Gum.Dialogs;
 using Gum.Services.Dialogs;
 using Gum.Undo;
 using Gum.Localization;
@@ -921,6 +922,23 @@ public class PluginManager : IPluginManager
             batch.AddExportedValue<ITypeManager>(Locator.GetRequiredService<ITypeManager>());
             batch.AddExportedValue<LocalizationService>(Locator.GetRequiredService<LocalizationService>());
             batch.AddExportedValue<IRetryService>(Locator.GetRequiredService<IRetryService>());
+
+            // Heavy-tier ctor drain: MainEditorTabPlugin (external Tool/EditorTabPlugin_XNA — the central
+            // editor/wireframe plugin). IReorderLogic and INameVerifier feed the EditingManager it builds;
+            // FileLocations is used for drag-drop file paths; IUiSettingsService feeds the SelectionManager;
+            // IThemingService feeds the BackgroundManager and the theme apply; IDragDropManager handles wireframe
+            // drops; WireframeCommands (concrete — passed to BackgroundManager, whose ctor takes the concrete) is
+            // distinct from the already-bridged IWireframeCommands interface but resolves to the same singleton.
+            // Its remaining ctor-time deps (ISelectedState, IProjectManager, IGuiCommands, IOutputManager,
+            // LocalizationService, IVariableInCategoryPropagationLogic, IWireframeObjectManager, IUndoManager,
+            // IDialogService, IHotkeyManager, IElementCommands, IFileCommands, ISetVariableLogic, IMessenger) are
+            // bridged above. PluginManager stays a body Locator call (host-into-its-own-plugin cycle smell).
+            batch.AddExportedValue<IReorderLogic>(Locator.GetRequiredService<IReorderLogic>());
+            batch.AddExportedValue<FileLocations>(Locator.GetRequiredService<FileLocations>());
+            batch.AddExportedValue<IUiSettingsService>(Locator.GetRequiredService<IUiSettingsService>());
+            batch.AddExportedValue<IThemingService>(Locator.GetRequiredService<IThemingService>());
+            batch.AddExportedValue<IDragDropManager>(Locator.GetRequiredService<IDragDropManager>());
+            batch.AddExportedValue<WireframeCommands>(Locator.GetRequiredService<WireframeCommands>());
 
 
             var container = new CompositionContainer(catalog);

--- a/Tool/EditorTabPlugin_XNA/MainEditorTabPlugin.cs
+++ b/Tool/EditorTabPlugin_XNA/MainEditorTabPlugin.cs
@@ -128,6 +128,7 @@ internal class MainEditorTabPlugin : PriorityPlugin, IRecipient<UiBaseFontSizeCh
     private readonly IProjectManager _projectManager;
     private EditorViewModel _editorViewModel;
     private readonly FileLocations _fileLocations;
+    private readonly IThemingService _themingService;
     private IDragDropManager _dragDropManager;
     WireframeControl _wireframeControl;
 
@@ -154,36 +155,56 @@ internal class MainEditorTabPlugin : PriorityPlugin, IRecipient<UiBaseFontSizeCh
 
     #endregion
 
-    public MainEditorTabPlugin()
+    [ImportingConstructor]
+    public MainEditorTabPlugin(
+        ISelectedState selectedState,
+        IProjectManager projectManager,
+        IGuiCommands guiCommands,
+        IOutputManager outputManager,
+        LocalizationService localizationService,
+        IReorderLogic reorderLogic,
+        INameVerifier nameVerifier,
+        IVariableInCategoryPropagationLogic variableInCategoryPropagationLogic,
+        IWireframeObjectManager wireframeObjectManager,
+        FileLocations fileLocations,
+        IUndoManager undoManager,
+        IDialogService dialogService,
+        IHotkeyManager hotkeyManager,
+        IElementCommands elementCommands,
+        IFileCommands fileCommands,
+        ISetVariableLogic setVariableLogic,
+        IUiSettingsService uiSettingsService,
+        WireframeCommands wireframeCommands,
+        IMessenger messenger,
+        IThemingService themingService,
+        IDragDropManager dragDropManager)
     {
-        _selectedState = Locator.GetRequiredService<ISelectedState>();
-        _projectManager = Locator.GetRequiredService<IProjectManager>();
+        _selectedState = selectedState;
+        _projectManager = projectManager;
+        _guiCommands = guiCommands;
+        _outputManager = outputManager;
+        _localizationService = localizationService;
+        _variableInCategoryPropagationLogic = variableInCategoryPropagationLogic;
+        _wireframeObjectManager = wireframeObjectManager;
+        _fileLocations = fileLocations;
+        _dialogService = dialogService;
+        _hotkeyManager = hotkeyManager;
+        _elementCommands = elementCommands;
+        _fileCommands = fileCommands;
+        _setVariableLogic = setVariableLogic;
+        _uiSettingsService = uiSettingsService;
+        _wireframeCommands = wireframeCommands;
+        _themingService = themingService;
+        _dragDropManager = dragDropManager;
 
         _scrollbarService = new ScrollbarService(_projectManager);
-        _guiCommands = Locator.GetRequiredService<IGuiCommands>();
-        _outputManager = Locator.GetRequiredService<IOutputManager>();
-        _localizationService = Locator.GetRequiredService<LocalizationService>();
         _editingManager = new EditingManager(
-            Locator.GetRequiredService<IWireframeObjectManager>(),
-            Locator.GetRequiredService<IReorderLogic>(),
-            Locator.GetRequiredService<IElementCommands>(),
-            Locator.GetRequiredService<INameVerifier>(),
-            Locator.GetRequiredService<ISetVariableLogic>()
+            _wireframeObjectManager,
+            reorderLogic,
+            _elementCommands,
+            nameVerifier,
+            _setVariableLogic
             );
-        _variableInCategoryPropagationLogic = Locator.GetRequiredService<IVariableInCategoryPropagationLogic>();
-        _wireframeObjectManager = Locator.GetRequiredService<IWireframeObjectManager>();
-        _fileLocations = Locator.GetRequiredService<FileLocations>();
-
-        IUndoManager undoManager = Locator.GetRequiredService<IUndoManager>();
-        IDialogService dialogService = Locator.GetRequiredService<IDialogService>();
-        _dialogService = dialogService;
-        IHotkeyManager hotkeyManager = Locator.GetRequiredService<IHotkeyManager>();
-
-        _elementCommands = Locator.GetRequiredService<IElementCommands>();
-        _fileCommands = Locator.GetRequiredService<IFileCommands>();
-        _setVariableLogic = Locator.GetRequiredService<ISetVariableLogic>();
-        _uiSettingsService = Locator.GetRequiredService<IUiSettingsService>();
-        _wireframeCommands = Locator.GetRequiredService<WireframeCommands>();
 
         _layerService = new Services.LayerService();
 
@@ -196,8 +217,8 @@ internal class MainEditorTabPlugin : PriorityPlugin, IRecipient<UiBaseFontSizeCh
             _selectedState,
             undoManager,
             _editingManager,
-            dialogService,
-            hotkeyManager,
+            _dialogService,
+            _hotkeyManager,
             _variableInCategoryPropagationLogic,
             _wireframeObjectManager,
             _projectManager,
@@ -210,19 +231,18 @@ internal class MainEditorTabPlugin : PriorityPlugin, IRecipient<UiBaseFontSizeCh
 
         _screenshotService = new ScreenshotService(_selectionManager);
         _singlePixelTextureService = new SinglePixelTextureService();
-        _backgroundManager = new BackgroundManager(_wireframeCommands, 
-            Locator.GetRequiredService<IMessenger>(), 
-            Locator.GetRequiredService<IThemingService>());
-        _dragDropManager = Locator.GetRequiredService<IDragDropManager>();
-        _hotkeyManager = hotkeyManager;
+        _backgroundManager = new BackgroundManager(_wireframeCommands, messenger, _themingService);
+
+        // Host-into-its-own-plugin self-injection: PluginManager can't be a ctor param (it owns this
+        // plugin's construction), so it stays a body Locator call — a cycle smell, not a drain target.
         PluginManager pluginManager = Locator.GetRequiredService<PluginManager>();
 
         _editorViewModel = new EditorViewModel(
-            pluginManager, 
-            _fileCommands, 
+            pluginManager,
+            _fileCommands,
             _wireframeObjectManager);
 
-        Locator.GetRequiredService<IMessenger>().RegisterAll(this);
+        messenger.RegisterAll(this);
     }
 
     public override void StartUp()
@@ -858,7 +878,7 @@ internal class MainEditorTabPlugin : PriorityPlugin, IRecipient<UiBaseFontSizeCh
 
         UpdateWireframeControlSizes();
 
-        IEffectiveThemeSettings themeSettings = Locator.GetRequiredService<IThemingService>().EffectiveSettings;
+        IEffectiveThemeSettings themeSettings = _themingService.EffectiveSettings;
         ApplyThemeSettings(themeSettings);
     }
 


### PR DESCRIPTION
## Phase 2 (static drain): MainEditorTabPlugin

Converts the parameterless constructor of `MainEditorTabPlugin` — the external, central editor/wireframe plugin in `Tool/EditorTabPlugin_XNA/` — from ~22 `Locator.GetRequiredService<T>()` lookups to a 21-param `[ImportingConstructor]`. **This is the last substantive plugin ctor-drain, finishing the plugin ctor-drain pass of Phase 2** (the UI/logic decoupling effort tracked in `Direction/ui-decoupling-plan.md`).

### What changed

- **`MainEditorTabPlugin.cs`** — parameterless ctor → 21-param `[ImportingConstructor]`; fields assigned from params; inline `EditingManager` / `SelectionManager` / `BackgroundManager` / `EditorViewModel` constructions now take the injected fields/params (they stay `new`). Added a `_themingService` field; the method-body `Locator<IThemingService>()` in `HandleXnaInitialized` now reuses it (sanctioned drive-by).
- **`PluginManager.cs`** — six new `batch.AddExportedValue<T>` bridges + one new `using Gum.Dialogs;`.
- **`Direction/ui-decoupling-plan.md`** — ledger: new "Drained so far" entry, triage marked complete, standing/snapshot refreshed.

### Six new bridges

Interfaces `IReorderLogic`, `IUiSettingsService`, `IThemingService`, `IDragDropManager`; concretes `FileLocations` and `WireframeCommands`. The concrete `WireframeCommands` is distinct from the already-bridged `IWireframeCommands` interface (resolves to the same singleton): the field is passed to `BackgroundManager`, whose ctor takes the **concrete** type, and `BackgroundManager.cs` is outside this PR's file boundary — so the "otherwise bridge concrete" branch applied rather than switching the field to the interface. The other 15 ctor-time deps were already bridged.

### Reuse & scope discipline

- Four service types resolved twice in the old ctor (`IWireframeObjectManager`, `IElementCommands`, `ISetVariableLogic`, `IMessenger`) are injected once and reused. `IMessenger` is param-only (no field), used twice — `BackgroundManager` arg + `messenger.RegisterAll(this)`.
- **Kept in the body (not drain targets):** the four `Locator<PluginManager>()` self-injection calls (ctor + three event handlers — the host-into-its-own-plugin cycle smell) and the StartUp `Locator<IFontManager>()` (StartUp-time, not a ctor dep). `using Gum.Services;` stays (still needed for `Locator` and `UiBaseFontSizeChangedMessage`).

### No cycle / no `Lazy<T>`

All 21 injected deps are host-container singletons built before `LoadPlugins`, so MEF only constructs the plugin from pre-built deps — no construction cycle (same benign topology scouted in #3327). No accessibility bump — all 21 deps are public and registered in `Builder.cs`.

### Verification

- **Build:** `GumFull.sln` — 0 errors; the external `EditorTabPlugin_XNA.dll` rebuilt and copied to `Gum/bin/Debug/Plugins/` via the `$(SolutionDir)` post-build.
- **No unit test:** behavior-preserving `static`→injected drain; cleanly unit-testing the ctor would require bootstrapping the static `Locator` (the kept `Locator<PluginManager>()` body call) plus heavy WinForms/XNA construction — the "harness would have to contort" case per the `refactoring-direction` skill. Compiler + DI composition + manual smoke are the proof.
- **Manual smoke (required, high-signal):** run Gum, load a project, confirm the wireframe renders, element selection + resize/drag-drop work, the background draws, and theming applies. If the plugin failed MEF composition the whole editor tab would break, so a working editor proves the drain is sound.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
