### PR TITLE
Extend FormsUtilities.Update's modal/popup handling to AdditionalPopupRootPairs

### DIFF
--- a/GumRuntime/GraphicalUiElement.cs
+++ b/GumRuntime/GraphicalUiElement.cs
@@ -1695,11 +1695,12 @@ public partial class GraphicalUiElement : IRenderableIpso, IVisible, INotifyProp
     /// multiple popup/modal root pairs, for example one pair per camera/viewport in a host
     /// that embeds several independent Gum viewports.
     /// A resolved root only receives content — it is the caller's responsibility to also add
-    /// it to whatever list drives input dispatch (the same mechanism used for any other root),
-    /// to keep it sized (e.g. to its camera/viewport), and to keep it on top of its Layer.
-    /// Gum's own input loop only does this automatically for the global default popup/modal
-    /// roots, and its modal-exclusivity behavior (blocking input to everything else while a
-    /// modal is open) currently only applies to the global default modal root.
+    /// it to whatever list drives input dispatch (the same mechanism used for any other root).
+    /// To also opt into Gum's automatic z-order raising, canvas sizing, and modal-exclusivity
+    /// handling for a resolved pair (the behavior Gum's input loop otherwise only applies to the
+    /// global default popup/modal roots), register the pair in
+    /// FrameworkElement.AdditionalPopupRootPairs — see that property's docs for the canvas-sizing
+    /// tradeoff a per-camera root should consider before opting in.
     /// </summary>
     public static Func<GraphicalUiElement, (InteractiveGue popup, InteractiveGue modal)>? ResolvePopupRoots;
 

--- a/MonoGameGum.Tests/BaseTestClass.cs
+++ b/MonoGameGum.Tests/BaseTestClass.cs
@@ -83,6 +83,7 @@ public class BaseTestClass : IDisposable
         GumService.Default.Root.Children!.Clear();
         GumService.Default.ModalRoot.Children!.Clear();
         GumService.Default.PopupRoot.Children!.Clear();
+        FrameworkElement.AdditionalPopupRootPairs.Clear();
 
         CustomSetPropertyOnRenderable.LocalizationService = null;
 

--- a/MonoGameGum.Tests/Forms/FormsUtilitiesPopupRootPairsTests.cs
+++ b/MonoGameGum.Tests/Forms/FormsUtilitiesPopupRootPairsTests.cs
@@ -1,0 +1,118 @@
+using Gum.Forms;
+using Gum.Forms.Controls;
+using Gum.GueDeriving;
+using Gum.Wireframe;
+using RenderingLibrary;
+using Shouldly;
+using Xunit;
+
+namespace MonoGameGum.Tests.Forms;
+
+// Covers issue #3585: FormsUtilities.Update's modal/popup special-casing extended to FrameworkElement.AdditionalPopupRootPairs.
+public class FormsUtilitiesPopupRootPairsTests : BaseTestClass
+{
+    [Fact]
+    public void Update_ModalExclusivity_AppliesToAdditionalModalRoot()
+    {
+        ContainerRuntime customPopupRoot = new();
+        ContainerRuntime customModalRoot = new();
+        customPopupRoot.AddToManagers(SystemManagers.Default);
+        customModalRoot.AddToManagers(SystemManagers.Default);
+        FrameworkElement.AdditionalPopupRootPairs.Add((customPopupRoot, customModalRoot));
+
+        Button modalChild = new();
+        customModalRoot.Children.Add(modalChild.Visual);
+
+        Button normalRootChild = new();
+        normalRootChild.AddToRoot();
+
+        customModalRoot.X = 999;
+        customModalRoot.Width = 1;
+
+        GumService.Default.Update(new Microsoft.Xna.Framework.GameTime());
+
+        customModalRoot.X.ShouldBe(0);
+        customModalRoot.Width.ShouldBe(GraphicalUiElement.CanvasWidth);
+
+        // Only the additional modal root's own content should be dispatched to — everything
+        // else, including the normal root's content, is excluded while it has children.
+        FormsUtilities.LastEventRoots.ShouldContain(modalChild.Visual);
+        FormsUtilities.LastEventRoots.ShouldNotContain(normalRootChild.Visual);
+    }
+
+    [Fact]
+    public void Update_ModalExclusivity_FallsThroughToAdditionalModalRoot_WhenGlobalModalRootHasNoVisibleChildren()
+    {
+        ContainerRuntime customPopupRoot = new();
+        ContainerRuntime customModalRoot = new();
+        customPopupRoot.AddToManagers(SystemManagers.Default);
+        customModalRoot.AddToManagers(SystemManagers.Default);
+        FrameworkElement.AdditionalPopupRootPairs.Add((customPopupRoot, customModalRoot));
+
+        Button invisibleGlobalModalChild = new();
+        invisibleGlobalModalChild.Visual.Visible = false;
+        FrameworkElement.ModalRoot.Children.Add(invisibleGlobalModalChild.Visual);
+
+        Button additionalModalChild = new();
+        customModalRoot.Children.Add(additionalModalChild.Visual);
+
+        Button normalRootChild = new();
+        normalRootChild.AddToRoot();
+
+        GumService.Default.Update(new Microsoft.Xna.Framework.GameTime());
+
+        // The global ModalRoot has children but none visible, so it isn't a candidate winner —
+        // exclusivity falls through to the additional modal root instead of to the normal root.
+        FormsUtilities.LastEventRoots.ShouldContain(additionalModalChild.Visual);
+        FormsUtilities.LastEventRoots.ShouldNotContain(normalRootChild.Visual);
+    }
+
+    [Fact]
+    public void Update_ModalExclusivity_GlobalModalRootWinsOverAdditionalModalRoot_WhenBothHaveChildren()
+    {
+        ContainerRuntime customPopupRoot = new();
+        ContainerRuntime customModalRoot = new();
+        customPopupRoot.AddToManagers(SystemManagers.Default);
+        customModalRoot.AddToManagers(SystemManagers.Default);
+        FrameworkElement.AdditionalPopupRootPairs.Add((customPopupRoot, customModalRoot));
+
+        Button additionalModalChild = new();
+        customModalRoot.Children.Add(additionalModalChild.Visual);
+
+        Button globalModalChild = new();
+        FrameworkElement.ModalRoot.Children.Add(globalModalChild.Visual);
+
+        GumService.Default.Update(new Microsoft.Xna.Framework.GameTime());
+
+        // The global ModalRoot is checked first, so it keeps input exclusivity over an additional
+        // modal root even when both have children in the same frame.
+        FormsUtilities.LastEventRoots.ShouldContain(globalModalChild.Visual);
+        FormsUtilities.LastEventRoots.ShouldNotContain(additionalModalChild.Visual);
+    }
+
+    [Fact]
+    public void Update_SizesToCanvas_ForAdditionalPopupRoot()
+    {
+        ContainerRuntime customPopupRoot = new();
+        ContainerRuntime customModalRoot = new();
+        customPopupRoot.AddToManagers(SystemManagers.Default);
+        customModalRoot.AddToManagers(SystemManagers.Default);
+        FrameworkElement.AdditionalPopupRootPairs.Add((customPopupRoot, customModalRoot));
+
+        Button popupChild = new();
+        customPopupRoot.Children.Add(popupChild.Visual);
+
+        customPopupRoot.X = 999;
+        customPopupRoot.Y = 999;
+        customPopupRoot.Width = 1;
+        customPopupRoot.Height = 1;
+
+        GumService.Default.Update(new Microsoft.Xna.Framework.GameTime());
+
+        customPopupRoot.X.ShouldBe(0);
+        customPopupRoot.Y.ShouldBe(0);
+        customPopupRoot.Width.ShouldBe(GraphicalUiElement.CanvasWidth);
+        customPopupRoot.Height.ShouldBe(GraphicalUiElement.CanvasHeight);
+        FormsUtilities.LastEventRoots.ShouldContain(popupChild.Visual);
+    }
+}

--- a/MonoGameGum/Forms/Controls/FrameworkElement.cs
+++ b/MonoGameGum/Forms/Controls/FrameworkElement.cs
@@ -133,6 +133,19 @@ public class FrameworkElement : INotifyPropertyChanged
     /// </summary>
     public static InteractiveGue ModalRoot { get; set; }
 
+    /// <summary>
+    /// Additional popup/modal root pairs, beyond the global <see cref="PopupRoot"/>/<see cref="ModalRoot"/>,
+    /// that should receive the same automatic z-order raising, canvas sizing, and modal-exclusivity
+    /// handling that FormsUtilities.Update gives the global roots. A host that resolves custom roots via
+    /// <see cref="GraphicalUiElement.ResolvePopupRoots"/> (for example, one root pair per camera/viewport)
+    /// should register that pair here to opt into this behavior.
+    /// Registering a pair here forces its size to the full canvas every frame (matching the global roots),
+    /// which is undesirable for a root that should instead track a specific camera/viewport. A host with
+    /// that requirement should not register the pair here, and should instead manage its root's z-order
+    /// and sizing itself while still adding its content to the list of roots passed into Update.
+    /// </summary>
+    public static List<(InteractiveGue popupRoot, InteractiveGue modalRoot)> AdditionalPopupRootPairs { get; } = new();
+
 #endif
 
     protected bool isFocused;

--- a/MonoGameGum/Forms/FormsUtilities.cs
+++ b/MonoGameGum/Forms/FormsUtilities.cs
@@ -412,37 +412,61 @@ public class FormsUtilities
         innerList.Clear();
 
         var didModalsProcessInput = false;
-        if (FrameworkElement.ModalRoot.Children.Count > 0)
+
+        RefreshPopupModalRootPairs();
+
+        // The global pair is checked first so it keeps priority (matching prior behavior) if a
+        // custom pair registered via FrameworkElement.AdditionalPopupRootPairs also has an open modal.
+        // A pair is only a candidate winner if it has a visible top child — otherwise (e.g. every
+        // child mid fade-out) it wouldn't have received input under the old single-root behavior
+        // either, so the search continues to the next pair rather than starving one that does.
+        GraphicalUiElement exclusiveModalItem = null;
+        for (int i = 0; i < popupModalRootPairs.Count && exclusiveModalItem == null; i++)
         {
-#if FULL_DIAGNOSTICS
-            if (FrameworkElement.ModalRoot.Managers == null)
+            var modalRoot = popupModalRootPairs[i].modalRoot;
+            for (int j = modalRoot.Children.Count - 1; j > -1; j--)
             {
-                throw new InvalidOperationException("The ModalRoot has a Managers property of null. Did you accidentally call RemoveFromManagers?");
-            }
-#endif
-            SetDimensionsToCanvas(FrameworkElement.ModalRoot);
-
-            // make sure this is the last:
-            foreach (var layer in SystemManagers.Default.Renderer.Layers)
-            {
-                if (layer.Renderables.Contains(FrameworkElement.ModalRoot.RenderableComponent) && layer.Renderables.Last() != FrameworkElement.ModalRoot.RenderableComponent)
+                if (modalRoot.Children[j].Visible)
                 {
-                    layer.Remove(FrameworkElement.ModalRoot.RenderableComponent as IRenderableIpso);
-                    layer.Add(FrameworkElement.ModalRoot.RenderableComponent as IRenderableIpso);
-                }
-            }
-
-            for (int i = FrameworkElement.ModalRoot.Children.Count - 1; i > -1; i--)
-            {
-                var item = FrameworkElement.ModalRoot.Children[i];
-                if (item.Visible)
-                {
-                    didModalsProcessInput = true;
-                    innerList.Add(item);
-                    // only the top-most element receives input
+                    exclusiveModalItem = modalRoot.Children[j];
                     break;
                 }
             }
+        }
+
+        // Raised in reverse priority order so the highest-priority populated modal root (the one
+        // that will actually receive input, i.e. exclusiveModalItem's root) is raised last and ends
+        // up visually on top — otherwise a lower-priority pair raised after it would cover it up.
+        for (int i = popupModalRootPairs.Count - 1; i > -1; i--)
+        {
+            var modalRoot = popupModalRootPairs[i].modalRoot;
+            if (modalRoot.Children.Count > 0)
+            {
+#if FULL_DIAGNOSTICS
+                if (modalRoot.Managers == null)
+                {
+                    throw new InvalidOperationException("The ModalRoot has a Managers property of null. Did you accidentally call RemoveFromManagers?");
+                }
+#endif
+                SetDimensionsToCanvas(modalRoot);
+
+                // make sure this is the last:
+                foreach (var layer in SystemManagers.Default.Renderer.Layers)
+                {
+                    if (layer.Renderables.Contains(modalRoot.RenderableComponent) && layer.Renderables.Last() != modalRoot.RenderableComponent)
+                    {
+                        layer.Remove(modalRoot.RenderableComponent as IRenderableIpso);
+                        layer.Add(modalRoot.RenderableComponent as IRenderableIpso);
+                    }
+                }
+            }
+        }
+
+        if (exclusiveModalItem != null)
+        {
+            didModalsProcessInput = true;
+            // only the top-most element receives input
+            innerList.Add(exclusiveModalItem);
         }
 
         if (!didModalsProcessInput)
@@ -452,32 +476,38 @@ public class FormsUtilities
                 innerList.AddRange(roots);
             }
 
-            var isRootInRoots = roots?.Contains(FrameworkElement.PopupRoot) == true;
-
-            if (!isRootInRoots && FrameworkElement.PopupRoot.Children.Count > 0)
+            // Note: like the modal loop above, a later pair's popup root ends up raised on top of
+            // an earlier one's when both have children in the same frame — there's no exclusivity
+            // concept for popups (unlike modals), so this ordering is unenforced but benign.
+            foreach (var (popupRoot, _) in popupModalRootPairs)
             {
-#if FULL_DIAGNOSTICS
-                if (FrameworkElement.PopupRoot.Managers == null)
+                var isRootInRoots = roots?.Contains(popupRoot) == true;
+
+                if (!isRootInRoots && popupRoot.Children.Count > 0)
                 {
-                    throw new InvalidOperationException("The PopupRoot has a Managers property of null. Did you accidentally call RemoveFromManagers?");
-                }
+#if FULL_DIAGNOSTICS
+                    if (popupRoot.Managers == null)
+                    {
+                        throw new InvalidOperationException("The PopupRoot has a Managers property of null. Did you accidentally call RemoveFromManagers?");
+                    }
 #endif
 
-                SetDimensionsToCanvas(FrameworkElement.PopupRoot);
-                // make sure this is the last:
-                foreach (var layer in SystemManagers.Default.Renderer.Layers)
-                {
-                    if (layer.Renderables.Contains(FrameworkElement.PopupRoot.RenderableComponent) &&
-                        layer.Renderables.Last() != FrameworkElement.PopupRoot.RenderableComponent)
+                    SetDimensionsToCanvas(popupRoot);
+                    // make sure this is the last:
+                    foreach (var layer in SystemManagers.Default.Renderer.Layers)
                     {
-                        layer.Remove(FrameworkElement.PopupRoot.RenderableComponent as IRenderableIpso);
-                        layer.Add(FrameworkElement.PopupRoot.RenderableComponent as IRenderableIpso);
+                        if (layer.Renderables.Contains(popupRoot.RenderableComponent) &&
+                            layer.Renderables.Last() != popupRoot.RenderableComponent)
+                        {
+                            layer.Remove(popupRoot.RenderableComponent as IRenderableIpso);
+                            layer.Add(popupRoot.RenderableComponent as IRenderableIpso);
+                        }
                     }
-                }
 
-                foreach (var item in FrameworkElement.PopupRoot.Children)
-                {
-                    innerList.Add(item);
+                    foreach (var item in popupRoot.Children)
+                    {
+                        innerList.Add(item);
+                    }
                 }
             }
         }
@@ -557,6 +587,15 @@ public class FormsUtilities
                 "This should not be done");
         }
 #endif
+    }
+
+    static readonly List<(InteractiveGue popupRoot, InteractiveGue modalRoot)> popupModalRootPairs = new();
+
+    static void RefreshPopupModalRootPairs()
+    {
+        popupModalRootPairs.Clear();
+        popupModalRootPairs.Add((FrameworkElement.PopupRoot, FrameworkElement.ModalRoot));
+        popupModalRootPairs.AddRange(FrameworkElement.AdditionalPopupRootPairs);
     }
 
     internal static void SetDimensionsToCanvas(InteractiveGue container)

--- a/Tests/MonoGameGum.Tests.V2/BaseTestClass.cs
+++ b/Tests/MonoGameGum.Tests.V2/BaseTestClass.cs
@@ -73,6 +73,7 @@ public class BaseTestClass : IDisposable
         GumService.Default.Root.Children.Clear();
         GumService.Default.ModalRoot.Children.Clear();
         GumService.Default.PopupRoot.Children.Clear();
+        FrameworkElement.AdditionalPopupRootPairs.Clear();
 
         // Clear any per-capability factories a test registered into the static
         // RenderableRegistry so they don't leak into the next test.

--- a/Tests/RaylibGum.Tests/BaseTestClass.cs
+++ b/Tests/RaylibGum.Tests/BaseTestClass.cs
@@ -85,6 +85,7 @@ public class BaseTestClass : IDisposable
         InteractiveGue.ClearNextClickActions();
 
         GumService.Default.Root.Children!.Clear();
+        FrameworkElement.AdditionalPopupRootPairs.Clear();
 
         // #3066: sweep any renderables a test added straight to the renderer layers via
         // AddToManagers without a matching RemoveFromManagers. Clearing Root.Children above does not


### PR DESCRIPTION
## Summary

`FormsUtilities.Update`'s modal/popup input-dispatch special-casing (z-order raising, canvas sizing, modal exclusivity) was hardcoded to the two global `FrameworkElement.PopupRoot`/`ModalRoot` statics, so a custom root pair resolved via `GraphicalUiElement.ResolvePopupRoots` (e.g. one pair per camera/viewport) got none of that automatic handling.

- Add `FrameworkElement.AdditionalPopupRootPairs` — a host registers a resolved pair here to opt into the same z-order/sizing/exclusivity handling the global roots get.
- Modal-exclusivity winner selection now requires a *visible* top child, not just `Children.Count > 0` — otherwise a root whose only children are mid-fade/invisible would win exclusivity and starve a different pair's genuinely visible modal of all input.
- Z-order raising runs in reverse priority order so whichever pair wins input exclusivity also ends up rendered on top (previously a lower-priority pair processed later in the same forward loop could end up covering the exclusive winner).
- `BaseTestClass` in `MonoGameGum.Tests`, `MonoGameGum.Tests.V2`, and `RaylibGum.Tests` now clear `AdditionalPopupRootPairs` between tests, mirroring the existing `ModalRoot`/`PopupRoot` children cleanup.

## Test plan

- [x] `dotnet test MonoGameGum.Tests/MonoGameGum.Tests.csproj` — 1835/1835 passing, including 4 new tests in `FormsUtilitiesPopupRootPairsTests` covering canvas sizing, modal exclusivity generalization, exclusivity fallback when the global modal's children are all invisible, and global-pair priority when both pairs have children.
- [x] `dotnet test Tests/MonoGameGum.Tests.V2/MonoGameGum.Tests.V2.csproj` — 120/120 passing.
- [x] `dotnet test Tests/RaylibGum.Tests/RaylibGum.Tests.csproj` — 462/462 passing.
- [x] `RaylibGum`/`SkiaGum` build clean (both compile `FormsUtilities.cs`/`FrameworkElement.cs`).
- Manual test: not needed. The existing global `ModalRoot`/`PopupRoot` path (exercised by every Forms sample/tool usage) is behavior-preserving per the full green regression suite. The new `AdditionalPopupRootPairs` opt-in path has no existing built-in control or sample wired up to it yet — this PR only adds the mechanism the issue asked for — so it's covered directly by the new unit tests driving the real `GumService.Default.Update()` path rather than a manual click-through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
