### PR TITLE
Extract IUndoRenameLogic narrow port; inject it into UndoManager in place of IRenameLogic (ADR-0005 Phase 3)

### DIFF
--- a/Gum/Logic/RenameLogic.cs
+++ b/Gum/Logic/RenameLogic.cs
@@ -22,84 +22,10 @@ using Gum.Plugins.InternalPlugins.VariableGrid;
 
 namespace Gum.Logic;
 
-#region Enums
-
-public enum NameChangeAction
-{
-    Move,
-    Rename
-}
-
-#endregion
-
-#region VariableChange Class
-
-public class VariableChange
-{
-    public IStateContainer Container;
-    public StateSaveCategory Category;
-    public StateSave State;
-    public VariableSave Variable;
-    public object NewValue;
-
-}
-
-public enum SideOfEquals
-{
-    Left,
-    Right,
-    Both
-}
-public class VariableReferenceChange
-{
-    public ElementSave Container;
-    public VariableListSave VariableReferenceList;
-    public int LineIndex;
-    public SideOfEquals ChangedSide;
-}
-
-public class VariableChangeResponse
-{
-    public List<VariableChange> VariableChanges = new List<VariableChange>();
-    public List<VariableReferenceChange> VariableReferenceChanges = new List<VariableReferenceChange>();
-
-    public string GetChangesDetails()
-    {
-        var details = string.Empty;
-
-        if (VariableChanges.Count > 0)
-        {
-            if (!string.IsNullOrEmpty(details)) details += "\n\n";
-            details += "This will also rename the following variables:";
-            foreach (var change in VariableChanges)
-            {
-                var containerName = change.Container is ElementSave elementSave
-                    ? elementSave.Name
-                    : change.Container.ToString();
-                details += $"\n• {change.Variable.Name} in {containerName}";
-            }
-        }
-
-        if (VariableReferenceChanges.Count > 0)
-        {
-            if (!string.IsNullOrEmpty(details)) details += "\n\n";
-            details += "This will also modify the following variable references:";
-            foreach (var change in VariableReferenceChanges)
-            {
-                try
-                {
-                    var line = change.VariableReferenceList.ValueAsIList[change.LineIndex];
-                    details += $"\n• {line} in {change.Container.Name}";
-                }
-                catch { }
-            }
-        }
-
-        return details;
-    }
-}
-
-#endregion
+// NameChangeAction, SideOfEquals, VariableChange, VariableReferenceChange, and VariableChangeResponse
+// were relocated to the headless Gum.Presentation assembly (Tools/Gum.Presentation/Logic/RenameChangeTypes.cs)
+// so the undo subsystem's narrow IUndoRenameLogic port can reference them without depending on the tool
+// (ADR-0005 Phase 3). They keep the Gum.Logic namespace, so consumers here compile unchanged.
 
 #region ElementReferences Class
 
@@ -486,7 +412,7 @@ public class CategoryReferences
 
 #endregion
 
-public class RenameLogic : IRenameLogic
+public class RenameLogic : IRenameLogic, IUndoRenameLogic
 {
     static bool isRenamingXmlFile;
 

--- a/Gum/Services/Builder.cs
+++ b/Gum/Services/Builder.cs
@@ -170,7 +170,11 @@ file static class ServiceCollectionExtensions
         services.AddSingleton<IVariableSaveLogic, VariableSaveLogic>();
         services.AddSingleton<IVariableReferenceLogic, VariableReferenceLogic>();
         services.AddSingleton<IReferenceFinder, ReferenceFinder>();
-        services.AddSingleton<IRenameLogic, RenameLogic>();
+        services.AddSingleton<RenameLogic>();
+        services.AddSingleton<IRenameLogic>(provider => provider.GetRequiredService<RenameLogic>());
+        // IUndoRenameLogic: narrow headless rename port (ADR-0005 Phase 3) so UndoManager no longer depends on the
+        // full IRenameLogic. Resolves to the same RenameLogic singleton, so rename calls fire as before.
+        services.AddSingleton<IUndoRenameLogic>(provider => provider.GetRequiredService<RenameLogic>());
         services.AddSingleton<ISetVariableLogic, SetVariableLogic>();
 
         services.AddSingleton<WireframeCommands>();

--- a/Gum/Undo/UndoManager.cs
+++ b/Gum/Undo/UndoManager.cs
@@ -21,7 +21,7 @@ public class UndoManager : IUndoManager
     #region Fields
 
     private readonly ISelectedState _selectedState;
-    private readonly IRenameLogic _renameLogic;
+    private readonly IUndoRenameLogic _renameLogic;
     private readonly IGuiCommands _guiCommands;
     private readonly IFileCommands _fileCommands;
     private readonly IMessenger _messenger;
@@ -69,8 +69,8 @@ public class UndoManager : IUndoManager
 
     #endregion
 
-    public UndoManager(ISelectedState selectedState, 
-        IRenameLogic renameLogic, 
+    public UndoManager(ISelectedState selectedState,
+        IUndoRenameLogic renameLogic,
         IGuiCommands guiCommands,
         IFileCommands fileCommands,
         IMessenger messenger,

--- a/Tool/Tests/GumToolUnitTests/Managers/UndoManagerTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Managers/UndoManagerTests.cs
@@ -18,7 +18,7 @@ namespace GumToolUnitTests.Managers;
 public class UndoManagerTests : BaseTestClass
 {
     private readonly Mock<ISelectedState> _selectedState;
-    private readonly Mock<IRenameLogic> _renameLogic;
+    private readonly Mock<IUndoRenameLogic> _renameLogic;
     private readonly Mock<IGuiCommands> _guiCommands;
     private readonly Mock<IFileCommands> _fileCommands;
     private readonly Mock<IMessenger> _messenger;
@@ -28,7 +28,7 @@ public class UndoManagerTests : BaseTestClass
     public UndoManagerTests()
     {
         _selectedState = new Mock<ISelectedState>();
-        _renameLogic = new Mock<IRenameLogic>();
+        _renameLogic = new Mock<IUndoRenameLogic>();
         _guiCommands = new Mock<IGuiCommands>();
         _fileCommands = new Mock<IFileCommands>();
         _messenger = new Mock<IMessenger>();
@@ -344,6 +344,33 @@ public class UndoManagerTests : BaseTestClass
             "NewName",
             "OldName",
             It.IsAny<HashSet<ElementSave>>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public void PerformUndo_OnElementRename_ShouldDelegateToRenameLogicHandleRename()
+    {
+        // Pins the third RenameLogic call routed through the narrow IUndoRenameLogic port
+        // (alongside GetChangesForRenamedVariable / ApplyVariableRenameChanges, covered by the two
+        // rename-delegation tests above): undoing an element whose Name changed must re-apply the
+        // rename via HandleRename so references stay consistent. This is the call that now travels
+        // through IUndoRenameLogic rather than the full IRenameLogic (ADR-0005 Phase 3, mirroring #3355).
+        ComponentSave component = _selectedState.Object.SelectedComponent!;
+        component.Name = "OriginalName";
+
+        _undoManager.RecordState();
+
+        component.Name = "RenamedName";
+
+        _undoManager.RecordUndo();
+        _undoManager.PerformUndo();
+
+        _renameLogic.Verify(x => x.HandleRename(
+            It.IsAny<IInstanceContainer>(),
+            It.IsAny<InstanceSave>(),
+            "RenamedName",
+            NameChangeAction.Rename,
+            false),
             Times.Once);
     }
 

--- a/Tools/Gum.Presentation/Logic/RenameChangeTypes.cs
+++ b/Tools/Gum.Presentation/Logic/RenameChangeTypes.cs
@@ -1,0 +1,91 @@
+using System.Collections.Generic;
+using Gum.DataTypes;
+using Gum.DataTypes.Variables;
+
+namespace Gum.Logic;
+
+// These rename-change data types were relocated out of the tool assembly's Gum/Logic/RenameLogic.cs
+// into the headless Gum.Presentation assembly (ADR-0005 Phase 3) so the undo subsystem's narrow
+// IUndoRenameLogic port can reference them without depending on the tool. They are framework-neutral
+// (GumDataTypes/ToolsUtilities only). The namespace is intentionally kept as Gum.Logic so the many
+// tool-side consumers compile unchanged.
+
+#region Enums
+
+public enum NameChangeAction
+{
+    Move,
+    Rename
+}
+
+public enum SideOfEquals
+{
+    Left,
+    Right,
+    Both
+}
+
+#endregion
+
+#region VariableChange Class
+
+public class VariableChange
+{
+    public IStateContainer Container;
+    public StateSaveCategory Category;
+    public StateSave State;
+    public VariableSave Variable;
+    public object NewValue;
+
+}
+
+public class VariableReferenceChange
+{
+    public ElementSave Container;
+    public VariableListSave VariableReferenceList;
+    public int LineIndex;
+    public SideOfEquals ChangedSide;
+}
+
+public class VariableChangeResponse
+{
+    public List<VariableChange> VariableChanges = new List<VariableChange>();
+    public List<VariableReferenceChange> VariableReferenceChanges = new List<VariableReferenceChange>();
+
+    public string GetChangesDetails()
+    {
+        var details = string.Empty;
+
+        if (VariableChanges.Count > 0)
+        {
+            if (!string.IsNullOrEmpty(details)) details += "\n\n";
+            details += "This will also rename the following variables:";
+            foreach (var change in VariableChanges)
+            {
+                var containerName = change.Container is ElementSave elementSave
+                    ? elementSave.Name
+                    : change.Container.ToString();
+                details += $"\n• {change.Variable.Name} in {containerName}";
+            }
+        }
+
+        if (VariableReferenceChanges.Count > 0)
+        {
+            if (!string.IsNullOrEmpty(details)) details += "\n\n";
+            details += "This will also modify the following variable references:";
+            foreach (var change in VariableReferenceChanges)
+            {
+                try
+                {
+                    var line = change.VariableReferenceList.ValueAsIList[change.LineIndex];
+                    details += $"\n• {line} in {change.Container.Name}";
+                }
+                catch { }
+            }
+        }
+
+        return details;
+    }
+}
+
+#endregion

--- a/Tools/Gum.Presentation/Undo/IUndoRenameLogic.cs
+++ b/Tools/Gum.Presentation/Undo/IUndoRenameLogic.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+using Gum.DataTypes;
+using Gum.Logic;
+using ToolsUtilities;
+
+namespace Gum.Undo;
+
+/// <summary>
+/// Narrow rename port the undo subsystem uses to re-apply name changes when an
+/// undo/redo restores an element or variable. It exposes only the three rename calls
+/// <see cref="UndoManager"/> actually makes, all of which take headless
+/// (<c>GumDataTypes</c>/<c>ToolsUtilities</c>) parameters, so the undo logic no longer
+/// needs to depend on the full, MEF/WinForms-entangled <c>IRenameLogic</c> (ADR-0005 Phase 3).
+/// The live implementation is <c>RenameLogic</c>, bridged via DI to the same instance as
+/// <c>IRenameLogic</c>. This mirrors <see cref="IUndoPluginNotifier"/>.
+/// </summary>
+public interface IUndoRenameLogic
+{
+    GeneralResponse HandleRename(IInstanceContainer instanceContainer, InstanceSave? instance, string oldName, NameChangeAction action, bool askAboutRename = true);
+
+    VariableChangeResponse GetChangesForRenamedVariable(IStateContainer owner, string oldFullName, string oldStrippedOrExposedName);
+
+    void ApplyVariableRenameChanges(VariableChangeResponse changes, string oldStrippedOrExposedName, string newStrippedOrExposedName, HashSet<ElementSave> elementsNeedingSave);
+}


### PR DESCRIPTION
## What

Mirrors #3355 (`IUndoPluginNotifier`), this time for `IRenameLogic` — the **last shell-only ctor dependency** `UndoManager` held before it can be relocated headless (ADR-0005 Phase 3).

`UndoManager` injected the full, MEF/WinForms-entangled `IRenameLogic` but called only **three** of its ~12 methods — `HandleRename`, `GetChangesForRenamedVariable`, `ApplyVariableRenameChanges` — all with headless `GumDataTypes`/`ToolsUtilities` parameters. This PR extracts those three calls into a narrow port, **`IUndoRenameLogic`**, in the headless `Gum.Presentation` assembly, and injects that port into `UndoManager` in place of `IRenameLogic`.

## How

- **New port** `Tools/Gum.Presentation/Undo/IUndoRenameLogic.cs` (namespace `Gum.Undo`, alongside `IUndoManager` / `IUndoPluginNotifier`) — exactly the 3 members.
- **Relocated 5 data types** out of the tool's `Gum/Logic/RenameLogic.cs` into `Tools/Gum.Presentation/Logic/RenameChangeTypes.cs` — the 3 methods' closure pulled them in: `NameChangeAction` + `SideOfEquals` enums, and `VariableChange` / `VariableReferenceChange` / `VariableChangeResponse`. All are framework-neutral (GumDataTypes/ToolsUtilities only). They **keep the `Gum.Logic` namespace**, so the ~20 tool-side consumers compile unchanged (the file physically moves assemblies; the namespace travels with the types). Confirmed via an assembly-graph sweep that no consumer compiles into `GumCommon`/`Gum.ProjectServices` (which would have forced them lower) — every consumer is in the tool `Gum.dll` or its test assembly.
- **`RenameLogic` implements it** — its existing method signatures matched the port *exactly*, so `: IRenameLogic, IUndoRenameLogic` was all that was needed — no shim/adapter.
- **DI** (`Builder.cs`) registers `RenameLogic` as its own singleton and resolves both `IRenameLogic` and `IUndoRenameLogic` to it, so the rename calls fire against the same instance as before (mirrors the `PluginManager` 3-line pattern).
- **`UndoManager`** field/ctor param `IRenameLogic _renameLogic` → `IUndoRenameLogic _renameLogic`; the 3 call sites are unchanged (field name kept).

## Behavior-preserving

The three rename calls route through the narrow port unchanged. This is the canonical refactoring-direction "narrow port over an entangled dependency" pattern. With it landed, **all of `UndoManager`'s ctor deps are now headless** (`ISelectedState`, `IUndoRenameLogic`, `IGuiCommands`, `IFileCommands`, `IMessenger`, `IUndoPluginNotifier`) — and its body references no tool-only types — so the class itself can be relocated to `Gum.Presentation` in a follow-up. **This PR does NOT move `UndoManager`.** File-disjoint from #3355.

## Tests

- The two existing rename-delegation pinning tests now mock `Mock<IUndoRenameLogic>` (covering `GetChangesForRenamedVariable` / `ApplyVariableRenameChanges`).
- Added `PerformUndo_OnElementRename_ShouldDelegateToRenameLogicHandleRename` to pin the third call (`HandleRename`) — **red-first verified** (disabling the seam produced "No invocations performed").
- Full `GumToolUnitTests` suite green: **1000 passed, 0 failed, 4 pre-existing skips**. `AllPluginsCompositionTests` confirms plugins still compose via MEF.
- `Gum.Presentation` builds standalone (zero WPF/WinForms leak); `GumFull.sln` builds with 0 errors.

Manual test: not needed — behavior-preserving narrow-port swap + type relocation, proven by the compiler (`GumFull.sln` + standalone `Gum.Presentation`), the full unit suite, and the red-first pinning check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
