### PR TITLE
Extract + pin MonoGame Text per-line height (follow-up to #3532)

### DIFF
--- a/MonoGameGum.Tests/RenderingLibraries/TextTests.cs
+++ b/MonoGameGum.Tests/RenderingLibraries/TextTests.cs
@@ -51,6 +51,50 @@ char id=37   x=161   y=0     width=22    height=20    xoffset=1     yoffset=6   
         return font;
     }
 
+    // Pins the per-line vertical growth the inline-text draw relies on: a styled line's rendered height
+    // must grow to the tallest run's scale, so a following wrapped line is advanced BELOW an enlarged run
+    // instead of drawn on top of it. This is the DRAW-side computation (ComputeStyledLineHeight, consumed
+    // by DrawWithInlineVariables to advance topOfLine) — distinct from the measurement path
+    // (WrappedTextHeight), which the raylib #3532 bug proved can be correct while the draw advance is
+    // wrong. A [FontScale=2] run must double the line height; the ratio keeps the assert independent of
+    // GlobalFontScale.
+    [Fact]
+    public void ComputeStyledLineHeight_ShouldGrowToTallestRunScale()
+    {
+        BitmapFont font = new BitmapFont((Texture2D)null!, AbcFontData(xadvance: 10, lineHeight: 20));
+        font.SetFontPattern(256, 256);
+
+        Text baseLine = new Text();
+        baseLine.BitmapFont = font;
+        baseLine.InlineVariables.Add(new InlineVariable
+        {
+            VariableName = "FontScale",
+            Value = 1f,
+            StartIndex = 0,
+            CharacterCount = 2
+        });
+        baseLine.RawText = "AA";
+        List<StyledSubstring> baseSubstrings = baseLine.GetStyledSubstrings(0, baseLine.WrappedText[0]);
+        float baseHeight = baseLine.ComputeStyledLineHeight(baseLine.BitmapFont, baseSubstrings, out float _);
+        baseHeight.ShouldBeGreaterThan(0);
+
+        Text scaledLine = new Text();
+        scaledLine.BitmapFont = font;
+        scaledLine.InlineVariables.Add(new InlineVariable
+        {
+            VariableName = "FontScale",
+            Value = 2f,
+            StartIndex = 0,
+            CharacterCount = 2
+        });
+        scaledLine.RawText = "AA";
+        List<StyledSubstring> scaledSubstrings = scaledLine.GetStyledSubstrings(0, scaledLine.WrappedText[0]);
+        float scaledHeight = scaledLine.ComputeStyledLineHeight(scaledLine.BitmapFont, scaledSubstrings, out float _);
+
+        scaledHeight.ShouldBe(baseHeight * 2,
+            "because the tallest run's [FontScale=2] doubles the line's rendered height, which is what advances the next line past it");
+    }
+
     // Regression guard for the #3372 fix: when the height is a real, independent constraint,
     // TextOverflowVerticalMode.TruncateLine MUST still clip to the number of fully-fitting
     // lines. The fix only removes the content-derived (RelativeToChildren) height->lines

--- a/RenderingLibrary/Graphics/Text.cs
+++ b/RenderingLibrary/Graphics/Text.cs
@@ -1093,36 +1093,7 @@ public class Text : SpriteBatchRenderableBase, IRenderableIpso, IVisible, IWrapp
             else
             {
                 individualLineWidth[0] = widths[i];
-                var lineHeight = fontToUse.EffectiveLineHeight(EffectiveFontScale, LineHeightMultiplier);
-                var defaultBaseline = fontToUse.BaselineY;
-
-                float currentFontScale = EffectiveFontScale;
-                float maxFontScale = EffectiveFontScale;
-                BitmapFont currentFont = fontToUse;
-
-                float maxBaseline = currentFontScale * currentFont.BaselineY;
-
-                foreach (var substring in substrings)
-                {
-                    for (int variableIndex = 0; variableIndex < substring.Variables.Count; variableIndex++)
-                    {
-                        var variable = substring.Variables[variableIndex];
-                        if (variable.VariableName == nameof(FontScale))
-                        {
-                            currentFontScale = (float)variable.Value * SystemManagers.GlobalFontScale;
-                            lineHeight = System.Math.Max(lineHeight, currentFont.EffectiveLineHeight(currentFontScale, 1));
-                            maxFontScale = System.Math.Max(maxFontScale, currentFontScale);
-                            maxBaseline = System.Math.Max(maxBaseline, currentFontScale * currentFont.BaselineY);
-                        }
-                        else if (variable.VariableName == nameof(BitmapFont))
-                        {
-                            currentFont = (BitmapFont)variable.Value;
-                            lineHeight = System.Math.Max(lineHeight, currentFont.EffectiveLineHeight(currentFontScale, 1));
-                            maxBaseline = System.Math.Max(maxBaseline, currentFontScale * currentFont.BaselineY);
-
-                        }
-                    }
-                }
+                float lineHeight = ComputeStyledLineHeight(fontToUse, substrings, out float maxBaseline);
 
                 for(int substringIndex = 0; substringIndex < substrings.Count; substringIndex++)
                 {
@@ -1302,6 +1273,44 @@ public class Text : SpriteBatchRenderableBase, IRenderableIpso, IVisible, IWrapp
             }
             startOfLineIndex += lineOfText.Length;
         }
+    }
+
+    /// <summary>
+    /// Computes a styled (inline-variable) line's rendered height in pixels, growing the base line height
+    /// by the tallest inline [FontScale]/[FontSize] run on the line, and returns that tallest run's baseline
+    /// via <paramref name="maxBaseline"/>. Primarily called by <see cref="DrawWithInlineVariables"/> — to
+    /// advance past an enlarged run (so a following line is not drawn on top of it) and to baseline-align
+    /// shorter runs — and exposed so the per-line height can be unit-pinned without rendering.
+    /// </summary>
+    public float ComputeStyledLineHeight(BitmapFont fontToUse, List<StyledSubstring> substrings, out float maxBaseline)
+    {
+        var lineHeight = fontToUse.EffectiveLineHeight(EffectiveFontScale, LineHeightMultiplier);
+
+        float currentFontScale = EffectiveFontScale;
+        BitmapFont currentFont = fontToUse;
+        maxBaseline = currentFontScale * currentFont.BaselineY;
+
+        foreach (var substring in substrings)
+        {
+            for (int variableIndex = 0; variableIndex < substring.Variables.Count; variableIndex++)
+            {
+                var variable = substring.Variables[variableIndex];
+                if (variable.VariableName == nameof(FontScale))
+                {
+                    currentFontScale = (float)variable.Value * SystemManagers.GlobalFontScale;
+                    lineHeight = System.Math.Max(lineHeight, currentFont.EffectiveLineHeight(currentFontScale, 1));
+                    maxBaseline = System.Math.Max(maxBaseline, currentFontScale * currentFont.BaselineY);
+                }
+                else if (variable.VariableName == nameof(BitmapFont))
+                {
+                    currentFont = (BitmapFont)variable.Value;
+                    lineHeight = System.Math.Max(lineHeight, currentFont.EffectiveLineHeight(currentFontScale, 1));
+                    maxBaseline = System.Math.Max(maxBaseline, currentFontScale * currentFont.BaselineY);
+                }
+            }
+        }
+
+        return lineHeight;
     }
 
     // made public for auto tests:


### PR DESCRIPTION
## What & why

A small, safe step toward making the XNA-family (MonoGame/KNI/FNA) **draw-time** vertical stacking of inline-styled text testable — a follow-up to the raylib fix in #3532/#3533.

`DrawWithInlineVariables` computes each styled line's grown height inline (base line height `Max`'d with each inline `[FontScale]`/`[FontSize]` run's scale) and advances `topOfLine` by it. MonoGame does this **correctly** (a wrapped line after an enlarged run is pushed below it), but the computation was **unobservable by any unit test** — `Text.Render` isn't unit-driven, and nothing exposed the per-line height. So a raylib-style regression (advancing by *base* height instead of the grown height) would ship uncaught.

Crucially, the existing measurement-level pins (`WrappedTextHeight_*`) do **not** guard this: raylib #3532 proved the **draw** path and the separate **measurement** path (`GetInlineVariableAwareWidthAndHeight`) can be correct in one and wrong in the other.

## Change

- **Behavior-preserving Extract Method.** The self-contained ~30-line height/baseline block moves verbatim into `public Text.ComputeStyledLineHeight(BitmapFont fontToUse, List<StyledSubstring> substrings, out float maxBaseline)`; `DrawWithInlineVariables` now calls it.
- **Boyscout:** drops two dead locals the block produced (`defaultBaseline`, `maxFontScale` — assigned, never read).
- **Pin:** `ComputeStyledLineHeight_ShouldGrowToTallestRunScale` asserts a `[FontScale=2]` run doubles the line height (ratio-based, so independent of `GlobalFontScale`). Confirmed it has teeth by temporarily sabotaging the growth and watching it go red.

## Scope note (deliberate)

This pins the **per-line height computation** — the complex, quirky part where a raylib-style bug's root cause lives — **not yet** the cross-line `topOfLine` accumulation. That's a deliberate first step: it converts "can't test the draw at all" into "the hard 30 lines are pinned," for near-zero risk. A later step could route the accumulation through this seam to pin the full stacking.

## Verification

- Full `MonoGameGum.Tests`: **1820 passed, 0 failed** (proves the extraction is behavior-preserving).
- Pin verified red-on-regression via sabotage, then restored.

Manual test: **not needed** — behavior-preserving Extract Method + dead-local removal; the compiler and the full suite are the proof (the draw produces byte-identical output).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
