### PR TITLE
Surface missing-source elements as GUM0004 in the Errors tab (#3309)

### DIFF
--- a/Tests/Gum.ProjectServices.Tests/HeadlessErrorCheckerTests.cs
+++ b/Tests/Gum.ProjectServices.Tests/HeadlessErrorCheckerTests.cs
@@ -909,4 +909,43 @@ public class HeadlessErrorCheckerTests : BaseTestClass
     }
 
     #endregion
+
+    #region GUM0004 — Missing source file
+
+    [Fact]
+    public void GetErrorsFor_ShouldNotReportGum0004_WhenElementSourceFileExists()
+    {
+        // A normally-loaded element has IsSourceFileMissing == false (the flag is only
+        // set by ElementReference.ToElementSave when the .gucx/.gusx/.gutx isn't on disk).
+        ComponentSave component = new ComponentSave { Name = "RealComponent", BaseType = "Container" };
+        Project.Components.Add(component);
+
+        IReadOnlyList<ErrorResult> errors = _sut.GetErrorsFor(component, Project);
+
+        errors.ShouldNotContain(e => e.Code == "GUM0004");
+    }
+
+    [Fact]
+    public void GetErrorsFor_ShouldReportGum0004_WhenElementSourceFileIsMissing()
+    {
+        // Repro #3309: when an element's backing file is missing on disk, the tree shows a
+        // red "!" (driven by IsSourceFileMissing) but the Errors tab stays empty because
+        // missing-source was never surfaced as an ErrorResult. Surface it so the user can
+        // see why the element is flagged and where the file was expected.
+        ComponentSave component = new ComponentSave { Name = "GhostComponent" };
+        component.IsSourceFileMissing = true;
+        Project.Components.Add(component);
+
+        IReadOnlyList<ErrorResult> errors = _sut.GetErrorsFor(component, Project);
+
+        ErrorResult error = errors.ShouldHaveSingleItem();
+        error.Code.ShouldBe("GUM0004");
+        error.ElementName.ShouldBe("GhostComponent");
+        error.Severity.ShouldBe(ErrorSeverity.Error);
+        error.Message.ShouldContain("GhostComponent");
+        error.Message.ShouldContain("Components");
+        error.Message.ShouldContain(".gucx");
+    }
+
+    #endregion
 }

--- a/Tools/Gum.ProjectServices/ErrorDocsRegistry.cs
+++ b/Tools/Gum.ProjectServices/ErrorDocsRegistry.cs
@@ -16,6 +16,7 @@ public class ErrorDocsRegistry : IErrorDocsRegistry
             ["GUM0001"] = "gum-tool/gum-elements/behaviors#behavior-instance-requirements",
             ["GUM0002"] = "gum-tool/gum-elements/states/categories#gum0002-variable-reference-conflicts-with-explicit-set",
             ["GUM0003"] = "gum-tool/gum-elements/states/categories#gum0003-category-state-sets-its-own-category-selector",
+            ["GUM0004"] = "gum-tool/project-files#missing-source-files-gum0004",
         };
     }
 

--- a/Tools/Gum.ProjectServices/HeadlessErrorChecker.cs
+++ b/Tools/Gum.ProjectServices/HeadlessErrorChecker.cs
@@ -102,6 +102,7 @@ public class HeadlessErrorChecker : IHeadlessErrorChecker
         {
             errors.AddRange(GetBehaviorErrorsFor(asComponent, project));
         }
+        errors.AddRange(GetMissingSourceFileErrorsFor(element));
         errors.AddRange(GetMissingElementBaseTypeErrorFor(element));
         errors.AddRange(GetMissingBaseTypeErrorsFor(element));
         errors.AddRange(GetParentErrorsFor(element));
@@ -490,6 +491,42 @@ public class HeadlessErrorChecker : IHeadlessErrorChecker
                     }
                 }
             }
+        }
+
+        return errors;
+    }
+
+    #endregion
+
+    #region GUM0004 — Missing source file
+
+    /// <summary>
+    /// Surfaces elements whose backing file (.gusx/.gucx/.gutx) was not found on disk when the
+    /// project loaded. <see cref="ElementReference.ToElementSave{T}"/> sets
+    /// <see cref="ElementSave.IsSourceFileMissing"/> in that case and the tree shows a red "!",
+    /// but without this check the Errors tab stays empty - leaving the user no way to find out
+    /// why the element is flagged (issue #3309).
+    /// This is intentionally a listed error only; it must not block saving (see the historical
+    /// comment in ElementReference.ToElementSave), because saving the element is exactly what
+    /// recreates the missing file.
+    /// </summary>
+    private static List<ErrorResult> GetMissingSourceFileErrorsFor(ElementSave element)
+    {
+        var errors = new List<ErrorResult>();
+
+        if (element.IsSourceFileMissing)
+        {
+            var expectedRelativePath = $"{element.Subfolder}/{element.Name}.{element.FileExtension}";
+            errors.Add(new ErrorResult
+            {
+                ElementName = element.Name,
+                Code = "GUM0004",
+                Severity = ErrorSeverity.Error,
+                Message = $"The source file for \"{element.Name}\" is missing. Gum expected it at " +
+                    $"\"{expectedRelativePath}\" but could not find it on disk. The element still exists " +
+                    $"in the project in memory - saving it will recreate the file, or restore the file " +
+                    $"to resolve this error."
+            });
         }
 
         return errors;

--- a/docs/gum-tool/project-files/README.md
+++ b/docs/gum-tool/project-files/README.md
@@ -115,6 +115,17 @@ This is an append-only log. Deleting a screen adds a "deleted" event rather than
 
 This file is transient and user-specific. It **should not be committed** to version control.
 
+## Missing Source Files (GUM0004)
+
+If the Gum tool opens a project whose `.gumx` references an element (screen, component, or standard element) but the matching element file is not found on disk, the element still appears in the tree with a red "!" indicator. This can happen when an element file is deleted, renamed, or moved outside the Gum tool — for example by a version-control operation that removes the file while the project is open.
+
+When this happens the Gum tool reports a **GUM0004** error in the [Errors tab](../editor-tab.md), naming the element and the path where its file was expected (for example `Components/Button.gucx`). The element itself is still present in memory, so the project keeps working. To resolve the error, either:
+
+* **Restore the missing file** — undo the deletion or move it back to the expected location, then reload the project.
+* **Re-save the element** — saving the element (for example by editing it) recreates the file from the in-memory copy.
+
+GUM0004 is a listed error only; it does not block saving the project.
+
 ## Version Control (.gitignore)
 
 The following `.gitignore` entries are recommended for Gum projects:


### PR DESCRIPTION
## Summary

Closes #3309.

When an element's source file (`.gusx`/`.gucx`/`.gutx`) is missing on disk at load time, `ElementReference.ToElementSave` sets `IsSourceFileMissing` and the tree shows a red `!`. But the Errors tab stayed **empty even on selection**, because missing-source was never converted into an error result — the icon and the Errors tab are fed by two independent paths, and only the icon honored the flag. The user saw a visible error indicator with no explanation anywhere in the UI.

## Change

- **`HeadlessErrorChecker`** — new core check `GetMissingSourceFileErrorsFor` emits a **`GUM0004`** `ErrorResult` for each element where `IsSourceFileMissing` is true, naming the element and the path where its file was expected (e.g. `Components/Button.gucx`). Living in the headless layer means both the tool's Errors tab (per-selected-element refresh) and `gumcli check` (whole-project pass) surface it.
- **`ErrorDocsRegistry`** — register `GUM0004` → a help URL.
- **`docs/gum-tool/project-files/README.md`** — new "Missing Source Files (GUM0004)" section (the `ErrorDocsRegistryTests` guard requires every registered code to resolve to a real docs heading).

## Deliberately a listed error, not a save-blocker

`ElementReference.ToElementSave` has a long-standing comment explaining missing-source was intentionally *not* treated as a hard error — doing so once put Gum into a state where it "can't save anything," since saving the element is exactly what recreates the file. This change only *lists* the error; it does not block saving.

## Tests

- `HeadlessErrorCheckerTests` — red-first: positive test (flag set → single `GUM0004` error with the expected path) failed before the implementation, passes after; negative test guards against a false positive when the file exists.
- Full `Gum.ProjectServices.Tests` (307) and CLI `CheckCommandTests` (5) green — the latter empirically confirms a clean `gumcli new` project has all standard `.gutx` on disk, so no `GUM0004` false positives.

## Scope note

The user separately observed that **deleting a source file while the tool is *running*** does not raise the `!` at all (`IsSourceFileMissing` is computed only at load; `FileWatchManager.HandleFileSystemDelete` is a no-op). That is a distinct false-*negative* and is **out of scope here** — fixing it well needs either replicating `ElementReference`'s path resolution (which risks the #3310-class false positive) or a delete-event refresh trigger in the FileWatch subsystem. Recommend a follow-up issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
