### PR TITLE
Fix headless SVG export crash on projects containing a Line (#3324)

### DIFF
--- a/Runtimes/SkiaGum/RenderingLibrary/SystemManagers.cs
+++ b/Runtimes/SkiaGum/RenderingLibrary/SystemManagers.cs
@@ -115,6 +115,14 @@ namespace RenderingLibrary
                 "Container",
                 () => new ContainerRuntime());
 
+            // Issue #3324 — without this registration a "Line" standard type created no
+            // renderable, so a Line was silently dropped from SVG export (the same #3259-class
+            // gap that hit Rectangle). The XNALIKE/Apos backend registers the same runtime in
+            // AposShapeRuntime. Pairs with the "Line" arm added to HandleCustomGetDefaultState.
+            ElementSaveExtensions.RegisterGueInstantiation(
+                "Line",
+                () => new LineRuntime());
+
             //ElementSaveExtensions.RegisterGueInstantiation(
             //    "NineSlice",
             //    () => new NineSliceRuntime());
@@ -169,6 +177,10 @@ namespace RenderingLibrary
                 "Arc" => StandardElementsManager.GetArcState(),
                 "Canvas" => DefaultStateManager.GetCanvasState(),
                 "ColoredCircle" => StandardElementsManager.GetColoredCircleState(),
+                // Issue #3324 — Line was the one extended shape type missing here, so headless
+                // SVG export (gumcli svg / File ▸ Export) threw "Could not get the default state
+                // for type Line" during GumProjectSave.Initialize for any project containing one.
+                "Line" => StandardElementsManager.GetLineState(),
                 "LottieAnimation" => DefaultStateManager.GetLottieAnimationState(),
                 "RoundedRectangle" => StandardElementsManager.GetRoundedRectangleState(),
                 "Svg" => DefaultStateManager.GetSvgState(),

--- a/Tests/Gum.ProjectServices.SkiaGum.Tests/SkiaGumSvgExportServiceTests.cs
+++ b/Tests/Gum.ProjectServices.SkiaGum.Tests/SkiaGumSvgExportServiceTests.cs
@@ -105,6 +105,36 @@ public class SkiaGumSvgExportServiceTests : IDisposable
             $"Expected the exported SVG for an Arc instance to contain a draw element, but it did not.{Environment.NewLine}SVG:{Environment.NewLine}{svg}");
     }
 
+    // Regression test for issue #3324: SVG export threw
+    // "Could not get the default state for type Line" whenever the project contained a Line
+    // standard element, because SkiaGum's SystemManagers wired Arc/ColoredCircle/RoundedRectangle/
+    // Canvas/Svg/LottieAnimation into CustomGetDefaultState but omitted Line. Like Arc, Line is not
+    // part of ProjectCreator's v3 seed, so a project that uses one ships its own Line standard. Seed
+    // one with GetLineState's real defaults (IsRounded false, StrokeWidth 2) and confirm the Line
+    // both exports without throwing AND renders a draw element (its runtime is now registered, the
+    // same #3259-class "silently dropped" gap that the Rectangle/Arc cases above guard against).
+    [Fact]
+    public void ExportSvg_LineInstance_WithSeededStandard_ShouldRenderADrawElement()
+    {
+        StandardElementSave lineStandard = new StandardElementSave { Name = "Line" };
+        StateSave lineState = new StateSave { Name = "Default", ParentContainer = lineStandard };
+        lineStandard.States.Add(lineState);
+        lineState.Variables.Add(new VariableSave { Name = "IsRounded", Type = "bool", Value = false, SetsValue = true });
+        lineState.Variables.Add(new VariableSave { Name = "StrokeWidth", Type = "float", Value = 2f, SetsValue = true });
+
+        string svg = ExportScreenWithInstance(
+            "Line",
+            new[] { lineStandard },
+            new VariableSave { Name = "ShapeInstance.X", Type = "float", Value = 10f, SetsValue = true },
+            new VariableSave { Name = "ShapeInstance.Y", Type = "float", Value = 10f, SetsValue = true },
+            new VariableSave { Name = "ShapeInstance.Width", Type = "float", Value = 100f, SetsValue = true },
+            new VariableSave { Name = "ShapeInstance.Height", Type = "float", Value = 80f, SetsValue = true });
+
+        bool hasDrawElement = DrawElementTags.Any(svg.Contains);
+        hasDrawElement.ShouldBeTrue(
+            $"Expected the exported SVG for a Line instance to contain a draw element, but it did not.{Environment.NewLine}SVG:{Environment.NewLine}{svg}");
+    }
+
     private string ExportScreenWithInstance(string baseType, params VariableSave[] instanceVariables) =>
         ExportScreenWithInstance(baseType, standardsToSeed: null, instanceVariables);
 

--- a/Tests/Gum.ProjectServices.SkiaGum.Tests/SkiaGumSvgExportServiceTests.cs
+++ b/Tests/Gum.ProjectServices.SkiaGum.Tests/SkiaGumSvgExportServiceTests.cs
@@ -135,6 +135,42 @@ public class SkiaGumSvgExportServiceTests : IDisposable
             $"Expected the exported SVG for a Line instance to contain a draw element, but it did not.{Environment.NewLine}SVG:{Environment.NewLine}{svg}");
     }
 
+    // Full coverage for issue #3324 across EVERY extended standard type — the shapes
+    // (Arc/ColoredCircle/RoundedRectangle/Line) and the Skia-only types (Canvas/Svg/LottieAnimation).
+    // None are in ProjectCreator's v3 seed, so each is seeded as its own standard, which is the exact
+    // condition that triggered the crash: GumProjectSave.Initialize calls GetDefaultStateFor for every
+    // standard in the project, and any type missing from the SkiaGum SystemManagers' CustomGetDefaultState
+    // switch threw "Could not get the default state for type X", failing the whole export. This pins all
+    // seven against that regression. (Export-success is the uniform assertion: Canvas/Svg/LottieAnimation
+    // render nothing without children or a SourceFile; per-shape render coverage lives in the tests above.)
+    [Theory]
+    [InlineData("Arc")]
+    [InlineData("ColoredCircle")]
+    [InlineData("RoundedRectangle")]
+    [InlineData("Line")]
+    [InlineData("Canvas")]
+    [InlineData("Svg")]
+    [InlineData("LottieAnimation")]
+    public void ExportSvg_ExtendedStandardType_WithSeededStandard_ShouldExportWithoutThrowing(string baseType)
+    {
+        StandardElementSave standard = new StandardElementSave { Name = baseType };
+        StateSave defaultState = new StateSave { Name = "Default", ParentContainer = standard };
+        standard.States.Add(defaultState);
+        defaultState.Variables.Add(new VariableSave { Name = "Visible", Type = "bool", Value = true, SetsValue = true });
+
+        // ExportScreenWithInstance asserts result.Success internally; before the fix this threw
+        // InvalidOperationException for any extended type absent from the SystemManagers switch.
+        string svg = ExportScreenWithInstance(
+            baseType,
+            new[] { standard },
+            new VariableSave { Name = "ShapeInstance.X", Type = "float", Value = 10f, SetsValue = true },
+            new VariableSave { Name = "ShapeInstance.Y", Type = "float", Value = 10f, SetsValue = true },
+            new VariableSave { Name = "ShapeInstance.Width", Type = "float", Value = 100f, SetsValue = true },
+            new VariableSave { Name = "ShapeInstance.Height", Type = "float", Value = 80f, SetsValue = true });
+
+        svg.ShouldNotBeNullOrEmpty();
+    }
+
     private string ExportScreenWithInstance(string baseType, params VariableSave[] instanceVariables) =>
         ExportScreenWithInstance(baseType, standardsToSeed: null, instanceVariables);
 


### PR DESCRIPTION
## Summary

Fixes #3324 — headless SVG export (`gumcli svg`, tool **File ▸ Export**) crashed with `InvalidOperationException: Could not get the default state for type Line` for any project containing a `Line` standard element.

## Root cause

The headless SkiaGum path uses the **Skia `SystemManagers`** (`Runtimes/SkiaGum/RenderingLibrary/SystemManagers.cs`), which sets `CustomGetDefaultState = HandleCustomGetDefaultState`. That switch already covered `Arc`, `Canvas`, `ColoredCircle`, `RoundedRectangle`, `Svg`, and `LottieAnimation` — **`Line` was the one extended shape type missing**, so a project containing a `Line` standard threw during `GumProjectSave.Initialize()` (which calls `GetDefaultStateFor(name)` for every standard), before any rendering.

### Scope of the crash — measured, not assumed

The issue body suggested *any* extended type would fail. That isn't what happens: a test exporting all seven extended types against the **pre-fix** code fails for **`Line` only** (6/7 pass). The other six were already wired. The new `ExportSvg_ExtendedStandardType_WithSeededStandard_ShouldExportWithoutThrowing` theory pins this for all seven so the boundary is a behavioral guard, not a claim.

## Fix

In the Skia `SystemManagers`, complete the existing per-type wiring for `Line` (mirroring how the XNALIKE/Apos backend wires it in `AposShapeRuntime`):

1. `HandleCustomGetDefaultState` — add `"Line" => StandardElementsManager.GetLineState()` (stops the crash).
2. `RegisterComponentRuntimeInstantiations` — register `RegisterGueInstantiation("Line", () => new LineRuntime())` so the Line actually **renders** rather than being silently dropped (the same #3259-class gap that previously hit `Rectangle`).

This is more targeted than re-introducing the headless `RegisterExtendedDefaultStates()` bridge, avoids a redundant second mechanism, and also fixes any other SkiaGum host (WPF/MAUI/Silk.NET), not just SVG export. The longer-term cleanup (promoting these extended types to first-class entries in `RefreshDefaults()`, per the `// INTERIM:` comment) remains out of scope.

## Tests

- `ExportSvg_ExtendedStandardType_WithSeededStandard_ShouldExportWithoutThrowing` — **theory over all 7** extended types; each seeded as its own standard and exported. Pre-fix it fails for `Line` only; post-fix all pass.
- `ExportSvg_LineInstance_WithSeededStandard_ShouldRenderADrawElement` — pins that a `Line` not only exports but **renders** a draw element (regression guard for the runtime registration).
- Full `Gum.ProjectServices.SkiaGum.Tests` (12/12) and `SkiaGum.Tests` (189/189) green.
- End-to-end: `gumcli svg` on a project with a `Line` now exits 0 and emits `<path stroke="white" stroke-width="4" d="M100 100L400 300"/>`.

Closes #3324

🤖 Generated with [Claude Code](https://claude.com/claude-code)
