### PR TITLE
CI: split the Gum tool build into its own parallel Windows job (#3349 item 1)

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -8,6 +8,44 @@ on:
   workflow_dispatch:
 
 jobs:
+  # The Gum tool (Gum.sln) builds with neither submodules nor .NET mobile
+  # workloads: it contains no FNA/Sokol projects and no mobile-TFM projects
+  # (MonoGameGum/RaylibGum are not in it; the in-solution KniGum defaults to
+  # net8.0). Isolating the tool build + its WPF unit tests onto their own
+  # Windows runner lets this lane skip the ~5 min submodule-init + workload-
+  # restore setup tax that the runtime lane (Build-and-Test) pays, shrinking
+  # overall PR wall-clock for free (standard runners cost nothing on a public
+  # repo). This lane installs no workloads on purpose; if it ever fails on a
+  # missing workload, the error names exactly which one to add here. (#3349)
+  #
+  # Skipped on push to main: the tool was already validated in the PR, and unlike
+  # Build-and-Test this lane seeds no cache, so there is nothing to do on push.
+  Build-Tool:
+    if: github.event_name != 'push'
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: false
+      - name: Setup .NET SDKs
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 9.0.x
+      - name: Build Gum (tool)
+        run: |
+          dotnet restore "Gum.sln" --verbosity quiet
+          dotnet build "Gum.sln" --configuration Release --no-restore --verbosity quiet -p:WarningLevel=0
+      - name: GumToolUnitTests
+        run: dotnet test "Tool/Tests/GumToolUnitTests" --configuration Release --no-build --logger "trx" --results-directory "TestResults"
+      - name: Publish Test Results
+        if: always()
+        uses: dorny/test-reporter@v2
+        with:
+          name: Tests Tool (Windows)
+          path: "TestResults/*.trx"
+          reporter: dotnet-trx
+          fail-on-error: true
+
   Build-and-Test:
     strategy:
       matrix:
@@ -78,11 +116,8 @@ jobs:
 
       # On push to main, the only purpose is to seed the workload cache.
       # If the cache already exists, skip the entire build and test.
-      - name: Build Gum (Windows Only)
-        if: (github.event_name != 'push' || steps.cache-workloads.outputs.cache-hit != 'true') && runner.os == 'Windows'
-        run: |
-          dotnet restore "Gum.sln" --verbosity quiet
-          dotnet build "Gum.sln" --configuration Release --no-restore --verbosity quiet -p:WarningLevel=0
+      # (The Gum tool is built + unit-tested in the separate Build-Tool job at
+      # the top of this file, which needs neither submodules nor workloads. #3349)
 
       # IncludeAndroid=true forces KniGum's net9.0-android TFM to be included so CI
       # actually validates the #if ANDROID code compiles. KniGum uses opt-in for Android
@@ -163,7 +198,9 @@ jobs:
       # MonoGame's headless TestGame harness):
       #   - MonoGameGum.Tests              (headless TestGame harness)
       #   - SokolGum.Tests                 (Sokol; headless)
-      #   - GumToolUnitTests               (WPF tool unit tests; Windows only)
+      #   - GumToolUnitTests               (WPF tool unit tests; Windows only —
+      #                                     now runs in the separate Build-Tool
+      #                                     job at the top of this file, #3349)
       #   - Gum.Bundle.Tests               (brotli/tar/format; pure IO)
       #   - Gum.ProjectServices.Tests      (headless project loading, codegen)
       #   - Gum.ProjectServices.SkiaGum.Tests (SkiaGum SVG export — renders into
@@ -215,10 +252,6 @@ jobs:
       - name: SokolGum.Tests
         if: github.event_name != 'push' || steps.cache-workloads.outputs.cache-hit != 'true'
         run: dotnet test "Tests/SokolGum.Tests" --configuration Release --no-build --logger "trx" --results-directory "TestResults"
-
-      - name: GumToolUnitTests (Windows Only)
-        if: (github.event_name != 'push' || steps.cache-workloads.outputs.cache-hit != 'true') && runner.os == 'Windows'
-        run: dotnet test "Tool/Tests/GumToolUnitTests" --configuration Release --no-build --logger "trx" --results-directory "TestResults"
 
       - name: Gum.Bundle.Tests
         if: github.event_name != 'push' || steps.cache-workloads.outputs.cache-hit != 'true'


### PR DESCRIPTION
**Part of #3349 — item 1 of 4** (does **not** close the tracking issue).

## What

Splits the `Gum.sln` tool build (and `GumToolUnitTests`) out of the monolithic `Build-and-Test` job into a new, parallel `Build-Tool` Windows job.

## Why

The runtime CI lane is one sequential job, so Windows wall-clock = the sum of its steps. The ~3:16 "Build Gum" tool build sat *behind* the ~5 min setup tax (submodule init + .NET workload restore) that the runtime work needs — but the tool needs **none** of that setup:

- **No submodules:** `Gum.sln` has no FNA/Sokol projects.
- **No workloads:** across all 31 member projects, the only mobile TFM is KniGum's `net9.0-android`, gated behind `IncludeAndroid=true`, which this lane doesn't pass — so KniGum builds `net8.0` only.

Isolating the tool onto its own free standard runner lets it skip the entire setup tax and run concurrently, removing ~3:16 from the runtime lane's critical path at $0 (free runners on a public repo).

## Safety

All nine test projects still run by `Build-and-Test` are built by `AllLibraries.sln`, so dropping the tool build from that job leaves them intact. `GumToolUnitTests` is the only suite tied to `Gum.sln`, and it moves with the tool build.

The new lane installs no workloads on purpose — if it ever fails on a missing one, the error names exactly which to add (the assumption above is verified, not just speculative).

## Verification

This is a CI-orchestration change with no local runtime aspect — **the verification is this PR's own Actions run.** Read the **Windows wall-clock** off the run here and compare to the ~12:52 baseline; I'll record the measured number on #3349. Expected: the runtime lane drops ~3-4 min, with the new `Build-Tool` lane finishing in parallel well under that.
