### PR TITLE
Drain ParentSetLogic + TextureCoordinate BackgroundManager Locator ctors to injection

### DIFF
--- a/Gum/CodeOutputPlugin/MainCodeOutputPlugin.cs
+++ b/Gum/CodeOutputPlugin/MainCodeOutputPlugin.cs
@@ -123,7 +123,7 @@ public class MainCodeOutputPlugin : PluginBase
         _codeOutputProjectSettingsManager = new CodeOutputProjectSettingsManager(
             codeGenLogger, _projectDirectoryProvider);
 
-        _parentSetLogic = new ParentSetLogic(_codeGenerator);
+        _parentSetLogic = new ParentSetLogic(_codeGenerator, _selectedState, dialogService, _fileCommands);
 
         _messenger.Register<RequestCodeGenerationMessage>(
             this,

--- a/Gum/CodeOutputPlugin/Manager/ParentSetLogic.cs
+++ b/Gum/CodeOutputPlugin/Manager/ParentSetLogic.cs
@@ -9,7 +9,6 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Gum.Commands;
-using Gum.Services;
 using Gum.Services.Dialogs;
 using ToolsUtilities;
 
@@ -17,14 +16,21 @@ namespace CodeOutputPlugin.Manager;
 
 public class ParentSetLogic
 {
-    private readonly ISelectedState _selectedState = Locator.GetRequiredService<ISelectedState>();
-    private readonly IDialogService _dialogService = Locator.GetRequiredService<IDialogService>();
-    private readonly IFileCommands _fileCommands = Locator.GetRequiredService<IFileCommands>();
+    private readonly ISelectedState _selectedState;
+    private readonly IDialogService _dialogService;
+    private readonly IFileCommands _fileCommands;
     private readonly CodeGenerator _codeGenerator;
 
-    public ParentSetLogic(CodeGenerator codeGenerator)
+    public ParentSetLogic(
+        CodeGenerator codeGenerator,
+        ISelectedState selectedState,
+        IDialogService dialogService,
+        IFileCommands fileCommands)
     {
         _codeGenerator = codeGenerator;
+        _selectedState = selectedState;
+        _dialogService = dialogService;
+        _fileCommands = fileCommands;
     }
 
     public void HandleVariableSet(ElementSave element, InstanceSave? instance, string variableName, object? oldValue, CodeOutputProjectSettings codeOutputProjectSettings)

--- a/Gum/TextureCoordinateSelectionPlugin/Logic/BackgroundManager.cs
+++ b/Gum/TextureCoordinateSelectionPlugin/Logic/BackgroundManager.cs
@@ -1,7 +1,6 @@
 using CommunityToolkit.Mvvm.Messaging;
 using Gum;
 using Gum.Dialogs;
-using Gum.Services;
 using Gum.Settings;
 using Microsoft.Xna.Framework.Graphics;
 using RenderingLibrary;
@@ -37,10 +36,10 @@ public class BackgroundManager : IVisualOverlayManager, IRecipient<ThemeChangedM
         }
     }
 
-    public BackgroundManager()
+    public BackgroundManager(IMessenger messenger, IThemingService themingService)
     {
-        _messenger = Locator.GetRequiredService<IMessenger>();
-        _themingService = Locator.GetRequiredService<IThemingService>();
+        _messenger = messenger;
+        _themingService = themingService;
         _messenger.RegisterAll(this);
     }
 

--- a/Gum/TextureCoordinateSelectionPlugin/Logic/ControlLogic.cs
+++ b/Gum/TextureCoordinateSelectionPlugin/Logic/ControlLogic.cs
@@ -1,7 +1,9 @@
-﻿using FlatRedBall.SpecializedXnaControls;
+﻿using CommunityToolkit.Mvvm.Messaging;
+using FlatRedBall.SpecializedXnaControls;
 using Gum;
 using Gum.Commands;
 using Gum.DataTypes;
+using Gum.Dialogs;
 using Gum.Managers;
 using Gum.Plugins;
 using Gum.Plugins.InternalPlugins.VariableGrid;
@@ -89,7 +91,9 @@ public class TextureCoordinateDisplayController : IDisposable
         ISetVariableLogic setVariableLogic,
         ITabManager tabManager,
         IHotkeyManager hotkeyManager,
-        ScrollBarLogicWpf scrollBarLogic)
+        ScrollBarLogicWpf scrollBarLogic,
+        IMessenger messenger,
+        IThemingService themingService)
     {
         _selectedState = selectedState;
         _undoManager = undoManager;
@@ -100,7 +104,7 @@ public class TextureCoordinateDisplayController : IDisposable
         _hotkeyManager = hotkeyManager;
         _scrollBarLogic = scrollBarLogic;
 
-        _backgroundManager = new BackgroundManager();
+        _backgroundManager = new BackgroundManager(messenger, themingService);
         _lineGridManager = new LineGridManager();
         _nineSliceGuideManager = new NineSliceGuideManager();
         _textureOutlineManager = new TextureOutlineManager();

--- a/Gum/TextureCoordinateSelectionPlugin/MainTextureCoordinatePlugin.cs
+++ b/Gum/TextureCoordinateSelectionPlugin/MainTextureCoordinatePlugin.cs
@@ -1,5 +1,6 @@
 using Gum.Commands;
 using Gum.DataTypes;
+using Gum.Dialogs;
 using Gum.Logic.FileWatch;
 using Gum.Managers;
 using Gum.Plugins;
@@ -58,7 +59,8 @@ public class MainTextureCoordinatePlugin : PluginBase, IRecipient<UiBaseFontSize
         IHotkeyManager hotkeyManager,
         IProjectManager projectManager,
         IFileWatchManager fileWatchManager,
-        IMessenger messenger)
+        IMessenger messenger,
+        IThemingService themingService)
     {
         _selectedState = selectedState;
         _wireframeCommands = wireframeCommands;
@@ -71,7 +73,9 @@ public class MainTextureCoordinatePlugin : PluginBase, IRecipient<UiBaseFontSize
             setVariableLogic,
             tabManager,
             hotkeyManager,
-            new ScrollBarLogicWpf());
+            new ScrollBarLogicWpf(),
+            messenger,
+            themingService);
 
         _viewModel = new (
             projectManager,

--- a/Tool/Tests/GumToolUnitTests/Plugins/CodeOutputPlugins/ParentSetLogicTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/CodeOutputPlugins/ParentSetLogicTests.cs
@@ -1,0 +1,63 @@
+using CodeOutputPlugin.Manager;
+using Gum.Commands;
+using Gum.DataTypes.Variables;
+using Gum.Services.Dialogs;
+using Gum.ToolStates;
+using Moq;
+using Xunit;
+
+namespace GumToolUnitTests.Plugins.CodeOutputPlugins;
+
+public class ParentSetLogicTests : BaseTestClass
+{
+    // ParentSetLogic now takes ISelectedState + IDialogService + IFileCommands via its constructor
+    // (drained from field-initializer Locator.GetRequiredService calls). These pin that the early-out
+    // paths of HandleVariableSet never touch the injected dialog/file dependencies. Because those
+    // guard paths never dereference the CodeGenerator either, passing null for it here is safe (and
+    // avoids standing up its multi-argument graph just to verify a guard).
+    private readonly Mock<ISelectedState> _selectedState = new();
+    private readonly Mock<IDialogService> _dialogService = new();
+    private readonly Mock<IFileCommands> _fileCommands = new();
+    private readonly ParentSetLogic _parentSetLogic;
+
+    public ParentSetLogicTests()
+    {
+        _parentSetLogic = new ParentSetLogic(
+            codeGenerator: null!,
+            _selectedState.Object,
+            _dialogService.Object,
+            _fileCommands.Object);
+    }
+
+    [Fact]
+    public void HandleVariableSet_does_nothing_when_no_state_is_selected()
+    {
+        _selectedState.Setup(x => x.SelectedStateSave).Returns((StateSave?)null);
+
+        _parentSetLogic.HandleVariableSet(
+            element: null!,
+            instance: null,
+            variableName: "Parent",
+            oldValue: null,
+            codeOutputProjectSettings: null!);
+
+        _dialogService.VerifyNoOtherCalls();
+        _fileCommands.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public void HandleVariableSet_does_nothing_for_non_parent_variable()
+    {
+        _selectedState.Setup(x => x.SelectedStateSave).Returns(new StateSave());
+
+        _parentSetLogic.HandleVariableSet(
+            element: null!,
+            instance: null,
+            variableName: "X",
+            oldValue: null,
+            codeOutputProjectSettings: null!);
+
+        _dialogService.VerifyNoOtherCalls();
+        _fileCommands.VerifyNoOtherCalls();
+    }
+}


### PR DESCRIPTION
## What

Continues the static-singleton drain batch (#3337 / #3338 / #3339), promoting field-initializer / ctor-body `Locator.GetRequiredService<T>()` lookups to constructor parameters in two tool-plugin helper classes. Behavior-preserving: the injected instances are the same DI singletons the classes previously service-located.

### `ParentSetLogic` (CodeOutputPlugin) — primary
- Injects `ISelectedState` + `IDialogService` + `IFileCommands` (were three field-initializer `Locator` calls), keeping the existing `CodeGenerator` param.
- `MainCodeOutputPlugin` (the only construction site) passes its already-injected `_selectedState` / `dialogService` / `_fileCommands`.
- No MEF bridge change: no new dependency crosses the plugin's `[ImportingConstructor]`.

### `BackgroundManager` (TextureCoordinateSelectionPlugin) — stretch, included
- Injects `IMessenger` + `IThemingService` (was a parameterless `Locator` ctor).
- The cascade is clean: `TextureCoordinateDisplayController` forwards both, and `MainTextureCoordinatePlugin` already injects `IMessenger` and now also injects `IThemingService`.
- Both services were **already** bridged in `PluginManager.LoadPlugins` and mirrored in `PluginBridgedServiceTypes.All` — the `LoadPlugins` comment already anticipated *"IThemingService feeds the BackgroundManager"*. So **no MEF bridge / test-list change** was needed.
- Note: there are two distinct `BackgroundManager` classes; only the TextureCoordinateSelectionPlugin one is touched here. The `EditorTabPlugin_XNA` one (already a 3-param injected ctor) is unaffected.

## Tests
- New `ParentSetLogicTests` pins that `HandleVariableSet`'s early-out paths never touch the injected dialog/file dependencies.
- `AllPluginsCompositionTests` + `ServiceProviderCompositionSpikeTests` stay green, confirming `MainTextureCoordinatePlugin` still composes via MEF with the new `IThemingService` param.

## Build / test result
- `dotnet build GumFull.sln` — succeeded, 0 errors.
- Focused tool tests (`ParentSetLogicTests | AllPluginsCompositionTests | ServiceProviderCompositionSpikeTests`) — 4 passed, 0 failed.

## Manual test
Not needed — behavior-preserving DI refactor (same singletons). The compiler, the pinning test, and the MEF composition guards are the proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
