### PR TITLE
Refresh animation keyframe errors after deleting a category (#3392)

### DIFF
--- a/Gum/StateAnimationPlugin/MainStateAnimationPlugin.cs
+++ b/Gum/StateAnimationPlugin/MainStateAnimationPlugin.cs
@@ -159,6 +159,11 @@ public class MainStateAnimationPlugin : PluginBase
 
         this.CategoryRename += HandleCategoryRename;
 
+        // Deleting a whole category (and its states) doesn't fire the granular StateDelete event, so
+        // recompute the view model afterward — otherwise a keyframe that referenced a state in the
+        // deleted category keeps its non-error icon until the element is reselected (issue #3392).
+        this.CategoryDelete += HandleCategoryDelete;
+
         this.ElementRename += HandleElementRename;
         this.ElementDuplicate += HandleElementDuplicate;
 
@@ -311,6 +316,11 @@ public class MainStateAnimationPlugin : PluginBase
     }
 
     private void HandleStateDelete(StateSave state)
+    {
+        RefreshViewModel();
+    }
+
+    private void HandleCategoryDelete(StateSaveCategory category)
     {
         RefreshViewModel();
     }

--- a/Gum/StateAnimationPlugin/MainStateAnimationPlugin.cs
+++ b/Gum/StateAnimationPlugin/MainStateAnimationPlugin.cs
@@ -501,9 +501,21 @@ public class MainStateAnimationPlugin : PluginBase
 
     private void RefreshAvailableStates()
     {
-        var states = new List<string>();
+        AvailableStates.ReplaceWith(GetAvailableStates(_selectedState.SelectedElement, _viewModel));
+    }
 
-        var element = _selectedState.SelectedElement;
+    /// <summary>
+    /// Builds the state names shown in each keyframe's state ComboBox: every state on the element,
+    /// plus any state still referenced by a keyframe even though it no longer exists on the element.
+    /// Keeping a referenced-but-missing state in the list matters because the ComboBox is editable
+    /// with its Text bound to the keyframe's StateName — if the referenced item left the ItemsSource,
+    /// the ComboBox would coerce its Text (and thus StateName) to empty, collapsing a broken state
+    /// keyframe into an event (issue #3392). The keyframe stays flagged as broken via
+    /// HasValidState/RefreshErrors, which is computed against the element, not this list.
+    /// </summary>
+    internal static List<string> GetAvailableStates(ElementSave? element, ElementAnimationsViewModel? viewModel)
+    {
+        var states = new List<string>();
 
         if (element != null)
         {
@@ -515,7 +527,25 @@ public class MainStateAnimationPlugin : PluginBase
             }
         }
 
-        AvailableStates.ReplaceWith(states);
+        // Keep any state still referenced by a keyframe even though it no longer exists on the
+        // element (e.g. its category was just deleted). The editable state ComboBox binds its Text to
+        // the keyframe's StateName; if the referenced item left this list it would coerce StateName to
+        // empty, collapsing the broken state keyframe into an event (issue #3392).
+        if (viewModel != null)
+        {
+            foreach (var animation in viewModel.Animations)
+            {
+                foreach (var keyframe in animation.Keyframes)
+                {
+                    if (!string.IsNullOrEmpty(keyframe.StateName) && !states.Contains(keyframe.StateName))
+                    {
+                        states.Add(keyframe.StateName);
+                    }
+                }
+            }
+        }
+
+        return states;
     }
 
     private void CreateViewModel()

--- a/Tool/Tests/GumToolUnitTests/Plugins/StateAnimationPlugin/AnimationStateRenameErrorTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/StateAnimationPlugin/AnimationStateRenameErrorTests.cs
@@ -10,6 +10,7 @@ using StateAnimationPlugin;
 using StateAnimationPlugin.Managers;
 using StateAnimationPlugin.ViewModels;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using Xunit;
@@ -51,6 +52,29 @@ public class AnimationStateRenameErrorTests : BaseTestClass
 
             viewModel.RefreshErrors(element);
             viewModel.GetErrors().ShouldBeEmpty();
+        });
+    }
+
+    [Fact]
+    public void GetAvailableStates_PreservesKeyframeStateName_WhenItsCategoryWasDeleted()
+    {
+        // Deleting a category recomputes the available-state list bound to the editable state
+        // ComboBox. If the still-referenced "Cat/Idle" were dropped from that list, the ComboBox
+        // would coerce its Text (bound to StateName) to empty, collapsing the broken state keyframe
+        // into an event (flag icon) instead of showing the red broken-reference icon (issue #3392).
+        // GetAvailableStates must keep the referenced-but-missing state so the ComboBox holds its
+        // selection; brokenness is still reported separately via RefreshErrors/HasValidState.
+        RunOnSta(() =>
+        {
+            ComponentSave element = ElementWithCategorizedState("Cat", "Idle");
+            ElementAnimationsViewModel viewModel = CreateViewModelWith(
+                CreateAnimationWithKeyframes(Keyframe(stateName: "Cat/Idle")));
+
+            element.Categories.Clear();  // delete the whole category, as DeleteLogic does
+
+            List<string> availableStates = MainStateAnimationPlugin.GetAvailableStates(element, viewModel);
+
+            availableStates.ShouldContain("Cat/Idle");
         });
     }
 


### PR DESCRIPTION
## What

Two commits, both needed:

1. **Subscribe to `CategoryDelete`** — the State Animation plugin recomputes keyframe errors on `StateAdd/StateDelete/StateRename/.../AfterUndo` but not category delete, so a keyframe referencing a state in a deleted category kept its normal icon until the element was reselected. `CategoryDelete` already exists (`PluginBase.CategoryDelete`, raised from `DeleteLogic`); route it to `RefreshViewModel`, matching `HandleStateDelete`.

2. **Preserve the broken keyframe's `StateName`** — fix #1 exposed a coercion bug. `RefreshViewModel` → `RefreshAvailableStates` does `AvailableStates.ReplaceWith(...)`, which dropped the now-deleted state from the editable state ComboBox's `ItemsSource`. The editable ComboBox then coerced its `Text` (bound TwoWay to `StateName`) to empty, clearing `StateName` and collapsing the broken state keyframe into an *event* (flag icon) instead of the red broken-reference icon.

   Fix: extract the list-building into a testable static `GetAvailableStates` that keeps any state still referenced by a keyframe even when it no longer exists on the element, so the ComboBox holds its selection. Brokenness is still reported via `RefreshErrors`/`HasValidState` (computed against the element), so the red icon and "Could not find state" label still show.

## Tests

`GetAvailableStates_PreservesKeyframeStateName_WhenItsCategoryWasDeleted` (red → green) pins the VM-level contract: after a category delete the referenced state stays in the available-states list so the ComboBox can't drop it. The WPF coercion itself (Text → StateName) is verified manually. The `CategoryDelete` subscription is event wiring onto the already-tested `RefreshErrors` path (no unit seam for the plugin event), matching the precedent of the `AfterUndo` fix in #3389.

Closes #3392

🤖 Generated with [Claude Code](https://claude.com/claude-code)
