### PR TITLE
Extract IDeleteProjectProvider narrow port; inject it into DeleteLogic in place of IProjectManager (ADR-0005 Phase 3)

### DIFF
--- a/Gum/Managers/DeleteLogic.cs
+++ b/Gum/Managers/DeleteLogic.cs
@@ -29,7 +29,7 @@ public class DeleteLogic : IDeleteLogic
     private readonly IPluginManager _pluginManager;
     private readonly IDeletePluginNotifier _deletePluginNotifier;
     private readonly IWireframeObjectManager _wireframeObjectManager;
-    private readonly IProjectManager _projectManager;
+    private readonly IDeleteProjectProvider _deleteProjectProvider;
     private readonly IReferenceFinder _referenceFinder;
 
     public DeleteLogic(
@@ -40,7 +40,7 @@ public class DeleteLogic : IDeleteLogic
         IPluginManager pluginManager,
         IDeletePluginNotifier deletePluginNotifier,
         IWireframeObjectManager wireframeObjectManager,
-        IProjectManager projectManager,
+        IDeleteProjectProvider deleteProjectProvider,
         IReferenceFinder referenceFinder)
     {
         _selectedState = selectedState;
@@ -50,7 +50,7 @@ public class DeleteLogic : IDeleteLogic
         _pluginManager = pluginManager;
         _deletePluginNotifier = deletePluginNotifier;
         _wireframeObjectManager = wireframeObjectManager;
-        _projectManager = projectManager;
+        _deleteProjectProvider = deleteProjectProvider;
         _referenceFinder = referenceFinder;
     }
 
@@ -784,7 +784,7 @@ public class DeleteLogic : IDeleteLogic
         {
             var behaviorNames = componentSave.Behaviors.Select(item => item.BehaviorName);
 
-            foreach (var behavior in _projectManager.GumProjectSave.Behaviors.Where(item => behaviorNames.Contains(item.Name)))
+            foreach (var behavior in _deleteProjectProvider.GumProjectSave.Behaviors.Where(item => behaviorNames.Contains(item.Name)))
             {
                 bool needsCategory = behavior.Categories.Any(item => item.Name == category.Name);
 
@@ -952,7 +952,7 @@ public class DeleteLogic : IDeleteLogic
 
     public void RemoveElement(ElementSave element)
     {
-        var gps = _projectManager.GumProjectSave;
+        var gps = _deleteProjectProvider.GumProjectSave;
         var name = element.Name;
         var removed = false;
 
@@ -995,7 +995,7 @@ public class DeleteLogic : IDeleteLogic
     public void RemoveBehavior(BehaviorSave behavior)
     {
         var behaviorName = behavior.Name;
-        var gps = _projectManager.GumProjectSave;
+        var gps = _deleteProjectProvider.GumProjectSave;
 
         gps.BehaviorReferences.RemoveAll(item => item.Name == behaviorName);
         gps.Behaviors.Remove(behavior);

--- a/Gum/Managers/ProjectManager.cs
+++ b/Gum/Managers/ProjectManager.cs
@@ -29,7 +29,7 @@ using ToolsUtilities;
 
 namespace Gum;
 
-public class ProjectManager : IProjectManager
+public class ProjectManager : IProjectManager, IDeleteProjectProvider
 {
     #region Fields
 

--- a/Gum/Services/Builder.cs
+++ b/Gum/Services/Builder.cs
@@ -102,6 +102,10 @@ file static class ServiceCollectionExtensions
         services.AddSingleton<StandardElementsManagerGumTool>();
         services.AddSingleton<IStandardElementsManagerGumTool>(provider => provider.GetRequiredService<StandardElementsManagerGumTool>());
         services.AddSingleton<IProjectManager>(provider => provider.GetRequiredService<ProjectManager>());
+        // IDeleteProjectProvider: narrow headless port (ADR-0005 Phase 3) so DeleteLogic reads the loaded
+        // project through a single-property port instead of the wider IProjectManager. Resolves to the same
+        // ProjectManager singleton, so it returns the live GumProjectSave exactly as before.
+        services.AddSingleton<IDeleteProjectProvider>(provider => provider.GetRequiredService<ProjectManager>());
         services.AddSingleton<ICommandLineManager, CommandLineManager>();
         services.AddSingleton<IProjectState, ProjectState>();
         // ElementTreeViewManager: drained from a static Self singleton (#3286). Concrete is needed for the

--- a/Tool/Tests/GumToolUnitTests/Managers/DeleteLogicTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Managers/DeleteLogicTests.cs
@@ -31,7 +31,7 @@ public class DeleteLogicTests : BaseTestClass
     private readonly Mock<IPluginManager> _pluginManager;
     private readonly Mock<IDeletePluginNotifier> _deletePluginNotifier;
     private readonly Mock<IWireframeObjectManager> _wireframeObjectManager;
-    private readonly Mock<IProjectManager> _projectManager;
+    private readonly Mock<IDeleteProjectProvider> _deleteProjectProvider;
     private readonly Mock<IReferenceFinder> _referenceFinder;
     private readonly GumProjectSave _gumProject;
 
@@ -45,7 +45,7 @@ public class DeleteLogicTests : BaseTestClass
         _pluginManager = _mocker.GetMock<IPluginManager>();
         _deletePluginNotifier = _mocker.GetMock<IDeletePluginNotifier>();
         _wireframeObjectManager = _mocker.GetMock<IWireframeObjectManager>();
-        _projectManager = _mocker.GetMock<IProjectManager>();
+        _deleteProjectProvider = _mocker.GetMock<IDeleteProjectProvider>();
         _referenceFinder = _mocker.GetMock<IReferenceFinder>();
 
         _referenceFinder
@@ -66,12 +66,12 @@ public class DeleteLogicTests : BaseTestClass
             _pluginManager.Object,
             _deletePluginNotifier.Object,
             _wireframeObjectManager.Object,
-            _projectManager.Object,
+            _deleteProjectProvider.Object,
             _referenceFinder.Object);
 
         _gumProject = new GumProjectSave();
         ObjectFinder.Self.GumProjectSave = _gumProject;
-        _projectManager.Setup(m => m.GumProjectSave).Returns(_gumProject);
+        _deleteProjectProvider.Setup(m => m.GumProjectSave).Returns(_gumProject);
     }
 
     [Fact]

--- a/Tools/Gum.Presentation/Managers/IDeleteProjectProvider.cs
+++ b/Tools/Gum.Presentation/Managers/IDeleteProjectProvider.cs
@@ -1,0 +1,17 @@
+using Gum.DataTypes;
+
+namespace Gum.Managers;
+
+/// <summary>
+/// Narrow headless port the delete subsystem uses to read the loaded project. It exposes only the
+/// single <see cref="GumProjectSave"/> property that <c>DeleteLogic</c> reads, so the delete logic
+/// no longer needs to depend on the concrete, WinForms-entangled <see cref="IProjectManager"/> —
+/// whose wider surface drags <c>GeneralSettingsFile</c> and the whole load/save flow — for that one
+/// access (ADR-0005 Phase 3). The return type is the headless <c>GumDataTypes</c>
+/// <see cref="DataTypes.GumProjectSave"/>, so this port carries no WPF/WinForms coupling. The live
+/// implementation is <c>ProjectManager</c>, bridged via DI to the same singleton.
+/// </summary>
+public interface IDeleteProjectProvider
+{
+    GumProjectSave? GumProjectSave { get; }
+}


### PR DESCRIPTION
## What

Extract a narrow headless port `IDeleteProjectProvider { GumProjectSave? GumProjectSave { get; } }` in `Gum.Presentation`, and inject it into `DeleteLogic` in place of the wider `IProjectManager` (ADR-0005 Phase 3). Same recipe as #3355 / #3356 / #3359.

`DeleteLogic` touched `IProjectManager` only through its headless `GumProjectSave?` property — three read sites (`GetBehaviorsNeedingCategory`, `RemoveElement`, `RemoveBehavior`). The audit from #3359 is confirmed: no other `IProjectManager` member is used. So the dependency is fully replaced by the single-property port rather than partially narrowed.

`IProjectManager` is **not** relocated wholesale — its closure drags `GeneralSettingsFile` (headlessness unverified) and every other consumer. Instead:

- New `IDeleteProjectProvider` lives in `Gum.Presentation` (return type is the headless `GumDataTypes.GumProjectSave`, so the port carries no WPF/WinForms coupling).
- The concrete `ProjectManager` impl now also implements the port (the `GumProjectSave` property already exists — just added the interface to its declaration).
- `Builder.cs` registers it resolving to the **same** `ProjectManager` singleton, so it returns the live `GumProjectSave` exactly as before.
- `DeleteLogic`'s `_projectManager` field/ctor param is replaced by `_deleteProjectProvider`.

No `PluginManager.LoadPlugins` bridging is involved (the impl is `ProjectManager`, not the plugin manager), so `PluginBridgedServiceTypes.All` is unchanged.

## Proof (behavior-preserving)

- **Gum.Presentation compiles standalone** — zero WPF leak (the port signature is headless `GumProjectSave?`).
- **GumFull.sln builds** — 0 errors.
- **GumToolUnitTests green** — `DeleteLogicTests` re-pinned through the new port (its existing `RemoveElement_*` / `RemoveBehavior_*` tests already exercise the project-save read; their mock is rewired to `IDeleteProjectProvider`), plus `AllPluginsCompositionTests` (MEF still composes) and `ServiceProviderCompositionSpikeTests` (real `Builder.cs` container resolves the new registration with no DI cycle). 35/35 in the filtered run.

Manual test: not needed — pure dependency-narrowing seam; the port returns the same live `GumProjectSave` from the same singleton, proven by the compiler + existing pinning tests + DI composition test.
