### PR TITLE
raylib: fix window background going black when an off-camera render-target container bakes (#3475)

### DIFF
--- a/RenderingLibrary/Graphics/RenderTargetService.cs
+++ b/RenderingLibrary/Graphics/RenderTargetService.cs
@@ -51,6 +51,17 @@ public abstract class RenderTargetServiceBase<TRenderTarget>
     /// fresh one if none exists or resizing if the existing one's dimensions differ. Marks
     /// the owner as "used this frame" so <see cref="ClearUnusedRenderTargetsLastFrame"/>
     /// won't sweep it. Returns <c>default</c> for non-positive sizes.
+    ///
+    /// <para><b>Value-type footgun:</b> <c>TRenderTarget</c> is unconstrained, so <c>TRenderTarget?</c>
+    /// is an unconstrained nullable — NOT <c>Nullable&lt;TRenderTarget&gt;</c>. When a backend
+    /// instantiates this with a <b>struct</b> render target (raylib's <c>RenderTexture2D</c>), the
+    /// <c>default</c> returned here is a <b>zeroed struct, not null</b>, and a caller's
+    /// <c>if (result == null)</c> can never catch it (the plain struct lifts to a non-null nullable).
+    /// A struct-backed consumer must therefore guard on the requested <c>width</c>/<c>height</c> being
+    /// positive itself rather than null-checking the result — see the raylib renderer's
+    /// <c>BakeRenderTarget</c> (a missing guard let a zeroed <c>RenderTexture2D</c> bind FBO id 0, the
+    /// default framebuffer, and clear the whole screen — issue #3475). Class-backed backends
+    /// (MonoGame's <c>RenderTarget2D</c>) get a real null and are unaffected.</para>
     /// </summary>
     public TRenderTarget? GetFor(IRenderableIpso owner, int width, int height)
     {

--- a/Runtimes/RaylibGum/RenderingLibrary/Renderer.cs
+++ b/Runtimes/RaylibGum/RenderingLibrary/Renderer.cs
@@ -519,6 +519,21 @@ public class Renderer : IRenderer
         ComputeRenderTargetBounds(container, out float left, out float top, out _, out _,
             out int width, out int height);
 
+        // Skip the bake when the container clamps to a non-positive size — a 0-sized pre-layout
+        // container, or (the #3475 case) one positioned entirely off-camera. This size guard is what
+        // actually stops the off-camera bake: GetFor returns default(RenderTexture2D) for a
+        // non-positive size, but because RenderTexture2D is a value type that default does NOT read as
+        // null through the RenderTexture2D? local below — RenderTargetServiceBase's TRenderTarget? is
+        // an unconstrained nullable, not a Nullable<>, so a plain (even zeroed) struct lifts to a
+        // non-null nullable and the `== null` check can never fire here. Without this guard,
+        // BeginTextureMode would bind the zeroed texture's FBO id 0 (the default framebuffer) and the
+        // ClearBackground below would wipe the whole window to transparent black. Mirrors the matching
+        // guard in TryCompositeRenderTarget.
+        if (width <= 0 || height <= 0)
+        {
+            return;
+        }
+
         IRenderableIpso cacheOwner = ResolveRenderTargetCacheOwner(container);
         RenderTexture2D? renderTexture = _renderTargetService.GetFor(cacheOwner, width, height);
         if (renderTexture == null)

--- a/Tests/RaylibGum.Tests/Rendering/RenderTargetTests.cs
+++ b/Tests/RaylibGum.Tests/Rendering/RenderTargetTests.cs
@@ -209,6 +209,47 @@ public class RenderTargetTests : BaseTestClass
         GumService.Default.Root.Children.Clear();
     }
 
+    // #3475: a render-target container positioned entirely off-camera clamps to a non-positive size.
+    // Its bake must be skipped, NOT run against the zeroed RenderTexture2D that GetFor returns for a
+    // non-positive size. That zeroed texture's FBO id is 0 — the default framebuffer — so
+    // BeginTextureMode would bind the screen and the bake's ClearBackground would wipe the whole
+    // window to transparent black (the reported symptom). This headless harness has no reliable
+    // screen readback, so the guarantee is pinned via draw-call count: an off-camera render-target
+    // container must cost exactly what the SAME off-camera container costs as a plain (non-RT)
+    // container — i.e. no extra bake work. Under the bug the errant bake re-drew the child a second
+    // time (offscreen), inflating the count above the plain-container baseline.
+    [Fact]
+    public void Draw_OffCameraRenderTarget_DoesNotBakeAgainstDefaultFramebuffer()
+    {
+        ContainerRuntime container = new();
+        container.Width = 100;
+        container.Height = 100;
+        // Far past the 800px-wide test camera's right edge, so ComputeRenderTargetBounds clamps to a
+        // negative width — the container is entirely off-camera.
+        container.X = 100000;
+        container.Y = 0;
+
+        ColoredRectangleRuntime rectangle = new();
+        rectangle.Width = 100;
+        rectangle.Height = 100;
+        rectangle.Color = new Color((byte)0, (byte)255, (byte)0, (byte)255);
+        container.Children.Add(rectangle);
+        container.AddToManagers();
+        container.UpdateLayout();
+
+        container.IsRenderTarget = false;
+        int plainContainerCalls = DrawAndCountDrawCalls();
+
+        container.IsRenderTarget = true;
+        int renderTargetCalls = DrawAndCountDrawCalls();
+
+        // Off-camera: nothing bakes, so the render-target container costs the same as the plain one.
+        Renderer.Self.HasBakedRenderTargetFor(container).ShouldBeFalse();
+        renderTargetCalls.ShouldBe(plainContainerCalls);
+
+        container.RemoveFromManagers();
+    }
+
     // Fix 2: after a blend-toggling child (a nested inner RT composite), a following semi-transparent
     // sibling must still bake under the premultiply pass — not straight alpha, which would halve its
     // coverage (the double-blend fringe). The sibling occupies the right half at full alpha coverage.


### PR DESCRIPTION
Closes #3475.

## Root cause

An off-camera render-target container clamps to a **non-positive** size in `ComputeRenderTargetBounds` (its left edge is past the camera's right edge, so `right - left < 0`).

`BakeRenderTarget` was supposed to skip that case via a `renderTexture == null` check on `RenderTargetServiceBase.GetFor`. But `GetFor` returns `TRenderTarget?` on an **unconstrained** type parameter. For raylib's **struct** `RenderTexture2D`, `TRenderTarget?` is an *unconstrained nullable* — **not** `Nullable<RenderTexture2D>`. So `GetFor` returns `default(RenderTexture2D)` (a zeroed struct, `Id = 0`), which lifts to a **non-null** `Nullable<>` at the call site — the `== null` check can never fire.

The bake then called `BeginTextureMode` on the zeroed texture, whose **FBO id 0 is the default framebuffer (the screen)**, and `ClearBackground(transparent)` wiped the whole window to black. That's the reported symptom: narrow the window until a render-target gallery cell is fully off-camera → background flips from blue to black.

`TryCompositeRenderTarget` escaped this only because it has a *second* `width <= 0 || height <= 0` guard; `BakeRenderTarget` had none.

This also explains issue-point-4's "loose thread" (the shadowed shape's `DrawGumRecursively` running *before* the main walk): that was the errant `BakeRenderTarget` executing during the bake pre-pass.

## Fix

- `Renderer.BakeRenderTarget`: guard on positive `width`/`height` before `GetFor`, mirroring `TryCompositeRenderTarget`'s existing guard.
- Documented the value-type footgun on `RenderTargetServiceBase.GetFor` so struct-backed backends guard on size rather than null-checking the result. MonoGame (class `RenderTarget2D`) gets a real null and was unaffected.

## Test

`Draw_OffCameraRenderTarget_DoesNotBakeAgainstDefaultFramebuffer` pins that an off-camera RT container costs the **same draw calls** as the same off-camera *plain* (non-RT) container — i.e. no errant bake. Red before the fix (2 vs 1 draw call), green after. Headless screen readback is unreliable in the test harness, so the wrongful bake's draw-call side effect is the observable.

Full `RaylibGum.Tests` suite: 411/411 green.

## Manual test

Needed (real-window only). raylib gallery → Render Target page → narrow the window until "Blurred shadow in RT" is off-camera → background stays blue (was black).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
