### PR TITLE
Fix AllPluginsCompositionTests: bridge MainEditorTabPlugin's 6 ctor services

### DIFF
--- a/Tool/Tests/GumToolUnitTests/Plugins/PluginBridgedServiceTypes.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/PluginBridgedServiceTypes.cs
@@ -10,6 +10,7 @@ using Gum.ToolCommands;
 using Gum.Commands;
 using CommunityToolkit.Mvvm.Messaging;
 using Gum.Services.Dialogs;
+using Gum.Dialogs;
 using Gum.Undo;
 using Gum.Localization;
 using Gum.Services.Fonts;
@@ -88,5 +89,15 @@ internal static class PluginBridgedServiceTypes
         typeof(ITypeManager),
         typeof(LocalizationService),
         typeof(IRetryService),
+
+        // MainEditorTabPlugin drain (#3331). WireframeCommands is the concrete (BackgroundManager's ctor
+        // takes it), distinct from the IWireframeCommands interface bridged above though it resolves to the
+        // same singleton.
+        typeof(IReorderLogic),
+        typeof(FileLocations),
+        typeof(IUiSettingsService),
+        typeof(IThemingService),
+        typeof(IDragDropManager),
+        typeof(WireframeCommands),
     };
 }


### PR DESCRIPTION
## Fix `AllPluginsCompositionTests` red on `main`

`AllPlugins_ComposeWithoutError` is currently **failing on `main`** (and therefore on every open PR that merges main, e.g. #3332). This is a semantic-merge regression, not a fault of any one PR.

### Root cause

- **#3331** drained `MainEditorTabPlugin` to `[ImportingConstructor]` and bridged six new services into `PluginManager.LoadPlugins`:
  `IReorderLogic`, `FileLocations`, `IUiSettingsService`, `IThemingService`, `IDragDropManager`, and the concrete `WireframeCommands`.
- **#3330** (the headless composition test) merged **after** that drain, but its hand-maintained mirror `PluginBridgedServiceTypes.All` was authored against the pre-#3331 list and never got those six entries.

Because those six aren't in the test's `CompositionBatch`, MEF can't satisfy `MainEditorTabPlugin`'s constructor, **silently rejects the part**, and the assertion `composedTypes.ShouldContain(MainEditorTabPlugin)` fails.

### Fix

Add the six services to `PluginBridgedServiceTypes.All` so the mirror matches `LoadPlugins` again (plus `using Gum.Dialogs;` for `IThemingService`). Test-only change — no production behavior affected. The eventual extraction of a shared `ComposePlugins(...)` (already tracked as a follow-up in the file's doc comment) will delete this duplicate list for good.

### Verification

`dotnet test ... --filter "FullyQualifiedName~GumToolUnitTests.Plugins"` → **247/247 pass** (was 1 failing). Confirmed red before the change, green after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
