### PR TITLE
Document OverlapDirection as intentionally XNALIKE-only

### DIFF
--- a/MonoGameGum/GueDeriving/TextRuntime.cs
+++ b/MonoGameGum/GueDeriving/TextRuntime.cs
@@ -753,9 +753,10 @@ public class TextRuntime : InteractiveGue
     /// for details. Defaults to <see cref="OverlapDirection.RightOnTop"/>.
     /// </summary>
     /// <remarks>
-    /// Not supported on Raylib — the underlying Raylib text-rendering calls draw
-    /// a full string as a single unit and do not expose per-glyph ordering.
-    /// Not supported on SkiaGum — Skia's text renderable uses a different path.
+    /// Not supported on Raylib or SkiaGum. Both draw a whole line/run in a single call into their
+    /// respective text-rendering library (raylib's <c>DrawTextPro</c>, RichTextKit's
+    /// <c>TextBlock.Paint</c>) rather than looping per-glyph the way this XNALIKE path does, so
+    /// there's no per-glyph draw-order hook to expose. Intentionally XNALIKE-only.
     /// </remarks>
     public OverlapDirection OverlapDirection
     {

--- a/Runtimes/RaylibGum/Renderables/Text.cs
+++ b/Runtimes/RaylibGum/Renderables/Text.cs
@@ -964,6 +964,11 @@ public class Text : IVisible, IRenderableIpso,
         return maxScale;
     }
 
+    // No OverlapDirection over here (or in DrawStyledLine below) -- both hand the whole line/run to
+    // one DrawTextPro call, there's no per-glyph draw-order knob to hook into. Getting it would mean
+    // hand-rolling the glyph loop ourselves instead of letting raylib draw the string, and nothing in
+    // Gum actually uses overlap direction. XNALIKE-only is fine, not adding it here.
+
     /// <summary>
     /// Draws a single line with no inline styling, honoring horizontal alignment and pixel snapping.
     /// </summary>

--- a/Runtimes/SkiaGum/Renderables/Text.cs
+++ b/Runtimes/SkiaGum/Renderables/Text.cs
@@ -879,6 +879,11 @@ public class Text : IRenderableIpso, IVisible, IFormsText, ICloneable
         return 0;
     }
 
+    // No OverlapDirection over here either -- paintBlock.Paint below hands the whole shaped run to
+    // RichTextKit in one call, no per-glyph z-order hook to plug into. Same story as raylib: getting
+    // this would mean hand-rolling glyph painting ourselves, and nothing in Gum uses overlap
+    // direction anyway. XNALIKE-only is fine, not adding it here.
+
     /// <summary>
     /// Paints the outline (when <see cref="OutlineThickness"/> &gt; 0) followed by the text fill.
     /// The outline is a single recolor+dilate pass: the text is painted into a layer whose paint


### PR DESCRIPTION
Part of #3708 -- classifies `OverlapDirection` as an intentional XNALIKE-only capability rather than a Raylib/Skia gap, and documents why so it doesn't get picked up as easy cross-platform-sweep work.

## Why

`OverlapDirection` only exists on XNALIKE because Gum's own bitmap-font path (`BitmapFont.DrawTextLines`) loops per-glyph, blitting each character quad itself -- draw order is a side effect of owning that loop. Raylib (`DrawTextPro`) and Skia (RichTextKit's `TextBlock.Paint`) both hand a whole line/run to their text library in a single call; neither exposes a per-glyph z-order hook. Getting this on either backend would mean abandoning their native text-shaping pipeline for a hand-rolled glyph loop -- a bad trade for a knob nothing in Gum actually uses.

## What changed

Comments only, no behavior change:
- `MonoGameGum/GueDeriving/TextRuntime.cs`: tightened the `<remarks>` on `OverlapDirection` to name the actual mechanism instead of a vague "different path."
- `Runtimes/RaylibGum/Renderables/Text.cs`, `Runtimes/SkiaGum/Renderables/Text.cs`: added a comment at each backend's single-call draw site explaining why `OverlapDirection` isn't there.

Follow-up: removing the `OverlapDirection` row from #3708's tracking table (same classification `BlendState` already got).

## Test plan

- [x] `dotnet build MonoGameGum.Tests/MonoGameGum.Tests.csproj` -- clean
- [x] `dotnet build Runtimes/RaylibGum/RaylibGum.csproj` -- clean
- [x] `dotnet build Runtimes/SkiaGum/SkiaGum.csproj` -- clean
- Manual test: not needed -- comment-only change, no runtime-observable behavior
