### PR TITLE
Focus the animation-name textbox when the New Animation popup opens (#3390)

### DIFF
--- a/Gum/StateAnimationPlugin/Views/AddAnimationDialogView.xaml
+++ b/Gum/StateAnimationPlugin/Views/AddAnimationDialogView.xaml
@@ -19,7 +19,7 @@
     </UserControl.Resources>
     <StackPanel Margin="4">
         <TextBlock Margin="0,0,0,4" Text="Animation name:" />
-        <TextBox Margin="0,0,0,8" Text="{Binding Name, UpdateSourceTrigger=PropertyChanged}" />
+        <TextBox x:Name="NameTextBox" Margin="0,0,0,8" Text="{Binding Name, UpdateSourceTrigger=PropertyChanged}" />
 
         <TextBlock
             Margin="0,0,0,8"

--- a/Gum/StateAnimationPlugin/Views/AddAnimationDialogView.xaml.cs
+++ b/Gum/StateAnimationPlugin/Views/AddAnimationDialogView.xaml.cs
@@ -13,5 +13,10 @@ public partial class AddAnimationDialogView : UserControl
     public AddAnimationDialogView()
     {
         InitializeComponent();
+        Loaded += (_, _) =>
+        {
+            NameTextBox.Focus();
+            NameTextBox.SelectAll();
+        };
     }
 }


### PR DESCRIPTION
Fixes the New Animation popup not giving keyboard focus to its name textbox — users had to click the field before they could type.

`AddAnimationDialogView`'s code-behind only called `InitializeComponent()`. Every other comparable dialog (`GetUserStringDialogView`) focuses its textbox on `Loaded`; this one didn't. Now it focuses (and selects) the textbox on `Loaded`, matching that pattern.

Closes #3390

🤖 Generated with [Claude Code](https://claude.com/claude-code)
