### PR TITLE
Remove dead RAYLIB/SOKOL #if blocks in Forms DialogBox

### DIFF
--- a/MonoGameGum/Forms/Controls/Games/DialogBox.cs
+++ b/MonoGameGum/Forms/Controls/Games/DialogBox.cs
@@ -25,24 +25,12 @@ namespace Gum.Forms.Controls.Games;
 #endif
 using global::RenderingLibrary.Graphics;
 
-#if RAYLIB
-using RaylibGum;
-using RaylibGum.Renderables;
-#endif
-
-#if SOKOL
-using SokolGum;
-#endif
-
-#if !FRB && !XNALIKE
 using GamepadButton = Gum.Input.GamepadButton;
-#endif
 
 #if XNALIKE
 using Microsoft.Xna.Framework.Input;
 using MonoGameGum;
 using System.Security.Cryptography;
-using GamepadButton = Gum.Input.GamepadButton;
 #else
 using Keys = Gum.Forms.Input.Keys;
 #endif


### PR DESCRIPTION
Part of #3543's dead-`#if` reduction. Cleans up `MonoGameGum/Forms/Controls/Games/DialogBox.cs` per-block, per #3544.

## Changes
- Removed the `#if RAYLIB` and `#if SOKOL` using-blocks — neither symbol is ever defined in GumCommon's compile (the sole owner of this file); `RaylibGum.csproj` and `SokolGum.csproj` both `<Compile Remove>` this file and only pull it in via the GumCommon project reference. Confirmed dead everywhere.
- Collapsed the two `GamepadButton` alias declarations (`#if !FRB && !XNALIKE` and inside `#if XNALIKE`) into a single unconditional `using GamepadButton = Gum.Input.GamepadButton;`. Every FRB-defining csproj in the FlatRedBall repo also defines `MONOGAME`, `FNA`, or `KNI` (confirmed across `FlatRedBall.Forms.DesktopGlNet6`, `.iOSMonoGame`, `.AndroidMonoGame`, `.FNA`, `.Kni.Web`, `.Kni.DesktopGL`), so `FRB` always implies `XNALIKE` and the alias was already active in every real build configuration — the two declarations were never actually gated differently.
- Left all live `#if FRB` / `#if XNALIKE` behavioral splits untouched (Tweener typewriter, `IInputDevice` input, `TimeManager.CurrentTime`, the XNA vs `Gum.Forms.Input` `Keys` selection, etc.) per the issue's guidance.

## Verification
Behavior-preserving dead-code removal — no new test needed per the `tdd` skill's exemption. Verified via:
- `dotnet build MonoGameGum.Tests/MonoGameGum.Tests.csproj` — clean, `DialogBoxTests` 15/15 pass
- `dotnet build Runtimes/RaylibGum/RaylibGum.csproj` — clean
- `dotnet build Runtimes/SkiaGum/SkiaGum.csproj` — clean
- FRB canary (`FlatRedBall.Forms.DesktopGlNet6.csproj`), built from the primary checkout: baseline (main) clean, branch clean, 0 new errors

Closes #3544

🤖 Generated with [Claude Code](https://claude.com/claude-code)
