### PR TITLE
Push/PR-trigger the Build Samples CI workflow

### DIFF
--- a/.github/workflows/build-samples.yaml
+++ b/.github/workflows/build-samples.yaml
@@ -1,6 +1,14 @@
 name: "Build Samples"
 
-on: workflow_dispatch
+# Push/PR triggers make this the regression test for Samples/SilkNetGum, the
+# proof-of-concept that SkiaGum is drop-in for a Silk.NET host (#2738). Without
+# them it only ran on manual dispatch and could silently bitrot (#3570).
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [master, main]
+  workflow_dispatch:
 
 jobs:
     Build-Samples:


### PR DESCRIPTION
## Summary
- `Samples/SilkNetGum` is the only regression test for "SkiaGum is drop-in for a Silk.NET host" (the assumption #2738's readiness audit rests on), but the `Build Samples` workflow only ran on manual `workflow_dispatch` and could silently bitrot.
- Adds `push` (main) / `pull_request` (master, main) triggers to `build-samples.yaml`, mirroring `build-and-test.yaml`'s trigger pattern. `build-all.ps1` discovers solutions via a glob over `Samples/`, so no per-project wiring was needed — `SilkNetGum.sln` is already picked up.

Closes #3570

## Test plan
- [x] Verified the manual-dispatch path already builds `SilkNetGum.sln` successfully (last run: 2026-06-21, success, 15m49s) — this change only adds triggers, not new build logic.
- [x] Confirmed this PR's own `Build Samples` check (now pull_request-triggered) went green (14m37s), proving the trigger wiring works end-to-end.