### PR TITLE
Docs + samples: TextRuntime baked drop shadow (#3414)

### DIFF
--- a/Runtimes/RaylibGum/Renderables/Text.cs
+++ b/Runtimes/RaylibGum/Renderables/Text.cs
@@ -304,7 +304,7 @@ public class Text : IVisible, IRenderableIpso,
     public Color Color
     {
         get; set;
-    } = Color.DarkGray;
+    } = Color.White;
 
 
     public bool IsTruncatingWithEllipsisOnLastLine { get; set; }

--- a/Samples/MonoGameGumInCode/MonoGameGumInCode/Game1.cs
+++ b/Samples/MonoGameGumInCode/MonoGameGumInCode/Game1.cs
@@ -4,6 +4,7 @@ using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Input;
 using Gum;
+using KernSmith.Gum;
 using MonoGameGumInCode.Screens;
 using RenderingLibrary;
 
@@ -43,6 +44,9 @@ namespace MonoGameGumInCode
         protected override void Initialize()
         {
             GumService.Default.Initialize(this);
+
+            CustomSetPropertyOnRenderable.InMemoryFontCreator =
+                new KernSmithFontCreator(GraphicsDevice);
 
             // Issue #3206: Gum core ships no shader loader, so the app registers a resolver that
             // turns a ContainerRuntime.SourceShaderFile (.fx path) into a platform Effect. Here it

--- a/Samples/MonoGameGumInCode/MonoGameGumInCode/MonoGameGumInCode.csproj
+++ b/Samples/MonoGameGumInCode/MonoGameGumInCode/MonoGameGumInCode.csproj
@@ -33,6 +33,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\..\GumCommon\GumCommon.csproj" />
     <ProjectReference Include="..\..\..\MonoGameGum\MonoGameGum.csproj" />
+    <ProjectReference Include="..\..\..\Integrations\KernSmith\KernSmith.MonoGameGum\KernSmith.MonoGameGum.csproj" />
   </ItemGroup>
   <ItemGroup>
     <None Update="Content\**\*.png">

--- a/Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/TextScreen.cs
+++ b/Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/TextScreen.cs
@@ -5,6 +5,9 @@ using Microsoft.Xna.Framework;
 using RenderingLibrary.Graphics;
 
 namespace MonoGameGumInCode.Screens;
+
+// Reference screen for TextRuntime font behavior. Raylib and SilkNetGum mirror the KernSmith
+// baked-shadow rows where that backend supports them (#3414 / #2724).
 internal class TextScreen : FrameworkElement
 {
     public TextScreen() : base(new ContainerRuntime())
@@ -14,7 +17,6 @@ internal class TextScreen : FrameworkElement
         var container = new ContainerRuntime();
         container.WidthUnits = Gum.DataTypes.DimensionUnitType.RelativeToParent;
         container.HeightUnits = Gum.DataTypes.DimensionUnitType.RelativeToParent;
-        // Give it 2 pixels on each side so text doesn't bump up against the edge of the screen
         container.X = 2;
         container.Y = 2;
         container.Width = -4;
@@ -27,14 +29,48 @@ internal class TextScreen : FrameworkElement
         textRuntime.Text = "Hi, I'm default text";
         container.Children.Add(textRuntime);
 
+        AddSectionLabel(container, "Baked drop shadow (HasDropshadow = true, first-enable defaults):");
+        var shadowDefault = new TextRuntime();
+        shadowDefault.Text = "Soft baked shadow";
+        shadowDefault.FontSize = 24;
+        shadowDefault.HasDropshadow = true;
+        container.Children.Add(shadowDefault);
+
+        AddSectionLabel(container, "Baked drop shadow (colored, offset, blur):");
+        var shadowColored = new TextRuntime();
+        shadowColored.Text = "Pink shadow";
+        shadowColored.FontSize = 24;
+        shadowColored.HasDropshadow = true;
+        shadowColored.DropshadowColor = new Color(220, 40, 160, 220);
+        shadowColored.DropshadowOffsetX = 2;
+        shadowColored.DropshadowOffsetY = 4;
+        shadowColored.DropshadowBlur = 4;
+        container.Children.Add(shadowColored);
+
+        AddSectionLabel(container, "Baked drop shadow + outline:");
+        var shadowOutline = new TextRuntime();
+        shadowOutline.Text = "Shadow and outline";
+        shadowOutline.FontSize = 24;
+        shadowOutline.OutlineThickness = 2;
+        shadowOutline.HasDropshadow = true;
+        container.Children.Add(shadowOutline);
+
         var withOutline = new TextRuntime();
         withOutline.Text = "I am text that has an outline.";
-        (withOutline.Component as RenderingLibrary.Graphics.Text).RenderBoundary = true;
+        (withOutline.Component as Text).RenderBoundary = true;
         container.Children.Add(withOutline);
 
         AddCustomOutlineText(container, Color.Red);
         AddCustomOutlineText(container, Color.DarkGreen);
         AddCustomOutlineText(container, Color.Blue);
+    }
+
+    private static void AddSectionLabel(ContainerRuntime container, string text)
+    {
+        var label = new TextRuntime();
+        label.Text = text;
+        label.FontSize = 14;
+        container.Children.Add(label);
     }
 
     private static void AddCustomOutlineText(ContainerRuntime container, Color color)

--- a/Samples/SilkNetGum/SilkNetGum/Program.cs
+++ b/Samples/SilkNetGum/SilkNetGum/Program.cs
@@ -58,6 +58,7 @@ unsafe class Program
     {
         () => new SilkNetGum.Screens.NineSliceScreen(),
         () => new SilkNetGum.Screens.SpriteScreen(),
+        () => new SilkNetGum.Screens.TextScreen(),
         () => new SilkNetGum.Screens.CirclesScreen(),
         () => new SilkNetGum.Screens.RectanglesScreen(),
         () => new SilkNetGum.Screens.ArcsScreen(),

--- a/Samples/SilkNetGum/SilkNetGum/Screens/TextScreen.cs
+++ b/Samples/SilkNetGum/SilkNetGum/Screens/TextScreen.cs
@@ -1,0 +1,66 @@
+using Gum.Forms.Controls;
+using Gum.GueDeriving;
+using Gum.Managers;
+using Gum.Wireframe;
+using SkiaSharp;
+
+namespace SilkNetGum.Screens;
+
+// Mirror of Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/TextScreen.cs where the backend
+// supports the same surface (#3414). SkiaGum dynamic fonts do not use KernSmith, so baked text
+// drop shadow (HasDropshadow) is not rendered here — the rows below document that gap explicitly.
+internal class TextScreen : FrameworkElement
+{
+    public TextScreen() : base(new ContainerRuntime())
+    {
+        Dock(Gum.Wireframe.Dock.Fill);
+
+        ContainerRuntime container = new ContainerRuntime();
+        container.WidthUnits = Gum.DataTypes.DimensionUnitType.RelativeToParent;
+        container.HeightUnits = Gum.DataTypes.DimensionUnitType.RelativeToParent;
+        container.X = 2;
+        container.Y = 2;
+        container.Width = -4;
+        container.Height = -4;
+        container.ChildrenLayout = ChildrenLayout.TopToBottomStack;
+        container.StackSpacing = 4;
+        this.AddChild(container);
+
+        TextRuntime textRuntime = new TextRuntime();
+        textRuntime.Text = "Hi, I'm default text";
+        container.Children.Add(textRuntime);
+
+        AddSectionLabel(container,
+            "Baked drop shadow requires KernSmith (MonoGame / KNI / Raylib). SkiaGum stores HasDropshadow but does not bake a shadow atlas — rows below show plain text for layout parity only:");
+
+        TextRuntime shadowDefault = new TextRuntime();
+        shadowDefault.Text = "Soft baked shadow (not on Skia)";
+        shadowDefault.FontSize = 24;
+        shadowDefault.HasDropshadow = true;
+        container.Children.Add(shadowDefault);
+
+        TextRuntime shadowColored = new TextRuntime();
+        shadowColored.Text = "Pink shadow (not on Skia)";
+        shadowColored.FontSize = 24;
+        shadowColored.HasDropshadow = true;
+        shadowColored.DropshadowColor = new SKColor(220, 40, 160, 220);
+        shadowColored.DropshadowOffsetX = 2;
+        shadowColored.DropshadowOffsetY = 4;
+        shadowColored.DropshadowBlur = 4;
+        container.Children.Add(shadowColored);
+
+        TextRuntime withOutline = new TextRuntime();
+        withOutline.Text = "OutlineThickness = 2 (Skia path)";
+        withOutline.FontSize = 24;
+        withOutline.OutlineThickness = 2;
+        container.Children.Add(withOutline);
+    }
+
+    private static void AddSectionLabel(ContainerRuntime container, string text)
+    {
+        TextRuntime label = new TextRuntime();
+        label.Text = text;
+        label.FontSize = 14;
+        container.Children.Add(label);
+    }
+}

--- a/Samples/raylib/GumTest.csproj
+++ b/Samples/raylib/GumTest.csproj
@@ -14,6 +14,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\GumCommon\GumCommon.csproj" />
     <ProjectReference Include="..\..\Runtimes\RaylibGum\RaylibGum.csproj" />
+    <ProjectReference Include="..\..\Integrations\KernSmith\KernSmith.RaylibGum\KernSmith.RaylibGum.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Samples/raylib/Program.cs
+++ b/Samples/raylib/Program.cs
@@ -3,7 +3,9 @@ using Gum.Forms.Controls;
 using Gum.Forms.DefaultVisuals.V3;
 using Gum.Wireframe;
 using Gum;
+using KernSmith.Gum;
 using Raylib_cs;
+using RaylibGum.Renderables;
 using RenderingLibrary;
 using RenderingLibrary.Graphics;
 using System;
@@ -56,6 +58,8 @@ public class BasicShapes
         InitWindow(screenWidth, screenHeight, "Gum raylib gallery");
 
         GumUI.Initialize();
+
+        CustomSetPropertyOnRenderable.InMemoryFontCreator = new KernSmithRaylibFontCreator();
 
         // Enable gamepad + keyboard navigation for Forms controls (see
         // https://docs.flatredball.com/gum/code/events-and-interactivity/gamepad-support).
@@ -135,6 +139,7 @@ public class BasicShapes
         AddNavButton("Arcs", () => new ArcsScreen());
         AddNavButton("Sprite", () => new SpriteScreen());
         AddNavButton("NineSlice", () => new NineSliceScreen());
+        AddNavButton("Text", () => new TextScreen());
 
         AddFitModeRadio("Zoom", isChecked: true, () =>
         {

--- a/Samples/raylib/Screens/TextScreen.cs
+++ b/Samples/raylib/Screens/TextScreen.cs
@@ -1,0 +1,74 @@
+using Gum.DataTypes;
+using Gum.Forms.Controls;
+using Gum.GueDeriving;
+using Gum.Managers;
+using Gum.Wireframe;
+using Raylib_cs;
+
+namespace Examples.Shapes;
+
+// Raylib mirror of Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/TextScreen.cs (#3414).
+// Section order matches the MG screen so baked-shadow regressions are easy to spot side by side.
+// Requires KernSmithRaylibFontCreator wired in Program.Main.
+internal class TextScreen : FrameworkElement
+{
+    public TextScreen() : base(new ContainerRuntime())
+    {
+        Dock(Gum.Wireframe.Dock.Fill);
+
+        var container = new ContainerRuntime();
+        container.WidthUnits = DimensionUnitType.RelativeToParent;
+        container.HeightUnits = DimensionUnitType.RelativeToParent;
+        container.X = 2;
+        container.Y = 2;
+        container.Width = -4;
+        container.Height = -4;
+        container.ChildrenLayout = ChildrenLayout.TopToBottomStack;
+        container.StackSpacing = 4;
+        this.AddChild(container);
+
+        var textRuntime = new TextRuntime();
+        textRuntime.Text = "Hi, I'm default text";
+        container.Children.Add(textRuntime);
+
+        AddSectionLabel(container, "Baked drop shadow (HasDropshadow = true, first-enable defaults):");
+        var shadowDefault = new TextRuntime();
+        shadowDefault.Text = "Soft baked shadow";
+        shadowDefault.FontSize = 24;
+        shadowDefault.HasDropshadow = true;
+        container.Children.Add(shadowDefault);
+
+        AddSectionLabel(container, "Baked drop shadow (colored, offset, blur):");
+        var shadowColored = new TextRuntime();
+        shadowColored.Text = "Pink shadow";
+        shadowColored.FontSize = 24;
+        shadowColored.HasDropshadow = true;
+        shadowColored.DropshadowColor = new Color(220, 40, 160, 220);
+        shadowColored.DropshadowOffsetX = 2;
+        shadowColored.DropshadowOffsetY = 4;
+        shadowColored.DropshadowBlur = 4;
+        container.Children.Add(shadowColored);
+
+        AddSectionLabel(container, "Baked drop shadow + outline:");
+        var shadowOutline = new TextRuntime();
+        shadowOutline.Text = "Shadow and outline";
+        shadowOutline.FontSize = 24;
+        shadowOutline.OutlineThickness = 2;
+        shadowOutline.HasDropshadow = true;
+        container.Children.Add(shadowOutline);
+
+        var withOutline = new TextRuntime();
+        withOutline.Text = "I am text with OutlineThickness = 2";
+        withOutline.FontSize = 24;
+        withOutline.OutlineThickness = 2;
+        container.Children.Add(withOutline);
+    }
+
+    private static void AddSectionLabel(ContainerRuntime container, string text)
+    {
+        var label = new TextRuntime();
+        label.Text = text;
+        label.FontSize = 14;
+        container.Children.Add(label);
+    }
+}

--- a/Tests/RaylibGum.Tests/Runtimes/TextRuntimeTests.cs
+++ b/Tests/RaylibGum.Tests/Runtimes/TextRuntimeTests.cs
@@ -122,6 +122,16 @@ public class TextRuntimeTests : BaseTestClass
         TextRuntime.DefaultFontSize.ShouldBe(18);
     }
 
+    [Fact]
+    public void NewInstance_ShouldDefaultToWhite_ForParityWithRenderingLibraryText()
+    {
+        TextRuntime sut = new();
+        sut.Red.ShouldBe(255);
+        sut.Green.ShouldBe(255);
+        sut.Blue.ShouldBe(255);
+        sut.Alpha.ShouldBe(255);
+    }
+
     #endregion
 
     #region Font Loading

--- a/docs/code/files-and-fonts/advanced-font-effects.md
+++ b/docs/code/files-and-fonts/advanced-font-effects.md
@@ -2,12 +2,14 @@
 
 ## Introduction
 
-KernSmith can generate fonts with effects that the `TextRuntime` property surface does not expose — outline color, drop shadows, gradient fills, SDF, color fonts, custom glyph subsets, and a choice of rasterizer backend. These all live on `KernSmith.FontGeneratorOptions`, but `BmfcSave` (the descriptor that drives the property path) only carries a small slice of those fields.
+KernSmith can generate fonts with effects that the `TextRuntime` property surface does not expose — outline color, gradient fills, SDF, color fonts, custom glyph subsets, and a choice of rasterizer backend. Drop shadow is on the property path when `HasDropshadow` is set (see [TextRuntime Fonts](../standard-visuals/textruntime/fonts.md#baked-drop-shadow)); the fields below cover the rest. They all live on `KernSmith.FontGeneratorOptions`, but `BmfcSave` (the descriptor that drives the property path) only carries a small slice of those fields.
 
 This page catalogs the effects available today and shows the `FontGeneratorOptions` fields that drive each one.
 
 {% hint style="info" %}
-These effects require constructing a `BitmapFont` via KernSmith yourself and assigning it directly to `TextRuntime.BitmapFont`. They are not reachable through `Font`, `FontSize`, `OutlineThickness`, or any other `TextRuntime` property — `BmfcSave` does not carry the fields they need.
+**Property path vs direct KernSmith:** `TextRuntime` exposes baked drop shadow through `HasDropshadow`, `DropshadowColor` (+ channel mirrors), `DropshadowOffsetX/Y`, and `DropshadowBlur` when an `InMemoryFontCreator` is registered — see [TextRuntime Fonts](../standard-visuals/textruntime/fonts.md#baked-drop-shadow).
+
+Everything else on this page still requires constructing a `BitmapFont` via KernSmith yourself and assigning it directly to `TextRuntime.BitmapFont` — outline color, gradient fills, SDF, color fonts, custom glyphs, backend selection, `HardShadow`, and custom `Padding`. `BmfcSave` does not carry those fields.
 
 For the full construction walkthrough (helper method, channel layout caveat, and `BmfcSave`-vs-from-scratch flows), see [Font Strategies — Direct BitmapFont Assignment](font-strategies.md#direct-bitmapfont-assignment). This page focuses on the per-effect options without repeating that setup.
 {% endhint %}
@@ -48,7 +50,17 @@ options.Channels = new KernSmith.Output.ChannelConfig(
 
 ## Drop Shadow
 
-Drop shadows are baked into the atlas itself — the glyph and its shadow render in a single draw call. Set `ShadowOffsetX/Y` to position the shadow, `ShadowR/G/B` for color, and optionally `ShadowOpacity`, `ShadowBlur`, and `HardShadow`:
+Drop shadows are baked into the atlas itself — the glyph and its shadow render in a single draw call. The property path covers the common case; direct `FontGeneratorOptions` remains for extras KernSmith exposes but `TextRuntime` does not.
+
+### Property path (`TextRuntime`)
+
+Set `HasDropshadow` and the dropshadow fields on a `TextRuntime` when KernSmith is wired up. Gum maps them through `BmfcSave` → `GumFontGenerator` at generation time. See [TextRuntime Fonts — Baked drop shadow](../standard-visuals/textruntime/fonts.md#baked-drop-shadow) for defaults, cache behavior, and a short sample.
+
+### Direct `FontGeneratorOptions`
+
+Use this path when you need KernSmith-only knobs (`HardShadow`, custom `Padding`, or shadow combined with effects not on `BmfcSave`) or when building a shared `BitmapFont` outside the property system.
+
+Set `ShadowOffsetX/Y` to position the shadow, `ShadowR/G/B` for color, and optionally `ShadowOpacity`, `ShadowBlur`, and `HardShadow`:
 
 ```csharp
 // Initialize
@@ -68,6 +80,10 @@ BitmapFont bitmapFont = CreateBitmapFont(result, GraphicsDevice);
 ```
 
 Because the shadow is baked into the glyph's own atlas cell, you may need to increase `Padding` to give the shadow room — otherwise blurred shadows can clip at the cell edge.
+
+{% hint style="info" %}
+When `HasDropshadow` is true on the property path, `GumFontGenerator` leaves `ChannelConfig` unset so KernSmith keeps full RGBA in the atlas. A custom `Channels` assignment on a shadowed font routes through KernSmith's channel compositor and can discard baked shadow color — the same reason outlined fonts use a different layout than plain text. On the direct path, mirror that rule: do not override `Channels` when baking shadow unless you know the compositor layout you need.
+{% endhint %}
 
 ## Gradient Fill
 
@@ -220,4 +236,4 @@ options.EnableHinting = false;
 
 * [Font Strategies — Direct BitmapFont Assignment](font-strategies.md#direct-bitmapfont-assignment) — full construction walkthrough.
 * [BitmapFont](bitmapfont.md) — the runtime type these samples produce.
-* [TextRuntime Fonts](../standard-visuals/textruntime/fonts.md) — the property surface these effects bypass.
+* [TextRuntime Fonts](../standard-visuals/textruntime/fonts.md) — the property surface; baked drop shadow and the fields that bypass direct assignment.

--- a/docs/code/files-and-fonts/bitmapfont.md
+++ b/docs/code/files-and-fonts/bitmapfont.md
@@ -16,7 +16,7 @@ A `BitmapFont` can be built from several sources:
 
 A single `BitmapFont` instance can be assigned to any number of `TextRuntime`s via `TextRuntime.BitmapFont`. The atlas textures are shared, so reuse costs nothing extra at draw time.
 
-For the full strategy comparison — when to assign a `BitmapFont` directly vs. drive fonts through `TextRuntime` properties — see [Font Strategies — Direct BitmapFont Assignment](font-strategies.md#direct-bitmapfont-assignment). For effects only available through direct construction (outline color, drop shadows, gradients, SDF, color fonts), see [Advanced Font Effects](advanced-font-effects.md).
+For the full strategy comparison — when to assign a `BitmapFont` directly vs. drive fonts through `TextRuntime` properties — see [Font Strategies — Direct BitmapFont Assignment](font-strategies.md#direct-bitmapfont-assignment). Baked drop shadow is available on the property path ([TextRuntime Fonts](../standard-visuals/textruntime/fonts.md#baked-drop-shadow)); for outline color, gradients, SDF, color fonts, and other KernSmith-only extras, see [Advanced Font Effects](advanced-font-effects.md).
 
 ## Measuring Text
 

--- a/docs/code/files-and-fonts/font-strategies.md
+++ b/docs/code/files-and-fonts/font-strategies.md
@@ -6,7 +6,7 @@ This page covers each font loading strategy in detail with code samples and trad
 
 The strategies are:
 
-* [Dynamic KernSmith Generation](#dynamic-kernsmith-generation) — recommended for MonoGame and KNI.
+* [Dynamic KernSmith Generation](#dynamic-kernsmith-generation) — recommended for MonoGame, KNI, and Raylib.
 * [Dynamic Generation on SkiaGum](#dynamic-generation-on-skiagum) — SkiaGum rasterizes glyphs itself, separate from KernSmith.
 * [Custom Font File](#custom-font-file) — load a specific `.fnt` file you ship with the game.
 * [Direct BitmapFont Assignment](#direct-bitmapfont-assignment) — fully manual.
@@ -18,14 +18,14 @@ The strategies are:
 |---|---|
 | MonoGame | Yes — via KernSmith. |
 | KNI | Yes — via KernSmith. |
+| Raylib | Yes — via KernSmith (`KernSmith.RaylibGum`). |
 | FNA | Not yet. If you need it, let us know on Discord or [open an issue](https://github.com/vchelaru/Gum/issues). |
-| Raylib | Not yet. Use the [Build-Time Font Cache](#build-time-font-cache) for now. |
 | Sokol | Not yet. Use the [Build-Time Font Cache](#build-time-font-cache) for now. |
 | SkiaGum | Yes — uses SkiaSharp's own glyph rasterization. See [Dynamic Generation on SkiaGum](#dynamic-generation-on-skiagum). |
 
 ## Dynamic KernSmith Generation
 
-KernSmith is an in-memory font generator for the XNA-family runtimes (MonoGame and KNI today). Install the NuGet package for your runtime and KernSmith generates font atlases at runtime so you can freely change font properties without managing files on disk.
+KernSmith is an in-memory font generator for MonoGame, KNI, and Raylib. Install the NuGet package for your runtime and KernSmith generates font atlases at runtime so you can freely change font properties without managing files on disk.
 
 {% tabs %}
 {% tab title="MonoGame" %}
@@ -40,7 +40,7 @@ CustomSetPropertyOnRenderable.InMemoryFontCreator =
     new KernSmithFontCreator(GraphicsDevice);
 ```
 
-Once this is set up, font properties work automatically. Setting `Font`, `FontSize`, `IsBold`, `IsItalic`, `OutlineThickness`, and `UseFontSmoothing` on a `TextRuntime` generates the needed font in memory without any font files on disk:
+Once this is set up, font properties work automatically. Setting `Font`, `FontSize`, `IsBold`, `IsItalic`, `OutlineThickness`, `UseFontSmoothing`, and baked drop shadow (`HasDropshadow` plus the dropshadow fields) on a `TextRuntime` generates the needed font in memory without any font files on disk:
 
 ```csharp
 // Initialize
@@ -80,14 +80,35 @@ text.AddToRoot();
 ```
 {% endtab %}
 
+{% tab title="Raylib" %}
+1. Add the `KernSmith.RaylibGum` NuGet package to your project.
+2. Assign the `InMemoryFontCreator` after initializing Gum:
+
+```csharp
+// Initialize
+GumService.Default.Initialize();
+
+CustomSetPropertyOnRenderable.InMemoryFontCreator =
+    new KernSmithRaylibFontCreator();
+```
+
+Once this is set up, font properties work automatically — the same `TextRuntime` fields as MonoGame/KNI, including baked drop shadow. See [TextRuntime Fonts — Baked drop shadow](../standard-visuals/textruntime/fonts.md#baked-drop-shadow).
+
+```csharp
+// Initialize
+var text = new TextRuntime();
+text.Text = "Hello, World!";
+text.Font = "Times New Roman";
+text.FontSize = 24;
+text.IsBold = true;
+text.AddToRoot();
+```
+{% endtab %}
+
 {% tab title="FNA" %}
 KernSmith is not currently published for FNA. If you need dynamic font generation on FNA, let us know on Discord or [open an issue](https://github.com/vchelaru/Gum/issues) — the request helps us prioritize.
 
 In the meantime, use the [Build-Time Font Cache](#build-time-font-cache) strategy.
-{% endtab %}
-
-{% tab title="Raylib" %}
-Dynamic font generation is not yet available on Raylib. Use the [Build-Time Font Cache](#build-time-font-cache) strategy.
 {% endtab %}
 
 {% tab title="Sokol" %}
@@ -155,7 +176,7 @@ Registered fonts take priority over system fonts. If you register a font with th
 ### When to Use This Strategy
 
 * You're using Latin, Cyrillic, Greek, or another small-charset script.
-* You want to change font, size, style, or outline thickness without rebuilding atlases.
+* You want to change font, size, style, outline thickness, or baked drop shadow without rebuilding atlases.
 * You don't want to check generated `.fnt` files into source control.
 * For CJK or other large charsets, this strategy still works — but you should pair it with [Font Preloading](font-preloading.md) so the per-atlas generation cost happens on a loading screen rather than during gameplay.
 
@@ -218,7 +239,7 @@ The easiest way to mark all content as "Copy to Output Directory" is to use wild
 You can construct a `BitmapFont` yourself and assign it directly, bypassing the font property system entirely. Two sources for the `BitmapFont` are common:
 
 * [From a .fnt file on disk](#from-a-fnt-file-on-disk) — when you already have a baked atlas.
-* [From KernSmith with custom options](#from-kernsmith-with-custom-options) — when you want visual effects (outline color, shadows, gradients, SDF, color fonts, custom glyph subsets) or backend control that the `TextRuntime` property surface does not expose.
+* [From KernSmith with custom options](#from-kernsmith-with-custom-options) — when you want visual effects (outline color, gradient fills, SDF, color fonts, custom glyph subsets) or backend control beyond what `TextRuntime` exposes. Baked drop shadow is on the property path — see [TextRuntime Fonts](../standard-visuals/textruntime/fonts.md#baked-drop-shadow).
 
 {% hint style="warning" %}
 Once a `BitmapFont` is assigned directly, do not set font component properties (`Font`, `FontSize`, etc.) or `UseCustomFont` on the same `TextRuntime`. Those properties trigger the font loading system, which overwrites the directly assigned `BitmapFont`.
@@ -239,12 +260,12 @@ text.AddToRoot();
 
 ### From KernSmith with Custom Options
 
-`TextRuntime` exposes only a subset of the options KernSmith actually supports (`Font`, `FontSize`, `IsBold`, `IsItalic`, `OutlineThickness`, `UseFontSmoothing`). To use effects like outline color, drop shadows, gradient fills, SDF, color fonts, custom glyph subsets, or a non-default rasterizer backend, build a `BitmapFont` yourself by calling KernSmith directly, then assign it.
+`TextRuntime` exposes a subset of KernSmith's options (`Font`, `FontSize`, `IsBold`, `IsItalic`, `OutlineThickness`, `UseFontSmoothing`, and baked drop shadow via `HasDropshadow` and the dropshadow fields). To use outline color, gradient fills, SDF, color fonts, custom glyph subsets, or a non-default rasterizer backend, build a `BitmapFont` yourself by calling KernSmith directly, then assign it.
 
 For the full catalog of effects available through this path, see [Advanced Font Effects](advanced-font-effects.md).
 
 {% hint style="info" %}
-This path requires the KernSmith package for your runtime (`KernSmith.MonoGameGum` or `KernSmith.KniGum`). The bridge type `GumFontGenerator` lives in `KernSmith.GumCommon`, which is a transitive dependency.
+This path requires the KernSmith package for your runtime (`KernSmith.MonoGameGum`, `KernSmith.KniGum`, or `KernSmith.RaylibGum`). The bridge type `GumFontGenerator` lives in `KernSmith.GumCommon`, which is a transitive dependency.
 {% endhint %}
 
 #### Flow 1: Start from a BmfcSave, mutate options, then generate
@@ -347,14 +368,14 @@ foreach (var label in titleLabels)
 
 * You want a single `BitmapFont` instance shared across many `TextRuntime`s without each one re-loading from disk.
 * You're loading fonts from a non-standard source (embedded resource, network, custom pipeline) and want to keep the load step out of the property-driven path.
-* You need effects that `TextRuntime` does not expose — outline color, drop shadows, gradient fills, SDF, color fonts, or custom glyph subsets. See [Advanced Font Effects](advanced-font-effects.md).
+* You need effects that `TextRuntime` does not expose — outline color, gradient fills, SDF, color fonts, or custom glyph subsets. Baked drop shadow is on the property path. See [Advanced Font Effects](advanced-font-effects.md).
 * You need a custom character set that doesn't match any `BmfcSave.Ranges` value you'd want to ship.
 * You need to override the rasterizer backend — for example forcing `RasterizerBackend.StbTrueType` on Blazor WASM where the native FreeType library isn't available.
 
 ## Build-Time Font Cache
 
 {% hint style="info" %}
-This approach is primarily useful when your project already has pre-generated font files from the Gum tool, or when dynamic font generation is not yet available for your runtime (Raylib, Sokol, FNA today). For MonoGame and KNI, [Dynamic KernSmith Generation](#dynamic-kernsmith-generation) is the recommended approach; for SkiaGum see [Dynamic Generation on SkiaGum](#dynamic-generation-on-skiagum).
+This approach is primarily useful when your project already has pre-generated font files from the Gum tool, or when dynamic font generation is not yet available for your runtime (Sokol and FNA today). For MonoGame, KNI, and Raylib, [Dynamic KernSmith Generation](#dynamic-kernsmith-generation) is the recommended approach; for SkiaGum see [Dynamic Generation on SkiaGum](#dynamic-generation-on-skiagum).
 {% endhint %}
 
 If `UseCustomFont` is `false` (the default) and no `InMemoryFontCreator` is registered, a `TextRuntime`'s font is determined by its font component values. These values combine to produce a file name, and the corresponding `.fnt` file must already exist in a `FontCache` folder.
@@ -364,7 +385,7 @@ For the naming convention, generation rules, and full details, see [Font Cache](
 ### When to Use This Strategy
 
 * Pixel-perfect determinism: the atlas in source control is the atlas the player sees, every time.
-* Dynamic generation isn't available for your runtime (Raylib, Sokol, FNA today).
+* Dynamic generation isn't available for your runtime (Sokol and FNA today).
 * You want zero runtime CPU cost for font generation (atlases are loaded from disk, not generated).
 
 ## Missing Font Exceptions

--- a/docs/code/files-and-fonts/fonts.md
+++ b/docs/code/files-and-fonts/fonts.md
@@ -6,7 +6,7 @@ Gum supports several font loading strategies. The right one depends on your char
 
 This page is a decision tree. Pick the path that matches your game, then follow the link for the full details and code samples.
 
-For the API surface (which properties on `TextRuntime` control the font), see the [TextRuntime Fonts](../standard-visuals/textruntime/fonts.md) page.
+For the API surface (which properties on `TextRuntime` control the font, including baked drop shadow), see the [TextRuntime Fonts](../standard-visuals/textruntime/fonts.md) page.
 
 ## Pick a Strategy
 
@@ -14,11 +14,11 @@ For the API surface (which properties on `TextRuntime` control the font), see th
 
 **Use dynamic font generation.** No font files on disk, no cache to manage, no preloading needed. The first time a `(font, size, style)` combination is used, the atlas is generated in memory — fast enough for most games with small character sets to do during gameplay without a noticeable hitch.
 
-How this works depends on the runtime: MonoGame and KNI use the KernSmith NuGet package. SkiaGum has its own built-in dynamic generation. Raylib, Sokol, and FNA don't have dynamic generation today — for those, follow Path D.
+How this works depends on the runtime: MonoGame, KNI, and Raylib use the KernSmith NuGet package. SkiaGum has its own built-in dynamic generation. Sokol and FNA don't have dynamic generation today — for those, follow Path D.
 
 This is the default recommendation for most projects.
 
-→ See [Font Strategies — Dynamic KernSmith](font-strategies.md#dynamic-kernsmith-generation) (MonoGame/KNI) or [Dynamic Generation on SkiaGum](font-strategies.md#dynamic-generation-on-skiagum).
+→ See [Font Strategies — Dynamic KernSmith](font-strategies.md#dynamic-kernsmith-generation) (MonoGame, KNI, or Raylib) or [Dynamic Generation on SkiaGum](font-strategies.md#dynamic-generation-on-skiagum).
 
 ### Path B — Large charset (CJK), single locale per build
 
@@ -37,7 +37,7 @@ This is the default recommendation for most projects.
 **Use the build-time FontCache.** Useful when:
 
 * You want pixel-perfect determinism (atlases are checked into source control and never regenerated).
-* Dynamic generation is not yet available for your runtime (Raylib, Sokol, FNA today).
+* Dynamic generation is not yet available for your runtime (Sokol and FNA today).
 * You have hand-tuned `.fnt` files from another tool and want to ship them as-is.
 
 The Gum tool generates these atlases automatically while you edit your project. There is no opt-out yet.
@@ -53,9 +53,11 @@ The Gum tool generates these atlases automatically while you edit your project. 
 * [Font Localization](font-localization.md) — current behavior, known limitations, and the per-locale design that's coming.
 * [Font Cache](font-cache.md) — the build-time `.fnt` atlas system, naming convention, and when to use it.
 
-## Need Outline Color, Shadows, or Gradients?
+## Need Outline Color, Gradients, or Other KernSmith Extras?
 
-The strategies above all drive fonts through `TextRuntime`'s property surface, which exposes only a subset of what KernSmith can actually generate. If you want outline color (not just thickness), drop shadows, gradient fills, SDF, color fonts, custom glyph subsets, or a non-default rasterizer backend, build a `BitmapFont` via KernSmith yourself and assign it directly. See [Advanced Font Effects](advanced-font-effects.md) for the per-effect catalog and [Font Strategies — Direct BitmapFont Assignment](font-strategies.md#direct-bitmapfont-assignment) for the construction walkthrough.
+The strategies above drive fonts through `TextRuntime`'s property surface. That includes baked drop shadow (`HasDropshadow` and the dropshadow fields) — see [TextRuntime Fonts](../standard-visuals/textruntime/fonts.md#baked-drop-shadow).
+
+For effects still outside the property surface — outline color (not just thickness), gradient fills, SDF, color fonts, custom glyph subsets, or a non-default rasterizer backend — build a `BitmapFont` via KernSmith yourself and assign it directly. See [Advanced Font Effects](advanced-font-effects.md) for the per-effect catalog and [Font Strategies — Direct BitmapFont Assignment](font-strategies.md#direct-bitmapfont-assignment) for the construction walkthrough.
 
 ## Known Limitations
 
@@ -70,6 +72,6 @@ The following items are not yet supported. None of them are dealbreakers for shi
 
 ## Related Pages
 
-* [TextRuntime Fonts](../standard-visuals/textruntime/fonts.md) — the API reference: properties on `TextRuntime` that control font selection.
+* [TextRuntime Fonts](../standard-visuals/textruntime/fonts.md) — the API reference: properties on `TextRuntime` that control font selection, including baked drop shadow.
 * [BitmapFont](bitmapfont.md) — text measurement API and character info.
 * [File Loading](file-loading.md) — `RelativeDirectory`, file caching, and general file loading.

--- a/docs/code/standard-visuals/textruntime/fonts.md
+++ b/docs/code/standard-visuals/textruntime/fonts.md
@@ -15,10 +15,42 @@ By default all `TextRuntime` instances use an Arial 18-point font embedded in th
 | `IsBold` | `bool` | Bold style. |
 | `IsItalic` | `bool` | Italic style. |
 | `OutlineThickness` | `int` | Outline thickness in pixels (0 = no outline). |
+| `HasDropshadow` | `bool` | When `true`, KernSmith bakes a drop shadow into the font atlas (see [Baked drop shadow](#baked-drop-shadow)). |
+| `DropshadowColor` | `Color` | Shadow color. Shortcut for the four channel properties below. |
+| `DropshadowRed`, `DropshadowGreen`, `DropshadowBlue`, `DropshadowAlpha` | `int` | Shadow color channels (0–255). `DropshadowAlpha` decomposes to KernSmith `ShadowOpacity` at generation time. |
+| `DropshadowOffsetX`, `DropshadowOffsetY` | `float` | Horizontal / vertical shadow offset in pixels. |
+| `DropshadowBlur` | `float` | Blur radius in pixels. `0` is a sharp shadow; larger values soften the edges. Single scalar (like shape `DropshadowBlur`), not a per-axis pair. |
 | `UseFontSmoothing` | `bool` | Whether to use anti-aliased glyph rasterization. |
 | `UseCustomFont` | `bool` | When `true`, ignore the property combo and load `CustomFontFile` directly. |
 | `CustomFontFile` | `string` | Path to a specific `.fnt` file (only used when `UseCustomFont` is `true`). |
 | `BitmapFont` | `BitmapFont` | A directly-assigned font instance — bypasses the property-driven font system entirely. |
+
+### Baked drop shadow
+
+When `HasDropshadow` is `true`, KernSmith composites the shadow into each glyph's atlas cell at font-generation time — the same baked model as `OutlineThickness`. The shadow is **not** a per-draw runtime overlay; every character in that font variant always carries the shadow. State-dependent shadows (on/off per frame, animated blur) still need a runtime overlay such as a shape behind the text — see [Shapes — Drop shadow](../shapes-apos.shapes.md#drop-shadow).
+
+Requirements and cache behavior:
+
+* **KernSmith / `InMemoryFontCreator` required** — shadow fields participate in the property-driven path only when an in-memory font creator is registered (MonoGame, KNI, or Raylib via `KernSmithRaylibFontCreator`). Without it, Gum falls back to FontCache `.fnt` files, which do not encode shadow today.
+* **Separate font variant per shadow tuple** — like outline thickness, shadow offset/blur/color are keyed into the font cache file name when `HasDropshadow` is true, so each distinct combination generates its own atlas.
+* **Channel layout** — when shadow is enabled, Gum omits a custom `ChannelConfig` so KernSmith's default RGBA atlas path is preserved. Baked shadow color survives the runtime's text-color modulate instead of being forced to white.
+
+**First-enable defaults:** toggling `HasDropshadow` from `false` to `true` seeds a visible shadow when offset and blur are still zero — black (`DropshadowAlpha` 180), `DropshadowOffsetY` 3, `DropshadowBlur` 2. `DropshadowOffsetX` stays 0. Set channels explicitly before enabling if you need a different color.
+
+```csharp
+// Initialize
+var title = new TextRuntime();
+title.Text = "Quest Log";
+title.Font = "Arial";
+title.FontSize = 28;
+title.HasDropshadow = true;
+title.DropshadowColor = new Color(0, 0, 0, 180);
+title.DropshadowOffsetY = 3;
+title.DropshadowBlur = 2;
+title.AddToRoot();
+```
+
+For KernSmith-only extras on the direct-assignment path (`HardShadow`, custom `Padding`, and so on), see [Advanced Font Effects — Drop Shadow](../../files-and-fonts/advanced-font-effects.md#drop-shadow).
 
 ## How These Properties Resolve to a Font
 
@@ -26,7 +58,7 @@ A `TextRuntime`'s font is chosen by one of these paths, in priority order:
 
 1. **`BitmapFont` is set directly** → that font is used; the component properties are ignored.
 2. **`UseCustomFont` is `true`** → `CustomFontFile` is loaded from disk.
-3. **`UseCustomFont` is `false` and an `InMemoryFontCreator` is registered** (e.g. KernSmith) → the font is generated in memory from the component properties.
+3. **`UseCustomFont` is `false` and an `InMemoryFontCreator` is registered** (e.g. KernSmith) → the font is generated in memory from the component properties, including `HasDropshadow` and the dropshadow fields when enabled.
 4. **`UseCustomFont` is `false` and no `InMemoryFontCreator` is registered** → Gum looks for a matching `.fnt` file in the project's `FontCache` folder, named according to the component properties.
 
 For the full details on each path — when to use it, code samples, and the costs involved — see:


### PR DESCRIPTION
## Summary

- Update font docs for `TextRuntime` baked drop shadow (#2724): property table, KernSmith requirement, Raylib dynamic generation, and corrected advanced-font-effects / font-strategies guidance.
- Extend the big-three samples with **Text** screens: MonoGame + raylib wire KernSmith and show baked shadow rows; SilkNetGum mirrors layout with an explicit note that Skia does not bake text shadows yet.

## Test plan

- [x] `dotnet build Samples/MonoGameGumInCode/MonoGameGumInCode/MonoGameGumInCode.csproj`
- [x] `dotnet build Samples/raylib/GumTest.csproj`
- [x] `dotnet build Samples/SilkNetGum/SilkNetGum/SilkNetGum.csproj`
- [x] MonoGameGumInCode → **Text** nav → verify three baked-shadow rows + legacy outline demos
- [x] raylib gallery → **Text** nav → same shadow rows visible
- [x] SilkNetGum → arrow to Text screen → label explains Skia gap; no false shadow expectation

Closes #3414
