### PR TITLE
Detect animation keyframe errors per-element (headless) so the tree '!' shows on project open and on edits (#3293)

### DIFF
--- a/Gum/Plugins/InternalPlugins/TreeView/MainTreeViewPlugin.cs
+++ b/Gum/Plugins/InternalPlugins/TreeView/MainTreeViewPlugin.cs
@@ -14,13 +14,14 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Gum.DataTypes.Variables;
+using Gum.Messages;
 using Gum.Services;
 using RenderingLibrary;
 
 namespace Gum.Plugins.InternalPlugins.TreeView;
 
 [Export(typeof(PluginBase))]
-internal class MainTreeViewPlugin : PriorityPlugin, IRecipient<ApplicationTeardownMessage>, IRecipient<UiBaseFontSizeChangedMessage>
+internal class MainTreeViewPlugin : PriorityPlugin, IRecipient<ApplicationTeardownMessage>, IRecipient<UiBaseFontSizeChangedMessage>, IRecipient<RequestErrorRefreshMessage>
 {
     private readonly ISelectedState _selectedState;
     private readonly ElementTreeViewManager _elementTreeViewManager;
@@ -288,6 +289,20 @@ internal class MainTreeViewPlugin : PriorityPlugin, IRecipient<ApplicationTeardo
     void IRecipient<UiBaseFontSizeChangedMessage>.Receive(UiBaseFontSizeChangedMessage message)
     {
         _elementTreeViewManager.UpdateCollapseButtonSizes(message.Size);
+    }
+
+    void IRecipient<RequestErrorRefreshMessage>.Receive(RequestErrorRefreshMessage message)
+    {
+        // A full error refresh (RequestingPlugin == null) is requested after an edit changes an
+        // element's error set but fires no structural plugin event — notably an animation keyframe
+        // edit (MainStateAnimationPlugin.HandleDataChange), which only saves the .ganx. Re-check the
+        // selected element's "!" indicator (detection itself is selection-independent and headless;
+        // this is purely the refresh trigger). Plugin-scoped requests (RequestingPlugin != null,
+        // sent on view-model refresh / selection) are ignored so selection is NOT a refresh trigger.
+        if (message.RequestingPlugin == null)
+        {
+            RefreshErrorIndicatorsForElement(_selectedState.SelectedElement);
+        }
     }
 
     private void RefreshErrorIndicatorsForElement(ElementSave? element)

--- a/Gum/Plugins/InternalPlugins/TreeView/MainTreeViewPlugin.cs
+++ b/Gum/Plugins/InternalPlugins/TreeView/MainTreeViewPlugin.cs
@@ -14,14 +14,13 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Gum.DataTypes.Variables;
-using Gum.Messages;
 using Gum.Services;
 using RenderingLibrary;
 
 namespace Gum.Plugins.InternalPlugins.TreeView;
 
 [Export(typeof(PluginBase))]
-internal class MainTreeViewPlugin : PriorityPlugin, IRecipient<ApplicationTeardownMessage>, IRecipient<UiBaseFontSizeChangedMessage>, IRecipient<RequestErrorRefreshMessage>
+internal class MainTreeViewPlugin : PriorityPlugin, IRecipient<ApplicationTeardownMessage>, IRecipient<UiBaseFontSizeChangedMessage>
 {
     private readonly ISelectedState _selectedState;
     private readonly ElementTreeViewManager _elementTreeViewManager;
@@ -289,19 +288,6 @@ internal class MainTreeViewPlugin : PriorityPlugin, IRecipient<ApplicationTeardo
     void IRecipient<UiBaseFontSizeChangedMessage>.Receive(UiBaseFontSizeChangedMessage message)
     {
         _elementTreeViewManager.UpdateCollapseButtonSizes(message.Size);
-    }
-
-    void IRecipient<RequestErrorRefreshMessage>.Receive(RequestErrorRefreshMessage message)
-    {
-        // Plugins broadcast this after recomputing their errors/viewmodels (the animation
-        // plugin does so when an element is selected). MainErrorsPlugin refreshes the Errors
-        // tab from the same signal; the tree "!" indicator must too, or it lags until an
-        // unrelated event fires. The broadcast happens AFTER the recompute, so the selected
-        // element's error state is current here — unlike the per-event handlers above, which
-        // (as a PriorityPlugin) run before non-priority plugins such as the animation plugin
-        // refresh. (Renaming a state does NOT yet refresh through here: the rename leaves the
-        // animation error in an inconsistent in-memory state at broadcast time — see #3383.)
-        RefreshErrorIndicatorsForElement(_selectedState.SelectedElement);
     }
 
     private void RefreshErrorIndicatorsForElement(ElementSave? element)

--- a/Gum/Plugins/InternalPlugins/TreeView/MainTreeViewPlugin.cs
+++ b/Gum/Plugins/InternalPlugins/TreeView/MainTreeViewPlugin.cs
@@ -233,7 +233,7 @@ internal class MainTreeViewPlugin : PriorityPlugin, IRecipient<ApplicationTeardo
         }
     }
 
-    private void HandleElementSelected(ElementSave save)
+    private void HandleElementSelected(ElementSave? save)
     {
         _elementTreeViewManager.SuppressCallAfterClickSelect = true;
         try
@@ -251,6 +251,13 @@ internal class MainTreeViewPlugin : PriorityPlugin, IRecipient<ApplicationTeardo
         {
             _elementTreeViewManager.SuppressCallAfterClickSelect = false;
         }
+
+        // The Errors tab refreshes on selection (MainErrorsPlugin), but the tree "!" indicator
+        // was only refreshed by other events (VariableSet, undo, add/delete, reload). Without
+        // this, an error first surfaced by selection (e.g. an animation frame referencing a
+        // missing state) shows in the Errors tab but the node's icon stays stale until an
+        // unrelated refresh fires. Refreshing here keeps the two paths in sync.
+        RefreshErrorIndicatorsForElement(save);
     }
 
     private void MainTreeViewPlugin_InstanceSelected(DataTypes.ElementSave element, DataTypes.InstanceSave instance)

--- a/Gum/Plugins/InternalPlugins/TreeView/MainTreeViewPlugin.cs
+++ b/Gum/Plugins/InternalPlugins/TreeView/MainTreeViewPlugin.cs
@@ -234,7 +234,7 @@ internal class MainTreeViewPlugin : PriorityPlugin, IRecipient<ApplicationTeardo
         }
     }
 
-    private void HandleElementSelected(ElementSave? save)
+    private void HandleElementSelected(ElementSave save)
     {
         _elementTreeViewManager.SuppressCallAfterClickSelect = true;
         try
@@ -252,12 +252,6 @@ internal class MainTreeViewPlugin : PriorityPlugin, IRecipient<ApplicationTeardo
         {
             _elementTreeViewManager.SuppressCallAfterClickSelect = false;
         }
-
-        // Mirror MainErrorsPlugin: refresh this element's "!" indicator on selection so
-        // structural errors surface immediately. Plugin-contributed errors (e.g. the
-        // animation missing-state error) are only valid once their plugin recomputes after
-        // selection — those are picked up via RequestErrorRefreshMessage (see Receive below).
-        RefreshErrorIndicatorsForElement(save);
     }
 
     private void MainTreeViewPlugin_InstanceSelected(DataTypes.ElementSave element, DataTypes.InstanceSave instance)
@@ -299,12 +293,14 @@ internal class MainTreeViewPlugin : PriorityPlugin, IRecipient<ApplicationTeardo
 
     void IRecipient<RequestErrorRefreshMessage>.Receive(RequestErrorRefreshMessage message)
     {
-        // Plugins broadcast this after recomputing their errors and viewmodels (e.g. the
-        // animation plugin on selection, state add/delete/rename, variable set). The Errors
-        // tab already refreshes here (MainErrorsPlugin); the tree "!" indicator must too, or
-        // it lags until an unrelated event fires. Because the broadcast happens after the
-        // recompute, the selected element's error state is current — unlike the per-event
-        // handlers above, which (as a PriorityPlugin) run before non-priority plugins refresh.
+        // Plugins broadcast this after recomputing their errors/viewmodels (the animation
+        // plugin does so when an element is selected). MainErrorsPlugin refreshes the Errors
+        // tab from the same signal; the tree "!" indicator must too, or it lags until an
+        // unrelated event fires. The broadcast happens AFTER the recompute, so the selected
+        // element's error state is current here — unlike the per-event handlers above, which
+        // (as a PriorityPlugin) run before non-priority plugins such as the animation plugin
+        // refresh. (Renaming a state does NOT yet refresh through here: the rename leaves the
+        // animation error in an inconsistent in-memory state at broadcast time — see #3383.)
         RefreshErrorIndicatorsForElement(_selectedState.SelectedElement);
     }
 

--- a/Gum/Plugins/InternalPlugins/TreeView/MainTreeViewPlugin.cs
+++ b/Gum/Plugins/InternalPlugins/TreeView/MainTreeViewPlugin.cs
@@ -14,13 +14,14 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Gum.DataTypes.Variables;
+using Gum.Messages;
 using Gum.Services;
 using RenderingLibrary;
 
 namespace Gum.Plugins.InternalPlugins.TreeView;
 
 [Export(typeof(PluginBase))]
-internal class MainTreeViewPlugin : PriorityPlugin, IRecipient<ApplicationTeardownMessage>, IRecipient<UiBaseFontSizeChangedMessage>
+internal class MainTreeViewPlugin : PriorityPlugin, IRecipient<ApplicationTeardownMessage>, IRecipient<UiBaseFontSizeChangedMessage>, IRecipient<RequestErrorRefreshMessage>
 {
     private readonly ISelectedState _selectedState;
     private readonly ElementTreeViewManager _elementTreeViewManager;
@@ -252,11 +253,10 @@ internal class MainTreeViewPlugin : PriorityPlugin, IRecipient<ApplicationTeardo
             _elementTreeViewManager.SuppressCallAfterClickSelect = false;
         }
 
-        // The Errors tab refreshes on selection (MainErrorsPlugin), but the tree "!" indicator
-        // was only refreshed by other events (VariableSet, undo, add/delete, reload). Without
-        // this, an error first surfaced by selection (e.g. an animation frame referencing a
-        // missing state) shows in the Errors tab but the node's icon stays stale until an
-        // unrelated refresh fires. Refreshing here keeps the two paths in sync.
+        // Mirror MainErrorsPlugin: refresh this element's "!" indicator on selection so
+        // structural errors surface immediately. Plugin-contributed errors (e.g. the
+        // animation missing-state error) are only valid once their plugin recomputes after
+        // selection — those are picked up via RequestErrorRefreshMessage (see Receive below).
         RefreshErrorIndicatorsForElement(save);
     }
 
@@ -295,6 +295,17 @@ internal class MainTreeViewPlugin : PriorityPlugin, IRecipient<ApplicationTeardo
     void IRecipient<UiBaseFontSizeChangedMessage>.Receive(UiBaseFontSizeChangedMessage message)
     {
         _elementTreeViewManager.UpdateCollapseButtonSizes(message.Size);
+    }
+
+    void IRecipient<RequestErrorRefreshMessage>.Receive(RequestErrorRefreshMessage message)
+    {
+        // Plugins broadcast this after recomputing their errors and viewmodels (e.g. the
+        // animation plugin on selection, state add/delete/rename, variable set). The Errors
+        // tab already refreshes here (MainErrorsPlugin); the tree "!" indicator must too, or
+        // it lags until an unrelated event fires. Because the broadcast happens after the
+        // recompute, the selected element's error state is current — unlike the per-event
+        // handlers above, which (as a PriorityPlugin) run before non-priority plugins refresh.
+        RefreshErrorIndicatorsForElement(_selectedState.SelectedElement);
     }
 
     private void RefreshErrorIndicatorsForElement(ElementSave? element)

--- a/Gum/Services/Builder.cs
+++ b/Gum/Services/Builder.cs
@@ -171,8 +171,12 @@ file static class ServiceCollectionExtensions
         services.AddSingleton<IUserProjectSettingsManager, UserProjectSettingsManager>();
         services.AddSingleton<ProjectServices.ITypeResolver>(provider =>
             new TypeManagerTypeResolverAdapter(provider.GetRequiredService<Reflection.ITypeManager>()));
+        services.AddSingleton<ProjectServices.IElementAnimationsProvider, ProjectServices.FileElementAnimationsProvider>();
+        services.AddSingleton<ProjectServices.IAdditionalErrorSource, ProjectServices.AnimationKeyframeErrorSource>();
         services.AddSingleton<ProjectServices.IHeadlessErrorChecker>(provider =>
-            new ProjectServices.HeadlessErrorChecker(provider.GetRequiredService<ProjectServices.ITypeResolver>()));
+            new ProjectServices.HeadlessErrorChecker(
+                provider.GetRequiredService<ProjectServices.ITypeResolver>(),
+                provider.GetServices<ProjectServices.IAdditionalErrorSource>()));
         services.AddSingleton<ProjectServices.IErrorDocsRegistry, ProjectServices.ErrorDocsRegistry>();
         services.AddSingleton<ErrorChecker>();
         services.AddSingleton<IErrorChecker>(provider => provider.GetRequiredService<ErrorChecker>());

--- a/Gum/StateAnimationPlugin/MainStateAnimationPlugin.cs
+++ b/Gum/StateAnimationPlugin/MainStateAnimationPlugin.cs
@@ -628,6 +628,13 @@ public class MainStateAnimationPlugin : PluginBase
             {
                 _guiCommands.PrintOutput($"Could not save animations for {_viewModel?.Element}:\n{exc}");
             }
+
+            // The edit changed which states/animations the keyframes reference, so an animation
+            // error (e.g. a keyframe pointing at a now-missing state) may have appeared or cleared.
+            // No structural plugin event fires for an animation edit, so request a full error
+            // refresh; the headless checker re-reads the just-saved .ganx. RequestingPlugin is left
+            // null (full refresh) so both the Errors tab and the tree "!" indicator re-check.
+            _messenger.Send(new RequestErrorRefreshMessage());
         }
     }
 

--- a/Gum/StateAnimationPlugin/MainStateAnimationPlugin.cs
+++ b/Gum/StateAnimationPlugin/MainStateAnimationPlugin.cs
@@ -168,7 +168,11 @@ public class MainStateAnimationPlugin : PluginBase
         this.DeleteOptionsWindowShow += _elementDeleteService.HandleDeleteOptionsWindowShow;
         this.DeleteConfirmed += _elementDeleteService.HandleConfirmDelete;
 
-        this.GetAllErrors += HandleGetAllErrors;
+        // Animation "keyframe references a missing state" errors are now detected per-element by
+        // the headless AnimationKeyframeErrorSource (issue #3293), which reads the .ganx so it
+        // works on project open and on edits regardless of selection. Contributing them here too
+        // (from this plugin's per-selection view model) would duplicate those errors for the
+        // selected element, so this plugin no longer subscribes to GetAllErrors.
     }
 
     private void HandleElementSelected(ElementSave? element)
@@ -692,23 +696,6 @@ public class MainStateAnimationPlugin : PluginBase
         }
 
         return response;
-    }
-
-    private IEnumerable<ErrorViewModel> HandleGetAllErrors()
-    {
-        if(_viewModel == null)
-        {
-            return Enumerable.Empty<ErrorViewModel>();
-        }
-
-        var toReturn = this._viewModel.GetErrors();
-
-        foreach(var item in toReturn)
-        {
-            item.OwnerPlugin = this;
-        }
-
-        return toReturn;
     }
 
     private List<AnimationSave> GetAnimationsReferencingState(StateSave state, ElementSave? element)

--- a/Gum/StateAnimationPlugin/Properties/AssemblyInfo.cs
+++ b/Gum/StateAnimationPlugin/Properties/AssemblyInfo.cs
@@ -14,8 +14,13 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+// Exposes internal members (e.g. the animation view models' RefreshErrors/GetErrors error
+// computation) to the tool unit test project so the rename/error logic can be characterized
+// without driving the WPF plugin.
+[assembly: InternalsVisibleTo("GumToolUnitTests")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 

--- a/Tests/Gum.ProjectServices.Tests/AnimationKeyframeErrorEndToEndTests.cs
+++ b/Tests/Gum.ProjectServices.Tests/AnimationKeyframeErrorEndToEndTests.cs
@@ -1,0 +1,72 @@
+using Gum.DataTypes;
+using Gum.DataTypes.Variables;
+using Gum.StateAnimation.SaveClasses;
+using Moq;
+using Shouldly;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using ToolsUtilities;
+using Xunit;
+
+namespace Gum.ProjectServices.Tests;
+
+/// <summary>
+/// End-to-end: the real <see cref="HeadlessErrorChecker"/> wired with the real
+/// <see cref="AnimationKeyframeErrorSource"/> + <see cref="FileElementAnimationsProvider"/> reports a
+/// dangling animation keyframe reference for a project on disk. This covers the integration seam
+/// (checker actually invokes the source; provider resolves the real <c>.ganx</c> path) that the
+/// unit tests mock out.
+/// </summary>
+public class AnimationKeyframeErrorEndToEndTests : BaseTestClass, IDisposable
+{
+    private readonly string _tempDirectory;
+    private readonly GumProjectSave _project;
+
+    public AnimationKeyframeErrorEndToEndTests()
+    {
+        _tempDirectory = Path.Combine(Path.GetTempPath(), "GumAnimE2E_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDirectory);
+        _project = new GumProjectSave { FullFileName = Path.Combine(_tempDirectory, "Project.gumx") };
+    }
+
+    public override void Dispose()
+    {
+        try { Directory.Delete(_tempDirectory, recursive: true); } catch { }
+        base.Dispose();
+    }
+
+    [Fact]
+    public void GetErrorsFor_ReportsDanglingAnimationKeyframe_ThroughTheRealChecker()
+    {
+        ComponentSave element = new ComponentSave { Name = "Foo" };
+        StateSaveCategory category = new StateSaveCategory { Name = "Cat" };
+        category.States.Add(new StateSave { Name = "Idle" });
+        element.Categories.Add(category);
+        _project.Components.Add(element);
+
+        WriteGanx("Components", "FooAnimations.ganx", animationName: "Anim", keyframeStateName: "Cat/Missing");
+
+        HeadlessErrorChecker checker = new HeadlessErrorChecker(
+            Mock.Of<ITypeResolver>(),
+            new IAdditionalErrorSource[] { new AnimationKeyframeErrorSource(new FileElementAnimationsProvider()) });
+
+        IReadOnlyList<ErrorResult> errors = checker.GetErrorsFor(element, _project);
+
+        errors.ShouldContain(error => error.Message.Contains("Cat/Missing"));
+    }
+
+    private void WriteGanx(string relativeDirectory, string fileName, string animationName, string keyframeStateName)
+    {
+        string directory = Path.Combine(_tempDirectory, relativeDirectory);
+        Directory.CreateDirectory(directory);
+
+        AnimationSave animation = new AnimationSave { Name = animationName };
+        animation.States.Add(new AnimatedStateSave { StateName = keyframeStateName });
+        ElementAnimationsSave animations = new ElementAnimationsSave();
+        animations.Animations.Add(animation);
+
+        FileManager.XmlSerialize(animations, Path.Combine(directory, fileName));
+    }
+}

--- a/Tests/Gum.ProjectServices.Tests/AnimationKeyframeErrorSourceTests.cs
+++ b/Tests/Gum.ProjectServices.Tests/AnimationKeyframeErrorSourceTests.cs
@@ -1,0 +1,93 @@
+using Gum.DataTypes;
+using Gum.DataTypes.Variables;
+using Gum.StateAnimation.SaveClasses;
+using Moq;
+using Shouldly;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Gum.ProjectServices.Tests;
+
+/// <summary>
+/// Pins the headless detection of animation keyframes that reference a missing state — the check
+/// that lets the tree "!" / Errors surface animation errors on project open and on edits without
+/// the State Animation plugin's per-selection view model (issue #3293).
+/// </summary>
+public class AnimationKeyframeErrorSourceTests
+{
+    private readonly Mock<IElementAnimationsProvider> _animationsProvider = new Mock<IElementAnimationsProvider>();
+
+    [Fact]
+    public void GetErrors_ReportsKeyframeReferencingMissingCategorizedState()
+    {
+        ComponentSave element = ElementWithCategorizedState("Cat", "Idle");
+        GivenAnimations(element, AnimationWithStateKeyframe("Anim", "Cat/Missing"));
+
+        List<ErrorResult> errors = CreateSut().GetErrors(element, new GumProjectSave()).ToList();
+
+        errors.Count.ShouldBe(1);
+        errors[0].ElementName.ShouldBe("Foo");
+        errors[0].Message.ShouldContain("Cat/Missing");
+    }
+
+    [Fact]
+    public void GetErrors_ReportsNoError_ForKeyframeReferencingExistingCategorizedState()
+    {
+        ComponentSave element = ElementWithCategorizedState("Cat", "Idle");
+        GivenAnimations(element, AnimationWithStateKeyframe("Anim", "Cat/Idle"));
+
+        CreateSut().GetErrors(element, new GumProjectSave()).ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void GetErrors_ReportsNoError_ForKeyframeReferencingExistingUncategorizedState()
+    {
+        ComponentSave element = new ComponentSave { Name = "Foo" };
+        element.States.Add(new StateSave { Name = "Idle" });
+        GivenAnimations(element, AnimationWithStateKeyframe("Anim", "Idle"));
+
+        CreateSut().GetErrors(element, new GumProjectSave()).ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void GetErrors_ReportsNoError_WhenElementHasNoAnimations()
+    {
+        ComponentSave element = ElementWithCategorizedState("Cat", "Idle");
+        _animationsProvider
+            .Setup(provider => provider.GetAnimationsFor(element, It.IsAny<GumProjectSave>()))
+            .Returns((ElementAnimationsSave?)null);
+
+        CreateSut().GetErrors(element, new GumProjectSave()).ShouldBeEmpty();
+    }
+
+    private AnimationKeyframeErrorSource CreateSut()
+    {
+        return new AnimationKeyframeErrorSource(_animationsProvider.Object);
+    }
+
+    private void GivenAnimations(ElementSave element, ElementAnimationsSave animations)
+    {
+        _animationsProvider
+            .Setup(provider => provider.GetAnimationsFor(element, It.IsAny<GumProjectSave>()))
+            .Returns(animations);
+    }
+
+    private static ComponentSave ElementWithCategorizedState(string categoryName, string stateName)
+    {
+        StateSaveCategory category = new StateSaveCategory { Name = categoryName };
+        category.States.Add(new StateSave { Name = stateName });
+        ComponentSave element = new ComponentSave { Name = "Foo" };
+        element.Categories.Add(category);
+        return element;
+    }
+
+    private static ElementAnimationsSave AnimationWithStateKeyframe(string animationName, string keyframeStateName)
+    {
+        AnimationSave animation = new AnimationSave { Name = animationName };
+        animation.States.Add(new AnimatedStateSave { StateName = keyframeStateName });
+        ElementAnimationsSave animations = new ElementAnimationsSave();
+        animations.Animations.Add(animation);
+        return animations;
+    }
+}

--- a/Tests/Gum.ProjectServices.Tests/FileElementAnimationsProviderTests.cs
+++ b/Tests/Gum.ProjectServices.Tests/FileElementAnimationsProviderTests.cs
@@ -1,0 +1,79 @@
+using Gum.DataTypes;
+using Gum.StateAnimation.SaveClasses;
+using Shouldly;
+using System;
+using System.IO;
+using System.Linq;
+using ToolsUtilities;
+using Xunit;
+
+namespace Gum.ProjectServices.Tests;
+
+/// <summary>
+/// Pins how the disk provider locates an element's <c>.ganx</c> (relative to the project, by element
+/// type), deserializes it, and caches the result. The <c>.ganx</c> is written to the convention path
+/// independently of the provider so a path-resolution regression is actually caught.
+/// </summary>
+public class FileElementAnimationsProviderTests : IDisposable
+{
+    private readonly string _tempDirectory;
+    private readonly GumProjectSave _project;
+
+    public FileElementAnimationsProviderTests()
+    {
+        _tempDirectory = Path.Combine(Path.GetTempPath(), "GumAnimProvider_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDirectory);
+        _project = new GumProjectSave { FullFileName = Path.Combine(_tempDirectory, "Project.gumx") };
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_tempDirectory, recursive: true); } catch { }
+    }
+
+    [Fact]
+    public void GetAnimationsFor_ReturnsDeserializedAnimations_FromTheComponentsGanx()
+    {
+        ComponentSave element = new ComponentSave { Name = "Foo" };
+        WriteGanx("Components", "FooAnimations.ganx", animationName: "Anim", keyframeStateName: "Cat/Idle");
+
+        ElementAnimationsSave? result = new FileElementAnimationsProvider().GetAnimationsFor(element, _project);
+
+        result.ShouldNotBeNull();
+        result!.Animations.Single().States.Single().StateName.ShouldBe("Cat/Idle");
+    }
+
+    [Fact]
+    public void GetAnimationsFor_ReturnsNull_WhenNoGanxExists()
+    {
+        ComponentSave element = new ComponentSave { Name = "Foo" };
+
+        new FileElementAnimationsProvider().GetAnimationsFor(element, _project).ShouldBeNull();
+    }
+
+    [Fact]
+    public void GetAnimationsFor_ReturnsCachedInstance_OnRepeatedCallsWithoutFileChange()
+    {
+        ComponentSave element = new ComponentSave { Name = "Foo" };
+        WriteGanx("Components", "FooAnimations.ganx", animationName: "Anim", keyframeStateName: "Cat/Idle");
+        FileElementAnimationsProvider provider = new FileElementAnimationsProvider();
+
+        ElementAnimationsSave? first = provider.GetAnimationsFor(element, _project);
+        ElementAnimationsSave? second = provider.GetAnimationsFor(element, _project);
+
+        second.ShouldBeSameAs(first);
+    }
+
+    private void WriteGanx(string relativeDirectory, string fileName, string animationName, string keyframeStateName)
+    {
+        string directory = Path.Combine(_tempDirectory, relativeDirectory);
+        Directory.CreateDirectory(directory);
+
+        AnimationSave animation = new AnimationSave { Name = animationName };
+        animation.States.Add(new AnimatedStateSave { StateName = keyframeStateName });
+        ElementAnimationsSave animations = new ElementAnimationsSave();
+        animations.Animations.Add(animation);
+
+        FileManager.XmlSerialize(animations, Path.Combine(directory, fileName));
+    }
+}

--- a/Tool/Tests/GumToolUnitTests/Plugins/StateAnimationPlugin/AnimationStateRenameErrorTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/StateAnimationPlugin/AnimationStateRenameErrorTests.cs
@@ -1,0 +1,189 @@
+using Gum.DataTypes;
+using Gum.DataTypes.Variables;
+using Gum.Managers;
+using Gum.Services.Dialogs;
+using Gum.ToolStates;
+using Gum.Wireframe;
+using Moq;
+using Shouldly;
+using StateAnimationPlugin.Managers;
+using StateAnimationPlugin.ViewModels;
+using System;
+using System.Linq;
+using System.Threading;
+using Xunit;
+
+namespace GumToolUnitTests.Plugins.StateAnimationPlugin;
+
+/// <summary>
+/// Characterizes how the animation view models detect missing-state errors (<c>RefreshErrors</c> →
+/// <c>GetErrors</c>) and how a state rename propagates to animation keyframes. Companion to
+/// <see cref="RenameManagerTests"/>: those pin the keyframe-mutating overloads in isolation, these
+/// pin the resulting error state — the same error the tree "!" indicator and the Errors tab surface
+/// (issue #3293) and that a rename leaves stale (issue #3383).
+///
+/// These were the behaviors repeatedly mis-read while reasoning about #3293/#3383; they are pinned
+/// here so future changes start from executable ground truth rather than speculation.
+/// </summary>
+public class AnimationStateRenameErrorTests : BaseTestClass
+{
+    private readonly IBitmapLoader _bitmapLoader = Mock.Of<IBitmapLoader>();
+    private readonly ISelectedState _selectedState = Mock.Of<ISelectedState>();
+    private readonly IWireframeObjectManager _wireframeObjectManager = Mock.Of<IWireframeObjectManager>();
+
+    [Fact]
+    public void HandleRename_OfCategorizedState_RewritesKeyframeAndClearsErrorOnRefresh()
+    {
+        RunOnSta(() =>
+        {
+            ComponentSave element = ElementWithCategorizedState("Cat", "Idle");
+            StateSave idle = element.Categories[0].States[0];
+            ElementAnimationsViewModel viewModel = CreateViewModelWith(
+                CreateAnimationWithKeyframes(Keyframe(stateName: "Cat/Idle")));
+
+            // Mirror RenameLogic.RenameState: the model is renamed first, then plugins are notified.
+            idle.Name = "Walk";
+            RenameManagerFor(element).HandleRename(idle, "Idle", viewModel);
+
+            viewModel.Animations[0].Keyframes[0].StateName.ShouldBe("Cat/Walk");
+
+            viewModel.RefreshErrors(element);
+            viewModel.GetErrors().ShouldBeEmpty();
+        });
+    }
+
+    [Fact]
+    public void RefreshErrors_ReportsKeyframeReferencingMissingCategorizedState()
+    {
+        RunOnSta(() =>
+        {
+            ComponentSave element = ElementWithCategorizedState("Cat", "Idle");
+            ElementAnimationsViewModel viewModel = CreateViewModelWith(
+                CreateAnimationWithKeyframes(Keyframe(stateName: "Cat/Missing")));
+
+            viewModel.RefreshErrors(element);
+
+            viewModel.GetErrors().Count().ShouldBe(1);
+            viewModel.GetErrors().Single().Message.ShouldContain("Cat/Missing");
+        });
+    }
+
+    [Fact]
+    public void RefreshErrors_ReportsNoError_ForKeyframeReferencingExistingCategorizedState()
+    {
+        RunOnSta(() =>
+        {
+            ComponentSave element = ElementWithCategorizedState("Cat", "Idle");
+            ElementAnimationsViewModel viewModel = CreateViewModelWith(
+                CreateAnimationWithKeyframes(Keyframe(stateName: "Cat/Idle")));
+
+            viewModel.RefreshErrors(element);
+
+            viewModel.GetErrors().ShouldBeEmpty();
+        });
+    }
+
+    [Fact]
+    public void RenameSequence_AsThePluginRunsIt_LeavesStaleError()
+    {
+        // Models MainStateAnimationPlugin.HandleStateRename ordering: RefreshViewModel (which calls
+        // RefreshErrors and broadcasts RequestErrorRefreshMessage) runs BEFORE the keyframe is
+        // rewritten, and errors are never recomputed afterward. This pins the #3383 root cause that
+        // makes the tree/Errors-tab refresh look broken: a rename leaves the error state stale until
+        // a full refresh (re-selecting the element) rebuilds it.
+        RunOnSta(() =>
+        {
+            ComponentSave element = ElementWithCategorizedState("Cat", "Idle");
+            StateSave idle = element.Categories[0].States[0];
+            ElementAnimationsViewModel viewModel = CreateViewModelWith(
+                CreateAnimationWithKeyframes(Keyframe(stateName: "Cat/Idle")));
+
+            idle.Name = "Walk";                              // state already renamed when the event fires
+            viewModel.RefreshErrors(element);                // plugin's RefreshViewModel: keyframe still "Cat/Idle"
+            RenameManagerFor(element).HandleRename(idle, "Idle", viewModel); // keyframe -> "Cat/Walk"
+
+            // The plugin does NOT recompute errors after the rewrite, so HasValidState is stale:
+            // it was computed when the keyframe still read "Cat/Idle". The keyframe now correctly
+            // reads "Cat/Walk", yet GetErrors still reports it as missing — a stale false positive.
+            viewModel.Animations[0].Keyframes[0].StateName.ShouldBe("Cat/Walk");
+            viewModel.GetErrors().Count().ShouldBe(1);
+            viewModel.GetErrors().Single().Message.ShouldContain("Cat/Walk");
+
+            // Recomputing (what re-selecting the element does) clears the stale error.
+            viewModel.RefreshErrors(element);
+            viewModel.GetErrors().ShouldBeEmpty();
+        });
+    }
+
+    private static ComponentSave ElementWithCategorizedState(string categoryName, string stateName)
+    {
+        StateSaveCategory category = new StateSaveCategory { Name = categoryName };
+        category.States.Add(new StateSave { Name = stateName });
+        ComponentSave element = new ComponentSave { Name = "Foo" };
+        element.Categories.Add(category);
+        return element;
+    }
+
+    private RenameManager RenameManagerFor(ElementSave selectedElement)
+    {
+        return new RenameManager(
+            Mock.Of<ISelectedState>(s => s.SelectedElement == selectedElement),
+            Mock.Of<IOutputManager>(),
+            Mock.Of<IAnimationFilePathService>(),
+            Mock.Of<IAnimationCollectionViewModelManager>());
+    }
+
+    private AnimatedKeyframeViewModel Keyframe(string stateName)
+    {
+        return new AnimatedKeyframeViewModel(_bitmapLoader) { StateName = stateName };
+    }
+
+    private AnimationViewModel CreateAnimationWithKeyframes(params AnimatedKeyframeViewModel[] keyframes)
+    {
+        AnimationViewModel animation = new AnimationViewModel(_bitmapLoader, _selectedState, _wireframeObjectManager) { Name = "Anim" };
+        foreach (AnimatedKeyframeViewModel keyframe in keyframes)
+        {
+            animation.Keyframes.Add(keyframe);
+        }
+        return animation;
+    }
+
+    private ElementAnimationsViewModel CreateViewModelWith(params AnimationViewModel[] animations)
+    {
+        ElementAnimationsViewModel viewModel = new ElementAnimationsViewModel(
+            Mock.Of<INameVerifier>(),
+            Mock.Of<IDialogService>(),
+            Mock.Of<IAnimationCollectionViewModelManager>(),
+            Mock.Of<IRenameManager>(),
+            _bitmapLoader,
+            _selectedState,
+            _wireframeObjectManager,
+            Mock.Of<IOutputManager>());
+        foreach (AnimationViewModel animation in animations)
+        {
+            viewModel.Animations.Add(animation);
+        }
+        return viewModel;
+    }
+
+    /// <summary>
+    /// WPF controls (the right-click MenuItems built in ElementAnimationsViewModel's constructor)
+    /// require an STA thread; xUnit's default runner is MTA.
+    /// </summary>
+    private static void RunOnSta(Action action)
+    {
+        Exception? caught = null;
+        Thread thread = new Thread(() =>
+        {
+            try { action(); }
+            catch (Exception ex) { caught = ex; }
+        });
+        thread.SetApartmentState(ApartmentState.STA);
+        thread.Start();
+        thread.Join();
+        if (caught != null)
+        {
+            throw new Exception("Test body threw on the STA thread.", caught);
+        }
+    }
+}

--- a/Tools/Gum.Cli/Commands/CheckCommand.cs
+++ b/Tools/Gum.Cli/Commands/CheckCommand.cs
@@ -63,7 +63,9 @@ public static class CheckCommand
         }
 
         ITypeResolver typeResolver = new DefaultTypeResolver();
-        IHeadlessErrorChecker checker = new HeadlessErrorChecker(typeResolver);
+        IHeadlessErrorChecker checker = new HeadlessErrorChecker(
+            typeResolver,
+            new IAdditionalErrorSource[] { new AnimationKeyframeErrorSource(new FileElementAnimationsProvider()) });
         IReadOnlyList<ErrorResult> checkerErrors = checker.GetAllErrors(loadResult.Project!);
 
         var allErrors = new List<ErrorResult>();

--- a/Tools/Gum.ProjectServices/AnimationKeyframeErrorSource.cs
+++ b/Tools/Gum.ProjectServices/AnimationKeyframeErrorSource.cs
@@ -1,0 +1,72 @@
+using Gum.DataTypes;
+using Gum.DataTypes.Variables;
+using Gum.StateAnimation.SaveClasses;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Gum.ProjectServices;
+
+/// <summary>
+/// Reports animation keyframes that reference a state which no longer exists on the element. Runs as
+/// part of the headless per-element error pass (via <see cref="IAdditionalErrorSource"/>), so the
+/// error surfaces on project open and on edits — not only when the State Animation plugin's view
+/// model happens to hold the element. See issue #3293.
+/// </summary>
+/// <remarks>
+/// Currently validates state keyframes (<c>AnimationSave.States</c>). Sub-animation references
+/// (<c>AnimationSave.Animations</c>) are not yet validated here.
+/// </remarks>
+public class AnimationKeyframeErrorSource : IAdditionalErrorSource
+{
+    private readonly IElementAnimationsProvider _animationsProvider;
+
+    public AnimationKeyframeErrorSource(IElementAnimationsProvider animationsProvider)
+    {
+        _animationsProvider = animationsProvider;
+    }
+
+    /// <inheritdoc/>
+    public IEnumerable<ErrorResult> GetErrors(ElementSave element, GumProjectSave project)
+    {
+        ElementAnimationsSave? animations = _animationsProvider.GetAnimationsFor(element, project);
+        if (animations == null)
+        {
+            yield break;
+        }
+
+        foreach (AnimationSave animation in animations.Animations)
+        {
+            foreach (AnimatedStateSave keyframe in animation.States)
+            {
+                if (!string.IsNullOrEmpty(keyframe.StateName) && !StateExists(keyframe.StateName, element))
+                {
+                    yield return new ErrorResult
+                    {
+                        ElementName = element.Name,
+                        Message = $"Animation '{animation.Name}' keyframe at time {keyframe.Time} " +
+                                  $"references state '{keyframe.StateName}' which does not exist.",
+                        Severity = ErrorSeverity.Error
+                    };
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Mirrors the State Animation plugin's categorized-name lookup: a keyframe's
+    /// <c>StateName</c> is either "Category/State" or a top-level state name.
+    /// </summary>
+    private static bool StateExists(string categorizedStateName, ElementSave element)
+    {
+        int slashIndex = categorizedStateName.IndexOf('/');
+        if (slashIndex >= 0)
+        {
+            string categoryName = categorizedStateName.Substring(0, slashIndex);
+            string stateName = categorizedStateName.Substring(slashIndex + 1);
+            StateSaveCategory? category = element.Categories.FirstOrDefault(item => item.Name == categoryName);
+            return category != null && category.States.Any(item => item.Name == stateName);
+        }
+
+        return element.States.Any(item => item.Name == categorizedStateName);
+    }
+}

--- a/Tools/Gum.ProjectServices/FileElementAnimationsProvider.cs
+++ b/Tools/Gum.ProjectServices/FileElementAnimationsProvider.cs
@@ -1,0 +1,67 @@
+using Gum.DataTypes;
+using Gum.ProjectServices.CodeGeneration;
+using Gum.StateAnimation.SaveClasses;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using ToolsUtilities;
+
+namespace Gum.ProjectServices;
+
+/// <summary>
+/// Loads each element's animations from its <c>.ganx</c> on disk, caching the deserialized result
+/// and invalidating it by the file's last-write time. Editing an element's <em>states</em> (the
+/// common way an animation error is introduced) does not touch the <c>.ganx</c>, so those checks
+/// hit the cache; only editing an animation itself re-reads. Suitable as an app-lifetime singleton
+/// (tool) or a per-run instance (CLI).
+/// </summary>
+public class FileElementAnimationsProvider : IElementAnimationsProvider
+{
+    private readonly Dictionary<string, CachedAnimations> _cache = new Dictionary<string, CachedAnimations>();
+
+    /// <inheritdoc/>
+    public ElementAnimationsSave? GetAnimationsFor(ElementSave element, GumProjectSave project)
+    {
+        if (string.IsNullOrEmpty(project?.FullFileName))
+        {
+            return null;
+        }
+
+        string projectDirectory = FileManager.GetDirectory(project.FullFileName);
+        FilePath? elementXmlPath = ElementFilePathHelper.GetFullPathXmlFile(element, projectDirectory);
+        if (elementXmlPath == null)
+        {
+            return null;
+        }
+
+        FilePath animationFilePath = elementXmlPath.RemoveExtension() + "Animations.ganx";
+        if (!animationFilePath.Exists())
+        {
+            return null;
+        }
+
+        string fullPath = animationFilePath.FullPath;
+        DateTime lastWriteUtc = File.GetLastWriteTimeUtc(fullPath);
+
+        if (_cache.TryGetValue(fullPath, out CachedAnimations cached) && cached.LastWriteUtc == lastWriteUtc)
+        {
+            return cached.Animations;
+        }
+
+        ElementAnimationsSave animations = FileManager.XmlDeserialize<ElementAnimationsSave>(fullPath);
+        _cache[fullPath] = new CachedAnimations(lastWriteUtc, animations);
+        return animations;
+    }
+
+    private readonly struct CachedAnimations
+    {
+        public CachedAnimations(DateTime lastWriteUtc, ElementAnimationsSave animations)
+        {
+            LastWriteUtc = lastWriteUtc;
+            Animations = animations;
+        }
+
+        public DateTime LastWriteUtc { get; }
+        public ElementAnimationsSave Animations { get; }
+    }
+}

--- a/Tools/Gum.ProjectServices/IElementAnimationsProvider.cs
+++ b/Tools/Gum.ProjectServices/IElementAnimationsProvider.cs
@@ -1,0 +1,18 @@
+using Gum.DataTypes;
+using Gum.StateAnimation.SaveClasses;
+
+namespace Gum.ProjectServices;
+
+/// <summary>
+/// Supplies an element's animation data (its deserialized <c>.ganx</c>) to headless consumers such
+/// as the error checker, decoupling them from how and where the data is loaded (disk, in-memory
+/// cache, etc.). Implementations may cache; callers should not assume a fresh disk read per call.
+/// </summary>
+public interface IElementAnimationsProvider
+{
+    /// <summary>
+    /// Returns the animations defined for <paramref name="element"/> in the given project, or
+    /// <c>null</c> if the element has no animation data.
+    /// </summary>
+    ElementAnimationsSave? GetAnimationsFor(ElementSave element, GumProjectSave project);
+}


### PR DESCRIPTION
## Summary

Reframed fix for #3293. Animation "keyframe references a missing state" errors were detected **only** through the State Animation plugin's per-selection view model, so the tree `!` (and Errors tab) missed them on project open and didn't refresh when you caused one — you had to (re)select the element. This moves detection into the **headless per-element error checker** so the indicator is correct independent of selection.

An earlier prototype refreshed the indicator on selection; that was a bandaid (it doesn't satisfy "show at a glance on open" or "update the moment you cause an error") and has been reverted.

## What it does

- **`AnimationKeyframeErrorSource`** (`IAdditionalErrorSource`) validates each animation state keyframe against the element's states/categories and reports dangling references. Pure logic, fed animation data via an injected **`IElementAnimationsProvider`** — unit-tested with a mocked provider.
- **`FileElementAnimationsProvider`** loads each element's `.ganx` from disk (path via `ElementFilePathHelper`) and **caches by last-write time**. Editing *states* (the usual way you introduce one of these errors) doesn't touch the `.ganx`, so those checks hit the cache against the live in-memory element; only editing an *animation* re-reads. Addresses the "won't this re-load `.ganx` over and over" perf concern.
- **Wiring:** registered in the tool DI (`Builder.cs`) as singletons (cache persists app-wide) and collected into the headless checker; also wired into `gumcli check` so CI catches dangling references. Deliberately **not** in `gumcli codegen` (a dangling keyframe shouldn't block code generation).
- **De-dup:** `MainStateAnimationPlugin` no longer contributes these errors via `GetAllErrors` — the headless source owns them now, so the selected element won't get duplicates.

Result: (1) on project open, every element with a dangling animation reference shows `!` at a glance; (2) removing/renaming a referenced state updates `!` immediately via the existing per-edit refreshes. Because it reads disk/cache rather than the view model, it's also robust to the view-model mangling in #3383.

## Tests

- `AnimationKeyframeErrorSourceTests` (4) — missing/valid categorized + uncategorized states, no-animations case (mocked provider).
- `FileElementAnimationsProviderTests` (3) — path resolution (`.ganx` written to the convention path independently), no-file, cache reuse.
- `AnimationStateRenameErrorTests` (4) + `InternalsVisibleTo` — characterize the plugin/#3383 rename behavior (kept as the foundation for #3383).
- Full suites green: `Gum.ProjectServices.Tests` 316, `StateAnimationPlugin` tool tests 19, `AllPluginsCompositionTests` 1. `GumFull.sln` + `Gum.Cli` build clean.

## Deferred (no silent caps)

- Sub-animation references (`AnimationSave.Animations`) are not yet validated — only state keyframes.
- A `GUM0005` code + docs heading for the new error (left `Code = null` for now to avoid the docs-heading gate).

## Related

- #3383 — renaming a state should cascade to animation keyframe references (separate correctness bug; this PR makes the *indicator* correct regardless).

Closes #3293

🤖 Generated with [Claude Code](https://claude.com/claude-code)
