### PR TITLE
Unify gamepad drivers under one GamePadDriver name; add Sokol no-op

### DIFF
--- a/MonoGameGum.Tests/Input/GamePadTestDriverExtensions.cs
+++ b/MonoGameGum.Tests/Input/GamePadTestDriverExtensions.cs
@@ -6,12 +6,12 @@ namespace MonoGameGum.Tests.Input;
 
 /// <summary>
 /// Test convenience that drives the platform-neutral <see cref="Gum.Input.GamePad"/> from an XNA
-/// <see cref="GamePadState"/> through the production <see cref="MonoGameGamePadDriver"/>, so the
+/// <see cref="GamePadState"/> through the production <see cref="GamePadDriver"/>, so the
 /// gamepad characterization tests read like the retired <c>GamePad.Activity(GamePadState, time)</c>
 /// API while actually exercising the real MonoGame input-driver mapping.
 /// </summary>
 internal static class GamePadTestDriverExtensions
 {
     public static void Activity(this GamePad pad, GamePadState state, double time)
-        => MonoGameGamePadDriver.Apply(pad, state, time);
+        => GamePadDriver.Apply(pad, state, time);
 }

--- a/MonoGameGum/Forms/FormsUtilities.cs
+++ b/MonoGameGum/Forms/FormsUtilities.cs
@@ -81,9 +81,10 @@ public class FormsUtilities
     public static Keyboard Keyboard => keyboard;
 
     // Typed explicitly as Gum.Input.GamePad (the platform-neutral holder in GumCommon) rather
-    // than relying on the per-platform `using` so MonoGame and Raylib resolve to the same type.
-    // The MonoGame side is fed by MonoGameGamePadDriver; the Raylib side by the #if RAYLIB branch
-    // of UpdateGamepads below.
+    // than relying on the per-platform `using` so MonoGame, Raylib, and Sokol resolve to the
+    // same type. Each platform is fed by its own same-named GamePadDriver.Apply(GamePad, int,
+    // double), resolved unqualified via the per-platform `using` block at the top of this file
+    // -- see UpdateGamepads below (issue #3559).
     public static Gum.Input.GamePad[] Gamepads { get; private set; } = new Gum.Input.GamePad[4];
 
 
@@ -557,26 +558,12 @@ public class FormsUtilities
 
     private static void UpdateGamepads(double time)
     {
-#if XNALIKE
         for (int i = 0; i < Gamepads.Length; i++)
         {
-#if FNA
-            var gamepadState = Microsoft.Xna.Framework.Input.GamePad.GetState((PlayerIndex)i);
-#else
-            var gamepadState = Microsoft.Xna.Framework.Input.GamePad.GetState((int)i);
-#endif
-            // Read the XNA state into the platform-neutral GamePad holder (GumCommon),
-            // mirroring the Raylib driver branch below.
-            MonoGameGum.Input.MonoGameGamePadDriver.Apply(Gamepads[i], gamepadState, time);
+            // GamePadDriver resolves per-platform via this file's top-of-file conditional
+            // `using` blocks (MonoGameGum.Input / Gum.Input) -- no #if needed here (issue #3559).
+            GamePadDriver.Apply(Gamepads[i], i, time);
         }
-#elif RAYLIB
-        for (int i = 0; i < Gamepads.Length; i++)
-        {
-            // Read the Raylib state into the platform-neutral GamePad holder (GumCommon),
-            // mirroring the MonoGame driver branch above.
-            Gum.Input.RaylibGamePadDriver.Apply(Gamepads[i], i, time);
-        }
-#endif
 
 #if FULL_DIAGNOSTICS
         var hashSet = FrameworkElement.GamePadsForUiControl.ToHashSet();

--- a/MonoGameGum/Input/GamePadDriver.cs
+++ b/MonoGameGum/Input/GamePadDriver.cs
@@ -5,21 +5,44 @@ namespace MonoGameGum.Input;
 
 /// <summary>
 /// Reads a MonoGame/XNA <see cref="GamePadState"/> and pushes it into the platform-neutral
-/// <see cref="Gum.Input.GamePad"/> holder (defined in GumCommon), mirroring the Raylib input
-/// driver branch of <c>FormsUtilities.UpdateGamepads</c>. Buttons map by name; triggers are
-/// thresholded to the digital <c>ButtonDown(LeftTrigger/RightTrigger)</c> semantics of the
-/// retired XNA <c>MonoGameGum.Input.GamePad</c>.
+/// <see cref="Gum.Input.GamePad"/> holder (defined in GumCommon). Every platform (MonoGame,
+/// Raylib, Sokol) exposes a same-named <c>GamePadDriver</c> class in its own namespace, so
+/// <c>FormsUtilities.UpdateGamepads</c> can dispatch through one unqualified call resolved by
+/// the file's per-platform <c>using</c> block, with no <c>#if</c> in the method body (issue
+/// #3559). Buttons map by name; triggers are thresholded to the digital
+/// <c>ButtonDown(LeftTrigger/RightTrigger)</c> semantics of the retired XNA
+/// <c>MonoGameGum.Input.GamePad</c>.
 /// </summary>
-internal static class MonoGameGamePadDriver
+internal static class GamePadDriver
 {
     // Matches the retired MonoGameGum.Input.GamePad.AnalogOnThreshold (0.5, compared with >=).
     const float TriggerThreshold = 0.5f;
 
     /// <summary>
-    /// Pushes the supplied <paramref name="state"/> into <paramref name="gamepad"/> via its
-    /// driver-facing setters and commits the frame with <see cref="Gum.Input.GamePad.Activity"/>.
+    /// Fetches the current <see cref="GamePadState"/> for gamepad <paramref name="index"/> and
+    /// pushes it into <paramref name="gamepad"/>. This is the production entry point that
+    /// mirrors the Raylib/Sokol drivers' <c>Apply(GamePad, int, double)</c> shape.
     /// </summary>
-    public static void Apply(Gum.Input.GamePad gamepad, GamePadState state, double time)
+    public static void Apply(Gum.Input.GamePad gamepad, int index, double time) =>
+        Apply(gamepad, GetState(index), time);
+
+    static GamePadState GetState(int index)
+    {
+#if FNA
+        return GamePad.GetState((PlayerIndex)index);
+#else
+        return GamePad.GetState(index);
+#endif
+    }
+
+    /// <summary>
+    /// Testing seam: pushes the supplied <paramref name="state"/> into <paramref name="gamepad"/>
+    /// via its driver-facing setters and commits the frame with
+    /// <see cref="Gum.Input.GamePad.Activity"/>, without fetching state itself. Used directly by
+    /// <c>MonoGameGum.Tests\Input\GamePadTestDriverExtensions.cs</c> so gamepad characterization
+    /// tests can drive an arbitrary <see cref="GamePadState"/>.
+    /// </summary>
+    internal static void Apply(Gum.Input.GamePad gamepad, GamePadState state, double time)
     {
         gamepad.SetConnected(state.IsConnected);
 

--- a/MonoGameGum/Input/GamePadDriver.cs
+++ b/MonoGameGum/Input/GamePadDriver.cs
@@ -1,3 +1,4 @@
+using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Input;
 using GamepadButton = Gum.Input.GamepadButton;
 

--- a/Runtimes/RaylibGum/Input/GamePadDriver.cs
+++ b/Runtimes/RaylibGum/Input/GamePadDriver.cs
@@ -7,13 +7,15 @@ namespace Gum.Input;
 
 /// <summary>
 /// Reads native Raylib controller input and pushes it into the platform-neutral
-/// <see cref="GamePad"/> holder (defined in GumCommon), mirroring the MonoGame input
-/// driver (<c>MonoGameGamePadDriver</c>) used by <c>FormsUtilities.UpdateGamepads</c>.
-/// Raylib exposes gamepad state through static query functions rather than a pre-fetched
-/// state struct, so <see cref="Apply(GamePad, int, double)"/> reads by gamepad index
-/// directly instead of taking a snapshot type like XNA's <c>GamePadState</c>.
+/// <see cref="GamePad"/> holder (defined in GumCommon). Every platform (MonoGame, Raylib,
+/// Sokol) exposes a same-named <c>GamePadDriver</c> class in its own namespace, so
+/// <c>FormsUtilities.UpdateGamepads</c> can dispatch through one unqualified call resolved by
+/// the file's per-platform <c>using</c> block, with no <c>#if</c> in the method body (issue
+/// #3559). Raylib exposes gamepad state through static query functions rather than a
+/// pre-fetched state struct, so <see cref="Apply(GamePad, int, double)"/> reads by gamepad
+/// index directly instead of taking a snapshot type like XNA's <c>GamePadState</c>.
 /// </summary>
-internal static class RaylibGamePadDriver
+internal static class GamePadDriver
 {
     /// <summary>
     /// Pushes the current Raylib input for gamepad <paramref name="index"/> into

--- a/Runtimes/SokolGum/Input/GamePadDriver.cs
+++ b/Runtimes/SokolGum/Input/GamePadDriver.cs
@@ -1,0 +1,20 @@
+namespace Gum.Input;
+
+/// <summary>
+/// No-op gamepad driver for the Sokol platform. Unlike <see cref="Keyboard"/> and
+/// <see cref="Cursor"/>, which read events the host forwards from its sokol_app callback,
+/// sokol_app exposes no gamepad/controller input API at all -- there is no event stream to
+/// forward. This driver exists so <c>FormsUtilities.UpdateGamepads</c> can dispatch through
+/// the same <c>GamePadDriver.Apply(GamePad, int, double)</c> shape as MonoGame/Raylib without
+/// a closed #if switch, and intentionally leaves every gamepad disconnected/neutral. Real
+/// Sokol gamepad support needs a separate native input source (e.g. platform-specific
+/// XInput/SDL2 bindings) -- not attempted here (issue #3559).
+/// </summary>
+internal static class GamePadDriver
+{
+    public static void Apply(GamePad gamepad, int index, double time)
+    {
+        gamepad.SetConnected(false);
+        gamepad.Activity(time);
+    }
+}

--- a/Tests/RaylibGum.Tests/Inputs/GamePadDriverTests.cs
+++ b/Tests/RaylibGum.Tests/Inputs/GamePadDriverTests.cs
@@ -7,20 +7,22 @@ using RaylibGamepadAxis = Raylib_cs.GamepadAxis;
 namespace RaylibGum.Tests.Inputs;
 
 /// <summary>
-/// Pins the button/axis mapping of <see cref="RaylibGamePadDriver"/> — the driver extracted
+/// Pins the button/axis mapping of <see cref="GamePadDriver"/> — the driver extracted
 /// (issue #3552) from the <c>#elif RAYLIB</c> branch of <c>FormsUtilities.UpdateGamepads</c> to
-/// mirror <c>MonoGameGamePadDriver</c>. Raylib's real button/axis reads are static functions that
-/// hit live hardware, so these tests exercise the driver's internal testing-seam overload with
-/// fake readers instead.
+/// mirror the MonoGame <c>GamePadDriver</c>. Every platform now exposes a same-named
+/// <c>GamePadDriver</c> class in its own namespace (issue #3559), so this Raylib driver's class
+/// name is no longer platform-prefixed. Raylib's real button/axis reads are static functions
+/// that hit live hardware, so these tests exercise the driver's internal testing-seam overload
+/// with fake readers instead.
 /// </summary>
-public class RaylibGamePadDriverTests : BaseTestClass
+public class GamePadDriverTests : BaseTestClass
 {
     [Fact]
     public void Apply_MapsRightFaceDown_ToA()
     {
         GamePad sut = new GamePad();
 
-        RaylibGamePadDriver.Apply(
+        GamePadDriver.Apply(
             sut,
             index: 0,
             time: 1,
@@ -35,7 +37,7 @@ public class RaylibGamePadDriverTests : BaseTestClass
     {
         GamePad sut = new GamePad();
 
-        RaylibGamePadDriver.Apply(
+        GamePadDriver.Apply(
             sut,
             index: 0,
             time: 1,
@@ -52,7 +54,7 @@ public class RaylibGamePadDriverTests : BaseTestClass
         GamePad sut = new GamePad();
 
         // Raylib reports stick Y as positive-down; Gum/XNA convention is positive-up.
-        RaylibGamePadDriver.Apply(
+        GamePadDriver.Apply(
             sut,
             index: 0,
             time: 1,
@@ -71,8 +73,8 @@ public class RaylibGamePadDriverTests : BaseTestClass
         bool IsButtonDown(int i, RaylibGamepadButton button) =>
             i == 0 && button == RaylibGamepadButton.RightFaceDown;
 
-        RaylibGamePadDriver.Apply(sutIndex0, index: 0, time: 1, IsButtonDown, (i, axis) => 0f);
-        RaylibGamePadDriver.Apply(sutIndex1, index: 1, time: 1, IsButtonDown, (i, axis) => 0f);
+        GamePadDriver.Apply(sutIndex0, index: 0, time: 1, IsButtonDown, (i, axis) => 0f);
+        GamePadDriver.Apply(sutIndex1, index: 1, time: 1, IsButtonDown, (i, axis) => 0f);
 
         sutIndex0.ButtonDown(GumGamepadButton.A).ShouldBeTrue();
         sutIndex1.ButtonDown(GumGamepadButton.A).ShouldBeFalse();

--- a/Tests/RaylibGum.Tests/Inputs/GamePadTests.cs
+++ b/Tests/RaylibGum.Tests/Inputs/GamePadTests.cs
@@ -5,12 +5,13 @@ namespace RaylibGum.Tests.Inputs;
 
 /// <summary>
 /// Tests for the platform-neutral <see cref="GamePad"/> data holder in GumCommon.
-/// The holder stores state pushed in by a platform driver (on Raylib, the
-/// <c>#if RAYLIB</c> branch of <c>FormsUtilities.UpdateGamepads</c>) via
-/// <see cref="GamePad.SetButtonState"/> / <see cref="GamePad.SetLeftStickPosition"/>
-/// and exposes it through the <see cref="IGamePad"/> query API that Forms navigation
-/// consumes. Before this holder was implemented every query returned false, so
-/// controller tabbing did nothing on Raylib (issue #3046).
+/// The holder stores state pushed in by a platform driver (on Raylib,
+/// <c>GamePadDriver.Apply(GamePad, int, double)</c>, dispatched from
+/// <c>FormsUtilities.UpdateGamepads</c>) via <see cref="GamePad.SetButtonState"/> /
+/// <see cref="GamePad.SetLeftStickPosition"/> and exposes it through the
+/// <see cref="IGamePad"/> query API that Forms navigation consumes. Before this holder
+/// was implemented every query returned false, so controller tabbing did nothing on
+/// Raylib (issue #3046).
 /// </summary>
 public class GamePadTests : BaseTestClass
 {


### PR DESCRIPTION
## Summary
- `FormsUtilities.UpdateGamepads` had a closed `#if XNALIKE`/`#elif RAYLIB` switch dispatching to platform-specific driver classes, silently leaving Sokol's `Gamepads[]` never populated.
- Renamed `MonoGameGamePadDriver` and `RaylibGamePadDriver` to the same class name `GamePadDriver` (kept in each platform's existing namespace: `MonoGameGum.Input` / `Gum.Input`), so the unqualified call resolves per-platform via `FormsUtilities.cs`'s existing top-of-file conditional `using` blocks -- mirroring how `Cursor`/`Keyboard` already dispatch. `UpdateGamepads` now has zero `#if` in its body.
- Added a MonoGame-side `Apply(GamePad, int, double)` entry point that fetches `GamePadState` internally (folding in the `#if FNA` `GetState` overload selection that used to live in `FormsUtilities`), keeping the `GamePadState`-taking overload as the internal testing seam already used by `MonoGameGum.Tests`.
- Added `Runtimes/SokolGum/Input/GamePadDriver.cs` as a documented no-op: sokol_app has no gamepad/controller API at all, so there's no event stream to forward (unlike Keyboard/Cursor). This gives Sokol the same `GamePadDriver.Apply` dispatch shape without a closed switch, and leaves gamepads disconnected/neutral rather than silently doing nothing.
- Renamed `RaylibGamePadDriverTests.cs` -> `GamePadDriverTests.cs` to match.

## Test plan
- [x] `dotnet test MonoGameGum.Tests/MonoGameGum.Tests.csproj` -- 1838 passed
- [x] `dotnet test Tests/RaylibGum.Tests/RaylibGum.Tests.csproj` -- 467 passed
- [x] `dotnet build MonoGameGum/KniGum/KniGum.csproj` -- clean (no new warnings/errors)
- [x] `dotnet build Runtimes/SokolGum/SokolGum.csproj` -- not run (Sokol.NET submodule not initialized in this worktree, and it's a 4.5 GB checkout, so a full clone wasn't feasible here); verified by inspection instead -- the new file uses only `Gum.Input.GamePad` (unqualified, same-namespace) and no Sokol-specific API, matching the no-import convention already used by the compiling `RaylibGamePadDriver.cs`/`Cursor.Sokol.cs`
- [x] FRB canary determined **not needed**: grepped `GumCoreShared.projitems` and `FlatRedBall.Forms.Shared.projitems` in the sibling FlatRedBall checkout -- neither includes any gamepad-driver file or `FormsUtilities.cs`
- No manual/visual test needed -- pure internal-plumbing, behavior-preserving change (MonoGame/Raylib runtime behavior unchanged; Sokol gains new, still-disconnected, no-op state instead of never populating)

Closes #3559

🤖 Generated with [Claude Code](https://claude.com/claude-code)