### PR TITLE
Keep BBCode inline styling during SkiaGum typewriter reveal

### DIFF
--- a/Runtimes/SkiaGum/Renderables/Text.cs
+++ b/Runtimes/SkiaGum/Renderables/Text.cs
@@ -974,6 +974,20 @@ public class Text : IRenderableIpso, IVisible, IFormsText, ICloneable
     /// reveal path), the text is added as a single unstyled run.</param>
     private TextBlock GetTextBlock(string textToRender, float? forcedWidth, bool allowMarkup)
     {
+        List<StyledTextRun> runs = allowMarkup && _hasMarkup
+            ? GetStyledRuns()
+            : new List<StyledTextRun> { new StyledTextRun(textToRender ?? string.Empty, GetStyle()) };
+        return BuildTextBlockFromRuns(runs, forcedWidth);
+    }
+
+    /// <summary>
+    /// Lays out the given styled runs into a RichTextKit <c>TextBlock</c>, applying this Text's
+    /// alignment/wrap/overflow properties. Shared by the full-layout path (<see cref="GetTextBlock(string, float?, bool)"/>)
+    /// and the <see cref="MaxLettersToShow"/> reveal path (<see cref="GetPaintTextBlock"/>) so both honor
+    /// per-run BBCode styling (issue #3679) and the <c>[Custom]</c> glyph-offset callback (issue #3692).
+    /// </summary>
+    private TextBlock BuildTextBlockFromRuns(List<StyledTextRun> runs, float? forcedWidth)
+    {
         var textBlock = new TextBlock();
         // Code-point start index (in the added-text stream, which lines up with _layoutText since
         // ReplacementCharacter substitution keeps a run's length at 1) -> the glyph offset a [Custom]
@@ -983,23 +997,16 @@ public class Text : IRenderableIpso, IVisible, IFormsText, ICloneable
         try
         {
             textBlock.MaxWidth = forcedWidth ?? this.Width;
-            if (allowMarkup && _hasMarkup)
+            int codePointIndex = 0;
+            foreach (var run in runs)
             {
-                int codePointIndex = 0;
-                foreach (var run in GetStyledRuns())
+                textBlock.AddText(run.Text, run.Style);
+                if (run.XOffset != 0 || run.YOffset != 0)
                 {
-                    textBlock.AddText(run.Text, run.Style);
-                    if (run.XOffset != 0 || run.YOffset != 0)
-                    {
-                        glyphOffsetsByStart ??= new();
-                        glyphOffsetsByStart[codePointIndex] = (run.XOffset, run.YOffset);
-                    }
-                    codePointIndex += run.Text.Length;
+                    glyphOffsetsByStart ??= new();
+                    glyphOffsetsByStart[codePointIndex] = (run.XOffset, run.YOffset);
                 }
-            }
-            else
-            {
-                textBlock.AddText(textToRender, GetStyle());
+                codePointIndex += run.Text.Length;
             }
             switch (HorizontalAlignment)
             {
@@ -1063,13 +1070,14 @@ public class Text : IRenderableIpso, IVisible, IFormsText, ICloneable
     /// <summary>
     /// The <c>TextBlock</c> that <see cref="Render"/> actually paints. When <see cref="MaxLettersToShow"/>
     /// is null (or already covers the whole text) this is the full cached block, leaving the render
-    /// fast path unchanged. Otherwise a throwaway block is built from <see cref="GetVisibleWrappedText"/>
-    /// so only the first N letters are drawn; because each revealed line is a prefix of a full wrapped
-    /// line and the breaks are re-inserted as hard newlines, the revealed lines land in the same
-    /// positions as in the full layout. The cached block (used for measurement / caret math) is
-    /// untouched.
+    /// fast path unchanged. Otherwise a throwaway block is built from the revealed prefix -- styled runs
+    /// (<see cref="GetVisibleStyledRuns"/>) when the text carries BBCode markup (issue #3701), or plain
+    /// <see cref="GetVisibleWrappedText"/> text otherwise -- so only the first N letters are drawn; because
+    /// each revealed line is a prefix of a full wrapped line and the breaks are re-inserted as hard
+    /// newlines, the revealed lines land in the same positions as in the full layout. The cached block
+    /// (used for measurement / caret math) is untouched. Exposed internally for unit testing.
     /// </summary>
-    private TextBlock GetPaintTextBlock(TextBlock fullBlock)
+    internal TextBlock GetPaintTextBlock(TextBlock fullBlock)
     {
         if (MaxLettersToShow == null)
         {
@@ -1088,9 +1096,13 @@ public class Text : IRenderableIpso, IVisible, IFormsText, ICloneable
             return fullBlock;
         }
 
-        // The reveal text is already tag-stripped (it comes from WrappedText), so no markup path:
-        // per-run styling in the typewriter reveal is a documented deferral (issue #3679).
-        return GetTextBlock(string.Join("\n", GetVisibleWrappedText()), this.Width, allowMarkup: false);
+        // Reveal keeps per-run BBCode styling (issue #3701): GetVisibleStyledRuns slices the same
+        // styled runs GetTextBlock uses for the full layout down to the revealed prefix, rather than
+        // falling back to the tag-stripped plain text GetVisibleWrappedText returns.
+        List<StyledTextRun> runs = _hasMarkup
+            ? GetVisibleStyledRuns()
+            : new List<StyledTextRun> { new StyledTextRun(string.Join("\n", GetVisibleWrappedText()), GetStyle()) };
+        return BuildTextBlockFromRuns(runs, this.Width);
     }
 
 
@@ -1149,6 +1161,61 @@ public class Text : IRenderableIpso, IVisible, IFormsText, ICloneable
         }
 
         return runs;
+    }
+
+    /// <summary>
+    /// <see cref="GetStyledRuns"/>, sliced to the prefix revealed by <see cref="MaxLettersToShow"/>
+    /// (issue #3701) with the same hard line breaks <see cref="GetVisibleWrappedText"/> inserts, so the
+    /// typewriter reveal keeps per-run BBCode styling instead of falling back to plain text. Both sources
+    /// index into <see cref="_layoutText"/> code-point-for-code-point (a run's text is only ever replaced
+    /// character-for-character by a <c>[Custom]</c> callback, never lengthened/shortened), so slicing runs
+    /// by the visible lines' lengths lines up with the correct styled content. Exposed internally for unit
+    /// testing.
+    /// </summary>
+    internal List<StyledTextRun> GetVisibleStyledRuns()
+    {
+        List<string> visibleLines = GetVisibleWrappedText();
+        List<StyledTextRun> fullRuns = GetStyledRuns();
+        var result = new List<StyledTextRun>();
+
+        int runIndex = 0;
+        int runOffset = 0;
+
+        for (int lineIndex = 0; lineIndex < visibleLines.Count; lineIndex++)
+        {
+            int remaining = visibleLines[lineIndex].Length;
+            while (remaining > 0 && runIndex < fullRuns.Count)
+            {
+                StyledTextRun run = fullRuns[runIndex];
+                int available = run.Text.Length - runOffset;
+                if (available <= 0)
+                {
+                    runIndex++;
+                    runOffset = 0;
+                    continue;
+                }
+
+                int take = System.Math.Min(available, remaining);
+                string text = run.Text.Substring(runOffset, take);
+                result.Add(new StyledTextRun(text, run.Style, run.XOffset, run.YOffset));
+
+                runOffset += take;
+                remaining -= take;
+                if (runOffset >= run.Text.Length)
+                {
+                    runIndex++;
+                    runOffset = 0;
+                }
+            }
+
+            if (lineIndex < visibleLines.Count - 1)
+            {
+                Style breakStyle = runIndex < fullRuns.Count ? fullRuns[runIndex].Style : GetStyle();
+                result.Add(new StyledTextRun("\n", breakStyle));
+            }
+        }
+
+        return result;
     }
 
     /// <summary>

--- a/Tests/SkiaGum.Tests/Renderables/TextMaxLettersToShowBbCodeTests.cs
+++ b/Tests/SkiaGum.Tests/Renderables/TextMaxLettersToShowBbCodeTests.cs
@@ -1,0 +1,70 @@
+using Shouldly;
+using SkiaGum;
+using SkiaSharp;
+using System.Collections.Generic;
+using System.Linq;
+using Topten.RichTextKit;
+
+namespace SkiaGum.Tests.Renderables;
+
+/// <summary>
+/// Verifies that SkiaGum's <see cref="Text"/> keeps per-run BBCode styling (issue #3679) during the
+/// <see cref="Text.MaxLettersToShow"/> typewriter reveal (issue #3701), instead of falling back to the
+/// tag-stripped plain text the reveal path used before.
+/// </summary>
+public class TextMaxLettersToShowBbCodeTests
+{
+    private static Text MakeText()
+    {
+        Text text = new();
+        text.FontName = "Arial";
+        text.FontSize = 20;
+        text.Width = 1000;
+        text.Color = SKColors.Black;
+        return text;
+    }
+
+    [Fact]
+    public void GetVisibleStyledRuns_PartialReveal_PreservesRunStyling()
+    {
+        Text text = MakeText();
+        text.RawText = "plain [Color=Red]red[/Color] plain";
+        text.MaxLettersToShow = 8;
+
+        List<Text.StyledTextRun> runs = text.GetVisibleStyledRuns();
+
+        string.Concat(runs.Select(r => r.Text)).ShouldBe("plain re");
+        runs.Last().Style.TextColor.ShouldBe(new SKColor(255, 0, 0, 255));
+        runs.First().Style.TextColor.ShouldBe(SKColors.Black);
+    }
+
+    [Fact]
+    public void GetVisibleStyledRuns_RevealSpansWrappedLines_ConcatenatesToVisibleWrappedTextAndKeepsStyle()
+    {
+        Text text = MakeText();
+        text.Width = 80;
+        text.RawText = "[Color=Red]Hello world this is a long line of text that wraps across many lines[/Color]";
+        List<string> fullWrapped = text.WrappedText;
+        text.MaxLettersToShow = fullWrapped[0].Length + 2;
+
+        List<Text.StyledTextRun> runs = text.GetVisibleStyledRuns();
+
+        string.Concat(runs.Select(r => r.Text)).Replace("\n", "").ShouldBe(string.Concat(text.GetVisibleWrappedText()));
+        runs.ShouldContain(r => r.Text == "\n");
+        runs.Where(r => r.Text != "\n").ShouldAllBe(r => r.Style.TextColor == new SKColor(255, 0, 0, 255));
+    }
+
+    [Fact]
+    public void GetPaintTextBlock_PartialReveal_ProducesMultipleFontRunColors()
+    {
+        Text text = MakeText();
+        text.RawText = "plain [Color=Red]red[/Color] plain";
+        text.MaxLettersToShow = 8;
+
+        TextBlock fullBlock = text.GetTextBlock();
+        TextBlock paintBlock = text.GetPaintTextBlock(fullBlock);
+
+        paintBlock.FontRuns.Select(r => r.Style.TextColor).Distinct().Count().ShouldBeGreaterThan(1);
+        paintBlock.FontRuns.Any(r => r.Style.TextColor == new SKColor(255, 0, 0, 255)).ShouldBeTrue();
+    }
+}


### PR DESCRIPTION
Closes #3701

`GetPaintTextBlock`'s `MaxLettersToShow` typewriter-reveal path built its throwaway block from tag-stripped `GetVisibleWrappedText()`, so any BBCode color/size/weight/italic styling was lost until the full string revealed — a documented deferral left over from #3679.

## Fix
- Extracted a shared `BuildTextBlockFromRuns` core out of `GetTextBlock` so both the full layout and the reveal path lay out from a `List<StyledTextRun>`.
- Added `GetVisibleStyledRuns()`: slices `GetStyledRuns()` down to the revealed prefix, inserting the same hard line breaks `GetVisibleWrappedText()` uses for wrap-spanning reveals. Both sources index into `_layoutText` code-point-for-code-point, so slicing by visible-line length lines up with the correct styled content.
- `GetPaintTextBlock` now uses `GetVisibleStyledRuns()` when the text carries markup, falling back to the old plain-text path otherwise (unchanged behavior for non-markup text).

Fixed a regression this surfaced along the way: unifying the plain-text branch into the runs loop called `.Length` on a null `RawText`, which the old code's single `AddText(null, ...)` call never touched — `SetTextNoTranslate(null)` is a supported case (see `TextRuntimeTests.SetTextNoTranslate_WhenNull_ShouldSetTextToNull`). Now normalizes to `string.Empty`.

## Tests
New `TextMaxLettersToShowBbCodeTests`: partial reveal mid-styled-run, reveal spanning wrapped lines with inline line-break style, and an integration check on the actual painted `TextBlock`'s `FontRuns`. Full `SkiaGum.Tests` suite: 304/304 green.
