### PR TITLE
Add KernSmith skill and pin Camera zoom/translation math

### DIFF
--- a/.claude/skills/gum-kernsmith-integrations/SKILL.md
+++ b/.claude/skills/gum-kernsmith-integrations/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: gum-kernsmith-integrations
+description: KernSmith runtime bitmap-font packages. Triggers: Integrations/KernSmith, KernSmith.MonoGameGum, KernSmith.RaylibGum, KernSmith.KniGum, KernSmith.FnaGum, KernSmith.GumCommon, InMemoryFontCreator.
+---
+
+# KernSmith Integrations
+
+[KernSmith](https://github.com/kaltinril/KernSmith) is a third-party, cross-platform, in-memory BMFont rasterizer. `Integrations/KernSmith/*` are optional first-party Gum packages that bridge it into each runtime — this is unrelated to the tool's `bmfont.exe`-based generation pipeline (see `gum-tool-font-generation`).
+
+## Package map
+
+| Package | Role |
+|---|---|
+| `KernSmith.GumCommon` | Shared mapping layer: Gum's `BmfcSave` → KernSmith's `FontGeneratorOptions` |
+| `KernSmith.MonoGameGum` | MonoGame `IRuntimeFontCreator`-style wiring, produces `BitmapFont` |
+| `KernSmith.KniGum` / `KernSmith.FnaGum` | Same shape, KNI/FNA targets |
+| `KernSmith.RaylibGum` | `KernSmithRaylibFontCreator`, produces `Raylib_cs.Font` |
+
+Each platform package plugs into `CustomSetPropertyOnRenderable.InMemoryFontCreator` (a game project sets this at startup) so Gum rasterizes fonts on the fly instead of loading pre-generated `.fnt`/`.png` files.
+
+## Gotcha
+
+These are opt-in NuGet add-ons a *game project* references directly — Gum does not wire one up by default. If `InMemoryFontCreator` is never set, Gum falls back to the tool's pre-generated bmfont.exe pipeline. Seeing a `KernSmith.*` package reference alongside `Gum.MonoGame`/etc. in a user's `.csproj` is expected, not a conflicting fork.
+
+See `docs/code/files-and-fonts/font-strategies.md` for the user-facing font strategy comparison.

--- a/MonoGameGum.Tests/RenderingLibraries/CameraTests.cs
+++ b/MonoGameGum.Tests/RenderingLibraries/CameraTests.cs
@@ -352,4 +352,86 @@ public class CameraTests : BaseTestClass
         screenX.ShouldBe(100);
         screenY.ShouldBe(150);
     }
+
+    // The tests above only prove GetTransformationMatrix round-trips through its own inverse
+    // (SetFromMatrix) or through ScreenToWorld/WorldToScreen. A self-consistent-but-wrong formula
+    // (e.g. a sign flip or a scale error that cancels itself out under inversion) would pass all of
+    // them. These pin the actual matrix values against independently hand-computed numbers instead.
+
+    [Fact]
+    public void GetTransformationMatrix_TopLeftMode_ScalesByZoom()
+    {
+        // TopLeft, X=Y=0 isolates the scale terms from the translation math below.
+        Camera _sut = new Camera();
+        _sut.ClientWidth = 800;
+        _sut.ClientHeight = 600;
+        _sut.CameraCenterOnScreen = CameraCenterOnScreen.TopLeft;
+        _sut.X = 0;
+        _sut.Y = 0;
+        _sut.Zoom = 4; // mirrors the MonoGame tutorial's "zoom in 4x on a quarter-size canvas" setup
+
+        Matrix4x4 matrix = _sut.GetTransformationMatrix();
+
+        matrix.M11.ShouldBe(4);
+        matrix.M22.ShouldBe(4);
+    }
+
+    [Fact]
+    public void GetTransformationMatrix_TopLeftMode_TranslationIsCameraPositionScaledByZoom()
+    {
+        // TopLeft mode composes as Translate(-X,-Y) * Scale(Zoom), so the translation stored in the
+        // resulting matrix is -X*Zoom / -Y*Zoom, not just -X/-Y. Values chosen to divide evenly so
+        // the ((int)(x*zoom))/zoom truncation inside GetTransformationMatrix is a no-op.
+        Camera _sut = new Camera();
+        _sut.ClientWidth = 800;
+        _sut.ClientHeight = 600;
+        _sut.CameraCenterOnScreen = CameraCenterOnScreen.TopLeft;
+        _sut.X = 10;
+        _sut.Y = 20;
+        _sut.Zoom = 4;
+
+        Matrix4x4 matrix = _sut.GetTransformationMatrix();
+
+        matrix.M11.ShouldBe(4);
+        matrix.M22.ShouldBe(4);
+        matrix.M41.ShouldBe(-40); // -X * Zoom
+        matrix.M42.ShouldBe(-80); // -Y * Zoom
+    }
+
+    [Fact]
+    public void GetTransformationMatrix_CenterMode_TranslationIncludesClientCenterOffset()
+    {
+        // Center mode additionally bakes in a translation by (ClientWidth/2, ClientHeight/2) — but
+        // only when !RendererSettings.UsingEffect (see Camera.GetTransformationMatrix's UsingEffect
+        // branch). UseBasicEffectRendering defaults to true, which makes UsingEffect true and skips
+        // the center-translation branch entirely, so it must be forced false here (restored after)
+        // for this test to actually exercise the center-offset math instead of silently degrading to
+        // the same formula as TopLeft mode.
+        bool _previousUseBasicEffect = RenderingLibrary.Graphics.RendererSettings.UseBasicEffectRendering;
+        try
+        {
+            RenderingLibrary.Graphics.RendererSettings.UseBasicEffectRendering = false;
+
+            // Even ClientWidth/Height avoids the odd-dimension half-pixel adjustment branch so this
+            // pins the core formula in isolation.
+            Camera _sut = new Camera();
+            _sut.ClientWidth = 800;
+            _sut.ClientHeight = 600;
+            _sut.CameraCenterOnScreen = CameraCenterOnScreen.Center;
+            _sut.X = 100;
+            _sut.Y = 50;
+            _sut.Zoom = 2;
+
+            Matrix4x4 matrix = _sut.GetTransformationMatrix();
+
+            matrix.M11.ShouldBe(2);
+            matrix.M22.ShouldBe(2);
+            matrix.M41.ShouldBe(200); // ClientWidth/2 (400) - X*Zoom (200)
+            matrix.M42.ShouldBe(200); // ClientHeight/2 (300) - Y*Zoom (100)
+        }
+        finally
+        {
+            RenderingLibrary.Graphics.RendererSettings.UseBasicEffectRendering = _previousUseBasicEffect;
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Adds `.claude/skills/gum-kernsmith-integrations/SKILL.md` documenting the first-party `Integrations/KernSmith/*` runtime bitmap-font packages, so they're not mistaken for a conflicting third-party fork (this came up while diagnosing a zoom-not-working report).
- Backfills `CameraTests.cs` with 3 tests that pin `Camera.GetTransformationMatrix()`'s actual scale/translation values for known zoom/position inputs. Existing tests only proved round-trip consistency (`SetFromMatrix`, `ScreenToWorld`/`WorldToScreen`) — a self-consistent-but-wrong formula would still pass those. Verified the new tests catch a real regression by temporarily flipping a translation sign in `Camera.cs` and confirming they go red, then reverted.

Test-only + skill change — no production behavior modified.

## Test plan
- [x] `dotnet test MonoGameGum.Tests/MonoGameGum.Tests.csproj --filter "CameraTests"` — 15/15 green
- [x] Sanity mutation (sign flip) confirmed the new tests are non-vacuous, then reverted

Manual test: not needed — test-only change, covered by unit tests.