### PR TITLE
Extract IDeletePluginNotifier narrow port; inject it into DeleteLogic (ADR-0005 Phase 3)

### DIFF
--- a/Gum/Managers/DeleteLogic.cs
+++ b/Gum/Managers/DeleteLogic.cs
@@ -27,6 +27,7 @@ public class DeleteLogic : IDeleteLogic
     private readonly IGuiCommands _guiCommands;
     private readonly IFileCommands _fileCommands;
     private readonly IPluginManager _pluginManager;
+    private readonly IDeletePluginNotifier _deletePluginNotifier;
     private readonly IWireframeObjectManager _wireframeObjectManager;
     private readonly IProjectManager _projectManager;
     private readonly IReferenceFinder _referenceFinder;
@@ -37,6 +38,7 @@ public class DeleteLogic : IDeleteLogic
         IGuiCommands guiCommands,
         IFileCommands fileCommands,
         IPluginManager pluginManager,
+        IDeletePluginNotifier deletePluginNotifier,
         IWireframeObjectManager wireframeObjectManager,
         IProjectManager projectManager,
         IReferenceFinder referenceFinder)
@@ -46,6 +48,7 @@ public class DeleteLogic : IDeleteLogic
         _guiCommands = guiCommands;
         _fileCommands = fileCommands;
         _pluginManager = pluginManager;
+        _deletePluginNotifier = deletePluginNotifier;
         _wireframeObjectManager = wireframeObjectManager;
         _projectManager = projectManager;
         _referenceFinder = referenceFinder;
@@ -54,7 +57,7 @@ public class DeleteLogic : IDeleteLogic
 
     public void HandleDeleteCommand()
     {
-        var handled = _pluginManager.TryHandleDelete();
+        var handled = _deletePluginNotifier.TryHandleDelete();
         if (!handled)
         {
             DoDeletingLogic();
@@ -239,7 +242,7 @@ public class DeleteLogic : IDeleteLogic
         else if (selectedBehavior != null && selectedInstance is BehaviorInstanceSave behaviorInstanceToDelete)
         {
             selectedBehavior.RequiredInstances.Remove(behaviorInstanceToDelete);
-            _pluginManager.BehaviorInstanceDelete(selectedBehavior, behaviorInstanceToDelete);
+            _deletePluginNotifier.BehaviorInstanceDelete(selectedBehavior, behaviorInstanceToDelete);
         }
 
         // Restore the owning element to live SelectedState before firing InstanceDelete.
@@ -251,7 +254,7 @@ public class DeleteLogic : IDeleteLogic
             _selectedState.SelectedElement = selectedElement;
         }
 
-        _pluginManager.InstanceDelete(selectedElement, selectedInstance);
+        _deletePluginNotifier.InstanceDelete(selectedElement, selectedInstance);
 
         var deletedSelection = _selectedState.SelectedInstance == selectedInstance;
 
@@ -385,7 +388,7 @@ public class DeleteLogic : IDeleteLogic
         //    this, multi-instance deletes leave plugin-owned state stale.
         foreach (var group in instancesByElementParent)
         {
-            _pluginManager.InstancesDelete(group.Key, group.ToArray());
+            _deletePluginNotifier.InstancesDelete(group.Key, group.ToArray());
         }
 
         // 4. Remove elements
@@ -770,7 +773,7 @@ public class DeleteLogic : IDeleteLogic
         _guiCommands.RefreshVariables();
         _wireframeObjectManager.RefreshAll(true);
 
-        _pluginManager.CategoryDelete(category);
+        _deletePluginNotifier.CategoryDelete(category);
     }
 
     public List<BehaviorSave> GetBehaviorsNeedingCategory(StateSaveCategory category, ComponentSave? componentSave)
@@ -802,7 +805,7 @@ public class DeleteLogic : IDeleteLogic
         int index = stateCategory?.States.IndexOf(stateSave) ?? -1;
 
         RemoveState(stateSave, _selectedState.SelectedStateContainer);
-        _pluginManager.StateDelete(stateSave);
+        _deletePluginNotifier.StateDelete(stateSave);
 
         _guiCommands.RefreshVariables();
         _wireframeObjectManager.RefreshAll(true);
@@ -864,7 +867,7 @@ public class DeleteLogic : IDeleteLogic
         // notifying plugins to avoid NREs and stale-state misroutes.
         _selectedState.SelectedElement = elementToRemoveFrom;
 
-        _pluginManager.InstanceDelete(elementToRemoveFrom, instanceToRemove);
+        _deletePluginNotifier.InstanceDelete(elementToRemoveFrom, instanceToRemove);
 
         if (_selectedState.SelectedInstance == instanceToRemove)
         {
@@ -922,7 +925,7 @@ public class DeleteLogic : IDeleteLogic
         }
 
 
-        _pluginManager.InstancesDelete(elementToRemoveFrom, instances.ToArray());
+        _deletePluginNotifier.InstancesDelete(elementToRemoveFrom, instances.ToArray());
 
         DeselectInstances(instances);
     }
@@ -972,7 +975,7 @@ public class DeleteLogic : IDeleteLogic
             {
                 _selectedState.SelectedElement = null;
             }
-            _pluginManager.ElementDelete(element);
+            _deletePluginNotifier.ElementDelete(element);
             _fileCommands.TryAutoSaveProject();
         }
     }
@@ -1010,7 +1013,7 @@ public class DeleteLogic : IDeleteLogic
 
         _selectedState.SelectedBehavior = null;
 
-        _pluginManager.BehaviorDeleted(behavior);
+        _deletePluginNotifier.BehaviorDeleted(behavior);
 
         _guiCommands.RefreshStateTreeView();
         _guiCommands.RefreshVariables();

--- a/Gum/Plugins/PluginManager.cs
+++ b/Gum/Plugins/PluginManager.cs
@@ -54,7 +54,7 @@ internal enum PluginCategories
 
 #endregion
 
-public class PluginManager : IPluginManager, IUndoPluginNotifier
+public class PluginManager : IPluginManager, IUndoPluginNotifier, IDeletePluginNotifier
 {
     #region Fields
 

--- a/Gum/Services/Builder.cs
+++ b/Gum/Services/Builder.cs
@@ -92,6 +92,10 @@ file static class ServiceCollectionExtensions
         // IUndoPluginNotifier: narrow headless port (ADR-0005 Phase 3) so UndoManager no longer depends on the
         // concrete PluginManager. Resolves to the same PluginManager singleton, so plugin calls fire as before.
         services.AddSingleton<IUndoPluginNotifier>(provider => provider.GetRequiredService<PluginManager>());
+        // IDeletePluginNotifier: narrow headless port (ADR-0005 Phase 3) so DeleteLogic no longer depends on the
+        // concrete PluginManager for delete notifications. Resolves to the same PluginManager singleton, so plugin
+        // calls fire as before. The two WPF-coupled delete calls (ShowDeleteDialog/DeleteConfirmed) remain on IPluginManager.
+        services.AddSingleton<IDeletePluginNotifier>(provider => provider.GetRequiredService<PluginManager>());
         services.AddSingleton<TypeManager>();
         services.AddSingleton<ITypeManager>(provider => provider.GetRequiredService<TypeManager>());
         services.AddSingleton<ProjectManager>();

--- a/Tool/Tests/GumToolUnitTests/Managers/DeleteLogicTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Managers/DeleteLogicTests.cs
@@ -29,6 +29,7 @@ public class DeleteLogicTests : BaseTestClass
     private readonly Mock<IGuiCommands> _guiCommands;
     private readonly Mock<IFileCommands> _fileCommands;
     private readonly Mock<IPluginManager> _pluginManager;
+    private readonly Mock<IDeletePluginNotifier> _deletePluginNotifier;
     private readonly Mock<IWireframeObjectManager> _wireframeObjectManager;
     private readonly Mock<IProjectManager> _projectManager;
     private readonly Mock<IReferenceFinder> _referenceFinder;
@@ -42,6 +43,7 @@ public class DeleteLogicTests : BaseTestClass
         _guiCommands = _mocker.GetMock<IGuiCommands>();
         _fileCommands = _mocker.GetMock<IFileCommands>();
         _pluginManager = _mocker.GetMock<IPluginManager>();
+        _deletePluginNotifier = _mocker.GetMock<IDeletePluginNotifier>();
         _wireframeObjectManager = _mocker.GetMock<IWireframeObjectManager>();
         _projectManager = _mocker.GetMock<IProjectManager>();
         _referenceFinder = _mocker.GetMock<IReferenceFinder>();
@@ -62,6 +64,7 @@ public class DeleteLogicTests : BaseTestClass
             _guiCommands.Object,
             _fileCommands.Object,
             _pluginManager.Object,
+            _deletePluginNotifier.Object,
             _wireframeObjectManager.Object,
             _projectManager.Object,
             _referenceFinder.Object);
@@ -206,11 +209,12 @@ public class DeleteLogicTests : BaseTestClass
     }
 
     [Fact]
-    public void PerformConfirmedMixedTypeDelete_MultipleInstancesInSameElement_FiresInstancesDeleteOnPluginManager()
+    public void PerformConfirmedMixedTypeDelete_MultipleInstancesInSameElement_FiresInstancesDeleteThroughPluginNotifier()
     {
-        // Regression: deleting multiple instances at once never fired InstancesDelete on the
-        // plugin manager, so plugins listening for instance removal (e.g. the codegen plugin
-        // that regenerates a screen's .Generated.cs) never refreshed.
+        // Regression: deleting multiple instances at once never fired InstancesDelete, so plugins
+        // listening for instance removal (e.g. the codegen plugin that regenerates a screen's
+        // .Generated.cs) never refreshed. This notification now travels through the narrow
+        // IDeletePluginNotifier port rather than the concrete PluginManager (ADR-0005 Phase 3).
         ScreenSave screen = CreateScreenWithInstances("InstA", "InstB");
         List<InstanceSave> instances = screen.Instances.ToList();
 
@@ -221,7 +225,7 @@ public class DeleteLogicTests : BaseTestClass
             instances.Cast<object>().ToArray(),
             optionsWindow: null);
 
-        _pluginManager.Verify(
+        _deletePluginNotifier.Verify(
             p => p.InstancesDelete(
                 screen,
                 It.Is<InstanceSave[]>(arr =>
@@ -329,7 +333,7 @@ public class DeleteLogicTests : BaseTestClass
             .Callback<ElementSave?>(e => liveSelectedElement = e);
 
         ElementSave? selectedAtFireTime = null;
-        _pluginManager
+        _deletePluginNotifier
             .Setup(p => p.InstanceDelete(It.IsAny<ElementSave>(), instance))
             .Callback(() => selectedAtFireTime = liveSelectedElement);
 
@@ -361,7 +365,7 @@ public class DeleteLogicTests : BaseTestClass
             .Callback<ElementSave?>(e => liveSelectedElement = e);
 
         ElementSave? selectedAtFireTime = null;
-        _pluginManager
+        _deletePluginNotifier
             .Setup(p => p.InstanceDelete(screen, instance))
             .Callback(() => selectedAtFireTime = liveSelectedElement);
 
@@ -399,6 +403,19 @@ public class DeleteLogicTests : BaseTestClass
     }
 
     [Fact]
+    public void RemoveBehavior_FiresBehaviorDeletedThroughPluginNotifier()
+    {
+        // Pins that the behavior-deleted notification still fires, now through the narrow
+        // IDeletePluginNotifier port rather than the concrete PluginManager (ADR-0005 Phase 3).
+        BehaviorSave behavior = new BehaviorSave { Name = "TestBehavior" };
+        _gumProject.Behaviors.Add(behavior);
+
+        _deleteLogic.RemoveBehavior(behavior);
+
+        _deletePluginNotifier.Verify(p => p.BehaviorDeleted(behavior), Times.Once);
+    }
+
+    [Fact]
     public void RemoveElement_Component_RemovesFromProjectLists()
     {
         ComponentSave component = new ComponentSave { Name = "TestComponent" };
@@ -422,6 +439,19 @@ public class DeleteLogicTests : BaseTestClass
 
         _gumProject.Screens.ShouldNotContain(screen);
         _gumProject.ScreenReferences.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void RemoveElement_Screen_FiresElementDeleteThroughPluginNotifier()
+    {
+        // Pins that the element-deleted notification still fires, now through the narrow
+        // IDeletePluginNotifier port rather than the concrete PluginManager (ADR-0005 Phase 3).
+        ScreenSave screen = new ScreenSave { Name = "TestScreen" };
+        _gumProject.Screens.Add(screen);
+
+        _deleteLogic.RemoveElement(screen);
+
+        _deletePluginNotifier.Verify(p => p.ElementDelete(screen), Times.Once);
     }
 
     [Fact]

--- a/Tools/Gum.Presentation/Managers/IDeletePluginNotifier.cs
+++ b/Tools/Gum.Presentation/Managers/IDeletePluginNotifier.cs
@@ -1,0 +1,34 @@
+using Gum.DataTypes;
+using Gum.DataTypes.Behaviors;
+using Gum.DataTypes.Variables;
+
+namespace Gum.Managers;
+
+/// <summary>
+/// Narrow notification port the delete subsystem uses to inform plugins that a delete just
+/// changed the model. It exposes only the headless (<c>GumDataTypes</c>) plugin calls
+/// <c>DeleteLogic</c> makes, so the delete logic no longer needs to depend on the concrete,
+/// MEF/WinForms-entangled <c>PluginManager</c> for those notifications (ADR-0005 Phase 3).
+/// The two WPF-coupled delete plugin calls — <c>ShowDeleteDialog</c> and <c>DeleteConfirmed</c>,
+/// which both take the WPF <c>DeleteOptionsWindow</c> — intentionally stay on
+/// <see cref="Gum.Plugins.IPluginManager"/> and cannot move here until that dialog flow is made
+/// headless. The live implementation is <c>PluginManager</c>, bridged via DI.
+/// </summary>
+public interface IDeletePluginNotifier
+{
+    bool TryHandleDelete();
+
+    void ElementDelete(ElementSave element);
+
+    void StateDelete(StateSave stateSave);
+
+    void CategoryDelete(StateSaveCategory category);
+
+    void BehaviorDeleted(BehaviorSave behavior);
+
+    void InstanceDelete(ElementSave elementSave, InstanceSave instance);
+
+    void InstancesDelete(ElementSave elementSave, InstanceSave[] instances);
+
+    void BehaviorInstanceDelete(BehaviorSave behavior, BehaviorInstanceSave instance);
+}


### PR DESCRIPTION
## What

Extracts a narrow **`IDeletePluginNotifier`** port (in headless `Gum.Presentation`) and injects it into `DeleteLogic`, so the delete logic's plugin notifications no longer go through the concrete, MEF/WinForms-entangled `PluginManager`. This mirrors `IUndoPluginNotifier` (#3355) and is the first, largest prerequisite for relocating `DeleteLogic` into headless `Gum.Presentation` (ADR-0005 Phase 3).

`DeleteLogic` made **10 distinct** plugin calls on `IPluginManager`. **8 are headless** (GumDataTypes-only params/returns) and now travel through the new port:

`TryHandleDelete`, `ElementDelete`, `StateDelete`, `CategoryDelete`, `BehaviorDeleted`, `InstanceDelete`, `InstancesDelete`, `BehaviorInstanceDelete`

Signatures match `IPluginManager` exactly (no shims) — notably `InstancesDelete(ElementSave, InstanceSave[])`.

## Stop-gate: the 2 WPF-bound calls stay on `IPluginManager`

`ShowDeleteDialog` and `DeleteConfirmed` **both take the WPF `DeleteOptionsWindow`** (`Gum.Gui.Windows`). Per the headless-signature rule ("the impl can show UI in the shell, but the interface signature must be headless"), they are **deliberately not** in the port. `DeleteLogic` keeps its `IPluginManager` dependency solely for those two until the `DeleteOptionsWindow` flow itself is made headless in a later PR. (It also still constructs `new DeleteOptionsWindow()` directly, so it is not yet headless regardless.)

## Wiring

- `PluginManager` now implements `IPluginManager, IUndoPluginNotifier, IDeletePluginNotifier` — one method set satisfies all three.
- `Builder.cs` binds `IDeletePluginNotifier` to the same `PluginManager` singleton, so plugin calls fire exactly as before. No new service is bridged into the plugin container (`LoadPlugins`), so `PluginBridgedServiceTypes.All` is unchanged.

## Tests

Behavior-preserving. `GumFull.sln` builds (0 errors); `GumToolUnitTests` = **982 passed / 4 skipped / 0 failed**, including:
- `AllPluginsCompositionTests` + `ServiceProviderCompositionSpikeTests` (DI graph resolves `DeleteLogic`'s new dependency, no cycle).
- Existing `InstanceDelete`/`InstancesDelete` assertions retargeted to the port mock.
- New pinning tests: `RemoveElement_Screen_FiresElementDeleteThroughPluginNotifier`, `RemoveBehavior_FiresBehaviorDeletedThroughPluginNotifier`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
