### PR TITLE
Upgrade RaylibGum to raylib-cs 8.0.0 (raylib 6.0)

### DIFF
--- a/Integrations/KernSmith/KernSmith.RaylibGum/KernSmith.RaylibGum.csproj
+++ b/Integrations/KernSmith/KernSmith.RaylibGum/KernSmith.RaylibGum.csproj
@@ -34,7 +34,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Raylib-cs" Version="7.0.1" />
+    <PackageReference Include="Raylib-cs" Version="8.0.0" />
   </ItemGroup>
 
 </Project>

--- a/Runtimes/RaylibGum/RaylibGum.csproj
+++ b/Runtimes/RaylibGum/RaylibGum.csproj
@@ -243,7 +243,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Raylib-cs" Version="7.0.1" />
+		<PackageReference Include="Raylib-cs" Version="8.0.0" />
 		<PackageReference Include="TextCopy" Version="6.2.1" Condition="!$(TargetFramework.Contains('ios'))" />
 
 	</ItemGroup>

--- a/Samples/FontPlayground/FontPlayground.Raylib/FontPlayground.Raylib.csproj
+++ b/Samples/FontPlayground/FontPlayground.Raylib/FontPlayground.Raylib.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Raylib-cs" Version="7.0.1" />
+    <PackageReference Include="Raylib-cs" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Samples/RaylibGumThemesShowcase/RaylibGumThemesShowcase.csproj
+++ b/Samples/RaylibGumThemesShowcase/RaylibGumThemesShowcase.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Raylib-cs" Version="7.0.1" />
+    <PackageReference Include="Raylib-cs" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Samples/raylib/GumTest.csproj
+++ b/Samples/raylib/GumTest.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Raylib-cs" Version="7.0.1" />
+    <PackageReference Include="Raylib-cs" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tests/CodeGen_Raylib_ByReference/CodeGen_Raylib_ByReference.csproj
+++ b/Tests/CodeGen_Raylib_ByReference/CodeGen_Raylib_ByReference.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Raylib-cs" Version="7.0.1" />
+    <PackageReference Include="Raylib-cs" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Runtimes\RaylibGum\RaylibGum.csproj" />

--- a/Tests/RaylibGum.Tests/RaylibGum.Tests.csproj
+++ b/Tests/RaylibGum.Tests/RaylibGum.Tests.csproj
@@ -16,7 +16,7 @@
 	  <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.5.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
-	<PackageReference Include="Raylib-cs" Version="7.0.1" />
+	<PackageReference Include="Raylib-cs" Version="8.0.0" />
 
 
   </ItemGroup>

--- a/Themes/Gum.Themes.Bubblegum.Raylib/Gum.Themes.Bubblegum.Raylib.csproj
+++ b/Themes/Gum.Themes.Bubblegum.Raylib/Gum.Themes.Bubblegum.Raylib.csproj
@@ -57,7 +57,7 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Raylib-cs" Version="7.0.1" />
+    <PackageReference Include="Raylib-cs" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\GumCommon\GumCommon.csproj" />

--- a/Themes/Gum.Themes.DarkPro.Raylib/Gum.Themes.DarkPro.Raylib.csproj
+++ b/Themes/Gum.Themes.DarkPro.Raylib/Gum.Themes.DarkPro.Raylib.csproj
@@ -57,7 +57,7 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Raylib-cs" Version="7.0.1" />
+    <PackageReference Include="Raylib-cs" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\GumCommon\GumCommon.csproj" />

--- a/Themes/Gum.Themes.Editor.Raylib/Gum.Themes.Editor.Raylib.csproj
+++ b/Themes/Gum.Themes.Editor.Raylib/Gum.Themes.Editor.Raylib.csproj
@@ -35,7 +35,7 @@
   <ItemGroup>
     <!-- Color (Raylib_cs.Color) resolves through this package on the RAYLIB branch of the theme
          sources; the theme imports it explicitly (no global using). -->
-    <PackageReference Include="Raylib-cs" Version="7.0.1" />
+    <PackageReference Include="Raylib-cs" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\GumCommon\GumCommon.csproj" />

--- a/Themes/Gum.Themes.ForestGlade.Raylib/Gum.Themes.ForestGlade.Raylib.csproj
+++ b/Themes/Gum.Themes.ForestGlade.Raylib/Gum.Themes.ForestGlade.Raylib.csproj
@@ -55,7 +55,7 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Raylib-cs" Version="7.0.1" />
+    <PackageReference Include="Raylib-cs" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\GumCommon\GumCommon.csproj" />

--- a/Themes/Gum.Themes.Hazard.Raylib/Gum.Themes.Hazard.Raylib.csproj
+++ b/Themes/Gum.Themes.Hazard.Raylib/Gum.Themes.Hazard.Raylib.csproj
@@ -52,7 +52,7 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Raylib-cs" Version="7.0.1" />
+    <PackageReference Include="Raylib-cs" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\GumCommon\GumCommon.csproj" />

--- a/Themes/Gum.Themes.Meadow.Raylib/Gum.Themes.Meadow.Raylib.csproj
+++ b/Themes/Gum.Themes.Meadow.Raylib/Gum.Themes.Meadow.Raylib.csproj
@@ -59,7 +59,7 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Raylib-cs" Version="7.0.1" />
+    <PackageReference Include="Raylib-cs" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\GumCommon\GumCommon.csproj" />

--- a/Themes/Gum.Themes.Neon.Raylib/Gum.Themes.Neon.Raylib.csproj
+++ b/Themes/Gum.Themes.Neon.Raylib/Gum.Themes.Neon.Raylib.csproj
@@ -58,7 +58,7 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Raylib-cs" Version="7.0.1" />
+    <PackageReference Include="Raylib-cs" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\GumCommon\GumCommon.csproj" />

--- a/Themes/Gum.Themes.Retro95.Raylib/Gum.Themes.Retro95.Raylib.csproj
+++ b/Themes/Gum.Themes.Retro95.Raylib/Gum.Themes.Retro95.Raylib.csproj
@@ -51,7 +51,7 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Raylib-cs" Version="7.0.1" />
+    <PackageReference Include="Raylib-cs" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\GumCommon\GumCommon.csproj" />

--- a/Themes/Gum.Themes.Template.Raylib/Gum.Themes.Template.Raylib.csproj
+++ b/Themes/Gum.Themes.Template.Raylib/Gum.Themes.Template.Raylib.csproj
@@ -70,7 +70,7 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Raylib-cs" Version="7.0.1" />
+    <PackageReference Include="Raylib-cs" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\GumCommon\GumCommon.csproj" />


### PR DESCRIPTION
## Summary
- Bumps `Raylib-cs` 7.0.1 → 8.0.0 (native raylib 5.5 → 6.0) in all 16 csproj files that reference it: `Runtimes/RaylibGum`, `Integrations/KernSmith/KernSmith.RaylibGum`, all 9 `Themes/*.Raylib` projects, `Samples/raylib`, `Samples/RaylibGumThemesShowcase`, `Samples/FontPlayground/FontPlayground.Raylib`, `Tests/CodeGen_Raylib_ByReference`, and `Tests/RaylibGum.Tests`.
- No source changes needed. See #3636 for the researched breaking-change surface (record-struct conversion of `Color`/`Rectangle`/etc. drops their custom `ToString()`, a `ShaderLocationIndex` rename that's model/3D-only, a few removed model/animation-only functions) — none of it touches anything RaylibGum calls.

## Test plan
- [x] `dotnet build Runtimes/RaylibGum/RaylibGum.csproj` — 0 errors
- [x] `dotnet test Tests/RaylibGum.Tests/RaylibGum.Tests.csproj` — 492/492 pass
- [x] `dotnet build` on all other bumped csprojs (KernSmith.RaylibGum, all 9 Themes.Raylib, all raylib samples, CodeGen_Raylib_ByReference) — 0 errors
- [x] `dotnet build Samples/raylib/RaylibSample.sln` — 0 errors
- [x] Manual visual smoke test of `Samples/raylib/RaylibSample.sln` (native library major-version bump — see manual-test note below)

Closes #3636
