### PR TITLE
Document CustomSetPropertyOnRenderable dispatchers + mark core file partial (#3650)

### DIFF
--- a/.claude/skills/gum-cross-platform-unification/SKILL.md
+++ b/.claude/skills/gum-cross-platform-unification/SKILL.md
@@ -113,4 +113,15 @@ Also not the pattern for duplication *between two different runtime classes on t
 
 The **convergence technique** above, however, applies to any source that *already exists as per-platform duplicate copies* heading for a single linked home — not only `GueDeriving` wrappers. The canonical non-wrapper example, now fully converged, is the string-path dispatch/bridge file `Gum/Wireframe/CustomSetPropertyOnRenderable.cs`, linked into `RaylibGum.csproj` in place of a separate Raylib copy. The "don't apply this to tool code" exclusion is about not *inventing* the source-sharing pattern for things that are genuinely single-home; it does not forbid converging files that are already duplicated per platform.
 
+### Two `CustomSetPropertyOnRenderable` dispatchers, split by shape capability
+
+The dispatcher exists as **two** separate source files — the split is by shape-renderable capability, not platform:
+
+| File | Compiled into | Shape renderables it dispatches |
+|---|---|---|
+| `Gum/Wireframe/CustomSetPropertyOnRenderable.cs` | MonoGame · KNI · FNA · Raylib · tool | core geometry — `LineRectangle`/`SolidRectangle`/`LineCircle`/`LinePolygon` |
+| `Runtimes/SkiaGum/CustomSetPropertyOnRenderable.cs` | SkiaGum · `MonoGameGumShapes`+`KniGumShapes` (Apos.Shapes) · SilkNet | rich `RenderableShapeBase` family — Arc/RoundedRectangle/etc. |
+
+The Skia file is `#if SKIA`/`#else`-split so one source serves **both** the Skia dispatcher and the Apos.Shapes dispatcher — the rich shape path is already shared between Skia and MonoGame-with-Apos. Both files are delegate-wired through `GraphicalUiElement.SetPropertyOnRenderable` (each backend's `SystemManagers` assigns it), so callers never name the class. **Landmine:** `AposShapeRuntime` and external FRB Glue reference these classes *by namespace* directly, so the namespace is not free to move. Convergence direction (runtime-type-first dispatch) and why the two files stay separate: `Direction/decisions/0007-converge-skia-property-dispatch.md`.
+
 This skill is also **not** the source of truth for *which* runtimes are unified. Roadmap and per-runtime status live in the (gitignored) design docs at `.claude/designs/runtime-unification/` — `RuntimeNorthStar.md` for the workstream-level roadmap, `RuntimeUnificationAndRefactor.md` for per-runtime details. Update those when a unification lands; do not duplicate status here.

--- a/Direction/decisions/0007-converge-skia-property-dispatch.md
+++ b/Direction/decisions/0007-converge-skia-property-dispatch.md
@@ -1,0 +1,69 @@
+# 0007. Converge the Skia property dispatcher via runtime-type-first dispatch
+
+- **Status:** Accepted
+- **Date:** 2026-07-13
+- **Deciders:** Victor Chelaru, Claude
+
+## Context
+
+`CustomSetPropertyOnRenderable` — the string-path property dispatcher wired into
+`GraphicalUiElement.SetPropertyOnRenderable` — exists as **two** separate source files, split by
+shape-renderable capability rather than by platform:
+
+- `Gum/Wireframe/CustomSetPropertyOnRenderable.cs` — the **core** dispatcher (MonoGame/KNI/FNA/Raylib/
+  tool). Branches on the core geometry renderables (`LineRectangle`/`SolidRectangle`/`LineCircle`/
+  `LinePolygon`).
+- `Runtimes/SkiaGum/CustomSetPropertyOnRenderable.cs` — the **rich** dispatcher, `#if SKIA`/`#else`-split
+  so one source serves both SkiaGum and the Apos.Shapes assemblies (`MonoGameGumShapes`/`KniGumShapes`),
+  plus SilkNet. Branches on the `RenderableShapeBase` family (Arc/RoundedRectangle/etc.).
+
+The two branch on **disjoint renderable types** — `LineCircle`/`LinePolygon` do not exist in the Skia
+assembly at all, and Skia's `LineRectangle`/`SolidRectangle` are different `RenderableShapeBase`
+subclasses. That is why they are two files. But the layer *above* the renderables is already unified:
+the shape **runtime** types (`RectangleRuntime`/`CircleRuntime`/`ArcRuntime`/`RoundedRectangleRuntime`)
+are one source file each, link-compiled into every backend, and each already knows how to forward to
+its own platform's renderable. The core file has already begun keying dispatch on those runtime types
+before the renderable-type tree (#2925).
+
+The originating goal of this workstream (Silk.NET + Forms) is already working, so the remaining work
+here is code-health convergence, not feature enablement.
+
+## Decision
+
+We will converge the two dispatchers by moving both toward **runtime-type-first dispatch**: branch on
+the shared runtime types (`RectangleRuntime`/`CircleRuntime`/`ArcRuntime`/…), which compile on every
+backend, and let each runtime forward to its own `#if`-gated concrete renderable at the leaf. This is
+driven **incrementally / boy-scout**, one small block at a time, and the two files stay **physically
+separate** — we are not forcing a single linked source file.
+
+Each convergence step is behavior-preserving and rests on the pinning tests for the Skia shape-runtime
+dispatch (#3662), so the standard manual-test verdict is "not needed" for a netted reorg step.
+
+## Consequences
+
+- Dispatcher code stops depending on platform-specific renderable types; the two files converge in
+  structure and shrink their cross-file diff, improving maintainability without touching the (essential)
+  renderable-layer divergence.
+- **A physical single-file merge stays deferred, and may never be worth it.** It is blocked by concrete
+  coupling: no compile symbol distinguishes the Apos assemblies from core (so a shared file cannot
+  `#if`-select the right namespace among `SkiaGum`/`RaylibGum.Renderables`/`MonoGameGumShapes`/
+  `Gum.Wireframe`), and `AposShapeRuntime` plus external **FRB Glue** reference these classes *by
+  namespace* directly, so the namespace is not free to move.
+- The core MonoGame default tier (no Apos.Shapes) remains a visual no-op for rich features
+  (`CornerRadius` stored but not rendered, no gradient/dropshadow) — an essential backend limit, not a
+  convergence target.
+
+## Alternatives considered
+
+- **Physical single-file merge now** (`#if`-gate the core geometry branches, link one file everywhere,
+  delete the Skia copy) — rejected: blocked by the namespace/symbol/FRB-Glue coupling above, and the
+  payoff over structural convergence is largely cosmetic now that the feature goal is met.
+- **Unify the renderables under a shared interface** so the dispatcher is type-agnostic at the leaf too
+  (the deeper Layer-3 fix) — a better long-term end state, but a far larger, riskier change touching
+  every shape renderable across three implementations; deferred, not rejected. Runtime-type-first is the
+  cheaper path that leans on the already-unified runtime layer.
+- **Leave the files fully separate / close the issue** — rejected: runtime-type-first still yields real
+  maintenance convergence at low risk, and the pinning net is already in place.
+
+Related: [0006](0006-runtimes-declare-capabilities-through-igumservice.md) (the same "one shared source,
+per-backend hooks" workstream; `SetPropertyOnRenderable` is one of those delegates).

--- a/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
+++ b/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
@@ -51,7 +51,7 @@ using ResolvedFont = RenderingLibrary.Graphics.BitmapFont;
 namespace Gum.Wireframe;
 #endif
 
-public class CustomSetPropertyOnRenderable
+public partial class CustomSetPropertyOnRenderable
 {
     private static ILocalizationService? _localizationService;
 


### PR DESCRIPTION
Part of #3650 (not a closing keyword — the issue stays open).

Documentation + a lowest-risk structural token, no behavior change:

- **ADR `Direction/decisions/0007`** — records the agreed convergence direction (runtime-type-first dispatch) for the Skia/rich `CustomSetPropertyOnRenderable`, why the two files stay physically separate for now, and the blockers to a single-file merge (namespace/symbol coupling; `AposShapeRuntime` + FRB Glue reference the classes by namespace).
- **`gum-cross-platform-unification` skill** — adds a timeless map of the two dispatcher files (core geometry vs rich `RenderableShapeBase`) and which backends compile each, plus the namespace-coupling landmine.
- **`Gum/Wireframe/CustomSetPropertyOnRenderable.cs`** — marked `partial` to match the Skia file; the lowest-risk step toward the eventual Common-partial split.

Manual test: not needed — `partial` is inert plumbing (builds clean) and the rest is docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
