### PR TITLE
Document Raylib code generation support (Output Library + codegen-init auto-detect)

### DIFF
--- a/docs/cli/codegen-init.md
+++ b/docs/cli/codegen-init.md
@@ -20,7 +20,11 @@ Most projects do not need to run `codegen-init` explicitly. The `codegen` comman
 - Walks up from the `.gumx` directory to find the nearest `.csproj`
 - Derives `CodeProjectRoot` as a relative path from the `.gumx` directory to the `.csproj` directory
 - Extracts `RootNamespace` from the `.csproj`, falling back to the `.csproj` filename (with `.`, `-`, and spaces replaced by `_`)
-- Detects MonoGame or KNI package references and sets the output library accordingly
+- Detects MonoGame or KNI package references and sets the output library accordingly. A `Raylib-cs` package reference sets `OutputLibrary` to `Raylib`.
+
+{% hint style="info" %}
+`Raylib-cs` detection is available in the Gum July 2026 release and newer.
+{% endhint %}
 
 ## Examples
 

--- a/docs/gum-tool/code-tab/README.md
+++ b/docs/gum-tool/code-tab/README.md
@@ -79,6 +79,11 @@ Select the desired Output Library, such as **MonoGame + Forms**. This should mat
 * **MonoGame + Forms** is the recommended code generation if your project is using MonoGame. This code generation generates code with classes containing properties which inherit from FrameworkElement such as Button and Textbox wherever possible. If a non-forms instance (such as a Sprite or Text instance) is added to a screen or component, then code will _fall back_ to generating non-forms properties (such as SpriteRuntime or TextRuntime).
 * **MonoGame (no forms, deprecated)** generates code without creating forms controls. Use this if your game does not use Forms, or if your game predates Forms support in MonoGame.
 * **SkiaSharp** generates code for runtimes which use SkiaSharp for graphics, such as WPF, .NET Maui, and Silk.NET
+* **Raylib** generates code for projects using the Raylib runtime. Raylib code generation currently supports only the **Reference Loaded Gum Project** instantiation type (see below); the **Fully in Code** type is not yet supported and Gum displays a warning if you select it.
+
+{% hint style="info" %}
+The **Raylib** Output Library is available in the Gum July 2026 release and newer.
+{% endhint %}
 
 Additional libraries may be added in the future. If your project needs support for code generation and you are using a library that is not supported, please contact the Gum team on Discord or GitHub.
 


### PR DESCRIPTION
Documents Raylib code generation support that shipped via #3430/#3431 but was missing from user-facing docs.

## Changes
- `docs/gum-tool/code-tab/README.md` — added a **Raylib** bullet to the Output Library section, noting it only supports the **Reference Loaded Gum Project** (`FindByName`) instantiation type; **Fully in Code** is not yet supported and warns if selected.
- `docs/cli/codegen-init.md` — noted that a `Raylib-cs` package reference sets `OutputLibrary` to `Raylib` in the "What It Detects" section.

Both additions are gated to the **July 2026 release and newer** via `{% hint %}` blocks, per the docs date-gating convention.

Docs-only change; no build or tests.

Closes #3433

🤖 Generated with [Claude Code](https://claude.com/claude-code)
