### PR TITLE
Docs: mark raylib native text input as intentional won't-do

### DIFF
--- a/MonoGameGum/GumService.cs
+++ b/MonoGameGum/GumService.cs
@@ -776,6 +776,13 @@ public class GumService : IGumService
         };
 
         DeferredQueue = new DeferredActionQueue();
+        // NativeTextInput is the OS-provided *modal* text-entry dialog (the iOS soft-keyboard
+        // popup / console prompt), wrapping XNA's KeyboardInput.Show. It is intentionally
+        // MonoGame/KNI only. raylib, FNA, and Sokol are desktop-only (or don't ship the API),
+        // so they deliberately leave this null and rely on inline typing via each Keyboard's
+        // GetStringTyped instead — this is not an unfinished raylib port (see issue #3432).
+        // The modal dialog only matters on true touch/console targets, which raylib-cs has no
+        // natives for. See INativeTextInput and TextBoxBase.TryShowNativeKeyboard.
 #if MONOGAME || KNI
         NativeTextInput = new MonoGameNativeTextInput();
 #endif


### PR DESCRIPTION
## What

Adds a source comment at the `#if MONOGAME || KNI` gate in `MonoGameGum/GumService.cs` documenting that leaving `NativeTextInput` null on raylib (and FNA/Sokol) is **intentional**, so it isn't mistaken for an unfinished port later.

`NativeTextInput` (`INativeTextInput` → `MonoGameNativeTextInput`, wrapping XNA `KeyboardInput.Show`) is the OS-provided *modal* text-entry dialog — the iOS soft-keyboard popup / console prompt. It's a touch/console affordance used only on iOS-via-MonoGame; MonoGame desktop never calls it either. Desktop raylib relies on inline typing via `Keyboard.GetStringTyped` → `Raylib.GetCharPressed`, and raylib-cs ships no mobile natives, so there's no target the modal would serve.

## Why

Requested so we don't revisit this as a gap. The umbrella epic #3432's "Native text input / IME absent" item has been updated to **NOT DOING** with the full rationale; this comment is the in-source pointer to that decision.

## Manual test

Not needed — comment-only change; `MonoGameGum` builds clean (0 errors, no new warnings).

Part of #3432 (raylib parity umbrella — intentionally **not** closing it here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
