### PR TITLE
Unify TextRuntime font-object property to Typeface across all 3 backends

### DIFF
--- a/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
+++ b/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
@@ -863,11 +863,23 @@ public partial class CustomSetPropertyOnRenderable
 
         }
 #if USE_GUMCOMMON
-        else if(propertyName == nameof(Gum.GueDeriving.TextRuntime.BitmapFont))
+        // "BitmapFont" is the pre-rename string kept for back-compat with any persisted/generated
+        // code still calling SetProperty("BitmapFont", ...); the property itself is now Typeface.
+        else if(propertyName == nameof(Gum.GueDeriving.TextRuntime.Typeface) || propertyName == "BitmapFont")
         {
             if(textRuntime != null)
             {
-                textRuntime.BitmapFont = (BitmapFont)value;
+                textRuntime.Typeface = (BitmapFont)value;
+            }
+            handled = true;
+        }
+#elif RAYLIB
+        // "CustomFont" is the pre-rename string kept for back-compat, mirroring the XNALIKE arm above.
+        else if (propertyName == nameof(Gum.GueDeriving.TextRuntime.Typeface) || propertyName == "CustomFont")
+        {
+            if (textRuntime != null)
+            {
+                textRuntime.Typeface = (Font)value;
             }
             handled = true;
         }

--- a/MonoGameGum.Tests/Runtimes/FontServiceTests.cs
+++ b/MonoGameGum.Tests/Runtimes/FontServiceTests.cs
@@ -612,7 +612,7 @@ public class FontServiceTests : BaseTestClass
 
         // The distinct font was actually assigned, proving the assignment branch (and thus the
         // suppression site) was reached — this test genuinely exercises the suppression.
-        textRuntime.BitmapFont.ShouldBe(distinctFont);
+        textRuntime.Typeface.ShouldBe(distinctFont);
         textRuntime.IsFontDirty.ShouldBeFalse();
         delta.ShouldBe(1);
     }

--- a/MonoGameGum.Tests/Runtimes/TextRuntimeTests.cs
+++ b/MonoGameGum.Tests/Runtimes/TextRuntimeTests.cs
@@ -57,7 +57,7 @@ $"chars count=223\r\n";
     {
         TextRuntime textRuntime = new();
 
-        var character = textRuntime.BitmapFont.Characters['\n'];
+        var character = textRuntime.Typeface.Characters['\n'];
         character.XAdvance = 10;
 
         textRuntime.Text = "Hello";
@@ -747,7 +747,7 @@ char id=67 x=0 y=0 width={xadvance} height=13 xoffset=0 yoffset=4 xadvance={xadv
 
         sut.IsBold = true;
 
-        sut.BitmapFont.ShouldBe(italicBoldFont);
+        sut.Typeface.ShouldBe(italicBoldFont);
     }
 
     #endregion
@@ -769,7 +769,7 @@ char id=67 x=0 y=0 width={xadvance} height=13 xoffset=0 yoffset=4 xadvance={xadv
         var lineCount = innerText.WrappedText.Count;
 
         var absoluteHeight = textRuntime.GetAbsoluteHeight();
-        absoluteHeight.ShouldBe(lineCount * textRuntime.BitmapFont.LineHeightInPixels);
+        absoluteHeight.ShouldBe(lineCount * textRuntime.Typeface.LineHeightInPixels);
     }
 
     #endregion
@@ -1392,7 +1392,102 @@ char id=67 x=0 y=0 width={xadvance} height=13 xoffset=0 yoffset=4 xadvance={xadv
 
         sut.UseCustomFont = false;
 
-        sut.BitmapFont.ShouldBe(italicBoldFont);
+        sut.Typeface.ShouldBe(italicBoldFont);
+    }
+
+    #endregion
+
+    #region Typeface
+
+    // Typeface (issue #3708): unifies XNALIKE's BitmapFont / Raylib's CustomFont / Skia's new
+    // Typeface under one name. BitmapFont/DefaultCustomFont are kept as [Obsolete] forwarders.
+
+    [Fact]
+    public void Typeface_ShouldRoundTrip()
+    {
+        TextRuntime sut = new();
+        BitmapFont font = new BitmapFont((Texture2D)null!, fontPattern);
+
+        sut.Typeface = font;
+
+        sut.Typeface.ShouldBe(font);
+    }
+
+    [Fact]
+    public void BitmapFont_ObsoleteAlias_ShouldForwardToTypeface()
+    {
+        TextRuntime sut = new();
+        BitmapFont font = new BitmapFont((Texture2D)null!, fontPattern);
+
+#pragma warning disable CS0618 // intentionally exercising the obsolete forwarder
+        sut.BitmapFont = font;
+
+        sut.Typeface.ShouldBe(font);
+        sut.BitmapFont.ShouldBe(font);
+#pragma warning restore CS0618
+    }
+
+    [Fact]
+    public void Typeface_SetProperty_ShouldForwardToTypeface()
+    {
+        TextRuntime sut = new();
+        BitmapFont font = new BitmapFont((Texture2D)null!, fontPattern);
+
+        sut.SetProperty("Typeface", font);
+
+        sut.Typeface.ShouldBe(font);
+    }
+
+    [Fact]
+    public void BitmapFont_LegacyStringName_SetProperty_ShouldForwardToTypeface()
+    {
+        // "BitmapFont" is kept as a legacy string alias in the dispatch bridge for any
+        // persisted/generated code still calling SetProperty("BitmapFont", ...).
+        TextRuntime sut = new();
+        BitmapFont font = new BitmapFont((Texture2D)null!, fontPattern);
+
+        sut.SetProperty("BitmapFont", font);
+
+        sut.Typeface.ShouldBe(font);
+    }
+
+    [Fact]
+    public void DefaultTypeface_AppliedInConstructor()
+    {
+        BitmapFont? saved = TextRuntime.DefaultTypeface;
+        try
+        {
+            BitmapFont font = new BitmapFont((Texture2D)null!, fontPattern);
+            TextRuntime.DefaultTypeface = font;
+
+            TextRuntime sut = new();
+
+            sut.Typeface.ShouldBe(font);
+        }
+        finally
+        {
+            TextRuntime.DefaultTypeface = saved;
+        }
+    }
+
+    [Fact]
+    public void DefaultCustomFont_ObsoleteAlias_ShouldForwardToDefaultTypeface()
+    {
+        BitmapFont? saved = TextRuntime.DefaultTypeface;
+        try
+        {
+            BitmapFont font = new BitmapFont((Texture2D)null!, fontPattern);
+#pragma warning disable CS0618 // intentionally exercising the obsolete forwarder
+            TextRuntime.DefaultCustomFont = font;
+
+            TextRuntime.DefaultTypeface.ShouldBe(font);
+            TextRuntime.DefaultCustomFont.ShouldBe(font);
+#pragma warning restore CS0618
+        }
+        finally
+        {
+            TextRuntime.DefaultTypeface = saved;
+        }
     }
 
     #endregion

--- a/MonoGameGum/GueDeriving/TextRuntime.cs
+++ b/MonoGameGum/GueDeriving/TextRuntime.cs
@@ -203,26 +203,55 @@ public class TextRuntime : InteractiveGue
     }
 
 #if RAYLIB
-    public Font CustomFont
+    /// <summary>
+    /// The concrete font object currently active on this text -- whatever <see cref="Font"/>/
+    /// <see cref="FontSize"/> resolved to, or an explicitly assigned override. Same concept as
+    /// XNALIKE's and Skia's <c>Typeface</c>, typed to this backend's own font representation.
+    /// </summary>
+    public Font Typeface
     {
         get => ContainedText.Font;
         set => ContainedText.Font = value;
     }
-#endif
 
-#if !RAYLIB && !SKIA
-    public BitmapFont BitmapFont
+    [Obsolete("Use Typeface instead.")]
+    public Font CustomFont
+    {
+        get => Typeface;
+        set => Typeface = value;
+    }
+#elif SKIA
+    /// <inheritdoc cref="Typeface"/>
+    public SKTypeface? Typeface
+    {
+        get => ContainedText.Typeface;
+        set => ContainedText.Typeface = value;
+    }
+#else
+    /// <summary>
+    /// The concrete font object currently active on this text -- whatever <see cref="Font"/>/
+    /// <see cref="FontSize"/> resolved to, or an explicitly assigned override. Same concept as
+    /// Raylib's and Skia's <c>Typeface</c>, typed to this backend's own font representation.
+    /// </summary>
+    public BitmapFont Typeface
     {
         get => ContainedText.BitmapFont;
         set
         {
-            if (value != BitmapFont)
+            if (value != Typeface)
             {
                 ContainedText.BitmapFont = value;
                 NotifyPropertyChanged();
                 UpdateLayout();
             }
         }
+    }
+
+    [Obsolete("Use Typeface instead.")]
+    public BitmapFont BitmapFont
+    {
+        get => Typeface;
+        set => Typeface = value;
     }
 #endif
 
@@ -787,14 +816,30 @@ public class TextRuntime : InteractiveGue
     public static bool AssignFontInConstructor = true;
 
     /// <summary>
-    /// A default BitmapFont to assign to all new TextRuntime instances during construction.
+    /// A default Typeface to assign to all new TextRuntime instances during construction.
     /// When set, this takes priority over <see cref="DefaultFont"/> and <see cref="DefaultFontSize"/>.
     /// When null, the default font is constructed from <see cref="DefaultFont"/> and <see cref="DefaultFontSize"/>.
     /// </summary>
-#if !RAYLIB && !SKIA
-    public static BitmapFont? DefaultCustomFont;
-#elif RAYLIB
-    public static Font? DefaultCustomFont;
+#if RAYLIB
+    public static Font? DefaultTypeface;
+
+    [Obsolete("Use DefaultTypeface instead.")]
+    public static Font? DefaultCustomFont
+    {
+        get => DefaultTypeface;
+        set => DefaultTypeface = value;
+    }
+#elif SKIA
+    public static SKTypeface? DefaultTypeface;
+#else
+    public static BitmapFont? DefaultTypeface;
+
+    [Obsolete("Use DefaultTypeface instead.")]
+    public static BitmapFont? DefaultCustomFont
+    {
+        get => DefaultTypeface;
+        set => DefaultTypeface = value;
+    }
 #endif
 
     public float DefaultWidth = 0;
@@ -824,17 +869,15 @@ public class TextRuntime : InteractiveGue
             HeightUnits = DefaultHeightUnits;
             if (AssignFontInConstructor)
             {
-#if !SKIA
-                if (DefaultCustomFont != null)
+                if (DefaultTypeface != null)
                 {
-#if !RAYLIB
-                    this.BitmapFont = DefaultCustomFont;
+#if RAYLIB
+                    this.Typeface = DefaultTypeface.Value;
 #else
-                    this.CustomFont = DefaultCustomFont.Value;
+                    this.Typeface = DefaultTypeface;
 #endif
                 }
                 else
-#endif
                 {
                     // The surrounding SuspendLayout/ResumeLayout pair coalesces these two
                     // assignments into a single font load at construction time. For default

--- a/Runtimes/SkiaGum/Content/Fonts/GumFontMapper.cs
+++ b/Runtimes/SkiaGum/Content/Fonts/GumFontMapper.cs
@@ -2,6 +2,8 @@ using RenderingLibrary.Graphics.Fonts;
 using SkiaSharp;
 using System;
 using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
+using System.Threading;
 using Topten.RichTextKit;
 
 namespace SkiaGum.Content.Fonts;
@@ -23,6 +25,30 @@ public class GumFontMapper : FontMapper
 {
     private static readonly ConcurrentDictionary<string, SKTypeface> registry =
         new ConcurrentDictionary<string, SKTypeface>(StringComparer.OrdinalIgnoreCase);
+
+    private static readonly ConditionalWeakTable<SKTypeface, string> typefaceKeys = new();
+    private static int nextTypefaceId;
+
+    /// <summary>
+    /// Registers an already-loaded <see cref="SKTypeface"/> directly (as opposed to
+    /// <see cref="RegisterFontFile"/>, which loads one from a path) and returns the family-name
+    /// key to assign as <c>Style.FontFamily</c> to reference it -- used by <c>Text.Typeface</c>.
+    /// Calling this again with the SAME instance returns the same key; a different instance --
+    /// even one loaded from the same file -- gets its own key, since callers may swap in a
+    /// distinct object at runtime and expect it to resolve independently.
+    /// </summary>
+    public static string RegisterTypeface(SKTypeface typeface)
+    {
+        if (typefaceKeys.TryGetValue(typeface, out string? existingKey))
+        {
+            return existingKey;
+        }
+
+        string key = $"__typeface_{Interlocked.Increment(ref nextTypefaceId)}";
+        registry[key] = typeface;
+        typefaceKeys.Add(typeface, key);
+        return key;
+    }
 
     /// <summary>
     /// Loads (or reuses an already-loaded) <see cref="SKTypeface"/> for <paramref name="fontFilePath"/>

--- a/Runtimes/SkiaGum/CustomSetPropertyOnRenderable.cs
+++ b/Runtimes/SkiaGum/CustomSetPropertyOnRenderable.cs
@@ -1316,6 +1316,24 @@ public partial class CustomSetPropertyOnRenderable
             }
             ReactToFontValueChange();
         }
+        // Typeface (#3708): an explicit SKTypeface override. Unlike UseCustomFont/CustomFontFile
+        // above, this does NOT call ReactToFontValueChange() -- that re-resolves via
+        // UpdateToFontValues() (the normal FontName/FontSize path), which would immediately stomp
+        // an explicit override. The property setter itself invalidates the cached RichTextKit
+        // block; only a pending relative-to-children layout still needs an explicit nudge here.
+        else if (propertyName == nameof(gueAsTextRuntime.Typeface))
+        {
+            if (gueAsTextRuntime != null)
+            {
+                gueAsTextRuntime.Typeface = value as SkiaSharp.SKTypeface;
+            }
+            if (gue.WidthUnits == DimensionUnitType.RelativeToChildren ||
+                gue.HeightUnits == DimensionUnitType.RelativeToChildren)
+            {
+                gue.UpdateLayout();
+            }
+            handled = true;
+        }
 
 
         else if (propertyName == nameof(gueAsTextRuntime.FontSize))

--- a/Runtimes/SkiaGum/Renderables/Text.cs
+++ b/Runtimes/SkiaGum/Renderables/Text.cs
@@ -154,7 +154,32 @@ public class Text : IRenderableIpso, IVisible, IFormsText, ICloneable
 
     public bool IsRenderTarget => false;
 
-    //public SKTypeface Font { get; set; }
+    /// <summary>
+    /// The concrete font object currently active on this text -- whatever <see cref="FontName"/>/
+    /// <see cref="FontSize"/> resolved to, or an explicitly assigned override. Same concept as
+    /// XNALIKE's <c>BitmapFont</c> and Raylib's <c>Typeface</c>, typed to Skia's own font
+    /// representation. When set, <see cref="EffectiveFontFamily"/> resolves to a
+    /// <see cref="Content.Fonts.GumFontMapper"/>-registered key for this instance instead of
+    /// <see cref="FontName"/>, bypassing family-name-based lookup entirely.
+    /// </summary>
+    public SKTypeface? Typeface
+    {
+        get => _typeface;
+        set
+        {
+            _typeface = value;
+            _cachedTextBlock = null;
+        }
+    }
+
+    /// <summary>
+    /// The family-name key actually fed to RichTextKit's <see cref="Style.FontFamily"/>: a
+    /// <see cref="Content.Fonts.GumFontMapper"/>-registered key for <see cref="Typeface"/> when
+    /// set, otherwise <see cref="FontName"/> unchanged.
+    /// </summary>
+    private string? EffectiveFontFamily =>
+        _typeface != null ? Content.Fonts.GumFontMapper.RegisterTypeface(_typeface) : FontName;
+
     public string FontName
     {
         get => _fontName; 
@@ -987,6 +1012,7 @@ public class Text : IRenderableIpso, IVisible, IFormsText, ICloneable
     private TextOverflowVerticalMode _textOverflowVerticalMode;
     private string _fontName = "Arial";
     private int _fontSize = 18;
+    private SKTypeface? _typeface;
     private float _fontScale;
     private float _boldWeight = 1;
     private SKColor _color;
@@ -1426,7 +1452,7 @@ public class Text : IRenderableIpso, IVisible, IFormsText, ICloneable
 
         var style = new Style()
         {
-            FontFamily = FontName,
+            FontFamily = EffectiveFontFamily,
             FontSize = fontSizePixels * (float)GlobalTextScale * fontScale,
             TextColor = color,
             FontItalic = italic,
@@ -1651,7 +1677,7 @@ public class Text : IRenderableIpso, IVisible, IFormsText, ICloneable
     {
         return new Style()
         {
-            FontFamily = FontName,
+            FontFamily = EffectiveFontFamily,
             FontSize = FontSize * (float)GlobalTextScale,
             TextColor = this.Color,
             FontItalic = this.IsItalic,

--- a/Tests/RaylibGum.Tests/Runtimes/TextRuntimeTests.cs
+++ b/Tests/RaylibGum.Tests/Runtimes/TextRuntimeTests.cs
@@ -372,6 +372,107 @@ public class TextRuntimeTests : BaseTestClass
 
     #endregion
 
+    #region Typeface
+
+    // Typeface (issue #3708): unifies Raylib's CustomFont / XNALIKE's BitmapFont / Skia's new
+    // Typeface under one name. CustomFont is kept as an [Obsolete] forwarder.
+
+    [Fact]
+    public void Typeface_ShouldRoundTrip()
+    {
+        TextRuntime sut = new();
+        Font font = default;
+        font.BaseSize = 42;
+
+        sut.Typeface = font;
+
+        sut.Typeface.BaseSize.ShouldBe(42);
+    }
+
+    [Fact]
+    public void CustomFont_ObsoleteAlias_ShouldForwardToTypeface()
+    {
+        TextRuntime sut = new();
+        Font font = default;
+        font.BaseSize = 42;
+
+#pragma warning disable CS0618 // intentionally exercising the obsolete forwarder
+        sut.CustomFont = font;
+
+        sut.Typeface.BaseSize.ShouldBe(42);
+        sut.CustomFont.BaseSize.ShouldBe(42);
+#pragma warning restore CS0618
+    }
+
+    [Fact]
+    public void Typeface_SetProperty_ShouldForwardToTypeface()
+    {
+        TextRuntime sut = new();
+        Font font = default;
+        font.BaseSize = 42;
+
+        sut.SetProperty("Typeface", font);
+
+        sut.Typeface.BaseSize.ShouldBe(42);
+    }
+
+    [Fact]
+    public void CustomFont_LegacyStringName_SetProperty_ShouldForwardToTypeface()
+    {
+        // "CustomFont" is kept as a legacy string alias in the dispatch bridge for any
+        // persisted/generated code still calling SetProperty("CustomFont", ...).
+        TextRuntime sut = new();
+        Font font = default;
+        font.BaseSize = 42;
+
+        sut.SetProperty("CustomFont", font);
+
+        sut.Typeface.BaseSize.ShouldBe(42);
+    }
+
+    [Fact]
+    public void DefaultTypeface_AppliedInConstructor()
+    {
+        Font? saved = TextRuntime.DefaultTypeface;
+        try
+        {
+            Font font = default;
+            font.BaseSize = 42;
+            TextRuntime.DefaultTypeface = font;
+
+            TextRuntime sut = new();
+
+            sut.Typeface.BaseSize.ShouldBe(42);
+        }
+        finally
+        {
+            TextRuntime.DefaultTypeface = saved;
+        }
+    }
+
+    [Fact]
+    public void DefaultCustomFont_ObsoleteAlias_ShouldForwardToDefaultTypeface()
+    {
+        Font? saved = TextRuntime.DefaultTypeface;
+        try
+        {
+            Font font = default;
+            font.BaseSize = 42;
+#pragma warning disable CS0618 // intentionally exercising the obsolete forwarder
+            TextRuntime.DefaultCustomFont = font;
+
+            TextRuntime.DefaultTypeface.Value.BaseSize.ShouldBe(42);
+            TextRuntime.DefaultCustomFont.Value.BaseSize.ShouldBe(42);
+#pragma warning restore CS0618
+        }
+        finally
+        {
+            TextRuntime.DefaultTypeface = saved;
+        }
+    }
+
+    #endregion
+
     #region FontFamily
 
     [Fact]

--- a/Tests/SkiaGum.Tests/Content/GumFontMapperTests.cs
+++ b/Tests/SkiaGum.Tests/Content/GumFontMapperTests.cs
@@ -1,6 +1,8 @@
 using Shouldly;
 using SkiaGum.Content.Fonts;
+using SkiaSharp;
 using System.IO;
+using Topten.RichTextKit;
 
 namespace SkiaGum.Tests.Content;
 
@@ -119,5 +121,55 @@ public class GumFontMapperTests
             useCustomFont: true, customFontFile: "Fonts/Prebaked.fnt", font: "Arial");
 
         resolved.ShouldBeNull();
+    }
+
+    // Typeface (issue #3708): registers an already-loaded SKTypeface directly (as opposed to
+    // RegisterFontFile, which loads one from a path), for Text.Typeface -- the explicit-font-object
+    // escape hatch Skia lacked entirely, mirroring XNALIKE's BitmapFont / Raylib's Typeface.
+
+    [Fact]
+    public void RegisterTypeface_ReturnsNonNullFamilyKey()
+    {
+        SKTypeface typeface = SKTypeface.FromFile(FixtureTtfPath);
+
+        string familyKey = GumFontMapper.RegisterTypeface(typeface);
+
+        familyKey.ShouldNotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public void RegisterTypeface_CalledTwiceWithSameInstance_ReturnsSameFamilyKey()
+    {
+        SKTypeface typeface = SKTypeface.FromFile(FixtureTtfPath);
+
+        string first = GumFontMapper.RegisterTypeface(typeface);
+        string second = GumFontMapper.RegisterTypeface(typeface);
+
+        second.ShouldBe(first);
+    }
+
+    [Fact]
+    public void RegisterTypeface_CalledWithDifferentInstances_ReturnsDifferentFamilyKeys()
+    {
+        SKTypeface first = SKTypeface.FromFile(FixtureTtfPath);
+        SKTypeface second = SKTypeface.FromFile(FixtureTtfPath);
+
+        string firstKey = GumFontMapper.RegisterTypeface(first);
+        string secondKey = GumFontMapper.RegisterTypeface(second);
+
+        secondKey.ShouldNotBe(firstKey);
+    }
+
+    [Fact]
+    public void TypefaceFromStyle_ResolvesRegisteredTypefaceKey_ReturnsSameInstance()
+    {
+        SKTypeface typeface = SKTypeface.FromFile(FixtureTtfPath);
+        string familyKey = GumFontMapper.RegisterTypeface(typeface);
+        GumFontMapper mapper = new();
+        Style style = new() { FontFamily = familyKey };
+
+        SKTypeface resolved = mapper.TypefaceFromStyle(style, ignoreFontVariants: false);
+
+        resolved.ShouldBeSameAs(typeface);
     }
 }

--- a/Tests/SkiaGum.Tests/GueDeriving/TextRuntimeTests.cs
+++ b/Tests/SkiaGum.Tests/GueDeriving/TextRuntimeTests.cs
@@ -523,6 +523,52 @@ public class TextRuntimeTests
 
     #endregion
 
+    #region Typeface
+
+    // Typeface (issue #3708): the explicit-font-object escape hatch Skia lacked entirely, unified
+    // under the same name as XNALIKE's BitmapFont / Raylib's Typeface. Forwards straight to the
+    // contained renderable.
+
+    [Fact]
+    public void Typeface_ShouldDefaultToNull()
+    {
+        TextRuntime sut = new();
+        sut.Typeface.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Typeface_ShouldRoundTripThroughRenderable()
+    {
+        TextRuntime sut = new();
+        SKTypeface typeface = SKTypeface.FromFamilyName("Arial");
+
+        sut.Typeface = typeface;
+
+        sut.Typeface.ShouldBe(typeface);
+        ((Text)sut.RenderableComponent).Typeface.ShouldBe(typeface);
+    }
+
+    [Fact]
+    public void DefaultTypeface_AppliedInConstructor()
+    {
+        SKTypeface? saved = TextRuntime.DefaultTypeface;
+        try
+        {
+            SKTypeface typeface = SKTypeface.FromFamilyName("Arial");
+            TextRuntime.DefaultTypeface = typeface;
+
+            TextRuntime sut = new();
+
+            sut.Typeface.ShouldBe(typeface);
+        }
+        finally
+        {
+            TextRuntime.DefaultTypeface = saved;
+        }
+    }
+
+    #endregion
+
     #region UseFontSmoothing
 
     [Fact]

--- a/Tests/SkiaGum.Tests/Renderables/TextTypefaceTests.cs
+++ b/Tests/SkiaGum.Tests/Renderables/TextTypefaceTests.cs
@@ -1,0 +1,48 @@
+using Shouldly;
+using SkiaGum;
+using SkiaSharp;
+using System.IO;
+
+namespace SkiaGum.Tests.Renderables;
+
+/// <summary>
+/// Pins Text.Typeface (issue #3708): the explicit-font-object escape hatch Skia lacked entirely,
+/// mirroring XNALIKE's BitmapFont / Raylib's Typeface. Setting it bypasses FontName-based
+/// resolution -- GetStyle().FontFamily resolves to a GumFontMapper-registered key for the
+/// assigned SKTypeface instead of the plain FontName string.
+/// </summary>
+public class TextTypefaceTests
+{
+    private static readonly string FixtureTtfPath =
+        Path.Combine(AppContext.BaseDirectory, "Assets", "Fonts", "TestFont.ttf");
+
+    [Fact]
+    public void Typeface_DefaultsToNull()
+    {
+        Text sut = new();
+
+        sut.Typeface.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Typeface_Null_StyleFontFamilyUsesFontName()
+    {
+        Text sut = new();
+        sut.FontName = "Arial";
+
+        sut.GetStyle().FontFamily.ShouldBe("Arial");
+    }
+
+    [Fact]
+    public void Typeface_SetExplicitly_StyleFontFamilyResolvesToRegisteredTypefaceKey()
+    {
+        Text sut = new();
+        sut.FontName = "Arial";
+        SKTypeface typeface = SKTypeface.FromFile(FixtureTtfPath);
+
+        sut.Typeface = typeface;
+
+        sut.GetStyle().FontFamily.ShouldBe(
+            SkiaGum.Content.Fonts.GumFontMapper.RegisterTypeface(typeface));
+    }
+}

--- a/Tests/SkiaGum.Tests/Runtimes/CustomSetPropertyOnRenderableTests.cs
+++ b/Tests/SkiaGum.Tests/Runtimes/CustomSetPropertyOnRenderableTests.cs
@@ -3,6 +3,7 @@ using RenderingLibrary.Graphics;
 using Shouldly;
 using SkiaGum;
 using SkiaGum.GueDeriving;
+using SkiaSharp;
 
 namespace SkiaGum.Tests.Runtimes;
 
@@ -41,5 +42,20 @@ public class CustomSetPropertyOnRenderableTests
         }
 
         wasCalled.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void SetPropertyOnRenderable_Typeface_ShouldForwardToRenderable()
+    {
+        // Typeface (#3708): SkiaGum's SetProperty dispatch had no arm for this at all -- it never
+        // existed on Skia before, so the string-based path (codegen/state application) had nothing
+        // to route to. Mirrors the MonoGame/Raylib Font/BitmapFont dispatch coverage.
+        Gum.GueDeriving.TextRuntime textRuntime = new();
+        IRenderableIpso renderable = (IRenderableIpso)textRuntime.RenderableComponent;
+        SKTypeface typeface = SKTypeface.FromFamilyName("Arial");
+
+        CustomSetPropertyOnRenderable.SetPropertyOnRenderable(renderable, textRuntime, "Typeface", typeface);
+
+        ((Text)renderable).Typeface.ShouldBe(typeface);
     }
 }

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -153,6 +153,7 @@
   * [Upgrading File (GUMX) Version](gum-tool/upgrading/upgrading-file-gumx-version.md)
   * [Syntax Versions](gum-tool/upgrading/syntax-versions.md)
     * [Syntax Version 1](gum-tool/upgrading/syntax-version-1.md)
+  * [Migrating to 2026 August](gum-tool/upgrading/migrating-to-2026-august.md)
   * [Migrating to 2026 July](gum-tool/upgrading/migrating-to-2026-july.md)
   * [Migrating to 2026 June](gum-tool/upgrading/migrating-to-2026-june.md)
   * [Migrating to 2026 May](gum-tool/upgrading/migrating-to-2026-may.md)

--- a/docs/gum-tool/upgrading/migrating-to-2026-august.md
+++ b/docs/gum-tool/upgrading/migrating-to-2026-august.md
@@ -1,0 +1,82 @@
+# Migrating to 2026 August
+
+## Introduction
+
+This page discusses breaking changes and other considerations when migrating from `2026 July` to `2026 August`.
+
+## What Changed at a Glance
+
+`2026 August` renames the explicit-font-object property on `TextRuntime` to `Typeface`, unifying a name that previously differed per backend (`BitmapFont` on MonoGame/KNI/FNA, `CustomFont` on raylib) and adding the same capability to SkiaSharp for the first time. This is a **soft break**: the old names still compile and work, but now emit a `CS0618` obsolete warning.
+
+## Upgrading the Gum Tool
+
+{% tabs %}
+{% tab title="Windows" %}
+To upgrade the Gum tool:
+
+1. Download Gum.zip from the [PLACEHOLDER!!!! August 2026 release on GitHub](https://github.com/vchelaru/Gum/releases)
+2. Delete the old tool from your machine
+3. Unzip the gum tool to the same location as to not break any file associations
+{% endtab %}
+
+{% tab title="Linux" %}
+Run the upgrade `gum upgrade` or `~/bin/gum upgrade`
+{% endtab %}
+{% endtabs %}
+
+## Upgrading the Runtime
+
+The `2026 August` runtime ships as NuGet version **`PLACEHOLDER!!!! version number`**. Upgrade your Gum NuGet packages to this version. For more information, see the NuGet packages for your particular platform:
+
+* MonoGame - [https://www.nuget.org/packages/Gum.MonoGame/](https://www.nuget.org/packages/Gum.MonoGame/)
+* KNI - [https://www.nuget.org/packages/Gum.KNI/](https://www.nuget.org/packages/Gum.KNI/)
+* FNA - [https://www.nuget.org/packages/Gum.FNA/](https://www.nuget.org/packages/Gum.FNA/)
+* raylib - [https://www.nuget.org/packages/Gum.raylib](https://www.nuget.org/packages/Gum.raylib)
+* .NET MAUI - [https://www.nuget.org/packages/Gum.SkiaSharp.Maui](https://www.nuget.org/packages/Gum.SkiaSharp.Maui)
+* SkiaSharp - [https://www.nuget.org/packages/Gum.SkiaSharp/](https://www.nuget.org/packages/Gum.SkiaSharp/)
+
+If using GumCommon directly, you can update the GumCommon NuGet:
+
+* GumCommon - [https://www.nuget.org/packages/FlatRedBall.GumCommon](https://www.nuget.org/packages/FlatRedBall.GumCommon)
+
+## Breaking Changes and Migrations
+
+### `BitmapFont` / `CustomFont` Renamed to `Typeface`
+
+`TextRuntime` has an explicit-font-object property for assigning an already-loaded font directly, bypassing the normal `Font`/`FontSize` name-based resolution. This property is also what you read to inspect whichever font object is actually active, whether it was resolved normally or assigned explicitly. It previously had a different name per backend:
+
+* **MonoGame / KNI / FNA** — `BitmapFont` (type `BitmapFont`)
+* **raylib** — `CustomFont` (type `Raylib_cs.Font`)
+* **SkiaSharp** — no equivalent existed at all
+
+All three backends now expose the same property name, `Typeface`, typed to each backend's own font object (`BitmapFont`, `Raylib_cs.Font`, or `SkiaSharp.SKTypeface`). `BitmapFont` and `CustomFont` still compile and work, but now emit a `CS0618` warning:
+
+```
+warning CS0618: 'TextRuntime.BitmapFont' is obsolete: 'Use Typeface instead.'
+```
+
+To migrate, rename the property at your call sites:
+
+❌ Old (MonoGame/KNI/FNA):
+```csharp
+// Initialize
+textRuntime.BitmapFont = myFont;
+```
+
+❌ Old (raylib):
+```csharp
+// Initialize
+textRuntime.CustomFont = myFont;
+```
+
+✅ New (all backends):
+```csharp
+// Initialize
+textRuntime.Typeface = myFont;
+```
+
+The static, constructor-time default (`TextRuntime.DefaultCustomFont` on MonoGame/KNI/FNA and raylib) is renamed the same way, to `TextRuntime.DefaultTypeface`, and is now also available on SkiaSharp.
+
+{% hint style="info" %}
+On SkiaSharp, `Typeface` is a new capability, not a rename — there is no obsolete alias to migrate from, since the property didn't exist there before.
+{% endhint %}


### PR DESCRIPTION
Part of #3708. Closes the `BitmapFont`/`CustomFont`/`DefaultCustomFont` rows -- unifies the explicit-font-object escape hatch under one name (`Typeface`) across all 3 backends, and adds it to Skia for the first time.

## Why

`BitmapFont` (XNALIKE) and `CustomFont` (Raylib) are the same concept under different names: both a direct "assign a pre-built font object" property that also reflects whatever `Font`/`FontSize` normally resolved to -- not a custom-only override, confirmed by tracing the assignment sites (`CustomSetPropertyOnRenderable.cs`'s ordinary FontName+FontSize resolution path writes into the same property the explicit-override path does, on both backends). `CustomFont` oversold its scope. Skia never had an equivalent at all, despite already having the underlying type (`SKTypeface`) and a commented-out stub for exactly this.

## What changed

- `TextRuntime.Typeface`: unified name, per-platform type (`BitmapFont` / `Raylib_cs.Font` / `SKTypeface`), same shape as `Blend`/`BlendState`. `BitmapFont` and `CustomFont` kept as `[Obsolete]` forwarders.
- `TextRuntime.DefaultTypeface`: same treatment for the static constructor-time default (was already name-unified as `DefaultCustomFont` across XNALIKE/Raylib; extended to Skia, renamed for consistency, `DefaultCustomFont` kept obsolete).
- `SkiaGum.Text.Typeface` (new): an `SKTypeface` override that bypasses `FontName`-based resolution. `GumFontMapper.RegisterTypeface` registers an already-loaded `SKTypeface` under a stable per-instance key so RichTextKit can resolve it without a portable typeface-object concept.
- `Gum/Wireframe/CustomSetPropertyOnRenderable.cs` (XNALIKE+Raylib) and `Runtimes/SkiaGum/CustomSetPropertyOnRenderable.cs`: `SetProperty("Typeface", ...)` dispatch on all 3 backends; `"BitmapFont"`/`"CustomFont"` kept as legacy string aliases for persisted/generated code. Mirrors the existing `USE_GUMCOMMON` FRB-safety gate on the XNALIKE arm.
- `docs/gum-tool/upgrading/migrating-to-2026-august.md`: soft-break migration entry, same pattern as prior `migrating-to-<month>` pages.

## Test plan

- [x] `dotnet test MonoGameGum.Tests/MonoGameGum.Tests.csproj` -- 1870 passed
- [x] `dotnet test Tests/RaylibGum.Tests/RaylibGum.Tests.csproj` -- 508 passed
- [x] `dotnet test Tests/SkiaGum.Tests/SkiaGum.Tests.csproj` -- 340 passed
- [x] `dotnet test Tool/Tests/GumToolUnitTests/GumToolUnitTests.csproj` -- 1066 passed
- [x] `dotnet build GumFull.sln` -- clean
- [x] FRB canary (`GumCore.DesktopGlNet6.csproj` from the primary checkout, baseline vs. branch) -- 0 errors on both; the new `Typeface` dispatch case is excluded from FRB compilation by the same `USE_GUMCOMMON` gate the old `BitmapFont` case used
- Manual test: not needed -- the full `Typeface -> Style.FontFamily -> GumFontMapper` resolution chain is covered end-to-end by `TextTypefaceTests`/`GumFontMapperTests` (the assigned `SKTypeface` round-trips to the exact object RichTextKit would resolve); the XNALIKE/Raylib sides are pure renames with zero behavior change
