### PR TITLE
Reset Raylib's Text.DefaultFont in GumService.Uninitialize()

### DIFF
--- a/MonoGameGum/GumService.cs
+++ b/MonoGameGum/GumService.cs
@@ -1434,6 +1434,11 @@ public class GumService : IGumService
 
         Gum.Forms.DefaultVisuals.Styling.ActiveStyle = null;
         Gum.Forms.DefaultVisuals.V3.Styling.ActiveStyle = null;
+#elif RAYLIB
+        // Raylib's Text has no Customizations/ContextCustomizations/DefaultBitmapFont
+        // equivalents to the XNALIKE Text above - only DefaultFont. default(Font) has
+        // BaseSize == 0, the constructor's documented uninitialized-Font sentinel (#3557).
+        Text.DefaultFont = default;
 #endif
 
         GraphicalUiElement.SetPropertyOnRenderable = null!;

--- a/Tests/RaylibGum.Tests/GumServiceUninitializeTests.cs
+++ b/Tests/RaylibGum.Tests/GumServiceUninitializeTests.cs
@@ -1,0 +1,34 @@
+using Gum.Renderables;
+using Raylib_cs;
+using RaylibGum;
+using Shouldly;
+
+namespace RaylibGum.Tests;
+
+/// <summary>
+/// Exercises <see cref="GumService.Uninitialize"/> on Raylib, where the reset logic
+/// mostly lives behind <c>#if XNALIKE</c> and needs a Raylib-specific mirror (#3557).
+/// </summary>
+public class GumServiceUninitializeTests
+{
+    [Fact]
+    public void Uninitialize_ResetsTextDefaultFont()
+    {
+        Font original = Text.DefaultFont;
+
+        try
+        {
+            Text.DefaultFont = Raylib.GetFontDefault();
+            Text.DefaultFont.BaseSize.ShouldBeGreaterThan(0);
+
+            GumService.Default.Uninitialize();
+
+            Text.DefaultFont.BaseSize.ShouldBe(0);
+        }
+        finally
+        {
+            Text.DefaultFont = original;
+            TestAssemblyInitialize.ApplyDefaultTestState();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- `GumService.Uninitialize()`'s `#if XNALIKE` block resets MonoGame's static `Text` font state, but had no Raylib equivalent, so Raylib's `Gum.Renderables.Text.DefaultFont` static survived teardown (#2757 introduced the static; Raylib's `Text` ctor treats `BaseSize == 0` as the "unset" sentinel).
- Added an `#elif RAYLIB` branch that resets `Text.DefaultFont = default;`. Raylib's `Text` has no `Customizations`/`ContextCustomizations`/`DefaultBitmapFont` equivalents to reset (confirmed by reading the class), and its `Sprite` has no `InvalidTexture`-style static either (per the issue's own investigation).

## Test plan
- [x] New failing test `GumServiceUninitializeTests.Uninitialize_ResetsTextDefaultFont` (`Tests/RaylibGum.Tests/`) reproduced the leak before the fix, passes after.
- [x] Full `RaylibGum.Tests` suite green (467/467).
- [x] `MonoGameGum.Tests` builds clean (XNALIKE branch untouched).

Closes #3557