### PR TITLE
Migrate UndoManager tests into headless Gum.Presentation.Tests (ADR-0005 Phase 3)

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -240,6 +240,9 @@ jobs:
       #                                     job at the top of this file, #3349)
       #   - Gum.Bundle.Tests               (brotli/tar/format; pure IO)
       #   - Gum.ProjectServices.Tests      (headless project loading, codegen)
+      #   - Gum.Presentation.Tests         (headless undo/redo + relocated tool
+      #                                     ViewModels; references Gum.Presentation
+      #                                     alone, no WPF/WinForms — ADR-0005)
       #   - Gum.ProjectServices.SkiaGum.Tests (SkiaGum SVG export — renders into
       #                                     SKSvgCanvas, CPU-only like SkiaGum.Tests)
       #   - Gum.Analyzers.Tests            (Roslyn analyzers; pure compilation)
@@ -297,6 +300,10 @@ jobs:
       - name: Gum.ProjectServices.Tests
         if: github.event_name != 'push' || steps.cache-workloads.outputs.cache-hit != 'true'
         run: dotnet test "Tests/Gum.ProjectServices.Tests" --configuration Release --no-build --logger "trx" --results-directory "TestResults"
+
+      - name: Gum.Presentation.Tests
+        if: github.event_name != 'push' || steps.cache-workloads.outputs.cache-hit != 'true'
+        run: dotnet test "Tests/Gum.Presentation.Tests" --configuration Release --no-build --logger "trx" --results-directory "TestResults"
 
       - name: Gum.Analyzers.Tests
         if: github.event_name != 'push' || steps.cache-workloads.outputs.cache-hit != 'true'

--- a/AllLibraries.sln
+++ b/AllLibraries.sln
@@ -151,6 +151,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Gum.Themes.Template.Raylib"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Gum.ProjectServices.SkiaGum.Tests", "Tests\Gum.ProjectServices.SkiaGum.Tests\Gum.ProjectServices.SkiaGum.Tests.csproj", "{9642D9F2-2087-450A-B6DD-80A3E0A05571}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Gum.Presentation.Tests", "Tests\Gum.Presentation.Tests\Gum.Presentation.Tests.csproj", "{6A4051AC-CF20-4357-A457-A517118D18C6}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Gum.Presentation", "Tools\Gum.Presentation\Gum.Presentation.csproj", "{20EC25E2-921F-4F6F-AB3F-4D2BB1A552DF}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1352,6 +1356,42 @@ Global
 		{9642D9F2-2087-450A-B6DD-80A3E0A05571}.Release|x64.Build.0 = Release|Any CPU
 		{9642D9F2-2087-450A-B6DD-80A3E0A05571}.Release|x86.ActiveCfg = Release|Any CPU
 		{9642D9F2-2087-450A-B6DD-80A3E0A05571}.Release|x86.Build.0 = Release|Any CPU
+		{6A4051AC-CF20-4357-A457-A517118D18C6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6A4051AC-CF20-4357-A457-A517118D18C6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6A4051AC-CF20-4357-A457-A517118D18C6}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{6A4051AC-CF20-4357-A457-A517118D18C6}.Debug|x64.Build.0 = Debug|Any CPU
+		{6A4051AC-CF20-4357-A457-A517118D18C6}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{6A4051AC-CF20-4357-A457-A517118D18C6}.Debug|x86.Build.0 = Debug|Any CPU
+		{6A4051AC-CF20-4357-A457-A517118D18C6}.Release_No_Diagnostics|Any CPU.ActiveCfg = Debug|Any CPU
+		{6A4051AC-CF20-4357-A457-A517118D18C6}.Release_No_Diagnostics|Any CPU.Build.0 = Debug|Any CPU
+		{6A4051AC-CF20-4357-A457-A517118D18C6}.Release_No_Diagnostics|x64.ActiveCfg = Debug|Any CPU
+		{6A4051AC-CF20-4357-A457-A517118D18C6}.Release_No_Diagnostics|x64.Build.0 = Debug|Any CPU
+		{6A4051AC-CF20-4357-A457-A517118D18C6}.Release_No_Diagnostics|x86.ActiveCfg = Debug|Any CPU
+		{6A4051AC-CF20-4357-A457-A517118D18C6}.Release_No_Diagnostics|x86.Build.0 = Debug|Any CPU
+		{6A4051AC-CF20-4357-A457-A517118D18C6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6A4051AC-CF20-4357-A457-A517118D18C6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6A4051AC-CF20-4357-A457-A517118D18C6}.Release|x64.ActiveCfg = Release|Any CPU
+		{6A4051AC-CF20-4357-A457-A517118D18C6}.Release|x64.Build.0 = Release|Any CPU
+		{6A4051AC-CF20-4357-A457-A517118D18C6}.Release|x86.ActiveCfg = Release|Any CPU
+		{6A4051AC-CF20-4357-A457-A517118D18C6}.Release|x86.Build.0 = Release|Any CPU
+		{20EC25E2-921F-4F6F-AB3F-4D2BB1A552DF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{20EC25E2-921F-4F6F-AB3F-4D2BB1A552DF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{20EC25E2-921F-4F6F-AB3F-4D2BB1A552DF}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{20EC25E2-921F-4F6F-AB3F-4D2BB1A552DF}.Debug|x64.Build.0 = Debug|Any CPU
+		{20EC25E2-921F-4F6F-AB3F-4D2BB1A552DF}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{20EC25E2-921F-4F6F-AB3F-4D2BB1A552DF}.Debug|x86.Build.0 = Debug|Any CPU
+		{20EC25E2-921F-4F6F-AB3F-4D2BB1A552DF}.Release_No_Diagnostics|Any CPU.ActiveCfg = Debug|Any CPU
+		{20EC25E2-921F-4F6F-AB3F-4D2BB1A552DF}.Release_No_Diagnostics|Any CPU.Build.0 = Debug|Any CPU
+		{20EC25E2-921F-4F6F-AB3F-4D2BB1A552DF}.Release_No_Diagnostics|x64.ActiveCfg = Debug|Any CPU
+		{20EC25E2-921F-4F6F-AB3F-4D2BB1A552DF}.Release_No_Diagnostics|x64.Build.0 = Debug|Any CPU
+		{20EC25E2-921F-4F6F-AB3F-4D2BB1A552DF}.Release_No_Diagnostics|x86.ActiveCfg = Debug|Any CPU
+		{20EC25E2-921F-4F6F-AB3F-4D2BB1A552DF}.Release_No_Diagnostics|x86.Build.0 = Debug|Any CPU
+		{20EC25E2-921F-4F6F-AB3F-4D2BB1A552DF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{20EC25E2-921F-4F6F-AB3F-4D2BB1A552DF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{20EC25E2-921F-4F6F-AB3F-4D2BB1A552DF}.Release|x64.ActiveCfg = Release|Any CPU
+		{20EC25E2-921F-4F6F-AB3F-4D2BB1A552DF}.Release|x64.Build.0 = Release|Any CPU
+		{20EC25E2-921F-4F6F-AB3F-4D2BB1A552DF}.Release|x86.ActiveCfg = Release|Any CPU
+		{20EC25E2-921F-4F6F-AB3F-4D2BB1A552DF}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1423,6 +1463,8 @@ Global
 		{80F871A3-4A72-4905-B849-62ED179B221B} = {90F7E5FD-146B-406A-C97D-A0D358256D37}
 		{5A3BA47A-7EFC-46A5-B28F-49085E4B7A19} = {90F7E5FD-146B-406A-C97D-A0D358256D37}
 		{9642D9F2-2087-450A-B6DD-80A3E0A05571} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{6A4051AC-CF20-4357-A457-A517118D18C6} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{20EC25E2-921F-4F6F-AB3F-4D2BB1A552DF} = {07C2787E-EAC7-C090-1BA3-A61EC2A24D84}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {01002AE6-0158-417E-9B83-D4234361EC1B}

--- a/Tests/Gum.Presentation.Tests/BaseTestClass.cs
+++ b/Tests/Gum.Presentation.Tests/BaseTestClass.cs
@@ -1,0 +1,23 @@
+using Gum.Managers;
+
+namespace Gum.Presentation.Tests;
+
+/// <summary>
+/// Headless base for Gum.Presentation tests that exercise logic depending on the shared
+/// GumCommon singletons. Initializes <see cref="StandardElementsManager"/> (so element/state
+/// defaults resolve) and clears <see cref="ObjectFinder"/>'s project on dispose to keep the
+/// singletons from leaking state across tests. Both singletons live in GumCommon, so this
+/// stays within the headless boundary — no WPF/WinForms required.
+/// </summary>
+public class BaseTestClass : IDisposable
+{
+    public BaseTestClass()
+    {
+        StandardElementsManager.Self.Initialize();
+    }
+
+    public virtual void Dispose()
+    {
+        ObjectFinder.Self.GumProjectSave = null;
+    }
+}

--- a/Tests/Gum.Presentation.Tests/TestAssemblyInitialize.cs
+++ b/Tests/Gum.Presentation.Tests/TestAssemblyInitialize.cs
@@ -1,0 +1,3 @@
+// Gum uses some statics internally (ObjectFinder.Self, StandardElementsManager.Self).
+// Disable parallel execution to avoid random test failures.
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/Tests/Gum.Presentation.Tests/UndoManagerTests.cs
+++ b/Tests/Gum.Presentation.Tests/UndoManagerTests.cs
@@ -1,4 +1,4 @@
-﻿using CommunityToolkit.Mvvm.Messaging;
+using CommunityToolkit.Mvvm.Messaging;
 using Gum.Commands;
 using Gum.DataTypes;
 using Gum.DataTypes.Behaviors;
@@ -14,7 +14,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace GumToolUnitTests.Managers;
+namespace Gum.Presentation.Tests;
 public class UndoManagerTests : BaseTestClass
 {
     private readonly Mock<ISelectedState> _selectedState;
@@ -35,7 +35,7 @@ public class UndoManagerTests : BaseTestClass
         _pluginNotifier = new Mock<IUndoPluginNotifier>();
 
         ComponentSave component = new();
-        component.States.Add(new Gum.DataTypes.Variables.StateSave 
+        component.States.Add(new Gum.DataTypes.Variables.StateSave
         {
             Name="Default"
         });
@@ -262,7 +262,7 @@ public class UndoManagerTests : BaseTestClass
             component,
             elementHistory.Actions[0].UndoState.Element);
 
-        comparisonInformation.ToString().ShouldBe("Variables in Default: X=10");   
+        comparisonInformation.ToString().ShouldBe("Variables in Default: X=10");
     }
 
     [Fact]
@@ -535,4 +535,108 @@ public class UndoManagerTests : BaseTestClass
         behavior.Categories[0].States.Count.ShouldBe(0);
     }
 
+    // ---------------------------------------------------------------------------------------------
+    // New headless coverage (added when the suite was migrated out of GumToolUnitTests into
+    // Gum.Presentation.Tests). These exercise core undo/redo control-flow branches that the ported
+    // tests above did not reach — the empty-history early-outs, the RequestLock defer-until-disposed
+    // contract, the redo-stack truncation on a divergent edit, ClearAll, and the post-undo autosave
+    // port interaction — all against mocked ports with no UI present.
+    // ---------------------------------------------------------------------------------------------
+
+    [Fact]
+    public void CanRedo_ShouldReturnFalse_WhenNoChangesRecorded()
+    {
+        _undoManager.CanRedo().ShouldBeFalse();
+    }
+
+    [Fact]
+    public void CanUndo_ShouldReturnFalse_WhenNoChangesRecorded()
+    {
+        _undoManager.CanUndo().ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ClearAll_ShouldDiscardUndoHistory()
+    {
+        ComponentSave component = _selectedState.Object.SelectedComponent!;
+        component.DefaultState.SetValue("X", 10f);
+
+        _undoManager.RecordState();
+        component.DefaultState.SetValue("X", 11f);
+        _undoManager.RecordUndo();
+        _undoManager.CanUndo().ShouldBeTrue();
+
+        _undoManager.ClearAll();
+
+        _undoManager.CanUndo().ShouldBeFalse();
+    }
+
+    [Fact]
+    public void PerformRedo_AfterDivergentChange_ShouldNotBeAvailable()
+    {
+        ComponentSave component = _selectedState.Object.SelectedComponent!;
+        component.DefaultState.SetValue("X", 10f);
+
+        _undoManager.RecordState();
+        component.DefaultState.SetValue("X", 11f);
+        _undoManager.RecordUndo();
+
+        // Undo back to 10; a redo to 11 is now available.
+        _undoManager.PerformUndo();
+        _undoManager.CanRedo().ShouldBeTrue();
+
+        // A new, divergent edit discards the redo branch (the truncation path in RecordUndo).
+        component.DefaultState.SetValue("X", 20f);
+        _undoManager.RecordUndo();
+
+        _undoManager.CanRedo().ShouldBeFalse();
+    }
+
+    [Fact]
+    public void PerformUndo_ShouldTriggerProjectAutoSave()
+    {
+        ComponentSave component = _selectedState.Object.SelectedComponent!;
+        component.DefaultState.SetValue("X", 10f);
+
+        _undoManager.RecordState();
+        component.DefaultState.SetValue("X", 11f);
+        _undoManager.RecordUndo();
+
+        _undoManager.PerformUndo();
+
+        // TryAutoSaveProject has an optional parameter; supply it explicitly so the Moq
+        // expression tree compiles (CS0854). UndoManager calls it with the default.
+        _fileCommands.Verify(x => x.TryAutoSaveProject(It.IsAny<bool>()), Times.Once);
+    }
+
+    [Fact]
+    public void PerformUndo_WhenNothingRecorded_ShouldLeaveValueUnchanged()
+    {
+        ComponentSave component = _selectedState.Object.SelectedComponent!;
+        component.DefaultState.SetValue("X", 7f);
+
+        _undoManager.PerformUndo();
+
+        component.DefaultState.GetValueOrDefault<float>("X").ShouldBe(7f);
+    }
+
+    [Fact]
+    public void RequestLock_ShouldDeferRecording_UntilDisposed()
+    {
+        ComponentSave component = _selectedState.Object.SelectedComponent!;
+        component.DefaultState.SetValue("X", 10f);
+        _undoManager.RecordState();
+
+        UndoLock undoLock = _undoManager.RequestLock();
+        component.DefaultState.SetValue("X", 11f);
+
+        // While the lock is held, RecordUndo is suppressed, so nothing is recorded yet.
+        _undoManager.CanUndo().ShouldBeFalse();
+
+        undoLock.Dispose();
+
+        // Disposing the last lock fires RecordUndo once, capturing the change as a single undo.
+        _undoManager.CanUndo().ShouldBeTrue();
+        _undoManager.CurrentElementHistory.Actions.Count.ShouldBe(1);
+    }
 }

--- a/Tools/Gum.Presentation/Gum.Presentation.csproj
+++ b/Tools/Gum.Presentation/Gum.Presentation.csproj
@@ -18,11 +18,10 @@
 	</PropertyGroup>
 
 	<ItemGroup>
+		<!-- UndoManagerTests reach UndoManager's internal UndoLocks. They now live in the dedicated
+		     headless Gum.Presentation.Tests project (migrated out of GumToolUnitTests, ADR-0005
+		     Phase 3), which is the only assembly that needs to see internals here. -->
 		<InternalsVisibleTo Include="Gum.Presentation.Tests" />
-		<!-- UndoManagerTests live in GumToolUnitTests and reach UndoManager's internal UndoLocks.
-		     UndoManager moved here from Gum.csproj (ADR-0005 Phase 3); Gum.csproj already granted
-		     this via Gum/Properties/AssemblyInfo.cs, so the grant moves with the class. -->
-		<InternalsVisibleTo Include="GumToolUnitTests" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
## What

Stands up the headless **`Gum.Presentation.Tests`** project and migrates the `UndoManager` test suite into it — the payoff of ADR-0005 Phase 3: **testing undo/redo logic with zero UI**. The project references `Gum.Presentation` alone (no WPF/WinForms), so a green run is the compiler-enforced proof that the relocated `UndoManager` is genuinely headless.

Depends on the now-merged move PR (#3357), which relocated `UndoManager`/`AfterUndoMessage` into `Gum.Presentation` and pre-wired the project entry into `GumFull.sln`/`Gum.sln`. Branched off fresh `origin/main`.

## Changes

- **Migrate the full `UndoManagerTests` suite** out of the WPF `GumToolUnitTests` into `Gum.Presentation.Tests`. All **20 tests port unchanged** (only the namespace + base class move) — none secretly needed the tool. Git detects it as an 80%-similar rename, so the migrated body is byte-identical and the review is the delta only. Removed from `GumToolUnitTests` (no duplicates).
- **Add 7 new tests** covering core undo/redo branches the ported suite missed, all against mocked ports (`ISelectedState`, `IUndoRenameLogic`, `IUndoPluginNotifier`, `IFileCommands`, `IGuiCommands`, `IMessenger`):
  - empty-history early-outs — `CanUndo` / `CanRedo` / `PerformUndo`
  - the `RequestLock` defer-until-disposed contract (records exactly one undo on lock disposal)
  - redo-stack truncation on a divergent edit
  - `ClearAll`
  - the post-undo autosave port interaction (`IFileCommands.TryAutoSaveProject`)
- **Add `BaseTestClass` + `TestAssemblyInitialize`** (`DisableTestParallelization` — the suite uses the `StandardElementsManager`/`ObjectFinder` GumCommon singletons), mirroring the headless `Gum.ProjectServices.Tests` conventions.
- **Wire `Gum.Presentation.Tests` into `AllLibraries.sln`** (under the `Tests` solution folder) and **add a Bucket-A CI step** next to `Gum.ProjectServices.Tests`, so the suite keeps running in CI after leaving the `GumToolUnitTests` job. `dotnet sln add` also pulled `Gum.Presentation` in as a first-class `AllLibraries` project (nested under `Tools` to match its sibling `Gum.ProjectServices`).
- **Drop the now-dead `InternalsVisibleTo("GumToolUnitTests")`** grant from `Gum.Presentation.csproj` — `UndoLocks` was the only internal it reached, and that suite moved. The dedicated headless test project is now the only assembly that sees internals.

## Notes / decisions

- **Project location is `Tests/Gum.Presentation.Tests/`, not `Tools/...`** as the task literally read. The move PR had already pre-registered the project at `Tests\Gum.Presentation.Tests\...` in `GumFull.sln`/`Gum.sln`, and every other headless test project (notably the direct sibling `Gum.ProjectServices.Tests`) lives under `Tests/`. The `InternalsVisibleTo` grant matches by assembly name, so the path is free to follow convention.
- **Migrated tests preserve their original `var` style** for a faithful, reviewable move (matches the existing `UndoLockTests` style in this project); the 7 new tests follow `code-style.md` (explicit types, braces, named bool params).
- One Moq footgun fixed in a new test: `IFileCommands.TryAutoSaveProject(bool = false)` has an optional parameter, which can't be omitted inside a Moq expression tree (CS0854) — the `Verify` supplies it explicitly.

## Verification

- `dotnet test Tests/Gum.Presentation.Tests` → **31 passed, 0 failed** (20 migrated + 7 new undo + 2 `UndoLockTests` + 2 `FileWatchViewModelTests`), compiling against `Gum.Presentation` with **no UI reference**.
- `dotnet build GumFull.sln` → **succeeded, 0 errors** — confirms `GumToolUnitTests` still compiles after the test removal + dead-IVT removal.
- `dotnet sln AllLibraries.sln list` confirms both projects registered and the solution parses.

The pre-existing `CS86xx` nullable warnings in `UndoManager.cs`/`UndoSnapshot.cs` are inherited from the relocated source and out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
