### PR TITLE
Add gradient surface to raylib ArcRuntime/LineArc (#3454)

### DIFF
--- a/Runtimes/RaylibGum/Renderables/LineArc.cs
+++ b/Runtimes/RaylibGum/Renderables/LineArc.cs
@@ -19,10 +19,10 @@ namespace Gum.Renderables;
 /// fill/stroke slots — matches the post-#2891 Skia <c>Arc</c> contract where arcs are stroked
 /// only and the wedge is reached via Thickness = W/2.
 /// <para>
-/// Gradients are not implemented in this pass (deferred follow-up to #2866). The per-segment
-/// triangle-fan approach that <c>LineCircle</c> uses for radial/linear gradients on a full disk
-/// applies cleanly to a stroked arc band, but lands separately so this PR stays scoped to
-/// achieving the gallery-parity baseline.
+/// Issue #3454 — the stroked band can also be painted with a linear or radial gradient
+/// (<see cref="UseGradient"/>), matching the Skia/Apos <c>Arc</c>. The band is tessellated into
+/// an annular-sector triangle strip whose vertices sample the gradient by world position — the
+/// arc-restricted version of the concentric-band approach <c>LineCircle</c> uses for a full disk.
 /// </para>
 /// </remarks>
 public class LineArc : InvisibleRenderable
@@ -96,6 +96,82 @@ public class LineArc : InvisibleRenderable
     /// <see cref="StrokeDashLength"/> is 0.
     /// </summary>
     public float StrokeGapLength { get; set; }
+
+    /// <summary>
+    /// When <c>true</c>, the stroked band is painted with a gradient from <see cref="Color1"/>
+    /// to <see cref="Color2"/> instead of a solid stroke color. Both <see cref="GradientType.Linear"/>
+    /// and <see cref="GradientType.Radial"/> are supported; rendering goes through an <c>rlgl</c>
+    /// annular-sector triangle strip with per-vertex colors computed from the gradient axis
+    /// (<see cref="GradientX1"/>/<see cref="GradientY1"/> → <see cref="GradientX2"/>/<see cref="GradientY2"/>)
+    /// and, for radial, <see cref="GradientInnerRadius"/>/<see cref="GradientOuterRadius"/>.
+    /// Mirrors <see cref="LineCircle.UseGradient"/>. Ignored on the dashed path (dashes stay solid).
+    /// </summary>
+    public bool UseGradient { get; set; }
+
+    /// <inheritdoc cref="LineCircle.GradientType"/>
+    public GradientType GradientType { get; set; }
+
+    /// <summary>
+    /// Gradient start color (linear: at the axis start; radial: at the inner radius). Per the
+    /// #3009 model the shared <c>ArcRuntime</c> mirrors the arc's primary <see cref="Color"/> into
+    /// this each frame, so the gradient start follows the body color.
+    /// </summary>
+    public Color Color1 { get; set; } = Color.White;
+
+    /// <summary>Gradient end color (linear: at the axis end; radial: at the outer radius).</summary>
+    public Color Color2 { get; set; } = Color.White;
+
+    /// <inheritdoc cref="LineCircle.GradientX1"/>
+    public float GradientX1 { get; set; }
+
+    /// <inheritdoc cref="LineCircle.GradientY1"/>
+    public float GradientY1 { get; set; }
+
+    /// <inheritdoc cref="LineCircle.GradientX2"/>
+    public float GradientX2 { get; set; }
+
+    /// <inheritdoc cref="LineCircle.GradientY2"/>
+    public float GradientY2 { get; set; }
+
+    /// <inheritdoc cref="LineCircle.GradientInnerRadius"/>
+    public float GradientInnerRadius { get; set; }
+
+    /// <inheritdoc cref="LineCircle.GradientOuterRadius"/>
+    public float GradientOuterRadius { get; set; }
+
+    /// <summary>
+    /// Issue #3454 — true when the gradient pass should paint. The arc is stroke-only (no fill
+    /// slot), so unlike <see cref="LineCircle.ShouldPaintFillGradient"/> this gates only on
+    /// <see cref="UseGradient"/> plus at least one visible gradient stop; there is no IsFilled /
+    /// FillColor slot to enable.
+    /// </summary>
+    public bool ShouldPaintGradient =>
+        UseGradient && (Color1.A > 0 || Color2.A > 0);
+
+    /// <inheritdoc cref="LineCircle.GetRotatedGradientEndpoints(float)"/>
+    /// <remarks>Pivots around the arc's bbox center (Width/2, Height/2) rather than
+    /// (Radius, Radius) so non-square bounds rotate correctly.</remarks>
+    public (float x1, float y1, float x2, float y2) GetRotatedGradientEndpoints(float rotationDegrees)
+    {
+        if (rotationDegrees == 0f)
+        {
+            return (GradientX1, GradientY1, GradientX2, GradientY2);
+        }
+        float rotRad = rotationDegrees * System.MathF.PI / 180f;
+        float cos = System.MathF.Cos(rotRad);
+        float sin = System.MathF.Sin(rotRad);
+        float pivotX = Width * 0.5f;
+        float pivotY = Height * 0.5f;
+        float dx1 = GradientX1 - pivotX;
+        float dy1 = GradientY1 - pivotY;
+        float dx2 = GradientX2 - pivotX;
+        float dy2 = GradientY2 - pivotY;
+        return (
+            pivotX + dx1 * cos + dy1 * sin,
+            pivotY - dx1 * sin + dy1 * cos,
+            pivotX + dx2 * cos + dy2 * sin,
+            pivotY - dx2 * sin + dy2 * cos);
+    }
 
     /// <summary>
     /// When <c>true</c>, a dropshadow pass renders behind the stroke using
@@ -236,6 +312,34 @@ public class LineArc : InvisibleRenderable
         {
             DrawDashed(new Vector2(cx, cy), innerRadius, outerRadius, strokeColor);
         }
+        else if (ShouldPaintGradient)
+        {
+            // Gradient axis lives in bbox-local coords (origin = bbox top-left); rotate it around
+            // the bbox center so it tracks the arc under self-rotation, then paint the annular
+            // sector as a per-vertex-colored triangle strip. bboxLeft/Top = (cx - halfW, cy - halfH)
+            // = the arc's absolute top-left.
+            float bboxLeft = cx - halfW;
+            float bboxTop = cy - halfH;
+            (float gx1, float gy1, float gx2, float gy2) =
+                GetRotatedGradientEndpoints(this.GetAbsoluteRotation());
+            DrawGradientBand(new Vector2(cx, cy), innerRadius, outerRadius,
+                startAngleDeg, endAngleDeg, segments, bboxLeft, bboxTop, gx1, gy1, gx2, gy2);
+            if (IsEndRounded && System.MathF.Abs(SweepAngle) < 360f && thickness > 0f)
+            {
+                // Sample the gradient at each cap's center so a rounded end blends with the band
+                // it caps instead of jumping to a single solid stroke color.
+                const float deg2rad = System.MathF.PI / 180f;
+                float midRadius = (innerRadius + outerRadius) * 0.5f;
+                float scx = cx + midRadius * System.MathF.Cos(startAngleDeg * deg2rad);
+                float scy = cy + midRadius * System.MathF.Sin(startAngleDeg * deg2rad);
+                float ecx = cx + midRadius * System.MathF.Cos(endAngleDeg * deg2rad);
+                float ecy = cy + midRadius * System.MathF.Sin(endAngleDeg * deg2rad);
+                Color startCap = ComputeGradientColor(scx, scy, bboxLeft, bboxTop, gx1, gy1, gx2, gy2, outerRadius);
+                Color endCap = ComputeGradientColor(ecx, ecy, bboxLeft, bboxTop, gx1, gy1, gx2, gy2, outerRadius);
+                DrawCaps(new Vector2(cx, cy), innerRadius, outerRadius,
+                    startAngleDeg, endAngleDeg, startCap, endCap);
+            }
+        }
         else
         {
             DrawRing(new Vector2(cx, cy), innerRadius, outerRadius,
@@ -243,7 +347,7 @@ public class LineArc : InvisibleRenderable
             if (IsEndRounded && System.MathF.Abs(SweepAngle) < 360f && thickness > 0f)
             {
                 DrawCaps(new Vector2(cx, cy), innerRadius, outerRadius,
-                    startAngleDeg, endAngleDeg, strokeColor);
+                    startAngleDeg, endAngleDeg, strokeColor, strokeColor);
             }
         }
     }
@@ -300,7 +404,7 @@ public class LineArc : InvisibleRenderable
             // as the solid path: skip when thickness collapses or the dash isn't actually a dash.
             if (IsEndRounded && outerRadius > innerRadius && dashEnd > currentAngle)
             {
-                DrawCaps(center, innerRadius, outerRadius, dashStartRl, dashEndRl, strokeColor);
+                DrawCaps(center, innerRadius, outerRadius, dashStartRl, dashEndRl, strokeColor, strokeColor);
             }
             currentAngle += patternAngleDeg;
         }
@@ -323,7 +427,7 @@ public class LineArc : InvisibleRenderable
     /// CW terms, which is identical to the radial axis at the endpoint.
     /// </remarks>
     private void DrawCaps(Vector2 center, float innerRadius, float outerRadius,
-        float startAngleRl, float endAngleRl, Color strokeColor)
+        float startAngleRl, float endAngleRl, Color startColor, Color endColor)
     {
         float thickness = outerRadius - innerRadius;
         if (thickness <= 0f)
@@ -343,12 +447,13 @@ public class LineArc : InvisibleRenderable
 
         const float deg2rad = System.MathF.PI / 180f;
 
-        // Start endpoint cap.
+        // Start endpoint cap. Under a gradient, startColor/endColor are the gradient samples at
+        // each endpoint; on the solid path they are the same stroke color.
         float startCx = center.X + midRadius * System.MathF.Cos(startAngleRl * deg2rad);
         float startCy = center.Y + midRadius * System.MathF.Sin(startAngleRl * deg2rad);
         float startBulge = startAngleRl + sweepSign * 90f;
         DrawCircleSector(new Vector2(startCx, startCy), capRadius,
-            startBulge - 90f, startBulge + 90f, capSegments, strokeColor);
+            startBulge - 90f, startBulge + 90f, capSegments, startColor);
 
         // End endpoint cap — bulge flips because the band tangent at the end points the other
         // way down the band relative to the start.
@@ -356,7 +461,121 @@ public class LineArc : InvisibleRenderable
         float endCy = center.Y + midRadius * System.MathF.Sin(endAngleRl * deg2rad);
         float endBulge = endAngleRl - sweepSign * 90f;
         DrawCircleSector(new Vector2(endCx, endCy), capRadius,
-            endBulge - 90f, endBulge + 90f, capSegments, strokeColor);
+            endBulge - 90f, endBulge + 90f, capSegments, endColor);
+    }
+
+    /// <summary>
+    /// Number of concentric annular sub-bands the gradient band is split into between
+    /// <c>innerRadius</c> and <c>outerRadius</c>. Radial subdivision keeps a radial gradient
+    /// smooth across a thick band (or a wedge, where innerRadius collapses to 0); a linear
+    /// gradient is unaffected by the count since every vertex samples by world position. Mirrors
+    /// <c>LineCircle.RadialLayers</c>.
+    /// </summary>
+    private const int GradientRadialLayers = 8;
+
+    /// <summary>
+    /// Issue #3454 — paints the arc's annular sector (<c>[innerRadius, outerRadius]</c> ×
+    /// <c>[startAngleRl, endAngleRl]</c>) as an <c>rlgl</c> triangle strip whose vertices sample
+    /// the gradient at their world position. The angular loop always steps from the smaller to the
+    /// larger raylib-space angle so the triangle winding stays front-facing under raylib's default
+    /// backface culling regardless of the sweep's sign — the sector covers the same region either
+    /// way and the gradient color is position-based, so iteration direction is free. This is the
+    /// arc-restricted analog of <see cref="LineCircle.DrawGradientFan"/> (a full disk); the arc
+    /// tessellates only the swept angular range and only the stroked band, not the whole disc.
+    /// </summary>
+    private void DrawGradientBand(Vector2 center, float innerRadius, float outerRadius,
+        float startAngleRl, float endAngleRl, int segments,
+        float bboxLeft, float bboxTop, float gx1, float gy1, float gx2, float gy2)
+    {
+        const float deg2rad = System.MathF.PI / 180f;
+        float aMin = System.MathF.Min(startAngleRl, endAngleRl);
+        float aMax = System.MathF.Max(startAngleRl, endAngleRl);
+        int safeSegments = System.Math.Max(1, segments);
+
+        Rlgl.Begin((int)DrawMode.Triangles);
+        for (int layer = 0; layer < GradientRadialLayers; layer++)
+        {
+            float rOuter = innerRadius + (outerRadius - innerRadius) * (GradientRadialLayers - layer) / GradientRadialLayers;
+            float rInner = innerRadius + (outerRadius - innerRadius) * (GradientRadialLayers - layer - 1) / GradientRadialLayers;
+            for (int i = 0; i < safeSegments; i++)
+            {
+                float a0 = (aMin + (aMax - aMin) * (i / (float)safeSegments)) * deg2rad;
+                float a1 = (aMin + (aMax - aMin) * ((i + 1) / (float)safeSegments)) * deg2rad;
+                float c0 = System.MathF.Cos(a0), s0 = System.MathF.Sin(a0);
+                float c1 = System.MathF.Cos(a1), s1 = System.MathF.Sin(a1);
+
+                float ox0 = center.X + c0 * rOuter, oy0 = center.Y + s0 * rOuter;
+                float ox1 = center.X + c1 * rOuter, oy1 = center.Y + s1 * rOuter;
+                float ix0 = center.X + c0 * rInner, iy0 = center.Y + s0 * rInner;
+                float ix1 = center.X + c1 * rInner, iy1 = center.Y + s1 * rInner;
+
+                // Winding matches LineCircle.DrawGradientFan (front-facing under default culling).
+                EmitGradientVertex(ix0, iy0, bboxLeft, bboxTop, gx1, gy1, gx2, gy2, outerRadius);
+                EmitGradientVertex(ox1, oy1, bboxLeft, bboxTop, gx1, gy1, gx2, gy2, outerRadius);
+                EmitGradientVertex(ox0, oy0, bboxLeft, bboxTop, gx1, gy1, gx2, gy2, outerRadius);
+
+                EmitGradientVertex(ix0, iy0, bboxLeft, bboxTop, gx1, gy1, gx2, gy2, outerRadius);
+                EmitGradientVertex(ix1, iy1, bboxLeft, bboxTop, gx1, gy1, gx2, gy2, outerRadius);
+                EmitGradientVertex(ox1, oy1, bboxLeft, bboxTop, gx1, gy1, gx2, gy2, outerRadius);
+            }
+        }
+        Rlgl.End();
+    }
+
+    private void EmitGradientVertex(float worldX, float worldY, float bboxLeft, float bboxTop,
+        float gx1, float gy1, float gx2, float gy2, float outerRadius)
+    {
+        Color color = ComputeGradientColor(worldX, worldY, bboxLeft, bboxTop, gx1, gy1, gx2, gy2, outerRadius);
+        Rlgl.Color4ub(color.R, color.G, color.B, color.A);
+        Rlgl.Vertex2f(worldX, worldY);
+    }
+
+    /// <summary>
+    /// Interpolates <see cref="Color1"/> → <see cref="Color2"/> for a world-space point. Linear
+    /// projects the point onto the (rotation-adjusted) axis; radial normalizes the distance from
+    /// the center against the <c>[InnerRadius, OuterRadius]</c> band. Matches
+    /// <see cref="LineCircle.EmitGradientVertex"/>'s math, but a default (0) radial outer radius
+    /// falls back to the arc's <paramref name="outerRadius"/> rather than a disc <c>Radius</c>.
+    /// </summary>
+    private Color ComputeGradientColor(float worldX, float worldY, float bboxLeft, float bboxTop,
+        float gx1, float gy1, float gx2, float gy2, float outerRadius)
+    {
+        float localX = worldX - bboxLeft;
+        float localY = worldY - bboxTop;
+
+        float t;
+        if (GradientType == GradientType.Linear)
+        {
+            float dx = gx2 - gx1;
+            float dy = gy2 - gy1;
+            float lenSq = dx * dx + dy * dy;
+            if (lenSq <= 0f)
+            {
+                return Color1;
+            }
+            t = ((localX - gx1) * dx + (localY - gy1) * dy) / lenSq;
+        }
+        else
+        {
+            float dx = localX - gx1;
+            float dy = localY - gy1;
+            float dist = System.MathF.Sqrt(dx * dx + dy * dy);
+            float outer = GradientOuterRadius > 0f ? GradientOuterRadius : outerRadius;
+            float span = outer - GradientInnerRadius;
+            if (span <= 0f)
+            {
+                return Color2;
+            }
+            t = (dist - GradientInnerRadius) / span;
+        }
+        if (t < 0f) t = 0f;
+        else if (t > 1f) t = 1f;
+
+        byte r = (byte)(Color1.R + (Color2.R - Color1.R) * t);
+        byte g = (byte)(Color1.G + (Color2.G - Color1.G) * t);
+        byte b = (byte)(Color1.B + (Color2.B - Color1.B) * t);
+        byte a = (byte)(Color1.A + (Color2.A - Color1.A) * t);
+        return new Color(r, g, b, a);
     }
 
     /// <summary>

--- a/Runtimes/SkiaGum/GueDeriving/ArcRuntime.cs
+++ b/Runtimes/SkiaGum/GueDeriving/ArcRuntime.cs
@@ -5,6 +5,7 @@ using System;
 using Gum.DataTypes;
 using Gum.Renderables;
 using RenderingLibrary;
+using RenderingLibrary.Graphics;
 using Color = Raylib_cs.Color;
 using ColorExtensions = RaylibGum.Helpers.ColorExtensions;
 #elif SKIA
@@ -34,9 +35,11 @@ namespace Gum.GueDeriving;
 /// any backend (sealed in PR #2891).
 /// </summary>
 /// <remarks>
-/// Gradients on arcs are intentionally not exposed in this pass (deferred follow-up to #2866)
-/// — see <see cref="LineArc"/> for the renderable-side rationale. <see cref="StrokeColor"/> is
-/// the single user-facing color slot, mirroring the post-PR-#2891 Skia <c>ArcRuntime</c>'s API.
+/// Issue #3454 — gradients are now exposed on raylib (<see cref="UseGradient"/>), matching the
+/// Skia/Apos branch. Per the #3009 model the gradient START is the arc's primary
+/// <see cref="Color"/> (synced into the renderable's <c>Color1</c> in <see cref="PreRender"/>);
+/// <see cref="Color2"/> is the standalone second stop. <see cref="StrokeColor"/> remains the
+/// explicit stroke-color slot for the solid (non-gradient) path.
 /// </remarks>
 public class ArcRuntime : GraphicalUiElement
 {
@@ -367,6 +370,157 @@ public class ArcRuntime : GraphicalUiElement
         }
     }
 
+    // Issue #3454 — gradient surface, forwarded to the contained LineArc. The gradient START color
+    // is not a standalone slot: per the #3009 model it mirrors the arc's primary Color, synced into
+    // the renderable's Color1 in PreRender. Color2 below is the standalone second stop. The obsolete
+    // Color1 / Red1 / Green1 / Blue1 / Alpha1 shims that the Skia/Apos branch carries are
+    // intentionally NOT widened to raylib — gradient support never shipped on raylib arcs, so there
+    // is no legacy data to preserve, and the cross-platform guidance is that the narrower footprint
+    // wins for deprecated members (see the gum-cross-platform-unification skill).
+
+    /// <inheritdoc cref="LineArc.UseGradient"/>
+    public bool UseGradient
+    {
+        get => ContainedLineArc.UseGradient;
+        set
+        {
+            ContainedLineArc.UseGradient = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    /// <inheritdoc cref="LineArc.GradientType"/>
+    public GradientType GradientType
+    {
+        get => ContainedLineArc.GradientType;
+        set
+        {
+            ContainedLineArc.GradientType = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    /// <inheritdoc cref="LineArc.Color2"/>
+    public Color Color2
+    {
+        get => ContainedLineArc.Color2;
+        set
+        {
+            ContainedLineArc.Color2 = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    /// <summary>Red channel of the gradient's second stop, <see cref="Color2"/>.</summary>
+    public int Red2
+    {
+        get => ContainedLineArc.Color2.R;
+        set
+        {
+            ContainedLineArc.Color2 = ColorExtensions.WithRed(ContainedLineArc.Color2, (byte)value);
+            NotifyPropertyChanged();
+        }
+    }
+
+    /// <summary>Green channel of the gradient's second stop, <see cref="Color2"/>.</summary>
+    public int Green2
+    {
+        get => ContainedLineArc.Color2.G;
+        set
+        {
+            ContainedLineArc.Color2 = ColorExtensions.WithGreen(ContainedLineArc.Color2, (byte)value);
+            NotifyPropertyChanged();
+        }
+    }
+
+    /// <summary>Blue channel of the gradient's second stop, <see cref="Color2"/>.</summary>
+    public int Blue2
+    {
+        get => ContainedLineArc.Color2.B;
+        set
+        {
+            ContainedLineArc.Color2 = ColorExtensions.WithBlue(ContainedLineArc.Color2, (byte)value);
+            NotifyPropertyChanged();
+        }
+    }
+
+    /// <summary>Alpha channel of the gradient's second stop, <see cref="Color2"/>.</summary>
+    public int Alpha2
+    {
+        get => ContainedLineArc.Color2.A;
+        set
+        {
+            ContainedLineArc.Color2 = ColorExtensions.WithAlpha(ContainedLineArc.Color2, (byte)value);
+            NotifyPropertyChanged();
+        }
+    }
+
+    /// <inheritdoc cref="LineArc.GradientX1"/>
+    public float GradientX1
+    {
+        get => ContainedLineArc.GradientX1;
+        set
+        {
+            ContainedLineArc.GradientX1 = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    /// <inheritdoc cref="LineArc.GradientY1"/>
+    public float GradientY1
+    {
+        get => ContainedLineArc.GradientY1;
+        set
+        {
+            ContainedLineArc.GradientY1 = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    /// <inheritdoc cref="LineArc.GradientX2"/>
+    public float GradientX2
+    {
+        get => ContainedLineArc.GradientX2;
+        set
+        {
+            ContainedLineArc.GradientX2 = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    /// <inheritdoc cref="LineArc.GradientY2"/>
+    public float GradientY2
+    {
+        get => ContainedLineArc.GradientY2;
+        set
+        {
+            ContainedLineArc.GradientY2 = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    /// <inheritdoc cref="LineArc.GradientInnerRadius"/>
+    public float GradientInnerRadius
+    {
+        get => ContainedLineArc.GradientInnerRadius;
+        set
+        {
+            ContainedLineArc.GradientInnerRadius = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    /// <inheritdoc cref="LineArc.GradientOuterRadius"/>
+    public float GradientOuterRadius
+    {
+        get => ContainedLineArc.GradientOuterRadius;
+        set
+        {
+            ContainedLineArc.GradientOuterRadius = value;
+            NotifyPropertyChanged();
+        }
+    }
+
     /// <summary>
     /// Initializes a new raylib <c>ArcRuntime</c>. Constructor defaults mirror the Skia/Apos
     /// branch so cross-backend sample code starts from the same baseline (Width = Height = 100,
@@ -387,6 +541,16 @@ public class ArcRuntime : GraphicalUiElement
             Thickness = 10;
             StartAngle = 0;
             SweepAngle = 90;
+
+            // Issue #3454 — seed the gradient second stop + axis to match the Skia/Apos branch's
+            // ctor so cross-backend sample code starts from the same baseline (yellow second stop,
+            // axis running to the bottom-right corner of the default 100x100 bounds). The gradient
+            // start follows the primary Color (White) via PreRender; UseGradient defaults off.
+            Red2 = 255;
+            Green2 = 255;
+            Blue2 = 0;
+            GradientX2 = 100;
+            GradientY2 = 100;
 
             // Pre-seed dropshadow offset/blur so toggling HasDropshadow = true at runtime
             // produces a visible shadow without further setup — same default the Skia/Apos
@@ -424,6 +588,12 @@ public class ArcRuntime : GraphicalUiElement
         // nominal Thickness, so the band width is pushed straight through. See
         // RectangleRuntime.PreRender for the full rationale.
         ContainedLineArc.Thickness = thickness;
+
+        // Issue #3454 / #3009 — the gradient START is the arc's primary body Color, not a standalone
+        // slot. Mirror it into the renderable's Color1 each frame so the start stop follows the body
+        // regardless of how Color was set (state change, animation, .gumx load). Matches the Skia/Apos
+        // branch's PreRender, which syncs ContainedArc.Red1/Green1/Blue1/Alpha1 from the body color.
+        ContainedLineArc.Color1 = ContainedLineArc.Color;
     }
 
     /// <inheritdoc/>

--- a/Samples/raylib/Screens/ArcsScreen.cs
+++ b/Samples/raylib/Screens/ArcsScreen.cs
@@ -14,9 +14,12 @@ namespace Examples.Shapes;
 // run side by side.
 //
 // What's intentionally NOT mirrored:
-//   * "Gradients" - deferred to a follow-up; the issue comment lists it as a stretch goal.
 //   * "Antialiasing" - raylib has no per-shape AA. Framebuffer MSAA (Msaa4xHint in Program.cs)
 //     is the only AA path, so toggling IsAntialiased would render identically.
+// Gradients on arcs ARE mirrored now (issue #3454) - the "Gradients on arcs" row matches the
+// Apos/Skia galleries cell-for-cell. Note the gradient START color is the arc's primary Color
+// (the #3009 model), so these cells set arc.Color rather than the obsolete Color1 the Apos
+// gallery still uses; the two are visually identical.
 // End caps DO render on raylib post-#2895 (DrawCircleSector half-disks synthesized in LineArc),
 // so the "End caps" row IS mirrored.
 internal class ArcsScreen : FrameworkElement
@@ -40,6 +43,7 @@ internal class ArcsScreen : FrameworkElement
         left.Children.Add(BuildSection("Sweep angles (90, 180, 270, 360)", BuildSweepRow()));
         left.Children.Add(BuildSection("Thickness progression: thin -> fat -> wedge (W/2)", BuildThicknessProgressionRow()));
         left.Children.Add(BuildSection("End caps: butt / rounded", BuildEndCapRow()));
+        left.Children.Add(BuildSection("Gradients on arcs (including gradient wedge)", BuildStrokeGradientRow()));
 
         right.Children.Add(BuildSection("Dashed strokes", BuildDashedStrokeRow()));
         right.Children.Add(BuildSection("Dropshadow (off / soft / hard / colored / faded body / rounded faded body)", BuildDropshadowRow()));
@@ -145,6 +149,86 @@ internal class ArcsScreen : FrameworkElement
         rounded.StrokeColor = Color.White;
         rounded.IsEndRounded = true;
         row.Children.Add(rounded);
+
+        return row;
+    }
+
+    // Issue #3454 - gradients on stroked arcs, mirroring the Apos/Skia BuildStrokeGradientRow
+    // cell-for-cell. Cells: linear horizontal / vertical / diagonal, radial centered, and a
+    // gradient-filled pie wedge (Thickness = Width/2). Named-color RGB values match the XNA colors
+    // the Apos gallery uses so the two galleries read identically side by side. The gradient START
+    // is the arc's primary Color (the #3009 model), so each cell sets arc.Color for the start stop
+    // and arc.Color2 for the end stop - the raylib branch does not carry the obsolete Color1 slot.
+    static ContainerRuntime BuildStrokeGradientRow()
+    {
+        ContainerRuntime row = BuildHorizontalRow();
+
+        // Linear horizontal: white -> steel blue
+        ArcRuntime linearH = new();
+        linearH.Width = 60; linearH.Height = 60;
+        linearH.SweepAngle = 270;
+        linearH.Thickness = 8;
+        linearH.UseGradient = true;
+        linearH.GradientType = GradientType.Linear;
+        linearH.Color = Color.White;
+        linearH.Color2 = new Color(70, 130, 180, 255); // SteelBlue
+        linearH.GradientX1 = 0; linearH.GradientY1 = 0;
+        linearH.GradientX2 = 60; linearH.GradientY2 = 0;
+        row.Children.Add(linearH);
+
+        // Linear vertical: gold -> crimson
+        ArcRuntime linearV = new();
+        linearV.Width = 60; linearV.Height = 60;
+        linearV.SweepAngle = 270;
+        linearV.Thickness = 8;
+        linearV.UseGradient = true;
+        linearV.GradientType = GradientType.Linear;
+        linearV.Color = new Color(255, 215, 0, 255); // Gold
+        linearV.Color2 = new Color(220, 20, 60, 255); // Crimson
+        linearV.GradientX1 = 0; linearV.GradientY1 = 0;
+        linearV.GradientX2 = 0; linearV.GradientY2 = 60;
+        row.Children.Add(linearV);
+
+        // Linear diagonal: cyan -> magenta
+        ArcRuntime linearD = new();
+        linearD.Width = 60; linearD.Height = 60;
+        linearD.SweepAngle = 270;
+        linearD.Thickness = 8;
+        linearD.UseGradient = true;
+        linearD.GradientType = GradientType.Linear;
+        linearD.Color = new Color(0, 255, 255, 255); // Cyan
+        linearD.Color2 = new Color(255, 0, 255, 255); // Magenta
+        linearD.GradientX1 = 0; linearD.GradientY1 = 0;
+        linearD.GradientX2 = 60; linearD.GradientY2 = 60;
+        row.Children.Add(linearD);
+
+        // Radial centered: white -> dark green
+        ArcRuntime radial = new();
+        radial.Width = 60; radial.Height = 60;
+        radial.SweepAngle = 270;
+        radial.Thickness = 8;
+        radial.UseGradient = true;
+        radial.GradientType = GradientType.Radial;
+        radial.Color = Color.White;
+        radial.Color2 = new Color(0, 100, 0, 255); // DarkGreen
+        radial.GradientX1 = 30; radial.GradientY1 = 30;
+        radial.GradientInnerRadius = 0;
+        radial.GradientOuterRadius = 30;
+        row.Children.Add(radial);
+
+        // Gradient-filled wedge: Thickness = Width / 2 collapses the band to a pie wedge, and the
+        // gradient applies across it. Tighter sweep so the wedge shape is unmistakable.
+        ArcRuntime wedge = new();
+        wedge.Width = 60; wedge.Height = 60;
+        wedge.SweepAngle = 90;
+        wedge.Thickness = 30; // W / 2 -> wedge
+        wedge.UseGradient = true;
+        wedge.GradientType = GradientType.Linear;
+        wedge.Color = new Color(255, 165, 0, 255); // Orange
+        wedge.Color2 = new Color(255, 20, 147, 255); // DeepPink
+        wedge.GradientX1 = 0; wedge.GradientY1 = 0;
+        wedge.GradientX2 = 60; wedge.GradientY2 = 60;
+        row.Children.Add(wedge);
 
         return row;
     }

--- a/Tests/RaylibGum.Tests/Renderables/LineArcTests.cs
+++ b/Tests/RaylibGum.Tests/Renderables/LineArcTests.cs
@@ -1,0 +1,163 @@
+using Gum.Renderables;
+using Raylib_cs;
+using RenderingLibrary.Graphics;
+using Shouldly;
+
+namespace RaylibGum.Tests.Renderables;
+
+/// <summary>
+/// Issue #3454 — verifies the gradient surface added to <see cref="LineArc"/> so the raylib arc
+/// renderable can paint a linear/radial gradient across its stroked band, matching the Skia/Apos
+/// <c>Arc</c>. Like <see cref="LineCircleTests"/>, these cover property round-trip and the paint
+/// gate only; the actual triangle-strip render path calls native rlgl functions that require a GL
+/// context and is validated visually in the raylib sample's arc screen.
+/// </summary>
+public class LineArcTests
+{
+    [Fact]
+    public void Gradient_Defaults_Off()
+    {
+        LineArc arc = new LineArc();
+
+        arc.UseGradient.ShouldBeFalse();
+        arc.GradientType.ShouldBe(GradientType.Linear);
+        arc.Color1.A.ShouldBe((byte)255);
+        arc.Color2.A.ShouldBe((byte)255);
+    }
+
+    [Fact]
+    public void Gradient_PropertiesRoundTrip()
+    {
+        LineArc arc = new LineArc();
+        Color c1 = new Color(255, 0, 0, 255);
+        Color c2 = new Color(0, 0, 255, 255);
+
+        arc.UseGradient = true;
+        arc.GradientType = GradientType.Radial;
+        arc.Color1 = c1;
+        arc.Color2 = c2;
+
+        arc.UseGradient.ShouldBeTrue();
+        arc.GradientType.ShouldBe(GradientType.Radial);
+        arc.Color1.R.ShouldBe((byte)255);
+        arc.Color2.B.ShouldBe((byte)255);
+    }
+
+    [Fact]
+    public void GradientAxis_PropertiesRoundTrip()
+    {
+        LineArc arc = new LineArc();
+
+        arc.GradientX1.ShouldBe(0f);
+        arc.GradientY1.ShouldBe(0f);
+        arc.GradientX2.ShouldBe(0f);
+        arc.GradientY2.ShouldBe(0f);
+        arc.GradientInnerRadius.ShouldBe(0f);
+        arc.GradientOuterRadius.ShouldBe(0f);
+
+        arc.GradientX1 = 4f;
+        arc.GradientY1 = 8f;
+        arc.GradientX2 = 56f;
+        arc.GradientY2 = 28f;
+        arc.GradientInnerRadius = 4f;
+        arc.GradientOuterRadius = 28f;
+
+        arc.GradientX1.ShouldBe(4f);
+        arc.GradientY1.ShouldBe(8f);
+        arc.GradientX2.ShouldBe(56f);
+        arc.GradientY2.ShouldBe(28f);
+        arc.GradientInnerRadius.ShouldBe(4f);
+        arc.GradientOuterRadius.ShouldBe(28f);
+    }
+
+    // Issue #3454 — the arc is stroke-only (no fill slot), so the gradient paint gate is simpler
+    // than LineCircle's ShouldPaintFillGradient: it keys on UseGradient plus at least one visible
+    // gradient stop. No IsFilled / FillColor to enable.
+    [Fact]
+    public void ShouldPaintGradient_GradientOff_False()
+    {
+        LineArc arc = new()
+        {
+            UseGradient = false,
+            Color1 = new Color(10, 20, 30, 255),
+            Color2 = new Color(40, 50, 60, 255),
+        };
+
+        arc.ShouldPaintGradient.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ShouldPaintGradient_BothStopsTransparent_False()
+    {
+        LineArc arc = new()
+        {
+            UseGradient = true,
+            Color1 = new Color(1, 2, 3, 0),
+            Color2 = new Color(4, 5, 6, 0),
+        };
+
+        arc.ShouldPaintGradient.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ShouldPaintGradient_OneStopVisible_True()
+    {
+        LineArc arc = new()
+        {
+            UseGradient = true,
+            Color1 = new Color(10, 20, 30, 255),
+            Color2 = new Color(40, 50, 60, 0),
+        };
+
+        arc.ShouldPaintGradient.ShouldBeTrue();
+    }
+
+    // Issue #3454 — the gradient axis is defined in object-local bbox coords and must rotate
+    // around the bbox center (Width/2, Height/2) to track the arc under self-rotation, matching
+    // LineCircle.GetRotatedGradientEndpoints. Rotation convention mirrors LineRectangle's R helper
+    // (visual CCW on screen: [cos sin; -sin cos]).
+    [Fact]
+    public void GetRotatedGradientEndpoints_ZeroRotation_ReturnsOriginalEndpoints()
+    {
+        LineArc arc = new()
+        {
+            Width = 100,
+            Height = 100,
+            GradientX1 = 0f,
+            GradientY1 = 0f,
+            GradientX2 = 100f,
+            GradientY2 = 0f,
+        };
+
+        (float x1, float y1, float x2, float y2) = arc.GetRotatedGradientEndpoints(rotationDegrees: 0f);
+
+        x1.ShouldBe(0f);
+        y1.ShouldBe(0f);
+        x2.ShouldBe(100f);
+        y2.ShouldBe(0f);
+    }
+
+    [Fact]
+    public void GetRotatedGradientEndpoints_OneHundredEightyDegrees_FlipsAcrossBboxCenter()
+    {
+        // bbox 100x100, center (50, 50). 180° flips both endpoints across the center:
+        //   (0, 0)   → (100, 100)
+        //   (100, 0) → (0, 100)
+        LineArc arc = new()
+        {
+            Width = 100,
+            Height = 100,
+            GradientX1 = 0f,
+            GradientY1 = 0f,
+            GradientX2 = 100f,
+            GradientY2 = 0f,
+        };
+
+        (float x1, float y1, float x2, float y2) = arc.GetRotatedGradientEndpoints(rotationDegrees: 180f);
+
+        x1.ShouldBe(100f, tolerance: 0.001);
+        y1.ShouldBe(100f, tolerance: 0.001);
+        x2.ShouldBe(0f, tolerance: 0.001);
+        y2.ShouldBe(100f, tolerance: 0.001);
+    }
+}

--- a/Tests/RaylibGum.Tests/Runtimes/ArcRuntimeTests.cs
+++ b/Tests/RaylibGum.Tests/Runtimes/ArcRuntimeTests.cs
@@ -1,0 +1,81 @@
+using Gum.GueDeriving;
+using Gum.Renderables;
+using Raylib_cs;
+using RenderingLibrary.Graphics;
+using Shouldly;
+
+namespace RaylibGum.Tests.Runtimes;
+
+/// <summary>
+/// Issue #3454 — pins the gradient surface added to the raylib branch of the shared
+/// <c>ArcRuntime</c>. The arc is stroke-only, so (per the #3009 model shared with Circle/Rectangle)
+/// the gradient START is the arc's primary <c>Color</c>, synced into the renderable's <c>Color1</c>
+/// each frame in <c>PreRender</c>; <c>Color2</c> is the standalone second stop.
+/// </summary>
+public class ArcRuntimeTests : BaseTestClass
+{
+    [Fact]
+    public void Gradient_Surface_ForwardsToContainedRenderable()
+    {
+        ArcRuntime sut = new();
+        Color c2 = new Color(0, 0, 255, 255);
+
+        sut.UseGradient = true;
+        sut.GradientType = GradientType.Radial;
+        sut.Color2 = c2;
+        sut.GradientX1 = 4f;
+        sut.GradientY1 = 8f;
+        sut.GradientX2 = 56f;
+        sut.GradientY2 = 28f;
+        sut.GradientInnerRadius = 4f;
+        sut.GradientOuterRadius = 28f;
+
+        LineArc inner = (LineArc)sut.RenderableComponent!;
+        inner.UseGradient.ShouldBeTrue();
+        inner.GradientType.ShouldBe(GradientType.Radial);
+        inner.Color2.B.ShouldBe((byte)255);
+        inner.GradientX1.ShouldBe(4f);
+        inner.GradientY1.ShouldBe(8f);
+        inner.GradientX2.ShouldBe(56f);
+        inner.GradientY2.ShouldBe(28f);
+        inner.GradientInnerRadius.ShouldBe(4f);
+        inner.GradientOuterRadius.ShouldBe(28f);
+    }
+
+    // Issue #3454 / #3009 — the arc's gradient start follows its primary body Color rather than a
+    // standalone Color1 slot. PreRender mirrors Color into the renderable's Color1 so the start
+    // stop tracks the body regardless of how Color was set (state change, animation, .gumx load).
+    [Fact]
+    public void PreRender_SyncsGradientStartToBodyColor()
+    {
+        ArcRuntime sut = new();
+        Color body = new Color(255, 0, 0, 255);
+
+        sut.Color = body;
+        sut.PreRender();
+
+        LineArc inner = (LineArc)sut.RenderableComponent!;
+        inner.Color1.R.ShouldBe((byte)255);
+        inner.Color1.G.ShouldBe((byte)0);
+        inner.Color1.B.ShouldBe((byte)0);
+        inner.Color1.A.ShouldBe((byte)255);
+    }
+
+    [Fact]
+    public void Color2_Channels_RoundTrip()
+    {
+        ArcRuntime sut = new();
+
+        sut.Red2 = 12;
+        sut.Green2 = 34;
+        sut.Blue2 = 56;
+        sut.Alpha2 = 78;
+
+        sut.Red2.ShouldBe(12);
+        sut.Green2.ShouldBe(34);
+        sut.Blue2.ShouldBe(56);
+        sut.Alpha2.ShouldBe(78);
+        sut.Color2.R.ShouldBe((byte)12);
+        sut.Color2.A.ShouldBe((byte)78);
+    }
+}


### PR DESCRIPTION
## What

Adds the gradient surface to raylib arcs — the last shape-gradient gap on raylib (Circle/Rectangle already had it). Closes #3454, split off from the RaylibGum parity umbrella #3432.

Two layers:

**Renderable — `Runtimes/RaylibGum/Renderables/LineArc.cs`**
- New gradient members (`UseGradient`, `GradientType`, `Color1`/`Color2`, `GradientX1/Y1/X2/Y2`, `GradientInnerRadius/OuterRadius`, `ShouldPaintGradient`, `GetRotatedGradientEndpoints`).
- The stroked band is painted as an `rlgl` triangle strip over the annular sector, per-vertex colors sampled by world position — the arc-restricted analog of `LineCircle.DrawGradientFan`. The angular loop steps `min→max` raylib-angle so winding stays front-facing under backface culling regardless of sweep sign.
- Rounded caps sample the gradient at each endpoint (so a cap blends with the band it caps). Dashed strokes stay solid — documented limitation.

**Runtime — `Runtimes/SkiaGum/GueDeriving/ArcRuntime.cs` (`#if RAYLIB` branch)**
- Forwards the gradient surface to `LineArc`. Per the #3009 model the gradient START is the arc's primary `Color`, synced into the renderable's `Color1` each frame in `PreRender`; `Color2` is the standalone second stop.
- The obsolete `Color1`/`Red1`… shims the Skia/Apos branch carries are **intentionally not widened** to raylib (gradient never shipped there, so no legacy data; per `gum-cross-platform-unification`, the narrower footprint wins for deprecated members).

**Sample** — mirrors the Apos/Skia `BuildStrokeGradientRow` into the raylib `ArcsScreen` (linear H/V/D, radial, gradient wedge) so the galleries read cell-for-cell side by side. The MonoGame shapes gallery already had this row.

## Tests

New `LineArcTests` + `ArcRuntimeTests` (11 tests): gradient property round-trip, the `ShouldPaintGradient` gate, `GetRotatedGradientEndpoints` rotation math, runtime→renderable forwarding, and the `PreRender` gradient-start sync. Full `RaylibGum.Tests` suite green (386/386). The triangle-strip render path itself needs a GL context, so it's covered visually in the sample (same convention as `LineCircleTests`).

## Manual test

Needed (rendering change). Open `Samples/raylib/RaylibSample.sln` and `Samples/GumShapesGallery/GumShapesGallery.sln`, run both, open the Arcs screen in each, and compare the new "Gradients on arcs" row side by side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
