### PR TITLE
Fix RaylibGum font-cache poisoning causing repeated texture regen/leak

### DIFF
--- a/Runtimes/RaylibGum/Renderables/CustomSetPropertyOnRenderable.cs
+++ b/Runtimes/RaylibGum/Renderables/CustomSetPropertyOnRenderable.cs
@@ -699,6 +699,16 @@ public class CustomSetPropertyOnRenderable
                             Raylib_cs.Font? createdFont = InMemoryFontCreator.TryCreateFont(bmfcSave);
                             if (createdFont.HasValue && createdFont.Value.BaseSize != 0)
                             {
+                                // Heal a poisoned cache slot: the disk-fallback path below can legitimately
+                                // cache an empty (BaseSize 0) placeholder under this exact key when no
+                                // FontCache .fnt exists on disk (see the cache-hit guard above) -- e.g. when
+                                // a font is requested before InMemoryFontCreator gets wired up. AddDisposable's
+                                // default ExistingContentBehavior.ThrowException would throw on that occupied
+                                // slot; left unguarded, the caller's catch swallows it and the newly created
+                                // (working) font -- and its GPU texture -- is discarded, forever re-triggering
+                                // this (expensive) rasterization on every subsequent request. Dispose the old
+                                // entry first (a no-op if nothing is cached) so the slot is free.
+                                loaderManager.Dispose(fullFileName);
                                 loaderManager.AddDisposable(fullFileName, new ManagedFont(createdFont.Value));
                                 AssignFontIfChanged(asText, createdFont.Value);
                                 return;

--- a/Samples/RaylibGumThemesShowcase/Program.cs
+++ b/Samples/RaylibGumThemesShowcase/Program.cs
@@ -88,6 +88,17 @@ public static class Program
             new ThemeOption("Template", TemplateTheme.Apply, () => TemplateStyling.ActiveStyle.Colors.Background, SetTemplateCustomized),
         };
 
+        _currentScreenFactory = () => new AllControlsScreen();
+
+        // ApplyTheme runs FIRST so its Apply() wires CustomSetPropertyOnRenderable.InMemoryFontCreator
+        // (KernSmith) before anything requests a font. Building the checkbox before this point (its
+        // Text setter requests a font) used to poison the (Arial, 18) FontCache cache slot with an
+        // empty placeholder — the disk-fallback path caches that empty entry when no InMemoryFontCreator
+        // is wired yet and no FontCache .fnt exists on disk. Once healing was fixed on the runtime side
+        // this reordering isn't strictly required to avoid a leak, but it still avoids the wasted first
+        // lookup and keeps font requests consistently flowing through the in-memory creator.
+        ApplyTheme(0);
+
         // Authoring-only "Show Customized" checkbox — survives F1/F2 screen swaps via its own
         // AddToRoot call, separate from ShowcaseScreen's root-element bookkeeping. Created
         // before the first RebuildScreen call below so RebuildScreen can always rely on it
@@ -101,8 +112,6 @@ public static class Program
         _customizeCheckBox.Unchecked += (_, _) => ApplyCustomizationToggle(false);
         _customizeCheckBox.AddToRoot();
 
-        _currentScreenFactory = () => new AllControlsScreen();
-        ApplyTheme(0);
         RebuildScreen();
 
         while (!WindowShouldClose())

--- a/Tests/RaylibGum.Tests/Runtimes/TextRuntimeFontCachingRegressionTests.cs
+++ b/Tests/RaylibGum.Tests/Runtimes/TextRuntimeFontCachingRegressionTests.cs
@@ -2,8 +2,11 @@ using Gum.DataTypes;
 using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
+using KernSmith.Gum;
 using Raylib_cs;
+using RaylibGum.Renderables;
 using RenderingLibrary.Content;
+using RenderingLibrary.Graphics.Fonts;
 using Shouldly;
 using System;
 using System.Collections.Generic;
@@ -70,6 +73,69 @@ public class TextRuntimeFontCachingRegressionTests : BaseTestClass
             TextRuntime second = NewArial18Text("List item 2");
             second.GetAbsoluteHeight().ShouldBe(21);
         });
+    }
+
+    // Regression for the font-cache-poisoning bug (RaylibGumThemesShowcase spamming texture loads on
+    // every theme switch): a font requested BEFORE InMemoryFontCreator is wired (e.g. a control built
+    // before ApplyTheme runs) falls to the disk-fallback path, finds no FontCache .fnt, and caches an
+    // empty (BaseSize 0) placeholder under that font's cache key. The *rendered* text still looks fine
+    // (a separate system-font-by-family-name fallback kicks in), so the poisoning is invisible except
+    // through what happens once InMemoryFontCreator IS wired: a later request for the SAME font must
+    // heal that poisoned slot -- not throw inside AddDisposable (default
+    // ExistingContentBehavior.ThrowException), get silently swallowed by the surrounding catch, and
+    // re-run the (expensive) in-memory rasterization -- and leak its GPU texture -- on every request.
+    [Fact]
+    public void UpdateToFontValues_WhenCacheSlotPoisonedByEmptyPlaceholder_AndInMemoryFontCreatorLaterWired_HealsCacheInsteadOfLeaking()
+    {
+        WithCachingOnAndNoFontFiles(() =>
+        {
+            // Step 1: poison the cache slot for (Arial, 18). No InMemoryFontCreator wired yet, so the
+            // lookup falls to disk, finds nothing, and caches an empty (BaseSize 0) placeholder under
+            // this font's cache key.
+            NewArial18Text("Poisoning request");
+
+            CountingFontCreator creator = new CountingFontCreator();
+            IRaylibFontCreator? savedCreator = CustomSetPropertyOnRenderable.InMemoryFontCreator;
+            try
+            {
+                CustomSetPropertyOnRenderable.InMemoryFontCreator = creator;
+
+                // Step 2: a second text requesting the SAME font, now that a creator can produce one,
+                // must heal the poisoned cache slot instead of the newly created font being discarded.
+                NewArial18Text("Healed request");
+                int callCountAfterHeal = creator.CallCount;
+                callCountAfterHeal.ShouldBeGreaterThan(0,
+                    "the wired creator must have been consulted at least once for the poisoned font");
+
+                // Step 3: a third text requesting the same font must hit the now-healed cache rather
+                // than calling into the creator again -- proves the heal actually persisted, not just a
+                // one-off lucky assignment.
+                NewArial18Text("Cached request");
+                creator.CallCount.ShouldBe(callCountAfterHeal,
+                    "a healed cache entry must be reused by later requests for the same font, not " +
+                    "regenerated (re-rasterized) on every request");
+            }
+            finally
+            {
+                CustomSetPropertyOnRenderable.InMemoryFontCreator = savedCreator;
+            }
+        });
+    }
+
+    // Wraps the real KernSmithRaylibFontCreator (rather than a hand-built Raylib_cs.Font, whose
+    // unmanaged Recs/Glyphs pointers would need to be valid for UnloadFont to safely dispose it later)
+    // so it produces a genuinely usable, disposable font while recording how many times it was asked.
+    private sealed class CountingFontCreator : IRaylibFontCreator
+    {
+        private readonly KernSmithRaylibFontCreator _inner = new();
+
+        public int CallCount { get; private set; }
+
+        public Raylib_cs.Font? TryCreateFont(BmfcSave bmfcSave)
+        {
+            CallCount++;
+            return _inner.TryCreateFont(bmfcSave);
+        }
     }
 
     // Positive guard for the user-visible symptom: with valid fonts, a vertical stack must reflow to the


### PR DESCRIPTION
## Summary
- Fixes a font-cache-poisoning bug in RaylibGum that caused `RaylibGumThemesShowcase` (and any raylib app relying on KernSmith's in-memory font creation) to repeatedly re-rasterize and re-upload the same font atlas texture on every request for it, once its cache slot was ever "poisoned" — flooding the console with `TEXTURE: [ID nnn] Texture loaded successfully` lines and making theme switches slow.
- Root cause: a font requested before `CustomSetPropertyOnRenderable.InMemoryFontCreator` is wired falls to the disk-fallback path and caches an empty (`BaseSize == 0`) placeholder under its cache key (no `FontCache/*.fnt` on disk, as expected for KernSmith-only setups). Once that slot is occupied, every later *successful* in-memory font creation for that same key threw inside `AddDisposable` (default `ExistingContentBehavior.ThrowException` on an occupied slot), got silently swallowed by the surrounding `catch`, and the newly-created (working) font/GPU texture was discarded — leaking VRAM and re-triggering the (expensive) rasterization on every subsequent request, forever.
- Fix: dispose the occupied cache slot before writing the newly-created font, so a later successful creation heals a poisoned entry instead of leaking it (`CustomSetPropertyOnRenderable.cs`). Also reordered `RaylibGumThemesShowcase/Program.cs` so no font gets requested before `ApplyTheme(0)` wires the in-memory creator, removing the trigger that poisoned the cache in the first place.

## Test plan
- [x] Added `UpdateToFontValues_WhenCacheSlotPoisonedByEmptyPlaceholder_AndInMemoryFontCreatorLaterWired_HealsCacheInsteadOfLeaking` in `TextRuntimeFontCachingRegressionTests.cs` — poisons a font's cache slot, wires an `IRaylibFontCreator` that wraps the real `KernSmithRaylibFontCreator` and counts calls, and asserts a third request for the same font does not re-invoke the creator (i.e. the cache healed). Confirmed red (creator re-invoked on every request) before the fix, green after.
- [x] Full `RaylibGum.Tests` suite green: 372 passed, 1 pre-existing/unrelated skip, 0 failed.
- [x] Manual verification: ran the (rebuilt) `RaylibGumThemesShowcase` sample, cycled themes via simulated keypresses, and confirmed via the console log line count that revisiting an already-loaded theme now produces **zero** new texture loads (previously it re-spammed the same ~120-190 lines every single switch, including revisits).
