### PR TITLE
CI: cache submodules + parallel --jobs fetch (#3349 item 2)

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -64,8 +64,45 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: false
+
+      # Cache the submodule object stores (.git/modules) + working trees, keyed on
+      # the pinned submodule SHAs, so a hit turns the recursive non-shallow init
+      # below into a fast local verify instead of re-cloning FNA's nested native
+      # submodules (SDL/FAudio/FNA3D/Theorafile) and Sokol.NET/box2d every run.
+      # Keyed on the SHAs (not the workflow-file hash) so it re-caches only when a
+      # submodule pointer actually moves. Save on main only, mirroring the workload
+      # cache: a PR-scoped cache is not reused across PRs, and the 10 GB repo cache
+      # budget is dominated by the workload packs — limiting submodule caches to one
+      # per OS on main avoids evicting those. (#3349 item 2)
+      - name: Compute submodule cache key
+        id: submodule-key
+        shell: bash
+        run: echo "shas=$(git submodule status | cut -c2-41 | tr -d '\n')" >> "$GITHUB_OUTPUT"
+      - name: Cache submodules (main only)
+        id: cache-submodules
+        if: github.ref == 'refs/heads/main'
+        uses: actions/cache@v4
+        with:
+          path: |
+            .git/modules
+            fna
+            Sokol.NET
+          key: submodules-${{ runner.os }}-${{ steps.submodule-key.outputs.shas }}
+      - name: Restore cached submodules (PRs)
+        id: cache-submodules-restore
+        if: github.ref != 'refs/heads/main'
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            .git/modules
+            fna
+            Sokol.NET
+          key: submodules-${{ runner.os }}-${{ steps.submodule-key.outputs.shas }}
+
+      # --jobs parallelizes the (still non-shallow) fetch of independent submodules
+      # on a cache miss; on a hit the objects are already local so this is fast.
       - name: Init submodules (non-shallow)
-        run: git submodule update --init --recursive
+        run: git submodule update --init --recursive --jobs 4
 
       - name: Setup .NET SDKs
         uses: actions/setup-dotnet@v4


### PR DESCRIPTION
**Part of #3349 — item 2 of 4** (does **not** close the tracking issue).

## What

Caches the submodule checkout and parallelizes the fetch:
- New `Cache submodules` step caches `.git/modules` + the `fna/` and `Sokol.NET/` working trees, keyed on the pinned submodule SHAs (`git submodule status`).
- `Init submodules` gains `--jobs 4`.

## Why

The `Init submodules (non-shallow)` step re-cloned FNA's nested native submodules (SDL/FAudio/FNA3D/Theorafile) and Sokol.NET/box2d on **every** run (~2m06 on Windows). On a cache hit, `git submodule update --init --recursive` becomes a fast local verify instead of a network clone. `--jobs 4` parallelizes the independent fetches on a miss.

The init still runs **unconditionally**, so git guarantees the submodules end up correct regardless of cache state — the cache only accelerates it (worst case on a stale/partial hit: git fetches the delta, i.e. slower, never wrong).

## Design notes

- **Keyed on submodule SHAs, not the workflow-file hash**, so it re-caches only when a submodule pointer actually moves (computed cross-platform via `shell: bash`, validated to yield the two 40-char SHAs).
- **Saved on main only**, mirroring the workload cache: PR-scoped caches aren't reused across PRs, and the shared 10 GB repo cache budget is dominated by the workload packs — limiting submodule caches to one per OS on main avoids evicting those. (#3349 item 3 trims the workload cache, which will free budget here.)

## Verification

CI-orchestration change, no local runtime aspect. This PR's run validates the key step (both OS), the cache-miss path, and that `--jobs` init + the build still pass. **The ~1m45 speedup is only visible on the *next main run after merge*** — like the workload cache, main-only-save means this PR still cache-misses. I'll record the measured submodule-init time from that main run on #3349.
