### PR TITLE
Extract shared Gradient/Dropshadow state from Circle/RectangleRuntime

### DIFF
--- a/MonoGameGum/GueDeriving/CircleRuntime.cs
+++ b/MonoGameGum/GueDeriving/CircleRuntime.cs
@@ -72,6 +72,8 @@ public class CircleRuntime : GraphicalUiElement
 #if XNALIKE
     IFilledCircleRenderable? _fill;
     IStrokedCircleRenderable _stroke = null!;
+    ShapeGradientState _gradientState;
+    ShapeDropshadowState _dropshadowState;
 #else
     ContainedCircleType containedLineCircle = null!;
 
@@ -562,7 +564,7 @@ public class CircleRuntime : GraphicalUiElement
                 _fill.Color = _isFilled ? _fillColor : new Color(0, 0, 0, 0);
             }
             // Issue #3009 — the fill slot's gradient start mirrors FillColor (no standalone Color1).
-            SyncGradientStart();
+            _gradientState.PushGradientStart(_fillColor, _strokeColor, _fill as IGradientedRenderable, _stroke as IGradientedRenderable);
             NotifyPropertyChanged();
         }
     }
@@ -618,10 +620,10 @@ public class CircleRuntime : GraphicalUiElement
             // Dropshadow routing depends on IsFilled — re-push so the active slot owns the
             // shadow flag and the inactive slot releases it. Otherwise toggling IsFilled
             // either ghosts the previous target or never wakes the new one up.
-            SyncDropshadowToTarget();
+            _dropshadowState.SyncTarget(_fill as IDropshadowRenderable, _stroke as IDropshadowRenderable, _isFilled);
             // Gradient routing also depends on IsFilled: the gradient paints the active body
             // (fill when filled, stroke when stroke-only), so re-route on toggle.
-            SyncGradientToTarget();
+            _gradientState.PushGradientGate(_fill as IGradientedRenderable, _stroke as IGradientedRenderable, _isFilled);
             NotifyPropertyChanged();
         }
     }
@@ -642,7 +644,7 @@ public class CircleRuntime : GraphicalUiElement
             _strokeColor = value;
             _stroke.Color = value;
             // Issue #3009 — the stroke slot's gradient start mirrors StrokeColor (no standalone Color1).
-            SyncGradientStart();
+            _gradientState.PushGradientStart(_fillColor, _strokeColor, _fill as IGradientedRenderable, _stroke as IGradientedRenderable);
             NotifyPropertyChanged();
         }
     }
@@ -758,53 +760,16 @@ public class CircleRuntime : GraphicalUiElement
 
     #region Gradient
 
-    // Issue #2791: gradient pass-through. Backing fields live on the runtime so values
-    // round-trip even when neither slot implements IGradientedRenderable (e.g. core-only stroke
-    // = DefaultStrokedCircleRenderable, no fill). The coordinate/color setters push to whichever
-    // slot(s) implement it so the values round-trip on either; the UseGradient GATE routes to the
-    // active body slot (see SyncGradientToTarget). The gradient is the active body's paint — a
-    // gradient on the other slot would share the single gradient and composite invisibly, so the
-    // inactive slot renders solid.
+    // Issue #2791 (extracted into ShapeGradientState — issue "shape-gradient-dropshadow-dedup"
+    // — shared with RectangleRuntime): gradient pass-through. Backing fields live in
+    // _gradientState so values round-trip even when neither slot implements
+    // IGradientedRenderable (e.g. core-only stroke = DefaultStrokedCircleRenderable, no fill).
+    // The coordinate/color setters push to whichever slot(s) implement it so the values
+    // round-trip on either; the UseGradient GATE routes to the active body slot (see
+    // ShapeGradientState.PushGradientGate). The gradient is the active body's paint — a
+    // gradient on the other slot would share the single gradient and composite invisibly, so
+    // the inactive slot renders solid.
 
-    // Routes the gradient gate to the ACTIVE body slot — the fill when IsFilled, the stroke when
-    // stroke-only — and forces the inactive slot's gate off. Mirrors SyncDropshadowToTarget. Re-run
-    // from both the UseGradient and IsFilled setters so toggling IsFilled re-routes the gate.
-    void SyncGradientToTarget()
-    {
-        var fillGrad = _fill as IGradientedRenderable;
-        var strokeGrad = _stroke as IGradientedRenderable;
-        var active = _isFilled ? fillGrad : strokeGrad;
-        var inactive = _isFilled ? strokeGrad : fillGrad;
-        if (active != null) active.UseGradient = _useGradient;
-        if (inactive != null) inactive.UseGradient = false;
-    }
-
-    // Issue #3009 — the gradient START stop is the slot's own solid body color; Circle/Rectangle
-    // no longer carry a standalone Color1. Each slot mirrors its solid color into its
-    // Red1/Green1/Blue1/Alpha1 so the gradient start equals the color the shape was already
-    // showing (no jump when UseGradient toggles), and the dropshadow alpha — which the Apos
-    // renderable scales by the slot's Color.A — converges onto the gradient start alpha. Called
-    // from the FillColor / StrokeColor setters and the constructor; the UseGradient gate routing
-    // stays in SyncGradientToTarget.
-    void SyncGradientStart()
-    {
-        if (_fill is IGradientedRenderable fillGrad)
-        {
-            fillGrad.Red1 = _fillColor.R;
-            fillGrad.Green1 = _fillColor.G;
-            fillGrad.Blue1 = _fillColor.B;
-            fillGrad.Alpha1 = _fillColor.A;
-        }
-        if (_stroke is IGradientedRenderable strokeGrad)
-        {
-            strokeGrad.Red1 = _strokeColor.R;
-            strokeGrad.Green1 = _strokeColor.G;
-            strokeGrad.Blue1 = _strokeColor.B;
-            strokeGrad.Alpha1 = _strokeColor.A;
-        }
-    }
-
-    bool _useGradient;
     /// <summary>
     /// When <c>true</c>, the gradient color/coordinate properties drive rendering instead of
     /// <see cref="FillColor"/> / <see cref="StrokeColor"/>. Visual effect requires the optional
@@ -813,88 +778,72 @@ public class CircleRuntime : GraphicalUiElement
     /// </summary>
     public bool UseGradient
     {
-        get => _useGradient;
+        get => _gradientState.UseGradient;
         set
         {
-            _useGradient = value;
-            SyncGradientToTarget();
+            _gradientState.SetUseGradient(value, _fill as IGradientedRenderable, _stroke as IGradientedRenderable, _isFilled);
             NotifyPropertyChanged();
         }
     }
 
-    GradientType _gradientType;
     public GradientType GradientType
     {
-        get => _gradientType;
+        get => _gradientState.GradientType;
         set
         {
-            _gradientType = value;
-            if (_fill is IGradientedRenderable fillGrad) fillGrad.GradientType = value;
-            if (_stroke is IGradientedRenderable strokeGrad) strokeGrad.GradientType = value;
+            _gradientState.SetGradientType(value, _fill as IGradientedRenderable, _stroke as IGradientedRenderable);
             NotifyPropertyChanged();
         }
     }
 
     // Issue #3009 — the gradient start (Red1/Green1/Blue1/Alpha1 / Color1) is no longer stored on
-    // the runtime. It is driven from the active body color via SyncGradientStart(); the standalone
-    // Color1 surface was dropped for Circle/Rectangle (gradient support is unshipped, so no data to
-    // preserve). Color2 below remains the only standalone gradient color.
+    // the runtime. It is driven from the active body color via ShapeGradientState.PushGradientStart;
+    // the standalone Color1 surface was dropped for Circle/Rectangle (gradient support is
+    // unshipped, so no data to preserve). Color2 below remains the only standalone gradient color.
 
-    int _alpha2 = 255;
     public int Alpha2
     {
-        get => _alpha2;
+        get => _gradientState.Alpha2;
         set
         {
-            _alpha2 = value;
-            if (_fill is IGradientedRenderable fillGrad) fillGrad.Alpha2 = value;
-            if (_stroke is IGradientedRenderable strokeGrad) strokeGrad.Alpha2 = value;
+            _gradientState.SetAlpha2(value, _fill as IGradientedRenderable, _stroke as IGradientedRenderable);
             NotifyPropertyChanged();
         }
     }
 
-    int _red2;
     public int Red2
     {
-        get => _red2;
+        get => _gradientState.Red2;
         set
         {
-            _red2 = value;
-            if (_fill is IGradientedRenderable fillGrad) fillGrad.Red2 = value;
-            if (_stroke is IGradientedRenderable strokeGrad) strokeGrad.Red2 = value;
+            _gradientState.SetRed2(value, _fill as IGradientedRenderable, _stroke as IGradientedRenderable);
             NotifyPropertyChanged();
         }
     }
 
-    int _green2;
     public int Green2
     {
-        get => _green2;
+        get => _gradientState.Green2;
         set
         {
-            _green2 = value;
-            if (_fill is IGradientedRenderable fillGrad) fillGrad.Green2 = value;
-            if (_stroke is IGradientedRenderable strokeGrad) strokeGrad.Green2 = value;
+            _gradientState.SetGreen2(value, _fill as IGradientedRenderable, _stroke as IGradientedRenderable);
             NotifyPropertyChanged();
         }
     }
 
-    int _blue2;
     public int Blue2
     {
-        get => _blue2;
+        get => _gradientState.Blue2;
         set
         {
-            _blue2 = value;
-            if (_fill is IGradientedRenderable fillGrad) fillGrad.Blue2 = value;
-            if (_stroke is IGradientedRenderable strokeGrad) strokeGrad.Blue2 = value;
+            _gradientState.SetBlue2(value, _fill as IGradientedRenderable, _stroke as IGradientedRenderable);
             NotifyPropertyChanged();
         }
     }
 
     public Color Color2
     {
-        get => new Color(_red2, _green2, _blue2, _alpha2);
+        get => _gradientState.Color2;
         set
         {
             Red2 = value.R;
@@ -904,158 +853,122 @@ public class CircleRuntime : GraphicalUiElement
         }
     }
 
-    float _gradientX1;
     public float GradientX1
     {
-        get => _gradientX1;
+        get => _gradientState.GradientX1;
         set
         {
-            _gradientX1 = value;
-            if (_fill is IGradientedRenderable fillGrad) fillGrad.GradientX1 = value;
-            if (_stroke is IGradientedRenderable strokeGrad) strokeGrad.GradientX1 = value;
+            _gradientState.SetGradientX1(value, _fill as IGradientedRenderable, _stroke as IGradientedRenderable);
             NotifyPropertyChanged();
         }
     }
 
-    GeneralUnitType _gradientX1Units;
     public GeneralUnitType GradientX1Units
     {
-        get => _gradientX1Units;
+        get => _gradientState.GradientX1Units;
         set
         {
-            _gradientX1Units = value;
-            if (_fill is IGradientedRenderable fillGrad) fillGrad.GradientX1Units = value;
-            if (_stroke is IGradientedRenderable strokeGrad) strokeGrad.GradientX1Units = value;
+            _gradientState.SetGradientX1Units(value, _fill as IGradientedRenderable, _stroke as IGradientedRenderable);
             NotifyPropertyChanged();
         }
     }
 
-    float _gradientY1;
     public float GradientY1
     {
-        get => _gradientY1;
+        get => _gradientState.GradientY1;
         set
         {
-            _gradientY1 = value;
-            if (_fill is IGradientedRenderable fillGrad) fillGrad.GradientY1 = value;
-            if (_stroke is IGradientedRenderable strokeGrad) strokeGrad.GradientY1 = value;
+            _gradientState.SetGradientY1(value, _fill as IGradientedRenderable, _stroke as IGradientedRenderable);
             NotifyPropertyChanged();
         }
     }
 
-    GeneralUnitType _gradientY1Units;
     public GeneralUnitType GradientY1Units
     {
-        get => _gradientY1Units;
+        get => _gradientState.GradientY1Units;
         set
         {
-            _gradientY1Units = value;
-            if (_fill is IGradientedRenderable fillGrad) fillGrad.GradientY1Units = value;
-            if (_stroke is IGradientedRenderable strokeGrad) strokeGrad.GradientY1Units = value;
+            _gradientState.SetGradientY1Units(value, _fill as IGradientedRenderable, _stroke as IGradientedRenderable);
             NotifyPropertyChanged();
         }
     }
 
-    float _gradientX2;
     public float GradientX2
     {
-        get => _gradientX2;
+        get => _gradientState.GradientX2;
         set
         {
-            _gradientX2 = value;
-            if (_fill is IGradientedRenderable fillGrad) fillGrad.GradientX2 = value;
-            if (_stroke is IGradientedRenderable strokeGrad) strokeGrad.GradientX2 = value;
+            _gradientState.SetGradientX2(value, _fill as IGradientedRenderable, _stroke as IGradientedRenderable);
             NotifyPropertyChanged();
         }
     }
 
-    GeneralUnitType _gradientX2Units;
     public GeneralUnitType GradientX2Units
     {
-        get => _gradientX2Units;
+        get => _gradientState.GradientX2Units;
         set
         {
-            _gradientX2Units = value;
-            if (_fill is IGradientedRenderable fillGrad) fillGrad.GradientX2Units = value;
-            if (_stroke is IGradientedRenderable strokeGrad) strokeGrad.GradientX2Units = value;
+            _gradientState.SetGradientX2Units(value, _fill as IGradientedRenderable, _stroke as IGradientedRenderable);
             NotifyPropertyChanged();
         }
     }
 
-    float _gradientY2;
     public float GradientY2
     {
-        get => _gradientY2;
+        get => _gradientState.GradientY2;
         set
         {
-            _gradientY2 = value;
-            if (_fill is IGradientedRenderable fillGrad) fillGrad.GradientY2 = value;
-            if (_stroke is IGradientedRenderable strokeGrad) strokeGrad.GradientY2 = value;
+            _gradientState.SetGradientY2(value, _fill as IGradientedRenderable, _stroke as IGradientedRenderable);
             NotifyPropertyChanged();
         }
     }
 
-    GeneralUnitType _gradientY2Units;
     public GeneralUnitType GradientY2Units
     {
-        get => _gradientY2Units;
+        get => _gradientState.GradientY2Units;
         set
         {
-            _gradientY2Units = value;
-            if (_fill is IGradientedRenderable fillGrad) fillGrad.GradientY2Units = value;
-            if (_stroke is IGradientedRenderable strokeGrad) strokeGrad.GradientY2Units = value;
+            _gradientState.SetGradientY2Units(value, _fill as IGradientedRenderable, _stroke as IGradientedRenderable);
             NotifyPropertyChanged();
         }
     }
 
-    float _gradientInnerRadius;
     public float GradientInnerRadius
     {
-        get => _gradientInnerRadius;
+        get => _gradientState.GradientInnerRadius;
         set
         {
-            _gradientInnerRadius = value;
-            if (_fill is IGradientedRenderable fillGrad) fillGrad.GradientInnerRadius = value;
-            if (_stroke is IGradientedRenderable strokeGrad) strokeGrad.GradientInnerRadius = value;
+            _gradientState.SetGradientInnerRadius(value, _fill as IGradientedRenderable, _stroke as IGradientedRenderable);
             NotifyPropertyChanged();
         }
     }
 
-    DimensionUnitType _gradientInnerRadiusUnits;
     public DimensionUnitType GradientInnerRadiusUnits
     {
-        get => _gradientInnerRadiusUnits;
+        get => _gradientState.GradientInnerRadiusUnits;
         set
         {
-            _gradientInnerRadiusUnits = value;
-            if (_fill is IGradientedRenderable fillGrad) fillGrad.GradientInnerRadiusUnits = value;
-            if (_stroke is IGradientedRenderable strokeGrad) strokeGrad.GradientInnerRadiusUnits = value;
+            _gradientState.SetGradientInnerRadiusUnits(value, _fill as IGradientedRenderable, _stroke as IGradientedRenderable);
             NotifyPropertyChanged();
         }
     }
 
-    float _gradientOuterRadius;
     public float GradientOuterRadius
     {
-        get => _gradientOuterRadius;
+        get => _gradientState.GradientOuterRadius;
         set
         {
-            _gradientOuterRadius = value;
-            if (_fill is IGradientedRenderable fillGrad) fillGrad.GradientOuterRadius = value;
-            if (_stroke is IGradientedRenderable strokeGrad) strokeGrad.GradientOuterRadius = value;
+            _gradientState.SetGradientOuterRadius(value, _fill as IGradientedRenderable, _stroke as IGradientedRenderable);
             NotifyPropertyChanged();
         }
     }
 
-    DimensionUnitType _gradientOuterRadiusUnits;
     public DimensionUnitType GradientOuterRadiusUnits
     {
-        get => _gradientOuterRadiusUnits;
+        get => _gradientState.GradientOuterRadiusUnits;
         set
         {
-            _gradientOuterRadiusUnits = value;
-            if (_fill is IGradientedRenderable fillGrad) fillGrad.GradientOuterRadiusUnits = value;
-            if (_stroke is IGradientedRenderable strokeGrad) strokeGrad.GradientOuterRadiusUnits = value;
+            _gradientState.SetGradientOuterRadiusUnits(value, _fill as IGradientedRenderable, _stroke as IGradientedRenderable);
             NotifyPropertyChanged();
         }
     }
@@ -1064,48 +977,16 @@ public class CircleRuntime : GraphicalUiElement
 
     #region Dropshadow
 
-    // Issue #2797: dropshadow pass-through. Backing fields live on the runtime so values
-    // round-trip even when neither slot implements IDropshadowRenderable (core-only stroke
-    // = DefaultStrokedCircleRenderable, no fill). Unlike gradient (#2791) and AA (#2798),
-    // which push to BOTH slots so a single setter covers fill and stroke, the shadow is
-    // drawn once per renderable — pushing to both would render the shadow twice and
-    // visibly double up. So the routing picks one slot: the fill when IsFilled = true (the
-    // disc casts the shadow), the stroke when IsFilled = false (the disc is gated to
-    // transparent and can't cast a visible shadow). The push-target helper is shared across
-    // every setter so the rule lives in one place. SyncDropshadowToTarget below re-routes
-    // shadow state when IsFilled toggles — without that the previous target keeps its
-    // HasDropshadow flag set and the new target never receives it.
+    // Issue #2797 (extracted into ShapeDropshadowState — shared with RectangleRuntime):
+    // dropshadow pass-through. Backing fields live in _dropshadowState so values round-trip
+    // even when neither slot implements IDropshadowRenderable (core-only stroke =
+    // DefaultStrokedCircleRenderable, no fill). Unlike gradient (#2791) and AA (#2798), which
+    // push to BOTH slots so a single setter covers fill and stroke, the shadow is drawn once
+    // per renderable — pushing to both would render the shadow twice and visibly double up. So
+    // the routing picks one slot: the fill when IsFilled = true (the disc casts the shadow),
+    // the stroke when IsFilled = false (the disc is gated to transparent and can't cast a
+    // visible shadow). See ShapeDropshadowState.GetTarget / SyncTarget for the shared rule.
 
-    IDropshadowRenderable? DropshadowTarget
-    {
-        get
-        {
-            var fillDs = _fill as IDropshadowRenderable;
-            var strokeDs = _stroke as IDropshadowRenderable;
-            return _isFilled ? (fillDs ?? strokeDs) : (strokeDs ?? fillDs);
-        }
-    }
-
-    void SyncDropshadowToTarget()
-    {
-        var fillDs = _fill as IDropshadowRenderable;
-        var strokeDs = _stroke as IDropshadowRenderable;
-        var target = DropshadowTarget;
-        var other = ReferenceEquals(target, fillDs) ? strokeDs : fillDs;
-
-        if (other != null) other.HasDropshadow = false;
-        if (target != null)
-        {
-            target.HasDropshadow = _hasDropshadow;
-            target.DropshadowColor = _dropshadowColor;
-            target.DropshadowOffsetX = _dropshadowOffsetX;
-            target.DropshadowOffsetY = _dropshadowOffsetY;
-            target.DropshadowBlurX = _dropshadowBlur;
-            target.DropshadowBlurY = _dropshadowBlur;
-        }
-    }
-
-    bool _hasDropshadow;
     /// <summary>
     /// When <c>true</c>, the dropshadow color/offset/blur properties drive an extra render
     /// pass behind the circle. Visual effect requires the optional MonoGameGumShapes
@@ -1113,88 +994,80 @@ public class CircleRuntime : GraphicalUiElement
     /// </summary>
     public bool HasDropshadow
     {
-        get => _hasDropshadow;
+        get => _dropshadowState.HasDropshadow;
         set
         {
-            _hasDropshadow = value;
-            if (DropshadowTarget is { } target) target.HasDropshadow = value;
+            _dropshadowState.SetHasDropshadow(value, _fill as IDropshadowRenderable, _stroke as IDropshadowRenderable, _isFilled);
             NotifyPropertyChanged();
         }
     }
 
-    Color _dropshadowColor;
     public Color DropshadowColor
     {
-        get => _dropshadowColor;
+        get => _dropshadowState.DropshadowColor;
         set
         {
-            _dropshadowColor = value;
-            if (DropshadowTarget is { } target) target.DropshadowColor = value;
+            _dropshadowState.SetDropshadowColor(value, _fill as IDropshadowRenderable, _stroke as IDropshadowRenderable, _isFilled);
             NotifyPropertyChanged();
         }
     }
 
     public int DropshadowAlpha
     {
-        get => _dropshadowColor.A;
+        get => _dropshadowState.DropshadowColor.A;
         set
         {
-            DropshadowColor = new Color(_dropshadowColor.R, _dropshadowColor.G, _dropshadowColor.B, (byte)value);
+            DropshadowColor = new Color(_dropshadowState.DropshadowColor.R, _dropshadowState.DropshadowColor.G, _dropshadowState.DropshadowColor.B, (byte)value);
         }
     }
 
     public int DropshadowRed
     {
-        get => _dropshadowColor.R;
+        get => _dropshadowState.DropshadowColor.R;
         set
         {
-            DropshadowColor = new Color((byte)value, _dropshadowColor.G, _dropshadowColor.B, _dropshadowColor.A);
+            DropshadowColor = new Color((byte)value, _dropshadowState.DropshadowColor.G, _dropshadowState.DropshadowColor.B, _dropshadowState.DropshadowColor.A);
         }
     }
 
     public int DropshadowGreen
     {
-        get => _dropshadowColor.G;
+        get => _dropshadowState.DropshadowColor.G;
         set
         {
-            DropshadowColor = new Color(_dropshadowColor.R, (byte)value, _dropshadowColor.B, _dropshadowColor.A);
+            DropshadowColor = new Color(_dropshadowState.DropshadowColor.R, (byte)value, _dropshadowState.DropshadowColor.B, _dropshadowState.DropshadowColor.A);
         }
     }
 
     public int DropshadowBlue
     {
-        get => _dropshadowColor.B;
+        get => _dropshadowState.DropshadowColor.B;
         set
         {
-            DropshadowColor = new Color(_dropshadowColor.R, _dropshadowColor.G, (byte)value, _dropshadowColor.A);
+            DropshadowColor = new Color(_dropshadowState.DropshadowColor.R, _dropshadowState.DropshadowColor.G, (byte)value, _dropshadowState.DropshadowColor.A);
         }
     }
 
-    float _dropshadowOffsetX;
     public float DropshadowOffsetX
     {
-        get => _dropshadowOffsetX;
+        get => _dropshadowState.DropshadowOffsetX;
         set
         {
-            _dropshadowOffsetX = value;
-            if (DropshadowTarget is { } target) target.DropshadowOffsetX = value;
+            _dropshadowState.SetDropshadowOffsetX(value, _fill as IDropshadowRenderable, _stroke as IDropshadowRenderable, _isFilled);
             NotifyPropertyChanged();
         }
     }
 
-    float _dropshadowOffsetY;
     public float DropshadowOffsetY
     {
-        get => _dropshadowOffsetY;
+        get => _dropshadowState.DropshadowOffsetY;
         set
         {
-            _dropshadowOffsetY = value;
-            if (DropshadowTarget is { } target) target.DropshadowOffsetY = value;
+            _dropshadowState.SetDropshadowOffsetY(value, _fill as IDropshadowRenderable, _stroke as IDropshadowRenderable, _isFilled);
             NotifyPropertyChanged();
         }
     }
 
-    float _dropshadowBlur;
     /// <summary>
     /// Isotropic blur radius in pixels for the dropshadow. Pushes a single value to both
     /// the underlying renderable's X and Y blur fields — Apos.Shapes approximates the
@@ -1204,15 +1077,10 @@ public class CircleRuntime : GraphicalUiElement
     /// </summary>
     public float DropshadowBlur
     {
-        get => _dropshadowBlur;
+        get => _dropshadowState.DropshadowBlur;
         set
         {
-            _dropshadowBlur = value;
-            if (DropshadowTarget is { } target)
-            {
-                target.DropshadowBlurX = value;
-                target.DropshadowBlurY = value;
-            }
+            _dropshadowState.SetDropshadowBlur(value, _fill as IDropshadowRenderable, _stroke as IDropshadowRenderable, _isFilled);
             NotifyPropertyChanged();
         }
     }
@@ -1460,6 +1328,13 @@ public class CircleRuntime : GraphicalUiElement
         toReturn.IsFilled = toReturn.IsFilled;
         // Issue #2937 — re-fire Blend onto the freshly-built slots for the same reason.
         toReturn.Blend = toReturn.Blend;
+        // Boyscout fix (shape-gradient-dropshadow-dedup) — push the Gradient/Dropshadow state
+        // onto the freshly-built slots too. Previously neither region re-fired here: the
+        // backing fields survived via MemberwiseClone but the clone's new slots never received
+        // them, so a clone with UseGradient/HasDropshadow = true silently rendered without its
+        // gradient/shadow until some other property write happened to re-trigger it.
+        toReturn._gradientState.PushAll(toReturn._fill as IGradientedRenderable, toReturn._stroke as IGradientedRenderable, toReturn._isFilled, toReturn._fillColor, toReturn._strokeColor);
+        toReturn._dropshadowState.PushAll(toReturn._fill as IDropshadowRenderable, toReturn._stroke as IDropshadowRenderable, toReturn._isFilled);
         if (toReturn._fill != null)
         {
             toReturn._stroke.Radius = toReturn._fill.Radius;
@@ -1912,7 +1787,7 @@ public class CircleRuntime : GraphicalUiElement
             // Issue #3009 — seed each slot's gradient start from its (white) body color so flipping
             // UseGradient on a freshly-constructed circle starts from white rather than a stale
             // default, matching the no-jump contract.
-            SyncGradientStart();
+            _gradientState.PushGradientStart(_fillColor, _strokeColor, _fill as IGradientedRenderable, _stroke as IGradientedRenderable);
 
             // Dropshadow defaults mirror SkiaShapeRuntime: opaque black, slight downward
             // offset, slight Y blur. HasDropshadow is false so the values are inert until

--- a/MonoGameGum/GueDeriving/RectangleRuntime.cs
+++ b/MonoGameGum/GueDeriving/RectangleRuntime.cs
@@ -65,6 +65,8 @@ public class RectangleRuntime : GraphicalUiElement
 #if XNALIKE
     IFilledRectangleRenderable? _fill;
     IStrokedRectangleRenderable _stroke = null!;
+    ShapeGradientState _gradientState;
+    ShapeDropshadowState _dropshadowState;
 #else
     ContainedLineRectangle containedLineRectangle = null!;
     ContainedLineRectangle ContainedLineRectangle
@@ -886,7 +888,7 @@ public class RectangleRuntime : GraphicalUiElement
                 _fill.Color = _isFilled ? _fillColor : new Color(0, 0, 0, 0);
             }
             // Issue #3009 — the fill slot's gradient start mirrors FillColor (no standalone Color1).
-            SyncGradientStart();
+            _gradientState.PushGradientStart(_fillColor, _strokeColor, _fill as IGradientedRenderable, _stroke as IGradientedRenderable);
             NotifyPropertyChanged();
         }
     }
@@ -940,10 +942,10 @@ public class RectangleRuntime : GraphicalUiElement
                 _fill.Color = _isFilled ? _fillColor : new Color(0, 0, 0, 0);
             }
             // Dropshadow routing depends on IsFilled — see CircleRuntime for the rationale.
-            SyncDropshadowToTarget();
+            _dropshadowState.SyncTarget(_fill as IDropshadowRenderable, _stroke as IDropshadowRenderable, _isFilled);
             // Gradient routing also depends on IsFilled: the gradient paints the active body
             // (fill when filled, stroke when stroke-only), so re-route on toggle.
-            SyncGradientToTarget();
+            _gradientState.PushGradientGate(_fill as IGradientedRenderable, _stroke as IGradientedRenderable, _isFilled);
             NotifyPropertyChanged();
         }
     }
@@ -964,7 +966,7 @@ public class RectangleRuntime : GraphicalUiElement
             _strokeColor = value;
             _stroke.Color = value;
             // Issue #3009 — the stroke slot's gradient start mirrors StrokeColor (no standalone Color1).
-            SyncGradientStart();
+            _gradientState.PushGradientStart(_fillColor, _strokeColor, _fill as IGradientedRenderable, _stroke as IGradientedRenderable);
             NotifyPropertyChanged();
         }
     }
@@ -1150,136 +1152,82 @@ public class RectangleRuntime : GraphicalUiElement
 
     #region Gradient
 
-    // Issue #2818 (mirror of CircleRuntime gradient region #2791): backing fields round-trip
-    // even when neither slot implements IGradientedRenderable (core defaults wrap SolidRectangle
-    // / LineRectangle, no gradient concept). Setters push to whichever slot(s) implement it.
+    // Issue #2818 (extracted into ShapeGradientState — issue "shape-gradient-dropshadow-dedup"
+    // — shared with CircleRuntime): gradient pass-through. Backing fields live in
+    // _gradientState so values round-trip even when neither slot implements
+    // IGradientedRenderable (core defaults wrap SolidRectangle / LineRectangle, no gradient
+    // concept). The coordinate/color setters push to whichever slot(s) implement it; the
+    // UseGradient GATE routes to the active body slot (see ShapeGradientState.PushGradientGate).
 
-    // Routes the gradient gate to the ACTIVE body slot — the fill when IsFilled, the stroke when
-    // stroke-only — and forces the inactive slot's gate off. Mirrors SyncDropshadowToTarget: a
-    // single gradient is the active body's paint, so the other slot renders solid (its StrokeColor
-    // / FillColor) rather than sharing the gradient and compositing invisibly over it. Re-run from
-    // both the UseGradient and IsFilled setters so toggling IsFilled re-routes the gate.
-    void SyncGradientToTarget()
-    {
-        var fillGrad = _fill as IGradientedRenderable;
-        var strokeGrad = _stroke as IGradientedRenderable;
-        var active = _isFilled ? fillGrad : strokeGrad;
-        var inactive = _isFilled ? strokeGrad : fillGrad;
-        if (active != null) active.UseGradient = _useGradient;
-        if (inactive != null) inactive.UseGradient = false;
-    }
-
-    // Issue #3009 — the gradient START stop is the slot's own solid body color; Circle/Rectangle
-    // no longer carry a standalone Color1. Each slot mirrors its solid color into its
-    // Red1/Green1/Blue1/Alpha1 so the gradient start equals the color the shape was already
-    // showing (no jump when UseGradient toggles), and the dropshadow alpha — which the Apos
-    // renderable scales by the slot's Color.A — converges onto the gradient start alpha. Called
-    // from the FillColor / StrokeColor setters and the constructor; the UseGradient gate routing
-    // stays in SyncGradientToTarget.
-    void SyncGradientStart()
-    {
-        if (_fill is IGradientedRenderable fillGrad)
-        {
-            fillGrad.Red1 = _fillColor.R;
-            fillGrad.Green1 = _fillColor.G;
-            fillGrad.Blue1 = _fillColor.B;
-            fillGrad.Alpha1 = _fillColor.A;
-        }
-        if (_stroke is IGradientedRenderable strokeGrad)
-        {
-            strokeGrad.Red1 = _strokeColor.R;
-            strokeGrad.Green1 = _strokeColor.G;
-            strokeGrad.Blue1 = _strokeColor.B;
-            strokeGrad.Alpha1 = _strokeColor.A;
-        }
-    }
-
-    bool _useGradient;
     /// <inheritdoc cref="CircleRuntime.UseGradient"/>
     public bool UseGradient
     {
-        get => _useGradient;
+        get => _gradientState.UseGradient;
         set
         {
-            _useGradient = value;
-            SyncGradientToTarget();
+            _gradientState.SetUseGradient(value, _fill as IGradientedRenderable, _stroke as IGradientedRenderable, _isFilled);
             NotifyPropertyChanged();
         }
     }
 
-    GradientType _gradientType;
     public GradientType GradientType
     {
-        get => _gradientType;
+        get => _gradientState.GradientType;
         set
         {
-            _gradientType = value;
-            if (_fill is IGradientedRenderable fillGrad) fillGrad.GradientType = value;
-            if (_stroke is IGradientedRenderable strokeGrad) strokeGrad.GradientType = value;
+            _gradientState.SetGradientType(value, _fill as IGradientedRenderable, _stroke as IGradientedRenderable);
             NotifyPropertyChanged();
         }
     }
 
     // Issue #3009 — the gradient start (Red1/Green1/Blue1/Alpha1 / Color1) is no longer stored on
-    // the runtime. It is driven from the active body color via SyncGradientStart(); the standalone
-    // Color1 surface was dropped for Circle/Rectangle (gradient support is unshipped, so no data to
-    // preserve). Color2 below remains the only standalone gradient color.
+    // the runtime. It is driven from the active body color via ShapeGradientState.PushGradientStart;
+    // the standalone Color1 surface was dropped for Circle/Rectangle (gradient support is
+    // unshipped, so no data to preserve). Color2 below remains the only standalone gradient color.
 
-    int _alpha2 = 255;
     public int Alpha2
     {
-        get => _alpha2;
+        get => _gradientState.Alpha2;
         set
         {
-            _alpha2 = value;
-            if (_fill is IGradientedRenderable fillGrad) fillGrad.Alpha2 = value;
-            if (_stroke is IGradientedRenderable strokeGrad) strokeGrad.Alpha2 = value;
+            _gradientState.SetAlpha2(value, _fill as IGradientedRenderable, _stroke as IGradientedRenderable);
             NotifyPropertyChanged();
         }
     }
 
-    int _red2;
     public int Red2
     {
-        get => _red2;
+        get => _gradientState.Red2;
         set
         {
-            _red2 = value;
-            if (_fill is IGradientedRenderable fillGrad) fillGrad.Red2 = value;
-            if (_stroke is IGradientedRenderable strokeGrad) strokeGrad.Red2 = value;
+            _gradientState.SetRed2(value, _fill as IGradientedRenderable, _stroke as IGradientedRenderable);
             NotifyPropertyChanged();
         }
     }
 
-    int _green2;
     public int Green2
     {
-        get => _green2;
+        get => _gradientState.Green2;
         set
         {
-            _green2 = value;
-            if (_fill is IGradientedRenderable fillGrad) fillGrad.Green2 = value;
-            if (_stroke is IGradientedRenderable strokeGrad) strokeGrad.Green2 = value;
+            _gradientState.SetGreen2(value, _fill as IGradientedRenderable, _stroke as IGradientedRenderable);
             NotifyPropertyChanged();
         }
     }
 
-    int _blue2;
     public int Blue2
     {
-        get => _blue2;
+        get => _gradientState.Blue2;
         set
         {
-            _blue2 = value;
-            if (_fill is IGradientedRenderable fillGrad) fillGrad.Blue2 = value;
-            if (_stroke is IGradientedRenderable strokeGrad) strokeGrad.Blue2 = value;
+            _gradientState.SetBlue2(value, _fill as IGradientedRenderable, _stroke as IGradientedRenderable);
             NotifyPropertyChanged();
         }
     }
 
     public Color Color2
     {
-        get => new Color(_red2, _green2, _blue2, _alpha2);
+        get => _gradientState.Color2;
         set
         {
             Red2 = value.R;
@@ -1289,158 +1237,122 @@ public class RectangleRuntime : GraphicalUiElement
         }
     }
 
-    float _gradientX1;
     public float GradientX1
     {
-        get => _gradientX1;
+        get => _gradientState.GradientX1;
         set
         {
-            _gradientX1 = value;
-            if (_fill is IGradientedRenderable fillGrad) fillGrad.GradientX1 = value;
-            if (_stroke is IGradientedRenderable strokeGrad) strokeGrad.GradientX1 = value;
+            _gradientState.SetGradientX1(value, _fill as IGradientedRenderable, _stroke as IGradientedRenderable);
             NotifyPropertyChanged();
         }
     }
 
-    GeneralUnitType _gradientX1Units;
     public GeneralUnitType GradientX1Units
     {
-        get => _gradientX1Units;
+        get => _gradientState.GradientX1Units;
         set
         {
-            _gradientX1Units = value;
-            if (_fill is IGradientedRenderable fillGrad) fillGrad.GradientX1Units = value;
-            if (_stroke is IGradientedRenderable strokeGrad) strokeGrad.GradientX1Units = value;
+            _gradientState.SetGradientX1Units(value, _fill as IGradientedRenderable, _stroke as IGradientedRenderable);
             NotifyPropertyChanged();
         }
     }
 
-    float _gradientY1;
     public float GradientY1
     {
-        get => _gradientY1;
+        get => _gradientState.GradientY1;
         set
         {
-            _gradientY1 = value;
-            if (_fill is IGradientedRenderable fillGrad) fillGrad.GradientY1 = value;
-            if (_stroke is IGradientedRenderable strokeGrad) strokeGrad.GradientY1 = value;
+            _gradientState.SetGradientY1(value, _fill as IGradientedRenderable, _stroke as IGradientedRenderable);
             NotifyPropertyChanged();
         }
     }
 
-    GeneralUnitType _gradientY1Units;
     public GeneralUnitType GradientY1Units
     {
-        get => _gradientY1Units;
+        get => _gradientState.GradientY1Units;
         set
         {
-            _gradientY1Units = value;
-            if (_fill is IGradientedRenderable fillGrad) fillGrad.GradientY1Units = value;
-            if (_stroke is IGradientedRenderable strokeGrad) strokeGrad.GradientY1Units = value;
+            _gradientState.SetGradientY1Units(value, _fill as IGradientedRenderable, _stroke as IGradientedRenderable);
             NotifyPropertyChanged();
         }
     }
 
-    float _gradientX2;
     public float GradientX2
     {
-        get => _gradientX2;
+        get => _gradientState.GradientX2;
         set
         {
-            _gradientX2 = value;
-            if (_fill is IGradientedRenderable fillGrad) fillGrad.GradientX2 = value;
-            if (_stroke is IGradientedRenderable strokeGrad) strokeGrad.GradientX2 = value;
+            _gradientState.SetGradientX2(value, _fill as IGradientedRenderable, _stroke as IGradientedRenderable);
             NotifyPropertyChanged();
         }
     }
 
-    GeneralUnitType _gradientX2Units;
     public GeneralUnitType GradientX2Units
     {
-        get => _gradientX2Units;
+        get => _gradientState.GradientX2Units;
         set
         {
-            _gradientX2Units = value;
-            if (_fill is IGradientedRenderable fillGrad) fillGrad.GradientX2Units = value;
-            if (_stroke is IGradientedRenderable strokeGrad) strokeGrad.GradientX2Units = value;
+            _gradientState.SetGradientX2Units(value, _fill as IGradientedRenderable, _stroke as IGradientedRenderable);
             NotifyPropertyChanged();
         }
     }
 
-    float _gradientY2;
     public float GradientY2
     {
-        get => _gradientY2;
+        get => _gradientState.GradientY2;
         set
         {
-            _gradientY2 = value;
-            if (_fill is IGradientedRenderable fillGrad) fillGrad.GradientY2 = value;
-            if (_stroke is IGradientedRenderable strokeGrad) strokeGrad.GradientY2 = value;
+            _gradientState.SetGradientY2(value, _fill as IGradientedRenderable, _stroke as IGradientedRenderable);
             NotifyPropertyChanged();
         }
     }
 
-    GeneralUnitType _gradientY2Units;
     public GeneralUnitType GradientY2Units
     {
-        get => _gradientY2Units;
+        get => _gradientState.GradientY2Units;
         set
         {
-            _gradientY2Units = value;
-            if (_fill is IGradientedRenderable fillGrad) fillGrad.GradientY2Units = value;
-            if (_stroke is IGradientedRenderable strokeGrad) strokeGrad.GradientY2Units = value;
+            _gradientState.SetGradientY2Units(value, _fill as IGradientedRenderable, _stroke as IGradientedRenderable);
             NotifyPropertyChanged();
         }
     }
 
-    float _gradientInnerRadius;
     public float GradientInnerRadius
     {
-        get => _gradientInnerRadius;
+        get => _gradientState.GradientInnerRadius;
         set
         {
-            _gradientInnerRadius = value;
-            if (_fill is IGradientedRenderable fillGrad) fillGrad.GradientInnerRadius = value;
-            if (_stroke is IGradientedRenderable strokeGrad) strokeGrad.GradientInnerRadius = value;
+            _gradientState.SetGradientInnerRadius(value, _fill as IGradientedRenderable, _stroke as IGradientedRenderable);
             NotifyPropertyChanged();
         }
     }
 
-    DimensionUnitType _gradientInnerRadiusUnits;
     public DimensionUnitType GradientInnerRadiusUnits
     {
-        get => _gradientInnerRadiusUnits;
+        get => _gradientState.GradientInnerRadiusUnits;
         set
         {
-            _gradientInnerRadiusUnits = value;
-            if (_fill is IGradientedRenderable fillGrad) fillGrad.GradientInnerRadiusUnits = value;
-            if (_stroke is IGradientedRenderable strokeGrad) strokeGrad.GradientInnerRadiusUnits = value;
+            _gradientState.SetGradientInnerRadiusUnits(value, _fill as IGradientedRenderable, _stroke as IGradientedRenderable);
             NotifyPropertyChanged();
         }
     }
 
-    float _gradientOuterRadius;
     public float GradientOuterRadius
     {
-        get => _gradientOuterRadius;
+        get => _gradientState.GradientOuterRadius;
         set
         {
-            _gradientOuterRadius = value;
-            if (_fill is IGradientedRenderable fillGrad) fillGrad.GradientOuterRadius = value;
-            if (_stroke is IGradientedRenderable strokeGrad) strokeGrad.GradientOuterRadius = value;
+            _gradientState.SetGradientOuterRadius(value, _fill as IGradientedRenderable, _stroke as IGradientedRenderable);
             NotifyPropertyChanged();
         }
     }
 
-    DimensionUnitType _gradientOuterRadiusUnits;
     public DimensionUnitType GradientOuterRadiusUnits
     {
-        get => _gradientOuterRadiusUnits;
+        get => _gradientState.GradientOuterRadiusUnits;
         set
         {
-            _gradientOuterRadiusUnits = value;
-            if (_fill is IGradientedRenderable fillGrad) fillGrad.GradientOuterRadiusUnits = value;
-            if (_stroke is IGradientedRenderable strokeGrad) strokeGrad.GradientOuterRadiusUnits = value;
+            _gradientState.SetGradientOuterRadiusUnits(value, _fill as IGradientedRenderable, _stroke as IGradientedRenderable);
             NotifyPropertyChanged();
         }
     }
@@ -1449,139 +1361,97 @@ public class RectangleRuntime : GraphicalUiElement
 
     #region Dropshadow
 
-    // Issue #2818 (mirror of CircleRuntime dropshadow region #2797): single-slot push via
-    // DropshadowTarget — pushing to both would double up the visible shadow. Target picks
-    // by IsFilled: fill when true (the rectangle casts the shadow), stroke when false
-    // (the fill is gated transparent and can't cast a visible shadow). SyncDropshadowToTarget
-    // re-routes on IsFilled toggle so the old target releases its flag.
+    // Issue #2818 (extracted into ShapeDropshadowState — shared with CircleRuntime): single-slot
+    // push via ShapeDropshadowState.GetTarget — pushing to both would double up the visible
+    // shadow. Target picks by IsFilled: fill when true (the rectangle casts the shadow), stroke
+    // when false (the fill is gated transparent and can't cast a visible shadow).
+    // ShapeDropshadowState.SyncTarget re-routes on IsFilled toggle so the old target releases
+    // its flag.
 
-    IDropshadowRenderable? DropshadowTarget
-    {
-        get
-        {
-            var fillDs = _fill as IDropshadowRenderable;
-            var strokeDs = _stroke as IDropshadowRenderable;
-            return _isFilled ? (fillDs ?? strokeDs) : (strokeDs ?? fillDs);
-        }
-    }
-
-    void SyncDropshadowToTarget()
-    {
-        var fillDs = _fill as IDropshadowRenderable;
-        var strokeDs = _stroke as IDropshadowRenderable;
-        var target = DropshadowTarget;
-        var other = ReferenceEquals(target, fillDs) ? strokeDs : fillDs;
-
-        if (other != null) other.HasDropshadow = false;
-        if (target != null)
-        {
-            target.HasDropshadow = _hasDropshadow;
-            target.DropshadowColor = _dropshadowColor;
-            target.DropshadowOffsetX = _dropshadowOffsetX;
-            target.DropshadowOffsetY = _dropshadowOffsetY;
-            target.DropshadowBlurX = _dropshadowBlur;
-            target.DropshadowBlurY = _dropshadowBlur;
-        }
-    }
-
-    bool _hasDropshadow;
     /// <inheritdoc cref="CircleRuntime.HasDropshadow"/>
     public bool HasDropshadow
     {
-        get => _hasDropshadow;
+        get => _dropshadowState.HasDropshadow;
         set
         {
-            _hasDropshadow = value;
-            if (DropshadowTarget is { } target) target.HasDropshadow = value;
+            _dropshadowState.SetHasDropshadow(value, _fill as IDropshadowRenderable, _stroke as IDropshadowRenderable, _isFilled);
             NotifyPropertyChanged();
         }
     }
 
-    Color _dropshadowColor;
     public Color DropshadowColor
     {
-        get => _dropshadowColor;
+        get => _dropshadowState.DropshadowColor;
         set
         {
-            _dropshadowColor = value;
-            if (DropshadowTarget is { } target) target.DropshadowColor = value;
+            _dropshadowState.SetDropshadowColor(value, _fill as IDropshadowRenderable, _stroke as IDropshadowRenderable, _isFilled);
             NotifyPropertyChanged();
         }
     }
 
     public int DropshadowAlpha
     {
-        get => _dropshadowColor.A;
+        get => _dropshadowState.DropshadowColor.A;
         set
         {
-            DropshadowColor = new Color(_dropshadowColor.R, _dropshadowColor.G, _dropshadowColor.B, (byte)value);
+            DropshadowColor = new Color(_dropshadowState.DropshadowColor.R, _dropshadowState.DropshadowColor.G, _dropshadowState.DropshadowColor.B, (byte)value);
         }
     }
 
     public int DropshadowRed
     {
-        get => _dropshadowColor.R;
+        get => _dropshadowState.DropshadowColor.R;
         set
         {
-            DropshadowColor = new Color((byte)value, _dropshadowColor.G, _dropshadowColor.B, _dropshadowColor.A);
+            DropshadowColor = new Color((byte)value, _dropshadowState.DropshadowColor.G, _dropshadowState.DropshadowColor.B, _dropshadowState.DropshadowColor.A);
         }
     }
 
     public int DropshadowGreen
     {
-        get => _dropshadowColor.G;
+        get => _dropshadowState.DropshadowColor.G;
         set
         {
-            DropshadowColor = new Color(_dropshadowColor.R, (byte)value, _dropshadowColor.B, _dropshadowColor.A);
+            DropshadowColor = new Color(_dropshadowState.DropshadowColor.R, (byte)value, _dropshadowState.DropshadowColor.B, _dropshadowState.DropshadowColor.A);
         }
     }
 
     public int DropshadowBlue
     {
-        get => _dropshadowColor.B;
+        get => _dropshadowState.DropshadowColor.B;
         set
         {
-            DropshadowColor = new Color(_dropshadowColor.R, _dropshadowColor.G, (byte)value, _dropshadowColor.A);
+            DropshadowColor = new Color(_dropshadowState.DropshadowColor.R, _dropshadowState.DropshadowColor.G, (byte)value, _dropshadowState.DropshadowColor.A);
         }
     }
 
-    float _dropshadowOffsetX;
     public float DropshadowOffsetX
     {
-        get => _dropshadowOffsetX;
+        get => _dropshadowState.DropshadowOffsetX;
         set
         {
-            _dropshadowOffsetX = value;
-            if (DropshadowTarget is { } target) target.DropshadowOffsetX = value;
+            _dropshadowState.SetDropshadowOffsetX(value, _fill as IDropshadowRenderable, _stroke as IDropshadowRenderable, _isFilled);
             NotifyPropertyChanged();
         }
     }
 
-    float _dropshadowOffsetY;
     public float DropshadowOffsetY
     {
-        get => _dropshadowOffsetY;
+        get => _dropshadowState.DropshadowOffsetY;
         set
         {
-            _dropshadowOffsetY = value;
-            if (DropshadowTarget is { } target) target.DropshadowOffsetY = value;
+            _dropshadowState.SetDropshadowOffsetY(value, _fill as IDropshadowRenderable, _stroke as IDropshadowRenderable, _isFilled);
             NotifyPropertyChanged();
         }
     }
 
-    float _dropshadowBlur;
     /// <inheritdoc cref="CircleRuntime.DropshadowBlur"/>
     public float DropshadowBlur
     {
-        get => _dropshadowBlur;
+        get => _dropshadowState.DropshadowBlur;
         set
         {
-            _dropshadowBlur = value;
-            if (DropshadowTarget is { } target)
-            {
-                target.DropshadowBlurX = value;
-                target.DropshadowBlurY = value;
-            }
+            _dropshadowState.SetDropshadowBlur(value, _fill as IDropshadowRenderable, _stroke as IDropshadowRenderable, _isFilled);
             NotifyPropertyChanged();
         }
     }
@@ -1778,6 +1648,10 @@ public class RectangleRuntime : GraphicalUiElement
         toReturn.IsFilled = toReturn.IsFilled;
         // Issue #2937 — re-fire Blend onto the freshly-built slots for the same reason.
         toReturn.Blend = toReturn.Blend;
+        // Boyscout fix (shape-gradient-dropshadow-dedup) — push the Gradient/Dropshadow state
+        // onto the freshly-built slots too. See CircleRuntime.Clone for the full rationale.
+        toReturn._gradientState.PushAll(toReturn._fill as IGradientedRenderable, toReturn._stroke as IGradientedRenderable, toReturn._isFilled, toReturn._fillColor, toReturn._strokeColor);
+        toReturn._dropshadowState.PushAll(toReturn._fill as IDropshadowRenderable, toReturn._stroke as IDropshadowRenderable, toReturn._isFilled);
         return toReturn;
     }
 #endif
@@ -2037,7 +1911,7 @@ public class RectangleRuntime : GraphicalUiElement
             // Issue #3009 — seed each slot's gradient start from its (white) body color so flipping
             // UseGradient on a freshly-constructed rectangle starts from white, matching the
             // no-jump contract.
-            SyncGradientStart();
+            _gradientState.PushGradientStart(_fillColor, _strokeColor, _fill as IGradientedRenderable, _stroke as IGradientedRenderable);
 
             // Issue #2818 (mirror of CircleRuntime #2797): pre-seed opaque-black dropshadow
             // with a slight downward offset/blur so toggling HasDropshadow = true at runtime

--- a/MonoGameGum/GueDeriving/Shapes/ShapeDropshadowState.cs
+++ b/MonoGameGum/GueDeriving/Shapes/ShapeDropshadowState.cs
@@ -1,0 +1,118 @@
+#if XNALIKE
+using Microsoft.Xna.Framework;
+
+namespace Gum.GueDeriving;
+
+/// <summary>
+/// Backing state and fill/stroke push logic for the Dropshadow property block shared by
+/// <see cref="CircleRuntime"/> and <see cref="RectangleRuntime"/> (issues #2797 / #2818 — the
+/// two runtimes' Dropshadow regions were near-byte-identical). A pure data struct, mirroring
+/// <see cref="ShapeGradientState"/>: callers pass the current fill/stroke slots (cast to
+/// <see cref="IDropshadowRenderable"/>) on every call rather than the struct caching them, so a
+/// stale reference can never survive a <c>Clone()</c> rebuild of those slots.
+/// </summary>
+/// <remarks>
+/// Unlike gradient (pushed to BOTH slots so a single gradient covers fill and stroke at once),
+/// a dropshadow is drawn once per renderable — pushing to both would render the shadow twice
+/// and visibly double up. <see cref="GetTarget"/> picks a single slot: fill when
+/// <c>isFilled</c>, stroke otherwise, falling back to whichever slot is non-null.
+/// </remarks>
+struct ShapeDropshadowState
+{
+    public bool HasDropshadow;
+    public Color DropshadowColor;
+    public float DropshadowOffsetX;
+    public float DropshadowOffsetY;
+    public float DropshadowBlur;
+
+    /// <summary>
+    /// The slot that owns the dropshadow: fill when <paramref name="isFilled"/> (the disc/disk
+    /// casts the shadow), stroke otherwise (the fill is gated to transparent and can't cast a
+    /// visible shadow). Falls back to whichever slot is non-null.
+    /// </summary>
+    public IDropshadowRenderable? GetTarget(IDropshadowRenderable? fill, IDropshadowRenderable? stroke, bool isFilled)
+    {
+        return isFilled ? (fill ?? stroke) : (stroke ?? fill);
+    }
+
+    /// <summary>
+    /// Pushes every backing field onto the active target (see <see cref="GetTarget"/>) and
+    /// clears the inactive slot's flag. Re-run whenever <c>isFilled</c> toggles so the previous
+    /// target releases its shadow and the new target picks it up — otherwise toggling
+    /// <c>IsFilled</c> either ghosts the previous target or never wakes the new one up.
+    /// </summary>
+    public void SyncTarget(IDropshadowRenderable? fill, IDropshadowRenderable? stroke, bool isFilled)
+    {
+        var target = GetTarget(fill, stroke, isFilled);
+        var other = ReferenceEquals(target, fill) ? stroke : fill;
+
+        if (other != null) other.HasDropshadow = false;
+        if (target != null)
+        {
+            target.HasDropshadow = HasDropshadow;
+            target.DropshadowColor = DropshadowColor;
+            target.DropshadowOffsetX = DropshadowOffsetX;
+            target.DropshadowOffsetY = DropshadowOffsetY;
+            target.DropshadowBlurX = DropshadowBlur;
+            target.DropshadowBlurY = DropshadowBlur;
+        }
+    }
+
+    public void SetHasDropshadow(bool value, IDropshadowRenderable? fill, IDropshadowRenderable? stroke, bool isFilled)
+    {
+        HasDropshadow = value;
+        var target = GetTarget(fill, stroke, isFilled);
+        if (target != null) target.HasDropshadow = value;
+    }
+
+    public void SetDropshadowColor(Color value, IDropshadowRenderable? fill, IDropshadowRenderable? stroke, bool isFilled)
+    {
+        DropshadowColor = value;
+        var target = GetTarget(fill, stroke, isFilled);
+        if (target != null) target.DropshadowColor = value;
+    }
+
+    public void SetDropshadowOffsetX(float value, IDropshadowRenderable? fill, IDropshadowRenderable? stroke, bool isFilled)
+    {
+        DropshadowOffsetX = value;
+        var target = GetTarget(fill, stroke, isFilled);
+        if (target != null) target.DropshadowOffsetX = value;
+    }
+
+    public void SetDropshadowOffsetY(float value, IDropshadowRenderable? fill, IDropshadowRenderable? stroke, bool isFilled)
+    {
+        DropshadowOffsetY = value;
+        var target = GetTarget(fill, stroke, isFilled);
+        if (target != null) target.DropshadowOffsetY = value;
+    }
+
+    /// <summary>
+    /// Isotropic blur radius — a single scalar pushed to both the target's X and Y blur fields
+    /// (Apos.Shapes approximates falloff via one <c>antiAliasSize</c> parameter; no per-axis
+    /// blur). Mirrors industry convention (CSS <c>box-shadow</c> blur-radius, Figma, Photoshop).
+    /// </summary>
+    public void SetDropshadowBlur(float value, IDropshadowRenderable? fill, IDropshadowRenderable? stroke, bool isFilled)
+    {
+        DropshadowBlur = value;
+        var target = GetTarget(fill, stroke, isFilled);
+        if (target != null)
+        {
+            target.DropshadowBlurX = value;
+            target.DropshadowBlurY = value;
+        }
+    }
+
+    /// <summary>
+    /// Pushes every backing field onto freshly-rebuilt fill/stroke slots. Called from
+    /// <c>Clone()</c> for symmetry with <see cref="ShapeGradientState.PushAll"/> (which closes a
+    /// real gap there). Unlike gradient, dropshadow state already reached the clone's slots
+    /// before this existed: <c>Clone()</c> re-fires <c>IsFilled</c> onto the freshly-built slots,
+    /// and that setter unconditionally calls <see cref="SyncTarget"/> — so this call is
+    /// defensive/idempotent here, not fixing a bug.
+    /// </summary>
+    public void PushAll(IDropshadowRenderable? fill, IDropshadowRenderable? stroke, bool isFilled)
+    {
+        SyncTarget(fill, stroke, isFilled);
+    }
+}
+#endif

--- a/MonoGameGum/GueDeriving/Shapes/ShapeGradientState.cs
+++ b/MonoGameGum/GueDeriving/Shapes/ShapeGradientState.cs
@@ -1,0 +1,238 @@
+#if XNALIKE
+using Gum.Converters;
+using Gum.DataTypes;
+using Microsoft.Xna.Framework;
+using RenderingLibrary.Graphics;
+
+namespace Gum.GueDeriving;
+
+/// <summary>
+/// Backing state and fill/stroke push logic for the Gradient property block shared by
+/// <see cref="CircleRuntime"/> and <see cref="RectangleRuntime"/> (issues #2791 / #2818 — the
+/// two runtimes' Gradient regions were near-byte-identical). A pure data struct: callers pass
+/// the current fill/stroke slots (cast to <see cref="IGradientedRenderable"/>) on every call
+/// rather than the struct caching them, so a stale reference can never survive a
+/// <c>Clone()</c> rebuild of those slots. Being a struct (not a class) also means the owning
+/// runtime's <c>MemberwiseClone</c>-based <c>Clone()</c> copies every backing field by value for
+/// free, matching the zero-explicit-handling pattern the runtimes already rely on for their
+/// other backing fields.
+/// </summary>
+struct ShapeGradientState
+{
+    public bool UseGradient;
+    public GradientType GradientType;
+    public int Alpha2;
+    public int Red2;
+    public int Green2;
+    public int Blue2;
+    public float GradientX1;
+    public GeneralUnitType GradientX1Units;
+    public float GradientY1;
+    public GeneralUnitType GradientY1Units;
+    public float GradientX2;
+    public GeneralUnitType GradientX2Units;
+    public float GradientY2;
+    public GeneralUnitType GradientY2Units;
+    public float GradientInnerRadius;
+    public DimensionUnitType GradientInnerRadiusUnits;
+    public float GradientOuterRadius;
+    public DimensionUnitType GradientOuterRadiusUnits;
+
+    /// <summary>Composed from <see cref="Red2"/>/<see cref="Green2"/>/<see cref="Blue2"/>/<see cref="Alpha2"/> — no dedicated backing field.</summary>
+    public Color Color2 => new Color(Red2, Green2, Blue2, Alpha2);
+
+    public void SetUseGradient(bool value, IGradientedRenderable? fill, IGradientedRenderable? stroke, bool isFilled)
+    {
+        UseGradient = value;
+        PushGradientGate(fill, stroke, isFilled);
+    }
+
+    public void SetGradientType(GradientType value, IGradientedRenderable? fill, IGradientedRenderable? stroke)
+    {
+        GradientType = value;
+        if (fill != null) fill.GradientType = value;
+        if (stroke != null) stroke.GradientType = value;
+    }
+
+    public void SetAlpha2(int value, IGradientedRenderable? fill, IGradientedRenderable? stroke)
+    {
+        Alpha2 = value;
+        if (fill != null) fill.Alpha2 = value;
+        if (stroke != null) stroke.Alpha2 = value;
+    }
+
+    public void SetRed2(int value, IGradientedRenderable? fill, IGradientedRenderable? stroke)
+    {
+        Red2 = value;
+        if (fill != null) fill.Red2 = value;
+        if (stroke != null) stroke.Red2 = value;
+    }
+
+    public void SetGreen2(int value, IGradientedRenderable? fill, IGradientedRenderable? stroke)
+    {
+        Green2 = value;
+        if (fill != null) fill.Green2 = value;
+        if (stroke != null) stroke.Green2 = value;
+    }
+
+    public void SetBlue2(int value, IGradientedRenderable? fill, IGradientedRenderable? stroke)
+    {
+        Blue2 = value;
+        if (fill != null) fill.Blue2 = value;
+        if (stroke != null) stroke.Blue2 = value;
+    }
+
+    public void SetGradientX1(float value, IGradientedRenderable? fill, IGradientedRenderable? stroke)
+    {
+        GradientX1 = value;
+        if (fill != null) fill.GradientX1 = value;
+        if (stroke != null) stroke.GradientX1 = value;
+    }
+
+    public void SetGradientX1Units(GeneralUnitType value, IGradientedRenderable? fill, IGradientedRenderable? stroke)
+    {
+        GradientX1Units = value;
+        if (fill != null) fill.GradientX1Units = value;
+        if (stroke != null) stroke.GradientX1Units = value;
+    }
+
+    public void SetGradientY1(float value, IGradientedRenderable? fill, IGradientedRenderable? stroke)
+    {
+        GradientY1 = value;
+        if (fill != null) fill.GradientY1 = value;
+        if (stroke != null) stroke.GradientY1 = value;
+    }
+
+    public void SetGradientY1Units(GeneralUnitType value, IGradientedRenderable? fill, IGradientedRenderable? stroke)
+    {
+        GradientY1Units = value;
+        if (fill != null) fill.GradientY1Units = value;
+        if (stroke != null) stroke.GradientY1Units = value;
+    }
+
+    public void SetGradientX2(float value, IGradientedRenderable? fill, IGradientedRenderable? stroke)
+    {
+        GradientX2 = value;
+        if (fill != null) fill.GradientX2 = value;
+        if (stroke != null) stroke.GradientX2 = value;
+    }
+
+    public void SetGradientX2Units(GeneralUnitType value, IGradientedRenderable? fill, IGradientedRenderable? stroke)
+    {
+        GradientX2Units = value;
+        if (fill != null) fill.GradientX2Units = value;
+        if (stroke != null) stroke.GradientX2Units = value;
+    }
+
+    public void SetGradientY2(float value, IGradientedRenderable? fill, IGradientedRenderable? stroke)
+    {
+        GradientY2 = value;
+        if (fill != null) fill.GradientY2 = value;
+        if (stroke != null) stroke.GradientY2 = value;
+    }
+
+    public void SetGradientY2Units(GeneralUnitType value, IGradientedRenderable? fill, IGradientedRenderable? stroke)
+    {
+        GradientY2Units = value;
+        if (fill != null) fill.GradientY2Units = value;
+        if (stroke != null) stroke.GradientY2Units = value;
+    }
+
+    public void SetGradientInnerRadius(float value, IGradientedRenderable? fill, IGradientedRenderable? stroke)
+    {
+        GradientInnerRadius = value;
+        if (fill != null) fill.GradientInnerRadius = value;
+        if (stroke != null) stroke.GradientInnerRadius = value;
+    }
+
+    public void SetGradientInnerRadiusUnits(DimensionUnitType value, IGradientedRenderable? fill, IGradientedRenderable? stroke)
+    {
+        GradientInnerRadiusUnits = value;
+        if (fill != null) fill.GradientInnerRadiusUnits = value;
+        if (stroke != null) stroke.GradientInnerRadiusUnits = value;
+    }
+
+    public void SetGradientOuterRadius(float value, IGradientedRenderable? fill, IGradientedRenderable? stroke)
+    {
+        GradientOuterRadius = value;
+        if (fill != null) fill.GradientOuterRadius = value;
+        if (stroke != null) stroke.GradientOuterRadius = value;
+    }
+
+    public void SetGradientOuterRadiusUnits(DimensionUnitType value, IGradientedRenderable? fill, IGradientedRenderable? stroke)
+    {
+        GradientOuterRadiusUnits = value;
+        if (fill != null) fill.GradientOuterRadiusUnits = value;
+        if (stroke != null) stroke.GradientOuterRadiusUnits = value;
+    }
+
+    /// <summary>
+    /// Routes the gradient gate to the ACTIVE body slot (fill when <paramref name="isFilled"/>,
+    /// else stroke) and forces the inactive slot's gate off — a single gradient is the active
+    /// body's paint, so the other slot renders solid rather than sharing the gradient and
+    /// compositing invisibly over it. Called from both <see cref="SetUseGradient"/> and the
+    /// owning runtime's <c>IsFilled</c> setter (toggling <c>IsFilled</c> re-routes the gate).
+    /// </summary>
+    public void PushGradientGate(IGradientedRenderable? fill, IGradientedRenderable? stroke, bool isFilled)
+    {
+        var active = isFilled ? fill : stroke;
+        var inactive = isFilled ? stroke : fill;
+        if (active != null) active.UseGradient = UseGradient;
+        if (inactive != null) inactive.UseGradient = false;
+    }
+
+    /// <summary>
+    /// Mirrors each slot's own solid body color into its Red1/Green1/Blue1/Alpha1 gradient
+    /// start so the gradient begins at the color the shape was already showing (no jump when
+    /// <c>UseGradient</c> toggles). Called from the owning runtime's <c>FillColor</c> /
+    /// <c>StrokeColor</c> setters and constructor.
+    /// </summary>
+    public void PushGradientStart(Color fillColor, Color strokeColor, IGradientedRenderable? fill, IGradientedRenderable? stroke)
+    {
+        if (fill != null)
+        {
+            fill.Red1 = fillColor.R;
+            fill.Green1 = fillColor.G;
+            fill.Blue1 = fillColor.B;
+            fill.Alpha1 = fillColor.A;
+        }
+        if (stroke != null)
+        {
+            stroke.Red1 = strokeColor.R;
+            stroke.Green1 = strokeColor.G;
+            stroke.Blue1 = strokeColor.B;
+            stroke.Alpha1 = strokeColor.A;
+        }
+    }
+
+    /// <summary>
+    /// Pushes every backing field onto freshly-rebuilt fill/stroke slots. Used only from
+    /// <c>Clone()</c> to close a pre-existing gap: the cloned runtime's gradient state
+    /// previously never reached its new renderable slots (only the backing fields survived via
+    /// <c>MemberwiseClone</c>), so a clone with <c>UseGradient = true</c> silently rendered
+    /// without its gradient until some other property write happened to re-trigger it.
+    /// </summary>
+    public void PushAll(IGradientedRenderable? fill, IGradientedRenderable? stroke, bool isFilled, Color fillColor, Color strokeColor)
+    {
+        SetGradientType(GradientType, fill, stroke);
+        SetAlpha2(Alpha2, fill, stroke);
+        SetRed2(Red2, fill, stroke);
+        SetGreen2(Green2, fill, stroke);
+        SetBlue2(Blue2, fill, stroke);
+        SetGradientX1(GradientX1, fill, stroke);
+        SetGradientX1Units(GradientX1Units, fill, stroke);
+        SetGradientY1(GradientY1, fill, stroke);
+        SetGradientY1Units(GradientY1Units, fill, stroke);
+        SetGradientX2(GradientX2, fill, stroke);
+        SetGradientX2Units(GradientX2Units, fill, stroke);
+        SetGradientY2(GradientY2, fill, stroke);
+        SetGradientY2Units(GradientY2Units, fill, stroke);
+        SetGradientInnerRadius(GradientInnerRadius, fill, stroke);
+        SetGradientInnerRadiusUnits(GradientInnerRadiusUnits, fill, stroke);
+        SetGradientOuterRadius(GradientOuterRadius, fill, stroke);
+        SetGradientOuterRadiusUnits(GradientOuterRadiusUnits, fill, stroke);
+        PushGradientStart(fillColor, strokeColor, fill, stroke);
+        PushGradientGate(fill, stroke, isFilled);
+    }
+}
+#endif

--- a/Tests/MonoGameGum.Shapes.Tests/CircleRuntimeTests.cs
+++ b/Tests/MonoGameGum.Shapes.Tests/CircleRuntimeTests.cs
@@ -569,6 +569,42 @@ public class CircleRuntimeTests
         sourceStroke.Color.ShouldBe(Color.Blue);
     }
 
+    // Boyscout fix (shape-gradient-dropshadow-dedup): neither Gradient nor Dropshadow state was
+    // fully re-fired onto the clone's freshly-rebuilt slots. Backing fields survived via
+    // MemberwiseClone, but the clone's own fill/stroke are brand-new renderable instances at
+    // their factory defaults — a clone with UseGradient / GradientType / Color2 set never
+    // reflected that on its own slots until some other property write happened to re-trigger it.
+    [Fact]
+    public void Clone_PushesGradientAndDropshadowState_ToClonesOwnRenderableSlots()
+    {
+        CircleRuntime source = new();
+        source.IsFilled = true;
+        source.FillColor = Color.Red;
+        source.UseGradient = true;
+        source.GradientType = GradientType.Linear;
+        source.Color2 = Color.Blue;
+        source.GradientX2 = 56;
+        source.HasDropshadow = true;
+        source.DropshadowColor = new Color(10, 20, 30, 40);
+        source.DropshadowOffsetX = 5;
+
+        CircleRuntime clone = (CircleRuntime)source.Clone();
+
+        Circle cloneFill = (Circle)clone.RenderableComponent;
+        Circle cloneStroke = (Circle)cloneFill.Children[0];
+
+        cloneFill.UseGradient.ShouldBeTrue();
+        cloneStroke.UseGradient.ShouldBeFalse();
+        cloneFill.GradientType.ShouldBe(GradientType.Linear);
+        cloneFill.Blue2.ShouldBe(Color.Blue.B);
+        cloneStroke.Blue2.ShouldBe(Color.Blue.B);
+        cloneFill.GradientX2.ShouldBe(56);
+        cloneFill.HasDropshadow.ShouldBeTrue();
+        cloneFill.DropshadowColor.ShouldBe(new Color(10, 20, 30, 40));
+        cloneFill.DropshadowOffsetX.ShouldBe(5);
+        cloneStroke.HasDropshadow.ShouldBeFalse();
+    }
+
     // Issue #2790 — runtime no longer compensates dash/gap. The Apos renderable (Gum.Shapes
     // Circle.RenderDashed) inflates the effective gap by aaSize internally when AA is on, so
     // dashes stay visually distinct without the runtime needing to second-guess the user's

--- a/Tests/MonoGameGum.Shapes.Tests/RectangleRuntimeTests.cs
+++ b/Tests/MonoGameGum.Shapes.Tests/RectangleRuntimeTests.cs
@@ -674,6 +674,42 @@ public class RectangleRuntimeTests
         sourceStroke.Color.ShouldBe(Color.Blue);
     }
 
+    // Boyscout fix (shape-gradient-dropshadow-dedup): neither Gradient nor Dropshadow state was
+    // fully re-fired onto the clone's freshly-rebuilt slots. Backing fields survived via
+    // MemberwiseClone, but the clone's own fill/stroke are brand-new renderable instances at
+    // their factory defaults — a clone with UseGradient / GradientType / Color2 set never
+    // reflected that on its own slots until some other property write happened to re-trigger it.
+    [Fact]
+    public void Clone_PushesGradientAndDropshadowState_ToClonesOwnRenderableSlots()
+    {
+        RectangleRuntime source = new();
+        source.IsFilled = true;
+        source.FillColor = Color.Red;
+        source.UseGradient = true;
+        source.GradientType = GradientType.Linear;
+        source.Color2 = Color.Blue;
+        source.GradientX2 = 56;
+        source.HasDropshadow = true;
+        source.DropshadowColor = new Color(10, 20, 30, 40);
+        source.DropshadowOffsetX = 5;
+
+        RectangleRuntime clone = (RectangleRuntime)source.Clone();
+
+        RoundedRectangle cloneFill = (RoundedRectangle)clone.RenderableComponent;
+        RoundedRectangle cloneStroke = (RoundedRectangle)cloneFill.Children[0];
+
+        cloneFill.UseGradient.ShouldBeTrue();
+        cloneStroke.UseGradient.ShouldBeFalse();
+        cloneFill.GradientType.ShouldBe(GradientType.Linear);
+        cloneFill.Blue2.ShouldBe(Color.Blue.B);
+        cloneStroke.Blue2.ShouldBe(Color.Blue.B);
+        cloneFill.GradientX2.ShouldBe(56);
+        cloneFill.HasDropshadow.ShouldBeTrue();
+        cloneFill.DropshadowColor.ShouldBe(new Color(10, 20, 30, 40));
+        cloneFill.DropshadowOffsetX.ShouldBe(5);
+        cloneStroke.HasDropshadow.ShouldBeFalse();
+    }
+
     // Issue #2925 — same bug as CircleRuntime: constructor sets the fill renderable as
     // mContainedObjectAsIpso, so the tool's variable-application path routes the legacy
     // "Color" / "Alpha" variables to the FILL renderable instead of stroke. Result: a


### PR DESCRIPTION
## Summary
- `CircleRuntime`/`RectangleRuntime`'s XNALIKE-only `#region Gradient` and `#region Dropshadow` blocks were near-byte-identical duplicates (same property names, same `SyncGradientToTarget`/`SyncGradientStart`/`DropshadowTarget`/`SyncDropshadowToTarget` routing logic). Extracted into two shared structs, `ShapeGradientState` and `ShapeDropshadowState` (`MonoGameGum/GueDeriving/Shapes/`), that both runtimes hold as fields and forward their public properties to.
- Structs (not classes): `Clone()` relies on `MemberwiseClone` to copy backing fields by value for free; a class field would instead share one mutable instance between clone and source. Slot references (`IGradientedRenderable?`/`IDropshadowRenderable?`) are passed in on every call rather than cached on the struct, so nothing can go stale when `Clone()` rebuilds fresh fill/stroke slots.
- **Boyscout fix**: neither runtime's `Clone()` re-fired Gradient state onto the freshly-rebuilt slots (only `StrokeColor`/`FillColor`/`IsFilled`/`Blend` were re-fired) — a real, previously-untested gap where a clone's `UseGradient`/`GradientType`/`Color2`/etc. never reached its own renderables until some other property write happened to re-trigger it. Fixed via a new `PushAll(...)` call in both `Clone()` overrides, with a new pinning test per shape that fails without the fix (verified via TDD). Dropshadow's equivalent `PushAll` call is defensive/symmetric rather than fixing a second bug — dropshadow already reached the clone's slots via the pre-existing `IsFilled` re-fire.
- Out of scope (flagged for follow-up): `Blend`/`IsAntialiased` (push to both slots unconditionally, smaller duplication) and `DashedStroke`/the `PreRender` stroke-width AA-compensation math.

## Test plan
- [x] `dotnet test MonoGameGum.Tests/MonoGameGum.Tests.csproj --filter "CircleRuntimeTests|RectangleRuntimeTests"` — 31/31 pass
- [x] `dotnet test Tests/MonoGameGum.Shapes.Tests/MonoGameGum.Shapes.Tests.csproj --filter "CircleRuntimeTests|RectangleRuntimeTests"` — 119/119 pass (117 existing + 2 new Clone pinning tests)
- [x] `dotnet test Tests/RaylibGum.Tests/RaylibGum.Tests.csproj --filter "CircleRuntimeTests|RectangleRuntimeTests"` — 50/50 pass, unchanged
- [x] `Runtimes/SkiaGum/SkiaGum.csproj` builds clean, identical warning count before/after

🤖 Generated with [Claude Code](https://claude.com/claude-code)