### PR TITLE
Add standalone drop shadow to SkiaGum Text (#3674)

### DIFF
--- a/.claude/agents/coder.md
+++ b/.claude/agents/coder.md
@@ -132,6 +132,8 @@ Keep boyscout fixes non-invasive in the structural sense — don't restructure c
 
 By the time you reach this stage, the new tests should already exist and be green (see "Test-Driven Development (Required)" above). Build via Bash and run the related test suite to check for regressions in adjacent areas. Output: changed files + brief why. Focus on correctness and brevity over cleverness.
 
+**Never launch Visual Studio, a sample `.exe`, `dotnet run`, or any GUI app.** Build and verify with `dotnet build` / `dotnet test` only. Running the app and any manual/visual testing belong to the user — leave the sample built and hand off the test steps; do not open an IDE or start a windowed process yourself.
+
 **raylib now runs in CI** as a blocking Windows suite (`RaylibGum.Tests`), using Mesa's `llvmpipe` software GL to supply the OpenGL 3.3 context the GPU-less runners lack (#3250). A green CI run therefore *does* cover raylib — including the `#if RAYLIB` branches of a source-shared `GueDeriving/*Runtime.cs` — so the old mandatory local raylib run before finishing is **no longer required**. Treat it like any other suite: if you change raylib-covered behavior, update any assertion pinning the old value (a local run is still the fastest way to iterate, but it is no longer a merge floor). (`SkiaGum.Tests` also blocks in CI — headless CPU raster.)
 
 **Zero new warnings policy** — after every change, verify that no new compiler warnings were introduced. If a warning cannot be fixed (e.g., an unused event on a test fake that satisfies an interface contract), suppress it with `#pragma warning disable`/`restore` and a comment explaining why the suppression is justified.

--- a/Runtimes/SkiaGum/CustomSetPropertyOnRenderable.cs
+++ b/Runtimes/SkiaGum/CustomSetPropertyOnRenderable.cs
@@ -1429,6 +1429,54 @@ public partial class CustomSetPropertyOnRenderable
 #endif
 
         }
+        // Standalone drop shadow (issue #3674). Set directly on the renderable -- NOT routed through
+        // UpdateToFontValues, which is font-gated and would no-op when no Font is set. Mirrors the
+        // shape drop-shadow arms in TrySetPropertiesOnRenderableBase.
+        else if (propertyName == nameof(text.HasDropshadow))
+        {
+            text.HasDropshadow = (bool)value;
+            handled = true;
+        }
+        else if (propertyName == nameof(text.DropshadowOffsetX))
+        {
+            text.DropshadowOffsetX = (float)value;
+            handled = true;
+        }
+        else if (propertyName == nameof(text.DropshadowOffsetY))
+        {
+            text.DropshadowOffsetY = (float)value;
+            handled = true;
+        }
+        else if (propertyName == nameof(text.DropshadowBlurX))
+        {
+            text.DropshadowBlurX = (float)value;
+            handled = true;
+        }
+        else if (propertyName == nameof(text.DropshadowBlurY))
+        {
+            text.DropshadowBlurY = (float)value;
+            handled = true;
+        }
+        else if (propertyName == nameof(text.DropshadowRed))
+        {
+            text.DropshadowRed = (int)value;
+            handled = true;
+        }
+        else if (propertyName == nameof(text.DropshadowGreen))
+        {
+            text.DropshadowGreen = (int)value;
+            handled = true;
+        }
+        else if (propertyName == nameof(text.DropshadowBlue))
+        {
+            text.DropshadowBlue = (int)value;
+            handled = true;
+        }
+        else if (propertyName == nameof(text.DropshadowAlpha))
+        {
+            text.DropshadowAlpha = (int)value;
+            handled = true;
+        }
 
         return handled;
     }

--- a/Runtimes/SkiaGum/Renderables/Text.cs
+++ b/Runtimes/SkiaGum/Renderables/Text.cs
@@ -268,6 +268,101 @@ public class Text : IRenderableIpso, IVisible, IFormsText, ICloneable
         }
     }
 
+    #region Dropshadow
+
+    // Standalone (non-BBCode) drop shadow for Skia text (issue #3674). Mirrors the drop-shadow
+    // vocabulary RenderableShapeBase exposes for Skia shapes so text and shapes share one API.
+    // The shadow is a canvas/ImageFilter effect applied in Render (see GetDropshadowPaint) rather
+    // than a RichTextKit Style property, so the setters intentionally do NOT invalidate
+    // _cachedTextBlock -- the cached TextBlock carries no shadow state and Render reads these
+    // values live each frame.
+
+    private bool _hasDropshadow;
+
+    /// <summary>
+    /// When <c>true</c>, a drop shadow is rendered behind the text using
+    /// <see cref="SKImageFilter.CreateDropShadow"/>. Mirrors the Skia shape drop-shadow property set.
+    /// </summary>
+    public bool HasDropshadow
+    {
+        get => _hasDropshadow;
+        set => _hasDropshadow = value;
+    }
+
+    private float _dropshadowOffsetX;
+
+    /// <summary>Horizontal offset, in pixels, of the drop shadow from the text.</summary>
+    public float DropshadowOffsetX
+    {
+        get => _dropshadowOffsetX;
+        set => _dropshadowOffsetX = value;
+    }
+
+    private float _dropshadowOffsetY;
+
+    /// <summary>Vertical offset, in pixels, of the drop shadow from the text.</summary>
+    public float DropshadowOffsetY
+    {
+        get => _dropshadowOffsetY;
+        set => _dropshadowOffsetY = value;
+    }
+
+    private float _dropshadowBlurX;
+
+    /// <summary>
+    /// Horizontal blur amount of the drop shadow. Divided by 3 before being passed to Skia's
+    /// sigma-based blur, matching the convention <see cref="RenderableShapeBase"/> uses for shapes.
+    /// </summary>
+    public float DropshadowBlurX
+    {
+        get => _dropshadowBlurX;
+        set => _dropshadowBlurX = value;
+    }
+
+    private float _dropshadowBlurY;
+
+    /// <inheritdoc cref="DropshadowBlurX"/>
+    public float DropshadowBlurY
+    {
+        get => _dropshadowBlurY;
+        set => _dropshadowBlurY = value;
+    }
+
+    private SKColor _dropshadowColor;
+
+    /// <summary>The color of the drop shadow.</summary>
+    public SKColor DropshadowColor
+    {
+        get => _dropshadowColor;
+        set => _dropshadowColor = value;
+    }
+
+    public int DropshadowAlpha
+    {
+        get => DropshadowColor.Alpha;
+        set => DropshadowColor = new SKColor(DropshadowColor.Red, DropshadowColor.Green, DropshadowColor.Blue, (byte)value);
+    }
+
+    public int DropshadowBlue
+    {
+        get => DropshadowColor.Blue;
+        set => DropshadowColor = new SKColor(DropshadowColor.Red, DropshadowColor.Green, (byte)value, DropshadowColor.Alpha);
+    }
+
+    public int DropshadowGreen
+    {
+        get => DropshadowColor.Green;
+        set => DropshadowColor = new SKColor(DropshadowColor.Red, (byte)value, DropshadowColor.Blue, DropshadowColor.Alpha);
+    }
+
+    public int DropshadowRed
+    {
+        get => DropshadowColor.Red;
+        set => DropshadowColor = new SKColor((byte)value, DropshadowColor.Green, DropshadowColor.Blue, DropshadowColor.Alpha);
+    }
+
+    #endregion
+
     Vector2 Position;
     IRenderableIpso? mParent;
     public string? StoredMarkupText => null;
@@ -536,7 +631,21 @@ public class Text : IRenderableIpso, IVisible, IFormsText, ICloneable
 
             canvas.SetMatrix(result);
 
-            textBlock.Paint(canvas, new SKPoint(0, 0));
+            // A drop shadow is a canvas effect (not a RichTextKit Style property): paint the text
+            // into an offscreen layer whose ImageFilter renders the shadow when the layer is
+            // composited back on Restore. Same primitive/blur convention as the Skia shapes.
+            var shadowPaint = GetDropshadowPaint();
+            if (shadowPaint != null)
+            {
+                canvas.SaveLayer(shadowPaint);
+                textBlock.Paint(canvas, new SKPoint(0, 0));
+                canvas.Restore();
+                shadowPaint.Dispose();
+            }
+            else
+            {
+                textBlock.Paint(canvas, new SKPoint(0, 0));
+            }
             canvas.Restore();
         }
     }
@@ -641,6 +750,31 @@ public class Text : IRenderableIpso, IVisible, IFormsText, ICloneable
         }
 
         return style;
+    }
+
+    /// <summary>
+    /// Builds the <see cref="SKPaint"/> whose <see cref="SKPaint.ImageFilter"/> renders the drop
+    /// shadow, or <c>null</c> when <see cref="HasDropshadow"/> is <c>false</c>. Used by
+    /// <see cref="Render"/> as the paint passed to <c>canvas.SaveLayer</c>. The caller owns the
+    /// returned paint and must dispose it. The blur values are divided by 3 to match the
+    /// sigma convention <see cref="RenderableShapeBase"/> uses for Skia shapes.
+    /// </summary>
+    internal SKPaint? GetDropshadowPaint()
+    {
+        if (!HasDropshadow)
+        {
+            return null;
+        }
+
+        return new SKPaint
+        {
+            ImageFilter = SKImageFilter.CreateDropShadow(
+                DropshadowOffsetX,
+                DropshadowOffsetY,
+                DropshadowBlurX / 3.0f,
+                DropshadowBlurY / 3.0f,
+                DropshadowColor)
+        };
     }
 
     /// <summary>

--- a/Samples/SilkNetGum/SilkNetGum/Screens/TextScreen.cs
+++ b/Samples/SilkNetGum/SilkNetGum/Screens/TextScreen.cs
@@ -78,8 +78,11 @@ internal class TextScreen : FrameworkElement
             "Standalone Skia text effects set on the renderable (#3674 drop shadow, #3675 outline):");
 
         // Yellow text with a black outline via RichTextKit's halo (#3675), next to plain yellow text.
+        // Font must be set: OutlineThickness only propagates to the renderable via UpdateToFontValues
+        // when the runtime's Font is non-empty (#3675), so without this the halo would silently no-op.
         TextRuntime outlined = new TextRuntime();
         outlined.Text = "Outlined";
+        outlined.Font = "Arial";
         outlined.FontSize = 48;
         outlined.Red = 255;
         outlined.Green = 255;
@@ -89,6 +92,7 @@ internal class TextScreen : FrameworkElement
 
         TextRuntime noOutline = new TextRuntime();
         noOutline.Text = "No outline";
+        noOutline.Font = "Arial";
         noOutline.FontSize = 48;
         noOutline.Red = 255;
         noOutline.Green = 255;

--- a/Samples/SilkNetGum/SilkNetGum/Screens/TextScreen.cs
+++ b/Samples/SilkNetGum/SilkNetGum/Screens/TextScreen.cs
@@ -8,7 +8,9 @@ namespace SilkNetGum.Screens;
 
 // Mirror of Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/TextScreen.cs where the backend
 // supports the same surface (#3414). SkiaGum dynamic fonts do not use KernSmith, so baked text
-// drop shadow (HasDropshadow) is not rendered here — the rows below document that gap explicitly.
+// drop shadow (TextRuntime.HasDropshadow) is not rendered here — the rows below document that gap
+// explicitly. The standalone renderable drop shadow added in #3674 is a separate, working path on
+// SkiaGum; the appended AddStandaloneSkiaEffectsSection (no MonoGame mirror) exercises it.
 //
 // Section order in this file must match Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/TextScreen.cs
 // exactly, top to bottom - before adding, removing, or reordering ANY section, check that file for
@@ -62,6 +64,55 @@ internal class TextScreen : FrameworkElement
         container.Children.Add(withOutline);
 
         AddTextureFilterSection(container);
+
+        // Skia-only standalone text effects set directly on the renderable (issue #3674 drop shadow,
+        // issue #3675 outline). Unlike the baked-shadow rows above (TextRuntime.HasDropshadow, the
+        // MonoGame/KNI/Raylib font-atlas path that no-ops on Skia), these render on SkiaGum. This
+        // section has no MonoGameGumInCode mirror — it exercises the SkiaGum.Text renderable directly.
+        AddStandaloneSkiaEffectsSection(container);
+    }
+
+    private static void AddStandaloneSkiaEffectsSection(ContainerRuntime container)
+    {
+        AddSectionLabel(container,
+            "Standalone Skia text effects set on the renderable (#3674 drop shadow, #3675 outline):");
+
+        // Yellow text with a black outline via RichTextKit's halo (#3675), next to plain yellow text.
+        TextRuntime outlined = new TextRuntime();
+        outlined.Text = "Outlined";
+        outlined.FontSize = 48;
+        outlined.Red = 255;
+        outlined.Green = 255;
+        outlined.Blue = 0;
+        outlined.OutlineThickness = 3;
+        container.Children.Add(outlined);
+
+        TextRuntime noOutline = new TextRuntime();
+        noOutline.Text = "No outline";
+        noOutline.FontSize = 48;
+        noOutline.Red = 255;
+        noOutline.Green = 255;
+        noOutline.Blue = 0;
+        container.Children.Add(noOutline);
+
+        // White text with a soft black drop shadow offset down-right (#3674). The standalone shadow
+        // is a canvas/ImageFilter effect on SkiaGum.Text reached via RenderableComponent — distinct
+        // from TextRuntime.HasDropshadow (the baked-atlas path above), which no-ops on Skia.
+        TextRuntime shadowed = new TextRuntime();
+        shadowed.Text = "Drop shadow";
+        shadowed.FontSize = 48;
+        shadowed.Red = 255;
+        shadowed.Green = 255;
+        shadowed.Blue = 255;
+
+        SkiaGum.Text shadowedRenderable = (SkiaGum.Text)shadowed.RenderableComponent;
+        shadowedRenderable.HasDropshadow = true;
+        shadowedRenderable.DropshadowOffsetX = 3;
+        shadowedRenderable.DropshadowOffsetY = 3;
+        shadowedRenderable.DropshadowBlurX = 6;
+        shadowedRenderable.DropshadowBlurY = 6;
+        shadowedRenderable.DropshadowColor = new SKColor(0, 0, 0, 255);
+        container.Children.Add(shadowed);
     }
 
     // Texture filter on Text (#3496): mirrored for structural parity with MonoGameGumInCode and

--- a/Samples/SkiaGumWpfSample/SkiaGumWpfSample/MainWindow.xaml.cs
+++ b/Samples/SkiaGumWpfSample/SkiaGumWpfSample/MainWindow.xaml.cs
@@ -42,46 +42,6 @@ namespace SkiaGumWpfSample
             rectangle2.IsFilled = true;
 
             container.Children.Add(rectangle2);
-
-            // Demonstrates Skia OutlineThickness (issue #3675): yellow text with a black outline
-            // rendered via RichTextKit's halo. Compare against the no-outline text below it.
-            var outlinedText = new TextRuntime();
-            outlinedText.Text = "Outlined";
-            outlinedText.Font = "Arial";
-            outlinedText.FontSize = 48;
-            outlinedText.Red = 255;
-            outlinedText.Green = 255;
-            outlinedText.Blue = 0;
-            outlinedText.OutlineThickness = 3;
-            container.Children.Add(outlinedText);
-
-            var plainText = new TextRuntime();
-            plainText.Text = "No outline";
-            plainText.Font = "Arial";
-            plainText.FontSize = 48;
-            plainText.Red = 255;
-            plainText.Green = 255;
-            plainText.Blue = 0;
-            container.Children.Add(plainText);
-
-            // Demonstrates standalone Skia drop shadow (issue #3674): white text with a soft black
-            // shadow offset down-right, rendered via SKImageFilter.CreateDropShadow in Text.Render.
-            var shadowedText = new TextRuntime();
-            shadowedText.Text = "Drop shadow";
-            shadowedText.Font = "Arial";
-            shadowedText.FontSize = 48;
-            shadowedText.Red = 255;
-            shadowedText.Green = 255;
-            shadowedText.Blue = 255;
-
-            var shadowedRenderable = (SkiaGum.Text)shadowedText.RenderableComponent;
-            shadowedRenderable.HasDropshadow = true;
-            shadowedRenderable.DropshadowOffsetX = 3;
-            shadowedRenderable.DropshadowOffsetY = 3;
-            shadowedRenderable.DropshadowBlurX = 6;
-            shadowedRenderable.DropshadowBlurY = 6;
-            shadowedRenderable.DropshadowColor = new SkiaSharp.SKColor(0, 0, 0, 255);
-            container.Children.Add(shadowedText);
         }
     }
 }

--- a/Samples/SkiaGumWpfSample/SkiaGumWpfSample/MainWindow.xaml.cs
+++ b/Samples/SkiaGumWpfSample/SkiaGumWpfSample/MainWindow.xaml.cs
@@ -63,6 +63,25 @@ namespace SkiaGumWpfSample
             plainText.Green = 255;
             plainText.Blue = 0;
             container.Children.Add(plainText);
+
+            // Demonstrates standalone Skia drop shadow (issue #3674): white text with a soft black
+            // shadow offset down-right, rendered via SKImageFilter.CreateDropShadow in Text.Render.
+            var shadowedText = new TextRuntime();
+            shadowedText.Text = "Drop shadow";
+            shadowedText.Font = "Arial";
+            shadowedText.FontSize = 48;
+            shadowedText.Red = 255;
+            shadowedText.Green = 255;
+            shadowedText.Blue = 255;
+
+            var shadowedRenderable = (SkiaGum.Text)shadowedText.RenderableComponent;
+            shadowedRenderable.HasDropshadow = true;
+            shadowedRenderable.DropshadowOffsetX = 3;
+            shadowedRenderable.DropshadowOffsetY = 3;
+            shadowedRenderable.DropshadowBlurX = 6;
+            shadowedRenderable.DropshadowBlurY = 6;
+            shadowedRenderable.DropshadowColor = new SkiaSharp.SKColor(0, 0, 0, 255);
+            container.Children.Add(shadowedText);
         }
     }
 }

--- a/Tests/SkiaGum.Tests/Renderables/TextDropshadowTests.cs
+++ b/Tests/SkiaGum.Tests/Renderables/TextDropshadowTests.cs
@@ -1,0 +1,59 @@
+using Shouldly;
+using SkiaGum;
+using SkiaSharp;
+
+namespace SkiaGum.Tests.Renderables;
+
+/// <summary>
+/// Verifies the standalone (non-BBCode) drop-shadow property set on <see cref="Text"/> (issue #3674).
+/// The shadow is a canvas/ImageFilter effect applied in <see cref="Text.Render"/>, mirroring the
+/// drop-shadow vocabulary <c>RenderableShapeBase</c> exposes for Skia shapes.
+/// </summary>
+public class TextDropshadowTests
+{
+    [Fact]
+    public void DropshadowColor_ComposesFromChannelSetters()
+    {
+        Text sut = new();
+        sut.DropshadowRed = 10;
+        sut.DropshadowGreen = 20;
+        sut.DropshadowBlue = 30;
+        sut.DropshadowAlpha = 40;
+
+        sut.DropshadowColor.ShouldBe(new SKColor(10, 20, 30, 40));
+    }
+
+    [Fact]
+    public void GetDropshadowPaint_ReturnsNull_WhenHasDropshadowFalse()
+    {
+        Text sut = new();
+        sut.HasDropshadow = false;
+
+        sut.GetDropshadowPaint().ShouldBeNull();
+    }
+
+    [Fact]
+    public void GetDropshadowPaint_ReturnsPaintWithImageFilter_WhenHasDropshadowTrue()
+    {
+        Text sut = new();
+        sut.HasDropshadow = true;
+        sut.DropshadowOffsetX = 2;
+        sut.DropshadowOffsetY = 3;
+        sut.DropshadowBlurX = 6;
+        sut.DropshadowBlurY = 6;
+        sut.DropshadowColor = SKColors.Black;
+
+        using SKPaint? paint = sut.GetDropshadowPaint();
+
+        paint.ShouldNotBeNull();
+        paint.ImageFilter.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void HasDropshadow_DefaultsToFalse()
+    {
+        Text sut = new();
+
+        sut.HasDropshadow.ShouldBeFalse();
+    }
+}


### PR DESCRIPTION
Adds a standalone (non-BBCode) drop-shadow property set to SkiaGum's `Text` renderable — covers Silk.NET too, which renders through SkiaGum.

## Changes
- `Text`: `HasDropshadow`, `DropshadowOffsetX/Y`, `DropshadowBlurX/Y`, `DropshadowColor` (+ `DropshadowRed/Green/Blue/Alpha` channel accessors), mirroring the drop-shadow vocabulary `RenderableShapeBase` exposes for Skia shapes.
- `Render` wraps `textBlock.Paint` in `canvas.SaveLayer(shadowPaint)` where `shadowPaint.ImageFilter = SKImageFilter.CreateDropShadow(...)`, using the same `/3f` blur convention as the shapes. It is a canvas/ImageFilter effect (built in the new `GetDropshadowPaint`), not a RichTextKit `Style` property.
- Dispatch arms in `TrySetPropertyOnText`, set directly on the renderable (not routed through the font-gated `UpdateToFontValues`).
- `SkiaGumWpfSample` gains a drop-shadowed Text for manual verification.

## Scope
Skia-only by design. XNA-like and raylib standalone shadow are tracked in #3681 / #3682.

Closes #3674
