### PR TITLE
Themes: mutable XyzStyling.ActiveStyle for Editor + fix missing Accent sync (part of theme palette redesign)

### DIFF
--- a/Tests/Gum.Themes.Tests/FourTokenGuardrailTests.cs
+++ b/Tests/Gum.Themes.Tests/FourTokenGuardrailTests.cs
@@ -1,6 +1,7 @@
 using System.Reflection;
 using Gum.Themes.Bubblegum;
 using Gum.Themes.DarkPro;
+using Gum.Themes.Editor;
 using Microsoft.Xna.Framework;
 using Shouldly;
 using V3Styling = Gum.Forms.DefaultVisuals.V3.Styling;
@@ -20,6 +21,7 @@ public class FourTokenGuardrailTests
     {
         yield return new object[] { typeof(DarkProColors), "DarkProColors" };
         yield return new object[] { typeof(BubblegumColors), "BubblegumColors" };
+        yield return new object[] { typeof(EditorColors), "EditorColors" };
     }
 
     [Theory]
@@ -73,6 +75,27 @@ public class FourTokenGuardrailTests
         BubblegumStyling.ActiveStyle.Colors.Accent = accent;
 
         BubblegumTheme.ConfigureStyling();
+
+        V3Styling.ActiveStyle.Colors.TextPrimary.ShouldBe(textPrimary);
+        V3Styling.ActiveStyle.Colors.TextMuted.ShouldBe(textMuted);
+        V3Styling.ActiveStyle.Colors.Primary.ShouldBe(primary);
+        V3Styling.ActiveStyle.Colors.Accent.ShouldBe(accent);
+    }
+
+    [Fact]
+    public void EditorTheme_ConfigureStyling_SyncsFourGuardrailTokensIntoV3Styling()
+    {
+        Color textPrimary = new Color(13, 24, 35);
+        Color textMuted = new Color(46, 57, 68);
+        Color primary = new Color(79, 90, 101);
+        Color accent = new Color(102, 112, 122);
+
+        EditorStyling.ActiveStyle.Colors.TextPrimary = textPrimary;
+        EditorStyling.ActiveStyle.Colors.TextMuted = textMuted;
+        EditorStyling.ActiveStyle.Colors.Primary = primary;
+        EditorStyling.ActiveStyle.Colors.Accent = accent;
+
+        EditorTheme.ConfigureStyling();
 
         V3Styling.ActiveStyle.Colors.TextPrimary.ShouldBe(textPrimary);
         V3Styling.ActiveStyle.Colors.TextMuted.ShouldBe(textMuted);

--- a/Tests/Gum.Themes.Tests/Gum.Themes.Tests.csproj
+++ b/Tests/Gum.Themes.Tests/Gum.Themes.Tests.csproj
@@ -21,6 +21,7 @@
     <ProjectReference Include="..\MonoGameGum.TestsCommon\MonoGameGum.TestsCommon.csproj" />
     <ProjectReference Include="..\..\Themes\Gum.Themes.DarkPro.MonoGame\Gum.Themes.DarkPro.MonoGame.csproj" />
     <ProjectReference Include="..\..\Themes\Gum.Themes.Bubblegum.MonoGame\Gum.Themes.Bubblegum.MonoGame.csproj" />
+    <ProjectReference Include="..\..\Themes\Gum.Themes.Editor.MonoGame\Gum.Themes.Editor.MonoGame.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Themes/Gum.Themes.Editor.MonoGame/ButtonVisual.cs
+++ b/Themes/Gum.Themes.Editor.MonoGame/ButtonVisual.cs
@@ -35,13 +35,13 @@ public class ButtonVisual : BaseButtonVisual
         this.States.Highlighted.Apply += () =>
         {
             rectangle.Visible = true;
-            rectangle.StrokeColor = new Color(150, 150, 150);
+            rectangle.StrokeColor = EditorStyling.ActiveStyle.Colors.BorderHover;
         };
         this.States.Pushed.Apply += () =>
         {
             rectangle.Visible = true;
 
-            rectangle.StrokeColor = new Color(255, 255, 255);
+            rectangle.StrokeColor = EditorStyling.ActiveStyle.Colors.BorderPushed;
         };
         this.States.Disabled.Apply += () =>
         {

--- a/Themes/Gum.Themes.Editor.MonoGame/CheckBoxVisual.cs
+++ b/Themes/Gum.Themes.Editor.MonoGame/CheckBoxVisual.cs
@@ -30,23 +30,23 @@ public class CheckBoxVisual : BaseCheckBoxVisual
         this.States.HighlightedOn.Apply += () =>
         {
             rectangle.Visible = true;
-            rectangle.StrokeColor = new Color(150, 150, 150);
+            rectangle.StrokeColor = EditorStyling.ActiveStyle.Colors.BorderHover;
         };
         this.States.HighlightedOff.Apply += () =>
         {
             rectangle.Visible = true;
-            rectangle.StrokeColor = new Color(150, 150, 150);
+            rectangle.StrokeColor = EditorStyling.ActiveStyle.Colors.BorderHover;
         };
 
         this.States.PushedOn.Apply += () =>
         {
             rectangle.Visible = true;
-            rectangle.StrokeColor = new Color(255, 255, 255);
+            rectangle.StrokeColor = EditorStyling.ActiveStyle.Colors.BorderPushed;
         };
         this.States.PushedOff.Apply += () =>
         {
             rectangle.Visible = true;
-            rectangle.StrokeColor = new Color(255, 255, 255);
+            rectangle.StrokeColor = EditorStyling.ActiveStyle.Colors.BorderPushed;
         };
 
         this.States.DisabledOn.Apply += () =>

--- a/Themes/Gum.Themes.Editor.MonoGame/ComboBoxVisual.cs
+++ b/Themes/Gum.Themes.Editor.MonoGame/ComboBoxVisual.cs
@@ -20,7 +20,7 @@ public class ComboBoxVisual : BaseComboBoxVisual
 
         this.FocusedIndicator.Parent = null;
 
-        DropdownIndicatorColor = Styling.ActiveStyle.Colors.TextPrimary;
+        DropdownIndicatorColor = EditorStyling.ActiveStyle.Colors.TextPrimary;
 
         this.States.Enabled.Apply += () =>
         {
@@ -29,12 +29,12 @@ public class ComboBoxVisual : BaseComboBoxVisual
         this.States.Highlighted.Apply += () =>
         {
             rectangle.Visible = true;
-            rectangle.StrokeColor = new Color(150, 150, 150);
+            rectangle.StrokeColor = EditorStyling.ActiveStyle.Colors.BorderHover;
         };
         this.States.Pushed.Apply += () =>
         {
             rectangle.Visible = true;
-            rectangle.StrokeColor = new Color(255, 255, 255);
+            rectangle.StrokeColor = EditorStyling.ActiveStyle.Colors.BorderPushed;
         };
         this.States.Disabled.Apply += () =>
         {

--- a/Themes/Gum.Themes.Editor.MonoGame/EditorStyling.cs
+++ b/Themes/Gum.Themes.Editor.MonoGame/EditorStyling.cs
@@ -1,0 +1,116 @@
+#if RAYLIB
+using Raylib_cs;
+#else
+using Microsoft.Xna.Framework;
+#endif
+
+namespace Gum.Themes.Editor;
+
+/// <summary>
+/// Root of the Editor theme's mutable per-theme styling. Mutate
+/// <see cref="ActiveStyle"/>'s <see cref="Colors"/>/<see cref="Text"/> before calling
+/// <see cref="EditorTheme.Apply"/> to restyle the theme without forking its source —
+/// mirrors the "mutate before construct" ordering of Gum's own
+/// <see cref="Gum.Forms.DefaultVisuals.V3.Styling.ActiveStyle"/>.
+/// </summary>
+public class EditorStyling
+{
+    /// <summary>
+    /// The active Editor styling instance. Get-only from outside this assembly so ordinary
+    /// code can't construct a second instance and forget to activate it; still a settable
+    /// property internally so a future theme-variant loader has a path to replace it.
+    /// </summary>
+    public static EditorStyling ActiveStyle { get; private set; } = new();
+
+    public EditorColors Colors { get; } = new();
+    public EditorText Text { get; } = new();
+}
+
+/// <summary>
+/// Centralized color tokens for the Editor theme. Editor previously had no palette class at
+/// all — every visual inlined its own <c>new Color(...)</c> literals. These properties collect
+/// the literals that were duplicated across two or more call sites (plus the 4-token guardrail,
+/// which every theme's <c>Colors</c> must expose regardless of duplication — see below). Values
+/// that appeared only once (e.g. the PropertyGridVisual row-stripe colors, ExpanderVisual's
+/// header fill) were left as local literals; they aren't part of a shared vocabulary yet.
+/// </summary>
+public class EditorColors
+{
+    // --- 4-token guardrail -------------------------------------------------
+    // Every theme's Apply()/ConfigureStyling() pushes these into V3.Styling.ActiveStyle.Colors
+    // for the stock, un-subclassed V3 visuals (e.g. Label) Editor leaves in place. Editor never
+    // had its own distinct vocabulary before this migration, so these are the theme's real,
+    // settable tokens directly (no alias indirection needed, unlike DarkPro/Bubblegum which
+    // already had differently-named equivalents to alias).
+
+    /// <summary>Primary text color. Previously inlined in <c>EditorTheme.Apply</c>.</summary>
+    public Color TextPrimary { get; set; } = new Color(180, 180, 180);
+
+    /// <summary>Muted / secondary text color. Previously inlined in <c>EditorTheme.Apply</c>.</summary>
+    public Color TextMuted { get; set; } = new Color(88, 88, 88);
+
+    /// <summary>
+    /// Primary surface/border gray. Previously inlined in <c>EditorTheme.Apply</c>
+    /// (<c>styling.Colors.Primary</c>) and also used directly as the resting-state stroke/fill
+    /// color on <c>ListBoxVisual</c>'s border and <c>ScrollBarVisual</c>'s thumb.
+    /// </summary>
+    public Color Primary { get; set; } = new Color(60, 60, 60);
+
+    /// <summary>
+    /// Accent — focus ring / caret. Previously inlined twice in <c>TextBoxVisual</c>
+    /// (<c>CaretColor</c> and the Focused-state outline stroke) but never pushed into
+    /// <c>V3.Styling.ActiveStyle.Colors.Accent</c> — see the Accent-sync bug fix in
+    /// <see cref="EditorTheme.ConfigureStyling"/>.
+    /// </summary>
+    public Color Accent { get; set; } = new Color(192, 222, 255);
+
+    // --- Additional deduplicated tokens -------------------------------------
+
+    /// <summary>
+    /// Hover/highlighted outline stroke. Previously inlined in <c>ButtonVisual</c>,
+    /// <c>CheckBoxVisual</c> (both On/Off), <c>ComboBoxVisual</c>, and <c>TextBoxVisual</c>'s
+    /// Highlighted-state stroke.
+    /// </summary>
+    public Color BorderHover { get; set; } = new Color(150, 150, 150);
+
+    /// <summary>
+    /// Pushed/pressed outline stroke. Previously inlined in <c>ButtonVisual</c>,
+    /// <c>CheckBoxVisual</c> (both On/Off), and <c>ComboBoxVisual</c>.
+    /// </summary>
+    public Color BorderPushed { get; set; } = new Color(255, 255, 255);
+
+    /// <summary>
+    /// Selected/highlighted background fill. Previously inlined in
+    /// <c>ListBoxItemVisual.SelectedBackgroundColor</c> and
+    /// <c>TextBoxVisual.SelectionBackgroundColor</c>.
+    /// </summary>
+    public Color Selection { get; set; } = new Color(0, 92, 128);
+
+    /// <summary>
+    /// Panel/container background. Previously inlined in <c>ListBoxVisual.BackgroundColor</c>
+    /// and <c>ScrollViewerVisual.BackgroundColor</c>.
+    /// </summary>
+    public Color PanelBackground { get; set; } = new Color(27, 27, 27);
+
+    /// <summary>
+    /// Recessed/sunken background — the darkest surface, used for content wells. Previously
+    /// inlined in <c>ScrollBarVisual.TrackBackgroundColor</c> and
+    /// <c>TextBoxVisual.BackgroundColor</c>.
+    /// </summary>
+    public Color RecessedBackground { get; set; } = new Color(10, 10, 10);
+}
+
+/// <summary>
+/// Font selection for the Editor theme. Unlike the other shipped themes, Editor never bundles
+/// or registers a TTF — it uses the host platform's system font ("Arial") as-is, so there is no
+/// registration/selection split (no fixed internal <c>Bundled*FontFamily</c> constant) and no
+/// icon font: <see cref="FontFamily"/> is just a plain, freely reassignable string.
+/// </summary>
+public class EditorText
+{
+    /// <summary>Family visuals use for body/control text. Defaults to the system "Arial" font.</summary>
+    public string FontFamily { get; set; } = "Arial";
+
+    /// <summary>Default text size used by the theme. Matches the pre-migration literal (15px).</summary>
+    public int FontSize { get; set; } = 15;
+}

--- a/Themes/Gum.Themes.Editor.MonoGame/EditorTheme.cs
+++ b/Themes/Gum.Themes.Editor.MonoGame/EditorTheme.cs
@@ -28,32 +28,7 @@ public static class EditorTheme
         // Register special characters used by editor theme visuals (e.g., ExpanderVisual arrows)
         BmfcSave.AddCharacters("►▼");
 
-        var styling = Styling.ActiveStyle;
-
-        styling.Text.Normal.Clear();
-        styling.Text.Normal.Variables.Add(
-            new VariableSave { Name = "Font", Type = "string", Value = "Arial" });
-        styling.Text.Normal.Variables.Add(
-            new VariableSave { Name = "FontSize", Type = "int", Value = 15 });
-        styling.Text.Normal.Variables.Add(
-            new VariableSave { Name = "IsBold", Type = "bool", Value = false });
-        styling.Text.Normal.Variables.Add(
-            new VariableSave { Name = "IsItalic", Type = "bool", Value = false });
-
-        styling.Text.Strong.Clear();
-        styling.Text.Strong.Variables.Add(
-            new VariableSave { Name = "Font", Type = "string", Value = "Arial" });
-        styling.Text.Strong.Variables.Add(
-            new VariableSave { Name = "FontSize", Type = "int", Value = 15 });
-        styling.Text.Strong.Variables.Add(
-            new VariableSave { Name = "IsBold", Type = "bool", Value = true });
-        styling.Text.Strong.Variables.Add(
-            new VariableSave { Name = "IsItalic", Type = "bool", Value = false });
-
-        styling.Colors.TextPrimary = new Color(180, 180, 180);
-        styling.Colors.TextMuted = new Color(88, 88, 88);
-
-        styling.Colors.Primary = new Color(60, 60, 60);
+        ConfigureStyling();
 
         RegisterVisuals();
     }
@@ -66,6 +41,45 @@ public static class EditorTheme
     /// </summary>
     public static void Apply(GraphicsDevice graphicsDevice) => Apply();
 #endif
+
+    // Internal (not private) so Tests/Gum.Themes.Tests can exercise the guardrail-token sync
+    // (TextPrimary/TextMuted/Primary/Accent → V3.Styling.ActiveStyle.Colors) without going
+    // through Apply(), which requires a real GraphicsDevice for font wiring and can't run
+    // headlessly in a unit test. See Gum.Themes.Editor.MonoGame.csproj's InternalsVisibleTo.
+    internal static void ConfigureStyling()
+    {
+        Styling styling = Styling.ActiveStyle;
+        EditorText text = EditorStyling.ActiveStyle.Text;
+
+        styling.Text.Normal.Clear();
+        styling.Text.Normal.Variables.Add(
+            new VariableSave { Name = "Font", Type = "string", Value = text.FontFamily });
+        styling.Text.Normal.Variables.Add(
+            new VariableSave { Name = "FontSize", Type = "int", Value = text.FontSize });
+        styling.Text.Normal.Variables.Add(
+            new VariableSave { Name = "IsBold", Type = "bool", Value = false });
+        styling.Text.Normal.Variables.Add(
+            new VariableSave { Name = "IsItalic", Type = "bool", Value = false });
+
+        styling.Text.Strong.Clear();
+        styling.Text.Strong.Variables.Add(
+            new VariableSave { Name = "Font", Type = "string", Value = text.FontFamily });
+        styling.Text.Strong.Variables.Add(
+            new VariableSave { Name = "FontSize", Type = "int", Value = text.FontSize });
+        styling.Text.Strong.Variables.Add(
+            new VariableSave { Name = "IsBold", Type = "bool", Value = true });
+        styling.Text.Strong.Variables.Add(
+            new VariableSave { Name = "IsItalic", Type = "bool", Value = false });
+
+        EditorColors colors = EditorStyling.ActiveStyle.Colors;
+        styling.Colors.TextPrimary = colors.TextPrimary;
+        styling.Colors.TextMuted = colors.TextMuted;
+        styling.Colors.Primary = colors.Primary;
+        // Bug fix: Editor previously omitted this line, so V3.Styling.ActiveStyle.Colors.Accent
+        // never got the theme's accent color — the only one of the 9 shipped themes with this
+        // gap. See FourTokenGuardrailTests.EditorTheme_ConfigureStyling_SyncsFourGuardrailTokensIntoV3Styling.
+        styling.Colors.Accent = colors.Accent;
+    }
 
     private static void RegisterVisuals()
     {

--- a/Themes/Gum.Themes.Editor.MonoGame/Gum.Themes.Editor.MonoGame.csproj
+++ b/Themes/Gum.Themes.Editor.MonoGame/Gum.Themes.Editor.MonoGame.csproj
@@ -39,4 +39,10 @@
     <ProjectReference Include="..\..\GumCommon\GumCommon.csproj" />
     <ProjectReference Include="..\..\MonoGameGum\MonoGameGum.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <!-- Lets Tests/Gum.Themes.Tests call the internal ConfigureStyling() directly to exercise
+         the 4-token guardrail sync without going through Apply(), which needs a real
+         GraphicsDevice for font wiring and can't run headlessly in a unit test. -->
+    <InternalsVisibleTo Include="Gum.Themes.Tests" />
+  </ItemGroup>
 </Project>

--- a/Themes/Gum.Themes.Editor.MonoGame/ListBoxItemVisual.cs
+++ b/Themes/Gum.Themes.Editor.MonoGame/ListBoxItemVisual.cs
@@ -15,7 +15,7 @@ public class ListBoxItemVisual : BaseListBoxItemVisual
         base(fullInstantiation, tryCreateFormsObject)
     {
         this.HighlightedBackgroundColor = new Color(70, 70, 70);
-        this.SelectedBackgroundColor = new Color(0, 92, 128);
+        this.SelectedBackgroundColor = EditorStyling.ActiveStyle.Colors.Selection;
 
         var rectangle = new RectangleRuntime();
         this.Children.Add(rectangle);

--- a/Themes/Gum.Themes.Editor.MonoGame/ListBoxVisual.cs
+++ b/Themes/Gum.Themes.Editor.MonoGame/ListBoxVisual.cs
@@ -13,11 +13,11 @@ public class ListBoxVisual : BaseListBoxVisual
     public ListBoxVisual(bool fullInstantiation = true, bool tryCreateFormsObject = true) :
         base(fullInstantiation, tryCreateFormsObject)
     {
-        this.BackgroundColor = new Color(27, 27, 27);
+        this.BackgroundColor = EditorStyling.ActiveStyle.Colors.PanelBackground;
 
         var rectangle = new RectangleRuntime();
         Background.Children.Add(rectangle);
-        rectangle.StrokeColor = new Color(60, 60, 60);
+        rectangle.StrokeColor = EditorStyling.ActiveStyle.Colors.Primary;
         rectangle.Dock(Gum.Wireframe.Dock.Fill);
     }
 }

--- a/Themes/Gum.Themes.Editor.MonoGame/ScrollBarVisual.cs
+++ b/Themes/Gum.Themes.Editor.MonoGame/ScrollBarVisual.cs
@@ -12,7 +12,7 @@ public class ScrollBarVisual : BaseScrollBarVisual
     public ScrollBarVisual(bool fullInstantiation = true, bool tryCreateFormsObject = true) :
         base(fullInstantiation, tryCreateFormsObject)
     {
-        this.TrackBackgroundColor = new Color(10, 10, 10);
-        this.ThumbInstance.BackgroundColor = new Color(60, 60, 60);
+        this.TrackBackgroundColor = EditorStyling.ActiveStyle.Colors.RecessedBackground;
+        this.ThumbInstance.BackgroundColor = EditorStyling.ActiveStyle.Colors.Primary;
     }
 }

--- a/Themes/Gum.Themes.Editor.MonoGame/ScrollViewerVisual.cs
+++ b/Themes/Gum.Themes.Editor.MonoGame/ScrollViewerVisual.cs
@@ -17,6 +17,6 @@ public class ScrollViewerVisual : BaseScrollViewerVisual
     public ScrollViewerVisual(bool fullInstantiation = true, bool tryCreateFormsObject = true) :
         base(fullInstantiation, tryCreateFormsObject)
     {
-        this.BackgroundColor = new Color(27, 27, 27);
+        this.BackgroundColor = EditorStyling.ActiveStyle.Colors.PanelBackground;
     }
 }

--- a/Themes/Gum.Themes.Editor.MonoGame/TextBoxVisual.cs
+++ b/Themes/Gum.Themes.Editor.MonoGame/TextBoxVisual.cs
@@ -20,12 +20,12 @@ public class TextBoxVisual : BaseTextBoxVisual
 
         this.FocusedIndicator.Parent = null;
 
-        PlaceholderColor = Styling.ActiveStyle.Colors.TextMuted;
-        ForegroundColor = Styling.ActiveStyle.Colors.TextPrimary;
-        BackgroundColor = new Color(10, 10, 10);
-        SelectionBackgroundColor = new Color(0, 92, 128);
+        PlaceholderColor = EditorStyling.ActiveStyle.Colors.TextMuted;
+        ForegroundColor = EditorStyling.ActiveStyle.Colors.TextPrimary;
+        BackgroundColor = EditorStyling.ActiveStyle.Colors.RecessedBackground;
+        SelectionBackgroundColor = EditorStyling.ActiveStyle.Colors.Selection;
         SelectionInstance.Blend = Gum.RenderingLibrary.Blend.Additive;
-        CaretColor = new Color(192, 222, 255);
+        CaretColor = EditorStyling.ActiveStyle.Colors.Accent;
 
         var selectionParent = SelectionInstance.Parent;
         selectionParent.Children.Move(selectionParent.Children.IndexOf(SelectionInstance), selectionParent.Children.Count - 1);
@@ -42,13 +42,13 @@ public class TextBoxVisual : BaseTextBoxVisual
 
         States.Highlighted.Apply += () =>
         {
-            outline.StrokeColor = new Color(150, 150, 150);
+            outline.StrokeColor = EditorStyling.ActiveStyle.Colors.BorderHover;
             outline.Visible = true;
         };
 
         States.Focused.Apply += () =>
         {
-            outline.StrokeColor = new Color(192, 222, 255);
+            outline.StrokeColor = EditorStyling.ActiveStyle.Colors.Accent;
             outline.Visible = true;
         };
     }


### PR DESCRIPTION
## Summary

- Editor previously had **no palette class at all** — every visual inlined its own `new Color(...)` literals, and `EditorTheme.FontFamily` was a bare `"Arial"` literal with no font-selection surface. Adds `EditorStyling`/`EditorColors`/`EditorText` (`Themes/Gum.Themes.Editor.MonoGame/EditorStyling.cs`) following the DarkPro/Bubblegum precedent from #3439, so consumers can restyle Editor the same way: `EditorStyling.ActiveStyle.Colors.Accent = Color.Orange; EditorTheme.Apply();`.
- Collected every `new Color(...)` literal duplicated across two or more call sites in `EditorTheme.cs`/`*Visual.cs` into named `EditorColors` properties (`BorderHover`, `BorderPushed`, `Selection`, `PanelBackground`, `RecessedBackground`, plus the 4 guardrail tokens). Single-use literals (PropertyGridVisual row stripes, ExpanderVisual header fill, ListBoxItemVisual's HighlightedBackgroundColor) were left inline — not part of a shared vocabulary yet.
- `EditorText` has only `FontFamily`/`FontSize` — **no `IconFontFamily`, no `Bundled*FontFamily` constant.** Editor never registers a bundled TTF (system-font-only), so there's no registration/selection split to decouple; `FontFamily` is a plain, freely reassignable string. This is a real divergence from PR 1's DarkPro/Bubblegum pattern, not an oversight — noted in `EditorText`'s doc comment.
- **Bug fix, called out separately:** `EditorTheme.ConfigureStyling()` (formerly inlined in `Apply()`) pushed only `TextPrimary`/`TextMuted`/`Primary` into `V3.Styling.ActiveStyle.Colors` — `Accent` was never synced. Editor was the only one of the 9 shipped themes with this gap (every other theme, including the now-merged DarkPro/Bubblegum, pushes all 4). Fixed by adding `styling.Colors.Accent = colors.Accent;`, using Editor's existing `new Color(192, 222, 255)` light-blue (previously inlined twice in `TextBoxVisual.cs` as `CaretColor` and the Focused-state outline) as the accent value — the clearest existing "this is the accent" color in Editor's source.
- Extended `Tests/Gum.Themes.Tests/FourTokenGuardrailTests.cs` to cover `EditorColors`, red-first: added the guardrail sync test before the fix, confirmed it failed specifically on `Accent` (not some other cause), then fixed `ConfigureStyling()` and confirmed green.

## Test plan

- [x] `dotnet test Tests/Gum.Themes.Tests/Gum.Themes.Tests.csproj` — 6/6 passing (DarkPro + Bubblegum guardrail coverage unregressed, Editor's new coverage green)
- [x] `dotnet build Themes/Gum.Themes.Editor.MonoGame/Gum.Themes.Editor.MonoGame.csproj` — 0 errors
- [x] `dotnet build Themes/Gum.Themes.Editor.Kni/Gum.Themes.Editor.Kni.csproj` — 0 errors
- [x] `dotnet build Themes/Gum.Themes.Editor.Raylib/Gum.Themes.Editor.Raylib.csproj` — 0 errors

Manual test: not performed — unattended run, covered by Tests/Gum.Themes.Tests + the 4-token guardrail only.

Part of #3437

🤖 Generated with [Claude Code](https://claude.com/claude-code)