### PR TITLE
Drain StateAnimationPlugin Locator-in-ctor classes to constructor injection

### DIFF
--- a/Gum/StateAnimationPlugin/MainStateAnimationPlugin.cs
+++ b/Gum/StateAnimationPlugin/MainStateAnimationPlugin.cs
@@ -48,6 +48,8 @@ public class MainStateAnimationPlugin : PluginBase
     private readonly IRenameManager _renameManager;
     private readonly ISettingsManager _settingsManager;
     private readonly IProjectState _projectState;
+    private readonly IProjectManager _projectManager;
+    private readonly IWireframeObjectManager _wireframeObjectManager;
     private readonly IAnimationCollectionViewModelManager _animationCollectionViewModelManager;
     private readonly IBitmapLoader _bitmapLoader;
     ElementAnimationsViewModel? _viewModel;
@@ -96,7 +98,9 @@ public class MainStateAnimationPlugin : PluginBase
         IMessenger messenger,
         IOutputManager outputManager,
         IFileWatchManager fileWatchManager,
-        IProjectState projectState)
+        IProjectState projectState,
+        IProjectManager projectManager,
+        IWireframeObjectManager wireframeObjectManager)
     {
         _selectedState = selectedState;
         _nameVerifier = nameVerifier;
@@ -104,10 +108,12 @@ public class MainStateAnimationPlugin : PluginBase
         _outputManager = outputManager;
         _fileWatchManager = fileWatchManager;
         _projectState = projectState;
+        _projectManager = projectManager;
+        _wireframeObjectManager = wireframeObjectManager;
 
         _animationFilePathService = new AnimationFilePathService(_selectedState);
-        _duplicateService = new DuplicateService();
-        _elementDeleteService = new ElementDeleteService(_animationFilePathService);
+        _duplicateService = new DuplicateService(_dialogService, _projectManager);
+        _elementDeleteService = new ElementDeleteService(_animationFilePathService, _dialogService);
         _settingsManager = new SettingsManager();
         _bitmapLoader = new BitmapLoader();
 
@@ -115,7 +121,8 @@ public class MainStateAnimationPlugin : PluginBase
         // (when invoked, after both are assigned just below), which breaks the
         // ACVMM -> ElementAnimationsViewModel -> RenameManager construction cycle without a Lazy<T>.
         _animationVmFactory = () => new ElementAnimationsViewModel(
-            _nameVerifier, _dialogService, _animationCollectionViewModelManager, _renameManager, _bitmapLoader);
+            _nameVerifier, _dialogService, _animationCollectionViewModelManager, _renameManager, _bitmapLoader,
+            _selectedState, _wireframeObjectManager, _outputManager);
         _animationCollectionViewModelManager = new AnimationCollectionViewModelManager(
             _selectedState, _outputManager, _fileWatchManager, _animationFilePathService, _animationVmFactory);
         _renameManager = new RenameManager(

--- a/Gum/StateAnimationPlugin/Managers/DuplicateService.cs
+++ b/Gum/StateAnimationPlugin/Managers/DuplicateService.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using Gum.Services;
 using Gum.Services.Dialogs;
 using ToolsUtilities;
 
@@ -15,14 +14,17 @@ namespace StateAnimationPlugin.Managers
     public class DuplicateService
     {
         private readonly IDialogService _dialogService;
-        public DuplicateService()
+        private readonly IProjectManager _projectManager;
+
+        public DuplicateService(IDialogService dialogService, IProjectManager projectManager)
         {
-            _dialogService = Locator.GetRequiredService<IDialogService>();
+            _dialogService = dialogService;
+            _projectManager = projectManager;
         }
-        
+
         public void HandleDuplicate(ElementSave oldElement, ElementSave newElement)
         {
-            var project = Locator.GetRequiredService<IProjectManager>().GumProjectSave;
+            var project = _projectManager.GumProjectSave;
             //////////////////////Early Out////////////////////
             if(project == null)
             {

--- a/Gum/StateAnimationPlugin/Managers/ElementDeleteService.cs
+++ b/Gum/StateAnimationPlugin/Managers/ElementDeleteService.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Controls;
-using Gum.Services;
 using Gum.Services.Dialogs;
 using ToolsUtilities;
 
@@ -18,13 +17,13 @@ internal class ElementDeleteService
     private readonly IDialogService _dialogService;
     private CheckBox deleteAnimationFileCheckbox;
 
-    public ElementDeleteService(AnimationFilePathService animationFilePathService)
+    public ElementDeleteService(AnimationFilePathService animationFilePathService, IDialogService dialogService)
     {
         _animationFilePathService = animationFilePathService;
         deleteAnimationFileCheckbox = new CheckBox();
         deleteAnimationFileCheckbox.IsChecked = true;
         deleteAnimationFileCheckbox.Width = 220;
-        _dialogService = Locator.GetRequiredService<IDialogService>();
+        _dialogService = dialogService;
     }
 
     internal void HandleDeleteOptionsWindowShow(DeleteOptionsWindow deleteWindow, Array objectsToDelete)

--- a/Gum/StateAnimationPlugin/ViewModels/AnimationViewModel.cs
+++ b/Gum/StateAnimationPlugin/ViewModels/AnimationViewModel.cs
@@ -18,7 +18,6 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Media.Imaging;
 using CommunityToolkit.Mvvm.Input;
-using Gum.Services;
 using Gum.StateAnimation.Runtime;
 
 namespace StateAnimationPlugin.ViewModels;
@@ -119,7 +118,7 @@ public partial class AnimationViewModel : ViewModel
 
     #region Methods
 
-    public AnimationViewModel(IBitmapLoader bitmapLoader)
+    public AnimationViewModel(IBitmapLoader bitmapLoader, ISelectedState selectedState, IWireframeObjectManager wireframeObjectManager)
     {
         Keyframes = new ObservableCollection<AnimatedKeyframeViewModel>();
         Keyframes.CollectionChanged += HandleKeyframeCollectionChanged;
@@ -127,8 +126,8 @@ public partial class AnimationViewModel : ViewModel
         mLoopBitmap = bitmapLoader.LoadImage("LoopIcon.png");
 
         mPlayOnceBitmap = bitmapLoader.LoadImage("PlayOnceIcon.png");
-        _selectedState = Locator.GetRequiredService<ISelectedState>();
-        _wireframeObjectManager = Locator.GetRequiredService<IWireframeObjectManager>();
+        _selectedState = selectedState;
+        _wireframeObjectManager = wireframeObjectManager;
     }
 
     public AnimationViewModel Clone()
@@ -148,9 +147,9 @@ public partial class AnimationViewModel : ViewModel
         return clone;
     }
 
-    public static AnimationViewModel FromSave(AnimationSave save, ElementSave element, IAnimationCollectionViewModelManager animationCollectionViewModelManager, IBitmapLoader bitmapLoader, ElementAnimationsSave? allAnimationSaves = null)
+    public static AnimationViewModel FromSave(AnimationSave save, ElementSave element, IAnimationCollectionViewModelManager animationCollectionViewModelManager, IBitmapLoader bitmapLoader, ISelectedState selectedState, IWireframeObjectManager wireframeObjectManager, ElementAnimationsSave? allAnimationSaves = null)
     {
-        AnimationViewModel toReturn = new AnimationViewModel(bitmapLoader);
+        AnimationViewModel toReturn = new AnimationViewModel(bitmapLoader, selectedState, wireframeObjectManager);
         toReturn.Name = save.Name;
         toReturn.Loops = save.Loops;
 
@@ -212,7 +211,7 @@ public partial class AnimationViewModel : ViewModel
 
             if(animationSave != null && subAnimationElement != null)
             {
-                newVm.SubAnimationViewModel = AnimationViewModel.FromSave(animationSave, subAnimationElement, animationCollectionViewModelManager, bitmapLoader, subAnimationSiblings);
+                newVm.SubAnimationViewModel = AnimationViewModel.FromSave(animationSave, subAnimationElement, animationCollectionViewModelManager, bitmapLoader, selectedState, wireframeObjectManager, subAnimationSiblings);
             }
 
 

--- a/Gum/StateAnimationPlugin/ViewModels/ElementAnimationsViewModel.cs
+++ b/Gum/StateAnimationPlugin/ViewModels/ElementAnimationsViewModel.cs
@@ -22,7 +22,6 @@ using System.Globalization;
 using CommunityToolkit.Mvvm.Input;
 using Gum.Mvvm;
 using Gum.Wireframe;
-using Gum.Services;
 using Gum.Services.Dialogs;
 
 namespace StateAnimationPlugin.ViewModels;
@@ -47,6 +46,8 @@ public partial class ElementAnimationsViewModel : ViewModel
     private readonly IAnimationCollectionViewModelManager _animationCollectionViewModelManager;
     private readonly IRenameManager _renameManager;
     private readonly IBitmapLoader _bitmapLoader;
+    private readonly IWireframeObjectManager _wireframeObjectManager;
+    private readonly IOutputManager _outputManager;
     private AnimatedKeyframeViewModel? _copiedKeyframe;
 
     #endregion
@@ -215,7 +216,8 @@ public partial class ElementAnimationsViewModel : ViewModel
 
     public ElementAnimationsViewModel(INameVerifier nameVerifier, IDialogService dialogService,
         IAnimationCollectionViewModelManager animationCollectionViewModelManager, IRenameManager renameManager,
-        IBitmapLoader bitmapLoader)
+        IBitmapLoader bitmapLoader, ISelectedState selectedState, IWireframeObjectManager wireframeObjectManager,
+        IOutputManager outputManager)
     {
         ClampInterpolationVisuals = true;
         CurrentGameSpeed = "100%";
@@ -233,13 +235,15 @@ public partial class ElementAnimationsViewModel : ViewModel
 
         mStopBitmap = bitmapLoader.LoadImage("StopIcon.png");
 
-        _selectedState = Locator.GetRequiredService<ISelectedState>();
+        _selectedState = selectedState;
         _nameVerifier = nameVerifier;
         _nameValidator = new NameValidator(_nameVerifier);
         _dialogService = dialogService;
         _animationCollectionViewModelManager = animationCollectionViewModelManager;
         _renameManager = renameManager;
         _bitmapLoader = bitmapLoader;
+        _wireframeObjectManager = wireframeObjectManager;
+        _outputManager = outputManager;
 
         RefreshAnimationsRightClickMenuItems();
     }
@@ -250,7 +254,7 @@ public partial class ElementAnimationsViewModel : ViewModel
 
         foreach (var animation in save.Animations)
         {
-            var vm = AnimationViewModel.FromSave(animation, element, _animationCollectionViewModelManager, _bitmapLoader);
+            var vm = AnimationViewModel.FromSave(animation, element, _animationCollectionViewModelManager, _bitmapLoader, _selectedState, _wireframeObjectManager);
             Animations.Add(vm);
         }
     }
@@ -607,7 +611,7 @@ public partial class ElementAnimationsViewModel : ViewModel
 
             if (_dialogService.Show(dialogViewModel))
             {
-                var newAnimation = new AnimationViewModel(_bitmapLoader)
+                var newAnimation = new AnimationViewModel(_bitmapLoader, _selectedState, _wireframeObjectManager)
                 {
                     Name = dialogViewModel.Name,
                     Loops = dialogViewModel.Loops
@@ -655,7 +659,7 @@ public partial class ElementAnimationsViewModel : ViewModel
             return;
         }
 
-        SubAnimationSelectionDialogViewModel window = new(_animationCollectionViewModelManager, _bitmapLoader);
+        SubAnimationSelectionDialogViewModel window = new(_animationCollectionViewModelManager, _bitmapLoader, _outputManager, _selectedState, _wireframeObjectManager);
         window.AnimationToExclude = SelectedAnimation;
         window.AnimationContainers = CreateAnimationContainers();
 

--- a/Gum/StateAnimationPlugin/ViewModels/SubAnimationSelectionDialogViewModel.cs
+++ b/Gum/StateAnimationPlugin/ViewModels/SubAnimationSelectionDialogViewModel.cs
@@ -3,6 +3,7 @@ using Gum.Managers;
 using Gum.Services.Dialogs;
 using Gum.StateAnimation.SaveClasses;
 using Gum.ToolStates;
+using Gum.Wireframe;
 using StateAnimationPlugin.Managers;
 using System;
 using System.Collections.Generic;
@@ -10,7 +11,6 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using Gum.Services;
 using ToolsUtilities;
 
 namespace StateAnimationPlugin.ViewModels;
@@ -19,6 +19,8 @@ public class SubAnimationSelectionDialogViewModel : DialogViewModel
 {
     private readonly IAnimationFilePathService _animationFilePathService;
     private readonly IOutputManager _outputManager;
+    private readonly ISelectedState _selectedState;
+    private readonly IWireframeObjectManager _wireframeObjectManager;
     private readonly IAnimationCollectionViewModelManager _animationCollectionViewModelManager;
     private readonly IBitmapLoader _bitmapLoader;
 
@@ -57,10 +59,13 @@ public class SubAnimationSelectionDialogViewModel : DialogViewModel
     public override bool CanExecuteAffirmative() => SelectedAnimation is not null;
 
     public SubAnimationSelectionDialogViewModel(IAnimationCollectionViewModelManager animationCollectionViewModelManager,
-        IBitmapLoader bitmapLoader)
+        IBitmapLoader bitmapLoader, IOutputManager outputManager, ISelectedState selectedState,
+        IWireframeObjectManager wireframeObjectManager)
     {
-        _outputManager = Locator.GetRequiredService<IOutputManager>();
-        _animationFilePathService = new AnimationFilePathService(Locator.GetRequiredService<ISelectedState>());
+        _outputManager = outputManager;
+        _selectedState = selectedState;
+        _wireframeObjectManager = wireframeObjectManager;
+        _animationFilePathService = new AnimationFilePathService(selectedState);
         _animationCollectionViewModelManager = animationCollectionViewModelManager;
         _bitmapLoader = bitmapLoader;
     }
@@ -90,7 +95,7 @@ public class SubAnimationSelectionDialogViewModel : DialogViewModel
                 foreach (var item in save.Animations)
                 {
                     AnimationViewModel toReturn = AnimationViewModel.FromSave(
-                        item, elementSave!, _animationCollectionViewModelManager, _bitmapLoader);
+                        item, elementSave!, _animationCollectionViewModelManager, _bitmapLoader, _selectedState, _wireframeObjectManager);
 
                     toReturn.Name = item.Name;
                     toReturn.ContainingInstance = container.InstanceSave;

--- a/Tool/Tests/GumToolUnitTests/Plugins/StateAnimationPlugin/DuplicateServiceTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/StateAnimationPlugin/DuplicateServiceTests.cs
@@ -1,0 +1,79 @@
+using Gum.DataTypes;
+using Gum.Managers;
+using Gum.Services.Dialogs;
+using Moq;
+using Shouldly;
+using StateAnimationPlugin.Managers;
+using System;
+using System.IO;
+using ToolsUtilities;
+using Xunit;
+
+namespace GumToolUnitTests.Plugins.StateAnimationPlugin;
+
+/// <summary>
+/// Characterization tests pinning <see cref="DuplicateService"/>'s animation-file copy behavior
+/// after it was drained from service-locator lookups to constructor injection
+/// (<see cref="IDialogService"/> + <see cref="IProjectManager"/>). The project is supplied via a
+/// mocked <see cref="IProjectManager"/> so these run without a loaded project or the service locator.
+/// The dialog is only consulted when the destination file already exists; both paths exercised here
+/// avoid it, so a bare <see cref="IDialogService"/> stub is sufficient.
+/// </summary>
+public class DuplicateServiceTests : BaseTestClass
+{
+    private readonly string _tempDirectory;
+    private readonly Mock<IProjectManager> _projectManager = new();
+    private readonly DuplicateService _duplicateService;
+
+    public DuplicateServiceTests()
+    {
+        _tempDirectory = Path.Combine(
+            Path.GetTempPath(), "GumDuplicateServiceTests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDirectory);
+
+        _duplicateService = new DuplicateService(Mock.Of<IDialogService>(), _projectManager.Object);
+    }
+
+    [Fact]
+    public void HandleDuplicate_copies_animation_file_when_destination_absent()
+    {
+        string projectFile = Path.Combine(_tempDirectory, "MyProject.gumx");
+        _projectManager.Setup(x => x.GumProjectSave).Returns(new GumProjectSave { FullFileName = projectFile });
+
+        // DuplicateService builds "<projectDir>/<Subfolder>/<Name>Animations.ganx"; ComponentSave's
+        // Subfolder is "Components".
+        string componentsDirectory = Path.Combine(FileManager.GetDirectory(projectFile), "Components");
+        Directory.CreateDirectory(componentsDirectory);
+        File.WriteAllText(Path.Combine(componentsDirectory, "FooAnimations.ganx"), "<ElementAnimationsSave/>");
+
+        _duplicateService.HandleDuplicate(
+            new ComponentSave { Name = "Foo" }, new ComponentSave { Name = "Bar" });
+
+        File.Exists(Path.Combine(componentsDirectory, "BarAnimations.ganx")).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void HandleDuplicate_does_nothing_when_project_is_null()
+    {
+        _projectManager.Setup(x => x.GumProjectSave).Returns((GumProjectSave?)null);
+
+        string componentsDirectory = Path.Combine(_tempDirectory, "Components");
+        Directory.CreateDirectory(componentsDirectory);
+        File.WriteAllText(Path.Combine(componentsDirectory, "FooAnimations.ganx"), "<ElementAnimationsSave/>");
+
+        Should.NotThrow(() => _duplicateService.HandleDuplicate(
+            new ComponentSave { Name = "Foo" }, new ComponentSave { Name = "Bar" }));
+
+        File.Exists(Path.Combine(componentsDirectory, "BarAnimations.ganx")).ShouldBeFalse();
+    }
+
+    public override void Dispose()
+    {
+        if (Directory.Exists(_tempDirectory))
+        {
+            Directory.Delete(_tempDirectory, recursive: true);
+        }
+
+        base.Dispose();
+    }
+}

--- a/Tool/Tests/GumToolUnitTests/Plugins/StateAnimationPlugin/RenameManagerTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/StateAnimationPlugin/RenameManagerTests.cs
@@ -1,18 +1,14 @@
 using Gum.DataTypes;
 using Gum.DataTypes.Variables;
 using Gum.Managers;
-using Gum.Services;
 using Gum.Services.Dialogs;
 using Gum.ToolStates;
 using Gum.Wireframe;
-using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using Shouldly;
 using StateAnimationPlugin.Managers;
 using StateAnimationPlugin.ViewModels;
 using System;
-using System.Collections.Generic;
-using System.Reflection;
 using System.Threading;
 using Xunit;
 
@@ -21,26 +17,16 @@ namespace GumToolUnitTests.Plugins.StateAnimationPlugin;
 /// <summary>
 /// Characterization tests pinning the keyframe-mutating <see cref="RenameManager"/> overloads.
 /// These were deferred when ACVMM/RenameManager were drained (#3281) because the animation view
-/// models could not be constructed in isolation. They can now: <see cref="BitmapLoader"/> is an
-/// injectable <see cref="IBitmapLoader"/> (stubbed here), the remaining ViewModel constructor
-/// dependencies are satisfied via the service locator, and <see cref="ElementAnimationsViewModel"/>'s
-/// WPF right-click <c>MenuItem</c> creation is handled by building it on an STA thread.
+/// models could not be constructed in isolation. They can now: the animation view models take all
+/// of their dependencies via the constructor (stubbed here with Moq), and
+/// <see cref="ElementAnimationsViewModel"/>'s WPF right-click <c>MenuItem</c> creation is handled
+/// by building it on an STA thread.
 /// </summary>
 public class RenameManagerTests : BaseTestClass
 {
-    private readonly IServiceProvider _testServiceProvider;
     private readonly IBitmapLoader _bitmapLoader = Mock.Of<IBitmapLoader>();
-
-    public RenameManagerTests()
-    {
-        // AnimationViewModel/ElementAnimationsViewModel still resolve ISelectedState and
-        // IWireframeObjectManager from the locator in their constructors.
-        ServiceCollection services = new ServiceCollection();
-        services.AddSingleton(Mock.Of<ISelectedState>());
-        services.AddSingleton(Mock.Of<IWireframeObjectManager>());
-        _testServiceProvider = services.BuildServiceProvider();
-        Locator.Register(_testServiceProvider);
-    }
+    private readonly ISelectedState _selectedState = Mock.Of<ISelectedState>();
+    private readonly IWireframeObjectManager _wireframeObjectManager = Mock.Of<IWireframeObjectManager>();
 
     [Fact]
     public void HandleRename_Animation_RenamesMatchingKeyframeAnimationNames()
@@ -53,7 +39,7 @@ public class RenameManagerTests : BaseTestClass
 
             AnimationViewModel animation = CreateAnimationWithKeyframes(
                 Keyframe(animationName: "OldAnim"));
-            AnimationViewModel renamed = new AnimationViewModel(_bitmapLoader) { Name = "NewAnim" };
+            AnimationViewModel renamed = new AnimationViewModel(_bitmapLoader, _selectedState, _wireframeObjectManager) { Name = "NewAnim" };
 
             RenameManager renameManager = CreateRenameManager();
 
@@ -132,7 +118,7 @@ public class RenameManagerTests : BaseTestClass
 
     private AnimationViewModel CreateAnimationWithKeyframes(params AnimatedKeyframeViewModel[] keyframes)
     {
-        AnimationViewModel animation = new AnimationViewModel(_bitmapLoader);
+        AnimationViewModel animation = new AnimationViewModel(_bitmapLoader, _selectedState, _wireframeObjectManager);
         foreach (AnimatedKeyframeViewModel keyframe in keyframes)
         {
             animation.Keyframes.Add(keyframe);
@@ -147,7 +133,10 @@ public class RenameManagerTests : BaseTestClass
             Mock.Of<IDialogService>(),
             Mock.Of<IAnimationCollectionViewModelManager>(),
             Mock.Of<IRenameManager>(),
-            _bitmapLoader);
+            _bitmapLoader,
+            _selectedState,
+            _wireframeObjectManager,
+            Mock.Of<IOutputManager>());
         foreach (AnimationViewModel animation in animations)
         {
             viewModel.Animations.Add(animation);
@@ -183,15 +172,5 @@ public class RenameManagerTests : BaseTestClass
         {
             throw new Exception("Test body threw on the STA thread.", caught);
         }
-    }
-
-    public override void Dispose()
-    {
-        PropertyInfo prop = typeof(Locator).GetProperty(
-            "ServiceProviders", BindingFlags.NonPublic | BindingFlags.Static)!;
-        List<IServiceProvider> providers = (List<IServiceProvider>)prop.GetValue(null)!;
-        providers.Remove(_testServiceProvider);
-
-        base.Dispose();
     }
 }


### PR DESCRIPTION
## What

Drains the `Locator.GetRequiredService<T>()`-in-constructor classes in `Gum/StateAnimationPlugin/` to constructor injection, same recipe as the EditorTab drain batch. Behavior-preserving — the injected instances are the same DI singletons the classes previously service-located.

### Drained
- **DuplicateService** — `IDialogService` + `IProjectManager` (the latter replacing the method-body lookup in `HandleDuplicate`).
- **SubAnimationSelectionDialogViewModel** — `IOutputManager` + `ISelectedState` (feeding `AnimationFilePathService`); also `IWireframeObjectManager` to thread `AnimationViewModel.FromSave`.
- **AnimationViewModel** — `ISelectedState` + `IWireframeObjectManager`; threaded through the static `FromSave` factory and all its callers.
- **ElementAnimationsViewModel** — drained its own `ISelectedState` lookup and added `IWireframeObjectManager` + `IOutputManager`, forwarded to the `AnimationViewModel` / `SubAnimationSelectionDialogViewModel` construction sites.
- **ElementDeleteService** — `IDialogService`. **Beyond the three named members**, but it's the same trivial recipe and is the last `Locator`-in-ctor in the directory; included to complete the directory drain. Easy to drop if you'd rather scope it separately.

### Plumbing
`MainStateAnimationPlugin` injects `IProjectManager` + `IWireframeObjectManager` and supplies the new deps to the constructed services and the `ElementAnimationsViewModel` factory closure. Both new plugin imports are **already bridged** in `PluginManager.LoadPlugins` and `PluginBridgedServiceTypes.All`, so no bridge/test-list change was needed.

`AnimationViewModel` is constructed in multiple spots (the `#3329` VM-factory closure, `ElementAnimationsViewModel`, `SubAnimationSelectionDialogViewModel.FromSave`, and tests). The cascade stayed entirely within the plugin project + its own test — it did **not** escape the plugin — so `AnimationViewModel` is included rather than split to a follow-up.

`CommonControlLogic` was excluded as instructed (it's `new`'d inside an AlignmentButtons View).

## Tests
- `RenameManagerTests` now constructs the view models via constructor injection, dropping the `Locator` scaffolding it only needed because those ctors used to service-locate `ISelectedState`/`IWireframeObjectManager`.
- New `DuplicateServiceTests` pins the file-copy-when-destination-absent and null-project early-out paths. (The "destination exists → confirm" path goes through the `ShowYesNoMessage` **extension method**, which Moq can't verify, so it's left to manual coverage rather than contorting the harness.)
- `AllPluginsCompositionTests` stays green — `MainStateAnimationPlugin` still composes via MEF with its two new ctor imports.

Focused run: **16 passed** (StateAnimationPlugin suite + composition guard).

## Manual test
Not needed — behavior-preserving drain (`Locator` → injected, same singletons). The compiler flags every stale call site, the MEF composition test proves the plugin still loads with the new imports, and the pinning tests cover the touched logic.
