### PR TITLE
Add raylib container post-process shader (RenderTargetEffect / SourceShaderFile) (#3465)

### DIFF
--- a/MonoGameGum/GueDeriving/ContainerRuntime.cs
+++ b/MonoGameGum/GueDeriving/ContainerRuntime.cs
@@ -70,12 +70,37 @@ public class ContainerRuntime : InteractiveGue
             }
         }
     }
-
+#elif RAYLIB
     /// <summary>
-    /// A file reference (e.g. a <c>.fx</c> path) to a post-process shader applied when this
-    /// container is drawn back to the screen as a render target. Mirrors how a Sprite references a
-    /// texture: setting this routes through the string property path, which resolves the reference
-    /// via <see cref="Gum.Wireframe.CustomSetPropertyOnRenderable.RenderTargetEffectResolver"/> and
+    /// An optional GLSL <see cref="global::Raylib_cs.Shader"/> applied when this container is drawn
+    /// back to the screen as a render target. Only has an effect when <see cref="IsRenderTarget"/>
+    /// is true. The shader is bound (<c>BeginShaderMode</c>) for the single texture draw that
+    /// composites the container's baked render target, so it acts as a post-process over the whole
+    /// container's contents. Load a shader with <c>Raylib.LoadShader</c> /
+    /// <c>Raylib.LoadShaderFromMemory</c> and assign it here (raylib loads GLSL directly, so no
+    /// shader-compiler dependency is needed).
+    /// </summary>
+    public global::Raylib_cs.Shader? RenderTargetEffect
+    {
+        get => (RenderableComponent as InvisibleRenderable)?.RenderTargetEffect
+            as global::Raylib_cs.Shader?;
+        set
+        {
+            if (RenderableComponent is InvisibleRenderable invisibleRenderable)
+            {
+                invisibleRenderable.RenderTargetEffect = value;
+            }
+        }
+    }
+#endif
+
+#if XNALIKE || RAYLIB
+    /// <summary>
+    /// A file reference (e.g. a <c>.fx</c> path on XNA-likes, a <c>.fs</c>/<c>.glsl</c> path on
+    /// raylib) to a post-process shader applied when this container is drawn back to the screen as a
+    /// render target. Mirrors how a Sprite references a texture: setting this routes through the
+    /// string property path, which resolves the reference via
+    /// <see cref="Gum.Wireframe.CustomSetPropertyOnRenderable.RenderTargetEffectResolver"/> and
     /// assigns the result to <see cref="RenderTargetEffect"/>. With no resolver registered the
     /// assignment is a graceful no-op (the container renders unshaded). Only has an effect when
     /// <see cref="IsRenderTarget"/> is true. Write-only: there is no backing field; the resolved

--- a/Runtimes/RaylibGum/Renderables/CustomSetPropertyOnRenderable.cs
+++ b/Runtimes/RaylibGum/Renderables/CustomSetPropertyOnRenderable.cs
@@ -123,9 +123,23 @@ public class CustomSetPropertyOnRenderable
 
     public static event Action<string>? PropertyAssignmentError;
 
+    /// <summary>
+    /// Optional resolver that turns a render-target shader file reference (e.g. a <c>.fs</c>/
+    /// <c>.glsl</c> path assigned via <c>ContainerRuntime.SourceShaderFile</c>) into a platform
+    /// effect object, which is stored in <see cref="RenderableBase.RenderTargetEffect"/>. Gum core
+    /// ships no shader loader; the consumer (or an opt-in library) registers this — typically doing
+    /// <c>Raylib.LoadShader</c> for a GLSL file. The returned object is boxed into the
+    /// backend-agnostic <see cref="RenderableBase.RenderTargetEffect"/> slot (on raylib, a
+    /// <see cref="Raylib_cs.Shader"/>). If null, assigning a shader file is a graceful no-op and the
+    /// container renders unshaded. Return null to signal a failed load (missing file / compile
+    /// error); resolution then honors <see cref="GraphicalUiElement.MissingFileBehavior"/>, mirroring
+    /// sprite source-file handling.
+    /// </summary>
+    public static Func<string, object?>? RenderTargetEffectResolver { get; set; }
+
 
     /// <summary>
-    /// Additional logic to perform before falling back to reflection. 
+    /// Additional logic to perform before falling back to reflection.
     /// This can be added by libraries adding additional runtime types
     /// </summary>
     public static Func<IRenderableIpso, GraphicalUiElement, string, object, bool>? AdditionalPropertyOnRenderable = null;
@@ -149,12 +163,116 @@ public class CustomSetPropertyOnRenderable
         {
             handled = TrySetPropertyOnNineSlice(renderableIpso, graphicalUiElement, propertyName, value, handled);
         }
+        else if (renderableIpso is InvisibleRenderable invisibleRenderable)
+        {
+            handled = TrySetPropertyOnContainer(invisibleRenderable, graphicalUiElement, propertyName, value);
+        }
 
         if (!handled)
         {
             GraphicalUiElement.SetPropertyThroughReflection(renderableIpso, graphicalUiElement, propertyName, value);
             //SetPropertyOnRenderable(mContainedObjectAsIpso, propertyName, value);
         }
+    }
+
+    private static bool TrySetPropertyOnContainer(InvisibleRenderable invisibleRenderable, GraphicalUiElement graphicalUiElement, string propertyName, object value)
+    {
+        switch (propertyName)
+        {
+            case "SourceShaderFile":
+                AssignSourceShaderFileOnContainer(invisibleRenderable, graphicalUiElement, value as string);
+                return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Resolves a render-target shader file reference (a <c>.fs</c>/<c>.glsl</c> path) into a raylib
+    /// <see cref="Raylib_cs.Shader"/> via <see cref="RenderTargetEffectResolver"/> and stores it in
+    /// the container's <see cref="RenderableBase.RenderTargetEffect"/> slot. A failed resolve honors
+    /// <see cref="GraphicalUiElement.MissingFileBehavior"/>. With no resolver registered this is a
+    /// graceful no-op (the container renders unshaded), matching how a missing texture degrades.
+    /// Called internally by the string property path. Mirrors the XNA-side method of the same name.
+    /// </summary>
+    public static void AssignSourceShaderFileOnContainer(IRenderTargetRenderable effectOwner, GraphicalUiElement graphicalUiElement, string? value)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            effectOwner.RenderTargetEffect = null;
+            return;
+        }
+
+        // No resolver registered: render unshaded rather than crash. A separate opt-in library or
+        // the consumer registers the resolver (typically doing Raylib.LoadShader).
+        if (RenderTargetEffectResolver == null)
+        {
+            return;
+        }
+
+        var loaderManager = global::RenderingLibrary.Content.LoaderManager.Self;
+
+        if (ToolsUtilities.FileManager.IsRelative(value) && ToolsUtilities.FileManager.IsUrl(value) == false)
+        {
+            value = ToolsUtilities.FileManager.RelativeDirectory + value;
+            value = ToolsUtilities.FileManager.RemoveDotDotSlash(value);
+        }
+
+        // LoaderManager caches disposables by normalized path so a shader shared by multiple
+        // containers loads once. A raylib Shader is a struct (not IDisposable), so it falls through
+        // the disposable cache below and simply re-resolves — acceptable for a first implementation.
+        if (loaderManager.CacheTextures)
+        {
+            var cachedEffect = loaderManager.GetDisposable(value);
+            if (cachedEffect != null)
+            {
+                effectOwner.RenderTargetEffect = cachedEffect;
+                return;
+            }
+        }
+
+        object? resolvedEffect = null;
+        Exception? resolveException = null;
+        try
+        {
+            resolvedEffect = RenderTargetEffectResolver(value);
+        }
+        catch (Exception ex)
+        {
+            resolveException = ex;
+        }
+
+        if (resolvedEffect == null)
+        {
+            // Resolver registered but couldn't produce an effect (missing file or load error).
+            // Mirror Sprite source-file handling: honor MissingFileBehavior, else report the error.
+            string message = $"Error setting SourceShaderFile on Container";
+            if (graphicalUiElement.Tag != null)
+            {
+                message += $" in {graphicalUiElement.Tag}";
+            }
+            message += $"\n{value}";
+            message += "\nCheck if the file exists. If necessary, set FileManager.RelativeDirectory";
+            message += "\nThe current relative directory is:\n" + ToolsUtilities.FileManager.RelativeDirectory;
+            if (GraphicalUiElement.MissingFileBehavior == MissingFileBehavior.ThrowException)
+            {
+                if (ObjectFinder.Self.GumProjectSave == null)
+                {
+                    message += "\nNo Gum project has been loaded";
+                }
+                throw new System.IO.FileNotFoundException(message, resolveException);
+            }
+            effectOwner.RenderTargetEffect = null;
+            PropertyAssignmentError?.Invoke(resolveException != null ? message + "\n" + resolveException.ToString() : message);
+            return;
+        }
+
+        if (loaderManager.CacheTextures && resolvedEffect is IDisposable disposableEffect)
+        {
+            loaderManager.AddDisposable(value, disposableEffect);
+        }
+
+        effectOwner.RenderTargetEffect = resolvedEffect;
     }
 
 

--- a/Runtimes/RaylibGum/RenderingLibrary/Renderer.cs
+++ b/Runtimes/RaylibGum/RenderingLibrary/Renderer.cs
@@ -548,6 +548,18 @@ public class Renderer : IRenderer
         {
             counter.BeginBlendMode(BlendMode.AlphaPremultiply);
         }
+
+        // Optional post-process shader (ContainerRuntime.RenderTargetEffect / SourceShaderFile,
+        // #3465): bind it around the single composite blit so it post-processes the whole baked
+        // container, mirroring MonoGame's DrawRenderTargetToScreen. The effect slot lives on the
+        // shared IRenderTargetRenderable — here the InvisibleRenderable resolved as the cache owner.
+        Raylib_cs.Shader? renderTargetShader =
+            (cacheOwner as IRenderTargetRenderable)?.RenderTargetEffect as Raylib_cs.Shader?;
+        if (renderTargetShader != null)
+        {
+            counter.BeginShaderMode(renderTargetShader.Value);
+        }
+
         // Negative source height flips the v range: an RT is stored bottom-up in GL coordinates, so
         // reading it with height -h yields the upright content (same idiom as ShadowBlurRenderer).
         Raylib.DrawTexturePro(
@@ -557,6 +569,11 @@ public class Renderer : IRenderer
             System.Numerics.Vector2.Zero,
             0,
             tint);
+
+        if (renderTargetShader != null)
+        {
+            counter.EndShaderMode();
+        }
         counter.EndBlendMode();
         return true;
     }

--- a/Samples/raylib/Program.cs
+++ b/Samples/raylib/Program.cs
@@ -61,6 +61,12 @@ public class BasicShapes
 
         CustomSetPropertyOnRenderable.InMemoryFontCreator = new KernSmithRaylibFontCreator();
 
+        // Issue #3465: Gum core ships no shader loader, so the app registers a resolver that turns a
+        // ContainerRuntime.SourceShaderFile (.fs path) into a Raylib_cs.Shader. raylib loads GLSL
+        // directly, so this is a one-liner — no runtime compiler needed (unlike the MonoGame side's
+        // ShadowDusk). With no resolver registered, SourceShaderFile is a graceful no-op.
+        CustomSetPropertyOnRenderable.RenderTargetEffectResolver = path => LoadShader(null, path);
+
         // Enable gamepad + keyboard navigation for Forms controls (see
         // https://docs.flatredball.com/gum/code/events-and-interactivity/gamepad-support).
         // GumUI.Update reads the connected controller into these gamepads each frame; the
@@ -141,6 +147,7 @@ public class BasicShapes
         AddNavButton("NineSlice", () => new NineSliceScreen());
         AddNavButton("Text", () => new TextScreen());
         AddNavButton("Render Target", () => new RenderTargetScreen());
+        AddNavButton("RT Shader", () => new RenderTargetShaderScreen());
 
         AddFitModeRadio("Zoom", isChecked: true, () =>
         {

--- a/Samples/raylib/Program.cs
+++ b/Samples/raylib/Program.cs
@@ -17,8 +17,6 @@ namespace Examples.Shapes;
 
 public class BasicShapes
 {
-    private const float NavStripHeight = 40;
-
     static GumService GumUI => GumService.Default;
 
     static StackPanel? navStrip;
@@ -135,6 +133,14 @@ public class BasicShapes
         navStrip.Spacing = 4;
         navStrip.Visual.X = 4;
         navStrip.Visual.Y = 4;
+        // Fill the window width and wrap the button row instead of letting buttons bleed off the
+        // right edge; height grows to fit however many rows the wrap produces. Mirrors
+        // MonoGameGumInCode/Game1.BuildNavStrip.
+        navStrip.WidthUnits = Gum.DataTypes.DimensionUnitType.RelativeToParent;
+        navStrip.Width = 0;
+        navStrip.HeightUnits = Gum.DataTypes.DimensionUnitType.RelativeToChildren;
+        navStrip.Height = 0;
+        navStrip.Visual.WrapsChildren = true;
         navStrip.AddToRoot();
 
         AddNavButton("Raw visuals", () => new RawVisualsScreen());
@@ -227,11 +233,13 @@ public class BasicShapes
 
         activeScreen = factory();
         // Offset the screen so it doesn't sit underneath the nav strip — same trick as
-        // MonoGameGumShapesGallery/Game1.ShowScreen.
+        // MonoGameGumShapesGallery/Game1.ShowScreen. Use the nav strip's actual laid-out height so a
+        // wrapped (multi-row) button strip still clears the screen content below it.
+        float navStripHeight = navStrip!.Visual.GetAbsoluteHeight();
         activeScreen.Visual.YOrigin = VerticalAlignment.Top;
         activeScreen.Visual.YUnits = GeneralUnitType.PixelsFromSmall;
-        activeScreen.Visual.Y = NavStripHeight;
-        activeScreen.Visual.Height = -NavStripHeight;
+        activeScreen.Visual.Y = navStripHeight;
+        activeScreen.Visual.Height = -navStripHeight;
         activeScreen.AddToRoot();
 
         // Defer initial gamepad focus to just after the next GumUI.Update (see field comment).

--- a/Samples/raylib/Screens/RenderTargetShaderScreen.cs
+++ b/Samples/raylib/Screens/RenderTargetShaderScreen.cs
@@ -1,0 +1,128 @@
+using Gum.DataTypes;
+using Gum.Forms.Controls;
+using Gum.GueDeriving;
+using Gum.Managers;
+using Gum.Wireframe;
+using Raylib_cs;
+using RenderingLibrary.Graphics;
+using static Raylib_cs.Raylib;
+
+namespace Examples.Shapes;
+
+// Raylib mirror of Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/RenderTargetEffectScreen.cs
+// (issue #3465). Demonstrates a post-process shader applied to a render-target container: the shader
+// is bound when the container's baked texture composites back to the screen, so it recolors the whole
+// container's contents. Two wiring styles, matching the MonoGame screen cell-for-cell:
+//   - Middle cell: load a Raylib_cs.Shader in code and assign it to ContainerRuntime.RenderTargetEffect.
+//   - Right cell:  reference the .fs by path via ContainerRuntime.SourceShaderFile; Gum resolves it
+//                  through the app-registered RenderTargetEffectResolver (wired in Program.Main).
+// Both use the same resources/Grayscale.fs. Left is the unmodified bear for comparison. Unlike the
+// MonoGame side (which compiles HLSL at runtime via ShadowDusk), raylib loads GLSL directly, so no
+// shader-compiler dependency is needed.
+internal class RenderTargetShaderScreen : FrameworkElement
+{
+    // Relative path (resolved against FileManager.RelativeDirectory) to the grayscale GLSL shader.
+    private const string ShaderFileName = "resources/Grayscale.fs";
+
+    public RenderTargetShaderScreen() : base(new ContainerRuntime())
+    {
+        Dock(Gum.Wireframe.Dock.Fill);
+
+        ContainerRuntime root = new();
+        root.ChildrenLayout = ChildrenLayout.TopToBottomStack;
+        root.WidthUnits = DimensionUnitType.RelativeToChildren;
+        root.HeightUnits = DimensionUnitType.RelativeToChildren;
+        root.Width = 0;
+        root.Height = 0;
+        root.StackSpacing = 16;
+        root.X = 12;
+        root.Y = 12;
+        this.AddChild(root);
+
+        // Load the shader in code for the middle cell. LoadShader returns a default (id 0) shader if
+        // the file is missing; the grayscale still degrades to a pass-through rather than crashing.
+        Shader inCodeShader = LoadShader(null, ShaderFileName);
+
+        TextRuntime statusLabel = new();
+        statusLabel.Text = "Grayscale GLSL post-process. Middle and right bears render grayscale; left is the original.";
+        statusLabel.Red = 220;
+        statusLabel.Green = 220;
+        statusLabel.Blue = 220;
+        statusLabel.WidthUnits = DimensionUnitType.RelativeToChildren;
+        statusLabel.HeightUnits = DimensionUnitType.RelativeToChildren;
+        statusLabel.Width = 0;
+        statusLabel.Height = 0;
+        root.AddChild(statusLabel);
+
+        ContainerRuntime row = new();
+        row.ChildrenLayout = ChildrenLayout.LeftToRightStack;
+        row.StackSpacing = 48;
+        row.WidthUnits = DimensionUnitType.RelativeToChildren;
+        row.HeightUnits = DimensionUnitType.RelativeToChildren;
+        row.Width = 0;
+        row.Height = 0;
+        root.AddChild(row);
+
+        // Left: the unmodified bear (no render target, no shader).
+        row.AddChild(BuildCell("Original", shader: null, sourceShaderFile: null));
+
+        // Middle: the grayscale shader loaded in code and assigned directly.
+        row.AddChild(BuildCell("RenderTargetEffect (loaded in code)", shader: inCodeShader, sourceShaderFile: null));
+
+        // Right: the same shader referenced by file path; Gum's registered resolver loads it.
+        row.AddChild(BuildCell("SourceShaderFile (.fs reference)", shader: null, sourceShaderFile: ShaderFileName));
+    }
+
+    private static ContainerRuntime BuildCell(string caption, Shader? shader, string? sourceShaderFile)
+    {
+        ContainerRuntime cell = new();
+        cell.ChildrenLayout = ChildrenLayout.TopToBottomStack;
+        cell.StackSpacing = 6;
+        cell.WidthUnits = DimensionUnitType.RelativeToChildren;
+        cell.HeightUnits = DimensionUnitType.RelativeToChildren;
+        cell.Width = 0;
+        cell.Height = 0;
+
+        AddLabel(cell, caption);
+
+        ContainerRuntime holder = new();
+        holder.Width = 128;
+        holder.Height = 128;
+
+        SpriteRuntime bear = new();
+        bear.SourceFileName = "resources\\BearTexture.png";
+        bear.WidthUnits = DimensionUnitType.Absolute;
+        bear.HeightUnits = DimensionUnitType.Absolute;
+        bear.Width = 128;
+        bear.Height = 128;
+        holder.AddChild(bear);
+
+        if (shader != null)
+        {
+            holder.IsRenderTarget = true;
+            holder.RenderTargetEffect = shader;
+        }
+        else if (!string.IsNullOrEmpty(sourceShaderFile))
+        {
+            holder.IsRenderTarget = true;
+            holder.SourceShaderFile = sourceShaderFile;
+        }
+
+        cell.AddChild(holder);
+        return cell;
+    }
+
+    private static void AddLabel(ContainerRuntime container, string text)
+    {
+        TextRuntime label = new();
+        label.Text = text;
+        label.Red = 200;
+        label.Green = 200;
+        label.Blue = 200;
+        label.WidthUnits = DimensionUnitType.RelativeToChildren;
+        label.HeightUnits = DimensionUnitType.RelativeToChildren;
+        label.Width = 0;
+        label.Height = 0;
+        container.AddChild(label);
+    }
+}

--- a/Samples/raylib/resources/Grayscale.fs
+++ b/Samples/raylib/resources/Grayscale.fs
@@ -1,0 +1,21 @@
+#version 330
+
+// Grayscale post-process for a render-target container (issue #3465). Bound by the raylib renderer
+// for the single composite blit of a container whose SourceShaderFile points here, so it recolors
+// the whole baked container. Uses raylib's default-shader interface (texture0 / colDiffuse /
+// fragColor / fragTexCoord).
+
+in vec2 fragTexCoord;
+in vec4 fragColor;
+
+out vec4 finalColor;
+
+uniform sampler2D texture0;
+uniform vec4 colDiffuse;
+
+void main()
+{
+    vec4 texel = texture(texture0, fragTexCoord);
+    float gray = dot(texel.rgb, vec3(0.299, 0.587, 0.114));
+    finalColor = vec4(gray, gray, gray, texel.a) * fragColor * colDiffuse;
+}

--- a/Tests/RaylibGum.Tests/Rendering/RenderTargetShaderTests.cs
+++ b/Tests/RaylibGum.Tests/Rendering/RenderTargetShaderTests.cs
@@ -1,0 +1,183 @@
+using System;
+using System.IO;
+using Gum.GueDeriving;
+using Gum.Wireframe;
+using Raylib_cs;
+using RaylibGum.Renderables;
+using RenderingLibrary.Graphics;
+using Shouldly;
+using static Raylib_cs.Raylib;
+
+namespace RaylibGum.Tests.Rendering;
+
+/// <summary>
+/// Pixel-readback tests for the raylib render-target post-process shader path (issue #3465). A
+/// render-target container carrying a <see cref="ContainerRuntime.RenderTargetEffect"/> (or a
+/// <see cref="ContainerRuntime.SourceShaderFile"/> that resolves into one) has that GLSL shader
+/// bound for the single composite blit, so it post-processes the whole container. Each test nests
+/// the shaded container inside a readable outer render target and samples the outer's baked texture
+/// — the same deterministic-surface trick the sibling <see cref="RenderTargetTests"/> use — so the
+/// shader's effect on the composite is observable without screen readback.
+/// </summary>
+public class RenderTargetShaderTests : BaseTestClass
+{
+    // A grayscale fragment shader in raylib's default-shader interface (texture0 / colDiffuse /
+    // fragColor / fragTexCoord). Collapses the sampled RGB to luma so a solid-red composite reads
+    // back as R ≈ G ≈ B, which a straight blit never would.
+    private const string GrayscaleFragmentShader = @"#version 330
+in vec2 fragTexCoord;
+in vec4 fragColor;
+out vec4 finalColor;
+uniform sampler2D texture0;
+uniform vec4 colDiffuse;
+void main()
+{
+    vec4 texel = texture(texture0, fragTexCoord);
+    float gray = dot(texel.rgb, vec3(0.299, 0.587, 0.114));
+    finalColor = vec4(gray, gray, gray, texel.a) * fragColor * colDiffuse;
+}
+";
+
+    private static void DrawOnce()
+    {
+        BeginDrawing();
+        GumService.Default.Draw();
+        EndDrawing();
+    }
+
+    // Reads a pixel in top-left-origin draw space. A render texture is stored bottom-up in GL, so
+    // the row index is flipped (same idiom as RenderTargetTests).
+    private static Color ReadRenderTargetCenter(RenderTexture2D renderTexture)
+    {
+        Image image = LoadImageFromTexture(renderTexture.Texture);
+        try
+        {
+            int x = renderTexture.Texture.Width / 2;
+            int y = renderTexture.Texture.Height / 2;
+            return GetImageColor(image, x, renderTexture.Texture.Height - 1 - y);
+        }
+        finally
+        {
+            UnloadImage(image);
+        }
+    }
+
+    // Builds a solid-red inner render target nested inside a readable outer render target and
+    // returns both. Sampling the outer's center reads whatever the inner composited into it.
+    private static (ContainerRuntime outer, ContainerRuntime inner) BuildNestedRedRenderTarget()
+    {
+        ContainerRuntime outer = new();
+        outer.X = 0;
+        outer.Y = 0;
+        outer.Width = 100;
+        outer.Height = 100;
+        outer.IsRenderTarget = true;
+
+        ContainerRuntime inner = new();
+        inner.Width = 100;
+        inner.Height = 100;
+        inner.IsRenderTarget = true;
+
+#pragma warning disable CS0618 // ColoredRectangleRuntime is obsolete; simplest solid fill without a shape dependency.
+        ColoredRectangleRuntime red = new();
+#pragma warning restore CS0618
+        red.Width = 100;
+        red.Height = 100;
+        red.Color = new Color((byte)255, (byte)0, (byte)0, (byte)255);
+        inner.Children.Add(red);
+        outer.Children.Add(inner);
+
+        return (outer, inner);
+    }
+
+    [Fact]
+    public void Draw_RenderTargetEffect_GraysTheCompositedPixels()
+    {
+        (ContainerRuntime outer, ContainerRuntime inner) = BuildNestedRedRenderTarget();
+
+        GumService.Default.Root.Children.Add(outer);
+        GumService.Default.Root.UpdateLayout();
+
+        Shader grayscale = LoadShaderFromMemory(null, GrayscaleFragmentShader);
+        try
+        {
+            // Control: no shader, the composited inner reads back clearly red.
+            DrawOnce();
+            Color withoutShader = ReadRenderTargetCenter(Renderer.Self.TryGetBakedRenderTargetFor(outer)!.Value);
+            withoutShader.R.ShouldBeGreaterThan((byte)200);
+            ((int)withoutShader.R - withoutShader.G).ShouldBeGreaterThan(80);
+
+            // With the grayscale shader bound for the composite blit, the channels collapse.
+            inner.RenderTargetEffect = grayscale;
+            DrawOnce();
+            Color withShader = ReadRenderTargetCenter(Renderer.Self.TryGetBakedRenderTargetFor(outer)!.Value);
+            Math.Abs(withShader.R - withShader.G).ShouldBeLessThan(25);
+            Math.Abs(withShader.R - withShader.B).ShouldBeLessThan(25);
+        }
+        finally
+        {
+            UnloadShader(grayscale);
+            GumService.Default.Root.Children.Clear();
+        }
+    }
+
+    [Fact]
+    public void Draw_SourceShaderFile_GraysTheCompositedPixels_WhenResolverRegistered()
+    {
+        string shaderPath = WriteTempShader(GrayscaleFragmentShader);
+        (ContainerRuntime outer, ContainerRuntime inner) = BuildNestedRedRenderTarget();
+
+        try
+        {
+            // Stand-in for a consumer's resolver: raylib loads GLSL directly, no compiler needed.
+            CustomSetPropertyOnRenderable.RenderTargetEffectResolver = path => LoadShader(null, path);
+
+            GumService.Default.Root.Children.Add(outer);
+            GumService.Default.Root.UpdateLayout();
+
+            // The .fs reference resolves through the string property path into RenderTargetEffect.
+            inner.SourceShaderFile = shaderPath;
+            DrawOnce();
+
+            Color center = ReadRenderTargetCenter(Renderer.Self.TryGetBakedRenderTargetFor(outer)!.Value);
+            Math.Abs(center.R - center.G).ShouldBeLessThan(25);
+            Math.Abs(center.R - center.B).ShouldBeLessThan(25);
+        }
+        finally
+        {
+            CustomSetPropertyOnRenderable.RenderTargetEffectResolver = null;
+            GumService.Default.Root.Children.Clear();
+            File.Delete(shaderPath);
+        }
+    }
+
+    [Fact]
+    public void Draw_SourceShaderFile_IsNoOp_WhenNoResolverRegistered()
+    {
+        // No resolver registered (clear any leakage from a prior test).
+        CustomSetPropertyOnRenderable.RenderTargetEffectResolver = null;
+
+        (ContainerRuntime outer, ContainerRuntime inner) = BuildNestedRedRenderTarget();
+
+        GumService.Default.Root.Children.Add(outer);
+        GumService.Default.Root.UpdateLayout();
+
+        // With no resolver the assignment is a graceful no-op (no crash); the container renders
+        // unshaded, so the composited pixel stays red.
+        inner.SourceShaderFile = "resources/DoesNotMatter.fs";
+        DrawOnce();
+
+        Color center = ReadRenderTargetCenter(Renderer.Self.TryGetBakedRenderTargetFor(outer)!.Value);
+        center.R.ShouldBeGreaterThan((byte)200);
+        ((int)center.R - center.G).ShouldBeGreaterThan(80);
+
+        GumService.Default.Root.Children.Clear();
+    }
+
+    private static string WriteTempShader(string source)
+    {
+        string path = Path.Combine(Path.GetTempPath(), "GumRaylibShaderTest_" + Guid.NewGuid().ToString("N") + ".fs");
+        File.WriteAllText(path, source);
+        return path;
+    }
+}


### PR DESCRIPTION
## Summary

Adds raylib support for a **post-process shader on a render-target container** (issue #3465). raylib containers with `IsRenderTarget=true` already baked and composited correctly (#3434/#3436/#3448), but there was no way to shade that composite — `ContainerRuntime.RenderTargetEffect`/`SourceShaderFile` existed only under `#if XNALIKE` (typed to MonoGame's `Effect`).

Unlike MonoGame (which needs ShadowDusk to compile HLSL at runtime), raylib loads GLSL directly via `Raylib.LoadShader`, so no shader-compiler dependency is needed.

## Changes

- **`ContainerRuntime.cs`** — add an `#elif RAYLIB` branch exposing `RenderTargetEffect` typed as `Raylib_cs.Shader?`, and widen `SourceShaderFile`'s gate to `#if XNALIKE || RAYLIB`. The effect slot itself (`RenderableBase.RenderTargetEffect`, `object?`) and `IRenderTargetRenderable` are already shared source.
- **raylib `Renderer.TryCompositeRenderTarget`** — read the container's `RenderTargetEffect as Shader?` and wrap the composite `DrawTexturePro` in `BeginShaderMode`/`EndShaderMode`, mirroring MonoGame's `DrawRenderTargetToScreen` and the existing `ShadowBlurRenderer` shader-binding pattern.
- **raylib `CustomSetPropertyOnRenderable`** — port the `RenderTargetEffectResolver` + `AssignSourceShaderFileOnContainer` string-path plumbing from the XNA home copy. The raylib copy had *no* container/`InvisibleRenderable` property dispatch at all, so this adds the `SourceShaderFile` case + resolver (the issue assumed this plumbing was already shared; it's shared only in the home copy, and raylib compiles its own duplicate copy pending convergence).
- **Sample** — register a resolver in `Samples/raylib/Program.cs` (`path => LoadShader(null, path)`) and add a `RenderTargetShaderScreen` gallery cell with a grayscale GLSL shader (`resources/Grayscale.fs`), mirroring MonoGame's `RenderTargetEffectScreen` cell-for-cell.
- **Tests** — `RenderTargetShaderTests` pins the `RenderTargetEffect` and `SourceShaderFile` grayscale paths plus the no-resolver no-op, via the existing headless raylib pixel-readback pattern.

## Deviation from the issue

Issue point 3 mentioned registering a raylib resolver "tool + `RaylibGumInCode` sample." The **tool side is intentionally unchanged**: the Gum tool renders via KNI (XNALIKE), so its `RenderTargetEffectResolver` compiles `.fx` to a KNI `Effect` — a raylib `Shader` can't be applied in the tool's preview. The raylib in-code sample is `Samples/raylib` (not a separate `RaylibGumInCode`).

## Testing

- `RaylibGum.Tests`: 398/398 pass (3 new shader tests + no regressions). Red-first confirmed: the two grayscale tests failed for the right reason (composite stayed red) before the renderer binding was added.
- `MonoGameGum.Tests` and `SkiaGum` build clean (shared `ContainerRuntime` change is a no-op for XNALIKE and excluded entirely on Skia/Sokol).
- Manual: raylib gallery → **RT Shader** screen; middle (`RenderTargetEffect` in code) and right (`SourceShaderFile` .fs reference) bears render grayscale, left is the original.

Part of #3432. Closes #3465.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
