### PR TITLE
Apply IsBold/IsItalic/OutlineThickness/Font BBCode tags on Raylib (converge onto MonoGame stack model)

### DIFF
--- a/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
+++ b/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
@@ -979,53 +979,14 @@ public class CustomSetPropertyOnRenderable
         var strippedText = BbCodeParser.RemoveTags(bbcode, resultsWithNewlines);
         asText.RawText = strippedText;
 
-        fontNameStack.Clear();
-
 #if FRB
         var textRuntime = graphicalUiElement;
 #else
         var textRuntime = graphicalUiElement as Gum.GueDeriving.TextRuntime;
 #endif
 
-        if(textRuntime != null)
-        {
-            if (textRuntime.UseCustomFont)
-            {
-                var customFont = textRuntime.CustomFontFile;
-                if (customFont?.EndsWith(".fnt") == true)
-                {
-                    customFont = customFont.Substring(0, customFont.Length - ".fnt".Length);
-                }
-                fontNameStack.Push(customFont);
-            }
-            else
-            {
-                fontNameStack.Push(textRuntime.Font);
-            }
-
-            fontSizeStack.Clear();
-            fontSizeStack.Push(textRuntime.FontSize);
-
-            outlineThicknessStack.Clear();
-            outlineThicknessStack.Push(textRuntime.OutlineThickness);
-
-            useFontSmoothingStack.Clear();
-            useFontSmoothingStack.Push(textRuntime.UseFontSmoothing);
-
-            isItalicStack.Clear();
-            isItalicStack.Push(textRuntime.IsItalic);
-
-            isBoldStack.Clear();
-            isBoldStack.Push(textRuntime.IsBold);
-
-            useCustomFontStack.Clear();
-            useCustomFontStack.Push(textRuntime.UseCustomFont);
-
-        }
-
-        var loaderManager = global::RenderingLibrary.Content.LoaderManager.Self;
-        var contentLoader = loaderManager.ContentLoader;
-
+        // Color / Red / Green / Blue / FontScale / Custom runs don't use the font-resolution stacks, so they
+        // are emitted regardless of whether the owning element is a TextRuntime.
         foreach (var item in resultsNoNewlines)
         {
             object castedValue = item.Open.Argument;
@@ -1116,7 +1077,58 @@ public class CustomSetPropertyOnRenderable
             }
         }
 
-        ApplyFontVariables(asText, resultsNoNewlines);
+        // Per-run font resolution requires the seven stacks to be seeded from a TextRuntime's base font
+        // values. A Text owned by a non-TextRuntime GraphicalUiElement has no such values, so we neither seed
+        // nor resolve here - otherwise ApplyFontVariables would peek/pop unseeded (stale or empty) stacks,
+        // giving a wrong font or an InvalidOperationException. One guard covers seeding and resolution; the
+        // text is still wrapped/measured below regardless. (Under #if FRB, textRuntime == graphicalUiElement,
+        // never null, so this guard is always-true and FRB behavior is unchanged - a pure structural move.)
+        if (textRuntime != null)
+        {
+            fontNameStack.Clear();
+            if (textRuntime.UseCustomFont)
+            {
+                var customFont = textRuntime.CustomFontFile;
+                if (customFont?.EndsWith(".fnt") == true)
+                {
+                    customFont = customFont.Substring(0, customFont.Length - ".fnt".Length);
+                }
+                fontNameStack.Push(customFont);
+            }
+            else
+            {
+                fontNameStack.Push(textRuntime.Font);
+            }
+
+            fontSizeStack.Clear();
+            fontSizeStack.Push(textRuntime.FontSize);
+
+            outlineThicknessStack.Clear();
+            outlineThicknessStack.Push(textRuntime.OutlineThickness);
+
+            useFontSmoothingStack.Clear();
+            useFontSmoothingStack.Push(textRuntime.UseFontSmoothing);
+
+            isItalicStack.Clear();
+            isItalicStack.Push(textRuntime.IsItalic);
+
+            isBoldStack.Clear();
+            isBoldStack.Push(textRuntime.IsBold);
+
+            useCustomFontStack.Clear();
+            useCustomFontStack.Push(textRuntime.UseCustomFont);
+
+            ApplyFontVariables(asText, resultsNoNewlines);
+        }
+
+        // #3481: RawText was assigned above (which wrapped + measured the text) before any InlineVariables
+        // existed, so that first pass was blind to inline [FontScale=N]/[FontSize=N] runs. Re-wrap first so
+        // line breaks account for an enlarged run's real size (#3520), then re-measure so the reported size
+        // accounts for per-line scale (#3481) — otherwise a tall run overflows its slot and overlaps the
+        // next stacked sibling, or a wide run spills past a fixed wrap width. Runs unconditionally (the text
+        // must wrap whether or not per-run fonts were resolved).
+        asText.UpdateWrappedText();
+        asText.UpdatePreRenderDimensions();
     }
 
     private static void ApplyFontVariables(Text asText, List<FoundTag> results)
@@ -1262,15 +1274,6 @@ public class CustomSetPropertyOnRenderable
         {
             lastFontInlineVariable.CharacterCount = asText.RawText.Length - lastFontInlineVariable.StartIndex;
         }
-
-        // #3481: RawText was assigned above (which wrapped + measured the text) before any InlineVariables
-        // existed, so that first pass was blind to inline [FontScale=N]/[FontSize=N] runs. Re-wrap first so
-        // line breaks account for an enlarged run's real size (#3520), then re-measure so the reported size
-        // accounts for per-line scale (#3481) — otherwise a tall run overflows its slot and overlaps the
-        // next stacked sibling, or a wide run spills past a fixed wrap width.
-        asText.UpdateWrappedText();
-        asText.UpdatePreRenderDimensions();
-
 
         BitmapFont GetAndCreateFontIfNecessary()
         {

--- a/MonoGameGum.Tests/Runtimes/TextRuntimeBbCodeFontCachingRegressionTests.cs
+++ b/MonoGameGum.Tests/Runtimes/TextRuntimeBbCodeFontCachingRegressionTests.cs
@@ -123,6 +123,27 @@ public class TextRuntimeBbCodeFontCachingRegressionTests : BaseTestClass
         }
     }
 
+    // #3624 regression: a Text owned by a GraphicalUiElement that is NOT a TextRuntime has unseeded font
+    // resolution stacks (SetBbCodeText seeds them only for a TextRuntime). Assigning font-family BBCode
+    // markup then drove ApplyFontVariables to peek/pop those unseeded stacks - an InvalidOperationException
+    // ("Stack empty"), or a wrong font from stale static state. The single guard must skip per-run font
+    // resolution in that case while still stripping the tags and wrapping the text.
+    [Fact]
+    public void SetBbCodeText_WithNonTextRuntimeOwner_DoesNotThrowOrResolveFonts()
+    {
+        // A real Text renderable, but driven through a base GraphicalUiElement (not a TextRuntime).
+        TextRuntime source = new();
+        Text text = (Text)source.RenderableComponent;
+        GraphicalUiElement nonTextRuntimeOwner = new();
+
+        Should.NotThrow(() => CustomSetPropertyOnRenderable.SetPropertyOnRenderable(
+            text, nonTextRuntimeOwner, "Text", "[IsBold=true]Hello[/IsBold] World"));
+
+        text.RawText.ShouldBe("Hello World");
+        // No TextRuntime to seed the stacks, so no resolved-font ("BitmapFont") runs are produced.
+        text.InlineVariables.ShouldNotContain(v => v.VariableName == "BitmapFont");
+    }
+
     // A unique relative directory makes the (absolute) font-cache key unique to this run so no prior
     // test can mask the collision and this test cannot poison a shared slot.
     private static string MakeUniqueRelativeDirectory() =>

--- a/Runtimes/RaylibGum/Renderables/CustomSetPropertyOnRenderable.cs
+++ b/Runtimes/RaylibGum/Renderables/CustomSetPropertyOnRenderable.cs
@@ -42,11 +42,16 @@ using Gum.ToolStates;
 #if RAYLIB
 using Gum.Renderables;
 using Gum.GueDeriving;
+// The font a BBCode font-run resolves to. On Raylib that is a Raylib_cs.Font; on the XNA-family
+// backends it is a BitmapFont. Mirrored #if so the shared BBCode stack-resolution loop below stays
+// type-neutral (see ApplyFontVariables) - only the font-CREATION body is platform-gated.
+using ResolvedFont = Raylib_cs.Font;
 namespace RaylibGum.Renderables;
 #else
 using Gum.Graphics.Animation;
 using RenderingLibrary.Math.Geometry;
 using Microsoft.Xna.Framework.Graphics;
+using ResolvedFont = RenderingLibrary.Graphics.BitmapFont;
 namespace Gum.Wireframe;
 #endif
 
@@ -685,11 +690,26 @@ public class CustomSetPropertyOnRenderable
         return handled;
     }
 
+    // The seven font-resolution stacks (mirroring the MonoGame path). Inline [FontSize]/[IsBold]/etc. tags
+    // push their value on open and pop on close, so a run resolves to the font implied by every tag currently
+    // open over it - the whole reason nested markup needs a stack rather than a flat lookup.
+    static Stack<int> fontSizeStack = new Stack<int>();
+    static Stack<string> fontNameStack = new Stack<string>();
+    static Stack<int> outlineThicknessStack = new Stack<int>();
+    static Stack<bool> useFontSmoothingStack = new Stack<bool>();
+    static Stack<bool> isItalicStack = new Stack<bool>();
+    static Stack<bool> isBoldStack = new Stack<bool>();
+    static Stack<bool> useCustomFontStack = new Stack<bool>();
+
+    static List<TagInfo> allTags = new List<TagInfo>();
+
     /// <summary>
     /// Parses BBCode markup, assigns the tag-stripped text to <see cref="Text.RawText"/>, and populates
-    /// <see cref="Text.InlineVariables"/> with the Color / FontScale / FontSize runs the Raylib renderer
-    /// applies per run. [Font=Name] family swaps and Custom per-letter tags are recognized (so their tags
-    /// are stripped from the visible text) but are not yet applied on the Raylib runtime - see #3471 / #3524.
+    /// <see cref="Text.InlineVariables"/> with the per-run styling the Raylib renderer applies: Color / Red /
+    /// Green / Blue and FontScale runs in the loop below, plus the resolved-font runs for the font family
+    /// tags (Font / FontSize / OutlineThickness / IsBold / IsItalic) produced by
+    /// <see cref="ApplyFontVariables"/> using the same stack model as the MonoGame path. Custom per-letter
+    /// callbacks are recognized (stripped) but not yet applied on the Raylib runtime (#3471).
     /// </summary>
     private static void SetBbCodeText(Text asText, GraphicalUiElement graphicalUiElement, string bbcode)
     {
@@ -702,6 +722,50 @@ public class CustomSetPropertyOnRenderable
         var strippedText = BbCodeParser.RemoveTags(normalized, results);
 
         asText.RawText = strippedText;
+
+#if FRB
+        var textRuntime = graphicalUiElement;
+#else
+        var textRuntime = graphicalUiElement as Gum.GueDeriving.TextRuntime;
+#endif
+
+        // Seed the font-resolution stacks with the element's base font values so ApplyFontVariables can
+        // push/pop inline overrides on top of them.
+        if (textRuntime != null)
+        {
+            fontNameStack.Clear();
+            if (textRuntime.UseCustomFont)
+            {
+                var customFont = textRuntime.CustomFontFile;
+                if (customFont?.EndsWith(".fnt") == true)
+                {
+                    customFont = customFont.Substring(0, customFont.Length - ".fnt".Length);
+                }
+                fontNameStack.Push(customFont);
+            }
+            else
+            {
+                fontNameStack.Push(textRuntime.Font);
+            }
+
+            fontSizeStack.Clear();
+            fontSizeStack.Push(textRuntime.FontSize);
+
+            outlineThicknessStack.Clear();
+            outlineThicknessStack.Push(textRuntime.OutlineThickness);
+
+            useFontSmoothingStack.Clear();
+            useFontSmoothingStack.Push(textRuntime.UseFontSmoothing);
+
+            isItalicStack.Clear();
+            isItalicStack.Push(textRuntime.IsItalic);
+
+            isBoldStack.Clear();
+            isBoldStack.Push(textRuntime.IsBold);
+
+            useCustomFontStack.Clear();
+            useCustomFontStack.Push(textRuntime.UseCustomFont);
+        }
 
         foreach (var item in results)
         {
@@ -740,26 +804,9 @@ public class CustomSetPropertyOnRenderable
                         }
                     }
                     break;
-                case "FontSize":
-                    {
-                        // #3524: [FontSize=N] swaps the font for the run to one rasterized at N (matching
-                        // the MonoGame BitmapFont swap). When a font creator is wired we re-rasterize a
-                        // crisp Raylib_cs.Font at N and store it as the run value; the run then draws with
-                        // that font at its native size. When no creator is available, store the raw size as
-                        // a float and let Text scale the base atlas to N (a blurry-but-correct fallback).
-                        // Either way Text measures the run at exactly the size it draws.
-                        if (int.TryParse(item.Open.Argument, NumberStyles.Integer, CultureInfo.InvariantCulture, out int parsedSize))
-                        {
-                            var textRuntime = graphicalUiElement as TextRuntime;
-                            Raylib_cs.Font? swapFont = textRuntime != null
-                                ? TryGetOrCreateFontAtSize(textRuntime, parsedSize)
-                                : null;
-                            castedValue = swapFont.HasValue ? (object)swapFont.Value : (float)parsedSize;
-                            shouldApply = true;
-                        }
-                    }
-                    break;
-                    // Font / Custom / IsBold family swaps are still not handled here (deferred per #3471).
+                    // Font / FontSize / OutlineThickness / IsBold / IsItalic family swaps are handled below in
+                    // ApplyFontVariables (stack model), not here. Custom per-letter callbacks are stripped but
+                    // not applied on the Raylib runtime yet (#3471).
             }
 
             if (shouldApply)
@@ -774,6 +821,141 @@ public class CustomSetPropertyOnRenderable
             }
         }
 
+        ApplyFontVariables(asText, results);
+    }
+
+    /// <summary>
+    /// Resolves the Font / FontSize / OutlineThickness / IsBold / IsItalic BBCode tags into per-run
+    /// resolved-font (<c>"BitmapFont"</c>) inline variables using a stack model: each open tag pushes its
+    /// value and each close tag pops it, so a run resolves to the font implied by every tag open over it.
+    /// The push/pop/sort/character-count loop is kept identical to the MonoGame path; only the font-CREATION
+    /// body (<see cref="GetAndCreateFontIfNecessary"/>) is platform-specific, since Raylib produces a
+    /// <see cref="Raylib_cs.Font"/> (or, with no creator, falls back to scaling the base atlas).
+    /// </summary>
+    private static void ApplyFontVariables(Text asText, List<FoundTag> results)
+    {
+        allTags.Clear();
+        allTags.AddRange(results.Select(item => item.Open));
+        allTags.AddRange(results.Select(item => item.Close));
+        allTags.Sort((a, b) => a.StartIndex - b.StartIndex);
+
+        InlineVariable lastFontInlineVariable = null;
+        foreach (var tag in allTags)
+        {
+            // The run's value: a resolved Raylib_cs.Font (crisp), or - for a [FontSize] tag with no font
+            // creator wired - the raw pixel size as a float (ResolveRunFont then scales the base atlas).
+            object castedValue = null;
+            string convertedName = "BitmapFont"; // shared historical run-marker name (see ResolvedFont note).
+            switch (tag.Name)
+            {
+                case "Font":
+                    if (!string.IsNullOrEmpty(tag.Argument))
+                    {
+                        // tolerate ".fnt" suffix
+                        var argument = tag.Argument;
+                        if (argument?.EndsWith(".fnt") == true)
+                        {
+                            argument = argument.Substring(0, argument.Length - ".fnt".Length);
+                        }
+                        fontNameStack.Push(argument);
+                    }
+                    else
+                    {
+                        fontNameStack.Pop();
+                    }
+                    castedValue = GetAndCreateFontIfNecessary();
+                    break;
+                case "FontSize":
+                    if (int.TryParse(tag.Argument, NumberStyles.Integer, CultureInfo.InvariantCulture, out int parsedSize))
+                    {
+                        fontSizeStack.Push(parsedSize);
+                        castedValue = GetAndCreateFontIfNecessary();
+                        // Platform-necessary Raylib fallback: with no font creator wired, no crisp font can be
+                        // rasterized at the requested size, so store the raw pixel size as a float and let the
+                        // renderer scale the base atlas to it (a blurry-but-correct approximation). The XNA
+                        // path never needs this - it can new BitmapFont(...) at any size.
+                        castedValue ??= (float)parsedSize;
+                    }
+                    else
+                    {
+                        fontSizeStack.Pop();
+                        castedValue = GetAndCreateFontIfNecessary();
+                    }
+                    break;
+                case "OutlineThickness":
+                    if (int.TryParse(tag.Argument, NumberStyles.Integer, CultureInfo.InvariantCulture, out int parsedOutline))
+                    {
+                        outlineThicknessStack.Push(parsedOutline);
+                    }
+                    else
+                    {
+                        outlineThicknessStack.Pop();
+                    }
+                    castedValue = GetAndCreateFontIfNecessary();
+                    break;
+                case "IsItalic":
+                    if (bool.TryParse(tag.Argument, out bool parsedItalic))
+                    {
+                        isItalicStack.Push(parsedItalic);
+                    }
+                    else
+                    {
+                        isItalicStack.Pop();
+                    }
+                    castedValue = GetAndCreateFontIfNecessary();
+                    break;
+                case "IsBold":
+                    if (bool.TryParse(tag.Argument, out bool parsedBold))
+                    {
+                        isBoldStack.Push(parsedBold);
+                    }
+                    else
+                    {
+                        isBoldStack.Pop();
+                    }
+                    castedValue = GetAndCreateFontIfNecessary();
+                    break;
+                case "UseCustomFont":
+                    // Never fires today (UseCustomFont is not a BbCodeParser.KnownTag), but the stack push/pop
+                    // is kept parallel to the MonoGame path for convergence.
+                    if (bool.TryParse(tag.Argument, out bool parsedCustom))
+                    {
+                        useCustomFontStack.Push(parsedCustom);
+                    }
+                    else
+                    {
+                        useCustomFontStack.Pop();
+                    }
+                    castedValue = GetAndCreateFontIfNecessary();
+                    break;
+            }
+
+            if (castedValue != null)
+            {
+                if (lastFontInlineVariable != null)
+                {
+                    lastFontInlineVariable.CharacterCount = tag.StartStrippedIndex - lastFontInlineVariable.StartIndex;
+                }
+
+                var inlineVariable = new InlineVariable
+                {
+                    StartIndex = tag.StartStrippedIndex,
+                    VariableName = convertedName,
+                    Value = castedValue
+                };
+
+                asText.InlineVariables.Add(inlineVariable);
+
+                lastFontInlineVariable = inlineVariable;
+            }
+        }
+
+        // Close off the last font run so it extends to the end of the text.
+        if (lastFontInlineVariable != null)
+        {
+            lastFontInlineVariable.CharacterCount = asText.RawText.Length - lastFontInlineVariable.StartIndex;
+        }
+
         // #3481/#3532: RawText was assigned above (which wrapped + measured the text) before any
         // InlineVariables existed, so that first pass was blind to inline [FontScale=N]/[FontSize=N]
         // runs. Re-wrap first so line breaks account for an enlarged run's real size (#3532), then
@@ -782,96 +964,119 @@ public class CustomSetPropertyOnRenderable
         // wrap width. Mirrors the MonoGame Gum/Wireframe/CustomSetPropertyOnRenderable.cs.
         asText.UpdateWrappedText();
         asText.UpdatePreRenderDimensions();
+
+        // Creates (or returns a cached) resolved font for the current stack state. Only the font-CREATION
+        // body is platform-specific; everything above is shared with the MonoGame path. Returns null when no
+        // creator is wired or creation fails - the caller then leaves the range at the base font (no run) or,
+        // for a [FontSize] tag, falls back to scaling the base atlas. Preserves the Dispose-then-AddDisposable
+        // cache-heal from the former TryGetOrCreateFontAtSize.
+        ResolvedFont? GetAndCreateFontIfNecessary()
+        {
+            // Raylib can only produce a crisp font for the current stack state via a wired IRaylibFontCreator
+            // (it cannot `new BitmapFont(file)` the way the XNA path does). The Raylib path always uses the
+            // FontCache key/creator - it does not branch on useCustomFontStack (matching the pre-#3624
+            // behavior, where custom fonts were not re-generated per inline run).
+            if (InMemoryFontCreator == null || fontSizeStack.Peek() <= 0)
+            {
+                return null;
+            }
+
+            var loaderManager = global::RenderingLibrary.Content.LoaderManager.Self;
+
+            try
+            {
+                string fontName = fontNameStack.Peek();
+                string? bbCodeFontFilePath = BmfcSave.IsFontFilePath(fontName) ? fontName : null;
+
+                string fontCacheName = BmfcSave.GetFontCacheFileNameFor(
+                    fontSizeStack.Peek(),
+                    fontName,
+                    outlineThicknessStack.Peek(),
+                    useFontSmoothingStack.Peek(),
+                    isItalicStack.Peek(),
+                    isBoldStack.Peek(),
+                    bbCodeFontFilePath);
+                string fullFileName = ToolsUtilities.FileManager.Standardize(fontCacheName, preserveCase: true, makeAbsolute: true);
+
+                // Reuse an already-generated font (its Raylib_cs.Font wraps an unmanaged GPU texture, so
+                // regenerating every layout would leak VRAM). Mirrors the base-font cache check.
+                if (loaderManager.GetDisposable(fullFileName) is ManagedFont cachedManagedFont
+                    && cachedManagedFont.Font.BaseSize != 0)
+                {
+                    return cachedManagedFont.Font;
+                }
+
+                BmfcSave bmfcSave = new BmfcSave();
+                bmfcSave.FontSize = fontSizeStack.Peek();
+                bmfcSave.OutlineThickness = outlineThicknessStack.Peek();
+                bmfcSave.UseSmoothing = useFontSmoothingStack.Peek();
+                bmfcSave.IsItalic = isItalicStack.Peek();
+                bmfcSave.IsBold = isBoldStack.Peek();
+
+                if (bbCodeFontFilePath != null)
+                {
+                    bmfcSave.FontFile = ResolveFontFilePath(bbCodeFontFilePath);
+                    bmfcSave.FontName = System.IO.Path.GetFileNameWithoutExtension(bbCodeFontFilePath);
+                }
+                else
+                {
+                    bmfcSave.FontName = fontName;
+                }
+
+                var gumProject = ObjectFinder.Self.GumProjectSave;
+                bmfcSave.Ranges = gumProject?.FontRanges ?? BmfcSave.GetEffectiveDefaultRanges();
+                bmfcSave.SpacingHorizontal = gumProject?.FontSpacingHorizontal ?? 1;
+                bmfcSave.SpacingVertical = gumProject?.FontSpacingVertical ?? 1;
+
+                Raylib_cs.Font? createdFont = InMemoryFontCreator.TryCreateFont(bmfcSave);
+                if (createdFont.HasValue && createdFont.Value.BaseSize != 0)
+                {
+                    // Dispose first so a poisoned empty slot (see the base path) can't make AddDisposable
+                    // throw; then cache under the same FontCache key the base-font path uses so a base text
+                    // and an inline run at the same size/style share one atlas.
+                    loaderManager.Dispose(fullFileName);
+                    loaderManager.AddDisposable(fullFileName, new ManagedFont(createdFont.Value));
+                    return createdFont.Value;
+                }
+            }
+            catch
+            {
+                // Fall through to null - the caller uses the base font / base-atlas scale fallback.
+            }
+
+            return null;
+        }
     }
 
     /// <summary>
-    /// Re-rasterizes (or returns a cached) <see cref="Raylib_cs.Font"/> for <paramref name="textRuntime"/>'s
-    /// font family/style but at <paramref name="fontSize"/>, used for inline [FontSize=N] BBCode runs (#3524).
-    /// This is the per-run mirror of the base-font creation in <see cref="UpdateToFontValues"/>: it copies the
-    /// runtime's font-generation fields, overrides only the size, and creates the font via
-    /// <see cref="InMemoryFontCreator"/>, caching it in the shared LoaderManager under the same FontCache key
-    /// the base path uses (so a base text and a run at the same size share one atlas). Returns null when no
-    /// creator is wired or creation fails; the caller then falls back to scaling the base atlas.
+    /// Resolves a font file path (from a <c>[Font=path]</c> tag) to an absolute path using the Gum project
+    /// directory. Font generators resolve paths relative to their own working directory, not the project
+    /// directory, so relative paths must be made absolute. Mirrors the XNA-side method of the same name.
     /// </summary>
-    private static Raylib_cs.Font? TryGetOrCreateFontAtSize(TextRuntime textRuntime, int fontSize)
+    private static string ResolveFontFilePath(string fontFilePath)
     {
-        if (InMemoryFontCreator == null || fontSize <= 0)
+        if (System.IO.Path.IsPathRooted(fontFilePath))
         {
-            return null;
+            return fontFilePath;
         }
 
-        var loaderManager = global::RenderingLibrary.Content.LoaderManager.Self;
-
-        try
+        var gumProject = ObjectFinder.Self.GumProjectSave;
+        if (gumProject != null)
         {
-            string? bbCodeFontFilePath = BmfcSave.IsFontFilePath(textRuntime.Font) ? textRuntime.Font : null;
-            string fontCacheName = BmfcSave.GetFontCacheFileNameFor(
-                fontSize,
-                textRuntime.Font,
-                textRuntime.OutlineThickness,
-                textRuntime.UseFontSmoothing,
-                textRuntime.IsItalic,
-                textRuntime.IsBold,
-                bbCodeFontFilePath);
-            string fullFileName = ToolsUtilities.FileManager.Standardize(fontCacheName, preserveCase: true, makeAbsolute: true);
-
-            // Reuse an already-generated font (its Raylib_cs.Font wraps an unmanaged GPU texture, so
-            // regenerating every layout would leak VRAM). Mirrors the base-font cache check.
-            if (loaderManager.GetDisposable(fullFileName) is ManagedFont cachedManagedFont
-                && cachedManagedFont.Font.BaseSize != 0)
-            {
-                return cachedManagedFont.Font;
-            }
-
-            BmfcSave bmfcSave = new BmfcSave();
-            textRuntime.CopyFontGenerationFieldsTo(bmfcSave, resolvedFontFilePath: null);
-            // The swap: keep the family/style, change only the size to the tag's value.
-            bmfcSave.FontSize = fontSize;
-
-            var gumProject = ObjectFinder.Self.GumProjectSave;
-            bmfcSave.Ranges = gumProject?.FontRanges ?? BmfcSave.GetEffectiveDefaultRanges();
-            bmfcSave.SpacingHorizontal = gumProject?.FontSpacingHorizontal ?? 1;
-            bmfcSave.SpacingVertical = gumProject?.FontSpacingVertical ?? 1;
-
-            Raylib_cs.Font? createdFont = InMemoryFontCreator.TryCreateFont(bmfcSave);
-            if (createdFont.HasValue && createdFont.Value.BaseSize != 0)
-            {
-                // Dispose first so a poisoned empty slot (see the base path) can't make AddDisposable throw.
-                loaderManager.Dispose(fullFileName);
-                loaderManager.AddDisposable(fullFileName, new ManagedFont(createdFont.Value));
-                return createdFont.Value;
-            }
-        }
-        catch
-        {
-            // Fall through to null - the caller uses the base-atlas scale fallback.
+            string projectDir = ToolsUtilities.FileManager.GetDirectory(gumProject.FullFileName);
+            return System.IO.Path.GetFullPath(System.IO.Path.Combine(projectDir, fontFilePath));
         }
 
-        return null;
+        return fontFilePath;
     }
 
-    // For some reason this crashes on web when uploading to itch:
-    //public static HashSet<string> Tags { get; private set; } = new HashSet<string>(StringComparer.InvariantCultureIgnoreCase)
-    // OrdinalIgnoreCase works fine:
-    public static HashSet<string> Tags { get; private set; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
-    {
-        "alpha",
-        "red",
-        "blue",
-        "green",
-        "color",
-        "font",
-        "fontsize",
-        "outlinethickness",
-        "isitalic",
-        "isbold",
-        "usefontsmoothing",
-        "fontscale",
-        "lineheightmultiplier",
-        // Added Sept 30, 2025 to handle parsing custom blocks
-        "custom"
-
-    };
+    /// <summary>
+    /// The canonical set of recognized BbCode tag names. Forwarder to the GumCommon-side
+    /// <see cref="BbCodeParser.KnownTags"/> so the Raylib and MonoGame paths recognize an identical tag set
+    /// (and a tag added to <see cref="BbCodeParser.KnownTags"/> is picked up here automatically). Kept as a
+    /// public member so existing callers referencing <c>CustomSetPropertyOnRenderable.Tags</c> still compile.
+    /// </summary>
+    public static HashSet<string> Tags => BbCodeParser.KnownTags;
 
     public static void UpdateToFontValues(IText text, GraphicalUiElement graphicalUiElement)
     {
@@ -1022,6 +1227,15 @@ public class CustomSetPropertyOnRenderable
             }
         }
 
+        // Re-parse BBCode segments so they pick up the new base font values. Without this, only the
+        // non-tagged text updates; runs after BBCode font tags retain the previous font because their
+        // InlineVariables still reference the old resolved font. (Boyscout #3624 - the MonoGame
+        // Gum/Wireframe/CustomSetPropertyOnRenderable.cs already does this; the Raylib copy had drifted.)
+        if (!string.IsNullOrEmpty(asText.StoredMarkupText))
+        {
+            asText.InlineVariables.Clear();
+            SetBbCodeText(asText, graphicalUiElement, asText.StoredMarkupText);
+        }
     }
 
     // Mirrors the MonoGame loader's `if (BitmapFont != fontToSet)` guard. A single SetProperty can

--- a/Runtimes/RaylibGum/Renderables/CustomSetPropertyOnRenderable.cs
+++ b/Runtimes/RaylibGum/Renderables/CustomSetPropertyOnRenderable.cs
@@ -723,50 +723,8 @@ public class CustomSetPropertyOnRenderable
 
         asText.RawText = strippedText;
 
-#if FRB
-        var textRuntime = graphicalUiElement;
-#else
-        var textRuntime = graphicalUiElement as Gum.GueDeriving.TextRuntime;
-#endif
-
-        // Seed the font-resolution stacks with the element's base font values so ApplyFontVariables can
-        // push/pop inline overrides on top of them.
-        if (textRuntime != null)
-        {
-            fontNameStack.Clear();
-            if (textRuntime.UseCustomFont)
-            {
-                var customFont = textRuntime.CustomFontFile;
-                if (customFont?.EndsWith(".fnt") == true)
-                {
-                    customFont = customFont.Substring(0, customFont.Length - ".fnt".Length);
-                }
-                fontNameStack.Push(customFont);
-            }
-            else
-            {
-                fontNameStack.Push(textRuntime.Font);
-            }
-
-            fontSizeStack.Clear();
-            fontSizeStack.Push(textRuntime.FontSize);
-
-            outlineThicknessStack.Clear();
-            outlineThicknessStack.Push(textRuntime.OutlineThickness);
-
-            useFontSmoothingStack.Clear();
-            useFontSmoothingStack.Push(textRuntime.UseFontSmoothing);
-
-            isItalicStack.Clear();
-            isItalicStack.Push(textRuntime.IsItalic);
-
-            isBoldStack.Clear();
-            isBoldStack.Push(textRuntime.IsBold);
-
-            useCustomFontStack.Clear();
-            useCustomFontStack.Push(textRuntime.UseCustomFont);
-        }
-
+        // Color / Red / Green / Blue / FontScale runs don't use the font-resolution stacks, so they are
+        // emitted regardless of whether the owning element is a TextRuntime.
         foreach (var item in results)
         {
             object castedValue = item.Open.Argument;
@@ -821,7 +779,63 @@ public class CustomSetPropertyOnRenderable
             }
         }
 
-        ApplyFontVariables(asText, results);
+#if FRB
+        var textRuntime = graphicalUiElement;
+#else
+        var textRuntime = graphicalUiElement as Gum.GueDeriving.TextRuntime;
+#endif
+
+        // Per-run font resolution requires the seven stacks to be seeded from a TextRuntime's base font
+        // values. A Text owned by a non-TextRuntime GraphicalUiElement has no such values, so we neither seed
+        // nor resolve here - otherwise ApplyFontVariables would peek/pop unseeded (stale or empty) stacks,
+        // giving a wrong font or an InvalidOperationException. One guard covers seeding and resolution; the
+        // text is still wrapped/measured below regardless.
+        if (textRuntime != null)
+        {
+            fontNameStack.Clear();
+            if (textRuntime.UseCustomFont)
+            {
+                var customFont = textRuntime.CustomFontFile;
+                if (customFont?.EndsWith(".fnt") == true)
+                {
+                    customFont = customFont.Substring(0, customFont.Length - ".fnt".Length);
+                }
+                fontNameStack.Push(customFont);
+            }
+            else
+            {
+                fontNameStack.Push(textRuntime.Font);
+            }
+
+            fontSizeStack.Clear();
+            fontSizeStack.Push(textRuntime.FontSize);
+
+            outlineThicknessStack.Clear();
+            outlineThicknessStack.Push(textRuntime.OutlineThickness);
+
+            useFontSmoothingStack.Clear();
+            useFontSmoothingStack.Push(textRuntime.UseFontSmoothing);
+
+            isItalicStack.Clear();
+            isItalicStack.Push(textRuntime.IsItalic);
+
+            isBoldStack.Clear();
+            isBoldStack.Push(textRuntime.IsBold);
+
+            useCustomFontStack.Clear();
+            useCustomFontStack.Push(textRuntime.UseCustomFont);
+
+            ApplyFontVariables(asText, results);
+        }
+
+        // #3481/#3532: RawText was assigned above (which wrapped + measured the text) before any
+        // InlineVariables existed, so that first pass was blind to inline [FontScale=N]/[FontSize=N] runs.
+        // Re-wrap first so line breaks account for an enlarged run's real size (#3532), then re-measure so the
+        // reported size accounts for per-line scale (#3481) - otherwise a tall run overflows its slot and
+        // overlaps the next stacked sibling, or a wide run spills past a fixed wrap width. Runs unconditionally
+        // (the text must wrap whether or not per-run fonts were resolved). Mirrors the MonoGame path.
+        asText.UpdateWrappedText();
+        asText.UpdatePreRenderDimensions();
     }
 
     /// <summary>
@@ -955,15 +969,6 @@ public class CustomSetPropertyOnRenderable
         {
             lastFontInlineVariable.CharacterCount = asText.RawText.Length - lastFontInlineVariable.StartIndex;
         }
-
-        // #3481/#3532: RawText was assigned above (which wrapped + measured the text) before any
-        // InlineVariables existed, so that first pass was blind to inline [FontScale=N]/[FontSize=N]
-        // runs. Re-wrap first so line breaks account for an enlarged run's real size (#3532), then
-        // re-measure so the reported size accounts for per-line scale (#3481) — otherwise a tall run
-        // overflows its slot and overlaps the next stacked sibling, or a wide run spills past a fixed
-        // wrap width. Mirrors the MonoGame Gum/Wireframe/CustomSetPropertyOnRenderable.cs.
-        asText.UpdateWrappedText();
-        asText.UpdatePreRenderDimensions();
 
         // Creates (or returns a cached) resolved font for the current stack state. Only the font-CREATION
         // body is platform-specific; everything above is shared with the MonoGame path. Returns null when no

--- a/Runtimes/RaylibGum/Renderables/Text.cs
+++ b/Runtimes/RaylibGum/Renderables/Text.cs
@@ -617,10 +617,11 @@ public class Text : IVisible, IRenderableIpso,
     public string? StoredMarkupText { get; set; }
 
     /// <summary>
-    /// The inline styling variables (Color / FontScale / FontSize runs) parsed from BBCode markup assigned
+    /// The inline styling variables (Color / FontScale runs, plus resolved-font "BitmapFont" runs for the
+    /// Font / FontSize / IsBold / IsItalic / OutlineThickness family tags) parsed from BBCode markup assigned
     /// to this Text. Populated by the property pipeline when the assigned text contains markup tags; empty
     /// for plain text. Consumed by <see cref="Render"/> to draw per-run styling. Custom per-letter callbacks
-    /// and [Font=Name] family swaps are not yet applied on the Raylib runtime (#3471).
+    /// are not yet applied on the Raylib runtime (#3471).
     /// </summary>
     public List<InlineVariable> InlineVariables { get; private set; }
 
@@ -949,7 +950,11 @@ public class Text : IVisible, IRenderableIpso,
                 case nameof(FontScale):
                     scale = (float)variable.Value;
                     break;
-                case nameof(FontSize):
+                // "BitmapFont" is the shared historical marker name the font-resolution stack model emits for
+                // every font-family tag (Font / FontSize / IsBold / IsItalic / OutlineThickness). On Raylib
+                // the value is a Raylib_cs.Font (a crisp per-run swap font) or a float (an absolute pixel size
+                // to scale the base atlas to when no font creator produced a crisp font) - not a BitmapFont.
+                case "BitmapFont":
                     if (variable.Value is Font swapFont && swapFont.BaseSize > 0)
                     {
                         drawFont = swapFont;
@@ -987,9 +992,10 @@ public class Text : IVisible, IRenderableIpso,
 
     /// <summary>
     /// Draws a single line as a sequence of styled runs (BBCode markup), applying per-run Color and per-run
-    /// size (FontScale multiplier or FontSize absolute-px swap). Runs are laid out left-to-right and
+    /// font (a resolved swap font from the Font / FontSize / IsBold / IsItalic / OutlineThickness family, or
+    /// a FontScale multiplier / FontSize absolute-px atlas scale). Runs are laid out left-to-right and
     /// baseline-aligned so a larger run sits on the same baseline as its neighbors. Custom per-letter
-    /// callbacks and [Font=Name] family swaps are not applied here on the Raylib runtime yet (#3471).
+    /// callbacks are not applied here on the Raylib runtime yet (#3471).
     /// </summary>
     private void DrawStyledLine(Font fontValue, List<StyledSubstring> substrings, Vector2 linePosition, float absoluteLeft, float originY)
     {

--- a/Tests/RaylibGum.Tests/Renderables/TextMarkupTests.cs
+++ b/Tests/RaylibGum.Tests/Renderables/TextMarkupTests.cs
@@ -4,6 +4,7 @@ using KernSmith.Gum;
 using RaylibGum.Renderables;
 using RenderingLibrary.Graphics;
 using Shouldly;
+using System.Linq;
 using Xunit;
 using Text = Gum.Renderables.Text;
 
@@ -33,6 +34,58 @@ public class TextMarkupTests
         float indexedMeasure = internalText.MeasureString("Hello World", 0);
 
         indexedMeasure.ShouldBe(baseMeasure);
+    }
+
+    // #3624: nested [IsBold][FontSize] WITHOUT a font creator. [IsBold] needs a rasterized bold atlas, which
+    // only a wired creator can produce, so with no creator the bold wrapper stays unapplied (produces no run)
+    // and only the inner [FontSize] survives - now under the shared "BitmapFont" font-run marker (the same
+    // name the MonoGame stack model emits), with the raw size as a float because no crisp font could be built.
+    // The crisp-nesting behavior is covered by Text_WithBoldWrappingFontSize_AppliesNestedResolvedRuns_WhenFontCreatorWired.
+    [Fact]
+    public void Text_WithBoldWrappingFontSize_StripsBothTagsButOnlyFontSizeBecomesInlineVariable()
+    {
+        TextRuntime textRuntime = new();
+        textRuntime.Text = "[IsBold=true][FontSize=20]inner[/FontSize][/IsBold]";
+
+        Text internalText = (Text)textRuntime.RenderableComponent;
+
+        internalText.RawText.ShouldBe("inner");
+        internalText.InlineVariables.Count.ShouldBe(1);
+        internalText.InlineVariables[0].VariableName.ShouldBe("BitmapFont");
+        internalText.InlineVariables[0].Value.ShouldBe(20f);
+        internalText.InlineVariables[0].StartIndex.ShouldBe(0);
+        internalText.InlineVariables[0].CharacterCount.ShouldBe(5);
+    }
+
+    // #3624 (the feature): with a font creator wired, nested [IsBold][FontSize=20] resolves the inner run to a
+    // crisp font rasterized at 20 within the bold context - the whole reason the stack model exists. The run
+    // covering all of "inner" is a resolved-font ("BitmapFont") run whose font is BaseSize 20 (the inner size
+    // applied on top of the outer bold). Restores the creator in finally so the no-creator tests stay unaffected.
+    [Fact]
+    public void Text_WithBoldWrappingFontSize_AppliesNestedResolvedRuns_WhenFontCreatorWired()
+    {
+        IRaylibFontCreator? savedCreator = CustomSetPropertyOnRenderable.InMemoryFontCreator;
+        try
+        {
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = new KernSmithRaylibFontCreator();
+
+            TextRuntime textRuntime = new();
+            textRuntime.Font = "Arial";
+            textRuntime.FontSize = 21;
+            textRuntime.Text = "[IsBold=true][FontSize=20]inner[/FontSize][/IsBold]";
+
+            Text internalText = (Text)textRuntime.RenderableComponent;
+
+            internalText.RawText.ShouldBe("inner");
+            InlineVariable innerRun = internalText.InlineVariables.Single(v => v.CharacterCount == 5);
+            innerRun.VariableName.ShouldBe("BitmapFont");
+            Raylib_cs.Font innerFont = innerRun.Value.ShouldBeOfType<Raylib_cs.Font>();
+            innerFont.BaseSize.ShouldBe(20);
+        }
+        finally
+        {
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = savedCreator;
+        }
     }
 
     [Fact]
@@ -68,7 +121,9 @@ public class TextMarkupTests
     }
 
     // No font creator is wired in the test harness, so [FontSize=N] can't re-rasterize a crisp font and
-    // falls back to storing the raw size as a float (Text then scales the base atlas to it). The crisp
+    // falls back to storing the raw size as a float (Text then scales the base atlas to it). The run is
+    // emitted under the shared "BitmapFont" font-run marker (the same name the MonoGame stack model uses;
+    // a misnomer on Raylib, where the value is a Raylib_cs.Font or a float, not a BitmapFont). The crisp
     // swap path is covered by Text_WithFontSizeMarkup_SwapsToCrispFont_WhenFontCreatorWired.
     [Fact]
     public void Text_WithFontSizeMarkup_PopulatesInlineVariable()
@@ -80,15 +135,17 @@ public class TextMarkupTests
 
         internalText.RawText.ShouldBe("Big text");
         internalText.InlineVariables.Count.ShouldBe(1);
-        internalText.InlineVariables[0].VariableName.ShouldBe("FontSize");
+        internalText.InlineVariables[0].VariableName.ShouldBe("BitmapFont");
         internalText.InlineVariables[0].Value.ShouldBe(40f);
         internalText.InlineVariables[0].StartIndex.ShouldBe(4);
         internalText.InlineVariables[0].CharacterCount.ShouldBe(4);
     }
 
     // With a font creator wired, [FontSize=N] re-rasterizes a crisp Raylib_cs.Font AT size N (BaseSize == N)
-    // and stores it as the run value - the actual font-swap, not an atlas scale-up. Mirrors the MonoGame
-    // BitmapFont swap. Restores the creator in finally so the no-creator fallback tests stay unaffected.
+    // emitted under the shared "BitmapFont" font-run marker - the actual font-swap, not an atlas scale-up.
+    // Mirrors the MonoGame BitmapFont swap: the stack model also emits a second (empty) run when the tag
+    // closes and the font pops back to the base size (21 here). Restores the creator in finally so the
+    // no-creator fallback tests stay unaffected.
     [Fact]
     public void Text_WithFontSizeMarkup_SwapsToCrispFont_WhenFontCreatorWired()
     {
@@ -104,10 +161,74 @@ public class TextMarkupTests
 
             Text internalText = (Text)textRuntime.RenderableComponent;
 
-            internalText.InlineVariables.Count.ShouldBe(1);
-            internalText.InlineVariables[0].VariableName.ShouldBe("FontSize");
+            internalText.InlineVariables.Count.ShouldBe(2);
+            internalText.InlineVariables[0].VariableName.ShouldBe("BitmapFont");
+            internalText.InlineVariables[0].StartIndex.ShouldBe(4);
+            internalText.InlineVariables[0].CharacterCount.ShouldBe(4);
             Raylib_cs.Font swapFont = internalText.InlineVariables[0].Value.ShouldBeOfType<Raylib_cs.Font>();
             swapFont.BaseSize.ShouldBe(40);
+
+            // The close tag pops the font size back to the base (21); that pop-back run covers no
+            // characters (it sits at the end of "Big text") but mirrors the MonoGame stack output.
+            internalText.InlineVariables[1].VariableName.ShouldBe("BitmapFont");
+            internalText.InlineVariables[1].CharacterCount.ShouldBe(0);
+            Raylib_cs.Font baseRun = internalText.InlineVariables[1].Value.ShouldBeOfType<Raylib_cs.Font>();
+            baseRun.BaseSize.ShouldBe(21);
+        }
+        finally
+        {
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = savedCreator;
+        }
+    }
+
+    // #3624 (no-creator characterization): [IsBold], [IsItalic], [OutlineThickness], and [Font=Name] are
+    // recognized tags, so their markup IS stripped from the visible RawText, but applying them requires a
+    // rasterized atlas that only a wired font creator can produce - so with no creator they remain unapplied
+    // (produce no run), exactly as before. This preserves the pre-#3624 no-creator behavior; the applied
+    // behavior is covered by Text_WithStyleMarkup_AppliesResolvedFontRuns_WhenFontCreatorWired.
+    [Theory]
+    [InlineData("[IsBold=true]Hello[/IsBold] World")]
+    [InlineData("[IsItalic=true]Hello[/IsItalic] World")]
+    [InlineData("[OutlineThickness=2]Hello[/OutlineThickness] World")]
+    [InlineData("[Font=SomeName]Hello[/Font] World")]
+    public void Text_WithUnappliedStyleMarkup_StripsTagsButAddsNoInlineVariable_WhenNoFontCreator(string markup)
+    {
+        TextRuntime textRuntime = new();
+        textRuntime.Text = markup;
+
+        Text internalText = (Text)textRuntime.RenderableComponent;
+
+        internalText.RawText.ShouldBe("Hello World");
+        internalText.InlineVariables.ShouldBeEmpty();
+    }
+
+    // #3624 (the feature): with a font creator wired, [IsBold], [IsItalic], [OutlineThickness], and
+    // [Font=Name] are now APPLIED - each produces a resolved-font ("BitmapFont") run over its wrapped text,
+    // instead of being stripped-but-ignored. The run covering "Hello" (5 chars) is the resolved font for that
+    // styled range. Restores the creator in finally so the no-creator tests stay unaffected.
+    [Theory]
+    [InlineData("[IsBold=true]Hello[/IsBold] World")]
+    [InlineData("[IsItalic=true]Hello[/IsItalic] World")]
+    [InlineData("[OutlineThickness=2]Hello[/OutlineThickness] World")]
+    [InlineData("[Font=Arial]Hello[/Font] World")]
+    public void Text_WithStyleMarkup_AppliesResolvedFontRuns_WhenFontCreatorWired(string markup)
+    {
+        IRaylibFontCreator? savedCreator = CustomSetPropertyOnRenderable.InMemoryFontCreator;
+        try
+        {
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = new KernSmithRaylibFontCreator();
+
+            TextRuntime textRuntime = new();
+            textRuntime.Font = "Arial";
+            textRuntime.FontSize = 20;
+            textRuntime.Text = markup;
+
+            Text internalText = (Text)textRuntime.RenderableComponent;
+
+            internalText.RawText.ShouldBe("Hello World");
+            InlineVariable helloRun = internalText.InlineVariables.Single(v => v.CharacterCount == 5);
+            helloRun.VariableName.ShouldBe("BitmapFont");
+            helloRun.Value.ShouldBeOfType<Raylib_cs.Font>();
         }
         finally
         {

--- a/Tests/RaylibGum.Tests/Renderables/TextMarkupTests.cs
+++ b/Tests/RaylibGum.Tests/Renderables/TextMarkupTests.cs
@@ -1,5 +1,6 @@
 using Gum.DataTypes;
 using Gum.GueDeriving;
+using Gum.Wireframe;
 using KernSmith.Gum;
 using RaylibGum.Renderables;
 using RenderingLibrary.Graphics;
@@ -229,6 +230,37 @@ public class TextMarkupTests
             InlineVariable helloRun = internalText.InlineVariables.Single(v => v.CharacterCount == 5);
             helloRun.VariableName.ShouldBe("BitmapFont");
             helloRun.Value.ShouldBeOfType<Raylib_cs.Font>();
+        }
+        finally
+        {
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = savedCreator;
+        }
+    }
+
+    // #3624 regression: a Text owned by a GraphicalUiElement that is NOT a TextRuntime has unseeded font
+    // stacks (SetBbCodeText seeds them only for a TextRuntime). With a font creator wired and font-family
+    // markup, the resolution loop would otherwise peek/pop those unseeded stacks - a wrong font, or an
+    // uncaught InvalidOperationException. The single guard must skip per-run font resolution in that case
+    // while still stripping the tags and wrapping the text. Restores the creator in finally.
+    [Fact]
+    public void SetBbCodeText_WithNonTextRuntimeOwner_DoesNotThrowOrResolveFonts_WhenFontCreatorWired()
+    {
+        IRaylibFontCreator? savedCreator = CustomSetPropertyOnRenderable.InMemoryFontCreator;
+        try
+        {
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = new KernSmithRaylibFontCreator();
+
+            // A real Text renderable, but driven through a base GraphicalUiElement (not a TextRuntime).
+            TextRuntime source = new();
+            Text text = (Text)source.RenderableComponent;
+            GraphicalUiElement nonTextRuntimeOwner = new();
+
+            Should.NotThrow(() => CustomSetPropertyOnRenderable.SetPropertyOnRenderable(
+                text, nonTextRuntimeOwner, "Text", "[IsBold=true]Hello[/IsBold] World"));
+
+            text.RawText.ShouldBe("Hello World");
+            // No TextRuntime to seed the stacks, so no resolved-font ("BitmapFont") runs are produced.
+            text.InlineVariables.Any(v => v.VariableName == "BitmapFont").ShouldBeFalse();
         }
         finally
         {


### PR DESCRIPTION
Closes #3624. Part of the `CustomSetPropertyOnRenderable` unification workstream (#3615).

## What

Converges Raylib's per-run BBCode font-tag resolution onto MonoGame's stack-based architecture. Previously Raylib's `CustomSetPropertyOnRenderable` handled only `[FontSize]` + color tags ad-hoc (with the swap consumed in `Text.cs` via `hasSwapFont`); `[IsBold]`, `[IsItalic]`, `[OutlineThickness]`, and `[Font=Name]` were parsed-and-stripped but silently unapplied. This ports the seven-stack push/pop resolution (`ApplyFontVariables`) into the Raylib copy and reroutes `Text.cs` to read the shared resolved-font run-marker, so those tags now render on Raylib.

## Notable

- **New Raylib behavior (with a font creator wired):** `[IsBold]` / `[IsItalic]` / `[OutlineThickness]` / `[Font]` now produce styled runs, and nesting works (the whole reason the stack model exists). Without a creator, styled tags gracefully no-op (Raylib can't rasterize a styled atlas without one); the existing `[FontSize]` base-atlas-scale fallback is preserved unchanged.
- **Null-owner guard:** a code-review found the ported stack resolution ran unconditionally while the stacks are only seeded for a `TextRuntime` owner — a `Text` owned by a non-`TextRuntime` `GraphicalUiElement` + a wired creator threw `InvalidOperationException` ("Stack empty"). Fixed with a single `if (textRuntime != null)` guard, applied to **both** the Raylib copy and the MonoGame/KNI/FNA/FRB home file (the latent bug existed on both — regression tests added on each). FRB behavior is unchanged (its owner is never null, so the guard is always-true).
- **Accepted behavior change:** inline font runs no longer carry the base text's dropshadow, matching MonoGame's existing inline-run behavior. Tracked for restoration in #3625.
- **Boyscout:** Raylib's base-font change now re-parses BBCode runs (it had drifted from MonoGame); Raylib's local tag set forwards to `BbCodeParser.KnownTags`; removed dead locals in the home `SetBbCodeText`.

The whole-file merge (delete the Raylib copy + add the csproj file-link) is deferred to a later step under #3615, gated on the rest of the file also reaching a zero cross-copy diff.

## Verification

- Unit tests: `RaylibGum.Tests` 478 passed, `MonoGameGum.Tests` 1843 passed, `KniGum` builds. Zero new warnings.
- FRB canary (`GumCore.DesktopGlNet6`, net6.0 + `FRB` constant): 0 errors.
- Manual Raylib visual test (FontPlayground.Raylib): inline `[IsBold]` / `[IsItalic]` / `[FontSize]` / `[OutlineThickness]` each render styled (previously stripped-but-plain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
