### PR TITLE
Pin Skia shape-runtime property dispatch ahead of runtime-first refactor (#3650)

### DIFF
--- a/Tests/SkiaGum.Tests/GueDeriving/ArcRuntimeTests.cs
+++ b/Tests/SkiaGum.Tests/GueDeriving/ArcRuntimeTests.cs
@@ -18,6 +18,58 @@ public class ArcRuntimeTests
         GraphicalUiElement.SetPropertyOnRenderable = CustomSetPropertyOnRenderable.SetPropertyOnRenderable;
     }
 
+    // ---- Dispatcher routing pins (issue #3650) ---------------------------------------------
+    // These lock the CURRENT behavior of the Skia CustomSetPropertyOnRenderable dispatcher for the
+    // ArcRuntime-intercepted property paths (the `graphicalUiElement is ArcRuntime` arms in the Arc
+    // branch of SetPropertyOnRenderableFunc). They drive the STRING property name through the
+    // production dispatcher (via SetProperty) and assert the value lands on the runtime — the safety
+    // net for the planned runtime-type-first restructure of the dispatcher. The legacy gradient-start
+    // channels (Red1/Green1/Blue1/Alpha1 -> primary Color) are already pinned below (issue #3009).
+
+    [Fact]
+    public void Dispatch_DropshadowBlur_RoutesToRuntime()
+    {
+        ArcRuntime sut = new();
+
+        sut.SetProperty("DropshadowBlur", 7f);
+
+        sut.DropshadowBlur.ShouldBe(7f);
+    }
+
+    [Fact]
+    public void Dispatch_StrokeDashLength_RoutesToRuntime()
+    {
+        ArcRuntime sut = new();
+
+        sut.SetProperty("StrokeDashLength", 9f);
+
+        sut.StrokeDashLength.ShouldBe(9f);
+    }
+
+    [Fact]
+    public void Dispatch_StrokeGapLength_RoutesToRuntime()
+    {
+        ArcRuntime sut = new();
+
+        sut.SetProperty("StrokeGapLength", 5f);
+
+        sut.StrokeGapLength.ShouldBe(5f);
+    }
+
+    // StrokeWidth is an obsolete alias for Thickness on ArcRuntime (both route to the same base
+    // StrokeWidth backing field). Assert via Thickness so the pin stays warning-free.
+    [Fact]
+    public void Dispatch_StrokeWidth_RoutesToRuntimeThickness()
+    {
+        ArcRuntime sut = new();
+
+        sut.SetProperty("StrokeWidth", 3f);
+
+        sut.Thickness.ShouldBe(3f);
+    }
+
+    // ---- End dispatcher routing pins -------------------------------------------------------
+
     // #2949: ArcRuntime exposes a single isotropic DropshadowBlur (mirroring CSS box-shadow /
     // Figma / Photoshop). Setting the scalar fans the value out to both axes; asserted on the
     // renderable's per-axis blur (which stays a real API at the renderable layer), not the

--- a/Tests/SkiaGum.Tests/GueDeriving/CircleRuntimeTests.cs
+++ b/Tests/SkiaGum.Tests/GueDeriving/CircleRuntimeTests.cs
@@ -1,6 +1,6 @@
+using Gum.GueDeriving;
 using Gum.Wireframe;
 using Shouldly;
-using SkiaGum.GueDeriving;
 using SkiaGum.Renderables;
 using SkiaSharp;
 using System.Linq;
@@ -19,6 +19,139 @@ public class CircleRuntimeTests
     {
         GraphicalUiElement.SetPropertyOnRenderable = CustomSetPropertyOnRenderable.SetPropertyOnRenderable;
     }
+
+    // ---- Dispatcher routing pins (issue #3650) ---------------------------------------------
+    // These lock the CURRENT behavior of the Skia CustomSetPropertyOnRenderable dispatcher for the
+    // CircleRuntime-intercepted property paths (the `graphicalUiElement is CircleRuntime` arms in
+    // the Circle branch of SetPropertyOnRenderableFunc). Unlike the tests below — which set the
+    // runtime's typed properties directly — these drive the STRING property name through the
+    // production dispatcher (via SetProperty) and assert the value lands on the runtime. They are
+    // the safety net for the planned runtime-type-first restructure of the dispatcher: that refactor
+    // must keep routing each name to the same runtime setter.
+
+    [Fact]
+    public void Dispatch_DropshadowBlur_RoutesToRuntime()
+    {
+        CircleRuntime sut = new();
+
+        sut.SetProperty("DropshadowBlur", 7f);
+
+        sut.DropshadowBlur.ShouldBe(7f);
+    }
+
+    [Fact]
+    public void Dispatch_DropshadowChannels_ComposeDropshadowColor()
+    {
+        CircleRuntime sut = new();
+
+        sut.SetProperty("DropshadowRed", 10);
+        sut.SetProperty("DropshadowGreen", 20);
+        sut.SetProperty("DropshadowBlue", 30);
+        sut.SetProperty("DropshadowAlpha", 40);
+
+        sut.DropshadowColor.ShouldBe(new SKColor(10, 20, 30, 40));
+    }
+
+    [Fact]
+    public void Dispatch_DropshadowOffset_RoutesToRuntime()
+    {
+        CircleRuntime sut = new();
+
+        sut.SetProperty("DropshadowOffsetX", 4f);
+        sut.SetProperty("DropshadowOffsetY", 6f);
+
+        sut.DropshadowOffsetX.ShouldBe(4f);
+        sut.DropshadowOffsetY.ShouldBe(6f);
+    }
+
+    [Fact]
+    public void Dispatch_FillChannels_ComposeFillColor()
+    {
+        CircleRuntime sut = new();
+
+        sut.SetProperty("FillRed", 10);
+        sut.SetProperty("FillGreen", 20);
+        sut.SetProperty("FillBlue", 30);
+        sut.SetProperty("FillAlpha", 40);
+
+        sut.FillColor.ShouldBe(new SKColor(10, 20, 30, 40));
+    }
+
+    [Fact]
+    public void Dispatch_HasDropshadow_RoutesToRuntime()
+    {
+        CircleRuntime sut = new();
+
+        sut.SetProperty("HasDropshadow", true);
+
+        sut.HasDropshadow.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Dispatch_IsFilled_RoutesToRuntime()
+    {
+        CircleRuntime sut = new();
+
+        sut.SetProperty("IsFilled", true);
+
+        sut.IsFilled.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Dispatch_Radius_SetsWidthAndHeight()
+    {
+        CircleRuntime sut = new();
+
+        sut.SetProperty("Radius", 20f);
+
+        sut.Width.ShouldBe(40f);
+        sut.Height.ShouldBe(40f);
+    }
+
+    [Fact]
+    public void Dispatch_StrokeChannels_ComposeStrokeColor()
+    {
+        CircleRuntime sut = new();
+
+        sut.SetProperty("StrokeRed", 11);
+        sut.SetProperty("StrokeGreen", 22);
+        sut.SetProperty("StrokeBlue", 33);
+        sut.SetProperty("StrokeAlpha", 44);
+
+        sut.StrokeColor.ShouldBe(new SKColor(11, 22, 33, 44));
+    }
+
+    [Fact]
+    public void Dispatch_StrokeDashLength_RoutesToRuntime()
+    {
+        CircleRuntime sut = new();
+
+        sut.SetProperty("StrokeDashLength", 9f);
+
+        sut.StrokeDashLength.ShouldBe(9f);
+    }
+
+    [Fact]
+    public void Dispatch_StrokeGapLength_RoutesToRuntime()
+    {
+        CircleRuntime sut = new();
+
+        sut.SetProperty("StrokeGapLength", 5f);
+
+        sut.StrokeGapLength.ShouldBe(5f);
+    }
+
+    [Fact]
+    public void Dispatch_StrokeWidth_RoutesToRuntime()
+    {
+        CircleRuntime sut = new();
+
+        sut.SetProperty("StrokeWidth", 3f);
+
+        sut.StrokeWidth.ShouldBe(3f);
+    }
+
+    // ---- End dispatcher routing pins -------------------------------------------------------
 
     [Fact]
     public void ContainedRenderable_ShouldBeCircle()

--- a/Tests/SkiaGum.Tests/GueDeriving/RectangleRuntimeTests.cs
+++ b/Tests/SkiaGum.Tests/GueDeriving/RectangleRuntimeTests.cs
@@ -19,6 +19,127 @@ public class RectangleRuntimeTests
         GraphicalUiElement.SetPropertyOnRenderable = CustomSetPropertyOnRenderable.SetPropertyOnRenderable;
     }
 
+    // ---- Dispatcher routing pins (issue #3650) ---------------------------------------------
+    // These lock the CURRENT behavior of the Skia CustomSetPropertyOnRenderable dispatcher for the
+    // RectangleRuntime-intercepted property paths (the `graphicalUiElement is RectangleRuntime` arms
+    // in the RoundedRectangle branch of SetPropertyOnRenderableFunc). They drive the STRING property
+    // name through the production dispatcher (via SetProperty) and assert the value lands on the
+    // runtime — the safety net for the planned runtime-type-first restructure of the dispatcher.
+    // CornerRadius / per-corner radii are already pinned this way below (issue #2720).
+
+    [Fact]
+    public void Dispatch_DropshadowBlur_RoutesToRuntime()
+    {
+        RectangleRuntime sut = new();
+
+        sut.SetProperty("DropshadowBlur", 7f);
+
+        sut.DropshadowBlur.ShouldBe(7f);
+    }
+
+    [Fact]
+    public void Dispatch_DropshadowChannels_ComposeDropshadowColor()
+    {
+        RectangleRuntime sut = new();
+
+        sut.SetProperty("DropshadowRed", 10);
+        sut.SetProperty("DropshadowGreen", 20);
+        sut.SetProperty("DropshadowBlue", 30);
+        sut.SetProperty("DropshadowAlpha", 40);
+
+        sut.DropshadowColor.ShouldBe(new SKColor(10, 20, 30, 40));
+    }
+
+    [Fact]
+    public void Dispatch_DropshadowOffset_RoutesToRuntime()
+    {
+        RectangleRuntime sut = new();
+
+        sut.SetProperty("DropshadowOffsetX", 4f);
+        sut.SetProperty("DropshadowOffsetY", 6f);
+
+        sut.DropshadowOffsetX.ShouldBe(4f);
+        sut.DropshadowOffsetY.ShouldBe(6f);
+    }
+
+    [Fact]
+    public void Dispatch_FillChannels_ComposeFillColor()
+    {
+        RectangleRuntime sut = new();
+
+        sut.SetProperty("FillRed", 10);
+        sut.SetProperty("FillGreen", 20);
+        sut.SetProperty("FillBlue", 30);
+        sut.SetProperty("FillAlpha", 40);
+
+        sut.FillColor.ShouldBe(new SKColor(10, 20, 30, 40));
+    }
+
+    [Fact]
+    public void Dispatch_HasDropshadow_RoutesToRuntime()
+    {
+        RectangleRuntime sut = new();
+
+        sut.SetProperty("HasDropshadow", true);
+
+        sut.HasDropshadow.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Dispatch_IsFilled_RoutesToRuntime()
+    {
+        RectangleRuntime sut = new();
+
+        sut.SetProperty("IsFilled", true);
+
+        sut.IsFilled.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Dispatch_StrokeChannels_ComposeStrokeColor()
+    {
+        RectangleRuntime sut = new();
+
+        sut.SetProperty("StrokeRed", 11);
+        sut.SetProperty("StrokeGreen", 22);
+        sut.SetProperty("StrokeBlue", 33);
+        sut.SetProperty("StrokeAlpha", 44);
+
+        sut.StrokeColor.ShouldBe(new SKColor(11, 22, 33, 44));
+    }
+
+    [Fact]
+    public void Dispatch_StrokeDashLength_RoutesToRuntime()
+    {
+        RectangleRuntime sut = new();
+
+        sut.SetProperty("StrokeDashLength", 9f);
+
+        sut.StrokeDashLength.ShouldBe(9f);
+    }
+
+    [Fact]
+    public void Dispatch_StrokeGapLength_RoutesToRuntime()
+    {
+        RectangleRuntime sut = new();
+
+        sut.SetProperty("StrokeGapLength", 5f);
+
+        sut.StrokeGapLength.ShouldBe(5f);
+    }
+
+    [Fact]
+    public void Dispatch_StrokeWidth_RoutesToRuntime()
+    {
+        RectangleRuntime sut = new();
+
+        sut.SetProperty("StrokeWidth", 3f);
+
+        sut.StrokeWidth.ShouldBe(3f);
+    }
+
+    // ---- End dispatcher routing pins -------------------------------------------------------
+
     [Fact]
     public void Clone_MutatingClone_DoesNotMutateSource()
     {

--- a/Tests/SkiaGum.Tests/GueDeriving/RoundedRectangleRuntimeTests.cs
+++ b/Tests/SkiaGum.Tests/GueDeriving/RoundedRectangleRuntimeTests.cs
@@ -19,6 +19,46 @@ public class RoundedRectangleRuntimeTests
         GraphicalUiElement.SetPropertyOnRenderable = CustomSetPropertyOnRenderable.SetPropertyOnRenderable;
     }
 
+    // ---- Dispatcher routing pins (issue #3650) ---------------------------------------------
+    // These lock the CURRENT behavior of the Skia CustomSetPropertyOnRenderable dispatcher for the
+    // RoundedRectangleRuntime-intercepted stroke paths (the `graphicalUiElement is
+    // RoundedRectangleRuntime` arms — checked BEFORE the RectangleRuntime arms — in the
+    // RoundedRectangle branch of SetPropertyOnRenderableFunc). They drive the STRING property name
+    // through the production dispatcher (via SetProperty) and assert the value lands on the runtime,
+    // the safety net for the planned runtime-type-first restructure of the dispatcher.
+
+    [Fact]
+    public void Dispatch_StrokeDashLength_RoutesToRuntime()
+    {
+        RoundedRectangleRuntime sut = new();
+
+        sut.SetProperty("StrokeDashLength", 9f);
+
+        sut.StrokeDashLength.ShouldBe(9f);
+    }
+
+    [Fact]
+    public void Dispatch_StrokeGapLength_RoutesToRuntime()
+    {
+        RoundedRectangleRuntime sut = new();
+
+        sut.SetProperty("StrokeGapLength", 5f);
+
+        sut.StrokeGapLength.ShouldBe(5f);
+    }
+
+    [Fact]
+    public void Dispatch_StrokeWidth_RoutesToRuntime()
+    {
+        RoundedRectangleRuntime sut = new();
+
+        sut.SetProperty("StrokeWidth", 3f);
+
+        sut.StrokeWidth.ShouldBe(3f);
+    }
+
+    // ---- End dispatcher routing pins -------------------------------------------------------
+
     [Fact]
     public void Clone_MutatingClone_DoesNotMutateSource()
     {


### PR DESCRIPTION
Part of #3650.

Test-only safety net for the upcoming behavior-preserving refactor that will make the Skia `CustomSetPropertyOnRenderable` dispatcher route runtime-type-first (matching the core file). No production code changes.

## What this pins

The Skia dispatcher intercepts several shape properties by runtime type *inside* the renderable branches (the `graphicalUiElement is RectangleRuntime` / `is CircleRuntime` / `is ArcRuntime` / `is RoundedRectangleRuntime` arms). The existing `*RuntimeTests` mostly set the runtime's typed properties **directly**, which does not exercise the dispatcher's string-name routing — exactly the logic the refactor will move. These new tests drive each property name through the production dispatcher (`SetProperty` → `CustomSetPropertyOnRenderable.SetPropertyOnRenderable`) and assert the value lands on the runtime, so the restructure can't silently reroute a property.

28 pins added across the four shape-runtime test files:

- **CircleRuntime** (11): IsFilled, Radius→Width/Height, Fill channels, Stroke channels, StrokeWidth, StrokeDashLength, StrokeGapLength, HasDropshadow, Dropshadow offset, DropshadowBlur, Dropshadow channels.
- **RectangleRuntime** (10): same set minus Radius (CornerRadius / per-corner radii were already pinned via the dispatcher in #2720).
- **RoundedRectangleRuntime** (3): StrokeWidth / StrokeDashLength / StrokeGapLength — the `is RoundedRectangleRuntime` arm is checked *before* the RectangleRuntime arms, so it's a distinct dispatcher path.
- **ArcRuntime** (4): StrokeWidth (via the Thickness alias), StrokeDashLength, StrokeGapLength, DropshadowBlur. The legacy gradient-start channels (Red1/Green1/Blue1/Alpha1 → primary Color) were already pinned via the dispatcher.

## Boyscout

`CircleRuntimeTests` used `using SkiaGum.GueDeriving;`, resolving `CircleRuntime` to the obsolete compatibility shim and emitting ~50 CS0618 warnings (the sibling test files already use `using Gum.GueDeriving;`). Switched it to `Gum.GueDeriving` — the real unified type the dispatcher actually checks (`is CircleRuntime`) — clearing every CS0618 in the file.

`dotnet test Tests/SkiaGum.Tests` is green (250 passed) with no new warnings from the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
