### PR TITLE
Raylib: Sprite/NineSlice Color converter (System.Drawing.Color -> Raylib_cs.Color)

### DIFF
--- a/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
+++ b/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
@@ -38,6 +38,7 @@ using Gum.GueDeriving;
 #if RAYLIB
 using Gum.Renderables;
 using Gum.GueDeriving;
+using RaylibGum.Helpers;
 // The font a BBCode font-run resolves to. On Raylib that is a Raylib_cs.Font; on the XNA-family
 // backends it is a BitmapFont. Mirrored #if so the shared BBCode stack-resolution loop below stays
 // type-neutral (see ApplyFontVariables) - only the font-CREATION body is platform-gated.
@@ -446,10 +447,11 @@ public class CustomSetPropertyOnRenderable
             }
             handled = true;
 #else
-            // TODO #3629 - no System.Drawing.Color -> Raylib_cs.Color converter exists yet, so this
-            // is a tracked no-op. SetPropertyOnRenderable falls back to reflection afterward, which
-            // also can't bridge the type mismatch, so a data-driven "Color" value is silently
-            // dropped on Raylib until #3629 lands.
+            if (value is System.Drawing.Color drawingColor)
+            {
+                nineSlice.Color = drawingColor.ToRaylib();
+                handled = true;
+            }
 #endif
         }
         else if(propertyName == "Red")
@@ -636,21 +638,25 @@ public class CustomSetPropertyOnRenderable
                     handled = true;
                     break;
                 }
-#if !RAYLIB
             case nameof(Sprite.Color):
                 {
                     if (value is System.Drawing.Color drawingColor)
                     {
+#if RAYLIB
+                        sprite.Color = drawingColor.ToRaylib();
+#else
                         sprite.Color = drawingColor;
+#endif
                     }
+#if !RAYLIB
                     else if (value is Microsoft.Xna.Framework.Color xnaColor)
                     {
                         sprite.Color = xnaColor.ToSystemDrawing();
                     }
+#endif
                     handled = true;
                     break;
                 }
-#endif
             case "Blend":
                 {
                     var valueAsGumBlend = (Gum.RenderingLibrary.Blend)value;

--- a/Runtimes/RaylibGum/Helpers/ColorExtensions.cs
+++ b/Runtimes/RaylibGum/Helpers/ColorExtensions.cs
@@ -46,6 +46,15 @@ public static class ColorExtensions
         return new Color(color.R, color.G, value, color.A);
     }
 
+    /// <summary>
+    /// Converts a <see cref="System.Drawing.Color"/> to its Raylib equivalent. Mirror of
+    /// <c>ToolsUtilitiesStandard.Helpers.ColorExtensions.ToXNA</c> for the Raylib backend.
+    /// </summary>
+    public static Color ToRaylib(this System.Drawing.Color value)
+    {
+        return new Color(value.R, value.G, value.B, value.A);
+    }
+
     // Identity overloads of the container/user color round-trip helpers added in #2757 for
     // shared runtime files (e.g. PolygonRuntime). On Raylib the contained renderable's color
     // type matches the user-facing Color, so no conversion is needed — but exposing the same

--- a/Tests/RaylibGum.Tests/Helpers/ColorExtensionsTests.cs
+++ b/Tests/RaylibGum.Tests/Helpers/ColorExtensionsTests.cs
@@ -55,4 +55,17 @@ public class ColorExtensionsTests : BaseTestClass
         result.B.ShouldBe((byte)30);
         result.A.ShouldBe((byte)40);
     }
+
+    [Fact]
+    public void ToRaylib_ShouldConvertChannelsFromSystemDrawingColor()
+    {
+        System.Drawing.Color drawingColor = System.Drawing.Color.FromArgb(40, 10, 20, 30);
+
+        Color result = drawingColor.ToRaylib();
+
+        result.R.ShouldBe((byte)10);
+        result.G.ShouldBe((byte)20);
+        result.B.ShouldBe((byte)30);
+        result.A.ShouldBe((byte)40);
+    }
 }

--- a/Tests/RaylibGum.Tests/Runtimes/DataDrivenNineSlicePropertyTests.cs
+++ b/Tests/RaylibGum.Tests/Runtimes/DataDrivenNineSlicePropertyTests.cs
@@ -1,5 +1,6 @@
 using Gum.GueDeriving;
 using Gum.Renderables;
+using RaylibGum.Helpers;
 using Shouldly;
 
 namespace RaylibGum.Tests.Runtimes;
@@ -43,13 +44,14 @@ public class DataDrivenNineSlicePropertyTests : BaseTestClass
         ((NineSlice)sut.RenderableComponent).IsTilingMiddleSections.ShouldBeTrue();
     }
 
-    // Color -> Raylib_cs.Color has no converter yet (#3629), so this data-driven path is a
-    // tracked no-op. This pins that it stays a silent no-op rather than throwing.
     [Fact]
-    public void SetProperty_Color_OnNineSlice_DoesNotThrow()
+    public void SetProperty_Color_OnNineSlice_AppliesValue()
     {
         NineSliceRuntime sut = new();
 
-        Should.NotThrow(() => sut.SetProperty("Color", System.Drawing.Color.Red));
+        Should.NotThrow(() => sut.SetProperty("Color", System.Drawing.Color.FromArgb(40, 10, 20, 30)));
+
+        ((NineSlice)sut.RenderableComponent).Color.ShouldBe(
+            System.Drawing.Color.FromArgb(40, 10, 20, 30).ToRaylib());
     }
 }

--- a/Tests/RaylibGum.Tests/Runtimes/SpriteSetPropertyTests.cs
+++ b/Tests/RaylibGum.Tests/Runtimes/SpriteSetPropertyTests.cs
@@ -2,6 +2,7 @@ using Gum.Graphics.Animation;
 using Gum.GueDeriving;
 using Gum.Wireframe;
 using Raylib_cs;
+using RaylibGum.Helpers;
 using RaylibGum.Renderables;
 using RenderingLibrary.Graphics;
 using Shouldly;
@@ -27,6 +28,17 @@ public class SpriteSetPropertyTests : BaseTestClass
         sut.SetProperty("Blend", Gum.RenderingLibrary.Blend.Additive);
 
         sut.Blend.ShouldBe(Gum.RenderingLibrary.Blend.Additive);
+    }
+
+    [Fact]
+    public void SetProperty_Color_ShouldForwardToContainedSprite()
+    {
+        SpriteRuntime sut = new();
+        var drawingColor = System.Drawing.Color.FromArgb(40, 10, 20, 30);
+
+        sut.SetProperty(nameof(SpriteRuntime.Color), drawingColor);
+
+        ((Gum.Renderables.Sprite)sut.RenderableComponent).Color.ShouldBe(drawingColor.ToRaylib());
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Adds `RaylibGum.Helpers.ColorExtensions.ToRaylib(this System.Drawing.Color)`, the mirror of the existing XNA-side `ToSystemDrawing()` direction.
- Wires up the previously commented-out/no-op `"Color"` cases for `NineSlice` and `Sprite` in the raylib branch of `CustomSetPropertyOnRenderable` to use the new converter.
- Updates the existing pinning test (`SetProperty_Color_OnNineSlice_DoesNotThrow` -> `SetProperty_Color_OnNineSlice_AppliesValue`) and adds equivalent coverage for `Sprite.Color` and the new converter.

Closes #3629

## Test plan
- [x] `dotnet test Tests/RaylibGum.Tests/RaylibGum.Tests.csproj` — 495/495 passed
- [x] `dotnet test MonoGameGum.Tests/MonoGameGum.Tests.csproj --filter "FullyQualifiedName~Sprite|FullyQualifiedName~NineSlice"` — 39/39 passed (confirms the shared file still compiles/behaves correctly on the XNA-family side)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
