### PR TITLE
Converge Sprite-family dispatch in CustomSetPropertyOnRenderable (Raylib <-> MonoGame/KNI/FNA)

### DIFF
--- a/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
+++ b/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
@@ -568,95 +568,110 @@ public class CustomSetPropertyOnRenderable
     {
         bool handled = false;
 
-        if (propertyName == "SourceFile")
+        switch (propertyName)
         {
-            var asString = value as String;
-            handled = AssignSourceFileOnSprite(sprite, graphicalUiElement, asString);
-
-        }
-        else if (propertyName == nameof(Sprite.Alpha))
-        {
-            int valueAsInt = (int)value;
-            sprite.Alpha = valueAsInt;
-            handled = true;
-        }
-        else if (propertyName == nameof(Sprite.Red))
-        {
-            int valueAsInt = (int)value;
-            sprite.Red = valueAsInt;
-            handled = true;
-        }
-        else if (propertyName == nameof(Sprite.Green))
-        {
-            int valueAsInt = (int)value;
-            sprite.Green = valueAsInt;
-            handled = true;
-        }
-        else if (propertyName == nameof(Sprite.Blue))
-        {
-            int valueAsInt = (int)value;
-            sprite.Blue = valueAsInt;
-            handled = true;
-        }
-        else if (propertyName == nameof(Sprite.Color))
-        {
-            if (value is System.Drawing.Color drawingColor)
-            {
-                sprite.Color = drawingColor;
-            }
-            else if (value is Microsoft.Xna.Framework.Color xnaColor)
-            {
-                sprite.Color = xnaColor.ToSystemDrawing();
-
-            }
-            handled = true;
-        }
-
-        else if (propertyName == "Blend")
-        {
-            var valueAsGumBlend = (RenderingLibrary.Blend)value;
-
-            var valueAsXnaBlend = valueAsGumBlend.ToBlendState();
-
-            sprite.BlendState = valueAsXnaBlend;
-
-            handled = true;
-        }
-        else if (propertyName == nameof(Sprite.Animate))
-        {
-            sprite.Animate = (bool)value;
-            handled = true;
-        }
-        else if (propertyName == nameof(Sprite.CurrentChainName))
-        {
-            sprite.CurrentChainName = (string)value;
-            graphicalUiElement.UpdateTextureValuesFrom(sprite);
-            graphicalUiElement.UpdateLayout();
-            handled = true;
-        }
-#if !FRB
-        else if(propertyName == nameof(SpriteRuntime.RenderTargetTextureSource))
-        {
-            var runtime = graphicalUiElement as SpriteRuntime;
-            if(runtime != null)
-            {
-                if(value == null)
+            case "SourceFile":
                 {
-                    runtime.RenderTargetTextureSource = null;
+                    var asString = value as String;
+                    handled = AssignSourceFileOnSprite(sprite, graphicalUiElement, asString);
+                    break;
                 }
-                else if(value is IRenderableIpso renderableIpso)
+            case nameof(Sprite.Alpha):
                 {
-                    runtime.RenderTargetTextureSource = renderableIpso;
+                    int valueAsInt = (int)value;
+                    sprite.Alpha = valueAsInt;
+                    handled = true;
+                    break;
                 }
-                else if(value is string asString)
+            case nameof(Sprite.Red):
                 {
-                    runtime.RenderTargetTextureSource =
-                        (graphicalUiElement.GetTopParent() as GraphicalUiElement)?.FindByName(asString);
+                    int valueAsInt = (int)value;
+                    sprite.Red = valueAsInt;
+                    handled = true;
+                    break;
                 }
-                handled = true;
-            }
-        }
+            case nameof(Sprite.Green):
+                {
+                    int valueAsInt = (int)value;
+                    sprite.Green = valueAsInt;
+                    handled = true;
+                    break;
+                }
+            case nameof(Sprite.Blue):
+                {
+                    int valueAsInt = (int)value;
+                    sprite.Blue = valueAsInt;
+                    handled = true;
+                    break;
+                }
+#if !RAYLIB
+            case nameof(Sprite.Color):
+                {
+                    if (value is System.Drawing.Color drawingColor)
+                    {
+                        sprite.Color = drawingColor;
+                    }
+                    else if (value is Microsoft.Xna.Framework.Color xnaColor)
+                    {
+                        sprite.Color = xnaColor.ToSystemDrawing();
+                    }
+                    handled = true;
+                    break;
+                }
 #endif
+            case "Blend":
+                {
+                    var valueAsGumBlend = (Gum.RenderingLibrary.Blend)value;
+#if RAYLIB
+                    sprite.Blend = valueAsGumBlend;
+#else
+                    var valueAsXnaBlend = valueAsGumBlend.ToBlendState();
+
+                    sprite.BlendState = valueAsXnaBlend;
+#endif
+                    handled = true;
+                    break;
+                }
+            case nameof(Sprite.Animate):
+                {
+                    sprite.Animate = (bool)value;
+                    handled = true;
+                    break;
+                }
+            case nameof(Sprite.CurrentChainName):
+                {
+                    sprite.CurrentChainName = (string)value;
+                    graphicalUiElement.UpdateTextureValuesFrom(sprite);
+                    graphicalUiElement.UpdateLayout();
+                    handled = true;
+                    break;
+                }
+#if !FRB
+            case nameof(SpriteRuntime.RenderTargetTextureSource):
+                {
+                    var runtime = graphicalUiElement as SpriteRuntime;
+                    if (runtime != null)
+                    {
+                        if (value == null)
+                        {
+                            runtime.RenderTargetTextureSource = null;
+                        }
+                        else if (value is IRenderableIpso renderableIpso)
+                        {
+                            runtime.RenderTargetTextureSource = renderableIpso;
+                        }
+                        else if (value is string asStringValue)
+                        {
+                            runtime.RenderTargetTextureSource =
+                                (graphicalUiElement.GetTopParent() as GraphicalUiElement)?.FindByName(asStringValue);
+                        }
+                        handled = true;
+                    }
+                    break;
+                }
+#endif
+        }
+
         return handled;
     }
 
@@ -2020,6 +2035,7 @@ public class CustomSetPropertyOnRenderable
                 value = ToolsUtilities.FileManager.RemoveDotDotSlash(value);
             }
 
+#if !RAYLIB
             // see if an atlas exists:
             var atlasedTexture = loaderManager.TryLoadContent<AtlasedTexture>(value);
 
@@ -2028,15 +2044,16 @@ public class CustomSetPropertyOnRenderable
                 graphicalUiElement.UpdateLayout();
             }
             else
+#endif
             {
                 // We used to check if the file exists. But internally something may
                 // alias a file. Ultimately the content loader should make that decision,
                 // not the GUE
-                Microsoft.Xna.Framework.Graphics.Texture2D? texture = null;
+                Texture2D? texture = null;
                 Exception? loadException = null;
                 try
                 {
-                    texture = loaderManager.LoadContent<Microsoft.Xna.Framework.Graphics.Texture2D>(value);
+                    texture = loaderManager.LoadContent<Texture2D>(value);
                 }
                 catch (Exception ex)
                 // Jan 1, 2025 - we used to only catch certain types of exceptions, but this list keeps growing as there

--- a/Runtimes/RaylibGum/Renderables/CustomSetPropertyOnRenderable.cs
+++ b/Runtimes/RaylibGum/Renderables/CustomSetPropertyOnRenderable.cs
@@ -422,15 +422,14 @@ public class CustomSetPropertyOnRenderable
     {
         bool handled = false;
 
-        SpriteRuntime? asSpriteRuntime = graphicalUiElement as SpriteRuntime;
-
         switch (propertyName)
         {
-
             case "SourceFile":
-                var asString = value as String;
-                handled = AssignSourceFileOnSprite(sprite, graphicalUiElement, asString);
-                break;
+                {
+                    var asString = value as String;
+                    handled = AssignSourceFileOnSprite(sprite, graphicalUiElement, asString);
+                    break;
+                }
             case nameof(Sprite.Alpha):
                 {
                     int valueAsInt = (int)value;
@@ -444,7 +443,6 @@ public class CustomSetPropertyOnRenderable
                     sprite.Red = valueAsInt;
                     handled = true;
                     break;
-
                 }
             case nameof(Sprite.Green):
                 {
@@ -460,50 +458,73 @@ public class CustomSetPropertyOnRenderable
                     handled = true;
                     break;
                 }
-            //else if (propertyName == nameof(Sprite.Color))
-            //{
-            //    if (value is System.Drawing.Color drawingColor)
-            //    {
-            //        sprite.Color = drawingColor;
-            //    }
-            //    else if (value is Microsoft.Xna.Framework.Color xnaColor)
-            //    {
-            //        sprite.Color = xnaColor.ToSystemDrawing();
-
-            //    }
-            //    handled = true;
-            //}
-
-            //else if (propertyName == "Blend")
-            //{
-            //    var valueAsGumBlend = (RenderingLibrary.Blend)value;
-
-            //    var valueAsXnaBlend = valueAsGumBlend.ToBlendState();
-
-            //    sprite.BlendState = valueAsXnaBlend;
-
-            //    handled = true;
-            //}
-            //else if (propertyName == nameof(Sprite.Animate))
-            //{
-            //    sprite.Animate = (bool)value;
-            //    handled = true;
-            //}
-            //else if (propertyName == nameof(Sprite.CurrentChainName))
-            //{
-            //    sprite.CurrentChainName = (string)value;
-            //    graphicalUiElement.UpdateTextureValuesFrom(sprite);
-            //    graphicalUiElement.UpdateLayout();
-            //    handled = true;
-            //}
-            case nameof(Sprite.Texture):
+#if !RAYLIB
+            case nameof(Sprite.Color):
                 {
-                    sprite.Texture = (Texture2D)value;
+                    if (value is System.Drawing.Color drawingColor)
+                    {
+                        sprite.Color = drawingColor;
+                    }
+                    else if (value is Microsoft.Xna.Framework.Color xnaColor)
+                    {
+                        sprite.Color = xnaColor.ToSystemDrawing();
+                    }
                     handled = true;
                     break;
                 }
-        }
+#endif
+            case "Blend":
+                {
+                    var valueAsGumBlend = (Gum.RenderingLibrary.Blend)value;
+#if RAYLIB
+                    sprite.Blend = valueAsGumBlend;
+#else
+                    var valueAsXnaBlend = valueAsGumBlend.ToBlendState();
 
+                    sprite.BlendState = valueAsXnaBlend;
+#endif
+                    handled = true;
+                    break;
+                }
+            case nameof(Sprite.Animate):
+                {
+                    sprite.Animate = (bool)value;
+                    handled = true;
+                    break;
+                }
+            case nameof(Sprite.CurrentChainName):
+                {
+                    sprite.CurrentChainName = (string)value;
+                    graphicalUiElement.UpdateTextureValuesFrom(sprite);
+                    graphicalUiElement.UpdateLayout();
+                    handled = true;
+                    break;
+                }
+#if !FRB
+            case nameof(SpriteRuntime.RenderTargetTextureSource):
+                {
+                    var runtime = graphicalUiElement as SpriteRuntime;
+                    if (runtime != null)
+                    {
+                        if (value == null)
+                        {
+                            runtime.RenderTargetTextureSource = null;
+                        }
+                        else if (value is IRenderableIpso renderableIpso)
+                        {
+                            runtime.RenderTargetTextureSource = renderableIpso;
+                        }
+                        else if (value is string asStringValue)
+                        {
+                            runtime.RenderTargetTextureSource =
+                                (graphicalUiElement.GetTopParent() as GraphicalUiElement)?.FindByName(asStringValue);
+                        }
+                        handled = true;
+                    }
+                    break;
+                }
+#endif
+        }
 
         return handled;
     }
@@ -1321,46 +1342,64 @@ public class CustomSetPropertyOnRenderable
                 value = ToolsUtilities.FileManager.RemoveDotDotSlash(value);
             }
 
+#if !RAYLIB
             // see if an atlas exists:
-            //var atlasedTexture = loaderManager.TryLoadContent<AtlasedTexture>(value);
+            var atlasedTexture = loaderManager.TryLoadContent<AtlasedTexture>(value);
 
-            //if (atlasedTexture != null)
-            //{
-            //    graphicalUiElement.UpdateLayout();
-            //}
-            //else
+            if (atlasedTexture != null)
+            {
+                graphicalUiElement.UpdateLayout();
+            }
+            else
+#endif
             {
                 // We used to check if the file exists. But internally something may
                 // alias a file. Ultimately the content loader should make that decision,
                 // not the GUE
+                Texture2D? texture = null;
+                Exception? loadException = null;
                 try
                 {
-                    sprite.Texture = loaderManager.LoadContent<Texture2D>(value);
+                    texture = loaderManager.LoadContent<Texture2D>(value);
                 }
                 catch (Exception ex)
                 // Jan 1, 2025 - we used to only catch certain types of exceptions, but this list keeps growing as there
                 // are a variety of types of crashes that can occur. NineSlice catches all exceptions, so let's just do that!
                 //when (ex is System.IO.FileNotFoundException or System.IO.DirectoryNotFoundException or WebException or IOException)
                 {
+                    loadException = ex;
+                }
+
+                if (texture == null)
+                {
+                    // On desktop the loader returns null for a missing file instead of throwing, and a
+                    // genuine load error is funneled here too (loadException). Report it the same way the
+                    // catch used to.
+                    string message = $"Error setting SourceFile on Sprite";
+
+                    if (graphicalUiElement.Tag != null)
+                    {
+                        message += $" in {graphicalUiElement.Tag}";
+                    }
+                    message += $"\n{value}";
+                    message += "\nCheck if the file exists. If necessary, set FileManager.RelativeDirectory";
+                    message += "\nThe current relative directory is:\n" + ToolsUtilities.FileManager.RelativeDirectory;
                     if (GraphicalUiElement.MissingFileBehavior == MissingFileBehavior.ThrowException)
                     {
-                        string message = $"Error setting SourceFile on Sprite";
-
-                        if (graphicalUiElement.Tag != null)
-                        {
-                            message += $" in {graphicalUiElement.Tag}";
-                        }
-                        message += $"\n{value}";
-                        message += "\nCheck if the file exists. If necessary, set FileManager.RelativeDirectory";
-                        message += "\nThe current relative directory is:\n" + ToolsUtilities.FileManager.RelativeDirectory;
                         if (ObjectFinder.Self.GumProjectSave == null)
                         {
                             message += "\nNo Gum project has been loaded";
                         }
 
-                        throw new System.IO.FileNotFoundException(message, ex);
+                        throw new System.IO.FileNotFoundException(message, loadException);
                     }
                     sprite.Texture = null;
+
+                    PropertyAssignmentError?.Invoke(loadException != null ? message + "\n" + loadException.ToString() : message);
+                }
+                else
+                {
+                    sprite.Texture = texture;
                 }
                 graphicalUiElement.UpdateLayout();
             }
@@ -1399,7 +1438,6 @@ public class CustomSetPropertyOnRenderable
 
         return animationChainList;
     }
-
 
     public static void AddRenderableToManagers(IRenderableIpso renderable, ISystemManagers iSystemManagers, Layer layer)
     {

--- a/Runtimes/RaylibGum/Renderables/Sprite.cs
+++ b/Runtimes/RaylibGum/Renderables/Sprite.cs
@@ -473,6 +473,18 @@ public class Sprite : InvisibleRenderable, IAspectRatio, ITextureCoordinate, IAn
         set => AnimationLogic.AnimationChains = value;
     }
 
+    public bool Animate
+    {
+        get => AnimationLogic.Animate;
+        set => AnimationLogic.Animate = value;
+    }
+
+    public string? CurrentChainName
+    {
+        get => AnimationLogic.CurrentChainName;
+        set => AnimationLogic.CurrentChainName = value;
+    }
+
     public bool UpdateToCurrentAnimationFrame() => AnimationLogic.UpdateToCurrentAnimationFrame();
 
     public void RefreshCurrentChainToDesiredName() => AnimationLogic.RefreshCurrentChainToDesiredName();

--- a/Tests/RaylibGum.Tests/Runtimes/SpriteSetPropertyTests.cs
+++ b/Tests/RaylibGum.Tests/Runtimes/SpriteSetPropertyTests.cs
@@ -1,0 +1,132 @@
+using Gum.Graphics.Animation;
+using Gum.GueDeriving;
+using Gum.Wireframe;
+using Raylib_cs;
+using RaylibGum.Renderables;
+using RenderingLibrary.Graphics;
+using Shouldly;
+using System;
+using Xunit;
+
+namespace RaylibGum.Tests.Runtimes;
+
+// Covers the string-property-dispatch path (SetProperty -> CustomSetPropertyOnRenderable ->
+// TrySetPropertyOnSprite / AssignSourceFileOnSprite) for cases that were previously commented
+// out or missing entirely on raylib (issue #3615 "Sprite family" convergence with the
+// MonoGame/KNI/FNA copy). These property names are set at runtime by the state/variable system
+// (StateSave/VariableSave applied via GraphicalUiElement.SetProperty), not by direct C# property
+// assignment, so a missing dispatch case here silently no-ops even though the equivalent direct
+// C# property (e.g. SpriteRuntime.Blend) works fine.
+public class SpriteSetPropertyTests : BaseTestClass
+{
+    [Fact]
+    public void SetProperty_Blend_ShouldForwardToContainedSprite()
+    {
+        SpriteRuntime sut = new();
+
+        sut.SetProperty("Blend", Gum.RenderingLibrary.Blend.Additive);
+
+        sut.Blend.ShouldBe(Gum.RenderingLibrary.Blend.Additive);
+    }
+
+    [Fact]
+    public void SetProperty_Animate_ShouldForwardToContainedSprite()
+    {
+        SpriteRuntime sut = new();
+
+        sut.SetProperty(nameof(SpriteRuntime.Animate), true);
+
+        sut.Animate.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void SetProperty_CurrentChainName_ShouldUpdateTextureValues()
+    {
+        SpriteRuntime sut = new();
+
+        // AnimationChains defaults to chain index 0 ("FirstChain"), so switching to
+        // "SecondChain" via SetProperty is what actually exercises the dispatch case
+        // (rather than the AnimationChains setter's own default-frame application).
+        var firstChain = new AnimationChain { Name = "FirstChain" };
+        firstChain.Add(new AnimationFrame
+        {
+            FrameLength = 1f,
+            Texture = new Texture2D { Width = 10, Height = 10 },
+            LeftCoordinate = 0f,
+            RightCoordinate = 1f,
+            TopCoordinate = 0f,
+            BottomCoordinate = 1f,
+        });
+        var secondChain = new AnimationChain { Name = "SecondChain" };
+        secondChain.Add(new AnimationFrame
+        {
+            FrameLength = 1f,
+            Texture = new Texture2D { Width = 20, Height = 20 },
+            LeftCoordinate = 0f,
+            RightCoordinate = 1f,
+            TopCoordinate = 0f,
+            BottomCoordinate = 1f,
+        });
+        var chainList = new AnimationChainList();
+        chainList.Add(firstChain);
+        chainList.Add(secondChain);
+        sut.AnimationChains = chainList;
+        sut.TextureWidth.ShouldBe(10);
+
+        sut.SetProperty(nameof(SpriteRuntime.CurrentChainName), "SecondChain");
+
+        sut.CurrentChainName.ShouldBe("SecondChain");
+        sut.TextureWidth.ShouldBe(20);
+    }
+
+    [Fact]
+    public void SetProperty_RenderTargetTextureSource_CanAssignStringDirectReferenceAndNull()
+    {
+        var parent = new ContainerRuntime();
+        var sut = new SpriteRuntime { Name = "TestSprite" };
+        var renderTarget = new SpriteRuntime { Name = "RenderTarget" };
+
+        parent.Children.Add(sut);
+        parent.Children.Add(renderTarget);
+
+        sut.SetProperty(nameof(SpriteRuntime.RenderTargetTextureSource), "RenderTarget");
+        sut.RenderTargetTextureSource.ShouldNotBeNull();
+        sut.RenderTargetTextureSource.ShouldBe(renderTarget);
+
+        var directReference = new SpriteRuntime { Name = "Direct" };
+        parent.Children.Add(directReference);
+
+        sut.SetProperty(nameof(SpriteRuntime.RenderTargetTextureSource), directReference);
+        sut.RenderTargetTextureSource.ShouldNotBeNull();
+        sut.RenderTargetTextureSource.ShouldBe(directReference);
+
+        sut.SetProperty(nameof(SpriteRuntime.RenderTargetTextureSource), null);
+        sut.RenderTargetTextureSource.ShouldBeNull();
+    }
+
+    [Fact]
+    public void SourceFileName_MissingFile_ShouldInvokePropertyAssignmentError_WhenNotThrowing()
+    {
+        var savedBehavior = GraphicalUiElement.MissingFileBehavior;
+        GraphicalUiElement.MissingFileBehavior = MissingFileBehavior.ConsumeSilently;
+
+        string? capturedMessage = null;
+        void Handler(string message) => capturedMessage = message;
+        CustomSetPropertyOnRenderable.PropertyAssignmentError += Handler;
+
+        try
+        {
+            SpriteRuntime sut = new();
+
+            sut.SourceFileName = "ThisFileDoesNotExist_" + Guid.NewGuid().ToString("N") + ".png";
+
+            capturedMessage.ShouldNotBeNull();
+            sut.Texture.ShouldBeNull();
+        }
+        finally
+        {
+            CustomSetPropertyOnRenderable.PropertyAssignmentError -= Handler;
+            GraphicalUiElement.MissingFileBehavior = savedBehavior;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Part of #3615 (Raylib/MonoGame runtime-file unification). This is the "Sprite family" convergence — disjoint from the font-region convergence in #3627 (different methods, no overlap).

Converges the two remaining per-platform copies of `CustomSetPropertyOnRenderable`'s Sprite-handling methods:
- `Gum/Wireframe/CustomSetPropertyOnRenderable.cs` (home copy — compiled into MonoGame/KNI/FNA and FRB)
- `Runtimes/RaylibGum/Renderables/CustomSetPropertyOnRenderable.cs` (Raylib copy)

Target methods: `TrySetPropertyOnSprite`, `AssignSourceFileOnSprite`, `GetAnimationChainList` (already identical, untouched). After this change the cross-file diff for these three methods is zero except for lines under mirrored `#if RAYLIB` / `#if !RAYLIB`.

### Structural changes (behavior-preserving)
- Home's `if/else if` chain converged onto Raylib's `switch` form (cleaner, per prior convergence precedent).
- `AssignSourceFileOnSprite`'s texture-load error handling unified onto the fuller structure (nullable `texture` + `loadException`, single `Texture2D` type reference instead of a redundant fully-qualified `Microsoft.Xna.Framework.Graphics.Texture2D`).
- Removed a dead `SpriteRuntime? asSpriteRuntime` local in the Raylib copy (unused; the disabled cases it was for are now live and each resolve their own runtime reference).
- Removed Raylib's `case nameof(Sprite.Texture): sprite.Texture = (Texture2D)value;` — redundant with the reflection fallback in `SetPropertyOnRenderable`, which already assigns the same value to the same renderable property when no case handles it. Home never had this case.

### Platform-necessary divergences (kept under mirrored `#if`)
- `Sprite.Color`: XNA/System.Drawing color handling is `#if !RAYLIB`-only. Raylib's branch stays absent — assigning `"Color"` via the state/variable system remains unimplemented on Raylib (there is no `System.Drawing.Color` → `Raylib_cs.Color` converter yet; NineSlice's identical gap is marked `// todo - need to convert`). This preserves current (non-)behavior; no regression.
- The `AtlasedTexture` check in `AssignSourceFileOnSprite` is `#if !RAYLIB`-only — `AtlasedTexture` isn't compiled into `RaylibGum.csproj` at all. Preserves current behavior.
- `Blend`: the propertyName dispatch is now shared, but the two platforms use genuinely different underlying storage — `#if RAYLIB` assigns Raylib's native `Gum.RenderingLibrary.Blend? Blend` property directly; `#if !RAYLIB` keeps the existing `.ToBlendState()` → XNA `BlendState` conversion.

### Latent bugs found & fixed (regression-tested)
Restructuring Raylib's commented-out cases into live ones surfaced real gaps — assigning these properties via the state/variable system (`GraphicalUiElement.SetProperty`, as opposed to direct C# property assignment) silently no-op'd on Raylib:
- **`Animate` / `CurrentChainName`**: entirely unwired in Raylib's dispatcher. Added pass-through `Animate`/`CurrentChainName` properties to `Runtimes/RaylibGum/Renderables/Sprite.cs` (mirroring the home renderable) so the shared case body compiles and works identically on both platforms. `CurrentChainName` additionally needed the `UpdateTextureValuesFrom` + `UpdateLayout` follow-up calls that were commented out — without them, `TextureWidth`/`TextureHeight` at the `GraphicalUiElement` layer don't sync when the chain switches this way.
- **`RenderTargetTextureSource`**: the dispatch case was missing entirely from the Raylib copy, even though `SpriteRuntime.RenderTargetTextureSource` is supported on Raylib (`#if XNALIKE || RAYLIB`). Added, mirroring home's `#if !FRB` case.
- **`AssignSourceFileOnSprite` missing-file path**: on Raylib, a failed texture load under `MissingFileBehavior.ConsumeSilently` (the default) silently cleared the texture with no notification. Home already fires `PropertyAssignmentError` in this case (used by the tool's error-indicator system) — Raylib now does too.
- **`Blend` was not actually broken** — it looked disabled (commented out in the dispatcher) but the reflection fallback in `SetPropertyOnRenderable` already found and set Raylib's native `Blend` property correctly via `Convert.ChangeType`. It's now handled explicitly (consistent with the shared switch and slightly clearer), not a behavior change.

### Tests
Added `Tests/RaylibGum.Tests/Runtimes/SpriteSetPropertyTests.cs` — 5 tests covering `SetProperty` for `Blend`, `Animate`, `CurrentChainName` (with two chains so the default chain-0 index doesn't mask the assertion), `RenderTargetTextureSource`, and the `PropertyAssignmentError` missing-file case. Verified red against the pre-fix Raylib source for the 4 genuine bugs (temporarily stashed the Raylib production changes and reran); `Blend` passed even pre-fix as expected (reflection fallback already worked).

- `dotnet test Tests/RaylibGum.Tests/RaylibGum.Tests.csproj` — 483 passed, 0 failed
- `dotnet test MonoGameGum.Tests/MonoGameGum.Tests.csproj` — 1844 passed, 0 failed
- `dotnet build MonoGameGum/KniGum/KniGum.csproj` — 0 errors
- No new compiler warnings from the touched files
- No files added/renamed in a way that needs `GumCoreShared.projitems` changes

**FRB CANARY NOT RUN** — this PR was built in a git worktree (`.claude/worktrees/3615-sprite-family`), and the FRB canary (`dotnet build GumCore/GumCoreXnaPc/GumCore.DesktopGlNet6/GumCore.DesktopGlNet6.csproj`) cannot run from a worktree. **Run it from the primary checkout on this branch before merge.** The touched `Gum/Wireframe/CustomSetPropertyOnRenderable.cs` is part of `GumCoreShared.projitems` (FRB-shared); all new/changed lines in the `#if !RAYLIB` live paths are unchanged from before except cosmetic (type qualification, structural reshuffling), so risk is low, but this hasn't been verified by an actual FRB build.

