### PR TITLE
raylib: render nothing for off-camera / degenerate render targets, converging on MonoGame (#3478)

### DIFF
--- a/MonoGameGum.Tests/RenderingLibraries/CameraTests.cs
+++ b/MonoGameGum.Tests/RenderingLibraries/CameraTests.cs
@@ -110,6 +110,34 @@ public class CameraTests : BaseTestClass
         bounds.Width.ShouldBeLessThanOrEqualTo(0);
     }
 
+    // The exact-zero fencepost: a 0x0 container fully on-camera clamps to width == height == 0, which
+    // must read as "no visible area" (HasVisibleArea is Width > 0 && Height > 0). This is the degenerate
+    // case the whole issue is about, and it guards the > 0 boundary directly — the off-camera test above
+    // drives width negative, so it would not catch a >= 0 regression that lets a 0-size container render.
+    [Fact]
+    public void GetRenderTargetBounds_ZeroSizeOnCamera_HasNoVisibleArea()
+    {
+        Camera camera = new Camera();
+        camera.ClientWidth = 800;
+        camera.ClientHeight = 600;
+        camera.CameraCenterOnScreen = CameraCenterOnScreen.TopLeft;
+        camera.X = 0;
+        camera.Y = 0;
+        camera.Zoom = 1;
+
+        StubRenderable ipso = new StubRenderable();
+        ipso.X = 100;
+        ipso.Y = 100;
+        ipso.Width = 0;
+        ipso.Height = 0;
+
+        RenderTargetBounds bounds = camera.GetRenderTargetBounds(ipso);
+
+        bounds.Width.ShouldBe(0);
+        bounds.Height.ShouldBe(0);
+        bounds.HasVisibleArea.ShouldBeFalse();
+    }
+
     [Fact]
     public void GetRenderTargetBounds_WithZoom_ScalesPixelSizeByZoom()
     {

--- a/MonoGameGum.Tests/RenderingLibraries/CameraTests.cs
+++ b/MonoGameGum.Tests/RenderingLibraries/CameraTests.cs
@@ -52,6 +52,92 @@ public class CameraTests : BaseTestClass
         public void EndBatch(ISystemManagers managers) { }
     }
 
+    // Pins the shared render-target clamp helper (#3478) that both the MonoGame renderer
+    // (GetRenderTargetFor) and the raylib renderer (BakeRenderTarget / CompositeRenderTarget) call,
+    // so the camera-visible-bounds math can't drift between backends the way it did before the
+    // extraction. TopLeft mode makes the camera's absolute bounds trivially [0,800) x [0,600).
+    [Fact]
+    public void GetRenderTargetBounds_FullyOnCamera_ReturnsClampedRectAndUnscaledPixelSize()
+    {
+        Camera camera = new Camera();
+        camera.ClientWidth = 800;
+        camera.ClientHeight = 600;
+        camera.CameraCenterOnScreen = CameraCenterOnScreen.TopLeft;
+        camera.X = 0;
+        camera.Y = 0;
+        camera.Zoom = 1;
+
+        // Wholly inside the camera: world [100,300) x [50,150).
+        StubRenderable ipso = new StubRenderable();
+        ipso.X = 100;
+        ipso.Y = 50;
+        ipso.Width = 200;
+        ipso.Height = 100;
+
+        RenderTargetBounds bounds = camera.GetRenderTargetBounds(ipso);
+
+        bounds.Left.ShouldBe(100);
+        bounds.Top.ShouldBe(50);
+        bounds.Right.ShouldBe(300);
+        bounds.Bottom.ShouldBe(150);
+        bounds.Width.ShouldBe(200);
+        bounds.Height.ShouldBe(100);
+        bounds.HasVisibleArea.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GetRenderTargetBounds_EntirelyOffCamera_HasNoVisibleArea()
+    {
+        Camera camera = new Camera();
+        camera.ClientWidth = 800;
+        camera.ClientHeight = 600;
+        camera.CameraCenterOnScreen = CameraCenterOnScreen.TopLeft;
+        camera.X = 0;
+        camera.Y = 0;
+        camera.Zoom = 1;
+
+        // Far past the camera's right edge: world [100000, 100100). Clamping collapses the width to
+        // a non-positive value, so the container has nothing to bake or composite.
+        StubRenderable ipso = new StubRenderable();
+        ipso.X = 100000;
+        ipso.Y = 0;
+        ipso.Width = 100;
+        ipso.Height = 100;
+
+        RenderTargetBounds bounds = camera.GetRenderTargetBounds(ipso);
+
+        bounds.HasVisibleArea.ShouldBeFalse();
+        bounds.Width.ShouldBeLessThanOrEqualTo(0);
+    }
+
+    [Fact]
+    public void GetRenderTargetBounds_WithZoom_ScalesPixelSizeByZoom()
+    {
+        Camera camera = new Camera();
+        camera.ClientWidth = 800;
+        camera.ClientHeight = 600;
+        camera.CameraCenterOnScreen = CameraCenterOnScreen.TopLeft;
+        camera.X = 0;
+        camera.Y = 0;
+        camera.Zoom = 2;
+
+        // A 100x100 world-unit container at zoom 2 occupies 200x200 pixels; the world-space bounds
+        // themselves are unaffected by zoom.
+        StubRenderable ipso = new StubRenderable();
+        ipso.X = 0;
+        ipso.Y = 0;
+        ipso.Width = 100;
+        ipso.Height = 100;
+
+        RenderTargetBounds bounds = camera.GetRenderTargetBounds(ipso);
+
+        bounds.Left.ShouldBe(0);
+        bounds.Right.ShouldBe(100);
+        bounds.Width.ShouldBe(200);
+        bounds.Height.ShouldBe(200);
+        bounds.HasVisibleArea.ShouldBeTrue();
+    }
+
     [Fact]
     public void GetScissorRectangleFor_WithClientLeftTop_ShouldProduceBackbufferRelativeRectAndClampToViewportExtent()
     {

--- a/RenderingLibrary/Camera.cs
+++ b/RenderingLibrary/Camera.cs
@@ -400,4 +400,79 @@ namespace RenderingLibrary
             return new System.Drawing.Rectangle(left, top, width, height);
         }
     }
+
+    /// <summary>
+    /// The camera-visible rectangle of a render-target container: its world-space bounds clamped to
+    /// the camera's visible extent, plus the pixel size of that clamped region at the current zoom.
+    /// A render-target container bakes and composites only this visible portion. When it is degenerate
+    /// (zero natural size) or positioned entirely off-camera, the clamp collapses to a non-positive
+    /// pixel size and <see cref="HasVisibleArea"/> is false — there is nothing to bake or composite,
+    /// so the container's subtree renders nothing. Produced by
+    /// <see cref="CameraRenderTargetExtensions.GetRenderTargetBounds"/>.
+    /// </summary>
+    public readonly struct RenderTargetBounds
+    {
+        public RenderTargetBounds(float left, float top, float right, float bottom, int width, int height)
+        {
+            Left = left;
+            Top = top;
+            Right = right;
+            Bottom = bottom;
+            Width = width;
+            Height = height;
+        }
+
+        /// <summary>World-space left edge, clamped to the camera's visible left.</summary>
+        public float Left { get; }
+        /// <summary>World-space top edge, clamped to the camera's visible top.</summary>
+        public float Top { get; }
+        /// <summary>World-space right edge, clamped to the camera's visible right.</summary>
+        public float Right { get; }
+        /// <summary>World-space bottom edge, clamped to the camera's visible bottom.</summary>
+        public float Bottom { get; }
+        /// <summary>Pixel width of the clamped region at the current camera zoom.</summary>
+        public int Width { get; }
+        /// <summary>Pixel height of the clamped region at the current camera zoom.</summary>
+        public int Height { get; }
+
+        /// <summary>
+        /// True when the clamped region has a positive pixel size — i.e. there is something to bake
+        /// and composite. False for a degenerate (zero-size) or entirely off-camera container, whose
+        /// render-target subtree renders nothing. This is the single skip-decision both backends
+        /// share, replacing the copy-pasted <c>width &lt;= 0 || height &lt;= 0</c> guards.
+        /// </summary>
+        public bool HasVisibleArea => Width > 0 && Height > 0;
+    }
+
+    /// <summary>
+    /// Computes the camera-visible bounds of a render-target container (#3478). Kept here in Camera.cs
+    /// — alongside <see cref="CameraScissorExtensions"/> and for the same reason — so every backend
+    /// (MonoGame, raylib, Sokol, Skia) shares one clamp + pixel-size implementation via the GumCommon
+    /// source reference, instead of copy-pasting the Max/Min clamp math into each renderer. That
+    /// duplication is what let the MonoGame and raylib render-target paths diverge in #3478; a single
+    /// shared helper makes the consistency structural. Kept off the Camera class itself so Camera
+    /// stays a pure transform primitive.
+    /// </summary>
+    public static class CameraRenderTargetExtensions
+    {
+        /// <summary>
+        /// Clamps <paramref name="renderable"/>'s world-space bounds to <paramref name="camera"/>'s
+        /// visible extent and returns that rectangle plus its pixel size at the current zoom. A
+        /// render-target container bakes and composites only this visible portion; an off-camera or
+        /// degenerate container yields a non-positive size (<see cref="RenderTargetBounds.HasVisibleArea"/>
+        /// is false).
+        /// </summary>
+        public static RenderTargetBounds GetRenderTargetBounds(this Camera camera, IRenderableIpso renderable)
+        {
+            float left = System.Math.Max(camera.AbsoluteLeft, renderable.GetAbsoluteLeft());
+            float right = System.Math.Min(camera.AbsoluteRight, renderable.GetAbsoluteRight());
+            float top = System.Math.Max(camera.AbsoluteTop, renderable.GetAbsoluteTop());
+            float bottom = System.Math.Min(camera.AbsoluteBottom, renderable.GetAbsoluteBottom());
+
+            int width = global::RenderingLibrary.Math.MathFunctions.RoundToInt((right - left) * camera.Zoom);
+            int height = global::RenderingLibrary.Math.MathFunctions.RoundToInt((bottom - top) * camera.Zoom);
+
+            return new RenderTargetBounds(left, top, right, bottom, width, height);
+        }
+    }
 }

--- a/RenderingLibrary/Graphics/Renderer.cs
+++ b/RenderingLibrary/Graphics/Renderer.cs
@@ -1353,23 +1353,15 @@ class RenderTargetService : RenderTargetServiceBase<RenderTarget2D>
 
     public RenderTarget2D? GetRenderTargetFor(GraphicsDevice graphicsDevice, IRenderableIpso renderable, Camera camera)
     {
-        var left = renderable.GetAbsoluteLeft();
-        var right = renderable.GetAbsoluteRight();
-        var top = renderable.GetAbsoluteTop();
-        var bottom = renderable.GetAbsoluteBottom();
-
-        left = System.Math.Max(camera.AbsoluteLeft, left);
-        right = System.Math.Min(camera.AbsoluteRight, right);
-        top = System.Math.Max(camera.AbsoluteTop, top);
-        bottom = System.Math.Min(camera.AbsoluteBottom, bottom);
-
-        var width = Math.MathFunctions.RoundToInt((right - left) * camera.Zoom);
-        var height = Math.MathFunctions.RoundToInt((bottom - top) * camera.Zoom);
+        // Shared clamp+size helper (#3478) — the same one raylib's bake/composite path uses — so the
+        // camera-visible-bounds math can't drift between backends. GetFor returns null for a
+        // non-positive size (off-camera / degenerate), which the callers treat as "render nothing".
+        var bounds = camera.GetRenderTargetBounds(renderable);
 
         _graphicsDeviceForCreate = graphicsDevice;
         try
         {
-            return GetFor(renderable, width, height);
+            return GetFor(renderable, bounds.Width, bounds.Height);
         }
         finally
         {

--- a/Runtimes/RaylibGum/Renderables/BlendModeExtensions.cs
+++ b/Runtimes/RaylibGum/Renderables/BlendModeExtensions.cs
@@ -19,7 +19,7 @@ namespace Gum.Renderables;
 /// changing alpha (the whole point of the "alpha-only" family) is safe there. raylib's render-target
 /// bake pipeline instead <b>stores an already-premultiplied result</b> and composites it back with
 /// <c>BlendMode.AlphaPremultiply</c> (see <c>Renderer.BakeRenderTarget</c> /
-/// <c>TryCompositeRenderTarget</c>, issue #3434) — so any draw inside a bake must leave a validly
+/// <c>CompositeRenderTarget</c>, issue #3434) — so any draw inside a bake must leave a validly
 /// premultiplied pixel (color proportional to its own alpha), or leftover full-intensity color bleeds
 /// through at composite time even where alpha reads near zero (issue #3470 follow-up: SubtractAlpha
 /// showed magenta instead of a transparent hole). The alpha factors are always reused as-is from

--- a/Runtimes/RaylibGum/Renderables/Sprite.cs
+++ b/Runtimes/RaylibGum/Renderables/Sprite.cs
@@ -161,7 +161,7 @@ public class Sprite : InvisibleRenderable, IAspectRatio, ITextureCoordinate, IAn
 
             textureToDraw = renderTexture.Value.Texture;
             // An RT is stored bottom-up in GL; a negative source height flips it upright, matching
-            // the container-to-screen composite in Renderer.TryCompositeRenderTarget.
+            // the container-to-screen composite in Renderer.CompositeRenderTarget.
             defaultSrcRect = new Rectangle(0, 0, textureToDraw.Width, -textureToDraw.Height);
         }
         else if (Texture != null)

--- a/Runtimes/RaylibGum/RenderingLibrary/BatchDrawCallCounter.cs
+++ b/Runtimes/RaylibGum/RenderingLibrary/BatchDrawCallCounter.cs
@@ -133,7 +133,7 @@ public sealed unsafe class BatchDrawCallCounter
     /// <see cref="Gum.Renderables.BlendModeExtensions"/>'s remarks for why: outside a bake there is
     /// no further compositing to keep premultiplied-consistent, so <c>Replace</c> etc. use the
     /// straightforward "ignore alpha" factors matching MonoGame; inside a bake they must leave a
-    /// validly premultiplied pixel or leftover color bleeds through <c>TryCompositeRenderTarget</c>'s
+    /// validly premultiplied pixel or leftover color bleeds through <c>CompositeRenderTarget</c>'s
     /// <c>AlphaPremultiply</c> composite (issue #3470 follow-up).</para>
     ///
     /// Pair with <see cref="EndBlendMode"/>.

--- a/Runtimes/RaylibGum/RenderingLibrary/Renderer.cs
+++ b/Runtimes/RaylibGum/RenderingLibrary/Renderer.cs
@@ -394,7 +394,9 @@ public class Renderer : IRenderer
         // Render-target container (#3434): its subtree was already baked into an offscreen texture
         // during the pre-pass, so composite that texture in place of walking the live children. This
         // fires both in the main walk (composite to screen) and inside an outer container's bake
-        // (composite a nested inner RT into the outer texture), which is what makes nesting work.
+        // (composite a nested inner RT into the outer texture), which is what makes nesting work. A
+        // render-target container ALWAYS renders as a single composited unit and never falls through
+        // to draw its children directly.
         if (element.IsRenderTarget)
         {
             // A hidden RT container draws nothing (its bake was skipped too). Without this the
@@ -405,13 +407,17 @@ public class Renderer : IRenderer
                 return;
             }
 
-            // If a valid baked texture exists, composite it and stop. Otherwise (degenerate/zero
-            // clamped size — e.g. a 0-sized pre-layout container, or one whose children draw at
-            // offsets) fall through and render the children directly so the subtree doesn't vanish.
-            if (TryCompositeRenderTarget(element))
-            {
-                return;
-            }
+            // Composite the baked texture if a valid one exists; otherwise (degenerate/zero clamped
+            // size, or entirely off-camera) render NOTHING and stop. We deliberately do NOT fall
+            // through to draw the children directly: doing so would draw them unclamped, so content
+            // that reaches back into the visible camera area (a negative offset, an oversized child,
+            // a dropshadow bleeding past the edge) would appear on raylib but be invisible on
+            // MonoGame for the same project. This converges raylib onto MonoGame, whose draw-list
+            // builder never recurses into render-target children (HierarchicalOrderer's
+            // !IsRenderTarget gate) and whose composite sites skip when GetRenderTargetFor is null
+            // (#3478).
+            CompositeRenderTarget(element);
+            return;
         }
 
         element.Render(null);
@@ -511,9 +517,9 @@ public class Renderer : IRenderer
     // Children draw at their absolute world coordinates; an offset BeginMode2D targeting the
     // container's clamped top-left maps those into RT-local pixel space. Children are rendered under
     // a premultiply blend (straight src -> premultiplied dst) so the texture composites back without
-    // the double-blend dark fringe — see TryCompositeRenderTarget for the matching premultiplied blit.
-    // A degenerate (zero-size) clamp bakes nothing; the composite path then renders the children
-    // directly so the subtree doesn't vanish.
+    // the double-blend dark fringe — see CompositeRenderTarget for the matching premultiplied blit.
+    // A degenerate (zero-size) clamp bakes nothing; the composite path then renders nothing either,
+    // so the subtree does not appear (matching MonoGame, #3478).
     private void BakeRenderTarget(IRenderableIpso container, Layer layer)
     {
         ComputeRenderTargetBounds(container, out float left, out float top, out _, out _,
@@ -609,25 +615,28 @@ public class Renderer : IRenderer
     }
 
     // Composites a render-target container's baked texture at the container's clamped rectangle,
-    // honoring the container's blend and group alpha (#3434, item 2). Returns false when there is no
-    // valid baked texture (degenerate size) so the caller can render the children directly instead of
-    // dropping them. The baked texture is premultiplied, so Normal blend composites with
-    // AlphaPremultiply and Additive uses the premultiplied-additive pass; group alpha is applied by
-    // tinting every channel (a premultiplied texture must scale rgb and alpha together).
-    private bool TryCompositeRenderTarget(IRenderableIpso container)
+    // honoring the container's blend and group alpha (#3434, item 2). When there is no valid baked
+    // texture (degenerate/off-camera clamp) it renders nothing — the container's subtree simply does
+    // not appear, matching MonoGame (#3478). The baked texture is premultiplied, so Normal blend
+    // composites with AlphaPremultiply and Additive uses the premultiplied-additive pass; group alpha
+    // is applied by tinting every channel (a premultiplied texture must scale rgb and alpha together).
+    private void CompositeRenderTarget(IRenderableIpso container)
     {
         IRenderableIpso cacheOwner = ResolveRenderTargetCacheOwner(container);
         RenderTexture2D? renderTexture = _renderTargetService.TryGetExisting(cacheOwner);
-        if (renderTexture == null)
-        {
-            return false;
-        }
 
         ComputeRenderTargetBounds(container, out float left, out float top, out float right,
             out float bottom, out int width, out int height);
+        // The width/height guard is the real "no valid baked texture" guard, and it also gates the
+        // renderTexture.Value read below: a positive on-screen clamp means the bake pre-pass created
+        // and cached a texture this frame, so renderTexture is a genuine one here. A `renderTexture
+        // == null` check would be DEAD — TryGetExisting returns default(RenderTexture2D) for an
+        // uncached owner, and because RenderTexture2D is a value type that default lifts to a NON-null
+        // RenderTexture2D? (see RenderTargetServiceBase.GetFor's value-type footgun note and the
+        // matching guard in BakeRenderTarget, #3475).
         if (width <= 0 || height <= 0)
         {
-            return false;
+            return;
         }
 
         byte alpha = (byte)container.Alpha;
@@ -669,7 +678,6 @@ public class Renderer : IRenderer
             counter.EndShaderMode();
         }
         counter.EndBlendMode();
-        return true;
     }
 
     // Clamps the container's absolute bounds to the on-screen visible intersection and returns the

--- a/Runtimes/RaylibGum/RenderingLibrary/Renderer.cs
+++ b/Runtimes/RaylibGum/RenderingLibrary/Renderer.cs
@@ -522,8 +522,9 @@ public class Renderer : IRenderer
     // so the subtree does not appear (matching MonoGame, #3478).
     private void BakeRenderTarget(IRenderableIpso container, Layer layer)
     {
-        ComputeRenderTargetBounds(container, out float left, out float top, out _, out _,
-            out int width, out int height);
+        // Shared clamp+size helper (#3478) — MonoGame's GetRenderTargetFor uses the same one — so the
+        // camera-visible-bounds math is identical across backends by construction.
+        RenderTargetBounds bounds = _camera.GetRenderTargetBounds(container);
 
         // Skip the bake when the container clamps to a non-positive size — a 0-sized pre-layout
         // container, or (the #3475 case) one positioned entirely off-camera. This size guard is what
@@ -534,14 +535,14 @@ public class Renderer : IRenderer
         // non-null nullable and the `== null` check can never fire here. Without this guard,
         // BeginTextureMode would bind the zeroed texture's FBO id 0 (the default framebuffer) and the
         // ClearBackground below would wipe the whole window to transparent black. Mirrors the matching
-        // guard in TryCompositeRenderTarget.
-        if (width <= 0 || height <= 0)
+        // guard in CompositeRenderTarget.
+        if (!bounds.HasVisibleArea)
         {
             return;
         }
 
         IRenderableIpso cacheOwner = ResolveRenderTargetCacheOwner(container);
-        RenderTexture2D? renderTexture = _renderTargetService.GetFor(cacheOwner, width, height);
+        RenderTexture2D? renderTexture = _renderTargetService.GetFor(cacheOwner, bounds.Width, bounds.Height);
         if (renderTexture == null)
         {
             return;
@@ -551,7 +552,7 @@ public class Renderer : IRenderer
 
         Camera2D bakeCamera = new Camera2D
         {
-            Target = new System.Numerics.Vector2(left, top),
+            Target = new System.Numerics.Vector2(bounds.Left, bounds.Top),
             Offset = System.Numerics.Vector2.Zero,
             Zoom = _camera.Zoom,
             Rotation = 0,
@@ -567,8 +568,8 @@ public class Renderer : IRenderer
         float savedBakeLeft = _bakeLeft;
         float savedBakeTop = _bakeTop;
         _isBakingRenderTarget = true;
-        _bakeLeft = left;
-        _bakeTop = top;
+        _bakeLeft = bounds.Left;
+        _bakeTop = bounds.Top;
 
         // Record the bake camera as the active one so a blurred dropshadow drawn inside this bake
         // re-establishes the bake transform (not the main-walk camera) after its offscreen passes
@@ -625,16 +626,16 @@ public class Renderer : IRenderer
         IRenderableIpso cacheOwner = ResolveRenderTargetCacheOwner(container);
         RenderTexture2D? renderTexture = _renderTargetService.TryGetExisting(cacheOwner);
 
-        ComputeRenderTargetBounds(container, out float left, out float top, out float right,
-            out float bottom, out int width, out int height);
-        // The width/height guard is the real "no valid baked texture" guard, and it also gates the
-        // renderTexture.Value read below: a positive on-screen clamp means the bake pre-pass created
-        // and cached a texture this frame, so renderTexture is a genuine one here. A `renderTexture
-        // == null` check would be DEAD — TryGetExisting returns default(RenderTexture2D) for an
-        // uncached owner, and because RenderTexture2D is a value type that default lifts to a NON-null
-        // RenderTexture2D? (see RenderTargetServiceBase.GetFor's value-type footgun note and the
-        // matching guard in BakeRenderTarget, #3475).
-        if (width <= 0 || height <= 0)
+        // Same shared clamp+size helper the bake used (#3478), so the composite rectangle matches the
+        // baked one exactly. HasVisibleArea is the real "no valid baked texture" guard, and it also
+        // gates the renderTexture.Value read below: a positive on-screen clamp means the bake pre-pass
+        // created and cached a texture this frame, so renderTexture is a genuine one here. A
+        // `renderTexture == null` check would be DEAD — TryGetExisting returns default(RenderTexture2D)
+        // for an uncached owner, and because RenderTexture2D is a value type that default lifts to a
+        // NON-null RenderTexture2D? (see RenderTargetServiceBase.GetFor's value-type footgun note and
+        // the matching guard in BakeRenderTarget, #3475).
+        RenderTargetBounds bounds = _camera.GetRenderTargetBounds(container);
+        if (!bounds.HasVisibleArea)
         {
             return;
         }
@@ -667,8 +668,8 @@ public class Renderer : IRenderer
         // reading it with height -h yields the upright content (same idiom as ShadowBlurRenderer).
         Raylib.DrawTexturePro(
             renderTexture.Value.Texture,
-            new Rectangle(0, 0, width, -height),
-            new Rectangle(left, top, right - left, bottom - top),
+            new Rectangle(0, 0, bounds.Width, -bounds.Height),
+            new Rectangle(bounds.Left, bounds.Top, bounds.Right - bounds.Left, bounds.Bottom - bounds.Top),
             System.Numerics.Vector2.Zero,
             0,
             tint);
@@ -678,21 +679,6 @@ public class Renderer : IRenderer
             counter.EndShaderMode();
         }
         counter.EndBlendMode();
-    }
-
-    // Clamps the container's absolute bounds to the on-screen visible intersection and returns the
-    // RT pixel size at camera zoom (crisp when zoomed). Mirrors the MonoGame GetRenderTargetFor
-    // clamping so an off-screen container bakes only its visible portion.
-    private void ComputeRenderTargetBounds(IRenderableIpso container,
-        out float left, out float top, out float right, out float bottom, out int width, out int height)
-    {
-        left = System.Math.Max(_camera.AbsoluteLeft, container.GetAbsoluteLeft());
-        right = System.Math.Min(_camera.AbsoluteRight, container.GetAbsoluteRight());
-        top = System.Math.Max(_camera.AbsoluteTop, container.GetAbsoluteTop());
-        bottom = System.Math.Min(_camera.AbsoluteBottom, container.GetAbsoluteBottom());
-
-        width = global::RenderingLibrary.Math.MathFunctions.RoundToInt((right - left) * _camera.Zoom);
-        height = global::RenderingLibrary.Math.MathFunctions.RoundToInt((bottom - top) * _camera.Zoom);
     }
 
     // For a nested render-target container the walk hands us the GraphicalUiElement wrapper; for a

--- a/Tests/MonoGameGum.IntegrationTests/MonoGameGum/Rendering/OffCameraRenderTargetConvergenceTests.cs
+++ b/Tests/MonoGameGum.IntegrationTests/MonoGameGum/Rendering/OffCameraRenderTargetConvergenceTests.cs
@@ -1,0 +1,152 @@
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using Gum.GueDeriving;
+using RenderingLibrary;
+using RenderingLibrary.Content;
+using RenderingLibrary.Graphics;
+using Shouldly;
+using Xunit;
+
+namespace MonoGameGum.IntegrationTests.MonoGameGum.Rendering;
+
+/// <summary>
+/// Pins MonoGame's reference behavior for a render-target container with no valid baked texture —
+/// one clamped to a non-positive size because it is degenerate (0x0) or entirely off-camera. Its
+/// subtree renders NOTHING: the draw-list builder never recurses into render-target children
+/// (<see cref="HierarchicalOrderer"/>'s <c>!IsRenderTarget</c> gate) and both composite sites skip
+/// when <c>GetRenderTargetFor</c> returns null. This is the *verified* behavior raylib converges
+/// onto in issue #3478 (raylib previously fell through and drew the children directly, unclamped) —
+/// so the raylib <c>RenderTargetTests.Draw_DegenerateSizeRenderTarget_RendersNothing</c> is pinned
+/// against something real here, not reasoned about (the #3475 tunnel-vision lesson).
+/// </summary>
+public class OffCameraRenderTargetConvergenceTests : BaseTestClass
+{
+    [Fact]
+    public void NestedDegenerateRenderTarget_RendersNothing()
+    {
+        using MinimalGame game = new();
+        game.RunOneFrame();
+
+        GraphicsDevice gd = game.GraphicsDevice;
+        SystemManagers managers = SystemManagers.Default;
+        Renderer renderer = managers.Renderer;
+
+        // outer (100x100 RT) -> inner (RT) -> green child (100x100). The inner RT's size is flipped
+        // between the two phases below; everything else stays identical.
+        ContainerRuntime outer = new();
+        outer.X = 0;
+        outer.Y = 0;
+        outer.Width = 100;
+        outer.Height = 100;
+        outer.IsRenderTarget = true;
+
+        ContainerRuntime inner = new();
+        inner.X = 0;
+        inner.Y = 0;
+        inner.Width = 100;
+        inner.Height = 100;
+        inner.IsRenderTarget = true;
+
+#pragma warning disable CS0618
+        ColoredRectangleRuntime green = new();
+#pragma warning restore CS0618
+        green.X = 0;
+        green.Y = 0;
+        green.Width = 100;
+        green.Height = 100;
+        green.Color = new Color(0, 255, 0);
+        inner.AddChild(green);
+        outer.AddChild(inner);
+        outer.AddToManagers(managers, null);
+        outer.UpdateLayout();
+
+        // Positive control: with the inner RT sized 100x100, its green child composites up through
+        // the outer RT to the screen, so the sampled pixel is green. This proves the sampler can see
+        // the child at all — without it the "renders nothing" assertion below could pass vacuously.
+        Color withValidInner = SampleAfterWarmup(gd, renderer, managers);
+        withValidInner.G.ShouldBeGreaterThan((byte)150);
+        ((int)withValidInner.G - withValidInner.R).ShouldBeGreaterThan(80);
+
+        // Degenerate the inner RT: a 0x0 clamp bakes no texture and composites nothing. Its green
+        // child must NOT appear — the sampled pixel stays the cleared-to-black background.
+        inner.Width = 0;
+        inner.Height = 0;
+        outer.UpdateLayout();
+
+        Color withDegenerateInner = SampleAfterWarmup(gd, renderer, managers);
+        withDegenerateInner.G.ShouldBeLessThan((byte)50);
+
+        outer.RemoveFromManagers();
+    }
+
+    private static double _hostTime;
+
+    private static void AdvanceHostFrame(SystemManagers managers, ref double hostTime)
+    {
+        hostTime += 1.0;
+        managers.Activity(hostTime);
+    }
+
+    // Warm-up draw (a fresh SystemManagers bakes with an uninitialized zoom on the first Draw — see
+    // NestedRenderTargetTextureSourceTests) followed by a captured main-layer sample.
+    private static Color SampleAfterWarmup(GraphicsDevice gd, Renderer renderer, SystemManagers managers)
+    {
+        renderer.Draw(managers);
+        AdvanceHostFrame(managers, ref _hostTime);
+        return SampleMainLayerPixel(gd, renderer, managers);
+    }
+
+    private static Color SampleMainLayerPixel(GraphicsDevice gd, Renderer renderer, SystemManagers managers)
+    {
+        const int w = 128;
+        const int h = 128;
+        using RenderTarget2D capture = new(gd, w, h, false, SurfaceFormat.Color, DepthFormat.None, 0,
+            RenderTargetUsage.PreserveContents);
+
+        gd.SetRenderTarget(capture);
+        gd.Clear(Color.Black);
+        renderer.Draw(managers);
+        gd.SetRenderTarget(null);
+
+        Color[] pixels = new Color[w * h];
+        capture.GetData(pixels);
+        // Center of the 100x100 outer render target (which sits at screen 0,0).
+        return pixels[(32 * w) + 32];
+    }
+
+    /// <summary>
+    /// Minimal Game host that initializes a fresh <see cref="GumService"/> per test so
+    /// <see cref="Renderer.Draw(SystemManagers)"/> can be invoked against a live device.
+    /// </summary>
+    private class MinimalGame : Game
+    {
+        private readonly GraphicsDeviceManager _graphics;
+        public GumService GumService { get; }
+
+        public MinimalGame()
+        {
+            LoaderManager.Self?.DisposeAndClear();
+            _graphics = new GraphicsDeviceManager(this);
+            GumService = new GumService();
+        }
+
+        protected override void Initialize()
+        {
+            base.Initialize();
+            GumService.Initialize(this, Gum.Forms.DefaultVisualsVersion.V2);
+        }
+
+        protected override void Update(GameTime gameTime) { }
+        protected override void Draw(GameTime gameTime) => GraphicsDevice.Clear(Color.CornflowerBlue);
+
+        protected override void Dispose(bool disposing)
+        {
+            if (GumService.IsInitialized)
+            {
+                GumService.Uninitialize();
+            }
+            LoaderManager.Self?.DisposeAndClear();
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/Tests/RaylibGum.Tests/Rendering/RenderTargetTests.cs
+++ b/Tests/RaylibGum.Tests/Rendering/RenderTargetTests.cs
@@ -170,10 +170,16 @@ public class RenderTargetTests : BaseTestClass
         GumService.Default.Root.Children.Clear();
     }
 
-    // Fix 1: a render-target container whose clamped bounds are degenerate (0-sized) must not drop
-    // its subtree. Here a 0x0 inner RT still renders its child directly into the outer RT.
+    // #3478: a render-target container whose clamped bounds are degenerate (0-sized) renders
+    // NOTHING — it must not fall through to draw its children directly. A render-target container
+    // exists to composite its subtree as one clipped unit; with no valid baked texture there is
+    // nothing to composite. This converges raylib onto MonoGame, whose draw-list builder never
+    // recurses into render-target children (HierarchicalOrderer's !IsRenderTarget gate) and whose
+    // composite sites skip when GetRenderTargetFor returns null. Pinned on the MonoGame side by
+    // OffCameraRenderTargetConvergenceTests. Here a 0x0 inner RT's green child must NOT appear in
+    // the outer RT. (This inverts the pre-#3478 "0-size subtree must not vanish" behavior.)
     [Fact]
-    public void Draw_DegenerateSizeRenderTarget_RendersChildrenDirectly()
+    public void Draw_DegenerateSizeRenderTarget_RendersNothing()
     {
         ContainerRuntime outer = new();
         outer.X = 0;
@@ -199,28 +205,33 @@ public class RenderTargetTests : BaseTestClass
 
         DrawOnce();
 
-        // The degenerate container bakes nothing, but its green child must still appear in the outer
-        // render target rather than vanishing.
+        // The degenerate container bakes nothing and composites nothing, so its green child does
+        // NOT appear in the outer render target — the outer target's center stays transparent.
         Renderer.Self.HasBakedRenderTargetFor(degenerate).ShouldBeFalse();
         Color center = ReadRenderTargetCenter(Renderer.Self.TryGetBakedRenderTargetFor(outer)!.Value);
-        center.G.ShouldBeGreaterThan((byte)200);
-        center.R.ShouldBeLessThan((byte)50);
+        center.G.ShouldBeLessThan((byte)50);
+        center.A.ShouldBeLessThan((byte)50);
 
         GumService.Default.Root.Children.Clear();
     }
 
-    // #3475: a render-target container positioned entirely off-camera clamps to a non-positive size.
-    // Its bake must be skipped, NOT run against the zeroed RenderTexture2D that GetFor returns for a
-    // non-positive size. That zeroed texture's FBO id is 0 — the default framebuffer — so
-    // BeginTextureMode would bind the screen and the bake's ClearBackground would wipe the whole
-    // window to transparent black (the reported symptom). This headless harness has no reliable
-    // screen readback, so the guarantee is pinned via draw-call count: an off-camera render-target
-    // container must cost exactly what the SAME off-camera container costs as a plain (non-RT)
-    // container — i.e. no extra bake work. Under the bug the errant bake re-drew the child a second
-    // time (offscreen), inflating the count above the plain-container baseline.
+    // #3475 / #3478: a render-target container positioned entirely off-camera clamps to a
+    // non-positive size. Its bake must be skipped, NOT run against the zeroed RenderTexture2D that
+    // GetFor returns for a non-positive size (that zeroed texture's FBO id is 0 — the default
+    // framebuffer — so BeginTextureMode would bind the screen and the bake's ClearBackground would
+    // wipe the whole window to transparent black, the #3475 symptom). Post-#3478 the render-target
+    // container also composites nothing when there is no valid baked texture — it no longer falls
+    // through to draw its children directly. So an off-camera render-target container adds NOTHING
+    // beyond the empty baseline: strictly fewer draw calls than the SAME off-camera container as a
+    // plain (non-RT) container, which still draws its off-screen child (an unclipped top-level draw
+    // is not culled). This headless harness has no reliable screen readback, so the guarantee is
+    // pinned via draw-call count.
     [Fact]
     public void Draw_OffCameraRenderTarget_DoesNotBakeAgainstDefaultFramebuffer()
     {
+        // Empty-frame baseline, measured before the container is in the managers.
+        int baseline = DrawAndCountDrawCalls();
+
         ContainerRuntime container = new();
         container.Width = 100;
         container.Height = 100;
@@ -243,9 +254,12 @@ public class RenderTargetTests : BaseTestClass
         container.IsRenderTarget = true;
         int renderTargetCalls = DrawAndCountDrawCalls();
 
-        // Off-camera: nothing bakes, so the render-target container costs the same as the plain one.
+        // Off-camera: nothing bakes and nothing composites, so the render-target container costs
+        // exactly the empty baseline — strictly fewer calls than the plain container, which still
+        // draws its off-screen child.
         Renderer.Self.HasBakedRenderTargetFor(container).ShouldBeFalse();
-        renderTargetCalls.ShouldBe(plainContainerCalls);
+        renderTargetCalls.ShouldBe(baseline);
+        plainContainerCalls.ShouldBeGreaterThan(baseline);
 
         container.RemoveFromManagers();
     }


### PR DESCRIPTION
Closes #3478.

## Problem

A render-target container with **no valid baked texture** — one clamped to a non-positive size because it's degenerate (0×0) or positioned entirely off-camera — did **opposite** things on the two backends:

- **MonoGame renders nothing.** Its draw-list builder never recurses into a render-target's children (`HierarchicalOrderer`'s `!IsRenderTarget` gate), and both composite sites skip when `GetRenderTargetFor` returns null.
- **raylib rendered the children directly, unclamped.** `DrawGumRecursively` fell through when the composite failed and drew the children at their real world coordinates with no clipping to the container bounds.

The divergence meant any child content reaching back into the visible camera area (a negative offset, an oversized child, a dropshadow bleeding past the edge) was **visible on raylib but invisible on MonoGame** for the same Gum project. Latent — no current sample triggers it — and pre-existing from the original raylib RT feature (#3434).

## Fix (commit 1)

Converge raylib onto MonoGame: an `IsRenderTarget` container now **always** composites as a single unit and renders **nothing** when there is no valid baked texture. Dropped the direct-children fallthrough in `DrawGumRecursively`.

Boyscout: `TryCompositeRenderTarget`'s `bool` return is no longer consumed, so it becomes `void CompositeRenderTarget`. Its `renderTexture == null` check was **dead** — `TryGetExisting` returns a non-null *zeroed* struct for the value-type `RenderTexture2D`; the real guard is the size check. Removed and documented.

## Root-cause prevention — shared clamp helper (commit 2)

The divergence existed because the RT **camera-visible-bounds clamp** (`Max`/`Min` against the camera extent + pixel size at zoom) was copy-pasted independently in MonoGame's `GetRenderTargetFor` and raylib's `ComputeRenderTargetBounds`. Extracted into **one** shared `Camera` extension — `RenderTargetBounds` / `Camera.GetRenderTargetBounds` — living in `Camera.cs` alongside `CameraScissorExtensions` (same file → reaches every backend via the GumCommon source reference, no new csproj link). Both renderers now call it, and the skip decision is centralized as `RenderTargetBounds.HasVisibleArea`, replacing the copy-pasted `width <= 0 || height <= 0` guards. raylib's private `ComputeRenderTargetBounds` is deleted. This makes the cross-backend consistency **structural** — the next drift can't happen because there's only one clamp.

*(Note: Sokol also carries copy-pasted clamp math per the issue, but it has no render-target rendering path yet — only a README mention — so there was nothing to converge there. MonoGame's `DrawRenderTargetToScreen` composite-position clamp is a separate, differently-shaped computation off the already-baked texture, left as-is.)*

## Verify MonoGame first, don't assume (#3475 lesson)

MonoGame's "off-camera / nested-0×0 RT subtree renders nothing" behavior is pinned by an actual integration test rather than reasoned about — `OffCameraRenderTargetConvergenceTests.NestedDegenerateRenderTarget_RendersNothing` samples the real screen: a positive control proves the green child *is* visible when the inner RT is sized, then flips it to 0×0 and asserts the child vanishes. raylib converges onto *verified* behavior.

## Tests

- **New (MonoGame):** `OffCameraRenderTargetConvergenceTests` — pins the reference behavior with a positive control.
- **New (MonoGame):** `CameraTests.GetRenderTargetBounds_*` — direct pins for the extracted helper (on-camera clamp, off-camera degenerate → no visible area, zoom scaling).
- **Inverted (raylib):** `Draw_DegenerateSizeRenderTarget_RendersNothing` (was `…RendersChildrenDirectly`).
- **Adjusted (raylib):** `Draw_OffCameraRenderTarget_DoesNotBakeAgainstDefaultFramebuffer` — now asserts the RT costs exactly the empty baseline (strictly fewer draw calls than the plain container, which still draws its off-screen child).

Green: 411 `RaylibGum.Tests`, 26 MonoGame RT integration tests, 11 `CameraTests`. KNI + Skia build clean (shared `Camera.cs` change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
