### PR TITLE
Converge NineSlice dispatch of CustomSetPropertyOnRenderable (Raylib <-> MonoGame/KNI/FNA/FRB)

### DIFF
--- a/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
+++ b/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
@@ -420,11 +420,18 @@ public class CustomSetPropertyOnRenderable
         }
         else if (propertyName == "Blend")
         {
-            var valueAsGumBlend = (RenderingLibrary.Blend)value;
+            var valueAsGumBlend = (Gum.RenderingLibrary.Blend)value;
 
+#if !RAYLIB
             var valueAsXnaBlend = valueAsGumBlend.ToBlendState();
 
             nineSlice.BlendState = valueAsXnaBlend;
+#else
+            // Gum.Renderables.NineSlice (Raylib) stores the Gum-level Blend enum directly (see its
+            // Blend property) rather than an XNA BlendState object, so no ToBlendState() bridge is
+            // needed here, unlike the XNA-family branch above.
+            nineSlice.Blend = valueAsGumBlend;
+#endif
 
             handled = true;
         }
@@ -438,6 +445,7 @@ public class CustomSetPropertyOnRenderable
         }
         else if (propertyName == "Color")
         {
+#if !RAYLIB
             if (value is System.Drawing.Color drawingColor)
             {
                 nineSlice.Color = drawingColor;
@@ -448,6 +456,12 @@ public class CustomSetPropertyOnRenderable
 
             }
             handled = true;
+#else
+            // TODO #3629 - no System.Drawing.Color -> Raylib_cs.Color converter exists yet, so this
+            // is a tracked no-op. SetPropertyOnRenderable falls back to reflection afterward, which
+            // also can't bridge the type mismatch, so a data-driven "Color" value is silently
+            // dropped on Raylib until #3629 lands.
+#endif
         }
         else if(propertyName == "Red")
         {
@@ -517,20 +531,25 @@ public class CustomSetPropertyOnRenderable
 
             //check if part of atlas
             //Note: assumes that if this filename is in an atlas that all 9 are in an atlas
+#if !RAYLIB
             var atlasedTexture = global::RenderingLibrary.Content.LoaderManager.Self.TryLoadContent<AtlasedTexture>(value);
             if (atlasedTexture != null)
             {
                 nineSlice.LoadAtlasedTexture(value, atlasedTexture);
             }
             else
+#endif
             {
+#if !RAYLIB
                 if (NineSliceExtensions.GetIfShouldUsePattern(value))
                 {
                     nineSlice.SetTexturesUsingPattern(value, SystemManagers.Default, false);
                 }
                 else
+#endif
                 {
 
+#if !RAYLIB
                     Microsoft.Xna.Framework.Graphics.Texture2D? texture =
                         Sprite.InvalidTexture;
 
@@ -558,6 +577,30 @@ public class CustomSetPropertyOnRenderable
                         texture = Sprite.InvalidTexture;
                     }
                     nineSlice.SetSingleTexture(texture);
+#else
+                    // Raylib has neither atlas (AtlasedTexture) nor tiled-pattern
+                    // (SetTexturesUsingPattern) NineSlice support, and no InvalidTexture placeholder
+                    // (Sprite.InvalidTexture lives on the XNA-only RenderingLibrary.Graphics.Sprite) -
+                    // so a load failure here can only honor MissingFileBehavior.ThrowException or
+                    // leave the texture unset.
+                    Texture2D? texture = null;
+
+                    try
+                    {
+                        texture =
+                            loaderManager.LoadContent<Texture2D>(value);
+                    }
+                    catch (Exception)
+                    {
+                        if (GraphicalUiElement.MissingFileBehavior == MissingFileBehavior.ThrowException)
+                        {
+                            string message = $"Error setting SourceFile on NineSlice named {nineSlice.Name}:\n{value}";
+                            throw new System.IO.FileNotFoundException(message);
+                        }
+                        // do nothing?
+                    }
+                    nineSlice.SetSingleTexture(texture);
+#endif
 
                 }
             }

--- a/Runtimes/RaylibGum/Renderables/CustomSetPropertyOnRenderable.cs
+++ b/Runtimes/RaylibGum/Renderables/CustomSetPropertyOnRenderable.cs
@@ -165,9 +165,9 @@ public class CustomSetPropertyOnRenderable
         {
             handled = TrySetPropertyOnSprite(renderableSprite, graphicalUiElement, propertyName, value);
         }
-        else if (renderableIpso is NineSlice)
+        else if (renderableIpso is NineSlice nineSlice)
         {
-            handled = TrySetPropertyOnNineSlice(renderableIpso, graphicalUiElement, propertyName, value, handled);
+            handled = TrySetPropertyOnNineSlice(nineSlice, graphicalUiElement, propertyName, value, handled);
         }
         else if (renderableIpso is InvisibleRenderable invisibleRenderable)
         {
@@ -282,48 +282,60 @@ public class CustomSetPropertyOnRenderable
     }
 
 
-    private static bool TrySetPropertyOnNineSlice(IRenderableIpso renderableIpso, GraphicalUiElement graphicalUiElement, string propertyName, object value, bool handled)
+    private static bool TrySetPropertyOnNineSlice(NineSlice nineSlice, GraphicalUiElement graphicalUiElement, string propertyName, object value, bool handled)
     {
-        var nineSlice = renderableIpso as NineSlice;
 
         if (propertyName == "SourceFile")
         {
             AssignSourceFileOnNineSlice(value as string, graphicalUiElement, nineSlice);
             handled = true;
         }
-        //else if (propertyName == "Blend")
-        //{
-        //    var valueAsGumBlend = (RenderingLibrary.Blend)value;
+        else if (propertyName == "Blend")
+        {
+            var valueAsGumBlend = (Gum.RenderingLibrary.Blend)value;
 
-        //    var valueAsXnaBlend = valueAsGumBlend.ToBlendState();
+#if !RAYLIB
+            var valueAsXnaBlend = valueAsGumBlend.ToBlendState();
 
-        //    nineSlice.BlendState = valueAsXnaBlend;
+            nineSlice.BlendState = valueAsXnaBlend;
+#else
+            // Gum.Renderables.NineSlice (Raylib) stores the Gum-level Blend enum directly (see its
+            // Blend property) rather than an XNA BlendState object, so no ToBlendState() bridge is
+            // needed here, unlike the XNA-family branch above.
+            nineSlice.Blend = valueAsGumBlend;
+#endif
 
-        //    handled = true;
-        //}
-        //else if (propertyName == nameof(NineSlice.CustomFrameTextureCoordinateWidth))
-        //{
-        //    var asFloat = value as float?;
+            handled = true;
+        }
+        else if (propertyName == nameof(NineSlice.CustomFrameTextureCoordinateWidth))
+        {
+            var asFloat = value as float?;
 
-        //    nineSlice.CustomFrameTextureCoordinateWidth = asFloat;
+            nineSlice.CustomFrameTextureCoordinateWidth = asFloat;
 
-        //    handled = true;
-        //}
+            handled = true;
+        }
         else if (propertyName == "Color")
         {
-            // todo - need to convert
-            //if (value is System.Drawing.Color drawingColor)
-            //{
-            //    nineSlice.Color = drawingColor;
-            //}
-            //else if (value is Microsoft.Xna.Framework.Color xnaColor)
-            //{
-            //    nineSlice.Color = xnaColor.ToSystemDrawing();
+#if !RAYLIB
+            if (value is System.Drawing.Color drawingColor)
+            {
+                nineSlice.Color = drawingColor;
+            }
+            else if (value is Microsoft.Xna.Framework.Color xnaColor)
+            {
+                nineSlice.Color = xnaColor.ToSystemDrawing();
 
-            //}
-            //handled = true;
+            }
+            handled = true;
+#else
+            // TODO #3629 - no System.Drawing.Color -> Raylib_cs.Color converter exists yet, so this
+            // is a tracked no-op. SetPropertyOnRenderable falls back to reflection afterward, which
+            // also can't bridge the type mismatch, so a data-driven "Color" value is silently
+            // dropped on Raylib until #3629 lands.
+#endif
         }
-        else if (propertyName == "Red")
+        else if(propertyName == "Red")
         {
             nineSlice.Red = (int)value;
             handled = true;
@@ -343,11 +355,21 @@ public class CustomSetPropertyOnRenderable
             nineSlice.SetSingleTexture((Texture2D)value);
             handled = true;
         }
+        else if(propertyName == nameof(NineSlice.BorderScale))
+        {
+            nineSlice.BorderScale = (float)value;
+            handled = true;
+        }
+        else if(propertyName == nameof(NineSlice.IsTilingMiddleSections))
+        {
+            nineSlice.IsTilingMiddleSections = (bool)value;
+            handled = true;
+        }
 
-        // Texture coordiantes like TextureLeft, TextureRight, TextureWidth, and TextureHeight
-        // are handled by GraphicalUiElement so we don't have to handle it here
+            // Texture coordiantes like TextureLeft, TextureRight, TextureWidth, and TextureHeight
+            // are handled by GraphicalUiElement so we don't have to handle it here
 
-        return handled;
+            return handled;
     }
 
     private static void AssignSourceFileOnNineSlice(string value, GraphicalUiElement graphicalUiElement, NineSlice nineSlice)
@@ -381,21 +403,58 @@ public class CustomSetPropertyOnRenderable
 
             //check if part of atlas
             //Note: assumes that if this filename is in an atlas that all 9 are in an atlas
-            //var atlasedTexture = global::RenderingLibrary.Content.LoaderManager.Self.TryLoadContent<AtlasedTexture>(value);
-            //if (atlasedTexture != null)
-            //{
-            //    nineSlice.LoadAtlasedTexture(value, atlasedTexture);
-            //}
-            //else
+#if !RAYLIB
+            var atlasedTexture = global::RenderingLibrary.Content.LoaderManager.Self.TryLoadContent<AtlasedTexture>(value);
+            if (atlasedTexture != null)
             {
-                //if (NineSliceExtensions.GetIfShouldUsePattern(value))
-                //{
-                //    nineSlice.SetTexturesUsingPattern(value, SystemManagers.Default, false);
-                //}
-                //else
+                nineSlice.LoadAtlasedTexture(value, atlasedTexture);
+            }
+            else
+#endif
+            {
+#if !RAYLIB
+                if (NineSliceExtensions.GetIfShouldUsePattern(value))
+                {
+                    nineSlice.SetTexturesUsingPattern(value, SystemManagers.Default, false);
+                }
+                else
+#endif
                 {
 
-                    //Texture2D? texture = Sprite.InvalidTexture;
+#if !RAYLIB
+                    Microsoft.Xna.Framework.Graphics.Texture2D? texture =
+                        Sprite.InvalidTexture;
+
+                    try
+                    {
+                        texture =
+                            loaderManager.LoadContent<Microsoft.Xna.Framework.Graphics.Texture2D>(value);
+                    }
+                    catch (Exception)
+                    {
+                        // Treated the same as a missing file below.
+                        texture = null;
+                    }
+
+                    if (texture == null)
+                    {
+                        // On desktop the loader returns null for a missing file instead of throwing, and a
+                        // genuine load error is funneled here too. Honor MissingFileBehavior; otherwise fall
+                        // back to the invalid-texture placeholder, matching the prior catch behavior.
+                        if (GraphicalUiElement.MissingFileBehavior == MissingFileBehavior.ThrowException)
+                        {
+                            string message = $"Error setting SourceFile on NineSlice named {nineSlice.Name}:\n{value}";
+                            throw new System.IO.FileNotFoundException(message);
+                        }
+                        texture = Sprite.InvalidTexture;
+                    }
+                    nineSlice.SetSingleTexture(texture);
+#else
+                    // Raylib has neither atlas (AtlasedTexture) nor tiled-pattern
+                    // (SetTexturesUsingPattern) NineSlice support, and no InvalidTexture placeholder
+                    // (Sprite.InvalidTexture lives on the XNA-only RenderingLibrary.Graphics.Sprite) -
+                    // so a load failure here can only honor MissingFileBehavior.ThrowException or
+                    // leave the texture unset.
                     Texture2D? texture = null;
 
                     try
@@ -403,7 +462,7 @@ public class CustomSetPropertyOnRenderable
                         texture =
                             loaderManager.LoadContent<Texture2D>(value);
                     }
-                    catch (Exception e)
+                    catch (Exception)
                     {
                         if (GraphicalUiElement.MissingFileBehavior == MissingFileBehavior.ThrowException)
                         {
@@ -413,6 +472,7 @@ public class CustomSetPropertyOnRenderable
                         // do nothing?
                     }
                     nineSlice.SetSingleTexture(texture);
+#endif
 
                 }
             }

--- a/Tests/RaylibGum.Tests/Runtimes/DataDrivenNineSlicePropertyTests.cs
+++ b/Tests/RaylibGum.Tests/Runtimes/DataDrivenNineSlicePropertyTests.cs
@@ -1,0 +1,55 @@
+using Gum.GueDeriving;
+using Gum.Renderables;
+using Shouldly;
+
+namespace RaylibGum.Tests.Runtimes;
+
+/// <summary>
+/// Reproduces the data-driven property-application path that loading a .gumx project uses
+/// (<c>ApplyState</c> → <c>SetProperty(string, object)</c>), for NineSlice properties dispatched
+/// through <c>CustomSetPropertyOnRenderable.TrySetPropertyOnNineSlice</c>. These pin that the
+/// explicit dispatch cases produce the same result as the generic reflection fallback they
+/// replace (issue #3615 NineSlice convergence).
+/// </summary>
+public class DataDrivenNineSlicePropertyTests : BaseTestClass
+{
+    [Fact]
+    public void SetProperty_CustomFrameTextureCoordinateWidth_OnNineSlice_AppliesValue()
+    {
+        NineSliceRuntime sut = new();
+
+        Should.NotThrow(() => sut.SetProperty("CustomFrameTextureCoordinateWidth", 7f));
+
+        ((NineSlice)sut.RenderableComponent).CustomFrameTextureCoordinateWidth.ShouldBe(7f);
+    }
+
+    [Fact]
+    public void SetProperty_BorderScale_OnNineSlice_AppliesValue()
+    {
+        NineSliceRuntime sut = new();
+
+        Should.NotThrow(() => sut.SetProperty("BorderScale", 3f));
+
+        ((NineSlice)sut.RenderableComponent).BorderScale.ShouldBe(3f);
+    }
+
+    [Fact]
+    public void SetProperty_IsTilingMiddleSections_OnNineSlice_AppliesValue()
+    {
+        NineSliceRuntime sut = new();
+
+        Should.NotThrow(() => sut.SetProperty("IsTilingMiddleSections", true));
+
+        ((NineSlice)sut.RenderableComponent).IsTilingMiddleSections.ShouldBeTrue();
+    }
+
+    // Color -> Raylib_cs.Color has no converter yet (#3629), so this data-driven path is a
+    // tracked no-op. This pins that it stays a silent no-op rather than throwing.
+    [Fact]
+    public void SetProperty_Color_OnNineSlice_DoesNotThrow()
+    {
+        NineSliceRuntime sut = new();
+
+        Should.NotThrow(() => sut.SetProperty("Color", System.Drawing.Color.Red));
+    }
+}


### PR DESCRIPTION
## Summary

Converges the NineSlice pair of `CustomSetPropertyOnRenderable.cs` (home copy: `Gum/Wireframe/`; Raylib copy: `Runtimes/RaylibGum/Renderables/`) — part of #3615. Prior PRs converged the font region, the Sprite family, and four support methods; this one does `TrySetPropertyOnNineSlice` and `AssignSourceFileOnNineSlice`.

- Cross-file diff for these two methods: **146 lines -> 0**. Both copies are now byte-identical, with platform-necessary lines under mirrored `#if !RAYLIB` / `#if RAYLIB`.
- **Signature reconciliation**: `TrySetPropertyOnNineSlice` now takes `NineSlice` on both platforms (Raylib previously took `IRenderableIpso` and cast internally with `as NineSlice`). The single NineSlice dispatch line in `SetPropertyOnRenderable` (both copies) now pattern-matches `renderableIpso is NineSlice nineSlice` and passes the typed variable — the only edit made to that dispatch method.
- **Blend**: Raylib's case was previously fully commented out. `Gum.Renderables.NineSlice` (Raylib) already exposes a `Blend` property that stores the Gum-level `Blend` enum directly (no XNA `BlendState` conversion needed, unlike the XNA-family branch), so it's now wired under `#if RAYLIB`.
- **CustomFrameTextureCoordinateWidth, BorderScale, IsTilingMiddleSections**: uncommented/added on Raylib — `Gum.Renderables.NineSlice` already has matching properties. These were previously silently handled correctly via the `GraphicalUiElement.SetPropertyThroughReflection` fallback (`SetPropertyOnRenderable` falls through to reflection when nothing sets `handled = true`), so this is not a behavior fix, just removing indirection and converging the text. Added `Tests/RaylibGum.Tests/Runtimes/DataDrivenNineSlicePropertyTests.cs` to pin the data-driven `SetProperty(string, object)` path for these (mirrors the existing `DataDrivenBlendPropertyTests.cs` pattern) — all 4 new tests were green *before* the source change (proving the reflection fallback already worked) and stayed green after.
- **Color**: kept as a tracked no-op on Raylib with a `// TODO #3629` comment (no `System.Drawing.Color` -> `Raylib_cs.Color` converter exists yet — tracked separately as #3629). Not implemented here per scope.
- **AssignSourceFileOnNineSlice**: the atlas (`AtlasedTexture`)/pattern (`SetTexturesUsingPattern`)/`InvalidTexture`-placeholder path is genuinely platform-necessary — Raylib's `NineSlice` has none of those three capabilities yet (`Sprite.InvalidTexture` lives on the XNA-only `RenderingLibrary.Graphics.Sprite`), so that whole block stays under mirrored `#if !RAYLIB`/`#if RAYLIB` with each platform's existing behavior preserved as-is.
- Fixed a `RenderingLibrary.Blend` -> `Gum.RenderingLibrary.Blend` qualification bug in the newly-shared cast line: it compiled in the home file only because that file is nested under `namespace Gum.Wireframe` (enclosing-namespace lookup found `Gum.RenderingLibrary.Blend`); Raylib's file lives in `namespace RaylibGum.Renderables` and doesn't get that benefit, so it hit the unrelated top-level `RenderingLibrary` namespace and failed with CS0234. Fully-qualified in both copies.

No files added/renamed in `GumCoreShared.projitems` scope besides the new test file (not FRB-relevant).

## Test plan

- [x] `dotnet test Tests/RaylibGum.Tests/RaylibGum.Tests.csproj` — 487/487 passed
- [x] `dotnet test MonoGameGum.Tests/MonoGameGum.Tests.csproj` — 1844/1844 passed
- [x] `dotnet build MonoGameGum/KniGum/KniGum.csproj` — succeeded, 0 errors
- [x] Zero new compiler warnings (verified against baseline)
- [x] FRB canary (`GumCore/GumCoreXnaPc/GumCore.DesktopGlNet6/GumCore.DesktopGlNet6.csproj`) built from the primary checkout — 0 errors, warnings identical to `main` baseline
- [x] Manual test: not needed — behavior-preserving convergence covered by unit tests + FRB canary + compilation; the only observable-but-unchanged path (Blend/CustomFrameTextureCoordinateWidth/BorderScale/IsTilingMiddleSections on Raylib) is pinned by the new `DataDrivenNineSlicePropertyTests.cs`, which was green before and after the source change.

Part of #3615. See #3629 for the deferred Raylib Color converter.

Co-Authored-By: Claude <noreply@anthropic.com>
