### PR TITLE
Add AdditionalPropertyOnRenderable hook to SkiaGum dispatch (#3650)

### DIFF
--- a/Runtimes/SkiaGum/CustomSetPropertyOnRenderable.cs
+++ b/Runtimes/SkiaGum/CustomSetPropertyOnRenderable.cs
@@ -86,6 +86,14 @@ public partial class CustomSetPropertyOnRenderable
 
     #endregion
 
+    /// <summary>
+    /// Additional logic to perform before falling back to reflection.
+    /// This can be added by libraries adding additional runtime types.
+    /// Mirrors the unified MonoGame/Raylib copy so SkiaGum consumers assigning this hook
+    /// (e.g. the Apos.Shapes runtimes) are honored before the reflection fallback.
+    /// </summary>
+    public static Func<IRenderableIpso, GraphicalUiElement, string, object, bool>? AdditionalPropertyOnRenderable = null;
+
     // Issue #2956 follow-up — two-slot CircleRuntime / RectangleRuntime own a fill renderable
     // AND a stroke renderable. The runtime's typed setters (UseGradient, IsFilled,
     // gradient color channels, gradient endpoints, etc.) forward to BOTH slots; reflection
@@ -1022,6 +1030,11 @@ public partial class CustomSetPropertyOnRenderable
         // SetPropertyThroughReflection now converts enum -> Nullable<enum> (issue #2924), so the
         // #2923 catch-all that routed them through TrySetPropertiesOnRenderableBase purely to
         // handle Blend? is no longer needed.
+        if (!handled && AdditionalPropertyOnRenderable != null)
+        {
+            handled = AdditionalPropertyOnRenderable(containedObjectAsIpso, graphicalUiElement, propertyName, value);
+        }
+
         if (!handled)
         {
             GraphicalUiElement.SetPropertyThroughReflection(containedObjectAsIpso, graphicalUiElement, propertyName, value);

--- a/Tests/SkiaGum.Tests/Runtimes/CustomSetPropertyOnRenderableTests.cs
+++ b/Tests/SkiaGum.Tests/Runtimes/CustomSetPropertyOnRenderableTests.cs
@@ -1,0 +1,45 @@
+using Gum.Wireframe;
+using RenderingLibrary.Graphics;
+using Shouldly;
+using SkiaGum;
+using SkiaGum.GueDeriving;
+
+namespace SkiaGum.Tests.Runtimes;
+
+// Covers the AdditionalPropertyOnRenderable extension hook on SkiaGum's SetPropertyOnRenderable
+// dispatch (issue #3650 file-unification convergence). The unified MonoGame/Raylib copy checks this
+// hook before falling back to reflection; SkiaGum's copy had dropped it entirely, so a plugin
+// registering AdditionalPropertyOnRenderable (e.g. the Apos.Shapes runtimes) would silently never
+// run under SkiaGum.
+public class CustomSetPropertyOnRenderableTests
+{
+    public CustomSetPropertyOnRenderableTests()
+    {
+        // Wire up the SkiaGum custom property setter so SetProperty routes correctly.
+        GraphicalUiElement.SetPropertyOnRenderable = CustomSetPropertyOnRenderable.SetPropertyOnRenderable;
+    }
+
+    [Fact]
+    public void SetPropertyOnRenderable_UnhandledProperty_ShouldInvokeAdditionalPropertyOnRenderable()
+    {
+        ContainerRuntime container = new();
+        IRenderableIpso renderable = (IRenderableIpso)container.RenderableComponent;
+        bool wasCalled = false;
+
+        CustomSetPropertyOnRenderable.AdditionalPropertyOnRenderable = (ipso, gue, propertyName, value) =>
+        {
+            wasCalled = true;
+            return true;
+        };
+        try
+        {
+            CustomSetPropertyOnRenderable.SetPropertyOnRenderable(renderable, container, "ThisPropertyDoesntExistAnywhere", 42);
+        }
+        finally
+        {
+            CustomSetPropertyOnRenderable.AdditionalPropertyOnRenderable = null;
+        }
+
+        wasCalled.ShouldBeTrue();
+    }
+}


### PR DESCRIPTION
Part of #3650.

SkiaGum's `CustomSetPropertyOnRenderable` was missing the `AdditionalPropertyOnRenderable` extension hook that the unified MonoGame/Raylib copy has, so any SkiaGum consumer (e.g. the Apos.Shapes runtimes) that assigned the hook was silently ignored — the dispatch fell straight through to reflection.

Adds the static field and the `if (!handled && AdditionalPropertyOnRenderable != null)` check immediately before the reflection fallback, matching the canonical file. Platform-agnostic, no `#if` guard on either.

TDD'd: new `Tests/SkiaGum.Tests/Runtimes/CustomSetPropertyOnRenderableTests.cs` failed (hook never invoked) before the change, passes after. Full SkiaGum.Tests suite green (222).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
