### PR TITLE
Samples: mirror Blend-on-Text row to MonoGame and make additive visible

### DIFF
--- a/Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/TextScreen.cs
+++ b/Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/TextScreen.cs
@@ -29,6 +29,20 @@ internal class TextScreen : FrameworkElement
         textRuntime.Text = "Hi, I'm default text";
         container.Children.Add(textRuntime);
 
+        // Blend on Text (#3432): additive (brightens) vs normal, over an identical blue box. Mirrors
+        // the raylib TextScreen's row so the two backends can be compared side by side.
+        AddSectionLabel(container, "Blend on Text (#3432): additive (brightens) vs normal, over a blue box");
+        var blendRow = new ContainerRuntime();
+        blendRow.WidthUnits = Gum.DataTypes.DimensionUnitType.RelativeToChildren;
+        blendRow.HeightUnits = Gum.DataTypes.DimensionUnitType.RelativeToChildren;
+        blendRow.Width = 0;
+        blendRow.Height = 0;
+        blendRow.ChildrenLayout = Gum.Managers.ChildrenLayout.LeftToRightStack;
+        blendRow.StackSpacing = 16;
+        blendRow.AddChild(BuildBlendCell("Additive", Gum.RenderingLibrary.Blend.Additive));
+        blendRow.AddChild(BuildBlendCell("Normal", null));
+        container.Children.Add(blendRow);
+
         AddSectionLabel(container, "BBCode markup - inline color runs (#3471):");
         var colorMarkup = new TextRuntime();
         colorMarkup.FontSize = 24;
@@ -83,6 +97,42 @@ internal class TextScreen : FrameworkElement
         label.Text = text;
         label.FontSize = 14;
         container.Children.Add(label);
+    }
+
+    // One Blend-on-Text cell: amber text over a blue box. Amber (not white) so the Additive cell
+    // visibly brightens - additive can only brighten, and white is already maxed, so white text would
+    // render identically under Additive and Normal. Mirrors BuildBlendCell in the raylib TextScreen.
+    private static ContainerRuntime BuildBlendCell(string label, Gum.RenderingLibrary.Blend? blend)
+    {
+        var cell = new ContainerRuntime();
+        cell.Width = 200;
+        cell.Height = 48;
+
+        var background = new RectangleRuntime();
+        background.WidthUnits = Gum.DataTypes.DimensionUnitType.RelativeToParent;
+        background.HeightUnits = Gum.DataTypes.DimensionUnitType.RelativeToParent;
+        background.Width = 0;
+        background.Height = 0;
+        background.IsFilled = true;
+        background.FillColor = new Color(40, 60, 160, 255);
+        cell.Children.Add(background);
+
+        var text = new TextRuntime();
+        text.WidthUnits = Gum.DataTypes.DimensionUnitType.RelativeToParent;
+        text.HeightUnits = Gum.DataTypes.DimensionUnitType.RelativeToParent;
+        text.Width = 0;
+        text.Height = 0;
+        text.FontSize = 24;
+        text.Text = label;
+        text.Red = 230;
+        text.Green = 150;
+        text.Blue = 40;
+        text.HorizontalAlignment = HorizontalAlignment.Center;
+        text.VerticalAlignment = VerticalAlignment.Center;
+        text.Blend = blend;
+        cell.Children.Add(text);
+
+        return cell;
     }
 
     private static void AddCustomOutlineText(ContainerRuntime container, Color color)

--- a/Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/TextScreen.cs
+++ b/Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/TextScreen.cs
@@ -1,5 +1,7 @@
+using Gum.DataTypes;
 using Gum.Forms.Controls;
 using Gum.GueDeriving;
+using Gum.Managers;
 using Gum.Wireframe;
 using Microsoft.Xna.Framework;
 using RenderingLibrary.Graphics;
@@ -15,33 +17,19 @@ internal class TextScreen : FrameworkElement
         Dock(Gum.Wireframe.Dock.Fill);
 
         var container = new ContainerRuntime();
-        container.WidthUnits = Gum.DataTypes.DimensionUnitType.RelativeToParent;
-        container.HeightUnits = Gum.DataTypes.DimensionUnitType.RelativeToParent;
+        container.WidthUnits = DimensionUnitType.RelativeToParent;
+        container.HeightUnits = DimensionUnitType.RelativeToParent;
         container.X = 2;
         container.Y = 2;
         container.Width = -4;
         container.Height = -4;
-        container.ChildrenLayout = Gum.Managers.ChildrenLayout.TopToBottomStack;
+        container.ChildrenLayout = ChildrenLayout.TopToBottomStack;
         container.StackSpacing = 4;
         this.AddChild(container);
 
         var textRuntime = new TextRuntime();
         textRuntime.Text = "Hi, I'm default text";
         container.Children.Add(textRuntime);
-
-        // Blend on Text (#3432): additive (brightens) vs normal, over an identical blue box. Mirrors
-        // the raylib TextScreen's row so the two backends can be compared side by side.
-        AddSectionLabel(container, "Blend on Text (#3432): additive (brightens) vs normal, over a blue box");
-        var blendRow = new ContainerRuntime();
-        blendRow.WidthUnits = Gum.DataTypes.DimensionUnitType.RelativeToChildren;
-        blendRow.HeightUnits = Gum.DataTypes.DimensionUnitType.RelativeToChildren;
-        blendRow.Width = 0;
-        blendRow.Height = 0;
-        blendRow.ChildrenLayout = Gum.Managers.ChildrenLayout.LeftToRightStack;
-        blendRow.StackSpacing = 16;
-        blendRow.AddChild(BuildBlendCell("Additive", Gum.RenderingLibrary.Blend.Additive));
-        blendRow.AddChild(BuildBlendCell("Normal", null));
-        container.Children.Add(blendRow);
 
         AddSectionLabel(container, "BBCode markup - inline color runs (#3471):");
         var colorMarkup = new TextRuntime();
@@ -89,6 +77,8 @@ internal class TextScreen : FrameworkElement
         AddCustomOutlineText(container, Color.Red);
         AddCustomOutlineText(container, Color.DarkGreen);
         AddCustomOutlineText(container, Color.Blue);
+
+        AddBlendOnTextSection(container);
     }
 
     private static void AddSectionLabel(ContainerRuntime container, string text)
@@ -99,9 +89,24 @@ internal class TextScreen : FrameworkElement
         container.Children.Add(label);
     }
 
-    // One Blend-on-Text cell: amber text over a blue box. Amber (not white) so the Additive cell
-    // visibly brightens - additive can only brighten, and white is already maxed, so white text would
-    // render identically under Additive and Normal. Mirrors BuildBlendCell in the raylib TextScreen.
+    // Blend on Text (#3432): additive (brightens) vs normal, over an identical blue box. Kept byte
+    // identical with the other backend's TextScreen (this method and BuildBlendCell) so the two can
+    // be diffed directly.
+    private static void AddBlendOnTextSection(ContainerRuntime container)
+    {
+        AddSectionLabel(container, "Blend on Text (#3432): additive (brightens) vs normal, over a blue box");
+        var blendRow = new ContainerRuntime();
+        blendRow.WidthUnits = DimensionUnitType.RelativeToChildren;
+        blendRow.HeightUnits = DimensionUnitType.RelativeToChildren;
+        blendRow.Width = 0;
+        blendRow.Height = 0;
+        blendRow.ChildrenLayout = ChildrenLayout.LeftToRightStack;
+        blendRow.StackSpacing = 16;
+        blendRow.AddChild(BuildBlendCell("Additive", Gum.RenderingLibrary.Blend.Additive));
+        blendRow.AddChild(BuildBlendCell("Normal", null));
+        container.Children.Add(blendRow);
+    }
+
     private static ContainerRuntime BuildBlendCell(string label, Gum.RenderingLibrary.Blend? blend)
     {
         var cell = new ContainerRuntime();
@@ -109,8 +114,8 @@ internal class TextScreen : FrameworkElement
         cell.Height = 48;
 
         var background = new RectangleRuntime();
-        background.WidthUnits = Gum.DataTypes.DimensionUnitType.RelativeToParent;
-        background.HeightUnits = Gum.DataTypes.DimensionUnitType.RelativeToParent;
+        background.WidthUnits = DimensionUnitType.RelativeToParent;
+        background.HeightUnits = DimensionUnitType.RelativeToParent;
         background.Width = 0;
         background.Height = 0;
         background.IsFilled = true;
@@ -118,12 +123,16 @@ internal class TextScreen : FrameworkElement
         cell.Children.Add(background);
 
         var text = new TextRuntime();
-        text.WidthUnits = Gum.DataTypes.DimensionUnitType.RelativeToParent;
-        text.HeightUnits = Gum.DataTypes.DimensionUnitType.RelativeToParent;
+        text.WidthUnits = DimensionUnitType.RelativeToParent;
+        text.HeightUnits = DimensionUnitType.RelativeToParent;
         text.Width = 0;
         text.Height = 0;
         text.FontSize = 24;
         text.Text = label;
+        // Amber, not white: additive can only brighten, and white is already maxed, so white text
+        // renders identically under Additive and Normal. A mid-intensity warm color visibly washes
+        // out toward bright peach when added to the blue box, making the Additive cell obviously
+        // different from the Normal one.
         text.Red = 230;
         text.Green = 150;
         text.Blue = 40;

--- a/Samples/raylib/Screens/TextScreen.cs
+++ b/Samples/raylib/Screens/TextScreen.cs
@@ -167,9 +167,13 @@ internal class TextScreen : FrameworkElement
         text.Height = 0;
         text.FontSize = 24;
         text.Text = label;
-        text.Red = 255;
-        text.Green = 255;
-        text.Blue = 255;
+        // Amber, not white: additive can only brighten, and white is already maxed, so white text
+        // renders identically under Additive and Normal. A mid-intensity warm color visibly washes
+        // out toward bright peach when added to the blue box, making the Additive cell obviously
+        // different from the Normal one.
+        text.Red = 230;
+        text.Green = 150;
+        text.Blue = 40;
         text.HorizontalAlignment = HorizontalAlignment.Center;
         text.VerticalAlignment = VerticalAlignment.Center;
         text.Blend = blend;

--- a/Samples/raylib/Screens/TextScreen.cs
+++ b/Samples/raylib/Screens/TextScreen.cs
@@ -84,18 +84,7 @@ internal class TextScreen : FrameworkElement
     // verification surface for the parity batch.
     private static void BuildTextParitySection(ContainerRuntime container)
     {
-        // --- Blend on Text: additive vs normal white text over an identical blue box ---
-        AddSectionLabel(container, "Blend on Text (#3432): additive (brightens) vs normal, over a blue box");
-        var blendRow = new ContainerRuntime();
-        blendRow.WidthUnits = DimensionUnitType.RelativeToChildren;
-        blendRow.HeightUnits = DimensionUnitType.RelativeToChildren;
-        blendRow.Width = 0;
-        blendRow.Height = 0;
-        blendRow.ChildrenLayout = ChildrenLayout.LeftToRightStack;
-        blendRow.StackSpacing = 16;
-        blendRow.AddChild(BuildBlendCell("Additive", Gum.RenderingLibrary.Blend.Additive));
-        blendRow.AddChild(BuildBlendCell("Normal", null));
-        container.Children.Add(blendRow);
+        AddBlendOnTextSection(container);
 
         // --- Per-instance TextRenderingPositionMode override, at a fractional origin ---
         AddSectionLabel(container, "TextRenderingPositionMode (#3432): fractional origin; button toggles snap");
@@ -143,6 +132,24 @@ internal class TextScreen : FrameworkElement
             int index = hitText.GetCharacterIndexAtPosition(cursorX, cursorY);
             hitResult.Text = $"Character index at click: {index}";
         };
+    }
+
+    // Blend on Text (#3432): additive (brightens) vs normal, over an identical blue box. Kept byte
+    // identical with the other backend's TextScreen (this method and BuildBlendCell) so the two can
+    // be diffed directly.
+    private static void AddBlendOnTextSection(ContainerRuntime container)
+    {
+        AddSectionLabel(container, "Blend on Text (#3432): additive (brightens) vs normal, over a blue box");
+        var blendRow = new ContainerRuntime();
+        blendRow.WidthUnits = DimensionUnitType.RelativeToChildren;
+        blendRow.HeightUnits = DimensionUnitType.RelativeToChildren;
+        blendRow.Width = 0;
+        blendRow.Height = 0;
+        blendRow.ChildrenLayout = ChildrenLayout.LeftToRightStack;
+        blendRow.StackSpacing = 16;
+        blendRow.AddChild(BuildBlendCell("Additive", Gum.RenderingLibrary.Blend.Additive));
+        blendRow.AddChild(BuildBlendCell("Normal", null));
+        container.Children.Add(blendRow);
     }
 
     private static ContainerRuntime BuildBlendCell(string label, Gum.RenderingLibrary.Blend? blend)


### PR DESCRIPTION
## What

Two fixes to the **Blend on Text** demo row (from the raylib Text parity work, #3432):

1. **Mirror the row to MonoGame.** It existed only in the raylib `TextScreen`, not the MonoGame one it's meant to mirror — added the matching section + `BuildBlendCell` helper so the two backends can be compared side by side.
2. **Make additive actually visible.** Both cells drew **white** text over a blue box. Additive can only brighten, and white is already maxed, so the Additive cell rendered identically to Normal — proving nothing. Both cells now use **amber** text (230,150,40): under Additive it washes toward bright peach over the blue box, obviously different from the Normal cell.

## Verification

Sample-only change (no library logic). Both sample projects build. Visual: the Additive cell is clearly brighter/washed-out vs the Normal cell, and the raylib and MonoGame screens now match.

Relates to #3432.
