### PR TITLE
Skill touch-ups: debugging self-invoke trigger + gum-samples SilkNet docs gap

### DIFF
--- a/.claude/skills/debugging/SKILL.md
+++ b/.claude/skills/debugging/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: debugging
-description: How to investigate a hard bug without tunnel-visioning on one method. Triggers: a hypothesis just failed, considering another automated repro attempt, "I'm stuck", a long-running investigation.
+description: How to investigate a hard bug without tunnel-visioning on one method. Triggers: a hypothesis just failed, a second same-category fix attempt is about to be proposed, "I'm stuck", a long-running investigation.
 ---
 
 # Debugging Without Tunnel Vision
@@ -18,6 +18,9 @@ window.)
 - **Structural isolation** — minimal repro outside the app/framework
 - **External verification** — read the actual upstream source, its issue tracker
 - **Specialized tooling** — GPU frame capture, other domain debuggers
+
+Self-invoke on the 2nd same-category miss — don't wait for the user to point this out (happened
+on #3660: 4 rounds of GL/Skia-semantics patches before switching to live-observation logging).
 
 ## Stop immediately if
 

--- a/.claude/skills/gum-samples/SKILL.md
+++ b/.claude/skills/gum-samples/SKILL.md
@@ -38,6 +38,10 @@ raylib and Skia render shapes natively. MonoGame's shape rendering comes from th
 
 **MonoGame/KNI host init (landmine).** Referencing the package is not enough — the game host must call `ShapeRenderer.Self.Initialize()` (namespace `MonoGameAndGum.Renderables`) **after** `GumService.Default.Initialize(...)`, **and** set `GraphicsProfile.HiDef` (Apos.Shapes uses an SM4 effect that Reach can't load). Miss either and shape fills/effects silently do not draw — no error. See `docs/code/standard-visuals/shapes-apos.shapes.md`.
 
+## Docs coverage lags SilkNetGum
+
+`docs/code/layout/resizing-the-game-window.md` documents window-resize handling with `{% tabs %}` per backend but has no Silk.NET tab yet (only MonoGame/raylib-flavored guidance exists). When fixing or documenting Silk.NET resize behavior, add its tab there too instead of leaving the doc MonoGame/raylib-only.
+
 ## Verification is human-driven
 
 These samples exist for visual confirmation; they have no automated assertions. After adding a screen, build the sample and tell the user to run it and eyeball the new screen. Behavioral correctness still gets a unit test in the matching `Tests/*` project (see [[tdd]]) — the sample is the visual complement, not a replacement.


### PR DESCRIPTION
Two small guidance-file improvements surfaced by recent work:

- **debugging**: self-invoke on the 2nd same-category fix attempt (the #3660 miss), rather than waiting to be told.
- **gum-samples**: note that `docs/code/layout/resizing-the-game-window.md` has no Silk.NET tab yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)