### PR TITLE
Revert TrySetPropertyOnText to public - fixes FRB build break

### DIFF
--- a/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
+++ b/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
@@ -709,7 +709,13 @@ public class CustomSetPropertyOnRenderable
 
     #region Text
 
-    private static bool TrySetPropertyOnText(Text textRenderable, GraphicalUiElement graphicalUiElement, string propertyName, object value)
+    // Public (not private) is deliberate: FlatRedBall's Glue tool generates FRB game projects'
+    // TextRuntime.Generated.cs with a hardcoded direct call to
+    // global::Gum.Wireframe.CustomSetPropertyOnRenderable.TrySetPropertyOnText(...) (and the same for
+    // TextNoTranslate). Since FRB1 compiles this file as source (not a compiled DLL, via
+    // GumCoreShared.projitems), narrowing this method breaks every FRB game's build with CS0117 even
+    // though nothing in this repo calls it directly. See issue #3641.
+    public static bool TrySetPropertyOnText(Text textRenderable, GraphicalUiElement graphicalUiElement, string propertyName, object value)
     {
         bool handled = false;
 

--- a/MonoGameGum.Tests/Runtimes/TextRuntimeTests.cs
+++ b/MonoGameGum.Tests/Runtimes/TextRuntimeTests.cs
@@ -11,6 +11,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel.Design;
 using System.Linq;
+using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
 using ToolsUtilities;
@@ -778,6 +779,26 @@ char id=67 x=0 y=0 width={xadvance} height=13 xoffset=0 yoffset=4 xadvance={xadv
         textRuntime.Text = "Hello 1234";
 
         wasChanged.ShouldBeTrue();
+    }
+
+    #endregion
+
+    #region TrySetPropertyOnText public API (FRB Glue compat)
+
+    // #3641 regression: FlatRedBall's Glue tool generates FRB game projects' TextRuntime.Generated.cs
+    // with a hardcoded direct call to
+    // global::Gum.Wireframe.CustomSetPropertyOnRenderable.TrySetPropertyOnText(...). Since FRB1
+    // compiles Gum/Wireframe/CustomSetPropertyOnRenderable.cs as source (via GumCoreShared.projitems,
+    // not a compiled DLL), narrowing this method to private breaks every FRB game's build with
+    // CS0117, even though nothing inside this repo calls it directly. Pin its accessibility so a
+    // future refactor of CustomSetPropertyOnRenderable doesn't silently re-narrow it.
+    [Fact]
+    public void TrySetPropertyOnText_ShouldStayPublic_ForFrbGlueGeneratedCallers()
+    {
+        MethodInfo? method = typeof(CustomSetPropertyOnRenderable).GetMethod(
+            "TrySetPropertyOnText", BindingFlags.Public | BindingFlags.Static);
+
+        method.ShouldNotBeNull();
     }
 
     #endregion


### PR DESCRIPTION
## Summary
- PR #3633 narrowed `CustomSetPropertyOnRenderable.TrySetPropertyOnText` from `public` to `private`, claiming "no external callers reference it."
- That's incorrect: FlatRedBall's Glue tool generates FRB game projects' `TextRuntime.Generated.cs` with a hardcoded direct call to `global::Gum.Wireframe.CustomSetPropertyOnRenderable.TrySetPropertyOnText(...)` for the `Text`/`TextNoTranslate` setters. Glue lives outside this repo, so grepping here found no callers.
- FRB1 compiles `Gum/Wireframe/CustomSetPropertyOnRenderable.cs` as source (via `GumCoreShared.projitems`, not a DLL), so the narrowing broke every FRB game's build with `CS0117`.
- Reverted to `public` with a comment explaining why, and added a reflection-based regression test pinning the accessibility.

Closes #3641

## Test plan
- [x] `MonoGameGum.Tests` — full suite green (1850/1850) including the new `TrySetPropertyOnText_ShouldStayPublic_ForFrbGlueGeneratedCallers` pinning test
- [x] Manual test: not needed — pure accessibility-modifier revert plus a reflection-based pinning test, no runtime-observable behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)