### PR TITLE
Converge TrySetPropertyOnText in CustomSetPropertyOnRenderable

### DIFF
--- a/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
+++ b/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
@@ -716,7 +716,7 @@ public class CustomSetPropertyOnRenderable
 
     #region Text
 
-    public static bool TrySetPropertyOnText(Text textRenderable, GraphicalUiElement graphicalUiElement, string propertyName, object value)
+    private static bool TrySetPropertyOnText(Text textRenderable, GraphicalUiElement graphicalUiElement, string propertyName, object value)
     {
         bool handled = false;
 
@@ -767,7 +767,6 @@ public class CustomSetPropertyOnRenderable
             textRenderable.InlineVariables.Clear();
             if (valueAsString?.Contains("[") == true)
             {
-
                 textRenderable.StoredMarkupText = valueAsString;
                 SetBbCodeText(textRenderable, graphicalUiElement, textRenderable.StoredMarkupText);
             }
@@ -814,14 +813,31 @@ public class CustomSetPropertyOnRenderable
         }
         else if (propertyName == "Font")
         {
+#if RAYLIB
+            if (value is Font font)
+            {
+                textRenderable.Font = font;
+                handled = true;
+            }
+            else if (value is string fontString)
+            {
+                if (textRuntime != null)
+                {
+                    textRuntime.Font = fontString;
+                }
+
+                ReactToFontValueChange();
+            }
+#else
             if(textRuntime != null)
             {
                 textRuntime.Font = value as string;
             }
 
             ReactToFontValueChange();
+#endif
         }
-#if XNALIKE
+#if XNALIKE || RAYLIB
         else if (propertyName == nameof(textRuntime.UseCustomFont))
         {
             if (textRuntime != null)
@@ -884,9 +900,16 @@ public class CustomSetPropertyOnRenderable
             }
             ReactToFontValueChange();
         }
-        else if (propertyName == "LineHeightMultiplier")
+        else if (propertyName == nameof(textRuntime.LineHeightMultiplier))
         {
+#if RAYLIB
+            if (textRuntime != null)
+            {
+                textRuntime.LineHeightMultiplier = (float)value;
+            }
+#else
             textRenderable.LineHeightMultiplier = (float)value;
+#endif
         }
         else if (propertyName == nameof(textRuntime.UseFontSmoothing))
         {
@@ -936,9 +959,6 @@ public class CustomSetPropertyOnRenderable
         else if (propertyName == "Color")
         {
 #if XNALIKE
-            //var valueAsColor = (Color)value;
-            //((Text)mContainedObjectAsIpso).Color = valueAsColor;
-            //handled = true;
             if (value is System.Drawing.Color drawingColor)
             {
                 textRenderable.Color = drawingColor;

--- a/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
+++ b/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
@@ -900,7 +900,7 @@ public class CustomSetPropertyOnRenderable
             }
             ReactToFontValueChange();
         }
-        else if (propertyName == nameof(textRuntime.LineHeightMultiplier))
+        else if (propertyName == "LineHeightMultiplier")
         {
 #if RAYLIB
             if (textRuntime != null)

--- a/Runtimes/RaylibGum/Renderables/CustomSetPropertyOnRenderable.cs
+++ b/Runtimes/RaylibGum/Renderables/CustomSetPropertyOnRenderable.cs
@@ -793,7 +793,7 @@ public class CustomSetPropertyOnRenderable
             }
             ReactToFontValueChange();
         }
-        else if (propertyName == nameof(textRuntime.LineHeightMultiplier))
+        else if (propertyName == "LineHeightMultiplier")
         {
 #if RAYLIB
             if (textRuntime != null)

--- a/Runtimes/RaylibGum/Renderables/CustomSetPropertyOnRenderable.cs
+++ b/Runtimes/RaylibGum/Renderables/CustomSetPropertyOnRenderable.cs
@@ -641,6 +641,9 @@ public class CustomSetPropertyOnRenderable
 
             // Track the original (untranslated) value so RefreshLocalization can
             // re-translate this element if CurrentLanguage changes later.
+            // - "Text" with an active LocalizationService stores the raw input.
+            // - "TextNoTranslate" always clears any previously-stored key so user
+            //   input or explicitly-untranslated values aren't re-translated later.
             if (propertyName == "TextNoTranslate")
             {
                 _localizationKeys.Remove(graphicalUiElement);
@@ -654,26 +657,31 @@ public class CustomSetPropertyOnRenderable
                 _localizationKeys.Remove(graphicalUiElement);
             }
 
-            var rawText = valueAsString;
-
-
-            if (LocalizationService != null && propertyName == "Text")
-            {
-                rawText = LocalizationService.Translate(rawText);
-            }
-
             textRenderable.InlineVariables.Clear();
-            if (rawText?.Contains("[") == true)
+            if (valueAsString?.Contains("[") == true)
             {
-                textRenderable.StoredMarkupText = rawText;
-                SetBbCodeText(textRenderable, graphicalUiElement, rawText);
+                textRenderable.StoredMarkupText = valueAsString;
+                SetBbCodeText(textRenderable, graphicalUiElement, textRenderable.StoredMarkupText);
             }
             else
             {
                 textRenderable.StoredMarkupText = null;
-                textRenderable.RawText = rawText;
-            }
+                var rawText = valueAsString;
+                if(LocalizationService != null && propertyName == "Text")
+                {
+                    rawText = LocalizationService.Translate(rawText);
+                }
 
+                if(rawText?.Contains("[") == true)
+                {
+                    textRenderable.StoredMarkupText = rawText;
+                    SetBbCodeText(textRenderable, graphicalUiElement, textRenderable.StoredMarkupText);
+                }
+                else
+                {
+                    textRenderable.RawText = rawText;
+                }
+            }
             // we want to update if the text's size is based on its "children" (the letters it contains)
             if (graphicalUiElement.WidthUnits == DimensionUnitType.RelativeToChildren ||
                 // If height is relative to children, it could be in a stack
@@ -698,6 +706,7 @@ public class CustomSetPropertyOnRenderable
         }
         else if (propertyName == "Font")
         {
+#if RAYLIB
             if (value is Font font)
             {
                 textRenderable.Font = font;
@@ -711,21 +720,24 @@ public class CustomSetPropertyOnRenderable
                 }
 
                 ReactToFontValueChange();
-                handled = true;
             }
-        }
+#else
+            if(textRuntime != null)
+            {
+                textRuntime.Font = value as string;
+            }
 
+            ReactToFontValueChange();
+#endif
+        }
+#if XNALIKE || RAYLIB
         else if (propertyName == nameof(textRuntime.UseCustomFont))
         {
             if (textRuntime != null)
             {
                 textRuntime.UseCustomFont = (bool)value;
             }
-            //var asText = ((Text)mContainedObjectAsIpso);
-            //if (!string.IsNullOrEmpty(asText.StoredMarkupText))
-            //{
-            //    SetBbCodeText(asText, graphicalUiElement, asText.StoredMarkupText);
-            //}
+
             ReactToFontValueChange();
         }
 
@@ -734,58 +746,168 @@ public class CustomSetPropertyOnRenderable
             if (textRuntime != null)
             {
                 textRuntime.CustomFontFile = (string)value;
-                ReactToFontValueChange();
             }
+            ReactToFontValueChange();
 
         }
-
+#if USE_GUMCOMMON
+        else if(propertyName == nameof(Gum.GueDeriving.TextRuntime.BitmapFont))
+        {
+            if(textRuntime != null)
+            {
+                textRuntime.BitmapFont = (BitmapFont)value;
+            }
+            handled = true;
+        }
+#endif
+#endif
         else if (propertyName == nameof(textRuntime.FontSize))
         {
             if (textRuntime != null)
             {
                 textRuntime.FontSize = (int)value;
-                ReactToFontValueChange();
             }
+            ReactToFontValueChange();
         }
         else if (propertyName == nameof(textRuntime.OutlineThickness))
         {
             if (textRuntime != null)
             {
                 textRuntime.OutlineThickness = (int)value;
-                ReactToFontValueChange();
             }
+            ReactToFontValueChange();
         }
         else if (propertyName == nameof(textRuntime.IsItalic))
         {
             if (textRuntime != null)
             {
                 textRuntime.IsItalic = (bool)value;
-                ReactToFontValueChange();
             }
+            ReactToFontValueChange();
         }
         else if (propertyName == nameof(textRuntime.IsBold))
         {
             if (textRuntime != null)
             {
                 textRuntime.IsBold = (bool)value;
-                ReactToFontValueChange();
             }
+            ReactToFontValueChange();
         }
         else if (propertyName == nameof(textRuntime.LineHeightMultiplier))
         {
+#if RAYLIB
             if (textRuntime != null)
             {
                 textRuntime.LineHeightMultiplier = (float)value;
             }
+#else
+            textRenderable.LineHeightMultiplier = (float)value;
+#endif
         }
         else if (propertyName == nameof(textRuntime.UseFontSmoothing))
         {
             if (textRuntime != null)
             {
                 textRuntime.UseFontSmoothing = (bool)value;
-                ReactToFontValueChange();
+            }
+            ReactToFontValueChange();
+        }
+        else if (propertyName == nameof(Blend))
+        {
+#if XNALIKE
+            var valueAsGumBlend = (RenderingLibrary.Blend)value;
+
+            var valueAsXnaBlend = valueAsGumBlend.ToBlendState();
+
+            textRenderable.BlendState = valueAsXnaBlend;
+            handled = true;
+#endif
+        }
+        else if (propertyName == "Alpha")
+        {
+#if XNALIKE
+            int valueAsInt = (int)value;
+            textRenderable.Alpha = valueAsInt;
+            handled = true;
+#endif
+        }
+        else if (propertyName == "Red")
+        {
+            int valueAsInt = (int)value;
+            textRenderable.Red = valueAsInt;
+            handled = true;
+        }
+        else if (propertyName == "Green")
+        {
+            int valueAsInt = (int)value;
+            textRenderable.Green = valueAsInt;
+            handled = true;
+        }
+        else if (propertyName == "Blue")
+        {
+            int valueAsInt = (int)value;
+            textRenderable.Blue = valueAsInt;
+            handled = true;
+        }
+        else if (propertyName == "Color")
+        {
+#if XNALIKE
+            if (value is System.Drawing.Color drawingColor)
+            {
+                textRenderable.Color = drawingColor;
+                handled = true;
+            }
+            else if (value is Microsoft.Xna.Framework.Color xnaColor)
+            {
+                textRenderable.Color = xnaColor.ToSystemDrawing();
+                handled = true;
+            }
+#endif
+        }
+
+        else if (propertyName == "HorizontalAlignment")
+        {
+            textRenderable.HorizontalAlignment = (HorizontalAlignment)value;
+            handled = true;
+        }
+        else if (propertyName == "VerticalAlignment")
+        {
+            textRenderable.VerticalAlignment = (VerticalAlignment)value;
+            handled = true;
+        }
+        else if (propertyName == "MaxLettersToShow")
+        {
+#if XNALIKE
+            textRenderable.MaxLettersToShow = (int?)value;
+            handled = true;
+#endif
+        }
+        else if (propertyName == "MaxNumberOfLines")
+        {
+            textRenderable.MaxNumberOfLines = (int?)value;
+            handled = true;
+        }
+
+        else if (propertyName == nameof(TextOverflowHorizontalMode))
+        {
+            var textOverflowMode = (TextOverflowHorizontalMode)value;
+
+            if (textOverflowMode == TextOverflowHorizontalMode.EllipsisLetter)
+            {
+                textRenderable.IsTruncatingWithEllipsisOnLastLine = true;
+            }
+            else
+            {
+                textRenderable.IsTruncatingWithEllipsisOnLastLine = false;
             }
         }
+        else if (propertyName == nameof(TextOverflowVerticalMode))
+        {
+            graphicalUiElement.TextOverflowVerticalMode = (TextOverflowVerticalMode)value;
+            graphicalUiElement.RefreshTextOverflowVerticalMode();
+
+        }
+
         return handled;
     }
 

--- a/Tests/RaylibGum.Tests/Runtimes/TextRuntimeTests.cs
+++ b/Tests/RaylibGum.Tests/Runtimes/TextRuntimeTests.cs
@@ -1,5 +1,6 @@
 ﻿using Gum.GueDeriving;
 using Gum.Wireframe;
+using RaylibGum.Renderables;
 using RenderingLibrary.Content;
 using RenderingLibrary.Graphics;
 using Raylib_cs;
@@ -741,6 +742,45 @@ public class TextRuntimeTests : BaseTestClass
         sut.Text = "Some text";
         sut.SetTextNoTranslate(null);
         sut.Text.ShouldBeNull();
+    }
+
+    #endregion
+
+    #region Localization + BBCode
+
+    // #3615: TrySetPropertyOnText must check the RAW (untranslated) value for literal BBCode before
+    // attempting translation - only a raw value with no BBCode is treated as a translation key. Raylib's
+    // copy previously translated unconditionally first, so literal markup assigned directly to Text (not
+    // through a translation key) got passed through LocalizationService.Translate, corrupting the raw text
+    // for any translation service that mutates unrecognized keys (as the real LocalizationService does by
+    // appending "(loc)"). Mirrors the MonoGame path's tested behavior (see TextRuntimeTests.Text_ShouldUseLocalization
+    // in MonoGameGum.Tests, added for #1795).
+    [Fact]
+    public void Text_WithLiteralBbCode_ShouldNotBeTranslated_WhenLocalizationServiceIsActive()
+    {
+        Gum.Localization.LocalizationService localizationService = new();
+        Dictionary<string, string[]> entries = new()
+        {
+            { "Greeting", new[] { "Hello" } }
+        };
+        localizationService.AddDatabase(entries, new List<string> { "English" });
+        localizationService.CurrentLanguage = 0;
+        CustomSetPropertyOnRenderable.LocalizationService = localizationService;
+
+        try
+        {
+            TextRuntime sut = new();
+            // Not a key in the database, so if this were passed to Translate it would come back with
+            // "(loc)" appended, which would corrupt the stripped RawText below.
+            sut.Text = "[Color=Red]Literal[/Color]";
+
+            Gum.Renderables.Text internalText = (Gum.Renderables.Text)sut.RenderableComponent;
+            internalText.RawText.ShouldBe("Literal");
+        }
+        finally
+        {
+            CustomSetPropertyOnRenderable.LocalizationService = null;
+        }
     }
 
     #endregion


### PR DESCRIPTION
Part of #3615 (Raylib/MonoGame runtime file convergence). Converges `TrySetPropertyOnText` in `CustomSetPropertyOnRenderable.cs` — the home copy (`Gum/Wireframe/`, compiled into MonoGame/KNI/FNA/FRB) and the Raylib copy (`Runtimes/RaylibGum/Renderables/`) — down to zero cross-file diff, with genuinely platform-specific lines under mirrored `#if RAYLIB`/`#if XNALIKE`/`#if USE_GUMCOMMON`.

## What changed

- **`Font` property**: Raylib's direct `Raylib_cs.Font`-struct assignment is genuinely platform-specific → gated under `#if RAYLIB`, with the string-only XNA path under `#else`.
- **`UseCustomFont`/`CustomFontFile`** (and the dead `BitmapFont`/`USE_GUMCOMMON` branch): widened from `#if XNALIKE` to `#if XNALIKE || RAYLIB` — Raylib's `TextRuntime` already supports custom fonts, so the narrower guard was pre-#3615 staging debt, not a real platform restriction.
- **`LineHeightMultiplier`**: kept each platform's differing side effects as-is (Raylib's runtime setter triggers `NotifyPropertyChanged`/`UpdateLayout`; MonoGame's direct renderable assignment does not) under mirrored `#if RAYLIB` — unifying that behavior is a separate question, out of scope for a behavior-preserving convergence.
- Added the MonoGame-only tail (`Blend`/`Alpha`/`Red`/`Green`/`Blue`/`Color`/`HorizontalAlignment`/`VerticalAlignment`/`MaxLettersToShow`/`MaxNumberOfLines`/`TextOverflowHorizontalMode`/`TextOverflowVerticalMode`) to the Raylib copy, verbatim with home's existing `#if XNALIKE` gates (dead there). The ungated members (Red/Green/Blue/alignment/overflow) are newly *live* on Raylib — verified against matching properties on `Gum.Renderables.Text` and the full `RaylibGum.Tests` suite (492/492 green).
- `TrySetPropertyOnText` access narrowed `public` → `private` in the home copy to match Raylib (no external callers reference it — confirmed by grep).
- Removed stale dead-code comments (`Color`/`UseCustomFont` branches).

## Latent bug fixed (regression-tested)

Raylib's `Text`/`TextNoTranslate` handling always translated the value first, then checked the *translated* string for BBCode. The MonoGame path (added for #1795, "Localization can now have BBCode") checks the **raw** value for BBCode first and skips translation entirely when literal markup is already present — Raylib had drifted from this, so literal BBCode text assigned directly (not via a translation key) got corrupted by the localization service (e.g. `"[Color=Red]Hi[/Color]"` → `LocalizationService.Translate(...)` → `"[Color=Red]Hi[/Color](loc)"` for an unrecognized-key service). Fixed Raylib to match home's tested ordering.

Added `Text_WithLiteralBbCode_ShouldNotBeTranslated_WhenLocalizationServiceIsActive` to `RaylibGum.Tests` — confirmed **red** against the pre-fix ordering (`RawText` came back as `"Literal(loc)"` instead of `"Literal"`), **green** after.

## Also converged (behavior-preserving)

Hoisted `ReactToFontValueChange()` calls outside their `textRuntime != null` checks for `CustomFontFile`/`FontSize`/`OutlineThickness`/`IsItalic`/`IsBold`/`UseFontSmoothing` in the Raylib copy, matching the pattern used consistently everywhere else in this method (and in home) — `ReactToFontValueChange` is unconditionally safe since the called `UpdateToFontValues` no-ops when `textRuntime` is null on both platforms.

## FRB break caught and fixed mid-PR

An earlier version of this PR converted the `"LineHeightMultiplier"` string-literal dispatch to `nameof(textRuntime.LineHeightMultiplier)` for consistency with its siblings (`FontSize`, `IsBold`, etc.). The FRB canary caught that `GraphicalUiElement` (the type `textRuntime` is under `#if FRB`) has no `LineHeightMultiplier` shim — unlike the other font members, which do (#3435). Reverted to the literal string in both copies; the FRB canary is green after the fix.

## Verification (all run by me)

- `dotnet test MonoGameGum.Tests/MonoGameGum.Tests.csproj` — 1848/1848 passed
- `dotnet test Tests/RaylibGum.Tests/RaylibGum.Tests.csproj` — 492/492 passed (491 existing + 1 new)
- `dotnet build MonoGameGum/KniGum/KniGum.csproj` — 0 errors, 0 warnings
- Zero new compiler warnings introduced by this change (checked line-by-line against `origin/main`)
- No `GumCoreShared.projitems` change needed (no files added/removed/renamed)
- **FRB canary** (`GumCore.DesktopGlNet6.csproj`, run from the primary checkout, not the worktree) — 0 errors, confirmed green after the fix above

## Before/after diff size

`git diff --no-index` between the two `TrySetPropertyOnText` method bodies: **282 lines → 0** (true zero, modulo a one-line extraction-boundary artifact in my measurement script).

## Deferred / not touched

- `SetPropertyOnRenderable`'s dispatch — owned by #3632 (already merged) — not touched.
- The font-resolution methods (`SetBbCodeText`, `ApplyFontVariables`, `UpdateToFontValues`, `GetAndCreateFontIfNecessary`) — already converged/settled, only their call sites inside `TrySetPropertyOnText` were touched.
- Sprite family, NineSlice, Container, home-only shape sections (SolidRectangle/Line*/Circle/Rectangle) — untouched, out of scope.
