### PR TITLE
Name the missing reference in animation keyframe error (#3400)

### DIFF
--- a/Gum/StateAnimationPlugin/ViewModels/AnimatedKeyframeViewModel.cs
+++ b/Gum/StateAnimationPlugin/ViewModels/AnimatedKeyframeViewModel.cs
@@ -180,6 +180,36 @@ public class AnimatedKeyframeViewModel : ViewModel, IComparable
     public bool IsMissingReference =>
         !HasValidState && (!string.IsNullOrEmpty(StateName) || !string.IsNullOrEmpty(AnimationName));
 
+    /// <summary>
+    /// The message shown when this keyframe's referenced state or animation is missing. Names the
+    /// specific reference (and its category, for a categorized state) so the user can find the broken
+    /// keyframe without hunting. Shown via <see cref="HasInvalidStateVisibility"/> (issue #3400).
+    /// </summary>
+    [DependsOn(nameof(StateName))]
+    [DependsOn(nameof(AnimationName))]
+    public string MissingReferenceMessage
+    {
+        get
+        {
+            if (!string.IsNullOrEmpty(StateName))
+            {
+                int slashIndex = StateName.IndexOf('/');
+                if (slashIndex >= 0)
+                {
+                    string category = StateName.Substring(0, slashIndex);
+                    string state = StateName.Substring(slashIndex + 1);
+                    return $"Could not find state \"{state}\" in category \"{category}\"";
+                }
+                return $"Could not find state \"{StateName}\"";
+            }
+            else if (!string.IsNullOrEmpty(AnimationName))
+            {
+                return $"Could not find animation \"{AnimationName}\"";
+            }
+            return "Could not find state or animation";
+        }
+    }
+
     [DependsOn(nameof(HasValidState))]
     public System.Windows.Visibility HasInvalidStateVisibility
     {

--- a/Gum/StateAnimationPlugin/Views/StateView.xaml
+++ b/Gum/StateAnimationPlugin/Views/StateView.xaml
@@ -45,7 +45,7 @@
                 Margin="0,0,0,2"
                 FontWeight="Bold"
                 Foreground="{DynamicResource Frb.Brushes.Error}"
-                Text="Could not find state or animation"
+                Text="{Binding MissingReferenceMessage, FallbackValue='Could not find state or animation'}"
                 TextWrapping="Wrap"
                 Visibility="{Binding HasInvalidStateVisibility, TargetNullValue=Collapsed, FallbackValue=Collapsed}" />
 

--- a/Tool/Tests/GumToolUnitTests/Plugins/StateAnimationPlugin/AnimatedKeyframeViewModelTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/StateAnimationPlugin/AnimatedKeyframeViewModelTests.cs
@@ -83,4 +83,37 @@ public class AnimatedKeyframeViewModelTests : BaseTestClass
 
         keyframe.IsMissingReference.ShouldBeTrue();
     }
+
+    [Fact]
+    public void MissingReferenceMessage_NamesAnimation_ForAnimationKeyframe()
+    {
+        AnimatedKeyframeViewModel keyframe = new AnimatedKeyframeViewModel(_bitmapLoader)
+        {
+            AnimationName = "Spin",
+        };
+
+        keyframe.MissingReferenceMessage.ShouldBe("Could not find animation \"Spin\"");
+    }
+
+    [Fact]
+    public void MissingReferenceMessage_NamesCategoryAndState_ForCategorizedState()
+    {
+        AnimatedKeyframeViewModel keyframe = new AnimatedKeyframeViewModel(_bitmapLoader)
+        {
+            StateName = "ButtonStates/Highlighted",
+        };
+
+        keyframe.MissingReferenceMessage.ShouldBe("Could not find state \"Highlighted\" in category \"ButtonStates\"");
+    }
+
+    [Fact]
+    public void MissingReferenceMessage_NamesStateOnly_ForUncategorizedState()
+    {
+        AnimatedKeyframeViewModel keyframe = new AnimatedKeyframeViewModel(_bitmapLoader)
+        {
+            StateName = "Highlighted",
+        };
+
+        keyframe.MissingReferenceMessage.ShouldBe("Could not find state \"Highlighted\"");
+    }
 }


### PR DESCRIPTION
## Problem

When an animation keyframe referenced a missing category/state/animation, Gum showed the generic message **"Could not find state or animation"** — it didn't say *which* reference was missing, so the user had to hunt for the broken keyframe.

## Fix

Added a `MissingReferenceMessage` computed property to `AnimatedKeyframeViewModel` that names the specific missing reference:

- Categorized state → `Could not find state "Highlighted" in category "ButtonStates"`
- Uncategorized state → `Could not find state "Highlighted"`
- Animation → `Could not find animation "Spin"`

`StateView.xaml`'s `NotFoundLabel` now binds its `Text` to that property (with the old literal kept as a `FallbackValue`). The property is a neutral `string` on the VM per the code-style rule for tool ViewModels.

## Tests

Added three `AnimatedKeyframeViewModelTests` covering the categorized-state, uncategorized-state, and animation messages. Full `AnimatedKeyframeViewModelTests` suite green (8/8); `GumFull.sln` builds clean.

Closes #3400
