### PR TITLE
Fix AposShapeRuntime silently discarding other default-state resolvers

### DIFF
--- a/Gum/DataTypes/ElementSaveExtensionMethods.cs
+++ b/Gum/DataTypes/ElementSaveExtensionMethods.cs
@@ -65,21 +65,24 @@ namespace Gum.DataTypes
             foreach (StateSave state in elementSave.AllStates)
             {
                 state.ParentContainer = elementSave;
+                // StateSave.Initialize only fixes enumeration in-memory representation and sorts
+                // variables - neither is a persisted-content change, so it doesn't feed wasModified.
                 state.Initialize();
 
-                FixStateVariableTypes(elementSave, state, ref wasModified);
+                FixStateVariableTypes(elementSave, state, ref wasModified, modifications);
             }
 
             foreach (InstanceSave instance in elementSave.Instances)
             {
                 instance.ParentContainer = elementSave;
-                instance.Initialize(elementSave, ref wasModified, throwExceptionOnMissing : !tolerateMissingDefaultStates);
+                instance.Initialize(elementSave, ref wasModified, throwExceptionOnMissing : !tolerateMissingDefaultStates, modifications: modifications);
             }
 
             return wasModified;
         }
 
-        private static void FixStateVariableTypes(ElementSave elementSave, StateSave state, ref bool wasModified)
+        private static void FixStateVariableTypes(ElementSave elementSave, StateSave state, ref bool wasModified,
+            ICollection<string>? modifications = null)
         {
             foreach(var variable in state.Variables.Where(item=>item.Type == "string" && item.Name.Contains("State")))
             {
@@ -91,11 +94,13 @@ namespace Gum.DataTypes
                 {
                     variable.Type = "State";
                     wasModified = true;
+                    modifications?.Add($"StateVariableTypeFix:{variable.Name}");
                 }
                 else if(elementSave.Categories.Any(item=>item.Name == withoutState))
                 {
                     variable.Type = withoutState;
                     wasModified = true;
+                    modifications?.Add($"StateVariableTypeFix:{variable.Name}");
                 }
             }
             // Feb 2, 2022
@@ -110,6 +115,7 @@ namespace Gum.DataTypes
                 {
                     variable.Type = withoutState;
                     wasModified = true;
+                    modifications?.Add($"StateVariableTypeFix:{variable.Name}");
                 }
             }
         }
@@ -185,7 +191,7 @@ namespace Gum.DataTypes
 
                             existingVariable.Value = asFloat;
                             wasModified = true;
-                            
+                            modifications?.Add($"FloatValueFix:{existingVariable.Name}");
                         }
                     }
                 }
@@ -215,6 +221,7 @@ namespace Gum.DataTypes
                         {
                             existingList.Type = variableList.Type;
                             wasModified = true;
+                            modifications?.Add($"VariableListTypeFix:{existingList.Name}");
                         }
                     }
                 }
@@ -232,6 +239,11 @@ namespace Gum.DataTypes
                             Value = null
 
                         });
+                        // This was previously not marking the element as modified even though a new
+                        // variable was added, so a category added without a re-save could silently
+                        // regenerate this placeholder every load instead of persisting it.
+                        wasModified = true;
+                        modifications?.Add($"(added {stateSaveCategory.Name}State variable)");
                     }
                 }
 

--- a/Gum/DataTypes/GumProjectSaveExtensionMethods.cs
+++ b/Gum/DataTypes/GumProjectSaveExtensionMethods.cs
@@ -48,10 +48,11 @@ namespace Gum.DataTypes
                     StateSave? effectiveDefaultState = FilterDefaultStateForProjectVersion(stateSave, gumProjectSave.Version);
                     // this will result in extra variables being
                     // added
-                    if (standardElementSave.Initialize(effectiveDefaultState))
+                    List<string>? standardElementAdded = modifications != null ? new List<string>() : null;
+                    if (standardElementSave.Initialize(effectiveDefaultState, modifications: standardElementAdded))
                     {
                         wasModified = true;
-                        modifications?.Add($"Standard:{standardElementSave.Name}");
+                        modifications?.Add($"Standard:{standardElementSave.Name}{FormatAddedVariables(standardElementAdded)}");
                     }
 
                     if(stateSave != null)
@@ -81,10 +82,11 @@ namespace Gum.DataTypes
             foreach (ScreenSave screenSave in gumProjectSave.Screens)
             {
                 var stateSave = StandardElementsManager.Self.GetDefaultStateFor("Screen");
-                if (screenSave.Initialize(stateSave, tolerateMissingDefaultStates))
+                List<string>? screenAdded = modifications != null ? new List<string>() : null;
+                if (screenSave.Initialize(stateSave, tolerateMissingDefaultStates, modifications: screenAdded))
                 {
                     wasModified = true;
-                    modifications?.Add($"Screen:{screenSave.Name}");
+                    modifications?.Add($"Screen:{screenSave.Name}{FormatAddedVariables(screenAdded)}");
                 }
             }
 

--- a/Gum/DataTypes/InstanceSaveExtensionMethods.cs
+++ b/Gum/DataTypes/InstanceSaveExtensionMethods.cs
@@ -39,7 +39,8 @@ namespace Gum.DataTypes
             return found;
         }
 
-        public static void Initialize(this InstanceSave instanceSave, ElementSave parent, ref bool wasModified, bool throwExceptionOnMissing = true)
+        public static void Initialize(this InstanceSave instanceSave, ElementSave parent, ref bool wasModified, bool throwExceptionOnMissing = true,
+            ICollection<string>? modifications = null)
         {
             var baseElementType = ObjectFinder.Self.GetRootStandardElementSave(instanceSave);
 
@@ -78,6 +79,7 @@ namespace Gum.DataTypes
                                             {
                                                 variable.Value = parsedBool;
                                                 wasModified = true;
+                                                modifications?.Add($"InstanceValueCoerce:{variable.Name}");
                                             }
                                             break;
                                         case "int":
@@ -85,6 +87,7 @@ namespace Gum.DataTypes
                                             {
                                                 variable.Value = parsedInt;
                                                 wasModified = true;
+                                                modifications?.Add($"InstanceValueCoerce:{variable.Name}");
                                             }
                                             break;
                                         case "float":
@@ -92,6 +95,7 @@ namespace Gum.DataTypes
                                             {
                                                 variable.Value = parsedFloat;
                                                 wasModified = true;
+                                                modifications?.Add($"InstanceValueCoerce:{variable.Name}");
                                             }
                                             break;
                                         case "double":
@@ -99,6 +103,7 @@ namespace Gum.DataTypes
                                             {
                                                 variable.Value = parsedDouble;
                                                 wasModified = true;
+                                                modifications?.Add($"InstanceValueCoerce:{variable.Name}");
                                             }
                                             break;
                                             // add more types here if needed

--- a/Gum/DataTypes/StateSaveExtensionMethods.cs
+++ b/Gum/DataTypes/StateSaveExtensionMethods.cs
@@ -18,9 +18,16 @@ namespace Gum.DataTypes.Variables;
 public static class StateSaveExtensionMethods
 {
     /// <summary>
-    /// Fixes enumeration values and sorts all variables alphabetically
+    /// Fixes enumeration values and sorts all variables alphabetically.
     /// </summary>
     /// <param name="stateSave">The state to initialize.</param>
+    /// <remarks>
+    /// <see cref="VariableSaveExtensionMethods.FixEnumerations"/> only coerces the in-memory
+    /// representation (int -&gt; enum) so reflection/property-grid code sees the right CLR type;
+    /// the persisted value is unchanged either way. That coercion must NOT count toward "this
+    /// project was modified and needs a re-save" — doing so would force a re-save on every load
+    /// of any project containing enum variables for no real content change.
+    /// </remarks>
     public static void Initialize(this StateSave stateSave)
     {
         foreach (VariableSave variable in stateSave.Variables)

--- a/Gum/Managers/StandardElementsManager.cs
+++ b/Gum/Managers/StandardElementsManager.cs
@@ -875,7 +875,7 @@ public class StandardElementsManager
         stateSave.Variables.Add(new VariableSave { SetsValue = true, Type = "bool", Value = false, Name = "IgnoredByParentSize", Category = "Parent" });
     }
 
-    public Func<string, StateSave> CustomGetDefaultState;
+    public Func<string, StateSave?>? CustomGetDefaultState;
 
     public StateSave? TryGetDefaultStateFor(string type, bool throwExceptionOnMissing = true)
     {

--- a/Runtimes/GumShapes/GueDeriving/AposShapeRuntime.cs
+++ b/Runtimes/GumShapes/GueDeriving/AposShapeRuntime.cs
@@ -127,7 +127,8 @@ public abstract class AposShapeRuntime : GraphicalUiElement
             () => new global::MonoGameGum.GueDeriving.RoundedRectangleRuntime());
 #pragma warning restore CS0618
 
-        StandardElementsManager.Self.CustomGetDefaultState += HandleCustomGetDefaultState;
+        StandardElementsManager.Self.CustomGetDefaultState =
+            CombineGetDefaultState(StandardElementsManager.Self.CustomGetDefaultState);
 
         CustomSetPropertyOnRenderable.AdditionalPropertyOnRenderable +=
             MonoGameGumShapes.CustomSetPropertyOnRenderable.SetPropertyOnRenderableFunc;
@@ -157,7 +158,7 @@ public abstract class AposShapeRuntime : GraphicalUiElement
         }
     }
 
-    private static StateSave HandleCustomGetDefaultState(string arg)
+    private static StateSave? HandleCustomGetDefaultState(string arg)
     {
         switch (arg)
         {
@@ -170,11 +171,32 @@ public abstract class AposShapeRuntime : GraphicalUiElement
             case "RoundedRectangle":
                 return StandardElementsManager.GetRoundedRectangleState();
 
-            // temp?
+            // Not a shape this runtime knows about - null lets CombineGetDefaultState fall back
+            // to whatever resolver was already registered (e.g. the Skia plugin, for
+            // Svg/LottieAnimation/Canvas) instead of guessing Container's default state.
             default:
-                return StandardElementsManager.Self.DefaultStates["Container"];
+                return null;
         }
     }
+
+    /// <summary>
+    /// Combines this runtime's own default-state resolution with <paramref name="existing"/>, so
+    /// registering this runtime's types never discards another resolver's answer for a type this
+    /// runtime doesn't recognize.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="StandardElementsManager.CustomGetDefaultState"/> is invoked with a single
+    /// <c>Invoke()</c> call, and a multicast delegate's <c>Invoke()</c> only returns its LAST
+    /// subscriber's result - every earlier subscriber still runs, but its return value is thrown
+    /// away. Chaining onto it with <c>+=</c> (as this runtime used to) silently discarded whatever
+    /// an earlier-registered resolver had already answered for any type this runtime doesn't
+    /// recognize. In the Gum tool process, where both this runtime (KniGumShapes) and the Skia
+    /// plugin register a resolver, that meant Svg/LottieAnimation/Canvas silently fell back to
+    /// Container's default state - injecting Container-only variables (e.g. IsRenderTarget) into
+    /// those standards' .gutx files on every project load.
+    /// </remarks>
+    internal static Func<string, StateSave?> CombineGetDefaultState(Func<string, StateSave?>? existing) =>
+        type => HandleCustomGetDefaultState(type) ?? existing?.Invoke(type);
 
     /// <summary>
     /// The underlying Apos.Shapes renderable that draws this shape. Derived runtime classes return

--- a/Tests/MonoGameGum.Shapes.Tests/AposShapeRuntimeDefaultStateTests.cs
+++ b/Tests/MonoGameGum.Shapes.Tests/AposShapeRuntimeDefaultStateTests.cs
@@ -1,0 +1,49 @@
+using System;
+using Gum.DataTypes;
+using Gum.DataTypes.Variables;
+using Gum.GueDeriving;
+using Gum.Managers;
+using Shouldly;
+
+namespace MonoGameGum.Shapes.Tests;
+
+// AposShapeRuntime.HandleCustomGetDefaultState used to fall back to Container's default state for
+// any type it didn't recognize (Svg, LottieAnimation, Canvas, ...), and it was chained onto
+// StandardElementsManager.CustomGetDefaultState via `+=` - a multicast Func whose Invoke() only
+// returns the LAST subscriber's result. In the Gum tool process, where both AposShapeRuntime
+// (KniGumShapes) and the Skia plugin register a resolver, this silently discarded the Skia
+// plugin's correct Svg/LottieAnimation/Canvas answer and injected Container-only variables (e.g.
+// IsRenderTarget) into those standards' .gutx files on every project load.
+public class AposShapeRuntimeDefaultStateTests
+{
+    [Fact]
+    public void CombineGetDefaultState_KnownShapeType_ResolvesOwnState()
+    {
+        var combined = AposShapeRuntime.CombineGetDefaultState(existing: null);
+
+        combined("Arc").ShouldBeSameAs(StandardElementsManager.GetArcState());
+    }
+
+    [Fact]
+    public void CombineGetDefaultState_UnknownType_NoExistingResolver_ReturnsNull()
+    {
+        var combined = AposShapeRuntime.CombineGetDefaultState(existing: null);
+
+        combined("LottieAnimation").ShouldBeNull(
+            "because AposShapeRuntime doesn't know about LottieAnimation and must not silently " +
+            "fall back to Container's default state for it.");
+    }
+
+    [Fact]
+    public void CombineGetDefaultState_UnknownType_FallsBackToExistingResolver()
+    {
+        StateSave sentinelLottieState = new() { Name = "SentinelLottieDefault" };
+        Func<string, StateSave?> existing = type => type == "LottieAnimation" ? sentinelLottieState : null;
+
+        var combined = AposShapeRuntime.CombineGetDefaultState(existing);
+
+        combined("LottieAnimation").ShouldBeSameAs(sentinelLottieState,
+            "because a previously-registered resolver's answer for a type AposShapeRuntime " +
+            "doesn't recognize must not be discarded.");
+    }
+}

--- a/Tool/Tests/GumToolUnitTests/DataTypes/ElementSaveExtensionMethodsTests.cs
+++ b/Tool/Tests/GumToolUnitTests/DataTypes/ElementSaveExtensionMethodsTests.cs
@@ -1,0 +1,46 @@
+using Gum.DataTypes;
+using Gum.DataTypes.Variables;
+using Shouldly;
+using Xunit;
+
+namespace GumToolUnitTests.DataTypes;
+
+public class ElementSaveExtensionMethodsTests : BaseTestClass
+{
+    public override void Dispose()
+    {
+        // CustomFixEnumerations is a static hook (normally wired up once via reflection in
+        // Program.cs) - reset it so this test's stub doesn't leak into other tests.
+        VariableSaveExtensionMethods.CustomFixEnumerations = null;
+        base.Dispose();
+    }
+
+    [Fact]
+    public void Initialize_VariableOnlyCoercedByFixEnumerations_ShouldNotMarkElementAsModified()
+    {
+        // FixEnumerations only coerces a variable's in-memory representation (int -> enum) so
+        // reflection/property-grid code sees the right CLR type; it never changes the persisted
+        // value. Simulate the tool's real coercion hook reporting "this value changed" to prove
+        // that alone does not mark the element (and therefore the project) as modified - doing so
+        // would force a re-save on every load of any project with enum variables, for no real
+        // content change.
+        VariableSaveExtensionMethods.CustomFixEnumerations = _ => true;
+
+        var component = new ComponentSave { Name = "EnumCoercionComponent", BaseType = "Container" };
+        var defaultState = new StateSave { Name = "Default", ParentContainer = component };
+        defaultState.Variables.Add(new VariableSave
+        {
+            Name = "SomeEnumVariable",
+            Type = "SomeEnumType",
+            Value = 0,
+            SetsValue = true
+        });
+        component.States.Add(defaultState);
+
+        var wasModified = component.Initialize(defaultState: null);
+
+        wasModified.ShouldBeFalse(
+            "because FixEnumerations coercing a variable's in-memory value must not, by itself, " +
+            "cause the element to be considered modified.");
+    }
+}


### PR DESCRIPTION
## Summary
- Svg/LottieAnimation/Canvas standards were silently getting Container-only variables (e.g. `IsRenderTarget`) injected into their `.gutx` files on every project load, with real downstream consequences for at least one game.
- Root cause: `AposShapeRuntime` chained onto `StandardElementsManager.CustomGetDefaultState` with `+=`, but `Invoke()` on a multicast `Func` only returns the LAST subscriber's result. Whenever Apos's module initializer registered after the Skia plugin's resolver (the normal case in the Gum tool process), every `GetDefaultStateFor` call - not just Arc/ColoredCircle/Line/RoundedRectangle - silently returned Apos's answer, and its `default:` case guessed Container's state for anything it didn't recognize.
- Fix: the `default:` case now returns `null`, and registration composes with whatever resolver was already present (first non-null answer wins) instead of discarding it.
- Second commit folds in the "why was this modified" tracking that was the diagnostic groundwork for finding this bug: `GumProjectSave.Initialize`'s re-save-on-load logic now reports which specific variable triggered a backfill (not just which top-level element), which is what made `IsRenderTarget` visible as the culprit in the first place. `FixEnumerations` is deliberately excluded from this tracking since it only coerces the in-memory int->enum representation and never changes the persisted value.

## Test plan
- [x] New unit tests in `AposShapeRuntimeDefaultStateTests.cs` (red before the fix - compile error - green after) pin: known Apos types still resolve; an unrecognized type with nothing else registered returns `null` (not Container); an unrecognized type falls through to a previously-registered resolver instead of clobbering it.
- [x] New unit test in `ElementSaveExtensionMethodsTests.cs` pins that `FixEnumerations` coercion alone does not mark an element as modified.
- [x] Full `GumFull.sln` build: 0 errors, no new warnings.
- [x] `MonoGameGum.Shapes.Tests` (222/222), `MonoGameGum.Tests` (1792/1792), `MonoGameGum.Tests.V2` (120/120), `GumToolUnitTests` (1048/1052, 4 pre-existing skips), `Gum.ProjectServices.SkiaGum.Tests` (12/12) - all green.
- [x] Manual test: confirmed by the reporter that Svg/LottieAnimation standards no longer get `IsRenderTarget` injected on project load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
