### PR TITLE
raylib: implement software Sprite clamp-to-edge for Wrap=false (#3459)

### DIFF
--- a/Runtimes/RaylibGum/Renderables/Sprite.cs
+++ b/Runtimes/RaylibGum/Renderables/Sprite.cs
@@ -190,13 +190,18 @@ public class Sprite : InvisibleRenderable, IAspectRatio, ITextureCoordinate, IAn
         }
 
         // RenderTargetTextureSource is excluded: its source rect already encodes the bottom-up GL
-        // flip via a negative height, which the tiling loop's positive-range math does not expect.
-        bool shouldTile = ((ITextureCoordinate)this).Wrap && RenderTargetTextureSource == null
+        // flip via a negative height, which the tiling/clamping loops' positive-range math does
+        // not expect.
+        bool canSoftwareAddress = RenderTargetTextureSource == null
             && srcRect.Width > 0 && srcRect.Height > 0;
 
-        if (shouldTile)
+        if (canSoftwareAddress && ((ITextureCoordinate)this).Wrap)
         {
             RenderTiled(textureToDraw, srcRect, destinationRectangle, absoluteRotation);
+        }
+        else if (canSoftwareAddress && IsOutOfTextureBounds(srcRect, textureToDraw))
+        {
+            RenderClamped(textureToDraw, srcRect, destinationRectangle, absoluteRotation);
         }
         else
         {
@@ -287,6 +292,144 @@ public class Sprite : InvisibleRenderable, IAspectRatio, ITextureCoordinate, IAn
             offsetYFromTopLeft += destHeight;
             y += texHeight;
         }
+    }
+
+    private static bool IsOutOfTextureBounds(Rectangle sourceRectangle, Texture2D texture)
+    {
+        return sourceRectangle.X < 0 || sourceRectangle.Y < 0
+            || sourceRectangle.X + sourceRectangle.Width > texture.Width
+            || sourceRectangle.Y + sourceRectangle.Height > texture.Height;
+    }
+
+    // Stretches the nearest edge row/column/corner texel of an oversized source rectangle across
+    // its out-of-bounds portion instead of letting raylib's GL default TextureWrap.Repeat sample
+    // repeat it (#3459). Splits source and destination into up to a 3x3 grid at the texture's
+    // 0/width and 0/height bounds - in-bounds cells draw straight through, out-of-bounds cells draw
+    // a single clamped edge/corner texel stretched to fill, the same edge-stretching idea as
+    // nine-slice. Never calls SetTextureWrap: raylib's negative-source-dimension flip trick (below)
+    // samples a single clamped texel across the whole quad under hardware TextureWrap.Clamp, which
+    // is why the earlier hardware-wrap attempt for this issue was reverted.
+    //
+    // Unlike RenderTiled, cells are reordered (not just content-flipped) when flipping, because a
+    // clamped edge and its in-bounds neighbor are not interchangeable the way repeating tiles are -
+    // flipping must swap which side carries the stretched edge, not just mirror each cell in place.
+    private void RenderClamped(Texture2D texture, Rectangle sourceRectangle, Rectangle destinationRectangle,
+        float absoluteRotationDegrees)
+    {
+        int textureWidth = texture.Width;
+        int textureHeight = texture.Height;
+        if (textureWidth <= 0 || textureHeight <= 0) return;
+
+        float textureWidthScale = destinationRectangle.Width / sourceRectangle.Width;
+        float textureHeightScale = destinationRectangle.Height / sourceRectangle.Height;
+
+        var matrix = this.GetRotationMatrix();
+
+        var xSegments = GetClampSegments(sourceRectangle.X, sourceRectangle.Width, textureWidth);
+        var ySegments = GetClampSegments(sourceRectangle.Y, sourceRectangle.Height, textureHeight);
+
+        if (FlipHorizontal) xSegments.Reverse();
+        if (FlipVertical) ySegments.Reverse();
+
+        float offsetYFromTopLeft = 0;
+        foreach (var ySegment in ySegments)
+        {
+            float destHeight = ySegment.Length * textureHeightScale;
+
+            float offsetXFromTopLeft = 0;
+            foreach (var xSegment in xSegments)
+            {
+                float destWidth = xSegment.Length * textureWidthScale;
+
+                var tileSourceRect = new Rectangle(xSegment.TexCoordinate, ySegment.TexCoordinate,
+                    xSegment.TexLength, ySegment.TexLength);
+
+                // Mirroring a single-texel span is a visual no-op (only one column/row is ever
+                // sampled), so skip the negate-and-shift for it. This also sidesteps a raylib
+                // DrawTexturePro quirk: negating a 1-wide/tall source rect pushes its X/Y to sit
+                // exactly on the texture's far edge (X == textureWidth), which samples garbage
+                // (observed: solid wrong-color fill) instead of the intended edge texel.
+                if (FlipHorizontal && tileSourceRect.Width > 1)
+                {
+                    tileSourceRect.X += tileSourceRect.Width;
+                    tileSourceRect.Width = -tileSourceRect.Width;
+                }
+
+                if (FlipVertical && tileSourceRect.Height > 1)
+                {
+                    tileSourceRect.Y += tileSourceRect.Height;
+                    tileSourceRect.Height = -tileSourceRect.Height;
+                }
+
+                Vector3 tileOffset = matrix.Right() * offsetXFromTopLeft + matrix.Up() * offsetYFromTopLeft;
+                var tileDestinationRect = new Rectangle(
+                    destinationRectangle.X + tileOffset.X,
+                    destinationRectangle.Y + tileOffset.Y,
+                    destWidth,
+                    destHeight);
+
+                DrawTexturePro(texture, tileSourceRect, tileDestinationRect, Vector2.Zero, -absoluteRotationDegrees, Color);
+
+                offsetXFromTopLeft += destWidth;
+            }
+
+            offsetYFromTopLeft += destHeight;
+        }
+    }
+
+    private readonly struct ClampSegment
+    {
+        public ClampSegment(float length, int texCoordinate, int texLength)
+        {
+            Length = length;
+            TexCoordinate = texCoordinate;
+            TexLength = texLength;
+        }
+
+        // Destination-space (pre-scale) length of this segment, in source units.
+        public float Length { get; }
+        // Texture column/row this segment samples: the real in-bounds coordinate for an in-bounds
+        // segment, or the nearest edge texel's coordinate for an out-of-bounds segment.
+        public int TexCoordinate { get; }
+        // 1 for an out-of-bounds (clamped) segment; the real span for an in-bounds segment.
+        public int TexLength { get; }
+    }
+
+    // Splits [start, start + length) into up to 3 segments at the texture's 0 and textureExtent
+    // bounds, so each segment is either fully in-bounds (samples real texels 1:1) or fully
+    // out-of-bounds (samples the single nearest edge texel, to be stretched across the segment).
+    private static List<ClampSegment> GetClampSegments(float start, float length, int textureExtent)
+    {
+        float end = start + length;
+
+        var breaks = new List<float> { start, end };
+        if (start < 0 && end > 0) breaks.Add(0);
+        if (start < textureExtent && end > textureExtent) breaks.Add(textureExtent);
+        breaks.Sort();
+
+        var segments = new List<ClampSegment>();
+        for (int i = 0; i < breaks.Count - 1; i++)
+        {
+            float segmentStart = breaks[i];
+            float segmentEnd = breaks[i + 1];
+            float segmentLength = segmentEnd - segmentStart;
+            if (segmentLength <= 0) continue;
+
+            if (segmentEnd <= 0)
+            {
+                segments.Add(new ClampSegment(segmentLength, 0, 1));
+            }
+            else if (segmentStart >= textureExtent)
+            {
+                segments.Add(new ClampSegment(segmentLength, textureExtent - 1, 1));
+            }
+            else
+            {
+                segments.Add(new ClampSegment(segmentLength, (int)segmentStart, (int)segmentLength));
+            }
+        }
+
+        return segments;
     }
 
     public AnimationChainLogic AnimationLogic { get; } = new AnimationChainLogic();

--- a/Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/SpriteScreen.cs
+++ b/Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/SpriteScreen.cs
@@ -62,8 +62,8 @@ internal class SpriteScreen : FrameworkElement
         // Wrap / tiling (issue #3456) — TextureWidth/Height set to 2x the source file's pixel
         // dimensions (BearTexture.png is 39x40) so the source rectangle extends past the texture
         // bounds. With Wrap=false the area beyond the bounds clamps/stretches; with Wrap=true it
-        // repeats the bear 2x2 across the sprite. Compare against the raylib mirror of this screen —
-        // raylib's Wrap=false cell is a known gap (#3459) and still repeats instead of clamping.
+        // repeats the bear 2x2 across the sprite. Compare against the raylib mirror of this screen,
+        // which now matches (issue #3459 — raylib's Wrap=false clamps via software edge-stretching).
         AddLabel(container, "Wrap (false = clamp/stretch, true = tile, BearTexture.png 2x2):");
         var wrapRow = AddRow(container);
         foreach (var wrap in new[] { false, true })

--- a/Samples/raylib/Screens/SpriteScreen.cs
+++ b/Samples/raylib/Screens/SpriteScreen.cs
@@ -65,13 +65,14 @@ internal class SpriteScreen : FrameworkElement
         custom.Height = 96;
         page.AddChild(custom);
 
-        // Wrap / tiling (issue #3456) — TextureWidth/Height set to 2x the source file's pixel
-        // dimensions (BearTexture.png is 39x40) so the source rectangle extends past the texture
-        // bounds. With Wrap=true it repeats the bear 2x2 across the sprite, matching MonoGame.
-        // Wrap=false is a KNOWN GAP (#3459): it should clamp to the edge pixel like MonoGame but
-        // currently repeats too (raylib's GL default wrap mode is Repeat) — a hardware-wrap fix was
-        // tried and reverted because it breaks FlipHorizontal/FlipVertical elsewhere in this class.
-        AddSectionLabel(page, "Wrap (false = clamp [KNOWN GAP #3459, still repeats], true = tile, BearTexture.png 2x2):");
+        // Wrap / tiling (issue #3456) and edge clamping (issue #3459) — TextureWidth/Height set to
+        // 2x the source file's pixel dimensions (BearTexture.png is 39x40) so the source rectangle
+        // extends past the texture bounds. With Wrap=true it repeats the bear 2x2 across the
+        // sprite; with Wrap=false it stretches the bear's edge pixels to fill the out-of-bounds
+        // area — both match MonoGame's hardware-sampler behavior, but done entirely in software
+        // (extra DrawTexturePro calls) since a hardware TextureWrap.Clamp attempt broke
+        // FlipHorizontal/FlipVertical elsewhere in this class (see the revert in #3457).
+        AddSectionLabel(page, "Wrap (false = clamp, true = tile, BearTexture.png 2x2):");
         var wrapRow = NewSection(ChildrenLayout.LeftToRightStack, spacing: 6);
         page.AddChild(wrapRow);
         foreach (var wrap in new[] { false, true })

--- a/Tests/RaylibGum.Tests/Rendering/SpriteClampTests.cs
+++ b/Tests/RaylibGum.Tests/Rendering/SpriteClampTests.cs
@@ -1,0 +1,170 @@
+using Gum.GueDeriving;
+using Gum.Managers;
+using Gum.RenderingLibrary;
+using Raylib_cs;
+using RenderingLibrary.Graphics;
+using Shouldly;
+using static Raylib_cs.Raylib;
+
+namespace RaylibGum.Tests.Rendering;
+
+/// <summary>
+/// Pixel-readback test for raylib Sprite clamp-to-edge (issue #3459, part of the #3432 parity
+/// umbrella). Renders into an <see cref="ContainerRuntime.IsRenderTarget"/> container so the baked
+/// texture can be sampled deterministically, mirroring the pattern in <see cref="SpriteWrapTests"/>.
+/// </summary>
+public class SpriteClampTests : BaseTestClass
+{
+    private static void DrawOnce()
+    {
+        BeginDrawing();
+        GumService.Default.Draw();
+        EndDrawing();
+    }
+
+    // Reads a pixel in top-left-origin draw space. A render texture is stored bottom-up in GL, so
+    // LoadImageFromTexture yields an image whose rows are flipped relative to draw space.
+    private static Color ReadRenderTargetPixel(RenderTexture2D renderTexture, int x, int y)
+    {
+        Image image = LoadImageFromTexture(renderTexture.Texture);
+        try
+        {
+            return GetImageColor(image, x, renderTexture.Texture.Height - 1 - y);
+        }
+        finally
+        {
+            UnloadImage(image);
+        }
+    }
+
+    private static Texture2D CreateRedBlueTexture()
+    {
+        // A 2x1 texture: left texel pure red, right texel pure blue. Explicit RGBA (not the named
+        // Color.Red/Blue constants, which raylib-cs defines as muted brand colors) so the R/B
+        // channel thresholds below are unambiguous.
+        Color pureRed = new Color((byte)255, (byte)0, (byte)0, (byte)255);
+        Color pureBlue = new Color((byte)0, (byte)0, (byte)255, (byte)255);
+        Image image = GenImageColor(2, 1, pureRed);
+        ImageDrawPixel(ref image, 1, 0, pureBlue);
+        Texture2D texture = LoadTextureFromImage(image);
+        UnloadImage(image);
+        return texture;
+    }
+
+    [Fact]
+    public void Render_WrapFalseFlipHorizontal_OversizedSourceRectangle_MirrorsClampedImage()
+    {
+        Texture2D texture = CreateRedBlueTexture();
+
+        ContainerRuntime container = new();
+        container.X = 0;
+        container.Y = 0;
+        container.Width = 40;
+        container.Height = 10;
+        container.IsRenderTarget = true;
+
+        SpriteRuntime sprite = new();
+        sprite.Texture = texture;
+        sprite.WidthUnits = Gum.DataTypes.DimensionUnitType.Absolute;
+        sprite.HeightUnits = Gum.DataTypes.DimensionUnitType.Absolute;
+        sprite.TextureAddress = TextureAddress.Custom;
+        sprite.TextureLeft = 0;
+        sprite.TextureTop = 0;
+        sprite.TextureWidth = 4; // 2x the texture width -> right half is out of bounds
+        sprite.TextureHeight = 1;
+        sprite.Wrap = false;
+        sprite.FlipHorizontal = true;
+        sprite.Width = 40;
+        sprite.Height = 10;
+        container.Children.Add(sprite);
+
+        GumService.Default.Root.Children.Add(container);
+        GumService.Default.Root.UpdateLayout();
+
+        DrawOnce();
+
+        RenderTexture2D renderTexture = Renderer.Self.TryGetBakedRenderTargetFor(container)!.Value;
+
+        // Unflipped, the strip reads Red, Blue, Blue(clamp), Blue(clamp) left-to-right (see
+        // Render_WrapFalse_OversizedSourceRectangle_ClampsToEdgeInsteadOfRepeating). Flipping the
+        // whole rendered strip mirrors that order: Blue(clamp), Blue(clamp), Blue, Red.
+        Color leftClamped = ReadRenderTargetPixel(renderTexture, 5, 5);
+        Color midClamped = ReadRenderTargetPixel(renderTexture, 15, 5);
+        Color inBoundsBlue = ReadRenderTargetPixel(renderTexture, 25, 5);
+        Color inBoundsRed = ReadRenderTargetPixel(renderTexture, 35, 5);
+
+        leftClamped.B.ShouldBeGreaterThan((byte)200);
+        leftClamped.R.ShouldBeLessThan((byte)50);
+
+        midClamped.B.ShouldBeGreaterThan((byte)200);
+        midClamped.R.ShouldBeLessThan((byte)50);
+
+        inBoundsBlue.B.ShouldBeGreaterThan((byte)200);
+        inBoundsBlue.R.ShouldBeLessThan((byte)50);
+
+        // This is the exact regression the revert in #3457 guarded against: under hardware
+        // TextureWrap.Clamp, FlipHorizontal's negative-source-dimension trick sampled a single
+        // clamped edge texel across the whole quad instead of the flipped image. This assertion
+        // fails the same way if RenderClamped ever routes back through SetTextureWrap.
+        inBoundsRed.R.ShouldBeGreaterThan((byte)200);
+        inBoundsRed.B.ShouldBeLessThan((byte)50);
+
+        GumService.Default.Root.Children.Clear();
+        UnloadTexture(texture);
+    }
+
+    [Fact]
+    public void Render_WrapFalse_OversizedSourceRectangle_ClampsToEdgeInsteadOfRepeating()
+    {
+        Texture2D texture = CreateRedBlueTexture();
+
+        ContainerRuntime container = new();
+        container.X = 0;
+        container.Y = 0;
+        container.Width = 40;
+        container.Height = 10;
+        container.IsRenderTarget = true;
+
+        SpriteRuntime sprite = new();
+        sprite.Texture = texture;
+        sprite.WidthUnits = Gum.DataTypes.DimensionUnitType.Absolute;
+        sprite.HeightUnits = Gum.DataTypes.DimensionUnitType.Absolute;
+        sprite.TextureAddress = TextureAddress.Custom;
+        sprite.TextureLeft = 0;
+        sprite.TextureTop = 0;
+        sprite.TextureWidth = 4; // 2x the texture width -> right half is out of bounds
+        sprite.TextureHeight = 1;
+        sprite.Wrap = false;
+        sprite.Width = 40;
+        sprite.Height = 10;
+        container.Children.Add(sprite);
+
+        GumService.Default.Root.Children.Add(container);
+        GumService.Default.Root.UpdateLayout();
+
+        DrawOnce();
+
+        RenderTexture2D renderTexture = Renderer.Self.TryGetBakedRenderTargetFor(container)!.Value;
+
+        Color inBoundsRed = ReadRenderTargetPixel(renderTexture, 5, 5);
+        Color inBoundsBlue = ReadRenderTargetPixel(renderTexture, 15, 5);
+        Color clampedNearEdge = ReadRenderTargetPixel(renderTexture, 25, 5);
+        Color clampedFarEdge = ReadRenderTargetPixel(renderTexture, 35, 5);
+
+        inBoundsRed.R.ShouldBeGreaterThan((byte)200);
+        inBoundsRed.B.ShouldBeLessThan((byte)50);
+
+        inBoundsBlue.B.ShouldBeGreaterThan((byte)200);
+        inBoundsBlue.R.ShouldBeLessThan((byte)50);
+
+        // The out-of-bounds half must stretch the last (blue) texel, not repeat back to red.
+        clampedNearEdge.B.ShouldBeGreaterThan((byte)200);
+        clampedNearEdge.R.ShouldBeLessThan((byte)50);
+
+        clampedFarEdge.B.ShouldBeGreaterThan((byte)200);
+        clampedFarEdge.R.ShouldBeLessThan((byte)50);
+
+        GumService.Default.Root.Children.Clear();
+        UnloadTexture(texture);
+    }
+}


### PR DESCRIPTION
## Summary
- Fixes raylib `Sprite` `Wrap=false` silently repeating an oversized source rectangle instead of clamping to the edge pixel, matching MonoGame's hardware-sampler `Clamp` behavior (`Runtimes/RaylibGum/Renderables/Sprite.cs`).
- Root cause: raylib's GL default texture wrap mode is `TextureWrap.Repeat`, and nothing set it otherwise — so an oversized `SourceRectangle` (from `TextureAddress.Custom`/`DimensionsBased` with `TextureWidth`/`TextureHeight` larger than the texture) always repeated regardless of Gum's `Wrap` value.
- A prior attempt to call `Raylib.SetTextureWrap(texture, TextureWrap.Clamp)` was tried and reverted in #3457 — it broke `FlipHorizontal`/`FlipVertical`'s negative-source-dimension flip trick (a flipped sprite rendered as a single solid clamped-edge color).
- This implements clamping entirely in **software**, the same way #3456 implemented tiling in software (`Sprite.RenderTiled`, merged in #3457): the out-of-bounds portion of an oversized source rectangle is split into up to a 3x3 grid at the texture's bounds (`GetClampSegments`); in-bounds cells draw straight through, and out-of-bounds cells stretch the single nearest edge/corner texel across their destination area — the same idea as nine-slice edge stretching. `SetTextureWrap` is never called.
- Flip handling required going slightly further than `RenderTiled`'s pattern: `RenderClamped` **reorders** cells (not just mirrors each cell's content in place) when flipping, because a clamped edge and its in-bounds neighbor aren't interchangeable the way repeating tiles are — flipping must swap which side carries the stretched edge. (`RenderTiled`'s same-order-plus-per-cell-flip approach only produces a true mirror for tiling counts that are an exact multiple of the texture size; that's out of scope here and unchanged.)
- Also found and worked around a raylib `DrawTexturePro` quirk while testing: negating a 1-texel-wide/tall source rect (the flip trick) pushes its `X`/`Y` to sit exactly on the texture's far edge, which samples garbage instead of the intended edge texel. Since mirroring a single-texel span is a visual no-op anyway, `RenderClamped` skips the negate for 1-texel segments.

## Test plan
- [x] New pixel-readback tests (`Tests/RaylibGum.Tests/Rendering/SpriteClampTests.cs`) — bake a clamped sprite into a render target and sample the in-bounds and clamped regions, confirming the edge texel stretches instead of repeating; a second test confirms the exact regression scenario from the #3457 revert (`Wrap=false` + oversized rect + `FlipHorizontal`) renders a correctly mirrored image rather than a solid color.
- [x] `dotnet test Tests/RaylibGum.Tests/RaylibGum.Tests.csproj` — 394/394 passing (no regressions).
- [x] `dotnet build Samples/raylib/GumTest.csproj` and `dotnet build Samples/MonoGameGumInCode/MonoGameGumInCode.sln` — both build clean.
- [x] Updated the "Wrap" comparison row's comments in both `Samples/raylib/Screens/SpriteScreen.cs` and `Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/SpriteScreen.cs` — the raylib sample no longer flags `Wrap=false` as a known gap.
- [ ] Manual: run both samples (Visual Studio opened for both `.sln`s) and confirm the raylib "Wrap = false" cell now stretches the bear's edge pixels to fill the out-of-bounds area instead of repeating, matching the MonoGame reference cell.

Closes #3459
