### PR TITLE
Correct refactoring-specialist: plugins DO receive DI via MEF

### DIFF
--- a/.claude/agents/refactoring-specialist.md
+++ b/.claude/agents/refactoring-specialist.md
@@ -75,7 +75,7 @@ public class MyService : IDisposable
 
 ## Dependency Injection
 - **Use constructor injection**, NOT Service Locator pattern (`Locator.GetRequiredService<>()`) except for in the following cases:
-  - Plugin classes (inheriting from PluginBase) where DI is not available
+  - Plugin classes (inheriting from `PluginBase`) **do** receive DI — via MEF, either an `[ImportingConstructor]` parameter or a settable `[Import]` property — and are in scope for the Phase 2 static drain. A service must first be bridged into the plugin container in `PluginManager.LoadPlugins` (`batch.AddExportedValue<T>(...)`) before a plugin can inject it. See the `refactoring-direction` skill for the recipe; do not reintroduce `Locator` calls in a plugin ctor.
   - Views such as SomeUserControl.xaml.cs where DI is not available
   - If a class is still a singleton (e.g., a static helper class) and cannot be refactored to use DI, then Service Locator may be used as a last resort, but this should be rare and justified in comments.
 - Makes dependencies explicit and testable


### PR DESCRIPTION
The Dependency Injection section of the refactoring-specialist agent listed plugins (`PluginBase`) as a case where DI is not available. That is wrong: plugins are MEF parts and receive DI via an `[ImportingConstructor]` parameter or a settable `[Import]` property, and are in scope for the Phase 2 static drain. A service must first be bridged into the plugin container in `PluginManager.LoadPlugins` (`batch.AddExportedValue<T>`) before a plugin can inject it. Now points at the `refactoring-direction` skill for the recipe.

Guidance-file-only fix, orphaned from the Phase 2 plugin ctor-drain work. No code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)