### PR TITLE
Relocate ISelectedState + extract ITreeNode into headless Gum.Presentation (Phase 3, ADR-0005)

### DIFF
--- a/Gum/Managers/DragDropManager.cs
+++ b/Gum/Managers/DragDropManager.cs
@@ -28,17 +28,6 @@ using Gum.Plugins.InternalPlugins.VariableGrid;
 namespace Gum.Managers;
 
 
-public interface ITreeNode
-{
-    object? Tag { get; }
-    FilePath GetFullFilePath();
-    ITreeNode? Parent { get; }
-    string Text { get; }
-    string FullPath { get; }
-
-    void Expand();
-}
-
 public class DragDropManager : IDragDropManager
 {
     #region Fields

--- a/Tools/Gum.Presentation/Managers/ITreeNode.cs
+++ b/Tools/Gum.Presentation/Managers/ITreeNode.cs
@@ -1,0 +1,14 @@
+using ToolsUtilities;
+
+namespace Gum.Managers;
+
+public interface ITreeNode
+{
+    object? Tag { get; }
+    FilePath GetFullFilePath();
+    ITreeNode? Parent { get; }
+    string Text { get; }
+    string FullPath { get; }
+
+    void Expand();
+}

--- a/Tools/Gum.Presentation/ToolStates/ISelectedState.cs
+++ b/Tools/Gum.Presentation/ToolStates/ISelectedState.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using Gum.DataTypes;
 using Gum.DataTypes.Variables;
-using System.Windows.Forms;
 using RenderingLibrary;
 using Gum.Wireframe;
 using Gum.DataTypes.Behaviors;


### PR DESCRIPTION
## What

Continues **ADR-0005 Phase 3** (after #3345 / #3346) by moving the `ISelectedState` contract into the headless **`Gum.Presentation`** assembly, gated on one small prerequisite handled in the same PR.

1. **Extract `ITreeNode`** — it was declared inside the WinForms-coupled `Gum/Managers/DragDropManager.cs`, but its contract is already framework-clean (`object? Tag`, `FilePath GetFullFilePath()`, `ITreeNode? Parent`, `string Text` / `string FullPath`, `void Expand()`). Lifted verbatim into `Tools/Gum.Presentation/Managers/ITreeNode.cs`, **preserving the `Gum.Managers` namespace**. The concrete tree-node implementation stays in the tool shell.
2. **Relocate `ISelectedState`** — moved `Gum/ToolStates/ISelectedState.cs` → `Tools/Gum.Presentation/ToolStates/ISelectedState.cs` (git rename, 99% similarity), **preserving the `Gum.ToolStates` namespace** so no consumer changes. The concrete `SelectedState` impl stays in the shell. Dropped the unused `using System.Windows.Forms;` — the only WinForms reference in the file.

## Why it compiles headless

The signature closure is already headless:
- `ElementWithState`, `RecursiveVariableFinder`, `IPositionedSizedObject` are `Compile`-linked into `GumCommon`; the `*Save` / `I*Container` types are `GumDataTypes`; `FilePath` is `ToolsUtilities` → `GumCommon`. All reachable via `Gum.Presentation → Gum.ProjectServices → GumCommon`.
- `ISelectedState`'s default-interface-method bodies (`SelectedRecursiveVariableFinder`, `GetTopLevelElementStack`, `SelectedInstanceContainer`) construct only those headless types — confirmed compiling in `Gum.Presentation`.

## Proof (behavior-preserving)

- **`Gum.Presentation` builds standalone — 0 errors.** The csproj has no WinForms/WPF reference, so any leak would fail the build; it doesn't.
- **`GumToolUnitTests` green — 997 passed, 0 failed, 4 skipped.** This recompiles the tool shell, so `DragDropManager` and every `ITreeNode` consumer still resolve through the preserved namespace.

No manual test needed — pure interface relocation; the compiler + unit suite are the proof.

Closes the `ISelectedState` cluster of ADR-0005 Phase 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
