### PR TITLE
Add gum-skills/ folder with 5 consumer-facing AI skills (#2700)

### DIFF
--- a/gum-skills/README.md
+++ b/gum-skills/README.md
@@ -1,0 +1,69 @@
+# gum-skills
+
+Skills for developers building game UI **with** Gum.
+
+Drop the subfolders you want into your project's `.claude/skills/` (or your
+user-global `~/.claude/skills/`) to give an AI assistant such as Claude Code
+durable, concept-level context on Gum — file formats, layout, Forms controls,
+and the `gumcli` command-line tool. A skill loads automatically when its
+`description` matches what you are doing, so the assistant stops guessing at
+Gum's conventions and starts following them.
+
+These are **3rd-party skills**: they describe how to *use* Gum from a game
+project. Skills for working *on* Gum itself live in the repo's own
+`/.claude/skills/` folder and are not meant for distribution — do not add
+engine-internal material here.
+
+## Getting started
+
+Copy `gum-overview` first — it is the single entry point the other skills
+assume — then add the topical skills that match your work:
+
+| Skill | Use it for |
+|-------|-----------|
+| `gum-overview` | What Gum is, project file types, usage modes, project wiring. **Start here.** |
+| `gumcli` | Scaffolding, code generation, validation, and screenshots from the command line. |
+| `gum-file-format` | Reading and safely hand-editing `.gumx`/`.gusx`/`.gucx`/`.gutx` XML. |
+| `gum-forms-controls` | Buttons, text boxes, lists, panels, and the state/category styling system. |
+| `gum-layout` | Positioning and sizing — units, anchor/dock, stacking. |
+
+A good default set is `gum-overview` + `gumcli` + whichever of `gum-layout`,
+`gum-forms-controls`, and `gum-file-format` your task touches.
+
+These skills pair with two other AI aids Gum ships: the **MCP documentation
+server** (live, authoritative doc lookups) and **`gumcli`** (act on a project
+and verify the result). See <https://docs.flatredball.com/gum/ai> for the full
+picture.
+
+## Authoring a new skill
+
+Each skill is a folder containing a single `SKILL.md`. The file starts with
+YAML frontmatter and uses `##` sections for the body:
+
+```markdown
+---
+name: gum-example
+description: One line telling the assistant WHEN this skill is relevant. Triggers: distinctive words, file types, symbols.
+---
+
+# Title
+
+## Section
+Concise, high-signal guidance. Link to the docs for depth.
+```
+
+Guidelines:
+
+- **`description` is a trigger, not a summary.** Keep it to one line. Lead with
+  the topic, then list the distinctive words, file extensions, or symbols that
+  should activate it. It is loaded on every session, so keep it short.
+- **Link to the docs; don't restate them.** Point at
+  <https://docs.flatredball.com/gum> for anything that lives there. A skill is a
+  map and a list of gotchas, not a copy of the manual.
+- **Keep it short and self-contained.** The reader does not have Gum's source
+  tree — favor concrete rules and small examples over "see this class."
+- **Add a `references/` subfolder** only when a skill needs bulky supporting
+  material (long tables, extended examples) that would bloat `SKILL.md`.
+
+When a skill becomes broadly useful, propose adding it here by opening an issue
+or PR on the [Gum repository](https://github.com/vchelaru/Gum).

--- a/gum-skills/gum-file-format/SKILL.md
+++ b/gum-skills/gum-file-format/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: gum-file-format
+description: Reading and safely hand-editing Gum's XML files — enum-to-int mappings for Units/Origins/ChildrenLayout, qualified InstanceName.Property variables, and why hand-edited files silently break. Triggers: editing .gusx/.gucx/.gutx by hand, WidthUnits/XOrigin values, gumcli check errors.
+---
+
+# Gum File Format
+
+Gum projects are XML, serialized with .NET's `XmlSerializer`. Prefer editing
+them with the Gum tool or `gumcli`; when you must read or hand-edit, this skill
+covers the structure and the traps. **Always run `gumcli check` after a hand
+edit** — several failure modes below are silent otherwise (see **gumcli**).
+
+## File → root element
+
+| Extension | Root element |
+|-----------|--------------|
+| `.gumx` (project) | `<GumProjectSave>` — lists element references, loaded first |
+| `.gusx` (screen) | `<ScreenSave>` |
+| `.gucx` (component) | `<ComponentSave>` |
+| `.gutx` (standard element) | `<StandardElementSave>` |
+| `.behx` (behavior) | `<BehaviorSave>` |
+
+## Element structure
+
+Every file needs the complete root tag **with both XML-schema namespaces** —
+the `xsi:`/`xsd:` prefixes used on every `<Value>` are undefined without them.
+The element has a `<Name>`, an optional `<BaseType>` (what it inherits from,
+e.g. `Container`), one or more `<State>`s (the first is `Default`), and a list
+of `<Instance>`s (child objects). A state holds `<Variable>` entries. This is a
+complete, valid screen (it passes `gumcli check`):
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<ScreenSave xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <Name>MainMenu</Name>
+  <State>
+    <Name>Default</Name>
+    <Variable Type="ChildrenLayout" Name="MenuStack.ChildrenLayout"><Value xsi:type="xsd:int">1</Value></Variable>
+    <Variable Type="string" Name="Title.Parent"><Value xsi:type="xsd:string">MenuStack</Value></Variable>
+    <Variable Type="string" Name="Title.Text"><Value xsi:type="xsd:string">Main Menu</Value></Variable>
+  </State>
+  <Instance><Name>MenuStack</Name><BaseType>Container</BaseType></Instance>
+  <Instance><Name>Title</Name><BaseType>Text</BaseType></Instance>
+</ScreenSave>
+```
+
+**`<Name>`** is the element's name — path-qualified for an element in a
+subfolder (`Elements/Divider`), otherwise bare (`MainMenu`). It must match the
+reference to it in the `.gumx`.
+
+**Qualified variable names.** A variable named `MenuStack.ChildrenLayout` sets
+the `ChildrenLayout` of the instance named `MenuStack`. No dot means an
+element-level value. The name before the dot must match an `<Instance>`'s
+`<Name>`.
+
+**Parenting instances.** Instances are siblings by default — all direct children
+of the element root. To nest one inside another, give the child a `Parent`
+variable whose value is the parent instance's name (`Title.Parent = MenuStack`
+above puts `Title` inside `MenuStack`, so the container's stacking layout
+arranges it). Without it, a stacking container has nothing to lay out.
+
+## Landmine: enum values are stored as integers
+
+For an enum-typed variable, the `Type` attribute holds the enum name but the
+`<Value>` holds its **underlying int** (`xsi:type="xsd:int"`), not the name.
+`WidthUnits` = `2` means `RelativeToParent`. You must know the mappings to read
+or write these correctly:
+
+### WidthUnits / HeightUnits — `DimensionUnitType`
+
+| Int | Name | Int | Name |
+|----|------|----|------|
+| 0 | Absolute | 6 | MaintainFileAspectRatio |
+| 1 | PercentageOfParent | 7 | Ratio |
+| 2 | RelativeToParent | 8 | AbsoluteMultipliedByFontScale |
+| 3 | PercentageOfSourceFile | 9 | ScreenPixel |
+| 4 | RelativeToChildren | 10 | RelativeToMaxParentOrChildren |
+| 5 | PercentageOfOtherDimension | | |
+
+### XUnits / YUnits — `PositionUnitType`
+
+One shared enum; some values apply to the X axis, some to Y. **This is not the
+`GeneralUnitType` enum you use in C# code** — on disk `XUnits`/`YUnits` are
+`PositionUnitType`. Do not copy int values between the two.
+
+| Int | Name | Axis | Int | Name | Axis |
+|----|------|:----:|----|------|:----:|
+| 0 | PixelsFromLeft | X | 5 | PixelsFromBottom | Y |
+| 1 | PixelsFromTop | Y | 6 | PixelsFromCenterX | X |
+| 2 | PercentageWidth | X | 7 | PixelsFromCenterY | Y |
+| 3 | PercentageHeight | Y | 8 | PixelsFromCenterYInverted | Y |
+| 4 | PixelsFromRight | X | 9 | PixelsFromBaseline | Y |
+
+### XOrigin, and Text `HorizontalAlignment` — `HorizontalAlignment`
+
+`0` = Left, `1` = Center, `2` = Right.
+
+### YOrigin, and Text `VerticalAlignment` — `VerticalAlignment`
+
+`0` = Top, `1` = Center, `2` = Bottom, `3` = TextBaseline.
+
+### ChildrenLayout (on a container) — `Type="ChildrenLayout"`
+
+`0` = Regular, `1` = TopToBottomStack, `2` = LeftToRightStack,
+`3` = AutoGridHorizontal, `4` = AutoGridVertical.
+
+## Landmine: two on-disk variable shapes exist
+
+Gum has written variables two ways over time — a compact **attribute form**
+(current tool output) and an expanded **element form** (older files). Both load:
+
+```xml
+<!-- attribute form -->
+<Variable Type="DimensionUnitType" Name="WidthUnits"><Value xsi:type="xsd:int">0</Value></Variable>
+<!-- element form -->
+<Variable><Type>DimensionUnitType</Type><Name>WidthUnits</Name><Value xsi:type="xsd:int">0</Value><SetsValue>true</SetsValue></Variable>
+```
+
+Do not hand-craft variables from scratch by guessing the shape. Copy the shape
+of an existing variable in the same file, or better, let the tool/`gumcli`
+write them and edit values only.
+
+## Landmine: wrong element names are dropped silently
+
+`XmlSerializer` ignores XML elements it does not recognize — it does not error.
+So `<States>` instead of `<State>`, or `<InstanceSave>` instead of `<Instance>`,
+loads as an **empty** element with no warning, and your UI is silently missing
+content. `gumcli check` is built to catch exactly this. Run it after every hand
+edit.
+
+## Bottom line
+
+Read these files freely; the tables above let you understand and sanity-check
+them. But to *write* them, prefer the Gum tool or `gumcli`, and validate with
+`gumcli check` before trusting the result. Data-model reference:
+<https://docs.flatredball.com/gum/gum-tool/gum-elements>.

--- a/gum-skills/gum-forms-controls/SKILL.md
+++ b/gum-skills/gum-forms-controls/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: gum-forms-controls
+description: Gum Forms controls (Button, Label, TextBox, CheckBox, ListBox, StackPanel…) vs raw visuals, and the state/category styling system. Triggers: adding a button/textbox/list, WPF-style properties not working, IsVisible, styling a control, DefaultVisuals.
+---
+
+# Gum Forms Controls
+
+Forms controls are interactive UI classes whose names mirror WPF (`Button`,
+`CheckBox`, `TextBox`, …), but they are laid out and rendered by **Gum**, not
+WPF. Reach for a Forms control for anything the player clicks, types in, or
+scrolls. For non-interactive HUD/decoration, use raw visuals instead (see
+below). Docs: <https://docs.flatredball.com/gum/code/controls>.
+
+## Common controls
+
+`Button`, `ToggleButton`, `RadioButton`, `CheckBox`, `Label`, `TextBox`,
+`PasswordBox`, `ComboBox`, `ListBox`, `Slider`, `ScrollBar`, `ScrollViewer`,
+`StackPanel`, `Panel`, `Menu`, `Window`, `Splitter`.
+
+## Using a control in code
+
+```csharp
+using Gum.Forms.Controls;
+
+var button = new Button();
+button.Text = "Play";
+button.AddToRoot();               // adds it to the screen
+button.Click += (_, _) => StartGame();
+```
+
+Text-bearing controls share this shape — `new Label()`, `new TextBox()`, etc.
+all expose `.Text`. Set position/size with Gum's unit system (see
+**gum-layout**), not WPF layout.
+
+## Composing controls (parenting in code)
+
+`AddToRoot()` attaches a control to the screen. To nest one control inside
+another — buttons inside a panel, anything inside a container — call `AddChild`
+on the parent. There is **no** `.Children.Add(...)` on a Forms control.
+
+```csharp
+var menu = new StackPanel();   // stacks its children; vertical by default
+menu.Spacing = 8;              // gap between children (StackPanel.Spacing)
+menu.AddToRoot();
+
+var play = new Button { Text = "Play" };
+var quit = new Button { Text = "Quit" };
+menu.AddChild(play);           // parents the control under the panel
+menu.AddChild(quit);
+```
+
+`AddChild(child)` sets the child's visual parent; the parent's layout then
+positions it — a `StackPanel` stacks them, and any container with
+`ChildrenLayout` set arranges them. `RemoveChild` undoes it. `StackPanel`
+defaults to `Orientation.Vertical`; set `Orientation = Orientation.Horizontal`
+for a row.
+
+## Forms vs raw visuals
+
+| Need | Use |
+|------|-----|
+| Player interaction (click/type/scroll) | A Forms control |
+| Static text | `TextRuntime` |
+| Solid color block | `ColoredRectangleRuntime` |
+| Image | `SpriteRuntime` |
+| Scalable panel/border | `NineSliceRuntime` |
+| Plain layout container | `ContainerRuntime` |
+
+Raw visuals: <https://docs.flatredball.com/gum/code/standard-visuals>.
+
+## Landmine: WPF conventions do not carry over
+
+The names match WPF; the property model does not. On a Forms control:
+
+- **No** `Margin`, `Padding`, or WPF-style `HorizontalAlignment`/`VerticalAlignment`.
+  Position and size come from Gum units (`X`, `XUnits`, `Width`, `WidthUnits`, …).
+- **No** `Background`, `Foreground`, or `BorderBrush`. Color and appearance come
+  from **states** (below), not brush properties.
+- **No** `Visibility` enum. Use the `IsVisible` bool.
+- **No** WPF `Auto` sizing. A `Button` with `Width = 128` is 128 px wide
+  regardless of its text unless `WidthUnits = RelativeToChildren`. See
+  **gum-layout**.
+
+For a fuller WPF-to-Gum translation:
+<https://docs.flatredball.com/gum/code/about/for-wpf-users>.
+
+## The state / category system (how styling works)
+
+Appearance is driven by named **states** grouped into a **category** on the
+control's visual, not by per-property setters. A `Button`'s visual, for example,
+carries a category with `Enabled`, `Highlighted`, `Pushed`, `Focused`, and
+`Disabled` states; the control switches between them automatically as the player
+interacts. Each state sets a batch of variables (colors, sizes) at once.
+
+To recognize this in code: applying a state name changes the look; the control
+does this for you on hover/press/focus. To *customize* appearance you edit the
+states (in the tool, or via the styling APIs) or swap in a different visual —
+you do **not** look for a `Color` property on the control. Don't panic when you
+see categories and states; they are Gum's equivalent of a style sheet. Styling
+guide: <https://docs.flatredball.com/gum/code/styling>.
+
+## Default visuals
+
+A newly-constructed control (`new Button()`) gets a built-in default visual so
+it renders without any project. Replacing or restyling that visual is the
+styling story above. If a control looks unstyled or blank, its visual — not the
+control class — is what to inspect.

--- a/gum-skills/gum-layout/SKILL.md
+++ b/gum-skills/gum-layout/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: gum-layout
+description: Positioning and sizing Gum UI — X/Y units, XOrigin/YOrigin, Width/Height units, Anchor/Dock, and child stacking. The top source of layout confusion. Triggers: element in wrong place/size, WidthUnits, XUnits, Anchor, Dock, stacking, centering, fill parent.
+---
+
+# Gum Layout
+
+Every element's position and size is a **number plus a unit** that says how to
+interpret the number relative to its parent, its children, or the screen.
+Getting the unit right — not the number — is what fixes almost all "it's in the
+wrong place / wrong size" problems. Docs:
+<https://docs.flatredball.com/gum/code/layout/introduction-to-gum-layout>.
+
+## The four position inputs
+
+- **`X`, `Y`** — the numbers.
+- **`XUnits`, `YUnits`** — how X/Y are measured. In C# these are
+  `GeneralUnitType` (`PixelsFromSmall` = from the left/top edge, `PixelsFromMiddle`
+  = from center, `PixelsFromLarge` = from the right/bottom edge, `Percentage`).
+  *(On disk these are stored as a different enum — see **gum-file-format**.)*
+- **`XOrigin`, `YOrigin`** — which point **on the element** is being placed
+  (`HorizontalAlignment` Left/Center/Right, `VerticalAlignment` Top/Center/Bottom).
+
+Example — center an element in its parent: set `XOrigin`/`YOrigin` to `Center`
+and `XUnits`/`YUnits` to `PixelsFromMiddle` with `X = 0, Y = 0`.
+
+## The two size inputs
+
+- **`Width`, `Height`** — the numbers.
+- **`WidthUnits`, `HeightUnits`** — `DimensionUnitType`. The ones you use most:
+
+| Unit | Meaning |
+|------|---------|
+| `Absolute` | Value is pixels. |
+| `PercentageOfParent` | Value is a % of the parent (100 = fill). |
+| `RelativeToParent` | Parent size **plus** value px (0 = match parent, −20 = 20 px smaller). |
+| `RelativeToChildren` | Sized to fit children, value = extra padding. |
+| `Ratio` | Split leftover space among `Ratio` siblings. |
+
+## Landmine: there is no WPF-style `Auto`
+
+An element does **not** grow to fit its content unless you ask it to. A `Button`
+with `Width = 128, WidthUnits = Absolute` is 128 px wide no matter how long its
+text is. For content-sized elements use `WidthUnits = RelativeToChildren`.
+
+## Landmine: children-vs-parent size cycles
+
+If a parent is `RelativeToChildren` and a child is `PercentageOfParent` on the
+same axis, the size is circular (parent waits for child, child waits for
+parent). Gum resolves it to avoid a crash, but the result is rarely what you
+want — make one side concrete.
+
+## Anchor & Dock (the easy path)
+
+Prefer these over hand-setting units for common cases. They work on both Forms
+controls and raw visuals, and set several position/size properties at once:
+
+- **`Anchor`** — snap to a spot: `TopLeft`, `Top`, `Center`,
+  `BottomRight`, etc.
+- **`Dock`** — attach and stretch: `Fill`, `Top`, `Left`, `FillHorizontally`,
+  `SizeToChildren`, etc.
+
+```csharp
+panel.Dock(Gum.Wireframe.Dock.Fill);   // fill the parent
+title.Anchor(Gum.Wireframe.Anchor.Top); // pin to top-center
+```
+
+Docs: <https://docs.flatredball.com/gum/code/layout/anchor-and-dock>.
+
+## Stacking children
+
+A container arranges its children by its `ChildrenLayout`:
+
+- `Regular` — children positioned independently (the default).
+- `TopToBottomStack` / `LeftToRightStack` — stack children in order; set
+  `StackSpacing` for gaps, `WrapsChildren = true` to wrap into rows/columns.
+- `AutoGridHorizontal` / `AutoGridVertical` — arrange into a uniform grid.
+
+A `StackPanel` Forms control is a container pre-set to stack — vertical by
+default, with a `Spacing` property (the Forms name for `StackSpacing`). In code,
+add children to any container with `AddChild` (see **gum-forms-controls**); the
+`ChildrenLayout` then arranges them. Docs:
+<https://docs.flatredball.com/gum/code/layout/stacking>.
+
+## Quick recipes
+
+| Goal | Do |
+|------|-----|
+| Fill parent | `Dock(Dock.Fill)` — or `Width/Height = 0`, units `RelativeToParent` |
+| Center in parent | `XOrigin/YOrigin = Center`, `XUnits/YUnits = PixelsFromMiddle`, `X/Y = 0` |
+| Size to text | `WidthUnits/HeightUnits = RelativeToChildren` |
+| Vertical menu | container `ChildrenLayout = TopToBottomStack`, set `StackSpacing` |
+
+**"Centered" is two different things.** Centering the *element* in its parent is
+the recipe above (`XOrigin/XUnits`). A `Text`/`Label`'s `HorizontalAlignment`
+only centers the *text within the element's own width* — if the element is
+auto-width, that looks left-aligned. Pick the one you actually mean.

--- a/gum-skills/gum-overview/SKILL.md
+++ b/gum-skills/gum-overview/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: gum-overview
+description: What Gum is and how a Gum project is wired — file types, Forms vs raw visuals, the three usage modes, project setup, and the content-copy rule. Start here. Triggers: adding Gum, GumService, .gumx, "how do I use Gum".
+---
+
+# Gum Overview
+
+Gum is a UI framework and WYSIWYG editor for C# games. The **tool** (a desktop
+editor) authors UI; the **runtime** libraries load and render it at game time on
+MonoGame, KNI, FNA, raylib, and SkiaSharp. This skill is the entry point the
+other `gum-*` skills assume. Full docs: <https://docs.flatredball.com/gum>.
+
+## Two visual layers: Forms vs raw visuals
+
+- **Forms** — WPF-like interactive controls (`Button`, `TextBox`, `ListBox`,
+  `CheckBox`, `StackPanel`, …). Use these for anything the player interacts with.
+  See **gum-forms-controls**.
+- **Raw visuals** — the drawing primitives Forms are built from
+  (`TextRuntime`, `ColoredRectangleRuntime`, `SpriteRuntime`, `NineSliceRuntime`,
+  `ContainerRuntime`). Use these for non-interactive HUD/decoration.
+
+Both are laid out by the same unit system — see **gum-layout**.
+
+## Project file types
+
+| Extension | Contains |
+|-----------|----------|
+| `.gumx` | The project. Lists references to the elements below; loaded first. |
+| `.gusx` | A **Screen** (a top-level UI page). |
+| `.gucx` | A **Component** (a reusable element, e.g. a custom button). |
+| `.gutx` | A **Standard element** (project defaults for `Text`, `Sprite`, `Container`, …). |
+| `.behx` | A **Behavior** (a contract components can implement). |
+
+These are XML. To read or hand-edit them safely, see **gum-file-format**.
+
+## Three usage modes
+
+Pick one up front — it shapes how code references UI:
+
+1. **Code-only** — no `.gumx`. Build UI entirely in C# (`new Button()`, etc.).
+   Simplest to start; no editor.
+2. **Project + dynamic** — load a `.gumx` at runtime and find elements by string
+   name (`GetGraphicalUiElementByName("Title")`). Visual editing, no codegen.
+3. **Project + codegen** — load a `.gumx` **and** generate strongly-typed C#
+   classes for each screen/component (via `gumcli codegen`), so UI is referenced
+   by property instead of magic string. Recommended for larger projects. See
+   **gumcli**.
+
+## Wiring Gum into a game (MonoGame)
+
+Install the runtime NuGet package for your platform — `Gum.MonoGame`,
+`Gum.KNI`, or `Gum.FNA` — then drive the service each frame:
+
+```csharp
+using Gum;
+using Gum.Forms;
+using Gum.Forms.Controls;
+
+GumService GumUI => GumService.Default;
+
+// Initialize(): code-only. Initialize(this, "GumProject/GumProject.gumx"): loads a project.
+protected override void Initialize()      { GumUI.Initialize(this); base.Initialize(); }
+protected override void Update(GameTime t){ GumUI.Update(t); base.Update(t); }
+protected override void Draw(GameTime t)  { GumUI.Draw(); base.Draw(t); }
+```
+
+Exact package IDs, other platforms, and optional add-ons (shapes, dynamic fonts,
+expressions) are in the setup docs:
+<https://docs.flatredball.com/gum/code/getting-started/setup>.
+
+## Content-copy rule (do not use the MonoGame Content Pipeline)
+
+Gum content files (`.gumx`, `.gusx`, `.gucx`, `.gutx`, `.png`, `.fnt`) are
+plain files loaded from disk. They must be copied to the output directory with a
+**wildcard `None` include**, *not* added to `Content.mgcb` / the MGCB pipeline:
+
+```xml
+<ItemGroup>
+  <None Update="Content\**\*.*">
+    <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+  </None>
+</ItemGroup>
+```
+
+AI assistants default to `Content.mgcb` because that is the dominant MonoGame
+pattern — for Gum it is **wrong** and the project will fail to find its UI at
+runtime. Fonts and images used by Gum go through this same `None` copy, not MGCB.
+Details: <https://docs.flatredball.com/gum/code/files-and-fonts/file-loading>.
+
+## States and categories (brief)
+
+Elements can define named **states** grouped into **categories** (e.g. a
+`ButtonCategory` with `Enabled`/`Highlighted`/`Pushed` states). Applying a state
+sets a batch of variables at once; Forms controls switch states automatically on
+interaction. You do not need to build these from scratch to use Gum — recognize
+them when you see them. See **gum-forms-controls** for how controls use them, and
+<https://docs.flatredball.com/gum/gum-tool/gum-elements/states>.

--- a/gum-skills/gumcli/SKILL.md
+++ b/gum-skills/gumcli/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: gumcli
+description: Driving the gumcli command-line tool to scaffold, generate code, validate, and screenshot a Gum project. Triggers: gumcli, codegen, gumcli check, screenshot, verifying generated UI, edit-validate-verify loop.
+---
+
+# gumcli
+
+`gumcli` is a cross-platform .NET tool for working with Gum projects **without**
+the editor. It is the primary way an AI assistant acts on a Gum project and
+verifies its own work: machine-readable output on stdout, meaningful exit codes,
+fully headless. Full reference: <https://docs.flatredball.com/gum/cli>.
+
+## Install
+
+```
+dotnet tool install -g GumCli
+```
+
+## The edit → validate → verify loop
+
+After **any** change to a Gum project (by hand, by tool, or by an assistant),
+run this loop. Skipping validation is the most common way agent-authored UI
+breaks silently.
+
+### 1. Generate code (project + codegen mode only)
+
+```
+gumcli codegen-init  MyProject.gumx     # once: writes code-gen settings
+gumcli codegen       MyProject.gumx     # after any element edit: emits typed C#
+```
+
+Regenerate after editing elements so the generated classes match the XML. If you
+rename or delete an element, delete its stale generated `.cs` file before
+regenerating.
+
+### 2. Validate — always
+
+```
+gumcli check MyProject.gumx            # human-readable
+gumcli check MyProject.gumx --json     # machine-readable
+```
+
+`check` catches the mistakes that are easy to make and invisible otherwise —
+most importantly **misspelled XML element names that Gum drops without error**
+(see **gum-file-format**). Exit code `0` = clean, `1` = errors found, `2` =
+project could not be loaded / bad arguments. Branch on the exit code; do not
+parse prose. Run `check` after every hand edit before trusting the file.
+
+### 3. Verify visually
+
+Compiling is not proof the UI looks right. Render it and inspect:
+
+```
+gumcli screenshot MyProject.gumx ScreenOrComponentName --output out.png
+gumcli svg        MyProject.gumx ScreenOrComponentName --output out.svg
+```
+
+Open the image to confirm layout matches intent. With a multimodal model, the
+assistant can look at the PNG directly.
+
+## Other commands
+
+| Command | Purpose |
+|---------|---------|
+| `gumcli new <path> [--template forms\|empty]` | Scaffold a new project. `forms` (default) includes the built-in Forms controls. |
+| `gumcli fonts <project.gumx>` | Generate missing bitmap font files (`.fnt`+`.png`). **Windows-only.** |
+| `gumcli pack <project.gumx>` | Bundle a project into a single file. |
+
+## Notes
+
+- **stdout is data, stderr is chatter.** Consume results (`--json`, paths) from
+  stdout; banners and progress go to stderr.
+- Pair `gumcli` with the MCP documentation server so the assistant can look up a
+  property while it drives the project. See
+  <https://docs.flatredball.com/gum/ai/gumcli-for-agents>.


### PR DESCRIPTION
Closes #2700.

## What

Adds a top-level **`gum-skills/`** folder: external-facing AI skills a consumer drops into their project's `.claude/skills/` to work **with** Gum. This is distinct from the engine-internal `.claude/skills/` set (which is about working **on** Gum), and it fulfills the folder the published docs (`docs/ai/ai-skills.md`) already link to but which didn't exist yet.

```
gum-skills/
  README.md
  gum-overview/SKILL.md
  gumcli/SKILL.md
  gum-file-format/SKILL.md
  gum-forms-controls/SKILL.md
  gum-layout/SKILL.md
```

- **`gum-overview`** — what Gum is, project file types (`.gumx`/`.gusx`/`.gucx`/`.gutx`/`.behx`), Forms-vs-raw-visuals, the three usage modes, project wiring (`GumService`, `Gum.MonoGame`/`Gum.KNI`/`Gum.FNA`), and the **content-copy rule** (`<None Update="Content\**\*.*" CopyToOutputDirectory="PreserveNewest">`, **not** `Content.mgcb`) — item 7 from #2197.
- **`gumcli`** — recipe-oriented edit → validate → verify loop (`codegen`, `check`, `screenshot`).
- **`gum-file-format`** — the original #2197 ask: enum→int tables for `WidthUnits`/`HeightUnits` (`DimensionUnitType`), `XUnits`/`YUnits` (`PositionUnitType`), `XOrigin`/`YOrigin` (`HorizontalAlignment`/`VerticalAlignment`), and `ChildrenLayout`; qualified `InstanceName.Property` variables; instance parenting via the `Parent` variable; and the silent-failure landmines (enum-as-int, two on-disk variable shapes, silently-dropped element names that `gumcli check` catches).
- **`gum-forms-controls`** — controls vs raw visuals, composition via `AddChild`, and the state/category system brief (item 8 from #2197).
- **`gum-layout`** — units, anchor/dock, child stacking.

The `README.md` covers the 3rd-party-vs-internal distinction, a getting-started set, and a short "how to author a new skill" section.

## Why these are more self-contained than the internal skills

These ship into a consumer's repo, so the reader has **no** Gum source tree or `docs/` folder. The skills therefore state the concrete rules (enum tables, APIs) inline and link to the public docs site (`docs.flatredball.com/gum/...`) for depth, rather than pointing at repo source paths.

## Verification (DoD #3/#4)

All factual content is grounded in source (enum values, `GumService` init, package IDs, and the `Anchor`/`Dock`/`AddChild` APIs), not from memory. Then a **fresh sub-agent given only these skills** attempted to build a small UI and hand-author a `.gusx`; its friction report surfaced a real blind spot around **composition/parenting** (adding a child control in code, nesting instances in XML, root-namespace boilerplate), which drove one round of fixes. The corrected file-format example now passes `gumcli check` and renders via `gumcli screenshot`.

A deeper test-run inside a full game project is left for follow-up as need is demonstrated — per the issue, this is deliberately **not** a long-running tracker; future skills (animation, hot reload, localization, styling, etc.) are each their own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
