### PR TITLE
raylib Text parity: GetCharacterIndexAtPosition, Blend, TextRenderingPositionMode override

### DIFF
--- a/MonoGameGum/GueDeriving/TextRuntime.cs
+++ b/MonoGameGum/GueDeriving/TextRuntime.cs
@@ -563,7 +563,7 @@ public class TextRuntime : InteractiveGue
         }
     }
 
-#if !RAYLIB && !SKIA
+#if !SKIA
     /// <summary>
     /// Gets or sets the text rendering position mode to use for the contained text, overriding the default behavior if
     /// specified.

--- a/MonoGameGum/GueDeriving/TextRuntime.cs
+++ b/MonoGameGum/GueDeriving/TextRuntime.cs
@@ -774,7 +774,7 @@ public class TextRuntime : InteractiveGue
     public void AddToManagers() => base.AddToManagers(SystemManagers.Default, layer: null);
 #endif
 
-#if !RAYLIB && !SKIA
+#if !SKIA
     /// <summary>
     /// Returns the index of the character at the specified screen position. This returns the index
     /// within the WrappedText, so to index in, you need to loop through each line.

--- a/MonoGameGum/GueDeriving/TextRuntime.cs
+++ b/MonoGameGum/GueDeriving/TextRuntime.cs
@@ -52,7 +52,7 @@ public class TextRuntime : InteractiveGue
 
 #if !RAYLIB && !SKIA
     /// <summary>
-    /// The XNA blend state used when rendering the text. This controls how 
+    /// The XNA blend state used when rendering the text. This controls how
     /// color and alpha values blend with the background.
     /// </summary>
     public Microsoft.Xna.Framework.Graphics.BlendState BlendState
@@ -65,20 +65,35 @@ public class TextRuntime : InteractiveGue
             NotifyPropertyChanged(nameof(Blend));
         }
     }
+#endif
 
+#if !SKIA
+    /// <summary>
+    /// The Gum-specific Blend mode for the text. Null means "use the renderer's current
+    /// blend mode" (typically alpha blending).
+    /// </summary>
     public Gum.RenderingLibrary.Blend? Blend
     {
         get
         {
+#if RAYLIB
+            return ContainedText.Blend;
+#else
             return Gum.RenderingLibrary.BlendExtensions.ToBlend(ContainedText.BlendState);
+#endif
         }
         set
         {
+#if RAYLIB
+            ContainedText.Blend = value;
+            NotifyPropertyChanged();
+#else
             if (value.HasValue)
             {
                 BlendState = value.Value.ToBlendState().ToXNA();
             }
             // NotifyPropertyChanged handled by BlendState:
+#endif
         }
     }
 #endif

--- a/Runtimes/RaylibGum/Renderables/Text.cs
+++ b/Runtimes/RaylibGum/Renderables/Text.cs
@@ -136,7 +136,23 @@ public class Text : IVisible, IRenderableIpso,
     /// small fonts.
     /// </summary>
     public static TextRenderingPositionMode TextRenderingPositionMode = TextRenderingPositionMode.SnapToPixel;
-    
+
+    /// <summary>
+    /// Per-instance override for <see cref="TextRenderingPositionMode"/>. When null (the default),
+    /// this Text uses the static <see cref="TextRenderingPositionMode"/>; when set, it overrides the
+    /// static default for this instance only. Mirrors the MonoGame Text renderable.
+    /// </summary>
+    public TextRenderingPositionMode? OverrideTextRenderingPositionMode;
+
+    /// <summary>
+    /// The position mode actually applied when drawing this Text: the per-instance
+    /// <see cref="OverrideTextRenderingPositionMode"/> when set, otherwise the static
+    /// <see cref="TextRenderingPositionMode"/>. Matches the MonoGame BitmapFont resolution.
+    /// </summary>
+    internal TextRenderingPositionMode EffectiveTextRenderingPositionMode =>
+        OverrideTextRenderingPositionMode ?? TextRenderingPositionMode;
+
+
     /// <summary>
     /// How the renderer should round text rendering to whole pixels. Only applies if
     /// TextRenderingPositionMode is SnapToPixel. Default is to use special integer rounding.
@@ -698,13 +714,13 @@ public class Text : IVisible, IRenderableIpso,
 
     /// <summary>
     /// Rounds a position/origin to whole pixels using the configured <see cref="TextPositionRoundingMode"/>
-    /// when <see cref="TextRenderingPositionMode"/> is SnapToPixel; otherwise returns the value unchanged.
+    /// when the <see cref="EffectiveTextRenderingPositionMode"/> is SnapToPixel; otherwise returns the value unchanged.
     /// Rounding origin along with position avoids the baseline misalignment / "sizzle" seen on small pixel
     /// fonts when vertical alignment produces fractional values.
     /// </summary>
-    private static Vector2 SnapToPixelIfNeeded(Vector2 value)
+    private Vector2 SnapToPixelIfNeeded(Vector2 value)
     {
-        if (TextRenderingPositionMode != TextRenderingPositionMode.SnapToPixel)
+        if (EffectiveTextRenderingPositionMode != TextRenderingPositionMode.SnapToPixel)
         {
             return value;
         }

--- a/Runtimes/RaylibGum/Renderables/Text.cs
+++ b/Runtimes/RaylibGum/Renderables/Text.cs
@@ -345,7 +345,22 @@ public class Text : IVisible, IRenderableIpso,
     public object Tag { get; set; }
 
 
-    public BlendState BlendState { get; set; } = BlendState.NonPremultiplied;
+    /// <summary>
+    /// The Gum blend mode applied when this text is drawn. Null means "use the renderer's current
+    /// blend mode" (typically alpha blending). Honored in <see cref="Render"/> via the shared
+    /// <see cref="RenderingLibrary.Graphics.BatchDrawCallCounter"/>, mirroring the raylib Sprite and
+    /// NineSlice renderables.
+    /// </summary>
+    public global::Gum.RenderingLibrary.Blend? Blend { get; set; }
+
+    // Satisfies the IRenderable contract by deriving from Blend, so there is a single source of
+    // truth for this Text's blend mode. Render consumes Blend directly; this getter exists only for
+    // the interface (e.g. render-target additive-composite detection on RenderableBase does not
+    // apply to Text, but any generic IRenderable consumer still gets the correct state).
+    global::Gum.BlendState IRenderable.BlendState =>
+        Blend.HasValue
+            ? global::Gum.RenderingLibrary.BlendExtensions.ToBlendState(Blend.Value)
+            : global::Gum.BlendState.NonPremultiplied;
 
     public int FontSize
     {
@@ -737,6 +752,13 @@ public class Text : IVisible, IRenderableIpso,
         // in the line string, so advancing by the (untruncated) line length keeps this in sync.
         int startOfLineIndex = 0;
 
+        // Honor an explicit Blend by wrapping every glyph draw in a begin/end pair, mirroring the
+        // raylib Sprite and NineSlice renderables. Null Blend leaves the renderer's ambient mode.
+        if (Blend.HasValue)
+        {
+            global::RenderingLibrary.Graphics.Renderer.Self.BatchDrawCallCounter.BeginBlendMode(Blend.Value);
+        }
+
         for(int i = 0; i < WrappedText.Count; i++)
         {
             var line = WrappedText[i];
@@ -772,6 +794,11 @@ public class Text : IVisible, IRenderableIpso,
             }
 
             startOfLineIndex += WrappedText[i].Length;
+        }
+
+        if (Blend.HasValue)
+        {
+            global::RenderingLibrary.Graphics.Renderer.Self.BatchDrawCallCounter.EndBlendMode();
         }
     }
 

--- a/Samples/raylib/Screens/TextScreen.cs
+++ b/Samples/raylib/Screens/TextScreen.cs
@@ -4,6 +4,7 @@ using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using Raylib_cs;
+using RenderingLibrary.Graphics;
 
 namespace Examples.Shapes;
 
@@ -74,6 +75,107 @@ internal class TextScreen : FrameworkElement
         withOutline.FontSize = 24;
         withOutline.OutlineThickness = 2;
         container.Children.Add(withOutline);
+
+        BuildTextParitySection(container);
+    }
+
+    // #3432 raylib Text parity: Blend, per-instance TextRenderingPositionMode override, and
+    // GetCharacterIndexAtPosition. All three are runtime-observable, so this section is the manual
+    // verification surface for the parity batch.
+    private static void BuildTextParitySection(ContainerRuntime container)
+    {
+        // --- Blend on Text: additive vs normal white text over an identical blue box ---
+        AddSectionLabel(container, "Blend on Text (#3432): additive (brightens) vs normal, over a blue box");
+        var blendRow = new ContainerRuntime();
+        blendRow.WidthUnits = DimensionUnitType.RelativeToChildren;
+        blendRow.HeightUnits = DimensionUnitType.RelativeToChildren;
+        blendRow.Width = 0;
+        blendRow.Height = 0;
+        blendRow.ChildrenLayout = ChildrenLayout.LeftToRightStack;
+        blendRow.StackSpacing = 16;
+        blendRow.AddChild(BuildBlendCell("Additive", Gum.RenderingLibrary.Blend.Additive));
+        blendRow.AddChild(BuildBlendCell("Normal", null));
+        container.Children.Add(blendRow);
+
+        // --- Per-instance TextRenderingPositionMode override, at a fractional origin ---
+        AddSectionLabel(container, "TextRenderingPositionMode (#3432): fractional origin; button toggles snap");
+        var snapText = new TextRuntime();
+        snapText.FontSize = 20;
+        snapText.X = 120.5f;
+        snapText.Text = "Fractional X=120.5 - SnapToPixel";
+        snapText.TextRenderingPositionMode = Gum.Renderables.TextRenderingPositionMode.SnapToPixel;
+        container.Children.Add(snapText);
+
+        var toggleButton = new Button();
+        toggleButton.Text = "Toggle snap mode";
+        toggleButton.Click += (_, _) =>
+        {
+            if (snapText.TextRenderingPositionMode == Gum.Renderables.TextRenderingPositionMode.SnapToPixel)
+            {
+                snapText.TextRenderingPositionMode = Gum.Renderables.TextRenderingPositionMode.FreeFloating;
+                snapText.Text = "Fractional X=120.5 - FreeFloating";
+            }
+            else
+            {
+                snapText.TextRenderingPositionMode = Gum.Renderables.TextRenderingPositionMode.SnapToPixel;
+                snapText.Text = "Fractional X=120.5 - SnapToPixel";
+            }
+        };
+        container.Children.Add(toggleButton.Visual);
+
+        // --- GetCharacterIndexAtPosition: click the text, report the hit index ---
+        AddSectionLabel(container, "GetCharacterIndexAtPosition (#3432): click the text below");
+        var hitText = new TextRuntime();
+        hitText.FontSize = 24;
+        hitText.Text = "Click me to report the character index";
+        hitText.HasEvents = true;
+        container.Children.Add(hitText);
+
+        var hitResult = new TextRuntime();
+        hitResult.FontSize = 16;
+        hitResult.Text = "(no click yet)";
+        container.Children.Add(hitResult);
+
+        hitText.Click += (_, _) =>
+        {
+            float cursorX = FrameworkElement.MainCursor.XRespectingGumZoomAndBounds();
+            float cursorY = FrameworkElement.MainCursor.YRespectingGumZoomAndBounds();
+            int index = hitText.GetCharacterIndexAtPosition(cursorX, cursorY);
+            hitResult.Text = $"Character index at click: {index}";
+        };
+    }
+
+    private static ContainerRuntime BuildBlendCell(string label, Gum.RenderingLibrary.Blend? blend)
+    {
+        var cell = new ContainerRuntime();
+        cell.Width = 200;
+        cell.Height = 48;
+
+        var background = new RectangleRuntime();
+        background.WidthUnits = DimensionUnitType.RelativeToParent;
+        background.HeightUnits = DimensionUnitType.RelativeToParent;
+        background.Width = 0;
+        background.Height = 0;
+        background.IsFilled = true;
+        background.FillColor = new Color(40, 60, 160, 255);
+        cell.Children.Add(background);
+
+        var text = new TextRuntime();
+        text.WidthUnits = DimensionUnitType.RelativeToParent;
+        text.HeightUnits = DimensionUnitType.RelativeToParent;
+        text.Width = 0;
+        text.Height = 0;
+        text.FontSize = 24;
+        text.Text = label;
+        text.Red = 255;
+        text.Green = 255;
+        text.Blue = 255;
+        text.HorizontalAlignment = HorizontalAlignment.Center;
+        text.VerticalAlignment = VerticalAlignment.Center;
+        text.Blend = blend;
+        cell.Children.Add(text);
+
+        return cell;
     }
 
     private static void AddSectionLabel(ContainerRuntime container, string text)

--- a/Tests/RaylibGum.Tests/Runtimes/BlendTests.cs
+++ b/Tests/RaylibGum.Tests/Runtimes/BlendTests.cs
@@ -62,4 +62,32 @@ public class BlendTests : BaseTestClass
         sut.Blend.ShouldBeNull();
         ((Sprite)sut.RenderableComponent).Blend.ShouldBeNull();
     }
+
+    [Fact]
+    public void TextRuntime_Blend_DefaultsToNull()
+    {
+        TextRuntime sut = new();
+        sut.Blend.ShouldBeNull();
+    }
+
+    [Fact]
+    public void TextRuntime_Blend_RoundTripsThroughContainedRenderable()
+    {
+        TextRuntime sut = new();
+        sut.Blend = Blend.Additive;
+
+        sut.Blend.ShouldBe(Blend.Additive);
+        ((Text)sut.RenderableComponent).Blend.ShouldBe(Blend.Additive);
+    }
+
+    [Fact]
+    public void TextRuntime_Blend_SetToNullClearsContainedRenderable()
+    {
+        TextRuntime sut = new();
+        sut.Blend = Blend.Additive;
+        sut.Blend = null;
+
+        sut.Blend.ShouldBeNull();
+        ((Text)sut.RenderableComponent).Blend.ShouldBeNull();
+    }
 }

--- a/Tests/RaylibGum.Tests/Runtimes/TextRuntimeTests.cs
+++ b/Tests/RaylibGum.Tests/Runtimes/TextRuntimeTests.cs
@@ -398,6 +398,34 @@ public class TextRuntimeTests : BaseTestClass
 
     #endregion
 
+    #region GetCharacterIndexAtPosition
+
+    // The pass-through delegates to the shared TextExtensions.GetCharacterIndexAtPosition, whose
+    // RAYLIB branch measures per-character width with MeasureTextEx. A click at the very left edge of
+    // an unmanaged Text (absolute origin 0,0) must land on the first character.
+    [Fact]
+    public void GetCharacterIndexAtPosition_AtLeftEdge_ShouldReturnZero()
+    {
+        // An unmanaged Text sits at absolute origin (0,0), so screen (0,0) is its top-left.
+        TextRuntime sut = new();
+        sut.Text = "Hello";
+
+        sut.GetCharacterIndexAtPosition(0, 0).ShouldBe(0);
+    }
+
+    // A click far past the right edge of a single line clamps to the end of the text (index == length),
+    // matching the MonoGame renderable's behavior.
+    [Fact]
+    public void GetCharacterIndexAtPosition_FarRightOfSingleLine_ShouldReturnTextLength()
+    {
+        TextRuntime sut = new();
+        sut.Text = "Hello";
+
+        sut.GetCharacterIndexAtPosition(1000, 0).ShouldBe(5);
+    }
+
+    #endregion
+
     #region HeightUnits
 
     [Fact]

--- a/Tests/RaylibGum.Tests/Runtimes/TextRuntimeTests.cs
+++ b/Tests/RaylibGum.Tests/Runtimes/TextRuntimeTests.cs
@@ -650,6 +650,69 @@ public class TextRuntimeTests : BaseTestClass
 
     #endregion
 
+    #region TextRenderingPositionMode
+
+    // The renderable resolves its effective mode as (instance override ?? static default), mirroring
+    // the MonoGame BitmapFont path. With no override set, the static default wins.
+    [Fact]
+    public void EffectiveTextRenderingPositionMode_ShouldFallBackToStatic_WhenNoOverride()
+    {
+        Gum.Renderables.TextRenderingPositionMode saved = Gum.Renderables.Text.TextRenderingPositionMode;
+        try
+        {
+            Gum.Renderables.Text.TextRenderingPositionMode = Gum.Renderables.TextRenderingPositionMode.FreeFloating;
+            TextRuntime sut = new();
+            Gum.Renderables.Text renderable = (Gum.Renderables.Text)sut.RenderableComponent;
+            renderable.OverrideTextRenderingPositionMode = null;
+
+            renderable.EffectiveTextRenderingPositionMode.ShouldBe(Gum.Renderables.TextRenderingPositionMode.FreeFloating);
+        }
+        finally
+        {
+            Gum.Renderables.Text.TextRenderingPositionMode = saved;
+        }
+    }
+
+    // A per-instance override takes precedence over the static default.
+    [Fact]
+    public void EffectiveTextRenderingPositionMode_ShouldPreferInstanceOverride_OverStatic()
+    {
+        Gum.Renderables.TextRenderingPositionMode saved = Gum.Renderables.Text.TextRenderingPositionMode;
+        try
+        {
+            Gum.Renderables.Text.TextRenderingPositionMode = Gum.Renderables.TextRenderingPositionMode.SnapToPixel;
+            TextRuntime sut = new();
+            Gum.Renderables.Text renderable = (Gum.Renderables.Text)sut.RenderableComponent;
+            renderable.OverrideTextRenderingPositionMode = Gum.Renderables.TextRenderingPositionMode.FreeFloating;
+
+            renderable.EffectiveTextRenderingPositionMode.ShouldBe(Gum.Renderables.TextRenderingPositionMode.FreeFloating);
+        }
+        finally
+        {
+            Gum.Renderables.Text.TextRenderingPositionMode = saved;
+        }
+    }
+
+    [Fact]
+    public void TextRenderingPositionMode_ShouldDefaultToNull()
+    {
+        TextRuntime sut = new();
+        sut.TextRenderingPositionMode.ShouldBeNull();
+    }
+
+    [Fact]
+    public void TextRenderingPositionMode_ShouldRoundTripThroughRenderable()
+    {
+        TextRuntime sut = new();
+        sut.TextRenderingPositionMode = Gum.Renderables.TextRenderingPositionMode.FreeFloating;
+
+        sut.TextRenderingPositionMode.ShouldBe(Gum.Renderables.TextRenderingPositionMode.FreeFloating);
+        ((Gum.Renderables.Text)sut.RenderableComponent).OverrideTextRenderingPositionMode
+            .ShouldBe(Gum.Renderables.TextRenderingPositionMode.FreeFloating);
+    }
+
+    #endregion
+
     #region WidthUnits
 
     [Fact]


### PR DESCRIPTION
Brings three raylib Text features to parity with the MonoGame runtime (one P2 bullet from #3432, minus OverlapDirection). Three commits, one per feature.

## Features

**1. GetCharacterIndexAtPosition (raylib)** — The screen-position-to-character-index hit test on `TextRuntime` was gated `#if !RAYLIB && !SKIA`. The underlying algorithm already exists as the source-shared `TextExtensions.GetCharacterIndexAtPosition`, whose `#if RAYLIB` branch measures per-character width via `MeasureTextEx` and is already compiled into RaylibGum — only the runtime pass-through was missing. Widened its gate to `#if !SKIA` (SKIA still excluded).

**2. Blend (raylib)** — The raylib `Text` renderable carried a dead `Gum.BlendState` field that `Render` never consulted, so text ignored the requested blend mode. Converged it onto the same `Gum.RenderingLibrary.Blend?` shape the raylib `Sprite`/`NineSlice` renderables use: replaced the dead field with a nullable `Blend` property (implementing the get-only `IRenderable.BlendState` contract derived from `Blend`, single source of truth), and `Render` now wraps its glyph draws in `BatchDrawCallCounter.BeginBlendMode(Blend)`/`EndBlendMode()` when set. `TextRuntime` gains a raylib branch for `Blend` mapping to `ContainedText.Blend` (mirroring `SpriteRuntime`); the XNA-typed `BlendState` stays XNALIKE-only.

**3. TextRenderingPositionMode per-instance override (raylib)** — The raylib `Text` renderable only had a static `TextRenderingPositionMode`. Added a nullable per-instance `OverrideTextRenderingPositionMode`, resolving the effective mode as `(override ?? static)` (mirroring the MonoGame `BitmapFont` path); `SnapToPixelIfNeeded` is now an instance method. Widened the shared `TextRuntime.TextRenderingPositionMode` pass-through to `#if !SKIA`.

Out of scope (declined for now): OverlapDirection, which needs a per-glyph render rework.

## Tests

New RaylibGum.Tests coverage: hit-test left-edge (index 0) and far-right clamp (index == length); Blend round-trip (default null, set/clear through the contained renderable); TextRenderingPositionMode runtime round-trip + renderable effective-mode resolution (static fallback and override-wins). Full RaylibGum.Tests (428) and MonoGameGum.Tests (1792, proving the shared `TextRuntime.cs` still compiles/passes on XNALIKE) are green; KniGum and SkiaGum also build.

The render-honoring of Blend on text glyphs is not unit-tested — headless, a Text does not reliably ink a sampled pixel, so a pixel differential would be a false-equal, and text batches as a single draw so a draw-call differential can't observe it either. It is covered by manual verification and by the shared `BatchDrawCallCounter` blend path that `BlendModeRenderTests` already pixel-validates.

## Manual test (needed — all three are runtime-observable)

Build `Samples/raylib/RaylibSample.sln` (`Samples/raylib/GumTest.csproj`) and run it, then:

1. Click the **Text** button in the top nav strip.
2. Scroll to the new "#3432" parity section at the bottom of the screen.
3. **Blend:** confirm the "Additive" white label over the blue box looks noticeably brighter/washed-out compared to the "Normal" white label over the identical blue box next to it.
4. **TextRenderingPositionMode:** find the "Fractional X=120.5 - SnapToPixel" line. Click **Toggle snap mode** a few times; the label text flips between "SnapToPixel" and "FreeFloating" and the glyphs shift by a sub-pixel (crisper vs. slightly softer/offset) as the mode changes. No crash.
5. **GetCharacterIndexAtPosition:** click at various horizontal positions along the "Click me to report the character index" line. Confirm the "Character index at click:" label below updates, and the reported index grows left-to-right (0 near the left edge, clamping to the full length past the right edge).

Part of #3432.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
