### PR TITLE
Detect runtime deletion of element files and flag missing source (#3367)

### DIFF
--- a/Gum/Managers/FileChangeReactionLogic.cs
+++ b/Gum/Managers/FileChangeReactionLogic.cs
@@ -177,6 +177,25 @@ namespace Gum.Managers
             return null;
         }
 
+        /// <summary>
+        /// True when <paramref name="file"/> is the reappearance on disk of an element whose source
+        /// we previously flagged missing (issue #3367) - a loaded element maps to this path and is
+        /// currently <see cref="ElementSave.IsSourceFileMissing"/>. The file watcher uses this to
+        /// process the lone Created event a restore fires (normally suppressed for Gum XML files, to
+        /// avoid double reloads on save) so the element reloads from disk and the flag clears.
+        /// </summary>
+        public bool IsReappearanceOfMissingSourceElement(FilePath file)
+            => IsReappearanceOfMissingSourceElement(file, _fileCommands.ProjectDirectory);
+
+        public static bool IsReappearanceOfMissingSourceElement(FilePath file, FilePath projectDirectory)
+        {
+            var elementName = GetElementNameForElementFile(file, projectDirectory);
+            if (elementName == null) return false;
+
+            var element = ObjectFinder.Self.GetElementSave(elementName);
+            return element != null && element.IsSourceFileMissing;
+        }
+
         private void ReactToLocalizationFileChanged(FilePath file)
         {
             var gumProject = _projectState.GumProjectSave;

--- a/Gum/Managers/FileChangeReactionLogic.cs
+++ b/Gum/Managers/FileChangeReactionLogic.cs
@@ -95,6 +95,88 @@ namespace Gum.Managers
             _pluginManager.ReactToFileChanged(file);
         }
 
+        /// <summary>
+        /// Reacts to an element file (.gusx/.gucx/.gutx) that was deleted on disk while the tool
+        /// is running. The flush routes here (instead of the change path) only once the file is
+        /// confirmed gone, so a delete-then-recreate within the debounce window is handled as a
+        /// normal reload instead. See <see cref="ReactToElementSaveDeleted"/> for why the element
+        /// is flagged rather than reloaded.
+        /// </summary>
+        public void ReactToFileDeleted(FilePath file)
+        {
+            var extension = file.Extension;
+            if (extension == GumProjectSave.ScreenExtension || extension == GumProjectSave.ComponentExtension ||
+                extension == GumProjectSave.StandardExtension)
+            {
+                ReactToElementSaveDeleted(file);
+            }
+        }
+
+        private void ReactToElementSaveDeleted(FilePath file)
+        {
+            // Defensive: the flush already gates on the file being gone, but if a delete event was
+            // really a transient delete-then-recreate (atomic save) the file is back by now - in
+            // which case the change path, not this one, should handle it.
+            if (file.Exists()) return;
+
+            var element = FlagElementForDeletedFile(file, _fileCommands.ProjectDirectory);
+            if (element == null) return;
+
+            _guiCommands.RefreshElementTreeView();
+            _pluginManager.ElementReloaded(element);
+        }
+
+        /// <summary>
+        /// Maps an element file path (.gusx/.gucx/.gutx) to the name ObjectFinder uses - the path
+        /// relative to its type folder, e.g. "MyButton" or "Sub/MyButton". Returns null when the
+        /// file isn't under the project directory (the same early-out the change path applied).
+        /// </summary>
+        internal static string? GetElementNameForElementFile(FilePath file, FilePath projectDirectory)
+        {
+            if (projectDirectory == null) return null;
+            if (!projectDirectory.IsRootOf(file)) return null;
+
+            FilePath standardized = file.RemoveExtension().StandardizedCaseSensitive;
+            var relativeToFolderForType = standardized.RelativeTo(projectDirectory).Replace("\\", "/");
+
+            if (relativeToFolderForType.StartsWith("Screens/"))
+            {
+                relativeToFolderForType = relativeToFolderForType.Substring("Screens/".Length);
+            }
+            else if (relativeToFolderForType.StartsWith("Components/"))
+            {
+                relativeToFolderForType = relativeToFolderForType.Substring("Components/".Length);
+            }
+            else if (relativeToFolderForType.StartsWith("Standards/"))
+            {
+                relativeToFolderForType = relativeToFolderForType.Substring("Standards/".Length);
+            }
+            return relativeToFolderForType;
+        }
+
+        /// <summary>
+        /// Finds the loaded element whose source file was deleted and flags it
+        /// <see cref="ElementSave.IsSourceFileMissing"/> so the tree shows the red "!" and the
+        /// Errors tab lists GUM0004 (issue #3367). The element is deliberately NOT reloaded or
+        /// removed: the in-memory copy is authoritative and may hold unsaved edits, and saving it
+        /// re-creates the file (clearing the flag). Returns the flagged element, or null when the
+        /// path maps to no loaded element or it was already flagged (so the caller can skip the
+        /// UI refresh).
+        /// </summary>
+        public static ElementSave? FlagElementForDeletedFile(FilePath deletedFile, FilePath projectDirectory)
+        {
+            var elementName = GetElementNameForElementFile(deletedFile, projectDirectory);
+            if (elementName == null) return null;
+
+            var element = ObjectFinder.Self.GetElementSave(elementName);
+            if (element != null && !element.IsSourceFileMissing)
+            {
+                element.IsSourceFileMissing = true;
+                return element;
+            }
+            return null;
+        }
+
         private void ReactToLocalizationFileChanged(FilePath file)
         {
             var gumProject = _projectState.GumProjectSave;
@@ -289,27 +371,10 @@ namespace Gum.Managers
         private void ReactToElementSaveChanged(FilePath file)
         {
             var projectDirectory = _fileCommands.ProjectDirectory;
+            var relativeToFolderForType = GetElementNameForElementFile(file, projectDirectory);
             ////////////////////////Early Out////////////////////////////
-            if (projectDirectory == null) return;
-            if (!projectDirectory.IsRootOf(file)) return;
+            if (relativeToFolderForType == null) return;
             ///////////////////////End Early Out/////////////////////////
-
-            FilePath standardized = file.RemoveExtension().StandardizedCaseSensitive;
-            var relativeToFolderForType = standardized.RelativeTo(projectDirectory).Replace("\\", "/");
-
-            if(relativeToFolderForType.StartsWith("Screens/"))
-            {
-                relativeToFolderForType = relativeToFolderForType.Substring("Screens/".Length);
-            }
-            else if(relativeToFolderForType.StartsWith("Components/"))
-            {
-                relativeToFolderForType = relativeToFolderForType.Substring("Components/".Length);
-            }
-            else if(relativeToFolderForType.StartsWith("Standards/"))
-            {
-                relativeToFolderForType = relativeToFolderForType.Substring("Standards/".Length);
-            }
-
 
             var element = ObjectFinder.Self.GetElementSave(relativeToFolderForType);
 

--- a/Gum/Plugins/InternalPlugins/FileWatchPlugin/FileWatchManager.cs
+++ b/Gum/Plugins/InternalPlugins/FileWatchPlugin/FileWatchManager.cs
@@ -199,6 +199,14 @@ public class FileWatchManager : IFileWatchManager
         {
             HandleFileSystemChange(fileName);
         }
+        // ...except when the Created file is the reappearance of an element we previously flagged
+        // missing (issue #3367). A restore (e.g. Explorer's undo-delete) fires only a Created - no
+        // Change - so without this the red "!" / GUM0004 would never clear. Limiting it to flagged
+        // elements keeps normal saves (which Gum ignore-lists anyway) on the suppressed path.
+        else if (_fileChangeReactionLogic.IsReappearanceOfMissingSourceElement(fileName))
+        {
+            HandleFileSystemChange(fileName);
+        }
     }
 
     private void HandleFileSystemChange(FilePath fileName)

--- a/Gum/Plugins/InternalPlugins/FileWatchPlugin/FileWatchManager.cs
+++ b/Gum/Plugins/InternalPlugins/FileWatchPlugin/FileWatchManager.cs
@@ -1,4 +1,5 @@
 using Gum.Commands;
+using Gum.DataTypes;
 using Gum.Managers;
 using Gum.Services;
 using System;
@@ -166,7 +167,24 @@ public class FileWatchManager : IFileWatchManager
 
     private void HandleFileSystemDelete(object? sender, FileSystemEventArgs e)
     {
-        // do anything?
+        var fileName = new FilePath(e.FullPath);
+        // Detect deletion of an element file so the tool can flag the element's source as missing
+        // (red "!" / GUM0004) instead of silently diverging from disk (issue #3367). Enqueue it
+        // like a change - the flush re-checks existence, so a delete-then-recreate (atomic save)
+        // within the debounce window collapses back into a normal reload. Non-element deletes are
+        // left unhandled, as before.
+        if (IsElementFileExtension(fileName))
+        {
+            HandleFileSystemChange(fileName);
+        }
+    }
+
+    private static bool IsElementFileExtension(FilePath file)
+    {
+        var extension = file.Extension;
+        return extension == GumProjectSave.ScreenExtension
+            || extension == GumProjectSave.ComponentExtension
+            || extension == GumProjectSave.StandardExtension;
     }
 
     private void HandleFileSystemChange(object? sender, FileSystemEventArgs e)
@@ -311,6 +329,7 @@ public class FileWatchManager : IFileWatchManager
         {
             var candidateFiles = _changedFilesWaitingForFlush.Keys.ToList();
             var filesToProcess = new List<FilePath>();
+            var deletedElementFiles = new List<FilePath>();
             foreach (var file in candidateFiles)
             {
                 var readiness = GetFileReadiness(file);
@@ -321,11 +340,15 @@ public class FileWatchManager : IFileWatchManager
                 }
                 else if (readiness == FileReadiness.Drop)
                 {
-                    // File no longer exists (e.g. atomic-save temp that was
-                    // renamed away) or is otherwise unprocessable. Drop it
-                    // silently — this is the normal path during agent edits
-                    // and doesn't warrant user-visible noise.
                     _changedFilesWaitingForFlush.TryRemove(file, out _);
+
+                    // Drop usually means an atomic-save temp that was renamed away. But an element
+                    // file that's still gone at flush time is a real deletion the user should see
+                    // (issue #3367) — route it to the delete reaction instead of dropping silently.
+                    if (IsElementFileExtension(file) && !IsTransientTempFile(file))
+                    {
+                        deletedElementFiles.Add(file);
+                    }
                 }
                 // else Locked: leave in queue and retry next cycle (e.g. git is writing it).
             }
@@ -354,6 +377,25 @@ public class FileWatchManager : IFileWatchManager
                     if (PrintFileChangesToOutput)
                     {
                         _guiCommands.PrintOutput($"Error reacting to file change for {file}: {ex.Message}");
+                    }
+                }
+            }
+
+            foreach (var file in deletedElementFiles)
+            {
+                try
+                {
+                    _fileChangeReactionLogic.ReactToFileDeleted(file);
+                    if (PrintFileChangesToOutput)
+                    {
+                        _guiCommands.PrintOutput($"Element file deletion processed: {file}");
+                    }
+                }
+                catch (Exception ex)
+                {
+                    if (PrintFileChangesToOutput)
+                    {
+                        _guiCommands.PrintOutput($"Error reacting to file deletion for {file}: {ex.Message}");
                     }
                 }
             }

--- a/Tool/Tests/GumToolUnitTests/Managers/FileChangeReactionLogicTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Managers/FileChangeReactionLogicTests.cs
@@ -1,3 +1,4 @@
+using Gum.DataTypes;
 using Gum.Managers;
 using Shouldly;
 using System.Collections.Generic;
@@ -9,6 +10,55 @@ namespace GumToolUnitTests.Managers;
 
 public class FileChangeReactionLogicTests
 {
+    [Fact]
+    public void FlagElementForDeletedFile_ShouldSetIsSourceFileMissing_WhenDeletedFileMapsToLoadedElement()
+    {
+        // Repro #3367: an element's source file is deleted on disk while the tool is running.
+        // The element must be flagged (red "!" / GUM0004) but NOT reloaded/removed — the in-memory
+        // copy stays authoritative.
+        GumProjectSave project = new GumProjectSave();
+        ComponentSave component = new ComponentSave { Name = "MyButton" };
+        project.Components.Add(component);
+        ObjectFinder.Self.GumProjectSave = project;
+        try
+        {
+            FilePath projectDirectory = new FilePath(@"C:\proj\");
+            FilePath deletedFile = new FilePath(@"C:\proj\Components\MyButton.gucx");
+
+            ElementSave? flagged = FileChangeReactionLogic.FlagElementForDeletedFile(deletedFile, projectDirectory);
+
+            flagged.ShouldBe(component);
+            component.IsSourceFileMissing.ShouldBeTrue();
+        }
+        finally
+        {
+            ObjectFinder.Self.GumProjectSave = null;
+        }
+    }
+
+    [Fact]
+    public void FlagElementForDeletedFile_ShouldReturnNull_WhenDeletedFileMapsToNoLoadedElement()
+    {
+        GumProjectSave project = new GumProjectSave();
+        ComponentSave component = new ComponentSave { Name = "MyButton" };
+        project.Components.Add(component);
+        ObjectFinder.Self.GumProjectSave = project;
+        try
+        {
+            FilePath projectDirectory = new FilePath(@"C:\proj\");
+            FilePath deletedFile = new FilePath(@"C:\proj\Components\Unrelated.gucx");
+
+            ElementSave? flagged = FileChangeReactionLogic.FlagElementForDeletedFile(deletedFile, projectDirectory);
+
+            flagged.ShouldBeNull();
+            component.IsSourceFileMissing.ShouldBeFalse();
+        }
+        finally
+        {
+            ObjectFinder.Self.GumProjectSave = null;
+        }
+    }
+
     [Fact]
     public void IsLocalizationFile_ReturnsFalse_WhenChangedFileIsUnrelated()
     {

--- a/Tool/Tests/GumToolUnitTests/Managers/FileChangeReactionLogicTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Managers/FileChangeReactionLogicTests.cs
@@ -1,7 +1,13 @@
+using Gum.Commands;
 using Gum.DataTypes;
 using Gum.Managers;
+using Gum.Plugins;
+using Moq;
+using Moq.AutoMock;
 using Shouldly;
+using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using ToolsUtilities;
 using Xunit;
@@ -10,6 +16,39 @@ namespace GumToolUnitTests.Managers;
 
 public class FileChangeReactionLogicTests
 {
+    [Fact]
+    public void ReactToFileDeleted_ShouldFlagElementAndRefresh_WhenElementFileWasDeleted()
+    {
+        // Covers the delete WIRING end-to-end at the reaction layer (issue #3367): a deleted
+        // element file must flag the loaded element IsSourceFileMissing and refresh the tree + errors
+        // so the red "!" appears. The leaf FlagElementForDeletedFile is tested separately; this pins
+        // that ReactToFileDeleted actually calls it and fires the UI refresh.
+        string tempDir = Path.Combine(Path.GetTempPath(), "GumDeleteWiringTest_" + Guid.NewGuid().ToString("N"));
+        FilePath projectDirectory = new FilePath(tempDir);
+        FilePath deletedFile = new FilePath(Path.Combine(tempDir, "Components", "MyButton.gucx")); // never created -> "deleted"
+
+        AutoMocker mocker = new AutoMocker();
+        mocker.GetMock<IFileCommands>().Setup(f => f.ProjectDirectory).Returns(projectDirectory);
+        FileChangeReactionLogic sut = mocker.CreateInstance<FileChangeReactionLogic>();
+
+        GumProjectSave project = new GumProjectSave();
+        ComponentSave component = new ComponentSave { Name = "MyButton" };
+        project.Components.Add(component);
+        ObjectFinder.Self.GumProjectSave = project;
+        try
+        {
+            sut.ReactToFileDeleted(deletedFile);
+
+            component.IsSourceFileMissing.ShouldBeTrue();
+            mocker.GetMock<IGuiCommands>().Verify(g => g.RefreshElementTreeView(), Times.Once);
+            mocker.GetMock<IPluginManager>().Verify(p => p.ElementReloaded(component), Times.Once);
+        }
+        finally
+        {
+            ObjectFinder.Self.GumProjectSave = null;
+        }
+    }
+
     [Fact]
     public void FlagElementForDeletedFile_ShouldSetIsSourceFileMissing_WhenDeletedFileMapsToLoadedElement()
     {
@@ -52,6 +91,55 @@ public class FileChangeReactionLogicTests
 
             flagged.ShouldBeNull();
             component.IsSourceFileMissing.ShouldBeFalse();
+        }
+        finally
+        {
+            ObjectFinder.Self.GumProjectSave = null;
+        }
+    }
+
+    [Fact]
+    public void IsReappearanceOfMissingSourceElement_ShouldReturnTrue_WhenFileMapsToFlaggedElement()
+    {
+        // #3367 clear-on-restore: a previously-deleted element file is restored on disk (a Created
+        // event). The watcher uses this to process that lone Created so the element reloads and the
+        // red "!" / GUM0004 clears.
+        GumProjectSave project = new GumProjectSave();
+        ComponentSave component = new ComponentSave { Name = "MyButton", IsSourceFileMissing = true };
+        project.Components.Add(component);
+        ObjectFinder.Self.GumProjectSave = project;
+        try
+        {
+            FilePath projectDirectory = new FilePath(@"C:\proj\");
+            FilePath restoredFile = new FilePath(@"C:\proj\Components\MyButton.gucx");
+
+            bool result = FileChangeReactionLogic.IsReappearanceOfMissingSourceElement(restoredFile, projectDirectory);
+
+            result.ShouldBeTrue();
+        }
+        finally
+        {
+            ObjectFinder.Self.GumProjectSave = null;
+        }
+    }
+
+    [Fact]
+    public void IsReappearanceOfMissingSourceElement_ShouldReturnFalse_WhenElementIsNotFlagged()
+    {
+        // A normal Created event (e.g. a save) for an element that isn't flagged missing must stay
+        // on the suppressed path - otherwise normal saves would double-reload.
+        GumProjectSave project = new GumProjectSave();
+        ComponentSave component = new ComponentSave { Name = "MyButton", IsSourceFileMissing = false };
+        project.Components.Add(component);
+        ObjectFinder.Self.GumProjectSave = project;
+        try
+        {
+            FilePath projectDirectory = new FilePath(@"C:\proj\");
+            FilePath createdFile = new FilePath(@"C:\proj\Components\MyButton.gucx");
+
+            bool result = FileChangeReactionLogic.IsReappearanceOfMissingSourceElement(createdFile, projectDirectory);
+
+            result.ShouldBeFalse();
         }
         finally
         {


### PR DESCRIPTION
## Summary

Closes #3367.

Deleting an element's source file (`.gusx`/`.gucx`/`.gutx`) on disk **while the tool is running** went undetected:
- `IsSourceFileMissing` is computed only at load (`ElementReference.ToElementSave`), and
- `FileWatchManager.HandleFileSystemDelete` was an explicit no-op (`// do anything?`).

So the in-memory model diverged silently from disk — no red `!`, empty Errors tab — until the next save quietly rewrote the file.

## Change

- **`FileWatchManager.HandleFileSystemDelete`** now enqueues element-file deletes through the normal change pipeline (non-element deletes stay unhandled, as before).
- **`Flush`** already drops missing files via `GetFileReadiness` (that's how atomic-save temp files get cleaned up). The `Drop` branch now routes element files that are *still gone at flush time* to a new **`FileChangeReactionLogic.ReactToFileDeleted`** instead of dropping them silently.
- **`ReactToFileDeleted`** flags the matching loaded element `IsSourceFileMissing` — **without reloading or removing it**, preserving the authoritative in-memory copy and any unsaved edits — then refreshes the tree `!` and the Errors tab (**GUM0004**, from #3366).

### Why this is robust to the noisy delete events that made deletes "deliberately ignored"

- The flush re-checks existence, so a **delete-then-recreate (atomic save)** within the debounce window collapses back into a normal reload — never a spurious `!`.
- `.tmp` / transient temp files are excluded.
- A genuine **reappearance via a `Changed` event clears the flag** through the existing reload path. (Edge: a pure `Created`-only restore — which the watcher ignores for Gum XML to avoid double-reloads — won't clear it until the next change. Left as a small follow-up; out of scope for "detect the delete.")

### Deliberately non-destructive

The element is flagged, never auto-removed or auto-reloaded. A stray `git checkout` that deletes a file must not nuke unsaved in-memory work; the user resolves it by restoring the file or saving the element (which re-creates it). Pairs with #3370, which already stops a project save from silently recreating a missing-source file.

## Tests

The decision+flag core is extracted into the static **`FlagElementForDeletedFile`** (file path → element → set flag) and unit-tested via `ObjectFinder`, mirroring the existing static helpers in `FileChangeReactionLogicTests`. Red-first verified by inversion (dropping the flag-set turns the positive test red). Full `GumToolUnitTests` (985) green; the `ReactToElementSaveChanged` refactor that extracts the shared path→element mapping is behavior-preserving.

The `FileSystemWatcher` enqueue/flush wiring and the UI refresh are thin plumbing, verified manually (see PR checklist).

## Related

- #3366 (#3309) — surfaces missing-source as GUM0004; this makes the flag get *set* at runtime so that surfacing fires.
- #3370 (#3369) — stops project save from recreating missing-source files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
