### PR TITLE
Document RenderBoundary as intentionally XNALIKE-only

### DIFF
--- a/RenderingLibrary/Graphics/Text.cs
+++ b/RenderingLibrary/Graphics/Text.cs
@@ -624,6 +624,11 @@ public class Text : SpriteBatchRenderableBase, IRenderableIpso, IVisible, IWrapp
         }
     }
 
+    /// <summary>
+    /// Draws a debug outline around the text's bounds. XNALIKE-only debug aid (used by the Gum tool's
+    /// rulers/distance arrows and the editor's "show text outlines" setting) — not planned for
+    /// Raylib/Skia (#3708).
+    /// </summary>
     public bool RenderBoundary
     {
         get;

--- a/Runtimes/RaylibGum/Renderables/Text.cs
+++ b/Runtimes/RaylibGum/Renderables/Text.cs
@@ -969,6 +969,10 @@ public class Text : IVisible, IRenderableIpso,
     // hand-rolling the glyph loop ourselves instead of letting raylib draw the string, and nothing in
     // Gum actually uses overlap direction. XNALIKE-only is fine, not adding it here.
 
+    // No RenderBoundary either -- it's a debug outline used by the Gum tool's XNA-based editor views
+    // (rulers, distance arrows), not a feature any game project needs. XNALIKE-only is fine, not
+    // adding it here (#3708).
+
     /// <summary>
     /// Draws a single line with no inline styling, honoring horizontal alignment and pixel snapping.
     /// </summary>

--- a/Runtimes/SkiaGum/Renderables/Text.cs
+++ b/Runtimes/SkiaGum/Renderables/Text.cs
@@ -973,6 +973,10 @@ public class Text : IRenderableIpso, IVisible, IFormsText, ICloneable
     // this would mean hand-rolling glyph painting ourselves, and nothing in Gum uses overlap
     // direction anyway. XNALIKE-only is fine, not adding it here.
 
+    // No RenderBoundary either -- it's a debug outline used by the Gum tool's XNA-based editor views
+    // (rulers, distance arrows), not a feature any game project needs. XNALIKE-only is fine, not
+    // adding it here (#3708).
+
     /// <summary>
     /// Paints the outline (when <see cref="OutlineThickness"/> &gt; 0) followed by the text fill.
     /// The outline is a single recolor+dilate pass: the text is painted into a layer whose paint


### PR DESCRIPTION
Part of #3708. Classifies `RenderBoundary` as intentionally XNALIKE-only rather than a gap: it's a debug-outline aid used by the Gum tool's XNA-based editor views (rulers, distance arrows, "show text outlines" setting), not a feature any game project needs on Raylib/Skia.

Comment-only, no behavior change.
