### PR TITLE
Redispatch TrySetPropertyOnText's mechanical batch through TextRuntime

### DIFF
--- a/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
+++ b/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
@@ -805,6 +805,7 @@ public partial class CustomSetPropertyOnRenderable
         }
         else if (propertyName == "Font Scale" || propertyName == "FontScale")
         {
+#if FRB
             textRenderable.FontScale = (float)value;
             // we want to update if the text's size is based on its "children" (the letters it contains)
             if (graphicalUiElement.WidthUnits == DimensionUnitType.RelativeToChildren ||
@@ -813,6 +814,12 @@ public partial class CustomSetPropertyOnRenderable
             {
                 graphicalUiElement.UpdateLayout();
             }
+#else
+            if (textRuntime != null)
+            {
+                textRuntime.FontScale = (float)value;
+            }
+#endif
             handled = true;
 
         }
@@ -919,14 +926,17 @@ public partial class CustomSetPropertyOnRenderable
         }
         else if (propertyName == "LineHeightMultiplier")
         {
-#if RAYLIB
+#if FRB
+            textRenderable.LineHeightMultiplier = (float)value;
+#else
+            // TextRuntime.LineHeightMultiplier is a single un-gated property shared by every
+            // backend (XNALIKE/RAYLIB/SKIA), so no platform split is needed here anymore.
             if (textRuntime != null)
             {
                 textRuntime.LineHeightMultiplier = (float)value;
             }
-#else
-            textRenderable.LineHeightMultiplier = (float)value;
 #endif
+            handled = true;
         }
         else if (propertyName == nameof(textRuntime.UseFontSmoothing))
         {
@@ -938,44 +948,84 @@ public partial class CustomSetPropertyOnRenderable
         }
         else if (propertyName == nameof(Blend))
         {
-#if XNALIKE
+#if FRB
             var valueAsGumBlend = (RenderingLibrary.Blend)value;
 
             var valueAsXnaBlend = valueAsGumBlend.ToBlendState();
 
             textRenderable.BlendState = valueAsXnaBlend;
             handled = true;
+#else
+            // Fully-qualified (unlike the FRB branch above) because this now also compiles under
+            // RAYLIB, where the short "RenderingLibrary.Blend" form doesn't resolve (this file's
+            // namespace there is RaylibGum.Renderables, not nested under Gum). TextRuntime.Blend's
+            // own setter does the platform-specific BlendState conversion (see its implementation).
+            var valueAsGumBlend = (Gum.RenderingLibrary.Blend)value;
+            if (textRuntime != null)
+            {
+                textRuntime.Blend = valueAsGumBlend;
+            }
+            handled = true;
 #endif
         }
         else if (propertyName == "Alpha")
         {
-#if XNALIKE
+#if FRB
             int valueAsInt = (int)value;
             textRenderable.Alpha = valueAsInt;
-            handled = true;
+#else
+            // TextRuntime.Alpha is a plain, un-gated int on every backend (no platform-specific
+            // conversion), so - like MaxLettersToShow below - the old #if XNALIKE restriction was
+            // needless and silently no-op'd this property on RAYLIB via the string path.
+            if (textRuntime != null)
+            {
+                textRuntime.Alpha = (int)value;
+            }
 #endif
+            handled = true;
         }
         else if (propertyName == "Red")
         {
+#if FRB
             int valueAsInt = (int)value;
             textRenderable.Red = valueAsInt;
+#else
+            if (textRuntime != null)
+            {
+                textRuntime.Red = (int)value;
+            }
+#endif
             handled = true;
         }
         else if (propertyName == "Green")
         {
+#if FRB
             int valueAsInt = (int)value;
             textRenderable.Green = valueAsInt;
+#else
+            if (textRuntime != null)
+            {
+                textRuntime.Green = (int)value;
+            }
+#endif
             handled = true;
         }
         else if (propertyName == "Blue")
         {
+#if FRB
             int valueAsInt = (int)value;
             textRenderable.Blue = valueAsInt;
+#else
+            if (textRuntime != null)
+            {
+                textRuntime.Blue = (int)value;
+            }
+#endif
             handled = true;
         }
         else if (propertyName == "Color")
         {
-#if XNALIKE
+#if FRB
             if (value is System.Drawing.Color drawingColor)
             {
                 textRenderable.Color = drawingColor;
@@ -986,34 +1036,84 @@ public partial class CustomSetPropertyOnRenderable
                 textRenderable.Color = xnaColor.ToSystemDrawing();
                 handled = true;
             }
+#elif XNALIKE
+            // Scoped to XNALIKE (matching the prior gate) rather than extended to RAYLIB: unlike
+            // Blend, TextRuntime.Color is typed per-backend (XNA Color here), so redispatching it
+            // to RAYLIB would need its own verified conversion, not covered by this change.
+            if (value is System.Drawing.Color drawingColor)
+            {
+                if (textRuntime != null)
+                {
+                    textRuntime.Color = global::RenderingLibrary.Graphics.XNAExtensions.ToXNA(drawingColor);
+                }
+                handled = true;
+            }
+            else if (value is Microsoft.Xna.Framework.Color xnaColor)
+            {
+                if (textRuntime != null)
+                {
+                    textRuntime.Color = xnaColor;
+                }
+                handled = true;
+            }
 #endif
         }
 
         else if (propertyName == "HorizontalAlignment")
         {
+#if FRB
             textRenderable.HorizontalAlignment = (HorizontalAlignment)value;
+#else
+            if (textRuntime != null)
+            {
+                textRuntime.HorizontalAlignment = (HorizontalAlignment)value;
+            }
+#endif
             handled = true;
         }
         else if (propertyName == "VerticalAlignment")
         {
+#if FRB
             textRenderable.VerticalAlignment = (VerticalAlignment)value;
+#else
+            if (textRuntime != null)
+            {
+                textRuntime.VerticalAlignment = (VerticalAlignment)value;
+            }
+#endif
             handled = true;
         }
         else if (propertyName == "MaxLettersToShow")
         {
-#if XNALIKE
+#if FRB
             textRenderable.MaxLettersToShow = (int?)value;
-            handled = true;
+#else
+            // Issue #3706/#3710: previously gated #if XNALIKE only, silently no-op'ing this
+            // string-path assignment on RAYLIB even though TextRuntime.MaxLettersToShow has worked
+            // on every backend since #3708/#3710.
+            if (textRuntime != null)
+            {
+                textRuntime.MaxLettersToShow = (int?)value;
+            }
 #endif
+            handled = true;
         }
         else if (propertyName == "MaxNumberOfLines")
         {
+#if FRB
             textRenderable.MaxNumberOfLines = (int?)value;
+#else
+            if (textRuntime != null)
+            {
+                textRuntime.MaxNumberOfLines = (int?)value;
+            }
+#endif
             handled = true;
         }
 
         else if (propertyName == nameof(TextOverflowHorizontalMode))
         {
+#if FRB
             var textOverflowMode = (TextOverflowHorizontalMode)value;
 
             if (textOverflowMode == TextOverflowHorizontalMode.EllipsisLetter)
@@ -1024,6 +1124,17 @@ public partial class CustomSetPropertyOnRenderable
             {
                 textRenderable.IsTruncatingWithEllipsisOnLastLine = false;
             }
+#else
+            // Issue #3706: this used to hand-roll the exact same EllipsisLetter <->
+            // IsTruncatingWithEllipsisOnLastLine mapping that TextRuntime.TextOverflowHorizontalMode
+            // already implements, and never set handled = true (so the value still applied, but
+            // every assignment redundantly fell through to reflection afterward).
+            if (textRuntime != null)
+            {
+                textRuntime.TextOverflowHorizontalMode = (TextOverflowHorizontalMode)value;
+            }
+#endif
+            handled = true;
         }
         else if (propertyName == nameof(TextOverflowVerticalMode))
         {

--- a/MonoGameGum.Tests/Runtimes/TextRuntimeTests.cs
+++ b/MonoGameGum.Tests/Runtimes/TextRuntimeTests.cs
@@ -811,6 +811,23 @@ char id=67 x=0 y=0 width={xadvance} height=13 xoffset=0 yoffset=4 xadvance={xadv
         method.ShouldNotBeNull();
     }
 
+    // Issue #3706 (ADR 0009): TrySetPropertyOnText's "TextOverflowHorizontalMode" branch
+    // never set handled = true, so every string-path assignment (a saved Gum-project state using
+    // this variable) fell through to AdditionalPropertyOnRenderable/reflection after already being
+    // applied -- redundant at best, and would let a registered AdditionalPropertyOnRenderable hook
+    // reprocess a property that was already handled.
+    [Fact]
+    public void TrySetPropertyOnText_TextOverflowHorizontalMode_ShouldReturnHandledTrue()
+    {
+        TextRuntime sut = new();
+        Text textRenderable = (Text)sut.RenderableComponent;
+
+        bool handled = CustomSetPropertyOnRenderable.TrySetPropertyOnText(
+            textRenderable, sut, nameof(TextOverflowHorizontalMode), TextOverflowHorizontalMode.EllipsisLetter);
+
+        handled.ShouldBeTrue();
+    }
+
     #endregion
 
     #region Text (including bbcode and localization)

--- a/Tests/RaylibGum.Tests/Runtimes/CustomSetPropertyOnRenderableTests.cs
+++ b/Tests/RaylibGum.Tests/Runtimes/CustomSetPropertyOnRenderableTests.cs
@@ -37,4 +37,18 @@ public class CustomSetPropertyOnRenderableTests : BaseTestClass
 
         wasCalled.ShouldBeTrue();
     }
+
+    // Issue #3706/#3708/#3710 — TrySetPropertyOnText's "MaxLettersToShow" branch was gated
+    // #if XNALIKE only, despite TextRuntime.MaxLettersToShow being a platform-neutral property
+    // that has worked on every backend via direct C# calls since #3708/#3710. Pins the explicit
+    // redispatch now that the needless gate is removed.
+    [Fact]
+    public void SetProperty_MaxLettersToShow_ShouldForwardToTextRuntime()
+    {
+        TextRuntime sut = new();
+
+        sut.SetProperty("MaxLettersToShow", (int?)5);
+
+        sut.MaxLettersToShow.ShouldBe(5);
+    }
 }


### PR DESCRIPTION
Part of #3706. Implements step 1 of ADR 0009 (`Direction/decisions/0009-converge-text-dispatch-onto-textruntime.md`): the mechanical batch of `TrySetPropertyOnText` redispatch, following #3706/#3708's parity work.

## What changed

In `Gum/Wireframe/CustomSetPropertyOnRenderable.cs::TrySetPropertyOnText`, converted these branches from `textRenderable.X = value` to `textRuntime.X = value`, each guarded `#if FRB` (unchanged) / `#else` (new redispatch, `textRuntime != null` guarded):

- `FontScale` / `"Font Scale"`
- `LineHeightMultiplier` (collapsed the old `#if RAYLIB`/`#else` split into one `#else` branch, since `TextRuntime.LineHeightMultiplier` is un-gated across every backend)
- `Blend` — extended to RAYLIB too (previously `#if XNALIKE` only); `TextRuntime.Blend`'s own setter already does the platform-specific `BlendState` conversion
- `Alpha` — also extended to RAYLIB (same reasoning as `MaxLettersToShow`: `TextRuntime.Alpha` is a plain, platform-neutral `int`, so the old `#if XNALIKE` gate was needless)
- `Red`, `Green`, `Blue`
- `Color` — kept scoped to XNALIKE (not extended to RAYLIB): `TextRuntime.Color` is typed per-backend, unlike `Blend`, so extending it needs its own verified conversion, out of scope here
- `HorizontalAlignment`, `VerticalAlignment`
- `MaxLettersToShow`
- `MaxNumberOfLines`
- `TextOverflowHorizontalMode`

Two incidental bugs fixed as part of the redispatch (per the ADR):
- **`MaxLettersToShow`** was gated `#if XNALIKE` only, silently no-op'ing the string-path assignment on raylib even though the direct C# setter has worked on every backend since #3708/#3710.
- **`TextOverflowHorizontalMode`** never set `handled = true`, so the hand-rolled `EllipsisLetter`/`IsTruncatingWithEllipsisOnLastLine` mapping (now deleted, replaced by `textRuntime.TextOverflowHorizontalMode = value`) always fell through to reflection afterward.

Not touched (per the ADR): `Text`/`RawText` (structurally blocked — `TextRuntime.Text`'s setter calls back into `SetProperty`, so a naive redispatch recurses; separate follow-up PR), `TextOverflowVerticalMode` (already correctly lives on `GraphicalUiElement`), `SetBbCodeText`/`ApplyFontVariables` (transient parse-time state, not a runtime property surface).

## Testing

- `MonoGameGum.Tests`: 1871/1871 passing (added a regression test pinning `TrySetPropertyOnText`'s `TextOverflowHorizontalMode` branch now returns `handled = true`, which reproduced red before the fix).
- `RaylibGum.Tests`: 509/509 passing (added a regression test pinning `MaxLettersToShow` forwards correctly through the string path on raylib).
- `MonoGameGum.Shapes.Tests`: 222/222 passing (adjacent shape-runtime regression check, since this is a shared dispatch file).
- FRB canary (`GumCore.DesktopGlNet6.csproj`, built from the primary checkout): 0 errors, same warning count as the `main` baseline (1948).

**Manual test:** needed and done — several converted properties now flow through `TextRuntime` setters that call `NotifyPropertyChanged`/`UpdateLayout` where the old direct-renderable assignment didn't (e.g. `FontScale`, `TextOverflowHorizontalMode`, `HorizontalAlignment`, `Blend`, XNALIKE `Color`). Verified visually with a MonoGame demo toggling a `StateSave` (via `ApplyState`) between two variable sets covering the whole batch — no visual glitches, all properties applied correctly (color/alpha/blend, alignment, scale, truncation with ellipsis).

## Note for the maintainer

`Text`/`RawText` (ADR 0009 step 2) is confirmed as the next target, not started here.
