### PR TITLE
Make SkiaResourceManager caches thread-safe (ConcurrentDictionary)

### DIFF
--- a/Runtimes/SkiaGum/Content/SkiaResourceManager.cs
+++ b/Runtimes/SkiaGum/Content/SkiaResourceManager.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.IO;
 using System.Reflection;
 using SkiaSharp;
@@ -23,7 +23,7 @@ public static class SkiaResourceManager
 
     #region SVG caching
 
-    private static Dictionary<string, SKSvg> svgCache;
+    private static ConcurrentDictionary<string, SKSvg> svgCache;
 
     public static bool ContainsSvg(string name) => svgCache.ContainsKey(name);
 
@@ -47,7 +47,7 @@ public static class SkiaResourceManager
             using var fileStream = System.IO.File.OpenRead(absoluteFile);
             SKSvg svg = new SKSvg();
             svg.Load(fileStream);
-            svgCache.Add(resourceName, svg);
+            svgCache[resourceName] = svg;
         }
         else
         {
@@ -64,7 +64,7 @@ public static class SkiaResourceManager
                 {
                     throw new Exception($"Error loading SVG {resourceName}\n{e}");
                 }
-                svgCache.Add(resourceName, svg);
+                svgCache[resourceName] = svg;
             }
         }
     }
@@ -78,7 +78,7 @@ public static class SkiaResourceManager
 
     #region Lottie Animation Caching
 
-    private static Dictionary<string, Animation> animationCache;
+    private static ConcurrentDictionary<string, Animation> animationCache;
 
     public static Animation GetLottieAnimation(string resourceName)
     {
@@ -103,7 +103,7 @@ public static class SkiaResourceManager
             {
                 throw new Exception($"Error loading Animation {resourceName}\n{e}");
             }
-            animationCache.Add(resourceName, animation);
+            animationCache[resourceName] = animation;
         }
     }
 
@@ -111,7 +111,7 @@ public static class SkiaResourceManager
 
     #region SKBitmap caching
 
-    private static Dictionary<string, SKBitmap> skBitmapCache = new Dictionary<string, SKBitmap>();
+    private static ConcurrentDictionary<string, SKBitmap> skBitmapCache = new ConcurrentDictionary<string, SKBitmap>();
 
     public static bool IsCached(string resourceName) => skBitmapCache.ContainsKey(resourceName);
 
@@ -151,7 +151,7 @@ public static class SkiaResourceManager
     }
 
 
-    public static SKBitmap GetSKBitmap(string resourceName, Stream stream = null)
+    public static SKBitmap GetSKBitmap(string resourceName, Stream? stream = null)
     {
         if (!skBitmapCache.ContainsKey(resourceName))
             CacheSKImage(resourceName);
@@ -174,7 +174,7 @@ public static class SkiaResourceManager
         {
             using var fileStream = System.IO.File.OpenRead(absoluteFile);
             var decoded = SKBitmap.Decode(fileStream);
-            skBitmapCache.Add(resourceName, decoded);
+            skBitmapCache[resourceName] = decoded;
         }
         else
         {
@@ -183,7 +183,7 @@ public static class SkiaResourceManager
             resourceName, ResourceAssembly))
             {
                 var decoded = SKBitmap.Decode(stream);
-                skBitmapCache.Add(resourceName, decoded);
+                skBitmapCache[resourceName] = decoded;
             }
         }
     }
@@ -194,7 +194,7 @@ public static class SkiaResourceManager
 
     #region Font caching
 
-    private static Dictionary<int, SKTypeface> typefaceCache;
+    private static ConcurrentDictionary<int, SKTypeface> typefaceCache;
 
     public enum TypefaceType
     {
@@ -264,9 +264,9 @@ public static class SkiaResourceManager
         if(IsInitialized == false)
         {
             IsInitialized = true;
-            svgCache = new Dictionary<string, SKSvg>();
-            animationCache = new Dictionary<string, Animation>();
-            typefaceCache = new Dictionary<int, SKTypeface>();
+            svgCache = new ConcurrentDictionary<string, SKSvg>();
+            animationCache = new ConcurrentDictionary<string, Animation>();
+            typefaceCache = new ConcurrentDictionary<int, SKTypeface>();
 
             foreach (int i in Enum.GetValues(typeof(TypefaceType)))
             {

--- a/Tests/SkiaGum.Tests/Content/SkiaResourceManagerTests.cs
+++ b/Tests/SkiaGum.Tests/Content/SkiaResourceManagerTests.cs
@@ -3,6 +3,7 @@ using SkiaSharp;
 using Shouldly;
 using System;
 using System.IO;
+using System.Threading.Tasks;
 using ToolsUtilities;
 using Xunit;
 
@@ -10,6 +11,61 @@ namespace SkiaGum.Tests.Content;
 
 public class SkiaResourceManagerTests
 {
+    // Regression for #3609: the SKBitmap cache used to be a plain, non-concurrent
+    // Dictionary. xUnit runs test classes in parallel, so concurrent GetSKBitmap
+    // calls raced on the Dictionary's internal state during a resize, and a
+    // just-inserted key could read back as missing → KeyNotFoundException. Hammer
+    // the shared static cache from many threads with distinct keys (which forces
+    // adds + resizes) to expose the race; a thread-safe cache loads every bitmap
+    // without throwing.
+    [Fact]
+    public void GetSKBitmap_ConcurrentAccessWithDistinctKeys_ShouldNotCorruptCache()
+    {
+        string tempRoot = Path.Combine(Path.GetTempPath(), "GumSkiaResMgrConcTest_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempRoot);
+
+        string savedRelativeDirectory = FileManager.RelativeDirectory;
+
+        try
+        {
+            const int fileCount = 500;
+            string[] absolutePaths = new string[fileCount];
+            for (int i = 0; i < fileCount; i++)
+            {
+                string absolutePath = Path.Combine(tempRoot, "conc_" + i + ".png");
+                using (SKBitmap source = new SKBitmap(2, 2))
+                using (SKImage image = SKImage.FromBitmap(source))
+                using (SKData encoded = image.Encode(SKEncodedImageFormat.Png, 100))
+                using (FileStream fileStream = File.OpenWrite(absolutePath))
+                {
+                    encoded.SaveTo(fileStream);
+                }
+                absolutePaths[i] = absolutePath;
+            }
+
+            FileManager.RelativeDirectory = tempRoot + Path.DirectorySeparatorChar;
+
+            ParallelOptions options = new ParallelOptions
+            {
+                MaxDegreeOfParallelism = Math.Max(4, Environment.ProcessorCount * 2)
+            };
+
+            Parallel.For(0, fileCount, options, i =>
+            {
+                SKBitmap loaded = SkiaResourceManager.GetSKBitmap(absolutePaths[i]);
+                loaded.ShouldNotBeNull();
+            });
+        }
+        finally
+        {
+            FileManager.RelativeDirectory = savedRelativeDirectory;
+            if (Directory.Exists(tempRoot))
+            {
+                Directory.Delete(tempRoot, recursive: true);
+            }
+        }
+    }
+
     // Regression: CacheSKImage used to do `RelativeDirectory + resourceName`
     // unconditionally, so any caller passing an already-absolute path (e.g.
     // AnimationFrame.ToAnimationFrame, which pre-prefixes RelativeDirectory


### PR DESCRIPTION
Closes #3609.

## Problem

`SkiaResourceManager`'s static caches (`skBitmapCache`, `svgCache`, `animationCache`, `typefaceCache`) were plain, non-concurrent `Dictionary`s accessed via a check-then-add-then-index pattern (`GetSKBitmap` etc.). xUnit runs test classes in parallel, so concurrent calls raced on a `Dictionary`'s internal state during a resize — a just-inserted key could read back as missing, throwing the intermittent `KeyNotFoundException` seen on CI.

## Fix

- Swap all four caches to `ConcurrentDictionary`.
- Replace `.Add(key, value)` with indexer assignment (`ConcurrentDictionary` has no public `.Add`). A same-key race now yields a benign redundant load instead of the `ArgumentException` the old `.Add` would throw.
- Boyscout: drop the now-unused `System.Collections.Generic` using; annotate `GetSKBitmap(..., Stream? stream = null)` to clear its pre-existing CS8625.

## Test

Added `GetSKBitmap_ConcurrentAccessWithDistinctKeys_ShouldNotCorruptCache`, a stress test that hammers the shared cache from many threads with distinct keys. It was **reliably red 5/5** on the old code (reproducing the exact `KeyNotFoundException`) and is **green 3/3** after the fix. Full `SkiaGum.Tests` suite: 206/206.

## Not included (flagged separately in the issue)

The issue also noted an unrelated masked-CI problem — `build-and-test.yaml`'s "Build Generated Code Projects" step chains ~6 `dotnet build`s so a mid-script failure is swallowed. That's a separate CI-plumbing concern and is intentionally left out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
