### PR TITLE
Bump Apos.Shapes / Apos.Shapes.KNI to 0.6.10-alpha

### DIFF
--- a/Runtimes/GumShapes/KniGumShapes.csproj
+++ b/Runtimes/GumShapes/KniGumShapes.csproj
@@ -46,7 +46,7 @@
 			ProjectReference path: see the Content item below). 'compile' and 'runtime' are
 			deliberately NOT in the list, so the Apos.Shapes.KNI DLL still flows to consumers.
 		-->
-		<PackageReference Include="Apos.Shapes.KNI" Version="0.6.9-alpha"
+		<PackageReference Include="Apos.Shapes.KNI" Version="0.6.10-alpha"
 		                  PrivateAssets="contentfiles;analyzers;build;buildTransitive" />
 		<PackageReference Include="nkast.Xna.Framework" Version="4.2.9001" PrivateAssets="All" />
 		<PackageReference Include="nkast.Xna.Framework.Content" Version="4.2.9001" PrivateAssets="All" />

--- a/Runtimes/GumShapes/MonoGameGumShapes.csproj
+++ b/Runtimes/GumShapes/MonoGameGumShapes.csproj
@@ -46,7 +46,7 @@
 			ProjectReference path: see the Content item below). 'compile' and 'runtime' are
 			deliberately NOT in the list, so the Apos.Shapes DLL still flows to consumers.
 		-->
-		<PackageReference Include="Apos.Shapes" Version="0.6.9-alpha"
+		<PackageReference Include="Apos.Shapes" Version="0.6.10-alpha"
 		                  PrivateAssets="contentfiles;analyzers;build;buildTransitive" />
 		<PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.4.1" PrivateAssets="All" />
 	</ItemGroup>

--- a/Runtimes/GumShapes/XnbBuilder/XnbBuilderBlazorGL/XnbBuilderBlazorGL.csproj
+++ b/Runtimes/GumShapes/XnbBuilder/XnbBuilderBlazorGL/XnbBuilderBlazorGL.csproj
@@ -16,7 +16,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Apos.Shapes.KNI" Version="0.6.9-alpha" />
+		<PackageReference Include="Apos.Shapes.KNI" Version="0.6.10-alpha" />
 		<PackageReference Include="nkast.Xna.Framework" Version="4.2.9001" />
 		<PackageReference Include="nkast.Xna.Framework.Content" Version="4.2.9001" />
 		<PackageReference Include="nkast.Xna.Framework.Graphics" Version="4.2.9001" />

--- a/Runtimes/GumShapes/XnbBuilder/XnbBuilderDesktopGL/XnbBuilderDesktopGL.csproj
+++ b/Runtimes/GumShapes/XnbBuilder/XnbBuilderDesktopGL/XnbBuilderDesktopGL.csproj
@@ -15,7 +15,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Apos.Shapes.KNI" Version="0.6.9-alpha" />
+		<PackageReference Include="Apos.Shapes.KNI" Version="0.6.10-alpha" />
 		<PackageReference Include="nkast.Xna.Framework" Version="4.2.9001" PrivateAssets="All" />
 		<PackageReference Include="nkast.Xna.Framework.Content" Version="4.2.9001" PrivateAssets="All" />
 		<PackageReference Include="nkast.Xna.Framework.Graphics" Version="4.2.9001" PrivateAssets="All" />

--- a/Runtimes/GumShapes/XnbBuilder/XnbBuilderDirectX/XnbBuilderDirectX.csproj
+++ b/Runtimes/GumShapes/XnbBuilder/XnbBuilderDirectX/XnbBuilderDirectX.csproj
@@ -15,7 +15,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Apos.Shapes.KNI" Version="0.6.9-alpha" />
+		<PackageReference Include="Apos.Shapes.KNI" Version="0.6.10-alpha" />
 		<PackageReference Include="nkast.Xna.Framework" Version="4.2.9001" PrivateAssets="All" />
 		<PackageReference Include="nkast.Xna.Framework.Content" Version="4.2.9001" PrivateAssets="All" />
 		<PackageReference Include="nkast.Xna.Framework.Graphics" Version="4.2.9001" PrivateAssets="All" />

--- a/Runtimes/GumShapes/XnbBuilder/XnbBuilderMonoGameDesktopGL/XnbBuilderMonoGameDesktopGL.csproj
+++ b/Runtimes/GumShapes/XnbBuilder/XnbBuilderMonoGameDesktopGL/XnbBuilderMonoGameDesktopGL.csproj
@@ -18,7 +18,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Apos.Shapes" Version="0.6.9-alpha" />
+		<PackageReference Include="Apos.Shapes" Version="0.6.10-alpha" />
 		<PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.4.1" />
 		<PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.4.1" />
 	</ItemGroup>

--- a/Runtimes/GumShapes/XnbBuilder/XnbBuilderMonoGameWindowsDX/XnbBuilderMonoGameWindowsDX.csproj
+++ b/Runtimes/GumShapes/XnbBuilder/XnbBuilderMonoGameWindowsDX/XnbBuilderMonoGameWindowsDX.csproj
@@ -18,7 +18,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Apos.Shapes" Version="0.6.9-alpha" />
+		<PackageReference Include="Apos.Shapes" Version="0.6.10-alpha" />
 		<PackageReference Include="MonoGame.Framework.WindowsDX" Version="3.8.4.1" />
 		<PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.4.1" />
 	</ItemGroup>


### PR DESCRIPTION
## Summary
- Bumps `Apos.Shapes` and `Apos.Shapes.KNI` PackageReference versions from `0.6.9-alpha` to `0.6.10-alpha` in all 7 csprojs that reference them (both shapes runtime csprojs and all 5 XnbBuilder helper csprojs used to produce the prebuilt `apos-shapes.xnb` shader files).

Closes #3603

## Test plan
- [x] `dotnet build Runtimes/GumShapes/MonoGameGumShapes.csproj` — 0 errors
- [x] `dotnet build Runtimes/GumShapes/KniGumShapes.csproj` — 0 errors
- Pure version-bump, no behavior change — no manual test needed.