### PR TITLE
Use raylib's GetRenderWidth/Height for physical-pixel window size

### DIFF
--- a/MonoGameGum/GumService.cs
+++ b/MonoGameGum/GumService.cs
@@ -331,10 +331,13 @@ public class GumService : IGumService
     private (int width, int height) GetWindowSize()
     {
 #if XNALIKE
+        // BackBufferWidth/Height is always physical pixels - XNA has no separate logical/DPI-scaled size.
         var pp = Game.GraphicsDevice.PresentationParameters;
         return (pp.BackBufferWidth, pp.BackBufferHeight);
 #elif RAYLIB
-        return (Raylib.GetScreenWidth(), Raylib.GetScreenHeight());
+        // GetRenderWidth/Height (physical framebuffer pixels) rather than GetScreenWidth/Height
+        // (logical/DPI-unaware size) to match XNALIKE's physical-pixel convention above (#3572).
+        return (Raylib.GetRenderWidth(), Raylib.GetRenderHeight());
 #endif
     }
 

--- a/Runtimes/RaylibGum/RenderingLibrary/Renderer.cs
+++ b/Runtimes/RaylibGum/RenderingLibrary/Renderer.cs
@@ -215,8 +215,10 @@ public class Renderer : IRenderer
             CollectReferencedRenderTargets(layers[i].Renderables);
         }
 
-        _camera.ClientWidth = Raylib.GetScreenWidth();
-        _camera.ClientHeight = Raylib.GetScreenHeight();
+        // GetRenderWidth/Height (physical framebuffer pixels) rather than GetScreenWidth/Height
+        // (logical/DPI-unaware size) to match XNALIKE's BackBufferWidth/Height convention (#3572).
+        _camera.ClientWidth = Raylib.GetRenderWidth();
+        _camera.ClientHeight = Raylib.GetRenderHeight();
 
         var camera2D = new Camera2D
         {


### PR DESCRIPTION
## Summary

Spike issue #3572 asked whether MonoGame and raylib's "window size" already disagree on HiDPI displays, and if so, to pick and document the convention Gum should use before `Gum.SilkNet` has to make the same choice blind.

Findings (documented in the issue thread, see #3572):
- raylib's `GetScreenWidth/Height()` returns the *logical* (DPI-unaware) window size; `GetRenderWidth/Height()` returns the *physical* framebuffer size, and the two only diverge when the window was created with `FLAG_WINDOW_HIGHDPI`.
- XNALIKE's `PresentationParameters.BackBufferWidth/Height` has no separate logical/physical concept - it's always physical pixels.
- RaylibGum's `GetWindowSize()` (`MonoGameGum/GumService.cs`) and `Renderer.cs`'s camera client size both hardcoded `GetScreenWidth/Height()`, so if a downstream raylib consumer ever enables `FLAG_WINDOW_HIGHDPI`, Gum's own camera/layout math would silently use the wrong (logical, not physical) pixel dimensions.

## Change

- `MonoGameGum/GumService.cs`: `GetWindowSize()`'s `RAYLIB` branch now calls `Raylib.GetRenderWidth()/GetRenderHeight()`.
- `Runtimes/RaylibGum/RenderingLibrary/Renderer.cs`: `Camera.ClientWidth/Height` now read the same physical-pixel APIs.
- Both sites now document the physical-pixel convention so a future `Gum.SilkNet` implementation matches it rather than guessing.

This closes the "decide and document the convention" part of the spike. Enabling `FLAG_WINDOW_HIGHDPI` itself (and a DPI-aware manifest) for Gum's own raylib sample is a separate, samples-only concern I did not fold into this PR — happy to file that as a follow-up if wanted.

## Test plan

- [x] `dotnet build MonoGameGum.Tests/MonoGameGum.Tests.csproj` - green, no new warnings
- [x] `dotnet build Runtimes/RaylibGum/RaylibGum.csproj` - green, no new warnings
- [x] `dotnet test Tests/RaylibGum.Tests/RaylibGum.Tests.csproj` - 462/462 passed
- [x] `dotnet test MonoGameGum.Tests` filtered to GumService/WindowFit/Zoom/Expand - 22/22 passed
- No new unit test added: `GetScreenWidth()` and `GetRenderWidth()` are provably equal in every environment this repo can exercise (no real OS DPI scaling in CI, or in this session's display) - the divergence only exists on a real scaled/HiDPI display with `FLAG_WINDOW_HIGHDPI` set, which nothing in this repo currently enables. A test could only assert which native function is called, not an observable behavior difference.
- Manual test: not needed - no code path in this repo (samples included) sets `FLAG_WINDOW_HIGHDPI`, so `GetScreenWidth()==GetRenderWidth()` always holds today; the change is a byte-identical no-op in every currently-runnable configuration, and a visual check couldn't show anything different from before.

Closes #3572
