### PR TITLE
Add RAYLIB arm to TrySetPropertyOnText's Color dispatch

### DIFF
--- a/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
+++ b/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
@@ -1037,9 +1037,6 @@ public partial class CustomSetPropertyOnRenderable
                 handled = true;
             }
 #elif XNALIKE
-            // Scoped to XNALIKE (matching the prior gate) rather than extended to RAYLIB: unlike
-            // Blend, TextRuntime.Color is typed per-backend (XNA Color here), so redispatching it
-            // to RAYLIB would need its own verified conversion, not covered by this change.
             if (value is System.Drawing.Color drawingColor)
             {
                 if (textRuntime != null)
@@ -1053,6 +1050,18 @@ public partial class CustomSetPropertyOnRenderable
                 if (textRuntime != null)
                 {
                     textRuntime.Color = xnaColor;
+                }
+                handled = true;
+            }
+#elif RAYLIB
+            // TextRuntime.Color on raylib is an unconverted passthrough to the renderable's
+            // Raylib_cs.Color (see TextRuntime.cs), so - unlike XNALIKE above - there's no
+            // raylib-native color type coming through the string path that also needs handling.
+            if (value is System.Drawing.Color drawingColor)
+            {
+                if (textRuntime != null)
+                {
+                    textRuntime.Color = drawingColor.ToRaylib();
                 }
                 handled = true;
             }

--- a/Tests/RaylibGum.Tests/Runtimes/CustomSetPropertyOnRenderableTests.cs
+++ b/Tests/RaylibGum.Tests/Runtimes/CustomSetPropertyOnRenderableTests.cs
@@ -51,4 +51,24 @@ public class CustomSetPropertyOnRenderableTests : BaseTestClass
 
         sut.MaxLettersToShow.ShouldBe(5);
     }
+
+    // Issue #3706/#3724 follow-up — TrySetPropertyOnText's "Color" branch was #if FRB / #elif
+    // XNALIKE with no RAYLIB arm at all, so the branch body didn't compile in on raylib and the
+    // string-path assignment silently did nothing (not even a reflection fallback, since
+    // "handled" only gates whether SetPropertyOnRenderable falls through to reflection for the
+    // property it was given — reflection can't find "Color" on TextRuntime either, since the
+    // combined Color property is FRB/XNALIKE-only there too).
+    [Fact]
+    public void SetProperty_Color_ShouldForwardToTextRuntime()
+    {
+        TextRuntime sut = new();
+        System.Drawing.Color drawingColor = System.Drawing.Color.FromArgb(10, 20, 30, 40);
+
+        sut.SetProperty("Color", drawingColor);
+
+        sut.Color.R.ShouldBe((byte)20);
+        sut.Color.G.ShouldBe((byte)30);
+        sut.Color.B.ShouldBe((byte)40);
+        sut.Color.A.ShouldBe((byte)10);
+    }
 }


### PR DESCRIPTION
Follow-up to #3706 / PR #3724.

`TrySetPropertyOnText`'s string-path `"Color"` branch was `#if FRB ... #elif XNALIKE ... #endif` with no `RAYLIB` case, so `SetProperty("Color", ...)` on a raylib Text element silently did nothing. Added a `#elif RAYLIB` arm mirroring XNALIKE's `System.Drawing.Color` case, using `ColorExtensions.ToRaylib()` (the existing raylib mirror of `XNAExtensions.ToXNA`).

**Reachability:** confirmed this was a real but currently-unreachable gap, not a live user-facing bug. `StandardElementsManager.AddColorVariables` (used to seed Text's default state) only adds `Alpha`/`Red`/`Green`/`Blue` — never a combined `Color` variable — and `TextRuntime.Color` is a direct C# passthrough that bypasses `SetProperty` entirely. No call site in the repo sets `"Color"` on Text via the string path today. This is parity work per ADR 0009's direction, not an active-bug fix.

**Tests:** added `SetProperty_Color_ShouldForwardToTextRuntime` in `CustomSetPropertyOnRenderableTests.cs` — confirmed red before the fix (`TextRuntime.Color` stayed at the default 255/255/255/255), green after. Full `RaylibGum.Tests` suite: 510/510 passing. `MonoGameGum.Tests` builds clean (XNALIKE branch untouched).

**FRB canary: pass.** Built `GumCore.DesktopGlNet6.csproj` from the primary checkout — baseline (main) 0 errors, with the fix 0 errors (no new errors).

**Manual test: not needed** — the gap has no reachable call site through the tool or codegen today (see Reachability above), so there's nothing to observe visually; unit test + FRB canary are the full proof.
