### PR TITLE
Converge font-resolution region of CustomSetPropertyOnRenderable toward Raylib copy

### DIFF
--- a/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
+++ b/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
@@ -38,12 +38,17 @@ using Gum.GueDeriving;
 using Gum.Renderables;
 using Gum.GueDeriving;
 using Raylib_cs;
+// The font a BBCode font-run resolves to. On Raylib that is a Raylib_cs.Font; on the XNA-family
+// backends it is a BitmapFont. Mirrored #if so the shared BBCode stack-resolution loop below stays
+// type-neutral (see ApplyFontVariables) - only the font-CREATION body is platform-gated.
+using ResolvedFont = Raylib_cs.Font;
 namespace RaylibGum.Renderables;
 #else
 using Gum.Graphics.Animation;
 using RenderingLibrary.Math.Geometry;
 using Microsoft.Xna.Framework.Graphics;
 using ToolsUtilities;
+using ResolvedFont = RenderingLibrary.Graphics.BitmapFont;
 namespace Gum.Wireframe;
 #endif
 
@@ -958,36 +963,19 @@ public class CustomSetPropertyOnRenderable
 
     private static void SetBbCodeText(global::RenderingLibrary.Graphics.Text asText, GraphicalUiElement graphicalUiElement, string bbcode)
     {
-        // Text can be rendered on multiple lines. This can happen due to explicit newline characters, or by automatic line wrapping.
-        // When line indexes are counted, newlines are not included. Therefore, we need to remove newlines here so that indexes match up.
-        var bbCodeNoNewlines =
-        // update November 18, 2024
-        // We now do include newline
-        // characters becuase those can
-        // be explicitly added for textboxes
-        // with multiple lines:
-        //bbcode?.Replace("\n", "");
-        // Update November 15, 2025
-        // The rendering code ignores
-        // the \r character so we need
-        // to remove that:
-        bbcode?.Replace("\r\n", "\n");
+        // The rendering/wrapping code ignores '\r', so normalize CRLF to LF before computing indexes.
+        // Parsing and stripping from the same normalized string keeps InlineVariable indexes aligned
+        // with the RawText the renderer sees.
+        var normalized = bbcode?.Replace("\r\n", "\n");
 
-        var resultsNoNewlines = BbCodeParser.Parse(bbCodeNoNewlines, Tags);
-        var resultsWithNewlines = BbCodeParser.Parse(bbcode, Tags);
+        var results = BbCodeParser.Parse(normalized, Tags);
+        var strippedText = BbCodeParser.RemoveTags(normalized, results);
 
-        var strippedText = BbCodeParser.RemoveTags(bbcode, resultsWithNewlines);
         asText.RawText = strippedText;
-
-#if FRB
-        var textRuntime = graphicalUiElement;
-#else
-        var textRuntime = graphicalUiElement as Gum.GueDeriving.TextRuntime;
-#endif
 
         // Color / Red / Green / Blue / FontScale / Custom runs don't use the font-resolution stacks, so they
         // are emitted regardless of whether the owning element is a TextRuntime.
-        foreach (var item in resultsNoNewlines)
+        foreach (var item in results)
         {
             object castedValue = item.Open.Argument;
             var shouldApply = false;
@@ -1077,6 +1065,12 @@ public class CustomSetPropertyOnRenderable
             }
         }
 
+#if FRB
+        var textRuntime = graphicalUiElement;
+#else
+        var textRuntime = graphicalUiElement as Gum.GueDeriving.TextRuntime;
+#endif
+
         // Per-run font resolution requires the seven stacks to be seeded from a TextRuntime's base font
         // values. A Text owned by a non-TextRuntime GraphicalUiElement has no such values, so we neither seed
         // nor resolve here - otherwise ApplyFontVariables would peek/pop unseeded (stale or empty) stacks,
@@ -1118,7 +1112,7 @@ public class CustomSetPropertyOnRenderable
             useCustomFontStack.Clear();
             useCustomFontStack.Push(textRuntime.UseCustomFont);
 
-            ApplyFontVariables(asText, resultsNoNewlines);
+            ApplyFontVariables(asText, results);
         }
 
         // #3481: RawText was assigned above (which wrapped + measured the text) before any InlineVariables
@@ -1149,7 +1143,7 @@ public class CustomSetPropertyOnRenderable
         foreach (var tag in allTags)
         {
 
-            BitmapFont castedValue = null;
+            object castedValue = null;
             string convertedName = "BitmapFont";
             var hasArg = !string.IsNullOrEmpty(tag.Argument);
             switch (tag.Name)
@@ -1180,6 +1174,13 @@ public class CustomSetPropertyOnRenderable
                         {
                             fontSizeStack.Push(parsedValue);
                             castedValue = GetAndCreateFontIfNecessary();
+#if RAYLIB
+                            // Platform-necessary Raylib fallback: with no font creator wired, no crisp font can be
+                            // rasterized at the requested size, so store the raw pixel size as a float and let the
+                            // renderer scale the base atlas to it (a blurry-but-correct approximation). The XNA
+                            // path never needs this - it can new BitmapFont(...) at any size.
+                            castedValue ??= (float)parsedValue;
+#endif
                         }
                         else
                         {
@@ -1275,7 +1276,7 @@ public class CustomSetPropertyOnRenderable
             lastFontInlineVariable.CharacterCount = asText.RawText.Length - lastFontInlineVariable.StartIndex;
         }
 
-        BitmapFont GetAndCreateFontIfNecessary()
+        ResolvedFont? GetAndCreateFontIfNecessary()
         {
             var fontFileName = GetFontFileName();
 

--- a/MonoGameGum.Tests/Runtimes/TextRuntimeTests.cs
+++ b/MonoGameGum.Tests/Runtimes/TextRuntimeTests.cs
@@ -771,6 +771,35 @@ char id=67 x=0 y=0 width={xadvance} height=13 xoffset=0 yoffset=4 xadvance={xadv
     }
 
     [Fact]
+    public void Text_WithCustomAfterSlashRSlashN_ShouldUseNormalizedIndexes()
+    {
+        Func<int, string, LetterCustomization> method = (int index, string block) =>
+        {
+            return new LetterCustomization();
+        };
+        Text.Customizations["CustomAfterCRLF"] = method;
+
+        string text = $"AB\r\n[Custom=CustomAfterCRLF]CD[/Custom]";
+
+        TextRuntime textRuntime = new();
+        textRuntime.Text = text;
+
+        var internalText = (RenderingLibrary.Graphics.Text)textRuntime.RenderableComponent;
+        var inlineVariables = internalText.InlineVariables;
+
+        inlineVariables.Count.ShouldBe(2);
+        foreach (InlineVariable variable in inlineVariables)
+        {
+            var asCall = (ParameterizedLetterCustomizationCall)variable.Value;
+            asCall.TextBlock.ShouldBe("CD", "Because \\r should be stripped before indexes are computed, so the substring must not include it");
+        }
+
+        ((ParameterizedLetterCustomizationCall)inlineVariables[0].Value).CharacterIndex.ShouldBe(3,
+            "Because \\r character should not be included, so the C character starts at index 3");
+        ((ParameterizedLetterCustomizationCall)inlineVariables[1].Value).CharacterIndex.ShouldBe(4);
+    }
+
+    [Fact]
     public void Text_WithCustom_ShouldAssignMethodCall()
     {
         Func<int, string, LetterCustomization> method = (int index, string block) =>


### PR DESCRIPTION
## Summary

Part of the `CustomSetPropertyOnRenderable` cross-platform unification tracked in #3615 (per the incremental-convergence technique in `.claude/skills/gum-cross-platform-unification/SKILL.md`). PR #3624 already converged the BBCode font-tag *resolution* architecture (the seven-stack `ApplyFontVariables` model) between the MonoGame/KNI/FNA home copy (`Gum/Wireframe/CustomSetPropertyOnRenderable.cs`) and the Raylib copy (`Runtimes/RaylibGum/Renderables/CustomSetPropertyOnRenderable.cs`). This PR closes the remaining textual divergence in that region:

- Adds a `using ResolvedFont = ...;` alias to the home file (`BitmapFont` under `#if !RAYLIB`, `Raylib_cs.Font` under `#if RAYLIB`), mirroring the Raylib copy, and retypes `GetAndCreateFontIfNecessary`'s return from `BitmapFont` to the neutral `ResolvedFont?` shape.
- Retypes `ApplyFontVariables`'s `castedValue` from `BitmapFont` to `object`, matching the Raylib copy (which needs `object` to also hold a `float` fallback value).
- Mirrors Raylib's `#if RAYLIB` float-size fallback line into the home file — dead in its own MonoGame/KNI/FNA build, pre-staged for the eventual full merge (the same pattern already used elsewhere in this file).
- Reconciles the parse-normalization difference in `SetBbCodeText`: both copies now parse BBCode once against a single CRLF-normalized string (previously the home copy parsed twice — once normalized for index math, once raw for `RawText`/`strippedText` — an artifact of an incomplete November 2025 edit). Also reorders the `textRuntime` lookup to sit after the Color/Custom loop, matching the Raylib copy.

**Bug fix as a byproduct of convergence:** the old dual-parse meant a `[Custom]` BBCode tag positioned after a literal `\r\n` read its per-letter substring from a string that still contained the raw `\r`, misaligned by one character relative to the indexes computed from the normalized parse. Added `Text_WithCustomAfterSlashRSlashN_ShouldUseNormalizedIndexes` (`MonoGameGum.Tests/Runtimes/TextRuntimeTests.cs`) — verified it reproduces the bug against the pre-change code and is green after.

This is behavior-preserving otherwise: the `git diff --no-index` between the two files for the font-resolution region (`SetBbCodeText`/`ApplyFontVariables`/`GetAndCreateFontIfNecessary`) shrank from 558 to 515 diff lines. The remaining divergence is legitimately platform-specific (the two files' font-*creation* bodies genuinely differ — LoaderManager/disk/FontService fallback on MonoGame vs. `ManagedFont`/`IRaylibFontCreator` on Raylib) or pre-existing (the `[Custom]` tag itself is a MonoGame-only feature, tracked separately as #3471; a couple of comments reference distinct historical issue numbers per platform and were left as-is).

## Test plan
- [x] `dotnet test MonoGameGum.Tests/MonoGameGum.Tests.csproj` — 1844/1844 passed (was 1843 before the new regression test)
- [x] `dotnet test Tests/RaylibGum.Tests/RaylibGum.Tests.csproj` — 478/478 passed
- [x] `dotnet build MonoGameGum/KniGum/KniGum.csproj` — 0 errors, 0 new warnings (verified via before/after diff of warnings from this file specifically)
- [x] FRB canary (`dotnet build GumCore/GumCoreXnaPc/GumCore.DesktopGlNet6/GumCore.DesktopGlNet6.csproj`) — 0 errors, no new warnings from the changed region. Run from the primary checkout after PR creation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)