### PR TITLE
Introduce headless IDeleteDialogService seam; remove DeleteLogic's last WPF/IPluginManager dependency (ADR-0005 Phase 3)

### DIFF
--- a/Gum/Managers/DeleteLogic.cs
+++ b/Gum/Managers/DeleteLogic.cs
@@ -2,7 +2,6 @@ using Gum.Commands;
 using Gum.DataTypes;
 using Gum.DataTypes.Behaviors;
 using Gum.DataTypes.Variables;
-using Gum.Gui.Windows;
 using Gum.Logic;
 using Gum.Plugins;
 using Gum.Services;
@@ -14,9 +13,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using System.Windows.Forms;
 using ToolsUtilities;
-using DialogResult = System.Windows.Forms.DialogResult;
 
 namespace Gum.Managers;
 
@@ -24,9 +21,9 @@ public class DeleteLogic : IDeleteLogic
 {
     private readonly ISelectedState _selectedState;
     private readonly IDialogService _dialogService;
+    private readonly IDeleteDialogService _deleteDialogService;
     private readonly IGuiCommands _guiCommands;
     private readonly IFileCommands _fileCommands;
-    private readonly IPluginManager _pluginManager;
     private readonly IDeletePluginNotifier _deletePluginNotifier;
     private readonly IWireframeObjectManager _wireframeObjectManager;
     private readonly IDeleteProjectProvider _deleteProjectProvider;
@@ -35,9 +32,9 @@ public class DeleteLogic : IDeleteLogic
     public DeleteLogic(
         ISelectedState selectedState,
         IDialogService dialogService,
+        IDeleteDialogService deleteDialogService,
         IGuiCommands guiCommands,
         IFileCommands fileCommands,
-        IPluginManager pluginManager,
         IDeletePluginNotifier deletePluginNotifier,
         IWireframeObjectManager wireframeObjectManager,
         IDeleteProjectProvider deleteProjectProvider,
@@ -45,9 +42,9 @@ public class DeleteLogic : IDeleteLogic
     {
         _selectedState = selectedState;
         _dialogService = dialogService;
+        _deleteDialogService = deleteDialogService;
         _guiCommands = guiCommands;
         _fileCommands = fileCommands;
-        _pluginManager = pluginManager;
         _deletePluginNotifier = deletePluginNotifier;
         _wireframeObjectManager = wireframeObjectManager;
         _deleteProjectProvider = deleteProjectProvider;
@@ -97,7 +94,7 @@ public class DeleteLogic : IDeleteLogic
         }
 
         Array? objectsDeleted = null;
-        DeleteOptionsWindow? optionsWindow = null;
+        IDeleteDialogResult? deleteDialogResult = null;
 
         var selectedElements = _selectedState.SelectedElements;
         var selectedInstance = _selectedState.SelectedInstance;
@@ -121,19 +118,16 @@ public class DeleteLogic : IDeleteLogic
             }
             else
             {
-                //DialogResult result =
-                //    MessageBox.Show("Are you sure you'd like to delete " + instance.Name + "?", "Delete instance?", MessageBoxButtons.YesNo);
-                var result = ShowDeleteDialog(array, out optionsWindow);
+                var result = ShowDeleteDialog(array);
 
-
-                if (result == true)
+                if (result.Result == true)
                 {
                     PerformConfirmedSingleInstanceDelete(
                         selectedInstance,
                         selectedElements.FirstOrDefault(),
                         selectedBehavior,
                         array,
-                        optionsWindow);
+                        result);
                     objectsDeleted = null; // prevent double-firing at the end of DoDeletingLogic
                 }
                 else
@@ -149,10 +143,9 @@ public class DeleteLogic : IDeleteLogic
 
             if (array.Length > 0)
             {
+                deleteDialogResult = ShowDeleteDialog(array);
 
-                var result = ShowDeleteDialog(array, out optionsWindow);
-
-                if (result == true)
+                if (deleteDialogResult.Result == true)
                 {
                     objectsDeleted = array;
 
@@ -188,9 +181,9 @@ public class DeleteLogic : IDeleteLogic
                     return;
             }
 
-            var result = ShowDeleteDialog(array, out optionsWindow);
+            deleteDialogResult = ShowDeleteDialog(array);
 
-            if (result == true)
+            if (deleteDialogResult.Result == true)
             {
                 objectsDeleted = array;
                 foreach(var item in array)
@@ -216,7 +209,7 @@ public class DeleteLogic : IDeleteLogic
 
         if (shouldDelete)
         {
-            _pluginManager.DeleteConfirmed(optionsWindow, objectsDeleted);
+            _deleteDialogService.NotifyConfirmed(deleteDialogResult!, objectsDeleted);
         }
     }
 
@@ -225,7 +218,7 @@ public class DeleteLogic : IDeleteLogic
         ElementSave? selectedElement,
         BehaviorSave? selectedBehavior,
         Array objectsDeleted,
-        DeleteOptionsWindow? optionsWindow)
+        IDeleteDialogResult? deleteDialogResult)
     {
         var siblings = selectedInstance.GetSiblingsIncludingThis();
         var parentInstance = selectedInstance.GetParentInstance();
@@ -233,7 +226,7 @@ public class DeleteLogic : IDeleteLogic
         // Fire DeleteConfirmed before removal so plugins can still find
         // children via parent reference variables (e.g. "Child.Parent = thisInstance").
         // RemoveInstanceFromElement destroys those references, breaking GetChildrenOf.
-        _pluginManager.DeleteConfirmed(optionsWindow!, objectsDeleted);
+        _deleteDialogService.NotifyConfirmed(deleteDialogResult!, objectsDeleted);
 
         if (selectedElement != null)
         {
@@ -320,11 +313,11 @@ public class DeleteLogic : IDeleteLogic
         }
 
         var combinedArray = combinedList.ToArray();
-        var result = ShowDeleteDialog(combinedArray, out var optionsWindow, instancesFromBase);
+        var result = ShowDeleteDialog(combinedArray, instancesFromBase);
 
-        if (result != true) return;
+        if (result.Result != true) return;
 
-        PerformConfirmedMixedTypeDelete(elements, behaviors, deletableInstances, combinedArray, optionsWindow);
+        PerformConfirmedMixedTypeDelete(elements, behaviors, deletableInstances, combinedArray, result);
     }
 
     internal void PerformConfirmedMixedTypeDelete(
@@ -332,7 +325,7 @@ public class DeleteLogic : IDeleteLogic
         List<BehaviorSave> behaviors,
         List<InstanceSave> deletableInstances,
         Array combinedArray,
-        DeleteOptionsWindow? optionsWindow)
+        IDeleteDialogResult? deleteDialogResult)
     {
         // Cache behavior parents before removal (GetBehaviorContainerOf won't find them after)
         var affectedBehaviorParents = deletableInstances
@@ -344,7 +337,7 @@ public class DeleteLogic : IDeleteLogic
         // 1. Notify plugins before removal so they can still find children via
         //    parent reference variables (e.g. "Child.Parent = thisInstance").
         //    RemoveInstanceFromElement destroys those references, breaking GetChildrenOf.
-        _pluginManager.DeleteConfirmed(optionsWindow!, combinedArray);
+        _deleteDialogService.NotifyConfirmed(deleteDialogResult!, combinedArray);
 
         // Group instances by their (non-deleted) parent element. Used both for the
         // post-removal InstancesDelete plugin notification and for the file-save pass below.
@@ -487,13 +480,10 @@ public class DeleteLogic : IDeleteLogic
         }
     }
 
-    bool? ShowDeleteDialog(Array objectsToDelete, out DeleteOptionsWindow optionsWindow,
+    IDeleteDialogResult ShowDeleteDialog(Array objectsToDelete,
         List<InstanceSave>? instancesFromBase = null)
     {
-
-        string titleText;
-
-        titleText = "Delete?";
+        string titleText = "Delete?";
         if (objectsToDelete.Length == 1)
         {
             var objectToDelete = objectsToDelete.GetValue(0);
@@ -515,20 +505,9 @@ public class DeleteLogic : IDeleteLogic
             }
         }
 
-        optionsWindow = new DeleteOptionsWindow();
-        optionsWindow.Title = titleText;
-        optionsWindow.Message = BuildDeleteDialogMessage(objectsToDelete, instancesFromBase);
-        optionsWindow.ObjectsToDelete = objectsToDelete;
+        var message = BuildDeleteDialogMessage(objectsToDelete, instancesFromBase);
 
-        // do this in Loaded so it has height
-        //_guiCommands.MoveToCursor(optionsWindow);
-
-        _pluginManager.ShowDeleteDialog(optionsWindow, objectsToDelete);
-
-        var result = optionsWindow.ShowDialog();
-
-
-        return result;
+        return _deleteDialogService.ShowDeleteDialog(titleText, message, objectsToDelete);
     }
 
     internal string BuildDeleteDialogMessage(Array objectsToDelete, List<InstanceSave>? instancesFromBase = null)

--- a/Gum/Services/Builder.cs
+++ b/Gum/Services/Builder.cs
@@ -94,7 +94,8 @@ file static class ServiceCollectionExtensions
         services.AddSingleton<IUndoPluginNotifier>(provider => provider.GetRequiredService<PluginManager>());
         // IDeletePluginNotifier: narrow headless port (ADR-0005 Phase 3) so DeleteLogic no longer depends on the
         // concrete PluginManager for delete notifications. Resolves to the same PluginManager singleton, so plugin
-        // calls fire as before. The two WPF-coupled delete calls (ShowDeleteDialog/DeleteConfirmed) remain on IPluginManager.
+        // calls fire as before. The two WPF-coupled delete calls (ShowDeleteDialog/DeleteConfirmed) now live behind
+        // IDeleteDialogService (see AddDialogs), removing DeleteLogic's last dependency on IPluginManager.
         services.AddSingleton<IDeletePluginNotifier>(provider => provider.GetRequiredService<PluginManager>());
         services.AddSingleton<TypeManager>();
         services.AddSingleton<ITypeManager>(provider => provider.GetRequiredService<TypeManager>());
@@ -215,6 +216,11 @@ file static class ServiceCollectionExtensions
     {
         services.AddSingleton<IDialogViewResolver, DialogViewResolver>();
         services.AddSingleton<IDialogService, DialogService>();
+        // IDeleteDialogService: headless seam (ADR-0005 Phase 3) over the standalone
+        // DeleteOptionsWindow so DeleteLogic no longer references WPF or the concrete plugin
+        // host for the delete-confirmation dialog. The WPF-coupled DeleteDialogService impl
+        // owns the window plus the ShowDeleteDialog/DeleteConfirmed plugin calls.
+        services.AddSingleton<IDeleteDialogService, DeleteDialogService>();
 
         return services;
     }

--- a/Gum/Services/Dialogs/DeleteDialogService.cs
+++ b/Gum/Services/Dialogs/DeleteDialogService.cs
@@ -1,0 +1,64 @@
+using Gum.Gui.Windows;
+using Gum.Plugins;
+using System;
+
+namespace Gum.Services.Dialogs;
+
+/// <summary>
+/// WPF implementation of <see cref="IDeleteDialogService"/>. Owns the standalone
+/// <see cref="DeleteOptionsWindow"/> and the plugin-host calls that compose and confirm it,
+/// keeping <see cref="Managers.DeleteLogic"/> free of any WPF reference (ADR-0005). This is
+/// shell/view code, so depending on the concrete plugin host (<see cref="IPluginManager"/>)
+/// here is legitimate.
+/// </summary>
+internal class DeleteDialogService : IDeleteDialogService
+{
+    private readonly IPluginManager _pluginManager;
+
+    public DeleteDialogService(IPluginManager pluginManager)
+    {
+        _pluginManager = pluginManager;
+    }
+
+    public IDeleteDialogResult ShowDeleteDialog(string title, string message, Array objectsToDelete)
+    {
+        DeleteOptionsWindow window = new()
+        {
+            Title = title,
+            Message = message,
+            ObjectsToDelete = objectsToDelete,
+        };
+
+        // Let plugins inject their checkboxes/options (e.g. "Delete XML file?") before the
+        // dialog is shown — this fires the DeleteOptionsWindowShow plugin event.
+        _pluginManager.ShowDeleteDialog(window, objectsToDelete);
+
+        bool? result = window.ShowDialog();
+
+        return new DeleteDialogResult(window, result);
+    }
+
+    public void NotifyConfirmed(IDeleteDialogResult result, Array objectsToDelete)
+    {
+        DeleteOptionsWindow window = ((DeleteDialogResult)result).Window;
+        _pluginManager.DeleteConfirmed(window, objectsToDelete);
+    }
+
+    /// <summary>
+    /// Concrete result returned by <see cref="ShowDeleteDialog"/>. Keeps a reference to the WPF
+    /// window so <see cref="NotifyConfirmed"/> can hand it back to plugins, while exposing only
+    /// the framework-neutral <see cref="IDeleteDialogResult.Result"/> to callers.
+    /// </summary>
+    private sealed class DeleteDialogResult : IDeleteDialogResult
+    {
+        public DeleteDialogResult(DeleteOptionsWindow window, bool? result)
+        {
+            Window = window;
+            Result = result;
+        }
+
+        public DeleteOptionsWindow Window { get; }
+
+        public bool? Result { get; }
+    }
+}

--- a/Tool/Tests/GumToolUnitTests/Managers/DeleteLogicTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Managers/DeleteLogicTests.cs
@@ -26,9 +26,9 @@ public class DeleteLogicTests : BaseTestClass
     private readonly DeleteLogic _deleteLogic;
     private readonly Mock<ISelectedState> _selectedState;
     private readonly Mock<IDialogService> _dialogService;
+    private readonly Mock<IDeleteDialogService> _deleteDialogService;
     private readonly Mock<IGuiCommands> _guiCommands;
     private readonly Mock<IFileCommands> _fileCommands;
-    private readonly Mock<IPluginManager> _pluginManager;
     private readonly Mock<IDeletePluginNotifier> _deletePluginNotifier;
     private readonly Mock<IWireframeObjectManager> _wireframeObjectManager;
     private readonly Mock<IDeleteProjectProvider> _deleteProjectProvider;
@@ -40,9 +40,9 @@ public class DeleteLogicTests : BaseTestClass
         _mocker = new AutoMocker();
         _selectedState = _mocker.GetMock<ISelectedState>();
         _dialogService = _mocker.GetMock<IDialogService>();
+        _deleteDialogService = _mocker.GetMock<IDeleteDialogService>();
         _guiCommands = _mocker.GetMock<IGuiCommands>();
         _fileCommands = _mocker.GetMock<IFileCommands>();
-        _pluginManager = _mocker.GetMock<IPluginManager>();
         _deletePluginNotifier = _mocker.GetMock<IDeletePluginNotifier>();
         _wireframeObjectManager = _mocker.GetMock<IWireframeObjectManager>();
         _deleteProjectProvider = _mocker.GetMock<IDeleteProjectProvider>();
@@ -61,9 +61,9 @@ public class DeleteLogicTests : BaseTestClass
         _deleteLogic = new DeleteLogic(
             _selectedState.Object,
             _dialogService.Object,
+            _deleteDialogService.Object,
             _guiCommands.Object,
             _fileCommands.Object,
-            _pluginManager.Object,
             _deletePluginNotifier.Object,
             _wireframeObjectManager.Object,
             _deleteProjectProvider.Object,
@@ -182,7 +182,7 @@ public class DeleteLogicTests : BaseTestClass
             new List<BehaviorSave>(),
             instances,
             instances.Cast<object>().ToArray(),
-            optionsWindow: null);
+            deleteDialogResult: null);
 
         _selectedState.Object.SelectedInstance.ShouldBeNull();
         _selectedState.Object.SelectedElement.ShouldBe(screen);
@@ -203,7 +203,7 @@ public class DeleteLogicTests : BaseTestClass
             new List<BehaviorSave>(),
             toDelete,
             toDelete.Cast<object>().ToArray(),
-            optionsWindow: null);
+            deleteDialogResult: null);
 
         _selectedState.Object.SelectedInstance.ShouldBe(instC);
     }
@@ -223,7 +223,7 @@ public class DeleteLogicTests : BaseTestClass
             new List<BehaviorSave>(),
             instances,
             instances.Cast<object>().ToArray(),
-            optionsWindow: null);
+            deleteDialogResult: null);
 
         _deletePluginNotifier.Verify(
             p => p.InstancesDelete(
@@ -251,7 +251,7 @@ public class DeleteLogicTests : BaseTestClass
             selectedElement: screen,
             selectedBehavior: null,
             objectsDeleted: new[] { child },
-            optionsWindow: null);
+            deleteDialogResult: null);
 
         _selectedState.Object.SelectedInstance.ShouldBe(parent);
     }
@@ -271,7 +271,7 @@ public class DeleteLogicTests : BaseTestClass
             selectedElement: screen,
             selectedBehavior: null,
             objectsDeleted: new[] { instC },
-            optionsWindow: null);
+            deleteDialogResult: null);
 
         _selectedState.Object.SelectedInstance.ShouldBe(instB);
     }
@@ -291,7 +291,7 @@ public class DeleteLogicTests : BaseTestClass
             selectedElement: screen,
             selectedBehavior: null,
             objectsDeleted: new[] { instB },
-            optionsWindow: null);
+            deleteDialogResult: null);
 
         _selectedState.Object.SelectedInstance.ShouldBe(instC);
     }
@@ -311,7 +311,7 @@ public class DeleteLogicTests : BaseTestClass
             selectedElement: screen,
             selectedBehavior: null,
             objectsDeleted: new[] { instance },
-            optionsWindow: null);
+            deleteDialogResult: null);
 
         _selectedState.Object.SelectedInstance.ShouldBeNull();
         _selectedState.Object.SelectedElement.ShouldBe(screen);
@@ -342,9 +342,35 @@ public class DeleteLogicTests : BaseTestClass
             selectedElement: screen,
             selectedBehavior: null,
             objectsDeleted: new[] { instance },
-            optionsWindow: null);
+            deleteDialogResult: null);
 
         selectedAtFireTime.ShouldBe(screen);
+    }
+
+    [Fact]
+    public void PerformConfirmedSingleInstanceDelete_NotifiesDeleteDialogServiceAndRemovesInstance()
+    {
+        // Pins that the post-confirmation plugin notification now routes through the headless
+        // IDeleteDialogService seam (ADR-0005 Phase 3) — carrying the dialog result and the exact
+        // objects being deleted — rather than the concrete PluginManager, and that the confirmed
+        // instance is actually removed from its owning element.
+        ScreenSave screen = CreateScreenWithInstances("InstA", "InstB");
+        InstanceSave instA = screen.Instances.Single(i => i.Name == "InstA");
+        TrackSelectionState();
+        _selectedState.Object.SelectedInstance = instA;
+
+        IDeleteDialogResult dialogResult = Mock.Of<IDeleteDialogResult>();
+        InstanceSave[] objectsDeleted = { instA };
+
+        _deleteLogic.PerformConfirmedSingleInstanceDelete(
+            selectedInstance: instA,
+            selectedElement: screen,
+            selectedBehavior: null,
+            objectsDeleted: objectsDeleted,
+            deleteDialogResult: dialogResult);
+
+        screen.Instances.ShouldNotContain(instA);
+        _deleteDialogService.Verify(d => d.NotifyConfirmed(dialogResult, objectsDeleted), Times.Once);
     }
 
     [Fact]

--- a/Tools/Gum.Presentation/Dialogs/IDeleteDialogService.cs
+++ b/Tools/Gum.Presentation/Dialogs/IDeleteDialogService.cs
@@ -1,0 +1,40 @@
+using System;
+
+namespace Gum.Services.Dialogs;
+
+/// <summary>
+/// Headless seam over the delete-confirmation dialog so DeleteLogic does not depend on WPF
+/// (the standalone DeleteOptionsWindow) or the concrete plugin host. The WPF implementation
+/// (DeleteDialogService) lives in the Gum shell; this interface and its opaque result type
+/// must stay free of any WPF/WinForms reference (ADR-0005). Mirrors <see cref="IDialogService"/>.
+/// </summary>
+public interface IDeleteDialogService
+{
+    /// <summary>
+    /// Builds and shows the modal delete-confirmation dialog — letting plugins inject their
+    /// options first — and blocks until the user responds. The returned handle carries the
+    /// user's choice via <see cref="IDeleteDialogResult.Result"/> and is otherwise opaque;
+    /// pass it back to <see cref="NotifyConfirmed"/> to fire the post-confirmation plugin event.
+    /// </summary>
+    IDeleteDialogResult ShowDeleteDialog(string title, string message, Array objectsToDelete);
+
+    /// <summary>
+    /// Notifies plugins that the delete was confirmed, for the dialog represented by
+    /// <paramref name="result"/>. Timing matters: callers fire this at specific points in the
+    /// delete flow (some before removal, some after) so plugins can still read parent references.
+    /// </summary>
+    void NotifyConfirmed(IDeleteDialogResult result, Array objectsToDelete);
+}
+
+/// <summary>
+/// Opaque handle to a shown delete dialog. Exposes only the user's choice; the WPF window it
+/// wraps stays hidden behind the implementation so this type carries no WPF dependency.
+/// </summary>
+public interface IDeleteDialogResult
+{
+    /// <summary>
+    /// The dialog's result: <c>true</c> = confirmed, <c>false</c> = cancelled,
+    /// <c>null</c> = closed without choosing.
+    /// </summary>
+    bool? Result { get; }
+}


### PR DESCRIPTION
## Summary

Introduces a headless `IDeleteDialogService` seam so `DeleteLogic` no longer touches WPF — the chosen "opaque seam" approach, mirroring how `IDialogService` was decoupled (headless interface in `Gum.Presentation`, WPF impl stays in the shell). **Seam only — `DeleteLogic` is not relocated here**; the `git mv` to `Gum.Presentation` is a separate follow-up, now unobstructed (its WPF blocker is gone).

Part of ADR-0005 Phase 3, following #3354/#3355/#3356/#3362.

## What changed

- **`IDeleteDialogService` + `IDeleteDialogResult`** (new, `Tools/Gum.Presentation/Dialogs/`, headless net8.0, zero WPF):
  - `IDeleteDialogResult ShowDeleteDialog(string title, string message, Array objectsToDelete)`
  - `void NotifyConfirmed(IDeleteDialogResult result, Array objectsToDelete)`
  - `IDeleteDialogResult` exposes only the dialog's `bool? Result` and is otherwise opaque — no WPF type appears on either interface.
- **`DeleteDialogService`** (new, shell impl in `Gum.csproj`): owns the `DeleteOptionsWindow` (`Title`/`Message`/`ObjectsToDelete`), the `IPluginManager.ShowDeleteDialog` call that fires the `DeleteOptionsWindowShow` plugin event, `ShowDialog()`, and `DeleteConfirmed`. `NotifyConfirmed` downcasts the opaque result back to the window. Injects `IPluginManager` (legitimate — it's shell/view code). Registered in `Builder.cs` (`AddDialogs`).
- **`DeleteLogic`**: injects `IDeleteDialogService` in place of `IPluginManager` (its **last** `IPluginManager` dependency — the other 8 plugin calls already route through `IDeletePluginNotifier`). The three interleaved `DeleteConfirmed` sites are rerouted to `NotifyConfirmed` at the **identical** points in the flow (two before removal, one after), so plugin-visible timing is unchanged. Removed `using Gum.Gui.Windows`, the dead `using System.Windows.Forms` / `DialogResult` alias / commented-out `MessageBox`. `DeleteLogic` no longer references any WPF/`Gum.Gui` type.

## Invariant

Behavior-preserving: the shell impl does precisely what `DeleteLogic` did. `DeleteLogic` reads only the `bool?` via `.Result`, never window/control state. No timing change was forced.

## Proof

- `Gum.Presentation` compiles standalone with **zero WPF reference** (0 errors).
- `GumFull.sln` builds, no new warnings.
- `GumToolUnitTests`: **983 passed, 4 skipped (pre-existing), 0 failed** — including re-pinned `DeleteLogicTests` (mock `IDeleteDialogService`; new test asserts `NotifyConfirmed` is invoked with the dialog result + exact objects and the instance is removed), `AllPluginsCompositionTests`, and `ServiceProviderCompositionSpikeTests`.
- Red-first: disabling one `NotifyConfirmed` call made the new pinning test go red ("No invocations performed"); restored to green.

## Manual test

Needed (runtime dialog behavior). With VS open on `Gum.sln`:
1. Select an instance, press Delete → the delete dialog appears with the plugins' options (Delete XML, "just parent / parent + children").
2. Select an element that has animations, delete it → confirm the dialog also shows "Delete .ganx".
3. Confirm a delete → the object(s) are removed and the chosen options are honored.

Closes — (ADR-0005 Phase 3, no tracking issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
