### PR TITLE
Honor Blend on SkiaGum Text

### DIFF
--- a/Runtimes/SkiaGum/CustomSetPropertyOnRenderable.cs
+++ b/Runtimes/SkiaGum/CustomSetPropertyOnRenderable.cs
@@ -1344,13 +1344,12 @@ public partial class CustomSetPropertyOnRenderable
 #endif
         else if (propertyName == nameof(Blend))
         {
-#if MONOGAME || XNA4
-            var valueAsGumBlend = (RenderingLibrary.Blend)value;
-
-            var valueAsXnaBlend = valueAsGumBlend.ToBlendState();
-
-            var text = mContainedObjectAsIpso as Text;
-            text.BlendState = valueAsXnaBlend;
+#if SKIA
+            // Mirror of the XNALIKE Blend arm in Gum/Wireframe/CustomSetPropertyOnRenderable.cs,
+            // which sets textRenderable.BlendState. Skia has no BlendState; it applies the Gum
+            // Blend as an SKPaint.BlendMode at render time (see Text.GetRenderPaint), so the same
+            // dispatch just assigns the nullable Blend property. (issue #3676)
+            text.Blend = (Gum.RenderingLibrary.Blend)value;
             handled = true;
 #endif
         }

--- a/Runtimes/SkiaGum/Renderables/Text.cs
+++ b/Runtimes/SkiaGum/Renderables/Text.cs
@@ -1,6 +1,7 @@
 ﻿using RenderingLibrary;
 using RenderingLibrary.Graphics;
 using Gum.GueDeriving;
+using SkiaGum.Renderables;
 using SkiaSharp;
 using System;
 using System.Collections.Generic;
@@ -272,7 +273,7 @@ public class Text : IRenderableIpso, IVisible, IFormsText, ICloneable
 
     // Standalone (non-BBCode) drop shadow for Skia text (issue #3674). Mirrors the drop-shadow
     // vocabulary RenderableShapeBase exposes for Skia shapes so text and shapes share one API.
-    // The shadow is a canvas/ImageFilter effect applied in Render (see GetDropshadowPaint) rather
+    // The shadow is a canvas/ImageFilter effect applied in Render (see GetRenderPaint) rather
     // than a RichTextKit Style property, so the setters intentionally do NOT invalidate
     // _cachedTextBlock -- the cached TextBlock carries no shadow state and Render reads these
     // values live each frame.
@@ -362,6 +363,17 @@ public class Text : IRenderableIpso, IVisible, IFormsText, ICloneable
     }
 
     #endregion
+
+    /// <summary>
+    /// The Gum blend mode applied when compositing this text. When null, the SkiaSharp default
+    /// (SrcOver / standard alpha blending) is used. Mirrors <see cref="RenderableShapeBase.Blend"/>
+    /// and the MonoGame/Raylib Text's Blend surface. Applied as an <see cref="SKPaint.BlendMode"/>
+    /// in <see cref="Render"/> (see <see cref="GetRenderPaint"/>); values without a clean SkiaSharp
+    /// equivalent fall through to SrcOver (see <see cref="BlendToSkBlendModeExtensions"/>). Like the
+    /// drop-shadow setters, this is a live render-time effect and intentionally does not invalidate
+    /// the cached <see cref="TextBlock"/>.
+    /// </summary>
+    public Gum.RenderingLibrary.Blend? Blend { get; set; }
 
     Vector2 Position;
     IRenderableIpso? mParent;
@@ -631,16 +643,17 @@ public class Text : IRenderableIpso, IVisible, IFormsText, ICloneable
 
             canvas.SetMatrix(result);
 
-            // A drop shadow is a canvas effect (not a RichTextKit Style property): paint the text
-            // into an offscreen layer whose ImageFilter renders the shadow when the layer is
-            // composited back on Restore. Same primitive/blur convention as the Skia shapes.
-            var shadowPaint = GetDropshadowPaint();
-            if (shadowPaint != null)
+            // Drop shadow and Blend are canvas effects (not RichTextKit Style properties): paint the
+            // text into an offscreen layer whose paint carries the ImageFilter (shadow) and/or
+            // BlendMode (blend) so both compose when the layer is composited back on Restore. Same
+            // primitive/blur convention as the Skia shapes.
+            var renderPaint = GetRenderPaint();
+            if (renderPaint != null)
             {
-                canvas.SaveLayer(shadowPaint);
+                canvas.SaveLayer(renderPaint);
                 textBlock.Paint(canvas, new SKPoint(0, 0));
                 canvas.Restore();
-                shadowPaint.Dispose();
+                renderPaint.Dispose();
             }
             else
             {
@@ -753,28 +766,39 @@ public class Text : IRenderableIpso, IVisible, IFormsText, ICloneable
     }
 
     /// <summary>
-    /// Builds the <see cref="SKPaint"/> whose <see cref="SKPaint.ImageFilter"/> renders the drop
-    /// shadow, or <c>null</c> when <see cref="HasDropshadow"/> is <c>false</c>. Used by
-    /// <see cref="Render"/> as the paint passed to <c>canvas.SaveLayer</c>. The caller owns the
-    /// returned paint and must dispose it. The blur values are divided by 3 to match the
-    /// sigma convention <see cref="RenderableShapeBase"/> uses for Skia shapes.
+    /// Builds the <see cref="SKPaint"/> used to composite the text when a render-time effect is
+    /// active, carrying the drop-shadow <see cref="SKPaint.ImageFilter"/> (when
+    /// <see cref="HasDropshadow"/>) and/or the <see cref="SKPaint.BlendMode"/> (when
+    /// <see cref="Blend"/> is set) so the two compose in one <c>canvas.SaveLayer</c>. Returns
+    /// <c>null</c> when neither effect is active, leaving <see cref="Render"/>'s fast path
+    /// unchanged. The caller owns the returned paint and must dispose it. The blur values are
+    /// divided by 3 to match the sigma convention <see cref="RenderableShapeBase"/> uses for Skia shapes.
     /// </summary>
-    internal SKPaint? GetDropshadowPaint()
+    internal SKPaint? GetRenderPaint()
     {
-        if (!HasDropshadow)
+        if (!HasDropshadow && !Blend.HasValue)
         {
             return null;
         }
 
-        return new SKPaint
+        var paint = new SKPaint();
+
+        if (HasDropshadow)
         {
-            ImageFilter = SKImageFilter.CreateDropShadow(
+            paint.ImageFilter = SKImageFilter.CreateDropShadow(
                 DropshadowOffsetX,
                 DropshadowOffsetY,
                 DropshadowBlurX / 3.0f,
                 DropshadowBlurY / 3.0f,
-                DropshadowColor)
-        };
+                DropshadowColor);
+        }
+
+        if (Blend.HasValue)
+        {
+            paint.BlendMode = Blend.Value.ToSKBlendMode();
+        }
+
+        return paint;
     }
 
     /// <summary>

--- a/Samples/SilkNetGum/SilkNetGum/Screens/TextScreen.cs
+++ b/Samples/SilkNetGum/SilkNetGum/Screens/TextScreen.cs
@@ -75,7 +75,7 @@ internal class TextScreen : FrameworkElement
     private static void AddStandaloneSkiaEffectsSection(ContainerRuntime container)
     {
         AddSectionLabel(container,
-            "Standalone Skia text effects set on the renderable (#3674 drop shadow, #3675 outline):");
+            "Standalone Skia text effects set on the renderable (#3674 drop shadow, #3675 outline, #3676 blend):");
 
         // Yellow text with a black outline via RichTextKit's halo (#3675), next to plain yellow text.
         // Font must be set: OutlineThickness only propagates to the renderable via UpdateToFontValues
@@ -117,6 +117,44 @@ internal class TextScreen : FrameworkElement
         shadowedRenderable.DropshadowBlurY = 6;
         shadowedRenderable.DropshadowColor = new SKColor(0, 0, 0, 255);
         container.Children.Add(shadowed);
+
+        // Blend on the renderable (#3676): the same warm text over a blue background renders far
+        // brighter with Additive blend (left) than with the default alpha blend (right), because
+        // Additive adds the text color to the background instead of covering it. Blend is applied as
+        // an SKPaint.BlendMode in Text.Render (see Text.GetRenderPaint). Font must be set or the text
+        // can silently no-op.
+        RectangleRuntime blendBackground = new RectangleRuntime();
+        blendBackground.Width = 520;
+        blendBackground.Height = 60;
+        blendBackground.WidthUnits = Gum.DataTypes.DimensionUnitType.Absolute;
+        blendBackground.HeightUnits = Gum.DataTypes.DimensionUnitType.Absolute;
+        blendBackground.FillColor = new SKColor(40, 40, 120);
+        blendBackground.IsFilled = true;
+
+        TextRuntime additiveBlend = new TextRuntime();
+        additiveBlend.Text = "Additive";
+        additiveBlend.Font = "Arial";
+        additiveBlend.FontSize = 36;
+        additiveBlend.Red = 210;
+        additiveBlend.Green = 150;
+        additiveBlend.Blue = 40;
+        additiveBlend.X = 8;
+        additiveBlend.Y = 8;
+        ((SkiaGum.Text)additiveBlend.RenderableComponent).Blend = Gum.RenderingLibrary.Blend.Additive;
+        blendBackground.Children.Add(additiveBlend);
+
+        TextRuntime normalBlend = new TextRuntime();
+        normalBlend.Text = "Normal";
+        normalBlend.Font = "Arial";
+        normalBlend.FontSize = 36;
+        normalBlend.Red = 210;
+        normalBlend.Green = 150;
+        normalBlend.Blue = 40;
+        normalBlend.X = 300;
+        normalBlend.Y = 8;
+        blendBackground.Children.Add(normalBlend);
+
+        container.Children.Add(blendBackground);
     }
 
     // Texture filter on Text (#3496): mirrored for structural parity with MonoGameGumInCode and

--- a/Tests/SkiaGum.Tests/Renderables/TextBlendTests.cs
+++ b/Tests/SkiaGum.Tests/Renderables/TextBlendTests.cs
@@ -1,0 +1,59 @@
+using Gum.RenderingLibrary;
+using Shouldly;
+using SkiaGum;
+using SkiaSharp;
+
+namespace SkiaGum.Tests.Renderables;
+
+/// <summary>
+/// Verifies that SkiaGum <see cref="Text"/> honors <see cref="Text.Blend"/> by carrying the
+/// mapped <see cref="SKBlendMode"/> on the paint built in <see cref="Text.Render"/> (issue #3676),
+/// and that a blend composes with a drop shadow in the same render paint.
+/// </summary>
+public class TextBlendTests
+{
+    [Fact]
+    public void Blend_DefaultsToNull()
+    {
+        Text sut = new();
+
+        sut.Blend.ShouldBeNull();
+    }
+
+    [Fact]
+    public void GetRenderPaint_CarriesBlendMode_WhenBlendSet()
+    {
+        Text sut = new();
+        sut.Blend = Blend.Additive;
+
+        using SKPaint? paint = sut.GetRenderPaint();
+
+        paint.ShouldNotBeNull();
+        paint.BlendMode.ShouldBe(SKBlendMode.Plus);
+    }
+
+    [Fact]
+    public void GetRenderPaint_ComposesBlendAndShadow_WhenBothSet()
+    {
+        Text sut = new();
+        sut.Blend = Blend.Additive;
+        sut.HasDropshadow = true;
+        sut.DropshadowOffsetX = 2;
+        sut.DropshadowOffsetY = 3;
+        sut.DropshadowColor = SKColors.Black;
+
+        using SKPaint? paint = sut.GetRenderPaint();
+
+        paint.ShouldNotBeNull();
+        paint.BlendMode.ShouldBe(SKBlendMode.Plus);
+        paint.ImageFilter.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void GetRenderPaint_ReturnsNull_WhenNoBlendOrShadow()
+    {
+        Text sut = new();
+
+        sut.GetRenderPaint().ShouldBeNull();
+    }
+}

--- a/Tests/SkiaGum.Tests/Renderables/TextDropshadowTests.cs
+++ b/Tests/SkiaGum.Tests/Renderables/TextDropshadowTests.cs
@@ -24,16 +24,16 @@ public class TextDropshadowTests
     }
 
     [Fact]
-    public void GetDropshadowPaint_ReturnsNull_WhenHasDropshadowFalse()
+    public void GetRenderPaint_ReturnsNull_WhenHasDropshadowFalse()
     {
         Text sut = new();
         sut.HasDropshadow = false;
 
-        sut.GetDropshadowPaint().ShouldBeNull();
+        sut.GetRenderPaint().ShouldBeNull();
     }
 
     [Fact]
-    public void GetDropshadowPaint_ReturnsPaintWithImageFilter_WhenHasDropshadowTrue()
+    public void GetRenderPaint_ReturnsPaintWithImageFilter_WhenHasDropshadowTrue()
     {
         Text sut = new();
         sut.HasDropshadow = true;
@@ -43,7 +43,7 @@ public class TextDropshadowTests
         sut.DropshadowBlurY = 6;
         sut.DropshadowColor = SKColors.Black;
 
-        using SKPaint? paint = sut.GetDropshadowPaint();
+        using SKPaint? paint = sut.GetRenderPaint();
 
         paint.ShouldNotBeNull();
         paint.ImageFilter.ShouldNotBeNull();


### PR DESCRIPTION
Skia `Text` hardcoded `BlendState => AlphaBlend` and its dispatch `Blend` arm was gated `#if MONOGAME || XNA4`, so `Blend` had no effect on Skia text.

- Add `Blend?` to Skia `Text` (mirrors `RenderableShapeBase.Blend` and the XNA-like Text surface).
- Generalize `GetDropshadowPaint()` into `GetRenderPaint()`: returns a paint carrying the drop-shadow `ImageFilter` and/or the `SKPaint.BlendMode` (via `ToSKBlendMode()`) so shadow + blend compose in one `SaveLayer`; null when neither is set (fast path unchanged).
- Wire the `#if SKIA` branch of the `Blend` arm in `TrySetPropertyOnText`, replacing the dead `#if MONOGAME || XNA4` block (referenced an out-of-scope symbol; never compiled in any consumer). Mirrors the XNALIKE arm in `Gum/Wireframe/CustomSetPropertyOnRenderable.cs`.
- SilkNet `TextScreen` blend demo (Additive vs Normal over a blue background).

XNA/raylib rendering unchanged. SkiaGum tests green (262). No new warnings.

Closes #3676
