### PR TITLE
ADR-0005: dedicated Gum.Presentation assembly for the headless presentation layer

### DIFF
--- a/Direction/decisions/0005-headless-presentation-assembly.md
+++ b/Direction/decisions/0005-headless-presentation-assembly.md
@@ -1,0 +1,56 @@
+# 0005. Home for the headless presentation layer: a dedicated `Gum.Presentation` assembly
+
+- **Status:** Accepted
+- **Date:** 2026-06-24
+- **Deciders:** Victor Chelaru, Claude
+
+## Context
+
+ADR-0003 set the target end-state as a headless `net8.0` assembly enforcing the logic↔view
+boundary, but deliberately left the *home* open: "grown from `Gum.ProjectServices`, or a new
+`Gum.Core`." Phase 3 of `ui-decoupling-plan.md` (moving ViewModels and their service interfaces
+headless) cannot start until this is settled — relocating interfaces into the wrong assembly means
+moving them twice.
+
+Today: all core UI-service interfaces (`ISelectedState`, `IDialogService`, `IUndoManager`,
+`IFileCommands`, `IGuiCommands`, `IElementCommands`, …) live in the WPF tool assembly
+(`Gum.csproj`) — the headless side cannot see any of them. `Gum.ProjectServices` is a
+project-**operations** layer (load/save, error-check, codegen, font/SVG export, import) genuinely
+shared by the **CLI** (`Gum.Cli`) and the tool. The CLI consumes operations; it does not consume
+presentation.
+
+## Decision
+
+We will introduce a dedicated headless `net8.0` **`Gum.Presentation`** assembly holding the
+ViewModels and the UI-service interface *contracts* (`IDialogService`, `ISelectedState`,
+`IUndoManager`, …). Dependency stack: **`Gum.Presentation` → `Gum.ProjectServices` → `GumCommon`**.
+Both the WPF tool and any future Avalonia shell reference `Gum.Presentation` and supply the
+framework-specific interface *implementations* (e.g. the WPF `DialogService`). The **CLI continues
+to reference only `Gum.ProjectServices`**. `Gum.ProjectServices` stays the operations layer and
+takes on no presentation code.
+
+## Consequences
+
+- **Easier:** a clean acyclic layer stack; the CLI stays lean (no presentation cruft it never
+  calls); the presentation↔operations boundary is **compiler-enforced**, consistent with ADR-0003's
+  "compiler, not convention" thesis; both UI shells bind the *same* ViewModels, so there is no logic
+  duplication across WPF/Avalonia (only view markup — XAML vs. AXAML — is reimplemented).
+- **Harder / cost:** one more project; Phase 3 must relocate interfaces in **dependency-ordered
+  clusters** (each interface drags the transitive closure of the types in its signatures);
+  framework-specific implementations must be split out to the shell.
+- **Watch-out:** the split only pays off if logic actually *leaves* the view code-behind (the
+  view-wall classes) — otherwise it just re-duplicates into the Avalonia shell.
+- **Follow-up:** per-interface placement (which implementations move to `Gum.Presentation` vs. stay
+  in the shell) is Phase 3 execution detail, not decided here.
+
+## Alternatives considered
+
+- **Grow `Gum.ProjectServices` to hold everything.** Rejected: conflates project-operations with
+  presentation; forces the CLI to compile presentation interfaces it never uses; and nothing stops
+  operations code from depending on a ViewModel (wrong direction) — the same convention-not-compiler
+  weakness ADR-0003 rejected.
+- **Folders within one assembly** (operations + presentation namespaces in one `net8.0` project).
+  Rejected: a namespace is not a boundary; per ADR-0003 only a project reference durably enforces a
+  layer.
+- **Keep interfaces in the WPF tool** (status quo). Rejected: this is exactly what blocks Phase 3 —
+  a ViewModel cannot go headless while its dependencies' interfaces are stranded in `Gum.csproj`.

--- a/Direction/decisions/README.md
+++ b/Direction/decisions/README.md
@@ -24,3 +24,4 @@ re-litigating it.
 | [0002](0002-target-code-first-frameworks-not-engines.md) | Target code-first C# frameworks, not full engines | Accepted | 2026-06-20 |
 | [0003](0003-decouple-tool-ui-from-logic.md) | Decouple the Gum tool's UI from its application logic | Accepted | 2026-06-20 |
 | [0004](0004-viewmodels-expose-neutral-presentation-state.md) | ViewModels expose resolved display state in neutral types | Accepted | 2026-06-20 |
+| [0005](0005-headless-presentation-assembly.md) | Home for the headless presentation layer: a dedicated `Gum.Presentation` assembly | Accepted | 2026-06-24 |


### PR DESCRIPTION
Records the decision (Accepted) that resolves the home left open by ADR-0003.

**Decision:** ViewModels + UI-service interface contracts (`IDialogService`, `ISelectedState`, `IUndoManager`, …) go into a new headless `net8.0` **`Gum.Presentation`** assembly. Dependency stack: `Gum.Presentation` → `Gum.ProjectServices` → `GumCommon`. Both the WPF tool and a future Avalonia shell reference `Gum.Presentation` and supply the framework-specific implementations; the CLI keeps referencing only `Gum.ProjectServices` (which stays the operations layer).

Gates Phase 3 of `Direction/ui-decoupling-plan.md` — interface relocation can't start until the home is fixed. Docs-only; adds the ADR + index row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)