### PR TITLE
Add Sprite.CreateForCurrentPlatform() factory, collapse GumService sprite #ifs

### DIFF
--- a/MonoGameGum/GumService.cs
+++ b/MonoGameGum/GumService.cs
@@ -31,6 +31,7 @@ using Microsoft.Xna.Framework.Graphics;
 #elif RAYLIB
 using Gum.GueDeriving;
 using Gum.Input;
+using Gum.Renderables;
 using GameTime = double;
 using Raylib_cs;
 using RaylibGum.Renderables;
@@ -156,14 +157,7 @@ public class GumService : IGumService
     public IGumClipboard? Clipboard { get; private set; }
 
     /// <inheritdoc/>
-    IRenderable IGumService.CreateSpriteRenderable() =>
-#if XNALIKE
-        new global::RenderingLibrary.Graphics.Sprite(texture: null);
-#elif RAYLIB
-        new global::Gum.Renderables.Sprite();
-#else
-        throw new NotSupportedException("This runtime does not have a sprite renderable implementation.");
-#endif
+    IRenderable IGumService.CreateSpriteRenderable() => Sprite.CreateForCurrentPlatform();
 
 #if !IOS && !ANDROID
     private IGumHotReloadManager? _hotReloadManager;

--- a/RenderingLibrary/Graphics/Sprite.cs
+++ b/RenderingLibrary/Graphics/Sprite.cs
@@ -342,6 +342,12 @@ public class Sprite : SpriteBatchRenderableBase,
 
     #endregion
 
+    /// <summary>
+    /// Constructs a <see cref="Sprite"/> for the current (MonoGame/KNI/FNA) platform, with no
+    /// initial texture assigned. Mirrors the Raylib platform's <c>Sprite.CreateForCurrentPlatform()</c>.
+    /// </summary>
+    internal static Sprite CreateForCurrentPlatform() => new Sprite(texture: null);
+
     public Sprite(Texture2D? texture)
     {
         this.Visible = true;

--- a/Runtimes/RaylibGum/Renderables/Sprite.cs
+++ b/Runtimes/RaylibGum/Renderables/Sprite.cs
@@ -477,6 +477,12 @@ public class Sprite : InvisibleRenderable, IAspectRatio, ITextureCoordinate, IAn
 
     public void RefreshCurrentChainToDesiredName() => AnimationLogic.RefreshCurrentChainToDesiredName();
 
+    /// <summary>
+    /// Constructs a <see cref="Sprite"/> for the current (Raylib) platform, with no initial
+    /// texture assigned. Mirrors the MonoGame/KNI/FNA platforms' <c>Sprite.CreateForCurrentPlatform()</c>.
+    /// </summary>
+    internal static Sprite CreateForCurrentPlatform() => new Sprite();
+
     public Sprite(Texture2D? texture = null)
     {
         this.Texture = texture;


### PR DESCRIPTION
## Summary
- Follow-up to #3552/#3553 and #3554/#3555: unifies `IGumService.CreateSpriteRenderable()` in `MonoGameGum/GumService.cs` using the same `CreateForCurrentPlatform()` factory pattern established for `Cursor`/`Keyboard`.
- Added `internal static Sprite CreateForCurrentPlatform()` to `RenderingLibrary/Graphics/Sprite.cs` (XNALIKE: `new Sprite(texture: null)`) and to `Runtimes/RaylibGum/Renderables/Sprite.cs` (RAYLIB: `new Sprite()`).
- `GumService.CreateSpriteRenderable()` now collapses to `IRenderable IGumService.CreateSpriteRenderable() => Sprite.CreateForCurrentPlatform();` with zero `#if`s (unlike Cursor/Keyboard, no `Game`-forwarding parameter is needed here, so it goes fully unguarded).
- Added a conditional `using Gum.Renderables;` under the `#elif RAYLIB` block in `GumService.cs` so the unqualified `Sprite` resolves to the Raylib renderable there (the XNALIKE branch already resolves via the existing unconditional `using RenderingLibrary.Graphics;`).

Sokol and Skia are unaffected — `GumService.cs` is only `<Compile Include>`d by `MonoGameGum.csproj` and `RaylibGum.csproj`; Sokol/Skia have their own independent `GumService.cs` files. The removed `#else`/`NotSupportedException` branch was dead code (no third consumer reached it).

Closes #3556

## Test plan
- [x] `dotnet build MonoGameGum.Tests/MonoGameGum.Tests.csproj` — 0 errors
- [x] `dotnet test MonoGameGum.Tests/MonoGameGum.Tests.csproj` — 1823/1823 passed
- [x] `dotnet build Runtimes/RaylibGum/RaylibGum.csproj` — 0 errors
- [x] `dotnet test Tests/RaylibGum.Tests/RaylibGum.Tests.csproj` — 460/460 passed
- Manual test verdict: not needed — backend-internal plumbing change (construction dispatch only), no user-visible behavior change, same reasoning as #3553/#3555.

🤖 Generated with [Claude Code](https://claude.com/claude-code)