### PR TITLE
Add raylib Blend support to RectangleRuntime (#3458)

### DIFF
--- a/MonoGameGum/GueDeriving/RectangleRuntime.cs
+++ b/MonoGameGum/GueDeriving/RectangleRuntime.cs
@@ -679,6 +679,26 @@ public class RectangleRuntime : GraphicalUiElement
         get => _gradientOuterRadiusUnits;
         set { _gradientOuterRadiusUnits = value; NotifyPropertyChanged(); }
     }
+
+    Gum.RenderingLibrary.Blend _blend = Gum.RenderingLibrary.Blend.Normal;
+    /// <inheritdoc cref="CircleRuntime.Blend"/>
+    /// <remarks>
+    /// Issue #3458 — raylib forwards the value straight to the contained <see cref="ContainedLineRectangle"/>'s
+    /// nullable blend member (no <c>ShapeStrokePreRenderMath.PushBlend</c> / <c>IBlendedRenderable</c>,
+    /// which are XNALIKE-only Apos.Shapes infrastructure). The renderable's <c>Render</c> wraps its
+    /// fill/stroke passes in the corresponding raylib blend mode. Only <c>Additive</c> maps to a
+    /// non-alpha raylib mode today.
+    /// </remarks>
+    public Gum.RenderingLibrary.Blend Blend
+    {
+        get => _blend;
+        set
+        {
+            _blend = value;
+            ContainedLineRectangle.Blend = value;
+            NotifyPropertyChanged();
+        }
+    }
 #endif
 
 #if !SKIA

--- a/Runtimes/RaylibGum/Renderables/LineRectangle.cs
+++ b/Runtimes/RaylibGum/Renderables/LineRectangle.cs
@@ -45,6 +45,16 @@ public class LineRectangle : InvisibleRenderable
     public Color Color { get; set; } = Color.White;
 
     /// <summary>
+    /// Blend mode applied to the fill and stroke passes. When set, <see cref="Render"/> wraps
+    /// those passes in <c>BeginBlendMode</c>/<c>EndBlendMode</c> (via the batch-counted wrappers)
+    /// using <see cref="BlendModeExtensions.ToRaylibBlendMode"/>. <c>null</c> (the default) leaves
+    /// raylib on its standard alpha blend. Mirrors the <c>Blend</c> member on the raylib
+    /// <c>Sprite</c> / <c>NineSlice</c> renderables (issue #3458). Only <see cref="global::Gum.RenderingLibrary.Blend.Additive"/>
+    /// maps to a non-alpha raylib mode today; other values fall through to alpha.
+    /// </summary>
+    public global::Gum.RenderingLibrary.Blend? Blend { get; set; }
+
+    /// <summary>
     /// When <c>true</c>, draws a filled rectangle using <see cref="Color"/> (or
     /// <see cref="FillColor"/> when set). Independent of the stroke pass — both fill and stroke
     /// may render in the same <see cref="Render"/> call.
@@ -360,6 +370,17 @@ public class LineRectangle : InvisibleRenderable
             }
         }
 
+        // Issue #3458 — wrap ONLY the fill + stroke passes in the blend mode. The dropshadow
+        // pre-pass above is deliberately left outside: on the blurred path it bakes into its own
+        // RenderTexture2D via Renderer.Self.ShadowBlur.Draw (which manages its own blend state),
+        // and the hard-offset path already composites the shadow with the correct alpha. Mirrors
+        // the raylib Sprite / NineSlice Blend wrap, using the batch-counted BeginBlendMode /
+        // EndBlendMode so the draw-call counter stays accurate.
+        if (Blend.HasValue)
+        {
+            global::RenderingLibrary.Graphics.Renderer.Self.BatchDrawCallCounter.BeginBlendMode(Blend.Value.ToRaylibBlendMode());
+        }
+
         // Fill pass — runs when FillColor is set, or when IsFilled is true with no explicit
         // FillColor (legacy Color slot supplies the fill color). Mirrors Skia's two-slot
         // composition (#2790) where setting FillColor alone, StrokeColor alone, or both lights
@@ -541,6 +562,11 @@ public class LineRectangle : InvisibleRenderable
                 DrawDashedSegment(sbr, sbl, dashLen, gapLen, strokeColor);
                 DrawDashedSegment(sbl, stl, dashLen, gapLen, strokeColor);
             }
+        }
+
+        if (Blend.HasValue)
+        {
+            global::RenderingLibrary.Graphics.Renderer.Self.BatchDrawCallCounter.EndBlendMode();
         }
     }
 

--- a/Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/RectanglesScreen.cs
+++ b/Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/RectanglesScreen.cs
@@ -36,6 +36,7 @@ internal class RectanglesScreen : FrameworkElement
         root.AddChild(BuildSection("StrokeWidth (1, 2, 4, 8 px on a filled card)", BuildStrokeWidthRow()));
         root.AddChild(BuildSection("Antialiasing (true vs false — visual no-op without MonoGameGumShapes)", BuildAntialiasingRow()));
         root.AddChild(BuildSection("Alignment inside a 220x100 container (Top / Center / Bottom)", BuildAlignmentRow()));
+        root.AddChild(BuildSection("Blend (Additive vs Normal) — overlaps brighten toward white with MonoGameGumShapes; visual no-op on the core SolidRectangle default (#3458)", BuildBlendRow()));
     }
 
     static ContainerRuntime BuildSection(string label, GraphicalUiElement body)
@@ -166,6 +167,64 @@ internal class RectanglesScreen : FrameworkElement
             row.AddChild(BuildAlignmentCell(alignment));
         }
         return row;
+    }
+
+    // Issue #3458 — mirror of the raylib RectanglesScreen "Blend (Additive)" section for
+    // side-by-side comparison. Same geometry/colors as the raylib cell: the left triad uses
+    // Blend.Additive so overlapping red/green/blue rectangles sum (R+G = yellow, R+G+B ≈ white);
+    // the right triad is the identical geometry left at Blend.Normal as an occlusion control.
+    //
+    // NOTE: on this Apos-less sample the effect is a VISUAL NO-OP. The core rectangle fill default
+    // (RenderingLibrary SolidRectangle) does not implement IBlendedRenderable, so
+    // ShapeStrokePreRenderMath.PushBlend has nothing to push to and both triads render identically
+    // with standard alpha — same graceful degradation this file documents for the Antialiasing row.
+    // Install MonoGameGumShapes (see the GumShapesGallery sample) to see the additive brightening;
+    // the raylib sample renders it natively. The section is kept here for API/round-trip parity and
+    // forward-compat, so the effect lights up automatically once the shapes package is present.
+    static ContainerRuntime BuildBlendRow()
+    {
+        ContainerRuntime row = BuildHorizontalRow();
+        row.AddChild(BuildBlendTriadCell(Gum.RenderingLibrary.Blend.Additive));
+        row.AddChild(BuildBlendTriadCell(Gum.RenderingLibrary.Blend.Normal));
+        return row;
+    }
+
+    // A dark 150x120 frame with three 70x70 primary-color rectangles arranged so all three overlap
+    // in the middle. Under Additive (with MonoGameGumShapes) the overlaps sum toward white; under
+    // Normal the last rectangle drawn just covers the earlier ones.
+    static ContainerRuntime BuildBlendTriadCell(Gum.RenderingLibrary.Blend blend)
+    {
+        ContainerRuntime frame = new();
+        frame.Width = 150;
+        frame.Height = 120;
+
+        RectangleRuntime backdrop = new();
+        backdrop.Width = 0;
+        backdrop.Height = 0;
+        backdrop.WidthUnits = Gum.DataTypes.DimensionUnitType.RelativeToParent;
+        backdrop.HeightUnits = Gum.DataTypes.DimensionUnitType.RelativeToParent;
+        backdrop.FillColor = new Color(20, 20, 30);
+        backdrop.IsFilled = true;
+        frame.Children.Add(backdrop);
+
+        AddBlendRect(frame, blend, new Color(255, 0, 0), x: 10, y: 10);
+        AddBlendRect(frame, blend, new Color(0, 255, 0), x: 45, y: 10);
+        AddBlendRect(frame, blend, new Color(0, 0, 255), x: 27, y: 42);
+
+        return frame;
+    }
+
+    static void AddBlendRect(ContainerRuntime frame, Gum.RenderingLibrary.Blend blend, Color color, float x, float y)
+    {
+        RectangleRuntime rect = new();
+        rect.Width = 70;
+        rect.Height = 70;
+        rect.X = x;
+        rect.Y = y;
+        rect.FillColor = color;
+        rect.IsFilled = true;
+        rect.Blend = blend;
+        frame.Children.Add(rect);
     }
 
     static ContainerRuntime BuildHorizontalRow()

--- a/Samples/raylib/Screens/RectanglesScreen.cs
+++ b/Samples/raylib/Screens/RectanglesScreen.cs
@@ -54,6 +54,7 @@ internal class RectanglesScreen : FrameworkElement
         right.Children.Add(BuildSection("Dropshadow (off / soft / hard offset / colored) — raylib approximates the blur via concentric rectangles (#2757)", BuildDropshadowRow()));
         right.Children.Add(BuildSection("Dashed strokes (solid / 6/4 / 2/2 dotted / long-dash) — raylib walks the perimeter, one DrawLineEx per dash (#2757)", BuildDashedStrokeRow()));
         right.Children.Add(BuildSection("FillColor + StrokeColor on the same instance — both layers render simultaneously (#2757)", BuildBothColorsRow()));
+        right.Children.Add(BuildSection("Blend (Additive) — overlapping R/G/B rectangles brighten toward white (#3458). Only Additive is a non-alpha mode on raylib today; the middle cell shows Normal for contrast.", BuildBlendRow()));
         right.Children.Add(BuildSection("Inscribed in a 64x64 frame — stroke must stay inside the gray rectangle's bounds at every StrokeWidth (#2757)", BuildInscribedRow()));
         right.Children.Add(BuildSection("Rotation (filled)", BuildRotationFilledRow()));
         right.Children.Add(BuildSection("Rotation (outline)", BuildRotationOutlineUnsupportedRow()));
@@ -316,6 +317,60 @@ internal class RectanglesScreen : FrameworkElement
         row.Children.Add(fillLast);
 
         return row;
+    }
+
+    // Issue #3458 — raylib RectangleRuntime.Blend. Two overlapping-triad cells sit side by side:
+    // the left cell uses Blend.Additive on all three rectangles so where red/green/blue overlap the
+    // channels sum and the intersection brightens (R+G = yellow, R+G+B ≈ white). The middle-right
+    // cell is the SAME geometry with Blend left at the default Normal, so the topmost rectangle
+    // simply occludes the others with no brightening — a side-by-side control that makes the
+    // additive effect obvious. raylib only maps Additive to a non-alpha blend today (Normal and the
+    // other Gum blend modes fall through to standard alpha in ToRaylibBlendMode), so those aren't
+    // demoed here.
+    static ContainerRuntime BuildBlendRow()
+    {
+        ContainerRuntime row = BuildHorizontalRow();
+        row.Children.Add(BuildBlendTriadCell(Gum.RenderingLibrary.Blend.Additive));
+        row.Children.Add(BuildBlendTriadCell(Gum.RenderingLibrary.Blend.Normal));
+        return row;
+    }
+
+    // A dark 150x120 frame with three 70x70 primary-color rectangles arranged so all three
+    // overlap in the middle. Under Additive the overlaps sum toward white; under Normal the last
+    // rectangle drawn just covers the earlier ones.
+    static ContainerRuntime BuildBlendTriadCell(Gum.RenderingLibrary.Blend blend)
+    {
+        ContainerRuntime frame = new();
+        frame.Width = 150;
+        frame.Height = 120;
+
+        RectangleRuntime backdrop = new();
+        backdrop.Width = 0;
+        backdrop.Height = 0;
+        backdrop.WidthUnits = DimensionUnitType.RelativeToParent;
+        backdrop.HeightUnits = DimensionUnitType.RelativeToParent;
+        backdrop.FillColor = new Color(20, 20, 30, 255);
+        backdrop.IsFilled = true;
+        frame.Children.Add(backdrop);
+
+        AddBlendRect(frame, blend, new Color(255, 0, 0, 255), x: 10, y: 10);
+        AddBlendRect(frame, blend, new Color(0, 255, 0, 255), x: 45, y: 10);
+        AddBlendRect(frame, blend, new Color(0, 0, 255, 255), x: 27, y: 42);
+
+        return frame;
+    }
+
+    static void AddBlendRect(ContainerRuntime frame, Gum.RenderingLibrary.Blend blend, Color color, float x, float y)
+    {
+        RectangleRuntime rect = new();
+        rect.Width = 70;
+        rect.Height = 70;
+        rect.X = x;
+        rect.Y = y;
+        rect.FillColor = color;
+        rect.IsFilled = true;
+        rect.Blend = blend;
+        frame.Children.Add(rect);
     }
 
     // Mirror of SilkNet's BuildInscribedRow. As of #2757, LineRectangle insets the rendered

--- a/Tests/RaylibGum.Tests/Runtimes/DataDrivenBlendPropertyTests.cs
+++ b/Tests/RaylibGum.Tests/Runtimes/DataDrivenBlendPropertyTests.cs
@@ -25,6 +25,18 @@ public class DataDrivenBlendPropertyTests : BaseTestClass
         ((NineSlice)sut.RenderableComponent).Blend.ShouldBe(Blend.Normal);
     }
 
+    // Issue #3458 — the .gumx "Blend" variable reaches the raylib RectangleRuntime the same way:
+    // reflection sets Blend on the contained LineRectangle (now that it exposes a nullable Blend).
+    [Fact]
+    public void SetProperty_Blend_OnRectangle_AppliesWithoutThrowing()
+    {
+        RectangleRuntime sut = new();
+
+        Should.NotThrow(() => sut.SetProperty("Blend", Blend.Additive));
+
+        ((LineRectangle)sut.RenderableComponent).Blend.ShouldBe(Blend.Additive);
+    }
+
     [Fact]
     public void SetProperty_Blend_OnSprite_AppliesWithoutThrowing()
     {

--- a/Tests/RaylibGum.Tests/Runtimes/RectangleRuntimeTests.cs
+++ b/Tests/RaylibGum.Tests/Runtimes/RectangleRuntimeTests.cs
@@ -69,6 +69,28 @@ public class RectangleRuntimeTests : BaseTestClass
         sut.Alpha.ShouldBe(128);
     }
 
+    // Issue #3458 — raylib Blend surface. The runtime exposes a non-nullable Blend (default Normal,
+    // matching the XNALIKE public signature) that forwards to the contained LineRectangle's nullable
+    // blend member, whose Render wraps the fill/stroke passes in BeginBlendMode when set.
+    [Fact]
+    public void Blend_DefaultsToNormal()
+    {
+        RectangleRuntime sut = new();
+        sut.Blend.ShouldBe(Gum.RenderingLibrary.Blend.Normal);
+    }
+
+    [Fact]
+    public void Blend_RoundTrips_AndPushesToContainedRenderable()
+    {
+        RectangleRuntime sut = new();
+
+        sut.Blend = Gum.RenderingLibrary.Blend.Additive;
+
+        sut.Blend.ShouldBe(Gum.RenderingLibrary.Blend.Additive);
+        LineRectangle inner = (LineRectangle)sut.RenderableComponent!;
+        inner.Blend.ShouldBe(Gum.RenderingLibrary.Blend.Additive);
+    }
+
     [Fact]
     public void Blue_ShouldRoundTrip()
     {


### PR DESCRIPTION
Closes #3458. Part of #3432 (RaylibGum feature-parity umbrella).

## What

Adds a `Blend` surface to `RectangleRuntime` on the **raylib** backend. Previously `RectangleRuntime.Blend` was `#if XNALIKE`-only, so setting a blend mode on a rectangle was a no-op on raylib.

## How

Mirrors the raylib `Sprite`/`NineSlice` **immediate-mode** blend pattern, **not** the XNALIKE two-slot path (`IBlendedRenderable` / `ShapeStrokePreRenderMath.PushBlend` / blend-in-`BatchKey`), which is Apos.Shapes-specific and does not compile on raylib.

- **`Runtimes/RaylibGum/Renderables/LineRectangle.cs`** — new nullable `Blend` member; `Render` wraps **only** the fill + stroke passes in the batch-counted `BeginBlendMode`/`EndBlendMode` (via `Renderer.Self.BatchDrawCallCounter`) using `ToRaylibBlendMode()`. The dropshadow pre-pass is left outside the wrap — it bakes into its own `RenderTexture2D` and manages its own blend state.
- **`MonoGameGum/GueDeriving/RectangleRuntime.cs`** — new `#if RAYLIB` `Blend` property (non-nullable `Gum.RenderingLibrary.Blend`, default `Normal`, matching the XNALIKE public signature) forwarding straight to the contained `LineRectangle`.
- Default rectangles never fire the setter, so the renderable's `Blend` stays `null` → zero added draw calls by default (confirmed by the passing draw-call-count suites).

## Limitation

`BlendModeExtensions.ToRaylibBlendMode` maps only `Additive` to a non-alpha raylib mode today; every other Gum `Blend` falls through to `Alpha`. So `Additive` is the one demoable non-alpha mode — same limitation `Sprite`/`NineSlice` already have. The broader "blend modes collapse to Alpha" gap is the separate P1 umbrella item.

## Samples

- **`Samples/raylib/Screens/RectanglesScreen.cs`** — new "Blend (Additive)" section: an additive overlapping R/G/B triad (overlaps brighten toward white) next to a `Normal`-blend control triad. Manually verified — the additive overlaps brighten, the control triad occludes with no brightening.
- **`Samples/MonoGameGumInCode/.../RectanglesScreen.cs`** — mirrored section for API/round-trip parity. Note: in *this* sample it is a documented **visual no-op** — MonoGameGumInCode has no Apos.Shapes reference, and the core `SolidRectangle` fill default doesn't implement `IBlendedRenderable`, so the XNALIKE `Blend` renders only when MonoGameGumShapes is installed. Header documents this, matching the file's existing Antialiasing-no-op convention. `GumShapesGallery` (which would show the effect) was intentionally left untouched.

## Tests

`RaylibGum.Tests` (headless in CI via llvmpipe): runtime default + forward-to-renderable + the from-file `.gumx` reflection path (`RectangleRuntimeTests`, `DataDrivenBlendPropertyTests`). Full suite green locally (391/391). Pixel-level rendering is validated visually in the raylib sample, per the RaylibGum.Tests convention (no pixel-readback harness exists).

## Not in scope
- `RectangleRuntime.CornerRadiusUnits` on raylib (P3 sibling).
- `CircleRuntime.Blend` on raylib — the identical immediate-mode follow-up.
- The obsolete `ColoredRectangleRuntime` / `SolidRectangle` rotation+blend (P2).

## Bug found while testing

Filed **#3460** — on raylib, a **blurred** dropshadow's offscreen `BeginTextureMode`/`EndTextureMode` passes run inside the frame's `BeginMode2D(camera)` and raylib's `EndTextureMode` doesn't restore the camera matrix, so the zoom resets for the rest of the frame. Separate bug, not addressed here.
