### PR TITLE
Fix RelativeToChildren Text under-measuring inline BBCode runs (part of #3520)

### DIFF
--- a/MonoGameGum.Tests/RenderingLibraries/TextTests.cs
+++ b/MonoGameGum.Tests/RenderingLibraries/TextTests.cs
@@ -99,6 +99,185 @@ char id=37   x=161   y=0     width=22    height=20    xoffset=1     yoffset=6   
             "Because a content-derived Height must not be used to truncate the very lines it was derived from");
     }
 
+    // Two-char ("ab") BMFont with every glyph at a caller-chosen xadvance, so a test can build a
+    // "base" font and a deliberately-wider "swapped" font and assert measurement honors each run's font.
+    private static string TwoCharFontData(int xadvance, int lineHeight) =>
+$@"info face=""Arial"" size=-18 bold=0 italic=0 charset="""" unicode=1 stretchH=100 smooth=1 aa=1 padding=0,0,0,0 spacing=1,1 outline=0
+common lineHeight={lineHeight} base={lineHeight} scaleW=256 scaleH=256 pages=1 packed=0 alphaChnl=0 redChnl=4 greenChnl=4 blueChnl=4
+page id=0 file=""x.png""
+chars count=2
+char id=97 x=0 y=0 width={xadvance} height=13 xoffset=0 yoffset=4 xadvance={xadvance} page=0 chnl=15
+char id=98 x=0 y=0 width={xadvance} height=13 xoffset=0 yoffset=4 xadvance={xadvance} page=0 chnl=15
+";
+
+    // #3520: a [FontSize=N] run becomes a "BitmapFont" inline variable pointing at a font generated at
+    // that size (CustomSetPropertyOnRenderable). The reported width must measure that run with ITS font,
+    // not the base font — otherwise a RelativeToChildren Text is sized too narrow and the larger run
+    // overflows / mis-wraps. Mirrors how DrawWithInlineVariables draws the run with the swapped font.
+    [Fact]
+    public void WrappedTextWidth_ShouldMeasureFontSwapRun_WithItsOwnFont()
+    {
+        const int baseAdvance = 10;
+        const int swappedAdvance = 20;
+
+        BitmapFont baseFont = new BitmapFont((Texture2D)null!, TwoCharFontData(baseAdvance, lineHeight: 20));
+        baseFont.SetFontPattern(256, 256);
+        BitmapFont swappedFont = new BitmapFont((Texture2D)null!, TwoCharFontData(swappedAdvance, lineHeight: 20));
+        swappedFont.SetFontPattern(256, 256);
+
+        Text plain = new Text();
+        plain.BitmapFont = baseFont;
+        plain.RawText = "ab";
+        float plainWidth = plain.WrappedTextWidth; // baseAdvance + baseAdvance
+
+        Text swapped = new Text();
+        swapped.BitmapFont = baseFont;
+        // 'b' (index 1) is rendered with the larger font, like [FontSize] swaps a run's font.
+        swapped.InlineVariables.Add(new InlineVariable
+        {
+            VariableName = "BitmapFont",
+            Value = swappedFont,
+            StartIndex = 1,
+            CharacterCount = 1
+        });
+        swapped.RawText = "ab";
+        float swappedWidth = swapped.WrappedTextWidth; // want: baseAdvance + swappedAdvance
+
+        // Ratio, not absolute, so the assert is independent of GlobalFontScale (both widths scale by it).
+        double expectedRatio = (baseAdvance + swappedAdvance) / (2.0 * baseAdvance);
+        ((double)swappedWidth).ShouldBe(plainWidth * expectedRatio, plainWidth * 0.02,
+            "because the font-swap run must be measured with its own (larger) font, not the base font");
+    }
+
+    // BMFont with space + A/B/C, every glyph at a caller-chosen xadvance.
+    private static string AbcFontData(int xadvance, int lineHeight) =>
+$@"info face=""Arial"" size=-18 bold=0 italic=0 charset="""" unicode=1 stretchH=100 smooth=1 aa=1 padding=0,0,0,0 spacing=1,1 outline=0
+common lineHeight={lineHeight} base={lineHeight} scaleW=256 scaleH=256 pages=1 packed=0 alphaChnl=0 redChnl=4 greenChnl=4 blueChnl=4
+page id=0 file=""x.png""
+chars count=4
+char id=32 x=0 y=0 width={xadvance} height=13 xoffset=0 yoffset=4 xadvance={xadvance} page=0 chnl=15
+char id=65 x=0 y=0 width={xadvance} height=13 xoffset=0 yoffset=4 xadvance={xadvance} page=0 chnl=15
+char id=66 x=0 y=0 width={xadvance} height=13 xoffset=0 yoffset=4 xadvance={xadvance} page=0 chnl=15
+char id=67 x=0 y=0 width={xadvance} height=13 xoffset=0 yoffset=4 xadvance={xadvance} page=0 chnl=15
+";
+
+    // #3520: a base run that FOLLOWS a font-swap run (like " text." after [FontSize=40]big[/FontSize])
+    // must be measured at the base size. Reproduces the residual under-measurement the manual test
+    // showed: the mid-line swap grows the box, but the trailing run was still being dropped/mismeasured.
+    [Fact]
+    public void WrappedTextWidth_ShouldMeasureTrailingBaseRun_AfterFontSwapRun()
+    {
+        const int baseAdvance = 10;
+        const int swappedAdvance = 20;
+
+        BitmapFont baseFont = new BitmapFont((Texture2D)null!, AbcFontData(baseAdvance, lineHeight: 20));
+        baseFont.SetFontPattern(256, 256);
+        BitmapFont swappedFont = new BitmapFont((Texture2D)null!, AbcFontData(swappedAdvance, lineHeight: 20));
+        swappedFont.SetFontPattern(256, 256);
+
+        Text plain = new Text();
+        plain.BitmapFont = baseFont;
+        plain.RawText = "AA BB CC";
+        float plainWidth = plain.WrappedTextWidth; // 8 chars * baseAdvance
+
+        Text swapped = new Text();
+        swapped.BitmapFont = baseFont;
+        // Swap the MIDDLE run "BB" (indices 3-4); "AA " before and " CC" after stay base.
+        swapped.InlineVariables.Add(new InlineVariable
+        {
+            VariableName = "BitmapFont",
+            Value = swappedFont,
+            StartIndex = 3,
+            CharacterCount = 2
+        });
+        swapped.RawText = "AA BB CC";
+        float swappedWidth = swapped.WrappedTextWidth; // want: 6 base chars + 2 swapped chars
+
+        double expectedRatio = (6 * baseAdvance + 2 * swappedAdvance) / (8.0 * baseAdvance);
+        ((double)swappedWidth).ShouldBe(plainWidth * expectedRatio, plainWidth * 0.02,
+            "because a base run after a font-swap run must still be fully measured at the base size");
+    }
+
+    // Font where the space advances 10px but is only 1px wide, and letters A/B/C are 10px wide with a
+    // 10px advance. The narrow space is what exposes per-run TrimRight trimming: an interior run ending
+    // in a space loses 9px if measured with TrimRight instead of Full.
+    private static string NarrowSpaceFontData(int lineHeight) =>
+$@"info face=""Arial"" size=-18 bold=0 italic=0 charset="""" unicode=1 stretchH=100 smooth=1 aa=1 padding=0,0,0,0 spacing=1,1 outline=0
+common lineHeight={lineHeight} base={lineHeight} scaleW=256 scaleH=256 pages=1 packed=0 alphaChnl=0 redChnl=4 greenChnl=4 blueChnl=4
+page id=0 file=""x.png""
+chars count=4
+char id=32 x=0 y=0 width=1 height=13 xoffset=0 yoffset=4 xadvance=10 page=0 chnl=15
+char id=65 x=0 y=0 width=10 height=13 xoffset=0 yoffset=4 xadvance=10 page=0 chnl=15
+char id=66 x=0 y=0 width=10 height=13 xoffset=0 yoffset=4 xadvance=10 page=0 chnl=15
+char id=67 x=0 y=0 width=10 height=13 xoffset=0 yoffset=4 xadvance=10 page=0 chnl=15
+";
+
+    private static BitmapFont CreateNarrowSpaceFontWithTexture()
+    {
+        BitmapFont font = new BitmapFont((Texture2D)null!, NarrowSpaceFontData(lineHeight: 20));
+        font.SetFontPattern(256, 256);
+
+        // BitmapFont.MeasureString only honors TrimRight when Texture != null (see the guard in
+        // MeasureString). Real fonts always have a texture, so plant a placeholder to match the runtime;
+        // MeasureString only reads the reference, never dereferences it, so this is safe.
+        Texture2D placeholderTexture = (Texture2D)RuntimeHelpers.GetUninitializedObject(typeof(Texture2D));
+        FieldInfo mTexturesField = typeof(BitmapFont).GetField("mTextures", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        Texture2D[] textures = (Texture2D[])mTexturesField.GetValue(font)!;
+        textures[0] = placeholderTexture;
+        return font;
+    }
+
+    // #3520 (the real-font manifestation the uniform-font tests missed): splitting a line into runs at
+    // inline-variable boundaries must NOT change its measured width when the runs carry no size change.
+    // BitmapFont.MeasureString defaults to TrimRight, which trims the last glyph of each measured string
+    // to its pixel extent. Measuring per-run trims at EVERY run boundary instead of once per line, so an
+    // interior run ending in a space (e.g. "This is " before a styled word) loses that space's advance
+    // and the line is under-measured — leaving a RelativeToChildren container too narrow and the tail
+    // spilling past it. A uniform font (width == xadvance) hides this, which is why it went unnoticed.
+    [Fact]
+    public void WrappedTextWidth_WithInteriorRunBeforeSpace_ShouldMatchPlainLineWidth()
+    {
+        BitmapFont font = CreateNarrowSpaceFontWithTexture();
+
+        Text plain = new Text();
+        plain.BitmapFont = font;
+        plain.RawText = "AA BB CC";
+        float plainWidth = plain.WrappedTextWidth;
+
+        Text styled = new Text();
+        styled.BitmapFont = font;
+        // A Color run over "BB" (indices 3-4) splits the line into "AA ", "BB", " CC" without changing
+        // any glyph size, so the measured width MUST equal the plain (single-run) line's width.
+        styled.InlineVariables.Add(new InlineVariable
+        {
+            VariableName = "Color",
+            Value = System.Drawing.Color.Red,
+            StartIndex = 3,
+            CharacterCount = 2
+        });
+        styled.RawText = "AA BB CC";
+        float styledWidth = styled.WrappedTextWidth;
+
+        styledWidth.ShouldBe(plainWidth,
+            "because inline runs that carry no size change must not alter the measured line width");
+    }
+
+    // Full must use XAdvance for the last glyph even when it is a trailing space (its documented
+    // contract). TrimRight instead trims a trailing space to its pixel extent, so end-of-line spaces add
+    // no width. This divergence is what lets a line be measured run-by-run for inline styling without
+    // losing interior spaces at the run boundaries (#3520).
+    [Fact]
+    public void MeasureString_Full_IncludesTrailingSpaceAdvance_UnlikeTrimRight()
+    {
+        BitmapFont font = CreateNarrowSpaceFontWithTexture(); // space: 1px wide, 10px advance
+
+        int full = font.MeasureString("AA ", HorizontalMeasurementStyle.Full);
+        int trimRight = font.MeasureString("AA ", HorizontalMeasurementStyle.TrimRight);
+
+        full.ShouldBe(30, "because Full counts the trailing space's full 10px XAdvance (10 + 10 + 10)");
+        trimRight.ShouldBe(21, "because TrimRight trims the trailing space to its 1px pixel width (10 + 10 + 1)");
+    }
+
     [Fact]
     public void MeasureString_WithStyleAndNoBitmapFont_DoesNotThrow()
     {

--- a/MonoGameGum.Tests/Runtimes/TextRuntimeTests.cs
+++ b/MonoGameGum.Tests/Runtimes/TextRuntimeTests.cs
@@ -5,6 +5,7 @@ using Gum.GueDeriving;
 using Gum.Localization;
 using Moq;
 using RenderingLibrary.Graphics;
+using RenderingLibrary.Graphics.Fonts;
 using Shouldly;
 using System;
 using System.Collections.Generic;
@@ -194,6 +195,181 @@ $"chars count=223\r\n";
 
         scaledWidth.ShouldBe(plainWidth * 2, 1.5,
             "Because a scaled run is measured at its own scale, so the reported width grows with it");
+    }
+
+    #endregion
+
+    #region BbCode FontSize Inline Measurement (issue #3520)
+
+    // BMFont with space + A/B/C, every glyph at a caller-chosen xadvance. Used by the stub font
+    // creator so a generated [FontSize=N] font has predictable, uniform metrics.
+    private static string AbcFontData(int xadvance, int lineHeight) =>
+$@"info face=""Arial"" size=-18 bold=0 italic=0 charset="""" unicode=1 stretchH=100 smooth=1 aa=1 padding=0,0,0,0 spacing=1,1 outline=0
+common lineHeight={lineHeight} base={lineHeight} scaleW=256 scaleH=256 pages=1 packed=0 alphaChnl=0 redChnl=4 greenChnl=4 blueChnl=4
+page id=0 file=""x.png""
+chars count=4
+char id=32 x=0 y=0 width={xadvance} height=13 xoffset=0 yoffset=4 xadvance={xadvance} page=0 chnl=15
+char id=65 x=0 y=0 width={xadvance} height=13 xoffset=0 yoffset=4 xadvance={xadvance} page=0 chnl=15
+char id=66 x=0 y=0 width={xadvance} height=13 xoffset=0 yoffset=4 xadvance={xadvance} page=0 chnl=15
+char id=67 x=0 y=0 width={xadvance} height=13 xoffset=0 yoffset=4 xadvance={xadvance} page=0 chnl=15
+";
+
+    // Stubs in-memory font generation so a [FontSize=N] run produces a font whose glyph advance is
+    // N/2 — i.e. the generated size-40 font is exactly 2x the base size-20 font. This is what lets the
+    // integration test exercise the real markup path (parse -> GetAndCreateFontIfNecessary ->
+    // InMemoryFontCreator -> "BitmapFont" inline var -> measure) with no .fnt files on disk.
+    private class SizeProportionalFontCreator : IInMemoryFontCreator
+    {
+        public BitmapFont? TryCreateFont(BmfcSave bmfcSave)
+        {
+            int advance = bmfcSave.FontSize / 2;
+            BitmapFont font = new BitmapFont((Texture2D)null!, AbcFontData(advance, lineHeight: bmfcSave.FontSize));
+            font.SetFontPattern(256, 256);
+            return font;
+        }
+    }
+
+    // End-to-end repro for #3520: a [FontSize=40] run under WidthUnits=RelativeToChildren must be
+    // measured with the generated size-40 font, not the base font. The isolated Text-level tests pin the
+    // measurement math; this one drives the FULL runtime path a game uses — real BBCode parsing, real
+    // font generation (via the stub) — so it proves the fix holds where the manual test showed it failing.
+    // Assumption-free: it reads the actual base and swapped glyph advances off the live objects, so it
+    // pins the exact width delta from swapping "BB" to the larger font regardless of font resolution.
+    [Fact]
+    public void WrappedTextWidth_ShouldMeasureBbCodeFontSizeRun_WithGeneratedFont()
+    {
+        var previousCreator = CustomSetPropertyOnRenderable.InMemoryFontCreator;
+        CustomSetPropertyOnRenderable.InMemoryFontCreator = new SizeProportionalFontCreator();
+        try
+        {
+            TextRuntime plain = new();
+            plain.WidthUnits = DimensionUnitType.RelativeToChildren;
+            plain.Width = 0;
+            plain.Font = "StubFont3520";
+            plain.FontSize = 20;
+            plain.Text = "AA BB CC";
+            Text plainText = (Text)plain.RenderableComponent;
+            float plainWidth = plainText.WrappedTextWidth;
+            float baseBAdvance = plainText.BitmapFont.Characters['B'].XAdvance;
+
+            TextRuntime swapped = new();
+            swapped.WidthUnits = DimensionUnitType.RelativeToChildren;
+            swapped.Width = 0;
+            swapped.Font = "StubFont3520";
+            swapped.FontSize = 20;
+            // Same visible text "AA BB CC"; only "BB" is enlarged via a generated size-40 font.
+            swapped.Text = "AA [FontSize=40]BB[/FontSize] CC";
+            Text swappedText = (Text)swapped.RenderableComponent;
+            float swappedWidth = swappedText.WrappedTextWidth;
+
+            InlineVariable fontSwapVariable =
+                swappedText.InlineVariables.First(v => v.VariableName == "BitmapFont");
+            float swappedBAdvance = ((BitmapFont)fontSwapVariable.Value).Characters['B'].XAdvance;
+            swappedBAdvance.ShouldBeGreaterThan(baseBAdvance,
+                "Because the [FontSize=40] run must generate a larger font than the size-20 base");
+
+            // Swapping the two 'B' glyphs from the base font to the larger font widens the line by
+            // exactly 2 * (swapped - base). Everything else ("AA ", " CC") is identical base text.
+            double expectedWidth = plainWidth + 2 * (swappedBAdvance - baseBAdvance);
+            ((double)swappedWidth).ShouldBe(expectedWidth, expectedWidth * 0.02,
+                "because the [FontSize=40] run must be measured end-to-end with the generated size-40 font");
+        }
+        finally
+        {
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = previousCreator;
+        }
+    }
+
+    // Repro attempt for the manual-test structure the earlier tests missed: the box also holds a
+    // RelativeToParent background sibling (added BEFORE the text). FontScale needs no font generation, so
+    // this isolates whether the RelativeToParent sibling breaks the box's RelativeToChildren sizing.
+    [Fact]
+    public void RelativeToChildrenContainer_WithRelativeToParentBackground_ShouldContainFontScaleRun()
+    {
+        ContainerRuntime box = new();
+        box.WidthUnits = DimensionUnitType.RelativeToChildren;
+        box.Width = 0;
+        box.Height = 100;
+        box.HeightUnits = DimensionUnitType.Absolute;
+
+        ContainerRuntime background = new();
+        background.WidthUnits = DimensionUnitType.RelativeToParent;
+        background.Width = 0;
+        background.HeightUnits = DimensionUnitType.RelativeToParent;
+        background.Height = 0;
+        box.Children.Add(background);
+
+        TextRuntime text = new();
+        text.WidthUnits = DimensionUnitType.RelativeToChildren;
+        text.Width = 0;
+        text.Text = "This is [FontScale=2]big[/FontScale] text.";
+        box.Children.Add(text);
+
+        box.AddToRoot();
+
+        float textContentWidth = ((Text)text.RenderableComponent).WrappedTextWidth;
+        textContentWidth.ShouldBeGreaterThan(0);
+        box.GetAbsoluteWidth().ShouldBeGreaterThanOrEqualTo(textContentWidth,
+            "because the RelativeToChildren box must be at least as wide as its text, even with a RelativeToParent background sibling");
+    }
+
+    // The #3520 bug as the user reported it: a RelativeToChildren-width container wrapping a
+    // RelativeToChildren-width Text must grow to the FULL measured width of a [FontSize=40] run, so a
+    // background filling the container also contains the text (no tail spill). The Text-level test above
+    // pins WrappedTextWidth; this one pins that the parent container actually picks that width up through
+    // layout propagation — the container-containment invariant the manual test showed failing.
+    [Fact]
+    public void RelativeToChildrenContainer_ShouldContainBbCodeFontSizeRun()
+    {
+        var previousCreator = CustomSetPropertyOnRenderable.InMemoryFontCreator;
+        CustomSetPropertyOnRenderable.InMemoryFontCreator = new SizeProportionalFontCreator();
+        try
+        {
+            ContainerRuntime plainContainer = new();
+            plainContainer.WidthUnits = DimensionUnitType.RelativeToChildren;
+            plainContainer.Width = 0;
+            TextRuntime plainText = new();
+            plainText.WidthUnits = DimensionUnitType.RelativeToChildren;
+            plainText.Width = 0;
+            plainText.Font = "StubFont3520";
+            plainText.FontSize = 20;
+            plainText.Text = "AA BB CC";
+            plainContainer.Children.Add(plainText);
+            plainContainer.AddToRoot();
+            float plainContainerWidth = plainContainer.GetAbsoluteWidth();
+            float baseBAdvance = plainText.BitmapFont.Characters['B'].XAdvance;
+
+            ContainerRuntime swappedContainer = new();
+            swappedContainer.WidthUnits = DimensionUnitType.RelativeToChildren;
+            swappedContainer.Width = 0;
+            TextRuntime swappedText = new();
+            swappedText.WidthUnits = DimensionUnitType.RelativeToChildren;
+            swappedText.Width = 0;
+            swappedText.Font = "StubFont3520";
+            swappedText.FontSize = 20;
+            swappedText.Text = "AA [FontSize=40]BB[/FontSize] CC";
+            swappedContainer.Children.Add(swappedText);
+            swappedContainer.AddToRoot();
+            float swappedContainerWidth = swappedContainer.GetAbsoluteWidth();
+
+            InlineVariable fontSwapVariable = ((Text)swappedText.RenderableComponent)
+                .InlineVariables.First(v => v.VariableName == "BitmapFont");
+            float swappedBAdvance = ((BitmapFont)fontSwapVariable.Value).Characters['B'].XAdvance;
+
+            // The container must wrap its child exactly — this is the "background contains the text" case.
+            swappedContainerWidth.ShouldBe(swappedText.GetAbsoluteWidth(),
+                "because a RelativeToChildren container must size to its child's full measured width");
+
+            // And that width must include the enlarged run: swapping the two 'B' glyphs to the size-40
+            // font widens the container by 2 * (swapped - base) versus the all-base plain container.
+            double expectedWidth = plainContainerWidth + 2 * (swappedBAdvance - baseBAdvance);
+            ((double)swappedContainerWidth).ShouldBe(expectedWidth, expectedWidth * 0.02,
+                "because the container must grow to contain the [FontSize=40] run, not just the base-size text");
+        }
+        finally
+        {
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = previousCreator;
+        }
     }
 
     #endregion

--- a/RenderingLibrary/Graphics/Fonts/BitmapFont.cs
+++ b/RenderingLibrary/Graphics/Fonts/BitmapFont.cs
@@ -1352,11 +1352,20 @@ public class BitmapFont : IDisposable
                 // rather than the XAdvance. This
                 // might be so that icons sit snug
                 // against the end of their line of
-                // of text. 
-                if ((isLast && horizontalMeasurementStyle == HorizontalMeasurementStyle.TrimRight && 
-                    // Texture being null should never happen in real development, but we want to check for this with unit tests:
-                    Texture != null) 
-                    || (isLast && char.IsWhiteSpace(character)))
+                // of text.
+                // The last glyph is trimmed to its pixel extent (instead of its full XAdvance) only in
+                // TrimRight mode. Full always uses XAdvance for the last glyph — including a trailing
+                // space — matching its documented contract, so a run measured with Full advances exactly
+                // as it renders. That is required when a line is measured run-by-run for inline styling:
+                // an interior run ending in a space must keep that space's advance or the line is
+                // under-measured, leaving a RelativeToChildren container too narrow (#3520).
+                bool trimLastGlyph = isLast &&
+                    horizontalMeasurementStyle == HorizontalMeasurementStyle.TrimRight &&
+                    // Texture null shouldn't happen in real dev (it is checked for in unit tests);
+                    // whitespace has no glyph pixels, so it is trimmed whether or not a texture is present.
+                    (Texture != null || char.IsWhiteSpace(character));
+
+                if (trimLastGlyph)
                 {
                     if (character == '\n')
                     {

--- a/RenderingLibrary/Graphics/Text.cs
+++ b/RenderingLibrary/Graphics/Text.cs
@@ -1547,14 +1547,31 @@ public class Text : SpriteBatchRenderableBase, IRenderableIpso, IVisible, IWrapp
                 {
                     var substring = substrings[substringIndex];
                     float runScale = effectiveFontScale;
+                    // A [FontSize=N] run swaps in a font generated at that size (a "BitmapFont" run),
+                    // which DrawWithInlineVariables draws the glyphs with. Measure the run with that same
+                    // font so the reported width matches what is drawn — otherwise a run in a larger font
+                    // is measured at the base size and a RelativeToChildren Text is sized too narrow (#3520).
+                    BitmapFont runFont = mBitmapFont;
                     for (int variableIndex = 0; variableIndex < substring.Variables.Count; variableIndex++)
                     {
-                        if (substring.Variables[variableIndex].VariableName == nameof(FontScale))
+                        var variable = substring.Variables[variableIndex];
+                        if (variable.VariableName == nameof(FontScale))
                         {
-                            runScale = (float)substring.Variables[variableIndex].Value * SystemManagers.GlobalFontScale;
+                            runScale = (float)variable.Value * SystemManagers.GlobalFontScale;
+                        }
+                        else if (variable.VariableName == nameof(BitmapFont))
+                        {
+                            runFont = (BitmapFont)variable.Value;
                         }
                     }
-                    lineWidthAtScale += mBitmapFont.MeasureString(substring.Substring) * runScale;
+                    // Only the final run of the line is measured with TrimRight (matching the whole-line
+                    // MeasureString the plain path uses); interior runs must use Full, or each run
+                    // boundary trims its last glyph (often a space before the next run) and the line is
+                    // under-measured — leaving a RelativeToChildren container too narrow (#3520).
+                    var measurementStyle = substringIndex == substrings.Count - 1
+                        ? HorizontalMeasurementStyle.TrimRight
+                        : HorizontalMeasurementStyle.Full;
+                    lineWidthAtScale += runFont.MeasureString(substring.Substring, measurementStyle) * runScale;
                     maxRunScale = System.Math.Max(maxRunScale, runScale);
                 }
                 lineHeightFactor = maxRunScale / effectiveFontScale;


### PR DESCRIPTION
## What

Part of #3520 — the **width-reporting** half. A `Text` sized `WidthUnits = RelativeToChildren` (and any container sized to it) was measured too narrow when it contained inline BBCode runs, so the rendered text spilled past its background / RelativeToChildren box. Affects both `[FontSize]` (font-swap) and `[FontScale]` runs.

## Root cause

Two independent bugs in the per-run measurement (`Text.GetInlineVariableAwareWidthAndHeight`):

1. **Font-swap runs measured with the base font.** A `[FontSize=N]` run swaps in a font generated at that size, but the width pass still measured it with the base font, ignoring the enlarged run's extra width.
2. **Per-run last-glyph trimming.** `BitmapFont.MeasureString` defaults to `TrimRight`, which trims the *last glyph of each measured string* to its pixel extent. Measuring per-run trimmed at **every run boundary** instead of once per line, so an interior run ending in a space (e.g. `"This is "` before a styled word) lost that space's advance. The trailing-whitespace trim also fired regardless of measurement style, violating `Full`'s documented `XAdvance` contract.

A uniform stub font (`width == xadvance`) hid this in earlier tests — only a real, variable-metric font (Arial) exposed it.

## Fix

- Measure each run with **its own font** (matching the render path).
- The last-glyph trim in `BitmapFont.MeasureString` now applies **only in `TrimRight` mode**, so `Full` truly uses `XAdvance` (trailing space included).
- Interior runs measure with `Full`; only the **final** run of the line uses `TrimRight` — matching whole-line / plain-text width and the render's full-advance inter-run spacing.

## Tests (red-first)

Repros at three levels using a **real-metrics (non-uniform) font**:
- `BitmapFont.MeasureString` `Full`-vs-`TrimRight` trailing-space contract (21 → 30).
- `Text` — a Color run (no size change) must not alter measured line width (71 → 80).
- `TextRuntime` / container — a `[FontSize]` font-swap run and a RelativeToChildren container that contains it.

All suites green: **MonoGameGum 1814, SkiaGum 197, RaylibGum 446**. `TextBoxTests` (the other `Full` caller — caret math) unaffected.

Manually verified in a MonoGame sample: `[FontSize]`, `[FontScale]`, and plain rows all fully contain their text.

## Scope / not closing

This is **Part of #3520**, not a full close. Still open:
- The **wrapping** half (`IWrappedText.UpdateLines` still decides breaks at the base font — the issue's titled concern).
- The **raylib-native** renderable (`RaylibGum/Renderables/Text.cs` measures via raylib `MeasureTextEx`, not `BitmapFont`; also needs `[FontSize]` font-swap support, #3471).

Note: the branch is issue-linked, so merging will auto-close #3520 — reopen it for the remaining halves.
