### PR TITLE
Fix Linear-filtered text edge darkening via load-time alpha edge bleed (#3691)

### DIFF
--- a/GumCoreShared.projitems
+++ b/GumCoreShared.projitems
@@ -80,6 +80,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)MonoGameIntegration\RuntimeLogic.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RenderingLibrary\Camera.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RenderingLibrary\Content\ContentLoader.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)RenderingLibrary\Content\TextureEdgeBleed.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RenderingLibrary\Content\IContentLoader.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RenderingLibrary\Content\LoaderManager.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RenderingLibrary\Graphics\Animation\AnimationChain.cs" />

--- a/MonoGameGum.Tests/RenderingLibraries/TextureEdgeBleedTests.cs
+++ b/MonoGameGum.Tests/RenderingLibraries/TextureEdgeBleedTests.cs
@@ -1,0 +1,53 @@
+using Microsoft.Xna.Framework;
+using RenderingLibrary.Content;
+using Shouldly;
+using Xunit;
+
+namespace MonoGameGum.Tests.RenderingLibraries;
+
+/// <summary>
+/// Covers issue #3691: <see cref="TextureEdgeBleed.Bleed"/> fills fully-transparent texels that
+/// border a visible texel with the neighbor's color (keeping alpha 0) so a non-premultiplied Linear
+/// pipeline no longer darkens edges toward black.
+/// </summary>
+public class TextureEdgeBleedTests
+{
+    [Fact]
+    public void Bleed_ShouldCopyNeighborColorIntoTransparentTexel_WhileKeepingAlphaZero()
+    {
+        // Left texel: opaque white "glyph". Right texel: transparent black "outside".
+        Color[] pixels =
+        {
+            new Color((byte)255, (byte)255, (byte)255, (byte)255),
+            new Color((byte)0,   (byte)0,   (byte)0,   (byte)0),
+        };
+
+        TextureEdgeBleed.Bleed(pixels, width: 2, height: 1);
+
+        // The transparent texel now carries the white glyph color, but stays fully transparent.
+        pixels[1].R.ShouldBe((byte)255);
+        pixels[1].G.ShouldBe((byte)255);
+        pixels[1].B.ShouldBe((byte)255);
+        pixels[1].A.ShouldBe((byte)0);
+
+        // The opaque texel is untouched.
+        pixels[0].ShouldBe(new Color((byte)255, (byte)255, (byte)255, (byte)255));
+    }
+
+    [Fact]
+    public void Bleed_ShouldLeaveTransparentTexelBlack_WhenNoVisibleNeighborExists()
+    {
+        // A transparent texel with only transparent neighbors is never sampled adjacent to a visible
+        // texel, so it must stay black (nothing to bleed from).
+        Color[] pixels =
+        {
+            new Color((byte)0, (byte)0, (byte)0, (byte)0),
+            new Color((byte)0, (byte)0, (byte)0, (byte)0),
+            new Color((byte)0, (byte)0, (byte)0, (byte)0),
+        };
+
+        TextureEdgeBleed.Bleed(pixels, width: 3, height: 1);
+
+        pixels[1].ShouldBe(new Color((byte)0, (byte)0, (byte)0, (byte)0));
+    }
+}

--- a/MonoGameGum/FnaGum/FnaGum.csproj
+++ b/MonoGameGum/FnaGum/FnaGum.csproj
@@ -48,6 +48,7 @@
 		<Compile Include="..\..\Gum\Wireframe\CustomSetPropertyOnRenderable.cs" Link="Utilities\CustomSetPropertyOnRenderable.cs" />
 		<Compile Include="..\..\Gum\Wireframe\FallbackRenderableFactory.cs" Link="GueDeriving\FallbackRenderableFactory.cs" />
 		<Compile Include="..\..\RenderingLibrary\Content\ContentLoader.cs" Link="RenderingLibrary\ContentLoader.cs" />
+		<Compile Include="..\..\RenderingLibrary\Content\TextureEdgeBleed.cs" Link="RenderingLibrary\TextureEdgeBleed.cs" />
 		<Compile Include="..\..\RenderingLibrary\Graphics\Animation\AnimationChain.cs" Link="Animation\AnimationChain.cs" />
 		<Compile Include="..\..\RenderingLibrary\Graphics\Animation\AnimationChainList.cs" Link="Animation\AnimationChainList.cs" />
 		<Compile Include="..\..\RenderingLibrary\Graphics\Animation\AnimationFrame.cs" Link="Animation\AnimationFrame.cs" />

--- a/MonoGameGum/KniGum/KniGum.csproj
+++ b/MonoGameGum/KniGum/KniGum.csproj
@@ -74,6 +74,7 @@
 		<Compile Include="..\..\Gum\Wireframe\CustomSetPropertyOnRenderable.cs" Link="Utilities\CustomSetPropertyOnRenderable.cs" />
 		<Compile Include="..\..\Gum\Wireframe\FallbackRenderableFactory.cs" Link="GueDeriving\FallbackRenderableFactory.cs" />
 		<Compile Include="..\..\RenderingLibrary\Content\ContentLoader.cs" Link="RenderingLibrary\ContentLoader.cs" />
+		<Compile Include="..\..\RenderingLibrary\Content\TextureEdgeBleed.cs" Link="RenderingLibrary\TextureEdgeBleed.cs" />
 		<Compile Include="..\..\RenderingLibrary\Content\LoaderManagerExtensionMethods.cs" Link="RenderingLibrary\LoaderManagerExtensionMethods.cs" />
 		<Compile Include="..\..\RenderingLibrary\Graphics\Animation\AnimationChain.cs" Link="Animation\AnimationChain.cs" />
 		<Compile Include="..\..\RenderingLibrary\Graphics\Animation\AnimationChainList.cs" Link="Animation\AnimationChainList.cs" />

--- a/MonoGameGum/MonoGameGum.csproj
+++ b/MonoGameGum/MonoGameGum.csproj
@@ -202,6 +202,7 @@
 		<Compile Include="..\Gum\Wireframe\CustomSetPropertyOnRenderable.cs" Link="Utilities\CustomSetPropertyOnRenderable.cs" />
 		<Compile Include="..\Gum\Wireframe\FallbackRenderableFactory.cs" Link="GueDeriving\FallbackRenderableFactory.cs" />
 		<Compile Include="..\RenderingLibrary\Content\ContentLoader.cs" Link="RenderingLibrary\ContentLoader.cs" />
+		<Compile Include="..\RenderingLibrary\Content\TextureEdgeBleed.cs" Link="RenderingLibrary\TextureEdgeBleed.cs" />
 		<Compile Include="..\RenderingLibrary\Graphics\Animation\AnimationChain.cs" Link="Animation\AnimationChain.cs" />
 		<Compile Include="..\RenderingLibrary\Graphics\Animation\AnimationChainList.cs" Link="Animation\AnimationChainList.cs" />
 		<Compile Include="..\RenderingLibrary\Graphics\Animation\AnimationFrame.cs" Link="Animation\AnimationFrame.cs" />

--- a/RenderingLibrary/Content/ContentLoader.cs
+++ b/RenderingLibrary/Content/ContentLoader.cs
@@ -121,12 +121,37 @@ public class ContentLoader : IContentLoader
         {
             toReturn = LoadTextureFromFile(fileName, managers);
         }
+
+        ApplyEdgeBleed(toReturn);
+
         if (LoaderManager.Self.CacheTextures && toReturn != null)
         {
             LoaderManager.Self.AddDisposable(fileNameStandardized, toReturn);
         }
         return toReturn;
 
+    }
+
+    /// <summary>
+    /// Bleeds edge color into fully-transparent texels so a non-premultiplied Linear pipeline does
+    /// not darken anti-aliased edges toward black (issue #3691). No-op unless
+    /// <see cref="Graphics.Renderer.BleedTransparentTextureEdgesOnLoad"/> is set, and only applies to
+    /// uncompressed <see cref="SurfaceFormat.Color"/> textures (what <c>Texture2D.FromStream</c>
+    /// produces) — compressed / content-pipeline formats are left untouched.
+    /// </summary>
+    private static void ApplyEdgeBleed(Texture2D? texture)
+    {
+        if (texture == null
+            || !Graphics.Renderer.BleedTransparentTextureEdgesOnLoad
+            || texture.Format != SurfaceFormat.Color)
+        {
+            return;
+        }
+
+        var pixels = new Microsoft.Xna.Framework.Color[texture.Width * texture.Height];
+        texture.GetData(pixels);
+        TextureEdgeBleed.Bleed(pixels, texture.Width, texture.Height);
+        texture.SetData(pixels);
     }
 
     public static string StandardizeCaseSensitive(string fileName)

--- a/RenderingLibrary/Content/TextureEdgeBleed.cs
+++ b/RenderingLibrary/Content/TextureEdgeBleed.cs
@@ -1,0 +1,90 @@
+using Microsoft.Xna.Framework;
+
+namespace RenderingLibrary.Content;
+
+/// <summary>
+/// Alpha-preserving edge dilation for loaded textures (issue #3691).
+/// </summary>
+/// <remarks>
+/// A non-premultiplied pipeline sampled with <c>TextureFilter.Linear</c> darkens the edges of any
+/// texture whose transparent texels are black (RGB 0,0,0) — the shape of a KernSmith-baked font
+/// atlas — because bilinear sampling interpolates the transparent texel's black RGB into the visible
+/// edge. This "bleeds" the neighboring visible color into fully-transparent (A==0) texels' RGB while
+/// leaving alpha untouched, so the sampler interpolates color-to-color instead of color-to-black.
+///
+/// Bilinear filtering only ever blends a texel with its immediate neighbor, so a single pass — fill
+/// every A==0 texel that borders a non-transparent texel — is sufficient at any scale.
+/// </remarks>
+public static class TextureEdgeBleed
+{
+    /// <summary>
+    /// Bleeds neighboring visible color into fully-transparent texels, in place. Alpha is preserved.
+    /// </summary>
+    /// <param name="pixels">Row-major pixel data (length must be <paramref name="width"/> * <paramref name="height"/>).</param>
+    /// <param name="width">Texture width in texels.</param>
+    /// <param name="height">Texture height in texels.</param>
+    public static void Bleed(Color[] pixels, int width, int height)
+    {
+        if (pixels == null || width <= 0 || height <= 0)
+        {
+            return;
+        }
+
+        // Read from a snapshot so bleeding never cascades within the single pass (results are
+        // independent of iteration order, and a just-filled texel can't seed its neighbors).
+        Color[] source = (Color[])pixels.Clone();
+
+        for (int y = 0; y < height; y++)
+        {
+            for (int x = 0; x < width; x++)
+            {
+                int index = (y * width) + x;
+                if (source[index].A != 0)
+                {
+                    // Visible (or partially visible) texels already carry the right color.
+                    continue;
+                }
+
+                int r = 0, g = 0, b = 0, count = 0;
+
+                for (int dy = -1; dy <= 1; dy++)
+                {
+                    int ny = y + dy;
+                    if (ny < 0 || ny >= height)
+                    {
+                        continue;
+                    }
+
+                    for (int dx = -1; dx <= 1; dx++)
+                    {
+                        if (dx == 0 && dy == 0)
+                        {
+                            continue;
+                        }
+
+                        int nx = x + dx;
+                        if (nx < 0 || nx >= width)
+                        {
+                            continue;
+                        }
+
+                        Color neighbor = source[(ny * width) + nx];
+                        if (neighbor.A != 0)
+                        {
+                            r += neighbor.R;
+                            g += neighbor.G;
+                            b += neighbor.B;
+                            count++;
+                        }
+                    }
+                }
+
+                if (count > 0)
+                {
+                    // Keep alpha 0 — only the color the sampler interpolates toward changes.
+                    pixels[index] = new Color((byte)(r / count), (byte)(g / count), (byte)(b / count), (byte)0);
+                }
+            }
+        }
+    }
+}

--- a/RenderingLibrary/Graphics/Renderer.cs
+++ b/RenderingLibrary/Graphics/Renderer.cs
@@ -319,6 +319,16 @@ public class Renderer : IRenderer
 
     public static TextureFilter TextureFilter { get; set; } = TextureFilter.Point;
 
+    /// <summary>
+    /// When true (the default), textures loaded from file bleed their edge color into
+    /// fully-transparent texels on load (see <see cref="Content.TextureEdgeBleed"/>). This stops the
+    /// non-premultiplied pipeline from darkening anti-aliased edges toward black when sampled with
+    /// <see cref="Microsoft.Xna.Framework.Graphics.TextureFilter.Linear"/> — most visibly on font
+    /// atlases (issue #3691). Only affects the RGB of texels whose alpha is 0, so it is visually a
+    /// no-op under Point filtering. Set false to skip the per-load pass.
+    /// </summary>
+    public static bool BleedTransparentTextureEdgesOnLoad { get; set; } = true;
+
 #endregion
 
     public Renderer()

--- a/Tests/MonoGameGum.IntegrationTests/MonoGameGum/Rendering/LinearFilterEdgeDarkeningTests.cs
+++ b/Tests/MonoGameGum.IntegrationTests/MonoGameGum/Rendering/LinearFilterEdgeDarkeningTests.cs
@@ -1,0 +1,177 @@
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using Gum.DataTypes;
+using Gum.GueDeriving;
+using RenderingLibrary;
+using RenderingLibrary.Content;
+using RenderingLibrary.Graphics;
+using Shouldly;
+using Xunit;
+using XnaColor = Microsoft.Xna.Framework.Color;
+
+namespace MonoGameGum.IntegrationTests.MonoGameGum.Rendering;
+
+/// <summary>
+/// Reproduces and pins the fix for issue #3691: a texture whose transparent texels are black
+/// (RGB 0,0,0 — the shape of a KernSmith-baked font atlas) darkens at its anti-aliased edges when
+/// sampled with <see cref="TextureFilter.Linear"/> under the default non-premultiplied pipeline.
+/// Bilinear sampling interpolates the transparent-black texel's RGB toward the opaque glyph color,
+/// so the edge blends toward gray instead of staying the glyph color — a dark fringe over light
+/// backgrounds. <see cref="TextureEdgeBleed"/>, run at load time, fixes it.
+///
+/// The repro is a 2x1 texture (opaque white | transparent black) saved to PNG and loaded back
+/// through the real <see cref="LoaderManager"/> path, stretched large over an opaque white
+/// background. With the fix the whole draw stays white; without it a gray band appears down the
+/// middle where linear sampling crosses the opaque/transparent boundary.
+/// </summary>
+public class LinearFilterEdgeDarkeningTests : BaseTestClass
+{
+    public override void Dispose()
+    {
+        Renderer.TextureFilter = TextureFilter.Point;
+        Renderer.BleedTransparentTextureEdgesOnLoad = true;
+        base.Dispose();
+    }
+
+    [Fact]
+    public void LinearFilteredSprite_WithBlackTransparentTexels_StaysWhite_WhenEdgeBleedEnabled()
+    {
+        Renderer.BleedTransparentTextureEdgesOnLoad = true;
+
+        XnaColor sampled = SampleMidpointOfLinearWhiteSpriteOverWhite();
+
+        // With the load-time edge bleed, the sprite over white stays white everywhere.
+        sampled.R.ShouldBeGreaterThanOrEqualTo((byte)250);
+        sampled.G.ShouldBeGreaterThanOrEqualTo((byte)250);
+        sampled.B.ShouldBeGreaterThanOrEqualTo((byte)250);
+    }
+
+    [Fact]
+    public void LinearFilteredSprite_WithBlackTransparentTexels_DarkensEdge_WhenEdgeBleedDisabled()
+    {
+        Renderer.BleedTransparentTextureEdgesOnLoad = false;
+
+        XnaColor sampled = SampleMidpointOfLinearWhiteSpriteOverWhite();
+
+        // Without the bleed the midpoint is dragged toward gray (~191): the fringe the fix removes.
+        sampled.R.ShouldBeLessThan((byte)210);
+    }
+
+    /// <summary>
+    /// Loads a 2x1 (opaque white | transparent black) PNG through the real LoaderManager, stretches
+    /// it to 100x100 over an opaque white background with Linear filtering, and returns the pixel at
+    /// the horizontal midpoint — where linear sampling is halfway between the two texels (the worst
+    /// case for the fringe).
+    /// </summary>
+    private static XnaColor SampleMidpointOfLinearWhiteSpriteOverWhite()
+    {
+        using MinimalGame game = new();
+        game.RunOneFrame();
+
+        GraphicsDevice gd = game.GraphicsDevice;
+        SystemManagers managers = SystemManagers.Default;
+        Renderer renderer = managers.Renderer;
+
+        Renderer.TextureFilter = TextureFilter.Linear;
+
+        // Save the texture to a PNG and load it back through the real LoaderManager/ContentLoader so
+        // the load-time edge bleed (the fix) is actually exercised — building the texture directly
+        // with SetData would bypass the loader.
+        string pngPath = System.IO.Path.Combine(
+            System.IO.Path.GetTempPath(), System.IO.Path.GetRandomFileName() + ".png");
+        using (Texture2D source = new(gd, 2, 1, false, SurfaceFormat.Color))
+        {
+            source.SetData(new[]
+            {
+                new XnaColor((byte)255, (byte)255, (byte)255, (byte)255),
+                new XnaColor((byte)0,   (byte)0,   (byte)0,   (byte)0),
+            });
+            using System.IO.FileStream fs = System.IO.File.Create(pngPath);
+            source.SaveAsPng(fs, 2, 1);
+        }
+
+        Texture2D texture = LoaderManager.Self.LoadContent<Texture2D>(pngPath);
+
+        ContainerRuntime root = new();
+        root.X = 0;
+        root.Y = 0;
+        root.Width = 100;
+        root.Height = 100;
+
+#pragma warning disable CS0618 // ColoredRectangleRuntime is obsolete; simplest opaque solid fill.
+        root.AddChild(new ColoredRectangleRuntime
+        {
+            Width = 100,
+            Height = 100,
+            Color = new XnaColor((byte)255, (byte)255, (byte)255, (byte)255),
+        });
+#pragma warning restore CS0618
+
+        SpriteRuntime sprite = new();
+        sprite.Texture = texture;
+        sprite.WidthUnits = DimensionUnitType.Absolute;
+        sprite.HeightUnits = DimensionUnitType.Absolute;
+        sprite.Width = 100;
+        sprite.Height = 100;
+        root.AddChild(sprite);
+
+        root.AddToManagers(managers, null);
+        root.UpdateLayout();
+
+        XnaColor sampled = RenderToCaptureAndSample(gd, renderer, managers, 100, 100, 50, 50);
+
+        root.RemoveFromManagers();
+        try { System.IO.File.Delete(pngPath); } catch { /* best effort */ }
+
+        return sampled;
+    }
+
+    private static XnaColor RenderToCaptureAndSample(GraphicsDevice gd, Renderer renderer, SystemManagers managers, int w, int h, int sx, int sy)
+    {
+        using RenderTarget2D capture = new(gd, w, h, false, SurfaceFormat.Color, DepthFormat.None, 0,
+            RenderTargetUsage.PreserveContents);
+
+        for (int i = 0; i < 2; i++)
+        {
+            gd.SetRenderTarget(capture);
+            gd.Clear(XnaColor.Black);
+            renderer.Draw(managers);
+        }
+        gd.SetRenderTarget(null);
+
+        XnaColor[] data = new XnaColor[w * h];
+        capture.GetData(data);
+
+        return data[(sy * w) + sx];
+    }
+
+    private class MinimalGame : Game
+    {
+        private readonly GraphicsDeviceManager _graphics;
+
+        public MinimalGame()
+        {
+            LoaderManager.Self?.DisposeAndClear();
+            _graphics = new GraphicsDeviceManager(this);
+        }
+
+        protected override void Initialize()
+        {
+            base.Initialize();
+            Gum.GumService.Default.Initialize(this, Gum.Forms.DefaultVisualsVersion.V2);
+        }
+
+        protected override void Update(GameTime gameTime) { }
+        protected override void Draw(GameTime gameTime) => GraphicsDevice.Clear(XnaColor.CornflowerBlue);
+
+        protected override void Dispose(bool disposing)
+        {
+            if (Gum.GumService.Default.IsInitialized)
+            {
+                Gum.GumService.Default.Uninitialize();
+            }
+            LoaderManager.Self?.DisposeAndClear();
+            base.Dispose(disposing);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #3691.

MonoGame text rendered with **Linear** filtering showed a dark fringe on glyph edges. Cause: non-premultiplied pipeline + Linear sampling interpolates the atlas's transparent-black texels (RGB 0,0,0) into the visible edge, dragging it toward gray. Confirmed at the pixel level — a white glyph edge over white sampled **R=191** instead of 255.

**Fix:** `TextureEdgeBleed` bleeds each fully-transparent texel's color from its visible neighbors (alpha stays 0) at load time in `ContentLoader`, so bilinear sampling interpolates color→color instead of color→black. Bilinear only blends adjacent texels, so a single pass suffices at any scale. No blend-state change, no batch churn, no atlas regeneration; fixes fonts and sprites uniformly (tool included). Gated by `Renderer.BleedTransparentTextureEdgesOnLoad` (default on).

Chose this over the global premultiplied-alpha pipeline (too wide a blast radius) and KernSmith bake-time dilation (out of repo, only helps newly-baked atlases).

**Tests** (real-GPU pixel readback + pure unit):
- `TextureEdgeBleedTests` — the dilation function.
- `LinearFilterEdgeDarkeningTests` — loads a PNG through the real loader, renders Linear over white: bleed on → white, bleed off → ~191 gray (both branches).

Full suites green (1864 + 65), KniGum builds.
