### PR TITLE
Document TextPositionRoundingMode as intentionally Raylib-only

### DIFF
--- a/RenderingLibrary/Graphics/Fonts/BitmapFont.cs
+++ b/RenderingLibrary/Graphics/Fonts/BitmapFont.cs
@@ -734,6 +734,8 @@ public class BitmapFont : IDisposable
         int lineNumber = 0;
 
         // int is used if pixel perfect
+        // No TextPositionRoundingMode (Floor/Ceiling) knob here -- away-from-zero rounding is hardcoded
+        // and no one has reported spacing jitter needing it. Raylib-only is fine (#3708).
         int xOffsetAsInt = MathFunctions.RoundToInt(xOffset);
         int yOffsetAsInt = MathFunctions.RoundToInt(yOffset);
 

--- a/Runtimes/RaylibGum/Renderables/Text.cs
+++ b/Runtimes/RaylibGum/Renderables/Text.cs
@@ -41,6 +41,13 @@ public enum TextRenderingPositionMode
 /// rendering to the nearest pixel. This only applies if
 /// TextRenderingPositionMode is set to SnapToPixel
 /// </summary>
+/// <remarks>
+/// Raylib-only (#3708): XNALIKE and Skia both hardcode away-from-zero rounding (matching
+/// <c>MathFunctions.RoundToInt</c>) with no Floor/Ceiling knob and no reported jitter. Raylib scales a live
+/// TTF via <c>DrawTextPro</c>/<c>MeasureTextEx</c> rather than blitting pre-baked, integer-advance
+/// bitmap glyphs, so fractional advances are far more common here, and always-round-to-nearest could
+/// visibly jitter inter-character spacing for some fonts. No platform has asked for Floor/Ceiling.
+/// </remarks>
 public enum TextPositionRoundingMode
 {
     /// <summary>

--- a/Runtimes/SkiaGum/Renderables/Text.cs
+++ b/Runtimes/SkiaGum/Renderables/Text.cs
@@ -529,6 +529,10 @@ public class Text : IRenderableIpso, IVisible, IFormsText, ICloneable
     /// otherwise returns them unchanged. Used by <see cref="Render"/> to snap the draw origin.
     /// Exposed internally for unit testing.
     /// </summary>
+    /// <remarks>
+    /// No Raylib-style TextPositionRoundingMode (Floor/Ceiling) knob here -- away-from-zero is
+    /// hardcoded and no one has reported spacing jitter needing it. Raylib-only is fine (#3708).
+    /// </remarks>
     internal (float X, float Y) GetSnappedOrigin(float x, float y)
     {
         if (EffectiveTextRenderingPositionMode != TextRenderingPositionMode.SnapToPixel)


### PR DESCRIPTION
Part of #3708. Classifies `TextPositionRoundingMode` as intentionally Raylib-only rather than a gap: XNALIKE and Skia both hardcode away-from-zero rounding with no reported jitter, and Raylib is the only backend scaling a live TTF (`DrawTextPro`/`MeasureTextEx`) rather than blitting pre-baked, integer-advance bitmap glyphs — fractional advances are far more common there.

Comment-only, no behavior change.
