### PR TITLE
Link Forms DefaultFromFileVisuals + BehaviorFormsPropertyApplier into SkiaGum (#3598)

### DIFF
--- a/Runtimes/SkiaGum/SkiaGum.csproj
+++ b/Runtimes/SkiaGum/SkiaGum.csproj
@@ -99,6 +99,29 @@
 		<Compile Include="..\..\MonoGameGum\Forms\DefaultVisuals\V3\TooltipVisual.cs" Link="Forms\DefaultVisuals\V3\TooltipVisual.cs" />
 	</ItemGroup>
 
+	<!--
+		Forms from-file default visuals + the behavior->Forms property bridge, linked so the types
+		FormsUtilities.RegisterFromFileFormRuntimeDefaults() references compile for Skia. This is
+		piece 3 of the Skia-Forms chain (#3598); the FormsUtilities glue that calls them is the
+		#3561 follow-up. Mirrors RaylibGum.csproj's glob + BehaviorFormsPropertyApplier link.
+		These are thin control-attach wrappers (no bare Color/Texture2D), so no #if SKIA aliases are
+		needed unlike the V3 *Visual files above.
+		Exclusion:
+		  - DefaultFromFileWindowRuntime.cs — attaches the Forms Window control
+		    (MonoGameGum/Forms/Window.cs), which is not yet linked into SkiaGum; it lands with #3563
+		    (same reason V3 WindowVisual is excluded above).
+		Note: DefaultFromFile{Menu,MenuItem,PasswordBox}Runtime are globbed in but self-exclude on
+		Skia via their own #if XNALIKE || FRB || RAYLIB guard (those controls aren't on Skia yet),
+		compiling to empty units — harmless, and they light up automatically if that guard widens.
+		Part of #3543 / #2738.
+	-->
+	<ItemGroup>
+		<Compile Include="..\..\MonoGameGum\Forms\BehaviorFormsPropertyApplier.cs" Link="Forms\BehaviorFormsPropertyApplier.cs" />
+		<Compile Include="..\..\MonoGameGum\Forms\DefaultFromFileVisuals\*.cs"
+				 Exclude="..\..\MonoGameGum\Forms\DefaultFromFileVisuals\DefaultFromFileWindowRuntime.cs"
+				 Link="Forms\DefaultFromFileVisuals\%(Filename)%(Extension)" />
+	</ItemGroup>
+
 	<ItemGroup>
 		<PackageReference Include="SkiaSharp" Version="3.119.1" />
 		<PackageReference Include="SkiaSharp.Extended" Version="3.0.0" />


### PR DESCRIPTION
Closes #3598

## What

Links the Forms **from-file** default visuals and the behavior→Forms property bridge into `SkiaGum.csproj`, so the types `FormsUtilities.RegisterFromFileFormRuntimeDefaults()` references now compile for Skia. This is **piece 3** of the Skia-Forms readiness chain (#3543 / #2738) and a **prerequisite for #3561** (wiring `FormsUtilities` into Skia's `GumService`). Sibling of #3562 (V3 default visuals, merged) and #3563 (Window.cs/ScreenBase.cs).

Added to `SkiaGum.csproj` (mirroring `RaylibGum.csproj:129,170`):
- `MonoGameGum/Forms/BehaviorFormsPropertyApplier.cs`
- `MonoGameGum/Forms/DefaultFromFileVisuals/*.cs` (glob)

Nothing registers these on Skia yet — that glue is the #3561 follow-up.

## Per-file verification

The issue flagged that these files might reference bare `Color`/`Texture2D` (like the V3 visuals in #3562, which needed `#if SKIA` aliases). **They don't** — verified per-file: the `DefaultFromFile*Runtime` classes are thin control-attach wrappers (`FormsControlAsObject = new Foo(this)` in `AfterFullCreation`) with **zero graphics-type references**, and `BehaviorFormsPropertyApplier.cs` uses only `Gum.*` types with no `#if`. So **no `#if SKIA` alias edits were needed** — the change is csproj-only.

## Exclusions

- **`DefaultFromFileWindowRuntime.cs`** — excluded via `Exclude=`. It attaches the Forms `Window` control (`MonoGameGum/Forms/Window.cs`), which is not linked into SkiaGum until #3563. Same reason V3 `WindowVisual` is excluded in #3562.
- **`DefaultFromFile{Menu,MenuItem,PasswordBox}Runtime.cs`** — globbed in but self-exclude on Skia via their own `#if XNALIKE || FRB || RAYLIB` guard (those controls aren't on Skia yet), so they compile to empty units. Harmless, and they light up automatically if that guard ever widens.

Verified the resolved MSBuild `Compile` item set: all 20 non-Window `DefaultFromFile*Runtime.cs` + `BehaviorFormsPropertyApplier.cs` are compiled; `DefaultFromFileWindowRuntime.cs` is absent.

## Verification

- `SkiaGum.csproj` builds green — **0 errors** (warnings are all pre-existing CS8618/CS0618/CS1574 from the already-linked V3 visuals and Skia renderables).
- `SkiaGum.Tests` — **204/204 pass**.

Part of #3543 / #2738.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
