### PR TITLE
Fix RelativeToChildren Text force-wrapping on inline [FontScale] runs (#3645)

### DIFF
--- a/MonoGameGum.Tests/Runtimes/TextRuntimeTests.cs
+++ b/MonoGameGum.Tests/Runtimes/TextRuntimeTests.cs
@@ -417,6 +417,16 @@ char id=67 x=0 y=0 width={xadvance} height=13 xoffset=0 yoffset=4 xadvance={xadv
         textContentWidth.ShouldBeGreaterThan(0);
         box.GetAbsoluteWidth().ShouldBeGreaterThanOrEqualTo(textContentWidth,
             "because the RelativeToChildren box must be at least as wide as its text, even with a RelativeToParent background sibling");
+        // #3645: containment alone isn't enough - a container that "correctly" grows to fit a wrapped
+        // 2-line block still passes the containment assertion above even though the wrap itself is the
+        // bug. (This assertion is a forward-looking regression guard, not a pin: the bug this issue fixed
+        // - a [FontScale] run's rounded self-measured width coming out narrower than its own unrounded
+        // content, forcing a self-inflicted wrap - reproduces on Raylib (real MeasureTextEx sub-pixel
+        // widths; see RaylibGum.Tests TextRuntimeTests) but not through this MonoGame harness even with a
+        // real generated font, matching the caveat in #3645 that the MonoGame path may not exercise the
+        // same fractional-width case.)
+        ((Text)text.RenderableComponent).WrappedText.Count.ShouldBe(1,
+            "because RelativeToChildren on both the Text and its container means the content should size to fit on one line, not wrap");
     }
 
     // The #3520 bug as the user reported it: a RelativeToChildren-width container wrapping a

--- a/RenderingLibrary/Graphics/Text.cs
+++ b/RenderingLibrary/Graphics/Text.cs
@@ -1581,7 +1581,15 @@ public class Text : SpriteBatchRenderableBase, IRenderableIpso, IVisible, IWrapp
         }
 
         const int MaxWidthAndHeight = 4096;
-        requiredWidth = System.Math.Min((int)(maxWidth + .5f), MaxWidthAndHeight);
+        // Width must round UP (not to-nearest): this value becomes the Text's own self-imposed wrap
+        // width (RelativeToChildren sets Text.Width to it), which is then compared against the same
+        // line's raw, unrounded measurement in IWrappedTextExtensions.UpdateLines. Rounding to-nearest
+        // can round DOWN when the fractional part is < 0.5 (e.g. maxWidth=116.4 -> 116), making that
+        // self-imposed width narrower than the content that produced it, so the very run that determined
+        // the width no longer "fits" and gets force-wrapped (#3645). Only affects fractional widths, which
+        // only occur via inline-run scaling (e.g. [FontScale]) - the non-inline-variable path measures
+        // whole bitmap-font glyph advances, which are already integers.
+        requiredWidth = System.Math.Min((int)System.Math.Ceiling(maxWidth), MaxWidthAndHeight);
         requiredHeight = System.Math.Min((int)(totalHeight + .5f), MaxWidthAndHeight);
     }
 

--- a/Runtimes/RaylibGum/Renderables/Text.cs
+++ b/Runtimes/RaylibGum/Renderables/Text.cs
@@ -1319,7 +1319,15 @@ public class Text : IVisible, IRenderableIpso,
         }
 
         const int MaxWidthAndHeight = 4096;
-        requiredWidth = System.Math.Min((int)(maxWidth + .5f), MaxWidthAndHeight);
+        // Width must round UP (not to-nearest): this value becomes the Text's own self-imposed wrap
+        // width (RelativeToChildren sets Text.Width to it), which is then compared against the same
+        // line's raw, unrounded measurement in IWrappedTextExtensions.UpdateLines. Rounding to-nearest
+        // can round DOWN when the fractional part is < 0.5 (e.g. maxWidth=152.4 -> 152), making that
+        // self-imposed width narrower than the content that produced it, so the very run that determined
+        // the width no longer "fits" and gets force-wrapped (#3645). Only affects fractional widths, which
+        // only occur via inline-run scaling (e.g. [FontScale]) - the non-inline-variable path measures
+        // whole bitmap-font glyph advances, which are already integers.
+        requiredWidth = System.Math.Min((int)System.Math.Ceiling(maxWidth), MaxWidthAndHeight);
         requiredHeight = System.Math.Min((int)(totalHeight + .5f), MaxWidthAndHeight);
     }
 

--- a/Tests/RaylibGum.Tests/Runtimes/TextRuntimeTests.cs
+++ b/Tests/RaylibGum.Tests/Runtimes/TextRuntimeTests.cs
@@ -814,5 +814,97 @@ public class TextRuntimeTests : BaseTestClass
         sut.WrappedText.ShouldNotBeEmpty();
     }
 
+    // Establishes scope for #3645 (see WrappedText_ShouldNotWrap_WhenRelativeToChildrenTextHasInlineFontScaleRun...
+    // below): same RelativeToChildren + RelativeToParent-background-sibling shape, but with a [FontSize]
+    // font-swap run instead of [FontScale] - a different inline run kind, still no per-run scale involved.
+    // This does NOT reproduce the bug (it passes with or without the fix), confirming the bug is
+    // FontScale-specific (fractional scale multiplication), not "any inline BBCode run."
+    [Fact]
+    public void WrappedText_ShouldNotWrap_ForFontSizeSwapRun_WhenParentHasRelativeToParentBackgroundSibling()
+    {
+        ContainerRuntime cell = new();
+        cell.WidthUnits = Gum.DataTypes.DimensionUnitType.RelativeToChildren;
+        cell.HeightUnits = Gum.DataTypes.DimensionUnitType.RelativeToChildren;
+
+        ContainerRuntime background = new();
+        background.WidthUnits = Gum.DataTypes.DimensionUnitType.RelativeToParent;
+        background.HeightUnits = Gum.DataTypes.DimensionUnitType.RelativeToParent;
+        cell.Children.Add(background);
+
+        TextRuntime text = new();
+        text.WidthUnits = Gum.DataTypes.DimensionUnitType.RelativeToChildren;
+        text.HeightUnits = Gum.DataTypes.DimensionUnitType.RelativeToChildren;
+        text.Text = "This is [FontSize=40]big[/FontSize] text.";
+        cell.Children.Add(text);
+
+        cell.AddToRoot();
+
+        var wrappedText = ((Gum.Renderables.Text)text.RenderableComponent).WrappedText;
+        wrappedText.Count.ShouldBe(1, $"got {wrappedText.Count} lines: {string.Join(" | ", wrappedText)}");
+    }
+
+    // Establishes scope for #3645 (see WrappedText_ShouldNotWrap_WhenRelativeToChildrenTextHasInlineFontScaleRun...
+    // below): same RelativeToChildren + RelativeToParent-background-sibling shape, but with plain text (no
+    // BBCode at all). This does NOT reproduce the bug (it passes with or without the fix), establishing that
+    // the bug is specific to fractional-pixel measurement from an inline run's scale, not a general
+    // RelativeToChildren + RelativeToParent-sibling layout defect. The non-inline-variable measurement path
+    // sums whole bitmap-font glyph advances, which are already integers, so it never produces the fractional
+    // width the bug depends on.
+    [Fact]
+    public void WrappedText_ShouldNotWrap_ForPlainTextWithNoFontScale_WhenParentHasRelativeToParentBackgroundSibling()
+    {
+        ContainerRuntime cell = new();
+        cell.WidthUnits = Gum.DataTypes.DimensionUnitType.RelativeToChildren;
+        cell.HeightUnits = Gum.DataTypes.DimensionUnitType.RelativeToChildren;
+
+        ContainerRuntime background = new();
+        background.WidthUnits = Gum.DataTypes.DimensionUnitType.RelativeToParent;
+        background.HeightUnits = Gum.DataTypes.DimensionUnitType.RelativeToParent;
+        cell.Children.Add(background);
+
+        TextRuntime text = new();
+        text.WidthUnits = Gum.DataTypes.DimensionUnitType.RelativeToChildren;
+        text.HeightUnits = Gum.DataTypes.DimensionUnitType.RelativeToChildren;
+        text.Text = "This is plain text with no font scale at all here.";
+        cell.Children.Add(text);
+
+        cell.AddToRoot();
+
+        var wrappedText = ((Gum.Renderables.Text)text.RenderableComponent).WrappedText;
+        wrappedText.Count.ShouldBe(1, $"got {wrappedText.Count} lines: {string.Join(" | ", wrappedText)}");
+    }
+
+    // #3645: a RelativeToChildren Text with an inline [FontScale] run, inside a RelativeToChildren
+    // container that also has a RelativeToParent background sibling, wrapped onto an extra line it
+    // shouldn't. Root cause: the run's measured width was rounded to the NEAREST int, then fed back as
+    // the Text's own self-imposed wrap-width constraint (RelativeToChildren -> Text.Width). When the true
+    // width has a fractional part under 0.5, rounding-to-nearest rounds DOWN, so the constraint ends up
+    // narrower than the very content that produced it, and the Text force-wraps against its own
+    // measurement. Fixed by rounding that width UP (Ceiling) instead. See the two tests above for the
+    // negative controls that scope this to FontScale specifically.
+    [Fact]
+    public void WrappedText_ShouldNotWrap_WhenRelativeToChildrenTextHasInlineFontScaleRun_AndParentHasRelativeToParentBackgroundSibling()
+    {
+        ContainerRuntime cell = new();
+        cell.WidthUnits = Gum.DataTypes.DimensionUnitType.RelativeToChildren;
+        cell.HeightUnits = Gum.DataTypes.DimensionUnitType.RelativeToChildren;
+
+        ContainerRuntime background = new();
+        background.WidthUnits = Gum.DataTypes.DimensionUnitType.RelativeToParent;
+        background.HeightUnits = Gum.DataTypes.DimensionUnitType.RelativeToParent;
+        cell.Children.Add(background);
+
+        TextRuntime text = new();
+        text.WidthUnits = Gum.DataTypes.DimensionUnitType.RelativeToChildren;
+        text.HeightUnits = Gum.DataTypes.DimensionUnitType.RelativeToChildren;
+        text.Text = "This is [FontScale=1.9]big[/FontScale] text.";
+        cell.Children.Add(text);
+
+        cell.AddToRoot();
+
+        var wrappedText = ((Gum.Renderables.Text)text.RenderableComponent).WrappedText;
+        wrappedText.Count.ShouldBe(1, $"got {wrappedText.Count} lines: {string.Join(" | ", wrappedText)}");
+    }
+
     #endregion
 }


### PR DESCRIPTION
## Summary

Root cause: `GetInlineVariableAwareWidthAndHeight` rounded a `[FontScale]` run's measured width to the **nearest** int, then that rounded value was fed back as the `Text`'s own self-imposed wrap-width constraint (`RelativeToChildren` sets `Text.Width` from it). When the true (unrounded) width has a fractional part under 0.5, round-to-nearest rounds **down**, making the constraint narrower than the content that produced it — so the very run that determined the width no longer "fits" within it and force-wraps.

Fix: round that width **up** (`Ceiling`) instead, in both the MonoGame/shared (`RenderingLibrary/Graphics/Text.cs`) and Raylib (`Runtimes/RaylibGum/Renderables/Text.cs`) copies of the method.

Not a FontScale coincidence — verified directly: negative-control tests with plain text and a `[FontSize]` swap, in the identical `RelativeToChildren` + `RelativeToParent`-background-sibling shape, do **not** reproduce the bug. Only fractional-scale glyph measurement (an inline `[FontScale]` run multiplying otherwise-integer glyph advances) produces the rounding mismatch — the non-inline-variable measurement path sums whole integer advances and never has a fraction to round wrong.

## Test plan
- [x] `RaylibGum.Tests` — 3 new tests: the exact repro (fails without the fix), plus 2 negative controls (plain text, `[FontSize]` swap) that pass regardless, scoping the bug to `[FontScale]`.
- [x] `MonoGameGum.Tests` — added a `WrappedText.Count` assertion to the existing `RelativeToChildrenContainer_WithRelativeToParentBackground_ShouldContainFontScaleRun` test (containment alone doesn't catch a "correctly" wrapped 2-line block).
- [x] Full suite: `RaylibGum.Tests` 501/501, `MonoGameGum.Tests` 1850/1850.
- [x] Manual test: confirmed on both `Samples/MonoGameGumInCode` and `Samples/raylib` — the `[FontScale=1.9]` cell in the `TextScreen` font-size-containment gallery row (which visually showed the bug before the fix) now renders on one line, matching the `[FontSize=40]` cell beside it.

Closes #3645
