### PR TITLE
Runtime allocation pass (#1934): idle Draw-walk zero-alloc + SpriteBatchStack NET8+ leak fix

### DIFF
--- a/RenderingLibrary/Graphics/Renderer.cs
+++ b/RenderingLibrary/Graphics/Renderer.cs
@@ -1215,6 +1215,13 @@ public class Renderer : IRenderer
         }
     }
 
+    // Diagnostic label for the clip-exit BeginSpriteBatch. A shared constant instead of a per-frame
+    // interpolation ($"Un-set {renderable} Clip") — the latter allocated a fresh string every clip
+    // exit, one of the idle Draw allocation sources (#1934). DrawStateSummary.FromDrawStates only
+    // checks that ObjectChangingState is a string (not its content) to bucket a begin as a clip exit,
+    // so a constant preserves that categorization exactly.
+    private const string ClipExitStateLabel = "Un-set Clip";
+
     private void EndClipScope(Layer layer, IRenderableIpso renderable, SystemManagers managers)
     {
         var previousClip = _clipScopeStack.Pop();
@@ -1224,7 +1231,7 @@ public class Renderer : IRenderer
 
             _batchOrchestrator.FlushAndReset(managers);
 
-            spriteRenderer.BeginSpriteBatch(mRenderStateVariables, layer, BeginType.Begin, mCamera, $"Un-set {renderable} Clip");
+            spriteRenderer.BeginSpriteBatch(mRenderStateVariables, layer, BeginType.Begin, mCamera, ClipExitStateLabel);
         }
     }
 

--- a/RenderingLibrary/Graphics/SpriteBatchStack.cs
+++ b/RenderingLibrary/Graphics/SpriteBatchStack.cs
@@ -438,6 +438,15 @@ namespace RenderingLibrary.Graphics
         {
             currentParameters = null;
             beginParametersUsedThisFrame.Clear();
+            // The state stack is per-frame scratch: a balanced frame pushes in RenderLayer's outer
+            // BeginSpriteBatch(Push) and pops in the matching EndSpriteBatch. On NET8+ that end-of-layer
+            // pop is skipped (RenderLayer relies on the frame-level ForceEnd instead), so without this
+            // reset the pushed states accumulate every frame — an unbounded List<BeginParameters?> growth
+            // whose amortized backing-array reallocation was the dominant idle Draw allocation (#1934).
+            // Clearing here (the per-frame reset, alongside the two lines above) keeps within-frame
+            // push/pop behavior intact while discarding the never-popped residue. On NET6 the stack is
+            // already empty at frame start, so this is a no-op there.
+            mStateStack.Clear();
         }
     }
 

--- a/RenderingLibrary/Graphics/SpriteRenderer.cs
+++ b/RenderingLibrary/Graphics/SpriteRenderer.cs
@@ -107,6 +107,15 @@ public class SpriteRenderer
         }
     }
 
+    /// <summary>
+    /// The current depth of the underlying <see cref="SpriteBatchStack"/>'s render-state stack.
+    /// Exposed for tests that guard against the state stack growing unbounded across frames
+    /// (issue #1934): on NET8+ the per-layer <c>EndSpriteBatch</c> pop is compiled out, so the
+    /// per-frame reset in <see cref="SpriteBatchStack.ClearPerformanceRecordingVariables"/> is
+    /// what keeps this bounded. Returns 0 before <see cref="Initialize(GraphicsDevice)"/> has run.
+    /// </summary>
+    public int RenderStateStackDepth => mSpriteBatch?.StackCount ?? 0;
+
     #endregion
 
     #region Properties

--- a/Tests/MonoGameGum.IntegrationTests/MonoGameGum.IntegrationTests.csproj
+++ b/Tests/MonoGameGum.IntegrationTests/MonoGameGum.IntegrationTests.csproj
@@ -25,6 +25,7 @@
 	<ItemGroup>
 		<ProjectReference Include="..\..\GumCommon\GumCommon.csproj" />
 		<ProjectReference Include="..\..\MonoGameGum\MonoGameGum.csproj" />
+		<ProjectReference Include="..\MonoGameGum.TestsCommon\MonoGameGum.TestsCommon.csproj" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Tests/MonoGameGum.IntegrationTests/MonoGameGum/GumServiceUnitTests.cs
+++ b/Tests/MonoGameGum.IntegrationTests/MonoGameGum/GumServiceUnitTests.cs
@@ -48,6 +48,24 @@ public class GumServiceUnitTests : BaseTestClass
     }
 
     [Fact]
+    public void Initialize_ThenDispose_UninitializesGumServiceDefault()
+    {
+        using (Game1 game = new Game1())
+        {
+            game.RunOneFrame();
+            GumService.Default.IsInitialized.ShouldBeTrue();
+        }
+
+        // The integration suite runs sequentially in a single process with non-deterministic
+        // test ordering (xUnit re-orders test cases between runs). If Game1 leaves
+        // GumService.Default initialized, whatever Game-based test xUnit schedules next throws
+        // "Initialize has already been called once" from its own GumService.Default.Initialize
+        // — an order-dependent flake that surfaced in the allocation/perf tests. Game1's
+        // teardown must uninitialize so every test starts from a clean, deterministic state.
+        GumService.Default.IsInitialized.ShouldBeFalse();
+    }
+
+    [Fact]
     public void SystemManagers_ThrowsException_WhenNotInitialized()
     {
         var gumService = new GumService();
@@ -114,6 +132,21 @@ public class GumServiceUnitTests : BaseTestClass
         protected override void Draw(GameTime gameTime)
         {
             GraphicsDevice.Clear(Color.CornflowerBlue);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            // Game1 initializes GumService.Default, so it must uninitialize it on teardown
+            // (before base.Dispose disposes the GraphicsDevice that Uninitialize releases
+            // GPU resources through). Without this, GumService.Default stays initialized and
+            // leaks into the next test in this sequential single-process suite, whose own
+            // GumService.Default.Initialize would then throw "already been called once".
+            if (GumUI.IsInitialized)
+            {
+                GumUI.Uninitialize();
+            }
+            LoaderManager.Self?.DisposeAndClear();
+            base.Dispose(disposing);
         }
     }
 

--- a/Tests/MonoGameGum.IntegrationTests/MonoGameGum/Performance/DrawAllocationTests.cs
+++ b/Tests/MonoGameGum.IntegrationTests/MonoGameGum/Performance/DrawAllocationTests.cs
@@ -1,0 +1,150 @@
+using System;
+using System.Linq;
+using Microsoft.Xna.Framework;
+using Gum.Forms.Controls;
+using Gum.GueDeriving;
+using MonoGameGum.TestsCommon;
+using RenderingLibrary;
+using RenderingLibrary.Content;
+using RenderingLibrary.Graphics;
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace MonoGameGum.IntegrationTests.MonoGameGum.Performance;
+
+/// <summary>
+/// Per-frame allocation baseline and regression guard for the idle-frame API
+/// (<see cref="global::Gum.GumService.Update(GameTime)"/> + <see cref="global::Gum.GumService.Draw()"/>)
+/// over a representative, unchanging Forms scene. Part of the runtime allocation pass, issue #1934:
+/// the target is zero managed bytes allocated per steady-state idle frame; the guard is a ratchet
+/// that tightens as allocation sources are removed in follow-up optimization PRs.
+/// </summary>
+public class DrawAllocationTests : BaseTestClass
+{
+    private readonly ITestOutputHelper _output;
+
+    public DrawAllocationTests(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    [Fact]
+    public void IdleUpdateAndDraw_RepresentativeFormsScene_AllocationBaseline()
+    {
+        using MinimalGame game = new();
+        game.RunOneFrame();
+
+        BuildScene();
+
+        // A single fixed GameTime reused every frame keeps the scene idle (no time advance, no
+        // animation) and avoids allocating a GameTime per iteration, so the measured delta reflects
+        // only the Update/Draw walk itself.
+        GameTime gameTime = new GameTime(TimeSpan.Zero, TimeSpan.FromSeconds(1.0 / 60.0));
+
+        AllocationResult result = AllocationMeasurer.Measure(
+            () =>
+            {
+                global::Gum.GumService.Default.Update(gameTime);
+                global::Gum.GumService.Default.Draw();
+            },
+            warmupIterations: 50,
+            measuredIterations: 500);
+
+        int drawStateCount = SystemManagers.Default.Renderer.SpriteRenderer.LastFrameDrawStates.Count();
+
+        _output.WriteLine($"Idle Update+Draw of a representative Forms scene (20-item ListBox, labels, " +
+            $"a Text, and a filled rectangle): {result.BytesPerIteration:N0} bytes/frame " +
+            $"({result.TotalBytes:N0} bytes over {result.Iterations} frames, {drawStateCount} draw states last frame)");
+
+        // Liveness: the Draw walk must actually render something each frame, otherwise a silent
+        // no-op would make a low/zero allocation result meaningless.
+        drawStateCount.ShouldBeGreaterThan(0);
+
+        // Baseline ratchet (#1934): the idle Update/Draw walk over an unchanging Forms scene still
+        // allocates today — measured at a deterministic 831 bytes/frame locally. The likely sources
+        // are the per-frame input/cursor pass in GumService.Update (FormsUtilities.Update) and
+        // per-frame collections in the Draw walk; driving it toward zero is deferred to follow-up
+        // optimization PRs. This guard pins the current cost so a regression that grows it fails the
+        // build; tighten the bound as sources are removed. Headroom is for JIT/runner variance.
+        result.BytesPerIteration.ShouldBeLessThanOrEqualTo(1200);
+    }
+
+    private static void BuildScene()
+    {
+        // A ListBox with ~20 string items exercises ListBoxItem visual realization and Text layout.
+        ListBox listBox = new ListBox();
+        listBox.X = 10;
+        listBox.Y = 10;
+        listBox.Width = 200;
+        listBox.Height = 300;
+        listBox.AddToRoot();
+
+        for (int i = 0; i < 20; i++)
+        {
+            listBox.Items!.Add("Item " + i);
+        }
+
+        Label titleLabel = new Label();
+        titleLabel.X = 230;
+        titleLabel.Y = 10;
+        titleLabel.Text = "Inventory";
+        titleLabel.AddToRoot();
+
+        Label subtitleLabel = new Label();
+        subtitleLabel.X = 230;
+        subtitleLabel.Y = 40;
+        subtitleLabel.Text = "Select an item to view details";
+        subtitleLabel.AddToRoot();
+
+        TextRuntime footer = new TextRuntime();
+        footer.X = 230;
+        footer.Y = 80;
+        footer.Text = "20 items in inventory";
+        footer.AddToRoot();
+
+        RectangleRuntime panel = new RectangleRuntime();
+        panel.X = 230;
+        panel.Y = 120;
+        panel.Width = 150;
+        panel.Height = 120;
+        panel.IsFilled = true;
+        panel.FillColor = Color.CornflowerBlue;
+        panel.AddToRoot();
+    }
+
+    /// <summary>
+    /// Minimal Game host that initializes the default <see cref="global::Gum.GumService"/> against a
+    /// live device so <see cref="global::Gum.GumService.Update(GameTime)"/> / <c>Draw()</c> can be
+    /// driven manually after <see cref="Game.RunOneFrame"/>.
+    /// </summary>
+    private class MinimalGame : Game
+    {
+        private readonly GraphicsDeviceManager _graphics;
+
+        public MinimalGame()
+        {
+            LoaderManager.Self?.DisposeAndClear();
+            _graphics = new GraphicsDeviceManager(this);
+        }
+
+        protected override void Initialize()
+        {
+            base.Initialize();
+            global::Gum.GumService.Default.Initialize(this, global::Gum.Forms.DefaultVisualsVersion.Newest);
+        }
+
+        protected override void Update(GameTime gameTime) { }
+        protected override void Draw(GameTime gameTime) => GraphicsDevice.Clear(Color.CornflowerBlue);
+
+        protected override void Dispose(bool disposing)
+        {
+            if (global::Gum.GumService.Default.IsInitialized)
+            {
+                global::Gum.GumService.Default.Uninitialize();
+            }
+            LoaderManager.Self?.DisposeAndClear();
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/Tests/MonoGameGum.IntegrationTests/MonoGameGum/Performance/DrawAllocationTests.cs
+++ b/Tests/MonoGameGum.IntegrationTests/MonoGameGum/Performance/DrawAllocationTests.cs
@@ -61,13 +61,14 @@ public class DrawAllocationTests : BaseTestClass
         // no-op would make a low/zero allocation result meaningless.
         drawStateCount.ShouldBeGreaterThan(0);
 
-        // Baseline ratchet (#1934): the idle Update/Draw walk over an unchanging Forms scene still
-        // allocates today — measured at a deterministic 831 bytes/frame locally. The likely sources
-        // are the per-frame input/cursor pass in GumService.Update (FormsUtilities.Update) and
-        // per-frame collections in the Draw walk; driving it toward zero is deferred to follow-up
-        // optimization PRs. This guard pins the current cost so a regression that grows it fails the
-        // build; tighten the bound as sources are removed. Headroom is for JIT/runner variance.
-        result.BytesPerIteration.ShouldBeLessThanOrEqualTo(1200);
+        // Baseline ratchet (#1934): the idle Update/Draw walk over an unchanging Forms scene.
+        // The Draw walk's ~752 bytes/frame were eliminated by fixing an unbounded SpriteBatchStack
+        // state-stack leak and a per-frame clip-exit string interpolation (see SpriteBatchStack /
+        // Renderer). The remaining cost is the per-frame input/cursor pass in GumService.Update
+        // (FormsUtilities.Update). This guard pins the current cost so a regression that grows it
+        // fails the build; tighten the bound further as sources are removed. Headroom is for
+        // JIT/runner variance.
+        result.BytesPerIteration.ShouldBeLessThanOrEqualTo(200);
     }
 
     private static void BuildScene()

--- a/Tests/MonoGameGum.IntegrationTests/MonoGameGum/Performance/LayoutAllocationTests.cs
+++ b/Tests/MonoGameGum.IntegrationTests/MonoGameGum/Performance/LayoutAllocationTests.cs
@@ -1,0 +1,200 @@
+using System;
+using Microsoft.Xna.Framework;
+using Gum.Forms;
+using Gum.Forms.Controls;
+using Gum.Wireframe;
+using MonoGameGum.TestsCommon;
+using RenderingLibrary;
+using RenderingLibrary.Content;
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace MonoGameGum.IntegrationTests.MonoGameGum.Performance;
+
+/// <summary>
+/// Per-layout-pass allocation baseline and regression guard for <see cref="GraphicalUiElement.UpdateLayout()"/>
+/// over a realistic Forms control tree with real Text (buttons, a text box, a combo box, a list box, and a
+/// floating window). Part of the runtime allocation pass, issue #1934. Unlike the headless container-only
+/// layout test in <c>MonoGameGum.Tests</c> (which reads zero because it has no Text and no Forms controls),
+/// this lives in the integration project so a real <see cref="Microsoft.Xna.Framework.Graphics.GraphicsDevice"/>
+/// backs Text measurement/glyph realization — i.e. it measures what laying out an actual game UI costs in GC.
+/// These are baselines, not zero-allocation assertions; each guard is a ratchet to drive down in a follow-up
+/// optimization PR.
+/// </summary>
+public class RealisticLayoutAllocationTests : BaseTestClass
+{
+    private const string TreeDescription =
+        "StackPanel(3 Buttons, TextBox, ComboBox[4 items], ListBox[15 items]) + floating Window(2 Buttons)";
+
+    private readonly ITestOutputHelper _output;
+
+    public RealisticLayoutAllocationTests(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    [Fact]
+    public void PropertyChange_TriggeringRelayout_RealisticTree_AllocationBaseline()
+    {
+        using MinimalGame game = new();
+        game.RunOneFrame();
+
+        Window floatingWindow = BuildRealisticTree();
+        global::Gum.GumService.Default.Root.UpdateLayout();
+
+        const int measuredIterations = 500;
+
+        // Alternate the floating window's height every frame so the change is real: the setter
+        // re-lays-out the window and its children (title bar, eight resize borders, inner panel and
+        // its two buttons). This exercises a property-driven relayout rooted at a live Forms control.
+        float height = floatingWindow.Height;
+        int layoutCallsBefore = GraphicalUiElement.UpdateLayoutCallCount;
+
+        AllocationResult result = AllocationMeasurer.Measure(
+            () =>
+            {
+                height = height == 200 ? 201 : 200;
+                floatingWindow.Height = height;
+            },
+            warmupIterations: 50,
+            measuredIterations: measuredIterations);
+
+        int layoutCalls = GraphicalUiElement.UpdateLayoutCallCount - layoutCallsBefore;
+
+        _output.WriteLine($"Height change on the floating Window of a realistic Forms tree " +
+            $"[{TreeDescription}]: {result.BytesPerIteration:N0} bytes/frame " +
+            $"({result.TotalBytes:N0} bytes over {result.Iterations} frames, {layoutCalls} layout calls total)");
+
+        // Liveness: prove the scenario actually drove relayout each frame, so a silent no-op setter
+        // cannot make the allocation result meaningless.
+        layoutCalls.ShouldBeGreaterThanOrEqualTo(measuredIterations);
+
+        // Baseline ratchet (#1934): a height change that relays out the floating Window subtree
+        // allocates a deterministic 40 bytes/frame locally. This pins that cost plus headroom for
+        // JIT/runner variance so a regression that grows it fails the build; tighten as sources are
+        // removed. No fix here.
+        result.BytesPerIteration.ShouldBeLessThanOrEqualTo(200);
+    }
+
+    [Fact]
+    public void UpdateLayout_RealisticTree_AllocationBaseline()
+    {
+        using MinimalGame game = new();
+        game.RunOneFrame();
+
+        BuildRealisticTree();
+        global::Gum.GumService.Default.Root.UpdateLayout();
+
+        AllocationResult result = AllocationMeasurer.Measure(
+            () => global::Gum.GumService.Default.Root.UpdateLayout(),
+            warmupIterations: 50,
+            measuredIterations: 500);
+
+        _output.WriteLine($"Full relayout of a realistic Forms tree [{TreeDescription}]: " +
+            $"{result.BytesPerIteration:N0} bytes/frame " +
+            $"({result.TotalBytes:N0} bytes over {result.Iterations} frames)");
+
+        // Baseline ratchet (#1934): a full relayout of a real Forms tree with Text allocates a
+        // deterministic 1,584 bytes/frame locally. This pins that cost plus headroom for JIT/runner
+        // variance so a regression that grows it fails the build; tighten as sources are removed.
+        // No fix here.
+        result.BytesPerIteration.ShouldBeLessThanOrEqualTo(2200);
+    }
+
+    /// <summary>
+    /// Builds a typical game-UI Forms layout in code and adds it to the default root: a vertical
+    /// <see cref="StackPanel"/> holding three buttons, a text box, a combo box, and a fifteen-item
+    /// list box, plus a separate floating <see cref="Window"/> containing two child buttons. Every
+    /// control carries real text so Text realization is exercised during layout. Returns the floating
+    /// window so callers can mutate it to trigger a property-driven relayout.
+    /// </summary>
+    private static Window BuildRealisticTree()
+    {
+        StackPanel panel = new();
+        panel.X = 10;
+        panel.Y = 10;
+        panel.Spacing = 4;
+        panel.AddToRoot();
+
+        string[] buttonLabels = { "Play", "Options", "Quit" };
+        foreach (string label in buttonLabels)
+        {
+            Button button = new();
+            button.Text = label;
+            panel.AddChild(button);
+        }
+
+        TextBox textBox = new();
+        textBox.Text = "Player One";
+        panel.AddChild(textBox);
+
+        ComboBox comboBox = new();
+        comboBox.Items!.Add("Easy");
+        comboBox.Items!.Add("Normal");
+        comboBox.Items!.Add("Hard");
+        comboBox.Items!.Add("Insane");
+        panel.AddChild(comboBox);
+
+        ListBox listBox = new();
+        listBox.Height = 200;
+        for (int i = 0; i < 15; i++)
+        {
+            listBox.Items!.Add("Save Slot " + i);
+        }
+        panel.AddChild(listBox);
+
+        Window floatingWindow = new();
+        floatingWindow.X = 300;
+        floatingWindow.Y = 40;
+        floatingWindow.Width = 240;
+        floatingWindow.Height = 200;
+        floatingWindow.AddToRoot();
+
+        Button okButton = new();
+        okButton.Text = "OK";
+        floatingWindow.AddChild(okButton);
+
+        Button cancelButton = new();
+        cancelButton.Text = "Cancel";
+        cancelButton.Y = 40;
+        floatingWindow.AddChild(cancelButton);
+
+        return floatingWindow;
+    }
+
+    /// <summary>
+    /// Minimal Game host that initializes the default <see cref="global::Gum.GumService"/> against a
+    /// live device so layout of a Text-bearing Forms tree can be driven manually after
+    /// <see cref="Game.RunOneFrame"/>.
+    /// </summary>
+    private class MinimalGame : Game
+    {
+        private readonly GraphicsDeviceManager _graphics;
+
+        public MinimalGame()
+        {
+            LoaderManager.Self?.DisposeAndClear();
+            _graphics = new GraphicsDeviceManager(this);
+        }
+
+        protected override void Initialize()
+        {
+            base.Initialize();
+            global::Gum.GumService.Default.Initialize(this, DefaultVisualsVersion.Newest);
+        }
+
+        protected override void Update(GameTime gameTime) { }
+        protected override void Draw(GameTime gameTime) => GraphicsDevice.Clear(Color.CornflowerBlue);
+
+        protected override void Dispose(bool disposing)
+        {
+            if (global::Gum.GumService.Default.IsInitialized)
+            {
+                global::Gum.GumService.Default.Uninitialize();
+            }
+            LoaderManager.Self?.DisposeAndClear();
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/Tests/MonoGameGum.IntegrationTests/MonoGameGum/Performance/RenderStateStackGrowthTests.cs
+++ b/Tests/MonoGameGum.IntegrationTests/MonoGameGum/Performance/RenderStateStackGrowthTests.cs
@@ -1,0 +1,138 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Xna.Framework;
+using Gum.Forms.Controls;
+using Gum.GueDeriving;
+using RenderingLibrary;
+using RenderingLibrary.Content;
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace MonoGameGum.IntegrationTests.MonoGameGum.Performance;
+
+/// <summary>
+/// Direct leak guard for the <see cref="global::RenderingLibrary.Graphics.SpriteBatchStack"/>
+/// render-state stack (issue #1934). On NET8+ the per-layer <c>EndSpriteBatch</c> pop that would
+/// balance <c>RenderLayer</c>'s <c>BeginSpriteBatch(Push)</c> is compiled out, so without the
+/// per-frame reset in <c>ClearPerformanceRecordingVariables</c> the stack grows one entry per
+/// layer per frame — an unbounded <see cref="List{T}"/> rooted by the long-lived Renderer. This
+/// test pins the collection depth itself (rather than a bytes/frame proxy): the depth after a
+/// late frame must equal the depth after an early frame, i.e. it does not scale with frame count.
+/// </summary>
+public class RenderStateStackGrowthTests : BaseTestClass
+{
+    private readonly ITestOutputHelper _output;
+
+    public RenderStateStackGrowthTests(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    [Fact]
+    public void SpriteBatchStack_StateStackDoesNotGrowAcrossFrames()
+    {
+        using MinimalGame game = new();
+        game.RunOneFrame();
+
+        BuildScene();
+
+        // A single fixed GameTime keeps the scene idle so the only thing that could change the
+        // stack depth from frame to frame is the leak under test, not layout/animation churn.
+        GameTime gameTime = new GameTime(TimeSpan.Zero, TimeSpan.FromSeconds(1.0 / 60.0));
+
+        // Warm up: the first few Draws after RunOneFrame do one-time work (font loads, render-target
+        // setup) that can vary the per-frame push count. Discard them so the measured run reflects
+        // only the steady-state stack behavior.
+        for (int i = 0; i < 5; i++)
+        {
+            global::Gum.GumService.Default.Update(gameTime);
+            global::Gum.GumService.Default.Draw();
+        }
+
+        const int measuredFrames = 200;
+        List<int> depths = new List<int>(measuredFrames);
+        for (int i = 0; i < measuredFrames; i++)
+        {
+            global::Gum.GumService.Default.Update(gameTime);
+            global::Gum.GumService.Default.Draw();
+            depths.Add(SystemManagers.Default.Renderer.SpriteRenderer.RenderStateStackDepth);
+        }
+
+        int earlyDepth = depths.First();
+        int lateDepth = depths.Last();
+        int maxDepth = depths.Max();
+        int minDepth = depths.Min();
+
+        _output.WriteLine($"RenderStateStackDepth over {measuredFrames} idle frames: " +
+            $"first={earlyDepth}, last={lateDepth}, min={minDepth}, max={maxDepth}");
+
+        // The stack must stay bounded: the depth after the last frame equals the depth after the
+        // first measured frame, and never climbs in between. Without the per-frame reset this would
+        // grow by one (per rendered layer) every frame, so lateDepth would be ~measuredFrames higher.
+        maxDepth.ShouldBe(minDepth);
+        lateDepth.ShouldBe(earlyDepth);
+    }
+
+    private static void BuildScene()
+    {
+        // A ListBox with a handful of items renders through the full clipped-tree path (outer layer
+        // push + per-container clip begins), which is exactly what drives the state stack.
+        ListBox listBox = new ListBox();
+        listBox.X = 10;
+        listBox.Y = 10;
+        listBox.Width = 200;
+        listBox.Height = 200;
+        listBox.AddToRoot();
+
+        for (int i = 0; i < 10; i++)
+        {
+            listBox.Items!.Add("Item " + i);
+        }
+
+        RectangleRuntime panel = new RectangleRuntime();
+        panel.X = 230;
+        panel.Y = 10;
+        panel.Width = 150;
+        panel.Height = 120;
+        panel.IsFilled = true;
+        panel.FillColor = Color.CornflowerBlue;
+        panel.AddToRoot();
+    }
+
+    /// <summary>
+    /// Minimal Game host that initializes the default <see cref="global::Gum.GumService"/> against a
+    /// live device so <see cref="global::Gum.GumService.Update(GameTime)"/> / <c>Draw()</c> can be
+    /// driven manually after <see cref="Game.RunOneFrame"/>.
+    /// </summary>
+    private class MinimalGame : Game
+    {
+        private readonly GraphicsDeviceManager _graphics;
+
+        public MinimalGame()
+        {
+            LoaderManager.Self?.DisposeAndClear();
+            _graphics = new GraphicsDeviceManager(this);
+        }
+
+        protected override void Initialize()
+        {
+            base.Initialize();
+            global::Gum.GumService.Default.Initialize(this, global::Gum.Forms.DefaultVisualsVersion.Newest);
+        }
+
+        protected override void Update(GameTime gameTime) { }
+        protected override void Draw(GameTime gameTime) => GraphicsDevice.Clear(Color.CornflowerBlue);
+
+        protected override void Dispose(bool disposing)
+        {
+            if (global::Gum.GumService.Default.IsInitialized)
+            {
+                global::Gum.GumService.Default.Uninitialize();
+            }
+            LoaderManager.Self?.DisposeAndClear();
+            base.Dispose(disposing);
+        }
+    }
+}


### PR DESCRIPTION
Part of #1934 (runtime allocation pass). Measurement infrastructure + the first optimization pass; the umbrella issue stays open for remaining scenarios.

## What's here

**Measurement scenarios** (built on the `AllocationMeasurer` harness from #3513): an idle `Update()`+`Draw()` allocation scenario and realistic-Forms-tree `UpdateLayout()` baselines. Each guard has a liveness check (draw-state count / layout-call count) so a silent no-op can't fake a zero.

**Idle Draw-walk fix: 831 → 128 bytes/frame** (measured on a realistic Forms scene — a 20-item `ListBox`, labels, a shape). Two sources removed, both in shared `RenderingLibrary/Graphics/`:

1. **`SpriteBatchStack` state-stack leak (~655 B/f).** On NET8+ the per-layer push (`PushRenderStates` → `mStateStack.Add`) runs every frame, but its balancing pop (`PopRenderStates`, via `SpriteRenderer.EndSpriteBatch`) is compiled out (`#if !NET8_0_OR_GREATER`). So the `List<BeginParameters?>` — rooted by the long-lived `Renderer` — grew unbounded every frame: a genuine managed leak (it also kept the referenced `Effect`/blend/sampler/rasterizer states and the pooled `ChangeRecord` alive), whose backing-array reallocation churn was the dominant idle allocation. Fixed by clearing the stack in the per-frame reset (`ClearPerformanceRecordingVariables`, called at the start of the full-frame `Draw(SystemManagers)`).
2. **Clip-exit string interpolation (~97 B/f).** `$"Un-set {renderable} Clip"` → a shared `const`; `DrawStateSummary` keys a clip-exit only on the state being a `string` (not its content), so categorization is preserved exactly.

**Leak proven directly (TDD).** `RenderStateStackGrowthTests` asserts the render-state stack depth stays constant across 200 frames. Without the fix it climbs exactly +1/frame (6 → 205); with it, constant at 1. Fails red for the right reason, passes green with the fix.

**Leak follow-up (#3515).** This fix covers the full-frame `Draw(SystemManagers)` path (what MonoGameGum renders through). The layered `Draw(SystemManagers, Layer)` / `Draw(SystemManagers, List<Layer>)` overloads — used by FlatRedBall — don't hit the reset and still leak on NET8+. Tracked separately in #3515.

**Test-isolation flake fix.** `GumServiceUnitTests.Game1` was the one Game-based integration test with no `Dispose`, leaving `GumService.Default` initialized; under xUnit's run-to-run reordering it could land ahead of a perf test and make that test's `Initialize` throw "already been called once". Added the `Dispose` → `Uninitialize` that every other Game-based test already has. Verified green across repeated full-suite runs.

## Not in this PR

Optimizing the full-relayout Text path (~1,584 B/f) and the residual idle `Update` cost (~128 B/f, the `FormsUtilities` input pass) — separate follow-up under #1934, test-first.

## Tests

`MonoGameGum.Tests` and `MonoGameGum.IntegrationTests` green (incl. real clipping/render-target paths). New allocation/leak tests are deterministic; baselines have liveness guards. KniGum/RaylibGum/SkiaGum build clean (shared `RenderingLibrary` change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
