### PR TITLE
Recognize .shproj (and .vbproj/.fsproj) as valid code-gen project roots

### DIFF
--- a/Gum/CodeOutputPlugin/MainCodeOutputPlugin.cs
+++ b/Gum/CodeOutputPlugin/MainCodeOutputPlugin.cs
@@ -543,8 +543,8 @@ public class MainCodeOutputPlugin : PluginBase
             if(csprojAboveGumx == null)
             {
                 message += "\n\n" +
-                    "Note: Your Gum project (.gumx) is currently not saved relative to a folder that contains a .csproj file. " +
-                    "Saving your Gum project relative to your .csproj is the recommended approach";
+                    "Note: Specify a Code Project Root above (Project-Wide Code Generation section). " +
+                    "This can be any folder - it does not need to contain a .csproj.";
             }
 
             _dialogService.ShowMessage(message);

--- a/Gum/CodeOutputPlugin/ViewModels/CodeWindowViewModel.cs
+++ b/Gum/CodeOutputPlugin/ViewModels/CodeWindowViewModel.cs
@@ -210,7 +210,7 @@ public class CodeWindowViewModel : ViewModel
         var files = _fileCommands.GetFiles(filePath.FullPath)
             .Select(item => new FilePath(item));
 
-        if (files.Any(item => item.Extension == "csproj"))
+        if (files.Any(item => CodeGenerationAutoSetupService.RecognizedProjectFileExtensions.Contains(item.Extension)))
         {
             return filePath;
         }

--- a/Tests/Gum.ProjectServices.Tests/CodeGenerationAutoSetupServiceTests.cs
+++ b/Tests/Gum.ProjectServices.Tests/CodeGenerationAutoSetupServiceTests.cs
@@ -154,6 +154,36 @@ public class CodeGenerationAutoSetupServiceTests : IDisposable
     }
 
     [Fact]
+    public void Run_WhenOnlyShprojFound_SetsCodeProjectRootToDot()
+    {
+        string shprojPath = Path.Combine(_tempDirectory, "MyGame.shproj");
+        File.WriteAllText(shprojPath, "<Project></Project>");
+        string gumxPath = Path.Combine(_tempDirectory, "MyProject.gumx");
+        File.WriteAllText(gumxPath, "");
+
+        AutoSetupResult result = _sut.Run(gumxPath);
+
+        result.Success.ShouldBeTrue();
+        result.Settings!.CodeProjectRoot.ShouldBe("./");
+    }
+
+    [Fact]
+    public void Run_WhenOnlyShprojFound_LeavesRootNamespaceAndOutputLibraryAsDefaults()
+    {
+        string shprojPath = Path.Combine(_tempDirectory, "MyGame.shproj");
+        File.WriteAllText(shprojPath,
+            "<Project><ItemGroup><PackageReference Include=\"MonoGame.Framework.DesktopGL\" Version=\"3.8.1.303\" /></ItemGroup></Project>");
+        string gumxPath = Path.Combine(_tempDirectory, "MyProject.gumx");
+        File.WriteAllText(gumxPath, "");
+
+        AutoSetupResult result = _sut.Run(gumxPath);
+
+        result.Success.ShouldBeTrue();
+        result.Settings!.RootNamespace.ShouldBe(string.Empty);
+        result.Settings!.OutputLibrary.ShouldBe(OutputLibrary.MonoGame);
+    }
+
+    [Fact]
     public void Run_WhenNoCsprojFound_ReturnsFailure()
     {
         // Use an isolated subdirectory of GetTempPath() which typically has no .csproj

--- a/Tests/Gum.ProjectServices.Tests/CodeGenerationAutoSetupServiceTests.cs
+++ b/Tests/Gum.ProjectServices.Tests/CodeGenerationAutoSetupServiceTests.cs
@@ -184,6 +184,23 @@ public class CodeGenerationAutoSetupServiceTests : IDisposable
     }
 
     [Fact]
+    public void Run_WithExplicitShprojPath_TreatsAsSharedProjectAndLeavesDefaults()
+    {
+        string shprojPath = Path.Combine(_tempDirectory, "Shared.shproj");
+        File.WriteAllText(shprojPath,
+            "<Project><ItemGroup><PackageReference Include=\"MonoGame.Framework.DesktopGL\" Version=\"3.8.1.303\" /></ItemGroup></Project>");
+        string gumxPath = Path.Combine(_tempDirectory, "MyProject.gumx");
+        File.WriteAllText(gumxPath, "");
+
+        AutoSetupResult result = _sut.Run(gumxPath, shprojPath);
+
+        result.Success.ShouldBeTrue();
+        result.Settings!.CodeProjectRoot.ShouldBe("./");
+        result.Settings!.RootNamespace.ShouldBe(string.Empty);
+        result.Settings!.OutputLibrary.ShouldBe(OutputLibrary.MonoGame);
+    }
+
+    [Fact]
     public void Run_WhenNoCsprojFound_ReturnsFailure()
     {
         // Use an isolated subdirectory of GetTempPath() which typically has no .csproj

--- a/Tool/Tests/GumToolUnitTests/Plugins/CodeOutputPlugins/CodeWindowViewModelTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/CodeOutputPlugins/CodeWindowViewModelTests.cs
@@ -91,6 +91,37 @@ public class CodeWindowViewModelTests
     }
 
     [Fact]
+    public void ShouldShowSetup_ReturnsTrue_WhenShprojAboveGumxAndCodeProjectRootEmpty()
+    {
+        string gumDirectory = @"C:\game\Content\GumProject\";
+        string shprojDirectory = @"C:\game\";
+
+        _mocker.GetMock<IProjectState>()
+            .Setup(p => p.ProjectDirectory)
+            .Returns(gumDirectory);
+
+        Mock<IFileCommands> fileCommandsMock = _mocker.GetMock<IFileCommands>();
+        FilePath shprojPath = new FilePath(shprojDirectory);
+        fileCommandsMock
+            .Setup(f => f.GetFiles(It.IsAny<string>()))
+            .Returns<string>(path =>
+            {
+                FilePath asFilePath = new FilePath(path);
+                if (asFilePath == shprojPath)
+                {
+                    return new[] { Path.Combine(shprojDirectory, "Shared.shproj") };
+                }
+                return Array.Empty<string>();
+            });
+
+        CodeOutputProjectSettings settings = new CodeOutputProjectSettings { CodeProjectRoot = string.Empty };
+
+        bool result = _viewModel.ShouldShowSetup(settings, hasClickedManualSetup: false);
+
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
     public void ShouldShowSetup_ReturnsFalse_WhenNoCsprojExistsAboveGumx()
     {
         string gumDirectory = @"C:\game\Content\GumProject\";

--- a/Tools/Gum.ProjectServices/CodeGeneration/CodeGenerationAutoSetupService.cs
+++ b/Tools/Gum.ProjectServices/CodeGeneration/CodeGenerationAutoSetupService.cs
@@ -21,11 +21,20 @@ public class AutoSetupResult
 
 /// <summary>
 /// Inspects the file system to automatically configure <see cref="CodeOutputProjectSettings"/> for a
-/// Gum project. Walks up from the .gumx directory to find the nearest .csproj, then derives
-/// <c>CodeProjectRoot</c>, <c>RootNamespace</c>, and <c>OutputLibrary</c> from it.
+/// Gum project. Walks up from the .gumx directory to find the nearest project file (see
+/// <see cref="RecognizedProjectFileExtensions"/>), then derives <c>CodeProjectRoot</c>,
+/// <c>RootNamespace</c>, and <c>OutputLibrary</c> from it.
 /// </summary>
 public class CodeGenerationAutoSetupService : ICodeGenerationAutoSetupService
 {
+    /// <summary>
+    /// File extensions (without the leading dot) recognized as marking a valid project root
+    /// directory above a .gumx file. Includes <c>.csproj</c>/<c>.vbproj</c>/<c>.fsproj</c> as well as
+    /// <c>.shproj</c> shared projects, which are a common container for Gum content in multi-head
+    /// (e.g. Desktop + Blazor) setups.
+    /// </summary>
+    public static readonly string[] RecognizedProjectFileExtensions = { "csproj", "shproj", "vbproj", "fsproj" };
+
     /// <inheritdoc/>
     public AutoSetupResult Run(string gumxFilePath)
     {
@@ -37,18 +46,19 @@ public class CodeGenerationAutoSetupService : ICodeGenerationAutoSetupService
             gumxDirectory += Path.DirectorySeparatorChar;
         }
 
-        string? csprojDirectory = FindCsprojDirectory(gumxDirectory);
+        string? projectDirectory = FindProjectDirectory(gumxDirectory);
 
-        if (csprojDirectory == null)
+        if (projectDirectory == null)
         {
+            string extensionList = string.Join(", ", RecognizedProjectFileExtensions.Select(extension => $".{extension}"));
             return new AutoSetupResult
             {
                 Success = false,
-                ErrorMessage = "No .csproj file found in any parent directory of the .gumx file. Cannot automatically configure code generation."
+                ErrorMessage = $"No {extensionList} file found in any parent directory of the .gumx file. Cannot automatically configure code generation."
             };
         }
 
-        return BuildResultFromCsprojDirectory(gumxDirectory, csprojDirectory, explicitCsprojPath: null);
+        return BuildResultFromCsprojDirectory(gumxDirectory, projectDirectory, explicitCsprojPath: null);
     }
 
     /// <inheritdoc/>
@@ -80,9 +90,9 @@ public class CodeGenerationAutoSetupService : ICodeGenerationAutoSetupService
     }
 
     private static AutoSetupResult BuildResultFromCsprojDirectory(
-        string gumxDirectory, string csprojDirectory, string? explicitCsprojPath)
+        string gumxDirectory, string projectDirectory, string? explicitCsprojPath)
     {
-        string codeProjectRoot = Path.GetRelativePath(gumxDirectory, csprojDirectory);
+        string codeProjectRoot = Path.GetRelativePath(gumxDirectory, projectDirectory);
         if (codeProjectRoot == ".")
         {
             codeProjectRoot = "./";
@@ -101,13 +111,19 @@ public class CodeGenerationAutoSetupService : ICodeGenerationAutoSetupService
 
         settings.SetDefaults();
 
-        string? csprojPath = explicitCsprojPath ?? Directory
-            .EnumerateFiles(csprojDirectory, "*.csproj", SearchOption.TopDirectoryOnly)
+        string? projectFilePath = explicitCsprojPath ?? RecognizedProjectFileExtensions
+            .SelectMany(extension => Directory.EnumerateFiles(projectDirectory, $"*.{extension}", SearchOption.TopDirectoryOnly))
             .FirstOrDefault();
 
-        if (csprojPath != null)
+        // Shared projects (.shproj) don't carry PackageReference/RootNamespace MSBuild metadata like a
+        // .csproj does, so leave OutputLibrary/RootNamespace at their defaults for the user to fill in
+        // manually — same as the no-project-found fallback does today.
+        bool isSharedProject = projectFilePath != null
+            && string.Equals(Path.GetExtension(projectFilePath), ".shproj", StringComparison.OrdinalIgnoreCase);
+
+        if (projectFilePath != null && !isSharedProject)
         {
-            string contents = File.ReadAllText(csprojPath);
+            string contents = File.ReadAllText(projectFilePath);
 
             bool isMonoGameBased =
                 contents.Contains("<PackageReference Include=\"MonoGame.Framework.", StringComparison.Ordinal) ||
@@ -128,7 +144,7 @@ public class CodeGenerationAutoSetupService : ICodeGenerationAutoSetupService
                 settings.OutputLibrary = OutputLibrary.Raylib;
             }
 
-            settings.RootNamespace = ExtractRootNamespace(contents, csprojPath);
+            settings.RootNamespace = ExtractRootNamespace(contents, projectFilePath);
         }
 
         return new AutoSetupResult
@@ -138,17 +154,16 @@ public class CodeGenerationAutoSetupService : ICodeGenerationAutoSetupService
         };
     }
 
-    private static string? FindCsprojDirectory(string startDirectory)
+    private static string? FindProjectDirectory(string startDirectory)
     {
         string? current = startDirectory;
 
         while (current != null)
         {
-            bool hasCsproj = Directory
-                .EnumerateFiles(current, "*.csproj", SearchOption.TopDirectoryOnly)
-                .Any();
+            bool hasProjectFile = RecognizedProjectFileExtensions
+                .Any(extension => Directory.EnumerateFiles(current, $"*.{extension}", SearchOption.TopDirectoryOnly).Any());
 
-            if (hasCsproj)
+            if (hasProjectFile)
             {
                 return current;
             }


### PR DESCRIPTION
## Summary

Gum's code-generation setup only detected `.csproj` when walking up from the `.gumx` to find a project root, so shared-project (`.shproj`) setups — a common pattern for KNI/MonoGame projects with multiple heads (e.g. Desktop + Blazor) sharing content through a Shared Project — never got auto-detected, even when the `.gumx` lives right next to the `.shproj`.

- Broadened both hardcoded `.csproj`-only checks — `CodeGenerationAutoSetupService.FindProjectDirectory`/`BuildResultFromCsprojDirectory` and `CodeWindowViewModel.GetCsprojDirectoryAboveGumx` — to also recognize `.shproj`, `.vbproj`, and `.fsproj`, via a single shared `RecognizedProjectFileExtensions` array (no duplicated/hardcoded extension lists).
- When the discovered/explicitly-specified project file is a `.shproj`, `PackageReference`/`RootNamespace` extraction is skipped (shared projects don't carry that MSBuild metadata) and `OutputLibrary`/`RootNamespace` are left at their defaults for the user to fill in manually — same as the existing no-project-found fallback.
- Reworded the "you must specify a Code Project Root" dialog message so it no longer implies a `.csproj` is required.

## Test plan
- [x] `Tests/Gum.ProjectServices.Tests` (`CodeGenerationAutoSetupServiceTests`) — new tests for auto-detected `.shproj`, explicit `--csproj` path pointing at a `.shproj`, and existing `.csproj` cases; full suite (338 tests) green.
- [x] `Tool/Tests/GumToolUnitTests` (`CodeWindowViewModelTests`) — new test for `.shproj` recognition in `ShouldShowSetup`; full suite (1039 tests) green.
- [x] `Tests/Gum.Cli.Tests` builds clean.
- [x] Confirmed the new `.shproj` tests actually go red when the shared-project guard is removed (not just green-by-default).

Closes #3498
