### PR TITLE
Docs: warn Custom Font File path bypasses KernSmith dropshadow

### DIFF
--- a/docs/code/files-and-fonts/font-strategies.md
+++ b/docs/code/files-and-fonts/font-strategies.md
@@ -220,6 +220,10 @@ text.Text = "Hello, I am using a custom font";
 text.AddToRoot();
 ```
 
+{% hint style="warning" %}
+This path loads the `.fnt` file as-is and bypasses KernSmith entirely, so `HasDropshadow` and the other KernSmith-driven properties (`OutlineThickness`, `IsBold`, `IsItalic`, `UseFontSmoothing`) have no effect here. If you need baked drop shadow with a font you own, register it as a `.ttf` and drive it through `Font`/`FontSize` instead — see [Registering Custom .ttf Fonts](font-strategies.md#registering-custom-ttf-fonts).
+{% endhint %}
+
 For information on creating your own `.fnt` file with Angelcode Bitmap Font Generator, see the [Use Custom Font](../../gum-tool/gum-elements/text/use-custom-font.md) page.
 
 This code assumes a font file named `WhitePeaberryOutline.fnt` is located in the `Content/WhitePeaberryOutline` folder. By default all Gum content loading is performed relative to the **Content** folder. See the [File Loading](file-loading.md) page for more information.


### PR DESCRIPTION
## Summary
- `font-strategies.md`'s Custom Font File section didn't mention that `UseCustomFont`/`CustomFontFile` loads the `.fnt` straight from disk, bypassing KernSmith entirely — so `HasDropshadow` (and outline/bold/italic/smoothing) silently have no effect there.
- Adds a warning hint pointing at the `Registering Custom .ttf Fonts` path for baked dropshadow with a custom font.

Prompted by a Discord user who set `HasDropshadow` alongside `UseCustomFont = true` and got no shadow.

## Test plan
- [x] Docs-only change, no runtime behavior — no manual test needed.