### PR TITLE
Anchor custom shader probe to app base directory, not working directory (#3694)

### DIFF
--- a/MonoGameGum.Tests/RenderingLibraries/CustomEffectManagerTests.cs
+++ b/MonoGameGum.Tests/RenderingLibraries/CustomEffectManagerTests.cs
@@ -1,0 +1,60 @@
+using System;
+using System.IO;
+using RenderingLibrary.Graphics;
+using Shouldly;
+using Xunit;
+
+namespace MonoGameGum.Tests.RenderingLibraries;
+
+/// <summary>
+/// Unit tests for <see cref="CustomEffectManager.CustomShaderFileExists"/>, the optional
+/// custom-shader probe. The probe must resolve relative to the app base directory (where the
+/// content actually ships) rather than the process working directory — launching an app via a
+/// Windows file association sets the working directory to the opened file's folder, which
+/// previously caused the probe to miss a shipped Content/Shader.xnb (#3694).
+/// </summary>
+public class CustomEffectManagerTests : BaseTestClass
+{
+    [Fact]
+    public void CustomShaderFileExists_FindsShaderRelativeToBaseDirectory_WhenWorkingDirectoryDiffers()
+    {
+        string baseDirectory = Path.Combine(Path.GetTempPath(), "gum_3694_base_" + Guid.NewGuid().ToString("N"));
+        string workingDirectory = Path.Combine(Path.GetTempPath(), "gum_3694_cwd_" + Guid.NewGuid().ToString("N"));
+        string originalWorkingDirectory = Directory.GetCurrentDirectory();
+
+        try
+        {
+            Directory.CreateDirectory(Path.Combine(baseDirectory, "Content"));
+            File.WriteAllText(Path.Combine(baseDirectory, "Content", "Shader.xnb"), "dummy");
+
+            // Simulate a file-association launch: the working directory is NOT where the app shipped.
+            Directory.CreateDirectory(workingDirectory);
+            Directory.SetCurrentDirectory(workingDirectory);
+
+            CustomEffectManager.CustomShaderFileExists(baseDirectory).ShouldBeTrue();
+        }
+        finally
+        {
+            Directory.SetCurrentDirectory(originalWorkingDirectory);
+            Directory.Delete(baseDirectory, recursive: true);
+            Directory.Delete(workingDirectory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void CustomShaderFileExists_ReturnsFalse_WhenNoShaderShippedInBaseDirectory()
+    {
+        string baseDirectory = Path.Combine(Path.GetTempPath(), "gum_3694_noshader_" + Guid.NewGuid().ToString("N"));
+
+        try
+        {
+            Directory.CreateDirectory(baseDirectory);
+
+            CustomEffectManager.CustomShaderFileExists(baseDirectory).ShouldBeFalse();
+        }
+        finally
+        {
+            Directory.Delete(baseDirectory, recursive: true);
+        }
+    }
+}

--- a/RenderingLibrary/Graphics/Renderer.cs
+++ b/RenderingLibrary/Graphics/Renderer.cs
@@ -1858,6 +1858,14 @@ public class CustomEffectManager
 
     static ContentManager mContentManager;
 
+    // The optional custom shader is probed for existence to avoid a noisy load exception when
+    // no shader ships. The path must be anchored to baseDirectory (the app base directory, where
+    // ContentManager loads title-relative content from) and NOT the process working directory:
+    // launching via a Windows file association sets the working directory to the opened file's
+    // folder, which made a working-directory-relative probe miss a shipped Content/Shader.xnb (#3694).
+    internal static bool CustomShaderFileExists(string baseDirectory) =>
+        System.IO.File.Exists(System.IO.Path.Combine(baseDirectory, "Content", "Shader.xnb"));
+
     public void Initialize(GraphicsDevice graphicsDevice)
     {
         if (mContentManager == null)
@@ -1877,7 +1885,7 @@ public class CustomEffectManager
             || OperatingSystem.IsLinux()
             || OperatingSystem.IsMacOS();
 
-        if (_canCheckFileExists && !System.IO.File.Exists("Content/Shader.xnb"))
+        if (_canCheckFileExists && !CustomShaderFileExists(AppContext.BaseDirectory))
         {
             Debug.WriteLine("'Content/Shader.xnb' not found. Custom rendering is not available.");
         }


### PR DESCRIPTION
Closes #3694.

The optional `Content/Shader.xnb` existence probe (added in #2470) resolved a **working-directory-relative** path. Launching an app via a Windows file association sets the working directory to the opened file's folder, so the probe missed a shipped shader and silently disabled custom rendering — a regression, since the pre-#2470 `try { Load } catch` went through MonoGame's `ContentManager`/`TitleContainer` (app-base-relative) and was launch-independent.

Fix: anchor the probe to `AppContext.BaseDirectory`, matching where the actual `Load` reads from. Extracted into a testable `CustomEffectManager.CustomShaderFileExists(baseDirectory)` seam.

Red→green unit test reproduces the exact scenario (shader present in base dir, working directory pointed elsewhere).
