### PR TITLE
Fix Pixel-coordinate .achx animation frames on raylib/Skia

### DIFF
--- a/RenderingLibrary/Graphics/Animation/AnimationFrame.cs
+++ b/RenderingLibrary/Graphics/Animation/AnimationFrame.cs
@@ -38,13 +38,14 @@ namespace Gum.Graphics.Animation
         #endregion
         public static AnimationFrame Empty;
 
-#if MONOGAME || KNI || XNA4 || RAYLIB || SKIA || SOKOL
+        // No #if guard needed: this file only ever compiles into MonoGameGum, KniGum,
+        // FnaGum, RaylibGum, SkiaGum, or SokolGum, each of which defines exactly one of
+        // MONOGAME/KNI/XNA4/RAYLIB/SKIA/SOKOL, so the Texture2D alias above always resolves.
         /// <summary>
         /// The texture that the AnimationFrame will show.
         /// </summary>
         [XmlIgnore]
         public Texture2D? Texture;
-#endif
 
         /// <summary>
         /// Whether the texture should be flipped horizontally.
@@ -240,13 +241,13 @@ namespace Gum.Graphics.Animation
             frame.TextureName = animationFrameSave.TextureName;
             frame.FrameLength = animationFrameSave.FrameLength;
 
-#if MONOGAME || KNI || XNA4 || RAYLIB || SKIA || SOKOL
             // Texture2D is a per-backend using alias (MG -> XNA Texture2D, Raylib ->
             // Raylib_cs.Texture2D, Skia -> SkiaSharp.SKBitmap, Sokol -> SokolGum.Texture2D),
             // declared at the top of this file. The load logic itself is identical across
             // backends, so one branch driven by the alias replaces the per-backend #if/#elif
             // ladder this used to be (which had no SKIA branch and silently dropped texture
-            // loads on Skia).
+            // loads on Skia). No #if guard needed here: see the comment on the Texture field
+            // above for why this file always has one of the backend symbols defined.
             if (loadTexture && !string.IsNullOrEmpty(animationFrameSave.TextureName))
             {
                 try
@@ -264,7 +265,6 @@ namespace Gum.Graphics.Animation
                     frame.Texture = null;
                 }
             }
-#endif
             frame.FlipHorizontal = animationFrameSave.FlipHorizontal;
             frame.FlipVertical = animationFrameSave.FlipVertical;
 
@@ -287,7 +287,6 @@ namespace Gum.Graphics.Animation
                 //    throw new Exception("The frame must have its texture loaded to use the Pixel coordinate type");
                 //}
 
-#if MONOGAME || KNI || XNA4 || RAYLIB || SKIA || SOKOL
                 if (frame.Texture != null)
                 {
                     // Raylib_cs.Texture2D is a struct, so the Texture2D? alias is a boxed
@@ -308,7 +307,6 @@ namespace Gum.Graphics.Animation
                     frame.TopCoordinate = animationFrameSave.TopCoordinate / textureHeight;
                     frame.BottomCoordinate = animationFrameSave.BottomCoordinate / textureHeight;
                 }
-#endif
             }
 
 

--- a/RenderingLibrary/Graphics/Animation/AnimationFrame.cs
+++ b/RenderingLibrary/Graphics/Animation/AnimationFrame.cs
@@ -287,14 +287,26 @@ namespace Gum.Graphics.Animation
                 //    throw new Exception("The frame must have its texture loaded to use the Pixel coordinate type");
                 //}
 
-#if MONOGAME || KNI || XNA4 || SOKOL
+#if MONOGAME || KNI || XNA4 || RAYLIB || SKIA || SOKOL
                 if (frame.Texture != null)
                 {
-                    frame.LeftCoordinate = animationFrameSave.LeftCoordinate / frame.Texture.Width;
-                    frame.RightCoordinate = animationFrameSave.RightCoordinate / frame.Texture.Width;
+                    // Raylib_cs.Texture2D is a struct, so the Texture2D? alias is a boxed
+                    // Nullable<T> requiring .Value before member access. The other backends'
+                    // Texture2D aliases are reference types, where the null check above is
+                    // enough to access members directly. Same split as
+                    // MonoGameGum/GueDeriving/SpriteRuntime.cs's Texture setter.
+#if RAYLIB
+                    int textureWidth = frame.Texture.Value.Width;
+                    int textureHeight = frame.Texture.Value.Height;
+#else
+                    int textureWidth = frame.Texture.Width;
+                    int textureHeight = frame.Texture.Height;
+#endif
+                    frame.LeftCoordinate = animationFrameSave.LeftCoordinate / textureWidth;
+                    frame.RightCoordinate = animationFrameSave.RightCoordinate / textureWidth;
 
-                    frame.TopCoordinate = animationFrameSave.TopCoordinate / frame.Texture.Height;
-                    frame.BottomCoordinate = animationFrameSave.BottomCoordinate / frame.Texture.Height;
+                    frame.TopCoordinate = animationFrameSave.TopCoordinate / textureHeight;
+                    frame.BottomCoordinate = animationFrameSave.BottomCoordinate / textureHeight;
                 }
 #endif
             }

--- a/Tests/RaylibGum.Tests/Content/AnimationChainTextureLoadingTests.cs
+++ b/Tests/RaylibGum.Tests/Content/AnimationChainTextureLoadingTests.cs
@@ -78,12 +78,49 @@ public class AnimationChainTextureLoadingTests : BaseTestClass
         }, count: 2);
     }
 
-    private static AnimationChainListSave BuildSave(string tempRoot, string achxName, (string TextureName, float FrameLength)[] frames)
+    // Regression for #3549: the Pixel-coordinate conversion block in
+    // AnimationFrame.ToAnimationFrame was gated behind
+    // `#if MONOGAME || KNI || XNA4 || SOKOL`, missing RAYLIB and SKIA. On those
+    // two backends a .achx with <CoordinateType>Pixel</CoordinateType> never had
+    // its LeftCoordinate/RightCoordinate/TopCoordinate/BottomCoordinate divided by
+    // the texture's Width/Height, so the frame silently fell back to the 0/0/1/1
+    // UV default (the entire texture) instead of the authored pixel sub-rect.
+    [Fact]
+    public void ToAnimationChainList_OnRaylib_ConvertsPixelCoordinatesToUv()
+    {
+        WithTempTextures((tempRoot, fileNames) =>
+        {
+            AnimationChainListSave save = BuildSave(
+                tempRoot,
+                "pixel.achx",
+                new[] { (fileNames[0], 0.1f) },
+                coordinateType: TextureCoordinateType.Pixel,
+                coordinates: (Left: 1f, Right: 3f, Top: 1f, Bottom: 3f));
+
+            AnimationChainList list = save.ToAnimationChainList();
+
+            AnimationFrame frame = list[0][0];
+            frame.LeftCoordinate.ShouldBe(0.25f);
+            frame.RightCoordinate.ShouldBe(0.75f);
+            frame.TopCoordinate.ShouldBe(0.25f);
+            frame.BottomCoordinate.ShouldBe(0.75f);
+        }, count: 1);
+    }
+
+    private static AnimationChainListSave BuildSave(
+        string tempRoot,
+        string achxName,
+        (string TextureName, float FrameLength)[] frames,
+        TextureCoordinateType coordinateType = TextureCoordinateType.UV,
+        (float Left, float Right, float Top, float Bottom)? coordinates = null)
     {
         AnimationChainListSave save = new AnimationChainListSave();
         save.FileName = Path.Combine(tempRoot, achxName).Replace('\\', '/');
         save.FileRelativeTextures = true;
+        save.CoordinateType = coordinateType;
         save.AnimationChains = new List<AnimationChainSave>();
+
+        (float Left, float Right, float Top, float Bottom) coords = coordinates ?? (0f, 1f, 0f, 1f);
 
         AnimationChainSave chainSave = new AnimationChainSave();
         chainSave.Name = "TestChain";
@@ -94,10 +131,10 @@ public class AnimationChainTextureLoadingTests : BaseTestClass
             {
                 TextureName = name,
                 FrameLength = length,
-                LeftCoordinate = 0f,
-                RightCoordinate = 1f,
-                TopCoordinate = 0f,
-                BottomCoordinate = 1f,
+                LeftCoordinate = coords.Left,
+                RightCoordinate = coords.Right,
+                TopCoordinate = coords.Top,
+                BottomCoordinate = coords.Bottom,
             });
         }
         save.AnimationChains.Add(chainSave);

--- a/Tests/SkiaGum.Tests/GueDeriving/SpriteRuntimeTests.cs
+++ b/Tests/SkiaGum.Tests/GueDeriving/SpriteRuntimeTests.cs
@@ -12,15 +12,24 @@ namespace SkiaGum.Tests.GueDeriving;
 
 public class MockContentLoader : IContentLoader
 {
+    private readonly int _bitmapWidth;
+    private readonly int _bitmapHeight;
+
     public object LastLoadedContent { get; private set; }
     public string LastLoadedName { get; private set; }
+
+    public MockContentLoader(int bitmapWidth = 10, int bitmapHeight = 10)
+    {
+        _bitmapWidth = bitmapWidth;
+        _bitmapHeight = bitmapHeight;
+    }
 
     public T LoadContent<T>(string contentName)
     {
         LastLoadedName = contentName;
         if (typeof(T) == typeof(SKBitmap))
         {
-            var bitmap = new SKBitmap(10, 10);
+            var bitmap = new SKBitmap(_bitmapWidth, _bitmapHeight);
             LastLoadedContent = bitmap;
             return (T)(object)bitmap;
         }
@@ -136,6 +145,45 @@ public class SpriteRuntimeTests
 
             frame.Texture.ShouldNotBeNull();
             mockLoader.LastLoadedName.ShouldEndWith("fake_texture.png");
+        }
+        finally
+        {
+            LoaderManager.Self.ContentLoader = originalLoader;
+        }
+    }
+
+    // Regression for #3549: the Pixel-coordinate conversion block in
+    // AnimationFrame.ToAnimationFrame was gated behind
+    // `#if MONOGAME || KNI || XNA4 || SOKOL`, missing RAYLIB and SKIA. On Skia a
+    // .achx with <CoordinateType>Pixel</CoordinateType> never had its
+    // LeftCoordinate/RightCoordinate/TopCoordinate/BottomCoordinate divided by
+    // the texture's Width/Height, so the frame silently fell back to the 0/0/1/1
+    // UV default (the entire texture) instead of the authored pixel sub-rect.
+    [Fact]
+    public void ToAnimationFrame_OnSkia_ConvertsPixelCoordinatesToUv()
+    {
+        MockContentLoader mockLoader = new MockContentLoader(bitmapWidth: 10, bitmapHeight: 10);
+        IContentLoader originalLoader = LoaderManager.Self.ContentLoader;
+        LoaderManager.Self.ContentLoader = mockLoader;
+
+        try
+        {
+            Gum.Content.AnimationChain.AnimationFrameSave save = new Gum.Content.AnimationChain.AnimationFrameSave
+            {
+                TextureName = "fake_texture.png",
+                FrameLength = 0.1f,
+                LeftCoordinate = 2f,
+                RightCoordinate = 8f,
+                TopCoordinate = 2f,
+                BottomCoordinate = 8f,
+            };
+
+            AnimationFrame frame = save.ToAnimationFrame(loadTexture: true, coordinateType: Gum.Content.AnimationChain.TextureCoordinateType.Pixel);
+
+            frame.LeftCoordinate.ShouldBe(0.2f);
+            frame.RightCoordinate.ShouldBe(0.8f);
+            frame.TopCoordinate.ShouldBe(0.2f);
+            frame.BottomCoordinate.ShouldBe(0.8f);
         }
         finally
         {


### PR DESCRIPTION
Closes #3549

## Bug

`AnimationFrame.ToAnimationFrame`'s Pixel-coordinate-to-UV conversion block was gated behind `#if MONOGAME || KNI || XNA4 || SOKOL`, missing `RAYLIB` and `SKIA`. On those two backends, a `.achx` declaring `<CoordinateType>Pixel</CoordinateType>` never had its `LeftCoordinate`/`RightCoordinate`/`TopCoordinate`/`BottomCoordinate` divided by the texture's `Width`/`Height`, so the frame silently fell back to the 0/0/1/1 UV default (the entire texture) instead of the authored pixel sub-rectangle.

## Fix

Widened the `#if` to `MONOGAME || KNI || XNA4 || RAYLIB || SKIA || SOKOL`, matching the sibling texture-load block a few lines above.

`Raylib_cs.Texture2D` is a struct, so the `Texture2D?` using-alias on raylib is a boxed `Nullable<T>` requiring `.Value` before member access — the other backends' aliases are reference types where the null check alone is enough. Split that with a nested `#if RAYLIB` inside the widened block, mirroring the existing pattern in `MonoGameGum/GueDeriving/SpriteRuntime.cs`'s `Texture` setter.

## Tests

- `RaylibGum.Tests.Content.AnimationChainTextureLoadingTests.ToAnimationChainList_OnRaylib_ConvertsPixelCoordinatesToUv` — builds a `.achx` save with `CoordinateType = Pixel` and pixel coordinates on a real 4x4 raylib texture, asserts the resulting UV coordinates.
- `SkiaGum.Tests.GueDeriving.SpriteRuntimeTests.ToAnimationFrame_OnSkia_ConvertsPixelCoordinatesToUv` — same via `AnimationFrameSave.ToAnimationFrame(loadTexture: true, coordinateType: Pixel)` against a mocked 10x10 `SKBitmap`.

Both were confirmed RED (asserting the wrong 0/0/1/1 default) before the fix and GREEN after.

Full suite results after the fix:
- `RaylibGum.Tests`: 456/456 passed
- `SkiaGum.Tests`: 198/198 passed
- `MonoGameGum.Tests` (Animation filter, sanity check): 74/74 passed

Manual test verdict: not needed — pure coordinate-computation fix, fully covered by unit tests, no rendering/visual behavior involved.
