### PR TITLE
Close #if/#elif fallback landmines for a future third backend

### DIFF
--- a/MonoGameGum/GumService.cs
+++ b/MonoGameGum/GumService.cs
@@ -55,6 +55,11 @@ public class GumService : IGumService
             "GumService.Default.Initialize(Game) on the concrete GumService instead.");
 #elif RAYLIB
         Initialize(DefaultVisualsVersion.Newest);
+#else
+        throw new NotSupportedException(
+            $"{nameof(GumService)}.Initialize() has no implementation for this backend. " +
+            "A new backend must add an explicit XNALIKE/RAYLIB-style arm here rather than " +
+            "relying on this fallback.");
 #endif
     }
 
@@ -66,6 +71,11 @@ public class GumService : IGumService
             "GumService.Default.Initialize(Game, gumProjectFile) on the concrete GumService instead.");
 #elif RAYLIB
         Initialize(gumProjectFile);
+#else
+        throw new NotSupportedException(
+            $"{nameof(GumService)}.Initialize(string) has no implementation for this backend. " +
+            "A new backend must add an explicit XNALIKE/RAYLIB-style arm here rather than " +
+            "relying on this fallback.");
 #endif
     }
 
@@ -76,6 +86,9 @@ public class GumService : IGumService
     // legacy-named subclass shim so existing code typed against it keeps compiling (soft migration,
     // issue #3119). Because static members are inherited, Gum.GumService.Default and the legacy
     // namespace's GumService.Default are the same single declaration and the same singleton.
+    // This switch is intentionally left closed (no #else): a third backend must add its own
+    // #elif arm here, with its own back-compat shim subclass, rather than assume a missing
+    // #else is an oversight — there is no sensible default subclass to fall back to.
 #if XNALIKE
     /// <summary>
     /// Gets the default instance of the GumService class.

--- a/MonoGameGum/GumServiceCompat.cs
+++ b/MonoGameGum/GumServiceCompat.cs
@@ -16,6 +16,12 @@ using System;
 // NOTE for FRB1 maintainers: this file is intentionally NOT in GumCoreShared.projitems.
 // It shims Gum.GumService, which is also not FRB-shared.
 
+// This entire shim only makes sense for the two legacy namespaces below. A new backend
+// (e.g. a future Silk.NET backend) has no legacy MonoGameGum/RaylibGum namespace to shim,
+// so none of this file should compile for it — hence the wrapper rather than an #else
+// that would just relocate the "pick a default namespace" landmine here instead.
+#if XNALIKE || RAYLIB
+
 #if XNALIKE
 namespace MonoGameGum;
 #elif RAYLIB
@@ -69,3 +75,4 @@ public static class ElementSaveExtensionMethods
     public static GraphicalUiElement ToGraphicalUiElement(this ElementSave elementSave, SystemManagers? systemManagers = null) =>
         global::Gum.ElementSaveExtensionMethods.ToGraphicalUiElement(elementSave, systemManagers);
 }
+#endif

--- a/MonoGameGum/Input/CursorExtensions.cs
+++ b/MonoGameGum/Input/CursorExtensions.cs
@@ -13,14 +13,15 @@ using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading.Tasks;
 
-#if XNALIKE || RAYLIB
-// GumService lives in the Gum namespace (issue #3119). The alias dodges the
-// [Obsolete] legacy shim that unqualified lookup would otherwise find through
-// this file's enclosing MonoGameGum namespace in the XNALIKE build.
-using GumServiceType = Gum.GumService;
-#else
+#if SOKOL
 // Sokol keeps its own GumService (no Gum-namespace move there).
 using GumServiceType = SokolGum.GumService;
+#else
+// GumService lives in the Gum namespace (issue #3119). Any backend other than the
+// un-migrated Sokol uses it — including future backends by default. The alias also
+// dodges the [Obsolete] legacy shim that unqualified lookup would otherwise find
+// through this file's enclosing MonoGameGum namespace in the XNALIKE build.
+using GumServiceType = Gum.GumService;
 #endif
 
 #if XNALIKE

--- a/MonoGameGum/Renderables/RenderableCreator.cs
+++ b/MonoGameGum/Renderables/RenderableCreator.cs
@@ -1,4 +1,7 @@
-﻿using Gum.Wireframe;
+﻿#if MONOGAME || KNI || FNA
+#define XNALIKE
+#endif
+using Gum.Wireframe;
 using RenderingLibrary.Graphics;
 using RenderingLibrary;
 using System;
@@ -7,10 +10,10 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-#if RAYLIB || SOKOL
-namespace Gum.Renderables;
-#else
+#if XNALIKE
 namespace MonoGameGum.Renderables;
+#else
+namespace Gum.Renderables;
 #endif
 public static class RenderableCreator
 {


### PR DESCRIPTION
## Summary

Several closed `#if XNALIKE ... #elif RAYLIB ... #endif`-style preprocessor switches (no `#else`) are landmines for a future third backend (e.g. a planned Silk.NET backend, #2738) — they either fail to compile or silently do the wrong thing once a build defines neither XNALIKE nor RAYLIB nor SOKOL.

- `MonoGameGum/GumService.cs`: `IGumService.Initialize()` and `IGumService.Initialize(string)` are `void` methods — an undefined-symbol build previously compiled these to a **silent no-op**, not a compile failure (a factual correction to the issue, which framed this as a compile-failure case). Added an `#else` arm to each that throws `NotSupportedException`, making the gap loud and diagnosable. Left the `Default` property switch intentionally closed (compile-fail for an unhandled backend) and extended its existing comment to say a new backend must add its own `#elif` arm with its own back-compat shim subclass.
- `MonoGameGum/GumServiceCompat.cs`: wrapped the entire legacy-namespace shim (both the namespace switch and the classes below it) in `#if XNALIKE || RAYLIB` — a new backend has no legacy `MonoGameGum`/`RaylibGum` namespace to shim, so none of this file should compile for it.
- `MonoGameGum/Input/CursorExtensions.cs`: flipped which side is the special case for `GumServiceType` — SOKOL is the actual un-migrated outlier (confirmed linked into `SokolGum.csproj`), so it's now the explicit `#if SOKOL` branch, and everything else (XNALIKE, RAYLIB, and any future backend) defaults to the migrated `Gum.GumService`.
- `MonoGameGum/Renderables/RenderableCreator.cs`: added the standard local `XNALIKE` alias preamble and flipped the namespace switch so XNALIKE is the explicit legacy special-case (`MonoGameGum.Renderables`) and everything else (RAYLIB, SOKOL, future backends) gets the migrated `Gum.Renderables` namespace.

## Test plan

Preprocessor/conditional-compilation plumbing only — no observable behavior change on any currently-buildable target (MONOGAME/KNI/FNA/RAYLIB/SOKOL all still resolve to their prior behavior). Only an undefined-symbol build's behavior changes, and no such build target exists yet to write a test against. TDD skipped for this reason.

- [x] `dotnet build MonoGameGum.Tests/MonoGameGum.Tests.csproj` — 0 errors (covers GumCommon + native MonoGameGum, XNALIKE via MONOGAME)
- [x] `dotnet build Runtimes/RaylibGum/RaylibGum.csproj` — 0 errors (covers RAYLIB)
- [x] `dotnet build Runtimes/SokolGum/SokolGum.csproj` — 0 errors (covers SOKOL, relevant since edits 3 and 4 touch files linked into it). Note: an earlier verification pass in this PR reported 47 errors here, misdiagnosed as pre-existing/environmental — the actual cause was that this PR's git worktree had never run `git submodule update --init` for `Sokol.NET`, so the `Runtimes/Sokol/Sokol.csproj` wrapper's wildcard `Compile Include` matched zero files and every `Sokol`/`sapp_*`/`sg_*` reference failed to resolve. Once the submodule was initialized, SokolGum built clean with no source changes needed — confirming this PR does not regress the Sokol build.

Closes #3560
