### PR TITLE
Document why RenderingLibrary/Content/LoaderManager.cs is duplicated for FRB1

### DIFF
--- a/GumCommon/Content/LoaderManager.cs
+++ b/GumCommon/Content/LoaderManager.cs
@@ -5,11 +5,18 @@ using System.Linq;
 namespace RenderingLibrary.Content;
 
 /// <summary>
-/// SkiaGum implementation that owns the texture/content cache and the active
-/// <see cref="IContentLoader"/>. All SkiaGum asset loading flows through here: callers use
-/// <see cref="LoadContent{T}"/> / <see cref="TryLoadContent{T}"/>, which delegate to
+/// Owns the texture/content cache and the active <see cref="IContentLoader"/> shared by every
+/// GumCommon-based runtime (MonoGameGum, RaylibGum, SkiaGum, KniGum, FnaGum) and the Gum tool.
+/// Callers use <see cref="LoadContent{T}"/> / <see cref="TryLoadContent{T}"/>, which delegate to
 /// <see cref="ContentLoader"/>.
 /// </summary>
+/// <remarks>
+/// <c>RenderingLibrary/Content/LoaderManager.cs</c> is a deliberate duplicate of this file (same
+/// namespace/type name, never compiled together): it's compiled only via
+/// <c>GumCoreShared.projitems</c>, whose sole consumer is FRB1 (FlatRedBall). See that file's
+/// remarks and https://github.com/vchelaru/Gum/issues/3566 for why <see cref="CacheTextures"/>
+/// defaults differently there.
+/// </remarks>
 public class LoaderManager
 {
     #region Enums
@@ -67,11 +74,9 @@ public class LoaderManager
         set;
     }
 
-    // February 6, 2024
-    // Why is this false?
-    // Caching should be turned
-    // on by default...
-    //bool mCacheTextures = false;
+    // Defaults to true here (unlike the RenderingLibrary/Content/LoaderManager.cs duplicate, which
+    // defaults false): this class's consumers mostly ride the built-in ContentLoader, which checks
+    // this flag before consulting the cache. See issue #3566 for the full explanation.
     bool mCacheTextures = true;
     Dictionary<string, IDisposable> mCachedDisposables = new Dictionary<string, IDisposable>(StringComparer.OrdinalIgnoreCase);
 

--- a/RenderingLibrary/Content/LoaderManager.cs
+++ b/RenderingLibrary/Content/LoaderManager.cs
@@ -20,6 +20,15 @@ namespace RenderingLibrary.Content
     /// that is already in memory), assign your own loader to <see cref="ContentLoader"/>.
     /// The cache itself is a dictionary of <see cref="IDisposable"/> keyed by standardized file path;
     /// see <see cref="LoadContent{T}"/> for why the cache is populated by the loader rather than here.
+    /// <para>
+    /// This file is a deliberate duplicate of <c>GumCommon/Content/LoaderManager.cs</c> (same
+    /// namespace/type name, never compiled together). This copy is compiled only via
+    /// <c>GumCoreShared.projitems</c>, whose sole consumer is FRB1 (FlatRedBall) — several of its
+    /// solutions (FlatRedBall.Forms per-platform, GlueView, samples, tests) reference the legacy
+    /// <c>GumCore*</c> project family directly. It looks orphaned from a Gum-repo-only grep, but it
+    /// is not; do not delete without checking the FRB1 repo. See
+    /// https://github.com/vchelaru/Gum/issues/3566 for the full investigation.
+    /// </para>
     /// </remarks>
     public class LoaderManager
     {
@@ -41,6 +50,11 @@ namespace RenderingLibrary.Content
 
         #region Fields
 
+        // Intentionally false, unlike GumCommon's copy (true): FRB1 always replaces ContentLoader
+        // with its own ContentManagerWrapper (see FRBDK/Glue/GumPlugin/GumPlugin/Embedded/ContentManagerWrapper.cs
+        // in the FRB1 repo), which delegates to FlatRedBall's own ContentManager and never consults
+        // this class's cache. So this flag is moot in practice for FRB1 games; false is just the
+        // safer default for the brief window before that swap happens. See issue #3566.
         bool mCacheTextures = false;
 
         static LoaderManager mSelf;


### PR DESCRIPTION
## Summary
- Issue #3566 originally proposed deleting `RenderingLibrary/Content/LoaderManager.cs` as a dead duplicate. Investigation (see the issue comment) found it's actively compiled by FRB1 (FlatRedBall) via `GumCoreShared.projitems` across ~13 solutions, and the `mCacheTextures` default divergence from `GumCommon`'s copy is intentional, not drift — FRB1 always swaps in its own `ContentManagerWrapper`, which bypasses this class's cache entirely.
- This PR doesn't change behavior — it snapshots that investigation directly in the source (both `LoaderManager.cs` copies), with a pointer back to #3566 for the full explanation, so a future audit doesn't re-flag this as accidental drift.
- Boyscout: fixed the `GumCommon` copy's stale class doc comment, which wrongly said "SkiaGum implementation" / "All SkiaGum asset loading" even though this class is shared by every GumCommon-based runtime, not Skia-specific.

## Test plan
- Doc-only change (comments), no behavior/API change.
- `dotnet build MonoGameGum.Tests/MonoGameGum.Tests.csproj` — 0 errors, only pre-existing unrelated warnings.
- Manual test: not needed — comment-only, no runtime-observable behavior.

Closes #3566
