### PR TITLE
Default Standards palette on when setting is absent (#3408)

### DIFF
--- a/Gum/Plugins/InternalPlugins/MenuStripPlugin/MenuStripManager.cs
+++ b/Gum/Plugins/InternalPlugins/MenuStripPlugin/MenuStripManager.cs
@@ -280,7 +280,7 @@ namespace Gum.Managers
             {
                 Header = "Standards palette (experimental)",
                 IsCheckable = true,
-                IsChecked = _projectManager.GeneralSettingsFile?.UseStandardsPalette ?? false
+                IsChecked = _projectManager.GeneralSettingsFile?.EffectiveUseStandardsPalette ?? false
             };
             // WPF toggles IsChecked before Click fires for a checkable item.
             _standardsPaletteMenuItem.Click += (_, _) =>
@@ -292,7 +292,7 @@ namespace Gum.Managers
                 }
                 settings.UseStandardsPalette = _standardsPaletteMenuItem.IsChecked;
                 settings.Save();
-                _messenger.Send(new StandardsPaletteSettingChangedMessage(settings.UseStandardsPalette));
+                _messenger.Send(new StandardsPaletteSettingChangedMessage(settings.EffectiveUseStandardsPalette));
             };
             _viewMenuItem.Items.Add(_standardsPaletteMenuItem);
 
@@ -349,7 +349,7 @@ namespace Gum.Managers
             // The settings file loads after PopulateMenu, so keep the checkmark in sync here.
             if (_standardsPaletteMenuItem != null && _projectManager.GeneralSettingsFile is { } generalSettings)
             {
-                _standardsPaletteMenuItem.IsChecked = generalSettings.UseStandardsPalette;
+                _standardsPaletteMenuItem.IsChecked = generalSettings.EffectiveUseStandardsPalette;
             }
 
             if (_selectedState.SelectedStateSave != null && _selectedState.SelectedStateSave.Name != "Default")

--- a/Gum/Plugins/InternalPlugins/TreeView/ElementTreeViewManager.cs
+++ b/Gum/Plugins/InternalPlugins/TreeView/ElementTreeViewManager.cs
@@ -839,7 +839,7 @@ public partial class ElementTreeViewManager : IRecipient<ThemeChangedMessage>, I
     /// </summary>
     public void ApplyStandardsPaletteMode()
     {
-        bool usePalette = _projectState.GeneralSettings?.UseStandardsPalette == true;
+        bool usePalette = _projectState.GeneralSettings?.EffectiveUseStandardsPalette == true;
 
         if (mStandardElementsTreeNode != null)
         {
@@ -1460,7 +1460,7 @@ public partial class ElementTreeViewManager : IRecipient<ThemeChangedMessage>, I
             // When the experimental Standards palette is on, the Standard folder is replaced by the
             // chip palette, so it is not shown in the tree. The node object is still kept (and still
             // populated) so toggling the setting at runtime can restore it without a full rebuild.
-            if (_projectState.GeneralSettings?.UseStandardsPalette != true)
+            if (_projectState.GeneralSettings?.EffectiveUseStandardsPalette != true)
             {
                 ObjectTreeView.Nodes.Add(mStandardElementsTreeNode);
             }
@@ -1807,7 +1807,7 @@ public partial class ElementTreeViewManager : IRecipient<ThemeChangedMessage>, I
         // signal that standard elements may have changed (e.g. "Add Skia Standard Elements", which
         // only calls RefreshElementTreeView and raises no ElementAdd event). RefreshChips is
         // idempotent, so this is a no-op when the standard set is unchanged.
-        if (_projectState.GeneralSettings?.UseStandardsPalette == true)
+        if (_projectState.GeneralSettings?.EffectiveUseStandardsPalette == true)
         {
             RefreshStandardsPaletteChips();
         }

--- a/Gum/Settings/GeneralSettingsFile.cs
+++ b/Gum/Settings/GeneralSettingsFile.cs
@@ -54,15 +54,26 @@ namespace Gum.Settings
         }
 
         /// <summary>
-        /// When true, the experimental "Standards palette" UI is used: the Standard folder is
-        /// removed from the element tree and the standard types are shown as a draggable chip
-        /// palette at the bottom of the Project panel instead. Opt-in while experimental.
+        /// The user's explicit choice for the "Standards palette" UI, or null when they have never
+        /// chosen. When on, the Standard folder is removed from the element tree and the standard
+        /// types are shown as a draggable chip palette at the bottom of the Project panel instead.
+        /// Null (absent from GeneralSettings.xml) resolves to on via <see cref="EffectiveUseStandardsPalette"/>;
+        /// an explicit false written by the View-menu toggle keeps a user opted out. Read
+        /// <see cref="EffectiveUseStandardsPalette"/> for the resolved value rather than this raw setting.
         /// </summary>
-        public bool UseStandardsPalette
+        public bool? UseStandardsPalette
         {
             get;
             set;
         }
+
+        /// <summary>
+        /// The resolved Standards-palette mode. Defaults to on when the user has never made an
+        /// explicit choice (<see cref="UseStandardsPalette"/> is null); otherwise honors their choice.
+        /// </summary>
+        [XmlIgnore]
+        [JsonIgnore]
+        public bool EffectiveUseStandardsPalette => UseStandardsPalette ?? true;
 
         public int FrameRate
         {
@@ -142,7 +153,8 @@ namespace Gum.Settings
         {
             ShowTextOutlines = false;
             AutoSave = true;
-            UseStandardsPalette = false;
+            // UseStandardsPalette is intentionally left null (unset) so a user who has never chosen
+            // resolves to on via EffectiveUseStandardsPalette. See #3408.
             FrameRate = 30;
             LeftAndEverythingSplitterDistance = 196;
             PreviewSplitterDistance = 558;

--- a/Tool/Tests/GumToolUnitTests/Settings/GeneralSettingsFileTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Settings/GeneralSettingsFileTests.cs
@@ -1,0 +1,47 @@
+using System.IO;
+using System.Xml.Serialization;
+using Gum.Settings;
+using Shouldly;
+
+namespace GumToolUnitTests.Settings;
+
+public class GeneralSettingsFileTests
+{
+    [Theory]
+    [InlineData(null, true)]   // Never chosen -> the Standards palette defaults on.
+    [InlineData(false, false)] // Explicit opt-out is honored.
+    [InlineData(true, true)]   // Explicit opt-in is honored.
+    public void EffectiveUseStandardsPalette_ResolvesUnsetToOn(bool? stored, bool expected)
+    {
+        GeneralSettingsFile settings = new GeneralSettingsFile
+        {
+            UseStandardsPalette = stored
+        };
+
+        settings.EffectiveUseStandardsPalette.ShouldBe(expected);
+    }
+
+    [Fact]
+    public void UseStandardsPalette_DefaultsToNull_SoNewUsersGetPaletteOn()
+    {
+        GeneralSettingsFile settings = new GeneralSettingsFile();
+
+        settings.UseStandardsPalette.HasValue.ShouldBeFalse();
+        settings.EffectiveUseStandardsPalette.ShouldBeTrue();
+    }
+
+    [Theory]
+    // Setting absent from the file (fresh installs / users who never toggled it) resolves to on.
+    [InlineData("<GeneralSettingsFile></GeneralSettingsFile>", true)]
+    // A value explicitly written to the file is honored, so an opt-out survives the flip.
+    [InlineData("<GeneralSettingsFile><UseStandardsPalette>false</UseStandardsPalette></GeneralSettingsFile>", false)]
+    [InlineData("<GeneralSettingsFile><UseStandardsPalette>true</UseStandardsPalette></GeneralSettingsFile>", true)]
+    public void EffectiveUseStandardsPalette_ResolvesFromDeserializedXml(string xml, bool expected)
+    {
+        XmlSerializer serializer = new XmlSerializer(typeof(GeneralSettingsFile));
+        using StringReader reader = new StringReader(xml);
+        GeneralSettingsFile settings = (GeneralSettingsFile)serializer.Deserialize(reader)!;
+
+        settings.EffectiveUseStandardsPalette.ShouldBe(expected);
+    }
+}


### PR DESCRIPTION
Closes #3408.

## What

Flip the default so the **Standards palette** is **on** for users who have never made an explicit choice, while keeping the View-menu toggle able to turn it off.

Implements the issue's recommended Option 1 (nullable backing field):

- `GeneralSettingsFile.UseStandardsPalette` is now `bool?`. `null` = never chosen; a non-null value = the user's explicit choice.
- New `EffectiveUseStandardsPalette => UseStandardsPalette ?? true` centralizes the "absent → on" resolution. The constructor no longer forces `false`, so a fresh settings object (and any file lacking the element) resolves to on.
- The three tree-view read sites (`ApplyStandardsPaletteMode`, `CreateRootTreeNodesIfNecessary`, the refresh-chips path) and the View-menu checkbox now read `EffectiveUseStandardsPalette`. Object-null (settings not yet loaded) still falls back to the classic tree, unchanged.
- The menu toggle still writes a concrete `true`/`false`, so **View → Standards palette** can turn it off, and an opt-out survives the default flip.

## Known limitation (by design, per the issue)

`UseStandardsPalette` shipped as a non-nullable `bool` in #3404, so every user who launched a palette-capable build and saved settings already has `<UseStandardsPalette>false</UseStandardsPalette>` auto-written. Those users are indistinguishable from an explicit opt-out and will **not** flip to on — only users whose file lacks the element (fresh installs / never-saved) get the new default. This is the "explicitly opted out stays out" trade-off the issue chose Option 1 for. Flipping the auto-`false` cohort too would require the heavier Option 2 (one-time migration).

## Tests

`GeneralSettingsFileTests` (new): resolution of null/false/true → effective value, the constructor default (null → on), and an XML round-trip proving an absent element resolves to on while a written value is honored. Red-first verified by inverting `?? true` → `?? false` (3 cases went red). Full `GumFull.sln` builds clean; menu/tree-view/composition suites green (35/35).
