### PR TITLE
Redispatch Sprite's mechanical SetProperty branch through SpriteRuntime

### DIFF
--- a/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
+++ b/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
@@ -602,6 +602,13 @@ public partial class CustomSetPropertyOnRenderable
     {
         bool handled = false;
 
+#if FRB
+        // FRB doesn't have a SpriteRuntime, so we have to do this:
+        var spriteRuntime = graphicalUiElement;
+#else
+        var spriteRuntime = graphicalUiElement as Gum.GueDeriving.SpriteRuntime;
+#endif
+
         switch (propertyName)
         {
             case "SourceFile":
@@ -613,45 +620,90 @@ public partial class CustomSetPropertyOnRenderable
             case nameof(Sprite.Alpha):
                 {
                     int valueAsInt = (int)value;
+#if FRB
                     sprite.Alpha = valueAsInt;
+#else
+                    if (spriteRuntime != null)
+                    {
+                        spriteRuntime.Alpha = valueAsInt;
+                    }
+#endif
                     handled = true;
                     break;
                 }
             case nameof(Sprite.Red):
                 {
                     int valueAsInt = (int)value;
+#if FRB
                     sprite.Red = valueAsInt;
+#else
+                    if (spriteRuntime != null)
+                    {
+                        spriteRuntime.Red = valueAsInt;
+                    }
+#endif
                     handled = true;
                     break;
                 }
             case nameof(Sprite.Green):
                 {
                     int valueAsInt = (int)value;
+#if FRB
                     sprite.Green = valueAsInt;
+#else
+                    if (spriteRuntime != null)
+                    {
+                        spriteRuntime.Green = valueAsInt;
+                    }
+#endif
                     handled = true;
                     break;
                 }
             case nameof(Sprite.Blue):
                 {
                     int valueAsInt = (int)value;
+#if FRB
                     sprite.Blue = valueAsInt;
+#else
+                    if (spriteRuntime != null)
+                    {
+                        spriteRuntime.Blue = valueAsInt;
+                    }
+#endif
                     handled = true;
                     break;
                 }
             case nameof(Sprite.Color):
                 {
+#if FRB
                     if (value is System.Drawing.Color drawingColor)
                     {
-#if RAYLIB
-                        sprite.Color = drawingColor.ToRaylib();
-#else
                         sprite.Color = drawingColor;
-#endif
                     }
-#if !RAYLIB
                     else if (value is Microsoft.Xna.Framework.Color xnaColor)
                     {
                         sprite.Color = xnaColor.ToSystemDrawing();
+                    }
+#else
+                    if (spriteRuntime != null)
+                    {
+                        if (value is System.Drawing.Color drawingColor)
+                        {
+#if RAYLIB
+                            spriteRuntime.Color = drawingColor.ToRaylib();
+#else
+                            // SpriteRuntime.Color is XNA-typed on this backend (unlike the renderable's
+                            // System.Drawing-typed Color), so the incoming System.Drawing value needs the
+                            // same ToXNA conversion the runtime's own getter uses in reverse.
+                            spriteRuntime.Color = global::RenderingLibrary.Graphics.XNAExtensions.ToXNA(drawingColor);
+#endif
+                        }
+#if !RAYLIB
+                        else if (value is Microsoft.Xna.Framework.Color xnaColor)
+                        {
+                            spriteRuntime.Color = xnaColor;
+                        }
+#endif
                     }
 #endif
                     handled = true;
@@ -660,6 +712,7 @@ public partial class CustomSetPropertyOnRenderable
             case "Blend":
                 {
                     var valueAsGumBlend = (Gum.RenderingLibrary.Blend)value;
+#if FRB
 #if RAYLIB
                     sprite.Blend = valueAsGumBlend;
 #else
@@ -667,18 +720,38 @@ public partial class CustomSetPropertyOnRenderable
 
                     sprite.BlendState = valueAsXnaBlend;
 #endif
+#else
+                    if (spriteRuntime != null)
+                    {
+                        spriteRuntime.Blend = valueAsGumBlend;
+                    }
+#endif
                     handled = true;
                     break;
                 }
             case nameof(Sprite.Animate):
                 {
+#if FRB
                     sprite.Animate = (bool)value;
+#else
+                    if (spriteRuntime != null)
+                    {
+                        spriteRuntime.Animate = (bool)value;
+                    }
+#endif
                     handled = true;
                     break;
                 }
             case nameof(Sprite.CurrentChainName):
                 {
+#if FRB
                     sprite.CurrentChainName = (string)value;
+#else
+                    if (spriteRuntime != null)
+                    {
+                        spriteRuntime.CurrentChainName = (string)value;
+                    }
+#endif
                     graphicalUiElement.UpdateTextureValuesFrom(sprite);
                     graphicalUiElement.UpdateLayout();
                     handled = true;

--- a/MonoGameGum.Tests/Runtimes/SpriteSetPropertyTests.cs
+++ b/MonoGameGum.Tests/Runtimes/SpriteSetPropertyTests.cs
@@ -1,0 +1,87 @@
+using Gum.Graphics.Animation;
+using Gum.GueDeriving;
+using Shouldly;
+using System;
+using Xunit;
+
+namespace MonoGameGum.Tests.Runtimes;
+
+// Covers the string-property-dispatch path (SetProperty -> CustomSetPropertyOnRenderable ->
+// TrySetPropertyOnSprite) for Sprite, mirroring Tests/RaylibGum.Tests/Runtimes/SpriteSetPropertyTests.cs.
+// These properties are set at runtime by the state/variable system (StateSave/VariableSave applied via
+// GraphicalUiElement.SetProperty), not by direct C# property assignment, so this pins that the
+// string-path dispatch produces the same result as direct C# usage (e.g. SpriteRuntime.Alpha = 128).
+public class SpriteSetPropertyTests : BaseTestClass
+{
+    [Fact]
+    public void SetProperty_AlphaRedGreenBlue_ShouldForwardToContainedSprite()
+    {
+        SpriteRuntime sut = new();
+
+        sut.SetProperty(nameof(SpriteRuntime.Alpha), 128);
+        sut.SetProperty(nameof(SpriteRuntime.Red), 10);
+        sut.SetProperty(nameof(SpriteRuntime.Green), 20);
+        sut.SetProperty(nameof(SpriteRuntime.Blue), 30);
+
+        sut.Alpha.ShouldBe(128);
+        sut.Red.ShouldBe(10);
+        sut.Green.ShouldBe(20);
+        sut.Blue.ShouldBe(30);
+    }
+
+    [Fact]
+    public void SetProperty_Animate_ShouldForwardToContainedSprite()
+    {
+        SpriteRuntime sut = new();
+
+        sut.SetProperty(nameof(SpriteRuntime.Animate), true);
+
+        sut.Animate.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void SetProperty_Blend_ShouldForwardToContainedSprite()
+    {
+        SpriteRuntime sut = new();
+
+        sut.SetProperty("Blend", Gum.RenderingLibrary.Blend.Additive);
+
+        sut.Blend.ShouldBe(Gum.RenderingLibrary.Blend.Additive);
+    }
+
+    [Fact]
+    public void SetProperty_Color_ShouldForwardToContainedSprite()
+    {
+        SpriteRuntime sut = new();
+        var drawingColor = System.Drawing.Color.FromArgb(255, 10, 20, 30);
+
+        sut.SetProperty(nameof(SpriteRuntime.Color), drawingColor);
+
+        sut.Color.R.ShouldBe((byte)10);
+        sut.Color.G.ShouldBe((byte)20);
+        sut.Color.B.ShouldBe((byte)30);
+    }
+
+    [Fact]
+    public void SetProperty_CurrentChainName_ShouldUpdateActiveChain()
+    {
+        SpriteRuntime sut = new();
+
+        // AnimationChains defaults to chain index 0 ("FirstChain"), so switching to
+        // "SecondChain" via SetProperty is what actually exercises the dispatch case
+        // (rather than the AnimationChains setter's own default-frame application).
+        var firstChain = new AnimationChain { Name = "FirstChain" };
+        firstChain.Add(new AnimationFrame { FrameLength = 1f });
+        var secondChain = new AnimationChain { Name = "SecondChain" };
+        secondChain.Add(new AnimationFrame { FrameLength = 1f });
+        var chainList = new AnimationChainList();
+        chainList.Add(firstChain);
+        chainList.Add(secondChain);
+        sut.AnimationChains = chainList;
+        sut.CurrentChainName.ShouldBe("FirstChain");
+
+        sut.SetProperty(nameof(SpriteRuntime.CurrentChainName), "SecondChain");
+
+        sut.CurrentChainName.ShouldBe("SecondChain");
+    }
+}

--- a/MonoGameGum.Tests/Runtimes/SpriteSetPropertyTests.cs
+++ b/MonoGameGum.Tests/Runtimes/SpriteSetPropertyTests.cs
@@ -63,6 +63,23 @@ public class SpriteSetPropertyTests : BaseTestClass
     }
 
     [Fact]
+    public void SetProperty_Color_WithXnaColorValue_ShouldForwardToContainedSprite()
+    {
+        // The dispatcher accepts both System.Drawing.Color and Microsoft.Xna.Framework.Color as
+        // the incoming value (state/variable values are stored as System.Drawing.Color, but direct
+        // callers can pass XNA's Color) — this pins the XNA-typed branch, which needs no conversion
+        // since SpriteRuntime.Color is itself XNA-typed on this backend.
+        SpriteRuntime sut = new();
+        var xnaColor = new Microsoft.Xna.Framework.Color(10, 20, 30, 255);
+
+        sut.SetProperty(nameof(SpriteRuntime.Color), xnaColor);
+
+        sut.Color.R.ShouldBe((byte)10);
+        sut.Color.G.ShouldBe((byte)20);
+        sut.Color.B.ShouldBe((byte)30);
+    }
+
+    [Fact]
     public void SetProperty_CurrentChainName_ShouldUpdateActiveChain()
     {
         SpriteRuntime sut = new();

--- a/Tests/RaylibGum.Tests/Runtimes/SpriteSetPropertyTests.cs
+++ b/Tests/RaylibGum.Tests/Runtimes/SpriteSetPropertyTests.cs
@@ -21,6 +21,22 @@ namespace RaylibGum.Tests.Runtimes;
 public class SpriteSetPropertyTests : BaseTestClass
 {
     [Fact]
+    public void SetProperty_AlphaRedGreenBlue_ShouldForwardToContainedSprite()
+    {
+        SpriteRuntime sut = new();
+
+        sut.SetProperty(nameof(SpriteRuntime.Alpha), 128);
+        sut.SetProperty(nameof(SpriteRuntime.Red), 10);
+        sut.SetProperty(nameof(SpriteRuntime.Green), 20);
+        sut.SetProperty(nameof(SpriteRuntime.Blue), 30);
+
+        sut.Alpha.ShouldBe(128);
+        sut.Red.ShouldBe(10);
+        sut.Green.ShouldBe(20);
+        sut.Blue.ShouldBe(30);
+    }
+
+    [Fact]
     public void SetProperty_Blend_ShouldForwardToContainedSprite()
     {
         SpriteRuntime sut = new();


### PR DESCRIPTION
## Summary
- First implementation PR under ADR 0010: redispatches `TrySetPropertyOnSprite` (`Gum/Wireframe/CustomSetPropertyOnRenderable.cs`) from renderable-direct writes to `SpriteRuntime`'s typed setters for `Alpha`, `Red`, `Green`, `Blue`, `Color`, `Blend`, `Animate`, and `CurrentChainName`.
- `#if FRB` keeps the unchanged renderable-direct path (FRB has no `SpriteRuntime`), mirroring the Text redispatch pattern (#3724).
- `Color` needed extra care: `SpriteRuntime.Color` is XNA-typed on XNALIKE (vs. the renderable's System.Drawing-typed `Color`), so the incoming `System.Drawing.Color` is converted via `XNAExtensions.ToXNA` before assignment.
- `CurrentChainName` keeps the existing `UpdateTextureValuesFrom`/`UpdateLayout` calls after the assignment — dropping them would silently break texture-size updates on chain switch (caught by a pinning test failure before the fix).
- `SourceFile` is untouched, per ADR 0010 (real logic in `AssignSourceFileOnSprite`, not a mechanical redirect).
- Added pinning/characterization tests (`SpriteSetPropertyTests.cs`, new for MonoGame, extended for Raylib) covering the string-path `SetProperty` dispatch for every redispatched property, run green before and after the change.

Part of #3727.

## Test plan
- New pinning tests pass on both MonoGame and Raylib (`MonoGameGum.Tests/Runtimes/SpriteSetPropertyTests.cs`, `Tests/RaylibGum.Tests/Runtimes/SpriteSetPropertyTests.cs`).
- Full `MonoGameGum.Tests` suite: 1876/1876 passing.
- Full `RaylibGum.Tests` suite: 511/511 passing.

Manual test: not needed — behavior-preserving dispatch-key relocation, covered by pinning tests + full suite green.
FRB canary: pass — built `GumCore.DesktopGlNet6.csproj` from the primary checkout with this change applied over `main`; 0 errors, same warning count as the `main` baseline.
