### PR TITLE
Fix raylib blurred dropshadow clobbering active render target inside a bake

### DIFF
--- a/.claude/skills/gum-samples/SKILL.md
+++ b/.claude/skills/gum-samples/SKILL.md
@@ -19,6 +19,8 @@ The "**big three**" refers to the three backends below (Silk.NET/Skia, raylib, M
 
 Each has a `Screens/` folder with one `*Screen.cs` per feature (`SpriteScreen`, `NineSliceScreen`, …). **MonoGameGumInCode is the reference** — mirror its screen section-for-section in the other two so the same screen can be opened side by side and any per-backend rendering difference stands out as a backend bug. The existing screen headers say exactly this ("Raylib mirror of …", "Mirror of MonoGameGumInCode.Screens…").
 
+**Mirror even when the underlying bug is backend-specific.** A fix that only reproduces on one backend (e.g. a raylib-only render-target/framebuffer quirk) is still a reason to add the demo *cell* to every mirrored screen, not just the one you're fixing — the point of mirroring is a side-by-side visual comparison, and skipping the other backends breaks that even though their code has nothing to fix. This applies to adding a new cell to an existing gallery screen (e.g. one more case in `RenderTargetScreen`), not just to creating a brand-new screen file. (Missed on issue #3464: only the raylib cell was added at first, because the fix itself was raylib-only — caught in review.)
+
 ### Cross-backend gotchas when mirroring
 
 - **Texture paths differ.** MonoGame uses MGCB `Content/` names (`"Frame.png"`); raylib loads from disk (`"resources\\Frame.png"`, copied via the `resources\**\*.*` glob in `GumTest.csproj`); SilkNetGum loads from `Content/GumProject/`. Drop any new texture into each sample's content dir.

--- a/Runtimes/RaylibGum/Renderables/LineArc.cs
+++ b/Runtimes/RaylibGum/Renderables/LineArc.cs
@@ -621,6 +621,7 @@ public class LineArc : InvisibleRenderable
             blur,
             effectiveDropshadowColor,
             global::RenderingLibrary.Graphics.Renderer.Self.ActiveCamera2D,
+            global::RenderingLibrary.Graphics.Renderer.Self.ActiveRenderTexture,
             (px, py) =>
             {
                 DrawRing(

--- a/Runtimes/RaylibGum/Renderables/LineCircle.cs
+++ b/Runtimes/RaylibGum/Renderables/LineCircle.cs
@@ -369,6 +369,7 @@ public class LineCircle : InvisibleRenderable
                     blur,
                     effectiveDropshadowColor,
                     global::RenderingLibrary.Graphics.Renderer.Self.ActiveCamera2D,
+                    global::RenderingLibrary.Graphics.Renderer.Self.ActiveRenderTexture,
                     (px, py) =>
                     {
                         DrawCircleV(new Vector2(px + r, py + r), r, silhouetteColor);

--- a/Runtimes/RaylibGum/Renderables/LineRectangle.cs
+++ b/Runtimes/RaylibGum/Renderables/LineRectangle.cs
@@ -340,6 +340,7 @@ public class LineRectangle : InvisibleRenderable
                     blur,
                     effectiveDropshadowColor,
                     global::RenderingLibrary.Graphics.Renderer.Self.ActiveCamera2D,
+                    global::RenderingLibrary.Graphics.Renderer.Self.ActiveRenderTexture,
                     (px, py) =>
                     {
                         if (useRounded)

--- a/Runtimes/RaylibGum/Renderables/ShadowBlurRenderer.cs
+++ b/Runtimes/RaylibGum/Renderables/ShadowBlurRenderer.cs
@@ -96,6 +96,13 @@ void main() {{
     /// <c>EndTextureMode</c> resets the modelview to identity, so the offscreen blur passes below would
     /// otherwise clobber this camera for the shadow's own composite and every later draw in the frame;
     /// it is re-established after the passes (issue #3460).</param>
+    /// <param name="activeRenderTexture">The render texture a render-target container's bake is
+    /// currently drawing into (see <see cref="Renderer.ActiveRenderTexture"/>), or <c>null</c> when
+    /// drawing directly to the screen. raylib's <c>EndTextureMode</c> unconditionally unbinds the
+    /// active render texture and does not restore an enclosing one, so the offscreen blur passes
+    /// below would otherwise leave the shadow's own composite — and every later draw in the bake —
+    /// landing on the screen instead of back in the container's texture; it is re-established after
+    /// the passes, alongside the camera (issue #3464).</param>
     /// <param name="drawSilhouetteAt">
     /// Callback invoked inside the offscreen render pass. Receives the RT-local top-left
     /// coordinates the caller should paint a SOLID-WHITE silhouette of the shape at. The
@@ -111,6 +118,7 @@ void main() {{
         float sigma,
         Color tint,
         Camera2D activeCamera,
+        RenderTexture2D? activeRenderTexture,
         Action<float, float> drawSilhouetteAt)
     {
         if (sigma <= 0f || shapeW <= 0f || shapeH <= 0f || tint.A == 0)
@@ -183,6 +191,17 @@ void main() {{
         counter.EndShaderMode();
         counter.EndBlendMode();
         counter.EndTextureMode();
+
+        // Re-establish the enclosing render target clobbered by the offscreen passes. raylib's
+        // EndTextureMode unconditionally unbinds the active render texture and does NOT restore a
+        // previously-active one, so without this the shadow composite below — and every later draw
+        // in the bake — would render to the screen instead of back into the container's texture
+        // (issue #3464). Must happen before re-establishing the camera below, mirroring the order
+        // BakeRenderTarget itself uses (BeginTextureMode then BeginMode2D).
+        if (activeRenderTexture.HasValue)
+        {
+            counter.BeginTextureMode(activeRenderTexture.Value);
+        }
 
         // Re-establish the active camera clobbered by the offscreen passes. raylib's EndTextureMode
         // resets the modelview to identity and does NOT restore the enclosing BeginMode2D transform,

--- a/Runtimes/RaylibGum/RenderingLibrary/Renderer.cs
+++ b/Runtimes/RaylibGum/RenderingLibrary/Renderer.cs
@@ -105,6 +105,17 @@ public class Renderer : IRenderer
     public Camera2D ActiveCamera2D { get; private set; }
 
     /// <summary>
+    /// The render texture a render-target container's bake is currently drawing into via
+    /// <c>BeginTextureMode</c>, or <c>null</c> during the main walk (which draws to the screen).
+    /// Exposed so a mid-walk offscreen consumer (e.g. <see cref="ShadowBlurRenderer"/>) can
+    /// re-establish it after its own <c>BeginTextureMode</c>/<c>EndTextureMode</c> passes, which
+    /// raylib's <c>EndTextureMode</c> unconditionally unbinds and does not restore an enclosing
+    /// render texture (issue #3464 — the render-target analogue of #3460's camera clobber).
+    /// Primarily for internal renderer/renderable use.
+    /// </summary>
+    public RenderTexture2D? ActiveRenderTexture { get; private set; }
+
+    /// <summary>
     /// Per-renderable shadow-blur service. Owns the Gaussian shader and the per-renderable
     /// render textures (issue #2865). Renderables call <c>Renderer.Self.ShadowBlur.Draw(this, ...)</c>
     /// from their <c>Render</c> method; the renderer sweeps unused entries at the top of every
@@ -484,6 +495,13 @@ public class Renderer : IRenderer
         Camera2D savedActiveCamera = ActiveCamera2D;
         ActiveCamera2D = bakeCamera;
 
+        // Record this bake's render texture as the active one so a blurred dropshadow drawn inside
+        // this bake re-establishes it (not the screen) after its own offscreen BeginTextureMode/
+        // EndTextureMode passes, which unconditionally unbind whatever render texture was active
+        // (issue #3464). Restored to the enclosing bake's texture (or null) below.
+        RenderTexture2D? savedActiveRenderTexture = ActiveRenderTexture;
+        ActiveRenderTexture = renderTexture;
+
         counter.BeginTextureMode(renderTexture.Value);
         Raylib.ClearBackground(new Color((byte)0, (byte)0, (byte)0, (byte)0));
         counter.BeginMode2D(bakeCamera);
@@ -512,6 +530,7 @@ public class Renderer : IRenderer
         _bakeTop = savedBakeTop;
         _scissorStack = savedScissorStack;
         ActiveCamera2D = savedActiveCamera;
+        ActiveRenderTexture = savedActiveRenderTexture;
     }
 
     // Composites a render-target container's baked texture at the container's clamped rectangle,

--- a/Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/RenderTargetScreen.cs
+++ b/Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/RenderTargetScreen.cs
@@ -40,6 +40,7 @@ internal class RenderTargetScreen : FrameworkElement
         root.AddChild(BuildCell("Overflow clipped", BuildOverflow()));
         root.AddChild(BuildCell("ClipsChildren inside RT", BuildClipsChildrenInside()));
         root.AddChild(BuildCell("Sprite shows RT texture", BuildSpriteFromRenderTarget()));
+        root.AddChild(BuildCell("Blurred shadow in RT", BuildBlurredShadowInRenderTarget()));
     }
 
     private static ContainerRuntime BuildCell(string caption, GraphicalUiElement body)
@@ -324,5 +325,39 @@ internal class RenderTargetScreen : FrameworkElement
         row.AddChild(BuildSwatch("source", source));
         row.AddChild(BuildSwatch("sprite (scaled + rotated)", sprite));
         return row;
+    }
+
+    // Issue #3464 (raylib-only bug, mirrored here for gallery parity/comparison — MonoGame's
+    // dropshadow is an Apos.Shapes shader pass, not an offscreen render-to-texture blur, so it never
+    // had the nested-render-target clobber raylib had). A blurred dropshadow inside a render-target
+    // container, plus a sibling drawn after it, should look identical to the raylib cell: a soft
+    // shadow offset down-right of the blue rectangle, and a red sibling rectangle below-right of it.
+    private static GraphicalUiElement BuildBlurredShadowInRenderTarget()
+    {
+        var holder = BuildFrame(150, 110);
+
+        var group = new ContainerRuntime();
+        group.Width = 150;
+        group.Height = 110;
+        group.IsRenderTarget = true;
+
+        var shadowed = new RectangleRuntime();
+        shadowed.X = 15;
+        shadowed.Y = 10;
+        shadowed.Width = 50;
+        shadowed.Height = 40;
+        shadowed.IsFilled = true;
+        shadowed.FillColor = new Color(60, 120, 220, 255);
+        shadowed.HasDropshadow = true;
+        shadowed.DropshadowColor = new Color(0, 0, 0, 200);
+        shadowed.DropshadowOffsetX = 6;
+        shadowed.DropshadowOffsetY = 6;
+        shadowed.DropshadowBlur = 8;
+        group.AddChild(shadowed);
+
+        group.AddChild(Rect(80, 55, 55, 45, new Color(220, 60, 60, 255)));
+
+        holder.AddChild(group);
+        return holder;
     }
 }

--- a/Samples/raylib/Screens/RenderTargetScreen.cs
+++ b/Samples/raylib/Screens/RenderTargetScreen.cs
@@ -43,6 +43,7 @@ internal class RenderTargetScreen : FrameworkElement
         root.Children.Add(BuildCell("Overflow clipped", BuildOverflow()));
         root.Children.Add(BuildCell("ClipsChildren inside RT", BuildClipsChildrenInside()));
         root.Children.Add(BuildCell("Sprite shows RT texture", BuildSpriteFromRenderTarget()));
+        root.Children.Add(BuildCell("Blurred shadow in RT", BuildBlurredShadowInRenderTarget()));
     }
 
     static ContainerRuntime BuildCell(string caption, GraphicalUiElement body)
@@ -334,5 +335,42 @@ internal class RenderTargetScreen : FrameworkElement
         row.Children.Add(BuildSwatch("source", source));
         row.Children.Add(BuildSwatch("sprite (scaled + rotated)", sprite));
         return row;
+    }
+
+    // Issue #3464: a blurred dropshadow inside a render-target container. ShadowBlurRenderer's
+    // offscreen BeginTextureMode/EndTextureMode passes run while the container's own BeginTextureMode
+    // is still active; before the fix, raylib's EndTextureMode left the default framebuffer bound
+    // afterward, so the shadow's composite AND the red sibling drawn after it would render to the
+    // screen instead of into the container's texture — both would be missing from this cell (and
+    // could show up as a stray flash on top of the whole gallery instead).
+    static GraphicalUiElement BuildBlurredShadowInRenderTarget()
+    {
+        ContainerRuntime holder = BuildFrame(150, 110);
+
+        ContainerRuntime group = new();
+        group.Width = 150;
+        group.Height = 110;
+        group.IsRenderTarget = true;
+
+        RectangleRuntime shadowed = new();
+        shadowed.X = 15;
+        shadowed.Y = 10;
+        shadowed.Width = 50;
+        shadowed.Height = 40;
+        shadowed.IsFilled = true;
+        shadowed.FillColor = new Color((byte)60, (byte)120, (byte)220, (byte)255);
+        shadowed.HasDropshadow = true;
+        shadowed.DropshadowColor = new Color((byte)0, (byte)0, (byte)0, (byte)200);
+        shadowed.DropshadowOffsetX = 6;
+        shadowed.DropshadowOffsetY = 6;
+        shadowed.DropshadowBlur = 8;
+        group.Children.Add(shadowed);
+
+        // Sibling drawn AFTER the shadowed shape — proves the container's render target is still
+        // bound for draws following the shadow, not just the shadow's own composite.
+        group.Children.Add(Rect(80, 55, 55, 45, new Color((byte)220, (byte)60, (byte)60, (byte)255)));
+
+        holder.Children.Add(group);
+        return holder;
     }
 }

--- a/Tests/RaylibGum.Tests/Rendering/ShadowBlurCameraRestoreTests.cs
+++ b/Tests/RaylibGum.Tests/Rendering/ShadowBlurCameraRestoreTests.cs
@@ -47,6 +47,7 @@ public class ShadowBlurCameraRestoreTests : BaseTestClass
             4f,
             tint,
             camera,
+            null,
             (px, py) => DrawRectangleV(new Vector2(px, py), new Vector2(40f, 40f), silhouette));
 
         Matrix4x4 afterShadow = Rlgl.GetMatrixModelview();

--- a/Tests/RaylibGum.Tests/Rendering/ShadowBlurRenderTargetRestoreTests.cs
+++ b/Tests/RaylibGum.Tests/Rendering/ShadowBlurRenderTargetRestoreTests.cs
@@ -1,0 +1,91 @@
+using Gum.GueDeriving;
+using Raylib_cs;
+using RenderingLibrary.Graphics;
+using Shouldly;
+using static Raylib_cs.Raylib;
+
+namespace RaylibGum.Tests.Rendering;
+
+/// <summary>
+/// Issue #3464: a blurred dropshadow drawn inside a render-target container's bake bakes to the
+/// screen instead of the container's offscreen texture. <see cref="Gum.Renderables.ShadowBlurRenderer.Draw"/>
+/// runs its own offscreen <c>BeginTextureMode</c>/<c>EndTextureMode</c> passes while the container's
+/// own <c>BeginTextureMode</c> is still active; raylib's <c>EndTextureMode</c> unconditionally
+/// unbinds the active render texture and does not restore an enclosing one, so after the shadow's
+/// passes the shadow's own composite — and every later sibling in the same bake — draws to the
+/// default framebuffer (the screen) instead of back into the container's texture. Fixed by having
+/// the renderer track the active bake's render texture (mirroring <c>ActiveCamera2D</c>) and having
+/// the shadow re-establish it after its offscreen passes, before its own composite.
+/// </summary>
+public class ShadowBlurRenderTargetRestoreTests : BaseTestClass
+{
+    private static Color ReadRenderTargetPixel(RenderTexture2D renderTexture, int x, int y)
+    {
+        Image image = LoadImageFromTexture(renderTexture.Texture);
+        try
+        {
+            return GetImageColor(image, x, renderTexture.Texture.Height - 1 - y);
+        }
+        finally
+        {
+            UnloadImage(image);
+        }
+    }
+
+    [Fact]
+    public void Draw_BlurredShadowInsideRenderTarget_BakesShadowAndLaterSiblingIntoContainerTexture()
+    {
+        ContainerRuntime container = new();
+        container.X = 0;
+        container.Y = 0;
+        container.Width = 100;
+        container.Height = 100;
+        container.IsRenderTarget = true;
+
+        // Shadow offset well clear of the body so the shadow region can be sampled independently.
+        RectangleRuntime shadowed = new();
+        shadowed.X = 10;
+        shadowed.Y = 10;
+        shadowed.Width = 30;
+        shadowed.Height = 30;
+        shadowed.IsFilled = true;
+        shadowed.FillColor = new Color((byte)0, (byte)0, (byte)255, (byte)255);
+        shadowed.HasDropshadow = true;
+        shadowed.DropshadowColor = new Color((byte)0, (byte)0, (byte)0, (byte)255);
+        shadowed.DropshadowOffsetX = 0;
+        shadowed.DropshadowOffsetY = 40;
+        shadowed.DropshadowBlur = 4;
+
+        // Sibling drawn AFTER the shadowed shape — proves the bake's render target is still bound
+        // for draws following the shadow, not just the shadow's own composite.
+        RectangleRuntime sibling = new();
+        sibling.X = 60;
+        sibling.Y = 60;
+        sibling.Width = 30;
+        sibling.Height = 30;
+        sibling.IsFilled = true;
+        sibling.FillColor = new Color((byte)0, (byte)255, (byte)0, (byte)255);
+
+        container.Children.Add(shadowed);
+        container.Children.Add(sibling);
+
+        GumService.Default.Root.Children.Add(container);
+        GumService.Default.Root.UpdateLayout();
+
+        BeginDrawing();
+        GumService.Default.Draw();
+        EndDrawing();
+
+        RenderTexture2D renderTexture = Renderer.Self.TryGetBakedRenderTargetFor(container)!.Value;
+
+        // Center of the shifted shadow region (shape is x:10-40,y:10-40; shadow shifted to y:50-80).
+        Color shadowRegion = ReadRenderTargetPixel(renderTexture, 25, 65);
+        // Center of the sibling (x:60-90, y:60-90).
+        Color siblingRegion = ReadRenderTargetPixel(renderTexture, 75, 75);
+
+        shadowRegion.A.ShouldBeGreaterThan((byte)50);
+        siblingRegion.G.ShouldBeGreaterThan((byte)200);
+
+        GumService.Default.Root.Children.Clear();
+    }
+}


### PR DESCRIPTION
## Summary
- Fix: a blurred dropshadow (`DropshadowBlur > 0`) drawn inside a render-target container's bake (`IsRenderTarget = true`) baked to the screen instead of the container's offscreen texture. `ShadowBlurRenderer.Draw`'s own `BeginTextureMode`/`EndTextureMode` offscreen passes run while the container's `BeginTextureMode` is still active; raylib's `EndTextureMode` unconditionally unbinds the active render texture and does not restore an enclosing one, so the shadow's composite (and any later sibling in the same bake) landed on the screen. Render-target analogue of the camera clobber fixed in #3460 / #3463.
- `Renderer` now tracks `ActiveRenderTexture` (the container's texture during a bake, `null` otherwise), mirroring `ActiveCamera2D`. `ShadowBlurRenderer.Draw` re-establishes it via `BeginTextureMode` right before re-establishing the camera, matching `BakeRenderTarget`'s own entry order.
- Adds a "Blurred shadow in RT" gallery cell to **both** the raylib and MonoGameGumInCode `RenderTargetScreen` samples (the `gum-samples` skill requires mirroring the three feature-sample galleries for side-by-side comparison, even though this particular bug is raylib-only — MonoGame's dropshadow is an Apos.Shapes shader pass, not an offscreen-RT blur, so it never had this clobber).
- Small addition to `.claude/skills/gum-samples/SKILL.md` calling out that mirroring applies even when the underlying fix is backend-specific (missed this on the first pass, caught in review).

## Test plan
- [x] New unit test `ShadowBlurRenderTargetRestoreTests` — confirmed red without the fix (shadow composite and a sibling drawn after it were both absent from the baked texture), green with it.
- [x] Full `RaylibGum.Tests` suite green (396/396).
- [x] `RaylibSample` and `MonoGameGumInCode` solutions build with the new `RenderTargetScreen` gallery cell.
- [x] Manual: run the raylib sample, open the "Render Target" screen (nav button), and check the new "Blurred shadow in RT" cell — the blue rectangle should show a soft black shadow offset down-right, and a red rectangle sibling should render below-right of it, both inside the gray frame. Same cell in MonoGameGumInCode for comparison.

Closes #3464
