### PR TITLE
Add Keyboard.CreateForCurrentPlatform() factories, remove FormsUtilities #if

### DIFF
--- a/MonoGameGum/Forms/FormsUtilities.cs
+++ b/MonoGameGum/Forms/FormsUtilities.cs
@@ -256,9 +256,13 @@ public class FormsUtilities
 #endif
 
 #if XNALIKE
-        keyboard = new Keyboard(game);
+        // The MonoGame-vs-Raylib/Sokol split lives entirely in Keyboard's own platform-specific
+        // implementations (MonoGameGum/Input/Keyboard.cs vs Runtimes/RaylibGum|SokolGum/Input/Keyboard.cs);
+        // this #if only forwards the `game` parameter, which exists on this overload of
+        // InitializeDefaults but not the other.
+        keyboard = Keyboard.CreateForCurrentPlatform(game);
 #else
-        keyboard = new Keyboard();
+        keyboard = Keyboard.CreateForCurrentPlatform();
 #endif
 
         for (int i = 0; i < Gamepads.Length; i++)

--- a/MonoGameGum/Input/Keyboard.cs
+++ b/MonoGameGum/Input/Keyboard.cs
@@ -129,6 +129,15 @@ public partial class Keyboard : IInputReceiverKeyboardMonoGame
     #endregion
 
     /// <summary>
+    /// Constructs a <see cref="Keyboard"/> for the current (MonoGame/KNI/FNA) platform, passing
+    /// the <see cref="Game"/> so it can subscribe to the Game's Window TextInput event. Mirrors
+    /// the Raylib/Sokol platforms' <c>Keyboard.CreateForCurrentPlatform()</c>.
+    /// </summary>
+    /// <param name="game">The optional <see cref="Game"/> instance, used to subscribe to the
+    /// Game's Window TextInput event if it is available on the current platform.</param>
+    internal static Keyboard CreateForCurrentPlatform(Game? game) => new Keyboard(game);
+
+    /// <summary>
     /// Instantiates a new Keyboard instance, optionally subscribing to the provided Game's Window TextInput event.
     /// </summary>
     /// <param name="game">The optional Game. If passed, the keyboard attempts to subscribe to the Game's Window TextInput event

--- a/Runtimes/RaylibGum/Input/Keyboard.cs
+++ b/Runtimes/RaylibGum/Input/Keyboard.cs
@@ -10,6 +10,14 @@ namespace Gum.Input;
 /// </summary>
 public class Keyboard : IInputReceiverKeyboard
 {
+    /// <summary>
+    /// Constructs a <see cref="Keyboard"/> for the current (Raylib) platform. Raylib's parameterless
+    /// <see cref="Keyboard()"/> ctor needs no game reference. Mirrors the MonoGame platform's
+    /// <c>Keyboard.CreateForCurrentPlatform(Game?)</c> and the Sokol platform's
+    /// <c>Keyboard.CreateForCurrentPlatform()</c>.
+    /// </summary>
+    internal static Keyboard CreateForCurrentPlatform() => new Keyboard();
+
     double _lastGameTime;
     double _lastGetStringTypedCall = -999;
     string _lastStringTyped = "";

--- a/Runtimes/SokolGum/Input/Keyboard.cs
+++ b/Runtimes/SokolGum/Input/Keyboard.cs
@@ -26,6 +26,14 @@ namespace Gum.Input;
 /// </remarks>
 public class Keyboard : IInputReceiverKeyboard
 {
+    /// <summary>
+    /// Constructs a <see cref="Keyboard"/> for the current (Sokol) platform. Sokol's parameterless
+    /// <see cref="Keyboard()"/> ctor needs no game reference. Mirrors the MonoGame platform's
+    /// <c>Keyboard.CreateForCurrentPlatform(Game?)</c> and the Raylib platform's
+    /// <c>Keyboard.CreateForCurrentPlatform()</c>.
+    /// </summary>
+    internal static Keyboard CreateForCurrentPlatform() => new Keyboard();
+
     #region Key translation tables
 
     /// <summary>


### PR DESCRIPTION
## Summary
- `Keyboard` is not structured like `Cursor` (#3553) — MonoGame, Raylib, and Sokol have three fully independent `Keyboard` classes with no shared source. Rather than converge them (out of scope, tracked separately), added a static `CreateForCurrentPlatform()` factory to each of the three, mirroring `Cursor.CreateForCurrentPlatform(...)` from #3553.
- `MonoGameGum/Forms/FormsUtilities.cs`'s `keyboard` construction now calls `Keyboard.CreateForCurrentPlatform(...)`, collapsing to a thin `#if XNALIKE` that only forwards the `game` argument (only one `InitializeDefaults` overload has it).
- No internals of any `Keyboard` class were touched beyond the one factory method each.

## Test plan
- [x] `dotnet test MonoGameGum.Tests/MonoGameGum.Tests.csproj` — 1823 passed, 0 failed
- [x] `dotnet test Tests/RaylibGum.Tests/RaylibGum.Tests.csproj` — 460 passed, 0 failed
- [x] `Runtimes/SokolGum/SokolGum.csproj` — could not be compiled (Sokol.NET submodule init fails with `fatal: Unable to find current revision in submodule path 'Sokol.NET'`, consistent with a known prior failure); verified by manual inspection instead — the Sokol `Keyboard.CreateForCurrentPlatform()` addition is a mechanical, line-for-line mirror of the Raylib one (same `internal static Keyboard CreateForCurrentPlatform() => new Keyboard();`, same implicit parameterless ctor, same `Gum.Input` namespace), which did compile clean.
- [x] FRB canary: `FlatRedBall.Forms.DesktopGlNet6.csproj` built via detached checkout of this branch's tip in the primary Gum checkout — 0 errors, 3228 warnings, matching #3553's reported baseline exactly.
- Manual test: not needed — backend-internal plumbing (keyboard construction) with no new user-visible behavior, covered by unit tests + FRB canary + compilation, same reasoning as #3553.

Closes #3554