### PR TITLE
Fix premultiplied-alpha double-blend for MonoGame render-target containers

### DIFF
--- a/RenderingLibrary/Graphics/Renderer.cs
+++ b/RenderingLibrary/Graphics/Renderer.cs
@@ -258,6 +258,22 @@ public class Renderer : IRenderer
         set;
     } = BlendState.NonPremultiplied;
 
+    // Used only while baking a render target's children over a transparent clear
+    // (RenderToRenderTarget). Color still premultiplies via (SourceAlpha, InverseSourceAlpha),
+    // same as NonPremultiplied — but Alpha uses (One, InverseSourceAlpha) instead of
+    // NonPremultiplied's (SourceAlpha, InverseSourceAlpha). The latter squares alpha when the
+    // destination starts fully transparent (result = srcAlpha*srcAlpha instead of srcAlpha),
+    // corrupting the baked texture's alpha channel — e.g. a 50%-alpha child bakes to 25% alpha
+    // instead of 50%. This is the standard "premultiply on bake" blend used industry-wide when
+    // rendering straight-alpha content onto a transparent render target (#1696).
+    private static readonly BlendState _bakeToRenderTargetBlendState = new BlendState
+    {
+        ColorSourceBlend = Gum.Blend.SourceAlpha,
+        ColorDestinationBlend = Gum.Blend.InverseSourceAlpha,
+        AlphaSourceBlend = Gum.Blend.One,
+        AlphaDestinationBlend = Gum.Blend.InverseSourceAlpha,
+    };
+
     public bool IsUsingPremultipliedAlpha
     {
         get; set;
@@ -849,6 +865,12 @@ public class Renderer : IRenderer
 
     bool hasSaved = false;
 
+    // True only while RenderToRenderTarget's nested Draw call is baking a subtree over a
+    // transparent clear. Tells AdjustRenderStates/AdjustNonClipRenderStates to substitute
+    // _bakeToRenderTargetBlendState wherever a renderable would otherwise resolve to
+    // NormalBlendState (#1696).
+    bool _isBakingRenderTarget = false;
+
     private void RenderToRenderTarget(IRenderableIpso renderable, SystemManagers systemManagers)
     {
 
@@ -927,7 +949,14 @@ public class Renderer : IRenderer
 
             //gumBatch.Draw(renderable);
             //systemManagers.Renderer.Draw(renderable);
+            // Children with the default (unconfigured) blend would otherwise resolve to
+            // NormalBlendState, whose alpha factors square alpha over the transparent clear
+            // above. _isBakingRenderTarget tells AdjustRenderStates/AdjustNonClipRenderStates to
+            // substitute the bake-safe blend for that case instead (#1696). A child with an
+            // explicitly custom BlendState is unaffected, same as the composite-back override.
+            _isBakingRenderTarget = true;
             Draw(systemManagers, _layers[0], renderable, forceRenderHierarchy:true, isPreRender:true);
+            _isBakingRenderTarget = false;
 
             gumBatch.End();
             GraphicsDevice.SetRenderTarget(oldRenderTarget as RenderTarget2D);
@@ -1075,7 +1104,12 @@ public class Renderer : IRenderer
         renderableAlpha = System.Math.Min(255, renderableAlpha);
         renderableAlpha = System.Math.Max(0, renderableAlpha);
 
-        var color = System.Drawing.Color.FromArgb(renderableAlpha, Color.White);
+        // RenderToRenderTarget always bakes children over a transparent clear, so the target's
+        // contents are premultiplied regardless of Renderer.NormalBlendState. A straight-white
+        // tint would re-lighten group alpha on top of that, so the tint must be premultiplied too
+        // (#1696) — otherwise group alpha renders too light relative to the same content drawn
+        // directly.
+        var color = System.Drawing.Color.FromArgb(renderableAlpha, renderableAlpha, renderableAlpha, renderableAlpha);
 
         renderTargetRenderableSprite.X = System.Math.Max(renderable.GetAbsoluteX(), Camera.AbsoluteLeft);
         renderTargetRenderableSprite.Y = System.Math.Max(renderable.GetAbsoluteY(), Camera.AbsoluteTop);
@@ -1091,22 +1125,41 @@ public class Renderer : IRenderer
             ?? ((renderable as Gum.Wireframe.GraphicalUiElement)?.RenderableComponent as IRenderTargetRenderable))
             ?.RenderTargetEffect as Effect;
 
-        if (renderTargetEffect == null)
+        // The blit must composite with a premultiplied blend since the target's contents are
+        // premultiplied by construction (see the `color` comment above). Only override the
+        // container's own default (unconfigured) blend — a container with an explicitly-configured
+        // custom BlendState (e.g. Additive) is left alone; making that combination correct against
+        // premultiplied content is that container's own concern, not this composite step's (#1696).
+        // A nested render target composites into its parent's bake while _isBakingRenderTarget is
+        // still true for that outer bake, so an unconfigured nested container's ambient blend has
+        // already been substituted to _bakeToRenderTargetBlendState by AdjustRenderStates — treat
+        // that the same as NormalBlendState here.
+        bool needsPremultipliedBlend = mRenderStateVariables.BlendState == Renderer.NormalBlendState
+            || mRenderStateVariables.BlendState == _bakeToRenderTargetBlendState;
+
+        if (renderTargetEffect == null && !needsPremultipliedBlend)
         {
             Sprite.Render(managers, spriteRenderer, renderTargetRenderableSprite, renderTarget, color, rotationInDegrees: renderable.Rotation, objectCausingRendering: renderable);
         }
         else
         {
-            // Bind the container's post-process shader for just this blit. Flush whatever batch
-            // is open (sprites or a custom Apos.Shapes batch) so prior draws paint first, re-begin
-            // the SpriteBatch with the effect overridden, draw the target, then re-begin with the
-            // normal effect so following renderables are unaffected. Mirrors the mid-walk
-            // clip-change flush in Draw/AdjustRenderStates.
+            // Bind the container's post-process shader and/or force a premultiplied blend for just
+            // this blit. Flush whatever batch is open (sprites or a custom Apos.Shapes batch) so
+            // prior draws paint first, re-begin the SpriteBatch with the override(s), draw the
+            // target, then re-begin with the normal state so following renderables are unaffected.
+            // Mirrors the mid-walk clip-change flush in Draw/AdjustRenderStates.
             _batchOrchestrator.FlushAndReset(managers);
+
+            var previousBlendState = mRenderStateVariables.BlendState;
+            if (needsPremultipliedBlend)
+            {
+                mRenderStateVariables.BlendState = BlendState.AlphaBlend;
+            }
 
             spriteRenderer.BeginSpriteBatch(mRenderStateVariables, layer, BeginType.Begin, mCamera, renderable, effectOverride: renderTargetEffect);
             Sprite.Render(managers, spriteRenderer, renderTargetRenderableSprite, renderTarget, color, rotationInDegrees: renderable.Rotation, objectCausingRendering: renderable);
 
+            mRenderStateVariables.BlendState = previousBlendState;
             spriteRenderer.BeginSpriteBatch(mRenderStateVariables, layer, BeginType.Begin, mCamera, renderable);
         }
     }
@@ -1178,6 +1231,10 @@ public class Renderer : IRenderer
     private void AdjustNonClipRenderStates(RenderStateVariables renderState, Layer layer, IRenderableIpso renderable, SystemManagers managers)
     {
         BlendState renderBlendState = renderable.BlendState ?? Renderer.NormalBlendState;
+        if (_isBakingRenderTarget && renderBlendState == Renderer.NormalBlendState)
+        {
+            renderBlendState = _bakeToRenderTargetBlendState;
+        }
         bool wrap = renderable.Wrap;
         bool shouldResetStates = false;
 
@@ -1215,6 +1272,10 @@ public class Renderer : IRenderer
         if (renderBlendState == null)
         {
             renderBlendState = Renderer.NormalBlendState;
+        }
+        if (_isBakingRenderTarget && renderBlendState == Renderer.NormalBlendState)
+        {
+            renderBlendState = _bakeToRenderTargetBlendState;
         }
         if (renderState.BlendState != renderBlendState)
         {

--- a/Tests/MonoGameGum.IntegrationTests/MonoGameGum/Rendering/RenderTargetAlphaCompositeTests.cs
+++ b/Tests/MonoGameGum.IntegrationTests/MonoGameGum/Rendering/RenderTargetAlphaCompositeTests.cs
@@ -1,0 +1,193 @@
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using Gum.GueDeriving;
+using RenderingLibrary;
+using RenderingLibrary.Content;
+using RenderingLibrary.Graphics;
+using Shouldly;
+using Xunit;
+
+namespace MonoGameGum.IntegrationTests.MonoGameGum.Rendering;
+
+/// <summary>
+/// Pins the premultiplied-alpha composite fix for <see cref="ContainerRuntime.IsRenderTarget"/>
+/// containers (issue #1696). <see cref="Renderer.RenderToRenderTarget"/> always bakes a render
+/// target's children over a transparent clear, which yields premultiplied contents regardless of
+/// <see cref="Renderer.NormalBlendState"/>. The composite-back blit in
+/// <see cref="Renderer.DrawRenderTargetToScreen"/> must therefore (1) blend with
+/// <c>BlendState.AlphaBlend</c> instead of the container's default (non-premultiplied) blend, and
+/// (2) tint with a premultiplied alpha color, or the result darkens (wrong blend) and/or
+/// re-lightens under group alpha (wrong tint) relative to the same content drawn directly.
+/// </summary>
+public class RenderTargetAlphaCompositeTests : BaseTestClass
+{
+    // Mirrors RaylibGum.Tests' Draw_SemiTransparentElement_InsideRenderTargetMatchesDirectDraw.
+    // Container.Alpha stays at its default (255) here, so the tint is (255,255,255,255) either
+    // way — this isolates the blend-state half of the fix from the tint half.
+    [Fact]
+    public void SemiTransparentElement_InsideRenderTarget_MatchesDirectDraw()
+    {
+        using MinimalGame game = new();
+        game.RunOneFrame();
+
+        GraphicsDevice gd = game.GraphicsDevice;
+        SystemManagers managers = SystemManagers.Default;
+        Renderer renderer = managers.Renderer;
+
+        Color frameColor = new Color((byte)70, (byte)70, (byte)90, (byte)255);
+        Color semiTransparentWhite = new Color((byte)255, (byte)255, (byte)255, (byte)128);
+
+        ContainerRuntime directRoot = new();
+        directRoot.X = 0;
+        directRoot.Y = 0;
+        directRoot.Width = 100;
+        directRoot.Height = 100;
+#pragma warning disable CS0618 // ColoredRectangleRuntime is obsolete; simplest solid fill without the shape dependency.
+        directRoot.AddChild(new ColoredRectangleRuntime { Width = 100, Height = 100, Color = frameColor });
+        directRoot.AddChild(new ColoredRectangleRuntime { Width = 100, Height = 100, Color = semiTransparentWhite });
+#pragma warning restore CS0618
+        directRoot.AddToManagers(managers, null);
+        directRoot.UpdateLayout();
+
+        Color direct = RenderToCaptureAndSample(gd, renderer, managers, 100, 100, 50, 50);
+
+        directRoot.RemoveFromManagers();
+
+        ContainerRuntime rtRoot = new();
+        rtRoot.X = 0;
+        rtRoot.Y = 0;
+        rtRoot.Width = 100;
+        rtRoot.Height = 100;
+#pragma warning disable CS0618
+        rtRoot.AddChild(new ColoredRectangleRuntime { Width = 100, Height = 100, Color = frameColor });
+#pragma warning restore CS0618
+
+        ContainerRuntime inner = new();
+        inner.Width = 100;
+        inner.Height = 100;
+        inner.IsRenderTarget = true;
+#pragma warning disable CS0618
+        inner.AddChild(new ColoredRectangleRuntime { Width = 100, Height = 100, Color = semiTransparentWhite });
+#pragma warning restore CS0618
+        rtRoot.AddChild(inner);
+
+        rtRoot.AddToManagers(managers, null);
+        rtRoot.UpdateLayout();
+
+        Color viaRenderTarget = RenderToCaptureAndSample(gd, renderer, managers, 100, 100, 50, 50);
+
+        rtRoot.RemoveFromManagers();
+
+        // Only RGB is compared: the outer capture texture's own alpha channel accumulates
+        // differently for the two scenes (the direct scene draws two overlapping semi-transparent
+        // layers into the capture; the RT scene draws one opaque layer plus one fully-covering
+        // composited blit), which is an artifact of the readback capture technique, not a
+        // difference a user would ever see on screen (there is no further compositing after the
+        // real backbuffer).
+        const int tolerance = 4;
+        System.Math.Abs(viaRenderTarget.R - direct.R).ShouldBeLessThanOrEqualTo(tolerance);
+        System.Math.Abs(viaRenderTarget.G - direct.G).ShouldBeLessThanOrEqualTo(tolerance);
+        System.Math.Abs(viaRenderTarget.B - direct.B).ShouldBeLessThanOrEqualTo(tolerance);
+    }
+
+    // Worked example from the issue: a 50%-alpha white child inside a render-target container
+    // whose group Alpha is also reduced to 50%. Isolates the tint half of the fix — reverting
+    // just the blend fix or just the tint fix each land far outside tolerance of the correct
+    // ~116, so this single assertion requires both halves of the fix together.
+    [Fact]
+    public void ReducedGroupAlpha_OnRenderTarget_CompositesToPremultipliedExpectedValue()
+    {
+        using MinimalGame game = new();
+        game.RunOneFrame();
+
+        GraphicsDevice gd = game.GraphicsDevice;
+        SystemManagers managers = SystemManagers.Default;
+        Renderer renderer = managers.Renderer;
+
+        Color frameColor = new Color((byte)70, (byte)70, (byte)90, (byte)255);
+        Color semiTransparentWhite = new Color((byte)255, (byte)255, (byte)255, (byte)128);
+
+        ContainerRuntime root = new();
+        root.X = 0;
+        root.Y = 0;
+        root.Width = 100;
+        root.Height = 100;
+#pragma warning disable CS0618
+        root.AddChild(new ColoredRectangleRuntime { Width = 100, Height = 100, Color = frameColor });
+#pragma warning restore CS0618
+
+        ContainerRuntime inner = new();
+        inner.Width = 100;
+        inner.Height = 100;
+        inner.IsRenderTarget = true;
+        inner.Alpha = 128;
+#pragma warning disable CS0618
+        inner.AddChild(new ColoredRectangleRuntime { Width = 100, Height = 100, Color = semiTransparentWhite });
+#pragma warning restore CS0618
+        root.AddChild(inner);
+
+        root.AddToManagers(managers, null);
+        root.UpdateLayout();
+
+        Color composited = RenderToCaptureAndSample(gd, renderer, managers, 100, 100, 50, 50);
+
+        root.RemoveFromManagers();
+
+        const int expected = 117;
+        const int tolerance = 6;
+        System.Math.Abs(composited.R - expected).ShouldBeLessThanOrEqualTo(tolerance);
+    }
+
+    private static Color RenderToCaptureAndSample(GraphicsDevice gd, Renderer renderer, SystemManagers managers, int w, int h, int sx, int sy)
+    {
+        using RenderTarget2D capture = new(gd, w, h, false, SurfaceFormat.Color, DepthFormat.None, 0,
+            RenderTargetUsage.PreserveContents);
+
+        for (int i = 0; i < 2; i++)
+        {
+            gd.SetRenderTarget(capture);
+            gd.Clear(Color.Black);
+            renderer.Draw(managers);
+        }
+        gd.SetRenderTarget(null);
+
+        Color[] data = new Color[w * h];
+        capture.GetData(data);
+
+        return data[(sy * w) + sx];
+    }
+
+    /// <summary>
+    /// Minimal Game host that initializes a fresh <see cref="GumService"/> per test so
+    /// <see cref="Renderer.Draw(SystemManagers)"/> can be invoked against a live device.
+    /// </summary>
+    private class MinimalGame : Game
+    {
+        private readonly GraphicsDeviceManager _graphics;
+
+        public MinimalGame()
+        {
+            LoaderManager.Self?.DisposeAndClear();
+            _graphics = new GraphicsDeviceManager(this);
+        }
+
+        protected override void Initialize()
+        {
+            base.Initialize();
+            Gum.GumService.Default.Initialize(this, Gum.Forms.DefaultVisualsVersion.V2);
+        }
+
+        protected override void Update(GameTime gameTime) { }
+        protected override void Draw(GameTime gameTime) => GraphicsDevice.Clear(Color.CornflowerBlue);
+
+        protected override void Dispose(bool disposing)
+        {
+            if (Gum.GumService.Default.IsInitialized)
+            {
+                Gum.GumService.Default.Uninitialize();
+            }
+            LoaderManager.Self?.DisposeAndClear();
+            base.Dispose(disposing);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- `RenderToRenderTarget`'s bake now substitutes a premultiplied-safe blend for a container's default (unconfigured) blend, so a child's alpha channel doesn't get squared over the transparent clear (a 50%-alpha child was baking to 25% alpha).
- `DrawRenderTargetToScreen`'s composite-back blit now forces a premultiplied blend and a premultiplied tint for a container's default blend, instead of double-applying alpha on top of the already-premultiplied baked texture.
- A container with an explicitly custom `BlendState` (e.g. Additive) is left untouched in both places — this stays scoped to the default/unconfigured case, matching the issue's own "targeted to the RT blit" framing.

Both changes were required: fixing only the composite-back blit (the issue's own suggested fix) still left semi-transparent content ~7% off from a direct draw, because the bake itself was independently corrupting the alpha channel. This second bug wasn't called out in the issue text; it surfaced during TDD when the composite-only fix didn't converge on a tight tolerance against a direct-draw reference.

## Test plan
- [x] New pixel-readback tests in `Tests/MonoGameGum.IntegrationTests/MonoGameGum/Rendering/RenderTargetAlphaCompositeTests.cs`, run against a real GraphicsDevice:
  - `SemiTransparentElement_InsideRenderTarget_MatchesDirectDraw` — a semi-transparent rect inside an `IsRenderTarget` container now matches the same rect drawn directly (both failed red before the fix: 78/255 delta).
  - `ReducedGroupAlpha_OnRenderTarget_CompositesToPremultipliedExpectedValue` — pins the worked example from the issue (50%-alpha child at 50% group alpha composites to ~117, not ~84 or ~180).
- [x] Full `Tests/MonoGameGum.IntegrationTests` suite green (55/55), including the existing `RenderTargetEffectTests` Grayscale.fx post-process regression coverage the issue flagged.
- [x] Full `MonoGameGum.Tests` suite green (1803/1803).
- [x] `KniGum` builds clean (shared `RenderingLibrary/Graphics/Renderer.cs` compiles under the same XNALIKE family).
- [x] Manual visual check: a semi-transparent white rect over a colored frame, drawn directly vs. inside an `IsRenderTarget` container, side by side in a MonoGame scratch project — now visually identical (previously the RT side was visibly darker).

Closes #1696