### PR TITLE
Implement TextRuntime.GetCharacterIndexAtPosition on Skia

### DIFF
--- a/MonoGameGum/GueDeriving/TextRuntime.cs
+++ b/MonoGameGum/GueDeriving/TextRuntime.cs
@@ -868,7 +868,6 @@ public class TextRuntime : InteractiveGue
     public void AddToManagers() => base.AddToManagers(SystemManagers.Default, layer: null);
 #endif
 
-#if !SKIA
     /// <summary>
     /// Returns the index of the character at the specified screen position. This returns the index
     /// within the WrappedText, so to index in, you need to loop through each line.
@@ -877,5 +876,4 @@ public class TextRuntime : InteractiveGue
     /// <param name="screenY">The screen y position, usually obtained by Cursor.YRespectingGumZoomAndBounds()</param>
     /// <returns>The index in the WrappedText</returns>
     public int GetCharacterIndexAtPosition(float screenX, float screenY) => ContainedText.GetCharacterIndexAtPosition(screenX, screenY);
-#endif
 }

--- a/Runtimes/SkiaGum/Renderables/Text.cs
+++ b/Runtimes/SkiaGum/Renderables/Text.cs
@@ -360,6 +360,37 @@ public class Text : IRenderableIpso, IVisible, IFormsText, ICloneable
         return lines;
     }
 
+    /// <summary>
+    /// Returns the index of the character at the specified screen position -- the code-point offset
+    /// into the same text stream <see cref="WrappedText"/> concatenates over, matching the "index within
+    /// the WrappedText" contract of the MonoGame/Raylib backends'
+    /// <c>TextExtensions.GetCharacterIndexAtPosition</c> (issue #3708). Unlike those backends, which
+    /// measure each character's advance in a loop (MonoGame via <c>BitmapFont</c>, Raylib via
+    /// <c>MeasureString</c>) because they have no other way to hit-test, this uses RichTextKit's own
+    /// <see cref="TextBlock.HitTest(float, float)"/> against the cached layout block -- it already
+    /// accounts for alignment, per-run BBCode styling, and Unicode line breaking, so there is no reason
+    /// to duplicate that math here.
+    /// </summary>
+    /// <param name="screenX">The screen x position, usually obtained by Cursor.XRespectingGumZoomAndBounds()</param>
+    /// <param name="screenY">The screen y position, usually obtained by Cursor.YRespectingGumZoomAndBounds()</param>
+    /// <returns>The index in the WrappedText</returns>
+    public int GetCharacterIndexAtPosition(float screenX, float screenY)
+    {
+        var textBlock = GetCachedTextBlock();
+
+        if (textBlock.Lines.Count == 0)
+        {
+            return 0;
+        }
+
+        var absoluteX = this.GetAbsoluteX();
+        var absoluteY = this.GetAbsoluteY() + GetVerticalAlignmentOffset(textBlock);
+
+        var hitTestResult = textBlock.HitTest(screenX - absoluteX, screenY - absoluteY);
+
+        return hitTestResult.ClosestCodePointIndex;
+    }
+
     /// <inheritdoc/>
     /// <remarks>
     /// Measured at the base font size (<see cref="FontSize"/> scaled only by
@@ -779,25 +810,7 @@ public class Text : IRenderableIpso, IVisible, IFormsText, ICloneable
             //// Gum uses counter clockwise rotation, Skia uses clockwise, so invert:
             SKMatrix rotationMatrix = SKMatrix.CreateRotationDegrees(-Rotation);
             var absoluteX = this.GetAbsoluteX();
-            var absoluteY = this.GetAbsoluteY();
-
-            if(this.VerticalAlignment == VerticalAlignment.Center)
-            {
-                // compare the bound height with the actual height, and adjust the offset
-                var textBlockHeight = textBlock.MeasuredHeight;
-                var boundsHeight = this.Height;
-
-                absoluteY += (boundsHeight - textBlockHeight)/2.0f;
-            }
-
-            if(this.VerticalAlignment == VerticalAlignment.Bottom)
-            {
-                // compare the bound height with the actual height, and adjust the offset
-                var textBlockHeight = textBlock.MeasuredHeight;
-                var boundsHeight = this.Height;
-
-                absoluteY += boundsHeight - textBlockHeight;
-            }
+            var absoluteY = this.GetAbsoluteY() + GetVerticalAlignmentOffset(textBlock);
 
             SKMatrix translateMatrix = SKMatrix.CreateTranslation(absoluteX, absoluteY);
             // Continue to apply the previou matrix in case there is scaling
@@ -843,6 +856,27 @@ public class Text : IRenderableIpso, IVisible, IFormsText, ICloneable
             }
             canvas.Restore();
         }
+    }
+
+    /// <summary>
+    /// The vertical shift applied to <see cref="GetAbsoluteY"/> before positioning <paramref name="textBlock"/>
+    /// -- Center/Bottom shift the block within <see cref="Height"/> so it isn't pinned to the top. Shared by
+    /// <see cref="Render"/> (positioning the painted block) and <see cref="GetCharacterIndexAtPosition(float, float)"/>
+    /// (converting a screen click into the same block-local coordinate space), so the two never drift apart.
+    /// </summary>
+    private float GetVerticalAlignmentOffset(TextBlock textBlock)
+    {
+        if (VerticalAlignment == VerticalAlignment.Center)
+        {
+            return (Height - textBlock.MeasuredHeight) / 2.0f;
+        }
+
+        if (VerticalAlignment == VerticalAlignment.Bottom)
+        {
+            return Height - textBlock.MeasuredHeight;
+        }
+
+        return 0;
     }
 
     /// <summary>

--- a/Samples/SilkNetGum/SilkNetGumSample/Screens/TextScreen.cs
+++ b/Samples/SilkNetGum/SilkNetGumSample/Screens/TextScreen.cs
@@ -121,6 +121,29 @@ internal class TextScreen : FrameworkElement
 
         AddOverflowSection(container);
 
+        // GetCharacterIndexAtPosition (#3708): click the text, report the hit index. Newly implemented
+        // on SkiaGum.Text via RichTextKit's TextBlock.HitTest -- same position in this section as the
+        // MonoGame/raylib screen's BuildTextParitySection, minus the TextRenderingPositionMode toggle
+        // right before it there, which is still a Skia gap (#3708) and has no equivalent here.
+        TextRuntime hitText = new TextRuntime();
+        hitText.FontSize = 24;
+        hitText.Text = "Click me to report the character index";
+        hitText.HasEvents = true;
+        container.Children.Add(hitText);
+
+        TextRuntime hitResult = new TextRuntime();
+        hitResult.FontSize = 16;
+        hitResult.Text = "(no click yet)";
+        container.Children.Add(hitResult);
+
+        hitText.Click += (_, _) =>
+        {
+            float cursorX = FrameworkElement.MainCursor.XRespectingGumZoomAndBounds();
+            float cursorY = FrameworkElement.MainCursor.YRespectingGumZoomAndBounds();
+            int index = hitText.GetCharacterIndexAtPosition(cursorX, cursorY);
+            hitResult.Text = $"Character index at click: {index}";
+        };
+
         AddMaxLettersToShowSection(container);
     }
 

--- a/Tests/SkiaGum.Tests/GueDeriving/TextRuntimeTests.cs
+++ b/Tests/SkiaGum.Tests/GueDeriving/TextRuntimeTests.cs
@@ -199,6 +199,57 @@ public class TextRuntimeTests
 
     #endregion
 
+    #region GetCharacterIndexAtPosition
+
+    // #3708: TextRuntime.GetCharacterIndexAtPosition was #if !SKIA -- SkiaGum's Text renderable had no
+    // equivalent at all. Implemented via RichTextKit's own TextBlock.HitTest rather than the per-character
+    // measurement loop TextExtensions.GetCharacterIndexAtPosition uses on MonoGame/Raylib, since Skia's
+    // renderable has no bitmap-font character-advance table to loop over.
+    // An unmanaged Text sits at absolute origin (0,0), so screen (0,0) is its top-left -- mirrors the
+    // Raylib parity test (RaylibGum.Tests.Runtimes.TextRuntimeTests).
+    [Fact]
+    public void GetCharacterIndexAtPosition_AtLeftEdge_ShouldReturnZero()
+    {
+        TextRuntime sut = new();
+        sut.Width = 200;
+        sut.Text = "Hello";
+
+        sut.GetCharacterIndexAtPosition(0, 0).ShouldBe(0);
+    }
+
+    // A click far past the right edge of a single line clamps to the end of the text (index == length),
+    // matching the MonoGame/Raylib renderables' behavior.
+    [Fact]
+    public void GetCharacterIndexAtPosition_FarRightOfSingleLine_ShouldReturnTextLength()
+    {
+        TextRuntime sut = new();
+        sut.Width = 200;
+        sut.Text = "Hello";
+
+        sut.GetCharacterIndexAtPosition(1000, 0).ShouldBe(5);
+    }
+
+    // The returned index is defined as an offset into the concatenation of WrappedText (issue body,
+    // "index within the WrappedText, so to index in, you need to loop through each line"), not an index
+    // local to whichever line was clicked. A click on the second line must therefore account for the
+    // first line's length -- clamping to the full text length here proves the cross-line accumulation
+    // works, since a line-local implementation would instead clamp to "Line2".Length.
+    [Fact]
+    public void GetCharacterIndexAtPosition_FarRightOfSecondLine_ShouldReturnFullTextLength()
+    {
+        TextRuntime sut = new();
+        sut.Width = 200;
+        string text = "Line1\nLine2";
+        sut.Text = text;
+
+        Text containedText = (Text)sut.RenderableComponent;
+        var lineHeight = containedText.LineHeightInPixels * containedText.LineHeightMultiplier;
+
+        sut.GetCharacterIndexAtPosition(1000, lineHeight + 1).ShouldBe(text.Length);
+    }
+
+    #endregion
+
     #region IsBold
 
     [Fact]


### PR DESCRIPTION
## Summary
- Implements `TextRuntime.GetCharacterIndexAtPosition(x, y)` on Skia -- one row of the #3708 tracker (the property was already `#if !SKIA`-gated with no renderable-level equivalent on Skia).
- `SkiaGum.Text.GetCharacterIndexAtPosition` uses RichTextKit's own `TextBlock.HitTest` rather than duplicating the per-character measurement loop `TextExtensions.GetCharacterIndexAtPosition` uses on MonoGame/Raylib -- it already accounts for alignment, per-run BBCode styling, and Unicode line breaking.
- Extracted the vertical-alignment offset math (Center/Bottom) that `Render` and the new method both need into a shared `GetVerticalAlignmentOffset` helper.

Part of #3708.

## Test plan
- [x] `dotnet test Tests/SkiaGum.Tests/SkiaGum.Tests.csproj` -- 322/322 passing (3 new tests covering left-edge, right-edge clamp, and cross-line index accumulation).
- [x] `dotnet test MonoGameGum.Tests/MonoGameGum.Tests.csproj --filter TextRuntime` -- 76/76 (no regression from un-gating the shared wrapper).
- [x] `dotnet test Tests/RaylibGum.Tests/RaylibGum.Tests.csproj --filter TextRuntime` -- 57/57 (no regression).
- Manual test: not needed -- pure hit-test/geometry math with no visual output, fully covered by unit tests; the `Render` refactor is behavior-preserving (confirmed by the full SkiaGum suite staying green).
- FRB canary: not needed -- `TextRuntime.cs` isn't part of FRB1-shared source (FRB1 uses codegen, not `TextRuntime`, per #3708's own notes), and `SkiaGum/Renderables/Text.cs` is Skia-only.
