### PR TITLE
Skip baking invisible render targets unless referenced

### DIFF
--- a/.claude/skills/gum-monogame-rendering/SKILL.md
+++ b/.claude/skills/gum-monogame-rendering/SKILL.md
@@ -33,7 +33,7 @@ Key contract difference: each `Renderer.Draw` is one top-level renderable. If a 
 The layered path runs a recursive `PreRender` pass on `layer.Renderables` **before** `BeginSpriteBatch`. That pass does two jobs:
 
 1. Calls `renderable.PreRender()` on every visible renderable, depth-first. This is the hook `RenderableShapeBase.PreRender` uses to invoke `OnPreRender`, which is wired by `AposShapeRuntime.SetContainedShape` to call `AposShapeRuntime.PreRender`. That's where runtime-only properties (notably `StrokeWidth` with its unit handling) get pushed onto the contained renderable. Without this walk, the renderable keeps its own default values (e.g. `RenderableShapeBase._strokeWidth = 2`) regardless of what the runtime was assigned.
-2. For any renderable with `IsRenderTarget == true`, calls `RenderToRenderTarget` — which sets a render target on the GraphicsDevice and runs its own SpriteBatch cycle inside.
+2. For any renderable with `IsRenderTarget == true`, calls `RenderToRenderTarget` — which sets a render target on the GraphicsDevice and runs its own SpriteBatch cycle inside. **Invisible** render targets (`Visible == false`) skip this bake unless a visible `IRenderTargetTextureReferencer` on any layer references them via `RenderTargetTextureSource` (#1643) — the reference set is collected once per host frame across all layers before the bake pass runs.
 
 Phase 2 is why the full PreRender walk **must** run before `BeginSpriteBatch` — once the outer SpriteBatch is begun, you can't safely change the render target or start a nested cycle.
 

--- a/RenderingLibrary/Graphics/Renderer.cs
+++ b/RenderingLibrary/Graphics/Renderer.cs
@@ -85,6 +85,8 @@ public class Renderer : IRenderer
     private RenderTargetService renderTargetService;
     private bool _renderTargetSweepCompletedForHostFrame;
     private bool _allLayersPreRenderedForHostFrame;
+    private bool _referencedRenderTargetsCollectedForHostFrame;
+    private readonly HashSet<IRenderableIpso> _referencedRenderTargetOwners = new();
     Camera mCamera;
 
     Texture2D mSinglePixelTexture;
@@ -430,6 +432,7 @@ public class Renderer : IRenderer
         {
             _renderTargetSweepCompletedForHostFrame = false;
             _allLayersPreRenderedForHostFrame = false;
+            _referencedRenderTargetsCollectedForHostFrame = false;
         }
     }
 
@@ -439,6 +442,7 @@ public class Renderer : IRenderer
         {
             _renderTargetSweepCompletedForHostFrame = false;
             _allLayersPreRenderedForHostFrame = false;
+            _referencedRenderTargetsCollectedForHostFrame = false;
         }
     }
 
@@ -482,6 +486,8 @@ public class Renderer : IRenderer
 
     private void PreRenderLayersCore(IReadOnlyList<Layer> layers)
     {
+        EnsureReferencedRenderTargetsCollected();
+
         for (int i = 0; i < layers.Count; i++)
         {
             SetFilteringForLayer(layers[i]);
@@ -725,28 +731,81 @@ public class Renderer : IRenderer
             return;
         }
 
+        EnsureReferencedRenderTargetsCollected();
+
         for (int i = 0; i < count; i++)
         {
             var renderable = renderables[i];
-            if(renderable.Visible || 
-                // If it's a render target, then we want to render it fully:
-                renderable.IsRenderTarget)
+            bool shouldBakeRenderTarget = ShouldRenderToRenderTarget(renderable);
+            if (renderable.Visible || shouldBakeRenderTarget)
             {
 
                 renderable.PreRender();
 
                 // Some Gum objects, like GraphicalUiElements, may not have children if the object hasn't
                 // yet been assigned a visual. Just skip over it...
-                if((renderable.Visible || renderable.IsRenderTarget) && renderable.Children != null)
+                if ((renderable.Visible || shouldBakeRenderTarget) && renderable.Children != null)
                 {
                     PreRender(renderable.Children);
                 }
-                if(renderable.IsRenderTarget)
+                if (shouldBakeRenderTarget)
                 {
                     RenderToRenderTarget(renderable, SystemManagers.Default);
                 }
             }
         }
+    }
+
+    private void EnsureReferencedRenderTargetsCollected()
+    {
+        if (_referencedRenderTargetsCollectedForHostFrame)
+        {
+            return;
+        }
+
+        _referencedRenderTargetOwners.Clear();
+        for (int i = 0; i < _layers.Count; i++)
+        {
+            CollectReferencedRenderTargets(_layers[i].Renderables);
+        }
+
+        _referencedRenderTargetsCollectedForHostFrame = true;
+    }
+
+    private void CollectReferencedRenderTargets(IList<IRenderableIpso> renderables)
+    {
+        int count = renderables.Count;
+        for (int i = 0; i < count; i++)
+        {
+            IRenderableIpso renderable = renderables[i];
+            if (renderable.Visible && renderable is IRenderTargetTextureReferencer textureReferencer &&
+                textureReferencer.RenderTargetTextureSource != null)
+            {
+                _referencedRenderTargetOwners.Add(
+                    ResolveRenderTargetCacheOwner(textureReferencer.RenderTargetTextureSource));
+            }
+
+            if (renderable.Visible && renderable.Children != null)
+            {
+                CollectReferencedRenderTargets(renderable.Children);
+            }
+        }
+    }
+
+    private bool ShouldRenderToRenderTarget(IRenderableIpso renderable)
+    {
+        if (!renderable.IsRenderTarget)
+        {
+            return false;
+        }
+
+        if (renderable.Visible)
+        {
+            return true;
+        }
+
+        EnsureReferencedRenderTargetsCollected();
+        return _referencedRenderTargetOwners.Contains(ResolveRenderTargetCacheOwner(renderable));
     }
 
     private void PreRenderWithSourceRenderTargets(IList<IRenderableIpso> renderables)

--- a/Tests/MonoGameGum.IntegrationTests/MonoGameGum/Rendering/InvisibleRenderTargetOptimizationTests.cs
+++ b/Tests/MonoGameGum.IntegrationTests/MonoGameGum/Rendering/InvisibleRenderTargetOptimizationTests.cs
@@ -1,0 +1,177 @@
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using Gum.GueDeriving;
+using RenderingLibrary;
+using RenderingLibrary.Content;
+using RenderingLibrary.Graphics;
+using Shouldly;
+using Xunit;
+
+namespace MonoGameGum.IntegrationTests.MonoGameGum.Rendering;
+
+/// <summary>
+/// Proves invisible <see cref="ContainerRuntime.IsRenderTarget"/> containers skip the bake pass
+/// unless a visible <see cref="IRenderTargetTextureReferencer"/> references them (issue #1643).
+/// </summary>
+public class InvisibleRenderTargetOptimizationTests : BaseTestClass
+{
+    [Fact]
+    public void InvisibleUnreferencedRenderTarget_ShouldNotBake()
+    {
+        using MinimalGame game = new();
+        game.RunOneFrame();
+
+        SystemManagers managers = SystemManagers.Default;
+        Renderer renderer = managers.Renderer;
+
+        ContainerRuntime container = CreateRedRenderTargetContainer();
+        container.Visible = false;
+        container.AddToManagers(managers, null);
+        container.UpdateLayout();
+
+        IRenderableIpso cacheOwner = (IRenderableIpso)container.RenderableComponent;
+
+        AdvanceHostFrame(managers, ref _hostTime);
+        renderer.Draw(managers);
+
+        renderer.HasCachedRenderTarget(cacheOwner).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void InvisibleReferencedRenderTarget_ShouldBake()
+    {
+        using MinimalGame game = new();
+        game.RunOneFrame();
+
+        GraphicsDevice gd = game.GraphicsDevice;
+        SystemManagers managers = SystemManagers.Default;
+        Renderer renderer = managers.Renderer;
+
+        ContainerRuntime container = CreateRedRenderTargetContainer();
+        container.Visible = false;
+        container.AddToManagers(managers, null);
+        container.UpdateLayout();
+
+        IRenderableIpso cacheOwner = (IRenderableIpso)container.RenderableComponent;
+
+        SpriteRuntime sprite = new();
+        sprite.X = 0;
+        sprite.Y = 0;
+        sprite.Width = 64;
+        sprite.Height = 64;
+        sprite.RenderTargetTextureSource = container;
+        sprite.AddToManagers(managers, null);
+        sprite.UpdateLayout();
+
+        AdvanceHostFrame(managers, ref _hostTime);
+        renderer.Draw(managers);
+
+        renderer.HasCachedRenderTarget(cacheOwner).ShouldBeTrue();
+
+        Color sampled = SampleMainLayerPixel(gd, renderer, managers);
+        sampled.R.ShouldBeGreaterThan((byte)150);
+        ((int)sampled.R - sampled.G).ShouldBeGreaterThan(80);
+    }
+
+    [Fact]
+    public void VisibleUnreferencedRenderTarget_ShouldStillBake()
+    {
+        using MinimalGame game = new();
+        game.RunOneFrame();
+
+        SystemManagers managers = SystemManagers.Default;
+        Renderer renderer = managers.Renderer;
+
+        ContainerRuntime container = CreateRedRenderTargetContainer();
+        container.AddToManagers(managers, null);
+        container.UpdateLayout();
+
+        IRenderableIpso cacheOwner = (IRenderableIpso)container.RenderableComponent;
+
+        AdvanceHostFrame(managers, ref _hostTime);
+        renderer.Draw(managers);
+
+        renderer.HasCachedRenderTarget(cacheOwner).ShouldBeTrue();
+    }
+
+    private static double _hostTime;
+
+    private static void AdvanceHostFrame(SystemManagers managers, ref double hostTime)
+    {
+        hostTime += 1.0;
+        managers.Activity(hostTime);
+    }
+
+    private static ContainerRuntime CreateRedRenderTargetContainer()
+    {
+        ContainerRuntime container = new();
+        container.X = 0;
+        container.Y = 0;
+        container.Width = 64;
+        container.Height = 64;
+        container.IsRenderTarget = true;
+
+#pragma warning disable CS0618
+        ColoredRectangleRuntime red = new();
+#pragma warning restore CS0618
+        red.Width = 64;
+        red.Height = 64;
+        red.Color = Color.Red;
+        container.AddChild(red);
+
+        return container;
+    }
+
+    private static Color SampleMainLayerPixel(GraphicsDevice gd, Renderer renderer, SystemManagers managers)
+    {
+        const int w = 128;
+        const int h = 128;
+        using RenderTarget2D capture = new(gd, w, h, false, SurfaceFormat.Color, DepthFormat.None, 0,
+            RenderTargetUsage.PreserveContents);
+
+        gd.SetRenderTarget(capture);
+        gd.Clear(Color.Black);
+        renderer.Draw(managers);
+        gd.SetRenderTarget(null);
+
+        Color[] pixels = new Color[w * h];
+        capture.GetData(pixels);
+        return pixels[32 * w + 32];
+    }
+
+    /// <summary>
+    /// Minimal Game host that initializes a fresh <see cref="GumService"/> per test so
+    /// <see cref="Renderer.Draw(SystemManagers)"/> can be invoked against a live device.
+    /// </summary>
+    private class MinimalGame : Game
+    {
+        private readonly GraphicsDeviceManager _graphics;
+        public GumService GumService { get; }
+
+        public MinimalGame()
+        {
+            LoaderManager.Self?.DisposeAndClear();
+            _graphics = new GraphicsDeviceManager(this);
+            GumService = new GumService();
+        }
+
+        protected override void Initialize()
+        {
+            base.Initialize();
+            GumService.Initialize(this, Gum.Forms.DefaultVisualsVersion.V2);
+        }
+
+        protected override void Update(GameTime gameTime) { }
+        protected override void Draw(GameTime gameTime) => GraphicsDevice.Clear(Color.CornflowerBlue);
+
+        protected override void Dispose(bool disposing)
+        {
+            if (GumService.IsInitialized)
+            {
+                GumService.Uninitialize();
+            }
+            LoaderManager.Self?.DisposeAndClear();
+            base.Dispose(disposing);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Skip the `RenderToRenderTarget` bake for invisible `IsRenderTarget` containers unless a visible `IRenderTargetTextureReferencer` on any layer references them via `RenderTargetTextureSource`.
- Collect referenced render-target owners once per host frame (reset on `EndFrame` / `NotifyHostFrameAdvanced`) using the existing `ResolveRenderTargetCacheOwner` helper.
- Add integration tests and document the behavior in `gum-monogame-rendering`.

Closes #1643

## Test plan

- [x] `dotnet test Tests/MonoGameGum.IntegrationTests/MonoGameGum.IntegrationTests.csproj --filter FullyQualifiedName~InvisibleRenderTargetOptimizationTests` (3/3)
- [x] `dotnet test Tests/MonoGameGum.IntegrationTests/MonoGameGum.IntegrationTests.csproj --filter FullyQualifiedName~RenderTarget` (24/24)
