### PR TITLE
Expose KernSmith baked text drop shadows at runtime (#2724)

### DIFF
--- a/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
+++ b/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
@@ -1537,14 +1537,7 @@ public class CustomSetPropertyOnRenderable
 
                 string? fontFilePath = BmfcSave.IsFontFilePath(textRuntime.Font) ? textRuntime.Font : null;
 
-                string fontName = global::RenderingLibrary.Graphics.Fonts.BmfcSave.GetFontCacheFileNameFor(
-                    textRuntime.FontSize,
-                    textRuntime.Font,
-                    textRuntime.OutlineThickness,
-                    textRuntime.UseFontSmoothing,
-                    textRuntime.IsItalic,
-                    textRuntime.IsBold,
-                    fontFilePath);
+                string fontName = textRuntime.GetFontCacheFileName(fontFilePath);
 
                 string fullFileName = ToolsUtilities.FileManager.Standardize(fontName, preserveCase: true, makeAbsolute: true);
 
@@ -1563,21 +1556,9 @@ public class CustomSetPropertyOnRenderable
                     try
                     {
                         BmfcSave bmfcSave = new BmfcSave();
-                        bmfcSave.FontSize = textRuntime.FontSize;
-                        bmfcSave.OutlineThickness = textRuntime.OutlineThickness;
-                        bmfcSave.UseSmoothing = textRuntime.UseFontSmoothing;
-                        bmfcSave.IsItalic = textRuntime.IsItalic;
-                        bmfcSave.IsBold = textRuntime.IsBold;
-
-                        if (fontFilePath != null)
-                        {
-                            bmfcSave.FontFile = ResolveFontFilePath(fontFilePath);
-                            bmfcSave.FontName = System.IO.Path.GetFileNameWithoutExtension(fontFilePath);
-                        }
-                        else
-                        {
-                            bmfcSave.FontName = textRuntime.Font;
-                        }
+                        textRuntime.CopyFontGenerationFieldsTo(
+                            bmfcSave,
+                            fontFilePath != null ? ResolveFontFilePath(fontFilePath) : null);
 
                         var gumProject = ObjectFinder.Self.GumProjectSave;
                         bmfcSave.Ranges = gumProject?.FontRanges ?? BmfcSave.GetEffectiveDefaultRanges();
@@ -1605,21 +1586,9 @@ public class CustomSetPropertyOnRenderable
                     try
                     {
                         BmfcSave bmfcSave = new BmfcSave();
-                        bmfcSave.FontSize = textRuntime.FontSize;
-                        bmfcSave.OutlineThickness = textRuntime.OutlineThickness;
-                        bmfcSave.UseSmoothing = textRuntime.UseFontSmoothing;
-                        bmfcSave.IsItalic = textRuntime.IsItalic;
-                        bmfcSave.IsBold = textRuntime.IsBold;
-
-                        if (fontFilePath != null)
-                        {
-                            bmfcSave.FontFile = ResolveFontFilePath(fontFilePath);
-                            bmfcSave.FontName = System.IO.Path.GetFileNameWithoutExtension(fontFilePath);
-                        }
-                        else
-                        {
-                            bmfcSave.FontName = textRuntime.Font;
-                        }
+                        textRuntime.CopyFontGenerationFieldsTo(
+                            bmfcSave,
+                            fontFilePath != null ? ResolveFontFilePath(fontFilePath) : null);
 
                         var gumProject = ObjectFinder.Self.GumProjectSave;
                         bmfcSave.Ranges = gumProject?.FontRanges ?? BmfcSave.GetEffectiveDefaultRanges();
@@ -2267,13 +2236,8 @@ public class CustomSetPropertyOnRenderable
                 {
                     if (textRuntime.FontSize > 0 && !string.IsNullOrEmpty(textRuntime.Font))
                     {
-                        string fontName = global::RenderingLibrary.Graphics.Fonts.BmfcSave.GetFontCacheFileNameFor(
-                            textRuntime.FontSize,
-                            textRuntime.Font,
-                            textRuntime.OutlineThickness,
-                            textRuntime.UseFontSmoothing,
-                            textRuntime.IsItalic,
-                            textRuntime.IsBold);
+                        string fontName = textRuntime.GetFontCacheFileName(
+                            BmfcSave.IsFontFilePath(textRuntime.Font) ? textRuntime.Font : null);
 
                         var standardized = ToolsUtilities.FileManager.Standardize(fontName, preserveCase: true, makeAbsolute: true);
 

--- a/Integrations/KernSmith/KernSmith.GumCommon/GumFontGenerator.cs
+++ b/Integrations/KernSmith/KernSmith.GumCommon/GumFontGenerator.cs
@@ -52,6 +52,32 @@ public static class GumFontGenerator
         options.MaxTextureWidth = bmfcSave.OutputWidth;
         options.MaxTextureHeight = bmfcSave.OutputHeight;
 
+        ApplyChannelLayout(bmfcSave, options);
+
+        List<int> codepoints = ParseCharRanges(bmfcSave.Ranges);
+        options.Characters = CharacterSet.FromChars(codepoints);
+
+        ApplyShadowOptions(bmfcSave, options);
+
+        return options;
+    }
+
+    /// <summary>
+    /// Selects BMFont channel layout for Gum's text renderer, or leaves channels at the KernSmith
+    /// default when baked effects need full RGBA preserved.
+    /// </summary>
+    private static void ApplyChannelLayout(BmfcSave bmfcSave, FontGeneratorOptions options)
+    {
+        // Drop shadow (and outline/shadow combos) are composited to RGBA by KernSmith's effect
+        // pipeline. A custom ChannelConfig routes through ChannelCompositor, which rebuilds RGB from
+        // alpha masks only — discarding baked shadow color and forcing white (RGB=One), so the
+        // runtime's text-color modulate tints the shadow the same as the glyph. Leave Channels unset
+        // so AtlasBuilder blits the RGBA glyphs directly.
+        if (bmfcSave.HasDropshadow)
+        {
+            return;
+        }
+
         // Match bmfont.exe channel layout so Gum's runtime renders correctly.
         // No outline: alpha=glyph shape, RGB=white (One). Glyph is white text with alpha transparency.
         // With outline: alpha=outline, RGB=glyph. Outline uses color channels.
@@ -71,11 +97,22 @@ public static class GumFontGenerator
                 Green: ChannelContent.Glyph,
                 Blue: ChannelContent.Glyph);
         }
+    }
 
-        List<int> codepoints = ParseCharRanges(bmfcSave.Ranges);
-        options.Characters = CharacterSet.FromChars(codepoints);
+    private static void ApplyShadowOptions(BmfcSave bmfcSave, FontGeneratorOptions options)
+    {
+        if (!bmfcSave.HasDropshadow)
+        {
+            return;
+        }
 
-        return options;
+        options.ShadowOffsetX = (int)MathF.Round(bmfcSave.DropshadowOffsetX);
+        options.ShadowOffsetY = (int)MathF.Round(bmfcSave.DropshadowOffsetY);
+        options.ShadowBlur = (int)MathF.Round(bmfcSave.DropshadowBlur);
+        options.ShadowR = bmfcSave.DropshadowRed;
+        options.ShadowG = bmfcSave.DropshadowGreen;
+        options.ShadowB = bmfcSave.DropshadowBlue;
+        options.ShadowOpacity = bmfcSave.DropshadowAlpha / 255f;
     }
 
     /// <summary>

--- a/MonoGameGum/GueDeriving/TextRuntime.cs
+++ b/MonoGameGum/GueDeriving/TextRuntime.cs
@@ -11,6 +11,7 @@ using Gum.RenderingLibrary;
 using Gum.Wireframe;
 using RenderingLibrary;
 using RenderingLibrary.Graphics;
+using RenderingLibrary.Graphics.Fonts;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -269,6 +270,7 @@ public class TextRuntime : InteractiveGue
     /// * IsBold
     /// * UseFontSmoothing
     /// * OutlineThickness
+    /// * HasDropshadow and dropshadow fields (when <see cref="HasDropshadow"/> is true)
     /// </summary>
     public bool UseCustomFont
     {
@@ -368,6 +370,171 @@ public class TextRuntime : InteractiveGue
         get { return outlineThickness; }
         set { outlineThickness = value; UpdateToFontValues(); }
     }
+
+    bool hasDropshadow;
+    /// <summary>
+    /// When true, KernSmith bakes a drop shadow into the font atlas using the dropshadow fields below.
+    /// </summary>
+    public bool HasDropshadow
+    {
+        get => hasDropshadow;
+        set
+        {
+            if (value && !hasDropshadow)
+            {
+                SeedDefaultDropshadowIfUnset();
+            }
+
+            hasDropshadow = value;
+            UpdateToFontValues();
+        }
+    }
+
+    byte dropshadowRed;
+    byte dropshadowGreen;
+    byte dropshadowBlue;
+    byte dropshadowAlpha = 180;
+
+    /// <summary>
+    /// Color of the baked glyph drop shadow. Alpha is decomposed into KernSmith opacity at generation time.
+    /// </summary>
+    public Color DropshadowColor
+    {
+        get => new Color(dropshadowRed, dropshadowGreen, dropshadowBlue, dropshadowAlpha);
+        set
+        {
+#if SKIA
+            dropshadowRed = value.Red;
+            dropshadowGreen = value.Green;
+            dropshadowBlue = value.Blue;
+            dropshadowAlpha = value.Alpha;
+#else
+            dropshadowRed = value.R;
+            dropshadowGreen = value.G;
+            dropshadowBlue = value.B;
+            dropshadowAlpha = value.A;
+#endif
+            UpdateToFontValues();
+        }
+    }
+
+    public int DropshadowRed
+    {
+        get => dropshadowRed;
+        set { dropshadowRed = (byte)value; UpdateToFontValues(); }
+    }
+
+    public int DropshadowGreen
+    {
+        get => dropshadowGreen;
+        set { dropshadowGreen = (byte)value; UpdateToFontValues(); }
+    }
+
+    public int DropshadowBlue
+    {
+        get => dropshadowBlue;
+        set { dropshadowBlue = (byte)value; UpdateToFontValues(); }
+    }
+
+    public int DropshadowAlpha
+    {
+        get => dropshadowAlpha;
+        set { dropshadowAlpha = (byte)value; UpdateToFontValues(); }
+    }
+
+    float dropshadowOffsetX;
+    public float DropshadowOffsetX
+    {
+        get => dropshadowOffsetX;
+        set { dropshadowOffsetX = value; UpdateToFontValues(); }
+    }
+
+    float dropshadowOffsetY;
+    public float DropshadowOffsetY
+    {
+        get => dropshadowOffsetY;
+        set { dropshadowOffsetY = value; UpdateToFontValues(); }
+    }
+
+    float dropshadowBlur;
+    /// <summary>
+    /// Blur radius for the baked drop shadow, passed to KernSmith as a single scalar.
+    /// </summary>
+    public float DropshadowBlur
+    {
+        get => dropshadowBlur;
+        set { dropshadowBlur = Math.Max(0f, value); UpdateToFontValues(); }
+    }
+
+    /// <summary>
+    /// Applies the first-enable defaults for baked shadow so toggling <see cref="HasDropshadow"/>
+    /// on at runtime produces a visible dark shadow without further setup.
+    /// </summary>
+    void SeedDefaultDropshadowIfUnset()
+    {
+        if (dropshadowOffsetX == 0f && dropshadowOffsetY == 0f && dropshadowBlur == 0f)
+        {
+            dropshadowOffsetY = 3f;
+            dropshadowBlur = 2f;
+        }
+    }
+
+#if !FRB
+    /// <summary>
+    /// Copies font-generation fields (including dropshadow) onto a <see cref="RenderingLibrary.Graphics.Fonts.BmfcSave"/>
+    /// for KernSmith or disk-cache font creation.
+    /// </summary>
+    internal void CopyFontGenerationFieldsTo(BmfcSave bmfcSave, string? resolvedFontFilePath)
+    {
+        bmfcSave.FontSize = FontSize;
+        bmfcSave.OutlineThickness = OutlineThickness;
+        bmfcSave.UseSmoothing = UseFontSmoothing;
+        bmfcSave.IsItalic = IsItalic;
+        bmfcSave.IsBold = IsBold;
+        bmfcSave.HasDropshadow = HasDropshadow;
+        bmfcSave.DropshadowOffsetX = DropshadowOffsetX;
+        bmfcSave.DropshadowOffsetY = DropshadowOffsetY;
+        bmfcSave.DropshadowBlur = DropshadowBlur;
+        bmfcSave.DropshadowRed = dropshadowRed;
+        bmfcSave.DropshadowGreen = dropshadowGreen;
+        bmfcSave.DropshadowBlue = dropshadowBlue;
+        bmfcSave.DropshadowAlpha = dropshadowAlpha;
+
+        if (resolvedFontFilePath != null)
+        {
+            bmfcSave.FontFile = resolvedFontFilePath;
+            bmfcSave.FontName = System.IO.Path.GetFileNameWithoutExtension(resolvedFontFilePath);
+        }
+        else
+        {
+            bmfcSave.FontName = Font;
+            bmfcSave.FontFile = null;
+        }
+    }
+
+    /// <summary>
+    /// Gets the FontCache file name for the current font property tuple, including dropshadow when enabled.
+    /// </summary>
+    internal string GetFontCacheFileName(string? fontFilePath)
+    {
+        return BmfcSave.GetFontCacheFileNameFor(
+            FontSize,
+            Font,
+            OutlineThickness,
+            UseFontSmoothing,
+            IsItalic,
+            IsBold,
+            fontFilePath,
+            HasDropshadow,
+            DropshadowOffsetX,
+            DropshadowOffsetY,
+            DropshadowBlur,
+            dropshadowRed,
+            dropshadowGreen,
+            dropshadowBlue,
+            dropshadowAlpha);
+    }
+#endif
 
     public TextOverflowHorizontalMode TextOverflowHorizontalMode
     {

--- a/RenderingLibrary/Graphics/Fonts/BmfcSave.cs
+++ b/RenderingLibrary/Graphics/Fonts/BmfcSave.cs
@@ -47,6 +47,47 @@ public class BmfcSave
     public bool IsBold = false;
 
     /// <summary>
+    /// When true, KernSmith bakes a drop shadow into the font atlas using the dropshadow fields below.
+    /// When false, dropshadow fields are ignored and do not affect <see cref="FontCacheFileName"/>.
+    /// </summary>
+    public bool HasDropshadow = false;
+
+    /// <summary>
+    /// Horizontal shadow offset in pixels passed to KernSmith.
+    /// </summary>
+    public float DropshadowOffsetX = 0f;
+
+    /// <summary>
+    /// Vertical shadow offset in pixels passed to KernSmith.
+    /// </summary>
+    public float DropshadowOffsetY = 0f;
+
+    /// <summary>
+    /// Shadow blur radius passed to KernSmith as a single scalar.
+    /// </summary>
+    public float DropshadowBlur = 0f;
+
+    /// <summary>
+    /// Shadow color red channel (0-255). Decomposed into KernSmith RGB at generation time.
+    /// </summary>
+    public byte DropshadowRed = 0;
+
+    /// <summary>
+    /// Shadow color green channel (0-255).
+    /// </summary>
+    public byte DropshadowGreen = 0;
+
+    /// <summary>
+    /// Shadow color blue channel (0-255).
+    /// </summary>
+    public byte DropshadowBlue = 0;
+
+    /// <summary>
+    /// Shadow color alpha channel (0-255). Decomposed into KernSmith <c>ShadowOpacity</c> as alpha/255.
+    /// </summary>
+    public byte DropshadowAlpha = 0;
+
+    /// <summary>
     /// The .ttf font file path when using a file-based font, or null/empty for system fonts.
     /// </summary>
     public string? FontFile = null;
@@ -552,7 +593,22 @@ public class BmfcSave
     {
         get
         {
-            return GetFontCacheFileNameFor(FontSize, FontName, OutlineThickness, UseSmoothing, IsItalic, IsBold, FontFile);
+            return GetFontCacheFileNameFor(
+                FontSize,
+                FontName,
+                OutlineThickness,
+                UseSmoothing,
+                IsItalic,
+                IsBold,
+                FontFile,
+                HasDropshadow,
+                DropshadowOffsetX,
+                DropshadowOffsetY,
+                DropshadowBlur,
+                DropshadowRed,
+                DropshadowGreen,
+                DropshadowBlue,
+                DropshadowAlpha);
         }
 
     }
@@ -572,7 +628,10 @@ public class BmfcSave
     /// as the font name and a "_ttf" suffix is appended to prevent collision with same-named system fonts.</param>
     /// <returns>A relative file path under "FontCache/" suitable for caching this font.</returns>
     public static string GetFontCacheFileNameFor(int fontSize, string fontName, int outline, bool useFontSmoothing,
-        bool isItalic = false, bool isBold = false, string? fontFilePath = null)
+        bool isItalic = false, bool isBold = false, string? fontFilePath = null,
+        bool hasDropshadow = false, float dropshadowOffsetX = 0f, float dropshadowOffsetY = 0f,
+        float dropshadowBlur = 0f, byte dropshadowRed = 0, byte dropshadowGreen = 0, byte dropshadowBlue = 0,
+        byte dropshadowAlpha = 0)
     {
         string fileName = null;
 
@@ -617,11 +676,28 @@ public class BmfcSave
             fileName += "_Bold";
         }
 
+        if (hasDropshadow)
+        {
+            fileName += "_ds"
+                + FormatCacheKeyFloat(dropshadowOffsetX) + "_"
+                + FormatCacheKeyFloat(dropshadowOffsetY) + "_"
+                + FormatCacheKeyFloat(dropshadowBlur) + "_"
+                + dropshadowRed + "_"
+                + dropshadowGreen + "_"
+                + dropshadowBlue + "_"
+                + dropshadowAlpha;
+        }
+
         fileName += ".fnt";
 
         fileName = System.IO.Path.Combine("FontCache", fileName);
 
         return fileName;
+    }
+
+    private static string FormatCacheKeyFloat(float value)
+    {
+        return value.ToString("0.###", System.Globalization.CultureInfo.InvariantCulture);
     }
 
 

--- a/Runtimes/RaylibGum/Renderables/CustomSetPropertyOnRenderable.cs
+++ b/Runtimes/RaylibGum/Renderables/CustomSetPropertyOnRenderable.cs
@@ -655,13 +655,8 @@ public class CustomSetPropertyOnRenderable
             {
                 if (textRuntime.FontSize > 0 && !string.IsNullOrEmpty(textRuntime.Font))
                 {
-                    string fontName = global::RenderingLibrary.Graphics.Fonts.BmfcSave.GetFontCacheFileNameFor(
-                    textRuntime.FontSize,
-                    textRuntime.Font,
-                    textRuntime.OutlineThickness,
-                    textRuntime.UseFontSmoothing,
-                    textRuntime.IsItalic,
-                    textRuntime.IsBold);
+                    string fontName = textRuntime.GetFontCacheFileName(
+                        BmfcSave.IsFontFilePath(textRuntime.Font) ? textRuntime.Font : null);
 
                     string fullFileName = ToolsUtilities.FileManager.Standardize(fontName, preserveCase: true, makeAbsolute: true);
 
@@ -694,12 +689,7 @@ public class CustomSetPropertyOnRenderable
                         try
                         {
                             BmfcSave bmfcSave = new BmfcSave();
-                            bmfcSave.FontSize = textRuntime.FontSize;
-                            bmfcSave.OutlineThickness = textRuntime.OutlineThickness;
-                            bmfcSave.UseSmoothing = textRuntime.UseFontSmoothing;
-                            bmfcSave.IsItalic = textRuntime.IsItalic;
-                            bmfcSave.IsBold = textRuntime.IsBold;
-                            bmfcSave.FontName = textRuntime.Font;
+                            textRuntime.CopyFontGenerationFieldsTo(bmfcSave, resolvedFontFilePath: null);
 
                             var gumProject = ObjectFinder.Self.GumProjectSave;
                             bmfcSave.Ranges = gumProject?.FontRanges ?? BmfcSave.GetEffectiveDefaultRanges();

--- a/Runtimes/SokolGum/GueDeriving/TextRuntime.cs
+++ b/Runtimes/SokolGum/GueDeriving/TextRuntime.cs
@@ -203,6 +203,94 @@ public class TextRuntime : InteractiveGue
         set { outlineThickness = value; UpdateToFontValues(); }
     }
 
+    bool hasDropshadow;
+    public bool HasDropshadow
+    {
+        get => hasDropshadow;
+        set
+        {
+            if (value && !hasDropshadow)
+            {
+                SeedDefaultDropshadowIfUnset();
+            }
+
+            hasDropshadow = value;
+            UpdateToFontValues();
+        }
+    }
+
+    byte dropshadowRed;
+    byte dropshadowGreen;
+    byte dropshadowBlue;
+    byte dropshadowAlpha = 180;
+
+    public SokolGum.Color DropshadowColor
+    {
+        get => new SokolGum.Color(dropshadowRed, dropshadowGreen, dropshadowBlue, dropshadowAlpha);
+        set
+        {
+            dropshadowRed = value.R;
+            dropshadowGreen = value.G;
+            dropshadowBlue = value.B;
+            dropshadowAlpha = value.A;
+            UpdateToFontValues();
+        }
+    }
+
+    public int DropshadowRed
+    {
+        get => dropshadowRed;
+        set { dropshadowRed = (byte)value; UpdateToFontValues(); }
+    }
+
+    public int DropshadowGreen
+    {
+        get => dropshadowGreen;
+        set { dropshadowGreen = (byte)value; UpdateToFontValues(); }
+    }
+
+    public int DropshadowBlue
+    {
+        get => dropshadowBlue;
+        set { dropshadowBlue = (byte)value; UpdateToFontValues(); }
+    }
+
+    public int DropshadowAlpha
+    {
+        get => dropshadowAlpha;
+        set { dropshadowAlpha = (byte)value; UpdateToFontValues(); }
+    }
+
+    float dropshadowOffsetX;
+    public float DropshadowOffsetX
+    {
+        get => dropshadowOffsetX;
+        set { dropshadowOffsetX = value; UpdateToFontValues(); }
+    }
+
+    float dropshadowOffsetY;
+    public float DropshadowOffsetY
+    {
+        get => dropshadowOffsetY;
+        set { dropshadowOffsetY = value; UpdateToFontValues(); }
+    }
+
+    float dropshadowBlur;
+    public float DropshadowBlur
+    {
+        get => dropshadowBlur;
+        set { dropshadowBlur = Math.Max(0f, value); UpdateToFontValues(); }
+    }
+
+    void SeedDefaultDropshadowIfUnset()
+    {
+        if (dropshadowOffsetX == 0f && dropshadowOffsetY == 0f && dropshadowBlur == 0f)
+        {
+            dropshadowOffsetY = 3f;
+            dropshadowBlur = 2f;
+        }
+    }
+
     public string? Text
     {
         get => ContainedText.RawText;

--- a/Samples/FontPlayground/Shared/FontPlaygroundScreen.cs
+++ b/Samples/FontPlayground/Shared/FontPlaygroundScreen.cs
@@ -37,6 +37,13 @@ public class FontPlaygroundScreen
     private Slider _outlineSlider = null!;
     private Label _outlineLabel = null!;
     private CheckBox _smoothingCheckBox = null!;
+    private CheckBox _dropshadowCheckBox = null!;
+    private Slider _dropshadowOffsetXSlider = null!;
+    private Slider _dropshadowOffsetYSlider = null!;
+    private Slider _dropshadowBlurSlider = null!;
+    private Label _dropshadowOffsetXLabel = null!;
+    private Label _dropshadowOffsetYLabel = null!;
+    private Label _dropshadowBlurLabel = null!;
     private TextRuntime _previewText = null!;
 
     /// <summary>
@@ -129,6 +136,53 @@ public class FontPlaygroundScreen
         _smoothingCheckBox.Unchecked += (_, _) => ApplyFontSettings();
         controlsPanel.AddChild(_smoothingCheckBox);
 
+        // Drop shadow (KernSmith baked atlas)
+        _dropshadowCheckBox = new CheckBox();
+        _dropshadowCheckBox.Text = "Drop Shadow";
+        _dropshadowCheckBox.Width = 240;
+        _dropshadowCheckBox.Checked += (_, _) => ApplyFontSettings();
+        _dropshadowCheckBox.Unchecked += (_, _) => ApplyFontSettings();
+        controlsPanel.AddChild(_dropshadowCheckBox);
+
+        _dropshadowOffsetXLabel = new Label();
+        controlsPanel.AddChild(_dropshadowOffsetXLabel);
+
+        _dropshadowOffsetXSlider = new Slider();
+        _dropshadowOffsetXSlider.Width = 240;
+        _dropshadowOffsetXSlider.Minimum = 0;
+        _dropshadowOffsetXSlider.Maximum = 8;
+        _dropshadowOffsetXSlider.IsSnapToTickEnabled = true;
+        _dropshadowOffsetXSlider.TicksFrequency = 1;
+        _dropshadowOffsetXSlider.Value = 2;
+        _dropshadowOffsetXSlider.ValueChanged += (_, _) => ApplyFontSettings();
+        controlsPanel.AddChild(_dropshadowOffsetXSlider);
+
+        _dropshadowOffsetYLabel = new Label();
+        controlsPanel.AddChild(_dropshadowOffsetYLabel);
+
+        _dropshadowOffsetYSlider = new Slider();
+        _dropshadowOffsetYSlider.Width = 240;
+        _dropshadowOffsetYSlider.Minimum = 0;
+        _dropshadowOffsetYSlider.Maximum = 8;
+        _dropshadowOffsetYSlider.IsSnapToTickEnabled = true;
+        _dropshadowOffsetYSlider.TicksFrequency = 1;
+        _dropshadowOffsetYSlider.Value = 2;
+        _dropshadowOffsetYSlider.ValueChanged += (_, _) => ApplyFontSettings();
+        controlsPanel.AddChild(_dropshadowOffsetYSlider);
+
+        _dropshadowBlurLabel = new Label();
+        controlsPanel.AddChild(_dropshadowBlurLabel);
+
+        _dropshadowBlurSlider = new Slider();
+        _dropshadowBlurSlider.Width = 240;
+        _dropshadowBlurSlider.Minimum = 0;
+        _dropshadowBlurSlider.Maximum = 8;
+        _dropshadowBlurSlider.IsSnapToTickEnabled = true;
+        _dropshadowBlurSlider.TicksFrequency = 1;
+        _dropshadowBlurSlider.Value = 2;
+        _dropshadowBlurSlider.ValueChanged += (_, _) => ApplyFontSettings();
+        controlsPanel.AddChild(_dropshadowBlurSlider);
+
         // Preview
         _previewText = new TextRuntime();
         _previewText.Text = "The quick brown fox 0123";
@@ -154,9 +208,15 @@ public class FontPlaygroundScreen
     {
         int fontSize = (int)_fontSizeSlider.Value;
         int outlineThickness = (int)_outlineSlider.Value;
+        int shadowOffsetX = (int)_dropshadowOffsetXSlider.Value;
+        int shadowOffsetY = (int)_dropshadowOffsetYSlider.Value;
+        int shadowBlur = (int)_dropshadowBlurSlider.Value;
 
         _fontSizeLabel.Text = $"Font Size: {fontSize}";
         _outlineLabel.Text = $"Outline Thickness: {outlineThickness}";
+        _dropshadowOffsetXLabel.Text = $"Shadow Offset X: {shadowOffsetX}";
+        _dropshadowOffsetYLabel.Text = $"Shadow Offset Y: {shadowOffsetY}";
+        _dropshadowBlurLabel.Text = $"Shadow Blur: {shadowBlur}";
 
         _previewText.Font = _fontFamilyComboBox.SelectedObject as string ?? "Arial";
         _previewText.FontSize = fontSize;
@@ -164,5 +224,9 @@ public class FontPlaygroundScreen
         _previewText.IsItalic = _italicCheckBox.IsChecked == true;
         _previewText.OutlineThickness = outlineThickness;
         _previewText.UseFontSmoothing = _smoothingCheckBox.IsChecked == true;
+        _previewText.HasDropshadow = _dropshadowCheckBox.IsChecked == true;
+        _previewText.DropshadowOffsetX = shadowOffsetX;
+        _previewText.DropshadowOffsetY = shadowOffsetY;
+        _previewText.DropshadowBlur = shadowBlur;
     }
 }

--- a/Tests/MonoGameGum.Tests.V2/GueDeriving/TextRuntimeDropshadowPlumbingTests.cs
+++ b/Tests/MonoGameGum.Tests.V2/GueDeriving/TextRuntimeDropshadowPlumbingTests.cs
@@ -1,0 +1,111 @@
+using Gum.GueDeriving;
+using Gum.Wireframe;
+using MonoGameGum.Renderables;
+using RenderingLibrary.Graphics.Fonts;
+using Shouldly;
+using Xunit;
+
+namespace MonoGameGum.Tests.V2.GueDeriving;
+
+/// <summary>
+/// Pins #2724 runtime plumbing: TextRuntime dropshadow properties flow into BmfcSave and the font cache key
+/// when UpdateToFontValues runs via the registered in-memory font creator.
+/// </summary>
+public class TextRuntimeDropshadowPlumbingTests
+{
+    [Fact]
+    public void SettingHasDropshadow_PassesShadowFieldsToInMemoryFontCreator()
+    {
+        CapturingInMemoryFontCreator creator = new CapturingInMemoryFontCreator();
+        IInMemoryFontCreator? previous = CustomSetPropertyOnRenderable.InMemoryFontCreator;
+        CustomSetPropertyOnRenderable.InMemoryFontCreator = creator;
+
+        try
+        {
+            TextRuntime text = new TextRuntime();
+            text.Font = "Arial";
+            text.FontSize = 24;
+            text.HasDropshadow = true;
+            text.DropshadowOffsetX = 2f;
+            text.DropshadowOffsetY = 3f;
+            text.DropshadowBlur = 4f;
+            text.DropshadowRed = 10;
+            text.DropshadowGreen = 20;
+            text.DropshadowBlue = 30;
+            text.DropshadowAlpha = 128;
+
+            creator.LastBmfcSave.ShouldNotBeNull();
+            creator.LastBmfcSave!.HasDropshadow.ShouldBeTrue();
+            creator.LastBmfcSave.DropshadowOffsetX.ShouldBe(2f);
+            creator.LastBmfcSave.DropshadowOffsetY.ShouldBe(3f);
+            creator.LastBmfcSave.DropshadowBlur.ShouldBe(4f);
+            creator.LastBmfcSave.DropshadowRed.ShouldBe((byte)10);
+            creator.LastBmfcSave.DropshadowGreen.ShouldBe((byte)20);
+            creator.LastBmfcSave.DropshadowBlue.ShouldBe((byte)30);
+            creator.LastBmfcSave.DropshadowAlpha.ShouldBe((byte)128);
+        }
+        finally
+        {
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = previous;
+        }
+    }
+
+    [Fact]
+    public void SettingHasDropshadowWithoutColor_UsesBlackSemiTransparentDefaults()
+    {
+        CapturingInMemoryFontCreator creator = new CapturingInMemoryFontCreator();
+        IInMemoryFontCreator? previous = CustomSetPropertyOnRenderable.InMemoryFontCreator;
+        CustomSetPropertyOnRenderable.InMemoryFontCreator = creator;
+
+        try
+        {
+            TextRuntime text = new TextRuntime();
+            text.Font = "Arial";
+            text.FontSize = 24;
+            text.HasDropshadow = true;
+
+            creator.LastBmfcSave.ShouldNotBeNull();
+            creator.LastBmfcSave!.HasDropshadow.ShouldBeTrue();
+            creator.LastBmfcSave.DropshadowRed.ShouldBe((byte)0);
+            creator.LastBmfcSave.DropshadowGreen.ShouldBe((byte)0);
+            creator.LastBmfcSave.DropshadowBlue.ShouldBe((byte)0);
+            creator.LastBmfcSave.DropshadowAlpha.ShouldBe((byte)180);
+            creator.LastBmfcSave.DropshadowOffsetY.ShouldBe(3f);
+            creator.LastBmfcSave.DropshadowBlur.ShouldBe(2f);
+        }
+        finally
+        {
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = previous;
+        }
+    }
+
+    [Fact]
+    public void GetFontCacheFileName_WhenHasDropshadowDiffersFromPlainKey()
+    {
+        TextRuntime text = new TextRuntime();
+        text.Font = "Arial";
+        text.FontSize = 24;
+
+        string plainKey = text.GetFontCacheFileName(fontFilePath: null);
+
+        text.HasDropshadow = true;
+        text.DropshadowOffsetX = 1f;
+        text.DropshadowOffsetY = 2f;
+        text.DropshadowBlur = 3f;
+        text.DropshadowAlpha = 4;
+
+        text.GetFontCacheFileName(fontFilePath: null).ShouldNotBe(plainKey);
+        text.GetFontCacheFileName(fontFilePath: null).ShouldContain("_ds");
+    }
+
+    private sealed class CapturingInMemoryFontCreator : IInMemoryFontCreator
+    {
+        public BmfcSave? LastBmfcSave { get; private set; }
+
+        public RenderingLibrary.Graphics.BitmapFont? TryCreateFont(BmfcSave bmfcSave)
+        {
+            LastBmfcSave = bmfcSave;
+            return null;
+        }
+    }
+}

--- a/Tests/RaylibGum.Tests/Renderables/GumFontGeneratorShadowTests.cs
+++ b/Tests/RaylibGum.Tests/Renderables/GumFontGeneratorShadowTests.cs
@@ -1,0 +1,227 @@
+using KernSmith;
+using KernSmith.Atlas;
+using KernSmith.Gum;
+using RenderingLibrary.Graphics.Fonts;
+using Shouldly;
+using Xunit;
+
+namespace RaylibGum.Tests.Renderables;
+
+/// <summary>
+/// Spike tests for #2724 — KernSmith baked drop shadow plumbed through <see cref="GumFontGenerator"/>.
+/// Validates option mapping, color decomposition, and that generation produces a visibly larger glyph footprint.
+/// </summary>
+public class GumFontGeneratorShadowTests
+{
+    [Fact]
+    public void BuildOptions_WhenHasDropshadow_MapsShadowFieldsAndDecomposesAlphaToOpacity()
+    {
+        BmfcSave bmfcSave = BaseBmfcSave();
+        bmfcSave.HasDropshadow = true;
+        bmfcSave.DropshadowOffsetX = 2f;
+        bmfcSave.DropshadowOffsetY = 3f;
+        bmfcSave.DropshadowBlur = 4f;
+        bmfcSave.DropshadowRed = 10;
+        bmfcSave.DropshadowGreen = 20;
+        bmfcSave.DropshadowBlue = 30;
+        bmfcSave.DropshadowAlpha = 128;
+
+        FontGeneratorOptions options = GumFontGenerator.BuildOptions(bmfcSave);
+
+        options.ShadowOffsetX.ShouldBe(2);
+        options.ShadowOffsetY.ShouldBe(3);
+        options.ShadowBlur.ShouldBe(4);
+        ((int)options.ShadowR).ShouldBe(10);
+        ((int)options.ShadowG).ShouldBe(20);
+        ((int)options.ShadowB).ShouldBe(30);
+        options.ShadowOpacity.ShouldBe(128 / 255f, 0.001f);
+    }
+
+    [Fact]
+    public void BuildOptions_WhenHasDropshadowIsFalse_LeavesShadowAtDefaults()
+    {
+        BmfcSave bmfcSave = BaseBmfcSave();
+        bmfcSave.HasDropshadow = false;
+        bmfcSave.DropshadowOffsetX = 5f;
+        bmfcSave.DropshadowBlur = 9f;
+
+        FontGeneratorOptions plain = GumFontGenerator.BuildOptions(bmfcSave);
+        FontGeneratorOptions reference = GumFontGenerator.BuildOptions(BaseBmfcSave());
+
+        plain.ShadowOffsetX.ShouldBe(reference.ShadowOffsetX);
+        plain.ShadowOffsetY.ShouldBe(reference.ShadowOffsetY);
+        plain.ShadowBlur.ShouldBe(reference.ShadowBlur);
+        plain.ShadowOpacity.ShouldBe(reference.ShadowOpacity);
+    }
+
+    [Fact]
+    public void Generate_WithDropshadow_ProducesLargerGlyphFootprintThanPlainFont()
+    {
+        BmfcSave plain = BaseBmfcSave();
+        plain.Ranges = "65";
+
+        BmfcSave shadowed = BaseBmfcSave();
+        shadowed.Ranges = "65";
+        shadowed.HasDropshadow = true;
+        shadowed.DropshadowOffsetX = 2f;
+        shadowed.DropshadowOffsetY = 2f;
+        shadowed.DropshadowBlur = 2f;
+        shadowed.DropshadowRed = 0;
+        shadowed.DropshadowGreen = 0;
+        shadowed.DropshadowBlue = 0;
+        shadowed.DropshadowAlpha = 255;
+
+        int plainAlpha = CountNonZeroAlphaPixels(GumFontGenerator.Generate(plain));
+        int shadowAlpha = CountNonZeroAlphaPixels(GumFontGenerator.Generate(shadowed));
+
+        shadowAlpha.ShouldBeGreaterThan(plainAlpha);
+    }
+
+    [Fact]
+    public void FontCacheFileName_WhenHasDropshadow_IncludesShadowSignature()
+    {
+        BmfcSave bmfcSave = BaseBmfcSave();
+        string plainName = bmfcSave.FontCacheFileName;
+
+        bmfcSave.HasDropshadow = true;
+        bmfcSave.DropshadowOffsetX = 1f;
+        bmfcSave.DropshadowOffsetY = 2f;
+        bmfcSave.DropshadowBlur = 3f;
+        bmfcSave.DropshadowRed = 4;
+        bmfcSave.DropshadowGreen = 5;
+        bmfcSave.DropshadowBlue = 6;
+        bmfcSave.DropshadowAlpha = 7;
+
+        bmfcSave.FontCacheFileName.ShouldNotBe(plainName);
+        bmfcSave.FontCacheFileName.ShouldContain("_ds");
+    }
+
+    [Fact]
+    public void BuildOptions_WhenHasDropshadow_LeavesChannelsUnsetSoAtlasPreservesShadowRgb()
+    {
+        BmfcSave bmfcSave = BaseBmfcSave();
+        bmfcSave.HasDropshadow = true;
+
+        FontGeneratorOptions options = GumFontGenerator.BuildOptions(bmfcSave);
+
+        options.Channels.ShouldBeNull();
+    }
+
+    [Fact]
+    public void BuildOptions_WhenHasDropshadowWithOutline_LeavesChannelsUnsetSoAtlasPreservesShadowRgb()
+    {
+        BmfcSave bmfcSave = BaseBmfcSave();
+        bmfcSave.OutlineThickness = 2;
+        bmfcSave.HasDropshadow = true;
+
+        FontGeneratorOptions options = GumFontGenerator.BuildOptions(bmfcSave);
+
+        options.Channels.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Generate_WithBlackShadow_BakesDarkAndBrightRgbPixels()
+    {
+        BmfcSave plain = BaseBmfcSave();
+        plain.Ranges = "65";
+
+        BmfcSave shadowed = BaseBmfcSave();
+        shadowed.Ranges = "65";
+        shadowed.HasDropshadow = true;
+        shadowed.DropshadowOffsetX = 2f;
+        shadowed.DropshadowOffsetY = 2f;
+        shadowed.DropshadowBlur = 2f;
+        shadowed.DropshadowRed = 0;
+        shadowed.DropshadowGreen = 0;
+        shadowed.DropshadowBlue = 0;
+        shadowed.DropshadowAlpha = 255;
+
+        (int plainMinR, int plainMaxR, int plainDark, int plainBright) =
+            SummarizeRedChannel(GumFontGenerator.Generate(plain));
+        (int shadowMinR, int shadowMaxR, int shadowDark, int shadowBright) =
+            SummarizeRedChannel(GumFontGenerator.Generate(shadowed));
+
+        plainDark.ShouldBe(0);
+        plainBright.ShouldBeGreaterThan(0);
+        plainMinR.ShouldBeGreaterThan(200);
+
+        shadowDark.ShouldBeGreaterThan(0);
+        shadowBright.ShouldBeGreaterThan(0);
+        shadowMinR.ShouldBeLessThan(32);
+        shadowMaxR.ShouldBeGreaterThan(200);
+    }
+
+    [Fact]
+    public void FontCacheFileName_WhenHasDropshadowIsFalse_MatchesPlainKey()
+    {
+        BmfcSave bmfcSave = BaseBmfcSave();
+        string plainName = bmfcSave.FontCacheFileName;
+
+        bmfcSave.DropshadowOffsetX = 99f;
+        bmfcSave.DropshadowBlur = 99f;
+
+        bmfcSave.FontCacheFileName.ShouldBe(plainName);
+    }
+
+    private static BmfcSave BaseBmfcSave() => new BmfcSave
+    {
+        FontName = "Arial",
+        FontSize = 24,
+        UseSmoothing = true,
+        Ranges = "65",
+    };
+
+    private static (int minR, int maxR, int darkPixelCount, int brightPixelCount) SummarizeRedChannel(KernSmith.Output.BmFontResult result)
+    {
+        int minR = 255;
+        int maxR = 0;
+        int darkPixelCount = 0;
+        int brightPixelCount = 0;
+
+        foreach (AtlasPage page in result.Pages)
+        {
+            byte[] pixels = page.PixelData;
+            for (int i = 0; i + 3 < pixels.Length; i += 4)
+            {
+                if (pixels[i + 3] == 0)
+                {
+                    continue;
+                }
+
+                byte r = pixels[i];
+                minR = Math.Min(minR, r);
+                maxR = Math.Max(maxR, r);
+
+                if (r < 32)
+                {
+                    darkPixelCount++;
+                }
+
+                if (r > 200)
+                {
+                    brightPixelCount++;
+                }
+            }
+        }
+
+        return (minR, maxR, darkPixelCount, brightPixelCount);
+    }
+
+    private static int CountNonZeroAlphaPixels(KernSmith.Output.BmFontResult result)
+    {
+        int count = 0;
+        foreach (AtlasPage page in result.Pages)
+        {
+            byte[] pixels = page.PixelData;
+            for (int i = 3; i < pixels.Length; i += 4)
+            {
+                if (pixels[i] > 0)
+                {
+                    count++;
+                }
+            }
+        }
+
+        return count;
+    }
+}

--- a/Tests/RaylibGum.Tests/Renderables/KernSmithRaylibFontCreatorTests.cs
+++ b/Tests/RaylibGum.Tests/Renderables/KernSmithRaylibFontCreatorTests.cs
@@ -39,4 +39,30 @@ public class KernSmithRaylibFontCreatorTests : BaseTestClass
         font.Value.GlyphCount.ShouldBeGreaterThan(0);
         font.Value.Texture.Id.ShouldBeGreaterThan(0u);
     }
+
+    [Fact]
+    public void TryCreateFont_WithDropshadow_ProducesUsableFont()
+    {
+        KernSmithRaylibFontCreator creator = new KernSmithRaylibFontCreator();
+
+        BmfcSave bmfcSave = new BmfcSave
+        {
+            FontName = "Arial",
+            FontSize = 32,
+            UseSmoothing = true,
+            Ranges = "65",
+            HasDropshadow = true,
+            DropshadowOffsetX = 2f,
+            DropshadowOffsetY = 2f,
+            DropshadowBlur = 2f,
+            DropshadowAlpha = 255,
+        };
+
+        Raylib_cs.Font? font = creator.TryCreateFont(bmfcSave);
+
+        font.ShouldNotBeNull();
+        font!.Value.BaseSize.ShouldBe(32);
+        font.Value.GlyphCount.ShouldBeGreaterThan(0);
+        font.Value.Texture.Id.ShouldBeGreaterThan(0u);
+    }
 }


### PR DESCRIPTION
## Summary

- Add HasDropshadow and Dropshadow* properties to TextRuntime (MonoGame source, linked on Skia/Raylib/Kni/FNA; Sokol API surface is a no-op).
- Extend BmfcSave with shadow fields and cache-key suffix; map through GumFontGenerator into KernSmith shadow options.
- When shadow is enabled, skip the plain-text ChannelConfig so KernSmith's RGBA atlas preserves baked shadow color (fixes white-shadow modulate bug).
- Seed defaults on first enable: black @ alpha 180, offset Y 3, blur 2.
- FontPlayground sample: drop-shadow checkbox + offset/blur sliders.

**Runtime-only scope.** Tool variable grid, headless font generation, ForestGlade chrome cleanup, and docs are follow-ups.

## Test plan

- [x] GumFontGeneratorShadowTests (8) — mapping, cache key, atlas footprint, dark+bright RGB pixels
- [x] TextRuntimeDropshadowPlumbingTests (3) — property → BmfcSave / cache key
- [x] KernSmithRaylibFontCreatorTests.TryCreateFont_WithDropshadow
- [x] Manual: FontPlayground MonoGame — drop shadow renders dark behind white text

Closes #2724

Made with [Cursor](https://cursor.com)