### PR TITLE
Remove dead WinForms clipboard/CapsLock branches in Keyboard.cs

### DIFF
--- a/MonoGameGum/Input/Keyboard.cs
+++ b/MonoGameGum/Input/Keyboard.cs
@@ -298,34 +298,6 @@ public partial class Keyboard : IInputReceiverKeyboardMonoGame
             }
         }
 
-        #region Add Text if the user presses CTRL+V
-        if (
-            isCtrlPressed
-            && KeyPushed(Keys.V)
-            )
-        {
-
-#if !MONOGAME && !KNI && !FNA
-            bool isSTAThreadUsed =
-                System.Threading.Thread.CurrentThread.GetApartmentState() == System.Threading.ApartmentState.STA;
-
-#if FULL_DIAGNOSTICS
-            if (!isSTAThreadUsed)
-            {
-                throw new InvalidOperationException("Need to set [STAThread] on Main to support copy/paste");
-            }
-#endif
-
-            if (isSTAThreadUsed && System.Windows.Forms.Clipboard.ContainsText())
-            {
-                returnString += System.Windows.Forms.Clipboard.GetText();
-
-            }
-#endif
-
-        }
-        #endregion
-
         return returnString;
 #endif
     }
@@ -519,13 +491,6 @@ public partial class Keyboard : IInputReceiverKeyboardMonoGame
     private string KeyToStringAtCurrentState(int key)
     {
         bool isShiftDown = KeyDown(Keys.LeftShift) || KeyDown(Keys.RightShift);
-
-#if !MONOGAME && !KNI && !FNA
-        if (System.Windows.Forms.Control.IsKeyLocked(System.Windows.Forms.Keys.CapsLock))
-        {
-            isShiftDown = !isShiftDown;
-        }
-#endif
 
         #region If Shift is down, return a different key
         if (isShiftDown && IsKeyLetter((Keys)key))


### PR DESCRIPTION
## Summary
- `MonoGameGum/Input/Keyboard.cs` had two `#if !MONOGAME && !KNI && !FNA` blocks calling `System.Windows.Forms.Clipboard`/`System.Windows.Forms.Control.IsKeyLocked` — a WinForms API with no assembly reference in any csproj that compiles this file.
- Every project that compiles this exact file (`MonoGameGum.csproj` directly, `KniGum.csproj`/`FnaGum.csproj` via their `..\**\*.cs` sweep) defines `MONOGAME`, `KNI`, or `FNA`, so the guard was always false. Raylib and Sokol each ship a separate `Keyboard.cs` and never include this one.
- Confirmed provably unreachable, then deleted both dead branches. Verified with `dotnet build MonoGameGum.Tests/MonoGameGum.Tests.csproj` and `dotnet build MonoGameGum/KniGum/KniGum.csproj` — 0 errors in both.

## Test plan
- [x] `dotnet build MonoGameGum.Tests/MonoGameGum.Tests.csproj` — 0 errors
- [x] `dotnet build MonoGameGum/KniGum/KniGum.csproj` — 0 errors (covers the Gum tool's runtime, which uses KNI)
- Manual test: not needed — pure removal of code that was already unreachable on every compiling backend; no behavior change.

Closes #3568