### PR TITLE
Collapse dead post-GumCommon platform #if branches in Forms header usings

### DIFF
--- a/MonoGameGum/Forms/Controls/ComboBox.cs
+++ b/MonoGameGum/Forms/Controls/ComboBox.cs
@@ -20,11 +20,6 @@ using InteractiveGue = global::Gum.Wireframe.GraphicalUiElement;
 using Buttons = FlatRedBall.Input.Xbox360GamePad.Button;
 using GamepadButton = FlatRedBall.Input.Xbox360GamePad.Button;
 namespace FlatRedBall.Forms.Controls;
-#elif XNALIKE
-using MonoGameGum.Input;
-using Gum.Input;
-using GamepadButton = Gum.Input.GamepadButton;
-using Microsoft.Xna.Framework.Input;
 #else
 using Gum.Input;
 using GamepadButton = Gum.Input.GamepadButton;

--- a/MonoGameGum/Forms/Controls/FrameworkElement.cs
+++ b/MonoGameGum/Forms/Controls/FrameworkElement.cs
@@ -32,24 +32,13 @@ using BindableGue = global::Gum.Wireframe.GraphicalUiElement;
 using Buttons = FlatRedBall.Input.Xbox360GamePad.Button;
 using GamepadButton = FlatRedBall.Input.Xbox360GamePad.Button;
 namespace FlatRedBall.Forms.Controls;
-#elif XNALIKE
-using Keys = Microsoft.Xna.Framework.Input.Keys;
-using Microsoft.Xna.Framework.Input;
-using MonoGameGum.Input;
-using Gum.Input;
-using GamepadButton = Gum.Input.GamepadButton;
-using Gum.Converters;
-#elif RAYLIB
-using RaylibGum;
-using Gum.Input;
-using Keys = Gum.Forms.Input.Keys;
-#elif SOKOL
-using Gum.Input;
-using Keys = Gum.Forms.Input.Keys;
 #else
-// Default branch — used when this file is compiled into GumCommon, which defines
-// none of FRB/XNALIKE/RAYLIB/SOKOL. The Forms abstraction lives in Gum.Input /
-// Gum.Forms.Input, so the headless build picks up the same shared types Raylib/Sokol use.
+// Non-FRB branch. These Forms control files compile exactly once — into GumCommon
+// (net8.0), which defines none of XNALIKE/RAYLIB/SOKOL/SKIA. Every runtime
+// (MonoGame/KNI/FNA/Raylib/Sokol) compile-Removes them and consumes them from that
+// GumCommon reference, so the former per-platform #elif branches were dead code and
+// were removed; only FRB compiles these files separately and keeps its own branch above.
+// The Forms abstraction lives in Gum.Input / Gum.Forms.Input.
 using Gum.Input;
 using Keys = Gum.Forms.Input.Keys;
 #endif

--- a/MonoGameGum/Forms/Controls/FrameworkElementExt.cs
+++ b/MonoGameGum/Forms/Controls/FrameworkElementExt.cs
@@ -20,12 +20,6 @@ using Gum.Forms.Data;
 namespace Gum.Forms.Controls;
 #endif
 
-#if MONOGAME
-
-using Microsoft.Xna.Framework;
-
-#endif
-
 
 public static class FrameworkElementExt
 {

--- a/MonoGameGum/Forms/Controls/ListBox.cs
+++ b/MonoGameGum/Forms/Controls/ListBox.cs
@@ -24,11 +24,6 @@ using InteractiveGue = global::Gum.Wireframe.GraphicalUiElement;
 using Buttons = FlatRedBall.Input.Xbox360GamePad.Button;
 using static FlatRedBall.Input.Xbox360GamePad;
 namespace FlatRedBall.Forms.Controls;
-#elif XNALIKE
-using MonoGameGum.Input;
-using Gum.Input;
-using GamepadButton = Gum.Input.GamepadButton;
-using Microsoft.Xna.Framework.Input;
 #else
 using Gum.Input;
 using GamepadButton = Gum.Input.GamepadButton;

--- a/MonoGameGum/Forms/Controls/Primitives/ButtonBase.cs
+++ b/MonoGameGum/Forms/Controls/Primitives/ButtonBase.cs
@@ -15,11 +15,6 @@ using InteractiveGue = global::Gum.Wireframe.GraphicalUiElement;
 using GamepadButton = FlatRedBall.Input.Xbox360GamePad.Button;
 using static FlatRedBall.Input.Xbox360GamePad;
 namespace FlatRedBall.Forms.Controls.Primitives;
-#elif XNALIKE
-using Microsoft.Xna.Framework.Input;
-using MonoGameGum.Input;
-using Gum.Input;
-using GamepadButton = Gum.Input.GamepadButton;
 #else
 using Gum.Input;
 using GamepadButton = Gum.Input.GamepadButton;

--- a/MonoGameGum/Forms/Controls/Primitives/RangeBase.cs
+++ b/MonoGameGum/Forms/Controls/Primitives/RangeBase.cs
@@ -12,8 +12,6 @@ using Gum.Converters;
 using FlatRedBall.Gui;
 using InteractiveGue = global::Gum.Wireframe.GraphicalUiElement;
 namespace FlatRedBall.Forms.Controls.Primitives;
-#elif XNALIKE
-using MonoGameGum.Input;
 #endif
 
 

--- a/MonoGameGum/Forms/Controls/ScrollBar.cs
+++ b/MonoGameGum/Forms/Controls/ScrollBar.cs
@@ -10,9 +10,6 @@ using FlatRedBall.Forms.GumExtensions;
 using FlatRedBall.Forms.Controls.Primitives;
 using InteractiveGue = global::Gum.Wireframe.GraphicalUiElement;
 namespace FlatRedBall.Forms.Controls;
-#elif XNALIKE
-using Microsoft.Xna.Framework;
-using MonoGameGum.Input;
 #endif
 
 #if !FRB

--- a/MonoGameGum/Forms/Controls/ScrollViewer.cs
+++ b/MonoGameGum/Forms/Controls/ScrollViewer.cs
@@ -17,10 +17,6 @@ using FlatRedBall.Input;
 using InteractiveGue = global::Gum.Wireframe.GraphicalUiElement;
 using Buttons = FlatRedBall.Input.Xbox360GamePad.Button;
 namespace FlatRedBall.Forms.Controls;
-#elif XNALIKE
-using GamepadButton = Gum.Input.GamepadButton;
-using Microsoft.Xna.Framework.Input;
-using MonoGameGum.Input;
 #else
 using Gum.Input;
 using GamepadButton = Gum.Input.GamepadButton;

--- a/MonoGameGum/Forms/Controls/Slider.cs
+++ b/MonoGameGum/Forms/Controls/Slider.cs
@@ -17,11 +17,6 @@ using InteractiveGue = global::Gum.Wireframe.GraphicalUiElement;
 using static FlatRedBall.Input.Xbox360GamePad;
 using GamepadButton = FlatRedBall.Input.Xbox360GamePad.Button;
 namespace FlatRedBall.Forms.Controls;
-#elif XNALIKE
-using Microsoft.Xna.Framework.Input;
-using MonoGameGum.Input;
-using Gum.Input;
-using GamepadButton = Gum.Input.GamepadButton;
 #else
 using Gum.Input;
 using GamepadButton = Gum.Input.GamepadButton;

--- a/MonoGameGum/Forms/Controls/TextBoxBase.cs
+++ b/MonoGameGum/Forms/Controls/TextBoxBase.cs
@@ -20,11 +20,6 @@ using InteractiveGue = global::Gum.Wireframe.GraphicalUiElement;
 using GamepadButton = FlatRedBall.Input.Xbox360GamePad.Button;
 using RenderingLibrary.Graphics;
 namespace FlatRedBall.Forms.Controls;
-#elif XNALIKE
-using Microsoft.Xna.Framework.Input;
-using RenderingLibrary.Graphics;
-using MonoGameGum.Input;
-using GamepadButton = Gum.Input.GamepadButton;
 #else
 using Gum.Input;
 using GamepadButton = Gum.Input.GamepadButton;

--- a/MonoGameGum/Forms/Controls/TextBoxBase.cs
+++ b/MonoGameGum/Forms/Controls/TextBoxBase.cs
@@ -766,6 +766,15 @@ public abstract class TextBoxBase :
     // long lines. If you change behavior here, **change BOTH branches**
     // and verify with a test that exercises GetCaretIndexAtPosition under
     // XNALIKE (typing alone does not hit GetIndex).
+    //
+    // NOTE (post-GumCommon migration): these control files now compile in
+    // GumCommon (which defines no XNALIKE), so standalone MonoGame/KNI/FNA/
+    // Raylib/Skia all take the #else path — only FRB's XNA-family builds still
+    // compile the #if XNALIKE fast path. It stays #if XNALIKE (not #if FRB) on
+    // purpose: it gates an XNA bitmap-font *capability*, and FRB has non-XNA
+    // builds (e.g. FlatRedBall.Forms.DesktopGL, SkiaInGum) that correctly use
+    // the #else path. Lifting this into IFormsText so every backend gets the
+    // fast path is tracked in https://github.com/vchelaru/Gum/issues/3542
     private int GetIndex(float cursorOffset, string textToUse)
     {
         var index = textToUse?.Length ?? 0;

--- a/MonoGameGum/Input/KeyCombo.cs
+++ b/MonoGameGum/Input/KeyCombo.cs
@@ -5,10 +5,10 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-#if !XNALIKE && !FRB
-using Keys = Gum.Forms.Input.Keys;
-#else
+#if FRB
 using Microsoft.Xna.Framework.Input;
+#else
+using Keys = Gum.Forms.Input.Keys;
 #endif
 
 // Needs to be in this namespace since it was originally
@@ -25,7 +25,7 @@ public struct KeyCombo
 
 public static class KeyComboExtensions
 {
-    // Converts the platform-local Keys alias (XNA Keys on MonoGame, Gum Keys on Raylib/Sokol)
+    // Converts the platform-local Keys alias (XNA Keys under FRB, Gum Keys everywhere else)
     // to the shared Gum.Forms.Input.Keys that IInputReceiverKeyboard's interface methods accept.
     // Values align across both enums, so an int round-trip is safe.
     private static Gum.Forms.Input.Keys ToGumKey(Keys key) => (Gum.Forms.Input.Keys)(int)key;

--- a/docs/gum-tool/upgrading/migrating-to-2026-may.md
+++ b/docs/gum-tool/upgrading/migrating-to-2026-may.md
@@ -522,6 +522,7 @@ Most user code is unaffected. The common path — reading `GumService.Keyboard` 
 | `ListBox.ControllerButtonPushed` event arg | XNA `Buttons` | `Gum.Input.GamepadButton` |
 | `KeyCombo.PushedKey` / `HeldKey` | XNA `Keys` | `Gum.Forms.Input.Keys` |
 | `KeyEventArgs.Key` | XNA `Keys` | `Gum.Forms.Input.Keys` |
+| `ListBox` selection modifier keys (`ToggleSelectionModifierKey`, etc.) | XNA `Keys` | `Gum.Forms.Input.Keys` |
 
 The `MonoGameGum.Input.GamePad` **class** itself is unchanged — `GumService.GamePads` still returns instances of it, and they still expose `XnaGamePad`, `Capabilities`, etc. Only the static type of the `FrameworkElement.GamePadsForUiControl` list element changed.
 
@@ -575,6 +576,22 @@ textBox.KeyDown += (s, e) =>
 {
     if (e.Key == Gum.Forms.Input.Keys.Escape) { /* ... */ }
 };
+```
+
+#### `ListBox` selection modifier keys
+
+`ListBox.ToggleSelectionModifierKey`, `AlternateToggleSelectionModifierKey`, `RangeSelectionModifierKey`, and `AlternateRangeSelectionModifierKey` — the `public static` keys that gate multi-select (Ctrl / Shift by default) — are now typed `Gum.Forms.Input.Keys`. Only code that reassigns them needs the type swap.
+
+❌ Old:
+
+```csharp
+ListBox.RangeSelectionModifierKey = Microsoft.Xna.Framework.Input.Keys.LeftAlt;
+```
+
+✅ New:
+
+```csharp
+ListBox.RangeSelectionModifierKey = Gum.Forms.Input.Keys.LeftAlt;
 ```
 
 #### `DPadDirection` namespace


### PR DESCRIPTION
## What

Collapse the dead top-of-file preprocessor `using`-selection blocks in the Gum Forms control files down to `#if FRB / #else`, deleting the non-FRB platform branches (`#elif XNALIKE`, `#elif RAYLIB`, `#elif SOKOL`).

Files touched (header `using` block only):
- `Forms/Controls/FrameworkElement.cs` (5-way → `#if FRB / #else`)
- `Forms/Controls/Primitives/ButtonBase.cs`
- `Forms/Controls/Primitives/RangeBase.cs` (had no neutral `#else`; now `#if FRB … #endif`)
- `Forms/Controls/ComboBox.cs`
- `Forms/Controls/ListBox.cs`
- `Forms/Controls/TextBoxBase.cs` (header block only)
- `Forms/Controls/ScrollViewer.cs`
- `Forms/Controls/ScrollBar.cs` (no neutral `#else`)
- `Forms/Controls/Slider.cs`
- `Forms/Controls/FrameworkElementExt.cs` — also deleted the dead `#if MONOGAME` block (an unused `using Microsoft.Xna.Framework;` whose only consumer is a commented-out `AddDebugOverlay`)
- `Input/KeyCombo.cs` — rewrote `#if !XNALIKE && !FRB / #else` to the same `#if FRB / #else` shape (behavior-identical), and corrected a stale comment

## Why

These Forms control files physically live in `MonoGameGum/Forms/` but are `<Compile Include>`-linked into **GumCommon** (net8.0), which defines none of `XNALIKE`/`RAYLIB`/`SOKOL`/`SKIA`/`FRB`. Every runtime (`MonoGameGum`, `KniGum`, `FnaGum`, `RaylibGum`, `SokolGum`) `<Compile Remove>`s these files and consumes them from the GumCommon reference. GumCommon is therefore the sole compile owner. FRB (FlatRedBall) is the one exception: it compiles the same files separately with `FRB` defined.

Consequently the `#elif XNALIKE` / `#elif RAYLIB` / `#elif SOKOL` branches of the header `using`-selection blocks were **dead code** — no build ever compiled them (FRB always matches `#if FRB` first; everyone else reaches the neutral `#else`). They were also actively misleading: the XNALIKE branch read as if MonoGame uses XNA `Keys`, which it no longer does after the shipped neutral-Keys migration (see `docs/gum-tool/upgrading/migrating-to-2026-may.md`).

## Safety

Content-only edits — no files added/renamed/deleted, so **no** `GumCoreShared.projitems` / FRB `FlatRedBall.Forms.Shared.projitems` changes needed. `#if FRB` branch content and all body platform `#if` blocks (TextBoxBase caret fast-path + native-keyboard path, RangeBase `#if MONOGAME && !FRB`, `#if ANDROID`, and the `#define XNALIKE` at the top of TextBoxBase) were left untouched.

## Verification

- Baseline `Forms|Input` suite green before edits (699 passed); still green after (699 passed).
- Builds succeeded with 0 errors and no new warnings: `MonoGameGum.Tests` (GumCommon + MonoGameGum, the XNALIKE-family neutral path), `KniGum` (XNALIKE — proves the deleted XNALIKE branch was dead for it), `RaylibGum` (proves the deleted RAYLIB branch was dead), `SkiaGum`.
- No pinning test added: end-to-end Tab navigation via `FrameworkElement.TabKeyCombos` is already pinned by `OnFocusUpdate_ShouldFocusNextItem_IfTabIsPressed` (mocks `IInputReceiverKeyboard`, two focusable controls, simulates Tab, asserts focus moved), and `KeyComboTests` comprehensively pins `KeyCombo` on the neutral Keys path.

**FRB canary pending** — this branch's `#if FRB` path must be verified by the orchestrator via `frb-build-verification` from the primary checkout (worktrees can't run it). The FRB branches here were not modified, so the canary is a belt-and-suspenders check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



Part of #3543.
