### PR TITLE
Add raylib inline [FontSize] BBCode font-swap (#3524)

### DIFF
--- a/MonoGameGum.Tests/Runtimes/TextRuntimeTests.cs
+++ b/MonoGameGum.Tests/Runtimes/TextRuntimeTests.cs
@@ -280,6 +280,47 @@ char id=67 x=0 y=0 width={xadvance} height=13 xoffset=0 yoffset=4 xadvance={xadv
         }
     }
 
+    // #3524 (the height half of #3520): a [FontSize=N] font-swap run must also drive the reported line
+    // HEIGHT, not just the width. #3523 fixed width (measure each run with its swapped font) but left
+    // height on the FontScale-only path, so the tallest run's taller generated font was ignored and a
+    // RelativeToChildren box stayed base-height while the enlarged run spilled above/below it. The stub
+    // font's lineHeight == FontSize, so the size-40 swap font is exactly 2x the size-20 base.
+    [Fact]
+    public void WrappedTextHeight_ShouldGrow_WhenLineHasBbCodeFontSizeRun()
+    {
+        var previousCreator = CustomSetPropertyOnRenderable.InMemoryFontCreator;
+        CustomSetPropertyOnRenderable.InMemoryFontCreator = new SizeProportionalFontCreator();
+        try
+        {
+            TextRuntime plain = new();
+            plain.WidthUnits = DimensionUnitType.RelativeToChildren;
+            plain.Width = 0;
+            plain.Font = "StubFont3520";
+            plain.FontSize = 20;
+            plain.Text = "AA BB CC";
+            Text plainText = (Text)plain.RenderableComponent;
+            float plainHeight = plainText.WrappedTextHeight;
+            plainHeight.ShouldBeGreaterThan(0);
+
+            TextRuntime swapped = new();
+            swapped.WidthUnits = DimensionUnitType.RelativeToChildren;
+            swapped.Width = 0;
+            swapped.Font = "StubFont3520";
+            swapped.FontSize = 20;
+            // Same visible text; only "BB" is enlarged via a generated size-40 font (lineHeight 40).
+            swapped.Text = "AA [FontSize=40]BB[/FontSize] CC";
+            Text swappedText = (Text)swapped.RenderableComponent;
+            float swappedHeight = swappedText.WrappedTextHeight;
+
+            swappedHeight.ShouldBe(plainHeight * 2, plainHeight * 0.02,
+                "because the [FontSize=40] run's taller size-40 font (lineHeight 40 vs the base's 20) must drive the measured line height");
+        }
+        finally
+        {
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = previousCreator;
+        }
+    }
+
     // Repro attempt for the manual-test structure the earlier tests missed: the box also holds a
     // RelativeToParent background sibling (added BEFORE the text). FontScale needs no font generation, so
     // this isolates whether the RelativeToParent sibling breaks the box's RelativeToChildren sizing.

--- a/RenderingLibrary/Graphics/Text.cs
+++ b/RenderingLibrary/Graphics/Text.cs
@@ -1552,16 +1552,27 @@ public class Text : SpriteBatchRenderableBase, IRenderableIpso, IVisible, IWrapp
                     // font so the reported width matches what is drawn — otherwise a run in a larger font
                     // is measured at the base size and a RelativeToChildren Text is sized too narrow (#3520).
                     BitmapFont runFont = mBitmapFont;
+                    // Height factor for this run relative to the base line height. A [FontScale] run scales
+                    // it directly; a [FontSize=N] swap run's taller generated font scales it by the ratio of
+                    // line heights, so the reported line grows to the swapped font's height. Without this the
+                    // height stays on the base font and a RelativeToChildren box is too short, letting the
+                    // enlarged run spill vertically — the height half of the #3520/#3523 width fix (#3524).
+                    float runHeightScale = effectiveFontScale;
                     for (int variableIndex = 0; variableIndex < substring.Variables.Count; variableIndex++)
                     {
                         var variable = substring.Variables[variableIndex];
                         if (variable.VariableName == nameof(FontScale))
                         {
                             runScale = (float)variable.Value * SystemManagers.GlobalFontScale;
+                            runHeightScale = runScale;
                         }
                         else if (variable.VariableName == nameof(BitmapFont))
                         {
                             runFont = (BitmapFont)variable.Value;
+                            if (mBitmapFont != null && mBitmapFont.LineHeightInPixels > 0)
+                            {
+                                runHeightScale = effectiveFontScale * runFont.LineHeightInPixels / mBitmapFont.LineHeightInPixels;
+                            }
                         }
                     }
                     // Only the final run of the line is measured with TrimRight (matching the whole-line
@@ -1572,7 +1583,7 @@ public class Text : SpriteBatchRenderableBase, IRenderableIpso, IVisible, IWrapp
                         ? HorizontalMeasurementStyle.TrimRight
                         : HorizontalMeasurementStyle.Full;
                     lineWidthAtScale += runFont.MeasureString(substring.Substring, measurementStyle) * runScale;
-                    maxRunScale = System.Math.Max(maxRunScale, runScale);
+                    maxRunScale = System.Math.Max(maxRunScale, runHeightScale);
                 }
                 lineHeightFactor = maxRunScale / effectiveFontScale;
                 lineWidthInBaseUnits = lineWidthAtScale / effectiveFontScale;

--- a/Runtimes/RaylibGum/Renderables/CustomSetPropertyOnRenderable.cs
+++ b/Runtimes/RaylibGum/Renderables/CustomSetPropertyOnRenderable.cs
@@ -742,15 +742,19 @@ public class CustomSetPropertyOnRenderable
                     break;
                 case "FontSize":
                     {
-                        // #3524: [FontSize=N] is an ABSOLUTE per-run pixel size (unlike [FontScale], which
-                        // is a multiplier). Store the raw size; Text.DrawStyledLine and
-                        // Text.GetInlineVariableAwareWidthAndHeight convert it to the equivalent atlas scale
-                        // (N / BaseSize) at draw/measure time so both use the same per-run size. Parsed as an
-                        // int to match the MonoGame font-swap path, then stored as float so the shared per-run
-                        // scale resolver can read it with a single (float) cast alongside FontScale.
+                        // #3524: [FontSize=N] swaps the font for the run to one rasterized at N (matching
+                        // the MonoGame BitmapFont swap). When a font creator is wired we re-rasterize a
+                        // crisp Raylib_cs.Font at N and store it as the run value; the run then draws with
+                        // that font at its native size. When no creator is available, store the raw size as
+                        // a float and let Text scale the base atlas to N (a blurry-but-correct fallback).
+                        // Either way Text measures the run at exactly the size it draws.
                         if (int.TryParse(item.Open.Argument, NumberStyles.Integer, CultureInfo.InvariantCulture, out int parsedSize))
                         {
-                            castedValue = (float)parsedSize;
+                            var textRuntime = graphicalUiElement as TextRuntime;
+                            Raylib_cs.Font? swapFont = textRuntime != null
+                                ? TryGetOrCreateFontAtSize(textRuntime, parsedSize)
+                                : null;
+                            castedValue = swapFont.HasValue ? (object)swapFont.Value : (float)parsedSize;
                             shouldApply = true;
                         }
                     }
@@ -775,6 +779,72 @@ public class CustomSetPropertyOnRenderable
         // that the runs are populated so the reported size accounts for per-line scale (otherwise a
         // tall run overflows its slot and overlaps the next stacked sibling).
         asText.UpdatePreRenderDimensions();
+    }
+
+    /// <summary>
+    /// Re-rasterizes (or returns a cached) <see cref="Raylib_cs.Font"/> for <paramref name="textRuntime"/>'s
+    /// font family/style but at <paramref name="fontSize"/>, used for inline [FontSize=N] BBCode runs (#3524).
+    /// This is the per-run mirror of the base-font creation in <see cref="UpdateToFontValues"/>: it copies the
+    /// runtime's font-generation fields, overrides only the size, and creates the font via
+    /// <see cref="InMemoryFontCreator"/>, caching it in the shared LoaderManager under the same FontCache key
+    /// the base path uses (so a base text and a run at the same size share one atlas). Returns null when no
+    /// creator is wired or creation fails; the caller then falls back to scaling the base atlas.
+    /// </summary>
+    private static Raylib_cs.Font? TryGetOrCreateFontAtSize(TextRuntime textRuntime, int fontSize)
+    {
+        if (InMemoryFontCreator == null || fontSize <= 0)
+        {
+            return null;
+        }
+
+        var loaderManager = global::RenderingLibrary.Content.LoaderManager.Self;
+
+        try
+        {
+            string? bbCodeFontFilePath = BmfcSave.IsFontFilePath(textRuntime.Font) ? textRuntime.Font : null;
+            string fontCacheName = BmfcSave.GetFontCacheFileNameFor(
+                fontSize,
+                textRuntime.Font,
+                textRuntime.OutlineThickness,
+                textRuntime.UseFontSmoothing,
+                textRuntime.IsItalic,
+                textRuntime.IsBold,
+                bbCodeFontFilePath);
+            string fullFileName = ToolsUtilities.FileManager.Standardize(fontCacheName, preserveCase: true, makeAbsolute: true);
+
+            // Reuse an already-generated font (its Raylib_cs.Font wraps an unmanaged GPU texture, so
+            // regenerating every layout would leak VRAM). Mirrors the base-font cache check.
+            if (loaderManager.GetDisposable(fullFileName) is ManagedFont cachedManagedFont
+                && cachedManagedFont.Font.BaseSize != 0)
+            {
+                return cachedManagedFont.Font;
+            }
+
+            BmfcSave bmfcSave = new BmfcSave();
+            textRuntime.CopyFontGenerationFieldsTo(bmfcSave, resolvedFontFilePath: null);
+            // The swap: keep the family/style, change only the size to the tag's value.
+            bmfcSave.FontSize = fontSize;
+
+            var gumProject = ObjectFinder.Self.GumProjectSave;
+            bmfcSave.Ranges = gumProject?.FontRanges ?? BmfcSave.GetEffectiveDefaultRanges();
+            bmfcSave.SpacingHorizontal = gumProject?.FontSpacingHorizontal ?? 1;
+            bmfcSave.SpacingVertical = gumProject?.FontSpacingVertical ?? 1;
+
+            Raylib_cs.Font? createdFont = InMemoryFontCreator.TryCreateFont(bmfcSave);
+            if (createdFont.HasValue && createdFont.Value.BaseSize != 0)
+            {
+                // Dispose first so a poisoned empty slot (see the base path) can't make AddDisposable throw.
+                loaderManager.Dispose(fullFileName);
+                loaderManager.AddDisposable(fullFileName, new ManagedFont(createdFont.Value));
+                return createdFont.Value;
+            }
+        }
+        catch
+        {
+            // Fall through to null - the caller uses the base-atlas scale fallback.
+        }
+
+        return null;
     }
 
     // For some reason this crashes on web when uploading to itch:

--- a/Runtimes/RaylibGum/Renderables/CustomSetPropertyOnRenderable.cs
+++ b/Runtimes/RaylibGum/Renderables/CustomSetPropertyOnRenderable.cs
@@ -687,9 +687,9 @@ public class CustomSetPropertyOnRenderable
 
     /// <summary>
     /// Parses BBCode markup, assigns the tag-stripped text to <see cref="Text.RawText"/>, and populates
-    /// <see cref="Text.InlineVariables"/> with the Color / FontScale runs the Raylib renderer applies per run.
-    /// Font-swap and Custom per-letter tags are recognized (so their tags are stripped from the visible text)
-    /// but are not yet applied on the Raylib runtime - see #3471.
+    /// <see cref="Text.InlineVariables"/> with the Color / FontScale / FontSize runs the Raylib renderer
+    /// applies per run. [Font=Name] family swaps and Custom per-letter tags are recognized (so their tags
+    /// are stripped from the visible text) but are not yet applied on the Raylib runtime - see #3471 / #3524.
     /// </summary>
     private static void SetBbCodeText(Text asText, GraphicalUiElement graphicalUiElement, string bbcode)
     {
@@ -740,7 +740,22 @@ public class CustomSetPropertyOnRenderable
                         }
                     }
                     break;
-                    // Font / Custom / IsBold / etc. are intentionally not handled here on the first pass (#3471).
+                case "FontSize":
+                    {
+                        // #3524: [FontSize=N] is an ABSOLUTE per-run pixel size (unlike [FontScale], which
+                        // is a multiplier). Store the raw size; Text.DrawStyledLine and
+                        // Text.GetInlineVariableAwareWidthAndHeight convert it to the equivalent atlas scale
+                        // (N / BaseSize) at draw/measure time so both use the same per-run size. Parsed as an
+                        // int to match the MonoGame font-swap path, then stored as float so the shared per-run
+                        // scale resolver can read it with a single (float) cast alongside FontScale.
+                        if (int.TryParse(item.Open.Argument, NumberStyles.Integer, CultureInfo.InvariantCulture, out int parsedSize))
+                        {
+                            castedValue = (float)parsedSize;
+                            shouldApply = true;
+                        }
+                    }
+                    break;
+                    // Font / Custom / IsBold family swaps are still not handled here (deferred per #3471).
             }
 
             if (shouldApply)

--- a/Runtimes/RaylibGum/Renderables/Text.cs
+++ b/Runtimes/RaylibGum/Renderables/Text.cs
@@ -847,35 +847,82 @@ public class Text : IVisible, IRenderableIpso,
     }
 
     /// <summary>
-    /// Resolves the effective per-run scale for a styled run: the base <see cref="FontScale"/> unless the
-    /// run carries a [FontScale] (a multiplier) or [FontSize] (an absolute pixel size) tag. A [FontSize=N]
-    /// run is converted to the atlas scale (N / BaseSize) that renders and measures the run at N px, since
-    /// Raylib draws by scaling the base font atlas rather than swapping in a re-rasterized font. Shared by
-    /// <see cref="DrawStyledLine"/> and <see cref="GetInlineVariableAwareWidthAndHeight"/> so the drawn and
-    /// measured size of a run cannot diverge (issue #3524).
+    /// The font, draw size, and layout scale a styled run resolves to. <see cref="Font"/> is the actual
+    /// Raylib font used to draw and measure the run (the base font, or a per-run [FontSize] swap font);
+    /// <see cref="DrawSize"/> is the pixel size passed to DrawTextPro/MeasureTextEx; <see cref="LayoutScale"/>
+    /// is the run's size relative to the base font's metrics, used for baseline/height layout.
     /// </summary>
-    private float ResolveRunFontScale(List<InlineVariable> variables)
+    private readonly struct ResolvedRunFont
     {
-        float runScale = FontScale;
+        public readonly Font Font;
+        public readonly float DrawSize;
+        public readonly float LayoutScale;
+
+        public ResolvedRunFont(Font font, float drawSize, float layoutScale)
+        {
+            Font = font;
+            DrawSize = drawSize;
+            LayoutScale = layoutScale;
+        }
+    }
+
+    /// <summary>
+    /// Resolves the font/size a styled run draws and is measured with. A [FontScale=v] run keeps the base
+    /// font at v times the base size. A [FontSize=N] run either swaps in a font re-rasterized at N (crisp;
+    /// its inline value is a <see cref="Font"/>) drawn at its native size, or - when no font creator was
+    /// wired so no swap font could be built - falls back to scaling the base atlas to N px (its inline value
+    /// is a float). Shared by <see cref="DrawStyledLine"/> (draw) and
+    /// <see cref="GetInlineVariableAwareWidthAndHeight"/> (measure) so the drawn and measured size of a run
+    /// cannot diverge - that drift is what reproduced the RelativeToChildren spill (#3524).
+    /// </summary>
+    private ResolvedRunFont ResolveRunFont(List<InlineVariable> variables)
+    {
+        Font drawFont = _font;
+        bool hasSwapFont = false;
+        float scale = FontScale;
+        float? absolutePixelSize = null;
+
         foreach (var variable in variables)
         {
             switch (variable.VariableName)
             {
                 case nameof(FontScale):
-                    runScale = (float)variable.Value;
+                    scale = (float)variable.Value;
                     break;
                 case nameof(FontSize):
-                    // Divide by the same BaseSize MeasureString measures at, so the resulting scale
-                    // draws/measures the run at exactly the requested absolute pixel size.
-                    float baseSize = _font.BaseSize;
-                    if (baseSize > 0)
+                    if (variable.Value is Font swapFont && swapFont.BaseSize > 0)
                     {
-                        runScale = (float)variable.Value / baseSize;
+                        drawFont = swapFont;
+                        hasSwapFont = true;
+                    }
+                    else if (variable.Value is float pixelSize)
+                    {
+                        absolutePixelSize = pixelSize;
                     }
                     break;
             }
         }
-        return runScale;
+
+        float baseSize = _font.BaseSize;
+        float drawSize;
+        if (hasSwapFont)
+        {
+            // A crisp font rasterized at the requested size: draw it at its native size times the base
+            // render scale, exactly as MonoGame renders a swapped BitmapFont.
+            drawSize = drawFont.BaseSize * FontScale;
+        }
+        else if (absolutePixelSize.HasValue)
+        {
+            // No font creator wired: approximate the swap by scaling the base atlas to the absolute size.
+            drawSize = absolutePixelSize.Value * FontScale;
+        }
+        else
+        {
+            drawSize = baseSize * scale;
+        }
+
+        float layoutScale = baseSize > 0 ? drawSize / baseSize : scale;
+        return new ResolvedRunFont(drawFont, drawSize, layoutScale);
     }
 
     /// <summary>
@@ -886,9 +933,13 @@ public class Text : IVisible, IRenderableIpso,
     /// </summary>
     private void DrawStyledLine(Font fontValue, List<StyledSubstring> substrings, Vector2 linePosition, float absoluteLeft, float originY)
     {
-        // First pass: resolve each run's effective color/scale and measured width, plus the line totals
-        // needed for horizontal alignment (total width) and baseline alignment (tallest run's baseline).
+        // First pass: resolve each run's effective color, font/size and measured width, plus the line
+        // totals needed for horizontal alignment (total width) and baseline alignment (tallest run's
+        // baseline). The font, draw size and layout scale come from the shared resolver, so draw and
+        // measure use the same per-run font and cannot diverge (issue #3524).
         var runColors = new Color[substrings.Count];
+        var runFonts = new Font[substrings.Count];
+        var runDrawSizes = new float[substrings.Count];
         var runScales = new float[substrings.Count];
         var runWidths = new float[substrings.Count];
         float totalWidth = 0;
@@ -898,9 +949,7 @@ public class Text : IVisible, IRenderableIpso,
         {
             var run = substrings[s];
             var runColor = Color;
-            // Scale (FontScale multiplier and FontSize absolute-px swap) is resolved by the shared helper
-            // so this draw loop and GetInlineVariableAwareWidthAndHeight can never diverge (issue #3524).
-            var runScale = ResolveRunFontScale(run.Variables);
+            var resolvedFont = ResolveRunFont(run.Variables);
 
             foreach (var variable in run.Variables)
             {
@@ -925,10 +974,12 @@ public class Text : IVisible, IRenderableIpso,
             }
 
             runColors[s] = runColor;
-            runScales[s] = runScale;
-            runWidths[s] = MeasureTextEx(fontValue, run.Substring, fontValue.BaseSize * runScale, 0).X;
+            runFonts[s] = resolvedFont.Font;
+            runDrawSizes[s] = resolvedFont.DrawSize;
+            runScales[s] = resolvedFont.LayoutScale;
+            runWidths[s] = MeasureTextEx(resolvedFont.Font, run.Substring, resolvedFont.DrawSize, 0).X;
             totalWidth += runWidths[s];
-            maxScale = System.Math.Max(maxScale, runScale);
+            maxScale = System.Math.Max(maxScale, resolvedFont.LayoutScale);
         }
 
         float maxBaseline = (LineHeightInPixels - _descenderHeight) * maxScale;
@@ -958,7 +1009,7 @@ public class Text : IVisible, IRenderableIpso,
             runPosition = SnapToPixelIfNeeded(runPosition);
             runOrigin = SnapToPixelIfNeeded(runOrigin);
 
-            DrawTextPro(fontValue, substrings[s].Substring, runPosition, runOrigin, 0, fontValue.BaseSize * runScale, 0, runColors[s]);
+            DrawTextPro(runFonts[s], substrings[s].Substring, runPosition, runOrigin, 0, runDrawSizes[s], 0, runColors[s]);
 
             advance += runWidths[s];
         }
@@ -1037,11 +1088,12 @@ public class Text : IVisible, IRenderableIpso,
                 for (int substringIndex = 0; substringIndex < substrings.Count; substringIndex++)
                 {
                     var substring = substrings[substringIndex];
-                    // Same helper the draw loop uses, so a run is measured at exactly the size it is
-                    // drawn - draw/measure drift is what reproduced the RelativeToChildren spill (#3524).
-                    float runScale = ResolveRunFontScale(substring.Variables);
-                    lineWidthAtScale += MeasureString(substring.Substring) * runScale;
-                    maxRunScale = System.Math.Max(maxRunScale, runScale);
+                    // Same resolver the draw loop uses, measured with the same per-run font at the same
+                    // size, so a run is measured at exactly the size it is drawn - draw/measure drift is
+                    // what reproduced the RelativeToChildren spill (#3524).
+                    var resolvedFont = ResolveRunFont(substring.Variables);
+                    lineWidthAtScale += MeasureTextEx(resolvedFont.Font, substring.Substring, resolvedFont.DrawSize, 0).X;
+                    maxRunScale = System.Math.Max(maxRunScale, resolvedFont.LayoutScale);
                 }
                 lineHeightFactor = maxRunScale / baseScale;
                 lineWidthInBaseUnits = lineWidthAtScale / baseScale;

--- a/Runtimes/RaylibGum/Renderables/Text.cs
+++ b/Runtimes/RaylibGum/Renderables/Text.cs
@@ -617,10 +617,10 @@ public class Text : IVisible, IRenderableIpso,
     public string? StoredMarkupText { get; set; }
 
     /// <summary>
-    /// The inline styling variables (Color / FontScale runs) parsed from BBCode markup assigned to
-    /// this Text. Populated by the property pipeline when the assigned text contains markup tags;
-    /// empty for plain text. Consumed by <see cref="Render"/> to draw per-run styling. Custom
-    /// per-letter callbacks and per-run Font swaps are not yet applied on the Raylib runtime (#3471).
+    /// The inline styling variables (Color / FontScale / FontSize runs) parsed from BBCode markup assigned
+    /// to this Text. Populated by the property pipeline when the assigned text contains markup tags; empty
+    /// for plain text. Consumed by <see cref="Render"/> to draw per-run styling. Custom per-letter callbacks
+    /// and [Font=Name] family swaps are not yet applied on the Raylib runtime (#3471).
     /// </summary>
     public List<InlineVariable> InlineVariables { get; private set; }
 
@@ -847,10 +847,42 @@ public class Text : IVisible, IRenderableIpso,
     }
 
     /// <summary>
-    /// Draws a single line as a sequence of styled runs (BBCode markup), applying per-run Color / FontScale.
-    /// Runs are laid out left-to-right and baseline-aligned so a larger FontScale run sits on the same
-    /// baseline as its neighbors. Custom per-letter callbacks and per-run Font swaps are not applied here
-    /// on the Raylib runtime yet (#3471).
+    /// Resolves the effective per-run scale for a styled run: the base <see cref="FontScale"/> unless the
+    /// run carries a [FontScale] (a multiplier) or [FontSize] (an absolute pixel size) tag. A [FontSize=N]
+    /// run is converted to the atlas scale (N / BaseSize) that renders and measures the run at N px, since
+    /// Raylib draws by scaling the base font atlas rather than swapping in a re-rasterized font. Shared by
+    /// <see cref="DrawStyledLine"/> and <see cref="GetInlineVariableAwareWidthAndHeight"/> so the drawn and
+    /// measured size of a run cannot diverge (issue #3524).
+    /// </summary>
+    private float ResolveRunFontScale(List<InlineVariable> variables)
+    {
+        float runScale = FontScale;
+        foreach (var variable in variables)
+        {
+            switch (variable.VariableName)
+            {
+                case nameof(FontScale):
+                    runScale = (float)variable.Value;
+                    break;
+                case nameof(FontSize):
+                    // Divide by the same BaseSize MeasureString measures at, so the resulting scale
+                    // draws/measures the run at exactly the requested absolute pixel size.
+                    float baseSize = _font.BaseSize;
+                    if (baseSize > 0)
+                    {
+                        runScale = (float)variable.Value / baseSize;
+                    }
+                    break;
+            }
+        }
+        return runScale;
+    }
+
+    /// <summary>
+    /// Draws a single line as a sequence of styled runs (BBCode markup), applying per-run Color and per-run
+    /// size (FontScale multiplier or FontSize absolute-px swap). Runs are laid out left-to-right and
+    /// baseline-aligned so a larger run sits on the same baseline as its neighbors. Custom per-letter
+    /// callbacks and [Font=Name] family swaps are not applied here on the Raylib runtime yet (#3471).
     /// </summary>
     private void DrawStyledLine(Font fontValue, List<StyledSubstring> substrings, Vector2 linePosition, float absoluteLeft, float originY)
     {
@@ -866,7 +898,9 @@ public class Text : IVisible, IRenderableIpso,
         {
             var run = substrings[s];
             var runColor = Color;
-            var runScale = FontScale;
+            // Scale (FontScale multiplier and FontSize absolute-px swap) is resolved by the shared helper
+            // so this draw loop and GetInlineVariableAwareWidthAndHeight can never diverge (issue #3524).
+            var runScale = ResolveRunFontScale(run.Variables);
 
             foreach (var variable in run.Variables)
             {
@@ -886,9 +920,6 @@ public class Text : IVisible, IRenderableIpso,
                         break;
                     case nameof(Blue):
                         runColor = new Color(runColor.R, runColor.G, (byte)variable.Value, runColor.A);
-                        break;
-                    case nameof(FontScale):
-                        runScale = (float)variable.Value;
                         break;
                 }
             }
@@ -1006,14 +1037,9 @@ public class Text : IVisible, IRenderableIpso,
                 for (int substringIndex = 0; substringIndex < substrings.Count; substringIndex++)
                 {
                     var substring = substrings[substringIndex];
-                    float runScale = baseScale;
-                    for (int variableIndex = 0; variableIndex < substring.Variables.Count; variableIndex++)
-                    {
-                        if (substring.Variables[variableIndex].VariableName == nameof(FontScale))
-                        {
-                            runScale = (float)substring.Variables[variableIndex].Value;
-                        }
-                    }
+                    // Same helper the draw loop uses, so a run is measured at exactly the size it is
+                    // drawn - draw/measure drift is what reproduced the RelativeToChildren spill (#3524).
+                    float runScale = ResolveRunFontScale(substring.Variables);
                     lineWidthAtScale += MeasureString(substring.Substring) * runScale;
                     maxRunScale = System.Math.Max(maxRunScale, runScale);
                 }

--- a/Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/TextScreen.cs
+++ b/Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/TextScreen.cs
@@ -9,15 +9,16 @@ using RenderingLibrary.Graphics;
 
 namespace MonoGameGumInCode.Screens;
 
-// Reference screen for TextRuntime font behavior. Raylib and SilkNetGum mirror the KernSmith
-// baked-shadow rows where that backend supports them (#3414 / #2724).
-//
-// Section order in this file must match the raylib and SilkNetGum TextScreen.cs mirrors
-// (Samples/raylib/Screens/TextScreen.cs, Samples/SilkNetGum/SilkNetGum/Screens/TextScreen.cs)
-// exactly, top to bottom - before adding, removing, or reordering ANY section, check the sibling
-// files for the same change or the side-by-side comparison breaks silently. (Broke once when this
-// file carried extra AddCustomOutlineText rows raylib never had, pushing every later section down
-// three rows relative to raylib - #3496.)
+// Reference screen for TextRuntime font behavior. The raylib and SilkNetGum TextScreen.cs mirrors
+// (Samples/raylib/Screens/TextScreen.cs, Samples/SilkNetGum/SilkNetGum/Screens/TextScreen.cs) match
+// this file section-for-section where the backend supports the same surface, so a per-backend
+// rendering difference stands out as a backend bug. Before adding, removing, or reordering ANY
+// section, make the same change in the siblings or the side-by-side comparison breaks silently
+// (#3414 / #3496). Only genuinely backend-specific things may differ: the color type
+// (Microsoft.Xna.Framework.Color vs Raylib_cs.Color), the TextRenderingPositionMode enum namespace,
+// and AddTextureFilterSection's mechanism (a per-layer sampler state here vs a baked font-cache
+// texture on raylib). SilkNetGum legitimately omits the BBCode / Blend / TextureFilter sections
+// because SkiaGum renders via RichTextKit rather than a font atlas.
 internal class TextScreen : FrameworkElement
 {
     public TextScreen() : base(new ContainerRuntime())
@@ -81,12 +82,68 @@ internal class TextScreen : FrameworkElement
         container.Children.Add(shadowOutline);
 
         var withOutline = new TextRuntime();
-        withOutline.Text = "I am text that has an outline.";
-        (withOutline.Component as Text).RenderBoundary = true;
+        withOutline.Text = "I am text with OutlineThickness = 2";
+        withOutline.FontSize = 24;
+        withOutline.OutlineThickness = 2;
         container.Children.Add(withOutline);
 
+        BuildTextParitySection(container);
+    }
+
+    // Text parity features (#3432): Blend, per-instance TextRenderingPositionMode override, and
+    // GetCharacterIndexAtPosition. All three are runtime-observable, so this section is the manual
+    // verification surface for the parity batch. Kept in step with the raylib mirror.
+    private static void BuildTextParitySection(ContainerRuntime container)
+    {
         AddBlendOnTextSection(container);
         AddTextureFilterSection(container);
+
+        // --- Per-instance TextRenderingPositionMode override, at a fractional origin ---
+        AddSectionLabel(container, "TextRenderingPositionMode (#3432): fractional origin; button toggles snap");
+        var snapText = new TextRuntime();
+        snapText.FontSize = 20;
+        snapText.X = 120.5f;
+        snapText.Text = "Fractional X=120.5 - SnapToPixel";
+        snapText.TextRenderingPositionMode = RenderingLibrary.Graphics.TextRenderingPositionMode.SnapToPixel;
+        container.Children.Add(snapText);
+
+        var toggleButton = new Button();
+        toggleButton.Text = "Toggle snap mode";
+        toggleButton.Click += (_, _) =>
+        {
+            if (snapText.TextRenderingPositionMode == RenderingLibrary.Graphics.TextRenderingPositionMode.SnapToPixel)
+            {
+                snapText.TextRenderingPositionMode = RenderingLibrary.Graphics.TextRenderingPositionMode.FreeFloating;
+                snapText.Text = "Fractional X=120.5 - FreeFloating";
+            }
+            else
+            {
+                snapText.TextRenderingPositionMode = RenderingLibrary.Graphics.TextRenderingPositionMode.SnapToPixel;
+                snapText.Text = "Fractional X=120.5 - SnapToPixel";
+            }
+        };
+        container.Children.Add(toggleButton.Visual);
+
+        // --- GetCharacterIndexAtPosition: click the text, report the hit index ---
+        AddSectionLabel(container, "GetCharacterIndexAtPosition (#3432): click the text below");
+        var hitText = new TextRuntime();
+        hitText.FontSize = 24;
+        hitText.Text = "Click me to report the character index";
+        hitText.HasEvents = true;
+        container.Children.Add(hitText);
+
+        var hitResult = new TextRuntime();
+        hitResult.FontSize = 16;
+        hitResult.Text = "(no click yet)";
+        container.Children.Add(hitResult);
+
+        hitText.Click += (_, _) =>
+        {
+            float cursorX = FrameworkElement.MainCursor.XRespectingGumZoomAndBounds();
+            float cursorY = FrameworkElement.MainCursor.YRespectingGumZoomAndBounds();
+            int index = hitText.GetCharacterIndexAtPosition(cursorX, cursorY);
+            hitResult.Text = $"Character index at click: {index}";
+        };
     }
 
     // Texture filter on Text (#3496): a font baked SMALL then magnified via FontScale, so
@@ -132,67 +189,6 @@ internal class TextScreen : FrameworkElement
         linearText.Text = "Linear";
         filterRow.AddChild(linearText);
         linearText.MoveToLayer(linearLayer);
-    }
-
-    // Inline FontSize font-swap (#3524): [FontSize=N] swaps in a BitmapFont rasterized at N (crisp), and
-    // must also be MEASURED at that size, or a RelativeToChildren Text is sized too narrow and the run
-    // spills past its background (the RelativeToChildren-too-narrow bug fixed in #3520 / #3523). Left cell
-    // = [FontSize=40] over a 21px base (crisp swap); right cell = a [FontScale=1.9] control (a scale-up of
-    // the 21px atlas, so visibly blurrier). Pass = "big" is enlarged, crisper on the left than the right,
-    // AND the blue box fully contains each line in both. This is the reference side for the raylib mirror
-    // (Samples/raylib/Screens/TextScreen.cs BuildFontSizeContainmentRow), which now matches it via KernSmith.
-    private static ContainerRuntime BuildFontSizeContainmentRow()
-    {
-        var row = new ContainerRuntime();
-        row.WidthUnits = DimensionUnitType.RelativeToChildren;
-        row.HeightUnits = DimensionUnitType.RelativeToChildren;
-        row.Width = 0;
-        row.Height = 0;
-        row.ChildrenLayout = ChildrenLayout.LeftToRightStack;
-        row.StackSpacing = 24;
-        row.AddChild(BuildContainedMarkupCell("This is [FontSize=40]big[/FontSize] text."));
-        row.AddChild(BuildContainedMarkupCell("This is [FontScale=1.9]big[/FontScale] text."));
-        return row;
-    }
-
-    // A RelativeToChildren cell sized to its TextRuntime, with a RelativeToParent background filling it.
-    // The background's edges mark where measurement thinks the text ends, so any measure-vs-render drift
-    // shows up as the run spilling outside the blue box.
-    private static ContainerRuntime BuildContainedMarkupCell(string markup)
-    {
-        var cell = new ContainerRuntime();
-        cell.WidthUnits = DimensionUnitType.RelativeToChildren;
-        cell.HeightUnits = DimensionUnitType.RelativeToChildren;
-        cell.Width = 0;
-        cell.Height = 0;
-
-        var background = new RectangleRuntime();
-        background.WidthUnits = DimensionUnitType.RelativeToParent;
-        background.HeightUnits = DimensionUnitType.RelativeToParent;
-        background.Width = 0;
-        background.Height = 0;
-        background.IsFilled = true;
-        background.FillColor = new Color(40, 60, 160);
-        cell.Children.Add(background);
-
-        var text = new TextRuntime();
-        text.WidthUnits = DimensionUnitType.RelativeToChildren;
-        text.HeightUnits = DimensionUnitType.RelativeToChildren;
-        text.Width = 0;
-        text.Height = 0;
-        text.FontSize = 21;
-        text.Text = markup;
-        cell.Children.Add(text);
-
-        return cell;
-    }
-
-    private static void AddSectionLabel(ContainerRuntime container, string text)
-    {
-        var label = new TextRuntime();
-        label.Text = text;
-        label.FontSize = 14;
-        container.Children.Add(label);
     }
 
     // Blend on Text (#3432): additive (brightens) vs normal, over an identical blue box. Kept byte
@@ -248,5 +244,66 @@ internal class TextScreen : FrameworkElement
         cell.Children.Add(text);
 
         return cell;
+    }
+
+    // Inline FontSize font-swap (#3524): [FontSize=N] swaps in a font rasterized at N (crisp) and must
+    // also be MEASURED at that size, or a RelativeToChildren Text is sized too narrow and the run spills
+    // past its background (the RelativeToChildren-too-narrow bug fixed in #3520 / #3523). Left cell =
+    // [FontSize=40] over a 21px base (crisp swap); right cell = a [FontScale=1.9] control (a scale-up of
+    // the 21px atlas, so visibly blurrier). Pass = "big" is enlarged, crisper on the left than the right,
+    // AND the blue box fully contains each line in both. Kept identical with the raylib mirror (which
+    // gets its crisp swap from KernSmith; this backend from the BitmapFont path).
+    private static ContainerRuntime BuildFontSizeContainmentRow()
+    {
+        var row = new ContainerRuntime();
+        row.WidthUnits = DimensionUnitType.RelativeToChildren;
+        row.HeightUnits = DimensionUnitType.RelativeToChildren;
+        row.Width = 0;
+        row.Height = 0;
+        row.ChildrenLayout = ChildrenLayout.LeftToRightStack;
+        row.StackSpacing = 24;
+        row.AddChild(BuildContainedMarkupCell("This is [FontSize=40]big[/FontSize] text."));
+        row.AddChild(BuildContainedMarkupCell("This is [FontScale=1.9]big[/FontScale] text."));
+        return row;
+    }
+
+    // A RelativeToChildren cell sized to its TextRuntime, with a RelativeToParent background filling it.
+    // The background's edges mark where measurement thinks the text ends, so any measure-vs-render drift
+    // shows up as the run spilling outside the blue box.
+    private static ContainerRuntime BuildContainedMarkupCell(string markup)
+    {
+        var cell = new ContainerRuntime();
+        cell.WidthUnits = DimensionUnitType.RelativeToChildren;
+        cell.HeightUnits = DimensionUnitType.RelativeToChildren;
+        cell.Width = 0;
+        cell.Height = 0;
+
+        var background = new RectangleRuntime();
+        background.WidthUnits = DimensionUnitType.RelativeToParent;
+        background.HeightUnits = DimensionUnitType.RelativeToParent;
+        background.Width = 0;
+        background.Height = 0;
+        background.IsFilled = true;
+        background.FillColor = new Color(40, 60, 160, 255);
+        cell.Children.Add(background);
+
+        var text = new TextRuntime();
+        text.WidthUnits = DimensionUnitType.RelativeToChildren;
+        text.HeightUnits = DimensionUnitType.RelativeToChildren;
+        text.Width = 0;
+        text.Height = 0;
+        text.FontSize = 21;
+        text.Text = markup;
+        cell.Children.Add(text);
+
+        return cell;
+    }
+
+    private static void AddSectionLabel(ContainerRuntime container, string text)
+    {
+        var label = new TextRuntime();
+        label.Text = text;
+        label.FontSize = 14;
+        container.Children.Add(label);
     }
 }

--- a/Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/TextScreen.cs
+++ b/Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/TextScreen.cs
@@ -51,7 +51,7 @@ internal class TextScreen : FrameworkElement
         scaleMarkup.Text = "small [FontScale=2]BIG[/FontScale] then [Color=Orange][FontScale=1.5]orange[/FontScale][/Color]";
         container.Children.Add(scaleMarkup);
 
-        AddSectionLabel(container, "BBCode markup - inline FontSize font-swap; blue box = measured width, must contain the run (#3524):");
+        AddSectionLabel(container, "BBCode markup - [FontSize=40] crisp swap (left) vs [FontScale=1.9] scale-up (right); blue box = measured width (#3524):");
         container.Children.Add(BuildFontSizeContainmentRow());
 
         AddSectionLabel(container, "Baked drop shadow (HasDropshadow = true, first-enable defaults):");
@@ -134,12 +134,13 @@ internal class TextScreen : FrameworkElement
         linearText.MoveToLayer(linearLayer);
     }
 
-    // Inline FontSize font-swap (#3524): a [FontSize=N] run must be MEASURED at its swapped size, not
-    // the base, or a RelativeToChildren Text is sized too narrow and the enlarged run spills past its
-    // background - the RelativeToChildren-too-narrow bug fixed for MonoGame in #3520 / #3523. The left
-    // cell is [FontSize=40] over a 21px base; the right cell is a [FontScale=1.9] control that already
-    // contained correctly. Pass = "big" is enlarged AND the blue box fully contains each line. Mirror
-    // of Samples/raylib/Screens/TextScreen.cs BuildFontSizeContainmentRow (this is the reference side).
+    // Inline FontSize font-swap (#3524): [FontSize=N] swaps in a BitmapFont rasterized at N (crisp), and
+    // must also be MEASURED at that size, or a RelativeToChildren Text is sized too narrow and the run
+    // spills past its background (the RelativeToChildren-too-narrow bug fixed in #3520 / #3523). Left cell
+    // = [FontSize=40] over a 21px base (crisp swap); right cell = a [FontScale=1.9] control (a scale-up of
+    // the 21px atlas, so visibly blurrier). Pass = "big" is enlarged, crisper on the left than the right,
+    // AND the blue box fully contains each line in both. This is the reference side for the raylib mirror
+    // (Samples/raylib/Screens/TextScreen.cs BuildFontSizeContainmentRow), which now matches it via KernSmith.
     private static ContainerRuntime BuildFontSizeContainmentRow()
     {
         var row = new ContainerRuntime();

--- a/Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/TextScreen.cs
+++ b/Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/TextScreen.cs
@@ -51,6 +51,9 @@ internal class TextScreen : FrameworkElement
         scaleMarkup.Text = "small [FontScale=2]BIG[/FontScale] then [Color=Orange][FontScale=1.5]orange[/FontScale][/Color]";
         container.Children.Add(scaleMarkup);
 
+        AddSectionLabel(container, "BBCode markup - inline FontSize font-swap; blue box = measured width, must contain the run (#3524):");
+        container.Children.Add(BuildFontSizeContainmentRow());
+
         AddSectionLabel(container, "Baked drop shadow (HasDropshadow = true, first-enable defaults):");
         var shadowDefault = new TextRuntime();
         shadowDefault.Text = "Soft baked shadow";
@@ -129,6 +132,58 @@ internal class TextScreen : FrameworkElement
         linearText.Text = "Linear";
         filterRow.AddChild(linearText);
         linearText.MoveToLayer(linearLayer);
+    }
+
+    // Inline FontSize font-swap (#3524): a [FontSize=N] run must be MEASURED at its swapped size, not
+    // the base, or a RelativeToChildren Text is sized too narrow and the enlarged run spills past its
+    // background - the RelativeToChildren-too-narrow bug fixed for MonoGame in #3520 / #3523. The left
+    // cell is [FontSize=40] over a 21px base; the right cell is a [FontScale=1.9] control that already
+    // contained correctly. Pass = "big" is enlarged AND the blue box fully contains each line. Mirror
+    // of Samples/raylib/Screens/TextScreen.cs BuildFontSizeContainmentRow (this is the reference side).
+    private static ContainerRuntime BuildFontSizeContainmentRow()
+    {
+        var row = new ContainerRuntime();
+        row.WidthUnits = DimensionUnitType.RelativeToChildren;
+        row.HeightUnits = DimensionUnitType.RelativeToChildren;
+        row.Width = 0;
+        row.Height = 0;
+        row.ChildrenLayout = ChildrenLayout.LeftToRightStack;
+        row.StackSpacing = 24;
+        row.AddChild(BuildContainedMarkupCell("This is [FontSize=40]big[/FontSize] text."));
+        row.AddChild(BuildContainedMarkupCell("This is [FontScale=1.9]big[/FontScale] text."));
+        return row;
+    }
+
+    // A RelativeToChildren cell sized to its TextRuntime, with a RelativeToParent background filling it.
+    // The background's edges mark where measurement thinks the text ends, so any measure-vs-render drift
+    // shows up as the run spilling outside the blue box.
+    private static ContainerRuntime BuildContainedMarkupCell(string markup)
+    {
+        var cell = new ContainerRuntime();
+        cell.WidthUnits = DimensionUnitType.RelativeToChildren;
+        cell.HeightUnits = DimensionUnitType.RelativeToChildren;
+        cell.Width = 0;
+        cell.Height = 0;
+
+        var background = new RectangleRuntime();
+        background.WidthUnits = DimensionUnitType.RelativeToParent;
+        background.HeightUnits = DimensionUnitType.RelativeToParent;
+        background.Width = 0;
+        background.Height = 0;
+        background.IsFilled = true;
+        background.FillColor = new Color(40, 60, 160);
+        cell.Children.Add(background);
+
+        var text = new TextRuntime();
+        text.WidthUnits = DimensionUnitType.RelativeToChildren;
+        text.HeightUnits = DimensionUnitType.RelativeToChildren;
+        text.Width = 0;
+        text.Height = 0;
+        text.FontSize = 21;
+        text.Text = markup;
+        cell.Children.Add(text);
+
+        return cell;
     }
 
     private static void AddSectionLabel(ContainerRuntime container, string text)

--- a/Samples/raylib/Screens/TextScreen.cs
+++ b/Samples/raylib/Screens/TextScreen.cs
@@ -52,7 +52,7 @@ internal class TextScreen : FrameworkElement
         scaleMarkup.Text = "small [FontScale=2]BIG[/FontScale] then [Color=Orange][FontScale=1.5]orange[/FontScale][/Color]";
         container.Children.Add(scaleMarkup);
 
-        AddSectionLabel(container, "BBCode markup - inline FontSize font-swap; blue box = measured width, must contain the run (#3524):");
+        AddSectionLabel(container, "BBCode markup - [FontSize=40] crisp swap (left) vs [FontScale=1.9] scale-up (right); blue box = measured width (#3524):");
         container.Children.Add(BuildFontSizeContainmentRow());
 
         AddSectionLabel(container, "Baked drop shadow (HasDropshadow = true, first-enable defaults):");
@@ -243,11 +243,13 @@ internal class TextScreen : FrameworkElement
         return cell;
     }
 
-    // Inline FontSize font-swap (#3524): a [FontSize=N] run must be MEASURED at its swapped size, not
-    // the base, or a RelativeToChildren Text is sized too narrow and the enlarged run spills past its
-    // background - the RelativeToChildren-too-narrow bug fixed for MonoGame in #3520 / #3523. The left
-    // cell is the fix ([FontSize=40] over a 21px base); the right cell is a [FontScale=1.9] control that
-    // already contained correctly. Pass = "big" is enlarged AND the blue box fully contains each line.
+    // Inline FontSize font-swap (#3524): [FontSize=N] re-rasterizes a crisp font at N (when a font creator
+    // like KernSmith is wired) and swaps it in for the run, matching MonoGame; it must also be MEASURED at
+    // that size, or a RelativeToChildren Text is sized too narrow and the run spills past its background
+    // (the RelativeToChildren-too-narrow bug fixed for MonoGame in #3520 / #3523). Left cell = [FontSize=40]
+    // over a 21px base (crisp swap); right cell = a [FontScale=1.9] control (a scale-up of the 21px atlas,
+    // so visibly blurrier). Pass = "big" is enlarged, crisper on the left than the right, AND the blue box
+    // fully contains each line in both.
     private static ContainerRuntime BuildFontSizeContainmentRow()
     {
         var row = new ContainerRuntime();

--- a/Samples/raylib/Screens/TextScreen.cs
+++ b/Samples/raylib/Screens/TextScreen.cs
@@ -52,6 +52,9 @@ internal class TextScreen : FrameworkElement
         scaleMarkup.Text = "small [FontScale=2]BIG[/FontScale] then [Color=Orange][FontScale=1.5]orange[/FontScale][/Color]";
         container.Children.Add(scaleMarkup);
 
+        AddSectionLabel(container, "BBCode markup - inline FontSize font-swap; blue box = measured width, must contain the run (#3524):");
+        container.Children.Add(BuildFontSizeContainmentRow());
+
         AddSectionLabel(container, "Baked drop shadow (HasDropshadow = true, first-enable defaults):");
         var shadowDefault = new TextRuntime();
         shadowDefault.Text = "Soft baked shadow";
@@ -235,6 +238,57 @@ internal class TextScreen : FrameworkElement
         text.HorizontalAlignment = HorizontalAlignment.Center;
         text.VerticalAlignment = VerticalAlignment.Center;
         text.Blend = blend;
+        cell.Children.Add(text);
+
+        return cell;
+    }
+
+    // Inline FontSize font-swap (#3524): a [FontSize=N] run must be MEASURED at its swapped size, not
+    // the base, or a RelativeToChildren Text is sized too narrow and the enlarged run spills past its
+    // background - the RelativeToChildren-too-narrow bug fixed for MonoGame in #3520 / #3523. The left
+    // cell is the fix ([FontSize=40] over a 21px base); the right cell is a [FontScale=1.9] control that
+    // already contained correctly. Pass = "big" is enlarged AND the blue box fully contains each line.
+    private static ContainerRuntime BuildFontSizeContainmentRow()
+    {
+        var row = new ContainerRuntime();
+        row.WidthUnits = DimensionUnitType.RelativeToChildren;
+        row.HeightUnits = DimensionUnitType.RelativeToChildren;
+        row.Width = 0;
+        row.Height = 0;
+        row.ChildrenLayout = ChildrenLayout.LeftToRightStack;
+        row.StackSpacing = 24;
+        row.AddChild(BuildContainedMarkupCell("This is [FontSize=40]big[/FontSize] text."));
+        row.AddChild(BuildContainedMarkupCell("This is [FontScale=1.9]big[/FontScale] text."));
+        return row;
+    }
+
+    // A RelativeToChildren cell sized to its TextRuntime, with a RelativeToParent background filling it.
+    // The background's edges mark where measurement thinks the text ends, so any measure-vs-render drift
+    // shows up as the run spilling outside the blue box.
+    private static ContainerRuntime BuildContainedMarkupCell(string markup)
+    {
+        var cell = new ContainerRuntime();
+        cell.WidthUnits = DimensionUnitType.RelativeToChildren;
+        cell.HeightUnits = DimensionUnitType.RelativeToChildren;
+        cell.Width = 0;
+        cell.Height = 0;
+
+        var background = new RectangleRuntime();
+        background.WidthUnits = DimensionUnitType.RelativeToParent;
+        background.HeightUnits = DimensionUnitType.RelativeToParent;
+        background.Width = 0;
+        background.Height = 0;
+        background.IsFilled = true;
+        background.FillColor = new Color(40, 60, 160, 255);
+        cell.Children.Add(background);
+
+        var text = new TextRuntime();
+        text.WidthUnits = DimensionUnitType.RelativeToChildren;
+        text.HeightUnits = DimensionUnitType.RelativeToChildren;
+        text.Width = 0;
+        text.Height = 0;
+        text.FontSize = 21;
+        text.Text = markup;
         cell.Children.Add(text);
 
         return cell;

--- a/Samples/raylib/Screens/TextScreen.cs
+++ b/Samples/raylib/Screens/TextScreen.cs
@@ -8,17 +8,18 @@ using RenderingLibrary.Graphics;
 
 namespace Examples.Shapes;
 
-// Raylib mirror of Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/TextScreen.cs (#3414).
-// Section order matches the MG screen so baked-shadow regressions are easy to spot side by side.
-// Requires KernSmithRaylibFontCreator wired in Program.Main.
+// Raylib mirror of Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/TextScreen.cs (#3414), which
+// is the reference. This file matches it section-for-section so a per-backend rendering difference
+// stands out as a backend bug. Requires KernSmithRaylibFontCreator wired in Program.Main.
 //
-// Section order in this file must match the MonoGameGumInCode and SilkNetGum TextScreen.cs mirrors
+// Before adding, removing, or reordering ANY section, make the same change in the sibling mirrors
 // (Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/TextScreen.cs,
-// Samples/SilkNetGum/SilkNetGum/Screens/TextScreen.cs) exactly, top to bottom - before adding,
-// removing, or reordering ANY section, check the sibling files for the same change or the
-// side-by-side comparison breaks silently. Raylib-only sections (TextRenderingPositionMode,
-// GetCharacterIndexAtPosition, #3432) are the sole expected exception, appended at the end.
-// (Broke once when MonoGameGumInCode carried extra AddCustomOutlineText rows raylib never had - #3496.)
+// Samples/SilkNetGum/SilkNetGum/Screens/TextScreen.cs) or the side-by-side comparison breaks
+// silently (#3496). Only genuinely backend-specific things may differ: the color type
+// (Raylib_cs.Color vs Microsoft.Xna.Framework.Color), the TextRenderingPositionMode enum namespace,
+// and AddTextureFilterSection's mechanism (a baked font-cache texture here vs a per-layer sampler
+// state on MonoGame). SilkNetGum legitimately omits the BBCode / Blend / TextureFilter sections
+// because SkiaGum renders via RichTextKit rather than a font atlas.
 internal class TextScreen : FrameworkElement
 {
     public TextScreen() : base(new ContainerRuntime())
@@ -90,9 +91,9 @@ internal class TextScreen : FrameworkElement
         BuildTextParitySection(container);
     }
 
-    // #3432 raylib Text parity: Blend, per-instance TextRenderingPositionMode override, and
+    // Text parity features (#3432): Blend, per-instance TextRenderingPositionMode override, and
     // GetCharacterIndexAtPosition. All three are runtime-observable, so this section is the manual
-    // verification surface for the parity batch.
+    // verification surface for the parity batch. Kept in step with the MonoGame mirror.
     private static void BuildTextParitySection(ContainerRuntime container)
     {
         AddBlendOnTextSection(container);

--- a/Tests/RaylibGum.Tests/Renderables/TextMarkupTests.cs
+++ b/Tests/RaylibGum.Tests/Renderables/TextMarkupTests.cs
@@ -253,4 +253,33 @@ public class TextMarkupTests
         sizedWidth.ShouldBe(plainWidth * 2, 1.5,
             "Because [FontSize=2xBase] renders the run at twice the base pixel size, so the measured width doubles");
     }
+
+    // Issue #3524: the HEIGHT half - a [FontSize=N] run must grow the reported line HEIGHT too, or a
+    // RelativeToChildren box is too short and the enlarged run spills above/below it (the vertical spill
+    // MonoGame had). Raylib gets this right by construction (one layout scale drives both width and
+    // height), but pin it so a future refactor can't silently regress it - the exact gap that let the
+    // MonoGame height bug ship uncaught.
+    [Fact]
+    public void WrappedTextHeight_ShouldGrow_WhenLineHasFontSizeLargerThanBase()
+    {
+        TextRuntime plain = new();
+        plain.WidthUnits = DimensionUnitType.RelativeToChildren;
+        plain.Width = 0;
+        plain.Text = "BIG";
+        Text plainText = (Text)plain.RenderableComponent;
+        float plainHeight = plainText.WrappedTextHeight;
+        plainHeight.ShouldBeGreaterThan(0);
+
+        int baseSize = plainText.Font.BaseSize;
+        int targetFontSize = baseSize * 2;
+
+        TextRuntime sized = new();
+        sized.WidthUnits = DimensionUnitType.RelativeToChildren;
+        sized.Width = 0;
+        sized.Text = $"[FontSize={targetFontSize}]BIG[/FontSize]";
+        float sizedHeight = ((Text)sized.RenderableComponent).WrappedTextHeight;
+
+        sizedHeight.ShouldBe(plainHeight * 2, plainHeight * 0.05,
+            "Because a [FontSize=2xBase] run is twice the base pixel size, so the measured line height doubles");
+    }
 }

--- a/Tests/RaylibGum.Tests/Renderables/TextMarkupTests.cs
+++ b/Tests/RaylibGum.Tests/Renderables/TextMarkupTests.cs
@@ -1,5 +1,7 @@
 using Gum.DataTypes;
 using Gum.GueDeriving;
+using KernSmith.Gum;
+using RaylibGum.Renderables;
 using RenderingLibrary.Graphics;
 using Shouldly;
 using Xunit;
@@ -46,6 +48,9 @@ public class TextMarkupTests
         internalText.InlineVariables[0].CharacterCount.ShouldBe(4);
     }
 
+    // No font creator is wired in the test harness, so [FontSize=N] can't re-rasterize a crisp font and
+    // falls back to storing the raw size as a float (Text then scales the base atlas to it). The crisp
+    // swap path is covered by Text_WithFontSizeMarkup_SwapsToCrispFont_WhenFontCreatorWired.
     [Fact]
     public void Text_WithFontSizeMarkup_PopulatesInlineVariable()
     {
@@ -60,6 +65,35 @@ public class TextMarkupTests
         internalText.InlineVariables[0].Value.ShouldBe(40f);
         internalText.InlineVariables[0].StartIndex.ShouldBe(4);
         internalText.InlineVariables[0].CharacterCount.ShouldBe(4);
+    }
+
+    // With a font creator wired, [FontSize=N] re-rasterizes a crisp Raylib_cs.Font AT size N (BaseSize == N)
+    // and stores it as the run value - the actual font-swap, not an atlas scale-up. Mirrors the MonoGame
+    // BitmapFont swap. Restores the creator in finally so the no-creator fallback tests stay unaffected.
+    [Fact]
+    public void Text_WithFontSizeMarkup_SwapsToCrispFont_WhenFontCreatorWired()
+    {
+        IRaylibFontCreator? savedCreator = CustomSetPropertyOnRenderable.InMemoryFontCreator;
+        try
+        {
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = new KernSmithRaylibFontCreator();
+
+            TextRuntime textRuntime = new();
+            textRuntime.Font = "Arial";
+            textRuntime.FontSize = 21;
+            textRuntime.Text = "Big [FontSize=40]text[/FontSize]";
+
+            Text internalText = (Text)textRuntime.RenderableComponent;
+
+            internalText.InlineVariables.Count.ShouldBe(1);
+            internalText.InlineVariables[0].VariableName.ShouldBe("FontSize");
+            Raylib_cs.Font swapFont = internalText.InlineVariables[0].Value.ShouldBeOfType<Raylib_cs.Font>();
+            swapFont.BaseSize.ShouldBe(40);
+        }
+        finally
+        {
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = savedCreator;
+        }
     }
 
     [Fact]

--- a/Tests/RaylibGum.Tests/Renderables/TextMarkupTests.cs
+++ b/Tests/RaylibGum.Tests/Renderables/TextMarkupTests.cs
@@ -47,6 +47,22 @@ public class TextMarkupTests
     }
 
     [Fact]
+    public void Text_WithFontSizeMarkup_PopulatesInlineVariable()
+    {
+        TextRuntime textRuntime = new();
+        textRuntime.Text = "Big [FontSize=40]text[/FontSize]";
+
+        Text internalText = (Text)textRuntime.RenderableComponent;
+
+        internalText.RawText.ShouldBe("Big text");
+        internalText.InlineVariables.Count.ShouldBe(1);
+        internalText.InlineVariables[0].VariableName.ShouldBe("FontSize");
+        internalText.InlineVariables[0].Value.ShouldBe(40f);
+        internalText.InlineVariables[0].StartIndex.ShouldBe(4);
+        internalText.InlineVariables[0].CharacterCount.ShouldBe(4);
+    }
+
+    [Fact]
     public void Text_ChangingFromMarkupToPlain_ClearsInlineVariablesAndStoredMarkup()
     {
         TextRuntime textRuntime = new();
@@ -172,5 +188,35 @@ public class TextMarkupTests
 
         scaledWidth.ShouldBe(plainWidth * 2, 1.5,
             "Because a scaled run is measured at its own scale, so the reported width grows with it");
+    }
+
+    // Issue #3524: a [FontSize=N] run is an ABSOLUTE per-run pixel size (unlike [FontScale], which
+    // is a multiplier). Raylib draws by scaling the base font atlas to N px, so a run requested at
+    // twice the base size must ALSO be measured at twice the width — otherwise a RelativeToChildren
+    // Text is sized too narrow and the enlarged run spills past its background (the exact bug fixed
+    // for MonoGame in #3520 / #3523). baseSize is read from the actual font so the expectation stays
+    // self-contained regardless of which default font the test harness loads.
+    [Fact]
+    public void WrappedTextWidth_ShouldGrow_WhenLineHasFontSizeLargerThanBase()
+    {
+        TextRuntime plain = new();
+        plain.WidthUnits = DimensionUnitType.RelativeToChildren;
+        plain.Width = 0;
+        plain.Text = "BIG";
+        Text plainText = (Text)plain.RenderableComponent;
+        float plainWidth = plainText.WrappedTextWidth;
+        plainWidth.ShouldBeGreaterThan(0);
+
+        int baseSize = plainText.Font.BaseSize;
+        int targetFontSize = baseSize * 2;
+
+        TextRuntime sized = new();
+        sized.WidthUnits = DimensionUnitType.RelativeToChildren;
+        sized.Width = 0;
+        sized.Text = $"[FontSize={targetFontSize}]BIG[/FontSize]";
+        float sizedWidth = ((Text)sized.RenderableComponent).WrappedTextWidth;
+
+        sizedWidth.ShouldBe(plainWidth * 2, 1.5,
+            "Because [FontSize=2xBase] renders the run at twice the base pixel size, so the measured width doubles");
     }
 }


### PR DESCRIPTION
Closes #3524.

## Problem

RaylibGum's `Text` stripped inline `[FontSize=N]` BBCode tags but never applied them, so the enclosed run rendered at the **base** size instead of `N`. MonoGame renders it at `N` by swapping in a font rasterized at that size.

## Approach

`[FontSize=N]` now performs a real per-run **font swap**, mirroring MonoGame's BitmapFont swap:

- **With a font creator wired** (`IRaylibFontCreator`, e.g. KernSmith — as the gallery sample and Forms styling both wire): the run re-rasterizes a **crisp** `Raylib_cs.Font` at size `N` and draws with it at its native size. `TryGetOrCreateFontAtSize` reuses the same `InMemoryFontCreator` + `BmfcSave` + `LoaderManager` cache the base-font path (`UpdateToFontValues`) uses — only the size is overridden — keyed by the shared FontCache name so a base text and a run at the same size share one atlas.
- **With no creator wired**: falls back to scaling the base atlas to the absolute size `N` (blurry but correct size + correct measurement). This is the previous first-pass behavior, preserved for backward compatibility.

Either way the run is rendered **and measured** at size `N` (× the base `FontScale`, matching MonoGame). A single `Text.ResolveRunFont` returns the per-run font + draw size + layout scale and is shared by `DrawStyledLine` (draw) **and** `GetInlineVariableAwareWidthAndHeight` (measure), so the drawn and measured size of a run structurally cannot drift — that drift is what reproduced the `RelativeToChildren`-too-narrow spill fixed for MonoGame in #3520 / #3523.

## Backward compatibility

- On released Gum, `[FontSize]` was a **no-op** on raylib (stripped, never applied), so no existing raylib project depended on any FontSize markup behavior.
- The **property** `FontSize` path (`UpdateToFontValues`) is **untouched** — only the BBCode `SetBbCodeText` path gained the swap.
- Projects **without** a font creator keep the atlas-scale-to-N behavior (no regression); projects **with** one get the crisp upgrade.

## Tests (`TextMarkupTests`, headless via llvmpipe)

- `Text_WithFontSizeMarkup_SwapsToCrispFont_WhenFontCreatorWired` — wires KernSmith and asserts the run's inline value is a `Raylib_cs.Font` with `BaseSize == 40` (the real swap).
- `Text_WithFontSizeMarkup_PopulatesInlineVariable` — the no-creator fallback: inline value is the raw size as a float.
- `WrappedTextWidth_ShouldGrow_WhenLineHasFontSizeLargerThanBase` — a `[FontSize=2×base]` run is **measured** at 2× the width (the containment guarantee).

Full raylib suite: **449/449 green**.

## Manual verification (visual)

`Samples/raylib/Screens/TextScreen.cs` and the mirrored `Samples/MonoGameGumInCode/.../TextScreen.cs` gain a `[FontSize]` section: a `RelativeToChildren` cell whose blue background reveals the measured width — the `[FontSize=40]` crisp swap on the left, a `[FontScale=1.9]` scale-up (blurrier) on the right. Pass = "big" is enlarged, crisper on the left, **and** the blue box fully contains each line in both. SilkNetGum's `TextScreen` deliberately omits BBCode sections (SkiaGum uses RichTextKit), so it's excluded.

## Follow-ups

- `[Font=Name]` family swap remains deferred (#3471).
- The switch matches the exact tag casing `[FontSize]` (as MonoGame and the sibling Color/FontScale cases do); a lowercase `[fontsize]` is stripped but not applied — a pre-existing quirk shared by all tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
