### PR TITLE
Re-enable ClipsChildren inside a render target on raylib (#3440)

### DIFF
--- a/Runtimes/RaylibGum/RenderingLibrary/Renderer.cs
+++ b/Runtimes/RaylibGum/RenderingLibrary/Renderer.cs
@@ -46,16 +46,20 @@ public class Renderer : IRenderer
     // (exact-size recreation on resize + frame-boundary sweep) exactly like ShadowBlur.
     readonly Gum.Renderables.RenderTextureService _renderTargetService = new();
 
-    // True while baking a render-target container's subtree into its offscreen texture. Used to
-    // suppress the screen-space scissor machinery in DrawGumRecursively, whose rects are wrong once
-    // drawing is redirected into an RT framebuffer (raylib flips scissor Y by the screen height, not
-    // the RT height, and that behavior diverges under software GL). Clipping descendants inside an RT
-    // container is therefore unsupported — deferred, see #3440.
+    // True while baking a render-target container's subtree into its offscreen texture. Inside a
+    // bake, DrawGumRecursively rebases scissor rects into RT-local space (the clamped top-left is
+    // the RT origin) so a ClipsChildren descendant clips correctly within the RT (#3440).
     bool _isBakingRenderTarget;
 
+    // The active bake's clamped top-left in world coords, captured so DrawGumRecursively can convert
+    // a descendant's absolute bounds into RT-local scissor pixels. Only meaningful while
+    // _isBakingRenderTarget is true; bakes are never re-entrant (post-order means an inner RT is
+    // fully baked before its outer one begins), so single fields suffice.
+    float _bakeLeft;
+    float _bakeTop;
+
     // Reused across bakes so a bake doesn't allocate a fresh scissor stack each frame. Swapped in
-    // for the duration of a bake and restored afterward; scissor is suppressed during a bake, so it
-    // simply guards the main-walk scissor stack from any leakage.
+    // for the duration of a bake and restored afterward; balanced push/pop leaves it empty.
     readonly Stack<System.Drawing.Rectangle> _bakeScissorStack = new();
 
     // Set during the PreRender walk (which already traverses the whole visible tree) when any
@@ -299,7 +303,7 @@ public class Renderer : IRenderer
         if (CameraScissorExtensions.CullOffscreenWhenClipped
             && _scissorStack.Count > 0
             && CameraScissorExtensions.IsFullyOutside(
-                _camera.GetScissorRectangleFor(layer, element),
+                GetScissorRectangleFor(layer, element),
                 _scissorStack.Peek(),
                 CameraScissorExtensions.OffscreenCullMarginInPixels))
         {
@@ -331,16 +335,9 @@ public class Renderer : IRenderer
 
         element.Render(null);
 
-        // Inside an RT bake the screen-space scissor rects are invalid — raylib flips scissor Y by
-        // the screen height (not the RT height) while a render texture is bound, and that behavior
-        // diverges under software GL (Mesa llvmpipe on CI). So clipping is suppressed during a bake:
-        // a ClipsChildren descendant inside a render-target container does NOT clip. Deferred, see
-        // #3440.
-        bool suppressScissor = _isBakingRenderTarget;
-
-        if (element.ClipsChildren && !suppressScissor)
+        if (element.ClipsChildren)
         {
-            System.Drawing.Rectangle rect = _camera.GetScissorRectangleFor(layer, element);
+            System.Drawing.Rectangle rect = GetScissorRectangleFor(layer, element);
             System.Drawing.Rectangle effective = _scissorStack.Count > 0
                 ? System.Drawing.Rectangle.Intersect(_scissorStack.Peek(), rect)
                 : rect;
@@ -359,7 +356,7 @@ public class Renderer : IRenderer
             }
         }
 
-        if (element.ClipsChildren && !suppressScissor)
+        if (element.ClipsChildren)
         {
             _scissorStack.Pop();
             if (_scissorStack.Count > 0)
@@ -372,6 +369,32 @@ public class Renderer : IRenderer
                 BatchDrawCallCounter.EndScissorMode();
             }
         }
+    }
+
+    // Scissor rectangle for a clipping element, in whatever coordinate space the current pass uses:
+    // screen space normally, RT-local pixel space during a bake. During a bake drawing is redirected
+    // into the container's offscreen framebuffer via an offset BeginMode2D, so a descendant's clip
+    // rect must be expressed relative to the bake origin (the clamped top-left). raylib's
+    // BeginScissorMode takes top-left coordinates and applies its own Y flip; passing the RT-local
+    // top-left rect directly clips the correct rows on both hardware GL and software GL (Mesa
+    // llvmpipe) — no screen-height compensation is needed (that was the #3436 mistake, #3440).
+    private System.Drawing.Rectangle GetScissorRectangleFor(Layer layer, IRenderableIpso element)
+    {
+        if (!_isBakingRenderTarget)
+        {
+            return _camera.GetScissorRectangleFor(layer, element);
+        }
+
+        float zoom = _camera.Zoom;
+        int left = global::RenderingLibrary.Math.MathFunctions.RoundToInt(
+            (element.GetAbsoluteLeft() - _bakeLeft) * zoom);
+        int top = global::RenderingLibrary.Math.MathFunctions.RoundToInt(
+            (element.GetAbsoluteTop() - _bakeTop) * zoom);
+        int right = global::RenderingLibrary.Math.MathFunctions.RoundToInt(
+            (element.GetAbsoluteRight() - _bakeLeft) * zoom);
+        int bottom = global::RenderingLibrary.Math.MathFunctions.RoundToInt(
+            (element.GetAbsoluteBottom() - _bakeTop) * zoom);
+        return new System.Drawing.Rectangle(left, top, right - left, bottom - top);
     }
 
     // Post-order (innermost-first) walk that bakes every render-target container's subtree into an
@@ -430,13 +453,17 @@ public class Renderer : IRenderer
         };
 
         // Swap in the reusable bake scissor stack (avoids a per-bake allocation) so the main-walk
-        // scissor stack is isolated from the bake. Scissor is suppressed during a bake anyway
-        // (clipping inside an RT is deferred, see #3440), so this only guards against leakage.
+        // scissor stack is isolated from the bake, and capture the bake origin so DrawGumRecursively
+        // can rebase a ClipsChildren descendant's clip rect into RT-local space (#3440).
         Stack<System.Drawing.Rectangle> savedScissorStack = _scissorStack;
         _bakeScissorStack.Clear();
         _scissorStack = _bakeScissorStack;
         bool wasBaking = _isBakingRenderTarget;
+        float savedBakeLeft = _bakeLeft;
+        float savedBakeTop = _bakeTop;
         _isBakingRenderTarget = true;
+        _bakeLeft = left;
+        _bakeTop = top;
 
         counter.BeginTextureMode(renderTexture.Value);
         Raylib.ClearBackground(new Color((byte)0, (byte)0, (byte)0, (byte)0));
@@ -462,6 +489,8 @@ public class Renderer : IRenderer
         counter.EndTextureMode();
 
         _isBakingRenderTarget = wasBaking;
+        _bakeLeft = savedBakeLeft;
+        _bakeTop = savedBakeTop;
         _scissorStack = savedScissorStack;
     }
 

--- a/Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/RenderTargetScreen.cs
+++ b/Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/RenderTargetScreen.cs
@@ -38,8 +38,7 @@ internal class RenderTargetScreen : FrameworkElement
         root.AddChild(BuildCell("Additive group", BuildAdditiveGroup()));
         root.AddChild(BuildCell("Nested RT + sibling", BuildNestedWithSibling()));
         root.AddChild(BuildCell("Overflow clipped", BuildOverflow()));
-        // clip-inside-RT: deferred, see #3440 — cell kept out to stay parallel with the raylib
-        // sample, where a ClipsChildren descendant inside a render target renders unclipped.
+        root.AddChild(BuildCell("ClipsChildren inside RT", BuildClipsChildrenInside()));
     }
 
     private static ContainerRuntime BuildCell(string caption, GraphicalUiElement body)
@@ -249,6 +248,31 @@ internal class RenderTargetScreen : FrameworkElement
         return holder;
     }
 
-    // clip-inside-RT: deferred, see #3440. A "ClipsChildren descendant inside an RT" cell used to
-    // live here; kept out to stay parallel with the raylib sample, where that case is unsupported.
+    // A ClipsChildren descendant inside the render target. The clip container is the left half; its
+    // over-wide red child must be clipped to that half within the baked texture (#3440).
+    private static GraphicalUiElement BuildClipsChildrenInside()
+    {
+        var holder = BuildFrame(150, 110);
+
+        var group = new ContainerRuntime();
+        group.Width = 150;
+        group.Height = 110;
+        group.IsRenderTarget = true;
+
+        var clip = new ContainerRuntime();
+        clip.X = 10;
+        clip.Y = 10;
+        clip.Width = 65;
+        clip.Height = 90;
+        clip.ClipsChildren = true;
+        clip.AddChild(Rect(0, 0, 260, 90, new Color(220, 60, 60, 255)));
+
+        // A marker on the right proves the render target itself extends past the clip region.
+        var marker = Rect(95, 10, 45, 90, new Color(60, 120, 220, 255));
+
+        group.AddChild(clip);
+        group.AddChild(marker);
+        holder.AddChild(group);
+        return holder;
+    }
 }

--- a/Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/RenderTargetScreen.cs
+++ b/Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/RenderTargetScreen.cs
@@ -255,8 +255,9 @@ internal class RenderTargetScreen : FrameworkElement
     // the child must be a circle.)
     //
     // Same outline-circle rules as BuildOverflow: leave IsFilled off and set the ring via Color (NOT
-    // StrokeColor) so it renders identically on MonoGame and raylib. Kept identical to the raylib
-    // sample's BuildClipsChildrenInside.
+    // StrokeColor) so it renders identically on MonoGame and raylib. The clip window is a sub-region
+    // of the render target, so the empty area to its right is the RT extending past the clip. Kept
+    // identical to the raylib sample's BuildClipsChildrenInside.
     private static GraphicalUiElement BuildClipsChildrenInside()
     {
         var holder = BuildFrame(150, 110);
@@ -281,12 +282,7 @@ internal class RenderTargetScreen : FrameworkElement
         circle.Color = new Color(220, 60, 60, 255);
         clip.AddChild(circle);
 
-        // A solid marker to the right of the clip window (still inside the render target) proves the
-        // RT itself extends past the clip: the circle is sliced by ClipsChildren, not by the RT bounds.
-        var marker = Rect(95, 10, 45, 90, new Color(60, 120, 220, 255));
-
         group.AddChild(clip);
-        group.AddChild(marker);
         holder.AddChild(group);
         return holder;
     }

--- a/Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/RenderTargetScreen.cs
+++ b/Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/RenderTargetScreen.cs
@@ -248,8 +248,15 @@ internal class RenderTargetScreen : FrameworkElement
         return holder;
     }
 
-    // A ClipsChildren descendant inside the render target. The clip container is the left half; its
-    // over-wide red child must be clipped to that half within the baked texture (#3440).
+    // A ClipsChildren descendant inside the render target (#3440). The clipped child is an OUTLINED
+    // circle far larger than the clip window: its right and bottom arcs are sliced dead flat at the
+    // clip boundary, so the clip is unmistakable — a curve cut to a straight edge. (Clipping a
+    // rectangle to a rectangle just yields a smaller rectangle and demonstrates nothing, which is why
+    // the child must be a circle.)
+    //
+    // Same outline-circle rules as BuildOverflow: leave IsFilled off and set the ring via Color (NOT
+    // StrokeColor) so it renders identically on MonoGame and raylib. Kept identical to the raylib
+    // sample's BuildClipsChildrenInside.
     private static GraphicalUiElement BuildClipsChildrenInside()
     {
         var holder = BuildFrame(150, 110);
@@ -265,9 +272,17 @@ internal class RenderTargetScreen : FrameworkElement
         clip.Width = 65;
         clip.Height = 90;
         clip.ClipsChildren = true;
-        clip.AddChild(Rect(0, 0, 260, 90, new Color(220, 60, 60, 255)));
 
-        // A marker on the right proves the render target itself extends past the clip region.
+        var circle = new CircleRuntime();
+        circle.X = 5;
+        circle.Y = 5;
+        circle.Width = 120;
+        circle.Height = 120;
+        circle.Color = new Color(220, 60, 60, 255);
+        clip.AddChild(circle);
+
+        // A solid marker to the right of the clip window (still inside the render target) proves the
+        // RT itself extends past the clip: the circle is sliced by ClipsChildren, not by the RT bounds.
         var marker = Rect(95, 10, 45, 90, new Color(60, 120, 220, 255));
 
         group.AddChild(clip);

--- a/Samples/raylib/Screens/RenderTargetScreen.cs
+++ b/Samples/raylib/Screens/RenderTargetScreen.cs
@@ -265,8 +265,9 @@ internal class RenderTargetScreen : FrameworkElement
     // rectangle and demonstrates nothing, which is why the child must be a circle.)
     //
     // Same outline-circle rules as BuildOverflow: leave IsFilled off and set the ring via Color (NOT
-    // StrokeColor) so it renders identically on MonoGame and raylib. Kept identical to the MonoGame
-    // sample's BuildClipsChildrenInside.
+    // StrokeColor) so it renders identically on MonoGame and raylib. The clip window is a sub-region
+    // of the render target, so the empty area to its right is the RT extending past the clip. Kept
+    // identical to the MonoGame sample's BuildClipsChildrenInside.
     static GraphicalUiElement BuildClipsChildrenInside()
     {
         ContainerRuntime holder = BuildFrame(150, 110);
@@ -291,13 +292,7 @@ internal class RenderTargetScreen : FrameworkElement
         circle.Color = new Color((byte)220, (byte)60, (byte)60, (byte)255);
         clip.Children.Add(circle);
 
-        // A solid marker to the right of the clip window (still inside the render target) proves the
-        // RT itself extends past the clip: the circle is sliced by ClipsChildren, not by the RT bounds.
-        ColoredRectangleRuntime marker =
-            Rect(95, 10, 45, 90, new Color((byte)60, (byte)120, (byte)220, (byte)255));
-
         group.Children.Add(clip);
-        group.Children.Add(marker);
         holder.Children.Add(group);
         return holder;
     }

--- a/Samples/raylib/Screens/RenderTargetScreen.cs
+++ b/Samples/raylib/Screens/RenderTargetScreen.cs
@@ -41,8 +41,7 @@ internal class RenderTargetScreen : FrameworkElement
         root.Children.Add(BuildCell("Additive group", BuildAdditiveGroup()));
         root.Children.Add(BuildCell("Nested RT + sibling", BuildNestedWithSibling()));
         root.Children.Add(BuildCell("Overflow clipped", BuildOverflow()));
-        // clip-inside-RT: deferred, see #3440 (fails under CI software GL) — cell removed so the
-        // sample doesn't show a ClipsChildren descendant rendering unclipped inside a render target.
+        root.Children.Add(BuildCell("ClipsChildren inside RT", BuildClipsChildrenInside()));
     }
 
     static ContainerRuntime BuildCell(string caption, GraphicalUiElement body)
@@ -258,7 +257,34 @@ internal class RenderTargetScreen : FrameworkElement
         return holder;
     }
 
-    // clip-inside-RT: deferred, see #3440. A "ClipsChildren descendant inside an RT" cell used to
-    // live here, but that case is unsupported (fails under CI software GL), so it was removed rather
-    // than show a descendant rendering unclipped.
+    // A ClipsChildren descendant inside the render target. The clip container is the left half; its
+    // over-wide red child must be clipped to that half within the baked texture (#3440). The clip
+    // rect is rebased into RT-local space during the bake, so it lands correctly on both hardware GL
+    // and software GL (Mesa llvmpipe).
+    static GraphicalUiElement BuildClipsChildrenInside()
+    {
+        ContainerRuntime holder = BuildFrame(150, 110);
+
+        ContainerRuntime group = new();
+        group.Width = 150;
+        group.Height = 110;
+        group.IsRenderTarget = true;
+
+        ContainerRuntime clip = new();
+        clip.X = 10;
+        clip.Y = 10;
+        clip.Width = 65;
+        clip.Height = 90;
+        clip.ClipsChildren = true;
+        clip.Children.Add(Rect(0, 0, 260, 90, new Color((byte)220, (byte)60, (byte)60, (byte)255)));
+
+        // A marker on the right proves the render target itself extends past the clip region.
+        ColoredRectangleRuntime marker =
+            Rect(95, 10, 45, 90, new Color((byte)60, (byte)120, (byte)220, (byte)255));
+
+        group.Children.Add(clip);
+        group.Children.Add(marker);
+        holder.Children.Add(group);
+        return holder;
+    }
 }

--- a/Samples/raylib/Screens/RenderTargetScreen.cs
+++ b/Samples/raylib/Screens/RenderTargetScreen.cs
@@ -257,10 +257,16 @@ internal class RenderTargetScreen : FrameworkElement
         return holder;
     }
 
-    // A ClipsChildren descendant inside the render target. The clip container is the left half; its
-    // over-wide red child must be clipped to that half within the baked texture (#3440). The clip
-    // rect is rebased into RT-local space during the bake, so it lands correctly on both hardware GL
-    // and software GL (Mesa llvmpipe).
+    // A ClipsChildren descendant inside the render target (#3440). The clip rect is rebased into
+    // RT-local space during the bake, so it clips correctly on both hardware GL and software GL
+    // (Mesa llvmpipe). The clipped child is an OUTLINED circle far larger than the clip window: its
+    // right and bottom arcs are sliced dead flat at the clip boundary, so the clip is unmistakable —
+    // a curve cut to a straight edge. (Clipping a rectangle to a rectangle just yields a smaller
+    // rectangle and demonstrates nothing, which is why the child must be a circle.)
+    //
+    // Same outline-circle rules as BuildOverflow: leave IsFilled off and set the ring via Color (NOT
+    // StrokeColor) so it renders identically on MonoGame and raylib. Kept identical to the MonoGame
+    // sample's BuildClipsChildrenInside.
     static GraphicalUiElement BuildClipsChildrenInside()
     {
         ContainerRuntime holder = BuildFrame(150, 110);
@@ -276,9 +282,17 @@ internal class RenderTargetScreen : FrameworkElement
         clip.Width = 65;
         clip.Height = 90;
         clip.ClipsChildren = true;
-        clip.Children.Add(Rect(0, 0, 260, 90, new Color((byte)220, (byte)60, (byte)60, (byte)255)));
 
-        // A marker on the right proves the render target itself extends past the clip region.
+        CircleRuntime circle = new();
+        circle.X = 5;
+        circle.Y = 5;
+        circle.Width = 120;
+        circle.Height = 120;
+        circle.Color = new Color((byte)220, (byte)60, (byte)60, (byte)255);
+        clip.Children.Add(circle);
+
+        // A solid marker to the right of the clip window (still inside the render target) proves the
+        // RT itself extends past the clip: the circle is sliced by ClipsChildren, not by the RT bounds.
         ColoredRectangleRuntime marker =
             Rect(95, 10, 45, 90, new Color((byte)60, (byte)120, (byte)220, (byte)255));
 

--- a/Tests/RaylibGum.Tests/Rendering/RenderTargetTests.cs
+++ b/Tests/RaylibGum.Tests/Rendering/RenderTargetTests.cs
@@ -347,11 +347,14 @@ public class RenderTargetTests : BaseTestClass
         GumService.Default.Root.Children.Clear();
     }
 
-    // A ClipsChildren descendant inside a render-target container should clip within the RT. This
-    // works on hardware GL but fails under CI's Mesa llvmpipe software GL (scissor-inside-an-FBO
-    // behaves differently), so clip-inside-RT is deferred and this pins the target behavior for when
-    // it lands. See #3440.
-    [Fact(Skip = "Clip inside RT unsupported under software GL — see #3440")]
+    // A ClipsChildren descendant inside a render-target container clips within the RT (#3440). The
+    // clip rect (a 50x50 window at 0,25 inside the 100x100 RT) is deliberately NOT full-height and
+    // NOT full-width: an over-sized red child must be clipped on all four sides. This discriminates
+    // the correct RT-local scissor rebasing from the earlier #3436 attempt, which over-compensated
+    // the scissor Y by the screen height — that only survived a full-height clip (where the wrong
+    // formula happens to coincide with the right one) and broke outright under software GL. Verified
+    // headless on both hardware GL and CI's Mesa llvmpipe.
+    [Fact]
     public void Draw_ClipsChildrenInsideRenderTarget_ClipsWithinTheTarget()
     {
         ContainerRuntime outer = new();
@@ -363,16 +366,16 @@ public class RenderTargetTests : BaseTestClass
 
         ContainerRuntime clip = new();
         clip.X = 0;
-        clip.Y = 0;
+        clip.Y = 25;
         clip.Width = 50;
-        clip.Height = 100;
+        clip.Height = 50;
         clip.ClipsChildren = true;
 
         ColoredRectangleRuntime wide = new();
         wide.X = 0;
-        wide.Y = 0;
+        wide.Y = -25;
         wide.Width = 200;
-        wide.Height = 100;
+        wide.Height = 200;
         wide.Color = new Color((byte)255, (byte)0, (byte)0, (byte)255);
         clip.Children.Add(wide);
         outer.Children.Add(clip);
@@ -383,13 +386,17 @@ public class RenderTargetTests : BaseTestClass
         DrawOnce();
 
         RenderTexture2D outerRenderTexture = Renderer.Self.TryGetBakedRenderTargetFor(outer)!.Value;
+        // Center of the 50x50 clip window (x in [0,50), y in [25,75)).
         Color insideClip = ReadRenderTargetPixel(outerRenderTexture, 25, 50);
-        Color outsideClip = ReadRenderTargetPixel(outerRenderTexture, 75, 50);
+        Color rightOfClip = ReadRenderTargetPixel(outerRenderTexture, 75, 50);
+        Color aboveClip = ReadRenderTargetPixel(outerRenderTexture, 25, 10);
+        Color belowClip = ReadRenderTargetPixel(outerRenderTexture, 25, 90);
 
-        // Left half (inside the clip) shows the red child; right half (beyond the clip) is clipped
-        // away and stays transparent.
+        // Inside the clip window: the red child shows. Beyond it on every side: clipped to transparent.
         insideClip.R.ShouldBeGreaterThan((byte)200);
-        outsideClip.A.ShouldBeLessThan((byte)50);
+        rightOfClip.A.ShouldBeLessThan((byte)50);
+        aboveClip.A.ShouldBeLessThan((byte)50);
+        belowClip.A.ShouldBeLessThan((byte)50);
 
         GumService.Default.Root.Children.Clear();
     }


### PR DESCRIPTION
Closes #3440. Umbrella: #3434. Restores what was deferred in #3436.

## What

Re-enables a `ClipsChildren` descendant clipping correctly *inside* an `IsRenderTarget` container on raylib — on both hardware GL and CI's Mesa `llvmpipe` software GL.

## Root cause

The #3436 deferral suppressed scissor during an RT bake, so a clipping descendant inside a render target rendered unclipped. The earlier RT-local scissor attempt over-compensated the scissor Y by `(GetScreenHeight() - rtHeight)`. That formula only *coincides* with the correct one when the clip spans the full RT height — which is exactly what the original test used, so it passed on hardware GL yet broke outright under `llvmpipe`.

I reproduced the CI-only failure **locally** (closing the issue's "reproduction gap") by dropping Mesa's `opengl32.dll` next to the test binaries and setting `GALLIUM_DRIVER=llvmpipe`, exactly as the Windows CI job does. A discriminating (non-full-height) scissor probe showed that passing the **RT-local top-left rect directly** to `BeginScissorMode` — with **no** screen-height compensation — clips the correct rows on **both** hardware GL and `llvmpipe`. raylib's `BeginScissorMode` already applies its own Y flip; the prior fix double-compensated.

## Changes

- **`Renderer.cs`**: during a bake, rebase the clip rect into RT-local space (subtract the bake origin, apply zoom) and pass it straight to `BeginScissorMode`. Restored the `_bakeLeft`/`_bakeTop` plumbing; dropped the screen-height Y-compensation.
- **Test**: un-skipped `Draw_ClipsChildrenInsideRenderTarget_ClipsWithinTheTarget` and strengthened it to a 50×50 window clip so it discriminates the clip on **all four sides** — the full-height coincidence that hid the original bug can no longer produce a false pass.
- **Samples**: restored the "ClipsChildren inside RT" cell in both render-target sample screens (raylib `GumTest` + `MonoGameGumInCode`).

## Verification

- Full `RaylibGum.Tests` suite: **372/372 green under `llvmpipe`** (0 skipped — the deferred test now runs), and 10/10 for `RenderTargetTests` on hardware GL.
- Both sample projects build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
