### PR TITLE
Don't recreate missing-source element files on project save (#3369)

### DIFF
--- a/GumDataTypes/GumProjectSave.cs
+++ b/GumDataTypes/GumProjectSave.cs
@@ -803,10 +803,14 @@ public class GumProjectSave
 
             foreach (var screenSave in Screens)
             {
+                // Don't recreate a file the user deleted and whose element is only an in-memory
+                // missing-source stub - saving would silently undo the deletion (issue #3369).
+                if (screenSave.IsSourceFileMissing) continue;
                 screenSave.Save(directory + ElementReference.ScreenSubfolder + "/" + screenSave.Name + "." + ScreenExtension, useCompact);
             }
             foreach (var componentSave in Components)
             {
+                if (componentSave.IsSourceFileMissing) continue;
                 componentSave.Save(directory + ElementReference.ComponentSubfolder + "/" + componentSave.Name + "." + ComponentExtension, useCompact);
             }
             SaveStandardElements(directory, useCompact);
@@ -817,6 +821,11 @@ public class GumProjectSave
     {
         foreach (var standardElement in StandardElements)
         {
+            // A missing-source standard is an in-memory stub for a .gutx the user removed (and
+            // declined to recreate). Persisting it here would silently recreate the file - and
+            // from a default reconstruction, not the original - overriding the user's intent
+            // and churning version control (issue #3369).
+            if (standardElement.IsSourceFileMissing) continue;
 
             const int maxNumberOfTries = 6;
             const int msBetweenSaves = 100;

--- a/Tests/Gum.ProjectServices.Tests/GumProjectSaveTests.cs
+++ b/Tests/Gum.ProjectServices.Tests/GumProjectSaveTests.cs
@@ -1,0 +1,63 @@
+using Gum.DataTypes;
+using Shouldly;
+
+namespace Gum.ProjectServices.Tests;
+
+public class GumProjectSaveTests
+{
+    [Fact]
+    public void Save_ShouldNotRecreateStandardElementFile_WhenSourceFileIsMissing()
+    {
+        string tempDir = Path.Combine(Path.GetTempPath(), "GumProjectSaveTest_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        string gumxPath = Path.Combine(tempDir, "Test.gumx");
+        try
+        {
+            // Repro #3369: the user deleted Arc.gutx on disk and declined the "Recreate?" prompt.
+            // The loader keeps an in-memory stub flagged IsSourceFileMissing. A subsequent project
+            // save (e.g. the load-time re-save) must NOT silently rewrite that file — but a present
+            // standard must still save normally.
+            GumProjectSave project = new GumProjectSave();
+            project.StandardElements.Add(new StandardElementSave { Name = "Arc", IsSourceFileMissing = true });
+            project.StandardElements.Add(new StandardElementSave { Name = "Container" });
+
+            project.Save(gumxPath, saveElements: true);
+
+            File.Exists(Path.Combine(tempDir, "Standards", "Arc.gutx")).ShouldBeFalse();
+            File.Exists(Path.Combine(tempDir, "Standards", "Container.gutx")).ShouldBeTrue();
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Save_ShouldNotRecreateScreenOrComponentFile_WhenSourceFileIsMissing()
+    {
+        string tempDir = Path.Combine(Path.GetTempPath(), "GumProjectSaveTest_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        string gumxPath = Path.Combine(tempDir, "Test.gumx");
+        try
+        {
+            // The same hazard applies to missing screens and components, not just standards: the
+            // load-time re-save loops over all three element types in GumProjectSave.Save.
+            GumProjectSave project = new GumProjectSave();
+            project.Screens.Add(new ScreenSave { Name = "GhostScreen", IsSourceFileMissing = true });
+            project.Screens.Add(new ScreenSave { Name = "RealScreen" });
+            project.Components.Add(new ComponentSave { Name = "GhostComponent", IsSourceFileMissing = true });
+            project.Components.Add(new ComponentSave { Name = "RealComponent" });
+
+            project.Save(gumxPath, saveElements: true);
+
+            File.Exists(Path.Combine(tempDir, "Screens", "GhostScreen.gusx")).ShouldBeFalse();
+            File.Exists(Path.Combine(tempDir, "Screens", "RealScreen.gusx")).ShouldBeTrue();
+            File.Exists(Path.Combine(tempDir, "Components", "GhostComponent.gucx")).ShouldBeFalse();
+            File.Exists(Path.Combine(tempDir, "Components", "RealComponent.gucx")).ShouldBeTrue();
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #3369.

When a project is opened with a missing element file (`.gusx`/`.gucx`/`.gutx`), the loader keeps an in-memory stub flagged `IsSourceFileMissing` — the tree shows a red `!` (and GUM0004 once #3366 lands). But `GumProjectSave.Save` looped over every screen, component, and standard and wrote each **unconditionally**, so a project save silently **recreated the deleted file** — from a *default reconstruction*, not the original — overriding the user's intent (e.g. declining the "Recreate this standard?" prompt) and churning version control.

## Root cause — and a correction to the original report

The issue first attributed the recreation to **selecting** the standard in the tree. Tracing the full selection cascade showed it performs **no disk write** at all (it's refresh/undo/display only, and the wireframe refresh is itself guarded against `IsSourceFileMissing`). The per-element writer `FileCommands.SaveElement` is *already* guarded (it shows a "cannot save" dialog).

The actual recreating writer is **`GumProjectSave.Save`** (`GumDataTypes/GumProjectSave.cs`), reached by:
- the **load-time re-save** — `ProjectManager.LoadProject` calls `SaveProject(forceSaveContainedElements: true)` whenever any load-repair pass marks the project modified, and
- **Save-All**.

A red-first unit test calling `GumProjectSave.Save` directly reproduces the recreation, confirming the writer independently of the UI trigger.

## Change

Add an `if (element.IsSourceFileMissing) continue;` skip to all three element loops in `GumProjectSave.Save` / `SaveStandardElements`, mirroring the existing skip in `ProjectLoader`. Guarding all three (not just standards) because the same hazard applies to a missing screen or component — same method, same one-line fix.

- **"Yes, recreate" still works:** that path builds a *fresh* element (`IsSourceFileMissing == false`), which the guard does not skip.
- **Normal saves unaffected:** present elements are always `IsSourceFileMissing == false`.
- **Honors "No":** the declined element stays an in-memory stub, still flagged in the tree, no longer rewritten to disk.

## Tests

`GumProjectSaveTests` (new) — red-first: both tests failed before the guard (the missing `Arc.gutx` / `GhostScreen.gusx` were recreated) and pass after; present siblings (`Container.gutx`, `RealScreen.gusx`, …) still save, proving the skip is selective. Full `Gum.ProjectServices.Tests` (307) green.

## Related

- #3366 (#3309) — surfaces missing-source as GUM0004; this PR stops the silent disk write underneath that signal.
- #3367 — separate staleness: the `!` / error don't clear when the file reappears at runtime (`IsSourceFileMissing` is load-time-only). Not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
