### PR TITLE
Add [State=Name] BBCode tag for Text

### DIFF
--- a/.claude/skills/frb-build-verification/SKILL.md
+++ b/.claude/skills/frb-build-verification/SKILL.md
@@ -13,18 +13,20 @@ The projitems-sync rules (which files FRB1 pulls, and what to update when you ad
 
 This is only doable when a **FlatRedBall checkout exists as a sibling of the Gum repo** (i.e. `<gum-repo>/../FlatRedBall/`). The cross-repo csproj imports are sibling-relative (`..\..\..\..\FlatRedBall\…`), so without that layout the build can't resolve. If the sibling is absent, **skip FRB verification and say so** — it is not a failure; the maintainer/CI covers it. Do not hardcode an absolute path; check for the sibling.
 
+Check the sibling's checked-out branch before trusting the canary — `git status`/`git branch --show-current` there. A stale or already-merged local branch doesn't error, it just silently compiles against old FRB-side source, so a clean canary result proves nothing. The sibling's default branch is `origin/NetStandard`, not `main`/`master`.
+
 ## Must run from the PRIMARY checkout, never a worktree
 
 The sibling-relative imports are computed from the csproj location, and the FlatRedBall-side csprojs pull Gum source by relative path into the **primary** Gum checkout (`…\Gum\MonoGameGum\…`). A worktree under `.claude/worktrees/<branch>/` is both nested too deep (so `..\..\..\..\FlatRedBall` resolves to nothing — `MSB4019`) and not the path FRB compiles from. To FRB-verify a branch, **check that branch out in the primary Gum checkout** and build there. Worktrees cannot FRB-verify.
 
 ## Canaries
 
-Pick by what you changed. Build from the primary Gum checkout (first row) / the sibling FlatRedBall repo (second row).
+Pick by what you changed. **The "Lives in" column is the repo containing the `.csproj` file itself** — don't go hunting for it in the other repo. Both rows still need the FlatRedBall sibling present (row 1's target also pulls in some FlatRedBall-side `Embedded\*.cs` files), but only row 2's `.csproj` is physically located there.
 
-| Changed source | Build target | Covers |
-|---|---|---|
-| `GumCommon/` (anything in `GumCoreShared.projitems`) | `GumCore/GumCoreXnaPc/GumCore.DesktopGlNet6/GumCore.DesktopGlNet6.csproj` | GumCommon shared into FRB |
-| `MonoGameGum/Forms/` (in `FlatRedBall.Forms.Shared.projitems`) | `<FlatRedBall>/Engines/Forms/FlatRedBall.Forms/FlatRedBall.Forms.DesktopGlNet6/FlatRedBall.Forms.DesktopGlNet6.csproj` | Forms shared into FRB |
+| Changed source | Lives in | Build target (relative to that repo's root) | Covers |
+|---|---|---|---|
+| `GumCommon/` (anything in `GumCoreShared.projitems`) | **Gum repo** (this repo) | `GumCore/GumCoreXnaPc/GumCore.DesktopGlNet6/GumCore.DesktopGlNet6.csproj` | GumCommon shared into FRB |
+| `MonoGameGum/Forms/` (in `FlatRedBall.Forms.Shared.projitems`) | **FlatRedBall sibling repo** | `Engines/Forms/FlatRedBall.Forms/FlatRedBall.Forms.DesktopGlNet6/FlatRedBall.Forms.DesktopGlNet6.csproj` | Forms shared into FRB |
 
 `GueDeriving/*Runtime`, `MonoGameGum/Renderables/`, `MonoGameGum/ExtensionMethods/`, `MonoGameGum/Input/` (Cursor, Keyboard, gamepad drivers), and the `Forms/DefaultVisuals/` runtimes are **not** compiled by FRB1 (it generates its own) — changing only those needs no FRB build.
 

--- a/Gum/DataTypes/GumProjectSaveExtensionMethods.cs
+++ b/Gum/DataTypes/GumProjectSaveExtensionMethods.cs
@@ -123,14 +123,14 @@ namespace Gum.DataTypes
                 //}
 
                 List<string>? defaultStateAdded = modifications != null ? new List<string>() : null;
-                if (componentSave.Initialize(new StateSave { Name = "Default" }, modifications: defaultStateAdded))
+                if (componentSave.Initialize(new StateSave { Name = "Default" }, tolerateMissingDefaultStates, modifications: defaultStateAdded))
                 {
                     wasModified = true;
                     modifications?.Add($"Component:{componentSave.Name} (default-state init{FormatAddedVariables(defaultStateAdded)})");
                 }
 
                 List<string>? componentBaseAdded = modifications != null ? new List<string>() : null;
-                if (componentSave.Initialize(StandardElementsManager.Self.GetDefaultStateFor("Component"), modifications: componentBaseAdded))
+                if (componentSave.Initialize(StandardElementsManager.Self.GetDefaultStateFor("Component"), tolerateMissingDefaultStates, modifications: componentBaseAdded))
                 {
                     wasModified = true;
                     modifications?.Add($"Component:{componentSave.Name} (Component-base init{FormatAddedVariables(componentBaseAdded)})");

--- a/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
+++ b/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
@@ -1233,15 +1233,16 @@ public partial class CustomSetPropertyOnRenderable
 
     /// <summary>
     /// Expands every <c>[state=Name]</c> <see cref="FoundTag"/> in <paramref name="results"/> into one
-    /// synthetic <see cref="FoundTag"/> per allowlisted variable on the named state (looked up on
-    /// <paramref name="graphicalUiElement"/>'s <see cref="GraphicalUiElement.States"/> - the same runtime
-    /// dictionary <see cref="GraphicalUiElement.ApplyState(string)"/> uses, populated identically whether
-    /// the state came from the Gum tool or was added in code), each spanning the state tag's own
-    /// open/close range. An unknown state name, or a state with no allowlisted variables, contributes
-    /// nothing - a no-op, not an error. Must run AFTER <see cref="BbCodeParser.RemoveTags"/> has already
-    /// stripped the source text using the original (unexpanded) <paramref name="results"/>: the synthetic
-    /// entries share character ranges with each other (and with the original state tag), so stripping
-    /// with them in play would remove the same range more than once.
+    /// synthetic <see cref="FoundTag"/> per allowlisted variable on the named state (looked up via
+    /// <see cref="GraphicalUiElementExtensions.TryGetStateByName"/> - the same States-then-Categories
+    /// resolution <see cref="GraphicalUiElement.ApplyState(string)"/> uses, so a state defined in the
+    /// Gum tool's States tab, inside a categorized state, or added in code all resolve identically),
+    /// each spanning the state tag's own open/close range. An unknown state name, or a state with no
+    /// allowlisted variables, contributes nothing - a no-op, not an error. Must run AFTER
+    /// <see cref="BbCodeParser.RemoveTags"/> has already stripped the source text using the original
+    /// (unexpanded) <paramref name="results"/>: the synthetic entries share character ranges with each
+    /// other (and with the original state tag), so stripping with them in play would remove the same
+    /// range more than once.
     /// </summary>
     private static List<FoundTag> ExpandStateTags(List<FoundTag> results, GraphicalUiElement graphicalUiElement)
     {
@@ -1253,7 +1254,7 @@ public partial class CustomSetPropertyOnRenderable
             {
                 expanded ??= new List<FoundTag>(results.Where(item => item.Name != "State"));
 
-                if (graphicalUiElement.States.TryGetValue(tag.Open.Argument ?? string.Empty,
+                if (graphicalUiElement.TryGetStateByName(tag.Open.Argument ?? string.Empty,
                         out Gum.DataTypes.Variables.StateSave? state))
                 {
                     foreach (Gum.DataTypes.Variables.VariableSave variable in state.Variables)

--- a/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
+++ b/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
@@ -1195,6 +1195,104 @@ public partial class CustomSetPropertyOnRenderable
     static List<TagInfo> allTags = new List<TagInfo>();
 
     /// <summary>
+    /// Variable names a <c>[state=Name]</c> BBCode tag is allowed to apply to the substring it wraps -
+    /// exactly the set already wired for per-run application elsewhere in this file (the direct-value
+    /// cases in <see cref="SetBbCodeText"/> plus the font-stack cases in <see cref="ApplyFontVariables"/>).
+    /// A state can hold arbitrary variables (X, Y, Width, etc.), but only these have per-run meaning, so
+    /// anything else on the state is silently skipped rather than applied to the whole element.
+    /// </summary>
+    private static readonly HashSet<string> StateBbCodeAllowlist = new HashSet<string>
+    {
+        "Color", "Red", "Green", "Blue", "FontScale",
+        "Font", "FontSize", "OutlineThickness", "IsItalic", "IsBold", "UseCustomFont",
+    };
+
+    /// <summary>
+    /// Formats an already-typed <see cref="Gum.DataTypes.Variables.VariableSave.Value"/> back into the
+    /// string <see cref="TagInfo.Argument"/> form the existing per-tag parsing (in
+    /// <see cref="SetBbCodeText"/> and <see cref="ApplyFontVariables"/>) expects, so a decomposed state
+    /// variable can be re-dispatched through that unchanged parsing without a bespoke typed-value path.
+    /// Lossless for every allowlisted type: bool/int/float format invariantly, and Color round-trips
+    /// through 8-digit ARGB hex (not <see cref="System.Drawing.Color.Name"/>, which is lossy for
+    /// non-named colors).
+    /// </summary>
+    private static string? FormatStateVariableArgument(object? value)
+    {
+        if (value == null)
+        {
+            return null;
+        }
+
+        if (value is System.Drawing.Color color)
+        {
+            return "0x" + color.ToArgb().ToString("X8", CultureInfo.InvariantCulture);
+        }
+
+        return Convert.ToString(value, CultureInfo.InvariantCulture);
+    }
+
+    /// <summary>
+    /// Expands every <c>[state=Name]</c> <see cref="FoundTag"/> in <paramref name="results"/> into one
+    /// synthetic <see cref="FoundTag"/> per allowlisted variable on the named state (looked up on
+    /// <paramref name="graphicalUiElement"/>'s <see cref="GraphicalUiElement.States"/> - the same runtime
+    /// dictionary <see cref="GraphicalUiElement.ApplyState(string)"/> uses, populated identically whether
+    /// the state came from the Gum tool or was added in code), each spanning the state tag's own
+    /// open/close range. An unknown state name, or a state with no allowlisted variables, contributes
+    /// nothing - a no-op, not an error. Must run AFTER <see cref="BbCodeParser.RemoveTags"/> has already
+    /// stripped the source text using the original (unexpanded) <paramref name="results"/>: the synthetic
+    /// entries share character ranges with each other (and with the original state tag), so stripping
+    /// with them in play would remove the same range more than once.
+    /// </summary>
+    private static List<FoundTag> ExpandStateTags(List<FoundTag> results, GraphicalUiElement graphicalUiElement)
+    {
+        List<FoundTag>? expanded = null;
+
+        foreach (FoundTag tag in results)
+        {
+            if (tag.Name == "State")
+            {
+                expanded ??= new List<FoundTag>(results.Where(item => item.Name != "State"));
+
+                if (graphicalUiElement.States.TryGetValue(tag.Open.Argument ?? string.Empty,
+                        out Gum.DataTypes.Variables.StateSave? state))
+                {
+                    foreach (Gum.DataTypes.Variables.VariableSave variable in state.Variables)
+                    {
+                        if (variable.SetsValue && StateBbCodeAllowlist.Contains(variable.Name))
+                        {
+                            string? argument = FormatStateVariableArgument(variable.Value);
+                            if (argument != null)
+                            {
+                                expanded.Add(new FoundTag
+                                {
+                                    Name = variable.Name,
+                                    Open = new TagInfo
+                                    {
+                                        StartIndex = tag.Open.StartIndex,
+                                        Count = tag.Open.Count,
+                                        StartStrippedIndex = tag.Open.StartStrippedIndex,
+                                        Argument = argument,
+                                        Name = variable.Name,
+                                    },
+                                    Close = new TagInfo
+                                    {
+                                        StartIndex = tag.Close.StartIndex,
+                                        Count = tag.Close.Count,
+                                        StartStrippedIndex = tag.Close.StartStrippedIndex,
+                                        Name = variable.Name,
+                                    },
+                                });
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        return expanded ?? results;
+    }
+
+    /// <summary>
     /// Parses BBCode markup, assigns the tag-stripped text to <see cref="Text.RawText"/>, and populates
     /// <see cref="Text.InlineVariables"/> with the per-run styling the renderer applies: Color / Red /
     /// Green / Blue and FontScale runs in the loop below, plus the resolved-font runs for the font family
@@ -1202,7 +1300,10 @@ public partial class CustomSetPropertyOnRenderable
     /// <see cref="ApplyFontVariables"/> using the same stack model on every platform. A <c>[Custom]</c> tag's
     /// per-letter callback is applied identically on every platform: it produces one
     /// <see cref="ParameterizedLetterCustomizationCall"/> InlineVariable per character, which each
-    /// platform's Text renderer resolves and applies at draw time (#3640).
+    /// platform's Text renderer resolves and applies at draw time (#3640). A <c>[state=Name]</c> tag is
+    /// expanded by <see cref="ExpandStateTags"/> into the allowlisted subset of that state's variables
+    /// BEFORE either loop below runs, so it needs no dedicated handling here - the expanded entries just
+    /// look like any other literal nested tag.
     /// </summary>
     private static void SetBbCodeText(Text asText, GraphicalUiElement graphicalUiElement, string bbcode)
     {
@@ -1216,9 +1317,13 @@ public partial class CustomSetPropertyOnRenderable
 
         asText.RawText = strippedText;
 
+        // Must happen after RemoveTags (see ExpandStateTags) - expanded entries are for value
+        // application only, not text stripping.
+        var expandedResults = ExpandStateTags(results, graphicalUiElement);
+
         // Color / Red / Green / Blue / FontScale runs don't use the font-resolution stacks, so they are
         // emitted regardless of whether the owning element is a TextRuntime.
-        foreach (var item in results)
+        foreach (var item in expandedResults)
         {
             object castedValue = item.Open.Argument;
             var shouldApply = false;
@@ -1373,7 +1478,7 @@ public partial class CustomSetPropertyOnRenderable
             currentDropshadowAlpha = (byte)textRuntime.DropshadowAlpha;
 #endif
 
-            ApplyFontVariables(asText, results);
+            ApplyFontVariables(asText, expandedResults);
         }
 
         // #3481: RawText was assigned above (which wrapped + measured the text) before any InlineVariables

--- a/GumRuntime/BbCodeParser.cs
+++ b/GumRuntime/BbCodeParser.cs
@@ -79,6 +79,7 @@ public static class BbCodeParser
         "fontscale",
         "lineheightmultiplier",
         "custom",
+        "state",
     };
 
     private struct Tag

--- a/GumRuntime/GraphicalUiElement.cs
+++ b/GumRuntime/GraphicalUiElement.cs
@@ -7392,6 +7392,39 @@ public partial class GraphicalUiElement : IRenderableIpso, IVisible, INotifyProp
 #region GraphicalUiElementExtensions
 public static class GraphicalUiElementExtensions
 {
+    #region State Lookup Extensions
+
+    /// <summary>
+    /// Attempts to resolve a state by its bare name, mirroring the lookup
+    /// <see cref="GraphicalUiElement.ApplyState(string)"/> uses: first the element's uncategorized
+    /// <see cref="GraphicalUiElement.States"/>, then every <see cref="GraphicalUiElement.Categories"/>
+    /// category's own states. Unlike <c>ApplyState(string)</c> (which applies every same-named match
+    /// it finds across categories), this returns only the first match - the right semantics for a
+    /// single lookup rather than an apply-everything call.
+    /// </summary>
+    public static bool TryGetStateByName(this GraphicalUiElement graphicalUiElement, string name,
+        out Gum.DataTypes.Variables.StateSave? state)
+    {
+        if (graphicalUiElement.States.TryGetValue(name, out state))
+        {
+            return true;
+        }
+
+        foreach (var category in graphicalUiElement.Categories.Values)
+        {
+            state = category.States.FirstOrDefault(item => item.Name == name);
+            if (state != null)
+            {
+                return true;
+            }
+        }
+
+        state = null;
+        return false;
+    }
+
+    #endregion
+
     #region Animation Extensions
 #if !FRB
 

--- a/MonoGameGum.Tests/Runtimes/BBCodeParserTests.cs
+++ b/MonoGameGum.Tests/Runtimes/BBCodeParserTests.cs
@@ -12,6 +12,12 @@ namespace MonoGameGum.Tests.Runtimes;
 public class BBCodeParserTests : BaseTestClass
 {
     [Fact]
+    public void KnownTags_ShouldIncludeState()
+    {
+        BbCodeParser.KnownTags.Contains("state").ShouldBeTrue();
+    }
+
+    [Fact]
     public void Parse_ShouldParseOverlappingColors()
     {
         HashSet<string> tags = new() { "Color" };

--- a/MonoGameGum.Tests/Runtimes/TextRuntimeBbCodeStateTests.cs
+++ b/MonoGameGum.Tests/Runtimes/TextRuntimeBbCodeStateTests.cs
@@ -1,0 +1,115 @@
+using Gum.DataTypes.Variables;
+using Gum.GueDeriving;
+using Gum.Wireframe;
+using Microsoft.Xna.Framework.Graphics;
+using RenderingLibrary.Graphics;
+using RenderingLibrary.Graphics.Fonts;
+using Shouldly;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace MonoGameGum.Tests.Runtimes;
+
+// [State=Name] BBCode tag: decomposes a GraphicalUiElement's named state (States/AddStates, the
+// same runtime concept ApplyState(string) already uses) into the substring the tag wraps, but only
+// for variables already wired for per-run application - Color/Red/Green/Blue/FontScale (direct
+// InlineVariable) and Font/FontSize/OutlineThickness/IsItalic/IsBold/UseCustomFont (the font-stack
+// path in ApplyFontVariables). Anything else in the state (X, Y, Width, etc.) is silently skipped,
+// and an unknown state name is a no-op - neither is an error.
+public class TextRuntimeBbCodeStateTests : BaseTestClass
+{
+    [Fact]
+    public void Text_WithStateBbCodeTag_AppliesAllowlistedColorAndSkipsDisallowedVariable()
+    {
+        TextRuntime textRuntime = new();
+
+        StateSave state = new() { Name = "Highlighted" };
+        state.Variables.Add(new VariableSave { Name = "Color", Value = System.Drawing.Color.FromArgb(255, 10, 20, 30) });
+        // Disallowed: X has no per-run meaning and must never be applied to the whole element from
+        // inside a text span.
+        state.Variables.Add(new VariableSave { Name = "X", Value = 999f });
+        textRuntime.AddStates(new List<StateSave> { state });
+
+        textRuntime.Text = "before [State=Highlighted]middle[/State] after";
+
+        Text text = (Text)textRuntime.RenderableComponent;
+        text.RawText.ShouldBe("before middle after");
+
+        InlineVariable colorVariable = text.InlineVariables.Single(v => v.VariableName == "Color");
+        colorVariable.Value.ShouldBe(System.Drawing.Color.FromArgb(255, 10, 20, 30));
+        colorVariable.StartIndex.ShouldBe(7);
+        colorVariable.CharacterCount.ShouldBe(6);
+
+        text.InlineVariables.ShouldNotContain(v => v.VariableName == "X");
+        textRuntime.X.ShouldBe(0);
+    }
+
+    [Fact]
+    public void Text_WithStateBbCodeTag_AppliesFontStackVariableLikeIndividualTag()
+    {
+        IInMemoryFontCreator? savedCreator = CustomSetPropertyOnRenderable.InMemoryFontCreator;
+        try
+        {
+            RecordingInMemoryFontCreator recordingCreator = new();
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = recordingCreator;
+
+            TextRuntime textRuntime = new();
+            // A font/size NOT in the test harness's stubbed embedded resources, so resolution
+            // actually reaches the in-memory creator instead of being satisfied by an embedded font
+            // (matches the convention in TextRuntimeBbCodeDropshadowRegressionTests).
+            textRuntime.Font = "Garet";
+            textRuntime.FontSize = 12;
+
+            StateSave state = new() { Name = "Bold" };
+            state.Variables.Add(new VariableSave { Name = "IsBold", Value = true });
+            textRuntime.AddStates(new List<StateSave> { state });
+
+            textRuntime.Text = "normal [State=Bold]bold[/State] normal";
+
+            // The base-font resolution requests IsBold=false; only a state-decomposed [IsBold=true]
+            // run produces a bold request.
+            recordingCreator.Requests.ShouldContain(r => r.IsBold);
+        }
+        finally
+        {
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = savedCreator;
+        }
+    }
+
+    [Fact]
+    public void Text_WithUnknownStateBbCodeTag_StripsTagAndDoesNotThrow()
+    {
+        TextRuntime textRuntime = new();
+
+        Should.NotThrow(() =>
+            textRuntime.Text = "before [State=DoesNotExist]middle[/State] after");
+
+        Text text = (Text)textRuntime.RenderableComponent;
+        text.RawText.ShouldBe("before middle after");
+        text.InlineVariables.ShouldBeEmpty();
+    }
+
+    // Records every BmfcSave a per-request font resolution asks for, and returns a minimal valid
+    // BitmapFont (only the space glyph is needed - measurement isn't asserted).
+    private sealed class RecordingInMemoryFontCreator : IInMemoryFontCreator
+    {
+        public List<BmfcSave> Requests { get; } = new();
+
+        public BitmapFont? TryCreateFont(BmfcSave bmfcSave)
+        {
+            Requests.Add(bmfcSave);
+            BitmapFont font = new BitmapFont((Texture2D)null!, FontData);
+            font.SetFontPattern(256, 256);
+            return font;
+        }
+
+        private const string FontData =
+@"info face=""Arial"" size=-18 bold=0 italic=0 charset="""" unicode=1 stretchH=100 smooth=1 aa=1 padding=0,0,0,0 spacing=1,1 outline=0
+common lineHeight=18 base=18 scaleW=256 scaleH=256 pages=1 packed=0 alphaChnl=0 redChnl=4 greenChnl=4 blueChnl=4
+page id=0 file=""x.png""
+chars count=1
+char id=32 x=0 y=0 width=9 height=13 xoffset=0 yoffset=4 xadvance=9 page=0 chnl=15
+";
+    }
+}

--- a/MonoGameGum.Tests/Runtimes/TextRuntimeBbCodeStateTests.cs
+++ b/MonoGameGum.Tests/Runtimes/TextRuntimeBbCodeStateTests.cs
@@ -45,6 +45,31 @@ public class TextRuntimeBbCodeStateTests : BaseTestClass
         textRuntime.X.ShouldBe(0);
     }
 
+    // Regression: a state defined inside a StateSaveCategory (e.g. the Gum tool's States tab,
+    // categorized states) - not just an uncategorized AddStates entry - must still resolve by bare
+    // name, mirroring GraphicalUiElement.ApplyState(string)'s own lookup (States, then every
+    // Category's States). Found via a real project where H1/H2/H3 lived under a "StyleCategory"
+    // category and [State=H3] silently no-opped because the lookup only checked the flat dictionary.
+    [Fact]
+    public void Text_WithStateBbCodeTag_ResolvesStateDefinedInsideCategory()
+    {
+        TextRuntime textRuntime = new();
+
+        StateSaveCategory styleCategory = new() { Name = "StyleCategory" };
+        StateSave h3 = new() { Name = "H3" };
+        h3.Variables.Add(new VariableSave { Name = "Color", Value = System.Drawing.Color.FromArgb(255, 10, 20, 30) });
+        styleCategory.States.Add(h3);
+        textRuntime.AddCategory(styleCategory);
+
+        textRuntime.Text = "before [State=H3]middle[/State] after";
+
+        Text text = (Text)textRuntime.RenderableComponent;
+        text.RawText.ShouldBe("before middle after");
+
+        InlineVariable colorVariable = text.InlineVariables.Single(v => v.VariableName == "Color");
+        colorVariable.Value.ShouldBe(System.Drawing.Color.FromArgb(255, 10, 20, 30));
+    }
+
     [Fact]
     public void Text_WithStateBbCodeTag_AppliesFontStackVariableLikeIndividualTag()
     {

--- a/Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/TextScreen.cs
+++ b/Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/TextScreen.cs
@@ -1,4 +1,5 @@
 using Gum.DataTypes;
+using Gum.DataTypes.Variables;
 using Gum.Forms;
 using Gum.Forms.Controls;
 using Gum.GueDeriving;
@@ -7,6 +8,7 @@ using Gum.Wireframe;
 using RenderingLibrary;
 using RenderingLibrary.Graphics;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 #if RAYLIB
 using Color = Raylib_cs.Color;
@@ -84,6 +86,22 @@ internal class TextScreen : FrameworkElement
             "[FontSize=40]big[/FontSize], [FontScale=1.5]scaled[/FontScale], " +
             "[IsBold=true]bold[/IsBold], and [IsItalic=true]italic[/IsItalic] runs, all styled inline in one Text.";
         container.Children.Add(bbcode);
+
+        // [State=Name] BBCode tag (MonoGame/raylib only -- SkiaGum has its own separate
+        // CustomSetPropertyOnRenderable.cs without this feature yet, so there's no SilkNetGum mirror
+        // for this section). The state is defined in code via AddStates (no Gum project needed) with
+        // a Color + IsBold pair; only variables already wired for per-run application (like these two)
+        // apply to the wrapped substring -- a state can hold anything, including layout properties like
+        // X/Width, but those are silently skipped rather than applied to the whole element.
+        var stateBbcode = new TextRuntime();
+        stateBbcode.Font = "Arial";
+        stateBbcode.FontSize = 24;
+        var highlightedState = new StateSave { Name = "Highlighted" };
+        highlightedState.Variables.Add(new VariableSave { Name = "Color", Value = System.Drawing.Color.Gold });
+        highlightedState.Variables.Add(new VariableSave { Name = "IsBold", Value = true });
+        stateBbcode.AddStates(new List<StateSave> { highlightedState });
+        stateBbcode.Text = "Plain text with a [State=Highlighted]bold gold run[/State] applied from a code-defined state.";
+        container.Children.Add(stateBbcode);
 
         Text.Customizations["Wave"] = (int index, string block) => new LetterCustomization
         {

--- a/Samples/SilkNetGum/SilkNetGumSample/Screens/TextScreen.cs
+++ b/Samples/SilkNetGum/SilkNetGumSample/Screens/TextScreen.cs
@@ -226,6 +226,11 @@ internal class TextScreen : FrameworkElement
     // per-run color, font size, font scale, bold, and italic. SkiaGum parses the tags and feeds
     // RichTextKit one Style per run (Text.GetStyledRuns), matching the MonoGame / Raylib inline-styling
     // path. Font = "Arial" because text can silently no-op without a font.
+    //
+    // No [State=Name] mirror here: that tag is decomposed by Gum/Wireframe/CustomSetPropertyOnRenderable.cs
+    // (shared MonoGame + raylib source), but SkiaGum owns a separate CustomSetPropertyOnRenderable.cs
+    // under Runtimes/SkiaGum/ that doesn't implement it yet -- adding the demo here would just show the
+    // tag being stripped with no styling applied, which isn't a useful visual.
     private static void AddBbCodeSection(ContainerRuntime container)
     {
         // One self-describing BBCode line: each styled word shows AND names its own effect, so no

--- a/Tests/RaylibGum.Tests/Renderables/TextMarkupTests.cs
+++ b/Tests/RaylibGum.Tests/Renderables/TextMarkupTests.cs
@@ -709,6 +709,31 @@ public class TextMarkupTests
         textRuntime.X.ShouldBe(0);
     }
 
+    // Regression: a state defined inside a StateSaveCategory (e.g. the Gum tool's States tab,
+    // categorized states) - not just an uncategorized AddStates entry - must still resolve by bare
+    // name, mirroring GraphicalUiElement.ApplyState(string)'s own lookup (States, then every
+    // Category's States). Found via a real project where H1/H2/H3 lived under a "StyleCategory"
+    // category and [State=H3] silently no-opped because the lookup only checked the flat dictionary.
+    [Fact]
+    public void Text_WithStateBbCodeTag_ResolvesStateDefinedInsideCategory()
+    {
+        TextRuntime textRuntime = new();
+
+        StateSaveCategory styleCategory = new() { Name = "StyleCategory" };
+        StateSave h3 = new() { Name = "H3" };
+        h3.Variables.Add(new VariableSave { Name = "Color", Value = System.Drawing.Color.FromArgb(255, 10, 20, 30) });
+        styleCategory.States.Add(h3);
+        textRuntime.AddCategory(styleCategory);
+
+        textRuntime.Text = "before [State=H3]middle[/State] after";
+
+        Text internalText = (Text)textRuntime.RenderableComponent;
+        internalText.RawText.ShouldBe("before middle after");
+
+        InlineVariable colorVariable = internalText.InlineVariables.Single(v => v.VariableName == "Color");
+        colorVariable.Value.ShouldBe(System.Drawing.Color.FromArgb(255, 10, 20, 30));
+    }
+
     [Fact]
     public void Text_WithStateBbCodeTag_AppliesFontStackVariableLikeIndividualTag()
     {

--- a/Tests/RaylibGum.Tests/Renderables/TextMarkupTests.cs
+++ b/Tests/RaylibGum.Tests/Renderables/TextMarkupTests.cs
@@ -1,10 +1,12 @@
 using Gum.DataTypes;
+using Gum.DataTypes.Variables;
 using Gum.GueDeriving;
 using Gum.Renderables;
 using Gum.Wireframe;
 using KernSmith.Gum;
 using RaylibGum.Renderables;
 using RenderingLibrary.Graphics;
+using RenderingLibrary.Graphics.Fonts;
 using Shouldly;
 using System;
 using System.Collections.Generic;
@@ -670,6 +672,103 @@ public class TextMarkupTests
         finally
         {
             CustomSetPropertyOnRenderable.InMemoryFontCreator = savedCreator;
+        }
+    }
+
+    // [State=Name] BBCode tag: decomposes a GraphicalUiElement's named state (States/AddStates, the
+    // same runtime concept ApplyState(string) already uses) into the substring the tag wraps, but only
+    // for variables already wired for per-run application - Color/Red/Green/Blue/FontScale (direct
+    // InlineVariable) and Font/FontSize/OutlineThickness/IsItalic/IsBold/UseCustomFont (the font-stack
+    // path in ApplyFontVariables). Anything else in the state (X, Y, Width, etc.) is silently skipped,
+    // and an unknown state name is a no-op - neither is an error. Mirrors
+    // MonoGameGum.Tests.Runtimes.TextRuntimeBbCodeStateTests, since the decomposition itself
+    // (CustomSetPropertyOnRenderable.ExpandStateTags) is shared source between the two platforms.
+    [Fact]
+    public void Text_WithStateBbCodeTag_AppliesAllowlistedColorAndSkipsDisallowedVariable()
+    {
+        TextRuntime textRuntime = new();
+
+        StateSave state = new() { Name = "Highlighted" };
+        state.Variables.Add(new VariableSave { Name = "Color", Value = System.Drawing.Color.FromArgb(255, 10, 20, 30) });
+        // Disallowed: X has no per-run meaning and must never be applied to the whole element from
+        // inside a text span.
+        state.Variables.Add(new VariableSave { Name = "X", Value = 999f });
+        textRuntime.AddStates(new List<StateSave> { state });
+
+        textRuntime.Text = "before [State=Highlighted]middle[/State] after";
+
+        Text internalText = (Text)textRuntime.RenderableComponent;
+        internalText.RawText.ShouldBe("before middle after");
+
+        InlineVariable colorVariable = internalText.InlineVariables.Single(v => v.VariableName == "Color");
+        colorVariable.Value.ShouldBe(System.Drawing.Color.FromArgb(255, 10, 20, 30));
+        colorVariable.StartIndex.ShouldBe(7);
+        colorVariable.CharacterCount.ShouldBe(6);
+
+        internalText.InlineVariables.ShouldNotContain(v => v.VariableName == "X");
+        textRuntime.X.ShouldBe(0);
+    }
+
+    [Fact]
+    public void Text_WithStateBbCodeTag_AppliesFontStackVariableLikeIndividualTag()
+    {
+        IRaylibFontCreator? savedCreator = CustomSetPropertyOnRenderable.InMemoryFontCreator;
+        try
+        {
+            RecordingRaylibFontCreator recordingCreator = new();
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = recordingCreator;
+
+            TextRuntime textRuntime = new();
+            textRuntime.Font = "Arial";
+            // A size not requested bold by any other test in this file/process - LoaderManager caches by
+            // (font, size, bold, ...) key and TextMarkupTests doesn't reset CacheTextures between tests
+            // (unlike BaseTestClass-derived classes), so reusing e.g. size 20 would hit another test's
+            // already-cached bold font instead of calling this test's own recording creator.
+            textRuntime.FontSize = 77;
+
+            StateSave state = new() { Name = "Bold" };
+            state.Variables.Add(new VariableSave { Name = "IsBold", Value = true });
+            textRuntime.AddStates(new List<StateSave> { state });
+
+            textRuntime.Text = "normal [State=Bold]bold[/State] normal";
+
+            // The base-font resolution requests IsBold=false; only a state-decomposed [IsBold=true]
+            // run produces a bold request.
+            recordingCreator.Requests.ShouldContain(r => r.IsBold);
+        }
+        finally
+        {
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = savedCreator;
+        }
+    }
+
+    [Fact]
+    public void Text_WithUnknownStateBbCodeTag_StripsTagAndDoesNotThrow()
+    {
+        TextRuntime textRuntime = new();
+
+        Should.NotThrow(() =>
+            textRuntime.Text = "before [State=DoesNotExist]middle[/State] after");
+
+        Text internalText = (Text)textRuntime.RenderableComponent;
+        internalText.RawText.ShouldBe("before middle after");
+        internalText.InlineVariables.ShouldBeEmpty();
+    }
+
+    // Wraps the real KernSmithRaylibFontCreator (rather than a hand-built Raylib_cs.Font, whose unmanaged
+    // Recs/Glyphs pointers would need to be valid for UnloadFont to safely dispose it later) so it
+    // produces a genuinely usable font while recording every BmfcSave requested - mirrors
+    // TextRuntimeFontCachingRegressionTests.CountingFontCreator.
+    private sealed class RecordingRaylibFontCreator : IRaylibFontCreator
+    {
+        private readonly KernSmithRaylibFontCreator _inner = new();
+
+        public List<BmfcSave> Requests { get; } = new();
+
+        public Raylib_cs.Font? TryCreateFont(BmfcSave bmfcSave)
+        {
+            Requests.Add(bmfcSave);
+            return _inner.TryCreateFont(bmfcSave);
         }
     }
 }

--- a/Tool/Tests/GumToolUnitTests/DataTypes/GumProjectSaveExtensionMethodsTests.cs
+++ b/Tool/Tests/GumToolUnitTests/DataTypes/GumProjectSaveExtensionMethodsTests.cs
@@ -1,0 +1,41 @@
+using Gum.DataTypes;
+using Gum.Managers;
+using Shouldly;
+using Xunit;
+
+namespace GumToolUnitTests.DataTypes;
+
+public class GumProjectSaveExtensionMethodsTests : BaseTestClass
+{
+    // Regression: GumProjectSaveExtensionMethods.Initialize's Screen loop forwards
+    // tolerateMissingDefaultStates, and the StandardElements loop tolerates via its own try/catch,
+    // but the Component loop's two componentSave.Initialize(...) calls never forward the flag - so
+    // it always resolves instances with throwExceptionOnMissing: true regardless of what the caller
+    // asked for. A component containing an instance of a type whose default state can't be resolved
+    // (e.g. a plugin-contributed standard the current process hasn't wired a resolver for) then
+    // crashes the entire load, even though ProjectManager.LoadProject explicitly requests
+    // tolerateMissingDefaultStates: true "so we don't immediately crash the tool."
+    [Fact]
+    public void Initialize_WithTolerateMissingDefaultStates_DoesNotThrow_WhenComponentInstanceHasUnresolvableBaseType()
+    {
+        const string unresolvableType = "TotallyUnresolvableTestStandardType";
+
+        StandardElementSave standard = new StandardElementSave { Name = unresolvableType };
+
+        ComponentSave component = new ComponentSave { Name = "MyComponent", BaseType = "Container" };
+        InstanceSave instance = new InstanceSave
+        {
+            Name = "MyInstance",
+            BaseType = unresolvableType,
+            ParentContainer = component
+        };
+        component.Instances.Add(instance);
+
+        GumProjectSave project = new GumProjectSave();
+        project.StandardElements.Add(standard);
+        project.Components.Add(component);
+        ObjectFinder.Self.GumProjectSave = project;
+
+        Should.NotThrow(() => project.Initialize(tolerateMissingDefaultStates: true));
+    }
+}


### PR DESCRIPTION
## Summary
Adds a `[State=Name]` BBCode tag for `Text`, letting a text run apply a state (including one defined inside a category) at runtime, without a crash when a component's default state is missing.

## Changes
- New `[State=Name]` BBCode tag, resolved through the state (including category-scoped states)
- Fix: tool crash when `tolerateMissingDefaultStates` wasn't threaded through the Component loop
- Demo added to the MonoGame/raylib text sample
- Unit tests: `BBCodeParserTests`, `TextRuntimeBbCodeStateTests`, `TextMarkupTests` (Raylib), `GumProjectSaveExtensionMethodsTests`

## Test plan
- [x] `MonoGameGum.Tests` (BBCodeParserTests, TextRuntimeBbCodeStateTests) — 6/6 pass
- [x] `RaylibGum.Tests` (TextMarkupTests) — 34/34 pass
- [x] `GumToolUnitTests` (GumProjectSaveExtensionMethodsTests) — 1/1 pass
- [x] FRB canary (`GumCore.DesktopGlNet6.csproj`) — 0 errors, matches main baseline
- [x] Manual test — verified in the MonoGame/raylib text sample demo
