### PR TITLE
Extract shared PreRender stroke math from Circle/RectangleRuntime

### DIFF
--- a/MonoGameGum/GueDeriving/CircleRuntime.cs
+++ b/MonoGameGum/GueDeriving/CircleRuntime.cs
@@ -702,8 +702,7 @@ public class CircleRuntime : GraphicalUiElement
         set
         {
             _blend = value;
-            if (_fill is IBlendedRenderable fillBlend) fillBlend.Blend = value;
-            if (_stroke is IBlendedRenderable strokeBlend) strokeBlend.Blend = value;
+            ShapeStrokePreRenderMath.PushBlend(value, _fill as IBlendedRenderable, _stroke as IBlendedRenderable);
             NotifyPropertyChanged();
         }
     }
@@ -1105,62 +1104,11 @@ public class CircleRuntime : GraphicalUiElement
         var camera = this.EffectiveManagers?.Renderer?.Camera;
         float cameraZoom = camera?.Zoom ?? 1f;
 
-        float strokeWidth = _strokeWidth;
-        float strokeDashLength = _strokeDashLength;
-        float strokeGapLength = _strokeGapLength;
-        if (_strokeWidthUnits == DimensionUnitType.ScreenPixel && camera != null)
-        {
-            // Mirrors AposShapeRuntime.PreRender — dash and gap scale alongside stroke
-            // width so a "1 px dotted" pattern stays 1 px on screen regardless of zoom.
-            strokeWidth /= cameraZoom;
-            strokeDashLength /= cameraZoom;
-            strokeGapLength /= cameraZoom;
-        }
-        // Two distinct cases for what to push to the renderable's StrokeWidth — don't collapse
-        // them, the difference is load-bearing:
-        //
-        // 1. User explicitly set StrokeWidth <= 0 → push a literal 0 (#2950 follow-up).
-        //    StrokeWidth = 0 is the canonical hide-stroke gate since #2938 made StrokeColor
-        //    non-nullable, so the user wants NO stroke at all. The renderable's
-        //    HasVisibleOutput predicate then short-circuits Circle.Render to skip the
-        //    stroke-slot draw entirely. **Do NOT route this case through the AA-compensation
-        //    path below** — the epsilon floor would push 0.01, the renderable's
-        //    HasVisibleOutput would return true (StrokeWidth > 0), and Apos's 1 px AA fringe
-        //    would render a hairline of stroke color the user thought they had disabled.
-        //
-        // 2. User set a positive StrokeWidth → subtract the 1 px Apos AA contribution
-        //    (#2790). Apos.Shapes' DrawCircle renders aaSize pixels of AA halo OUTSIDE the
-        //    nominal thickness; Circle.Render passes aaSize = 1 when IsAntialiased is true.
-        //    Skia fits AA WITHIN the thickness, so the same user-set StrokeWidth would
-        //    otherwise read 1 px wider on Apos than on Skia. The result is floored at a tiny
-        //    positive epsilon — NOT to hide a "0 means don't draw" case (that's handled
-        //    above by case 1), but to keep thin strokes like StrokeWidth = 1 visible: after
-        //    subtracting the AA contribution the math would be 0, which Apos refuses to draw
-        //    even with aaSize > 0. The epsilon push pairs with the 1 px AA halo to produce
-        //    the intended ~1 px visible stroke. Gated by IAntialiasedRenderable so the core
-        //    stroke default (LineCircle wrapper, no AA concept) still receives the raw value.
-        const float aposAaContribution = 1f;
-        const float aposMinThicknessEpsilon = 0.01f;
-        // Issue #2936 — aposAaContribution is in SCREEN pixels (Apos's hardcoded 1 px AA halo).
-        // Convert to world units before mixing with strokeWidth, which has already been
-        // resolved to world units above. At cameraZoom = 1 this is a no-op (original #2790
-        // behavior preserved); at cameraZoom > 1 the world value shrinks proportionally, which
-        // is what closes the gap below.
-        float aposAaContributionWorld = aposAaContribution / cameraZoom;
-        float renderableStrokeWidth;
-        if (strokeWidth <= 0)
-        {
-            renderableStrokeWidth = 0f;
-        }
-        else if (_isAntialiased && _stroke is IAntialiasedRenderable)
-        {
-            renderableStrokeWidth = Math.Max(aposMinThicknessEpsilon, strokeWidth - aposAaContributionWorld);
-        }
-        else
-        {
-            renderableStrokeWidth = strokeWidth;
-        }
-        _stroke.StrokeWidth = renderableStrokeWidth;
+        var strokeMath = ShapeStrokePreRenderMath.Compute(
+            _strokeWidth, _strokeDashLength, _strokeGapLength, _strokeWidthUnits,
+            _isAntialiased, _stroke is IAntialiasedRenderable, cameraZoom, _stroke.Color.A);
+
+        _stroke.StrokeWidth = strokeMath.StrokeWidth;
 
         // Issue #2796: push dash/gap to the stroke slot when it supports dashing. Skipped
         // for slots that don't implement the interface (core DefaultStrokedCircleRenderable
@@ -1171,8 +1119,8 @@ public class CircleRuntime : GraphicalUiElement
         // distinct — runtime just pushes the user's values through unchanged.
         if (_stroke is IDashedStrokeRenderable strokeDashed)
         {
-            strokeDashed.StrokeDashLength = strokeDashLength;
-            strokeDashed.StrokeGapLength = strokeGapLength;
+            strokeDashed.StrokeDashLength = strokeMath.DashLength;
+            strokeDashed.StrokeGapLength = strokeMath.GapLength;
         }
 
         // Issue #2798: push AA to both slots so a single setter flips fill + stroke together.
@@ -1192,41 +1140,17 @@ public class CircleRuntime : GraphicalUiElement
         }
 
         // Issue #2834 — when both slots are visible, push a radius inset to the fill so its
-        // rendered outer AA halo sits inside the stroke's opaque band. Two separate
-        // antialiased Apos draws at the same radius composite their AA pixels, producing a
-        // red fringe outside the white stroke (the Apos symptom; Skia shows a mirror-image
-        // pink halo on the inside).
+        // rendered outer AA halo sits inside the stroke's opaque band (see
+        // ShapeStrokePreRenderMath.Compute for the fill-inset calculation and rationale).
         //
         // We can't mutate fillSized.Width/Height to do this — the fill IS the runtime's
         // contained sizing object, so mutating its Width feeds back into layout and the
         // shrink accumulates each frame until the circle vanishes. Inset is pushed via the
         // dedicated FillRadiusInset property instead; Width/Height stay layout-owned, and
         // the Apos Circle subtracts the inset from its computed radius at render time.
-        //
-        // Inset per side = max(renderableStrokeWidth, aposAaContribution when AA on).
-        // renderableStrokeWidth alone aligns fine for thick strokes, but hairline (1 px)
-        // strokes push a sub-pixel epsilon to Apos so the AA halo (still ~1 px) dominates
-        // and would re-create the overlap without the floor.
-        //
-        // Gated on stroke visibility: alpha 0 OR StrokeWidth 0 means the stroke isn't drawn,
-        // and inset would render a thin background ring where the stroke would have been.
-        // Issue #2938 made StrokeWidth = 0 the canonical hide-stroke gate (StrokeColor is now
-        // non-nullable); the alpha guard stays as the pre-existing #2834 path.
         if (_fill != null)
         {
-            float fillRadiusInset = 0f;
-            if (_stroke.Color.A > 0 && _strokeWidth > 0)
-            {
-                fillRadiusInset = renderableStrokeWidth;
-                if (_isAntialiased && _stroke is IAntialiasedRenderable)
-                {
-                    // #2936: aaContribution in WORLD units (= 1 screen px / zoom). At Zoom > 1
-                    // this is < 1 world unit, so the inset no longer over-shrinks the fill
-                    // relative to the visible stroke band's inward extent.
-                    fillRadiusInset = Math.Max(fillRadiusInset, aposAaContributionWorld);
-                }
-            }
-            _fill.FillRadiusInset = fillRadiusInset;
+            _fill.FillRadiusInset = strokeMath.FillInset;
         }
 
         // Do NOT call base.PreRender() — same caveat as AposShapeRuntime.PreRender. Forwarding

--- a/MonoGameGum/GueDeriving/RectangleRuntime.cs
+++ b/MonoGameGum/GueDeriving/RectangleRuntime.cs
@@ -947,8 +947,7 @@ public class RectangleRuntime : GraphicalUiElement
         set
         {
             _blend = value;
-            if (_fill is IBlendedRenderable fillBlend) fillBlend.Blend = value;
-            if (_stroke is IBlendedRenderable strokeBlend) strokeBlend.Blend = value;
+            ShapeStrokePreRenderMath.PushBlend(value, _fill as IBlendedRenderable, _stroke as IBlendedRenderable);
             NotifyPropertyChanged();
         }
     }
@@ -1414,48 +1413,17 @@ public class RectangleRuntime : GraphicalUiElement
         var camera = this.EffectiveManagers?.Renderer?.Camera;
         float cameraZoom = camera?.Zoom ?? 1f;
 
-        float strokeWidth = _strokeWidth;
-        float strokeDashLength = _strokeDashLength;
-        float strokeGapLength = _strokeGapLength;
-        if (_strokeWidthUnits == DimensionUnitType.ScreenPixel && camera != null)
-        {
-            // Mirror AposShapeRuntime.PreRender — dash and gap scale alongside stroke width.
-            strokeWidth /= cameraZoom;
-            strokeDashLength /= cameraZoom;
-            strokeGapLength /= cameraZoom;
-        }
-        // Mirror of CircleRuntime.PreRender — same two-case structure (user-set <= 0 vs
-        // positive thin stroke). See CircleRuntime.PreRender for the full rationale on why
-        // these two cases must stay separate. tl;dr:
-        //   - StrokeWidth <= 0 (user hide-stroke gate, #2950 follow-up) → push literal 0
-        //     so the renderable's HasVisibleOutput suppresses the draw.
-        //   - StrokeWidth > 0 with AA → subtract the 1 px Apos AA contribution and floor at
-        //     a tiny positive epsilon so thin strokes still render (#2818).
-        const float aposAaContribution = 1f;
-        const float aposMinThicknessEpsilon = 0.01f;
-        // #2936 — aposAaContribution is in SCREEN pixels; convert to world units. See
-        // CircleRuntime.PreRender for the full rationale.
-        float aposAaContributionWorld = aposAaContribution / cameraZoom;
-        float renderableStrokeWidth;
-        if (strokeWidth <= 0)
-        {
-            renderableStrokeWidth = 0f;
-        }
-        else if (_isAntialiased && _stroke is IAntialiasedRenderable)
-        {
-            renderableStrokeWidth = Math.Max(aposMinThicknessEpsilon, strokeWidth - aposAaContributionWorld);
-        }
-        else
-        {
-            renderableStrokeWidth = strokeWidth;
-        }
-        _stroke.StrokeWidth = renderableStrokeWidth;
+        var strokeMath = ShapeStrokePreRenderMath.Compute(
+            _strokeWidth, _strokeDashLength, _strokeGapLength, _strokeWidthUnits,
+            _isAntialiased, _stroke is IAntialiasedRenderable, cameraZoom, _stroke.Color.A);
+
+        _stroke.StrokeWidth = strokeMath.StrokeWidth;
 
         // Issue #2818: push dash/gap to the stroke slot when it supports dashing.
         if (_stroke is IDashedStrokeRenderable strokeDashed)
         {
-            strokeDashed.StrokeDashLength = strokeDashLength;
-            strokeDashed.StrokeGapLength = strokeGapLength;
+            strokeDashed.StrokeDashLength = strokeMath.DashLength;
+            strokeDashed.StrokeGapLength = strokeMath.GapLength;
         }
 
         // Issue #2818: push AA to both slots so a single setter flips fill + stroke together.
@@ -1512,22 +1480,11 @@ public class RectangleRuntime : GraphicalUiElement
         // otherwise a filled rectangle with a semi-transparent stroke shows the FILL through the
         // stroke instead of the background. Pushed via FillInset rather than mutating
         // fill.Width/Height (the fill IS the runtime's contained sizing object; mutating Width
-        // would feed back into layout and shrink the rectangle each frame). Inset per side =
-        // AA-compensated stroke width, floored at the AA contribution for hairline strokes.
-        // Gated on stroke visibility: alpha 0 OR StrokeWidth 0 means no stroke is drawn, and an
-        // inset would render a thin background gap where the stroke would have been.
+        // would feed back into layout and shrink the rectangle each frame). See
+        // ShapeStrokePreRenderMath.Compute for the inset calculation and rationale.
         if (_fill != null)
         {
-            float fillInset = 0f;
-            if (_stroke.Color.A > 0 && _strokeWidth > 0)
-            {
-                fillInset = renderableStrokeWidth;
-                if (_isAntialiased && _stroke is IAntialiasedRenderable)
-                {
-                    fillInset = Math.Max(fillInset, aposAaContributionWorld);
-                }
-            }
-            _fill.FillInset = fillInset;
+            _fill.FillInset = strokeMath.FillInset;
         }
     }
 

--- a/MonoGameGum/GueDeriving/Shapes/ShapeStrokePreRenderMath.cs
+++ b/MonoGameGum/GueDeriving/Shapes/ShapeStrokePreRenderMath.cs
@@ -1,0 +1,167 @@
+#if XNALIKE
+using System;
+using Gum.DataTypes;
+
+namespace Gum.GueDeriving;
+
+/// <summary>
+/// Shared per-frame stroke math for the Blend push and the <c>PreRender</c> stroke-width /
+/// dash-gap / fill-inset calculations duplicated (near-byte-identical) between
+/// <see cref="CircleRuntime"/> and <see cref="RectangleRuntime"/>. Unlike
+/// <see cref="ShapeGradientState"/> / <see cref="ShapeDropshadowState"/> this is pure
+/// computation with no per-instance backing state to survive a <c>Clone()</c> — a static class,
+/// not a struct.
+/// </summary>
+static class ShapeStrokePreRenderMath
+{
+    /// <summary>
+    /// Issue #2937 — pushes a blend mode to both slots (blend is folded into each renderable's
+    /// <c>BatchKey</c>; a fill/stroke disagreement would split them across two ShapeBatches and
+    /// render the stroke with the wrong blend).
+    /// </summary>
+    public static void PushBlend(Gum.RenderingLibrary.Blend value, IBlendedRenderable? fill, IBlendedRenderable? stroke)
+    {
+        if (fill != null) fill.Blend = value;
+        if (stroke != null) stroke.Blend = value;
+    }
+
+    /// <summary>
+    /// Result of <see cref="Compute"/>: values ready to push onto the stroke/fill slots in
+    /// <c>PreRender</c>. <see cref="FillInset"/> is intentionally unnamed after either
+    /// <c>FillRadiusInset</c> (Circle) or <c>FillInset</c> (Rectangle) — the caller assigns it to
+    /// its own differently-named property.
+    /// </summary>
+    public readonly struct Result
+    {
+        /// <summary>AA-compensated stroke width, ready to push to the stroke slot's <c>StrokeWidth</c>.</summary>
+        public float StrokeWidth { get; init; }
+
+        /// <summary>ScreenPixel-scaled dash length, ready to push to a dash-capable stroke slot.</summary>
+        public float DashLength { get; init; }
+
+        /// <summary>ScreenPixel-scaled gap length, ready to push to a dash-capable stroke slot.</summary>
+        public float GapLength { get; init; }
+
+        /// <summary>Fill inset value, ready to push to the fill slot's radius/edge inset property.</summary>
+        public float FillInset { get; init; }
+    }
+
+    /// <summary>
+    /// Computes the AA-compensated stroke width, the ScreenPixel-scaled dash/gap lengths, and
+    /// the fill-inset value shared by <see cref="CircleRuntime.PreRender"/> and
+    /// <see cref="RectangleRuntime.PreRender"/>. Body is today's <c>PreRender</c> math verbatim
+    /// (both runtimes agreed byte-for-byte before this extraction).
+    /// </summary>
+    /// <param name="strokeWidth">The user-set stroke width (runtime's <c>_strokeWidth</c> field), in <paramref name="strokeWidthUnits"/>.</param>
+    /// <param name="strokeDashLength">The user-set dash length, in <paramref name="strokeWidthUnits"/>.</param>
+    /// <param name="strokeGapLength">The user-set gap length, in <paramref name="strokeWidthUnits"/>.</param>
+    /// <param name="strokeWidthUnits">Unit of measurement for <paramref name="strokeWidth"/> / dash / gap.</param>
+    /// <param name="isAntialiased">The runtime's <c>IsAntialiased</c> value.</param>
+    /// <param name="strokeSupportsAntialiasing">Whether the stroke slot implements <see cref="IAntialiasedRenderable"/>.</param>
+    /// <param name="cameraZoom">Current camera zoom (1 when there is no camera).</param>
+    /// <param name="strokeColorAlpha">The stroke slot's current color alpha, gating the fill inset.</param>
+    public static Result Compute(
+        float strokeWidth, float strokeDashLength, float strokeGapLength,
+        DimensionUnitType strokeWidthUnits, bool isAntialiased, bool strokeSupportsAntialiasing,
+        float cameraZoom, byte strokeColorAlpha)
+    {
+        // Issue #2834/#2938 — the fill-inset gate below must read the ORIGINAL, unscaled
+        // user-set stroke width (not the post-ScreenPixel-scaled local reassigned just below).
+        // Capture it before the division so the gate is unaffected by ScreenPixel/zoom.
+        float userStrokeWidth = strokeWidth;
+
+        if (strokeWidthUnits == DimensionUnitType.ScreenPixel)
+        {
+            // Mirrors AposShapeRuntime.PreRender — dash and gap scale alongside stroke
+            // width so a "1 px dotted" pattern stays 1 px on screen regardless of zoom.
+            // (Dividing by cameraZoom is a no-op when there is no camera, since callers resolve
+            // cameraZoom to 1f in that case — no separate "camera != null" guard needed here.)
+            strokeWidth /= cameraZoom;
+            strokeDashLength /= cameraZoom;
+            strokeGapLength /= cameraZoom;
+        }
+
+        // Two distinct cases for what to push to the renderable's StrokeWidth — don't collapse
+        // them, the difference is load-bearing:
+        //
+        // 1. User explicitly set StrokeWidth <= 0 → push a literal 0 (#2950 follow-up).
+        //    StrokeWidth = 0 is the canonical hide-stroke gate since #2938 made StrokeColor
+        //    non-nullable, so the user wants NO stroke at all. The renderable's
+        //    HasVisibleOutput predicate then short-circuits Render to skip the stroke-slot
+        //    draw entirely. **Do NOT route this case through the AA-compensation path
+        //    below** — the epsilon floor would push 0.01, the renderable's HasVisibleOutput
+        //    would return true (StrokeWidth > 0), and Apos's 1 px AA fringe would render a
+        //    hairline of stroke color the user thought they had disabled.
+        //
+        // 2. User set a positive StrokeWidth → subtract the 1 px Apos AA contribution
+        //    (#2790). Apos.Shapes' DrawCircle/DrawRectangle renders aaSize pixels of AA halo
+        //    OUTSIDE the nominal thickness; Render passes aaSize = 1 when IsAntialiased is
+        //    true. Skia fits AA WITHIN the thickness, so the same user-set StrokeWidth would
+        //    otherwise read 1 px wider on Apos than on Skia. The result is floored at a tiny
+        //    positive epsilon — NOT to hide a "0 means don't draw" case (that's handled above
+        //    by case 1), but to keep thin strokes like StrokeWidth = 1 visible: after
+        //    subtracting the AA contribution the math would be 0, which Apos refuses to draw
+        //    even with aaSize > 0. The epsilon push pairs with the 1 px AA halo to produce the
+        //    intended ~1 px visible stroke. Gated by strokeSupportsAntialiasing so the core
+        //    stroke default (no AA concept) still receives the raw value.
+        const float aposAaContribution = 1f;
+        const float aposMinThicknessEpsilon = 0.01f;
+        // Issue #2936 — aposAaContribution is in SCREEN pixels (Apos's hardcoded 1 px AA
+        // halo). Convert to world units before mixing with strokeWidth, which has already been
+        // resolved to world units above. At cameraZoom = 1 this is a no-op (original #2790
+        // behavior preserved); at cameraZoom > 1 the world value shrinks proportionally, which
+        // is what closes the gap below.
+        float aposAaContributionWorld = aposAaContribution / cameraZoom;
+
+        float renderableStrokeWidth;
+        if (strokeWidth <= 0)
+        {
+            renderableStrokeWidth = 0f;
+        }
+        else if (isAntialiased && strokeSupportsAntialiasing)
+        {
+            renderableStrokeWidth = Math.Max(aposMinThicknessEpsilon, strokeWidth - aposAaContributionWorld);
+        }
+        else
+        {
+            renderableStrokeWidth = strokeWidth;
+        }
+
+        // Issue #2834 — when both slots are visible, compute a radius/edge inset for the fill so
+        // its rendered outer AA halo sits inside the stroke's opaque band. Two separate
+        // antialiased Apos draws at the same radius composite their AA pixels, producing a red
+        // fringe outside the white stroke (the Apos symptom; Skia shows a mirror-image pink
+        // halo on the inside).
+        //
+        // Inset per side = max(renderableStrokeWidth, aposAaContribution when AA on).
+        // renderableStrokeWidth alone aligns fine for thick strokes, but hairline (1 px)
+        // strokes push a sub-pixel epsilon to Apos so the AA halo (still ~1 px) dominates and
+        // would re-create the overlap without the floor.
+        //
+        // Gated on stroke visibility: alpha 0 OR StrokeWidth 0 means the stroke isn't drawn,
+        // and inset would render a thin background ring/gap where the stroke would have been.
+        // Issue #2938 made StrokeWidth = 0 the canonical hide-stroke gate (StrokeColor is now
+        // non-nullable); the alpha guard stays as the pre-existing #2834 path.
+        float fillInset = 0f;
+        if (strokeColorAlpha > 0 && userStrokeWidth > 0)
+        {
+            fillInset = renderableStrokeWidth;
+            if (isAntialiased && strokeSupportsAntialiasing)
+            {
+                // #2936: aaContribution in WORLD units (= 1 screen px / zoom). At Zoom > 1 this
+                // is < 1 world unit, so the inset no longer over-shrinks the fill relative to
+                // the visible stroke band's inward extent.
+                fillInset = Math.Max(fillInset, aposAaContributionWorld);
+            }
+        }
+
+        return new Result
+        {
+            StrokeWidth = renderableStrokeWidth,
+            DashLength = strokeDashLength,
+            GapLength = strokeGapLength,
+            FillInset = fillInset,
+        };
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- Follow-up to #3427. `IsAntialiased`/`StrokeDashLength`/`StrokeGapLength` turned out to be plain backing-field properties with no push logic of their own (the push happens once in `PreRender`) — not touched, wrapping them in a struct would've added indirection with nothing to consolidate.
- The real duplication was `PreRender`'s stroke-width AA-compensation math, dash/gap ScreenPixel scaling, and fill-inset calculation (near-byte-identical between `CircleRuntime`/`RectangleRuntime`), plus `Blend`'s immediate push-to-both-slots. Extracted into a new `ShapeStrokePreRenderMath` **static class** — not a struct like `ShapeGradientState`/`ShapeDropshadowState`, since this is pure computation with no state that needs to survive `Clone()`.
- `RectangleRuntime`'s corner-radius block and each shape's differently-named final fill-inset assignment (`FillRadiusInset` vs `FillInset` — genuinely different renderable members, not naming drift) stay untouched and per-shape.
- Pure refactor, no intended behavior change.

## Test plan
- [x] `dotnet test MonoGameGum.Tests/MonoGameGum.Tests.csproj --filter "CircleRuntimeTests|RectangleRuntimeTests"` — 33/33 pass
- [x] `dotnet test Tests/MonoGameGum.Shapes.Tests/MonoGameGum.Shapes.Tests.csproj --filter "CircleRuntimeTests|RectangleRuntimeTests"` — 119/119 pass (covers `Blend_ForwardsToBothSlots`, `FillRadiusInset_*`/`FillInset_*` AA/hairline/invisible-stroke cases, dash/gap ScreenPixel scaling, `IsAntialiased_PushedViaPreRender_*`, `StrokeWidth_AaOn_*`, `CornerRadiusUnits_ScreenPixel_*`)
- [x] `dotnet test Tests/RaylibGum.Tests/RaylibGum.Tests.csproj --filter "CircleRuntimeTests|RectangleRuntimeTests"` — 50/50 pass, unchanged
- [x] `Runtimes/SkiaGum/SkiaGum.csproj` builds clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)