### PR TITLE
Drain ScrollbarService + EditingManager: inject their service-located deps

### DIFF
--- a/Gum/Plugins/PluginManager.cs
+++ b/Gum/Plugins/PluginManager.cs
@@ -940,7 +940,7 @@ public class PluginManager : IPluginManager
             batch.AddExportedValue<IDragDropManager>(Locator.GetRequiredService<IDragDropManager>());
             batch.AddExportedValue<WireframeCommands>(Locator.GetRequiredService<WireframeCommands>());
 
-            // EditingManager drain: MainEditorTabPlugin builds EditingManager, which now injects
+            // EditingManager drain (#3338): MainEditorTabPlugin builds EditingManager, which now injects
             // ICircularReferenceManager (drained from a ctor-body Locator call). Its other drained dep,
             // IFavoriteComponentManager, is already bridged above.
             batch.AddExportedValue<ICircularReferenceManager>(Locator.GetRequiredService<ICircularReferenceManager>());

--- a/Gum/Plugins/PluginManager.cs
+++ b/Gum/Plugins/PluginManager.cs
@@ -940,6 +940,11 @@ public class PluginManager : IPluginManager
             batch.AddExportedValue<IDragDropManager>(Locator.GetRequiredService<IDragDropManager>());
             batch.AddExportedValue<WireframeCommands>(Locator.GetRequiredService<WireframeCommands>());
 
+            // EditingManager drain: MainEditorTabPlugin builds EditingManager, which now injects
+            // ICircularReferenceManager (drained from a ctor-body Locator call). Its other drained dep,
+            // IFavoriteComponentManager, is already bridged above.
+            batch.AddExportedValue<ICircularReferenceManager>(Locator.GetRequiredService<ICircularReferenceManager>());
+
 
             var container = new CompositionContainer(catalog);
 

--- a/Tool/EditorTabPlugin_XNA/EditingManager.cs
+++ b/Tool/EditorTabPlugin_XNA/EditingManager.cs
@@ -34,16 +34,19 @@ public partial class EditingManager : IEditingManager
         IReorderLogic reorderLogic,
         IElementCommands elementCommands,
         INameVerifier nameVerifier,
-        ISetVariableLogic setVariableLogic)
+        ISetVariableLogic setVariableLogic,
+        ISelectedState selectedState,
+        ICircularReferenceManager circularReferenceManager,
+        IFavoriteComponentManager favoriteComponentManager)
     {
-        _selectedState = Locator.GetRequiredService<ISelectedState>();
+        _selectedState = selectedState;
         _reorderLogic = reorderLogic;
         _wireframeObjectManager = wireframeObjectManager;
         _elementCommands = elementCommands;
         _nameVerifier = nameVerifier;
         _setVariableLogic = setVariableLogic;
-        _circularReferenceManager = Locator.GetRequiredService<ICircularReferenceManager>();
-        _favoriteComponentManager = Locator.GetRequiredService<IFavoriteComponentManager>();
+        _circularReferenceManager = circularReferenceManager;
+        _favoriteComponentManager = favoriteComponentManager;
     }
 
     public void Initialize(System.Windows.Controls.ContextMenu contextMenu)

--- a/Tool/EditorTabPlugin_XNA/MainEditorTabPlugin.cs
+++ b/Tool/EditorTabPlugin_XNA/MainEditorTabPlugin.cs
@@ -141,6 +141,8 @@ internal class MainEditorTabPlugin : PriorityPlugin, IRecipient<UiBaseFontSizeCh
     private readonly IDialogService _dialogService;
     private readonly IVariableInCategoryPropagationLogic _variableInCategoryPropagationLogic;
     private readonly IWireframeObjectManager _wireframeObjectManager;
+    private readonly ICircularReferenceManager _circularReferenceManager;
+    private readonly IFavoriteComponentManager _favoriteComponentManager;
     private readonly IToolFontService _toolFontService;
     private readonly IToolLayerService _toolLayerService;
 
@@ -177,7 +179,9 @@ internal class MainEditorTabPlugin : PriorityPlugin, IRecipient<UiBaseFontSizeCh
         WireframeCommands wireframeCommands,
         IMessenger messenger,
         IThemingService themingService,
-        IDragDropManager dragDropManager)
+        IDragDropManager dragDropManager,
+        ICircularReferenceManager circularReferenceManager,
+        IFavoriteComponentManager favoriteComponentManager)
     {
         _selectedState = selectedState;
         _projectManager = projectManager;
@@ -196,14 +200,19 @@ internal class MainEditorTabPlugin : PriorityPlugin, IRecipient<UiBaseFontSizeCh
         _wireframeCommands = wireframeCommands;
         _themingService = themingService;
         _dragDropManager = dragDropManager;
+        _circularReferenceManager = circularReferenceManager;
+        _favoriteComponentManager = favoriteComponentManager;
 
-        _scrollbarService = new ScrollbarService(_projectManager);
+        _scrollbarService = new ScrollbarService(_selectedState, _wireframeObjectManager, _projectManager);
         _editingManager = new EditingManager(
             _wireframeObjectManager,
             reorderLogic,
             _elementCommands,
             nameVerifier,
-            _setVariableLogic
+            _setVariableLogic,
+            _selectedState,
+            _circularReferenceManager,
+            _favoriteComponentManager
             );
 
         _layerService = new Services.LayerService();

--- a/Tool/EditorTabPlugin_XNA/ScrollbarService.cs
+++ b/Tool/EditorTabPlugin_XNA/ScrollbarService.cs
@@ -3,7 +3,6 @@ using Gum.DataTypes;
 using Gum.Managers;
 using Gum.Plugins.BaseClasses;
 using Gum.Plugins.InternalPlugins.EditorTab.Views;
-using Gum.Services;
 using Gum.ToolStates;
 using Gum.Wireframe;
 using RenderingLibrary;
@@ -21,10 +20,13 @@ public class ScrollbarService
     private readonly IWireframeObjectManager _wireframeObjectManager;
     private readonly IProjectManager _projectManager;
 
-    public ScrollbarService(IProjectManager projectManager)
+    public ScrollbarService(
+        ISelectedState selectedState,
+        IWireframeObjectManager wireframeObjectManager,
+        IProjectManager projectManager)
     {
-        _selectedState = Locator.GetRequiredService<ISelectedState>();
-        _wireframeObjectManager = Locator.GetRequiredService<IWireframeObjectManager>();
+        _selectedState = selectedState;
+        _wireframeObjectManager = wireframeObjectManager;
         _projectManager = projectManager;
     }
     

--- a/Tool/Tests/GumToolUnitTests/Plugins/InternalPlugins/EditorTab/EditingManagerTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/InternalPlugins/EditorTab/EditingManagerTests.cs
@@ -1,0 +1,53 @@
+using System.Collections.Generic;
+using Gum.DataTypes;
+using Gum.Logic;
+using Gum.Managers;
+using Gum.Plugins.InternalPlugins.VariableGrid;
+using Gum.Services;
+using Gum.ToolCommands;
+using Gum.ToolStates;
+using Gum.Wireframe;
+using Moq;
+using Xunit;
+
+namespace GumToolUnitTests.Plugins.InternalPlugins.EditorTab;
+
+public class EditingManagerTests : BaseTestClass
+{
+    // EditingManager now takes ISelectedState, ICircularReferenceManager, and IFavoriteComponentManager
+    // via its constructor (drained from Locator), alongside the five dependencies it already injected.
+    // RefreshPositionsAndScalesForInstance forwards only to the injected IWireframeObjectManager; this
+    // pins that forwarding and that the three drained dependencies stay untouched on that path.
+    private readonly Mock<IWireframeObjectManager> _wireframeObjectManager = new();
+    private readonly Mock<ISelectedState> _selectedState = new();
+    private readonly Mock<ICircularReferenceManager> _circularReferenceManager = new();
+    private readonly Mock<IFavoriteComponentManager> _favoriteComponentManager = new();
+    private readonly EditingManager _editingManager;
+
+    public EditingManagerTests()
+    {
+        _editingManager = new EditingManager(
+            _wireframeObjectManager.Object,
+            Mock.Of<IReorderLogic>(),
+            Mock.Of<IElementCommands>(),
+            Mock.Of<INameVerifier>(),
+            Mock.Of<ISetVariableLogic>(),
+            _selectedState.Object,
+            _circularReferenceManager.Object,
+            _favoriteComponentManager.Object);
+    }
+
+    [Fact]
+    public void RefreshPositionsAndScalesForInstance_forwards_to_wireframe_object_manager()
+    {
+        InstanceSave instance = new();
+        List<ElementWithState> elementStack = new();
+
+        _editingManager.RefreshPositionsAndScalesForInstance(instance, elementStack);
+
+        _wireframeObjectManager.Verify(m => m.GetRepresentation(instance, elementStack), Times.Once);
+        _selectedState.VerifyNoOtherCalls();
+        _circularReferenceManager.VerifyNoOtherCalls();
+        _favoriteComponentManager.VerifyNoOtherCalls();
+    }
+}

--- a/Tool/Tests/GumToolUnitTests/Plugins/InternalPlugins/EditorTab/ScrollbarServiceTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/InternalPlugins/EditorTab/ScrollbarServiceTests.cs
@@ -1,0 +1,40 @@
+using Gum.Managers;
+using Gum.Plugins.ScrollBarPlugin;
+using Gum.ToolStates;
+using Gum.Wireframe;
+using Moq;
+using Shouldly;
+using Xunit;
+
+namespace GumToolUnitTests.Plugins.InternalPlugins.EditorTab;
+
+public class ScrollbarServiceTests : BaseTestClass
+{
+    // ScrollbarService now takes ISelectedState + IWireframeObjectManager via its constructor (drained
+    // from Locator), alongside the IProjectManager it already injected. This pins that the constructor
+    // only stores its dependencies -- it service-locates nothing and touches none of them, which is the
+    // behavior the drain must preserve. (Its event handlers all dereference a ScrollBarControlLogic that
+    // only exists once a WinForms wireframe is initialized, so they are not exercisable headless.)
+    private readonly Mock<ISelectedState> _selectedState = new();
+    private readonly Mock<IWireframeObjectManager> _wireframeObjectManager = new();
+    private readonly Mock<IProjectManager> _projectManager = new();
+    private readonly ScrollbarService _scrollbarService;
+
+    public ScrollbarServiceTests()
+    {
+        _scrollbarService = new ScrollbarService(
+            _selectedState.Object,
+            _wireframeObjectManager.Object,
+            _projectManager.Object);
+    }
+
+    [Fact]
+    public void Constructor_stores_dependencies_without_invoking_them()
+    {
+        _scrollbarService.ShouldNotBeNull();
+
+        _selectedState.VerifyNoOtherCalls();
+        _wireframeObjectManager.VerifyNoOtherCalls();
+        _projectManager.VerifyNoOtherCalls();
+    }
+}

--- a/Tool/Tests/GumToolUnitTests/Plugins/PluginBridgedServiceTypes.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/PluginBridgedServiceTypes.cs
@@ -100,7 +100,7 @@ internal static class PluginBridgedServiceTypes
         typeof(IDragDropManager),
         typeof(WireframeCommands),
 
-        // EditingManager drain: ICircularReferenceManager is bridged for the EditingManager that
+        // EditingManager drain (#3338): ICircularReferenceManager is bridged for the EditingManager that
         // MainEditorTabPlugin constructs (its other drained dep, IFavoriteComponentManager, is above).
         typeof(ICircularReferenceManager),
     };

--- a/Tool/Tests/GumToolUnitTests/Plugins/PluginBridgedServiceTypes.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/PluginBridgedServiceTypes.cs
@@ -99,5 +99,9 @@ internal static class PluginBridgedServiceTypes
         typeof(IThemingService),
         typeof(IDragDropManager),
         typeof(WireframeCommands),
+
+        // EditingManager drain: ICircularReferenceManager is bridged for the EditingManager that
+        // MainEditorTabPlugin constructs (its other drained dep, IFavoriteComponentManager, is above).
+        typeof(ICircularReferenceManager),
     };
 }


### PR DESCRIPTION
## What

Drains the remaining `Locator.GetRequiredService` calls out of two `EditorTabPlugin_XNA` services' constructors, continuing the ScreenshotService drain (#3337) with the identical recipe.

Both services already injected *some* dependencies but service-located the rest in the ctor body. Each Locator'd dep is promoted to a constructor parameter (typed as its interface) and the Locator call deleted; `MainEditorTabPlugin` — the host-container construction site that `new`s both — passes them in.

| Service | Promoted to ctor params | Already injected |
|---|---|---|
| `ScrollbarService` | `ISelectedState`, `IWireframeObjectManager` | `IProjectManager` |
| `EditingManager` | `ISelectedState`, `ICircularReferenceManager`, `IFavoriteComponentManager` | `IWireframeObjectManager`, `IReorderLogic`, `IElementCommands`, `INameVerifier`, `ISetVariableLogic` |

## MEF bridge

`MainEditorTabPlugin` is a MEF part, so its new `[ImportingConstructor]` params must be bridged into the plugin container:

- `IFavoriteComponentManager` — already bridged, no change.
- `ICircularReferenceManager` — **not** bridged, so it's now added in `PluginManager.LoadPlugins` and mirrored into `PluginBridgedServiceTypes.All` (the hand-maintained duplicate that `AllPluginsCompositionTests` checks — out of sync ⇒ red).

Both are DI-registered singletons in `Builder.cs`, so the injected instances are identical to what the old Locator calls returned — **behavior preserving**.

Housekeeping: `ScrollbarService` drops its now-unused `using Gum.Services;`. `EditingManager` keeps it — `ICircularReferenceManager` lives in that namespace.

## Tests

Adds `ScrollbarServiceTests` and `EditingManagerTests` pinning the drained seams (construct with mocked interfaces, verify the drained deps aren't touched on the headless path).

Verification: `dotnet test` on the `GumToolUnitTests.Plugins` namespace — **251 passed, 0 failed**, including `AllPluginsCompositionTests` (every plugin still composes through MEF with the new ctor params + bridge) and `ServiceProviderCompositionSpikeTests` (the real `Builder.cs` container resolves the bridged set, catching DI cycles / missing registrations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
