### PR TITLE
Add animated typewriter reveal to Text sample screens

### DIFF
--- a/Samples/MonoGameGumInCode/MonoGameGumInCode/Game1.cs
+++ b/Samples/MonoGameGumInCode/MonoGameGumInCode/Game1.cs
@@ -158,6 +158,10 @@ namespace MonoGameGumInCode
 
             GumService.Default.Update(gameTime);
 
+            // FrameworkElement.Activity() is FRB-only and unavailable here, so screens that animate
+            // (e.g. TextScreen's typewriter reveal, #3701) get a host-driven per-frame Tick instead.
+            (_currentScreen as TextScreen)?.Tick(gameTime.ElapsedGameTime.TotalSeconds);
+
             bool moveCameraWithMouse = false;
             if (moveCameraWithMouse)
             {

--- a/Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/TextScreen.cs
+++ b/Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/TextScreen.cs
@@ -1,4 +1,5 @@
 using Gum.DataTypes;
+using Gum.Forms;
 using Gum.Forms.Controls;
 using Gum.GueDeriving;
 using Gum.Managers;
@@ -6,6 +7,7 @@ using Gum.Wireframe;
 using RenderingLibrary;
 using RenderingLibrary.Graphics;
 using System;
+using System.Linq;
 #if RAYLIB
 using Color = Raylib_cs.Color;
 using Text = Gum.Renderables.Text;
@@ -38,6 +40,11 @@ namespace MonoGameGumInCode.Screens;
 // the namespace, the Color/Text/LetterCustomization/TextRenderingPositionMode aliases above, and
 // AddTextureFilterSection's mechanism (a per-layer sampler state on MonoGame vs a baked font-cache
 // texture on raylib).
+//
+// Tick(elapsedSeconds) (#3701) drives the animated typewriter section and must be called once per
+// frame by the host while this screen is active — see Game1.Update / Program.cs's main loop
+// (`(currentScreen as TextScreen)?.Tick(...)`). FrameworkElement.Activity() is FRB-only (`#if FRB`)
+// and not available in these plain samples, hence the host-driven Tick instead.
 internal class TextScreen : FrameworkElement
 {
     public TextScreen() : base(new ContainerRuntime())
@@ -58,6 +65,11 @@ internal class TextScreen : FrameworkElement
         var textRuntime = new TextRuntime();
         textRuntime.Text = "Hi, I'm default text";
         container.Children.Add(textRuntime);
+
+        // Placed right after the default text -- this screen has no ScrollViewer, and the rest of the
+        // stack (BBCode/shadows/BuildTextParitySection/static reveal rows) comfortably exceeds a
+        // typical window height, so anything appended after it is invisible without resizing.
+        AddTypewriterSection(container);
 
         // One self-describing BBCode line: each styled word shows AND names its own effect, so no
         // separate label is needed. Kept byte-identical to the same line in the SilkNetGumSample text
@@ -117,6 +129,51 @@ internal class TextScreen : FrameworkElement
         container.Children.Add(withOutline);
 
         BuildTextParitySection(container);
+
+        AddMaxLettersToShowSection(container);
+    }
+
+    // Typewriter reveal (#3701): MaxLettersToShow (the same property AddRevealRow sets to a
+    // fixed count) driven by elapsed time instead, via Tick. Pressing any key restarts the reveal
+    // from the beginning. FormsUtilities.Keyboard.KeysTyped is the platform-neutral "keys typed this
+    // frame" feed every backend's UseKeyboardDefaults() populates, so this needs no #if branching.
+    private const string TypewriterParagraph =
+        "This paragraph types itself out one letter at a time. Press any key to start the reveal over from the beginning.";
+    private const double TypewriterLettersPerSecond = 18;
+    private TextRuntime _typewriterText;
+    private double _typewriterElapsedSeconds;
+
+    /// <summary>
+    /// Advances the typewriter reveal by <paramref name="elapsedSeconds"/>. Call once per frame from
+    /// the host's game loop while this screen is active.
+    /// </summary>
+    public void Tick(double elapsedSeconds)
+    {
+        if (FormsUtilities.Keyboard.KeysTyped.Any())
+        {
+            _typewriterElapsedSeconds = 0;
+        }
+        else
+        {
+            _typewriterElapsedSeconds += elapsedSeconds;
+        }
+
+        int lettersToShow = (int)(_typewriterElapsedSeconds * TypewriterLettersPerSecond);
+        _typewriterText.MaxLettersToShow = Math.Min(lettersToShow, TypewriterParagraph.Length);
+    }
+
+    private void AddTypewriterSection(ContainerRuntime container)
+    {
+        _typewriterText = new TextRuntime();
+        _typewriterText.Font = "Arial";
+        _typewriterText.FontSize = 20;
+        _typewriterText.WidthUnits = DimensionUnitType.Absolute;
+        _typewriterText.Width = 300;
+        _typewriterText.HeightUnits = DimensionUnitType.RelativeToChildren;
+        _typewriterText.Height = 0;
+        _typewriterText.Text = TypewriterParagraph;
+        _typewriterText.MaxLettersToShow = 0;
+        container.Children.Add(_typewriterText);
     }
 
     // Text parity features (#3432): Blend, per-instance TextRenderingPositionMode override, and
@@ -240,6 +297,38 @@ internal class TextScreen : FrameworkElement
         filterRow.AddChild(linearText);
         linearText.MoveToLayer(linearLayer);
 #endif
+    }
+
+    // MaxLettersToShow typewriter reveal (#3678). The same wrapping paragraph is shown fully, then
+    // with MaxLettersToShow set to a partial count so only the first N letters are visible while the
+    // hidden tail still occupies its final layout (reveal is paint-only: WrappedText / measurement
+    // stay built from the full RawText). Font = "Arial" because text can silently no-op without a
+    // font. Kept content-identical to the SilkNetGumSample text screen.
+    private static void AddMaxLettersToShowSection(ContainerRuntime container)
+    {
+        const string paragraph =
+            "This paragraph reveals only its first letters while the rest stays hidden.";
+
+        // Explicit RelativeToChildren height so each Text takes its own content height in the stack
+        // (leaving Height at its default let the rows overlap in the earlier demo). null MaxLettersToShow
+        // = full text; 10 and 30 are fixed counts so the difference is visible without any animation.
+        AddRevealRow(container, paragraph, null);
+        AddRevealRow(container, paragraph, 10);
+        AddRevealRow(container, paragraph, 30);
+    }
+
+    private static void AddRevealRow(ContainerRuntime container, string paragraph, int? maxLetters)
+    {
+        var row = new TextRuntime();
+        row.Font = "Arial";
+        row.FontSize = 20;
+        row.WidthUnits = DimensionUnitType.Absolute;
+        row.Width = 300;
+        row.HeightUnits = DimensionUnitType.RelativeToChildren;
+        row.Height = 0;
+        row.Text = paragraph;
+        row.MaxLettersToShow = maxLetters;
+        container.Children.Add(row);
     }
 
     // Blend on Text (#3432): additive (brightens) vs normal, over an identical blue box. Each cell's

--- a/Samples/SilkNetGum/SilkNetGumSample/Program.cs
+++ b/Samples/SilkNetGum/SilkNetGumSample/Program.cs
@@ -464,6 +464,9 @@ unsafe class Program
             // for FPS reporting, so we keep a separate monotonic clock here.
             Stopwatch totalTime = new Stopwatch();
             totalTime.Start();
+            // Per-frame delta for TextScreen's Tick (#3701) -- FrameworkElement.Activity() is FRB-only
+            // and unavailable here, and GumUI.Update below only wants the running total, not a delta.
+            double previousTotalSeconds = 0;
             while (running && !window.IsClosing)
             {
 
@@ -495,7 +498,11 @@ unsafe class Program
                 // Per-frame Update drives AnimateSelf (and any other Forms
                 // input/activity pumps). Without this the .achx animation row
                 // on SpriteScreen shows the first frame and never advances.
-                GumUI.Update(totalTime.Elapsed.TotalSeconds);
+                double currentTotalSeconds = totalTime.Elapsed.TotalSeconds;
+                GumUI.Update(currentTotalSeconds);
+
+                (currentCodeScreen as TextScreen)?.Tick(currentTotalSeconds - previousTotalSeconds);
+                previousTotalSeconds = currentTotalSeconds;
 
 
 

--- a/Samples/SilkNetGum/SilkNetGumSample/Screens/TextScreen.cs
+++ b/Samples/SilkNetGum/SilkNetGumSample/Screens/TextScreen.cs
@@ -1,3 +1,5 @@
+using Gum.DataTypes;
+using Gum.Forms;
 using Gum.Forms.Controls;
 using Gum.GueDeriving;
 using Gum.Managers;
@@ -5,6 +7,7 @@ using Gum.Wireframe;
 using RenderingLibrary.Graphics;
 using SkiaSharp;
 using System;
+using System.Linq;
 
 namespace SilkNetGum.Screens;
 
@@ -17,6 +20,11 @@ namespace SilkNetGum.Screens;
 // (#3674/#3675/#3676), RichTextKit overflow (#3677), and MaxLettersToShow (#3678) — exercise the
 // SkiaGum.Text renderable directly; the baked-atlas drop shadow and texture-filter demos the MonoGame
 // screen shows have no Skia equivalent and are intentionally absent.
+//
+// Tick(elapsedSeconds) (#3701) drives the animated typewriter section and must be called once per
+// frame by Program.cs's main loop while this screen is active (`(currentCodeScreen as
+// TextScreen)?.Tick(...)`). FrameworkElement.Activity() is FRB-only (`#if FRB`) and not available in
+// these plain samples, hence the host-driven Tick instead.
 internal class TextScreen : FrameworkElement
 {
     public TextScreen() : base(new ContainerRuntime())
@@ -24,8 +32,8 @@ internal class TextScreen : FrameworkElement
         Dock(Gum.Wireframe.Dock.Fill);
 
         ContainerRuntime container = new ContainerRuntime();
-        container.WidthUnits = Gum.DataTypes.DimensionUnitType.RelativeToParent;
-        container.HeightUnits = Gum.DataTypes.DimensionUnitType.RelativeToParent;
+        container.WidthUnits = DimensionUnitType.RelativeToParent;
+        container.HeightUnits = DimensionUnitType.RelativeToParent;
         container.X = 2;
         container.Y = 2;
         container.Width = -4;
@@ -37,6 +45,11 @@ internal class TextScreen : FrameworkElement
         TextRuntime textRuntime = new TextRuntime();
         textRuntime.Text = "Hi, I'm default text";
         container.Children.Add(textRuntime);
+
+        // Placed right after the default text -- this screen has no ScrollViewer, and the rest of the
+        // stack (BBCode/shadows/blend/overflow/static reveal rows) comfortably exceeds a typical window
+        // height, so anything appended after it is invisible without resizing.
+        AddTypewriterSection(container);
 
         AddBbCodeSection(container);
 
@@ -99,6 +112,52 @@ internal class TextScreen : FrameworkElement
         AddMaxLettersToShowSection(container);
     }
 
+    // Typewriter reveal (#3701): MaxLettersToShow (the same property AddRevealRow sets to a
+    // fixed count) driven by elapsed time instead, via Tick. Pressing any key restarts the reveal
+    // from the beginning. FormsUtilities.Keyboard.KeysTyped is the platform-neutral "keys typed this
+    // frame" feed every backend's UseKeyboardDefaults() populates, so this needs no #if branching.
+    private const string TypewriterParagraph =
+        "This paragraph types itself out one letter at a time. Press any key to start the reveal over from the beginning.";
+    private const double TypewriterLettersPerSecond = 18;
+    private TextRuntime _typewriterText;
+    private double _typewriterElapsedSeconds;
+
+    /// <summary>
+    /// Advances the typewriter reveal by <paramref name="elapsedSeconds"/>. Call once per frame from
+    /// the host's game loop while this screen is active.
+    /// </summary>
+    public void Tick(double elapsedSeconds)
+    {
+        if (FormsUtilities.Keyboard.KeysTyped.Any())
+        {
+            _typewriterElapsedSeconds = 0;
+        }
+        else
+        {
+            _typewriterElapsedSeconds += elapsedSeconds;
+        }
+
+        int lettersToShow = (int)(_typewriterElapsedSeconds * TypewriterLettersPerSecond);
+        // TextRuntime.MaxLettersToShow is #if !SKIA-gated (see AddRevealRow above), so this goes
+        // through the renderable directly like the other MaxLettersToShow rows do.
+        ((SkiaGum.Text)_typewriterText.RenderableComponent).MaxLettersToShow =
+            Math.Min(lettersToShow, TypewriterParagraph.Length);
+    }
+
+    private void AddTypewriterSection(ContainerRuntime container)
+    {
+        _typewriterText = new TextRuntime();
+        _typewriterText.Font = "Arial";
+        _typewriterText.FontSize = 20;
+        _typewriterText.WidthUnits = DimensionUnitType.Absolute;
+        _typewriterText.Width = 300;
+        _typewriterText.HeightUnits = DimensionUnitType.RelativeToChildren;
+        _typewriterText.Height = 0;
+        _typewriterText.Text = TypewriterParagraph;
+        ((SkiaGum.Text)_typewriterText.RenderableComponent).MaxLettersToShow = 0;
+        container.Children.Add(_typewriterText);
+    }
+
     // BBCode inline styling on the SkiaGum.Text renderable (#3679): a single Text whose markup mixes
     // per-run color, font size, font scale, bold, and italic. SkiaGum parses the tags and feeds
     // RichTextKit one Style per run (Text.GetStyledRuns), matching the MonoGame / Raylib inline-styling
@@ -111,7 +170,7 @@ internal class TextScreen : FrameworkElement
         TextRuntime bbcode = new TextRuntime();
         bbcode.Font = "Arial";
         bbcode.FontSize = 24;
-        bbcode.WidthUnits = Gum.DataTypes.DimensionUnitType.Absolute;
+        bbcode.WidthUnits = DimensionUnitType.Absolute;
         bbcode.Width = 520;
         bbcode.Text =
             "[Color=Red]red[/Color], [Color=Blue]blue[/Color], " +
@@ -143,11 +202,14 @@ internal class TextScreen : FrameworkElement
         TextRuntime row = new TextRuntime();
         row.Font = "Arial";
         row.FontSize = 20;
-        row.WidthUnits = Gum.DataTypes.DimensionUnitType.Absolute;
+        row.WidthUnits = DimensionUnitType.Absolute;
         row.Width = 300;
-        row.HeightUnits = Gum.DataTypes.DimensionUnitType.RelativeToChildren;
+        row.HeightUnits = DimensionUnitType.RelativeToChildren;
         row.Height = 0;
         row.Text = paragraph;
+        // TextRuntime.MaxLettersToShow is #if !SKIA-gated in MonoGameGum/GueDeriving/TextRuntime.cs --
+        // SkiaGum.Text supports the property, the shared runtime forwarder just hasn't caught up -- so
+        // this goes through the renderable directly instead of the (MonoGame/raylib-only) runtime property.
         ((SkiaGum.Text)row.RenderableComponent).MaxLettersToShow = maxLetters;
         container.Children.Add(row);
     }
@@ -196,8 +258,8 @@ internal class TextScreen : FrameworkElement
         // The SpillOver box renders past its own bottom edge by design; reserve room below it so the
         // overflowing lines don't land on top of the next section in the top-to-bottom stack.
         var spillSpacer = new ContainerRuntime();
-        spillSpacer.WidthUnits = Gum.DataTypes.DimensionUnitType.Absolute;
-        spillSpacer.HeightUnits = Gum.DataTypes.DimensionUnitType.Absolute;
+        spillSpacer.WidthUnits = DimensionUnitType.Absolute;
+        spillSpacer.HeightUnits = DimensionUnitType.Absolute;
         spillSpacer.Width = 0;
         spillSpacer.Height = 40;
         container.Children.Add(spillSpacer);
@@ -207,8 +269,8 @@ internal class TextScreen : FrameworkElement
     private static RectangleRuntime MakeOverflowBox(float width, float height)
     {
         RectangleRuntime box = new RectangleRuntime();
-        box.WidthUnits = Gum.DataTypes.DimensionUnitType.Absolute;
-        box.HeightUnits = Gum.DataTypes.DimensionUnitType.Absolute;
+        box.WidthUnits = DimensionUnitType.Absolute;
+        box.HeightUnits = DimensionUnitType.Absolute;
         box.Width = width;
         box.Height = height;
         box.FillColor = new SKColor(40, 40, 40);
@@ -223,8 +285,8 @@ internal class TextScreen : FrameworkElement
         textRuntime.Text = text;
         textRuntime.Font = "Arial";
         textRuntime.FontSize = 18;
-        textRuntime.WidthUnits = Gum.DataTypes.DimensionUnitType.RelativeToParent;
-        textRuntime.HeightUnits = Gum.DataTypes.DimensionUnitType.RelativeToParent;
+        textRuntime.WidthUnits = DimensionUnitType.RelativeToParent;
+        textRuntime.HeightUnits = DimensionUnitType.RelativeToParent;
         textRuntime.Width = 0;
         textRuntime.Height = 0;
         return textRuntime;
@@ -235,8 +297,8 @@ internal class TextScreen : FrameworkElement
     private static void AddBlendOnTextSection(ContainerRuntime container)
     {
         var blendRow = new ContainerRuntime();
-        blendRow.WidthUnits = Gum.DataTypes.DimensionUnitType.RelativeToChildren;
-        blendRow.HeightUnits = Gum.DataTypes.DimensionUnitType.RelativeToChildren;
+        blendRow.WidthUnits = DimensionUnitType.RelativeToChildren;
+        blendRow.HeightUnits = DimensionUnitType.RelativeToChildren;
         blendRow.Width = 0;
         blendRow.Height = 0;
         blendRow.ChildrenLayout = ChildrenLayout.LeftToRightStack;
@@ -253,8 +315,8 @@ internal class TextScreen : FrameworkElement
         cell.Height = 48;
 
         var background = new RectangleRuntime();
-        background.WidthUnits = Gum.DataTypes.DimensionUnitType.RelativeToParent;
-        background.HeightUnits = Gum.DataTypes.DimensionUnitType.RelativeToParent;
+        background.WidthUnits = DimensionUnitType.RelativeToParent;
+        background.HeightUnits = DimensionUnitType.RelativeToParent;
         background.Width = 0;
         background.Height = 0;
         background.IsFilled = true;
@@ -262,8 +324,8 @@ internal class TextScreen : FrameworkElement
         cell.Children.Add(background);
 
         var text = new TextRuntime();
-        text.WidthUnits = Gum.DataTypes.DimensionUnitType.RelativeToParent;
-        text.HeightUnits = Gum.DataTypes.DimensionUnitType.RelativeToParent;
+        text.WidthUnits = DimensionUnitType.RelativeToParent;
+        text.HeightUnits = DimensionUnitType.RelativeToParent;
         text.Width = 0;
         text.Height = 0;
         text.FontSize = 24;

--- a/Samples/raylib/Program.cs
+++ b/Samples/raylib/Program.cs
@@ -89,6 +89,10 @@ public class BasicShapes
         {
             GumUI.Update(GetTime());
 
+            // FrameworkElement.Activity() is FRB-only and unavailable here, so screens that animate
+            // (e.g. TextScreen's typewriter reveal, #3701) get a host-driven per-frame Tick instead.
+            (activeScreen as TextScreen)?.Tick(GetFrameTime());
+
             // Apply a freshly-shown screen's initial gamepad focus now that this frame's
             // input (including the nav-button click that swapped screens) has been processed.
             if (_applyInitialFocusAfterUpdate)


### PR DESCRIPTION
## Summary
Adds a live typewriter-style reveal to the Text screen in all three feature samples (MonoGameGumInCode, raylib gallery — sharing one physical file — and SilkNetGum): a paragraph types itself out via `TextRuntime.MaxLettersToShow`, and any keypress resets it to 0.

Also ports the previously SilkNetGum-only static `MaxLettersToShow` demo (full/10/30 fixed reveal counts) into the shared MonoGame/raylib file, closing a pre-existing content-parity gap between the samples.

## Implementation
- `TextScreen.Tick(elapsedSeconds)` — new, called once per frame from each host's game loop while the screen is active. `FrameworkElement.Activity()` is FRB-only and unavailable in these plain samples, so this is host-driven instead.
- Key detection: `Gum.Forms.FormsUtilities.Keyboard.KeysTyped.Any()` — the existing cross-platform "keys typed this frame" feed, no `#if` branching needed.
- SilkNetGum's `MaxLettersToShow` access goes through `(SkiaGum.Text)row.RenderableComponent` rather than the `TextRuntime` property directly — `TextRuntime.MaxLettersToShow` is `#if !SKIA`-gated in the shared runtime even though `SkiaGum.Text` supports it. Follow-up filed separately to drain that gate and fully unify the two Text screens into one physical file (parity with the MonoGame/raylib merge from #3640).

## Manual test
Author-verified via build only; visual/interactive confirmation in progress by the repo owner across all three samples now.
