### PR TITLE
RaylibGum RectangleRuntime: add CornerRadiusUnits (ScreenPixel scaling) (#3494)

### DIFF
--- a/MonoGameGum/GueDeriving/RectangleRuntime.cs
+++ b/MonoGameGum/GueDeriving/RectangleRuntime.cs
@@ -248,6 +248,20 @@ public class RectangleRuntime : GraphicalUiElement
         // a nominal 1px outline to ~0.01px — invisible. StrokeWidth <= 0 still pushes literal 0 so
         // LineRectangle's positive-width gate suppresses the stroke (the fill-only-shape fix above).
         ContainedLineRectangle.LinePixelWidth = strokeWidth <= 0 ? 0f : strokeWidth;
+
+#if RAYLIB
+        // Issue #3494 — resolve CornerRadiusUnits the same way as StrokeWidthUnits: a ScreenPixel
+        // corner radius is divided by the camera zoom so it holds a constant on-screen size.
+        // Reads the raw _cornerRadius backing field (not the renderable's possibly-already-scaled
+        // value) so re-running PreRender each frame doesn't compound the division. CornerRadius is
+        // RAYLIB-only (SOKOL's contained type has none), so this is gated tighter than the block.
+        float cornerRadius = _cornerRadius;
+        if (_cornerRadiusUnits == DimensionUnitType.ScreenPixel && camera != null)
+        {
+            cornerRadius /= cameraZoom;
+        }
+        ContainedLineRectangle.CornerRadius = cornerRadius;
+#endif
     }
 #endif
 
@@ -379,13 +393,37 @@ public class RectangleRuntime : GraphicalUiElement
         }
     }
 
+    float _cornerRadius;
     /// <inheritdoc cref="Gum.Renderables.LineRectangle.CornerRadius"/>
     public float CornerRadius
     {
-        get => ContainedLineRectangle.CornerRadius;
+        get => _cornerRadius;
         set
         {
+            _cornerRadius = value;
+            // Push the raw value immediately so an Absolute radius is correct before the first
+            // PreRender. PreRender re-resolves it against CornerRadiusUnits each frame (ScreenPixel
+            // ÷ zoom), reading the raw backing field — so this eager push never causes runaway
+            // scaling. Mirrors how the runtime holds the raw StrokeWidth alongside its units.
             ContainedLineRectangle.CornerRadius = value;
+            NotifyPropertyChanged();
+        }
+    }
+
+    DimensionUnitType _cornerRadiusUnits;
+    /// <summary>
+    /// Issue #3494 — unit of measurement for <see cref="CornerRadius"/>. <c>Absolute</c> renders the
+    /// raw pixel value; <c>ScreenPixel</c> divides it by the camera zoom each frame in
+    /// <see cref="PreRender"/> so the corner holds a constant on-screen size as the camera zooms,
+    /// matching <see cref="StrokeWidthUnits"/> and the XNALIKE/Skia behavior. (Per-corner overrides
+    /// are round-trip parity only on raylib — see the <c>CustomRadius*</c> members.)
+    /// </summary>
+    public DimensionUnitType CornerRadiusUnits
+    {
+        get => _cornerRadiusUnits;
+        set
+        {
+            _cornerRadiusUnits = value;
             NotifyPropertyChanged();
         }
     }

--- a/Tests/RaylibGum.Tests/Runtimes/RectangleRuntimeTests.cs
+++ b/Tests/RaylibGum.Tests/Runtimes/RectangleRuntimeTests.cs
@@ -1,6 +1,7 @@
 using Gum.GueDeriving;
 using Gum.Renderables;
 using Raylib_cs;
+using RenderingLibrary;
 using RenderingLibrary.Graphics;
 using Shouldly;
 
@@ -358,6 +359,53 @@ public class RectangleRuntimeTests : BaseTestClass
 
         sut.CornerRadius.ShouldBe(8f);
         ((LineRectangle)sut.RenderableComponent!).CornerRadius.ShouldBe(8f);
+    }
+
+    // Issue #3494 — CornerRadiusUnits raylib parity. Absolute (default) pushes the raw radius;
+    // ScreenPixel divides it by the camera zoom in PreRender so the corner holds a constant on-
+    // screen size, mirroring StrokeWidthUnits and the XNALIKE/Skia behavior.
+
+    [Fact]
+    public void CornerRadiusUnits_DefaultsToAbsolute()
+    {
+        RectangleRuntime sut = new();
+        sut.CornerRadiusUnits.ShouldBe(Gum.DataTypes.DimensionUnitType.Absolute);
+    }
+
+    [Fact]
+    public void CornerRadiusUnits_RoundTrips()
+    {
+        RectangleRuntime sut = new();
+        sut.CornerRadiusUnits = Gum.DataTypes.DimensionUnitType.ScreenPixel;
+        sut.CornerRadiusUnits.ShouldBe(Gum.DataTypes.DimensionUnitType.ScreenPixel);
+    }
+
+    [Fact]
+    public void PreRender_ScreenPixelCornerRadius_ScaledByCameraZoom()
+    {
+        // Wire managers by parenting to Root so EffectiveManagers (hence the camera) resolves,
+        // then set a non-1 zoom. The runtime getter keeps the raw value; the renderable receives
+        // the zoom-divided value.
+        RectangleRuntime sut = new();
+        Gum.GumService.Default.Root.Children.Add(sut);
+
+        float originalZoom = SystemManagers.Default.Renderer.Camera.Zoom;
+        try
+        {
+            SystemManagers.Default.Renderer.Camera.Zoom = 2f;
+            sut.CornerRadius = 8f;
+            sut.CornerRadiusUnits = Gum.DataTypes.DimensionUnitType.ScreenPixel;
+
+            sut.PreRender();
+
+            sut.CornerRadius.ShouldBe(8f);
+            ((LineRectangle)sut.RenderableComponent!).CornerRadius.ShouldBe(4f);
+        }
+        finally
+        {
+            SystemManagers.Default.Renderer.Camera.Zoom = originalZoom;
+            Gum.GumService.Default.Root.Children.Remove(sut);
+        }
     }
 
     [Fact]


### PR DESCRIPTION
Closes #3494. Part of the RaylibGum parity umbrella #3432 (P3).

## What

Adds `CornerRadiusUnits` to the raylib `RectangleRuntime`, the one genuine remaining gap from the stale #3432 "RectangleRuntime missing Blend and CornerRadiusUnits" bullet (re-verified: **Blend already landed via #3458**, `IsAntialiased` and shared `CornerRadius` are already present).

raylib pushed `CornerRadius` straight to the renderable in the setter with no unit resolution, so a `ScreenPixel` corner radius did not hold a constant on-screen size under camera zoom the way it does on XNALIKE/Skia. Now:

- `CornerRadius` holds its raw value in a backing field (getter returns raw).
- `PreRender` divides it by the camera zoom when `CornerRadiusUnits == ScreenPixel` before pushing to the contained `LineRectangle` — mirroring the `StrokeWidthUnits` handling already in the same `PreRender`.
- The setter still eagerly pushes the raw value so an `Absolute` radius is correct before the first `PreRender` (keeps the existing `CornerRadius_RoundTrips` test green); `PreRender` reads the raw backing field, so re-running it each frame never compounds the division.

## Out of scope

**Per-corner radii** (`CustomRadiusTopLeft`…) remain round-trip parity only — not rendered on raylib (`DrawRectangleRounded` takes a single roundness for all four corners; per-corner needs custom mesh tessellation). That's the real remaining *rendering* gap, tracked in #3432.

## Tests

- `CornerRadiusUnits` default (`Absolute`) + round-trip.
- `PreRender_ScreenPixelCornerRadius_ScaledByCameraZoom`: parents to `Root` so the camera resolves, sets zoom 2, and asserts the renderable receives `radius / 2` while the runtime getter keeps the raw value.
- Full `RaylibGum.Tests` green (436); `MonoGameGum` builds clean.

## Manual test

**Not needed** — the `ScreenPixel` behavior is only observable under a non-1 camera zoom, which the sample galleries render at 1 (so an `Absolute` vs `ScreenPixel` cell would look identical and be misleading). The zoom-scaling is proven by the `PreRender` unit test. Same reasoning as the sibling `StrokeWidthUnits`, which likewise has no gallery demo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
