### PR TITLE
Add TextRenderingPositionMode pixel-snap support to Skia text

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,8 @@ For every task, read the guidelines in the matching agent file under `.claude/ag
 
 Also load any skill whose trigger matches the area you're working in — before reading code, designing a fix, or making changes. "I'm only investigating, not editing yet" is not a reason to skip; the skill exists to inform the investigation, not just the keystrokes. The only time it's acceptable to skip is for a trivial single-file lookup that won't influence any recommendation or change.
 
+**This check re-runs per new file path, not once per task.** Matching skills against the files identified at task start (e.g. the source file a bug lives in) does not cover a different file touched later in the same task — a sample or test project pulled in only for manual verification, a config file edited in passing, a doc updated alongside. Each new file gets its own trigger-match against the skill list before it's edited, even when the task's "main" skill is already loaded.
+
 Available agents:
 - **coder** — Writing or modifying code and unit tests for new features or bugs
 - **refactoring-specialist** — Refactoring and improving code structure

--- a/MonoGameGum/GueDeriving/TextRuntime.cs
+++ b/MonoGameGum/GueDeriving/TextRuntime.cs
@@ -639,7 +639,6 @@ public class TextRuntime : InteractiveGue
     // truncation silently stops working (broke DialogBox multi-page splitting). The inherited property
     // already forwards to the contained renderable, so no cast is needed to set it from a TextRuntime.
 
-#if !SKIA
     /// <summary>
     /// Gets or sets the text rendering position mode to use for the contained text, overriding the default behavior if
     /// specified.
@@ -652,7 +651,6 @@ public class TextRuntime : InteractiveGue
         get => ContainedText.OverrideTextRenderingPositionMode;
         set => ContainedText.OverrideTextRenderingPositionMode = value;
     }
-#endif
 
     /// <summary>
     /// Gets or sets the raw text content displayed by the control. This is the value before line wrapping and bbcode parsing has been applied.

--- a/Runtimes/SkiaGum/Renderables/Text.cs
+++ b/Runtimes/SkiaGum/Renderables/Text.cs
@@ -1,5 +1,6 @@
 ﻿using RenderingLibrary;
 using RenderingLibrary.Graphics;
+using RenderingLibrary.Math;
 using Gum.GueDeriving;
 using SkiaGum.Renderables;
 using SkiaSharp;
@@ -84,6 +85,29 @@ public class ParameterizedLetterCustomizationCall
     public int CharacterIndex { get; set; }
 
     public string TextBlock { get; set; } = string.Empty;
+}
+
+#endregion
+
+#region TextRenderingPositionMode
+
+/// <summary>
+/// Controls whether <see cref="Text.Render"/> snaps this Text's draw origin to a whole pixel
+/// (issue #3708). Skia rasterizes glyphs live via RichTextKit with anti-aliasing rather than
+/// blitting a pre-baked glyph-atlas texture (the XNALIKE/Raylib approach), so a sub-pixel origin
+/// doesn't cause texture-sampling shimmer -- but it does give each glyph a slightly different
+/// anti-aliasing pattern per frame, or between sibling items in a list, which reads as
+/// jitter/inconsistency at small pixel-art font sizes. Mirrors the XNALIKE
+/// (<see cref="RenderingLibrary.Graphics.TextRenderingPositionMode"/>) and Raylib
+/// (<see cref="Gum.Renderables.TextRenderingPositionMode"/>) enum values and default.
+/// </summary>
+public enum TextRenderingPositionMode
+{
+    /// <summary>The draw origin is rounded to the nearest whole pixel before painting.</summary>
+    SnapToPixel,
+
+    /// <summary>The draw origin is used exactly as computed, including any fractional offset.</summary>
+    FreeFloating,
 }
 
 #endregion
@@ -451,6 +475,45 @@ public class Text : IRenderableIpso, IVisible, IFormsText, ICloneable
         }
     }
 
+    /// <summary>
+    /// The default pixel-snap behavior applied to every <see cref="Text"/> instance that doesn't
+    /// set <see cref="OverrideTextRenderingPositionMode"/>. Mirrors the XNALIKE/Raylib static
+    /// default (<see cref="TextRenderingPositionMode.SnapToPixel"/>).
+    /// </summary>
+    public static TextRenderingPositionMode TextRenderingPositionMode = TextRenderingPositionMode.SnapToPixel;
+
+    /// <summary>
+    /// Per-instance override for <see cref="TextRenderingPositionMode"/>. When null (the default),
+    /// this Text uses the static <see cref="TextRenderingPositionMode"/>; when set, it overrides the
+    /// static default for this instance only. Mirrors the XNALIKE/Raylib Text renderables.
+    /// </summary>
+    public TextRenderingPositionMode? OverrideTextRenderingPositionMode;
+
+    /// <summary>
+    /// The position mode actually applied when drawing this Text: the per-instance
+    /// <see cref="OverrideTextRenderingPositionMode"/> when set, otherwise the static
+    /// <see cref="TextRenderingPositionMode"/>.
+    /// </summary>
+    internal TextRenderingPositionMode EffectiveTextRenderingPositionMode =>
+        OverrideTextRenderingPositionMode ?? TextRenderingPositionMode;
+
+    /// <summary>
+    /// Rounds <paramref name="x"/>/<paramref name="y"/> to the nearest whole pixel (matching the
+    /// away-from-zero rounding <see cref="MathFunctions.RoundToInt(float)"/> uses on XNALIKE/Raylib)
+    /// when <see cref="EffectiveTextRenderingPositionMode"/> is <see cref="TextRenderingPositionMode.SnapToPixel"/>;
+    /// otherwise returns them unchanged. Used by <see cref="Render"/> to snap the draw origin.
+    /// Exposed internally for unit testing.
+    /// </summary>
+    internal (float X, float Y) GetSnappedOrigin(float x, float y)
+    {
+        if (EffectiveTextRenderingPositionMode != TextRenderingPositionMode.SnapToPixel)
+        {
+            return (x, y);
+        }
+
+        return (MathFunctions.RoundToInt(x), MathFunctions.RoundToInt(y));
+    }
+
     #region Dropshadow
 
     // Standalone (non-BBCode) drop shadow for Skia text (issue #3674). Mirrors the drop-shadow
@@ -811,6 +874,7 @@ public class Text : IRenderableIpso, IVisible, IFormsText, ICloneable
             SKMatrix rotationMatrix = SKMatrix.CreateRotationDegrees(-Rotation);
             var absoluteX = this.GetAbsoluteX();
             var absoluteY = this.GetAbsoluteY() + GetVerticalAlignmentOffset(textBlock);
+            (absoluteX, absoluteY) = GetSnappedOrigin(absoluteX, absoluteY);
 
             SKMatrix translateMatrix = SKMatrix.CreateTranslation(absoluteX, absoluteY);
             // Continue to apply the previou matrix in case there is scaling

--- a/Samples/SilkNetGum/SilkNetGumSample/Screens/TextScreen.cs
+++ b/Samples/SilkNetGum/SilkNetGumSample/Screens/TextScreen.cs
@@ -5,6 +5,7 @@ using Gum.GueDeriving;
 using Gum.Managers;
 using Gum.Wireframe;
 using RenderingLibrary.Graphics;
+using SkiaGum;
 using SkiaSharp;
 using System;
 using System.Linq;
@@ -121,10 +122,38 @@ internal class TextScreen : FrameworkElement
 
         AddOverflowSection(container);
 
+        // --- Per-instance TextRenderingPositionMode override, at a fractional origin (#3708) ---
+        // Same position/content as the MonoGame/raylib screen's BuildTextParitySection. Skia rounds the
+        // RichTextKit draw origin to a whole pixel under SnapToPixel (default) instead of blitting a
+        // glyph-atlas texture, so this keeps anti-aliasing consistent rather than avoiding sampling
+        // shimmer -- but the visible effect on this toggle is the same either way.
+        TextRuntime snapText = new TextRuntime();
+        snapText.FontSize = 20;
+        snapText.X = 120.5f;
+        snapText.Text = "Fractional X=120.5 - SnapToPixel";
+        snapText.TextRenderingPositionMode = TextRenderingPositionMode.SnapToPixel;
+        container.Children.Add(snapText);
+
+        Button toggleButton = new Button();
+        toggleButton.Text = "Toggle snap mode";
+        toggleButton.Click += (_, _) =>
+        {
+            if (snapText.TextRenderingPositionMode == TextRenderingPositionMode.SnapToPixel)
+            {
+                snapText.TextRenderingPositionMode = TextRenderingPositionMode.FreeFloating;
+                snapText.Text = "Fractional X=120.5 - FreeFloating";
+            }
+            else
+            {
+                snapText.TextRenderingPositionMode = TextRenderingPositionMode.SnapToPixel;
+                snapText.Text = "Fractional X=120.5 - SnapToPixel";
+            }
+        };
+        container.Children.Add(toggleButton.Visual);
+
         // GetCharacterIndexAtPosition (#3708): click the text, report the hit index. Newly implemented
         // on SkiaGum.Text via RichTextKit's TextBlock.HitTest -- same position in this section as the
-        // MonoGame/raylib screen's BuildTextParitySection, minus the TextRenderingPositionMode toggle
-        // right before it there, which is still a Skia gap (#3708) and has no equivalent here.
+        // MonoGame/raylib screen's BuildTextParitySection.
         TextRuntime hitText = new TextRuntime();
         hitText.FontSize = 24;
         hitText.Text = "Click me to report the character index";

--- a/Samples/SkiaGumWpfSample/SkiaGumWpfSample/MainWindow.xaml.cs
+++ b/Samples/SkiaGumWpfSample/SkiaGumWpfSample/MainWindow.xaml.cs
@@ -1,5 +1,4 @@
 ﻿using Gum.GueDeriving;
-using SkiaGum;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -43,46 +42,6 @@ namespace SkiaGumWpfSample
             rectangle2.IsFilled = true;
 
             container.Children.Add(rectangle2);
-
-            // Issue #3708 manual check: two columns of small-font list items, each row nudged to a
-            // different fractional X so it lands at a different sub-pixel offset -- like real list
-            // items whose X varies with scroll/animation. Left column uses the SnapToPixel default
-            // (rounds the draw origin to a whole pixel); right column forces FreeFloating (paints at
-            // the exact fractional position). At a small font size the left column's glyph edges
-            // should look uniformly crisp row-to-row; the right column's edges should look slightly
-            // softer/inconsistent since each row's anti-aliasing lands on a different sub-pixel offset.
-            string[] labels = { "Item One", "Item Two", "Item Three", "Item Four", "Item Five" };
-            float[] fractionalOffsets = { 0.1f, 0.3f, 0.5f, 0.7f, 0.9f };
-
-            var textBackground = new RectangleRuntime();
-            textBackground.FillColor = new SkiaSharp.SKColor(230, 230, 230);
-            textBackground.IsFilled = true;
-            textBackground.X = 10;
-            textBackground.Y = 140;
-            textBackground.Width = 400;
-            textBackground.Height = 120;
-            SkiaElement.Children.Add(textBackground);
-
-            for (int i = 0; i < labels.Length; i++)
-            {
-                var snapped = new TextRuntime();
-                snapped.Text = labels[i];
-                snapped.FontSize = 11;
-                snapped.Color = new SkiaSharp.SKColor(0, 0, 0);
-                snapped.X = 20 + fractionalOffsets[i];
-                snapped.Y = 150 + i * 20;
-                // TextRenderingPositionMode left at its default (SnapToPixel).
-                SkiaElement.Children.Add(snapped);
-
-                var freeFloating = new TextRuntime();
-                freeFloating.Text = labels[i];
-                freeFloating.FontSize = 11;
-                freeFloating.Color = new SkiaSharp.SKColor(0, 0, 0);
-                freeFloating.X = 220 + fractionalOffsets[i];
-                freeFloating.Y = 150 + i * 20;
-                freeFloating.TextRenderingPositionMode = TextRenderingPositionMode.FreeFloating;
-                SkiaElement.Children.Add(freeFloating);
-            }
         }
     }
 }

--- a/Samples/SkiaGumWpfSample/SkiaGumWpfSample/MainWindow.xaml.cs
+++ b/Samples/SkiaGumWpfSample/SkiaGumWpfSample/MainWindow.xaml.cs
@@ -54,21 +54,32 @@ namespace SkiaGumWpfSample
             string[] labels = { "Item One", "Item Two", "Item Three", "Item Four", "Item Five" };
             float[] fractionalOffsets = { 0.1f, 0.3f, 0.5f, 0.7f, 0.9f };
 
+            var textBackground = new RectangleRuntime();
+            textBackground.FillColor = new SkiaSharp.SKColor(230, 230, 230);
+            textBackground.IsFilled = true;
+            textBackground.X = 10;
+            textBackground.Y = 140;
+            textBackground.Width = 400;
+            textBackground.Height = 120;
+            SkiaElement.Children.Add(textBackground);
+
             for (int i = 0; i < labels.Length; i++)
             {
                 var snapped = new TextRuntime();
                 snapped.Text = labels[i];
                 snapped.FontSize = 11;
+                snapped.Color = new SkiaSharp.SKColor(0, 0, 0);
                 snapped.X = 20 + fractionalOffsets[i];
-                snapped.Y = 80 + i * 20;
+                snapped.Y = 150 + i * 20;
                 // TextRenderingPositionMode left at its default (SnapToPixel).
                 SkiaElement.Children.Add(snapped);
 
                 var freeFloating = new TextRuntime();
                 freeFloating.Text = labels[i];
                 freeFloating.FontSize = 11;
+                freeFloating.Color = new SkiaSharp.SKColor(0, 0, 0);
                 freeFloating.X = 220 + fractionalOffsets[i];
-                freeFloating.Y = 80 + i * 20;
+                freeFloating.Y = 150 + i * 20;
                 freeFloating.TextRenderingPositionMode = TextRenderingPositionMode.FreeFloating;
                 SkiaElement.Children.Add(freeFloating);
             }

--- a/Samples/SkiaGumWpfSample/SkiaGumWpfSample/MainWindow.xaml.cs
+++ b/Samples/SkiaGumWpfSample/SkiaGumWpfSample/MainWindow.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using Gum.GueDeriving;
+using SkiaGum;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -42,6 +43,35 @@ namespace SkiaGumWpfSample
             rectangle2.IsFilled = true;
 
             container.Children.Add(rectangle2);
+
+            // Issue #3708 manual check: two columns of small-font list items, each row nudged to a
+            // different fractional X so it lands at a different sub-pixel offset -- like real list
+            // items whose X varies with scroll/animation. Left column uses the SnapToPixel default
+            // (rounds the draw origin to a whole pixel); right column forces FreeFloating (paints at
+            // the exact fractional position). At a small font size the left column's glyph edges
+            // should look uniformly crisp row-to-row; the right column's edges should look slightly
+            // softer/inconsistent since each row's anti-aliasing lands on a different sub-pixel offset.
+            string[] labels = { "Item One", "Item Two", "Item Three", "Item Four", "Item Five" };
+            float[] fractionalOffsets = { 0.1f, 0.3f, 0.5f, 0.7f, 0.9f };
+
+            for (int i = 0; i < labels.Length; i++)
+            {
+                var snapped = new TextRuntime();
+                snapped.Text = labels[i];
+                snapped.FontSize = 11;
+                snapped.X = 20 + fractionalOffsets[i];
+                snapped.Y = 80 + i * 20;
+                // TextRenderingPositionMode left at its default (SnapToPixel).
+                SkiaElement.Children.Add(snapped);
+
+                var freeFloating = new TextRuntime();
+                freeFloating.Text = labels[i];
+                freeFloating.FontSize = 11;
+                freeFloating.X = 220 + fractionalOffsets[i];
+                freeFloating.Y = 80 + i * 20;
+                freeFloating.TextRenderingPositionMode = TextRenderingPositionMode.FreeFloating;
+                SkiaElement.Children.Add(freeFloating);
+            }
         }
     }
 }

--- a/Tests/SkiaGum.Tests/GueDeriving/TextRuntimeTests.cs
+++ b/Tests/SkiaGum.Tests/GueDeriving/TextRuntimeTests.cs
@@ -497,6 +497,32 @@ public class TextRuntimeTests
 
     #endregion
 
+    #region TextRenderingPositionMode
+
+    // TextRuntime.TextRenderingPositionMode was #if !SKIA -- Skia's Text renderable had no
+    // pixel-snap concept at all (issue #3708). Now forwards straight to the contained renderable,
+    // matching the MonoGame/Raylib TextRuntime surface.
+
+    [Fact]
+    public void TextRenderingPositionMode_ShouldDefaultToNull()
+    {
+        TextRuntime sut = new();
+        sut.TextRenderingPositionMode.ShouldBeNull();
+    }
+
+    [Fact]
+    public void TextRenderingPositionMode_ShouldRoundTripThroughRenderable()
+    {
+        TextRuntime sut = new();
+        sut.TextRenderingPositionMode = TextRenderingPositionMode.FreeFloating;
+
+        sut.TextRenderingPositionMode.ShouldBe(TextRenderingPositionMode.FreeFloating);
+        ((Text)sut.RenderableComponent).OverrideTextRenderingPositionMode
+            .ShouldBe(TextRenderingPositionMode.FreeFloating);
+    }
+
+    #endregion
+
     #region UseFontSmoothing
 
     [Fact]

--- a/Tests/SkiaGum.Tests/Renderables/TextRenderingPositionModeTests.cs
+++ b/Tests/SkiaGum.Tests/Renderables/TextRenderingPositionModeTests.cs
@@ -1,0 +1,79 @@
+using Shouldly;
+using SkiaGum;
+
+namespace SkiaGum.Tests.Renderables;
+
+/// <summary>
+/// Verifies Skia's pixel-snap knob for <see cref="Text"/> (issue #3708). Unlike XNALIKE/Raylib,
+/// Skia rasterizes glyphs live via RichTextKit rather than blitting a pre-baked glyph-atlas
+/// texture, so snapping isn't about avoiding texture-sampling shimmer -- it keeps the
+/// anti-aliasing pattern consistent frame to frame and across sibling items in a list.
+/// </summary>
+public class TextRenderingPositionModeTests
+{
+    [Fact]
+    public void TextRenderingPositionMode_DefaultsToSnapToPixel()
+    {
+        Text.TextRenderingPositionMode.ShouldBe(TextRenderingPositionMode.SnapToPixel);
+    }
+
+    [Fact]
+    public void EffectiveTextRenderingPositionMode_ShouldFallBackToStatic_WhenNoOverride()
+    {
+        TextRenderingPositionMode saved = Text.TextRenderingPositionMode;
+        try
+        {
+            Text.TextRenderingPositionMode = TextRenderingPositionMode.FreeFloating;
+            Text sut = new();
+            sut.OverrideTextRenderingPositionMode = null;
+
+            sut.EffectiveTextRenderingPositionMode.ShouldBe(TextRenderingPositionMode.FreeFloating);
+        }
+        finally
+        {
+            Text.TextRenderingPositionMode = saved;
+        }
+    }
+
+    [Fact]
+    public void EffectiveTextRenderingPositionMode_ShouldPreferInstanceOverride_OverStatic()
+    {
+        TextRenderingPositionMode saved = Text.TextRenderingPositionMode;
+        try
+        {
+            Text.TextRenderingPositionMode = TextRenderingPositionMode.SnapToPixel;
+            Text sut = new();
+            sut.OverrideTextRenderingPositionMode = TextRenderingPositionMode.FreeFloating;
+
+            sut.EffectiveTextRenderingPositionMode.ShouldBe(TextRenderingPositionMode.FreeFloating);
+        }
+        finally
+        {
+            Text.TextRenderingPositionMode = saved;
+        }
+    }
+
+    [Fact]
+    public void GetSnappedOrigin_RoundsToNearestWholePixel_WhenSnapToPixel()
+    {
+        Text sut = new();
+        sut.OverrideTextRenderingPositionMode = TextRenderingPositionMode.SnapToPixel;
+
+        (float X, float Y) result = sut.GetSnappedOrigin(10.6f, 20.4f);
+
+        result.X.ShouldBe(11f);
+        result.Y.ShouldBe(20f);
+    }
+
+    [Fact]
+    public void GetSnappedOrigin_ReturnsValueUnchanged_WhenFreeFloating()
+    {
+        Text sut = new();
+        sut.OverrideTextRenderingPositionMode = TextRenderingPositionMode.FreeFloating;
+
+        (float X, float Y) result = sut.GetSnappedOrigin(10.6f, 20.4f);
+
+        result.X.ShouldBe(10.6f);
+        result.Y.ShouldBe(20.4f);
+    }
+}


### PR DESCRIPTION
Closes the `TextRenderingPositionMode` row of #3708 for Skia (the last ❌ in that row's table).

## Why Skia needs this too

XNALIKE/Raylib's `SnapToPixel` exists to avoid texture-sampling shimmer when blitting a pre-baked glyph-atlas texture at a non-integer position. Skia (via RichTextKit) instead rasterizes glyphs live with anti-aliasing every frame, so a sub-pixel draw origin doesn't cause that shimmer -- but it does give each glyph a slightly different AA pattern per frame or between sibling items in a list, which reads as jitter/inconsistency at small pixel-art font sizes.

## What changed

- `Runtimes/SkiaGum/Renderables/Text.cs`: new `TextRenderingPositionMode` enum (`SnapToPixel`/`FreeFloating`), static default + per-instance override (mirroring XNALIKE/Raylib), and an `internal GetSnappedOrigin` helper that rounds the render-time draw origin to the nearest whole pixel (away-from-zero, matching `MathFunctions.RoundToInt`) when `SnapToPixel` is active. Wired into `Render()` right before building the translation matrix. No rotation/scale gate (unlike XNALIKE) -- Skia composes rotation as a separate matrix rather than baking it per-character, so it doesn't need XNALIKE's per-character-blit workaround; this mirrors Raylib's simpler matrix-based approach instead.
- `MonoGameGum/GueDeriving/TextRuntime.cs`: un-gated `TextRenderingPositionMode` from `#if !SKIA` now that Skia has a real implementation to forward to.
- Tests: renderable-level coverage in `Tests/SkiaGum.Tests/Renderables/TextRenderingPositionModeTests.cs`, `TextRuntime` round-trip coverage added to `Tests/SkiaGum.Tests/GueDeriving/TextRuntimeTests.cs`.
- `Samples/SkiaGumWpfSample`: added a manual-check demo (two columns of small-font list items at varying fractional X, one column SnapToPixel/default, one FreeFloating).

## Test plan

- [x] `dotnet test Tests/SkiaGum.Tests/SkiaGum.Tests.csproj` -- 329 passed
- [x] `dotnet test MonoGameGum.Tests/MonoGameGum.Tests.csproj` -- 1864 passed
- [x] `dotnet test Tests/RaylibGum.Tests/RaylibGum.Tests.csproj` -- 502 passed
- [x] `dotnet build Runtimes/SkiaGum.Wpf/SkiaGum.Wpf.csproj` -- clean
- [ ] Manual: `Samples/SkiaGumWpfSample` opened in VS -- run and visually compare the two columns (left: SnapToPixel default, right: FreeFloating) at a small font size
