### PR TITLE
Gate net9.0 mobile TFMs on a .NET 9+ SDK so net8 source-linkers restore cleanly

### DIFF
--- a/MonoGameGum/MonoGameGum.csproj
+++ b/MonoGameGum/MonoGameGum.csproj
@@ -6,10 +6,18 @@
 			installed. ExcludeIOS=true skips the iOS target (no iOS workload needed);
 			ExcludeAndroid=true skips the Android target (no Android workload needed). CI uses
 			both escape hatches because the release runner only has the base .NET SDK installed.
+
+			The mobile targets are net9.0-* and are additionally gated on the active SDK being
+			.NET 9+. A .NET 8 SDK cannot evaluate a net9.0-* TFM at all (NETSDK1139), and that
+			evaluation happens during NuGet restore — where ProjectReference AdditionalProperties
+			like ExcludeIOS do NOT flow — so source-linkers pinned to the .NET 8 SDK would
+			otherwise break on restore before the build-time escape hatches ever apply. The
+			SDK gate keeps net8.0-SDK restores clean while net9+ SDK builds still get the mobile
+			TFMs.
 		-->
 		<TargetFrameworks>net8.0</TargetFrameworks>
-		<TargetFrameworks Condition="'$(ExcludeIOS)' != 'true'">$(TargetFrameworks);net9.0-ios</TargetFrameworks>
-		<TargetFrameworks Condition="'$(ExcludeAndroid)' != 'true'">$(TargetFrameworks);net9.0-android</TargetFrameworks>
+		<TargetFrameworks Condition="'$(ExcludeIOS)' != 'true' AND $([MSBuild]::VersionGreaterThanOrEquals('$(NETCoreSdkVersion)', '9.0'))">$(TargetFrameworks);net9.0-ios</TargetFrameworks>
+		<TargetFrameworks Condition="'$(ExcludeAndroid)' != 'true' AND $([MSBuild]::VersionGreaterThanOrEquals('$(NETCoreSdkVersion)', '9.0'))">$(TargetFrameworks);net9.0-android</TargetFrameworks>
 		<ImplicitUsings>disable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>


### PR DESCRIPTION
## Summary

Gates the `net9.0-ios` / `net9.0-android` target frameworks on the active SDK being .NET 9+, so consumers pinned to the **.NET 8 SDK** can restore `MonoGameGum.csproj` cleanly.

### Problem

The mobile TFMs were added to `TargetFrameworks` gated only on the existing `ExcludeIOS` / `ExcludeAndroid` build-time escape hatches. Those flags are `ProjectReference` `AdditionalProperties`, which do **not** flow through NuGet **restore**. A .NET 8 SDK cannot evaluate a `net9.0-*` TFM at all (NETSDK1139), and that evaluation happens during restore — so a source-linking consumer pinned to the .NET 8 SDK (FRB, the link-to-source scratch templates) breaks on restore *before* the `ExcludeIOS` hatch can ever apply.

### Fix

Add an SDK-version gate to the mobile TFM conditions:

```
Condition="'$(ExcludeIOS)' != 'true' AND $([MSBuild]::VersionGreaterThanOrEquals('$(NETCoreSdkVersion)', '9.0'))"
```

`net9+` SDK builds still get the mobile targets; `net8`-SDK restores skip them cleanly instead of erroring. Additive and safe — the only behavior that changes is sub-9 SDK restores, which previously errored.

Manual test: not needed — build/restore plumbing; verified by `GumFull.sln` building green and unchanged behavior on a .NET 9+ SDK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
