### PR TITLE
Honor MaxLettersToShow on SkiaGum Text (typewriter reveal)

### DIFF
--- a/Runtimes/SkiaGum/CustomSetPropertyOnRenderable.cs
+++ b/Runtimes/SkiaGum/CustomSetPropertyOnRenderable.cs
@@ -1400,8 +1400,11 @@ public partial class CustomSetPropertyOnRenderable
         }
         else if (propertyName == "MaxLettersToShow")
         {
-#if MONOGAME || XNA4
-            ((Text)mContainedObjectAsIpso).MaxLettersToShow = (int?)value;
+#if SKIA
+            // Mirror of the XNALIKE MaxLettersToShow arm in Gum/Wireframe/CustomSetPropertyOnRenderable.cs.
+            // Skia honors this as a paint-only typewriter reveal on the renderable (see Text.Render /
+            // Text.GetVisibleWrappedText); the assignment is otherwise identical. (issue #3678)
+            text.MaxLettersToShow = (int?)value;
             handled = true;
 #endif
         }

--- a/Runtimes/SkiaGum/Renderables/Text.cs
+++ b/Runtimes/SkiaGum/Renderables/Text.cs
@@ -163,12 +163,54 @@ public class Text : IRenderableIpso, IVisible, IFormsText, ICloneable
     /// effects (e.g. <c>DialogBox</c>).
     /// </summary>
     /// <remarks>
-    /// Unlike the MonoGame/Raylib Text renderables, SkiaGum's <see cref="Render"/> does not yet
-    /// honor this value to truncate the rendered glyphs -- it is provided so SkiaGum.Text
-    /// satisfies <see cref="IFormsText"/> (issue #3653) and so callers can set it without an
-    /// InvalidCastException. Letter-reveal rendering support can be added later.
+    /// This is a paint-only effect (issue #3678): <see cref="Render"/> paints a throwaway
+    /// <c>TextBlock</c> built from <see cref="GetVisibleWrappedText"/> (the wrapped lines truncated
+    /// to this budget), while the cached block that drives <see cref="WrappedText"/>, measurement and
+    /// caret math stays built from the full <see cref="RawText"/>. It therefore intentionally does
+    /// NOT invalidate <c>_cachedTextBlock</c> -- mirroring how the other render-time effects
+    /// (drop shadow, blend) keep out of the layout cache. Matches the per-line reveal the
+    /// MonoGame/Raylib/Sokol backends perform.
     /// </remarks>
     public int? MaxLettersToShow { get; set; }
+
+    /// <summary>
+    /// The wrapped lines actually revealed given <see cref="MaxLettersToShow"/>: <see cref="WrappedText"/>
+    /// with each line truncated to the remaining letter budget so a typewriter reveal pauses mid-line
+    /// rather than popping line-by-line (matching the MonoGame/Raylib/Sokol backends). Returns
+    /// <see cref="WrappedText"/> unchanged when <see cref="MaxLettersToShow"/> is null, and an empty
+    /// list when it is zero. Used by <see cref="Render"/> to build the painted block.
+    /// </summary>
+    public List<string> GetVisibleWrappedText()
+    {
+        List<string> fullWrapped = WrappedText;
+        if (MaxLettersToShow == null)
+        {
+            return fullWrapped;
+        }
+
+        var revealed = new List<string>();
+        int remaining = MaxLettersToShow.Value;
+        foreach (var line in fullWrapped)
+        {
+            if (remaining <= 0)
+            {
+                break;
+            }
+
+            if (line.Length <= remaining)
+            {
+                revealed.Add(line);
+                remaining -= line.Length;
+            }
+            else
+            {
+                revealed.Add(line.Substring(0, remaining));
+                remaining = 0;
+            }
+        }
+
+        return revealed;
+    }
 
     /// <inheritdoc/>
     /// <remarks>
@@ -672,6 +714,11 @@ public class Text : IRenderableIpso, IVisible, IFormsText, ICloneable
 
             canvas.SetMatrix(result);
 
+            // MaxLettersToShow (issue #3678): the paint block reveals only the first N letters, but
+            // vertical alignment above was computed from the full block so the revealed letters stay in
+            // their final positions (typewriter reveal). Null MaxLettersToShow returns the full block.
+            var paintBlock = GetPaintTextBlock(textBlock);
+
             // Drop shadow and Blend are canvas effects (not RichTextKit Style properties): paint the
             // text into an offscreen layer whose paint carries the ImageFilter (shadow) and/or
             // BlendMode (blend) so both compose when the layer is composited back on Restore. Same
@@ -680,13 +727,13 @@ public class Text : IRenderableIpso, IVisible, IFormsText, ICloneable
             if (renderPaint != null)
             {
                 canvas.SaveLayer(renderPaint);
-                textBlock.Paint(canvas, new SKPoint(0, 0));
+                paintBlock.Paint(canvas, new SKPoint(0, 0));
                 canvas.Restore();
                 renderPaint.Dispose();
             }
             else
             {
-                textBlock.Paint(canvas, new SKPoint(0, 0));
+                paintBlock.Paint(canvas, new SKPoint(0, 0));
             }
             canvas.Restore();
         }
@@ -751,13 +798,19 @@ public class Text : IRenderableIpso, IVisible, IFormsText, ICloneable
             ? Height
             : (float?)null;
 
-    public TextBlock GetTextBlock(float? forcedWidth = null)
+    public TextBlock GetTextBlock(float? forcedWidth = null) => GetTextBlock(mRawText, forcedWidth);
+
+    /// <summary>
+    /// Builds a RichTextKit <c>TextBlock</c> for the given text (normally <see cref="RawText"/>, but
+    /// <see cref="GetPaintTextBlock"/> passes the reveal-truncated text for <see cref="MaxLettersToShow"/>).
+    /// </summary>
+    private TextBlock GetTextBlock(string textToRender, float? forcedWidth)
     {
         var textBlock = new TextBlock();
         try
         {
             textBlock.MaxWidth = forcedWidth ?? this.Width;
-            textBlock.AddText(mRawText, GetStyle());
+            textBlock.AddText(textToRender, GetStyle());
             switch (HorizontalAlignment)
             {
                 case HorizontalAlignment.Left:
@@ -801,6 +854,37 @@ public class Text : IRenderableIpso, IVisible, IFormsText, ICloneable
 
 
         return textBlock;
+    }
+
+    /// <summary>
+    /// The <c>TextBlock</c> that <see cref="Render"/> actually paints. When <see cref="MaxLettersToShow"/>
+    /// is null (or already covers the whole text) this is the full cached block, leaving the render
+    /// fast path unchanged. Otherwise a throwaway block is built from <see cref="GetVisibleWrappedText"/>
+    /// so only the first N letters are drawn; because each revealed line is a prefix of a full wrapped
+    /// line and the breaks are re-inserted as hard newlines, the revealed lines land in the same
+    /// positions as in the full layout. The cached block (used for measurement / caret math) is
+    /// untouched.
+    /// </summary>
+    private TextBlock GetPaintTextBlock(TextBlock fullBlock)
+    {
+        if (MaxLettersToShow == null)
+        {
+            return fullBlock;
+        }
+
+        List<string> fullWrapped = WrappedText;
+        int fullLength = 0;
+        foreach (var line in fullWrapped)
+        {
+            fullLength += line.Length;
+        }
+
+        if (MaxLettersToShow.Value >= fullLength)
+        {
+            return fullBlock;
+        }
+
+        return GetTextBlock(string.Join("\n", GetVisibleWrappedText()), this.Width);
     }
 
 

--- a/Samples/SilkNetGum/SilkNetGum/Screens/TextScreen.cs
+++ b/Samples/SilkNetGum/SilkNetGum/Screens/TextScreen.cs
@@ -73,6 +73,40 @@ internal class TextScreen : FrameworkElement
         AddStandaloneSkiaEffectsSection(container);
 
         AddOverflowSection(container);
+
+        AddMaxLettersToShowSection(container);
+    }
+
+    // MaxLettersToShow typewriter reveal on the SkiaGum.Text renderable (#3678). The same wrapping
+    // paragraph is shown fully, then with MaxLettersToShow set to a partial count so only the first N
+    // letters are visible while the hidden tail still occupies its final layout (reveal is paint-only:
+    // WrappedText / measurement stay built from the full RawText). Font = "Arial" because text can
+    // silently no-op without a font. No MonoGameGumInCode mirror — exercises the renderable directly.
+    private static void AddMaxLettersToShowSection(ContainerRuntime container)
+    {
+        AddSectionLabel(container,
+            "MaxLettersToShow (#3678): full text, then the same text revealed to the first 12 letters (typewriter):");
+
+        const string paragraph =
+            "This paragraph reveals only its first letters while the rest stays hidden.";
+
+        TextRuntime full = new TextRuntime();
+        full.Font = "Arial";
+        full.FontSize = 20;
+        full.Width = 300;
+        full.WidthUnits = Gum.DataTypes.DimensionUnitType.Absolute;
+        full.Text = paragraph;
+        container.Children.Add(full);
+
+        TextRuntime revealed = new TextRuntime();
+        revealed.Font = "Arial";
+        revealed.FontSize = 20;
+        revealed.Width = 300;
+        revealed.WidthUnits = Gum.DataTypes.DimensionUnitType.Absolute;
+        revealed.Text = paragraph;
+        SkiaGum.Text revealedRenderable = (SkiaGum.Text)revealed.RenderableComponent;
+        revealedRenderable.MaxLettersToShow = 12;
+        container.Children.Add(revealed);
     }
 
     // Overflow modes on the SkiaGum.Text renderable (#3677): ellipsis on horizontal overflow, then

--- a/Tests/SkiaGum.Tests/GueDeriving/TextRuntimeTests.cs
+++ b/Tests/SkiaGum.Tests/GueDeriving/TextRuntimeTests.cs
@@ -197,6 +197,23 @@ public class TextRuntimeTests
 
     #endregion
 
+    #region MaxLettersToShow
+
+    [Fact]
+    public void MaxLettersToShow_SetProperty_ShouldPushToContainedText()
+    {
+        TextRuntime sut = new();
+
+        // Routes through the newly-wired SKIA dispatch arm (issue #3678), which was previously
+        // gated #if MONOGAME || XNA4 and dead on Skia.
+        sut.SetProperty("MaxLettersToShow", (int?)4);
+
+        Text containedText = (Text)sut.RenderableComponent;
+        containedText.MaxLettersToShow.ShouldBe(4);
+    }
+
+    #endregion
+
     #region PropertyChanged
 
     [Fact]

--- a/Tests/SkiaGum.Tests/Renderables/TextMaxLettersToShowTests.cs
+++ b/Tests/SkiaGum.Tests/Renderables/TextMaxLettersToShowTests.cs
@@ -1,0 +1,109 @@
+using RenderingLibrary.Graphics;
+using Shouldly;
+using SkiaGum;
+using System.Linq;
+
+namespace SkiaGum.Tests.Renderables;
+
+/// <summary>
+/// Verifies that SkiaGum's <see cref="Text"/> honors <see cref="Text.MaxLettersToShow"/> for
+/// typewriter-style reveal (issue #3678) without disturbing the full-text layout the caret /
+/// measurement APIs depend on. The visible reveal is exposed through
+/// <see cref="Text.GetVisibleWrappedText"/>, which truncates each wrapped line to the remaining
+/// letter budget (matching the per-line reveal of the MonoGame/Raylib/Sokol backends).
+/// </summary>
+public class TextMaxLettersToShowTests
+{
+    /// <summary>
+    /// Builds a Text whose content wraps to several lines at the given width, so a small
+    /// MaxLettersToShow forces the reveal to stop partway through a wrapped line.
+    /// </summary>
+    private static Text MakeWrappingText()
+    {
+        Text text = new();
+        text.FontName = "Arial";
+        text.FontSize = 20;
+        text.Width = 80;
+        text.RawText = "Hello world this is a long line of text that wraps across many lines";
+        return text;
+    }
+
+    [Fact]
+    public void GetVisibleWrappedText_Null_ReturnsFullWrappedText()
+    {
+        Text text = MakeWrappingText();
+        text.MaxLettersToShow = null;
+
+        text.GetVisibleWrappedText().ShouldBe(text.WrappedText);
+    }
+
+    [Fact]
+    public void GetVisibleWrappedText_PartialCount_RevealsExactlyThatManyLetters()
+    {
+        Text text = MakeWrappingText();
+        text.MaxLettersToShow = 8;
+
+        string revealed = string.Concat(text.GetVisibleWrappedText());
+
+        revealed.Length.ShouldBe(8);
+    }
+
+    [Fact]
+    public void GetVisibleWrappedText_PartialCount_TruncatesFirstLine_WhenSingleLine()
+    {
+        Text text = new();
+        text.FontName = "Arial";
+        text.FontSize = 20;
+        text.Width = 1000;
+        text.RawText = "Hello World";
+        text.MaxLettersToShow = 5;
+
+        text.GetVisibleWrappedText().ShouldBe(new[] { "Hello" });
+    }
+
+    [Fact]
+    public void GetVisibleWrappedText_RevealSpansWrappedLines_MatchesPerLineTruncation()
+    {
+        Text text = MakeWrappingText();
+        System.Collections.Generic.List<string> full = text.WrappedText;
+        int firstLineLength = full[0].Length;
+        text.MaxLettersToShow = firstLineLength + 2;
+
+        System.Collections.Generic.List<string> revealed = text.GetVisibleWrappedText();
+
+        revealed.Count.ShouldBe(2);
+        revealed[0].ShouldBe(full[0]);
+        revealed[1].ShouldBe(full[1].Substring(0, 2));
+    }
+
+    [Fact]
+    public void GetVisibleWrappedText_Zero_RevealsNothing()
+    {
+        Text text = MakeWrappingText();
+        text.MaxLettersToShow = 0;
+
+        text.GetVisibleWrappedText().ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void MaxLettersToShow_DoesNotAffectMeasuredWidth()
+    {
+        Text text = MakeWrappingText();
+        float widthWithoutLimit = text.WrappedTextWidth;
+
+        text.MaxLettersToShow = 3;
+
+        text.WrappedTextWidth.ShouldBe(widthWithoutLimit);
+    }
+
+    [Fact]
+    public void MaxLettersToShow_DoesNotAffectWrappedText()
+    {
+        Text text = MakeWrappingText();
+        System.Collections.Generic.List<string> fullWrapped = text.WrappedText.ToList();
+
+        text.MaxLettersToShow = 3;
+
+        text.WrappedText.ShouldBe(fullWrapped);
+    }
+}


### PR DESCRIPTION
SkiaGum's `Text` carried `MaxLettersToShow` only to satisfy `IFormsText` (#3653) — `Render` ignored it, so no typewriter reveal happened.

## Change
- `Render` now paints a throwaway `TextBlock` built from the new `GetVisibleWrappedText()` (the wrapped lines truncated to the letter budget), while the **cached** block that drives `WrappedText` / measurement / caret math stays built from the full `RawText`. So the reveal is paint-only and preserves layout/caret parity (path 2), matching the per-line reveal of the MonoGame/Raylib/Sokol backends. Vertical alignment is computed from the full block, so revealed letters land in their final positions.
- `null` `MaxLettersToShow` (or a budget covering the whole text) is a zero-behavior-change fast path.
- Wired the previously-dead `#if MONOGAME || XNA4` dispatch arm to `#if SKIA`, mirroring the XNALIKE copy in `Gum/Wireframe/CustomSetPropertyOnRenderable.cs`.

## Why path 2 (not substring-before-AddText)
RichTextKit has no "show first N glyphs" knob and paints whole blocks. Rebuilding the paint block from the per-line-truncated `WrappedText` (re-inserting the wrap points as hard newlines) reveals exactly N letters without disturbing the cached full-text block — so a Text that is also a text box keeps correct `WrappedText`/measurement/caret indices.

## Tests
`Tests/SkiaGum.Tests` — new `TextMaxLettersToShowTests` (visible-letter count reflects N, null shows all, zero shows nothing, per-line truncation across wrapped lines, `WrappedText`/`WrappedTextWidth` unaffected) + a dispatch test in `TextRuntimeTests`. Full suite 274 green.

## Manual test
SilkNet `TextScreen` gains a MaxLettersToShow section (full vs. first-12-letters, `Font = "Arial"`). Sample builds; not run.

Closes #3678
