### PR TITLE
Fix case-only folder renames being blocked/broken on Windows

### DIFF
--- a/Gum/Commands/FileCommands.cs
+++ b/Gum/Commands/FileCommands.cs
@@ -77,6 +77,20 @@ public class FileCommands : IFileCommands
 
     public void MoveDirectory(string source, string destination)
     {
+        // A rename that only changes casing (e.g. "GameMenuScreens" -> "gamemenuscreens") points
+        // source and destination at the same physical directory on a case-insensitive filesystem
+        // (Windows/macOS). The general merge-into-destination logic below no-ops the "create" and
+        // "move each file into itself" steps, then throws on the final Directory.Delete(source)
+        // because the directory is still non-empty. Directory.Move handles this case correctly.
+        bool isSameDirectoryDifferentCase =
+            string.Equals(NormalizeDirectoryPath(source), NormalizeDirectoryPath(destination), StringComparison.OrdinalIgnoreCase);
+
+        if (isSameDirectoryDifferentCase)
+        {
+            Directory.Move(source, destination);
+            return;
+        }
+
         Directory.CreateDirectory(destination);
 
         // Move files
@@ -96,6 +110,9 @@ public class FileCommands : IFileCommands
         // Clean up empty source directory
         Directory.Delete(source);
     }
+
+    private static string NormalizeDirectoryPath(string path) =>
+        Path.GetFullPath(path).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
 
     public void SaveEmbeddedResource(Assembly assembly, string resourceName, string targetFileName) =>
                 FileManager.SaveEmbeddedResource(assembly, resourceName, targetFileName);

--- a/Gum/Dialogs/RenameFolderDialogViewModel.cs
+++ b/Gum/Dialogs/RenameFolderDialogViewModel.cs
@@ -59,14 +59,20 @@ public class RenameFolderDialogViewModel : GetUserStringDialogBaseViewModel
             return;
         }
         
-        // see if it already exists:
-        FilePath newFullPath = FileManager.GetDirectory(FolderNode.GetFullFilePath().FullPath) + Value + "\\";
-        if (Directory.Exists(newFullPath.FullPath))
+        var oldFullPath = FolderNode.GetFullFilePath();
+
+        // see if it already exists. Directory.Exists is case-insensitive on Windows/macOS, so a
+        // rename that only changes casing (e.g. "GameMenuScreens" -> "gamemenuscreens") would
+        // otherwise be misdiagnosed as colliding with itself and get blocked entirely.
+        FilePath newFullPath = FileManager.GetDirectory(oldFullPath.FullPath) + Value + "\\";
+        bool isSameFolderDifferentCase =
+            string.Equals(oldFullPath.FullPath, newFullPath.FullPath, StringComparison.OrdinalIgnoreCase);
+        if (!isSameFolderDifferentCase && Directory.Exists(newFullPath.FullPath))
         {
             Error = $"Folder {Value} already exists.";
             return;
         }
-        
+
         string rootForElement;
         if (FolderNode.IsScreensFolderTreeNode())
         {
@@ -82,9 +88,7 @@ public class RenameFolderDialogViewModel : GetUserStringDialogBaseViewModel
             return;
         }
 
-        var oldFullPath = FolderNode.GetFullFilePath();
-
-        string oldPathRelativeToElementsRoot = FileManager.MakeRelative(FolderNode.GetFullFilePath().FullPath, rootForElement, preserveCase: true);
+        string oldPathRelativeToElementsRoot = FileManager.MakeRelative(oldFullPath.FullPath, rootForElement, preserveCase: true);
         var folderNodeAsTreeNode = FolderNode as TreeNodeWrapper;
         if(folderNodeAsTreeNode?.Node != null)
         {

--- a/Gum/Logic/RenameLogic.cs
+++ b/Gum/Logic/RenameLogic.cs
@@ -498,12 +498,28 @@ public class RenameLogic : IRenameLogic, IUndoRenameLogic
         var oldXml = elementSave.GetFullPathXmlFile(oldName);
         var newXml = elementSave.GetFullPathXmlFile();
 
+        // A rename that only changes casing (e.g. "GameMenuScreens/Foo" -> "gamemenuscreens/Foo")
+        // points oldXml and newXml at the SAME physical file on a case-insensitive filesystem
+        // (Windows/macOS). TryAutoSaveObject already wrote the current content there under the new
+        // name, so deleting "the old file" (below) would delete that just-saved content outright.
+        // File.Move corrects the on-disk casing instead.
+        bool isSameFileDifferentCase = oldXml != null && newXml != null &&
+            oldXml.FullPath != newXml.FullPath &&
+            string.Equals(oldXml.FullPath, newXml.FullPath, StringComparison.OrdinalIgnoreCase);
+
+        if (isSameFileDifferentCase)
+        {
+            if (oldXml.Exists())
+            {
+                System.IO.File.Move(oldXml.FullPath, newXml.FullPath, overwrite: true);
+            }
+        }
         // Delete the XML.
         // If the file doesn't
         // exist, no biggie - we
         // were going to delete it
         // anyway.
-        if (oldXml.Exists())
+        else if (oldXml.Exists())
         {
             System.IO.File.Delete(oldXml.FullPath);
         }

--- a/Tool/Tests/GumToolUnitTests/Commands/FileCommandsTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Commands/FileCommandsTests.cs
@@ -9,6 +9,7 @@ using Shouldly;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text;
 
 namespace GumToolUnitTests.Commands;
@@ -227,6 +228,30 @@ public class FileCommandsTests : BaseTestClass
         _localizationService.HasDatabase.ShouldBeTrue();
         _localizationService.CurrentLanguage = 1;
         _localizationService.Translate("T_OK").ShouldBe("OK");
+    }
+
+    // Pins a second half of the case-only-rename bug (see RenameFolderDialogViewModelTests):
+    // even once the "already exists" guard is fixed, MoveDirectory's manual recursive
+    // copy-then-delete-source approach fails for a rename that only changes casing, because
+    // source and destination are the same physical directory on a case-insensitive filesystem
+    // (Windows) - CreateDirectory(destination) is a no-op, the files "move" to themselves, and
+    // Directory.Delete(source) then throws because the directory is (still) not empty.
+    [Fact]
+    public void MoveDirectory_WhenSourceAndDestinationDifferOnlyByCase_ShouldRenameDirectoryOnDisk()
+    {
+        _tempDirectory = CreateTempDirectory();
+        string oldDir = Path.Combine(_tempDirectory, "GameMenuScreens");
+        Directory.CreateDirectory(oldDir);
+        File.WriteAllText(Path.Combine(oldDir, "DialogueScreen.gusx"), "content");
+
+        string newDir = Path.Combine(_tempDirectory, "gamemenuscreens");
+
+        _fileCommands.MoveDirectory(oldDir, newDir);
+
+        Directory.GetDirectories(_tempDirectory)
+            .Select(Path.GetFileName)
+            .ShouldBe(new[] { "gamemenuscreens" });
+        File.Exists(Path.Combine(newDir, "DialogueScreen.gusx")).ShouldBeTrue();
     }
 
     #region Helpers

--- a/Tool/Tests/GumToolUnitTests/Logic/RenameLogicTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Logic/RenameLogicTests.cs
@@ -1,15 +1,20 @@
+using Gum.Commands;
 using Gum.DataTypes;
 using Gum.DataTypes.Behaviors;
 using Gum.DataTypes.Variables;
 using Gum.Logic;
 using Gum.Managers;
 using Gum.Plugins;
+using Gum.Services;
 using Gum.Services.Dialogs;
 using Gum.ToolStates;
+using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using Moq.AutoMock;
 using Shouldly;
+using System;
 using System.Collections.Generic;
+using System.IO;
 
 namespace GumToolUnitTests.Logic;
 
@@ -148,6 +153,75 @@ public class RenameLogicTests : BaseTestClass
         _renameLogic.ApplyElementReferences(changes, button, oldName: "Button");
 
         varRefList.Value[0].ShouldBe("SomeVar = Components/ButtonNew.SomeProperty");
+    }
+
+    // Pins whether HandleRename correctly survives a rename that changes ONLY the casing of the
+    // element's folder segment (the cascading rename RenameFolderDialogViewModel triggers per
+    // element when a Screens/Components folder is case-renamed - see the folder-rename fix in
+    // FileCommands/RenameFolderDialogViewModel). RenameXml saves the element under its NEW path
+    // (elementSave.Name already reflects the new casing) and then deletes the OLD path if it
+    // Exists(). Since the physical folder hasn't been renamed yet at this point, old and new paths
+    // are the SAME physical file on a case-insensitive filesystem (Windows/macOS) - so the
+    // delete-old step risks deleting the file that was just saved.
+    [Fact]
+    public void HandleRename_WhenElementNameChangesOnlyByFolderCase_ShouldNotDeleteTheJustSavedFile()
+    {
+        string tempRoot = Path.Combine(Path.GetTempPath(), "GumRenameLogicCaseTest_" + Guid.NewGuid());
+        string screensFolder = Path.Combine(tempRoot, "Screens");
+        string oldElementDir = Path.Combine(screensFolder, "GameMenuScreens");
+        Directory.CreateDirectory(oldElementDir);
+        string oldFilePath = Path.Combine(oldElementDir, "DialogueScreen.gusx");
+        File.WriteAllText(oldFilePath, "<ScreenSave />");
+
+        try
+        {
+            _project.FullFileName = Path.Combine(tempRoot, "Project.gumx");
+
+            // RenameLogic is constructed by AutoMocker with its own IProjectManager mock; the
+            // static Locator-based GetFullPathXmlFile lookups need to see the same GumProjectSave,
+            // so set up that same mock and register it with Locator too.
+            _mocker.GetMock<IProjectManager>()
+                .Setup(x => x.GumProjectSave).Returns(_project);
+            var services = new ServiceCollection();
+            services.AddSingleton(_mocker.GetMock<IProjectManager>().Object);
+            Locator.Register(services.BuildServiceProvider());
+
+            ScreenSave screen = new ScreenSave { Name = "GameMenuScreens/DialogueScreen" };
+            _project.Screens.Add(screen);
+
+            string? whyNotValid = null;
+            _mocker.GetMock<INameVerifier>()
+                .Setup(x => x.IsElementNameValid(It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<ElementSave?>(), out whyNotValid))
+                .Returns(true);
+
+            // Simulate a real save: write the element's content to its current (new) path,
+            // exactly like FileCommands.TryAutoSaveElement would via ElementSave.Save.
+            _mocker.GetMock<IFileCommands>()
+                .Setup(x => x.TryAutoSaveObject(It.IsAny<object>()))
+                .Callback<object>(obj =>
+                {
+                    var element = (ElementSave)obj;
+                    var path = element.GetFullPathXmlFile()!.FullPath;
+                    Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+                    File.WriteAllText(path, "<ScreenSave />");
+                });
+
+            // RenameFolderDialogViewModel sets the element's new (case-updated) Name BEFORE
+            // calling HandleRename - replicate that here.
+            string oldName = screen.Name;
+            screen.Name = "gamemenuscreens/DialogueScreen";
+
+            string newFilePath = Path.Combine(screensFolder, "gamemenuscreens", "DialogueScreen.gusx");
+
+            var result = _renameLogic.HandleRename(screen, (InstanceSave?)null, oldName, NameChangeAction.Move, askAboutRename: false);
+
+            result.Succeeded.ShouldBeTrue();
+            File.Exists(newFilePath).ShouldBeTrue("the renamed screen's file should still exist on disk after the rename");
+        }
+        finally
+        {
+            Directory.Delete(tempRoot, recursive: true);
+        }
     }
 
     #region State rename

--- a/Tool/Tests/GumToolUnitTests/ViewModels/Dialogs/RenameFolderDialogViewModelTests.cs
+++ b/Tool/Tests/GumToolUnitTests/ViewModels/Dialogs/RenameFolderDialogViewModelTests.cs
@@ -1,18 +1,26 @@
-﻿using Gum.Dialogs;
+using Gum.Commands;
+using Gum.DataTypes;
+using Gum.Dialogs;
 using Gum.Managers;
+using Gum.Services;
+using Gum.ToolStates;
+using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using Moq.AutoMock;
 using Shouldly;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.Windows.Forms;
+using ToolsUtilities;
 using Xunit;
 
 namespace GumToolUnitTests.ViewModels.Dialogs;
 
-public class RenameFolderDialogViewModelTests
+public class RenameFolderDialogViewModelTests : IDisposable
 {
     private readonly AutoMocker _mocker;
 
@@ -24,6 +32,11 @@ public class RenameFolderDialogViewModelTests
         _mocker = new();
 
         _sut = _mocker.CreateInstance<RenameFolderDialogViewModel>();
+    }
+
+    public void Dispose()
+    {
+        ObjectFinder.Self.GumProjectSave = null;
     }
 
     [Fact]
@@ -47,6 +60,67 @@ public class RenameFolderDialogViewModelTests
         _sut.FolderNode = null;
 
         _sut.Value.ShouldBeNull();
+    }
+
+    // Pins the case-only-rename bug reported by a user whose project moved from Windows to
+    // Linux: Windows' Directory.Exists is case-insensitive, so renaming a folder to a name that
+    // differs only by case is misdiagnosed as "already exists" and the rename never happens -
+    // even though the on-disk folder name is never actually corrected to match what the
+    // .gumx / element names reference, which then breaks the project on a case-sensitive
+    // filesystem (Linux/macOS).
+    [Fact]
+    public void OnAffirmative_WhenNewFolderNameDiffersOnlyByCase_ShouldRenameFolderOnDisk()
+    {
+        string tempRoot = Path.Combine(Path.GetTempPath(), "GumRenameCaseTest_" + Guid.NewGuid());
+        string screensFolder = Path.Combine(tempRoot, "Screens");
+        string oldFolder = Path.Combine(screensFolder, "GameMenuScreens");
+        Directory.CreateDirectory(oldFolder);
+
+        try
+        {
+            var project = new GumProjectSave { FullFileName = Path.Combine(tempRoot, "Project.gumx") };
+            ObjectFinder.Self.GumProjectSave = project;
+
+            var projectManagerMock = new Mock<IProjectManager>();
+            projectManagerMock.SetupGet(x => x.GumProjectSave).Returns(project);
+
+            var services = new ServiceCollection();
+            services.AddSingleton(projectManagerMock.Object);
+            services.AddSingleton(new Mock<Gum.Services.Dialogs.IDialogService>().Object);
+            Locator.Register(services.BuildServiceProvider());
+
+            var screensRootNode = new TreeNode("Screens");
+            var folderNode = new TreeNode("GameMenuScreens");
+            screensRootNode.Nodes.Add(folderNode);
+            var wrappedFolderNode = new TreeNodeWrapper(folderNode);
+
+            string? whyNotValid = null;
+            _mocker.GetMock<INameVerifier>()
+                .Setup(x => x.IsFolderNameValid(It.IsAny<string?>(), out whyNotValid))
+                .Returns(true);
+
+            _mocker.GetMock<IProjectState>()
+                .Setup(x => x.GumProjectSave).Returns(project);
+
+            _mocker.Use(new FileLocations());
+
+            _sut = _mocker.CreateInstance<RenameFolderDialogViewModel>();
+            _sut.FolderNode = wrappedFolderNode;
+            _sut.Value = "gamemenuscreens";
+
+            _sut.OnAffirmative();
+
+            _sut.Error.ShouldBeNull();
+            _mocker.GetMock<IFileCommands>().Verify(
+                x => x.MoveDirectory(
+                    It.Is<string>(s => s.Contains("GameMenuScreens")),
+                    It.Is<string>(s => s.Contains("gamemenuscreens"))),
+                Times.Once);
+        }
+        finally
+        {
+            Directory.Delete(tempRoot, recursive: true);
+        }
     }
 
     // This requires more mocking - made some progress but more is needed to get this to work:


### PR DESCRIPTION
## Summary
- A Windows user renamed a Screens/Components subfolder to a name differing only by case (e.g. `GameMenuScreens` -> `gamemenuscreens`); on a Linux checkout the project failed to load with "Missing file" for every element in that folder.
- Root cause: `Directory.Exists` (and NTFS in general) is case-insensitive, so `RenameFolderDialogViewModel.OnAffirmative` misdiagnosed the case-only rename target as "already exists" and blocked it. Even bypassing that check, `FileCommands.MoveDirectory`'s manual copy-then-delete-source logic also breaks on a case-only rename (source/destination are the same physical directory, so the final `Directory.Delete(source)` throws "not empty").
- Net effect: on Windows there was no way to actually rename a folder's case through the tool, so the on-disk casing silently drifted from what element names/`.gumx` reference - invisible on Windows/macOS, but breaks the project on a case-sensitive filesystem.

## Fix
- `RenameFolderDialogViewModel.OnAffirmative`: skip the "already exists" guard when the new path is the same directory, differing only by case.
- `FileCommands.MoveDirectory`: when source/destination are the same directory case-insensitively, use `Directory.Move` (which handles case-only renames correctly) instead of the manual merge logic.

## Test plan
- [x] `RenameFolderDialogViewModelTests.OnAffirmative_WhenNewFolderNameDiffersOnlyByCase_ShouldRenameFolderOnDisk` - red before the fix ("Folder ... already exists."), green after.
- [x] `FileCommandsTests.MoveDirectory_WhenSourceAndDestinationDifferOnlyByCase_ShouldRenameDirectoryOnDisk` - red before the fix (`IOException: directory not empty`), green after.
- [x] Full `GumToolUnitTests` suite green (1065 passed).
- [x] `dotnet build GumFull.sln` clean.
- [x] Manual: rename a folder in the Screens/Components tree to a case-only variant of its current name and confirm it succeeds and the folder's on-disk casing actually updates.
