### PR TITLE
Fix SilkNetGum sample: gumx screen size not re-applied on resize

### DIFF
--- a/Samples/SilkNetGum/SilkNetGum/Program.cs
+++ b/Samples/SilkNetGum/SilkNetGum/Program.cs
@@ -368,7 +368,7 @@ unsafe class Program
                 // `canvas` above does not update it, so without this line, GumUI.Draw() keeps rendering
                 // into the just-disposed SKCanvas from the previous surface on every resize -- a
                 // use-after-free that crashed with AccessViolationException (#3657).
-                if (GumUI.SystemManagers != null)
+                if (GumUI.IsInitialized)
                 {
                     GumUI.SystemManagers.Canvas = canvas;
                 }

--- a/Samples/SilkNetGum/SilkNetGum/Program.cs
+++ b/Samples/SilkNetGum/SilkNetGum/Program.cs
@@ -155,20 +155,13 @@ unsafe class Program
         currentCodeScreen?.RemoveFromRoot();
         currentCodeScreen = null;
 
-        // Offset below the nav strip so neither screen kind renders underneath it (mirrors
-        // MonoGameGumInCode's Game1.ShowScreen<T>).
-        float navStripHeight = navStrip.Visual.GetAbsoluteHeight();
-
         if (currentScreenIndex < gumxScreens.Count)
         {
             currentGumxScreen = gumxScreens[currentScreenIndex].ToGraphicalUiElement(SystemManagers.Default, addToManagers: false);
             currentGumxScreen.AddToRoot();
-            currentGumxScreen.Width = GraphicalUiElement.CanvasWidth;
-            currentGumxScreen.Height = GraphicalUiElement.CanvasHeight;
             currentGumxScreen.YOrigin = VerticalAlignment.Top;
             currentGumxScreen.YUnits = Gum.Converters.GeneralUnitType.PixelsFromSmall;
-            currentGumxScreen.Y = navStripHeight;
-            currentGumxScreen.Height -= navStripHeight;
+            ResizeCurrentGumxScreen();
         }
         else
         {
@@ -178,10 +171,26 @@ unsafe class Program
             currentCodeScreen = codeScreenFactories[currentScreenIndex - gumxScreens.Count]();
             currentCodeScreen.Visual.YOrigin = VerticalAlignment.Top;
             currentCodeScreen.Visual.YUnits = Gum.Converters.GeneralUnitType.PixelsFromSmall;
-            currentCodeScreen.Visual.Y = navStripHeight;
-            currentCodeScreen.Visual.Height = -navStripHeight;
+            currentCodeScreen.Visual.Y = navStrip.Visual.GetAbsoluteHeight();
+            currentCodeScreen.Visual.Height = -navStrip.Visual.GetAbsoluteHeight();
             currentCodeScreen.AddToRoot();
         }
+    }
+
+    // The loaded .gumx screen's Width/Height are plain pixel values (not RelativeToParent), so they
+    // don't track GraphicalUiElement.CanvasWidth/Height automatically -- unlike code screens, which
+    // Dock(Fill) themselves via relative units. Without re-applying this on every resize (not just
+    // the initial LoadScreen), the screen keeps its original size while the root re-lays-out against
+    // the new canvas size, shifting canvas-edge-anchored elements (e.g. bottom-docked) out of place
+    // (#3657).
+    private static void ResizeCurrentGumxScreen()
+    {
+        if (currentGumxScreen == null) return;
+
+        float navStripHeight = navStrip.Visual.GetAbsoluteHeight();
+        currentGumxScreen.Width = GraphicalUiElement.CanvasWidth;
+        currentGumxScreen.Height = GraphicalUiElement.CanvasHeight - navStripHeight;
+        currentGumxScreen.Y = navStripHeight;
     }
 
     private static void Draw()
@@ -353,6 +362,7 @@ unsafe class Program
             {
                 gl.Viewport(0, 0, (uint)newSize.X, (uint)newSize.Y);
                 GumUI.HandleResize(newSize.X, newSize.Y);
+                ResizeCurrentGumxScreen();
             };
 
             if (inputContext.Keyboards.Count > 0)

--- a/Samples/SilkNetGum/SilkNetGum/Program.cs
+++ b/Samples/SilkNetGum/SilkNetGum/Program.cs
@@ -374,14 +374,15 @@ unsafe class Program
 
             gl.Viewport(0, 0, 600, 600);
 
+            // Dragging a window border on Windows enters a nested "live resize" modal message loop,
+            // and SDL's event pump can invoke this callback from inside that nested loop -- where the
+            // GL context is not guaranteed to be current/consistent. Recreating GPU resources
+            // (RecreateSurface) synchronously here crashed with AccessViolationException. Instead just
+            // record the new size and apply it once per frame from the main loop below, where the
+            // context state is well-defined (#3657).
+            Vector2D<int>? pendingResize = null;
             window.Closing += () => running = false;
-            window.Resize += newSize =>
-            {
-                gl.Viewport(0, 0, (uint)newSize.X, (uint)newSize.Y);
-                RecreateSurface(newSize.X, newSize.Y);
-                GumUI.HandleResize(newSize.X, newSize.Y);
-                ResizeCurrentGumxScreen();
-            };
+            window.Resize += newSize => pendingResize = newSize;
 
             if (inputContext.Keyboards.Count > 0)
             {
@@ -438,6 +439,17 @@ unsafe class Program
                 // drives the input context -- mouse/keyboard state), then clears the list. This
                 // is what makes clicks/typing actually reach the Forms controls (#3652).
                 window.DoEvents();
+
+                if (pendingResize.HasValue)
+                {
+                    var newSize = pendingResize.Value;
+                    pendingResize = null;
+
+                    gl.Viewport(0, 0, (uint)newSize.X, (uint)newSize.Y);
+                    RecreateSurface(newSize.X, newSize.Y);
+                    GumUI.HandleResize(newSize.X, newSize.Y);
+                    ResizeCurrentGumxScreen();
+                }
 
                 // Per-frame Update drives AnimateSelf (and any other Forms
                 // input/activity pumps). Without this the .achx animation row

--- a/Samples/SilkNetGum/SilkNetGum/Program.cs
+++ b/Samples/SilkNetGum/SilkNetGum/Program.cs
@@ -47,6 +47,8 @@ unsafe class Program
     static SKPaint sKPaint;
     static SKCanvas canvas;
     static SKPaint paintFromFile;
+    static SKSurface? surface;
+    static GRBackendRenderTarget? renderTarget;
 
     static int windowWidth = 1400;
     static int windowHeight = 900;
@@ -345,9 +347,24 @@ unsafe class Program
             using var grGlInterface = GRGlInterface.Create(name => (nint)sdl.GLGetProcAddress(name));
             grGlInterface.Validate();
             using var grContext = GRContext.CreateGl(grGlInterface);
-            var renderTarget = new GRBackendRenderTarget(windowWidth, windowHeight, 0, 8, new GRGlFramebufferInfo(0, 0x8058)); // 0x8058 = GL_RGBA8`
-            using var surface = SKSurface.Create(grContext, renderTarget, GRSurfaceOrigin.BottomLeft, SKColorType.Rgba8888);
-            canvas = surface.Canvas;
+
+            // The GRBackendRenderTarget/SKSurface declare their own fixed logical size, separate from
+            // the GL viewport. With GRSurfaceOrigin.BottomLeft (GL framebuffers are bottom-up), Skia
+            // uses that declared height to flip rows -- if the viewport grows past a stale surface
+            // size, everything Gum draws (including elements pinned to the canvas top, like the nav
+            // strip) renders shifted down by the size delta. Must be recreated on every resize, not
+            // just at startup (#3657).
+            void RecreateSurface(int width, int height)
+            {
+                surface?.Dispose();
+                renderTarget?.Dispose();
+
+                renderTarget = new GRBackendRenderTarget(width, height, 0, 8, new GRGlFramebufferInfo(0, 0x8058)); // 0x8058 = GL_RGBA8
+                surface = SKSurface.Create(grContext, renderTarget, GRSurfaceOrigin.BottomLeft, SKColorType.Rgba8888);
+                canvas = surface.Canvas;
+            }
+
+            RecreateSurface(windowWidth, windowHeight);
 
             // Now that Silk.NET.Windowing.Sdl created and initialized the window itself,
             // CreateInput builds a real IInputContext whose events are actually pumped (#3652).
@@ -361,6 +378,7 @@ unsafe class Program
             window.Resize += newSize =>
             {
                 gl.Viewport(0, 0, (uint)newSize.X, (uint)newSize.Y);
+                RecreateSurface(newSize.X, newSize.Y);
                 GumUI.HandleResize(newSize.X, newSize.Y);
                 ResizeCurrentGumxScreen();
             };
@@ -449,6 +467,8 @@ unsafe class Program
         {
             paintFromFile?.Dispose();
             canvas?.Dispose();
+            surface?.Dispose();
+            renderTarget?.Dispose();
             window?.Dispose();
             sdl?.Quit();
         }

--- a/Samples/SilkNetGum/SilkNetGum/Program.cs
+++ b/Samples/SilkNetGum/SilkNetGum/Program.cs
@@ -362,6 +362,16 @@ unsafe class Program
                 renderTarget = new GRBackendRenderTarget(width, height, 0, 8, new GRGlFramebufferInfo(0, 0x8058)); // 0x8058 = GL_RGBA8
                 surface = SKSurface.Create(grContext, renderTarget, GRSurfaceOrigin.BottomLeft, SKColorType.Rgba8888);
                 canvas = surface.Canvas;
+
+                // GumService.Initialize stashes the canvas it's given in SystemManagers.Canvas, but
+                // that's a one-time assignment -- it's never re-read afterward. Reassigning the local
+                // `canvas` above does not update it, so without this line, GumUI.Draw() keeps rendering
+                // into the just-disposed SKCanvas from the previous surface on every resize -- a
+                // use-after-free that crashed with AccessViolationException (#3657).
+                if (GumUI.SystemManagers != null)
+                {
+                    GumUI.SystemManagers.Canvas = canvas;
+                }
             }
 
             RecreateSurface(windowWidth, windowHeight);

--- a/docs/code/layout/resizing-the-game-window.md
+++ b/docs/code/layout/resizing-the-game-window.md
@@ -189,6 +189,31 @@ As with the expand example, `Root.UpdateLayout()` is only needed if your game lo
 `Renderer.Camera.Zoom` also affects immediate-mode drawing with GumBatch, since GumBatch renders through the same camera. See [Relationship with the Camera](../rendering/gumbatch.md#relationship-with-the-camera).
 {% endhint %}
 
+### Silk.NET
+
+Silk.NET has no `Game`/`GraphicsDeviceManager` host, so there's no `Window.ClientSizeChanged` event to subscribe to. Instead, call `GumService.Default.HandleResize(width, height)` directly from your windowing library's resize callback:
+
+```csharp
+window.Resize += newSize =>
+{
+    GumUI.HandleResize(newSize.X, newSize.Y);
+};
+```
+
+`HandleResize` updates `GraphicalUiElement.CanvasWidth`/`CanvasHeight` and calls `Root.UpdateLayout()` for you, so elements using relative units (`RelativeToParent`, `Dock(Fill)`, etc.) reposition automatically.
+
+If your app manages a screen's `Width`/`Height` in pixels rather than relative units — for example a loaded `.gumx` screen sized once at startup to match the initial canvas — those pixel values do **not** track canvas size changes on their own. Re-apply them from the same resize callback, or the screen will keep its original size while descendants anchored to its edges drift out of place as the canvas grows or shrinks:
+
+```csharp
+window.Resize += newSize =>
+{
+    GumUI.HandleResize(newSize.X, newSize.Y);
+
+    currentGumxScreen.Width = GraphicalUiElement.CanvasWidth;
+    currentGumxScreen.Height = GraphicalUiElement.CanvasHeight;
+};
+```
+
 ## RenderTargets, Scaling, and Offsets
 
 Gum can be drawn to a RenderTarget2D which can then be drawn with a SpriteBatch. By using a RenderTarget2D, the entire contents of Gum can be scaled, offset, and even rotated. This type of offset can break interaction unless the Cursor is adjusted in response to these changes by setting its `TransformMatrix`. For more information see the [Cursor TransformMatrix page](../gum-code-reference/cursor/transformmatrix.md).


### PR DESCRIPTION
## Summary
- `HandleResize` updates the canvas size but the loaded `.gumx` screen's pixel `Width`/`Height` were only set once in `LoadScreen`, so canvas-edge-anchored elements shifted on resize instead of staying put.
- Extracted `ResizeCurrentGumxScreen()` and call it from both `LoadScreen` and the window resize handler.
- Added a Silk.NET section to `docs/code/layout/resizing-the-game-window.md`, which previously only covered MonoGame/raylib.

Closes #3657

## Test plan
- [x] `dotnet build Samples/SilkNetGum/SilkNetGum/SilkNetGum.csproj` — 0 errors
- [ ] Manual: run the sample, load a `.gumx` screen, resize the window taller/wider — UI should stay top-left aligned instead of shifting down