### PR TITLE
Clamp popup reposition against the resolved popup/modal root, not the global canvas

### DIFF
--- a/MonoGameGum.Tests/Forms/FrameworkElementTests.cs
+++ b/MonoGameGum.Tests/Forms/FrameworkElementTests.cs
@@ -748,6 +748,67 @@ public class FrameworkElementTests : BaseTestClass
         GumService.Default.Root.Children.ShouldNotContain(child.Visual);
     }
 
+    #region RepositionToKeepInScreen
+
+    [Fact]
+    public void RepositionToKeepInScreen_WithBoundsRoot_ClampsAgainstRootBounds_NotGlobalCanvas()
+    {
+        // Issue #3591: a popup routed to a per-camera/viewport root must clamp against
+        // that root's bounds, not the global canvas, or it can overflow the smaller root.
+        GraphicalUiElement.CanvasWidth = 800;
+        GraphicalUiElement.CanvasHeight = 600;
+
+        ContainerRuntime boundsRoot = new();
+        boundsRoot.X = 100;
+        boundsRoot.Y = 50;
+        boundsRoot.Width = 200;
+        boundsRoot.Height = 150;
+
+        FrameworkElement frameworkElement = new(new ContainerRuntime());
+        frameworkElement.Width = 100;
+        frameworkElement.Height = 50;
+        // Fits within the 800x600 global canvas, but overflows boundsRoot's right/bottom edges (300, 200):
+        frameworkElement.X = 250;
+        frameworkElement.Y = 180;
+
+        frameworkElement.RepositionToKeepInScreen(boundsRoot);
+
+        (frameworkElement.Visual.AbsoluteX + frameworkElement.Visual.GetAbsoluteWidth())
+            .ShouldBeLessThanOrEqualTo(boundsRoot.X + boundsRoot.GetAbsoluteWidth());
+        (frameworkElement.Visual.AbsoluteY + frameworkElement.Visual.GetAbsoluteHeight())
+            .ShouldBeLessThanOrEqualTo(boundsRoot.Y + boundsRoot.GetAbsoluteHeight());
+    }
+
+    [Fact]
+    public void RepositionToKeepInScreen_WithBoundsRoot_ClampsUnderflowAgainstRootOrigin_NotZero()
+    {
+        // Companion to the overflow test above: boundsRoot has a non-zero origin (100, 50), so the
+        // left/top clamp must compare against boundsRoot's origin, not the literal 0 the global-canvas
+        // path uses.
+        GraphicalUiElement.CanvasWidth = 800;
+        GraphicalUiElement.CanvasHeight = 600;
+
+        ContainerRuntime boundsRoot = new();
+        boundsRoot.X = 100;
+        boundsRoot.Y = 50;
+        boundsRoot.Width = 200;
+        boundsRoot.Height = 150;
+
+        FrameworkElement frameworkElement = new(new ContainerRuntime());
+        frameworkElement.Width = 20;
+        frameworkElement.Height = 10;
+        // Positive (so it would pass a "< 0" underflow check), but still left/above boundsRoot's origin:
+        frameworkElement.X = 10;
+        frameworkElement.Y = 5;
+
+        frameworkElement.RepositionToKeepInScreen(boundsRoot);
+
+        frameworkElement.Visual.AbsoluteX.ShouldBeGreaterThanOrEqualTo(boundsRoot.X);
+        frameworkElement.Visual.AbsoluteY.ShouldBeGreaterThanOrEqualTo(boundsRoot.Y);
+    }
+
+    #endregion
+
     [Fact]
     public void SizeValues_ShouldApplyToVisual()
     {

--- a/MonoGameGum.Tests/Forms/ListBoxTests.cs
+++ b/MonoGameGum.Tests/Forms/ListBoxTests.cs
@@ -2327,5 +2327,55 @@ public class ListBoxTests : BaseTestClass
         Gum.GumService.Default.PopupRoot.Children.ShouldContain(comboBox.ListBox!.Visual);
     }
 
+    [Fact]
+    public void ShowPopupListBox_ClampsAgainstResolvedPopupRootBounds_NotGlobalCanvas()
+    {
+        // Issue #3591: reposition-to-keep-in-screen ran before the popup root was resolved
+        // and clamped against the global canvas, so a popup routed to a smaller per-camera
+        // root (via ResolvePopupRoots) could still overflow that root's bounds.
+        GraphicalUiElement.CanvasWidth = 800;
+        GraphicalUiElement.CanvasHeight = 600;
+
+        ContainerRuntime customPopupRoot = new();
+        customPopupRoot.X = 100;
+        customPopupRoot.Y = 50;
+        customPopupRoot.Width = 200;
+        customPopupRoot.Height = 150;
+        customPopupRoot.AddToManagers(RenderingLibrary.SystemManagers.Default);
+        ContainerRuntime customModalRoot = new();
+        customModalRoot.AddToManagers(RenderingLibrary.SystemManagers.Default);
+
+        Gum.Wireframe.GraphicalUiElement.ResolvePopupRoots = _ => (customPopupRoot, customModalRoot);
+
+        try
+        {
+            ContainerRuntime listBoxParent = new();
+            listBoxParent.AddToRoot();
+
+            ScrollViewer popup = new();
+            popup.Width = 100;
+            popup.Height = 50;
+            // Fits within the 800x600 global canvas, but overflows customPopupRoot's
+            // right/bottom edges (300, 200) once parented under it:
+            popup.X = 250;
+            popup.Y = 180;
+
+            ListBox.ShowPopupListBox(popup, listBoxParent);
+
+            (popup.Visual.AbsoluteX + popup.Visual.GetAbsoluteWidth())
+                .ShouldBeLessThanOrEqualTo(customPopupRoot.X + customPopupRoot.GetAbsoluteWidth());
+            (popup.Visual.AbsoluteY + popup.Visual.GetAbsoluteHeight())
+                .ShouldBeLessThanOrEqualTo(customPopupRoot.Y + customPopupRoot.GetAbsoluteHeight());
+        }
+        finally
+        {
+            Gum.Wireframe.GraphicalUiElement.ResolvePopupRoots = null;
+            customPopupRoot.Children.Clear();
+            customPopupRoot.RemoveFromManagers();
+            customModalRoot.Children.Clear();
+            customModalRoot.RemoveFromManagers();
+        }
+    }
+
     #endregion
 }

--- a/MonoGameGum/Forms/Controls/FrameworkElement.cs
+++ b/MonoGameGum/Forms/Controls/FrameworkElement.cs
@@ -936,21 +936,41 @@ public class FrameworkElement : INotifyPropertyChanged
 #endif
 
     /// <summary>
-    /// Repositions this element so it stays inside the logical Gum canvas
-    /// (<see cref="GraphicalUiElement.CanvasWidth"/> / <see cref="GraphicalUiElement.CanvasHeight"/>),
-    /// which is the space PopupRoot/ModalRoot are sized to. Clamps all four edges.
-    /// Used by popups (ListBox dropdown, Tooltip, MenuItem submenu) so they don't
-    /// render past the canvas edge regardless of how the camera/screen is sized.
+    /// Repositions this element so it stays inside <paramref name="boundsRoot"/>'s absolute bounds,
+    /// or the logical Gum canvas (<see cref="GraphicalUiElement.CanvasWidth"/> / <see cref="GraphicalUiElement.CanvasHeight"/>),
+    /// which is the space PopupRoot/ModalRoot are sized to, when <paramref name="boundsRoot"/> is null.
+    /// Clamps all four edges. Used by popups (ListBox dropdown, Tooltip, MenuItem submenu) so they
+    /// don't render past their root's edge regardless of how the camera/screen is sized.
     /// </summary>
-    public void RepositionToKeepInScreen()
+    /// <param name="boundsRoot">
+    /// The root the popup was (or will be) parented under, used as the clamp bounds instead of the
+    /// global canvas. Pass the root resolved from <see cref="GraphicalUiElement.ResolvePopupRoots"/>
+    /// so a popup routed to a per-camera/viewport root clamps against that root, not the whole window.
+    /// </param>
+    public void RepositionToKeepInScreen(GraphicalUiElement? boundsRoot = null)
     {
         if (Visual == null)
         {
             return;
         }
 
-        var canvasWidth = GraphicalUiElement.CanvasWidth;
-        var canvasHeight = GraphicalUiElement.CanvasHeight;
+        float originX, originY, canvasWidth, canvasHeight;
+        if (boundsRoot != null)
+        {
+            // AbsoluteLeft/Top/Right/Bottom (unlike AbsoluteX/Y) are origin-independent, so this
+            // stays correct even if boundsRoot has a non-default XOrigin/YOrigin.
+            originX = boundsRoot.AbsoluteLeft;
+            originY = boundsRoot.AbsoluteTop;
+            canvasWidth = boundsRoot.AbsoluteRight;
+            canvasHeight = boundsRoot.AbsoluteBottom;
+        }
+        else
+        {
+            originX = 0;
+            originY = 0;
+            canvasWidth = GraphicalUiElement.CanvasWidth;
+            canvasHeight = GraphicalUiElement.CanvasHeight;
+        }
 
         var width = Visual.GetAbsoluteWidth();
         var height = Visual.GetAbsoluteHeight();
@@ -963,9 +983,9 @@ public class FrameworkElement : INotifyPropertyChanged
         {
             this.X -= (right - canvasWidth);
         }
-        if (Visual.AbsoluteX < 0)
+        if (Visual.AbsoluteX < originX)
         {
-            this.X -= Visual.AbsoluteX;
+            this.X -= (Visual.AbsoluteX - originX);
         }
 
         var bottom = Visual.AbsoluteY + height;
@@ -973,9 +993,9 @@ public class FrameworkElement : INotifyPropertyChanged
         {
             this.Y -= (bottom - canvasHeight);
         }
-        if (Visual.AbsoluteY < 0)
+        if (Visual.AbsoluteY < originY)
         {
-            this.Y -= Visual.AbsoluteY;
+            this.Y -= (Visual.AbsoluteY - originY);
         }
     }
 

--- a/MonoGameGum/Forms/Controls/ListBox.cs
+++ b/MonoGameGum/Forms/Controls/ListBox.cs
@@ -1626,19 +1626,24 @@ public class ListBox : ItemsControl, IInputReceiver
         }
 
 #else
-        popup.RepositionToKeepInScreen();
-
         var (popupRoot, modalRoot) = GraphicalUiElement.ResolvePopupRoots?.Invoke(listBoxParent)
             ?? (FrameworkElement.PopupRoot, FrameworkElement.ModalRoot);
 
+        GraphicalUiElement targetRoot;
         if (listBoxParent.GetTopParent() == modalRoot)
         {
+            targetRoot = modalRoot;
             modalRoot.Children.Add(popup.Visual);
         }
         else
         {
+            targetRoot = popupRoot;
             popupRoot.Children.Add(popup.Visual);
         }
+
+        // Reposition after resolving and parenting to the target root, so the clamp reflects
+        // that root's bounds (e.g. a per-camera viewport) rather than the global canvas.
+        popup.RepositionToKeepInScreen(targetRoot);
 
 #endif
 


### PR DESCRIPTION
## Summary
- `ListBox.ShowPopupListBox` (non-FRB path) called `popup.RepositionToKeepInScreen()` **before** resolving/parenting the popup to its target root via `ResolvePopupRoots`, and the clamp always used the global static `GraphicalUiElement.CanvasWidth/CanvasHeight`. A popup routed to a smaller per-camera/viewport root (e.g. from FlatRedBall2) drew correctly (right routing, right z-order) but could still overflow that root's bounds.
- `RepositionToKeepInScreen` now takes an optional `boundsRoot`; when supplied, it clamps against that root's `AbsoluteLeft/Top/Right/Bottom` (origin-independent, so it stays correct even for a root with a non-default `XOrigin`/`YOrigin`) instead of the global canvas. `ShowPopupListBox` now resolves and parents the popup to its target root **first**, then repositions against that same root.
- All other callers (`Tooltip.Show`, and the `#if FRB` branches in `ComboBox`/`MenuItem`) call the parameterless overload, which falls back to the prior global-canvas behavior unchanged.

## Out of scope
`Tooltip.Show` never consults `ResolvePopupRoots` at all — it always adds to the global `FrameworkElement.PopupRoot` — so it has no per-camera routing to fix yet. Flagging as a possible follow-up, not fixed here since #3591's repro is scoped to ListBox/MenuItem popups.

## Test plan
- [x] New unit tests: `RepositionToKeepInScreen_WithBoundsRoot_ClampsAgainstRootBounds_NotGlobalCanvas`, `RepositionToKeepInScreen_WithBoundsRoot_ClampsUnderflowAgainstRootOrigin_NotZero` (`FrameworkElementTests.cs`), `ShowPopupListBox_ClampsAgainstResolvedPopupRootBounds_NotGlobalCanvas` (`ListBoxTests.cs`)
- [x] Full `MonoGameGum.Tests` suite green (1838/1838)
- [x] `KniGum`/`RaylibGum` rebuilt to confirm the shared `Forms/Controls` source still compiles
- Manual test: not needed — pure runtime/library logic change, fully covered by unit tests + compilation across the shared runtimes.

Closes #3591.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
