### PR TITLE
Render Skia text OutlineThickness via RichTextKit halo

### DIFF
--- a/Runtimes/SkiaGum/CustomSetPropertyOnRenderable.cs
+++ b/Runtimes/SkiaGum/CustomSetPropertyOnRenderable.cs
@@ -1195,6 +1195,13 @@ public partial class CustomSetPropertyOnRenderable
                 {
                     text.FontName = asTextRuntime.Font;
                     text.FontSize = asTextRuntime.FontSize;
+#if SKIA
+                    // Skia draws the outline at render time via RichTextKit's halo (there is no
+                    // font-generation step to bake it into, unlike MonoGame/Raylib), so push the
+                    // runtime's OutlineThickness onto the renderable here. #if SKIA-gated because the
+                    // #else (Apos.Shapes) build's Text renderable has no OutlineThickness property.
+                    text.OutlineThickness = asTextRuntime.OutlineThickness;
+#endif
                 }
             }
         }

--- a/Runtimes/SkiaGum/Renderables/Text.cs
+++ b/Runtimes/SkiaGum/Renderables/Text.cs
@@ -236,6 +236,38 @@ public class Text : IRenderableIpso, IVisible, IFormsText, ICloneable
         }
     }
 
+    /// <summary>
+    /// The thickness, in pixels, of the outline drawn around the text. Zero (the default) draws no
+    /// outline. Rendered through RichTextKit's halo (<see cref="Style.HaloWidth"/>). Mirrors the
+    /// OutlineThickness font property on the MonoGame/Raylib backends, which instead bake the outline
+    /// into the generated bitmap font since they have no runtime font-drawing outline mechanism.
+    /// </summary>
+    public int OutlineThickness
+    {
+        get => _outlineThickness;
+        set
+        {
+            _outlineThickness = value;
+            _cachedTextBlock = null;
+        }
+    }
+
+    /// <summary>
+    /// The color of the outline drawn when <see cref="OutlineThickness"/> is greater than zero.
+    /// Defaults to black. This is SkiaGum-specific: the MonoGame/Raylib backends bake the outline
+    /// into the font atlas and expose no runtime outline-color property, so there is no shared
+    /// cross-backend concept to mirror.
+    /// </summary>
+    public SKColor OutlineColor
+    {
+        get => _outlineColor;
+        set
+        {
+            _outlineColor = value;
+            _cachedTextBlock = null;
+        }
+    }
+
     Vector2 Position;
     IRenderableIpso? mParent;
     public string? StoredMarkupText => null;
@@ -439,6 +471,7 @@ public class Text : IRenderableIpso, IVisible, IFormsText, ICloneable
 
         this.Visible = true;
         Color = SKColors.Black;
+        OutlineColor = SKColors.Black;
         mChildren = new ();
     }
 
@@ -520,6 +553,8 @@ public class Text : IRenderableIpso, IVisible, IFormsText, ICloneable
     private float _fontScale;
     private float _boldWeight = 1;
     private SKColor _color;
+    private int _outlineThickness;
+    private SKColor _outlineColor;
     private bool _isItalic;
     private float _lineHeightMultiplier = 1;
     private HorizontalAlignment _horizontalAlignment;
@@ -587,7 +622,7 @@ public class Text : IRenderableIpso, IVisible, IFormsText, ICloneable
     }
 
 
-    private Style GetStyle()
+    internal Style GetStyle()
     {
         var style = new Style()
         {
@@ -598,6 +633,12 @@ public class Text : IRenderableIpso, IVisible, IFormsText, ICloneable
             FontWeight = (int)(400 * BoldWeight),
             LineHeight = LineHeightMultiplier
         };
+
+        if (OutlineThickness > 0)
+        {
+            style.HaloColor = OutlineColor;
+            style.HaloWidth = OutlineThickness;
+        }
 
         return style;
     }

--- a/Runtimes/SkiaGum/SkiaGum.csproj
+++ b/Runtimes/SkiaGum/SkiaGum.csproj
@@ -163,6 +163,10 @@
 		<ProjectReference Include="..\..\GumCommon\GumCommon.csproj" />
 	</ItemGroup>
 
+	<ItemGroup>
+		<InternalsVisibleTo Include="SkiaGum.Tests" />
+	</ItemGroup>
+
 	<!--
 		Bundle the Gum.Analyzers Roslyn analyzer DLL into this package so NuGet consumers
 		get GUM001 namespace-migration warnings + code fixes. This is NOT a ProjectReference

--- a/Samples/SkiaGumWpfSample/SkiaGumWpfSample/MainWindow.xaml.cs
+++ b/Samples/SkiaGumWpfSample/SkiaGumWpfSample/MainWindow.xaml.cs
@@ -43,7 +43,26 @@ namespace SkiaGumWpfSample
 
             container.Children.Add(rectangle2);
 
+            // Demonstrates Skia OutlineThickness (issue #3675): yellow text with a black outline
+            // rendered via RichTextKit's halo. Compare against the no-outline text below it.
+            var outlinedText = new TextRuntime();
+            outlinedText.Text = "Outlined";
+            outlinedText.Font = "Arial";
+            outlinedText.FontSize = 48;
+            outlinedText.Red = 255;
+            outlinedText.Green = 255;
+            outlinedText.Blue = 0;
+            outlinedText.OutlineThickness = 3;
+            container.Children.Add(outlinedText);
 
+            var plainText = new TextRuntime();
+            plainText.Text = "No outline";
+            plainText.Font = "Arial";
+            plainText.FontSize = 48;
+            plainText.Red = 255;
+            plainText.Green = 255;
+            plainText.Blue = 0;
+            container.Children.Add(plainText);
         }
     }
 }

--- a/Tests/SkiaGum.Tests/Renderables/TextOutlineTests.cs
+++ b/Tests/SkiaGum.Tests/Renderables/TextOutlineTests.cs
@@ -1,0 +1,55 @@
+using Shouldly;
+using SkiaGum;
+using SkiaSharp;
+
+namespace SkiaGum.Tests.Renderables;
+
+/// <summary>
+/// Verifies that <see cref="Text.OutlineThickness"/> is rendered through RichTextKit's halo
+/// (issue #3675). Before this change the property was accepted by the dispatch layer but the
+/// Skia renderer never drew an outline, so it had zero visual effect.
+/// </summary>
+public class TextOutlineTests
+{
+    [Fact]
+    public void GetStyle_NoHalo_WhenOutlineThicknessIsZero()
+    {
+        Text sut = new();
+        sut.OutlineThickness = 0;
+
+        Topten.RichTextKit.Style style = sut.GetStyle();
+
+        style.HaloWidth.ShouldBe(0f);
+    }
+
+    [Fact]
+    public void GetStyle_SetsHaloColor_FromOutlineColor()
+    {
+        Text sut = new();
+        sut.OutlineThickness = 3;
+        sut.OutlineColor = SKColors.Red;
+
+        Topten.RichTextKit.Style style = sut.GetStyle();
+
+        style.HaloColor.ShouldBe(SKColors.Red);
+    }
+
+    [Fact]
+    public void GetStyle_SetsHaloWidth_FromOutlineThickness()
+    {
+        Text sut = new();
+        sut.OutlineThickness = 4;
+
+        Topten.RichTextKit.Style style = sut.GetStyle();
+
+        style.HaloWidth.ShouldBe(4f);
+    }
+
+    [Fact]
+    public void OutlineColor_DefaultsToBlack()
+    {
+        Text sut = new();
+
+        sut.OutlineColor.ShouldBe(SKColors.Black);
+    }
+}


### PR DESCRIPTION
Skia text `OutlineThickness` was wired through the dispatch layer but inert — the renderer never drew an outline (Skia has no font-generation step to bake one into, unlike MonoGame/Raylib, which regenerate the bitmap font with the outline).

Fix: add `OutlineThickness` / `OutlineColor` to the SkiaGum `Text` renderable, map them to RichTextKit's `Style.HaloWidth` / `HaloColor` in `GetStyle`, and push `OutlineThickness` from the runtime in `UpdateToFontValues` (`#if SKIA`-gated — the shared file's Apos.Shapes `#else` build has no such renderable property).

`OutlineColor` defaults to black and is SkiaGum-specific: MonoGame/Raylib bake the outline into the font atlas and expose no runtime outline-color concept, so there's nothing cross-backend to mirror.

Dispatch parity: the `OutlineThickness` arm in `TrySetPropertyOnText` was already identical to the MonoGame copy and is untouched; the only Skia-specific addition is the font-value push, which is inherently platform-divergent (font-gen vs. draw-time halo).

Tests: `TextOutlineTests` (SkiaGum.Tests) — halo width/color reflect the outline props, no halo at thickness 0, black default. Manually verified in `SkiaGumWpfSample` (yellow "Outlined" text with black halo vs. plain).

Closes #3675
