### PR TITLE
Fix FRB1 build break: GetOrCreateBakedFont referenced TextRuntime unguarded

### DIFF
--- a/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
+++ b/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
@@ -1707,8 +1707,14 @@ public partial class CustomSetPropertyOnRenderable
     /// and the CustomFontFile-as-.ttf/.otf path (#3703) so both bake through the same
     /// cache/embedded-resource/InMemoryFontCreator/FontService/disk cascade.
     /// </summary>
+#if FRB
+    // FRB doesn't yet have a TextRuntime, so we have to do this:
+    private static BitmapFont GetOrCreateBakedFont(GraphicalUiElement textRuntime,
+        global::RenderingLibrary.Content.LoaderManager loaderManager, string? fontFilePath)
+#else
     private static BitmapFont GetOrCreateBakedFont(Gum.GueDeriving.TextRuntime textRuntime,
         global::RenderingLibrary.Content.LoaderManager loaderManager, string? fontFilePath)
+#endif
     {
         BitmapFont font = null;
 


### PR DESCRIPTION
#3707 added `GetOrCreateBakedFont` with an unguarded `Gum.GueDeriving.TextRuntime` parameter. FRB1 compiles this file as source (no `TextRuntime` type there), so it broke every FRB1 game build with CS0234.

Splits the signature with `#if FRB`/`#else`, mirroring the existing `textRuntime`-typing pattern already used elsewhere in this file (`GraphicalUiElement` under FRB, `TextRuntime` otherwise).

Verified: FRB1's `GumCore.DesktopGlNet6` canary (net6.0 + net8.0), `MonoGameGum.Tests`, `RaylibGum` all build clean.

Root cause analysis (why this wasn't caught before merge) to follow separately.