### PR TITLE
Fix RefreshInternalVisualReferences codegen gate to MonoGameForms only

### DIFF
--- a/Tests/Gum.ProjectServices.Tests/CodeGeneratorRefreshInternalVisualReferencesTests.cs
+++ b/Tests/Gum.ProjectServices.Tests/CodeGeneratorRefreshInternalVisualReferencesTests.cs
@@ -1,0 +1,104 @@
+using Gum.DataTypes;
+using Gum.DataTypes.Variables;
+using Gum.Localization;
+using Gum.Managers;
+using Gum.ProjectServices.CodeGeneration;
+using Moq;
+using Shouldly;
+
+namespace Gum.ProjectServices.Tests;
+
+/// <summary>
+/// Tests for #3501: <c>base.RefreshInternalVisualReferences();</c> must only be emitted for
+/// <see cref="OutputLibrary.MonoGameForms"/>, since that method only exists on the Forms
+/// <c>FrameworkElement</c> hierarchy (<c>MonoGameGum/Forms/Controls/FrameworkElement.cs</c>). The
+/// generator previously gated the call on <c>OutputLibrary != OutputLibrary.Skia</c>, which wrongly
+/// emitted the call for plain <see cref="OutputLibrary.MonoGame"/> (and Raylib/WPF/Maui/XamarinForms)
+/// projects, producing generated code that failed to compile with CS0117 because the base type
+/// (<c>GraphicalUiElement</c>/<c>ContainerRuntime</c>) has no such member.
+/// </summary>
+public class CodeGeneratorRefreshInternalVisualReferencesTests : BaseTestClass
+{
+    private static CodeGenerator CreateCodeGenerator()
+    {
+        Mock<INameVerifier> mockNameVerifier = new Mock<INameVerifier>();
+        string whyNotValid;
+        CommonValidationError error;
+        mockNameVerifier
+            .Setup(v => v.IsValidCSharpName(It.IsAny<string>(), out whyNotValid, out error))
+            .Returns(true);
+        CodeGenerationNameVerifier codeGenNameVerifier = new CodeGenerationNameVerifier(mockNameVerifier.Object);
+        FixedProjectDirectoryProvider directoryProvider = new FixedProjectDirectoryProvider(projectDirectory: null);
+        CodeOutputElementSettingsManager elementSettingsManager = new CodeOutputElementSettingsManager(directoryProvider);
+        LocalizationService localizationService = new LocalizationService();
+
+        return new CodeGenerator(
+            codeGenNameVerifier,
+            localizationService,
+            elementSettingsManager,
+            directoryProvider);
+    }
+
+    private static ComponentSave CreateComponent(string name, string baseType)
+    {
+        ComponentSave component = new ComponentSave { Name = name, BaseType = baseType };
+        StateSave defaultState = new StateSave { Name = "Default", ParentContainer = component };
+        component.States.Add(defaultState);
+        return component;
+    }
+
+    private static CodeOutputProjectSettings CreateProjectSettings(OutputLibrary outputLibrary) => new CodeOutputProjectSettings
+    {
+        OutputLibrary = outputLibrary,
+        ObjectInstantiationType = ObjectInstantiationType.FullyInCode,
+        RootNamespace = "MyGame",
+    };
+
+    [Fact]
+    public void GetGeneratedCodeForElement_MonoGame_DoesNotEmitRefreshInternalVisualReferences()
+    {
+        GumProjectSave project = Project;
+
+        ComponentSave component = CreateComponent("MainComponent", "Container");
+        project.Components.Add(component);
+
+        ObjectFinder.Self.GumProjectSave = project;
+        try
+        {
+            string code = CreateCodeGenerator().GetGeneratedCodeForElement(
+                component,
+                new CodeOutputElementSettings(),
+                CreateProjectSettings(OutputLibrary.MonoGame));
+
+            code.ShouldNotContain("RefreshInternalVisualReferences");
+        }
+        finally
+        {
+            ObjectFinder.Self.GumProjectSave = null;
+        }
+    }
+
+    [Fact]
+    public void GetGeneratedCodeForElement_MonoGameForms_EmitsRefreshInternalVisualReferences()
+    {
+        GumProjectSave project = Project;
+
+        ComponentSave component = CreateComponent("MainComponent", "Container");
+        project.Components.Add(component);
+
+        ObjectFinder.Self.GumProjectSave = project;
+        try
+        {
+            string code = CreateCodeGenerator().GetGeneratedCodeForElement(
+                component,
+                new CodeOutputElementSettings(),
+                CreateProjectSettings(OutputLibrary.MonoGameForms));
+
+            code.ShouldContain("base.RefreshInternalVisualReferences();");
+        }
+        finally
+        {
+            ObjectFinder.Self.GumProjectSave = null;
+        }
+    }
+}

--- a/Tools/Gum.ProjectServices/CodeGeneration/CodeGenerator.cs
+++ b/Tools/Gum.ProjectServices/CodeGeneration/CodeGenerator.cs
@@ -1375,7 +1375,7 @@ public class CodeGenerator
             context.Instance = null;
         }
 
-        if(isFullyInstantiatingInCode && !isDerived && context.CodeOutputProjectSettings.OutputLibrary != OutputLibrary.Skia)
+        if(isFullyInstantiatingInCode && !isDerived && context.CodeOutputProjectSettings.OutputLibrary == OutputLibrary.MonoGameForms)
         {
             //RefreshInternalVisualReferences
             context.StringBuilder.AppendLine(context.Tabs + "base.RefreshInternalVisualReferences();");


### PR DESCRIPTION
## Summary
- `GenerateInitializeInstancesMethod` emitted `base.RefreshInternalVisualReferences();` whenever `OutputLibrary != Skia`. That method only exists on the Forms `FrameworkElement` hierarchy (`MonoGameGum/Forms/Controls/FrameworkElement.cs`), not on plain `GraphicalUiElement`/`ContainerRuntime`.
- Any project with `ObjectInstantiationType.FullyInCode` and a non-derived element, targeting `OutputLibrary.MonoGame` (plain), `Raylib`, `WPF`, `Maui`, or `XamarinForms`, got this call baked into generated code, failing to compile with CS0117.
- Fixed by gating on `OutputLibrary == OutputLibrary.MonoGameForms`, matching the equivalent, correctly-gated `base.ReactToVisualChanged();` check ~70 lines above.

## Test plan
- [x] Added `Tests/Gum.ProjectServices.Tests/CodeGeneratorRefreshInternalVisualReferencesTests.cs`:
  - `GetGeneratedCodeForElement_MonoGame_DoesNotEmitRefreshInternalVisualReferences` — reproduces the bug (failed before the fix, showing the erroneous call in generated MonoGame code).
  - `GetGeneratedCodeForElement_MonoGameForms_EmitsRefreshInternalVisualReferences` — regression guard for the original #2328 Forms feature.
- [x] `dotnet test Tests/Gum.ProjectServices.Tests/Gum.ProjectServices.Tests.csproj` — 338 passed, 2 skipped (pre-existing helper tests), 0 failed.
- No manual/visual test needed — this is a pure codegen-string fix with no runtime/visual surface; it only changes which line of text is appended to a generated `.Generated.cs` file.

Closes #3501