### PR TITLE
Make animation edits undoable (fold into the element undo snapshot) + keyframe-delete prompt

### DIFF
--- a/.claude/skills/gum-tool-undo/SKILL.md
+++ b/.claude/skills/gum-tool-undo/SKILL.md
@@ -47,6 +47,12 @@ The undo system records changes to:
 - State additions, removals, and variable changes within states
 - Category additions and removals
 - Variable exposure and unexposure
+- **Element animations** (the `.ganx` sidecar) — folded into the element's `UndoSnapshot.Animations`
+  so an animation edit undoes **atomically** with the state rename/delete it was made next to (#3406).
+  Keyframes reference states by name, so the two are coupled and must restore together or the
+  reference desyncs. `ElementUndoStrategy` captures/diffs/applies animations through the headless
+  `IAnimationUndoProvider` seam; the animation plugin implements it (reading the live tab or the
+  `.ganx`) and flushes a record from its `HandleDataChange` choke point via an empty `RequestLock`.
 
 ## How Recording Works
 

--- a/Gum/Plugins/InternalPlugins/Undos/UndosViewModel.cs
+++ b/Gum/Plugins/InternalPlugins/Undos/UndosViewModel.cs
@@ -3,6 +3,7 @@ using Gum.DataTypes.Behaviors;
 using Gum.DataTypes.Variables;
 using Gum.Plugins.InternalPlugins.Undos;
 using Gum.Services;
+using Gum.StateAnimation.SaveClasses;
 using Gum.ToolStates;
 using Gum.Undo;
 using System;
@@ -190,14 +191,16 @@ namespace Gum.Plugins.Undos
 
                 var comparisonInformationDisplay = comparisonInformation.ToString();
 
-                if (string.IsNullOrEmpty(comparisonInformationDisplay))
-                {
-                    undoStringList.Insert(0, "Unknown Undo");
-                }
-                else
-                {
-                    undoStringList.Insert(0, comparisonInformation.ToString());
-                }
+                // The element diff above ignores animations (they live in the .ganx, not the element).
+                // Describe the action's animation change directly from its snapshot: UndoState.Animations
+                // is the pre-change state, RedoState.Animations the post-change state.
+                var animationDisplay = DescribeAnimationChange(undo.UndoState.Animations, undo.RedoState?.Animations);
+
+                var parts = new List<string>();
+                if (!string.IsNullOrEmpty(comparisonInformationDisplay)) parts.Add(comparisonInformationDisplay);
+                if (!string.IsNullOrEmpty(animationDisplay)) parts.Add(animationDisplay);
+
+                undoStringList.Insert(0, parts.Count > 0 ? string.Join("\n    ", parts) : "Unknown Undo");
 
                 _undoManager.ApplyUndoSnapshotToElement(undo.UndoState, selectedElementClone, false);
 
@@ -209,6 +212,41 @@ namespace Gum.Plugins.Undos
 
 
             return undoStringList;
+        }
+
+        /// <summary>
+        /// Describes how an action changed an element's animations, for the History tab. Compares the
+        /// snapshot's pre-change animations (<see cref="UndoSnapshot.Animations"/> on the undo state)
+        /// against the post-change animations (on the redo state). Returns an empty string when the
+        /// action did not touch animations.
+        /// </summary>
+        internal static string DescribeAnimationChange(ElementAnimationsSave? before, ElementAnimationsSave? after)
+        {
+            if (before == null && after == null)
+            {
+                return string.Empty;
+            }
+
+            var beforeAnimations = before?.Animations ?? new List<AnimationSave>();
+            var afterAnimations = after?.Animations ?? new List<AnimationSave>();
+
+            var beforeNames = beforeAnimations.Select(item => item.Name).ToHashSet();
+            var afterNames = afterAnimations.Select(item => item.Name).ToHashSet();
+
+            var added = afterAnimations.Where(item => !beforeNames.Contains(item.Name)).Select(item => item.Name).ToList();
+            var removed = beforeAnimations.Where(item => !afterNames.Contains(item.Name)).Select(item => item.Name).ToList();
+            var modified = afterAnimations
+                .Where(item => beforeNames.Contains(item.Name)
+                    && !FileManager.AreSaveObjectsEqual(item, beforeAnimations.First(other => other.Name == item.Name)))
+                .Select(item => item.Name)
+                .ToList();
+
+            var lines = new List<string>();
+            if (added.Count > 0) lines.Add($"Add animation: {string.Join(", ", added)}");
+            if (removed.Count > 0) lines.Add($"Remove animation: {string.Join(", ", removed)}");
+            if (modified.Count > 0) lines.Add($"Modify animation: {string.Join(", ", modified)}");
+
+            return string.Join("\n    ", lines);
         }
 
         private ElementSave GetSelectedElementClone()

--- a/Gum/Plugins/PluginManager.cs
+++ b/Gum/Plugins/PluginManager.cs
@@ -945,6 +945,10 @@ public class PluginManager : IPluginManager, IUndoPluginNotifier, IDeletePluginN
             // IFavoriteComponentManager, is already bridged above.
             batch.AddExportedValue<ICircularReferenceManager>(Locator.GetRequiredService<ICircularReferenceManager>());
 
+            // Animation undo (#3406): MainStateAnimationPlugin injects this to register itself as the
+            // live IAnimationUndoProvider with the already-constructed UndoManager/ElementUndoStrategy.
+            batch.AddExportedValue<IAnimationUndoProviderRegistrar>(Locator.GetRequiredService<IAnimationUndoProviderRegistrar>());
+
 
             var container = new CompositionContainer(catalog);
 

--- a/Gum/Services/Builder.cs
+++ b/Gum/Services/Builder.cs
@@ -148,6 +148,13 @@ file static class ServiceCollectionExtensions
         services.AddSingleton<ISelectedState, SelectedState>();
         services.AddSingleton<INameVerifier, NameVerifier>();
         services.AddSingleton<IUndoManager, UndoManager>();
+        // Late-bound seam for folding animation edits into the element undo snapshot (#3406). The relay
+        // is what UndoManager/ElementUndoStrategy receive at construction; the animation plugin registers
+        // itself as the real provider in its StartUp (via IAnimationUndoProviderRegistrar, bridged into
+        // the plugin MEF container). Both interfaces resolve to the one relay singleton.
+        services.AddSingleton<AnimationUndoProviderRelay>();
+        services.AddSingleton<IAnimationUndoProvider>(provider => provider.GetRequiredService<AnimationUndoProviderRelay>());
+        services.AddSingleton<IAnimationUndoProviderRegistrar>(provider => provider.GetRequiredService<AnimationUndoProviderRelay>());
         services.AddSingleton<IEditVariableService, EditVariableService>();
         services.AddSingleton<IDeleteVariableService, DeleteVariableService>();
         services.AddSingleton<IExposeVariableService, ExposeVariableService>();

--- a/Gum/StateAnimationPlugin/MainStateAnimationPlugin.cs
+++ b/Gum/StateAnimationPlugin/MainStateAnimationPlugin.cs
@@ -351,13 +351,84 @@ public class MainStateAnimationPlugin : PluginBase, IAnimationUndoProvider
 
     private void HandleAfterUndo()
     {
+        // Capture the selection before the forced rebuild below replaces the view model (and with it
+        // every AnimationViewModel/keyframe instance), then reselect by identity afterward so the
+        // user's animation + keyframe selection survives undo/redo — mirroring element-undo's state
+        // selection restore (#3406).
+        var selectedAnimationName = _viewModel?.SelectedAnimation?.Name;
+        var selectedKeyframe = _viewModel?.SelectedAnimation?.SelectedKeyframe;
+
         // Repaint the tab from the just-restored .ganx, then re-arm undo recording. The flag spanned
         // the .ganx write (ApplyAnimations) through this repaint so neither flushed a spurious undo.
         // forceReload bypasses CreateViewModel's same-element early-out: an in-place undo leaves the
         // selected element unchanged, so without forcing it the stale view model would survive and the
         // tab would keep showing the pre-undo animations until the element was reselected (#3406).
         RefreshViewModel(forceReload: true);
+
+        if (_viewModel != null)
+        {
+            var keyframeToReselect = RestoreAnimationSelection(_viewModel, selectedAnimationName, selectedKeyframe);
+
+            if (keyframeToReselect != null && _viewModel.SelectedAnimation is { } reselectedAnimation)
+            {
+                // Setting SelectedAnimation above rebinds the keyframes ListBox's ItemsSource, and that
+                // rebind resets its SelectedItem — writing null back through the two-way SelectedKeyframe
+                // binding — on the next layout pass. A synchronous assignment here would be clobbered by
+                // it, so defer the keyframe reselect to DispatcherPriority.Background, which runs after the
+                // rebind. Without this the keyframe (and the right-side property panel bound to it) is lost
+                // on undo even though the animation stays selected (#3406).
+                _mainWindow?.Dispatcher.BeginInvoke(
+                    new Action(() => reselectedAnimation.SelectedKeyframe = keyframeToReselect),
+                    System.Windows.Threading.DispatcherPriority.Background);
+            }
+        }
+
         _isApplyingUndo = false;
+    }
+
+    /// <summary>
+    /// Reselects the animation named <paramref name="animationName"/> on a freshly-rebuilt
+    /// <paramref name="viewModel"/> and returns the keyframe within it matching <paramref name="keyframe"/>
+    /// by content (for the caller to apply once the keyframes ListBox has rebound — see
+    /// <see cref="HandleAfterUndo"/>). Best-effort: a missing animation returns null with no selection
+    /// change; a missing keyframe returns null but the animation is still reselected — mirroring
+    /// element-undo's silent selection drop when the selected object no longer exists.
+    /// </summary>
+    internal static AnimatedKeyframeViewModel? RestoreAnimationSelection(ElementAnimationsViewModel viewModel,
+        string? animationName, AnimatedKeyframeViewModel? keyframe)
+    {
+        if (animationName == null)
+        {
+            return null;
+        }
+
+        var animation = viewModel.Animations.FirstOrDefault(item => item.Name == animationName);
+        if (animation == null)
+        {
+            return null;
+        }
+
+        viewModel.SelectedAnimation = animation;
+
+        if (keyframe == null)
+        {
+            return null;
+        }
+
+        return animation.Keyframes.FirstOrDefault(item => AreSameKeyframe(item, keyframe));
+    }
+
+    /// <summary>
+    /// Identity match for a keyframe across a view-model rebuild: same discriminator (state /
+    /// sub-animation / event name) and time. Used to reselect the previously-selected keyframe on the
+    /// new instances after an undo/redo reload.
+    /// </summary>
+    private static bool AreSameKeyframe(AnimatedKeyframeViewModel first, AnimatedKeyframeViewModel second)
+    {
+        return first.StateName == second.StateName
+            && first.AnimationName == second.AnimationName
+            && first.EventName == second.EventName
+            && first.Time == second.Time;
     }
 
     private void HandleStateAdd(StateSave state)

--- a/Gum/StateAnimationPlugin/MainStateAnimationPlugin.cs
+++ b/Gum/StateAnimationPlugin/MainStateAnimationPlugin.cs
@@ -367,33 +367,28 @@ public class MainStateAnimationPlugin : PluginBase, IAnimationUndoProvider
 
         if (_viewModel != null)
         {
-            var keyframeToReselect = RestoreAnimationSelection(_viewModel, selectedAnimationName, selectedKeyframe);
-
-            if (keyframeToReselect != null && _viewModel.SelectedAnimation is { } reselectedAnimation)
-            {
-                // Setting SelectedAnimation above rebinds the keyframes ListBox's ItemsSource, and that
-                // rebind resets its SelectedItem — writing null back through the two-way SelectedKeyframe
-                // binding — on the next layout pass. A synchronous assignment here would be clobbered by
-                // it, so defer the keyframe reselect to DispatcherPriority.Background, which runs after the
-                // rebind. Without this the keyframe (and the right-side property panel bound to it) is lost
-                // on undo even though the animation stays selected (#3406).
-                _mainWindow?.Dispatcher.BeginInvoke(
-                    new Action(() => reselectedAnimation.SelectedKeyframe = keyframeToReselect),
-                    System.Windows.Threading.DispatcherPriority.Background);
-            }
+            RestoreAnimationSelection(_viewModel, selectedAnimationName, selectedKeyframe);
         }
 
         _isApplyingUndo = false;
     }
 
     /// <summary>
-    /// Reselects the animation named <paramref name="animationName"/> on a freshly-rebuilt
-    /// <paramref name="viewModel"/> and returns the keyframe within it matching <paramref name="keyframe"/>
-    /// by content (for the caller to apply once the keyframes ListBox has rebound — see
-    /// <see cref="HandleAfterUndo"/>). Best-effort: a missing animation returns null with no selection
-    /// change; a missing keyframe returns null but the animation is still reselected — mirroring
-    /// element-undo's silent selection drop when the selected object no longer exists.
+    /// Reselects, on a freshly-rebuilt <paramref name="viewModel"/>, the animation named
+    /// <paramref name="animationName"/> and the keyframe within it matching <paramref name="keyframe"/>
+    /// by content. Returns the matched keyframe (or null). Best-effort: a missing animation returns null
+    /// with no selection change; a missing keyframe reselects the animation with no keyframe selected —
+    /// mirroring element-undo's silent selection drop when the selected object no longer exists.
     /// </summary>
+    /// <remarks>
+    /// The keyframe is selected on the animation <em>before</em> the animation is made the active
+    /// SelectedAnimation. That ordering matters: setting SelectedAnimation rebinds the keyframes
+    /// ListBox's ItemsSource, and the ListBox initializes its SelectedItem from the (two-way) bound
+    /// SelectedKeyframe at bind time. If SelectedKeyframe is still null then, the ListBox settles on no
+    /// selection and a later assignment gets reset; pre-setting it means the ListBox binds straight to
+    /// the right, already-present keyframe — so the selection (and the right-side property panel) sticks
+    /// without any dispatcher timing games (#3406).
+    /// </remarks>
     internal static AnimatedKeyframeViewModel? RestoreAnimationSelection(ElementAnimationsViewModel viewModel,
         string? animationName, AnimatedKeyframeViewModel? keyframe)
     {
@@ -408,14 +403,14 @@ public class MainStateAnimationPlugin : PluginBase, IAnimationUndoProvider
             return null;
         }
 
+        var matched = keyframe == null
+            ? null
+            : animation.Keyframes.FirstOrDefault(item => AreSameKeyframe(item, keyframe));
+
+        animation.SelectedKeyframe = matched;
         viewModel.SelectedAnimation = animation;
 
-        if (keyframe == null)
-        {
-            return null;
-        }
-
-        return animation.Keyframes.FirstOrDefault(item => AreSameKeyframe(item, keyframe));
+        return matched;
     }
 
     /// <summary>

--- a/Gum/StateAnimationPlugin/MainStateAnimationPlugin.cs
+++ b/Gum/StateAnimationPlugin/MainStateAnimationPlugin.cs
@@ -354,9 +354,16 @@ public class MainStateAnimationPlugin : PluginBase, IAnimationUndoProvider
         // Capture the selection before the forced rebuild below replaces the view model (and with it
         // every AnimationViewModel/keyframe instance), then reselect by identity afterward so the
         // user's animation + keyframe selection survives undo/redo — mirroring element-undo's state
-        // selection restore (#3406).
-        var selectedAnimationName = _viewModel?.SelectedAnimation?.Name;
-        var selectedKeyframe = _viewModel?.SelectedAnimation?.SelectedKeyframe;
+        // selection restore (#3406). Index + count are captured alongside the keyframe so the reselect
+        // can fall back to position when the undo reverted the selected keyframe's own value (see
+        // RestoreAnimationSelection).
+        var selectedAnimation = _viewModel?.SelectedAnimation;
+        var selectedKeyframe = selectedAnimation?.SelectedKeyframe;
+        var selection = new AnimationSelectionState(
+            selectedAnimation?.Name,
+            selectedKeyframe,
+            selectedKeyframe != null ? selectedAnimation!.Keyframes.IndexOf(selectedKeyframe) : -1,
+            selectedAnimation?.Keyframes.Count ?? 0);
 
         // Repaint the tab from the just-restored .ganx, then re-arm undo recording. The flag spanned
         // the .ganx write (ApplyAnimations) through this repaint so neither flushed a spurious undo.
@@ -367,18 +374,27 @@ public class MainStateAnimationPlugin : PluginBase, IAnimationUndoProvider
 
         if (_viewModel != null)
         {
-            RestoreAnimationSelection(_viewModel, selectedAnimationName, selectedKeyframe);
+            RestoreAnimationSelection(_viewModel, selection);
         }
 
         _isApplyingUndo = false;
     }
 
+    /// <summary>The animation/keyframe selection captured before an undo rebuilds the view model.</summary>
+    internal readonly record struct AnimationSelectionState(
+        string? AnimationName,
+        AnimatedKeyframeViewModel? Keyframe,
+        int KeyframeIndex,
+        int KeyframeCount);
+
     /// <summary>
-    /// Reselects, on a freshly-rebuilt <paramref name="viewModel"/>, the animation named
-    /// <paramref name="animationName"/> and the keyframe within it matching <paramref name="keyframe"/>
-    /// by content. Returns the matched keyframe (or null). Best-effort: a missing animation returns null
-    /// with no selection change; a missing keyframe reselects the animation with no keyframe selected —
-    /// mirroring element-undo's silent selection drop when the selected object no longer exists.
+    /// Reselects, on a freshly-rebuilt <paramref name="viewModel"/>, the animation and keyframe captured
+    /// in <paramref name="selection"/>. The keyframe is matched by content; if that fails because the
+    /// undo reverted the selected keyframe's <em>own</em> value (e.g. its time), it falls back to the
+    /// captured index — but only when the keyframe count is unchanged, so an add/delete undo (which
+    /// changes the count) drops the selection rather than grabbing a neighbor. Returns the matched
+    /// keyframe (or null). Best-effort, mirroring element-undo's silent selection drop when the selected
+    /// object no longer exists.
     /// </summary>
     /// <remarks>
     /// The keyframe is selected on the animation <em>before</em> the animation is made the active
@@ -390,22 +406,32 @@ public class MainStateAnimationPlugin : PluginBase, IAnimationUndoProvider
     /// without any dispatcher timing games (#3406).
     /// </remarks>
     internal static AnimatedKeyframeViewModel? RestoreAnimationSelection(ElementAnimationsViewModel viewModel,
-        string? animationName, AnimatedKeyframeViewModel? keyframe)
+        AnimationSelectionState selection)
     {
-        if (animationName == null)
+        if (selection.AnimationName == null)
         {
             return null;
         }
 
-        var animation = viewModel.Animations.FirstOrDefault(item => item.Name == animationName);
+        var animation = viewModel.Animations.FirstOrDefault(item => item.Name == selection.AnimationName);
         if (animation == null)
         {
             return null;
         }
 
-        var matched = keyframe == null
-            ? null
-            : animation.Keyframes.FirstOrDefault(item => AreSameKeyframe(item, keyframe));
+        AnimatedKeyframeViewModel? matched = null;
+        if (selection.Keyframe != null)
+        {
+            matched = animation.Keyframes.FirstOrDefault(item => AreSameKeyframe(item, selection.Keyframe));
+
+            if (matched == null
+                && animation.Keyframes.Count == selection.KeyframeCount
+                && selection.KeyframeIndex >= 0
+                && selection.KeyframeIndex < animation.Keyframes.Count)
+            {
+                matched = animation.Keyframes[selection.KeyframeIndex];
+            }
+        }
 
         animation.SelectedKeyframe = matched;
         viewModel.SelectedAnimation = animation;

--- a/Gum/StateAnimationPlugin/MainStateAnimationPlugin.cs
+++ b/Gum/StateAnimationPlugin/MainStateAnimationPlugin.cs
@@ -13,6 +13,7 @@ using Gum.Responses;
 using Gum.Services.Dialogs;
 using Gum.StateAnimation.SaveClasses;
 using Gum.ToolStates;
+using Gum.Undo;
 using Gum.Wireframe;
 using StateAnimationPlugin.Managers;
 using StateAnimationPlugin.ViewModels;
@@ -32,14 +33,20 @@ using System.Windows.Controls;
 namespace StateAnimationPlugin;
 
 [Export(typeof(PluginBase))]
-public class MainStateAnimationPlugin : PluginBase
+public class MainStateAnimationPlugin : PluginBase, IAnimationUndoProvider
 {
     private readonly ISelectedState _selectedState;
     private readonly INameVerifier _nameVerifier;
     private readonly IMessenger _messenger;
     private readonly IOutputManager _outputManager;
     private readonly IFileWatchManager _fileWatchManager;
+    private readonly IUndoManager _undoManager;
+    private readonly IAnimationUndoProviderRegistrar _animationUndoProviderRegistrar;
     private readonly Func<ElementAnimationsViewModel> _animationVmFactory;
+
+    // True while an undo/redo is restoring animations to disk and the tab is repainting from it.
+    // Guards HandleDataChange from flushing a *new* undo for the change the undo itself just made.
+    private bool _isApplyingUndo;
 
     #region Fields
     private readonly DuplicateService _duplicateService;
@@ -100,7 +107,9 @@ public class MainStateAnimationPlugin : PluginBase
         IFileWatchManager fileWatchManager,
         IProjectState projectState,
         IProjectManager projectManager,
-        IWireframeObjectManager wireframeObjectManager)
+        IWireframeObjectManager wireframeObjectManager,
+        IUndoManager undoManager,
+        IAnimationUndoProviderRegistrar animationUndoProviderRegistrar)
     {
         _selectedState = selectedState;
         _nameVerifier = nameVerifier;
@@ -110,6 +119,8 @@ public class MainStateAnimationPlugin : PluginBase
         _projectState = projectState;
         _projectManager = projectManager;
         _wireframeObjectManager = wireframeObjectManager;
+        _undoManager = undoManager;
+        _animationUndoProviderRegistrar = animationUndoProviderRegistrar;
 
         _animationFilePathService = new AnimationFilePathService(_selectedState);
         _duplicateService = new DuplicateService(_dialogService, _projectManager);
@@ -131,10 +142,43 @@ public class MainStateAnimationPlugin : PluginBase
 
     public override void StartUp()
     {
+        // Register as the live animation provider so the element undo strategy can fold this
+        // element's animations into its snapshot (#3406). UndoManager was constructed at DI time,
+        // before any plugin existed, so it holds a relay that this call now points at us.
+        _animationUndoProviderRegistrar.Register(this);
+
         CreateMenuItems();
         CreateAnimationWindow();
         AssignEvents();
     }
+
+    #region IAnimationUndoProvider
+
+    ElementAnimationsSave? IAnimationUndoProvider.GetCurrentAnimations(ElementSave element)
+    {
+        // Prefer the live tab contents when this element is the one loaded; otherwise read the .ganx.
+        ElementAnimationsSave? save = _viewModel?.Element == element
+            ? _viewModel!.ToSave()
+            : _animationCollectionViewModelManager.GetElementAnimationsSave(element);
+
+        // Normalize "no animations" to null so a null-vs-null diff compares equal (no spurious undo).
+        if (save == null || save.Animations.Count == 0)
+        {
+            return null;
+        }
+
+        return save;
+    }
+
+    void IAnimationUndoProvider.ApplyAnimations(ElementSave element, ElementAnimationsSave animations)
+    {
+        // Suppress undo recording for the write itself and the after-undo tab repaint that follows
+        // (HandleAfterUndo clears the flag once the repaint is done).
+        _isApplyingUndo = true;
+        _animationCollectionViewModelManager.SaveElementAnimations(element, animations);
+    }
+
+    #endregion
 
     private void CreateMenuItems()
     {
@@ -307,7 +351,10 @@ public class MainStateAnimationPlugin : PluginBase
 
     private void HandleAfterUndo()
     {
+        // Repaint the tab from the just-restored .ganx, then re-arm undo recording. The flag spanned
+        // the .ganx write (ApplyAnimations) through this repaint so neither flushed a spurious undo.
         RefreshViewModel();
+        _isApplyingUndo = false;
     }
 
     private void HandleStateAdd(StateSave state)
@@ -692,6 +739,17 @@ public class MainStateAnimationPlugin : PluginBase
             catch (Exception exc)
             {
                 _guiCommands.PrintOutput($"Could not save animations for {_viewModel?.Element}:\n{exc}");
+            }
+
+            // Fold this animation edit into the selected element's undo timeline. Opening and disposing
+            // an undo lock fires the element strategy's TryRecord, whose baseline (captured on selection
+            // / after the previous record) now differs from the just-saved animations, so it records the
+            // change atomically with any element edit and re-baselines. One mechanism covers every
+            // persisted gesture — keyframe add/delete/paste, time/interpolation/loop edits. Skipped while
+            // an undo is being applied, so restoring animations doesn't record a brand-new undo (#3406).
+            if (!_isApplyingUndo)
+            {
+                using (_undoManager.RequestLock()) { }
             }
 
             // The edit changed which states/animations the keyframes reference, so an animation

--- a/Gum/StateAnimationPlugin/MainStateAnimationPlugin.cs
+++ b/Gum/StateAnimationPlugin/MainStateAnimationPlugin.cs
@@ -353,7 +353,10 @@ public class MainStateAnimationPlugin : PluginBase, IAnimationUndoProvider
     {
         // Repaint the tab from the just-restored .ganx, then re-arm undo recording. The flag spanned
         // the .ganx write (ApplyAnimations) through this repaint so neither flushed a spurious undo.
-        RefreshViewModel();
+        // forceReload bypasses CreateViewModel's same-element early-out: an in-place undo leaves the
+        // selected element unchanged, so without forcing it the stale view model would survive and the
+        // tab would keep showing the pre-undo animations until the element was reselected (#3406).
+        RefreshViewModel(forceReload: true);
         _isApplyingUndo = false;
     }
 
@@ -534,11 +537,11 @@ public class MainStateAnimationPlugin : PluginBase, IAnimationUndoProvider
         }
     }
 
-    private void RefreshViewModel()
+    private void RefreshViewModel(bool forceReload = false)
     {
         RefreshAvailableStates();
 
-        CreateViewModel();
+        CreateViewModel(forceReload);
 
         if (_mainWindow != null)
         {
@@ -595,7 +598,20 @@ public class MainStateAnimationPlugin : PluginBase, IAnimationUndoProvider
         return states;
     }
 
-    private void CreateViewModel()
+    /// <summary>
+    /// Decides whether <see cref="CreateViewModel"/> should rebuild the view model from the element's
+    /// .ganx. Normally the view model is only reloaded when the selected element changes; an in-place
+    /// undo/redo restores the .ganx without changing the selection, so the after-undo path passes
+    /// <paramref name="forceReload"/> to repaint the tab immediately rather than keeping the stale view
+    /// model until the element is reselected (#3406).
+    /// </summary>
+    internal static bool ShouldReloadViewModel(ElementSave? currentlyReferencedElement,
+        ElementSave? selectedElement, bool forceReload)
+    {
+        return currentlyReferencedElement != selectedElement || forceReload;
+    }
+
+    private void CreateViewModel(bool forceReload = false)
     {
         ElementSave? currentlyReferencedElement = null;
         if (_viewModel != null)
@@ -605,7 +621,7 @@ public class MainStateAnimationPlugin : PluginBase, IAnimationUndoProvider
 
         var element = _selectedState.SelectedElement;
 
-        if (currentlyReferencedElement != element)
+        if (ShouldReloadViewModel(currentlyReferencedElement, element, forceReload))
         {
             if (_projectState.GumProjectSave?.FullFileName == null)
             {

--- a/Gum/StateAnimationPlugin/Managers/AnimationCollectionViewModelManager.cs
+++ b/Gum/StateAnimationPlugin/Managers/AnimationCollectionViewModelManager.cs
@@ -97,4 +97,16 @@ public class AnimationCollectionViewModelManager : IAnimationCollectionViewModel
             FileManager.XmlSerialize(save, fileName.FullPath);
         }
     }
+
+    /// <inheritdoc/>
+    public void SaveElementAnimations(ElementSave element, ElementAnimationsSave save)
+    {
+        var fileName = _animationFilePathService.GetAbsoluteAnimationFileNameFor(element);
+
+        if (fileName != null)
+        {
+            _fileWatchManager.IgnoreNextChangeUntil(fileName.FullPath);
+            FileManager.XmlSerialize(save, fileName.FullPath);
+        }
+    }
 }

--- a/Gum/StateAnimationPlugin/Managers/IAnimationCollectionViewModelManager.cs
+++ b/Gum/StateAnimationPlugin/Managers/IAnimationCollectionViewModelManager.cs
@@ -26,4 +26,11 @@ public interface IAnimationCollectionViewModelManager
     /// Persists the given view model's animations to the selected element's animation file.
     /// </summary>
     void Save(ElementAnimationsViewModel viewModel);
+
+    /// <summary>
+    /// Persists an already-built <see cref="ElementAnimationsSave"/> to the given element's animation
+    /// file, suppressing the resulting file-watch event. Used by undo/redo, which restores a captured
+    /// animations snapshot (not a live view model) for the element it is applying to.
+    /// </summary>
+    void SaveElementAnimations(ElementSave element, ElementAnimationsSave save);
 }

--- a/Gum/StateAnimationPlugin/ViewModels/ElementAnimationsViewModel.cs
+++ b/Gum/StateAnimationPlugin/ViewModels/ElementAnimationsViewModel.cs
@@ -358,10 +358,9 @@ public partial class ElementAnimationsViewModel : ViewModel
 
     private void HandleDeleteKeyframe(object? sender, System.Windows.RoutedEventArgs e)
     {
-        if(SelectedAnimation != null && SelectedAnimation.SelectedKeyframe != null)
-        {
-            SelectedAnimation.Keyframes.Remove(SelectedAnimation.SelectedKeyframe);
-        }
+        // Route the right-click "Delete Keyframe" through the same method as the Delete hotkey so both
+        // get the confirmation prompt and clear the selection identically.
+        DeleteSelectedKeyframe();
     }
 
     private void HandleRenameAnimation(object? sender, System.Windows.RoutedEventArgs e)
@@ -750,6 +749,10 @@ public partial class ElementAnimationsViewModel : ViewModel
     {
         if (SelectedAnimation?.SelectedKeyframe != null)
         {
+            if (!_dialogService.ShowYesNoMessage("Delete the selected keyframe?", "Delete?"))
+            {
+                return;
+            }
             SelectedAnimation.Keyframes.Remove(SelectedAnimation.SelectedKeyframe);
             SelectedAnimation.SelectedKeyframe = null;
         }

--- a/Tests/Gum.Presentation.Tests/UndoManagerTests.cs
+++ b/Tests/Gum.Presentation.Tests/UndoManagerTests.cs
@@ -4,6 +4,7 @@ using Gum.DataTypes;
 using Gum.DataTypes.Behaviors;
 using Gum.DataTypes.Variables;
 using Gum.Logic;
+using Gum.StateAnimation.SaveClasses;
 using Gum.ToolStates;
 using Gum.Undo;
 using Moq;
@@ -13,6 +14,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using ToolsUtilities;
 
 namespace Gum.Presentation.Tests;
 public class UndoManagerTests : BaseTestClass
@@ -23,7 +25,34 @@ public class UndoManagerTests : BaseTestClass
     private readonly Mock<IFileCommands> _fileCommands;
     private readonly Mock<IMessenger> _messenger;
     private readonly Mock<IUndoPluginNotifier> _pluginNotifier;
+    private readonly FakeAnimationUndoProvider _animationUndoProvider;
     private readonly UndoManager _undoManager;
+
+    /// <summary>
+    /// Stands in for the animation plugin's <see cref="IAnimationUndoProvider"/>. Backs each element's
+    /// animations with an in-memory store (the headless analogue of the .ganx). GetCurrentAnimations
+    /// returns a clone (so the strategy's captured baseline doesn't alias the store, mirroring how the
+    /// real provider returns a fresh ToSave()/deserialize) and normalizes an empty save to null, just
+    /// like the real provider does for an element with no animations. ApplyAnimations writes a clone back.
+    /// </summary>
+    private sealed class FakeAnimationUndoProvider : IAnimationUndoProvider
+    {
+        public Dictionary<ElementSave, ElementAnimationsSave> Store { get; } = new();
+
+        public ElementAnimationsSave? GetCurrentAnimations(ElementSave element)
+        {
+            if (!Store.TryGetValue(element, out var save) || save == null || save.Animations.Count == 0)
+            {
+                return null;
+            }
+            return FileManager.CloneSaveObject(save);
+        }
+
+        public void ApplyAnimations(ElementSave element, ElementAnimationsSave animations)
+        {
+            Store[element] = FileManager.CloneSaveObject(animations);
+        }
+    }
 
     public UndoManagerTests()
     {
@@ -33,6 +62,7 @@ public class UndoManagerTests : BaseTestClass
         _fileCommands = new Mock<IFileCommands>();
         _messenger = new Mock<IMessenger>();
         _pluginNotifier = new Mock<IUndoPluginNotifier>();
+        _animationUndoProvider = new FakeAnimationUndoProvider();
 
         ComponentSave component = new();
         component.States.Add(new Gum.DataTypes.Variables.StateSave
@@ -60,7 +90,8 @@ public class UndoManagerTests : BaseTestClass
             _guiCommands.Object,
             _fileCommands.Object,
             _messenger.Object,
-            _pluginNotifier.Object
+            _pluginNotifier.Object,
+            _animationUndoProvider
             );
     }
 
@@ -776,5 +807,126 @@ public class UndoManagerTests : BaseTestClass
         _selectedState.VerifySet(
             x => x.SelectedStateSave = It.Is<StateSave>(state => state.Name == "Default"),
             Times.AtLeastOnce);
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Animation undo (#3406). Animations are folded into the element's UndoSnapshot via the injected
+    // IAnimationUndoProvider (here the in-memory FakeAnimationUndoProvider), so an animation edit and
+    // the element edit it was made next to undo/redo as one atomic action. The headline guard is the
+    // combined state-rename + keyframe-reference change: both must revert from a single undo, or the
+    // keyframe desyncs from the state it names.
+    // ---------------------------------------------------------------------------------------------
+
+    private static ElementAnimationsSave AnimationsWithKeyframes(string animationName, params string[] keyframeStateNames)
+    {
+        var save = new ElementAnimationsSave();
+        var animation = new AnimationSave { Name = animationName };
+        float time = 0;
+        foreach (var stateName in keyframeStateNames)
+        {
+            animation.States.Add(new AnimatedStateSave { StateName = stateName, Time = time++ });
+        }
+        save.Animations.Add(animation);
+        return save;
+    }
+
+    [Fact]
+    public void PerformRedo_OnAnimationKeyframeDelete_ShouldReapplyTheDeletion()
+    {
+        ComponentSave component = _selectedState.Object.SelectedComponent!;
+        _animationUndoProvider.Store[component] = AnimationsWithKeyframes("Anim", "Default", "Highlighted");
+
+        _undoManager.RecordState();
+
+        // Simulate deleting the second keyframe in the live Animations tab.
+        _animationUndoProvider.Store[component] = AnimationsWithKeyframes("Anim", "Default");
+
+        _undoManager.RecordUndo();
+        _undoManager.PerformUndo();
+        _animationUndoProvider.Store[component].Animations[0].States.Count.ShouldBe(2);
+
+        _undoManager.PerformRedo();
+
+        _animationUndoProvider.Store[component].Animations[0].States.Count.ShouldBe(1);
+        _animationUndoProvider.Store[component].Animations[0].States[0].StateName.ShouldBe("Default");
+    }
+
+    [Fact]
+    public void PerformUndo_OnAnimationKeyframeDelete_ShouldRestoreTheKeyframe()
+    {
+        ComponentSave component = _selectedState.Object.SelectedComponent!;
+        _animationUndoProvider.Store[component] = AnimationsWithKeyframes("Anim", "Default", "Highlighted");
+
+        _undoManager.RecordState();
+
+        // Simulate deleting the second keyframe in the live Animations tab.
+        _animationUndoProvider.Store[component] = AnimationsWithKeyframes("Anim", "Default");
+
+        _undoManager.RecordUndo();
+        _undoManager.PerformUndo();
+
+        _animationUndoProvider.Store[component].Animations[0].States.Count.ShouldBe(2);
+        _animationUndoProvider.Store[component].Animations[0].States[1].StateName.ShouldBe("Highlighted");
+    }
+
+    [Fact]
+    public void PerformUndo_OnCombinedStateRenameAndKeyframeEdit_ShouldUndoBothAtomically()
+    {
+        // The desync guard. A keyframe references an element state by name ("Category/State"), so a
+        // state rename is one logical edit that changes BOTH the element data and the keyframe. It
+        // must record as a single snapshot and undo both halves together; otherwise Ctrl+Z reverts
+        // the rename while the keyframe still points at the new name (a dangling reference).
+        ComponentSave component = _selectedState.Object.SelectedComponent!;
+        var category = new StateSaveCategory { Name = "Category" };
+        category.States.Add(new StateSave { Name = "Old", ParentContainer = component });
+        component.Categories.Add(category);
+
+        _animationUndoProvider.Store[component] = AnimationsWithKeyframes("Anim", "Category/Old");
+
+        _undoManager.RecordState();
+
+        // One logical edit: rename the state on the element and rewrite the keyframe that names it.
+        component.Categories[0].States[0].Name = "New";
+        _animationUndoProvider.Store[component] = AnimationsWithKeyframes("Anim", "Category/New");
+
+        _undoManager.RecordUndo();
+
+        // A single atomic action captures the coupled change.
+        _undoManager.CurrentElementHistory.Actions.Count.ShouldBe(1);
+
+        _undoManager.PerformUndo();
+
+        // Both halves revert from the one undo, keeping the keyframe and the state name in sync.
+        component.Categories[0].States[0].Name.ShouldBe("Old");
+        _animationUndoProvider.Store[component].Animations[0].States[0].StateName.ShouldBe("Category/Old");
+    }
+
+    [Fact]
+    public void RecordUndo_OnElementOnlyChange_ShouldLeaveSnapshotAnimationsNull()
+    {
+        // An element edit with no animation change must leave the snapshot's Animations null (the
+        // null-when-unchanged convention), so applying the undo touches no .ganx.
+        ComponentSave component = _selectedState.Object.SelectedComponent!;
+        _animationUndoProvider.Store[component] = AnimationsWithKeyframes("Anim", "Default");
+
+        component.DefaultState.SetValue("X", 10f);
+        _undoManager.RecordState();
+        component.DefaultState.SetValue("X", 11f);
+        _undoManager.RecordUndo();
+
+        var action = _undoManager.CurrentElementHistory.Actions.Single();
+        action.UndoState.Animations.ShouldBeNull();
+        action.RedoState!.Animations.ShouldBeNull();
+    }
+
+    [Fact]
+    public void RecordUndo_WithNoAnimationsAndNoEdit_ShouldRecordNothing()
+    {
+        // An element with no animations (provider returns null) and no edit must produce no undo: a
+        // null-vs-null animation diff has to compare equal, or every selection would record spuriously.
+        _undoManager.RecordState();
+        _undoManager.RecordUndo();
+
+        _undoManager.CanUndo().ShouldBeFalse();
     }
 }

--- a/Tool/Tests/GumToolUnitTests/Plugins/PluginBridgedServiceTypes.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/PluginBridgedServiceTypes.cs
@@ -103,5 +103,9 @@ internal static class PluginBridgedServiceTypes
         // EditingManager drain (#3338): ICircularReferenceManager is bridged for the EditingManager that
         // MainEditorTabPlugin constructs (its other drained dep, IFavoriteComponentManager, is above).
         typeof(ICircularReferenceManager),
+
+        // Animation undo (#3406): MainStateAnimationPlugin injects this to register itself as the live
+        // IAnimationUndoProvider with UndoManager/ElementUndoStrategy.
+        typeof(IAnimationUndoProviderRegistrar),
     };
 }

--- a/Tool/Tests/GumToolUnitTests/Plugins/StateAnimationPlugin/AnimationUndoTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/StateAnimationPlugin/AnimationUndoTests.cs
@@ -134,20 +134,21 @@ public class AnimationUndoTests : BaseTestClass
     }
 
     [Fact]
-    public void RestoreAnimationSelection_ReselectsAnimationAndReturnsMatchingKeyframe_ByIdentity()
+    public void RestoreAnimationSelection_ReselectsAnimationAndReturnsMatchingKeyframe_ByContent()
     {
         // After an undo forces the view model to rebuild, the previously-selected animation is
         // reselected and the keyframe matching by content (state/sub-animation/event name + time) is
-        // returned, so the caller can reapply it once the keyframes ListBox has rebound. This is what
-        // keeps the user's selection — and the right-side property panel — across the reload.
+        // selected on it. This is what keeps the user's selection — and the right-side property panel —
+        // across the reload when the selected keyframe itself was unchanged by the undo.
         RunOnSta(() =>
         {
             ElementAnimationsViewModel rebuilt = ViewModelWithAnimation("Anim", out AnimationViewModel animation,
                 Keyframe("Default", 0f), Keyframe("Highlighted", 1f));
-            AnimatedKeyframeViewModel previouslySelected = Keyframe("Highlighted", 1f);
+            var selection = new MainStateAnimationPlugin.AnimationSelectionState(
+                "Anim", Keyframe("Highlighted", 1f), KeyframeIndex: 1, KeyframeCount: 2);
 
             AnimatedKeyframeViewModel? matched =
-                MainStateAnimationPlugin.RestoreAnimationSelection(rebuilt, "Anim", previouslySelected);
+                MainStateAnimationPlugin.RestoreAnimationSelection(rebuilt, selection);
 
             rebuilt.SelectedAnimation.ShouldBe(animation);
             matched.ShouldNotBeNull();
@@ -159,19 +160,43 @@ public class AnimationUndoTests : BaseTestClass
     }
 
     [Fact]
-    public void RestoreAnimationSelection_ReselectsAnimationButReturnsNull_WhenKeyframeNoLongerExists()
+    public void RestoreAnimationSelection_FallsBackToIndex_WhenSelectedKeyframesOwnValueWasReverted()
     {
-        // If the undo removed the keyframe that was selected, the match fails (returns null) while the
-        // animation is still reselected. Mirrors element-undo's silent selection drop when the selected
-        // object no longer exists.
+        // The user's repro: select a keyframe, change its time 5 -> 4, undo. The reverted keyframe is
+        // back at time 5, so the captured keyframe (time 4) matches nothing by content; since the count
+        // is unchanged, fall back to the captured index so the keyframe the user was editing stays
+        // selected (with its time showing 5 again).
+        RunOnSta(() =>
+        {
+            ElementAnimationsViewModel rebuilt = ViewModelWithAnimation("Anim", out AnimationViewModel animation,
+                Keyframe("Default", 0f), Keyframe("Highlighted", 5f));
+            var selection = new MainStateAnimationPlugin.AnimationSelectionState(
+                "Anim", Keyframe("Highlighted", 4f), KeyframeIndex: 1, KeyframeCount: 2);
+
+            AnimatedKeyframeViewModel? matched =
+                MainStateAnimationPlugin.RestoreAnimationSelection(rebuilt, selection);
+
+            matched.ShouldNotBeNull();
+            matched!.Time.ShouldBe(5f);
+            animation.SelectedKeyframe.ShouldBe(matched);
+        });
+    }
+
+    [Fact]
+    public void RestoreAnimationSelection_DropsKeyframeSelection_WhenCountChanged()
+    {
+        // Undo of an add removes the selected keyframe and changes the count. Content match fails and
+        // the index fallback is suppressed (count differs), so the keyframe selection drops cleanly
+        // rather than grabbing a neighbor. The animation is still reselected.
         RunOnSta(() =>
         {
             ElementAnimationsViewModel rebuilt = ViewModelWithAnimation("Anim", out AnimationViewModel animation,
                 Keyframe("Default", 0f));
-            AnimatedKeyframeViewModel removed = Keyframe("Highlighted", 1f);
+            var selection = new MainStateAnimationPlugin.AnimationSelectionState(
+                "Anim", Keyframe("Highlighted", 1f), KeyframeIndex: 1, KeyframeCount: 2);
 
             AnimatedKeyframeViewModel? matched =
-                MainStateAnimationPlugin.RestoreAnimationSelection(rebuilt, "Anim", removed);
+                MainStateAnimationPlugin.RestoreAnimationSelection(rebuilt, selection);
 
             rebuilt.SelectedAnimation.ShouldBe(animation);
             matched.ShouldBeNull();

--- a/Tool/Tests/GumToolUnitTests/Plugins/StateAnimationPlugin/AnimationUndoTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/StateAnimationPlugin/AnimationUndoTests.cs
@@ -133,6 +133,74 @@ public class AnimationUndoTests : BaseTestClass
         shouldReload.ShouldBeTrue();
     }
 
+    [Fact]
+    public void RestoreAnimationSelection_ReselectsAnimationAndReturnsMatchingKeyframe_ByIdentity()
+    {
+        // After an undo forces the view model to rebuild, the previously-selected animation is
+        // reselected and the keyframe matching by content (state/sub-animation/event name + time) is
+        // returned, so the caller can reapply it once the keyframes ListBox has rebound. This is what
+        // keeps the user's selection — and the right-side property panel — across the reload.
+        RunOnSta(() =>
+        {
+            ElementAnimationsViewModel rebuilt = ViewModelWithAnimation("Anim", out AnimationViewModel animation,
+                Keyframe("Default", 0f), Keyframe("Highlighted", 1f));
+            AnimatedKeyframeViewModel previouslySelected = Keyframe("Highlighted", 1f);
+
+            AnimatedKeyframeViewModel? matched =
+                MainStateAnimationPlugin.RestoreAnimationSelection(rebuilt, "Anim", previouslySelected);
+
+            rebuilt.SelectedAnimation.ShouldBe(animation);
+            matched.ShouldNotBeNull();
+            matched!.StateName.ShouldBe("Highlighted");
+            matched.Time.ShouldBe(1f);
+        });
+    }
+
+    [Fact]
+    public void RestoreAnimationSelection_ReselectsAnimationButReturnsNull_WhenKeyframeNoLongerExists()
+    {
+        // If the undo removed the keyframe that was selected, the match fails (returns null) while the
+        // animation is still reselected. Mirrors element-undo's silent selection drop when the selected
+        // object no longer exists.
+        RunOnSta(() =>
+        {
+            ElementAnimationsViewModel rebuilt = ViewModelWithAnimation("Anim", out AnimationViewModel animation,
+                Keyframe("Default", 0f));
+            AnimatedKeyframeViewModel removed = Keyframe("Highlighted", 1f);
+
+            AnimatedKeyframeViewModel? matched =
+                MainStateAnimationPlugin.RestoreAnimationSelection(rebuilt, "Anim", removed);
+
+            rebuilt.SelectedAnimation.ShouldBe(animation);
+            matched.ShouldBeNull();
+        });
+    }
+
+    private AnimatedKeyframeViewModel Keyframe(string stateName, float time)
+        => new(_bitmapLoader) { StateName = stateName, Time = time };
+
+    private ElementAnimationsViewModel ViewModelWithAnimation(string animationName, out AnimationViewModel animation,
+        params AnimatedKeyframeViewModel[] keyframes)
+    {
+        animation = new AnimationViewModel(_bitmapLoader, _selectedState, _wireframeObjectManager) { Name = animationName };
+        foreach (AnimatedKeyframeViewModel keyframe in keyframes)
+        {
+            animation.Keyframes.Add(keyframe);
+        }
+
+        ElementAnimationsViewModel viewModel = new(
+            Mock.Of<INameVerifier>(),
+            Mock.Of<IDialogService>(),
+            Mock.Of<IAnimationCollectionViewModelManager>(),
+            Mock.Of<IRenameManager>(),
+            _bitmapLoader,
+            _selectedState,
+            _wireframeObjectManager,
+            Mock.Of<IOutputManager>());
+        viewModel.Animations.Add(animation);
+        return viewModel;
+    }
+
     private ElementAnimationsViewModel CreateViewModel(IDialogService dialogService, out AnimationViewModel animation)
     {
         animation = new AnimationViewModel(_bitmapLoader, _selectedState, _wireframeObjectManager) { Name = "Anim" };

--- a/Tool/Tests/GumToolUnitTests/Plugins/StateAnimationPlugin/AnimationUndoTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/StateAnimationPlugin/AnimationUndoTests.cs
@@ -153,6 +153,8 @@ public class AnimationUndoTests : BaseTestClass
             matched.ShouldNotBeNull();
             matched!.StateName.ShouldBe("Highlighted");
             matched.Time.ShouldBe(1f);
+            // Selected on the animation, and pre-set before it became the active animation.
+            animation.SelectedKeyframe.ShouldBe(matched);
         });
     }
 
@@ -173,6 +175,7 @@ public class AnimationUndoTests : BaseTestClass
 
             rebuilt.SelectedAnimation.ShouldBe(animation);
             matched.ShouldBeNull();
+            animation.SelectedKeyframe.ShouldBeNull();
         });
     }
 

--- a/Tool/Tests/GumToolUnitTests/Plugins/StateAnimationPlugin/AnimationUndoTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/StateAnimationPlugin/AnimationUndoTests.cs
@@ -1,0 +1,133 @@
+using Gum.DataTypes;
+using Gum.Managers;
+using Gum.Plugins.Undos;
+using Gum.Services.Dialogs;
+using Gum.StateAnimation.SaveClasses;
+using Gum.ToolStates;
+using Gum.Wireframe;
+using Moq;
+using Shouldly;
+using StateAnimationPlugin.Managers;
+using StateAnimationPlugin.ViewModels;
+using System;
+using System.Threading;
+using Xunit;
+
+namespace GumToolUnitTests.Plugins.StateAnimationPlugin;
+
+/// <summary>
+/// Covers the user-facing halves of animation undo (#3406): the keyframe-delete confirmation prompt
+/// on <see cref="ElementAnimationsViewModel.DeleteSelectedKeyframe"/> (the issue's minimum bar) and the
+/// History-tab wording for an animation change (<see cref="UndosViewModel.DescribeAnimationChange"/>).
+/// The headless capture/diff/apply and the desync guard live in Gum.Presentation.Tests' UndoManagerTests.
+/// </summary>
+public class AnimationUndoTests : BaseTestClass
+{
+    private readonly IBitmapLoader _bitmapLoader = Mock.Of<IBitmapLoader>();
+    private readonly ISelectedState _selectedState = Mock.Of<ISelectedState>();
+    private readonly IWireframeObjectManager _wireframeObjectManager = Mock.Of<IWireframeObjectManager>();
+
+    [Fact]
+    public void DeleteSelectedKeyframe_DoesNotRemoveKeyframe_WhenPromptDeclined()
+    {
+        RunOnSta(() =>
+        {
+            Mock<IDialogService> dialogService = new();
+            // ShowYesNoMessage is an extension over ShowMessage(...); a non-affirmative result is "No".
+            dialogService
+                .Setup(x => x.ShowMessage(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<MessageDialogStyle?>()))
+                .Returns(MessageDialogResult.Negative);
+            ElementAnimationsViewModel viewModel = CreateViewModel(dialogService.Object, out AnimationViewModel animation);
+
+            viewModel.DeleteSelectedKeyframe();
+
+            animation.Keyframes.Count.ShouldBe(1);
+        });
+    }
+
+    [Fact]
+    public void DeleteSelectedKeyframe_RemovesKeyframe_WhenPromptConfirmed()
+    {
+        RunOnSta(() =>
+        {
+            Mock<IDialogService> dialogService = new();
+            // ShowYesNoMessage is an extension over ShowMessage(...); an affirmative result is "Yes".
+            dialogService
+                .Setup(x => x.ShowMessage(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<MessageDialogStyle?>()))
+                .Returns(MessageDialogResult.Affirmative);
+            ElementAnimationsViewModel viewModel = CreateViewModel(dialogService.Object, out AnimationViewModel animation);
+
+            viewModel.DeleteSelectedKeyframe();
+
+            animation.Keyframes.Count.ShouldBe(0);
+        });
+    }
+
+    [Fact]
+    public void DescribeAnimationChange_DescribesAddedRemovedAndModifiedAnimations()
+    {
+        // before: "Idle" with one keyframe, "Walk" present. after: "Idle" with two keyframes (modified),
+        // "Walk" gone (removed), "Run" new (added).
+        ElementAnimationsSave before = new();
+        before.Animations.Add(new AnimationSave { Name = "Idle", States = { new AnimatedStateSave { StateName = "Default", Time = 0 } } });
+        before.Animations.Add(new AnimationSave { Name = "Walk" });
+
+        ElementAnimationsSave after = new();
+        after.Animations.Add(new AnimationSave { Name = "Idle", States = { new AnimatedStateSave { StateName = "Default", Time = 0 }, new AnimatedStateSave { StateName = "Highlighted", Time = 1 } } });
+        after.Animations.Add(new AnimationSave { Name = "Run" });
+
+        string description = UndosViewModel.DescribeAnimationChange(before, after);
+
+        description.ShouldContain("Add animation: Run");
+        description.ShouldContain("Remove animation: Walk");
+        description.ShouldContain("Modify animation: Idle");
+    }
+
+    [Fact]
+    public void DescribeAnimationChange_ReturnsEmpty_WhenNeitherSnapshotHasAnimations()
+    {
+        UndosViewModel.DescribeAnimationChange(null, null).ShouldBeEmpty();
+    }
+
+    private ElementAnimationsViewModel CreateViewModel(IDialogService dialogService, out AnimationViewModel animation)
+    {
+        animation = new AnimationViewModel(_bitmapLoader, _selectedState, _wireframeObjectManager) { Name = "Anim" };
+        AnimatedKeyframeViewModel keyframe = new(_bitmapLoader) { StateName = "Default" };
+        animation.Keyframes.Add(keyframe);
+        animation.SelectedKeyframe = keyframe;
+
+        ElementAnimationsViewModel viewModel = new(
+            Mock.Of<INameVerifier>(),
+            dialogService,
+            Mock.Of<IAnimationCollectionViewModelManager>(),
+            Mock.Of<IRenameManager>(),
+            _bitmapLoader,
+            _selectedState,
+            _wireframeObjectManager,
+            Mock.Of<IOutputManager>());
+        viewModel.Animations.Add(animation);
+        viewModel.SelectedAnimation = animation;
+        return viewModel;
+    }
+
+    /// <summary>
+    /// WPF controls (the right-click MenuItems built in ElementAnimationsViewModel's constructor)
+    /// require an STA thread; xUnit's default runner is MTA.
+    /// </summary>
+    private static void RunOnSta(Action action)
+    {
+        Exception? caught = null;
+        Thread thread = new(() =>
+        {
+            try { action(); }
+            catch (Exception ex) { caught = ex; }
+        });
+        thread.SetApartmentState(ApartmentState.STA);
+        thread.Start();
+        thread.Join();
+        if (caught != null)
+        {
+            throw new Exception("Test body threw on the STA thread.", caught);
+        }
+    }
+}

--- a/Tool/Tests/GumToolUnitTests/Plugins/StateAnimationPlugin/AnimationUndoTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/StateAnimationPlugin/AnimationUndoTests.cs
@@ -7,6 +7,7 @@ using Gum.ToolStates;
 using Gum.Wireframe;
 using Moq;
 using Shouldly;
+using StateAnimationPlugin;
 using StateAnimationPlugin.Managers;
 using StateAnimationPlugin.ViewModels;
 using System;
@@ -87,6 +88,49 @@ public class AnimationUndoTests : BaseTestClass
     public void DescribeAnimationChange_ReturnsEmpty_WhenNeitherSnapshotHasAnimations()
     {
         UndosViewModel.DescribeAnimationChange(null, null).ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void ShouldReloadViewModel_ReturnsTrue_WhenForcedEvenThoughElementUnchanged()
+    {
+        // The after-undo path passes forceReload: true so the tab repaints from the just-restored
+        // .ganx even when the selected element is the same one already loaded (issue #3406 follow-up).
+        ComponentSave element = new();
+
+        bool shouldReload = MainStateAnimationPlugin.ShouldReloadViewModel(
+            currentlyReferencedElement: element,
+            selectedElement: element,
+            forceReload: true);
+
+        shouldReload.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void ShouldReloadViewModel_ReturnsFalse_WhenElementUnchangedAndNotForced()
+    {
+        // The stale-VM early-out the normal refresh path relies on: same element, no reload.
+        ComponentSave element = new();
+
+        bool shouldReload = MainStateAnimationPlugin.ShouldReloadViewModel(
+            currentlyReferencedElement: element,
+            selectedElement: element,
+            forceReload: false);
+
+        shouldReload.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ShouldReloadViewModel_ReturnsTrue_WhenElementChanged()
+    {
+        ComponentSave currentElement = new();
+        ComponentSave selectedElement = new();
+
+        bool shouldReload = MainStateAnimationPlugin.ShouldReloadViewModel(
+            currentlyReferencedElement: currentElement,
+            selectedElement: selectedElement,
+            forceReload: false);
+
+        shouldReload.ShouldBeTrue();
     }
 
     private ElementAnimationsViewModel CreateViewModel(IDialogService dialogService, out AnimationViewModel animation)

--- a/Tool/Tests/GumToolUnitTests/VariableGrid/CompositeMemberLogicApplyTests.cs
+++ b/Tool/Tests/GumToolUnitTests/VariableGrid/CompositeMemberLogicApplyTests.cs
@@ -41,7 +41,7 @@ public class CompositeMemberLogicApplyTests : BaseTestClass
         _dialogService = new Mock<IDialogService>();
         _nameVerifier = new Mock<INameVerifier>();
 
-        _realUndoManager = new UndoManager(null!, null!, null!, null!, null!, null!);
+        _realUndoManager = new UndoManager(null!, null!, null!, null!, null!, null!, null!);
         _undoManager = new Mock<IUndoManager>();
         _undoManager.Setup(x => x.RequestLock()).Returns(() => _realUndoManager.RequestLock());
 

--- a/Tools/Gum.Presentation/Undo/AnimationUndoProviderRelay.cs
+++ b/Tools/Gum.Presentation/Undo/AnimationUndoProviderRelay.cs
@@ -1,0 +1,25 @@
+using Gum.DataTypes;
+using Gum.StateAnimation.SaveClasses;
+
+namespace Gum.Undo;
+
+/// <summary>
+/// Late-bound bridge between the headless undo strategy and the animation plugin. <see cref="UndoManager"/>
+/// and its <see cref="ElementUndoStrategy"/> are constructed by DI at startup, before any plugin exists,
+/// so they receive this relay as their <see cref="IAnimationUndoProvider"/>. The animation plugin then
+/// registers itself as the real provider in its StartUp via <see cref="IAnimationUndoProviderRegistrar"/>.
+/// Until a provider is registered (e.g. in headless tests or before the plugin loads) every call is a
+/// no-op returning null, which the strategy treats as "this element has no animations".
+/// </summary>
+public class AnimationUndoProviderRelay : IAnimationUndoProvider, IAnimationUndoProviderRegistrar
+{
+    private IAnimationUndoProvider? _provider;
+
+    public void Register(IAnimationUndoProvider provider) => _provider = provider;
+
+    public ElementAnimationsSave? GetCurrentAnimations(ElementSave element)
+        => _provider?.GetCurrentAnimations(element);
+
+    public void ApplyAnimations(ElementSave element, ElementAnimationsSave animations)
+        => _provider?.ApplyAnimations(element, animations);
+}

--- a/Tools/Gum.Presentation/Undo/ElementUndoStrategy.cs
+++ b/Tools/Gum.Presentation/Undo/ElementUndoStrategy.cs
@@ -4,6 +4,7 @@ using Gum.DataTypes;
 using Gum.DataTypes.Behaviors;
 using Gum.DataTypes.Variables;
 using Gum.Logic;
+using Gum.StateAnimation.SaveClasses;
 using Gum.ToolStates;
 using System;
 using System.Collections.Generic;
@@ -26,6 +27,7 @@ public class ElementUndoStrategy : IUndoStrategy
     private readonly IFileCommands _fileCommands;
     private readonly IMessenger _messenger;
     private readonly IUndoPluginNotifier _pluginNotifier;
+    private readonly IAnimationUndoProvider _animationUndoProvider;
     private readonly Func<bool> _areUndoLocksActive;
     private readonly Action<UndoOperation> _raiseUndosChanged;
 
@@ -60,6 +62,7 @@ public class ElementUndoStrategy : IUndoStrategy
         IFileCommands fileCommands,
         IMessenger messenger,
         IUndoPluginNotifier pluginNotifier,
+        IAnimationUndoProvider animationUndoProvider,
         Func<bool> areUndoLocksActive,
         Action<UndoOperation> raiseUndosChanged)
     {
@@ -69,6 +72,7 @@ public class ElementUndoStrategy : IUndoStrategy
         _fileCommands = fileCommands;
         _messenger = messenger;
         _pluginNotifier = pluginNotifier;
+        _animationUndoProvider = animationUndoProvider;
         _areUndoLocksActive = areUndoLocksActive;
         _raiseUndosChanged = raiseUndosChanged;
     }
@@ -108,6 +112,11 @@ public class ElementUndoStrategy : IUndoStrategy
             }
             recordedSnapshot.StateName = _selectedState.SelectedStateSave?.Name;
             recordedSnapshot.CategoryName = _selectedState.SelectedStateCategorySave?.Name;
+
+            // Capture the element's animations as part of the same baseline. GetCurrentAnimations
+            // returns the live tab contents when loaded, else the .ganx, else null when the element
+            // has no animations. This is a freshly-produced object, so it is safe to hold as-is.
+            recordedSnapshot.Animations = _animationUndoProvider.GetCurrentAnimations(_selectedState.SelectedElement);
         }
 
         //PrintStatus("RecordState");
@@ -154,8 +163,14 @@ public class ElementUndoStrategy : IUndoStrategy
             }
         }
 
+        // The live animation state, diffed against the baseline captured on selection / after the
+        // previous record. baselineAnimations restores on undo; currentAnimations re-applies on redo.
+        var baselineAnimations = recordedSnapshot.Animations;
+        var currentAnimations = _animationUndoProvider.GetCurrentAnimations(newElement);
+
         UndoSnapshot undoSnapshot = TryGetUndoSnapshotToAdd(newStateSave, newElement, oldState,
-            recordedSnapshot.Element, recordedSnapshot.CategoryName, recordedSnapshot.StateName);
+            recordedSnapshot.Element, recordedSnapshot.CategoryName, recordedSnapshot.StateName,
+            baselineAnimations, currentAnimations);
 
         if (undoSnapshot != null)
         {
@@ -178,7 +193,8 @@ public class ElementUndoStrategy : IUndoStrategy
                 history.Actions.Add(action);
                 history.UndoIndex = history.Actions.Count - 1;
 
-                var redoSnapshot = TryGetUndoSnapshotToAdd(oldState, recordedSnapshot.Element, newStateSave, newElement, recordedSnapshot.CategoryName, recordedSnapshot.StateName);
+                var redoSnapshot = TryGetUndoSnapshotToAdd(oldState, recordedSnapshot.Element, newStateSave, newElement, recordedSnapshot.CategoryName, recordedSnapshot.StateName,
+                    currentAnimations, baselineAnimations);
 
                 if(redoSnapshot != null)
                 {
@@ -204,7 +220,8 @@ public class ElementUndoStrategy : IUndoStrategy
     /// Checks if anything has changed and if so returns an UndoSnapshot
     /// </summary>
     private UndoSnapshot? TryGetUndoSnapshotToAdd(StateSave newState, ElementSave newElement,
-        StateSave oldState, ElementSave oldElement, string categoryName, string stateName)
+        StateSave oldState, ElementSave oldElement, string categoryName, string stateName,
+        ElementAnimationsSave? oldAnimations, ElementAnimationsSave? newAnimations)
     {
         bool doStatesDiffer = FileManager.AreSaveObjectsEqual(oldState, newState) == false;
         bool doStateCategoriesDiffer =
@@ -215,6 +232,7 @@ public class ElementUndoStrategy : IUndoStrategy
         bool doBehaviorsDiffer = FileManager.AreSaveObjectsEqual(oldElement.Behaviors, newElement.Behaviors) == false;
         bool doVariablesHiddenFromInstancesDiffer =
             FileManager.AreSaveObjectsEqual(oldElement.VariablesHiddenFromInstances, newElement.VariablesHiddenFromInstances) == false;
+        bool doAnimationsDiffer = FileManager.AreSaveObjectsEqual(oldAnimations, newAnimations) == false;
 
         // Why do we care if the user selected a different state?
         // This seems to cause bugs, and we don't care about undoing selections...
@@ -225,7 +243,7 @@ public class ElementUndoStrategy : IUndoStrategy
         UndoSnapshot? snapshotToAdd = null;
 
         bool didAnythingChange = doStatesDiffer || doStateCategoriesDiffer || doInstanceListsDiffer || doTypesDiffer || doNamesDiffer ||
-            doBehaviorsDiffer || doVariablesHiddenFromInstancesDiffer
+            doBehaviorsDiffer || doVariablesHiddenFromInstancesDiffer || doAnimationsDiffer
             //|| doesSelectedStateDiffer
             ;
         if (didAnythingChange)
@@ -265,7 +283,14 @@ public class ElementUndoStrategy : IUndoStrategy
             {
                 Element = clone,
                 CategoryName = categoryName,
-                StateName = stateName
+                StateName = stateName,
+                // Null when unchanged (mirrors the States/Instances trick); otherwise the animations
+                // to restore. oldAnimations being null but differing means the element had no
+                // animations before, so restore to an empty save rather than null (null would read as
+                // "no animation change to apply").
+                Animations = doAnimationsDiffer
+                    ? (oldAnimations != null ? FileManager.CloneSaveObject(oldAnimations) : new ElementAnimationsSave())
+                    : null
             };
         }
 
@@ -677,6 +702,14 @@ public class ElementUndoStrategy : IUndoStrategy
                 listOfStates = toApplyTo.Categories
                     .FirstOrDefault(item => item.Name == undoSnapshot.CategoryName)?.States;
             }
+        }
+
+        // Restore animations only on a real apply. The History tab calls this with
+        // propagateNameChanges == false to dry-run snapshots against a throwaway element clone; doing
+        // the .ganx write there would corrupt the on-disk animations just to build a description.
+        if (propagateNameChanges && undoSnapshot.Animations != null)
+        {
+            _animationUndoProvider.ApplyAnimations(toApplyTo, undoSnapshot.Animations);
         }
 
         return addedAndRemovedInstances;

--- a/Tools/Gum.Presentation/Undo/IAnimationUndoProvider.cs
+++ b/Tools/Gum.Presentation/Undo/IAnimationUndoProvider.cs
@@ -1,0 +1,40 @@
+using Gum.DataTypes;
+using Gum.StateAnimation.SaveClasses;
+
+namespace Gum.Undo;
+
+/// <summary>
+/// Headless seam that lets <see cref="ElementUndoStrategy"/> capture and restore an element's
+/// animations without knowing how they are stored (the <c>.ganx</c> sidecar) or rendered (the WPF
+/// Animations tab). Implemented by the animation plugin and injected into the strategy via DI.
+/// Animations are folded into the element's undo snapshot so element edits and animation edits
+/// share one atomic timeline — required because animation keyframes reference element states by
+/// name and would otherwise desync from a rename/delete. See #3406 (PR 2 of 2 toward #3399).
+/// </summary>
+public interface IAnimationUndoProvider
+{
+    /// <summary>
+    /// Returns the element's live animation edit state — the in-memory tab contents when that
+    /// element's Animations tab is loaded, otherwise the deserialized <c>.ganx</c>. Returns null
+    /// when the element has no animations (so a null-vs-null diff compares equal and records nothing).
+    /// </summary>
+    ElementAnimationsSave? GetCurrentAnimations(ElementSave element);
+
+    /// <summary>
+    /// Writes <paramref name="animations"/> back as the element's animations (persisting the
+    /// <c>.ganx</c> and repainting the tab). An empty <see cref="ElementAnimationsSave"/> restores
+    /// the element to having no animations.
+    /// </summary>
+    void ApplyAnimations(ElementSave element, ElementAnimationsSave animations);
+}
+
+/// <summary>
+/// Lets the animation plugin register itself as the active <see cref="IAnimationUndoProvider"/> at
+/// plugin StartUp — after <see cref="UndoManager"/> (and its <see cref="ElementUndoStrategy"/>) have
+/// already been constructed by DI. The registrar and the provider resolve to the same late-bound
+/// relay singleton (see <c>AnimationUndoProviderRelay</c>).
+/// </summary>
+public interface IAnimationUndoProviderRegistrar
+{
+    void Register(IAnimationUndoProvider provider);
+}

--- a/Tools/Gum.Presentation/Undo/UndoManager.cs
+++ b/Tools/Gum.Presentation/Undo/UndoManager.cs
@@ -54,7 +54,8 @@ public class UndoManager : IUndoManager
         IGuiCommands guiCommands,
         IFileCommands fileCommands,
         IMessenger messenger,
-        IUndoPluginNotifier pluginNotifier)
+        IUndoPluginNotifier pluginNotifier,
+        IAnimationUndoProvider animationUndoProvider)
     {
         UndoLocks = new ObservableCollection<UndoLock>();
         UndoLocks.CollectionChanged += HandleUndoLockChanged;
@@ -62,7 +63,7 @@ public class UndoManager : IUndoManager
         bool AreUndoLocksActive() => UndoLocks.Count > 0;
 
         _elementStrategy = new ElementUndoStrategy(selectedState, renameLogic, guiCommands, fileCommands,
-            messenger, pluginNotifier, AreUndoLocksActive, InvokeUndosChanged);
+            messenger, pluginNotifier, animationUndoProvider, AreUndoLocksActive, InvokeUndosChanged);
         _behaviorStrategy = new BehaviorUndoStrategy(selectedState, guiCommands, fileCommands,
             messenger, pluginNotifier, AreUndoLocksActive, InvokeUndosChanged);
 

--- a/Tools/Gum.Presentation/Undo/UndoSnapshot.cs
+++ b/Tools/Gum.Presentation/Undo/UndoSnapshot.cs
@@ -1,6 +1,7 @@
 ﻿using Gum.DataTypes;
 using Gum.DataTypes.Behaviors;
 using Gum.DataTypes.Variables;
+using Gum.StateAnimation.SaveClasses;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -144,6 +145,15 @@ public class UndoSnapshot
     public ElementSave Element;
     public string CategoryName;
     public string StateName;
+
+    /// <summary>
+    /// The element's animations captured alongside its element data, so an animation edit undoes
+    /// atomically with the element edit it was made next to (#3406). Null means "no animation change
+    /// in this snapshot" (the same null-when-unchanged convention used for <see cref="ElementSave.States"/>
+    /// and <see cref="ElementSave.Instances"/>); an empty <see cref="ElementAnimationsSave"/> means
+    /// "restore the element to having no animations".
+    /// </summary>
+    public ElementAnimationsSave? Animations;
 
     public override string ToString()
     {


### PR DESCRIPTION
## What this does

Makes **all** animation edits undoable (PR 2/2 toward #3399, building on the #3403 orchestrator/strategy split) and adds the keyframe-delete confirmation prompt.

Animation keyframes reference element states **by name** (`"Category/State"`), so a state rename/delete changes *both* the element data and the animation keyframes — coupled data that must undo **atomically** or the keyframe desyncs (undo the rename, keyframe still points at the new name). So animations are folded into the element's existing per-element `UndoSnapshot` rather than getting a separate stack/strategy.

## How

- **`UndoSnapshot.Animations`** (`ElementAnimationsSave?`) — null = no animation change in this snapshot (the same null-when-unchanged convention as `States`/`Instances`); an empty save = "restore to no animations".
- **`IAnimationUndoProvider`** — new headless seam (`GetCurrentAnimations` / `ApplyAnimations`) so `.ganx` IO and the WPF tab stay out of `ElementUndoStrategy`. The animation plugin implements it (live tab contents when loaded, else the deserialized `.ganx`); a late-bound `AnimationUndoProviderRelay` bridges DI (UndoManager built at startup) to the plugin (registers itself at StartUp via `IAnimationUndoProviderRegistrar`, bridged into the plugin MEF container).
- **`ElementUndoStrategy`** captures/diffs/applies animations in its existing three phases; the History-tab dry-run (`propagateNameChanges == false`) never writes the `.ganx`.
- **Recording** rides the plugin's existing `HandleDataChange` choke point: after the save, an empty `using (_undoManager.RequestLock()) { }` flushes a record — one mechanism for every persisted gesture (keyframe add/delete/paste, time/interpolation/loop). A suppression flag spans undo-apply + the after-undo tab repaint so restoring doesn't record a new undo.
- **Keyframe-delete prompt** on `DeleteSelectedKeyframe` (the right-click menu now routes through it too).
- **History tab** describes animation changes (`DescribeAnimationChange`).

No new `AnimationUndoStrategy` and no per-sub-domain decomposition — see the issue for why. The `Animations` field is the clean seam to split along later.

## Tests (TDD)

- Headless (`Gum.Presentation.Tests`, fake `IAnimationUndoProvider`): keyframe-delete undo/redo, element-only change leaves `Animations` null, no-edit records nothing, and the **headline desync guard** — a combined state-rename + keyframe-reference change records as **one** action and undoes both halves together.
- Plugin-side (`GumToolUnitTests`): the delete prompt (No → keep, Yes → delete) and the History wording. `AllPluginsCompositionTests` stays green (bridged type mirrored into `PluginBridgedServiceTypes`).

`Gum.Presentation.Tests`: 42 passing. `GumToolUnitTests` undo/animation: 39 passing. `GumFull.sln` builds clean.

Closes #3399
