### PR TITLE
Zero-alloc fast path for single-line text wrapping (Part of #1934)

### DIFF
--- a/MonoGameGum.Tests/RenderingLibraries/TextTests.cs
+++ b/MonoGameGum.Tests/RenderingLibraries/TextTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.Xna.Framework.Graphics;
+using MonoGameGum.TestsCommon;
 using RenderingLibrary.Graphics;
 using Shouldly;
 using System.Reflection;
@@ -204,6 +205,32 @@ char id=65 x=0 y=0 width={xadvance} height=13 xoffset=0 yoffset=4 xadvance={xadv
 char id=66 x=0 y=0 width={xadvance} height=13 xoffset=0 yoffset=4 xadvance={xadvance} page=0 chnl=15
 char id=67 x=0 y=0 width={xadvance} height=13 xoffset=0 yoffset=4 xadvance={xadvance} page=0 chnl=15
 ";
+
+    // #1934 allocation pass: the RelativeToChildren natural-size measurement re-wraps a Text every
+    // layout frame by toggling its Width (unconstrained to read natural size, then back). For a Text
+    // that fits on a single line, the word-by-word wrapping algorithm reproduces the raw text verbatim,
+    // so re-wrapping must short-circuit to zero managed allocation rather than churning a List/Split/
+    // per-word string concatenation on every frame. This is the dominant full-relayout allocation source.
+    [Fact]
+    public void UpdateWrappedText_WhenTextFitsOnOneLine_DoesNotAllocate()
+    {
+        const int advance = 10;
+        BitmapFont font = new BitmapFont((Texture2D)null!, AbcFontData(advance, lineHeight: 20));
+        font.SetFontPattern(256, 256);
+
+        Text text = new Text();
+        text.BitmapFont = font;
+        text.Width = 1000;            // "AB AB" is 5 chars * 10 = 50 wide, far under 1000 -> one line
+        text.RawText = "AB AB";
+        text.WrappedText.Count.ShouldBe(1); // guard: the scenario really is single-line
+
+        AllocationResult result = AllocationMeasurer.Measure(
+            () => text.UpdateWrappedText(),
+            warmupIterations: 50,
+            measuredIterations: 500);
+
+        result.TotalBytes.ShouldBe(0);
+    }
 
     // #3520: a base run that FOLLOWS a font-swap run (like " text." after [FontSize=40]big[/FontSize])
     // must be measured at the base size. Reproduces the residual under-measurement the manual test

--- a/RenderingLibrary/Graphics/IWrappedText.cs
+++ b/RenderingLibrary/Graphics/IWrappedText.cs
@@ -79,9 +79,9 @@ public static class IWrappedTextExtensions
             ? ellipsisWidth = textInstance.MeasureString(ellipsis)
             : 0;
 
-        string? stringToUse = string.IsNullOrEmpty(textInstance.RawText)
-            ? null
-            : stringToUse = textInstance.RawText.Replace("\r\n", "\n");
+        // Past the early-out above, RawText is non-empty. Multiline text editing in Gum can add \r's,
+        // so normalize CRLF once here; both the fast path and the wrapping loop consume this form.
+        string stringToUse = textInstance.RawText!.Replace("\r\n", "\n");
 
 
         int wrappingWidth = int.MaxValue;
@@ -92,12 +92,28 @@ public static class IWrappedTextExtensions
 
         wrappingWidth = System.Math.Max(0, wrappingWidth);
 
+        // FAST PATH (issue #1934): a string with no explicit newline that already fits within the wrap
+        // width wraps to exactly one line equal to itself, so short-circuit the word-by-word algorithm
+        // below and add it directly with zero managed allocation. The general algorithm reproduces
+        // stringToUse verbatim in this case — interior/leading/trailing spaces included (see #2617) — so
+        // this is behavior-preserving. This is the common case, and specifically the natural-size
+        // (unconstrained-width) measurement pass a RelativeToChildren Text runs every layout frame, which
+        // was the dominant full-relayout allocation source (it re-tokenized/Split/concatenated an
+        // unchanged, unwrapped string ~60x/second). MeasureString is allocation-free when the text has no
+        // inline runs (it sums glyph advances); inline-BBCode text still measures correctly, just not for
+        // free. Ellipsis/truncation only engages on a word that overflows, so it never applies when the
+        // whole string fits — safe to skip.
+        if (!ToolsUtilities.StringFunctions.ContainsNoAlloc(stringToUse, '\n')
+            && textInstance.MeasureString(stringToUse, 0) <= wrappingWidth)
+        {
+            lines.Add(stringToUse);
+            return;
+        }
 
         // This allocates like crazy but we're
         // on the PC and prob won't be calling this
-        // very frequently so let's 
+        // very frequently so let's
         String currentLine = String.Empty;
-        String returnString = String.Empty;
 
         // The absolute character index (in the stripped text) where the current line begins. It equals the
         // total length of the lines already committed, so it stays in sync with the inline-variable indexing
@@ -109,15 +125,7 @@ public static class IWrappedTextExtensions
 
         // The words to process, including the current word
         List<string> remainingWordsToProcess = new();
-
-        // The user may have entered "\n" in the string, which would 
-        // be written as "\\n".  Let's replace that, shall we?
-        if (!string.IsNullOrEmpty(textInstance.RawText))
-        {
-            // multiline text editing in Gum can add \r's, so get rid of those:
-            stringToUse = textInstance.RawText.Replace("\r\n", "\n");
-            remainingWordsToProcess.AddRange(stringToUse.Split(whatToSplitOn));
-        }
+        remainingWordsToProcess.AddRange(stringToUse.Split(whatToSplitOn));
 
 
         bool isLastLine = false;
@@ -287,7 +295,6 @@ public static class IWrappedTextExtensions
                         }
                     }
 
-                    //returnString = returnString + line + '\n';
                     currentLine = String.Empty;
                 }
             }

--- a/Tests/MonoGameGum.IntegrationTests/MonoGameGum/Performance/LayoutAllocationTests.cs
+++ b/Tests/MonoGameGum.IntegrationTests/MonoGameGum/Performance/LayoutAllocationTests.cs
@@ -95,11 +95,14 @@ public class RealisticLayoutAllocationTests : BaseTestClass
             $"{result.BytesPerIteration:N0} bytes/frame " +
             $"({result.TotalBytes:N0} bytes over {result.Iterations} frames)");
 
-        // Baseline ratchet (#1934): a full relayout of a real Forms tree with Text allocates a
-        // deterministic 1,584 bytes/frame locally. This pins that cost plus headroom for JIT/runner
-        // variance so a regression that grows it fails the build; tighten as sources are removed.
-        // No fix here.
-        result.BytesPerIteration.ShouldBeLessThanOrEqualTo(2200);
+        // Ratchet (#1934): a full relayout of a real Forms tree with Text allocates a deterministic
+        // 240 bytes/frame locally — down from 1,584 after the single-line-wrap fast path in
+        // IWrappedTextExtensions.UpdateLines (pinned by
+        // TextTests.UpdateWrappedText_WhenTextFitsOnOneLine_DoesNotAllocate). The residual is the one
+        // genuinely-wrapping Text — the TextBox content re-wrapping at its constrained width each frame,
+        // which still tokenizes/Splits/concatenates; tighten further as that word-by-word path is made
+        // allocation-free. Pins the current cost plus headroom for runtime/runner variance.
+        result.BytesPerIteration.ShouldBeLessThanOrEqualTo(400);
     }
 
     /// <summary>


### PR DESCRIPTION
Part of #1934 (runtime allocation pass). Continues the ratchet after the idle `Draw` pass (#3514); this one targets the **full-relayout Text path** the handoff comment flagged as next.

## Finding

Profiling the realistic-Forms full-relayout scenario showed **1,504 of 1,584 bytes/frame (95%)** came from text **wrapping**, from just **4 wrap calls/frame** — all the *same* unchanged `TextBox` string, re-wrapped with its `Width` toggling ∞↔90 by the `RelativeToChildren` natural-size measurement (measure unconstrained, then restore). `IWrappedTextExtensions.UpdateLines` re-tokenized/`Split`/concatenated that string on every call even though it fits on one line and the result is the raw string itself.

## Fix

A **single-line fast path** in `UpdateLines`: when a string has no explicit newline and already fits within the wrap width, add it as the one line and return — zero managed allocation. The word-by-word algorithm reproduces the raw string verbatim in that case (interior/leading/trailing spaces included, per #2617), so it's behavior-preserving. `MeasureString` is allocation-free for text without inline runs (it sums glyph advances).

## Impact

| Scenario | Before | After |
|---|---|---|
| Realistic Forms full relayout | 1,584 B/f | **240 B/f** (−85%) |
| `UpdateWrappedText` on a fitting single line | 288 B/call | **0 B/call** |

The residual **240 B/f** is the one genuinely-wrapping Text (the `TextBox` content re-wrapping at its constrained width) — the next ratchet target (making the word-by-word path itself allocation-free).

## Tests (TDD, red→green)

- New `TextTests.UpdateWrappedText_WhenTextFitsOnOneLine_DoesNotAllocate` — asserted `288 → 0` (failed red before the fast path).
- Ratchet `RealisticLayoutAllocationTests` tightened **2,200 → 400** (pins 240).
- Full suites green: MonoGameGum.Tests 1821, Integration, SkiaGum 197, RaylibGum 454 — the ~25 existing wrapping tests (fixed-width, mid-word break, zero-width space, trailing space #2617, newlines, ellipsis, inline BBCode) pin the algorithm's output.

Boyscout: removed a dead `stringToUse` recompute (`Replace` ran twice) and an unused `returnString` local in the same method.
