### PR TITLE
Fix FRB build break from #3413 font-cache refactor (guard symmetry)

### DIFF
--- a/.claude/agents/coder.md
+++ b/.claude/agents/coder.md
@@ -75,6 +75,14 @@ Gating pattern:
 
 Don't `#if` away entire types or methods unless you've confirmed no caller references them across targets — that's a much harder refactor.
 
+## Guard symmetry — a member behind `#if !FRB` cannot be called from shared un-guarded code
+
+The mirror of the rule above, and the single most common way a Gum change silently breaks FRB1: you add a method/property behind `#if !FRB` (e.g. on `TextRuntime`, which does not exist under FRB — FRB uses `GraphicalUiElement` directly), then call it from **shared** code that compiles under both FRB and non-FRB. The non-FRB build is green, so the break is invisible until the FRB canary runs — which is exactly what CI does not gate on. This broke FRB in #3413 (`GetFontCacheFileName`/`CopyFontGenerationFieldsTo`).
+
+So whenever you add or move a member behind **any** platform `#if` (`!FRB`, `!RAYLIB`, `XNALIKE`, etc.):
+1. `grep` for every call site of that member. If any lives in un-guarded shared source, the call site must be guarded too **or** you must provide a same-named shim for the excluded platform (an FRB-only extension method on `GraphicalUiElement` is the established pattern — see `CustomSetPropertyOnRenderable.cs`).
+2. Run the FRB canary build (`frb-build-verification` skill) from the **primary checkout** before finishing — it is the only build that exercises the `#if FRB` path, and worktrees cannot run it.
+
 # Test-Driven Development (Required)
 
 **For new features: you must TDD.** Write a failing test that captures the desired behavior, then implement to make it pass.

--- a/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
+++ b/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
@@ -2390,3 +2390,46 @@ public class CustomSetPropertyOnRenderable
     }
 #endif
 }
+
+#if FRB
+// FRB compiles Gum source without a TextRuntime, so the shared font-loading code above uses
+// GraphicalUiElement directly and cannot see TextRuntime's font-cache helpers (which live behind
+// #if !FRB). These extension methods provide the same helpers on GraphicalUiElement for the FRB
+// build. FRB's GraphicalUiElement has no dropshadow font properties, so dropshadow is intentionally
+// omitted here (matching the pre-#3413 inline behavior on FRB).
+internal static class FrbGraphicalUiElementFontExtensions
+{
+    internal static string GetFontCacheFileName(this GraphicalUiElement textRuntime, string? fontFilePath)
+    {
+        return BmfcSave.GetFontCacheFileNameFor(
+            textRuntime.FontSize,
+            textRuntime.Font,
+            textRuntime.OutlineThickness,
+            textRuntime.UseFontSmoothing,
+            textRuntime.IsItalic,
+            textRuntime.IsBold,
+            fontFilePath);
+    }
+
+    internal static void CopyFontGenerationFieldsTo(this GraphicalUiElement textRuntime,
+        BmfcSave bmfcSave, string? resolvedFontFilePath)
+    {
+        bmfcSave.FontSize = textRuntime.FontSize;
+        bmfcSave.OutlineThickness = textRuntime.OutlineThickness;
+        bmfcSave.UseSmoothing = textRuntime.UseFontSmoothing;
+        bmfcSave.IsItalic = textRuntime.IsItalic;
+        bmfcSave.IsBold = textRuntime.IsBold;
+
+        if (resolvedFontFilePath != null)
+        {
+            bmfcSave.FontFile = resolvedFontFilePath;
+            bmfcSave.FontName = System.IO.Path.GetFileNameWithoutExtension(resolvedFontFilePath);
+        }
+        else
+        {
+            bmfcSave.FontName = textRuntime.Font;
+            bmfcSave.FontFile = null;
+        }
+    }
+}
+#endif


### PR DESCRIPTION
## Problem

A Gum change broke the FRB (FlatRedBall) build:

```
CustomSetPropertyOnRenderable.cs(1540,47): error CS1061: 'GraphicalUiElement' does not contain a definition for 'GetFontCacheFileName' ...
CustomSetPropertyOnRenderable.cs(1559,37): error CS1061: 'GraphicalUiElement' does not contain a definition for 'CopyFontGenerationFieldsTo' ...
CustomSetPropertyOnRenderable.cs(2239,55): error CS1061: 'GraphicalUiElement' does not contain a definition for 'GetFontCacheFileName' ...
```

## Root cause (trace)

Commit `81dcbc3fc` — *"Expose KernSmith baked text drop shadows at runtime (#2724). (#3413)"* — refactored three inline `BmfcSave.GetFontCacheFileNameFor(...)` / `bmfcSave.Font* = ...` blocks into two new `TextRuntime` methods, `GetFontCacheFileName` and `CopyFontGenerationFieldsTo`, both behind `#if !FRB`.

But the call sites live in **shared** `CustomSetPropertyOnRenderable.cs`, which FRB1 compiles into `GumCore.DesktopGlNet6`. Under `#if FRB` there is no `TextRuntime`, so `textRuntime` is a `GraphicalUiElement` — which has no such methods. The non-FRB build was green, so the break merged unnoticed. This is the textbook "`#if !FRB` member called from un-guarded shared code" failure the `frb-build-verification` skill warns about; the skill just wasn't run for #3413, and CI does not gate on the FRB canary.

## Fix

Add FRB-only extension-method shims on `GraphicalUiElement` (`GetFontCacheFileName` / `CopyFontGenerationFieldsTo`) that mirror the non-FRB `TextRuntime` helpers **minus dropshadow** — FRB's `GraphicalUiElement` has no dropshadow font properties, so this restores exactly the pre-#3413 FRB behavior. The three shared call sites are unchanged.

Verified: FRB canary `GumCore.DesktopGlNet6.csproj` builds green (0 errors) from the primary checkout against the sibling FlatRedBall repo. Non-FRB is untouched (the shim is entirely `#if FRB`).

## Never-again

Added a **guard-symmetry** rule to `.claude/agents/coder.md`: when adding/moving a member behind any platform `#if`, grep its call sites and guard them (or provide a shim for the excluded platform), then run the FRB canary from the primary checkout before finishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
