### PR TITLE
Live-reload .ganx animation files edited on disk (#3410)

### DIFF
--- a/Gum/Managers/FileChangeReactionLogic.cs
+++ b/Gum/Managers/FileChangeReactionLogic.cs
@@ -78,11 +78,10 @@ namespace Gum.Managers
                     ReactToProjectChanged(file);
                 }
             }
-            else if(extension == "ganx")
-            {
-                _outputManager.AddOutput($"Gum detected a changed animation file: \n{file}" +
-                    $"Gum does not currently support reloading animation files, so you should restart Gum to reload this file.");
-            }
+            // .ganx (animation collection) reload is handled by the StateAnimationPlugin via the
+            // _pluginManager.ReactToFileChanged call below. The animation data is a per-element
+            // sidecar owned by that plugin (not part of GumProjectSave), so there is no core-side
+            // reload to perform here (issue #3410).
             else if(extension == "behx")
             {
                 ReactToBehaviorChanged(file);

--- a/Gum/StateAnimationPlugin/MainStateAnimationPlugin.cs
+++ b/Gum/StateAnimationPlugin/MainStateAnimationPlugin.cs
@@ -28,6 +28,7 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
+using ToolsUtilities;
 
 
 namespace StateAnimationPlugin;
@@ -211,6 +212,12 @@ public class MainStateAnimationPlugin : PluginBase, IAnimationUndoProvider
         this.ElementRename += HandleElementRename;
         this.ElementDuplicate += HandleElementDuplicate;
 
+        // Live-reload the tab when the selected element's .ganx is edited on disk (issue #3410).
+        // FileChangeReactionLogic owns no animation data (the .ganx is a per-element sidecar loaded
+        // on demand here, not part of GumProjectSave), so the reload lives in this plugin rather than
+        // in the core dispatch.
+        this.ReactToFileChanged += HandleFileChanged;
+
         this.GetDeleteStateResponse = HandleGetDeleteStateResponse;
         this.GetDeleteStateCategoryResponse = HandleGetDeleteStateCategoryResponse;
 
@@ -227,6 +234,40 @@ public class MainStateAnimationPlugin : PluginBase, IAnimationUndoProvider
         // works on project open and on edits regardless of selection. Contributing them here too
         // (from this plugin's per-selection view model) would duplicate those errors for the
         // selected element, so this plugin no longer subscribes to GetAllErrors.
+    }
+
+    private void HandleFileChanged(FilePath filePath)
+    {
+        var selectedElement = _selectedState.SelectedElement;
+        var selectedElementAnimationFile = selectedElement != null
+            ? _animationFilePathService.GetAbsoluteAnimationFileNameFor(selectedElement)
+            : null;
+
+        if (ShouldReloadAnimationsForChangedFile(filePath, selectedElementAnimationFile))
+        {
+            // forceReload bypasses CreateViewModel's same-element early-out: the external edit doesn't
+            // change the selection, so without forcing it the stale view model would survive and the
+            // tab would keep showing the pre-edit animations until the element was reselected. Mirrors
+            // the after-undo repaint (#3406).
+            RefreshViewModel(forceReload: true);
+        }
+    }
+
+    /// <summary>
+    /// Decides whether an on-disk file change should live-reload the Animations tab (issue #3410):
+    /// true only when <paramref name="changedFile"/> is a <c>.ganx</c> and is the selected element's
+    /// own animation sidecar (<paramref name="selectedElementAnimationFile"/>). Other elements' .ganx
+    /// files reload lazily when that element is next selected, so they are ignored here.
+    /// </summary>
+    internal static bool ShouldReloadAnimationsForChangedFile(FilePath changedFile,
+        FilePath? selectedElementAnimationFile)
+    {
+        if (changedFile.Extension != "ganx")
+        {
+            return false;
+        }
+
+        return selectedElementAnimationFile != null && changedFile == selectedElementAnimationFile;
     }
 
     private void HandleElementSelected(ElementSave? element)

--- a/Gum/StateAnimationPlugin/MainStateAnimationPlugin.cs
+++ b/Gum/StateAnimationPlugin/MainStateAnimationPlugin.cs
@@ -245,11 +245,20 @@ public class MainStateAnimationPlugin : PluginBase, IAnimationUndoProvider
 
         if (ShouldReloadAnimationsForChangedFile(filePath, selectedElementAnimationFile))
         {
+            // Capture the selection before the rebuild replaces every animation/keyframe instance, then
+            // reapply it so the external edit doesn't deselect the user's animation + keyframe (#3410).
+            var selection = CaptureAnimationSelection(_viewModel);
+
             // forceReload bypasses CreateViewModel's same-element early-out: the external edit doesn't
             // change the selection, so without forcing it the stale view model would survive and the
             // tab would keep showing the pre-edit animations until the element was reselected. Mirrors
             // the after-undo repaint (#3406).
             RefreshViewModel(forceReload: true);
+
+            if (_viewModel != null)
+            {
+                RestoreAnimationSelection(_viewModel, selection);
+            }
         }
     }
 
@@ -398,13 +407,7 @@ public class MainStateAnimationPlugin : PluginBase, IAnimationUndoProvider
         // selection restore (#3406). Index + count are captured alongside the keyframe so the reselect
         // can fall back to position when the undo reverted the selected keyframe's own value (see
         // RestoreAnimationSelection).
-        var selectedAnimation = _viewModel?.SelectedAnimation;
-        var selectedKeyframe = selectedAnimation?.SelectedKeyframe;
-        var selection = new AnimationSelectionState(
-            selectedAnimation?.Name,
-            selectedKeyframe,
-            selectedKeyframe != null ? selectedAnimation!.Keyframes.IndexOf(selectedKeyframe) : -1,
-            selectedAnimation?.Keyframes.Count ?? 0);
+        var selection = CaptureAnimationSelection(_viewModel);
 
         // Repaint the tab from the just-restored .ganx, then re-arm undo recording. The flag spanned
         // the .ganx write (ApplyAnimations) through this repaint so neither flushed a spurious undo.
@@ -421,19 +424,46 @@ public class MainStateAnimationPlugin : PluginBase, IAnimationUndoProvider
         _isApplyingUndo = false;
     }
 
-    /// <summary>The animation/keyframe selection captured before an undo rebuilds the view model.</summary>
+    /// <summary>
+    /// The animation/keyframe selection captured before a forced view-model rebuild (undo/redo or an
+    /// external .ganx reload). Carries both the identity (animation name + keyframe content) and the
+    /// position (animation/keyframe index + sibling counts) so <see cref="RestoreAnimationSelection"/>
+    /// can fall back to the slot when the identity changed — e.g. the selected animation was renamed.
+    /// </summary>
     internal readonly record struct AnimationSelectionState(
         string? AnimationName,
         AnimatedKeyframeViewModel? Keyframe,
         int KeyframeIndex,
-        int KeyframeCount);
+        int KeyframeCount,
+        int AnimationIndex = -1,
+        int AnimationCount = 0);
+
+    /// <summary>
+    /// Snapshots the currently-selected animation and keyframe (identity + position) so the selection
+    /// can be reapplied after a forced view-model rebuild replaces every animation/keyframe instance.
+    /// Pairs with <see cref="RestoreAnimationSelection"/>.
+    /// </summary>
+    internal static AnimationSelectionState CaptureAnimationSelection(ElementAnimationsViewModel? viewModel)
+    {
+        var selectedAnimation = viewModel?.SelectedAnimation;
+        var selectedKeyframe = selectedAnimation?.SelectedKeyframe;
+        return new AnimationSelectionState(
+            selectedAnimation?.Name,
+            selectedKeyframe,
+            selectedKeyframe != null ? selectedAnimation!.Keyframes.IndexOf(selectedKeyframe) : -1,
+            selectedAnimation?.Keyframes.Count ?? 0,
+            selectedAnimation != null && viewModel != null ? viewModel.Animations.IndexOf(selectedAnimation) : -1,
+            viewModel?.Animations.Count ?? 0);
+    }
 
     /// <summary>
     /// Reselects, on a freshly-rebuilt <paramref name="viewModel"/>, the animation and keyframe captured
-    /// in <paramref name="selection"/>. The keyframe is matched by content; if that fails because the
+    /// in <paramref name="selection"/>. The animation is matched by name; if that fails because it was
+    /// renamed (e.g. an external .ganx edit), it falls back to the captured animation index when the
+    /// animation count is unchanged. The keyframe is then matched by content; if that fails because the
     /// undo reverted the selected keyframe's <em>own</em> value (e.g. its time), it falls back to the
-    /// captured index — but only when the keyframe count is unchanged, so an add/delete undo (which
-    /// changes the count) drops the selection rather than grabbing a neighbor. Returns the matched
+    /// captured index — but only when the keyframe count is unchanged, so an add/delete (which
+    /// changes the count) drops that selection rather than grabbing a neighbor. Returns the matched
     /// keyframe (or null). Best-effort, mirroring element-undo's silent selection drop when the selected
     /// object no longer exists.
     /// </summary>
@@ -455,6 +485,19 @@ public class MainStateAnimationPlugin : PluginBase, IAnimationUndoProvider
         }
 
         var animation = viewModel.Animations.FirstOrDefault(item => item.Name == selection.AnimationName);
+
+        // The selected animation may have been renamed by an external .ganx edit, so the captured name
+        // matches nothing. Fall back to the captured slot when the animation count is unchanged, keeping
+        // the same row selected through the rename (#3410). A count change means an add/delete, where
+        // grabbing a neighbor by index would be wrong, so the selection drops instead.
+        if (animation == null
+            && viewModel.Animations.Count == selection.AnimationCount
+            && selection.AnimationIndex >= 0
+            && selection.AnimationIndex < viewModel.Animations.Count)
+        {
+            animation = viewModel.Animations[selection.AnimationIndex];
+        }
+
         if (animation == null)
         {
             return null;

--- a/Tool/Tests/GumToolUnitTests/Plugins/StateAnimationPlugin/AnimationFileReloadTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/StateAnimationPlugin/AnimationFileReloadTests.cs
@@ -1,0 +1,55 @@
+using Shouldly;
+using StateAnimationPlugin;
+using ToolsUtilities;
+using Xunit;
+
+namespace GumToolUnitTests.Plugins.StateAnimationPlugin;
+
+/// <summary>
+/// Pins the decision the Animations tab uses to live-reload when a <c>.ganx</c> file is edited on
+/// disk (issue #3410): only the currently-selected element's animation sidecar should trigger a
+/// repaint, and only for the <c>.ganx</c> extension. The plugin subscribes to the file-watch
+/// <c>ReactToFileChanged</c> event for every changed file, so the extension and per-element gates
+/// both live in <see cref="MainStateAnimationPlugin.ShouldReloadAnimationsForChangedFile"/>.
+/// </summary>
+public class AnimationFileReloadTests
+{
+    [Fact]
+    public void ShouldReload_WhenChangedFileIsSelectedElementsAnimationFile()
+    {
+        FilePath changed = new FilePath(@"C:\Proj\Components\MyButtonAnimations.ganx");
+        FilePath selectedElementAnimationFile = new FilePath(@"C:\Proj\Components\MyButtonAnimations.ganx");
+
+        MainStateAnimationPlugin.ShouldReloadAnimationsForChangedFile(changed, selectedElementAnimationFile)
+            .ShouldBeTrue();
+    }
+
+    [Fact]
+    public void ShouldNotReload_WhenChangedGanxBelongsToADifferentElement()
+    {
+        FilePath changed = new FilePath(@"C:\Proj\Components\OtherAnimations.ganx");
+        FilePath selectedElementAnimationFile = new FilePath(@"C:\Proj\Components\MyButtonAnimations.ganx");
+
+        MainStateAnimationPlugin.ShouldReloadAnimationsForChangedFile(changed, selectedElementAnimationFile)
+            .ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ShouldNotReload_WhenChangedFileIsNotAGanx()
+    {
+        FilePath changed = new FilePath(@"C:\Proj\Components\MyButton.gucx");
+        FilePath selectedElementAnimationFile = new FilePath(@"C:\Proj\Components\MyButtonAnimations.ganx");
+
+        MainStateAnimationPlugin.ShouldReloadAnimationsForChangedFile(changed, selectedElementAnimationFile)
+            .ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ShouldNotReload_WhenNoElementHasAnAnimationFile()
+    {
+        FilePath changed = new FilePath(@"C:\Proj\Components\MyButtonAnimations.ganx");
+
+        MainStateAnimationPlugin.ShouldReloadAnimationsForChangedFile(changed, null)
+            .ShouldBeFalse();
+    }
+}

--- a/Tool/Tests/GumToolUnitTests/Plugins/StateAnimationPlugin/AnimationUndoTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/StateAnimationPlugin/AnimationUndoTests.cs
@@ -204,6 +204,53 @@ public class AnimationUndoTests : BaseTestClass
         });
     }
 
+    [Fact]
+    public void RestoreAnimationSelection_FallsBackToAnimationIndex_WhenSelectedAnimationWasRenamed()
+    {
+        // An external .ganx edit renamed the selected animation, so the captured name ("OldName")
+        // matches nothing in the rebuilt view model. Because the animation count is unchanged, fall
+        // back to the captured slot so the same row stays selected through the rename (#3410), and the
+        // keyframe is re-matched on it by content.
+        RunOnSta(() =>
+        {
+            ElementAnimationsViewModel rebuilt = ViewModelWithAnimation("NewName", out AnimationViewModel animation,
+                Keyframe("Default", 0f), Keyframe("Highlighted", 1f));
+            var selection = new MainStateAnimationPlugin.AnimationSelectionState(
+                "OldName", Keyframe("Highlighted", 1f), KeyframeIndex: 1, KeyframeCount: 2,
+                AnimationIndex: 0, AnimationCount: 1);
+
+            AnimatedKeyframeViewModel? matched =
+                MainStateAnimationPlugin.RestoreAnimationSelection(rebuilt, selection);
+
+            rebuilt.SelectedAnimation.ShouldBe(animation);
+            matched.ShouldNotBeNull();
+            matched!.StateName.ShouldBe("Highlighted");
+            animation.SelectedKeyframe.ShouldBe(matched);
+        });
+    }
+
+    [Fact]
+    public void RestoreAnimationSelection_DropsAnimationSelection_WhenRenamedAndAnimationCountChanged()
+    {
+        // The selected animation's name doesn't match AND the animation count changed (an animation was
+        // added/deleted in the external edit), so reselecting by index would grab an unrelated row.
+        // Drop the selection cleanly instead.
+        RunOnSta(() =>
+        {
+            ElementAnimationsViewModel rebuilt = ViewModelWithAnimation("NewName", out AnimationViewModel _,
+                Keyframe("Default", 0f));
+            var selection = new MainStateAnimationPlugin.AnimationSelectionState(
+                "OldName", Keyframe("Default", 0f), KeyframeIndex: 0, KeyframeCount: 1,
+                AnimationIndex: 1, AnimationCount: 2);
+
+            AnimatedKeyframeViewModel? matched =
+                MainStateAnimationPlugin.RestoreAnimationSelection(rebuilt, selection);
+
+            rebuilt.SelectedAnimation.ShouldBeNull();
+            matched.ShouldBeNull();
+        });
+    }
+
     private AnimatedKeyframeViewModel Keyframe(string stateName, float time)
         => new(_bitmapLoader) { StateName = stateName, Time = time };
 


### PR DESCRIPTION
## Problem

Editing a `.ganx` (animation collection) file on disk did not refresh the Gum UI — `FileChangeReactionLogic.ReactToFileChanged` deliberately printed a "restart Gum to reload" message instead of reloading (issue #3410). Every other Gum file type reloads live.

## Fix

The `.ganx` is a **per-element sidecar owned by the `StateAnimationPlugin`** — it's loaded on demand from disk, not part of `GumProjectSave` — so the core dispatch has no in-memory data to reload. The reload therefore lives in the plugin:

- `MainStateAnimationPlugin` now subscribes to the `ReactToFileChanged` plugin event and, when the changed file is the **currently-selected element's own** `.ganx`, force-reloads its view model (`RefreshViewModel(forceReload: true)`) — the same repaint path used after undo (#3406). Other elements' `.ganx` files still reload lazily when that element is next selected.
- The decision (extension gate + per-element match) is a pure static `ShouldReloadAnimationsForChangedFile`, unit-tested without WPF.
- `FileChangeReactionLogic`'s `.ganx` stub branch is removed; a comment points to the plugin path (`_pluginManager.ReactToFileChanged` already runs for every file).

## Tests

`AnimationFileReloadTests` (4 cases): selected element's `.ganx` → reload; a different element's `.ganx` → no; a non-`.ganx` change → no; no animation file → no. Full `GumToolUnitTests` StateAnimationPlugin + FileChange suites green (61), `GumFull.sln` builds clean.

## Manual test

Needed — runtime/UI behavior. VS is open; with a project loaded: select an element that has animations, open the Animations tab, edit its `*Animations.ganx` in an external editor (e.g. add/rename an animation) and save. The tab should refresh within ~2s (the file-watch flush) without restarting Gum.

Closes #3410

🤖 Generated with [Claude Code](https://claude.com/claude-code)
