### PR TITLE
Honor BBCode inline styling on SkiaGum Text (#3679)

### DIFF
--- a/Runtimes/SilkNetGum/SilkNetGum.csproj
+++ b/Runtimes/SilkNetGum/SilkNetGum.csproj
@@ -69,6 +69,9 @@
 		<Compile Include="..\..\RenderingLibrary\Graphics\Animation\AnimationFrame.cs" Link="Animation\AnimationFrame.cs" />
 		<Compile Include="..\..\RenderingLibrary\Graphics\Animation\AnimationChainLogic.cs" Link="Animation\AnimationChainLogic.cs" />
 		<Compile Include="..\..\RenderingLibrary\Graphics\Animation\SpriteAnimationLogic.cs" Link="Animation\SpriteAnimationLogic.cs" />
+		<!-- Shared markup model + run-splitter (InlineVariable, StyledSubstring, StyledSubstringSplitter)
+		     so Skia's Text can render BBCode inline styling (#3679); mirrors SkiaGum.csproj's link. -->
+		<Compile Include="..\..\RenderingLibrary\Graphics\StyledSubstringSplitter.cs" Link="RenderingLibrary\StyledSubstringSplitter.cs" />
 		<!-- IAnimatable intentionally NOT linked (arrives via GumCommon); a local copy would create
 		     two distinct same-FQN types and silently break AnimateSelf — see SkiaGum.csproj. -->
 		<Compile Include="..\..\MonoGameGum\GueDeriving\CircleRuntime.cs" Link="GueDeriving\CircleRuntime.cs" />

--- a/Runtimes/SkiaGum/CustomSetPropertyOnRenderable.cs
+++ b/Runtimes/SkiaGum/CustomSetPropertyOnRenderable.cs
@@ -1263,9 +1263,11 @@ public partial class CustomSetPropertyOnRenderable
                 rawText = LocalizationService.Translate(rawText);
             }
 
-            // Unlike the MonoGame copy (StoredMarkupText / SetBbCodeText), SkiaGum's Text renders
-            // RawText literally through RichTextKit — there is no separate markup path — so a
-            // translated value containing [...] flows through here exactly as any other string.
+            // SkiaGum honors BBCode inline styling too (issue #3679), but unlike the MonoGame copy
+            // (which strips tags here via SetBbCodeText and stores the markup in StoredMarkupText),
+            // the Skia Text renderable parses the markup lazily when it builds its RichTextKit
+            // TextBlock. So the raw (possibly translated) value flows straight through; a value
+            // containing [Color=..]/[FontSize=..]/bold/italic tags renders as mixed per-run styling.
             text.RawText = rawText;
             // we want to update if the text's size is based on its "children" (the letters it contains)
             if (gue.WidthUnits == DimensionUnitType.RelativeToChildren ||

--- a/Runtimes/SkiaGum/Renderables/Text.cs
+++ b/Runtimes/SkiaGum/Renderables/Text.cs
@@ -6,6 +6,7 @@ using SkiaSharp;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Globalization;
 using Topten.RichTextKit;
 using Vector2 = System.Numerics.Vector2;
 using Matrix = System.Numerics.Matrix4x4;
@@ -247,19 +248,21 @@ public class Text : IRenderableIpso, IVisible, IFormsText, ICloneable
     private List<string> BuildWrappedTextList(TextBlock textBlock)
     {
         var lines = new List<string>();
-        if (string.IsNullOrEmpty(mRawText))
+        // The TextBlock is built from the tag-stripped, CRLF-normalized layout text when the RawText
+        // carries BBCode markup (issue #3679); for plain text _layoutText is mRawText verbatim. Either
+        // way RichTextKit's TextLine.Start/Length are code-point indices into that exact string, so
+        // index into it rather than mRawText (which still holds the markup).
+        var source = _layoutText;
+        if (string.IsNullOrEmpty(source))
         {
             return lines;
         }
 
-        // RichTextKit's TextLine.Start/Length are code-point indices into the text that was
-        // added to the TextBlock. GetTextBlock adds mRawText verbatim (no CRLF normalization),
-        // so index directly into mRawText rather than a normalized copy.
         foreach (var line in textBlock.Lines)
         {
-            if (line.Start + line.Length <= mRawText.Length)
+            if (line.Start + line.Length <= source.Length)
             {
-                lines.Add(mRawText.Substring(line.Start, line.Length));
+                lines.Add(source.Substring(line.Start, line.Length));
             }
         }
 
@@ -434,7 +437,15 @@ public class Text : IRenderableIpso, IVisible, IFormsText, ICloneable
 
     Vector2 Position;
     IRenderableIpso? mParent;
-    public string? StoredMarkupText => null;
+
+    /// <summary>
+    /// The original BBCode / markup string assigned to <see cref="RawText"/> when it contained inline
+    /// styling tags, or null when the assigned text was plain. Mirrors the MonoGame/Raylib Text's
+    /// property so shared code can re-parse markup after a font change. Unlike those backends (which
+    /// strip the tags out of <see cref="RawText"/>), SkiaGum keeps the markup in <see cref="RawText"/>
+    /// and strips it lazily when building the RichTextKit <c>TextBlock</c> (issue #3679).
+    /// </summary>
+    public string? StoredMarkupText => _hasMarkup ? mRawText : null;
 
     public IRenderableIpso? Parent
     {
@@ -564,6 +575,7 @@ public class Text : IRenderableIpso, IVisible, IFormsText, ICloneable
             if (mRawText != value)
             {
                 mRawText = value;
+                ParseMarkup();
                 _cachedTextBlock = null;
 
                 //UpdateWrappedText();
@@ -763,6 +775,31 @@ public class Text : IRenderableIpso, IVisible, IFormsText, ICloneable
     private TextBlock? _wrappedTextSourceBlock;
     private List<string> _cachedWrappedTextList = new();
 
+    // BBCode inline-styling state (issue #3679). Parsed from mRawText whenever it changes:
+    // _hasMarkup is true when the text contains at least one recognized tag, _layoutText is the
+    // tag-stripped (and CRLF-normalized) text the RichTextKit TextBlock is built from, and
+    // _inlineVariables are the per-character styling directives fed to the shared splitter. For
+    // plain text _hasMarkup is false and _layoutText == mRawText, keeping the render path unchanged.
+    private bool _hasMarkup;
+    private string? _layoutText;
+    private List<InlineVariable> _inlineVariables = new();
+    private readonly StyledSubstringSplitter _styledSubstringSplitter = new();
+
+    // The subset of BbCodeParser.KnownTags SkiaGum honors as RichTextKit Style overrides. Font family
+    // ("font"), outline, and custom per-letter callbacks are intentionally excluded (see the PR's
+    // deferred scope); unrecognized tags are left as literal characters, matching the parser.
+    private static readonly HashSet<string> SupportedTags = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "color",
+        "red",
+        "green",
+        "blue",
+        "fontsize",
+        "fontscale",
+        "isbold",
+        "isitalic",
+    };
+
     public TextBlock GetCachedTextBlock(float? forcedWidth = null)
     {
         var effectiveWidth = forcedWidth ?? this.Width;
@@ -798,19 +835,35 @@ public class Text : IRenderableIpso, IVisible, IFormsText, ICloneable
             ? Height
             : (float?)null;
 
-    public TextBlock GetTextBlock(float? forcedWidth = null) => GetTextBlock(mRawText, forcedWidth);
+    public TextBlock GetTextBlock(float? forcedWidth = null) => GetTextBlock(mRawText, forcedWidth, allowMarkup: true);
 
     /// <summary>
     /// Builds a RichTextKit <c>TextBlock</c> for the given text (normally <see cref="RawText"/>, but
     /// <see cref="GetPaintTextBlock"/> passes the reveal-truncated text for <see cref="MaxLettersToShow"/>).
     /// </summary>
-    private TextBlock GetTextBlock(string textToRender, float? forcedWidth)
+    /// <param name="textToRender">The text to lay out. Ignored when <paramref name="allowMarkup"/> is
+    /// true and the RawText carries BBCode -- the parsed <see cref="_layoutText"/> / styled runs are
+    /// used instead.</param>
+    /// <param name="allowMarkup">When true, BBCode inline styling (issue #3679) is honored by adding
+    /// one styled run per <see cref="StyledSubstring"/>. When false (the <see cref="MaxLettersToShow"/>
+    /// reveal path), the text is added as a single unstyled run.</param>
+    private TextBlock GetTextBlock(string textToRender, float? forcedWidth, bool allowMarkup)
     {
         var textBlock = new TextBlock();
         try
         {
             textBlock.MaxWidth = forcedWidth ?? this.Width;
-            textBlock.AddText(textToRender, GetStyle());
+            if (allowMarkup && _hasMarkup)
+            {
+                foreach (var run in GetStyledRuns())
+                {
+                    textBlock.AddText(run.Text, run.Style);
+                }
+            }
+            else
+            {
+                textBlock.AddText(textToRender, GetStyle());
+            }
             switch (HorizontalAlignment)
             {
                 case HorizontalAlignment.Left:
@@ -884,19 +937,119 @@ public class Text : IRenderableIpso, IVisible, IFormsText, ICloneable
             return fullBlock;
         }
 
-        return GetTextBlock(string.Join("\n", GetVisibleWrappedText()), this.Width);
+        // The reveal text is already tag-stripped (it comes from WrappedText), so no markup path:
+        // per-run styling in the typewriter reveal is a documented deferral (issue #3679).
+        return GetTextBlock(string.Join("\n", GetVisibleWrappedText()), this.Width, allowMarkup: false);
     }
 
 
-    internal Style GetStyle()
+    internal Style GetStyle() => BuildRunStyle(null);
+
+    /// <summary>
+    /// A single run of text plus the RichTextKit <see cref="Style"/> it is drawn with. Produced by
+    /// <see cref="GetStyledRuns"/> from BBCode markup (issue #3679) and fed to the TextBlock one
+    /// <c>AddText</c> call per run so a line can carry mixed per-run color / size / weight / italic.
+    /// </summary>
+    internal readonly struct StyledTextRun
     {
+        public readonly string Text;
+        public readonly Style Style;
+
+        public StyledTextRun(string text, Style style)
+        {
+            Text = text;
+            Style = style;
+        }
+    }
+
+    /// <summary>
+    /// Splits the text into styled runs according to the inline BBCode variables parsed from the markup
+    /// (issue #3679). Plain text (or text with no recognized tags) yields a single run carrying the base
+    /// <see cref="GetStyle"/>, so the non-markup path is unchanged. Exposed internally for unit testing.
+    /// </summary>
+    internal List<StyledTextRun> GetStyledRuns()
+    {
+        var runs = new List<StyledTextRun>();
+
+        if (!_hasMarkup || string.IsNullOrEmpty(_layoutText))
+        {
+            runs.Add(new StyledTextRun(_hasMarkup ? _layoutText : mRawText, GetStyle()));
+            return runs;
+        }
+
+        var substrings = _styledSubstringSplitter.GetStyledSubstrings(0, _layoutText, _inlineVariables);
+        if (substrings.Count == 0)
+        {
+            runs.Add(new StyledTextRun(_layoutText, GetStyle()));
+            return runs;
+        }
+
+        foreach (var substring in substrings)
+        {
+            runs.Add(new StyledTextRun(substring.Substring, BuildRunStyle(substring.Variables)));
+        }
+
+        return runs;
+    }
+
+    /// <summary>
+    /// Builds the RichTextKit <see cref="Style"/> for one run: the base font/color/weight/italic from
+    /// this Text's properties, overridden by the run's inline BBCode <paramref name="variables"/>
+    /// (Color / Red / Green / Blue, FontSize, FontScale, IsBold, IsItalic). A null or empty
+    /// <paramref name="variables"/> reproduces <see cref="GetStyle"/> exactly.
+    /// </summary>
+    private Style BuildRunStyle(List<InlineVariable>? variables)
+    {
+        var color = this.Color;
+        int fontSizePixels = FontSize;
+        float fontScale = FontScale;
+        bool italic = this.IsItalic;
+        int weight = (int)(400 * BoldWeight);
+
+        if (variables != null)
+        {
+            foreach (var variable in variables)
+            {
+                switch (variable.VariableName)
+                {
+                    case "Color":
+                        if (variable.Value is System.Drawing.Color drawingColor)
+                        {
+                            color = new SKColor(drawingColor.R, drawingColor.G, drawingColor.B, drawingColor.A);
+                        }
+                        break;
+                    case "Red":
+                        color = new SKColor((byte)variable.Value, color.Green, color.Blue, color.Alpha);
+                        break;
+                    case "Green":
+                        color = new SKColor(color.Red, (byte)variable.Value, color.Blue, color.Alpha);
+                        break;
+                    case "Blue":
+                        color = new SKColor(color.Red, color.Green, (byte)variable.Value, color.Alpha);
+                        break;
+                    case "FontSize":
+                        fontSizePixels = (int)variable.Value;
+                        break;
+                    case "FontScale":
+                        fontScale = (float)variable.Value;
+                        break;
+                    case "IsBold":
+                        weight = (bool)variable.Value ? 700 : (int)(400 * BoldWeight);
+                        break;
+                    case "IsItalic":
+                        italic = (bool)variable.Value;
+                        break;
+                }
+            }
+        }
+
         var style = new Style()
         {
             FontFamily = FontName,
-            FontSize = FontSize * (float)GlobalTextScale * FontScale,
-            TextColor = this.Color,
-            FontItalic = this.IsItalic,
-            FontWeight = (int)(400 * BoldWeight),
+            FontSize = fontSizePixels * (float)GlobalTextScale * fontScale,
+            TextColor = color,
+            FontItalic = italic,
+            FontWeight = weight,
             LineHeight = LineHeightMultiplier
         };
 
@@ -907,6 +1060,135 @@ public class Text : IRenderableIpso, IVisible, IFormsText, ICloneable
         }
 
         return style;
+    }
+
+    /// <summary>
+    /// Re-parses <see cref="mRawText"/> into BBCode inline-styling state (issue #3679): sets
+    /// <see cref="_hasMarkup"/>, the tag-stripped <see cref="_layoutText"/> the TextBlock is built from,
+    /// and <see cref="_inlineVariables"/>. Plain text (no recognized tags) leaves _layoutText equal to
+    /// mRawText so the render/measure path is byte-for-byte unchanged. Called whenever RawText changes.
+    /// </summary>
+    private void ParseMarkup()
+    {
+        _inlineVariables.Clear();
+
+        if (string.IsNullOrEmpty(mRawText) || mRawText.IndexOf('[') < 0)
+        {
+            _hasMarkup = false;
+            _layoutText = mRawText;
+            return;
+        }
+
+        // The rendering/wrapping code ignores '\r', so normalize CRLF to LF before computing indexes,
+        // mirroring the MonoGame/Raylib SetBbCodeText path. Parsing and stripping from the same
+        // normalized string keeps InlineVariable indexes aligned with the layout text.
+        var normalized = mRawText.Replace("\r\n", "\n");
+        var tags = BbCodeParser.Parse(normalized, SupportedTags);
+        if (tags.Count == 0)
+        {
+            _hasMarkup = false;
+            _layoutText = mRawText;
+            return;
+        }
+
+        _hasMarkup = true;
+        _layoutText = BbCodeParser.RemoveTags(normalized, tags);
+        BuildInlineVariables(tags);
+    }
+
+    /// <summary>
+    /// Converts the parsed BBCode <paramref name="tags"/> into <see cref="_inlineVariables"/> keyed by
+    /// their character range in the stripped <see cref="_layoutText"/>. Each supported tag maps to a
+    /// value the shared <see cref="StyledSubstringSplitter"/> and <see cref="BuildRunStyle"/> understand:
+    /// Color -> System.Drawing.Color, Red/Green/Blue -> byte, FontSize -> int, FontScale -> float,
+    /// IsBold/IsItalic -> bool. Tags whose argument fails to parse are skipped (rendered with base style).
+    /// </summary>
+    private void BuildInlineVariables(List<FoundTag> tags)
+    {
+        foreach (var tag in tags)
+        {
+            var argument = tag.Open.Argument;
+            string variableName;
+            object? value;
+
+            switch (tag.Name.ToLowerInvariant())
+            {
+                case "color":
+                    variableName = "Color";
+                    value = ParseColor(argument);
+                    break;
+                case "red":
+                    variableName = "Red";
+                    value = byte.TryParse(argument, out var red) ? red : (byte?)null;
+                    break;
+                case "green":
+                    variableName = "Green";
+                    value = byte.TryParse(argument, out var green) ? green : (byte?)null;
+                    break;
+                case "blue":
+                    variableName = "Blue";
+                    value = byte.TryParse(argument, out var blue) ? blue : (byte?)null;
+                    break;
+                case "fontsize":
+                    variableName = "FontSize";
+                    value = int.TryParse(argument, NumberStyles.Integer, CultureInfo.InvariantCulture, out var size)
+                        ? size
+                        : (int?)null;
+                    break;
+                case "fontscale":
+                    variableName = "FontScale";
+                    value = float.TryParse(argument, NumberStyles.Float, CultureInfo.InvariantCulture, out var scale)
+                        ? scale
+                        : (float?)null;
+                    break;
+                case "isbold":
+                    variableName = "IsBold";
+                    value = bool.TryParse(argument, out var bold) ? bold : (bool?)null;
+                    break;
+                case "isitalic":
+                    variableName = "IsItalic";
+                    value = bool.TryParse(argument, out var italic) ? italic : (bool?)null;
+                    break;
+                default:
+                    continue;
+            }
+
+            if (value == null)
+            {
+                continue;
+            }
+
+            _inlineVariables.Add(new InlineVariable
+            {
+                VariableName = variableName,
+                StartIndex = tag.Open.StartStrippedIndex,
+                CharacterCount = tag.Close.StartStrippedIndex - tag.Open.StartStrippedIndex,
+                Value = value,
+            });
+        }
+    }
+
+    /// <summary>
+    /// Parses a <c>[Color=..]</c> argument, honoring both a hex form (<c>0xAARRGGBB</c>) and a named
+    /// color (<c>Red</c>, <c>CornflowerBlue</c>, ...), matching the MonoGame/Raylib SetBbCodeText parsing.
+    /// Returns null (run keeps the base color) when the argument is empty or unrecognized.
+    /// </summary>
+    private static System.Drawing.Color? ParseColor(string? argument)
+    {
+        if (string.IsNullOrEmpty(argument))
+        {
+            return null;
+        }
+
+        if (argument.StartsWith("0x") &&
+            int.TryParse(argument.Substring(2), NumberStyles.AllowHexSpecifier, CultureInfo.InvariantCulture, out int hex))
+        {
+            return System.Drawing.Color.FromArgb(hex);
+        }
+
+        var named = System.Drawing.Color.FromName(argument);
+        // FromName returns a non-known color with ARGB 0 for an unrecognized name; treat that as "no color".
+        return named.IsKnownColor ? named : (System.Drawing.Color?)null;
     }
 
     /// <summary>
@@ -1025,6 +1307,9 @@ public class Text : IRenderableIpso, IVisible, IFormsText, ICloneable
         newInstance.mParent = null;
         newInstance.mChildren = new();
         newInstance._cachedTextBlock = null;
+        // MemberwiseClone shares the list reference; give the clone its own copy so re-parsing markup
+        // on one instance (via RawText) doesn't mutate the other's inline-styling runs (issue #3679).
+        newInstance._inlineVariables = new List<InlineVariable>(_inlineVariables);
 
         return newInstance;
     }

--- a/Runtimes/SkiaGum/SkiaGum.csproj
+++ b/Runtimes/SkiaGum/SkiaGum.csproj
@@ -42,6 +42,9 @@
 		<Compile Include="..\..\RenderingLibrary\Graphics\Animation\AnimationFrame.cs" Link="Animation\AnimationFrame.cs" />
 		<Compile Include="..\..\RenderingLibrary\Graphics\Animation\AnimationChainLogic.cs" Link="Animation\AnimationChainLogic.cs" />
 		<Compile Include="..\..\RenderingLibrary\Graphics\Animation\SpriteAnimationLogic.cs" Link="Animation\SpriteAnimationLogic.cs" />
+		<!-- Shared markup model + run-splitter (InlineVariable, StyledSubstring, StyledSubstringSplitter)
+		     so Skia's Text can render BBCode inline styling without reimplementing the split (#3679). -->
+		<Compile Include="..\..\RenderingLibrary\Graphics\StyledSubstringSplitter.cs" Link="RenderingLibrary\StyledSubstringSplitter.cs" />
 		<!--
 		  IAnimatable is file-linked into GumCommon (GumCommon.csproj line 89) and arrives
 		  here via the GumCommon ProjectReference below. Compiling it locally too produced two

--- a/Samples/SilkNetGum/SilkNetGum/Screens/TextScreen.cs
+++ b/Samples/SilkNetGum/SilkNetGum/Screens/TextScreen.cs
@@ -75,6 +75,30 @@ internal class TextScreen : FrameworkElement
         AddOverflowSection(container);
 
         AddMaxLettersToShowSection(container);
+
+        AddBbCodeSection(container);
+    }
+
+    // BBCode inline styling on the SkiaGum.Text renderable (#3679): a single Text whose markup mixes
+    // per-run color, font size, font scale, bold, and italic. SkiaGum parses the tags and feeds
+    // RichTextKit one Style per run (Text.GetStyledRuns), matching the MonoGame / Raylib inline-styling
+    // path. Font = "Arial" because text can silently no-op without a font. No MonoGameGumInCode mirror —
+    // this exercises the SkiaGum inline-styling path directly.
+    private static void AddBbCodeSection(ContainerRuntime container)
+    {
+        AddSectionLabel(container,
+            "BBCode inline styling (#3679): per-run color / font size / font scale / bold / italic in one Text:");
+
+        TextRuntime markup = new TextRuntime();
+        markup.Font = "Arial";
+        markup.FontSize = 24;
+        markup.WidthUnits = Gum.DataTypes.DimensionUnitType.Absolute;
+        markup.Width = 520;
+        markup.Text =
+            "Plain, [Color=Red]red[/Color], [Color=CornflowerBlue]blue[/Color], " +
+            "[FontSize=40]big[/FontSize], [FontScale=1.5]scaled[/FontScale], " +
+            "[IsBold=true]bold[/IsBold], and [IsItalic=true]italic[/IsItalic] runs.";
+        container.Children.Add(markup);
     }
 
     // MaxLettersToShow typewriter reveal on the SkiaGum.Text renderable (#3678). The same wrapping

--- a/Tests/SkiaGum.Tests/Renderables/TextBbCodeTests.cs
+++ b/Tests/SkiaGum.Tests/Renderables/TextBbCodeTests.cs
@@ -1,0 +1,131 @@
+using Shouldly;
+using SkiaGum;
+using SkiaSharp;
+using System.Collections.Generic;
+using System.Linq;
+using Topten.RichTextKit;
+
+namespace SkiaGum.Tests.Renderables;
+
+/// <summary>
+/// Verifies that SkiaGum's <see cref="Text"/> honors inline BBCode styling (issue #3679) by parsing
+/// the markup into styled runs and feeding RichTextKit one <see cref="Style"/> per run, matching the
+/// per-run color / font-size / font-scale / bold / italic styling the MonoGame and Raylib backends
+/// already support. Plain (no-markup) text must remain a single-run fast path.
+/// </summary>
+public class TextBbCodeTests
+{
+    private static Text MakeText()
+    {
+        Text text = new();
+        text.FontName = "Arial";
+        text.FontSize = 20;
+        text.Width = 1000;
+        text.Color = SKColors.Black;
+        return text;
+    }
+
+    [Fact]
+    public void GetStyledRuns_BoldTag_ProducesBoldRun()
+    {
+        Text text = MakeText();
+        text.RawText = "plain [IsBold=true]bold[/IsBold] plain";
+
+        List<Text.StyledTextRun> runs = text.GetStyledRuns();
+
+        runs.Single(r => r.Text == "bold").Style.FontWeight.ShouldBe(700);
+        runs.First(r => r.Text.StartsWith("plain")).Style.FontWeight.ShouldBe(400);
+    }
+
+    [Fact]
+    public void GetStyledRuns_ColorTag_ProducesRunWithParsedColor()
+    {
+        Text text = MakeText();
+        text.RawText = "plain [Color=Red]red[/Color] plain";
+
+        List<Text.StyledTextRun> runs = text.GetStyledRuns();
+
+        runs.Single(r => r.Text == "red").Style.TextColor.ShouldBe(new SKColor(255, 0, 0, 255));
+        runs.First(r => r.Text.StartsWith("plain")).Style.TextColor.ShouldBe(SKColors.Black);
+    }
+
+    [Fact]
+    public void GetStyledRuns_FontScaleTag_ScalesRunFontSize()
+    {
+        Text text = MakeText();
+        float baseFontSize = text.GetStyle().FontSize;
+        text.RawText = "plain [FontScale=2]big[/FontScale] plain";
+
+        List<Text.StyledTextRun> runs = text.GetStyledRuns();
+
+        runs.Single(r => r.Text == "big").Style.FontSize.ShouldBe(baseFontSize * 2);
+    }
+
+    [Fact]
+    public void GetStyledRuns_FontSizeTag_OverridesRunFontSize()
+    {
+        Text text = MakeText();
+        // Base FontSize is 20, so [FontSize=40] is exactly double once the shared
+        // GlobalTextScale / FontScale factors (identical between base and run) cancel out.
+        float baseFontSize = text.GetStyle().FontSize;
+        text.RawText = "plain [FontSize=40]big[/FontSize] plain";
+
+        List<Text.StyledTextRun> runs = text.GetStyledRuns();
+
+        runs.Single(r => r.Text == "big").Style.FontSize.ShouldBe(baseFontSize * 2);
+    }
+
+    [Fact]
+    public void GetStyledRuns_ItalicTag_ProducesItalicRun()
+    {
+        Text text = MakeText();
+        text.RawText = "plain [IsItalic=true]slanted[/IsItalic] plain";
+
+        List<Text.StyledTextRun> runs = text.GetStyledRuns();
+
+        runs.Single(r => r.Text == "slanted").Style.FontItalic.ShouldBeTrue();
+        runs.First(r => r.Text.StartsWith("plain")).Style.FontItalic.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GetStyledRuns_PlainText_ProducesSingleUnchangedRun()
+    {
+        Text text = MakeText();
+        text.RawText = "just plain text";
+
+        List<Text.StyledTextRun> runs = text.GetStyledRuns();
+
+        runs.Count.ShouldBe(1);
+        runs[0].Text.ShouldBe("just plain text");
+    }
+
+    [Fact]
+    public void GetTextBlock_BbCodeColor_ProducesMultipleFontRuns()
+    {
+        Text text = MakeText();
+        text.RawText = "plain [Color=Red]red[/Color] plain";
+
+        TextBlock block = text.GetTextBlock();
+
+        block.FontRuns.Select(r => r.Style.TextColor).Distinct().Count().ShouldBeGreaterThan(1);
+        block.FontRuns.Any(r => r.Style.TextColor == new SKColor(255, 0, 0, 255)).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void StoredMarkupText_IsNull_WhenPlainText()
+    {
+        Text text = MakeText();
+        text.RawText = "just plain text";
+
+        text.StoredMarkupText.ShouldBeNull();
+    }
+
+    [Fact]
+    public void StoredMarkupText_ReturnsMarkup_WhenTagsPresent()
+    {
+        Text text = MakeText();
+        text.RawText = "plain [Color=Red]red[/Color] plain";
+
+        text.StoredMarkupText.ShouldBe("plain [Color=Red]red[/Color] plain");
+    }
+}


### PR DESCRIPTION
Largest item in the Skia text-parity epic (#3672); the five siblings (#3674 shadow, #3675 outline, #3676 blend, #3677 overflow, #3678 max-letters) are already merged.

## Problem
SkiaGum's `Text` rendered `RawText` literally through a single RichTextKit `Style`, so inline BBCode (`[Color=..]`, `[FontSize=..]`, `[FontScale]`, `[IsBold]`, `[IsItalic]`) showed up as literal characters — unlike the XNA-like and raylib backends, which honor inline styling.

## Approach
Parse the markup and feed RichTextKit one styled run at a time, reusing the existing shared infrastructure — no new parser:
- `GumRuntime/BbCodeParser.cs` parses + strips the tags.
- `RenderingLibrary/Graphics/StyledSubstringSplitter.cs` (`InlineVariable` / `StyledSubstring`) splits the stripped text into runs by active variables — the same split the MonoGame/raylib renderers consume.
- SkiaGum's `Text` builds one RichTextKit `Style` per run (base `GetStyle()` overridden by the run's variables) and does one `AddText(run, style)` per run in `GetTextBlock`.

Parsing happens lazily off `RawText` (`ParseMarkup`): plain text (no `[` or no recognized tag) takes an unchanged single-`AddText` fast path.

## Scope — honored vs deferred
**Honored (per-run):** `Color` (named + `0x` hex), `Red`/`Green`/`Blue`, `FontSize`, `FontScale`, `IsBold`, `IsItalic`. Each maps cleanly to a RichTextKit `Style` field (`TextColor` / `FontSize` / `FontWeight` / `FontItalic`).

**Deferred (documented, not half-wired):**
- **Font family (`[Font=..]`), outline, and `[Custom]` per-letter callbacks** — left out of the supported-tag set; unrecognized tags render as literal characters (same as any unknown tag). Font-family and outline are trivial follow-ups if wanted; `[Custom]` is a larger per-letter effort.
- **Inline per-run drop shadow / outline** — the #3674/#3675 primitives are whole-`Text`, not per-run; not pursued here.
- **Per-run styling during a `MaxLettersToShow` typewriter reveal** — the reveal repaints from the tag-stripped `WrappedText`, so revealed text is unstyled (still better than the old literal-markup behavior). BBCode + typewriter together is the DialogBox case; flagged for a follow-up.

## StoredMarkupText / WrappedText / caret
- `StoredMarkupText` now returns the markup when tags are present (was hard-coded `null`).
- Unlike MonoGame/raylib (which strip tags out of `RawText`), SkiaGum keeps the markup in `RawText` and strips lazily; `WrappedText` / `BuildWrappedTextList` now index into the tag-stripped **layout** text so the non-BBCode caret/measurement path the merged siblings depend on is preserved. A plain string is a zero-behavior-change fast path.
- **Limitation:** for BBCode text, `WrappedText` returns tag-stripped lines whose indices do **not** map back to positions in the markup string, so caret-index editing of BBCode text is not supported. BBCode is intended for labels/dialog, not editable text boxes.

## Cross-backend
No XNA/raylib behavior changed. The stale "no separate markup path" comment in the Skia dispatcher (`CustomSetPropertyOnRenderable`) is updated.

## Build/link plumbing
`StyledSubstringSplitter.cs` was compiled per-backend (MonoGame/KNI/FNA/raylib) but not into SkiaGum. Added the file-link to `SkiaGum.csproj` and `SilkNetGum.csproj` (SilkNet file-links SkiaGum sources rather than referencing the project), mirroring the raylib link. FRB already gets it via `GumCoreShared.projitems` (SkiaGum is not part of FRB).

## Tests
`Tests/SkiaGum.Tests/Renderables/TextBbCodeTests.cs` — 9 tests: per-run color / font-size / font-scale / bold / italic, plain-text single run unchanged, a `GetTextBlock` integration check (multiple `FontRun`s), and `StoredMarkupText` presence/absence. Full SkiaGum suite green (283).

## Manual test
Needed (visual). SilkNet `TextScreen` gains a BBCode section (`Font = "Arial"`): one `Text` mixing `[Color]`/`[FontSize]`/`[FontScale]`/`[IsBold]`/`[IsItalic]` runs. Build only — not run here.

Closes #3679

🤖 Generated with [Claude Code](https://claude.com/claude-code)
