### PR TITLE
Converge support-method dispatch of CustomSetPropertyOnRenderable (Raylib <-> MonoGame)

### DIFF
--- a/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
+++ b/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
@@ -2136,6 +2136,7 @@ public class CustomSetPropertyOnRenderable
     {
         var managers = iSystemManagers as SystemManagers;
 
+#if !RAYLIB
         if (renderable is Sprite)
         {
             managers.SpriteManager.Add(renderable as Sprite, layer);
@@ -2169,6 +2170,7 @@ public class CustomSetPropertyOnRenderable
             managers.SpriteManager.Add(renderable as InvisibleRenderable, layer);
         }
         else
+#endif
         {
             if (layer == null)
             {
@@ -2181,8 +2183,32 @@ public class CustomSetPropertyOnRenderable
         }
     }
 
+    /// <summary>
+    /// Detaches <paramref name="renderable"/> from the renderer so it stops drawing. On raylib,
+    /// where the add path (<see cref="AddRenderableToManagers"/>) is purely layer-based (no
+    /// Sprite/Shape/TextManager), removal just searches the renderer's layers for the renderable
+    /// and removes it (issue #3048). On XNA-like backends, removal dispatches by renderable type
+    /// to the matching manager, mirroring the type-dispatch add path.
+    /// </summary>
     public static void RemoveRenderableFromManagers(IRenderableIpso renderable, ISystemManagers iSystemManagers)
     {
+#if RAYLIB
+        if (renderable == null)
+        {
+            return;
+        }
+
+        var managers = (SystemManagers)iSystemManagers;
+
+        foreach (var layer in managers.Renderer.Layers)
+        {
+            if (layer.Renderables.Contains(renderable))
+            {
+                layer.Remove(renderable);
+                return;
+            }
+        }
+#else
         var managers = (SystemManagers)iSystemManagers;
 
         if (renderable is Sprite asSprite)
@@ -2227,6 +2253,7 @@ public class CustomSetPropertyOnRenderable
         {
             asManagedObject.RemoveFromManagers();
         }
+#endif
     }
 
     public static void ThrowExceptionsForMissingFiles(GraphicalUiElement graphicalUiElement)

--- a/Runtimes/RaylibGum/Renderables/CustomSetPropertyOnRenderable.cs
+++ b/Runtimes/RaylibGum/Renderables/CustomSetPropertyOnRenderable.cs
@@ -90,11 +90,12 @@ public class CustomSetPropertyOnRenderable
 
     /// <summary>
     /// Returns the original (pre-translation) string assigned via the localization
-    /// path on the given element, or null if no localizable text has been assigned.
+    /// path on the given element, or null if no localizable text has been assigned
+    /// (or it was overwritten via <c>SetTextNoTranslate</c>).
     /// </summary>
-    public static string TryGetLocalizationKey(GraphicalUiElement element)
+    public static string? TryGetLocalizationKey(GraphicalUiElement element)
     {
-        return _localizationKeys.TryGetValue(element, out string key) ? key : null;
+        return _localizationKeys.TryGetValue(element, out string? key) ? key : null;
     }
 
 #if !FRB
@@ -1443,39 +1444,41 @@ public class CustomSetPropertyOnRenderable
     {
         var managers = iSystemManagers as SystemManagers;
 
-        //if (renderable is Sprite)
-        //{
-        //    managers.SpriteManager.Add(renderable as Sprite, layer);
-        //}
-        //else if (renderable is NineSlice)
-        //{
-        //    managers.SpriteManager.Add(renderable as NineSlice, layer);
-        //}
-        //else if (renderable is LineRectangle)
-        //{
-        //    managers.ShapeManager.Add(renderable as LineRectangle, layer);
-        //}
-        //else if (renderable is SolidRectangle)
-        //{
-        //    managers.ShapeManager.Add(renderable as SolidRectangle, layer);
-        //}
-        //else if (renderable is Text)
-        //{
-        //    managers.TextManager.Add(renderable as Text, layer);
-        //}
-        //else if (renderable is LineCircle)
-        //{
-        //    managers.ShapeManager.Add(renderable as LineCircle, layer);
-        //}
-        //else if (renderable is LinePolygon)
-        //{
-        //    managers.ShapeManager.Add(renderable as LinePolygon, layer);
-        //}
-        //else if (renderable is InvisibleRenderable)
-        //{
-        //    managers.SpriteManager.Add(renderable as InvisibleRenderable, layer);
-        //}
-        //else
+#if !RAYLIB
+        if (renderable is Sprite)
+        {
+            managers.SpriteManager.Add(renderable as Sprite, layer);
+        }
+        else if (renderable is NineSlice)
+        {
+            managers.SpriteManager.Add(renderable as NineSlice, layer);
+        }
+        else if (renderable is LineRectangle)
+        {
+            managers.ShapeManager.Add(renderable as LineRectangle, layer);
+        }
+        else if (renderable is SolidRectangle)
+        {
+            managers.ShapeManager.Add(renderable as SolidRectangle, layer);
+        }
+        else if (renderable is Text)
+        {
+            managers.TextManager.Add(renderable as Text, layer);
+        }
+        else if (renderable is LineCircle)
+        {
+            managers.ShapeManager.Add(renderable as LineCircle, layer);
+        }
+        else if (renderable is LinePolygon)
+        {
+            managers.ShapeManager.Add(renderable as LinePolygon, layer);
+        }
+        else if (renderable is InvisibleRenderable)
+        {
+            managers.SpriteManager.Add(renderable as InvisibleRenderable, layer);
+        }
+        else
+#endif
         {
             if (layer == null)
             {
@@ -1489,14 +1492,15 @@ public class CustomSetPropertyOnRenderable
     }
 
     /// <summary>
-    /// Detaches <paramref name="renderable"/> from the renderer so it stops drawing. This is the
-    /// remove counterpart to <see cref="AddRenderableToManagers"/> and is wired into
-    /// <see cref="GraphicalUiElement.RemoveRenderableFromManagers"/> by <c>SystemManagers.Initialize</c>
-    /// (issue #3048). Because the Raylib add path is purely layer-based (no Sprite/Shape/TextManager),
-    /// removal just searches the renderer's layers for the renderable and removes it.
+    /// Detaches <paramref name="renderable"/> from the renderer so it stops drawing. On raylib,
+    /// where the add path (<see cref="AddRenderableToManagers"/>) is purely layer-based (no
+    /// Sprite/Shape/TextManager), removal just searches the renderer's layers for the renderable
+    /// and removes it (issue #3048). On XNA-like backends, removal dispatches by renderable type
+    /// to the matching manager, mirroring the type-dispatch add path.
     /// </summary>
     public static void RemoveRenderableFromManagers(IRenderableIpso renderable, ISystemManagers iSystemManagers)
     {
+#if RAYLIB
         if (renderable == null)
         {
             return;
@@ -1512,5 +1516,51 @@ public class CustomSetPropertyOnRenderable
                 return;
             }
         }
+#else
+        var managers = (SystemManagers)iSystemManagers;
+
+        if (renderable is Sprite asSprite)
+        {
+            managers.SpriteManager.Remove(asSprite);
+        }
+        else if (renderable is NineSlice asNineSlice)
+        {
+            managers.SpriteManager.Remove(asNineSlice);
+        }
+        else if (renderable is global::RenderingLibrary.Math.Geometry.LineRectangle asLineRectangle)
+        {
+            managers.ShapeManager.Remove(asLineRectangle);
+        }
+        else if (renderable is global::RenderingLibrary.Math.Geometry.LinePolygon asLinePolygon)
+        {
+            managers.ShapeManager.Remove(asLinePolygon);
+        }
+        else if (renderable is global::RenderingLibrary.Graphics.SolidRectangle solidRectangle)
+        {
+            managers.ShapeManager.Remove(solidRectangle);
+        }
+        else if (renderable is Text asText)
+        {
+            managers.TextManager.Remove(asText);
+        }
+        else if (renderable is LineCircle asLineCircle)
+        {
+            managers.ShapeManager.Remove(asLineCircle);
+        }
+        else if (renderable is InvisibleRenderable asInvisibleRenderable)
+        {
+            managers.SpriteManager.Remove(asInvisibleRenderable);
+        }
+        else if (renderable != null)
+        {
+            // This could be a custom visual object, so don't do anything:
+            //throw new NotImplementedException();
+            managers.Renderer.RemoveRenderable(renderable);
+        }
+        if (renderable is IManagedObject asManagedObject)
+        {
+            asManagedObject.RemoveFromManagers();
+        }
+#endif
     }
 }


### PR DESCRIPTION
## Summary

Part of the #3615 whole-file convergence (MonoGame/KNI/FNA/FRB `Gum/Wireframe/CustomSetPropertyOnRenderable.cs` <-> Raylib `Runtimes/RaylibGum/Renderables/CustomSetPropertyOnRenderable.cs`). Disjoint from the font-region and Sprite-family convergence PRs — this is the "support-methods" pass, converging four smaller dispatch-independent methods to identical text:

- `TryGetLocalizationKey` — reconciled nullability (`string?` everywhere; Raylib project also has `Nullable enable`, and there are no callers within `RaylibGum` to ripple to).
- `AssignSourceShaderFileOnContainer` — code was already logically identical; confirmed via `git diff --no-index` that only doc/inline comments differ, and those differences are genuinely platform-specific (`.fx`/`Effect` vs `.fs`/`.glsl`/`Shader`, and a note about `Shader` being a non-`IDisposable` struct on raylib) — left as-is, matching the existing per-platform XML-doc pattern already used elsewhere in this file.
- `AddRenderableToManagers` — Raylib's copy had the entire type-dispatch block commented out as dead code (raylib has no `SpriteManager`/`ShapeManager`/`TextManager`). Converted it to live code gated by a mirrored `#if !RAYLIB`/`#endif`, identical to the home copy — same runtime behavior (raylib always fell through to the generic layer-add path), now expressed as compiled+guarded code instead of a comment block.
- `RemoveRenderableFromManagers` — the two implementations are architecturally different (manager-type dispatch on XNA-like vs. layer-search on raylib, per issue #3048) with no shared skeleton, so the whole body is now wrapped in a mirrored `#if RAYLIB` / `#else` / `#endif` — byte-identical text in both files.

No behavior changes. `git diff --no-index` on all four target methods is now zero (modulo the two platform-accurate comment lines in `AssignSourceShaderFileOnContainer`).

## Test plan
- [x] `dotnet test MonoGameGum.Tests/MonoGameGum.Tests.csproj` — 1844 passed, 0 failed
- [x] `dotnet test Tests/RaylibGum.Tests/RaylibGum.Tests.csproj` — 483 passed, 0 failed
- [x] `dotnet build MonoGameGum/KniGum/KniGum.csproj` — 0 errors, only pre-existing warnings
- [x] `dotnet build Runtimes/RaylibGum/RaylibGum.csproj` — 0 errors, only pre-existing warnings
- [ ] **FRB CANARY NOT RUN** — this PR was built in a `.claude/worktrees/` git worktree, and the FRB canary (`dotnet build GumCore/GumCoreXnaPc/GumCore.DesktopGlNet6/GumCore.DesktopGlNet6.csproj`) cannot run from a worktree. Run it from the primary checkout on this branch before merge.

No new files added/renamed, so no `GumCoreShared.projitems` change is needed.

Co-Authored-By: Claude <noreply@anthropic.com>
