### PR TITLE
Text: grow reported size by per-line inline [FontScale] run (#3481)

### DIFF
--- a/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
+++ b/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
@@ -1263,6 +1263,12 @@ public class CustomSetPropertyOnRenderable
             lastFontInlineVariable.CharacterCount = asText.RawText.Length - lastFontInlineVariable.StartIndex;
         }
 
+        // #3481: RawText was assigned above (which measured the text) before any InlineVariables
+        // existed, so that first measurement was blind to inline [FontScale=N] runs. Re-measure now
+        // that the runs are populated so the reported size accounts for per-line scale (otherwise a
+        // tall run overflows its slot and overlaps the next stacked sibling).
+        asText.UpdatePreRenderDimensions();
+
 
         BitmapFont GetAndCreateFontIfNecessary()
         {

--- a/MonoGameGum.Tests/Runtimes/TextRuntimeTests.cs
+++ b/MonoGameGum.Tests/Runtimes/TextRuntimeTests.cs
@@ -82,6 +82,122 @@ $"chars count=223\r\n";
 
     #endregion
 
+    #region FontScale Inline Measurement (issue #3481)
+
+    // Issue #3481: an inline [FontScale=N] run renders larger but the Text used to report its
+    // size to the layout as if every line were at the base scale, so the tall run overflowed its
+    // slot and overlapped the next stacked sibling. These pin that the *reported* size now grows
+    // by the per-line max inline FontScale. RelativeToChildren width 0 keeps each line un-wrapped
+    // so line counts are deterministic.
+
+    [Fact]
+    public void WrappedTextHeight_ShouldDouble_WhenEntireLineHasFontScale2()
+    {
+        TextRuntime plain = new();
+        plain.WidthUnits = DimensionUnitType.RelativeToChildren;
+        plain.Width = 0;
+        plain.Text = "BIG";
+        float plainHeight = ((Text)plain.RenderableComponent).WrappedTextHeight;
+        plainHeight.ShouldBeGreaterThan(0);
+
+        TextRuntime scaled = new();
+        scaled.WidthUnits = DimensionUnitType.RelativeToChildren;
+        scaled.Width = 0;
+        scaled.Text = "[FontScale=2]BIG[/FontScale]";
+        float scaledHeight = ((Text)scaled.RenderableComponent).WrappedTextHeight;
+
+        scaledHeight.ShouldBe(plainHeight * 2,
+            "Because a whole line scaled 2x should report twice the height");
+    }
+
+    [Fact]
+    public void WrappedTextHeight_ShouldDouble_WhenPartOfLineHasFontScale2()
+    {
+        // Default (unscaled) text and a scaled run share the same line: the line's height is
+        // driven by the tallest run, so the whole line reports 2x even though only "BIG" is scaled.
+        TextRuntime plain = new();
+        plain.WidthUnits = DimensionUnitType.RelativeToChildren;
+        plain.Width = 0;
+        plain.Text = "small BIG";
+        float plainHeight = ((Text)plain.RenderableComponent).WrappedTextHeight;
+        plainHeight.ShouldBeGreaterThan(0);
+
+        TextRuntime scaled = new();
+        scaled.WidthUnits = DimensionUnitType.RelativeToChildren;
+        scaled.Width = 0;
+        scaled.Text = "small [FontScale=2]BIG[/FontScale]";
+        float scaledHeight = ((Text)scaled.RenderableComponent).WrappedTextHeight;
+
+        scaledHeight.ShouldBe(plainHeight * 2,
+            "Because the tallest run on the line drives the line height, even when mixed with base-scale text");
+    }
+
+    [Fact]
+    public void WrappedTextHeight_ShouldGrowOnlyScaledLine_WhenMultiLine()
+    {
+        // Only line 1 carries the scaled run; line 2 must stay at base height. Expected total is
+        // 2x (line 1) + 1x (line 2) = 3x a single plain line — proving the growth is per-line.
+        TextRuntime plain = new();
+        plain.WidthUnits = DimensionUnitType.RelativeToChildren;
+        plain.Width = 0;
+        plain.Text = "BIG";
+        float plainSingleLineHeight = ((Text)plain.RenderableComponent).WrappedTextHeight;
+        plainSingleLineHeight.ShouldBeGreaterThan(0);
+
+        TextRuntime scaled = new();
+        scaled.WidthUnits = DimensionUnitType.RelativeToChildren;
+        scaled.Width = 0;
+        scaled.Text = "[FontScale=2]BIG[/FontScale]\nsmall";
+        float scaledHeight = ((Text)scaled.RenderableComponent).WrappedTextHeight;
+
+        scaledHeight.ShouldBe(plainSingleLineHeight * 3,
+            "Because only the first line is scaled 2x; the second line stays at base height");
+    }
+
+    [Fact]
+    public void WrappedTextHeight_ShouldNotGrow_WhenLineHasOnlyColorMarkup()
+    {
+        // A non-scale inline variable (Color) intertwined with the line must not change the
+        // reported height — only FontScale runs grow it.
+        TextRuntime plain = new();
+        plain.WidthUnits = DimensionUnitType.RelativeToChildren;
+        plain.Width = 0;
+        plain.Text = "Hello World";
+        float plainHeight = ((Text)plain.RenderableComponent).WrappedTextHeight;
+        plainHeight.ShouldBeGreaterThan(0);
+
+        TextRuntime colored = new();
+        colored.WidthUnits = DimensionUnitType.RelativeToChildren;
+        colored.Width = 0;
+        colored.Text = "[Color=Red]Hello[/Color] World";
+        float coloredHeight = ((Text)colored.RenderableComponent).WrappedTextHeight;
+
+        coloredHeight.ShouldBe(plainHeight,
+            "Because a Color-only run carries no scale and must not affect the reported height");
+    }
+
+    [Fact]
+    public void WrappedTextWidth_ShouldGrow_WhenLineHasFontScale2()
+    {
+        TextRuntime plain = new();
+        plain.WidthUnits = DimensionUnitType.RelativeToChildren;
+        plain.Width = 0;
+        plain.Text = "BIG";
+        float plainWidth = ((Text)plain.RenderableComponent).WrappedTextWidth;
+        plainWidth.ShouldBeGreaterThan(0);
+
+        TextRuntime scaled = new();
+        scaled.WidthUnits = DimensionUnitType.RelativeToChildren;
+        scaled.Width = 0;
+        scaled.Text = "[FontScale=2]BIG[/FontScale]";
+        float scaledWidth = ((Text)scaled.RenderableComponent).WrappedTextWidth;
+
+        scaledWidth.ShouldBe(plainWidth * 2, 1.5,
+            "Because a scaled run is measured at its own scale, so the reported width grows with it");
+    }
+
+    #endregion
+
     #region GetStyledSubstrings
 
     [Fact]

--- a/RenderingLibrary/Graphics/Text.cs
+++ b/RenderingLibrary/Graphics/Text.cs
@@ -1483,12 +1483,93 @@ public class Text : SpriteBatchRenderableBase, IRenderableIpso, IVisible, IWrapp
 
             if (this.mRawText != null)
             {
-                mBitmapFont.GetRequiredWidthAndHeight(WrappedText, out requiredWidth, out requiredHeight);
+                // #3481: when the text carries inline [FontScale=N] runs, each line's reported size
+                // must grow by the largest scale covering it, or a tall run overflows its slot and
+                // overlaps the next stacked sibling. EffectiveFontScale <= 0 falls through to the
+                // plain path (everything downstream multiplies by it, so the result is 0 either way,
+                // and it avoids a divide-by-zero in the per-run base-unit conversion).
+                if (InlineVariables.Count > 0 && EffectiveFontScale > 0)
+                {
+                    GetInlineVariableAwareWidthAndHeight(out requiredWidth, out requiredHeight);
+                }
+                else
+                {
+                    mBitmapFont.GetRequiredWidthAndHeight(WrappedText, out requiredWidth, out requiredHeight);
+                }
             }
 
             mPreRenderWidth = requiredWidth;
             mPreRenderHeight = (int)(requiredHeight * LineHeightMultiplier + .5f);
         }
+    }
+
+    /// <summary>
+    /// Mirrors <see cref="BitmapFont.GetRequiredWidthAndHeight(List{string}, out int, out int, List{int}?)"/>
+    /// but grows each line by the largest inline <see cref="FontScale"/> run covering it (issue #3481).
+    /// </summary>
+    /// <remarks>
+    /// <see cref="mPreRenderWidth"/>/<see cref="mPreRenderHeight"/> are stored in BASE units (the caller
+    /// multiplies by <see cref="EffectiveFontScale"/> downstream), while an inline [FontScale=N] is an
+    /// ABSOLUTE per-run scale (matching how <see cref="DrawWithInlineVariables"/> draws it). So each
+    /// run's contribution is divided by <see cref="EffectiveFontScale"/> to land back in base units.
+    /// A line with no runs, or only non-scale runs (e.g. Color), keeps a factor of 1. FontScale (the
+    /// base Text scale) is the floor, so an inline run smaller than the base does not shrink the line.
+    /// Line-wrapping is intentionally still base-scale-only (deferred per #3471); this only affects
+    /// size reporting. The outline-thickness padding the BitmapFont path adds is skipped here because
+    /// that field is private to BitmapFont and outline + inline scale is a rare combination.
+    /// </remarks>
+    private void GetInlineVariableAwareWidthAndHeight(out int requiredWidth, out int requiredHeight)
+    {
+        var effectiveFontScale = EffectiveFontScale;
+
+        float maxWidth = 0;
+        float totalHeight = 0;
+
+        int startOfLineIndex = 0;
+        for (int lineIndex = 0; lineIndex < WrappedText.Count; lineIndex++)
+        {
+            var line = WrappedText[lineIndex];
+            var substrings = GetStyledSubstrings(startOfLineIndex, line);
+
+            float lineHeightFactor;
+            float lineWidthInBaseUnits;
+
+            if (substrings.Count == 0)
+            {
+                lineHeightFactor = 1;
+                lineWidthInBaseUnits = mBitmapFont.MeasureString(line);
+            }
+            else
+            {
+                float maxRunScale = effectiveFontScale;
+                float lineWidthAtScale = 0;
+                for (int substringIndex = 0; substringIndex < substrings.Count; substringIndex++)
+                {
+                    var substring = substrings[substringIndex];
+                    float runScale = effectiveFontScale;
+                    for (int variableIndex = 0; variableIndex < substring.Variables.Count; variableIndex++)
+                    {
+                        if (substring.Variables[variableIndex].VariableName == nameof(FontScale))
+                        {
+                            runScale = (float)substring.Variables[variableIndex].Value * SystemManagers.GlobalFontScale;
+                        }
+                    }
+                    lineWidthAtScale += mBitmapFont.MeasureString(substring.Substring) * runScale;
+                    maxRunScale = System.Math.Max(maxRunScale, runScale);
+                }
+                lineHeightFactor = maxRunScale / effectiveFontScale;
+                lineWidthInBaseUnits = lineWidthAtScale / effectiveFontScale;
+            }
+
+            maxWidth = System.Math.Max(maxWidth, lineWidthInBaseUnits);
+            totalHeight += LineHeightInPixels * lineHeightFactor;
+
+            startOfLineIndex += line.Length;
+        }
+
+        const int MaxWidthAndHeight = 4096;
+        requiredWidth = System.Math.Min((int)(maxWidth + .5f), MaxWidthAndHeight);
+        requiredHeight = System.Math.Min((int)(totalHeight + .5f), MaxWidthAndHeight);
     }
     #endregion
 

--- a/Runtimes/RaylibGum/Renderables/CustomSetPropertyOnRenderable.cs
+++ b/Runtimes/RaylibGum/Renderables/CustomSetPropertyOnRenderable.cs
@@ -754,6 +754,12 @@ public class CustomSetPropertyOnRenderable
                 });
             }
         }
+
+        // #3481: RawText was assigned above (which measured the text) before any InlineVariables
+        // existed, so that first measurement was blind to inline [FontScale=N] runs. Re-measure now
+        // that the runs are populated so the reported size accounts for per-line scale (otherwise a
+        // tall run overflows its slot and overlaps the next stacked sibling).
+        asText.UpdatePreRenderDimensions();
     }
 
     // For some reason this crashes on web when uploading to itch:

--- a/Runtimes/RaylibGum/Renderables/Text.cs
+++ b/Runtimes/RaylibGum/Renderables/Text.cs
@@ -899,11 +899,92 @@ public class Text : IVisible, IRenderableIpso,
 
         if (this.mRawText != null)
         {
-            GetRequiredWidthAndHeight(WrappedText, out requiredWidth, out requiredHeight, null);
+            // #3481: when the text carries inline [FontScale=N] runs, each line's reported size must
+            // grow by the largest scale covering it, or a tall run overflows its slot and overlaps
+            // the next stacked sibling. FontScale <= 0 falls through to the plain path (everything
+            // downstream multiplies by it, so the result is 0 either way, and it avoids a
+            // divide-by-zero in the per-run base-unit conversion). Kept in parity with the MonoGame
+            // Text.UpdatePreRenderDimensions (RenderingLibrary/Graphics/Text.cs).
+            if (InlineVariables.Count > 0 && FontScale > 0)
+            {
+                GetInlineVariableAwareWidthAndHeight(out requiredWidth, out requiredHeight);
+            }
+            else
+            {
+                GetRequiredWidthAndHeight(WrappedText, out requiredWidth, out requiredHeight, null);
+            }
         }
 
         mPreRenderWidth = (int)(requiredWidth + .5f);
         mPreRenderHeight = (int)(requiredHeight * LineHeightMultiplier + .5f);
+    }
+
+    /// <summary>
+    /// Mirrors <see cref="GetRequiredWidthAndHeight"/> but grows each line by the largest inline
+    /// <see cref="FontScale"/> run covering it (issue #3481).
+    /// </summary>
+    /// <remarks>
+    /// <see cref="mPreRenderWidth"/>/<see cref="mPreRenderHeight"/> are stored in BASE units (the
+    /// caller multiplies by <see cref="FontScale"/> downstream), while an inline [FontScale=N] is an
+    /// ABSOLUTE per-run scale (matching how <see cref="DrawStyledLine"/> draws it). So each run's
+    /// contribution is divided by <see cref="FontScale"/> to land back in base units. A line with no
+    /// runs, or only non-scale runs (e.g. Color), keeps a factor of 1. FontScale (the base Text
+    /// scale) is the floor, so an inline run smaller than the base does not shrink the line.
+    /// Line-wrapping is intentionally still base-scale-only (deferred per #3471); this only affects
+    /// size reporting.
+    /// </remarks>
+    private void GetInlineVariableAwareWidthAndHeight(out int requiredWidth, out int requiredHeight)
+    {
+        float baseScale = FontScale;
+
+        float maxWidth = 0;
+        float totalHeight = 0;
+
+        int startOfLineIndex = 0;
+        for (int lineIndex = 0; lineIndex < WrappedText.Count; lineIndex++)
+        {
+            var line = WrappedText[lineIndex];
+            var substrings = GetStyledSubstrings(startOfLineIndex, line);
+
+            float lineHeightFactor;
+            float lineWidthInBaseUnits;
+
+            if (substrings.Count == 0)
+            {
+                lineHeightFactor = 1;
+                lineWidthInBaseUnits = MeasureString(line);
+            }
+            else
+            {
+                float maxRunScale = baseScale;
+                float lineWidthAtScale = 0;
+                for (int substringIndex = 0; substringIndex < substrings.Count; substringIndex++)
+                {
+                    var substring = substrings[substringIndex];
+                    float runScale = baseScale;
+                    for (int variableIndex = 0; variableIndex < substring.Variables.Count; variableIndex++)
+                    {
+                        if (substring.Variables[variableIndex].VariableName == nameof(FontScale))
+                        {
+                            runScale = (float)substring.Variables[variableIndex].Value;
+                        }
+                    }
+                    lineWidthAtScale += MeasureString(substring.Substring) * runScale;
+                    maxRunScale = System.Math.Max(maxRunScale, runScale);
+                }
+                lineHeightFactor = maxRunScale / baseScale;
+                lineWidthInBaseUnits = lineWidthAtScale / baseScale;
+            }
+
+            maxWidth = System.Math.Max(maxWidth, lineWidthInBaseUnits);
+            totalHeight += LineHeightInPixels * lineHeightFactor;
+
+            startOfLineIndex += line.Length;
+        }
+
+        const int MaxWidthAndHeight = 4096;
+        requiredWidth = System.Math.Min((int)(maxWidth + .5f), MaxWidthAndHeight);
+        requiredHeight = System.Math.Min((int)(totalHeight + .5f), MaxWidthAndHeight);
     }
 
     public void GetRequiredWidthAndHeight(IEnumerable<string> lines, out int requiredWidth, out int requiredHeight, List<float>? widths)

--- a/Tests/RaylibGum.Tests/Renderables/TextMarkupTests.cs
+++ b/Tests/RaylibGum.Tests/Renderables/TextMarkupTests.cs
@@ -1,3 +1,4 @@
+using Gum.DataTypes;
 using Gum.GueDeriving;
 using RenderingLibrary.Graphics;
 using Shouldly;
@@ -59,5 +60,117 @@ public class TextMarkupTests
         internalText.RawText.ShouldBe("Plain text");
         internalText.StoredMarkupText.ShouldBeNull();
         internalText.InlineVariables.ShouldBeEmpty();
+    }
+
+    // Issue #3481: an inline [FontScale=N] run renders larger but the Text used to report its size
+    // to the layout as if every line were at the base scale, so the tall run overflowed its slot
+    // and overlapped the next stacked sibling. These pin that the *reported* size now grows by the
+    // per-line max inline FontScale on the Raylib runtime too (kept in parity with MonoGame).
+    // RelativeToChildren width 0 keeps each line un-wrapped so line counts are deterministic.
+
+    [Fact]
+    public void WrappedTextHeight_ShouldDouble_WhenEntireLineHasFontScale2()
+    {
+        TextRuntime plain = new();
+        plain.WidthUnits = DimensionUnitType.RelativeToChildren;
+        plain.Width = 0;
+        plain.Text = "BIG";
+        float plainHeight = ((Text)plain.RenderableComponent).WrappedTextHeight;
+        plainHeight.ShouldBeGreaterThan(0);
+
+        TextRuntime scaled = new();
+        scaled.WidthUnits = DimensionUnitType.RelativeToChildren;
+        scaled.Width = 0;
+        scaled.Text = "[FontScale=2]BIG[/FontScale]";
+        float scaledHeight = ((Text)scaled.RenderableComponent).WrappedTextHeight;
+
+        scaledHeight.ShouldBe(plainHeight * 2,
+            "Because a whole line scaled 2x should report twice the height");
+    }
+
+    [Fact]
+    public void WrappedTextHeight_ShouldDouble_WhenPartOfLineHasFontScale2()
+    {
+        // Default (unscaled) text and a scaled run share the same line: the line's height is
+        // driven by the tallest run, so the whole line reports 2x even though only "BIG" is scaled.
+        TextRuntime plain = new();
+        plain.WidthUnits = DimensionUnitType.RelativeToChildren;
+        plain.Width = 0;
+        plain.Text = "small BIG";
+        float plainHeight = ((Text)plain.RenderableComponent).WrappedTextHeight;
+        plainHeight.ShouldBeGreaterThan(0);
+
+        TextRuntime scaled = new();
+        scaled.WidthUnits = DimensionUnitType.RelativeToChildren;
+        scaled.Width = 0;
+        scaled.Text = "small [FontScale=2]BIG[/FontScale]";
+        float scaledHeight = ((Text)scaled.RenderableComponent).WrappedTextHeight;
+
+        scaledHeight.ShouldBe(plainHeight * 2,
+            "Because the tallest run on the line drives the line height, even when mixed with base-scale text");
+    }
+
+    [Fact]
+    public void WrappedTextHeight_ShouldGrowOnlyScaledLine_WhenMultiLine()
+    {
+        // Only line 1 carries the scaled run; line 2 must stay at base height. Expected total is
+        // 2x (line 1) + 1x (line 2) = 3x a single plain line — proving the growth is per-line.
+        TextRuntime plain = new();
+        plain.WidthUnits = DimensionUnitType.RelativeToChildren;
+        plain.Width = 0;
+        plain.Text = "BIG";
+        float plainSingleLineHeight = ((Text)plain.RenderableComponent).WrappedTextHeight;
+        plainSingleLineHeight.ShouldBeGreaterThan(0);
+
+        TextRuntime scaled = new();
+        scaled.WidthUnits = DimensionUnitType.RelativeToChildren;
+        scaled.Width = 0;
+        scaled.Text = "[FontScale=2]BIG[/FontScale]\nsmall";
+        float scaledHeight = ((Text)scaled.RenderableComponent).WrappedTextHeight;
+
+        scaledHeight.ShouldBe(plainSingleLineHeight * 3,
+            "Because only the first line is scaled 2x; the second line stays at base height");
+    }
+
+    [Fact]
+    public void WrappedTextHeight_ShouldNotGrow_WhenLineHasOnlyColorMarkup()
+    {
+        // A non-scale inline variable (Color) intertwined with the line must not change the
+        // reported height — only FontScale runs grow it.
+        TextRuntime plain = new();
+        plain.WidthUnits = DimensionUnitType.RelativeToChildren;
+        plain.Width = 0;
+        plain.Text = "Hello World";
+        float plainHeight = ((Text)plain.RenderableComponent).WrappedTextHeight;
+        plainHeight.ShouldBeGreaterThan(0);
+
+        TextRuntime colored = new();
+        colored.WidthUnits = DimensionUnitType.RelativeToChildren;
+        colored.Width = 0;
+        colored.Text = "[Color=Red]Hello[/Color] World";
+        float coloredHeight = ((Text)colored.RenderableComponent).WrappedTextHeight;
+
+        coloredHeight.ShouldBe(plainHeight,
+            "Because a Color-only run carries no scale and must not affect the reported height");
+    }
+
+    [Fact]
+    public void WrappedTextWidth_ShouldGrow_WhenLineHasFontScale2()
+    {
+        TextRuntime plain = new();
+        plain.WidthUnits = DimensionUnitType.RelativeToChildren;
+        plain.Width = 0;
+        plain.Text = "BIG";
+        float plainWidth = ((Text)plain.RenderableComponent).WrappedTextWidth;
+        plainWidth.ShouldBeGreaterThan(0);
+
+        TextRuntime scaled = new();
+        scaled.WidthUnits = DimensionUnitType.RelativeToChildren;
+        scaled.Width = 0;
+        scaled.Text = "[FontScale=2]BIG[/FontScale]";
+        float scaledWidth = ((Text)scaled.RenderableComponent).WrappedTextWidth;
+
+        scaledWidth.ShouldBe(plainWidth * 2, 1.5,
+            "Because a scaled run is measured at its own scale, so the reported width grows with it");
     }
 }


### PR DESCRIPTION
Closes #3481.

## Problem

A `Text` with an inline `[FontScale=N]` markup run (N > 1) rendered the larger run but reported its size to the layout as if every line were at the base scale. In a `TopToBottomStack` (or any `RelativeToChildren`-height / sibling-stacking scenario) the tall run overflowed its slot and visually collided with the next stacked element. Affected **both** MonoGame and raylib.

## Fix

`UpdatePreRenderDimensions()` now grows each line by the largest inline `FontScale` run covering it:

- **Per-line max scale** — a line's height is driven by its tallest run; the base `FontScale` is the floor, so an inline run *smaller* than the base doesn't shrink the line. Non-scale runs (e.g. `Color`) and lines with no runs keep a factor of 1.
- **Width per run** — each run is measured at its own scale and summed.
- **Units wrinkle** — `mPreRender*` are stored in *base* units (multiplied by `FontScale` downstream) while inline `FontScale` is an *absolute* per-run scale, so each run's contribution is divided by the base scale to land back in base units.
- Scope is **size reporting only** — line-*wrapping* stays base-scale-only (deferred per #3471).
- Mirrored across the MonoGame (`RenderingLibrary/Graphics/Text.cs`) and raylib (`Runtimes/RaylibGum/Renderables/Text.cs`) measurement paths, which are kept in parity.

### Pipeline ordering (the non-obvious part)

The BBCode pipeline assigned `RawText` (which triggers a measure) **before** populating `InlineVariables`, so that first measurement was blind to the inline runs and there was no re-measure afterward. Both `SetBbCodeText` copies (MonoGame `Gum/Wireframe/` + raylib `Runtimes/RaylibGum/Renderables/`) now re-measure once the runs are populated — without this, the fix never takes effect through the normal `TextRuntime.Text = "...[FontScale=2]..."` path.

## Tests (TDD, both runtimes)

Added 5 pinning tests each to `MonoGameGum.Tests` and `RaylibGum.Tests`, covering the edge cases where default and inline styling intertwine on a line:

- whole line scaled → reported height doubles
- mixed base + scaled run on one line → line still reports the tall run's height
- multi-line → only the scaled line grows (per-line, not whole-text)
- `Color`-only run → height unchanged (non-scale variable)
- width grows with the run's scale

All were red before the fix, green after. Full suites green: MonoGame 1792/1792, raylib 419/419. KNI builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
