### PR TITLE
Harden skills-writer: ban in-flight migration/refactor state from skills

### DIFF
--- a/.claude/skills/skills-writer/SKILL.md
+++ b/.claude/skills/skills-writer/SKILL.md
@@ -85,7 +85,7 @@ description: Reference guide for Gum's undo/redo system. Load this when working 
 - Anything already in `docs/` — link instead of restating.
 - Full class outlines or property lists — read source directly.
 - Code examples unless the snippet captures an irreplaceable pattern.
-- Time-sensitive info (versions, dates, migration notes).
+- **In-flight migration / refactor STATE** — what's done *now*, what currently blocks what, what's left, "X is already headless," "Y can't move until Z." This **inverts to false the moment the work lands**, turning the skill into an active liar that every future agent re-reads as fact. Skills hold *timeless* structure only. Transient progress belongs in the ephemeral working ledger; durable design *direction* belongs in the relevant ADR (`Direction/decisions/`), not the skill. (Subsumes the old "migration notes" rule, plus versions and dates — any time-sensitive fact.)
 - Anything Claude already knows from general C# or .NET knowledge.
 
 ## Output


### PR DESCRIPTION
Upgrades the weak `migration notes` exclusion in the skills-writer guidance into a named landmine.

**Motivation:** a recent skill edit (since reverted) encoded in-flight ADR-0005 refactor state — which classes were headless, what blocked DeleteLogic's relocation, what was left. That kind of fact inverts to false the moment the work lands, turning a persistent skill into an active liar that every future agent re-reads as truth. The pre-existing one-word `migration notes` exclusion didn't carry enough weight to prevent it.

**Change:** docs-only. Replaces the bullet with an explicit landmine stating *why* (skills hold timeless structure; transient state misleads) and *where such content belongs instead* — the ephemeral working ledger for progress, the ADR (`Direction/decisions/`) for durable design direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)