### PR TITLE
Converge Skia's Text SetProperty dispatch onto TextRuntime

### DIFF
--- a/Direction/decisions/0010-converge-skia-text-dispatch-onto-textruntime.md
+++ b/Direction/decisions/0010-converge-skia-text-dispatch-onto-textruntime.md
@@ -1,0 +1,97 @@
+# 0010. Converge Skia's Text dispatch onto TextRuntime, without merging the two dispatcher files
+
+- **Status:** Accepted
+- **Date:** 2026-07-16
+- **Deciders:** Victor Chelaru, Claude
+
+## Context
+
+[0009](0009-converge-text-dispatch-onto-textruntime.md) redispatched the mechanical group of
+`TrySetPropertyOnText` properties onto `TextRuntime` in the core dispatcher
+(`Gum/Wireframe/CustomSetPropertyOnRenderable.cs`, XNALIKE/Raylib/tool), and explicitly deferred
+the Skia copy (`Runtimes/SkiaGum/CustomSetPropertyOnRenderable.cs`) as out of scope. Issue #3706,
+which both ADRs implement, always covered both files.
+
+Auditing Skia's `TrySetPropertyOnText` end to end found the same three-group split 0009 used for
+core:
+
+1. **Already redispatched.** Font, UseCustomFont, CustomFontFile, Typeface, FontSize,
+   OutlineThickness, IsItalic, IsBold already route through `gueAsTextRuntime.X = value`.
+2. **Mechanical — parity confirmed (#3708), no structural blocker.** FontScale, Red, Green, Blue,
+   HorizontalAlignment, VerticalAlignment, Blend, and TextOverflowHorizontalMode still write
+   `text.X = value` directly. TextOverflowHorizontalMode also never sets `handled = true` — the
+   same incidental bug 0009 fixed in the core file's copy of this property.
+3. **Structurally blocked / intentionally divergent — leave alone.** Text/RawText (Skia parses
+   BBCode lazily at render time by design, unlike core's eager strip-and-store; inverting this is
+   its own future step, mirroring 0009's deferred `Text`/`RawText` step for core) and
+   TextOverflowVerticalMode (intentionally renderable-direct per the #3677 comment already in the
+   file — Skia honors vertical overflow natively, unlike core's `GraphicalUiElement` route).
+
+Two further findings, specific to Skia and not present in 0009's audit of core:
+
+- **Alpha, LineHeightMultiplier, MaxNumberOfLines have no live dispatch arm at all**, yet all three
+  already work today by accident: each property exists on `SkiaGum.Renderables.Text` with a type
+  that exactly matches the boxed value, so the reflection fallback
+  (`GraphicalUiElement.SetPropertyThroughReflection`) silently succeeds. No behavior bug, but every
+  assignment pays a `PropertyInfo` lookup instead of a direct call, and the dispatch is
+  inconsistent with every other property in the method.
+- **Color is a real, currently-shipping bug.** `SkiaGum.Renderables.Text.Color` is `SKColor`;
+  `SetProperty("Color", ...)` passes a boxed `System.Drawing.Color`, matching every other
+  Color-consuming branch in both dispatchers. The reflection fallback's type-mismatch path only
+  special-cases enums — `Convert.ChangeType(System.Drawing.Color, SKColor)` throws, the catch
+  swallows it, and the assignment silently never applies. No test in `Tests/SkiaGum.Tests`
+  exercised `SetProperty("Color", ...)` on Text before this decision.
+
+**The dead code inside these branches is not incidental cruft to delete.** `Alpha` and `Color`
+each have an inner `#if MONOGAME || XNA4` block, and `UseFontSmoothing` has an inner `#if !SKIA`
+block — all unreachable today, since the whole method only compiles under `#if SKIA`. These read
+like a leftover from bootstrapping this file off the core dispatcher's structure. Even though
+unreachable in every current build, they are exactly the mirrored-`#if` scaffolding the
+[gum-cross-platform-unification](../../.claude/skills/gum-cross-platform-unification/SKILL.md)
+convergence technique depends on: [0007](0007-converge-skia-property-dispatch.md)'s physical
+single-file merge is blocked today by a missing compile symbol (nothing distinguishes the
+`MonoGameGumShapes`/Apos assemblies from core for namespace selection), not by anything structural
+in this method — and that symbol gap is a small, addressable fix (a new `DefineConstants` entry),
+not a permanent wall. Stripping the dead branches now would make a future resolution of that
+blocker strictly more work, for a cleanup payoff that is purely cosmetic today.
+
+## Decision
+
+We will redispatch Skia's mechanical group (2) onto `gueAsTextRuntime`, fixing
+TextOverflowHorizontalMode's missing `handled = true` en route, and add explicit
+`gueAsTextRuntime.X` dispatch arms for Alpha, LineHeightMultiplier, and MaxNumberOfLines (behavior
+preserving — they already work via reflection). We will fix Color by adding a
+`System.Drawing.Color -> SKColor` converter (`ToSkia()`, mirroring
+`RaylibGum.Helpers.ColorExtensions.ToRaylib()`) and a real dispatch arm, pinned by a test that
+first proves the bug red.
+
+**Every existing dead `#if` branch stays exactly where it is — none are deleted.** New dispatch
+arms are added alongside them, the same way the core file already stacks multiple platform arms
+(`#if FRB ... #else ... #endif`) at one dispatch point. Where a dead branch has a minor internal
+inconsistency and touching it costs nothing (e.g. `UseFontSmoothing`'s dead arm assigns through
+`gue` instead of the `gueAsTextRuntime` it null-checks), we normalize it in place without removing
+the guard.
+
+Text/RawText and TextOverflowVerticalMode are left untouched, matching core's own deferrals.
+
+## Consequences
+
+- Skia's `TrySetPropertyOnText` converges structurally with core's redispatch-onto-runtime shape
+  for every property that isn't intentionally divergent, closing out issue #3706's Skia half.
+- The Color fix is a real behavior change (not a structural no-op), so it needs its own red-green
+  test rather than a pinning test — called out separately from the mechanical redispatch.
+- No FRB canary is needed: SkiaGum is not FRB-shared source.
+- A future resolution of 0007's namespace-symbol blocker (e.g. a new `APOS_SHAPES` define) still
+  has the same amount of mirrored scaffolding to work with as before this PR — this decision adds
+  to that scaffolding (new dispatch arms match core's shape) rather than spending it down.
+
+## Alternatives considered
+
+- **Delete the unreachable `#if` blocks as dead-code cleanup.** Rejected — they are mirrored
+  scaffolding for a physical merge that 0007 called blocked-but-not-impossible, not incidental
+  cruft; deleting them only pays off if that merge is permanently off the table, which is a bigger
+  call than this PR makes.
+- **Fix Color by widening the existing dead `#if MONOGAME || XNA4` block to also include `SKIA`.**
+  Rejected — that block casts to `Color` (the XNA type) via `(Color)value`, which doesn't apply to
+  Skia's `SKColor`; widening it would conflate two genuinely different conversions under one guard
+  instead of adding a parallel arm, working against the mirrored-`#if` convergence goal.

--- a/Direction/decisions/README.md
+++ b/Direction/decisions/README.md
@@ -29,3 +29,4 @@ re-litigating it.
 | [0007](0007-converge-skia-property-dispatch.md) | Converge the Skia property dispatcher via runtime-type-first dispatch | Accepted | 2026-07-13 |
 | [0008](0008-sequence-runtime-dispatch-convergence.md) | Sequence the runtime-type-first dispatch convergence: parity, then redispatch, then converge | Accepted | 2026-07-13 |
 | [0009](0009-converge-text-dispatch-onto-textruntime.md) | Converge Text's SetProperty dispatch onto TextRuntime, phased by risk | Accepted | 2026-07-15 |
+| [0010](0010-converge-skia-text-dispatch-onto-textruntime.md) | Converge Skia's Text dispatch onto TextRuntime, without merging the two dispatcher files | Accepted | 2026-07-16 |

--- a/Runtimes/SkiaGum/CustomSetPropertyOnRenderable.cs
+++ b/Runtimes/SkiaGum/CustomSetPropertyOnRenderable.cs
@@ -16,6 +16,7 @@ using System.Threading.Tasks;
 #if SKIA
 using HarfBuzzSharp;
 using SkiaGum.Content;
+using SkiaGum.Helpers;
 using Gum.GueDeriving;
 using SkiaGum.Renderables;
 using SkiaSharp;
@@ -1277,16 +1278,14 @@ public partial class CustomSetPropertyOnRenderable
         }
         else if (propertyName == "Font Scale" || propertyName == "FontScale")
         {
-            text.FontScale = (float)value;
-            // we want to update if the text's size is based on its "children" (the letters it contains)
-            if (gue.WidthUnits == DimensionUnitType.RelativeToChildren ||
-                // If height is relative to children, it could be in a stack
-                gue.HeightUnits == DimensionUnitType.RelativeToChildren)
+            // Redispatched onto TextRuntime (issue #3706/ADR 0010, mirroring the core dispatcher's
+            // FontScale arm). TextRuntime.FontScale's own setter already calls UpdateLayout() on
+            // change, so the manual RelativeToChildren check this used to duplicate is redundant.
+            if (gueAsTextRuntime != null)
             {
-                gue.UpdateLayout();
+                gueAsTextRuntime.FontScale = (float)value;
             }
             handled = true;
-
         }
         else if (propertyName == "Font")
         {
@@ -1373,7 +1372,7 @@ public partial class CustomSetPropertyOnRenderable
         {
             if (gueAsTextRuntime != null)
             {
-                gue.UseFontSmoothing = (bool)value;
+                gueAsTextRuntime.UseFontSmoothing = (bool)value;
             }
             ReactToFontValueChange();
         }
@@ -1385,7 +1384,12 @@ public partial class CustomSetPropertyOnRenderable
             // which sets textRenderable.BlendState. Skia has no BlendState; it applies the Gum
             // Blend as an SKPaint.BlendMode at render time (see Text.GetRenderPaint), so the same
             // dispatch just assigns the nullable Blend property. (issue #3676)
-            text.Blend = (Gum.RenderingLibrary.Blend)value;
+            // Redispatched onto TextRuntime (issue #3706/ADR 0010): TextRuntime.Blend already
+            // forwards to ContainedText.Blend, so this is a structural no-op, not a behavior change.
+            if (gueAsTextRuntime != null)
+            {
+                gueAsTextRuntime.Blend = (Gum.RenderingLibrary.Blend)value;
+            }
             handled = true;
 #endif
         }
@@ -1396,23 +1400,41 @@ public partial class CustomSetPropertyOnRenderable
             ((Text)mContainedObjectAsIpso).Alpha = valueAsInt;
             handled = true;
 #endif
+            // Issue #3706/ADR 0010: previously had no live dispatch arm at all (the block above is
+            // dead -- this method only compiles under SKIA). Worked by accident via the reflection
+            // fallback (SkiaGum.Renderables.Text.Alpha is `int`, an exact type match), so this is a
+            // consistency/perf fix, not a behavior change.
+            if (gueAsTextRuntime != null)
+            {
+                gueAsTextRuntime.Alpha = (int)value;
+            }
+            handled = true;
         }
         else if (propertyName == "Red")
         {
             int valueAsInt = (int)value;
-            text.Red = valueAsInt;
+            if (gueAsTextRuntime != null)
+            {
+                gueAsTextRuntime.Red = valueAsInt;
+            }
             handled = true;
         }
         else if (propertyName == "Green")
         {
             int valueAsInt = (int)value;
-            text.Green = valueAsInt;
+            if (gueAsTextRuntime != null)
+            {
+                gueAsTextRuntime.Green = valueAsInt;
+            }
             handled = true;
         }
         else if (propertyName == "Blue")
         {
             int valueAsInt = (int)value;
-            text.Blue = valueAsInt;
+            if (gueAsTextRuntime != null)
+            {
+                gueAsTextRuntime.Blue = valueAsInt;
+            }
             handled = true;
         }
         else if (propertyName == "Color")
@@ -1422,16 +1444,31 @@ public partial class CustomSetPropertyOnRenderable
             ((Text)mContainedObjectAsIpso).Color = valueAsColor;
             handled = true;
 #endif
+            // Issue #3706/ADR 0010: this dispatch arm was dead (see the Alpha comment above), and
+            // unlike Alpha, Color was a genuine bug -- SkiaGum.Renderables.Text.Color is SKColor, and
+            // SetProperty("Color", ...) passes a boxed System.Drawing.Color, so the reflection
+            // fallback's Convert.ChangeType threw internally and silently swallowed the assignment.
+            if (gueAsTextRuntime != null && value is System.Drawing.Color drawingColor)
+            {
+                gueAsTextRuntime.Color = drawingColor.ToSkia();
+            }
+            handled = true;
         }
 
         else if (propertyName == "HorizontalAlignment")
         {
-            text.HorizontalAlignment = (RenderingLibrary.Graphics.HorizontalAlignment)value;
+            if (gueAsTextRuntime != null)
+            {
+                gueAsTextRuntime.HorizontalAlignment = (RenderingLibrary.Graphics.HorizontalAlignment)value;
+            }
             handled = true;
         }
         else if (propertyName == "VerticalAlignment")
         {
-            text.VerticalAlignment = (VerticalAlignment)value;
+            if (gueAsTextRuntime != null)
+            {
+                gueAsTextRuntime.VerticalAlignment = (VerticalAlignment)value;
+            }
             handled = true;
         }
         else if (propertyName == "MaxLettersToShow")
@@ -1440,23 +1477,48 @@ public partial class CustomSetPropertyOnRenderable
             // Mirror of the XNALIKE MaxLettersToShow arm in Gum/Wireframe/CustomSetPropertyOnRenderable.cs.
             // Skia honors this as a paint-only typewriter reveal on the renderable (see Text.Render /
             // Text.GetVisibleWrappedText); the assignment is otherwise identical. (issue #3678)
-            text.MaxLettersToShow = (int?)value;
+            // Redispatched onto TextRuntime (issue #3706/ADR 0010) for consistency with core.
+            if (gueAsTextRuntime != null)
+            {
+                gueAsTextRuntime.MaxLettersToShow = (int?)value;
+            }
             handled = true;
 #endif
+        }
+        else if (propertyName == nameof(gueAsTextRuntime.LineHeightMultiplier))
+        {
+            // Issue #3706/ADR 0010: had no dispatch arm at all. Worked by accident via the
+            // reflection fallback (SkiaGum.Renderables.Text.LineHeightMultiplier is `float`, an
+            // exact type match), so this is a consistency/perf fix, not a behavior change.
+            if (gueAsTextRuntime != null)
+            {
+                gueAsTextRuntime.LineHeightMultiplier = (float)value;
+            }
+            handled = true;
+        }
+        else if (propertyName == nameof(gueAsTextRuntime.MaxNumberOfLines))
+        {
+            // Issue #3706/ADR 0010: same as LineHeightMultiplier above -- worked by accident via
+            // the reflection fallback (SkiaGum.Renderables.Text.MaxNumberOfLines is `int?`, an
+            // exact type match).
+            if (gueAsTextRuntime != null)
+            {
+                gueAsTextRuntime.MaxNumberOfLines = (int?)value;
+            }
+            handled = true;
         }
 
         else if (propertyName == nameof(TextOverflowHorizontalMode))
         {
-            var textOverflowMode = (TextOverflowHorizontalMode)value;
-
-            if (textOverflowMode == TextOverflowHorizontalMode.EllipsisLetter)
+            // Issue #3706/ADR 0010: this arm never set handled = true (the same incidental bug
+            // ADR 0009 fixed in the core dispatcher's copy of this property), so every assignment
+            // redundantly fell through to reflection afterward. Redispatched onto TextRuntime, which
+            // already implements the identical enum-to-bool mapping this used to duplicate.
+            if (gueAsTextRuntime != null)
             {
-                text.IsTruncatingWithEllipsisOnLastLine = true;
+                gueAsTextRuntime.TextOverflowHorizontalMode = (TextOverflowHorizontalMode)value;
             }
-            else
-            {
-                text.IsTruncatingWithEllipsisOnLastLine = false;
-            }
+            handled = true;
         }
         else if (propertyName == nameof(TextOverflowVerticalMode))
         {

--- a/Runtimes/SkiaGum/Helpers/ColorExtensions.cs
+++ b/Runtimes/SkiaGum/Helpers/ColorExtensions.cs
@@ -44,4 +44,13 @@ public static class ColorExtensions
     {
         return new SKColor(color.Red, color.Green, value, color.Alpha);
     }
+
+    /// <summary>
+    /// Converts a <see cref="System.Drawing.Color"/> to its Skia equivalent. Mirror of
+    /// <c>RaylibGum.Helpers.ColorExtensions.ToRaylib</c> for the Skia backend.
+    /// </summary>
+    public static SKColor ToSkia(this System.Drawing.Color value)
+    {
+        return new SKColor(value.R, value.G, value.B, value.A);
+    }
 }

--- a/Tests/SkiaGum.Tests/GueDeriving/TextRuntimeTests.cs
+++ b/Tests/SkiaGum.Tests/GueDeriving/TextRuntimeTests.cs
@@ -17,6 +17,24 @@ public class TextRuntimeTests
         GraphicalUiElement.SetPropertyOnRenderable = CustomSetPropertyOnRenderable.SetPropertyOnRenderable;
     }
 
+    #region Alpha
+
+    [Fact]
+    public void Alpha_SetProperty_ShouldPushToContainedText()
+    {
+        // Issue #3706/ADR 0010: this dispatch arm was gated #if MONOGAME || XNA4, which is dead
+        // inside a method that only compiles under SKIA, so this previously worked only by
+        // accident via the reflection fallback. Now redispatched onto TextRuntime.
+        TextRuntime sut = new();
+
+        sut.SetProperty("Alpha", 128);
+
+        Text containedText = (Text)sut.RenderableComponent;
+        containedText.Alpha.ShouldBe(128);
+    }
+
+    #endregion
+
     #region Blend
 
     [Fact]
@@ -28,6 +46,19 @@ public class TextRuntimeTests
         // setter forwards straight to the contained renderable, not through the font-update delegate.
         TextRuntime sut = new();
         sut.Blend = Gum.RenderingLibrary.Blend.Additive;
+
+        Text containedText = (Text)sut.RenderableComponent;
+        containedText.Blend.ShouldBe(Gum.RenderingLibrary.Blend.Additive);
+    }
+
+    [Fact]
+    public void Blend_SetProperty_ShouldPushToContainedText()
+    {
+        // Issue #3706/ADR 0010: redispatched onto TextRuntime.Blend (previously wrote
+        // text.Blend directly) -- structurally different, same end result.
+        TextRuntime sut = new();
+
+        sut.SetProperty("Blend", Gum.RenderingLibrary.Blend.Additive);
 
         Text containedText = (Text)sut.RenderableComponent;
         containedText.Blend.ShouldBe(Gum.RenderingLibrary.Blend.Additive);
@@ -88,6 +119,21 @@ public class TextRuntimeTests
 
         Text containedText = (Text)sut.RenderableComponent;
         containedText.Color.ShouldBe(SKColors.White);
+    }
+
+    [Fact]
+    public void Color_SetProperty_ShouldPushToContainedText()
+    {
+        // Issue #3706/ADR 0010: this dispatch arm was gated #if MONOGAME || XNA4, which is dead
+        // inside a method that only compiles under SKIA, so SetProperty("Color", ...) silently
+        // fell through to the reflection fallback -- which throws internally converting
+        // System.Drawing.Color to SKColor (not IConvertible-compatible) and swallows the failure.
+        TextRuntime sut = new();
+
+        sut.SetProperty("Color", System.Drawing.Color.FromArgb(200, 10, 20, 30));
+
+        Text containedText = (Text)sut.RenderableComponent;
+        containedText.Color.ShouldBe(new SKColor(10, 20, 30, 200));
     }
 
     #endregion
@@ -195,6 +241,19 @@ public class TextRuntimeTests
         TextRuntime sut = new();
         sut.FontScale = 3.0f;
         sut.FontScale.ShouldBe(3.0f);
+    }
+
+    [Fact]
+    public void FontScale_SetProperty_ShouldPushToContainedText()
+    {
+        // Issue #3706/ADR 0010: redispatched onto TextRuntime.FontScale (previously wrote
+        // text.FontScale directly) -- structurally different, same end result.
+        TextRuntime sut = new();
+
+        sut.SetProperty("FontScale", 2.5f);
+
+        Text containedText = (Text)sut.RenderableComponent;
+        containedText.FontScale.ShouldBe(2.5f);
     }
 
     #endregion
@@ -316,6 +375,23 @@ public class TextRuntimeTests
 
     #endregion
 
+    #region HorizontalAlignment
+
+    [Fact]
+    public void HorizontalAlignment_SetProperty_ShouldPushToContainedText()
+    {
+        // Issue #3706/ADR 0010: redispatched onto TextRuntime.HorizontalAlignment (previously
+        // wrote text.HorizontalAlignment directly) -- structurally different, same end result.
+        TextRuntime sut = new();
+
+        sut.SetProperty("HorizontalAlignment", RenderingLibrary.Graphics.HorizontalAlignment.Right);
+
+        Text containedText = (Text)sut.RenderableComponent;
+        containedText.HorizontalAlignment.ShouldBe(RenderingLibrary.Graphics.HorizontalAlignment.Right);
+    }
+
+    #endregion
+
     #region HeightUnits
 
     [Fact]
@@ -343,6 +419,19 @@ public class TextRuntimeTests
         TextRuntime sut = new();
         sut.LineHeightMultiplier = 1.5f;
         sut.LineHeightMultiplier.ShouldBe(1.5f);
+    }
+
+    [Fact]
+    public void LineHeightMultiplier_SetProperty_ShouldPushToContainedText()
+    {
+        // Issue #3706/ADR 0010: had no dispatch arm at all, so this previously worked only by
+        // accident via the reflection fallback. Now redispatched onto TextRuntime.
+        TextRuntime sut = new();
+
+        sut.SetProperty("LineHeightMultiplier", 1.75f);
+
+        Text containedText = (Text)sut.RenderableComponent;
+        containedText.LineHeightMultiplier.ShouldBe(1.75f);
     }
 
     #endregion
@@ -374,6 +463,44 @@ public class TextRuntimeTests
 
         Text containedText = (Text)sut.RenderableComponent;
         containedText.MaxLettersToShow.ShouldBe(4);
+    }
+
+    #endregion
+
+    #region MaxNumberOfLines
+
+    [Fact]
+    public void MaxNumberOfLines_SetProperty_ShouldPushToContainedText()
+    {
+        // Issue #3706/ADR 0010: had no dispatch arm at all, so this previously worked only by
+        // accident via the reflection fallback. Now redispatched onto TextRuntime.
+        TextRuntime sut = new();
+
+        sut.SetProperty("MaxNumberOfLines", (int?)3);
+
+        Text containedText = (Text)sut.RenderableComponent;
+        containedText.MaxNumberOfLines.ShouldBe(3);
+    }
+
+    #endregion
+
+    #region Red, Green, Blue
+
+    [Fact]
+    public void RedGreenBlue_SetProperty_ShouldPushToContainedText()
+    {
+        // Issue #3706/ADR 0010: redispatched onto TextRuntime.Red/Green/Blue (previously wrote
+        // text.Red/Green/Blue directly) -- structurally different, same end result.
+        TextRuntime sut = new();
+
+        sut.SetProperty("Red", 10);
+        sut.SetProperty("Green", 20);
+        sut.SetProperty("Blue", 30);
+
+        Text containedText = (Text)sut.RenderableComponent;
+        containedText.Red.ShouldBe(10);
+        containedText.Green.ShouldBe(20);
+        containedText.Blue.ShouldBe(30);
     }
 
     #endregion
@@ -477,6 +604,20 @@ public class TextRuntimeTests
         sut.TextOverflowHorizontalMode = TextOverflowHorizontalMode.EllipsisLetter;
         sut.TextOverflowHorizontalMode = TextOverflowHorizontalMode.TruncateWord;
         sut.TextOverflowHorizontalMode.ShouldBe(TextOverflowHorizontalMode.TruncateWord);
+    }
+
+    [Fact]
+    public void TextOverflowHorizontalMode_SetProperty_ShouldPushToContainedText()
+    {
+        // Issue #3706/ADR 0010: this arm never set handled = true, so every assignment redundantly
+        // fell through to reflection afterward (the value still applied). Redispatched onto
+        // TextRuntime.TextOverflowHorizontalMode, which already implements this enum-to-bool mapping.
+        TextRuntime sut = new();
+
+        sut.SetProperty("TextOverflowHorizontalMode", TextOverflowHorizontalMode.EllipsisLetter);
+
+        Text containedText = (Text)sut.RenderableComponent;
+        containedText.IsTruncatingWithEllipsisOnLastLine.ShouldBeTrue();
     }
 
     #endregion
@@ -584,6 +725,23 @@ public class TextRuntimeTests
         TextRuntime sut = new();
         sut.UseFontSmoothing = false;
         sut.UseFontSmoothing.ShouldBeFalse();
+    }
+
+    #endregion
+
+    #region VerticalAlignment
+
+    [Fact]
+    public void VerticalAlignment_SetProperty_ShouldPushToContainedText()
+    {
+        // Issue #3706/ADR 0010: redispatched onto TextRuntime.VerticalAlignment (previously wrote
+        // text.VerticalAlignment directly) -- structurally different, same end result.
+        TextRuntime sut = new();
+
+        sut.SetProperty("VerticalAlignment", VerticalAlignment.Bottom);
+
+        Text containedText = (Text)sut.RenderableComponent;
+        containedText.VerticalAlignment.ShouldBe(VerticalAlignment.Bottom);
     }
 
     #endregion


### PR DESCRIPTION
## Summary
- Redispatches `TrySetPropertyOnText`'s mechanical properties (FontScale, Red/Green/Blue, HorizontalAlignment/VerticalAlignment, Blend, TextOverflowHorizontalMode) onto `TextRuntime` in the Skia dispatcher, mirroring PR #3724's fix for the core (XNALIKE/Raylib) dispatcher.
- Adds explicit dispatch for Alpha/LineHeightMultiplier/MaxNumberOfLines (previously worked only by accident via the reflection fallback).
- Fixes a real bug: `SetProperty("Color", ...)` silently no-op'd on Skia `Text` — the reflection fallback can't convert `System.Drawing.Color` to `SKColor`, so the assignment threw internally and was swallowed.
- Every dead `#if MONOGAME || XNA4` / `#if !SKIA` branch is preserved as mirrored scaffolding for a possible future dispatcher merge (see ADR 0007's namespace-symbol blocker), not deleted — see `Direction/decisions/0010-converge-skia-text-dispatch-onto-textruntime.md`.

Part of #3706 (also covers the core dispatcher's deferred `Text`/`RawText` inversion step, ADR 0009 step 2 — not this PR).

## Test plan
- [x] New failing test (`Color_SetProperty_ShouldPushToContainedText`) confirmed the Color bug red before the fix, green after.
- [x] Pinning tests added for every redispatched/newly-dispatched property (Alpha, Blend, FontScale, HorizontalAlignment/VerticalAlignment, LineHeightMultiplier, MaxNumberOfLines, Red/Green/Blue, TextOverflowHorizontalMode).
- [x] Full `SkiaGum.Tests` suite green (350/350).
- [x] `MonoGameGumShapes.csproj` (Apos.Shapes, the `#else` branch of this shared file) builds clean.
- Manual test: not needed — this is dispatch plumbing covered by unit tests asserting on the renderable's resulting state; no new runtime-observable behavior beyond what the tests already exercise.
- FRB canary: not needed — SkiaGum is not FRB-shared source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
