### PR TITLE
Fix SpriteBatchStack state-stack leak on NET8+ layered Draw paths (#3515)

### DIFF
--- a/RenderingLibrary/Graphics/Renderer.cs
+++ b/RenderingLibrary/Graphics/Renderer.cs
@@ -661,6 +661,15 @@ public class Renderer : IRenderer
 
 #if !NET8_0_OR_GREATER
         spriteRenderer.EndSpriteBatch();
+#else
+        // The full EndSpriteBatch pop (with its End()/currentParameters reset) is intentionally
+        // skipped on NET8+ — the frame-level ForceEnd flushes instead. But the matching
+        // BeginSpriteBatch(Push) above still adds a state-stack entry, so without balancing it here
+        // mStateStack grows one entry per layer per frame on the Draw(Layer)/Draw(List<Layer>) paths
+        // that never run the per-frame ClearPerformanceRecordingVariables reset — an unbounded leak
+        // rooted by the long-lived Renderer (#3515). Remove just the pushed entry, preserving the
+        // NET8+ currentParameters carry-over that the frame-level flush relies on.
+        spriteRenderer.RemoveLastStateStackEntry();
 #endif
     }
 

--- a/RenderingLibrary/Graphics/SpriteBatchStack.cs
+++ b/RenderingLibrary/Graphics/SpriteBatchStack.cs
@@ -426,6 +426,23 @@ namespace RenderingLibrary.Graphics
             }
         }
 
+        /// <summary>
+        /// Removes the entry added by the most recent <see cref="PushRenderStates"/> without applying
+        /// it — no <see cref="ReplaceRenderStates"/> / <see cref="End"/> side-effects. On NET8+ the
+        /// outer per-layer push in <c>Renderer.RenderLayer</c> is not balanced by the full
+        /// <see cref="PopRenderStates"/> (that pop's <see cref="End"/> is handled by the frame-level
+        /// ForceEnd instead), so this keeps <see cref="StackCount"/> from growing one entry per layer
+        /// per frame — the leak on the per-layer Draw paths that never run the per-frame reset (#3515).
+        /// A no-op when the stack is empty.
+        /// </summary>
+        public void RemoveLastStateStackEntry()
+        {
+            if (mStateStack.Count > 0)
+            {
+                mStateStack.RemoveAt(mStateStack.Count - 1);
+            }
+        }
+
         private void RecordCurrentParameters()
         {
             if (currentParameters != null)

--- a/RenderingLibrary/Graphics/SpriteRenderer.cs
+++ b/RenderingLibrary/Graphics/SpriteRenderer.cs
@@ -144,6 +144,16 @@ public class SpriteRenderer
 
     }
 
+    /// <summary>
+    /// Balances <see cref="BeginSpriteBatch"/>'s <see cref="BeginType.Push"/> on NET8+ by discarding
+    /// the pushed render-state stack entry without the side-effects of <see cref="EndSpriteBatch"/>.
+    /// Called from <c>Renderer.RenderLayer</c>, where the full pop is compiled out on NET8+ (#3515).
+    /// </summary>
+    public void RemoveLastStateStackEntry()
+    {
+        mSpriteBatch.RemoveLastStateStackEntry();
+    }
+
     public void BeginSpriteBatch(RenderStateVariables renderStates, Layer layer, BeginType beginType, Camera camera, object objectStartingSpriteBatch, Effect? effectOverride = null)
     {
         // Use the full camera transform for both UsingEffect and non-UsingEffect paths.

--- a/Tests/MonoGameGum.IntegrationTests/MonoGameGum/Performance/RenderStateStackGrowthTests.cs
+++ b/Tests/MonoGameGum.IntegrationTests/MonoGameGum/Performance/RenderStateStackGrowthTests.cs
@@ -6,6 +6,7 @@ using Gum.Forms.Controls;
 using Gum.GueDeriving;
 using RenderingLibrary;
 using RenderingLibrary.Content;
+using RenderingLibrary.Graphics;
 using Shouldly;
 using Xunit;
 using Xunit.Abstractions;
@@ -13,13 +14,16 @@ using Xunit.Abstractions;
 namespace MonoGameGum.IntegrationTests.MonoGameGum.Performance;
 
 /// <summary>
-/// Direct leak guard for the <see cref="global::RenderingLibrary.Graphics.SpriteBatchStack"/>
-/// render-state stack (issue #1934). On NET8+ the per-layer <c>EndSpriteBatch</c> pop that would
-/// balance <c>RenderLayer</c>'s <c>BeginSpriteBatch(Push)</c> is compiled out, so without the
-/// per-frame reset in <c>ClearPerformanceRecordingVariables</c> the stack grows one entry per
-/// layer per frame — an unbounded <see cref="List{T}"/> rooted by the long-lived Renderer. This
-/// test pins the collection depth itself (rather than a bytes/frame proxy): the depth after a
-/// late frame must equal the depth after an early frame, i.e. it does not scale with frame count.
+/// Direct leak guards for the <see cref="global::RenderingLibrary.Graphics.SpriteBatchStack"/>
+/// render-state stack (issues #1934, #3515). On NET8+ the per-layer <c>EndSpriteBatch</c> pop that
+/// would balance <c>RenderLayer</c>'s <c>BeginSpriteBatch(Push)</c> is compiled out, so the pushed
+/// entry accumulates one per layer per frame — an unbounded <see cref="List{T}"/> rooted by the
+/// long-lived Renderer. These tests pin the collection depth itself (rather than a bytes/frame
+/// proxy): the depth after a late frame must equal the depth after an early frame, i.e. it does not
+/// scale with frame count. Two entry paths are covered: the full-frame <c>GumService.Draw()</c> path
+/// (kept bounded by the per-frame reset in <c>ClearPerformanceRecordingVariables</c>, #1934) and the
+/// per-layer <c>Renderer.Draw(SystemManagers, Layer)</c> path used by FRB, which never runs that
+/// reset and is instead balanced by the NET8+ pop in <c>RenderLayer</c> (#3515).
 /// </summary>
 public class RenderStateStackGrowthTests : BaseTestClass
 {
@@ -31,7 +35,7 @@ public class RenderStateStackGrowthTests : BaseTestClass
     }
 
     [Fact]
-    public void SpriteBatchStack_StateStackDoesNotGrowAcrossFrames()
+    public void SpriteBatchStack_StateStackDoesNotGrowAcrossFrames_OnFullFrameDrawPath()
     {
         using MinimalGame game = new();
         game.RunOneFrame();
@@ -73,6 +77,65 @@ public class RenderStateStackGrowthTests : BaseTestClass
         // grow by one (per rendered layer) every frame, so lateDepth would be ~measuredFrames higher.
         maxDepth.ShouldBe(minDepth);
         lateDepth.ShouldBe(earlyDepth);
+    }
+
+    [Fact]
+    public void SpriteBatchStack_StateStackDoesNotGrowAcrossFrames_OnPerLayerDrawPath()
+    {
+        using MinimalGame game = new();
+        game.RunOneFrame();
+
+        BuildScene();
+
+        SystemManagers managers = SystemManagers.Default;
+        Renderer renderer = managers.Renderer;
+        Layer mainLayer = renderer.MainLayer;
+
+        // One layout pass for the idle scene, then measure the per-layer Draw path only
+        // (Renderer.Draw(SystemManagers, Layer) — the FRB / GumIdb entry point). That path never
+        // runs the full-frame ClearPerformanceRecordingVariables reset, so on NET8+ it relies on
+        // RenderLayer's own push balance to stay bounded (#3515).
+        GameTime gameTime = new GameTime(TimeSpan.Zero, TimeSpan.FromSeconds(1.0 / 60.0));
+        global::Gum.GumService.Default.Update(gameTime);
+
+        double hostTime = 0;
+
+        // Warm up: the first Draws do one-time work (font loads, render-target setup) that can vary
+        // the per-frame push count. Discard them so the measured run reflects only steady state.
+        for (int i = 0; i < 5; i++)
+        {
+            AdvanceHostFrame(managers, ref hostTime);
+            renderer.Draw(managers, mainLayer);
+        }
+
+        const int measuredFrames = 200;
+        List<int> depths = new List<int>(measuredFrames);
+        for (int i = 0; i < measuredFrames; i++)
+        {
+            AdvanceHostFrame(managers, ref hostTime);
+            renderer.Draw(managers, mainLayer);
+            depths.Add(renderer.SpriteRenderer.RenderStateStackDepth);
+        }
+
+        int earlyDepth = depths.First();
+        int lateDepth = depths.Last();
+        int maxDepth = depths.Max();
+        int minDepth = depths.Min();
+
+        _output.WriteLine($"RenderStateStackDepth over {measuredFrames} per-layer draws: " +
+            $"first={earlyDepth}, last={lateDepth}, min={minDepth}, max={maxDepth}");
+
+        // The stack must stay bounded across per-layer draws: without the NET8+ balance in
+        // RenderLayer, each Draw(Layer) pushes an entry that is never popped, so lateDepth would be
+        // ~measuredFrames higher than earlyDepth. The fix keeps the depth constant.
+        maxDepth.ShouldBe(minDepth);
+        lateDepth.ShouldBe(earlyDepth);
+    }
+
+    private static void AdvanceHostFrame(SystemManagers managers, ref double hostTime)
+    {
+        hostTime += 1.0 / 60.0;
+        managers.Activity(hostTime);
     }
 
     private static void BuildScene()


### PR DESCRIPTION
Closes #3515.

## Problem

`RenderLayer`'s per-layer `spriteRenderer.BeginSpriteBatch(BeginType.Push)` adds one entry to `SpriteBatchStack.mStateStack`. On NET8+ the matching `EndSpriteBatch()` pop is `#if !NET8_0_OR_GREATER` (the frame-level `ForceEnd` handles the flush instead), so nothing pops during the layered walk.

PR #3514 bounded the standard **full-frame** `GumService.Draw()` path by clearing `mStateStack` in the per-frame `ClearPerformanceRecordingVariables()` reset. But `Draw(SystemManagers, Layer)` and `Draw(SystemManagers, List<Layer>)` — the **FRB / `GumIdb` per-layer path** — never run that reset, so the stack still grew one entry per layer per frame: an unbounded `List<BeginParameters?>` rooted by the long-lived `Renderer`, which also kept the referenced graphics resources (`Effect`, blend/sampler/etc., pooled `ChangeRecord`) alive.

## Fix

Balance the push at its source. `RenderLayer`'s existing `#if !NET8_0_OR_GREATER` gets an `#else` that calls a new `SpriteBatchStack.RemoveLastStateStackEntry()` (a bare `RemoveAt`, exposed via a `SpriteRenderer` passthrough). It removes only the pushed entry — **without** the `End()` / `currentParameters = null` side-effects that got the full `EndSpriteBatch` pop compiled out on NET8+ in the first place.

Consequences:
- **Rendering output is byte-identical on NET8+.** `mStateStack` is never read again on the layered path on NET8+ (`PopRenderStates` is only reachable via the `#if`'d-out `EndSpriteBatch`), and `currentParameters`/`SpriteBatch` lifecycle are untouched.
- **Covers all three layered Draw entry points** (all funnel through `RenderLayer`), making #3514's per-frame stack-clear redundant-but-harmless.
- **net6 / FRB1 is untouched** — that target keeps the existing `EndSpriteBatch` pop under `#if !NET8_0_OR_GREATER`.

This is the issue's "restore a NET8+-appropriate pop" option, done as a side-effect-free collection pop rather than re-enabling the full pop.

## Test

New sibling in `RenderStateStackGrowthTests` drives the **per-layer** `Renderer.Draw(SystemManagers, Layer)` path across 200 frames and pins `RenderStateStackDepth` bounded (a direct leak pin, not a bytes/frame proxy). Red before the fix (`first=6, last=205`, +1/frame); green after (constant). The existing full-frame test is renamed `..._OnFullFrameDrawPath` for symmetry.

## Verification

- `MonoGameGum.Tests` — 1807 passed
- `MonoGameGum.IntegrationTests` — 61 passed
- `KniGum`, `RaylibGum`, `SkiaGum` build clean (they compile `RenderingLibrary` and target net8, so they exercise the `#else` branch)
- No new compiler warnings; no `GumCoreShared.projitems` change needed (edited existing shared files only, no new `using`, pure-BCL `List.RemoveAt`)

Manual test: not needed — pure internal memory-lifecycle fix with byte-identical rendering; the direct `StackCount` leak-pin test is the proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
