### PR TITLE
Add RaylibGum.Tests coverage for GumHotReloadManager texture-filter reload and WindowFit wiring

### DIFF
--- a/Tests/RaylibGum.Tests/GumServiceWindowFitTests.cs
+++ b/Tests/RaylibGum.Tests/GumServiceWindowFitTests.cs
@@ -1,0 +1,75 @@
+using Gum;
+using Gum.Forms;
+using Raylib_cs;
+using RenderingLibrary;
+using Shouldly;
+
+namespace RaylibGum.Tests;
+
+/// <summary>
+/// Exercises <see cref="GumService.EnableZoomToWindow"/>/<see cref="GumService.EnableExpandToWindow"/>
+/// end-to-end on Raylib. <c>WindowFitMathTests</c> already proves the pure math in
+/// <c>WindowFitMath</c> is correct; these tests instead prove the Raylib-specific wiring around
+/// it — <c>GumService.GetWindowSize</c>'s <c>#elif RAYLIB</c> branch (<c>Raylib.GetRenderWidth/
+/// GetRenderHeight</c>) and applying the computed zoom/canvas onto the real
+/// <see cref="SystemManagers"/> camera — actually works. Issue #3571.
+/// </summary>
+public class GumServiceWindowFitTests
+{
+    [Fact]
+    public void EnableExpandToWindow_AppliesComputedCanvasAndZoom_ToRealRaylibCamera()
+    {
+        GumService.Default.Uninitialize();
+        try
+        {
+            GumService.Default.Initialize(DefaultVisualsVersion.V2);
+
+            GumService.Default.EnableExpandToWindow(defaultZoom: 2f);
+
+            int windowWidth = Raylib.GetRenderWidth();
+            int windowHeight = Raylib.GetRenderHeight();
+
+            SystemManagers.Default.Renderer.Camera.Zoom.ShouldBe(2f);
+            GumService.Default.CanvasWidth.ShouldBe(windowWidth / 2f);
+            GumService.Default.CanvasHeight.ShouldBe(windowHeight / 2f);
+        }
+        finally
+        {
+            GumService.Default.Uninitialize();
+            TestAssemblyInitialize.ApplyDefaultTestState();
+        }
+    }
+
+    [Fact]
+    public void ApplyFitForSize_HeightDominantZoom_ScalesCameraZoomRelativeToCapturedReferenceSize()
+    {
+        GumService.Default.Uninitialize();
+        try
+        {
+            GumService.Default.Initialize(DefaultVisualsVersion.V2);
+
+            GumService.Default.EnableZoomToWindow(WindowZoomMode.HeightDominant, defaultZoom: 1f);
+
+            // The reference resolution is captured on this first call/fit, from the real
+            // (hidden) Raylib window's physical framebuffer size.
+            int referenceWidth = Raylib.GetRenderWidth();
+            int referenceHeight = Raylib.GetRenderHeight();
+            SystemManagers.Default.Renderer.Camera.Zoom.ShouldBe(1f);
+            GumService.Default.CanvasWidth.ShouldBe((float)referenceWidth);
+            GumService.Default.CanvasHeight.ShouldBe((float)referenceHeight);
+
+            // Doubling both dimensions at height-dominant fit should double the zoom while the
+            // canvas snaps back to the reference size (mirrors WindowFitMathTests' pure-math case).
+            GumService.Default.ApplyFitForSize(referenceWidth * 2, referenceHeight * 2);
+
+            SystemManagers.Default.Renderer.Camera.Zoom.ShouldBe(2f);
+            GumService.Default.CanvasWidth.ShouldBe((float)referenceWidth);
+            GumService.Default.CanvasHeight.ShouldBe((float)referenceHeight);
+        }
+        finally
+        {
+            GumService.Default.Uninitialize();
+            TestAssemblyInitialize.ApplyDefaultTestState();
+        }
+    }
+}

--- a/Tests/RaylibGum.Tests/Hot/GumHotReloadTextureFilterTests.cs
+++ b/Tests/RaylibGum.Tests/Hot/GumHotReloadTextureFilterTests.cs
@@ -1,0 +1,96 @@
+using Gum;
+using Gum.DataTypes;
+using Gum.Managers;
+using Gum.Wireframe;
+using RenderingLibrary.Content;
+using Shouldly;
+using System;
+using System.IO;
+using Xunit;
+
+namespace RaylibGum.Tests.Hot;
+
+/// <summary>
+/// Drives <see cref="GumHotReloadManager.PerformReload"/> end-to-end on Raylib to cover the
+/// platform-divergent branch of <c>GumService.ApplyProjectTextureFilter</c> it calls
+/// (documented as diverging at <c>GumHotReloadManager.cs:236-239</c>): on raylib there is no
+/// global sampler state, so a reload must push the project's <c>TextureFilter</c> into
+/// <see cref="ContentLoader.DefaultTextureFilter"/> instead of the XNALIKE
+/// <c>Renderer.TextureFilter</c> path. Issue #3571.
+/// </summary>
+public class GumHotReloadTextureFilterTests : BaseTestClass
+{
+    public override void Dispose()
+    {
+        ObjectFinder.Self.GumProjectSave = null;
+        base.Dispose();
+    }
+
+    private static string CreateSourceDirectory()
+    {
+        string sourceDirectory = Path.Combine(
+            Path.GetTempPath(), "GumHotReloadTextureFilterTests_" + Path.GetRandomFileName());
+        Directory.CreateDirectory(sourceDirectory);
+        return sourceDirectory;
+    }
+
+    [Fact]
+    public void PerformReload_WhenProjectTextureFilterIsLinear_SetsContentLoaderDefaultTextureFilterToBilinear()
+    {
+        Raylib_cs.TextureFilter savedDefaultFilter = ContentLoader.DefaultTextureFilter;
+        string sourceDirectory = CreateSourceDirectory();
+
+        try
+        {
+            ContentLoader.DefaultTextureFilter = Raylib_cs.TextureFilter.Point;
+
+            string gumxPath = Path.Combine(sourceDirectory, "Proj.gumx");
+            GumProjectSave project = new GumProjectSave { TextureFilter = "Linear" };
+            project.Save(gumxPath, saveElements: false);
+
+            GumHotReloadManager manager = new GumHotReloadManager();
+            manager.Start(gumxPath);
+            // Release the OS watcher immediately; Start has already recorded the source path.
+            manager.Stop();
+
+            manager.PerformReload(Array.Empty<GraphicalUiElement>());
+
+            ContentLoader.DefaultTextureFilter.ShouldBe(Raylib_cs.TextureFilter.Bilinear);
+        }
+        finally
+        {
+            ContentLoader.DefaultTextureFilter = savedDefaultFilter;
+            try { Directory.Delete(sourceDirectory, recursive: true); } catch { /* best-effort */ }
+        }
+    }
+
+    [Fact]
+    public void PerformReload_WhenProjectTextureFilterIsNotLinear_SetsContentLoaderDefaultTextureFilterToPoint()
+    {
+        Raylib_cs.TextureFilter savedDefaultFilter = ContentLoader.DefaultTextureFilter;
+        string sourceDirectory = CreateSourceDirectory();
+
+        try
+        {
+            // Start from the opposite filter so the assertion actually proves the reload changed it.
+            ContentLoader.DefaultTextureFilter = Raylib_cs.TextureFilter.Bilinear;
+
+            string gumxPath = Path.Combine(sourceDirectory, "Proj.gumx");
+            GumProjectSave project = new GumProjectSave { TextureFilter = "Point" };
+            project.Save(gumxPath, saveElements: false);
+
+            GumHotReloadManager manager = new GumHotReloadManager();
+            manager.Start(gumxPath);
+            manager.Stop();
+
+            manager.PerformReload(Array.Empty<GraphicalUiElement>());
+
+            ContentLoader.DefaultTextureFilter.ShouldBe(Raylib_cs.TextureFilter.Point);
+        }
+        finally
+        {
+            ContentLoader.DefaultTextureFilter = savedDefaultFilter;
+            try { Directory.Delete(sourceDirectory, recursive: true); } catch { /* best-effort */ }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `RaylibGum.Tests` coverage for `EnableZoomToWindow`/`EnableExpandToWindow` wiring (`GumServiceWindowFitTests`) — proves the RAYLIB `GetWindowSize` branch (`Raylib.GetRenderWidth/GetRenderHeight`) and applying `WindowFitMath`'s computed zoom/canvas onto the real `SystemManagers` camera actually work end to end, not just that the pure math is correct (already covered by `WindowFitMathTests`).
- Adds `RaylibGum.Tests` coverage for `GumHotReloadManager.PerformReload`'s raylib-specific texture-filter-reload path (`GumHotReloadTextureFilterTests`) — the divergence documented at `GumHotReloadManager.cs:236-239`, where raylib has no global sampler state and must push the project's `TextureFilter` into `ContentLoader.DefaultTextureFilter` instead of XNALIKE's `Renderer.TextureFilter`.
- No product source changed — test-only addition.

## Test plan
- [x] `dotnet test Tests/RaylibGum.Tests/RaylibGum.Tests.csproj` — 466/466 passed
- [x] Sanity red/green check: temporarily broke both raylib-specific branches under test (`GumService.GetWindowSize`'s RAYLIB arm, `ApplyProjectTextureFilter`'s RAYLIB arm), confirmed the new tests failed, reverted, confirmed green again.

Closes #3571

🤖 Generated with [Claude Code](https://claude.com/claude-code)
