### PR TITLE
Make missing-state keyframe error readable in both themes and move it to the top (#3385)

### DIFF
--- a/Gum/StateAnimationPlugin/Views/StateView.xaml
+++ b/Gum/StateAnimationPlugin/Views/StateView.xaml
@@ -33,13 +33,29 @@
                 HorizontalAlignment="Left"
                 VerticalAlignment="Top" />
 
+            <!--  Rendered as Error-colored foreground text (not a colored background block):
+                  Frb.Colors.Error flips lightness between light/dark themes, so no single
+                  foreground reads on it as a background. This matches how errors are shown
+                  elsewhere in the app and stays readable in both themes. See issue #3385.  -->
+            <TextBlock
+                x:Name="NotFoundLabel"
+                Grid.Row="0"
+                Grid.Column="0"
+                Grid.ColumnSpan="2"
+                Margin="0,0,0,2"
+                FontWeight="Bold"
+                Foreground="{DynamicResource Frb.Brushes.Error}"
+                Text="Could not find state or animation"
+                TextWrapping="Wrap"
+                Visibility="{Binding HasInvalidStateVisibility, TargetNullValue=Collapsed, FallbackValue=Collapsed}" />
+
             <!--<Label Grid.Row="0" x:Name="NameLabel" Grid.ColumnSpan="2" Content="{Binding DisplayName, FallbackValue=StateName}"></Label>-->
             <!--  Editable so a renamed/deleted referenced state can't be coerced to null by the
                   Selector (which would collapse a broken state keyframe into an event). Text is a
                   plain string binding, unconstrained by the item list. See issue #3386.  -->
             <ComboBox
                 x:Name="StateComboBox"
-                Grid.Row="0"
+                Grid.Row="1"
                 Grid.Column="0"
                 Grid.ColumnSpan="2"
                 Margin="0,0,0,1"
@@ -50,34 +66,26 @@
                 Visibility="{Binding StateComboBoxVisibility}" />
 
             <TextBlock
-                Grid.Row="1"
+                Grid.Row="2"
                 Grid.Column="0"
                 Margin="0,0,4,0"
                 VerticalAlignment="Center"
                 Text="Time" />
 
             <TextBlock
-                Grid.Row="2"
+                Grid.Row="3"
                 Grid.Column="0"
                 Margin="0,0,4,0"
                 VerticalAlignment="Center"
                 Text="Interpolation Type"
                 Visibility="{Binding InterpolationElementVisibility}" />
             <TextBlock
-                Grid.Row="3"
+                Grid.Row="4"
                 Grid.Column="0"
                 Margin="0,0,4,0"
                 VerticalAlignment="Center"
                 Text="In/Out"
                 Visibility="{Binding InterpolationElementVisibility}" />
-            <TextBlock
-                x:Name="NotFoundLabel"
-                Grid.Row="4"
-                Grid.Column="0"
-                Grid.ColumnSpan="2"
-                Background="{DynamicResource Frb.Brushes.Error}"
-                Text="Could not find state or animation"
-                Visibility="{Binding HasInvalidStateVisibility, TargetNullValue=Collapsed, FallbackValue=Collapsed}" />
 
             <TextBlock
                 Grid.Row="5"
@@ -89,7 +97,7 @@
                 TextWrapping="Wrap" />
             <TextBox
                 x:Name="TimeTextBox"
-                Grid.Row="1"
+                Grid.Row="2"
                 Grid.Column="1"
                 Margin="0,1"
                 HorizontalContentAlignment="Center"
@@ -99,7 +107,7 @@
 
             <ComboBox
                 x:Name="InterpolationTypeComboBox"
-                Grid.Row="2"
+                Grid.Row="3"
                 Grid.Column="1"
                 Margin="0,1"
                 VerticalContentAlignment="Center"
@@ -107,7 +115,7 @@
                 Visibility="{Binding InterpolationElementVisibility}" />
             <ComboBox
                 x:Name="EasingTypeComboBox"
-                Grid.Row="3"
+                Grid.Row="4"
                 Grid.Column="1"
                 Margin="0,1"
                 VerticalAlignment="Center"


### PR DESCRIPTION
## Summary

Fixes the missing-state keyframe error label in the animation keyframe editor (`StateView.xaml`):

1. **Readable in both themes.** The label used `Frb.Brushes.Error` as a **Background** (a light pink in dark mode) with the default near-white foreground — unreadable in dark mode. `Frb.Colors.Error` flips lightness between themes (light: dark red `#C62828`, dark: light pink `#EF9A9A`), so no single foreground reads on it as a background. Now it renders the way every other error in the app does: **bold Error-colored foreground text, no background block** — theme-safe by construction.
2. **Moved to the top.** Relocated from `Grid.Row="4"` (under the In/Out field) to `Grid.Row="0"`, above the state ComboBox, since it is critical context. Other rows shifted down by one.

### Note on approach

The issue offered two options: pick a foreground that reads on the pink background, or use a dedicated error style. I took the second — a hand-picked foreground can't contrast both a dark-red and a light-pink background, so the foreground-text treatment is the robust, convention-matching fix.

Manual test: needed — visual only (XAML). Open a project with an animation keyframe referencing a missing state; confirm the red "Could not find state or animation" text appears at the top of the keyframe editor and is readable in both light and dark themes.

Closes #3385

🤖 Generated with [Claude Code](https://claude.com/claude-code)
