### PR TITLE
Add runtime allocation-measurement harness + layout zero-alloc guards

### DIFF
--- a/MonoGameGum.Tests/Performance/AllocationMeasurerTests.cs
+++ b/MonoGameGum.Tests/Performance/AllocationMeasurerTests.cs
@@ -1,0 +1,38 @@
+using MonoGameGum.TestsCommon;
+using Shouldly;
+using System;
+using Xunit;
+
+namespace MonoGameGum.Tests.Performance;
+
+/// <summary>
+/// Self-tests for <see cref="AllocationMeasurer"/> — proves the measurement mechanism itself
+/// reports zero for a no-op and tracks a known allocation, so the runtime allocation scenarios
+/// that depend on it can be trusted.
+/// </summary>
+public class AllocationMeasurerTests
+{
+    [Fact]
+    public void Measure_KnownAllocation_ReportsAtLeastAllocatedSize()
+    {
+        const int arraySize = 10_000;
+
+        AllocationResult result = AllocationMeasurer.Measure(
+            () => GC.KeepAlive(new byte[arraySize]),
+            warmupIterations: 10,
+            measuredIterations: 100);
+
+        result.BytesPerIteration.ShouldBeGreaterThanOrEqualTo(arraySize);
+    }
+
+    [Fact]
+    public void Measure_NoOpAction_ReportsZeroAllocations()
+    {
+        AllocationResult result = AllocationMeasurer.Measure(
+            () => { },
+            warmupIterations: 10,
+            measuredIterations: 1000);
+
+        result.TotalBytes.ShouldBe(0);
+    }
+}

--- a/MonoGameGum.Tests/Performance/LayoutAllocationTests.cs
+++ b/MonoGameGum.Tests/Performance/LayoutAllocationTests.cs
@@ -1,0 +1,126 @@
+using Gum.DataTypes;
+using Gum.GueDeriving;
+using Gum.Managers;
+using Gum.Wireframe;
+using MonoGameGum.TestsCommon;
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace MonoGameGum.Tests.Performance;
+
+/// <summary>
+/// Per-frame allocation baselines and regression guards for the layout engine
+/// (<see cref="Gum.Wireframe.GraphicalUiElement.UpdateLayout()"/>). Part of the runtime
+/// allocation pass, issue #1934: the target is zero managed bytes allocated per steady-state
+/// layout pass; each guard ratchets down as allocation sources are removed.
+/// </summary>
+public class LayoutAllocationTests : BaseTestClass
+{
+    private readonly ITestOutputHelper _output;
+
+    public LayoutAllocationTests(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    /// <summary>
+    /// Builds a content-sized vertical stack of <paramref name="itemCount"/> items, each with a
+    /// nested child, and runs one layout pass so it starts in a laid-out state. This exercises the
+    /// content-measuring recursion (RelativeToChildren height, parent-relative width, stacking)
+    /// that dominates the scroll/layout scenario. Returns the stack and its first item so callers
+    /// can mutate a child to trigger a realistic relayout.
+    /// </summary>
+    private static (ContainerRuntime Stack, ContainerRuntime FirstItem) BuildContentSizedStack(int itemCount)
+    {
+        ContainerRuntime stack = new();
+        stack.ChildrenLayout = ChildrenLayout.TopToBottomStack;
+        stack.Width = 200;
+        stack.WidthUnits = DimensionUnitType.Absolute;
+        stack.Height = 0;
+        stack.HeightUnits = DimensionUnitType.RelativeToChildren;
+
+        ContainerRuntime firstItem = null!;
+
+        for (int i = 0; i < itemCount; i++)
+        {
+            ContainerRuntime item = new();
+            item.Width = 0;
+            item.WidthUnits = DimensionUnitType.RelativeToParent;
+            item.Height = 30;
+            item.HeightUnits = DimensionUnitType.Absolute;
+            stack.AddChild(item);
+
+            ContainerRuntime inner = new();
+            inner.Width = 0;
+            inner.WidthUnits = DimensionUnitType.RelativeToParent;
+            inner.Height = 20;
+            inner.HeightUnits = DimensionUnitType.Absolute;
+            item.AddChild(inner);
+
+            if (i == 0)
+            {
+                firstItem = item;
+            }
+        }
+
+        stack.UpdateLayout();
+        return (stack, firstItem);
+    }
+
+    [Fact]
+    public void PropertyChange_TriggeringRelayout_IsZeroAllocation()
+    {
+        const int itemCount = 20;
+
+        (ContainerRuntime stack, ContainerRuntime firstItem) = BuildContentSizedStack(itemCount);
+
+        // Alternate the first item's height every frame so the change is real (the setter re-lays-out
+        // and, because the stack is content-sized, propagates up to re-measure and re-stack siblings).
+        float height = 30;
+        const int measuredIterations = 500;
+
+        int layoutCallsBefore = GraphicalUiElement.UpdateLayoutCallCount;
+
+        AllocationResult result = AllocationMeasurer.Measure(
+            () =>
+            {
+                height = height == 30 ? 31 : 30;
+                firstItem.Height = height;
+            },
+            warmupIterations: 50,
+            measuredIterations: measuredIterations);
+
+        int layoutCalls = GraphicalUiElement.UpdateLayoutCallCount - layoutCallsBefore;
+
+        _output.WriteLine($"Height change on the first item of a {itemCount}-item content-sized stack: " +
+            $"{result.BytesPerIteration:N0} bytes/frame ({result.TotalBytes:N0} bytes over {result.Iterations} frames)");
+
+        // Liveness: prove the scenario actually drove relayout each frame (guards against a silent
+        // no-op setter making the zero-allocation result meaningless).
+        layoutCalls.ShouldBeGreaterThanOrEqualTo(measuredIterations);
+        // A property change that re-lays-out and propagates up a content-sized stack allocates
+        // nothing in steady state; this guards against a regression reintroducing allocations (#1934).
+        result.TotalBytes.ShouldBe(0);
+    }
+
+    [Fact]
+    public void UpdateLayout_ContentSizedStack_IsZeroAllocation()
+    {
+        const int itemCount = 20;
+
+        (ContainerRuntime stack, _) = BuildContentSizedStack(itemCount);
+
+        AllocationResult result = AllocationMeasurer.Measure(
+            () => stack.UpdateLayout(),
+            warmupIterations: 50,
+            measuredIterations: 500);
+
+        _output.WriteLine($"UpdateLayout on a {itemCount}-item content-sized stack: " +
+            $"{result.BytesPerIteration:N0} bytes/frame ({result.TotalBytes:N0} bytes over {result.Iterations} frames)");
+
+        // A steady-state layout pass over a container-only tree allocates nothing; this guards
+        // against a regression (e.g. a new LINQ call or per-pass list) reintroducing allocations.
+        result.TotalBytes.ShouldBe(0);
+    }
+}

--- a/Tests/MonoGameGum.TestsCommon/AllocationMeasurer.cs
+++ b/Tests/MonoGameGum.TestsCommon/AllocationMeasurer.cs
@@ -1,0 +1,78 @@
+namespace MonoGameGum.TestsCommon;
+
+/// <summary>
+/// Measures managed heap allocations produced by an operation, for use in runtime allocation
+/// regression tests (issue #1934). Wraps <see cref="System.GC.GetAllocatedBytesForCurrentThread"/>
+/// with a warmup phase so JIT, tiered compilation, and first-run lazy initialization do not
+/// pollute the measured window.
+/// </summary>
+/// <remarks>
+/// The measured operation MUST run synchronously on the calling thread. The underlying counter is
+/// per-thread, so any <c>await</c> that resumes on a different thread makes the delta meaningless.
+/// Because the counter tracks cumulative allocation (not live-heap size), a garbage collection
+/// occurring inside the measured window does not affect the result.
+/// </remarks>
+public static class AllocationMeasurer
+{
+    /// <summary>
+    /// Runs <paramref name="action"/> for a warmup phase, then measures the total managed bytes
+    /// allocated on the current thread across <paramref name="measuredIterations"/> runs.
+    /// </summary>
+    /// <param name="action">The operation to measure. Must be synchronous and single-threaded.</param>
+    /// <param name="warmupIterations">Runs performed before measuring, to settle JIT and lazy init.</param>
+    /// <param name="measuredIterations">Runs performed inside the measured window.</param>
+    /// <returns>The allocation result, including total bytes and bytes per iteration.</returns>
+    public static AllocationResult Measure(Action action, int warmupIterations = 100, int measuredIterations = 1000)
+    {
+        if (action == null)
+        {
+            throw new ArgumentNullException(nameof(action));
+        }
+        if (warmupIterations < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(warmupIterations), "Warmup iterations cannot be negative.");
+        }
+        if (measuredIterations < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(measuredIterations), "Must run at least one measured iteration.");
+        }
+
+        for (int i = 0; i < warmupIterations; i++)
+        {
+            action();
+        }
+
+        long before = GC.GetAllocatedBytesForCurrentThread();
+        for (int i = 0; i < measuredIterations; i++)
+        {
+            action();
+        }
+        long after = GC.GetAllocatedBytesForCurrentThread();
+
+        return new AllocationResult(after - before, measuredIterations);
+    }
+}
+
+/// <summary>
+/// The outcome of an <see cref="AllocationMeasurer.Measure"/> call.
+/// </summary>
+public readonly struct AllocationResult
+{
+    /// <summary>Total managed bytes allocated across all measured iterations.</summary>
+    public long TotalBytes { get; }
+
+    /// <summary>Number of iterations run inside the measured window.</summary>
+    public int Iterations { get; }
+
+    /// <summary>Average managed bytes allocated per iteration (one "frame" of the measured operation).</summary>
+    public double BytesPerIteration => (double)TotalBytes / Iterations;
+
+    /// <summary>Initializes a new <see cref="AllocationResult"/>.</summary>
+    /// <param name="totalBytes">Total managed bytes allocated across all measured iterations.</param>
+    /// <param name="iterations">Number of iterations run inside the measured window.</param>
+    public AllocationResult(long totalBytes, int iterations)
+    {
+        TotalBytes = totalBytes;
+        Iterations = iterations;
+    }
+}


### PR DESCRIPTION
Part of #1934. **This PR intentionally does not close the issue** — it lands the measurement infrastructure and the first guards; binding / Text / Draw scenarios are follow-ups.

## What this adds

Runtime allocation-measurement infrastructure so we can measure and regression-guard per-frame managed heap allocations (the goal of #1934: zero allocations in steady-state loops).

- **`AllocationMeasurer`** (`Tests/MonoGameGum.TestsCommon/`) — wraps `GC.GetAllocatedBytesForCurrentThread()` with a warmup phase and returns `AllocationResult { TotalBytes, BytesPerIteration }`. Lives in the shared test lib so headless *and* GPU (`IntegrationTests`) scenarios can reuse it.
- **Self-tests** — prove the mechanism reports exactly `0` for a no-op and `>=` the allocated size for a known `byte[10_000]`, so its numbers can be trusted.
- **Two layout scenarios** with zero-allocation regression guards.

## Finding

The layout engine's steady-state relayout of a container-only tree already allocates **nothing**:

| Scenario (20-item content-sized stack) | bytes/frame |
|---|---|
| Forced `UpdateLayout()` full relayout | **0** |
| Property change (`Height`) → relayout + upward propagation | **0** |

The property-change test carries a liveness guard (`UpdateLayoutCallCount` delta ≥ 500) so the zero is proven to be a real relayout, not a no-op false negative. The LINQ sites in `GraphicalUiElement` are therefore in cold paths (add/remove child, first-time property assignment), not the relayout hot loop.

**Scope:** container-only trees. Text (font/string realization), Forms controls, data-binding (`INotifyPropertyChanged`), and the per-frame **Draw** walk (the "idle" scenario, needs the GPU harness) are not yet measured — those are the next scenarios and the likelier allocation sources.

## Testing

`dotnet test MonoGameGum.Tests --filter "FullyQualifiedName~MonoGameGum.Tests.Performance"` → 4/4 green. Test/infra only — no production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
