### PR TITLE
Implement IFormsText on SkiaGum.Text so TextBox/PasswordBox construct

### DIFF
--- a/Runtimes/SkiaGum/Renderables/Text.cs
+++ b/Runtimes/SkiaGum/Renderables/Text.cs
@@ -3,6 +3,7 @@ using RenderingLibrary.Graphics;
 using Gum.GueDeriving;
 using SkiaSharp;
 using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using Topten.RichTextKit;
 using Vector2 = System.Numerics.Vector2;
@@ -13,7 +14,7 @@ using Gum.Wireframe;
 
 namespace SkiaGum;
 
-public class Text : IRenderableIpso, IVisible, IText, ICloneable
+public class Text : IRenderableIpso, IVisible, IFormsText, ICloneable
 {
     #region Fields/Properties
 
@@ -139,6 +140,92 @@ public class Text : IRenderableIpso, IVisible, IText, ICloneable
 
     /// <inheritdoc/>
     public bool IsHeightDependentOnLines { get; set; }
+
+    /// <summary>
+    /// The maximum number of characters to display visually. Characters beyond this count
+    /// are hidden but remain in <see cref="RawText"/>. Intended for typewriter-style reveal
+    /// effects (e.g. <c>DialogBox</c>).
+    /// </summary>
+    /// <remarks>
+    /// Unlike the MonoGame/Raylib Text renderables, SkiaGum's <see cref="Render"/> does not yet
+    /// honor this value to truncate the rendered glyphs -- it is provided so SkiaGum.Text
+    /// satisfies <see cref="IFormsText"/> (issue #3653) and so callers can set it without an
+    /// InvalidCastException. Letter-reveal rendering support can be added later.
+    /// </remarks>
+    public int? MaxLettersToShow { get; set; }
+
+    /// <inheritdoc/>
+    /// <remarks>
+    /// SkiaGum's own wrapping is performed by Topten.RichTextKit's <see cref="TextBlock"/>
+    /// (see <see cref="GetTextBlock"/>), not by the shared <see cref="IWrappedTextExtensions.UpdateLines"/>
+    /// word-wrap algorithm the MonoGame/Raylib backends use, so this value has no effect on
+    /// SkiaGum's own layout. RichTextKit performs Unicode (UAX#14) line breaking, which does
+    /// break within an overlong word when no earlier break opportunity fits the wrap width, so
+    /// <c>true</c> matches its actual behavior (as well as MonoGame/Raylib's default).
+    /// </remarks>
+    bool IWrappedText.IsMidWordLineBreakEnabled => true;
+
+    /// <summary>
+    /// The current wrapped lines after layout, reconstructed from the cached
+    /// <see cref="TextBlock"/>'s line ranges so each entry (including any trailing
+    /// spaces RichTextKit's layout preserves) lines up with <see cref="RawText"/>
+    /// the same way <c>WrappedText[i].Length</c> summed across lines does for the
+    /// MonoGame/Raylib backends -- <c>TextBoxBase</c> relies on that for caret-index math.
+    /// </summary>
+    public List<string> WrappedText
+    {
+        get
+        {
+            var textBlock = GetCachedTextBlock();
+            if (!ReferenceEquals(textBlock, _wrappedTextSourceBlock))
+            {
+                _wrappedTextSourceBlock = textBlock;
+                _cachedWrappedTextList = BuildWrappedTextList(textBlock);
+            }
+            return _cachedWrappedTextList;
+        }
+    }
+
+    private List<string> BuildWrappedTextList(TextBlock textBlock)
+    {
+        var lines = new List<string>();
+        if (string.IsNullOrEmpty(mRawText))
+        {
+            return lines;
+        }
+
+        // RichTextKit's TextLine.Start/Length are code-point indices into the text that was
+        // added to the TextBlock. GetTextBlock adds mRawText verbatim (no CRLF normalization),
+        // so index directly into mRawText rather than a normalized copy.
+        foreach (var line in textBlock.Lines)
+        {
+            if (line.Start + line.Length <= mRawText.Length)
+            {
+                lines.Add(mRawText.Substring(line.Start, line.Length));
+            }
+        }
+
+        return lines;
+    }
+
+    /// <inheritdoc/>
+    /// <remarks>
+    /// Measured at the base font size (<see cref="FontSize"/> scaled only by
+    /// <see cref="GlobalTextScale"/>), with <see cref="FontScale"/> factored out -- matching
+    /// callers such as <c>TextBoxBase.GetIndex</c> which multiply the result by
+    /// <see cref="FontScale"/> themselves.
+    /// </remarks>
+    public int LineHeightInPixels
+    {
+        get
+        {
+            var textBlock = new TextBlock();
+            textBlock.AddText("My", GetRawMeasurementStyle());
+            return textBlock.Lines.Count > 0
+                ? (int)MathF.Ceiling(textBlock.Lines[0].Height)
+                : FontSize;
+        }
+    }
 
     public bool IsItalic
     {
@@ -437,6 +524,8 @@ public class Text : IRenderableIpso, IVisible, IText, ICloneable
     private float _lineHeightMultiplier = 1;
     private HorizontalAlignment _horizontalAlignment;
     private int? _maximumNumberOfLines;
+    private TextBlock? _wrappedTextSourceBlock;
+    private List<string> _cachedWrappedTextList = new();
 
     public TextBlock GetCachedTextBlock(float? forcedWidth = null)
     {
@@ -512,6 +601,47 @@ public class Text : IRenderableIpso, IVisible, IText, ICloneable
 
         return style;
     }
+
+    /// <summary>
+    /// Same font/weight/italics as <see cref="GetStyle"/>, but sized at the base
+    /// <see cref="FontSize"/> * <see cref="GlobalTextScale"/> only -- <see cref="FontScale"/>
+    /// and <see cref="LineHeightMultiplier"/> are left out because <see cref="MeasureString(string)"/>
+    /// and <see cref="LineHeightInPixels"/> return raw glyph-pixel values that callers (e.g.
+    /// <c>TextBoxBase</c>) scale by those factors themselves.
+    /// </summary>
+    private Style GetRawMeasurementStyle()
+    {
+        return new Style()
+        {
+            FontFamily = FontName,
+            FontSize = FontSize * (float)GlobalTextScale,
+            TextColor = this.Color,
+            FontItalic = this.IsItalic,
+            FontWeight = (int)(400 * BoldWeight),
+        };
+    }
+
+    /// <inheritdoc/>
+    public float MeasureString(string text)
+    {
+        if (string.IsNullOrEmpty(text))
+        {
+            return 0;
+        }
+
+        var textBlock = new TextBlock();
+        textBlock.AddText(text, GetRawMeasurementStyle());
+        return textBlock.MeasuredWidth;
+    }
+
+    /// <summary>
+    /// Measures <paramref name="text"/> using this Text's active font. The
+    /// <paramref name="style"/> parameter is advisory on the SkiaGum runtime and is
+    /// ignored -- RichTextKit's own measurement is used regardless of the requested
+    /// style. This overload exists so callers can write platform-agnostic code that
+    /// also works on runtimes (such as the MonoGame runtime) where the style is honored.
+    /// </summary>
+    public float MeasureString(string text, HorizontalMeasurementStyle style) => MeasureString(text);
 
     void IRenderableIpso.SetParentDirect(IRenderableIpso? parent)
     {

--- a/Tests/SilkNetGum.Tests/Forms/TextBoxPasswordBoxTests.cs
+++ b/Tests/SilkNetGum.Tests/Forms/TextBoxPasswordBoxTests.cs
@@ -1,0 +1,33 @@
+using Gum.Forms.Controls;
+using Shouldly;
+
+namespace SilkNetGum.Tests.Forms;
+
+/// <summary>
+/// End-to-end regression for issue #3653: <c>TextBoxBase.RefreshInternalVisualReferences</c> casts
+/// the TextInstance child's RenderableComponent to <see cref="RenderingLibrary.Graphics.IFormsText"/>
+/// and throws under <c>FULL_DIAGNOSTICS</c> (defined in SkiaGum's Debug/Release configs and in
+/// MonoGameGum's, which TextBoxBase's shared source compiles through) if that cast fails. Before
+/// SkiaGum's Text implemented <see cref="RenderingLibrary.Graphics.IFormsText"/>, constructing any
+/// text-input control crashed here. Uses the real Silk-backed cursor from the assembly bootstrap
+/// (unlike <c>SkiaGum.Tests.Forms.MenuPasswordBoxTests</c>, which uses the render-only
+/// SkiaGum.Standalone GumService with no MainCursor, so it cannot construct these end-to-end).
+/// </summary>
+public class TextBoxPasswordBoxTests : BaseTestClass
+{
+    [Fact]
+    public void TextBox_ConstructsWithVisual_OnSkia()
+    {
+        TextBox textBox = new();
+
+        textBox.Visual.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void PasswordBox_ConstructsWithVisual_OnSkia()
+    {
+        PasswordBox passwordBox = new();
+
+        passwordBox.Visual.ShouldNotBeNull();
+    }
+}

--- a/Tests/SkiaGum.Tests/Forms/MenuPasswordBoxTests.cs
+++ b/Tests/SkiaGum.Tests/Forms/MenuPasswordBoxTests.cs
@@ -20,10 +20,13 @@ namespace SkiaGum.Tests.Forms;
 /// calls it, unlike the game-loop Gum.GumService used by SilkNetGum.
 ///
 /// Menu/MenuItem construct their Visual and are asserted end-to-end. PasswordBox is asserted via
-/// the DefaultFormsTemplates registration only, not by constructing it -- Skia's Text renderable
-/// doesn't implement IFormsText yet, so constructing any text-input control (TextBox too, not just
-/// PasswordBox) throws in TextBoxBase.RefreshInternalVisualReferences regardless of this
-/// registration fix. See #3653.
+/// the DefaultFormsTemplates registration only, not by constructing it here -- this render-only
+/// SkiaGum.Standalone GumService never assigns FrameworkElement.MainCursor, which
+/// TextBoxBase.UpdateState (invoked during construction) dereferences unconditionally,
+/// independent of the IFormsText cast this class's remarks used to describe. The IFormsText cast
+/// itself no longer throws (#3653) -- see
+/// <see cref="SilkNetGum.Tests.Forms.TextBoxPasswordBoxTests"/> for the full end-to-end
+/// construction regression test, since SilkNetGum's bootstrap does provide a MainCursor.
 /// </summary>
 public class MenuPasswordBoxTests
 {
@@ -51,7 +54,7 @@ public class MenuPasswordBoxTests
     [Fact]
     public void PasswordBox_IsRegistered_OnV3()
     {
-        // Not constructing a PasswordBox here -- see the class remarks and #3653.
+        // Not constructing a PasswordBox here -- see the class remarks.
         FrameworkElement.DefaultFormsTemplates.ShouldContainKey(typeof(PasswordBox));
     }
 }

--- a/Tests/SkiaGum.Tests/Renderables/TextIFormsTextTests.cs
+++ b/Tests/SkiaGum.Tests/Renderables/TextIFormsTextTests.cs
@@ -1,0 +1,122 @@
+using RenderingLibrary.Graphics;
+using Shouldly;
+using SkiaGum;
+
+namespace SkiaGum.Tests.Renderables;
+
+/// <summary>
+/// Verifies that <see cref="Text"/> satisfies <see cref="IFormsText"/> (issue #3653). Before this
+/// change, SkiaGum's Text only implemented <see cref="IText"/>, so
+/// <c>TextBoxBase.RefreshInternalVisualReferences</c>'s cast to <see cref="IFormsText"/> failed
+/// under <c>FULL_DIAGNOSTICS</c> (defined in SkiaGum's Debug and Release configs), crashing
+/// <c>new TextBox()</c>/<c>new PasswordBox()</c> on construction.
+/// </summary>
+public class TextIFormsTextTests
+{
+    [Fact]
+    public void Text_IsIFormsText()
+    {
+        Text sut = new();
+
+        (sut is IFormsText).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void WrappedText_SingleLineFittingWidth_ReturnsOneLineMatchingRawText()
+    {
+        Text sut = new();
+        sut.Width = 1000;
+        sut.RawText = "Hello world";
+
+        IFormsText formsText = sut;
+
+        formsText.WrappedText.Count.ShouldBe(1);
+        formsText.WrappedText[0].ShouldBe("Hello world");
+    }
+
+    [Fact]
+    public void WrappedText_WrapsAcrossMultipleLines_WhenWidthIsNarrow()
+    {
+        Text sut = new();
+        sut.FontSize = 20;
+        sut.Width = 60;
+        sut.RawText = "Hello world this is a long line of text";
+
+        IFormsText formsText = sut;
+
+        formsText.WrappedText.Count.ShouldBeGreaterThan(1);
+    }
+
+    [Fact]
+    public void WrappedText_LinesConcatenate_ToOriginalRawText()
+    {
+        Text sut = new();
+        sut.FontSize = 20;
+        sut.Width = 60;
+        string rawText = "Hello world this is a long line of text";
+        sut.RawText = rawText;
+
+        IFormsText formsText = sut;
+
+        string reconstructed = string.Concat(formsText.WrappedText);
+        reconstructed.ShouldBe(rawText);
+    }
+
+    [Fact]
+    public void LineHeightInPixels_IsPositive()
+    {
+        Text sut = new();
+        sut.FontSize = 18;
+
+        IWrappedText wrappedText = sut;
+
+        wrappedText.LineHeightInPixels.ShouldBeGreaterThan(0);
+    }
+
+    [Fact]
+    public void MeasureString_LongerString_ReturnsLargerWidth()
+    {
+        Text sut = new();
+        sut.FontSize = 18;
+
+        IWrappedText wrappedText = sut;
+
+        float shortWidth = wrappedText.MeasureString("Hi");
+        float longWidth = wrappedText.MeasureString("Hello, this is a much longer string");
+
+        longWidth.ShouldBeGreaterThan(shortWidth);
+    }
+
+    [Fact]
+    public void MeasureString_EmptyString_ReturnsZero()
+    {
+        Text sut = new();
+
+        IWrappedText wrappedText = sut;
+
+        wrappedText.MeasureString("").ShouldBe(0f);
+    }
+
+    [Fact]
+    public void MaxLettersToShow_RoundTrips()
+    {
+        Text sut = new();
+
+        IFormsText formsText = sut;
+        formsText.MaxLettersToShow = 5;
+
+        formsText.MaxLettersToShow.ShouldBe(5);
+    }
+
+    [Fact]
+    public void MaxNumberOfLines_SettableThroughIFormsText()
+    {
+        Text sut = new();
+
+        IFormsText formsText = sut;
+        formsText.MaxNumberOfLines = 3;
+
+        formsText.MaxNumberOfLines.ShouldBe(3);
+        sut.MaxNumberOfLines.ShouldBe(3);
+    }
+}


### PR DESCRIPTION
## Summary
- `TextBoxBase.RefreshInternalVisualReferences` casts the TextInstance child's `RenderableComponent` to `IFormsText` and throws under `FULL_DIAGNOSTICS` when the cast fails. SkiaGum's `Text` only implemented `IText` (not even `IWrappedText`), so `new TextBox()`/`new PasswordBox()` crashed on construction on SkiaGum/SilkNetGum.
- Adds the missing `IWrappedText`/`IFormsText` members to `Runtimes/SkiaGum/Renderables/Text.cs`:
  - `WrappedText` — reconstructed from the cached RichTextKit `TextBlock`'s `TextLine.Start`/`Length` (code-point ranges), indexed directly into `RawText` (no CRLF normalization needed since `GetTextBlock` adds `RawText` verbatim).
  - `LineHeightInPixels` / `MeasureString(string)` / `MeasureString(string, HorizontalMeasurementStyle)` — measured with a throwaway `TextBlock` at the *base* font size (`FontSize * GlobalTextScale`, no `FontScale`/`LineHeightMultiplier`), matching how `TextBoxBase` scales the raw result itself (mirrors the Raylib backend's convention).
  - `IsMidWordLineBreakEnabled` — `true`; unused by SkiaGum's own wrapping (RichTextKit does its own UAX#14 line breaking, not the shared `IWrappedTextExtensions.UpdateLines` algorithm), provided only to satisfy the interface.
  - `MaxLettersToShow` — a plain settable `int?`; `Render` does not yet honor it for letter-reveal effects (documented as a follow-up, not implemented here).
  - `MaxNumberOfLines`'s existing `int? { get; set; }` already satisfies `IFormsText`'s `new` shadow with no changes needed.

## Testing
- `Tests/SkiaGum.Tests/Renderables/TextIFormsTextTests.cs` (new): interface-cast pin, `WrappedText` line count/content for wrapped multi-line text (and that lines concatenate back to `RawText`), `LineHeightInPixels` positivity, `MeasureString` monotonicity.
- `Tests/SilkNetGum.Tests/Forms/TextBoxPasswordBoxTests.cs` (new): end-to-end `new TextBox()`/`new PasswordBox()` construction against the real Silk-backed cursor — this is the actual regression reproducer for #3653 and was red before the fix (verified via `git stash`), green after.
- `Tests/SkiaGum.Tests/Forms/MenuPasswordBoxTests.cs`: left as registration-only for PasswordBox — the render-only `SkiaGum.Standalone` `GumService` used by that suite never assigns `FrameworkElement.MainCursor`, which `TextBoxBase.UpdateState` (invoked during construction) dereferences unconditionally, independent of the `IFormsText` fix. Full construction is exercised in `SilkNetGum.Tests` instead, where a real cursor exists.

**Manual-test verdict: not needed.** SkiaGum has no visual host comparable to the MonoGame/Raylib samples; the `SilkNetGum.Tests` end-to-end construction test (confirmed red-before/green-after) is the regression pin for the actual crash, and is a stronger guarantee than an ad hoc manual run since it's now part of CI.

Closes #3653