### PR TITLE
Implement SkiaGum EmbeddedResourceContentLoader.TryLoadContent; remove dead members

### DIFF
--- a/Runtimes/SkiaGum/Content/EmbeddedResourceContentLoader.cs
+++ b/Runtimes/SkiaGum/Content/EmbeddedResourceContentLoader.cs
@@ -1,17 +1,11 @@
 ﻿using RenderingLibrary.Content;
 using SkiaSharp;
-using System;
 using SKSvg = Svg.Skia.SKSvg;
 
 namespace SkiaGum.Content
 {
     public class EmbeddedResourceContentLoader : IContentLoader
     {
-        public void AddDisposable(string contentName, IDisposable disposable)
-        {
-            throw new NotImplementedException();
-        }
-
         public T LoadContent<T>(string contentName)
         {
             if (typeof(T) == typeof(SKTypeface))
@@ -54,14 +48,17 @@ namespace SkiaGum.Content
             return SkiaResourceManager.GetTypeface(modifiedContentName);
         }
 
-        public T TryGetCachedDisposable<T>(string contentName)
-        {
-            throw new NotImplementedException();
-        }
-
+        /// <inheritdoc/>
         public T TryLoadContent<T>(string contentName)
         {
-            throw new NotImplementedException();
+            try
+            {
+                return LoadContent<T>(contentName);
+            }
+            catch
+            {
+                return default(T);
+            }
         }
     }
 }

--- a/Tests/SkiaGum.Tests/Content/EmbeddedResourceContentLoaderTests.cs
+++ b/Tests/SkiaGum.Tests/Content/EmbeddedResourceContentLoaderTests.cs
@@ -1,0 +1,77 @@
+using SkiaGum.Content;
+using SkiaSharp;
+using Shouldly;
+using System;
+using System.IO;
+using ToolsUtilities;
+using Xunit;
+
+namespace SkiaGum.Tests.Content;
+
+// #3567: TryLoadContent used to unconditionally throw NotImplementedException, breaking the
+// IContentLoader contract (TryXxx should never throw) and diverging from every other backend's
+// ContentLoader (MonoGame-family, Raylib, Sokol), which all implement it as a non-throwing
+// mirror of LoadContent.
+public class EmbeddedResourceContentLoaderTests
+{
+    [Fact]
+    public void TryLoadContent_WhenContentExists_ShouldReturnLoadedContent()
+    {
+        string tempRoot = Path.Combine(Path.GetTempPath(), "GumSkiaTryLoadTest_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempRoot);
+        string savedRelativeDirectory = FileManager.RelativeDirectory;
+
+        try
+        {
+            string absolutePath = Path.Combine(tempRoot, "try_load_pixel.png");
+            using (SKBitmap source = new SKBitmap(4, 5))
+            using (SKImage image = SKImage.FromBitmap(source))
+            using (SKData encoded = image.Encode(SKEncodedImageFormat.Png, 100))
+            using (FileStream fileStream = File.OpenWrite(absolutePath))
+            {
+                encoded.SaveTo(fileStream);
+            }
+
+            EmbeddedResourceContentLoader loader = new EmbeddedResourceContentLoader();
+
+            SKBitmap loaded = loader.TryLoadContent<SKBitmap>(absolutePath);
+
+            loaded.ShouldNotBeNull();
+            loaded.Width.ShouldBe(4);
+            loaded.Height.ShouldBe(5);
+        }
+        finally
+        {
+            FileManager.RelativeDirectory = savedRelativeDirectory;
+            if (Directory.Exists(tempRoot))
+            {
+                Directory.Delete(tempRoot, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public void TryLoadContent_WhenContentMissing_ShouldReturnDefaultWithoutThrowing()
+    {
+        string missingPath = Path.Combine(Path.GetTempPath(),
+            "GumSkiaTryLoadMissingTest_" + Guid.NewGuid().ToString("N"), "does_not_exist.png");
+
+        EmbeddedResourceContentLoader loader = new EmbeddedResourceContentLoader();
+
+        SKBitmap loaded = null;
+        Should.NotThrow(() => loaded = loader.TryLoadContent<SKBitmap>(missingPath));
+
+        loaded.ShouldBeNull();
+    }
+
+    [Fact]
+    public void TryLoadContent_ForUnsupportedType_ShouldReturnDefaultWithoutThrowing()
+    {
+        EmbeddedResourceContentLoader loader = new EmbeddedResourceContentLoader();
+
+        string loaded = "not-yet-overwritten";
+        Should.NotThrow(() => loaded = loader.TryLoadContent<string>("whatever.png"));
+
+        loaded.ShouldBeNull();
+    }
+}


### PR DESCRIPTION
## Summary
- `TryLoadContent<T>` on SkiaGum's `EmbeddedResourceContentLoader` unconditionally threw `NotImplementedException`, breaking `IContentLoader`'s documented "never throws, returns default" contract for the Try variant.
- Every other backend (MonoGame/KNI/FNA, Raylib, Sokol) implements `TryLoadContent` as a non-throwing wrapper around `LoadContent`. This brings SkiaGum to parity: `TryLoadContent` now delegates to `LoadContent` and catches any failure, returning `default(T)`.
- Removed `AddDisposable`/`TryGetCachedDisposable` — not part of `IContentLoader`, shadow `LoaderManager`'s real methods of the same name, and had zero call sites (confirmed via grep).

## Test plan
- [x] Added `Tests/SkiaGum.Tests/Content/EmbeddedResourceContentLoaderTests.cs` — 3 cases: successful load, missing-content swallowed (no throw), unsupported type returns default (no throw). Confirmed red (NotImplementedException) before the fix, green after.
- [x] Full `SkiaGum.Tests` suite green (201/201), no new compiler warnings.
- Manual test: not needed — this is an internal `IContentLoader` API with no prior call sites and no UI/visual surface; covered by unit tests + compilation.

Closes #3567