### PR TITLE
Drain ScreenshotService: inject IWireframeCommands + IGuiCommands

### DIFF
--- a/Tool/EditorTabPlugin_XNA/MainEditorTabPlugin.cs
+++ b/Tool/EditorTabPlugin_XNA/MainEditorTabPlugin.cs
@@ -229,7 +229,7 @@ internal class MainEditorTabPlugin : PriorityPlugin, IRecipient<UiBaseFontSizeCh
             _uiSettingsService,
             _toolFontService);
 
-        _screenshotService = new ScreenshotService(_selectionManager);
+        _screenshotService = new ScreenshotService(_selectionManager, _wireframeCommands, _guiCommands);
         _singlePixelTextureService = new SinglePixelTextureService();
         _backgroundManager = new BackgroundManager(_wireframeCommands, messenger, _themingService);
 

--- a/Tool/EditorTabPlugin_XNA/Services/ScreenshotService.cs
+++ b/Tool/EditorTabPlugin_XNA/Services/ScreenshotService.cs
@@ -1,6 +1,5 @@
 ﻿using Gum.Commands;
 using Gum.Plugins.BaseClasses;
-using Gum.Services;
 using Gum.ToolStates;
 using Gum.Wireframe;
 using RenderingLibrary.Graphics;
@@ -16,14 +15,17 @@ internal class ScreenshotService
     string? nextScreenshotFileLocation = null;
     Microsoft.Xna.Framework.Graphics.RenderTarget2D renderTarget;
     private readonly SelectionManager _selectionManager;
-    private readonly WireframeCommands _wireframeCommands;
+    private readonly IWireframeCommands _wireframeCommands;
     private readonly IGuiCommands _guiCommands;
 
-    public ScreenshotService(SelectionManager selectionManager)
+    public ScreenshotService(
+        SelectionManager selectionManager,
+        IWireframeCommands wireframeCommands,
+        IGuiCommands guiCommands)
     {
         _selectionManager = selectionManager;
-        _wireframeCommands = Locator.GetRequiredService<WireframeCommands>();
-        _guiCommands = Locator.GetRequiredService<IGuiCommands>();
+        _wireframeCommands = wireframeCommands;
+        _guiCommands = guiCommands;
     }
 
     public void InitializeMenuItem(System.Windows.Controls.MenuItem item)

--- a/Tool/Tests/GumToolUnitTests/Plugins/InternalPlugins/EditorTab/ScreenshotServiceTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/InternalPlugins/EditorTab/ScreenshotServiceTests.cs
@@ -1,0 +1,43 @@
+using Gum.Commands;
+using Gum.Plugins.InternalPlugins.EditorTab.Services;
+using Moq;
+using Xunit;
+
+namespace GumToolUnitTests.Plugins.InternalPlugins.EditorTab;
+
+public class ScreenshotServiceTests : BaseTestClass
+{
+    // ScreenshotService now takes IWireframeCommands + IGuiCommands via its constructor (drained
+    // from Locator). These pin that, until a screenshot is actually requested, the render hooks are
+    // no-ops that never touch the injected dependencies. Because that no-op path never dereferences
+    // the SelectionManager either, passing null for it here is safe (and avoids standing up its
+    // ~14-argument graph just to verify a guard).
+    private readonly Mock<IWireframeCommands> _wireframeCommands = new();
+    private readonly Mock<IGuiCommands> _guiCommands = new();
+    private readonly ScreenshotService _screenshotService;
+
+    public ScreenshotServiceTests()
+    {
+        _screenshotService = new ScreenshotService(
+            selectionManager: null!,
+            _wireframeCommands.Object,
+            _guiCommands.Object);
+    }
+
+    [Fact]
+    public void HandleAfterRender_does_nothing_when_no_screenshot_is_requested()
+    {
+        _screenshotService.HandleAfterRender();
+
+        _wireframeCommands.VerifyNoOtherCalls();
+        _guiCommands.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public void HandleBeforeRender_does_nothing_when_no_screenshot_is_requested()
+    {
+        _screenshotService.HandleBeforeRender();
+
+        _wireframeCommands.VerifyNoOtherCalls();
+    }
+}


### PR DESCRIPTION
## What

Drains `ScreenshotService` (`Tool/EditorTabPlugin_XNA/Services/ScreenshotService.cs`) off the service locator. It already took `SelectionManager` via its constructor but still service-located `WireframeCommands` and `IGuiCommands` in the ctor body — both are now constructor parameters, and the two `Locator.GetRequiredService` calls (plus the now-unused `using Gum.Services;`) are gone.

`MainEditorTabPlugin` — the host-container construction site — passes its already-injected fields:

```csharp
_screenshotService = new ScreenshotService(_selectionManager, _wireframeCommands, _guiCommands);
```

## Notes

- **Wireframe dep typed as the interface.** The task asked for the concrete `WireframeCommands`, but it implements `IWireframeCommands`, which exposes exactly the four visibility properties the service touches. Injected the interface instead, per the `refactoring-direction` skill ("inject the interface, not the concrete class"). The host still passes its concrete field; it upcasts implicitly.
- **Behavior-preserving.** `WireframeCommands`, `IWireframeCommands`, and `IGuiCommands` are all registered as the same singletons in `Builder.cs`, so the injected instances are identical to what the old `Locator` calls returned.
- **No MEF bridge needed.** The service is constructed via `new()` by the plugin host, not as a MEF part, so nothing changes in `PluginManager.LoadPlugins` / `PluginBridgedServiceTypes`.

## Tests

New `ScreenshotServiceTests` (2 pinning tests) verifies the render hooks (`HandleBeforeRender` / `HandleAfterRender`) are no-ops that never touch the injected dependencies until a screenshot is actually requested. Passing 2/2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
