### PR TITLE
Fix FullyInCode codegen crash and layout bugs for unified-runtime Screens with no BaseType

### DIFF
--- a/Tests/CodeGen_Maui_FullCodegen/Screens/ExampleScreenRuntime.Generated.cs
+++ b/Tests/CodeGen_Maui_FullCodegen/Screens/ExampleScreenRuntime.Generated.cs
@@ -79,6 +79,10 @@ partial class ExampleScreenRuntime : Gum.Wireframe.GraphicalUiElement
     }
     private void ApplyDefaultVariables()
     {
+        this.Width = 0f;
+        this.WidthUnits = global::Gum.DataTypes.DimensionUnitType.RelativeToParent;
+        this.Height = 0f;
+        this.HeightUnits = global::Gum.DataTypes.DimensionUnitType.RelativeToParent;
         this.ContainerInstance.ChildrenLayout = global::Gum.Managers.ChildrenLayout.TopToBottomStack;
         this.ContainerInstance.Height = 358f;
         this.ContainerInstance.Width = 256f;

--- a/Tests/CodeGen_Maui_FullCodegen/Screens/With_Spaces_ScreenRuntime.Generated.cs
+++ b/Tests/CodeGen_Maui_FullCodegen/Screens/With_Spaces_ScreenRuntime.Generated.cs
@@ -62,6 +62,10 @@ partial class With_Spaces_ScreenRuntime : Gum.Wireframe.GraphicalUiElement
     }
     private void ApplyDefaultVariables()
     {
+        this.Width = 0f;
+        this.WidthUnits = global::Gum.DataTypes.DimensionUnitType.RelativeToParent;
+        this.Height = 0f;
+        this.HeightUnits = global::Gum.DataTypes.DimensionUnitType.RelativeToParent;
 
 
 

--- a/Tests/Gum.ProjectServices.Tests/CodeGeneratorScreenContainedObjectTests.cs
+++ b/Tests/Gum.ProjectServices.Tests/CodeGeneratorScreenContainedObjectTests.cs
@@ -84,4 +84,44 @@ public class CodeGeneratorScreenContainedObjectTests : BaseTestClass
             ObjectFinder.Self.GumProjectSave = null;
         }
     }
+
+    [Fact]
+    public void FullyInCode_MonoGame_ScreenWithChildInstance_AddsDirectlyToChildrenWithoutDeadNullCheck()
+    {
+        // The generated "if(this.Children != null) ... else this.WhatThisContains.Add(...)" guard
+        // was dead: Children is a property that always returns a collection (real or the read-only
+        // Empty singleton) and is never itself null, so the else branch could never run - it was a
+        // (non-functional) attempt to guard against exactly the Empty-collection crash fixed above.
+        // Now that a contained object is always assigned first, this can be a plain, unconditional
+        // Children.Add(...) - matching what non-Screen elements already emit (see the "else" branch
+        // a few lines below this one in CodeGenerator.FillWithParentAssignments).
+        GumProjectSave project = Project;
+
+        ScreenSave mainMenu = new ScreenSave { Name = "MainMenuUI" };
+        StateSave defaultState = new StateSave { Name = "Default", ParentContainer = mainMenu };
+        mainMenu.States.Add(defaultState);
+        InstanceSave textInstance = new InstanceSave
+        {
+            Name = "TextInstance",
+            BaseType = "Text",
+            ParentContainer = mainMenu,
+        };
+        mainMenu.Instances.Add(textInstance);
+        project.Screens.Add(mainMenu);
+
+        ObjectFinder.Self.GumProjectSave = project;
+        try
+        {
+            string code = CreateCodeGenerator().GetGeneratedCodeForElement(
+                mainMenu, elementSettings: null!, CreateMonoGame());
+
+            code.ShouldContain("this.Children.Add(TextInstance);");
+            code.ShouldNotContain("this.Children != null");
+            code.ShouldNotContain("this.WhatThisContains.Add(TextInstance);");
+        }
+        finally
+        {
+            ObjectFinder.Self.GumProjectSave = null;
+        }
+    }
 }

--- a/Tests/Gum.ProjectServices.Tests/CodeGeneratorScreenContainedObjectTests.cs
+++ b/Tests/Gum.ProjectServices.Tests/CodeGeneratorScreenContainedObjectTests.cs
@@ -1,0 +1,87 @@
+using Gum.DataTypes;
+using Gum.DataTypes.Variables;
+using Gum.Localization;
+using Gum.Managers;
+using Gum.ProjectServices.CodeGeneration;
+using Moq;
+using Shouldly;
+
+namespace Gum.ProjectServices.Tests;
+
+/// <summary>
+/// Regression for a Screen with no BaseType, code-generated FullyInCode against the unified
+/// runtime (OutputLibrary.MonoGame, which KNI/FNA projects also select): GetInheritance resolves
+/// such a Screen to bare Gum.Wireframe.GraphicalUiElement (see
+/// CodeGeneratorGetInheritanceTests.GetInheritance_MonoGame_Screen_NoBaseType_NoDefaultScreenBase_ReturnsGraphicalUiElement),
+/// which never assigns itself a contained renderable. The constructor generator only emitted
+/// SetContainedObject(new InvisibleRenderable()) when element.BaseType == "Container", which a
+/// Screen's BaseType never is - so the emitted constructor called AssignParents() (and thus
+/// this.AddChild(...)) while Children was still the read-only GraphicalUiElementCollection.Empty
+/// singleton, throwing "Cannot modify the empty collection" at runtime.
+/// </summary>
+public class CodeGeneratorScreenContainedObjectTests : BaseTestClass
+{
+    private static CodeGenerator CreateCodeGenerator()
+    {
+        Mock<INameVerifier> mockNameVerifier = new Mock<INameVerifier>();
+        string whyNotValid;
+        CommonValidationError error;
+        mockNameVerifier
+            .Setup(v => v.IsValidCSharpName(It.IsAny<string>(), out whyNotValid, out error))
+            .Returns(true);
+        CodeGenerationNameVerifier codeGenNameVerifier = new CodeGenerationNameVerifier(mockNameVerifier.Object);
+        FixedProjectDirectoryProvider directoryProvider = new FixedProjectDirectoryProvider(projectDirectory: null);
+        CodeOutputElementSettingsManager elementSettingsManager = new CodeOutputElementSettingsManager(directoryProvider);
+        LocalizationService localizationService = new LocalizationService();
+
+        return new CodeGenerator(
+            codeGenNameVerifier,
+            localizationService,
+            elementSettingsManager,
+            directoryProvider);
+    }
+
+    private static CodeOutputProjectSettings CreateMonoGame() => new CodeOutputProjectSettings
+    {
+        OutputLibrary = OutputLibrary.MonoGame,
+        RootNamespace = "MyGame",
+    };
+
+    [Fact]
+    public void FullyInCode_MonoGame_ScreenWithNoBaseTypeAndChildInstance_AssignsContainedObjectBeforeAssigningParents()
+    {
+        GumProjectSave project = Project;
+
+        ScreenSave mainMenu = new ScreenSave { Name = "MainMenuUI" };
+        StateSave defaultState = new StateSave { Name = "Default", ParentContainer = mainMenu };
+        mainMenu.States.Add(defaultState);
+        InstanceSave textInstance = new InstanceSave
+        {
+            Name = "TextInstance",
+            BaseType = "Text",
+            ParentContainer = mainMenu,
+        };
+        mainMenu.Instances.Add(textInstance);
+        project.Screens.Add(mainMenu);
+
+        ObjectFinder.Self.GumProjectSave = project;
+        try
+        {
+            string code = CreateCodeGenerator().GetGeneratedCodeForElement(
+                mainMenu, elementSettings: null!, CreateMonoGame());
+
+            // The Screen has no BaseType, so it inherits bare GraphicalUiElement and must set its
+            // own contained renderable before AssignParents() touches Children.
+            code.ShouldContain("SetContainedObject(new InvisibleRenderable());");
+            int containedObjectIndex = code.IndexOf("SetContainedObject(new InvisibleRenderable());");
+            int assignParentsCallIndex = code.IndexOf("AssignParents();");
+            containedObjectIndex.ShouldBeGreaterThanOrEqualTo(0);
+            assignParentsCallIndex.ShouldBeGreaterThanOrEqualTo(0);
+            containedObjectIndex.ShouldBeLessThan(assignParentsCallIndex);
+        }
+        finally
+        {
+            ObjectFinder.Self.GumProjectSave = null;
+        }
+    }
+}

--- a/Tests/Gum.ProjectServices.Tests/CodeGeneratorScreenSizeTests.cs
+++ b/Tests/Gum.ProjectServices.Tests/CodeGeneratorScreenSizeTests.cs
@@ -1,0 +1,130 @@
+using Gum.DataTypes;
+using Gum.DataTypes.Variables;
+using Gum.Localization;
+using Gum.Managers;
+using Gum.ProjectServices.CodeGeneration;
+using Moq;
+using Shouldly;
+
+namespace Gum.ProjectServices.Tests;
+
+/// <summary>
+/// Regression: GenerateApplyDefaultVariables has a "October 5, 2025 - Generate the screen size"
+/// block that makes a FullyInCode Screen fill its parent (Width/HeightUnits = RelativeToParent),
+/// but it only emitted that for OutputLibrary.MonoGameForms ("this.Visual.Width = ..."). Every
+/// other Gum-API output library (plain MonoGame - which KNI/FNA projects also select, Raylib,
+/// Skia) fell into an empty else branch, so a Screen with no explicit Width/Height in its .gusx
+/// kept Gum.Wireframe.GraphicalUiElement's hardcoded 32x32 constructor default instead of filling
+/// the window.
+/// </summary>
+public class CodeGeneratorScreenSizeTests : BaseTestClass
+{
+    private static CodeGenerator CreateCodeGenerator()
+    {
+        Mock<INameVerifier> mockNameVerifier = new Mock<INameVerifier>();
+        string whyNotValid;
+        CommonValidationError error;
+        mockNameVerifier
+            .Setup(v => v.IsValidCSharpName(It.IsAny<string>(), out whyNotValid, out error))
+            .Returns(true);
+        CodeGenerationNameVerifier codeGenNameVerifier = new CodeGenerationNameVerifier(mockNameVerifier.Object);
+        FixedProjectDirectoryProvider directoryProvider = new FixedProjectDirectoryProvider(projectDirectory: null);
+        CodeOutputElementSettingsManager elementSettingsManager = new CodeOutputElementSettingsManager(directoryProvider);
+        LocalizationService localizationService = new LocalizationService();
+
+        return new CodeGenerator(
+            codeGenNameVerifier,
+            localizationService,
+            elementSettingsManager,
+            directoryProvider);
+    }
+
+    private static ScreenSave CreateScreenWithNoSize(GumProjectSave project)
+    {
+        ScreenSave screen = new ScreenSave { Name = "MainMenuUI" };
+        StateSave defaultState = new StateSave { Name = "Default", ParentContainer = screen };
+        screen.States.Add(defaultState);
+        project.Screens.Add(screen);
+        return screen;
+    }
+
+    [Fact]
+    public void FullyInCode_MonoGame_ScreenWithNoExplicitSize_FillsParent()
+    {
+        GumProjectSave project = Project;
+        ScreenSave screen = CreateScreenWithNoSize(project);
+
+        ObjectFinder.Self.GumProjectSave = project;
+        try
+        {
+            string code = CreateCodeGenerator().GetGeneratedCodeForElement(
+                screen,
+                elementSettings: null!,
+                new CodeOutputProjectSettings { OutputLibrary = OutputLibrary.MonoGame, RootNamespace = "MyGame" });
+
+            code.ShouldContain("this.Width = 0f;");
+            code.ShouldContain("this.WidthUnits = global::Gum.DataTypes.DimensionUnitType.RelativeToParent;");
+            code.ShouldContain("this.Height = 0f;");
+            code.ShouldContain("this.HeightUnits = global::Gum.DataTypes.DimensionUnitType.RelativeToParent;");
+            // Not Forms-wrapped, so it must not emit the ".Visual." variant.
+            code.ShouldNotContain("this.Visual.Width");
+        }
+        finally
+        {
+            ObjectFinder.Self.GumProjectSave = null;
+        }
+    }
+
+    [Fact]
+    public void FullyInCode_Skia_ScreenWithNoExplicitSize_FillsParent()
+    {
+        // Skia Screens with no BaseType also resolve to bare GraphicalUiElement (same fallback as
+        // MonoGame/Raylib - see CodeGenerator.GetInheritance), so they need the same fill-in.
+        GumProjectSave project = Project;
+        ScreenSave screen = CreateScreenWithNoSize(project);
+
+        ObjectFinder.Self.GumProjectSave = project;
+        try
+        {
+            string code = CreateCodeGenerator().GetGeneratedCodeForElement(
+                screen,
+                elementSettings: null!,
+                new CodeOutputProjectSettings { OutputLibrary = OutputLibrary.Skia, RootNamespace = "MyGame" });
+
+            code.ShouldContain("this.Width = 0f;");
+            code.ShouldContain("this.WidthUnits = global::Gum.DataTypes.DimensionUnitType.RelativeToParent;");
+            code.ShouldContain("this.Height = 0f;");
+            code.ShouldContain("this.HeightUnits = global::Gum.DataTypes.DimensionUnitType.RelativeToParent;");
+        }
+        finally
+        {
+            ObjectFinder.Self.GumProjectSave = null;
+        }
+    }
+
+    [Fact]
+    public void FullyInCode_MonoGameForms_ScreenWithNoExplicitSize_StillFillsParentThroughVisual()
+    {
+        // Pin the pre-existing MonoGameForms behavior so the fix above doesn't regress it.
+        GumProjectSave project = Project;
+        ScreenSave screen = CreateScreenWithNoSize(project);
+
+        ObjectFinder.Self.GumProjectSave = project;
+        try
+        {
+            string code = CreateCodeGenerator().GetGeneratedCodeForElement(
+                screen,
+                elementSettings: null!,
+                new CodeOutputProjectSettings { OutputLibrary = OutputLibrary.MonoGameForms, RootNamespace = "MyGame" });
+
+            code.ShouldContain("this.Visual.Width = 0f;");
+            code.ShouldContain("this.Visual.WidthUnits = global::Gum.DataTypes.DimensionUnitType.RelativeToParent;");
+            code.ShouldContain("this.Visual.Height = 0f;");
+            code.ShouldContain("this.Visual.HeightUnits = global::Gum.DataTypes.DimensionUnitType.RelativeToParent;");
+        }
+        finally
+        {
+            ObjectFinder.Self.GumProjectSave = null;
+        }
+    }
+}

--- a/Tools/Gum.ProjectServices/CodeGeneration/CodeGenerator.cs
+++ b/Tools/Gum.ProjectServices/CodeGeneration/CodeGenerator.cs
@@ -5022,9 +5022,17 @@ public class CodeGenerator
                 context.StringBuilder.AppendLine(context.Tabs + "this.Visual.Height = 0f;");
                 context.StringBuilder.AppendLine(context.Tabs + "this.Visual.HeightUnits = global::Gum.DataTypes.DimensionUnitType.RelativeToParent;");
             }
-            else
+            else if (context.VisualApi == VisualApi.Gum)
             {
-
+                // Same as above, but for Screens whose generated class inherits GraphicalUiElement
+                // directly instead of wrapping a Visual (plain MonoGame - which KNI/FNA projects
+                // also select, Raylib, Skia). Without this, such a Screen kept
+                // Gum.Wireframe.GraphicalUiElement's hardcoded 32x32 constructor default instead of
+                // filling its parent.
+                context.StringBuilder.AppendLine(context.Tabs + "this.Width = 0f;");
+                context.StringBuilder.AppendLine(context.Tabs + "this.WidthUnits = global::Gum.DataTypes.DimensionUnitType.RelativeToParent;");
+                context.StringBuilder.AppendLine(context.Tabs + "this.Height = 0f;");
+                context.StringBuilder.AppendLine(context.Tabs + "this.HeightUnits = global::Gum.DataTypes.DimensionUnitType.RelativeToParent;");
             }
         }
 

--- a/Tools/Gum.ProjectServices/CodeGeneration/CodeGenerator.cs
+++ b/Tools/Gum.ProjectServices/CodeGeneration/CodeGenerator.cs
@@ -3168,9 +3168,21 @@ public class CodeGenerator
             }
             if (projectSettings.ObjectInstantiationType == ObjectInstantiationType.FullyInCode)
             {
-                if (element.BaseType == "Container" &&
+                bool isContainerNeedingOwnRenderable = element.BaseType == "Container" &&
                     // In MonoGame the Container is a ContainerRuntime which handles this already
-                    (projectSettings.OutputLibrary != OutputLibrary.MonoGame && projectSettings.OutputLibrary != OutputLibrary.MonoGameForms))
+                    (projectSettings.OutputLibrary != OutputLibrary.MonoGame && projectSettings.OutputLibrary != OutputLibrary.MonoGameForms);
+
+                // A Screen with no BaseType and no custom DefaultScreenBase falls back to bare
+                // Gum.Wireframe.GraphicalUiElement for the unified runtime (see GetInheritance),
+                // which - unlike ContainerRuntime - never assigns itself a contained renderable.
+                // Without this, AssignParents() below calls AddChild() while Children is still
+                // the read-only GraphicalUiElementCollection.Empty singleton.
+                bool isUnifiedRuntimeScreenWithNoBase = element is ScreenSave &&
+                    string.IsNullOrEmpty(element.BaseType) &&
+                    string.IsNullOrEmpty(projectSettings.DefaultScreenBase) &&
+                    UsesUnifiedGumRuntime(projectSettings.OutputLibrary);
+
+                if (isContainerNeedingOwnRenderable || isUnifiedRuntimeScreenWithNoBase)
                 {
                     stringBuilder.AppendLine(context.Tabs + "this.SetContainedObject(new InvisibleRenderable());");
                 }

--- a/Tools/Gum.ProjectServices/CodeGeneration/CodeGenerator.cs
+++ b/Tools/Gum.ProjectServices/CodeGeneration/CodeGenerator.cs
@@ -3002,10 +3002,13 @@ public class CodeGenerator
                     }
                     else if (UsesUnifiedGumRuntime(context.CodeOutputProjectSettings.OutputLibrary))
                     {
-                        // If it's a screen it may have children, or it may not. We just don't know, so we need to check
-
-                        context.StringBuilder.AppendLine($"{context.Tabs}if(this.Children != null) this.Children.Add({_codeGenerationNameVerifier.ToCSharpName(instance.Name)});");
-                        context.StringBuilder.AppendLine($"{context.Tabs}else this.WhatThisContains.Add({_codeGenerationNameVerifier.ToCSharpName(instance.Name)});");
+                        // Children is never null - it's always at least the read-only
+                        // GraphicalUiElementCollection.Empty singleton - so the previous
+                        // "if(this.Children != null) ... else this.WhatThisContains.Add(...)" guard
+                        // could never take its else branch. The constructor now always assigns a
+                        // contained object before this runs (see GenerateConstructors), so Children
+                        // is guaranteed to be a real, writable collection here.
+                        context.StringBuilder.AppendLine($"{context.Tabs}this.Children.Add({_codeGenerationNameVerifier.ToCSharpName(instance.Name)});");
                     }
                     else
                     {


### PR DESCRIPTION
## Summary

Both bugs below were confirmed against a real reporting user's KNI project (`OutputLibrary: 4` = MonoGame, `ObjectInstantiationType: 0` = FullyInCode, no `DefaultScreenBase`, and a `MainMenuUI` Screen with no `BaseType`) - the combination that resolves to bare `Gum.Wireframe.GraphicalUiElement` per `GetInheritance`, which is the "old"/direct-inheritance FullyInCode codegen path (as opposed to the `MonoGameForms`-wrapped path).

1. **Crash**: `InvalidOperationException: Cannot modify the empty collection` inside a generated Screen's `AssignParents()`. `GenerateConstructors` only emitted `this.SetContainedObject(new InvisibleRenderable());` when `element.BaseType == "Container"`, which a Screen's `BaseType` never is by default. Without a contained object, `Children` stayed the read-only `GraphicalUiElementCollection.Empty` singleton, so `AssignParents()`'s `AddChild` calls threw. Fixed by also emitting `SetContainedObject` for Screens with no `BaseType`/`DefaultScreenBase` under the unified runtime, mirroring what `ContainerRuntime` already does for Container-based components.
2. **Dead code**: the codegen for adding a Screen's own instance to `Children` had `if(this.Children != null) this.Children.Add(...) else this.WhatThisContains.Add(...)` - `Children` is never actually `null`, so the `else` could never run. Simplified to an unconditional `this.Children.Add(...)`, matching what non-Screen elements already emit.
3. **Layout bug** (found while helping the user test #1/#2 against their real project): `GenerateApplyDefaultVariables` has an "October 5, 2025 - Generate the screen size" block that fills a Screen's Width/Height to `RelativeToParent` so it fills its parent - but only for `OutputLibrary.MonoGameForms`. Every other Gum-API library (plain `MonoGame`, Raylib, Skia) hit an empty `else`, so a Screen with no explicit Width/Height in its `.gusx` kept `GraphicalUiElement`'s hardcoded 32x32 constructor default instead of filling the window. This is very likely why the reporting user's screen rendered almost nothing visible even after the crash fix. Fixed by emitting the equivalent direct (`this.Width`/`this.WidthUnits`/etc., no `.Visual.` prefix) assignment for any `VisualApi.Gum` output library.

## Test plan
- [x] Added failing-then-passing unit tests for all three fixes (`CodeGeneratorScreenContainedObjectTests`, `CodeGeneratorScreenSizeTests`), including a pin of the pre-existing `MonoGameForms` size behavior so it isn't regressed.
- [x] `dotnet test Tests/Gum.ProjectServices.Tests/Gum.ProjectServices.Tests.csproj` - 343 passed, 0 failed.
- [x] `dotnet test Tests/Gum.Cli.Tests/Gum.Cli.Tests.csproj --filter CodegenCommandTests` - 9 passed.
- [x] Rebuilt `gumcli` from this branch and re-ran `gumcli codegen` against the reporting user's actual project (`--element MainMenuUI`); diffed the regenerated file to confirm exactly the expected changes and nothing else. Rebuilt the user's `Core.DesktopGL.csproj` against the regenerated file - 0 errors.

Manual test: not needed for the codegen logic itself (proven by the unit tests + a real-project regen/rebuild above), but the reporting user is going to re-run their game to confirm the screen now renders correctly end-to-end.
