### PR TITLE
Fix Text vanishing under TruncateLine + RelativeToChildren height (#3372)

### DIFF
--- a/GumRuntime/GraphicalUiElement.cs
+++ b/GumRuntime/GraphicalUiElement.cs
@@ -2365,6 +2365,16 @@ public partial class GraphicalUiElement : IRenderableIpso, IVisible, INotifyProp
     {
         float pixelHeightToSet = mHeight;
 
+        // Tell a contained text whether its Height is derived from its own lines, so
+        // TextOverflowVerticalMode.TruncateLine does not cap the lines by a height that came from
+        // those lines (issue #3372). Set before the switch because the RelativeToChildren branch below
+        // temporarily reassigns the text's Width, which re-wraps it. Mirrors how a RelativeToChildren
+        // width pushes a null wrap Width onto the renderable.
+        if (mContainedObjectAsIpso is IWrappedText wrappedText)
+        {
+            wrappedText.IsHeightDependentOnLines = mHeightUnit == DimensionUnitType.RelativeToChildren;
+        }
+
         switch (mHeightUnit)
         {
 

--- a/MonoGameGum.Tests/RenderingLibraries/TextTests.cs
+++ b/MonoGameGum.Tests/RenderingLibraries/TextTests.cs
@@ -51,6 +51,54 @@ char id=37   x=161   y=0     width=22    height=20    xoffset=1     yoffset=6   
         return font;
     }
 
+    // Regression guard for the #3372 fix: when the height is a real, independent constraint,
+    // TextOverflowVerticalMode.TruncateLine MUST still clip to the number of fully-fitting
+    // lines. The fix only removes the content-derived (RelativeToChildren) height->lines
+    // feedback; it must not disable height-based truncation for fixed-height text (the
+    // DialogBox pagination path relies on this). Tested at the renderable level because this
+    // is the pure UpdateLines contract — the lineHeight is 21 (from basicBMFontFileData), so
+    // a height of 52 leaves room for two full lines and a partial third.
+    [Fact]
+    public void UpdateLines_TruncateLine_WithFixedHeight_ClipsToFittingLines()
+    {
+        BitmapFont font = new BitmapFont((Texture2D)null!, basicBMFontFileData);
+        font.SetFontPattern(256, 256);
+
+        Text text = new Text();
+        text.BitmapFont = font;
+        text.TextOverflowVerticalMode = TextOverflowVerticalMode.TruncateLine;
+        text.Width = 1000; // wide enough that the explicit lines never wrap
+        text.Height = 52;  // two full 21px lines plus a partial third
+
+        text.RawText = "Line1\nLine2\nLine3";
+
+        text.WrappedText.Count.ShouldBe(2,
+            "Because TruncateLine with a fixed height must clip to the number of fully-fitting lines");
+    }
+
+    // The #3372 fix at the renderable level: when the layout marks the Height as content-derived
+    // (IsHeightDependentOnLines = true, set by GraphicalUiElement for RelativeToChildren height),
+    // TruncateLine must NOT cap the lines by Height — every line renders even when Height is smaller
+    // than the content. Same arrangement as the clip guard above, only the flag differs.
+    [Fact]
+    public void UpdateLines_TruncateLine_WithHeightDependentOnLines_DoesNotClip()
+    {
+        BitmapFont font = new BitmapFont((Texture2D)null!, basicBMFontFileData);
+        font.SetFontPattern(256, 256);
+
+        Text text = new Text();
+        text.BitmapFont = font;
+        text.TextOverflowVerticalMode = TextOverflowVerticalMode.TruncateLine;
+        text.IsHeightDependentOnLines = true;
+        text.Width = 1000;
+        text.Height = 52; // smaller than the three 21px lines, but content-derived so it must not clip
+
+        text.RawText = "Line1\nLine2\nLine3";
+
+        text.WrappedText.Count.ShouldBe(3,
+            "Because a content-derived Height must not be used to truncate the very lines it was derived from");
+    }
+
     [Fact]
     public void MeasureString_WithStyleAndNoBitmapFont_DoesNotThrow()
     {

--- a/MonoGameGum.Tests/Runtimes/TextRuntimeTests.cs
+++ b/MonoGameGum.Tests/Runtimes/TextRuntimeTests.cs
@@ -1106,4 +1106,94 @@ $"chars count=223\r\n";
 
     #endregion
 
+    #region TextOverflowVerticalMode + RelativeToChildren (issue #3372)
+
+    // Issue #3372 background: a Text sized HeightUnits=RelativeToChildren derives its
+    // height from its own WrappedTextHeight (height = WrappedTextHeight + Height-offset).
+    // With TextOverflowVerticalMode.TruncateLine, UpdateLines then derives a max line
+    // count back from that height:
+    //     maxLinesFromHeight = (int)(Height / LineHeightInPixels)
+    // That is a circular dependency: a negative Height offset (commonly used to tighten
+    // line spacing) drops the height below the content's natural height, the integer
+    // division floors to one-too-few lines, and because pushing the height re-triggers
+    // wrapping, each layout pass shaves off another line. The two tests below pin the two
+    // agreed invariants: (1) when height follows content, every line renders; (2) a
+    // negative offset shrinks the bounds below the rendered text height without dropping
+    // a line.
+
+    // Invariant 1 (+ stability): RelativeToChildren height is derived from content, so the
+    // height-based line cap must not fire — all lines render regardless of a negative
+    // Height offset, and they keep rendering across repeated layouts (no progressive
+    // "leave and return" collapse). An explicit MaxNumberOfLines is a separate constraint,
+    // covered below.
+    [Fact]
+    public void TruncateLine_WithRelativeToChildrenHeight_ShouldRenderAllLinesStablyAcrossLayouts()
+    {
+        TextRuntime sut = new();
+        sut.HeightUnits = DimensionUnitType.RelativeToChildren;
+        sut.Height = -1;
+
+        Text renderable = (Text)sut.RenderableComponent;
+        renderable.TextOverflowVerticalMode = TextOverflowVerticalMode.TruncateLine;
+
+        sut.Text = "Line1\nLine2\nLine3";
+
+        sut.UpdateLayout();
+        sut.UpdateLayout();
+        sut.UpdateLayout();
+
+        sut.WrappedText.Count.ShouldBe(3,
+            "Because RelativeToChildren height follows content, so no line may be truncated by the derived height, stably across layouts");
+    }
+
+    // Invariant 2: a negative Height offset shrinks the layout bounds below the rendered
+    // text height (the "tighten spacing" intent) by exactly the offset — and, per
+    // invariant 1, without dropping the line (so the rendered height stays positive).
+    [Fact]
+    public void RelativeToChildrenHeight_WithNegativeOffset_ShouldShrinkBoundsBelowRenderedTextHeight()
+    {
+        const float heightOffset = -5;
+
+        TextRuntime sut = new();
+        sut.HeightUnits = DimensionUnitType.RelativeToChildren;
+        sut.Height = heightOffset;
+
+        Text renderable = (Text)sut.RenderableComponent;
+        renderable.TextOverflowVerticalMode = TextOverflowVerticalMode.TruncateLine;
+
+        sut.Text = "Hello";
+        sut.UpdateLayout();
+
+        float renderedHeight = renderable.WrappedTextHeight;
+        renderedHeight.ShouldBeGreaterThan(0, "Because the single line must still be rendered");
+        sut.GetAbsoluteHeight().ShouldBe(renderedHeight + heightOffset,
+            "Because the bounds are the full rendered height plus the (negative) offset");
+        sut.GetAbsoluteHeight().ShouldBeLessThan(renderedHeight);
+        sut.GetAbsoluteHeight().ShouldBeGreaterThan(0);
+    }
+
+    // The exact issue #3372 repro: vertical truncation + RelativeToChildren height +
+    // negative offset + an explicit one-line cap. An explicit MaxNumberOfLines is NOT the
+    // height-derived cap and must still apply, so the text shows exactly one line — not
+    // zero (the bug) and not all three.
+    [Fact]
+    public void TruncateLine_WithRelativeToChildrenHeightAndMaxNumberOfLines_ShouldHonorMaxNumberOfLines()
+    {
+        TextRuntime sut = new();
+        sut.HeightUnits = DimensionUnitType.RelativeToChildren;
+        sut.Height = -1;
+        sut.MaxNumberOfLines = 1;
+
+        Text renderable = (Text)sut.RenderableComponent;
+        renderable.TextOverflowVerticalMode = TextOverflowVerticalMode.TruncateLine;
+
+        sut.Text = "Line1\nLine2\nLine3";
+        sut.UpdateLayout();
+
+        sut.WrappedText.Count.ShouldBe(1,
+            "Because an explicit MaxNumberOfLines still caps wrapping, even though the height-derived cap is gone");
+    }
+
+    #endregion
+
 }

--- a/RenderingLibrary/Graphics/IWrappedText.cs
+++ b/RenderingLibrary/Graphics/IWrappedText.cs
@@ -18,6 +18,17 @@ public interface IWrappedText : IText
     int LineHeightInPixels { get; }
     bool IsTruncatingWithEllipsisOnLastLine { get; }
 
+    /// <summary>
+    /// Whether this text's Height is derived from its own lines (content), as opposed to being an
+    /// independent constraint. When true, <see cref="TextOverflowVerticalMode.TruncateLine"/> must NOT
+    /// limit the number of lines by Height — doing so would be a circular dependency (the height comes
+    /// from the lines, so capping the lines by that height progressively collapses the text). This is
+    /// pushed by the layout (GraphicalUiElement) and is true when the element's HeightUnits is
+    /// RelativeToChildren. The renderable itself has no concept of HeightUnits, which is why the layout
+    /// sets this, mirroring how a RelativeToChildren width pushes a null wrap Width onto the renderable.
+    /// </summary>
+    bool IsHeightDependentOnLines { get; set; }
+
     float MeasureString(string text);
 
     bool IsMidWordLineBreakEnabled { get; }
@@ -32,7 +43,12 @@ public static class IWrappedTextExtensions
     {
         var effectiveMaxNumberOfLines = textInstance.MaxNumberOfLines;
 
-        if (textInstance.TextOverflowVerticalMode == TextOverflowVerticalMode.TruncateLine)
+        // The Height-derived line cap only makes sense when Height is an independent constraint. When
+        // Height is derived from the lines (RelativeToChildren), capping the lines by that height is a
+        // circular dependency that collapses the text (issue #3372), so skip it — an explicit
+        // MaxNumberOfLines still applies below.
+        if (textInstance.TextOverflowVerticalMode == TextOverflowVerticalMode.TruncateLine
+            && !textInstance.IsHeightDependentOnLines)
         {
 
             var maxLinesFromHeight = (int)(textInstance.Height / textInstance.LineHeightInPixels);

--- a/RenderingLibrary/Graphics/Text.cs
+++ b/RenderingLibrary/Graphics/Text.cs
@@ -327,6 +327,9 @@ public class Text : SpriteBatchRenderableBase, IRenderableIpso, IVisible, IWrapp
 
     public bool IsTruncatingWithEllipsisOnLastLine { get; set; }
 
+    /// <inheritdoc/>
+    public bool IsHeightDependentOnLines { get; set; }
+
     string? mRawText;
     public string? RawText
     {

--- a/Runtimes/RaylibGum/Renderables/Text.cs
+++ b/Runtimes/RaylibGum/Renderables/Text.cs
@@ -309,6 +309,9 @@ public class Text : IVisible, IRenderableIpso,
 
     public bool IsTruncatingWithEllipsisOnLastLine { get; set; }
 
+    /// <inheritdoc/>
+    public bool IsHeightDependentOnLines { get; set; }
+
     public string Name
     {
         get;

--- a/Runtimes/SkiaGum/Renderables/Text.cs
+++ b/Runtimes/SkiaGum/Renderables/Text.cs
@@ -137,6 +137,9 @@ public class Text : IRenderableIpso, IVisible, IText, ICloneable
 
     public bool IsTruncatingWithEllipsisOnLastLine { get; set; }
 
+    /// <inheritdoc/>
+    public bool IsHeightDependentOnLines { get; set; }
+
     public bool IsItalic
     {
         get => _isItalic; set

--- a/Runtimes/SokolGum/Renderables/Text.cs
+++ b/Runtimes/SokolGum/Renderables/Text.cs
@@ -154,6 +154,10 @@ public sealed class Text : RenderableBase, IText, IWrappedText, IFormsText, IClo
     public TextOverflowVerticalMode   TextOverflowVerticalMode   { get; set; } = TextOverflowVerticalMode.SpillOver;
 
     public bool IsTruncatingWithEllipsisOnLastLine { get; set; }
+
+    /// <inheritdoc/>
+    public bool IsHeightDependentOnLines { get; set; }
+
     public bool IsMidWordLineBreakEnabled { get; set; }
 
     /// <summary>Line-to-line spacing multiplier. 1.0 = font-native line height.</summary>


### PR DESCRIPTION
## Problem

Reported in #3372: a Text with vertical truncation on and a content-derived height can render in neither the runtime nor (stably) the editor.

Repro: a Text with `TextOverflowVerticalMode.TruncateLine`, `HeightUnits = RelativeToChildren`, and a small **negative** `Height` (used to tighten line spacing) collapses to **zero** rendered lines. Multi-line text "shows then doesn't show" — each time you leave and return to the component it loses another line.

## Root cause

A circular dependency between two features:

1. `HeightUnits = RelativeToChildren` makes the Text's height = `WrappedTextHeight + Height-offset`.
2. With `TruncateLine`, `IWrappedText.UpdateLines` derives a line cap *back* from that height: `maxLinesFromHeight = (int)(Height / LineHeightInPixels)`.

A negative offset drops the height just below the content's natural height, so the integer division floors to one-too-few lines. Pushing the (smaller) height re-triggers wrapping, so each layout pass shaves off another line — for a single line, straight to zero.

## Fix

The height-derived line cap only makes sense when `Height` is an **independent** constraint (Absolute, Percentage, …). When the height is derived *from* the lines, it must not cap them.

- Add `bool IsHeightDependentOnLines` to `IWrappedText`, **pushed by the layout** (`GraphicalUiElement.UpdateHeight`, true when `HeightUnits == RelativeToChildren`). The renderable has no concept of `HeightUnits`, so the layout sets it — mirroring how a `RelativeToChildren` width already pushes a null wrap `Width` onto the renderable.
- Gate the cap in `UpdateLines` on `!IsHeightDependentOnLines`. An explicit `MaxNumberOfLines` still applies in all cases.

Behavior now matches the two agreed invariants: (1) when height follows content, every line renders; (2) a negative offset shrinks the bounds below the rendered text height (the "tighten spacing" intent) without dropping a line.

## Tests

New pins (TDD, red-first verified):

- `UpdateLines_TruncateLine_WithFixedHeight_ClipsToFittingLines` — regression guard: fixed height still clips (e.g. DialogBox pagination).
- `UpdateLines_TruncateLine_WithHeightDependentOnLines_DoesNotClip` — content-derived height does not clip.
- `TruncateLine_WithRelativeToChildrenHeight_ShouldRenderAllLinesStablyAcrossLayouts` — all lines render and stay stable across repeated layouts (the "leave and return" instability).
- `RelativeToChildrenHeight_WithNegativeOffset_ShouldShrinkBoundsBelowRenderedTextHeight` — bounds < rendered height, line still visible.
- `TruncateLine_WithRelativeToChildrenHeightAndMaxNumberOfLines_ShouldHonorMaxNumberOfLines` — the exact issue repro; explicit cap still honored.

All suites green: MonoGameGum.Tests (1774), RaylibGum.Tests (351), SkiaGum.Tests (189); KniGum compiles.

## Known follow-ups (out of scope, flagged not silently skipped)

- `RelativeToMaxParentOrChildren` height is also potentially content-derived; this fix scopes the flag to `RelativeToChildren`.
- `LineHeightMultiplier` vs. the raw-`LineHeightInPixels` cap is a pre-existing latent mismatch.
- A separate GUE layout-ordering quirk: routing a fixed-Absolute-height truncation through `TextRuntime` can leave the renderable wrapped at a transiently larger height (the Absolute-clip contract is pinned at the renderable level instead).

Closes #3372

🤖 Generated with [Claude Code](https://claude.com/claude-code)
