### PR TITLE
Document TextOverflowVerticalMode as correctly living on GraphicalUiElement

### DIFF
--- a/GumRuntime/GraphicalUiElement.cs
+++ b/GumRuntime/GraphicalUiElement.cs
@@ -750,6 +750,12 @@ public partial class GraphicalUiElement : IRenderableIpso, IVisible, INotifyProp
 
     TextOverflowVerticalMode textOverflowVerticalMode;
     // we have to store this locally because we are going to effectively assign the overflow mode based on the height units and this value
+    //
+    // Intentionally NOT #if FRB-gated like the other FRB1-only font properties (Font, FontSize, IsBold,
+    // etc.) further down this class -- this one isn't FRB1-specific plumbing, it's read directly by this
+    // class's own layout coordination on every backend (RefreshTextOverflowVerticalMode's
+    // RelativeToChildren-forces-SpillOver override, DialogBox page-splitting, RelativeToChildren sizing).
+    // GraphicalUiElement genuinely owns this value; it isn't leaking a FRB1-only concern (#3708).
     public TextOverflowVerticalMode TextOverflowVerticalMode
     {
         get => textOverflowVerticalMode;


### PR DESCRIPTION
Part of #3708. Reclassifies `TextOverflowVerticalMode` as correctly placed on `GraphicalUiElement` rather than FRB1-only leakage: unlike the sibling `#if FRB` font properties, this one is read directly by the base class's own universal layout coordination (`RefreshTextOverflowVerticalMode`'s `RelativeToChildren`-forces-`SpillOver` override, `DialogBox` pagination, `RelativeToChildren` sizing) on every backend, not just FRB1. Gating it would require re-plumbing all three call sites for no benefit.

Comment-only, no behavior change.
