### PR TITLE
Make line wrapping honor inline BBCode [FontSize]/[FontScale] runs (part of #3520)

### DIFF
--- a/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
+++ b/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
@@ -1263,10 +1263,12 @@ public class CustomSetPropertyOnRenderable
             lastFontInlineVariable.CharacterCount = asText.RawText.Length - lastFontInlineVariable.StartIndex;
         }
 
-        // #3481: RawText was assigned above (which measured the text) before any InlineVariables
-        // existed, so that first measurement was blind to inline [FontScale=N] runs. Re-measure now
-        // that the runs are populated so the reported size accounts for per-line scale (otherwise a
-        // tall run overflows its slot and overlaps the next stacked sibling).
+        // #3481: RawText was assigned above (which wrapped + measured the text) before any InlineVariables
+        // existed, so that first pass was blind to inline [FontScale=N]/[FontSize=N] runs. Re-wrap first so
+        // line breaks account for an enlarged run's real size (#3520), then re-measure so the reported size
+        // accounts for per-line scale (#3481) — otherwise a tall run overflows its slot and overlaps the
+        // next stacked sibling, or a wide run spills past a fixed wrap width.
+        asText.UpdateWrappedText();
         asText.UpdatePreRenderDimensions();
 
 

--- a/MonoGameGum.Tests/RenderingLibraries/TextTests.cs
+++ b/MonoGameGum.Tests/RenderingLibraries/TextTests.cs
@@ -198,6 +198,47 @@ char id=67 x=0 y=0 width={xadvance} height=13 xoffset=0 yoffset=4 xadvance={xadv
             "because a base run after a font-swap run must still be fully measured at the base size");
     }
 
+    // #3520 (the wrapping half): line wrapping must measure each inline run at its own size, not the
+    // base size. A fixed-width line that fits "AA BB CC" at the base size must wrap once "BB" is
+    // enlarged via a font-swap run (like [FontSize=40]) — otherwise the wrap packs all three words at
+    // the base size and the enlarged run spills past the width. This is the renderable-level (UpdateLines)
+    // contract; InlineVariables are populated before RawText here, so it isolates the wrap seam from the
+    // re-wrap sequencing exercised end-to-end in TextRuntimeTests.
+    [Fact]
+    public void UpdateLines_WithFontSwapRun_WrapsWhereTheEnlargedRunNoLongerFits()
+    {
+        const int baseAdvance = 10;
+        const int swappedAdvance = 20;
+
+        BitmapFont baseFont = new BitmapFont((Texture2D)null!, AbcFontData(baseAdvance, lineHeight: 20));
+        baseFont.SetFontPattern(256, 256);
+        BitmapFont swappedFont = new BitmapFont((Texture2D)null!, AbcFontData(swappedAdvance, lineHeight: 20));
+        swappedFont.SetFontPattern(256, 256);
+
+        Text text = new Text();
+        text.BitmapFont = baseFont;
+        // "BB" (indices 3-4) is drawn with the larger font, like [FontSize] swaps a run's font.
+        text.InlineVariables.Add(new InlineVariable
+        {
+            VariableName = "BitmapFont",
+            Value = swappedFont,
+            StartIndex = 3,
+            CharacterCount = 2
+        });
+
+        // A wrap width (base units) that fits all three words at the base size (8 chars * 10 = 80) but not
+        // once "BB" is measured at the swapped size (6*10 + 2*20 = 100). 85 sits between the two. Width is
+        // in the Text's own space (UpdateLines divides by FontScale), so scale the base-unit target back up
+        // to stay correct regardless of GlobalFontScale.
+        float fontScale = ((IText)text).FontScale;
+        text.Width = 85 * fontScale;
+
+        text.RawText = "AA BB CC";
+
+        text.WrappedText.Count.ShouldBe(2,
+            "because the enlarged font-swap run must be measured at its own size when wrapping, forcing an earlier break");
+    }
+
     // Font where the space advances 10px but is only 1px wide, and letters A/B/C are 10px wide with a
     // 10px advance. The narrow space is what exposes per-run TrimRight trimming: an interior run ending
     // in a space loses 9px if measured with TrimRight instead of Full.

--- a/MonoGameGum.Tests/Runtimes/TextRuntimeTests.cs
+++ b/MonoGameGum.Tests/Runtimes/TextRuntimeTests.cs
@@ -321,6 +321,37 @@ char id=67 x=0 y=0 width={xadvance} height=13 xoffset=0 yoffset=4 xadvance={xadv
         }
     }
 
+    // #3520 (the wrapping half, end-to-end): a fixed-width Text that fits "AA BB CC" at the base size must
+    // re-wrap once the inline [FontSize=40] run enlarges "BB". The real BBCode path sets RawText (which
+    // wraps) BEFORE the InlineVariables are populated, so the first wrap is blind to the runs; the fix must
+    // re-wrap after the runs exist. Without that re-wrap this stays one line and the enlarged run spills
+    // past the width. Widths use the stub creator's advance = FontSize/2 (base 20 -> 10, run 40 -> 20).
+    [Fact]
+    public void WrappedText_ShouldRewrapFontAware_WhenBbCodeFontSizeRunWidensLine()
+    {
+        var previousCreator = CustomSetPropertyOnRenderable.InMemoryFontCreator;
+        CustomSetPropertyOnRenderable.InMemoryFontCreator = new SizeProportionalFontCreator();
+        try
+        {
+            TextRuntime rt = new();
+            rt.Font = "StubFont3520";
+            rt.FontSize = 20;
+            rt.WidthUnits = DimensionUnitType.Absolute;
+            // Fits "AA BB CC" at the base size (8 chars * 10 = 80) but not with "BB" at size 40
+            // (6*10 + 2*20 = 100). 85 sits between the two, so only a font-aware re-wrap breaks the line.
+            rt.Width = 85;
+            rt.Text = "AA [FontSize=40]BB[/FontSize] CC";
+
+            var wrapped = ((Text)rt.RenderableComponent).WrappedText;
+            wrapped.Count.ShouldBe(2,
+                "because after the inline [FontSize] runs populate, the text must re-wrap measuring the enlarged run at its own size");
+        }
+        finally
+        {
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = previousCreator;
+        }
+    }
+
     // Repro attempt for the manual-test structure the earlier tests missed: the box also holds a
     // RelativeToParent background sibling (added BEFORE the text). FontScale needs no font generation, so
     // this isolates whether the RelativeToParent sibling breaks the box's RelativeToChildren sizing.

--- a/RenderingLibrary/Graphics/IWrappedText.cs
+++ b/RenderingLibrary/Graphics/IWrappedText.cs
@@ -31,6 +31,17 @@ public interface IWrappedText : IText
 
     float MeasureString(string text);
 
+    /// <summary>
+    /// Measures <paramref name="text"/>, which begins at <paramref name="absoluteStartIndexInStrippedText"/>
+    /// within the full stripped (tags-removed) text, honoring any inline BBCode runs (a [FontSize] font swap
+    /// or a [FontScale] multiplier) active over that character range so line wrapping breaks where the text
+    /// actually renders rather than where the base font would. The returned width is in the same base units
+    /// as <see cref="MeasureString(string)"/> (font scale factored out), so it compares directly against the
+    /// wrap width. The default implementation ignores inline runs (measures at the base font); a backend
+    /// opts in to font-aware wrapping by overriding it.
+    /// </summary>
+    float MeasureString(string text, int absoluteStartIndexInStrippedText) => MeasureString(text);
+
     bool IsMidWordLineBreakEnabled { get; }
 }
 
@@ -88,6 +99,14 @@ public static class IWrappedTextExtensions
         String currentLine = String.Empty;
         String returnString = String.Empty;
 
+        // The absolute character index (in the stripped text) where the current line begins. It equals the
+        // total length of the lines already committed, so it stays in sync with the inline-variable indexing
+        // the styled measurement uses (the same accounting DrawWithInlineVariables/size passes do with
+        // `startOfLineIndex += line.Length`). We advance it whenever a line is committed below, and pass it
+        // to the styled MeasureString overload so a line containing an inline [FontSize]/[FontScale] run is
+        // measured at the run's real size while wrapping.
+        int absoluteLineStartIndex = 0;
+
         // The words to process, including the current word
         List<string> remainingWordsToProcess = new();
 
@@ -130,7 +149,7 @@ public static class IWrappedTextExtensions
             // If it's not the last word, we show ellipsis, and the last word plus ellipsis won't fit, then we need
             // to include part of the word:
 
-            float linePlusWordWidth = textInstance.MeasureString(currentLine + currentWord);
+            float linePlusWordWidth = textInstance.MeasureString(currentLine + currentWord, absoluteLineStartIndex);
 
             var shouldAddEllipsis =
                 textInstance.IsTruncatingWithEllipsisOnLastLine &&
@@ -146,7 +165,7 @@ public static class IWrappedTextExtensions
                 {
                     var substringEnd = currentWord.SubstringEnd(i);
 
-                    float linePlusWordSub = textInstance.MeasureString(currentLine + substringEnd);
+                    float linePlusWordSub = textInstance.MeasureString(currentLine + substringEnd, absoluteLineStartIndex);
 
                     if (linePlusWordSub + ellipsisWidth <= wrappingWidth)
                     {
@@ -174,6 +193,7 @@ public static class IWrappedTextExtensions
                     // We already have a line started, so let's add it
                     // and start the next line
                     lines.Add(currentLine);
+                    absoluteLineStartIndex += currentLine.Length;
                     if (lines.Count == effectiveMaxNumberOfLines)
                     {
                         break;
@@ -190,6 +210,7 @@ public static class IWrappedTextExtensions
                     if (currentWord.Length == 1)
                     {
                         lines.Add(currentWord);
+                        absoluteLineStartIndex += currentWord.Length;
                         remainingWordsToProcess.RemoveAt(0);
                     }
                     else
@@ -203,7 +224,9 @@ public static class IWrappedTextExtensions
                         for (int i = 1; i < currentWord.Length; i++)
                         {
                             var substring = currentWord.Substring(0, i + 1);
-                            float substringLength = textInstance.MeasureString(substring);
+                            // currentLine is empty in this mid-word-break branch, so the substring begins at
+                            // the current line's absolute start.
+                            float substringLength = textInstance.MeasureString(substring, absoluteLineStartIndex);
 
                             // Check if there's a zero-width space at this position that could be a preferred break point
                             if (i < currentWord.Length && currentWord[i] == '\u200B' && substringLength < wrappingWidth)
@@ -222,6 +245,9 @@ public static class IWrappedTextExtensions
                                     // Break at the zero-width space position
                                     stringToAdd = currentWord.Substring(0, preferredBreakIndex.Value);
                                     lines.Add(stringToAdd);
+                                    // The zero-width space at preferredBreakIndex is skipped (the next line
+                                    // starts one past it), so advance past it too to stay in sync.
+                                    absoluteLineStartIndex += stringToAdd.Length + 1;
 
                                     // Skip the zero-width space character when continuing
                                     currentWord = remainingWordsToProcess[0].Substring(preferredBreakIndex.Value + 1);
@@ -236,6 +262,7 @@ public static class IWrappedTextExtensions
                                     // from the current word:
                                     stringToAdd = currentWord.Substring(0, i + 1);
                                     lines.Add(stringToAdd);
+                                    absoluteLineStartIndex += stringToAdd.Length;
 
                                     // Be sure to use remainingWordsToProcess[0] so we get everything
                                     // before it was broken up by newlines
@@ -247,6 +274,7 @@ public static class IWrappedTextExtensions
                                 {
                                     stringToAdd = currentWord.Substring(0, i);
                                     lines.Add(stringToAdd);
+                                    absoluteLineStartIndex += stringToAdd.Length;
 
                                     // Be sure to use remainingWordsToProcess[0] so we get everything
                                     // before it was broken up by newlines
@@ -292,6 +320,7 @@ public static class IWrappedTextExtensions
                 if (containsNewline)
                 {
                     lines.Add(currentLine);
+                    absoluteLineStartIndex += currentLine.Length;
 
 
                     if (lines.Count == effectiveMaxNumberOfLines)

--- a/RenderingLibrary/Graphics/Text.cs
+++ b/RenderingLibrary/Graphics/Text.cs
@@ -778,7 +778,14 @@ public class Text : SpriteBatchRenderableBase, IRenderableIpso, IVisible, IWrapp
     static char[] preservedNewlinableCharacters = new char[] { ',', '-', ':', '.', '?', '!', '&', 
         // 
         ')' };
-    private void UpdateWrappedText()
+    /// <summary>
+    /// Re-runs line wrapping and rebuilds <see cref="WrappedText"/>. Normally invoked by the property
+    /// setters that affect wrapping (RawText, Width, FontScale, ...), but also callable after the inline
+    /// BBCode <see cref="InlineVariables"/> are populated: the BBCode assignment path sets RawText (which
+    /// wraps) before the runs exist, so a re-wrap is needed for wrapping to account for an inline
+    /// [FontSize]/[FontScale] run's real size (issue #3520).
+    /// </summary>
+    public void UpdateWrappedText()
     {
         ///////////EARLY OUT/////////////
         if (this.BitmapFont == null && DefaultBitmapFont == null)
@@ -1520,8 +1527,6 @@ public class Text : SpriteBatchRenderableBase, IRenderableIpso, IVisible, IWrapp
     /// </remarks>
     private void GetInlineVariableAwareWidthAndHeight(out int requiredWidth, out int requiredHeight)
     {
-        var effectiveFontScale = EffectiveFontScale;
-
         float maxWidth = 0;
         float totalHeight = 0;
 
@@ -1541,52 +1546,7 @@ public class Text : SpriteBatchRenderableBase, IRenderableIpso, IVisible, IWrapp
             }
             else
             {
-                float maxRunScale = effectiveFontScale;
-                float lineWidthAtScale = 0;
-                for (int substringIndex = 0; substringIndex < substrings.Count; substringIndex++)
-                {
-                    var substring = substrings[substringIndex];
-                    float runScale = effectiveFontScale;
-                    // A [FontSize=N] run swaps in a font generated at that size (a "BitmapFont" run),
-                    // which DrawWithInlineVariables draws the glyphs with. Measure the run with that same
-                    // font so the reported width matches what is drawn — otherwise a run in a larger font
-                    // is measured at the base size and a RelativeToChildren Text is sized too narrow (#3520).
-                    BitmapFont runFont = mBitmapFont;
-                    // Height factor for this run relative to the base line height. A [FontScale] run scales
-                    // it directly; a [FontSize=N] swap run's taller generated font scales it by the ratio of
-                    // line heights, so the reported line grows to the swapped font's height. Without this the
-                    // height stays on the base font and a RelativeToChildren box is too short, letting the
-                    // enlarged run spill vertically — the height half of the #3520/#3523 width fix (#3524).
-                    float runHeightScale = effectiveFontScale;
-                    for (int variableIndex = 0; variableIndex < substring.Variables.Count; variableIndex++)
-                    {
-                        var variable = substring.Variables[variableIndex];
-                        if (variable.VariableName == nameof(FontScale))
-                        {
-                            runScale = (float)variable.Value * SystemManagers.GlobalFontScale;
-                            runHeightScale = runScale;
-                        }
-                        else if (variable.VariableName == nameof(BitmapFont))
-                        {
-                            runFont = (BitmapFont)variable.Value;
-                            if (mBitmapFont != null && mBitmapFont.LineHeightInPixels > 0)
-                            {
-                                runHeightScale = effectiveFontScale * runFont.LineHeightInPixels / mBitmapFont.LineHeightInPixels;
-                            }
-                        }
-                    }
-                    // Only the final run of the line is measured with TrimRight (matching the whole-line
-                    // MeasureString the plain path uses); interior runs must use Full, or each run
-                    // boundary trims its last glyph (often a space before the next run) and the line is
-                    // under-measured — leaving a RelativeToChildren container too narrow (#3520).
-                    var measurementStyle = substringIndex == substrings.Count - 1
-                        ? HorizontalMeasurementStyle.TrimRight
-                        : HorizontalMeasurementStyle.Full;
-                    lineWidthAtScale += runFont.MeasureString(substring.Substring, measurementStyle) * runScale;
-                    maxRunScale = System.Math.Max(maxRunScale, runHeightScale);
-                }
-                lineHeightFactor = maxRunScale / effectiveFontScale;
-                lineWidthInBaseUnits = lineWidthAtScale / effectiveFontScale;
+                lineWidthInBaseUnits = MeasureStyledLineInBaseUnits(substrings, out lineHeightFactor);
             }
 
             maxWidth = System.Math.Max(maxWidth, lineWidthInBaseUnits);
@@ -1598,6 +1558,84 @@ public class Text : SpriteBatchRenderableBase, IRenderableIpso, IVisible, IWrapp
         const int MaxWidthAndHeight = 4096;
         requiredWidth = System.Math.Min((int)(maxWidth + .5f), MaxWidthAndHeight);
         requiredHeight = System.Math.Min((int)(totalHeight + .5f), MaxWidthAndHeight);
+    }
+
+    /// <summary>
+    /// Sums the base-unit width of a single line already split into styled runs, measuring each run with its
+    /// own inline font (a [FontSize] "BitmapFont" swap run) and scale (a [FontScale] run) — the same per-run
+    /// resolution <see cref="DrawWithInlineVariables"/> draws with — and reports the tallest run's height
+    /// factor relative to the base line height.
+    /// </summary>
+    /// <remarks>
+    /// Shared by the size pass (<see cref="GetInlineVariableAwareWidthAndHeight"/>, #3481/#3523/#3524) and
+    /// the font-aware wrap seam (<see cref="MeasureString(string, int)"/>, #3520) so the measured, drawn, and
+    /// wrapped size of a run cannot drift. A [FontSize=N] run swaps in a font generated at that size which the
+    /// run is drawn with, so measuring it with the base font sizes a RelativeToChildren Text too narrow and
+    /// wraps it at the base size. Only the final run uses TrimRight (matching the whole-line MeasureString the
+    /// plain path uses); interior runs use Full, or each run boundary trims its last glyph (often a space
+    /// before the next run) and the line is under-measured. Widths are returned in BASE units (font scale
+    /// factored out), matching <see cref="MeasureString(string)"/>.
+    /// </remarks>
+    private float MeasureStyledLineInBaseUnits(List<StyledSubstring> substrings, out float lineHeightFactor)
+    {
+        var effectiveFontScale = EffectiveFontScale;
+
+        float maxRunScale = effectiveFontScale;
+        float lineWidthAtScale = 0;
+        for (int substringIndex = 0; substringIndex < substrings.Count; substringIndex++)
+        {
+            var substring = substrings[substringIndex];
+            float runScale = effectiveFontScale;
+            BitmapFont runFont = mBitmapFont;
+            float runHeightScale = effectiveFontScale;
+            for (int variableIndex = 0; variableIndex < substring.Variables.Count; variableIndex++)
+            {
+                var variable = substring.Variables[variableIndex];
+                if (variable.VariableName == nameof(FontScale))
+                {
+                    runScale = (float)variable.Value * SystemManagers.GlobalFontScale;
+                    runHeightScale = runScale;
+                }
+                else if (variable.VariableName == nameof(BitmapFont))
+                {
+                    runFont = (BitmapFont)variable.Value;
+                    if (mBitmapFont != null && mBitmapFont.LineHeightInPixels > 0)
+                    {
+                        runHeightScale = effectiveFontScale * runFont.LineHeightInPixels / mBitmapFont.LineHeightInPixels;
+                    }
+                }
+            }
+            var measurementStyle = substringIndex == substrings.Count - 1
+                ? HorizontalMeasurementStyle.TrimRight
+                : HorizontalMeasurementStyle.Full;
+            lineWidthAtScale += runFont.MeasureString(substring.Substring, measurementStyle) * runScale;
+            maxRunScale = System.Math.Max(maxRunScale, runHeightScale);
+        }
+        lineHeightFactor = effectiveFontScale > 0 ? maxRunScale / effectiveFontScale : 1;
+        return effectiveFontScale > 0 ? lineWidthAtScale / effectiveFontScale : 0;
+    }
+
+    /// <summary>
+    /// Font-aware measurement used by line wrapping (issue #3520): measures <paramref name="whatToMeasure"/>
+    /// (which begins at <paramref name="absoluteStartIndexInStrippedText"/> in the stripped text) honoring the
+    /// inline [FontSize]/[FontScale] runs active over that range, so a line containing an enlarged run wraps at
+    /// the run's real size instead of the base size. Falls back to the base <see cref="MeasureString(string)"/>
+    /// when no inline runs cover the range, keeping plain-text wrapping byte-identical.
+    /// </summary>
+    public float MeasureString(string whatToMeasure, int absoluteStartIndexInStrippedText)
+    {
+        if (InlineVariables.Count == 0)
+        {
+            return MeasureString(whatToMeasure);
+        }
+
+        var substrings = GetStyledSubstrings(absoluteStartIndexInStrippedText, whatToMeasure);
+        if (substrings.Count == 0)
+        {
+            return MeasureString(whatToMeasure);
+        }
+
+        return MeasureStyledLineInBaseUnits(substrings, out _);
     }
     #endregion
 


### PR DESCRIPTION
## What

Part of #3520 — the **wrapping** half. A fixed-width `Text` containing an inline BBCode run that
enlarges the text (`[FontSize=N]` font swap or `[FontScale=N]` multiplier) wrapped at the **base**
font size, so words packed onto a base-measured line and the enlarged run then spilled past the wrap
width. The **size-reporting** halves already shipped: #3523 (RelativeToChildren width) and
#3524/#3525 (swap-run height + raylib font-swap). This is the deferred line-breaking half.

## How

- **Font-aware measurement seam.** New `IWrappedText.MeasureString(string, int absoluteStartIndexInStrippedText)`
  as a **default interface method** (base-font fallback), following the existing
  `IRenderable.BatchKey => string.Empty` DIM precedent so raylib/Sokol `Text` keep compiling unchanged.
  `RenderingLibrary.Graphics.Text` overrides it to split the range into styled runs (via the existing
  `GetStyledSubstrings`) and measure each run at its own font/scale, in base units.
- **Index tracking in `UpdateLines`.** The shared wrap loop now threads the current line's absolute
  stripped-text start index (kept in sync with committed line lengths — the same accounting the
  draw/size passes already use) into the seam at its three measurement sites.
- **Shared per-run helper.** Extracted `Text.MeasureStyledLineInBaseUnits`, reused by the size pass
  (`GetInlineVariableAwareWidthAndHeight`) and the new wrap seam, so a run's drawn/measured/wrapped
  size can't drift.
- **Re-wrap after runs populate.** The BBCode path sets `RawText` (which wraps) *before* the
  `InlineVariables` exist, so the first wrap is blind to the runs. `CustomSetPropertyOnRenderable` now
  re-wraps (`UpdateWrappedText`, made public) once the runs are populated, before re-measuring.

Plain-text wrapping is byte-identical (the seam falls back to base `MeasureString` when no run covers
the range), so the existing mid-word / zero-width-space / newline / trailing-space (#2617) wrap pins
stay green.

## Scope

MonoGame / XNA-family (`RenderingLibrary Text`) only. **raylib's wrap stays base-only** this PR and
gets a follow-up (its own font-aware override + re-wrap + pins) — hence "Part of", not "Closes".
Note: because this branch is linked to the issue via `gh issue develop`, merging will auto-close
#3520; reopen it until the raylib follow-up lands.

## Tests

- Red-first, renderable level: `UpdateLines_WithFontSwapRun_WrapsWhereTheEnlargedRunNoLongerFits`
  (isolates the wrap seam).
- Red-first, end-to-end through the real BBCode + font-generation + re-wrap path:
  `WrappedText_ShouldRewrapFontAware_WhenBbCodeFontSizeRunWidensLine` (exercises the re-wrap
  sequencing).
- Full `MonoGameGum.Tests` green (1817); `RaylibGum` + `SkiaGum` build.

## Manual test

Needed (runtime-observable wrap change). Verified via a copy of the MonoGame link-to-source template
pointed at this branch: a fixed-width `Text` with an inline `[FontScale=3]` run now breaks the
enlarged word onto its own line inside the box instead of spilling past the right edge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
