### PR TITLE
Show broken-keyframe indicator on animation list rows (#3401)

### DIFF
--- a/Gum/StateAnimationPlugin/ViewModels/AnimationViewModel.cs
+++ b/Gum/StateAnimationPlugin/ViewModels/AnimationViewModel.cs
@@ -66,6 +66,13 @@ public partial class AnimationViewModel : ViewModel
         set => Set(value);
     }
 
+    /// <summary>
+    /// True when any keyframe references a missing state or animation. Drives the animation-list
+    /// error icon (issue #3401); mirrors <see cref="GetErrors"/> and
+    /// <see cref="AnimatedKeyframeViewModel.IsMissingReference"/>.
+    /// </summary>
+    public bool HasBrokenKeyframe => Keyframes.Any(keyframe => keyframe.IsMissingReference);
+
     public ObservableCollection<AnimatedKeyframeViewModel> Keyframes { get; private set; }
 
     public event PropertyChangedEventHandler? FramePropertyChanged;
@@ -270,6 +277,7 @@ public partial class AnimationViewModel : ViewModel
         NotifyPropertyChanged(nameof(Length));
 
         NotifyPropertyChanged(nameof(Keyframes));
+        NotifyPropertyChanged(nameof(HasBrokenKeyframe));
 
         if (_selectedState.SelectedElement != null)
         {
@@ -301,9 +309,19 @@ public partial class AnimationViewModel : ViewModel
                     RefreshCumulativeStates(_selectedState.SelectedElement);
                 }
                 break;
-
+            case nameof(AnimatedKeyframeViewModel.HasValidState):
+            case nameof(AnimatedKeyframeViewModel.AnimationName):
+            case nameof(AnimatedKeyframeViewModel.IsMissingReference):
+                NotifyPropertyChanged(nameof(HasBrokenKeyframe));
+                return;
             default:
                 return;
+        }
+
+        if (e.PropertyName is nameof(AnimatedKeyframeViewModel.StateName)
+            or nameof(AnimatedKeyframeViewModel.AnimationName))
+        {
+            NotifyPropertyChanged(nameof(HasBrokenKeyframe));
         }
 
         FramePropertyChanged?.Invoke(sender, e);
@@ -431,6 +449,8 @@ public partial class AnimationViewModel : ViewModel
                 keyframe.HasValidState = keyframe.SubAnimationViewModel != null;
             }
         }
+
+        NotifyPropertyChanged(nameof(HasBrokenKeyframe));
     }
 
     #endregion

--- a/Gum/StateAnimationPlugin/Views/MainWindow.xaml
+++ b/Gum/StateAnimationPlugin/Views/MainWindow.xaml
@@ -205,6 +205,7 @@
                             <Grid>
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="Auto" />
                                     <ColumnDefinition />
                                 </Grid.ColumnDefinitions>
                                 <ToggleButton IsChecked="{Binding Loops, Mode=TwoWay}">
@@ -235,8 +236,19 @@
                                         </Style>
                                     </ToggleButton.Style>
                                 </ToggleButton>
-                                <TextBlock
+                                <wpf:FluentIcon
                                     Grid.Column="1"
+                                    Icon="ErrorCircle"
+                                    Visibility="{Binding HasBrokenKeyframe, Converter={StaticResource BoolToVisibilityConverter}}">
+                                    <wpf:FluentIcon.Style>
+                                        <Style BasedOn="{StaticResource FluentIcon.ButtonSize}" TargetType="{x:Type wpf:FluentIcon}">
+                                            <Setter Property="Foreground" Value="{DynamicResource Frb.Brushes.Error}" />
+                                            <Setter Property="ToolTip" Value="This animation contains a keyframe that references a missing state or animation." />
+                                        </Style>
+                                    </wpf:FluentIcon.Style>
+                                </wpf:FluentIcon>
+                                <TextBlock
+                                    Grid.Column="2"
                                     Margin="6,0,0,0"
                                     VerticalAlignment="Center"
                                     Text="{Binding Name}" />

--- a/Tool/Tests/GumToolUnitTests/Plugins/StateAnimationPlugin/AnimationViewModelBrokenKeyframeTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/StateAnimationPlugin/AnimationViewModelBrokenKeyframeTests.cs
@@ -1,0 +1,104 @@
+using Gum.ToolStates;
+using Gum.Wireframe;
+using Moq;
+using Shouldly;
+using StateAnimationPlugin.Managers;
+using StateAnimationPlugin.ViewModels;
+using System.Collections.Generic;
+using System.ComponentModel;
+using Xunit;
+
+namespace GumToolUnitTests.Plugins.StateAnimationPlugin;
+
+/// <summary>
+/// Pins <see cref="AnimationViewModel.HasBrokenKeyframe"/>, the flag the animation list uses to
+/// show a broken-keyframe indicator without replacing the functional loop toggle (issue #3401).
+/// Mirrors <see cref="AnimatedKeyframeViewModel.IsMissingReference"/> aggregated across keyframes.
+/// </summary>
+public class AnimationViewModelBrokenKeyframeTests : BaseTestClass
+{
+    private readonly IBitmapLoader _bitmapLoader = Mock.Of<IBitmapLoader>();
+    private readonly ISelectedState _selectedState = Mock.Of<ISelectedState>();
+    private readonly IWireframeObjectManager _wireframeObjectManager = Mock.Of<IWireframeObjectManager>();
+
+    [Fact]
+    public void HasBrokenKeyframe_IsFalse_WhenAllKeyframesAreValid()
+    {
+        AnimationViewModel animation = CreateAnimation(
+            Keyframe(stateName: "Cat/Idle", hasValidState: true),
+            Keyframe(eventName: "OnSomething", hasValidState: false));
+
+        animation.HasBrokenKeyframe.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void HasBrokenKeyframe_IsTrue_WhenAnyKeyframeHasMissingReference()
+    {
+        AnimationViewModel animation = CreateAnimation(
+            Keyframe(stateName: "Cat/Idle", hasValidState: true),
+            Keyframe(stateName: "Cat/Missing", hasValidState: false));
+
+        animation.HasBrokenKeyframe.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void ChangingKeyframeHasValidState_RaisesPropertyChanged_ForHasBrokenKeyframe()
+    {
+        AnimatedKeyframeViewModel keyframe = Keyframe(stateName: "Cat/Idle", hasValidState: true);
+        AnimationViewModel animation = CreateAnimation(keyframe);
+        List<string> changed = new List<string>();
+        animation.PropertyChanged += (_, e) => changed.Add(e.PropertyName ?? "");
+
+        keyframe.HasValidState = false;
+
+        changed.ShouldContain(nameof(AnimationViewModel.HasBrokenKeyframe));
+    }
+
+    [Fact]
+    public void RefreshErrors_UpdatesHasBrokenKeyframe_WhenMissingStateIsDetected()
+    {
+        Gum.DataTypes.ComponentSave element = ElementWithCategorizedState("Cat", "Idle");
+        AnimatedKeyframeViewModel keyframe = Keyframe(stateName: "Cat/Missing", hasValidState: true);
+        AnimationViewModel animation = CreateAnimation(keyframe);
+
+        animation.HasBrokenKeyframe.ShouldBeFalse();
+
+        animation.RefreshErrors(element);
+
+        animation.HasBrokenKeyframe.ShouldBeTrue();
+    }
+
+    private static Gum.DataTypes.ComponentSave ElementWithCategorizedState(string categoryName, string stateName)
+    {
+        Gum.DataTypes.Variables.StateSaveCategory category = new Gum.DataTypes.Variables.StateSaveCategory { Name = categoryName };
+        category.States.Add(new Gum.DataTypes.Variables.StateSave { Name = stateName });
+        Gum.DataTypes.ComponentSave element = new Gum.DataTypes.ComponentSave { Name = "Foo" };
+        element.Categories.Add(category);
+        return element;
+    }
+
+    private AnimatedKeyframeViewModel Keyframe(string? stateName = null, string? eventName = null, bool hasValidState = false)
+    {
+        AnimatedKeyframeViewModel keyframe = new AnimatedKeyframeViewModel(_bitmapLoader);
+        if (stateName != null)
+        {
+            keyframe.StateName = stateName;
+        }
+        if (eventName != null)
+        {
+            keyframe.EventName = eventName;
+        }
+        keyframe.HasValidState = hasValidState;
+        return keyframe;
+    }
+
+    private AnimationViewModel CreateAnimation(params AnimatedKeyframeViewModel[] keyframes)
+    {
+        AnimationViewModel animation = new AnimationViewModel(_bitmapLoader, _selectedState, _wireframeObjectManager) { Name = "Anim" };
+        foreach (AnimatedKeyframeViewModel keyframe in keyframes)
+        {
+            animation.Keyframes.Add(keyframe);
+        }
+        return animation;
+    }
+}


### PR DESCRIPTION
## Summary

- Add `AnimationViewModel.HasBrokenKeyframe` (aggregates per-keyframe `IsMissingReference`) with reactive updates when keyframes change or `RefreshErrors` runs.
- Show a red `ErrorCircle` icon beside the loop/play-once toggle in the animation list when an animation contains a broken keyframe, matching the existing per-keyframe error icon pattern.
- Unit tests pin the computed property and `PropertyChanged` contract.

Closes #3401

## Test plan

- [x] `dotnet test Tool/Tests/GumToolUnitTests/GumToolUnitTests.csproj --filter "AnimationViewModelBrokenKeyframeTests|AnimationStateRenameErrorTests|AnimatedKeyframeViewModelTests"`
- [x] Manual: open an element with animations, create or load an animation whose keyframe references a missing state — confirm a red error icon appears on the animation row (next to the loop toggle) without selecting/expanding keyframes.
