### PR TITLE
Add clipboard and manual key-repeat support to SilkNetGum

### DIFF
--- a/Runtimes/SilkNetGum/GumService.Silk.cs
+++ b/Runtimes/SilkNetGum/GumService.Silk.cs
@@ -90,11 +90,20 @@ public partial class GumService
     // ApplyGamePadState is intentionally NOT overridden -- gamepad support is out of scope (#3564),
     // so the IGumService default no-op is inherited.
 
-    // The AssignNativeTextInput / AssignClipboard / UninitializePlatform / ApplyTextureFilterPlatform
-    // / ExtractUnresolvedTextures partial seams are all intentionally left unimplemented (elided) on
-    // SILK: SilkNet keeps NativeTextInput and Clipboard null (no Skia host implementation), has no
-    // Skia-specific Uninitialize teardown, applies no global texture filter (Skia has none), and
-    // cannot save embedded snapshot textures to PNG. This matches the prior standalone service.
+    // AssignClipboard is implemented below via Silk.NET.Input's IKeyboard.ClipboardText (#3651).
+    // The AssignNativeTextInput / UninitializePlatform / ApplyTextureFilterPlatform /
+    // ExtractUnresolvedTextures partial seams remain intentionally unimplemented (elided) on SILK:
+    // Silk.NET.Input exposes no IME/composition API to back NativeTextInput (KeyChar only reports
+    // committed characters), so TextBox/PasswordBox type through GetStringTyped same as Raylib; Skia
+    // has no Skia-specific Uninitialize teardown or global texture filter; and there is no embedded
+    // snapshot texture PNG export. This matches the prior standalone service.
+    partial void AssignClipboard()
+    {
+        if (_inputContext != null)
+        {
+            Clipboard = new global::Gum.Input.SilkGumClipboard(_inputContext);
+        }
+    }
 
     // GetWindowSize backs the shared window-fit helpers. SilkNet has no OS window (the caller owns it
     // and hands us an SKCanvas), so report the current canvas size. SilkNet's own resize path is

--- a/Runtimes/SilkNetGum/GumService.Silk.cs
+++ b/Runtimes/SilkNetGum/GumService.Silk.cs
@@ -152,6 +152,12 @@ public partial class GumService
         // build Silk-backed input from this context.
         _inputContext = inputContext;
 
+        // The ctor-time AssignClipboard() call (GumService.cs) runs before this Initialize -- Default's
+        // lazy new GumService() constructs the instance on first access, which normally happens before
+        // Initialize assigns _inputContext above -- so its null-guard always failed and Clipboard stayed
+        // null. Re-run it now that _inputContext is guaranteed non-null (#3651).
+        AssignClipboard();
+
         var managers = new SystemManagers();
         this.SystemManagers = managers;
         SystemManagers.Default = managers;

--- a/Runtimes/SilkNetGum/Input/Keyboard.Silk.cs
+++ b/Runtimes/SilkNetGum/Input/Keyboard.Silk.cs
@@ -170,6 +170,25 @@ public class Keyboard : IInputReceiverKeyboard
     private readonly HashSet<GumKeys> _currentDown = new();
     private readonly HashSet<GumKeys> _previousDown = new();
 
+    // Manual OS-independent key-repeat: Silk.NET.Input has no repeat-rate poll (unlike Raylib's
+    // IsKeyPressedRepeat), so discrete key actions (e.g. holding an arrow key to move a caret or
+    // navigate a ListBox) are timed here instead. Mirrors MonoGame's Keyboard.RepeatDelay/RepeatRate
+    // semantics (Runtimes/MonoGameGum/Input/Keyboard.cs).
+    private readonly Dictionary<GumKeys, double> _keyDownSince = new();
+    private readonly Dictionary<GumKeys, double> _lastRepeatTime = new();
+    private double _currentGameTime;
+
+    /// <summary>
+    /// Delay after the initial key press before repeat typing begins.
+    /// </summary>
+    public System.TimeSpan RepeatDelay { get; set; } = System.TimeSpan.FromMilliseconds(500);
+
+    /// <summary>
+    /// Interval between repeated key-typed events while a key is held down, once
+    /// <see cref="RepeatDelay"/> has elapsed.
+    /// </summary>
+    public System.TimeSpan RepeatRate { get; set; } = System.TimeSpan.FromMilliseconds(70);
+
     // Typed chars accrue from KeyChar events as they arrive (before Update). Activity snapshots
     // and clears them so the frame's DoKeyboardAction reads exactly this frame's input.
     private readonly StringBuilder _charsTyped = new();
@@ -208,11 +227,38 @@ public class Keyboard : IInputReceiverKeyboard
 
     /// <inheritdoc/>
     /// <remarks>
-    /// Silk provides no OS-driven key-repeat poll, so KeyTyped reports the initial press only.
-    /// Character-producing input (including repeat) still flows through <see cref="GetStringTyped"/>
-    /// via the KeyChar event, which is what TextBox text entry consumes.
+    /// Returns true on the initial press and again at <see cref="RepeatDelay"/>/<see cref="RepeatRate"/>
+    /// intervals while the key is held, manually timed since Silk provides no OS-driven repeat poll.
+    /// Character-producing input (including repeat) also flows through <see cref="GetStringTyped"/>
+    /// via the KeyChar event (which the OS already repeats), which is what TextBox text entry consumes.
     /// </remarks>
-    public bool KeyTyped(GumKeys key) => KeyPushed(key);
+    public bool KeyTyped(GumKeys key)
+    {
+        if (KeyPushed(key))
+        {
+            return true;
+        }
+
+        if (!KeyDown(key) || !_keyDownSince.TryGetValue(key, out double downSince))
+        {
+            return false;
+        }
+
+        double elapsedSincePush = _currentGameTime - downSince;
+        if (elapsedSincePush < RepeatDelay.TotalSeconds)
+        {
+            return false;
+        }
+
+        if (_lastRepeatTime.TryGetValue(key, out double lastRepeat) &&
+            _currentGameTime - lastRepeat < RepeatRate.TotalSeconds)
+        {
+            return false;
+        }
+
+        _lastRepeatTime[key] = _currentGameTime;
+        return true;
+    }
 
     /// <summary>
     /// Performs every-frame activity: rolls the down-state snapshot forward (for push/release edge
@@ -222,6 +268,8 @@ public class Keyboard : IInputReceiverKeyboard
     /// <param name="gameTime">The number of seconds since the start of the game.</param>
     public void Activity(double gameTime)
     {
+        _currentGameTime = gameTime;
+
         _previousDown.Clear();
         foreach (GumKeys key in _currentDown)
         {
@@ -234,6 +282,24 @@ public class Keyboard : IInputReceiverKeyboard
             if (IsKeyPressed(pair.Value))
             {
                 _currentDown.Add(pair.Key);
+            }
+        }
+
+        foreach (GumKeys key in _currentDown)
+        {
+            if (!_previousDown.Contains(key))
+            {
+                _keyDownSince[key] = gameTime;
+                _lastRepeatTime.Remove(key);
+            }
+        }
+
+        foreach (GumKeys key in _previousDown)
+        {
+            if (!_currentDown.Contains(key))
+            {
+                _keyDownSince.Remove(key);
+                _lastRepeatTime.Remove(key);
             }
         }
 

--- a/Runtimes/SilkNetGum/Input/SilkGumClipboard.cs
+++ b/Runtimes/SilkNetGum/Input/SilkGumClipboard.cs
@@ -1,0 +1,34 @@
+using Gum.Forms.Controls;
+using Silk.NET.Input;
+using System;
+
+namespace Gum.Input;
+
+/// <summary>
+/// Silk.NET.Input implementation of <see cref="IGumClipboard"/>. Wraps
+/// <see cref="IKeyboard.ClipboardText"/>, which reads/writes the real OS clipboard synchronously
+/// on every desktop Silk backend. Registered onto <c>GumService.Clipboard</c> from
+/// <c>GumService.Silk.cs</c>'s <c>AssignClipboard</c> seam.
+/// </summary>
+internal sealed class SilkGumClipboard : IGumClipboard
+{
+    private readonly IInputContext _inputContext;
+
+    public SilkGumClipboard(IInputContext inputContext)
+    {
+        _inputContext = inputContext;
+    }
+
+    private IKeyboard? Keyboard => _inputContext.Keyboards.Count > 0 ? _inputContext.Keyboards[0] : null;
+
+    public string? GetText(Action? callback) => Keyboard?.ClipboardText;
+
+    public void SetText(string text)
+    {
+        var keyboard = Keyboard;
+        if (keyboard != null)
+        {
+            keyboard.ClipboardText = text;
+        }
+    }
+}

--- a/Tests/SilkNetGum.Tests/GumServiceTests.cs
+++ b/Tests/SilkNetGum.Tests/GumServiceTests.cs
@@ -33,6 +33,16 @@ public class GumServiceTests : BaseTestClass
     }
 
     [Fact]
+    public void Clipboard_IsAssigned_AfterInitialize()
+    {
+        // Regression test for #3651: GumService.Default's lazy ctor runs AssignClipboard() before
+        // Initialize assigns _inputContext, so the ctor-time call always no-oped. Initialize must
+        // re-run AssignClipboard() once _inputContext is set, or Clipboard silently stays null and
+        // TextBox copy/paste never reaches the OS clipboard.
+        GumService.Default.Clipboard.ShouldNotBeNull();
+    }
+
+    [Fact]
     public void Cursor_IsCreatedBySilkService()
     {
         // The service's CreateCursor override ran during Initialize, so FormsUtilities.Cursor (and the

--- a/Tests/SilkNetGum.Tests/KeyboardSilkTests.cs
+++ b/Tests/SilkNetGum.Tests/KeyboardSilkTests.cs
@@ -48,6 +48,55 @@ public class KeyboardSilkTests
     }
 
     [Fact]
+    public void KeyTyped_DoesNotRepeatBeforeRepeatDelayElapses()
+    {
+        var keyboard = new TestableKeyboard();
+        keyboard.PressedKeys.Add(Key.A);
+
+        keyboard.Activity(0);
+        keyboard.KeyTyped(GumKeys.A).ShouldBeTrue(); // initial push
+
+        keyboard.Activity(keyboard.RepeatDelay.TotalSeconds - 0.01);
+        keyboard.KeyTyped(GumKeys.A).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void KeyTyped_RepeatsAtRepeatRateAfterRepeatDelayElapses()
+    {
+        var keyboard = new TestableKeyboard();
+        keyboard.PressedKeys.Add(Key.A);
+
+        keyboard.Activity(0);
+        keyboard.KeyTyped(GumKeys.A).ShouldBeTrue(); // initial push
+
+        keyboard.Activity(keyboard.RepeatDelay.TotalSeconds);
+        keyboard.KeyTyped(GumKeys.A).ShouldBeTrue(); // first repeat
+
+        keyboard.Activity(keyboard.RepeatDelay.TotalSeconds + keyboard.RepeatRate.TotalSeconds - 0.01);
+        keyboard.KeyTyped(GumKeys.A).ShouldBeFalse(); // too soon for the next repeat
+
+        keyboard.Activity(keyboard.RepeatDelay.TotalSeconds + keyboard.RepeatRate.TotalSeconds);
+        keyboard.KeyTyped(GumKeys.A).ShouldBeTrue(); // second repeat
+    }
+
+    [Fact]
+    public void KeyTyped_ResetsRepeatTimingAfterKeyIsReleasedAndPressedAgain()
+    {
+        var keyboard = new TestableKeyboard();
+        keyboard.PressedKeys.Add(Key.A);
+        keyboard.Activity(0);
+        keyboard.Activity(keyboard.RepeatDelay.TotalSeconds); // would repeat if still held
+
+        keyboard.PressedKeys.Remove(Key.A);
+        keyboard.Activity(keyboard.RepeatDelay.TotalSeconds + 0.01);
+
+        keyboard.PressedKeys.Add(Key.A);
+        keyboard.Activity(keyboard.RepeatDelay.TotalSeconds + 0.02);
+
+        keyboard.KeyTyped(GumKeys.A).ShouldBeTrue(); // fresh push, not a stale repeat
+    }
+
+    [Fact]
     public void KeyPushed_IsTrueOnlyOnTheFrameOfInitialPress()
     {
         var keyboard = new TestableKeyboard();

--- a/Tests/SilkNetGum.Tests/SilkGumClipboardTests.cs
+++ b/Tests/SilkNetGum.Tests/SilkGumClipboardTests.cs
@@ -1,0 +1,62 @@
+using Gum.Input;
+using Moq;
+using Shouldly;
+using Silk.NET.Input;
+using System.Collections.Generic;
+
+namespace SilkNetGum.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="SilkGumClipboard"/>, which bridges Gum's <c>IGumClipboard</c> to
+/// Silk.NET.Input's <see cref="IKeyboard.ClipboardText"/>.
+/// </summary>
+public class SilkGumClipboardTests
+{
+    private static IInputContext CreateInputContext(IKeyboard? keyboard)
+    {
+        var context = new Mock<IInputContext>();
+        var keyboards = keyboard == null
+            ? new List<IKeyboard>()
+            : new List<IKeyboard> { keyboard };
+        context.Setup(c => c.Keyboards).Returns(keyboards);
+        return context.Object;
+    }
+
+    [Fact]
+    public void GetText_ReturnsNull_WhenNoKeyboardIsPresent()
+    {
+        var clipboard = new SilkGumClipboard(CreateInputContext(null));
+
+        clipboard.GetText(null).ShouldBeNull();
+    }
+
+    [Fact]
+    public void GetText_ReturnsKeyboardClipboardText()
+    {
+        var device = new Mock<IKeyboard>();
+        device.SetupProperty(k => k.ClipboardText, "hello");
+        var clipboard = new SilkGumClipboard(CreateInputContext(device.Object));
+
+        clipboard.GetText(null).ShouldBe("hello");
+    }
+
+    [Fact]
+    public void SetText_WritesToKeyboardClipboardText()
+    {
+        var device = new Mock<IKeyboard>();
+        device.SetupProperty(k => k.ClipboardText, "");
+        var clipboard = new SilkGumClipboard(CreateInputContext(device.Object));
+
+        clipboard.SetText("copied");
+
+        device.Object.ClipboardText.ShouldBe("copied");
+    }
+
+    [Fact]
+    public void SetText_DoesNotThrow_WhenNoKeyboardIsPresent()
+    {
+        var clipboard = new SilkGumClipboard(CreateInputContext(null));
+
+        Should.NotThrow(() => clipboard.SetText("copied"));
+    }
+}


### PR DESCRIPTION
## Summary

Implements the two genuinely feasible gaps from #3651: clipboard and manual key-repeat for SilkNetGum. The other three (native text input/IME, touch, gamepad) are not implementable given Silk.NET.Input's actual public API — see below.

- **Clipboard**: `AssignClipboard()` now backs `GumService.Clipboard` with `SilkGumClipboard`, wrapping `IKeyboard.ClipboardText` (Silk.NET.Input's real, synchronous OS clipboard get/set). TextBox/PasswordBox copy/cut/paste now work on Silk.
- **Key-repeat**: `Keyboard.KeyTyped` now times repeat manually (initial press + `RepeatDelay`, then every `RepeatRate` while held), since Silk has no OS-driven repeat poll. Mirrors MonoGame's `Keyboard.RepeatDelay`/`RepeatRate` semantics. Fixes holding an arrow key to repeat caret movement / ListBox / Slider navigation. Character-repeat (typing) was already fine — it flows through the OS-repeated `KeyChar` event.

## Out of scope (confirmed against Silk.NET.Input's source, not assumed)

- **Native text input / IME**: Silk.NET.Input has no composition/candidate-list/IME API — `KeyChar` only reports committed characters. Even MonoGame's `INativeTextInput` doesn't do real desktop IME; it's a mobile on-screen-keyboard modal shim, so there's nothing worth porting here.
- **Touch**: no touch device abstraction exists in Silk.NET.Input's public interfaces at all (`IInputContext` has `Gamepads`/`Joysticks`/`Keyboards`/`Mice`/`OtherDevices`, no touch collection).
- **Gamepad**: `IInputContext.Gamepads`/`IGamepad` do exist and could be wired, but gamepad support for Silk was already explicitly deferred in #3564 as a separate concern.

## Test plan

- [x] `dotnet test Tests/SilkNetGum.Tests/SilkNetGum.Tests.csproj` — 24/24 passing (7 new: 3 key-repeat, 4 clipboard)
- [x] Built `Samples/SilkNetGum` sample (unchanged, already has a `FormsScreen` with a `TextBox`)
- [ ] Manual: open the sample, go to the "Forms" screen, verify copy/paste into the TextBox and holding an arrow key repeats caret movement

Closes #3651
