### PR TITLE
Lift TextBox caret glyph-advance fast path into IFormsText

### DIFF
--- a/GumCommon/AssemblyInfo.cs
+++ b/GumCommon/AssemblyInfo.cs
@@ -2,6 +2,7 @@ using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("MonoGameGum.Tests")]
 [assembly: InternalsVisibleTo("MonoGameGum.Tests.V2")]
+[assembly: InternalsVisibleTo("RaylibGum.Tests")]
 
 // MonoGameGum, KniGum, and FnaGum each link in CustomSetPropertyOnRenderable.cs,
 // which writes to internal members on GraphicalUiElement (e.g., IsFontDirty.set).

--- a/MonoGameGum.Tests/Forms/ButtonTests.cs
+++ b/MonoGameGum.Tests/Forms/ButtonTests.cs
@@ -36,6 +36,27 @@ public class ButtonTests : BaseTestClass
     }
 
     [Fact]
+    public void DefaultButtonRuntimeConstructor_ShouldNotThrow_WhenActiveStyleNeverInitialized()
+    {
+        // Constructing a legacy default-visual class directly ("create a button through its
+        // visual type", a documented pattern - see GumFormsSample's FrameworkElementExampleScreen)
+        // used to NRE in Styling.ActiveStyle.Colors.Primary whenever the app only ever called
+        // InitializeDefaults with V3 (or never called the V1/V2 overload) - nothing else sets the
+        // V1/V2-shared Styling.ActiveStyle, so it stayed null.
+        var previousActiveStyle = Gum.Forms.DefaultVisuals.Styling.ActiveStyle;
+        try
+        {
+            Gum.Forms.DefaultVisuals.Styling.ActiveStyle = null;
+
+            Should.NotThrow(() => new DefaultButtonRuntime());
+        }
+        finally
+        {
+            Gum.Forms.DefaultVisuals.Styling.ActiveStyle = previousActiveStyle;
+        }
+    }
+
+    [Fact]
     public void UpdateState_ShouldSetPushed_IfPushedWithKeyboard()
     {
         bool wasApplied = false;

--- a/MonoGameGum.Tests/Forms/SliderTests.cs
+++ b/MonoGameGum.Tests/Forms/SliderTests.cs
@@ -1,4 +1,6 @@
-﻿using Gum.Forms.Controls;
+﻿using Gum.Forms;
+using Gum.Forms.Controls;
+using Gum.Forms.DefaultVisuals.V3;
 using Gum.Wireframe;
 using Gum.GueDeriving;
 using MonoGameGum.Input;
@@ -15,6 +17,42 @@ using Xunit;
 namespace MonoGameGum.Tests.Forms;
 public class SliderTests : BaseTestClass
 {
+    [Fact]
+    public void UpdateState_ShouldNotThrow_WhenButtonTemplateIsNotButtonVisual()
+    {
+        // Mirrors a real crash: if an app overrides FrameworkElement.DefaultFormsTemplates[typeof(Button)]
+        // with a visual that isn't a V3 ButtonVisual (e.g. a fully custom InteractiveGue - a documented
+        // pattern for customizing button appearance), any composite control that builds an internal
+        // Button sub-part - like Slider's thumb - ends up with a null ThumbInstance (the "as ButtonVisual"
+        // cast in SliderVisual's constructor fails), and SetValuesForState used to NRE dereferencing it
+        // unguarded whenever the slider's enabled/focused state changed.
+        var previousSliderTemplate = FrameworkElement.DefaultFormsTemplates[typeof(Slider)];
+        var previousButtonTemplate = FrameworkElement.DefaultFormsTemplates[typeof(Button)];
+        try
+        {
+            FrameworkElement.DefaultFormsTemplates[typeof(Slider)] =
+                new VisualTemplate((_, createForms) => new SliderVisual(tryCreateFormsObject: createForms));
+            FrameworkElement.DefaultFormsTemplates[typeof(Button)] = new VisualTemplate((_, createForms) =>
+            {
+                var customButtonVisual = new InteractiveGue(new RenderingLibrary.Graphics.InvisibleRenderable());
+                var textInstance = new TextRuntime { Name = "TextInstance" };
+                customButtonVisual.Children.Add(textInstance);
+                return customButtonVisual;
+            });
+
+            Slider slider = new();
+            var visual = (SliderVisual)slider.Visual;
+            visual.ThumbInstance.ShouldBeNull("because the overridden Button template isn't a ButtonVisual");
+
+            Should.NotThrow(() => slider.IsEnabled = false);
+        }
+        finally
+        {
+            FrameworkElement.DefaultFormsTemplates[typeof(Slider)] = previousSliderTemplate;
+            FrameworkElement.DefaultFormsTemplates[typeof(Button)] = previousButtonTemplate;
+        }
+    }
+
     [Fact]
     public void Children_Containers_ShouldNotHaveEvents()
     {

--- a/MonoGameGum/Forms/Controls/TextBoxBase.cs
+++ b/MonoGameGum/Forms/Controls/TextBoxBase.cs
@@ -747,61 +747,25 @@ public abstract class TextBoxBase :
         return index;
     }
 
-    // Two implementations of the same logical operation: walk characters
-    // accumulating their X-advance until we pass cursorOffset, then return
-    // the character index nearest the cursor.
-    //
-    // The split exists because the XNALIKE backends (MonoGame/KNI/FNA)
-    // expose `coreTextObject.BitmapFont` and per-character `XAdvance`,
-    // giving an allocation-free O(n) walk. Raylib's Text has no BitmapFont
-    // property — it uses raylib's own font system — so the #else branch
-    // falls back to repeated MeasureString(substring), which is O(n^2) and
-    // allocates a substring per character.
-    //
-    // We considered unifying onto the substring path (it would eliminate
-    // the dual-maintenance footgun that bit issue #2687 — the FontScale
-    // fix originally only landed in the #else branch). For now we are
-    // keeping the optimization: GetIndex runs only on click and Up/Down
-    // arrow, but it's still nicer to avoid the per-char allocations on
-    // long lines. If you change behavior here, **change BOTH branches**
-    // and verify with a test that exercises GetCaretIndexAtPosition under
-    // XNALIKE (typing alone does not hit GetIndex).
-    //
-    // NOTE (post-GumCommon migration): these control files now compile in
-    // GumCommon (which defines no XNALIKE), so standalone MonoGame/KNI/FNA/
-    // Raylib/Skia all take the #else path — only FRB's XNA-family builds still
-    // compile the #if XNALIKE fast path. It stays #if XNALIKE (not #if FRB) on
-    // purpose: it gates an XNA bitmap-font *capability*, and FRB has non-XNA
-    // builds (e.g. FlatRedBall.Forms.DesktopGL, SkiaInGum) that correctly use
-    // the #else path. Lifting this into IFormsText so every backend gets the
-    // fast path is tracked in https://github.com/vchelaru/Gum/issues/3542
+    // Walks characters accumulating their X-advance until we pass cursorOffset, then returns
+    // the character index nearest the cursor. Per-character advance comes from
+    // IFormsText.GetCharacterAdvance, which each backend's concrete Text implements — the
+    // XNA-family Text (RenderingLibrary/Graphics/Text.cs) overrides it with an allocation-free
+    // BitmapFont.XAdvance lookup; other backends fall back to measuring a one-character string.
+    // Either way this method itself needs no #if: virtual dispatch on coreTextObject picks the
+    // right implementation at runtime. See https://github.com/vchelaru/Gum/issues/3542.
     private int GetIndex(float cursorOffset, string textToUse)
     {
         var index = textToUse?.Length ?? 0;
         float distanceMeasuredSoFar = 0;
-
-#if XNALIKE
-
-        // Cast to concrete Text inside this XNALIKE-only block to reach BitmapFont,
-        // which is a MonoGame-specific concrete-class member (not on IFormsText).
-        var concreteText = (global::RenderingLibrary.Graphics.Text)this.coreTextObject;
-        var bitmapFont = concreteText.BitmapFont ?? global::RenderingLibrary.Graphics.Text.DefaultBitmapFont;
         var fontScale = coreTextObject.FontScale;
 
         for (int i = 0; i < (textToUse?.Length ?? 0); i++)
         {
-            char character = textToUse[i];
-            global::RenderingLibrary.Graphics.BitmapCharacterInfo characterInfo = bitmapFont?.GetCharacterInfo(character);
-
-            float advance = 0;
-
-            if (characterInfo != null)
-            {
-                // XAdvance is raw glyph-pixel width; the rendered glyph is
-                // FontScale-wider, so the hit-test must scale to match the
-                // screen-space cursor offset coming in.
-                advance = characterInfo.XAdvance * fontScale;
-            }
+            // GetCharacterAdvance returns raw glyph-pixel width; the rendered glyph is
+            // FontScale-wider, so the hit-test must scale to match the screen-space
+            // cursor offset coming in.
+            float advance = coreTextObject.GetCharacterAdvance(textToUse[i]) * fontScale;
 
             distanceMeasuredSoFar += advance;
 
@@ -820,30 +784,6 @@ public abstract class TextBoxBase :
                 break;
             }
         }
-#else
-        for (int i = 0; i < (textToUse?.Length ?? 0); i++)
-        {
-            // Is there a faster way to do this?
-            distanceMeasuredSoFar = MeasureStringScaled(textToUse.Substring(0, i + 1));
-
-            // This should find which side of the character you're closest to, but for now it's good enough...
-            if (distanceMeasuredSoFar > cursorOffset)
-            {
-                var distanceBefore = MeasureStringScaled(textToUse.Substring(0, i));
-                var advance = distanceMeasuredSoFar - distanceBefore;
-                var halfwayPoint = distanceMeasuredSoFar - (advance / 2.0f);
-                if (halfwayPoint > cursorOffset)
-                {
-                    index = i;
-                }
-                else
-                {
-                    index = i + 1;
-                }
-                break;
-            }
-        }
-#endif
         return index;
     }
 
@@ -2102,9 +2042,7 @@ public abstract class TextBoxBase :
     // IText is fully qualified here (and below) because this file compiles
     // under multiple backends: under XNALIKE the using directives include
     // RenderingLibrary.Graphics, but under the #else branch (Raylib/Sokol)
-    // they do not — so the unqualified IText would not resolve. The
-    // XNALIKE-guarded cast inside GetIndex can stay unqualified because
-    // that block only compiles when the using is in scope.
+    // they do not — so the unqualified IText would not resolve.
     private float EffectiveLineHeightInPixels =>
         coreTextObject.LineHeightInPixels
         * ((global::RenderingLibrary.Graphics.IText)coreTextObject).FontScale

--- a/MonoGameGum/Forms/DefaultVisuals/Styling.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/Styling.cs
@@ -13,10 +13,23 @@ namespace Gum.Forms.DefaultVisuals;
 
 public class Styling
 {
+    private static Styling _activeStyle;
+
     /// <summary>
     /// This allows someone to get the active style from any instance they create, or from the class self like Styling.ActiveStyle.
     /// </summary>
-    public static Styling ActiveStyle { get; set; }
+    /// <remarks>
+    /// Lazily creates a default-styled instance (loading the embedded UISpriteSheet) if nothing has
+    /// explicitly set this yet. This covers directly constructing a V1/V2 default-visual class (e.g.
+    /// <c>new DefaultButtonRuntime()</c> - the "create a control through its visual type" pattern)
+    /// in an app that only ever called <c>InitializeDefaults</c> with V3/Newest, which populates the
+    /// separate <c>DefaultVisuals.V3.Styling.ActiveStyle</c> and never touches this legacy one.
+    /// </remarks>
+    public static Styling ActiveStyle
+    {
+        get => _activeStyle ??= new Styling(spriteSheet: null);
+        set => _activeStyle = value;
+    }
 
     private Texture2D _spriteSheet;
     public Texture2D SpriteSheet 
@@ -55,14 +68,17 @@ public class Styling
             this.SpriteSheet = spriteSheet;
         }
 #elif RAYLIB
-        this.SpriteSheet = spriteSheet.Value;
+        this.SpriteSheet = spriteSheet ?? SystemManagers.Default.LoadEmbeddedTexture2d("UISpriteSheet.png")!.Value;
 #elif SOKOL
-        this.SpriteSheet = spriteSheet!;
+        this.SpriteSheet = spriteSheet ?? SystemManagers.Default.LoadEmbeddedTexture2d("UISpriteSheet.png")!;
 #endif
 
-        if (ActiveStyle == null)
+        // Set the backing field directly rather than going through the ActiveStyle property:
+        // ActiveStyle's getter lazily constructs a Styling(null) when unset, and re-entering that
+        // getter here (before this constructor call returns) would recurse infinitely.
+        if (_activeStyle == null)
         {
-            ActiveStyle = this;
+            _activeStyle = this;
         }
 
         if (useDefaults)

--- a/MonoGameGum/Forms/DefaultVisuals/V3/SliderVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/V3/SliderVisual.cs
@@ -243,7 +243,12 @@ public class SliderVisual : InteractiveGue
     {
         TrackBackground.Color = _trackBackgroundColor;
         FocusedIndicator.Visible = isFocused;
-        ThumbInstance.IsEnabled = isEnabled;
+        // ThumbInstance is null when the Button template registered in DefaultFormsTemplates
+        // isn't a ButtonVisual - the "as ButtonVisual" cast in the constructor fails silently.
+        if (ThumbInstance != null)
+        {
+            ThumbInstance.IsEnabled = isEnabled;
+        }
         FocusedIndicator.Color = _focusedIndicatorColor;
     }
 

--- a/MonoGameGum/Forms/DefaultVisuals/V3/Styling.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/V3/Styling.cs
@@ -13,10 +13,24 @@ namespace Gum.Forms.DefaultVisuals.V3;
 
 public class Styling
 {
+    private static Styling _activeStyle;
+
     /// <summary>
     /// This allows someone to get the active style from any instance they create, or from the class self like Styling.ActiveStyle.
     /// </summary>
-    public static Styling ActiveStyle { get; set; }
+    /// <remarks>
+    /// Lazily creates a default-styled instance (loading the embedded UISpriteSheet) if nothing has
+    /// explicitly set this yet. This covers constructing a V3 default-visual class (directly, or via
+    /// a <see cref="Gum.Forms.FrameworkElement.DefaultFormsTemplates"/> override) in an app that never
+    /// called <c>InitializeDefaults</c> with V3/Newest - e.g. a test host initialized with V1/V2, or a
+    /// composite control (like Slider's thumb) that internally builds a V3 visual regardless of which
+    /// version the app registered.
+    /// </remarks>
+    public static Styling ActiveStyle
+    {
+        get => _activeStyle ??= new Styling(spriteSheet: null);
+        set => _activeStyle = value;
+    }
 
     private Texture2D _spriteSheet;
     public Texture2D SpriteSheet 
@@ -55,14 +69,17 @@ public class Styling
             this.SpriteSheet = spriteSheet;
         }
 #elif RAYLIB
-        this.SpriteSheet = spriteSheet.Value;
+        this.SpriteSheet = spriteSheet ?? SystemManagers.Default.LoadEmbeddedTexture2d("UISpriteSheet.png")!.Value;
 #elif SOKOL
-        this.SpriteSheet = spriteSheet!;
+        this.SpriteSheet = spriteSheet ?? SystemManagers.Default.LoadEmbeddedTexture2d("UISpriteSheet.png")!;
 #endif
 
-        if (ActiveStyle == null)
+        // Set the backing field directly rather than going through the ActiveStyle property:
+        // ActiveStyle's getter lazily constructs a Styling(null) when unset, and re-entering that
+        // getter here (before this constructor call returns) would recurse infinitely.
+        if (_activeStyle == null)
         {
-            ActiveStyle = this;
+            _activeStyle = this;
         }
 
         if (useDefaults)

--- a/RenderingLibrary/Graphics/IFormsText.cs
+++ b/RenderingLibrary/Graphics/IFormsText.cs
@@ -60,5 +60,16 @@ namespace RenderingLibrary.Graphics
         /// render in screen space must multiply by <see cref="IText.FontScale"/>.
         /// </summary>
         float MeasureString(string value, HorizontalMeasurementStyle style);
+
+        /// <summary>
+        /// The horizontal advance of a single character in this Text's active font, in raw
+        /// glyph pixels (before <see cref="IText.FontScale"/>) — used by caret hit-testing
+        /// (<c>TextBoxBase.GetIndex</c>) to walk a string one character at a time without
+        /// repeated substring measurement. The default implementation measures the character
+        /// via <see cref="IWrappedText.MeasureString(string)"/>; backends with cheap per-glyph
+        /// metrics (e.g. a bitmap font's XAdvance table) override this for an allocation-free
+        /// lookup.
+        /// </summary>
+        float GetCharacterAdvance(char character) => MeasureString(character.ToString());
     }
 }

--- a/RenderingLibrary/Graphics/Text.cs
+++ b/RenderingLibrary/Graphics/Text.cs
@@ -859,6 +859,22 @@ public class Text : SpriteBatchRenderableBase, IRenderableIpso, IVisible, IWrapp
         }
     }
 
+    /// <summary>
+    /// Fast override of <see cref="IFormsText.GetCharacterAdvance(char)"/>: reads the character's
+    /// XAdvance directly off the active BitmapFont instead of measuring a one-character string,
+    /// avoiding both the allocation and the BitmapFont.MeasureString call overhead. Falls back to
+    /// <see cref="MeasureString(string)"/> when no BitmapFont is set.
+    /// </summary>
+    public float GetCharacterAdvance(char character)
+    {
+        var bitmapFontToUse = BitmapFont ?? DefaultBitmapFont;
+        if (bitmapFontToUse == null)
+        {
+            return MeasureString(character.ToString());
+        }
+        return bitmapFontToUse.GetCharacterInfo(character)?.XAdvance ?? 0;
+    }
+
     // made public so that objects that need to position based off of the texture can force call this
     public void TryUpdateTextureToRender()
     {

--- a/Samples/GumFormsSample/GumFormsSampleCommon/CustomRuntimes/FullyCustomizedButton.cs
+++ b/Samples/GumFormsSample/GumFormsSampleCommon/CustomRuntimes/FullyCustomizedButton.cs
@@ -17,6 +17,7 @@ namespace GumFormsSample
         public TextRuntime TextInstance { get; private set; }
         public FullyCustomizedButton(bool fullInstantiation = true, bool tryCreateFormsObject = true) : base(new InvisibleRenderable())
         {
+            this.HasEvents = true;
             if (fullInstantiation)
             {
                 this.Width = 128;

--- a/Samples/GumFormsSample/GumFormsSampleCommon/Screens/FrameworkElementExampleScreen.cs
+++ b/Samples/GumFormsSample/GumFormsSampleCommon/Screens/FrameworkElementExampleScreen.cs
@@ -89,10 +89,10 @@ namespace GumFormsSample.Screens
             CustomMenuItem.Header = "Custom Dropdown";
             var customScrollViewerVisualTemplate = new VisualTemplate(() =>
             {
-                var toReturn = new Gum.Forms.DefaultVisuals.DefaultScrollViewerRuntime();
+                var toReturn = new Gum.Forms.DefaultVisuals.V3.ScrollViewerVisual();
                 toReturn.MakeSizedToChildren();
                 var background = toReturn.GetGraphicalUiElementByName("Background")
-                    as ColoredRectangleRuntime;
+                    as NineSliceRuntime;
 
                 background.Color = Color.Orange;
 
@@ -173,7 +173,7 @@ namespace GumFormsSample.Screens
             stackPanel.AddChild(comboBox);
 
             // We can also create buttons through their visual type:
-            var buttonRuntime = new Gum.Forms.DefaultVisuals.DefaultButtonRuntime();
+            var buttonRuntime = new Gum.Forms.DefaultVisuals.V3.ButtonVisual();
             buttonRuntime.Width = 100;
             buttonRuntime.Height = 50;
             buttonRuntime.TextInstance.Text = "Other Button!";

--- a/Samples/GumFormsSample/MonoGameGumFormsSample/StyledButtonRuntime.cs
+++ b/Samples/GumFormsSample/MonoGameGumFormsSample/StyledButtonRuntime.cs
@@ -4,35 +4,20 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Xna.Framework;
-using Gum.Forms.DefaultVisuals;
+using Gum.Forms.DefaultVisuals.V3;
 
 namespace GumFormsSample
 {
-    class StyledButtonRuntime : DefaultButtonRuntime
+    class StyledButtonRuntime : ButtonVisual
     {
-        public StyledButtonRuntime(bool fullInstantiation = true, bool tryCreateFormsObject = true) : 
+        public StyledButtonRuntime(bool fullInstantiation = true, bool tryCreateFormsObject = true) :
             base(fullInstantiation, tryCreateFormsObject)
         {
             if(fullInstantiation)
             {
-                var category = this.Categories["ButtonCategory"];
-
-                var highlightedState = category.States.Find(item => item.Name == "Highlighted");
-                highlightedState.Variables.Clear();
-                highlightedState.Variables.Add(new Gum.DataTypes.Variables.VariableSave
-                {
-                    Name = "ButtonBackground.Color",
-                    Value = new Color(255,0,191)
-                });
-
-                var enabledState = category.States.Find(item => item.Name == "Enabled");
-                enabledState.Variables.Clear();
-                enabledState.Variables.Add(new Gum.DataTypes.Variables.VariableSave
-                {
-                    Name = "ButtonBackground.Color",
-                    Value = new Color(255, 100, 194),
-                });
-
+                // V3's states are computed from BackgroundColor/ForegroundColor rather than
+                // per-state variables, so a custom look only needs the base color set.
+                BackgroundColor = new Color(255, 100, 194);
             }
         }
     }

--- a/Tests/RaylibGum.Tests/Forms/TextBoxTests.cs
+++ b/Tests/RaylibGum.Tests/Forms/TextBoxTests.cs
@@ -1,6 +1,8 @@
 using Gum.Forms;
 using Gum.Forms.Controls;
+using Gum.Forms.DefaultVisuals.V3;
 using RenderingLibrary;
+using RenderingLibrary.Graphics;
 using Shouldly;
 
 namespace RaylibGum.Tests.Forms;
@@ -53,5 +55,35 @@ public class TextBoxTests : BaseTestClass
         textBox.Text = "some text that may wrap depending on width";
 
         Should.NotThrow(() => textBox.SelectAll());
+    }
+
+    [Fact]
+    public void GetCaretIndexAtPosition_MapsFurtherRightClicksToLaterIndices()
+    {
+        // Issue #3542: TextBoxBase.GetIndex's per-character advance now comes from
+        // IFormsText.GetCharacterAdvance. Raylib's Text has no fast override (no bitmap-font
+        // XAdvance table), so it falls back to the default interface implementation
+        // (single-character MeasureString). Pin that this fallback still produces a sane,
+        // monotonically-increasing caret hit-test — this path previously used a different,
+        // O(n^2) growing-substring measurement, so a wrong or reversed result here would be new.
+        var textBox = new TextBox();
+        textBox.IsFocused = true;
+        textBox.Text = "aaaa";
+
+        var visual = (TextBoxVisual)textBox.Visual;
+        var coreTextObject = (IFormsText)visual.TextInstance.RenderableComponent;
+
+        float widthOfTwo = coreTextObject.MeasureString("aa");
+
+        float textLeft = visual.TextInstance.AbsoluteLeft;
+        float textTop = visual.TextInstance.AbsoluteTop + 2f;
+
+        int indexNearStart = textBox.GetCaretIndexAtPosition(textLeft + 1f, textTop);
+        int indexPastTwoChars = textBox.GetCaretIndexAtPosition(textLeft + widthOfTwo + 1f, textTop);
+
+        indexNearStart.ShouldBeLessThan(indexPastTwoChars,
+            "clicking further right in the text should map to a later character index");
+        indexPastTwoChars.ShouldBeGreaterThanOrEqualTo(2,
+            "clicking past the measured width of the first two characters should land at or past index 2");
     }
 }


### PR DESCRIPTION
Fixes #3542.

## Problem
`TextBoxBase.GetIndex` (caret hit-testing) had an `#if XNALIKE` fast path (BitmapFont `XAdvance` walk, allocation-free O(n)) and an `#else` fallback (repeated growing-substring `MeasureString`, O(n^2), allocating a substring per character). Since Forms controls moved into GumCommon (which defines no `XNALIKE`), every backend except FRB's XNA-family builds silently lost the fast path and took the O(n^2) fallback — including standalone MonoGame/KNI/FNA.

## Change
- Added `IFormsText.GetCharacterAdvance(char)`, a default interface method that falls back to measuring a single-character string (O(1) per call → O(n) total, already an improvement over the old growing-substring fallback).
- The XNA-family concrete `Text` (`RenderingLibrary/Graphics/Text.cs`) overrides it with the allocation-free `BitmapFont.XAdvance` lookup — the same computation the old `#if XNALIKE` block did.
- `TextBoxBase.GetIndex` now calls `coreTextObject.GetCharacterAdvance(...)` directly with **no `#if`** — virtual dispatch on the concrete `Text` instance picks the right implementation at runtime. Result: MonoGame/KNI/FNA/FRB get the allocation-free walk back (restoring what was silently lost), and Raylib/Sokol move from O(n^2) to O(n).

## Verification
- `MonoGameGum.Tests`: full suite green (1821/1821), including the existing `FontScale_ShouldScaleClickHitTestX` regression test (#2687) which now exercises the new `GetCharacterAdvance` override.
- `RaylibGum.Tests`: full suite green (455/455), including a new `GetCaretIndexAtPosition_MapsFurtherRightClicksToLaterIndices` test pinning the new default-interface fallback path (previously untested — Raylib's caret hit-test had no coverage at all). Needed adding `RaylibGum.Tests` to `GumCommon`'s `InternalsVisibleTo` list (mirroring the existing `MonoGameGum.Tests` entry) to reach the `internal GetCaretIndexAtPosition`.
- `SkiaGum` build: clean (unaffected — Skia doesn't compile `TextBoxBase.cs` yet).
- FRB canary (`FlatRedBall.Forms.DesktopGlNet6.csproj`), built from the primary checkout: baseline (main) clean, branch clean, 0 new errors/warnings.

**Manual test:** built `Samples/GumFormsSample/MonoGameGumFormsSample` (clean, no sample edits needed — `FrameworkElementExampleScreen` already has TextBox instances) and opened the `.sln` for a real click-to-caret sanity check, given this touches a genuinely user-facing input path (clicking in a TextBox) across runtimes, even though the unit tests directly cover the click→index computation end-to-end.

Steps to verify manually in the opened solution:
1. Run the `MonoGameGumFormsSample` project (F5).
2. Press `2` to switch to the Framework Element Example screen (only works while no control is focused — click empty space first if needed).
3. Click into either TextBox at various horizontal positions and confirm the caret lands at the clicked character, including after typing enough text to test near start/middle/end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Additional fix (found during manual testing above)

Pressing `2` in the `MonoGameGumFormsSample` to reach `FrameworkElementExampleScreen` crashed with:

```
System.NullReferenceException: Object reference not set to an instance of an object.
   at Gum.Forms.DefaultVisuals.DefaultButtonRuntime..ctor(Boolean fullInstantiation, Boolean tryCreateFormsObject)
```

**Root cause:** the sample directly constructs a legacy V1 default-visual class (`new DefaultButtonRuntime()` — the documented "create a control through its visual type" pattern). `DefaultButtonRuntime`'s constructor reads `Styling.ActiveStyle.Colors.Primary`, but `Styling.ActiveStyle` (the V1/V2-shared style) is only ever set inside `FormsUtilities.InitializeDefaults`'s V1/V2 switch cases. The sample only calls `InitializeDefaults` with `DefaultVisualsVersion.Newest` (V3), which populates a *separate* `DefaultVisuals.V3.Styling.ActiveStyle` and never touches the legacy one — so it stayed null for any V3-only app that also directly instantiates a legacy visual class.

**Fix:** `Styling.ActiveStyle` now lazily self-initializes (loading the embedded `UISpriteSheet`) when read while unset, instead of depending entirely on `InitializeDefaults(V1/V2)` having run. Extended the constructor's null-spritesheet fallback (already present for XNALIKE) to RAYLIB and SOKOL too, so the lazy path works on every platform.

**Verification:**
- New regression test `ButtonTests.DefaultButtonRuntimeConstructor_ShouldNotThrow_WhenActiveStyleNeverInitialized` — confirmed it reproduced the crash before the fix, green after.
- `MonoGameGum.Tests` (1822/1822), `MonoGameGum.Tests.V2` (120/120), `MonoGameGum.Tests.V3` (59/59), `RaylibGum.Tests` (455/455) all green.
- `SkiaGum` build clean. `SokolGum` build fails on pre-existing, unrelated native-binding errors (`sg_image`/`sgp_blend_mode` not found — missing submodule, not touched by this change).
- FRB canary (`FlatRedBall.Forms.DesktopGlNet6.csproj`): baseline clean, branch clean, 0 new errors.
- Sample rebuilt clean with the fix applied — ready for you to re-verify by pressing `2` again in the already-open Visual Studio solution.


---

## Sample cleanup (follow-up to the crash fix above)

The crash above only surfaced because the sample demonstrated the "create/subclass a control through its visual type" pattern using obsolete V1 classes (`DefaultButtonRuntime`, `DefaultScrollViewerRuntime`) while the rest of the sample runs V3. Migrated the sample off V1:

- `FrameworkElementExampleScreen`: `DefaultButtonRuntime` → `V3.ButtonVisual`; the custom ScrollViewer background template moved from `DefaultScrollViewerRuntime`/`ColoredRectangleRuntime` → `V3.ScrollViewerVisual`/`NineSliceRuntime` (V3's `Background` child type).
- `StyledButtonRuntime` (dead sample code — never actually instantiated, but still triggered a `CS0618` warning via its base type): now subclasses `V3.ButtonVisual` and sets `BackgroundColor` directly, since V3 computes highlighted/pushed/etc. tints from that one color instead of requiring per-state variable edits.

Verified: `MonoGameGumFormsSample.csproj` and the full `MonoGameGumFormsSample.sln` build clean (0 errors), and the `CS0618` obsolete-API warnings from these two files are gone on a full rebuild.


---

## Second crash fix (still on screen 2)

Pressing `2` still crashed after the first `Styling.ActiveStyle` fix, this time in `SliderVisual.SetValuesForState`:

```
System.NullReferenceException: Object reference not set to an instance of an object.
   at Gum.Forms.DefaultVisuals.V3.SliderVisual.SetValuesForState(Boolean isFocused, Boolean isEnabled)
```

Two distinct bugs, both surfaced by the same root cause: `FrameworkElementExampleScreen`'s constructor overrides `FrameworkElement.DefaultFormsTemplates[typeof(Button)]` with a custom visual for its own demo button — and that override leaks into every composite control built afterward that internally constructs a `Button` sub-part, like `Slider`'s thumb.

1. **`Gum.Forms.DefaultVisuals.V3.Styling.ActiveStyle` had the exact same bug as the legacy `Styling` fixed earlier in this PR** — it's a separate static class, so that first fix didn't cover it. Applied the identical lazy-self-init fix.
2. **`SliderVisual.ThumbInstance` is nullable by design** (the `as ButtonVisual` cast fails when the registered `Button` template isn't a `ButtonVisual` — exactly what the screen's override does), **but `SetValuesForState` dereferenced it unguarded.** Added the null check. Checked every other V3 visual that builds a nested `Button` (`ScrollBarVisual`) — it never dereferences its equivalent nullable fields unsafely, so this was the only latent instance of the bug.

**Verification:**
- New regression test `SliderTests.UpdateState_ShouldNotThrow_WhenButtonTemplateIsNotButtonVisual` reproduces both bugs (registers a non-`ButtonVisual` `Button` template, constructs a V3 `Slider`) — confirmed it failed on each bug in turn before its respective fix, green after both.
- `MonoGameGum.Tests` (1823/1823), `.V2` (120/120), `.V3` (59/59), `RaylibGum.Tests` (455/455) all green. `SkiaGum` build clean.
- FRB canary: baseline clean, branch clean, 0 new errors.
- Sample rebuilds clean — ready for another pass at pressing `2`.


---

## Third fix: "Add Items" and ScrollBar up/down buttons not clickable

After the screen loaded and rendered, you found "Add Items" (and the `ScrollBar`'s up/down buttons) weren't clickable, while the "Other Button!" demo button was.

**Root cause:** `FrameworkElementExampleScreen`'s constructor overrides `FrameworkElement.DefaultFormsTemplates[typeof(Button)]` with `FullyCustomizedButton`, screen-wide. That applies to every plain `new Button()` on the screen — including nested ones inside composite controls (`ScrollBarVisual`'s up/down buttons are built with `new Button()` too). `FullyCustomizedButton` never set `HasEvents = true` (unlike every other button visual — `DefaultButtonRuntime`, `V3.ButtonVisual`), so nothing built through it could receive clicks. The one working button was the one already swapped to construct `V3.ButtonVisual` directly, bypassing the template lookup. The `ScrollBar` thumb is drag-based on its own container (not a `Button`), so it was unaffected — consistent with what you saw.

**Fix:** added `this.HasEvents = true;` to `FullyCustomizedButton`'s constructor, matching the pattern every other button visual already follows.

Pre-existing sample bug, unrelated to this PR's actual changes — just never visible before because the screen crashed before anything was clickable.

**Manual test:** rebuilt the sample clean; re-verify in the already-open Visual Studio session that "Add Items" and the ScrollBar's up/down arrows are now clickable.
