### PR TITLE
Clarify in Forms skills that a control doesn't own its visual's structure

### DIFF
--- a/.claude/skills/gum-forms-controls/SKILL.md
+++ b/.claude/skills/gum-forms-controls/SKILL.md
@@ -22,6 +22,8 @@ Every `FrameworkElement` has a `Visual` property of type `InteractiveGue` (which
 - `FrameworkElement.X/Y/Width/Height/etc.` — all forward to `Visual`; there is no separate logical sizing
 - `ActualWidth` / `ActualHeight` — computed pixel values, read from `Visual.GetAbsoluteWidth/Height()`
 
+**The control does not own or know its visual's internal structure.** The `Visual` is arbitrary and pluggable — the code-only default (`*Visual`/`Default*Runtime`), a tool-authored component with Forms behaviors, or a custom `InteractiveGue` subclass — and the control knows only the **named children** it looks up in `ReactToVisualChanged` (which may be absent). So "a Window has an `InnerPanelInstance` that fills it" is a property of *one visual*, not of `Window`. Any feature that depends on internal layout (e.g. sizing the content host to children) must live in a **visual**, never in the control, and cannot be assumed across visuals — which is why `WindowVisual.MakeSizedToChildren()` is on the visual. See **gum-forms-default-visuals**.
+
 ## Two Construction Paths
 
 **Forms-first** (`new Button()`): The default constructor calls `GetGraphicalUiElementFor(this)` which looks up `DefaultFormsTemplates` (or the older `DefaultFormsComponents`) to find the registered visual type, instantiates it with `createFormsInternally: false`, and assigns it as `Visual`. This path requires the type to be registered before the constructor runs.

--- a/.claude/skills/gum-forms-default-visuals/SKILL.md
+++ b/.claude/skills/gum-forms-default-visuals/SKILL.md
@@ -9,6 +9,8 @@ description: Forms DefaultVisuals — code-only visual classes backing Forms con
 
 Default visuals are `InteractiveGue` subclasses that procedurally build a complete visual tree in their constructor — no Gum project file needed. Each one backs a specific Forms control (e.g., `ButtonVisual` backs `Button`). They live in `MonoGameGum/Forms/DefaultVisuals/`.
 
+**These are *one* implementation, not *the* structure.** A control can be backed by any visual — a tool-authored component or a custom `InteractiveGue` subclass with a completely different tree — so structural features (a Window's Fill `InnerPanelInstance`, or sizing it to children via `WindowVisual.MakeSizedToChildren()`) live in the visual, never in the control. See the Visual/FrameworkElement split in **gum-forms-controls**.
+
 ## Two Generations
 
 **V1 (legacy `Default*Runtime`)** — Solid-colored rectangles (`ColoredRectangleRuntime`, `RectangleRuntime`). No textures, no centralized styling. Still shipped but superseded.


### PR DESCRIPTION
## What

Adds a principle to the Forms skills: **a Forms control does not own or know its visual's internal structure.**

- `gum-forms-controls` (Visual/FrameworkElement split) — full-strength statement that the `Visual` is arbitrary and pluggable, the control knows only the named children it looks up, and structural features (e.g. a Window's Fill `InnerPanelInstance`, sizing it to children) live in a **visual**, never the control.
- `gum-forms-default-visuals` ("What They Are") — a tight cross-reference pointing back to the split.

## Why

Surfaced while discussing #1167 (sizing a `Window` to its children). The skills documented the Visual/FrameworkElement split but not the **design consequence** that follows from it — that a structural/layout problem can't be solved "in the control" or by changing "the control's default," because there is no single structure; any control can be backed by arbitrarily many visuals (the code-only default, a tool-authored component, or a custom `InteractiveGue` subclass). That missing rule led to a wrong recommendation. This is the docs-only fix for that gap.

Does **not** close #1167 — the design discussion for that issue is still open; this only clarifies the skills.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
