### PR TITLE
raylib: implement full Blend mapping (Replace/ReplaceAlpha/SubtractAlpha/MinAlpha)

### DIFF
--- a/MonoGameGum.Tests/RenderingLibraries/BlendExtensionsTests.cs
+++ b/MonoGameGum.Tests/RenderingLibraries/BlendExtensionsTests.cs
@@ -47,4 +47,33 @@ public class BlendExtensionsTests : BaseTestClass
     {
         Gum.BlendState.SubtractAlpha.ToBlend().ShouldBe(Blend.SubtractAlpha);
     }
+
+    // Forward direction (Blend -> BlendState). Previously untested even though ToBlendState is what
+    // every runtime (SpriteRuntime, ContainerRuntime, NineSliceRuntime, TextRuntime, ...) actually
+    // calls to apply a Blend value — RaylibGum's BlendModeExtensions (issue #3470) now also depends
+    // on it to derive raylib's low-level blend factors, so pin the exact BlendState each Blend value
+    // resolves to.
+    [Fact]
+    public void ToBlendState_ReturnsMinAlpha_WhenBlendIsMinAlpha()
+    {
+        Blend.MinAlpha.ToBlendState().ShouldBeSameAs(Gum.BlendState.MinAlpha);
+    }
+
+    [Fact]
+    public void ToBlendState_ReturnsOpaque_WhenBlendIsReplace()
+    {
+        Blend.Replace.ToBlendState().ShouldBeSameAs(Gum.BlendState.Opaque);
+    }
+
+    [Fact]
+    public void ToBlendState_ReturnsReplaceAlpha_WhenBlendIsReplaceAlpha()
+    {
+        Blend.ReplaceAlpha.ToBlendState().ShouldBeSameAs(Gum.BlendState.ReplaceAlpha);
+    }
+
+    [Fact]
+    public void ToBlendState_ReturnsSubtractAlpha_WhenBlendIsSubtractAlpha()
+    {
+        Blend.SubtractAlpha.ToBlendState().ShouldBeSameAs(Gum.BlendState.SubtractAlpha);
+    }
 }

--- a/Runtimes/RaylibGum/Renderables/BlendModeExtensions.cs
+++ b/Runtimes/RaylibGum/Renderables/BlendModeExtensions.cs
@@ -2,18 +2,114 @@ using Raylib_cs;
 
 namespace Gum.Renderables;
 
+/// <summary>
+/// Translates Gum's backend-agnostic <see cref="global::Gum.RenderingLibrary.Blend"/> values into
+/// what raylib needs to reproduce them. <see cref="global::Gum.RenderingLibrary.Blend.Normal"/> and
+/// <see cref="global::Gum.RenderingLibrary.Blend.Additive"/> have a direct raylib
+/// <see cref="BlendMode"/> equivalent; every other value (<c>Replace</c>, <c>ReplaceAlpha</c>,
+/// <c>SubtractAlpha</c>, <c>MinAlpha</c> — issue #3470) needs distinct per-channel blend
+/// factors/equations that only <c>Rlgl.SetBlendFactorsSeparate</c> +
+/// <see cref="BlendMode.CustomSeparate"/> can express.
+///
+/// <para>Rather than re-deriving those factors, this reuses
+/// <see cref="global::Gum.RenderingLibrary.BlendExtensions.ToBlendState"/> — the same
+/// backend-agnostic <see cref="global::Gum.BlendState"/> that MonoGame turns into XNA
+/// <c>BlendState</c> objects — and maps its abstract <see cref="global::Gum.Blend"/> /
+/// <see cref="global::Gum.BlendFunction"/> fields onto the equivalent GL constants. This keeps the
+/// raylib result matching MonoGame's blend semantics exactly instead of approximating them.</para>
+/// </summary>
 internal static class BlendModeExtensions
 {
-    public static BlendMode ToRaylibBlendMode(this global::Gum.RenderingLibrary.Blend blend)
+    // GL blend-factor / equation constants (OpenGL / OpenGL ES spec, not raylib-specific).
+    private const int GlZero = 0;
+    private const int GlOne = 1;
+    private const int GlSrcColor = 0x0300;
+    private const int GlOneMinusSrcColor = 0x0301;
+    private const int GlSrcAlpha = 0x0302;
+    private const int GlOneMinusSrcAlpha = 0x0303;
+    private const int GlDstAlpha = 0x0304;
+    private const int GlOneMinusDstAlpha = 0x0305;
+    private const int GlDstColor = 0x0306;
+    private const int GlOneMinusDstColor = 0x0307;
+    private const int GlSrcAlphaSaturate = 0x0308;
+    private const int GlConstantColor = 0x8001;
+    private const int GlOneMinusConstantColor = 0x8002;
+
+    private const int GlFuncAdd = 0x8006;
+    private const int GlMin = 0x8007;
+    private const int GlMax = 0x8008;
+    private const int GlFuncSubtract = 0x800A;
+    private const int GlFuncReverseSubtract = 0x800B;
+
+    /// <summary>
+    /// Attempts to map <paramref name="blend"/> onto one of raylib's built-in canned
+    /// <see cref="BlendMode"/> values. Only <c>Normal</c> and <c>Additive</c> have one; every other
+    /// value returns <c>false</c> and must go through <see cref="ToGlBlendFactorsSeparate"/> instead.
+    /// </summary>
+    public static bool TryGetSimpleRaylibBlendMode(this global::Gum.RenderingLibrary.Blend blend, out BlendMode mode)
     {
-        // Unmapped values (Replace, ReplaceAlpha, MinAlpha, SubtractAlpha) fall through
-        // to Alpha rather than guessing a wrong raylib mode: e.g. SubtractAlpha targets the
-        // alpha channel for masking, which BlendMode.SubtractColors does not — a silent
-        // visual mismatch is worse than no effect.
-        return blend switch
+        switch (blend)
         {
-            global::Gum.RenderingLibrary.Blend.Additive => BlendMode.Additive,
-            _ => BlendMode.Alpha,
-        };
+            case global::Gum.RenderingLibrary.Blend.Additive:
+                mode = BlendMode.Additive;
+                return true;
+            case global::Gum.RenderingLibrary.Blend.Normal:
+                mode = BlendMode.Alpha;
+                return true;
+            default:
+                mode = BlendMode.Alpha;
+                return false;
+        }
     }
+
+    /// <summary>
+    /// Converts <paramref name="blend"/> into the six GL parameters
+    /// <c>Rlgl.SetBlendFactorsSeparate</c> needs to reproduce it exactly (for the values
+    /// <see cref="TryGetSimpleRaylibBlendMode"/> can't handle: <c>Replace</c>, <c>ReplaceAlpha</c>,
+    /// <c>SubtractAlpha</c>, <c>MinAlpha</c>).
+    /// </summary>
+    public static (int srcRgb, int dstRgb, int srcAlpha, int dstAlpha, int eqRgb, int eqAlpha) ToGlBlendFactorsSeparate(
+        this global::Gum.RenderingLibrary.Blend blend)
+    {
+        // raylib currently has no premultiplied-alpha texture handling, so false matches existing
+        // raylib behavior (see Sprite/NineSlice, which never premultiply on load).
+        global::Gum.BlendState blendState = global::Gum.RenderingLibrary.BlendExtensions.ToBlendState(
+            blend, isUsingPremultipliedAlpha: false);
+
+        return (
+            ToGlBlendFactor(blendState.ColorSourceBlend),
+            ToGlBlendFactor(blendState.ColorDestinationBlend),
+            ToGlBlendFactor(blendState.AlphaSourceBlend),
+            ToGlBlendFactor(blendState.AlphaDestinationBlend),
+            ToGlBlendEquation(blendState.ColorBlendFunction),
+            ToGlBlendEquation(blendState.AlphaBlendFunction));
+    }
+
+    private static int ToGlBlendFactor(global::Gum.Blend blend) => blend switch
+    {
+        global::Gum.Blend.Zero => GlZero,
+        global::Gum.Blend.One => GlOne,
+        global::Gum.Blend.SourceColor => GlSrcColor,
+        global::Gum.Blend.InverseSourceColor => GlOneMinusSrcColor,
+        global::Gum.Blend.SourceAlpha => GlSrcAlpha,
+        global::Gum.Blend.InverseSourceAlpha => GlOneMinusSrcAlpha,
+        global::Gum.Blend.DestinationAlpha => GlDstAlpha,
+        global::Gum.Blend.InverseDestinationAlpha => GlOneMinusDstAlpha,
+        global::Gum.Blend.DestinationColor => GlDstColor,
+        global::Gum.Blend.InverseDestinationColor => GlOneMinusDstColor,
+        global::Gum.Blend.SourceAlphaSaturation => GlSrcAlphaSaturate,
+        global::Gum.Blend.BlendFactor => GlConstantColor,
+        global::Gum.Blend.InverseBlendFactor => GlOneMinusConstantColor,
+        _ => throw new System.ArgumentOutOfRangeException(nameof(blend), blend, message: null),
+    };
+
+    private static int ToGlBlendEquation(global::Gum.BlendFunction function) => function switch
+    {
+        global::Gum.BlendFunction.Add => GlFuncAdd,
+        global::Gum.BlendFunction.Subtract => GlFuncSubtract,
+        global::Gum.BlendFunction.ReverseSubtract => GlFuncReverseSubtract,
+        global::Gum.BlendFunction.Min => GlMin,
+        global::Gum.BlendFunction.Max => GlMax,
+        _ => throw new System.ArgumentOutOfRangeException(nameof(function), function, message: null),
+    };
 }

--- a/Runtimes/RaylibGum/Renderables/BlendModeExtensions.cs
+++ b/Runtimes/RaylibGum/Renderables/BlendModeExtensions.cs
@@ -8,15 +8,27 @@ namespace Gum.Renderables;
 /// <see cref="global::Gum.RenderingLibrary.Blend.Additive"/> have a direct raylib
 /// <see cref="BlendMode"/> equivalent; every other value (<c>Replace</c>, <c>ReplaceAlpha</c>,
 /// <c>SubtractAlpha</c>, <c>MinAlpha</c> — issue #3470) needs distinct per-channel blend
-/// factors/equations that only <c>Rlgl.SetBlendFactorsSeparate</c> +
-/// <see cref="BlendMode.CustomSeparate"/> can express.
+/// factors/equations that only <c>Rlgl.SetBlendFactorsSeparate</c> + <see cref="BlendMode.CustomSeparate"/>
+/// can express.
 ///
-/// <para>Rather than re-deriving those factors, this reuses
-/// <see cref="global::Gum.RenderingLibrary.BlendExtensions.ToBlendState"/> — the same
-/// backend-agnostic <see cref="global::Gum.BlendState"/> that MonoGame turns into XNA
-/// <c>BlendState</c> objects — and maps its abstract <see cref="global::Gum.Blend"/> /
-/// <see cref="global::Gum.BlendFunction"/> fields onto the equivalent GL constants. This keeps the
-/// raylib result matching MonoGame's blend semantics exactly instead of approximating them.</para>
+/// <para><b>Why the color factors are NOT simply reused from <c>BlendExtensions.ToBlendState</c>:</b>
+/// that shared, backend-agnostic <see cref="global::Gum.BlendState"/> model was designed for
+/// MonoGame, which stores a baked render target as plain straight (non-premultiplied) color+alpha
+/// and re-multiplies by alpha at composite time (<c>Renderer.NormalBlendState</c> defaults to
+/// <c>BlendState.NonPremultiplied</c>) — so a blend that intentionally leaves color untouched while
+/// changing alpha (the whole point of the "alpha-only" family) is safe there. raylib's render-target
+/// bake pipeline instead <b>stores an already-premultiplied result</b> and composites it back with
+/// <c>BlendMode.AlphaPremultiply</c> (see <c>Renderer.BakeRenderTarget</c> /
+/// <c>TryCompositeRenderTarget</c>, issue #3434) — so any draw inside a bake must leave a validly
+/// premultiplied pixel (color proportional to its own alpha), or leftover full-intensity color bleeds
+/// through at composite time even where alpha reads near zero (issue #3470 follow-up: SubtractAlpha
+/// showed magenta instead of a transparent hole). The alpha factors are always reused as-is from
+/// <c>ToBlendState</c> (alpha has no premultiplication concept). The color factors only switch to
+/// raylib's own premultiplied-consistent derivation while a bake is actually active — outside a bake
+/// (e.g. a plain Sprite drawn straight to the screen) there is nothing further compositing the
+/// result, so <c>ToBlendState</c>'s "ignore alpha" factors are used directly instead, matching
+/// MonoGame's own visual (a translucent <c>Replace</c> sprite should still render at full brightness
+/// there, not dimmed by its own alpha).</para>
 /// </summary>
 internal static class BlendModeExtensions
 {
@@ -64,26 +76,64 @@ internal static class BlendModeExtensions
 
     /// <summary>
     /// Converts <paramref name="blend"/> into the six GL parameters
-    /// <c>Rlgl.SetBlendFactorsSeparate</c> needs to reproduce it exactly (for the values
+    /// <c>Rlgl.SetBlendFactorsSeparate</c> needs to reproduce it (for the values
     /// <see cref="TryGetSimpleRaylibBlendMode"/> can't handle: <c>Replace</c>, <c>ReplaceAlpha</c>,
-    /// <c>SubtractAlpha</c>, <c>MinAlpha</c>).
+    /// <c>SubtractAlpha</c>, <c>MinAlpha</c>). The alpha factors always come from the shared
+    /// <c>BlendExtensions.ToBlendState</c> model (alpha has no premultiplication concept). The color
+    /// factors depend on <paramref name="isPremultiplyingContext"/> — see the class remarks: inside a
+    /// render-target bake they use raylib's own premultiplied-consistent derivation; outside one they
+    /// reuse <c>ToBlendState</c>'s factors directly, matching MonoGame's "ignore alpha" semantics.
     /// </summary>
     public static (int srcRgb, int dstRgb, int srcAlpha, int dstAlpha, int eqRgb, int eqAlpha) ToGlBlendFactorsSeparate(
-        this global::Gum.RenderingLibrary.Blend blend)
+        this global::Gum.RenderingLibrary.Blend blend, bool isPremultiplyingContext)
     {
         // raylib currently has no premultiplied-alpha texture handling, so false matches existing
         // raylib behavior (see Sprite/NineSlice, which never premultiply on load).
         global::Gum.BlendState blendState = global::Gum.RenderingLibrary.BlendExtensions.ToBlendState(
             blend, isUsingPremultipliedAlpha: false);
 
+        (int colorSrc, int colorDst, int colorFunc) = isPremultiplyingContext
+            ? ToPremultipliedConsistentColorFactors(blend)
+            : (ToGlBlendFactor(blendState.ColorSourceBlend), ToGlBlendFactor(blendState.ColorDestinationBlend),
+                ToGlBlendEquation(blendState.ColorBlendFunction));
+
         return (
-            ToGlBlendFactor(blendState.ColorSourceBlend),
-            ToGlBlendFactor(blendState.ColorDestinationBlend),
+            colorSrc,
+            colorDst,
             ToGlBlendFactor(blendState.AlphaSourceBlend),
             ToGlBlendFactor(blendState.AlphaDestinationBlend),
-            ToGlBlendEquation(blendState.ColorBlendFunction),
+            colorFunc,
             ToGlBlendEquation(blendState.AlphaBlendFunction));
     }
+
+    // Raylib-specific color factors that keep a bake's premultiplied-storage invariant intact — see
+    // the class remarks. Each scales color down in lockstep with however that mode changes alpha,
+    // rather than reusing ToBlendState's MonoGame-oriented "leave color untouched" factors. Every
+    // case (Add) is a plain scale-and-keep, never a subtraction, so the equation is always Add.
+    //
+    // Known limitation: ReplaceAlpha/MinAlpha's color scale (Dst*SrcAlpha) is only exactly correct
+    // when the destination was already fully opaque going in — fixed-function blending can't divide
+    // by the destination's own current alpha to generalize further. Replace and SubtractAlpha have no
+    // such caveat (Replace discards the destination outright; SubtractAlpha's complementary factor
+    // falls out of the same subtraction driving its alpha). This matches every documented use of
+    // these blends (masking over an opaque backing layer), so the common case renders exactly right
+    // and the edge case (masking onto an already-translucent layer) is a minor intensity error, not a
+    // wrong-color leak.
+    private static (int colorSrc, int colorDst, int colorFunc) ToPremultipliedConsistentColorFactors(global::Gum.RenderingLibrary.Blend blend) => blend switch
+    {
+        // Fully replaces the destination, so premultiply the incoming color by its own alpha
+        // (Src*SrcAlpha) rather than writing it raw (Src*One) — fully general, no destination
+        // assumption needed since Replace discards the destination outright.
+        global::Gum.RenderingLibrary.Blend.Replace => (GlSrcAlpha, GlZero, GlFuncAdd),
+        // Alpha is overwritten with SrcAlpha; scale destination color by that same SrcAlpha so
+        // color and alpha shrink together.
+        global::Gum.RenderingLibrary.Blend.ReplaceAlpha => (GlZero, GlSrcAlpha, GlFuncAdd),
+        global::Gum.RenderingLibrary.Blend.MinAlpha => (GlZero, GlSrcAlpha, GlFuncAdd),
+        // Alpha is reverse-subtracted by SrcAlpha (Dst - Src); scale destination color by the
+        // complementary (1 - SrcAlpha) so it shrinks toward zero exactly as alpha does.
+        global::Gum.RenderingLibrary.Blend.SubtractAlpha => (GlZero, GlOneMinusSrcAlpha, GlFuncAdd),
+        _ => throw new System.ArgumentOutOfRangeException(nameof(blend), blend, message: null),
+    };
 
     private static int ToGlBlendFactor(global::Gum.Blend blend) => blend switch
     {

--- a/Runtimes/RaylibGum/Renderables/LineRectangle.cs
+++ b/Runtimes/RaylibGum/Renderables/LineRectangle.cs
@@ -46,11 +46,11 @@ public class LineRectangle : InvisibleRenderable
 
     /// <summary>
     /// Blend mode applied to the fill and stroke passes. When set, <see cref="Render"/> wraps
-    /// those passes in <c>BeginBlendMode</c>/<c>EndBlendMode</c> (via the batch-counted wrappers)
-    /// using <see cref="BlendModeExtensions.ToRaylibBlendMode"/>. <c>null</c> (the default) leaves
-    /// raylib on its standard alpha blend. Mirrors the <c>Blend</c> member on the raylib
-    /// <c>Sprite</c> / <c>NineSlice</c> renderables (issue #3458). Only <see cref="global::Gum.RenderingLibrary.Blend.Additive"/>
-    /// maps to a non-alpha raylib mode today; other values fall through to alpha.
+    /// those passes in <c>BeginBlendMode</c>/<c>EndBlendMode</c> (via the batch-counted wrappers),
+    /// which reproduce every <see cref="global::Gum.RenderingLibrary.Blend"/> value exactly
+    /// (issue #3470). <c>null</c> (the default) leaves raylib on its standard alpha blend. Mirrors
+    /// the <c>Blend</c> member on the raylib <c>Sprite</c> / <c>NineSlice</c> renderables
+    /// (issue #3458).
     /// </summary>
     public global::Gum.RenderingLibrary.Blend? Blend { get; set; }
 
@@ -379,7 +379,7 @@ public class LineRectangle : InvisibleRenderable
         // EndBlendMode so the draw-call counter stays accurate.
         if (Blend.HasValue)
         {
-            global::RenderingLibrary.Graphics.Renderer.Self.BatchDrawCallCounter.BeginBlendMode(Blend.Value.ToRaylibBlendMode());
+            global::RenderingLibrary.Graphics.Renderer.Self.BatchDrawCallCounter.BeginBlendMode(Blend.Value);
         }
 
         // Fill pass — runs when FillColor is set, or when IsFilled is true with no explicit

--- a/Runtimes/RaylibGum/Renderables/NineSlice.cs
+++ b/Runtimes/RaylibGum/Renderables/NineSlice.cs
@@ -238,7 +238,7 @@ public class NineSlice : RenderableBase, IAnimatable, ITextureCoordinate, IClone
 
         if (Blend.HasValue)
         {
-            global::RenderingLibrary.Graphics.Renderer.Self.BatchDrawCallCounter.BeginBlendMode(Blend.Value.ToRaylibBlendMode());
+            global::RenderingLibrary.Graphics.Renderer.Self.BatchDrawCallCounter.BeginBlendMode(Blend.Value);
         }
 
         // The default (non-tiling, BorderScale 1, no custom frame width) case is left on

--- a/Runtimes/RaylibGum/Renderables/Sprite.cs
+++ b/Runtimes/RaylibGum/Renderables/Sprite.cs
@@ -186,7 +186,7 @@ public class Sprite : InvisibleRenderable, IAspectRatio, ITextureCoordinate, IAn
 
         if (Blend.HasValue)
         {
-            global::RenderingLibrary.Graphics.Renderer.Self.BatchDrawCallCounter.BeginBlendMode(Blend.Value.ToRaylibBlendMode());
+            global::RenderingLibrary.Graphics.Renderer.Self.BatchDrawCallCounter.BeginBlendMode(Blend.Value);
         }
 
         // RenderTargetTextureSource is excluded: its source rect already encodes the bottom-up GL

--- a/Runtimes/RaylibGum/RenderingLibrary/BatchDrawCallCounter.cs
+++ b/Runtimes/RaylibGum/RenderingLibrary/BatchDrawCallCounter.cs
@@ -1,3 +1,4 @@
+using Gum.Renderables;
 using Raylib_cs;
 using System;
 using System.Runtime.InteropServices;
@@ -117,6 +118,29 @@ public sealed unsafe class BatchDrawCallCounter
     {
         Bank();
         Raylib.BeginBlendMode(mode);
+    }
+
+    /// <summary>
+    /// Counted wrapper that reproduces a Gum <see cref="global::Gum.RenderingLibrary.Blend"/> value
+    /// on raylib. <c>Normal</c>/<c>Additive</c> use a canned raylib <see cref="BlendMode"/>; every
+    /// other value (<c>Replace</c>, <c>ReplaceAlpha</c>, <c>SubtractAlpha</c>, <c>MinAlpha</c> —
+    /// issue #3470) sets explicit per-channel GL blend factors/equations via
+    /// <c>Rlgl.SetBlendFactorsSeparate</c> and <see cref="BlendMode.CustomSeparate"/>, since raylib
+    /// has no canned mode for them. Pair with <see cref="EndBlendMode"/>.
+    /// </summary>
+    public void BeginBlendMode(global::Gum.RenderingLibrary.Blend blend)
+    {
+        Bank();
+
+        if (blend.TryGetSimpleRaylibBlendMode(out BlendMode mode))
+        {
+            Raylib.BeginBlendMode(mode);
+            return;
+        }
+
+        (int srcRgb, int dstRgb, int srcAlpha, int dstAlpha, int eqRgb, int eqAlpha) = blend.ToGlBlendFactorsSeparate();
+        Rlgl.SetBlendFactorsSeparate(srcRgb, dstRgb, srcAlpha, dstAlpha, eqRgb, eqAlpha);
+        Raylib.BeginBlendMode(BlendMode.CustomSeparate);
     }
 
     /// <summary>

--- a/Runtimes/RaylibGum/RenderingLibrary/BatchDrawCallCounter.cs
+++ b/Runtimes/RaylibGum/RenderingLibrary/BatchDrawCallCounter.cs
@@ -126,7 +126,17 @@ public sealed unsafe class BatchDrawCallCounter
     /// other value (<c>Replace</c>, <c>ReplaceAlpha</c>, <c>SubtractAlpha</c>, <c>MinAlpha</c> —
     /// issue #3470) sets explicit per-channel GL blend factors/equations via
     /// <c>Rlgl.SetBlendFactorsSeparate</c> and <see cref="BlendMode.CustomSeparate"/>, since raylib
-    /// has no canned mode for them. Pair with <see cref="EndBlendMode"/>.
+    /// has no canned mode for them.
+    ///
+    /// <para>Whether this is called while <see cref="_renderTargetBlendActive"/> determines which
+    /// color-factor derivation those four values use — see
+    /// <see cref="Gum.Renderables.BlendModeExtensions"/>'s remarks for why: outside a bake there is
+    /// no further compositing to keep premultiplied-consistent, so <c>Replace</c> etc. use the
+    /// straightforward "ignore alpha" factors matching MonoGame; inside a bake they must leave a
+    /// validly premultiplied pixel or leftover color bleeds through <c>TryCompositeRenderTarget</c>'s
+    /// <c>AlphaPremultiply</c> composite (issue #3470 follow-up).</para>
+    ///
+    /// Pair with <see cref="EndBlendMode"/>.
     /// </summary>
     public void BeginBlendMode(global::Gum.RenderingLibrary.Blend blend)
     {
@@ -138,7 +148,8 @@ public sealed unsafe class BatchDrawCallCounter
             return;
         }
 
-        (int srcRgb, int dstRgb, int srcAlpha, int dstAlpha, int eqRgb, int eqAlpha) = blend.ToGlBlendFactorsSeparate();
+        (int srcRgb, int dstRgb, int srcAlpha, int dstAlpha, int eqRgb, int eqAlpha) =
+            blend.ToGlBlendFactorsSeparate(isPremultiplyingContext: _renderTargetBlendActive);
         Rlgl.SetBlendFactorsSeparate(srcRgb, dstRgb, srcAlpha, dstAlpha, eqRgb, eqAlpha);
         Raylib.BeginBlendMode(BlendMode.CustomSeparate);
     }

--- a/Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/SpriteScreen.cs
+++ b/Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/SpriteScreen.cs
@@ -187,16 +187,6 @@ internal class SpriteScreen : FrameworkElement
             redBackground.Width = 32;
             redBackground.Height = 32;
             redBackground.Color = Color.Red;
-            // MinAlpha cell only: drop the underlying alpha to 128 so the
-            // result is visibly distinct from ReplaceAlpha. ReplaceAlpha
-            // overwrites with the bear's alpha (opaque bear → 255), while
-            // MinAlpha keeps the lower of the two (min(128, 255) = 128, so
-            // the bear silhouette renders at half opacity instead of fully
-            // opaque). With alpha=255 underlying, the two cells look identical.
-            if (blend == Gum.RenderingLibrary.Blend.MinAlpha)
-            {
-                redBackground.Alpha = 128;
-            }
             cell.AddChild(redBackground);
 
             var alphaMasker = new SpriteRuntime();
@@ -204,6 +194,20 @@ internal class SpriteScreen : FrameworkElement
             alphaMasker.Width = 64;
             alphaMasker.Height = 64;
             alphaMasker.Blend = blend;
+            // MinAlpha cell only: drop the BEAR's own alpha to 128 (background stays fully
+            // opaque at 255). This makes min() actually pick a *different* side depending on
+            // region rather than always landing on the same one: inside the bear,
+            // min(255, 128) = 128 (the bear's reduced alpha wins over the opaque background);
+            // outside the bear (fully transparent PNG area), min(255, 0) = 0 (fully punched
+            // through); at the bear's anti-aliased edge, the texture's own partial alpha gives
+            // a third, in-between level. Three visibly distinct bands from one texture, no
+            // gradient asset needed. (Previously this dropped the *background*'s alpha to 128
+            // instead, which only ever showed two flat levels — min(128, 255) always resolved
+            // to the same fixed 128 everywhere the bear covered.)
+            if (blend == Gum.RenderingLibrary.Blend.MinAlpha)
+            {
+                alphaMasker.Alpha = 128;
+            }
             cell.AddChild(alphaMasker);
 
             alphaBlendRow.AddChild(cell);

--- a/Samples/raylib/Screens/SpriteScreen.cs
+++ b/Samples/raylib/Screens/SpriteScreen.cs
@@ -13,10 +13,6 @@ namespace Examples.Shapes;
 // Raylib mirror of Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/SpriteScreen.cs (issue #2912).
 // Section order and parameter sweeps match the MG version so visual regressions in one backend are
 // easy to spot against the other when both samples are run side-by-side.
-//
-// The alpha-only Blend row (SubtractAlpha/ReplaceAlpha/MinAlpha) from the MG screen is intentionally
-// skipped here: raylib's BlendMode enum has no alpha-stencil equivalents, so those values fall
-// through to BlendMode.Alpha and would render identically — no useful visual signal.
 internal class SpriteScreen : FrameworkElement
 {
     public SpriteScreen() : base(new ContainerRuntime())
@@ -149,9 +145,9 @@ internal class SpriteScreen : FrameworkElement
             rotRow.AddChild(s);
         }
 
-        // Blend modes — Normal/Additive/Replace from the MG screen. On raylib, Normal and Replace
-        // both map to BlendMode.Alpha (raylib has no opaque/replace variant), so they render
-        // identically; Additive is the visually distinct cell.
+        // Blend modes — Normal/Additive/Replace (issue #3470: Replace now overwrites the
+        // destination outright via raylib's separate-factors blend path, rather than falling
+        // through to the same result as Normal).
         AddSectionLabel(page, "Blend, normal rendering (Normal, Additive, Replace):");
         var blendRow = NewSection(ChildrenLayout.LeftToRightStack, spacing: 6);
         page.AddChild(blendRow);
@@ -168,6 +164,51 @@ internal class SpriteScreen : FrameworkElement
             s.Height = 64;
             s.Blend = blend;
             blendRow.AddChild(s);
+        }
+
+        // Alpha-only blends (issue #3470) — each cell is a render-target Container holding a red
+        // rectangle as the underlying layer, then a bear sprite on top with the alpha-only Blend
+        // modifying that rectangle's alpha per pixel. SubtractAlpha punches a hole; ReplaceAlpha
+        // overwrites alpha with the bear's alpha; MinAlpha keeps whichever alpha is lower. Mirrors
+        // the MG screen's identical row.
+        AddSectionLabel(page, "Blend, alpha-only on render-target Container (SubtractAlpha, ReplaceAlpha, MinAlpha):");
+        var alphaBlendRow = NewSection(ChildrenLayout.LeftToRightStack, spacing: 6);
+        page.AddChild(alphaBlendRow);
+        foreach (var blend in new[]
+        {
+            Gum.RenderingLibrary.Blend.SubtractAlpha,
+            Gum.RenderingLibrary.Blend.ReplaceAlpha,
+            Gum.RenderingLibrary.Blend.MinAlpha,
+        })
+        {
+            var cell = new ContainerRuntime();
+            cell.IsRenderTarget = true;
+            cell.Width = 32;
+            cell.Height = 32;
+
+            var redBackground = new ColoredRectangleRuntime();
+            redBackground.Width = 32;
+            redBackground.Height = 32;
+            redBackground.Color = Color.Red;
+            // MinAlpha cell only: drop the underlying alpha to 128 so the result is visibly
+            // distinct from ReplaceAlpha. ReplaceAlpha overwrites with the bear's alpha (opaque
+            // bear -> 255), while MinAlpha keeps the lower of the two (min(128, 255) = 128, so the
+            // bear silhouette renders at half opacity instead of fully opaque). With alpha=255
+            // underlying, the two cells look identical.
+            if (blend == Gum.RenderingLibrary.Blend.MinAlpha)
+            {
+                redBackground.Alpha = 128;
+            }
+            cell.AddChild(redBackground);
+
+            var alphaMasker = new SpriteRuntime();
+            alphaMasker.SourceFileName = "resources\\BearTexture.png";
+            alphaMasker.Width = 64;
+            alphaMasker.Height = 64;
+            alphaMasker.Blend = blend;
+            cell.AddChild(alphaMasker);
+
+            alphaBlendRow.AddChild(cell);
         }
 
         // AnimationChain-driven sprite — same .achx pipeline the MG sample uses. .achx +

--- a/Samples/raylib/Screens/SpriteScreen.cs
+++ b/Samples/raylib/Screens/SpriteScreen.cs
@@ -190,15 +190,6 @@ internal class SpriteScreen : FrameworkElement
             redBackground.Width = 32;
             redBackground.Height = 32;
             redBackground.Color = Color.Red;
-            // MinAlpha cell only: drop the underlying alpha to 128 so the result is visibly
-            // distinct from ReplaceAlpha. ReplaceAlpha overwrites with the bear's alpha (opaque
-            // bear -> 255), while MinAlpha keeps the lower of the two (min(128, 255) = 128, so the
-            // bear silhouette renders at half opacity instead of fully opaque). With alpha=255
-            // underlying, the two cells look identical.
-            if (blend == Gum.RenderingLibrary.Blend.MinAlpha)
-            {
-                redBackground.Alpha = 128;
-            }
             cell.AddChild(redBackground);
 
             var alphaMasker = new SpriteRuntime();
@@ -206,6 +197,19 @@ internal class SpriteScreen : FrameworkElement
             alphaMasker.Width = 64;
             alphaMasker.Height = 64;
             alphaMasker.Blend = blend;
+            // MinAlpha cell only: drop the BEAR's own alpha to 128 (background stays fully opaque
+            // at 255). This makes min() actually pick a *different* side depending on region rather
+            // than always landing on the same one: inside the bear, min(255, 128) = 128 (the bear's
+            // reduced alpha wins over the opaque background); outside the bear (fully transparent
+            // PNG area), min(255, 0) = 0 (fully punched through); at the bear's anti-aliased edge,
+            // the texture's own partial alpha gives a third, in-between level. Three visibly
+            // distinct bands from one texture, no gradient asset needed. (Previously this dropped
+            // the *background*'s alpha to 128 instead, which only ever showed two flat levels —
+            // min(128, 255) always resolved to the same fixed 128 everywhere the bear covered.)
+            if (blend == Gum.RenderingLibrary.Blend.MinAlpha)
+            {
+                alphaMasker.Alpha = 128;
+            }
             cell.AddChild(alphaMasker);
 
             alphaBlendRow.AddChild(cell);

--- a/Tests/RaylibGum.Tests/Rendering/BlendModeRenderTests.cs
+++ b/Tests/RaylibGum.Tests/Rendering/BlendModeRenderTests.cs
@@ -9,12 +9,22 @@ using static Raylib_cs.Raylib;
 namespace RaylibGum.Tests.Rendering;
 
 /// <summary>
-/// Pixel-readback tests proving each Gum <see cref="Blend"/> value produces its own distinct
-/// result on raylib (issue #3470) instead of every non-<c>Additive</c> value silently collapsing
-/// to straight alpha. Uses the same render-target pixel-readback harness as
+/// Pixel-readback tests proving each Gum <see cref="Blend"/> value produces its own distinct,
+/// correct result on raylib (issue #3470) instead of every non-<c>Additive</c> value silently
+/// collapsing to straight alpha. Uses the same render-target pixel-readback harness as
 /// <see cref="RenderTargetTests"/> — the alpha-affecting blends (SubtractAlpha/ReplaceAlpha/
 /// MinAlpha) only have an observable effect against a persisted destination alpha, which only a
 /// baked render target gives us headlessly.
+///
+/// <para>Each case nests the masked cell inside an outer render-target container with its own
+/// solid-blue background, and asserts on the <b>outer, composited</b> pixel rather than just the
+/// cell's raw bake. A follow-up to the original fix found that reading only the raw bake missed a
+/// real bug: the cell's baked pixel can carry leftover full-intensity color at near-zero alpha,
+/// which is invisible until something composites that bake elsewhere — exactly what raylib's
+/// render-target pipeline always does (<c>TryCompositeRenderTarget</c>'s <c>AlphaPremultiply</c>
+/// blend trusts the bake is already premultiplied). Uncaught, that leftover color bled through as a
+/// visibly wrong tint (e.g. SubtractAlpha showing magenta instead of revealing the blue background)
+/// — see <see cref="Gum.Renderables.BlendModeExtensions"/>'s remarks for the fix.</para>
 /// </summary>
 public class BlendModeRenderTests : BaseTestClass
 {
@@ -77,92 +87,112 @@ public class BlendModeRenderTests : BaseTestClass
         return sprite;
     }
 
-    [Fact]
-    public void Draw_ReplaceBlendSprite_OverwritesDestinationColorIgnoringAlpha()
+    // Wraps a masked cell (red background + alpha-blended masker) inside an outer render-target
+    // container with a solid-blue background, so the composite step — not just the cell's own
+    // bake — is exercised. Returns (raw cell bake, composited outer) center pixels.
+    private static (Color cell, Color outer) DrawMaskedCellOverBlueBackground(
+        int size, Color backgroundColor, Color maskerTextureColor, Blend maskerBlend)
     {
-        int size = 32;
-        ContainerRuntime cell = RenderTargetCell(size);
-        cell.Children.Add(Background(size, new Color((byte)0, (byte)255, (byte)0, (byte)255)));
-        cell.Children.Add(MaskerSprite(size, new Color((byte)255, (byte)0, (byte)0, (byte)128), Blend.Replace));
+        ContainerRuntime outer = RenderTargetCell(size);
+        outer.Children.Add(Background(size, new Color((byte)0, (byte)0, (byte)255, (byte)255)));
 
-        GumService.Default.Root.Children.Add(cell);
+        ContainerRuntime cell = RenderTargetCell(size);
+        cell.Children.Add(Background(size, backgroundColor));
+        cell.Children.Add(MaskerSprite(size, maskerTextureColor, maskerBlend));
+        outer.Children.Add(cell);
+
+        GumService.Default.Root.Children.Add(outer);
         GumService.Default.Root.UpdateLayout();
 
         DrawOnce();
 
-        Color center = ReadRenderTargetCenter(Renderer.Self.TryGetBakedRenderTargetFor(cell)!.Value);
-
-        // Replace overwrites the destination outright (color factors One/Zero) — the half-alpha
-        // red texture must fully replace the green background, not blend with it.
-        center.R.ShouldBeGreaterThan((byte)200);
-        center.G.ShouldBeLessThan((byte)50);
+        Color cellPixel = ReadRenderTargetCenter(Renderer.Self.TryGetBakedRenderTargetFor(cell)!.Value);
+        Color outerPixel = ReadRenderTargetCenter(Renderer.Self.TryGetBakedRenderTargetFor(outer)!.Value);
 
         GumService.Default.Root.Children.Clear();
+
+        return (cellPixel, outerPixel);
     }
 
     [Fact]
-    public void Draw_ReplaceAlphaBlendSprite_OverwritesDestinationAlphaOnly()
+    public void Draw_ReplaceBlendSprite_CompositesAsProperTranslucentOverwrite()
     {
-        int size = 32;
-        ContainerRuntime cell = RenderTargetCell(size);
-        cell.Children.Add(Background(size, new Color((byte)255, (byte)0, (byte)0, (byte)255)));
-        cell.Children.Add(MaskerSprite(size, new Color((byte)0, (byte)0, (byte)0, (byte)50), Blend.ReplaceAlpha));
+        (Color cell, Color outer) = DrawMaskedCellOverBlueBackground(
+            32,
+            backgroundColor: new Color((byte)0, (byte)255, (byte)0, (byte)255),
+            maskerTextureColor: new Color((byte)255, (byte)0, (byte)0, (byte)128),
+            maskerBlend: Blend.Replace);
 
-        GumService.Default.Root.Children.Add(cell);
-        GumService.Default.Root.UpdateLayout();
+        // Replace overwrites the destination outright (ignoring the green background entirely). The
+        // raw bake stores the masker's color premultiplied by its own alpha (~128 at alpha ~128,
+        // ratio 1:1) rather than raw full-intensity red — that premultiplication is exactly what
+        // keeps the composite below correct.
+        cell.R.ShouldBeInRange((byte)110, (byte)145);
+        cell.G.ShouldBeLessThan((byte)50);
+        cell.A.ShouldBeInRange((byte)110, (byte)145);
 
-        DrawOnce();
-
-        Color center = ReadRenderTargetCenter(Renderer.Self.TryGetBakedRenderTargetFor(cell)!.Value);
-
-        // ReplaceAlpha leaves color untouched (color factors Zero/One) but overwrites alpha with
-        // the masker's alpha (alpha factors One/Zero) rather than blending it with the background's.
-        center.R.ShouldBeGreaterThan((byte)200);
-        center.A.ShouldBeInRange((byte)30, (byte)70);
-
-        GumService.Default.Root.Children.Clear();
+        // Composited over the outer blue background, a half-alpha red overwrite must look like a
+        // roughly even red/blue blend — not full-intensity red leaking through (the original bug:
+        // an un-premultiplied bake reads its own alpha as "keep everything", showing solid red with
+        // no hint of the blue behind it) and not pure blue (over-erased).
+        outer.R.ShouldBeInRange((byte)100, (byte)160);
+        outer.B.ShouldBeInRange((byte)100, (byte)160);
     }
 
     [Fact]
-    public void Draw_SubtractAlphaBlendSprite_PunchesHoleInDestinationAlpha()
+    public void Draw_ReplaceAlphaBlendSprite_CompositesWithoutLeakingFullIntensityColor()
     {
-        int size = 32;
-        ContainerRuntime cell = RenderTargetCell(size);
-        cell.Children.Add(Background(size, new Color((byte)255, (byte)0, (byte)0, (byte)255)));
-        cell.Children.Add(MaskerSprite(size, new Color((byte)0, (byte)0, (byte)0, (byte)255), Blend.SubtractAlpha));
+        (Color cell, Color outer) = DrawMaskedCellOverBlueBackground(
+            32,
+            backgroundColor: new Color((byte)255, (byte)0, (byte)0, (byte)255),
+            maskerTextureColor: new Color((byte)0, (byte)0, (byte)0, (byte)50),
+            maskerBlend: Blend.ReplaceAlpha);
 
-        GumService.Default.Root.Children.Add(cell);
-        GumService.Default.Root.UpdateLayout();
+        // ReplaceAlpha overwrites alpha with the masker's alpha rather than blending it with the
+        // background's.
+        cell.A.ShouldBeInRange((byte)30, (byte)70);
 
-        DrawOnce();
+        // Composited over blue: at ~20% alpha, red should barely tint a mostly-blue result — not
+        // show full-intensity red bleeding through (the bug: the bake's un-scaled red survives the
+        // near-zero alpha and gets added on top of the blue instead of mostly replaced by it).
+        outer.R.ShouldBeInRange((byte)20, (byte)90);
+        outer.B.ShouldBeGreaterThan((byte)150);
+    }
 
-        Color center = ReadRenderTargetCenter(Renderer.Self.TryGetBakedRenderTargetFor(cell)!.Value);
+    [Fact]
+    public void Draw_SubtractAlphaBlendSprite_PunchesASeeThroughHoleRevealingBackground()
+    {
+        (Color cell, Color outer) = DrawMaskedCellOverBlueBackground(
+            32,
+            backgroundColor: new Color((byte)255, (byte)0, (byte)0, (byte)255),
+            maskerTextureColor: new Color((byte)0, (byte)0, (byte)0, (byte)255),
+            maskerBlend: Blend.SubtractAlpha);
 
         // SubtractAlpha reverse-subtracts the masker's opaque alpha from the destination's opaque
         // alpha, punching a fully-transparent hole (255 - 255 = 0).
-        center.A.ShouldBeLessThan((byte)20);
+        cell.A.ShouldBeLessThan((byte)20);
 
-        GumService.Default.Root.Children.Clear();
+        // Composited over blue, a fully-punched hole must reveal pure blue — not the pink/magenta
+        // the original bug produced (leftover un-zeroed red bleeding through the "transparent" hole).
+        outer.R.ShouldBeLessThan((byte)40);
+        outer.B.ShouldBeGreaterThan((byte)220);
     }
 
     [Fact]
-    public void Draw_MinAlphaBlendSprite_KeepsLowerOfTheTwoAlphas()
+    public void Draw_MinAlphaBlendSprite_CompositesWithoutLeakingFullIntensityColor()
     {
-        int size = 32;
-        ContainerRuntime cell = RenderTargetCell(size);
-        cell.Children.Add(Background(size, new Color((byte)255, (byte)0, (byte)0, (byte)200)));
-        cell.Children.Add(MaskerSprite(size, new Color((byte)0, (byte)0, (byte)0, (byte)100), Blend.MinAlpha));
-
-        GumService.Default.Root.Children.Add(cell);
-        GumService.Default.Root.UpdateLayout();
-
-        DrawOnce();
-
-        Color center = ReadRenderTargetCenter(Renderer.Self.TryGetBakedRenderTargetFor(cell)!.Value);
+        (Color cell, Color outer) = DrawMaskedCellOverBlueBackground(
+            32,
+            backgroundColor: new Color((byte)255, (byte)0, (byte)0, (byte)200),
+            maskerTextureColor: new Color((byte)0, (byte)0, (byte)0, (byte)100),
+            maskerBlend: Blend.MinAlpha);
 
         // MinAlpha keeps whichever alpha is lower — min(200, 100) = 100.
-        center.A.ShouldBeInRange((byte)80, (byte)120);
+        cell.A.ShouldBeInRange((byte)80, (byte)120);
 
-        GumService.Default.Root.Children.Clear();
+        // Composited over blue: red should be dimmed toward blue, not showing full-intensity red on
+        // top of an also-visible blue (the double-exposure look the original bug produced).
+        outer.R.ShouldBeInRange((byte)40, (byte)120);
+        outer.B.ShouldBeGreaterThan((byte)120);
     }
 }

--- a/Tests/RaylibGum.Tests/Rendering/BlendModeRenderTests.cs
+++ b/Tests/RaylibGum.Tests/Rendering/BlendModeRenderTests.cs
@@ -1,0 +1,168 @@
+using Gum.DataTypes;
+using Gum.GueDeriving;
+using Gum.RenderingLibrary;
+using Raylib_cs;
+using RenderingLibrary.Graphics;
+using Shouldly;
+using static Raylib_cs.Raylib;
+
+namespace RaylibGum.Tests.Rendering;
+
+/// <summary>
+/// Pixel-readback tests proving each Gum <see cref="Blend"/> value produces its own distinct
+/// result on raylib (issue #3470) instead of every non-<c>Additive</c> value silently collapsing
+/// to straight alpha. Uses the same render-target pixel-readback harness as
+/// <see cref="RenderTargetTests"/> — the alpha-affecting blends (SubtractAlpha/ReplaceAlpha/
+/// MinAlpha) only have an observable effect against a persisted destination alpha, which only a
+/// baked render target gives us headlessly.
+/// </summary>
+public class BlendModeRenderTests : BaseTestClass
+{
+    private static void DrawOnce()
+    {
+        BeginDrawing();
+        GumService.Default.Draw();
+        EndDrawing();
+    }
+
+    // Render targets are stored bottom-up in GL (see RenderTargetTests), but every case here reads
+    // the exact center pixel, which is unaffected by a vertical flip.
+    private static Color ReadRenderTargetCenter(RenderTexture2D renderTexture)
+    {
+        Image image = LoadImageFromTexture(renderTexture.Texture);
+        try
+        {
+            return GetImageColor(image, renderTexture.Texture.Width / 2, renderTexture.Texture.Height / 2);
+        }
+        finally
+        {
+            UnloadImage(image);
+        }
+    }
+
+    private static ContainerRuntime RenderTargetCell(int size)
+    {
+        ContainerRuntime container = new();
+        container.Width = size;
+        container.Height = size;
+        container.IsRenderTarget = true;
+        return container;
+    }
+
+    private static ColoredRectangleRuntime Background(int size, Color color)
+    {
+        ColoredRectangleRuntime rectangle = new();
+        rectangle.Width = size;
+        rectangle.Height = size;
+        rectangle.Color = color;
+        return rectangle;
+    }
+
+    // SpriteRuntime defaults WidthUnits/HeightUnits to PercentageOfSourceFile, so Width/Height must
+    // be forced to Absolute here — otherwise "Width = size" is read as "size% of the source
+    // texture", shrinking a 4px test texture to a near-invisible sliver.
+    private static SpriteRuntime MaskerSprite(int size, Color textureColor, Blend blend)
+    {
+        Image image = GenImageColor(4, 4, textureColor);
+        Texture2D texture = LoadTextureFromImage(image);
+        UnloadImage(image);
+
+        SpriteRuntime sprite = new();
+        sprite.WidthUnits = DimensionUnitType.Absolute;
+        sprite.HeightUnits = DimensionUnitType.Absolute;
+        sprite.Width = size;
+        sprite.Height = size;
+        sprite.Texture = texture;
+        sprite.Blend = blend;
+        return sprite;
+    }
+
+    [Fact]
+    public void Draw_ReplaceBlendSprite_OverwritesDestinationColorIgnoringAlpha()
+    {
+        int size = 32;
+        ContainerRuntime cell = RenderTargetCell(size);
+        cell.Children.Add(Background(size, new Color((byte)0, (byte)255, (byte)0, (byte)255)));
+        cell.Children.Add(MaskerSprite(size, new Color((byte)255, (byte)0, (byte)0, (byte)128), Blend.Replace));
+
+        GumService.Default.Root.Children.Add(cell);
+        GumService.Default.Root.UpdateLayout();
+
+        DrawOnce();
+
+        Color center = ReadRenderTargetCenter(Renderer.Self.TryGetBakedRenderTargetFor(cell)!.Value);
+
+        // Replace overwrites the destination outright (color factors One/Zero) — the half-alpha
+        // red texture must fully replace the green background, not blend with it.
+        center.R.ShouldBeGreaterThan((byte)200);
+        center.G.ShouldBeLessThan((byte)50);
+
+        GumService.Default.Root.Children.Clear();
+    }
+
+    [Fact]
+    public void Draw_ReplaceAlphaBlendSprite_OverwritesDestinationAlphaOnly()
+    {
+        int size = 32;
+        ContainerRuntime cell = RenderTargetCell(size);
+        cell.Children.Add(Background(size, new Color((byte)255, (byte)0, (byte)0, (byte)255)));
+        cell.Children.Add(MaskerSprite(size, new Color((byte)0, (byte)0, (byte)0, (byte)50), Blend.ReplaceAlpha));
+
+        GumService.Default.Root.Children.Add(cell);
+        GumService.Default.Root.UpdateLayout();
+
+        DrawOnce();
+
+        Color center = ReadRenderTargetCenter(Renderer.Self.TryGetBakedRenderTargetFor(cell)!.Value);
+
+        // ReplaceAlpha leaves color untouched (color factors Zero/One) but overwrites alpha with
+        // the masker's alpha (alpha factors One/Zero) rather than blending it with the background's.
+        center.R.ShouldBeGreaterThan((byte)200);
+        center.A.ShouldBeInRange((byte)30, (byte)70);
+
+        GumService.Default.Root.Children.Clear();
+    }
+
+    [Fact]
+    public void Draw_SubtractAlphaBlendSprite_PunchesHoleInDestinationAlpha()
+    {
+        int size = 32;
+        ContainerRuntime cell = RenderTargetCell(size);
+        cell.Children.Add(Background(size, new Color((byte)255, (byte)0, (byte)0, (byte)255)));
+        cell.Children.Add(MaskerSprite(size, new Color((byte)0, (byte)0, (byte)0, (byte)255), Blend.SubtractAlpha));
+
+        GumService.Default.Root.Children.Add(cell);
+        GumService.Default.Root.UpdateLayout();
+
+        DrawOnce();
+
+        Color center = ReadRenderTargetCenter(Renderer.Self.TryGetBakedRenderTargetFor(cell)!.Value);
+
+        // SubtractAlpha reverse-subtracts the masker's opaque alpha from the destination's opaque
+        // alpha, punching a fully-transparent hole (255 - 255 = 0).
+        center.A.ShouldBeLessThan((byte)20);
+
+        GumService.Default.Root.Children.Clear();
+    }
+
+    [Fact]
+    public void Draw_MinAlphaBlendSprite_KeepsLowerOfTheTwoAlphas()
+    {
+        int size = 32;
+        ContainerRuntime cell = RenderTargetCell(size);
+        cell.Children.Add(Background(size, new Color((byte)255, (byte)0, (byte)0, (byte)200)));
+        cell.Children.Add(MaskerSprite(size, new Color((byte)0, (byte)0, (byte)0, (byte)100), Blend.MinAlpha));
+
+        GumService.Default.Root.Children.Add(cell);
+        GumService.Default.Root.UpdateLayout();
+
+        DrawOnce();
+
+        Color center = ReadRenderTargetCenter(Renderer.Self.TryGetBakedRenderTargetFor(cell)!.Value);
+
+        // MinAlpha keeps whichever alpha is lower — min(200, 100) = 100.
+        center.A.ShouldBeInRange((byte)80, (byte)120);
+
+        GumService.Default.Root.Children.Clear();
+    }
+}

--- a/Tests/RaylibGum.Tests/Rendering/RendererDrawCallMatrixTests.cs
+++ b/Tests/RaylibGum.Tests/Rendering/RendererDrawCallMatrixTests.cs
@@ -173,25 +173,35 @@ public class RendererDrawCallMatrixTests : BaseTestClass
     }
 
     // ---- Blend mode: a blended sprite wraps its draw in BeginBlendMode/EndBlendMode (both flush);
-    //      the draw must still be banked (without routing those flushes it would be lost). ----
+    //      the draw must still be banked (without routing those flushes it would be lost). Every
+    //      Blend value is covered here (not just Additive) because Replace/ReplaceAlpha/
+    //      SubtractAlpha/MinAlpha (issue #3470) now route through the separate-factors
+    //      BeginBlendMode(Blend) overload instead of the simple BlendMode one, and a regression
+    //      that skipped the counted wrapper for that path would only show up on those values. ----
 
-    [Fact]
-    public void BlendedSprite_RendersAndIsCountedAcrossBlendFlushes()
+    [Theory]
+    [InlineData(global::Gum.RenderingLibrary.Blend.Normal)]
+    [InlineData(global::Gum.RenderingLibrary.Blend.Additive)]
+    [InlineData(global::Gum.RenderingLibrary.Blend.Replace)]
+    [InlineData(global::Gum.RenderingLibrary.Blend.ReplaceAlpha)]
+    [InlineData(global::Gum.RenderingLibrary.Blend.SubtractAlpha)]
+    [InlineData(global::Gum.RenderingLibrary.Blend.MinAlpha)]
+    public void BlendedSprite_RendersAndIsCountedAcrossBlendFlushes(global::Gum.RenderingLibrary.Blend blend)
     {
         Texture2D texture = CreateTexture();
 
         int baseline = CountWith();
-        int blended = CountWith(BlendedSprite(texture));
+        int blended = CountWith(BlendedSprite(texture, blend));
 
         blended.ShouldBeGreaterThan(baseline);
 
         UnloadTexture(texture);
     }
 
-    private static SpriteRuntime BlendedSprite(Texture2D texture)
+    private static SpriteRuntime BlendedSprite(Texture2D texture, global::Gum.RenderingLibrary.Blend blend)
     {
         SpriteRuntime sprite = Sprite(texture);
-        sprite.Blend = global::Gum.RenderingLibrary.Blend.Additive;
+        sprite.Blend = blend;
         return sprite;
     }
 

--- a/Tests/SkiaGum.Tests/Renderables/BlendTests.cs
+++ b/Tests/SkiaGum.Tests/Renderables/BlendTests.cs
@@ -78,9 +78,10 @@ public class BlendTests
         paint.BlendMode.ShouldBe(SKBlendMode.DstOut);
     }
 
-    // ReplaceAlpha and MinAlpha have no clean SkiaSharp equivalent. Mirror the Raylib precedent
-    // (see Runtimes/RaylibGum/Renderables/BlendModeExtensions.cs) and fall through to the default
-    // SrcOver rather than picking a Skia mode that would silently change visuals.
+    // ReplaceAlpha and MinAlpha have no clean SkiaSharp equivalent — SKBlendMode has no separate
+    // per-channel blend-factor/equation override the way raylib's rlgl does (see
+    // Runtimes/RaylibGum/Renderables/BlendModeExtensions.cs, issue #3470), so fall through to the
+    // default SrcOver rather than picking a Skia mode that would silently change visuals.
     [Fact]
     public void Sprite_GetPaint_ReplaceAlpha_FallsThroughToSrcOver()
     {


### PR DESCRIPTION
## Summary

- `Runtimes/RaylibGum/Renderables/BlendModeExtensions.cs` only mapped `Blend.Additive`; every other Gum `Blend` value (`Replace`, `ReplaceAlpha`, `SubtractAlpha`, `MinAlpha`) silently fell through to `BlendMode.Alpha`.
- Reuses the existing backend-agnostic `Gum.BlendState` model (the same one MonoGame's `BlendExtensions.ToBlendState` turns into XNA `BlendState` objects) and maps its abstract blend-factor/equation fields onto raylib's low-level `Rlgl.SetBlendFactorsSeparate` + `BlendMode.CustomSeparate` — the same mechanism this codebase already uses for the render-target premultiply/additive-premultiplied passes (`BatchDrawCallCounter.cs`). This gives raylib parity with MonoGame's blend semantics rather than an approximation.
- `Sprite`, `NineSlice`, and (as a side effect of the shared `BeginBlendMode(Blend)` overload) `RectangleRuntime`'s raylib `LineRectangle` backing all pick up the fix for free — one shared mapping, three call sites.
- Updated stale doc comments describing the old "only Additive maps" limitation (`LineRectangle.cs`, a `SkiaGum.Tests` cross-reference comment).

## Test plan
- [x] New pixel-readback tests (`Tests/RaylibGum.Tests/Rendering/BlendModeRenderTests.cs`) prove each of the 4 previously-broken modes produces its distinct, correct GPU result — verified red against the pre-fix mapping (via `git stash`) and green against the fix.
- [x] Extended the existing draw-call-count regression test (`RendererDrawCallMatrixTests.BlendedSprite_RendersAndIsCountedAcrossBlendFlushes`) to a `[Theory]` covering all 6 `Blend` values, confirming every mode still routes through the counted `BeginBlendMode` wrapper.
- [x] Full `RaylibGum.Tests` suite green (409/409), no regressions.
- [x] Added the alpha-only blend row to `Samples/raylib/Screens/SpriteScreen.cs`, mirroring the MonoGame sample (which already had it) — removed the stale "raylib can't do this" comment.
- [ ] Manual: Visual Studio is open on `Samples/raylib/RaylibSample.sln`. Run it, click the **Sprite** nav button, and check the two blend rows near the bottom:
  - "Blend, normal rendering (Normal, Additive, Replace)" — the Replace cell should now look like a flat, un-blended bear (no background bleed-through), visibly different from Normal.
  - "Blend, alpha-only on render-target Container (SubtractAlpha, ReplaceAlpha, MinAlpha)" — a new row; SubtractAlpha punches a transparent bear-shaped hole in the red square, ReplaceAlpha/MinAlpha show the bear silhouette at differing opacity.

Closes #3470
