### PR TITLE
RaylibGum CircleRuntime: add Blend (real) and IsAntialiased (parity) (#3491)

### DIFF
--- a/.claude/skills/gum-samples/SKILL.md
+++ b/.claude/skills/gum-samples/SKILL.md
@@ -30,7 +30,7 @@ Each has a `Screens/` folder with one `*Screen.cs` per feature (`SpriteScreen`, 
 
 ## Shape features → the shapes gallery instead
 
-If the feature touches **shapes** (Circle, Rectangle, RoundedRectangle, Arc, Polygon, Line — anything from [[gum-shapes-xnb-packaging]] / the shape runtimes), do **not** add it to the three samples above. Add it to `Samples/GumShapesGallery/MonoGameGumShapesGallery/` (and its KNI siblings under `Samples/GumShapesGallery/`).
+If the feature touches **shapes** (Circle, Rectangle, RoundedRectangle, Arc, Polygon, Line — anything from [[gum-shapes-xnb-packaging]] / the shape runtimes), only the XNA-like slot changes: still mirror to the raylib and SilkNet feature samples (they render shapes natively, so their shape screens live *in* the feature samples — `Samples/raylib/Screens/CirclesScreen.cs`, `Samples/SilkNetGum/…`), but for MonoGame/KNI add to `Samples/GumShapesGallery/MonoGameGumShapesGallery/` (and its KNI siblings) **instead of** `MonoGameGumInCode`. So a shape cell still lands in three galleries — raylib + SilkNet + GumShapesGallery — just not `MonoGameGumInCode`.
 
 **Why shapes get their own project:** raylib and Skia render shapes natively (built-in, full support), so shape demos for those backends live in the regular feature samples. XNA-likes (MonoGame, KNI) have **no built-in shape rendering** — they must be supplemented with the separate **Gum.Shapes** library, so their shape coverage lives in the dedicated `GumShapesGallery` project rather than `MonoGameGumInCode`. That's the split referenced above. This is expected to be unified eventually.
 

--- a/MonoGameGum/GueDeriving/CircleRuntime.cs
+++ b/MonoGameGum/GueDeriving/CircleRuntime.cs
@@ -495,6 +495,45 @@ public class CircleRuntime : GraphicalUiElement
         get => _gradientOuterRadiusUnits;
         set { _gradientOuterRadiusUnits = value; NotifyPropertyChanged(); }
     }
+
+    Gum.RenderingLibrary.Blend _blend = Gum.RenderingLibrary.Blend.Normal;
+    /// <summary>
+    /// Issue #3491 — blend mode for the circle, matching the XNALIKE <see cref="CircleRuntime"/>
+    /// surface (non-nullable, default <see cref="Gum.RenderingLibrary.Blend.Normal"/>) so cross-
+    /// backend code reads and writes it identically. Normal is the no-op default and maps to a
+    /// null renderable Blend so <see cref="Gum.Renderables.LineCircle"/>'s render skips the blend
+    /// wrap; any other value pushes through and wraps the fill/stroke passes (the #3470 mapping,
+    /// shared with Sprite / NineSlice).
+    /// </summary>
+    public Gum.RenderingLibrary.Blend Blend
+    {
+        get => _blend;
+        set
+        {
+            _blend = value;
+            ContainedLineCircle.Blend = value == Gum.RenderingLibrary.Blend.Normal ? null : value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    bool _isAntialiased = true;
+    /// <summary>
+    /// Issue #3491 — parity surface with XNALIKE <see cref="CircleRuntime"/>'s
+    /// <c>IsAntialiased</c>. raylib has no per-shape AA primitive (<c>DrawCircle</c>/<c>DrawRing</c>
+    /// are hard-edged; AA is a global window flag, not per-draw), so this value round-trips on the
+    /// runtime but is not rendered — mirroring the <see cref="GradientX1Units"/> family above, and
+    /// XNALIKE's own no-op when the Apos.Shapes package is absent. Kept so theme / user code that
+    /// toggles antialiasing compiles unchanged across backends.
+    /// </summary>
+    public bool IsAntialiased
+    {
+        get => _isAntialiased;
+        set
+        {
+            _isAntialiased = value;
+            NotifyPropertyChanged();
+        }
+    }
 #endif
 
 #if XNALIKE

--- a/Runtimes/RaylibGum/Renderables/LineCircle.cs
+++ b/Runtimes/RaylibGum/Renderables/LineCircle.cs
@@ -173,6 +173,17 @@ public class LineCircle : InvisibleRenderable
     /// rendering collapses anisotropic blur to <c>max(BlurX, BlurY)</c>.</remarks>
     public float DropshadowBlurY { get; set; }
 
+    /// <summary>
+    /// Issue #3491 — blend mode for the fill + stroke passes, matching the XNALIKE
+    /// <c>CircleRuntime.Blend</c>. <c>null</c> (the default) leaves raylib's ambient blend
+    /// untouched (straight alpha); a non-null value wraps both passes in the counted
+    /// <c>BatchDrawCallCounter.BeginBlendMode</c> / <c>EndBlendMode</c> pair, reusing the same
+    /// mapping the Sprite / NineSlice blends use (#3470). The dropshadow pre-pass is deliberately
+    /// left out of the wrap — it composites via its own render-to-texture path, and XNALIKE
+    /// applies blend to the fill/stroke renderables only, not the shadow.
+    /// </summary>
+    public global::Gum.RenderingLibrary.Blend? Blend { get; set; }
+
     /// <inheritdoc/>
     public override int Alpha
     {
@@ -382,6 +393,14 @@ public class LineCircle : InvisibleRenderable
             }
         }
 
+        // Issue #3491 — wrap the fill + stroke passes in the requested blend so a non-Normal
+        // Blend (e.g. Additive) composites correctly, mirroring the #3470 Sprite/NineSlice pattern.
+        // Left off the dropshadow above (it composites through its own render-to-texture path).
+        if (Blend.HasValue)
+        {
+            global::RenderingLibrary.Graphics.Renderer.Self.BatchDrawCallCounter.BeginBlendMode(Blend.Value);
+        }
+
         // Fill pass — runs when FillColor is set, or when IsFilled is true with no explicit
         // FillColor (legacy Color slot supplies the fill color). Mirrors Skia's two-slot
         // composition (#2790) where setting FillColor alone, StrokeColor alone, or both lights
@@ -489,6 +508,11 @@ public class LineCircle : InvisibleRenderable
                 DrawRing(center, innerRadius, Radius,
                     startAngle: 0f, endAngle: 360f, segments, strokeColor);
             }
+        }
+
+        if (Blend.HasValue)
+        {
+            global::RenderingLibrary.Graphics.Renderer.Self.BatchDrawCallCounter.EndBlendMode();
         }
     }
 

--- a/Samples/GumShapesGallery/GumShapesGalleryCommon/Screens/CirclesScreen.cs
+++ b/Samples/GumShapesGallery/GumShapesGalleryCommon/Screens/CirclesScreen.cs
@@ -60,6 +60,47 @@ internal class CirclesScreen : FrameworkElement
         right.AddChild(BuildSection("Hairline bleed (#2834)", BuildHairlineBleedRow()));
         right.AddChild(BuildSection("Inscribed", BuildInscribedRow()));
         right.AddChild(BuildSection("Non-square aspect", BuildNonSquareRow()));
+        right.AddChild(BuildSection("Blend (additive #3491)", BuildBlendRow()));
+    }
+
+    // Issue #3491 — mirror of the raylib CirclesScreen "Blend (additive)" cell so the galleries
+    // stay comparable side-by-side. Three filled RGB circles overlapping on a black frame, each
+    // with Blend = Additive. On the shapes-package (Apos) side the blend folds into each circle's
+    // batch key, so the overlaps read yellow (R+G) / cyan (G+B) / magenta (R+B) and the center
+    // white. Blend is XNALIKE-only on CircleRuntime, so there's no Skia mirror (SkiaShapeRuntime
+    // has no Blend); this cell is the MonoGame/raylib counterpart pair.
+    static RectangleRuntime BuildBlendRow()
+    {
+        RectangleRuntime frame = new();
+        frame.Width = 130;
+        frame.Height = 110;
+        frame.FillColor = Color.Black;
+        frame.IsFilled = true;
+
+        (Color color, float x, float y)[] discs =
+        {
+            (Color.Red, 0f, -14f),
+            (Color.Lime, -14f, 10f),
+            (Color.Blue, 14f, 10f),
+        };
+
+        foreach ((Color color, float x, float y) in discs)
+        {
+            CircleRuntime circle = new();
+            circle.Radius = 26;
+            circle.FillColor = color;
+            circle.IsFilled = true;
+            circle.Blend = Gum.RenderingLibrary.Blend.Additive;
+            circle.XOrigin = HorizontalAlignment.Center;
+            circle.XUnits = Gum.Converters.GeneralUnitType.PixelsFromMiddle;
+            circle.X = x;
+            circle.YOrigin = VerticalAlignment.Center;
+            circle.YUnits = Gum.Converters.GeneralUnitType.PixelsFromMiddle;
+            circle.Y = y;
+            frame.Children.Add(circle);
+        }
+
+        return frame;
     }
 
     static ContainerRuntime BuildColumn()

--- a/Samples/raylib/Screens/CirclesScreen.cs
+++ b/Samples/raylib/Screens/CirclesScreen.cs
@@ -17,8 +17,10 @@ namespace Examples.Shapes;
 //
 // What's intentionally NOT mirrored: the Antialiasing section. raylib has no per-shape AA —
 // framebuffer MSAA via SetConfigFlags(Msaa4xHint) in Program.Main is the only AA path, so
-// toggling the runtime IsAntialiased flag would render identically. Tracked as a #2757
-// follow-up.
+// toggling the runtime IsAntialiased flag would render identically. As of #3491 the flag DOES
+// exist on the raylib CircleRuntime (round-trip parity so cross-backend code compiles), but it
+// stays a no-op visually — hence still no Antialiasing row. The Blend section below IS new in
+// #3491: unlike AA, raylib blend is real (LineCircle wraps its fill/stroke draws in the blend).
 internal class CirclesScreen : FrameworkElement
 {
     public CirclesScreen() : base(new ContainerRuntime())
@@ -57,6 +59,7 @@ internal class CirclesScreen : FrameworkElement
         right.Children.Add(BuildSection("Hairline bleed (#2834)", BuildHairlineBleedRow()));
         right.Children.Add(BuildSection("Inscribed", BuildInscribedRow()));
         right.Children.Add(BuildSection("Non-square aspect", BuildNonSquareRow()));
+        right.Children.Add(BuildSection("Blend (additive #3491)", BuildBlendRow()));
     }
 
     static ContainerRuntime BuildColumn()
@@ -150,6 +153,45 @@ internal class CirclesScreen : FrameworkElement
         row.Children.Add(defaultCircle);
 
         return row;
+    }
+
+    // Issue #3491 — classic additive-blend demo: three filled RGB circles overlapping on a black
+    // frame, each with Blend = Additive. Additive keeps the destination and adds the source, so the
+    // pairwise overlaps read yellow (R+G) / cyan (G+B) / magenta (R+B) and the center reads white.
+    // With the pre-#3491 behavior (Blend ignored) the circles would just paint over each other in
+    // draw order — opaque, no color mixing — so this row makes the feature obvious at a glance.
+    static RectangleRuntime BuildBlendRow()
+    {
+        RectangleRuntime frame = new();
+        frame.Width = 130;
+        frame.Height = 110;
+        frame.FillColor = Color.Black;
+        frame.IsFilled = true;
+
+        (Color color, float x, float y)[] discs =
+        {
+            (new Color((byte)255, (byte)0, (byte)0, (byte)255), 0f, -14f),
+            (new Color((byte)0, (byte)255, (byte)0, (byte)255), -14f, 10f),
+            (new Color((byte)0, (byte)0, (byte)255, (byte)255), 14f, 10f),
+        };
+
+        foreach ((Color color, float x, float y) in discs)
+        {
+            CircleRuntime circle = new();
+            circle.Radius = 26;
+            circle.FillColor = color;
+            circle.IsFilled = true;
+            circle.Blend = Gum.RenderingLibrary.Blend.Additive;
+            circle.XOrigin = HorizontalAlignment.Center;
+            circle.XUnits = GeneralUnitType.PixelsFromMiddle;
+            circle.X = x;
+            circle.YOrigin = VerticalAlignment.Center;
+            circle.YUnits = GeneralUnitType.PixelsFromMiddle;
+            circle.Y = y;
+            frame.Children.Add(circle);
+        }
+
+        return frame;
     }
 
     static ContainerRuntime BuildStrokeWidthRow()

--- a/Tests/RaylibGum.Tests/Rendering/CircleBlendRenderTests.cs
+++ b/Tests/RaylibGum.Tests/Rendering/CircleBlendRenderTests.cs
@@ -1,0 +1,75 @@
+using Gum.GueDeriving;
+using Gum.RenderingLibrary;
+using Raylib_cs;
+using RenderingLibrary.Graphics;
+using Shouldly;
+using static Raylib_cs.Raylib;
+
+namespace RaylibGum.Tests.Rendering;
+
+/// <summary>
+/// Pixel-readback test proving <see cref="CircleRuntime.Blend"/> actually reaches raylib's
+/// blend state on the circle's fill/stroke passes (issue #3491), rather than being a dead
+/// round-trip. Uses the same baked-render-target harness as <see cref="BlendModeRenderTests"/> —
+/// the composite is what makes the blend observable headlessly.
+/// </summary>
+public class CircleBlendRenderTests : BaseTestClass
+{
+    private static Color ReadRenderTargetCenter(RenderTexture2D renderTexture)
+    {
+        Image image = LoadImageFromTexture(renderTexture.Texture);
+        try
+        {
+            return GetImageColor(image, renderTexture.Texture.Width / 2, renderTexture.Texture.Height / 2);
+        }
+        finally
+        {
+            UnloadImage(image);
+        }
+    }
+
+    [Fact]
+    public void Draw_AdditiveBlendCircle_AddsFillColorOntoBackgroundInsteadOfOverwriting()
+    {
+        const int size = 32;
+
+        ContainerRuntime container = new();
+        container.Width = size;
+        container.Height = size;
+        container.IsRenderTarget = true;
+
+        // Opaque blue background fills the cell.
+        RectangleRuntime background = new();
+        background.Width = size;
+        background.Height = size;
+        background.IsFilled = true;
+        background.FillColor = new Color((byte)0, (byte)0, (byte)255, (byte)255);
+        container.Children.Add(background);
+
+        // Opaque red circle drawn additively over the blue. Additive keeps the destination
+        // (blue) and adds the source (red), so the center reads as magenta (R and B both high).
+        // Without the blend wrap the circle draws with straight alpha — an opaque red overwrite,
+        // leaving blue near zero — which is exactly what this asserts against.
+        CircleRuntime circle = new();
+        circle.Width = size;
+        circle.Height = size;
+        circle.IsFilled = true;
+        circle.FillColor = new Color((byte)255, (byte)0, (byte)0, (byte)255);
+        circle.Blend = Blend.Additive;
+        container.Children.Add(circle);
+
+        GumService.Default.Root.Children.Add(container);
+        GumService.Default.Root.UpdateLayout();
+
+        BeginDrawing();
+        GumService.Default.Draw();
+        EndDrawing();
+
+        Color center = ReadRenderTargetCenter(Renderer.Self.TryGetBakedRenderTargetFor(container)!.Value);
+
+        GumService.Default.Root.Children.Clear();
+
+        center.R.ShouldBeGreaterThan((byte)150);
+        center.B.ShouldBeGreaterThan((byte)150);
+    }
+}

--- a/Tests/RaylibGum.Tests/Runtimes/CircleRuntimeTests.cs
+++ b/Tests/RaylibGum.Tests/Runtimes/CircleRuntimeTests.cs
@@ -326,4 +326,57 @@ public class CircleRuntimeTests : BaseTestClass
         sut.GradientInnerRadiusUnits.ShouldBe(Gum.DataTypes.DimensionUnitType.ScreenPixel);
         sut.GradientOuterRadiusUnits.ShouldBe(Gum.DataTypes.DimensionUnitType.ScreenPixel);
     }
+
+    // Issue #3491 — Blend / IsAntialiased raylib parity with the XNALIKE CircleRuntime surface.
+    // Blend is real (LineCircle wraps its fill/stroke draws in the counted BeginBlendMode /
+    // EndBlendMode pair, mirroring the #3470 Sprite/NineSlice work); IsAntialiased is a round-trip
+    // parity surface only — raylib has no per-shape AA primitive, matching the GradientUnits
+    // "not yet rendered on raylib" props above and XNALIKE's own no-Apos.Shapes round-trip no-op.
+
+    [Fact]
+    public void Blend_DefaultsToNormal()
+    {
+        // Matches the non-nullable XNALIKE CircleRuntime.Blend (default Blend.Normal) so cross-
+        // backend code reading circle.Blend compiles and behaves identically on both backends.
+        CircleRuntime sut = new();
+        sut.Blend.ShouldBe(Gum.RenderingLibrary.Blend.Normal);
+    }
+
+    [Fact]
+    public void Blend_Normal_ClearsContainedRenderableBlend()
+    {
+        // Normal is the no-op default, so it maps to a null renderable Blend — LineCircle.Render
+        // then skips the BeginBlendMode/EndBlendMode wrap entirely (its `if (Blend.HasValue)` gate).
+        CircleRuntime sut = new();
+        sut.Blend = Gum.RenderingLibrary.Blend.Additive;
+        sut.Blend = Gum.RenderingLibrary.Blend.Normal;
+
+        ((LineCircle)sut.RenderableComponent!).Blend.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Blend_RoundTrips_AndPushesToContainedRenderable()
+    {
+        CircleRuntime sut = new();
+        sut.Blend = Gum.RenderingLibrary.Blend.Additive;
+
+        sut.Blend.ShouldBe(Gum.RenderingLibrary.Blend.Additive);
+        ((LineCircle)sut.RenderableComponent!).Blend.ShouldBe(Gum.RenderingLibrary.Blend.Additive);
+    }
+
+    [Fact]
+    public void IsAntialiased_DefaultsToTrue()
+    {
+        // Matches XNALIKE (and Apos.Shapes) — AA on by default.
+        CircleRuntime sut = new();
+        sut.IsAntialiased.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsAntialiased_RoundTrips()
+    {
+        CircleRuntime sut = new();
+        sut.IsAntialiased = false;
+        sut.IsAntialiased.ShouldBeFalse();
+    }
 }


### PR DESCRIPTION
Closes #3491. Part of the RaylibGum parity umbrella #3432 (P3).

## What

Adds `Blend` and `IsAntialiased` to the raylib `CircleRuntime`, which previously existed only on `#if XNALIKE`.

- **`Blend` — real.** The raylib `LineCircle` renderable gains a nullable `Blend` and wraps its fill/stroke draw passes in the counted `BatchDrawCallCounter.BeginBlendMode`/`EndBlendMode` pair, reusing the exact mapping the Sprite/NineSlice blends use (#3470). `CircleRuntime.Blend` matches the XNALIKE surface (non-nullable, default `Normal`) so cross-backend code reads/writes it identically; `Normal` (the no-op default) maps to a null renderable `Blend` so the wrap is skipped. The dropshadow pre-pass is deliberately left outside the wrap (it composites via its own render-to-texture path, and XNALIKE applies blend to the fill/stroke renderables only).
- **`IsAntialiased` — round-trip parity only.** raylib has no per-shape AA primitive (`DrawCircle`/`DrawRing` are hard-edged; AA is a global `FLAG_MSAA_4X_HINT`, not per-draw), so this round-trips on the runtime but is **not rendered** — matching the existing `GradientX1Units` "parity surface, not yet rendered on raylib" props and XNALIKE's own no-op when the Apos.Shapes package is absent. Kept so cross-backend theme/user code toggling AA compiles unchanged.

Out of scope: `RectangleRuntime.Blend`/`CornerRadiusUnits` (the sibling P3 bullet) — `RectangleRuntime.Blend` is the identical pattern and a natural follow-up.

## Tests

- `CircleRuntimeTests`: `Blend` default (`Normal`), round-trip + push-to-renderable, `Normal`→null clearing; `IsAntialiased` default (`true`) + round-trip.
- `CircleBlendRenderTests`: pixel-readback proving an Additive filled red circle over a blue background composites to magenta (R+B both high) — red-first verified (inverting the wrap makes it go red). Mirrors the `BlendModeRenderTests` harness.
- Full `RaylibGum.Tests` green (440); `MonoGameGum` + raylib sample build clean.

## Manual test

Case (b): added a **"Blend (additive #3491)"** section to the raylib `CirclesScreen` — three overlapping RGB filled circles with `Blend = Additive`, so the overlaps read yellow/cyan/magenta and the center white. Run the raylib sample and navigate to the Circles screen to confirm the additive mixing (pre-#3491 the circles would paint over each other opaque, no mixing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
---

**Update:** the additive-Blend demo cell is now mirrored to **both** galleries — the raylib `CirclesScreen` and the MonoGame/Apos `GumShapesGalleryCommon/CirclesScreen` (also used by the Kni hosts) — so the side-by-side gallery comparison holds. Blend renders on the Apos side via `IBlendedRenderable`. No Skia mirror (`SkiaShapeRuntime` has no `Blend`); no `MonoGameGumInCode` mirror (no shapes package there — fill/blend degrade to outline-only). Visual check: run either gallery, open the Circles screen, confirm the overlaps read yellow/cyan/magenta with a white center.
