### PR TITLE
RaylibGum: bake invisible render-target containers when referenced by a Sprite (#3452)

### DIFF
--- a/Runtimes/RaylibGum/RenderingLibrary/Renderer.cs
+++ b/Runtimes/RaylibGum/RenderingLibrary/Renderer.cs
@@ -67,6 +67,13 @@ public class Renderer : IRenderer
     // case of screens with no render targets — no extra full traversal.
     bool _frameHasRenderTarget;
 
+    // Cache owners of render-target containers referenced by a visible Sprite's
+    // RenderTargetTextureSource. Collected once per Draw (before PreRender) so an INVISIBLE but
+    // referenced container still bakes — mirrors MonoGame's #1643 fix (Renderer.cs). Unlike MonoGame
+    // this needs no per-host-frame caching: raylib bakes all layers in a single pass per Draw, so one
+    // collection per Draw suffices (#3452).
+    readonly HashSet<IRenderableIpso> _referencedRenderTargetOwners = new();
+
 #if XNALIKE
     SpriteRenderer spriteRenderer = new SpriteRenderer();
 #endif
@@ -179,6 +186,15 @@ public class Renderer : IRenderer
         // which is the only thing that makes the bake pre-pass run (#3434 perf fast-out).
         _frameHasRenderTarget = false;
 
+        // Collect the render-target containers referenced by visible Sprites before PreRender so an
+        // invisible-but-referenced container still bakes (#3452). Runs every Draw; raylib bakes all
+        // layers in one pass so no per-host-frame caching is needed (unlike MonoGame).
+        _referencedRenderTargetOwners.Clear();
+        for (int i = 0; i < layers.Count; i++)
+        {
+            CollectReferencedRenderTargets(layers[i].Renderables);
+        }
+
         _camera.ClientWidth = Raylib.GetScreenWidth();
         _camera.ClientHeight = Raylib.GetScreenHeight();
 
@@ -263,7 +279,11 @@ public class Renderer : IRenderer
         for (int i = 0; i < renderables.Count; i++)
         {
             IRenderableIpso renderable = renderables[i];
-            if (!renderable.Visible)
+            // An invisible render-target container still needs its subtree PreRendered (and must flip
+            // _frameHasRenderTarget) when a visible Sprite references it, so the bake pre-pass runs and
+            // resolves its children's layout-time properties (#3452).
+            bool isReferencedRenderTarget = renderable.IsRenderTarget && IsReferencedRenderTargetOwner(renderable);
+            if (!renderable.Visible && !isReferencedRenderTarget)
             {
                 continue;
             }
@@ -278,6 +298,43 @@ public class Renderer : IRenderer
             }
         }
     }
+
+    // Populates _referencedRenderTargetOwners with the cache owner of every render-target container
+    // referenced by a visible Sprite's RenderTargetTextureSource. Both a top-level Sprite (the walk
+    // hands the contained Sprite directly) and a nested one (a GraphicalUiElement wrapping the Sprite)
+    // are handled. Mirrors MonoGame's CollectReferencedRenderTargets, but resolves the raylib
+    // Gum.Renderables.Sprite concretely — raylib has no IRenderTargetTextureReferencer interface (its
+    // Texture member is XNA-typed). See #3452 / #1643.
+    private void CollectReferencedRenderTargets(System.Collections.Generic.IList<IRenderableIpso> renderables)
+    {
+        for (int i = 0; i < renderables.Count; i++)
+        {
+            IRenderableIpso renderable = renderables[i];
+            if (!renderable.Visible)
+            {
+                continue;
+            }
+
+            Sprite? sprite = renderable as Sprite
+                ?? (renderable as GraphicalUiElement)?.RenderableComponent as Sprite;
+            if (sprite?.RenderTargetTextureSource != null)
+            {
+                _referencedRenderTargetOwners.Add(
+                    ResolveRenderTargetCacheOwner(sprite.RenderTargetTextureSource));
+            }
+
+            if (renderable.Children != null)
+            {
+                CollectReferencedRenderTargets(renderable.Children);
+            }
+        }
+    }
+
+    // Whether the given render-target container is referenced by a visible Sprite this Draw. Resolves
+    // to the container's cache owner so both the GraphicalUiElement wrapper and the contained
+    // renderable form match the keys stored during collection (#3452).
+    private bool IsReferencedRenderTargetOwner(IRenderableIpso renderable) =>
+        _referencedRenderTargetOwners.Contains(ResolveRenderTargetCacheOwner(renderable));
 
     private void Render(ReadOnlyCollection<IRenderableIpso> renderables, ISystemManagers managers, Layer layer)
     {
@@ -419,7 +476,10 @@ public class Renderer : IRenderer
         for (int i = 0; i < renderables.Count; i++)
         {
             IRenderableIpso renderable = renderables[i];
-            if (!renderable.Visible)
+            // An invisible container is normally skipped (it draws nothing to screen), but a
+            // referenced one still bakes so a visible Sprite can sample its cached texture (#3452).
+            bool isReferencedRenderTarget = renderable.IsRenderTarget && IsReferencedRenderTargetOwner(renderable);
+            if (!renderable.Visible && !isReferencedRenderTarget)
             {
                 continue;
             }

--- a/Tests/RaylibGum.Tests/Rendering/RenderTargetTests.cs
+++ b/Tests/RaylibGum.Tests/Rendering/RenderTargetTests.cs
@@ -594,6 +594,87 @@ public class RenderTargetTests : BaseTestClass
         GumService.Default.Root.Children.Clear();
     }
 
+    // Issue #3452: a Sprite referencing an INVISIBLE IsRenderTarget container must still show the
+    // baked texture. An invisible source is skipped by the plain Visible-gated bake walk, so the
+    // referenced-owners collection must force it to bake anyway (mirrors MonoGame #1643). The source
+    // is hidden but referenced by a visible sprite inside a readable outer RT; the outer RT's center
+    // must show the source's baked red.
+    [Fact]
+    public void Draw_SpriteReferencingInvisibleRenderTarget_ShowsBakedTexture()
+    {
+        ContainerRuntime source = new();
+        source.Width = 64;
+        source.Height = 64;
+        source.IsRenderTarget = true;
+        source.Visible = false;
+
+        ColoredRectangleRuntime fill = new();
+        fill.Width = 64;
+        fill.Height = 64;
+        fill.Color = new Color((byte)255, (byte)0, (byte)0, (byte)255);
+        source.Children.Add(fill);
+
+        ContainerRuntime readableOuter = new();
+        readableOuter.X = 0;
+        readableOuter.Y = 0;
+        readableOuter.Width = 64;
+        readableOuter.Height = 64;
+        readableOuter.IsRenderTarget = true;
+
+        SpriteRuntime sprite = new();
+        sprite.X = 0;
+        sprite.Y = 0;
+        sprite.WidthUnits = Gum.DataTypes.DimensionUnitType.Absolute;
+        sprite.HeightUnits = Gum.DataTypes.DimensionUnitType.Absolute;
+        sprite.Width = 64;
+        sprite.Height = 64;
+        sprite.RenderTargetTextureSource = source;
+        readableOuter.Children.Add(sprite);
+
+        GumService.Default.Root.Children.Add(source);
+        GumService.Default.Root.Children.Add(readableOuter);
+        GumService.Default.Root.UpdateLayout();
+
+        DrawOnce();
+
+        // The invisible source still baked because a visible sprite references it.
+        Renderer.Self.HasBakedRenderTargetFor(source).ShouldBeTrue();
+
+        Color center = ReadRenderTargetCenter(Renderer.Self.TryGetBakedRenderTargetFor(readableOuter)!.Value);
+        center.R.ShouldBeGreaterThan((byte)200);
+        center.G.ShouldBeLessThan((byte)50);
+
+        GumService.Default.Root.Children.Clear();
+    }
+
+    // Issue #3452 perf guard: an invisible IsRenderTarget container that NOTHING references must not
+    // bake. This keeps the fast-path intact — screens with no visible/referenced render targets skip
+    // the bake pre-pass entirely rather than baking hidden content for nobody.
+    [Fact]
+    public void Draw_InvisibleUnreferencedRenderTarget_DoesNotBake()
+    {
+        ContainerRuntime container = new();
+        container.Width = 64;
+        container.Height = 64;
+        container.IsRenderTarget = true;
+        container.Visible = false;
+
+        ColoredRectangleRuntime fill = new();
+        fill.Width = 64;
+        fill.Height = 64;
+        fill.Color = new Color((byte)0, (byte)0, (byte)255, (byte)255);
+        container.Children.Add(fill);
+
+        GumService.Default.Root.Children.Add(container);
+        GumService.Default.Root.UpdateLayout();
+
+        DrawOnce();
+
+        Renderer.Self.HasBakedRenderTargetFor(container).ShouldBeFalse();
+
+        GumService.Default.Root.Children.Clear();
+    }
+
     // A Sprite referencing a container that never baked (not an IsRenderTarget) must draw nothing
     // rather than crash on a null lookup.
     [Fact]


### PR DESCRIPTION
## Problem

RaylibGum's `SpriteRuntime.RenderTargetTextureSource` (#3449/#3451) only baked a source container when it was *visible*. A Sprite referencing an **invisible** `IsRenderTarget` container got nothing — the source never baked, so `TryGetBakedRenderTargetFor` returned null and the Sprite drew nothing.

MonoGame already solved this for #1643: an invisible render-target container still bakes if a visible referencer points at it.

## Change

Ports the MonoGame #1643 algorithm to raylib's `Renderer.cs`:

- **`CollectReferencedRenderTargets`** walks all layers once per `Draw()` and records the cache owner (via the existing `ResolveRenderTargetCacheOwner`) of every render-target container referenced by a visible Sprite's `RenderTargetTextureSource`. Raylib bakes all layers in one pass per `Draw()`, so no per-host-frame caching is needed (unlike MonoGame's `_referencedRenderTargetsCollectedForHostFrame`).
- **`PreRender`** now flips `_frameHasRenderTarget` (and recurses) for an invisible-but-referenced container, so the bake pre-pass runs and its children's layout-time properties resolve.
- **`BakeRenderTargetsInSubtree`** bakes an invisible-but-referenced container instead of skipping it.
- The screen-composite path in `DrawGumRecursively` is **unchanged** — an invisible container still doesn't draw itself; only its cached bake exists for the referencing Sprite to sample.
- The perf fast-path is preserved: an invisible, *unreferenced* `IsRenderTarget` container still doesn't bake.

Raylib has no `IRenderTargetTextureReferencer` interface (its `Texture` member is XNA-typed), so the collection resolves the concrete `Gum.Renderables.Sprite` directly.

## Tests

Two new headless-frame pixel-readback tests in `RenderTargetTests` (drive a real raylib `Draw()` and read back the composited GPU pixels):

- `Draw_SpriteReferencingInvisibleRenderTarget_ShowsBakedTexture` — an invisible source bakes and its red shows through a referencing Sprite.
- `Draw_InvisibleUnreferencedRenderTarget_DoesNotBake` — guards the perf fast-path.

Full raylib suite: 397/397 green.

Part of #3432 (RaylibGum feature-parity umbrella). Follow-up to #3449.

Closes #3452

🤖 Generated with [Claude Code](https://claude.com/claude-code)
