### PR TITLE
Unify FormsUtilities gamepad/cursor construction across MonoGame and Raylib

### DIFF
--- a/MonoGameGum/Forms/FormsUtilities.cs
+++ b/MonoGameGum/Forms/FormsUtilities.cs
@@ -26,14 +26,6 @@ using Gum.Input;
 #else
 using Gum.GueDeriving;
 using Gum.Input;
-#if RAYLIB
-// Both Gum.Input and Raylib_cs (a project-wide global using on Raylib) define a
-// GamepadButton type, so alias both to disambiguate inside the Raylib read branch
-// of UpdateGamepads.
-using GumGamepadButton = Gum.Input.GamepadButton;
-using RaylibGamepadButton = Raylib_cs.GamepadButton;
-using RaylibGamepadAxis = Raylib_cs.GamepadAxis;
-#endif
 #endif
 
 #if FRB
@@ -249,9 +241,12 @@ public class FormsUtilities
         }
 
 #if XNALIKE
-        cursor = new Cursor(game?.Window);
+        // The GameWindow-vs-nothing split lives entirely in Cursor's own platform-specific
+        // factories (Cursor.MonoGame.cs / Cursor.Raylib.cs); this #if only forwards the `game`
+        // parameter, which exists on this overload of InitializeDefaults but not the other.
+        cursor = Cursor.CreateForCurrentPlatform(game);
 #else
-        cursor = new Cursor();
+        cursor = Cursor.CreateForCurrentPlatform();
 #endif
 
 #if !FRB
@@ -483,19 +478,11 @@ public class FormsUtilities
             }
         }
 
-#if XNALIKE
         GueInteractiveExtensionMethods.DoUiActivityRecursively(
             innerList,
             cursor,
             keyboard,
-            gameTime.TotalGameTime.TotalSeconds);
-#else
-        GueInteractiveExtensionMethods.DoUiActivityRecursively(
-            innerList,
-            cursor,
-            keyboard,
-            gameTime);
-#endif
+            gameTimeSeconds);
 
         _lastEventRoots.Clear();
         _lastEventRoots.AddRange(innerList);
@@ -549,52 +536,11 @@ public class FormsUtilities
             MonoGameGum.Input.MonoGameGamePadDriver.Apply(Gamepads[i], gamepadState, time);
         }
 #elif RAYLIB
-        // Read native Raylib controller input and push it into the platform-neutral
-        // GamePad holders. Raylib's IsGamepadButtonDown / GetGamepadAxisMovement return
-        // false / 0 for unavailable indices, so no connectivity guard is needed — a
-        // disconnected pad naturally reads as all-released and centered.
         for (int i = 0; i < Gamepads.Length; i++)
         {
-            var gamepad = Gamepads[i];
-
-            gamepad.SetButtonState(GumGamepadButton.DPadUp, Raylib.IsGamepadButtonDown(i, RaylibGamepadButton.LeftFaceUp));
-            gamepad.SetButtonState(GumGamepadButton.DPadDown, Raylib.IsGamepadButtonDown(i, RaylibGamepadButton.LeftFaceDown));
-            gamepad.SetButtonState(GumGamepadButton.DPadLeft, Raylib.IsGamepadButtonDown(i, RaylibGamepadButton.LeftFaceLeft));
-            gamepad.SetButtonState(GumGamepadButton.DPadRight, Raylib.IsGamepadButtonDown(i, RaylibGamepadButton.LeftFaceRight));
-
-            // Raylib's right-face buttons map to the XNA/Gum face buttons by position:
-            // RightFaceDown = A, RightFaceRight = B, RightFaceLeft = X, RightFaceUp = Y.
-            gamepad.SetButtonState(GumGamepadButton.A, Raylib.IsGamepadButtonDown(i, RaylibGamepadButton.RightFaceDown));
-            gamepad.SetButtonState(GumGamepadButton.B, Raylib.IsGamepadButtonDown(i, RaylibGamepadButton.RightFaceRight));
-            gamepad.SetButtonState(GumGamepadButton.X, Raylib.IsGamepadButtonDown(i, RaylibGamepadButton.RightFaceLeft));
-            gamepad.SetButtonState(GumGamepadButton.Y, Raylib.IsGamepadButtonDown(i, RaylibGamepadButton.RightFaceUp));
-
-            gamepad.SetButtonState(GumGamepadButton.LeftShoulder, Raylib.IsGamepadButtonDown(i, RaylibGamepadButton.LeftTrigger1));
-            gamepad.SetButtonState(GumGamepadButton.RightShoulder, Raylib.IsGamepadButtonDown(i, RaylibGamepadButton.RightTrigger1));
-
-            gamepad.SetButtonState(GumGamepadButton.Start, Raylib.IsGamepadButtonDown(i, RaylibGamepadButton.MiddleRight));
-            gamepad.SetButtonState(GumGamepadButton.Back, Raylib.IsGamepadButtonDown(i, RaylibGamepadButton.MiddleLeft));
-
-            gamepad.SetButtonState(GumGamepadButton.LeftStick, Raylib.IsGamepadButtonDown(i, RaylibGamepadButton.LeftThumb));
-            gamepad.SetButtonState(GumGamepadButton.RightStick, Raylib.IsGamepadButtonDown(i, RaylibGamepadButton.RightThumb));
-
-            // Gum's GamePad models triggers as a digital button only (no analog trigger value), so
-            // read the digital trigger buttons LeftTrigger2/RightTrigger2 (LT/RT) directly — this is
-            // exact parity with the MonoGame driver's thresholded triggers and avoids raylib's
-            // trigger-axis rest-at-(-1) convention. (LeftTrigger1/RightTrigger1 are the shoulders above.)
-            gamepad.SetButtonState(GumGamepadButton.LeftTrigger, Raylib.IsGamepadButtonDown(i, RaylibGamepadButton.LeftTrigger2));
-            gamepad.SetButtonState(GumGamepadButton.RightTrigger, Raylib.IsGamepadButtonDown(i, RaylibGamepadButton.RightTrigger2));
-
-            // Raylib reports stick Y as positive-down; flip it to the XNA/Gum convention (positive-up).
-            float leftX = Raylib.GetGamepadAxisMovement(i, RaylibGamepadAxis.LeftX);
-            float leftY = Raylib.GetGamepadAxisMovement(i, RaylibGamepadAxis.LeftY);
-            gamepad.SetLeftStickPosition(leftX, -leftY);
-
-            float rightX = Raylib.GetGamepadAxisMovement(i, RaylibGamepadAxis.RightX);
-            float rightY = Raylib.GetGamepadAxisMovement(i, RaylibGamepadAxis.RightY);
-            gamepad.SetRightStickPosition(rightX, -rightY);
-
-            gamepad.Activity(time);
+            // Read the Raylib state into the platform-neutral GamePad holder (GumCommon),
+            // mirroring the MonoGame driver branch above.
+            Gum.Input.RaylibGamePadDriver.Apply(Gamepads[i], i, time);
         }
 #endif
 

--- a/MonoGameGum/Input/Cursor.MonoGame.cs
+++ b/MonoGameGum/Input/Cursor.MonoGame.cs
@@ -18,7 +18,15 @@ namespace MonoGameGum.Input;
 /// </summary>
 public partial class Cursor
 {
-    
+    /// <summary>
+    /// Constructs a <see cref="Cursor"/> for the current (MonoGame/KNI/FNA) platform, passing
+    /// the game's <see cref="GameWindow"/> so mobile touch positions can be offset by the
+    /// window's client bounds. Mirrors the Raylib platform's <c>Cursor.CreateForCurrentPlatform()</c>.
+    /// </summary>
+    /// <param name="game">The optional <see cref="Game"/> instance, used only to source the
+    /// <see cref="GameWindow"/> for mobile touch-offset math.</param>
+    internal static Cursor CreateForCurrentPlatform(Game? game) => new Cursor(game?.Window);
+
     private MouseState GetMouseState()
     {
         return Microsoft.Xna.Framework.Input.Mouse.GetState();

--- a/Runtimes/RaylibGum/Input/Cursor.Raylib.cs
+++ b/Runtimes/RaylibGum/Input/Cursor.Raylib.cs
@@ -21,9 +21,15 @@ namespace MonoGameGum.Input;
 /// This class includes properties necessary for interacting with Gum UI elements, such 
 /// as push, click, and position tracking.
 /// </summary>
-public partial class Cursor 
+public partial class Cursor
 {
-    
+    /// <summary>
+    /// Constructs a <see cref="Cursor"/> for the current (Raylib) platform. Raylib's parameterless
+    /// <see cref="Cursor()"/> ctor needs no game/window reference. Mirrors the MonoGame platform's
+    /// <c>Cursor.CreateForCurrentPlatform(Game?)</c>.
+    /// </summary>
+    internal static Cursor CreateForCurrentPlatform() => new Cursor();
+
     private MouseState GetMouseState()
     {
         var state = new MouseState();

--- a/Runtimes/RaylibGum/Input/RaylibGamePadDriver.cs
+++ b/Runtimes/RaylibGum/Input/RaylibGamePadDriver.cs
@@ -1,0 +1,84 @@
+using System;
+using GumGamepadButton = Gum.Input.GamepadButton;
+using RaylibGamepadButton = Raylib_cs.GamepadButton;
+using RaylibGamepadAxis = Raylib_cs.GamepadAxis;
+
+namespace Gum.Input;
+
+/// <summary>
+/// Reads native Raylib controller input and pushes it into the platform-neutral
+/// <see cref="GamePad"/> holder (defined in GumCommon), mirroring the MonoGame input
+/// driver (<c>MonoGameGamePadDriver</c>) used by <c>FormsUtilities.UpdateGamepads</c>.
+/// Raylib exposes gamepad state through static query functions rather than a pre-fetched
+/// state struct, so <see cref="Apply(GamePad, int, double)"/> reads by gamepad index
+/// directly instead of taking a snapshot type like XNA's <c>GamePadState</c>.
+/// </summary>
+internal static class RaylibGamePadDriver
+{
+    /// <summary>
+    /// Pushes the current Raylib input for gamepad <paramref name="index"/> into
+    /// <paramref name="gamepad"/> via its driver-facing setters and commits the frame with
+    /// <see cref="GamePad.Activity"/>. Raylib's IsGamepadButtonDown / GetGamepadAxisMovement
+    /// return false / 0 for unavailable indices, so no connectivity guard is needed — a
+    /// disconnected pad naturally reads as all-released and centered.
+    /// </summary>
+    public static void Apply(GamePad gamepad, int index, double time) =>
+        Apply(
+            gamepad,
+            index,
+            time,
+            (i, button) => Raylib_cs.Raylib.IsGamepadButtonDown(i, button),
+            Raylib_cs.Raylib.GetGamepadAxisMovement);
+
+    /// <summary>
+    /// Testing seam: identical mapping to <see cref="Apply(GamePad, int, double)"/>, but with the
+    /// Raylib button/axis reads injected so the mapping can be pinned by a unit test — Raylib's
+    /// static query functions read live hardware and can't be faked directly.
+    /// </summary>
+    internal static void Apply(
+        GamePad gamepad,
+        int index,
+        double time,
+        Func<int, RaylibGamepadButton, bool> isButtonDown,
+        Func<int, RaylibGamepadAxis, float> getAxisMovement)
+    {
+        gamepad.SetButtonState(GumGamepadButton.DPadUp, isButtonDown(index, RaylibGamepadButton.LeftFaceUp));
+        gamepad.SetButtonState(GumGamepadButton.DPadDown, isButtonDown(index, RaylibGamepadButton.LeftFaceDown));
+        gamepad.SetButtonState(GumGamepadButton.DPadLeft, isButtonDown(index, RaylibGamepadButton.LeftFaceLeft));
+        gamepad.SetButtonState(GumGamepadButton.DPadRight, isButtonDown(index, RaylibGamepadButton.LeftFaceRight));
+
+        // Raylib's right-face buttons map to the XNA/Gum face buttons by position:
+        // RightFaceDown = A, RightFaceRight = B, RightFaceLeft = X, RightFaceUp = Y.
+        gamepad.SetButtonState(GumGamepadButton.A, isButtonDown(index, RaylibGamepadButton.RightFaceDown));
+        gamepad.SetButtonState(GumGamepadButton.B, isButtonDown(index, RaylibGamepadButton.RightFaceRight));
+        gamepad.SetButtonState(GumGamepadButton.X, isButtonDown(index, RaylibGamepadButton.RightFaceLeft));
+        gamepad.SetButtonState(GumGamepadButton.Y, isButtonDown(index, RaylibGamepadButton.RightFaceUp));
+
+        gamepad.SetButtonState(GumGamepadButton.LeftShoulder, isButtonDown(index, RaylibGamepadButton.LeftTrigger1));
+        gamepad.SetButtonState(GumGamepadButton.RightShoulder, isButtonDown(index, RaylibGamepadButton.RightTrigger1));
+
+        gamepad.SetButtonState(GumGamepadButton.Start, isButtonDown(index, RaylibGamepadButton.MiddleRight));
+        gamepad.SetButtonState(GumGamepadButton.Back, isButtonDown(index, RaylibGamepadButton.MiddleLeft));
+
+        gamepad.SetButtonState(GumGamepadButton.LeftStick, isButtonDown(index, RaylibGamepadButton.LeftThumb));
+        gamepad.SetButtonState(GumGamepadButton.RightStick, isButtonDown(index, RaylibGamepadButton.RightThumb));
+
+        // Gum's GamePad models triggers as a digital button only (no analog trigger value), so
+        // read the digital trigger buttons LeftTrigger2/RightTrigger2 (LT/RT) directly — this is
+        // exact parity with the MonoGame driver's thresholded triggers and avoids raylib's
+        // trigger-axis rest-at-(-1) convention. (LeftTrigger1/RightTrigger1 are the shoulders above.)
+        gamepad.SetButtonState(GumGamepadButton.LeftTrigger, isButtonDown(index, RaylibGamepadButton.LeftTrigger2));
+        gamepad.SetButtonState(GumGamepadButton.RightTrigger, isButtonDown(index, RaylibGamepadButton.RightTrigger2));
+
+        // Raylib reports stick Y as positive-down; flip it to the XNA/Gum convention (positive-up).
+        float leftX = getAxisMovement(index, RaylibGamepadAxis.LeftX);
+        float leftY = getAxisMovement(index, RaylibGamepadAxis.LeftY);
+        gamepad.SetLeftStickPosition(leftX, -leftY);
+
+        float rightX = getAxisMovement(index, RaylibGamepadAxis.RightX);
+        float rightY = getAxisMovement(index, RaylibGamepadAxis.RightY);
+        gamepad.SetRightStickPosition(rightX, -rightY);
+
+        gamepad.Activity(time);
+    }
+}

--- a/Runtimes/SokolGum/Input/Cursor.Sokol.cs
+++ b/Runtimes/SokolGum/Input/Cursor.Sokol.cs
@@ -4,6 +4,14 @@ namespace Gum.Input;
 
 public partial class Cursor
 {
+    /// <summary>
+    /// Constructs a <see cref="Cursor"/> for the current (Sokol) platform. Sokol's parameterless
+    /// <see cref="Cursor()"/> ctor needs no game/window reference. Mirrors the MonoGame platform's
+    /// <c>Cursor.CreateForCurrentPlatform(Game?)</c> and the Raylib platform's
+    /// <c>Cursor.CreateForCurrentPlatform()</c>.
+    /// </summary>
+    internal static Cursor CreateForCurrentPlatform() => new Cursor();
+
     // Thread-safety: _pendingState is not synchronized. Matches MonoGame/Raylib —
     // event intake and per-frame reads are assumed to run on the same thread
     // (the main/game thread). sokol_app delivers events synchronously on the

--- a/Tests/RaylibGum.Tests/Inputs/RaylibGamePadDriverTests.cs
+++ b/Tests/RaylibGum.Tests/Inputs/RaylibGamePadDriverTests.cs
@@ -1,0 +1,80 @@
+using Gum.Input;
+using Shouldly;
+using GumGamepadButton = Gum.Input.GamepadButton;
+using RaylibGamepadButton = Raylib_cs.GamepadButton;
+using RaylibGamepadAxis = Raylib_cs.GamepadAxis;
+
+namespace RaylibGum.Tests.Inputs;
+
+/// <summary>
+/// Pins the button/axis mapping of <see cref="RaylibGamePadDriver"/> — the driver extracted
+/// (issue #3552) from the <c>#elif RAYLIB</c> branch of <c>FormsUtilities.UpdateGamepads</c> to
+/// mirror <c>MonoGameGamePadDriver</c>. Raylib's real button/axis reads are static functions that
+/// hit live hardware, so these tests exercise the driver's internal testing-seam overload with
+/// fake readers instead.
+/// </summary>
+public class RaylibGamePadDriverTests : BaseTestClass
+{
+    [Fact]
+    public void Apply_MapsRightFaceDown_ToA()
+    {
+        GamePad sut = new GamePad();
+
+        RaylibGamePadDriver.Apply(
+            sut,
+            index: 0,
+            time: 1,
+            isButtonDown: (i, button) => button == RaylibGamepadButton.RightFaceDown,
+            getAxisMovement: (i, axis) => 0f);
+
+        sut.ButtonDown(GumGamepadButton.A).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Apply_MapsLeftTrigger2_ToLeftTrigger_NotLeftShoulder()
+    {
+        GamePad sut = new GamePad();
+
+        RaylibGamePadDriver.Apply(
+            sut,
+            index: 0,
+            time: 1,
+            isButtonDown: (i, button) => button == RaylibGamepadButton.LeftTrigger2,
+            getAxisMovement: (i, axis) => 0f);
+
+        sut.ButtonDown(GumGamepadButton.LeftTrigger).ShouldBeTrue();
+        sut.ButtonDown(GumGamepadButton.LeftShoulder).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Apply_FlipsLeftStickY_ToXnaGumConvention()
+    {
+        GamePad sut = new GamePad();
+
+        // Raylib reports stick Y as positive-down; Gum/XNA convention is positive-up.
+        RaylibGamePadDriver.Apply(
+            sut,
+            index: 0,
+            time: 1,
+            isButtonDown: (i, button) => false,
+            getAxisMovement: (i, axis) => axis == RaylibGamepadAxis.LeftY ? 1f : 0f);
+
+        sut.LeftStick.AsDPadDown(DPadDirection.Down).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Apply_ReadsGivenGamepadIndex()
+    {
+        GamePad sutIndex0 = new GamePad();
+        GamePad sutIndex1 = new GamePad();
+
+        bool IsButtonDown(int i, RaylibGamepadButton button) =>
+            i == 0 && button == RaylibGamepadButton.RightFaceDown;
+
+        RaylibGamePadDriver.Apply(sutIndex0, index: 0, time: 1, IsButtonDown, (i, axis) => 0f);
+        RaylibGamePadDriver.Apply(sutIndex1, index: 1, time: 1, IsButtonDown, (i, axis) => 0f);
+
+        sutIndex0.ButtonDown(GumGamepadButton.A).ShouldBeTrue();
+        sutIndex1.ButtonDown(GumGamepadButton.A).ShouldBeFalse();
+    }
+}


### PR DESCRIPTION
## Summary
- Extracts `RaylibGamePadDriver` (mirroring `MonoGameGamePadDriver`) so `FormsUtilities.UpdateGamepads`'s `#elif RAYLIB` branch collapses from ~45 inlined lines to a single driver call, matching the XNALIKE branch's shape.
- Adds `Cursor.CreateForCurrentPlatform(...)` factories to the existing MonoGame/Raylib `Cursor` partial-class split, so `FormsUtilities.cs` no longer inlines platform-specific `Cursor` construction logic (GameWindow-vs-nothing) — that now lives with `Cursor` itself.
- Collapses a redundant duplicate `#if XNALIKE`/`#else` derivation of `gameTimeSeconds` in `Update(...)` that was re-deriving a value already computed a few lines earlier in the same method.
- Removes the now-unused `RaylibGamepadButton`/`RaylibGamepadAxis`/`GumGamepadButton` `using` aliases from `FormsUtilities.cs` (their only use sites moved into the new driver).

## Scope
Scoped to issue #3552, itself a scoped-down slice of #3543's item 2. `GumService.cs` is intentionally **not** touched here (per #3552's own scope note) — candidate for a follow-up issue.

## Testing
- Added `RaylibGamePadDriverTests` (4 tests) pinning the extracted driver's button/axis mapping via an internal testing-seam overload (`Apply(gamepad, index, time, isButtonDown, getAxisMovement)`), since Raylib's real gamepad reads are static functions hitting live hardware and can't be faked directly.
- `MonoGameGum.Tests`: 1823/1823 passing.
- `RaylibGum.Tests`: 459/459 passing (including the 4 new tests).
- `KniGum.csproj` builds clean (0 errors) — confirms the XNALIKE-branch changes (Cursor/gameTimeSeconds) don't regress KNI.
- FRB canary (`FlatRedBall.Forms.DesktopGlNet6.csproj`, since FRB implies XNALIKE): baseline (`docs-manual-animation-chains`) and this branch both build with **0 errors, 3228 warnings** — identical, no regression.

Manual test: not needed — this is backend-internal plumbing (gamepad polling, cursor construction) with no new user-visible behavior; covered by unit tests + FRB canary + compilation.

Closes #3552
