### PR TITLE
Support FRB2-style embedding: public Root setter, AttachManagersOnly, pluggable popup roots

### DIFF
--- a/GumRuntime/GraphicalUiElement.cs
+++ b/GumRuntime/GraphicalUiElement.cs
@@ -1688,6 +1688,21 @@ public partial class GraphicalUiElement : IRenderableIpso, IVisible, INotifyProp
 
     public static Func<IRenderable, IRenderable>? CloneRenderableFunction;
 
+    /// <summary>
+    /// Resolves the popup and modal root containers used when showing a popup (for example a
+    /// ComboBox or MenuItem dropdown), keyed off the element being shown. When null, callers
+    /// fall back to their own default global popup/modal roots. Override this to support
+    /// multiple popup/modal root pairs, for example one pair per camera/viewport in a host
+    /// that embeds several independent Gum viewports.
+    /// A resolved root only receives content — it is the caller's responsibility to also add
+    /// it to whatever list drives input dispatch (the same mechanism used for any other root),
+    /// to keep it sized (e.g. to its camera/viewport), and to keep it on top of its Layer.
+    /// Gum's own input loop only does this automatically for the global default popup/modal
+    /// roots, and its modal-exclusivity behavior (blocking input to everything else while a
+    /// modal is open) currently only applies to the global default modal root.
+    /// </summary>
+    public static Func<GraphicalUiElement, (InteractiveGue popup, InteractiveGue modal)>? ResolvePopupRoots;
+
 
     #endregion
 
@@ -5753,6 +5768,24 @@ public partial class GraphicalUiElement : IRenderableIpso, IVisible, INotifyProp
                 CustomAddChildren();
             }
         }
+    }
+
+    /// <summary>
+    /// Sets this instance's <see cref="Managers"/> so that <see cref="EffectiveManagers"/>
+    /// resolves for this element and its children, without registering any renderable with a
+    /// Layer — unlike <see cref="AddToManagers(ISystemManagers, Layer)"/>. Use this for
+    /// containers that are drawn through some other, external render pass rather than Gum's
+    /// own Renderer.Draw pipeline, but which still need EffectiveManagers-dependent behavior
+    /// (such as closing a ComboBox/MenuItem popup on an outside click) to work correctly.
+    /// Do not also call <see cref="AddToManagers(ISystemManagers, Layer)"/> on the same
+    /// instance afterward expecting it to now register for real Gum-driven drawing — its
+    /// "already added" guard treats <see cref="Managers"/> being non-null as sufficient, so
+    /// it will silently no-op.
+    /// </summary>
+    /// <param name="managers">The SystemManagers instance to resolve as this element's EffectiveManagers.</param>
+    public void AttachManagersOnly(ISystemManagers managers)
+    {
+        mManagers = managers;
     }
 
     private static void RecursivelyAddIManagedChildren(GraphicalUiElement gue)

--- a/MonoGameGum.Tests/Forms/ListBoxTests.cs
+++ b/MonoGameGum.Tests/Forms/ListBoxTests.cs
@@ -2283,4 +2283,49 @@ public class ListBoxTests : BaseTestClass
     }
 
     #endregion
+
+    #region ShowPopupListBox
+
+    [Fact]
+    public void ShowPopupListBox_UsesResolvePopupRootsOverride_WhenSet()
+    {
+        ContainerRuntime customPopupRoot = new();
+        customPopupRoot.AddToManagers(RenderingLibrary.SystemManagers.Default);
+        ContainerRuntime customModalRoot = new();
+        customModalRoot.AddToManagers(RenderingLibrary.SystemManagers.Default);
+
+        Gum.Wireframe.GraphicalUiElement.ResolvePopupRoots = _ => (customPopupRoot, customModalRoot);
+
+        try
+        {
+            ComboBox comboBox = new();
+            comboBox.AddToRoot();
+
+            comboBox.IsDropDownOpen = true;
+
+            customPopupRoot.Children.ShouldContain(comboBox.ListBox!.Visual);
+            Gum.GumService.Default.PopupRoot.Children.ShouldNotContain(comboBox.ListBox!.Visual);
+        }
+        finally
+        {
+            Gum.Wireframe.GraphicalUiElement.ResolvePopupRoots = null;
+            customPopupRoot.Children.Clear();
+            customPopupRoot.RemoveFromManagers();
+            customModalRoot.Children.Clear();
+            customModalRoot.RemoveFromManagers();
+        }
+    }
+
+    [Fact]
+    public void ShowPopupListBox_FallsBackToGlobalPopupRoot_WhenResolvePopupRootsIsNotSet()
+    {
+        ComboBox comboBox = new();
+        comboBox.AddToRoot();
+
+        comboBox.IsDropDownOpen = true;
+
+        Gum.GumService.Default.PopupRoot.Children.ShouldContain(comboBox.ListBox!.Visual);
+    }
+
+    #endregion
 }

--- a/MonoGameGum.Tests/Forms/RootTests.cs
+++ b/MonoGameGum.Tests/Forms/RootTests.cs
@@ -1,4 +1,7 @@
 ﻿using Gum.Forms.Controls;
+using Gum.GueDeriving;
+using Gum.Wireframe;
+using Shouldly;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -9,6 +12,63 @@ using Xunit;
 namespace MonoGameGum.Tests.Forms;
 public class RootTests : BaseTestClass
 {
+    [Fact]
+    public void Root_CanBeReassigned_AndIsUsedByAddToRoot()
+    {
+        InteractiveGue originalRoot = Gum.GumService.Default.Root;
+        ContainerRuntime customRoot = new();
+        customRoot.AddToManagers(RenderingLibrary.SystemManagers.Default);
+
+        try
+        {
+            Gum.GumService.Default.Root = customRoot;
+            Gum.GumService.Default.Root.ShouldBe(customRoot);
+
+            TextBox textBox = new();
+            textBox.AddToRoot();
+
+            customRoot.Children.ShouldContain(textBox.Visual);
+            originalRoot.Children.ShouldNotContain(textBox.Visual);
+        }
+        finally
+        {
+            Gum.GumService.Default.Root = originalRoot;
+            customRoot.Children.Clear();
+            customRoot.RemoveFromManagers();
+        }
+    }
+
+    [Fact]
+    public void Root_Reassigned_MovesFocusCleanupSubscriptionToNewRoot()
+    {
+        InteractiveGue originalRoot = Gum.GumService.Default.Root;
+        ContainerRuntime customRoot = new();
+        customRoot.AddToManagers(RenderingLibrary.SystemManagers.Default);
+
+        try
+        {
+            Gum.GumService.Default.Root = customRoot;
+
+            TextBox textBox = new();
+            textBox.AddToRoot();
+            textBox.IsFocused = true;
+
+            ((object?)InteractiveGue.CurrentInputReceiver).ShouldBe(textBox);
+
+            customRoot.Children.Clear();
+
+            InteractiveGue.CurrentInputReceiver.ShouldBeNull(
+                "because the focus-cleanup subscription must move to the reassigned root, or focus on a " +
+                "control removed from it would never clear");
+        }
+        finally
+        {
+            Gum.GumService.Default.Root = originalRoot;
+            customRoot.Children.Clear();
+            customRoot.RemoveFromManagers();
+        }
+    }
+
     [Fact]
     public void RemovingChildren_ShouldNotThrowException()
     {

--- a/MonoGameGum.Tests/Runtimes/AttachManagersOnlyTests.cs
+++ b/MonoGameGum.Tests/Runtimes/AttachManagersOnlyTests.cs
@@ -1,0 +1,59 @@
+using Gum.GueDeriving;
+using Gum.Wireframe;
+using RenderingLibrary;
+using RenderingLibrary.Graphics;
+using Shouldly;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace MonoGameGum.Tests.Runtimes;
+
+public class AttachManagersOnlyTests : BaseTestClass
+{
+    [Fact]
+    public void AttachManagersOnly_ResolvesEffectiveManagers_ButDoesNotRegisterRenderableForDrawing()
+    {
+        // AddRenderableToManagers is the hook that actually puts a renderable on a Layer
+        // (see CustomSetPropertyOnRenderable.AddRenderableToManagers -> SpriteManager.Add ->
+        // Layer.Add). Recording its calls lets us prove AttachManagersOnly never reaches it,
+        // while AddToManagers still does.
+        Action<IRenderableIpso, ISystemManagers, Layer>? originalHook = GraphicalUiElement.AddRenderableToManagers;
+        List<object> registeredRenderables = new();
+        GraphicalUiElement.AddRenderableToManagers = (renderable, managers, layer) => registeredRenderables.Add(renderable);
+
+        try
+        {
+            SpriteRuntime attachOnlySprite = new();
+            attachOnlySprite.AttachManagersOnly(SystemManagers.Default);
+
+            SpriteRuntime addedSprite = new();
+            addedSprite.AddToManagers(SystemManagers.Default);
+
+            attachOnlySprite.EffectiveManagers.ShouldBe(SystemManagers.Default);
+
+            registeredRenderables.ShouldNotContain(attachOnlySprite.RenderableComponent,
+                "because AttachManagersOnly must not register the renderable, or Renderer.Draw would double-draw it " +
+                "in hosts (like FlatRedBall2) that draw this element themselves through their own render pass.");
+            registeredRenderables.ShouldContain(addedSprite.RenderableComponent,
+                "because AddToManagers should still register the renderable, confirming the assertion above is a " +
+                "real difference and not an artifact of the test environment.");
+        }
+        finally
+        {
+            GraphicalUiElement.AddRenderableToManagers = originalHook;
+        }
+    }
+
+    [Fact]
+    public void AttachManagersOnly_OnAContainer_LetsChildrenResolveEffectiveManagers()
+    {
+        ContainerRuntime container = new();
+        SpriteRuntime child = new();
+        child.Parent = container;
+
+        container.AttachManagersOnly(SystemManagers.Default);
+
+        child.EffectiveManagers.ShouldBe(SystemManagers.Default);
+    }
+}

--- a/MonoGameGum/Forms/Controls/ListBox.cs
+++ b/MonoGameGum/Forms/Controls/ListBox.cs
@@ -1628,13 +1628,16 @@ public class ListBox : ItemsControl, IInputReceiver
 #else
         popup.RepositionToKeepInScreen();
 
-        if (listBoxParent.GetTopParent() == FrameworkElement.ModalRoot)
+        var (popupRoot, modalRoot) = GraphicalUiElement.ResolvePopupRoots?.Invoke(listBoxParent)
+            ?? (FrameworkElement.PopupRoot, FrameworkElement.ModalRoot);
+
+        if (listBoxParent.GetTopParent() == modalRoot)
         {
-            FrameworkElement.ModalRoot.Children.Add(popup.Visual);
+            modalRoot.Children.Add(popup.Visual);
         }
         else
         {
-            FrameworkElement.PopupRoot.Children.Add(popup.Visual);
+            popupRoot.Children.Add(popup.Visual);
         }
 
 #endif

--- a/MonoGameGum/GumService.cs
+++ b/MonoGameGum/GumService.cs
@@ -13,6 +13,7 @@ using RenderingLibrary.Content;
 using RenderingLibrary.Graphics;
 using System;
 using System.Collections.Generic;
+using System.Collections.Specialized;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -326,7 +327,41 @@ public class GumService : IGumService
 
     public ContentLoader? ContentLoader => LoaderManager.Self.ContentLoader as ContentLoader;
 
-    public InteractiveGue Root { get; private set; } = new ContainerRuntime();
+    InteractiveGue _root = null!;
+    /// <summary>
+    /// The root container that owns top-level elements added via <c>AddToRoot</c>. Can be
+    /// reassigned to a custom container (for example, one an embedding host already draws
+    /// through its own render pass) so that <c>AddToRoot</c> and the host's own root become
+    /// the same object. Reassigning moves the focus-cleanup subscription (see
+    /// <see cref="Gum.Forms.FormsUtilities.HandleRootCollectionChanged"/>) from the old root
+    /// onto the new one. Like <see cref="Gum.Forms.Controls.FrameworkElement.PopupRoot"/> and
+    /// <see cref="Gum.Forms.Controls.FrameworkElement.ModalRoot"/>, a reassigned Root is still
+    /// cleared and detached from its SystemManagers by <see cref="Uninitialize"/> — a host that
+    /// reassigns this should not call Uninitialize while still using its own container.
+    /// </summary>
+    public InteractiveGue Root
+    {
+        get => _root;
+        set
+        {
+            if (_root == value)
+            {
+                return;
+            }
+
+            if (_root != null)
+            {
+                _root.Children.CollectionChanged -= HandleRootChildrenCollectionChanged;
+            }
+
+            _root = value;
+            _root.Children.CollectionChanged += HandleRootChildrenCollectionChanged;
+        }
+    }
+
+    void HandleRootChildrenCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e) =>
+        Gum.Forms.FormsUtilities.HandleRootCollectionChanged(Root, e);
+
     /// <inheritdoc/>
     public InteractiveGue PopupRoot => FrameworkElement.PopupRoot;
     /// <inheritdoc/>
@@ -747,14 +782,13 @@ public class GumService : IGumService
     /// </summary>
     public GumService()
     {
+        Root = new ContainerRuntime();
         Root.Width = 0;
         Root.WidthUnits = DimensionUnitType.RelativeToParent;
         Root.Height = 0;
         Root.HeightUnits = DimensionUnitType.RelativeToParent;
         Root.Name = "Main Root";
         Root.HasEvents = false;
-
-        Root.Children.CollectionChanged += (o, e) => Gum.Forms.FormsUtilities.HandleRootCollectionChanged(Root, e);
 
         CustomSetPropertyOnRenderable.LocalizationServiceChanged += HandleLocalizationServiceChanged;
         // Pick up any LocalizationService that was assigned before this GumService was constructed.

--- a/MonoGameGum/GumService.cs
+++ b/MonoGameGum/GumService.cs
@@ -328,16 +328,17 @@ public class GumService : IGumService
     public ContentLoader? ContentLoader => LoaderManager.Self.ContentLoader as ContentLoader;
 
     InteractiveGue _root = null!;
+    bool _rootOwnedByGumService;
     /// <summary>
     /// The root container that owns top-level elements added via <c>AddToRoot</c>. Can be
     /// reassigned to a custom container (for example, one an embedding host already draws
     /// through its own render pass) so that <c>AddToRoot</c> and the host's own root become
     /// the same object. Reassigning moves the focus-cleanup subscription (see
     /// <see cref="Gum.Forms.FormsUtilities.HandleRootCollectionChanged"/>) from the old root
-    /// onto the new one. Like <see cref="Gum.Forms.Controls.FrameworkElement.PopupRoot"/> and
-    /// <see cref="Gum.Forms.Controls.FrameworkElement.ModalRoot"/>, a reassigned Root is still
-    /// cleared and detached from its SystemManagers by <see cref="Uninitialize"/> — a host that
-    /// reassigns this should not call Uninitialize while still using its own container.
+    /// onto the new one. Unlike <see cref="Gum.Forms.Controls.FrameworkElement.PopupRoot"/> and
+    /// <see cref="Gum.Forms.Controls.FrameworkElement.ModalRoot"/>, <see cref="Uninitialize"/>
+    /// does not clear or detach a reassigned Root — it only tears down the default Root that
+    /// GumService itself created, since a host-supplied Root is the host's own object.
     /// </summary>
     public InteractiveGue Root
     {
@@ -355,6 +356,7 @@ public class GumService : IGumService
             }
 
             _root = value;
+            _rootOwnedByGumService = false;
             _root.Children.CollectionChanged += HandleRootChildrenCollectionChanged;
         }
     }
@@ -783,6 +785,7 @@ public class GumService : IGumService
     public GumService()
     {
         Root = new ContainerRuntime();
+        _rootOwnedByGumService = true;
         Root.Width = 0;
         Root.WidthUnits = DimensionUnitType.RelativeToParent;
         Root.Height = 0;
@@ -1344,8 +1347,15 @@ public class GumService : IGumService
 
         InteractiveGue.CurrentInputReceiver = null;
 
-        Root.Children.Clear();
-        Root.RemoveFromManagers();
+        // Only tear down Root if GumService itself created it. A reassigned Root
+        // (see the Root property doc) is the host's own object — clearing its
+        // children or detaching its Managers would silently corrupt state the host
+        // still owns and expects to keep using.
+        if (_rootOwnedByGumService)
+        {
+            Root.Children.Clear();
+            Root.RemoveFromManagers();
+        }
 
         if (FrameworkElement.PopupRoot != null)
         {

--- a/Tests/MonoGameGum.IntegrationTests/MonoGameGum/UninitializeTests.cs
+++ b/Tests/MonoGameGum.IntegrationTests/MonoGameGum/UninitializeTests.cs
@@ -97,6 +97,30 @@ public class UninitializeTests : BaseTestClass
     }
 
     [Fact]
+    public void Uninitialize_DoesNotClearOrDetachAReassignedHostRoot()
+    {
+        using var game = new GameForUninitializeTest();
+        game.RunOneFrame();
+
+        // Mirrors how an embedding host (e.g. FlatRedBall2) reassigns Root to its own
+        // container, attached via AttachManagersOnly rather than AddToManagers since the
+        // host draws it through its own render pass.
+        var hostRoot = new ContainerRuntime();
+        hostRoot.AttachManagersOnly(game.GumService.SystemManagers);
+        var hostChild = new ContainerRuntime();
+        hostRoot.Children.Add(hostChild);
+
+        game.GumService.Root = hostRoot;
+
+        game.GumService.Uninitialize();
+
+        hostRoot.Children.ShouldContain(hostChild,
+            "because Uninitialize must not clear a host-reassigned Root's own children");
+        hostRoot.Managers.ShouldNotBeNull(
+            "because Uninitialize must not detach a host-reassigned Root's EffectiveManagers resolution");
+    }
+
+    [Fact]
     public void Uninitialize_ClearsRenderableRegistry()
     {
         using GameForUninitializeTest game = new GameForUninitializeTest();


### PR DESCRIPTION
## Summary
Adds the three additive APIs FlatRedBall2 needs to embed Gum without using Gum's own render loop (see #3581):

1. **`GumService.Root` gets a public setter.** Hosts can now point it at their own container so `AddToRoot()` and the host's own overlay API operate on the same object. No default-path behavior change.
2. **`GraphicalUiElement.AttachManagersOnly(ISystemManagers)`.** Sets `Managers` so `EffectiveManagers` resolves (fixing the `ComboBox`/`MenuItem` popup-never-closes bug once a host uses it) without registering any renderable with a Layer, so a host that draws that container itself never gets a double-draw. Pinned by a test that intercepts `GraphicalUiElement.AddRenderableToManagers` and proves it's never invoked for an attach-only element (but is for a normal `AddToManagers` element).
3. **`GraphicalUiElement.ResolvePopupRoots` hook.** `ListBox.ShowPopupListBox` now calls this (if set) instead of hardcoding `FrameworkElement.PopupRoot`/`ModalRoot`, so a host can resolve a different popup/modal root pair per camera/viewport. Default behavior (hook unset) is unchanged — pinned by a fallback test.

Also fixes two bugs a multi-agent code review found in the new `Root` reassignment capability itself:

- **Stale focus-cleanup subscription.** The `Children.CollectionChanged` handler that clears keyboard focus when a focused control is removed was subscribed once, in the constructor, to the *original* default `Root`. Reassigning `Root` left that subscription pointing at the abandoned object, so removing a focused control from a reassigned root would leave `CurrentInputReceiver` stale. `Root`'s setter now moves the subscription to whichever object is current.
- **`Uninitialize()` was still clearing/detaching a reassigned `Root`.** `Uninitialize()` discards the whole `GumService` singleton (`_default = null`), so the old unconditional `Root.Children.Clear()`/`RemoveFromManagers()` existed only to tear down whatever `Root` currently was before the instance was thrown away. For a host-reassigned `Root` — the host's own long-lived container — that's destructive: clearing children wipes the host's UI tree, and `RemoveFromManagers()` nulls `Managers`, silently breaking `EffectiveManagers` resolution tree-wide (the exact failure mode `AttachManagersOnly` exists to fix). `GumService` now tracks whether it constructed `Root` itself and only tears down that one.

## Deliberately out of scope (per the issue) — tracked in #3585
`FormsUtilities.Update`'s modal/popup input-dispatch special-casing (z-order raise, canvas sizing, and modal exclusivity) is still hardcoded to the two global default roots — a custom `ResolvePopupRoots` root gets input dispatch once the host adds it to their own generic root list (same mechanism `roots` already uses), but not the automatic sizing/z-order/exclusivity behavior. This is the gap #3581 explicitly flagged as "known, do not try to solve it here" (item 4). Documented on `ResolvePopupRoots`'s XML doc, and filed as #3585 so it stays tracked once #3581 auto-closes with this PR.

## Test plan
- [x] New unit tests: `RootTests` (reassignment routes `AddToRoot`, focus-cleanup subscription follows reassignment), `AttachManagersOnlyTests` (EffectiveManagers resolves, renderable never registered vs. `AddToManagers` which does, children resolve through the parent chain), `ListBoxTests` (`ResolvePopupRoots` override routes popups, default behavior unchanged when unset), `UninitializeTests` (a reassigned `Root`'s children and `Managers` survive `Uninitialize()`; the pre-existing default-`Root`-is-still-cleared test still passes)
- [x] Full `MonoGameGum.Tests` suite green (1829/1829), `MonoGameGum.Tests.V2` green (120/120), `MonoGameGum.IntegrationTests` green (62/62), `RaylibGum.Tests` green (462/462)
- [x] `RaylibGum`, `SkiaGum`, `KniGum` build clean
- [x] FRB1 canary build (`GumCore.DesktopGlNet6`, `FlatRedBall.Forms.DesktopGlNet6`) clean against this diff applied to `main`
- [x] Manual test: not needed — this is pure new API surface for an external consumer (FRB2, a separate repo); no built-in Gum control or sample exercises it, and default behavior (nobody calling the new APIs) is pinned unchanged by the unit tests above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
