### PR TITLE
Migrate Forms/Window.cs into GumCommon; link ScreenBase + WindowVisual into SkiaGum (#3563)

### DIFF
--- a/GumCommon/GumCommon.csproj
+++ b/GumCommon/GumCommon.csproj
@@ -294,6 +294,7 @@
 		<Compile Include="..\MonoGameGum\Forms\Controls\Tooltip.cs" Link="Forms\Controls\Tooltip.cs" />
 		<Compile Include="..\MonoGameGum\Forms\Controls\ToolTipService.cs" Link="Forms\Controls\ToolTipService.cs" />
 		<Compile Include="..\MonoGameGum\Forms\Controls\UserControl.cs" Link="Forms\Controls\UserControl.cs" />
+		<Compile Include="..\MonoGameGum\Forms\Window.cs" Link="Forms\Window.cs" />
 		<Compile Include="..\MonoGameGum\Forms\GraphicalUiElementFormsExtensions.cs" Link="Forms\GraphicalUiElementFormsExtensions.cs" />
 		<Compile Include="..\MonoGameGum\Threading\DeferredActionQueue.cs" Link="Threading\DeferredActionQueue.cs" />
 	</ItemGroup>

--- a/MonoGameGum/FnaGum/FnaGum.csproj
+++ b/MonoGameGum/FnaGum/FnaGum.csproj
@@ -167,6 +167,7 @@
 		<Compile Remove="..\Forms\Controls\Tooltip.cs" />
 		<Compile Remove="..\Forms\Controls\ToolTipService.cs" />
 		<Compile Remove="..\Forms\GraphicalUiElementFormsExtensions.cs" />
+		<Compile Remove="..\Forms\Window.cs" />
 		<Compile Remove="..\Threading\DeferredActionQueue.cs" />
 	</ItemGroup>
 

--- a/MonoGameGum/Forms/DefaultVisuals/V3/WindowVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/V3/WindowVisual.cs
@@ -16,6 +16,9 @@ using Microsoft.Xna.Framework;
 using Gum.GueDeriving;
 #endif
 using Gum.Forms.Controls;
+#if SKIA
+using Color = SkiaSharp.SKColor;
+#endif
 
 
 namespace Gum.Forms.DefaultVisuals.V3;

--- a/MonoGameGum/KniGum/KniGum.csproj
+++ b/MonoGameGum/KniGum/KniGum.csproj
@@ -200,6 +200,7 @@
 		<Compile Remove="..\Forms\Controls\Tooltip.cs" />
 		<Compile Remove="..\Forms\Controls\ToolTipService.cs" />
 		<Compile Remove="..\Forms\GraphicalUiElementFormsExtensions.cs" />
+		<Compile Remove="..\Forms\Window.cs" />
 		<Compile Remove="..\Threading\DeferredActionQueue.cs" />
 	</ItemGroup>
 

--- a/MonoGameGum/MonoGameGum.csproj
+++ b/MonoGameGum/MonoGameGum.csproj
@@ -179,6 +179,7 @@
 		<Compile Remove="Forms\Controls\Tooltip.cs" />
 		<Compile Remove="Forms\Controls\ToolTipService.cs" />
 		<Compile Remove="Forms\GraphicalUiElementFormsExtensions.cs" />
+		<Compile Remove="Forms\Window.cs" />
 		<EmbeddedResource Remove="FnaGum\**" />
 		<EmbeddedResource Remove="KniGum\**" />
 		<None Remove="FnaGum\**" />

--- a/Runtimes/RaylibGum/RaylibGum.csproj
+++ b/Runtimes/RaylibGum/RaylibGum.csproj
@@ -129,7 +129,6 @@
 		<Compile Include="..\..\MonoGameGum\Forms\BehaviorFormsPropertyApplier.cs" Link="Forms\BehaviorFormsPropertyApplier.cs" />
 		<Compile Include="..\..\MonoGameGum\Forms\FormsUtilities.cs" Link="Forms\FormsUtilities.cs" />
 		<Compile Include="..\..\MonoGameGum\Forms\ScreenBase.cs" Link="Forms\ScreenBase.cs" />
-		<Compile Include="..\..\MonoGameGum\Forms\Window.cs" Link="Forms\Window.cs" />
 		<Compile Include="..\..\MonoGameGum\GueDeriving\ColoredRectangleRuntime.cs" Link="GueDeriving\ColoredRectangleRuntime.cs" />
 		<Compile Include="..\..\MonoGameGum\GueDeriving\ContainerRuntime.cs" Link="GueDeriving\ContainerRuntime.cs" />
 		<Compile Include="..\..\MonoGameGum\GueDeriving\SpriteRuntime.cs" Link="GueDeriving\SpriteRuntime.cs" />

--- a/Runtimes/SkiaGum/SkiaGum.csproj
+++ b/Runtimes/SkiaGum/SkiaGum.csproj
@@ -63,6 +63,15 @@
 
 	</ItemGroup>
 
+	<ItemGroup>
+		<!--
+			ScreenBase stays per-backend (not migrated to GumCommon like Window.cs) because its
+			default ctor news up ContainerRuntime, a per-backend GueDeriving type GumCommon can't
+			reference. Window.cs itself arrives via the GumCommon ProjectReference.
+		-->
+		<Compile Include="..\..\MonoGameGum\Forms\ScreenBase.cs" Link="Forms\ScreenBase.cs" />
+	</ItemGroup>
+
 	<!--
 		Forms code-only V3 default visuals, linked so the *Visual classes compile for Skia. This is
 		piece 2 of the Skia-Forms chain (#3562); the FormsUtilities glue that registers them is a
@@ -70,8 +79,6 @@
 		  - The legacy V1/V2 default visuals ([Obsolete], slated for removal) — Skia is a new backend
 		    with no back-compat need, so only the current V3 generation is ported. (#3561 will then
 		    need to #if-exclude the V1/V2 registration cases in FormsUtilities for Skia.)
-		  - V3 WindowVisual — depends on the Forms Window control (MonoGameGum/Forms/Window.cs), which
-		    is not yet linked into SkiaGum; it lands with #3563 (Window.cs/ScreenBase.cs).
 		Part of #3562 / #3543.
 	-->
 	<ItemGroup>
@@ -97,6 +104,7 @@
 		<Compile Include="..\..\MonoGameGum\Forms\DefaultVisuals\V3\TextBoxBaseVisual.cs" Link="Forms\DefaultVisuals\V3\TextBoxBaseVisual.cs" />
 		<Compile Include="..\..\MonoGameGum\Forms\DefaultVisuals\V3\TextBoxVisual.cs" Link="Forms\DefaultVisuals\V3\TextBoxVisual.cs" />
 		<Compile Include="..\..\MonoGameGum\Forms\DefaultVisuals\V3\TooltipVisual.cs" Link="Forms\DefaultVisuals\V3\TooltipVisual.cs" />
+		<Compile Include="..\..\MonoGameGum\Forms\DefaultVisuals\V3\WindowVisual.cs" Link="Forms\DefaultVisuals\V3\WindowVisual.cs" />
 	</ItemGroup>
 
 	<!--
@@ -106,10 +114,6 @@
 		#3561 follow-up. Mirrors RaylibGum.csproj's glob + BehaviorFormsPropertyApplier link.
 		These are thin control-attach wrappers (no bare Color/Texture2D), so no #if SKIA aliases are
 		needed unlike the V3 *Visual files above.
-		Exclusion:
-		  - DefaultFromFileWindowRuntime.cs — attaches the Forms Window control
-		    (MonoGameGum/Forms/Window.cs), which is not yet linked into SkiaGum; it lands with #3563
-		    (same reason V3 WindowVisual is excluded above).
 		Note: DefaultFromFile{Menu,MenuItem,PasswordBox}Runtime are globbed in but self-exclude on
 		Skia via their own #if XNALIKE || FRB || RAYLIB guard (those controls aren't on Skia yet),
 		compiling to empty units — harmless, and they light up automatically if that guard widens.
@@ -118,7 +122,6 @@
 	<ItemGroup>
 		<Compile Include="..\..\MonoGameGum\Forms\BehaviorFormsPropertyApplier.cs" Link="Forms\BehaviorFormsPropertyApplier.cs" />
 		<Compile Include="..\..\MonoGameGum\Forms\DefaultFromFileVisuals\*.cs"
-				 Exclude="..\..\MonoGameGum\Forms\DefaultFromFileVisuals\DefaultFromFileWindowRuntime.cs"
 				 Link="Forms\DefaultFromFileVisuals\%(Filename)%(Extension)" />
 	</ItemGroup>
 

--- a/Runtimes/SokolGum/SokolGum.csproj
+++ b/Runtimes/SokolGum/SokolGum.csproj
@@ -139,7 +139,6 @@
 		<Compile Include="..\..\MonoGameGum\Forms\BehaviorFormsPropertyApplier.cs" Link="Forms\BehaviorFormsPropertyApplier.cs" />
 		<Compile Include="..\..\MonoGameGum\Forms\FormsUtilities.cs" Link="Forms\FormsUtilities.cs" />
 		<Compile Include="..\..\MonoGameGum\Forms\ScreenBase.cs" Link="Forms\ScreenBase.cs" />
-		<Compile Include="..\..\MonoGameGum\Forms\Window.cs" Link="Forms\Window.cs" />
 		<Compile Include="..\..\MonoGameGum\Forms\DefaultFromFileVisuals\*.cs" Link="Forms\DefaultFromFileVisuals\%(Filename)%(Extension)" />
 	</ItemGroup>
 


### PR DESCRIPTION
## Summary

Closes #3563.

The issue as written asked to "link `Window.cs` and `ScreenBase.cs` into `SkiaGum.csproj` so `PopupRoot`/`ModalRoot` don't stay null." This PR takes the cleaner approach approved during analysis: **migrate `Window.cs` down into `GumCommon`** (deleting the per-backend links), and **link `ScreenBase.cs` directly into SkiaGum** (it can't move to GumCommon).

### Why this approach instead of the literal wording

`FrameworkElement.cs` and every other Forms control already live this way: `<Compile Include>`'d once in `GumCommon.csproj` and `<Compile Remove>`'d from every project that would otherwise double-compile them. Window was the lone Forms-control holdout still linked per-backend (RaylibGum, SokolGum, and previously the issue would have added Skia too). Migrating it to GumCommon follows that established precedent, and because every backend references `GumCommon.csproj`, Window now reaches all of them as a binary — which also lets us **remove the Window triplication** in Raylib/Sokol rather than adding a fourth copy for Skia.

`Window.cs` stays physically at `MonoGameGum/Forms/Window.cs`; only which csproj *compiles* it changes.

### ScreenBase stays per-backend

`ScreenBase`'s default ctor does `new ContainerRuntime()` — a per-backend `GueDeriving` type that lives a layer *above* GumCommon, which GumCommon cannot reference. So ScreenBase is linked into SkiaGum explicitly (with a comment) rather than migrated.

### Skia deferrals resolved

With Window available on Skia via the GumCommon reference, the two Skia-Forms deferrals from #3562 / #3599 are unblocked and now included:
- V3 `WindowVisual` linked into the Skia V3 list.
- `DefaultFromFileWindowRuntime` no longer excluded from the from-file glob.

### One `.cs` deviation from the pure-csproj plan

The Skia build revealed `WindowVisual.cs` was missing the `#if SKIA using Color = SkiaSharp.SKColor;` alias that #3562 applied to *every other* V3 visual but deferred for WindowVisual to this issue (#3563). On Raylib/Sokol `Color` resolves through their global `<Using>` (Raylib_cs.Color / SokolGum.Color); Skia has no such global using, so WindowVisual failed to compile there without the file-scoped alias. Added the one-line alias, mirroring `ButtonVisual`/`CheckBoxVisual` exactly. It sits inside `#if SKIA`, so it is inert on MonoGame/KNI/FNA/Raylib/Sokol/FRB. This completes #3562's own alias pattern for the file it explicitly deferred.

### Files changed

- `GumCommon/GumCommon.csproj` — add `Window.cs` include.
- `MonoGameGum/MonoGameGum.csproj`, `KniGum.csproj`, `FnaGum.csproj` — `<Compile Remove>` Window so it isn't double-compiled against the GumCommon copy.
- `Runtimes/RaylibGum/RaylibGum.csproj`, `Runtimes/SokolGum/SokolGum.csproj` — delete the explicit `Window.cs` include (now via GumCommon). ScreenBase links left untouched.
- `Runtimes/SkiaGum/SkiaGum.csproj` — link `ScreenBase.cs`; add V3 `WindowVisual`; drop the `DefaultFromFileWindowRuntime` exclusion; update the stale exclusion comments.
- `MonoGameGum/Forms/DefaultVisuals/V3/WindowVisual.cs` — one-line `#if SKIA` Color alias (see deviation above).

### FRB1 sync

None required. Window.cs is not physically added/renamed/moved/deleted, so `GumCoreShared.projitems` and `FlatRedBall.Forms.Shared.projitems` are unaffected. The WindowVisual edit is a one-line addition inside an existing file (not an add/rename), and its `#if SKIA` block is inert on FRB.

### Verification

- `MonoGameGum.Tests` build + suite: **1838 passed, 0 failed** (proves Window compiles in GumCommon and MonoGameGum doesn't double-compile it).
- `KniGum` build: green (proves the KNI sweep + remove is correct).
- `RaylibGum` build: green (proves Raylib gets Window via GumCommon after the explicit-link removal).
- `SkiaGum` build + `SkiaGum.Tests` suite: **204 passed, 0 failed** (Window via GumCommon + ScreenBase + V3 WindowVisual + DefaultFromFileWindowRuntime all compile on Skia).
- Zero new compiler warnings from any touched/newly-linked file.

`FnaGum` and `SokolGum` were **not** built (they require the FNA/Sokol submodules, which repo guidance says not to initialize for a non-FNA/Sokol change). FnaGum is `XNALIKE` — the same compile family as MonoGame/KNI — and its edit is mechanically identical to KniGum's, so if those build it will. SokolGum's edit mirrors Raylib's verified one.

Manual test: not needed — this is compile-topology only, and the newly-available Skia types aren't wired up until #3561 links FormsUtilities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
