### PR TITLE
Fix CI masking mid-block build failures in codegen build step

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -202,23 +202,42 @@ jobs:
       - name: Build Generated Code Projects (Windows Only)
         if: (github.event_name != 'push' || steps.cache-workloads.outputs.cache-hit != 'true') && runner.os == 'Windows'
         run: |
+          # Note: the Maui project is built by csproj (not its .sln) with --framework
+          # rather than -p:TargetFrameworks=. A -p: override on a solution build is a
+          # global MSBuild property that leaks into every project in the graph — it
+          # forced GumCommon's own <TargetFrameworks>net8.0</TargetFrameworks> to
+          # net9.0-windows10.0.19041.0 too, breaking the SkiaGum.Maui -> SkiaGum ->
+          # GumCommon reference chain. --framework on the csproj scopes the TFM
+          # selection to just that project via the SDK's outer/inner multi-target build.
           dotnet restore "Tests/CodeGen_Maui_FullCodegen/CodeGen_Maui_FullCodegen.sln" --verbosity quiet
-          dotnet build "Tests/CodeGen_Maui_FullCodegen/CodeGen_Maui_FullCodegen.sln" --configuration Debug --no-restore --verbosity quiet -p:WarningLevel=0 -p:TargetFrameworks=net9.0-windows10.0.19041.0
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          dotnet build "Tests/CodeGen_Maui_FullCodegen/CodeGen_Maui_FullCodegen.csproj" --configuration Debug --no-restore --verbosity quiet -p:WarningLevel=0 --framework net9.0-windows10.0.19041.0
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
           dotnet restore "Tests/CodeGen_MonoGame_ByReference/CodeGen_MonoGame_ByReference.sln" --verbosity quiet
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           dotnet build "Tests/CodeGen_MonoGame_ByReference/CodeGen_MonoGame_ByReference.sln" --configuration Debug --no-restore --verbosity quiet -p:WarningLevel=0
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
           dotnet restore "Tests/CodeGen_MonoGameForms_ByReference/CodeGenProject.sln" --verbosity quiet
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           dotnet build "Tests/CodeGen_MonoGameForms_ByReference/CodeGenProject.sln" --configuration Debug --no-restore --verbosity quiet -p:WarningLevel=0
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
           dotnet restore "Tests/CodeGen_MonoGameForms_Localization_ByReference/CodeGen_MonoGameForms_Localization_ByReference.csproj" --verbosity quiet
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           dotnet build "Tests/CodeGen_MonoGameForms_Localization_ByReference/CodeGen_MonoGameForms_Localization_ByReference.csproj" --configuration Debug --no-restore --verbosity quiet -p:WarningLevel=0
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
           dotnet restore "Tests/CodeGen_MonoGameForms_FullCodegen/CodeGen_MonoGameForms_FullCodegen.sln" --verbosity quiet
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           dotnet build "Tests/CodeGen_MonoGameForms_FullCodegen/CodeGen_MonoGameForms_FullCodegen.sln" --configuration Debug --no-restore --verbosity quiet -p:WarningLevel=0
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
           dotnet restore "Tests/CodeGen_Raylib_ByReference/CodeGen_Raylib_ByReference.sln" --verbosity quiet
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           dotnet build "Tests/CodeGen_Raylib_ByReference/CodeGen_Raylib_ByReference.sln" --configuration Debug --no-restore --verbosity quiet -p:WarningLevel=0
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
       # ---------------------------------------------------------------------
       # Test allow-list policy


### PR DESCRIPTION
## Summary
- `Build Generated Code Projects (Windows Only)` chained 6 `dotnet restore`/`dotnet build` pairs in one PowerShell block with no per-command exit-code check, so only the *last* build's exit code gated the step — earlier failures were silently swallowed.
- Added an explicit `if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }` guard after every restore/build, mirroring the sibling "Codegen Drift Check" step's pattern.
- Fixing the masking unmasked a real failure: the Maui codegen build forced `-p:TargetFrameworks=net9.0-windows10.0.19041.0` on the whole `.sln` build. That's a global MSBuild property, so it also silently overrode `GumCommon`'s own `<TargetFrameworks>net8.0</TargetFrameworks>`, breaking the `SkiaGum.Maui -> SkiaGum -> GumCommon` reference chain (`GumCommon.csproj targets 'net9.0-windows10.0.19041.0'. It cannot be referenced by a project that targets '.NETCoreApp,Version=v9.0'`).
- Fixed by building the Maui `.csproj` directly (not its `.sln`) with `--framework net9.0-windows10.0.19041.0` instead of `-p:TargetFrameworks=`. `--framework` triggers the SDK's outer/inner multi-target build, which scopes the TFM selection to just that one project instead of leaking as a global property across the whole solution's project graph.

## Verification
Reproduced the exact fixed `run:` block locally via `pwsh` (extracted from the workflow file), including a clean `obj`/`bin` restore+build of the Maui codegen project — full step passes end-to-end. Also confirmed the exit-code guard actually halts and propagates failure on a deliberately-broken build.

Closes #3611
