### PR TITLE
Enable Sprite/NineSlice .achx auto-load via SourceFile on raylib (part of #3432)

### DIFF
--- a/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
+++ b/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
@@ -2068,7 +2068,7 @@ public class CustomSetPropertyOnRenderable
         return handled;
     }
 
-    private static AnimationChainList? GetAnimationChainList(ref string value, 
+    private static AnimationChainList? GetAnimationChainList(ref string value,
         // fully qualify to avoid Android namign conflicts
         global::RenderingLibrary.Content.LoaderManager loaderManager)
     {

--- a/Runtimes/RaylibGum/Renderables/CustomSetPropertyOnRenderable.cs
+++ b/Runtimes/RaylibGum/Renderables/CustomSetPropertyOnRenderable.cs
@@ -3,6 +3,7 @@
 #endif
 using Gum.Content.AnimationChain;
 using Gum.DataTypes;
+using Gum.Graphics.Animation;
 using Gum.RenderingLibrary;
 using RenderingLibrary;
 using RenderingLibrary.Content;
@@ -233,20 +234,19 @@ public class CustomSetPropertyOnRenderable
         {
             nineSlice.SetSingleTexture(null);
         }
-        // not yet supported:
-        //else if (value.EndsWith(".achx"))
-        //{
-        //    AnimationChainList animationChainList = GetAnimationChainList(ref value, loaderManager);
+        else if (value.EndsWith(".achx"))
+        {
+            AnimationChainList animationChainList = GetAnimationChainList(ref value, loaderManager);
 
-        //    nineSlice.AnimationChains = animationChainList;
+            nineSlice.AnimationChains = animationChainList;
 
-        //    nineSlice.RefreshCurrentChainToDesiredName();
+            nineSlice.RefreshCurrentChainToDesiredName();
 
-        //    nineSlice.UpdateToCurrentAnimationFrame();
+            nineSlice.UpdateToCurrentAnimationFrame();
 
-        //    graphicalUiElement.UpdateTextureValuesFrom(nineSlice);
+            graphicalUiElement.UpdateTextureValuesFrom(nineSlice);
 
-        //}
+        }
         else
         {
             if (ToolsUtilities.FileManager.IsRelative(value))
@@ -760,19 +760,47 @@ public class CustomSetPropertyOnRenderable
 
             graphicalUiElement.UpdateLayout();
         }
-        //else if (value.EndsWith(".achx"))
-        //{
-        //    AnimationChainList animationChainList = GetAnimationChainList(ref value, loaderManager);
+        else if (value.EndsWith(".achx"))
+        {
+            AnimationChainList? animationChainList = null;
+            try
+            {
+                animationChainList = GetAnimationChainList(ref value, loaderManager);
+                sprite.AnimationChains = animationChainList;
+            }
+            catch(Exception ex)
+            {
+                string message = $"Error setting SourceFile to on Sprite";
 
-        //    sprite.AnimationChains = animationChainList;
+                if (graphicalUiElement.Tag != null)
+                {
+                    message += $" in {graphicalUiElement.Tag}";
+                }
+                message += $"\n{value}";
+                message += "\nCheck if the file exists. If necessary, set FileManager.RelativeDirectory";
+                message += "\nThe current relative directory is:\n" + ToolsUtilities.FileManager.RelativeDirectory;
+                if (GraphicalUiElement.MissingFileBehavior == MissingFileBehavior.ThrowException)
+                {
+                    if (ObjectFinder.Self.GumProjectSave == null)
+                    {
+                        message += "\nNo Gum project has been loaded";
+                    }
 
-        //    sprite.RefreshCurrentChainToDesiredName();
+                    throw new System.IO.FileNotFoundException(message, ex);
+                }
+                sprite.AnimationChains = null;
 
-        //    sprite.UpdateToCurrentAnimationFrame();
+                PropertyAssignmentError?.Invoke(message + "\n" + ex.ToString());
+            }
 
-        //    graphicalUiElement.UpdateTextureValuesFrom(sprite);
-        //    handled = true;
-        //}
+
+            sprite.RefreshCurrentChainToDesiredName();
+
+            sprite.UpdateToCurrentAnimationFrame();
+
+            graphicalUiElement.UpdateTextureValuesFrom(sprite);
+            handled = true;
+        }
         else
         {
             if (ToolsUtilities.FileManager.IsRelative(value) && ToolsUtilities.FileManager.IsUrl(value) == false)
@@ -828,6 +856,37 @@ public class CustomSetPropertyOnRenderable
         }
         handled = true;
         return handled;
+    }
+
+    private static AnimationChainList? GetAnimationChainList(ref string value,
+        // fully qualify to avoid Android namign conflicts
+        global::RenderingLibrary.Content.LoaderManager loaderManager)
+    {
+        if (ToolsUtilities.FileManager.IsRelative(value))
+        {
+            value = ToolsUtilities.FileManager.RelativeDirectory + value;
+
+            value = ToolsUtilities.FileManager.RemoveDotDotSlash(value);
+        }
+
+        AnimationChainList? animationChainList = null;
+
+        if (loaderManager.CacheTextures)
+        {
+            animationChainList = loaderManager.GetDisposable(value) as AnimationChainList;
+        }
+
+        if (animationChainList == null)
+        {
+            var animationChainListSave = AnimationChainListSave.FromFile(value);
+            animationChainList = animationChainListSave.ToAnimationChainList();
+            if (loaderManager.CacheTextures)
+            {
+                loaderManager.AddDisposable(value, animationChainList);
+            }
+        }
+
+        return animationChainList;
     }
 
 

--- a/Runtimes/RaylibGum/Renderables/NineSlice.cs
+++ b/Runtimes/RaylibGum/Renderables/NineSlice.cs
@@ -1,4 +1,5 @@
-﻿using RenderingLibrary;
+﻿using Gum.Graphics.Animation;
+using RenderingLibrary;
 using RenderingLibrary.Graphics;
 using RenderingLibrary.Graphics.Animation;
 using RenderingLibrary.Math;
@@ -21,6 +22,19 @@ public class NineSlice : RenderableBase, IAnimatable, ITextureCoordinate, IClone
     /// texture and (UV-derived) source rectangle onto this NineSlice.
     /// </summary>
     public AnimationChainLogic AnimationLogic { get; } = new AnimationChainLogic();
+
+    // Convenience pass-throughs to AnimationLogic, mirroring the MonoGame NineSlice renderable
+    // (RenderingLibrary/Graphics/NineSlice.cs) so shared code such as
+    // CustomSetPropertyOnRenderable.AssignSourceFileOnNineSlice compiles identically on both.
+    public AnimationChainList? AnimationChains
+    {
+        get => AnimationLogic.AnimationChains;
+        set => AnimationLogic.AnimationChains = value;
+    }
+
+    public bool UpdateToCurrentAnimationFrame() => AnimationLogic.UpdateToCurrentAnimationFrame();
+
+    public void RefreshCurrentChainToDesiredName() => AnimationLogic.RefreshCurrentChainToDesiredName();
 
     public NineSlice()
     {

--- a/Runtimes/RaylibGum/Renderables/Sprite.cs
+++ b/Runtimes/RaylibGum/Renderables/Sprite.cs
@@ -1,4 +1,5 @@
-﻿using RenderingLibrary;
+﻿using Gum.Graphics.Animation;
+using RenderingLibrary;
 using RenderingLibrary.Graphics;
 using RenderingLibrary.Graphics.Animation;
 using RenderingLibrary.Math;
@@ -176,6 +177,19 @@ public class Sprite : InvisibleRenderable, IAspectRatio, ITextureCoordinate, IAn
     }
 
     public AnimationChainLogic AnimationLogic { get; } = new AnimationChainLogic();
+
+    // Convenience pass-throughs to AnimationLogic, mirroring the MonoGame Sprite renderable
+    // (RenderingLibrary/Graphics/Sprite.cs) so shared code such as
+    // CustomSetPropertyOnRenderable.AssignSourceFileOnSprite compiles identically on both.
+    public AnimationChainList? AnimationChains
+    {
+        get => AnimationLogic.AnimationChains;
+        set => AnimationLogic.AnimationChains = value;
+    }
+
+    public bool UpdateToCurrentAnimationFrame() => AnimationLogic.UpdateToCurrentAnimationFrame();
+
+    public void RefreshCurrentChainToDesiredName() => AnimationLogic.RefreshCurrentChainToDesiredName();
 
     public Sprite(Texture2D? texture = null)
     {

--- a/Tests/RaylibGum.Tests/Content/SourceFileAchxAutoLoadTests.cs
+++ b/Tests/RaylibGum.Tests/Content/SourceFileAchxAutoLoadTests.cs
@@ -1,0 +1,112 @@
+using Gum.Content.AnimationChain;
+using Gum.Graphics.Animation;
+using Gum.GueDeriving;
+using Raylib_cs;
+using RenderingLibrary.Content;
+using Shouldly;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using ToolsUtilities;
+using Xunit;
+
+namespace RaylibGum.Tests.Content;
+
+// Covers the raylib .achx auto-load path in CustomSetPropertyOnRenderable
+// (AssignSourceFileOnSprite / AssignSourceFileOnNineSlice). Setting SourceFile to
+// an .achx must populate AnimationChains and advance to the first frame's texture.
+// This path was previously commented out ("not yet supported") on raylib, so
+// AnimationChains stayed null even though the programmatic chain API worked.
+public class SourceFileAchxAutoLoadTests : BaseTestClass
+{
+    [Fact]
+    public void SpriteRuntime_SourceFileSetToAchx_PopulatesAnimationChainsAndFirstFrameTexture()
+    {
+        WithTempAchx(achxPath =>
+        {
+            SpriteRuntime sut = new();
+
+            sut.SourceFileName = achxPath;
+
+            sut.AnimationChains.ShouldNotBeNull();
+            sut.AnimationChains.Count.ShouldBe(1);
+            sut.Texture.ShouldNotBeNull();
+            sut.Texture!.Value.Width.ShouldBe(4);
+        });
+    }
+
+    [Fact]
+    public void NineSliceRuntime_SourceFileSetToAchx_PopulatesAnimationChains()
+    {
+        WithTempAchx(achxPath =>
+        {
+            NineSliceRuntime sut = new();
+
+            sut.SourceFileName = achxPath;
+
+            sut.AnimationChains.ShouldNotBeNull();
+            sut.AnimationChains.Count.ShouldBe(1);
+        });
+    }
+
+    private static void WithTempAchx(Action<string> action)
+    {
+        string tempRoot = Path.Combine(Path.GetTempPath(), "GumRaylibAchxAutoLoad_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempRoot);
+
+        string savedRelativeDirectory = FileManager.RelativeDirectory;
+        bool savedCacheTextures = LoaderManager.Self.CacheTextures;
+
+        try
+        {
+            const string textureName = "achx_frame.png";
+            Image image = Raylib.GenImageColor(4, 4, Raylib_cs.Color.Blue);
+            try
+            {
+                Raylib.ExportImage(image, Path.Combine(tempRoot, textureName));
+            }
+            finally
+            {
+                Raylib.UnloadImage(image);
+            }
+
+            string achxPath = Path.Combine(tempRoot, "test.achx").Replace('\\', '/');
+            AnimationChainListSave save = new();
+            save.FileName = achxPath;
+            save.FileRelativeTextures = true;
+            save.AnimationChains = new List<AnimationChainSave>
+            {
+                new AnimationChainSave
+                {
+                    Name = "TestChain",
+                    Frames = new List<AnimationFrameSave>
+                    {
+                        new AnimationFrameSave
+                        {
+                            TextureName = textureName,
+                            FrameLength = 0.1f,
+                            LeftCoordinate = 0f,
+                            RightCoordinate = 1f,
+                            TopCoordinate = 0f,
+                            BottomCoordinate = 1f,
+                        },
+                    },
+                },
+            };
+            FileManager.XmlSerialize(save, achxPath);
+
+            LoaderManager.Self.CacheTextures = false;
+
+            action(achxPath);
+        }
+        finally
+        {
+            FileManager.RelativeDirectory = savedRelativeDirectory;
+            LoaderManager.Self.CacheTextures = savedCacheTextures;
+            if (Directory.Exists(tempRoot))
+            {
+                Directory.Delete(tempRoot, recursive: true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What

Enables the `.achx` auto-load path via `SourceFile` on the **raylib** backend for both `SpriteRuntime` and `NineSliceRuntime`. Setting `SourceFile` (i.e. `SourceFileName`) to a `*.achx` file now populates `AnimationChains` and advances to the first frame — matching the MonoGame/XNALIKE backend. Programmatic animation chains already worked on raylib; only this file-load entry point was disabled.

Addresses the P2 item in the RaylibGum parity umbrella (**Part of #3432**).

## Why it was disabled

In `Runtimes/RaylibGum/Renderables/CustomSetPropertyOnRenderable.cs`, the `.achx` branches of `AssignSourceFileOnSprite` / `AssignSourceFileOnNineSlice` were commented out ("not yet supported"). They call `sprite.AnimationChains`, `sprite.RefreshCurrentChainToDesiredName()`, and `sprite.UpdateToCurrentAnimationFrame()` — convenience pass-throughs that the **MonoGame** `Sprite`/`NineSlice` renderables expose (delegating to the shared `AnimationChainLogic`) but the **raylib** renderables never had. Both backends already store playback state in the same `AnimationLogic` object, so the fix is purely to expose the missing surface.

## Changes

- **raylib `Sprite.cs` / `NineSlice.cs`**: add the three pass-through members (`AnimationChains`, `UpdateToCurrentAnimationFrame()`, `RefreshCurrentChainToDesiredName()`) that delegate to `AnimationLogic`, mirroring the MonoGame renderables.
- **raylib `CustomSetPropertyOnRenderable.cs`**: copy the `GetAnimationChainList` helper from the MonoGame copy and uncomment the two `.achx` branches verbatim.
- **`Gum/Wireframe/CustomSetPropertyOnRenderable.cs`**: trim one trailing-whitespace char in the helper so both copies stay byte-identical *and* clean.

### Cross-platform unification (convergence)

Per the `gum-cross-platform-unification` skill, this drives the cross-file diff for the `.achx` blocks to **zero** — the two `.achx` branches and the `GetAnimationChainList` helper are now byte-identical across the MonoGame and raylib copies of `CustomSetPropertyOnRenderable.cs`. The remaining divergence in these methods (atlas/pattern handling, invalid-texture placeholder, richer error reporting) is intentionally left for separate convergence steps — each needs its own historical-drift-vs-platform-necessary classification.

## Tests

New `SourceFileAchxAutoLoadTests` (raylib) — TDD, red before / green after:
- `SpriteRuntime_SourceFileSetToAchx_...` — writes a real `.achx` + PNG to disk, sets `SourceFileName`, asserts `AnimationChains` populated and the first frame's texture (4×4) applied.
- `NineSliceRuntime_SourceFileSetToAchx_...` — same for NineSlice.

These exercise the real runtime path (real file I/O, real raylib texture load under headless GL). Full `RaylibGum.Tests` suite green (375/375); no new compiler warnings from this change.

Part of #3432

🤖 Generated with [Claude Code](https://claude.com/claude-code)
