### PR TITLE
Register RectangleRuntime/PolygonRuntime for Raylib project-loaded elements

### DIFF
--- a/Runtimes/RaylibGum/RenderingLibrary/SystemManagers.cs
+++ b/Runtimes/RaylibGum/RenderingLibrary/SystemManagers.cs
@@ -228,13 +228,13 @@ public class SystemManagers : ISystemManagers
             "NineSlice",
             () => new NineSliceRuntime());
 
-        //ElementSaveExtensions.RegisterGueInstantiation(
-        //    "Polygon",
-        //    () => new PolygonRuntime(systemManagers: this));
+        ElementSaveExtensions.RegisterGueInstantiation(
+            "Polygon",
+            () => new PolygonRuntime(systemManagers: this));
 
-        //ElementSaveExtensions.RegisterGueInstantiation(
-        //    "Rectangle",
-        //    () => new RectangleRuntime(systemManagers: this));
+        ElementSaveExtensions.RegisterGueInstantiation(
+            "Rectangle",
+            () => new RectangleRuntime(systemManagers: this));
 
         ElementSaveExtensions.RegisterGueInstantiation(
             "Sprite",

--- a/Tests/RaylibGum.Tests/Runtimes/ElementSaveExtensionsTests.cs
+++ b/Tests/RaylibGum.Tests/Runtimes/ElementSaveExtensionsTests.cs
@@ -1,0 +1,51 @@
+using Gum.DataTypes;
+using Gum.GueDeriving;
+using GumRuntime;
+using RenderingLibrary;
+using Shouldly;
+using System.Reflection;
+
+namespace RaylibGum.Tests.Runtimes;
+
+// Issue #3574 — SystemManagers.RegisterComponentRuntimeInstantiations is the canonical
+// primary-registry hook on the raylib backend (mirrors MonoGame's #2925 fix). The Rectangle and
+// Polygon registrations were previously commented out with no test pinning them, so a
+// .gumx-project-loaded "Rectangle"/"Polygon" standard element silently fell back to a plain
+// GraphicalUiElement instead of RectangleRuntime/PolygonRuntime. Method is private, so we invoke
+// it via reflection — same pattern MonoGameGum.Tests.Runtimes.ElementSaveExtensionsTests uses.
+public class ElementSaveExtensionsTests
+{
+    [Fact]
+    public void RegisterComponentRuntimeInstantiations_ShouldRegisterPolygonRuntime_ForPolygonBaseType()
+    {
+        InvokeRegisterComponentRuntimeInstantiations();
+
+        var element = new StandardElementSave { Name = "Polygon" };
+
+        var created = ElementSaveExtensions.CreateGueForElement(element);
+
+        created.ShouldBeAssignableTo<PolygonRuntime>();
+    }
+
+    [Fact]
+    public void RegisterComponentRuntimeInstantiations_ShouldRegisterRectangleRuntime_ForRectangleBaseType()
+    {
+        InvokeRegisterComponentRuntimeInstantiations();
+
+        var element = new StandardElementSave { Name = "Rectangle" };
+
+        var created = ElementSaveExtensions.CreateGueForElement(element);
+
+        created.ShouldBeAssignableTo<RectangleRuntime>();
+    }
+
+    private static void InvokeRegisterComponentRuntimeInstantiations()
+    {
+        var managers = new SystemManagers();
+        var method = typeof(SystemManagers).GetMethod(
+            "RegisterComponentRuntimeInstantiations",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+        method.ShouldNotBeNull("RegisterComponentRuntimeInstantiations must exist on SystemManagers.");
+        method!.Invoke(managers, parameters: null);
+    }
+}


### PR DESCRIPTION
## Summary
- `SystemManagers.RegisterComponentRuntimeInstantiations()` (Raylib) had the `"Rectangle"`/`"Polygon"` `RegisterGueInstantiation` calls commented out, unlike the other five standard elements (`ColoredRectangle`, `Container`, `NineSlice`, `Sprite`, `Text`).
- This only affected `.gumx`-project-loaded elements: a project-authored `Rectangle`/`Polygon` resolved to a plain `GraphicalUiElement` instead of `RectangleRuntime`/`PolygonRuntime`, so `RectangleRuntime`'s Raylib property surface (`FillColor`, `CornerRadius`, gradients, dropshadow) wasn't reachable and any downstream cast would fail. It rendered fine either way (via `FallbackRenderableFactory`), so this wasn't visually observable.
- Uncommented the two calls to close the gap with the fallback path.
- Added pinning tests (`Tests/RaylibGum.Tests/Runtimes/ElementSaveExtensionsTests.cs`) mirroring the MonoGame `Circle` precedent (#2925) that originally caught this exact bug class — confirmed red before the fix, green after.

Closes #3574

## Test plan
- [x] `dotnet test Tests/RaylibGum.Tests/RaylibGum.Tests.csproj` — 462/462 passed
- [x] New tests confirmed red with the registrations re-commented, green with the fix restored
- [x] `dotnet build Runtimes/RaylibGum/RaylibGum.csproj` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
