### PR TITLE
Add theme customization checkbox + docs

### DIFF
--- a/Samples/MonoGameGumThemesShowcase/Game1.cs
+++ b/Samples/MonoGameGumThemesShowcase/Game1.cs
@@ -43,14 +43,17 @@ public class Game1 : Game
     {
         public string Name { get; }
         public Action<GraphicsDevice> Apply { get; }
-        public Color ClearColor { get; }
+        // A delegate, not a snapshot Color — some customizations change the theme's
+        // background-equivalent token (e.g. Meadow's Cream), and re-querying live is
+        // what lets the showcase's clear color follow that change.
+        public Func<Color> GetClearColor { get; }
         public Action<bool> SetCustomized { get; }
 
-        public ThemeOption(string name, Action<GraphicsDevice> apply, Color clearColor, Action<bool> setCustomized)
+        public ThemeOption(string name, Action<GraphicsDevice> apply, Func<Color> getClearColor, Action<bool> setCustomized)
         {
             Name = name;
             Apply = apply;
-            ClearColor = clearColor;
+            GetClearColor = getClearColor;
             SetCustomized = setCustomized;
         }
     }
@@ -93,15 +96,15 @@ public class Game1 : Game
         // Retro95 chrome is its Surface (battleship gray).
         _themes = new[]
         {
-            new ThemeOption("Forest Glade", ForestGladeTheme.Apply, ForestGladeStyling.ActiveStyle.Colors.CanopyDeep, SetForestGladeCustomized),
-            new ThemeOption("Neon", NeonTheme.Apply, NeonStyling.ActiveStyle.Colors.Background, SetNeonCustomized),
-            new ThemeOption("Dark Pro", DarkProTheme.Apply, DarkProStyling.ActiveStyle.Colors.Background, SetDarkProCustomized),
-            new ThemeOption("Bubblegum", BubblegumTheme.Apply, BubblegumStyling.ActiveStyle.Colors.Background, SetBubblegumCustomized),
-            new ThemeOption("Editor", EditorTheme.Apply, new Color(40, 40, 40), SetEditorCustomized),
-            new ThemeOption("Retro 95", Retro95Theme.Apply, Retro95Styling.ActiveStyle.Colors.Surface, SetRetro95Customized),
-            new ThemeOption("Hazard", HazardTheme.Apply, HazardStyling.ActiveStyle.Colors.Background, SetHazardCustomized),
-            new ThemeOption("Meadow", MeadowTheme.Apply, MeadowStyling.ActiveStyle.Colors.Cream, SetMeadowCustomized),
-            new ThemeOption("Template Theme", TemplateTheme.Apply, TemplateStyling.ActiveStyle.Colors.Background, SetTemplateCustomized),
+            new ThemeOption("Forest Glade", ForestGladeTheme.Apply, () => ForestGladeStyling.ActiveStyle.Colors.CanopyDeep, SetForestGladeCustomized),
+            new ThemeOption("Neon", NeonTheme.Apply, () => NeonStyling.ActiveStyle.Colors.Background, SetNeonCustomized),
+            new ThemeOption("Dark Pro", DarkProTheme.Apply, () => DarkProStyling.ActiveStyle.Colors.Background, SetDarkProCustomized),
+            new ThemeOption("Bubblegum", BubblegumTheme.Apply, () => BubblegumStyling.ActiveStyle.Colors.Background, SetBubblegumCustomized),
+            new ThemeOption("Editor", EditorTheme.Apply, () => new Color(40, 40, 40), SetEditorCustomized),
+            new ThemeOption("Retro 95", Retro95Theme.Apply, () => Retro95Styling.ActiveStyle.Colors.Surface, SetRetro95Customized),
+            new ThemeOption("Hazard", HazardTheme.Apply, () => HazardStyling.ActiveStyle.Colors.Background, SetHazardCustomized),
+            new ThemeOption("Meadow", MeadowTheme.Apply, () => MeadowStyling.ActiveStyle.Colors.Cream, SetMeadowCustomized),
+            new ThemeOption("Template Theme", TemplateTheme.Apply, () => TemplateStyling.ActiveStyle.Colors.Background, SetTemplateCustomized),
         };
 
         // Authoring-only "Show Customized" checkbox — survives F1/F2 screen swaps via its own
@@ -113,16 +116,8 @@ public class Game1 : Game
         _customizeCheckBox.Anchor(Anchor.TopRight);
         _customizeCheckBox.X = -20;
         _customizeCheckBox.Y = 10;
-        _customizeCheckBox.Checked += (_, _) =>
-        {
-            _themes[_currentThemeIndex].SetCustomized(true);
-            RebuildScreen();
-        };
-        _customizeCheckBox.Unchecked += (_, _) =>
-        {
-            _themes[_currentThemeIndex].SetCustomized(false);
-            RebuildScreen();
-        };
+        _customizeCheckBox.Checked += (_, _) => ApplyCustomizationToggle(true);
+        _customizeCheckBox.Unchecked += (_, _) => ApplyCustomizationToggle(false);
         _customizeCheckBox.AddToRoot();
 
         // F1: all controls. F2: screenshot panel.
@@ -132,6 +127,21 @@ public class Game1 : Game
         RebuildScreen();
 
         base.Initialize();
+    }
+
+    // Mutating a theme's Colors/Text alone isn't enough: font selection and the 4-token
+    // guardrail that colors stock, un-restyled V3 visuals (Label, etc.) are only pushed into
+    // Gum.Forms.DefaultVisuals.V3.Styling.ActiveStyle once, inside the theme's own Apply() —
+    // see ConfigureStyling() in each XyzTheme.cs. So re-calling theme.Apply() after
+    // SetCustomized() is what actually refreshes fonts and Label-style text, matching the
+    // theme's own documented "mutate before Apply()" pattern.
+    void ApplyCustomizationToggle(bool customized)
+    {
+        ThemeOption theme = _themes[_currentThemeIndex];
+        theme.SetCustomized(customized);
+        theme.Apply(GraphicsDevice);
+        _clearColor = theme.GetClearColor();
+        RebuildScreen();
     }
 
     // If Show Customized is checked when the user swaps themes, revert the previous theme's
@@ -158,7 +168,7 @@ public class Game1 : Game
         _currentThemeIndex = index;
         ThemeOption theme = _themes[index];
         theme.Apply(GraphicsDevice);
-        _clearColor = theme.ClearColor;
+        _clearColor = theme.GetClearColor();
         Window.Title = $"Gum Theme Showcase — {index + 1}. {theme.Name}  (1-{_themes.Length} swap theme, F1/F2 swap screen)";
     }
 
@@ -234,9 +244,18 @@ public class Game1 : Game
         var text = EditorStyling.ActiveStyle.Text;
         if (customized)
         {
-            colors.Accent = new Color(255, 140, 0);
-            colors.TextPrimary = new Color(235, 235, 245);
-            colors.TextMuted = new Color(140, 140, 160);
+            // Tints the whole gray chrome toward blue, not just the accent — Primary,
+            // BorderHover/BorderPushed, and the panel/recessed backgrounds all feed into
+            // the same neutral gray by default, so all four need to move together.
+            colors.Accent = new Color(140, 190, 255);
+            colors.TextPrimary = new Color(210, 220, 255);
+            colors.TextMuted = new Color(100, 110, 140);
+            colors.Primary = new Color(50, 60, 90);
+            colors.BorderHover = new Color(120, 150, 210);
+            colors.BorderPushed = new Color(220, 230, 255);
+            colors.Selection = new Color(30, 80, 200);
+            colors.PanelBackground = new Color(18, 20, 32);
+            colors.RecessedBackground = new Color(8, 10, 20);
             text.FontFamily = "Consolas";
             text.FontSize = 19;
         }
@@ -245,6 +264,12 @@ public class Game1 : Game
             colors.Accent = new Color(192, 222, 255);
             colors.TextPrimary = new Color(180, 180, 180);
             colors.TextMuted = new Color(88, 88, 88);
+            colors.Primary = new Color(60, 60, 60);
+            colors.BorderHover = new Color(150, 150, 150);
+            colors.BorderPushed = new Color(255, 255, 255);
+            colors.Selection = new Color(0, 92, 128);
+            colors.PanelBackground = new Color(27, 27, 27);
+            colors.RecessedBackground = new Color(10, 10, 10);
             text.FontFamily = "Arial";
             text.FontSize = 15;
         }
@@ -259,8 +284,11 @@ public class Game1 : Game
             colors.Accent = new Color(214, 64, 214);
             colors.Text = new Color(245, 240, 235);
             colors.Muted = new Color(150, 140, 135);
-            text.FontFamily = "Consolas";
-            text.FontSize = 18;
+            // Deliberately a serif, not another mono font — DM Mono vs. Consolas would
+            // read as "basically the same," so this picks something unmissable to
+            // demonstrate the font-swap mechanism clearly.
+            text.FontFamily = "Georgia";
+            text.FontSize = 20;
         }
         else
         {
@@ -278,9 +306,16 @@ public class Game1 : Game
         var text = BubblegumStyling.ActiveStyle.Text;
         if (customized)
         {
+            // Surface1/Background/Border/Placeholder are what TextBox actually reads for
+            // its fill/border/placeholder (see BubblegumTextInputDecoration) — Accent/Text
+            // alone only moved the caret and typed-text color, not the box itself.
             colors.Accent = new Color(40, 190, 190);
             colors.Text = new Color(20, 30, 60);
             colors.Muted = new Color(110, 120, 150);
+            colors.Surface1 = new Color(235, 250, 250);
+            colors.Background = new Color(230, 250, 248);
+            colors.Border = new Color(120, 200, 200);
+            colors.Placeholder = new Color(140, 170, 180);
             text.FontFamily = "Consolas";
             text.FontSize = 18;
         }
@@ -289,6 +324,10 @@ public class Game1 : Game
             colors.Accent = new Color(255, 107, 157);
             colors.Text = new Color(61, 17, 85);
             colors.Muted = new Color(160, 123, 176);
+            colors.Surface1 = new Color(255, 255, 255);
+            colors.Background = new Color(255, 240, 249);
+            colors.Border = new Color(240, 170, 204);
+            colors.Placeholder = new Color(201, 168, 217);
             text.FontFamily = "Nunito"; // BubblegumTheme.BundledFontFamily is internal; mirrors it
             text.FontSize = 14;
         }
@@ -322,9 +361,14 @@ public class Game1 : Game
         var text = NeonStyling.ActiveStyle.Text;
         if (customized)
         {
+            // Surface1 is what ListBoxVisual actually fills its background with; Surface2
+            // is the ListBox hover-row tint (HoverRow aliases it) — both need to move
+            // together or hovering a row looks like a mismatched leftover of the old theme.
             colors.Accent = new Color(255, 0, 200);
             colors.Text = new Color(255, 250, 200);
             colors.Muted = new Color(140, 110, 160);
+            colors.Surface1 = new Color(40, 10, 40);
+            colors.Surface2 = new Color(55, 15, 55);
             text.FontFamily = "Consolas";
             text.FontSize = 17;
         }
@@ -333,6 +377,8 @@ public class Game1 : Game
             colors.Accent = new Color(0, 229, 255);
             colors.Text = new Color(200, 250, 255);
             colors.Muted = new Color(74, 96, 128);
+            colors.Surface1 = new Color(13, 13, 34);
+            colors.Surface2 = new Color(19, 19, 48);
             text.FontFamily = "Share Tech Mono"; // NeonTheme.BundledFontFamily is internal; mirrors it
             text.FontSize = 13;
         }
@@ -344,16 +390,28 @@ public class Game1 : Game
         var text = Retro95Styling.ActiveStyle.Text;
         if (customized)
         {
+            // Surface also drives the showcase's own clear color (via GetClearColor), so
+            // this is the one theme where "tint everything" includes the window backdrop.
+            colors.Surface = new Color(0, 128, 128);
+            colors.WhiteFill = new Color(220, 255, 255);
             colors.Selection = new Color(128, 0, 32);
-            colors.Text = new Color(10, 10, 60);
+            colors.HighlightInner = new Color(150, 220, 220);
+            colors.HighlightOuter = new Color(200, 255, 255);
+            colors.ShadowInner = new Color(0, 80, 80);
+            colors.ShadowOuter = new Color(0, 50, 50);
             colors.DisabledText = new Color(110, 70, 70);
             text.FontFamily = "Consolas";
             text.FontSize = 15;
         }
         else
         {
+            colors.Surface = new Color(192, 192, 192);
+            colors.WhiteFill = new Color(255, 255, 255);
             colors.Selection = new Color(0, 0, 128);
-            colors.Text = new Color(0, 0, 0);
+            colors.HighlightInner = new Color(223, 223, 223);
+            colors.HighlightOuter = new Color(255, 255, 255);
+            colors.ShadowInner = new Color(128, 128, 128);
+            colors.ShadowOuter = new Color(64, 64, 64);
             colors.DisabledText = new Color(128, 128, 128);
             text.FontFamily = "Nunito"; // Retro95Theme.BundledFontFamily is internal; mirrors it
             text.FontSize = 13;
@@ -366,17 +424,34 @@ public class Game1 : Game
         var text = MeadowStyling.ActiveStyle.Text;
         if (customized)
         {
+            // Blue/BlueDark/BlueHover are the button's rest/pressed/hover fills — changing
+            // only Blue left the shadow and hover states stuck on the old sky-blue gradient.
+            // SageDark is the checkbox/radio checked color; PeachDark is the shared
+            // border/outline token (ListBox, input fields, dashed panels, splitter).
+            // Cream/Cream2 are the page and panel backgrounds.
             colors.Blue = new Color(230, 90, 70);
+            colors.BlueDark = new Color(150, 45, 35);
+            colors.BlueHover = new Color(245, 130, 105);
             colors.TealDark = new Color(90, 40, 80);
             colors.Muted = new Color(170, 130, 150);
+            colors.SageDark = new Color(170, 90, 140);
+            colors.PeachDark = new Color(200, 150, 175);
+            colors.Cream = new Color(238, 222, 235);
+            colors.Cream2 = new Color(245, 232, 242);
             text.FontFamily = "Consolas";
             text.FontSize = 17;
         }
         else
         {
             colors.Blue = new Color(70, 173, 230);
+            colors.BlueDark = new Color(46, 147, 210);
+            colors.BlueHover = new Color(94, 187, 240);
             colors.TealDark = new Color(30, 106, 91);
             colors.Muted = new Color(180, 156, 132);
+            colors.SageDark = new Color(132, 194, 166);
+            colors.PeachDark = new Color(239, 200, 160);
+            colors.Cream = new Color(247, 237, 214);
+            colors.Cream2 = new Color(252, 245, 230);
             text.FontFamily = "Baloo 2"; // MeadowTheme.BundledFontFamily is internal; mirrors it
             text.FontSize = 15;
         }
@@ -388,9 +463,17 @@ public class Game1 : Game
         var text = HazardStyling.ActiveStyle.Text;
         if (customized)
         {
+            // Selection is the ListBox/MenuItem selected-row fill and TextBright is its
+            // hover-row text — both defaulted to the same hazard-yellow as Accent, so only
+            // changing Accent left selected/hovered list rows still orange. AccentPressed is
+            // a separate explicit token (not derived from Accent), so the Slider thumb's
+            // pressed state was the same gap.
             colors.Accent = new Color(40, 140, 255);
             colors.Text = new Color(200, 230, 255);
             colors.Muted = new Color(90, 110, 140);
+            colors.Selection = new Color(40, 140, 255);
+            colors.TextBright = new Color(150, 200, 255);
+            colors.AccentPressed = new Color(20, 100, 200);
             text.FontFamily = "Consolas";
             text.FontSize = 17;
         }
@@ -399,6 +482,9 @@ public class Game1 : Game
             colors.Accent = new Color(244, 200, 26);
             colors.Text = new Color(227, 181, 40);
             colors.Muted = new Color(120, 102, 38);
+            colors.Selection = new Color(244, 200, 26);
+            colors.TextBright = new Color(248, 212, 59);
+            colors.AccentPressed = new Color(201, 163, 12);
             text.FontFamily = "Saira Condensed"; // HazardTheme.BundledFontFamily is internal; mirrors it
             text.FontSize = 15;
         }

--- a/Samples/MonoGameGumThemesShowcase/Game1.cs
+++ b/Samples/MonoGameGumThemesShowcase/Game1.cs
@@ -38,7 +38,7 @@ public class Game1 : Game
 
     // A selectable theme: its display name, its Apply entry point, the backdrop color the
     // showcase should clear to while it is active, and a hardcoded customize/revert action
-    // used only by the "Customize" checkbox (authoring tooling, not part of the theme itself).
+    // used only by the "Show Customized" checkbox (authoring tooling, not part of the theme itself).
     sealed class ThemeOption
     {
         public string Name { get; }
@@ -104,16 +104,12 @@ public class Game1 : Game
             new ThemeOption("Template Theme", TemplateTheme.Apply, TemplateStyling.ActiveStyle.Colors.Background, SetTemplateCustomized),
         };
 
-        // F1: all controls. F2: screenshot panel.
-        _currentScreenFactory = () => new AllControlsScreen();
-
-        ApplyTheme(0);
-        RebuildScreen();
-
-        // Authoring-only "Customize" checkbox — survives F1/F2 screen swaps via its own
-        // AddToRoot call, separate from ShowcaseScreen's root-element bookkeeping.
+        // Authoring-only "Show Customized" checkbox — survives F1/F2 screen swaps via its own
+        // AddToRoot call, separate from ShowcaseScreen's root-element bookkeeping. Created
+        // before the first RebuildScreen call below so RebuildScreen can always rely on it
+        // existing (see the re-parent-to-top comment inside RebuildScreen).
         _customizeCheckBox = new CheckBox();
-        _customizeCheckBox.Text = "Customize";
+        _customizeCheckBox.Text = "Show Customized";
         _customizeCheckBox.Anchor(Anchor.TopRight);
         _customizeCheckBox.X = -20;
         _customizeCheckBox.Y = 10;
@@ -129,10 +125,16 @@ public class Game1 : Game
         };
         _customizeCheckBox.AddToRoot();
 
+        // F1: all controls. F2: screenshot panel.
+        _currentScreenFactory = () => new AllControlsScreen();
+
+        ApplyTheme(0);
+        RebuildScreen();
+
         base.Initialize();
     }
 
-    // If Customize is checked when the user swaps themes, revert the previous theme's
+    // If Show Customized is checked when the user swaps themes, revert the previous theme's
     // customization and uncheck the box first — don't let a customization silently persist
     // onto/across a theme switch, and don't auto-apply the new theme's customization.
     void RevertCustomizationIfChecked()
@@ -163,6 +165,13 @@ public class Game1 : Game
     void RebuildScreen()
     {
         SwitchScreen(_currentScreenFactory);
+
+        // Root.Children.Add appends, and later children paint on top in Gum, so every
+        // ShowcaseScreen rebuild re-adds fresh controls AFTER _customizeCheckBox in the
+        // root's child list — burying it behind the new screen unless it's re-parented to
+        // the end again here.
+        _customizeCheckBox.RemoveFromRoot();
+        _customizeCheckBox.AddToRoot();
     }
 
     void SwitchScreen(Func<ShowcaseScreen> factory)
@@ -215,8 +224,8 @@ public class Game1 : Game
         base.Draw(gameTime);
     }
 
-    // --- Hardcoded per-theme "Customize" preview values --------------------
-    // Authoring tooling only, used by the Customize checkbox above. These values are not a
+    // --- Hardcoded per-theme "Show Customized" preview values --------------------
+    // Authoring tooling only, used by the Show Customized checkbox above. These values are not a
     // shared source of truth with any documentation example — they may drift over time.
 
     static void SetEditorCustomized(bool customized)

--- a/Samples/MonoGameGumThemesShowcase/Game1.cs
+++ b/Samples/MonoGameGumThemesShowcase/Game1.cs
@@ -1,4 +1,6 @@
 using System;
+using Gum.Forms;
+using Gum.Forms.Controls;
 using Gum.Themes.Bubblegum;
 using Gum.Themes.DarkPro;
 using Gum.Themes.Editor;
@@ -8,6 +10,7 @@ using Gum.Themes.Meadow;
 using Gum.Themes.Neon;
 using Gum.Themes.Retro95;
 using Gum.Themes.Template;
+using Gum.Wireframe;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Input;
@@ -28,19 +31,27 @@ public class Game1 : Game
     KeyboardState _previousKeyboard;
     Color _clearColor;
 
-    // A selectable theme: its display name, its Apply entry point, and the
-    // backdrop color the showcase should clear to while it is active.
+    // Authoring-only toggle (not part of the ShowcaseScreen root bookkeeping) that lets a
+    // maintainer preview a hardcoded per-theme customization before manually capturing
+    // screenshots. See ThemeOption.SetCustomized below for the per-theme values.
+    CheckBox _customizeCheckBox;
+
+    // A selectable theme: its display name, its Apply entry point, the backdrop color the
+    // showcase should clear to while it is active, and a hardcoded customize/revert action
+    // used only by the "Customize" checkbox (authoring tooling, not part of the theme itself).
     sealed class ThemeOption
     {
         public string Name { get; }
         public Action<GraphicsDevice> Apply { get; }
         public Color ClearColor { get; }
+        public Action<bool> SetCustomized { get; }
 
-        public ThemeOption(string name, Action<GraphicsDevice> apply, Color clearColor)
+        public ThemeOption(string name, Action<GraphicsDevice> apply, Color clearColor, Action<bool> setCustomized)
         {
             Name = name;
             Apply = apply;
             ClearColor = clearColor;
+            SetCustomized = setCustomized;
         }
     }
 
@@ -82,15 +93,15 @@ public class Game1 : Game
         // Retro95 chrome is its Surface (battleship gray).
         _themes = new[]
         {
-            new ThemeOption("Forest Glade", ForestGladeTheme.Apply, ForestGladeStyling.ActiveStyle.Colors.CanopyDeep),
-            new ThemeOption("Neon", NeonTheme.Apply, NeonStyling.ActiveStyle.Colors.Background),
-            new ThemeOption("Dark Pro", DarkProTheme.Apply, DarkProStyling.ActiveStyle.Colors.Background),
-            new ThemeOption("Bubblegum", BubblegumTheme.Apply, BubblegumStyling.ActiveStyle.Colors.Background),
-            new ThemeOption("Editor", EditorTheme.Apply, new Color(40, 40, 40)),
-            new ThemeOption("Retro 95", Retro95Theme.Apply, Retro95Styling.ActiveStyle.Colors.Surface),
-            new ThemeOption("Hazard", HazardTheme.Apply, HazardStyling.ActiveStyle.Colors.Background),
-            new ThemeOption("Meadow", MeadowTheme.Apply, MeadowStyling.ActiveStyle.Colors.Cream),
-            new ThemeOption("Template Theme", TemplateTheme.Apply, TemplateStyling.ActiveStyle.Colors.Background),
+            new ThemeOption("Forest Glade", ForestGladeTheme.Apply, ForestGladeStyling.ActiveStyle.Colors.CanopyDeep, SetForestGladeCustomized),
+            new ThemeOption("Neon", NeonTheme.Apply, NeonStyling.ActiveStyle.Colors.Background, SetNeonCustomized),
+            new ThemeOption("Dark Pro", DarkProTheme.Apply, DarkProStyling.ActiveStyle.Colors.Background, SetDarkProCustomized),
+            new ThemeOption("Bubblegum", BubblegumTheme.Apply, BubblegumStyling.ActiveStyle.Colors.Background, SetBubblegumCustomized),
+            new ThemeOption("Editor", EditorTheme.Apply, new Color(40, 40, 40), SetEditorCustomized),
+            new ThemeOption("Retro 95", Retro95Theme.Apply, Retro95Styling.ActiveStyle.Colors.Surface, SetRetro95Customized),
+            new ThemeOption("Hazard", HazardTheme.Apply, HazardStyling.ActiveStyle.Colors.Background, SetHazardCustomized),
+            new ThemeOption("Meadow", MeadowTheme.Apply, MeadowStyling.ActiveStyle.Colors.Cream, SetMeadowCustomized),
+            new ThemeOption("Template Theme", TemplateTheme.Apply, TemplateStyling.ActiveStyle.Colors.Background, SetTemplateCustomized),
         };
 
         // F1: all controls. F2: screenshot panel.
@@ -99,7 +110,37 @@ public class Game1 : Game
         ApplyTheme(0);
         RebuildScreen();
 
+        // Authoring-only "Customize" checkbox — survives F1/F2 screen swaps via its own
+        // AddToRoot call, separate from ShowcaseScreen's root-element bookkeeping.
+        _customizeCheckBox = new CheckBox();
+        _customizeCheckBox.Text = "Customize";
+        _customizeCheckBox.Anchor(Anchor.TopRight);
+        _customizeCheckBox.X = -20;
+        _customizeCheckBox.Y = 10;
+        _customizeCheckBox.Checked += (_, _) =>
+        {
+            _themes[_currentThemeIndex].SetCustomized(true);
+            RebuildScreen();
+        };
+        _customizeCheckBox.Unchecked += (_, _) =>
+        {
+            _themes[_currentThemeIndex].SetCustomized(false);
+            RebuildScreen();
+        };
+        _customizeCheckBox.AddToRoot();
+
         base.Initialize();
+    }
+
+    // If Customize is checked when the user swaps themes, revert the previous theme's
+    // customization and uncheck the box first — don't let a customization silently persist
+    // onto/across a theme switch, and don't auto-apply the new theme's customization.
+    void RevertCustomizationIfChecked()
+    {
+        if (_customizeCheckBox.IsChecked == true)
+        {
+            _customizeCheckBox.IsChecked = false;
+        }
     }
 
     // Installs the theme's default templates / styling and updates the
@@ -153,6 +194,7 @@ public class Game1 : Game
             {
                 if (i != _currentThemeIndex)
                 {
+                    RevertCustomizationIfChecked();
                     ApplyTheme(i);
                     RebuildScreen();
                 }
@@ -171,5 +213,207 @@ public class Game1 : Game
         GraphicsDevice.Clear(_clearColor);
         GumUI.Draw();
         base.Draw(gameTime);
+    }
+
+    // --- Hardcoded per-theme "Customize" preview values --------------------
+    // Authoring tooling only, used by the Customize checkbox above. These values are not a
+    // shared source of truth with any documentation example — they may drift over time.
+
+    static void SetEditorCustomized(bool customized)
+    {
+        var colors = EditorStyling.ActiveStyle.Colors;
+        var text = EditorStyling.ActiveStyle.Text;
+        if (customized)
+        {
+            colors.Accent = new Color(255, 140, 0);
+            colors.TextPrimary = new Color(235, 235, 245);
+            colors.TextMuted = new Color(140, 140, 160);
+            text.FontFamily = "Consolas";
+            text.FontSize = 19;
+        }
+        else
+        {
+            colors.Accent = new Color(192, 222, 255);
+            colors.TextPrimary = new Color(180, 180, 180);
+            colors.TextMuted = new Color(88, 88, 88);
+            text.FontFamily = "Arial";
+            text.FontSize = 15;
+        }
+    }
+
+    static void SetDarkProCustomized(bool customized)
+    {
+        var colors = DarkProStyling.ActiveStyle.Colors;
+        var text = DarkProStyling.ActiveStyle.Text;
+        if (customized)
+        {
+            colors.Accent = new Color(214, 64, 214);
+            colors.Text = new Color(245, 240, 235);
+            colors.Muted = new Color(150, 140, 135);
+            text.FontFamily = "Consolas";
+            text.FontSize = 18;
+        }
+        else
+        {
+            colors.Accent = new Color(0, 122, 204);
+            colors.Text = new Color(212, 212, 212);
+            colors.Muted = new Color(136, 136, 136);
+            text.FontFamily = "DM Mono"; // DarkProTheme.BundledFontFamily is internal; mirrors it
+            text.FontSize = 14;
+        }
+    }
+
+    static void SetBubblegumCustomized(bool customized)
+    {
+        var colors = BubblegumStyling.ActiveStyle.Colors;
+        var text = BubblegumStyling.ActiveStyle.Text;
+        if (customized)
+        {
+            colors.Accent = new Color(40, 190, 190);
+            colors.Text = new Color(20, 30, 60);
+            colors.Muted = new Color(110, 120, 150);
+            text.FontFamily = "Consolas";
+            text.FontSize = 18;
+        }
+        else
+        {
+            colors.Accent = new Color(255, 107, 157);
+            colors.Text = new Color(61, 17, 85);
+            colors.Muted = new Color(160, 123, 176);
+            text.FontFamily = "Nunito"; // BubblegumTheme.BundledFontFamily is internal; mirrors it
+            text.FontSize = 14;
+        }
+    }
+
+    static void SetForestGladeCustomized(bool customized)
+    {
+        var colors = ForestGladeStyling.ActiveStyle.Colors;
+        var text = ForestGladeStyling.ActiveStyle.Text;
+        if (customized)
+        {
+            colors.LeafBright = new Color(255, 105, 180);
+            colors.Text = new Color(255, 240, 245);
+            colors.Muted = new Color(200, 150, 165);
+            text.FontFamily = "Consolas";
+            text.FontSize = 18;
+        }
+        else
+        {
+            colors.LeafBright = new Color(71, 246, 65);
+            colors.Text = new Color(241, 255, 240);
+            colors.Muted = new Color(155, 186, 163);
+            text.FontFamily = "Nunito"; // ForestGladeTheme.BundledFontFamily is internal; mirrors it
+            text.FontSize = 14;
+        }
+    }
+
+    static void SetNeonCustomized(bool customized)
+    {
+        var colors = NeonStyling.ActiveStyle.Colors;
+        var text = NeonStyling.ActiveStyle.Text;
+        if (customized)
+        {
+            colors.Accent = new Color(255, 0, 200);
+            colors.Text = new Color(255, 250, 200);
+            colors.Muted = new Color(140, 110, 160);
+            text.FontFamily = "Consolas";
+            text.FontSize = 17;
+        }
+        else
+        {
+            colors.Accent = new Color(0, 229, 255);
+            colors.Text = new Color(200, 250, 255);
+            colors.Muted = new Color(74, 96, 128);
+            text.FontFamily = "Share Tech Mono"; // NeonTheme.BundledFontFamily is internal; mirrors it
+            text.FontSize = 13;
+        }
+    }
+
+    static void SetRetro95Customized(bool customized)
+    {
+        var colors = Retro95Styling.ActiveStyle.Colors;
+        var text = Retro95Styling.ActiveStyle.Text;
+        if (customized)
+        {
+            colors.Selection = new Color(128, 0, 32);
+            colors.Text = new Color(10, 10, 60);
+            colors.DisabledText = new Color(110, 70, 70);
+            text.FontFamily = "Consolas";
+            text.FontSize = 15;
+        }
+        else
+        {
+            colors.Selection = new Color(0, 0, 128);
+            colors.Text = new Color(0, 0, 0);
+            colors.DisabledText = new Color(128, 128, 128);
+            text.FontFamily = "Nunito"; // Retro95Theme.BundledFontFamily is internal; mirrors it
+            text.FontSize = 13;
+        }
+    }
+
+    static void SetMeadowCustomized(bool customized)
+    {
+        var colors = MeadowStyling.ActiveStyle.Colors;
+        var text = MeadowStyling.ActiveStyle.Text;
+        if (customized)
+        {
+            colors.Blue = new Color(230, 90, 70);
+            colors.TealDark = new Color(90, 40, 80);
+            colors.Muted = new Color(170, 130, 150);
+            text.FontFamily = "Consolas";
+            text.FontSize = 17;
+        }
+        else
+        {
+            colors.Blue = new Color(70, 173, 230);
+            colors.TealDark = new Color(30, 106, 91);
+            colors.Muted = new Color(180, 156, 132);
+            text.FontFamily = "Baloo 2"; // MeadowTheme.BundledFontFamily is internal; mirrors it
+            text.FontSize = 15;
+        }
+    }
+
+    static void SetHazardCustomized(bool customized)
+    {
+        var colors = HazardStyling.ActiveStyle.Colors;
+        var text = HazardStyling.ActiveStyle.Text;
+        if (customized)
+        {
+            colors.Accent = new Color(40, 140, 255);
+            colors.Text = new Color(200, 230, 255);
+            colors.Muted = new Color(90, 110, 140);
+            text.FontFamily = "Consolas";
+            text.FontSize = 17;
+        }
+        else
+        {
+            colors.Accent = new Color(244, 200, 26);
+            colors.Text = new Color(227, 181, 40);
+            colors.Muted = new Color(120, 102, 38);
+            text.FontFamily = "Saira Condensed"; // HazardTheme.BundledFontFamily is internal; mirrors it
+            text.FontSize = 15;
+        }
+    }
+
+    static void SetTemplateCustomized(bool customized)
+    {
+        var colors = TemplateStyling.ActiveStyle.Colors;
+        var text = TemplateStyling.ActiveStyle.Text;
+        if (customized)
+        {
+            colors.Accent = new Color(60, 200, 120);
+            colors.Text = new Color(225, 245, 235);
+            colors.Muted = new Color(130, 150, 135);
+            text.FontFamily = "Consolas";
+            text.FontSize = 17;
+        }
+        else
+        {
+            colors.Accent = new Color(0, 122, 204);
+            colors.Text = new Color(212, 212, 212);
+            colors.Muted = new Color(136, 136, 136);
+            text.FontFamily = "DM Mono"; // TemplateTheme.BundledFontFamily is internal; mirrors it
+            text.FontSize = 14;
+        }
     }
 }

--- a/Samples/MonoGameGumThemesShowcase/Game1.cs
+++ b/Samples/MonoGameGumThemesShowcase/Game1.cs
@@ -335,23 +335,37 @@ public class Game1 : Game
 
     static void SetForestGladeCustomized(bool customized)
     {
+        // No font swap here — gradients and glows are the theme's most visually
+        // load-bearing tokens, and ButtonVisual/ForestGladeButtonChrome read the
+        // Rest/Hover gradient-stop pairs and DarkShadow/GlowStrong/GlowMedium directly,
+        // independent of LeafBright. Leaving Accent/Text/Muted unchanged left the button
+        // fill, its shadow, and its hover glow all on the old green palette.
         var colors = ForestGladeStyling.ActiveStyle.Colors;
-        var text = ForestGladeStyling.ActiveStyle.Text;
         if (customized)
         {
             colors.LeafBright = new Color(255, 105, 180);
             colors.Text = new Color(255, 240, 245);
             colors.Muted = new Color(200, 150, 165);
-            text.FontFamily = "Consolas";
-            text.FontSize = 18;
+            colors.ButtonRestFillTop = new Color(255, 130, 190);
+            colors.ButtonRestFillBottom = new Color(220, 60, 140);
+            colors.ButtonHoverFillTop = new Color(255, 160, 210);
+            colors.ButtonHoverFillBottom = new Color(255, 105, 180);
+            colors.DarkShadow = new Color(60, 0, 40, 200);
+            colors.GlowStrong = new Color(255, 105, 180, 170);
+            colors.GlowMedium = new Color(255, 105, 180, 110);
         }
         else
         {
             colors.LeafBright = new Color(71, 246, 65);
             colors.Text = new Color(241, 255, 240);
             colors.Muted = new Color(155, 186, 163);
-            text.FontFamily = "Nunito"; // ForestGladeTheme.BundledFontFamily is internal; mirrors it
-            text.FontSize = 14;
+            colors.ButtonRestFillTop = new Color(15, 196, 72);
+            colors.ButtonRestFillBottom = new Color(0, 140, 46);
+            colors.ButtonHoverFillTop = new Color(44, 219, 92);
+            colors.ButtonHoverFillBottom = new Color(8, 178, 59);
+            colors.DarkShadow = new Color(0, 60, 30, 200);
+            colors.GlowStrong = new Color(71, 246, 65, 170);
+            colors.GlowMedium = new Color(71, 246, 65, 110);
         }
     }
 
@@ -467,13 +481,18 @@ public class Game1 : Game
             // hover-row text — both defaulted to the same hazard-yellow as Accent, so only
             // changing Accent left selected/hovered list rows still orange. AccentPressed is
             // a separate explicit token (not derived from Accent), so the Slider thumb's
-            // pressed state was the same gap.
+            // pressed state was the same gap. Border/BorderHover are the shared muted-gold
+            // outline every restyled control uses (ListBox panel, Slider track, TextBox) —
+            // this is what was still reading "yellow" on all three even after Accent moved.
             colors.Accent = new Color(40, 140, 255);
             colors.Text = new Color(200, 230, 255);
             colors.Muted = new Color(90, 110, 140);
             colors.Selection = new Color(40, 140, 255);
             colors.TextBright = new Color(150, 200, 255);
             colors.AccentPressed = new Color(20, 100, 200);
+            colors.Border = new Color(30, 70, 130);
+            colors.BorderHover = new Color(70, 130, 200);
+            colors.Placeholder = new Color(100, 120, 150);
             text.FontFamily = "Consolas";
             text.FontSize = 17;
         }
@@ -485,6 +504,9 @@ public class Game1 : Game
             colors.Selection = new Color(244, 200, 26);
             colors.TextBright = new Color(248, 212, 59);
             colors.AccentPressed = new Color(201, 163, 12);
+            colors.Border = new Color(74, 63, 22);
+            colors.BorderHover = new Color(140, 117, 31);
+            colors.Placeholder = new Color(120, 102, 38);
             text.FontFamily = "Saira Condensed"; // HazardTheme.BundledFontFamily is internal; mirrors it
             text.FontSize = 15;
         }

--- a/Samples/RaylibGumThemesShowcase/Program.cs
+++ b/Samples/RaylibGumThemesShowcase/Program.cs
@@ -303,23 +303,37 @@ public static class Program
 
     private static void SetForestGladeCustomized(bool customized)
     {
+        // No font swap here — gradients and glows are the theme's most visually
+        // load-bearing tokens, and ButtonVisual/ForestGladeButtonChrome read the
+        // Rest/Hover gradient-stop pairs and DarkShadow/GlowStrong/GlowMedium directly,
+        // independent of LeafBright. Leaving Accent/Text/Muted unchanged left the button
+        // fill, its shadow, and its hover glow all on the old green palette.
         var colors = ForestGladeStyling.ActiveStyle.Colors;
-        var text = ForestGladeStyling.ActiveStyle.Text;
         if (customized)
         {
             colors.LeafBright = new Color(255, 105, 180);
             colors.Text = new Color(255, 240, 245);
             colors.Muted = new Color(200, 150, 165);
-            text.FontFamily = "Consolas";
-            text.FontSize = 18;
+            colors.ButtonRestFillTop = new Color(255, 130, 190);
+            colors.ButtonRestFillBottom = new Color(220, 60, 140);
+            colors.ButtonHoverFillTop = new Color(255, 160, 210);
+            colors.ButtonHoverFillBottom = new Color(255, 105, 180);
+            colors.DarkShadow = new Color(60, 0, 40, 200);
+            colors.GlowStrong = new Color(255, 105, 180, 170);
+            colors.GlowMedium = new Color(255, 105, 180, 110);
         }
         else
         {
             colors.LeafBright = new Color(71, 246, 65);
             colors.Text = new Color(241, 255, 240);
             colors.Muted = new Color(155, 186, 163);
-            text.FontFamily = "Nunito"; // ForestGladeTheme.BundledFontFamily is internal; mirrors it
-            text.FontSize = 14;
+            colors.ButtonRestFillTop = new Color(15, 196, 72);
+            colors.ButtonRestFillBottom = new Color(0, 140, 46);
+            colors.ButtonHoverFillTop = new Color(44, 219, 92);
+            colors.ButtonHoverFillBottom = new Color(8, 178, 59);
+            colors.DarkShadow = new Color(0, 60, 30, 200);
+            colors.GlowStrong = new Color(71, 246, 65, 170);
+            colors.GlowMedium = new Color(71, 246, 65, 110);
         }
     }
 
@@ -435,13 +449,18 @@ public static class Program
             // hover-row text — both defaulted to the same hazard-yellow as Accent, so only
             // changing Accent left selected/hovered list rows still orange. AccentPressed is
             // a separate explicit token (not derived from Accent), so the Slider thumb's
-            // pressed state was the same gap.
+            // pressed state was the same gap. Border/BorderHover are the shared muted-gold
+            // outline every restyled control uses (ListBox panel, Slider track, TextBox) —
+            // this is what was still reading "yellow" on all three even after Accent moved.
             colors.Accent = new Color(40, 140, 255);
             colors.Text = new Color(200, 230, 255);
             colors.Muted = new Color(90, 110, 140);
             colors.Selection = new Color(40, 140, 255);
             colors.TextBright = new Color(150, 200, 255);
             colors.AccentPressed = new Color(20, 100, 200);
+            colors.Border = new Color(30, 70, 130);
+            colors.BorderHover = new Color(70, 130, 200);
+            colors.Placeholder = new Color(100, 120, 150);
             text.FontFamily = "Consolas";
             text.FontSize = 17;
         }
@@ -453,6 +472,9 @@ public static class Program
             colors.Selection = new Color(244, 200, 26);
             colors.TextBright = new Color(248, 212, 59);
             colors.AccentPressed = new Color(201, 163, 12);
+            colors.Border = new Color(74, 63, 22);
+            colors.BorderHover = new Color(140, 117, 31);
+            colors.Placeholder = new Color(120, 102, 38);
             text.FontFamily = "Saira Condensed"; // HazardTheme.BundledFontFamily is internal; mirrors it
             text.FontSize = 15;
         }

--- a/Samples/RaylibGumThemesShowcase/Program.cs
+++ b/Samples/RaylibGumThemesShowcase/Program.cs
@@ -32,14 +32,17 @@ public static class Program
     {
         public string Name { get; }
         public Action Apply { get; }
-        public Color ClearColor { get; }
+        // A delegate, not a snapshot Color — some customizations change the theme's
+        // background-equivalent token (e.g. Meadow's Cream), and re-querying live is
+        // what lets the showcase's clear color follow that change.
+        public Func<Color> GetClearColor { get; }
         public Action<bool> SetCustomized { get; }
 
-        public ThemeOption(string name, Action apply, Color clearColor, Action<bool> setCustomized)
+        public ThemeOption(string name, Action apply, Func<Color> getClearColor, Action<bool> setCustomized)
         {
             Name = name;
             Apply = apply;
-            ClearColor = clearColor;
+            GetClearColor = getClearColor;
             SetCustomized = setCustomized;
         }
     }
@@ -74,15 +77,15 @@ public static class Program
         // sensible dark surround is used.
         _themes = new[]
         {
-            new ThemeOption("Editor", EditorTheme.Apply, new Color(40, 40, 40, 255), SetEditorCustomized),
-            new ThemeOption("Dark Pro", DarkProTheme.Apply, DarkProStyling.ActiveStyle.Colors.Background, SetDarkProCustomized),
-            new ThemeOption("Bubblegum", BubblegumTheme.Apply, BubblegumStyling.ActiveStyle.Colors.Background, SetBubblegumCustomized),
-            new ThemeOption("Forest Glade", ForestGladeTheme.Apply, ForestGladeStyling.ActiveStyle.Colors.CanopyDeep, SetForestGladeCustomized),
-            new ThemeOption("Hazard", HazardTheme.Apply, HazardStyling.ActiveStyle.Colors.Background, SetHazardCustomized),
-            new ThemeOption("Meadow", MeadowTheme.Apply, MeadowStyling.ActiveStyle.Colors.Cream, SetMeadowCustomized),
-            new ThemeOption("Neon", NeonTheme.Apply, NeonStyling.ActiveStyle.Colors.Background, SetNeonCustomized),
-            new ThemeOption("Retro 95", Retro95Theme.Apply, Retro95Styling.ActiveStyle.Colors.Surface, SetRetro95Customized),
-            new ThemeOption("Template", TemplateTheme.Apply, TemplateStyling.ActiveStyle.Colors.Background, SetTemplateCustomized),
+            new ThemeOption("Editor", EditorTheme.Apply, () => new Color(40, 40, 40, 255), SetEditorCustomized),
+            new ThemeOption("Dark Pro", DarkProTheme.Apply, () => DarkProStyling.ActiveStyle.Colors.Background, SetDarkProCustomized),
+            new ThemeOption("Bubblegum", BubblegumTheme.Apply, () => BubblegumStyling.ActiveStyle.Colors.Background, SetBubblegumCustomized),
+            new ThemeOption("Forest Glade", ForestGladeTheme.Apply, () => ForestGladeStyling.ActiveStyle.Colors.CanopyDeep, SetForestGladeCustomized),
+            new ThemeOption("Hazard", HazardTheme.Apply, () => HazardStyling.ActiveStyle.Colors.Background, SetHazardCustomized),
+            new ThemeOption("Meadow", MeadowTheme.Apply, () => MeadowStyling.ActiveStyle.Colors.Cream, SetMeadowCustomized),
+            new ThemeOption("Neon", NeonTheme.Apply, () => NeonStyling.ActiveStyle.Colors.Background, SetNeonCustomized),
+            new ThemeOption("Retro 95", Retro95Theme.Apply, () => Retro95Styling.ActiveStyle.Colors.Surface, SetRetro95Customized),
+            new ThemeOption("Template", TemplateTheme.Apply, () => TemplateStyling.ActiveStyle.Colors.Background, SetTemplateCustomized),
         };
 
         // Authoring-only "Show Customized" checkbox — survives F1/F2 screen swaps via its own
@@ -94,16 +97,8 @@ public static class Program
         _customizeCheckBox.Anchor(Anchor.TopRight);
         _customizeCheckBox.X = -20;
         _customizeCheckBox.Y = 10;
-        _customizeCheckBox.Checked += (_, _) =>
-        {
-            _themes[_currentThemeIndex].SetCustomized(true);
-            RebuildScreen();
-        };
-        _customizeCheckBox.Unchecked += (_, _) =>
-        {
-            _themes[_currentThemeIndex].SetCustomized(false);
-            RebuildScreen();
-        };
+        _customizeCheckBox.Checked += (_, _) => ApplyCustomizationToggle(true);
+        _customizeCheckBox.Unchecked += (_, _) => ApplyCustomizationToggle(false);
         _customizeCheckBox.AddToRoot();
 
         _currentScreenFactory = () => new AllControlsScreen();
@@ -163,12 +158,27 @@ public static class Program
         }
     }
 
+    // Mutating a theme's Colors/Text alone isn't enough: font selection and the 4-token
+    // guardrail that colors stock, un-restyled V3 visuals (Label, etc.) are only pushed into
+    // Gum.Forms.DefaultVisuals.V3.Styling.ActiveStyle once, inside the theme's own Apply() —
+    // see ConfigureStyling() in each XyzTheme.cs. So re-calling theme.Apply() after
+    // SetCustomized() is what actually refreshes fonts and Label-style text, matching the
+    // theme's own documented "mutate before Apply()" pattern.
+    private static void ApplyCustomizationToggle(bool customized)
+    {
+        ThemeOption theme = _themes[_currentThemeIndex];
+        theme.SetCustomized(customized);
+        theme.Apply();
+        _clearColor = theme.GetClearColor();
+        RebuildScreen();
+    }
+
     private static void ApplyTheme(int index)
     {
         _currentThemeIndex = index;
         ThemeOption theme = _themes[index];
         theme.Apply();
-        _clearColor = theme.ClearColor;
+        _clearColor = theme.GetClearColor();
         SetWindowTitle($"Gum raylib - Themes Showcase  -  {index + 1}. {theme.Name}  (1-{_themes.Length} theme, F1/F2 screen)");
     }
 
@@ -202,9 +212,18 @@ public static class Program
         var text = EditorStyling.ActiveStyle.Text;
         if (customized)
         {
-            colors.Accent = new Color(255, 140, 0);
-            colors.TextPrimary = new Color(235, 235, 245);
-            colors.TextMuted = new Color(140, 140, 160);
+            // Tints the whole gray chrome toward blue, not just the accent — Primary,
+            // BorderHover/BorderPushed, and the panel/recessed backgrounds all feed into
+            // the same neutral gray by default, so all four need to move together.
+            colors.Accent = new Color(140, 190, 255);
+            colors.TextPrimary = new Color(210, 220, 255);
+            colors.TextMuted = new Color(100, 110, 140);
+            colors.Primary = new Color(50, 60, 90);
+            colors.BorderHover = new Color(120, 150, 210);
+            colors.BorderPushed = new Color(220, 230, 255);
+            colors.Selection = new Color(30, 80, 200);
+            colors.PanelBackground = new Color(18, 20, 32);
+            colors.RecessedBackground = new Color(8, 10, 20);
             text.FontFamily = "Consolas";
             text.FontSize = 19;
         }
@@ -213,6 +232,12 @@ public static class Program
             colors.Accent = new Color(192, 222, 255);
             colors.TextPrimary = new Color(180, 180, 180);
             colors.TextMuted = new Color(88, 88, 88);
+            colors.Primary = new Color(60, 60, 60);
+            colors.BorderHover = new Color(150, 150, 150);
+            colors.BorderPushed = new Color(255, 255, 255);
+            colors.Selection = new Color(0, 92, 128);
+            colors.PanelBackground = new Color(27, 27, 27);
+            colors.RecessedBackground = new Color(10, 10, 10);
             text.FontFamily = "Arial";
             text.FontSize = 15;
         }
@@ -227,8 +252,11 @@ public static class Program
             colors.Accent = new Color(214, 64, 214);
             colors.Text = new Color(245, 240, 235);
             colors.Muted = new Color(150, 140, 135);
-            text.FontFamily = "Consolas";
-            text.FontSize = 18;
+            // Deliberately a serif, not another mono font — DM Mono vs. Consolas would
+            // read as "basically the same," so this picks something unmissable to
+            // demonstrate the font-swap mechanism clearly.
+            text.FontFamily = "Georgia";
+            text.FontSize = 20;
         }
         else
         {
@@ -246,9 +274,16 @@ public static class Program
         var text = BubblegumStyling.ActiveStyle.Text;
         if (customized)
         {
+            // Surface1/Background/Border/Placeholder are what TextBox actually reads for
+            // its fill/border/placeholder (see BubblegumTextInputDecoration) — Accent/Text
+            // alone only moved the caret and typed-text color, not the box itself.
             colors.Accent = new Color(40, 190, 190);
             colors.Text = new Color(20, 30, 60);
             colors.Muted = new Color(110, 120, 150);
+            colors.Surface1 = new Color(235, 250, 250);
+            colors.Background = new Color(230, 250, 248);
+            colors.Border = new Color(120, 200, 200);
+            colors.Placeholder = new Color(140, 170, 180);
             text.FontFamily = "Consolas";
             text.FontSize = 18;
         }
@@ -257,6 +292,10 @@ public static class Program
             colors.Accent = new Color(255, 107, 157);
             colors.Text = new Color(61, 17, 85);
             colors.Muted = new Color(160, 123, 176);
+            colors.Surface1 = new Color(255, 255, 255);
+            colors.Background = new Color(255, 240, 249);
+            colors.Border = new Color(240, 170, 204);
+            colors.Placeholder = new Color(201, 168, 217);
             text.FontFamily = "Nunito"; // BubblegumTheme.BundledFontFamily is internal; mirrors it
             text.FontSize = 14;
         }
@@ -290,9 +329,14 @@ public static class Program
         var text = NeonStyling.ActiveStyle.Text;
         if (customized)
         {
+            // Surface1 is what ListBoxVisual actually fills its background with; Surface2
+            // is the ListBox hover-row tint (HoverRow aliases it) — both need to move
+            // together or hovering a row looks like a mismatched leftover of the old theme.
             colors.Accent = new Color(255, 0, 200);
             colors.Text = new Color(255, 250, 200);
             colors.Muted = new Color(140, 110, 160);
+            colors.Surface1 = new Color(40, 10, 40);
+            colors.Surface2 = new Color(55, 15, 55);
             text.FontFamily = "Consolas";
             text.FontSize = 17;
         }
@@ -301,6 +345,8 @@ public static class Program
             colors.Accent = new Color(0, 229, 255);
             colors.Text = new Color(200, 250, 255);
             colors.Muted = new Color(74, 96, 128);
+            colors.Surface1 = new Color(13, 13, 34);
+            colors.Surface2 = new Color(19, 19, 48);
             text.FontFamily = "Share Tech Mono"; // NeonTheme.BundledFontFamily is internal; mirrors it
             text.FontSize = 13;
         }
@@ -312,16 +358,28 @@ public static class Program
         var text = Retro95Styling.ActiveStyle.Text;
         if (customized)
         {
+            // Surface also drives the showcase's own clear color (via GetClearColor), so
+            // this is the one theme where "tint everything" includes the window backdrop.
+            colors.Surface = new Color(0, 128, 128);
+            colors.WhiteFill = new Color(220, 255, 255);
             colors.Selection = new Color(128, 0, 32);
-            colors.Text = new Color(10, 10, 60);
+            colors.HighlightInner = new Color(150, 220, 220);
+            colors.HighlightOuter = new Color(200, 255, 255);
+            colors.ShadowInner = new Color(0, 80, 80);
+            colors.ShadowOuter = new Color(0, 50, 50);
             colors.DisabledText = new Color(110, 70, 70);
             text.FontFamily = "Consolas";
             text.FontSize = 15;
         }
         else
         {
+            colors.Surface = new Color(192, 192, 192);
+            colors.WhiteFill = new Color(255, 255, 255);
             colors.Selection = new Color(0, 0, 128);
-            colors.Text = new Color(0, 0, 0);
+            colors.HighlightInner = new Color(223, 223, 223);
+            colors.HighlightOuter = new Color(255, 255, 255);
+            colors.ShadowInner = new Color(128, 128, 128);
+            colors.ShadowOuter = new Color(64, 64, 64);
             colors.DisabledText = new Color(128, 128, 128);
             text.FontFamily = "Nunito"; // Retro95Theme.BundledFontFamily is internal; mirrors it
             text.FontSize = 13;
@@ -334,17 +392,34 @@ public static class Program
         var text = MeadowStyling.ActiveStyle.Text;
         if (customized)
         {
+            // Blue/BlueDark/BlueHover are the button's rest/pressed/hover fills — changing
+            // only Blue left the shadow and hover states stuck on the old sky-blue gradient.
+            // SageDark is the checkbox/radio checked color; PeachDark is the shared
+            // border/outline token (ListBox, input fields, dashed panels, splitter).
+            // Cream/Cream2 are the page and panel backgrounds.
             colors.Blue = new Color(230, 90, 70);
+            colors.BlueDark = new Color(150, 45, 35);
+            colors.BlueHover = new Color(245, 130, 105);
             colors.TealDark = new Color(90, 40, 80);
             colors.Muted = new Color(170, 130, 150);
+            colors.SageDark = new Color(170, 90, 140);
+            colors.PeachDark = new Color(200, 150, 175);
+            colors.Cream = new Color(238, 222, 235);
+            colors.Cream2 = new Color(245, 232, 242);
             text.FontFamily = "Consolas";
             text.FontSize = 17;
         }
         else
         {
             colors.Blue = new Color(70, 173, 230);
+            colors.BlueDark = new Color(46, 147, 210);
+            colors.BlueHover = new Color(94, 187, 240);
             colors.TealDark = new Color(30, 106, 91);
             colors.Muted = new Color(180, 156, 132);
+            colors.SageDark = new Color(132, 194, 166);
+            colors.PeachDark = new Color(239, 200, 160);
+            colors.Cream = new Color(247, 237, 214);
+            colors.Cream2 = new Color(252, 245, 230);
             text.FontFamily = "Baloo 2"; // MeadowTheme.BundledFontFamily is internal; mirrors it
             text.FontSize = 15;
         }
@@ -356,9 +431,17 @@ public static class Program
         var text = HazardStyling.ActiveStyle.Text;
         if (customized)
         {
+            // Selection is the ListBox/MenuItem selected-row fill and TextBright is its
+            // hover-row text — both defaulted to the same hazard-yellow as Accent, so only
+            // changing Accent left selected/hovered list rows still orange. AccentPressed is
+            // a separate explicit token (not derived from Accent), so the Slider thumb's
+            // pressed state was the same gap.
             colors.Accent = new Color(40, 140, 255);
             colors.Text = new Color(200, 230, 255);
             colors.Muted = new Color(90, 110, 140);
+            colors.Selection = new Color(40, 140, 255);
+            colors.TextBright = new Color(150, 200, 255);
+            colors.AccentPressed = new Color(20, 100, 200);
             text.FontFamily = "Consolas";
             text.FontSize = 17;
         }
@@ -367,6 +450,9 @@ public static class Program
             colors.Accent = new Color(244, 200, 26);
             colors.Text = new Color(227, 181, 40);
             colors.Muted = new Color(120, 102, 38);
+            colors.Selection = new Color(244, 200, 26);
+            colors.TextBright = new Color(248, 212, 59);
+            colors.AccentPressed = new Color(201, 163, 12);
             text.FontFamily = "Saira Condensed"; // HazardTheme.BundledFontFamily is internal; mirrors it
             text.FontSize = 15;
         }

--- a/Samples/RaylibGumThemesShowcase/Program.cs
+++ b/Samples/RaylibGumThemesShowcase/Program.cs
@@ -85,14 +85,12 @@ public static class Program
             new ThemeOption("Template", TemplateTheme.Apply, TemplateStyling.ActiveStyle.Colors.Background, SetTemplateCustomized),
         };
 
-        _currentScreenFactory = () => new AllControlsScreen();
-        ApplyTheme(0);
-        RebuildScreen();
-
-        // Authoring-only "Customize" checkbox — survives F1/F2 screen swaps via its own
-        // AddToRoot call, separate from ShowcaseScreen's root-element bookkeeping.
+        // Authoring-only "Show Customized" checkbox — survives F1/F2 screen swaps via its own
+        // AddToRoot call, separate from ShowcaseScreen's root-element bookkeeping. Created
+        // before the first RebuildScreen call below so RebuildScreen can always rely on it
+        // existing (see the re-parent-to-top comment inside RebuildScreen).
         _customizeCheckBox = new CheckBox();
-        _customizeCheckBox.Text = "Customize";
+        _customizeCheckBox.Text = "Show Customized";
         _customizeCheckBox.Anchor(Anchor.TopRight);
         _customizeCheckBox.X = -20;
         _customizeCheckBox.Y = 10;
@@ -107,6 +105,10 @@ public static class Program
             RebuildScreen();
         };
         _customizeCheckBox.AddToRoot();
+
+        _currentScreenFactory = () => new AllControlsScreen();
+        ApplyTheme(0);
+        RebuildScreen();
 
         while (!WindowShouldClose())
         {
@@ -150,7 +152,7 @@ public static class Program
         }
     }
 
-    // If Customize is checked when the user swaps themes, revert the previous theme's
+    // If Show Customized is checked when the user swaps themes, revert the previous theme's
     // customization and uncheck the box first — don't let a customization silently persist
     // onto/across a theme switch, and don't auto-apply the new theme's customization.
     private static void RevertCustomizationIfChecked()
@@ -173,6 +175,13 @@ public static class Program
     private static void RebuildScreen()
     {
         SwitchScreen(_currentScreenFactory);
+
+        // Root.Children.Add appends, and later children paint on top in Gum, so every
+        // ShowcaseScreen rebuild re-adds fresh controls AFTER _customizeCheckBox in the
+        // root's child list — burying it behind the new screen unless it's re-parented to
+        // the end again here.
+        _customizeCheckBox.RemoveFromRoot();
+        _customizeCheckBox.AddToRoot();
     }
 
     private static void SwitchScreen(Func<ShowcaseScreen> factory)
@@ -183,8 +192,8 @@ public static class Program
         _currentScreen.Build();
     }
 
-    // --- Hardcoded per-theme "Customize" preview values --------------------
-    // Authoring tooling only, used by the Customize checkbox above. These values are not a
+    // --- Hardcoded per-theme "Show Customized" preview values --------------------
+    // Authoring tooling only, used by the Show Customized checkbox above. These values are not a
     // shared source of truth with any documentation example — they may drift over time.
 
     private static void SetEditorCustomized(bool customized)

--- a/Samples/RaylibGumThemesShowcase/Program.cs
+++ b/Samples/RaylibGumThemesShowcase/Program.cs
@@ -1,5 +1,7 @@
 using System;
 using Gum;
+using Gum.Forms;
+using Gum.Forms.Controls;
 using Gum.Themes.Bubblegum;
 using Gum.Themes.DarkPro;
 using Gum.Themes.Editor;
@@ -9,6 +11,7 @@ using Gum.Themes.Meadow;
 using Gum.Themes.Neon;
 using Gum.Themes.Retro95;
 using Gum.Themes.Template;
+using Gum.Wireframe;
 using MonoGameGumThemesShowcase.Screens;
 using Raylib_cs;
 using static Raylib_cs.Raylib;
@@ -30,12 +33,14 @@ public static class Program
         public string Name { get; }
         public Action Apply { get; }
         public Color ClearColor { get; }
+        public Action<bool> SetCustomized { get; }
 
-        public ThemeOption(string name, Action apply, Color clearColor)
+        public ThemeOption(string name, Action apply, Color clearColor, Action<bool> setCustomized)
         {
             Name = name;
             Apply = apply;
             ClearColor = clearColor;
+            SetCustomized = setCustomized;
         }
     }
 
@@ -44,6 +49,11 @@ public static class Program
     private static Color _clearColor;
     private static ShowcaseScreen _currentScreen;
     private static Func<ShowcaseScreen> _currentScreenFactory;
+
+    // Authoring-only toggle (not part of the ShowcaseScreen root bookkeeping) that lets a
+    // maintainer preview a hardcoded per-theme customization before manually capturing
+    // screenshots. See the SetXyzCustomized methods below for the per-theme values.
+    private static CheckBox _customizeCheckBox;
 
     public static void Main()
     {
@@ -64,20 +74,39 @@ public static class Program
         // sensible dark surround is used.
         _themes = new[]
         {
-            new ThemeOption("Editor", EditorTheme.Apply, new Color(40, 40, 40, 255)),
-            new ThemeOption("Dark Pro", DarkProTheme.Apply, DarkProStyling.ActiveStyle.Colors.Background),
-            new ThemeOption("Bubblegum", BubblegumTheme.Apply, BubblegumStyling.ActiveStyle.Colors.Background),
-            new ThemeOption("Forest Glade", ForestGladeTheme.Apply, ForestGladeStyling.ActiveStyle.Colors.CanopyDeep),
-            new ThemeOption("Hazard", HazardTheme.Apply, HazardStyling.ActiveStyle.Colors.Background),
-            new ThemeOption("Meadow", MeadowTheme.Apply, MeadowStyling.ActiveStyle.Colors.Cream),
-            new ThemeOption("Neon", NeonTheme.Apply, NeonStyling.ActiveStyle.Colors.Background),
-            new ThemeOption("Retro 95", Retro95Theme.Apply, Retro95Styling.ActiveStyle.Colors.Surface),
-            new ThemeOption("Template", TemplateTheme.Apply, TemplateStyling.ActiveStyle.Colors.Background),
+            new ThemeOption("Editor", EditorTheme.Apply, new Color(40, 40, 40, 255), SetEditorCustomized),
+            new ThemeOption("Dark Pro", DarkProTheme.Apply, DarkProStyling.ActiveStyle.Colors.Background, SetDarkProCustomized),
+            new ThemeOption("Bubblegum", BubblegumTheme.Apply, BubblegumStyling.ActiveStyle.Colors.Background, SetBubblegumCustomized),
+            new ThemeOption("Forest Glade", ForestGladeTheme.Apply, ForestGladeStyling.ActiveStyle.Colors.CanopyDeep, SetForestGladeCustomized),
+            new ThemeOption("Hazard", HazardTheme.Apply, HazardStyling.ActiveStyle.Colors.Background, SetHazardCustomized),
+            new ThemeOption("Meadow", MeadowTheme.Apply, MeadowStyling.ActiveStyle.Colors.Cream, SetMeadowCustomized),
+            new ThemeOption("Neon", NeonTheme.Apply, NeonStyling.ActiveStyle.Colors.Background, SetNeonCustomized),
+            new ThemeOption("Retro 95", Retro95Theme.Apply, Retro95Styling.ActiveStyle.Colors.Surface, SetRetro95Customized),
+            new ThemeOption("Template", TemplateTheme.Apply, TemplateStyling.ActiveStyle.Colors.Background, SetTemplateCustomized),
         };
 
         _currentScreenFactory = () => new AllControlsScreen();
         ApplyTheme(0);
         RebuildScreen();
+
+        // Authoring-only "Customize" checkbox — survives F1/F2 screen swaps via its own
+        // AddToRoot call, separate from ShowcaseScreen's root-element bookkeeping.
+        _customizeCheckBox = new CheckBox();
+        _customizeCheckBox.Text = "Customize";
+        _customizeCheckBox.Anchor(Anchor.TopRight);
+        _customizeCheckBox.X = -20;
+        _customizeCheckBox.Y = 10;
+        _customizeCheckBox.Checked += (_, _) =>
+        {
+            _themes[_currentThemeIndex].SetCustomized(true);
+            RebuildScreen();
+        };
+        _customizeCheckBox.Unchecked += (_, _) =>
+        {
+            _themes[_currentThemeIndex].SetCustomized(false);
+            RebuildScreen();
+        };
+        _customizeCheckBox.AddToRoot();
 
         while (!WindowShouldClose())
         {
@@ -113,10 +142,22 @@ public static class Program
         {
             if (IsKeyPressed(KeyboardKey.One + i) && i != _currentThemeIndex)
             {
+                RevertCustomizationIfChecked();
                 ApplyTheme(i);
                 RebuildScreen();
                 break;
             }
+        }
+    }
+
+    // If Customize is checked when the user swaps themes, revert the previous theme's
+    // customization and uncheck the box first — don't let a customization silently persist
+    // onto/across a theme switch, and don't auto-apply the new theme's customization.
+    private static void RevertCustomizationIfChecked()
+    {
+        if (_customizeCheckBox.IsChecked == true)
+        {
+            _customizeCheckBox.IsChecked = false;
         }
     }
 
@@ -140,5 +181,207 @@ public static class Program
         _currentScreen?.Destroy();
         _currentScreen = factory();
         _currentScreen.Build();
+    }
+
+    // --- Hardcoded per-theme "Customize" preview values --------------------
+    // Authoring tooling only, used by the Customize checkbox above. These values are not a
+    // shared source of truth with any documentation example — they may drift over time.
+
+    private static void SetEditorCustomized(bool customized)
+    {
+        var colors = EditorStyling.ActiveStyle.Colors;
+        var text = EditorStyling.ActiveStyle.Text;
+        if (customized)
+        {
+            colors.Accent = new Color(255, 140, 0);
+            colors.TextPrimary = new Color(235, 235, 245);
+            colors.TextMuted = new Color(140, 140, 160);
+            text.FontFamily = "Consolas";
+            text.FontSize = 19;
+        }
+        else
+        {
+            colors.Accent = new Color(192, 222, 255);
+            colors.TextPrimary = new Color(180, 180, 180);
+            colors.TextMuted = new Color(88, 88, 88);
+            text.FontFamily = "Arial";
+            text.FontSize = 15;
+        }
+    }
+
+    private static void SetDarkProCustomized(bool customized)
+    {
+        var colors = DarkProStyling.ActiveStyle.Colors;
+        var text = DarkProStyling.ActiveStyle.Text;
+        if (customized)
+        {
+            colors.Accent = new Color(214, 64, 214);
+            colors.Text = new Color(245, 240, 235);
+            colors.Muted = new Color(150, 140, 135);
+            text.FontFamily = "Consolas";
+            text.FontSize = 18;
+        }
+        else
+        {
+            colors.Accent = new Color(0, 122, 204);
+            colors.Text = new Color(212, 212, 212);
+            colors.Muted = new Color(136, 136, 136);
+            text.FontFamily = "DM Mono"; // DarkProTheme.BundledFontFamily is internal; mirrors it
+            text.FontSize = 14;
+        }
+    }
+
+    private static void SetBubblegumCustomized(bool customized)
+    {
+        var colors = BubblegumStyling.ActiveStyle.Colors;
+        var text = BubblegumStyling.ActiveStyle.Text;
+        if (customized)
+        {
+            colors.Accent = new Color(40, 190, 190);
+            colors.Text = new Color(20, 30, 60);
+            colors.Muted = new Color(110, 120, 150);
+            text.FontFamily = "Consolas";
+            text.FontSize = 18;
+        }
+        else
+        {
+            colors.Accent = new Color(255, 107, 157);
+            colors.Text = new Color(61, 17, 85);
+            colors.Muted = new Color(160, 123, 176);
+            text.FontFamily = "Nunito"; // BubblegumTheme.BundledFontFamily is internal; mirrors it
+            text.FontSize = 14;
+        }
+    }
+
+    private static void SetForestGladeCustomized(bool customized)
+    {
+        var colors = ForestGladeStyling.ActiveStyle.Colors;
+        var text = ForestGladeStyling.ActiveStyle.Text;
+        if (customized)
+        {
+            colors.LeafBright = new Color(255, 105, 180);
+            colors.Text = new Color(255, 240, 245);
+            colors.Muted = new Color(200, 150, 165);
+            text.FontFamily = "Consolas";
+            text.FontSize = 18;
+        }
+        else
+        {
+            colors.LeafBright = new Color(71, 246, 65);
+            colors.Text = new Color(241, 255, 240);
+            colors.Muted = new Color(155, 186, 163);
+            text.FontFamily = "Nunito"; // ForestGladeTheme.BundledFontFamily is internal; mirrors it
+            text.FontSize = 14;
+        }
+    }
+
+    private static void SetNeonCustomized(bool customized)
+    {
+        var colors = NeonStyling.ActiveStyle.Colors;
+        var text = NeonStyling.ActiveStyle.Text;
+        if (customized)
+        {
+            colors.Accent = new Color(255, 0, 200);
+            colors.Text = new Color(255, 250, 200);
+            colors.Muted = new Color(140, 110, 160);
+            text.FontFamily = "Consolas";
+            text.FontSize = 17;
+        }
+        else
+        {
+            colors.Accent = new Color(0, 229, 255);
+            colors.Text = new Color(200, 250, 255);
+            colors.Muted = new Color(74, 96, 128);
+            text.FontFamily = "Share Tech Mono"; // NeonTheme.BundledFontFamily is internal; mirrors it
+            text.FontSize = 13;
+        }
+    }
+
+    private static void SetRetro95Customized(bool customized)
+    {
+        var colors = Retro95Styling.ActiveStyle.Colors;
+        var text = Retro95Styling.ActiveStyle.Text;
+        if (customized)
+        {
+            colors.Selection = new Color(128, 0, 32);
+            colors.Text = new Color(10, 10, 60);
+            colors.DisabledText = new Color(110, 70, 70);
+            text.FontFamily = "Consolas";
+            text.FontSize = 15;
+        }
+        else
+        {
+            colors.Selection = new Color(0, 0, 128);
+            colors.Text = new Color(0, 0, 0);
+            colors.DisabledText = new Color(128, 128, 128);
+            text.FontFamily = "Nunito"; // Retro95Theme.BundledFontFamily is internal; mirrors it
+            text.FontSize = 13;
+        }
+    }
+
+    private static void SetMeadowCustomized(bool customized)
+    {
+        var colors = MeadowStyling.ActiveStyle.Colors;
+        var text = MeadowStyling.ActiveStyle.Text;
+        if (customized)
+        {
+            colors.Blue = new Color(230, 90, 70);
+            colors.TealDark = new Color(90, 40, 80);
+            colors.Muted = new Color(170, 130, 150);
+            text.FontFamily = "Consolas";
+            text.FontSize = 17;
+        }
+        else
+        {
+            colors.Blue = new Color(70, 173, 230);
+            colors.TealDark = new Color(30, 106, 91);
+            colors.Muted = new Color(180, 156, 132);
+            text.FontFamily = "Baloo 2"; // MeadowTheme.BundledFontFamily is internal; mirrors it
+            text.FontSize = 15;
+        }
+    }
+
+    private static void SetHazardCustomized(bool customized)
+    {
+        var colors = HazardStyling.ActiveStyle.Colors;
+        var text = HazardStyling.ActiveStyle.Text;
+        if (customized)
+        {
+            colors.Accent = new Color(40, 140, 255);
+            colors.Text = new Color(200, 230, 255);
+            colors.Muted = new Color(90, 110, 140);
+            text.FontFamily = "Consolas";
+            text.FontSize = 17;
+        }
+        else
+        {
+            colors.Accent = new Color(244, 200, 26);
+            colors.Text = new Color(227, 181, 40);
+            colors.Muted = new Color(120, 102, 38);
+            text.FontFamily = "Saira Condensed"; // HazardTheme.BundledFontFamily is internal; mirrors it
+            text.FontSize = 15;
+        }
+    }
+
+    private static void SetTemplateCustomized(bool customized)
+    {
+        var colors = TemplateStyling.ActiveStyle.Colors;
+        var text = TemplateStyling.ActiveStyle.Text;
+        if (customized)
+        {
+            colors.Accent = new Color(60, 200, 120);
+            colors.Text = new Color(225, 245, 235);
+            colors.Muted = new Color(130, 150, 135);
+            text.FontFamily = "Consolas";
+            text.FontSize = 17;
+        }
+        else
+        {
+            colors.Accent = new Color(0, 122, 204);
+            colors.Text = new Color(212, 212, 212);
+            colors.Muted = new Color(136, 136, 136);
+            text.FontFamily = "DM Mono"; // TemplateTheme.BundledFontFamily is internal; mirrors it
+            text.FontSize = 14;
+        }
     }
 }

--- a/docs/code/styling/themes/README.md
+++ b/docs/code/styling/themes/README.md
@@ -123,11 +123,15 @@ EditorTheme.Apply();
 // Initialize
 using Gum.Themes.Editor;
 
-EditorStyling.ActiveStyle.Colors.TextPrimary = new Color(210, 225, 255);
-EditorStyling.ActiveStyle.Colors.TextMuted = new Color(120, 130, 150);
-EditorStyling.ActiveStyle.Colors.Primary = new Color(40, 46, 64);
-EditorStyling.ActiveStyle.Colors.Accent = new Color(255, 196, 84);
-EditorStyling.ActiveStyle.Colors.Selection = new Color(64, 52, 16);
+EditorStyling.ActiveStyle.Colors.Accent = new Color(140, 190, 255);
+EditorStyling.ActiveStyle.Colors.TextPrimary = new Color(210, 220, 255);
+EditorStyling.ActiveStyle.Colors.TextMuted = new Color(100, 110, 140);
+EditorStyling.ActiveStyle.Colors.Primary = new Color(50, 60, 90);
+EditorStyling.ActiveStyle.Colors.BorderHover = new Color(120, 150, 210);
+EditorStyling.ActiveStyle.Colors.BorderPushed = new Color(220, 230, 255);
+EditorStyling.ActiveStyle.Colors.Selection = new Color(30, 80, 200);
+EditorStyling.ActiveStyle.Colors.PanelBackground = new Color(18, 20, 32);
+EditorStyling.ActiveStyle.Colors.RecessedBackground = new Color(8, 10, 20);
 EditorStyling.ActiveStyle.Text.FontFamily = "Consolas";
 
 EditorTheme.Apply(GraphicsDevice);
@@ -185,12 +189,13 @@ DarkProTheme.Apply();
 // Initialize
 using Gum.Themes.DarkPro;
 
-DarkProStyling.ActiveStyle.Colors.Text = new Color(220, 220, 225);
-DarkProStyling.ActiveStyle.Colors.Muted = new Color(150, 150, 160);
-DarkProStyling.ActiveStyle.Colors.Surface1 = new Color(30, 34, 42);
-DarkProStyling.ActiveStyle.Colors.Accent = new Color(198, 120, 255);
-DarkProStyling.ActiveStyle.Colors.AccentDark = new Color(110, 60, 150);
-DarkProStyling.ActiveStyle.Text.FontFamily = "Consolas";
+DarkProStyling.ActiveStyle.Colors.Accent = new Color(214, 64, 214);
+DarkProStyling.ActiveStyle.Colors.Text = new Color(245, 240, 235);
+DarkProStyling.ActiveStyle.Colors.Muted = new Color(150, 140, 135);
+// A serif reads as an obviously different font from the bundled DM Mono —
+// a different monospace font would look "basically the same" at a glance.
+DarkProStyling.ActiveStyle.Text.FontFamily = "Georgia";
+DarkProStyling.ActiveStyle.Text.FontSize = 20;
 
 DarkProTheme.Apply(GraphicsDevice);
 ```
@@ -247,12 +252,17 @@ BubblegumTheme.Apply();
 // Initialize
 using Gum.Themes.Bubblegum;
 
-BubblegumStyling.ActiveStyle.Colors.Text = new Color(35, 20, 60);
-BubblegumStyling.ActiveStyle.Colors.Muted = new Color(150, 120, 190);
-BubblegumStyling.ActiveStyle.Colors.Surface1 = new Color(255, 250, 253);
-BubblegumStyling.ActiveStyle.Colors.Accent = new Color(120, 200, 255);
-BubblegumStyling.ActiveStyle.Colors.AccentLight = new Color(210, 240, 255);
-BubblegumStyling.ActiveStyle.Text.FontSize = 16;
+// Surface1/Background/Border/Placeholder are what TextBox actually reads for its
+// fill/border/placeholder — Accent/Text alone only move the caret and typed text.
+BubblegumStyling.ActiveStyle.Colors.Accent = new Color(40, 190, 190);
+BubblegumStyling.ActiveStyle.Colors.Text = new Color(20, 30, 60);
+BubblegumStyling.ActiveStyle.Colors.Muted = new Color(110, 120, 150);
+BubblegumStyling.ActiveStyle.Colors.Surface1 = new Color(235, 250, 250);
+BubblegumStyling.ActiveStyle.Colors.Background = new Color(230, 250, 248);
+BubblegumStyling.ActiveStyle.Colors.Border = new Color(120, 200, 200);
+BubblegumStyling.ActiveStyle.Colors.Placeholder = new Color(140, 170, 180);
+BubblegumStyling.ActiveStyle.Text.FontFamily = "Consolas";
+BubblegumStyling.ActiveStyle.Text.FontSize = 18;
 
 BubblegumTheme.Apply(GraphicsDevice);
 ```
@@ -313,13 +323,19 @@ For the intended look, clear the back buffer to `ForestGladeStyling.ActiveStyle.
 // Initialize
 using Gum.Themes.ForestGlade;
 
-ForestGladeStyling.ActiveStyle.Colors.Text = new Color(255, 246, 224);
-ForestGladeStyling.ActiveStyle.Colors.Muted = new Color(196, 168, 130);
-ForestGladeStyling.ActiveStyle.Colors.CanopyDeep = new Color(48, 24, 10);
-ForestGladeStyling.ActiveStyle.Colors.LeafBright = new Color(255, 176, 59);
-ForestGladeStyling.ActiveStyle.Colors.ButtonRestFillTop = new Color(230, 140, 40);
-ForestGladeStyling.ActiveStyle.Colors.ButtonRestFillBottom = new Color(180, 90, 20);
-ForestGladeStyling.ActiveStyle.Text.FontSize = 15;
+// ButtonVisual reads the Rest/Hover gradient-stop pairs and the glow/shadow tokens
+// directly — LeafBright alone leaves the button fill, shadow, and hover glow on the
+// old green palette, so gradients and glows matter more here than a font swap.
+ForestGladeStyling.ActiveStyle.Colors.LeafBright = new Color(255, 105, 180);
+ForestGladeStyling.ActiveStyle.Colors.Text = new Color(255, 240, 245);
+ForestGladeStyling.ActiveStyle.Colors.Muted = new Color(200, 150, 165);
+ForestGladeStyling.ActiveStyle.Colors.ButtonRestFillTop = new Color(255, 130, 190);
+ForestGladeStyling.ActiveStyle.Colors.ButtonRestFillBottom = new Color(220, 60, 140);
+ForestGladeStyling.ActiveStyle.Colors.ButtonHoverFillTop = new Color(255, 160, 210);
+ForestGladeStyling.ActiveStyle.Colors.ButtonHoverFillBottom = new Color(255, 105, 180);
+ForestGladeStyling.ActiveStyle.Colors.DarkShadow = new Color(60, 0, 40, 200);
+ForestGladeStyling.ActiveStyle.Colors.GlowStrong = new Color(255, 105, 180, 170);
+ForestGladeStyling.ActiveStyle.Colors.GlowMedium = new Color(255, 105, 180, 110);
 
 ForestGladeTheme.Apply(GraphicsDevice);
 ```
@@ -380,12 +396,15 @@ For the intended look, clear the back buffer to `NeonStyling.ActiveStyle.Colors.
 // Initialize
 using Gum.Themes.Neon;
 
-NeonStyling.ActiveStyle.Colors.Text = new Color(255, 224, 250);
-NeonStyling.ActiveStyle.Colors.Muted = new Color(128, 80, 128);
-NeonStyling.ActiveStyle.Colors.Surface1 = new Color(24, 8, 28);
+// Surface1 is what ListBoxVisual fills its background with, and Surface2 is its
+// hover-row tint — both need to move together or a hovered row looks stale.
 NeonStyling.ActiveStyle.Colors.Accent = new Color(255, 0, 200);
-NeonStyling.ActiveStyle.Colors.Glow = new Color(255, 0, 200);
-NeonStyling.ActiveStyle.Text.FontSize = 14;
+NeonStyling.ActiveStyle.Colors.Text = new Color(255, 250, 200);
+NeonStyling.ActiveStyle.Colors.Muted = new Color(140, 110, 160);
+NeonStyling.ActiveStyle.Colors.Surface1 = new Color(40, 10, 40);
+NeonStyling.ActiveStyle.Colors.Surface2 = new Color(55, 15, 55);
+NeonStyling.ActiveStyle.Text.FontFamily = "Consolas";
+NeonStyling.ActiveStyle.Text.FontSize = 17;
 
 NeonTheme.Apply(GraphicsDevice);
 ```
@@ -442,12 +461,19 @@ Retro95Theme.Apply();
 // Initialize
 using Gum.Themes.Retro95;
 
-Retro95Styling.ActiveStyle.Colors.Text = new Color(0, 0, 0);
-Retro95Styling.ActiveStyle.Colors.DisabledText = new Color(110, 110, 110);
+// Surface also drives the app's own clear color if you follow the pattern from the
+// Usage section above — Retro95 is the one theme where the outer backdrop is a real,
+// settable token rather than a separate literal.
 Retro95Styling.ActiveStyle.Colors.Surface = new Color(0, 128, 128);
-Retro95Styling.ActiveStyle.Colors.Selection = new Color(128, 0, 0);
+Retro95Styling.ActiveStyle.Colors.WhiteFill = new Color(220, 255, 255);
+Retro95Styling.ActiveStyle.Colors.Selection = new Color(128, 0, 32);
+Retro95Styling.ActiveStyle.Colors.HighlightInner = new Color(150, 220, 220);
 Retro95Styling.ActiveStyle.Colors.HighlightOuter = new Color(200, 255, 255);
-Retro95Styling.ActiveStyle.Text.FontSize = 13;
+Retro95Styling.ActiveStyle.Colors.ShadowInner = new Color(0, 80, 80);
+Retro95Styling.ActiveStyle.Colors.ShadowOuter = new Color(0, 50, 50);
+Retro95Styling.ActiveStyle.Colors.DisabledText = new Color(110, 70, 70);
+Retro95Styling.ActiveStyle.Text.FontFamily = "Consolas";
+Retro95Styling.ActiveStyle.Text.FontSize = 15;
 
 Retro95Theme.Apply(GraphicsDevice);
 ```
@@ -508,12 +534,21 @@ For the intended look, clear the back buffer to `MeadowStyling.ActiveStyle.Color
 // Initialize
 using Gum.Themes.Meadow;
 
-MeadowStyling.ActiveStyle.Colors.TealDark = new Color(20, 80, 70);
-MeadowStyling.ActiveStyle.Colors.Muted = new Color(150, 130, 110);
-MeadowStyling.ActiveStyle.Colors.Cream2 = new Color(255, 248, 235);
-MeadowStyling.ActiveStyle.Colors.Blue = new Color(237, 154, 120);
-MeadowStyling.ActiveStyle.Colors.Coral = new Color(70, 173, 230);
-MeadowStyling.ActiveStyle.Text.FontSize = 16;
+// Blue/BlueDark/BlueHover are the button's rest/pressed/hover fills — changing only
+// Blue leaves the shadow and hover states on the old sky-blue gradient. SageDark is
+// the checkbox/radio checked color; PeachDark is the shared border/outline token
+// (ListBox, input fields, dashed panels, splitter).
+MeadowStyling.ActiveStyle.Colors.Blue = new Color(230, 90, 70);
+MeadowStyling.ActiveStyle.Colors.BlueDark = new Color(150, 45, 35);
+MeadowStyling.ActiveStyle.Colors.BlueHover = new Color(245, 130, 105);
+MeadowStyling.ActiveStyle.Colors.TealDark = new Color(90, 40, 80);
+MeadowStyling.ActiveStyle.Colors.Muted = new Color(170, 130, 150);
+MeadowStyling.ActiveStyle.Colors.SageDark = new Color(170, 90, 140);
+MeadowStyling.ActiveStyle.Colors.PeachDark = new Color(200, 150, 175);
+MeadowStyling.ActiveStyle.Colors.Cream = new Color(238, 222, 235);
+MeadowStyling.ActiveStyle.Colors.Cream2 = new Color(245, 232, 242);
+MeadowStyling.ActiveStyle.Text.FontFamily = "Consolas";
+MeadowStyling.ActiveStyle.Text.FontSize = 17;
 
 MeadowTheme.Apply(GraphicsDevice);
 ```
@@ -574,12 +609,22 @@ For the intended look, clear the back buffer to `HazardStyling.ActiveStyle.Color
 // Initialize
 using Gum.Themes.Hazard;
 
-HazardStyling.ActiveStyle.Colors.Text = new Color(227, 100, 40);
-HazardStyling.ActiveStyle.Colors.Muted = new Color(120, 70, 38);
-HazardStyling.ActiveStyle.Colors.Surface1 = new Color(18, 16, 7);
-HazardStyling.ActiveStyle.Colors.Accent = new Color(244, 90, 26);
-HazardStyling.ActiveStyle.Colors.TextBright = new Color(255, 140, 59);
-HazardStyling.ActiveStyle.Text.FontSize = 16;
+// Selection (ListBox/MenuItem selected-row fill) and TextBright (its hover-row text)
+// default to the same hazard-yellow as Accent, and AccentPressed (Slider thumb press)
+// is a separate explicit token not derived from Accent — all three need to move with
+// it. Border/BorderHover is the shared outline every restyled control uses (ListBox
+// panel, Slider track, TextBox), so it has to move too or those three still read gold.
+HazardStyling.ActiveStyle.Colors.Accent = new Color(40, 140, 255);
+HazardStyling.ActiveStyle.Colors.Text = new Color(200, 230, 255);
+HazardStyling.ActiveStyle.Colors.Muted = new Color(90, 110, 140);
+HazardStyling.ActiveStyle.Colors.Selection = new Color(40, 140, 255);
+HazardStyling.ActiveStyle.Colors.TextBright = new Color(150, 200, 255);
+HazardStyling.ActiveStyle.Colors.AccentPressed = new Color(20, 100, 200);
+HazardStyling.ActiveStyle.Colors.Border = new Color(30, 70, 130);
+HazardStyling.ActiveStyle.Colors.BorderHover = new Color(70, 130, 200);
+HazardStyling.ActiveStyle.Colors.Placeholder = new Color(100, 120, 150);
+HazardStyling.ActiveStyle.Text.FontFamily = "Consolas";
+HazardStyling.ActiveStyle.Text.FontSize = 17;
 
 HazardTheme.Apply(GraphicsDevice);
 ```

--- a/docs/code/styling/themes/README.md
+++ b/docs/code/styling/themes/README.md
@@ -56,6 +56,23 @@ A few things to keep in mind:
 * **Call `Apply` after `Initialize` and before constructing Forms controls.** Controls capture their visuals at construction time, so any control built before `Apply` will keep the default styling.
 * **Themes compose with per-control styling.** For tweaking a single control on top of a theme, see [Code-Only Styling](../code-only-styling/styling-using-activestyles.md) and [Control Customization in Gum Tool](../control-customization-in-gum-tool.md).
 
+### Customizing a theme's colors and fonts
+
+Every theme exposes a mutable `XyzStyling.ActiveStyle` object — its own analog of V3's [`Styling.ActiveStyle`](../code-only-styling/styling-using-activestyles.md), and mutated the same way: set properties on `Colors`/`Text` *before* calling the theme's `Apply()`, not after. Controls created after `Apply()` pick up the change; this is the same "mutate before construct" creation-order rule that page documents for V3's own styling.
+
+```csharp
+// Initialize
+using Gum.Themes.DarkPro;
+
+DarkProStyling.ActiveStyle.Colors.Accent = Color.Purple;
+
+DarkProTheme.Apply(GraphicsDevice);
+```
+
+Every theme's `Colors` exposes the same four guardrail properties — `TextPrimary`, `TextMuted`, `Primary`, and `Accent` — which also flow into V3's own `Styling.ActiveStyle.Colors` for any stock, un-restyled control the theme leaves in place. On some themes these are the theme's real, settable color names directly. On others — where the theme already had its own color vocabulary before the guardrail existed — they're get-only aliases onto a differently named real property; for example Forest Glade's `Colors.Accent` is a read-only alias for `Colors.LeafBright`. Assign the theme's real property in that case; the guardrail alias reflects the change automatically, the same "reactivity is free" behavior as any other derived color. The "How to customize" example under each theme below names the real, settable property to use.
+
+`Text.FontFamily` selects among **already-registered** font families — it doesn't register a new one. Each theme registers its bundled TTFs once, inside `Apply()` / `RegisterBundledFonts()`, under a fixed family name exposed as a `BundledFontFamily` constant (e.g. `DarkProTheme.BundledFontFamily`). Reassigning `Text.FontFamily` only works if the family you name is already registered this way — either one of the theme's own bundled constants, or a font already installed on the host system, such as `"Consolas"` on Windows. KernSmith can resolve an installed system font by name without any explicit registration step, the same as the `Consolas` example on the [Styling Using ActiveStyles](../code-only-styling/styling-using-activestyles.md) page.
+
 ## Available themes
 
 ### Editor
@@ -100,6 +117,26 @@ EditorTheme.Apply();
 {% endtab %}
 {% endtabs %}
 
+#### How to customize
+
+```csharp
+// Initialize
+using Gum.Themes.Editor;
+
+EditorStyling.ActiveStyle.Colors.TextPrimary = new Color(210, 225, 255);
+EditorStyling.ActiveStyle.Colors.TextMuted = new Color(120, 130, 150);
+EditorStyling.ActiveStyle.Colors.Primary = new Color(40, 46, 64);
+EditorStyling.ActiveStyle.Colors.Accent = new Color(255, 196, 84);
+EditorStyling.ActiveStyle.Colors.Selection = new Color(64, 52, 16);
+EditorStyling.ActiveStyle.Text.FontFamily = "Consolas";
+
+EditorTheme.Apply(GraphicsDevice);
+```
+
+{% hint style="warning" %}
+Screenshot placeholder — replace with an `EditorCustomized` screenshot showing the above customization applied, captured via the Customize checkbox in `MonoGameGumThemesShowcase`.
+{% endhint %}
+
 ### DarkPro
 
 <figure><img src="../../../.gitbook/assets/DarkProThemeScreenshot.png" alt="DarkPro theme preview"><figcaption><p>The DarkPro theme applied to a sample settings panel.</p></figcaption></figure>
@@ -142,6 +179,26 @@ DarkProTheme.Apply();
 {% endtab %}
 {% endtabs %}
 
+#### How to customize
+
+```csharp
+// Initialize
+using Gum.Themes.DarkPro;
+
+DarkProStyling.ActiveStyle.Colors.Text = new Color(220, 220, 225);
+DarkProStyling.ActiveStyle.Colors.Muted = new Color(150, 150, 160);
+DarkProStyling.ActiveStyle.Colors.Surface1 = new Color(30, 34, 42);
+DarkProStyling.ActiveStyle.Colors.Accent = new Color(198, 120, 255);
+DarkProStyling.ActiveStyle.Colors.AccentDark = new Color(110, 60, 150);
+DarkProStyling.ActiveStyle.Text.FontFamily = "Consolas";
+
+DarkProTheme.Apply(GraphicsDevice);
+```
+
+{% hint style="warning" %}
+Screenshot placeholder — replace with a `DarkProCustomized` screenshot showing the above customization applied, captured via the Customize checkbox in `MonoGameGumThemesShowcase`.
+{% endhint %}
+
 ### Bubblegum
 
 <figure><img src="../../../.gitbook/assets/BubblegumThemeScreenshot.png" alt="Bubblegum theme preview"><figcaption><p>The Bubblegum theme applied to a sample settings panel.</p></figcaption></figure>
@@ -183,6 +240,26 @@ BubblegumTheme.Apply();
 ```
 {% endtab %}
 {% endtabs %}
+
+#### How to customize
+
+```csharp
+// Initialize
+using Gum.Themes.Bubblegum;
+
+BubblegumStyling.ActiveStyle.Colors.Text = new Color(35, 20, 60);
+BubblegumStyling.ActiveStyle.Colors.Muted = new Color(150, 120, 190);
+BubblegumStyling.ActiveStyle.Colors.Surface1 = new Color(255, 250, 253);
+BubblegumStyling.ActiveStyle.Colors.Accent = new Color(120, 200, 255);
+BubblegumStyling.ActiveStyle.Colors.AccentLight = new Color(210, 240, 255);
+BubblegumStyling.ActiveStyle.Text.FontSize = 16;
+
+BubblegumTheme.Apply(GraphicsDevice);
+```
+
+{% hint style="warning" %}
+Screenshot placeholder — replace with a `BubblegumCustomized` screenshot showing the above customization applied, captured via the Customize checkbox in `MonoGameGumThemesShowcase`.
+{% endhint %}
 
 ### Forest Glade
 
@@ -228,6 +305,27 @@ ForestGladeTheme.Apply();
 
 {% hint style="info" %}
 For the intended look, clear the back buffer to `ForestGladeStyling.ActiveStyle.Colors.CanopyDeep`.
+{% endhint %}
+
+#### How to customize
+
+```csharp
+// Initialize
+using Gum.Themes.ForestGlade;
+
+ForestGladeStyling.ActiveStyle.Colors.Text = new Color(255, 246, 224);
+ForestGladeStyling.ActiveStyle.Colors.Muted = new Color(196, 168, 130);
+ForestGladeStyling.ActiveStyle.Colors.CanopyDeep = new Color(48, 24, 10);
+ForestGladeStyling.ActiveStyle.Colors.LeafBright = new Color(255, 176, 59);
+ForestGladeStyling.ActiveStyle.Colors.ButtonRestFillTop = new Color(230, 140, 40);
+ForestGladeStyling.ActiveStyle.Colors.ButtonRestFillBottom = new Color(180, 90, 20);
+ForestGladeStyling.ActiveStyle.Text.FontSize = 15;
+
+ForestGladeTheme.Apply(GraphicsDevice);
+```
+
+{% hint style="warning" %}
+Screenshot placeholder — replace with a `ForestGladeCustomized` screenshot showing the above customization applied, captured via the Customize checkbox in `MonoGameGumThemesShowcase`.
 {% endhint %}
 
 ### Neon
@@ -276,6 +374,26 @@ NeonTheme.Apply();
 For the intended look, clear the back buffer to `NeonStyling.ActiveStyle.Colors.Background` (`#060612`).
 {% endhint %}
 
+#### How to customize
+
+```csharp
+// Initialize
+using Gum.Themes.Neon;
+
+NeonStyling.ActiveStyle.Colors.Text = new Color(255, 224, 250);
+NeonStyling.ActiveStyle.Colors.Muted = new Color(128, 80, 128);
+NeonStyling.ActiveStyle.Colors.Surface1 = new Color(24, 8, 28);
+NeonStyling.ActiveStyle.Colors.Accent = new Color(255, 0, 200);
+NeonStyling.ActiveStyle.Colors.Glow = new Color(255, 0, 200);
+NeonStyling.ActiveStyle.Text.FontSize = 14;
+
+NeonTheme.Apply(GraphicsDevice);
+```
+
+{% hint style="warning" %}
+Screenshot placeholder — replace with a `NeonCustomized` screenshot showing the above customization applied, captured via the Customize checkbox in `MonoGameGumThemesShowcase`.
+{% endhint %}
+
 ### Retro95
 
 <figure><img src="../../../.gitbook/assets/Retro95ThemeScreenshot.png" alt="Retro95 theme preview"><figcaption><p>The Retro95 theme applied to a sample settings panel.</p></figcaption></figure>
@@ -317,6 +435,26 @@ Retro95Theme.Apply();
 ```
 {% endtab %}
 {% endtabs %}
+
+#### How to customize
+
+```csharp
+// Initialize
+using Gum.Themes.Retro95;
+
+Retro95Styling.ActiveStyle.Colors.Text = new Color(0, 0, 0);
+Retro95Styling.ActiveStyle.Colors.DisabledText = new Color(110, 110, 110);
+Retro95Styling.ActiveStyle.Colors.Surface = new Color(0, 128, 128);
+Retro95Styling.ActiveStyle.Colors.Selection = new Color(128, 0, 0);
+Retro95Styling.ActiveStyle.Colors.HighlightOuter = new Color(200, 255, 255);
+Retro95Styling.ActiveStyle.Text.FontSize = 13;
+
+Retro95Theme.Apply(GraphicsDevice);
+```
+
+{% hint style="warning" %}
+Screenshot placeholder — replace with a `Retro95Customized` screenshot showing the above customization applied, captured via the Customize checkbox in `MonoGameGumThemesShowcase`.
+{% endhint %}
 
 ### Meadow
 
@@ -364,6 +502,26 @@ MeadowTheme.Apply();
 For the intended look, clear the back buffer to `MeadowStyling.ActiveStyle.Colors.Cream` (`#F7EDD6`).
 {% endhint %}
 
+#### How to customize
+
+```csharp
+// Initialize
+using Gum.Themes.Meadow;
+
+MeadowStyling.ActiveStyle.Colors.TealDark = new Color(20, 80, 70);
+MeadowStyling.ActiveStyle.Colors.Muted = new Color(150, 130, 110);
+MeadowStyling.ActiveStyle.Colors.Cream2 = new Color(255, 248, 235);
+MeadowStyling.ActiveStyle.Colors.Blue = new Color(237, 154, 120);
+MeadowStyling.ActiveStyle.Colors.Coral = new Color(70, 173, 230);
+MeadowStyling.ActiveStyle.Text.FontSize = 16;
+
+MeadowTheme.Apply(GraphicsDevice);
+```
+
+{% hint style="warning" %}
+Screenshot placeholder — replace with a `MeadowCustomized` screenshot showing the above customization applied, captured via the Customize checkbox in `MonoGameGumThemesShowcase`.
+{% endhint %}
+
 ### Hazard
 
 <figure><img src="../../../.gitbook/assets/31_19 13 36.png" alt=""><figcaption><p>The Hazard theme applied to a sample settings panel.</p></figcaption></figure>
@@ -408,6 +566,26 @@ HazardTheme.Apply();
 
 {% hint style="info" %}
 For the intended look, clear the back buffer to `HazardStyling.ActiveStyle.Colors.Background` (`#0A0A08`).
+{% endhint %}
+
+#### How to customize
+
+```csharp
+// Initialize
+using Gum.Themes.Hazard;
+
+HazardStyling.ActiveStyle.Colors.Text = new Color(227, 100, 40);
+HazardStyling.ActiveStyle.Colors.Muted = new Color(120, 70, 38);
+HazardStyling.ActiveStyle.Colors.Surface1 = new Color(18, 16, 7);
+HazardStyling.ActiveStyle.Colors.Accent = new Color(244, 90, 26);
+HazardStyling.ActiveStyle.Colors.TextBright = new Color(255, 140, 59);
+HazardStyling.ActiveStyle.Text.FontSize = 16;
+
+HazardTheme.Apply(GraphicsDevice);
+```
+
+{% hint style="warning" %}
+Screenshot placeholder — replace with a `HazardCustomized` screenshot showing the above customization applied, captured via the Customize checkbox in `MonoGameGumThemesShowcase`.
 {% endhint %}
 
 ## Fonts and licensing

--- a/docs/code/styling/themes/README.md
+++ b/docs/code/styling/themes/README.md
@@ -134,7 +134,7 @@ EditorTheme.Apply(GraphicsDevice);
 ```
 
 {% hint style="warning" %}
-Screenshot placeholder — replace with an `EditorCustomized` screenshot showing the above customization applied, captured via the Customize checkbox in `MonoGameGumThemesShowcase`.
+Screenshot placeholder — replace with an `EditorCustomized` screenshot showing the above customization applied, captured via the "Show Customized" checkbox in `MonoGameGumThemesShowcase`.
 {% endhint %}
 
 ### DarkPro
@@ -196,7 +196,7 @@ DarkProTheme.Apply(GraphicsDevice);
 ```
 
 {% hint style="warning" %}
-Screenshot placeholder — replace with a `DarkProCustomized` screenshot showing the above customization applied, captured via the Customize checkbox in `MonoGameGumThemesShowcase`.
+Screenshot placeholder — replace with a `DarkProCustomized` screenshot showing the above customization applied, captured via the "Show Customized" checkbox in `MonoGameGumThemesShowcase`.
 {% endhint %}
 
 ### Bubblegum
@@ -258,7 +258,7 @@ BubblegumTheme.Apply(GraphicsDevice);
 ```
 
 {% hint style="warning" %}
-Screenshot placeholder — replace with a `BubblegumCustomized` screenshot showing the above customization applied, captured via the Customize checkbox in `MonoGameGumThemesShowcase`.
+Screenshot placeholder — replace with a `BubblegumCustomized` screenshot showing the above customization applied, captured via the "Show Customized" checkbox in `MonoGameGumThemesShowcase`.
 {% endhint %}
 
 ### Forest Glade
@@ -325,7 +325,7 @@ ForestGladeTheme.Apply(GraphicsDevice);
 ```
 
 {% hint style="warning" %}
-Screenshot placeholder — replace with a `ForestGladeCustomized` screenshot showing the above customization applied, captured via the Customize checkbox in `MonoGameGumThemesShowcase`.
+Screenshot placeholder — replace with a `ForestGladeCustomized` screenshot showing the above customization applied, captured via the "Show Customized" checkbox in `MonoGameGumThemesShowcase`.
 {% endhint %}
 
 ### Neon
@@ -391,7 +391,7 @@ NeonTheme.Apply(GraphicsDevice);
 ```
 
 {% hint style="warning" %}
-Screenshot placeholder — replace with a `NeonCustomized` screenshot showing the above customization applied, captured via the Customize checkbox in `MonoGameGumThemesShowcase`.
+Screenshot placeholder — replace with a `NeonCustomized` screenshot showing the above customization applied, captured via the "Show Customized" checkbox in `MonoGameGumThemesShowcase`.
 {% endhint %}
 
 ### Retro95
@@ -453,7 +453,7 @@ Retro95Theme.Apply(GraphicsDevice);
 ```
 
 {% hint style="warning" %}
-Screenshot placeholder — replace with a `Retro95Customized` screenshot showing the above customization applied, captured via the Customize checkbox in `MonoGameGumThemesShowcase`.
+Screenshot placeholder — replace with a `Retro95Customized` screenshot showing the above customization applied, captured via the "Show Customized" checkbox in `MonoGameGumThemesShowcase`.
 {% endhint %}
 
 ### Meadow
@@ -519,7 +519,7 @@ MeadowTheme.Apply(GraphicsDevice);
 ```
 
 {% hint style="warning" %}
-Screenshot placeholder — replace with a `MeadowCustomized` screenshot showing the above customization applied, captured via the Customize checkbox in `MonoGameGumThemesShowcase`.
+Screenshot placeholder — replace with a `MeadowCustomized` screenshot showing the above customization applied, captured via the "Show Customized" checkbox in `MonoGameGumThemesShowcase`.
 {% endhint %}
 
 ### Hazard
@@ -585,7 +585,7 @@ HazardTheme.Apply(GraphicsDevice);
 ```
 
 {% hint style="warning" %}
-Screenshot placeholder — replace with a `HazardCustomized` screenshot showing the above customization applied, captured via the Customize checkbox in `MonoGameGumThemesShowcase`.
+Screenshot placeholder — replace with a `HazardCustomized` screenshot showing the above customization applied, captured via the "Show Customized" checkbox in `MonoGameGumThemesShowcase`.
 {% endhint %}
 
 ## Fonts and licensing


### PR DESCRIPTION
## Summary
- Adds a persistent "Customize" checkbox to `MonoGameGumThemesShowcase` and `RaylibGumThemesShowcase` that applies a hardcoded per-theme color/font customization to whichever theme is currently active (number-key switcher), reverting on uncheck. Throwaway authoring tooling to preview values before manually capturing docs screenshots — not a documented public feature, no shared source of truth with the docs examples.
- Adds a "How to customize" subsection to each of the 8 shipped themes in `docs/code/styling/themes/README.md`, plus a once-only mechanics explanation in the shared `## Usage` section (mutate-before-`Apply()`, the `TextPrimary`/`TextMuted`/`Primary`/`Accent` guardrail-alias caveat, and the font registration/selection split). Each example leaves a `{% hint %}` screenshot placeholder for the "customized" variant image.

Follow-up to the theme-palette migration (#3437, merged via #3439/#3441/#3442/#3443).

## Test plan
- [x] `dotnet build Samples\MonoGameGumThemesShowcase\MonoGameGumThemesShowcase.csproj` — 0 warnings, 0 errors
- [x] `dotnet build Samples\RaylibGumThemesShowcase\RaylibGumThemesShowcase.csproj` — 0 errors (no new warnings)
- [x] Manual: run the showcase, cycle themes 1-9, toggle Customize on each, confirm colors/font swap and revert cleanly, and confirm swapping themes while checked doesn't leave stale customization applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)
