### PR TITLE
Fix raylib blurred dropshadow clobbering active camera for rest of frame (#3460)

### DIFF
--- a/Runtimes/RaylibGum/Renderables/LineArc.cs
+++ b/Runtimes/RaylibGum/Renderables/LineArc.cs
@@ -620,6 +620,7 @@ public class LineArc : InvisibleRenderable
             diameter,
             blur,
             effectiveDropshadowColor,
+            global::RenderingLibrary.Graphics.Renderer.Self.ActiveCamera2D,
             (px, py) =>
             {
                 DrawRing(

--- a/Runtimes/RaylibGum/Renderables/LineCircle.cs
+++ b/Runtimes/RaylibGum/Renderables/LineCircle.cs
@@ -368,6 +368,7 @@ public class LineCircle : InvisibleRenderable
                     diameter,
                     blur,
                     effectiveDropshadowColor,
+                    global::RenderingLibrary.Graphics.Renderer.Self.ActiveCamera2D,
                     (px, py) =>
                     {
                         DrawCircleV(new Vector2(px + r, py + r), r, silhouetteColor);

--- a/Runtimes/RaylibGum/Renderables/LineRectangle.cs
+++ b/Runtimes/RaylibGum/Renderables/LineRectangle.cs
@@ -329,6 +329,7 @@ public class LineRectangle : InvisibleRenderable
                     h,
                     blur,
                     effectiveDropshadowColor,
+                    global::RenderingLibrary.Graphics.Renderer.Self.ActiveCamera2D,
                     (px, py) =>
                     {
                         if (useRounded)

--- a/Runtimes/RaylibGum/Renderables/ShadowBlurRenderer.cs
+++ b/Runtimes/RaylibGum/Renderables/ShadowBlurRenderer.cs
@@ -91,6 +91,11 @@ void main() {{
     /// <param name="shapeH">Shape height in pixels.</param>
     /// <param name="sigma">Gaussian sigma in pixels. Mirrors Skia's <c>SKImageFilter.CreateDropShadow</c> sigma.</param>
     /// <param name="tint">Shadow color including alpha. Multiplied into the blurred mask at composite time.</param>
+    /// <param name="activeCamera">The <see cref="Camera2D"/> currently established via <c>BeginMode2D</c>
+    /// for the pass this shadow draws in (see <see cref="Renderer.ActiveCamera2D"/>). raylib's
+    /// <c>EndTextureMode</c> resets the modelview to identity, so the offscreen blur passes below would
+    /// otherwise clobber this camera for the shadow's own composite and every later draw in the frame;
+    /// it is re-established after the passes (issue #3460).</param>
     /// <param name="drawSilhouetteAt">
     /// Callback invoked inside the offscreen render pass. Receives the RT-local top-left
     /// coordinates the caller should paint a SOLID-WHITE silhouette of the shape at. The
@@ -105,6 +110,7 @@ void main() {{
         float shapeH,
         float sigma,
         Color tint,
+        Camera2D activeCamera,
         Action<float, float> drawSilhouetteAt)
     {
         if (sigma <= 0f || shapeW <= 0f || shapeH <= 0f || tint.A == 0)
@@ -177,6 +183,12 @@ void main() {{
         counter.EndShaderMode();
         counter.EndBlendMode();
         counter.EndTextureMode();
+
+        // Re-establish the active camera clobbered by the offscreen passes. raylib's EndTextureMode
+        // resets the modelview to identity and does NOT restore the enclosing BeginMode2D transform,
+        // so without this the shadow composite below — and every later draw in the frame — would
+        // render at identity zoom/pan (issue #3460).
+        counter.BeginMode2D(activeCamera);
 
         // 4) Composite RT_A onto the screen, tinted. shadowMinX/Y are the shape's top-left;
         // the RT contains `radius` pixels of falloff padding around the shape, so the on-screen

--- a/Runtimes/RaylibGum/RenderingLibrary/Renderer.cs
+++ b/Runtimes/RaylibGum/RenderingLibrary/Renderer.cs
@@ -95,6 +95,16 @@ public class Renderer : IRenderer
     public Camera Camera => _camera;
 
     /// <summary>
+    /// The raylib <see cref="Camera2D"/> currently established via <c>BeginMode2D</c> for the pass in
+    /// progress — the main-walk camera during the main walk, or a render-target container's bake
+    /// camera while that container's subtree is baking. Exposed so a mid-walk offscreen consumer
+    /// (e.g. <see cref="ShadowBlurRenderer"/>) can re-establish it after its own
+    /// <c>BeginTextureMode</c>/<c>EndTextureMode</c> passes, which raylib's <c>EndTextureMode</c>
+    /// resets to identity (issue #3460). Primarily for internal renderer/renderable use.
+    /// </summary>
+    public Camera2D ActiveCamera2D { get; private set; }
+
+    /// <summary>
     /// Per-renderable shadow-blur service. Owns the Gaussian shader and the per-renderable
     /// render textures (issue #2865). Renderables call <c>Renderer.Self.ShadowBlur.Draw(this, ...)</c>
     /// from their <c>Render</c> method; the renderer sweeps unused entries at the top of every
@@ -214,6 +224,9 @@ public class Renderer : IRenderer
             }
         }
 
+        // Record the outer camera so a mid-walk offscreen consumer can re-establish it after its
+        // own EndTextureMode resets the modelview (issue #3460).
+        ActiveCamera2D = camera2D;
         BatchDrawCallCounter.BeginMode2D(camera2D);
 
         for (int i = 0; i < layers.Count; i++)
@@ -465,6 +478,12 @@ public class Renderer : IRenderer
         _bakeLeft = left;
         _bakeTop = top;
 
+        // Record the bake camera as the active one so a blurred dropshadow drawn inside this bake
+        // re-establishes the bake transform (not the main-walk camera) after its offscreen passes
+        // (issue #3460). Restored to the main-walk camera before the main BeginMode2D below.
+        Camera2D savedActiveCamera = ActiveCamera2D;
+        ActiveCamera2D = bakeCamera;
+
         counter.BeginTextureMode(renderTexture.Value);
         Raylib.ClearBackground(new Color((byte)0, (byte)0, (byte)0, (byte)0));
         counter.BeginMode2D(bakeCamera);
@@ -492,6 +511,7 @@ public class Renderer : IRenderer
         _bakeLeft = savedBakeLeft;
         _bakeTop = savedBakeTop;
         _scissorStack = savedScissorStack;
+        ActiveCamera2D = savedActiveCamera;
     }
 
     // Composites a render-target container's baked texture at the container's clamped rectangle,

--- a/Tests/RaylibGum.Tests/Rendering/ShadowBlurCameraRestoreTests.cs
+++ b/Tests/RaylibGum.Tests/Rendering/ShadowBlurCameraRestoreTests.cs
@@ -1,0 +1,61 @@
+using System.Numerics;
+using Gum.Renderables;
+using Raylib_cs;
+using RenderingLibrary.Graphics;
+using Shouldly;
+using static Raylib_cs.Raylib;
+
+namespace RaylibGum.Tests.Rendering;
+
+/// <summary>
+/// Issue #3460: a blurred dropshadow paints via <see cref="ShadowBlurRenderer"/>'s offscreen
+/// <c>BeginTextureMode</c>/<c>EndTextureMode</c> passes. raylib's <c>EndTextureMode</c> resets the
+/// modelview to identity and does NOT restore a previously-active <c>BeginMode2D</c> camera, so
+/// before the fix the outer camera transform (zoom/pan) was clobbered for the shadow's own
+/// composite and every draw after it in the same frame. The fix re-establishes the active camera
+/// after the offscreen passes. Asserted by reading the rlgl modelview matrix directly (deterministic,
+/// no flaky screen readback).
+/// </summary>
+public class ShadowBlurCameraRestoreTests : BaseTestClass
+{
+    [Fact]
+    public void Draw_BlurredShadow_RestoresActiveCameraTransform()
+    {
+        Camera2D camera = new Camera2D
+        {
+            Zoom = 2f,
+            Target = new Vector2(15f, 25f),
+            Offset = Vector2.Zero,
+            Rotation = 0f,
+        };
+
+        LineRectangle owner = new LineRectangle();
+        Color tint = new Color((byte)0, (byte)0, (byte)0, (byte)255);
+        Color silhouette = new Color((byte)255, (byte)255, (byte)255, (byte)255);
+
+        BeginDrawing();
+        BeginMode2D(camera);
+
+        // Sanity: BeginMode2D must actually be observable in the rlgl modelview (zoom shows as the
+        // x-scale). If this fails the observation point is wrong and the rest of the test is moot.
+        Matrix4x4 beforeShadow = Rlgl.GetMatrixModelview();
+        beforeShadow.M11.ShouldBe(2f);
+
+        Renderer.Self.ShadowBlur.Draw(
+            owner,
+            0f, 0f, 40f, 40f,
+            4f,
+            tint,
+            camera,
+            (px, py) => DrawRectangleV(new Vector2(px, py), new Vector2(40f, 40f), silhouette));
+
+        Matrix4x4 afterShadow = Rlgl.GetMatrixModelview();
+
+        EndMode2D();
+        EndDrawing();
+
+        // The zoom-2 camera transform must survive the offscreen blur passes. Before the fix
+        // EndTextureMode leaves the modelview at identity (M11 == 1) and this equality fails.
+        afterShadow.ShouldBe(beforeShadow);
+    }
+}


### PR DESCRIPTION
## Problem

On the raylib backend, rendering a shape with a **blurred** dropshadow (`DropshadowBlur > 0`) clobbered the active camera transform (zoom/pan) for the rest of the frame — every draw after that shape rendered as if the camera were at identity. Hard-offset shadows (`DropshadowBlur == 0`) were unaffected.

## Root cause

`ShadowBlurRenderer.Draw` paints its silhouette / H-blur / V-blur offscreen passes with `BeginTextureMode`/`EndTextureMode` while running *inside* the render walk's outer `BeginMode2D(camera2D)`. raylib's `EndTextureMode` resets the modelview to identity and does **not** restore a previously-active `BeginMode2D` camera, so the first blurred dropshadow left the camera at identity for its own composite and every subsequent draw that frame. Same hazard #3434 already dodged for the render-target bake by hoisting it before the outer `BeginMode2D`; the dropshadow bakes inline mid-walk and was never given the equivalent treatment.

## Fix

Re-establish the active camera (`BeginMode2D`) after the offscreen passes, before the composite. `Renderer` now exposes `ActiveCamera2D` — the main-walk camera, or a render-target container's bake camera while that container is baking — which the three shadow call sites (`LineRectangle`, `LineCircle`, `LineArc`) thread into `ShadowBlurRenderer.Draw`. Covers all blurred shape shadows. This also corrects the shadow's *own* placement under zoom, not just later draws.

## Test

`ShadowBlurCameraRestoreTests` asserts the rlgl modelview matrix is unchanged across a blurred-shadow `Draw` under a zoom-2 camera — deterministic GL-state assertion, no flaky screen readback. Red before the fix (modelview came back as identity), green after. Full `RaylibGum.Tests` suite: 390/390 green.

Closes #3460

🤖 Generated with [Claude Code](https://claude.com/claude-code)
