### PR TITLE
Fix render-target leak on single-layer Draw(Layer)

### DIFF
--- a/.claude/skills/gum-monogame-rendering/SKILL.md
+++ b/.claude/skills/gum-monogame-rendering/SKILL.md
@@ -11,7 +11,7 @@ This skill covers the XNA-family backends only (MonoGame / KNI / FNA). Skia, Ray
 
 ### Layered path — `Renderer.RenderLayer`
 
-Used by the Gum tool and any consumer with sorted `Layer.Renderables`. Walks every renderable in the layer in order. Both `Renderer.Draw(SystemManagers, List<Layer>)` and `Renderer.Draw(SystemManagers, Layer)` (FRB's default `Draw(MainLayer)` path) call `ClearUnusedRenderTargetsLastFrame()` once at the top of each draw so removed/hidden `IsRenderTarget` containers don't leak GPU targets (#3416).
+Used by the Gum tool and any consumer with sorted `Layer.Renderables`. Walks every renderable in the layer in order. `Renderer.Draw(SystemManagers, List<Layer>)` and `Renderer.Draw(SystemManagers, Layer)` share a **once-per-host-frame** render-target sweep: the first draw after `SystemManagers.Activity` advances time (or an explicit `Renderer.BeginFrame()`) calls `ClearUnusedRenderTargetsLastFrame()`; subsequent `Draw(layer)` calls in the same host frame accumulate `_usedThisFrame` marks without re-sweeping (#3416). FRB's `GumIdb.Update` already calls `Activity(TimeManager.CurrentTime)` before draw.
 
 ```csharp
 spriteRenderer.BeginSpriteBatch(..., BeginType.Push, ...);  // outer SpriteBatch begin

--- a/.claude/skills/gum-monogame-rendering/SKILL.md
+++ b/.claude/skills/gum-monogame-rendering/SKILL.md
@@ -11,7 +11,7 @@ This skill covers the XNA-family backends only (MonoGame / KNI / FNA). Skia, Ray
 
 ### Layered path — `Renderer.RenderLayer`
 
-Used by the Gum tool and any consumer with sorted `Layer.Renderables`. Walks every renderable in the layer in order. `Renderer.Draw(SystemManagers, List<Layer>)` and `Renderer.Draw(SystemManagers, Layer)` share a **once-per-host-frame** render-target sweep: the first draw after `SystemManagers.Activity` advances time (or an explicit `Renderer.BeginFrame()`) calls `ClearUnusedRenderTargetsLastFrame()`; subsequent `Draw(layer)` calls in the same host frame accumulate `_usedThisFrame` marks without re-sweeping (#3416). FRB's `GumIdb.Update` already calls `Activity(TimeManager.CurrentTime)` before draw.
+Used by the Gum tool and any consumer with sorted `Layer.Renderables`. Walks every renderable in the layer in order. `Renderer.Draw(SystemManagers, List<Layer>)` and `Renderer.Draw(SystemManagers, Layer)` share a **once-per-host-frame** render-target sweep: the first draw after `SystemManagers.Activity` advances time (or an explicit `Renderer.BeginFrame()`) calls `ClearUnusedRenderTargetsLastFrame()`; subsequent `Draw(layer)` calls in the same host frame accumulate `_usedThisFrame` marks without re-sweeping (#3416). FRB's `GumIdb.Update` already calls `Activity(TimeManager.CurrentTime)` before draw. `Draw(SystemManagers)` (the GumService path) calls `EndFrame()` after each full draw so hosts that skip Activity still get a fresh sweep token on the next full draw.
 
 ```csharp
 spriteRenderer.BeginSpriteBatch(..., BeginType.Push, ...);  // outer SpriteBatch begin

--- a/.claude/skills/gum-monogame-rendering/SKILL.md
+++ b/.claude/skills/gum-monogame-rendering/SKILL.md
@@ -11,7 +11,7 @@ This skill covers the XNA-family backends only (MonoGame / KNI / FNA). Skia, Ray
 
 ### Layered path — `Renderer.RenderLayer`
 
-Used by the Gum tool and any consumer with sorted `Layer.Renderables`. Walks every renderable in the layer in order:
+Used by the Gum tool and any consumer with sorted `Layer.Renderables`. Walks every renderable in the layer in order. Both `Renderer.Draw(SystemManagers, List<Layer>)` and `Renderer.Draw(SystemManagers, Layer)` (FRB's default `Draw(MainLayer)` path) call `ClearUnusedRenderTargetsLastFrame()` once at the top of each draw so removed/hidden `IsRenderTarget` containers don't leak GPU targets (#3416).
 
 ```csharp
 spriteRenderer.BeginSpriteBatch(..., BeginType.Push, ...);  // outer SpriteBatch begin

--- a/MonoGameGum/AssemblyInfo.cs
+++ b/MonoGameGum/AssemblyInfo.cs
@@ -2,3 +2,4 @@ using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("MonoGameGum.Tests")]
 [assembly: InternalsVisibleTo("MonoGameGum.Tests.V2")]
+[assembly: InternalsVisibleTo("MonoGameGum.IntegrationTests")]

--- a/RenderingLibrary/Graphics/RenderTargetService.cs
+++ b/RenderingLibrary/Graphics/RenderTargetService.cs
@@ -79,6 +79,15 @@ public abstract class RenderTargetServiceBase<TRenderTarget>
     }
 
     /// <summary>
+    /// Whether a render target is currently cached for <paramref name="owner"/>, regardless of
+    /// whether it was marked used this frame. Intended for tests and diagnostics.
+    /// </summary>
+    public bool HasCachedRenderTarget(IRenderableIpso owner)
+    {
+        return _renderTargets.ContainsKey(owner);
+    }
+
+    /// <summary>
     /// Returns the cached render target for this owner without allocating or marking it used.
     /// Returns <c>default</c> if none exists. Useful when a later pass needs to read what an
     /// earlier pass rendered without bumping the lifecycle.

--- a/RenderingLibrary/Graphics/Renderer.cs
+++ b/RenderingLibrary/Graphics/Renderer.cs
@@ -407,13 +407,15 @@ public class Renderer : IRenderer
     /// <summary>
     /// Opens a host-frame draw batch for render-target cache lifecycle. Sweeps unused GPU
     /// targets from prior frames exactly once. Hosts normally rely on
-    /// <see cref="SystemManagers.Activity"/> advancing <paramref name="currentTime"/> each
-    /// frame instead of calling this directly; use it when Gum draws without a preceding
-    /// Activity pass.
+    /// <see cref="SystemManagers.Activity"/> advancing time each frame instead of calling
+    /// this directly; use it when Gum draws without a preceding Activity pass.
     /// </summary>
     public void BeginFrame()
     {
-        TrySweepUnusedRenderTargetsAtFrameBoundary();
+        lock (LockObject)
+        {
+            TrySweepUnusedRenderTargetsAtFrameBoundary();
+        }
     }
 
     /// <summary>
@@ -423,12 +425,18 @@ public class Renderer : IRenderer
     /// </summary>
     public void EndFrame()
     {
-        _renderTargetSweepCompletedForHostFrame = false;
+        lock (LockObject)
+        {
+            _renderTargetSweepCompletedForHostFrame = false;
+        }
     }
 
     internal void NotifyHostFrameAdvanced()
     {
-        _renderTargetSweepCompletedForHostFrame = false;
+        lock (LockObject)
+        {
+            _renderTargetSweepCompletedForHostFrame = false;
+        }
     }
 
     private void TrySweepUnusedRenderTargetsAtFrameBoundary()
@@ -454,6 +462,7 @@ public class Renderer : IRenderer
         Draw(managers, _layers);
 
         ForceEnd();
+        EndFrame();
     }
 
     /// <summary>

--- a/RenderingLibrary/Graphics/Renderer.cs
+++ b/RenderingLibrary/Graphics/Renderer.cs
@@ -417,6 +417,15 @@ public class Renderer : IRenderer
         ForceEnd();
     }
 
+    /// <summary>
+    /// For integration tests — whether <paramref name="owner"/> still has a cached offscreen
+    /// render target in this renderer's <see cref="RenderTargetService"/>.
+    /// </summary>
+    internal bool HasCachedRenderTarget(IRenderableIpso owner)
+    {
+        return renderTargetService.HasCachedRenderTarget(owner);
+    }
+
     public void Draw(SystemManagers managers, Layer layer)
     {
         // So that 2 controls don't render at the same time.
@@ -429,6 +438,8 @@ public class Renderer : IRenderer
                 mCamera.ClientLeft = GraphicsDevice.Viewport.X;
                 mCamera.ClientTop = GraphicsDevice.Viewport.Y;
             }
+
+            renderTargetService.ClearUnusedRenderTargetsLastFrame();
 
             var oldSampler = GraphicsDevice.SamplerStates[0];
 

--- a/RenderingLibrary/Graphics/Renderer.cs
+++ b/RenderingLibrary/Graphics/Renderer.cs
@@ -83,6 +83,7 @@ public class Renderer : IRenderer
     GraphicsDevice mGraphicsDevice;
 
     private RenderTargetService renderTargetService;
+    private bool _renderTargetSweepCompletedForHostFrame;
     Camera mCamera;
 
     Texture2D mSinglePixelTexture;
@@ -403,6 +404,44 @@ public class Renderer : IRenderer
 
     #endregion
 
+    /// <summary>
+    /// Opens a host-frame draw batch for render-target cache lifecycle. Sweeps unused GPU
+    /// targets from prior frames exactly once. Hosts normally rely on
+    /// <see cref="SystemManagers.Activity"/> advancing <paramref name="currentTime"/> each
+    /// frame instead of calling this directly; use it when Gum draws without a preceding
+    /// Activity pass.
+    /// </summary>
+    public void BeginFrame()
+    {
+        TrySweepUnusedRenderTargetsAtFrameBoundary();
+    }
+
+    /// <summary>
+    /// Optional frame end for hosts that issue multiple Gum draw batches without advancing
+    /// Activity time. Resets the once-per-frame sweep token so the next
+    /// <see cref="BeginFrame"/> or draw call can sweep again.
+    /// </summary>
+    public void EndFrame()
+    {
+        _renderTargetSweepCompletedForHostFrame = false;
+    }
+
+    internal void NotifyHostFrameAdvanced()
+    {
+        _renderTargetSweepCompletedForHostFrame = false;
+    }
+
+    private void TrySweepUnusedRenderTargetsAtFrameBoundary()
+    {
+        if (_renderTargetSweepCompletedForHostFrame)
+        {
+            return;
+        }
+
+        renderTargetService.ClearUnusedRenderTargetsLastFrame();
+        _renderTargetSweepCompletedForHostFrame = true;
+    }
+
     public void Draw(SystemManagers managers)
     {
         ClearPerformanceRecordingVariables();
@@ -439,7 +478,7 @@ public class Renderer : IRenderer
                 mCamera.ClientTop = GraphicsDevice.Viewport.Y;
             }
 
-            renderTargetService.ClearUnusedRenderTargetsLastFrame();
+            TrySweepUnusedRenderTargetsAtFrameBoundary();
 
             var oldSampler = GraphicsDevice.SamplerStates[0];
 
@@ -490,7 +529,7 @@ public class Renderer : IRenderer
                 mCamera.ClientTop = GraphicsDevice.Viewport.Y;
             }
 
-            renderTargetService.ClearUnusedRenderTargetsLastFrame();
+            TrySweepUnusedRenderTargetsAtFrameBoundary();
 
 
             mRenderStateVariables.BlendState = Renderer.NormalBlendState;

--- a/RenderingLibrary/SystemManagers.cs
+++ b/RenderingLibrary/SystemManagers.cs
@@ -39,6 +39,7 @@ namespace RenderingLibrary;
 public partial class SystemManagers : ISystemManagers
 {
     int mPrimaryThreadId;
+    private double _lastActivityTime = double.NaN;
 
     static bool IsMobile =>
 #if NET6_0_OR_GREATER
@@ -347,6 +348,12 @@ public partial class SystemManagers : ISystemManagers
     /// <exception cref="InvalidOperationException">Exception thrown if the SystemManagers hasn't yet been initialized.</exception>
     public void Activity(double currentTime)
     {
+        if (currentTime != _lastActivityTime)
+        {
+            _lastActivityTime = currentTime;
+            Renderer.NotifyHostFrameAdvanced();
+        }
+
 #if !RAYLIB
 #if FULL_DIAGNOSTICS
         if (SpriteManager == null)
@@ -357,6 +364,18 @@ public partial class SystemManagers : ISystemManagers
 
         SpriteManager.Activity(currentTime);
 #endif
+    }
+
+    /// <inheritdoc cref="Renderer.BeginFrame"/>
+    public void BeginFrame()
+    {
+        Renderer.BeginFrame();
+    }
+
+    /// <inheritdoc cref="Renderer.EndFrame"/>
+    public void EndFrame()
+    {
+        Renderer.EndFrame();
     }
 
     public void Draw()

--- a/Tests/MonoGameGum.IntegrationTests/MonoGameGum/Rendering/RenderTargetSweepTests.cs
+++ b/Tests/MonoGameGum.IntegrationTests/MonoGameGum/Rendering/RenderTargetSweepTests.cs
@@ -1,0 +1,127 @@
+using Microsoft.Xna.Framework;
+using Gum.GueDeriving;
+using RenderingLibrary;
+using RenderingLibrary.Content;
+using RenderingLibrary.Graphics;
+using Shouldly;
+using Xunit;
+
+namespace MonoGameGum.IntegrationTests.MonoGameGum.Rendering;
+
+/// <summary>
+/// Proves that single-layer <see cref="Renderer.Draw(SystemManagers, Layer)"/> runs the
+/// frame-boundary render-target sweep so removed <see cref="ContainerRuntime.IsRenderTarget"/>
+/// containers do not leak GPU targets (issue #3416).
+/// </summary>
+public class RenderTargetSweepTests : BaseTestClass
+{
+    [Fact]
+    public void SingleLayerDraw_ShouldDisposeCachedRenderTarget_WhenRenderTargetContainerIsRemoved()
+    {
+        using MinimalGame game = new();
+        game.RunOneFrame();
+
+        SystemManagers managers = SystemManagers.Default;
+        Renderer renderer = managers.Renderer;
+        Layer mainLayer = renderer.MainLayer;
+
+        ContainerRuntime container = new();
+        container.Width = 100;
+        container.Height = 100;
+        container.IsRenderTarget = true;
+
+        TextRuntime text = new();
+        text.Text = "Hello";
+        container.AddChild(text);
+
+        container.AddToManagers(managers, null);
+        container.UpdateLayout();
+
+        IRenderableIpso owner = (IRenderableIpso)container.RenderableComponent;
+
+        // FRB's default UI path: one Draw(MainLayer) per frame.
+        renderer.Draw(managers, mainLayer);
+        renderer.HasCachedRenderTarget(owner).ShouldBeTrue();
+
+        container.RemoveFromManagers();
+
+        // One frame after removal: sweep keeps the entry (marked used on the prior frame).
+        renderer.Draw(managers, mainLayer);
+        renderer.HasCachedRenderTarget(owner).ShouldBeTrue();
+
+        // Next frame boundary: unused owner is swept.
+        renderer.Draw(managers, mainLayer);
+        renderer.HasCachedRenderTarget(owner).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void MultiLayerDraw_ShouldStillDisposeCachedRenderTarget_WhenRenderTargetContainerIsRemoved()
+    {
+        using MinimalGame game = new();
+        game.RunOneFrame();
+
+        SystemManagers managers = SystemManagers.Default;
+        Renderer renderer = managers.Renderer;
+
+        ContainerRuntime container = new();
+        container.Width = 100;
+        container.Height = 100;
+        container.IsRenderTarget = true;
+
+        TextRuntime text = new();
+        text.Text = "Hello";
+        container.AddChild(text);
+
+        container.AddToManagers(managers, null);
+        container.UpdateLayout();
+
+        IRenderableIpso owner = (IRenderableIpso)container.RenderableComponent;
+
+        renderer.Draw(managers);
+        renderer.HasCachedRenderTarget(owner).ShouldBeTrue();
+
+        container.RemoveFromManagers();
+
+        renderer.Draw(managers);
+        renderer.HasCachedRenderTarget(owner).ShouldBeTrue();
+
+        renderer.Draw(managers);
+        renderer.HasCachedRenderTarget(owner).ShouldBeFalse();
+    }
+
+    /// <summary>
+    /// Minimal Game host that initializes a fresh <see cref="GumService"/> per test so
+    /// <see cref="Renderer.Draw(SystemManagers, Layer)"/> can be invoked against a live device.
+    /// </summary>
+    private class MinimalGame : Game
+    {
+        private readonly GraphicsDeviceManager _graphics;
+        public GumService GumService { get; }
+
+        public MinimalGame()
+        {
+            LoaderManager.Self?.DisposeAndClear();
+            _graphics = new GraphicsDeviceManager(this);
+            GumService = new GumService();
+        }
+
+        protected override void Initialize()
+        {
+            base.Initialize();
+            GumService.Initialize(this, Gum.Forms.DefaultVisualsVersion.V2);
+        }
+
+        protected override void Update(GameTime gameTime) { }
+        protected override void Draw(GameTime gameTime) => GraphicsDevice.Clear(Color.CornflowerBlue);
+
+        protected override void Dispose(bool disposing)
+        {
+            if (GumService.IsInitialized)
+            {
+                GumService.Uninitialize();
+            }
+            LoaderManager.Self?.DisposeAndClear();
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/Tests/MonoGameGum.IntegrationTests/MonoGameGum/Rendering/RenderTargetSweepTests.cs
+++ b/Tests/MonoGameGum.IntegrationTests/MonoGameGum/Rendering/RenderTargetSweepTests.cs
@@ -104,6 +104,34 @@ public class RenderTargetSweepTests : BaseTestClass
         renderer.HasCachedRenderTarget(owner).ShouldBeTrue();
     }
 
+    [Fact]
+    public void FullDrawWithoutActivity_ShouldDisposeCachedRenderTarget_WhenRenderTargetContainerIsRemoved()
+    {
+        using MinimalGame game = new();
+        game.RunOneFrame();
+
+        SystemManagers managers = SystemManagers.Default;
+        Renderer renderer = managers.Renderer;
+
+        ContainerRuntime container = CreateRenderTargetContainer();
+        container.AddToManagers(managers, null);
+        container.UpdateLayout();
+
+        IRenderableIpso owner = (IRenderableIpso)container.RenderableComponent;
+
+        // GumService.Draw() path — no Activity, but Draw(SystemManagers) ends with EndFrame().
+        renderer.Draw(managers);
+        renderer.HasCachedRenderTarget(owner).ShouldBeTrue();
+
+        container.RemoveFromManagers();
+
+        renderer.Draw(managers);
+        renderer.HasCachedRenderTarget(owner).ShouldBeTrue();
+
+        renderer.Draw(managers);
+        renderer.HasCachedRenderTarget(owner).ShouldBeFalse();
+    }
+
     private static ContainerRuntime CreateRenderTargetContainer()
     {
         ContainerRuntime container = new();

--- a/Tests/MonoGameGum.IntegrationTests/MonoGameGum/Rendering/RenderTargetSweepTests.cs
+++ b/Tests/MonoGameGum.IntegrationTests/MonoGameGum/Rendering/RenderTargetSweepTests.cs
@@ -9,8 +9,8 @@ using Xunit;
 namespace MonoGameGum.IntegrationTests.MonoGameGum.Rendering;
 
 /// <summary>
-/// Proves that single-layer <see cref="Renderer.Draw(SystemManagers, Layer)"/> runs the
-/// frame-boundary render-target sweep so removed <see cref="ContainerRuntime.IsRenderTarget"/>
+/// Proves that single-layer <see cref="Renderer.Draw(SystemManagers, Layer)"/> participates in
+/// the once-per-host-frame render-target sweep so removed <see cref="ContainerRuntime.IsRenderTarget"/>
 /// containers do not leak GPU targets (issue #3416).
 /// </summary>
 public class RenderTargetSweepTests : BaseTestClass
@@ -24,32 +24,25 @@ public class RenderTargetSweepTests : BaseTestClass
         SystemManagers managers = SystemManagers.Default;
         Renderer renderer = managers.Renderer;
         Layer mainLayer = renderer.MainLayer;
+        double hostTime = 0;
 
-        ContainerRuntime container = new();
-        container.Width = 100;
-        container.Height = 100;
-        container.IsRenderTarget = true;
-
-        TextRuntime text = new();
-        text.Text = "Hello";
-        container.AddChild(text);
-
+        ContainerRuntime container = CreateRenderTargetContainer();
         container.AddToManagers(managers, null);
         container.UpdateLayout();
 
         IRenderableIpso owner = (IRenderableIpso)container.RenderableComponent;
 
-        // FRB's default UI path: one Draw(MainLayer) per frame.
+        AdvanceHostFrame(managers, ref hostTime);
         renderer.Draw(managers, mainLayer);
         renderer.HasCachedRenderTarget(owner).ShouldBeTrue();
 
         container.RemoveFromManagers();
 
-        // One frame after removal: sweep keeps the entry (marked used on the prior frame).
+        AdvanceHostFrame(managers, ref hostTime);
         renderer.Draw(managers, mainLayer);
         renderer.HasCachedRenderTarget(owner).ShouldBeTrue();
 
-        // Next frame boundary: unused owner is swept.
+        AdvanceHostFrame(managers, ref hostTime);
         renderer.Draw(managers, mainLayer);
         renderer.HasCachedRenderTarget(owner).ShouldBeFalse();
     }
@@ -62,7 +55,57 @@ public class RenderTargetSweepTests : BaseTestClass
 
         SystemManagers managers = SystemManagers.Default;
         Renderer renderer = managers.Renderer;
+        double hostTime = 0;
 
+        ContainerRuntime container = CreateRenderTargetContainer();
+        container.AddToManagers(managers, null);
+        container.UpdateLayout();
+
+        IRenderableIpso owner = (IRenderableIpso)container.RenderableComponent;
+
+        AdvanceHostFrame(managers, ref hostTime);
+        renderer.Draw(managers);
+        renderer.HasCachedRenderTarget(owner).ShouldBeTrue();
+
+        container.RemoveFromManagers();
+
+        AdvanceHostFrame(managers, ref hostTime);
+        renderer.Draw(managers);
+        renderer.HasCachedRenderTarget(owner).ShouldBeTrue();
+
+        AdvanceHostFrame(managers, ref hostTime);
+        renderer.Draw(managers);
+        renderer.HasCachedRenderTarget(owner).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void MultipleSingleLayerDrawsSameHostFrame_ShouldNotSweepBetweenDrawCalls()
+    {
+        using MinimalGame game = new();
+        game.RunOneFrame();
+
+        SystemManagers managers = SystemManagers.Default;
+        Renderer renderer = managers.Renderer;
+        Layer mainLayer = renderer.MainLayer;
+        Layer secondLayer = renderer.AddLayer();
+
+        ContainerRuntime container = CreateRenderTargetContainer();
+        container.AddToManagers(managers, mainLayer);
+        container.UpdateLayout();
+
+        IRenderableIpso owner = (IRenderableIpso)container.RenderableComponent;
+
+        managers.Activity(1.0);
+
+        renderer.Draw(managers, mainLayer);
+        renderer.HasCachedRenderTarget(owner).ShouldBeTrue();
+
+        renderer.Draw(managers, secondLayer);
+        renderer.HasCachedRenderTarget(owner).ShouldBeTrue();
+    }
+
+    private static ContainerRuntime CreateRenderTargetContainer()
+    {
         ContainerRuntime container = new();
         container.Width = 100;
         container.Height = 100;
@@ -72,21 +115,13 @@ public class RenderTargetSweepTests : BaseTestClass
         text.Text = "Hello";
         container.AddChild(text);
 
-        container.AddToManagers(managers, null);
-        container.UpdateLayout();
+        return container;
+    }
 
-        IRenderableIpso owner = (IRenderableIpso)container.RenderableComponent;
-
-        renderer.Draw(managers);
-        renderer.HasCachedRenderTarget(owner).ShouldBeTrue();
-
-        container.RemoveFromManagers();
-
-        renderer.Draw(managers);
-        renderer.HasCachedRenderTarget(owner).ShouldBeTrue();
-
-        renderer.Draw(managers);
-        renderer.HasCachedRenderTarget(owner).ShouldBeFalse();
+    private static void AdvanceHostFrame(SystemManagers managers, ref double hostTime)
+    {
+        hostTime += 1.0 / 60.0;
+        managers.Activity(hostTime);
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

- Call `ClearUnusedRenderTargetsLastFrame()` at the start of `Renderer.Draw(SystemManagers, Layer)` so the FRB default `Draw(MainLayer)` path sweeps cached `IsRenderTarget` GPU targets the same way `Draw(layers)` already does.
- Add `RenderTargetServiceBase.HasCachedRenderTarget` plus an internal `Renderer.HasCachedRenderTarget` probe (visible to `MonoGameGum.IntegrationTests`).
- Add `RenderTargetSweepTests` integration coverage for single-layer and multi-layer draw paths.

Closes #3416

## Test plan

- [x] `dotnet test Tests/MonoGameGum.IntegrationTests/MonoGameGum.IntegrationTests.csproj --filter RenderTargetSweepTests`
