### PR TITLE
Register extended standard default states in GumService load path (Canvas/Svg/Lottie/shape standards no longer crash init)

### DIFF
--- a/MonoGameGum/GumService.cs
+++ b/MonoGameGum/GumService.cs
@@ -1238,6 +1238,17 @@ public class GumService : IGumService
             }
 
             ObjectFinder.Self.GumProjectSave = gumProject;
+
+            // A loaded project may declare Skia-only standards (Canvas/Svg/LottieAnimation) or the
+            // shape standards (Arc/ColoredCircle/RoundedRectangle/Line). This runtime has no Skia
+            // plugin to resolve those, so register their default states here; otherwise
+            // gumProject.Initialize() throws "Could not get the default state for type ..." for a
+            // declared-but-unrendered standard. #3507 removed the shape runtime's Container fallback
+            // that used to mask this. Headless Gum.ProjectServices / gumcli register the same states
+            // for the same reason (no Skia plugin). Idempotent, and composes with the shape runtime's
+            // own resolver, so it is safe to call unconditionally on every load.
+            StandardElementsManager.Self.RegisterExtendedDefaultStates();
+
             gumProject.Initialize();
             ApplyProjectTextureFilter(gumProject);
             Gum.Forms.FormsUtilities.RegisterFromFileFormRuntimeDefaults();

--- a/Tests/MonoGameGum.IntegrationTests/MonoGameGum/GumServiceExtendedStandardTests.cs
+++ b/Tests/MonoGameGum.IntegrationTests/MonoGameGum/GumServiceExtendedStandardTests.cs
@@ -1,0 +1,159 @@
+using Gum.Managers;
+using Microsoft.Xna.Framework;
+using RenderingLibrary.Content;
+using Shouldly;
+using System;
+using System.IO;
+using Xunit;
+
+namespace MonoGameGum.IntegrationTests.MonoGameGum;
+
+/// <summary>
+/// Regression tests for a runtime crash where a project that declares a Skia-only standard element
+/// (Canvas/Svg/LottieAnimation) threw "Could not get the default state for type Canvas" from
+/// GumService.Initialize on a non-Skia runtime. #3507 changed the shape runtime's default-state
+/// resolver to return null for types it does not own — correct for the Gum tool, where the Skia
+/// plugin resolves them, but it removed the Container fallback the game runtime had relied on to
+/// tolerate these declared-but-never-rendered standards. GumService now registers the extended
+/// default states at load so they resolve instead of throwing.
+/// </summary>
+public class GumServiceExtendedStandardTests : BaseTestClass, IDisposable
+{
+    private string? _tempDirectory;
+
+    public override void Dispose()
+    {
+        base.Dispose();
+
+        if (_tempDirectory != null && Directory.Exists(_tempDirectory))
+        {
+            try
+            {
+                Directory.Delete(_tempDirectory, recursive: true);
+            }
+            catch
+            {
+                // Best effort - file handles may still be held during test teardown.
+            }
+        }
+    }
+
+    [Fact]
+    public void Initialize_ResolvesCanvasStandard_WhenProjectDeclaresCanvasStandard()
+    {
+        _tempDirectory = CreateTempDirectory();
+        string gumxPath = WriteProjectDeclaringStandard(_tempDirectory, "Canvas");
+
+        using GameForExtendedStandardTest game = new GameForExtendedStandardTest(gumxPath);
+        game.RunOneFrame();
+
+        game.GumService.LastLoadResult.ShouldNotBeNull();
+        game.GumService.LastLoadResult!.ErrorMessage.ShouldBeNullOrEmpty();
+        StandardElementsManager.Self.TryGetDefaultStateFor("Canvas", throwExceptionOnMissing: false)
+            .ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void Initialize_ResolvesCanvasStandard_AfterUninitializeAndReinitialize()
+    {
+        _tempDirectory = CreateTempDirectory();
+        string gumxPath = WriteProjectDeclaringStandard(_tempDirectory, "Canvas");
+
+        using GameForExtendedStandardTest game = new GameForExtendedStandardTest(gumxPath);
+        game.RunOneFrame();
+        StandardElementsManager.Self.TryGetDefaultStateFor("Canvas", throwExceptionOnMissing: false)
+            .ShouldNotBeNull();
+
+        // The extended-state registration guard and the wired resolver are process-global and are
+        // NOT reset by Uninitialize, so a second Initialize must still resolve Canvas. If a future
+        // change makes Uninitialize clear StandardElementsManager state, this pins that it must also
+        // re-register.
+        game.GumService.Uninitialize();
+        game.GumService.Initialize(game, gumxPath);
+
+        StandardElementsManager.Self.TryGetDefaultStateFor("Canvas", throwExceptionOnMissing: false)
+            .ShouldNotBeNull();
+    }
+
+    #region Helpers
+
+    private static string CreateTempDirectory()
+    {
+        string tempDir = Path.Combine(Path.GetTempPath(), "GumExtendedStandardTests_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        return tempDir;
+    }
+
+    private static string WriteProjectDeclaringStandard(string tempDirectory, string standardName)
+    {
+        string standardsDir = Path.Combine(tempDirectory, "Standards");
+        Directory.CreateDirectory(standardsDir);
+        File.WriteAllText(Path.Combine(standardsDir, $"{standardName}.gutx"), $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <StandardElementSave xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+              <Name>{standardName}</Name>
+              <State>
+                <Name>Default</Name>
+              </State>
+              <Behaviors />
+            </StandardElementSave>
+            """);
+
+        string gumxPath = Path.Combine(tempDirectory, "Project.gumx");
+        File.WriteAllText(gumxPath, $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <GumProjectSave xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+              <DefaultCanvasWidth>800</DefaultCanvasWidth>
+              <DefaultCanvasHeight>600</DefaultCanvasHeight>
+              <StandardElementReference Name="{standardName}" />
+            </GumProjectSave>
+            """);
+        return gumxPath;
+    }
+
+    #endregion
+
+    #region Test Game
+
+    private class GameForExtendedStandardTest : Game
+    {
+        private readonly GraphicsDeviceManager _graphics;
+        private readonly string _gumProjectFile;
+        public Gum.GumService GumService { get; private set; }
+
+        public GameForExtendedStandardTest(string gumProjectFile)
+        {
+            LoaderManager.Self?.DisposeAndClear();
+            _graphics = new GraphicsDeviceManager(this);
+            Content.RootDirectory = "Content";
+            IsMouseVisible = true;
+            _gumProjectFile = gumProjectFile;
+            GumService = new Gum.GumService();
+        }
+
+        protected override void Initialize()
+        {
+            base.Initialize();
+            GumService.Initialize(this, _gumProjectFile);
+        }
+
+        protected override void Update(GameTime gameTime) { }
+
+        protected override void Draw(GameTime gameTime)
+        {
+            GraphicsDevice.Clear(Color.CornflowerBlue);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (GumService.IsInitialized)
+            {
+                GumService.Uninitialize();
+            }
+            LoaderManager.Self?.DisposeAndClear();
+            base.Dispose(disposing);
+        }
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Problem

A project that **declares** a Skia-only standard element (`Canvas`/`Svg`/`LottieAnimation`) — or a shape standard (`Arc`/`ColoredCircle`/`RoundedRectangle`/`Line`) — threw at runtime on a non-Skia backend (MonoGame/KNI/FNA/raylib):

```
System.InvalidOperationException: Could not get the default state for type Canvas in either the default or through plugins
   at StandardElementsManager.TryGetDefaultStateFor
   at GumProjectSaveExtensionMethods.Initialize
   at GumService.InitializeInternal
```

This is a regression surfaced by FlatRedBall2. Older projects still declare Skia shapes (translated to Apos.Shapes/raylib types at runtime); such projects also carry the unsupported `Canvas`/`Svg`/`LottieAnimation` standards, declared-but-never-instantiated.

## Root cause

#3507 changed the shape runtime's default-state resolver (`AposShapeRuntime.HandleCustomGetDefaultState`) so its `default:` case returns `null` instead of `Container`'s default state. That was **correct for the Gum tool** (the Skia plugin resolves those types via the fallback chain, and the old Container fallback was injecting Container-only variables like `IsRenderTarget` into those standards' `.gutx`). But it also removed the fallback the **game runtime** relied on to tolerate a declared-but-unrendered Skia standard. With no Skia plugin present and `tolerateMissingDefaultStates: false` hardcoded in `GumService.InitializeInternal`, `Canvas` now resolves to nothing and init throws.

## Fix

`GumService` now calls `StandardElementsManager.Self.RegisterExtendedDefaultStates()` before initializing a loaded project — the same bridge headless `Gum.ProjectServices` / `gumcli` already use for the same "no Skia plugin" situation. The standards resolve to their real default states (not Container's), covering the complete set of extended standards. One shared line covers MonoGame/KNI/FNA and raylib (`GumService.cs` is XNALIKE + RAYLIB). The call is idempotent and composes with the shape runtime's own resolver.

## Tests

`GumServiceExtendedStandardTests` (MonoGameGum.IntegrationTests) drives the real `GumService.Initialize(game, gumx)` end-to-end over a project declaring `Canvas`, with a live `GraphicsDevice`:
- reproduces the exact crash (red before the fix, green after);
- pins re-resolution across an `Initialize → Uninitialize → Initialize` cycle (the extended-state guard and resolver are process-global and survive Uninitialize).

Full `MonoGameGum.IntegrationTests` (64) and `MonoGameGum.Tests` (1838) green; `RaylibGum` compiles.
