### PR TITLE
Don't crash recreating a missing Skia standard; inform instead (#3373)

### DIFF
--- a/.claude/skills/gum-tool-dialogs/SKILL.md
+++ b/.claude/skills/gum-tool-dialogs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gum-tool-dialogs
-description: Gum dialog/popup systems. Triggers: DialogService, DialogWindow, DeleteOptionsWindow, dialog scrolling/layout, adding new dialog types.
+description: Gum dialog/popup systems. Triggers: DialogService, DialogWindow, DeleteOptionsWindow, dialog scrolling/layout, adding new dialog types, ShowMessage/ShowYesNoMessage, mocking IDialogService in unit tests.
 ---
 
 # Gum Dialog Systems Reference
@@ -57,3 +57,9 @@ Used by: delete confirmation only (`DeleteLogic.ShowDeleteDialog`).
 **ScrollViewer behavior**: The `Dialog` template wraps content in a ScrollViewer. With `Auto` scrolling, child controls get infinite available height during WPF measure — so internal scroll viewers (like a TreeView) won't scroll. Set `Dialog.ScrollContent="False"` on views that need bounded height for internal scrolling.
 
 **Deferred binding**: `Dialog.OnContentChanged` binds attached properties at `DispatcherPriority.Loaded`, not immediately. Code that reads these values before the dispatch fires will see defaults.
+
+## Testing Dialog Interactions (mocking IDialogService)
+
+`IDialogService` exposes one message primitive: `ShowMessage(message, title?, MessageDialogStyle?)`, returning a `MessageDialogResult` enum (`Affirmative` / `Negative` / `Canceled`; `Negative == 0` is the unmocked Moq default → a `Mock<IDialogService>` returns "No" unless you set it up). The friendly helpers — `ShowYesNoMessage`, `ShowChoices`, etc. — are **extension methods** in `IDialogServiceExt`, so a Moq mock can only `Setup`/`Verify` the underlying `ShowMessage`. A Yes/No prompt arrives as `ShowMessage(msg, title, MessageDialogStyle.YesNo)`.
+
+Gotcha: `MessageDialogStyle` is a **class**, and `.Ok` / `.YesNo` / `.OkCancel` each `new` up a fresh instance with no equality override — you cannot match a specific style by reference or equality. Distinguish a styled prompt (Yes/No, OK/Cancel) from a plain informational popup by **`style != null` vs `style == null`** — a bare `ShowMessage(msg)` passes `null` — or by inspecting `AffirmativeText`.

--- a/Gum/Managers/ProjectManager.cs
+++ b/Gum/Managers/ProjectManager.cs
@@ -665,7 +665,7 @@ public class ProjectManager : IProjectManager, IDeleteProjectProvider
         return didChange;
     }
 
-    private void RecreateMissingStandardElements()
+    internal void RecreateMissingStandardElements()
     {
         List<StandardElementSave> missingElements = new List<StandardElementSave>();
         foreach (var element in _gumProjectSave.StandardElements)
@@ -677,8 +677,21 @@ public class ProjectManager : IProjectManager, IDeleteProjectProvider
             }
         }
 
+        List<string> unrecreatableStandardNames = new List<string>();
+
         foreach (var element in missingElements)
         {
+            // Plugin-contributed standards (the Skia shapes Arc/Canvas/Line/Svg/LottieAnimation and the
+            // legacy ColoredCircle/RoundedRectangle) are not in StandardElementsManager's built-in
+            // defaults, so the tool can't rebuild them from mDefaults -- clicking "Yes" used to crash
+            // with a KeyNotFoundException (#3373). Collect them and inform the user instead of offering
+            // a Yes/No we can't honor.
+            if (!StandardElementsManager.Self.IsDefaultType(element.Name))
+            {
+                unrecreatableStandardNames.Add(element.Name);
+                continue;
+            }
+
             var result = _dialogService.ShowYesNoMessage(
                 "The following standard is missing: " + element.Name + "  Recreate it?", "Recreate " + element.Name + "?");
 
@@ -687,12 +700,22 @@ public class ProjectManager : IProjectManager, IDeleteProjectProvider
                 _gumProjectSave.StandardElements.RemoveAll(item => item.Name == element.Name);
                 _gumProjectSave.StandardElementReferences.RemoveAll(item => item.Name == element.Name);
 
-                var newElement = StandardElementsManager.Self.AddStandardElementSaveInstance(_gumProjectSave, element.Name);
+                StandardElementsManager.Self.AddStandardElementSaveInstance(_gumProjectSave, element.Name);
 
                 string gumProjectDirectory = FileManager.GetDirectory(_gumProjectSave.FullFileName);
 
                 _gumProjectSave.SaveStandardElements(gumProjectDirectory);
             }
+        }
+
+        if (unrecreatableStandardNames.Count > 0)
+        {
+            string names = string.Join(", ", unrecreatableStandardNames);
+            _dialogService.ShowMessage(
+                $"The following standard element(s) are missing and can't be recreated automatically " +
+                $"because they are provided by a plugin: {names}.\n\n" +
+                $"Restore the matching Standards/<name>.gutx file from version control, or re-add the " +
+                $"plugin that provides it (for the Skia shapes: Plugins → Add Skia).");
         }
     }
 

--- a/Gum/Managers/StandardElementsManager.cs
+++ b/Gum/Managers/StandardElementsManager.cs
@@ -953,8 +953,20 @@ public class StandardElementsManager
 
     public StandardElementSave AddStandardElementSaveInstance(GumProjectSave gumProjectSave, string type)
     {
+        if (!mDefaults.TryGetValue(type, out StateSave defaultState))
+        {
+            // Plugin-contributed standards (the Skia shapes Arc/Canvas/Line/Svg/LottieAnimation and
+            // the legacy ColoredCircle/RoundedRectangle) are never placed in mDefaults, so they can't
+            // be rebuilt here. Throw a clear, typed error instead of letting the indexer surface a
+            // cryptic KeyNotFoundException -- callers must filter to built-in types first (#3373).
+            throw new ArgumentException(
+                $"'{type}' is not a built-in standard element type, so it can't be created from the " +
+                $"default states. Plugin-contributed standards must be added by their owning plugin.",
+                nameof(type));
+        }
+
         StandardElementSave elementSave = new StandardElementSave();
-        elementSave.Initialize(mDefaults[type]);
+        elementSave.Initialize(defaultState);
         elementSave.Name = type;
 
         

--- a/MonoGameGum.Tests/Managers/StandardElementsManagerTests.cs
+++ b/MonoGameGum.Tests/Managers/StandardElementsManagerTests.cs
@@ -26,6 +26,20 @@ public class StandardElementsManagerTests
     }
 
     [Fact]
+    public void AddStandardElementSaveInstance_ShouldThrowArgumentException_ForPluginStandard()
+    {
+        // The Skia shapes (Arc, Canvas, Line, Svg, LottieAnimation) are added by a plugin and are
+        // never placed in the built-in defaults, so recreating one through this method must surface a
+        // clear, typed error instead of a cryptic KeyNotFoundException from the mDefaults indexer (#3373).
+        StandardElementsManager self = StandardElementsManager.Self;
+        self.RefreshDefaults();
+
+        GumProjectSave project = new GumProjectSave();
+
+        Should.Throw<ArgumentException>(() => self.AddStandardElementSaveInstance(project, "Arc"));
+    }
+
+    [Fact]
     public void CircleDefault_ShouldExposeWidthAndHeight_NotRadius()
     {
         StandardElementsManager self = StandardElementsManager.Self;

--- a/Tool/Tests/GumToolUnitTests/Managers/ProjectManagerTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Managers/ProjectManagerTests.cs
@@ -152,6 +152,68 @@ public class ProjectManagerTests : BaseTestClass
         _fileCommands.Verify(f => f.LoadProject(It.IsAny<string>()), Times.Never);
     }
 
+    [Fact]
+    public void RecreateMissingStandardElements_DoesNotCrash_AndInforms_ForMissingPluginStandard()
+    {
+        // Repro of #3373: clicking "Yes" to recreate a missing Skia standard (Arc) crashed with
+        // KeyNotFoundException because Arc is not in StandardElementsManager's built-in defaults. The
+        // tool must not offer a Yes/No it cannot honor; it leaves the element flagged and shows a
+        // single informational message instead.
+        GumProjectSave project = new GumProjectSave();
+        project.StandardElements.Add(new StandardElementSave { Name = "Arc", IsSourceFileMissing = true });
+        SetCurrentProject(project);
+
+        // Simulate the user clicking "Yes" on any recreate prompt -- the pre-fix crash path.
+        _dialogService
+            .Setup(d => d.ShowMessage(It.IsAny<string>(), It.IsAny<string?>(), It.Is<MessageDialogStyle?>(s => s != null)))
+            .Returns(MessageDialogResult.Affirmative);
+
+        Should.NotThrow(() => _projectManager.RecreateMissingStandardElements());
+
+        // No Yes/No prompt (the only call with a non-null style) is offered for a plugin standard.
+        _dialogService.Verify(
+            d => d.ShowMessage(It.IsAny<string>(), It.IsAny<string?>(), It.Is<MessageDialogStyle?>(s => s != null)),
+            Times.Never);
+        // A single informational message (null style) names the missing standard.
+        _dialogService.Verify(
+            d => d.ShowMessage(
+                It.Is<string>(m => m.Contains("Arc")),
+                It.IsAny<string?>(),
+                It.Is<MessageDialogStyle?>(s => s == null)),
+            Times.Once);
+        // The element is left in place (still flagged missing) rather than removed.
+        project.StandardElements.ShouldContain(e => e.Name == "Arc");
+    }
+
+    [Fact]
+    public void RecreateMissingStandardElements_PromptsToRecreate_ForMissingBuiltInStandard()
+    {
+        // A built-in standard (Sprite) lives in StandardElementsManager's defaults, so the tool can
+        // rebuild it and still offers the Yes/No prompt. Declining leaves the project untouched and
+        // shows no plugin-standard informational message.
+        GumProjectSave project = new GumProjectSave();
+        project.StandardElements.Add(new StandardElementSave { Name = "Sprite", IsSourceFileMissing = true });
+        SetCurrentProject(project);
+
+        _dialogService
+            .Setup(d => d.ShowMessage(It.IsAny<string>(), It.IsAny<string?>(), It.Is<MessageDialogStyle?>(s => s != null)))
+            .Returns(MessageDialogResult.Negative);
+
+        _projectManager.RecreateMissingStandardElements();
+
+        // The Yes/No recreate prompt (non-null style) is offered for a built-in standard...
+        _dialogService.Verify(
+            d => d.ShowMessage(
+                It.Is<string>(m => m.Contains("Sprite")),
+                It.IsAny<string?>(),
+                It.Is<MessageDialogStyle?>(s => s != null)),
+            Times.Once);
+        // ...and no informational (null style) message is shown for it.
+        _dialogService.Verify(
+            d => d.ShowMessage(It.IsAny<string>(), It.IsAny<string?>(), It.Is<MessageDialogStyle?>(s => s == null)),
+            Times.Never);
+    }
+
     // IDialogService.Show has an out parameter, which Moq can only populate through a
     // callback delegate whose signature mirrors the method; this delegate provides that shape.
     private delegate void ShowChoiceDialogCallback(


### PR DESCRIPTION
## Summary

Clicking **Yes** on the "The following standard is missing: X — Recreate it?" prompt crashed the tool with `KeyNotFoundException` when `X` was a Skia/plugin standard (Arc, Canvas, Line, LottieAnimation, Svg, and the legacy ColoredCircle/RoundedRectangle). Because the prompt fires during `LoadProject`, the project failed to open at all.

**Root cause:** `RecreateMissingStandardElements` offered to recreate *any* missing standard, routing through `StandardElementsManager.AddStandardElementSaveInstance`, whose `mDefaults[type]` indexer only knows the built-in/core standards. Skia standards are added by a separate plugin path (`SkiaShapeStandardsLogic`), never placed in `mDefaults`, so the lookup threw.

## Fix

- **`ProjectManager.RecreateMissingStandardElements`** now gates recreation on `StandardElementsManager.IsDefaultType`:
  - Built-in standards keep the existing Yes/No recreate prompt.
  - Plugin standards the tool can't rebuild are collected and surfaced in **one** informational message ("…can't be recreated automatically because they are provided by a plugin… restore the matching `Standards/<name>.gutx` from version control, or re-add the plugin"). No more Yes/No it can't honor.
- **`StandardElementsManager.AddStandardElementSaveInstance`** is hardened to throw a clear `ArgumentException` (naming the type) instead of a cryptic `KeyNotFoundException` if ever reached with an unknown type — the indexer is no longer reachable with an unknown key from a user action.

This implements the issue's "at minimum, don't crash" option. Plugin-aware *regeneration* (re-running `SkiaShapeStandardsLogic`'s embedded-resource write) remains a possible future enhancement; the safe non-crash + honest message was chosen to avoid coupling load-time repair to the Skia plugin and to avoid synthesizing a possibly-wrong element.

## Tests (TDD, red-first confirmed)

- `StandardElementsManagerTests.AddStandardElementSaveInstance_ShouldThrowArgumentException_ForPluginStandard` — pins the hardened guard (was red with `KeyNotFoundException`).
- `ProjectManagerTests.RecreateMissingStandardElements_DoesNotCrash_AndInforms_ForMissingPluginStandard` — reproduces the exact crash (red with `KeyNotFoundException 'Arc'`), then asserts no Yes/No prompt, a single informational message, and the element left in place.
- `ProjectManagerTests.RecreateMissingStandardElements_PromptsToRecreate_ForMissingBuiltInStandard` — guards the unchanged built-in branch (still prompts).

All green after the fix; full `StandardElementsManagerTests` (14) and `ProjectManagerTests` (8) pass. `GumFull.sln` builds with 0 errors.

## Guidance file (bundled per repo policy)

`gum-tool-dialogs` skill gains a **Testing Dialog Interactions** note: `IDialogService` exposes one `ShowMessage` primitive (the `ShowYesNoMessage`/`ShowChoices` helpers are `IDialogServiceExt` extensions, so Moq can only intercept `ShowMessage`), and `MessageDialogStyle` is a *class* with per-call `new` instances — so a styled prompt vs a plain popup is distinguished by `style != null`/`== null`, not equality. This is the non-obvious gotcha that slowed down writing these tests.

Closes #3373
