### PR TITLE
Fix cross-layer RenderTargetTextureSource on per-layer Draw(Layer)

### DIFF
--- a/.claude/skills/gum-monogame-rendering/SKILL.md
+++ b/.claude/skills/gum-monogame-rendering/SKILL.md
@@ -41,6 +41,22 @@ The GumBatch path (`Renderer.Begin/Draw/End`) calls `BeginSpriteBatch` immediate
 
 Practical consequence: any new "runtime resolves a property in `PreRender` and pushes it to the renderable" pattern (the `AposShapeRuntime.StrokeWidth` shape) works on both entry paths, but only the layered path renders nested render targets.
 
+## Cross-Layer `RenderTargetTextureSource` and Per-Layer Draw (issues #3416 / #3417)
+
+`Sprite.RenderTargetTextureSource` lets a sprite sample a cached offscreen target owned by a render-target container on **another** layer. The multi-layer `Draw(SystemManagers, List<Layer>)` path already ran a two-pass pre-render (bake all layers, then bind referencer textures on all layers) before compositing. Per-layer `Draw(SystemManagers, Layer)` — the FRB / `GumIdb` default — did not, so cross-layer references went stale.
+
+**Per-layer draw contract (post-#3417):**
+
+1. **Once per host frame** (first `Draw(Layer)` or explicit `PreRenderLayers`): `TryPreRenderAllLayersForHostFrame` → `PreRenderLayersCore(_layers)` — bake every layer's render targets, then bind every layer's `IRenderTargetTextureReferencer` textures. Token resets when `SystemManagers.Activity` time advances (`NotifyHostFrameAdvanced`) or `EndFrame()` runs.
+2. **Every `Draw(Layer)` call** (even when step 1 already ran): `PreRender(currentLayer.Renderables)` + `PreRenderWithSourceRenderTargets(currentLayer.Renderables)` — same per-layer hooks the legacy path always ran. Do **not** skip step 2 when the all-layer bake already ran; layout hooks and texture rebind still need to run for the layer being composited.
+3. **Compositing:** `RenderLayer(..., prerender: false)`.
+
+Optional explicit API: `SystemManagers.PreRenderLayers(layers)` / `Renderer.PreRenderLayers(layers)` — bake+bind without drawing (for hosts that want to separate pre-render from compositing).
+
+`ResolveRenderTargetCacheOwner` maps a `GraphicalUiElement` `RenderTargetTextureSource` to its `RenderableComponent` for cache lookup — the cache key is always the contained `IRenderableIpso`, not the GUE wrapper.
+
+**Integration tests:** `CrossLayerRenderTargetTextureSourceTests` (per-layer draw, consumer-first and source-first order) + `RenderTargetSweepTests` (#3416 sweep). Tests share `SystemManagers.Default`; advance Activity time uniquely each frame (`AdvanceHostFrame`) so once-per-frame tokens reset.
+
 ## Render-Target Post-Process Effects (issue #816)
 
 A render-target container can carry a post-process shader applied when its cached texture is blitted **back** to the screen — not while children render *into* the target. Storage is `RenderableBase.RenderTargetEffect`, typed `object?` so the shared (non-XNA) rendering layer stays backend-agnostic; the xnalike `Renderer` casts it to a MonoGame `Effect`. The user-facing setter is the strongly-typed `ContainerRuntime.RenderTargetEffect` (`#if XNALIKE`).

--- a/RenderingLibrary/Graphics/Renderer.cs
+++ b/RenderingLibrary/Graphics/Renderer.cs
@@ -84,6 +84,7 @@ public class Renderer : IRenderer
 
     private RenderTargetService renderTargetService;
     private bool _renderTargetSweepCompletedForHostFrame;
+    private bool _allLayersPreRenderedForHostFrame;
     Camera mCamera;
 
     Texture2D mSinglePixelTexture;
@@ -428,6 +429,7 @@ public class Renderer : IRenderer
         lock (LockObject)
         {
             _renderTargetSweepCompletedForHostFrame = false;
+            _allLayersPreRenderedForHostFrame = false;
         }
     }
 
@@ -436,6 +438,7 @@ public class Renderer : IRenderer
         lock (LockObject)
         {
             _renderTargetSweepCompletedForHostFrame = false;
+            _allLayersPreRenderedForHostFrame = false;
         }
     }
 
@@ -448,6 +451,60 @@ public class Renderer : IRenderer
 
         renderTargetService.ClearUnusedRenderTargetsLastFrame();
         _renderTargetSweepCompletedForHostFrame = true;
+    }
+
+    /// <summary>
+    /// Bakes render targets and binds <see cref="IRenderTargetTextureReferencer"/> textures for
+    /// the supplied layers without compositing them. Per-layer hosts (or FRB drawing Gum layers
+    /// across multiple draw calls) should call this once per frame with every layer that can
+    /// supply a <see cref="IRenderTargetTextureReferencer.RenderTargetTextureSource"/> before
+    /// any <see cref="Draw(SystemManagers, Layer)"/> compositing pass.
+    /// </summary>
+    public void PreRenderLayers(IReadOnlyList<Layer> layers)
+    {
+        lock (LockObject)
+        {
+            PreRenderLayersCore(layers);
+            _allLayersPreRenderedForHostFrame = true;
+        }
+    }
+
+    private void TryPreRenderAllLayersForHostFrame()
+    {
+        if (_allLayersPreRenderedForHostFrame)
+        {
+            return;
+        }
+
+        PreRenderLayersCore(_layers);
+        _allLayersPreRenderedForHostFrame = true;
+    }
+
+    private void PreRenderLayersCore(IReadOnlyList<Layer> layers)
+    {
+        for (int i = 0; i < layers.Count; i++)
+        {
+            SetFilteringForLayer(layers[i]);
+            PreRender(layers[i].Renderables);
+        }
+
+        for (int i = 0; i < layers.Count; i++)
+        {
+            SetFilteringForLayer(layers[i]);
+            PreRenderWithSourceRenderTargets(layers[i].Renderables);
+        }
+    }
+
+    private void SetFilteringForLayer(Layer layer)
+    {
+        if (layer.IsLinearFilteringEnabled != null)
+        {
+            mRenderStateVariables.Filtering = layer.IsLinearFilteringEnabled.Value;
+        }
+        else
+        {
+            mRenderStateVariables.Filtering = TextureFilter == TextureFilter.Linear;
+        }
     }
 
     public void Draw(SystemManagers managers)
@@ -494,28 +551,13 @@ public class Renderer : IRenderer
             mRenderStateVariables.BlendState = Renderer.NormalBlendState;
             mRenderStateVariables.Wrap = false;
 
-            if (layer.IsLinearFilteringEnabled != null)
-            {
-                mRenderStateVariables.Filtering = layer.IsLinearFilteringEnabled.Value;
-            }
-            else
-            {
-                mRenderStateVariables.Filtering = TextureFilter == TextureFilter.Linear;
-            }
+            TryPreRenderAllLayersForHostFrame();
 
+            SetFilteringForLayer(layer);
             PreRender(layer.Renderables);
-
             PreRenderWithSourceRenderTargets(layer.Renderables);
 
-            if (layer.IsLinearFilteringEnabled != null)
-            {
-                mRenderStateVariables.Filtering = layer.IsLinearFilteringEnabled.Value;
-            }
-            else
-            {
-                mRenderStateVariables.Filtering = TextureFilter == TextureFilter.Linear;
-            }
-
+            SetFilteringForLayer(layer);
             RenderLayer(managers, layer, prerender:false);
 
             if (oldSampler != null)
@@ -544,33 +586,12 @@ public class Renderer : IRenderer
             mRenderStateVariables.BlendState = Renderer.NormalBlendState;
             mRenderStateVariables.Wrap = false;
 
-            for (int i = 0; i < layers.Count; i++)
-            {
-                var layer = layers[i];
-                if(layer.IsLinearFilteringEnabled != null)
-                {
-                    mRenderStateVariables.Filtering = layer.IsLinearFilteringEnabled.Value;
-                }
-                else
-                {
-                    mRenderStateVariables.Filtering = TextureFilter == TextureFilter.Linear;
-                }
-                PreRender(layer.Renderables);
-
-                PreRenderWithSourceRenderTargets(layer.Renderables);
-            }
+            PreRenderLayersCore(layers);
 
             for (int i = 0; i < layers.Count; i++)
             {
                 Layer layer = layers[i];
-                if (layer.IsLinearFilteringEnabled != null)
-                {
-                    mRenderStateVariables.Filtering = layer.IsLinearFilteringEnabled.Value;
-                }
-                else
-                {
-                    mRenderStateVariables.Filtering = TextureFilter == TextureFilter.Linear;
-                }
+                SetFilteringForLayer(layer);
                 RenderLayer(managers, layer, prerender:false);
             }
         }
@@ -743,8 +764,9 @@ public class Renderer : IRenderer
             if (renderable.Visible && renderable is IRenderTargetTextureReferencer textureReferencer &&
                 textureReferencer.RenderTargetTextureSource != null)
             {
-                textureReferencer.Texture = renderTargetService.GetExistingRenderTarget(
+                IRenderableIpso cacheOwner = ResolveRenderTargetCacheOwner(
                     textureReferencer.RenderTargetTextureSource);
+                textureReferencer.Texture = renderTargetService.GetExistingRenderTarget(cacheOwner);
             }
 
             if (renderable.Visible && renderable.Children != null)
@@ -752,6 +774,16 @@ public class Renderer : IRenderer
                 PreRenderWithSourceRenderTargets(renderable.Children);
             }
         }
+    }
+
+    private static IRenderableIpso ResolveRenderTargetCacheOwner(IRenderableIpso source)
+    {
+        if (source is GraphicalUiElement gue && gue.RenderableComponent is IRenderableIpso contained)
+        {
+            return contained;
+        }
+
+        return source;
     }
 
     GumBatch gumBatch;

--- a/RenderingLibrary/SystemManagers.cs
+++ b/RenderingLibrary/SystemManagers.cs
@@ -378,6 +378,12 @@ public partial class SystemManagers : ISystemManagers
         Renderer.EndFrame();
     }
 
+    /// <inheritdoc cref="Renderer.PreRenderLayers"/>
+    public void PreRenderLayers(IReadOnlyList<Layer> layers)
+    {
+        Renderer.PreRenderLayers(layers);
+    }
+
     public void Draw()
     {
         Renderer.Draw(this);

--- a/Tests/MonoGameGum.IntegrationTests/MonoGameGum/Rendering/CrossLayerRenderTargetTextureSourceTests.cs
+++ b/Tests/MonoGameGum.IntegrationTests/MonoGameGum/Rendering/CrossLayerRenderTargetTextureSourceTests.cs
@@ -1,0 +1,273 @@
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using Gum.GueDeriving;
+using RenderingLibrary;
+using RenderingLibrary.Content;
+using RenderingLibrary.Graphics;
+using Shouldly;
+using Xunit;
+
+namespace MonoGameGum.IntegrationTests.MonoGameGum.Rendering;
+
+/// <summary>
+/// Proves per-layer <see cref="Renderer.Draw(SystemManagers, Layer)"/> bakes render targets on
+/// other layers before compositing a sprite that references them via
+/// <see cref="SpriteRuntime.RenderTargetTextureSource"/> (issue #3417).
+/// </summary>
+public class CrossLayerRenderTargetTextureSourceTests : BaseTestClass
+{
+    [Fact]
+    public void SameLayerDraw_ShouldShowRenderTargetTextureSourceOnSprite()
+    {
+        using MinimalGame game = new();
+        game.RunOneFrame();
+
+        GraphicsDevice gd = game.GraphicsDevice;
+        SystemManagers managers = SystemManagers.Default;
+        Renderer renderer = managers.Renderer;
+
+        ContainerRuntime container = CreateRedRenderTargetContainer();
+        container.AddToManagers(managers, null);
+        container.UpdateLayout();
+
+        IRenderableIpso cacheOwner = (IRenderableIpso)container.RenderableComponent;
+        renderer.Draw(managers);
+        renderer.HasCachedRenderTarget(cacheOwner).ShouldBeTrue();
+
+        SpriteRuntime sprite = new();
+        sprite.X = 0;
+        sprite.Y = 0;
+        sprite.Width = 64;
+        sprite.Height = 64;
+        sprite.RenderTargetTextureSource = container;
+        sprite.AddToManagers(managers, null);
+        sprite.UpdateLayout();
+
+        AdvanceHostFrame(managers, ref _hostTime);
+
+        Color sampled = RenderLayersToCapture(
+            gd, renderer, managers, new List<Layer> { renderer.MainLayer });
+
+        sampled.R.ShouldBeGreaterThan((byte)150);
+        ((int)sampled.R - sampled.G).ShouldBeGreaterThan(80);
+    }
+
+    [Fact]
+    public void MultiLayerListDraw_ShouldShowCrossLayerRenderTargetReference()
+    {
+        using MinimalGame game = new();
+        game.RunOneFrame();
+
+        GraphicsDevice gd = game.GraphicsDevice;
+        SystemManagers managers = SystemManagers.Default;
+        Renderer renderer = managers.Renderer;
+
+        Layer sourceLayer = renderer.MainLayer;
+        Layer consumerLayer = renderer.AddLayer();
+
+        ContainerRuntime container = CreateRedRenderTargetContainer();
+        container.AddToManagers(managers, sourceLayer);
+        container.UpdateLayout();
+
+        SpriteRuntime sprite = new();
+        sprite.X = 0;
+        sprite.Y = 0;
+        sprite.Width = 64;
+        sprite.Height = 64;
+        sprite.RenderTargetTextureSource = container;
+        sprite.AddToManagers(managers, consumerLayer);
+        sprite.UpdateLayout();
+
+        AdvanceHostFrame(managers, ref _hostTime);
+
+        Color sampled = RenderLayersToCapture(
+            gd, renderer, managers, new List<Layer> { sourceLayer, consumerLayer });
+
+        sampled.R.ShouldBeGreaterThan((byte)150);
+        ((int)sampled.R - sampled.G).ShouldBeGreaterThan(80);
+    }
+
+    [Fact]
+    public void SingleLayerDraw_ShouldShowSourceLayerRenderTarget_WhenDrawnBeforeConsumerLayer()
+    {
+        using MinimalGame game = new();
+        game.RunOneFrame();
+
+        GraphicsDevice gd = game.GraphicsDevice;
+        SystemManagers managers = SystemManagers.Default;
+        Renderer renderer = managers.Renderer;
+
+        Layer sourceLayer = renderer.MainLayer;
+        Layer consumerLayer = renderer.AddLayer();
+
+        ContainerRuntime container = CreateRedRenderTargetContainer();
+        container.AddToManagers(managers, sourceLayer);
+        container.UpdateLayout();
+
+        SpriteRuntime sprite = new();
+        sprite.X = 0;
+        sprite.Y = 0;
+        sprite.Width = 64;
+        sprite.Height = 64;
+        sprite.RenderTargetTextureSource = container;
+        sprite.AddToManagers(managers, consumerLayer);
+        sprite.UpdateLayout();
+
+        AdvanceHostFrame(managers, ref _hostTime);
+
+        Color sampled = RenderLayerToCapture(gd, renderer, managers, sourceLayer, consumerLayer);
+
+        sampled.R.ShouldBeGreaterThan((byte)150);
+        ((int)sampled.R - sampled.G).ShouldBeGreaterThan(80);
+    }
+
+    [Fact]
+    public void SingleLayerDraw_ShouldShowSourceLayerRenderTarget_WhenConsumerLayerDrawnFirst()
+    {
+        using MinimalGame game = new();
+        game.RunOneFrame();
+
+        GraphicsDevice gd = game.GraphicsDevice;
+        SystemManagers managers = SystemManagers.Default;
+        Renderer renderer = managers.Renderer;
+
+        Layer sourceLayer = renderer.MainLayer;
+        Layer consumerLayer = renderer.AddLayer();
+
+        ContainerRuntime container = CreateRedRenderTargetContainer();
+        container.AddToManagers(managers, sourceLayer);
+        container.UpdateLayout();
+
+        SpriteRuntime sprite = new();
+        sprite.X = 0;
+        sprite.Y = 0;
+        sprite.Width = 64;
+        sprite.Height = 64;
+        sprite.RenderTargetTextureSource = container;
+        sprite.AddToManagers(managers, consumerLayer);
+        sprite.UpdateLayout();
+
+        AdvanceHostFrame(managers, ref _hostTime);
+
+        Color sampled = RenderLayerToCapture(gd, renderer, managers, consumerLayer, sourceLayer);
+
+        sampled.R.ShouldBeGreaterThan((byte)150);
+        ((int)sampled.R - sampled.G).ShouldBeGreaterThan(80);
+    }
+
+    private static double _hostTime;
+
+    private static void AdvanceHostFrame(SystemManagers managers, ref double hostTime)
+    {
+        hostTime += 1.0;
+        managers.Activity(hostTime);
+    }
+
+    private static ContainerRuntime CreateRedRenderTargetContainer()
+    {
+        ContainerRuntime container = new();
+        container.X = 0;
+        container.Y = 0;
+        container.Width = 64;
+        container.Height = 64;
+        container.IsRenderTarget = true;
+
+#pragma warning disable CS0618
+        ColoredRectangleRuntime red = new();
+#pragma warning restore CS0618
+        red.Width = 64;
+        red.Height = 64;
+        red.Color = Color.Red;
+        container.AddChild(red);
+
+        return container;
+    }
+
+    private static Color RenderLayersToCapture(
+        GraphicsDevice gd,
+        Renderer renderer,
+        SystemManagers managers,
+        List<Layer> layers)
+    {
+        const int w = 128;
+        const int h = 128;
+        using RenderTarget2D capture = new(gd, w, h, false, SurfaceFormat.Color, DepthFormat.None, 0,
+            RenderTargetUsage.PreserveContents);
+
+        gd.SetRenderTarget(capture);
+        gd.Clear(Color.Black);
+        for (int i = 0; i < 2; i++)
+        {
+            renderer.Draw(managers, layers);
+        }
+        gd.SetRenderTarget(null);
+
+        Color[] data = new Color[w * h];
+        capture.GetData(data);
+
+        return data[(20 * w) + 20];
+    }
+
+    private static Color RenderLayerToCapture(
+        GraphicsDevice gd,
+        Renderer renderer,
+        SystemManagers managers,
+        params Layer[] drawOrder)
+    {
+        const int w = 128;
+        const int h = 128;
+        using RenderTarget2D capture = new(gd, w, h, false, SurfaceFormat.Color, DepthFormat.None, 0,
+            RenderTargetUsage.PreserveContents);
+
+        gd.SetRenderTarget(capture);
+        gd.Clear(Color.Black);
+
+        for (int i = 0; i < 2; i++)
+        {
+            for (int j = 0; j < drawOrder.Length; j++)
+            {
+                renderer.Draw(managers, drawOrder[j]);
+            }
+        }
+
+        gd.SetRenderTarget(null);
+
+        Color[] data = new Color[w * h];
+        capture.GetData(data);
+
+        return data[(20 * w) + 20];
+    }
+
+    private class MinimalGame : Game
+    {
+        private readonly GraphicsDeviceManager _graphics;
+        public GumService GumService { get; }
+
+        public MinimalGame()
+        {
+            LoaderManager.Self?.DisposeAndClear();
+            _graphics = new GraphicsDeviceManager(this);
+            GumService = new GumService();
+            _hostTime = 0;
+        }
+
+        protected override void Initialize()
+        {
+            base.Initialize();
+            GumService.Initialize(this, Gum.Forms.DefaultVisualsVersion.V2);
+        }
+
+        protected override void Update(GameTime gameTime) { }
+        protected override void Draw(GameTime gameTime) => GraphicsDevice.Clear(Color.CornflowerBlue);
+
+        protected override void Dispose(bool disposing)
+        {
+            if (GumService.IsInitialized)
+            {
+                GumService.Uninitialize();
+            }
+            LoaderManager.Self?.DisposeAndClear();
+            base.Dispose(disposing);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Pre-render all layers once per host frame on the first \Draw(Layer)\ call so RT containers on other layers are baked before compositing.
- Keep per-draw \PreRender\ + \PreRenderWithSourceRenderTargets\ on the layer being drawn (layout hooks and texture rebind).
- Add \PreRenderLayers\ / \SystemManagers.PreRenderLayers\ for hosts that want bake+bind without compositing.
- Map GUE \RenderTargetTextureSource\ to \RenderableComponent\ for RT cache lookup.

Closes #3417

## Test plan
- [x] \CrossLayerRenderTargetTextureSourceTests\ (4 integration tests)
- [x] \RenderTargetSweepTests\ (no regressions from #3416)

Made with [Cursor](https://cursor.com)