### PR TITLE
Make generated element null check unconditional, not Debug-only

### DIFF
--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/@interface.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/@interface.Generated.cs
@@ -17,10 +17,7 @@ partial class @interface : global::Gum.Forms.Controls.FrameworkElement
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("interface");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named interface - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("interface") ?? throw new System.InvalidOperationException("Could not find an element named interface - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new @interface(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/AnimatedComponent.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/AnimatedComponent.Generated.cs
@@ -18,10 +18,7 @@ partial class AnimatedComponent : global::Gum.Forms.Controls.FrameworkElement
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("AnimatedComponent");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named AnimatedComponent - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("AnimatedComponent") ?? throw new System.InvalidOperationException("Could not find an element named AnimatedComponent - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new AnimatedComponent(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/ComponentWithChangedTypes.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/ComponentWithChangedTypes.Generated.cs
@@ -17,10 +17,7 @@ partial class ComponentWithChangedTypes : global::Gum.Forms.Controls.FrameworkEl
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("ComponentWithChangedTypes");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named ComponentWithChangedTypes - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("ComponentWithChangedTypes") ?? throw new System.InvalidOperationException("Could not find an element named ComponentWithChangedTypes - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new ComponentWithChangedTypes(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/ComponentWithExposedVariables.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/ComponentWithExposedVariables.Generated.cs
@@ -18,10 +18,7 @@ partial class ComponentWithExposedVariables : global::Gum.Forms.Controls.Framewo
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("ComponentWithExposedVariables");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named ComponentWithExposedVariables - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("ComponentWithExposedVariables") ?? throw new System.InvalidOperationException("Could not find an element named ComponentWithExposedVariables - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new ComponentWithExposedVariables(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/ContainerOfFormsObjects.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/ContainerOfFormsObjects.Generated.cs
@@ -18,10 +18,7 @@ partial class ContainerOfFormsObjects : global::Gum.Forms.Controls.FrameworkElem
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("ContainerOfFormsObjects");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named ContainerOfFormsObjects - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("ContainerOfFormsObjects") ?? throw new System.InvalidOperationException("Could not find an element named ContainerOfFormsObjects - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new ContainerOfFormsObjects(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/ButtonClose.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/ButtonClose.Generated.cs
@@ -18,10 +18,7 @@ partial class ButtonClose : global::Gum.Forms.Controls.Button
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/ButtonClose");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/ButtonClose - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/ButtonClose") ?? throw new System.InvalidOperationException("Could not find an element named Controls/ButtonClose - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new ButtonClose(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/ButtonConfirm.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/ButtonConfirm.Generated.cs
@@ -17,10 +17,7 @@ partial class ButtonConfirm : global::Gum.Forms.Controls.Button
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/ButtonConfirm");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/ButtonConfirm - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/ButtonConfirm") ?? throw new System.InvalidOperationException("Could not find an element named Controls/ButtonConfirm - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new ButtonConfirm(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/ButtonDeny.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/ButtonDeny.Generated.cs
@@ -17,10 +17,7 @@ partial class ButtonDeny : global::Gum.Forms.Controls.Button
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/ButtonDeny");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/ButtonDeny - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/ButtonDeny") ?? throw new System.InvalidOperationException("Could not find an element named Controls/ButtonDeny - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new ButtonDeny(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/ButtonIcon.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/ButtonIcon.Generated.cs
@@ -18,10 +18,7 @@ partial class ButtonIcon : global::Gum.Forms.Controls.Button
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/ButtonIcon");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/ButtonIcon - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/ButtonIcon") ?? throw new System.InvalidOperationException("Could not find an element named Controls/ButtonIcon - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new ButtonIcon(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/ButtonStandard.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/ButtonStandard.Generated.cs
@@ -17,10 +17,7 @@ partial class ButtonStandard : global::Gum.Forms.Controls.Button
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/ButtonStandard");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/ButtonStandard - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/ButtonStandard") ?? throw new System.InvalidOperationException("Could not find an element named Controls/ButtonStandard - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new ButtonStandard(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/ButtonStandardIcon.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/ButtonStandardIcon.Generated.cs
@@ -18,10 +18,7 @@ partial class ButtonStandardIcon : global::Gum.Forms.Controls.Button
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/ButtonStandardIcon");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/ButtonStandardIcon - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/ButtonStandardIcon") ?? throw new System.InvalidOperationException("Could not find an element named Controls/ButtonStandardIcon - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new ButtonStandardIcon(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/ButtonTab.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/ButtonTab.Generated.cs
@@ -17,10 +17,7 @@ partial class ButtonTab : global::Gum.Forms.Controls.Button
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/ButtonTab");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/ButtonTab - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/ButtonTab") ?? throw new System.InvalidOperationException("Could not find an element named Controls/ButtonTab - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new ButtonTab(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/CheckBox.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/CheckBox.Generated.cs
@@ -18,10 +18,7 @@ partial class CheckBox : global::Gum.Forms.Controls.CheckBox
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/CheckBox");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/CheckBox - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/CheckBox") ?? throw new System.InvalidOperationException("Could not find an element named Controls/CheckBox - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new CheckBox(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/ComboBox.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/ComboBox.Generated.cs
@@ -19,10 +19,7 @@ partial class ComboBox : global::Gum.Forms.Controls.ComboBox
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/ComboBox");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/ComboBox - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/ComboBox") ?? throw new System.InvalidOperationException("Could not find an element named Controls/ComboBox - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new ComboBox(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/DialogBox.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/DialogBox.Generated.cs
@@ -18,10 +18,7 @@ partial class DialogBox : global::Gum.Forms.Controls.FrameworkElement
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/DialogBox");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/DialogBox - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/DialogBox") ?? throw new System.InvalidOperationException("Could not find an element named Controls/DialogBox - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new DialogBox(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/InputDeviceSelectionItem.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/InputDeviceSelectionItem.Generated.cs
@@ -19,10 +19,7 @@ partial class InputDeviceSelectionItem : global::Gum.Forms.Controls.FrameworkEle
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/InputDeviceSelectionItem");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/InputDeviceSelectionItem - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/InputDeviceSelectionItem") ?? throw new System.InvalidOperationException("Could not find an element named Controls/InputDeviceSelectionItem - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new InputDeviceSelectionItem(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/InputDeviceSelector.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/InputDeviceSelector.Generated.cs
@@ -18,10 +18,7 @@ partial class InputDeviceSelector : global::Gum.Forms.Controls.FrameworkElement
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/InputDeviceSelector");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/InputDeviceSelector - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/InputDeviceSelector") ?? throw new System.InvalidOperationException("Could not find an element named Controls/InputDeviceSelector - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new InputDeviceSelector(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/Keyboard.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/Keyboard.Generated.cs
@@ -20,10 +20,7 @@ partial class Keyboard : global::Gum.Forms.Controls.FrameworkElement
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/Keyboard");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/Keyboard - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/Keyboard") ?? throw new System.InvalidOperationException("Could not find an element named Controls/Keyboard - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new Keyboard(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/KeyboardKey.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/KeyboardKey.Generated.cs
@@ -18,10 +18,7 @@ partial class KeyboardKey : global::Gum.Forms.Controls.Button
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/KeyboardKey");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/KeyboardKey - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/KeyboardKey") ?? throw new System.InvalidOperationException("Could not find an element named Controls/KeyboardKey - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new KeyboardKey(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/Label.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/Label.Generated.cs
@@ -17,10 +17,7 @@ partial class Label : global::Gum.Forms.Controls.Label
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.TextRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/Label");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/Label - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/Label") ?? throw new System.InvalidOperationException("Could not find an element named Controls/Label - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new Label(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/ListBox.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/ListBox.Generated.cs
@@ -18,10 +18,7 @@ partial class ListBox : global::Gum.Forms.Controls.ListBox
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/ListBox");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/ListBox - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/ListBox") ?? throw new System.InvalidOperationException("Could not find an element named Controls/ListBox - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new ListBox(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/ListBoxItem.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/ListBoxItem.Generated.cs
@@ -17,10 +17,7 @@ partial class ListBoxItem : global::Gum.Forms.Controls.ListBoxItem
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/ListBoxItem");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/ListBoxItem - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/ListBoxItem") ?? throw new System.InvalidOperationException("Could not find an element named Controls/ListBoxItem - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new ListBoxItem(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/Menu.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/Menu.Generated.cs
@@ -17,10 +17,7 @@ partial class Menu : global::Gum.Forms.Controls.Menu
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/Menu");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/Menu - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/Menu") ?? throw new System.InvalidOperationException("Could not find an element named Controls/Menu - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new Menu(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/MenuItem.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/MenuItem.Generated.cs
@@ -17,10 +17,7 @@ partial class MenuItem : global::Gum.Forms.Controls.MenuItem
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/MenuItem");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/MenuItem - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/MenuItem") ?? throw new System.InvalidOperationException("Could not find an element named Controls/MenuItem - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new MenuItem(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/Panel.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/Panel.Generated.cs
@@ -17,10 +17,7 @@ partial class Panel : global::Gum.Forms.Controls.Panel
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/Panel");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/Panel - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/Panel") ?? throw new System.InvalidOperationException("Could not find an element named Controls/Panel - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new Panel(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/PasswordBox.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/PasswordBox.Generated.cs
@@ -17,10 +17,7 @@ partial class PasswordBox : global::Gum.Forms.Controls.PasswordBox
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/PasswordBox");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/PasswordBox - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/PasswordBox") ?? throw new System.InvalidOperationException("Could not find an element named Controls/PasswordBox - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new PasswordBox(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/PlayerJoinView.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/PlayerJoinView.Generated.cs
@@ -18,10 +18,7 @@ partial class PlayerJoinView : global::Gum.Forms.Controls.FrameworkElement
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/PlayerJoinView");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/PlayerJoinView - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/PlayerJoinView") ?? throw new System.InvalidOperationException("Could not find an element named Controls/PlayerJoinView - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new PlayerJoinView(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/PlayerJoinViewItem.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/PlayerJoinViewItem.Generated.cs
@@ -18,10 +18,7 @@ partial class PlayerJoinViewItem : global::Gum.Forms.Controls.FrameworkElement
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/PlayerJoinViewItem");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/PlayerJoinViewItem - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/PlayerJoinViewItem") ?? throw new System.InvalidOperationException("Could not find an element named Controls/PlayerJoinViewItem - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new PlayerJoinViewItem(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/RadioButton.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/RadioButton.Generated.cs
@@ -18,10 +18,7 @@ partial class RadioButton : global::Gum.Forms.Controls.RadioButton
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/RadioButton");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/RadioButton - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/RadioButton") ?? throw new System.InvalidOperationException("Could not find an element named Controls/RadioButton - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new RadioButton(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/ScrollBar.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/ScrollBar.Generated.cs
@@ -18,10 +18,7 @@ partial class ScrollBar : global::Gum.Forms.Controls.ScrollBar
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/ScrollBar");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/ScrollBar - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/ScrollBar") ?? throw new System.InvalidOperationException("Could not find an element named Controls/ScrollBar - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new ScrollBar(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/ScrollViewer.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/ScrollViewer.Generated.cs
@@ -18,10 +18,7 @@ partial class ScrollViewer : global::Gum.Forms.Controls.ScrollViewer
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/ScrollViewer");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/ScrollViewer - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/ScrollViewer") ?? throw new System.InvalidOperationException("Could not find an element named Controls/ScrollViewer - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new ScrollViewer(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/SettingsView.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/SettingsView.Generated.cs
@@ -18,10 +18,7 @@ partial class SettingsView : global::Gum.Forms.Controls.FrameworkElement
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/SettingsView");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/SettingsView - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/SettingsView") ?? throw new System.InvalidOperationException("Could not find an element named Controls/SettingsView - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new SettingsView(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/Slider.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/Slider.Generated.cs
@@ -18,10 +18,7 @@ partial class Slider : global::Gum.Forms.Controls.Slider
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/Slider");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/Slider - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/Slider") ?? throw new System.InvalidOperationException("Could not find an element named Controls/Slider - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new Slider(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/SplitterStandard.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/SplitterStandard.Generated.cs
@@ -17,10 +17,7 @@ partial class SplitterStandard : global::Gum.Forms.Controls.Splitter
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/SplitterStandard");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/SplitterStandard - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/SplitterStandard") ?? throw new System.InvalidOperationException("Could not find an element named Controls/SplitterStandard - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new SplitterStandard(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/StackPanel.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/StackPanel.Generated.cs
@@ -17,10 +17,7 @@ partial class StackPanel : global::Gum.Forms.Controls.StackPanel
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/StackPanel");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/StackPanel - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/StackPanel") ?? throw new System.InvalidOperationException("Could not find an element named Controls/StackPanel - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new StackPanel(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/TextBox.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/TextBox.Generated.cs
@@ -18,10 +18,7 @@ partial class TextBox : global::Gum.Forms.Controls.TextBox
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/TextBox");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/TextBox - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/TextBox") ?? throw new System.InvalidOperationException("Could not find an element named Controls/TextBox - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new TextBox(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/Toast.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/Toast.Generated.cs
@@ -17,10 +17,7 @@ partial class Toast : global::Gum.Forms.Controls.FrameworkElement
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/Toast");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/Toast - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/Toast") ?? throw new System.InvalidOperationException("Could not find an element named Controls/Toast - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new Toast(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/TreeView.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/TreeView.Generated.cs
@@ -18,10 +18,7 @@ partial class TreeView : global::Gum.Forms.Controls.FrameworkElement
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/TreeView");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/TreeView - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/TreeView") ?? throw new System.InvalidOperationException("Could not find an element named Controls/TreeView - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new TreeView(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/TreeViewItem.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/TreeViewItem.Generated.cs
@@ -18,10 +18,7 @@ partial class TreeViewItem : global::Gum.Forms.Controls.FrameworkElement
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/TreeViewItem");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/TreeViewItem - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/TreeViewItem") ?? throw new System.InvalidOperationException("Could not find an element named Controls/TreeViewItem - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new TreeViewItem(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/TreeViewToggle.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/TreeViewToggle.Generated.cs
@@ -19,10 +19,7 @@ partial class TreeViewToggle : global::Gum.Forms.Controls.FrameworkElement
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/TreeViewToggle");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/TreeViewToggle - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/TreeViewToggle") ?? throw new System.InvalidOperationException("Could not find an element named Controls/TreeViewToggle - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new TreeViewToggle(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/UserControl.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/UserControl.Generated.cs
@@ -17,10 +17,7 @@ partial class UserControl : global::Gum.Forms.Controls.FrameworkElement
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/UserControl");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/UserControl - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/UserControl") ?? throw new System.InvalidOperationException("Could not find an element named Controls/UserControl - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new UserControl(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/WindowStandard.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/Controls/WindowStandard.Generated.cs
@@ -18,10 +18,7 @@ partial class WindowStandard : global::Gum.Forms.Window
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/WindowStandard");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/WindowStandard - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/WindowStandard") ?? throw new System.InvalidOperationException("Could not find an element named Controls/WindowStandard - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new WindowStandard(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/Elements/CautionLines.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/Elements/CautionLines.Generated.cs
@@ -17,10 +17,7 @@ partial class CautionLines : global::Gum.Forms.Controls.FrameworkElement
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Elements/CautionLines");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Elements/CautionLines - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Elements/CautionLines") ?? throw new System.InvalidOperationException("Could not find an element named Elements/CautionLines - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new CautionLines(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/Elements/Divider.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/Elements/Divider.Generated.cs
@@ -17,10 +17,7 @@ partial class Divider : global::Gum.Forms.Controls.FrameworkElement
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Elements/Divider");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Elements/Divider - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Elements/Divider") ?? throw new System.InvalidOperationException("Could not find an element named Elements/Divider - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new Divider(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/Elements/DividerHorizontal.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/Elements/DividerHorizontal.Generated.cs
@@ -18,10 +18,7 @@ partial class DividerHorizontal : global::Gum.Forms.Controls.FrameworkElement
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Elements/DividerHorizontal");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Elements/DividerHorizontal - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Elements/DividerHorizontal") ?? throw new System.InvalidOperationException("Could not find an element named Elements/DividerHorizontal - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new DividerHorizontal(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/Elements/DividerVertical.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/Elements/DividerVertical.Generated.cs
@@ -18,10 +18,7 @@ partial class DividerVertical : global::Gum.Forms.Controls.FrameworkElement
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Elements/DividerVertical");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Elements/DividerVertical - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Elements/DividerVertical") ?? throw new System.InvalidOperationException("Could not find an element named Elements/DividerVertical - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new DividerVertical(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/Elements/Icon.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/Elements/Icon.Generated.cs
@@ -18,10 +18,7 @@ partial class Icon : global::Gum.Forms.Controls.FrameworkElement
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Elements/Icon");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Elements/Icon - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Elements/Icon") ?? throw new System.InvalidOperationException("Could not find an element named Elements/Icon - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new Icon(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/Elements/PercentBar.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/Elements/PercentBar.Generated.cs
@@ -18,10 +18,7 @@ partial class PercentBar : global::Gum.Forms.Controls.FrameworkElement
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Elements/PercentBar");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Elements/PercentBar - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Elements/PercentBar") ?? throw new System.InvalidOperationException("Could not find an element named Elements/PercentBar - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new PercentBar(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/Elements/PercentBarIcon.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/Elements/PercentBarIcon.Generated.cs
@@ -18,10 +18,7 @@ partial class PercentBarIcon : global::Gum.Forms.Controls.FrameworkElement
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Elements/PercentBarIcon");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Elements/PercentBarIcon - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Elements/PercentBarIcon") ?? throw new System.InvalidOperationException("Could not find an element named Elements/PercentBarIcon - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new PercentBarIcon(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/Elements/VerticalLines.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/Elements/VerticalLines.Generated.cs
@@ -17,10 +17,7 @@ partial class VerticalLines : global::Gum.Forms.Controls.FrameworkElement
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Elements/VerticalLines");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Elements/VerticalLines - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Elements/VerticalLines") ?? throw new System.InvalidOperationException("Could not find an element named Elements/VerticalLines - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new VerticalLines(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/LabelContainer.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/LabelContainer.Generated.cs
@@ -18,10 +18,7 @@ partial class LabelContainer : global::Gum.Forms.Controls.FrameworkElement
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("LabelContainer");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named LabelContainer - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("LabelContainer") ?? throw new System.InvalidOperationException("Could not find an element named LabelContainer - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new LabelContainer(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/NineSliceComponent.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/NineSliceComponent.Generated.cs
@@ -17,10 +17,7 @@ partial class NineSliceComponent : global::Gum.Forms.Controls.FrameworkElement
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("NineSliceComponent");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named NineSliceComponent - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("NineSliceComponent") ?? throw new System.InvalidOperationException("Could not find an element named NineSliceComponent - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new NineSliceComponent(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/Spaced_Component.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/Spaced_Component.Generated.cs
@@ -17,10 +17,7 @@ partial class Spaced_Component : global::Gum.Forms.Controls.FrameworkElement
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Spaced Component");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Spaced Component - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Spaced Component") ?? throw new System.InvalidOperationException("Could not find an element named Spaced Component - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new Spaced_Component(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/SpriteComponent.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/SpriteComponent.Generated.cs
@@ -17,10 +17,7 @@ partial class SpriteComponent : global::Gum.Forms.Controls.FrameworkElement
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("SpriteComponent");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named SpriteComponent - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("SpriteComponent") ?? throw new System.InvalidOperationException("Could not find an element named SpriteComponent - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new SpriteComponent(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/Styles.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/Styles.Generated.cs
@@ -17,10 +17,7 @@ partial class Styles : global::Gum.Forms.Controls.FrameworkElement
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Styles");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Styles - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Styles") ?? throw new System.InvalidOperationException("Could not find an element named Styles - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new Styles(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/TextComponent.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/TextComponent.Generated.cs
@@ -17,10 +17,7 @@ partial class TextComponent : global::Gum.Forms.Controls.FrameworkElement
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("TextComponent");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named TextComponent - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("TextComponent") ?? throw new System.InvalidOperationException("Could not find an element named TextComponent - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new TextComponent(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_ByReference/Components/_123Component.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Components/_123Component.Generated.cs
@@ -17,10 +17,7 @@ partial class _123Component : global::Gum.Forms.Controls.FrameworkElement
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("123Component");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named 123Component - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("123Component") ?? throw new System.InvalidOperationException("Could not find an element named 123Component - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new _123Component(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_ByReference/Screens/FormsScreenWithVariablesSet.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Screens/FormsScreenWithVariablesSet.Generated.cs
@@ -18,10 +18,7 @@ partial class FormsScreenWithVariablesSet : global::Gum.Forms.Controls.Framework
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("FormsScreenWithVariablesSet");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named FormsScreenWithVariablesSet - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("FormsScreenWithVariablesSet") ?? throw new System.InvalidOperationException("Could not find an element named FormsScreenWithVariablesSet - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new FormsScreenWithVariablesSet(visual);
             visual.Width = 0;

--- a/Tests/CodeGen_MonoGameForms_ByReference/Screens/GameScreenHud.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Screens/GameScreenHud.Generated.cs
@@ -18,10 +18,7 @@ partial class GameScreenHud : global::Gum.Forms.Controls.FrameworkElement
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("GameScreenHud");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named GameScreenHud - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("GameScreenHud") ?? throw new System.InvalidOperationException("Could not find an element named GameScreenHud - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new GameScreenHud(visual);
             visual.Width = 0;

--- a/Tests/CodeGen_MonoGameForms_ByReference/Screens/GeneralScreen.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Screens/GeneralScreen.Generated.cs
@@ -19,10 +19,7 @@ partial class GeneralScreen : global::Gum.Forms.Controls.FrameworkElement
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("GeneralScreen");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named GeneralScreen - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("GeneralScreen") ?? throw new System.InvalidOperationException("Could not find an element named GeneralScreen - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new GeneralScreen(visual);
             visual.Width = 0;

--- a/Tests/CodeGen_MonoGameForms_ByReference/Screens/Spaced_Screen.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/Screens/Spaced_Screen.Generated.cs
@@ -18,10 +18,7 @@ partial class Spaced_Screen : global::Gum.Forms.Controls.FrameworkElement
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Spaced Screen");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Spaced Screen - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Spaced Screen") ?? throw new System.InvalidOperationException("Could not find an element named Spaced Screen - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new Spaced_Screen(visual);
             visual.Width = 0;

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/@interface.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/@interface.Generated.cs
@@ -17,10 +17,7 @@ partial class @interface : global::Gum.Forms.Controls.FrameworkElement
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("interface");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named interface - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("interface") ?? throw new System.InvalidOperationException("Could not find an element named interface - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new @interface(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/ButtonClose.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/ButtonClose.Generated.cs
@@ -18,10 +18,7 @@ partial class ButtonClose : global::Gum.Forms.Controls.Button
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/ButtonClose");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/ButtonClose - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/ButtonClose") ?? throw new System.InvalidOperationException("Could not find an element named Controls/ButtonClose - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new ButtonClose(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/ButtonConfirm.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/ButtonConfirm.Generated.cs
@@ -17,10 +17,7 @@ partial class ButtonConfirm : global::Gum.Forms.Controls.Button
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/ButtonConfirm");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/ButtonConfirm - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/ButtonConfirm") ?? throw new System.InvalidOperationException("Could not find an element named Controls/ButtonConfirm - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new ButtonConfirm(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/ButtonDeny.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/ButtonDeny.Generated.cs
@@ -17,10 +17,7 @@ partial class ButtonDeny : global::Gum.Forms.Controls.Button
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/ButtonDeny");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/ButtonDeny - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/ButtonDeny") ?? throw new System.InvalidOperationException("Could not find an element named Controls/ButtonDeny - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new ButtonDeny(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/ButtonIcon.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/ButtonIcon.Generated.cs
@@ -18,10 +18,7 @@ partial class ButtonIcon : global::Gum.Forms.Controls.Button
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/ButtonIcon");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/ButtonIcon - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/ButtonIcon") ?? throw new System.InvalidOperationException("Could not find an element named Controls/ButtonIcon - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new ButtonIcon(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/ButtonStandard.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/ButtonStandard.Generated.cs
@@ -17,10 +17,7 @@ partial class ButtonStandard : global::Gum.Forms.Controls.Button
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/ButtonStandard");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/ButtonStandard - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/ButtonStandard") ?? throw new System.InvalidOperationException("Could not find an element named Controls/ButtonStandard - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new ButtonStandard(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/ButtonStandardIcon.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/ButtonStandardIcon.Generated.cs
@@ -18,10 +18,7 @@ partial class ButtonStandardIcon : global::Gum.Forms.Controls.Button
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/ButtonStandardIcon");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/ButtonStandardIcon - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/ButtonStandardIcon") ?? throw new System.InvalidOperationException("Could not find an element named Controls/ButtonStandardIcon - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new ButtonStandardIcon(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/ButtonTab.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/ButtonTab.Generated.cs
@@ -17,10 +17,7 @@ partial class ButtonTab : global::Gum.Forms.Controls.Button
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/ButtonTab");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/ButtonTab - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/ButtonTab") ?? throw new System.InvalidOperationException("Could not find an element named Controls/ButtonTab - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new ButtonTab(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/CheckBox.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/CheckBox.Generated.cs
@@ -18,10 +18,7 @@ partial class CheckBox : global::Gum.Forms.Controls.CheckBox
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/CheckBox");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/CheckBox - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/CheckBox") ?? throw new System.InvalidOperationException("Could not find an element named Controls/CheckBox - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new CheckBox(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/ComboBox.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/ComboBox.Generated.cs
@@ -19,10 +19,7 @@ partial class ComboBox : global::Gum.Forms.Controls.ComboBox
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/ComboBox");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/ComboBox - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/ComboBox") ?? throw new System.InvalidOperationException("Could not find an element named Controls/ComboBox - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new ComboBox(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/DialogBox.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/DialogBox.Generated.cs
@@ -18,10 +18,7 @@ partial class DialogBox : global::Gum.Forms.Controls.FrameworkElement
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/DialogBox");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/DialogBox - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/DialogBox") ?? throw new System.InvalidOperationException("Could not find an element named Controls/DialogBox - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new DialogBox(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/InputDeviceSelectionItem.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/InputDeviceSelectionItem.Generated.cs
@@ -19,10 +19,7 @@ partial class InputDeviceSelectionItem : global::Gum.Forms.Controls.FrameworkEle
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/InputDeviceSelectionItem");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/InputDeviceSelectionItem - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/InputDeviceSelectionItem") ?? throw new System.InvalidOperationException("Could not find an element named Controls/InputDeviceSelectionItem - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new InputDeviceSelectionItem(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/InputDeviceSelector.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/InputDeviceSelector.Generated.cs
@@ -18,10 +18,7 @@ partial class InputDeviceSelector : global::Gum.Forms.Controls.FrameworkElement
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/InputDeviceSelector");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/InputDeviceSelector - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/InputDeviceSelector") ?? throw new System.InvalidOperationException("Could not find an element named Controls/InputDeviceSelector - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new InputDeviceSelector(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/Keyboard.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/Keyboard.Generated.cs
@@ -20,10 +20,7 @@ partial class Keyboard : global::Gum.Forms.Controls.FrameworkElement
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/Keyboard");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/Keyboard - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/Keyboard") ?? throw new System.InvalidOperationException("Could not find an element named Controls/Keyboard - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new Keyboard(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/KeyboardKey.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/KeyboardKey.Generated.cs
@@ -18,10 +18,7 @@ partial class KeyboardKey : global::Gum.Forms.Controls.Button
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/KeyboardKey");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/KeyboardKey - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/KeyboardKey") ?? throw new System.InvalidOperationException("Could not find an element named Controls/KeyboardKey - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new KeyboardKey(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/Label.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/Label.Generated.cs
@@ -17,10 +17,7 @@ partial class Label : global::Gum.Forms.Controls.Label
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.TextRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/Label");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/Label - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/Label") ?? throw new System.InvalidOperationException("Could not find an element named Controls/Label - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new Label(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/ListBox.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/ListBox.Generated.cs
@@ -18,10 +18,7 @@ partial class ListBox : global::Gum.Forms.Controls.ListBox
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/ListBox");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/ListBox - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/ListBox") ?? throw new System.InvalidOperationException("Could not find an element named Controls/ListBox - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new ListBox(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/ListBoxItem.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/ListBoxItem.Generated.cs
@@ -17,10 +17,7 @@ partial class ListBoxItem : global::Gum.Forms.Controls.ListBoxItem
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/ListBoxItem");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/ListBoxItem - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/ListBoxItem") ?? throw new System.InvalidOperationException("Could not find an element named Controls/ListBoxItem - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new ListBoxItem(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/Menu.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/Menu.Generated.cs
@@ -17,10 +17,7 @@ partial class Menu : global::Gum.Forms.Controls.Menu
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/Menu");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/Menu - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/Menu") ?? throw new System.InvalidOperationException("Could not find an element named Controls/Menu - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new Menu(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/MenuItem.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/MenuItem.Generated.cs
@@ -17,10 +17,7 @@ partial class MenuItem : global::Gum.Forms.Controls.MenuItem
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/MenuItem");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/MenuItem - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/MenuItem") ?? throw new System.InvalidOperationException("Could not find an element named Controls/MenuItem - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new MenuItem(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/Panel.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/Panel.Generated.cs
@@ -17,10 +17,7 @@ partial class Panel : global::Gum.Forms.Controls.Panel
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/Panel");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/Panel - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/Panel") ?? throw new System.InvalidOperationException("Could not find an element named Controls/Panel - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new Panel(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/PasswordBox.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/PasswordBox.Generated.cs
@@ -17,10 +17,7 @@ partial class PasswordBox : global::Gum.Forms.Controls.PasswordBox
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/PasswordBox");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/PasswordBox - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/PasswordBox") ?? throw new System.InvalidOperationException("Could not find an element named Controls/PasswordBox - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new PasswordBox(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/PlayerJoinView.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/PlayerJoinView.Generated.cs
@@ -18,10 +18,7 @@ partial class PlayerJoinView : global::Gum.Forms.Controls.FrameworkElement
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/PlayerJoinView");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/PlayerJoinView - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/PlayerJoinView") ?? throw new System.InvalidOperationException("Could not find an element named Controls/PlayerJoinView - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new PlayerJoinView(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/PlayerJoinViewItem.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/PlayerJoinViewItem.Generated.cs
@@ -18,10 +18,7 @@ partial class PlayerJoinViewItem : global::Gum.Forms.Controls.FrameworkElement
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/PlayerJoinViewItem");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/PlayerJoinViewItem - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/PlayerJoinViewItem") ?? throw new System.InvalidOperationException("Could not find an element named Controls/PlayerJoinViewItem - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new PlayerJoinViewItem(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/RadioButton.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/RadioButton.Generated.cs
@@ -18,10 +18,7 @@ partial class RadioButton : global::Gum.Forms.Controls.RadioButton
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/RadioButton");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/RadioButton - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/RadioButton") ?? throw new System.InvalidOperationException("Could not find an element named Controls/RadioButton - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new RadioButton(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/ScrollBar.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/ScrollBar.Generated.cs
@@ -18,10 +18,7 @@ partial class ScrollBar : global::Gum.Forms.Controls.ScrollBar
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/ScrollBar");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/ScrollBar - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/ScrollBar") ?? throw new System.InvalidOperationException("Could not find an element named Controls/ScrollBar - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new ScrollBar(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/ScrollViewer.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/ScrollViewer.Generated.cs
@@ -18,10 +18,7 @@ partial class ScrollViewer : global::Gum.Forms.Controls.ScrollViewer
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/ScrollViewer");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/ScrollViewer - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/ScrollViewer") ?? throw new System.InvalidOperationException("Could not find an element named Controls/ScrollViewer - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new ScrollViewer(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/SettingsView.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/SettingsView.Generated.cs
@@ -18,10 +18,7 @@ partial class SettingsView : global::Gum.Forms.Controls.FrameworkElement
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/SettingsView");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/SettingsView - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/SettingsView") ?? throw new System.InvalidOperationException("Could not find an element named Controls/SettingsView - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new SettingsView(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/Slider.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/Slider.Generated.cs
@@ -18,10 +18,7 @@ partial class Slider : global::Gum.Forms.Controls.Slider
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/Slider");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/Slider - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/Slider") ?? throw new System.InvalidOperationException("Could not find an element named Controls/Slider - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new Slider(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/SplitterStandard.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/SplitterStandard.Generated.cs
@@ -17,10 +17,7 @@ partial class SplitterStandard : global::Gum.Forms.Controls.Splitter
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/SplitterStandard");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/SplitterStandard - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/SplitterStandard") ?? throw new System.InvalidOperationException("Could not find an element named Controls/SplitterStandard - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new SplitterStandard(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/StackPanel.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/StackPanel.Generated.cs
@@ -17,10 +17,7 @@ partial class StackPanel : global::Gum.Forms.Controls.StackPanel
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/StackPanel");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/StackPanel - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/StackPanel") ?? throw new System.InvalidOperationException("Could not find an element named Controls/StackPanel - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new StackPanel(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/TextBox.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/TextBox.Generated.cs
@@ -18,10 +18,7 @@ partial class TextBox : global::Gum.Forms.Controls.TextBox
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/TextBox");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/TextBox - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/TextBox") ?? throw new System.InvalidOperationException("Could not find an element named Controls/TextBox - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new TextBox(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/Toast.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/Toast.Generated.cs
@@ -17,10 +17,7 @@ partial class Toast : global::Gum.Forms.Controls.FrameworkElement
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/Toast");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/Toast - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/Toast") ?? throw new System.InvalidOperationException("Could not find an element named Controls/Toast - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new Toast(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/TreeView.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/TreeView.Generated.cs
@@ -18,10 +18,7 @@ partial class TreeView : global::Gum.Forms.Controls.FrameworkElement
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/TreeView");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/TreeView - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/TreeView") ?? throw new System.InvalidOperationException("Could not find an element named Controls/TreeView - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new TreeView(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/TreeViewItem.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/TreeViewItem.Generated.cs
@@ -18,10 +18,7 @@ partial class TreeViewItem : global::Gum.Forms.Controls.FrameworkElement
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/TreeViewItem");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/TreeViewItem - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/TreeViewItem") ?? throw new System.InvalidOperationException("Could not find an element named Controls/TreeViewItem - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new TreeViewItem(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/TreeViewToggle.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/TreeViewToggle.Generated.cs
@@ -19,10 +19,7 @@ partial class TreeViewToggle : global::Gum.Forms.Controls.FrameworkElement
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/TreeViewToggle");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/TreeViewToggle - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/TreeViewToggle") ?? throw new System.InvalidOperationException("Could not find an element named Controls/TreeViewToggle - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new TreeViewToggle(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/UserControl.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/UserControl.Generated.cs
@@ -17,10 +17,7 @@ partial class UserControl : global::Gum.Forms.Controls.FrameworkElement
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/UserControl");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/UserControl - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/UserControl") ?? throw new System.InvalidOperationException("Could not find an element named Controls/UserControl - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new UserControl(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/WindowStandard.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Controls/WindowStandard.Generated.cs
@@ -18,10 +18,7 @@ partial class WindowStandard : global::Gum.Forms.Window
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/WindowStandard");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/WindowStandard - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/WindowStandard") ?? throw new System.InvalidOperationException("Could not find an element named Controls/WindowStandard - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new WindowStandard(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Elements/CautionLines.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Elements/CautionLines.Generated.cs
@@ -17,10 +17,7 @@ partial class CautionLines : global::Gum.Forms.Controls.FrameworkElement
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Elements/CautionLines");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Elements/CautionLines - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Elements/CautionLines") ?? throw new System.InvalidOperationException("Could not find an element named Elements/CautionLines - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new CautionLines(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Elements/Divider.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Elements/Divider.Generated.cs
@@ -17,10 +17,7 @@ partial class Divider : global::Gum.Forms.Controls.FrameworkElement
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Elements/Divider");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Elements/Divider - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Elements/Divider") ?? throw new System.InvalidOperationException("Could not find an element named Elements/Divider - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new Divider(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Elements/DividerHorizontal.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Elements/DividerHorizontal.Generated.cs
@@ -18,10 +18,7 @@ partial class DividerHorizontal : global::Gum.Forms.Controls.FrameworkElement
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Elements/DividerHorizontal");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Elements/DividerHorizontal - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Elements/DividerHorizontal") ?? throw new System.InvalidOperationException("Could not find an element named Elements/DividerHorizontal - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new DividerHorizontal(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Elements/DividerVertical.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Elements/DividerVertical.Generated.cs
@@ -18,10 +18,7 @@ partial class DividerVertical : global::Gum.Forms.Controls.FrameworkElement
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Elements/DividerVertical");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Elements/DividerVertical - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Elements/DividerVertical") ?? throw new System.InvalidOperationException("Could not find an element named Elements/DividerVertical - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new DividerVertical(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Elements/Icon.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Elements/Icon.Generated.cs
@@ -18,10 +18,7 @@ partial class Icon : global::Gum.Forms.Controls.FrameworkElement
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Elements/Icon");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Elements/Icon - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Elements/Icon") ?? throw new System.InvalidOperationException("Could not find an element named Elements/Icon - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new Icon(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Elements/PercentBar.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Elements/PercentBar.Generated.cs
@@ -18,10 +18,7 @@ partial class PercentBar : global::Gum.Forms.Controls.FrameworkElement
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Elements/PercentBar");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Elements/PercentBar - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Elements/PercentBar") ?? throw new System.InvalidOperationException("Could not find an element named Elements/PercentBar - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new PercentBar(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Elements/PercentBarIcon.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Elements/PercentBarIcon.Generated.cs
@@ -18,10 +18,7 @@ partial class PercentBarIcon : global::Gum.Forms.Controls.FrameworkElement
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Elements/PercentBarIcon");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Elements/PercentBarIcon - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Elements/PercentBarIcon") ?? throw new System.InvalidOperationException("Could not find an element named Elements/PercentBarIcon - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new PercentBarIcon(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Elements/VerticalLines.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Elements/VerticalLines.Generated.cs
@@ -17,10 +17,7 @@ partial class VerticalLines : global::Gum.Forms.Controls.FrameworkElement
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Elements/VerticalLines");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Elements/VerticalLines - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Elements/VerticalLines") ?? throw new System.InvalidOperationException("Could not find an element named Elements/VerticalLines - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new VerticalLines(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/LegacyShapes.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/LegacyShapes.Generated.cs
@@ -17,10 +17,7 @@ partial class LegacyShapes : global::Gum.Forms.Controls.FrameworkElement
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("LegacyShapes");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named LegacyShapes - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("LegacyShapes") ?? throw new System.InvalidOperationException("Could not find an element named LegacyShapes - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new LegacyShapes(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Spaced_Component.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Spaced_Component.Generated.cs
@@ -17,10 +17,7 @@ partial class Spaced_Component : global::Gum.Forms.Controls.FrameworkElement
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Spaced Component");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Spaced Component - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Spaced Component") ?? throw new System.InvalidOperationException("Could not find an element named Spaced Component - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new Spaced_Component(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Styles.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/Styles.Generated.cs
@@ -17,10 +17,7 @@ partial class Styles : global::Gum.Forms.Controls.FrameworkElement
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Styles");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Styles - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Styles") ?? throw new System.InvalidOperationException("Could not find an element named Styles - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new Styles(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Components/_123Component.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Components/_123Component.Generated.cs
@@ -17,10 +17,7 @@ partial class _123Component : global::Gum.Forms.Controls.FrameworkElement
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("123Component");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named 123Component - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("123Component") ?? throw new System.InvalidOperationException("Could not find an element named 123Component - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new _123Component(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Screens/FormsScreen.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Screens/FormsScreen.Generated.cs
@@ -18,10 +18,7 @@ partial class FormsScreen : global::Gum.Forms.Controls.FrameworkElement
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("FormsScreen");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named FormsScreen - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("FormsScreen") ?? throw new System.InvalidOperationException("Could not find an element named FormsScreen - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new FormsScreen(visual);
             visual.Width = 0;

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/Screens/GeneralScreen.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/Screens/GeneralScreen.Generated.cs
@@ -18,10 +18,7 @@ partial class GeneralScreen : global::Gum.Forms.Controls.FrameworkElement
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("GeneralScreen");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named GeneralScreen - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("GeneralScreen") ?? throw new System.InvalidOperationException("Could not find an element named GeneralScreen - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new GeneralScreen(visual);
             visual.Width = 0;

--- a/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/ButtonClose.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/ButtonClose.Generated.cs
@@ -18,10 +18,7 @@ partial class ButtonClose : global::Gum.Forms.Controls.Button
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/ButtonClose");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/ButtonClose - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/ButtonClose") ?? throw new System.InvalidOperationException("Could not find an element named Controls/ButtonClose - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new ButtonClose(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/ButtonConfirm.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/ButtonConfirm.Generated.cs
@@ -17,10 +17,7 @@ partial class ButtonConfirm : global::Gum.Forms.Controls.Button
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/ButtonConfirm");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/ButtonConfirm - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/ButtonConfirm") ?? throw new System.InvalidOperationException("Could not find an element named Controls/ButtonConfirm - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new ButtonConfirm(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/ButtonDeny.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/ButtonDeny.Generated.cs
@@ -17,10 +17,7 @@ partial class ButtonDeny : global::Gum.Forms.Controls.Button
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/ButtonDeny");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/ButtonDeny - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/ButtonDeny") ?? throw new System.InvalidOperationException("Could not find an element named Controls/ButtonDeny - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new ButtonDeny(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/ButtonIcon.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/ButtonIcon.Generated.cs
@@ -18,10 +18,7 @@ partial class ButtonIcon : global::Gum.Forms.Controls.Button
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/ButtonIcon");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/ButtonIcon - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/ButtonIcon") ?? throw new System.InvalidOperationException("Could not find an element named Controls/ButtonIcon - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new ButtonIcon(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/ButtonStandard.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/ButtonStandard.Generated.cs
@@ -17,10 +17,7 @@ partial class ButtonStandard : global::Gum.Forms.Controls.Button
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/ButtonStandard");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/ButtonStandard - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/ButtonStandard") ?? throw new System.InvalidOperationException("Could not find an element named Controls/ButtonStandard - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new ButtonStandard(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/ButtonStandardIcon.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/ButtonStandardIcon.Generated.cs
@@ -18,10 +18,7 @@ partial class ButtonStandardIcon : global::Gum.Forms.Controls.Button
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/ButtonStandardIcon");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/ButtonStandardIcon - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/ButtonStandardIcon") ?? throw new System.InvalidOperationException("Could not find an element named Controls/ButtonStandardIcon - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new ButtonStandardIcon(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/ButtonTab.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/ButtonTab.Generated.cs
@@ -17,10 +17,7 @@ partial class ButtonTab : global::Gum.Forms.Controls.Button
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/ButtonTab");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/ButtonTab - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/ButtonTab") ?? throw new System.InvalidOperationException("Could not find an element named Controls/ButtonTab - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new ButtonTab(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/CheckBox.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/CheckBox.Generated.cs
@@ -18,10 +18,7 @@ partial class CheckBox : global::Gum.Forms.Controls.CheckBox
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/CheckBox");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/CheckBox - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/CheckBox") ?? throw new System.InvalidOperationException("Could not find an element named Controls/CheckBox - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new CheckBox(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/ComboBox.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/ComboBox.Generated.cs
@@ -19,10 +19,7 @@ partial class ComboBox : global::Gum.Forms.Controls.ComboBox
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/ComboBox");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/ComboBox - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/ComboBox") ?? throw new System.InvalidOperationException("Could not find an element named Controls/ComboBox - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new ComboBox(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/DialogBox.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/DialogBox.Generated.cs
@@ -18,10 +18,7 @@ partial class DialogBox : global::Gum.Forms.Controls.FrameworkElement
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/DialogBox");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/DialogBox - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/DialogBox") ?? throw new System.InvalidOperationException("Could not find an element named Controls/DialogBox - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new DialogBox(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/InputDeviceSelectionItem.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/InputDeviceSelectionItem.Generated.cs
@@ -19,10 +19,7 @@ partial class InputDeviceSelectionItem : global::Gum.Forms.Controls.FrameworkEle
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/InputDeviceSelectionItem");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/InputDeviceSelectionItem - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/InputDeviceSelectionItem") ?? throw new System.InvalidOperationException("Could not find an element named Controls/InputDeviceSelectionItem - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new InputDeviceSelectionItem(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/InputDeviceSelector.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/InputDeviceSelector.Generated.cs
@@ -18,10 +18,7 @@ partial class InputDeviceSelector : global::Gum.Forms.Controls.FrameworkElement
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/InputDeviceSelector");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/InputDeviceSelector - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/InputDeviceSelector") ?? throw new System.InvalidOperationException("Could not find an element named Controls/InputDeviceSelector - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new InputDeviceSelector(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/ItemsControl.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/ItemsControl.Generated.cs
@@ -19,10 +19,7 @@ partial class ItemsControl : global::Gum.Forms.Controls.ItemsControl
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/ItemsControl");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/ItemsControl - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/ItemsControl") ?? throw new System.InvalidOperationException("Could not find an element named Controls/ItemsControl - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new ItemsControl(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/Keyboard.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/Keyboard.Generated.cs
@@ -20,10 +20,7 @@ partial class Keyboard : global::Gum.Forms.Controls.FrameworkElement
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/Keyboard");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/Keyboard - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/Keyboard") ?? throw new System.InvalidOperationException("Could not find an element named Controls/Keyboard - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new Keyboard(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/KeyboardKey.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/KeyboardKey.Generated.cs
@@ -18,10 +18,7 @@ partial class KeyboardKey : global::Gum.Forms.Controls.Button
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/KeyboardKey");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/KeyboardKey - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/KeyboardKey") ?? throw new System.InvalidOperationException("Could not find an element named Controls/KeyboardKey - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new KeyboardKey(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/Label.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/Label.Generated.cs
@@ -17,10 +17,7 @@ partial class Label : global::Gum.Forms.Controls.Label
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.TextRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/Label");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/Label - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/Label") ?? throw new System.InvalidOperationException("Could not find an element named Controls/Label - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new Label(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/ListBox.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/ListBox.Generated.cs
@@ -18,10 +18,7 @@ partial class ListBox : global::Gum.Forms.Controls.ListBox
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/ListBox");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/ListBox - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/ListBox") ?? throw new System.InvalidOperationException("Could not find an element named Controls/ListBox - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new ListBox(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/ListBoxItem.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/ListBoxItem.Generated.cs
@@ -17,10 +17,7 @@ partial class ListBoxItem : global::Gum.Forms.Controls.ListBoxItem
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/ListBoxItem");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/ListBoxItem - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/ListBoxItem") ?? throw new System.InvalidOperationException("Could not find an element named Controls/ListBoxItem - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new ListBoxItem(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/Menu.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/Menu.Generated.cs
@@ -17,10 +17,7 @@ partial class Menu : global::Gum.Forms.Controls.Menu
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/Menu");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/Menu - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/Menu") ?? throw new System.InvalidOperationException("Could not find an element named Controls/Menu - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new Menu(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/MenuItem.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/MenuItem.Generated.cs
@@ -17,10 +17,7 @@ partial class MenuItem : global::Gum.Forms.Controls.MenuItem
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/MenuItem");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/MenuItem - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/MenuItem") ?? throw new System.InvalidOperationException("Could not find an element named Controls/MenuItem - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new MenuItem(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/Panel.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/Panel.Generated.cs
@@ -17,10 +17,7 @@ partial class Panel : global::Gum.Forms.Controls.Panel
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/Panel");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/Panel - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/Panel") ?? throw new System.InvalidOperationException("Could not find an element named Controls/Panel - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new Panel(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/PasswordBox.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/PasswordBox.Generated.cs
@@ -17,10 +17,7 @@ partial class PasswordBox : global::Gum.Forms.Controls.PasswordBox
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/PasswordBox");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/PasswordBox - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/PasswordBox") ?? throw new System.InvalidOperationException("Could not find an element named Controls/PasswordBox - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new PasswordBox(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/PlayerJoinView.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/PlayerJoinView.Generated.cs
@@ -18,10 +18,7 @@ partial class PlayerJoinView : global::Gum.Forms.Controls.FrameworkElement
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/PlayerJoinView");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/PlayerJoinView - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/PlayerJoinView") ?? throw new System.InvalidOperationException("Could not find an element named Controls/PlayerJoinView - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new PlayerJoinView(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/PlayerJoinViewItem.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/PlayerJoinViewItem.Generated.cs
@@ -18,10 +18,7 @@ partial class PlayerJoinViewItem : global::Gum.Forms.Controls.FrameworkElement
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/PlayerJoinViewItem");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/PlayerJoinViewItem - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/PlayerJoinViewItem") ?? throw new System.InvalidOperationException("Could not find an element named Controls/PlayerJoinViewItem - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new PlayerJoinViewItem(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/RadioButton.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/RadioButton.Generated.cs
@@ -18,10 +18,7 @@ partial class RadioButton : global::Gum.Forms.Controls.RadioButton
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/RadioButton");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/RadioButton - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/RadioButton") ?? throw new System.InvalidOperationException("Could not find an element named Controls/RadioButton - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new RadioButton(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/ScrollBar.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/ScrollBar.Generated.cs
@@ -18,10 +18,7 @@ partial class ScrollBar : global::Gum.Forms.Controls.ScrollBar
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/ScrollBar");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/ScrollBar - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/ScrollBar") ?? throw new System.InvalidOperationException("Could not find an element named Controls/ScrollBar - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new ScrollBar(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/ScrollViewer.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/ScrollViewer.Generated.cs
@@ -18,10 +18,7 @@ partial class ScrollViewer : global::Gum.Forms.Controls.ScrollViewer
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/ScrollViewer");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/ScrollViewer - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/ScrollViewer") ?? throw new System.InvalidOperationException("Could not find an element named Controls/ScrollViewer - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new ScrollViewer(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/SettingsView.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/SettingsView.Generated.cs
@@ -18,10 +18,7 @@ partial class SettingsView : global::Gum.Forms.Controls.FrameworkElement
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/SettingsView");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/SettingsView - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/SettingsView") ?? throw new System.InvalidOperationException("Could not find an element named Controls/SettingsView - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new SettingsView(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/Slider.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/Slider.Generated.cs
@@ -18,10 +18,7 @@ partial class Slider : global::Gum.Forms.Controls.Slider
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/Slider");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/Slider - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/Slider") ?? throw new System.InvalidOperationException("Could not find an element named Controls/Slider - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new Slider(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/SplitterStandard.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/SplitterStandard.Generated.cs
@@ -17,10 +17,7 @@ partial class SplitterStandard : global::Gum.Forms.Controls.Splitter
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/SplitterStandard");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/SplitterStandard - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/SplitterStandard") ?? throw new System.InvalidOperationException("Could not find an element named Controls/SplitterStandard - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new SplitterStandard(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/StackPanel.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/StackPanel.Generated.cs
@@ -17,10 +17,7 @@ partial class StackPanel : global::Gum.Forms.Controls.StackPanel
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/StackPanel");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/StackPanel - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/StackPanel") ?? throw new System.InvalidOperationException("Could not find an element named Controls/StackPanel - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new StackPanel(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/TextBox.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/TextBox.Generated.cs
@@ -18,10 +18,7 @@ partial class TextBox : global::Gum.Forms.Controls.TextBox
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/TextBox");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/TextBox - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/TextBox") ?? throw new System.InvalidOperationException("Could not find an element named Controls/TextBox - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new TextBox(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/Toast.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/Toast.Generated.cs
@@ -17,10 +17,7 @@ partial class Toast : global::Gum.Forms.Controls.FrameworkElement
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/Toast");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/Toast - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/Toast") ?? throw new System.InvalidOperationException("Could not find an element named Controls/Toast - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new Toast(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/TreeView.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/TreeView.Generated.cs
@@ -18,10 +18,7 @@ partial class TreeView : global::Gum.Forms.Controls.FrameworkElement
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/TreeView");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/TreeView - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/TreeView") ?? throw new System.InvalidOperationException("Could not find an element named Controls/TreeView - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new TreeView(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/TreeViewItem.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/TreeViewItem.Generated.cs
@@ -18,10 +18,7 @@ partial class TreeViewItem : global::Gum.Forms.Controls.FrameworkElement
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/TreeViewItem");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/TreeViewItem - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/TreeViewItem") ?? throw new System.InvalidOperationException("Could not find an element named Controls/TreeViewItem - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new TreeViewItem(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/TreeViewToggle.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/TreeViewToggle.Generated.cs
@@ -19,10 +19,7 @@ partial class TreeViewToggle : global::Gum.Forms.Controls.FrameworkElement
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/TreeViewToggle");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/TreeViewToggle - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/TreeViewToggle") ?? throw new System.InvalidOperationException("Could not find an element named Controls/TreeViewToggle - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new TreeViewToggle(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/UserControl.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/UserControl.Generated.cs
@@ -17,10 +17,7 @@ partial class UserControl : global::Gum.Forms.Controls.FrameworkElement
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/UserControl");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/UserControl - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/UserControl") ?? throw new System.InvalidOperationException("Could not find an element named Controls/UserControl - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new UserControl(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/Window.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Controls/Window.Generated.cs
@@ -19,10 +19,7 @@ partial class Window : global::Gum.Forms.Window
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Controls/Window");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Controls/Window - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Controls/Window") ?? throw new System.InvalidOperationException("Could not find an element named Controls/Window - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new Window(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Elements/CautionLines.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Elements/CautionLines.Generated.cs
@@ -17,10 +17,7 @@ partial class CautionLines : global::Gum.Forms.Controls.FrameworkElement
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Elements/CautionLines");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Elements/CautionLines - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Elements/CautionLines") ?? throw new System.InvalidOperationException("Could not find an element named Elements/CautionLines - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new CautionLines(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Elements/Divider.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Elements/Divider.Generated.cs
@@ -17,10 +17,7 @@ partial class Divider : global::Gum.Forms.Controls.FrameworkElement
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Elements/Divider");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Elements/Divider - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Elements/Divider") ?? throw new System.InvalidOperationException("Could not find an element named Elements/Divider - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new Divider(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Elements/DividerHorizontal.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Elements/DividerHorizontal.Generated.cs
@@ -18,10 +18,7 @@ partial class DividerHorizontal : global::Gum.Forms.Controls.FrameworkElement
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Elements/DividerHorizontal");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Elements/DividerHorizontal - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Elements/DividerHorizontal") ?? throw new System.InvalidOperationException("Could not find an element named Elements/DividerHorizontal - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new DividerHorizontal(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Elements/DividerVertical.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Elements/DividerVertical.Generated.cs
@@ -18,10 +18,7 @@ partial class DividerVertical : global::Gum.Forms.Controls.FrameworkElement
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Elements/DividerVertical");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Elements/DividerVertical - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Elements/DividerVertical") ?? throw new System.InvalidOperationException("Could not find an element named Elements/DividerVertical - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new DividerVertical(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Elements/Icon.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Elements/Icon.Generated.cs
@@ -18,10 +18,7 @@ partial class Icon : global::Gum.Forms.Controls.FrameworkElement
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Elements/Icon");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Elements/Icon - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Elements/Icon") ?? throw new System.InvalidOperationException("Could not find an element named Elements/Icon - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new Icon(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Elements/PercentBar.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Elements/PercentBar.Generated.cs
@@ -18,10 +18,7 @@ partial class PercentBar : global::Gum.Forms.Controls.FrameworkElement
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Elements/PercentBar");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Elements/PercentBar - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Elements/PercentBar") ?? throw new System.InvalidOperationException("Could not find an element named Elements/PercentBar - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new PercentBar(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Elements/PercentBarIcon.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Elements/PercentBarIcon.Generated.cs
@@ -18,10 +18,7 @@ partial class PercentBarIcon : global::Gum.Forms.Controls.FrameworkElement
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Elements/PercentBarIcon");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Elements/PercentBarIcon - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Elements/PercentBarIcon") ?? throw new System.InvalidOperationException("Could not find an element named Elements/PercentBarIcon - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new PercentBarIcon(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Elements/VerticalLines.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Elements/VerticalLines.Generated.cs
@@ -17,10 +17,7 @@ partial class VerticalLines : global::Gum.Forms.Controls.FrameworkElement
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Elements/VerticalLines");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Elements/VerticalLines - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Elements/VerticalLines") ?? throw new System.InvalidOperationException("Could not find an element named Elements/VerticalLines - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new VerticalLines(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Styles.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_Localization_ByReference/Components/Styles.Generated.cs
@@ -17,10 +17,7 @@ partial class Styles : global::Gum.Forms.Controls.FrameworkElement
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("Styles");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named Styles - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("Styles") ?? throw new System.InvalidOperationException("Could not find an element named Styles - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new Styles(visual);
             return visual;

--- a/Tests/CodeGen_MonoGameForms_Localization_ByReference/Screens/MainScreen.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_Localization_ByReference/Screens/MainScreen.Generated.cs
@@ -18,10 +18,7 @@ partial class MainScreen : global::Gum.Forms.Controls.FrameworkElement
         var template = new global::Gum.Forms.VisualTemplate((vm, createForms) =>
         {
             var visual = new global::Gum.GueDeriving.ContainerRuntime();
-            var element = ObjectFinder.Self.GetElementSave("MainScreen");
-#if DEBUG
-if(element == null) throw new System.InvalidOperationException("Could not find an element named MainScreen - did you forget to load a Gum project?");
-#endif
+            var element = ObjectFinder.Self.GetElementSave("MainScreen") ?? throw new System.InvalidOperationException("Could not find an element named MainScreen - did you forget to load a Gum project?");
             element.SetGraphicalUiElement(visual, RenderingLibrary.SystemManagers.Default);
             if(createForms) visual.FormsControlAsObject = new MainScreen(visual);
             visual.Width = 0;

--- a/Tests/Gum.ProjectServices.Tests/CodeGeneratorRegisterRuntimeTypeTests.cs
+++ b/Tests/Gum.ProjectServices.Tests/CodeGeneratorRegisterRuntimeTypeTests.cs
@@ -170,4 +170,30 @@ public class CodeGeneratorRegisterRuntimeTypeTests : BaseTestClass
             ObjectFinder.Self.GumProjectSave = null;
         }
     }
+
+    [Fact]
+    public void MissingElementNullCheck_IsEmittedUnconditionally()
+    {
+        // #3576: the null check on ObjectFinder.Self.GetElementSave(...) used to be wrapped in
+        // #if DEBUG, so a Release build hit an opaque NullReferenceException instead of the
+        // descriptive message. It must be emitted unconditionally.
+        GumProjectSave project = Project;
+        ComponentSave panel = CreateComponent("Panel", "Container");
+        project.Components.Add(panel);
+        ObjectFinder.Self.GumProjectSave = project;
+
+        try
+        {
+            string code = CreateCodeGenerator().GetGeneratedCodeForElement(
+                panel, elementSettings: null!, CreateForms());
+
+            code.ShouldNotContain("#if DEBUG");
+            code.ShouldContain(
+                "ObjectFinder.Self.GetElementSave(\"Panel\") ?? throw new System.InvalidOperationException(\"Could not find an element named Panel - did you forget to load a Gum project?\");");
+        }
+        finally
+        {
+            ObjectFinder.Self.GumProjectSave = null;
+        }
+    }
 }

--- a/Tools/Gum.ProjectServices/CodeGeneration/CodeGenerator.cs
+++ b/Tools/Gum.ProjectServices/CodeGeneration/CodeGenerator.cs
@@ -1662,11 +1662,7 @@ public class CodeGenerator
 
 
             builder.AppendLine(context.Tabs +
-                $"var element = ObjectFinder.Self.GetElementSave(\"{context.Element.Name}\");");
-
-            builder.AppendLine("#if DEBUG");
-            builder.AppendLine($"if(element == null) throw new System.InvalidOperationException(\"Could not find an element named {context.Element.Name} - did you forget to load a Gum project?\");");
-            builder.AppendLine("#endif");
+                $"var element = ObjectFinder.Self.GetElementSave(\"{context.Element.Name}\") ?? throw new System.InvalidOperationException(\"Could not find an element named {context.Element.Name} - did you forget to load a Gum project?\");");
 
 
             builder.AppendLine(context.Tabs +


### PR DESCRIPTION
## Summary
- The codegen-emitted null check on `ObjectFinder.Self.GetElementSave(...)` in `RegisterRuntimeType` was wrapped in `#if DEBUG`, so a Release build of a generated element hit an opaque `NullReferenceException` instead of the descriptive `InvalidOperationException`.
- Dropped the `#if DEBUG`/`#endif` entirely and switched to a null-coalescing throw, so the check always fires. It's a one-time cost in a static module initializer, not a hot path, so there's no perf case for gating it.
- Considered gating on `FULL_DIAGNOSTICS` (Gum's existing "strippable in Release_No_Diagnostics" symbol) instead of `DEBUG`, but that symbol is only ever defined in Gum's own runtime csprojs (`GumCommon`, `MonoGameGum`, `RaylibGum`, etc.) — this generated code compiles as part of the *user's own project*, which never defines that symbol, so gating on it there would make the check never fire for anyone.

## Test plan
- [x] Added a failing-first unit test (`CodeGeneratorRegisterRuntimeTypeTests.MissingElementNullCheck_IsEmittedUnconditionally`) asserting the generated code has no `#if DEBUG` and always throws.
- [x] `dotnet test Tests/Gum.ProjectServices.Tests/Gum.ProjectServices.Tests.csproj` — 358 passed, 2 skipped, 0 failed.
- Manual test: not needed — pure codegen text-emission change, proven by the unit test asserting exact generated output; no visual/runtime surface to exercise.

Closes #3576