### PR TITLE
Add gum-issue-creation skill capturing issue-filing conventions

### DIFF
--- a/.claude/skills/gum-issue-creation/SKILL.md
+++ b/.claude/skills/gum-issue-creation/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: gum-issue-creation
+description: Conventions for filing GitHub issues in the Gum repo via gh. Triggers when the user asks to "log an issue", "create an issue", "file a bug", or otherwise capture a problem/idea as a GitHub issue (as opposed to fixing one).
+---
+
+# Creating Gum Issues
+
+Use `gh issue create` to file issues. Conventions:
+
+## Labels
+- **Bug reports get `--label bug`** (label exists, color `#fc2929`). Apply it at creation time.
+- The `bug` label is real and applies silently — don't second-guess it or omit it on later issues.
+
+## Multi-line bodies
+`gh` runs through the **Bash tool (bash, not PowerShell)** — do NOT use PowerShell here-strings (`@'...'@`); a stray `@` leaks onto the first body line. Write the body to a temp file and pass `--body-file`:
+
+```bash
+cat > /tmp/issue_body.md << 'EOF'
+...body...
+EOF
+gh issue create --title "..." --body-file /tmp/issue_body.md --label bug
+rm /tmp/issue_body.md
+```
+
+## Body structure
+Keep it scannable for a future implementer:
+- **Problem** — what's wrong / the user's report, verbatim intent preserved.
+- **Suggested improvement** (when applicable) — concrete target behavior or message.
+- **Source** — file:line pointer(s) found by a quick Grep, plus a one-line note on what the fix touches. A precise pointer turns a vague report into actionable work; spend a moment to find it.
+
+## Title
+Specific and self-describing — names the feature area and the gap (e.g. `Animation keyframe "Could not find state or animation" error should name the missing reference`), not a generic summary.
+
+After creating, report the issue URL back to the user.


### PR DESCRIPTION
## What

Adds a new `gum-issue-creation` skill (`.claude/skills/gum-issue-creation/SKILL.md`) that captures the conventions used when filing GitHub issues for Gum via `gh`.

## Why

These conventions were being applied ad hoc across several issue-filing requests. Checking them into a skill makes them discoverable (trigger-matched when the user asks to "log/create an issue"), versioned, and shared with collaborators.

## Conventions captured

- **Default `--label bug`** on bug reports (the label exists; don't second-guess it).
- **Use `--body-file`** with a temp file for multi-line bodies — never PowerShell here-strings, since `gh` runs through the bash tool and a stray `@` leaks onto the first line.
- **Body structure:** Problem / Suggested improvement / Source, with a `file:line` pointer found via a quick Grep so the report is actionable.
- **Specific, self-describing titles**; report the issue URL back to the user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
