### PR TITLE
raylib Text: render BBCode inline Color/FontScale markup (#3471)

### DIFF
--- a/RenderingLibrary/Graphics/StyledSubstringSplitter.cs
+++ b/RenderingLibrary/Graphics/StyledSubstringSplitter.cs
@@ -4,6 +4,37 @@ using System.Linq;
 namespace RenderingLibrary.Graphics;
 
 /// <summary>
+/// A single styling directive parsed from a BBCode tag, covering a contiguous range of characters in the
+/// "stripped" (tags-removed) text. Produced when markup text is assigned to a Text renderable and consumed
+/// by <see cref="StyledSubstringSplitter"/> to break a line into styled runs. Lives here (rather than in a
+/// specific Text renderable) so every rendering backend can share both the model and the splitter.
+/// </summary>
+public class InlineVariable
+{
+    /// <summary>
+    /// Variable name, such as "Font". This translates to the left-side of the assignment in the tag. For example
+    /// [Font=Arial] would have a VariableName of "Font".
+    /// </summary>
+    public string VariableName;
+
+    /// <summary>
+    /// The start index of the tag in the "stripped" text (after all tags have been removed).
+    /// </summary>
+    public int StartIndex;
+
+    /// <summary>
+    /// The number of characters covered by this inline variable. This is the character count on the "stripped" text.
+    /// </summary>
+    public int CharacterCount;
+    public object Value;
+
+    public override string ToString()
+    {
+        return $"{VariableName} = {Value} at [{StartIndex}] for {CharacterCount} characters";
+    }
+}
+
+/// <summary>
 /// A single run of text within a line that shares the same set of active <see cref="InlineVariable"/>s,
 /// as produced by <see cref="StyledSubstringSplitter.GetStyledSubstrings"/>.
 /// </summary>

--- a/RenderingLibrary/Graphics/Text.cs
+++ b/RenderingLibrary/Graphics/Text.cs
@@ -40,36 +40,6 @@ public enum TextRenderingPositionMode
 
 #endregion
 
-#region InlineVariable
-
-public class InlineVariable
-{
-    /// <summary>
-    /// Variable name, such as "Font". This translates to the left-side of the assignment in the tag. For example
-    /// [Font=Arial] would have a VariableName of "Font".
-    /// </summary>
-    public string VariableName;
-
-    /// <summary>
-    /// The start index of the tag in the "stripped" text (after all tags have been removed).
-    /// </summary>
-    public int StartIndex;
-
-    /// <summary>
-    /// The number of characters covered by this inline variable. This is the character count on the "stripped" text.
-    /// </summary>
-    public int CharacterCount;
-    public object Value;
-
-    public override string ToString()
-    {
-        return $"{VariableName} = {Value} at [{StartIndex}] for {CharacterCount} characters";
-    }
-}
-
-#endregion
-
-
 #region LetterCustomization
 public struct LetterCustomization
 {

--- a/Runtimes/RaylibGum/RaylibGum.csproj
+++ b/Runtimes/RaylibGum/RaylibGum.csproj
@@ -163,6 +163,9 @@
 		<Compile Include="..\..\RenderingLibrary\Graphics\Fonts\ParsedFontFile.cs" Link="RenderingLibrary\Fonts\ParsedFontFile.cs" />
 		<Compile Include="..\..\RenderingLibrary\Graphics\RenderStateChangeStatistics.cs" Link="RenderingLibrary\RenderStateChangeStatistics.cs" />
 		<Compile Include="..\..\RenderingLibrary\Graphics\RenderTargetService.cs" Link="RenderingLibrary\RenderTargetService.cs" />
+		<!-- Shared markup model + run-splitter (InlineVariable, StyledSubstring, StyledSubstringSplitter)
+		     so Raylib's Text can render BBCode inline styling without reimplementing the split. #3471 -->
+		<Compile Include="..\..\RenderingLibrary\Graphics\StyledSubstringSplitter.cs" Link="RenderingLibrary\StyledSubstringSplitter.cs" />
 		<Compile Include="..\..\RenderingLibrary\Graphics\TextExtensions.cs" Link="Renderables\TextExtensions.cs" />
 		<Compile Include="..\..\MonoGameGum\Forms\DefaultFromFileVisuals\*.cs" Link="Forms\DefaultFromFileVisuals\%(Filename)%(Extension)" />
 	</ItemGroup>

--- a/Runtimes/RaylibGum/Renderables/CustomSetPropertyOnRenderable.cs
+++ b/Runtimes/RaylibGum/Renderables/CustomSetPropertyOnRenderable.cs
@@ -558,8 +558,17 @@ public class CustomSetPropertyOnRenderable
                 rawText = LocalizationService.Translate(rawText);
             }
 
-            textRenderable.RawText = rawText;
-            // todo - markup
+            textRenderable.InlineVariables.Clear();
+            if (rawText?.Contains("[") == true)
+            {
+                textRenderable.StoredMarkupText = rawText;
+                SetBbCodeText(textRenderable, graphicalUiElement, rawText);
+            }
+            else
+            {
+                textRenderable.StoredMarkupText = null;
+                textRenderable.RawText = rawText;
+            }
 
             // we want to update if the text's size is based on its "children" (the letters it contains)
             if (graphicalUiElement.WidthUnits == DimensionUnitType.RelativeToChildren ||
@@ -674,6 +683,77 @@ public class CustomSetPropertyOnRenderable
             }
         }
         return handled;
+    }
+
+    /// <summary>
+    /// Parses BBCode markup, assigns the tag-stripped text to <see cref="Text.RawText"/>, and populates
+    /// <see cref="Text.InlineVariables"/> with the Color / FontScale runs the Raylib renderer applies per run.
+    /// Font-swap and Custom per-letter tags are recognized (so their tags are stripped from the visible text)
+    /// but are not yet applied on the Raylib runtime - see #3471.
+    /// </summary>
+    private static void SetBbCodeText(Text asText, GraphicalUiElement graphicalUiElement, string bbcode)
+    {
+        // The rendering/wrapping code ignores '\r', so normalize CRLF to LF before computing indexes.
+        // Parsing and stripping from the same normalized string keeps InlineVariable indexes aligned
+        // with the RawText the renderer sees.
+        var normalized = bbcode?.Replace("\r\n", "\n");
+
+        var results = BbCodeParser.Parse(normalized, Tags);
+        var strippedText = BbCodeParser.RemoveTags(normalized, results);
+
+        asText.RawText = strippedText;
+
+        foreach (var item in results)
+        {
+            object castedValue = item.Open.Argument;
+            var shouldApply = false;
+            switch (item.Name)
+            {
+                case "Red":
+                case "Green":
+                case "Blue":
+                    castedValue = byte.Parse(item.Open.Argument);
+                    shouldApply = true;
+                    break;
+                case "Color":
+                    {
+                        if (item.Open.Argument?.StartsWith("0x") == true && int.TryParse(item.Open.Argument.Substring(2),
+                                                                            NumberStyles.AllowHexSpecifier,
+                                                                            null,
+                                                                            out int result))
+                        {
+                            castedValue = System.Drawing.Color.FromArgb(result);
+                        }
+                        else
+                        {
+                            castedValue = System.Drawing.Color.FromName(item.Open.Argument);
+                        }
+                        shouldApply = true;
+                    }
+                    break;
+                case "FontScale":
+                    {
+                        if (float.TryParse(item.Open.Argument, NumberStyles.Float, CultureInfo.InvariantCulture, out float parsed))
+                        {
+                            castedValue = parsed;
+                            shouldApply = true;
+                        }
+                    }
+                    break;
+                    // Font / Custom / IsBold / etc. are intentionally not handled here on the first pass (#3471).
+            }
+
+            if (shouldApply)
+            {
+                asText.InlineVariables.Add(new InlineVariable
+                {
+                    CharacterCount = item.Close.StartStrippedIndex - item.Open.StartStrippedIndex,
+                    StartIndex = item.Open.StartStrippedIndex,
+                    VariableName = item.Name,
+                    Value = castedValue
+                });
+            }
+        }
     }
 
     // For some reason this crashes on web when uploading to itch:

--- a/Runtimes/RaylibGum/Renderables/Text.cs
+++ b/Runtimes/RaylibGum/Renderables/Text.cs
@@ -75,6 +75,9 @@ public class Text : IVisible, IRenderableIpso,
         var newInstance = (Text)this.MemberwiseClone();
         newInstance.mParent = null;
         newInstance.mChildren = new();
+        // MemberwiseClone shares the list reference; give the clone its own copy so
+        // re-parsing markup on one instance doesn't mutate the other's runs.
+        newInstance.InlineVariables = new List<InlineVariable>(InlineVariables);
         return newInstance;
     }
 
@@ -141,6 +144,7 @@ public class Text : IVisible, IRenderableIpso,
     public static TextPositionRoundingMode TextPositionRoundingMode = TextPositionRoundingMode.RoundToInt;
 
     List<string> mWrappedText = new List<string>();
+    readonly StyledSubstringSplitter _styledSubstringSplitter = new StyledSubstringSplitter();
     float? mWidth = 200;
     float mHeight = 200;
 
@@ -574,7 +578,20 @@ public class Text : IVisible, IRenderableIpso,
         }
     }
 
-    public string? StoredMarkupText => null;
+    /// <summary>
+    /// The original BBCode / markup string assigned to this Text (before tags were stripped),
+    /// or null when the assigned text contained no markup. Set by the property pipeline
+    /// (<c>CustomSetPropertyOnRenderable</c>) so font/style changes can re-parse the markup.
+    /// </summary>
+    public string? StoredMarkupText { get; set; }
+
+    /// <summary>
+    /// The inline styling variables (Color / FontScale runs) parsed from BBCode markup assigned to
+    /// this Text. Populated by the property pipeline when the assigned text contains markup tags;
+    /// empty for plain text. Consumed by <see cref="Render"/> to draw per-run styling. Custom
+    /// per-letter callbacks and per-run Font swaps are not yet applied on the Raylib runtime (#3471).
+    /// </summary>
+    public List<InlineVariable> InlineVariables { get; private set; }
 
     public float LineHeightMultiplier { get; set; } = 1;
 
@@ -623,6 +640,7 @@ public class Text : IVisible, IRenderableIpso,
         // of raylib's tiny pixel default. BaseSize == 0 is the uninitialized-Font sentinel.
         Font = DefaultFont.BaseSize > 0 ? DefaultFont : GetFontDefault();
         mChildren = new();
+        InlineVariables = new List<InlineVariable>();
         Visible = true;
     }
 
@@ -656,6 +674,37 @@ public class Text : IVisible, IRenderableIpso,
 
     public virtual void PreRender() { }
 
+    /// <summary>
+    /// Splits a single wrapped line into styled runs according to which <see cref="InlineVariables"/>
+    /// are active over it. Backed by the shared <see cref="StyledSubstringSplitter"/>.
+    /// </summary>
+    public List<StyledSubstring> GetStyledSubstrings(int startOfLineIndex, string lineOfText) =>
+        _styledSubstringSplitter.GetStyledSubstrings(startOfLineIndex, lineOfText, InlineVariables);
+
+    /// <summary>
+    /// Rounds a position/origin to whole pixels using the configured <see cref="TextPositionRoundingMode"/>
+    /// when <see cref="TextRenderingPositionMode"/> is SnapToPixel; otherwise returns the value unchanged.
+    /// Rounding origin along with position avoids the baseline misalignment / "sizzle" seen on small pixel
+    /// fonts when vertical alignment produces fractional values.
+    /// </summary>
+    private static Vector2 SnapToPixelIfNeeded(Vector2 value)
+    {
+        if (TextRenderingPositionMode != TextRenderingPositionMode.SnapToPixel)
+        {
+            return value;
+        }
+
+        switch (TextPositionRoundingMode)
+        {
+            case TextPositionRoundingMode.Floor:
+                return new Vector2((int)Math.Floor(value.X), (int)Math.Floor(value.Y));
+            case TextPositionRoundingMode.Ceiling:
+                return new Vector2((int)Math.Ceiling(value.X), (int)Math.Ceiling(value.Y));
+            default:
+                return new Vector2(MathFunctions.RoundToInt(value.X), MathFunctions.RoundToInt(value.Y));
+        }
+    }
+
     public void Render(ISystemManagers managers)
     {
         if (!Visible) return;
@@ -683,6 +732,10 @@ public class Text : IVisible, IRenderableIpso,
         }
 
         int lettersShown = 0;
+        // Absolute index of the first character of the current line within the stripped RawText,
+        // used to look up which InlineVariables are active. UpdateLines keeps explicit '\n' chars
+        // in the line string, so advancing by the (untruncated) line length keeps this in sync.
+        int startOfLineIndex = 0;
 
         for(int i = 0; i < WrappedText.Count; i++)
         {
@@ -702,72 +755,137 @@ public class Text : IVisible, IRenderableIpso,
                 lettersShown += line.Length;
             }
 
-            origin.X = 0;
-            position.X = absoluteLeft;
-
-            if(HorizontalAlignment == HorizontalAlignment.Center)
-            {
-                position.X += (this.Width??32) / 2;
-                origin.X = MeasureTextEx(fontValue, line, fontValue.BaseSize * FontScale, 0).X/2;
-            }
-            else if (HorizontalAlignment == HorizontalAlignment.Right)
-            {
-                position.X += this.Width??32;
-                origin.X = MeasureTextEx(fontValue, line, fontValue.BaseSize * FontScale, 0).X;
-            }
             var linePosition = position;
             linePosition.Y += i * LineHeightInPixels * LineHeightMultiplier;
 
-            if (TextRenderingPositionMode == TextRenderingPositionMode.SnapToPixel)
+            var substrings = InlineVariables.Count > 0
+                ? GetStyledSubstrings(startOfLineIndex, line)
+                : null;
+
+            if (substrings == null || substrings.Count == 0)
             {
-                // 2025-12 JUSTIN: Changes to vertical alignment resulted fractional
-                // origin values which cause baseline misalignment and broken text.
-                // Applied the same rounding used for position to origin, which fixes
-                // the problem but may cause weird artifacts or "sizzle" for really
-                // small pixel fonts
-                
-                switch (TextPositionRoundingMode)
+                DrawPlainLine(fontValue, line, linePosition, absoluteLeft, origin.Y);
+            }
+            else
+            {
+                DrawStyledLine(fontValue, substrings, linePosition, absoluteLeft, origin.Y);
+            }
+
+            startOfLineIndex += WrappedText[i].Length;
+        }
+    }
+
+    /// <summary>
+    /// Draws a single line with no inline styling, honoring horizontal alignment and pixel snapping.
+    /// </summary>
+    private void DrawPlainLine(Font fontValue, string line, Vector2 linePosition, float absoluteLeft, float originY)
+    {
+        var origin = new Vector2(0, originY);
+        linePosition.X = absoluteLeft;
+
+        if (HorizontalAlignment == HorizontalAlignment.Center)
+        {
+            linePosition.X += (this.Width ?? 32) / 2;
+            origin.X = MeasureTextEx(fontValue, line, fontValue.BaseSize * FontScale, 0).X / 2;
+        }
+        else if (HorizontalAlignment == HorizontalAlignment.Right)
+        {
+            linePosition.X += this.Width ?? 32;
+            origin.X = MeasureTextEx(fontValue, line, fontValue.BaseSize * FontScale, 0).X;
+        }
+
+        linePosition = SnapToPixelIfNeeded(linePosition);
+        origin = SnapToPixelIfNeeded(origin);
+
+        Raylib.SetTextureFilter(fontValue.Texture, TextureFilter.Point);
+        DrawTextPro(fontValue, line, linePosition, origin, 0, fontValue.BaseSize * FontScale, 0, Color);
+    }
+
+    /// <summary>
+    /// Draws a single line as a sequence of styled runs (BBCode markup), applying per-run Color / FontScale.
+    /// Runs are laid out left-to-right and baseline-aligned so a larger FontScale run sits on the same
+    /// baseline as its neighbors. Custom per-letter callbacks and per-run Font swaps are not applied here
+    /// on the Raylib runtime yet (#3471).
+    /// </summary>
+    private void DrawStyledLine(Font fontValue, List<StyledSubstring> substrings, Vector2 linePosition, float absoluteLeft, float originY)
+    {
+        // First pass: resolve each run's effective color/scale and measured width, plus the line totals
+        // needed for horizontal alignment (total width) and baseline alignment (tallest run's baseline).
+        var runColors = new Color[substrings.Count];
+        var runScales = new float[substrings.Count];
+        var runWidths = new float[substrings.Count];
+        float totalWidth = 0;
+        float maxScale = FontScale;
+
+        for (int s = 0; s < substrings.Count; s++)
+        {
+            var run = substrings[s];
+            var runColor = Color;
+            var runScale = FontScale;
+
+            foreach (var variable in run.Variables)
+            {
+                switch (variable.VariableName)
                 {
-                    case TextPositionRoundingMode.Floor:
-                        linePosition = new Vector2(
-                            (int)Math.Floor(linePosition.X),
-                            (int)Math.Floor(linePosition.Y));
-                        origin = new Vector2(
-                            (int)Math.Floor(origin.X),
-                            (int)Math.Floor(origin.Y)
-                        );
+                    case nameof(Color):
+                        if (variable.Value is System.Drawing.Color drawingColor)
+                        {
+                            runColor = new Color(drawingColor.R, drawingColor.G, drawingColor.B, drawingColor.A);
+                        }
                         break;
-                    case TextPositionRoundingMode.Ceiling:
-                        linePosition = new Vector2(
-                            (int)Math.Ceiling(linePosition.X),
-                            (int)Math.Ceiling(linePosition.Y));
-                        origin = new Vector2(
-                            (int)Math.Ceiling(origin.X),
-                            (int)Math.Ceiling(origin.Y)
-                        );
+                    case nameof(Red):
+                        runColor = new Color((byte)variable.Value, runColor.G, runColor.B, runColor.A);
                         break;
-                    default:
-                        linePosition = new Vector2(
-                            MathFunctions.RoundToInt(linePosition.X),
-                            MathFunctions.RoundToInt(linePosition.Y));
-                        origin = new Vector2(
-                            MathFunctions.RoundToInt(origin.X),
-                            MathFunctions.RoundToInt(origin.Y)
-                        );
+                    case nameof(Green):
+                        runColor = new Color(runColor.R, (byte)variable.Value, runColor.B, runColor.A);
+                        break;
+                    case nameof(Blue):
+                        runColor = new Color(runColor.R, runColor.G, (byte)variable.Value, runColor.A);
+                        break;
+                    case nameof(FontScale):
+                        runScale = (float)variable.Value;
                         break;
                 }
             }
 
-            Raylib.SetTextureFilter(fontValue.Texture, TextureFilter.Point);
-            DrawTextPro(fontValue, line, linePosition, origin, 0, fontValue.BaseSize * FontScale, 0, Color);
+            runColors[s] = runColor;
+            runScales[s] = runScale;
+            runWidths[s] = MeasureTextEx(fontValue, run.Substring, fontValue.BaseSize * runScale, 0).X;
+            totalWidth += runWidths[s];
+            maxScale = System.Math.Max(maxScale, runScale);
         }
 
-        // todo - handle alignment
-        //DrawText(RawText, x, y, 20, Color.DarkGray);
-        //DrawTextEx(Font, RawText, position, FontSize, 0, Color);
-        //const float spacing = 1;
-        //DrawTextPro(fontValue, RawText, position, origin, 0, FontSize, spacing, Color);
+        float maxBaseline = (LineHeightInPixels - _descenderHeight) * maxScale;
 
+        float lineStartX = absoluteLeft;
+        if (HorizontalAlignment == HorizontalAlignment.Center)
+        {
+            lineStartX += ((this.Width ?? 32) - totalWidth) / 2;
+        }
+        else if (HorizontalAlignment == HorizontalAlignment.Right)
+        {
+            lineStartX += (this.Width ?? 32) - totalWidth;
+        }
+
+        Raylib.SetTextureFilter(fontValue.Texture, TextureFilter.Point);
+
+        float advance = 0;
+        for (int s = 0; s < substrings.Count; s++)
+        {
+            var runScale = runScales[s];
+            // Push shorter runs down so every run shares the tallest run's baseline.
+            float baselineDelta = maxBaseline - (LineHeightInPixels - _descenderHeight) * runScale;
+
+            var runPosition = new Vector2(lineStartX + advance, linePosition.Y + baselineDelta);
+            var runOrigin = new Vector2(0, originY);
+
+            runPosition = SnapToPixelIfNeeded(runPosition);
+            runOrigin = SnapToPixelIfNeeded(runOrigin);
+
+            DrawTextPro(fontValue, substrings[s].Substring, runPosition, runOrigin, 0, fontValue.BaseSize * runScale, 0, runColors[s]);
+
+            advance += runWidths[s];
+        }
     }
 
     public void SetNeedsRefreshToTrue()

--- a/Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/TextScreen.cs
+++ b/Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/TextScreen.cs
@@ -29,6 +29,18 @@ internal class TextScreen : FrameworkElement
         textRuntime.Text = "Hi, I'm default text";
         container.Children.Add(textRuntime);
 
+        AddSectionLabel(container, "BBCode markup - inline color runs (#3471):");
+        var colorMarkup = new TextRuntime();
+        colorMarkup.FontSize = 24;
+        colorMarkup.Text = "[Color=Red]Red[/Color] plain [Color=Lime]green[/Color] [Color=Cyan]cyan[/Color]";
+        container.Children.Add(colorMarkup);
+
+        AddSectionLabel(container, "BBCode markup - inline FontScale runs (baseline aligned):");
+        var scaleMarkup = new TextRuntime();
+        scaleMarkup.FontSize = 24;
+        scaleMarkup.Text = "small [FontScale=2]BIG[/FontScale] then [Color=Orange][FontScale=1.5]orange[/FontScale][/Color]";
+        container.Children.Add(scaleMarkup);
+
         AddSectionLabel(container, "Baked drop shadow (HasDropshadow = true, first-enable defaults):");
         var shadowDefault = new TextRuntime();
         shadowDefault.Text = "Soft baked shadow";

--- a/Samples/raylib/Screens/TextScreen.cs
+++ b/Samples/raylib/Screens/TextScreen.cs
@@ -31,6 +31,18 @@ internal class TextScreen : FrameworkElement
         textRuntime.Text = "Hi, I'm default text";
         container.Children.Add(textRuntime);
 
+        AddSectionLabel(container, "BBCode markup - inline color runs (#3471):");
+        var colorMarkup = new TextRuntime();
+        colorMarkup.FontSize = 24;
+        colorMarkup.Text = "[Color=Red]Red[/Color] plain [Color=Lime]green[/Color] [Color=Cyan]cyan[/Color]";
+        container.Children.Add(colorMarkup);
+
+        AddSectionLabel(container, "BBCode markup - inline FontScale runs (baseline aligned):");
+        var scaleMarkup = new TextRuntime();
+        scaleMarkup.FontSize = 24;
+        scaleMarkup.Text = "small [FontScale=2]BIG[/FontScale] then [Color=Orange][FontScale=1.5]orange[/FontScale][/Color]";
+        container.Children.Add(scaleMarkup);
+
         AddSectionLabel(container, "Baked drop shadow (HasDropshadow = true, first-enable defaults):");
         var shadowDefault = new TextRuntime();
         shadowDefault.Text = "Soft baked shadow";

--- a/Tests/RaylibGum.Tests/Renderables/TextMarkupTests.cs
+++ b/Tests/RaylibGum.Tests/Renderables/TextMarkupTests.cs
@@ -1,0 +1,63 @@
+using Gum.GueDeriving;
+using RenderingLibrary.Graphics;
+using Shouldly;
+using Xunit;
+using Text = Gum.Renderables.Text;
+
+namespace RaylibGum.Tests.Renderables;
+
+/// <summary>
+/// Verifies that the Raylib <see cref="Text"/> renderable stores BBCode / markup inline
+/// styling (Color / FontScale runs) when text is assigned through the property pipeline,
+/// mirroring the MonoGame runtime's behavior. Issue #3471.
+/// </summary>
+public class TextMarkupTests
+{
+    [Fact]
+    public void Text_WithColorMarkup_PopulatesInlineVariablesAndStripsTags()
+    {
+        TextRuntime textRuntime = new();
+        textRuntime.Text = "[Color=Green]Hello[/Color] World";
+
+        Text internalText = (Text)textRuntime.RenderableComponent;
+
+        internalText.RawText.ShouldBe("Hello World");
+        internalText.StoredMarkupText.ShouldBe("[Color=Green]Hello[/Color] World");
+        internalText.InlineVariables.Count.ShouldBe(1);
+        internalText.InlineVariables[0].VariableName.ShouldBe("Color");
+        internalText.InlineVariables[0].StartIndex.ShouldBe(0);
+        internalText.InlineVariables[0].CharacterCount.ShouldBe(5);
+    }
+
+    [Fact]
+    public void Text_WithFontScaleMarkup_PopulatesInlineVariable()
+    {
+        TextRuntime textRuntime = new();
+        textRuntime.Text = "Big [FontScale=2]text[/FontScale]";
+
+        Text internalText = (Text)textRuntime.RenderableComponent;
+
+        internalText.RawText.ShouldBe("Big text");
+        internalText.InlineVariables.Count.ShouldBe(1);
+        internalText.InlineVariables[0].VariableName.ShouldBe("FontScale");
+        internalText.InlineVariables[0].Value.ShouldBe(2f);
+        internalText.InlineVariables[0].StartIndex.ShouldBe(4);
+        internalText.InlineVariables[0].CharacterCount.ShouldBe(4);
+    }
+
+    [Fact]
+    public void Text_ChangingFromMarkupToPlain_ClearsInlineVariablesAndStoredMarkup()
+    {
+        TextRuntime textRuntime = new();
+        textRuntime.Text = "[Color=Green]Hello[/Color] World";
+
+        Text internalText = (Text)textRuntime.RenderableComponent;
+        internalText.InlineVariables.Count.ShouldBe(1);
+
+        textRuntime.Text = "Plain text";
+
+        internalText.RawText.ShouldBe("Plain text");
+        internalText.StoredMarkupText.ShouldBeNull();
+        internalText.InlineVariables.ShouldBeEmpty();
+    }
+}


### PR DESCRIPTION
## What

Adds BBCode / markup **inline rendering** to RaylibGum's `Text` renderable. Previously `StoredMarkupText` was hardcoded to `null` and `Render()` drew each wrapped line with a single `DrawTextPro`/one `Color`, so `Text = "[Color=Red]Hello[/Color] world"` had no styling effect.

First pass scope (per the issue): **Color / Red / Green / Blue** and **FontScale** runs — the common cases (colored spans, size changes). `Custom` per-letter callbacks and per-run `Font` swaps are recognized (their tags are stripped from the visible text) but **not yet applied** on the raylib runtime — deferred follow-up, since they need a codepoint-level draw path / `BitmapFont` which raylib doesn't use.

## How

- **Shared prep:** moved `InlineVariable` out of `RenderingLibrary/Graphics/Text.cs` (the MonoGame renderable) into `StyledSubstringSplitter.cs`. Every project that compiles `Text.cs` already links `StyledSubstringSplitter.cs` on the adjacent line, so this is a no-op for existing XNALIKE/FRB consumers and lets RaylibGum file-link the shared markup model **and** the run-splitter with a single `<Compile>` entry.
- **Raylib `Text`:** added `InlineVariables` + a real `StoredMarkupText`, exposed `GetStyledSubstrings` via the shared `StyledSubstringSplitter`, and rewrote `Render()` to draw each wrapped line as styled runs — per-run `Color`/`FontScale`, laid out left-to-right and baseline-aligned so a larger `FontScale` run sits on the same baseline as its neighbors. Plain (non-markup) text keeps the original single-draw path.
- **Raylib `CustomSetPropertyOnRenderable`:** parses assigned text via `BbCodeParser`, strips tags into `RawText`, and populates `InlineVariables` for the supported runs.
- Added a markup demo section to the raylib `TextScreen` sample.

## Tests

- New `TextMarkupTests` (raylib): color-run populate + tag stripping, FontScale-run populate, and markup→plain clearing.
- Full `RaylibGum.Tests` (414) and full `MonoGameGum.Tests` (1783) green; `KniGum` builds. The `InlineVariable` move is verified clean across XNALIKE consumers.

## Manual test

Runtime-observable rendering, so a visual pass is needed. Run the raylib sample (`Samples/raylib/RaylibSample.sln`) → **Text** screen and confirm the two new markup sections render with the right per-run colors and baseline-aligned size changes.

Part of #3432.
Closes #3471.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
