### PR TITLE
Fix SyntaxVersionDetectionService's stale NuGet package names

### DIFF
--- a/Tests/Gum.ProjectServices.Tests/SyntaxVersionDetectionServiceTests.cs
+++ b/Tests/Gum.ProjectServices.Tests/SyntaxVersionDetectionServiceTests.cs
@@ -1,6 +1,7 @@
 using Gum.ProjectServices.CodeGeneration;
 using Shouldly;
 using System;
+using System.Collections.Generic;
 using System.IO;
 
 namespace Gum.ProjectServices.Tests;
@@ -421,6 +422,109 @@ public class SyntaxVersionDetectionServiceTests : IDisposable
 
     #endregion
 
+    #region NuGet PackageReference detection tests
+
+    [Theory]
+    [InlineData("Gum.MonoGame")]
+    [InlineData("Gum.KNI")]
+    [InlineData("Gum.FNA")]
+    [InlineData("Gum.SkiaSharp")]
+    [InlineData("Gum.raylib")]
+    [InlineData("Gum.sokol")]
+    [InlineData("Gum.SilkNet")]
+    public void ExtractPackageReferenceVersion_RealPublishedPackageId_ReturnsVersion(string packageId)
+    {
+        string csproj = $@"<Project Sdk=""Microsoft.NET.Sdk"">
+  <ItemGroup>
+    <PackageReference Include=""{packageId}"" Version=""2026.4.1"" />
+  </ItemGroup>
+</Project>";
+
+        string? result = SyntaxVersionDetectionService.ExtractPackageReferenceVersion(csproj, packageId);
+
+        result.ShouldNotBeNull();
+        result.ShouldBe("2026.4.1");
+    }
+
+    [Fact]
+    public void Detect_NuGetPackage_RealPackageId_MatchesAndLogsCacheMiss()
+    {
+        string nuGetCacheRoot = Path.Combine(_tempDirectory, "nuget-cache");
+        SyntaxVersionDetectionService sut = new SyntaxVersionDetectionService(_logger, nuGetCacheRoot);
+
+        string gameDir = Path.Combine(_tempDirectory, "game");
+        Directory.CreateDirectory(gameDir);
+
+        string csprojPath = Path.Combine(gameDir, "MyGame.csproj");
+        File.WriteAllText(csprojPath,
+@"<Project Sdk=""Microsoft.NET.Sdk"">
+  <ItemGroup>
+    <PackageReference Include=""Gum.MonoGame"" Version=""2026.4.1"" />
+  </ItemGroup>
+</Project>");
+
+        CodeOutputProjectSettings settings = new CodeOutputProjectSettings
+        {
+            SyntaxVersion = "*",
+            CodeProjectRoot = "./"
+        };
+
+        SyntaxVersionResult result = sut.Detect(settings, gameDir);
+
+        result.Source.ShouldBe(SyntaxVersionSource.Fallback);
+        _logger.OutputMessages.ShouldContain(message => message.Contains("Gum.MonoGame") && message.Contains("NuGet cache"));
+    }
+
+    [Fact]
+    public void FindDllInNuGetCache_DllNameDiffersFromPackageId_ReturnsDllPath()
+    {
+        string nuGetCacheRoot = Path.Combine(_tempDirectory, "nuget-cache");
+        string tfmDir = Path.Combine(nuGetCacheRoot, "gum.monogame", "2026.4.1", "lib", "net8.0");
+        Directory.CreateDirectory(tfmDir);
+        string dllPath = Path.Combine(tfmDir, "MonoGameGum.dll");
+        File.WriteAllText(dllPath, "");
+
+        SyntaxVersionDetectionService sut = new SyntaxVersionDetectionService(_logger, nuGetCacheRoot);
+
+        string? result = sut.FindDllInNuGetCache("Gum.MonoGame", "2026.4.1");
+
+        result.ShouldBe(dllPath);
+    }
+
+    [Fact]
+    public void FindDllInNuGetCache_PrefersHigherPriorityTfm()
+    {
+        string nuGetCacheRoot = Path.Combine(_tempDirectory, "nuget-cache");
+        string net6Dir = Path.Combine(nuGetCacheRoot, "gum.skiasharp", "1.0.0", "lib", "net6.0");
+        string net8Dir = Path.Combine(nuGetCacheRoot, "gum.skiasharp", "1.0.0", "lib", "net8.0");
+        Directory.CreateDirectory(net6Dir);
+        Directory.CreateDirectory(net8Dir);
+        File.WriteAllText(Path.Combine(net6Dir, "SkiaGum.dll"), "");
+        string net8DllPath = Path.Combine(net8Dir, "SkiaGum.dll");
+        File.WriteAllText(net8DllPath, "");
+
+        SyntaxVersionDetectionService sut = new SyntaxVersionDetectionService(_logger, nuGetCacheRoot);
+
+        string? result = sut.FindDllInNuGetCache("Gum.SkiaSharp", "1.0.0");
+
+        result.ShouldBe(net8DllPath);
+    }
+
+    [Fact]
+    public void FindDllInNuGetCache_PackageNotInCache_ReturnsNull()
+    {
+        string nuGetCacheRoot = Path.Combine(_tempDirectory, "nuget-cache");
+        Directory.CreateDirectory(nuGetCacheRoot);
+
+        SyntaxVersionDetectionService sut = new SyntaxVersionDetectionService(_logger, nuGetCacheRoot);
+
+        string? result = sut.FindDllInNuGetCache("Gum.raylib", "1.0.0");
+
+        result.ShouldBeNull();
+    }
+
+    #endregion
+
     public void Dispose()
     {
         try
@@ -435,7 +539,17 @@ public class SyntaxVersionDetectionServiceTests : IDisposable
 
     private class TestLogger : ICodeGenLogger
     {
-        public void PrintOutput(string message) { }
-        public void PrintError(string message) { }
+        public List<string> OutputMessages { get; } = new List<string>();
+        public List<string> ErrorMessages { get; } = new List<string>();
+
+        public void PrintOutput(string message)
+        {
+            OutputMessages.Add(message);
+        }
+
+        public void PrintError(string message)
+        {
+            ErrorMessages.Add(message);
+        }
     }
 }

--- a/Tools/Gum.ProjectServices/CodeGeneration/SyntaxVersionDetectionService.cs
+++ b/Tools/Gum.ProjectServices/CodeGeneration/SyntaxVersionDetectionService.cs
@@ -51,10 +51,23 @@ public enum SyntaxVersionSource
 public class SyntaxVersionDetectionService : ISyntaxVersionDetectionService
 {
     private readonly ICodeGenLogger _logger;
+    private readonly string _nuGetCacheRoot;
 
     public SyntaxVersionDetectionService(ICodeGenLogger logger)
+        : this(logger, nuGetCacheRoot: null)
+    {
+    }
+
+    /// <summary>
+    /// Test seam allowing the NuGet global-packages cache root to be overridden, so the
+    /// NuGet PackageReference detection path is testable without a populated ~/.nuget/packages.
+    /// </summary>
+    internal SyntaxVersionDetectionService(ICodeGenLogger logger, string? nuGetCacheRoot)
     {
         _logger = logger;
+        _nuGetCacheRoot = nuGetCacheRoot ?? Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+            ".nuget", "packages");
     }
 
     /// <inheritdoc/>
@@ -187,16 +200,16 @@ public class SyntaxVersionDetectionService : ISyntaxVersionDetectionService
 
     private SyntaxVersionResult? TryDetectFromNuGetPackage(string csprojContents)
     {
-        // Look for PackageReference to Gum runtime packages
+        // Look for PackageReference to Gum runtime packages (published NuGet package IDs)
         string[] gumPackageNames =
         {
-            "FlatRedBall.MonoGameGum",
-            "FlatRedBall.SkiaGum",
-            "FlatRedBall.RaylibGum",
-            // Also check non-FRB package names in case they're used
-            "MonoGameGum",
-            "SkiaGum",
-            "RaylibGum"
+            "Gum.MonoGame",
+            "Gum.KNI",
+            "Gum.FNA",
+            "Gum.SkiaSharp",
+            "Gum.raylib",
+            "Gum.sokol",
+            "Gum.SilkNet"
         };
 
         foreach (string packageName in gumPackageNames)
@@ -247,13 +260,9 @@ public class SyntaxVersionDetectionService : ISyntaxVersionDetectionService
         return match.Success ? match.Groups[1].Value : null;
     }
 
-    private static string? FindDllInNuGetCache(string packageName, string version)
+    internal string? FindDllInNuGetCache(string packageName, string version)
     {
-        string nugetCache = Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
-            ".nuget", "packages");
-
-        string packageDir = Path.Combine(nugetCache, packageName.ToLowerInvariant(), version, "lib");
+        string packageDir = Path.Combine(_nuGetCacheRoot, packageName.ToLowerInvariant(), version, "lib");
 
         if (!Directory.Exists(packageDir))
         {


### PR DESCRIPTION
## Summary
- `gumPackageNames` in `SyntaxVersionDetectionService.TryDetectFromNuGetPackage` held names that never match a real published package (`FlatRedBall.MonoGameGum`, bare `MonoGameGum`, etc.), so any NuGet consumer (as opposed to `ProjectReference`) always fell through to syntax-version 0 (Fallback).
- Replaced the list with the actual published package IDs: `Gum.MonoGame`, `Gum.KNI`, `Gum.FNA`, `Gum.SkiaSharp`, `Gum.raylib`, `Gum.sokol`, `Gum.SilkNet`.
- Added a `nuGetCacheRoot` test seam (internal ctor overload) so the NuGet PackageReference path — previously untested — is covered without a populated `~/.nuget/packages`.
- Verified `FindDllInNuGetCache` correctly locates the DLL when its filename differs from the package ID (e.g. `Gum.MonoGame` → `MonoGameGum.dll`) and respects TFM preference order.

Closes #3607

## Test plan
- [x] New tests added covering the real package IDs, `FindDllInNuGetCache` path resolution, and full `Detect()` NuGet flow
- [x] `dotnet test Tests/Gum.ProjectServices.Tests/Gum.ProjectServices.Tests.csproj` — 370 passed, 2 pre-existing skips, 0 failed
- [x] Confirmed the new regression test fails against the original stale array (reverted temporarily, re-ran, restored)
- Manual test: not needed — headless service logic fully covered by unit tests; no runtime/visual surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)
