### PR TITLE
Don't crash the tool when Ctrl+C clipboard copy hits CLIPBRD_E_CANT_OPEN (#3368)

### DIFF
--- a/Gum/Services/Dialogs/DialogWindow.xaml.cs
+++ b/Gum/Services/Dialogs/DialogWindow.xaml.cs
@@ -1,5 +1,7 @@
 using Gum.Controls;
 using System;
+using System.Runtime.InteropServices;
+using System.Threading;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
@@ -60,28 +62,56 @@ public partial class DialogWindow : WindowChromeWindow
         {
             if (DataContext is MessageDialogViewModel messageVm && !string.IsNullOrEmpty(messageVm.Message))
             {
-                TrySetClipboardText(messageVm.Message);
+                try
+                {
+                    TrySetClipboardText(messageVm.Message);
+                }
+                catch
+                {
+                    // Copying the dialog text is a convenience; never let a clipboard failure
+                    // crash the tool from this key handler (issue #3368). TrySetClipboard already
+                    // swallows the transient COMException, so this only guards against anything
+                    // unexpected Clipboard.SetText might throw.
+                }
                 e.Handled = true;
             }
         }
     }
 
-    private static void TrySetClipboardText(string text, int retries = 3)
+    private static void TrySetClipboardText(string text) =>
+        TrySetClipboard(() => Clipboard.SetText(text), retries: 10, delayMilliseconds: 10);
+
+    /// <summary>
+    /// Runs a clipboard operation, retrying when Windows raises the transient
+    /// CLIPBRD_E_CANT_OPEN <see cref="COMException"/> (only one process may hold the
+    /// clipboard open at a time, so clipboard managers, RDP sessions, and browsers
+    /// routinely block it for short windows). Gives up silently after
+    /// <paramref name="retries"/> attempts — a best-effort copy must never crash the
+    /// tool (issue #3368).
+    /// </summary>
+    /// <returns>True if the operation succeeded; false if every attempt failed.</returns>
+    internal static bool TrySetClipboard(Action setClipboard, int retries, int delayMilliseconds)
     {
         for (int i = 0; i < retries; i++)
         {
             try
             {
-                Clipboard.SetText(text);
-                return;
+                setClipboard();
+                return true;
             }
-            catch (System.Runtime.InteropServices.COMException)
+            catch (COMException)
             {
                 if (i == retries - 1)
-                    throw;
-                System.Threading.Thread.Sleep(10);
+                {
+                    return false;
+                }
+                if (delayMilliseconds > 0)
+                {
+                    Thread.Sleep(delayMilliseconds);
+                }
             }
         }
+        return false;
     }
 
     private void ScrollViewer_PreviewMouseWheel(object? sender, MouseWheelEventArgs e)

--- a/Tool/Tests/GumToolUnitTests/Dialogs/DialogWindowClipboardTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Dialogs/DialogWindowClipboardTests.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Runtime.InteropServices;
+using Gum.Services.Dialogs;
+using Shouldly;
+using Xunit;
+
+namespace GumToolUnitTests.Dialogs;
+
+public class DialogWindowClipboardTests
+{
+    // CLIPBRD_E_CANT_OPEN — the transient HRESULT the real clipboard raises when another
+    // process is holding it open. Issue #3368: this must never escape and crash the tool.
+    private const int CLIPBRD_E_CANT_OPEN = unchecked((int)0x800401D0);
+
+    private static COMException ClipboardBusy() => new("OpenClipboard Failed", CLIPBRD_E_CANT_OPEN);
+
+    [Fact]
+    public void TrySetClipboard_DoesNotThrowAndReturnsFalse_WhenEveryAttemptThrowsComException()
+    {
+        int attempts = 0;
+        bool result = true;
+
+        Should.NotThrow(() =>
+            result = DialogWindow.TrySetClipboard(
+                () => { attempts++; throw ClipboardBusy(); },
+                retries: 4,
+                delayMilliseconds: 0));
+
+        result.ShouldBeFalse();
+        attempts.ShouldBe(4);
+    }
+
+    [Fact]
+    public void TrySetClipboard_ReturnsTrue_WhenOperationSucceedsImmediately()
+    {
+        int attempts = 0;
+
+        bool result = DialogWindow.TrySetClipboard(() => attempts++, retries: 4, delayMilliseconds: 0);
+
+        result.ShouldBeTrue();
+        attempts.ShouldBe(1);
+    }
+
+    [Fact]
+    public void TrySetClipboard_StopsAfterSuccess_WhenOperationSucceedsOnLaterAttempt()
+    {
+        int attempts = 0;
+
+        bool result = DialogWindow.TrySetClipboard(
+            () =>
+            {
+                attempts++;
+                if (attempts < 3)
+                {
+                    throw ClipboardBusy();
+                }
+            },
+            retries: 10,
+            delayMilliseconds: 0);
+
+        result.ShouldBeTrue();
+        attempts.ShouldBe(3);
+    }
+}


### PR DESCRIPTION
## Summary

Pressing **Ctrl+C** on a Gum message dialog could crash the entire tool with `OpenClipboard Failed (0x800401D0 (CLIPBRD_E_CANT_OPEN))`.

`DialogWindow.TrySetClipboardText` retried `Clipboard.SetText` 3× then **rethrew** the transient `COMException` on the final attempt. The caller is `OnPreviewKeyDown` — a WPF `PreviewKeyDown` handler with no try/catch — so the rethrow propagated to the dispatcher and terminated the process (reproduced while loading a project with a missing standard element, on the "Recreate it?" prompt).

`CLIPBRD_E_CANT_OPEN` is a routine, transient Windows condition: only one process can hold the clipboard open at a time, and clipboard managers, RDP sessions, and browsers frequently hold it for short windows. Failing to copy dialog text is a convenience operation that should never crash the tool.

## Fix

- Extracted the retry loop into an `internal static bool TrySetClipboard(Action, retries, delayMilliseconds)` that **swallows** the `COMException` on the final attempt (returns `false` instead of rethrowing).
- Bumped retries `3 → 10` for more headroom against the race (≤100 ms worst case).
- Belt-and-suspenders: wrapped the Ctrl+C copy branch in `OnPreviewKeyDown` in a try/catch so no clipboard path can escape the handler.

## Tests

New `DialogWindowClipboardTests` (the extraction made the retry/swallow logic testable without WPF/STA or the real clipboard):
- does **not** throw and returns `false` when every attempt raises `CLIPBRD_E_CANT_OPEN` (the regression — red against the old rethrow)
- returns `true` and stops after the first success
- retries and stops once the operation succeeds on a later attempt

All 3 pass; happy-path copy behavior is unchanged.

Closes #3368

🤖 Generated with [Claude Code](https://claude.com/claude-code)
