### PR TITLE
Propagate base text dropshadow to inline BBCode font runs

### DIFF
--- a/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
+++ b/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
@@ -1034,6 +1034,32 @@ public class CustomSetPropertyOnRenderable
     static Stack<bool> isBoldStack = new Stack<bool>();
     static Stack<bool> useCustomFontStack = new Stack<bool>();
 
+    // The base text's dropshadow, snapshotted once per SetBbCodeText call (no BBCode tag toggles
+    // dropshadow mid-text, so unlike the seven stacks above this needs no push/pop) and applied to
+    // every per-run font resolved by GetAndCreateFontIfNecessary, matching the base-font path
+    // (TextRuntime.CopyFontGenerationFieldsTo / GetFontCacheFileName). See #3625.
+    static bool currentHasDropshadow;
+    static float currentDropshadowOffsetX;
+    static float currentDropshadowOffsetY;
+    static float currentDropshadowBlur;
+    static byte currentDropshadowRed;
+    static byte currentDropshadowGreen;
+    static byte currentDropshadowBlue;
+    static byte currentDropshadowAlpha;
+
+    // Copies the snapshotted base-text dropshadow (see the fields above) onto a per-run BmfcSave.
+    static void ApplyCurrentDropshadowTo(BmfcSave bmfcSave)
+    {
+        bmfcSave.HasDropshadow = currentHasDropshadow;
+        bmfcSave.DropshadowOffsetX = currentDropshadowOffsetX;
+        bmfcSave.DropshadowOffsetY = currentDropshadowOffsetY;
+        bmfcSave.DropshadowBlur = currentDropshadowBlur;
+        bmfcSave.DropshadowRed = currentDropshadowRed;
+        bmfcSave.DropshadowGreen = currentDropshadowGreen;
+        bmfcSave.DropshadowBlue = currentDropshadowBlue;
+        bmfcSave.DropshadowAlpha = currentDropshadowAlpha;
+    }
+
     static List<TagInfo> allTags = new List<TagInfo>();
 
     /// <summary>
@@ -1192,6 +1218,28 @@ public class CustomSetPropertyOnRenderable
 
             useCustomFontStack.Clear();
             useCustomFontStack.Push(textRuntime.UseCustomFont);
+
+#if FRB
+            // FRB's GraphicalUiElement has no dropshadow font properties (see the FRB extension
+            // methods below), so per-run resolution never applies a dropshadow there either.
+            currentHasDropshadow = false;
+            currentDropshadowOffsetX = 0f;
+            currentDropshadowOffsetY = 0f;
+            currentDropshadowBlur = 0f;
+            currentDropshadowRed = 0;
+            currentDropshadowGreen = 0;
+            currentDropshadowBlue = 0;
+            currentDropshadowAlpha = 0;
+#else
+            currentHasDropshadow = textRuntime.HasDropshadow;
+            currentDropshadowOffsetX = textRuntime.DropshadowOffsetX;
+            currentDropshadowOffsetY = textRuntime.DropshadowOffsetY;
+            currentDropshadowBlur = textRuntime.DropshadowBlur;
+            currentDropshadowRed = (byte)textRuntime.DropshadowRed;
+            currentDropshadowGreen = (byte)textRuntime.DropshadowGreen;
+            currentDropshadowBlue = (byte)textRuntime.DropshadowBlue;
+            currentDropshadowAlpha = (byte)textRuntime.DropshadowAlpha;
+#endif
 
             ApplyFontVariables(asText, results);
         }
@@ -1381,6 +1429,7 @@ public class CustomSetPropertyOnRenderable
                         bmfcSave.UseSmoothing = useFontSmoothingStack.Peek();
                         bmfcSave.IsItalic = isItalicStack.Peek();
                         bmfcSave.IsBold = isBoldStack.Peek();
+                        ApplyCurrentDropshadowTo(bmfcSave);
 
                         if (bbFontFile != null)
                         {
@@ -1441,6 +1490,7 @@ public class CustomSetPropertyOnRenderable
                             bmfcSave.UseSmoothing = useFontSmoothingStack.Peek();
                             bmfcSave.IsItalic = isItalicStack.Peek();
                             bmfcSave.IsBold = isBoldStack.Peek();
+                            ApplyCurrentDropshadowTo(bmfcSave);
 
                             if (bbFontFileForDisk != null)
                             {
@@ -1510,7 +1560,15 @@ public class CustomSetPropertyOnRenderable
                     useFontSmoothingStack.Peek(),
                     isItalicStack.Peek(),
                     isBoldStack.Peek(),
-                    bbCodeFontFilePath);
+                    bbCodeFontFilePath,
+                    currentHasDropshadow,
+                    currentDropshadowOffsetX,
+                    currentDropshadowOffsetY,
+                    currentDropshadowBlur,
+                    currentDropshadowRed,
+                    currentDropshadowGreen,
+                    currentDropshadowBlue,
+                    currentDropshadowAlpha);
                 string fullFileName = ToolsUtilities.FileManager.Standardize(fontCacheName, preserveCase: true, makeAbsolute: true);
 
                 // Reuse an already-generated font (its Raylib_cs.Font wraps an unmanaged GPU texture, so
@@ -1527,6 +1585,7 @@ public class CustomSetPropertyOnRenderable
                 bmfcSave.UseSmoothing = useFontSmoothingStack.Peek();
                 bmfcSave.IsItalic = isItalicStack.Peek();
                 bmfcSave.IsBold = isBoldStack.Peek();
+                ApplyCurrentDropshadowTo(bmfcSave);
 
                 if (bbCodeFontFilePath != null)
                 {
@@ -1582,7 +1641,15 @@ public class CustomSetPropertyOnRenderable
                     useFontSmoothingStack.Peek(),
                     isItalicStack.Peek(),
                     isBoldStack.Peek(),
-                    bbCodeFontFilePath);
+                    bbCodeFontFilePath,
+                    currentHasDropshadow,
+                    currentDropshadowOffsetX,
+                    currentDropshadowOffsetY,
+                    currentDropshadowBlur,
+                    currentDropshadowRed,
+                    currentDropshadowGreen,
+                    currentDropshadowBlue,
+                    currentDropshadowAlpha);
 
             }
 

--- a/MonoGameGum.Tests/Runtimes/TextRuntimeBbCodeDropshadowRegressionTests.cs
+++ b/MonoGameGum.Tests/Runtimes/TextRuntimeBbCodeDropshadowRegressionTests.cs
@@ -1,0 +1,87 @@
+using Gum.GueDeriving;
+using Gum.Wireframe;
+using Microsoft.Xna.Framework.Graphics;
+using RenderingLibrary.Graphics;
+using RenderingLibrary.Graphics.Fonts;
+using Shouldly;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace MonoGameGum.Tests.Runtimes;
+
+// #3625: a Text with a base HasDropshadow=true and an inline BBCode font-family run (e.g.
+// [IsBold=true]) generated the per-run font WITHOUT the dropshadow fields, so the tagged run
+// rendered without the shadow while the surrounding base text kept it. GetAndCreateFontIfNecessary
+// (Gum/Wireframe/CustomSetPropertyOnRenderable.cs) must copy the base TextRuntime's dropshadow
+// fields onto every per-run BmfcSave, matching TextRuntime.CopyFontGenerationFieldsTo (the base-font
+// path). Deferred from #3624.
+public class TextRuntimeBbCodeDropshadowRegressionTests : BaseTestClass
+{
+    [Fact]
+    public void Text_WithBbCodeBoldRun_WhenBaseHasDropshadow_PropagatesDropshadowToInlineRunFont()
+    {
+        IInMemoryFontCreator? savedCreator = CustomSetPropertyOnRenderable.InMemoryFontCreator;
+        try
+        {
+            var recordingCreator = new RecordingInMemoryFontCreator();
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = recordingCreator;
+
+            TextRuntime textRuntime = new();
+            // A font/size NOT in the test harness's stubbed embedded resources (which only cover
+            // Arial-18 and its Bold/Italic/Bold_Italic variants), so resolution actually reaches the
+            // in-memory creator instead of being satisfied by an embedded font.
+            textRuntime.Font = "Garet";
+            textRuntime.FontSize = 12;
+            textRuntime.HasDropshadow = true;
+            textRuntime.DropshadowOffsetX = 2f;
+            textRuntime.DropshadowOffsetY = 3f;
+            textRuntime.DropshadowBlur = 1.5f;
+            textRuntime.DropshadowRed = 10;
+            textRuntime.DropshadowGreen = 20;
+            textRuntime.DropshadowBlue = 30;
+            textRuntime.DropshadowAlpha = 200;
+
+            textRuntime.Text = "normal [IsBold=true]bold[/IsBold] normal";
+
+            // The base-font resolution and the inline-bold-run resolution both call the creator; only
+            // the bold request exercises the per-run path this issue is about.
+            var boldRequest = recordingCreator.Requests.Single(r => r.IsBold);
+            boldRequest.HasDropshadow.ShouldBeTrue();
+            boldRequest.DropshadowOffsetX.ShouldBe(2f);
+            boldRequest.DropshadowOffsetY.ShouldBe(3f);
+            boldRequest.DropshadowBlur.ShouldBe(1.5f);
+            boldRequest.DropshadowRed.ShouldBe((byte)10);
+            boldRequest.DropshadowGreen.ShouldBe((byte)20);
+            boldRequest.DropshadowBlue.ShouldBe((byte)30);
+            boldRequest.DropshadowAlpha.ShouldBe((byte)200);
+        }
+        finally
+        {
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = savedCreator;
+        }
+    }
+
+    // Records every BmfcSave a per-request font resolution asks for, and returns a minimal valid
+    // BitmapFont (space + A/B/C/D/L/N/O/R/M/space glyphs aren't needed - measurement isn't asserted).
+    private sealed class RecordingInMemoryFontCreator : IInMemoryFontCreator
+    {
+        public List<BmfcSave> Requests { get; } = new();
+
+        public BitmapFont? TryCreateFont(BmfcSave bmfcSave)
+        {
+            Requests.Add(bmfcSave);
+            BitmapFont font = new BitmapFont((Texture2D)null!, FontData);
+            font.SetFontPattern(256, 256);
+            return font;
+        }
+
+        private const string FontData =
+@"info face=""Arial"" size=-18 bold=0 italic=0 charset="""" unicode=1 stretchH=100 smooth=1 aa=1 padding=0,0,0,0 spacing=1,1 outline=0
+common lineHeight=18 base=18 scaleW=256 scaleH=256 pages=1 packed=0 alphaChnl=0 redChnl=4 greenChnl=4 blueChnl=4
+page id=0 file=""x.png""
+chars count=1
+char id=32 x=0 y=0 width=9 height=13 xoffset=0 yoffset=4 xadvance=9 page=0 chnl=15
+";
+    }
+}


### PR DESCRIPTION
## Summary
- Inline BBCode font-family tags (`[FontSize]`, `[IsBold]`, `[IsItalic]`, `[Font]`, `[OutlineThickness]`) resolved their per-run font without the base `Text`'s dropshadow fields, so a tagged run rendered without the shadow while the surrounding base text kept it.
- Snapshots the owning `TextRuntime`'s `HasDropshadow`/offset/blur/RGBA fields once per `SetBbCodeText` call (no BBCode tag toggles dropshadow mid-text, so no stack is needed) and applies them to every per-run `BmfcSave` and font-cache-key lookup, on both the MonoGame/KNI/FNA and Raylib branches of the now-converged `Gum/Wireframe/CustomSetPropertyOnRenderable.cs`.
- Under FRB, dropshadow stays omitted for inline runs, matching the existing base-font behavior there (FRB's `GraphicalUiElement` has no dropshadow properties).

Deferred from #3624.

## Test plan
- [x] New regression test `TextRuntimeBbCodeDropshadowRegressionTests` (records the `BmfcSave` sent to an `IInMemoryFontCreator` for an inline `[IsBold=true]` run and asserts the base text's dropshadow fields are present)
- [x] `dotnet test MonoGameGum.Tests` — 1851/1851 passing
- [x] `dotnet build Runtimes/RaylibGum/RaylibGum.csproj` — clean (confirms the shared file compiles under `RAYLIB`)

Manual test: not needed — this is a font-cache-key/generation-request fix proven by the unit test (records the exact `BmfcSave` fed to font creation) plus a clean Raylib build; no new runtime-observable code path beyond what the test already exercises.

Closes #3625
