### PR TITLE
Fix stale palette references in themes README

### DIFF
--- a/docs/code/styling/themes/README.md
+++ b/docs/code/styling/themes/README.md
@@ -227,7 +227,7 @@ ForestGladeTheme.Apply();
 {% endtabs %}
 
 {% hint style="info" %}
-For the intended look, clear the back buffer to `ForestGladeColors.CanopyDeep`.
+For the intended look, clear the back buffer to `ForestGladeStyling.ActiveStyle.Colors.CanopyDeep`.
 {% endhint %}
 
 ### Neon
@@ -273,7 +273,7 @@ NeonTheme.Apply();
 {% endtabs %}
 
 {% hint style="info" %}
-For the intended look, clear the back buffer to `NeonColors.Background` (`#060612`).
+For the intended look, clear the back buffer to `NeonStyling.ActiveStyle.Colors.Background` (`#060612`).
 {% endhint %}
 
 ### Retro95
@@ -361,7 +361,7 @@ MeadowTheme.Apply();
 {% endtabs %}
 
 {% hint style="info" %}
-For the intended look, clear the back buffer to `MeadowColors.Cream` (`#F7EDD6`).
+For the intended look, clear the back buffer to `MeadowStyling.ActiveStyle.Colors.Cream` (`#F7EDD6`).
 {% endhint %}
 
 ### Hazard
@@ -407,7 +407,7 @@ HazardTheme.Apply();
 {% endtabs %}
 
 {% hint style="info" %}
-For the intended look, clear the back buffer to `HazardPalette.Background` (`#0A0A08`).
+For the intended look, clear the back buffer to `HazardStyling.ActiveStyle.Colors.Background` (`#0A0A08`).
 {% endhint %}
 
 ## Fonts and licensing


### PR DESCRIPTION
## Summary
- `docs/code/styling/themes/README.md` had 4 "clear the back buffer to `XyzColors.Foo`" callouts still referencing the pre-migration static palette types (`ForestGladeColors`, `NeonColors`, `MeadowColors`, `HazardPalette`), which no longer exist after #3439/#3441/#3442 migrated all 9 shipped themes to `XyzStyling.ActiveStyle.Colors`.
- This doc wasn't in scope for any of the 3 migration PRs' dispatched work, so it was missed. Fixed all 4 to the current `XyzStyling.ActiveStyle.Colors.Foo` path.

Follow-up to #3437 (already closed).

## Test plan
- [x] Docs-only change — no build/test required. Verified no remaining stale references via `git grep` across the repo.