### PR TITLE
Extract IUndoPluginNotifier narrow port over PluginManager for UndoManager (ADR-0005 Phase 3)

### DIFF
--- a/Gum/Plugins/PluginManager.cs
+++ b/Gum/Plugins/PluginManager.cs
@@ -54,7 +54,7 @@ internal enum PluginCategories
 
 #endregion
 
-public class PluginManager : IPluginManager
+public class PluginManager : IPluginManager, IUndoPluginNotifier
 {
     #region Fields
 

--- a/Gum/Services/Builder.cs
+++ b/Gum/Services/Builder.cs
@@ -89,6 +89,9 @@ file static class ServiceCollectionExtensions
         // (Program.cs) does the heavy two-stage setup and registers the global instance for the static plugin machinery.
         services.AddSingleton<PluginManager>();
         services.AddSingleton<IPluginManager>(provider => provider.GetRequiredService<PluginManager>());
+        // IUndoPluginNotifier: narrow headless port (ADR-0005 Phase 3) so UndoManager no longer depends on the
+        // concrete PluginManager. Resolves to the same PluginManager singleton, so plugin calls fire as before.
+        services.AddSingleton<IUndoPluginNotifier>(provider => provider.GetRequiredService<PluginManager>());
         services.AddSingleton<TypeManager>();
         services.AddSingleton<ITypeManager>(provider => provider.GetRequiredService<TypeManager>());
         services.AddSingleton<ProjectManager>();

--- a/Gum/Undo/UndoManager.cs
+++ b/Gum/Undo/UndoManager.cs
@@ -5,7 +5,6 @@ using Gum.DataTypes.Behaviors;
 using Gum.DataTypes.Variables;
 using Gum.Logic;
 using Gum.Managers;
-using Gum.Plugins;
 using Gum.ToolStates;
 using Gum.Wireframe;
 using System;
@@ -26,7 +25,7 @@ public class UndoManager : IUndoManager
     private readonly IGuiCommands _guiCommands;
     private readonly IFileCommands _fileCommands;
     private readonly IMessenger _messenger;
-    private readonly PluginManager _pluginManager;
+    private readonly IUndoPluginNotifier _pluginNotifier;
 
     internal ObservableCollection<UndoLock> UndoLocks { get; private set; }
 
@@ -75,14 +74,14 @@ public class UndoManager : IUndoManager
         IGuiCommands guiCommands,
         IFileCommands fileCommands,
         IMessenger messenger,
-        PluginManager pluginManager)
+        IUndoPluginNotifier pluginNotifier)
     {
         _selectedState = selectedState;
         _renameLogic = renameLogic;
         _guiCommands = guiCommands;
         _fileCommands = fileCommands;
         _messenger = messenger;
-        _pluginManager = pluginManager;
+        _pluginNotifier = pluginNotifier;
 
         UndoLocks = new ObservableCollection<UndoLock>();
         UndoLocks.CollectionChanged += HandleUndoLockChanged;
@@ -507,9 +506,9 @@ public class UndoManager : IUndoManager
         {
             foreach(var addedInstance in addedAndRemovedInstances.Value.Added)
             {
-                _pluginManager.InstanceAdd(toApplyTo, addedInstance);
+                _pluginNotifier.InstanceAdd(toApplyTo, addedInstance);
             }
-            _pluginManager.InstancesDelete(toApplyTo, addedAndRemovedInstances.Value.Removed);
+            _pluginNotifier.InstancesDelete(toApplyTo, addedAndRemovedInstances.Value.Removed);
         }
 
         if (shouldRefreshStateTreeView)
@@ -1097,7 +1096,7 @@ public class UndoManager : IUndoManager
 
         _guiCommands.RefreshStateTreeView();
 
-        _pluginManager.BehaviorSelected(behavior);
+        _pluginNotifier.BehaviorSelected(behavior);
 
         _fileCommands.TryAutoSaveBehavior(behavior);
     }

--- a/Tool/Tests/GumToolUnitTests/Managers/UndoManagerTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Managers/UndoManagerTests.cs
@@ -4,8 +4,6 @@ using Gum.DataTypes;
 using Gum.DataTypes.Behaviors;
 using Gum.DataTypes.Variables;
 using Gum.Logic;
-using Gum.Plugins;
-using Gum.Plugins.BaseClasses;
 using Gum.ToolStates;
 using Gum.Undo;
 using Moq;
@@ -24,7 +22,7 @@ public class UndoManagerTests : BaseTestClass
     private readonly Mock<IGuiCommands> _guiCommands;
     private readonly Mock<IFileCommands> _fileCommands;
     private readonly Mock<IMessenger> _messenger;
-    private readonly Mock<PluginManager> _pluginManager;
+    private readonly Mock<IUndoPluginNotifier> _pluginNotifier;
     private readonly UndoManager _undoManager;
 
     public UndoManagerTests()
@@ -34,8 +32,7 @@ public class UndoManagerTests : BaseTestClass
         _guiCommands = new Mock<IGuiCommands>();
         _fileCommands = new Mock<IFileCommands>();
         _messenger = new Mock<IMessenger>();
-        _pluginManager = new Mock<PluginManager>();
-        _pluginManager.Object.Plugins = new List<PluginBase>();
+        _pluginNotifier = new Mock<IUndoPluginNotifier>();
 
         ComponentSave component = new();
         component.States.Add(new Gum.DataTypes.Variables.StateSave 
@@ -63,7 +60,7 @@ public class UndoManagerTests : BaseTestClass
             _guiCommands.Object,
             _fileCommands.Object,
             _messenger.Object,
-            _pluginManager.Object
+            _pluginNotifier.Object
             );
     }
 
@@ -192,7 +189,7 @@ public class UndoManagerTests : BaseTestClass
         _undoManager.RecordUndo();
         _undoManager.PerformUndo();
 
-        _pluginManager.Verify(x => x.InstanceAdd(It.IsAny<ElementSave>(), It.IsAny<InstanceSave>()),
+        _pluginNotifier.Verify(x => x.InstanceAdd(It.IsAny<ElementSave>(), It.IsAny<InstanceSave>()),
             Times.Once);
     }
 
@@ -215,9 +212,33 @@ public class UndoManagerTests : BaseTestClass
         _undoManager.RecordUndo();
         _undoManager.PerformUndo();
 
-        _pluginManager.Verify(
+        _pluginNotifier.Verify(
             x => x.InstancesDelete(It.IsAny<ElementSave>(), It.IsAny<InstanceSave[]>()),
             Times.Once);
+    }
+
+    [Fact]
+    public void PerformUndo_OnBehaviorChange_ShouldNotifyPluginOfBehaviorSelected()
+    {
+        // Pins the third undo->plugin notification (alongside InstanceAdd / InstancesDelete above):
+        // a behavior undo must still fire BehaviorSelected. This is the call that now travels through the
+        // narrow IUndoPluginNotifier port rather than the concrete PluginManager (ADR-0005 Phase 3).
+        var behavior = new BehaviorSave { Name = "MyBehavior" };
+        var category = new StateSaveCategory { Name = "MyCategory" };
+        behavior.Categories.Add(category);
+
+        _selectedState
+            .Setup(x => x.SelectedBehavior)
+            .Returns(behavior);
+
+        _undoManager.RecordBehaviorState();
+
+        category.States.Add(new StateSave { Name = "State1" });
+
+        _undoManager.RecordBehaviorUndo();
+        _undoManager.PerformUndo();
+
+        _pluginNotifier.Verify(x => x.BehaviorSelected(behavior), Times.Once);
     }
 
 

--- a/Tools/Gum.Presentation/Undo/IUndoPluginNotifier.cs
+++ b/Tools/Gum.Presentation/Undo/IUndoPluginNotifier.cs
@@ -1,0 +1,21 @@
+using Gum.DataTypes;
+using Gum.DataTypes.Behaviors;
+
+namespace Gum.Undo;
+
+/// <summary>
+/// Narrow notification port the undo subsystem uses to inform plugins that an
+/// undo/redo just changed the model. It exposes only the three plugin calls
+/// <see cref="UndoManager"/> actually makes, all of which take headless
+/// (<c>GumDataTypes</c>) parameters, so the undo logic no longer needs to depend
+/// on the concrete, MEF/WinForms-entangled <c>PluginManager</c> (ADR-0005 Phase 3).
+/// The live implementation is <c>PluginManager</c>, bridged via DI.
+/// </summary>
+public interface IUndoPluginNotifier
+{
+    void InstanceAdd(ElementSave elementSave, InstanceSave instance);
+
+    void InstancesDelete(ElementSave elementSave, InstanceSave[] instances);
+
+    void BehaviorSelected(BehaviorSave? behaviorSave);
+}


### PR DESCRIPTION
## What

First step toward moving `UndoManager` headless (ADR-0005 Phase 3). `UndoManager` injected the concrete, MEF/WinForms-entangled `PluginManager` but called only **three** methods on it — `InstanceAdd(ElementSave, InstanceSave)`, `InstancesDelete(ElementSave, InstanceSave[])`, and `BehaviorSelected(BehaviorSave?)` — all with headless `GumDataTypes` parameters.

This PR extracts those three calls into a narrow notification port, **`IUndoPluginNotifier`**, in the headless `Gum.Presentation` assembly, and injects that port into `UndoManager` in place of the concrete `PluginManager`.

## How

- **New port** `Tools/Gum.Presentation/Undo/IUndoPluginNotifier.cs` (namespace `Gum.Undo`, alongside `IUndoManager`) — exactly the 3 members.
- **`PluginManager` implements it** — its existing methods matched the signatures *exactly* (including the nullable `BehaviorSave?`), so `: IPluginManager, IUndoPluginNotifier` was all that was needed — no shim/adapter.
- **DI** (`Builder.cs`) registers `IUndoPluginNotifier` to resolve to the same `PluginManager` singleton, so the three plugin calls fire exactly as before.
- **`UndoManager`** field/ctor param `PluginManager _pluginManager` → `IUndoPluginNotifier _pluginNotifier`; the 3 call sites updated; now-dead `using Gum.Plugins;` removed.

## Behavior-preserving

The three notifications route through the port unchanged — **not** rerouted through `IMessenger` (that would change how plugins receive them). This is the canonical refactoring-direction "narrow port over an entangled singleton" pattern, and decouples the undo logic from `PluginManager` — a prerequisite for relocating `UndoManager` itself headless in a later PR (still gated on the separate `IRenameLogic` relocation). This PR does **not** move `UndoManager`.

## Tests

- The two existing instance-notification pinning tests now mock the narrow `Mock<IUndoPluginNotifier>` instead of `Mock<PluginManager>` (no more concrete-class mock, no `Plugins` list setup).
- Added `PerformUndo_OnBehaviorChange_ShouldNotifyPluginOfBehaviorSelected` to pin the third call — **red-first verified** (disabling the seam produced "No invocations performed").
- Full `GumToolUnitTests` suite green: **999 passed, 0 failed, 4 pre-existing skips**. `AllPluginsCompositionTests` confirms `PluginManager` still composes via MEF.
- `Gum.Presentation` builds standalone (zero WPF/WinForms leak).

Manual test: not needed — behavior-preserving narrow-port swap, proven by the compiler, the full unit suite, and the red-first pinning check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
