### PR TITLE
Seam-seal IHotkeyManager.ProcessCmdKeyWireframe off WinForms Keys (Phase 1)

### DIFF
--- a/Gum/Managers/HotkeyManager.cs
+++ b/Gum/Managers/HotkeyManager.cs
@@ -458,13 +458,19 @@ public class HotkeyManager : IHotkeyManager
 
     bool _isNudging;
 
-    public bool ProcessCmdKeyWireframe(Keys keyData)
+    public bool ProcessCmdKeyWireframe(GumKey? key, bool isShiftDown, bool isCtrlDown, bool isAltDown)
     {
-        bool handled = false;
+        // The interface is framework-neutral (GumKey, not WinForms Keys). Rebuild the Keys value the
+        // nudge logic matches against: GumKey values equal Win32 virtual-key codes (pinned by GumKeyTests),
+        // so the key is a pure cast, and the modifier bits are re-applied from the booleans. Reconstructing
+        // here keeps HandleNudge / KeyCombination.IsPressed unchanged and behavior identical — including the
+        // existing suppression of nudging while Ctrl/Alt are held (Ctrl+arrow pans the camera instead).
+        Keys keyData = key.HasValue ? (Keys)(int)key.Value : Keys.None;
+        if (isShiftDown) { keyData |= Keys.Shift; }
+        if (isCtrlDown) { keyData |= Keys.Control; }
+        if (isAltDown) { keyData |= Keys.Alt; }
 
-        handled = HandleNudge(keyData);
-
-        return handled;
+        return HandleNudge(keyData);
     }
 
     private bool HandleNudge(Keys keyData)

--- a/Gum/Managers/IHotkeyManager.cs
+++ b/Gum/Managers/IHotkeyManager.cs
@@ -44,5 +44,12 @@ public interface IHotkeyManager
     void HandleKeyDownElementTreeView(System.Windows.Forms.KeyEventArgs e);
     void HandleEditorKeyDown(System.Windows.Forms.KeyEventArgs e);
     void HandleKeyUpWireframe(System.Windows.Forms.KeyEventArgs e);
-    bool ProcessCmdKeyWireframe(System.Windows.Forms.Keys keyData);
+
+    /// <summary>
+    /// Handles wireframe command keys (arrow-key nudging) using Gum's framework-neutral
+    /// <see cref="Gum.Input.GumKey"/> so this interface stays free of WinForms. Callers at the WinForms
+    /// boundary translate <c>System.Windows.Forms.Keys</c> via <c>ToGumKey()</c> and pass the modifier
+    /// state explicitly. Returns true if the key was handled.
+    /// </summary>
+    bool ProcessCmdKeyWireframe(Gum.Input.GumKey? key, bool isShiftDown, bool isCtrlDown, bool isAltDown);
 }

--- a/Tool/EditorTabPlugin_XNA/ExtensionMethods/KeysExtensions.cs
+++ b/Tool/EditorTabPlugin_XNA/ExtensionMethods/KeysExtensions.cs
@@ -1,0 +1,30 @@
+using Gum.Input;
+using System.Windows.Forms;
+
+namespace EditorTabPlugin_XNA.ExtensionMethods;
+
+/// <summary>
+/// Converts WinForms key codes to Gum's framework-neutral <see cref="GumKey"/> at the editor-host
+/// (WinForms) boundary, so interfaces such as <c>IHotkeyManager</c> need not reference
+/// <c>System.Windows.Forms</c>.
+/// </summary>
+public static class KeysExtensions
+{
+    /// <summary>
+    /// Maps a WinForms <see cref="Keys"/> value to the matching <see cref="GumKey"/>, ignoring any
+    /// modifier flags (Shift/Ctrl/Alt) present on <paramref name="keys"/>. Only the keys the wireframe
+    /// hotkey path actually binds are mapped; any other key returns <c>null</c>.
+    /// </summary>
+    public static GumKey? ToGumKey(this Keys keys)
+    {
+        Keys keyCode = keys & Keys.KeyCode;
+        return keyCode switch
+        {
+            Keys.Up => GumKey.Up,
+            Keys.Down => GumKey.Down,
+            Keys.Left => GumKey.Left,
+            Keys.Right => GumKey.Right,
+            _ => null,
+        };
+    }
+}

--- a/Tool/EditorTabPlugin_XNA/Views/WireframeControl.cs
+++ b/Tool/EditorTabPlugin_XNA/Views/WireframeControl.cs
@@ -1,4 +1,5 @@
-﻿using EditorTabPlugin_XNA.ViewModels;
+﻿using EditorTabPlugin_XNA.ExtensionMethods;
+using EditorTabPlugin_XNA.ViewModels;
 using Gum.DataTypes;
 using Gum.Managers;
 using Gum.Plugins;
@@ -125,7 +126,12 @@ public class WireframeControl : GraphicsDeviceControl
 
     protected override bool ProcessCmdKey(ref Message msg, Keys keyData)
     {
-        bool handled = _hotkeyManager.ProcessCmdKeyWireframe(keyData);
+        // Translate the WinForms key at this boundary so IHotkeyManager stays framework-neutral.
+        bool handled = _hotkeyManager.ProcessCmdKeyWireframe(
+            keyData.ToGumKey(),
+            isShiftDown: (keyData & Keys.Shift) == Keys.Shift,
+            isCtrlDown: (keyData & Keys.Control) == Keys.Control,
+            isAltDown: (keyData & Keys.Alt) == Keys.Alt);
 
         if (handled)
         {

--- a/Tool/Tests/GumToolUnitTests/Input/KeysExtensionsTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Input/KeysExtensionsTests.cs
@@ -1,0 +1,35 @@
+using EditorTabPlugin_XNA.ExtensionMethods;
+using Gum.Input;
+using Shouldly;
+using WinFormsKeys = System.Windows.Forms.Keys;
+
+namespace GumToolUnitTests.Input;
+
+public class KeysExtensionsTests : BaseTestClass
+{
+    [Fact]
+    public void ToGumKey_Arrows_MapToMatchingGumKey()
+    {
+        WinFormsKeys.Up.ToGumKey().ShouldBe(GumKey.Up);
+        WinFormsKeys.Down.ToGumKey().ShouldBe(GumKey.Down);
+        WinFormsKeys.Left.ToGumKey().ShouldBe(GumKey.Left);
+        WinFormsKeys.Right.ToGumKey().ShouldBe(GumKey.Right);
+    }
+
+    [Fact]
+    public void ToGumKey_IgnoresModifierFlags()
+    {
+        // The boundary passes modifier state separately, so ToGumKey strips Shift/Ctrl/Alt and
+        // maps only the key code.
+        (WinFormsKeys.Shift | WinFormsKeys.Up).ToGumKey().ShouldBe(GumKey.Up);
+        (WinFormsKeys.Control | WinFormsKeys.Left).ToGumKey().ShouldBe(GumKey.Left);
+    }
+
+    [Fact]
+    public void ToGumKey_UnmappedKey_ReturnsNull()
+    {
+        // Only the keys the wireframe nudge path binds are mapped; everything else is null.
+        WinFormsKeys.A.ToGumKey().ShouldBeNull();
+        WinFormsKeys.Enter.ToGumKey().ShouldBeNull();
+    }
+}

--- a/Tool/Tests/GumToolUnitTests/Managers/HotkeyManagerTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Managers/HotkeyManagerTests.cs
@@ -116,7 +116,7 @@ public class HotkeyManagerTests : BaseTestClass
     {
         (ComponentSave element, InstanceSave instance) = SetUpSelectedInstance(x: 10f, y: 20f);
 
-        bool handled = _hotkeyManager.ProcessCmdKeyWireframe(System.Windows.Forms.Keys.Up);
+        bool handled = _hotkeyManager.ProcessCmdKeyWireframe(GumKey.Up, isShiftDown: false, isCtrlDown: false, isAltDown: false);
 
         handled.ShouldBeTrue();
         _elementCommands.Verify(e => e.MoveSelectedObjectsBy(0f, -1f), Times.Once);
@@ -129,11 +129,23 @@ public class HotkeyManagerTests : BaseTestClass
     }
 
     [Fact]
+    public void ProcessCmdKeyWireframe_CtrlArrow_DoesNotNudge()
+    {
+        // Ctrl+arrow pans the camera elsewhere, so it must not also nudge the selection here.
+        SetUpSelectedInstance(x: 10f, y: 20f);
+
+        bool handled = _hotkeyManager.ProcessCmdKeyWireframe(GumKey.Up, isShiftDown: false, isCtrlDown: true, isAltDown: false);
+
+        handled.ShouldBeFalse();
+        _elementCommands.Verify(e => e.MoveSelectedObjectsBy(It.IsAny<float>(), It.IsAny<float>()), Times.Never);
+    }
+
+    [Fact]
     public void ProcessCmdKeyWireframe_LockedInstance_DoesNothing()
     {
         SetUpSelectedInstance(x: 10f, y: 20f, locked: true);
 
-        bool handled = _hotkeyManager.ProcessCmdKeyWireframe(System.Windows.Forms.Keys.Up);
+        bool handled = _hotkeyManager.ProcessCmdKeyWireframe(GumKey.Up, isShiftDown: false, isCtrlDown: false, isAltDown: false);
 
         handled.ShouldBeFalse();
         _elementCommands.Verify(e => e.MoveSelectedObjectsBy(It.IsAny<float>(), It.IsAny<float>()), Times.Never);
@@ -145,7 +157,7 @@ public class HotkeyManagerTests : BaseTestClass
     {
         SetUpSelectedInstance(x: 10f, y: 20f);
 
-        bool handled = _hotkeyManager.ProcessCmdKeyWireframe(System.Windows.Forms.Keys.Shift | System.Windows.Forms.Keys.Up);
+        bool handled = _hotkeyManager.ProcessCmdKeyWireframe(GumKey.Up, isShiftDown: true, isCtrlDown: false, isAltDown: false);
 
         handled.ShouldBeTrue();
         _elementCommands.Verify(e => e.MoveSelectedObjectsBy(0f, -5f), Times.Once);


### PR DESCRIPTION
## What

Phase 1 seam-seal: lift `System.Windows.Forms.Keys` out of `IHotkeyManager` so the interface can eventually move into the headless `Gum.Presentation` assembly (ADR-0005, Phase 3 relocation).

`IHotkeyManager.ProcessCmdKeyWireframe(System.Windows.Forms.Keys keyData)` now takes the framework-neutral `GumKey` plus explicit modifier booleans:

```csharp
bool ProcessCmdKeyWireframe(GumKey? key, bool isShiftDown, bool isCtrlDown, bool isAltDown);
```

The interface no longer references WinForms.

## Why modifier booleans (not just `GumKey`)

The wireframe nudge path needs more than a bare key:
- **Shift+arrow nudges 5px vs. arrow nudges 1px** — the magnitude depends on Shift.
- **Ctrl/Alt suppress nudging** — `Ctrl+arrow` pans the camera elsewhere and must *not* also nudge the selection. The old `IsPressed(Keys)` logic encoded this via the combined `Keys` value.

A single `GumKey` (a plain key identity, no modifier flags) can't carry that, so the modifier state is passed explicitly alongside it.

## Boundary translation

`WireframeControl.ProcessCmdKey` is the only place that still touches `Keys`. It translates via a new adapter:

- `Keys.ToGumKey()` (`EditorTabPlugin_XNA.ExtensionMethods.KeysExtensions`) maps a WinForms key code to `GumKey`, stripping modifier flags. It reuses `GumKey`'s pinned VK-code invariant and only maps the keys the nudge path actually binds (the four arrows), returning `null` for anything else.
- Modifier bits are extracted separately and passed as the booleans.

No pre-existing `Keys → GumKey` mapping existed (only the inverse `GumKey → Keys` pure cast inside `KeyCombination`), so this adds the reverse direction at the boundary rather than duplicating anything.

## Behavior-preserving

The `HotkeyManager` impl reconstructs the same `Keys` value internally and feeds the **unchanged** `HandleNudge` / `KeyCombination.IsPressed` logic, so the downstream matching is byte-for-byte identical: arrow = 1px, Shift+arrow = 5px, Ctrl/Alt = no nudge.

## Tests

- New `KeysExtensionsTests` — characterizes the `ToGumKey` mapping (arrows map, modifiers stripped, unmapped keys → null).
- New `ProcessCmdKeyWireframe_CtrlArrow_DoesNotNudge` — pins the preserved Ctrl-suppression now that modifiers are explicit params.
- Updated the existing `ProcessCmdKeyWireframe_*` tests to the new signature.

All 18 in scope pass; `GumFull.sln` builds clean (0 errors).

## Manual smoke

Behavior is pinned by unit tests; the only un-unit-tested seam is the `WireframeControl` boundary wiring. Recommended manual check in the running tool: select an instance in the wireframe, press arrow keys (nudge 1px), Shift+arrow (nudge 5px), and Ctrl+arrow (camera pans, selection does not nudge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
