### PR TITLE
RaylibGum: read gamepad triggers and right stick in Forms driver

### DIFF
--- a/MonoGameGum/Forms/FormsUtilities.cs
+++ b/MonoGameGum/Forms/FormsUtilities.cs
@@ -570,10 +570,21 @@ public class FormsUtilities
             gamepad.SetButtonState(GumGamepadButton.LeftStick, Raylib.IsGamepadButtonDown(i, RaylibGamepadButton.LeftThumb));
             gamepad.SetButtonState(GumGamepadButton.RightStick, Raylib.IsGamepadButtonDown(i, RaylibGamepadButton.RightThumb));
 
+            // Gum's GamePad models triggers as a digital button only (no analog trigger value), so
+            // read the digital trigger buttons LeftTrigger2/RightTrigger2 (LT/RT) directly — this is
+            // exact parity with the MonoGame driver's thresholded triggers and avoids raylib's
+            // trigger-axis rest-at-(-1) convention. (LeftTrigger1/RightTrigger1 are the shoulders above.)
+            gamepad.SetButtonState(GumGamepadButton.LeftTrigger, Raylib.IsGamepadButtonDown(i, RaylibGamepadButton.LeftTrigger2));
+            gamepad.SetButtonState(GumGamepadButton.RightTrigger, Raylib.IsGamepadButtonDown(i, RaylibGamepadButton.RightTrigger2));
+
             // Raylib reports stick Y as positive-down; flip it to the XNA/Gum convention (positive-up).
             float leftX = Raylib.GetGamepadAxisMovement(i, RaylibGamepadAxis.LeftX);
             float leftY = Raylib.GetGamepadAxisMovement(i, RaylibGamepadAxis.LeftY);
             gamepad.SetLeftStickPosition(leftX, -leftY);
+
+            float rightX = Raylib.GetGamepadAxisMovement(i, RaylibGamepadAxis.RightX);
+            float rightY = Raylib.GetGamepadAxisMovement(i, RaylibGamepadAxis.RightY);
+            gamepad.SetRightStickPosition(rightX, -rightY);
 
             gamepad.Activity(time);
         }


### PR DESCRIPTION
## What

On raylib, the Forms gamepad driver (`#elif RAYLIB` branch of `FormsUtilities.UpdateGamepads`) read **only the left stick axis** — it never populated the **triggers** (analog or digital) or the **right stick**. This is a feature-parity gap vs the MonoGame driver (`MonoGameGamePadDriver.Apply`, which reads both sticks + digitally-thresholded triggers).

## Change

Mirror the MonoGame driver in the raylib branch (one file, +11 lines):

- **Triggers** — map raylib's digital `LeftTrigger2`/`RightTrigger2` (LT/RT) buttons to the Gum `LeftTrigger`/`RightTrigger` buttons. Gum's `GamePad` models triggers as a **digital button only** (no analog trigger value), so the digital read is exact parity with MonoGame's thresholded triggers and sidesteps raylib's trigger-**axis** rest-at-(−1) convention. (LT1/RT1 are already the shoulders.)
- **Right stick** — read `RightX`/`RightY` into `SetRightStickPosition`, with the same Y flip the left stick already uses.

The platform-neutral `Gum.Input.GamePad` holder already supported both (`SetRightStickPosition`/`RightStick`, `LeftTrigger`/`RightTrigger` enum members) — the raylib branch just wasn't calling into them.

## Testing

- `RaylibGum.csproj` builds clean (0 errors, no new warnings).
- The change is entirely `#if RAYLIB` native-read glue (`Raylib.*` statics) and is **not unit-testable**; the holder logic it feeds is already covered. Verified manually with a controller via a copy of the raylib FromFile template displaying live right-stick-direction and trigger booleans (both dead before this change, responsive after).

Part of #3432. Closes #3483.
