### PR TITLE
Version-gate DropshadowBlur back-fill on legacy shapes (Arc/ColoredCircle/RoundedRectangle/Line)

### DIFF
--- a/Gum/Managers/StandardElementsManager.cs
+++ b/Gum/Managers/StandardElementsManager.cs
@@ -992,7 +992,7 @@ public class StandardElementsManager
 
             AddGradientVariables(filledCircleState);
 
-            AddDropshadowVariables(filledCircleState);
+            AddDropshadowVariables(filledCircleState, minimumGumxVersion: V3StandardSurfaceVersion);
 
 
             AddStrokeAndFilledVariables(filledCircleState);
@@ -1029,7 +1029,7 @@ public class StandardElementsManager
 
             AddGradientVariables(roundedRectangleState);
 
-            AddDropshadowVariables(roundedRectangleState);
+            AddDropshadowVariables(roundedRectangleState, minimumGumxVersion: V3StandardSurfaceVersion);
 
             AddStrokeAndFilledVariables(roundedRectangleState);
 
@@ -1085,7 +1085,7 @@ public class StandardElementsManager
 
             AddGradientVariables(arcState);
 
-            AddDropshadowVariables(arcState);
+            AddDropshadowVariables(arcState, minimumGumxVersion: V3StandardSurfaceVersion);
 
             AddVariableReferenceList(arcState);
         }
@@ -1231,7 +1231,7 @@ public class StandardElementsManager
 
             AddGradientVariables(lineState);
 
-            AddDropshadowVariables(lineState);
+            AddDropshadowVariables(lineState, minimumGumxVersion: V3StandardSurfaceVersion);
 
             AddBlendVariable(lineState);
 
@@ -1362,6 +1362,25 @@ public class StandardElementsManager
     }
 
 
+    /// <summary>
+    /// Appends the dropshadow surface (HasDropshadow, offsets, blur, and color channels) to a
+    /// standard element's default state. Shared by the plain Circle/Rectangle and the legacy Skia
+    /// shapes (Arc/ColoredCircle/RoundedRectangle/Line).
+    /// </summary>
+    /// <param name="stateSave">The default state to append the dropshadow variables to.</param>
+    /// <param name="minimumGumxVersion">
+    /// When non-zero, stamps each appended variable's <see cref="VariableSave.MinimumGumxVersion"/>
+    /// so the load-time back-fill gates them for older projects. All six current callers pass
+    /// <see cref="V3StandardSurfaceVersion"/>: dropshadow itself predates v3 on the legacy shapes,
+    /// but #2950 renamed their per-axis DropshadowBlurX/DropshadowBlurY into this single scalar
+    /// DropshadowBlur for every caller of this helper, not just Circle/Rectangle. FRB1's generated
+    /// runtime for the legacy shapes (frozen outside this repo -- see
+    /// SkiaGum.Renderables.RenderableArc and friends) predates that rename and never gained the
+    /// scalar name, so back-filling "DropshadowBlur" into an old FRB1 project broke the regenerated
+    /// runtime with CS0246. If you add a new variable to this method (or any other shared default-
+    /// state helper used by these four legacy call sites), gate it explicitly -- there is no build
+    /// in this repo that exercises FRB1's frozen consumer to catch a regression here.
+    /// </param>
     public static void AddDropshadowVariables(StateSave stateSave, int minimumGumxVersion = 0)
     {
         int startIndex = stateSave.Variables.Count;

--- a/Tool/Tests/GumToolUnitTests/DataTypes/StandardElementBackfillVersionGateTests.cs
+++ b/Tool/Tests/GumToolUnitTests/DataTypes/StandardElementBackfillVersionGateTests.cs
@@ -74,6 +74,20 @@ public class StandardElementBackfillVersionGateTests : BaseTestClass
         return project.StandardElements.Single(e => e.Name == standardName).DefaultState;
     }
 
+    // Arc/ColoredCircle/RoundedRectangle/Line are plugin-contributed legacy shapes never placed in
+    // StandardElementsManager.DefaultStates (mDefaults) -- they're reached through
+    // CustomGetDefaultState instead, so tests must go through RegisterExtendedDefaultStates() and
+    // the individual Get*State() accessors rather than the DefaultStates indexer used for
+    // Circle/Rectangle above.
+    private static StateSave GetLegacyShapeDefaultState(string standardName) => standardName switch
+    {
+        "Arc" => StandardElementsManager.GetArcState(),
+        "ColoredCircle" => StandardElementsManager.GetColoredCircleState(),
+        "RoundedRectangle" => StandardElementsManager.GetRoundedRectangleState(),
+        "Line" => StandardElementsManager.GetLineState(),
+        _ => throw new System.ArgumentException($"Unknown legacy shape standard '{standardName}'", nameof(standardName)),
+    };
+
     [Fact]
     public void Initialize_DoesNotInjectV3ShapeVariables_IntoPreV3CircleStandard()
     {
@@ -194,6 +208,58 @@ public class StandardElementBackfillVersionGateTests : BaseTestClass
 
         VariableSave variable = defaultState.Variables.First(v => v.Name == variableName);
         variable.MinimumGumxVersion.ShouldBe(0);
+    }
+
+    [Theory]
+    // #2950 unified the legacy per-axis DropshadowBlurX/DropshadowBlurY into a single scalar
+    // DropshadowBlur across every AddDropshadowVariables caller, including these four legacy
+    // shapes. Their FRB1-generated runtime (frozen outside this repo -- see
+    // SkiaGum.Renderables.RenderableArc and friends) predates that rename and never gained the
+    // scalar name, so back-filling "DropshadowBlur" into an old FRB1 project broke the regenerated
+    // runtime with CS0246 ('RenderableArc' does not contain a definition for 'DropshadowBlur').
+    // These call sites were missed when Circle/Rectangle got the same gate for FRB #1881.
+    [InlineData("Arc")]
+    [InlineData("ColoredCircle")]
+    [InlineData("RoundedRectangle")]
+    [InlineData("Line")]
+    public void DefaultState_TagsDropshadowVariables_WithV3MinimumGumxVersion_OnLegacyShapes(string standardName)
+    {
+        StateSave defaultState = GetLegacyShapeDefaultState(standardName);
+
+        VariableSave variable = defaultState.Variables.First(v => v.Name == "DropshadowBlur");
+        variable.MinimumGumxVersion.ShouldBe(V3);
+    }
+
+    [Theory]
+    [InlineData("Arc")]
+    [InlineData("ColoredCircle")]
+    [InlineData("RoundedRectangle")]
+    [InlineData("Line")]
+    public void Initialize_DoesNotInjectDropshadowBlur_IntoPreV3LegacyShapeStandard(string standardName)
+    {
+        StandardElementsManager.Self.RegisterExtendedDefaultStates();
+        GumProjectSave project = MakeProjectWithBareStandard(standardName, PreV3, "Visible", "Width", "Height");
+
+        StateSave legacyShapeDefault = DefaultStateAfterInitialize(project, standardName);
+
+        legacyShapeDefault.Variables.Any(v => v.Name == "DropshadowBlur").ShouldBeFalse(
+            $"A pre-v3 project must not have DropshadowBlur back-filled into its {standardName} standard.");
+    }
+
+    [Theory]
+    [InlineData("Arc")]
+    [InlineData("ColoredCircle")]
+    [InlineData("RoundedRectangle")]
+    [InlineData("Line")]
+    public void Initialize_InjectsDropshadowBlur_IntoV3LegacyShapeStandard(string standardName)
+    {
+        StandardElementsManager.Self.RegisterExtendedDefaultStates();
+        GumProjectSave project = MakeProjectWithBareStandard(standardName, V3, "Visible", "Width", "Height");
+
+        StateSave legacyShapeDefault = DefaultStateAfterInitialize(project, standardName);
+
+        legacyShapeDefault.Variables.Any(v => v.Name == "DropshadowBlur").ShouldBeTrue(
+            $"A v3 project should still get DropshadowBlur back-filled into its {standardName} standard.");
     }
 
     [Theory]


### PR DESCRIPTION
## Summary

- FRB #1881's fix (commit 214782666) version-gated the v3 shape-surface back-fill for plain Circle/Rectangle so old FRB1 projects aren't injected with variables their pinned runtime can't compile against. It missed that `AddDropshadowVariables` is also called (ungated) by the four legacy shape standards: `GetColoredCircleState`, `GetRoundedRectangleState`, `GetArcState`, `GetLineState`.
- Separately, #2950 renamed the legacy per-axis `DropshadowBlurX`/`DropshadowBlurY` into a single scalar `DropshadowBlur` across **every** caller of that shared helper, not just Circle/Rectangle.
- FRB1's generated runtime for these legacy shapes (frozen outside this repo — e.g. `SkiaGum.Renderables.RenderableArc`) predates that rename and only ever exposed `DropshadowBlurX`/`DropshadowBlurY`, never the unified scalar. Opening an old FRB1 project therefore back-filled `DropshadowBlur` into the standard's default state, and the regenerated runtime broke with `CS0246` ('RenderableArc' does not contain a definition for 'DropshadowBlur') — a real-world compile failure reported downstream.
- Fix: gate all four `AddDropshadowVariables(...)` call sites to the v3 surface version (`V3StandardSurfaceVersion`), mirroring the existing Circle/Rectangle gate exactly. Added a doc comment on `AddDropshadowVariables` explaining why every caller must gate this helper — there is no build in this repo that exercises FRB1's frozen consumer, so this is the only guardrail against a repeat.
- `ShapeVariableVersionGate.GatedStandardTypeNames` (the variable-grid display gate) was intentionally left untouched — that's an unrelated UI-visibility concern that correctly excludes these legacy shapes.

## Test plan
- [x] Added failing tests first (`StandardElementBackfillVersionGateTests`): `DefaultState_TagsDropshadowVariables_WithV3MinimumGumxVersion_OnLegacyShapes`, `Initialize_DoesNotInjectDropshadowBlur_IntoPreV3LegacyShapeStandard`, `Initialize_InjectsDropshadowBlur_IntoV3LegacyShapeStandard` — confirmed red before the fix (8 failing cases), green after.
- [x] Full `GumToolUnitTests` suite: 1047 passed, 0 failed, 4 skipped (pre-existing skips, unrelated).
- [x] No new compiler warnings introduced.
- Manual test verdict: not needed — this is pure back-fill/data-model logic (which variables get injected into a project's saved state, gated by version) with no visual/runtime-observable surface, fully covered by unit tests + compilation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)