### PR TITLE
Route Forms input creation through IGumService (ADR 0006, prep for #3561)

### DIFF
--- a/Direction/decisions/0006-runtimes-declare-capabilities-through-igumservice.md
+++ b/Direction/decisions/0006-runtimes-declare-capabilities-through-igumservice.md
@@ -1,0 +1,67 @@
+# 0006. Runtimes declare platform capabilities through `IGumService`
+
+- **Status:** Accepted
+- **Date:** 2026-07-10
+- **Deciders:** Victor Chelaru, Claude
+
+## Context
+
+Gum has no single "runtime" assembly — the same shared source is compiled into each backend
+(MonoGame/KNI/FNA, raylib, Skia, Sokol) and into FlatRedBall. Each backend supplies its
+platform-specific behavior by assigning a **scattered set of hooks** during its initialization:
+
+- static delegates on `GraphicalUiElement` — `SetPropertyOnRenderable`, `AddRenderableToManagers`,
+  `RemoveRenderableFromManagers`, `UpdateFontFromProperties`;
+- `ElementSaveExtensions.CustomCreateGraphicalComponentFunc` and the
+  `ElementSaveExtensions.RegisterGueInstantiation(...)` type→factory map;
+- the `LoaderManager` content loader;
+- a factory method already on `IGumService` — `CreateSpriteRenderable()`;
+- and, until now, **compile-time-resolved** same-named input types (`Cursor` / `Keyboard` /
+  `GamePadDriver`, via `CreateForCurrentPlatform` / `Apply`).
+
+A new-backend author has **no single place to look**. They discover the required hooks by reading an
+existing runtime and hoping the set is complete — nothing enforces completeness. This bit us while
+extending Forms to the Skia/Silk rendering path: `FormsUtilities` could not compile on Skia because
+input creation was resolved at compile time against `Cursor`/`Keyboard`/`GamePadDriver` types that a
+render-only backend does not have. The reflex fix (`#if`-gating the input pieces) was rejected as
+sprinkling conditional compilation over what is really a missing abstraction.
+
+## Decision
+
+We will grow **`IGumService`** (`RenderingLibrary/IGumService.cs`, compiled into GumCommon) into the
+**single runtime-capability interface** — the checklist a new runtime implements — and migrate the
+scattered per-runtime hooks onto it **incrementally and behavior-preservingly**.
+
+- **Input creation is the first slice:** `CreateCursor()`, `CreateKeyboard()`, and the per-frame
+  `ApplyGamePadState(...)` driver join the existing `CreateSpriteRenderable()`.
+- New capabilities are added as **default interface methods** returning a safe no-op, so render-only
+  hosts (e.g. the Skia standalone service) inherit the default and only input-capable runtimes
+  override. The platform `#if` moves *out* of shared files and *into* each runtime's service.
+- **Not every hook must be flattened onto the interface.** The hot-path layout delegates
+  (`SetPropertyOnRenderable`) are called from deep in GumCommon layout code and may be *referenced by*
+  the provider rather than absorbed into it — interface-segregation judgment governs each migration.
+
+## Consequences
+
+- **The compiler becomes the checklist.** A runtime that omits a required capability fails to compile
+  (for non-defaulted members) or receives an explicit no-op default — instead of silently missing a
+  hook discovered only at runtime.
+- Input is decoupled from concrete platform types, so `FormsUtilities` (and future Forms-bearing
+  shared code) compiles on any backend; enablement on Skia becomes a linking step, not an `#if` sweep.
+- Migration risk is spread over many small behavior-preserving PRs rather than one big-bang.
+- FRB consumes parts of GumCommon by source; default interface methods keep existing implementors
+  source-compatible. (FRB does not compile `IGumService.cs` today, so the input slice is inert for it.)
+- **Follow-ups (one capability per PR):** migrate the renderable/font delegates,
+  `CustomCreateGraphicalComponentFunc`, the `RegisterGueInstantiation` map, and the content loader onto
+  (or behind) `IGumService`.
+
+## Alternatives considered
+
+- **A new dedicated `IGumRuntimePlatform` interface** — rejected: `IGumService` is already the
+  emerging composition point (it holds `CreateSpriteRenderable`, `Cursor`, `Renderer`); a parallel
+  interface would split the "one place" in two.
+- **Big-bang consolidation of every hook at once** — rejected: too much behavior-preserving surface
+  across every runtime plus FRB to land safely in a single step.
+- **Leave the hooks scattered and only document them** — rejected: a doc checklist is not
+  compiler-enforced, and documentation does not remove the compile-time input coupling that blocks
+  Forms on Skia.

--- a/Direction/decisions/README.md
+++ b/Direction/decisions/README.md
@@ -25,3 +25,4 @@ re-litigating it.
 | [0003](0003-decouple-tool-ui-from-logic.md) | Decouple the Gum tool's UI from its application logic | Accepted | 2026-06-20 |
 | [0004](0004-viewmodels-expose-neutral-presentation-state.md) | ViewModels expose resolved display state in neutral types | Accepted | 2026-06-20 |
 | [0005](0005-headless-presentation-assembly.md) | Home for the headless presentation layer: a dedicated `Gum.Presentation` assembly | Accepted | 2026-06-24 |
+| [0006](0006-runtimes-declare-capabilities-through-igumservice.md) | Runtimes declare platform capabilities through `IGumService` | Accepted | 2026-07-10 |

--- a/MonoGameGum/Forms/FormsUtilities.cs
+++ b/MonoGameGum/Forms/FormsUtilities.cs
@@ -19,14 +19,13 @@ using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Gum.Forms.DefaultVisuals;
 using Gum.GueDeriving;
-using MonoGameGum.Input;
-// Keyboard, GamePad and the rest of the input group now live in Gum.Input (issue #3137);
-// MonoGameGum.Input is still imported for the Cursor types that have not moved.
-using Gum.Input;
 #else
 using Gum.GueDeriving;
-using Gum.Input;
 #endif
+// Concrete per-platform input types (Cursor / Keyboard / GamePadDriver) are no longer referenced
+// here: input creation is delegated to IGumService (CreateCursor / CreateKeyboard / ApplyGamePadState)
+// so this shared file compiles on backends without those types (e.g. Skia). GamePad is used only as
+// the fully-qualified platform-neutral Gum.Input.GamePad holder.
 
 #if FRB
 namespace MonoGameGum.Forms;
@@ -68,7 +67,7 @@ public class FormsUtilities
 {
     static ICursor cursor;
 
-    public static Cursor? Cursor => cursor as Cursor;
+    public static ICursor Cursor => cursor;
 
     public static void SetCursor(ICursor cursor)
     {
@@ -76,9 +75,9 @@ public class FormsUtilities
         FrameworkElement.MainCursor = cursor;
     }
 
-    static Keyboard keyboard;
+    static IInputReceiverKeyboard keyboard;
 
-    public static Keyboard Keyboard => keyboard;
+    public static IInputReceiverKeyboard Keyboard => keyboard;
 
     // Typed explicitly as Gum.Input.GamePad (the platform-neutral holder in GumCommon) rather
     // than relying on the per-platform `using` so MonoGame, Raylib, and Sokol resolve to the
@@ -241,14 +240,14 @@ public class FormsUtilities
 #endif
         }
 
-#if XNALIKE
-        // The GameWindow-vs-nothing split lives entirely in Cursor's own platform-specific
-        // factories (Cursor.MonoGame.cs / Cursor.Raylib.cs); this #if only forwards the `game`
-        // parameter, which exists on this overload of InitializeDefaults but not the other.
-        cursor = Cursor.CreateForCurrentPlatform(game);
-#else
-        cursor = Cursor.CreateForCurrentPlatform();
-#endif
+        // Input creation is delegated to the active runtime's IGumService so this shared file no
+        // longer references any concrete per-platform input type (which lets it compile on backends
+        // that have no such types, e.g. Skia). The runtime's override bakes in whatever platform
+        // context it needs (e.g. MonoGame's Game/GameWindow for touch-offset math). Default is set
+        // before this method runs -- see each runtime's Initialize (ordering is asserted there) --
+        // and its input-capable runtimes return a non-null cursor/keyboard, hence the null-forgiveness.
+        IGumService service = IGumService.Default!;
+        cursor = service.CreateCursor()!;
 
 #if !FRB
         // This was added to MonoGame/raylib on 1/22/2026 to support
@@ -256,15 +255,7 @@ public class FormsUtilities
         ICursor.VisualOverBehavior = VisualOverBehavior.IfHasEventsIsTrue;
 #endif
 
-#if XNALIKE
-        // The MonoGame-vs-Raylib/Sokol split lives entirely in Keyboard's own platform-specific
-        // implementations (MonoGameGum/Input/Keyboard.cs vs Runtimes/RaylibGum|SokolGum/Input/Keyboard.cs);
-        // this #if only forwards the `game` parameter, which exists on this overload of
-        // InitializeDefaults but not the other.
-        keyboard = Keyboard.CreateForCurrentPlatform(game);
-#else
-        keyboard = Keyboard.CreateForCurrentPlatform();
-#endif
+        keyboard = service.CreateKeyboard()!;
 
         for (int i = 0; i < Gamepads.Length; i++)
         {
@@ -560,9 +551,9 @@ public class FormsUtilities
     {
         for (int i = 0; i < Gamepads.Length; i++)
         {
-            // GamePadDriver resolves per-platform via this file's top-of-file conditional
-            // `using` blocks (MonoGameGum.Input / Gum.Input) -- no #if needed here (issue #3559).
-            GamePadDriver.Apply(Gamepads[i], i, time);
+            // The per-frame gamepad driver is delegated to the active runtime's IGumService so this
+            // shared file references no concrete per-platform driver type (issue #3559 / Skia support).
+            IGumService.Default!.ApplyGamePadState(Gamepads[i], i, time);
         }
 
 #if FULL_DIAGNOSTICS

--- a/MonoGameGum/GumService.cs
+++ b/MonoGameGum/GumService.cs
@@ -135,12 +135,16 @@ public class GumService : IGumService
     /// <summary>
     /// Gets the default cursor, which represents either mouse or touch screen depending on hardware capabilities.
     /// </summary>
-    public Cursor Cursor => FormsUtilities.Cursor;
+    // 'as' (not a hard cast) preserves the prior null-on-mismatch behavior: tests may install a mock
+    // ICursor/IInputReceiverKeyboard via FormsUtilities.SetCursor, and this forwarder returned null for
+    // a non-Cursor before FormsUtilities.Cursor changed from 'Cursor?' to 'ICursor'. The '!' only
+    // suppresses the nullable-return warning (runtime no-op) and does not reintroduce a throw.
+    public Cursor Cursor => (FormsUtilities.Cursor as Cursor)!;
 
     /// <summary>
     /// Gets the default keyboard.
     /// </summary>
-    public Keyboard Keyboard => FormsUtilities.Keyboard;
+    public Keyboard Keyboard => (FormsUtilities.Keyboard as Keyboard)!;
 
     /// <summary>
     /// Gets the service used to provide localized strings and resources for the application.
@@ -172,6 +176,31 @@ public class GumService : IGumService
 
     /// <inheritdoc/>
     IRenderable IGumService.CreateSpriteRenderable() => Sprite.CreateForCurrentPlatform();
+
+    /// <inheritdoc/>
+    ICursor? IGumService.CreateCursor()
+    {
+#if XNALIKE
+        // MonoGame/KNI/FNA bake the Game (for its GameWindow) into the cursor for mobile touch-offset.
+        return Cursor.CreateForCurrentPlatform(_game);
+#elif RAYLIB
+        return Cursor.CreateForCurrentPlatform();
+#endif
+    }
+
+    /// <inheritdoc/>
+    IInputReceiverKeyboard? IGumService.CreateKeyboard()
+    {
+#if XNALIKE
+        return Keyboard.CreateForCurrentPlatform(_game);
+#elif RAYLIB
+        return Keyboard.CreateForCurrentPlatform();
+#endif
+    }
+
+    /// <inheritdoc/>
+    void IGumService.ApplyGamePadState(Gum.Input.GamePad gamepad, int index, double time) =>
+        GamePadDriver.Apply(gamepad, index, time);
 
 #if !IOS && !ANDROID
     private IGumHotReloadManager? _hotReloadManager;

--- a/RenderingLibrary/IGumService.cs
+++ b/RenderingLibrary/IGumService.cs
@@ -126,6 +126,32 @@ namespace RenderingLibrary
         /// </summary>
         IRenderable CreateSpriteRenderable();
 
+        /// <summary>
+        /// Creates the cursor (mouse or touch, depending on the platform's input capabilities) for the
+        /// active runtime. Called by <c>FormsUtilities.InitializeDefaults</c> so cursor creation no
+        /// longer references a concrete per-platform input type. Render-only hosts (e.g. the Skia
+        /// standalone service) inherit this default and return <c>null</c> — they have no input pump.
+        /// </summary>
+        ICursor? CreateCursor() => null;
+
+        /// <summary>
+        /// Creates the keyboard for the active runtime. Called by <c>FormsUtilities.InitializeDefaults</c>
+        /// so keyboard creation no longer references a concrete per-platform input type. Render-only hosts
+        /// inherit this default and return <c>null</c> — they have no input pump.
+        /// </summary>
+        IInputReceiverKeyboard? CreateKeyboard() => null;
+
+        /// <summary>
+        /// Applies the current OS gamepad state at <paramref name="index"/> to <paramref name="gamepad"/>
+        /// for the active runtime. This is a per-frame driver (not a create-once factory), called each
+        /// frame by <c>FormsUtilities.UpdateGamepads</c>. Render-only hosts inherit this default no-op —
+        /// they have no gamepad input source.
+        /// </summary>
+        /// <param name="gamepad">The platform-neutral gamepad holder to update.</param>
+        /// <param name="index">The zero-based gamepad index to sample.</param>
+        /// <param name="time">The total elapsed game time, in seconds.</param>
+        void ApplyGamePadState(Gum.Input.GamePad gamepad, int index, double time) { }
+
 #if NET6_0_OR_GREATER
         /// <summary>
         /// The current default <see cref="IGumService"/>. Assigned by the

--- a/Runtimes/SokolGum/GumService.cs
+++ b/Runtimes/SokolGum/GumService.cs
@@ -75,19 +75,29 @@ public sealed class GumService : IGumService
     /// <inheritdoc/>
     IRenderable IGumService.CreateSpriteRenderable() => new Gum.Renderables.Sprite();
 
+    /// <inheritdoc/>
+    ICursor? IGumService.CreateCursor() => Cursor.CreateForCurrentPlatform();
+
+    /// <inheritdoc/>
+    IInputReceiverKeyboard? IGumService.CreateKeyboard() => Keyboard.CreateForCurrentPlatform();
+
+    /// <inheritdoc/>
+    void IGumService.ApplyGamePadState(GamePad gamepad, int index, double time) =>
+        GamePadDriver.Apply(gamepad, index, time);
+
     #endregion
 
     /// <summary>
     /// Gets the default cursor, fed by Sokol mouse events forwarded via
     /// <see cref="HandleSokolEvent"/>.
     /// </summary>
-    public Cursor Cursor => FormsUtilities.Cursor!;
+    public Cursor Cursor => (FormsUtilities.Cursor as Cursor)!;
 
     /// <summary>
     /// Gets the default keyboard, fed by Sokol key / char events forwarded via
     /// <see cref="HandleSokolEvent"/>.
     /// </summary>
-    public Keyboard Keyboard => FormsUtilities.Keyboard;
+    public Keyboard Keyboard => (FormsUtilities.Keyboard as Keyboard)!;
 
     /// <summary>
     /// The popup root, which mirrors <c>FrameworkElement.PopupRoot</c> so callers

--- a/Samples/GumFormsSample/GumFormsSampleCommon/Screens/FrameworkElementExampleScreen.cs
+++ b/Samples/GumFormsSample/GumFormsSampleCommon/Screens/FrameworkElementExampleScreen.cs
@@ -414,7 +414,9 @@ namespace GumFormsSample.Screens
 
         public void Update(GameTime gameTime)
         {
-            var keyboard = FormsUtilities.Keyboard;
+            // FormsUtilities.Keyboard is typed as the platform-neutral IInputReceiverKeyboard now;
+            // cast to the concrete MonoGame Keyboard to use its XNA-Keys KeyPushed(Keys) overload.
+            var keyboard = (Gum.Input.Keyboard)FormsUtilities.Keyboard;
 
             if(keyboard.IsAltDown)
             {

--- a/Tests/MonoGameGum.Tests.V2/GumServiceInterfaceTests.cs
+++ b/Tests/MonoGameGum.Tests.V2/GumServiceInterfaceTests.cs
@@ -69,6 +69,19 @@ public class GumServiceInterfaceTests
     }
 
     [Fact]
+    public void IGumService_CreateCursor_OnXnaLikeRuntime_ReturnsNonNullCursor()
+    {
+        // The MonoGame GumService overrides the IGumService.CreateCursor default (which returns
+        // null on render-only hosts). FormsUtilities.InitializeDefaults creates the cursor through
+        // this service path, so this pins that the XNALIKE override is wired and non-null.
+        IGumService service = GumService.Default;
+
+        ICursor? cursor = service.CreateCursor();
+
+        cursor.ShouldNotBeNull();
+    }
+
+    [Fact]
     public void IGumService_Cursor_ReturnsServiceCursor()
     {
         IGumService service = GumService.Default;

--- a/Tests/MonoGameGum.Tests.V2/GumServiceUninitializeTests.cs
+++ b/Tests/MonoGameGum.Tests.V2/GumServiceUninitializeTests.cs
@@ -200,7 +200,7 @@ public class GumServiceUninitializeTests
     public void FormsUtilities_Uninitialize_SetsCursorToNull()
     {
         // Save state so we can restore it in teardown.
-        Cursor? savedCursor = FormsUtilities.Cursor;
+        ICursor? savedCursor = FormsUtilities.Cursor;
         InteractiveGue? savedPopupRoot = FrameworkElement.PopupRoot;
         InteractiveGue? savedModalRoot = FrameworkElement.ModalRoot;
 
@@ -222,7 +222,7 @@ public class GumServiceUninitializeTests
     [Fact]
     public void FormsUtilities_Uninitialize_SetsKeyboardToNull()
     {
-        Cursor? savedCursor = FormsUtilities.Cursor;
+        ICursor? savedCursor = FormsUtilities.Cursor;
         InteractiveGue? savedPopupRoot = FrameworkElement.PopupRoot;
         InteractiveGue? savedModalRoot = FrameworkElement.ModalRoot;
 
@@ -244,7 +244,7 @@ public class GumServiceUninitializeTests
     [Fact]
     public void FormsUtilities_Uninitialize_ResetsGamepadsToNewArray()
     {
-        Cursor? savedCursor = FormsUtilities.Cursor;
+        ICursor? savedCursor = FormsUtilities.Cursor;
         InteractiveGue? savedPopupRoot = FrameworkElement.PopupRoot;
         InteractiveGue? savedModalRoot = FrameworkElement.ModalRoot;
 
@@ -278,7 +278,7 @@ public class GumServiceUninitializeTests
     /// <c>InitializeDefaults</c> is the only public way to reinstate them.
     /// </remarks>
     private static void RestoreFormsUtilitiesState(
-        Cursor? cursor,
+        ICursor? cursor,
         InteractiveGue? popupRoot,
         InteractiveGue? modalRoot)
     {

--- a/Tests/MonoGameGum.TestsCommon/TestAssemblyInitializeBase.cs
+++ b/Tests/MonoGameGum.TestsCommon/TestAssemblyInitializeBase.cs
@@ -55,6 +55,11 @@ public class TestAssemblyInitializeBase : XunitTestFramework
         
         ElementSaveExtensions.CustomCreateGraphicalComponentFunc = RenderableCreator.HandleCreateGraphicalComponent;
 
+        // FormsUtilities.InitializeDefaults now creates the cursor/keyboard/gamepad driver through
+        // IGumService.Default, so the service must be the active default before that call -- exactly as
+        // the real runtime's Initialize orders it (IGumService.Default = this; before InitializeDefaults).
+        // Qualified as Gum.GumService (the modern, non-obsolete class) to stay warning-free.
+        IGumService.Default = Gum.GumService.Default;
 
         FormsUtilities.InitializeDefaults(defaultVisualsVersion: visualVersion);
         CreateStubbedFonts();

--- a/Tests/RaylibGum.Tests/TestAssemblyInitialize.cs
+++ b/Tests/RaylibGum.Tests/TestAssemblyInitialize.cs
@@ -66,6 +66,12 @@ public class TestAssemblyInitialize : XunitTestFramework
             ISystemManagers.Default = SystemManagers.Default;
         }
 
+        // FormsUtilities.InitializeDefaults now creates the cursor/keyboard/gamepad driver through
+        // IGumService.Default, so the service must be the active default before that call -- exactly as
+        // the real runtime's Initialize orders it (IGumService.Default = this; before InitializeDefaults).
+        // Qualified as Gum.GumService (the modern, non-obsolete class) to stay warning-free.
+        IGumService.Default = Gum.GumService.Default;
+
         // Registers V2 DefaultFormsTemplates (Button, ListBox, Slider, ComboBox, ...) so
         // parameterless Forms constructors produce a control with Visual != null on Raylib.
         FormsUtilities.InitializeDefaults(SystemManagers.Default, DefaultVisualsVersion.V2);


### PR DESCRIPTION
## What

Route Forms input creation (cursor / keyboard / gamepad) through `IGumService` so `MonoGameGum/Forms/FormsUtilities.cs` no longer references any concrete platform input type. Behavior-preserving for MonoGame / raylib / Sokol.

## Why

`FormsUtilities` created input by calling compile-time-resolved concrete platform types — `Cursor.CreateForCurrentPlatform`, `Keyboard.CreateForCurrentPlatform`, `GamePadDriver.Apply` — which resolve to whichever runtime's same-named class is compiled. Those types **don't exist on Skia** (a render-only backend; input comes from the host — Silk/SDL, WPF, MAUI), so the shared file couldn't compile there. `#if`-gating the input pieces would sprinkle conditional compilation over what is really a missing abstraction.

This is the first slice of **ADR 0006** (included): grow `IGumService` into the single runtime-capability checklist a new backend implements, migrating the scattered per-runtime hooks onto it incrementally.

## Changes

- **`RenderingLibrary/IGumService.cs`** (GumCommon): add three **default interface methods** — `ICursor? CreateCursor() => null`, `IInputReceiverKeyboard? CreateKeyboard() => null`, `void ApplyGamePadState(GamePad, int, double) { }`. Render-only hosts inherit the no-input defaults and keep compiling without overrides. `Create*` (create-once) vs `Apply*` (per-frame driver) is the intentional naming split.
- **`MonoGameGum/GumService.cs`** (XNALIKE + RAYLIB) and **`Runtimes/SokolGum/GumService.cs`**: override the three — the platform `#if` moves *out* of the shared `FormsUtilities` and *into* each runtime's service (MonoGame bakes in `_game`; raylib/Sokol parameterless).
- **`FormsUtilities.cs`**: `Cursor` → `ICursor`, `keyboard`/`Keyboard` → `IInputReceiverKeyboard`; `InitializeDefaults`/`UpdateGamepads` consume `IGumService.Default`; concrete forwarders (`GumService.Cursor`/`Keyboard`) cast via `(x as T)!` to preserve prior null-on-mismatch behavior.
- Test harnesses set `IGumService.Default` before `InitializeDefaults` (mirrors runtime ordering); new characterization test pins that the MonoGame service's `CreateCursor()` returns non-null.
- **ADR 0006** records the direction.

## Verification

- `MonoGameGum.Tests` (1838) ✅, `MonoGameGum.Tests.V2` (121) ✅, `SkiaGum.Tests` (204) ✅
- Builds: `KniGum`, `RaylibGum`(+Tests), `SkiaGum`, `SkiaGum.Wpf` ✅ — zero new warnings
- **FRB:** none of the changed files are compiled by FlatRedBall (`IGumService.cs` is not in `GumCoreShared.projitems`; `FormsUtilities.cs`/`GumService.cs` are not in FRB's Forms shared project, which pulls only `Forms/Controls/*`), and the interfaces FRB does use (`ICursor`/`IInputReceiverKeyboard`) are unchanged — so FRB is unaffected.

Prep for #3561 (Part of #3543 / #2738). The follow-up PR links `FormsUtilities` into SkiaGum and closes #3561.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
