### PR TITLE
Finish font-region byte-identity convergence (CustomSetPropertyOnRenderable)

### DIFF
--- a/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
+++ b/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
@@ -1037,7 +1037,16 @@ public class CustomSetPropertyOnRenderable
 
     static List<TagInfo> allTags = new List<TagInfo>();
 
-    private static void SetBbCodeText(global::RenderingLibrary.Graphics.Text asText, GraphicalUiElement graphicalUiElement, string bbcode)
+    /// <summary>
+    /// Parses BBCode markup, assigns the tag-stripped text to <see cref="Text.RawText"/>, and populates
+    /// <see cref="Text.InlineVariables"/> with the per-run styling the renderer applies: Color / Red /
+    /// Green / Blue and FontScale runs in the loop below, plus the resolved-font runs for the font family
+    /// tags (Font / FontSize / OutlineThickness / IsBold / IsItalic) produced by
+    /// <see cref="ApplyFontVariables"/> using the same stack model on every platform. A <c>[Custom]</c> tag's
+    /// per-letter callback is applied on the XNA-family backends (<c>#if !RAYLIB</c> below); on Raylib the tag
+    /// is recognized by the parser but has no effect yet (#3471).
+    /// </summary>
+    private static void SetBbCodeText(Text asText, GraphicalUiElement graphicalUiElement, string bbcode)
     {
         // The rendering/wrapping code ignores '\r', so normalize CRLF to LF before computing indexes.
         // Parsing and stripping from the same normalized string keeps InlineVariable indexes aligned
@@ -1049,8 +1058,8 @@ public class CustomSetPropertyOnRenderable
 
         asText.RawText = strippedText;
 
-        // Color / Red / Green / Blue / FontScale / Custom runs don't use the font-resolution stacks, so they
-        // are emitted regardless of whether the owning element is a TextRuntime.
+        // Color / Red / Green / Blue / FontScale runs don't use the font-resolution stacks, so they are
+        // emitted regardless of whether the owning element is a TextRuntime.
         foreach (var item in results)
         {
             object castedValue = item.Open.Argument;
@@ -1065,14 +1074,11 @@ public class CustomSetPropertyOnRenderable
                     break;
                 case "Color":
                     {
-                        int result;
-
                         if (item.Open.Argument?.StartsWith("0x") == true && int.TryParse(item.Open.Argument.Substring(2),
                                                                             NumberStyles.AllowHexSpecifier,
                                                                             null,
-                                                                            out result))
+                                                                            out int result))
                         {
-                            castedValue = result;
                             castedValue = System.Drawing.Color.FromArgb(result);
                         }
                         else
@@ -1084,13 +1090,14 @@ public class CustomSetPropertyOnRenderable
                     break;
                 case "FontScale":
                     {
-                        if (float.TryParse(item.Open.Argument, out float parsed))
+                        if (float.TryParse(item.Open.Argument, NumberStyles.Float, CultureInfo.InvariantCulture, out float parsed))
                         {
                             castedValue = parsed;
                             shouldApply = true;
                         }
                     }
                     break;
+#if !RAYLIB
                 case "Custom":
                     if(castedValue is string functionName)
                     {
@@ -1124,20 +1131,20 @@ public class CustomSetPropertyOnRenderable
                     // we apply the inline ourselves
                     shouldApply = false;
                     break;
-                    // Don't do anything like IsBold or IsItalic here - these are handled in ApplyFontVariables
+#endif
+                    // Font / FontSize / OutlineThickness / IsBold / IsItalic family swaps are handled below in
+                    // ApplyFontVariables (stack model), not here.
             }
 
             if (shouldApply)
             {
-                var inlineVariable = new InlineVariable
+                asText.InlineVariables.Add(new InlineVariable
                 {
                     CharacterCount = item.Close.StartStrippedIndex - item.Open.StartStrippedIndex,
                     StartIndex = item.Open.StartStrippedIndex,
                     VariableName = item.Name,
                     Value = castedValue
-                };
-
-                asText.InlineVariables.Add(inlineVariable);
+                });
             }
         }
 
@@ -1193,14 +1200,23 @@ public class CustomSetPropertyOnRenderable
 
         // #3481: RawText was assigned above (which wrapped + measured the text) before any InlineVariables
         // existed, so that first pass was blind to inline [FontScale=N]/[FontSize=N] runs. Re-wrap first so
-        // line breaks account for an enlarged run's real size (#3520), then re-measure so the reported size
-        // accounts for per-line scale (#3481) — otherwise a tall run overflows its slot and overlaps the
-        // next stacked sibling, or a wide run spills past a fixed wrap width. Runs unconditionally (the text
-        // must wrap whether or not per-run fonts were resolved).
+        // line breaks account for an enlarged run's real size (#3520 MonoGame / #3532 Raylib), then re-measure
+        // so the reported size accounts for per-line scale (#3481) — otherwise a tall run overflows its slot
+        // and overlaps the next stacked sibling, or a wide run spills past a fixed wrap width. Runs
+        // unconditionally (the text must wrap whether or not per-run fonts were resolved).
         asText.UpdateWrappedText();
         asText.UpdatePreRenderDimensions();
     }
 
+    /// <summary>
+    /// Resolves the Font / FontSize / OutlineThickness / IsBold / IsItalic BBCode tags into per-run
+    /// resolved-font (<c>"BitmapFont"</c>) inline variables using a stack model: each open tag pushes its
+    /// value and each close tag pops it, so a run resolves to the font implied by every tag open over it.
+    /// The push/pop/sort/character-count loop is identical on every platform; only the font-CREATION body
+    /// (<see cref="GetAndCreateFontIfNecessary"/>) is platform-specific, since Raylib produces a
+    /// <see cref="Raylib_cs.Font"/> (or, with no creator, falls back to scaling the base atlas) while the
+    /// XNA-family backends produce a <see cref="BitmapFont"/>.
+    /// </summary>
     private static void ApplyFontVariables(Text asText, List<FoundTag> results)
     {
         allTags.Clear();
@@ -1218,110 +1234,94 @@ public class CustomSetPropertyOnRenderable
         // slow on cache hits, fix it in the underlying loader.
         foreach (var tag in allTags)
         {
-
+            // The run's value: a resolved Raylib_cs.Font (crisp), or - for a [FontSize] tag with no font
+            // creator wired - the raw pixel size as a float (ResolveRunFont then scales the base atlas).
             object castedValue = null;
-            string convertedName = "BitmapFont";
-            var hasArg = !string.IsNullOrEmpty(tag.Argument);
+            string convertedName = "BitmapFont"; // shared historical run-marker name (see ResolvedFont note).
             switch (tag.Name)
             {
                 case "Font":
+                    if (!string.IsNullOrEmpty(tag.Argument))
                     {
-                        if (hasArg)
+                        // tolerate ".fnt" suffix
+                        var argument = tag.Argument;
+                        if (argument?.EndsWith(".fnt") == true)
                         {
-                            // tolerate ".fnt" suffix
-                            var argument = tag.Argument;
-                            if (argument?.EndsWith(".fnt") == true)
-                            {
-                                argument = argument.Substring(0, argument.Length - ".fnt".Length);
-                            }
-                            fontNameStack.Push(argument);
-                            castedValue = GetAndCreateFontIfNecessary();
+                            argument = argument.Substring(0, argument.Length - ".fnt".Length);
                         }
-                        else
-                        {
-                            fontNameStack.Pop();
-                            castedValue = GetAndCreateFontIfNecessary();
-                        }
+                        fontNameStack.Push(argument);
                     }
+                    else
+                    {
+                        fontNameStack.Pop();
+                    }
+                    castedValue = GetAndCreateFontIfNecessary();
                     break;
                 case "FontSize":
+                    if (int.TryParse(tag.Argument, NumberStyles.Integer, CultureInfo.InvariantCulture, out int parsedSize))
                     {
-                        if (int.TryParse(tag.Argument, out int parsedValue))
-                        {
-                            fontSizeStack.Push(parsedValue);
-                            castedValue = GetAndCreateFontIfNecessary();
+                        fontSizeStack.Push(parsedSize);
+                        castedValue = GetAndCreateFontIfNecessary();
 #if RAYLIB
-                            // Platform-necessary Raylib fallback: with no font creator wired, no crisp font can be
-                            // rasterized at the requested size, so store the raw pixel size as a float and let the
-                            // renderer scale the base atlas to it (a blurry-but-correct approximation). The XNA
-                            // path never needs this - it can new BitmapFont(...) at any size.
-                            castedValue ??= (float)parsedValue;
+                        // Platform-necessary Raylib fallback: with no font creator wired, no crisp font can be
+                        // rasterized at the requested size, so store the raw pixel size as a float and let the
+                        // renderer scale the base atlas to it (a blurry-but-correct approximation). The XNA
+                        // path never needs this - it can new BitmapFont(...) at any size.
+                        castedValue ??= (float)parsedSize;
 #endif
-                        }
-                        else
-                        {
-                            fontSizeStack.Pop();
-                            castedValue = GetAndCreateFontIfNecessary();
-                        }
+                    }
+                    else
+                    {
+                        fontSizeStack.Pop();
+                        castedValue = GetAndCreateFontIfNecessary();
                     }
                     break;
                 case "OutlineThickness":
+                    if (int.TryParse(tag.Argument, NumberStyles.Integer, CultureInfo.InvariantCulture, out int parsedOutline))
                     {
-                        if (int.TryParse(tag.Argument, out int parsedValue))
-                        {
-                            outlineThicknessStack.Push(parsedValue);
-                            castedValue = GetAndCreateFontIfNecessary();
-                        }
-                        else
-                        {
-                            outlineThicknessStack.Pop();
-                            castedValue = GetAndCreateFontIfNecessary();
-                        }
+                        outlineThicknessStack.Push(parsedOutline);
                     }
+                    else
+                    {
+                        outlineThicknessStack.Pop();
+                    }
+                    castedValue = GetAndCreateFontIfNecessary();
                     break;
                 case "IsItalic":
+                    if (bool.TryParse(tag.Argument, out bool parsedItalic))
                     {
-                        if (bool.TryParse(tag.Argument, out bool parsedValue))
-                        {
-                            isItalicStack.Push(parsedValue);
-                            castedValue = GetAndCreateFontIfNecessary();
-                        }
-                        else
-                        {
-                            isItalicStack.Pop();
-                            castedValue = GetAndCreateFontIfNecessary();
-                        }
+                        isItalicStack.Push(parsedItalic);
                     }
+                    else
+                    {
+                        isItalicStack.Pop();
+                    }
+                    castedValue = GetAndCreateFontIfNecessary();
                     break;
                 case "IsBold":
+                    if (bool.TryParse(tag.Argument, out bool parsedBold))
                     {
-                        if (bool.TryParse(tag.Argument, out bool parsedValue))
-                        {
-                            isBoldStack.Push(parsedValue);
-                            castedValue = GetAndCreateFontIfNecessary();
-                        }
-                        else
-                        {
-                            isBoldStack.Pop();
-                            castedValue = GetAndCreateFontIfNecessary();
-                        }
+                        isBoldStack.Push(parsedBold);
                     }
+                    else
+                    {
+                        isBoldStack.Pop();
+                    }
+                    castedValue = GetAndCreateFontIfNecessary();
                     break;
                 case "UseCustomFont":
+                    // Never fires today (UseCustomFont is not a BbCodeParser.KnownTag), but the stack push/pop
+                    // is kept parallel to the MonoGame path for convergence.
+                    if (bool.TryParse(tag.Argument, out bool parsedCustom))
                     {
-                        if (bool.TryParse(tag.Argument, out bool parsedValue))
-                        {
-                            useCustomFontStack.Push(parsedValue);
-                            castedValue = GetAndCreateFontIfNecessary();
-                        }
-                        else
-                        {
-                            useCustomFontStack.Pop();
-                            castedValue = GetAndCreateFontIfNecessary();
-                        }
+                        useCustomFontStack.Push(parsedCustom);
                     }
+                    else
+                    {
+                        useCustomFontStack.Pop();
+                    }
+                    castedValue = GetAndCreateFontIfNecessary();
                     break;
-
             }
 
             if (castedValue != null)
@@ -1333,8 +1333,6 @@ public class CustomSetPropertyOnRenderable
 
                 var inlineVariable = new InlineVariable
                 {
-                    // assigned above:
-                    //CharacterCount = tag.Close.StartStrippedIndex - tag.Open.StartStrippedIndex,
                     StartIndex = tag.StartStrippedIndex,
                     VariableName = convertedName,
                     Value = castedValue
@@ -1346,14 +1344,20 @@ public class CustomSetPropertyOnRenderable
             }
         }
 
-        // close off the last one:
+        // Close off the last font run so it extends to the end of the text.
         if (lastFontInlineVariable != null)
         {
             lastFontInlineVariable.CharacterCount = asText.RawText.Length - lastFontInlineVariable.StartIndex;
         }
 
+        // Creates (or returns a cached) resolved font for the current stack state. Only the font-CREATION
+        // body is platform-specific; everything above is shared on every platform. Returns null when no
+        // creator is available or creation fails - the caller then leaves the range at the base font (no
+        // run) or, for a [FontSize] tag, falls back to scaling the base atlas (Raylib only). The Raylib body
+        // preserves the Dispose-then-AddDisposable cache-heal from the former TryGetOrCreateFontAtSize.
         ResolvedFont? GetAndCreateFontIfNecessary()
         {
+#if !RAYLIB
             var fontFileName = GetFontFileName();
 
             var font = global::RenderingLibrary.Content.LoaderManager.Self.GetDisposable(fontFileName) as BitmapFont;
@@ -1484,8 +1488,84 @@ public class CustomSetPropertyOnRenderable
             }
 
             return font;
+#else
+            // Raylib can only produce a crisp font for the current stack state via a wired IRaylibFontCreator
+            // (it cannot `new BitmapFont(file)` the way the XNA path does). The Raylib path always uses the
+            // FontCache key/creator - it does not branch on useCustomFontStack (matching the pre-#3624
+            // behavior, where custom fonts were not re-generated per inline run).
+            if (InMemoryFontCreator == null || fontSizeStack.Peek() <= 0)
+            {
+                return null;
+            }
+
+            var loaderManager = global::RenderingLibrary.Content.LoaderManager.Self;
+
+            try
+            {
+                string fontName = fontNameStack.Peek();
+                string? bbCodeFontFilePath = BmfcSave.IsFontFilePath(fontName) ? fontName : null;
+
+                string fontCacheName = BmfcSave.GetFontCacheFileNameFor(
+                    fontSizeStack.Peek(),
+                    fontName,
+                    outlineThicknessStack.Peek(),
+                    useFontSmoothingStack.Peek(),
+                    isItalicStack.Peek(),
+                    isBoldStack.Peek(),
+                    bbCodeFontFilePath);
+                string fullFileName = ToolsUtilities.FileManager.Standardize(fontCacheName, preserveCase: true, makeAbsolute: true);
+
+                // Reuse an already-generated font (its Raylib_cs.Font wraps an unmanaged GPU texture, so
+                // regenerating every layout would leak VRAM). Mirrors the base-font cache check.
+                if (loaderManager.GetDisposable(fullFileName) is ManagedFont cachedManagedFont
+                    && cachedManagedFont.Font.BaseSize != 0)
+                {
+                    return cachedManagedFont.Font;
+                }
+
+                BmfcSave bmfcSave = new BmfcSave();
+                bmfcSave.FontSize = fontSizeStack.Peek();
+                bmfcSave.OutlineThickness = outlineThicknessStack.Peek();
+                bmfcSave.UseSmoothing = useFontSmoothingStack.Peek();
+                bmfcSave.IsItalic = isItalicStack.Peek();
+                bmfcSave.IsBold = isBoldStack.Peek();
+
+                if (bbCodeFontFilePath != null)
+                {
+                    bmfcSave.FontFile = ResolveFontFilePath(bbCodeFontFilePath);
+                    bmfcSave.FontName = System.IO.Path.GetFileNameWithoutExtension(bbCodeFontFilePath);
+                }
+                else
+                {
+                    bmfcSave.FontName = fontName;
+                }
+
+                var gumProject = ObjectFinder.Self.GumProjectSave;
+                bmfcSave.Ranges = gumProject?.FontRanges ?? BmfcSave.GetEffectiveDefaultRanges();
+                bmfcSave.SpacingHorizontal = gumProject?.FontSpacingHorizontal ?? 1;
+                bmfcSave.SpacingVertical = gumProject?.FontSpacingVertical ?? 1;
+
+                Raylib_cs.Font? createdFont = InMemoryFontCreator.TryCreateFont(bmfcSave);
+                if (createdFont.HasValue && createdFont.Value.BaseSize != 0)
+                {
+                    // Dispose first so a poisoned empty slot (see the base path) can't make AddDisposable
+                    // throw; then cache under the same FontCache key the base-font path uses so a base text
+                    // and an inline run at the same size/style share one atlas.
+                    loaderManager.Dispose(fullFileName);
+                    loaderManager.AddDisposable(fullFileName, new ManagedFont(createdFont.Value));
+                    return createdFont.Value;
+                }
+            }
+            catch
+            {
+                // Fall through to null - the caller uses the base font / base-atlas scale fallback.
+            }
+
+            return null;
+#endif
         }
 
+#if !RAYLIB
         string GetFontFileName()
         {
             string fontFileNameName;
@@ -1514,6 +1594,7 @@ public class CustomSetPropertyOnRenderable
 #endif
             return fullFileName;
         }
+#endif
     }
 
     public static void UpdateToFontValues(IText text, GraphicalUiElement graphicalUiElement)
@@ -1553,6 +1634,9 @@ public class CustomSetPropertyOnRenderable
             return;
         }
 
+        var asText = (Text)text;
+
+#if !RAYLIB
         // Residual properties could exist on a Text instance, so we need to
         // tolerate a missing item and not crash.
 
@@ -1748,10 +1832,9 @@ public class CustomSetPropertyOnRenderable
 
         var fontToSet = font ?? Text.DefaultBitmapFont;
 
-        var asRenderableText = (Text)text;
-        if (asRenderableText.BitmapFont != fontToSet)
+        if (asText.BitmapFont != fontToSet)
         {
-            asRenderableText.BitmapFont = fontToSet;
+            asText.BitmapFont = fontToSet;
 
             // we want to update if the text's size is based on its "children" (the letters it contains)
             if (graphicalUiElement.WidthUnits == DimensionUnitType.RelativeToChildren ||
@@ -1768,18 +1851,145 @@ public class CustomSetPropertyOnRenderable
                 }
             }
         }
+#else
+        var textRuntime = graphicalUiElement as TextRuntime;
 
-        // Re-parse BBCode segments so they pick up the new base font values.
-        // Without this, only the non-tagged text updates; segments after BBCode tags
-        // retain old font properties because their InlineVariables still reference
-        // the previous BitmapFont.
-        if (!string.IsNullOrEmpty(asRenderableText.StoredMarkupText))
+        var loaderManager = global::RenderingLibrary.Content.LoaderManager.Self;
+
+        if(textRuntime != null)
         {
-            asRenderableText.InlineVariables.Clear();
-            SetBbCodeText(asRenderableText, graphicalUiElement, asRenderableText.StoredMarkupText);
+            // The font family and size are authoritative on the TextRuntime — both the direct
+            // property setters and the string/state path write them there. Sync them onto the
+            // renderable so its font-based fallbacks (and rendering) stay correct. This subsumes
+            // what the former HandleUpdateFontValues stub did, but also actually loads the font.
+            asText.FontFamily = textRuntime.Font;
+            // Skip the size sync when unchanged: the setter recomputes line height (a native text
+            // measure), and on the double-call string path the second pass would otherwise repeat it.
+            if (asText.FontSize != textRuntime.FontSize)
+            {
+                asText.FontSize = textRuntime.FontSize;
+            }
+
+            if (textRuntime.UseCustomFont == true)
+            {
+                // todo here:
+                string fontName = textRuntime.CustomFontFile;
+
+                string fullFileName = ToolsUtilities.FileManager.Standardize(fontName, preserveCase: true, makeAbsolute: true);
+
+                var fontFromGum = loaderManager.LoadContent<Raylib_cs.Font>(fullFileName);
+                if (fontFromGum.BaseSize == 0)
+                {
+                    fontFromGum = loaderManager.LoadContent<Raylib_cs.Font>(asText.FontFamily);
+                }
+                AssignFontIfChanged(asText, fontFromGum);
+            }
+            else
+            {
+                if (textRuntime.FontSize > 0 && !string.IsNullOrEmpty(textRuntime.Font))
+                {
+                    string fontName = textRuntime.GetFontCacheFileName(
+                        BmfcSave.IsFontFilePath(textRuntime.Font) ? textRuntime.Font : null);
+
+                    string fullFileName = ToolsUtilities.FileManager.Standardize(fontName, preserveCase: true, makeAbsolute: true);
+
+                    // Cache hit: reuse the already-generated/loaded font rather than regenerating.
+                    // A Raylib_cs.Font wraps an unmanaged GPU texture, so regenerating on every font
+                    // property change would leak VRAM (the previous texture is never reclaimed). This
+                    // is the LoaderManager cache the MonoGame path also uses.
+                    //
+                    // Only short-circuit on a USABLE cached font (BaseSize != 0). When no FontCache .fnt
+                    // exists on disk and no stream hook supplies it, the loader caches an empty
+                    // default(Font) (BaseSize 0) under this key (ContentLoader.LoadFont). Without this
+                    // guard the early-return would hand that empty font to every text after the first
+                    // instead of falling through to the disk / system-font fallback below — so text lost
+                    // its font and, being RelativeToChildren, collapsed to zero size. Mirrors the MonoGame
+                    // path, which assigns the resolved font once at the end rather than early-returning on
+                    // any cache entry.
+                    if (loaderManager.GetDisposable(fullFileName) is ManagedFont cachedManagedFont
+                        && cachedManagedFont.Font.BaseSize != 0)
+                    {
+                        AssignFontIfChanged(asText, cachedManagedFont.Font);
+                        return;
+                    }
+
+                    // In-memory font creation (no disk I/O). The BmfcSave construction below is kept
+                    // byte-identical to the MonoGame path in Gum/Wireframe/CustomSetPropertyOnRenderable.cs;
+                    // only the created-font type (Raylib_cs.Font vs BitmapFont) and how it is cached are
+                    // necessarily platform-gated. Null/failure falls through to the FontCache .fnt path.
+                    if (InMemoryFontCreator != null)
+                    {
+                        try
+                        {
+                            BmfcSave bmfcSave = new BmfcSave();
+                            textRuntime.CopyFontGenerationFieldsTo(bmfcSave, resolvedFontFilePath: null);
+
+                            var gumProject = ObjectFinder.Self.GumProjectSave;
+                            bmfcSave.Ranges = gumProject?.FontRanges ?? BmfcSave.GetEffectiveDefaultRanges();
+                            bmfcSave.SpacingHorizontal = gumProject?.FontSpacingHorizontal ?? 1;
+                            bmfcSave.SpacingVertical = gumProject?.FontSpacingVertical ?? 1;
+
+                            Raylib_cs.Font? createdFont = InMemoryFontCreator.TryCreateFont(bmfcSave);
+                            if (createdFont.HasValue && createdFont.Value.BaseSize != 0)
+                            {
+                                // Heal a poisoned cache slot: the disk-fallback path below can legitimately
+                                // cache an empty (BaseSize 0) placeholder under this exact key when no
+                                // FontCache .fnt exists on disk (see the cache-hit guard above) -- e.g. when
+                                // a font is requested before InMemoryFontCreator gets wired up. AddDisposable's
+                                // default ExistingContentBehavior.ThrowException would throw on that occupied
+                                // slot; left unguarded, the caller's catch swallows it and the newly created
+                                // (working) font -- and its GPU texture -- is discarded, forever re-triggering
+                                // this (expensive) rasterization on every subsequent request. Dispose the old
+                                // entry first (a no-op if nothing is cached) so the slot is free.
+                                loaderManager.Dispose(fullFileName);
+                                loaderManager.AddDisposable(fullFileName, new ManagedFont(createdFont.Value));
+                                AssignFontIfChanged(asText, createdFont.Value);
+                                return;
+                            }
+                        }
+                        catch
+                        {
+                            // Fall through to the disk / system-font path.
+                        }
+                    }
+
+                    var fontFromGum = loaderManager.LoadContent<Raylib_cs.Font>(fullFileName);
+                    if (fontFromGum.BaseSize == 0)
+                    {
+                        fontFromGum = loaderManager.LoadContent<Raylib_cs.Font>(asText.FontFamily);
+                    }
+                    AssignFontIfChanged(asText, fontFromGum);
+                }
+            }
+        }
+#endif
+
+        // Re-parse BBCode segments so they pick up the new base font values. Without this, only the
+        // non-tagged text updates; segments after BBCode tags retain old font properties because their
+        // InlineVariables still reference the previous resolved font.
+        if (!string.IsNullOrEmpty(asText.StoredMarkupText))
+        {
+            asText.InlineVariables.Clear();
+            SetBbCodeText(asText, graphicalUiElement, asText.StoredMarkupText);
         }
     }
 
+#if RAYLIB
+    // Mirrors the MonoGame loader's `if (BitmapFont != fontToSet)` guard. A single SetProperty can
+    // reach this loader twice — once via the TextRuntime setter (UpdateFontFromProperties) and once
+    // via the explicit ReactToFontValueChange call — and with font caching on the second load is a
+    // cache hit, so skipping the redundant reassignment keeps it to one font assignment.
+    // Raylib_cs.Font is a struct, so font identity is compared via the loaded atlas texture id.
+    private static void AssignFontIfChanged(Text asText, Raylib_cs.Font font)
+    {
+        if (asText.Font.Texture.Id != font.Texture.Id)
+        {
+            asText.Font = font;
+        }
+    }
+#endif
+
+#if !RAYLIB
     private static BitmapFont? GetFontDisposable(string fontName)
     {
 #if KNI
@@ -1789,11 +1999,12 @@ public class CustomSetPropertyOnRenderable
 #else
         string prefix = "MonoGameGum.Content";
 #endif
-        
+
         string fontFilenameOnly = Path.GetFileName(fontName);
         string embeddedFontName = $"EmbeddedResource.{prefix}.{fontFilenameOnly}";
         return global::RenderingLibrary.Content.LoaderManager.Self.GetDisposable(embeddedFontName) as BitmapFont;
     }
+#endif
 
 #endregion
 

--- a/MonoGameGum.Tests/Runtimes/TextRuntimeTests.cs
+++ b/MonoGameGum.Tests/Runtimes/TextRuntimeTests.cs
@@ -197,6 +197,39 @@ $"chars count=223\r\n";
             "Because a scaled run is measured at its own scale, so the reported width grows with it");
     }
 
+    [Fact]
+    public void WrappedTextHeight_ShouldScaleBy1Point5_WhenFontScaleHasDecimalPoint_RegardlessOfCurrentCulture()
+    {
+        // FontScale parsing used to rely on the current thread culture. Under a culture where '.' is the
+        // thousands separator (e.g. de-DE), float.TryParse("1.5") does not fail - it silently parses as
+        // 15 (the '.' is consumed as a group separator), applying a 10x-too-large scale. BBCode markup is
+        // always written with '.' as the decimal point, so parsing must be culture-invariant.
+        var originalCulture = System.Threading.Thread.CurrentThread.CurrentCulture;
+        System.Threading.Thread.CurrentThread.CurrentCulture = new System.Globalization.CultureInfo("de-DE");
+        try
+        {
+            TextRuntime plain = new();
+            plain.WidthUnits = DimensionUnitType.RelativeToChildren;
+            plain.Width = 0;
+            plain.Text = "BIG";
+            float plainHeight = ((Text)plain.RenderableComponent).WrappedTextHeight;
+            plainHeight.ShouldBeGreaterThan(0);
+
+            TextRuntime scaled = new();
+            scaled.WidthUnits = DimensionUnitType.RelativeToChildren;
+            scaled.Width = 0;
+            scaled.Text = "[FontScale=1.5]BIG[/FontScale]";
+            float scaledHeight = ((Text)scaled.RenderableComponent).WrappedTextHeight;
+
+            scaledHeight.ShouldBe(plainHeight * 1.5f, 1.5,
+                "Because FontScale must parse '.' as a decimal point (scale of 1.5x) regardless of the thread's current culture, not as a thousands separator (scale of 15x)");
+        }
+        finally
+        {
+            System.Threading.Thread.CurrentThread.CurrentCulture = originalCulture;
+        }
+    }
+
     #endregion
 
     #region BbCode FontSize Inline Measurement (issue #3520)

--- a/Runtimes/RaylibGum/Renderables/CustomSetPropertyOnRenderable.cs
+++ b/Runtimes/RaylibGum/Renderables/CustomSetPropertyOnRenderable.cs
@@ -1021,11 +1021,12 @@ public class CustomSetPropertyOnRenderable
 
     /// <summary>
     /// Parses BBCode markup, assigns the tag-stripped text to <see cref="Text.RawText"/>, and populates
-    /// <see cref="Text.InlineVariables"/> with the per-run styling the Raylib renderer applies: Color / Red /
+    /// <see cref="Text.InlineVariables"/> with the per-run styling the renderer applies: Color / Red /
     /// Green / Blue and FontScale runs in the loop below, plus the resolved-font runs for the font family
     /// tags (Font / FontSize / OutlineThickness / IsBold / IsItalic) produced by
-    /// <see cref="ApplyFontVariables"/> using the same stack model as the MonoGame path. Custom per-letter
-    /// callbacks are recognized (stripped) but not yet applied on the Raylib runtime (#3471).
+    /// <see cref="ApplyFontVariables"/> using the same stack model on every platform. A <c>[Custom]</c> tag's
+    /// per-letter callback is applied on the XNA-family backends (<c>#if !RAYLIB</c> below); on Raylib the tag
+    /// is recognized by the parser but has no effect yet (#3471).
     /// </summary>
     private static void SetBbCodeText(Text asText, GraphicalUiElement graphicalUiElement, string bbcode)
     {
@@ -1078,9 +1079,43 @@ public class CustomSetPropertyOnRenderable
                         }
                     }
                     break;
+#if !RAYLIB
+                case "Custom":
+                    if(castedValue is string functionName)
+                    {
+                        var startStripped = item.Open.StartStrippedIndex;
+
+                        var substring = strippedText.Substring(startStripped, item.Close.StartStrippedIndex - startStripped);
+
+
+                        // this function needs to be called on every letter:
+                        for (int i = 0; i < substring.Length; i++)
+                        {
+                            var call = new ParameterizedLetterCustomizationCall
+                            {
+                                FunctionName = functionName,
+                                CharacterIndex = startStripped + i,
+                                TextBlock = substring
+                            };
+                            // we probably need to check and add variables only as needed
+                            var inlineVariable = new InlineVariable
+                            {
+                                CharacterCount = 1,
+                                StartIndex = startStripped + i,
+                                VariableName = "Custom",
+                                Value = call
+                            };
+
+                            asText.InlineVariables.Add(inlineVariable);
+                        }
+                    }
+
+                    // we apply the inline ourselves
+                    shouldApply = false;
+                    break;
+#endif
                     // Font / FontSize / OutlineThickness / IsBold / IsItalic family swaps are handled below in
-                    // ApplyFontVariables (stack model), not here. Custom per-letter callbacks are stripped but
-                    // not applied on the Raylib runtime yet (#3471).
+                    // ApplyFontVariables (stack model), not here.
             }
 
             if (shouldApply)
@@ -1105,7 +1140,8 @@ public class CustomSetPropertyOnRenderable
         // values. A Text owned by a non-TextRuntime GraphicalUiElement has no such values, so we neither seed
         // nor resolve here - otherwise ApplyFontVariables would peek/pop unseeded (stale or empty) stacks,
         // giving a wrong font or an InvalidOperationException. One guard covers seeding and resolution; the
-        // text is still wrapped/measured below regardless.
+        // text is still wrapped/measured below regardless. (Under #if FRB, textRuntime == graphicalUiElement,
+        // never null, so this guard is always-true and FRB behavior is unchanged - a pure structural move.)
         if (textRuntime != null)
         {
             fontNameStack.Clear();
@@ -1144,12 +1180,12 @@ public class CustomSetPropertyOnRenderable
             ApplyFontVariables(asText, results);
         }
 
-        // #3481/#3532: RawText was assigned above (which wrapped + measured the text) before any
-        // InlineVariables existed, so that first pass was blind to inline [FontScale=N]/[FontSize=N] runs.
-        // Re-wrap first so line breaks account for an enlarged run's real size (#3532), then re-measure so the
-        // reported size accounts for per-line scale (#3481) - otherwise a tall run overflows its slot and
-        // overlaps the next stacked sibling, or a wide run spills past a fixed wrap width. Runs unconditionally
-        // (the text must wrap whether or not per-run fonts were resolved). Mirrors the MonoGame path.
+        // #3481: RawText was assigned above (which wrapped + measured the text) before any InlineVariables
+        // existed, so that first pass was blind to inline [FontScale=N]/[FontSize=N] runs. Re-wrap first so
+        // line breaks account for an enlarged run's real size (#3520 MonoGame / #3532 Raylib), then re-measure
+        // so the reported size accounts for per-line scale (#3481) — otherwise a tall run overflows its slot
+        // and overlaps the next stacked sibling, or a wide run spills past a fixed wrap width. Runs
+        // unconditionally (the text must wrap whether or not per-run fonts were resolved).
         asText.UpdateWrappedText();
         asText.UpdatePreRenderDimensions();
     }
@@ -1158,9 +1194,10 @@ public class CustomSetPropertyOnRenderable
     /// Resolves the Font / FontSize / OutlineThickness / IsBold / IsItalic BBCode tags into per-run
     /// resolved-font (<c>"BitmapFont"</c>) inline variables using a stack model: each open tag pushes its
     /// value and each close tag pops it, so a run resolves to the font implied by every tag open over it.
-    /// The push/pop/sort/character-count loop is kept identical to the MonoGame path; only the font-CREATION
-    /// body (<see cref="GetAndCreateFontIfNecessary"/>) is platform-specific, since Raylib produces a
-    /// <see cref="Raylib_cs.Font"/> (or, with no creator, falls back to scaling the base atlas).
+    /// The push/pop/sort/character-count loop is identical on every platform; only the font-CREATION body
+    /// (<see cref="GetAndCreateFontIfNecessary"/>) is platform-specific, since Raylib produces a
+    /// <see cref="Raylib_cs.Font"/> (or, with no creator, falls back to scaling the base atlas) while the
+    /// XNA-family backends produce a <see cref="BitmapFont"/>.
     /// </summary>
     private static void ApplyFontVariables(Text asText, List<FoundTag> results)
     {
@@ -1170,6 +1207,13 @@ public class CustomSetPropertyOnRenderable
         allTags.Sort((a, b) => a.StartIndex - b.StartIndex);
 
         InlineVariable lastFontInlineVariable = null;
+        // Every BBCode push (open tag) and pop (close tag) below calls
+        // GetAndCreateFontIfNecessary. The pop case re-asks for a font that was
+        // already resolved on the matching push — caching is intentionally NOT
+        // this method's job. LoaderManager handles cache hits on the second
+        // lookup, so the cost of asking twice is the cache check, not a full
+        // font generation. Do not add caching here; if a generation path is
+        // slow on cache hits, fix it in the underlying loader.
         foreach (var tag in allTags)
         {
             // The run's value: a resolved Raylib_cs.Font (crisp), or - for a [FontSize] tag with no font
@@ -1200,11 +1244,13 @@ public class CustomSetPropertyOnRenderable
                     {
                         fontSizeStack.Push(parsedSize);
                         castedValue = GetAndCreateFontIfNecessary();
+#if RAYLIB
                         // Platform-necessary Raylib fallback: with no font creator wired, no crisp font can be
                         // rasterized at the requested size, so store the raw pixel size as a float and let the
                         // renderer scale the base atlas to it (a blurry-but-correct approximation). The XNA
                         // path never needs this - it can new BitmapFont(...) at any size.
                         castedValue ??= (float)parsedSize;
+#endif
                     }
                     else
                     {
@@ -1287,12 +1333,144 @@ public class CustomSetPropertyOnRenderable
         }
 
         // Creates (or returns a cached) resolved font for the current stack state. Only the font-CREATION
-        // body is platform-specific; everything above is shared with the MonoGame path. Returns null when no
-        // creator is wired or creation fails - the caller then leaves the range at the base font (no run) or,
-        // for a [FontSize] tag, falls back to scaling the base atlas. Preserves the Dispose-then-AddDisposable
-        // cache-heal from the former TryGetOrCreateFontAtSize.
+        // body is platform-specific; everything above is shared on every platform. Returns null when no
+        // creator is available or creation fails - the caller then leaves the range at the base font (no
+        // run) or, for a [FontSize] tag, falls back to scaling the base atlas (Raylib only). The Raylib body
+        // preserves the Dispose-then-AddDisposable cache-heal from the former TryGetOrCreateFontAtSize.
         ResolvedFont? GetAndCreateFontIfNecessary()
         {
+#if !RAYLIB
+            var fontFileName = GetFontFileName();
+
+            var font = global::RenderingLibrary.Content.LoaderManager.Self.GetDisposable(fontFileName) as BitmapFont;
+
+            if (font == null)
+            {
+                font = GetFontDisposable(fontFileName);
+            }
+
+            // no cache, does it need to be created?
+            if (font == null)
+            {
+                // Try in-memory font creation first (no disk I/O)
+                if (InMemoryFontCreator != null)
+                {
+                    try
+                    {
+                        string? bbFontFile = BmfcSave.IsFontFilePath(fontNameStack.Peek()) ? fontNameStack.Peek() : null;
+
+                        BmfcSave bmfcSave = new BmfcSave();
+                        bmfcSave.FontSize = fontSizeStack.Peek();
+                        bmfcSave.OutlineThickness = outlineThicknessStack.Peek();
+                        bmfcSave.UseSmoothing = useFontSmoothingStack.Peek();
+                        bmfcSave.IsItalic = isItalicStack.Peek();
+                        bmfcSave.IsBold = isBoldStack.Peek();
+
+                        if (bbFontFile != null)
+                        {
+                            bmfcSave.FontFile = ResolveFontFilePath(bbFontFile);
+                            bmfcSave.FontName = System.IO.Path.GetFileNameWithoutExtension(bbFontFile);
+                        }
+                        else
+                        {
+                            bmfcSave.FontName = fontNameStack.Peek();
+                        }
+
+                        var gumProject = ObjectFinder.Self.GumProjectSave;
+                        bmfcSave.Ranges = gumProject?.FontRanges ?? BmfcSave.GetEffectiveDefaultRanges();
+                        bmfcSave.SpacingHorizontal = gumProject?.FontSpacingHorizontal ?? 1;
+                        bmfcSave.SpacingVertical = gumProject?.FontSpacingVertical ?? 1;
+
+                        font = InMemoryFontCreator.TryCreateFont(bmfcSave);
+                        if (font != null)
+                        {
+                            // #3530: Replace so re-adding an already-occupied key heals it instead of throwing.
+                            global::RenderingLibrary.Content.LoaderManager.Self.AddDisposable(fontFileName, font,
+                                global::RenderingLibrary.Content.LoaderManager.ExistingContentBehavior.Replace);
+                        }
+                    }
+                    catch
+                    {
+                        // Fall through to disk-based path
+                    }
+                }
+
+                // Fall back to disk-based font creation
+                if (font == null)
+                {
+                    // this could be a custom font, so let's see if it exists:
+
+                    string fileName = String.Empty;
+                    if (ToolsUtilities.FileManager.FileExists(fontFileName))
+                    {
+                        fileName = fontFileName;
+                    }
+#if !FRB
+                    else if (FontService != null)
+                    {
+                        fileName = FontService.AbsoluteFontCacheFolder +
+                            ToolsUtilities.FileManager.RemovePath(fontFileName);
+                    }
+
+                    if (FontService != null && !ToolsUtilities.FileManager.FileExists(fileName))
+                    {
+                        // user could have typed anything in there, so who knows if this will succeed. Therefore, try/catch:
+                        try
+                        {
+                            string? bbFontFileForDisk = BmfcSave.IsFontFilePath(fontNameStack.Peek()) ? fontNameStack.Peek() : null;
+
+                            BmfcSave bmfcSave = new BmfcSave();
+                            bmfcSave.FontSize = fontSizeStack.Peek();
+                            bmfcSave.OutlineThickness = outlineThicknessStack.Peek();
+                            bmfcSave.UseSmoothing = useFontSmoothingStack.Peek();
+                            bmfcSave.IsItalic = isItalicStack.Peek();
+                            bmfcSave.IsBold = isBoldStack.Peek();
+
+                            if (bbFontFileForDisk != null)
+                            {
+                                bmfcSave.FontFile = ResolveFontFilePath(bbFontFileForDisk);
+                                bmfcSave.FontName = System.IO.Path.GetFileNameWithoutExtension(bbFontFileForDisk);
+                            }
+                            else
+                            {
+                                bmfcSave.FontName = fontNameStack.Peek();
+                            }
+#if !FRB
+                            // BBCode inline font creation: when BBCode tags like [FontSize=24] reference a font
+                            // that doesn't exist, create it on demand. This parallels the font creation in
+                            // UpdateToFontValues — both use FontService.CreateFontIfNecessary with the same pattern.
+                            var gumProject = ObjectFinder.Self.GumProjectSave;
+                            bmfcSave.Ranges = gumProject?.FontRanges ?? BmfcSave.GetEffectiveDefaultRanges();
+                            bmfcSave.SpacingHorizontal = gumProject?.FontSpacingHorizontal ?? 1;
+                            bmfcSave.SpacingVertical = gumProject?.FontSpacingVertical ?? 1;
+#endif
+
+                            FontService.CreateFontIfNecessary(bmfcSave);
+                        }
+                        catch
+                        {
+                            // do nothing?
+                        }
+                    }
+#endif
+
+                    if (ToolsUtilities.FileManager.FileExists(fileName))
+                    {
+                        font = new BitmapFont(fileName);
+                    }
+                    else
+                    {
+                        // This can happen when closing tags are encountered at the end of a font. If no font exists, we can just go to the default
+                        font = Text.DefaultBitmapFont;
+                    }
+                    // #3530: Replace so re-adding an already-occupied key heals it instead of throwing.
+                    global::RenderingLibrary.Content.LoaderManager.Self.AddDisposable(fontFileName, font,
+                        global::RenderingLibrary.Content.LoaderManager.ExistingContentBehavior.Replace);
+                }
+            }
+
+            return font;
+#else
             // Raylib can only produce a crisp font for the current stack state via a wired IRaylibFontCreator
             // (it cannot `new BitmapFont(file)` the way the XNA path does). The Raylib path always uses the
             // FontCache key/creator - it does not branch on useCustomFontStack (matching the pre-#3624
@@ -1366,7 +1544,39 @@ public class CustomSetPropertyOnRenderable
             }
 
             return null;
+#endif
         }
+
+#if !RAYLIB
+        string GetFontFileName()
+        {
+            string fontFileNameName;
+            if (useCustomFontStack.Peek())
+            {
+                fontFileNameName = fontNameStack.Peek() + ".fnt";
+            }
+            else
+            {
+                string? bbCodeFontFilePath = BmfcSave.IsFontFilePath(fontNameStack.Peek()) ? fontNameStack.Peek() : null;
+
+                fontFileNameName = global::RenderingLibrary.Graphics.Fonts.BmfcSave.GetFontCacheFileNameFor(
+                    fontSizeStack.Peek(),
+                    fontNameStack.Peek(),
+                    outlineThicknessStack.Peek(),
+                    useFontSmoothingStack.Peek(),
+                    isItalicStack.Peek(),
+                    isBoldStack.Peek(),
+                    bbCodeFontFilePath);
+
+            }
+
+            var fullFileName = ToolsUtilities.FileManager.RemoveDotDotSlash(ToolsUtilities.FileManager.Standardize(fontFileNameName, false, true));
+#if ANDROID || IOS
+            fullFileName = fullFileName.ToLowerInvariant();
+#endif
+            return fullFileName;
+        }
+#endif
     }
 
     /// <summary>
@@ -1437,6 +1647,223 @@ public class CustomSetPropertyOnRenderable
         }
 
         var asText = (Text)text;
+
+#if !RAYLIB
+        // Residual properties could exist on a Text instance, so we need to
+        // tolerate a missing item and not crash.
+
+#if FRB
+        // FRB doesn't yet have a TextRuntime, so we have to do this:
+        var textRuntime = graphicalUiElement;
+#else
+        var textRuntime = graphicalUiElement as Gum.GueDeriving.TextRuntime;
+
+#endif
+        if (text == null || textRuntime == null)
+        {
+            return;
+        }
+
+        BitmapFont font = null;
+
+        var loaderManager = global::RenderingLibrary.Content.LoaderManager.Self;
+        var contentLoader = loaderManager.ContentLoader;
+
+        if (textRuntime.UseCustomFont)
+        {
+
+            if (!string.IsNullOrEmpty(textRuntime.CustomFontFile))
+            {
+                font = loaderManager.GetDisposable(textRuntime.CustomFontFile) as BitmapFont;
+                if (font == null)
+                {
+#if KNI
+                        try
+                        {
+                            // this could be running in browser where we don't have File.Exists, so JUST DO IT
+                            font = new BitmapFont(textRuntime.CustomFontFile);
+                            loaderManager.AddDisposable(textRuntime.CustomFontFile, font);
+                        }
+                        catch
+                        {
+                            // font doesn't exist, carry on...
+                        }
+#else
+                    // so normally we would just let the content loader check if the file exists but since we're not going to
+                    // use the content loader for BitmapFont, we're going to protect this with a file.exists.
+                    if (ToolsUtilities.FileManager.FileExists(textRuntime.CustomFontFile))
+                    {
+                        try
+                        {
+                            font = new BitmapFont(textRuntime.CustomFontFile);
+                            loaderManager.AddDisposable(textRuntime.CustomFontFile, font);
+
+                        }
+                        catch(System.Text.DecoderFallbackException exception)
+                        {
+                            throw new Exception($"Error trying to load font from file {textRuntime.CustomFontFile}:\n" + exception, exception);
+                        }
+                    }
+#endif
+                }
+                else if (font.Textures.Any(item => item?.IsDisposed == true))
+                {
+                    // The BitmapFont is cached by Gum, but the underlying Texture2D might be managed by something else (like FRB).
+                    // This means that the Texture can be disposed without the BitmapFont being disposed. If this is the case we should
+                    // ask the underlying system for a new .png, but we can keep the same BitmapFont since that should stay the same and
+                    // .fnt parsing can be the slow part for large fonts.
+                    font.ReAssignTextures();
+                }
+            }
+
+
+        }
+        else
+        {
+            if (textRuntime.FontSize > 0 && !string.IsNullOrEmpty(textRuntime.Font))
+            {
+
+                string? fontFilePath = BmfcSave.IsFontFilePath(textRuntime.Font) ? textRuntime.Font : null;
+
+                string fontName = textRuntime.GetFontCacheFileName(fontFilePath);
+
+                string fullFileName = ToolsUtilities.FileManager.Standardize(fontName, preserveCase: true, makeAbsolute: true);
+
+                font = loaderManager.GetDisposable(fullFileName) as BitmapFont;
+
+                // Attempt to load from Embedded Resource
+
+                if (fontName != null && font == null)
+                {
+                    font = GetFontDisposable(fontName);
+                }
+
+                // Try in-memory font creation first (no disk I/O)
+                if (font == null && InMemoryFontCreator != null)
+                {
+                    try
+                    {
+                        BmfcSave bmfcSave = new BmfcSave();
+                        textRuntime.CopyFontGenerationFieldsTo(
+                            bmfcSave,
+                            fontFilePath != null ? ResolveFontFilePath(fontFilePath) : null);
+
+                        var gumProject = ObjectFinder.Self.GumProjectSave;
+                        bmfcSave.Ranges = gumProject?.FontRanges ?? BmfcSave.GetEffectiveDefaultRanges();
+                        bmfcSave.SpacingHorizontal = gumProject?.FontSpacingHorizontal ?? 1;
+                        bmfcSave.SpacingVertical = gumProject?.FontSpacingVertical ?? 1;
+
+                        font = InMemoryFontCreator.TryCreateFont(bmfcSave);
+                        if (font != null)
+                        {
+                            loaderManager.AddDisposable(fullFileName, font);
+                        }
+                    }
+                    catch
+                    {
+                        // Fall through to disk-based path
+                    }
+                }
+
+#if !FRB
+                // Disk-based font creation: ask FontService to generate .fnt/.png files,
+                // then load from disk. This is the fallback when no InMemoryFontCreator
+                // is available or when in-memory creation fails.
+                if (font == null && FontService != null)
+                {
+                    try
+                    {
+                        BmfcSave bmfcSave = new BmfcSave();
+                        textRuntime.CopyFontGenerationFieldsTo(
+                            bmfcSave,
+                            fontFilePath != null ? ResolveFontFilePath(fontFilePath) : null);
+
+                        var gumProject = ObjectFinder.Self.GumProjectSave;
+                        bmfcSave.Ranges = gumProject?.FontRanges ?? BmfcSave.GetEffectiveDefaultRanges();
+                        bmfcSave.SpacingHorizontal = gumProject?.FontSpacingHorizontal ?? 1;
+                        bmfcSave.SpacingVertical = gumProject?.FontSpacingVertical ?? 1;
+
+                        FontService.CreateFontIfNecessary(bmfcSave);
+                    }
+                    catch
+                    {
+                        // Font creation can fail for many reasons (invalid font name, missing bmfont.exe, etc.)
+                        // Silently fall through to the disk load attempt or default font fallback.
+                    }
+                }
+#endif
+
+                if (font == null || font.Texture?.IsDisposed == true)
+                {
+#if KNI
+                        try
+                        {
+                            // this could be running in browser where we don't have File.Exists, so JUST DO IT
+                            font = new BitmapFont(fullFileName);
+
+                            loaderManager.AddDisposable(fullFileName, font);
+                        }
+                        catch
+                        {
+                            // font doesn't exist, carry on...
+                        }
+#else
+                    // so normally we would just let the content loader check if the file exists but since we're not going to
+                    // use the content loader for BitmapFont, we're going to protect this with a file.exists.
+                    if (ToolsUtilities.FileManager.FileExists(fullFileName))
+                    {
+                        // kill the old font:
+                        if(font?.Texture?.IsDisposed == true)
+                        {
+                            loaderManager.Dispose(fullFileName);
+                        }
+
+                        try
+                        {
+                            font = new BitmapFont(fullFileName);
+                            loaderManager.AddDisposable(fullFileName, font);
+                        }
+                        catch (System.Text.DecoderFallbackException exception)
+                        {
+                            throw new Exception($"Error trying to load font from file {fullFileName}:\n" + exception, exception);
+                        }
+                    }
+#endif
+                }
+
+                // FRB may dispose fonts, so let's check:
+
+#if FULL_DIAGNOSTICS
+                if (font?.Textures.Any(item => item?.IsDisposed == true) == true)
+                {
+                    throw new InvalidOperationException("The returned font has a disposed texture");
+                }
+#endif
+            }
+        }
+
+        var fontToSet = font ?? Text.DefaultBitmapFont;
+
+        if (asText.BitmapFont != fontToSet)
+        {
+            asText.BitmapFont = fontToSet;
+
+            // we want to update if the text's size is based on its "children" (the letters it contains)
+            if (graphicalUiElement.WidthUnits == DimensionUnitType.RelativeToChildren ||
+                // If height is relative to children, it could be in a stack
+                graphicalUiElement.HeightUnits == DimensionUnitType.RelativeToChildren)
+            {
+                // When this font load is the #2999 deferred-font flush performed from inside
+                // UpdateLayout, the enclosing layout pass already sizes this element, so this
+                // extra UpdateLayout would be redundant and re-entrant (no-arg UpdateLayout also
+                // requests a parent update). Skip it in that case.
+                if (!GraphicalUiElement.SuppressLayoutFromFontChange)
+                {
+                    graphicalUiElement.UpdateLayout();
+                }
+            }
+        }
+#else
         var textRuntime = graphicalUiElement as TextRuntime;
 
         var loaderManager = global::RenderingLibrary.Content.LoaderManager.Self;
@@ -1547,11 +1974,11 @@ public class CustomSetPropertyOnRenderable
                 }
             }
         }
+#endif
 
         // Re-parse BBCode segments so they pick up the new base font values. Without this, only the
-        // non-tagged text updates; runs after BBCode font tags retain the previous font because their
-        // InlineVariables still reference the old resolved font. (Boyscout #3624 - the MonoGame
-        // Gum/Wireframe/CustomSetPropertyOnRenderable.cs already does this; the Raylib copy had drifted.)
+        // non-tagged text updates; segments after BBCode tags retain old font properties because their
+        // InlineVariables still reference the previous resolved font.
         if (!string.IsNullOrEmpty(asText.StoredMarkupText))
         {
             asText.InlineVariables.Clear();
@@ -1559,6 +1986,7 @@ public class CustomSetPropertyOnRenderable
         }
     }
 
+#if RAYLIB
     // Mirrors the MonoGame loader's `if (BitmapFont != fontToSet)` guard. A single SetProperty can
     // reach this loader twice — once via the TextRuntime setter (UpdateFontFromProperties) and once
     // via the explicit ReactToFontValueChange call — and with font caching on the second load is a
@@ -1571,6 +1999,24 @@ public class CustomSetPropertyOnRenderable
             asText.Font = font;
         }
     }
+#endif
+
+#if !RAYLIB
+    private static BitmapFont? GetFontDisposable(string fontName)
+    {
+#if KNI
+        string prefix = "KniGum";
+#elif FNA
+        string prefix = "FnaGum";
+#else
+        string prefix = "MonoGameGum.Content";
+#endif
+
+        string fontFilenameOnly = Path.GetFileName(fontName);
+        string embeddedFontName = $"EmbeddedResource.{prefix}.{fontFilenameOnly}";
+        return global::RenderingLibrary.Content.LoaderManager.Self.GetDisposable(embeddedFontName) as BitmapFont;
+    }
+#endif
 
     #endregion
 


### PR DESCRIPTION
## Summary

Continuation of the `CustomSetPropertyOnRenderable` cross-platform unification tracked in #3615. PR #3627 converged the *architecture* of the font-resolution region (`SetBbCodeText`/`ApplyFontVariables`/`GetAndCreateFontIfNecessary`/`ReactToFontValueChange`/`UpdateToFontValues`) between the MonoGame/KNI/FNA home copy (`Gum/Wireframe/CustomSetPropertyOnRenderable.cs`) and the Raylib copy (`Runtimes/RaylibGum/Renderables/CustomSetPropertyOnRenderable.cs`), but explicitly left several blocks un-mirrored (558→515 diff lines for that region, not 0) — the MonoGame-only `[Custom]` BBCode tag, the platform-specific font-*creation* bodies, and a scattering of textual/doc-comment drift.

This PR finishes the convergence per the incremental-convergence technique in `.claude/skills/gum-cross-platform-unification/SKILL.md`:

- Mirrors the `[Custom]` BBCode tag case (#3471) into the Raylib file under `#if !RAYLIB` (dead there), and into the home file under the same guard, so both files carry identical text.
- Mirrors the font-CREATION bodies of `GetAndCreateFontIfNecessary` (+ its `GetFontFileName` helper) and `UpdateToFontValues` into **both** files under matching `#if !RAYLIB` / `#if RAYLIB` guards — each file now contains both platforms' creation logic, with only the native one live per build. Also mirrors the small platform helpers `GetFontDisposable` (MonoGame) and `AssignFontIfChanged` (Raylib) the same way.
- Converges remaining historical-drift text to identical wording with no guard: `Color`/`FontSize`/`OutlineThickness` parsing style (dead redundant line, inline `out` declarations), doc comments, the "close off the last font run" comment, and the re-wrap/re-measure comment (now credits both `#3520` MonoGame and `#3532` Raylib, since the two were fixed independently per-platform).
- Hoists `var asText = (Text)text;` to the shared prologue of `UpdateToFontValues` so the (now-shared) epilogue references one consistent variable name instead of home's `asRenderableText` vs Raylib's `asText`.

**Result:** `git diff --no-index` between the two files for the font-resolution region (the 5 named methods + their font-creation helpers) is now **0**.

**Bug fix as a byproduct:** `FontScale`'s `float.TryParse` used the current thread culture. Under a culture where `.` is the thousands separator (e.g. `de-DE`), `"1.5"` does not fail to parse — it silently parses as `15`, applying a 10x-too-large scale. Converged to `CultureInfo.InvariantCulture` (matching the Raylib side, which already had this right, and matching the `int.TryParse` calls for `FontSize`/`OutlineThickness` in the same method). Added `WrappedTextHeight_ShouldScaleBy1Point5_WhenFontScaleHasDecimalPoint_RegardlessOfCurrentCulture` (`MonoGameGum.Tests/Runtimes/TextRuntimeTests.cs`) — confirmed it reproduces the bug (315px instead of ~31.5px) against the pre-fix code and is green after.

**Deferred (out of scope):** the `Tags` property and `ResolveFontFilePath` method are used by this region but physically live at different positions in the two files (and, for `ResolveFontFilePath`, a different location outside the `#region Text` block in the home file entirely). Reordering them would touch already-converged and out-of-region code, so they're left as-is; the isolated diff of the named methods' bodies is unaffected by their declaration position.

## Test plan
- [x] `dotnet test MonoGameGum.Tests/MonoGameGum.Tests.csproj` — 1849/1849 passed (was 1848 before the new regression test)
- [x] `dotnet test Tests/RaylibGum.Tests/RaylibGum.Tests.csproj` — 492/492 passed
- [x] `dotnet build MonoGameGum/KniGum/KniGum.csproj` — 0 errors; 0 new warnings from the changed file
- [x] No `GumCoreShared.projitems` change needed (no files added/removed)
- [x] FRB canary (`dotnet build GumCore/GumCoreXnaPc/GumCore.DesktopGlNet6/GumCore.DesktopGlNet6.csproj`) — 0 errors; warnings from the changed file actually decreased (236→224 lines), no new ones. Run from the primary checkout after pushing.

Part of #3615.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
