### PR TITLE
raylib Sprite: honor ColorOperation.ColorTextureAlpha (#3486)

### DIFF
--- a/RenderingLibrary/Graphics/SpriteBatchStack.cs
+++ b/RenderingLibrary/Graphics/SpriteBatchStack.cs
@@ -158,6 +158,25 @@ namespace RenderingLibrary.Graphics
             StateChangeInfoListPool.MakeAllUnused();
         }
 
+        /// <summary>
+        /// Flushes the currently-open SpriteBatch — drawing its queued sprites with the effect's
+        /// <b>current</b> state — without touching the parameter stack or <see cref="currentParameters"/>.
+        /// Call this before mutating a shared <see cref="Effect"/>'s state (e.g. BasicEffect fog for
+        /// ColorTextureAlpha, or View/Projection) so a still-pending Deferred batch is drawn with the
+        /// state it was queued under, not the incoming one. Without it, the subsequent
+        /// <see cref="ReplaceRenderStates"/> flush would apply the just-mutated shared effect to the
+        /// previous batch's sprites (the ColorTextureAlpha whole-frame fog leak, #3486). A no-op when
+        /// no batch is open; the following <see cref="ReplaceRenderStates"/> then simply re-begins.
+        /// </summary>
+        public void FlushIfBegan()
+        {
+            if (beginEndState == SpriteBatchBeginEndState.Began)
+            {
+                SpriteBatch.End();
+                beginEndState = SpriteBatchBeginEndState.Ended;
+            }
+        }
+
         public void Begin(bool createNewParameters = true)
         {
             if(createNewParameters)

--- a/RenderingLibrary/Graphics/SpriteRenderer.cs
+++ b/RenderingLibrary/Graphics/SpriteRenderer.cs
@@ -183,6 +183,13 @@ public class SpriteRenderer
         int width = camera.ClientWidth;
         int height = camera.ClientHeight;
 
+        // Flush any still-open Deferred batch BEFORE mutating the shared BasicEffect below. In Deferred
+        // mode SpriteBatch applies the effect's state at End, so the ColorTextureAlpha fog toggle (and
+        // View/Projection) set below would otherwise be applied retroactively to the previous batch's
+        // already-queued sprites — the whole-frame fog leak (#3486). The following ReplaceRenderStates
+        // re-begins the batch; for state that isn't changing this is output-identical.
+        mSpriteBatch.FlushIfBegan();
+
         Effect effectiveEffect = null;
 
         // A render-target container can supply its own post-process shader. When present it

--- a/Runtimes/RaylibGum/Renderables/ColorTextureAlphaShader.cs
+++ b/Runtimes/RaylibGum/Renderables/ColorTextureAlphaShader.cs
@@ -1,0 +1,74 @@
+using Raylib_cs;
+using static Raylib_cs.Raylib;
+
+namespace Gum.Renderables;
+
+/// <summary>
+/// Owns the single fragment shader that reproduces MonoGame's
+/// <see cref="global::RenderingLibrary.Graphics.ColorOperation.ColorTextureAlpha"/> on raylib: the
+/// texture supplies only an alpha mask, and the sprite is filled with its tint color (issue #3486,
+/// umbrella #3432). A <see cref="global::Gum.Renderables.Sprite"/> whose
+/// <see cref="Sprite.ColorOperation"/> is <c>ColorTextureAlpha</c> binds this shader around its
+/// <c>DrawTexturePro</c> calls; a <c>Modulate</c> sprite (the default) draws unshaded exactly as before.
+///
+/// <para><b>Output form:</b> the shader emits <b>non-premultiplied</b> <c>(tint.rgb, tint.a * texA)</c>
+/// — the same form a normal <c>DrawTexturePro</c> emits (<c>texture.rgba * tint</c>), just with the
+/// texture's RGB replaced by the tint's and the alpha masked by the texture. That is what lets a
+/// ColorTextureAlpha sprite composite correctly both on screen (raylib's default straight-alpha blend)
+/// and inside a render-target bake (the SrcAlpha/OneMinusSrcAlpha premultiply pass in
+/// <see cref="global::RenderingLibrary.Graphics.BatchDrawCallCounter"/>), with no extra premultiply math.</para>
+///
+/// <para><b>Lifecycle:</b> the shader is created lazily on first <see cref="Shader"/> access (a GL
+/// context must exist by then — the first Render inside a draw), held for reuse, and released by
+/// <see cref="Dispose"/>. Mirrors <see cref="ShadowBlurRenderer"/>'s shader-ownership pattern; the
+/// raylib <see cref="global::RenderingLibrary.Graphics.Renderer"/> owns the instance.</para>
+/// </summary>
+public sealed class ColorTextureAlphaShader
+{
+    // raylib's default-shader interface (texture0 / colDiffuse / fragColor / fragTexCoord). The tint
+    // passed to DrawTexturePro arrives as fragColor; colDiffuse stays white unless a material color is
+    // set. rgb is taken from the tint and alpha is the tint's alpha masked by the sampled texture alpha.
+    private const string FragmentShader = @"#version 330
+in vec2 fragTexCoord;
+in vec4 fragColor;
+out vec4 finalColor;
+uniform sampler2D texture0;
+uniform vec4 colDiffuse;
+void main()
+{
+    float texAlpha = texture(texture0, fragTexCoord).a;
+    vec4 tint = fragColor * colDiffuse;
+    finalColor = vec4(tint.rgb, tint.a * texAlpha);
+}
+";
+
+    private Shader _shader;
+    private bool _loaded;
+
+    /// <summary>
+    /// The loaded fragment shader, created on first access. Bind it via
+    /// <c>BatchDrawCallCounter.BeginShaderMode</c> around a ColorTextureAlpha sprite's draw calls.
+    /// </summary>
+    public Shader Shader
+    {
+        get
+        {
+            if (!_loaded)
+            {
+                _shader = LoadShaderFromMemory(null, FragmentShader);
+                _loaded = true;
+            }
+            return _shader;
+        }
+    }
+
+    /// <summary>Releases the shader if it was loaded. Call on renderer shutdown.</summary>
+    public void Dispose()
+    {
+        if (_loaded)
+        {
+            UnloadShader(_shader);
+            _loaded = false;
+        }
+    }
+}

--- a/Runtimes/RaylibGum/Renderables/Sprite.cs
+++ b/Runtimes/RaylibGum/Renderables/Sprite.cs
@@ -14,7 +14,7 @@ using ToolsUtilitiesStandard.Helpers;
 using static Raylib_cs.Raylib;
 
 namespace Gum.Renderables;
-public class Sprite : InvisibleRenderable, IAspectRatio, ITextureCoordinate, IAnimatable
+public class Sprite : InvisibleRenderable, IAspectRatio, ITextureCoordinate, IAnimatable, IRenderableIpso
 {
     public Texture2D? Texture { get; set; }
 
@@ -135,6 +135,20 @@ public class Sprite : InvisibleRenderable, IAspectRatio, ITextureCoordinate, IAn
 
     public global::Gum.RenderingLibrary.Blend? Blend { get; set; }
 
+    /// <summary>
+    /// How the sprite's tint <see cref="Color"/> combines with its texture, matching MonoGame's
+    /// <see cref="ColorOperation"/> (issue #3486). <see cref="ColorOperation.Modulate"/> (the default)
+    /// multiplies texture RGBA by the tint; <see cref="ColorOperation.ColorTextureAlpha"/> uses the
+    /// texture only as an alpha mask and fills with the tint color, via
+    /// <see cref="global::RenderingLibrary.Graphics.Renderer.ColorTextureAlphaShader"/>.
+    /// </summary>
+    public ColorOperation ColorOperation { get; set; } = ColorOperation.Modulate;
+
+    // Re-implement the interface getter so it reports this sprite's real ColorOperation. The base
+    // RenderableBase explicitly implements IRenderableIpso.ColorOperation as a hardcoded Modulate
+    // (correct for Text/NineSlice/shapes, which never vary it); a Sprite is the one renderable that does.
+    ColorOperation IRenderableIpso.ColorOperation => ColorOperation;
+
     public float? TextureWidth => RenderTargetTextureSource?.Width ?? Texture?.Width;
 
     public float? TextureHeight => RenderTargetTextureSource?.Height ?? Texture?.Height;
@@ -184,6 +198,17 @@ public class Sprite : InvisibleRenderable, IAspectRatio, ITextureCoordinate, IAn
         // if we don't have a source rectangle, the source is the entire texture
         var srcRect = SourceRectangle ?? defaultSrcRect;
 
+        // ColorTextureAlpha (issue #3486): bind the mask shader around every draw path below so the
+        // texture supplies only alpha and the sprite fills with its tint Color, matching MonoGame. The
+        // shader's non-premultiplied output composites identically to a normal Modulate draw, so it is
+        // correct both on screen and inside a render-target bake. Modulate (the default) draws unshaded.
+        bool useColorTextureAlpha = ColorOperation == ColorOperation.ColorTextureAlpha;
+        if (useColorTextureAlpha)
+        {
+            global::RenderingLibrary.Graphics.Renderer.Self.BatchDrawCallCounter.BeginShaderMode(
+                global::RenderingLibrary.Graphics.Renderer.Self.ColorTextureAlphaShader.Shader);
+        }
+
         if (Blend.HasValue)
         {
             global::RenderingLibrary.Graphics.Renderer.Self.BatchDrawCallCounter.BeginBlendMode(Blend.Value);
@@ -224,6 +249,11 @@ public class Sprite : InvisibleRenderable, IAspectRatio, ITextureCoordinate, IAn
         if (Blend.HasValue)
         {
             global::RenderingLibrary.Graphics.Renderer.Self.BatchDrawCallCounter.EndBlendMode();
+        }
+
+        if (useColorTextureAlpha)
+        {
+            global::RenderingLibrary.Graphics.Renderer.Self.BatchDrawCallCounter.EndShaderMode();
         }
     }
 

--- a/Runtimes/RaylibGum/RenderingLibrary/Renderer.cs
+++ b/Runtimes/RaylibGum/RenderingLibrary/Renderer.cs
@@ -131,6 +131,14 @@ public class Renderer : IRenderer
     public ShadowBlurRenderer ShadowBlur { get; }
 
     /// <summary>
+    /// Owns the fragment shader that reproduces MonoGame's <see cref="ColorOperation.ColorTextureAlpha"/>
+    /// on raylib. A <see cref="Gum.Renderables.Sprite"/> whose <c>ColorOperation</c> is
+    /// <c>ColorTextureAlpha</c> binds <c>ColorTextureAlphaShader.Shader</c> around its draw calls so the
+    /// texture acts as an alpha mask filled with the sprite's tint color (issue #3486).
+    /// </summary>
+    public Gum.Renderables.ColorTextureAlphaShader ColorTextureAlphaShader { get; }
+
+    /// <summary>
     /// Per-frame render-state-change counters for this renderer, including the authoritative
     /// <see cref="RenderStateChangeStatistics.DrawCallCount"/> measured via the owned RenderBatch.
     /// Reset at the start of each <see cref="Draw(SystemManagers)"/> and readable afterward to
@@ -161,6 +169,7 @@ public class Renderer : IRenderer
         _layersReadOnly = new ReadOnlyCollection<Layer>(_layers);
         _layers.Add(new Layer());
         ShadowBlur = new ShadowBlurRenderer();
+        ColorTextureAlphaShader = new Gum.Renderables.ColorTextureAlphaShader();
         RenderStateChangeStatistics = new RenderStateChangeStatistics();
         BatchDrawCallCounter = new BatchDrawCallCounter();
     }

--- a/Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/SpriteScreen.cs
+++ b/Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/SpriteScreen.cs
@@ -94,6 +94,28 @@ internal class SpriteScreen : FrameworkElement
             tintRow.AddChild(s);
         }
 
+        // ColorOperation (issue #3486) — Modulate (default) multiplies the texture by the red tint,
+        // so the bear's detail shows through red; ColorTextureAlpha uses the texture only as an alpha
+        // mask and fills with the tint, so the bear reads as a flat red silhouette. ColorOperation is
+        // exposed on the renderable only (no SpriteRuntime property), so it is set through
+        // RenderableComponent. Mirrors the raylib SpriteScreen's identical row.
+        AddLabel(container, "ColorOperation on a red-tinted bear (Modulate, ColorTextureAlpha):");
+        var colorOpRow = AddRow(container);
+        foreach (var colorOperation in new[]
+        {
+            RenderingLibrary.Graphics.ColorOperation.Modulate,
+            RenderingLibrary.Graphics.ColorOperation.ColorTextureAlpha,
+        })
+        {
+            var s = new SpriteRuntime();
+            s.SourceFileName = "BearTexture.png";
+            s.Width = 64;
+            s.Height = 64;
+            s.Color = Color.Red;
+            ((RenderingLibrary.Graphics.Sprite)s.RenderableComponent).ColorOperation = colorOperation;
+            colorOpRow.AddChild(s);
+        }
+
         // Alpha — same sprite at 64 / 128 / 192 / 255.
         AddLabel(container, "Alpha (64, 128, 192, 255):");
         var alphaRow = AddRow(container);

--- a/Samples/raylib/Screens/SpriteScreen.cs
+++ b/Samples/raylib/Screens/SpriteScreen.cs
@@ -100,6 +100,25 @@ internal class SpriteScreen : FrameworkElement
             tintRow.AddChild(s);
         }
 
+        // ColorOperation (issue #3486) — Modulate (default) multiplies the texture by the red tint,
+        // so the bear's detail shows through red; ColorTextureAlpha uses the texture only as an alpha
+        // mask and fills with the tint, so the bear reads as a flat red silhouette. ColorOperation is
+        // exposed on the renderable only (parity with MonoGame — no SpriteRuntime property), so it is
+        // set through RenderableComponent. Mirrors the MG SpriteScreen's identical row.
+        AddSectionLabel(page, "ColorOperation on a red-tinted bear (Modulate, ColorTextureAlpha):");
+        var colorOpRow = NewSection(ChildrenLayout.LeftToRightStack, spacing: 6);
+        page.AddChild(colorOpRow);
+        foreach (var colorOperation in new[] { ColorOperation.Modulate, ColorOperation.ColorTextureAlpha })
+        {
+            var s = new SpriteRuntime();
+            s.SourceFileName = "resources\\BearTexture.png";
+            s.Width = 64;
+            s.Height = 64;
+            s.Color = Color.Red;
+            ((Gum.Renderables.Sprite)s.RenderableComponent).ColorOperation = colorOperation;
+            colorOpRow.AddChild(s);
+        }
+
         // Alpha — same sprite at 64 / 128 / 192 / 255.
         AddSectionLabel(page, "Alpha (64, 128, 192, 255):");
         var alphaRow = NewSection(ChildrenLayout.LeftToRightStack, spacing: 6);

--- a/Tests/MonoGameGum.IntegrationTests/MonoGameGum/Rendering/SpriteColorOperationLeakTests.cs
+++ b/Tests/MonoGameGum.IntegrationTests/MonoGameGum/Rendering/SpriteColorOperationLeakTests.cs
@@ -1,0 +1,142 @@
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using Gum.DataTypes;
+using Gum.GueDeriving;
+using RenderingLibrary;
+using RenderingLibrary.Content;
+using RenderingLibrary.Graphics;
+using Shouldly;
+using Xunit;
+
+namespace MonoGameGum.IntegrationTests.MonoGameGum.Rendering;
+
+/// <summary>
+/// Regression for the ColorTextureAlpha state leak (surfaced alongside issue #3486). MonoGame's
+/// ColorTextureAlpha technique is a Fog hack that mutates the shared BasicEffect. In Deferred
+/// SpriteBatch mode the effect state is applied at the batch's End, so mutating fog for an incoming
+/// ColorTextureAlpha sprite BEFORE the previous (Modulate) batch was flushed retroactively fogged
+/// every sprite already queued — the whole frame drawn above the ColorTextureAlpha sprite came out
+/// wrong. The fix flushes the pending batch before any shared-effect mutation
+/// (<c>SpriteBatchStack.FlushIfBegan</c>, called at the top of <c>SpriteRenderer.BeginSpriteBatch</c>).
+/// </summary>
+public class SpriteColorOperationLeakTests : BaseTestClass
+{
+    [Fact]
+    public void Draw_ModulateSpriteAboveColorTextureAlphaSprite_DoesNotFogTheModulateSprite()
+    {
+        using MinimalGame game = new();
+        game.RunOneFrame();
+
+        GraphicsDevice gd = game.GraphicsDevice;
+        SystemManagers managers = SystemManagers.Default;
+        Renderer renderer = managers.Renderer;
+
+        // Pure green (Color.Green is HTML green = 0,128,0 — use full-intensity so the assertion is
+        // unambiguous about "the sprite kept its own color").
+        Texture2D green = new(gd, 1, 1);
+        green.SetData(new[] { new Color((byte)0, (byte)255, (byte)0, (byte)255) });
+
+        // Modulate sprite (green texture, white tint => green) at the top; it is queued first.
+        SpriteRuntime modulate = MakeSprite(green, x: 0, y: 0, RenderingLibrary.Graphics.ColorOperation.Modulate);
+
+        // ColorTextureAlpha sprite below it. Drawing this one flips the shared BasicEffect's fog;
+        // before the fix that flushed the still-pending Modulate batch fogged.
+        SpriteRuntime colorTextureAlpha = MakeSprite(green, x: 0, y: 40,
+            RenderingLibrary.Graphics.ColorOperation.ColorTextureAlpha);
+
+        ContainerRuntime root = new();
+        root.X = 0;
+        root.Y = 0;
+        root.AddChild(modulate);
+        root.AddChild(colorTextureAlpha);
+
+        root.AddToManagers(managers, null);
+        root.UpdateLayout();
+
+        try
+        {
+            Color modulatePixel = RenderAndSample(gd, renderer, managers, sampleX: 16, sampleY: 16);
+
+            // The Modulate sprite must still read green — its own texture*tint result — not the
+            // leaked fog color the ColorTextureAlpha sprite's Fog toggle produced.
+            modulatePixel.G.ShouldBeGreaterThan((byte)200);
+            modulatePixel.R.ShouldBeLessThan((byte)80);
+            modulatePixel.B.ShouldBeLessThan((byte)80);
+        }
+        finally
+        {
+            green.Dispose();
+        }
+    }
+
+    private static SpriteRuntime MakeSprite(Texture2D texture, int x, int y,
+        RenderingLibrary.Graphics.ColorOperation colorOperation)
+    {
+        SpriteRuntime sprite = new();
+        sprite.WidthUnits = DimensionUnitType.Absolute;
+        sprite.HeightUnits = DimensionUnitType.Absolute;
+        sprite.Width = 32;
+        sprite.Height = 32;
+        sprite.X = x;
+        sprite.Y = y;
+        sprite.Texture = texture;
+        sprite.Color = Color.White;
+        ((RenderingLibrary.Graphics.Sprite)sprite.RenderableComponent).ColorOperation = colorOperation;
+        return sprite;
+    }
+
+    // Renders the managers tree into an off-screen capture target (twice, so first-frame one-time
+    // setup doesn't skew the pixels) and samples one pixel. Mirrors RenderTargetEffectTests.
+    private static Color RenderAndSample(GraphicsDevice gd, Renderer renderer, SystemManagers managers,
+        int sampleX, int sampleY)
+    {
+        const int w = 128;
+        const int h = 128;
+        using RenderTarget2D capture = new(gd, w, h, false, SurfaceFormat.Color, DepthFormat.None, 0,
+            RenderTargetUsage.PreserveContents);
+
+        for (int i = 0; i < 2; i++)
+        {
+            gd.SetRenderTarget(capture);
+            gd.Clear(Color.Black);
+            renderer.Draw(managers);
+        }
+        gd.SetRenderTarget(null);
+
+        Color[] data = new Color[w * h];
+        capture.GetData(data);
+        return data[(sampleY * w) + sampleX];
+    }
+
+    private class MinimalGame : Game
+    {
+        private readonly GraphicsDeviceManager _graphics;
+        public GumService GumService { get; }
+
+        public MinimalGame()
+        {
+            LoaderManager.Self?.DisposeAndClear();
+            _graphics = new GraphicsDeviceManager(this);
+            GumService = new GumService();
+        }
+
+        protected override void Initialize()
+        {
+            base.Initialize();
+            GumService.Initialize(this, Gum.Forms.DefaultVisualsVersion.V2);
+        }
+
+        protected override void Update(GameTime gameTime) { }
+        protected override void Draw(GameTime gameTime) => GraphicsDevice.Clear(Color.CornflowerBlue);
+
+        protected override void Dispose(bool disposing)
+        {
+            if (GumService.IsInitialized)
+            {
+                GumService.Uninitialize();
+            }
+            LoaderManager.Self?.DisposeAndClear();
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/Tests/RaylibGum.Tests/Rendering/SpriteColorOperationTests.cs
+++ b/Tests/RaylibGum.Tests/Rendering/SpriteColorOperationTests.cs
@@ -1,0 +1,112 @@
+using Gum.DataTypes;
+using Gum.GueDeriving;
+using Gum.Renderables;
+using Raylib_cs;
+using RenderingLibrary.Graphics;
+using Shouldly;
+using static Raylib_cs.Raylib;
+
+namespace RaylibGum.Tests.Rendering;
+
+/// <summary>
+/// Pixel-readback tests proving the raylib Sprite honors <see cref="ColorOperation.ColorTextureAlpha"/>
+/// (issue #3486, umbrella #3432): the texture's alpha is used as a mask and the sprite is filled with
+/// its tint <c>Color</c>, so the texture's own RGB is discarded — matching MonoGame's ColorTextureAlpha
+/// technique. The default <see cref="ColorOperation.Modulate"/> still multiplies texture RGB by the tint.
+/// Uses the same render-target pixel-readback harness as the sibling <see cref="BlendModeRenderTests"/>:
+/// a single opaque sprite whose texture color and tint color differ is baked into a render-target cell,
+/// so Modulate (texture*tint) and ColorTextureAlpha (tint, texture-alpha-masked) land on visibly
+/// different pixels. The cell center is unaffected by the RT's bottom-up GL vertical flip.
+/// </summary>
+public class SpriteColorOperationTests : BaseTestClass
+{
+    private static void DrawOnce()
+    {
+        BeginDrawing();
+        GumService.Default.Draw();
+        EndDrawing();
+    }
+
+    private static Color ReadRenderTargetCenter(RenderTexture2D renderTexture)
+    {
+        Image image = LoadImageFromTexture(renderTexture.Texture);
+        try
+        {
+            return GetImageColor(image, renderTexture.Texture.Width / 2, renderTexture.Texture.Height / 2);
+        }
+        finally
+        {
+            UnloadImage(image);
+        }
+    }
+
+    // SpriteRuntime defaults WidthUnits/HeightUnits to PercentageOfSourceFile, so Width/Height must be
+    // forced to Absolute — otherwise "Width = size" is read as "size% of the 4px source", shrinking the
+    // sprite to a sliver that misses the sampled center. ColorOperation lives on the renderable only
+    // (parity with MonoGame, which exposes no SpriteRuntime.ColorOperation), so it is set via the
+    // contained Sprite through RenderableComponent.
+    private static Color BakeSpriteCell(int size, Color textureColor, Color tint, ColorOperation colorOperation)
+    {
+        Image image = GenImageColor(4, 4, textureColor);
+        Texture2D texture = LoadTextureFromImage(image);
+        UnloadImage(image);
+
+        SpriteRuntime sprite = new();
+        sprite.WidthUnits = DimensionUnitType.Absolute;
+        sprite.HeightUnits = DimensionUnitType.Absolute;
+        sprite.Width = size;
+        sprite.Height = size;
+        sprite.Texture = texture;
+        sprite.Color = tint;
+        ((Sprite)sprite.RenderableComponent).ColorOperation = colorOperation;
+
+        ContainerRuntime cell = new();
+        cell.Width = size;
+        cell.Height = size;
+        cell.IsRenderTarget = true;
+        cell.Children.Add(sprite);
+
+        GumService.Default.Root.Children.Add(cell);
+        GumService.Default.Root.UpdateLayout();
+
+        DrawOnce();
+
+        Color center = ReadRenderTargetCenter(Renderer.Self.TryGetBakedRenderTargetFor(cell)!.Value);
+
+        GumService.Default.Root.Children.Clear();
+        UnloadTexture(texture);
+        return center;
+    }
+
+    [Fact]
+    public void Draw_ColorTextureAlphaSprite_FillsWithTintColorIgnoringTextureRgb()
+    {
+        Color center = BakeSpriteCell(
+            32,
+            textureColor: new Color((byte)0, (byte)0, (byte)255, (byte)255),
+            tint: new Color((byte)255, (byte)0, (byte)0, (byte)255),
+            colorOperation: ColorOperation.ColorTextureAlpha);
+
+        // The blue texture's RGB is discarded; the sprite is filled with its red tint, masked by the
+        // texture's (fully opaque) alpha. So the baked pixel reads red — not the blue*red = black a
+        // Modulate draw would produce.
+        center.R.ShouldBeGreaterThan((byte)200);
+        center.G.ShouldBeLessThan((byte)50);
+        center.B.ShouldBeLessThan((byte)50);
+    }
+
+    [Fact]
+    public void Draw_ModulateSprite_MultipliesTextureRgbByTint()
+    {
+        Color center = BakeSpriteCell(
+            32,
+            textureColor: new Color((byte)0, (byte)0, (byte)255, (byte)255),
+            tint: new Color((byte)255, (byte)0, (byte)0, (byte)255),
+            colorOperation: ColorOperation.Modulate);
+
+        // The default Modulate multiplies texture (blue) by tint (red) => black. Pins the untouched
+        // default path and contrasts it with ColorTextureAlpha above.
+        center.R.ShouldBeLessThan((byte)50);
+        center.B.ShouldBeLessThan((byte)50);
+    }
+}


### PR DESCRIPTION
## What

The raylib `Sprite` renderable ignored `ColorOperation` and always rendered `Modulate`, unlike MonoGame. It now honors `ColorOperation.ColorTextureAlpha` — the texture supplies only an alpha mask and the sprite is filled with its tint `Color` — matching MonoGame's technique.

- `Gum.Renderables.Sprite` gains a settable `ColorOperation` (default `Modulate`), re-implementing the `IRenderableIpso.ColorOperation` getter that `RenderableBase` hardcodes to `Modulate`.
- A small `Renderer`-owned `ColorTextureAlphaShader` holds one GLSL fragment shader (load-once/dispose, mirroring `ShadowBlurRenderer`). A `ColorTextureAlpha` sprite binds it around its `DrawTexturePro` calls; a `Modulate` sprite draws unshaded exactly as before.
- The shader emits **non-premultiplied** `(tint.rgb, tint.a·texA)` — the same output form a normal `DrawTexturePro` emits — so it composites correctly both on screen (raylib's straight-alpha blend) and inside a render-target bake (the `SrcAlpha/OneMinusSrcAlpha` premultiply pass), with no extra premultiply math.

## Scope — strict parity with MonoGame

Exposed on the **renderable only** (set via `RenderableComponent`). No `SpriteRuntime.ColorOperation` and no Gum editor variable, because MonoGame exposes neither — adding them would make raylib exceed MonoGame. `RenderableBase.cs:31`'s hardcoded `Modulate` is left as-is (correct for Text/NineSlice/shapes, which never vary it) and re-implemented only on `Sprite`.

## Tests

`Tests/RaylibGum.Tests/Rendering/SpriteColorOperationTests.cs` — pixel-readback (llvmpipe) proving a blue-texture / red-tint sprite bakes **red** under `ColorTextureAlpha` (texture RGB discarded) and **black** under `Modulate` (blue×red). Full RaylibGum.Tests suite green (432/432).

## Manual verification

Added a matching **ColorOperation** row (red-tinted bear: `Modulate` vs `ColorTextureAlpha`) to the mirrored raylib and MonoGame in-code `SpriteScreen` samples, so the two backends can be compared side by side. Both sample projects build. Expected: `Modulate` shows a red-tinted bear with texture detail; `ColorTextureAlpha` shows a flat red bear silhouette. Identical on both backends.

## Bundled fix — MonoGame ColorTextureAlpha whole-frame fog leak (core renderer)

Exercising `ColorTextureAlpha` in the MonoGame sample surfaced a **pre-existing, latent** MonoGame bug (unrelated to the raylib change): the whole frame drawn *above* a `ColorTextureAlpha` sprite came out fogged/red.

- **Root cause:** MonoGame's `ColorTextureAlpha` is a BasicEffect **Fog hack**. In Deferred `SpriteBatch`, effect state applies at the batch's `End`, but `SpriteRenderer.BeginSpriteBatch` mutated the **shared** `basicEffect` (fog on, plus View/Projection) *before* `ReplaceRenderStates` flushed the previous batch — retroactively fogging every already-queued sprite.
- **Fix:** `SpriteBatchStack.FlushIfBegan()` flushes the pending batch (with its own pre-mutation effect state) and `BeginSpriteBatch` calls it before touching the shared effect. For state that isn't changing this is **output-identical**, so all existing MonoGame render tests are unaffected — **53 integration + 1792 unit green**.
- **Scope note for review:** this touches the core shared `RenderingLibrary` SpriteBatch path (MonoGame/KNI/FNA, and the Gum tool via KNI). TDD'd with a GL pixel-readback regression (`SpriteColorOperationLeakTests`). Not `#if`-gated and adds no guarded members, so no FRB compile asymmetry.

Closes #3486. Part of #3432.
