### PR TITLE
Document DeleteOptionsWindow's headless/ADR-0005 coupling in gum-tool-dialogs skill

### DIFF
--- a/.claude/skills/gum-tool-dialogs/SKILL.md
+++ b/.claude/skills/gum-tool-dialogs/SKILL.md
@@ -35,6 +35,8 @@ Used by: delete confirmation only (`DeleteLogic.ShowDeleteDialog`).
 
 **Not managed by DialogService** — no view model, no template selection, no attached property binding. Changes to `DialogWindow.xaml` or `Dialog.cs` have **zero effect** on this window.
 
+**Headless / ADR-0005 implication**: the MVVM `DialogService` and its `IDialogService` contract are already headless (relocated to `Gum.Presentation`), so dialogs on that path don't couple their callers to WPF. `DeleteOptionsWindow` does — and it is the reason `DeleteLogic` cannot fully relocate to the headless presentation layer. The coupling is the extension point itself: `PluginManager.ShowDeleteDialog(window)` / `DeleteConfirmed(window)` hand plugins a concrete WPF `StackPanel` to add `UIElement`s to. That "mutate a live WPF panel" contract cannot be expressed headlessly as-is. Decoupling it is a **plugin-facing API change**, not a mechanical move: replace the panel-injection with a data-driven options model (option descriptors — label + bool + callback) that the headless layer owns and the WPF (later Avalonia) shell renders. Until that contract changes, the last `IPluginManager` calls and `using Gum.Gui.Windows;` cannot leave `DeleteLogic`.
+
 ## Key Files
 
 | File | System | Purpose |


### PR DESCRIPTION
Adds a "Headless / ADR-0005 implication" note to the `gum-tool-dialogs` skill.

The skill already documented the two dialog systems and *why* `DeleteOptionsWindow` is standalone (plugins inject controls into a live WPF `StackPanel`, which the MVVM template system can't express). What it was missing — and what surfaced during the ADR-0005 headless-presentation refactor — is the decoupling consequence:

- The MVVM `DialogService` / `IDialogService` path is already headless, so dialogs on it don't couple callers to WPF.
- `DeleteOptionsWindow` does, and it is the specific coupling that blocks relocating `DeleteLogic` into the headless `Gum.Presentation` assembly.
- The coupling is the extension point itself (`PluginManager.ShowDeleteDialog`/`DeleteConfirmed` hand plugins a concrete WPF `StackPanel`). Undoing it is a plugin-facing API change — replace panel-injection with a data-driven options model — not a mechanical move.

Docs-only change to a checked-in skill file; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
