### PR TITLE
Fix shape runtime docs: correct FillColor/IsFilled model and mirror Circle/Rectangle pages

### DIFF
--- a/docs/code/standard-visuals/circleruntime.md
+++ b/docs/code/standard-visuals/circleruntime.md
@@ -4,9 +4,15 @@
 
 `CircleRuntime` draws a circle with a **fill** and an **outline (stroke)**. The circle is sized to fit within its `Width` × `Height` bounds. The fill is set by `FillColor`; the outline is set by `StrokeColor` and `StrokeWidth`. On top of fill and outline, a `CircleRuntime` can also render a gradient, a drop shadow, and a dashed outline.
 
-A freshly-constructed `CircleRuntime` renders as a **stroke-only outline** — `FillColor` defaults to transparent, `StrokeColor` defaults to white, and `StrokeWidth` defaults to `1`. Assign a visible `FillColor` to light up the fill, or set `StrokeWidth` to `0` to hide the outline.
+A freshly-constructed `CircleRuntime` is 32 × 32 and renders as a **stroke-only outline** — `IsFilled` defaults to `false`, so the fill is gated off even though `FillColor` defaults to opaque white. `StrokeColor` defaults to white and `StrokeWidth` defaults to `1`. Set `IsFilled = true` to show the fill (assigning `FillColor` alone does not show it), or set `StrokeWidth` to `0` to hide the outline.
+
+`IsFilled` defaults to `false` because `CircleRuntime` is historically outline-only. It pairs with an opaque white `FillColor`, so setting `IsFilled = true` alone yields a visible white fill — see [Shapes](shapes-apos.shapes.md#fill) for the full rationale.
 
 For the full property surface — fill, outline, gradient, drop shadow, dashed stroke, and the platform/package requirements — see the [Shapes](shapes-apos.shapes.md#circleruntime-and-rectangleruntime) page. The examples below cover the common cases.
+
+{% hint style="info" %}
+A `CircleRuntime` also exposes a `Radius` property, but sizing through `Width` / `Height` is recommended — it keeps the circle consistent with every other visual and participates in the layout system. Setting `Radius` simply sets `Width` and `Height` to `Radius × 2`.
+{% endhint %}
 
 {% hint style="info" %}
 On MonoGame, KNI, and FNA the outline and geometry render out of the box, but the **fill** and the richer effects (gradient, drop shadow, dashed stroke, anti-aliasing) only draw once the `Gum.Shapes.<platform>` package is added — otherwise they are stored and round-trip but silently do not draw. Skia, .NET MAUI, and raylib support the full surface natively. See the [Shapes](shapes-apos.shapes.md) page for setup.
@@ -27,14 +33,15 @@ container.Children.Add(circle);
 
 <figure><img src="../../.gitbook/assets/07_06 14 58.png" alt=""><figcaption><p>Green outlined circle</p></figcaption></figure>
 
-To fill the circle, assign a visible `FillColor`. On MonoGame, KNI, and FNA the fill requires the shape support package (see the [Shapes](shapes-apos.shapes.md) page):
+To fill the circle, set `IsFilled = true` and assign a `FillColor`. On MonoGame, KNI, and FNA the fill requires the shape support package (see the [Shapes](shapes-apos.shapes.md) page):
 
 ```csharp
 // Initialize
 var circle = new CircleRuntime();
 circle.Width = 128;
 circle.Height = 128;
-circle.FillColor = Color.Green; // light up the fill
+circle.IsFilled = true;
+circle.FillColor = Color.Green; // show the fill
 container.Children.Add(circle);
 ```
 

--- a/docs/code/standard-visuals/rectangleruntime.md
+++ b/docs/code/standard-visuals/rectangleruntime.md
@@ -4,7 +4,9 @@
 
 `RectangleRuntime` draws a rectangle with a **fill** and an **outline (stroke)**, plus an optional uniform `CornerRadius` for rounded corners. Its size is controlled by `Width` and `Height`. The fill is set by `FillColor`; the outline is set by `StrokeColor` and `StrokeWidth`. On top of fill and outline, a `RectangleRuntime` can also render a gradient, a drop shadow, and a dashed outline.
 
-A freshly-constructed `RectangleRuntime` renders as a **stroke-only outline** — `FillColor` defaults to transparent, `StrokeColor` defaults to white, and `StrokeWidth` defaults to `1`. Assign a visible `FillColor` to light up the fill, or set `StrokeWidth` to `0` to hide the outline.
+A freshly-constructed `RectangleRuntime` is 50 × 50 and renders as a **stroke-only outline** — `IsFilled` defaults to `false`, so the fill is gated off even though `FillColor` defaults to opaque white. `StrokeColor` defaults to white and `StrokeWidth` defaults to `1`. Set `IsFilled = true` to show the fill (assigning `FillColor` alone does not show it), or set `StrokeWidth` to `0` to hide the outline.
+
+`IsFilled` defaults to `false` because `RectangleRuntime` is historically outline-only. It pairs with an opaque white `FillColor`, so setting `IsFilled = true` alone yields a visible white fill — see [Shapes](shapes-apos.shapes.md#fill) for the full rationale.
 
 For the full property surface — fill, outline, corner radius, gradient, drop shadow, dashed stroke, and the platform/package requirements — see the [Shapes](shapes-apos.shapes.md#circleruntime-and-rectangleruntime) page. The examples below cover the common cases.
 
@@ -27,7 +29,7 @@ container.Children.Add(rectangle);
 
 <figure><img src="../../.gitbook/assets/WideRectOverBlue.png" alt=""><figcaption><p>Pink outlined rectangle</p></figcaption></figure>
 
-To fill the rectangle and round its corners, assign a visible `FillColor` and a `CornerRadius`. On MonoGame, KNI, and FNA the fill requires the shape support package (see the [Shapes](shapes-apos.shapes.md) page):
+To fill the rectangle and round its corners, set `IsFilled = true`, assign a `FillColor`, and set a `CornerRadius`. On MonoGame, KNI, and FNA the fill requires the shape support package (see the [Shapes](shapes-apos.shapes.md) page):
 
 ```csharp
 // Initialize
@@ -35,7 +37,8 @@ var rectangle = new RectangleRuntime();
 rectangle.Width = 120;
 rectangle.Height = 24;
 rectangle.CornerRadius = 8;
-rectangle.FillColor = Color.Pink; // light up the fill
+rectangle.IsFilled = true;
+rectangle.FillColor = Color.Pink; // show the fill
 container.Children.Add(rectangle);
 ```
 

--- a/docs/code/standard-visuals/shapes-apos.shapes.md
+++ b/docs/code/standard-visuals/shapes-apos.shapes.md
@@ -137,13 +137,15 @@ public class Game1 : Game
         circle.AddToRoot();
         circle.Width = 100;
         circle.Height = 100;
+        circle.IsFilled = true;
         circle.FillColor = Color.Red;
 
         var rectangle = new RectangleRuntime();
         rectangle.AddToRoot();
         rectangle.X = 100;
         rectangle.CornerRadius = 15;
-        rectangle.FillColor = Color.Blue; // the fill color is the gradient start, so light it up
+        rectangle.IsFilled = true; // FillColor is the gradient start, so show the fill
+        rectangle.FillColor = Color.Blue;
         rectangle.UseGradient = true;
         rectangle.Color2 = Color.Green;
 
@@ -179,7 +181,7 @@ public class Game1 : Game
 
 `CircleRuntime` and `RectangleRuntime` are the current shape runtimes. Each has a **fill** and an **outline (stroke)**, plus optional gradient, drop shadow, dashed-outline, and anti-aliasing effects. `RectangleRuntime` adds rounded-corner support.
 
-A freshly-constructed shape renders as a **stroke-only outline**: `FillColor` defaults to transparent, `StrokeColor` defaults to white, and `StrokeWidth` defaults to `1`. Assign a visible `FillColor` to light up the fill, or set `StrokeWidth` to `0` to hide the outline. A `CircleRuntime` is 32 × 32 by default; a `RectangleRuntime` is 50 × 50.
+A freshly-constructed shape renders as a **stroke-only outline**: `IsFilled` defaults to `false`, so the fill is gated off even though `FillColor` defaults to opaque white. `StrokeColor` defaults to white and `StrokeWidth` defaults to `1`. Set `IsFilled = true` to show the fill (assigning `FillColor` alone does not show it), or set `StrokeWidth` to `0` to hide the outline. A `CircleRuntime` is 32 × 32 by default; a `RectangleRuntime` is 50 × 50.
 
 {% hint style="info" %}
 On MonoGame, KNI, and FNA the outline and geometry render without the shapes package, but the fill and effects (gradient, drop shadow, dashed stroke, anti-aliasing, `Blend`) only draw once the `Gum.Shapes.<platform>` package is added — otherwise the values round-trip but silently do not draw. Skia and .NET MAUI support the full surface natively; raylib supports a near-full subset (see [Shape Support Across Platforms](../../gum-tool/gum-elements/skia-standard-elements/shapes-platform-support.md)).
@@ -204,9 +206,13 @@ A `CircleRuntime` also exposes a `Radius` property, but sizing through `Width` /
 
 | Property | Type | Description |
 | --- | --- | --- |
-| `FillColor` | `Color` | The fill color. Defaults to transparent, so a freshly-constructed shape renders as an outline only — assign a visible color to light up the fill. |
+| `FillColor` | `Color` | The fill color. Defaults to opaque white, but the fill is gated off because `IsFilled` defaults to `false` — so a freshly-constructed shape renders as an outline only. Set `IsFilled = true` to render the fill. |
 | `FillRed`, `FillGreen`, `FillBlue`, `FillAlpha` | `int` | Individual fill channels (0–255). |
-| `IsFilled` | `bool` | Gates the fill. `true` by default; setting it to `false` renders an outline-only shape without discarding `FillColor`. |
+| `IsFilled` | `bool` | The canonical fill gate. Defaults to `false`, so a freshly-constructed shape is outline-only; set it to `true` to render the fill. Assigning `FillColor` alone does not show the fill. |
+
+{% hint style="info" %}
+**Why `IsFilled` defaults to `false`:** `CircleRuntime` and `RectangleRuntime` are historically outline-only, so a freshly-constructed shape stays a stroke-only outline for visual back-compat. The default pairs `IsFilled = false` with an **opaque white** `FillColor` — so flipping `IsFilled = true` alone yields a visible white fill with no need to also assign a color. (The earlier pairing of `IsFilled = true` with a *transparent* `FillColor` was a footgun: setting `IsFilled = true` left the shape invisible until you also assigned a `FillColor`.)
+{% endhint %}
 
 ### Outline (stroke)
 
@@ -277,6 +283,7 @@ A filled circle with a soft drop shadow:
 var circle = new CircleRuntime();
 circle.Width = 100;
 circle.Height = 100;
+circle.IsFilled = true;
 circle.FillColor = Color.Red;
 circle.HasDropshadow = true;
 circle.DropshadowColor = Color.Black;
@@ -294,7 +301,8 @@ var rectangle = new RectangleRuntime();
 rectangle.Width = 200;
 rectangle.Height = 80;
 rectangle.CornerRadius = 12;
-rectangle.FillColor = Color.Blue; // the fill color is the gradient start, so light it up
+rectangle.IsFilled = true; // FillColor is the gradient start, so show the fill
+rectangle.FillColor = Color.Blue;
 rectangle.UseGradient = true;
 rectangle.Color2 = Color.Green;
 container.Children.Add(rectangle);


### PR DESCRIPTION
## What

Corrects the `RectangleRuntime` / `CircleRuntime` documentation, which still described the **dropped transitional model** ("`FillColor` defaults to transparent — assign a visible `FillColor` to light up the fill"). Since #2938 / #3005, `FillColor` is non-nullable and defaults to **opaque white**, and **`IsFilled` (default `false`) is the canonical fill gate** — assigning `FillColor` alone does *not* show the fill. A user hit exactly this: a `RectangleRuntime` with `FillColor = Red` rendered as a stroke-only outline because `IsFilled` was never set.

## Changes (docs-only — no `.cs` touched)

- **`rectangleruntime.md` / `circleruntime.md`**
  - Corrected the intro fill/stroke story; each page now states its default size (Rectangle 50×50, Circle 32×32) and that `FillColor` defaults to opaque white but is gated off by `IsFilled = false`.
  - Added `IsFilled = true` to the fill code examples; replaced "light up the fill" wording with "show the fill".
  - Added a mirrored one-line "why `IsFilled` defaults to false" note linking to the full rationale.
  - Mirrored the two pages: added the Circle-only `Radius`-proxy note to match the Rectangle-only `CornerRadius` note.
- **`shapes-apos.shapes.md`**
  - Corrected the section intro and the **Fill table** — the `IsFilled` row previously claimed "**`true` by default**" (it defaults to `false`); the `FillColor` row now reads opaque-white-gated-by-`IsFilled`.
  - Added `IsFilled = true` to the in-page Game1 sample (circle, gradient rectangle) and the dropshadow/gradient examples so they actually render filled. (This also re-aligns the examples with the existing screenshot, which already shows filled shapes.)
  - Added a **"Why `IsFilled` defaults to `false`"** hint under the Fill table: the new shapes are historically outline-only (visual back-compat), and pairing `IsFilled = false` with an opaque-white `FillColor` makes `IsFilled = true` alone produce a visible fill ("pit of success"), replacing the earlier footgun (`IsFilled = true` + transparent `FillColor` = invisible).

## Deliberately left unchanged

- The dashed **stroke-only** example (already correctly sets `IsFilled = false`).
- The entire **"Obsolete shape runtimes"** section — the legacy `ColoredCircleRuntime` / `RoundedRectangleRuntime` shims genuinely default `IsFilled = true`, so their docs are correct as-is. The two models must not bleed together.

## Verification

Docs-only Markdown/GitBook edits — no build or runtime behavior. No xnafiddles are involved (these pages use static code blocks + figure images). The one figure-adjacent example now matches its screenshot rather than diverging from it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
