### PR TITLE
Honor ellipsis and vertical overflow on SkiaGum Text (#3677)

### DIFF
--- a/Runtimes/SkiaGum/CustomSetPropertyOnRenderable.cs
+++ b/Runtimes/SkiaGum/CustomSetPropertyOnRenderable.cs
@@ -1422,9 +1422,13 @@ public partial class CustomSetPropertyOnRenderable
         else if (propertyName == nameof(TextOverflowVerticalMode))
         {
             var textOverflowMode = (TextOverflowVerticalMode)value;
-#if MONOGAME || XNA4
-
-            ((Text)mContainedObjectAsIpso).TextOverflowVerticalMode = textOverflowMode;
+#if SKIA
+            // Skia honors vertical overflow directly on the renderable: TruncateLine caps the
+            // RichTextKit TextBlock to the Text's Height (see Text.GetTextBlock), SpillOver renders
+            // unbounded. The XNALIKE copy (Gum/Wireframe/CustomSetPropertyOnRenderable.cs) instead
+            // routes through GraphicalUiElement.RefreshTextOverflowVerticalMode. (issue #3677)
+            text.TextOverflowVerticalMode = textOverflowMode;
+            handled = true;
 #endif
 
         }

--- a/Runtimes/SkiaGum/Renderables/Text.cs
+++ b/Runtimes/SkiaGum/Renderables/Text.cs
@@ -137,7 +137,22 @@ public class Text : IRenderableIpso, IVisible, IFormsText, ICloneable
         }
     }
 
-    public bool IsTruncatingWithEllipsisOnLastLine { get; set; }
+    /// <summary>
+    /// When <c>true</c>, an overflowing last line ends with an ellipsis ("...") once the text is
+    /// truncated (by <see cref="MaxNumberOfLines"/> or by <see cref="TextOverflowVerticalMode"/>
+    /// clipping to <see cref="Height"/>). Honored through RichTextKit's
+    /// <c>TextBlock.EllipsisEnabled</c> in <see cref="GetTextBlock"/> (issue #3677). Set on the
+    /// MonoGame/Raylib backends via <c>TextOverflowHorizontalMode.EllipsisLetter</c>.
+    /// </summary>
+    public bool IsTruncatingWithEllipsisOnLastLine
+    {
+        get => _isTruncatingWithEllipsisOnLastLine;
+        set
+        {
+            _isTruncatingWithEllipsisOnLastLine = value;
+            _cachedTextBlock = null;
+        }
+    }
 
     /// <inheritdoc/>
     public bool IsHeightDependentOnLines { get; set; }
@@ -565,8 +580,22 @@ public class Text : IRenderableIpso, IVisible, IFormsText, ICloneable
     // This could cache the prerendered for speed, but we currently don't do that...
     public void UpdatePreRenderDimensions() { }
 
-    // todo - need to make this actually functional:
-    public TextOverflowVerticalMode TextOverflowVerticalMode { get; set; } 
+    /// <summary>
+    /// Controls what happens when the text is taller than <see cref="Height"/>.
+    /// <see cref="TextOverflowVerticalMode.TruncateLine"/> caps the RichTextKit
+    /// <c>TextBlock</c> to <see cref="Height"/> (dropping lines that would spill past the
+    /// bottom); <see cref="TextOverflowVerticalMode.SpillOver"/> (the default) renders
+    /// unbounded. Honored in <see cref="GetTextBlock"/> via <c>TextBlock.MaxHeight</c> (issue #3677).
+    /// </summary>
+    public TextOverflowVerticalMode TextOverflowVerticalMode
+    {
+        get => _textOverflowVerticalMode;
+        set
+        {
+            _textOverflowVerticalMode = value;
+            _cachedTextBlock = null;
+        }
+    }
 
     #endregion
 
@@ -669,7 +698,10 @@ public class Text : IRenderableIpso, IVisible, IFormsText, ICloneable
 
     TextBlock? _cachedTextBlock;
     float? _lastEffectiveWidth;
+    float? _lastEffectiveMaxHeight;
     decimal _lastScreenDensity;
+    private bool _isTruncatingWithEllipsisOnLastLine;
+    private TextOverflowVerticalMode _textOverflowVerticalMode;
     private string _fontName = "Arial";
     private int _fontSize = 18;
     private float _fontScale;
@@ -687,12 +719,19 @@ public class Text : IRenderableIpso, IVisible, IFormsText, ICloneable
     public TextBlock GetCachedTextBlock(float? forcedWidth = null)
     {
         var effectiveWidth = forcedWidth ?? this.Width;
+        // Height only feeds layout when TruncateLine is active, so keying the cache on the
+        // effective max height (null under SpillOver) avoids rebuilding every layout frame just
+        // because Height changed while overflow is unbounded (issue #3677).
+        var effectiveMaxHeight = GetEffectiveMaxHeight();
 
-        if(effectiveWidth != _lastEffectiveWidth || _lastScreenDensity != ScreenDensity)
+        if(effectiveWidth != _lastEffectiveWidth
+            || _lastScreenDensity != ScreenDensity
+            || effectiveMaxHeight != _lastEffectiveMaxHeight)
         {
             _cachedTextBlock = null;
             _lastEffectiveWidth = effectiveWidth;
             _lastScreenDensity = ScreenDensity;
+            _lastEffectiveMaxHeight = effectiveMaxHeight;
         }
 
         if(_cachedTextBlock == null)
@@ -701,6 +740,16 @@ public class Text : IRenderableIpso, IVisible, IFormsText, ICloneable
         }
         return _cachedTextBlock;
     }
+
+    /// <summary>
+    /// The max height passed to the RichTextKit <c>TextBlock</c>: <see cref="Height"/> when
+    /// <see cref="TextOverflowVerticalMode.TruncateLine"/> is active and Height is positive,
+    /// otherwise <c>null</c> (unbounded, the SpillOver default).
+    /// </summary>
+    private float? GetEffectiveMaxHeight() =>
+        TextOverflowVerticalMode == TextOverflowVerticalMode.TruncateLine && Height > 0
+            ? Height
+            : (float?)null;
 
     public TextBlock GetTextBlock(float? forcedWidth = null)
     {
@@ -723,6 +772,17 @@ public class Text : IRenderableIpso, IVisible, IFormsText, ICloneable
             }
 
             textBlock.MaxLines = MaximumNumberOfLines;
+
+            // Vertical overflow (issue #3677): TruncateLine caps the block to this Text's Height so
+            // RichTextKit drops lines that would spill past the bottom; SpillOver leaves MaxHeight
+            // null and renders unbounded (the historical Skia behavior).
+            textBlock.MaxHeight = GetEffectiveMaxHeight();
+
+            // Ellipsis (issue #3677): RichTextKit appends "..." to the final line whenever it
+            // truncates the block (via MaxLines/MaxHeight) and EllipsisEnabled is true. Its default
+            // is true, so set it explicitly to honor IsTruncatingWithEllipsisOnLastLine and suppress
+            // the ellipsis when the caller wants a hard cut instead.
+            textBlock.EllipsisEnabled = IsTruncatingWithEllipsisOnLastLine;
         }
         catch(Exception e)
         {

--- a/Samples/SilkNetGum/SilkNetGum/Screens/TextScreen.cs
+++ b/Samples/SilkNetGum/SilkNetGum/Screens/TextScreen.cs
@@ -2,6 +2,7 @@ using Gum.Forms.Controls;
 using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
+using RenderingLibrary.Graphics;
 using SkiaSharp;
 
 namespace SilkNetGum.Screens;
@@ -70,6 +71,81 @@ internal class TextScreen : FrameworkElement
         // MonoGame/KNI/Raylib font-atlas path that no-ops on Skia), these render on SkiaGum. This
         // section has no MonoGameGumInCode mirror — it exercises the SkiaGum.Text renderable directly.
         AddStandaloneSkiaEffectsSection(container);
+
+        AddOverflowSection(container);
+    }
+
+    // Overflow modes on the SkiaGum.Text renderable (#3677): ellipsis on horizontal overflow, then
+    // vertical TruncateLine vs SpillOver for the same text in the same fixed-size box. Each Text sets
+    // Font = "Arial" (text can silently no-op without a font). Both properties live on the renderable
+    // (SkiaGum.Text) and are honored by RichTextKit's TextBlock (MaxHeight / EllipsisEnabled) in
+    // Text.GetTextBlock. No MonoGameGumInCode mirror — this exercises the SkiaGum.Text renderable directly.
+    private static void AddOverflowSection(ContainerRuntime container)
+    {
+        AddSectionLabel(container,
+            "Overflow (#3677): ellipsis on horizontal overflow, then vertical TruncateLine vs SpillOver (same text + box):");
+
+        const string longLine =
+            "This is a single long line of text that will not fit within the fixed width of its box";
+        const string longParagraph =
+            "This is a longer block of text with enough words to wrap across several lines so it overflows " +
+            "the fixed height of its box and demonstrates the difference between truncation and spillover.";
+
+        // (a) Horizontal overflow -> ellipsis. MaxNumberOfLines = 1 caps the block to one line;
+        // IsTruncatingWithEllipsisOnLastLine appends the trailing "...".
+        RectangleRuntime ellipsisBox = MakeOverflowBox(width: 300, height: 30);
+        TextRuntime ellipsisText = MakeBoxFillingText(longLine);
+        SkiaGum.Text ellipsisRenderable = (SkiaGum.Text)ellipsisText.RenderableComponent;
+        ellipsisRenderable.MaxNumberOfLines = 1;
+        ellipsisRenderable.IsTruncatingWithEllipsisOnLastLine = true;
+        ellipsisBox.Children.Add(ellipsisText);
+        container.Children.Add(ellipsisBox);
+
+        // (b) Vertical TruncateLine: the paragraph is clipped to the lines that fit the box Height,
+        // with an ellipsis on the last visible line.
+        RectangleRuntime truncateBox = MakeOverflowBox(width: 300, height: 60);
+        TextRuntime truncateText = MakeBoxFillingText(longParagraph);
+        SkiaGum.Text truncateRenderable = (SkiaGum.Text)truncateText.RenderableComponent;
+        truncateRenderable.TextOverflowVerticalMode = TextOverflowVerticalMode.TruncateLine;
+        truncateRenderable.IsTruncatingWithEllipsisOnLastLine = true;
+        truncateBox.Children.Add(truncateText);
+        container.Children.Add(truncateBox);
+
+        // (c) Vertical SpillOver (today's default): the same paragraph in the same box renders every
+        // line, overflowing past the box's bottom edge.
+        RectangleRuntime spillBox = MakeOverflowBox(width: 300, height: 60);
+        TextRuntime spillText = MakeBoxFillingText(longParagraph);
+        SkiaGum.Text spillRenderable = (SkiaGum.Text)spillText.RenderableComponent;
+        spillRenderable.TextOverflowVerticalMode = TextOverflowVerticalMode.SpillOver;
+        spillBox.Children.Add(spillText);
+        container.Children.Add(spillBox);
+    }
+
+    // A fixed-size, translucent-bordered box so the text's overflow bounds are visible.
+    private static RectangleRuntime MakeOverflowBox(float width, float height)
+    {
+        RectangleRuntime box = new RectangleRuntime();
+        box.WidthUnits = Gum.DataTypes.DimensionUnitType.Absolute;
+        box.HeightUnits = Gum.DataTypes.DimensionUnitType.Absolute;
+        box.Width = width;
+        box.Height = height;
+        box.FillColor = new SKColor(40, 40, 40);
+        box.IsFilled = true;
+        return box;
+    }
+
+    // A Text that fills its parent box, so its overflow is exactly the box's bounds.
+    private static TextRuntime MakeBoxFillingText(string text)
+    {
+        TextRuntime textRuntime = new TextRuntime();
+        textRuntime.Text = text;
+        textRuntime.Font = "Arial";
+        textRuntime.FontSize = 18;
+        textRuntime.WidthUnits = Gum.DataTypes.DimensionUnitType.RelativeToParent;
+        textRuntime.HeightUnits = Gum.DataTypes.DimensionUnitType.RelativeToParent;
+        textRuntime.Width = 0;
+        textRuntime.Height = 0;
+        return textRuntime;
     }
 
     private static void AddStandaloneSkiaEffectsSection(ContainerRuntime container)

--- a/Tests/SkiaGum.Tests/Renderables/TextOverflowTests.cs
+++ b/Tests/SkiaGum.Tests/Renderables/TextOverflowTests.cs
@@ -1,0 +1,90 @@
+using RenderingLibrary.Graphics;
+using Shouldly;
+using SkiaGum;
+using System.Linq;
+using Topten.RichTextKit;
+
+namespace SkiaGum.Tests.Renderables;
+
+/// <summary>
+/// Verifies that SkiaGum's <see cref="Text"/> honors the existing ellipsis
+/// (<see cref="Text.IsTruncatingWithEllipsisOnLastLine"/>) and vertical overflow
+/// (<see cref="Text.TextOverflowVerticalMode"/>) properties through RichTextKit's
+/// <c>TextBlock</c> truncation (<c>MaxHeight</c> / <c>EllipsisEnabled</c>), issue #3677.
+/// </summary>
+public class TextOverflowTests
+{
+    /// <summary>
+    /// Builds a Text whose content wraps to several lines at the given width, so a small
+    /// Height forces vertical truncation. Callers set Height / overflow mode / ellipsis and
+    /// assert against the resulting <c>TextBlock</c>.
+    /// </summary>
+    private static Text MakeWrappingText()
+    {
+        Text text = new();
+        text.FontName = "Arial";
+        text.FontSize = 20;
+        text.Width = 80;
+        text.RawText = "Hello world this is a long line of text that wraps across many lines";
+        return text;
+    }
+
+    [Fact]
+    public void GetTextBlock_EmitsEllipsisRun_WhenTruncatingWithEllipsisAndVerticalTruncation()
+    {
+        Text text = MakeWrappingText();
+        text.Height = 30;
+        text.TextOverflowVerticalMode = TextOverflowVerticalMode.TruncateLine;
+        text.IsTruncatingWithEllipsisOnLastLine = true;
+
+        TextBlock block = text.GetTextBlock();
+
+        block.Truncated.ShouldBeTrue();
+        block.Lines.SelectMany(line => line.Runs).Any(run => run.RunKind == FontRunKind.Ellipsis).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GetTextBlock_OmitsEllipsisRun_WhenNotTruncatingWithEllipsis()
+    {
+        Text text = MakeWrappingText();
+        text.Height = 30;
+        text.TextOverflowVerticalMode = TextOverflowVerticalMode.TruncateLine;
+        text.IsTruncatingWithEllipsisOnLastLine = false;
+
+        TextBlock block = text.GetTextBlock();
+
+        block.Truncated.ShouldBeTrue();
+        block.Lines.SelectMany(line => line.Runs).Any(run => run.RunKind == FontRunKind.Ellipsis).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GetTextBlock_SpillOver_RendersAllLinesUnbounded()
+    {
+        Text text = MakeWrappingText();
+        text.Height = 30;
+        text.TextOverflowVerticalMode = TextOverflowVerticalMode.SpillOver;
+
+        TextBlock block = text.GetTextBlock();
+
+        block.Truncated.ShouldBeFalse();
+        block.MaxHeight.ShouldBeNull();
+    }
+
+    [Fact]
+    public void GetTextBlock_TruncateLine_ClipsToHeight()
+    {
+        Text spillOver = MakeWrappingText();
+        spillOver.Height = 30;
+        spillOver.TextOverflowVerticalMode = TextOverflowVerticalMode.SpillOver;
+        int unboundedLineCount = spillOver.GetTextBlock().Lines.Count;
+
+        Text truncated = MakeWrappingText();
+        truncated.Height = 30;
+        truncated.TextOverflowVerticalMode = TextOverflowVerticalMode.TruncateLine;
+
+        TextBlock block = truncated.GetTextBlock();
+
+        block.Lines.Count.ShouldBeLessThan(unboundedLineCount);
+        block.MaxHeight.ShouldBe(30f);
+    }
+}


### PR DESCRIPTION
Makes SkiaGum's `Text` honor two overflow properties it previously stored but ignored, via RichTextKit's `TextBlock` truncation.

## What changed
- **Ellipsis** — `GetTextBlock` sets `TextBlock.EllipsisEnabled = IsTruncatingWithEllipsisOnLastLine`, so an overflowing last line ends with "..." once the block is truncated (by `MaxNumberOfLines` or by vertical truncation). Previously the field was inert.
- **Vertical overflow** — `TruncateLine` sets `TextBlock.MaxHeight = Height` (RichTextKit drops lines that spill past the bottom); `SpillOver` leaves it null / unbounded (today's behavior).
- Both setters now null `_cachedTextBlock`, and `GetCachedTextBlock` keys on the effective max height so a `Height` change under `TruncateLine` rebuilds the block (mirroring the existing width/screen-density invalidation).
- **Dispatch** — the Skia `TextOverflowVerticalMode` arm was gated `#if MONOGAME || XNA4` (dead on Skia). Rewired to `#if SKIA`, mirroring the XNALIKE arm in `Gum/Wireframe/CustomSetPropertyOnRenderable.cs`; the non-SKIA (Apos.Shapes) build is unchanged.

## RichTextKit notes
`TextBlock` exposes `MaxHeight`/`MaxLines`/`EllipsisEnabled` natively, so both features map cleanly with no approximation. The ellipsis run lands on the truncated `TextLine.Runs` (kind `Ellipsis`), not `TextBlock.FontRuns` — the tests assert against the line runs.

## Behavior note
RichTextKit's `EllipsisEnabled` defaults to true. Previously, setting `MaxNumberOfLines` alone showed an ellipsis automatically; now it's explicitly tied to `IsTruncatingWithEllipsisOnLastLine` (default false), matching Gum's cross-backend semantics (MonoGame requires the flag).

## Tests / manual
`Tests/SkiaGum.Tests/Renderables/TextOverflowTests.cs` (4 tests, green); full SkiaGum suite 266/266. SilkNet-only demo added to `TextScreen` (ellipsis + TruncateLine vs SpillOver, `Font = "Arial"` on each). No public API change.

Closes #3677
